### PR TITLE
[herd] KVM, consider permissions of PTE acccesses.

### DIFF
--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -246,6 +246,6 @@ end = struct
      "Ftotal",is_total_barrier;]
 
   let arch_rels = []
-
+  let arch_dirty = []
 
 end

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -345,6 +345,7 @@ end = struct
   ]
 
   let arch_rels = []
+  and arch_dirty = []
 
   let is_isync _ = raise Misc.NoIsync
   let pp_isync = "???"

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -29,6 +29,7 @@ module type S = sig
 (* Some architecture-specific sets and relations, with their definitions *)
   val arch_sets : (string * (action -> bool)) list
   val arch_rels : (string * (action -> action -> bool)) list
+  val arch_dirty : (string * (DirtyBit.my_t -> action -> bool)) list
 
 (* control fence *)
   val is_isync : action -> bool

--- a/herd/model.ml
+++ b/herd/model.ml
@@ -95,6 +95,7 @@ module type Config = sig
   val optace : bool
   val libfind : string -> string
   val variant : Variant.t -> bool
+  val dirty : DirtyBit.t
 end
 
 let get_default_model variant a =

--- a/herd/model.mli
+++ b/herd/model.mli
@@ -54,6 +54,7 @@ module type Config = sig
   val optace : bool
   val libfind : string -> string
   val variant : Variant.t -> bool
+  val dirty : DirtyBit.t
 end
 
 (* Defaults *)

--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -149,6 +149,7 @@ module Top (Conf:Config) = struct
             Model.Generic (P.parse fname)
         | _ -> m in
         check_arch_model arch m in
+
       let module ModelConfig = struct
         let bell_model_info = Conf.bell_model_info
         let model = model
@@ -167,6 +168,7 @@ module Top (Conf:Config) = struct
         let optace = Conf.optace
         let libfind = Conf.libfind
         let variant = Conf.variant
+        let dirty = DirtyBit.get splitted.Splitter.info
 
         let statelessrc11 = Conf.statelessrc11
       end in
@@ -237,7 +239,7 @@ module Top (Conf:Config) = struct
             module C = Conf
 
             let precision = Conf.precision
-            let dirty = DirtyBit.get splitted.Splitter.info
+            let dirty = ModelConfig.dirty
 
           end in
           let module AArch64S = AArch64Sem.Make(AArch64SemConf)(Int64Value) in

--- a/lib/dirtyBit.mli
+++ b/lib/dirtyBit.mli
@@ -23,5 +23,7 @@ type t =
      some_hd : bool;
    }
 
+type my_t = { my_ha : unit -> bool; my_hd : unit -> bool; }
+
 val get : MiscParser.info -> t
  

--- a/lib/dirtyBit.mll
+++ b/lib/dirtyBit.mll
@@ -24,6 +24,8 @@
      some_hd : bool;
    }
 
+type my_t = { my_ha : unit -> bool; my_hd : unit -> bool; }
+
 type nat = HA | HD | SW
 
 exception Error

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -53,6 +53,10 @@ external int_compare : int -> int -> int = "caml_int_compare"
 let int_eq (x:int) (y:int) = x == y
 let string_eq (s1:string) (s2:string) = (=) s1 s2
 
+let bool_eq b1 b2 = match b1,b2 with
+| (true,true)|(false,false) -> true
+| (false,true)|(true,false) -> false
+
 external identity : 'a -> 'a = "%identity"
 
 let ing _ = ()
@@ -400,6 +404,19 @@ let group_iteri same do_it xs =
     | [] -> assert false
     | x::_ -> do_it k x xs)
     xss
+
+(* Check f yield eq results on a list, and returns the result  *)
+
+let check_same eq f xs =
+  try
+    List.fold_left
+      (fun prev x -> match prev with
+      | None -> Some (f x)
+      | Some y0 ->
+          if eq y0 (f x) then prev
+          else raise Exit)
+      None xs
+  with Exit -> None
 
 (* Bool's *)
 

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -47,6 +47,7 @@ val polymorphic_compare : 'a -> 'a -> int
 external int_compare : int -> int -> int = "caml_int_compare"
 val int_eq : int -> int -> bool
 val string_eq : string -> string -> bool
+val bool_eq : bool -> bool -> bool
 
 external identity : 'a -> 'a = "%identity"
 (* ignore argument(s) *)
@@ -134,6 +135,9 @@ val rem_dups : ('a -> 'a -> bool) -> 'a list -> 'a list
 val group : ('a -> 'a -> bool) -> 'a list -> 'a list list
 val group_iter : ('a -> 'a -> bool) -> ('a -> 'a list -> unit) -> 'a list -> unit
 val group_iteri : ('a -> 'a -> bool) -> (int -> 'a -> 'a list -> unit) -> 'a list -> unit
+
+(* Check that f yields the same result on all list elements *)
+val check_same : ('a -> 'a -> bool) -> ('b -> 'a) -> 'b list -> 'a option
 
 (* Lift boolean connectors to predicates *)
 val (|||) : ('a -> bool) -> ('a -> bool) -> 'a -> bool


### PR DESCRIPTION
  Permissions first apply to the pteval accessed and extend to events.
  - ReadOnly
     (af:1 || (af:0 && HA)) && (db:0 && (!HD || (dmb:0 && HD)))
  - ReadWrite
     (af:1 || (af:0 && HA)) && (db:1 || (db:0 && dbm:1 && HD)))

  Cat models initial environemnt is now enriched by two
  new sets of events `ReadOnly` and `ReadWrite`.

  Permissions are not obvious for initial writes as HA/HD (wich may
  vary per core) may be unkown. In case where all test threads have the
  same settings of HA and HD, those are taken for initial writes.
  Otherwise there is a fatal failure.