### PR TITLE
Set internal control dependency from PTE read to db test-and-set attempt, replacing data dependency.

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -57,6 +57,7 @@ module Make
       let (>>=) = M.(>>=)
       let (>>==) = M.(>>==)
       let (>>*=) = M.(>>*=)
+      let (>>*==) = M.(>>*==)
       let (>>|) = M.(>>|)
       let (>>!) = M.(>>!)
       let (>>::) = M.(>>::)
@@ -325,7 +326,7 @@ module Make
         let ha = ha || hd in (* As far as we know hd => ha *)
 (* Perform PTE update, when told to do so *)
         let setbits_get_oa a_pte m =
-          m >>== fun pte_v ->
+          m >>*== fun pte_v ->
            (* >>== is important, as the test and set below
               is performed 'on the side ' *)
             begin if hd && dir = Dir.W then

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -170,6 +170,7 @@ Monad type:
     let (=**=) = E.(=**=)
     let (=*$=) = E.(=*$=)
     let (=$$=) = E.(=$$=)
+    let (=*$$=) = E.(=*$$=)
     let (+|+) = E.(+|+)
     let (=|=) = E.para_comp true
 
@@ -208,9 +209,11 @@ Monad type:
     let (>>==) : 'a t -> ('a -> 'b t) -> ('b) t
         = fun s f -> data_comp (=$$=) s f
 
-(* Bind the result *)
     let (>>*=) : 'a t -> ('a -> 'b t) -> ('b) t
-        = fun s f -> data_comp (=**=) s f
+      = fun s f -> data_comp (=**=) s f
+
+    let (>>*==) : 'a t -> ('a -> 'b t) -> ('b) t
+        = fun s f -> data_comp (=*$$=) s f
 
     let bind_ctrl_avoid ma s f = fun eiid ->
       let eiid,(mact,spec) = ma eiid in

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -46,6 +46,7 @@ module type S =
     val (>>=) : 'a t -> ('a -> 'b t) -> ('b) t
     val (>>==) : 'a t -> ('a -> 'b t) -> ('b) t (* Output event stay in first arg *)
     val (>>*=) : 'a t -> ('a -> 'b t) -> ('b) t
+    val (>>*==) : 'a t -> ('a -> 'b t) -> ('b) t (* Output event stay in first argument *)
     val bind_ctrl_avoid : 'c t -> 'a t -> ('a -> 'b t) -> 'b t
     val check_tags : 'v t -> ('v -> 'v t) -> ('v -> 'v t) -> 'x t -> 'v t
     val exch : 'a t -> 'a t -> ('a -> 'b t) ->  ('a -> 'c t) ->  ('b * 'c) t


### PR DESCRIPTION
It is more logical to have such an internal dependency from
page table read to db test-and-set, as the latter is attempted
when pteval bits have some values (db:0, dbm:1, valid:1) and not
attempted otherwise.