### PR TITLE
[all]: LDR(Immediate) post-indexed write + LDR barrel shifters

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -112,10 +112,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       match sz with
       | Byte -> I_LDRBH (B,r1,r2,K o)
       | Short -> I_LDRBH (H,r1,r2,K o)
-      | Word -> I_LDR (V32,r1,r2,K o)
-      | Quad -> I_LDR (V64,r1,r2,K o)
+      | Word -> I_LDR (V32,r1,r2,K o, S_NOEXT)
+      | Quad -> I_LDR (V64,r1,r2,K o, S_NOEXT)
 
-    let do_ldr v r1 r2 = I_LDR (v,r1,r2,K 0)
+    let do_ldr v r1 r2 = I_LDR (v,r1,r2,K 0, S_NOEXT)
     let ldr = do_ldr vloc
     let ldg r1 r2 = I_LDG (r1,r2,K 0)
     let ldar r1 r2 = I_LDAR (vloc,AA,r1,r2)
@@ -123,7 +123,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let ldxr r1 r2 = I_LDAR (vloc,XX,r1,r2)
     let ldaxr r1 r2 = I_LDAR (vloc,AX,r1,r2)
     let sxtw r1 r2 = I_SXTW (r1,r2)
-    let do_ldr_idx v r1 r2 idx = I_LDR (v,r1,r2,RV (vloc,idx))
+    let do_ldr_idx v r1 r2 idx = I_LDR (v,r1,r2,RV (vloc,idx), S_NOEXT)
     let ldr_idx = do_ldr_idx vloc
 
 
@@ -132,8 +132,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       match sz with
       | Byte -> I_LDRBH (B,r1,r2,RV (v,idx))
       | Short -> I_LDRBH (H,r1,r2,RV (v,idx))
-      | Word -> I_LDR (V32,r1,r2,RV (v,idx))
-      | Quad -> I_LDR (V64,r1,r2,RV (v,idx))
+      | Word -> I_LDR (V32,r1,r2,RV (v,idx), S_NOEXT)
+      | Quad -> I_LDR (V64,r1,r2,RV (v,idx), S_NOEXT)
 
     let str_mixed sz o r1 r2 =
       let open MachSize in

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -96,7 +96,8 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
     module V = V
 
     let mem_access_size = function
-      | I_LDR (v,_,_,_) | I_LDP (_,v,_,_,_,_)
+      | I_LDR (v,_,_,_,_) | I_LDP (_,v,_,_,_,_)
+      | I_LDR_P(v,_,_,_)
       | I_STR (v,_,_,_) | I_STLR (v,_,_) | I_STXR (v,_,_,_,_)
       | I_STP (_,v,_,_,_,_)
       | I_CAS (v,_,_,_,_) | I_SWP (v,_,_,_,_)

--- a/herd/unittests/AArch64/A04.litmus
+++ b/herd/unittests/AArch64/A04.litmus
@@ -1,0 +1,8 @@
+AArch64 A4
+(* Tests load immediate, no offset, from location *)
+{ 0:X1=x }
+
+P0;
+  LDR X0, [X1];
+
+exists (0:X0=0)

--- a/herd/unittests/AArch64/A08.litmus
+++ b/herd/unittests/AArch64/A08.litmus
@@ -1,0 +1,9 @@
+AArch64 A8
+(* Tests load immediate, post-indexed, symbolic location *)
+{ 0:x1=x;}
+
+P0;
+  LDR X0, [X1], #44;
+
+exists (0:X0=0 /\ 0:X1!=x) (* This should be x+44, todo: encode arbitrary expressions *)
+(* See test A9 for a variant that uses a concrete address*)

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -56,6 +56,15 @@ module Make(V:Constant.S)(C:Config) =
     let add_q = add_type quad
     let add_v = add_type voidstar
 
