### PR TITLE
[build] Mirror Dune and OCamlBuild configs

### DIFF
--- a/defs.sh
+++ b/defs.sh
@@ -1,15 +1,27 @@
 set -o errexit
 
-HERD="herd.native"
-LITMUS="litmus.native klitmus.native"
-TOOLS="mfind.native moutcomes.native splitcond.native mshowhashes.native mlog2cond.native mflags.native mdiag.native recond.native mcycles.native mmixer.native knames.native mdiff.native mcmp.native madd.native mtopos.native mfilter.native mapply.native mcompare.native mhash.native mrcu.native mprog.native mnames.native ksort.native mobserved.native msort.native msum.native mselect.native mcond.native mproj.native rehash.native splitdot.native mlock.native mtrue.native mlisa2c.native cat2html.native mlog2name.native mcat2includes.native"
-GEN="readRelax.native atoms.native diycross.native mexpand.native atomize.native diyone.native nexts.native classify.native diy.native norm.native"
-JINGLE="jingle.native gen_theme.native"
+# Extract binary names from dune files.
+binaries_of_dune () {
+  local readonly kind="${1}"; shift
+  local readonly dune_file="${1}"; shift
+  for bin in $(internal/binaries_of_dune "${kind}" "${dune_file}")
+  do
+    echo "${bin}.native"
+  done
+}
+
+HERD="$(binaries_of_dune executables herd/dune)"
+LITMUS="$(binaries_of_dune executables litmus/dune)"
+TOOLS="$(binaries_of_dune executables tools/dune)"
+GEN="$(binaries_of_dune executables gen/dune)"
+JINGLE="$(binaries_of_dune executables jingle/dune)"
+
 NATIVE="$HERD $LITMUS $TOOLS $GEN $JINGLE"
 
 # Internal-only, not installed.
