### PR TITLE
Add free-form attributes (e.g., cacheability, shareability, etc) to the PTE

### DIFF
--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -122,6 +122,9 @@ end = struct
 
   let is_PA_val _ = false
 
+  (* Unimplemented *)
+  let is_implicit_pte_read _ = assert false
+
   let is_atomic a = match a with
   | Access (_,_,_,true,_,_) ->
       assert (is_mem a); true

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -183,6 +183,9 @@ end = struct
 
   let is_PA_val _ = false
 
+  (* Unimplemented *)
+  let is_implicit_pte_read _ = assert false
+
         (* The following definition of is_atomic
            is quite arbitrary. *)
 

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -65,6 +65,7 @@ module type S = sig
   val get_mem_dir : action -> Dir.dirn
   val get_mem_size : action -> MachSize.sz
   val is_PA_val : A.V.v -> bool
+  val is_implicit_pte_read : action -> bool
 
 (* relative to the registers of the given proc *)
   val is_reg_store : action -> A.proc -> bool

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -339,6 +339,10 @@ end = struct
         end
   | Some _,Some _ -> Warn.fatal "No Amo action on pteval"
 
+  let is_implicit_pte_read = function
+  | Access (R,_,_,_,_,_,A_PTE) -> true
+  | _ -> false
+
 (* relative to the registers of the given proc *)
   let is_reg_store a (p:int) = match a with
   | Access (W,A.Location_reg (q,_),_,_,_,_,_) -> p = q

--- a/lib/PTEVal.ml
+++ b/lib/PTEVal.ml
@@ -16,6 +16,24 @@
 
 open Printf
 
