### PR TITLE
[catalogue] Add tool `lint_shelf`, and use it to lint the shelves

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,9 @@ repos:
         language: system
         entry: opam lint
         files: (\.opam$)
+
+    -   id: lint-shelves
+        name: Lint Catalogue shelves
+        language: system
+        entry: internal/run_built_binary lint_shelves
+        files: shelf.py$

--- a/catalogue/aarch64-MTE/shelf.py
+++ b/catalogue/aarch64-MTE/shelf.py
@@ -11,7 +11,6 @@ cfgs = [
 illustrative_tests = [
     "tests/MP+dmb.stPT+addr.litmus",
     "tests/MP+dmb.stTT+addr.litmus",
-    "tests/R+dmb.stTT+rel-acq.litmus",
     "tests/S+dmb.stTT+addr.litmus",
     "tests/S+dmb.stTT+ctrl.litmus",
     "tests/S+dmb.stTT+data.litmus",

--- a/catalogue/aarch64/shelf.py
+++ b/catalogue/aarch64/shelf.py
@@ -14,7 +14,7 @@ cfgs = [
     "cfgs/new-web.cfg",
 ]
 
-illustrative_tests = [    
+illustrative_tests = [
     "tests/MP.litmus",
     "tests/MP+dmb.sy+po.litmus",
     "tests/MP+dmb.sys.litmus",
@@ -39,11 +39,11 @@ illustrative_tests = [
     "tests/LB+rel+BEQ.litmus",
     "tests/LB+rel+BEQ2.litmus",
     "tests/LB+rel+BEQ3.litmus",
-    "tests/LB+rel+BEQ4.litmus",
+    "tests/LB+BEQ4.litmus",
     "tests/LB+rel+CSEL.litmus",
     "tests/LB+rel+CSEL2.litmus",
     "tests/LB+rel+CSEL3.litmus",
-    "tests/LB+rel+CSEL4.litmus",
+    "tests/LB+CSEL4.litmus",
     "tests/CAS+data1.litmus",
     "tests/CAS+data2.litmus",
 ]

--- a/catalogue/c11popl15/shelf.py
+++ b/catalogue/c11popl15/shelf.py
@@ -8,7 +8,6 @@ cats = \
 cfgs = [
     "cfgs/c11web.cfg",
     "cfgs/cpp11.cfg",
-    "c11popl15/c11popl15.cfg",
     "c11.cfg",
 ]
 

--- a/catalogue/tutorial/shelf.py
+++ b/catalogue/tutorial/shelf.py
@@ -38,9 +38,9 @@ illustrative_tests = [
     "tests/ledzep.litmus",
     "tests/mp.litmus",
     "tests/mp+lw+dep.litmus",
-    "tests/mp-mit-scopes+fcta+fgpu.litmus"
-    "tests/mp-mit-scopes+fgpu+fsys.litmus"
-    "tests/mp-mit-scopes+fgpus.litmus"
+    "tests/mp-mit-scopes+fcta+fgpu.litmus",
+    "tests/mp-mit-scopes+fgpu+fsys.litmus",
+    "tests/mp-mit-scopes+fgpus.litmus",
     "tests/mp-mit-scopes.litmus",
     "tests/mp-plain.litmus",
     "tests/mp-special+branch.litmus",

--- a/internal/dune
+++ b/internal/dune
@@ -1,4 +1,4 @@
 (executables
- (names herd_regression_test herd_diycross_regression_test)
+ (names herd_regression_test herd_diycross_regression_test lint_shelves)
  (libraries internal_lib)
  (modes native))

--- a/internal/lib/base.ml
+++ b/internal/lib/base.ml
@@ -62,6 +62,11 @@ module Option = struct
     | None -> invalid_arg "option is None"
     | Some v -> v
 
+  let value o ~default =
+    match o with
+    | None -> default
+    | Some v -> v
+
   let compare cf a b =
     match a, b with
     | None, None -> 0

--- a/internal/lib/base.mli
+++ b/internal/lib/base.mli
@@ -61,6 +61,9 @@ module Option : sig
    *  It raises [Invalid_argument] if [o] is [None]. *)
   val get : 'a t -> 'a
 
+  (** [value o ~default] is [v] if [o] is [Some v] and [default] otherwise. *)
+  val value : 'a option -> default:'a -> 'a
+
   (** [compare c x y] compares [x] and [y]. [None] is smaller than [Some _]. If
    *  they are both [Some _] their elements are compared with function [c]. *)
   val compare : ('a -> 'a -> int) -> 'a option -> 'a option -> int

--- a/internal/lint_shelves.ml
+++ b/internal/lint_shelves.ml
@@ -1,0 +1,81 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** A tool to lint the contents of one or more Catalogue Shelf files. *)
+
+module Option = Base.Option
+
+let flatten_fields fields =
+  let flatten_field (name, values) =
+    List.map (fun v -> name, v) values
+  in
+  List.map flatten_field fields |> List.concat
+
+
+let lint_shelf shelf_path =
+  let shelf = Shelf.of_file shelf_path in
+  let shelf_dir = Filename.dirname shelf_path in
+
+  let file_fields =
+    let open Shelf in [
+      "cat", shelf.cats ;
+      "config", shelf.configs ;
+      "illustrative test", shelf.illustrative_tests ;
+      "bell", Option.value shelf.bells ~default:[] ;
+    ]
+  in
+
+  let file_missing p =
+    not (Sys.file_exists (Filename.concat shelf_dir p))
+  in
+
+  let missing_files =
+    flatten_fields file_fields
+      |> List.filter (fun (_name, path) -> file_missing path)
+  in
+  match missing_files with
+  | [] -> Ok ()
+  | missing -> Error missing
+
+
+let usage = String.concat "\n" [
+  Printf.sprintf "Usage: %s <path/to/shelf.py> [more paths ...]" Sys.argv.(0) ;
+  "" ;
+  "Synopsis: Lint the contents of one or more Catalogue Shelf files."
+]
+
+let () =
+  let shelves = ref [] in
+  Arg.parse [] (fun s -> shelves := s :: !shelves) usage ;
+  let shelves = List.rev !shelves in
+  if List.length shelves = 0 then begin
+    Printf.printf "%s\n" usage ;
+    exit 1
+  end ;
+
+  let ok = ref true in
+  List.iter (fun shelf ->
+    match lint_shelf shelf with
+    | Ok () -> ()
+    | Error errors ->
+        ok := false ;
+        List.iter (fun (name, path) -> Printf.printf "Shelf %s: Missing %s: %s\n" shelf name path) errors ;
+  ) shelves ;
+  if !ok then begin
+    if Unix.isatty Unix.stdout then
+      Printf.printf "Shelves OK\n"
+  end else
+    exit 1

--- a/internal/run_built_binary
+++ b/internal/run_built_binary
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -eu
+
+if [ $# -eq 0 ]
+then
+  echo "Usage: $(basename "${0}") <binary> [args]"
+  echo ""
+  echo "Synopsis: Run the most recently built <binary>.exe or <binary>.native under _build, with args."
+  exit 1
+fi
+
+readonly binary="${1}"
+shift
+
+readonly paths="$(find _build -name "${binary}.exe" -o -name "${binary}.native")"
+
+if [ ! "${paths}" ]
+then
+  echo "Could not find ${binary}"
+  exit 1
+fi
+
+function most_recent() {
+  # List (mtime, path) pairs.
+  # Sort them descending by mtime.
+  # Take the first of the list.
+  # Extract the path back out.
+  stat -f '%m %N' $@ \
+    | sort --reverse \
+    | head -n1 \
+    | cut -d' ' -f2
+}
+
+"$(most_recent ${paths})" $@


### PR DESCRIPTION
This PR creates a tool `lint_shelves` to lint shelves.

It also:
- Backports `Option.value` from OCaml 4.08, and fixes errors in some `shelf.py` files.
- Fixes errors with some `shelf.py` files.
- Adds a tool `internal/run_built_binary` to run the most recently built version of a binary under `_build/`.
- Uses the new linter with Pre-Commit.
