### PR TITLE
Kvm diy reloaded

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -414,8 +414,13 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
 
     let emit_obs t = match t with
-    | Code.Ord|Code.Pte -> emit_load_mixed naturalsize 0
+    | Code.Ord-> emit_load_mixed naturalsize 0
+    | Code.Pte->
+        fun st p init loc ->
+        let r,init,cs,st = LDR.emit_load_var A64.V64 st p init (Misc.add_pte loc) in
+        r,init,cs,st
     | Code.Tag -> LDG.emit_load
+
     let emit_obs_not_value = OBS.emit_load_not_value
     let emit_obs_not_eq = OBS.emit_load_not_eq
     let emit_obs_not_zero = OBS.emit_load_not_zero

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -105,7 +105,9 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let lsri64 r1 r2 k = I_OP3 (V64,LSR,r1,r2,K k, S_NOEXT)
     let addi_64 r1 r2 k = I_OP3 (V64,ADD,r1,r2,K k, S_NOEXT)
     let add v r1 r2 r3 = I_OP3 (v,ADD,r1,r2,RV (v,r3), S_NOEXT)
-    let do_add64 v r1 r2 r3 = I_OP3 (V64,ADD,r1,r2,RV (v,r3), S_NOEXT)
+    let do_add64 v r1 r2 r3 =
+      let ext = match v with | A64.V32 -> S_SXTW | A64.V64 -> S_NOEXT in
+      I_OP3 (V64,ADD,r1,r2,RV (v,r3), ext)
 
     let ldr_mixed r1 r2 sz o =
       let open MachSize in
@@ -122,7 +124,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let ldxr r1 r2 = I_LDAR (vloc,XX,r1,r2)
     let ldaxr r1 r2 = I_LDAR (vloc,AX,r1,r2)
     let sxtw r1 r2 = I_SXTW (r1,r2)
-    let do_ldr_idx v r1 r2 idx = I_LDR (v,r1,r2,RV (vloc,idx))
+    let do_ldr_idx v1 v2 r1 r2 idx = I_LDR (v1,r1,r2,RV (v2,idx))
 
 
     let ldr_mixed_idx v r1 r2 idx sz  =
@@ -224,9 +226,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let stop op a rS rN =  I_STOP (op,vloc,a,rS,rN)
 
 (* Compute address in tempo1 *)
-    let _sxtw r k = match vloc with
-    | V64 -> k
-    | V32 -> sxtw r r::k
 
     let do_sum_addr v st rA idx =
       let r,st = tempo1 st in
@@ -283,7 +282,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       type sz
       val sz0 : sz
       val load : sz -> A.st -> reg -> reg -> instruction list * A.st
-      val load_idx : sz -> A.st -> reg -> reg -> reg -> instruction list * A.st
+      val load_idx : sz -> sz -> A.st -> reg -> reg -> reg -> instruction list * A.st
     end
 
     let emit_load_mixed sz o st p init x =
@@ -294,11 +293,14 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     module LOAD(L:L) =
       struct
 
-        let emit_load_var vr st p init x =
+        let emit_load_var_reg vr st init rB =
           let rA,st = next_reg st in
-          let rB,init,st = U.next_init st p init x in
           let ld,st = L.load vr st rA rB in
           rA,init,lift_code ld,st
+
+        let emit_load_var vr st p init x =
+          let rB,init,st = U.next_init st p init x in
+          emit_load_var_reg vr st init rB
 
         let emit_load =  emit_load_var L.sz0
 
@@ -360,12 +362,13 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let emit_load_not_value st p init x v =
           emit_load_not st p init x (fun r -> cmpi r v)
 
-        let emit_load_idx st p init x idx =
+        let emit_load_idx_var v1 v2  st p init x idx =
           let rA,st = next_reg st in
           let rB,init,st = U.next_init st p init x in
-          let ins,st = L.load_idx L.sz0 st rA rB idx in
+          let ins,st = L.load_idx v1 v2 st rA rB idx in
           rA,init,pseudo ins ,st
 
+        let emit_load_idx = emit_load_idx_var L.sz0 L.sz0
       end
 
     let wrap_st emit st r1 r2 =
@@ -378,7 +381,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           type sz = A64.variant
           let sz0 = vloc
           let load vr = wrap_st (do_ldr vr)
-          let load_idx vr st rA rB idx = [do_ldr_idx vr rA rB idx],st
+          let load_idx v1 v2 st rA rB idx = [do_ldr_idx v1 v2 rA rB idx],st
         end)
 
     module LDG = struct
