### PR TITLE
[internal_lib] Unify Command.run* into a single Command.run

### DIFF
--- a/internal/lib/base.ml
+++ b/internal/lib/base.ml
@@ -17,6 +17,26 @@
 (** Extending built-in / base modules, either to port future features into
  *  earlier versions of OCaml, or to add extra functionality. *)
 
+module Fun = struct
+  exception Finally_raised of exn
+
+  let protect ~finally f =
+    let finally' () =
+      try finally ()
+      with e -> raise (Finally_raised e)
+    in
+    let ret =
+      try
+        f ()
+      with e -> begin
+        finally' () ;
+        raise e
+      end
+    in
+    finally' () ;
+    ret
+end
+
 module List = struct
   include List
 
@@ -36,6 +56,11 @@ end
 
 module Option = struct
   type 'a t = 'a option
+
+  let get o =
+    match o with
+    | None -> invalid_arg "option is None"
+    | Some v -> v
 
   let compare cf a b =
     match a, b with

--- a/internal/lib/base.mli
+++ b/internal/lib/base.mli
@@ -17,6 +17,20 @@
 (** Extending built-in / base modules, either to port future features into
  *  earlier versions of OCaml, or to add extra functionality. *)
 
+module Fun : sig
+  (** [Finally_raised e] is raised by [protect ~finally f] if [~finally] raises
+   *  an exception [e], to disambiguate it from exceptions raised by [f].
+   *  If [Finally_raised] is raised, it is either an unexpected exception (e.g.
+   *  [Out_of_memory]), or programmer error. *)
+  exception Finally_raised of exn
+
+  (** [protect ~finally f] calls [f], then calls [~finally]. If [f] raises an
+   *  exception [e], it calls [~finally] before re-raising [e]. If [~finally]
+   *  raises an exception [e], [e] is re-raised as [Finally_raised e].
+   *  It is equivalent to [Fun.protect] from OCaml >= 4.08. *)
+  val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
+end
+
 module List : sig
   include module type of List
 
@@ -42,6 +56,10 @@ end
 
 module Option : sig
   type 'a t = 'a option
+
+  (** [get o] is [v] if [o] is [Some v].
+   *  It raises [Invalid_argument] if [o] is [None]. *)
+  val get : 'a t -> 'a
 
   (** [compare c x y] compares [x] and [y]. [None] is smaller than [Some _]. If
    *  they are both [Some _] their elements are compared with function [c]. *)

--- a/internal/lib/command.ml
+++ b/internal/lib/command.ml
@@ -16,6 +16,9 @@
 
 (** Utilities for running commands. *)
 
+module Fun = Base.Fun
+module Option = Base.Option
+
 exception Error of string
 
 let command bin args =
@@ -23,29 +26,74 @@ let command bin args =
   | [] -> (Filename.quote bin)
   | _ -> Printf.sprintf "%s %s" (Filename.quote bin) (String.concat " " (List.map Filename.quote args))
 
-let run bin args =
-  let cmd = command bin args in
-  match Sys.command cmd with
-  | 0 -> ()
-  | n -> raise (Error (Printf.sprintf "Process returned error code %i" n))
 
-let run_with_stdout bin args f =
-  let cmd = command bin args in
-  let stdout = Unix.open_process_in cmd in
-  let ret = f stdout in
-  match Unix.close_process_in stdout with
-  | Unix.WEXITED 0 -> ret
+let run ?stdin:in_f ?stdout:out_f ?stderr:err_f bin args =
+  (* Notes:
+   * - By default, the file descriptors are Unix.stdin, Unix.stdout, Unix.stderr,
+   *   and the {in,out,err}_f and close_{in,out,err}_pipe functions are all nops.
+   * - If the user passed us a function, the corresponding file descriptor is
+   *   one side of a pipe, and the close_*_pipe function closes the other side.
+   * - Communication pipes need to be marked ~cloexec:true.
+   * - We need to close our side of each pipe once the subprocess has started.
+   *)
+  let nop _ = () in
+
+  let in_pipe () =
+    let in_fd, out_fd = Unix.pipe ~cloexec:true () in
+    out_fd, Unix.in_channel_of_descr in_fd
+  in
+  let out_pipe () =
+    let in_fd, out_fd = Unix.pipe ~cloexec:true () in
+    in_fd, Unix.out_channel_of_descr out_fd
+  in
+
+  let in_fd, in_f, close_in_pipe =
+    match in_f with
+    | None -> Unix.stdin, nop, nop
+    | Some f ->
+        let fd, o = out_pipe () in
+        fd, (fun _ -> Unix.close fd ; f o), (fun _ -> close_out o)
+  in
+  let out_fd, out_f, close_out_pipe =
+    match out_f with
+    | None -> Unix.stdout, nop, nop
+    | Some f ->
+        let fd, i = in_pipe () in
+        fd, (fun _ -> Unix.close fd ; f i), (fun _ -> close_in i)
+  in
+  let err_fd, err_f, close_err_pipe =
+    match err_f with
+    | None -> Unix.stderr, nop, nop
+    | Some f ->
+        let fd, i = in_pipe () in
+        fd, (fun _ -> Unix.close fd ; f i), (fun _ -> close_in i)
+  in
+
+  let pid =
+    Fun.protect
+      ~finally:(fun _ -> close_in_pipe () ; close_out_pipe () ; close_err_pipe ())
+      (fun _ ->
+        let pid = Unix.create_process bin (Array.of_list (bin :: args)) in_fd out_fd err_fd in
+        in_f () ;
+        out_f () ;
+        err_f () ;
+        pid
+      )
+  in
+  let _, status = Unix.waitpid [] pid in
+  match status with
+  | Unix.WEXITED 0 -> ()
   | Unix.WEXITED n -> raise (Error (Printf.sprintf "Process returned error code %i" n))
   | Unix.WSIGNALED n -> raise (Error (Printf.sprintf "Process was killed by signal %i" n))
   | Unix.WSTOPPED n -> raise (Error (Printf.sprintf "Process was stopped by signal %i" n))
 
