### PR TITLE
Add el0 field to page table entry value (pteval).

### DIFF
--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -256,6 +256,7 @@ module Top (Conf:Config) = struct
           let module AArch64SemConf = struct
             module C = Conf
             let dirty = ModelConfig.dirty
+            let procs_user = ProcsUser.get splitted.Splitter.info
           end in
           let module AArch64S = AArch64Sem.Make(AArch64SemConf)(Int64Value) in
           let module AArch64Barrier = struct

--- a/lib/PTEVal.ml
+++ b/lib/PTEVal.ml
@@ -61,7 +61,7 @@ let my_int_of_string s v =
     _ -> Warn.user_error "PTE field %s should be an integer" s
   in v
 
-let of_list pte l =
+let do_of_list p l =
 
   let add_field a (s,v) = match s with
   | "oa" -> { a with oa = v }
@@ -76,7 +76,10 @@ let of_list pte l =
     | [] -> a
     | h::t -> of_list (add_field a h) t in
 
-  of_list (default pte) l
+  of_list p l
+
+let of_list s = do_of_list (default s)
+and of_list0 = do_of_list prot_default
 
 let lex_compare c1 c2 x y  = match c1 x y with
 | 0 -> c2 x y

--- a/lib/PTEVal.ml
+++ b/lib/PTEVal.ml
@@ -22,10 +22,11 @@ type t = {
   af : int;
   db : int;
   dbm : int;
+  el0 : int;
   }
 
 (* For ordinary tests not to fault, the dirty bit has to be set. *)
-let prot_default =  { oa=""; valid=1; af=1; db=1; dbm=0; }
+let prot_default =  { oa=""; valid=1; af=1; db=1; dbm=0; el0=1;}
 let default s = { prot_default with  oa=Misc.add_physical s; }
 
 let pp_field ok pp eq ac p k =
@@ -36,13 +37,22 @@ let pp_valid ok = pp_int_field ok "valid" (fun p -> p.valid)
 and pp_af ok = pp_int_field ok "af" (fun p -> p.af)
 and pp_db ok = pp_int_field ok "db" (fun p -> p.db)
 and pp_dbm ok = pp_int_field ok "dbm" (fun p -> p.dbm)
+and pp_el0 ok = pp_int_field ok "el0" (fun p -> p.el0)
 
 let set_oa p s = { p with oa = Misc.add_physical s; }
 
-let is_default t = t.valid=1 && t.af=1 && t.db=1 && t.dbm=0
+let is_default t =
+  let d = prot_default in
+  t.valid=d.valid && t.af=d.af && t.db=d.db && t.dbm=d.dbm && t.el0=d.el0
 
+(* If showall is true, field will always be printed.
+   Otherwise, field will be printed only if non-default.
+   While computing hashes, backward compatibility commands that:
+   (1) Fields older than el0 are always printed.
+   (2) Fields from el0 (included) are printed if non-default. *)
 let do_pp showall p =
-  let k = pp_valid showall p [] in
+  let k = pp_el0 false p [] in
+  let k = pp_valid showall p k in
   let k = pp_dbm showall p k in
   let k = pp_db showall p k in
   let k = pp_af showall p k in
@@ -69,6 +79,7 @@ let do_of_list p l =
   | "db" -> { a with db = my_int_of_string s v }
   | "dbm" -> { a with dbm = my_int_of_string s v }
   | "valid" -> { a with valid = my_int_of_string s v }
+  | "el0" -> { a with el0 = my_int_of_string s v }
   | _ ->
       Warn.user_error "Illegal PTE property %s" s in
 
@@ -86,19 +97,23 @@ let lex_compare c1 c2 x y  = match c1 x y with
 | r -> r
 
 let compare =