-INTERNAL="herd_regression_test.native herd_diycross_regression_test.native"
-TESTS="base_test.native channel_test.native command_test.native compare_test.native filesystem_test.native test_test.native ocamlString_test.native shelf_test.native uint_test.native"
+INTERNAL="$(binaries_of_dune executables internal/dune)"
+
+TESTS="$(find . -name 'dune' | while read f; do binaries_of_dune tests "${f}"; done)"
 
 mk_exe () {
   D=$1

--- a/internal/binaries_of_dune
+++ b/internal/binaries_of_dune
@@ -1,0 +1,54 @@
+#!/usr/bin/env ocaml
+
+#use "lib/sexp.ml";;
+
+let string_of_atom sexp =
+  match sexp with
+  | Atom s -> s
+  | _ -> failwith "expected Atom"
+
+let field_values name sexp =
+  match sexp with
+  | List (Atom name' :: values) ->
+      if String.compare name name' = 0 then
+        values
+      else
+        []
+  | _ -> []
+
+let nested_field_values key subkey stanza = stanza |> field_values key |> List.map (field_values subkey) |> List.concat
+
+let binaries_of_dune key keys dune =
+  match dune with
+  | List stanzas ->
+      let key_name = List.map (nested_field_values key "name") stanzas in
+      let keys_names = List.map (nested_field_values keys "names") stanzas in
+
+      let all_names = key_name @ keys_names in
+      all_names |> List.concat |> List.map string_of_atom
+  | _ -> failwith "expected List of stanzas"
+
+let usage = String.concat "\n" [
+  Printf.sprintf "Usage: %s (executables|tests) <path/to/dune>" Sys.argv.(0) ;
+  "" ;
+  " executables  Prints executable names from a Dune file," ;
+  "              e.g. (executables (names ...)) or (executable (name ...))." ;
+  "" ;
+  " tests        Prints test names from a Dune file," ;
+  "              e.g. (tests (names ...)) or (test (name ...))." ;
+]
+
+let () =
+  if Array.length Sys.argv <> 3 then begin
+    Printf.printf "%s\n" usage ;
+    exit 1
+  end ;
+  let key, keys =
+    match Sys.argv.(1) with
+    | "tests" -> "test", "tests"
+    | "executables" -> "executable", "executables"
+    | s -> failwith (Printf.sprintf "unknown kind: %s" s)
+  in
+  let path = Sys.argv.(2) in
+  let dune = of_dune_file path in
+  dune |> binaries_of_dune key keys |> List.iter (Printf.printf "%s\n")

--- a/internal/lib/sexp.ml
+++ b/internal/lib/sexp.ml
@@ -1,0 +1,117 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* jade alglave, university college london, uk.                             *)
+(* luc marange_inclusivet, inria paris-rocquencourt, france.                *)
+(*                                                                          *)
+(* copyright 2010-present institut national de recherche en informatique et *)
+(* en automatique and the authors. all rights reserved.                     *)
+(*                                                                          *)
+(* this software is governed by the cecill-b license under french law and   *)
+(* abiding by the rules of distribution of free software. you can use,      *)
+(* modify and/ or redistribute the software under the terms of the cecill-b *)
+(* license as circulated by cea, cnrs and inria at the following url        *)
+(* "http://www.cecill.info". we also give a copy in license.txt.            *)
+(****************************************************************************)
+
+(** An S-expression type, parser, and Dune-specific parser. *)
+
+(* NOTE: Because this is used by scripts run with the OCaml top-level, it MUST
+ * NOT depend on any code from outside this file. *)
+
+exception ParseError of string
+
+type t =
+  | Atom of string
+  | List of t list
+
+let compare x y =
+  let rec compare_sexp x y =
+    match x, y with
+    | Atom x, Atom y -> String.compare x y
+    | Atom _, List _ -> -1
+    | List _, Atom _ -> 1
+    | List xs, List ys -> compare_sexp_list xs ys
+  and compare_sexp_list xs ys =
+    match xs, ys with
+    | [], [] -> 0
+    | [], _ -> -1
+    | _, [] -> 1
+    | x :: xs, y :: ys ->
+        match compare_sexp x y with
+        | 0 -> compare_sexp_list xs ys
+        | n -> n
+  in
+  compare_sexp x y
+
+let rec to_string sexp =
+  match sexp with
+  | Atom s -> s
+  | List sexps ->
+      let subexps = List.map to_string sexps in
+      Printf.sprintf "(%s)" (String.concat " " subexps)
+
+
+(* Parser. *)
+
+let from_dune_channel chan =
+  (* This parser is written by hand because this module is used by a script run
+   * with the OCaml top-level, and so cannot have any compilation steps, and so
+   * cannot use ocamllex/etc. *)
+
+  let printable c =
+    match c with
+    | '0' .. '9' | 'a' .. 'z' | 'A' .. 'Z' | '_' | '-' | '+' | ':' | '.' | '/' -> true
+    | _ -> false
+  in
+  let stream = Stream.of_channel chan in
+  let junk () = Stream.junk stream in
+  let peek () = Stream.peek stream in
+
+  let unexpected_character c =
+    ParseError (Printf.sprintf "Unexpected character %c at char %i" c (Stream.count stream))
+  in
+
+  let rec whitespace () =
+    match peek () with
+    | Some ' ' | Some '\t' | Some '\n' | Some '\r' -> junk () ; whitespace ()
+    | _ -> ()
+  in
+  let atom () =
+    let buf = Buffer.create 16 in
+    let rec atom' () =
+      match peek () with
+      | Some c when printable c -> junk () ; Buffer.add_char buf c ; atom' ()
+      | _ -> Atom (Buffer.contents buf)
+    in
+    atom' ()
+  in
+  let rec list (acc : t list) =
+    whitespace () ;
+    match peek () with
+    | None -> raise (ParseError "Unexpected end of input")
+    | Some '(' -> junk () ; list ((list []) :: acc)
+    | Some ')' -> junk () ; List (List.rev acc)
+    | Some c when printable c -> list ((atom ()) :: acc)
+    | Some c ->
+        raise (unexpected_character c)
+  in
+  let rec dune_file (acc : t list) =
+    whitespace () ;
+    match peek () with
+    | None -> List (List.rev acc)
+    | Some '(' -> junk () ; dune_file ((list []) :: acc)
+    | Some c when printable c -> dune_file ((atom ()) :: acc)
+    | Some c ->
+        raise (unexpected_character c)
+  in
+  dune_file []
+
+let of_dune_file path =
+  let ch = open_in path in
+  let dune =
+    try
+      from_dune_channel ch
+    with e -> close_in ch ; raise e
+  in
+  close_in ch ; dune

--- a/internal/lib/sexp.mli
+++ b/internal/lib/sexp.mli
@@ -1,0 +1,33 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** An S-expression type, parser, and Dune-specific parser. *)
+
+exception ParseError of string
+
+type t =
+  | Atom of string
+  | List of t list
+
+val compare : t -> t -> int
+
+val to_string : t -> string
+
+(** [of_dune_file path] reads the Dune configuration file at [path].
+ *  It is a special case of S-expression, because the Dune file itself is an
+ *  implicit [List].
+ *  [of_dune_file] can raise [ParseError]. *)
+val of_dune_file : string -> t

