### PR TITLE
[internal] herd_regression_test takes an optional -variant flag

### DIFF
--- a/internal/lib/args.ml
+++ b/internal/lib/args.ml
@@ -1,0 +1,51 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2013-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for using the built-in Arg module. *)
+
+
+(** Specs. *)
+
+let append_string r =
+  Arg.String (fun v -> r := !r @ [v])
+
+let set_string_option r =
+  Arg.String (fun v -> r := Some v)
+
+
+(** Validators. *)
+
+let validate check msg (key, spec, doc) =
+  let check_value v =
+    if not (check v) then
+      raise (Arg.Bad (Printf.sprintf "Invalid %s: %s" key msg))
+  in
+  let spec =
+    match spec with
+    | Arg.String f ->
+        Arg.String (fun v -> check_value v ; f v)
+    | Arg.Set_string r ->
+        Arg.String (fun v -> check_value v ; r := v)
+    | _ ->
+        failwith "Args.validate only accepts Arg.String or Arg.Set_string"
+  in
+  key, spec, doc
+
+let is_file =
+  validate (fun v -> Sys.file_exists v && not (Sys.is_directory v)) "Must be a path to a file"
+
+let is_dir =
+  validate Sys.is_directory "Must be a path to a directory"

--- a/internal/lib/args.mli
+++ b/internal/lib/args.mli
@@ -1,0 +1,40 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2013-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Utilities for using the built-in Arg module. *)
+
+
+(* Specs. *)
+
+(** [append_string r] builds an Arg.spec that appends to the string list
+ *  referenced by [r]. *)
+val append_string : string list ref -> Arg.spec
+
+(** [set_string_option r] builds an Arg.spec that, for argument value [v], sets
+ *  the string option referenced by [r] to [Some v]. *)
+val set_string_option : string option ref -> Arg.spec
+
+
+(** Validators. *)
+
+(** [is_file (k, s, d)] returns [k, s', d], where [s'] wraps [s] with an
+ *  Arg.spec that raises Arg.Bad if the argument is not a valid path to a file. *)
+val is_file : Arg.key * Arg.spec * Arg.doc -> Arg.key * Arg.spec * Arg.doc
+
+(** [is_dir (k, s, d)] returns [k, s', d], where [s'] wraps [s] with an
+ *  Arg.spec that raises Arg.Bad if the argument is not a valid path to a
+ *  directory. *)
+val is_dir : Arg.key * Arg.spec * Arg.doc -> Arg.key * Arg.spec * Arg.doc

--- a/internal/lib/base.ml
+++ b/internal/lib/base.ml
@@ -70,6 +70,11 @@ module Option = struct
     | None -> default
     | Some v -> v
 
+  let map f o =
+    match o with
+    | None -> None
+    | Some v -> Some (f v)
+
   let is_none o =
     match o with
     | None -> true

--- a/internal/lib/base.mli
+++ b/internal/lib/base.mli
@@ -67,6 +67,9 @@ module Option : sig
   (** [value o ~default] is [v] if [o] is [Some v] and [default] otherwise. *)
   val value : 'a option -> default:'a -> 'a
 
+  (** [map f o] is [None] if [o] is [None] and [Some (f v)] if [o] is [Some v]. *)
+  val map : ('a -> 'b) -> 'a option -> 'b option
+
   (** [is_none o] is [true] iff [o] is [None]. *)
   val is_none : 'a option -> bool
 

--- a/internal/lib/testHerd.mli
+++ b/internal/lib/testHerd.mli
@@ -16,48 +16,64 @@
 
 (* Utilities for running Herd binaries in tests. *)
 
-(** [herd_command ?bell ?cat ?variants herd libdir litmuses] returns the command line that [run_herd]
-  * would run. *)
-val herd_command :
-  ?bell:string ->
-  ?cat:string ->
-  ?variants:string list ->
-    string -> string -> string list -> string
+type path = string
 
 type stdout_lines = string list
 type stderr_lines = string list
 
