### PR TITLE
[internal_all] Support for expected-failure tests

### DIFF
--- a/herd/tests/instructions/AArch64/L005.litmus
+++ b/herd/tests/instructions/AArch64/L005.litmus
@@ -1,0 +1,9 @@
+AArch64 L005
+(* test checks if we can check for deliberate failure *)
+
+{}
+
+P0;
+fictional_instruction X0, X1;
+
+exists (1:X0=1)

--- a/herd/tests/instructions/AArch64/L005.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/L005.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/L005.litmus", line 7, characters 22-24: unexpected 'X0' (in prog) (User error)

--- a/internal/herd_diycross_regression_test.ml
+++ b/internal/herd_diycross_regression_test.ml
@@ -79,7 +79,7 @@ let run_tests flags =
     (List.map TestHerd.expected_of_litmus in_both)
   in
   let results = List.map
-    (fun (l, e) -> TestHerd.herd_output_matches_expected flags.herd flags.libdir l e)
+    (fun (l, e) -> TestHerd.herd_output_matches_expected flags.herd flags.libdir l e "")
     (List.combine litmus_paths expected_paths)
   in
   let passed x = x in
@@ -113,9 +113,9 @@ let promote_tests flags =
   let expected_paths = concat_dir flags.expected_dir expecteds in
 
   let outputs = List.map (TestHerd.run_herd flags.herd flags.libdir) litmus_paths in
-  List.iter
-    (fun (path, lines) -> Filesystem.write_file path (fun o -> Channel.write_lines o lines))
-    (List.combine expected_paths outputs) ;
+  let write_file (path, (lines,_)) =
+    Filesystem.write_file path (fun o -> Channel.write_lines o lines) in
+  List.combine expected_paths outputs |> List.iter write_file ;
   Filesystem.remove_recursive tmp_dir
 
 

--- a/internal/lib/testHerd.ml
+++ b/internal/lib/testHerd.ml
@@ -14,6 +14,10 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
+(*Test runs output two kinds of information, we should check both *)
+type stdout_lines = string list
+type stderr_lines = string list
+
 let time_re = Str.regexp "^Time "
 let without_unstable_lines lines =
   let not_time l = not (Str.string_match time_re l 0) in
@@ -26,31 +30,55 @@ let herd_command herd libdir litmus =
   Command.command herd ["-set-libdir"; libdir; litmus]
 
 let run_herd herd libdir litmus =
+  (* Record stdout and stderr to two sources if we need to reason about them separately *)
   let lines = ref [] in
+  let err_lines = ref [] in
   let read_lines c = lines := Channel.read_lines c in
-  Command.run ~stdout:read_lines herd ["-set-libdir"; libdir; litmus] ;
-  without_unstable_lines !lines
+  let read_err_lines c = err_lines := Channel.read_lines c in
+  Command.run ~stdout:read_lines ~stderr:read_err_lines herd ["-set-libdir"; libdir; litmus] ;
+  (without_unstable_lines !lines, !err_lines)
 
-let herd_output_matches_expected herd libdir litmus expected =
-  let output = try
-    Some (run_herd herd libdir litmus)
-  with _ -> None in
-  match output with
-  | None -> Printf.printf "Failed %s : Herd returned non-zero\n" litmus ; false
-  | Some output ->
+let herd_output_matches_expected herd libdir litmus expected expected_failure =
+  try
+    match run_herd herd libdir litmus with
+    | [],[] ->
+      Printf.printf "Failed %s : Herd finished but returned no output or errors\n" litmus ; false
+    | stdout, [] -> (* Herd finished without errors - normal *)
+      begin
+        let expected_output = try
+          Some (Filesystem.read_file expected Channel.read_lines)
+        with _ -> None in
+        match expected_output with
+        | None -> Printf.printf "Failed %s : Missing file %s\n" litmus expected ; false
+        | Some expected_output ->
 
-  let expected_output = try
-    Some (Filesystem.read_file expected Channel.read_lines)
-  with _ -> None in
-  match expected_output with
-  | None -> Printf.printf "Failed %s : Missing file %s\n" litmus expected ; false
-  | Some expected_output ->
+        if log_compare stdout expected_output <> 0 then begin
+          Printf.printf "Failed %s : Logs do not match\n" litmus ;
+          false
+        end else
+          true
+      end
 
