### PR TITLE
[lib]: HALTs as Nops in AArch64

### DIFF
--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -28,6 +28,8 @@ match name with
 | "nop"|"NOP" -> NOP
 (* Hints are NOPS in AArch64 *)
 | "hint"|"HINT" -> HINT
+(* Halt instructions are used by Debug mode, not needed here - NOP *)
+| "hlt" | "HLT" -> HLT
 (* Branch *)
 | "b"  | "B"  -> B
 | "br"  | "BR"  -> BR

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -36,7 +36,7 @@ module A = AArch64Base
 %token LSL LSR ASR UXTW
 
 /* Instructions */
-%token NOP HINT
+%token NOP HINT HLT
 %token B BR BEQ BNE BGE BGT BLE BLT CBZ CBNZ EQ NE GE GT LE LT TBZ TBNZ
 %token BL BLR RET
 %token LDR LDP LDNP STP STNP LDRB LDRH STR STRB STRH STLR STLRB STLRH
@@ -200,6 +200,7 @@ label_addr:
 instr:
 | NOP { A.I_NOP }
 | HINT NUM { A.I_NOP }
+| HLT NUM { A.I_NOP }
 /* Branch */
 | B NAME { A.I_B $2 }
 | BR xreg { A.I_BR $2 }


### PR DESCRIPTION
Following: https://github.com/herd/herdtools7/pull/31

This patch upstreams the HLT instruction in AArch64.
This instruction is used to enter debug mode, which we don't model here - deferred to NOP.

https://developer.arm.com/docs/ddi0596/b/base-instructions-alphabetic-order/hlt-halt-instruction
