### PR TITLE
[build] remove the `stdint` dependency from herdtools7.opam

### DIFF
--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -21,5 +21,4 @@ depends: [
   "dune"  {>= "1.4" }
   "ocamlfind" { build }
   "menhir" {>= "20180530"}
-  "stdint" {>= "0.5.1" }
 ]


### PR DESCRIPTION
The actual code dependency was removed in commit 8cd04096a8e3203a75b24d7506ea84a82d6ca3d8.