-  if log_compare output expected_output <> 0 then begin
-    Printf.printf "Failed %s : Logs do not match\n" litmus ;
-    false
-  end else
-    true
+    | [], stderr -> (* Herd finished with errors - check expected failure *)
+      begin
+        let expected_failure_output = try
+          Some (Filesystem.read_file expected_failure Channel.read_lines)
+        with _ -> None in
+        match expected_failure_output with
+        | None -> Printf.printf "Failed %s : Missing file %s\n" litmus expected_failure ; false
+        | Some expected_failure_output ->
+
+        if log_compare stderr expected_failure_output <> 0 then begin
+          Printf.printf "Failed %s : Expected Failure Logs do not match\n" litmus ;
+          false
+        end else
+          true
+      end
+
+    | _,_ -> (* Herd returned both output and errors *)
+      Printf.printf "Failed %s : %s and %s exist, only one expected\n" litmus expected expected_failure ; false
+  with
+    Command.Error msg -> Printf.printf "Failed %s : %s \n" litmus msg ; false
 
 
 let is_litmus path = Filename.check_suffix path ".litmus"
@@ -58,3 +86,6 @@ let is_expected path = Filename.check_suffix path ".litmus.expected"
 
 let expected_of_litmus litmus = litmus ^ ".expected"
 let litmus_of_expected expected = Filename.chop_suffix expected ".expected"
+
+let expected_failure_of_litmus litmus = litmus ^ ".expected-failure"
+let litmus_of_expected_failure expected = Filename.chop_suffix expected ".expected-failure"

--- a/internal/lib/testHerd.mli
+++ b/internal/lib/testHerd.mli
@@ -18,15 +18,20 @@
   * would run. *)
 val herd_command: string -> string -> string -> string
 
-(** [run_herd herd libdir litmus] runs the binary [herd] with a custom [libdir]
-  * on a [litmus] file, and returns the output with unstable lines removed (e.g.
-  * Time). *)
-val run_herd : string -> string -> string -> string list
+type stdout_lines = string list
+type stderr_lines = string list
 
-(** [herd_output_matches_expected herd libdir litmus expected] runs the binary
+(** [run_herd herd libdir litmus] runs the binary [herd] with a custom [libdir]
+  * on a [litmus] file, and returns the stdout with unstable lines removed (e.g.
+  * Time) and stderr *)
+val run_herd : string -> string -> string -> stdout_lines * stderr_lines
+
+(** [herd_output_matches_expected herd libdir litmus expected expected_failure] runs the binary
   * [herd] with a custom [libdir] on a [litmus] file, and compares the output
-  * with an [expected] file. *)
-val herd_output_matches_expected : string -> string -> string -> string -> bool
+  * with an [expected] file. If the run writes to stderr then we check [expected_failure].
+  * If the contents of [expected_failure] match then it is an expected failure, otherwise
+  * it is an unexpected failure and will raise an Error. *)
+val herd_output_matches_expected : string -> string -> string -> string -> string -> bool
 
 (** [is_litmus filename] returns whether the [filename] is a .litmus file. *)
 val is_litmus : string -> bool
@@ -39,3 +44,9 @@ val expected_of_litmus : string -> string
 
 (** [litmus_of_expected filename] returns the .litmus name for a given .litmus.expected [filename]. *)
 val litmus_of_expected : string -> string
+
+(** [expected_failure_of_litmus filename] returns the .litmus.expected-failure name for a given .litmus [filename]. *)
+val expected_failure_of_litmus : string -> string
+
+(** [litmus_of_expected_failure filename] returns the .litmus name for a given .litmus.expected-failure [filename]. *)
+val litmus_of_expected_failure : string -> string


### PR DESCRIPTION
Setting this patch as a draft so that it isn't merged before #132 which contains the patches included below to make this patch work

This patch unblocks the expected failures in herd#94
This patch depends on changes in herd#132 and should not be merged before #132 
This patch has also been pre-reviewed by @eth-arm as an initial check 

Consider the test `LB003.litmus`:
```
fictional_instruction X0, X1;
```
which should fail in Herd with a parser error, written in
`LB003.litmus.expected-failure`
```
Warning: File "./herd/tests/instructions/AArch64/L003.litmus", line 7, characters 22-24: unexpected 'X0' (in prog) (User error)
```
This patch extends the testing infrastructure to test for expected failures.
This unblocks herd#94, in particular allows us to test an expected failure of Herd.
