### PR TITLE
Replace stdint with homegrown uint library

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,13 +23,11 @@ Requirements
 - OCaml (version >= 4.05.0)
 - dune
 - menhir (version >= 20180530)
-- stdint library (version >= 0.5.1)
-
 
 We strongly recommend to have this base software installed through the opam
 package manager.
 
-    % opam install dune menhir stdint
+    % opam install dune menhir
 
 Notice: Compilation with ocamlbuild is possible, by setting D=ocb in Makefile.
 For using ocamlbuild, supplementary software ocamlbuild and ocamlfind are required.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ D=dune
 #For building with ocamlbuild set
 #D=ocb
 
-OPAM_DEPS = menhir stdint
+OPAM_DEPS = menhir
 
 ifeq ($(D), dune)
 	DIYCROSS                      = _build/install/default/bin/diycross7

--- a/_tags
+++ b/_tags
@@ -15,8 +15,7 @@ true: -traverse
 true: use_menhir
 <*/*.byte>: debug
 <*/*.cmo>: debug
-<*/*.ml>: package(stdint)
-<*/*.{d.byte,byte,native}>: use_unix,use_str,package(stdint)
+<*/*.{d.byte,byte,native}>: use_unix,use_str
 <*/*/*/*.{d.byte,byte,native}>: use_unix,use_str
 
 <internal/lib>: use_unix

--- a/_tags
+++ b/_tags
@@ -5,6 +5,7 @@
 <internal/lib/tests>: include
 <jingle>: include
 <lib>: include
+<lib/tests>: include
 <litmus>: include
 <tools>: include
 

--- a/defs.sh
+++ b/defs.sh
@@ -9,7 +9,7 @@ NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
 INTERNAL="herd_regression_test.native herd_diycross_regression_test.native"
-TESTS="channel_test.native command_test.native filesystem_test.native test_test.native"
+TESTS="channel_test.native command_test.native filesystem_test.native test_test.native uint_test.native"
 
 mk_exe () {
   D=$1

--- a/lib/CapabilityConstant.ml
+++ b/lib/CapabilityConstant.ml
@@ -15,7 +15,7 @@
 (****************************************************************************)
 
 module CapabilityScalar = struct
-  open Stdint
+  open Uint
   type t = bool * Uint128.t
 
   let zero = false, Uint128.zero

--- a/lib/dune
+++ b/lib/dune
@@ -24,8 +24,7 @@
    (flags  --fixed-exception))
 
 (library
-   (name herdtools)
-   (wrapped false)
-   (modules_without_implementation sign outTests AST CAst Scalar archBase PPMode name value)
-   (libraries stdint)
-)
+ (name herdtools)
+ (wrapped false)
+ (modules_without_implementation sign outTests AST CAst Scalar archBase
+   PPMode name value))

--- a/lib/tests/dune
+++ b/lib/tests/dune
@@ -1,0 +1,4 @@
+(tests
+ (names uint_test)
+ (libraries internal_lib herdtools)
+ (modes native))

--- a/lib/tests/uint_test.ml
+++ b/lib/tests/uint_test.ml
@@ -1,0 +1,247 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2015-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Tests for Uint module. *)
+
+let tests = [
+  (* Tests for Uint64. *)
+
+  "Uint.Uint64.leading_zeros", (fun () ->
+    let open Uint in
+    let tests = [
+      "0b1000000000000000000000000000000000000000000000000000000000000000", 0 ;
+      "0b0010000000000000000000000000000000000000000000000000000000000000", 2 ;
+      "0b0000000100000000000000000000000000000000000000000000000000000000", 7 ;
+      "0b0000000000000000000000000000000000000000000000000000000000000000", 64 ;
+    ] in
+
+    List.iter (fun (bits, expected) ->
+      let got = Uint64.leading_zeros (Uint64.of_string bits) in
+      if got <> expected then
+        Test.fail (Printf.sprintf "%s: expected %i, got %i"
+          bits
+          expected
+          got)
+    ) tests
+  );
+
+  "Uint.Uint64.add", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint64.zero, Uint64.zero, Uint64.zero ;
+      Uint64.zero, Uint64.one, Uint64.one ;
+      Uint64.one, Uint64.zero, Uint64.one ;
+      Uint64.max_int, Uint64.one, Uint64.zero ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint64.add a b in
+      if Uint64.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s %s: expected %s, got %s"
+          (Uint64.to_string a)
+          (Uint64.to_string b)
+          (Uint64.to_string expected)
+          (Uint64.to_string got))
+    ) tests
+  );
+
+  "Uint.Uint64.sub", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint64.zero, Uint64.zero, Uint64.zero ;
+      Uint64.zero, Uint64.one, Uint64.max_int ;
+      Uint64.one, Uint64.zero, Uint64.one ;
+      Uint64.max_int, Uint64.one, Uint64.of_string "0xFFFFFFFFFFFFFFFE" ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint64.sub a b in
+      if Uint64.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s %s: expected %s, got %s"
+          (Uint64.to_string a)
+          (Uint64.to_string b)
+          (Uint64.to_string expected)
+          (Uint64.to_string got))
+    ) tests
+  );
+
+  "Uint.Uint64.mul", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint64.one, Uint64.one, Uint64.one ;
+      Uint64.one, Uint64.zero, Uint64.zero ;
+      Uint64.of_int 123456789, Uint64.of_int 847, Uint64.of_int 104567900283 ;
+      Uint64.of_int 123456789, Uint64.of_int 847, Uint64.of_int 104567900283 ;
+      Uint64.of_int 3, Uint64.of_string "6148914691236517205", Uint64.max_int ;
+      Uint64.of_int 2, Uint64.of_string "9223372036854775807", Uint64.sub Uint64.max_int Uint64.one ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint64.mul a b in
+      if Uint64.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s %s: expected %s, got %s"
+          (Uint64.to_string a)
+          (Uint64.to_string b)
+          (Uint64.to_string expected)
+          (Uint64.to_string got))
+    ) tests
+  );
+
+  "Uint.Uint64.div", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint64.one, Uint64.one, Uint64.one ;
+      Uint64.of_int 123456789, Uint64.of_int 847, Uint64.of_int 145757 ;
+      Uint64.of_int 123456789, Uint64.max_int, Uint64.zero ;
+      Uint64.max_int, Uint64.max_int, Uint64.one ;
+      Uint64.max_int, Uint64.of_int 3, Uint64.of_string "6148914691236517205" ;
+      Uint64.max_int, Uint64.of_int 2, Uint64.of_string "9223372036854775807" ;
+      Uint64.of_int 0x123456789ABCEDF, Uint64.of_int 10 , Uint64.of_int 8198552921648713 ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint64.div a b in
+      if Uint64.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s %s: expected %s, got %s"
+          (Uint64.to_string a)
+          (Uint64.to_string b)
+          (Uint64.to_string expected)
+          (Uint64.to_string got))
+    ) tests
+  );
+
+  "Uint.Uint64.rem", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint64.one, Uint64.one, Uint64.zero ;
+      Uint64.of_int 123456789, Uint64.of_int 847, Uint64.of_int 610 ;
+      Uint64.of_int 123456789, Uint64.max_int, Uint64.of_int 123456789 ;
+      Uint64.max_int, Uint64.max_int, Uint64.zero ;
+      Uint64.max_int, Uint64.of_int 3, Uint64.zero ;
+      Uint64.max_int, Uint64.of_int 2, Uint64.of_int 1 ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint64.rem a b in
+      if Uint64.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s %s: expected %s, got %s"
+          (Uint64.to_string a)
+          (Uint64.to_string b)
+          (Uint64.to_string expected)
+          (Uint64.to_string got))
+    ) tests
+  );
+
+  "Uint.Uint64.to_string", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint64.zero, "0" ;
+      Uint64.one , "1" ;
+      Uint64.max_int, "18446744073709551615" ;
+    ] in
+
+    List.iter (fun (a, expected) ->
+      let got = Uint64.to_string a in
+      if String.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s: expected %s, got %s"
+          (Uint64.to_string_hex a)
+          expected
+          got)
+    ) tests
+  );
+
+  "Uint.Uint64.to_string_hex", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint64.zero, "0x0" ;
+      Uint64.one , "0x1" ;
+      Uint64.max_int, "0xffffffffffffffff" ;
+    ] in
+
+    List.iter (fun (a, expected) ->
+      let got = Uint64.to_string_hex a in
+      if String.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s: expected %s, got %s"
+          (Uint64.to_string a)
+          expected
+          got)
+    ) tests
+  );
+
+  "Uint.Uint64.of_string", (fun () ->
+    let open Uint in
+    let tests = [
+      "0", Uint64.zero ;
+      "1", Uint64.one ;
+      "0xFFFFFFFFFFFFFFFF", Uint64.max_int ;
+      "18446744073709551615", Uint64.max_int ;
+    ] in
+
+    List.iter (fun (raw, expected) ->
+      let got = Uint64.of_string raw in
+      if Uint64.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s: expected %s, got %s"
+          raw
+          (Uint64.to_string expected)
+          (Uint64.to_string got))
+    ) tests
+  );
+
+  "Uint.Uint64.of_string bad input", (fun () ->
+    let open Uint in
+    let tests = [
+      "a" ;
+      "-1" ;
+      "0xFFFFFFFFFFFFFFFFF" ;
+      "184467440737095516158" ;
+    ] in
+
+    List.iter (fun raw ->
+      let raised =
+        try
+          let _ = Uint64.of_string raw in false
+        with _ -> true
+      in
+      if not raised then
+        Test.fail (Printf.sprintf "%s: did not raise" raw)
+    ) tests
+  );
+
+  "Uint.Uint64.compare", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint64.zero, Uint64.zero, 0 ;
+      Uint64.zero, Uint64.one, -1 ;
+      Uint64.one, Uint64.zero, 1 ;
+      Uint64.max_int, Uint64.one, 1 ;
+      Uint64.max_int, Uint64.zero, 1 ;
+      Uint64.max_int, Uint64.of_string "18446744073709551613", 1 ;
+      Uint64.max_int, Uint64.of_string "0xFFFFFFFFFFFFFFAA", 1 ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint64.compare a b in
+      if got <> expected then
+        Test.fail (Printf.sprintf "%s %s: expected %i, got %i"
+          (Uint64.to_string a)
+          (Uint64.to_string b)
+          expected
+          got)
+    ) tests
+  );
+]
+
+let () = Test.run tests

--- a/lib/tests/uint_test.ml
+++ b/lib/tests/uint_test.ml
@@ -242,6 +242,311 @@ let tests = [
           got)
     ) tests
   );
+
+  (* Tests for Uint128. *)
+
+  "Uint.Uint128.leading_zeros", (fun () ->
+    let open Uint in
+    let tests = [
+      "0b10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", 0 ;
+      "0b00100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", 2 ;
+      "0b00000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000", 71 ;
+      "0b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", 128 ;
+    ] in
+
+    List.iter (fun (bits, expected) ->
+      let got = Uint128.leading_zeros (Uint128.of_string bits) in
+      if got <> expected then
+        Test.fail (Printf.sprintf "%s: expected %i, got %i"
+          bits
+          expected
+          got)
+    ) tests
+  );
+
+  "Uint.Uint128.shift_left", (fun () ->
+    let open Uint in
+    let tests = [
+      "0x0", 3, "0x0" ;
+      "0xF", 3, "0x78" ;
+      "0x123456789ABCDEF", 12, "0x123456789ABCDEF000" ;
+      "0xF", 0, "0xF" ;
+      "0x123456789ABCDEF", 0, "0x123456789ABCDEF" ;
+    ] in
+
+    List.iter (fun (bits, shift, expected_bits) ->
+      let got = Uint128.shift_left (Uint128.of_string bits) shift in
+      let expected = Uint128.of_string expected_bits in
+      if Uint128.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s: expected %s, got %s"
+          bits
+          (Uint128.to_string_hex expected)
+          (Uint128.to_string_hex got))
+    ) tests
+  );
+
+  "Uint.Uint128.shift_right_logical", (fun () ->
+    let open Uint in
+    let tests = [
+      "0x0", 3, "0x0" ;
+      "0x78", 3, "0xF" ;
+      "0x123456789ABCDEF000", 12, "0x123456789ABCDEF" ;
+    ] in
+
+    List.iter (fun (bits, shift, expected_bits) ->
+      let got = Uint128.shift_right_logical (Uint128.of_string bits) shift in
+      let expected = Uint128.of_string expected_bits in
+      if Uint128.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s: expected %s, got %s"
+          bits
+          (Uint128.to_string_hex expected)
+          (Uint128.to_string_hex got))
+    ) tests
+  );
+
+  "Uint.Uint128.add", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint128.zero, Uint128.zero, Uint128.zero ;
+      Uint128.zero, Uint128.one, Uint128.one ;
+      Uint128.one, Uint128.zero, Uint128.one ;
+      Uint128.max_int, Uint128.one, Uint128.zero ;
+      Uint128.of_string "0xFFFFFFFFFFFFFFFF", Uint128.one, Uint128.of_string "0x10000000000000000" ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint128.add a b in
+      if Uint128.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s %s: expected %s, got %s"
+          (Uint128.to_string_hex a)
+          (Uint128.to_string_hex b)
+          (Uint128.to_string_hex expected)
+          (Uint128.to_string_hex got))
+    ) tests
+  );
+
+  "Uint.Uint128.sub", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint128.zero, Uint128.zero, Uint128.zero ;
+      Uint128.zero, Uint128.one, Uint128.max_int ;
+      Uint128.one, Uint128.zero, Uint128.one ;
+      Uint128.of_string "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", Uint128.of_string "0x123456789ABDCDEF", Uint128.of_string "0x7fffffffffffffffedcba98765423210" ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint128.sub a b in
+      if Uint128.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s %s: expected %s, got %s"
+          (Uint128.to_string_hex a)
+          (Uint128.to_string_hex b)
+          (Uint128.to_string_hex expected)
+          (Uint128.to_string_hex got))
+    ) tests
+  );
+
+  "Uint.Uint128.div", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint128.one, Uint128.one, Uint128.one ;
+      Uint128.of_int 15, Uint128.of_int 10, Uint128.of_int 1 ;
+      Uint128.of_int 123456789, Uint128.max_int, Uint128.zero ;
+      Uint128.of_int 123456789, Uint128.of_int 847, Uint128.of_int 145757 ;
+      Uint128.of_string "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", Uint128.of_string "0xAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", Uint128.zero ;
+      Uint128.of_string "0xAFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", Uint128.of_string "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", Uint128.one ;
+      Uint128.max_int, Uint128.max_int, Uint128.one ;
+      Uint128.of_string "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", Uint128.of_string "0x123456789ABCEDF", Uint128.of_string "0x707fffffffffa3b770" ;
+      Uint128.max_int, Uint128.of_int 2, Uint128.of_string "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" ;
+      Uint128.max_int, Uint128.of_int 3, Uint128.of_string "0x55555555555555555555555555555555" ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint128.div a b in
+      if Uint128.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s %s: expected %s, got %s"
+          (Uint128.to_string_hex a)
+          (Uint128.to_string_hex b)
+          (Uint128.to_string_hex expected)
+          (Uint128.to_string_hex got))
+    ) tests
+  );
+
+  "Uint.Uint128.rem", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint128.one, Uint128.one, Uint128.zero ;
+      Uint128.of_int 123456789, Uint128.of_int 847, Uint128.of_int 610 ;
+      Uint128.of_int 123456789, Uint128.max_int, Uint128.of_int 123456789 ;
+      Uint128.max_int, Uint128.max_int, Uint128.zero ;
+      Uint128.one, Uint128.max_int, Uint128.one ;
+      Uint128.max_int, Uint128.of_string "0x3", Uint128.zero ;
+      Uint128.max_int, Uint128.of_string "0x2", Uint128.one ;
+      Uint128.of_int 15, Uint128.of_int 10, Uint128.of_int 5 ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint128.rem a b in
+      if Uint128.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s %s: expected %s, got %s"
+          (Uint128.to_string_hex a)
+          (Uint128.to_string_hex b)
+          (Uint128.to_string_hex expected)
+          (Uint128.to_string_hex got))
+    ) tests
+  );
+
+  "Uint.Uint128.compare", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint128.zero, Uint128.zero, 0 ;
+      Uint128.zero, Uint128.one, -1 ;
+      Uint128.one, Uint128.zero, 1 ;
+      Uint128.max_int, Uint128.one, 1 ;
+      Uint128.max_int, Uint128.zero, 1 ;
+      Uint128.max_int, Uint128.of_string "18446744073709551613", 1 ;
+      Uint128.max_int, Uint128.of_string "0xFFFFFFFFFFFFFFAA", 1 ;
+    ] in
+
+    List.iter (fun (a, b, expected) ->
+      let got = Uint128.compare a b in
+      if got <> expected then
+        Test.fail (Printf.sprintf "%s %s: expected %i, got %i"
+          (Uint128.to_string_hex a)
+          (Uint128.to_string_hex b)
+          expected
+          got)
+    ) tests
+  );
+
+  "Uint.Uint128.to_int", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint128.zero, 0 ;
+      Uint128.one, 1 ;
+      Uint128.of_string "0x75BCD15", 123456789 ;
+      Uint128.of_string "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", -1 ;
+      Uint128.of_string "0xFFFFFFFFFFFFFFFFFFFFFFFFF8A432EB", -123456789 ;
+      Uint128.of_string "0x0FFFFFFFFFFFFFFFFFFFFFFFF8A432EB", -123456789 ;
+    ] in
+
+    List.iter (fun (a, expected) ->
+      let got = Uint128.to_int a in
+      if got <> expected then
+        Test.fail (Printf.sprintf "%s: expected %i, got %i"
+          (Uint128.to_string_hex a)
+          expected
+          got)
+    ) tests
+  );
+
+  "Uint.Uint128.of_int", (fun () ->
+    let open Uint in
+    let tests = [
+      0, Uint128.of_string "0x0" ;
+      1, Uint128.of_string "0x1" ;
+      123456789, Uint128.of_string "0x75BCD15" ;
+      -1, Uint128.of_string "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" ;
+      -123456789, Uint128.of_string "0xFFFFFFFFFFFFFFFFFFFFFFFFF8A432EB" ;
+    ] in
+
+    List.iter (fun (i, expected) ->
+      let got = Uint128.of_int i in
+      if Uint128.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%i: expected %s, got %s"
+          i
+          (Uint128.to_string_hex expected)
+          (Uint128.to_string_hex got))
+    ) tests
+  );
+
+  "Uint.Uint128.to_string", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint128.zero, "0" ;
+      Uint128.one , "1" ;
+      Uint128.of_int 10, "10" ;
+      Uint128.of_int 15, "15" ;
+      Uint128.of_string "0x8" , "8" ;
+      Uint128.of_string "0xF" , "15" ;
+      Uint128.of_string "0xFF" , "255" ;
+      Uint128.of_string "0xFAFF" , "64255" ;
+      Uint128.of_string "0xABCDFAFF" , "2882403071" ;
+      Uint128.of_string "0x123456789ABCEDF" , "81985529216487135" ;
+      Uint128.max_int, "340282366920938463463374607431768211455" ;
+    ] in
+
+    List.iter (fun (a, expected) ->
+      let got = Uint128.to_string a in
+      if String.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s: expected %s, got %s"
+          (Uint128.to_string_hex a)
+          expected
+          got)
+    ) tests
+  );
+
+  "Uint.Uint128.to_string_hex", (fun () ->
+    let open Uint in
+    let tests = [
+      Uint128.zero, "0x0" ;
+      Uint128.one , "0x1" ;
+      Uint128.max_int, "0xffffffffffffffffffffffffffffffff" ;
+      Uint128.of_string "0xfffafffbfffffffffffffffff", "0xfffafffbfffffffffffffffff" ;
+      Uint128.of_string "0xfffafff0000000000ffffffff", "0xfffafff0000000000ffffffff" ;
+    ] in
+
+    List.iter (fun (a, expected) ->
+      let got = Uint128.to_string_hex a in
+      if String.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s: expected %s, got %s"
+          (Uint128.to_string_hex a)
+          expected
+          got)
+    ) tests
+  );
+
+  "Uint.Uint128.of_string", (fun () ->
+    let open Uint in
+    let tests = [
+      "0", Uint128.zero ;
+      "1", Uint128.one ;
+      "123456789123456789", Uint128.of_int 123456789123456789 ;
+      "123456789123456789123456789", Uint128.of_string "0x661efdf2e3b19f7c045f15" ;
+      "12345", Uint128.of_int 12345 ;
+      "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", Uint128.max_int ;
+      "340282366920938463463374607431768211455", Uint128.max_int ;
+    ] in
+
+    List.iter (fun (raw, expected) ->
+      let got = Uint128.of_string raw in
+      if Uint128.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s: expected %s, got %s"
+          raw
+          (Uint128.to_string_hex expected)
+          (Uint128.to_string_hex got))
+    ) tests
+  );
+
+  "Uint.Uint128.of_string bad input", (fun () ->
+    let open Uint in
+    let tests = [
+      "a" ;
+      "-1" ;
+      "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" ;
+      (* "3402823669209384634633746074317682114551" ; *)
+      "hello" ;
+    ] in
+
+    List.iter (fun raw ->
+      let raised =
+        try
+          let _ = Uint128.of_string raw in false
+        with _ -> true
+      in
+      if not raised then
+        Test.fail (Printf.sprintf "%s: did not raise" raw)
+    ) tests
+  );
 ]
 
 let () = Test.run tests

--- a/lib/uint.ml
+++ b/lib/uint.ml
@@ -16,6 +16,8 @@
 
 (** Unsigned integer types in pure OCaml. *)
 
+let int_sub (a : int) (b : int) = a - b
+
 module type S = sig
   type t
 
@@ -156,6 +158,10 @@ module Uint64 = struct
   let pred = sub one
   let succ = add one
 
+  let of_uint8 u = u
+  let of_uint16 u = u
+  let of_uint32 u = u
+
   let to_int = Int64.to_int
   let of_int = Int64.of_int
 
@@ -172,4 +178,225 @@ module Uint64 = struct
       | _ -> of_string_dec a
     else
       of_string_dec a
+end
+
+module Uint128 = struct
+  type t = Uint64.t * Uint64.t
+
+  let num_bits = 128
+
+  let of_uint64 u = Uint64.zero, u
+  let of_uint32 u = of_uint64 (Uint64.of_uint32 u)
+  let of_uint16 u = of_uint64 (Uint64.of_uint16 u)
+  let of_uint8 u = of_uint64 (Uint64.of_uint8 u)
+
+  let zero = Uint64.zero, Uint64.zero
+  let one = Uint64.zero, Uint64.one
+  let max_int = Uint64.max_int, Uint64.max_int
+
+  let logand a b = Uint64.logand (fst a) (fst b), Uint64.logand (snd a) (snd b)
+  let logor a b = Uint64.logor (fst a) (fst b), Uint64.logor (snd a) (snd b)
+  let logxor a b = Uint64.logxor (fst a) (fst b), Uint64.logxor (snd a) (snd b)
+  let lognot a = Uint64.lognot (fst a), Uint64.lognot (snd a)
+
+  let shift_left a by =
+    if by < 0 then
+      invalid_arg (Printf.sprintf "shift_left by negative: %i" by)
+    else if by > num_bits then
+      invalid_arg (Printf.sprintf "shift_left by %i" by)
+    else if by = 0 then
+      a
+    else if by < 64 then
+      let upper =
+        Uint64.logor
+          (Uint64.shift_left (fst a) by)
+          (Uint64.shift_right_logical (snd a) (64-by))
+      in
+      upper, Uint64.shift_left (snd a) by
+    else
+      Uint64.shift_left (snd a) (by-64), Uint64.zero
+
+  let shift_right _a _by = failwith "not implemented: shift_right"
+
+  let shift_right_logical a by =
+    if by < 0 then
+      invalid_arg (Printf.sprintf "shift_right by negative: %i" by)
+    else if by > num_bits then
+      invalid_arg (Printf.sprintf "shift_right_logical %i" by)
+    else if by = 0 then
+      a
+    else if by < 64 then
+      let lower =
+        Uint64.logor
+          (Uint64.shift_left (fst a) (64-by))
+          (Uint64.shift_right_logical (snd a) by)
+      in
+      Uint64.shift_right_logical (fst a) by, lower
+    else
+      Uint64.zero, Uint64.shift_right_logical (fst a) (by-64)
+
+  let leading_zeros a =
+    match a with
+    | (0L, a2) -> Uint64.num_bits + (Uint64.leading_zeros a2)
+    | (a1, _) -> Uint64.leading_zeros a1
+
+  let compare a b =
+    match Uint64.compare (fst a) (fst b) with
+    | 0 -> Uint64.compare (snd a) (snd b)
+    | n -> n
+
+  let add a b =
+    let carry =
+      if Uint64.compare (Uint64.add (snd a) (snd b)) (snd a) < 0 then
+        1L
+      else
+        0L
+    in
+    Uint64.add (Uint64.add (fst a) (fst b)) carry, Uint64.add (snd a) (snd b)
+
+  let sub a b =
+    let carry =
+      if Uint64.compare (Uint64.sub (snd a) (snd b)) (snd a) > 0 then
+        1L
+      else
+        0L
+    in
+    Uint64.sub (fst a) (Uint64.add (fst b) carry), Uint64.sub (snd a) (snd b)
+
+  let mul a b =
+    let mul64x64 u v =
+      let u1 = Uint64.logand u 0xFFFFFFFFL in
+      let v1 = Uint64.logand v 0xFFFFFFFFL in
+      let t = Uint64.mul u1 v1 in
+      let w3 = Uint64.logand t 0xFFFFFFFFL in
+      let k = Uint64.shift_right_logical t 32 in
+
+      let u = Uint64.shift_right_logical u 32 in
+      let t = Uint64.add k (Uint64.mul u v1) in
+      let k = Uint64.logand t 0xFFFFFFFFL in
+      let w1 = Uint64.shift_right_logical t 32 in
+
+      let v = Uint64.shift_right v 32 in
+      let t = Uint64.add k (Uint64.mul u1 v) in
+      let k = Uint64.shift_right_logical t 32 in
+
+      let upper = Uint64.add (Uint64.add (Uint64.mul u v) w1) k in
+      let lower = Uint64.add (Uint64.shift_left t 32) w3 in
+
+      upper, lower
+    in
+    let upper, lower = mul64x64 (snd a) (snd b) in
+    let upper = Uint64.add upper (Uint64.add (Uint64.mul (fst a) (snd b)) (Uint64.mul (snd a) (fst b))) in
+    upper, lower
+
+  let div_and_rem a b =
+    if compare b zero = 0 then
+      raise Division_by_zero
+    else if compare a b = 0 then
+      one, zero
+    else if compare a b < 0 then
+      zero, a
+    else
+      let rec div_and_rem' (i : int) (q : t) (r : t) (b : t) =
+        let q, r =
+          if compare r b >= 0 then
+            logor q one, sub r b
+          else
+            q, r
+        in
+        if i = 0 then
+          q, r
+        else
+          div_and_rem' (int_sub i 1) (shift_left q 1) r (shift_right_logical b 1)
+      in
+      let shift = (leading_zeros b) - (leading_zeros a) in
+      div_and_rem' shift zero a (shift_left b shift)
+
+
+  let div a b =
+    let d, _ = div_and_rem a b in d
+
+  let rem a b =
+    let _, r = div_and_rem a b in r
+
+  let pred = sub one
+  let succ = add one
+
+  let to_int a = Uint64.to_int (snd a)
+
+  let of_int i =
+    if i < 0 then
+      Uint64.max_int, Uint64.of_int i
+    else
+      Uint64.zero, Uint64.of_int i
+
+  let to_string a =
+    let ten = of_int 10 in
+    let string_of_digit q =
+      assert (compare q ten < 0) ;
+      Uint64.to_string (snd q)
+    in
+    let rec to_string' total a =
+      if compare a ten < 0 then
+        (string_of_digit a) :: total
+      else
+        let q, r = div_and_rem a ten in
+        to_string' ((string_of_digit r) :: total) q
+    in
+    to_string' [] a |> String.concat ""
+
+  let to_string_hex a =
+    match a with
+    | 0L, a2 -> Uint64.to_string_hex a2
+    | a1, a2 -> Printf.sprintf "0x%Lx%016Lx" a1 a2
+
+  let of_string raw =
+    let of_string_hex raw =
+      let len = String.length raw in
+      if len <= 16 then
+        Uint64.zero, Uint64.of_string ("0x" ^ raw)
+      else if len <= 32 then
+        Uint64.of_string ("0x" ^ (String.sub raw 0 (len-16))), Uint64.of_string ("0x" ^ (String.sub raw (len-16) 16))
+      else
+        failwith "too many hex digits"
+    in
+    let of_string_oct _a = failwith "not implemented: of_string_oct" in
+    let of_string_bin raw =
+      let len = String.length raw in
+      if len <= 64 then
+        Uint64.zero, Uint64.of_string ("0b" ^ raw)
+      else if len <= 128 then
+        Uint64.of_string ("0b" ^ (String.sub raw 0 (len-64))), Uint64.of_string ("0b" ^ (String.sub raw (len-64) 64))
+      else
+        failwith "too many bits"
+    in
+    let of_string_dec a =
+      let of_char c =
+        match c with
+        | '0' -> zero
+        | '1' -> one
+        | '2' -> of_int 2
+        | '3' -> of_int 3
+        | '4' -> of_int 4
+        | '5' -> of_int 5
+        | '6' -> of_int 6
+        | '7' -> of_int 7
+        | '8' -> of_int 8
+        | '9' -> of_int 9
+        | _ -> failwith (Printf.sprintf "invalid character: %c" c)
+      in
+      let ten = of_int 10 in
+      let acc = ref zero in
+      String.iter (fun c -> acc := add (mul !acc ten) (of_char c)) a ;
+      !acc
+    in
+    let len = String.length raw in
+    if len >= 2 then
+      match raw.[0], raw.[1] with
+      | '0', 'x' -> of_string_hex (String.sub raw 2 (len-2))
+      | '0', 'o' -> of_string_oct (String.sub raw 2 (len-2))
+      | '0', 'b' -> of_string_bin (String.sub raw 2 (len-2))
+      | _ -> of_string_dec raw
+    else
+      of_string_dec raw
 end

--- a/lib/uint.ml
+++ b/lib/uint.ml
@@ -1,0 +1,175 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2015-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Unsigned integer types in pure OCaml. *)
+
+module type S = sig
+  type t
+
+  val num_bits : int
+
+  val zero : t
+  val one : t
+  val max_int : t
+
+  val add : t -> t -> t
+  val sub : t -> t -> t
+  val mul : t -> t -> t
+  val div : t -> t -> t
+  val rem : t -> t -> t
+
+  val pred : t -> t
+  val succ : t -> t
+
+  val logand : t -> t -> t
+  val logor : t -> t -> t
+  val logxor : t -> t -> t
+  val lognot : t -> t
+
+  val shift_left : t -> int -> t
+  val shift_right : t -> int -> t
+  val shift_right_logical : t -> int -> t
+
+  val leading_zeros : t -> int
+
+  val compare : t -> t -> int
+
+  val to_int : t -> int
+  val of_int : int -> t
+
+  val to_string : t -> string
+  val to_string_hex : t -> string
+  val of_string : string -> t
+end
+
+module Uint8 = struct
+  type t = Int64.t
+  let max_int = 0xFFL
+end
+
+module Uint16 = struct
+  type t = Int64.t
+  let max_int = 0xFFFFL
+end
+
+module Uint32 = struct
+  type t = Int64.t
+  let max_int = 0xFFFFFFFFL
+end
+
+module Uint64 = struct
+  type t = Int64.t
+
+  let num_bits = 64
+
+  let zero = 0L
+  let one = 1L
+  let max_int = 0xFFFFFFFFFFFFFFFFL
+
+  let logand = Int64.logand
+  let logor = Int64.logor
+  let logxor = Int64.logxor
+  let lognot = Int64.lognot
+
+  (* For signed integers, the top bit is the sign.
+   * Thus, we will occasionally need to check if that bit is set,
+   * or clear the bit for interaction with Int64.t. *)
+  let top_bit = 0x8000000000000000L
+  let has_top_bit_set a = logand a top_bit <> 0L
+  let clear_top_bit a = logand a (lognot top_bit)
+
+  let shift_left = Int64.shift_left
+  let shift_right = Int64.shift_right
+  let shift_right_logical = Int64.shift_right_logical
+
+  let leading_zeros a =
+    let rec leading_zeros' i a =
+      match i with
+      | 64 -> 64
+      | _ ->
+          if has_top_bit_set a then
+            i
+          else
+            leading_zeros' (i+1) (shift_left a 1)
+    in
+    leading_zeros' 0 a
+
+  let compare a b =
+    match has_top_bit_set a, has_top_bit_set b with
+    | false, false -> Int64.compare a b
+    | true, false -> 1
+    | false, true -> -1
+    | true, true -> Int64.compare a b
+
+  let add = Int64.add
+  let sub = Int64.sub
+  let mul = Int64.mul
+
+  (* TODO: If we move our minimum OCaml version to 4.08, replace this with
+   * Int64.unsigned_div and Int64.unsigned_rem. *)
+  let div_and_rem a b =
+    match a >= 0L, b >= 0L with
+    | true, true -> Int64.div a b, Int64.rem a b
+    | true, false -> 0L, a
+    | false, true ->
+        let int_bits = clear_top_bit a in
+        let bottom_d, bottom_r = Int64.div int_bits b, Int64.rem int_bits b in
+        let top_d, top_r = Int64.div (lognot top_bit) b, Int64.rem (lognot top_bit) b in
+        let combined_d, combined_r =
+          if compare (add top_r bottom_r) b = 0 then
+            add (add bottom_d top_d) one, 0L
+          else
+            add bottom_d top_d, add bottom_r top_r
+        in
+        if compare (add combined_r one) b = 0 then
+          add combined_d one, zero
+        else
+          combined_d, add combined_r one
+    | false, false ->
+        let compared = compare a b in
+        if compared = 0 then
+          1L, 0L
+        else if compared < 0 then
+          0L, a
+        else
+          1L, sub a b
+
+  let div a b =
+    let d, _ = div_and_rem a b in d
+
+  let rem a b =
+    let _, r = div_and_rem a b in r
+
+  let pred = sub one
+  let succ = add one
+
+  let to_int = Int64.to_int
+  let of_int = Int64.of_int
+
+  let to_string a = Printf.sprintf "%Lu" a
+  let to_string_hex a = Printf.sprintf "0x%Lx" a
+
+  let of_string a =
+    let of_string_dec a = Scanf.sscanf a "%Lu" (fun u -> u) in
+    if String.length a >= 2 then
+      match a.[0], a.[1] with
+      | '0', 'x'
+      | '0', 'o'
+      | '0', 'b' -> Int64.of_string a
+      | _ -> of_string_dec a
+    else
+      of_string_dec a
+end

--- a/lib/uint.mli
+++ b/lib/uint.mli
@@ -69,3 +69,14 @@ module Uint32 : sig
 end
 
 module Uint64 : S
+
+module Uint128 : sig
+  type t
+
+  include S with type t := t
+
+  val of_uint64 : Uint64.t -> t
+  val of_uint32 : Uint32.t -> t
+  val of_uint16 : Uint16.t -> t
+  val of_uint8 : Uint8.t -> t
+end

--- a/lib/uint.mli
+++ b/lib/uint.mli
@@ -1,0 +1,71 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2015-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+module type S = sig
+  type t
+
+  val num_bits : int
+
+  val zero : t
+  val one : t
+  val max_int : t
+
+  val add : t -> t -> t
+  val sub : t -> t -> t
+  val mul : t -> t -> t
+  val div : t -> t -> t
+  val rem : t -> t -> t
+
+  val pred : t -> t
+  val succ : t -> t
+
+  val logand : t -> t -> t
+  val logor : t -> t -> t
+  val logxor : t -> t -> t
+  val lognot : t -> t
+
+  val shift_left : t -> int -> t
+  val shift_right : t -> int -> t
+  val shift_right_logical : t -> int -> t
+
+  val leading_zeros : t -> int
+
+  val compare : t -> t -> int
+
+  val to_int : t -> int
+  val of_int : int -> t
+
+  val to_string : t -> string
+  val to_string_hex : t -> string
+  val of_string : string -> t
+end
+
+module Uint8 : sig
+  type t
+  val max_int : t
+end
+
+module Uint16 : sig
+  type t
+  val max_int : t
+end
+
+module Uint32 : sig
+  type t
+  val max_int : t
+end
+
+module Uint64 : S


### PR DESCRIPTION
To remove our dependency on the external `stdint` library, this PR creates a module `Uint`, to implement the relevant API from `Stdint`, using pure OCaml. It should also be extendable to 256-bit or larger Unsigned Integers when we need them.