### PR TITLE
[doc] Allow the user to specify a LATEX, with fallbacks

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -321,7 +321,11 @@ clean::
 	/bin/rm -rf html
 
 #PS/PDF
-LATEX=rubber -f
+LATEX ?= $(if $(shell which rubber),\
+		rubber -f,\
+		$(if $(shell which latexmk),\
+			latexmk,\
+			$(error "Could not find either rubber or latexmk in PATH")))
 DVIPS=dvips
 PS2PDF=ps2pdf
 


### PR DESCRIPTION
This PR allows a user to build the documentation with the LaTeX build system of their choice.

Order of precidence:

- `make LATEX=mytex` will use `mytex`.
- `export LATEX=mytex; make` will use `mytex`.
- `make` with `rubber` in the `PATH` will use `rubber -f`.
- `make` with `latexmk` in the `PATH` will use `latexmk`.
- `make` with nothing suitable in the `PATH` will error.

Rationale: `latexmk` ships with TeX Live, while [`rubber`](https://gitlab.com/latex-rubber/rubber) can be hard to find.
The documentation seems to build fine with `latexmk`.
