### PR TITLE
[internal] Create ExtendedBaseModules module

### DIFF
--- a/defs.sh
+++ b/defs.sh
@@ -9,7 +9,7 @@ NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
 INTERNAL="herd_regression_test.native herd_diycross_regression_test.native"
-TESTS="channel_test.native command_test.native filesystem_test.native test_test.native"
+TESTS="channel_test.native command_test.native extendedBaseModules_test.native filesystem_test.native"
 
 mk_exe () {
   D=$1

--- a/internal/lib/compare.ml
+++ b/internal/lib/compare.ml
@@ -14,46 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Extending built-in / base modules, either to port future features into
- *  earlier versions of OCaml, or to add new functionality. *)
-
-module Int = struct
-  type t = int
-
-  let compare (x : int) (y : int) = compare x y
-
-  let to_ocaml_string i = Printf.sprintf "%i" i
-end
-
-module String = struct
-  include String
-
-  let to_ocaml_string s = Printf.sprintf "%S" s
-end
-
-module List = struct
-  include List
-
-  let compare cf xs ys =
-    let rec find_comparison cs =
-      match cs with
-      | [] -> 0
-      | c :: cs' -> if c <> 0 then c else (find_comparison cs')
-    in
-    let compared_length = Int.compare (List.length xs) (List.length ys) in
-    if compared_length = 0 then begin
-      List.combine xs ys
-      |> List.map (fun (x, y) -> cf x y)
-      |> find_comparison
-    end else
-      compared_length
-
-  let to_ocaml_string f xs =
-    Printf.sprintf "[%s]" (String.concat "; " (List.map f xs))
-
-  module Make (Elt : Compare.S) : Compare.S with type t = Elt.t list = struct
-    include List
-    type t = Elt.t list
-    let compare = compare Elt.compare
-  end
+module type S = sig
+  type t
+  val compare : t -> t -> int
 end

--- a/internal/lib/compare.mli
+++ b/internal/lib/compare.mli
@@ -14,46 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Extending built-in / base modules, either to port future features into
- *  earlier versions of OCaml, or to add new functionality. *)
-
-module Int = struct
-  type t = int
-
-  let compare (x : int) (y : int) = compare x y
-
-  let to_ocaml_string i = Printf.sprintf "%i" i
-end
-
-module String = struct
-  include String
-
-  let to_ocaml_string s = Printf.sprintf "%S" s
-end
-
-module List = struct
-  include List
-
-  let compare cf xs ys =
-    let rec find_comparison cs =
-      match cs with
-      | [] -> 0
-      | c :: cs' -> if c <> 0 then c else (find_comparison cs')
-    in
-    let compared_length = Int.compare (List.length xs) (List.length ys) in
-    if compared_length = 0 then begin
-      List.combine xs ys
-      |> List.map (fun (x, y) -> cf x y)
-      |> find_comparison
-    end else
-      compared_length
-
-  let to_ocaml_string f xs =
-    Printf.sprintf "[%s]" (String.concat "; " (List.map f xs))
-
-  module Make (Elt : Compare.S) : Compare.S with type t = Elt.t list = struct
-    include List
-    type t = Elt.t list
-    let compare = compare Elt.compare
-  end
+module type S = sig
+  type t
+  val compare : t -> t -> int
 end

--- a/internal/lib/extendedBaseModules.mli
+++ b/internal/lib/extendedBaseModules.mli
@@ -20,7 +20,6 @@
 module Int : sig
   (* TODO: iff we raise our minimum OCaml version to 4.08,
    *       include module type of Int. *)
