### PR TITLE
Generators for kvm tests.

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (ignored_subdirs (herd-www))
 (env
  (release
-(flags (:standard -w +a-3-4-9-29-33-41-45-60-67))))
+(flags (:standard -w +a-3-4-8-9-29-33-41-45-60-67))))

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (ignored_subdirs (herd-www))
 (env
  (release
-(flags (:standard -w +a-3-4-8-9-29-33-41-45-60-67))))
+(flags (:standard -w +a-3-4-9-29-33-41-45-60-67))))

--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -252,13 +252,18 @@ let compare_fence b1 b2 = match b1,b2 with
 let default = Barrier (DMB (SY,FULL))
 let strong = default
 
+let add_dot f x = match f x with
+| "" -> ""
+| s -> "." ^ s
+
 let pp_fence f = match f with
 | Barrier f -> do_pp_barrier "." f
 | CacheSync (s,isb) -> sprintf "CacheSync%s%s"
       (match s with Strong -> "Strong" | Weak -> "")
       (if isb then "Isb" else "")
-| Shootdown (d,op) -> sprintf "Shootdown%s%s"
-      (pp_domain d) (TLBI.pp_op op)
+| Shootdown (d,op) ->
+    sprintf "TLBI%s%s"
+      (add_dot TLBI.short_pp_op op) (add_dot pp_domain d)
 
 let fold_cumul_fences f k =
    do_fold_dmb_dsb C.moreedges (fun b k -> f (Barrier b) k) k

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -65,7 +65,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     | Std (_,MachSize.Quad) -> V64
     | Int |Std (_,MachSize.Word) -> V32
     | Std (_,(MachSize.Short|MachSize.Byte)) -> V32
-
+    | Pteval -> V64
 
     let sz2v =
       let open MachSize in
@@ -104,7 +104,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let addi r1 r2 k = I_OP3 (vloc,ADD,r1,r2,K k, S_NOEXT)
     let lsri64 r1 r2 k = I_OP3 (V64,LSR,r1,r2,K k, S_NOEXT)
     let addi_64 r1 r2 k = I_OP3 (V64,ADD,r1,r2,K k, S_NOEXT)
-(*    let add r1 r2 r3 = I_OP3 (vloc,ADD,r1,r2,r3) *)
     let add v r1 r2 r3 = I_OP3 (v,ADD,r1,r2,RV (v,r3), S_NOEXT)
     let do_add64 v r1 r2 r3 = I_OP3 (V64,ADD,r1,r2,RV (v,r3), S_NOEXT)
 
@@ -117,15 +116,13 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Quad -> I_LDR (V64,r1,r2,K o)
 
     let do_ldr v r1 r2 = I_LDR (v,r1,r2,K 0)
-    let ldr = do_ldr vloc
     let ldg r1 r2 = I_LDG (r1,r2,K 0)
-    let ldar r1 r2 = I_LDAR (vloc,AA,r1,r2)
-    let ldapr r1 r2 = I_LDAR (vloc,AQ,r1,r2)
+    let do_ldar vr r1 r2 = I_LDAR (vr,AA,r1,r2)
+    let do_ldapr vr r1 r2 = I_LDAR (vr,AQ,r1,r2)
     let ldxr r1 r2 = I_LDAR (vloc,XX,r1,r2)
     let ldaxr r1 r2 = I_LDAR (vloc,AX,r1,r2)
     let sxtw r1 r2 = I_SXTW (r1,r2)
     let do_ldr_idx v r1 r2 idx = I_LDR (v,r1,r2,RV (vloc,idx))
-    let ldr_idx = do_ldr_idx vloc
 
 
     let ldr_mixed_idx v r1 r2 idx sz  =
@@ -282,9 +279,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 (*********)
 
     module type L = sig
-
-      val load : A.st -> reg -> reg -> instruction list * A.st
-      val load_idx : A.st -> reg -> reg -> reg -> instruction list * A.st
+      type sz
+      val sz0 : sz
+      val load : sz -> A.st -> reg -> reg -> instruction list * A.st
+      val load_idx : sz -> A.st -> reg -> reg -> reg -> instruction list * A.st
     end
 
     let emit_load_mixed sz o st p init x =
@@ -295,11 +293,13 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     module LOAD(L:L) =
       struct
 
-        let emit_load st p init x =
+        let emit_load_var vr st p init x =
           let rA,st = next_reg st in
           let rB,init,st = U.next_init st p init x in
-          let ld,st = L.load st rA rB in
+          let ld,st = L.load vr st rA rB in
           rA,init,lift_code ld,st
+
+        let emit_load =  emit_load_var L.sz0
 
         let emit_fetch st _p init lab =
           let rA,st = next_reg st in
@@ -317,7 +317,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let emit_load_not_zero st p init x =
           let rA,st = next_reg st in
           let rB,init,st = U.next_init st p init x in
