### PR TITLE
Variant in test metadata

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -17,7 +17,6 @@
 module Make
     (TopConf:sig
       module C : Sem.Config
-      val precision : bool
       val dirty : DirtyBit.t
     end)
     (V:Value.S)
@@ -466,7 +465,7 @@ module Make
             delayed_check_tags a_virt ma ii
               (mm  >>! B.Next)
               (let mfault = mk_fault a_virt ii None in
-              if TopConf.precision then  mfault >>! B.Exit
+              if C.precision then  mfault >>! B.Exit
               else (mfault >>| mm) >>! B.Next))
 
       let lift_memtag_virt mop ma ii =
@@ -476,13 +475,13 @@ module Make
             delayed_check_tags a_virt ma ii
               (mm  >>! B.Next)
               (let mfault = ma >>= fun a -> mk_fault a ii None in
-              if TopConf.precision then  mfault >>! B.Exit
+              if C.precision then  mfault >>! B.Exit
               else (mfault >>| mm) >>! B.Next))
 
       let lift_kvm dir mop ma an ii mphy =
         let mfault ma a =
           ma >>= fun _ -> mk_fault a ii None
-              >>! if TopConf.precision then B.Exit else B.ReExec
+              >>! if C.precision then B.Exit else B.ReExec
         in
         M.delay_kont "6" ma
           (fun a ma ->

--- a/herd/opts.ml
+++ b/herd/opts.ml
@@ -42,18 +42,12 @@ let archcheck = ref true
 let optace = ref None
 let variant = ref (fun _ -> false)
 let precision = ref false
+
 module OptS = struct
   include Variant
-  let setnow tag =
-    try
-      precision :=
-        (match tag with
-        | TagCheckPrecise -> true
-        | TagCheckUnprecise -> false
-        | _ -> raise Exit) ;
-      true
-    with Exit -> false
+  let setnow tag = set_precision precision tag
 end
+
 let byte = ref MachSize.Tag.Auto
 let endian = ref None
 let initwrites = ref None

--- a/herd/parseTest.mli
+++ b/herd/parseTest.mli
@@ -33,7 +33,6 @@ module type Config = sig
 
   val statelessrc11 : bool
   val byte : MachSize.Tag.t
-  val precision : bool
 end
 
 module Top :

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -21,6 +21,7 @@ module type Config = sig
   val verbose : int
   val optace : bool
   val debug : Debug_herd.t
+  val precision : bool
   val variant : Variant.t -> bool
   val endian : Endian.t option
   module PC : PrettyConf.S

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -52,7 +52,8 @@ let tags =
   ["success";"instr";"specialx0";"normw";"acqrelasfence";"backcompat";
    "fullscdepend";"splittedrmw";"switchdepscwrite";"switchdepscresult";"lrscdiffok";
    "mixed";"dontcheckmixed";"weakpredicated"; "memtag";
-   "tagcheckprecise"; "tagcheckunprecise"; "toofar"; "deps"; "instances"; ]
+   "tagcheckprecise"; "tagcheckunprecise"; "precise"; "imprecise";
+   "toofar"; "deps"; "instances"; ]
 
 let parse s = match Misc.lowercase s with
 | "success" -> Some Success
@@ -72,7 +73,7 @@ let parse s = match Misc.lowercase s with
 | "notweakpredicated"|"notweakpred" -> Some NotWeakPredicated
 | "tagmem"|"memtag" -> Some MemTag
 | "tagcheckprecise"|"precise" -> Some TagCheckPrecise
-| "tagcheckunprecise"|"unprecise" -> Some TagCheckUnprecise
+| "tagcheckimprecise"|"imprecise" -> Some TagCheckUnprecise
 | "toofar" -> Some TooFar
 | "deps" -> Some Deps
 | "instances"|"instance" -> Some Instances
@@ -101,7 +102,7 @@ let pp = function
   | NotWeakPredicated -> "NotWeakPredicated"
   | MemTag -> "memtag"
   | TagCheckPrecise -> "TagCheckPrecise"
-  | TagCheckUnprecise -> "TagCheckUnprecise"
+  | TagCheckUnprecise -> "TagCheckImprecise"
   | TooFar -> "TooFar"
   | Deps -> "Deps"
   | Instances -> "Instances"
@@ -125,3 +126,13 @@ let get_default a = function
       | _ -> true
       end
   | v -> Warn.fatal "No default for variant %s" (pp v)
+
+let set_precision r tag = 
+    try
+      r :=
+        (match tag with
+        | TagCheckPrecise -> true
+        | TagCheckUnprecise -> false
+        | _ -> raise Exit) ;
+      true
+    with Exit -> false

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -53,3 +53,6 @@ val pp : t -> string
 
 (* switch variant that flips an arch-dependent, default value *)
 val get_default :  Archs.t -> t -> bool
+
+(* set precision *)
+val set_precision : bool ref -> t -> bool

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -223,7 +223,7 @@ let hash_key =  "Hash"
 and stable_key = "Stable"
 and align_key = "Align"
 and tthm_key = "TTHM"
-
+and variant_key = "Variant"
 let low_hash = "hash"
 
 let get_info_on_info key =

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -116,6 +116,7 @@ val hash_key : string
 val stable_key : string
 val align_key : string
 val tthm_key : string
+val variant_key : string
 
 (* Extract hash *)
 val get_hash : ('i, 'p, 'c, 'loc) result -> string option

