### PR TITLE
Explicit markers for the absence of faults for observed faults in tools output logs.

### DIFF
--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -453,7 +453,7 @@ module Make(O:Config)(M:XXXMem.S) =
         A.StateSet.pp stdout ""
           (fun chan st ->
             fprintf chan "%s\n"
-              (A.do_dump_final_state tr_out st))
+              (A.do_dump_final_state test.Test_herd.ffaults tr_out st))
           finals ;
 (* Condition result *)
         let ok = check_cond test c in

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -689,9 +689,8 @@ module Make
             let fmt2 = U.fmt_faults faults
             and args2 =
               List.map
-                (fun f -> sprintf "p->%s?\" %s;\":\"\""
-                    (SkelUtil.dump_fatom_tag A.V.pp_v f)
-                    (Fault.pp_fatom A.V.pp_v f))
+                (fun f -> sprintf "p->%s?\"\":\"~\""
+                    (SkelUtil.dump_fatom_tag A.V.pp_v f))
                 faults in
             EPF.fi ~out:"chan" fmt2 args2 ;
         end ;

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -297,7 +297,11 @@ module Make
         String.concat " "
           (List.map (fun (p1,p2) -> sprintf "%s=%s;" p1 p2) pps)
 
-      let fmt_faults fs = String.concat "" (List.map (fun _ -> "%s") fs)
+      let fmt_faults fs =
+        String.concat ""
+          (List.map
+             (fun f -> sprintf " %s%s;" "%s" (Fault.pp_fatom A.V.pp_v f))
+             fs)
 
 (* Locations *)
       let get_displayed_locs t =

--- a/tools/condPP.mli
+++ b/tools/condPP.mli
@@ -16,7 +16,7 @@
 
 type bd = string * string
 type fault = string
-type bds = bd list * fault list
+type bds = bd list * fault list * fault list
 type cnf = bds list
 
 

--- a/tools/logState.mli
+++ b/tools/logState.mli
@@ -90,7 +90,8 @@ type simple_t = { s_name : string ; s_tests : simple_test list; }
 module Make(O:sig val verbose : int end) : sig
 
 val as_st_concrete :
-    HashedBinding.node list -> HashedFault.node list -> st_concrete
+  HashedBinding.node list -> HashedFault.node list ->
+  HashedFault.node list -> st_concrete
 
 val is_empty_simple : simple_test -> bool
 val empty_sts : sts
@@ -98,7 +99,8 @@ val get_nouts : sts -> Int64.t
 val millions : Int64.t -> float
 
 (* Extract bindings from states, break abstraction, use with care *)
-val get_bindings : sts -> ((string * string) list * string list) list
+val get_bindings :
+  sts -> ((string * string) list * string list * string list) list
 
 (* - first argument is to be prefixed to all states
    - second argument is pp mode.


### PR DESCRIPTION
This permits correct final conditions for tests that describe behaviours in tables. Consider for instance two logs A an B, where A and B contain the outcome `0:X0=0 /\ fault (P0,x)`, with B containing the additional outcome `0:X0=0`. That is, the absence of `fault(P0,x)` is left implicit. Then, the comparison mechanics of `mcompare` will yield the conditon `exists 0:X0=0` to encode the outcomes present in B and absent in A. This is not correct as `0:X0=0 /\ Fault(p0,x)` does match this condition. With explicit fault absence, `mcompare` will produce the correct condition:
```
exists 0:X0=0 /\ ~Fault(P0,x)
```

Legacy logs are handled by the `sum` tools, identical outcomes up to having or not having explicit absent faults are considered equal and their number of occurrences are summed. The outcome in output is the one with explicit fault absence.