### PR TITLE
[herd]: CMP (shifted register) barrel shifters

### DIFF
--- a/herd/tests/instructions/AArch64/A164.litmus
+++ b/herd/tests/instructions/AArch64/A164.litmus
@@ -1,0 +1,13 @@
+AArch64 A164
+(* CMP shifted register is equivalent to SUBS WZR *)
+(* tests xreg *)
+
+ { 0:X1=1; }
+
+P0;
+  CMP XZR, X1, ASR #1;
+  B.EQ foo;
+  MOV X0, #1;
+  foo: NOP;
+
+forall (0:X1=1 /\ 0:XZR=0 /\ 0:X0=0)

--- a/herd/tests/instructions/AArch64/A164.litmus.expected
+++ b/herd/tests/instructions/AArch64/A164.litmus.expected
@@ -1,0 +1,10 @@
+Test A164 Required
+States 1
+0:XZR=0; 0:X0=0; 0:X1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=1 /\ 0:XZR=0 /\ 0:X0=0)
+Observation A164 Always 1 0
+Hash=3bd310e3e05cadf68e96348fc5afea37
+

--- a/herd/tests/instructions/AArch64/A165.litmus
+++ b/herd/tests/instructions/AArch64/A165.litmus
@@ -1,0 +1,14 @@
+AArch64 A165
+(* CMP shifted register is equivalent to SUBS WZR *)
+(* tests xwreg *)
+
+ { 0:X1=1; }
+
+P0;
+  CMP WZR, W1, ASR #1;
+  B.EQ foo;
+  MOV X0, #1;
+  foo: NOP;
+
+forall (0:X1=1 /\ 0:XZR=0 /\ 0:X0=0)
+

--- a/herd/tests/instructions/AArch64/A165.litmus.expected
+++ b/herd/tests/instructions/AArch64/A165.litmus.expected
@@ -1,0 +1,10 @@
+Test A165 Required
+States 1
+0:XZR=0; 0:X0=0; 0:X1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=1 /\ 0:XZR=0 /\ 0:X0=0)
+Observation A165 Always 1 0
+Hash=e48a8df97eecd5c13e11852310f40a04
+

--- a/herd/tests/instructions/AArch64/A166.litmus
+++ b/herd/tests/instructions/AArch64/A166.litmus
@@ -1,0 +1,13 @@
+AArch64 A166
+(* CMP shifted register is equivalent to SUBS WZR *)
+(* This test is equivalent to to A164 - but uses SUBS*)
+
+ { 0:X1=1; }
+
+P0;
+  SUBS XZR, XZR, X1, ASR #1;
+  B.EQ foo;
+  MOV X0, #1;
+  foo: NOP;
+
+forall (0:X1=1 /\ 0:XZR=0 /\ 0:X0=0)

--- a/herd/tests/instructions/AArch64/A166.litmus.expected
+++ b/herd/tests/instructions/AArch64/A166.litmus.expected
@@ -1,0 +1,10 @@
+Test A166 Required
+States 1
+0:XZR=0; 0:X0=0; 0:X1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=1 /\ 0:XZR=0 /\ 0:X0=0)
+Observation A166 Always 1 0
+Hash=3bd310e3e05cadf68e96348fc5afea37
+

--- a/herd/tests/instructions/AArch64/A167.litmus
+++ b/herd/tests/instructions/AArch64/A167.litmus
@@ -1,0 +1,13 @@
+AArch64 A167
+(* CMP shifted register is equivalent to SUBS WZR *)
+(* This test is equivalent to to A165 - but uses SUBS*)
+
+ { 0:X1=1; }
+
+P0;
+  SUBS WZR, WZR, W1, ASR #1;
+  B.EQ foo;
+  MOV X0, #1;
+  foo: NOP;
+
+forall (0:X1=1 /\ 0:XZR=0 /\ 0:X0=0)

--- a/herd/tests/instructions/AArch64/A167.litmus.expected
+++ b/herd/tests/instructions/AArch64/A167.litmus.expected
@@ -1,0 +1,10 @@
+Test A167 Required
+States 1
+0:XZR=0; 0:X0=0; 0:X1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=1 /\ 0:XZR=0 /\ 0:X0=0)
+Observation A167 Always 1 0
+Hash=e48a8df97eecd5c13e11852310f40a04
+

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1265,8 +1265,8 @@ let do_pp_instruction m =
       sprintf "SXTW %s,%s" (pp_xreg r1) (pp_wreg r2)
   | I_OP3 (v,SUBS,ZR,r,K k, S_NOEXT) ->
       pp_ri "CMP" v r k
