### PR TITLE
Bbm primitives

### DIFF
--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -107,6 +107,11 @@ end = struct
   | Access (_,A.Location_global _,_,_,_,_)   -> true
   | _ -> false
 
+  let is_pt a = match a with
+    | Access (_,A.Location_global (A.V.Val c),_,_,_,_)   ->
+        Constant.is_pt c
+    | _ -> false
+
 (* None of those below *)
   let is_tag _ = false
   let is_mem_physical a = let open Constant in match a with
@@ -114,8 +119,6 @@ end = struct
   | _ -> false
 
   let is_additional_mem _ = false
-
-  let is_PTE_access _ = false
 
   let is_PA_val _ = false
 

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -169,7 +169,9 @@ end = struct
   | RMW (A.Location_global _,_,_,_,_) -> true
   | _ -> false
 
+  let is_pt _ = false
   let is_tag _ = false
+
   let is_mem_physical a = let open Constant in match a with
   | Access (_,A.Location_global (V.Val (Symbolic (Physical _))),_,_,_,_)
   | RMW (A.Location_global (V.Val (Symbolic (Physical _))),_,_,_,_) -> true
@@ -178,8 +180,6 @@ end = struct
   let is_additional_mem a = match a with
   | Lock _|Unlock _|TryLock _|ReadLock _ -> true
   | _ -> false
-
-  let is_PTE_access _ = false
 
   let is_PA_val _ = false
 

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -55,6 +55,7 @@ module type S = sig
   val is_mem_load : action ->  bool
   val is_additional_mem_load :  action -> bool (* trylock *)
   val is_mem : action -> bool
+  val is_pt : action -> bool
   val is_tag : action -> bool
   val is_mem_physical : action -> bool
   val is_additional_mem : action -> bool (* abstract memory actions, eg locks *)
@@ -63,7 +64,6 @@ module type S = sig
   val to_fault : action -> A.fault option
   val get_mem_dir : action -> Dir.dirn
   val get_mem_size : action -> MachSize.sz
-  val is_PTE_access : action -> bool
   val is_PA_val : A.V.v -> bool
 
 (* relative to the registers of the given proc *)

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -29,6 +29,7 @@ module type S = sig
 (* Some architecture-specific sets and relations, with their definitions *)
   val arch_sets : (string * (action -> bool)) list
   val arch_rels : (string * (action -> action -> bool)) list
+(* To be deprecated *)
   val arch_dirty : (string * (DirtyBit.my_t -> action -> bool)) list
 
 (* control fence *)

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -75,6 +75,8 @@ val same_instance : event -> event -> bool
   val is_mem_load : event ->  bool
   val is_additional_mem_load : event ->  bool (* trylock... *)
   val is_mem : event -> bool
+(* Page table access *)
+  val is_pt : event -> bool
 (* Tag memory access *)
   val is_tag : event -> bool
   val is_mem_physical : event -> bool
@@ -510,6 +512,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
     let is_mem_load e = Act.is_mem_load e.action
     let is_additional_mem_load e = Act.is_additional_mem_load e.action
     let is_mem e = Act.is_mem e.action
+    let is_pt e = Act.is_pt e.action
     let is_tag e = Act.is_tag e.action
     let is_mem_physical e =  Act.is_mem_physical e.action
     let is_additional_mem e = Act.is_additional_mem e.action

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -511,7 +511,7 @@ end = struct
       [("inv-domain",inv_domain_act); ("alias",alias_act);]
     else []
 
-  let arch_dirty =
+  let arch_dirty = (* To be deprecated *)
     if kvm then
       let open DirtyBit in
       let check_pred f d  =

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -526,6 +526,7 @@ end = struct
           (match get_pteval act with
           | None -> false
           | Some pteval -> f d pteval) in
+
       let read_only =
         check_pred
           (fun t p ->
@@ -533,14 +534,13 @@ end = struct
             (p.af=1 || p.af=0 && t.my_ha ()) &&
             (p.db=0 && (not (t.my_hd ()) || p.dbm=0)))
 
