### PR TITLE
[all] Lint opam

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,9 @@ repos:
         entry: make all
         files: (dune|\.ml.*$)
         pass_filenames: false
+
+    -   id: opam-lint
+        name: opam lint
+        language: system
+        entry: opam lint
+        files: (\.opam$)

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "herdtools7"
-version: "7.56+02(dev)"
+version: "7.56+02~dev"
 synopsis: "The herdtools suite for simulating and studying weak memory models"
 description: ""
 maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"


### PR DESCRIPTION
This PR fixes the version in `herdtools7.opam`, and adds a [pre-commit](https://pre-commit.com) check to run `opam lint` on commits that change it.