### PR TITLE
[litmus] Add EL0 mode for KVM AArch64

### DIFF
--- a/lib/lexScan.mli
+++ b/lib/lexScan.mli
@@ -15,6 +15,8 @@
 (****************************************************************************)
 
 (** Miscellaneous lexers *)
+exception Error
 
 val is_num : string -> bool
 val info : string -> (string * string) option
+val procs : string -> Proc.t list

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -286,6 +286,10 @@ let fold_bool f k =  f true (f false k)
 (******************)
 (* List utilities *)
 (******************)
+let nilp = function
+  | [] -> true
+  | _::_ -> false
+
 let consp = function
   | [] -> false
   | _::_ -> true

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -101,6 +101,7 @@ val fold_bool : (bool -> 'a -> 'a) -> 'a -> 'a
 
 
 (* Some useful function on lists *)
+val nilp : 'a list -> bool
 val consp : 'a list -> bool
 val cons : 'a -> 'a list -> 'a list
 val last : 'a list -> 'a

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -212,6 +212,8 @@ and stable_key = "Stable"
 and align_key = "Align"
 and tthm_key = "TTHM"
 and variant_key = "Variant"
+and user_key = "user"
+and el0_key = "el0"
 let low_hash = "hash"
 
 let get_info_on_info key =

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -109,6 +109,8 @@ val stable_key : string
 val align_key : string
 val tthm_key : string
 val variant_key : string
+val user_key : string
+val el0_key : string
 
 (* Extract hash *)
 val get_hash : ('i, 'p, 'c, 'loc, 'v) result -> string option

--- a/lib/procsUser.ml
+++ b/lib/procsUser.ml
@@ -14,39 +14,19 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Miscellaneous lexers *)
+(** Threads in user mode *)
 
-{
-exception Error
-}
-
-let digit = ['0'-'9']
-let num = ['1'-'9']digit*
-let hexa_digit = (digit|['a'-'f''A'-'F'])
-let hexa_num = ("0x"|"0X")hexa_digit+
-let alpha = [ 'a'-'z' 'A'-'Z']
-let blank = [' ' '\t' '\r']
-let not_blank = [^' ''\t''\r']
-let name  = alpha (alpha|digit|'_' | '/' | '.' | '-')*
-
-rule num_rule = parse
-| blank* (num|hexa_num) blank* eof { true }
-| ""  { false }
-
-and info_rule = parse
-| (name as key) blank* '=' blank* (_* as value) blank* eof
-  { let p = key,value in Some p }
-| "" { None }
-
-and procs_rule = parse
-| 'P' (digit+ as p)
-{ let p = try int_of_string p with _ -> assert false in
-  p::procs_rule lexbuf }
-| [' '',']+ { procs_rule lexbuf }
-| eof { [] }
-| "" { raise Error }
-{
-let is_num s = num_rule (Lexing.from_string s)
-let info s = info_rule (Lexing.from_string s)
-let procs s = procs_rule (Lexing.from_string s)
-}
+let get info =
+  let get k = MiscParser.get_info_on_info k info in
+  let procs = match get MiscParser.el0_key with
+      | None -> get MiscParser.user_key
+      | Some _ as r -> r in
+    match procs with
+    | None -> []
+    | Some p ->
+        begin
+          try LexScan.procs p
+          with
+          | LexScan.Error ->
+              Warn.user_error "'%s' is not a list of thread names" p
+        end

--- a/lib/procsUser.mli
+++ b/lib/procsUser.mli
@@ -14,39 +14,6 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Miscellaneous lexers *)
+(** LIst of threads in user mode *)
 
-{
-exception Error
-}
-
-let digit = ['0'-'9']
-let num = ['1'-'9']digit*
-let hexa_digit = (digit|['a'-'f''A'-'F'])
-let hexa_num = ("0x"|"0X")hexa_digit+
-let alpha = [ 'a'-'z' 'A'-'Z']
-let blank = [' ' '\t' '\r']
-let not_blank = [^' ''\t''\r']
-let name  = alpha (alpha|digit|'_' | '/' | '.' | '-')*
-
-rule num_rule = parse
-| blank* (num|hexa_num) blank* eof { true }
-| ""  { false }
-
-and info_rule = parse
-| (name as key) blank* '=' blank* (_* as value) blank* eof
-  { let p = key,value in Some p }
-| "" { None }
-
-and procs_rule = parse
-| 'P' (digit+ as p)
-{ let p = try int_of_string p with _ -> assert false in
-  p::procs_rule lexbuf }
-| [' '',']+ { procs_rule lexbuf }
-| eof { [] }
-| "" { raise Error }
-{
-let is_num s = num_rule (Lexing.from_string s)
-let info s = info_rule (Lexing.from_string s)
-let procs s = procs_rule (Lexing.from_string s)
-}
+val get : (string * string) list -> Proc.t list

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -580,6 +580,18 @@ module Make(V:Constant.S)(C:Config) =
 (* Not that useful *)
     let emit_loop _k = assert false
 
