### PR TITLE
[herd] Reformulate the `alias` relation.

### DIFF
--- a/herd/event.ml
+++ b/herd/event.ml
@@ -261,7 +261,6 @@ val same_instance : event -> event -> bool
   val same_location : event -> event -> bool
   val same_location_with_faults : event -> event -> bool
   val same_value : event -> event -> bool
-  val same_PA : event -> event -> bool
 (*  val is_visible_location : A.location -> bool *)
 
 (********************************)
@@ -451,12 +450,6 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
     | Some (A.Location_global a) -> Some a
     | _ -> None
 
-    let is_PTE_loc e = Act.is_PTE_access e.action 
-
-    let is_PA_val e = match value_of e with 
-    | Some v -> Act.is_PA_val v
-    | _ -> assert false
-
 (* Visible locations *)
 (*
     let is_visible_location  = function
@@ -477,9 +470,6 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
     let same_value e1 e2 = match value_of e1, value_of e2 with
     | Some v1,Some v2 -> V.compare v1 v2 = 0
     | _,_ -> false
-
-    let same_PA e1 e2 = 
-      (is_PTE_loc e1) && (is_PA_val e1) && (same_value e1 e2)
 
     let proc_of e = match e.iiid with
     | Some i -> Some i.A.proc

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -37,8 +37,8 @@ end
 
 module Make (C:Config) (A : A) : sig
 
- (* All sorts of accesses, redundunt with symbol hidden in location,
-    when symbol is known, which may not be the case *)
+  (* All sorts of accesses, redundunt with symbol hidden in location,
+     when symbol is known, which may not be the case *)
 
   type access_t = A_REG | A_VIR | A_PHY | A_PTE | A_TLB | A_TAG
 
@@ -107,23 +107,23 @@ end = struct
           else Warn.fatal "PTE %s while -variant kvm is not active"
               (A.pp_location loc)
 (*    | A.Location_global (V.Val (Symbolic ((System (AF,_))))) as loc
-        ->
-          if kvm then A_AF
-          else Warn.fatal "AF %s while -variant kvm is not active"
-              (A.pp_location loc)
+      ->
+      if kvm then A_AF
+      else Warn.fatal "AF %s while -variant kvm is not active"
+      (A.pp_location loc)
       | A.Location_global (V.Val (Symbolic ((System (DB,_))))) as loc
-        ->
-          if kvm then A_DB
-          else Warn.fatal "DB %s while -variant kvm is not active"
-              (A.pp_location loc)
+      ->
+      if kvm then A_DB
+      else Warn.fatal "DB %s while -variant kvm is not active"
+      (A.pp_location loc)
       | A.Location_global (V.Val (Symbolic ((System (DBM,_))))) as loc
-        ->
-          if kvm then A_DBM
-          else Warn.fatal "DBM %s while -variant kvm is not active"
-              (A.pp_location loc)
-*)    | A.Location_global v
-      | A.Location_deref (v,_)
-        -> Warn.fatal "access_of_location_std on non-standard symbol '%s'\n" (V.pp_v v)
+      ->
+      if kvm then A_DBM
+      else Warn.fatal "DBM %s while -variant kvm is not active"
+      (A.pp_location loc)
+ *)    | A.Location_global v
+| A.Location_deref (v,_)
+  -> Warn.fatal "access_of_location_std on non-standard symbol '%s'\n" (V.pp_v v)
 
 
   type action =
@@ -172,7 +172,7 @@ end = struct
       Printf.sprintf "TLBI(%s,%s)" (A.TLBI.pp_op op) (A.pp_location loc)
   | DC (op,None) ->
       Printf.sprintf "DC(%s)" (AArch64Base.DC.pp_op op)
-   | DC(op,Some loc) -> 
+  | DC(op,Some loc) ->
       Printf.sprintf "DC(%s,%s)" (AArch64Base.DC.pp_op op) (A.pp_location loc)
 
 (* Utility functions to pick out components *)
@@ -286,23 +286,23 @@ end = struct
   | _ -> assert false
 
   let is_PTE_access = function 
-  | Access (_,_,_,_,_,_,A_PTE) -> true
-  | _ -> false
+    | Access (_,_,_,_,_,_,A_PTE) -> true
+    | _ -> false
 
   let is_PA_val = let open Constant in function
-  | (A.V.Val (Symbolic (Physical _))) -> true
-  | _ -> false
+    | (A.V.Val (Symbolic (Physical _))) -> true
+    | _ -> false
 
   let is_invalid_val = let open Constant in function
-  | Some (A.V.Val (PteVal v)) -> V.is_zero (V.intToV v.PTEVal.valid) 
-  | _ -> false
+    | Some (A.V.Val (PteVal v)) -> V.is_zero (V.intToV v.PTEVal.valid)
+    | _ -> false
 
   let invalid_pte act = is_invalid_val (written_of act) || is_invalid_val (read_of act)
 
   let is_valid_val = let open Constant in function
-  | Some (A.V.Val (PteVal v)) -> V.is_one (V.intToV v.PTEVal.valid) 
-  | _ -> false
-  
+    | Some (A.V.Val (PteVal v)) -> V.is_one (V.intToV v.PTEVal.valid)
+    | _ -> false
+
   let valid_pte act = is_valid_val (written_of act) || is_valid_val (read_of act)
 
 (* relative to the registers of the given proc *)
@@ -331,7 +331,7 @@ end = struct
   | (A.Location_global _,A.Location_global _)
   | (A.Location_reg _,A.Location_reg _)
   | (A.Location_deref _,A.Location_deref _)
