### PR TITLE
Run `make all` at pre-commit when changing OCaml & Dune files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,12 @@ repos:
     -   id: check-executables-have-shebangs
     -   id: check-yaml
     -   id: mixed-line-ending
+
+-   repo: local
+    hooks:
+    -   id: make-all
+        name: Run make all
+        language: system
+        entry: make all
+        files: (dune|\.ml.*$)
+        pass_filenames: false


### PR DESCRIPTION
This should help ensure that changes being committed definitely don't break anything, but allowing e.g. documentation to be updated without triggering a rebuild.

From here, I want to add some tests, then add a similar pre-commit hook to run those via `make test` or similar.