### PR TITLE
More handling of Page Table Entry from code

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -886,12 +886,13 @@ module Make
             | AND|ANDS -> fun (v1,v2) -> M.op Op.And v1 v2
             | ASR -> fun (v1, v2) -> M.op Op.ASR v1 v2
             | LSR -> fun (v1,v2) -> M.op Op.Lsr v1 v2
+            | LSL -> fun (v1,v2) -> M.op Op.ShiftLeft v1 v2
             end >>=
             (let m =  (fun v ->
               (write_reg rd v ii) >>|
               (match op with
               | ADDS|SUBS|ANDS -> is_zero v >>= fun v -> write_reg NZP v ii
-              | ADD|EOR|ORR|AND|SUB|ASR|LSR -> M.unitT ())) in
+              | ADD|EOR|ORR|AND|SUB|ASR|LSR|LSL -> M.unitT ())) in
             mask32 ty m) >>!
             B.Next
               (* Barrier *)

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -887,12 +887,13 @@ module Make
             | ASR -> fun (v1, v2) -> M.op Op.ASR v1 v2
             | LSR -> fun (v1,v2) -> M.op Op.Lsr v1 v2
             | LSL -> fun (v1,v2) -> M.op Op.ShiftLeft v1 v2
+            | BIC|BICS -> fun (v1,v2) -> M.op Op.AndNot2 v1 v2
             end >>=
             (let m =  (fun v ->
               (write_reg rd v ii) >>|
               (match op with
-              | ADDS|SUBS|ANDS -> is_zero v >>= fun v -> write_reg NZP v ii
-              | ADD|EOR|ORR|AND|SUB|ASR|LSR|LSL -> M.unitT ())) in
+              | ADDS|SUBS|ANDS|BICS -> is_zero v >>= fun v -> write_reg NZP v ii
+              | ADD|EOR|ORR|AND|SUB|ASR|LSR|LSL|BIC -> M.unitT ())) in
             mask32 ty m) >>!
             B.Next
               (* Barrier *)

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -421,7 +421,7 @@ let inverse_cond = function
   | GE -> GT
   | GT -> LE
 
-type op = ADD | ADDS | SUB | SUBS | AND | ANDS | ORR | EOR | ASR | LSR | LSL
+type op = ADD | ADDS | SUB | SUBS | AND | ANDS | ORR | EOR | ASR | LSR | LSL | BICS | BIC
 type variant = V32 | V64
 
 let pp_variant = function
@@ -629,6 +629,8 @@ let pp_op = function
   | ASR  -> "ASR"
   | LSR  -> "LSR"
   | LSL  -> "LSL"
+  | BICS -> "BICS"
+  | BIC -> "BIC"
 
 let do_pp_instruction m =
   let pp_rrr memo v rt rn rm =

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -421,7 +421,7 @@ let inverse_cond = function
   | GE -> GT
   | GT -> LE
 
-type op = ADD | ADDS | SUB | SUBS | AND | ANDS | ORR | EOR | ASR | LSR
+type op = ADD | ADDS | SUB | SUBS | AND | ANDS | ORR | EOR | ASR | LSR | LSL
 type variant = V32 | V64
 
 let pp_variant = function
@@ -627,7 +627,8 @@ let pp_op = function
   | AND  -> "AND"
   | ANDS -> "ANDS"
   | ASR  -> "ASR"
-  | LSR   -> "LSR"
+  | LSR  -> "LSR"
+  | LSL  -> "LSL"
 
 let do_pp_instruction m =
   let pp_rrr memo v rt rn rm =

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -278,6 +278,8 @@ match name with
 | "ands"|"ANDS" -> OP A.ANDS
 | "sub"|"SUB" -> OP A.SUB
 | "subs"|"SUBS" -> OP A.SUBS
+| "bic"|"BIC" -> OP A.BIC
+| "bics"|"BICS" -> OP A.BICS
 (* Although ASR is an instruction, it is also a barrel shift *)
 (* It needs special handling as both an operation and operand *)
 | "asr" | "ASR" -> ASR

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -16,6 +16,11 @@
 (****************************************************************************)
 
 module A = AArch64Base
+
+let check_op3 op kr = match op,kr with
+|(A.BIC|A.BICS),A.K _ -> raise Parsing.Parse_error
+| _ -> ()
+
 %}
 
 %token EOF
@@ -665,13 +670,13 @@ instr:
 | LSL xreg COMMA xreg COMMA kr
   { A.I_OP3 (A.V64, AArch64Base.LSL, $2, $4, $6, A.S_NOEXT) }
 | OP xreg COMMA xreg COMMA kr
-  { A.I_OP3 (A.V64,$1,$2,$4,$6, A.S_NOEXT) }
+  { check_op3 $1 $6 ; A.I_OP3 (A.V64,$1,$2,$4,$6, A.S_NOEXT) }
 | OP xreg COMMA xreg COMMA kr COMMA shift
-  { A.I_OP3 (A.V64,$1,$2,$4,$6, $8) }
+  { check_op3 $1 $6 ; A.I_OP3 (A.V64,$1,$2,$4,$6, $8) }
 | OP wreg COMMA wreg COMMA kwr
-  { A.I_OP3 (A.V32,$1,$2,$4,$6, A.S_NOEXT) }
+  { check_op3 $1 $6 ; A.I_OP3 (A.V32,$1,$2,$4,$6, A.S_NOEXT) }
 | OP wreg COMMA wreg COMMA kwr COMMA shift
-  { A.I_OP3 (A.V32,$1,$2,$4,$6, $8) }
+  { check_op3 $1 $6 ; A.I_OP3 (A.V32,$1,$2,$4,$6, $8) }
 | CMP wreg COMMA kwr
   { A.I_OP3 (A.V32,A.SUBS,A.ZR,$2,$4, A.S_NOEXT) }
 | CMP xreg COMMA kr

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -659,9 +659,11 @@ instr:
   { A.I_ADDR ($2,$4) }
 | SXTW xreg COMMA wreg
   { A.I_SXTW ($2,$4) }
-/* Special handling for ASR operation */
+/* Special handling for ASR/LSL operation */
 | ASR xreg COMMA xreg COMMA kr
   { A.I_OP3 (A.V64, AArch64Base.ASR, $2, $4, $6, A.S_NOEXT) }
+| LSL xreg COMMA xreg COMMA kr
+  { A.I_OP3 (A.V64, AArch64Base.LSL, $2, $4, $6, A.S_NOEXT) }
 | OP xreg COMMA xreg COMMA kr
   { A.I_OP3 (A.V64,$1,$2,$4,$6, A.S_NOEXT) }
 | OP xreg COMMA xreg COMMA kr COMMA shift


### PR DESCRIPTION
More specifically, this PR implements:
 - Clearing of AF and DBM bits with BIC and {LD,ST}CLR instructions.
 - New instruction BIC (and BICS).