+    let user_mode =
+      let ins =
+        ["msr sp_el0,%[sp_usr]";
+         "adr %[tr0],9f";
+         "msr elr_el1,%[tr0]";
+         "msr spsr_el1,xzr";
+         "eret";
+         "9:"] in
+      List.map (fun s -> { empty_ins with memo=s;}) ins
+
+    let kernel_mode = [{ empty_ins with memo="svc #471"}]
+
     let compile_ins tr_lab ins k = match ins with
     | I_NOP -> { empty_ins with memo = "nop"; }::k
 (* Branches *)

--- a/litmus/ARMCompile_litmus.ml
+++ b/litmus/ARMCompile_litmus.ml
@@ -207,6 +207,8 @@ module Make(V:Constant.S)(C:Config) =
       let memo = sprintf "%s %s" memo (emit_opt o) in
       { empty_ins with memo =memo; }
 
+    let user_mode = [] and kernel_mode = []
+
     let compile_ins tr_lab ins k = match ins with
     | I_NOP -> { empty_ins with memo = "nop"; }::k
 (* Arithmetic *)

--- a/litmus/CLang.ml
+++ b/litmus/CLang.ml
@@ -82,7 +82,7 @@ module Make(C:Config)(E:Extra) = struct
     and ty = out_type env x in
     sprintf "%s*" (CType.dump ty),outname
 