-      and read_write =
+      and _read_write =
         check_pred
           (fun t p ->
             let open PTEVal in
             (p.af=1 || (p.af=0 && t.my_ha ())) &&
             (p.db=1 || (p.db=0 && p.dbm=1 && t.my_hd ()))) in
-      ["ReadOnly",read_only;
-       "ReadWrite",read_write;]
+      ["ReadOnly",read_only;]
     else []
 
   let is_isync act = match act with

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -314,8 +314,8 @@ module Make
              E.Act.arch_sets) in
       let m = (* To be deprecated *)
         if kvm then
-          let nexps = match I.get_set m "NExp" with
-            | Some nexps -> nexps
+          let mevt = match I.get_set m "M" with
+            | Some mevt -> mevt
             | None -> (* Must exists *) assert false in
           I.add_sets m
             (List.map
@@ -334,7 +334,7 @@ module Make
                        (* Init writes have no proc, but there are no loads *)
                        | None -> assert false
                        end)
-                     (Lazy.force nexps)
+                     (Lazy.force mevt)
                  end)
                E.Act.arch_dirty)
         else m in

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -114,6 +114,10 @@ module Make
       | Some v1,Some v2 -> S.A.V.compare v1 v2 = 0
       | _ -> false
 
+      let same_oa e1 e2 = match S.E.value_of e1,S.E.value_of e2 with
+        | Some (S.A.V.Val c1),Some (S.A.V.Val c2) -> Constant.same_oa c1 c2
+        | _ -> false
+
     end
 
     module I = Interpreter.Make(IConfig)(S)(IUtils)

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -328,11 +328,10 @@ module Make
                      { my_ha; my_hd; } in
                    E.EventSet.filter
                      (fun e ->
-                       E.is_load e &&
                        begin match E.proc_of e with
                        | Some proc -> a (tr_proc proc) e.E.action
-                       (* Init writes have no proc, but there are no loads *)
-                       | None -> assert false
+                       (* Init writes excluded as no proc for them *)
+                       | None -> false
                        end)
                      (Lazy.force mevt)
                  end)

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -312,7 +312,7 @@ module Make
              (fun (k,a) ->
                k,lazy (E.EventSet.filter (fun e -> a e.E.action) evts))
              E.Act.arch_sets) in
-      let m =
+      let m = (* To be deprecated *)
         if kvm then
           let nexps = match I.get_set m "NExp" with
             | Some nexps -> nexps

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -118,6 +118,19 @@ module Make
         | Some (S.A.V.Val c1),Some (S.A.V.Val c2) -> Constant.same_oa c1 c2
         | _ -> false
 
+      let writable2 =
+        let writable ha hd e = match S.E.value_of e with
+          | Some (S.A.V.Val c) -> Constant.writable ha hd c
+          | _ -> false in
+        fun e1 e2 ->
+        let p = S.E.proc_of e1 in
+        match p with
+        | None -> Warn.user_error "Init write as first argument of writable2"
+        | Some p ->
+            let open DirtyBit in
+            let ha = O.dirty.ha p and hd = O.dirty.hd p in
+            writable ha hd e1 || writable ha hd e2
+
     end
 
     module I = Interpreter.Make(IConfig)(S)(IUtils)

--- a/lib/BellInterpreter.ml
+++ b/lib/BellInterpreter.ml
@@ -63,6 +63,7 @@ module Make (C: Config) = struct
         let pp_eiid () = "eiid"
         let pp_instance () = "instance"
         let is_store () = false
+        let is_pt () = false
 
         module Ordered = struct
           type t = unit

--- a/lib/BellInterpreter.ml
+++ b/lib/BellInterpreter.ml
@@ -62,6 +62,7 @@ module Make (C: Config) = struct
         let event_compare () () = 0
         let pp_eiid () = "eiid"
         let pp_instance () = "instance"
