### PR TITLE
[herd]: Updated label support for BNE,BEQ,CBZ,CBNZ,B,and BL

### DIFF
--- a/herd/unittests/AArch64/A117.litmus
+++ b/herd/unittests/AArch64/A117.litmus
@@ -1,0 +1,11 @@
+AArch64 A117
+(* unconditional Branch instruction *)
+
+ { 0:X0=1; }
+
+P0;
+  B foo;
+  ADD X0, X0, #1;
+  foo: NOP;
+
+forall (0:X0=1)

--- a/herd/unittests/AArch64/A118.litmus
+++ b/herd/unittests/AArch64/A118.litmus
@@ -1,0 +1,11 @@
+AArch64 A118
+(* CBZ instruction *)
+
+ { 0:X0=0; }
+
+P0;
+  CBZ X0, foo;
+  ADD X0, X0, #1;
+  foo: NOP;
+
+forall (0:X0=0)

--- a/herd/unittests/AArch64/A119.litmus
+++ b/herd/unittests/AArch64/A119.litmus
@@ -1,0 +1,11 @@
+AArch64 A119
+(* CBZ instruction *)
+
+ { 0:X0=1; }
+
+P0;
+  CBZ X0, foo;
+  ADD X0, X0, #1;
+  foo: NOP;
+
+forall (0:X0=2)

--- a/herd/unittests/AArch64/A120.litmus
+++ b/herd/unittests/AArch64/A120.litmus
@@ -1,0 +1,11 @@
+AArch64 A120
+(* CBNZ instruction *)
+
+ { 0:X0=0; }
+
+P0;
+  CBNZ X0, foo;
+  ADD X0, X0, #1;
+  foo: NOP;
+
+forall (0:X0=1)

--- a/herd/unittests/AArch64/A121.litmus
+++ b/herd/unittests/AArch64/A121.litmus
@@ -1,0 +1,11 @@
+AArch64 A121
+(* CBNZ instruction *)
+
+ { 0:X0=1; }
+
+P0;
+  CBNZ X0, foo;
+  ADD X0, X0, #1;
+  foo: NOP;
+
+forall (0:X0=1)

--- a/herd/unittests/AArch64/A122.litmus
+++ b/herd/unittests/AArch64/A122.litmus
@@ -1,0 +1,12 @@
+AArch64 A122
+(* BEQ instruction, relies on CMP  *)
+
+ { 0:X0=1; }
+
+P0;
+  CMP X0, #1;
+  B.EQ foo;
+  ADD X0, X0, #1;
+  foo: NOP;
+
+forall (0:X0=1)

--- a/herd/unittests/AArch64/A123.litmus
+++ b/herd/unittests/AArch64/A123.litmus
@@ -1,0 +1,12 @@
+AArch64 A123
+(* BEQ instruction, relies on CMP  *)
+
+ { 0:X0=1; }
+
+P0;
+  CMP X0, #0;
+  B.EQ foo;
+  ADD X0, X0, #1;
+  foo: NOP;
+
+forall (0:X0=2)

--- a/herd/unittests/AArch64/A124.litmus
+++ b/herd/unittests/AArch64/A124.litmus
@@ -1,0 +1,12 @@
+AArch64 A124
+(* BNE instruction, relies on CMP  *)
+
+ { 0:X0=1; }
+
+P0;
+  CMP X0, #1;
+  B.NE foo;
+  ADD X0, X0, #1;
+  foo: NOP;
+
+forall (0:X0=2)

--- a/herd/unittests/AArch64/A125.litmus
+++ b/herd/unittests/AArch64/A125.litmus
@@ -1,0 +1,12 @@
+AArch64 A125
+(* BNE instruction, relies on CMP  *)
+
+ { 0:X0=0; }
+
+P0;
+  CMP X0, #1;
+  B.NE foo;
+  ADD X0, X0, #1;
+  foo: NOP;
+
+forall (0:X0=0)

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -200,20 +200,20 @@ label_addr:
 instr:
 | NOP { A.I_NOP }
 /* Branch */
-| B NAME { A.I_B $2 }
+| B label_addr { A.I_B $2 }
 | BR xreg { A.I_BR $2 }
-| BL NAME { A.I_BL $2 }
+| BL label_addr { A.I_BL $2 }
 | BLR xreg { A.I_BLR $2 }
 | RET  { A.I_RET None }
 | RET xreg { A.I_RET (Some $2) }
-| BEQ NAME { A.I_BC (A.EQ,$2) }
-| BNE NAME { A.I_BC (A.NE,$2) }
+| BEQ label_addr { A.I_BC (A.EQ,$2) }
+| BNE label_addr { A.I_BC (A.NE,$2) }
 | BLE NAME { A.I_BC (A.LE,$2) }
 | BLT NAME { A.I_BC (A.LT,$2) }
 | BGE NAME { A.I_BC (A.GE,$2) }
 | BGT NAME { A.I_BC (A.GT,$2) }
-| CBZ reg COMMA NAME   { let v,r = $2 in A.I_CBZ (v,r,$4) }
-| CBNZ reg COMMA NAME  { let v,r = $2 in A.I_CBNZ (v,r,$4) }
+| CBZ reg COMMA label_addr { let v,r = $2 in A.I_CBZ (v,r,$4) }
+| CBNZ reg COMMA label_addr { let v,r = $2 in A.I_CBNZ (v,r,$4) }
 | TBNZ reg COMMA NUM COMMA label_addr
   { let v,r = $2 in A.I_TBNZ (v,r,MetaConst.Int $4,$6) }
 | TBZ reg COMMA NUM COMMA label_addr


### PR DESCRIPTION
Added support for labels, unittests also provided.

The label_addr production rule will be extended later to support
numeric addresses.

Following https://github.com/herd/herdtools7/pull/32