### PR TITLE
[herd] Extract parts of test_herd to a library internal_lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,18 @@ versions:
 	@ sh ./version-gen.sh $(PREFIX)
 	@ dune build --workspace dune-workspace.versions @all
 
+
+# Tests.
+
 test:: | build
+
+test:: $(D)-test
+
+dune-test:
+	dune runtest
+
+ocb-test:
+	./ocb-test.sh
+
+test::
 	$(TEST_HERD) -herd-path $(HERD) -libdir-path ./herd/libdir -litmus-dir ./herd/unittests/AArch64 test

--- a/_tags
+++ b/_tags
@@ -1,6 +1,8 @@
 <gen>: include
 <herd>: include
 <internal>: include
+<internal/lib>: include
+<internal/lib/tests>: include
 <jingle>: include
 <lib>: include
 <litmus>: include
@@ -13,3 +15,6 @@ true: use_menhir
 <*/*.byte>: debug
 <*/*.cmo>: debug
 <*/*.{d.byte,byte,native}>: use_unix,use_str
+<*/*/*/*.{d.byte,byte,native}>: use_unix,use_str
+
+<internal/lib>: use_unix

--- a/defs.sh
+++ b/defs.sh
@@ -9,7 +9,7 @@ NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
 INTERNAL="test_herd.native"
-TESTS="test_test.native"
+TESTS="channel_test.native command_test.native test_test.native"
 
 mk_exe () {
   D=$1

--- a/defs.sh
+++ b/defs.sh
@@ -9,7 +9,7 @@ NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
 INTERNAL="test_herd.native"
-TESTS="channel_test.native command_test.native test_test.native"
+TESTS="channel_test.native command_test.native filesystem_test.native test_test.native"
 
 mk_exe () {
   D=$1

--- a/defs.sh
+++ b/defs.sh
@@ -9,6 +9,7 @@ NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
 INTERNAL="test_herd.native"
+TESTS="test_test.native"
 
 mk_exe () {
   D=$1

--- a/internal/dune
+++ b/internal/dune
@@ -1,1 +1,4 @@
-(executables (names test_herd) (libraries str unix))
+(executables
+ (names test_herd)
+ (modes native)
+ (libraries internal_lib str))

--- a/internal/lib/channel.ml
+++ b/internal/lib/channel.ml
@@ -1,0 +1,38 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for handling in_channel and out_channel. *)
+
+(* in_channel utilities *)
+
+let iter_lines f chan =
+  try
+    let rec iter () = f (input_line chan) ; iter () in iter ()
+  with End_of_file -> ()
+
+let map_lines f chan =
+  let ret = ref [] in
+  iter_lines (fun l -> ret := f l :: !ret) chan ;
+  List.rev !ret
+
+let read_lines chan =
+  map_lines (fun l -> l) chan
+
+
+(* out_channel utilities *)
+
+let write_lines chan lines =
+  List.iter (fun l -> Printf.fprintf chan "%s\n" l) lines

--- a/internal/lib/channel.mli
+++ b/internal/lib/channel.mli
@@ -1,0 +1,35 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for handling in_channel and out_channel. *)
+
+(* in_channel utilities *)
+
+(** [iter_lines f chan] applies function [f] in turn to each line of in_channel [chan]. *)
+val iter_lines : (string -> unit) -> in_channel -> unit
+
+(** [map_lines f chan] applies function [f] to each line of in_channel [chan],
+ *  and returns the list [f l1; ...; f ln]. *)
+val map_lines : (string -> 'a) -> in_channel -> 'a list
+
+(** [read_lines chan] reads all of in_channel [chan] as lines into a string list. *)
+val read_lines : in_channel -> string list
+
+
+(* out_channel utilities *)
+
+(** [write_lines chan lines] writes every line in [lines] to out_channel [chan]. *)
+val write_lines : out_channel -> string list -> unit

--- a/internal/lib/command.ml
+++ b/internal/lib/command.ml
@@ -1,0 +1,34 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for running commands. *)
+
+exception Error of string
+
+let command bin args =
+  match args with
+  | [] -> (Filename.quote bin)
+  | _ -> Printf.sprintf "%s %s" (Filename.quote bin) (String.concat " " (List.map Filename.quote args))
+
+let run_with_stdout bin args f =
+  let cmd = command bin args in
+  let stdout = Unix.open_process_in cmd in
+  let ret = f stdout in
+  match Unix.close_process_in stdout with
+  | Unix.WEXITED 0 -> ret
+  | Unix.WEXITED n -> raise (Error (Printf.sprintf "Process returned error code %i" n))
+  | Unix.WSIGNALED n -> raise (Error (Printf.sprintf "Process was killed by signal %i" n))
+  | Unix.WSTOPPED n -> raise (Error (Printf.sprintf "Process was stopped by signal %i" n))

--- a/internal/lib/command.mli
+++ b/internal/lib/command.mli
@@ -1,0 +1,27 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for running commands. *)
+
+exception Error of string
+
+(** [command bin args] returns a fully escaped command line for running the
+ *  binary [bin] with arguments [args]. *)
+val command : string -> string list -> string
+
+(** [run_with_stdout bin args f] runs the binary [bin] with arguments [args], and
+ *  applies function [f] to the open in_channel, returning the result. *)
+val run_with_stdout : string -> string list -> (in_channel -> 'a) -> 'a

--- a/internal/lib/dune
+++ b/internal/lib/dune
@@ -1,3 +1,5 @@
 (library
  (name internal_lib)
+ (libraries unix)
+ (modes native)
  (wrapped false))

--- a/internal/lib/dune
+++ b/internal/lib/dune
@@ -1,0 +1,3 @@
+(library
+ (name internal_lib)
+ (wrapped false))

--- a/internal/lib/filesystem.ml
+++ b/internal/lib/filesystem.ml
@@ -1,0 +1,37 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Filesystem and file utilities. *)
+
+let read_file path f =
+  let chan = open_in path in
+  let ret = try
+    f chan
+  with e -> begin
+    close_in chan ;
+    raise e
+  end in
+  close_in chan ; ret
+
+let write_file path f =
+  let chan = open_out path in
+  let ret = try
+    f chan
+  with e -> begin
+    close_out chan ;
+    raise e
+  end in
+  close_out chan ; ret

--- a/internal/lib/filesystem.mli
+++ b/internal/lib/filesystem.mli
@@ -1,0 +1,27 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Filesystem and file utilities. *)
+
+(** [read_file path f] opens a file for reading at [path], and calls [f] on the
+ *  open channel. The file is closed after [f] returns. If an exception is
+ *  raised, the file is closed before re-raising the exception. *)
+val read_file : string -> (in_channel -> 'a) -> 'a
+
+(** [write_file path f] opens a file for writing at [path], and calls [f] on
+ *  the open channel. The file is closed after [f] returns. If an exception is
+ *  raised, the file is closed before re-raising the exception. *)
+val write_file : string -> (out_channel -> 'a) -> 'a

--- a/internal/lib/test.ml
+++ b/internal/lib/test.ml
@@ -1,0 +1,69 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Unit-testing utilities. *)
+
+let run_test (name, test) =
+  try
+    test () ;
+    true
+  with
+  | Failure msg ->
+      Printf.printf "Failed: %s: %s\n" name msg ;
+      false
+  | e ->
+      Printf.printf "Failed %s: raised exception\n" name ;
+      raise e
+
+let run tests =
+  let results = List.map run_test tests in
+  let failed r = not r in
+  if List.exists failed results then
+    exit 1
+
+
+(* Pretty-printing for failure messages. *)
+
+let pp_list pp_x xs = Printf.sprintf "[%s]" (String.concat "; " (List.map pp_x xs))
+
+let pp_int_list xs = pp_list (Printf.sprintf "%i") xs
+
+let pp_string_list xs = pp_list (Printf.sprintf "%S") xs
+
+
+(* Comparisons. *)
+
+let int_compare (x:int) (y:int) = compare x y
+
+let rec find_comparison cs =
+  match cs with
+  | [] -> 0
+  | c :: cs' -> if c <> 0 then c else (find_comparison cs')
+
+let list_compare c xs ys =
+  let compared_length = int_compare (List.length xs) (List.length ys) in
+  if compared_length = 0 then begin
+    List.combine xs ys
+    |> List.map (fun (x, y) -> c x y)
+    |> find_comparison
+  end else
+    compared_length
+
+let string_list_compare xs ys =
+  list_compare String.compare xs ys
+
+let int_list_compare xs ys =
+  list_compare int_compare xs ys

--- a/internal/lib/test.mli
+++ b/internal/lib/test.mli
@@ -1,0 +1,51 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Unit-testing utilities. *)
+
+(** [run tests] runs every named test in [tests], printing an error message if
+ *  a test fails. *)
+val run : (string * (unit -> unit)) list -> unit
+
+
+(* Pretty-printing for failure messages. *)
+
+(** [pp_list f xs] prints a list [xs] as though OCaml syntax, applying [f] to
+ *  each member. *)
+val pp_list : ('a -> string) -> 'a list -> string
+
+(** [pp_int_list xs] prints a list [xs] of ints as though OCaml syntax. For
+ *  example, [pp_int_list [1; 2]] returns "[1; 2]". *)
+val pp_int_list : int list -> string
+
+(** [pp_string_list xs] prints a list [xs] of strings as though OCaml
+ *  syntax. For example, [pp_string_list ["a"; "b"]] returns
+ *  "[\"a\"; \"b\"]". *)
+val pp_string_list : string list -> string
+
+
+(* Comparisons. *)
+
+(** [list_compare c xs ys] compares lists [xs] and [ys], first by length,
+ *  comparing each pair of elements of [xs] and [ys] with compare function [c]
+ *  until a pair differs. *)
+val list_compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+
+(** [int_list_compare xs ys] compares int lists [xs] and [ys]. *)
+val int_list_compare : int list -> int list -> int
+
+(** [string_list_compare xs ys] compares string lists [xs] and [ys]. *)
+val string_list_compare : string list -> string list -> int

--- a/internal/lib/tests/channel_test.ml
+++ b/internal/lib/tests/channel_test.ml
@@ -1,0 +1,55 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Tests for the Channel module. *)
+
+let pp_int_list = Test.pp_int_list
+let pp_string_list = Test.pp_string_list
+
+let tests = [
+  "Channel.read_lines and Channel.write_lines", (fun () ->
+    let in_fd, out_fd = Unix.pipe () in
+    let in_ch, out_ch = Unix.in_channel_of_descr in_fd, Unix.out_channel_of_descr out_fd in
+
+    let lines = ["mew"; "purr"] in
+    Channel.write_lines out_ch lines ;
+    close_out out_ch ;
+
+    let actual = Channel.read_lines in_ch in
+    close_in in_ch ;
+
+    if Test.string_list_compare lines actual <> 0 then
+      failwith (Printf.sprintf "Expected %s, got %s" (pp_string_list lines) (pp_string_list actual))
+  );
+
+  "Channel.map_lines applies f", (fun () ->
+    let in_fd, out_fd = Unix.pipe () in
+    let in_ch, out_ch = Unix.in_channel_of_descr in_fd, Unix.out_channel_of_descr out_fd in
+
+    let lines = ["mew"; "purr"] in
+    Channel.write_lines out_ch lines ;
+    close_out out_ch ;
+
+    let expected = [3; 4] in
+    let actual = Channel.map_lines String.length in_ch in
+    close_in in_ch ;
+
+    if Test.int_list_compare expected actual <> 0 then
+      failwith (Printf.sprintf "Expected %s, got %s" (pp_int_list expected) (pp_int_list actual))
+  );
+]
+
+let () = Test.run tests

--- a/internal/lib/tests/command_test.ml
+++ b/internal/lib/tests/command_test.ml
@@ -1,0 +1,68 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Tests for the Command module. *)
+
+let pp_string_list = Test.pp_string_list
+
+let tests = [
+  "Command.command without args", (fun () ->
+    let expected = "'foo'" in
+    let actual = Command.command "foo" [] in
+    if String.compare actual expected <> 0 then
+      failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+  );
+  "Command.command with args", (fun () ->
+    let expected = "'foo' '-bar' 'baz'" in
+    let actual = Command.command "foo" ["-bar"; "baz"] in
+    if String.compare actual expected <> 0 then
+      failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+  );
+  "Command.command with escaping args", (fun () ->
+    let expected = "'/bin/do foo' '-a flag' '~/foo'\\''s files/'" in
+    let actual = Command.command "/bin/do foo" ["-a flag"; "~/foo's files/"] in
+    if String.compare actual expected <> 0 then
+      failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+  );
+
+  "Command.run_with_stdout captures stdout", (fun () ->
+    let tests = [
+      ("true", [], []);
+      ("echo", ["foo"], ["foo"]);
+      ("echo", ["foo\nbar"], ["foo"; "bar"]);
+    ] in
+
+    List.iter
+      (fun (cmd, args, expected) ->
+        let actual = Command.run_with_stdout cmd args Channel.read_lines in
+        if Test.string_list_compare actual expected <> 0 then
+          failwith (Printf.sprintf "Expected %s, got %s" (pp_string_list expected) (pp_string_list actual)))
+      tests
+  );
+  "Command.run_with_stdout_lines raises on error", (fun () ->
+    (* Deliberately fail. *)
+    let raised_exception = try
+      let _ = Command.run_with_stdout "false" [] (fun _ -> ()) in false
+    with
+      Command.Error _ -> true
+    in
+
+    if not raised_exception then
+      failwith "Expected exception, did not raise";
+  );
+]
+
+let () = Test.run tests

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,4 +1,4 @@
 (tests
- (names channel_test test_test)
+ (names channel_test command_test test_test)
  (libraries internal_lib unix)
  (modes native))

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,4 +1,4 @@
 (tests
- (names channel_test command_test test_test)
+ (names channel_test command_test filesystem_test test_test)
  (libraries internal_lib unix)
  (modes native))

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,0 +1,3 @@
+(tests
+ (names test_test)
+ (libraries internal_lib))

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,3 +1,4 @@
 (tests
- (names test_test)
- (libraries internal_lib))
+ (names channel_test test_test)
+ (libraries internal_lib unix)
+ (modes native))

--- a/internal/lib/tests/filesystem_test.ml
+++ b/internal/lib/tests/filesystem_test.ml
@@ -1,0 +1,45 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Filesystem and file utilities. *)
+
+let pp_string_list = Test.pp_string_list
+
+let tests = [
+  "Filesystem.read_file and Filesystem.write_file", (fun () ->
+    let tests = [
+      [] ;
+      ["foo"; "bar"] ;
+    ] in
+
+    List.iter (fun lines ->
+        let path = Filename.temp_file "" "" in
+
+        Filesystem.write_file path (fun o -> Channel.write_lines o lines) ;
+
+        let actual = Filesystem.read_file path Channel.read_lines in
+
+        (* Clean up. *)
+        Sys.remove path ;
+
+        if Test.string_list_compare lines actual <> 0 then
+          failwith (Printf.sprintf "Expected %s, got %s" (pp_string_list lines) (pp_string_list actual))
+      )
+      tests
+  );
+]
+
+let () = Test.run tests

--- a/internal/lib/tests/test_test.ml
+++ b/internal/lib/tests/test_test.ml
@@ -1,0 +1,94 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Tests for the Test module. *)
+
+let pp_int_list = Test.pp_int_list
+let pp_string_list = Test.pp_string_list
+
+let tests = [
+  "Test.pp_int_list", (fun () ->
+    let tests = [
+      [], "[]" ;
+      [1], "[1]" ;
+      [1; 2; 3], "[1; 2; 3]" ;
+    ] in
+
+    List.iter
+      (fun (xs, expected) ->
+        let actual = Test.pp_int_list xs in
+        if String.compare actual expected <> 0 then
+          failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+      )
+      tests
+  );
+
+  "Test.pp_string_list", (fun () ->
+    let tests = [
+      [], "[]" ;
+      ["a"], "[\"a\"]" ;
+      ["a"; "b"], "[\"a\"; \"b\"]" ;
+    ] in
+
+    List.iter
+      (fun (xs, expected) ->
+        let actual = Test.pp_string_list xs in
+        if String.compare actual expected <> 0 then
+          failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+      )
+      tests
+  );
+
+  "Test.int_list_compare", (fun () ->
+    let tests = [
+      [], [], 0 ;
+      [1], [], 1 ;
+      [], [1], -1 ;
+      [1], [1], 0 ;
+      [1], [2], -1 ;
+      [1; 2], [12; 2], -1 ;
+    ] in
+
+    List.iter
+      (fun (xs, ys, expected) ->
+        let actual = Test.int_list_compare xs ys in
+        if actual <> expected then
+          failwith (Printf.sprintf "Expected %i, got %i" expected actual)
+      )
+      tests
+  );
+
+  "Test.string_list_compare", (fun () ->
+    let tests = [
+      [], [], 0 ;
+      ["a"], [], 1 ;
+      [], ["a"], -1 ;
+      ["a"], ["a"], 0 ;
+      ["a"], ["b"], -1 ;
+      ["a"; "b"], ["ab"; "b"], -1 ;
+    ] in
+
+    List.iter
+      (fun (xs, ys, expected) ->
+        let actual = Test.string_list_compare xs ys in
+        if actual <> expected then
+          failwith (Printf.sprintf "Expected %i, got %i" expected actual)
+      )
+      tests
+  );
+]
+
+let () = Test.run tests

--- a/internal/test_herd.ml
+++ b/internal/test_herd.ml
@@ -18,33 +18,8 @@
 
 (* Contributed by Ethel Morgan <Ethel.Morgan@arm.com> *)
 
-(* General util *)
-
-let rec read_all chan =
-  let line = try Some (input_line chan) with End_of_file -> None in
-  match line with
-  | None -> []
-  | Some line -> line :: (read_all chan)
-
-let read_file path =
-  if Sys.file_exists path
-  then begin
-    let chan = open_in path in
-    let lines = read_all chan in
-    close_in chan ;
-    Some lines
-  end
-  else None
-
-let write_file path lines =
-  let chan = open_out path in
-  List.iter (fun l -> Printf.fprintf chan "%s\n" l) lines ;
-  close_out chan
-
-(* Tool-specific util *)
-
-let herd_command herd libdir litmus =
-  Printf.sprintf "%s -set-libdir %s %s" herd libdir litmus
+let herd_args libdir litmus =
+  ["-set-libdir"; libdir; litmus]
 
 let time_re = Str.regexp "^Time "
 let without_time lines =
@@ -52,35 +27,40 @@ let without_time lines =
   List.filter not_time lines
 
 let run_herd herd libdir litmus =
-  let command = herd_command herd libdir litmus in
-  let stdout = Unix.open_process_in command in
-  let lines = read_all stdout in
-  match Unix.close_process_in stdout with
-  | Unix.WEXITED 0 -> Some (without_time lines)
-  | _ -> None
+  let args = herd_args libdir litmus in
+  let lines = Command.run_with_stdout herd args Channel.read_lines in
+  without_time lines
 
-(* TODO: Return a meaningful diff. *)
-let logs_differ a b = not (a = b)
+let log_compare a b = String.compare (String.concat "\n" a) (String.concat "\n" b)
 
 let expected_of_litmus litmus = litmus ^ ".expected"
+let is_litmus path = Filename.extension path = ".litmus"
 
 let run_test herd libdir litmus =
-  match run_herd herd libdir litmus with
+  let output = try
+    Some (run_herd herd libdir litmus)
+  with _ -> None in
+  match output with
   | None -> Printf.printf "Failed %s : Herd returned non-zero\n" litmus ; false
   | Some output ->
+
   let expected = expected_of_litmus litmus in
-  match read_file expected with
+  let expected_output = try
+    Some (Filesystem.read_file expected Channel.read_lines)
+  with _ -> None in
+  match expected_output with
   | None -> Printf.printf "Failed %s : Missing file %s\n" litmus expected ; false
   | Some expected_output ->
-  if logs_differ output expected_output then begin
+
+  if log_compare output expected_output <> 0 then begin
     Printf.printf "Failed %s : Logs do not match\n" litmus ;
     false
-  end
-  else true
+  end else
+    true
 
 let litmuses_of_dir dir =
   let all_files = Array.to_list (Sys.readdir dir) in
-  let only_litmus = List.filter (fun p -> (Filename.extension p) = ".litmus") all_files in
+  let only_litmus = List.filter is_litmus all_files in
   let full_paths = List.map (Filename.concat dir) only_litmus in
   List.sort String.compare full_paths
 
@@ -88,8 +68,9 @@ let litmuses_of_dir dir =
 
 let show_tests herd libdir litmus_dir =
   let litmuses = litmuses_of_dir litmus_dir in
-  let commands = List.map (herd_command herd libdir) litmuses in
-  List.iter (Printf.printf "%s\n") commands
+  let command_of_litmus l = Command.command herd (herd_args libdir l) in
+  let commands = List.map command_of_litmus litmuses in
+  Channel.write_lines stdout commands
 
 let run_tests herd libdir litmus_dir =
   let litmuses = litmuses_of_dir litmus_dir in
@@ -106,12 +87,10 @@ let promote_tests herd libdir litmus_dir =
   let litmuses = litmuses_of_dir litmus_dir in
   let outputs = List.map (run_herd herd libdir) litmuses in
   let expecteds = List.map expected_of_litmus litmuses in
-  let write_file_or_raise (path, lines) =
-    match lines with
-    | None -> failwith "Herd encountered error"
-    | Some lines -> write_file path lines
+  let write_file (path, lines) =
+    Filesystem.write_file path (fun o -> Channel.write_lines o lines)
   in
-  List.combine expecteds outputs |> List.iter write_file_or_raise
+  List.combine expecteds outputs |> List.iter write_file
 
 let usage = String.concat "\n" [
   Printf.sprintf "Usage: %s [opts] (show|test|promote)" Sys.argv.(0) ;

--- a/ocb-build.sh
+++ b/ocb-build.sh
@@ -24,7 +24,7 @@ let rev = "$REV"
 let libdir = "$libdir/"
 EOD
 
-ocamlbuild -no-links -j 5 -cflags -w,+a-3-4-9-29-33-41-45-67,-strict-sequence ${NATIVE} ${INTERNAL}
+ocamlbuild -no-links -j 5 -cflags -w,+a-3-4-9-29-33-41-45-67,-strict-sequence ${NATIVE} ${INTERNAL} ${TESTS}
 # Warnings ignored on purpose:
 # Warning 4: this pattern-matching is fragile
 # Warning 33: unused open

--- a/ocb-test.sh
+++ b/ocb-test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+. ./defs.sh
+
+for test in ${TESTS}
+do
+	"$(find ./_build -name "${test}")"
+done


### PR DESCRIPTION
This PR is the first in a series that will add `test_herd_diycross` and `test_herd_catalogue`, for testing `herd` with `diycross` and against the Catalogue respectively.

It is being sent as a separate PR because it already introduces multiple new concepts (a new library, tests written in OCaml for testing that library directly), so this will be enough to review on its own.

If approved, future PRs will further extract "running `herd` against an expected output" to a library.

Where possible, functions are named similarly to standard library functions (e.g. `Channel.iter_lines` like `List.iter`).

I have been using exceptions instead of error values, because to my current understanding, that is more "the OCaml way".

`Command.run_with_stdout` is called that because later PRs will include `Command.run` and `Command.run_with_stdin_and_stdout`.