### PR TITLE
Regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ D=dune
 #For building with ocamlbuild set
 #D=ocb
 
+ifeq ($(D), dune)
+	HERD = _build/install/default/bin/herd7
+else
+	HERD = _build/herd/herd.native
+endif
+
 all: build
 
 build:
@@ -26,3 +32,19 @@ dune-clean:
 versions:
 	@ sh ./version-gen.sh $(PREFIX)
 	@ dune build --workspace dune-workspace.versions @all
+
+test: regression-tests
+	@ echo "Tests OK."
+
+regression-tests: AArch64-regression-tests
+
+REGRESSION_TEST_DIR = _build/regression-tests
+AARCH64_REGRESSION_TEST_LITMUSES = $(shell find herd/unittests/AArch64 -type f -name '*.litmus')
+AARCH64_REGRESSION_TEST_OUTPUTS  = $(patsubst %.litmus,$(REGRESSION_TEST_DIR)/%.litmus.expected,$(AARCH64_REGRESSION_TEST_LITMUSES))
+
+AArch64-regression-tests: $(AARCH64_REGRESSION_TEST_OUTPUTS)
+	@ $(foreach output,$^,(diff --new-file $(output) $(patsubst $(REGRESSION_TEST_DIR)/%.litmus.expected,%.litmus.expected,$(output)) || (echo $(output); exit 1)) && ) true
+
+$(REGRESSION_TEST_DIR)/%.litmus.expected: %.litmus | build
+	@ mkdir -p $(@D)
+	$(HERD) -set-libdir ./herd/libdir $^ | grep -v -E '^Time' > $@

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ D=dune
 #For building with ocamlbuild set
 #D=ocb
 
-all:
-	sh ./$(D)-build.sh $(PREFIX)
+all: build
 
+build:
+	sh ./$(D)-build.sh $(PREFIX)
 
 install:
 	sh ./$(D)-install.sh $(PREFIX)

--- a/herd/unittests/AArch64/A04.litmus.expected
+++ b/herd/unittests/AArch64/A04.litmus.expected
@@ -1,0 +1,10 @@
+Test A4 Allowed
+States 1
+0:X0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=0)
+Observation A4 Always 1 0
+Hash=b0a348f458429140b16552cc100cdc7c
+

--- a/herd/unittests/AArch64/A08.litmus.expected
+++ b/herd/unittests/AArch64/A08.litmus.expected
@@ -1,0 +1,10 @@
+Test A8 Allowed
+States 1
+0:X0=0; 0:X1=x+44;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=0 /\ not (0:X1=x))
+Observation A8 Always 1 0
+Hash=d1591baf0ba882a97685e1fa37c64e74
+

--- a/herd/unittests/AArch64/A117.litmus.expected
+++ b/herd/unittests/AArch64/A117.litmus.expected
@@ -1,0 +1,10 @@
+Test A117 Required
+States 1
+0:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=1)
+Observation A117 Always 1 0
+Hash=2395520d6f37fe762fc77b0c7a639309
+

--- a/herd/unittests/AArch64/A118.litmus.expected
+++ b/herd/unittests/AArch64/A118.litmus.expected
@@ -1,0 +1,10 @@
+Test A118 Required
+States 1
+0:X0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=0)
+Observation A118 Always 1 0
+Hash=2c67ca5f7d5dba8516e38e179ce54014
+

--- a/herd/unittests/AArch64/A119.litmus.expected
+++ b/herd/unittests/AArch64/A119.litmus.expected
@@ -1,0 +1,10 @@
+Test A119 Required
+States 1
+0:X0=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=2)
+Observation A119 Always 1 0
+Hash=5daab931b4166a533b07d653f8dbc68b
+

--- a/herd/unittests/AArch64/A120.litmus.expected
+++ b/herd/unittests/AArch64/A120.litmus.expected
@@ -1,0 +1,10 @@
+Test A120 Required
+States 1
+0:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=1)
+Observation A120 Always 1 0
+Hash=d12d12f9d769d7e929a451f23adf86af
+