-let run_with_stdin_and_stdout bin args in_f out_f =
-  let cmd = command bin args in
-  let stdout, stdin = Unix.open_process cmd in
-  in_f stdin ;
-  let ret = out_f stdout in
-  match Unix.close_process (stdout, stdin) with
-  | Unix.WEXITED 0 -> ret
-  | Unix.WEXITED n -> raise (Error (Printf.sprintf "Process returned error code %i" n))
-  | Unix.WSIGNALED n -> raise (Error (Printf.sprintf "Process was killed by signal %i" n))
-  | Unix.WSTOPPED n -> raise (Error (Printf.sprintf "Process was stopped by signal %i" n))
+
+let run_with_stdout ?(stdin = unset_in) bin args f =
+  let ret = ref None in
+  let f' a = ret := Some (f a) in
+  run ~stdin:stdin ~stdout:f' bin args ;
+  Option.get !ret
+
+
+let run_with_stdin_and_stdout bin args f g =
+  run_with_stdout ~stdin:f bin args g

--- a/internal/lib/command.ml
+++ b/internal/lib/command.ml
@@ -86,14 +86,3 @@ let run ?stdin:in_f ?stdout:out_f ?stderr:err_f bin args =
   | Unix.WEXITED n -> raise (Error (Printf.sprintf "Process returned error code %i" n))
   | Unix.WSIGNALED n -> raise (Error (Printf.sprintf "Process was killed by signal %i" n))
   | Unix.WSTOPPED n -> raise (Error (Printf.sprintf "Process was stopped by signal %i" n))
-
-
-let run_with_stdout ?(stdin = unset_in) bin args f =
-  let ret = ref None in
-  let f' a = ret := Some (f a) in
-  run ~stdin:stdin ~stdout:f' bin args ;
-  Option.get !ret
-
-
-let run_with_stdin_and_stdout bin args f g =
-  run_with_stdout ~stdin:f bin args g

--- a/internal/lib/command.mli
+++ b/internal/lib/command.mli
@@ -31,18 +31,3 @@ val run :
   ?stdin:(out_channel -> unit) ->
   ?stdout:(in_channel -> unit) ->
   ?stderr:(in_channel -> unit) -> string -> string list -> unit