-
   type t = int
 
   (** [compare x y] is a non-polymorphic version of [Pervasives.compare] or
@@ -54,4 +53,6 @@ module List : sig
    *  [to_ocaml_string String.to_ocaml_string ["a"; "b"]] returns
    *  "[\"a\"; \"b\"]". *)
   val to_ocaml_string : ('a -> string) -> 'a list -> string
+
+  module Make : functor (Elt : Compare.S) -> Compare.S with type t = Elt.t list
 end

--- a/internal/lib/extendedBaseModules.mli
+++ b/internal/lib/extendedBaseModules.mli
@@ -1,0 +1,57 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Extending built-in / base modules, either to port future features into
+ *  earlier versions of OCaml, or to add new functionality. *)
+
+module Int : sig
+  (* TODO: iff we raise our minimum OCaml version to 4.08,
+   *       include module type of Int. *)
+
+  type t = int
+
+  (** [compare x y] is a non-polymorphic version of [Pervasives.compare] or
+   *  [Stdlib.compare]. It has identical semantics to [Int.compare] from OCaml
+   *  >= 4.08. *)
+  val compare : int -> int -> int
+
+  (** [to_ocaml_string i] returns an OCaml syntax form of [i].
+   *  For example, [to_ocaml_string 1] returns ["1"]. *)
+  val to_ocaml_string : int -> string
+end
+
+module String : sig
+  include module type of String
+
+  (** [to_ocaml_string s] returns an OCaml syntax form of [s].
+   *  For example, [to_ocaml_string "a"] returns ["\"a\""]. *)
+  val to_ocaml_string : string -> string
+end
+
+module List : sig
+  include module type of List
+
+  (** [compare c xs ys] compares lists [xs] and [ys], first by length, then by
+   *  comparing each pair of elements of [xs] and [ys] with compare function [c]
+   *  until a pair differs. *)
+  val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+
+  (** [to_ocaml_string f xs] returns an OCaml syntax form of [xs], applying [f]
+   *  to each element of [xs]. For example,
+   *  [to_ocaml_string String.to_ocaml_string ["a"; "b"]] returns
+   *  "[\"a\"; \"b\"]". *)
+  val to_ocaml_string : ('a -> string) -> 'a list -> string
+end

--- a/internal/lib/test.ml
+++ b/internal/lib/test.ml
@@ -38,37 +38,3 @@ let run tests =
 
 let fail msg =
     raise (AssertionFailure msg)
-
-
-(* Pretty-printing for failure messages. *)
-
-let pp_list pp_x xs = Printf.sprintf "[%s]" (String.concat "; " (List.map pp_x xs))
-
-let pp_int_list xs = pp_list (Printf.sprintf "%i") xs
-
-let pp_string_list xs = pp_list (Printf.sprintf "%S") xs
-
-
-(* Comparisons. *)
-
-let int_compare (x:int) (y:int) = compare x y
-
-let rec find_comparison cs =
-  match cs with
-  | [] -> 0
-  | c :: cs' -> if c <> 0 then c else (find_comparison cs')
-
-let list_compare c xs ys =
-  let compared_length = int_compare (List.length xs) (List.length ys) in
-  if compared_length = 0 then begin
-    List.combine xs ys
-    |> List.map (fun (x, y) -> c x y)
-    |> find_comparison
-  end else
-    compared_length
-
-let string_list_compare xs ys =
-  list_compare String.compare xs ys
-
-let int_list_compare xs ys =
-  list_compare int_compare xs ys

--- a/internal/lib/tests/channel_test.ml
+++ b/internal/lib/tests/channel_test.ml
@@ -16,8 +16,17 @@
 
 (** Tests for the Channel module. *)
 
