### PR TITLE
[herd] Fix size component of initial writes.

### DIFF
--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -402,23 +402,23 @@ module Make(C:Config) (I:I) : S with module I = I
 
       let misc_to_size ty  = match ty with
       | MiscParser.TyDef -> size_of "int"
-      | MiscParser.Ty t|MiscParser.Atomic t -> (size_of t)
-      | MiscParser.Pointer _
-      | MiscParser.TyDefPointer
+      | MiscParser.Ty t|MiscParser.Atomic t
+        -> size_of t
+      | MiscParser.Pointer _| MiscParser.TyDefPointer
+      (* Assuming pointer size is machine 'natural' size *)
+        ->  I.V.Cst.Scalar.machsize
       | MiscParser.TyArray _ ->
           Warn.fatal "Type %s is not allowed in mixed size mode"
             (MiscParser.pp_run_type ty)
 
-      let build_size_env =
-        if is_mixed then
-          fun bds ->
-            List.fold_left
-              (fun m (loc,(t,_)) -> match loc with
-              | Location_global a -> StringMap.add (I.V.as_symbol a) (misc_to_size t) m
-              | _ -> m)
-              StringMap.empty bds
-        else
-          (fun _ -> StringMap.empty)
+      let build_size_env bds =
+        List.fold_left
+          (fun m (loc,(t,_)) ->
+            match loc with
+            | Location_global a ->
+                StringMap.add (I.V.as_symbol a) (misc_to_size t) m
+            | _ -> m)
+          size_env_empty bds
 
       type final_state = state * FaultSet.t
 

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -1071,14 +1071,21 @@ let (>>>) = if do_deps then comb_instr_code_deps else comb_instr_code
             (A.V.Val (Constant.Symbolic ((Misc.add_ctag s,None,0),0))))
             def_size v; }
 
-      let initwrites_non_mixed env _ =
+      let initwrites_non_mixed env size_env =
         fun eiid ->
           let eiid,es =
             List.fold_left
               (fun (eiid,es) (loc,v) ->
+                let sz =
+                  match loc with
+                  | A.Location_global
+                    (A.V.Val (Constant.Symbolic ((s,_,_),0)))
+                        when not (Misc.check_atag s) ->
+                      A.look_size size_env s
+                  | _ -> def_size in
                 let eiid,ew =
                   make_one_init_event
-                    (E.Act.mk_init_write loc def_size v) eiid in
+                    (E.Act.mk_init_write loc sz v) eiid in
                 match loc with
                 | A.Location_global (A.V.Val (Constant.Symbolic ((s,_,_),0))) ->
                     let eiid,ews =

--- a/herd/tests/instructions/AArch64/L006.litmus
+++ b/herd/tests/instructions/AArch64/L006.litmus
@@ -1,0 +1,17 @@
+AArch64 L007
+{
+int x=2;
+int *p=&x;
+0:X2=p;
+int64_t y=3;
+int64_t *q=&y;
+0:X6=q;
+}
+
+ P0          ;
+ LDR X4,[X2] ;
+ LDR W0,[X4] ;
+ LDR X4,[X6] ;
+ LDR X1,[X4] ;
+
+forall (0:X0=2 /\ 0:X1=3)

--- a/herd/tests/instructions/AArch64/L006.litmus.expected
+++ b/herd/tests/instructions/AArch64/L006.litmus.expected
@@ -1,0 +1,10 @@
+Test L007 Required
+States 1
+0:X0=2; 0:X1=3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=2 /\ 0:X1=3)
+Observation L007 Always 1 0
+Hash=b77677b1c56acd8e1f4f4f944aa294c2
+


### PR DESCRIPTION
This PR add (correct) size component to initial writes.

Before, this size was systematically the machine 'natural' size (_e.g._ `Quad` for AArch64).
Now it depends on location type, with location of pointer type being the machine 'natural' size.