-  let dump_fun chan env globEnv _envVolatile proc t =
+  let dump_fun chan _args0 env globEnv _envVolatile proc t =
 (*
   let pp_env =
   String.concat "; "
@@ -119,7 +119,7 @@ module Make(C:Config)(E:Extra) = struct
     out "}\n\n"
 
 
-  let dump_call f_id tr_idx chan indent _env globEnv _envVolatile proc t =
+  let dump_call f_id args0 tr_idx chan indent _env globEnv _envVolatile proc t =
     let is_array_of a =
       try  match List.assoc a globEnv with
       | CType.Array (t,_) -> Some t
@@ -145,7 +145,7 @@ module Make(C:Config)(E:Extra) = struct
             List.map
               (fun x -> sprintf "&%s" (E.out_ctx (CTarget.compile_out_reg proc x)))
               t.CTarget.finals in
-          let args = String.concat "," (global_args@out_args) in
+          let args = String.concat "," (args0@global_args@out_args) in
           LangUtils.dump_code_call chan indent f_id args
 
 

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -510,7 +510,8 @@ let dump_threads _tname env test =
   List.iter
     (fun (proc,(out,(_outregs,envVolatile))) ->
       let myenv = U.select_proc proc env in
-      Lang.dump_fun O.out myenv global_env envVolatile proc out ;
+      Lang.dump_fun O.out Template.no_extra_args
+        myenv global_env envVolatile proc out ;
       O.f "static int thread%i(void *_p) {" proc ;
       O.oi "ctx_t *_a = (ctx_t *)_p;" ;
       O.o "" ;
@@ -529,7 +530,7 @@ let dump_threads _tname env test =
           sprintf "%s %% %s" idx spinsize
       | Some _|None -> idx in
       Lang.dump_call (LangUtils.code_fun proc)
-        tr_idx O.out (Indent.as_string indent3)
+        [] tr_idx O.out (Indent.as_string indent3)
         myenv global_env envVolatile proc out ;
       O.oii "}" ;
       O.oi "}" ;

--- a/litmus/LISACompile.ml
+++ b/litmus/LISACompile.ml
@@ -89,6 +89,8 @@ module Make(V:Constant.S) =
             let m,i = compile_roi roi in
             add_par (reg_to_string r ^ "+" ^ m),r::i,[r,type_vo vo]
 
+    let user_mode = []
+    and kernel_mode = []
 
     let compile_ins tr_lab ins k = match ins with
     | Pld (r,a,["once"]) ->

--- a/litmus/LISALang.ml
+++ b/litmus/LISALang.ml
@@ -98,7 +98,7 @@ module Make(V:Constant.S) = struct
 
   and compile_out_reg_fun p r = sprintf "*%s" (Tmpl.dump_out_reg p r)
 
-  let dump_fun chan env globEnv _volatileEnv proc t =
+  let dump_fun chan _args0 env globEnv _volatileEnv proc t =
     let addrs_proc = A.Out.get_addrs_only t in
     let addrs =
       List.map
@@ -137,11 +137,12 @@ module Make(V:Constant.S) = struct
   let compile_out_reg_call proc reg =
     sprintf "&_a->%s" (Tmpl.compile_out_reg proc reg)
 
-  let dump_call f_id _tr_idx chan indent _env _globEnv _volatileEnv proc t =
+  let dump_call f_id args0
+        _tr_idx chan indent _env _globEnv _volatileEnv proc t =
     let addrs_proc = Tmpl.get_addrs_only t in
     let addrs = List.map compile_addr_call addrs_proc
     and outs = List.map (compile_out_reg_call proc) t.Tmpl.final in
-    let args = String.concat "," (addrs@outs) in
+    let args = String.concat "," (args0@addrs@outs) in
     LangUtils.dump_code_call chan indent f_id args
 
 

--- a/litmus/MIPSCompile_litmus.ml
+++ b/litmus/MIPSCompile_litmus.ml
@@ -111,6 +111,8 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
 
     let emit_loop _k = assert false
 
+    let user_mode = [] and kernel_mode = []
+
     let compile_ins tr_lab ins k = match ins with
     | NOP -> { empty_ins with memo = "nop"; }::k
     | LI (r,i) -> li r i::k

--- a/litmus/PPCCompile_litmus.ml
+++ b/litmus/PPCCompile_litmus.ml
@@ -219,6 +219,8 @@ module Make(V:Constant.S)(C:Config) =
           cmpwi loop_idx 0;
           bcc tr_nolab Gt lbl1; ]
 
+    let user_mode = [] and kernel_mode = []
+
     let do_compile_ins tr_lab ins k = match tr_ins ins with
     | Pnop -> { empty_ins with memo="nop"; }::k
     | Pmr (rD,rS) -> mr rD rS::k

--- a/litmus/RISCVCompile_litmus.ml
+++ b/litmus/RISCVCompile_litmus.ml
@@ -67,6 +67,8 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
 
     let emit_loop _ins = assert false
 
+    let user_mode = [] and kernel_mode = []
+
     let compile_ins tr_lab ins k = match ins with
     | A.INop -> { empty_ins with memo="nop"; }::k
     | A.OpI (op,r1,r2,i) ->

--- a/litmus/X86Compile_litmus.ml
+++ b/litmus/X86Compile_litmus.ml
@@ -234,6 +234,8 @@ module Make(V:Constant.S)(O:Arch_litmus.Config) =
        emit_lbl lbl2;
        jcc no_tr C_GT lbl1;]
 
+    let user_mode = [] and kernel_mode = []
+
     let rec do_compile_ins tr_lab ins = match ins with
     | I_NOP ->
         { empty_ins with memo = "nop"; }

--- a/litmus/X86_64Compile_litmus.ml
+++ b/litmus/X86_64Compile_litmus.ml
@@ -250,8 +250,10 @@ module Make(V:Constant.S)(O:Arch_litmus.Config) =
       in
            Misc.lowercase inst_str
 
+    let user_mode = [] and kernel_mode = []
+
     let rec do_compile_ins tr_lab ins = match ins with
-   | I_NOP ->
+    | I_NOP ->
         { empty_ins with memo = "nop"; }
     | I_EFF_OP (inst, _, ea, op) as i ->
        begin

--- a/litmus/XXXCompile_litmus.mli
+++ b/litmus/XXXCompile_litmus.mli
@@ -22,6 +22,8 @@ module type S = sig
   val extract_addrs : A.instruction -> Global_litmus.Set.t
   val stable_regs : A.instruction -> A.RegSet.t
   val emit_loop : A.Out.ins list -> A.Out.ins list
