### PR TITLE
HINTs as Nops in AArch64

### DIFF
--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -26,6 +26,8 @@ let check_name name =
 if O.debug then Printf.eprintf "Check: '%s'\n"  name ;
 match name with
 | "nop"|"NOP" -> NOP
+(* Hints are NOPS in AArch64 *)
+| "hint"|"HINT" -> HINT
 (* Branch *)
 | "b"  | "B"  -> B
 | "br"  | "BR"  -> BR

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -36,7 +36,7 @@ module A = AArch64Base
 %token LSL LSR ASR UXTW
 
 /* Instructions */
-%token NOP
+%token NOP HINT
 %token B BR BEQ BNE BGE BGT BLE BLT CBZ CBNZ EQ NE GE GT LE LT TBZ TBNZ
 %token BL BLR RET
 %token LDR LDP LDNP STP STNP LDRB LDRH STR STRB STRH STLR STLRB STLRH
@@ -199,6 +199,7 @@ label_addr:
 
 instr:
 | NOP { A.I_NOP }
+| HINT NUM { A.I_NOP }
 /* Branch */
 | B NAME { A.I_B $2 }
 | BR xreg { A.I_BR $2 }


### PR DESCRIPTION
Following https://github.com/herd/herdtools7/pull/30

This patch upstreams support for the HINT instruction. This
instruction has specific meaning allocated on a case by case basis, or
otherwise implemented as a NOP, as noted here:

https://developer.arm.com/docs/ddi0596/e/base-instructions-alphabetic-order/hi
nt-hint-instruction