-  lex_compare
-    (fun p1 p2 -> String.compare p1.oa p2.oa)
-    (lex_compare
-       (fun p1 p2 -> Misc.int_compare p1.af p2.af)
-       (lex_compare
-          (fun p1 p2 -> Misc.int_compare p1.db p2.db)
-          (lex_compare
-             (fun p1 p2 -> Misc.int_compare p1.dbm p2.dbm)
-             (fun p1 p2 -> Misc.int_compare p1.valid p2.valid))))
+  let cmp = (fun p1 p2 -> Misc.int_compare p1.el0 p2.el0) in
+  let cmp =
+    lex_compare (fun p1 p2 -> Misc.int_compare p1.valid p2.valid) cmp in
+  let cmp =
+    lex_compare (fun p1 p2 -> Misc.int_compare p1.dbm p2.dbm) cmp in
+  let cmp =
+    lex_compare (fun p1 p2 -> Misc.int_compare p1.db p2.db) cmp in
+  let cmp =
+    lex_compare (fun p1 p2 -> Misc.int_compare p1.af p2.af) cmp in
+  let cmp =
+    lex_compare (fun p1 p2 -> String.compare p1.oa p2.oa) cmp in
+  cmp
 
 let eq p1 p2 =
   Misc.string_eq p1.oa p2.oa &&
   Misc.int_eq p1.af p2.af &&
   Misc.int_eq p1.db p2.db &&
   Misc.int_eq p1.dbm p2.dbm &&
-  Misc.int_eq p1.valid p2.valid
+  Misc.int_eq p1.valid p2.valid &&
+  Misc.int_eq p1.el0 p2.el0

--- a/lib/PTEVal.mli
+++ b/lib/PTEVal.mli
@@ -32,6 +32,7 @@ val set_oa : t -> string -> t
 val is_default : t -> bool
 val of_list : string -> (string * string) list -> t
 val pp : t -> string
+val pp_hash : t -> string
 
 val compare : t -> t -> int
 val eq : t -> t -> bool

--- a/lib/PTEVal.mli
+++ b/lib/PTEVal.mli
@@ -25,6 +25,7 @@ type t = {
   }
 
 (* Default value for location argument *)
+val prot_default : t
 val default : string -> t
 val set_oa : t -> string -> t
 

--- a/lib/PTEVal.mli
+++ b/lib/PTEVal.mli
@@ -22,6 +22,7 @@ type t = {
   af : int;
   db : int;
   dbm : int;
+  el0 : int;
   }
 
 (* Default value *)

--- a/lib/PTEVal.mli
+++ b/lib/PTEVal.mli
@@ -24,16 +24,24 @@ type t = {
   dbm : int;
   }
 
-(* Default value for location argument *)
-val prot_default : t
-val default : string -> t
+(* Default value *)
+val prot_default : t (* Fields only *)
+val default : string -> t (* Physical address + default fields *)
+
 val set_oa : t -> string -> t
 
 (* Flags have default values *)
 val is_default : t -> bool
+
+(* Create fresh pteval *)
+(* With physical adress *)
 val of_list : string -> (string * string) list -> t
-val pp : t -> string
-val pp_hash : t -> string
+(* Without physcal adress *)
+val of_list0 : (string * string) list -> t
+
+(* Pretty print *)
+val pp : t -> string  (* Default field not printed *)
+val pp_hash : t -> string (* Backward compatibility for test hashes *)
 
 val compare : t -> t -> int
 val eq : t -> t -> bool

--- a/lib/op.ml
+++ b/lib/op.ml
@@ -89,6 +89,7 @@ type op1 =
   | SetDB (* set DB to 1 in PTE entry *)
   | DBM (* get DBM from PTE entry *)
   | Valid (* get Valid bit from PTE entry *)
+  | EL0 (* get EL0 bit from PTE entry *)
   | OA (* get OA from PTE entry *)
   | IsVirtual (* Detect virtual addresses *)
 
@@ -111,13 +112,14 @@ let pp_op1 hexa o = match o with
 | PTELoc -> "PTEloc"
 | PhyLoc -> "Phyloc"
 | IsVirtual -> "IsVirtual"
-| AF -> "AF" 
-| SetAF -> "SetAF" 
-| DB -> "DB" 
-| SetDB -> "SetDB" 
-| DBM -> "DBM" 
-| Valid -> "Valid" 
-| OA -> "OA" 
+| AF -> "AF"
+| SetAF -> "SetAF"
+| DB -> "DB"
+| SetDB -> "SetDB"
+| DBM -> "DBM"
+| Valid -> "Valid"
+| EL0 -> "EL0"
+| OA -> "OA"
 
 (***********)
 

--- a/lib/op.mli
+++ b/lib/op.mli
@@ -70,6 +70,7 @@ type op1 =
   | SetDB (* set DB to 1 in PTE entry *)
   | DBM (* get DBM from PTE entry *)
   | Valid (* get Valid from PTE entry *)