+  val user_mode : A.Out.ins list
+  val kernel_mode : A.Out.ins list
   val compile_ins :
       (Label.t -> string) ->
         A.instruction ->  A.Out.ins list -> A.Out.ins list

--- a/litmus/language.ml
+++ b/litmus/language.ml
@@ -22,6 +22,7 @@ module type S = sig
 (* Function dump *)
   val dump_fun :
     out_channel ->
+    Template.extra_args ->
     CType.t RegMap.t ->
     (string * CType.t) list ->
     string list ->
@@ -31,6 +32,7 @@ module type S = sig
 
   val dump_call :
     string ->
+    string list ->
     (CType.t -> string -> string) ->
     out_channel ->
     string ->

--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -11,6 +11,10 @@ static void fault_handler(struct pt_regs *regs,unsigned int esr) {
 #endif
 }
 
-static void install_fault_handler(void) {
+static void install_fault_handler(int cpu) {
   install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1,fault_handler);
+#ifdef USER_MODE
+  struct thread_info *ti = thread_info_sp(user_stack[cpu]);
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
+#endif
 }

--- a/litmus/libdir/_aarch64/kvm_user_stacks.c
+++ b/litmus/libdir/_aarch64/kvm_user_stacks.c
@@ -1,0 +1,24 @@
+/**************************/
+/* Setup user mode stacks */
+/**************************/
+
+#define USER_MODE 1
+
+void back_to_el1(struct pt_regs *regs,unsigned int esr) {
+  regs->pstate |= 0b0101;  
+}
+
+static uint64_t user_stack[AVAIL];
+
+static void set_user_stack(int cpu) {
+  uint64_t sp_usr = (uint64_t)thread_stack_alloc();
+  sp_usr &= (~15UL); /* stack ptr needs 16-byte alignment */
+  //  printf("Cpu %d has stack 0x%" PRIx64 "\n",cpu,sp_usr);
+  struct thread_info *ti0 = current_thread_info();
+  struct thread_info *ti = thread_info_sp(sp_usr);
+  thread_info_init(ti, TIF_USER_MODE);
+  ti->pgtable = ti0->pgtable;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = back_to_el1;
+  ti0->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = back_to_el1;
+  user_stack[cpu] = sp_usr;
+}

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -1729,7 +1729,8 @@ module Make
             let myenv = U.select_proc proc env
             and global_env = U.select_global env in
             if do_ascall then begin
-              Lang.dump_fun O.out myenv global_env envVolatile proc out
+                Lang.dump_fun O.out
+                  Template.no_extra_args myenv global_env envVolatile proc out
             end ;
             let  do_collect =  do_collect_local && (do_safer || proc=0) in
             O.f "static void *P%i(void *_vb) {" proc ;
@@ -1935,7 +1936,7 @@ module Make
               let f_id =
                 if do_self then LangUtils.code_fun_cpy proc else
                 LangUtils.code_fun proc in
-              Lang.dump_call f_id (fun _ s -> s) else Lang.dump)
+              Lang.dump_call f_id [] (fun _ s -> s) else Lang.dump)
               O.out (Indent.as_string iloop) myenv aligned_env envVolatile proc out ;
             if do_verbose_barrier && have_timebase  then begin
               if do_timebase then begin

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -47,6 +47,11 @@ module DefaultConfig = struct
   let mode = Mode.Std
 end
 
+type extra_args =
+  { trashed: string list;
+    inputs: ((CType.t * string) * (string * string)) list; }
+
+let no_extra_args = { trashed=[]; inputs=[];}
 
 module type S = sig
   module V : Constant.S


### PR DESCRIPTION
Tests metadata may specify EL0 mode for a comma separated list of thread names:
`EL0=P<i1>,P<i2>,...`

Switch to EL0 is performed at the beginning of thread code (by `eret`
with proper setting of `sp_el0` (per cpu user stack), `elr_el1`
(next instruction after eret) and spsr_el1 (all zero).

Return to EL1 is performed by a system call `svc`. Handler code changes
saved pstate so as to fool kvm infrastructure and return to EL1. Surprisingly
it looks as if the trick is working.

Notice that stacks are different in EL0 and EL1 mode, which may
cause problems (not yet observed). Namely, thread code is in a function body.
Switch to EL0 is performed as late as possible, so as
to alleviate the risk of a reference to stack pointer crossing
this boundary.