### PR TITLE
[test] Add spacing between tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,15 @@ test:: $(D)-test
 	@ echo "OCaml unit tests: OK"
 
 dune-test:
+	@ echo
 	dune runtest
 
 ocb-test:
+	@ echo
 	./ocb-test.sh
 
 test::
+	@ echo
 	$(HERD_REGRESSION_TEST) \
 		-herd-path $(HERD) \
 		-libdir-path ./herd/libdir \
@@ -84,6 +87,7 @@ test::
 	@ echo "herd7 AArch64 instructions tests: OK"
 
 test::
+	@ echo
 	$(HERD_DIYCROSS_REGRESSION_TEST) \
 		-herd-path $(HERD) \
 		-diycross-path $(DIYCROSS) \

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,11 @@ ocb-test:
 	./ocb-test.sh
 
 test::
-	$(HERD_REGRESSION_TEST) -herd-path $(HERD) -libdir-path ./herd/libdir -litmus-dir ./herd/tests/instructions/AArch64 test
+	$(HERD_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/AArch64 \
+		test
 	@ echo "herd7 AArch64 instructions tests: OK"
 
 test::


### PR DESCRIPTION
This PR implements [a request](https://github.com/herd/herdtools7/pull/104#issuecomment-721822069) from PR #104.

Especially for long test commandlines, e.g. regression tests, the output should be more readable.

The output of `make test` used to be:

    sh ./dune-build.sh $HOME
    dune runtest
    OCaml unit tests: OK
    _build/default/internal/herd_regression_test.exe \
                  -herd-path _build/install/default/bin/herd7 \
                  -libdir-path ./herd/libdir \
                  -litmus-dir ./herd/unittests/AArch64 \
                  test
    herd7 AArch64 instructions tests: OK
    _build/default/internal/herd_diycross_regression_test.exe \
                  -herd-path _build/install/default/bin/herd7 \
                  -diycross-path _build/install/default/bin/diycross7 \
                  -libdir-path ./herd/libdir \
                  -expected-dir ./herd/unittests/AArch64.diycross \
                  -arch AArch64 \
                  -relaxlist 'Pod**,Fenced**' \
                  -relaxlist 'Rfe,Fre,Coe' \
                  -relaxlist 'Pod**,Fenced**,DpAddrdR,DpAddrdW,DpDatadW,CtrldR,CtrldW' \
                  -relaxlist 'Rfe,Fre,Coe' \
                  test
    Generator produced 37 tests
    herd7 AArch64 diycross7 tests: OK

It is now:

    sh ./dune-build.sh $HOME

    dune runtest
    OCaml unit tests: OK

    _build/default/internal/herd_regression_test.exe \
                  -herd-path _build/install/default/bin/herd7 \
                  -libdir-path ./herd/libdir \
                  -litmus-dir ./herd/unittests/AArch64 \
                  test
    herd7 AArch64 instructions tests: OK

    _build/default/internal/herd_diycross_regression_test.exe \
                  -herd-path _build/install/default/bin/herd7 \
                  -diycross-path _build/install/default/bin/diycross7 \
                  -libdir-path ./herd/libdir \
                  -expected-dir ./herd/unittests/AArch64.diycross \
                  -arch AArch64 \
                  -relaxlist 'Pod**,Fenced**' \
                  -relaxlist 'Rfe,Fre,Coe' \
                  -relaxlist 'Pod**,Fenced**,DpAddrdR,DpAddrdW,DpDatadW,CtrldR,CtrldW' \
                  -relaxlist 'Rfe,Fre,Coe' \
                  test
    Generator produced 37 tests
    herd7 AArch64 diycross7 tests: OK