### PR TITLE
x86 mixed-size: new instructions, truncated sentinel

### DIFF
--- a/herd/X86Sem.ml
+++ b/herd/X86Sem.ml
@@ -159,7 +159,7 @@ module Make (C:Sem.Config)(V : Value.S)
 	  fun v_result ->
 	    (write_loc_gen locked loc v_result ii >>|
 	    write_all_flags v_result V.zero ii) >>! B.Next
-    |  X86.I_MOV (ea,op)|X86.I_MOVQ (ea,op) ->
+    |  X86.I_MOV (ea,op)|X86.I_MOVB (ea,op)|X86.I_MOVW (ea,op)|X86.I_MOVL (ea,op)|X86.I_MOVQ (ea,op)|X86.I_MOVT (ea,op) ->
 	(lval_ea ea ii >>| rval_op locked op ii) >>=
 	fun (loc,v_op) ->
 	  write_loc_gen locked loc v_op ii >>! B.Next

--- a/lib/X86Lexer.mll
+++ b/lib/X86Lexer.mll
@@ -47,7 +47,11 @@ rule token = parse
 | "add"|"ADD"   { I_ADD }
 | "xor"|"XOR"   { I_XOR }
 | "mov"|"MOV"   { I_MOV }
+| "movb"|"MOVB"   { I_MOVB }
+| "movw"|"MOVW"   { I_MOVW }
+| "movl"|"MOVL"   { I_MOVL }
 | "movq"|"MOVQ"   { I_MOVQ }
+| "movt"|"MOVT"   { I_MOVT }
 | "movsd"|"MOVSD"   { I_MOVSD }
 | "dec"|"DEC"   { I_DEC }
 | "cmp"|"CMP"   { I_CMP }

--- a/lib/X86Parser.mly
+++ b/lib/X86Parser.mly
@@ -31,7 +31,7 @@ open X86
 %token LPAR RPAR COLON
 /* Instruction tokens */
 
-%token  I_XOR I_ADD  I_MOV  I_MOVQ I_MOVSD I_DEC  I_CMP  I_CMOVC  I_INC  I_JMP
+%token  I_XOR I_ADD  I_MOV  I_MOVB I_MOVW I_MOVL I_MOVQ I_MOVT I_MOVSD I_DEC  I_CMP  I_CMOVC  I_INC  I_JMP
 %token  I_LOCK  I_XCHG   I_LFENCE  I_SFENCE  I_MFENCE
 %token  I_READ I_SETNB I_JE I_JNE
 %token  I_CMPXCHG
@@ -83,8 +83,16 @@ instr:
     {I_ADD ($2,$4)}
   | I_MOV   effaddr  COMMA  operand
     {I_MOV ($2,$4)}
+  | I_MOVB   effaddr  COMMA  operand
+    {I_MOVB ($2,$4)}
+  | I_MOVW   effaddr  COMMA  operand
+    {I_MOVW ($2,$4)}
+  | I_MOVL   effaddr  COMMA  operand
+    {I_MOVL ($2,$4)}
   | I_MOVQ   effaddr  COMMA  operand
     {I_MOVQ ($2,$4)}
+  | I_MOVT   effaddr  COMMA  operand
+    {I_MOVT ($2,$4)}
   | I_MOVSD
     {I_MOVSD}
   | I_DEC   effaddr

--- a/litmus/X86Compile_litmus.ml
+++ b/litmus/X86Compile_litmus.ml
@@ -54,7 +54,11 @@ module Make(V:Constant.S)(O:Arch_litmus.Config) =
     | I_XOR (ea,op)
     | I_ADD (ea,op)
     | I_MOV (ea,op)
+    | I_MOVB (ea,op)
+    | I_MOVW (ea,op)
+    | I_MOVL (ea,op)
     | I_MOVQ (ea,op)
+    | I_MOVT (ea,op)
     | I_CMP (ea,op)
         ->  StringSet.union (extract_ea ea) (extract_op op)
     | I_XCHG (ea1,ea2)
@@ -154,7 +158,7 @@ module Make(V:Constant.S)(O:Arch_litmus.Config) =
       let ea2,(_,ins2),(_,outs2) = compile_ea_output i o ea2 in
 (* For exchange, order of operands is irrelevant,
    let us swap them anyway... good idea since operands
-   as asymetric in practice (ea2 must be a reg) *)
+   as asymmetric in practice (ea2 must be a reg) *)
       { empty_ins with
         memo = sprintf "%s %s,%s" memo ea2 ea1;
         inputs = ins1@ins2;
@@ -230,7 +234,11 @@ module Make(V:Constant.S)(O:Arch_litmus.Config) =
     | I_ADD (ea,op) -> op_ea_output_op "addl" ea op
 (* as usual, move is quite special *)
     | I_MOV (ea,op) ->  move "movl" ea op
+    | I_MOVB (ea,op) ->  move "movb" ea op
+    | I_MOVW (ea,op) ->  move "movw" ea op
+    | I_MOVL (ea,op) ->  move "movl" ea op
     | I_MOVQ (ea,op) ->  move "movq" ea op
+    | I_MOVT (ea,op) ->  move "movt" ea op
 (* Trap!! ea is input only... *)
     | I_CMP (ea,op) -> op_ea_input_op "cmpl" ea op
 (* ea is always output here *)

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -68,7 +68,15 @@ module type Config = sig
   include DumpParams.Config
 end
 
-let sentinel = "-239487" (* Susmit's sentinel *)
+let sentinel   = "-239487" (* Susmit's sentinel *)
+let sentinel16 =   "39487"
+let sentinel8  =      "87"
+
+let sentinel_of t =
+  match t with
+  | CType.Base "uint8_t"  -> sentinel8
+  | CType.Base "uint16_t" -> sentinel16
+  | _ -> sentinel
 
 module Make
     (Cfg:sig include Config val sysarch : Archs.System.t end)
@@ -1142,7 +1150,7 @@ end = struct
                   (sprintf "_a->%s[_i] != %s"
                      (A.Out.dump_out_reg proc reg)
                      (match CType.is_ptr t with
-                     | false -> sentinel
+                     | false -> sentinel_of t
                      | true -> "NULL"))
                   doc.Name.name)
               outs)
@@ -1546,7 +1554,7 @@ end = struct
               O.fii "_a->%s[_i] = %s;"
                 (A.Out.dump_out_reg proc reg)
                 (match CType.is_ptr t with
-                | false -> sentinel
+                | false -> sentinel_of t
                 | true -> "NULL"))
             outs)
         test.T.code ;


### PR DESCRIPTION
Added movb, movw etc instructions to litmus' x86 parser for writing mixed-size litmus tests. Also truncated the sentinel value in some cases.