### PR TITLE
Extend fault support.

### DIFF
--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -59,7 +59,7 @@ module type S = sig
   type proc_info = Test_herd.proc_info
   type test =
       (program, nice_prog, start_points,
-       state, A.size_env, prop, location, A.LocSet.t) Test_herd.t
+       state, A.size_env, prop, location, A.LocSet.t, A.FaultAtomSet.t) Test_herd.t
 
 (* Get list of locations observed in outcomes *)
   type loc_set = A.LocSet.t
@@ -217,7 +217,7 @@ module Make(C:Config) (A:Arch_herd.S) (Act:Action.S with module A = A)
   type proc_info = Test_herd.proc_info
     type test =
       (program, nice_prog, start_points,
-       state, A.size_env, prop, location, A.LocSet.t) Test_herd.t
+       state, A.size_env, prop, location, A.LocSet.t,A.FaultAtomSet.t) Test_herd.t
 
 (* List of relevant location *)
     type loc_set = A.LocSet.t

--- a/herd/test_herd.ml
+++ b/herd/test_herd.ml
@@ -109,7 +109,7 @@ module Make(A:Arch_herd.S) =
          } = t in
 
       let prog,starts = Load.load nice_prog in
-      let flocs = List.map fst locs in
+      let flocs = LocationsItem.fold_locs Misc.cons locs [] in
       let displayed =
         let flocs = A.LocSet.of_list flocs in
         ConstrGen.fold_constr collect_atom final flocs in

--- a/herd/test_herd.mli
+++ b/herd/test_herd.mli
@@ -17,7 +17,7 @@
 (** Litmus tests *)
 type proc_info = (string * int list) list
 
-type ('prog,'nice_prog,'start,'state, 'size_env, 'prop, 'loc, 'locset) t =
+type ('prog,'nice_prog,'start,'state, 'size_env, 'prop, 'loc, 'locset, 'fset) t =
     {
      arch : Archs.t ;
      name : Name.t ;
@@ -28,7 +28,7 @@ type ('prog,'nice_prog,'start,'state, 'size_env, 'prop, 'loc, 'locset) t =
      init_state : 'state ; size_env : 'size_env ;
      filter : 'prop option ;
      cond : 'prop ConstrGen.constr ;
-     flocs : 'loc list ;
+     flocs : 'loc list ; ffaults : 'fset;
      observed : 'locset ;
      displayed : 'locset ;
      extra_data : MiscParser.extra_data ;
@@ -37,13 +37,13 @@ type ('prog,'nice_prog,'start,'state, 'size_env, 'prop, 'loc, 'locset) t =
    }
 
 val simple_name :
-    ('prog,'nice_prog,'start,'state,'size_env,'prop,'loc,'locset) t -> string
+    ('prog,'nice_prog,'start,'state,'size_env,'prop,'loc,'locset,'fset) t -> string
 val readable_name :
-    ('prog,'nice_prog,'start,'state,'size_env,'prop,'loc,'locset) t -> string
+    ('prog,'nice_prog,'start,'state,'size_env,'prop,'loc,'locset,'fset) t -> string
 val very_readable_name :
-    ('prog,'nice_prog,'start,'state,'size_env,'prop,'loc,'locset) t -> string
+    ('prog,'nice_prog,'start,'state,'size_env,'prop,'loc,'locset,'fset) t -> string
 val basename :
-    ('prog,'nice_prog,'start,'state,'size_env,'prop,'loc,'locset) t -> string
+    ('prog,'nice_prog,'start,'state,'size_env,'prop,'loc,'locset,'fset) t -> string
 
 
 module Make(A:Arch_herd.S) : sig
@@ -56,7 +56,8 @@ module Make(A:Arch_herd.S) : sig
        A.size_env,
        A.prop,
        A.location,
-       A.LocSet.t
+       A.LocSet.t,
+       A.FaultAtomSet.t
       ) t
 
   val build : Name.t -> A.pseudo MiscParser.t -> result

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -224,12 +224,6 @@ module Make(O:Config)(M:XXXMem.S) =
       and loads = S.E.mem_loads_of es.S.E.events in
       S.E.EventSet.subset loads obs
 
-    let collect_atom_fault a r =
-      let open ConstrGen in
-      match a with
-      | (LV _|LL _) -> r
-      | FF f -> f::r
-
 (* Called by model simulator in case of success *)
     let model_kont loop ochan test do_restrict cstr =
 
@@ -359,12 +353,10 @@ module Make(O:Config)(M:XXXMem.S) =
 
       let restrict_faults =
         if memtag || kvm then
-          let faults_in_cond =
-            ConstrGen.fold_constr collect_atom_fault cstr [] in
           A.FaultSet.filter
             (fun flt ->
-              List.exists
-                (fun f -> A.check_one_fatom flt f) faults_in_cond)
+              A.FaultAtomSet.exists
+                (fun f -> A.check_one_fatom flt f) test.Test_herd.ffaults)
         else fun _ -> A.FaultSet.empty in
 
       let final_state_restrict_locs dlocs senv fsc =

--- a/jingle/arch.ml
+++ b/jingle/arch.ml
@@ -27,7 +27,7 @@ module type Dumper = sig
     val dump_info :
       out_channel -> Name.t ->
       (MiscParser.state, (MiscParser.proc * pseudo list) list,
-       MiscParser.prop, MiscParser.location)
+       MiscParser.prop, MiscParser.location,MiscParser.maybev)
         MiscParser.result
       -> unit
 end
@@ -376,10 +376,13 @@ module DefaultDumper(A:ArchBase.S) = struct
       (struct
         module A = A
 
+        type v = ParsedConstant.v
+        let dump_v = ParsedConstant.pp_v
+
         let dump_loc = MiscParser.dump_location
 
         let dump_state_atom a =
-          MiscParser.dump_state_atom dump_loc ParsedConstant.pp_v a
+          MiscParser.dump_state_atom dump_loc dump_v a
 
         type state = MiscParser.state
 
@@ -395,7 +398,7 @@ module DefaultDumper(A:ArchBase.S) = struct
         let dump_atom a =
           let open ConstrGen in
           match a with
-          | LV (loc,v) -> dump_state_atom (loc,(MiscParser.TyDef,v))
+          | LV (loc,v) -> dump_state_atom (loc,(TestType.TyDef,v))
           | LL (loc1,loc2) ->
               sprintf "%s=%s" (dump_loc loc1) (MiscParser.dump_rval loc2)
           | FF f ->

--- a/jingle/cDumper.ml
+++ b/jingle/cDumper.ml
@@ -35,7 +35,7 @@ type constr = MiscParser.constr
 let dump_atom a =
   let open ConstrGen in
   match a with
-  | LV (loc,v) -> dump_state_atom (loc,(MiscParser.TyDef,v))
+  | LV (loc,v) -> dump_state_atom (loc,(TestType.TyDef,v))
   | LL (loc1,loc2) ->
      sprintf "%s=%s" (dump_loc loc1) (MiscParser.dump_rval loc2)
   | FF f -> Fault.pp_fatom ParsedConstant.pp_v f
@@ -171,8 +171,9 @@ let do_dump withinfo chan doc t =
     end ;
   fprintf chan "\n{%s}\n\n" (dump_state  t.MiscParser.init) ;
   prog chan (code t.MiscParser.init t.MiscParser.prog) ;
-  let locs = DumpUtils.dump_locations
-	       dump_location t.MiscParser.locations in
+  let locs =
+    DumpUtils.dump_locations
+      dump_location ParsedConstant.pp_v t.MiscParser.locations in
   if locs <> "" then fprintf chan "%s\n" locs ;
   begin match t.MiscParser.extra_data with
 	| MiscParser.NoExtra|MiscParser.CExtra _ -> ()

--- a/jingle/mapping.ml
+++ b/jingle/mapping.ml
@@ -243,7 +243,7 @@ module Make(C:Config) = struct
       acc@
       (List.map (fun (sa,tr) ->
         (Location_reg(i,Target.pp_reg tr),
-         (TyDef,ParsedConstant.nameToV sa)))
+         (TestType.TyDef,ParsedConstant.nameToV sa)))
          b.Env.addr)
                    ) []
 
