### PR TITLE
[jingle,litmus] Allow setting libdir with -set-libdir

### DIFF
--- a/jingle/Version_jingle.ml
+++ b/jingle/Version_jingle.ml
@@ -1,3 +1,0 @@
-include Version
-
-let libdir = Filename.concat libdir "jingle"

--- a/jingle/gen_theme.ml
+++ b/jingle/gen_theme.ml
@@ -15,6 +15,7 @@
 open Printf
 
 let verbose = ref false
+let libdir = ref (Filename.concat Version.libdir "jingle")
 let includes = ref []
 let map = ref None
 let call = ref None
@@ -32,12 +33,14 @@ let () =
     ["-version",
      Arg.Unit
        (fun () ->
-         printf "%s, Rev: %s\n" Version_jingle.version Version_jingle.rev ;
+         printf "%s, Rev: %s\n" Version.version Version.rev ;
          exit 0),
      " - show version number and exit" ;
      "-libdir",
-     Arg.Unit (fun () -> print_endline Version_jingle.libdir; exit 0),
+     Arg.Unit (fun () -> print_endline !libdir; exit 0),
      " - show installation directory and exit";
+     "-set-libdir", Arg.String (fun s -> libdir := s),
+     "<path> set installation directory to <path>";
      "-v",Arg.Unit (fun () -> verbose := true),
      "- be verbose";
      "-I", Arg.String (fun s -> includes := !includes @ [s]),
@@ -67,7 +70,7 @@ let libfind =
       (struct
         let includes = includes
         let env = None
-        let libdir = Version_jingle.libdir
+        let libdir = !libdir
         let debug = verbose
       end) in
   ML.find

--- a/jingle/jingle.ml
+++ b/jingle/jingle.ml
@@ -16,6 +16,7 @@
 open Printf
 
 let verbose = ref 0
+let libdir = ref (Filename.concat Version.libdir "jingle")
 let includes = ref []
 let map = ref None
 let outdir = ref None
@@ -132,12 +133,14 @@ let () =
     ["-version",
      Arg.Unit
        (fun () ->
-         printf "%s, Rev: %s\n" Version_jingle.version Version_jingle.rev ;
+         printf "%s, Rev: %s\n" Version.version Version.rev ;
          exit 0),
      " show version number and exit" ;
      "-libdir",
-     Arg.Unit (fun () -> print_endline Version_jingle.libdir; exit 0),
+     Arg.Unit (fun () -> print_endline !libdir; exit 0),
      " show installation directory and exit";
+     "-set-libdir", Arg.String (fun s -> libdir := s),
+     "<path> set installation directory to <path>";
      "-v",Arg.Unit (fun () -> incr verbose),
      " be verbose, repeat to increase verbosity";
      "-I", Arg.String (fun s -> includes := !includes @ [s]),
@@ -162,7 +165,7 @@ let libfind =
       (struct
         let includes = includes
         let env = None
-        let libdir = Version_jingle.libdir
+        let libdir = !libdir
         let debug = verbose > 0
       end) in
   ML.find

--- a/litmus/Version_litmus.ml
+++ b/litmus/Version_litmus.ml
@@ -1,3 +1,0 @@
-include Version
-
-let libdir = Filename.concat libdir "litmus"

--- a/litmus/klitmus.ml
+++ b/litmus/klitmus.ml
@@ -74,10 +74,12 @@ let opts =
   [
 (* General behavior *)
    "-v", Arg.Unit (fun () -> incr verbose), " be verbose";
-   "-version", Arg.Unit (fun () -> print_endline Version_litmus.version; exit 0),
+   "-version", Arg.Unit (fun () -> print_endline Version.version; exit 0),
    " show version number and exit";
-   "-libdir", Arg.Unit (fun () -> print_endline Version_litmus.libdir; exit 0),
+   "-libdir", Arg.Unit (fun () -> print_endline !Option.libdir; exit 0),
    " show installation directory and exit";
+   "-set-libdir", Arg.String (fun s -> Option.libdir := s),
+   "<path> set installation directory to <path>";
    "-o", Arg.String set_tar,
      "<name> cross compilation to directory or tar file <name>" ;
    "-hexa", Arg.Set KOption.hexa,

--- a/litmus/litmus.ml
+++ b/litmus/litmus.ml
@@ -29,10 +29,12 @@ let opts =
   [
 (* General behavior *)
    "-v", Arg.Unit (fun () -> incr verbose), " be verbose";
-   "-version", Arg.Unit (fun () -> print_endline Version_litmus.version; exit 0),
+   "-version", Arg.Unit (fun () -> print_endline Version.version; exit 0),
    " show version number and exit";
-   "-libdir", Arg.Unit (fun () -> print_endline Version_litmus.libdir; exit 0),
+   "-libdir", Arg.Unit (fun () -> print_endline !Option.libdir; exit 0),
    " show installation directory and exit";
+   "-set-libdir", Arg.String (fun s -> Option.libdir := s),
+   "<path> set installation directory to <path>";
    "-switch", Arg.Set Misc.switch, "switch something" ;
    "-o", Arg.String set_tar,
      "<name> cross compilation to directory or tar file <name>" ;

--- a/litmus/myName.ml
+++ b/litmus/myName.ml
@@ -46,7 +46,7 @@ let open_lib name =
   with Exit -> try match envlib with
   | Some lib -> try_open lib name
   | None -> raise Exit
-  with Exit -> try try_open Version_litmus.libdir name
+  with Exit -> try try_open !Option.libdir name
   with Exit -> Warn.fatal "Cannot find file %s" name
 
 

--- a/litmus/option.ml
+++ b/litmus/option.ml
@@ -71,6 +71,9 @@ let argfloato opt r msg =
 (* verbose *)
 let verbose = ref 0
 
+(* Libdir *)
+let libdir = ref (Filename.concat Version.libdir "litmus")
+
 (* Special *)
 let tar = ref None
 let cross = ref false

--- a/litmus/option.mli
+++ b/litmus/option.mli
@@ -35,6 +35,9 @@ val argfloato : string -> float option ref -> string -> arg_triple
 (* Verbose *)
 val verbose : int ref
 
+(* Libdir *)
+val libdir : string ref
+
 (* Somehow special *)
 val cross : bool ref
 val set_tar : string -> unit

--- a/litmus/runUtils.ml
+++ b/litmus/runUtils.ml
@@ -133,7 +133,7 @@ let pp_barrier_loc =
 
 let report_parameters out =
   let pf fmt = ksprintf out fmt in
-  pf "Revision %s, version %s" Version_litmus.rev Version_litmus.version;
+  pf "Revision %s, version %s" Version.rev Version.version;
   pf "Command line:%s"
     (String.concat ""
        (List.map (sprintf " %s") (Array.to_list Sys.argv))) ;


### PR DESCRIPTION
This PR allows setting the libdir for Jingle & Litmus binaries with a flag, `-set-libdir`.

This was added to Herd in commit d465040feb53c1363c8c63868b4b6297195d7ad9.
