### PR TITLE
Added MOVZ operation with barrel shift operands

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -109,7 +109,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
           Some (bh_to_sz v)
       | I_NOP|I_B _|I_BR _|I_BC (_, _)|I_CBZ (_, _, _)
       | I_CBNZ (_, _, _)|I_BL _|I_BLR _|I_RET _|I_LDAR (_, _, _, _)
-      | I_TBZ (_,_,_,_) | I_TBNZ (_,_,_,_) | I_MOV (_, _, _)|I_SXTW (_, _)|I_OP3 (_, _, _, _, _, _)
+      | I_TBZ (_,_,_,_) | I_TBNZ (_,_,_,_) | I_MOVZ (_,_,_,_)|I_MOV (_, _, _)|I_SXTW (_, _)|I_OP3 (_, _, _, _, _, _)
       | I_ADDR (_, _)|I_RBIT (_, _, _)|I_FENCE _
       | I_CSEL (_, _, _, _, _, _)|I_IC (_, _)|I_DC (_, _)|I_MRS (_, _)
       | I_STG _ | I_STZG _ | I_LDG _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -282,6 +282,24 @@ module Make
                   read_mem_acquire_pc sz rd a ii)
           (read_reg_ord rs ii) ii
 
+      let movz sz rd k os ii =
+        let open AArch64Base in
+        assert (MachSize.is_imm16 k);
+        begin match sz, os with
+        | V32, S_NOEXT | V64, S_NOEXT ->
+          (* Or'ing zero with value should zero out what's left *)
+          M.unitT (V.intToV k)
+        | V32, S_LSL(0|16 as s)
+        | V64, S_LSL((0|16|32|48 as s)) ->
+          M.op1 (Op.LeftShift s) (V.intToV k)
+        | _, S_LSL(_) | _, _ ->
+            Warn.fatal
+              "illegal instruction %s"
+              (dump_instruction (I_MOVZ (sz, rd, K k, os)))
+        end
+          >>= (fun v -> write_reg rd v ii)
+          >>! B.Next
+
       and stxr sz t rr rs rd ii =
         let open AArch64Base in
         lift_memop
@@ -507,6 +525,11 @@ module Make
         | I_MOV(var,r1,RV (_,r2)) ->
             let sz = tr_variant var in
             read_reg_ord_sz sz r2 ii >>= fun v -> write_reg r1 v ii >>! B.Next
+
+        | I_MOVZ(var,rd,K k,os) ->
+            movz var rd k os ii
+        | I_MOVZ(_,_,_,_) ->
+            Warn.fatal "Illegal argument in movz, expecting imm16 only"
 
         | I_ADDR (r,lbl) ->
             write_reg r (V.nameToV lbl) ii >>! B.Next

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -295,7 +295,7 @@ module Make
         | _, S_LSL(_) | _, _ ->
             Warn.fatal
               "illegal instruction %s"
-              (dump_instruction (I_MOVZ (sz, rd, K k, os)))
+              (dump_instruction (I_MOVZ (sz, rd, k, os)))
         end
           >>= (fun v -> write_reg rd v ii)
           >>! B.Next
@@ -526,10 +526,8 @@ module Make
             let sz = tr_variant var in
             read_reg_ord_sz sz r2 ii >>= fun v -> write_reg r1 v ii >>! B.Next
 
-        | I_MOVZ(var,rd,K k,os) ->
+        | I_MOVZ(var,rd,k,os) ->
             movz var rd k os ii
-        | I_MOVZ(_,_,_,_) ->
-            Warn.fatal "Illegal argument in movz, expecting imm16 only"
 
         | I_ADDR (r,lbl) ->
             write_reg r (V.nameToV lbl) ii >>! B.Next

--- a/herd/unittests/AArch64/A51.litmus
+++ b/herd/unittests/AArch64/A51.litmus
@@ -1,0 +1,10 @@
+AArch64 A51
+(* Tests movz, 32-bit, no shift *)
+
+{ 0:X0=0; }
+
+P0;
+MOVZ W0, #42;
+
+exists (0:X0=42)
+

--- a/herd/unittests/AArch64/A52.litmus
+++ b/herd/unittests/AArch64/A52.litmus
@@ -1,0 +1,10 @@
+AArch64 A52
+(* Tests movz, 64-bit, no shift *)
+
+{ 0:X0=0; }
+
+P0;
+MOVZ X0, #42;
+
+exists (0:X0=42)
+