+module Attrs = struct
+  type t = StringSet.t
+
+  (* By default we assume the attributes of the memory malloc would
+     return on Linux. This is architecture specific, however, for now,
+     translation is supported only for AArch64. *)
+  let default =
+    List.fold_right StringSet.add
+      [ "Normal" ; "Inner-shareable"; "Inner-write-back"; "Outer-write-back" ]
+      StringSet.empty
+
+  let compare a1 a2 = StringSet.compare a1 a2
+  let eq a1 a2 = StringSet.equal a1 a2
+  let pp a = String.concat ", " (StringSet.elements a)
+  let as_list a = StringSet.elements a
+  let of_list l = StringSet.of_list l
+end
+
 type t = {
   oa : string;
   valid : int;
@@ -23,10 +41,11 @@ type t = {
   db : int;
   dbm : int;
   el0 : int;
+  attrs: Attrs.t;
   }
 
 (* For ordinary tests not to fault, the dirty bit has to be set. *)
-let prot_default =  { oa=""; valid=1; af=1; db=1; dbm=0; el0=1;}
+let prot_default =  { oa=""; valid=1; af=1; db=1; dbm=0; el0=1; attrs=Attrs.default; }
 let default s = { prot_default with  oa=Misc.add_physical s; }
 
 let pp_field ok pp eq ac p k =
@@ -38,12 +57,14 @@ and pp_af ok = pp_int_field ok "af" (fun p -> p.af)
 and pp_db ok = pp_int_field ok "db" (fun p -> p.db)
 and pp_dbm ok = pp_int_field ok "dbm" (fun p -> p.dbm)
 and pp_el0 ok = pp_int_field ok "el0" (fun p -> p.el0)
+and pp_attrs ok = pp_field ok (fun a -> Attrs.pp a) Attrs.eq (fun p -> p.attrs)
 
 let set_oa p s = { p with oa = Misc.add_physical s; }
 
 let is_default t =
   let d = prot_default in
-  t.valid=d.valid && t.af=d.af && t.db=d.db && t.dbm=d.dbm && t.el0=d.el0
+  t.valid=d.valid && t.af=d.af && t.db=d.db && t.dbm=d.dbm && t.el0=d.el0 &&
+    t.attrs=Attrs.default
 
 (* If showall is true, field will always be printed.
    Otherwise, field will be printed only if non-default.
@@ -51,7 +72,8 @@ let is_default t =
    (1) Fields older than el0 are always printed.
    (2) Fields from el0 (included) are printed if non-default. *)
 let do_pp showall p =
-  let k = pp_el0 false p [] in
+  let k = pp_attrs false p [] in
+  let k = pp_el0 false p k in
   let k = pp_valid showall p k in
   let k = pp_dbm showall p k in
   let k = pp_db showall p k in
@@ -71,18 +93,25 @@ let my_int_of_string s v =
     _ -> Warn.user_error "PTE field %s should be an integer" s
   in v
 
+type pte_prop =
+  | KV of (string * string)
+  | Attrs of string list
+
 let do_of_list p l =
-
-  let add_field a (s,v) = match s with
-  | "oa" -> { a with oa = v }
-  | "af" -> { a with af = my_int_of_string s v }
-  | "db" -> { a with db = my_int_of_string s v }
-  | "dbm" -> { a with dbm = my_int_of_string s v }
-  | "valid" -> { a with valid = my_int_of_string s v }
-  | "el0" -> { a with el0 = my_int_of_string s v }
-  | _ ->
-      Warn.user_error "Illegal PTE property %s" s in
-
+  let add_field a v = match v with
+    | KV (s, v) -> begin
+        match s with
+        | "oa" -> { a with oa = v }
+        | "af" -> { a with af = my_int_of_string s v }
+        | "db" -> { a with db = my_int_of_string s v }
+        | "dbm" -> { a with dbm = my_int_of_string s v }
+        | "valid" -> { a with valid = my_int_of_string s v }
+        | "el0" -> { a with el0 = my_int_of_string s v }
+        | _ ->
+           Warn.user_error "Illegal PTE property %s" s
+      end
+    | Attrs l -> { a with attrs = Attrs.of_list l }
+  in
   let rec of_list a = function
     | [] -> a
     | h::t -> of_list (add_field a h) t in
@@ -108,6 +137,8 @@ let compare =
     lex_compare (fun p1 p2 -> Misc.int_compare p1.af p2.af) cmp in
   let cmp =
     lex_compare (fun p1 p2 -> String.compare p1.oa p2.oa) cmp in
+  let cmp =
+    lex_compare (fun p1 p2 -> Attrs.compare p1.attrs p2.attrs) cmp in
   cmp
 
 let eq p1 p2 =
@@ -116,4 +147,5 @@ let eq p1 p2 =
   Misc.int_eq p1.db p2.db &&
   Misc.int_eq p1.dbm p2.dbm &&
   Misc.int_eq p1.valid p2.valid &&
-  Misc.int_eq p1.el0 p2.el0
+  Misc.int_eq p1.el0 p2.el0 &&
+  Attrs.eq p1.attrs p2.attrs

--- a/lib/PTEVal.mli
+++ b/lib/PTEVal.mli
@@ -16,6 +16,16 @@
 
 (** Abstraction of page table entry (PTE) *)
 
+module Attrs : sig
+  type t
+  val default : t
+  val compare : t -> t -> int
+  val eq : t -> t -> bool
+  val pp : t -> string
+  val as_list : t -> string list
+  val of_list : string list -> t
+end
+
 type t = {
   oa : string;
   valid : int;
@@ -23,6 +33,7 @@ type t = {
   db : int;
   dbm : int;
   el0 : int;
+  attrs : Attrs.t;
   }
 
 (* Default value *)
@@ -34,11 +45,15 @@ val set_oa : t -> string -> t
 (* Flags have default values *)
 val is_default : t -> bool
 
+type pte_prop =
+| KV of (string * string)
+| Attrs of string list
+
 (* Create fresh pteval *)
 (* With physical adress *)
-val of_list : string -> (string * string) list -> t
+val of_list : string -> pte_prop list -> t
 (* Without physcal adress *)
-val of_list0 : (string * string) list -> t
+val of_list0 : pte_prop list -> t
 
 (* Pretty print *)
 val pp : t -> string  (* Default field not printed *)

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -123,4 +123,4 @@ val get_info_on_info : string -> (string * string) list -> string option
 
 val get_info :  ('i, 'p, 'c, 'loc, 'v) result -> string -> string option
 
-val mk_pte_val : location -> (string * string) list -> 'b Constant.t
+val mk_pte_val : location -> (PTEVal.pte_prop) list -> 'b Constant.t

--- a/lib/stateLexer.mll
+++ b/lib/stateLexer.mll
@@ -66,6 +66,7 @@ rule token = parse
 | "locations" { LOCATIONS }
 | "filter" { FILTER }
 | "fault"|"Fault" { FAULT }
+| "attrs"|"Attrs" { ATTRS }
 (* Typing *)
 | "_Atomic" { ATOMIC }
 | "ATOMIC_INIT" { ATOMICINIT }

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -38,6 +38,7 @@ let mk_lab p s = Label (p,s)
 %token LBRK RBRK LPAR RPAR SEMI COLON AMPER COMMA
 %token ATOMIC
 %token ATOMICINIT
+%token ATTRS
 
 %token PTX_REG_DEC
 %token <string> PTX_REG_TYPE
@@ -78,10 +79,11 @@ reg:
 
 name_or_num:
 | NAME { $1 }
-| NUM { $1 };
+| NUM { $1 }
 
 maybev_prop:
-| separated_pair(NAME, COLON, name_or_num) { $1 };
+| separated_pair(NAME, COLON, name_or_num) { PTEVal.KV $1 }
+| ATTRS COLON LPAR separated_nonempty_list(COMMA, NAME) RPAR { PTEVal.Attrs $4 }
 
 pteval:
 | LPAR separated_nonempty_list(COMMA, maybev_prop) RPAR

--- a/litmus/libdir/_aarch64/kvm-headers.h
+++ b/litmus/libdir/_aarch64/kvm-headers.h
@@ -94,14 +94,14 @@ static inline pteval_t litmus_set_pte_flags(pteval_t old,pteval_t flags) {
 /* set 'global' PTE attributes */
 
 typedef enum
-  {attr_normal, attr_write_2D_through,
-   attr_write_2D_back, attr_non_2D_cacheable,
-   attr_device,
-   attr_nGnRnE,attr_nGnRE,
-   attr_nGRE,attr_GRE,
-   attr_rNsh,attr_rIsh,attr_rOsh,
-   /* attr_rSy, ?? */
-   /*   attr_peripherical, LM:?? */
+  { attr_Normal, attr_Inner_2D_write_2D_through,
+    attr_Inner_2D_write_2D_back, attr_Inner_2D_non_2D_cacheable,
+    attr_Outer_2D_write_2D_through,
+    attr_Outer_2D_write_2D_back, attr_Outer_2D_non_2D_cacheable,
+    attr_Device,
+    attr_NGnRnE,attr_NGnRE,
+    attr_NGRE,attr_GRE,
+    attr_Non_2D_shareable,attr_Inner_2D_shareable,attr_Outer_2D_shareable,
   } pte_attr_key;
 
 /* Act on SH[1:0] ie bits [9:8] */
@@ -116,22 +116,24 @@ static inline pteval_t litmus_set_memattr(pteval_t old,pteval_t memattr) {
 
 static inline void litmus_set_pte_attribute(pteval_t *p,pte_attr_key k) {
   switch (k) {
-  case attr_rNsh:
+  case attr_Non_2D_shareable:
     *p = litmus_set_sh(*p,0) ;
     break;
-  case attr_rIsh:
+  case attr_Inner_2D_shareable:
     *p = litmus_set_sh(*p,3) ;
     break;
-  case attr_rOsh:
+  case attr_Outer_2D_shareable:
     *p = litmus_set_sh(*p,2) ;
     break;
   /* For cacheability, set inner-cacheability only,
      is always non-cacheabke */
-  case attr_normal:
-  case attr_write_2D_back:
+  case attr_Normal:
+  case attr_Inner_2D_write_2D_back:
+  case attr_Outer_2D_write_2D_back:
     *p = litmus_set_memattr(*p, MT_NORMAL);
     break;
-  case attr_write_2D_through:
+  case attr_Inner_2D_write_2D_through:
+  case attr_Outer_2D_write_2D_through:
 #ifdef MT_NORMAL_WT
     *p = litmus_set_memattr(*p, MT_NORMAL_WT);
 #else
@@ -139,17 +141,18 @@ static inline void litmus_set_pte_attribute(pteval_t *p,pte_attr_key k) {
     *p = litmus_set_memattr(*p, MT_NORMAL_NC);
 #endif
     break;
-  case attr_non_2D_cacheable:
+  case attr_Inner_2D_non_2D_cacheable:
+  case attr_Outer_2D_non_2D_cacheable:
     *p = litmus_set_memattr(*p, MT_NORMAL_NC);
     break;
-  case attr_device:
-  case attr_nGnRE:
+  case attr_Device:
+  case attr_NGnRE:
     *p = litmus_set_memattr(*p, MT_DEVICE_nGnRE);
     break;
-  case attr_nGnRnE:
+  case attr_NGnRnE:
     *p = litmus_set_memattr(*p, MT_DEVICE_nGnRnE);
     break;
-  case attr_nGRE:
+  case attr_NGRE:
 #ifdef MT_DEVICE_nGRE
     *p = litmus_set_memattr(*p, MT_DEVICE_nGRE);
 #else

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1231,7 +1231,12 @@ module Make
                         | None -> sprintf "_vars->saved_pte_%s" x
                         | Some s -> sprintf "_vars->saved_pte_%s" s in
                         O.fii "*_vars->pte_%s = %s;"
-                          x (SkelUtil.dump_pteval_flags arg pteval)
+                          x (SkelUtil.dump_pteval_flags arg pteval);
+                        List.iter
+                          (fun attr ->
+                            let attr = sprintf "attr_%s" (MyName.name_as_symbol attr) in
+                            O.fii "litmus_set_pte_attribute(_vars->pte_%s, %s);"
+                              x attr) (PTEVal.Attrs.as_list pteval.PTEVal.attrs)
                       end
                   end ;
                   true


### PR DESCRIPTION
This series of patches adds support for specifying attributes in the PTE. The motivation is to use to specify cacheability and shareability attributes. For example:

`pte_x = (oa:phy_y,af:1,db:0,dbm:0,attrs:(Normal,Inner-shareable,Inner-write-back,Outer-write-back))`

These attributes are used to annotate Access Actions and the corresponding events. They are also exposed to cat and enable rules that use these annotations.

These annotations are more of a free-form list of strings, without any specific rules of what these strings can be, to allow different architectures to express their own.