-          let ld,st = L.load st rA rB in
+          let ld,st = L.load L.sz0 st rA rB in
           let lab = Label.next_label "L" in
           rA,init,
           Label (lab,Nop)::
@@ -327,7 +327,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let emit_load_one st p init x =
           let rA,st = next_reg st in
           let rB,init,st = U.next_init st p init x in
-          let ld,st = L.load st rA rB in
+          let ld,st = L.load L.sz0 st rA rB in
           let lab = Label.next_label "L" in
           rA,init,
           Label (lab,Nop)::
@@ -338,7 +338,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           let rA,st = next_reg st in
           let rC,st = tempo4 st in
           let rB,init,st = U.next_init st p init x in
-          let ld,st = L.load st rA rB in
+          let ld,st = L.load L.sz0 st rA rB in
           let lab = Label.next_label "L" in
           let out = Label.next_label "L" in
           rA,init,
@@ -362,7 +362,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let emit_load_idx st p init x idx =
           let rA,st = next_reg st in
           let rB,init,st = U.next_init st p init x in
-          let ins,st = L.load_idx st rA rB idx in
+          let ins,st = L.load_idx L.sz0 st rA rB idx in
           rA,init,pseudo ins ,st
 
       end
@@ -374,8 +374,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     module LDR =
       LOAD
         (struct
-          let load = wrap_st ldr
-          let load_idx st rA rB idx = [ldr_idx rA rB idx],st
+          type sz = A64.variant
+          let sz0 = vloc
+          let load vr = wrap_st (do_ldr vr)
+          let load_idx vr st rA rB idx = [do_ldr_idx vr rA rB idx],st
         end)
 
     module LDG = struct
@@ -401,9 +403,11 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     module OBS =
       LOAD
         (struct
-          let load st rA rB = [ldr_mixed rA rB naturalsize 0],st
-          let load_idx st rA rB idx =
-            [ldr_mixed_idx vloc rA rB idx naturalsize],st
+          type sz = MachSize.sz
+          let sz0 = naturalsize
+          let load vr st rA rB = [ldr_mixed rA rB vr 0],st
+          let load_idx vr st rA rB idx =
+            [ldr_mixed_idx vloc rA rB idx vr],st
         end)
 
 (* For export *)
@@ -412,7 +416,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
 
     let emit_obs t = match t with
-    | Code.Ord -> emit_load_mixed naturalsize 0
+    | Code.Ord|Code.Pte -> emit_load_mixed naturalsize 0
     | Code.Tag -> LDG.emit_load
     let emit_obs_not_value = OBS.emit_load_not_value
     let emit_obs_not_eq = OBS.emit_load_not_eq
@@ -420,19 +424,24 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     module LDAR = LOAD
         (struct
-          let load = wrap_st ldar
-          let load_idx st rA rB idx =
+          type sz = A64.variant
+          let sz0 = vloc
+          let load vr = wrap_st (do_ldar vr)
+          let load_idx vr st rA rB idx =
             let r,ins,st = sum_addr st rB idx in
-            ins@[ldar rA r],st
+            ins@[do_ldar vr rA r],st
         end)
 
     module LDAPR = LOAD
         (struct
-          let load = wrap_st ldapr
-          let load_idx st rA rB idx =
+          type sz = A64.variant
+          let sz0 = vloc
+          let load vr = wrap_st (do_ldapr vr)
+          let load_idx vr st rA rB idx =
             let r,ins,st = sum_addr st rB idx in
-            ins@[ldapr rA r],st
+            ins@[do_ldapr vr rA r],st
         end)
+
 
 (**********)
 (* Stores *)
@@ -594,7 +603,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let loc_ok = Code.as_data (Code.myok p n) in
       let init,cs,st =
         STR.emit_store st p init loc_ok 0 in
-      (A.Loc loc_ok,Some "1")::init,
+      (A.Loc loc_ok,Some (A.S "1"))::init,
       Instruction (get_xload ar rR rA)::
       Instruction (get_xstore aw r rW rA)::
       Instruction (cbnz r (Label.fail p n))::
@@ -741,6 +750,11 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let rR,cs2,st = do_emit_sta_mixed sz o rw st p init rW rA in
       rR,init,csi@pseudo cs1@cs2,st
 
+    let emit_set_pteval st p init v loc =
+      let rA,init,st = U.next_init st p init loc in
+      let rB,init,st = U.emit_pteval st p init v in
+      init,pseudo [do_str A64.V64 rB rA],st
+
 (**********)
 (* Access *)
 (**********)
@@ -777,8 +791,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let module L =
               LOAD
                 (struct
-                  let load = ldar_mixed AA sz o
-                  let load_idx = ldar_mixed_idx AA sz o
+                  type sz = MachSize.sz
+                  let sz0 = sz
+                  let load sz = ldar_mixed AA sz o
+                  let load_idx sz = ldar_mixed_idx AA sz o
                 end) in
             let r,init,cs,st = L.emit_load st p init loc in
             Some r,init,cs,st
