### PR TITLE
[test] Move "Tests OK" messages from herd_*_test to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ $(foreach dep,$(OPAM_DEPS),$(eval $(call check-opam-dep,$(dep))))
 test:: | build
 
 test:: $(D)-test
+	@ echo "OCaml unit tests: OK"
 
 dune-test:
 	dune runtest
@@ -76,6 +77,7 @@ ocb-test:
 
 test::
 	$(HERD_REGRESSION_TEST) -herd-path $(HERD) -libdir-path ./herd/libdir -litmus-dir ./herd/unittests/AArch64 test
+	@ echo "herd7 AArch64 instructions tests: OK"
 
 test::
 	$(HERD_DIYCROSS_REGRESSION_TEST) \
@@ -89,3 +91,4 @@ test::
 		-relaxlist 'Pod**,Fenced**,DpAddrdR,DpAddrdW,DpDatadW,CtrldR,CtrldW' \
 		-relaxlist 'Rfe,Fre,Coe' \
 		test
+	@ echo "herd7 AArch64 diycross7 tests: OK"

--- a/internal/herd_diycross_regression_test.ml
+++ b/internal/herd_diycross_regression_test.ml
@@ -82,15 +82,15 @@ let run_tests flags =
     (fun (l, e) -> TestHerd.herd_output_matches_expected flags.herd flags.libdir l e)
     (List.combine litmus_paths expected_paths)
   in
+  let passed x = x in
 
   let ok =
     (List.length only_in_expected = 0) &&
     (List.length only_in_got = 0) &&
-    (List.for_all (fun x -> x) results) in
+    (List.for_all passed results) in
   if ok then begin
     (* Clean up and exit cleanly. *)
-    Filesystem.remove_recursive tmp_dir ;
-    Printf.printf "Herd diycross regression tests OK\n"
+    Filesystem.remove_recursive tmp_dir
   end else begin
     (* Don't clean up in case the user wants to inspect the errors. *)
     Printf.printf "Some tests had errors\n" ;

--- a/internal/herd_regression_test.ml
+++ b/internal/herd_regression_test.ml
@@ -38,9 +38,8 @@ let run_tests herd libdir litmus_dir =
    (fun (l, e) -> TestHerd.herd_output_matches_expected herd libdir l e)
    (List.combine litmuses expecteds)
   in
-  if List.for_all (fun x -> x) results then
-    Printf.printf "Herd regression tests OK\n"
-  else begin
+  let failed r = not r in
+  if List.exists failed results then begin
     Printf.printf "Some tests had errors\n" ;
     exit 1
   end


### PR DESCRIPTION
This PR:
- Adds informative messages to tests passing, saying what kind of test passed.
- Removes "Tests OK" messages from `herd_regression_test` and `herd_diycross_regression_test`, instead only printing messages on failure. This is similar to other tools such as `dune runtest`.

The output of `make test` used to be:

	dune runtest
	_build/internal/herd_regression_test.native <flags and stuff>
	Tests OK
	_build/internal/herd_diycross_regression_test.native <flags and stuff>
	Tests OK

It is now:

	dune runtest
	OCaml unit tests: OK
	_build/internal/herd_regression_test.native <flags and stuff>
	herd7 AArch64 instructions tests: OK
	_build/internal/herd_diycross_regression_test.native <flags and stuff>
	herd7 AArch64 diycross7 tests: OK