-  | I_OP3 (v,SUBS,ZR,r2,RV (v3,r3), S_NOEXT) when v=v3->
-      pp_rr "CMP" v r2 r3
+  | I_OP3 (v,SUBS,ZR,r2,RV (v3,r3), s) when v=v3->
+      pp_rr "CMP" v r2 r3 ^ (pp_barrel_shift "," s m.pp_k)
   | I_OP3 (v,ANDS,ZR,r,(K _ as kr), S_NOEXT) ->
       pp_rkr "TST" v r kr
   | I_OP3 (v,op,r1,r2,K k, S_NOEXT) ->

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -1004,10 +1004,12 @@ instr:
   { A.I_OP3 (A.V128,A.SUBS,$2,$4,A.RV (A.V128,$6), A.S_NOEXT) }
 | OP wreg COMMA wreg COMMA kwr COMMA shift
   { check_op3 $1 $6 ; A.I_OP3 (A.V32,$1,$2,$4,$6,$8) }
-| CMP wreg COMMA kwr
-  { A.I_OP3 (A.V32,A.SUBS,A.ZR,$2,$4, A.S_NOEXT) }
-| CMP xreg COMMA kr
-  { A.I_OP3 (A.V64,A.SUBS,A.ZR,$2,$4, A.S_NOEXT) }
+| CMP wreg COMMA kr_shift
+  { let (reg,shift) = $4 in
+    A.I_OP3 (A.V32,A.SUBS,A.ZR,$2,reg,shift) }
+| CMP xreg COMMA kr_shift
+  { let (reg,shift) = $4 in
+    A.I_OP3 (A.V64,A.SUBS,A.ZR,$2,reg,shift) }
 | TST wreg COMMA k
   { A.I_OP3 (A.V32,A.ANDS,A.ZR,$2,A.K $4, A.S_NOEXT) }
 | TST xreg COMMA k

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1027,18 +1027,20 @@ module Make(V:Constant.S)(C:Config) =
           inputs = [r;]; reg_env=[r,quad;];}
     | V128 -> assert false
 
-    let cmp v r1 r2 = match v with
+    let cmp v r1 r2 s = match v with
     | V32 ->
         let r1,fm1,r2,fm2 = args2 "wzr" (fun s -> "^wi"^s) r1 r2 in
+        let shift = Misc.lowercase (pp_barrel_shift "," s pp_imm) in
         let rs = r1 @ r2 in
         { empty_ins with
-          memo = sprintf "cmp %s,%s" fm1 fm2;
+          memo = sprintf "cmp %s,%s%s" fm1 fm2 shift;
           inputs = rs; reg_env=List.map (fun r -> r,word) rs; }
     | V64 ->
         let r1,fm1,r2,fm2 = args2 "xzr" (fun s -> "^i"^s) r1 r2 in
+        let shift = Misc.lowercase (pp_barrel_shift "," s pp_imm) in
         let rs = r1 @ r2 in
         { empty_ins with
-          memo = sprintf "cmp %s,%s" fm1 fm2;
+          memo = sprintf "cmp %s,%s%s" fm1 fm2 shift;
           inputs = rs; reg_env=List.map (fun r -> r,quad) rs; }
     | V128 -> assert false
 
@@ -1233,7 +1235,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_RBIT (v,rd,rs) -> rbit v rd rs::k
     | I_SXTW (r1,r2) -> sxtw r1 r2::k
     | I_OP3 (v,SUBS,ZR,r,K i, S_NOEXT) ->  cmpk v r i::k
-    | I_OP3 (v,SUBS,ZR,r2,RV (v3,r3), S_NOEXT) when v=v3->  cmp v r2 r3::k
+    | I_OP3 (v,SUBS,ZR,r2,RV (v3,r3), s) when v=v3->  cmp v r2 r3 s::k
     | I_OP3 (v,ANDS,ZR,r,K i, S_NOEXT) -> tst v r i::k
     | I_OP3 (V64,_,_,_,RV(V32,_),S_NOEXT) ->
         Warn.fatal "Instruction %s is illegal (extension required)"


### PR DESCRIPTION
Consider the following AArch64 instruction:
```
CMP WZR, w1, asr #1;
CMP XZR, x1, asr #1;
```
which arithmetic shifts right the value in w1/x1 by 1 before
comparing with xzr/wzr. This is equivalent to:
```
SUBS XZR, WZR, w1, asr #1;
SUBS XZR, XZR, x1, asr #1;
```
This patch adds:
- barrel shifters to the CMP command
- tests for CMP with barrel shifters
- tests for the equivalent SUBS instructions

tested with:
- pre-commit tests - all pass
- make test - all pass
- make version - all pass/no warnings