### PR TITLE
[AArch64 MTE] Fix tag init on DpAddr and DpData

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -992,6 +992,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       match e.dir,e.loc with
       | None,_ -> Warn.fatal "TODO"
       | Some d,Data loc ->
+          let loc = add_tag loc e.tag in
           begin match d,e.atom with
           | R,None ->
               let module LDR =
@@ -1179,6 +1180,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
                   [Instruction (calc0 vdep r2 r1) ;
                    Instruction (addi r2 r2 e.v); ] in
                 r2,cs2,init,st in
+          let loc = add_tag loc e.tag in
           begin match e.atom with
           | None ->
               let init,cs,st = STR.emit_store_reg st p init loc r2 in


### PR DESCRIPTION
Currently, using diy with address or data dependencies generates litmus tests where some addresses have no tag. From what I have observed it doesn't change anything functionnally, as the missing tags are the default ones, but there may be other cases.
In any case, having all addresses be tagged seems better for consistency.