### PR TITLE
[all] Add `make check-deps` to ensure dependencies are installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,24 @@ D=dune
 #For building with ocamlbuild set
 #D=ocb
 
+OPAM_DEPS = menhir stdint
+
 ifeq ($(D), dune)
 	HERD = _build/install/default/bin/herd7
 	HERD_REGRESSION_TEST = _build/default/internal/herd_regression_test.exe
+
+	OPAM_DEPS += dune
 else
 	HERD = _build/herd/herd.native
 	HERD_REGRESSION_TEST = _build/internal/herd_regression_test.native
+
+	OPAM_DEPS += ocamlbuild ocamlfind
 endif
+
 
 all: build
 
-build:
+build: | check-deps
 	sh ./$(D)-build.sh $(PREFIX)
 
 install:
@@ -34,6 +41,21 @@ dune-clean:
 versions:
 	@ sh ./version-gen.sh $(PREFIX)
 	@ dune build --workspace dune-workspace.versions @all
+
+
+check-deps::
+	@ command -v opam >/dev/null \
+		|| (echo "Opam not installed; please install it from your system's package manager" \
+			&& exit 1)
+
+define check-opam-dep
+check-deps::
+	@ (opam list --installed --columns=name \
+		| grep -E '^$(1)$$$$' >/dev/null) \
+	|| (echo "Package $(1) not installed; please run: opam install $(1)" \
+		&& exit 1)
+endef
+$(foreach dep,$(OPAM_DEPS),$(eval $(call check-opam-dep,$(dep))))
 
 
 # Tests.


### PR DESCRIPTION
This PR:
- Adds a `check-deps` phony target.
- Checks that `opam` is installed.
- Checks that `menhir` and `stdint` are installed.
- If `D=dune`, check that `dune` is installed.
- If `D=ocb`, check that `ocamlbuild` and `ocamlfind` are installed.
- Performs this check before `make build`.