### PR TITLE
Added void star as ret type for C functions

### DIFF
--- a/lib/CParser.mly
+++ b/lib/CParser.mly
@@ -128,6 +128,7 @@ shallow_main:
 
 voidopt:
 | VOID { () }
+| VOID STAR { () }
 | { () }
 
 declaration:


### PR DESCRIPTION
Following https://github.com/herd/herdtools7/pull/31

Consider functions such as:
```
void *P0(int *x) {
  ...
}
```
which are passed to pthread_create functions as commonplace in
concurrent c11 code.

This patch adds the ability to parse `void *` like `void`, that is, we
accept functions with the `void *` or `void` signature but do not yet
act on the semantics of functions.

This patch is needed to work with compiler friendly tests.