### PR TITLE
Regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,17 @@ D=dune
 OPAM_DEPS = menhir stdint
 
 ifeq ($(D), dune)
-	HERD = _build/install/default/bin/herd7
-	HERD_REGRESSION_TEST = _build/default/internal/herd_regression_test.exe
+	DIYCROSS                      = _build/install/default/bin/diycross7
+	HERD                          = _build/install/default/bin/herd7
+	HERD_REGRESSION_TEST          = _build/default/internal/herd_regression_test.exe
+	HERD_DIYCROSS_REGRESSION_TEST = _build/default/internal/herd_diycross_regression_test.exe
 
 	OPAM_DEPS += dune
 else
-	HERD = _build/herd/herd.native
-	HERD_REGRESSION_TEST = _build/internal/herd_regression_test.native
+	DIYCROSS                      = _build/gen/diycross.native
+	HERD                          = _build/herd/herd.native
+	HERD_REGRESSION_TEST          = _build/internal/herd_regression_test.native
+	HERD_DIYCROSS_REGRESSION_TEST = _build/internal/herd_diycross_regression_test.native
 
 	OPAM_DEPS += ocamlbuild ocamlfind
 endif
@@ -72,3 +76,16 @@ ocb-test:
 
 test::
 	$(HERD_REGRESSION_TEST) -herd-path $(HERD) -libdir-path ./herd/libdir -litmus-dir ./herd/unittests/AArch64 test
+
+test::
+	$(HERD_DIYCROSS_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-diycross-path $(DIYCROSS) \
+		-libdir-path ./herd/libdir \
+		-expected-dir ./herd/unittests/AArch64.diycross \
+		-arch AArch64 \
+		-relaxlist 'Pod**,Fenced**' \
+		-relaxlist 'Rfe,Fre,Coe' \
+		-relaxlist 'Pod**,Fenced**,DpAddrdR,DpAddrdW,DpDatadW,CtrldR,CtrldW' \
+		-relaxlist 'Rfe,Fre,Coe' \
+		test

--- a/defs.sh
+++ b/defs.sh
@@ -8,7 +8,7 @@ JINGLE="jingle.native gen_theme.native"
 NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
-INTERNAL="herd_regression_test.native"
+INTERNAL="herd_regression_test.native herd_diycross_regression_test.native"
 TESTS="channel_test.native command_test.native filesystem_test.native test_test.native"
 
 mk_exe () {

--- a/gen/Version_gen.ml
+++ b/gen/Version_gen.ml
@@ -1,3 +1,0 @@
-include Version
-
-let libdir = Filename.concat libdir "herd"

--- a/gen/config.ml
+++ b/gen/config.ml
@@ -17,6 +17,7 @@
 open Printf
 open Code
 let verbose = ref 0
+let libdir = ref (Filename.concat Version.libdir "herd")
 let nprocs = ref 4
 let size = ref 6
 let one = ref false
@@ -122,8 +123,10 @@ let parse_cumul = function
 
 let common_specs =
   ("-v", Arg.Unit (fun () -> incr verbose),"  be verbose")::
-  ("-version", Arg.Unit (fun () -> print_endline Version_gen.version ; exit 0),
+  ("-version", Arg.Unit (fun () -> print_endline Version.version ; exit 0),
    " show version number and exit")::
+  ("-set-libdir", Arg.String (fun s -> libdir := s),
+   " <path> path to libdir")::
   Util.parse_tag "-debug"
     (fun tag -> match Debug_gen.parse !debug tag with
     | None -> false
@@ -273,7 +276,7 @@ let varatomspec =
    "<atom specs> specify atom variations")
 
 let prog = if Array.length Sys.argv > 0 then Sys.argv.(0) else "XXX"
-let baseprog = sprintf "%s (version %s)" (Filename.basename prog) (Version_gen.version)
+let baseprog = sprintf "%s (version %s)" (Filename.basename prog) (Version.version)
 
 let usage_msg = "Usage: " ^ prog ^   "[options]*"
 
@@ -322,7 +325,7 @@ module ToLisa = functor
   end) -> struct
     let debug = !O.debug
     let verbose = !O.verbose
-    let libdir = Version_gen.libdir
+    let libdir = !libdir
     let prog = O.prog
     let bell = !O.bell
     let varatom = !O.varatom

--- a/gen/dumpAll.ml
+++ b/gen/dumpAll.ml
@@ -431,7 +431,7 @@ module Make(Config:Config)(T:Builder.S)
             fprintf all_chan
               "# %s\n" (String.concat " " (Array.to_list Sys.argv)) ;
             fprintf all_chan "# Version %s, Revision: %s\n"
-              Version_gen.version Version_gen.rev ;
+              Version.version Version.rev ;
             let res =  gen (check_dump all_chan check) empty_t in
             flush stderr ;
             printf

--- a/herd/unittests/AArch64.diycross/2+2W+dmb.sy+po.litmus.expected
+++ b/herd/unittests/AArch64.diycross/2+2W+dmb.sy+po.litmus.expected
@@ -1,0 +1,13 @@
+Test 2+2W+dmb.sy+po Allowed
+States 4
+x=1; y=1;
+x=1; y=2;
+x=2; y=1;
+x=2; y=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (x=2 /\ y=2)
+Observation 2+2W+dmb.sy+po Sometimes 1 3
+Hash=5dbeaed3a1aa88c4cdded063346ba075
+

--- a/herd/unittests/AArch64.diycross/2+2W+dmb.sys.litmus.expected
+++ b/herd/unittests/AArch64.diycross/2+2W+dmb.sys.litmus.expected
@@ -1,0 +1,12 @@
+Test 2+2W+dmb.sys Allowed
+States 3
+x=1; y=1;
+x=1; y=2;
+x=2; y=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (x=2 /\ y=2)
+Observation 2+2W+dmb.sys Never 0 3
+Hash=9495f1f810a4f034c732242a8a2c3eed
+

--- a/herd/unittests/AArch64.diycross/2+2W.litmus.expected
+++ b/herd/unittests/AArch64.diycross/2+2W.litmus.expected
@@ -1,0 +1,13 @@
+Test 2+2W Allowed
+States 4
+x=1; y=1;
+x=1; y=2;
+x=2; y=1;
+x=2; y=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (x=2 /\ y=2)
+Observation 2+2W Sometimes 1 3
+Hash=5112e7c862483914f9d4e140b60657b2
+

--- a/herd/unittests/AArch64.diycross/LB+addr+po.litmus.expected
+++ b/herd/unittests/AArch64.diycross/LB+addr+po.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+addr+po Allowed
+States 4
+0:X0=0; 1:X0=0;
+0:X0=0; 1:X0=1;
+0:X0=1; 1:X0=0;
+0:X0=1; 1:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:X0=1 /\ 1:X0=1)
+Observation LB+addr+po Sometimes 1 3
+Hash=e9d156d9a67af36131db1a2e212783f0
+

--- a/herd/unittests/AArch64.diycross/LB+ctrl+po.litmus.expected
+++ b/herd/unittests/AArch64.diycross/LB+ctrl+po.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+ctrl+po Allowed
+States 4
+0:X0=0; 1:X0=0;
+0:X0=0; 1:X0=1;
+0:X0=1; 1:X0=0;
+0:X0=1; 1:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:X0=1 /\ 1:X0=1)
+Observation LB+ctrl+po Sometimes 1 3
+Hash=404c27451a6d36998d635b18a854f131
+

