### PR TITLE
[diy]: Add NoVolatile value to Variant.t in diy

### DIFF
--- a/gen/CCompile_gen.ml
+++ b/gen/CCompile_gen.ml
@@ -811,7 +811,10 @@ module Make(O:Config) : Builder.S
           List.map
             (fun (t,loc) -> match t with
             | A.Plain _ ->
-                sprintf "volatile %s* %s" (A.dump_typ t) loc
+                let novolatile = O.variant Variant_gen.NoVolatile in
+                let volatile = if novolatile then
+                    "" else "volatile " in
+                sprintf "%s%s* %s" volatile (A.dump_typ t) loc
             | A.Atomic _ ->
                 sprintf "%s* %s" (A.dump_typ t) loc)
             args in

--- a/gen/variant_gen.ml
+++ b/gen/variant_gen.ml
@@ -26,8 +26,10 @@ type t =
   | Self
 (* MTE = Memory tagging *)
   | MemTag
+(* C: Prevents the use of Volatile to capture bugs in compilation *)
+  | NoVolatile
 
-let tags = ["AsAmo";"ConstsInInit";"Mixed";"FullMixed";"Self"; "MemTag"; ]
+let tags = ["AsAmo";"ConstsInInit";"Mixed";"FullMixed";"Self"; "MemTag"; "NoVolatile"]
 
 let parse tag = match Misc.lowercase tag with
 | "asamo" -> Some AsAmo
@@ -36,6 +38,7 @@ let parse tag = match Misc.lowercase tag with
 | "fullmixed" -> Some FullMixed
 | "self" -> Some Self
 | "memtag" -> Some MemTag
+| "novolatile" -> Some NoVolatile
 | _ -> None
 
 let pp = function
@@ -45,3 +48,4 @@ let pp = function
   | FullMixed -> "FullMixed"
   | Self -> "Self"
   | MemTag -> "MemTag"
+  | NoVolatile -> "NoVolatile"

--- a/gen/variant_gen.mli
+++ b/gen/variant_gen.mli
@@ -26,6 +26,8 @@ type t =
   | Self
 (* MTE = Memory tagging *)
   | MemTag
+(* C: Prevents the use of Volatile to capture bugs in compilation *)
+  | NoVolatile
 
 val tags : string list
 


### PR DESCRIPTION
Following https://github.com/herd/herdtools7/pull/33

Added the option to generate C tests without the Volatile option.
Volatile is not currently used for any other reason than to prevent
compiler optimisations to be applied in litmus. If we are to use such
optimisations we must trust they are correct.

This patch removes the qualifier on types as it is not needed in this
case.

No unittests are provided but you can run test the implementation by
running

diy7 -arch C -variant NoVolatile

and check the output C tests do not have volatile qualified types,
you can check these are then accepted by Herd using

herd7 -model rc11.cat *.litmus

We can follow this up with tests once the infrastructure to do this exists.