### PR TITLE
[herd,C] support "(void) expr;" statement

### DIFF
--- a/lib/CParser.mly
+++ b/lib/CParser.mly
@@ -239,6 +239,8 @@ instruction:
   { $1 }
 | IDENTIFIER EQ expr SEMI
   { StoreReg(None,$1,$3) }
+| LPAR VOID RPAR expr SEMI
+  { StoreReg(None,"",$4) }
 | STAR location EQ expr SEMI
   { StoreMem($2,$4,AN []) }
 | STORE LBRACE annot_list RBRACE LPAR expr COMMA expr RPAR SEMI


### PR DESCRIPTION
In C language, a "(void) expr;" statement is used for executing "expr"
while discarding the return value of "expr". And currently herd doesn't
support this kind of statement.

In order to support the following litmus test, this functionality is
added.

	C Atomic-set-observable-to-RMW

	{
	  atomic_t v = ATOMIC_INIT(1);
	}

	P0(atomic_t *v)
	{
	  (void)atomic_add_unless(v,1,0);
	}

	P1(atomic_t *v)
	{
	  atomic_set(v, 0);
	}

	locations [v]
	exists
	(v=2)

The implementation is quite simple: we convert the "(void) expr;"
statement into a StoreReg whose destination is register named "", since
no one can declare a identifier named "", so we don't need to worry
about the side effect of storing to this register.

Signed-off-by: Boqun Feng <boqun.feng@gmail.com>