--- a/herd/unittests/AArch64/A53.litmus
+++ b/herd/unittests/AArch64/A53.litmus
@@ -1,0 +1,10 @@
+AArch64 A53
+(* Tests movz, 32-bit, LSL 0 (noop) *)
+
+{ 0:X0=0; }
+
+P0;
+MOVZ W0, #42, LSL #0;
+
+exists (0:X0=42)
+

--- a/herd/unittests/AArch64/A54.litmus
+++ b/herd/unittests/AArch64/A54.litmus
@@ -1,0 +1,10 @@
+AArch64 A54
+(* Tests movz, 64-bit, LSL 0 (noop) *)
+
+{ 0:X0=0; }
+
+P0;
+MOVZ X0, #42, LSL #0;
+
+exists (0:X0=42)
+

--- a/herd/unittests/AArch64/A55.litmus
+++ b/herd/unittests/AArch64/A55.litmus
@@ -1,0 +1,10 @@
+AArch64 A55
+(* Tests movz, 32-bit, LSL 16 *)
+
+{ 0:X0=0; }
+
+P0;
+MOVZ W0, #42, LSL #16;
+
+exists (0:X0=2752512)
+

--- a/herd/unittests/AArch64/A56.litmus
+++ b/herd/unittests/AArch64/A56.litmus
@@ -1,0 +1,10 @@
+AArch64 A56
+(* Tests movz, 64-bit, LSL 16 *)
+
+{ 0:X0=0; }
+
+P0;
+MOVZ X0, #42, LSL #16;
+
+exists (0:X0=2752512)
+

