### PR TITLE
[lib]: LDUR instruction in AArch64

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -97,7 +97,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     let mem_access_size = function
       | I_LDR (v,_,_,_,_) | I_LDP (_,v,_,_,_,_)
-      | I_LDR_P(v,_,_,_)
+      | I_LDUR (v,_,_,_)  | I_LDR_P(v,_,_,_)
       | I_STR (v,_,_,_) | I_STLR (v,_,_) | I_STXR (v,_,_,_,_)
       | I_STP (_,v,_,_,_,_)
       | I_CAS (v,_,_,_,_) | I_SWP (v,_,_,_,_)

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -487,6 +487,9 @@ module Make
         | I_LDR_P(var,rd,rs,k) ->
             let sz = tr_variant var in
             ldr_p sz rd rs k ii
+        | I_LDUR(var,rd,rs,k) ->
+            let sz = tr_variant var in
+            ldr sz rd rs (AArch64.K (Option.value k ~default:0)) AArch64.S_NOEXT ii
 
         | I_LDAR(var,t,rd,rs) ->
             let sz = tr_variant var in

--- a/herd/unittests/AArch64/A18.litmus
+++ b/herd/unittests/AArch64/A18.litmus
@@ -1,0 +1,9 @@
+AArch64 A18
+(* Tests unscaled load, given a symbolic location, no offset*)
+{ int64_t x; 0:X1=x;}
+
+P0;
+  LDUR X0, [X1];
+
+exists (0:X0=0)(* Symbolic locations, we can't do much here*)
+

--- a/herd/unittests/AArch64/A18.litmus.expected
+++ b/herd/unittests/AArch64/A18.litmus.expected
@@ -1,0 +1,10 @@
+Test A18 Allowed
+States 1
+0:X0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=0)
+Observation A18 Always 1 0
+Hash=fdc2d418f32e27847c22d22a5d6a55c3
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -70,6 +70,12 @@ include Arch.MakeArch(struct
       ->
         match_kr subs (K k) (K k') >>>
         add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')]
+    | I_LDUR(_,r1,r2,None),I_LDUR(_,r1',r2',None)
+      -> add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')] subs
+    | I_LDUR(_,r1,r2,Some(k)),I_LDUR(_,r1',r2',Some(k'))
+      ->
+        match_kr subs (K k) (K k') >>>
+        add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')]
     | I_LDR(_,r1,r2,kr,s),I_LDR(_,r1',r2',kr',s')
       ->
         match_kr subs kr kr' >>>
@@ -195,6 +201,15 @@ include Arch.MakeArch(struct
         conv_reg r2 >> fun r2 ->
         find_cst k >! fun k ->
         I_LDR_P(a,r1,r2,k)
+    | I_LDUR(a,r1,r2,Some(k)) ->
+        conv_reg r1 >> fun r1 ->
+        conv_reg r2 >> fun r2 ->
+        find_cst k >! fun k ->
+        I_LDUR(a,r1,r2,Some(k))
+    | I_LDUR(a,r1,r2,None) ->
+        conv_reg r1 >> fun r1 ->
+        conv_reg r2 >! fun r2 ->
+        I_LDUR(a,r1,r2,None)
     | I_LDP(t,a,r1,r2,r3,kr) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -54,6 +54,7 @@ match name with
 | "tbz" | "TBZ" -> TBZ
 (* Memory *)
 | "ldr"|"LDR" -> LDR
+| "ldur"|"LDUR" -> LDUR
 | "ldp"|"LDP" -> LDP
 | "ldnp"|"LDNP" -> LDNP
 | "stp"|"STP" -> STP

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -39,7 +39,7 @@ module A = AArch64Base
 %token NOP HINT HLT
 %token B BR BEQ BNE BGE BGT BLE BLT CBZ CBNZ EQ NE GE GT LE LT TBZ TBNZ
 %token BL BLR RET
-%token LDR LDP LDNP STP STNP LDRB LDRH STR STRB STRH STLR STLRB STLRH
+%token LDR LDP LDNP STP STNP LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
 %token CMP MOV MOVZ ADR
 %token  LDAR LDARB LDARH LDAPR LDAPRB LDAPRH  LDXR LDXRB LDXRH LDAXR LDAXRB LDAXRH
 %token STXR STXRB STXRH STLXR STLXRB STLXRH
@@ -247,6 +247,8 @@ instr:
       A.I_LDR_P (v,r,$5,post)
     | _ ->
       A.I_LDR (v,r,$5,kr,os) }
+| LDUR reg COMMA LBRK xreg k0 RBRK
+  { let v,r = $2 in A.I_LDUR (v,r,$5,$6)}
 | ldp_instr wreg COMMA wreg COMMA LBRK xreg kr0_no_shift RBRK
   { $1 A.V32 $2 $4 $7 $8 }
 | ldp_instr xreg COMMA xreg COMMA LBRK xreg kr0_no_shift RBRK

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -625,6 +625,8 @@ let pp_shifter = function
     | I_TBZ (v,r,k2,lbl) -> tbz tr_lab "tbz" v r k2 lbl::k
 (* Load and Store *)
     | I_LDR (v,r1,r2,kr,os) -> load "ldr" v r1 r2 kr os::k
+    | I_LDUR (v,r1,r2,Some(k')) -> load "ldur" v r1 r2 (K k') S_NOEXT ::k
+    | I_LDUR (v,r1,r2,None) -> load "ldur" v r1 r2 (K 0) S_NOEXT ::k
     | I_LDR_P (v,r1,r2,k1) -> load_p "ldr" v r1 r2 k1::k
     | I_LDP (t,v,r1,r2,r3,kr) ->
         load_pair (match t with TT -> "ldp" | NT -> "ldnp") v r1 r2 r3 kr::k


### PR DESCRIPTION
This patch upstreams support for the ldur instruction in AArch64
This does an unscaled load. Unittests are provided.

Following https://github.com/herd/herdtools7/pull/31