--- a/herd/unittests/AArch64/A121.litmus.expected
+++ b/herd/unittests/AArch64/A121.litmus.expected
@@ -1,0 +1,10 @@
+Test A121 Required
+States 1
+0:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=1)
+Observation A121 Always 1 0
+Hash=4b4169d7e3d627d740b73aeb5b160baf
+

--- a/herd/unittests/AArch64/A122.litmus.expected
+++ b/herd/unittests/AArch64/A122.litmus.expected
@@ -1,0 +1,10 @@
+Test A122 Required
+States 1
+0:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=1)
+Observation A122 Always 1 0
+Hash=b8db76538bdf5ff87be1c35eb1b79fb0
+

--- a/herd/unittests/AArch64/A123.litmus.expected
+++ b/herd/unittests/AArch64/A123.litmus.expected
@@ -1,0 +1,10 @@
+Test A123 Required
+States 1
+0:X0=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=2)
+Observation A123 Always 1 0
+Hash=c8aa1bf1a6264d7527bc370b1333039e
+

--- a/herd/unittests/AArch64/A124.litmus.expected
+++ b/herd/unittests/AArch64/A124.litmus.expected
@@ -1,0 +1,10 @@
+Test A124 Required
+States 1
+0:X0=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=2)
+Observation A124 Always 1 0
+Hash=5570f1f22606f38e48fd51fe1c8265e1
+

--- a/herd/unittests/AArch64/A125.litmus.expected
+++ b/herd/unittests/AArch64/A125.litmus.expected
@@ -1,0 +1,10 @@
+Test A125 Required
+States 1
+0:X0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=0)
+Observation A125 Always 1 0
+Hash=8684c1601b66a4d38149409840529ea6
+

--- a/herd/unittests/AArch64/A39.litmus.expected
+++ b/herd/unittests/AArch64/A39.litmus.expected
@@ -1,0 +1,10 @@
+Test A39 Allowed
+States 1
+0:X1=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X1=0)
+Observation A39 Always 1 0
+Hash=3532427aa9a00b9c73419e84b6720dc9
+

--- a/herd/unittests/AArch64/A40.litmus.expected
+++ b/herd/unittests/AArch64/A40.litmus.expected
@@ -1,0 +1,10 @@
+Test A40 Allowed
+States 1
+0:X1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X1=1)
+Observation A40 Always 1 0
+Hash=89a94b7537aac3cf0c54ce11fedc9299
+

--- a/herd/unittests/AArch64/A41.litmus.expected
+++ b/herd/unittests/AArch64/A41.litmus.expected
@@ -1,0 +1,10 @@
+Test A41 Allowed
+States 1
+0:X1=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X1=0)
+Observation A41 Always 1 0
+Hash=68fcc3fe810b23f725f15397c7e749a4
+

--- a/herd/unittests/AArch64/A42.litmus.expected
+++ b/herd/unittests/AArch64/A42.litmus.expected
@@ -1,0 +1,10 @@
+Test A42 Allowed
+States 1
+0:X1=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X1=0)
+Observation A42 Always 1 0
+Hash=52e5ef1e11570ba4e96f1b8962d85024
+

--- a/herd/unittests/AArch64/A47.litmus.expected
+++ b/herd/unittests/AArch64/A47.litmus.expected
@@ -1,0 +1,10 @@
+Test A47 Allowed
+States 1
+0:X1=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X1=0)
+Observation A47 Always 1 0
+Hash=58368972f556f3fc5e7b084c9534a537
+

--- a/herd/unittests/AArch64/A48.litmus.expected
+++ b/herd/unittests/AArch64/A48.litmus.expected
@@ -1,0 +1,10 @@
+Test A48 Allowed
+States 1
+0:X1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X1=1)
+Observation A48 Always 1 0
+Hash=c9eb0228a45c4dcd9a397f799004860d
+

