### PR TITLE
 [herd]: Fix same-register I_OP3 barrel shift bug

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -864,12 +864,12 @@ module Make
             | RV (_,r) when reg_compare r rn = 0 -> (* register variant*)
                 (* Keep sharing here, otherwise performance penalty on address
                    dependency by r^r in mixed size mode *)
-                read_reg_ord_sz sz rn ii >>= fun v ->
+                read_reg_ord_sz sz rn ii >>= fun v1 ->
                 (* if present, apply an optional inline barrel shift *)
                 begin match os with
-                | S_NOEXT    -> M.unitT (v,v)
-                | s -> check_and_shift op ty s v
-                       >>= fun v -> M.unitT (v,v)
+                | S_NOEXT    -> M.unitT (v1,v1)
+                | s -> check_and_shift op ty s v1
+                       >>= fun v2 -> M.unitT (v1,v2)
                 end
             | RV (_,r) -> (* register variant *)
                 (* no sharing, we optionally shift v2 and return the pair *)

--- a/herd/unittests/AArch64/A58.litmus
+++ b/herd/unittests/AArch64/A58.litmus
@@ -1,0 +1,10 @@
+AArch64 A58
+(* Tests movz, 64-bit, LSL 48 *)
+
+{ 0:X0=0; }
+
+P0;
+MOVZ X0, #42, LSL #48;
+
+exists (0:X0=11821949021847552)
+

--- a/herd/unittests/AArch64/A58.litmus.expected
+++ b/herd/unittests/AArch64/A58.litmus.expected
@@ -1,0 +1,10 @@
+Test A58 Allowed
+States 1
+0:X0=11821949021847552;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=11821949021847552)
+Observation A58 Always 1 0
+Hash=2f39da8bd1fa45a65e52a6e7fc2f3dd6
+

--- a/herd/unittests/AArch64/A95.litmus
+++ b/herd/unittests/AArch64/A95.litmus
@@ -1,0 +1,10 @@
+AArch64 A95
+(* Tests add (shifted register), left shift by 1 *)
+
+{ 0:X0=1; }
+
+P0;
+ADD W1, W0, W0, lsl #1;
+
+forall (0:X1=3)
+

--- a/herd/unittests/AArch64/A95.litmus.expected
+++ b/herd/unittests/AArch64/A95.litmus.expected
@@ -1,0 +1,10 @@
+Test A95 Required
+States 1
+0:X1=3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=3)
+Observation A95 Always 1 0
+Hash=993a5ac27bc3548b67b13f7c2abec3b5
+


### PR DESCRIPTION
Consider the following:
```
ADD W1, W0, W0, lsl #1;
```
when `0:X0=1`

the final result `0:X1=3` should always occur,
however `0:X1=4` occurs since a single variable `v` is used
when the registers are the same, when two variables are required.

This patch fixes the above for `I_OP3` and adds a `MOVZ` test
missed before.