-
-(** [run_with_stdout ~stdin bin args f] runs the binary [bin] with arguments
- *  [args], optionally applies [~stdin] to the process's stdin, and applies
- *  function [f] the process's stdout, returning the result.
- *  It raises [Error] on error or non-zero exit code.
- *  This function is DEPRECATED: please use [run]. *)
-val run_with_stdout :
-  ?stdin:(out_channel -> unit) ->
-    string -> string list -> (in_channel -> 'a) -> 'a
-
-(** [run_with_stdin_and_stdout bin args f g] runs the binary [bin] with
- *  arguments [args], applies [f] to the process's stdin, returns the result of
- *  applying [g] to the process's stdout.
- *  This function is DEPRECATED: please use [run]. *)
-val run_with_stdin_and_stdout : string -> string list -> (out_channel -> unit) -> (in_channel -> 'a) -> 'a

--- a/internal/lib/command.mli
+++ b/internal/lib/command.mli
@@ -22,15 +22,27 @@ exception Error of string
  *  binary [bin] with arguments [args]. *)
 val command : string -> string list -> string
 
-(** [run bin args] runs the binary [bin] with arguments [args].
- *  It raises Error on error or non-zero exit code. *)
-val run : string -> string list -> unit
+(** [run ~stdin ~stdout ~stderr bin args] runs the binary [bin] with arguments [args].
+ *  The optional parameters [~stdin], [~stdout], and [~stderr] are functions
+ *  that are applied to the stdin, stdout, and stderr of the command, in that
+ *  order.
+ *  It raises [Error] on error or non-zero exit code. *)
+val run :
+  ?stdin:(out_channel -> unit) ->
+  ?stdout:(in_channel -> unit) ->
+  ?stderr:(in_channel -> unit) -> string -> string list -> unit
 
-(** [run_with_stdout bin args f] runs the binary [bin] with arguments [args], and
- *  applies function [f] to the open in_channel, returning the result. *)
-val run_with_stdout : string -> string list -> (in_channel -> 'a) -> 'a
+(** [run_with_stdout ~stdin bin args f] runs the binary [bin] with arguments
+ *  [args], optionally applies [~stdin] to the process's stdin, and applies
+ *  function [f] the process's stdout, returning the result.
+ *  It raises [Error] on error or non-zero exit code.
+ *  This function is DEPRECATED: please use [run]. *)
+val run_with_stdout :
+  ?stdin:(out_channel -> unit) ->
+    string -> string list -> (in_channel -> 'a) -> 'a
 
-(** [run_with_stdout_and_stdin_lines bin args in_lines] runs the binary [bin]
-  * with arguments [args], pipes [in_lines] into the process's stdin, and returns
-  * the process's stdout as a string list. *)
+(** [run_with_stdin_and_stdout bin args f g] runs the binary [bin] with
+ *  arguments [args], applies [f] to the process's stdin, returns the result of
+ *  applying [g] to the process's stdout.
+ *  This function is DEPRECATED: please use [run]. *)
 val run_with_stdin_and_stdout : string -> string list -> (out_channel -> unit) -> (in_channel -> 'a) -> 'a

--- a/internal/lib/filesystem.ml
+++ b/internal/lib/filesystem.ml
@@ -48,6 +48,6 @@ let rec remove_recursive path =
   end
 
 let new_temp_dir () =
-  match Command.run_with_stdout "mktemp" ["-d"] Channel.read_lines with
-  | path :: [] -> path
-  | _ -> failwith "mktemp is behaving abnormally"
+  let path = ref "" in
+  Command.run ~stdout:(fun c -> path := input_line c) "mktemp" ["-d"] ;
+  !path

--- a/internal/lib/shelf.ml
+++ b/internal/lib/shelf.ml
@@ -75,9 +75,11 @@ let list_of_file path key =
     Printf.fprintf chan "  pass\n" ;
     close_out chan
   in
-  let lines = Command.run_with_stdin_and_stdout "python" [] script Channel.read_lines in
+  let lines = ref [] in
+  let read_lines c = lines := Channel.read_lines c in
+  Command.run ~stdin:script ~stdout:read_lines "python" [] ;
   (* Sorted for stability / comparability. *)
-  List.sort String.compare lines
+  List.sort String.compare !lines
 
 let string_of_file path key =
   match list_of_file path key with

--- a/internal/lib/testHerd.ml
+++ b/internal/lib/testHerd.ml
@@ -26,8 +26,10 @@ let herd_command herd libdir litmus =
   Command.command herd ["-set-libdir"; libdir; litmus]
 
 let run_herd herd libdir litmus =
-  let lines = Command.run_with_stdout herd ["-set-libdir"; libdir; litmus] Channel.read_lines in
-  without_unstable_lines lines
+  let lines = ref [] in
+  let read_lines c = lines := Channel.read_lines c in
+  Command.run ~stdout:read_lines herd ["-set-libdir"; libdir; litmus] ;
+  without_unstable_lines !lines
 
 let herd_output_matches_expected herd libdir litmus expected =
   let output = try

--- a/internal/lib/tests/command_test.ml
+++ b/internal/lib/tests/command_test.ml
@@ -137,25 +137,6 @@ let tests = [
         (StringList.to_ocaml_string actual_stderr)
       )
   );
-
-  "Command.run_with_stdout captures stdout", (fun () ->
-    let tests = [
-      ("true", [], []);
-      ("echo", ["foo"], ["foo"]);
-      ("echo", ["foo\nbar"], ["foo"; "bar"]);
-    ] in
-
-    List.iter
-      (fun (bin, args, expected) ->
-        let actual = Command.run_with_stdout bin args Channel.read_lines in
-        if StringList.compare actual expected <> 0 then
-          Test.fail (Printf.sprintf "Expected %s, got %s"
-            (StringList.to_ocaml_string expected)
-            (StringList.to_ocaml_string actual)
-          )
-      )
-      tests
-  );
 ]
 
 let () = Test.run tests


### PR DESCRIPTION
The number of functions to run commands has grown to 3:
- `Command.run`,
- `Command.run_with_stdout`,
- `Command.run_with_stdin_and_stdout`.

As upcoming PR (#133) is going to need to use the stderr of a command, this is going to grow to 4, and may eventually have one for each of the full powerset of {`stdin`,`stdout`,`stderr`}.

Instead, this PR implements One True Function, `Command.run`, which takes 3 optional function parameters, one for each of `~stdin`, `~stdout`, and `~stderr`. The named arguments should also be easier to read than positional arguments after a long function name.

This PR also backports `Fun.protect` and `Option.get` from OCaml 4.08.

This PR blocks PR #133, which in-turn blocks PR #94.