### PR TITLE
Hopefully-improved macOS detector

### DIFF
--- a/litmus/runUtils.ml
+++ b/litmus/runUtils.ml
@@ -65,12 +65,15 @@ let open_quote chan =
 and close_quote chan =
   if O.is_out then output_line chan "EOF"
 
+let is_darwin () : bool =
+  Sys.unix && Sys.command "sh -c 'test \"$(uname -s)\" = Darwin'" = 0
+
 module W = Warn.Make(O)
 let target_os =
   if O.is_out then
     O.targetos
   else begin
-    if Sys.file_exists "/mach_kernel"
+    if is_darwin ()
     then begin
       W.warn "OS: Darwin" ;
       TargetOS.Mac


### PR DESCRIPTION
Attempt to fix #21, though there are probably more principled versions, and I haven't been able to test this as exhaustively as I'd like.  (It gives the right response on macOS, though may need a bit more checking on other *nix.)

Commit message reads thusly:

`/mach_kernel` hasn't existed for several macOS revisions, so the
existing detection heuristic (checking that `/mach_kernel` exists) fails on
modern macOS.

This change replaces that detection logic with a test to make sure that
1) the system is a Unix system; and 2) `uname -s` is `Darwin`.

Ideally, I'd have used `Unix` to execute `uname -s` and read its stdout,
but the `Unix` library is unavailable (herdtools7 targeting things other
than *nix!)