-(** [run_herd ?bell ?cat ?variants herd libdir litmuses] runs the binary [herd]
-  * with a custom [libdir] on a [litmuses] files, and returns the stdout with
-  * unstable lines removed (e.g. Time) and stderr. Paths to cat & bell files,
-  * as well as variants, can also be passed in. *)
-val run_herd :
-  ?bell:string ->
-  ?cat:string ->
-  ?variants:string list ->
-    string -> string -> string list -> stdout_lines * stdout_lines
+(** [herd_command ~bell ~cat ~conf ~variants ~libdir herd litmuses] returns the
+ *  command line that [run_herd] would run. *)
+val herd_command :
+  bell     : path option ->
+  cat      : path option ->
+  conf     : path option ->
+  variants : string list ->
+  libdir   : path ->
+    path -> path list -> string
 
-(** [herd_output_matches_expected herd libdir litmus expected expected_failure] runs the binary
-  * [herd] with a custom [libdir] on a [litmus] file, and compares the output
-  * with an [expected] file. If the run writes to stderr then we check [expected_failure].
-  * If the contents of [expected_failure] match then it is an expected failure, otherwise
-  * it is an unexpected failure and will raise an Error. *)
-val herd_output_matches_expected : string -> string -> string -> string -> string -> bool
+(** [run_herd ~bell ~cat ~conf ~variants ~libdir herd litmuses] runs the
+ *  binary [herd] with a custom [libdir] on list of litmus files [litmuses],
+ *  and returns the stdout with unstable lines removed (e.g. Time) and stderr.
+ *  Paths to [cat], [bell], and [conf] files, as well as [variants], can also
+ *  be passed in. *)
+val run_herd :
+  bell     : path option ->
+  cat      : path option ->
+  conf     : path option ->
+  variants : string list ->
+  libdir   : path ->
+    path -> path list -> stdout_lines * stdout_lines
+
+(** [herd_output_matches_expected ~bell ~cat ~conf ~variants ~libdir herd
+ *  litmus expected expected_failure] runs the binary [herd] with a custom
+ *  [libdir] on a [litmus] file, and compares the output with an [expected]
+ *  file. If the run writes to stderr then we check [expected_failure]. If the
+ *  contents of [expected_failure] match then it is an expected failure,
+ *  otherwise it is an unexpected failure and will raise an Error.
+ *  Paths to [cat], [bell], and [conf] files, as well as [variants], can also
+ *  be passed in. *)
+val herd_output_matches_expected :
+  bell     : path option ->
+  cat      : path option ->
+  conf     : path option ->
+  variants : string list ->
+  libdir   : path ->
+    path -> path -> path -> path -> bool
 
 (** [is_litmus filename] returns whether the [filename] is a .litmus file. *)
-val is_litmus : string -> bool
+val is_litmus : path -> bool
 
 (** [is_expected filename] returns whether [filename] is a .litmus.expected file. *)
-val is_expected : string -> bool
+val is_expected : path -> bool
 
 (** [expected_of_litmus filename] returns the .litmus.expected name for a given .litmus [filename]. *)
-val expected_of_litmus : string -> string
+val expected_of_litmus : path -> path
 
 (** [litmus_of_expected filename] returns the .litmus name for a given .litmus.expected [filename]. *)
-val litmus_of_expected : string -> string
+val litmus_of_expected : path -> path
 
 (** [expected_failure_of_litmus filename] returns the .litmus.expected-failure name for a given .litmus [filename]. *)
-val expected_failure_of_litmus : string -> string
+val expected_failure_of_litmus : path -> path
 
 (** [litmus_of_expected_failure filename] returns the .litmus name for a given .litmus.expected-failure [filename]. *)
-val litmus_of_expected_failure : string -> string
+val litmus_of_expected_failure : path -> path


### PR DESCRIPTION
This PR:
- Adds a `-variant` flag to `herd_regression_test`.
- Adds a `-conf` flag to `herd_regression_test` and `herd_diycross_regression_test`.
- Adds a `~conf` parameter to all `TestHerd` functions.
- Adds a module for additional argument types & validation, `Args`.
- Rewrites & unifies argument parsing for `herd_regression_test`, `herd_catalogue_regression_test`, and `herd_diycross_regression_test`.

It also:
- Backports `Option.map` from OCaml 4.08 into `Base`.
- Modifies 2 existing Herd regression litmus tests so that they pass under `-variant mixed`.