@@ -401,8 +404,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           type sz = MachSize.sz
           let sz0 = naturalsize
           let load vr st rA rB = [ldr_mixed rA rB vr 0],st
-          let load_idx vr st rA rB idx =
-            [ldr_mixed_idx vloc rA rB idx vr],st
+          let load_idx v1 _v2 st rA rB idx =
+            [ldr_mixed_idx vloc rA rB idx v1],st
         end)
 
 (* For export *)
@@ -417,14 +420,15 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let emit_obs_not_eq = OBS.emit_load_not_eq
     let emit_obs_not_zero = OBS.emit_load_not_zero
 
+
     module LDAR = LOAD
         (struct
           type sz = A64.variant
           let sz0 = vloc
           let load vr = wrap_st (do_ldar vr)
-          let load_idx vr st rA rB idx =
-            let r,ins,st = sum_addr st rB idx in
-            ins@[do_ldar vr rA r],st
+          let load_idx v1 v2 st rA rB idx =
+            let r,ins,st = do_sum_addr v2 st rB idx in
+            ins@[do_ldar v1 rA r],st
         end)
 
     module LDAPR = LOAD
@@ -432,9 +436,9 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           type sz = A64.variant
           let sz0 = vloc
           let load vr = wrap_st (do_ldapr vr)
-          let load_idx vr st rA rB idx =
-            let r,ins,st = sum_addr st rB idx in
-            ins@[do_ldapr vr rA r],st
+          let load_idx v1 v2 st rA rB idx =
+            let r,ins,st = do_sum_addr v2 st rB idx in
+            ins@[do_ldapr v1 rA r],st
         end)
 
 
@@ -745,9 +749,23 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let rR,cs2,st = do_emit_sta_mixed sz o rw st p init rW rA in
       rR,init,csi@pseudo cs1@cs2,st
 
+    let do_emit_set_pteval rel st p init v rA =
+      let rB,init,st = U.emit_pteval st p init v in
+      let do_str = if rel then do_stlr else do_str in
+      init,pseudo [do_str A64.V64 rB rA],st
+
     let emit_set_pteval rel st p init v loc =
       let rA,init,st = U.next_init st p init loc in
-      let rB,init,st = U.emit_pteval st p init v in
+      do_emit_set_pteval rel st p init v rA
+
+    let emit_set_pteval_idx rel vdep idx st p init v loc =
+      let rA,init,st = U.next_init st p init loc in
+      let rA,cs1,st = do_sum_addr vdep st rA idx in
+      let init,cs2,st = do_emit_set_pteval rel st p init v rA in
+      init,pseudo cs1@cs2,st
+
+    let emit_set_pteval_reg rel st p init rB loc =
+      let rA,init,st = U.next_init st p init loc in
       let do_str = if rel then do_stlr else do_str in
       init,pseudo [do_str A64.V64 rB rA],st
 
@@ -790,7 +808,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
                   type sz = MachSize.sz
                   let sz0 = sz
                   let load sz = ldar_mixed AA sz o
-                  let load_idx sz = ldar_mixed_idx AA sz o
+                  let load_idx sz _ = ldar_mixed_idx AA sz o
                 end) in
             let r,init,cs,st = L.emit_load st p init loc in
             Some r,init,cs,st
@@ -804,7 +822,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
                   type sz = MachSize.sz
                   let sz0 = sz
                   let load sz = ldar_mixed AQ sz o
-                  let load_idx sz = ldar_mixed_idx AQ sz o
+                  let load_idx sz _ = ldar_mixed_idx AQ sz o
                 end) in
             let r,init,cs,st = L.emit_load st p init loc in
             Some r,init,cs,st
@@ -856,14 +874,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | W,Some (Tag,None) ->
             let init,cs,st = STG.emit_store st p init e in
             None,init,cs,st
-        | R,Some (Pte rk,None) ->
+        | R,Some (Pte (Read|ReadAcq|ReadAcqPc as rk),None) ->
             let emit = match rk with
             | Read -> LDR.emit_load_var
             | ReadAcq -> LDAR.emit_load_var
             | ReadAcqPc -> LDAPR.emit_load_var
-            | _ ->
-                Warn.fatal
-                  "Annotation %s on a read" (A64.pp_atom_pte rk) in
+            | _ -> assert false in
             let r,init,cs,st = emit A64.V64 st p init (Misc.add_pte loc) in
             Some r,init,cs,st
         | W,Some (Pte (Set _),None) ->