--- a/lib/testVariant.ml
+++ b/lib/testVariant.ml
@@ -1,0 +1,59 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Parse in-test variant info *)
+
+module
+  Make
+    (Var:sig
+      module Opt:sig
+        include ParseTag.Opt
+        val compare : t -> t -> int
+      end
+      val info : MiscParser.info
+      val precision : bool
+      val variant : Opt.t -> bool
+      val set_precision : bool ref -> Opt.t -> bool
+    end) : sig
+      type t = Var.Opt.t
+      val precision : bool
+      val variant : Var.Opt.t -> bool
+    end= struct
+      type t = Var.Opt.t
+
+      let pref = ref Var.precision
+      and vref = ref Var.variant
+
+      let () =
+        match
+          MiscParser.get_info_on_info
+            MiscParser.variant_key Var.info
+        with
+        | None -> ()
+        | Some tags ->
+            let tags = LexSplit.strings_spaces tags in
+            let module Opt = struct
+              include Var.Opt
+              let setnow = Var.set_precision pref
+            end in
+            let module P = ParseTag.MakeS(Opt) in
+            try
+              List.iter (P.parse_tag_set "variant" vref) tags
+            with Arg.Bad msg ->  Warn.user_error "%s" msg
+
+      let precision = !pref
+      let variant = !vref
+    end

--- a/lib/testVariant.mli
+++ b/lib/testVariant.mli
@@ -1,0 +1,34 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Parse in-test variant info *)
+
+module Make : functor 
+  (Var:sig
+      module Opt:sig
+        include ParseTag.Opt
+        val compare : t -> t -> int
+      end
+      val info : MiscParser.info
+      val precision : bool
+      val variant : Opt.t -> bool
+      val set_precision : bool ref -> Opt.t -> bool
+    end) ->
+      sig
+        type t = Var.Opt.t
+        val precision : bool
+        val variant : t -> bool
+      end

--- a/litmus/litmus.ml
+++ b/litmus/litmus.ml
@@ -63,7 +63,12 @@ let opts =
    argfloato "-timelimit" Option.timelimit "bound on runtime (presi only)" ;
 
 (* Modes *)
-   begin let module P = ParseTag.MakeS(Variant_litmus) in
+   begin
+     let module Opt = struct
+       include Variant_litmus
+       let setnow tag = set_precision precision tag 
+     end in
+     let module P = ParseTag.MakeS(Opt) in
    P.parse "-variant" Option.variant "select a variation" end ;
    begin let module P = ParseTag.Make(Barrier) in
    P.parse "-barrier" Option.barrier "set type of barriers" end ;
@@ -304,6 +309,7 @@ let () =
           end
       | Some b -> b
       let ascall = !ascall
+      let precision = !precision
       let variant = !variant
       let crossrun = match !mode,!crossrun with
       | Mode.Kvm,Crossrun.Qemu s -> Crossrun.Kvm s

--- a/litmus/option.ml
+++ b/litmus/option.ml
@@ -169,6 +169,7 @@ let morearch = ref MoreArch.No
 let carch = ref None
 let mode = ref Mode.Std
 let usearch = ref UseArch.Trad
+let precision = ref false
 let variant = ref (fun _ -> false)
 
 (* Arch dependent options *)

--- a/litmus/option.mli
+++ b/litmus/option.mli
@@ -117,6 +117,7 @@ val cacheflush : bool ref
 val carch : Archs.System.t option ref
 val mode : Mode.t ref
 val usearch : UseArch.t ref
+val precision : bool ref
 val variant : (Variant_litmus.t -> bool) ref
 
 (* Arch dependent option *)

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -41,6 +41,7 @@ module type Config = sig
   val cacheflush : bool
   val exit_cond : bool
   include DumpParams.Config
+  val precision : bool
   val variant : Variant_litmus.t -> bool
 end
 

--- a/litmus/top_litmus.mli
+++ b/litmus/top_litmus.mli
@@ -50,6 +50,7 @@ module type CommonConfig = sig
   val c11 : bool
   val c11_fence : bool
   val ascall : bool
+  val precision : bool
   val variant : Variant_litmus.t -> bool
   val stdio : bool
   val xy : bool

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -17,21 +17,33 @@
 type t =
   | Self (* Self modifying code *)
   | Precise (* Precise exception in kvm mode, ie jump to end of thread code in case of exception *)
+  | Imprecise (* Standard mode, will try access (twice) *)
+
 let compare = compare
 
-let tags = ["self";"precise";]
+let tags = ["self";"precise";"imprecise";]
 
 let parse s = match Misc.lowercase s with
 | "self" -> Some Self
 | "precise" -> Some Precise
+| "imprecise" -> Some Imprecise
 | _ -> None
 
 let pp = function
   | Self -> "self"
   | Precise -> "precise"
+  | Imprecise -> "imprecise"
 
 let ok v a = match v,a with
 | Self,`AArch64 -> true
 | _,_ -> false
 
-let setnow _ = false
+let set_precision r tag = 
+    try
+      r :=
+        (match tag with
+        | Precise -> true
+        | Imprecise -> false
+        | _ -> raise Exit) ;
+      true
+    with Exit -> false

--- a/litmus/variant_litmus.mli
+++ b/litmus/variant_litmus.mli
@@ -17,10 +17,11 @@
 type t =
   | Self (* Self modifying code *)
   | Precise (* Precise exception in kvm mode, ie jump to end of thread code in case of exception *)
+  | Imprecise (* Standard mode, will try access (twice) *)
 
 val tags : string list
 val parse : string -> t option
 val pp : t -> string
 val ok : t -> Archs.t -> bool
 val compare : t -> t -> int
-val setnow : t -> bool
+val set_precision : bool ref -> t -> bool


### PR DESCRIPTION
This PR introduces "variants" in the metadata of tests. This is done by using a "Variant" field.

Writing
```
Variant=<tags>
```
Has the same effect as adding option `-variant <tags>` at the end the the command line. As a consequence, variants from the test take precedence over the variants from the command line. 