--- a/herd/unittests/AArch64.diycross/LB+data+po.litmus.expected
+++ b/herd/unittests/AArch64.diycross/LB+data+po.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+data+po Allowed
+States 4
+0:X0=0; 1:X0=0;
+0:X0=0; 1:X0=1;
+0:X0=1; 1:X0=0;
+0:X0=1; 1:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:X0=1 /\ 1:X0=1)
+Observation LB+data+po Sometimes 1 3
+Hash=186bb380ec9146e7b6efad21c3a0e85a
+

--- a/herd/unittests/AArch64.diycross/LB+dmb.sy+addr.litmus.expected
+++ b/herd/unittests/AArch64.diycross/LB+dmb.sy+addr.litmus.expected
@@ -1,0 +1,12 @@
+Test LB+dmb.sy+addr Allowed
+States 3
+0:X0=0; 1:X0=0;
+0:X0=0; 1:X0=1;
+0:X0=1; 1:X0=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:X0=1 /\ 1:X0=1)
+Observation LB+dmb.sy+addr Never 0 3
+Hash=57a36a94cdd96dba5494687469096486
+

--- a/herd/unittests/AArch64.diycross/LB+dmb.sy+ctrl.litmus.expected
+++ b/herd/unittests/AArch64.diycross/LB+dmb.sy+ctrl.litmus.expected
@@ -1,0 +1,12 @@
+Test LB+dmb.sy+ctrl Allowed
+States 3
+0:X0=0; 1:X0=0;
+0:X0=0; 1:X0=1;
+0:X0=1; 1:X0=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:X0=1 /\ 1:X0=1)
+Observation LB+dmb.sy+ctrl Never 0 3
+Hash=09dd50996dd3a70f794e79c60d599dc5
+

--- a/herd/unittests/AArch64.diycross/LB+dmb.sy+data.litmus.expected
+++ b/herd/unittests/AArch64.diycross/LB+dmb.sy+data.litmus.expected
@@ -1,0 +1,12 @@
+Test LB+dmb.sy+data Allowed
+States 3
+0:X0=0; 1:X0=0;
+0:X0=0; 1:X0=1;
+0:X0=1; 1:X0=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:X0=1 /\ 1:X0=1)
+Observation LB+dmb.sy+data Never 0 3
+Hash=a8ba120332793078f3da72029529493b
+

--- a/herd/unittests/AArch64.diycross/LB+dmb.sy+po.litmus.expected
+++ b/herd/unittests/AArch64.diycross/LB+dmb.sy+po.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+dmb.sy+po Allowed
+States 4
+0:X0=0; 1:X0=0;
+0:X0=0; 1:X0=1;
+0:X0=1; 1:X0=0;
+0:X0=1; 1:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:X0=1 /\ 1:X0=1)
+Observation LB+dmb.sy+po Sometimes 1 3
+Hash=0ec74bfe39e34fff214b2ea74f1407c5
+

--- a/herd/unittests/AArch64.diycross/LB+dmb.sys.litmus.expected
+++ b/herd/unittests/AArch64.diycross/LB+dmb.sys.litmus.expected
@@ -1,0 +1,12 @@
+Test LB+dmb.sys Allowed
+States 3
+0:X0=0; 1:X0=0;
+0:X0=0; 1:X0=1;
+0:X0=1; 1:X0=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:X0=1 /\ 1:X0=1)
+Observation LB+dmb.sys Never 0 3
+Hash=016af9c5476352f228452a1de398c157
+