--- a/herd/unittests/AArch64/A49.litmus.expected
+++ b/herd/unittests/AArch64/A49.litmus.expected
@@ -1,0 +1,10 @@
+Test A49 Allowed
+States 1
+0:X1=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X1=0)
+Observation A49 Always 1 0
+Hash=c1d27ce8314b5761aee04c1460e84a1b
+

--- a/herd/unittests/AArch64/A50.litmus.expected
+++ b/herd/unittests/AArch64/A50.litmus.expected
@@ -1,0 +1,10 @@
+Test A50 Allowed
+States 1
+0:X1=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X1=0)
+Observation A50 Always 1 0
+Hash=c4a0d8401f96a845b7e3488b0aea1ec1
+

--- a/herd/unittests/AArch64/A51.litmus.expected
+++ b/herd/unittests/AArch64/A51.litmus.expected
@@ -1,0 +1,10 @@
+Test A51 Allowed
+States 1
+0:X0=42;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=42)
+Observation A51 Always 1 0
+Hash=1611ac52d31d484b8a8d216395caf808
+

--- a/herd/unittests/AArch64/A52.litmus.expected
+++ b/herd/unittests/AArch64/A52.litmus.expected
@@ -1,0 +1,10 @@
+Test A52 Allowed
+States 1
+0:X0=42;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=42)
+Observation A52 Always 1 0
+Hash=3c026fd18ddf34f3f54848067f25f89f
+

--- a/herd/unittests/AArch64/A53.litmus.expected
+++ b/herd/unittests/AArch64/A53.litmus.expected
@@ -1,0 +1,10 @@
+Test A53 Allowed
+States 1
+0:X0=42;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=42)
+Observation A53 Always 1 0
+Hash=d8d50ee03150172d1e9afcc4b6da8d8a
+

--- a/herd/unittests/AArch64/A54.litmus.expected
+++ b/herd/unittests/AArch64/A54.litmus.expected
@@ -1,0 +1,10 @@
+Test A54 Allowed
+States 1
+0:X0=42;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=42)
+Observation A54 Always 1 0
+Hash=d5b1fa241606e0c8f360e8400cf64d22
+

--- a/herd/unittests/AArch64/A55.litmus.expected
+++ b/herd/unittests/AArch64/A55.litmus.expected
@@ -1,0 +1,10 @@
+Test A55 Allowed
+States 1
+0:X0=2752512;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=2752512)
+Observation A55 Always 1 0
+Hash=e59e662963bc13a720b6862fb3066839
+

--- a/herd/unittests/AArch64/A56.litmus.expected
+++ b/herd/unittests/AArch64/A56.litmus.expected
@@ -1,0 +1,10 @@
+Test A56 Allowed
+States 1
+0:X0=2752512;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=2752512)
+Observation A56 Always 1 0
+Hash=f61feec80de6b2ee66d55203f307a3b8
+

--- a/herd/unittests/AArch64/A57.litmus.expected
+++ b/herd/unittests/AArch64/A57.litmus.expected
@@ -1,0 +1,10 @@
+Test A57 Allowed
+States 1
+0:X0=180388626432;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=180388626432)
+Observation A57 Always 1 0
+Hash=a018ed683fabc467b67793fb012b13be
+

--- a/herd/unittests/AArch64/A63.litmus.expected
+++ b/herd/unittests/AArch64/A63.litmus.expected
@@ -1,0 +1,10 @@
+Test A63 Allowed
+States 1
+0:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=1)
+Observation A63 Always 1 0
+Hash=d16bbe1d52e5026fb2bd42d1e3f90eb4
+

--- a/herd/unittests/AArch64/A64.litmus.expected
+++ b/herd/unittests/AArch64/A64.litmus.expected
@@ -1,0 +1,10 @@
+Test A64 Allowed
+States 1
+0:X0=32;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=32)
+Observation A64 Always 1 0
+Hash=f345fb541fef63340c7b35623a5fda88
+

