### PR TITLE
Intra-dependency changes for AArch64

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -371,10 +371,11 @@ module Make
             | A_SMIN -> Op.Min in
             let read_mem = if noret then fun sz -> old_do_read_mem sz NoRet else rmw_amo_read rmw
             and write_mem = rmw_amo_write rmw in
-            M.amo op
-              ma (read_reg_data sz rs ii)
-              (fun a -> read_mem sz a ii) (fun a v -> write_mem sz a v ii)
-            >>= fun w ->if noret then M.unitT () else write_reg_sz_non_mixed sz rt w ii)
+            M.amo_strict op
+              ma
+              (fun a -> read_mem sz a ii) (read_reg_data sz rs ii)
+              (fun a v -> write_mem sz a v ii)
+              (fun w ->if noret then M.unitT () else write_reg_sz_non_mixed sz rt w ii))
           (read_reg_ord rn ii)
           ii
 

--- a/herd/libdir/deps.cat
+++ b/herd/libdir/deps.cat
@@ -6,10 +6,10 @@ let addr = [R]; dd-restrict; [NDATA]; intrinsic; [M]
 let sim = (same-instr & ((EXEC*SPEC) | (SPEC*EXEC))) \ id
 
 (* Computation of equiv-spec, by intersection with equivalent  histories *)
-let co-loc =
+let co-step =
     let ww-loc = [W];po-loc;[W] in
     ww-loc\(ww-loc;ww-loc)
-let dep = (iico_data|rf-reg-restrict|rfi|co-loc)^-1
+let dep = (iico_data|iico_ctrl|rf-reg-restrict|rfi|co-step)^-1
 let diffw =(loc & (W * W)) \ id
 let diff = ((rfe^-1;diffw;rf)|(rf^-1;diffw;rfe))
 let bisim = bisimulation(dep,same-static\diff)\id

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -47,11 +47,32 @@ module type S =
     val bind_ctrl_avoid : 'c t -> 'a t -> ('a -> 'b t) -> 'b t
     val check_tags : 'v t -> ('v -> 'v t) -> ('v -> 'v -> 'v t) -> 'x t -> 'v t
     val exch : 'a t -> 'a t -> ('a -> 'b t) ->  ('a -> 'c t) ->  ('b * 'c) t
+
+(*
+  Those amo_strict and swp are the AArch64 combinators,
+  with complete internal dependencies.
+
+  In particular there is a iico_ctrl dependency
+  from read_register to write_register.
+  The dependency from read_mem to write_mem is iico_ctrl for swp
+  and iico_data for amo_strict.
+*)
     val swp : ('loc t) ->
-        ('loc -> 'v t) -> 'w t -> ('loc -> 'w -> unit t) -> ('v -> unit t)
+      ('loc -> A.V.v t) -> A.V.v t (* read reg *) ->
+        ('loc -> A.V.v -> unit t) ->  (A.V.v -> unit t) (* Write reg *)
           -> unit t
+
+    val amo_strict : Op.op -> ('loc t) ->
+      ('loc -> A.V.v t) -> A.V.v t (* read reg *) ->
+        ('loc -> A.V.v -> unit t) ->  (A.V.v -> unit t) (* Write reg *)
+          -> unit t
+
+
     val linux_exch :
         'loc t -> 'v t -> ('loc -> 'w t) -> ('loc -> 'v -> unit t) -> 'w t
+
+(* Weak amo, without control dependency from read read to write reg.
+  In fact, the write reg is absent *)
     val amo : Op.op ->
       'loc t -> A.V.v t -> ('loc -> A.V.v t) -> ('loc -> A.V.v -> unit t) -> A.V.v t
 


### PR DESCRIPTION
Have stronger dependencies by adding some iico_ctrl internal dependencies and by including iico_ctrl in addr/data dependencies and in transition relation history reconstruction.