--- a/herd/unittests/AArch64.diycross/LB.litmus.expected
+++ b/herd/unittests/AArch64.diycross/LB.litmus.expected
@@ -1,0 +1,13 @@
+Test LB Allowed
+States 4
+0:X0=0; 1:X0=0;
+0:X0=0; 1:X0=1;
+0:X0=1; 1:X0=0;
+0:X0=1; 1:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:X0=1 /\ 1:X0=1)
+Observation LB Sometimes 1 3
+Hash=c913e27eb60f622be0f95306bf58afc1
+

--- a/herd/unittests/AArch64.diycross/MP+dmb.sy+addr.litmus.expected
+++ b/herd/unittests/AArch64.diycross/MP+dmb.sy+addr.litmus.expected
@@ -1,0 +1,12 @@
+Test MP+dmb.sy+addr Allowed
+States 3
+1:X0=0; 1:X3=0;
+1:X0=0; 1:X3=1;
+1:X0=1; 1:X3=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (1:X0=1 /\ 1:X3=0)
+Observation MP+dmb.sy+addr Never 0 3
+Hash=9844f4fdc0df79e7053412eb50d9c29b
+

--- a/herd/unittests/AArch64.diycross/MP+dmb.sy+ctrlisb.litmus.expected
+++ b/herd/unittests/AArch64.diycross/MP+dmb.sy+ctrlisb.litmus.expected
@@ -1,0 +1,12 @@
+Test MP+dmb.sy+ctrlisb Allowed
+States 3
+1:X0=0; 1:X2=0;
+1:X0=0; 1:X2=1;
+1:X0=1; 1:X2=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (1:X0=1 /\ 1:X2=0)
+Observation MP+dmb.sy+ctrlisb Never 0 3
+Hash=54c591dbb706e7b9c836ec35582c8151
+

--- a/herd/unittests/AArch64.diycross/MP+dmb.sy+po.litmus.expected
+++ b/herd/unittests/AArch64.diycross/MP+dmb.sy+po.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+dmb.sy+po Allowed
+States 4
+1:X0=0; 1:X2=0;
+1:X0=0; 1:X2=1;
+1:X0=1; 1:X2=0;
+1:X0=1; 1:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (1:X0=1 /\ 1:X2=0)
+Observation MP+dmb.sy+po Sometimes 1 3
+Hash=d9d62612e298d213bc62ef2977f2c49c
+

--- a/herd/unittests/AArch64.diycross/MP+dmb.sys.litmus.expected
+++ b/herd/unittests/AArch64.diycross/MP+dmb.sys.litmus.expected
@@ -1,0 +1,12 @@
+Test MP+dmb.sys Allowed
+States 3
+1:X0=0; 1:X2=0;
+1:X0=0; 1:X2=1;
+1:X0=1; 1:X2=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (1:X0=1 /\ 1:X2=0)
+Observation MP+dmb.sys Never 0 3
+Hash=592564b7f5bb278c1fc33861dd44472b
+

--- a/herd/unittests/AArch64.diycross/MP+po+addr.litmus.expected
+++ b/herd/unittests/AArch64.diycross/MP+po+addr.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+po+addr Allowed
+States 4
+1:X0=0; 1:X3=0;
+1:X0=0; 1:X3=1;
+1:X0=1; 1:X3=0;
+1:X0=1; 1:X3=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (1:X0=1 /\ 1:X3=0)
+Observation MP+po+addr Sometimes 1 3
+Hash=9e94c2c82855aab757088bf83d7a2eca
+

--- a/herd/unittests/AArch64.diycross/MP+po+ctrlisb.litmus.expected
+++ b/herd/unittests/AArch64.diycross/MP+po+ctrlisb.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+po+ctrlisb Allowed
+States 4
+1:X0=0; 1:X2=0;
+1:X0=0; 1:X2=1;
+1:X0=1; 1:X2=0;
+1:X0=1; 1:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (1:X0=1 /\ 1:X2=0)
+Observation MP+po+ctrlisb Sometimes 1 3
+Hash=bc1eb3954ddd25a52d036b56b3240fd9
+

--- a/herd/unittests/AArch64.diycross/MP+po+dmb.sy.litmus.expected
+++ b/herd/unittests/AArch64.diycross/MP+po+dmb.sy.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+po+dmb.sy Allowed
+States 4
+1:X0=0; 1:X2=0;
+1:X0=0; 1:X2=1;
+1:X0=1; 1:X2=0;
+1:X0=1; 1:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (1:X0=1 /\ 1:X2=0)
+Observation MP+po+dmb.sy Sometimes 1 3
+Hash=f6d308977d905450cfe2dbe3b2b657ba
+

--- a/herd/unittests/AArch64.diycross/MP.litmus.expected
+++ b/herd/unittests/AArch64.diycross/MP.litmus.expected
@@ -1,0 +1,13 @@
+Test MP Allowed
+States 4
+1:X0=0; 1:X2=0;
+1:X0=0; 1:X2=1;
+1:X0=1; 1:X2=0;
+1:X0=1; 1:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (1:X0=1 /\ 1:X2=0)
+Observation MP Sometimes 1 3
+Hash=211d5b298572012a0869d4ded6a40b7f
+