@@ -789,8 +805,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let module L =
               LOAD
                 (struct
-                  let load = ldar_mixed AQ sz o
-                  let load_idx = ldar_mixed_idx AQ sz o
+                  type sz = MachSize.sz
+                  let sz0 = sz
+                  let load sz = ldar_mixed AQ sz o
+                  let load_idx sz = ldar_mixed_idx AQ sz o
                 end) in
             let r,init,cs,st = L.emit_load st p init loc in
             Some r,init,cs,st
@@ -842,6 +860,13 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | W,Some (Tag,None) ->
             let init,cs,st = STG.emit_store st p init e in
             None,init,cs,st
+        | R,Some (Pte Read,None) ->
+            let r,init,cs,st = LDR.emit_load_var A64.V64 st p init (Misc.add_pte loc) in
+            Some r,init,cs,st
+        | W,Some (Pte (Set _),None) ->
+            let init,cs,st = emit_set_pteval st p init e.C.pte (Misc.add_pte loc) in
+            None,init,cs,st
+        | _,Some (Pte _,_) -> assert false
         | _,Some (Plain,None) -> assert false
         | _,Some (Tag,_) -> assert false
         | J,_ -> emit_joker st init
@@ -1004,8 +1029,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let module LDR =
                 LOAD
                   (struct
-                    let load = wrap_st ldr
-                    let load_idx  st rA rB idx = [do_ldr_idx vdep rA rB idx],st
+                    type sz = A64.variant
+                    let sz0 = vloc
+                    let load vr = wrap_st (do_ldr vr)
+                    let load_idx vr st rA rB idx = [do_ldr_idx vr rA rB idx],st
                   end) in
               let r,init,cs,st = LDR.emit_load_idx st p init loc r2 in
               Some r,init, Instruction c::cs,st
@@ -1013,10 +1040,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let module LDAR =
                 LOAD
                   (struct
-                    let load = wrap_st ldar
-                    let load_idx  st rA rB idx =
+                    type sz = A64.variant
+                    let sz0 = vloc
+                    let load vr = wrap_st (do_ldar vr)
+                    let load_idx vr st rA rB idx =
                       let r,ins,st = do_sum_addr vdep st rB idx in
-                      ins@[ldar rA r],st
+                      ins@[do_ldar vr rA r],st
                   end) in
               let r,init,cs,st = LDAR.emit_load_idx st p init loc r2 in
               Some r,init, Instruction c::cs,st
@@ -1024,8 +1053,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let module L =
                 LOAD
                   (struct
-                    let load = ldar_mixed AA sz o
-                    let load_idx = do_ldar_mixed_idx vdep AA sz o
+                    type sz = MachSize.sz
+                    let sz0 = sz
+                    let load sz = ldar_mixed AA sz o
+                    let load_idx sz = do_ldar_mixed_idx vdep AA sz o
                   end) in
               let r,init,cs,st = L.emit_load_idx st p init loc r2 in
               Some r,init,Instruction c::cs,st
@@ -1033,10 +1064,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let module LDAPR =
                 LOAD
                   (struct
-                    let load = wrap_st ldapr
-                    let load_idx st rA rB idx =
+                    type sz = A64.variant
+                    let sz0 = vloc
+                    let load sz = wrap_st (do_ldapr sz)
+                    let load_idx sz st rA rB idx =
                       let r,ins,st = do_sum_addr vdep st rB idx in
-                      ins@[ldapr rA r],st
+                      ins@[do_ldapr sz rA r],st
                   end) in
               let r,init,cs,st = LDAPR.emit_load_idx st p init loc r2 in
               Some r,init, Instruction c::cs,st
@@ -1044,8 +1077,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let module L =
                 LOAD
                   (struct
-                    let load = ldar_mixed AQ sz o
-                    let load_idx = do_ldar_mixed_idx vdep AQ sz o
+                    type sz = MachSize.sz
+                    let sz0 = sz
+                    let load sz = ldar_mixed AQ sz o
+                    let load_idx sz = do_ldar_mixed_idx vdep AQ sz o
                   end) in
               let r,init,cs,st = L.emit_load_idx st p init loc r2 in
               Some r,init,Instruction c::cs,st