+  | EL0 (* get EL0 bit from PTE entry *)
   | OA (* get OA from PTE entry *)
   | IsVirtual (* Predicate for virtual adresses *)
 

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -47,6 +47,8 @@ let mk_lab p s = Label (p,s)
 %right IMPLIES
 %nonassoc NOT
 
+%type <PTEVal.t> pteval
+%start pteval
 %type <MiscParser.state> init
 %start init
 %type <MiscParser.location> main_location
@@ -80,6 +82,10 @@ name_or_num:
 
 maybev_prop:
 | separated_pair(NAME, COLON, name_or_num) { $1 };
+
+pteval:
+| LPAR separated_nonempty_list(COMMA, maybev_prop) RPAR
+    { PTEVal.of_list0 $2 }
 
 maybev_notag:
 | NUM  { Concrete $1 }

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -376,6 +376,9 @@ module Make(Cst:Constant.S) = struct
   let op_validloc a = Cst.intToV a.valid
   let validloc = op_pte_val "validloc" op_validloc
 
+  let op_el0loc a = Cst.intToV a.el0
+  let el0loc = op_pte_val "el0loc" op_el0loc
+
   let op_oaloc a = Cst.nameToV a.oa
   let oaloc = op_pte_val "oaloc" op_oaloc
 
@@ -435,6 +438,7 @@ module Make(Cst:Constant.S) = struct
     | SetDB -> setdb 
     | DBM -> dbmloc
     | Valid -> validloc
+    | EL0 -> el0loc
     | OA -> oaloc  
 
   let op op = match op with

--- a/lib/testHash.ml
+++ b/lib/testHash.ml
@@ -73,26 +73,30 @@ let digest_init debug init =
     | Location_deref (v,i) ->
         Printf.sprintf "%s[%i]" (ParsedConstant.pp_v v) i
   in
-
+  let pp_v v =
+    let open Constant in
+    match v with
+    | PteVal p -> PTEVal.pp_hash p
+    | _ -> ParsedConstant.pp_v v in
   let pp =
     (String.concat "; "
        (List.map
           (fun (loc,(t,v)) -> match t with
           | TyDef ->
               sprintf "%s=%s"
-                (dump_location loc) (ParsedConstant.pp_v v)
+                (dump_location loc) (pp_v v)
           | TyDefPointer ->
               sprintf "*%s=%s"
-                (dump_location loc) (ParsedConstant.pp_v v)
+                (dump_location loc) (pp_v v)
           | Ty t ->
               sprintf "%s %s=%s" t
-                (dump_location loc) (ParsedConstant.pp_v v)
+                (dump_location loc) (pp_v v)
           | Atomic t ->
               sprintf "_Atomic %s %s=%s" t
-                (dump_location loc) (ParsedConstant.pp_v v)
+                (dump_location loc) (pp_v v)
           | Pointer t ->
               sprintf "%s *%s=%s" t
-                (dump_location loc) (ParsedConstant.pp_v v)
+                (dump_location loc) (pp_v v)
           | TyArray (t,sz) ->
               sprintf "%s %s[%i]" t (dump_location loc) sz)
           init)) in

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -669,7 +669,7 @@ module Make
                   sprintf "pretty_addr_physical[unpack_oa(%s)]" v::
                   List.map
                     (fun f -> sprintf "unpack_%s(%s)" f v)
-                    ["af";"db";"dbm";"valid";] in
+                    ["af";"db";"dbm";"valid";"el0";] in
                 Some v,fs
             | _ ->
                 None,[sprintf "p->%s" (dump_loc_tag loc)])
@@ -695,7 +695,7 @@ module Make
                 let ds =
                   let open PTEVal in
                   let p = prot_default in
-                  let ds = [p.af; p.db; p.dbm; p.valid;] in
+                  let ds = [p.af; p.db; p.dbm; p.valid;p.el0;] in
                   List.map (sprintf "%i") ds in
                 let rec do_rec ds fs fmts = match ds,fs,fmts with
                   | [],[],[c] ->
@@ -770,8 +770,8 @@ module Make
               | Constant.PteVal p ->
                   let open PTEVal in
                   sprintf