@@ -304,7 +304,7 @@ module Make(C:Config) = struct
     let condition = ConstrGen.map_constr map_lv_ll src.condition
     and filter = Misc.app_opt (ConstrGen.map_prop map_lv_ll) src.filter in
     let locations =
-      List.map (fun (loc,ty) -> conv_loc map loc,ty) src.locations in
+      LocationsItem.map_locs (fun loc -> conv_loc map loc) src.locations in
     { info = (OutMapping.key,dump_map map)::src.info;
       init = init;
       prog = prog;

--- a/lib/CGenParser_lib.ml
+++ b/lib/CGenParser_lib.ml
@@ -131,7 +131,7 @@ let check_atom procs a =
 
 let check_regs procs init locs final =
   List.iter (fun (loc,_) -> check_loc procs  loc) init ;
-  List.iter (fun (loc,_) -> check_loc procs  loc) locs ;
+  List.iter (LocationsItem.iter_loc (check_loc procs)) locs ;
   ConstrGen.fold_constr (fun a () -> check_atom procs a) final ()
 
 
@@ -197,7 +197,7 @@ module Do
 			 List.fold_left
 			   (fun env param ->
 			    let loc = param.param_name in
-			    let ty = MiscParser.TyDef in
+			    let ty = TestType.TyDef in
 			    (MiscParser.Location_reg (p,loc),
 			     (ty,ParsedConstant.nameToV loc))::env)
 			   env t.params)
@@ -240,8 +240,9 @@ module Do
 		      chan constr_loc SL.token StateParser.constraints in
     check_regs procs init locs final ;
     let all_locs =
