### PR TITLE
[herd/lib]: Added SP Register to AArch64Base

### DIFF
--- a/herd/tests/instructions/AArch64/A172.litmus
+++ b/herd/tests/instructions/AArch64/A172.litmus
@@ -1,0 +1,9 @@
+AArch64 A172
+(* Tests load immediate, no offset, from stack pointer*)
+{ 0:sp = x; uint64_t x=1; uint64_t 0:X1 = 0; }
+
+P0;
+  ldr X1, [SP];
+
+
+forall (0:X1=1)

--- a/herd/tests/instructions/AArch64/A172.litmus.expected
+++ b/herd/tests/instructions/AArch64/A172.litmus.expected
@@ -1,0 +1,10 @@
+Test A172 Required
+States 1
+0:X1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=1)
+Observation A172 Always 1 0
+Hash=bf9bc25d44c8579a87f8d01aefd1536f
+

--- a/herd/tests/instructions/AArch64/A173.litmus
+++ b/herd/tests/instructions/AArch64/A173.litmus
@@ -1,0 +1,9 @@
+AArch64 A173
+(* Tests Add, from stack pointer*)
+{ uint64_t 0:SP = 1; x=1; uint64_t 0:X2=0; }
+
+P0;
+  add X2, SP, #8;
+
+
+forall (0:X2=9)

--- a/herd/tests/instructions/AArch64/A173.litmus.expected
+++ b/herd/tests/instructions/AArch64/A173.litmus.expected
@@ -1,0 +1,10 @@
+Test A173 Required
+States 1
+0:X2=9;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=9)
+Observation A173 Always 1 0
+Hash=81e30b7672e9d35849025c5af0cb2d71
+

--- a/herd/tests/instructions/AArch64/A174.litmus
+++ b/herd/tests/instructions/AArch64/A174.litmus
@@ -1,0 +1,9 @@
+AArch64 A174
+(* Tests mov immediate, no offset, from stack pointer*)
+{ uint64_t 0:SP = 1; uint64_t 0:X6; }
+
+P0;
+ mov X6, SP;
+
+
+forall (0:X6=1)

--- a/herd/tests/instructions/AArch64/A174.litmus.expected
+++ b/herd/tests/instructions/AArch64/A174.litmus.expected
@@ -1,0 +1,10 @@
+Test A174 Required
+States 1
+0:X6=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X6=1)
+Observation A174 Always 1 0
+Hash=535879c1c8a17cd9288b4bfc126f607f
+

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -64,6 +64,7 @@ type reg =
   | Symbolic_reg of string
   | Internal of int
   | NZP
+  | SP
   | ResAddr
 
 let gprs =
@@ -75,7 +76,7 @@ let gprs =
   R16; R17; R18; R19 ;
   R20; R21; R22; R23 ;
   R24; R25; R26; R27 ;
-  R28; R29; R30 ;
+  R28; R29; R30;
 ]
 
 let vec_regs =
@@ -117,10 +118,10 @@ let xgprs =
  R16,"X16" ; R17,"X17" ; R18,"X18" ; R19,"X19" ;
  R20,"X20" ; R21,"X21" ; R22,"X22" ; R23,"X23" ;
  R24,"X24" ; R25,"X25" ; R26,"X26" ; R27,"X27" ;
- R28,"X28" ; R29,"X29" ; R30,"X30" ;
+ R28,"X28" ; R29,"X29" ; R30,"X30" ; R30, "LR" ;
 ]
 
-let xregs = (ZR,"XZR")::List.map (fun (r,s) -> Ireg r,s) xgprs
+let xregs = (ZR,"XZR")::(SP,"SP")::List.map (fun (r,s) -> Ireg r,s) xgprs
 
 let regs = xregs
 
@@ -1338,7 +1339,7 @@ let fold_regs (f_regs,f_sregs) =
   | Vreg _ -> f_regs reg y_reg,y_sreg
   | SIMDreg _ -> f_regs reg y_reg,y_sreg
   | Symbolic_reg reg ->  y_reg,f_sregs reg y_sreg
-  | Internal _ | NZP | ZR | ResAddr | Tag _ -> y_reg,y_sreg in
+  | Internal _ | NZP | ZR | SP | ResAddr | Tag _ -> y_reg,y_sreg in
 
   let fold_kr kr y = match kr with
   | K _ -> y
@@ -1412,7 +1413,7 @@ let map_regs f_reg f_symb =
   | Vreg _ -> f_reg reg
   | SIMDreg _ -> f_reg reg
   | Symbolic_reg reg -> f_symb reg
-  | Internal _ | ZR | NZP | ResAddr | Tag _-> reg in
+  | Internal _ | ZR | SP | NZP | ResAddr | Tag _-> reg in
 
   let map_kr kr = match kr with
   | K _ -> kr


### PR DESCRIPTION
Following #30

Consider the following code emitted by LLVM:
```
ldr x1, [sp]
add x2, sp, #8
mov x6, sp
```
Each of which use the stack pointer register as an argument.

This patch upstreams support for the stack pointer register in AArch64,
with tests included.