--- a/herd/unittests/AArch64/A65.litmus.expected
+++ b/herd/unittests/AArch64/A65.litmus.expected
@@ -1,0 +1,10 @@
+Test A65 Allowed
+States 1
+0:X0=32;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=32)
+Observation A65 Always 1 0
+Hash=436f9ec7d06118b7abb83eeec247fe45
+

--- a/herd/unittests/AArch64/A66.litmus.expected
+++ b/herd/unittests/AArch64/A66.litmus.expected
@@ -1,0 +1,10 @@
+Test A66 Allowed
+States 1
+0:X0=42;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=42)
+Observation A66 Always 1 0
+Hash=0bbf4832cac85dbe6dc262ccbb4239ac
+

--- a/herd/unittests/AArch64/A67.litmus.expected
+++ b/herd/unittests/AArch64/A67.litmus.expected
@@ -1,0 +1,10 @@
+Test A67 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A67 Always 1 0
+Hash=2da12aedee65fffa2c410381fd99590e
+

--- a/herd/unittests/AArch64/A68.litmus.expected
+++ b/herd/unittests/AArch64/A68.litmus.expected
@@ -1,0 +1,10 @@
+Test A68 Allowed
+States 1
+0:X0=42;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=42)
+Observation A68 Always 1 0
+Hash=795cc773f32a2bb8918e1dfbe8d918c0
+

--- a/herd/unittests/AArch64/A69.litmus.expected
+++ b/herd/unittests/AArch64/A69.litmus.expected
@@ -1,0 +1,10 @@
+Test A69 Allowed
+States 1
+0:X0=4138;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=4138)
+Observation A69 Always 1 0
+Hash=9f7e1e7ff5aa637baa76567da789bd58
+

--- a/herd/unittests/AArch64/A70.litmus.expected
+++ b/herd/unittests/AArch64/A70.litmus.expected
@@ -1,0 +1,10 @@
+Test A70 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A70 Always 1 0
+Hash=90123e3972cdfa5e7e7beccc76e5ab5c
+

--- a/herd/unittests/AArch64/A71.litmus.expected
+++ b/herd/unittests/AArch64/A71.litmus.expected
@@ -1,0 +1,10 @@
+Test A71 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A71 Always 1 0
+Hash=9bc5cba1374f1ad7fa83e94084a4d23a
+

--- a/herd/unittests/AArch64/A72.litmus.expected
+++ b/herd/unittests/AArch64/A72.litmus.expected
@@ -1,0 +1,10 @@
+Test A72 Allowed
+States 1
+0:X0=58;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=58)
+Observation A72 Always 1 0
+Hash=7d28e54891b24c45a43debc0ea8a4d10
+

--- a/herd/unittests/AArch64/A73.litmus.expected
+++ b/herd/unittests/AArch64/A73.litmus.expected
@@ -1,0 +1,10 @@
+Test A73 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A73 Always 1 0
+Hash=0de471b4b506fda3fa0df471f80e8a45
+

--- a/herd/unittests/AArch64/A74.litmus.expected
+++ b/herd/unittests/AArch64/A74.litmus.expected
@@ -1,0 +1,10 @@
+Test A74 Allowed
+States 1
+0:X0=50;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=50)
+Observation A74 Always 1 0
+Hash=36fe0805cc0febc64c0720a09a03f884
+

--- a/herd/unittests/AArch64/A75.litmus.expected
+++ b/herd/unittests/AArch64/A75.litmus.expected
@@ -1,0 +1,10 @@
+Test A75 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A75 Always 1 0
+Hash=4c9be865453c62f3bf413d04f90156ea
+

--- a/herd/unittests/AArch64/A76.litmus.expected
+++ b/herd/unittests/AArch64/A76.litmus.expected
@@ -1,0 +1,10 @@
+Test A76 Allowed
+States 1
+0:X0=50;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=50)
+Observation A76 Always 1 0
+Hash=06221238e8bc21fedc22d51d70bdd208
+