@@ -874,7 +890,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let init,cs,st =
               emit_set_pteval true st p init e.C.pte (Misc.add_pte loc) in
             None,init,cs,st
-        | _,Some (Pte _,_) -> assert false
+        | d,Some (Pte _,_ as a) ->
+            Warn.fatal
+              "Atom %s does not apply to direction %s"
+              (A.pp_atom a) (Code.pp_dir d)
         | _,Some (Plain,None) -> assert false
         | _,Some (Tag,_) -> assert false
         | J,_ -> emit_joker st init
@@ -956,7 +975,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Rel -> W_L
       | _ ->
           Warn.fatal "Unexpected atom in STOP instruction: %s"
-            (pp_atom_acc a) in
+           (pp_atom_acc a) in
       let rW,init,csi,st = mk_emit_mov sz st p init ew.v in
       let cs,st = match sz with
       | None -> [stop op a rW rA],st
@@ -1031,7 +1050,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       else
         fun dst src -> eor vdep dst src src
 
-
     let emit_access_dep_addr vdep st p init e rd =
       let r2,st = next_reg st in
       let c =  calc0 vdep r2 rd in
@@ -1041,28 +1059,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           let loc = add_tag loc e.tag in
           begin match d,e.atom with
           | R,None ->
-              let module LDR =
-                LOAD
-                  (struct
-                    type sz = A64.variant
-                    let sz0 = vloc
-                    let load vr = wrap_st (do_ldr vr)
-                    let load_idx vr st rA rB idx = [do_ldr_idx vr rA rB idx],st
-                  end) in
-              let r,init,cs,st = LDR.emit_load_idx st p init loc r2 in
+              let r,init,cs,st = LDR.emit_load_idx_var vloc vdep st p init loc r2 in
               Some r,init, Instruction c::cs,st
           | R,Some (Acq,None) ->
-              let module LDAR =
-                LOAD
-                  (struct
-                    type sz = A64.variant
-                    let sz0 = vloc
-                    let load vr = wrap_st (do_ldar vr)
-                    let load_idx vr st rA rB idx =
-                      let r,ins,st = do_sum_addr vdep st rB idx in
-                      ins@[do_ldar vr rA r],st
-                  end) in
-              let r,init,cs,st = LDAR.emit_load_idx st p init loc r2 in
+              let r,init,cs,st = LDAR.emit_load_idx_var vloc vdep st p init loc r2 in
               Some r,init, Instruction c::cs,st
           | R,Some (Acq,Some (sz,o)) ->
               let module L =
@@ -1071,22 +1071,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
                     type sz = MachSize.sz
                     let sz0 = sz
                     let load sz = ldar_mixed AA sz o
-                    let load_idx sz = do_ldar_mixed_idx vdep AA sz o
+                    let load_idx sz _ = do_ldar_mixed_idx vdep AA sz o
                   end) in
               let r,init,cs,st = L.emit_load_idx st p init loc r2 in
               Some r,init,Instruction c::cs,st
           | R,Some (AcqPc,None) ->
-              let module LDAPR =
-                LOAD
-                  (struct
-                    type sz = A64.variant
-                    let sz0 = vloc
-                    let load sz = wrap_st (do_ldapr sz)
-                    let load_idx sz st rA rB idx =
-                      let r,ins,st = do_sum_addr vdep st rB idx in
-                      ins@[do_ldapr sz rA r],st
-                  end) in
-              let r,init,cs,st = LDAPR.emit_load_idx st p init loc r2 in
+              let r,init,cs,st = LDAPR.emit_load_idx_var vloc vdep st p init loc r2 in
               Some r,init, Instruction c::cs,st
           | R,Some (AcqPc,Some (sz,o)) ->
               let module L =
@@ -1095,7 +1085,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
                     type sz = MachSize.sz
                     let sz0 = sz
                     let load sz = ldar_mixed AQ sz o
-                    let load_idx sz = do_ldar_mixed_idx vdep AQ sz o
+                    let load_idx sz _ = do_ldar_mixed_idx vdep AQ sz o
                   end) in
               let r,init,cs,st = L.emit_load_idx st p init loc r2 in
               Some r,init,Instruction c::cs,st
@@ -1163,7 +1153,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
                     type sz = MachSize.sz
                     let sz0 = sz
                     let load sz st r1 r2 = [ldr_mixed r1 r2 sz o],st