--- a/herd/unittests/AArch64/A57.litmus
+++ b/herd/unittests/AArch64/A57.litmus
@@ -1,0 +1,10 @@
+AArch64 A57
+(* Tests movz, 64-bit, LSL 32 *)
+
+{ 0:X0=0; }
+
+P0;
+MOVZ X0, #42, LSL #32;
+
+exists (0:X0=180388626432)
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -125,6 +125,11 @@ include Arch.MakeArch(struct
         conv_reg r >> fun r ->
         expl_kr kr >! fun kr ->
         I_MOV(a,r,kr)
+    | I_MOVZ(a,r,kr,s) ->
+        conv_reg r >> fun r  ->
+        expl_kr kr >> fun kr ->
+        find_shift s >! fun s->
+        I_MOVZ(a,r,kr,s)
     | I_ADDR (r,lbl) ->
         conv_reg r >> fun r ->
         find_lab lbl >! fun lbl ->

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -125,11 +125,11 @@ include Arch.MakeArch(struct
         conv_reg r >> fun r ->
         expl_kr kr >! fun kr ->
         I_MOV(a,r,kr)
-    | I_MOVZ(a,r,kr,s) ->
+    | I_MOVZ(a,r,k,s) ->
         conv_reg r >> fun r  ->
-        expl_kr kr >> fun kr ->
+        find_cst k >> fun k ->
         find_shift s >! fun s->
-        I_MOVZ(a,r,kr,s)
+        I_MOVZ(a,r,k,s)
     | I_ADDR (r,lbl) ->
         conv_reg r >> fun r ->
         find_lab lbl >! fun lbl ->

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -441,6 +441,7 @@ type 'k kinstruction =
   | I_STOPBH of  atomic_op * bh * w_type  * reg * reg
 (* Operations *)
   | I_MOV of variant * reg * 'k kr
+  | I_MOVZ of variant * reg * 'k kr * 'k s
   | I_SXTW of reg * reg
   | I_OP3 of variant * op * reg * reg * 'k kr * 'k s
   | I_ADDR of reg * lbl
@@ -632,6 +633,10 @@ let do_pp_instruction m =
 (* Operations *)
   | I_MOV (v,r,kr) ->
       pp_rkr "MOV" v r kr
+  | I_MOVZ (v,r,kr,S_NOEXT) ->
+      pp_rkr "MOVZ" v r kr
+  | I_MOVZ (v,r,kr,s) ->
+      pp_rkr "MOVZ" v r kr ^ "," ^ pp_barrel_shift "," s (m.pp_k)
   | I_SXTW (r1,r2) ->
       sprintf "SXTW %s,%s" (pp_xreg r1) (pp_wreg r2)
   | I_OP3 (v,SUBS,ZR,r,K k, S_NOEXT) ->
@@ -712,7 +717,7 @@ let fold_regs (f_regs,f_sregs) =
   | I_NOP | I_B _ | I_BC _ | I_BL _ | I_FENCE _ | I_RET None
     -> c
   | I_CBZ (_,r,_) | I_CBNZ (_,r,_) | I_BLR r | I_BR r | I_RET (Some r)
-  | I_MOV (_,r,_) | I_ADDR (r,_) | I_IC (_,r) | I_DC (_,r) | I_MRS (r,_)
+  | I_MOV (_,r,_) | I_MOVZ (_,r,_,_) |  I_ADDR (r,_) | I_IC (_,r) | I_DC (_,r) | I_MRS (r,_)
   | I_TBNZ (_,r,_,_) | I_TBZ (_,r,_,_) -> fold_reg r c
   | I_LDAR (_,_,r1,r2) | I_STLR (_,r1,r2) | I_STLRBH (_,r1,r2)
   | I_SXTW (r1,r2) | I_LDARBH (_,_,r1,r2)
@@ -821,6 +826,8 @@ let map_regs f_reg f_symb =
 (* Operations *)
   | I_MOV (v,r,k) ->
       I_MOV (v,map_reg r,k)
+  | I_MOVZ (v,r,k,s) ->
+      I_MOVZ (v,map_reg r,k,s)
   | I_SXTW (r1,r2) ->
       I_SXTW (map_reg r1,map_reg r2)
   | I_OP3 (v,op,r1,r2,kr,os) ->
@@ -883,6 +890,7 @@ let get_next = function
   | I_LDRBH _
   | I_STRBH _
   | I_MOV _
+  | I_MOVZ _
   | I_SXTW _
   | I_OP3 _
   | I_FENCE _
@@ -967,6 +975,7 @@ include Pseudo.Make
         | I_TBNZ (v,r1,k,lbl) -> I_TBNZ (v,r1,k_tr k, lbl)
         | I_TBZ (v,r1,k,lbl) -> I_TBZ (v,r1,k_tr k, lbl)
         | I_MOV (v,r,k) -> I_MOV (v,r,kr_tr k)
+        | I_MOVZ (v,r,k,s) -> I_MOVZ (v,r,kr_tr k,ap_shift k_tr s)
         | I_OP3 (v,op,r1,r2,kr,s) -> I_OP3 (v,op,r1,r2,kr_tr kr,ap_shift k_tr s)
 
 
@@ -993,6 +1002,7 @@ include Pseudo.Make
         | I_TBZ _
         | I_TBNZ _
         | I_MOV _
+        | I_MOVZ _
         | I_SXTW _
         | I_OP3 _
         | I_FENCE _

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -441,7 +441,7 @@ type 'k kinstruction =
   | I_STOPBH of  atomic_op * bh * w_type  * reg * reg
 (* Operations *)
   | I_MOV of variant * reg * 'k kr
-  | I_MOVZ of variant * reg * 'k kr * 'k s
+  | I_MOVZ of variant * reg * 'k * 'k s
   | I_SXTW of reg * reg
   | I_OP3 of variant * op * reg * reg * 'k kr * 'k s
   | I_ADDR of reg * lbl
@@ -633,10 +633,13 @@ let do_pp_instruction m =
 (* Operations *)
   | I_MOV (v,r,kr) ->
       pp_rkr "MOV" v r kr
-  | I_MOVZ (v,r,kr,S_NOEXT) ->
-      pp_rkr "MOVZ" v r kr
-  | I_MOVZ (v,r,kr,s) ->
-      pp_rkr "MOVZ" v r kr ^ "," ^ pp_barrel_shift "," s (m.pp_k)
+  | I_MOVZ (v,r,k,S_NOEXT) ->
+      sprintf "MOVZ %s,%s" (pp_vreg v r) (m.pp_k k)
+  | I_MOVZ (v,r,k,s) ->
+      sprintf "MOVZ %s,%s,%s"
+        (pp_vreg v r)
+        (m.pp_k k)
+        (pp_barrel_shift "," s (m.pp_k))
   | I_SXTW (r1,r2) ->
       sprintf "SXTW %s,%s" (pp_xreg r1) (pp_wreg r2)
   | I_OP3 (v,SUBS,ZR,r,K k, S_NOEXT) ->
@@ -975,7 +978,7 @@ include Pseudo.Make
         | I_TBNZ (v,r1,k,lbl) -> I_TBNZ (v,r1,k_tr k, lbl)
         | I_TBZ (v,r1,k,lbl) -> I_TBZ (v,r1,k_tr k, lbl)
         | I_MOV (v,r,k) -> I_MOV (v,r,kr_tr k)
-        | I_MOVZ (v,r,k,s) -> I_MOVZ (v,r,kr_tr k,ap_shift k_tr s)
+        | I_MOVZ (v,r,k,s) -> I_MOVZ (v,r,k_tr k,ap_shift k_tr s)
         | I_OP3 (v,op,r1,r2,kr,s) -> I_OP3 (v,op,r1,r2,kr_tr kr,ap_shift k_tr s)
 
 

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -268,6 +268,7 @@ match name with
 | "sxtw"|"SXTW" -> SXTW
 | "uxtw"|"UXTW" -> UXTW
 | "mov"|"MOV" -> MOV
+| "movz"|"MOVZ" -> MOVZ
 | "adr"|"ADR" -> ADR
 | "rbit"|"RBIT" -> RBIT
 | "add"|"ADD" -> OP A.ADD

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -40,7 +40,7 @@ module A = AArch64Base
 %token B BR BEQ BNE BGE BGT BLE BLT CBZ CBNZ EQ NE GE GT LE LT TBZ TBNZ
 %token BL BLR RET
 %token LDR LDP LDNP STP STNP LDRB LDRH STR STRB STRH STLR STLRB STLRH
-%token CMP MOV ADR
+%token CMP MOV MOVZ ADR
 %token  LDAR LDARB LDARH LDAPR LDAPRB LDAPRH  LDXR LDXRB LDXRH LDAXR LDAXRB LDAXRH
 %token STXR STXRB STXRH STLXR STLXRB STLXRH
 %token <AArch64Base.op> OP
@@ -654,6 +654,14 @@ instr:
   { A.I_MOV (A.V64,$2,$4) }
 | MOV wreg COMMA kwr
   { A.I_MOV (A.V32,$2,$4) }
+| MOVZ xreg COMMA NUM
+  { A.I_MOVZ (A.V64,$2, A.K (MetaConst.Int $4), A.S_NOEXT) }
+| MOVZ xreg COMMA NUM COMMA LSL k
+  { A.I_MOVZ (A.V64,$2, A.K (MetaConst.Int $4), A.S_LSL $7) }
+| MOVZ wreg COMMA kwr
+  { A.I_MOVZ (A.V32,$2,$4, A.S_NOEXT) }
+| MOVZ wreg COMMA kwr COMMA LSL k
+  { A.I_MOVZ (A.V32,$2,$4, A.S_LSL $7) }
 | ADR xreg COMMA NAME
   { A.I_ADDR ($2,$4) }
 | SXTW xreg COMMA wreg

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -654,13 +654,13 @@ instr:
   { A.I_MOV (A.V64,$2,$4) }
 | MOV wreg COMMA kwr
   { A.I_MOV (A.V32,$2,$4) }
-| MOVZ xreg COMMA NUM
-  { A.I_MOVZ (A.V64,$2, A.K (MetaConst.Int $4), A.S_NOEXT) }
-| MOVZ xreg COMMA NUM COMMA LSL k
-  { A.I_MOVZ (A.V64,$2, A.K (MetaConst.Int $4), A.S_LSL $7) }
-| MOVZ wreg COMMA kwr
+| MOVZ xreg COMMA k
+  { A.I_MOVZ (A.V64,$2, $4, A.S_NOEXT) }
+| MOVZ xreg COMMA k COMMA LSL k
+  { A.I_MOVZ (A.V64,$2, $4, A.S_LSL $7) }
+| MOVZ wreg COMMA k
   { A.I_MOVZ (A.V32,$2,$4, A.S_NOEXT) }
-| MOVZ wreg COMMA kwr COMMA LSL k
+| MOVZ wreg COMMA k COMMA LSL k
   { A.I_MOVZ (A.V32,$2,$4, A.S_LSL $7) }
 | ADR xreg COMMA NAME
   { A.I_ADDR ($2,$4) }

--- a/lib/machSize.ml
+++ b/lib/machSize.ml
@@ -43,6 +43,9 @@ let nbytes = function
 
 let nbits sz = nbytes sz * 8
 
+(* check is 16 bit immediate *)
+let is_imm16 n = n >= 0 && n < 65535
+
 (* Correct endianess *)
 let swap16 x =
   let r = (x land 0xff) lsl 8 in

--- a/lib/machSize.mli
+++ b/lib/machSize.mli
@@ -22,6 +22,7 @@ val debug : sz -> string
 
 val nbytes : sz -> int
 val nbits : sz -> int
+val is_imm16 : int -> bool
 
 val tr_endian : sz -> int -> int
 

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -56,6 +56,15 @@ module Make(V:Constant.S)(C:Config) =
     let add_q = add_type quad
     let add_v = add_type voidstar
 
+(* pretty prints barrel shifters *)
+let pp_shifter = function
+  | S_LSL(s) -> Printf.sprintf "LSL #%d" s;
+  | S_LSR(s) -> Printf.sprintf "LSR #%d" s;
+  | S_ASR(s) -> Printf.sprintf "ASR #%d" s;
+  | S_SXTW -> "SXTW";
+  | S_UXTW -> "UXTW";
+  | S_NOEXT  -> ""
+
 (************************)
 (* Template compilation *)
 (************************)
@@ -445,7 +454,31 @@ module Make(V:Constant.S)(C:Config) =
           memo=sprintf "%s %s,%s" memo f1 f2;
           inputs = r2; outputs=r1; reg_env=add_q (r1@r2);}
 
+    let do_movz memo v rd k os = match v, k, os with
+    | V32, K k, S_LSL(s) ->
+        let r1,f1 = arg1 "wzr" (fun s -> "^wo"^s) rd in
+        { empty_ins with
+          memo=sprintf "%s %s, #%d, %s" memo f1 k (pp_shifter (S_LSL s));
+          outputs=r1; reg_env=add_w r1;}
+    | V32, K k, S_NOEXT ->
+        let r1,f1 = arg1 "wzr" (fun s -> "^wo"^s) rd in
+        { empty_ins with
+          memo=sprintf "%s %s, #%d" memo f1 k;
+          outputs=r1; reg_env=add_w r1;}
+    | V64, K k, S_LSL(s) ->
+        let r1,f1 = arg1 "xzr" (fun s -> "^o"^s) rd in
+        { empty_ins with
+          memo=sprintf "%s %s, #%d, %s" memo f1 k (pp_shifter (S_LSL s));
+          outputs=r1; reg_env=add_q r1;}
+    | V64, K k, S_NOEXT ->
+        let r1,f1 = arg1 "xzr" (fun s -> "^o"^s) rd in
+        { empty_ins with
+          memo=sprintf "%s %s, #%d" memo f1 k;
+          outputs=r1; reg_env=add_q r1;}
+    | _ -> Warn.fatal "Illegal form of %s instruction" memo
+
     let movr = do_movr "mov"
+    and movz = do_movz "movz"
     and rbit = do_movr "rbit"
 
     let sxtw r1 r2 =
@@ -585,6 +618,7 @@ module Make(V:Constant.S)(C:Config) =
 (* Arithmetic *)
     | I_MOV (v,r,K i) ->  movk v r i::k
     | I_MOV (v,r1,RV (_,r2)) ->  movr v r1 r2::k
+    | I_MOVZ (v,rd,i,os) -> movz v rd i os::k
     | I_ADDR (r,lbl) -> adr tr_lab r lbl::k
     | I_RBIT (v,rd,rs) -> rbit v rd rs::k
     | I_SXTW (r1,r2) -> sxtw r1 r2::k

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -618,7 +618,7 @@ let pp_shifter = function
 (* Arithmetic *)
     | I_MOV (v,r,K i) ->  movk v r i::k
     | I_MOV (v,r1,RV (_,r2)) ->  movr v r1 r2::k
-    | I_MOVZ (v,rd,i,os) -> movz v rd i os::k
+    | I_MOVZ (v,rd,i,os) -> movz v rd (K i) os::k
     | I_ADDR (r,lbl) -> adr tr_lab r lbl::k
     | I_RBIT (v,rd,rs) -> rbit v rd rs::k
     | I_SXTW (r1,r2) -> sxtw r1 r2::k


### PR DESCRIPTION
following https://github.com/herd/herdtools7/pull/30

This patch upstreams support for the MOVZ operation in AArch64
with logical shift left (LSL)  operand:

movz Wn, #imm{, LSL #shift1}
movz Xn, #imm{, LSL #shift2}

where shift1 is 0 or 16 for 32-bit register
where shift2 is 0, 16, 32, 48 for 64-bit register