--- a/internal/lib/tests/dune
+++ b/internal/lib/tests/dune
@@ -1,5 +1,5 @@
 (tests
  (names base_test channel_test command_test compare_test filesystem_test
-   ocamlString_test shelf_test test_test)
+   ocamlString_test sexp_test shelf_test test_test)
  (libraries internal_lib unix)
  (modes native))

--- a/internal/lib/tests/sexp_test.ml
+++ b/internal/lib/tests/sexp_test.ml
@@ -1,0 +1,77 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+let tests = [
+  "Sexp.of_dune_file", (fun () ->
+    let dune o =
+      Printf.fprintf o "(tests" ;
+      Printf.fprintf o "  (names a_test b_test)" ;
+      Printf.fprintf o "  (libraries lib))" ;
+      close_out o
+    in
+
+    let expected = let open Sexp in
+      List [
+        List [Atom "tests" ;
+          List [Atom "names"; Atom "a_test"; Atom "b_test"] ;
+          List [Atom "libraries"; Atom "lib"] ;
+        ]
+      ]
+    in
+
+    let tmp_file = Filename.temp_file "" "" in
+    Filesystem.write_file tmp_file dune ;
+
+    let actual = Sexp.of_dune_file tmp_file in
+    Sys.remove tmp_file ;
+
+    if Sexp.compare expected actual <> 0 then
+      Test.fail (Printf.sprintf "expected %s, got %s"
+        (Sexp.to_string expected)
+        (Sexp.to_string actual)
+      )
+  );
+
+  "Sexp_of_dune_file raises on bad input", (fun () ->
+    let bad_dunes = [
+      (fun o ->
+        Printf.fprintf o "(tests" ;
+        close_out o
+      );
+      (fun o ->
+        Printf.fprintf o "tests)" ;
+        close_out o
+      );
+    ] in
+
+    List.iteri (fun i bad_dune ->
+      let tmp_file = Filename.temp_file "" "" in
+      Filesystem.write_file tmp_file bad_dune ;
+
+      let raised_exception =
+        try
+          ignore (Sexp.of_dune_file tmp_file); false
+        with Sexp.ParseError _ -> true
+      in
+
+      Sys.remove tmp_file ;
+      if not raised_exception then
+        Test.fail (Printf.sprintf "[%i] expected exception, did not raise" i)
+    ) bad_dunes
+  );
+]
+
+let () = Test.run tests


### PR DESCRIPTION
**Summary**: Replace manual lists in `defs.sh` with a new script that reads from Dune files, `binaries_of_dune`.

Currently, there are two places that binaries are defined:

- For Dune, they are in a given directory's `dune` file.
- For OCamlBuild, they are in `defs.sh`.

These two sources of truth have become out-of-sync before (commit e2837555c73417ac9f207c863298ccbf7890be16, PR #63), and as more tests are added to the project, the risk of error increases.

This commit makes OCB use Dune files as the single source of truth. To do this, this PR:

- Adds a module `Sexp`, to parse Dune files (and other S-expressions).
- Adds tests for `Sexp`.
- Adds a binary `binaries_of_dune` to extract executables and tests from Dune files. To avoid bootstrapping issues from the need for compilation, this binary is a script run with the OCaml top-level.
- Modifies the manual lists of binaries in `defs.sh` with shell functions that call `binaries_of_dune`.

I have tested this on my machine with OCaml 4.05 & 4.11.1, running `make test D=ocb` and `make install D=ocb`.

AFAICT, there is no way to use a module in the OCaml top-level without compiling to bytecode, so instead I have used `#use`, a textual import.