-      MiscParser.LocSet.union
-        (MiscParser.LocSet.of_list (List.map fst locs))
+      let open MiscParser in
+      LocSet.union
+        (LocationsItem.fold_locs LocSet.add locs LocSet.empty)
         (get_locs final) in
     let parsed =
       {

--- a/lib/dumpUtils.ml
+++ b/lib/dumpUtils.ml
@@ -18,15 +18,22 @@ open Printf
 open MiscParser
 
 
-let dump_locations dump_location env = match env with
+let dump_locations dump_location dump_v env = match env with
 | [] -> ""
 | _::_ ->
-    let dump_loc_type (loc,t) = match t with
+    let open TestType in
+    let dump_loc_type loc t = match t with
     | TyDef -> dump_location loc ^";"
     | TyDefPointer -> dump_location loc ^"*;"
     | Ty t -> sprintf "%s %s;" (dump_location loc) t
     | Pointer t -> sprintf "%s %s*;" (dump_location loc) t
-    | TyArray _|Atomic _ -> assert false (* No arrays nor atomics here *) in
-    let pp = List.map dump_loc_type env in
+    | TyArray _|Atomic _ -> assert false (* No arrays nor atomics here *)
+    and dump_fault f = sprintf "%s;" (Fault.pp_fatom dump_v f) in
+    let dump_item i =
+      let open LocationsItem in
+      match i with
+      | Loc (loc,t) -> dump_loc_type loc t
+      | Fault f -> dump_fault f in
+    let pp = List.map dump_item env in
     let pp = String.concat " " pp in
     sprintf "locations [%s]" pp

--- a/lib/dumpUtils.mli
+++ b/lib/dumpUtils.mli
@@ -15,4 +15,4 @@
 (****************************************************************************)
 
 val dump_locations :
- ('loc -> string) -> ('loc * MiscParser.run_type) list -> string
+ ('loc -> string) -> ('v -> string) -> ('loc ,'v) LocationsItem.t list -> string

--- a/lib/fault.ml
+++ b/lib/fault.ml
@@ -44,6 +44,8 @@ let atom_compare compare ((p1,lbl1),v1) ((p2,lbl2),v2) = match Proc.compare p1 p
     end
 | r -> r
 
+let map_value f (p,v) = (p,f v)
+
 module type S = sig
   type loc_global
   type fault = (Proc.t * Label.Set.t) * loc_global * string option

--- a/lib/fault.mli
+++ b/lib/fault.mli
@@ -45,6 +45,8 @@ module type S = sig
   val check_one_fatom : fault -> fatom -> bool
   val check_fatom : FaultSet.t -> fatom -> bool
 
+  module FaultAtomSet : MySet.S with type elt = fatom
+
 end
 
 module Make : functor (A:I) -> S with type loc_global := A.arch_global

--- a/lib/genParser.ml
+++ b/lib/genParser.ml
@@ -126,8 +126,8 @@ let check_atom procs a =
 
  let check_regs procs init locs final =
    let procs = List.map fst procs in
-   List.iter (fun (loc,_) -> check_loc procs  loc) init ;
-   List.iter (fun (loc,_) -> check_loc procs  loc) locs ;
+   List.iter (fun (loc,_) -> check_loc procs loc) init ;
+   List.iter (LocationsItem.iter_loc (check_loc procs)) locs ;
    ConstrGen.fold_constr (fun a () -> check_atom procs a) final ()
 
 (*******************)
@@ -158,6 +158,7 @@ let check_atom procs a =
 (***********)
 
 (* Extract locations from condition *)
+
 let get_locs_atom a =
   let open ConstrGen in
   let open MiscParser in
@@ -213,8 +214,9 @@ let get_locs c = ConstrGen.fold_constr get_locs_atom c MiscParser.LocSet.empty
           chan constr_loc SL.token StateParser.constraints in
       check_regs procs init locs final ;
       let all_locs =
-        MiscParser.LocSet.union
-          (MiscParser.LocSet.of_list (List.map fst locs))
+        let open MiscParser in
+        LocSet.union
+          (LocationsItem.fold_locs LocSet.add locs LocSet.empty)
           (get_locs final) in
       let parsed =
         {

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -20,6 +20,8 @@ type t = string
 
 let pp = Misc.identity
 
+let compare = String.compare
+
 let lab_count = ref 0
 
 let reset () = lab_count := 0

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -19,6 +19,7 @@
 type t = string
 
 val pp : t -> string
+val compare : t -> t -> int
 val reset : unit -> unit
 val next_label : string -> t
 

--- a/lib/locationsItem.ml
+++ b/lib/locationsItem.ml
@@ -29,3 +29,10 @@ let map_loc f i = match i with
 | Loc (loc,t) -> Loc (f loc,t)
 | Fault _ as j -> j
 let map_locs f = List.map (map_loc f)
+
+let locs_and_faults locs =
+  List.fold_right
+    (fun i (ls,fs) -> match i with
+    | Loc (loc,_) -> loc::ls,fs
+    | Fault f -> ls,f::fs)
+    locs ([],[])

--- a/lib/locationsItem.ml
+++ b/lib/locationsItem.ml
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2019-present Institut National de Recherche en Informatique et *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,37 +14,18 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** External view of faults, which are part of final state *)
+type ('loc,'v) t = Loc of 'loc * TestType.t | Fault of 'v Fault.atom
 
+let fold_loc f i r = match i with
+| Loc (loc,_) -> f loc r
+| Fault _-> r
 
-module type I = sig
-  type arch_global
-  val pp_global : arch_global -> string
-  val global_compare : arch_global -> arch_global -> int
-  val same_base : arch_global -> arch_global -> bool
-end
+let fold_locs f is r = List.fold_right (fold_loc f) is r
 
-type 'loc atom =  (Proc.t * Label.t option) * 'loc
+let iter_loc f locs = fold_loc (fun i () -> f i) locs ()
+let iter_locs f = List.iter (iter_loc f)
 
-val pp_fatom : ('loc -> string) -> 'loc atom -> string
-
-val atom_compare : ('loc -> 'loc -> int) -> 'loc atom -> 'loc atom -> int
-
-val map_value : ('v -> 'w) -> 'v atom -> 'w atom
-
-module type S = sig
-
-  type loc_global
-
-  type fault = (Proc.t * Label.Set.t) * loc_global * string option
-  val pp_fault : fault -> string
-
-  module FaultSet : MySet.S with type elt = fault
-
-  type fatom = loc_global atom
-  val check_one_fatom : fault -> fatom -> bool
-  val check_fatom : FaultSet.t -> fatom -> bool
-
-end
-
-module Make : functor (A:I) -> S with type loc_global := A.arch_global
+let map_loc f i = match i with
+| Loc (loc,t) -> Loc (f loc,t)
+| Fault _ as j -> j
+let map_locs f = List.map (map_loc f)

--- a/lib/locationsItem.mli
+++ b/lib/locationsItem.mli
@@ -24,3 +24,5 @@ val iter_locs : ('loc -> unit) -> ('loc,'v) t list -> unit
 
 val map_loc : ('loc -> 'a) -> ('loc,'v) t -> ('a,'v) t
 val map_locs : ('loc -> 'a) -> ('loc,'v) t list -> ('a,'v) t list
+
+val locs_and_faults : ('loc, 'v) t list -> ('loc list * 'v Fault.atom list)

--- a/lib/locationsItem.mli
+++ b/lib/locationsItem.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2019-present Institut National de Recherche en Informatique et *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,37 +14,13 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** External view of faults, which are part of final state *)
+type ('loc,'v) t = Loc of 'loc * TestType.t | Fault of 'v Fault.atom
 
+val fold_loc : ('loc -> 'r -> 'r) -> ('loc,'v) t -> 'r -> 'r
+val fold_locs : ('loc -> 'r -> 'r) -> ('loc,'v) t list -> 'r -> 'r
 
-module type I = sig
-  type arch_global
-  val pp_global : arch_global -> string
-  val global_compare : arch_global -> arch_global -> int
-  val same_base : arch_global -> arch_global -> bool
-end
+val iter_loc : ('loc -> unit) -> ('loc,'v) t -> unit
+val iter_locs : ('loc -> unit) -> ('loc,'v) t list -> unit
 
-type 'loc atom =  (Proc.t * Label.t option) * 'loc
-
-val pp_fatom : ('loc -> string) -> 'loc atom -> string
-
-val atom_compare : ('loc -> 'loc -> int) -> 'loc atom -> 'loc atom -> int
-
-val map_value : ('v -> 'w) -> 'v atom -> 'w atom
-
-module type S = sig
-
-  type loc_global
-
-  type fault = (Proc.t * Label.Set.t) * loc_global * string option
-  val pp_fault : fault -> string
-
-  module FaultSet : MySet.S with type elt = fault
-
-  type fatom = loc_global atom
-  val check_one_fatom : fault -> fatom -> bool
-  val check_fatom : FaultSet.t -> fatom -> bool
-
-end
-
-module Make : functor (A:I) -> S with type loc_global := A.arch_global
+val map_loc : ('loc -> 'a) -> ('loc,'v) t -> ('a,'v) t
+val map_locs : ('loc -> 'a) -> ('loc,'v) t list -> ('a,'v) t list

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -749,22 +749,29 @@ let tr_atag s =
     Some (Filename.chop_suffix s ".atag")
   else None
 
+let is_prefix prf =
+  let prf_len = String.length prf in
+  fun s ->
+    let len = String.length s in
+    len > prf_len && string_eq prf (String.sub s 0 prf_len )
+
 let do_tr prf =
   let prf_len = String.length prf in
     (*Printf.printf "prf: %s\n" prf;*)
   fun s ->
     let len = String.length s in
-        (*Printf.printf "s: %s\n" s;*)
-    if len > prf_len && String.sub s 0 prf_len = prf then
+    (*Printf.printf "s: %s\n" s;*)
+    if is_prefix prf s then
       let news = (String.sub s prf_len (len-prf_len)) in
-          (*Printf.printf "news: %s\n" news;*)
+      (*Printf.printf "news: %s\n" news;*)
       Some news 
     else 
-        (*Printf.printf "notnews: %s\n" s;*)
+      (*Printf.printf "notnews: %s\n" s;*)
       None
 
 let add_pte = sprintf "pte_%s"
 let tr_pte = do_tr "pte_"
+let is_pte = is_prefix "pte_"
 
 let add_tlb = sprintf "tlb_%s"
 

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -269,6 +269,7 @@ val tr_atag : string -> string option
 
 val add_pte : string -> string
 val tr_pte : string ->  string option
+val is_pte : string -> bool
 val add_tlb : string -> string
 val add_af : string -> string
 val tr_af : string ->  string option

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -53,20 +53,12 @@ type outcome = atom list
 val pp_atom : atom -> string
 val pp_outcome : outcome -> string
 
-type run_type =
-  | TyDef | TyDefPointer
-  | Ty of string | Pointer of string
-  | TyArray of string * int
-  | Atomic of string
-
-val pp_run_type : run_type -> string
-
-type state = (location * (run_type * maybev)) list
+type state = (location * (TestType.t * maybev)) list
 
 val check_env_for_dups : state -> unit
 
 val dump_state_atom :
-  ('loc -> string) -> ('v -> string) -> ('loc * (run_type * 'v)) -> string
+  ('loc -> string) -> ('v -> string) -> ('loc * (TestType.t * 'v)) -> string
 
 (* Packed result *)
 type info = (string * string) list
@@ -80,31 +72,31 @@ type extra_data =
 
 val empty_extra : extra_data
 
-type ('i, 'p, 'prop, 'loc) result =
+type ('i, 'p, 'prop, 'loc, 'v) result =
     { info : info ;
       init : 'i ;
       prog : 'p ;
       filter : 'prop option ;
       condition : 'prop ConstrGen.constr ;
-      locations : ('loc * run_type) list ;
+      locations : ('loc,'v) LocationsItem.t list ;
       extra_data : extra_data ;
     }
 
 (* Easier to handle *)
 type ('loc,'v,'ins) r3 =
-       (('loc * (run_type * 'v)) list,
+       (('loc * (TestType.t * 'v)) list,
        (proc * 'ins list) list,
        ('loc, 'v) ConstrGen.prop,
-       'loc) result
+       'loc,'v) result
 
 type ('loc,'v,'code) r4 =
-      (('loc * (run_type * 'v)) list,
+      (('loc * (TestType.t * 'v)) list,
        'code list,
        ('loc, 'v) ConstrGen.prop,
-       'loc) result
+       'loc,'v) result
 
 (* Result of generic parsing *)
-type 'pseudo t = (state, (proc * 'pseudo list) list, prop, location) result
+type 'pseudo t = (state, (proc * 'pseudo list) list, prop, location,maybev) result
 
 (* Add empty extra info to machine parsers *)
 val mach2generic :
@@ -119,14 +111,14 @@ val tthm_key : string
 val variant_key : string
 
 (* Extract hash *)
-val get_hash : ('i, 'p, 'c, 'loc) result -> string option
+val get_hash : ('i, 'p, 'c, 'loc, 'v) result -> string option
 val set_hash :
-    ('i, 'p, 'c, 'loc) result -> string ->
-      ('i, 'p, 'c, 'loc) result
+    ('i, 'p, 'c, 'loc, 'v) result -> string ->
+      ('i, 'p, 'c, 'loc, 'v) result
 
 (* Extract meta information from key *)
 val get_info_on_info : string -> (string * string) list -> string option
 
-val get_info :  ('i, 'p, 'c, 'loc) result -> string -> string option
+val get_info :  ('i, 'p, 'c, 'loc, 'v) result -> string -> string option
 
 val mk_pte_val : location -> (string * string) list -> 'b Constant.t

--- a/lib/simpleDumper.ml
+++ b/lib/simpleDumper.ml
@@ -13,11 +13,13 @@
 (* license as circulated by CEA, CNRS and INRIA at the following URL        *)
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
-
 (** Parsable dump *)
 
 module type I = sig
   module A : ArchBase.S
+
+  type v
+  val dump_v : v -> string
 
   type state
   val dump_state : state -> string
@@ -43,17 +45,17 @@ end
 module Make(Out:Out)(I:I) : sig
   val dump : Out.t ->
     Name.t ->
-    (I.state, (MiscParser.proc * I.A.pseudo list) list, I.prop, I.location)
+    (I.state, (MiscParser.proc * I.A.pseudo list) list, I.prop, I.location,I.v)
         MiscParser.result
       -> unit
   val dump_info : Out.t ->
     Name.t ->
-    (I.state, (MiscParser.proc * I.A.pseudo list) list, I.prop, I.location)
+    (I.state, (MiscParser.proc * I.A.pseudo list) list, I.prop, I.location,I.v)
         MiscParser.result
       -> unit
   val lines :
       Name.t ->
-        (I.state, (MiscParser.proc * I.A.pseudo list) list, I.prop, I.location)
+        (I.state, (MiscParser.proc * I.A.pseudo list) list, I.prop, I.location,I.v)
           MiscParser.result
       -> string list
 end = struct
@@ -98,7 +100,7 @@ end = struct
     Out.fprintf chan "\n{%s}\n\n" (dump_state  t.init) ;
     prog chan t.prog ;
     Out.fprintf chan "\n" ;
-    let locs = DumpUtils.dump_locations I.dump_location t.locations in
+    let locs = DumpUtils.dump_locations I.dump_location I.dump_v t.locations in
     if locs <> "" then Out.fprintf chan "%s\n" locs ;
     begin match t.filter with
     | None -> ()
@@ -137,7 +139,7 @@ end = struct
       match t.locations with
       | [] -> k
       | locs ->
-          DumpUtils.dump_locations I.dump_location locs::k
+          DumpUtils.dump_locations I.dump_location I.dump_v locs::k
     end @@
     [I.dump_constr t.condition]
 end

--- a/lib/symbReg.ml
+++ b/lib/symbReg.ml
@@ -79,8 +79,14 @@ and type pseudo = A.pseudo
 
   let finish_state f_reg = List.map (finish_state_atom f_reg)
 
+  let finish_location_item f_reg =
+    let open LocationsItem in
+    function
+    | Loc (loc,t) -> Loc (f_reg loc,t)
+    | Fault v -> Fault (Fault.map_value A.maybevToV v)
+
   let finish_locations f_reg =
-    List.map (fun (loc,t) -> finish_location f_reg loc,t)
+    List.map (finish_location_item (finish_location f_reg))
 
   let finish_atom f_reg a =
     let open ConstrGen in
@@ -162,7 +168,7 @@ and type pseudo = A.pseudo
 
   let collect_constr = ConstrGen.fold_constr collect_atom
 
-  let collect_locs = List.fold_right (fun (loc,_) -> collect_location loc)
+  let collect_locs locs = LocationsItem.fold_locs collect_location locs 
 
 (*********************************************)
 (* Here we go: collect, allocate, substitute *)

--- a/lib/testHash.ml
+++ b/lib/testHash.ml
@@ -41,6 +41,7 @@ open Printf
 
 let digest_init debug init =
   let open MiscParser in
+  let open TestType in
   let init =
     List.sort
       (fun (loc1,(t1,v1)) (loc2,(t2,v2)) ->

--- a/lib/testType.ml
+++ b/lib/testType.ml
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2019-present Institut National de Recherche en Informatique et *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,37 +14,20 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** External view of faults, which are part of final state *)
+(** Type as specified in tests *)
 
+open Printf
 
-module type I = sig
-  type arch_global
-  val pp_global : arch_global -> string
-  val global_compare : arch_global -> arch_global -> int
-  val same_base : arch_global -> arch_global -> bool
-end
+type t =
+  | TyDef | TyDefPointer
+  | Ty of string | Pointer of string
+  | TyArray of string * int
+  | Atomic of string
 
-type 'loc atom =  (Proc.t * Label.t option) * 'loc
-
-val pp_fatom : ('loc -> string) -> 'loc atom -> string
-
-val atom_compare : ('loc -> 'loc -> int) -> 'loc atom -> 'loc atom -> int
-
-val map_value : ('v -> 'w) -> 'v atom -> 'w atom
-
-module type S = sig
-
-  type loc_global
-
-  type fault = (Proc.t * Label.Set.t) * loc_global * string option
-  val pp_fault : fault -> string
-
-  module FaultSet : MySet.S with type elt = fault
-
-  type fatom = loc_global atom
-  val check_one_fatom : fault -> fatom -> bool
-  val check_fatom : FaultSet.t -> fatom -> bool
-
-end
-
-module Make : functor (A:I) -> S with type loc_global := A.arch_global
+let pp = function
+  | TyDef -> "TyDef"
+  | TyDefPointer -> "TyDefPointer"
+  | Ty s -> sprintf "Ty<%s>" s
+  | Atomic s -> sprintf "Atomic<%s>" s
+  | Pointer s -> sprintf "Pointer<%s>" s
+  | TyArray (s,sz) -> sprintf "TyArray<%s,%i>" s sz

--- a/lib/testType.mli
+++ b/lib/testType.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2019-present Institut National de Recherche en Informatique et *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,37 +14,12 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** External view of faults, which are part of final state *)
+(** Type as specified in tests *)
 
+type t =
+  | TyDef | TyDefPointer
+  | Ty of string | Pointer of string
+  | TyArray of string * int
+  | Atomic of string
 
-module type I = sig
-  type arch_global
-  val pp_global : arch_global -> string
-  val global_compare : arch_global -> arch_global -> int
-  val same_base : arch_global -> arch_global -> bool
-end
-
-type 'loc atom =  (Proc.t * Label.t option) * 'loc
-
-val pp_fatom : ('loc -> string) -> 'loc atom -> string
-
-val atom_compare : ('loc -> 'loc -> int) -> 'loc atom -> 'loc atom -> int
-
-val map_value : ('v -> 'w) -> 'v atom -> 'w atom
-
-module type S = sig
-
-  type loc_global
-
-  type fault = (Proc.t * Label.Set.t) * loc_global * string option
-  val pp_fault : fault -> string
-
-  module FaultSet : MySet.S with type elt = fault
-
-  type fatom = loc_global atom
-  val check_one_fatom : fault -> fatom -> bool
-  val check_fatom : FaultSet.t -> fatom -> bool
-
-end
-
-module Make : functor (A:I) -> S with type loc_global := A.arch_global
+val pp : t -> string

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -472,7 +472,7 @@ module Make(V:Constant.S)(C:Config) =
 
     let sxtw r1 r2 =
       { empty_ins with
-        memo = "sxtw ^o0,^wi1";
+        memo = "sxtw ^o0,^wi0";
         inputs = [r2;]; outputs=[r1;]; reg_env=[r1,quad; r2,word];}
 
     let cmpk v r k = match v with

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -60,7 +60,7 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
          (fun (loc,v) -> Printf.sprintf "<%s -> %s>" (pp_location loc) (V.pp_v v))
          st)
 
-  type fullstate = (location * (MiscParser.run_type * V.v)) list
+  type fullstate = (location * (TestType.t * V.v)) list
 
   module Out = struct
     module V = V

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -49,6 +49,7 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
 
   include Location.Make(Internal)
 
+  let is_pte_loc _ = false
   let parse_reg x = Some x
   let reg_compare = Internal.reg_compare
 

--- a/litmus/CCompile_litmus.ml
+++ b/litmus/CCompile_litmus.ml
@@ -177,7 +177,7 @@ module Make
           (fun env (s,ty) -> A.LocMap.add (A.Location_global (G.Addr s)) ty env)
           env globals in
       let observed = Generic.all_observed final filter locs in
-      let flocs,ffaults = Compile.locs_and_faults locs in
+      let flocs,ffaults = LocationsItem.locs_and_faults locs in
       { T.init = initenv;
         info = info;
         code = comp_code observed env code;

--- a/litmus/CCompile_litmus.ml
+++ b/litmus/CCompile_litmus.ml
@@ -177,12 +177,13 @@ module Make
           (fun env (s,ty) -> A.LocMap.add (A.Location_global (G.Addr s)) ty env)
           env globals in
       let observed = Generic.all_observed final filter locs in
+      let flocs,ffaults = Compile.locs_and_faults locs in
       { T.init = initenv;
         info = info;
         code = comp_code observed env code;
         condition = final; filter;
         globals = globals;
-        flocs = List.map fst locs;
+        flocs; ffaults;
         global_code = get_global_code code;
         src = t;
         type_env = env,StringMap.empty;

--- a/litmus/archExtra_litmus.ml
+++ b/litmus/archExtra_litmus.ml
@@ -61,7 +61,7 @@ module type S = sig
 
   val debug_state : state -> string
 
-  type fullstate = (location * (MiscParser.run_type * I.V.v)) list
+  type fullstate = (location * (TestType.t * I.V.v)) list
 
   val find_in_state : location -> state -> I.V.v
 
@@ -155,7 +155,7 @@ module Make(O:Config)(I:I) : S with module I = I
          (fun (loc,v) -> Printf.sprintf "<%s -> %s>" (pp_location loc) (I.V.pp_v v))
          st)
 
-  type fullstate = (location * (MiscParser.run_type * I.V.v)) list
+  type fullstate = (location * (TestType.t * I.V.v)) list
 
   let rec find_in_state loc = function
     | [] -> I.V.zero

--- a/litmus/archExtra_litmus.ml
+++ b/litmus/archExtra_litmus.ml
@@ -43,6 +43,7 @@ module type S = sig
   include Location.S
   with type loc_reg = I.arch_reg and type loc_global = Global_litmus.t
   val location_of_addr : string -> location
+  val is_pte_loc : location -> bool
   val tr_global : MiscParser.maybev -> Global_litmus.t
 
   module Out : Template.S with
@@ -105,6 +106,10 @@ module Make(O:Config)(I:I) : S with module I = I
       end)
 
   let location_of_addr a = Location_global (Global_litmus.Addr a)
+
+  let is_pte_loc = function
+    | Location_global (Global_litmus.Pte _) -> true
+    | _ -> false
 
   let tr_global (c:ParsedConstant.v) = 
     let open Constant in

--- a/litmus/arch_litmus.mli
+++ b/litmus/arch_litmus.mli
@@ -32,9 +32,13 @@ module type Base = sig
   module RegMap : MyMap.S with type key = reg
 
   include Location.S
+
   with type loc_reg = reg and
   type loc_global = Global_litmus.t
+
+  val is_pte_loc : location -> bool
   val location_of_addr : string -> location
+
 
   val parse_reg : string -> reg option
   val reg_compare : reg -> reg -> int

--- a/litmus/arch_litmus.mli
+++ b/litmus/arch_litmus.mli
@@ -43,7 +43,7 @@ module type Base = sig
 
   val debug_state : state -> string
 
-  type fullstate = (location * (MiscParser.run_type * V.v)) list
+  type fullstate = (location * (TestType.t * V.v)) list
 
   module Out : Target.S
   with type arch_reg = reg (* Out abstracted *)
@@ -73,7 +73,7 @@ module type K = sig
   type loc_global = string
 
   type state = (location * V.v) list
-  type fullstate = (location * (MiscParser.run_type * V.v)) list
+  type fullstate = (location * (TestType.t * V.v)) list
 
   module Out : Target.S
   with type arch_reg = reg (* Out abstracted *)

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -39,14 +39,6 @@ let get_fmt hexa base = match CType.get_fmt hexa base with
 let base =  CType.Base "int"
 let pointer = CType.Pointer base
 
-let locs_and_faults locs =
-  let open LocationsItem in
-  List.fold_right
-    (fun i (ls,fs) -> match i with
-          | Loc (loc,_) -> loc::ls,fs
-          | Fault f -> ls,f::fs)
-    locs ([],[])
-
 module Generic (A : Arch_litmus.Base)
     (C:Constr.S
     with type location = A.location and module LocSet = A.LocSet) = struct
@@ -694,7 +686,7 @@ type P.code = MiscParser.proc * A.pseudo list)
         | NoExtra|CExtra _ -> None
         | BellExtra i -> Some i in
       let code_typed = type_outs ty_env1 code in
-      let flocs,ffaults = locs_and_faults locs in
+      let flocs,ffaults = LocationsItem.locs_and_faults locs in
         { T.init = initenv ;
           info = info;
           code = code_typed;

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -59,7 +59,8 @@ module Generic (A : Arch_litmus.Base)
         | Constant.Tag _ -> tag
         | Constant.PteVal _ -> pteval_t
 
-      let misc_to_c  = function
+      let misc_to_c loc = function
+        | TestType.TyDef when A.is_pte_loc loc -> pteval_t
         | TestType.TyDef -> base
         | TestType.TyDefPointer  -> pointer
         | TestType.Ty t -> Base t
@@ -166,7 +167,7 @@ module Generic (A : Arch_litmus.Base)
                 ignore (A.LocMap.find loc env) ; env
               with
               | Not_found ->
-                  A.LocMap.add loc (misc_to_c t) env
+                  A.LocMap.add loc (misc_to_c loc t) env
               end
           | Fault _ -> env)
           env flocs
@@ -184,7 +185,7 @@ module Generic (A : Arch_litmus.Base)
               with Not_found ->
                 A.LocMap.add loc (typeof v) env
               end
-          | _ -> A.LocMap.add loc (misc_to_c t) env)
+          | _ -> A.LocMap.add loc (misc_to_c loc t) env)
           env init
 
       let type_init_values init env =
@@ -206,7 +207,7 @@ module Generic (A : Arch_litmus.Base)
                     Warn.user_error
                       "variable %s should be of pointer type"
                       (A.pp_location loc) in
-                A.LocMap.add a (misc_to_c tv) env
+                A.LocMap.add a (misc_to_c a tv) env
               end
           | _,_ -> env)
           env init

--- a/litmus/simpleDumper_prime.ml
+++ b/litmus/simpleDumper_prime.ml
@@ -22,6 +22,9 @@ module type I = sig
 
   module P : PseudoAbstract.S
 
+  type v
+  val dump_v : v -> string
+
   type state
   val dump_state :state -> string
 
@@ -36,43 +39,44 @@ end
 module Make(I:I) : sig
   val dump : out_channel ->
     Name.t ->
-    (I.state, I.P.code list, I.prop, I.location)
+    (I.state, I.P.code list, I.prop, I.location,I.v)
         MiscParser.result
       -> unit
   val dump_info : out_channel ->
     Name.t ->
-    (I.state, I.P.code list, I.prop, I.location)
+    (I.state, I.P.code list, I.prop, I.location,I.v)
         MiscParser.result
       -> unit
   val lines :
       Name.t ->
-        (I.state, I.P.code list, I.prop, I.location)
+        (I.state, I.P.code list, I.prop, I.location,I.v)
           MiscParser.result
       -> string list
 end = struct
   open Printf
   open I
 
-(*
-    let prog chan prog =
-    let pp = List.map I.P.dump_prog prog in
-    Misc.pp_prog chan pp
-*)
-(*
-    dump_procs chan prog ;
-    iter_prog (dump_ios chan)
-      (List.map snd prog)
-*)
   open MiscParser
 
-  let dump_loc_type (loc,t) = match t with
-  | TyDef -> I.dump_location loc ^";"
-  | TyDefPointer -> I.dump_location loc ^"*;"
-  | Ty t -> sprintf "%s %s;" (I.dump_location loc) t
-  | Pointer t -> sprintf "%s %s*;" (I.dump_location loc) t
-  | TyArray _|Atomic _ -> assert false (* No arrays nor atomics in locations *)
-  let dump_locations env =
-    let pp = List.map dump_loc_type env in
+  let dump_loc_type loc t =
+    let open TestType in
+    match t with
+    | TyDef -> I.dump_location loc ^";"
+    | TyDefPointer -> I.dump_location loc ^"*;"
+    | Ty t -> sprintf "%s %s;" (I.dump_location loc) t
+    | Pointer t -> sprintf "%s %s*;" (I.dump_location loc) t
+    | TyArray _|Atomic _ -> assert false (* No arrays nor atomics in locations *)
+
+  let dump_fault f = sprintf "%s;" (Fault.pp_fatom I.dump_v f)
+
+  let dump_locations_item =
+    let open LocationsItem in
+    function
+      | Loc (loc,t) -> dump_loc_type loc t
+      | Fault f -> dump_fault f
+
+  let dump_locations locs =
+    let pp = List.map dump_locations_item locs in
     String.concat " " pp
 
   let do_dump withinfo chan doc t =

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -365,7 +365,10 @@ module Make
         let locs = get_displayed_locs test in
         A.LocSet.exists (fun loc ->is_ptr_pte loc env) locs
 
-      let get_faults test = T.C.get_faults test.T.condition
+      let get_faults test =        
+        let inc = T.C.get_faults test.T.condition
+        and inf = test.T.ffaults in
+        inc@inf
 
       let find_label_offset p lbl test =
         try

--- a/litmus/testDump.ml
+++ b/litmus/testDump.ml
@@ -28,12 +28,12 @@ end
 
 module Make(I:I) : sig
   type code =  I.P.code list
-  type test =  (I.A.fullstate, code, I.C.prop, I.A.location)  MiscParser.result
+  type test =  (I.A.fullstate, code, I.C.prop, I.A.location, I.A.V.v)  MiscParser.result
   val dump : out_channel -> Name.t -> test -> unit
   val lines : Name.t -> test -> string list
 end = struct
   type code =  I.P.code list
-  type test =  (I.A.fullstate, code, I.C.prop, I.A.location)  MiscParser.result
+  type test =  (I.A.fullstate, code, I.C.prop, I.A.location, I.A.V.v)  MiscParser.result
   include SimpleDumper_prime.Make
       (struct
         open Printf
@@ -42,10 +42,11 @@ end = struct
 
         module P = I.P
 
-        let dump_init_val = A.V.pp I.hexa
+        type v = A.V.v
+        let dump_v = A.V.pp I.hexa
 
         let dump_state_atom =
-          MiscParser.dump_state_atom A.pp_location dump_init_val
+          MiscParser.dump_state_atom A.pp_location dump_v
 
         type state = A.fullstate
 
@@ -58,7 +59,7 @@ end = struct
         type prop = I.C.prop
 
         let dump_atom a =
-          ConstrGen.dump_atom A.pp_location A.pp_rval (A.V.pp I.hexa) a
+          ConstrGen.dump_atom A.pp_location A.pp_rval dump_v a
 
         let dump_prop = ConstrGen.prop_to_string dump_atom
         let dump_constr = ConstrGen.constraints_to_string dump_atom

--- a/litmus/test_litmus.ml
+++ b/litmus/test_litmus.ml
@@ -26,8 +26,8 @@ module type S = sig
   module P : PseudoAbstract.S
 
   type src =
-    ((A.location * (MiscParser.run_type * A.V.v)) list, P.code list,
-          C.prop, A.location)
+    ((A.location * (TestType.t * A.V.v)) list, P.code list,
+          C.prop, A.location, A.V.v)
          MiscParser.result
 
   type 'a type_env = ('a * CType.t) list
@@ -40,7 +40,7 @@ module type S = sig
       condition : C.cond ;
       filter : C.prop option ;
       globals : string type_env ;
-      flocs : A.location list ;
+      flocs : A.location list ; ffaults : A.V.v Fault.atom list;
       global_code : string list;
       src : src ;
       type_env : CType.t A.LocMap.t * CType.t StringMap.t ;
@@ -74,8 +74,8 @@ struct
 
   type 'a type_env = ('a * CType.t) list
   type src =
-    ((A.location * (MiscParser.run_type * A.V.v)) list, P.code list,
-          C.prop, A.location)
+    ((A.location * (TestType.t * A.V.v)) list, P.code list,
+          C.prop, A.location,A.V.v)
          MiscParser.result
 
   type env_volatile = string list
@@ -87,7 +87,7 @@ struct
       condition : C.cond ;
       filter : C.prop option ;
       globals : string type_env ; (* Virtual addresses only *)
-      flocs : A.location list ;
+      flocs : A.location list ; ffaults : A.V.v Fault.atom list;
       global_code : string list;
       src : src ;
       type_env : CType.t A.LocMap.t * CType.t StringMap.t ;

--- a/tools/CDumper.ml
+++ b/tools/CDumper.ml
@@ -87,7 +87,7 @@ end = struct
           t.prog pss
     | _ -> ()
     end ;
-    let locs = DumpUtils.dump_locations dump_loc t.locations in
+    let locs = DumpUtils.dump_locations dump_loc ParsedConstant.pp_v t.locations in
     if locs <> "" then Out.fprintf chan "%s\n" locs ;
     begin match t.filter with
     | None -> ()

--- a/tools/HashedFault.ml
+++ b/tools/HashedFault.ml
@@ -15,12 +15,12 @@
 (****************************************************************************)
 
 module S = struct
-  type t = int * HashedString.t * HashedString.t
+  type t = int * HashedStringOpt.t * HashedString.t
 
   let equal (p1,a1,b1) (p2,a2,b2) =  p1 == p2 && a1 == a2 && b1 == b2
 
   let hash (p,a,b) =
-    let ah =  HashedString.as_hash a
+    let ah =  HashedStringOpt.as_hash a
     and bh = HashedString.as_hash b in
     abs (Misc.mix (0x4F1BBCDC+ah) (0x4F1BBCDC+bh) (0x4F1BBCDC+p))
 end
@@ -32,11 +32,11 @@ let table = create 101
 let as_tt h = h.Hashcons.node
 
 let as_hashed ((p,lab),x) =
-  hashcons table (p,HashedString.as_hashed lab,HashedString.as_hashed x)
+  hashcons table (p,HashedStringOpt.as_hashed lab,HashedString.as_hashed x)
 
 let as_t h =
   let p,hlab,hx = h.Hashcons.node in
-  ((p,HashedString.as_t hlab),HashedString.as_t hx)
+  ((p,HashedStringOpt.as_t hlab),HashedString.as_t hx)
 
 let as_hash h = h.Hashcons.hkey
     
@@ -44,7 +44,7 @@ let compare h1 h2 =
   let p1,lab1,x1 = as_tt h1
   and p2,lab2,x2 = as_tt h2 in
   match Misc.int_compare p1 p2 with
-  | 0 -> begin  match HashedString.compare lab1 lab2 with
+  | 0 -> begin  match HashedStringOpt.compare lab1 lab2 with
     | 0 -> HashedString.compare x1 x2
     | r -> r
   end

--- a/tools/HashedFault.mli
+++ b/tools/HashedFault.mli
@@ -14,7 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-include (Hashcons.S with type key = Proc.t * HashedString.t * HashedString.t)
+include (Hashcons.S with type key = Proc.t * HashedStringOpt.t * HashedString.t)
 
 open Hashcons
 

--- a/tools/HashedStringOpt.ml
+++ b/tools/HashedStringOpt.ml
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2013-present Institut National de Recherche en Informatique et *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -15,14 +15,21 @@
 (****************************************************************************)
 
 module S = struct
-  type t = string
-  let equal s1 s2 = Misc.string_eq s1 s2
-  let hash = Hashtbl.hash
+  type t = string option
+  let equal s1 s2 = match s1,s2 with
+  | Some s1,Some s2 -> Misc.string_eq s1 s2
+  | None,None -> true
+  | (Some _,None)|(None,Some _)
+      -> false
+
+  let hash = function
+    | None -> 0
+    | Some s -> Hashtbl.hash s
 end
 
 module H = Hashcons.Make(S)
 
-type t = string Hashcons.hash_consed
+type t = string option Hashcons.hash_consed
 
 let table = H.create 101
 
@@ -32,4 +39,4 @@ let as_t h = h.Hashcons.node
 
 let as_hash h = h.Hashcons.hkey
 
-let compare s1 s2 = String.compare (as_t s1) (as_t s2)
+let compare s1 s2 = Misc.opt_compare String.compare (as_t s1) (as_t s2)

--- a/tools/HashedStringOpt.mli
+++ b/tools/HashedStringOpt.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2013-present Institut National de Recherche en Informatique et *)
+(* Copyright 2020-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,22 +14,12 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-module S = struct
-  type t = string
-  let equal s1 s2 = Misc.string_eq s1 s2
-  let hash = Hashtbl.hash
-end
+type t
 
-module H = Hashcons.Make(S)
+val as_hashed  : string option -> t
 
-type t = string Hashcons.hash_consed
+val as_t : t -> string option
 
-let table = H.create 101
+val as_hash : t -> int
 
-let as_hashed s = H.hashcons table s
-
-let as_t h = h.Hashcons.node
-
-let as_hash h = h.Hashcons.hkey
-
-let compare s1 s2 = String.compare (as_t s1) (as_t s2)
+val compare : t -> t -> int

--- a/tools/collectRegs.ml
+++ b/tools/collectRegs.ml
@@ -57,7 +57,7 @@ module Make(A:Arch_tools.S) = struct
 
   let collect_constr = ConstrGen.fold_constr collect_atom
 
-  let collect_locs = List.fold_right (fun (loc,_) -> collect_location loc)
+  let collect_locs = LocationsItem.fold_locs collect_location
 
   open MiscParser
 

--- a/tools/dumper.ml
+++ b/tools/dumper.ml
@@ -22,11 +22,14 @@ module Make(A:Arch_tools.S) = struct
       (struct
         module A = A
 
-        type atom = (A.location * (MiscParser.run_type * A.v))
+        type v = A.v
+        let dump_v = A.pp_v
+
+        type atom = (A.location * (TestType.t * A.v))
         type state = atom list
 
         let dump_atom_state a =
-          MiscParser.dump_state_atom A.pp_location A.pp_v a
+          MiscParser.dump_state_atom A.pp_location dump_v a
 
 
         let dump_state st =

--- a/tools/dumperMiscParser.ml
+++ b/tools/dumperMiscParser.ml
@@ -31,10 +31,13 @@ end = struct
 
         module A = A
 
+        type v = MiscParser.maybev
+        let dump_v = ParsedConstant.pp Opt.hexa
+
         let dump_loc = MiscParser.dump_location
 
         let dump_state_atom a =
-          MiscParser.dump_state_atom dump_loc (ParsedConstant.pp Opt.hexa) a
+          MiscParser.dump_state_atom dump_loc dump_v  a
 
         type state = MiscParser.state
 
@@ -50,7 +53,7 @@ end = struct
         let dump_atom a =
           let open ConstrGen in
           match a with
-          | LV (loc,v) -> dump_state_atom (loc,(MiscParser.TyDef,v))
+          | LV (loc,v) -> dump_state_atom (loc,(TestType.TyDef,v))
           | LL (loc1,loc2) ->
               sprintf "%s=%s" (dump_loc loc1) (MiscParser.dump_rval loc2)
           | FF f ->

--- a/tools/fault_tools.ml
+++ b/tools/fault_tools.ml
@@ -14,12 +14,13 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type t = ((Proc.t * string) * string)
+type t = ((Proc.t * string option) * string)
 
 let equal ((p1,lab1),x1) ((p2,lab2),x2) =
   Proc.equal p1 p2 &&
-  Misc.string_eq lab1 lab2 &&
+  Misc.opt_eq Misc.string_eq lab1 lab2 &&
   Misc.string_eq x1 x2
 
-let pp ((p,lab),v) = Printf.sprintf "fault(%s:%s,%s)" (Proc.pp p) lab v
-
+let pp ((p,lab),v) =
+  Printf.sprintf "fault(%s%s,%s)"
+    (Proc.pp p) (match lab with None -> "" | Some lab -> ":"^lab) v

--- a/tools/fault_tools.mli
+++ b/tools/fault_tools.mli
@@ -14,7 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type t = (Proc.t * string) * string
+type t = (Proc.t * string option) * string
 
 val equal : t -> t -> bool
 

--- a/tools/lexLog_tools.mll
+++ b/tools/lexLog_tools.mll
@@ -195,7 +195,7 @@ and pline bds fs = parse
      let v = to_xxx v in  (* Translate to decimal *)
      let p = poolize loc v in
      pline (p::bds) fs lexbuf }
-| blank* fault blank* '(' blank* ('P'? (num as proc)) ':' (label as lbl) blank* ','
+| blank* fault blank* '(' blank* ('P'? (num as proc)) (':' (label as lbl))? blank* ','
     (loc as loc) blank* ')' blank* ';'
     {
      let f = (to_proc proc,lbl),loc in

--- a/tools/logConstr.ml
+++ b/tools/logConstr.ml
@@ -89,7 +89,7 @@ let parse_observed s =
     let locs,c = StateParser.main_loc_constr SL.token lxb in
     Some
       (LocSet.union
-         (LocSet.of_list (List.map fst locs))
+         (LocationsItem.fold_locs LocSet.add locs LocSet.empty)
          (get_locs c))
   with
   | Parsing.Parse_error
@@ -108,7 +108,10 @@ let parse_locs s =
   try
     let lxb = Lexing.from_string s in
     let locs,cstr = StateParser.main_loc_constr SL.token lxb in
-    Some (LocSet.union (LocSet.of_list (List.map fst locs)) (get_locs cstr))
+    Some
+      (LocSet.union
+         (LocationsItem.fold_locs LocSet.add locs LocSet.empty)
+         (get_locs cstr))
   with
   | Parsing.Parse_error
   | LexMisc.Error _ -> None

--- a/tools/logState.ml
+++ b/tools/logState.ml
@@ -416,7 +416,8 @@ module LC =
         let (p0,lbl0),v0 = f in
         let eq_label = match lbl0 with
         | None -> fun _ -> true
-        | Some lbl0 -> Misc.string_eq lbl0 in
+        | Some lbl0 ->
+            Misc.app_opt_def true (Misc.string_eq lbl0) in
         let sym0 = V.pp_v v0 in
         let rec find fs = match fs.Hashcons.node with
           | Nil -> false

--- a/tools/mixMerge.ml
+++ b/tools/mixMerge.ml
@@ -152,7 +152,12 @@ end =
 
     let shift_state k = List.map (shift_state_atom k)
 
-    let shift_locations = shift_state
+    let shift_locations k =
+      let open LocationsItem in
+      List.map
+        (function
+          | Loc (l,v) -> Loc (shift_location k l,v)
+          | Fault ((i,lbls),x) -> Fault ((i+k,lbls),x))
 
     let shift_atom k a = match a with
     | LV (l,v) ->  LV (shift_location k l,v)

--- a/tools/mixPerm.ml
+++ b/tools/mixPerm.ml
@@ -28,7 +28,7 @@ end =
 
     let perm_state p = List.map (perm_state_atom p)
 
-    let perm_locations p = perm_state p
+    let perm_locations p = LocationsItem.map_locs (perm_location p)
 
     let perm_atom p a = match a with
     | LV (loc,v) -> LV (perm_location p loc,v)

--- a/tools/mprog.ml
+++ b/tools/mprog.ml
@@ -49,11 +49,13 @@ module Top
             module A = A
             type prog =  (MiscParser.proc * A.pseudo list) list
 
+            type v = ParsedConstant.v
+            let dump_v = ParsedConstant.pp_v
+
             let dump_loc = MiscParser.dump_location
             let dump_reg r = r
 
-            let dump_state_atom dump_loc a =
-              MiscParser.dump_state_atom dump_loc ParsedConstant.pp_v a
+            let dump_state_atom dump_loc a = MiscParser.dump_state_atom dump_loc dump_v a
 
             type state = MiscParser.state
 
@@ -93,7 +95,7 @@ module Top
                           MiscParser.location_compare loc loc0 = 0)
                         global_st
                     then k
-                    else (loc,(MiscParser.TyDef,ParsedConstant.intToV 0))::k)
+                    else (loc,(TestType.TyDef,ParsedConstant.intToV 0))::k)
                   gs [] in
               let st = global_st @ zeros in
               String.concat " "

--- a/tools/prettyProg.ml
+++ b/tools/prettyProg.ml
@@ -36,7 +36,7 @@ module Make(O:Config)(A:Arch_tools.S) =
          arch : Archs.t ;
          name : Name.t ;
          prog : (MiscParser.proc * A.pseudo list) list ;
-         init : (A.location * (MiscParser.run_type * A.v)) list ;
+         init : (A.location * (TestType.t * A.v)) list ;
          constr : (A.location, A.v) ConstrGen.prop ConstrGen.constr ;
        }
 