--- a/herd/unittests/AArch64.diycross/R+dmb.sy+po.litmus.expected
+++ b/herd/unittests/AArch64.diycross/R+dmb.sy+po.litmus.expected
@@ -1,0 +1,13 @@
+Test R+dmb.sy+po Allowed
+States 4
+1:X2=0; y=1;
+1:X2=0; y=2;
+1:X2=1; y=1;
+1:X2=1; y=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (y=2 /\ 1:X2=0)
+Observation R+dmb.sy+po Sometimes 1 3
+Hash=3814bb855fe3c41615f97f5306827907
+

--- a/herd/unittests/AArch64.diycross/R+dmb.sys.litmus.expected
+++ b/herd/unittests/AArch64.diycross/R+dmb.sys.litmus.expected
@@ -1,0 +1,12 @@
+Test R+dmb.sys Allowed
+States 3
+1:X2=0; y=1;
+1:X2=1; y=1;
+1:X2=1; y=2;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (y=2 /\ 1:X2=0)
+Observation R+dmb.sys Never 0 3
+Hash=27b30cccf8f93d544bb1f886cf4cdf48
+

--- a/herd/unittests/AArch64.diycross/R+po+dmb.sy.litmus.expected
+++ b/herd/unittests/AArch64.diycross/R+po+dmb.sy.litmus.expected
@@ -1,0 +1,13 @@
+Test R+po+dmb.sy Allowed
+States 4
+1:X2=0; y=1;
+1:X2=0; y=2;
+1:X2=1; y=1;
+1:X2=1; y=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (y=2 /\ 1:X2=0)
+Observation R+po+dmb.sy Sometimes 1 3
+Hash=7e79fc9e18490d47d7cfa40151966790
+

--- a/herd/unittests/AArch64.diycross/R.litmus.expected
+++ b/herd/unittests/AArch64.diycross/R.litmus.expected
@@ -1,0 +1,13 @@
+Test R Allowed
+States 4
+1:X2=0; y=1;
+1:X2=0; y=2;
+1:X2=1; y=1;
+1:X2=1; y=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (y=2 /\ 1:X2=0)
+Observation R Sometimes 1 3
+Hash=94bd088306941f8b078a424a46e25395
+

--- a/herd/unittests/AArch64.diycross/S+dmb.sy+addr.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S+dmb.sy+addr.litmus.expected
@@ -1,0 +1,12 @@
+Test S+dmb.sy+addr Allowed
+States 3
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S+dmb.sy+addr Never 0 3
+Hash=33238b8bf9673deb451a505c11ca6123
+

--- a/herd/unittests/AArch64.diycross/S+dmb.sy+ctrl.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S+dmb.sy+ctrl.litmus.expected
@@ -1,0 +1,12 @@
+Test S+dmb.sy+ctrl Allowed
+States 3
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S+dmb.sy+ctrl Never 0 3
+Hash=73030742b02104aa1c857dc27b07d889
+

--- a/herd/unittests/AArch64.diycross/S+dmb.sy+data.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S+dmb.sy+data.litmus.expected
@@ -1,0 +1,12 @@
+Test S+dmb.sy+data Allowed
+States 3
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S+dmb.sy+data Never 0 3
+Hash=e8e69a7e825cc38617d9b5cf47f12048
+

--- a/herd/unittests/AArch64.diycross/S+dmb.sy+po.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S+dmb.sy+po.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sy+po Allowed
+States 4
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+1:X0=1; x=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S+dmb.sy+po Sometimes 1 3
+Hash=c2abe86986acac7dd650f566d671d7de
+

--- a/herd/unittests/AArch64.diycross/S+dmb.sys.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S+dmb.sys.litmus.expected
@@ -1,0 +1,12 @@
+Test S+dmb.sys Allowed
+States 3
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S+dmb.sys Never 0 3
+Hash=687f291fee293c61358dfb0225d8ceee
+

--- a/herd/unittests/AArch64.diycross/S+po+addr.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S+po+addr.litmus.expected
@@ -1,0 +1,13 @@
+Test S+po+addr Allowed
+States 4
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+1:X0=1; x=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S+po+addr Sometimes 1 3
+Hash=f1fa5d71f4cde5415b13edb4b06fac41
+

--- a/herd/unittests/AArch64.diycross/S+po+ctrl.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S+po+ctrl.litmus.expected
@@ -1,0 +1,13 @@
+Test S+po+ctrl Allowed
+States 4
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+1:X0=1; x=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S+po+ctrl Sometimes 1 3
+Hash=458bfab2215046379b712d1c0b080e8e
+

--- a/herd/unittests/AArch64.diycross/S+po+data.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S+po+data.litmus.expected
@@ -1,0 +1,13 @@
+Test S+po+data Allowed
+States 4
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+1:X0=1; x=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S+po+data Sometimes 1 3
+Hash=8faeebb106420ee78310ccdd86ac1b8a
+

--- a/herd/unittests/AArch64.diycross/S+po+dmb.sy.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S+po+dmb.sy.litmus.expected
@@ -1,0 +1,13 @@
+Test S+po+dmb.sy Allowed
+States 4
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+1:X0=1; x=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S+po+dmb.sy Sometimes 1 3
+Hash=faf1e5ddc3da6ae2a5a9a4e5f73d1d71
+