+(* pretty prints barrel shifters *)
+let pp_shifter = function
+  | S_LSL(s) -> Printf.sprintf "LSL #%d" s;
+  | S_LSR(s) -> Printf.sprintf "LSR #%d" s;
+  | S_ASR(s) -> Printf.sprintf "ASR #%d" s;
+  | S_SXTW -> "SXTW";
+  | S_UXTW -> "UXTW";
+  | S_NOEXT  -> ""
+
 (************************)
 (* Template compilation *)
 (************************)
@@ -133,67 +142,97 @@ module Make(V:Constant.S)(C:Config) =
     let ldr_memo t = Misc.lowercase (ldr_memo t)
     let str_memo t = Misc.lowercase (str_memo t)
 
-    let load memo v rD rA kr = match v,kr with
-      | V32,K 0 ->
+    let load memo v rD rA kr os = match v,kr,os with
+      | V32,K 0, S_NOEXT ->
           { empty_ins with
             memo= sprintf "%s ^wo0,[^i0]" memo;
             inputs=[rA];
             outputs=[rD];
             reg_env=[(rA,voidstar);(rD,word)]; }
-      | V32,K k ->
+      | V32,K k, S_NOEXT ->
           { empty_ins with
             memo= sprintf "%s ^wo0,[^i0,#%i]" memo k;
             inputs=[rA];
             outputs=[rD];
             reg_env=[(rA,voidstar);(rD,word)];}
-      | V32,RV (V32,rB) ->
+      | V32,RV (V32,rB), s ->
           let rB,fB = match rB with
           | ZR -> [],"wzr"
           | _  -> [rB],"^wi1" in
+          let shift = match s with
+          | S_NOEXT -> ""
+          | s -> "," ^ pp_shifter s in
           { empty_ins with
-            memo=memo^ sprintf " ^wo0,[^i0,%s,sxtw]" fB;
+            memo=memo^ sprintf " ^wo0,[^i0,%s%s]" fB shift;
             inputs=[rA]@rB;
             outputs=[rD];
             reg_env=add_w rB@[(rA,voidstar); (rD,word);]; }
-      | V64,K 0 ->
+      | V64,K 0, S_NOEXT ->
           { empty_ins with
             memo=memo ^ sprintf " ^o0,[^i0]";
             inputs=[rA];
             outputs=[rD];
             reg_env=[rA,voidstar;rD,quad;]; }
-      | V64,K k ->
+      | V64,K k, s ->
+          let shift = match s with
+          | S_NOEXT -> ""
+          | s -> "," ^ pp_shifter s in
           { empty_ins with
-            memo=memo ^ sprintf " ^o0,[^i0,#%i]" k;
+            memo=memo ^ sprintf " ^o0,[^i0,#%i%s]" k shift;
             inputs=[rA];
             outputs=[rD];
             reg_env=[rA,voidstar; rD,quad;]; }
-      | V64,RV (V64,rB) ->
+      | V64,RV (V64,rB), s ->
           let rB,fB = match rB with
           | ZR -> [],"xzr"
           | _  -> [rB],"^i1" in
+          let shift = match s with
+          | S_NOEXT -> ""
+          | s       -> "," ^ pp_shifter s in
           { empty_ins with
-            memo=memo^ sprintf " ^o0,[^i0,%s]" fB;
+            memo=memo^ sprintf " ^o0,[^i0,%s%s]" fB shift;
             inputs=[rA;]@rB;
             outputs=[rD];
             reg_env=add_q rB@[rA,voidstar;rD,quad]; }
-      | V64,RV (V32,rB) ->
+      | V64,RV (V32,rB), s ->
           let rB,fB = match rB with
           | ZR -> [],"wzr"
           | _  -> [rB],"^wi1" in
+          let shift = match s with
+          | S_NOEXT -> ""
+          | s -> "," ^ pp_shifter s in
           { empty_ins with
-            memo=memo ^ sprintf " ^o0,[^i0,%s,sxtw]" fB;
+            memo=memo ^ sprintf " ^o0,[^i0,%s%s]" fB shift;
             inputs=[rA]@rB;
             outputs=[rD];
             reg_env=add_w rB@[rA,voidstar;rD,quad;]; }