-let pp_int_list = Test.pp_int_list
-let pp_string_list = Test.pp_string_list
+open ExtendedBaseModules
+
+module StringList = struct
+  let compare = List.compare String.compare
+  let to_ocaml_string = List.to_ocaml_string String.to_ocaml_string
+end
+
+module IntList = struct
+  let compare = List.compare Int.compare
+  let to_ocaml_string = List.to_ocaml_string Int.to_ocaml_string
+end
 
 let tests = [
   "Channel.read_lines and Channel.write_lines", (fun () ->
@@ -31,8 +40,8 @@ let tests = [
     let actual = Channel.read_lines in_ch in
     close_in in_ch ;
 
-    if Test.string_list_compare lines actual <> 0 then
-      Test.fail (Printf.sprintf "Expected %s, got %s" (pp_string_list lines) (pp_string_list actual))
+    if StringList.compare lines actual <> 0 then
+      Test.fail (Printf.sprintf "Expected %s, got %s" (StringList.to_ocaml_string lines) (StringList.to_ocaml_string actual))
   );
 
   "Channel.map_lines applies f", (fun () ->
@@ -47,8 +56,8 @@ let tests = [
     let actual = Channel.map_lines String.length in_ch in
     close_in in_ch ;
 
-    if Test.int_list_compare expected actual <> 0 then
-      Test.fail (Printf.sprintf "Expected %s, got %s" (pp_int_list expected) (pp_int_list actual))
+    if IntList.compare expected actual <> 0 then
+      Test.fail (Printf.sprintf "Expected %s, got %s" (IntList.to_ocaml_string expected) (IntList.to_ocaml_string actual))
   );
 ]
 

--- a/internal/lib/tests/command_test.ml
+++ b/internal/lib/tests/command_test.ml
@@ -16,7 +16,12 @@
 
 (** Tests for the Command module. *)
 
-let pp_string_list = Test.pp_string_list
+open ExtendedBaseModules
+
+module StringList = struct
+  let compare = List.compare String.compare
+  let to_ocaml_string = List.to_ocaml_string String.to_ocaml_string
+end
 
 let tests = [
   "Command.command without args", (fun () ->
@@ -77,8 +82,8 @@ let tests = [
     List.iter
       (fun (cmd, args, expected) ->
         let actual = Command.run_with_stdout cmd args Channel.read_lines in
-        if Test.string_list_compare actual expected <> 0 then
-          Test.fail (Printf.sprintf "Expected %s, got %s" (pp_string_list expected) (pp_string_list actual)))
+        if StringList.compare actual expected <> 0 then
+          Test.fail (Printf.sprintf "Expected %s, got %s" (StringList.to_ocaml_string expected) (StringList.to_ocaml_string actual)))
       tests
   );
   "Command.run_with_stdout_lines raises on error", (fun () ->

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,4 +1,4 @@
 (tests
- (names channel_test command_test filesystem_test test_test)
+ (names channel_test command_test extendedBaseModules_test filesystem_test)
  (libraries internal_lib unix)
  (modes native))

--- a/internal/lib/tests/extendedBaseModules_test.ml
+++ b/internal/lib/tests/extendedBaseModules_test.ml
@@ -14,29 +14,44 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Tests for the Test module. *)
-
-let pp_int_list = Test.pp_int_list
-let pp_string_list = Test.pp_string_list
+(** Tests for the ExtendedBaseModules module. *)
 
 let tests = [
-  "Test.pp_int_list", (fun () ->
+  "ExtendedBaseModules.Int.to_ocaml_string", (fun () ->
     let tests = [
-      [], "[]" ;
-      [1], "[1]" ;
-      [1; 2; 3], "[1; 2; 3]" ;
+      0, "0" ;
+      1, "1" ;
+      -1, "-1" ;
     ] in
 
     List.iter
-      (fun (xs, expected) ->
-        let actual = Test.pp_int_list xs in
+      (fun (i, expected) ->
+        let actual = ExtendedBaseModules.Int.to_ocaml_string i in
         if String.compare actual expected <> 0 then
           Test.fail (Printf.sprintf "Expected %s, got %s" expected actual)
       )
       tests
   );
 
-  "Test.pp_string_list", (fun () ->
+  "ExtendedBaseModules.String.to_ocaml_string", (fun () ->
+    let to_ocaml_string = ExtendedBaseModules.String.to_ocaml_string in
+    let tests = [
+      "", "\"\"" ;
+      "a", "\"a\"" ;
+      "a\"", "\"a\\\"\"" ;
+    ] in
+
+    List.iter
+      (fun (x, expected) ->
+        let actual = to_ocaml_string x in
+        if String.compare actual expected <> 0 then
+          Test.fail (Printf.sprintf "Expected %s, got %s" expected actual)
+      )
+      tests
+  );
+
+  "ExtendedBaseModules.List.to_ocaml_string(String)", (fun () ->
+    let to_ocaml_string = ExtendedBaseModules.List.to_ocaml_string ExtendedBaseModules.String.to_ocaml_string in
     let tests = [
       [], "[]" ;
       ["a"], "[\"a\"]" ;
@@ -45,14 +60,15 @@ let tests = [
 
     List.iter
       (fun (xs, expected) ->
-        let actual = Test.pp_string_list xs in
+        let actual = to_ocaml_string xs in
         if String.compare actual expected <> 0 then
           Test.fail (Printf.sprintf "Expected %s, got %s" expected actual)
       )
       tests
   );
 
-  "Test.int_list_compare", (fun () ->
+  "ExtendedBaseModules.List.compare(Int)", (fun () ->
+    let compare = ExtendedBaseModules.List.compare ExtendedBaseModules.Int.compare in
     let tests = [
       [], [], 0 ;
       [1], [], 1 ;
@@ -64,14 +80,15 @@ let tests = [
 
     List.iter
       (fun (xs, ys, expected) ->
-        let actual = Test.int_list_compare xs ys in
+        let actual = compare xs ys in
         if actual <> expected then
           Test.fail (Printf.sprintf "Expected %i, got %i" expected actual)
       )
       tests
   );
 
-  "Test.string_list_compare", (fun () ->
+  "ExtendedBaseModules.List.compare(String)", (fun () ->
+    let compare = ExtendedBaseModules.List.compare String.compare in
     let tests = [
       [], [], 0 ;
       ["a"], [], 1 ;
@@ -83,7 +100,7 @@ let tests = [
 
     List.iter
       (fun (xs, ys, expected) ->
-        let actual = Test.string_list_compare xs ys in
+        let actual = compare xs ys in
         if actual <> expected then
           Test.fail (Printf.sprintf "Expected %i, got %i" expected actual)
       )

--- a/internal/lib/tests/filesystem_test.ml
+++ b/internal/lib/tests/filesystem_test.ml
@@ -16,7 +16,12 @@
 
 (** Filesystem and file utilities. *)
 
-let pp_string_list = Test.pp_string_list
+open ExtendedBaseModules
+
+module StringList = struct
+  let compare = List.compare String.compare
+  let to_ocaml_string = List.to_ocaml_string String.to_ocaml_string
+end
 
 let tests = [
   "Filesystem.read_file and Filesystem.write_file", (fun () ->
@@ -35,8 +40,8 @@ let tests = [
         (* Clean up. *)
         Sys.remove path ;
 
-        if Test.string_list_compare lines actual <> 0 then
-          Test.fail (Printf.sprintf "Expected %s, got %s" (pp_string_list lines) (pp_string_list actual))
+        if StringList.compare lines actual <> 0 then
+          Test.fail (Printf.sprintf "Expected %s, got %s" (StringList.to_ocaml_string lines) (StringList.to_ocaml_string actual))
       )
       tests
   );

--- a/internal/lib/tests/filesystem_test.ml
+++ b/internal/lib/tests/filesystem_test.ml
@@ -19,9 +19,11 @@
 open ExtendedBaseModules
 
 module StringList = struct
-  let compare = List.compare String.compare
+  include List.Make(String)
   let to_ocaml_string = List.to_ocaml_string String.to_ocaml_string
 end
+
+module IntListSet = Set.Make(List.Make(Int))
 
 let tests = [
   "Filesystem.read_file and Filesystem.write_file", (fun () ->


### PR DESCRIPTION
I am sending this PR as more of a "request for discussion" / "request for advice", rather than "this code is ready to merge".

This PR:
- Creates a module, `ExtendedBaseModules`, to:
  - Backport modules and functions from future versions of OCaml to 4.05, e.g. `Int`.
  - Extend built-in modules with new features, e.g. `to_ocaml_string`, which returns an OCaml-syntax representation of the value.
  - Creates a functor `List.Make` that builds a `List` with a typed `compare` function, suitable for e.g. creating sets of lists of things.
- Adds relevant tests for these modules.
- Converts existing uses of `Test.pp_{int,string}_list` and `Test.{int,string}_list_compare` to use these new modules.
- Removes the replaced functions from `Test`.

For example, using OCaml 4.05:

```ocaml
open ExtendedBaseModules

module IntList = struct
  let compare = List.compare Int.compare
end

if IntList.compare xs [1; 2; 3] <> 0 then
    failwith "oh no"
```

I would also like to use this mechanism to backport `Option.compare` & `Option.equal` to parse catalogue shelf files in an upcoming PR.

Regarding `List.compare` specifically, the second commit adds a functor `List.Make` to mirror `Set.Make`. For example:

```ocaml
module IntList = List.Make(Int)

module IntListSet = Set.Make(List.Make(Int))
```

I plan to keep this approach limited to `internal/` for now, to experiment with this and find out what does and does not work.

Do you have opinions about this approach, for either extending built-ins, or backporting features? What do you think about the usefulness of `List.Make`? Do you think the names could be better, e.g. `open FutureFeatures` or `List.Make_compare`?