### PR TITLE
Lib: Misc: Fix split_on_char

### DIFF
--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -197,7 +197,7 @@ let split_on_char c s =
   let rec do_rec k0 k =
     if k >= len then [String.sub s k0 (k-k0) ]
     else if c = String.unsafe_get s k then
-      String.sub s k0 (k-k0)::do_rec k (k+1)
+      String.sub s k0 (k-k0)::do_rec (k+1) (k+1)
     else do_rec k0 (k+1) in
   do_rec 0 0
 


### PR DESCRIPTION
split_on_char should skip the 'sep', so we need to change "k" with
"(k+1)" in hit branch

Signed-off-by: Boqun Feng <boqun.feng@gmail.com>