### PR TITLE
[internal_lib] Add module Shelf

### DIFF
--- a/defs.sh
+++ b/defs.sh
@@ -9,7 +9,7 @@ NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
 INTERNAL="herd_regression_test.native herd_diycross_regression_test.native"
-TESTS="channel_test.native command_test.native filesystem_test.native test_test.native uint_test.native"
+TESTS="base_test.native channel_test.native command_test.native filesystem_test.native test_test.native uint_test.native"
 
 mk_exe () {
   D=$1

--- a/defs.sh
+++ b/defs.sh
@@ -9,7 +9,7 @@ NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
 INTERNAL="herd_regression_test.native herd_diycross_regression_test.native"
-TESTS="base_test.native channel_test.native command_test.native compare_test.native filesystem_test.native test_test.native ocamlString_test.native uint_test.native"
+TESTS="base_test.native channel_test.native command_test.native compare_test.native filesystem_test.native test_test.native ocamlString_test.native shelf_test.native uint_test.native"
 
 mk_exe () {
   D=$1

--- a/defs.sh
+++ b/defs.sh
@@ -9,7 +9,7 @@ NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
 INTERNAL="herd_regression_test.native herd_diycross_regression_test.native"
-TESTS="base_test.native channel_test.native command_test.native compare_test.native filesystem_test.native test_test.native uint_test.native"
+TESTS="base_test.native channel_test.native command_test.native compare_test.native filesystem_test.native test_test.native ocamlString_test.native uint_test.native"
 
 mk_exe () {
   D=$1

--- a/defs.sh
+++ b/defs.sh
@@ -9,7 +9,7 @@ NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
 INTERNAL="herd_regression_test.native herd_diycross_regression_test.native"
-TESTS="base_test.native channel_test.native command_test.native filesystem_test.native test_test.native uint_test.native"
+TESTS="base_test.native channel_test.native command_test.native compare_test.native filesystem_test.native test_test.native uint_test.native"
 
 mk_exe () {
   D=$1

--- a/internal/lib/base.ml
+++ b/internal/lib/base.ml
@@ -1,0 +1,57 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Extending built-in / base modules, either to port future features into
+ *  earlier versions of OCaml, or to add extra functionality. *)
+
+module List = struct
+  include List
+
+  let rec compare cf xs ys =
+    match xs, ys with
+    | [], [] -> 0
+    | [], _ -> -1
+    | _, [] -> 1
+    | x :: xs, y :: ys ->
+        match cf x y with
+        | 0 -> compare cf xs ys
+        | n -> n
+
+  let to_ocaml_string f xs =
+    Printf.sprintf "[%s]" (String.concat "; " (List.map f xs))
+end
+
+module Option = struct
+  type 'a t = 'a option
+
+  let compare cf a b =
+    match a, b with
+    | None, None -> 0
+    | Some _, None -> 1
+    | None, Some _ -> -1
+    | Some a, Some b -> cf a b
+
+  let to_ocaml_string f o =
+    match o with
+    | None -> "None"
+    | Some a -> Printf.sprintf "Some (%s)" (f a)
+end
+
+module String = struct
+  include String
+
+  let to_ocaml_string s = Printf.sprintf "%S" s
+end

--- a/internal/lib/base.mli
+++ b/internal/lib/base.mli
@@ -1,0 +1,55 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Extending built-in / base modules, either to port future features into
+ *  earlier versions of OCaml, or to add extra functionality. *)
+
+module List : sig
+  include module type of List
+
+  (** [compare c xs ys] compares lists [xs] and [ys], first by length, then by
+   *  comparing each pair of elements of [xs] and [ys] with compare function [c]
+   *  until a pair differs. *)
+  val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+
+  (** [to_ocaml_string f xs] returns an OCaml syntax form of [xs], applying [f]
+   *  to each element of [xs]. For example,
+   *  [to_ocaml_string String.to_ocaml_string ["a"; "b"]] returns
+   *  "[\"a\"; \"b\"]". *)
+  val to_ocaml_string : ('a -> string) -> 'a list -> string
+end
+
+module String : sig
+  include module type of String
+
+  (** [to_ocaml_string s] returns an OCaml syntax form of [s].
+   *  For example, [to_ocaml_string "a"] returns ["\"a\""]. *)
+  val to_ocaml_string : string -> string
+end
+
+module Option : sig
+  type 'a t = 'a option
+
+  (** [compare c x y] compares [x] and [y]. [None] is smaller than [Some _]. If
+   *  they are both [Some _] their elements are compared with function [c]. *)
+  val compare : ('a -> 'a -> int) -> 'a option -> 'a option -> int
+
+  (** [to_ocaml_string f x] returns an OCaml syntax form of [x]. If [x] is
+   * [Some x'], [f] is applied to the element [x'].
+   * For example, [to_ocaml_string String.to_ocaml_string (Some "hello")]
+   * returns ["Some (\"hello\")"]. *)
+  val to_ocaml_string : ('a -> string) -> 'a option -> string
+end

--- a/internal/lib/command.ml
+++ b/internal/lib/command.ml
@@ -38,3 +38,14 @@ let run_with_stdout bin args f =
   | Unix.WEXITED n -> raise (Error (Printf.sprintf "Process returned error code %i" n))
   | Unix.WSIGNALED n -> raise (Error (Printf.sprintf "Process was killed by signal %i" n))
   | Unix.WSTOPPED n -> raise (Error (Printf.sprintf "Process was stopped by signal %i" n))
+
+let run_with_stdin_and_stdout bin args in_f out_f =
+  let cmd = command bin args in
+  let stdout, stdin = Unix.open_process cmd in
+  in_f stdin ;
+  let ret = out_f stdout in
+  match Unix.close_process (stdout, stdin) with
+  | Unix.WEXITED 0 -> ret
+  | Unix.WEXITED n -> raise (Error (Printf.sprintf "Process returned error code %i" n))
+  | Unix.WSIGNALED n -> raise (Error (Printf.sprintf "Process was killed by signal %i" n))
+  | Unix.WSTOPPED n -> raise (Error (Printf.sprintf "Process was stopped by signal %i" n))

--- a/internal/lib/command.mli
+++ b/internal/lib/command.mli
@@ -29,3 +29,8 @@ val run : string -> string list -> unit
 (** [run_with_stdout bin args f] runs the binary [bin] with arguments [args], and
  *  applies function [f] to the open in_channel, returning the result. *)
 val run_with_stdout : string -> string list -> (in_channel -> 'a) -> 'a
+
+(** [run_with_stdout_and_stdin_lines bin args in_lines] runs the binary [bin]
+  * with arguments [args], pipes [in_lines] into the process's stdin, and returns
+  * the process's stdout as a string list. *)
+val run_with_stdin_and_stdout : string -> string list -> (out_channel -> unit) -> (in_channel -> 'a) -> 'a

--- a/internal/lib/compare.ml
+++ b/internal/lib/compare.ml
@@ -1,0 +1,22 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for writing compare functions. *)
+
+let rec chain cs =
+  match cs with
+  | [] -> 0
+  | c :: cs -> if c <> 0 then c else chain cs

--- a/internal/lib/compare.mli
+++ b/internal/lib/compare.mli
@@ -1,0 +1,21 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for writing compare functions. *)
+
+(** [chain cs] returns the first non-zero element of [cs], or zero if there are
+ *  no non-zero elements. *)
+val chain : int list -> int

--- a/internal/lib/ocamlString.ml
+++ b/internal/lib/ocamlString.ml
@@ -1,0 +1,24 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for writing to_ocaml_string functions. *)
+
+let record fields =
+  match fields with
+  | [] -> "{}"
+  | _ ->
+      let print (field, value) = Printf.sprintf "%s = %s" field value in
+      Printf.sprintf "{ %s }" (String.concat " ; " (List.map print fields))

--- a/internal/lib/ocamlString.mli
+++ b/internal/lib/ocamlString.mli
@@ -1,0 +1,21 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for writing to_ocaml_string functions. *)
+
+(** [record fields] returns an OCaml representation of a record of a list of
+ *  (field, OCaml-representation) pairs. *)
+val record : (string * string) list -> string

--- a/internal/lib/shelf.ml
+++ b/internal/lib/shelf.ml
@@ -1,0 +1,103 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** An OCaml representation of a shelf.py file. *)
+
+module StringList = struct
+  let compare = Base.List.compare String.compare
+  let to_ocaml_string = Base.List.to_ocaml_string Base.String.to_ocaml_string
+end
+module StringListOption = struct
+  let compare = Base.Option.compare StringList.compare
+  let to_ocaml_string = Base.Option.to_ocaml_string StringList.to_ocaml_string
+end
+
+exception ParseError of string
+
+type t = {
+  record : string ;
+
+  cats : string list ;
+  configs : string list ;
+  illustrative_tests : string list ;
+
+  bells : string list option ;
+  compatibilities : string list option ;
+}
+
+let compare a b = Compare.chain [
+  String.compare a.record b.record ;
+  StringList.compare a.cats b.cats ;
+  StringList.compare a.configs b.configs ;
+  StringList.compare a.illustrative_tests b.illustrative_tests ;
+  StringListOption.compare a.bells b.bells ;
+  StringListOption.compare a.compatibilities b.compatibilities ;
+]
+
+let to_ocaml_string shelf = OcamlString.record [
+  "record",              Base.String.to_ocaml_string       shelf.record ;
+  "cats",                StringList.to_ocaml_string        shelf.cats ;
+  "configs",             StringList.to_ocaml_string        shelf.configs ;
+  "illustrative_tests",  StringList.to_ocaml_string        shelf.illustrative_tests ;
+  "bells",               StringListOption.to_ocaml_string  shelf.bells ;
+  "compatibilities",     StringListOption.to_ocaml_string  shelf.compatibilities ;
+]
+
+let list_of_file path key =
+  (* Shelf files are executable Python code, so this Python script imports the
+   * shelf.py file, then prints the given global variables. *)
+  let script chan =
+    Printf.fprintf chan "import os\n" ;
+    Printf.fprintf chan "os.chdir(%s)\n" (Filename.quote (Filename.dirname path)) ;
+    Printf.fprintf chan "m = {}\n" ;
+    Printf.fprintf chan "execfile(%s, m)\n" (Filename.quote (Filename.basename path)) ;
+    Printf.fprintf chan "try:\n" ;
+    Printf.fprintf chan "  v = m[%s]\n" (Filename.quote key) ;
+    Printf.fprintf chan "  if isinstance(v, str):\n" ;
+    Printf.fprintf chan "    print(v)\n" ;
+    Printf.fprintf chan "  else:\n" ;
+    Printf.fprintf chan "    for x in v:\n" ;
+    Printf.fprintf chan "      print(x)\n" ;
+    Printf.fprintf chan "except:\n" ;
+    Printf.fprintf chan "  pass\n" ;
+    close_out chan
+  in
+  let lines = Command.run_with_stdin_and_stdout "python" [] script Channel.read_lines in
+  (* Sorted for stability / comparability. *)
+  List.sort String.compare lines
+
+let string_of_file path key =
+  match list_of_file path key with
+  | x :: [] -> x
+  | [] -> raise (ParseError (Printf.sprintf "Missing value for key %s" key))
+  | xs -> raise (ParseError (Printf.sprintf "Expected single value for key %s, found %i" key (List.length xs)))
+
+let optional_list_of_file path key =
+  match list_of_file path key with
+  | [] -> None
+  | xs -> Some xs
+
+let of_file path =
+  {
+    record = string_of_file path "record" ;
+
+    cats               = list_of_file path "cats" ;
+    configs            = list_of_file path "cfgs" ;
+    illustrative_tests = list_of_file path "illustrative_tests" ;
+
+    bells           = optional_list_of_file path "bells" ;
+    compatibilities = optional_list_of_file path "compatibilities" ;
+  }

--- a/internal/lib/shelf.mli
+++ b/internal/lib/shelf.mli
@@ -1,0 +1,38 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** An OCaml representation of a shelf.py file. *)
+
+type t = {
+  record : string ;
+
+  cats : string list ;
+  configs : string list ;
+  illustrative_tests : string list ;
+
+  bells : string list option ;
+  compatibilities : string list option ;
+}
+
+val compare : t -> t -> int
+
+(** [to_ocaml_string s] returns a string of the OCaml literal representation of
+ *  a Shelf [s]. *)
+val to_ocaml_string : t -> string
+
+(** [of_file path] reads a Shelf from a shelf.py file.
+ *  It can raise [ParseError]. *)
+val of_file : string -> t

--- a/internal/lib/tests/base_test.ml
+++ b/internal/lib/tests/base_test.ml
@@ -1,0 +1,89 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Tests for the Base modules. *)
+
+let tests = [
+  "Base.List.compare", (fun () ->
+    let tests = [
+      [], [], 0 ;
+      ["a"], [], 1 ;
+      [], ["a"], -1 ;
+      ["a"], ["a"], 0 ;
+      ["a"], ["b"], -1 ;
+    ] in
+
+    List.iteri
+      (fun i (xs, ys, expected) ->
+        let actual = Base.List.compare Base.String.compare xs ys in
+        if actual <> expected then
+          Test.fail (Printf.sprintf "[%i] expected %i, got %i" i expected actual)
+      )
+      tests
+  );
+
+  "Base.List.to_ocaml_string", (fun () ->
+    let tests = [
+      [], "[]" ;
+      ["a"], "[\"a\"]" ;
+      ["a"; "b"], "[\"a\"; \"b\"]" ;
+    ] in
+
+    List.iter
+      (fun (xs, expected) ->
+        let actual = Base.List.to_ocaml_string Base.String.to_ocaml_string xs in
+        if String.compare actual expected <> 0 then
+          Test.fail (Printf.sprintf "expected %s, got %s" expected actual)
+      )
+      tests
+  );
+
+  "Base.Option.compare", (fun () ->
+    let tests = [
+      None, None, 0 ;
+      Some "a", None, 1 ;
+      None, Some "a", -1 ;
+      Some "a", Some "a", 0 ;
+      Some "a", Some "b", -1 ;
+    ] in
+
+    List.iteri
+      (fun i (xs, ys, expected) ->
+        let actual = Base.Option.compare Base.String.compare xs ys in
+        if actual <> expected then
+          Test.fail (Printf.sprintf "[%i] expected %i, got %i" i expected actual)
+      )
+      tests
+  );
+
+  "Base.Option.to_ocaml_string", (fun () ->
+    let tests = [
+      None, "None" ;
+      Some "a", "Some (\"a\")" ;
+    ] in
+
+    List.iter
+      (fun (xs, expected) ->
+        let actual = Base.Option.to_ocaml_string Base.String.to_ocaml_string xs in
+        if String.compare actual expected <> 0 then
+          Test.fail (Printf.sprintf "expected %s, got %s" expected actual)
+      )
+      tests
+  );
+]
+
+let () = Test.run tests
+