--- a/herd/unittests/AArch64/A77.litmus.expected
+++ b/herd/unittests/AArch64/A77.litmus.expected
@@ -1,0 +1,10 @@
+Test A77 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A77 Always 1 0
+Hash=6eb82cdb5b6305661eb73eba5b4e416e
+

--- a/herd/unittests/AArch64/A78.litmus.expected
+++ b/herd/unittests/AArch64/A78.litmus.expected
@@ -1,0 +1,10 @@
+Test A78 Allowed
+States 1
+0:X0=42;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=42)
+Observation A78 Always 1 0
+Hash=0b0d3b9d024fe336337b35aa3fab7c22
+

--- a/herd/unittests/AArch64/A79.litmus.expected
+++ b/herd/unittests/AArch64/A79.litmus.expected
@@ -1,0 +1,10 @@
+Test A79 Allowed
+States 1
+0:X0=4138;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=4138)
+Observation A79 Always 1 0
+Hash=ff4beec78c01d093a15c1d7e8fd14abb
+

--- a/herd/unittests/AArch64/A80.litmus.expected
+++ b/herd/unittests/AArch64/A80.litmus.expected
@@ -1,0 +1,10 @@
+Test A80 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A80 Always 1 0
+Hash=c5bb91df2d37b38f41a1a3b11e4e2b9e
+

--- a/herd/unittests/AArch64/A81.litmus.expected
+++ b/herd/unittests/AArch64/A81.litmus.expected
@@ -1,0 +1,10 @@
+Test A81 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A81 Always 1 0
+Hash=739eda1d46909d97bc187850fdfe84c1
+

--- a/herd/unittests/AArch64/A82.litmus.expected
+++ b/herd/unittests/AArch64/A82.litmus.expected
@@ -1,0 +1,10 @@
+Test A82 Allowed
+States 1
+0:X0=58;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=58)
+Observation A82 Always 1 0
+Hash=3c9d63800113f942bfeffddf99d36141
+

--- a/herd/unittests/AArch64/A83.litmus.expected
+++ b/herd/unittests/AArch64/A83.litmus.expected
@@ -1,0 +1,10 @@
+Test A83 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A83 Always 1 0
+Hash=129295e3e1c4463d060e458fe3b830c2
+

--- a/herd/unittests/AArch64/A84.litmus.expected
+++ b/herd/unittests/AArch64/A84.litmus.expected
@@ -1,0 +1,10 @@
+Test A84 Allowed
+States 1
+0:X0=50;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=50)
+Observation A84 Always 1 0
+Hash=06b0ab8a1d46d77e7931eb7cb4a1a71b
+

--- a/herd/unittests/AArch64/A85.litmus.expected
+++ b/herd/unittests/AArch64/A85.litmus.expected
@@ -1,0 +1,10 @@
+Test A85 Allowed
+States 1
+0:X0=43;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=43)
+Observation A85 Always 1 0
+Hash=f303694eda4417bf8195fbe234902377
+

--- a/herd/unittests/AArch64/A86.litmus.expected
+++ b/herd/unittests/AArch64/A86.litmus.expected
@@ -1,0 +1,10 @@
+Test A86 Allowed
+States 1
+0:X0=50;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=50)
+Observation A86 Always 1 0
+Hash=b21f163e719017f811e394d8b47a35cb
+

--- a/herd/unittests/AArch64/L000.litmus.expected
+++ b/herd/unittests/AArch64/L000.litmus.expected
@@ -1,0 +1,10 @@
+Test L000 Required
+States 1
+x=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (x=1)
+Observation L000 Always 1 0
+Hash=3c5726f58582737286d66b578b284edb
+


### PR DESCRIPTION
This PR adds a `make test` target that runs some basic regression tests against `herd` for AArch64 using `mcompare`.