-                    "pack_pack(%s,%d,%d,%d,%d)"
-                    (dump_addr_idx p.oa) p.af p.db p.dbm p.valid
+                    "pack_pack(%s,%d,%d,%d,%d,%d)"
+                    (dump_addr_idx p.oa) p.af p.db p.dbm p.valid p.el0
               | _ -> T.C.V.pp O.hexa v
               module Loc = struct
                 type t = A.location

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -680,14 +680,37 @@ module Make
             let prf = if !fst then "" else " " in
             fst := false ;
             match as_whole with
-            | Some as_whole ->
+            | Some as_whole -> (* Assuming a pteval_t *)
                 O.fi "if (%s == NULL_PACKED) {" as_whole ;
                 EPF.fii ~out:"chan"
                   "%s;" ["\""^prf^p1^"="^(if Cfg.hexa then "0x0" else "0")^"\""] ;
                 O.oi "} else {" ;
-                EPF.fii ~out:"chan" (sprintf "%s%s=%s;" prf p1 p2) arg ;
+                let oa,rem = match arg with
+                  | oa::rem -> oa,rem
+                  | [] -> assert false
+                and oa_fmt,rem_fmt = match p2 with
+                  | o::oa::rem -> o^oa,rem
+                  | _ -> assert false in
+                EPF.fii ~out:"chan" (sprintf "%s%s=%s" prf p1 oa_fmt) [oa] ;
+                let ds =
+                  let open PTEVal in
+                  let p = prot_default in
+                  let ds = [p.af; p.db; p.dbm; p.valid;] in
+                  List.map (sprintf "%i") ds in
+                let rec do_rec ds fs fmts = match ds,fs,fmts with
+                  | [],[],[c] ->
+                      let c = sprintf "\"%s\"" (String.escaped c) in
+                      EPF.fii ~out:"chan" "%s;" [c]
+                  | d::ds,f::fs,fmt::fmts ->
+                      O.fii "if (%s != %s)" f d ;
+                      EPF.fiii ~out:"chan" fmt [f] ;
+                      do_rec ds fs fmts
+                  |_ ->  (* All, defaults, arguments and formats agree *)
+                     assert false in
+                do_rec ds rem rem_fmt ;
                 O.oi "}"
             | None ->
+                let p2 = String.concat "" p2 in
                 EPF.fi ~out:"chan" (sprintf "%s%s=%s;" prf p1 p2) arg)
           fmt args ;
         begin match faults with

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -63,10 +63,11 @@ let dump_pteval_flags s p =
     let open PTEVal in
     let add b s k = if b<>0 then s::k else k in
     let msk =
-      add p.valid "msk_valid"
-        (add p.af "msk_af"
-           (add p.dbm "msk_dbm"
-              (add p.db "msk_db" []))) in
+      add p.el0 "msk_el0"
+        (add p.valid "msk_valid"
+           (add p.af "msk_af"
+              (add p.dbm "msk_dbm"
+                 (add p.db "msk_db" [])))) in
     let msk = String.concat "|" msk in
     sprintf "litmus_set_pte_flags(%s,%s)" s msk
 
@@ -280,7 +281,7 @@ module Make
         | CType.Pointer _ -> ["%s"]
         | CType.Base "pteval_t" ->
             ["("; "oa:%s";  ", af:%d"; ", db:%d";
-             ",  dbm:%d"; ", valid:%d"; ")"]
+             ", dbm:%d"; ", valid:%d"; ", el0:%d"; ")"]
         | CType.Base t -> [pp_fmt_base t]
         | CType.Atomic t|CType.Volatile t -> pp_fmt t
         | CType.Array (t,sz) ->


### PR DESCRIPTION
This field ---AP[1], bit 6 of pteval's--- controls access to virtual memory from exception level EL0. A value of 0 forbids access, a value of 1 allows access.

It is to be noticed that adding a field to pteval's would result in untimely consequences if one does not change the printing of pteval's (print all fields). To avoid those, this PR also includes the following changes.
1. Output by all tools is now changed, fields are not printed when their value is default.
2. For handling old logs, pteval's are normalised to new format internally by tools that consume logs (mcompare, msum..).
3. While computing hashes, a special printing mode is used: old mode for old fields (always print) and new mode for new fields (print when non-default).