### PR TITLE
C/Linux: Mark the load of non-value-return atomics as "noreturn"

### DIFF
--- a/herd/CSem.ml
+++ b/herd/CSem.ml
@@ -37,6 +37,7 @@ module Make (Conf:Sem.Config)(V:Value.S)
 
     module MOorAN = MemOrderOrAnnot
     let a_once = ["once"]
+    let a_noreturn = ["noreturn"]
     let an_once = MOorAN.AN a_once
     let a_mb = ["mb"]
     let a_rb_dep = ["rb_dep"]
@@ -311,7 +312,7 @@ module Make (Conf:Sem.Config)(V:Value.S)
               >>= fun _ -> M.unitT (ii.A.program_order_index, B.Next)
 (********************)
       | C.AtomicOp  (eloc,op,e) ->
-          build_atomic_op a_once a_once eloc op e ii
+          build_atomic_op a_noreturn a_once eloc op e ii
             >>= fun _ -> M.unitT (ii.A.program_order_index, B.Next)
 (********************)
       | C.Fence(mo) ->


### PR DESCRIPTION
On some architectures, there exists atomic memory operations which will
be run directly at memory controller after issued by a CPU. Such an
operation doesn't return a value to a register, therefore the load part
is not treated as a load by barriers. In order to differ this kind of
operations, we mark the load part of a non-value-return atomic as
"noreturn" annotation. The memory model's cat file can add special rules
to it afterwards.

Signed-off-by: Boqun Feng <boqun.feng@gmail.com>