--- a/internal/lib/tests/command_test.ml
+++ b/internal/lib/tests/command_test.ml
@@ -92,6 +92,32 @@ let tests = [
     if not raised_exception then
       Test.fail "Expected exception, did not raise";
   );
+
+  "Command.run_with_stdout captures stdout", (fun () ->
+    let tests = [
+      ("true", [], []);
+      ("echo", ["foo"], ["foo"]);
+      ("echo", ["foo\nbar"], ["foo"; "bar"]);
+    ] in
+
+    List.iter
+      (fun (cmd, args, expected) ->
+        let actual = Command.run_with_stdout cmd args Channel.read_lines in
+        if Test.string_list_compare actual expected <> 0 then
+          Test.fail (Printf.sprintf "Expected %s, got %s" (pp_string_list expected) (pp_string_list actual)))
+      tests
+  );
+  "Command.run_with_stdout_lines raises on error", (fun () ->
+    (* Deliberately fail. *)
+    let raised_exception = try
+      let _ = Command.run_with_stdout "false" [] (fun _ -> ()) in false
+    with
+      Command.Error _ -> true
+    in
+
+    if not raised_exception then
+      Test.fail "Expected exception, did not raise";
+  );
 ]
 
 let () = Test.run tests

--- a/internal/lib/tests/compare_test.ml
+++ b/internal/lib/tests/compare_test.ml
@@ -1,0 +1,39 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Tests for the Compare module. *)
+
+let tests = [
+  "Compare.chain", (fun () ->
+    let tests = [
+      [], 0 ;
+      [0; 0], 0 ;
+      [1; 0], 1 ;
+      [-1; 1; 0], -1 ;
+      [0; -1; 1; 0], -1 ;
+    ] in
+
+    List.iter
+      (fun (cs, expected) ->
+        let actual = Compare.chain cs in
+        if actual <> expected then
+          Test.fail (Printf.sprintf "expected %i, got %i" expected actual)
+      )
+      tests
+  );
+]
+
+let () = Test.run tests

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,5 +1,5 @@
 (tests
  (names base_test channel_test command_test compare_test filesystem_test
-   ocamlString_test test_test)
+   ocamlString_test shelf_test test_test)
  (libraries internal_lib unix)
  (modes native))

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,4 +1,4 @@
 (tests
- (names channel_test command_test filesystem_test test_test)
+ (names base_test channel_test command_test filesystem_test test_test)
  (libraries internal_lib unix)
  (modes native))

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,5 +1,5 @@
 (tests
  (names base_test channel_test command_test compare_test filesystem_test
-   test_test)
+   ocamlString_test test_test)
  (libraries internal_lib unix)
  (modes native))

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,4 +1,5 @@
 (tests
- (names base_test channel_test command_test filesystem_test test_test)
+ (names base_test channel_test command_test compare_test filesystem_test
+   test_test)
  (libraries internal_lib unix)
  (modes native))