-                    let load_idx sz st r1 r2 idx =
+                    let load_idx sz _ st r1 r2 idx =
                       let cs = [ldr_mixed_idx V64 r1 r2 idx sz] in
                       let cs = match o with
                       | 0 -> cs
@@ -1190,12 +1180,30 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | W,Some (Tag, None) ->
               let init,cs,st = STG.emit_store_idx vdep st p init e r2 in
               None,init,Instruction c::cs,st
-          | (W,(Some (Pte (Set _),None)))
-          | (R,(Some (Pte Read,None)))
+          | (W,(Some (Pte (Set _),None))) ->
+              let init,cs,st =
+                emit_set_pteval_idx false vdep r2 st p init e.C.pte (Misc.add_pte loc) in
+              None,init,Instruction c::cs,st
+          | (W,(Some (Pte (SetRel _),None))) ->
+              let init,cs,st =
+                emit_set_pteval_idx true vdep r2 st p init e.C.pte (Misc.add_pte loc) in
+              None,init,Instruction c::cs,st
+          | (R,(Some (Pte (Read|ReadAcq|ReadAcqPc as rk),None)))
             ->
-              Warn.fatal "Not Yet Dep Addr on Pte"
-          | (W|R),Some (Pte _,_) ->
-              assert false
+              let emit = match rk with
+              | Read -> LDR.emit_load_var_reg
+              | ReadAcq -> LDAR.emit_load_var_reg
+              | ReadAcqPc -> LDAPR.emit_load_var_reg
+              | _ -> assert false in
+              let loc = Misc.add_pte loc in
+              let rA,init,st = U.next_init st p init loc in
+              let rA,cs1,st = do_sum_addr vdep st rA r2 in
+              let r,init,cs,st = emit A64.V64 st init rA in
+              Some r,init,Instruction c::pseudo cs1@cs,st
+         | (W|R) as d,Some (Pte _,_ as a) ->
+             Warn.fatal
+               "Annotation %s does not apply to direction %s"
+               (A64.pp_atom a) (Code.pp_dir d)
           | W,Some (Tag,Some _) -> assert false
           | J,_ -> emit_joker st init
           | _,Some (Plain,None) -> assert false
@@ -1206,7 +1214,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let r2,st = next_reg st in
       let c = calc0 vdep r2 rd in
       let rA,init,st = U.next_init st p init loc in
-      let rA,csum,st = sum_addr st rA r2 in
+      let rA,csum,st = do_sum_addr vdep st rA r2 in
       rA,init,pseudo (c::csum),st
 
     let emit_addr_dep = do_emit_addr_dep vloc
@@ -1226,6 +1234,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | None,_ -> Warn.fatal "TODO"
       | Some R,_ -> Warn.fatal "data dependency to load"
       | Some W,Data loc ->
+
           let r2,cs2,init,st =
             let r2,st = next_reg st in
             match e.atom with
@@ -1239,11 +1248,30 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
                   [Instruction (calc0 vdep r2 r1) ;
                    Instruction (add (sz2v sz) r2 r2 rA); ] in
                 r2,csA@cs2,init,st
+            | Some (Pte _,None) ->
+                let rA,init,st = U.emit_pteval st p init e.pte in
+                let cs,st =
+                  match vdep with
+                  | A64.V64 ->
+                      [Instruction (calc0 A64.V64 r2 r1)],st
+                  | A64.V32 ->
+                      let r3,st = tempo1 st in
+                      [Instruction (sxtw r3 r1);
+                       Instruction (calc0 A64.V64 r2 r3);],st in
+                let cs2 = cs@[Instruction (add A64.V64 r2 r2 rA);] in
+                r2,cs2,init,st
             | _ ->
-                let cs2 =
-                  [Instruction (calc0 vdep r2 r1) ;
-                   Instruction (addi r2 r2 e.v); ] in
+                let cs2,st =
+                  match vdep,vloc with
+                  | (V32,V32)|(V64,V64)|(V64,V32) ->
+                      [Instruction (calc0 vdep r2 r1);],st
+                  | (V32,V64) ->
+                      let r3,st = tempo1 st in
+                      [Instruction (calc0 vdep r3 r1);
+                       Instruction (sxtw r2 r3);],st in
+                let cs2 = cs2@[Instruction (addi r2 r2 e.v);] in
                 r2,cs2,init,st in
+
           let loc = add_tag loc e.tag in
           begin match e.atom with
           | None ->