--- a/herd/unittests/AArch64.diycross/S.litmus.expected
+++ b/herd/unittests/AArch64.diycross/S.litmus.expected
@@ -1,0 +1,13 @@
+Test S Allowed
+States 4
+1:X0=0; x=1;
+1:X0=0; x=2;
+1:X0=1; x=1;
+1:X0=1; x=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (x=2 /\ 1:X0=1)
+Observation S Sometimes 1 3
+Hash=360f3ba324aec9ecd26a677e3f33f112
+

--- a/herd/unittests/AArch64.diycross/SB+dmb.sy+po.litmus.expected
+++ b/herd/unittests/AArch64.diycross/SB+dmb.sy+po.litmus.expected
@@ -1,0 +1,13 @@
+Test SB+dmb.sy+po Allowed
+States 4
+0:X2=0; 1:X2=0;
+0:X2=0; 1:X2=1;
+0:X2=1; 1:X2=0;
+0:X2=1; 1:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:X2=0 /\ 1:X2=0)
+Observation SB+dmb.sy+po Sometimes 1 3
+Hash=a74f6bc90f49d58ec86c36ccc8a47a0a
+

--- a/herd/unittests/AArch64.diycross/SB+dmb.sys.litmus.expected
+++ b/herd/unittests/AArch64.diycross/SB+dmb.sys.litmus.expected
@@ -1,0 +1,12 @@
+Test SB+dmb.sys Allowed
+States 3
+0:X2=0; 1:X2=1;
+0:X2=1; 1:X2=0;
+0:X2=1; 1:X2=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:X2=0 /\ 1:X2=0)
+Observation SB+dmb.sys Never 0 3
+Hash=38b65863d32068bb3325505c2570bcef
+

--- a/herd/unittests/AArch64.diycross/SB.litmus.expected
+++ b/herd/unittests/AArch64.diycross/SB.litmus.expected
@@ -1,0 +1,13 @@
+Test SB Allowed
+States 4
+0:X2=0; 1:X2=0;
+0:X2=0; 1:X2=1;
+0:X2=1; 1:X2=0;
+0:X2=1; 1:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:X2=0 /\ 1:X2=0)
+Observation SB Sometimes 1 3
+Hash=dca0cdb9995839b737bab4e9b28561fa
+

--- a/internal/dune
+++ b/internal/dune
@@ -1,4 +1,4 @@
 (executables
  (names herd_regression_test)
- (modes native)
- (libraries internal_lib str))
+ (libraries internal_lib)
+ (modes native))

--- a/internal/dune
+++ b/internal/dune
@@ -1,4 +1,4 @@
 (executables
- (names herd_regression_test)
+ (names herd_regression_test herd_diycross_regression_test)
  (libraries internal_lib)
  (modes native))

