### PR TITLE
[herd]: Added partial support for AArch64 LDP/STP

### DIFF
--- a/herd/unittests/AArch64/A144.litmus
+++ b/herd/unittests/AArch64/A144.litmus
@@ -1,0 +1,12 @@
+AArch64 A144
+
+(* Equivalent to A02, but with symbolic addresses *)
+
+ { 0:X0 = 1; 0:X1=2; int64_t z=0; 0:X2=z; }
+(* Note we cannot do the fully symbolic case yet without a larger 128-bit type*)
+(* to store 2 64-bit values, or a vector type - cannot do XREG case *)
+P0;
+  STP W0, W1, [X2];
+
+exists (z=8589934593)
+(* this is 1 and 2 next to each other in binary*)

--- a/herd/unittests/AArch64/A145.litmus
+++ b/herd/unittests/AArch64/A145.litmus
@@ -1,0 +1,12 @@
+AArch64 A145
+(* Tests load pair *)
+(* Equivalent to A03, but with symbolic addresses *)
+(* Note we cannot do the fully symbolic case yet without a larger 128-bit type*)
+(* to store 2 64-bit values, or a vector type - cannot do XREG case *)
+{ 0:X2=x; uint64_t x=8589934593}
+(* this is 1 and 2 next to each other in binary*)
+
+P0;
+  LDP W0, W1, [X2];
+
+exists (0:X0=1 /\ 0:X1=2)

--- a/herd/unittests/AArch64/A146.litmus
+++ b/herd/unittests/AArch64/A146.litmus
@@ -1,0 +1,13 @@
+AArch64 A146
+(* Tests load pair, symbolic location, no offset*)
+(* equivalent to A31 but without numeric addresses*)
+
+(* Note we cannot do the fully symbolic case yet without a larger 128-bit type*)
+(* to store 2 64-bit values, or a vector type - cannot do XREG case *)
+{ 0:X2=x; uint64_t x=8589934593}
+(* this is 1 and 2 next to each other in binary*)
+
+P0;
+  LDP W0, W1, [X2];
+
+exists (0:X0=1 /\ 0:X1=2)

--- a/herd/unittests/README.md
+++ b/herd/unittests/README.md
@@ -1,0 +1,15 @@
+
+This repository contains unittests for the implementations of architectures in herd.
+
+These are intended as sanity checks to ensure that the instruction act as originally intended. This is by no means exhaustive.
+
+As a principle, each time you extend an architecture you should add unit tests for all instruction variants you touch.
+
+The tests should return Always, that is a precise state/set of states when run with, for instance:
+
+For AArch64
+```
+herd7 -model aarch64.cat A**.litmus
+```
+
+

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -159,6 +159,10 @@ kr0:
 | COMMA wreg COMMA SXTW {  A.RV (A.V32,$2) }
 /* For indexed accesses SXTW is considered always present */
 
+kr0_no_shift:
+| { A.K (MetaConst.zero) }
+| COMMA k { A.K $2 }
+
 kwr:
 | k { A.K $1 }
 | wreg { A.RV (A.V32,$1) }
@@ -221,13 +225,13 @@ instr:
 /* Memory */
 | LDR reg COMMA LBRK xreg kr0 RBRK
   { let v,r = $2 in A.I_LDR (v,r,$5,$6) }
-| ldp_instr wreg COMMA wreg COMMA LBRK xreg kr0 RBRK
+| ldp_instr wreg COMMA wreg COMMA LBRK xreg kr0_no_shift RBRK
   { $1 A.V32 $2 $4 $7 $8 }
-| ldp_instr xreg COMMA xreg COMMA LBRK xreg kr0 RBRK
+| ldp_instr xreg COMMA xreg COMMA LBRK xreg kr0_no_shift RBRK
   { $1 A.V64 $2 $4 $7 $8 }
-| stp_instr wreg COMMA wreg COMMA LBRK xreg kr0 RBRK
+| stp_instr wreg COMMA wreg COMMA LBRK xreg kr0_no_shift RBRK
   { $1 A.V32 $2 $4 $7 $8 }
-| stp_instr xreg COMMA xreg COMMA LBRK xreg kr0 RBRK
+| stp_instr xreg COMMA xreg COMMA LBRK xreg kr0_no_shift RBRK
   { $1 A.V64 $2 $4 $7 $8 }
 | LDRB wreg COMMA LBRK xreg kr0 RBRK
   { A.I_LDRBH (A.B,$2,$5,$6) }


### PR DESCRIPTION
Following the review of https://github.com/herd/herdtools7/pull/29

This patch upstreams support for Load/Store pair instructions for
AArch64 in Herd. The patch linked above contains more code for numeric
addressing which has been removed here. In detail this patch does:

- partial support for Wreg load/store pairs, we cannot handle the xreg
  case just yet as it requires more work.

This patch does not:

- Add any kind of numeric addressing capabilities as alluded to in #29.
- Add any kind of support for vectors - or indeed a large 128-bit type.

This patch raises questions about what we do in the fully symbolic case
for:

STP Xn, Xm, [Xn] where Xn and Xm contain 64-bit values and Xn points to
a value

In herd the largest possible sized type is int64_t and so storing Xn
causes out-of-bounds errors as we are writing 128-bits worth of data. We
have a solution to this in the works, but for now we can safely upstream
this patch so that it works for wregs. It may be preferable to add a
pattern for 'unsupported xregs' until we upstream the solution for xregs.

The same reasoning applies to LDP instructions