--- a/internal/lib/tests/ocamlString_test.ml
+++ b/internal/lib/tests/ocamlString_test.ml
@@ -1,0 +1,40 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Tests for the OcamlString module. *)
+
+let tests = [
+  "OcamlString.record", (fun () ->
+    let tests = [
+      [], "{}" ;
+      ["a", Base.String.to_ocaml_string "b"], "{ a = \"b\" }" ;
+      [
+        "a", Base.String.to_ocaml_string "b" ;
+        "c", Base.String.to_ocaml_string "d" ;
+      ], "{ a = \"b\" ; c = \"d\" }" ;
+    ] in
+
+    List.iter
+      (fun (fields, expected) ->
+        let actual = OcamlString.record fields in
+        if String.compare actual expected <> 0 then
+          Test.fail (Printf.sprintf "expected %s, got %s" expected actual)
+      )
+      tests
+  );
+]
+
+let () = Test.run tests

--- a/internal/lib/tests/shelf_test.ml
+++ b/internal/lib/tests/shelf_test.ml
@@ -1,0 +1,163 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Tests for the Shelf module. *)
+
+let tests = [
+  "Shelf.of_file reads simple valid files", (fun () ->
+    let tmp_dir = Filesystem.new_temp_dir () in
+    let shelf_path = Filename.concat tmp_dir "shelf.py" in
+    let shelf_py o =
+      Printf.fprintf o "record = 'AArch64'\n" ;
+      Printf.fprintf o "cats = [ 'cats/sc.cat' ]\n" ;
+      Printf.fprintf o "cfgs = [ 'cfgs/web.cfg' ]\n" ;
+      Printf.fprintf o "bells = [ 'bells/tabby.bell' ]\n" ;
+      Printf.fprintf o "illustrative_tests = [ \n" ;
+      Printf.fprintf o "  'tests/meow.litmus',\n" ;
+      Printf.fprintf o "  'tests/mew.litmus',\n" ;
+      Printf.fprintf o "]\n" ;
+      Printf.fprintf o "references = [ { 'title': 'Garfield' } ]\n" ;
+      ()
+    in
+    Filesystem.write_file shelf_path shelf_py ;
+
+    let expected = let open Shelf in {
+      record = "AArch64" ;
+      cats = [ "cats/sc.cat" ] ;
+      configs = [ "cfgs/web.cfg" ] ;
+      illustrative_tests = [ "tests/meow.litmus"; "tests/mew.litmus" ] ;
+      bells = Some [ "bells/tabby.bell" ] ;
+      compatibilities = None ;
+    } in
+
+    let actual = Shelf.of_file shelf_path in
+
+    Filesystem.remove_recursive tmp_dir ;
+
+    if Shelf.compare expected actual <> 0 then
+      Test.fail (Printf.sprintf "expected %s, got %s"
+        (Shelf.to_ocaml_string expected)
+        (Shelf.to_ocaml_string actual)
+      )
+  );
+
+  "Shelf.of_file reads valid files with non-standard names", (fun () ->
+    let tmp_dir = Filesystem.new_temp_dir () in
+    let shelf_path = Filename.concat tmp_dir "shlaf shelf.py" in
+    let shelf_py o =
+      Printf.fprintf o "record = 'AArch64'\n" ;
+      Printf.fprintf o "cats = [ 'cats/sc.cat' ]\n" ;
+      Printf.fprintf o "cfgs = [ 'cfgs/web.cfg' ]\n" ;
+      Printf.fprintf o "illustrative_tests = [ \n" ;
+      Printf.fprintf o "  'tests/meow.litmus',\n" ;
+      Printf.fprintf o "  'tests/mew.litmus',\n" ;
+      Printf.fprintf o "]\n" ;
+      ()
+    in
+    Filesystem.write_file shelf_path shelf_py ;
+
+    let expected = let open Shelf in {
+      record = "AArch64" ;
+      cats = [ "cats/sc.cat" ] ;
+      configs = [ "cfgs/web.cfg" ] ;
+      illustrative_tests = [ "tests/meow.litmus"; "tests/mew.litmus" ] ;
+      bells = None ;
+      compatibilities = None ;
+    } in
+
+    let actual = Shelf.of_file shelf_path in
+
+    Filesystem.remove_recursive tmp_dir ;
+
+    if Shelf.compare expected actual <> 0 then
+      Test.fail (Printf.sprintf "expected %s, got %s"
+        (Shelf.to_ocaml_string expected)
+        (Shelf.to_ocaml_string actual)
+      )
+  );
+
+  "Shelf.of_file sorts lists for stability", (fun () ->
+    let tmp_dir = Filesystem.new_temp_dir () in
+    let shelf_path = Filename.concat tmp_dir "shlaf shelf.py" in
+    let shelf_py o =
+      Printf.fprintf o "record = 'AArch64'\n" ;
+      Printf.fprintf o "cats = [ 'cats/sc.cat' ]\n" ;
+      Printf.fprintf o "cfgs = [ 'cfgs/web.cfg' ]\n" ;
+      Printf.fprintf o "illustrative_tests = [ \n" ;
+      Printf.fprintf o "  'tests/b.litmus',\n" ;
+      Printf.fprintf o "  'tests/a.litmus',\n" ;
+      Printf.fprintf o "]\n" ;
+      ()
+    in
+    Filesystem.write_file shelf_path shelf_py ;
+
+    let expected = let open Shelf in {
+      record = "AArch64" ;
+      cats = [ "cats/sc.cat" ] ;
+      configs = [ "cfgs/web.cfg" ] ;
+      illustrative_tests = [ "tests/a.litmus"; "tests/b.litmus" ] ;
+      bells = None ;
+      compatibilities = None ;
+    } in
+
+    let actual = Shelf.of_file shelf_path in
+
+    Filesystem.remove_recursive tmp_dir ;
+
+    if Shelf.compare expected actual <> 0 then
+      Test.fail (Printf.sprintf "expected %s, got %s"
+        (Shelf.to_ocaml_string expected)
+        (Shelf.to_ocaml_string actual)
+      )
+  );
+
+  "Shelf.of_file reads valid files with globs", (fun () ->
+    let tmp_dir = Filesystem.new_temp_dir () in
+    let shelf_path = Filename.concat tmp_dir "shelf.py" in
+    let shelf_py o =
+      Printf.fprintf o "import glob\n" ;
+      Printf.fprintf o "record = 'AArch64'\n" ;
+      Printf.fprintf o "cats = [ 'cats/sc.cat' ]\n" ;
+      Printf.fprintf o "cfgs = [ 'cfgs/web.cfg' ]\n" ;
+      Printf.fprintf o "illustrative_tests = glob.glob( '*.litmus' ) \n" ;
+      ()
+    in
+    Filesystem.write_file (Filename.concat tmp_dir "mew.litmus") (fun _ -> ()) ;
+    Filesystem.write_file (Filename.concat tmp_dir "purr.litmus") (fun _ -> ()) ;
+    Filesystem.write_file shelf_path shelf_py ;
+
+    let expected = let open Shelf in {
+      record = "AArch64" ;
+      cats = [ "cats/sc.cat" ] ;
+      configs = [ "cfgs/web.cfg" ] ;
+      illustrative_tests = [ "mew.litmus"; "purr.litmus" ] ;
+      bells = None ;
+      compatibilities = None ;
+    } in
+
+    let actual = Shelf.of_file shelf_path in
+
+    Filesystem.remove_recursive tmp_dir ;
+
+    if Shelf.compare expected actual <> 0 then
+      Test.fail (Printf.sprintf "expected %s, got %s"
+        (Shelf.to_ocaml_string expected)
+        (Shelf.to_ocaml_string actual)
+      )
+  );
+]
+
+let () = Test.run tests


### PR DESCRIPTION
This PR adds a module `Shelf`, to work with `shelf.py` Catalogue files using OCaml.

To do this, this PR also:
- Adds a module `Base`, to extend builtin modules, and backport modules from future versions of OCaml.
- Adds a module `Compare`, to house utilities for writing or generating `compare` functions.
- Adds a module `OcamlString`, to house utilities for writing or generating `to_ocaml_string` functions.
- Extends `Command` with `run_with_stdin_and_stdout`, to run runtime-generated Python scripts on `shelf.py` files.

This PR is a part of Issue #123, implementing regression-testing of the Catalogue.

Regarding the name `to_ocaml_string`, I also considered a name like `repr` like Python's `__repr__` ("internal representation"); what do you think? The contract of `to_ocaml_string` is that it returns a similar representation to the OCaml toplevel REPL.