### PR TITLE
[internal] Add function Test.fail for use in unit tests

### DIFF
--- a/internal/lib/test.ml
+++ b/internal/lib/test.ml
@@ -16,12 +16,14 @@
 
 (** Unit-testing utilities. *)
 
+exception AssertionFailure of string
+
 let run_test (name, test) =
   try
     test () ;
     true
   with
-  | Failure msg ->
+  | AssertionFailure msg ->
       Printf.printf "Failed: %s: %s\n" name msg ;
       false
   | e ->
@@ -33,6 +35,9 @@ let run tests =
   let failed r = not r in
   if List.exists failed results then
     exit 1
+
+let fail msg =
+    raise (AssertionFailure msg)
 
 
 (* Pretty-printing for failure messages. *)

--- a/internal/lib/test.mli
+++ b/internal/lib/test.mli
@@ -16,9 +16,17 @@
 
 (** Unit-testing utilities. *)
 
+(** Raising [AssertionFailure msg] causes a test to fail, printing the reason
+ *  for failing [msg]. *)
+exception AssertionFailure of string
+
 (** [run tests] runs every named test in [tests], printing an error message if
  *  a test fails. *)
 val run : (string * (unit -> unit)) list -> unit
+
+(** [fail msg] raises an AssertionFailure with error message [msg], causing
+ *  the test to fail. *)
+val fail : string -> unit
 
 
 (* Pretty-printing for failure messages. *)

--- a/internal/lib/tests/channel_test.ml
+++ b/internal/lib/tests/channel_test.ml
@@ -32,7 +32,7 @@ let tests = [
     close_in in_ch ;
 
     if Test.string_list_compare lines actual <> 0 then
-      failwith (Printf.sprintf "Expected %s, got %s" (pp_string_list lines) (pp_string_list actual))
+      Test.fail (Printf.sprintf "Expected %s, got %s" (pp_string_list lines) (pp_string_list actual))
   );
 
   "Channel.map_lines applies f", (fun () ->
@@ -48,7 +48,7 @@ let tests = [
     close_in in_ch ;
 
     if Test.int_list_compare expected actual <> 0 then
-      failwith (Printf.sprintf "Expected %s, got %s" (pp_int_list expected) (pp_int_list actual))
+      Test.fail (Printf.sprintf "Expected %s, got %s" (pp_int_list expected) (pp_int_list actual))
   );
 ]
 

--- a/internal/lib/tests/command_test.ml
+++ b/internal/lib/tests/command_test.ml
@@ -23,19 +23,19 @@ let tests = [
     let expected = "'foo'" in
     let actual = Command.command "foo" [] in
     if String.compare actual expected <> 0 then
-      failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+      Test.fail (Printf.sprintf "Expected %s, got %s" expected actual)
   );
   "Command.command with args", (fun () ->
     let expected = "'foo' '-bar' 'baz'" in
     let actual = Command.command "foo" ["-bar"; "baz"] in
     if String.compare actual expected <> 0 then
-      failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+      Test.fail (Printf.sprintf "Expected %s, got %s" expected actual)
   );
   "Command.command with escaping args", (fun () ->
     let expected = "'/bin/do foo' '-a flag' '~/foo'\\''s files/'" in
     let actual = Command.command "/bin/do foo" ["-a flag"; "~/foo's files/"] in
     if String.compare actual expected <> 0 then
-      failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+      Test.fail (Printf.sprintf "Expected %s, got %s" expected actual)
   );
 
   "Command.run_with_stdout captures stdout", (fun () ->
@@ -49,7 +49,7 @@ let tests = [
       (fun (cmd, args, expected) ->
         let actual = Command.run_with_stdout cmd args Channel.read_lines in
         if Test.string_list_compare actual expected <> 0 then
-          failwith (Printf.sprintf "Expected %s, got %s" (pp_string_list expected) (pp_string_list actual)))
+          Test.fail (Printf.sprintf "Expected %s, got %s" (pp_string_list expected) (pp_string_list actual)))
       tests
   );
   "Command.run_with_stdout_lines raises on error", (fun () ->
@@ -61,7 +61,7 @@ let tests = [
     in
 
     if not raised_exception then
-      failwith "Expected exception, did not raise";
+      Test.fail "Expected exception, did not raise";
   );
 ]
 

--- a/internal/lib/tests/filesystem_test.ml
+++ b/internal/lib/tests/filesystem_test.ml
@@ -36,7 +36,7 @@ let tests = [
         Sys.remove path ;
 
         if Test.string_list_compare lines actual <> 0 then
-          failwith (Printf.sprintf "Expected %s, got %s" (pp_string_list lines) (pp_string_list actual))
+          Test.fail (Printf.sprintf "Expected %s, got %s" (pp_string_list lines) (pp_string_list actual))
       )
       tests
   );

--- a/internal/lib/tests/test_test.ml
+++ b/internal/lib/tests/test_test.ml
@@ -31,7 +31,7 @@ let tests = [
       (fun (xs, expected) ->
         let actual = Test.pp_int_list xs in
         if String.compare actual expected <> 0 then
-          failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+          Test.fail (Printf.sprintf "Expected %s, got %s" expected actual)
       )
       tests
   );
@@ -47,7 +47,7 @@ let tests = [
       (fun (xs, expected) ->
         let actual = Test.pp_string_list xs in
         if String.compare actual expected <> 0 then
-          failwith (Printf.sprintf "Expected %s, got %s" expected actual)
+          Test.fail (Printf.sprintf "Expected %s, got %s" expected actual)
       )
       tests
   );
@@ -66,7 +66,7 @@ let tests = [
       (fun (xs, ys, expected) ->
         let actual = Test.int_list_compare xs ys in
         if actual <> expected then
-          failwith (Printf.sprintf "Expected %i, got %i" expected actual)
+          Test.fail (Printf.sprintf "Expected %i, got %i" expected actual)
       )
       tests
   );
@@ -85,7 +85,7 @@ let tests = [
       (fun (xs, ys, expected) ->
         let actual = Test.string_list_compare xs ys in
         if actual <> expected then
-          failwith (Printf.sprintf "Expected %i, got %i" expected actual)
+          Test.fail (Printf.sprintf "Expected %i, got %i" expected actual)
       )
       tests
   );


### PR DESCRIPTION
Because Failure & failwith are built-ins, I want to avoid using them for
test assertion failures, which might catch / mask / mis-represent
Failure exceptions elsewhere in the callstack.

A contrived example:

  let f xs =
    match xs with
    | [] -> failwith "this should never happen"
    | xs -> ...

  let g xs =
    (* uses f in some way, possibly deep in its callstack. *)

  . . .

  (* xs has become []. *)
  if g xs <> 0 then
    failwith "Did not return 0"

This will print as:

  Failed Foo.g: this should never happen

It should now print as:

  Failed Foo.g: raised exception
  Fatal error: exception Failure("this should never happen")

I have called the exception AssertionFailure and the function Test.fail
to ensure that they won't pun the built-in Failure & failwith.