### PR TITLE
[test] Run `dune runtest` with --profile=release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test:: $(D)-test
 
 dune-test:
 	@ echo
-	dune runtest
+	dune runtest --profile=release
 
 ocb-test:
 	@ echo


### PR DESCRIPTION
This builds the test binaries with the same profile as `make build`, which stops Dune from rebuilding them, resulting in faster pre-commits.