--- a/internal/herd_diycross_regression_test.ml
+++ b/internal/herd_diycross_regression_test.ml
@@ -1,0 +1,160 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** A tool that generates regression tests for herd7 using diycross7, comparing
+ *  the output against .expected files. *)
+
+let list_dir dir = List.sort String.compare (Array.to_list (Sys.readdir dir))
+let concat_dir dir names = List.map (Filename.concat dir) names
+
+let without_members cutset xs =
+  List.filter (fun x -> not (List.mem x cutset)) xs
+
+let common xs ys =
+  List.filter (fun x -> List.mem x ys) xs
+
+let diycross_args libdir arch relaxlists out_dir =
+  ["-o"; out_dir; "-set-libdir"; libdir; "-arch"; arch] @ relaxlists
+
+
+(* Commands *)
+
+type flags = {
+  herd : string ;
+  diycross : string ;
+  libdir : string ;
+  expected_dir : string ;
+  arch : string ;
+  relaxlists : string list
+}
+
+let show_tests flags =
+  let tmp_dir = Filesystem.new_temp_dir () in
+  let args = diycross_args flags.libdir flags.arch flags.relaxlists tmp_dir in
+  Command.run flags.diycross args ;
+  let litmuses = List.filter TestHerd.is_litmus (list_dir tmp_dir) in
+
+  let litmus_paths = concat_dir tmp_dir litmuses in
+  let commands = List.map (TestHerd.herd_command flags.herd flags.libdir) litmus_paths in
+  Channel.write_lines stdout commands
+
+
+let run_tests flags =
+  let tmp_dir = Filesystem.new_temp_dir () in
+  let args = diycross_args flags.libdir flags.arch flags.relaxlists tmp_dir in
+  Command.run flags.diycross args ;
+  let litmuses = List.filter TestHerd.is_litmus (list_dir tmp_dir) in
+
+  let expecteds = List.filter TestHerd.is_expected (list_dir flags.expected_dir) in
+  let expected_litmuses = List.map TestHerd.litmus_of_expected expecteds in
+
+  let only_in_expected = without_members litmuses expected_litmuses in
+  let only_in_got = without_members expected_litmuses litmuses in
+  if List.length only_in_expected > 0 then begin
+    Printf.printf "Missing files:\n" ;
+    List.iter (fun f -> Printf.printf "  %s\n" f) only_in_expected
+  end ;
+  if List.length only_in_got > 0 then begin
+    Printf.printf "Extra files:\n" ;
+    List.iter (fun f -> Printf.printf "  %s\n" f) only_in_got
+  end ;
+
+  let in_both = common litmuses expected_litmuses in
+  let litmus_paths = concat_dir tmp_dir in_both in
+  let expected_paths =
+    concat_dir flags.expected_dir
+    (List.map TestHerd.expected_of_litmus in_both)
+  in
+  let results = List.map
+    (fun (l, e) -> TestHerd.herd_output_matches_expected flags.herd flags.libdir l e)
+    (List.combine litmus_paths expected_paths)
+  in
+
+  let ok =
+    (List.length only_in_expected = 0) &&
+    (List.length only_in_got = 0) &&
+    (List.for_all (fun x -> x) results) in
+  if ok then begin
+    (* Clean up and exit cleanly. *)
+    Filesystem.remove_recursive tmp_dir ;
+    Printf.printf "Herd diycross regression tests OK\n"
+  end else begin
+    (* Don't clean up in case the user wants to inspect the errors. *)
+    Printf.printf "Some tests had errors\n" ;
+    exit 1
+  end
+
+
+let promote_tests flags =
+  let old_paths = concat_dir flags.expected_dir (list_dir flags.expected_dir) in
+  List.iter Sys.remove old_paths ;
+
+  let tmp_dir = Filesystem.new_temp_dir () in
+  let args = diycross_args flags.libdir flags.arch flags.relaxlists tmp_dir in
+  Command.run flags.diycross args ;
+  let litmuses = List.filter TestHerd.is_litmus (list_dir tmp_dir) in
+
+  let expecteds = List.map TestHerd.expected_of_litmus litmuses in
+
+  let litmus_paths = concat_dir tmp_dir litmuses in
+  let expected_paths = concat_dir flags.expected_dir expecteds in
+
+  let outputs = List.map (TestHerd.run_herd flags.herd flags.libdir) litmus_paths in
+  List.iter
+    (fun (path, lines) -> Filesystem.write_file path (fun o -> Channel.write_lines o lines))
+    (List.combine expected_paths outputs) ;
+  Filesystem.remove_recursive tmp_dir
+
+
+let usage = String.concat "\n" [
+  Printf.sprintf "Usage: %s [opts] (show|test|promote)" Sys.argv.(0) ;
+  "" ;
+  " show     Print the diycross7 and herd7 commands that would be run." ;
+  " test     Compare the output of running herd7 on generated diycross7 tests against .expected files." ;
+  " promote  Update .expected files to the output of herd7." ;
+]
+
+let () =
+  let flags = ref {
+    herd = "" ;
+    diycross = "" ;
+    libdir = "" ;
+    expected_dir = "" ;
+    arch = "" ;
+    relaxlists = []
+  } in
+  let anon_args = ref [] in
+  Arg.parse [
+    ("-herd-path", Arg.String (fun p -> flags := {!flags with herd = p}), "path to herd binary") ;
+    ("-diycross-path", Arg.String (fun p -> flags := {!flags with diycross = p}), "path to diycross binary") ;
+    ("-libdir-path", Arg.String (fun p -> flags := {!flags with libdir = p}), "path to herd libdir") ;
+    ("-expected-dir", Arg.String (fun p -> flags := {!flags with expected_dir = p}), "path to directory of .expected files to test against") ;
+    ("-arch", Arg.String (fun a -> flags := {!flags with arch = a}), "arch to test") ;
+    ("-relaxlist", Arg.String (fun s -> flags := {!flags with relaxlists = (s :: !flags.relaxlists)}), "relaxlist to cross-product (specify multiple times)") ;
+  ] (fun a -> anon_args := a :: !anon_args) usage ;
+  if (List.exists (fun a -> a = "") [!flags.herd; !flags.diycross; !flags.libdir; !flags.expected_dir; !flags.arch]) then begin
+    Printf.printf "A flag is missing!\n" ;
+    exit 1
+  end ;
+  if (List.length !flags.relaxlists) = 0 then begin
+    Printf.printf "Must provide at least one -relaxlist.\n" ;
+    exit 1
+  end ;
+  match !anon_args with
+  | "show" :: [] -> show_tests !flags
+  | "test" :: [] -> run_tests !flags
+  | "promote" :: [] -> promote_tests !flags
+  | _ -> Printf.printf "%s\n" usage ; exit 1

--- a/internal/herd_regression_test.ml
+++ b/internal/herd_regression_test.ml
@@ -39,7 +39,7 @@ let run_tests herd libdir litmus_dir =
    (List.combine litmuses expecteds)
   in
   if List.for_all (fun x -> x) results then
-    Printf.printf "Tests OK\n"
+    Printf.printf "Herd regression tests OK\n"
   else begin
     Printf.printf "Some tests had errors\n" ;
     exit 1

--- a/internal/herd_regression_test.ml
+++ b/internal/herd_regression_test.ml
@@ -110,6 +110,10 @@ let () =
     ("-libdir-path", Arg.String (fun p -> libdir := p), "path to herd libdir") ;
     ("-litmus-dir", Arg.String (fun p -> litmus_dir := p), "path to directory of .litmus files to test against") ;
   ] (fun a -> anon_args := a :: !anon_args) usage ;
+  if (List.exists (fun a -> a = "") [!herd; !libdir; !litmus_dir]) then begin
+    Printf.printf "A flag is missing!\n" ;
+    exit 1
+  end ;
   match !anon_args with
   | "show" :: [] -> show_tests !herd !libdir !litmus_dir
   | "test" :: [] -> run_tests !herd !libdir !litmus_dir