@@ -1110,8 +1145,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let module L =
                 LOAD
                   (struct
-                    let load st r1 r2 = [ldr_mixed r1 r2 sz o],st
-                    let load_idx st r1 r2 idx =
+                    type sz = MachSize.sz
+                    let sz0 = sz
+                    let load sz st r1 r2 = [ldr_mixed r1 r2 sz o],st
+                    let load_idx sz st r1 r2 idx =
                       let cs = [ldr_mixed_idx V64 r1 r2 idx sz] in
                       let cs = match o with
                       | 0 -> cs
@@ -1138,6 +1175,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | W,Some (Tag, None) ->
               let init,cs,st = STG.emit_store_idx vdep st p init e r2 in
               None,init,Instruction c::cs,st
+          | (W,(Some (Pte (Set _),None)))
+          | (R,(Some (Pte Read,None)))
+            ->
+              Warn.fatal "Not Yet"
+          | (W|R),Some (Pte _,_) ->
+              assert false
           | W,Some (Tag,Some _) -> assert false
           | J,_ -> emit_joker st init
           | _,Some (Plain,None) -> assert false
@@ -1230,6 +1273,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | Some (Tag, None) ->
               let init,cs,st = STG.emit_store_reg st p init loc r2 in
               None,init,cs2@cs,st
+          | Some (Pte (Set _),None) -> Warn.fatal "Not Yet either"
+          | Some ((Pte _,Some _)|(Pte Read,_)) -> assert false
           | Some (Plain,None) -> assert false
           | Some (Tag,Some _) -> assert false
           end
@@ -1259,7 +1304,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       ropt,init,insert_isb isb c cs,st
 
     let tr_atom = function
-      | Some (Tag,_) -> V64
+      | Some ((Tag|Pte _),_) -> V64
       | _ -> vloc
 
     let emit_access_dep st p init e dp r1 n1 =

--- a/gen/ARMArch_gen.ml
+++ b/gen/ARMArch_gen.ml
@@ -34,7 +34,7 @@ include MachAtom.Make
       let fullmixed = C.moreedges
     end)
 
-let x = default_atom
+let set_pteval _ p _ = p
 
 (**********)
 (* Fences *)

--- a/gen/BellArch_gen.ml
+++ b/gen/BellArch_gen.ml
@@ -200,6 +200,8 @@ let varatom_rmw = match varatom with
 
 include NoMixed
 
+let set_pteval _ p _ = p
+
 (* End of atoms *)
 
 (**********)

--- a/gen/CArch_gen.ml
+++ b/gen/CArch_gen.ml
@@ -59,7 +59,10 @@ let atom_to_bank _ = Code.Ord
 
 include NoMixed
 
+let set_pteval _ p _ = p
+
 (* Fences, to be completed *)
+
 type fence = MemOrder.t
 
 let is_isync _ = false

--- a/gen/MIPSArch_gen.ml
+++ b/gen/MIPSArch_gen.ml
@@ -30,6 +30,7 @@ include MachAtom.Make
       let fullmixed = C.moreedges
     end)
 
+let set_pteval _ p _ = p
 
 (**********)
 (* Fences *)

--- a/gen/PPCArch_gen.ml
+++ b/gen/PPCArch_gen.ml
@@ -43,6 +43,8 @@ module Make(C:Config)  =
           let fullmixed = C.moreedges
         end)
 
+    let set_pteval _ p _ = p
+
 (**********)
 (* Fences *)
 (**********)

--- a/gen/RISCVArch_gen.ml
+++ b/gen/RISCVArch_gen.ml
@@ -38,6 +38,8 @@ module Make
          let fullmixed = C.moreedges
        end)
 
+   let set_pteval _ p _ = p
+
 (*********)
 (* Atoms *)
 (*********)

--- a/gen/X86Arch_gen.ml
+++ b/gen/X86Arch_gen.ml
@@ -53,6 +53,8 @@ let atom_to_bank _ = Code.Ord
 
 include NoMixed
 
+let set_pteval _ p _ = p
+
 (**********)
 (* Fences *)
 (**********)

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -134,6 +134,8 @@ module Make
       | Some ((Plain|Atomic|NonTemporal),Some (sz, o)) ->
           ValsMixed.extract_value v sz o
 
+      let set_pteval _ p _ = p
+
             (**********)
             (* Fences *)
             (**********)

--- a/gen/X86_64Compile_gen.ml
+++ b/gen/X86_64Compile_gen.ml
@@ -28,6 +28,7 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
       | Int | Std (_,Word) -> Word
       | Std (_,Short) -> Short
       | Std (_,Byte) -> Byte
+      | Pteval -> assert false
 
     let size_to_inst_size =
       let open X86_64Base in

--- a/gen/code.ml
+++ b/gen/code.ml
@@ -125,11 +125,12 @@ type info = (string * string) list
 let plain = "Na"
 
 (* Memory Space *)
-type bank = Ord | Tag
+type bank = Ord | Tag |Pte
 
 let pp_bank = function
   | Ord -> "Ord"
   | Tag -> "Tag"
+  | Pte -> "Pte"
 
 let tag_of_int  = function
   | 0 -> "green"

--- a/gen/code.mli
+++ b/gen/code.mli
@@ -81,8 +81,8 @@ type info = (string * string) list
 (* Name of plain accesses *)
 val plain : string
 
-(* Memory bank (for MTE)  *)
-type bank = Ord | Tag
+(* Memory bank (for MTE, KVM)  *)
+type bank = Ord | Tag | Pte
 
 val pp_bank : bank -> string
 

--- a/gen/config.ml
+++ b/gen/config.ml
@@ -49,6 +49,14 @@ let bell = ref None
 let scope = ref Scope.No
 let variant = ref (fun (_:Variant_gen.t) -> false)
 