-      | V32,RV (V64,rB) ->
+      | V32,RV (V64,rB), s ->
           let rB,fB = match rB with
           | ZR -> [],"xzr"
           | _  -> [rB],"^i1" in
+          let shift = match s with
+          | S_NOEXT -> ""
+          | s -> "," ^ pp_shifter s in
           { empty_ins with
-            memo=memo^ sprintf " ^wo0,[^i0,%s]" fB;
+            memo=memo^ sprintf " ^wo0,[^i0,%s%s]" fB shift;
             inputs=[rA;]@rB;
             outputs=[rD];
             reg_env=add_q rB@[rA,voidstar;rD,word]; }
+     | _,_,_ -> assert false
+
+    let load_p memo v rD rA k = match v with
+      | V32 ->
+          { empty_ins with
+            memo= sprintf "%s ^wo0,[^i0],#%i" memo k;
+            inputs=[rA];
+            outputs=[rD];
+            reg_env=[(rA,voidstar);(rD,word)];}
+      | V64 ->
+          { empty_ins with
+            memo=memo ^ sprintf " ^o0,[^i0],#%i" k;
+            inputs=[rA];
+            outputs=[rD];
+            reg_env=[rA,voidstar; rD,quad;]; }
 
     let load_pair memo v rD1 rD2 rA kr = match v,kr with
       | V32,K 0 ->
@@ -561,15 +600,16 @@ module Make(V:Constant.S)(C:Config) =
     | I_TBNZ (v,r,k2,lbl) -> tbz tr_lab "tbnz" v r k2 lbl::k
     | I_TBZ (v,r,k2,lbl) -> tbz tr_lab "tbz" v r k2 lbl::k
 (* Load and Store *)
-    | I_LDR (v,r1,r2,kr) -> load "ldr" v r1 r2 kr::k
+    | I_LDR (v,r1,r2,kr,os) -> load "ldr" v r1 r2 kr os::k
+    | I_LDR_P (v,r1,r2,k1) -> load_p "ldr" v r1 r2 k1::k
     | I_LDP (t,v,r1,r2,r3,kr) ->
         load_pair (match t with TT -> "ldp" | NT -> "ldnp") v r1 r2 r3 kr::k
     | I_STP (t,v,r1,r2,r3,kr) ->
         store_pair (match t with TT -> "stp" | NT -> "stnp") v r1 r2 r3 kr::k
-    | I_LDRBH (B,r1,r2,kr) -> load "ldrb" V32 r1 r2 kr::k
-    | I_LDRBH (H,r1,r2,kr) -> load "ldrh" V32 r1 r2 kr::k
-    | I_LDAR (v,t,r1,r2) -> load (ldr_memo t) v r1 r2 k0::k
-    | I_LDARBH (bh,t,r1,r2) -> load (ldrbh_memo bh t) V32 r1 r2 k0::k
+    | I_LDRBH (B,r1,r2,kr) -> load "ldrb" V32 r1 r2 kr S_NOEXT::k
+    | I_LDRBH (H,r1,r2,kr) -> load "ldrh" V32 r1 r2 kr S_NOEXT::k
+    | I_LDAR (v,t,r1,r2) -> load (ldr_memo t) v r1 r2 k0 S_NOEXT::k
+    | I_LDARBH (bh,t,r1,r2) -> load (ldrbh_memo bh t) V32 r1 r2 k0 S_NOEXT::k
     | I_STR (v,r1,r2,kr) -> store "str" v r1 r2 kr::k
     | I_STRBH (B,r1,r2,kr) -> store "strb" V32 r1 r2 kr::k
     | I_STRBH (H,r1,r2,kr) -> store "strh" V32 r1 r2 kr::k


### PR DESCRIPTION
This commit upstreams support for LDR (immediate) with post-indexed
write to the address. This commit also upstreams inline barrel shifters
for the LDR instruction.

This commit also upstreams unittests for these examples

Following https://github.com/herd/herdtools7/pull/31