--- a/internal/lib/command.ml
+++ b/internal/lib/command.ml
@@ -23,6 +23,12 @@ let command bin args =
   | [] -> (Filename.quote bin)
   | _ -> Printf.sprintf "%s %s" (Filename.quote bin) (String.concat " " (List.map Filename.quote args))
 
+let run bin args =
+  let cmd = command bin args in
+  match Sys.command cmd with
+  | 0 -> ()
+  | n -> raise (Error (Printf.sprintf "Process returned error code %i" n))
+
 let run_with_stdout bin args f =
   let cmd = command bin args in
   let stdout = Unix.open_process_in cmd in

--- a/internal/lib/command.mli
+++ b/internal/lib/command.mli
@@ -22,6 +22,10 @@ exception Error of string
  *  binary [bin] with arguments [args]. *)
 val command : string -> string list -> string
 
+(** [run bin args] runs the binary [bin] with arguments [args].
+ *  It raises Error on error or non-zero exit code. *)
+val run : string -> string list -> unit
+
 (** [run_with_stdout bin args f] runs the binary [bin] with arguments [args], and
  *  applies function [f] to the open in_channel, returning the result. *)
 val run_with_stdout : string -> string list -> (in_channel -> 'a) -> 'a

--- a/internal/lib/dune
+++ b/internal/lib/dune
@@ -1,5 +1,5 @@
 (library
  (name internal_lib)
- (libraries unix)
+ (libraries str unix)
  (modes native)
  (wrapped false))

--- a/internal/lib/filesystem.ml
+++ b/internal/lib/filesystem.ml
@@ -35,3 +35,19 @@ let write_file path f =
     raise e
   end in
   close_out chan ; ret
+
+let rec remove_recursive path =
+  if Sys.file_exists path then begin
+    if Sys.is_directory path then begin
+      let children = Array.to_list (Sys.readdir path) in
+      let child_paths = List.map (Filename.concat path) children in
+      List.iter remove_recursive child_paths ;
+      Unix.rmdir path
+    end else
+      Sys.remove path
+  end
+
+let new_temp_dir () =
+  match Command.run_with_stdout "mktemp" ["-d"] Channel.read_lines with
+  | path :: [] -> path
+  | _ -> failwith "mktemp is behaving abnormally"

--- a/internal/lib/filesystem.mli
+++ b/internal/lib/filesystem.mli
@@ -25,3 +25,9 @@ val read_file : string -> (in_channel -> 'a) -> 'a
  *  the open channel. The file is closed after [f] returns. If an exception is
  *  raised, the file is closed before re-raising the exception. *)
 val write_file : string -> (out_channel -> 'a) -> 'a
+
+(** [remove_recursive path] removes [path] and all of its children, a la `rm -rf`. *)
+val remove_recursive : string -> unit
+
+(** [new_temp_dir ()] creates a new temporary directory, and returns the path. *)
+val new_temp_dir : unit -> string

--- a/internal/lib/testHerd.ml
+++ b/internal/lib/testHerd.ml
@@ -1,0 +1,58 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+let time_re = Str.regexp "^Time "
+let without_unstable_lines lines =
+  let not_time l = not (Str.string_match time_re l 0) in
+  List.filter not_time lines
+
+let log_compare a b = String.compare (String.concat "\n" a) (String.concat "\n" b)
+
+
+let herd_command herd libdir litmus =
+  Command.command herd ["-set-libdir"; libdir; litmus]
+
+let run_herd herd libdir litmus =
+  let lines = Command.run_with_stdout herd ["-set-libdir"; libdir; litmus] Channel.read_lines in
+  without_unstable_lines lines
+
+let herd_output_matches_expected herd libdir litmus expected =
+  let output = try
+    Some (run_herd herd libdir litmus)
+  with _ -> None in
+  match output with
+  | None -> Printf.printf "Failed %s : Herd returned non-zero\n" litmus ; false
+  | Some output ->
+
+  let expected_output = try
+    Some (Filesystem.read_file expected Channel.read_lines)
+  with _ -> None in
+  match expected_output with
+  | None -> Printf.printf "Failed %s : Missing file %s\n" litmus expected ; false
+  | Some expected_output ->
+
+  if log_compare output expected_output <> 0 then begin
+    Printf.printf "Failed %s : Logs do not match\n" litmus ;
+    false
+  end else
+    true
+
+
+let is_litmus path = Filename.check_suffix path ".litmus"
+let is_expected path = Filename.check_suffix path ".litmus.expected"
+
+let expected_of_litmus litmus = litmus ^ ".expected"
+let litmus_of_expected expected = Filename.chop_suffix expected ".expected"

--- a/internal/lib/testHerd.mli
+++ b/internal/lib/testHerd.mli
@@ -1,0 +1,41 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** [herd_command herd libdir litmus] returns the command line that [run_herd]
+  * would run. *)
+val herd_command: string -> string -> string -> string
+
+(** [run_herd herd libdir litmus] runs the binary [herd] with a custom [libdir]
+  * on a [litmus] file, and returns the output with unstable lines removed (e.g.
+  * Time). *)
+val run_herd : string -> string -> string -> string list
+
+(** [herd_output_matches_expected herd libdir litmus expected] runs the binary
+  * [herd] with a custom [libdir] on a [litmus] file, and compares the output
+  * with an [expected] file. *)
+val herd_output_matches_expected : string -> string -> string -> string -> bool
+
+(** [is_litmus filename] returns whether the [filename] is a .litmus file. *)
+val is_litmus : string -> bool
+
+(** [is_expected filename] returns whether [filename] is a .litmus.expected file. *)
+val is_expected : string -> bool
+
+(** [expected_of_litmus filename] returns the .litmus.expected name for a given .litmus [filename]. *)
+val expected_of_litmus : string -> string
+
+(** [litmus_of_expected filename] returns the .litmus name for a given .litmus.expected [filename]. *)
+val litmus_of_expected : string -> string

--- a/internal/lib/tests/command_test.ml
+++ b/internal/lib/tests/command_test.ml
@@ -38,6 +38,35 @@ let tests = [
       Test.fail (Printf.sprintf "Expected %s, got %s" expected actual)
   );
 
+  "Command.run runs cleanly", (fun () ->
+    (* This test uses `touch`, because it is a command that produces a
+     * side-effect, and so can be verified to have run. *)
+
+    (* Create a random file path, by creating a random file and deleting it. *)
+    let path = Filename.temp_file "" "" in
+    Sys.remove path ;
+
+    (* Recreate it with `touch`. *)
+    Command.run "touch" [path] ;
+
+    if not (Sys.file_exists path) then
+      Test.fail "File doesn't exist after `touch`"
+    else
+      (* Cleanup. *)
+      Sys.remove path
+  );
+  "Command.run_with_stdout_lines raises on error", (fun () ->
+    (* Deliberately fail. *)
+    let raised_exception = try
+      let _ = Command.run "false" [] in false
+    with
+      Command.Error _ -> true
+    in
+
+    if not raised_exception then
+      Test.fail "Expected exception, did not raise";
+  );
+
   "Command.run_with_stdout captures stdout", (fun () ->
     let tests = [
       ("true", [], []);

--- a/internal/lib/tests/filesystem_test.ml
+++ b/internal/lib/tests/filesystem_test.ml
@@ -40,6 +40,72 @@ let tests = [
       )
       tests
   );
+
+  "Filesystem.new_temp_dir creates directories", (fun () ->
+    let path = Filesystem.new_temp_dir () in
+
+    if not (Sys.is_directory path) then
+      Test.fail (Printf.sprintf "path %s is not a directory" path)
+    else
+      (* Cleanup. *)
+      Unix.rmdir path
+  );
+  "Filesystem.new_temp_dir creates unique paths", (fun () ->
+    let path1 = Filesystem.new_temp_dir () in
+    let path2 = Filesystem.new_temp_dir () in
+
+    if String.compare path1 path2 = 0 then
+      Test.fail (Printf.sprintf "paths are the same (%s)" path1)
+    else begin
+      (* Cleanup. *)
+      Unix.rmdir path1 ;
+      Unix.rmdir path2
+    end
+  );
+
+  "Filesystem.remove_recursive does not raise when removing nothing", (fun () ->
+    (* Generate a random temporary name that does not exist. *)
+    let tmp_file = Filename.temp_file "" "" in
+    Sys.remove tmp_file ;
+
+    Filesystem.remove_recursive tmp_file
+  );
+  "Filesystem.remove_recursive removes a single file", (fun () ->
+    let tmp_file = Filename.temp_file "" "" in
+    Filesystem.remove_recursive tmp_file ;
+    if Sys.file_exists tmp_file then
+      Test.fail "File not removed"
+  );
+  "Filesystem.remove_recursive removes an empty directory", (fun () ->
+    let tmp_dir = Filesystem.new_temp_dir () in
+    Filesystem.remove_recursive tmp_dir ;
+    if Sys.file_exists tmp_dir then
+      Test.fail "Directory not removed"
+  );
+  "Filesystem.remove_recursive removes a directory of files", (fun () ->
+    let tmp_dir = Filesystem.new_temp_dir () in
+    let touch name = Filesystem.write_file (Filename.concat tmp_dir name) (fun _ -> ()) in
+    touch "mew" ;
+    touch "purr" ;
+
+    Filesystem.remove_recursive tmp_dir ;
+
+    if Sys.file_exists tmp_dir then
+      Test.fail "Directory not removed"
+  );
+  "Filesystem.remove_recursive removes nested a directory of files", (fun () ->
+    let tmp_dir = Filesystem.new_temp_dir () in
+    let mkdir name = Unix.mkdir (Filename.concat tmp_dir name) 0o700 in
+    let touch name = Filesystem.write_file (Filename.concat tmp_dir name) (fun _ -> ()) in
+    touch "mew" ;
+    mkdir "purr" ;
+    touch "purr/meow" ;
+
+    Filesystem.remove_recursive tmp_dir ;
+
+    if Sys.file_exists tmp_dir then
+      Test.fail "Directory not removed"
+  );
 ]
 
 let () = Test.run tests


### PR DESCRIPTION
This PR creates a new binary, `test_herd_diycross`, for regression testing `herd7` using Litmuses generated by `diycross7` (thus also implicitly testing `diycross7` itself). It also adds new `internal_lib` features and a `-set-libdir` flag to binaries under `gen/`.

I haven't tested it with OCamlbuild at HEAD (see #98), but it did work at a previous commit.