### PR TITLE
jingle: gen_theme: Support func sequence

### DIFF
--- a/jingle/libdir/Linux.call
+++ b/jingle/libdir/Linux.call
@@ -12,9 +12,7 @@ C
 
 "%r = xchg_release(%x, %y);" -> "@release %r = xchg_relaxed(%x, %y);"
 
-"%r = xchg_acq_rel(%x, %y);" -> "@release %r = xchg_acquire(%x, %y);"
-
-"%r = xchg(%x, %y);" -> "@full_on_acq_rel %r = xchg_acq_rel(%x, %y);"
+"%r = xchg(%x, %y);" -> "@full %r = xchg_relaxed(%x, %y);"
 
 "%r = xchg_acquire(%x, constvar:c);" -> "@acquire %r = xchg_relaxed(%x, constvar:c);"
 
@@ -28,18 +26,8 @@ C
 
 "%r = atomic_xchg_release(%x, constvar:c);" -> "@id %r = xchg_release(%x, constvar:c);"
 
-"%r = xchg_acq_rel(%x, constvar:c);" -> "@release %r = xchg_acquire(%x, constvar:c);"
+"%r = xchg(%x, constvar:c);" -> "@full %r = xchg(%x, constvar:c);"
 
-"%r = xchg(%x, constvar:c);" -> "@full_on_acq_rel %r = xchg_acq_rel(%x, constvar:c);"
+"spin_lock(%x);" -> "@lock %r = cmpxchg_acquire(%x, constvar:c, constvar:d);"
 
-"temp_spin_lock(%x);" -> "@id %r = cmpxchg_acquire(%x, constvar:c, constvar:d);"
-
-"temp2_spin_lock(%x);" -> "@const_to_0 temp_spin_lock(%x);"
-
-"temp3_spin_lock(%x);" -> "@out_to_loop temp2_spin_lock(%x);"
-
-"spin_lock(%x);" -> "@constd_to_1 temp3_spin_lock(%x);"
-
-"temp_spin_unlock(%y);" -> "@id smp_store_release(%y, constvar:c);"
-
-"spin_unlock(%y);" -> "@const_to_0 temp_spin_unlock(%y);"
+"spin_unlock(%y);" -> "@const_c_to_0 smp_store_release(%y, constvar:c);"

--- a/jingle/libdir/Linux2AArch64.map
+++ b/jingle/libdir/Linux2AArch64.map
@@ -114,10 +114,13 @@ store: STLR %t2,[%t1]"
 
 "full_on_acq_rel" : "\([^;]$\)" -> "\1;
 				   DMB ISH"
+"full" : "acquire | release | full_on_acq_rel"
 
 "id" : "" -> ""
-"const_to_1" : "&c" -> "#1"
-"const_to_0" : "&c" -> "#0"
-"constd_to_1" : "&d" -> "#1"
+"const_c_to_1" : "&c" -> "#1"
+"const_c_to_0" : "&c" -> "#0"
+"const_d_to_1" : "&d" -> "#1"
 
 "out_to_loop" : "B.NE out" -> "B.NE loop"
+
+"lock" : "const_c_to_0 | const_d_to_1 | out_to_loop"


### PR DESCRIPTION
"Func sequence" is a series of functions concatenated by vertical bars
"|" (or pipes). It provides a way to compose functions in defined in map
file to get another function. For example:

	"acq_rel" : "acquire | release"

, this defines a new function named "acq_rel", whose behavior is simply
doing a "release" on a rule after an "acquire", IOW, first apply
"acquire" function to a rule A, get a intermediate rule B, and then
applying "release" function to rule B, get a final rule C.

For example, if we define two funcs:

	"release" : "store:STR" -> "store:STLXR"
	"acquire" : "load:LDXR" -> "load:LDAXR"

, then we can get a new func via func sequence (or composing funcs):

	"acq_rel" : "acquire | release"

and mapping for xchg_relaxed():

	"%r = xchg_relaxed(%x, constvar:c);" -> "MOV %tmp,&c;
						 loop:load:LDXR %r,[%x];
						 store:STXR w%wmp, %tmp,[%x];
						 CBNZ w%wmp, loop"

, when we apply this func:

	"%r = xchg_acq_rel(%x, constvar:c);" -> "@acq_rel %r = xchg_relaxed(%x, constvar:c);"

, we expand "acq_rel" as func sequence:

	"%r = xchg_acq_rel(%x, constvar:c);" -> "@(acquire | release" %r = xchg_relaxed(%x, constvar:c);"

, apply "acquire" first:

	"%r = xchg_acq_rel(%x, constvar:c);" -> "@release %r = tmp_xchg_acquire(%x, constvar:c);"

	where we have a unobservable tmp rule:

	"%r = tmp_xchg_acquire(%x, constvar:c);" -> "MOV %tmp,&c;
						 loop:load:LDAXR %r,[%x];
						 store:STXR w%wmp, %tmp,[%x];
						 CBNZ w%wmp, loop"
, and apply "release":

	"%r = xchg_acq_rel(%x, constvar:c);" -> "MOV %tmp,&c;
						 loop:load:LDAXR %r,[%x];
						 store:STXLR w%wmp, %tmp,[%x];
						 CBNZ w%wmp, loop"

With this ability, we can save a few lines in the call file, because we
don't need to write intermediate callsites to generate intermediate
rules, e.g. temp_spin_lock() in Linux.call.

Also, while I'm at it, clean a bit of the code.

Signed-off-by: Boqun Feng <boqun.feng@gmail.com>