+        let is_store () = false
 
         module Ordered = struct
           type t = unit
@@ -96,6 +97,7 @@ module Make (C: Config) = struct
           let pp _ _ _ _ = ()
           let fromto _ _ = assert false
           let same_value _ _ = assert false
+          let same_oa _ _ = assert false
         end) in
 
     let empty_test = () in

--- a/lib/BellInterpreter.ml
+++ b/lib/BellInterpreter.ml
@@ -98,6 +98,7 @@ module Make (C: Config) = struct
           let fromto _ _ = assert false
           let same_value _ _ = assert false
           let same_oa _ _ = assert false
+          let writable2 _ _ = assert false
         end) in
 
     let empty_test = () in

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -129,6 +129,10 @@ let as_virtual v = match v with
 | Symbolic (Virtual ((s,_),_)) -> Some s
 | _ -> None
 
+let is_pt v = match v with
+| Symbolic (System (PTE,_)) -> true
+| _ -> false
+
 let same_oa v1 v2 =
   let open PTEVal in
   match v1,v2 with

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -129,6 +129,12 @@ let as_virtual v = match v with
 | Symbolic (Virtual ((s,_),_)) -> Some s
 | _ -> None
 
+let same_oa v1 v2 =
+  let open PTEVal in
+  match v1,v2 with
+  | PteVal p1,PteVal p2 ->  Misc.string_eq p1.oa p2.oa
+  | _ -> false
+
 module type S =  sig
 
   module Scalar : Scalar.S

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -135,6 +135,14 @@ let same_oa v1 v2 =
   | PteVal p1,PteVal p2 ->  Misc.string_eq p1.oa p2.oa
   | _ -> false
 
+let writable ha hd v =
+  let open PTEVal in
+  match v with
+  | PteVal p ->
+      (p.af=1 || ha) && (* access allowed *)
+      (p.db=1 || (p.dbm=1 && hd)) (* write allowed *)
+  | _ -> false
+
 module type S =  sig
 
   module Scalar : Scalar.S

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -57,6 +57,7 @@ val check_sym : 'a t -> 'b t
 
 val is_virtual : 'a t -> bool
 val as_virtual : 'a t -> string option
+val is_pt : 'a t -> bool
 
 (* Those two are properties of ptevals.
    At the moment pteval are arch-independant. *)

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -57,8 +57,12 @@ val check_sym : 'a t -> 'b t
 
 val is_virtual : 'a t -> bool
 val as_virtual : 'a t -> string option
-val same_oa : 'a t -> 'a t -> bool
 
+(* Those two are properties of ptevals.
+   At the moment pteval are arch-independant. *)
+val same_oa : 'a t -> 'a t -> bool
+val writable : bool -> bool -> 'a t -> bool
+  
 module type S =  sig
 
   module Scalar : Scalar.S

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -57,6 +57,7 @@ val check_sym : 'a t -> 'b t
 
 val is_virtual : 'a t -> bool
 val as_virtual : 'a t -> string option
+val same_oa : 'a t -> 'a t -> bool
 
 module type S =  sig
 

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -53,6 +53,7 @@ module type SimplifiedSem = sig
     val pp_eiid : event -> string
     val pp_instance : event -> string
     val is_store : event -> bool
+    val is_pt : event -> bool
 
     module EventSet : MySet.S
     with type elt = event
@@ -1145,7 +1146,7 @@ module Make
           let ws =
             E.EventSet.filter
               (fun w ->
-                E.is_store w &&
+                E.is_store w && E.is_pt w &&
                 begin let p =
                   match E.EventSet.as_singleton (E.EventRel.M.succs w m) with
                   | Some p -> p


### PR DESCRIPTION
Add two Cat primitives, in order to implement one of the conditions requiring break-before-make. 

#### Using break-before-make when updating translation table entries
...
- A change of the output address (OA), if the OA of at least one of the old translation table entries and the new translation table entry is writable.
...