@@ -231,7 +231,7 @@ module Make(O:Config)(A:Arch_tools.S) =
     let pp_asm_v v = pp_asm (pp_v v)
 
     let pp_initial_state sc =
-      let open MiscParser in
+      let open TestType in
       "\\begin{tabular}[t]{|l|}\n\\hline\n"
       ^ "Initial state\\\\ \\hline \n"
       ^ pp_nice_state sc ""

--- a/tools/recond.ml
+++ b/tools/recond.ml
@@ -80,11 +80,11 @@ module Make(Config:Config)(Out:OutTests.S) =
           "    " in
       ()
 
-    let dump_locs out dump_loc locs = match locs with
+    let dump_locs out dump_loc dump_v locs = match locs with
     | [] -> ()
     | _::_ ->
         Out.fprintf out "%s\n"
-          (DumpUtils.dump_locations dump_loc locs)
+          (DumpUtils.dump_locations dump_loc dump_v locs)
 
     let reparse map =
       if
@@ -184,7 +184,7 @@ module Make(Config:Config)(Out:OutTests.S) =
               if Config.asobserved then begin match cond with
                   | Some (locs,cond) ->
                       dump_filter constr_sec ;
-                      dump_locs out (mk_dump_loc map) locs ;
+                      dump_locs out (mk_dump_loc map) ParsedConstant.pp_v locs ;
                       dump_observed out (mk_dump_loc map) cond ;
               | None -> assert false
               end else if Config.toexists then begin match cond with
@@ -194,7 +194,7 @@ module Make(Config:Config)(Out:OutTests.S) =
                         echo_cond cond_checked
                     | _ ->
                         dump_filter constr_sec ;
-                        dump_locs out (mk_dump_loc map) locs ;
+                        dump_locs out (mk_dump_loc map) ParsedConstant.pp_v locs ;
                         D.dump (Out.chan out) (toexists cond) ;
                         Out.fprintf out "\n"
                   end
@@ -202,7 +202,7 @@ module Make(Config:Config)(Out:OutTests.S) =
               end else begin match cond with
               | Some (locs,cond) ->
                   dump_filter constr_sec ;
-                  dump_locs out (mk_dump_loc map) locs ;
+                  dump_locs out (mk_dump_loc map) ParsedConstant.pp_v locs ;
                   D.dump (Out.chan out) cond ;
                   Out.fprintf out "\n"
               | None -> ()


### PR DESCRIPTION
There are two extensions:
- Faults can now occur in the `locations`  field of litmus tests. As a convenient mean to observe faults with no a priori on their occurrence or absence.
- Comparison tools `mcmp7` and `mcompare7` handle faults with no label, _i.e._ `Fault(<proc>,<var>)`.