@@ -1288,8 +1316,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | Some (Tag, None) ->
               let init,cs,st = STG.emit_store_reg st p init loc r2 in
               None,init,cs2@cs,st
-          | Some (Pte (Set _|SetRel _),None) ->
-              Warn.fatal "Not Yet Dep Data on Pte"
+          | Some (Pte (Set _),None) ->
+              let init,cs,st = emit_set_pteval_reg false st p init r2 (Misc.add_pte loc) in
+              None,init,cs2@cs,st
+          | Some (Pte (SetRel _),None) ->
+              let init,cs,st = emit_set_pteval_reg true st p init r2 (Misc.add_pte loc) in
+              None,init,cs2@cs,st
           | Some ((Pte _,Some _)|(Pte (Read|ReadAcq|ReadAcqPc),_))
             -> assert false
           | Some (Plain,None) -> assert false

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -31,9 +31,12 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
 (* Add an observation to fenv *)
     val add_final_v :
         Code.proc -> C.A.arch_reg -> IntSet.t -> fenv -> fenv
+    val add_final_pte :
+        Code.proc -> C.A.arch_reg -> PTEVal.t -> fenv -> fenv
     val add_final_loc :
         Code.proc -> C.A.arch_reg -> string -> fenv -> fenv
     val cons_int :   C.A.location -> int -> fenv -> fenv
+    val cons_pteval :   C.A.location -> PTEVal.t -> fenv -> fenv
     val cons_int_set :  (C.A.location * IntSet.t) -> fenv -> fenv
     val add_int_sets : fenv -> (C.A.location * IntSet.t) list -> fenv
     val add_final :
@@ -103,10 +106,14 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
 
     let add_final_v p r v finals = (C.A.of_reg p r,intset2vset v)::finals
 
+    let add_final_pte p r v finals = (C.A.of_reg p r,VSet.singleton (P v))::finals
+
     let add_final_loc p r v finals =
       (C.A.of_reg p r,VSet.singleton (S v))::finals
 
-    let cons_int loc i fs= (loc,VSet.singleton (I i))::fs
+    let cons_int loc i fs = (loc,VSet.singleton (I i))::fs
+
+    let cons_pteval loc p fs = (loc,VSet.singleton (P p))::fs
 
     let cons_int_set (l,is) fs = (l,intset2vset is)::fs
 

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -40,6 +40,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
 (* Misc *)
     val comp_loc_writes : C.C.node -> StringSet.t
     val comp_atoms : C.C.node -> StringSet.t
+    val find_next_pte_write : C.C.node -> C.C.node option
     val check_here : C.C.node -> bool
     val do_poll : C.C.node -> bool
     val fetch_val : C.C.node -> Code.v
@@ -251,16 +252,36 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
         k in
       do_rec n0
 
-(* insert local check *)
+(* Worth inserting local check *)
+    let find_next_pte_write n =
+      let loc = n.C.C.evt.C.C.loc  in
+      try
+        let r =
+          C.C.find_node
+            (fun m ->
+              let e = m.C.C.evt in
+              if Code.loc_eq loc e.C.C.loc then match e.C.C.dir,e.C.C.bank with
+              | Some W,Pte -> true
+              | _,_ -> false
+              else raise Not_found)
+            n.C.C.next in
+        Some r
+      with Not_found -> None
 
     let is_load_init e = e.C.C.dir = Some R && e.C.C.v = 0
 
-    let check_here n = match n.C.C.edge.C.E.edge with
-    | C.E.Ws Ext
-    | C.E.Fr Ext
-    | C.E.Leave (CFr|CWs)
-    | C.E.Back(CFr|CWs)  -> not (is_load_init n.C.C.evt)
-    | _ -> false
+    let check_edge = function
+      | C.E.Ws Ext
+      | C.E.Fr Ext
+      | C.E.Leave (CFr|CWs)
+      | C.E.Back(CFr|CWs)  -> true
+      | _-> false
+
+    let check_here n = match n.C.C.evt.C.C.bank with
+    | Pte ->
+        Misc.is_some (find_next_pte_write n)
+    | Ord|Tag ->
+        check_edge n.C.C.edge.C.E.edge && not (is_load_init n.C.C.evt)
 
 (* Poll for value is possible *)
     let do_poll n =


### PR DESCRIPTION
More KVM related features for generators
- Release (L) and Acquire (both of them, A and Q) combine with PTE writes and reads.
- Address and data dependencies to and from PTE accesses, clarify size issue.
- Observation of chains of PTE writes, either by local observers or by reading final value of PTE.