### PR TITLE
[internal_lib] Support parsing shelves on systems with no Python2

### DIFF
--- a/internal/lib/shelf.ml
+++ b/internal/lib/shelf.ml
@@ -61,9 +61,13 @@ let list_of_file path key =
    * shelf.py file, then prints the given global variables. *)
   let script chan =
     Printf.fprintf chan "import os\n" ;
+    Printf.fprintf chan "import sys\n" ;
     Printf.fprintf chan "os.chdir(%s)\n" (Filename.quote (Filename.dirname path)) ;
     Printf.fprintf chan "m = {}\n" ;
-    Printf.fprintf chan "execfile(%s, m)\n" (Filename.quote (Filename.basename path)) ;
+    Printf.fprintf chan "if sys.version_info >= (3, 0):\n" ;
+    Printf.fprintf chan "  exec(open(%s).read(), m)\n" (Filename.quote (Filename.basename path)) ;
+    Printf.fprintf chan "else:\n" ;
+    Printf.fprintf chan "  execfile(%s, m)\n" (Filename.quote (Filename.basename path)) ;
     Printf.fprintf chan "try:\n" ;
     Printf.fprintf chan "  v = m[%s]\n" (Filename.quote key) ;
     Printf.fprintf chan "  if isinstance(v, str):\n" ;


### PR DESCRIPTION
On macOS & some Linux distributions `python` is legacy Python 2, and `python3` is Python 3. However, on other Linux distributions `python` is Python 3 and there is no Python 2.

One of the changes from Python 2 to 3 was removing `execfile()` in favor of `exec()`. This commit uses the correct one depending on Python version.

This PR fixes Issue #149.