+let info = ref ([]:MiscParser.info)
+let add_info_line line = match LexScan.info line with
+| Some kv -> info := !info @ [kv]
+| None ->
+    let msg =
+      Printf.sprintf "argument '%s' is not in 'key = value' format" line in
+    raise (Arg.Bad msg)
+
 type do_observers =
   | Avoid   (* was false *)
   | Accept  (* was true  *)
@@ -182,6 +190,7 @@ let common_specs =
   ("-nooptcond", Arg.Clear optcond, "do not optimize conditions")::
   ("-optcoherence", Arg.Set optcoherence, " optimize coherence")::
   ("-nooptcoherence", Arg.Clear optcoherence, "do not optimize coherence (default)")::
+  ("-info",Arg.String add_info_line,"add metadata to generated test(s)")::
   ("-moreedges", Arg.Bool (fun b -> moreedges := b),
    Printf.sprintf
      "consider a very complete set of edges, default %b" !moreedges)::

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -237,6 +237,7 @@ let () =
     let neg = !Config.neg
     let cpp = cpp
     let scope = !scope
+    let info = !Config.info
     let docheck = !Config.docheck
     let typ = !Config.typ
     let hexa = !Config.hexa

--- a/gen/diycross.ml
+++ b/gen/diycross.ml
@@ -210,6 +210,7 @@ let () =
       let realdep = !Config.realdep
       let cpp = match !Config.arch with `CPP -> true | _ -> false
       let scope = !Config.scope
+      let info = !Config.info
       let variant = !Config.variant
     end in
     let module T = Top_gen.Make(C) in

--- a/gen/diyone.ml
+++ b/gen/diyone.ml
@@ -221,6 +221,7 @@ let () =
     let scope = !Config.scope
     let docheck = !Config.docheck
     let prog = Config.prog
+    let info = !Config.info
     let variant = !Config.variant
   end in
   let module Build = Make(Co) in

--- a/gen/dumpAll.ml
+++ b/gen/dumpAll.ml
@@ -30,6 +30,7 @@ module type Config = sig
   val overload : int option
   val cpp : bool
   val scope : Scope.t
+  val info : MiscParser.info
 end
 
 module Make(Config:Config)(T:Builder.S)
@@ -315,7 +316,7 @@ module Make(Config:Config)(T:Builder.S)
             n,res.env in
         let cy = T.E.pp_edges cycle.norm in
         let info,relaxed = mk_info cycle.norm in
-        let info = ("Cycle",cy)::info in
+        let info = Config.info@("Cycle",cy)::info in
 
         match Config.scope with
         | Scope.No ->

--- a/gen/dumpAll.mli
+++ b/gen/dumpAll.mli
@@ -28,6 +28,7 @@ module type Config = sig
   val overload : int option
   val cpp : bool
   val scope : Scope.t
+  val info : MiscParser.info
 end
 
 module Make(Config:Config) (T:Builder.S) : sig

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -31,6 +31,7 @@ module type S = sig
   val tr_value : atom option -> Code.v -> Code.v
   val overwrite_value : Code.v -> atom option -> Code.v -> Code.v
   val extract_value : Code.v -> atom option -> Code.v
+  val set_pteval : atom option -> PTEVal.t -> (unit -> string) -> PTEVal.t
   val merge_atoms : atom -> atom -> atom option
   val atom_to_bank : atom option -> Code.bank
   val strong : fence
@@ -156,6 +157,10 @@ and type rmw = F.rmw = struct
   let tr_value = F.tr_value
   let overwrite_value = F.overwrite_value
   let extract_value = F.extract_value
+  let set_pteval ao p = match ao with
+  | None -> fun _ -> p
+  | Some a -> F.set_pteval a p
+
   let applies_atom ao d = match ao,d with
   | (None,_)|(_,(Irr|NoDir)) -> true
   | Some a,Dir d -> F.applies_atom a d

--- a/gen/fence.mli
+++ b/gen/fence.mli
@@ -27,6 +27,7 @@ end
 module type S = sig
 (* Atoms *)
   include Atom.S
+  val set_pteval : atom -> PTEVal.t -> (unit -> string) -> PTEVal.t
 
 (* Fences *)
   type fence

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -19,6 +19,7 @@ module type Config = sig
   val cond : Config.cond
   val optcond : bool
   val hexa : bool
+  val variant : Variant_gen.t -> bool
 end
 
 module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
@@ -48,9 +49,18 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
 
     val dump_final : out_channel ->  final -> unit
 
+(* Complement init environemt *)
+    val extract_ptes : fenv -> C.A.location list
+
   end = functor (O:Config) -> functor (C:ArchRun.S) ->
   struct
-    type v = I of int | S of string
+
+    let do_kvm = O.variant Variant_gen.KVM
+
+    type v = I of int | S of string | P of PTEVal.t
+    let pte_def = P (PTEVal.default "*")
+    let () = ignore pte_def
+
     module VSet =
       MySet.Make
         (struct
@@ -59,8 +69,13 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           let compare v1 v2 = match v1,v2 with
           | I i1,I i2 -> compare i1 i2
           | S s1,S s2 -> String.compare s1 s2
-          | S _,I _ -> -1
-          | I _,S _ -> +1
+          | P p1,P p2 -> PTEVal.compare p1 p2
+          | ((P _|S _),I _)
+          | (P _,S _)
+            -> -1
+          | (I _,(S _|P _))
+          | (S _,P _)
+            -> +1
         end)
     type vset = VSet.t
     type fenv = (C.A.location * vset) list
@@ -111,13 +126,15 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
                 Some (I evt.C.C.v)
             | Code.Tag ->
                 Some (S (Code.add_tag (Code.as_data evt.C.C.loc) evt.C.C.v))
+            | Code.Pte ->
+                Some (P evt.C.C.pte)
             end
         | Some Code.W -> assert (evt.C.C.bank = Code.Ord) ; Some (I (prev_value evt.C.C.v))
         | None|Some Code.J -> None in
         if show_in_cond n then match v with
         | Some v ->
             C.C.EventMap.add n.C.C.evt (C.A.of_reg p r) m,
-             (C.A.of_reg p r,VSet.singleton v)::fs
+            (C.A.of_reg p r,VSet.singleton v)::fs
         | None -> finals
         else finals
     | None -> finals
@@ -145,6 +162,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           if O.hexa then sprintf "0x%x" i
           else sprintf "%i" i
       | S s -> s
+      | P p -> PTEVal.pp p
 
     let dump_atom r v = sprintf "%s=%s" (C.A.pp_location r) (dump_val v)
 
@@ -163,41 +181,71 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
                  sprintf "(%s)" pp)
            fs)
 
-    let dump_flts flts =
-      let pp =
-        List.map
-          (fun (p,xs) ->
-            StringSet.pp_str " \\/ " (fun x -> sprintf "fault(%s,%s)" (Proc.pp p) x) xs)
-          flts in
-      let pp = String.concat " \\/ " pp in
-      match flts with
-      | [] -> ""
-      | [_,xs] when StringSet.is_singleton xs -> "~" ^ pp
-      | _ -> sprintf "~(%s)" pp
+    let dump_one_flt p x =  sprintf "fault (%s,%s)" (Proc.pp p) x
 
-    let dump_final chan (f,flts) = match f with
-    | Exists fs ->
-        let ppfs = dump_state fs
-        and ppflts = dump_flts flts in
-        let cc = match ppfs,ppflts with
-        | "","" -> ""
-        | "",_ -> ppflts
-        | _,"" -> sprintf "(%s)" ppfs
-        | _,_ -> sprintf "(%s) /\\ %s" ppfs ppflts in
-        if cc <> "" then
-          fprintf chan "%sexists %s\n" (if !Config.neg then "~" else "") cc
-    | Forall ffs ->
-        fprintf chan "forall\n" ;
-        fprintf chan "%s%s\n" (Run.dump_cond ffs)
-          (match dump_flts flts with
-          | "" -> ""
-          | pp -> " /\\ "^pp)
-    | Locations locs ->
-        fprintf chan "locations [%s]\n"
-          (String.concat ""
-             (List.map (fun loc -> sprintf "%s;" (C.A.pp_location loc)) locs)) ;
-        begin match dump_flts flts with
-        | "" -> ()
-        | pp -> fprintf chan "forall %s\n" pp
-        end
+    let dump_flt sep (p,xs) = StringSet.pp_str sep (dump_one_flt p) xs
+
+    let dump_flts =
+      if do_kvm then fun _ ->   ""
+      else fun flts ->
+        let pp = List.map (dump_flt " \\/ ") flts in
+        let pp = String.concat " \\/ " pp in
+        match flts with
+        | [] -> ""
+        | [_,xs] when StringSet.is_singleton xs -> "~" ^ pp
+        | _ -> sprintf "~(%s)" pp
+
+    let dump_locations chan = function
+      | [] -> ()
+      | locs -> fprintf chan "locations [%s]\n" (String.concat " " locs)
+
+    let dump_final chan (f,flts) =
+      let loc_flts =
+        if do_kvm then
+          List.fold_right
+            (fun (p,xs) ->
+              StringSet.fold
+                (fun x k -> sprintf "%s;" (dump_one_flt p x)::k)
+                xs)
+            flts []
+        else [] in
+      match f with
+      | Exists fs ->
+          dump_locations chan loc_flts ;
+          let ppfs = dump_state fs
+          and ppflts = dump_flts flts in
+          let cc = match ppfs,ppflts with
+          | "","" -> ""
+          | "",_ -> ppflts
+          | _,"" -> sprintf "(%s)" ppfs
+          | _,_ -> sprintf "(%s) /\\ %s" ppfs ppflts in
+          if cc <> "" then
+            fprintf chan "%sexists %s\n" (if !Config.neg then "~" else "") cc
+      | Forall ffs ->
+          dump_locations chan loc_flts ;
+          fprintf chan "forall\n" ;
+          fprintf chan "%s%s\n" (Run.dump_cond ffs)
+            (match dump_flts flts with
+            | "" -> ""
+            | pp -> " /\\ "^pp)
+      | Locations locs ->
+          dump_locations chan           
+            (List.fold_right
+               (fun loc k -> sprintf "%s;" (C.A.pp_location loc)::k)
+               locs loc_flts) ;
+          begin match dump_flts flts with
+          | "" -> ()
+          | pp -> if not do_kvm then fprintf chan "forall %s\n" pp
+          end
+
+(* Extract ptes *)
+    let extract_ptes =
+      List.fold_left
+        (fun k (loc,vset) ->
+          if
+            VSet.exists (function | P _ -> true | (I _|S _) -> false)
+              vset then
+            loc::k
+          else k)
+        []
   end

--- a/gen/genUtils.mli
+++ b/gen/genUtils.mli
@@ -52,6 +52,9 @@ functor (Cfg:Config) ->
     val emit_const :
         A.st -> Code.proc -> A.init -> int -> A.reg option * A.init * A.st
 
+    val emit_pteval :
+        A.st -> Code.proc -> A.init -> PTEVal.t -> A.reg * A.init * A.st
+
     val emit_nop :
         A.st -> Code.proc -> A.init -> string -> A.reg * A.init * A.st
 

--- a/gen/typBase.ml
+++ b/gen/typBase.ml
@@ -19,7 +19,8 @@
 open MachSize
 
 type sgn = Signed | Unsigned
-type t =   Int | Std of sgn * MachSize.sz
+
+type t =   Int | Std of sgn * MachSize.sz | Pteval
 
 let tags =
   ["int";
@@ -51,14 +52,19 @@ let pp = function
 | Std (Unsigned,Word) ->  "uint32_t"
 | Std (Signed,Quad) ->  "int64_t"
 | Std (Unsigned,Quad) ->  "uint64_t"
-
+| Pteval -> "pteval_t"
 
 let default = Int
-
 let is_default = function
   | Int -> true
+  | _ -> false
+
+let pteval_t = Pteval
+let is_pteval_t = function
+  | Pteval -> true
   | _ -> false
 
 let get_size = function
   | Int -> Word
   | Std (_,sz) -> sz
+  | Pteval -> Quad

--- a/gen/typBase.mli
+++ b/gen/typBase.mli
@@ -17,7 +17,7 @@
 (* Base type for produced tests *)
 
 type sgn = Signed | Unsigned
-type t =   Int | Std of sgn * MachSize.sz
+type t = Int | Std of sgn * MachSize.sz | Pteval
 
 val tags : string list
 
@@ -27,4 +27,8 @@ val pp : t -> string
 
 val default : t
 val is_default : t -> bool
+
+val pteval_t : t
+val is_pteval_t : t -> bool
+
 val get_size : t -> MachSize.sz

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -363,11 +363,16 @@ let fold_domain f k =
       k
 
   let fold_op f k =
-    let k = f  {typ=VMALLS12; level=E1; domain=IS;} k in
+    let k = f  {typ=VMALL; level=E1; domain=IS;} k in
     f {typ=VAA; level=E1; domain=IS; } k
 
   let pp_op { typ; level; domain; } =
     sprintf "%s%s%s" (pp_typ typ) (pp_level level) (pp_domain domain)
+
+  let short_pp_op = function
+    | {typ=VMALL; level=E1; domain=IS} -> "VMALL"
+    | {typ=VAA; level=E1; domain=IS} -> ""
+    | op -> pp_op op
 
   let is_at_level lvl op =  op.level = lvl
 

--- a/lib/PTEVal.ml
+++ b/lib/PTEVal.ml
@@ -28,6 +28,8 @@ type t = {
 let default s =
   { oa=Misc.add_physical s; valid=1; af=1; db=1; dbm=0; }
 
+let set_oa p s = { p with oa = Misc.add_physical s; }
+
 let is_default t = t.valid=1 && t.af=1 && t.db=1 && t.dbm=0
 
 let pp p =
@@ -74,3 +76,10 @@ let compare =
           (lex_compare
              (fun p1 p2 -> Misc.int_compare p1.dbm p2.dbm)
              (fun p1 p2 -> Misc.int_compare p1.valid p2.valid))))
+
+let eq p1 p2 =
+  Misc.string_eq p1.oa p2.oa &&
+  Misc.int_eq p1.af p2.af &&
+  Misc.int_eq p1.db p2.db &&
+  Misc.int_eq p1.dbm p2.dbm &&
+  Misc.int_eq p1.valid p2.valid

--- a/lib/PTEVal.mli
+++ b/lib/PTEVal.mli
@@ -26,9 +26,12 @@ type t = {
 
 (* Default value for location argument *)
 val default : string -> t
+val set_oa : t -> string -> t
+
 (* Flags have default values *)
 val is_default : t -> bool
 val of_list : string -> (string * string) list -> t
 val pp : t -> string
 
 val compare : t -> t -> int
+val eq : t -> t -> bool

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
-(ocamllex AArch64Lexer ARMLexer BellLexer CLexer lexHint lexOutMapping lexRename lexSplit lexUtils MIPSLexer modelLexer PPCLexer RISCVLexer runTypeUtils scopeLexer splitter stateLexer X86Lexer X86_64Lexer echo dirtyBit)
+(ocamllex AArch64Lexer ARMLexer BellLexer CLexer lexHint lexOutMapping lexRename lexSplit lexUtils MIPSLexer modelLexer PPCLexer RISCVLexer runTypeUtils scopeLexer splitter stateLexer X86Lexer X86_64Lexer echo dirtyBit lexScan)
 
 
 (menhir (modules PPCParser) (flags  --fixed-exception))

--- a/lib/lexScan.mli
+++ b/lib/lexScan.mli
@@ -15,4 +15,6 @@
 (****************************************************************************)
 
 (** Miscellaneous lexers *)
+
 val is_num : string -> bool
+val info : string -> (string * string) option

--- a/lib/lexScan.mli
+++ b/lib/lexScan.mli
@@ -1,0 +1,18 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Miscellaneous lexers *)
+val is_num : string -> bool

--- a/lib/lexScan.mll
+++ b/lib/lexScan.mll
@@ -1,0 +1,35 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Miscellaneous lexers *)
+
+{
+
+}
+
+let digit = ['0'-'9']
+let num = ['1'-'9']digit*
+let hexa_digit = (digit|['a'-'f''A'-'F'])
+let hexa_num = ("0x"|"0X")hexa_digit+
+let space = [' ''\t']
+
+rule main = parse
+| space* (num|hexa_num) space* eof { true }
+| ""  { false }
+
+{
+let is_num s = main (Lexing.from_string s)
+}

--- a/lib/lexScan.mll
+++ b/lib/lexScan.mll
@@ -24,12 +24,20 @@ let digit = ['0'-'9']
 let num = ['1'-'9']digit*
 let hexa_digit = (digit|['a'-'f''A'-'F'])
 let hexa_num = ("0x"|"0X")hexa_digit+
-let space = [' ''\t']
+let alpha = [ 'a'-'z' 'A'-'Z']
+let blank = [' ' '\t' '\r']
+let not_blank = [^' ''\t''\r']
+let name  = alpha (alpha|digit|'_' | '/' | '.' | '-')*
 
-rule main = parse
-| space* (num|hexa_num) space* eof { true }
+rule num_rule = parse
+| blank* (num|hexa_num) blank* eof { true }
 | ""  { false }
 
+and info_rule = parse
+| (name as key) blank* '=' blank* (_* as value) blank* eof
+  { let p = key,value in Some p }
+| "" { None }
 {
-let is_num s = main (Lexing.from_string s)
+let is_num s = num_rule (Lexing.from_string s)
+let info s = info_rule (Lexing.from_string s)
 }


### PR DESCRIPTION
The ability to generate kvm tests is activated by variant `-variant kvm`.

Support is primitive, new annotations are added for reading `pte_<var>` in place of `<var>`  (Pte) and for writing (PteAF, PteDB etc., see `diyone7 -arch AArch64 -variant kvm -show annotations`).

Example, MP on Pte, changing AF bit
```
% diyone7 -arch AArch64 -variant kvm FencedWW PteAF Rfe Pte PosRR FenceddRR Fre
AArch64 A
"DMB.SYdWWPPteAF RfePteAFPte PosRRPteP DMB.SYdRR Fre"
Variant=precise
Generator=diyone7 (version 7.56+02~dev)
Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
Com=Rf Fr
Orig=DMB.SYdWWPPteAF RfePteAFPte PosRRPteP DMB.SYdRR Fre
{
pteval_t 1:X0;

0:X1=x; 0:X2=pte_y; 0:X3=(oa:phy_y, af:0, db:1, dbm:0, valid:1);
1:X1=pte_y; 1:X3=y; 1:X5=x;
}
 P0          | P1          ;
 MOV W0,#1   | LDR X0,[X1] ;
 STR W0,[X1] | LDR W2,[X3] ;
 DMB SY      | DMB SY      ;
 STR X3,[X2] | LDR W4,[X5] ;
locations [fault (P0,x); fault (P1,y); fault (P1,x);]
exists (1:X0=(oa:phy_y, af:0, db:1, dbm:0, valid:1) /\ 1:X4=0)
```
Notice that faults now appear in the `locations` field. The tools `herd` and `litmus` will evolve accordingly.

Variations:
```
% diycross7 -arch AArch64 -variant kvm FencedWW PteAF,PteDB,PteVA,PteOA Rfe Pte PosRR FencedRR Fre
```