### PR TITLE
Fix ctrl

### DIFF
--- a/herd/libdir/aarch64deps.cat
+++ b/herd/libdir/aarch64deps.cat
@@ -62,6 +62,6 @@ let addrR =
 let addr = addrW | addrR
 
 (** Control dependencies *)
-let ctrl = to-PoD; po; [W]
+let ctrl = to-PoD; po
 
 include "aarch64show.cat"

--- a/herd/libdir/show-deps.cat
+++ b/herd/libdir/show-deps.cat
@@ -1,9 +1,9 @@
 (* Show dependencies *)
 show data,addr
-let ctrlisb = try ctrl;[ISB];po with 0
+(* Show of control dependencies is restricted, so as not to clobber diagrams *) 
+let ctrlisb = try ctrl;[ISB];po;[M] with 0
 show ctrlisb
-show isb \ ctrlisb as isb
-show ctrl \ ctrlisb as ctrl
+show (ctrl;[M]) \ ctrlisb as ctrl
 
 (* Communication relations *)
 let rf-mem = rf \ rf-reg

--- a/herd/unittests/AArch64/L002.litmus
+++ b/herd/unittests/AArch64/L002.litmus
@@ -1,0 +1,14 @@
+AArch64 L002
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
+Com=Rf Fr
+{
+0:X1=x; 0:X3=y;
+1:X1=y; 1:X3=x;
+}
+ P0          | P1           ;
+ MOV W0,#1   | LDR W0,[X1]  ;
+ STR W0,[X1] | CBZ W0,LC00  ;
+ DMB SY      | ISB          ;
+ MOV W2,#1   | LDR W2,[X3]  ;
+ STR W2,[X3] |LC00:         ;
+exists (1:X0=1 /\ 1:X2=0)

--- a/herd/unittests/AArch64/L002.litmus.expected
+++ b/herd/unittests/AArch64/L002.litmus.expected
@@ -1,0 +1,11 @@
+Test L002 Allowed
+States 2
+1:X0=0; 1:X2=0;
+1:X0=1; 1:X2=1;
+No
+Witnesses
+Positive: 0 Negative: 2
+Condition exists (1:X0=1 /\ 1:X2=0)
+Observation L002 Never 0 2
+Hash=46b6dd93851ecaa429cdcdb54a03ca77
+


### PR DESCRIPTION
Fix too strict definition of ctrl in cat file. As a consequence control + isb dependency to reads was absent, ie not part of dob.