-      -> true
+    -> true
   | (A.Location_global _,(A.Location_deref _|A.Location_reg _))
   | (A.Location_deref _,(A.Location_global _|A.Location_reg _))
   | (A.Location_reg _,(A.Location_global _|A.Location_deref _))
@@ -412,16 +412,8 @@ end = struct
           | Access(_,_,_,_,e,_,_)|Amo (_,_,_,_,e,_,_) -> p e
           | _ -> false
           in tag,p) A.explicit_sets
-      
-(*    and esets =
-      List.map
-        (fun (tag,p) ->
-          let p act = match act with
-          | Access(_,_,_,_,annot,_,_)|Amo (_,_,_,_,annot,_,_) -> 
-            let _ = Printf.sprintf "EXP_OR_NOT: %s\n" (A.pp_annot annot) in p annot
-          | _ -> false
-          in tag,p) A.annot_sets
-*)     and lsets =
+
+    and lsets =
       List.map
         (fun lvl -> A.pp_level lvl,is_at_level lvl)
         A.levels
@@ -432,35 +424,60 @@ end = struct
   let arch_rels =
     if kvm then
       let open Constant in
-      let ok_sym a1 a2 = match a1,a2 with
-      | ((Virtual ((s1,_),_)|Physical (s1,_)|System (PTE,s1)),System (TLB,s2))
-      | (System (TLB,s2),(Virtual ((s1,_),_)|Physical (s1,_)|System (PTE,s1)))
+
+      let inv_domain_act =
+
+        let inv_domain_sym a1 a2 = match a1,a2 with
+        | ((Virtual ((s1,_),_)|Physical (s1,_)|System (PTE,s1)),System (TLB,s2))
+        | (System (TLB,s2),(Virtual ((s1,_),_)|Physical (s1,_)|System (PTE,s1)))
           -> Misc.string_eq s1 s2
-      | _,_ -> false in
+        | _,_ -> false in
 
-      let ok_loc loc1 loc2 = match loc1,loc2 with
-      | A.Location_global (A.V.Val (Symbolic a1)),
-        A.Location_global (A.V.Val (Symbolic a2))
-          -> ok_sym a1 a2
-      | _,_ -> false in
+        let inv_domain_loc loc1 loc2 = match loc1,loc2 with
+        | A.Location_global (A.V.Val (Symbolic a1)),
+          A.Location_global (A.V.Val (Symbolic a2))
+          -> inv_domain_sym a1 a2
+        | _,_ -> false in
 
-      let ok_act act1 act2 = match act1,act2 with
-      | (act,Inv (_,None))|(Inv (_, None),act)
-        ->
-          is_mem act &&
-          begin match location_of act with
-          | Some (A.Location_global _) ->  true
-          | Some _|None -> false
-          end
-      | (e,Inv (_,Some loc1))|(Inv (_, Some loc1),e)
-        ->
-          is_mem e &&
-          begin match location_of e with
-          | Some loc2 -> ok_loc loc1 loc2
-          | None -> false
-          end
-      | _ -> false in
-      ["inv-domain",ok_act]
+        fun act1 act2 -> match act1,act2 with
+        | (act,Inv (_,None))|(Inv (_, None),act)
+          ->
+            is_mem act &&
+            begin match location_of act with
+            | Some (A.Location_global _) ->  true
+            | Some _|None -> false
+            end
+        | (e,Inv (_,Some loc1))|(Inv (_, Some loc1),e)
+          ->
+            is_mem e &&
+            begin match location_of e with
+            | Some loc2 -> inv_domain_loc loc1 loc2
+            | None -> false
+            end
+        | _ -> false
+
+      and alias_act =
+        let get_oa = function
+          | Some (A.V.Val (PteVal v)) -> Some v.PTEVal.oa
+          | Some (A.V.Val (Concrete _|Symbolic _|Label (_, _)|Tag _))
+          | None -> None
+          | Some (A.V.Var _) ->
+              Warn.fatal "Cannot decide alias on variables"
+        and is_amo = function
+          | Amo _ -> true
+          | _ -> false in
+
+        fun act1 act2 ->
+          (* RMW events are not compatible with this alias
+          that relies on event values.
+          Reason: RWM events have two values.. *)
+          assert (not (is_amo act1 || is_amo act2)) ;
+          is_PTE_access act1 && is_PTE_access act2 &&
+          (match get_oa (value_of act1), get_oa (value_of act2) with
+          | Some s1,Some s2 -> Misc.string_eq s1 s2
+          | _,_ -> false) in
+
+      [("inv-domain",inv_domain_act); ("alias",alias_act);]
     else []
 
   let is_isync act = match act with
@@ -486,7 +503,7 @@ end = struct
         | None -> V.ValueSet.empty
         | Some v -> V.ValueSet.singleton v in
         add_v_undet v1 (add_v_undet v2 undet)
-   | Barrier _|Commit _|Fault _|TooFar|Inv _ | DC _ -> V.ValueSet.empty
+    | Barrier _|Commit _|Fault _|TooFar|Inv _ | DC _ -> V.ValueSet.empty
 
   let simplify_vars_in_action soln a =
     match a with

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -230,12 +230,7 @@ module Make
                   E.same_location_with_faults
                   (Lazy.force unv)
               end;
-              "alias", lazy begin
-                if kvm then
-                  E.EventRel.restrict_rel E.same_PA (Lazy.force unv)
-                else assert false
-                end;
-               "int",lazy begin
+              "int",lazy begin
                 E.EventRel.restrict_rel E.same_proc_not_init (Lazy.force unv)
               end ;
               "ext",lazy begin


### PR DESCRIPTION
       + Confine definition to `machAction.ml`.
       + Two events are related by `alias` when:
          - Both accesses are PTE accesses
          - And the oa fields of accessed values are equal.