### PR TITLE
[herd] Add a flag -set-libdir to set the libdir

### DIFF
--- a/herd/Version_herd.ml
+++ b/herd/Version_herd.ml
@@ -1,3 +1,0 @@
-include Version
-
-let libdir = Filename.concat libdir "herd"

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -148,10 +148,12 @@ let gen_model_opt s =
 let options = [
 (* Basic *)
   ("-version", Arg.Unit
-     (fun () -> printf "%s, Rev: %s\n" Version_herd.version Version_herd.rev ; exit 0),
+     (fun () -> printf "%s, Rev: %s\n" Version.version Version.rev ; exit 0),
    " show version number and exit") ;
-  ("-libdir", Arg.Unit (fun () -> print_endline Version_herd.libdir; exit 0),
+  ("-libdir", Arg.Unit (fun () -> print_endline !Opts.libdir; exit 0),
     " show installation directory and exit");
+  ("-set-libdir", Arg.String (fun s -> Opts.libdir := s),
+    "<path> set installation directory to <path>");
   ("-v", Arg.Unit (fun _ -> incr verbose),
    "<non-default> show various diagnostics, repeat to increase verbosity");
   ("-q", Arg.Unit (fun _ -> verbose := -1; debug := Debug_herd.none),

--- a/herd/lexConf_herd.mll
+++ b/herd/lexConf_herd.mll
@@ -106,7 +106,7 @@ let handle_key main key arg = match key with
         (struct
           let includes = !includes
           let env = Some "HERDLIB"
-          let libdir = Version_herd.libdir
+          let libdir = !Opts.libdir
           let debug = !debug.Debug_herd.files
         end) in
       dolex main (ML.find arg)

--- a/herd/opts.ml
+++ b/herd/opts.ml
@@ -24,6 +24,7 @@ let prog =
 
 (* Local options *)
 let verbose = ref 0
+let libdir = ref (Filename.concat Version.libdir "herd")
 let includes = ref []
 let exit_if_failed = ref false
 let debug = ref Debug_herd.none
@@ -163,7 +164,7 @@ let libfind includes debug =
       (struct
         let includes = includes
         let env = Some "HERDLIB"
-        let libdir = Version_herd.libdir
+        let libdir = !libdir
         let debug = debug
       end) in
   ML.find

--- a/herd/opts.mli
+++ b/herd/opts.mli
@@ -23,6 +23,7 @@ val prog : string
 
 (* Local options *)
 val verbose : int ref
+val libdir : string ref
 val includes : string list ref
 val exit_if_failed : bool ref
 val debug : Debug_herd.t ref


### PR DESCRIPTION
Also remove Version_herd.ml, because libdir is now defined in opts.ml.

This means that the binary can be run as, e.g.

    % _build/herd/herd.native -set-libdir=./herd/libdir foo.litmus

Comparing with & without the flag:

    % _build/install/default/bin/herd7 -libdir
    /Users/ethmor02/share/herdtools7/herd
    % _build/install/default/bin/herd7 -set-libdir=./herd/libdir -libdir
    ./herd/libdir

