### PR TITLE
[litmus] Add an optional-ccopt Makefile macro to kvm-aarch64.cfg

### DIFF
--- a/litmus/libdir/kvm-aarch64.cfg
+++ b/litmus/libdir/kvm-aarch64.cfg
@@ -23,5 +23,6 @@ makevar = LIBFDT_archive = $(SRCDIR)/lib/libfdt/libfdt.a
 makevar = libgcc := $(shell $(GCC) $(machine) --print-libgcc-file-name)
 makevar = cstart.o = $(SRCDIR)/arm/cstart64.o
 makevar = FLATLIBS = $(libcflat) $(LIBFDT_archive) $(libgcc) $(libeabi)
+makevar = optional-ccopt = $(shell if $(GCC) -Werror $(1) -S -o /dev/null -xc /dev/null > /dev/null 2>&1; then echo "$(1)"; fi)
 gcc = aarch64-linux-gnu-gcc
-ccopts = -std=gnu99 -ffreestanding -I $(SRCDIR)/lib -I $(SRCDIR)/libfdt -Wall -Werror  -fomit-frame-pointer -Wno-frame-address   -fno-pic  -no-pie -Wmissing-parameter-type -Wold-style-declaration -Woverride-init -O2
+ccopts = -std=gnu99 -ffreestanding -I $(SRCDIR)/lib -I $(SRCDIR)/libfdt -Wall -Werror  -fomit-frame-pointer -Wno-frame-address   -fno-pic  -no-pie -Wmissing-parameter-type -Wold-style-declaration -Woverride-init -O2 $(call optional-ccopt, -mno-outline-atomics)


### PR DESCRIPTION
Building kvm-aarch64 with GCC >= 10.1.0 needs the flag
-mno-outline-atomics. Thus, the ability to optionally enable a flag is
required. This fix is based on upstream kvm-unit-tests,
https://gitlab.com/kvm-unit-tests/kvm-unit-tests/-/commit/4e40b0232355a78234281cd42a8df2cecd30643b.