### PR TITLE
[all] Replace pre-commit `make all` with `make test`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,11 @@ repos:
 
 -   repo: local
     hooks:
-    -   id: make-all
-        name: Run make all
+    -   id: make-test
+        name: Run make test
         language: system
-        entry: make all
-        files: (dune|\.ml.*$)
+        entry: make test
+        files: (dune|\.ml.*$|\.litmus.*$)
         pass_filenames: false
 
     -   id: opam-lint


### PR DESCRIPTION
This PR:
- Changes the pre-commit `make all` for `make test`. We have tests now, so we should run them, and commits that break tests should not be allowed.
- Correspondingly triggers a `make test` if any `.litmus` or `.litmus.expected` files change.