### PR TITLE
Pte squared

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -532,7 +532,7 @@ module Make
         else if kvm then
           let mphy ma a_virt =
             M.op1 Op.IsVirtual a_virt >>= fun c ->
-              M.choiceT c (mop Act.A_PHY ma) (mop Act.A_PTE ma) >>! B.Next in
+              M.choiceT c (mop Act.A_PHY ma) (mop Act.A_PHY_PTE ma) >>! B.Next in
           lift_kvm dir mop ma an ii mphy
         else
           mop Act.A_VIR ma >>! B.Next

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -305,9 +305,13 @@ module Make(C:Config) (I:I) : S with module I = I
       module FaultArg = struct
         include LocArg
         open Constant
-        let same_base v1 v2 =  match v1,v2 with
-        |I.V.Val (Symbolic (Virtual ((s1,_),_))),
-          I.V.Val (Symbolic (Virtual ((s2,_),_))) ->
+
+        let same_id_fault v1 v2 =  match v1,v2 with
+        | (I.V.Val (Symbolic (Virtual ((s1,_),_))),
+           I.V.Val (Symbolic (Virtual ((s2,_),_))))
+        | (I.V.Val (Symbolic (System (PTE,s1))),
+           I.V.Val (Symbolic (System (PTE,s2))))
+           ->
             Misc.string_eq s1 s2
         | _,_ -> false
 
@@ -319,7 +323,7 @@ module Make(C:Config) (I:I) : S with module I = I
         match loc1,loc2 with
         | (Location_global v1|Location_deref (v1,_)),
           (Location_global v2|Location_deref (v2,_))
-          -> FaultArg.same_base v1 v2
+          -> FaultArg.same_id_fault v1 v2
         |  _,_ -> false
 
 (************************)

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -1189,13 +1189,15 @@ Monad type:
                 else (pte_loc s,default_pteval s)::env)
               virt env in
           let env =
-            List.fold_right
-              (fun (loc,_ as bd) env -> match loc with
-              | A.Location_global (V.Val (Symbolic (System (PTE,s))))
-                ->
+            if C.variant Variant.PTE2 then
+              List.fold_right
+                (fun (loc,_ as bd) env -> match loc with
+                | A.Location_global (V.Val (Symbolic (System (PTE,s))))
+                  ->
                   bd::(pte2_loc s,pteval_of_pte s)::env
-              | _ -> bd::env)
-              env [] in
+               | _ -> bd::env)
+                env []
+            else env in
           env
 
       let debug_add_initpte env =

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -1128,8 +1128,10 @@ Monad type:
              (fun (loc,v) -> sprintf "%s -> %s" (A.pp_location loc) (A.V.pp_v v))
              env)
 
-      let default_pteval s =
-        V.Val (Constant.PteVal (PTEVal.default s))
+      let val_of_pteval p = V.Val (Constant.PteVal p)
+
+      let default_pteval s = val_of_pteval (PTEVal.default s)
+      and pteval_of_pte s = val_of_pteval (PTEVal.of_pte s)
 
       let expand_pteval loc v =
         let open Constant in
@@ -1161,6 +1163,10 @@ Monad type:
         let open Constant in
         A.Location_global (V.Val (Symbolic (System (PTE,s))))
 
+      let pte2_loc s =
+        let open Constant in
+        A.Location_global (V.Val (Symbolic (System (PTE2,s))))
+
       let phy_loc s =
         let open Constant in
         A.Location_global (V.Val (Symbolic (Physical (s,0))))
@@ -1182,6 +1188,14 @@ Monad type:
                 if StringSet.mem s pte then env
                 else (pte_loc s,default_pteval s)::env)
               virt env in
+          let env =
+            List.fold_right
+              (fun (loc,_ as bd) env -> match loc with
+              | A.Location_global (V.Val (Symbolic (System (PTE,s))))
+                ->
+                  bd::(pte2_loc s,pteval_of_pte s)::env
+              | _ -> bd::env)
+              env [] in
           env
 
       let debug_add_initpte env =

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -77,7 +77,7 @@ end = struct
     match cst with
     | Symbolic (Virtual _) -> A_VIR
     | Symbolic (Physical _) -> A_PHY
-    | Symbolic (System (PTE,_)) -> A_PTE
+    | Symbolic (System ((PTE|PTE2),_)) -> A_PTE
     | Symbolic (System (TLB,_)) -> A_TLB
     | Symbolic (System (TAG,_)) -> A_TAG
     | Label _|Tag _|Concrete _|PteVal _ as v ->
@@ -89,7 +89,7 @@ end = struct
   | V.Var _ -> assert false
   | V.Val cst -> access_of_constant cst
 
-  let access_of_location = function
+  let access_of_location_init = function
     | A.Location_reg _ -> A_REG
     | A.Location_global v
     | A.Location_deref (v,_)
@@ -106,24 +106,10 @@ end = struct
           if kvm then A_PTE
           else Warn.fatal "PTE %s while -variant kvm is not active"
               (A.pp_location loc)
-(*    | A.Location_global (V.Val (Symbolic ((System (AF,_))))) as loc
-      ->
-      if kvm then A_AF
-      else Warn.fatal "AF %s while -variant kvm is not active"
-      (A.pp_location loc)
-      | A.Location_global (V.Val (Symbolic ((System (DB,_))))) as loc
-      ->
-      if kvm then A_DB
-      else Warn.fatal "DB %s while -variant kvm is not active"
-      (A.pp_location loc)
-      | A.Location_global (V.Val (Symbolic ((System (DBM,_))))) as loc
-      ->
-      if kvm then A_DBM
-      else Warn.fatal "DBM %s while -variant kvm is not active"
-      (A.pp_location loc)
- *)    | A.Location_global v
-| A.Location_deref (v,_)
-  -> Warn.fatal "access_of_location_std on non-standard symbol '%s'\n" (V.pp_v v)
+      | A.Location_global v
+      | A.Location_deref (v,_)
+        -> Warn.fatal "access_of_location_std on non-standard symbol '%s'\n" (V.pp_v v)
+
 
 
   type action =
@@ -140,7 +126,7 @@ end = struct
   | A.V.Val (Constant.Tag _) ->
       Access(W,l,v,A.empty_annot,A.exp_annot,sz,A_TAG)
   | _ ->
-      Access(W,l,v,A.empty_annot,A.exp_annot,sz,access_of_location l)
+      Access(W,l,v,A.empty_annot,A.exp_annot,sz,access_of_location_init l)
 
   let pp_action a = match a with
   | Access (d,l,v,an,exp_an,sz,_) ->

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -44,7 +44,10 @@ type t =
   | Instances (* Compute dependencies on instruction instances *)
   | Kvm
   | ETS
-  | PteBranch (* Insert branching event between pte read and accesses *)
+(* Insert branching event between pte read and accesses *)
+  | PteBranch
+(* Pte-Squared: all accesses through page table, including PT accesses *)
+  | PTE2
 (* Perform experiment *)
   | Exp
   
@@ -53,7 +56,9 @@ let tags =
    "fullscdepend";"splittedrmw";"switchdepscwrite";"switchdepscresult";"lrscdiffok";
    "mixed";"dontcheckmixed";"weakpredicated"; "memtag";
    "tagcheckprecise"; "tagcheckunprecise"; "precise"; "imprecise";
-   "toofar"; "deps"; "instances"; "ptebranch"; "exp"; ]
+   "toofar"; "deps"; "instances"; "ptebranch"; "pte2"; "pte-squared";
+   "exp"; ]
+
 
 let parse s = match Misc.lowercase s with
 | "success" -> Some Success
@@ -80,6 +85,7 @@ let parse s = match Misc.lowercase s with
 | "kvm" -> Some Kvm
 | "ets" -> Some ETS
 | "ptebranch"|"branch" -> Some PteBranch
+| "pte2" | "pte-squared" -> Some PTE2
 | "exp" -> Some Exp
 | _ -> None
 
@@ -108,6 +114,7 @@ let pp = function
   | Kvm -> "kvm" 
   | ETS -> "ets"
   | PteBranch -> "PteBranch"
+  | PTE2 -> "pte-squared"
   | Exp -> "exp"
 
 let compare = compare

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -42,7 +42,10 @@ type t =
   | Instances (* Compute dependencies on instruction instances *)
   | Kvm
   | ETS 
-  | PteBranch (* Insert branching event between pte read and accesses *)
+(* Insert branching event between pte read and accesses *)
+  | PteBranch
+(* Pte-Squared: all accesses through page table, including PT accesses *)
+  | PTE2
 (* Perform experiment *)
   | Exp
 

--- a/lib/PTEVal.ml
+++ b/lib/PTEVal.ml
@@ -48,6 +48,8 @@ type t = {
 let prot_default =  { oa=""; valid=1; af=1; db=1; dbm=0; el0=1; attrs=Attrs.default; }
 let default s = { prot_default with  oa=Misc.add_physical s; }
 
+let of_pte s = { prot_default with  oa=Misc.add_pte s; el0=0; }
+
 let pp_field ok pp eq ac p k =
   let f = ac p in if not ok && eq f (ac prot_default) then k else pp f::k
 

--- a/lib/PTEVal.mli
+++ b/lib/PTEVal.mli
@@ -40,6 +40,10 @@ type t = {
 val prot_default : t (* Fields only *)
 val default : string -> t (* Physical address + default fields *)
 
+(* Value for pte argument *)
+val of_pte : string -> t
+
+(* Set oa  field *)
 val set_oa : t -> string -> t
 
 (* Flags have default values *)

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -18,7 +18,7 @@ open Printf
 
 (** Constants in code *)
 
-type syskind = PTE|TAG|TLB
+type syskind = PTE|PTE2|TLB|TAG
 
 type symbol =
   | Virtual of (string * string option) * int (* (symbol, optional tag), index *)
@@ -38,6 +38,7 @@ let pp_symbol = function
   | Physical (s,o) -> pp_index (Misc.add_physical s) o
   | System (TLB,s) -> Misc.add_tlb s
   | System (PTE,s) -> Misc.add_pte s
+  | System (PTE2,s) -> Misc.add_pte (Misc.add_pte s)
   | System (TAG,s) -> Misc.add_atag s
 
 let as_address = function

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -21,7 +21,13 @@
    used by all tools. Abstract later?
 *)
 
-type syskind = PTE|TAG|TLB (* Various kinds of system memory *)
+(* Various kinds of system memory *)
+
+type syskind =
+  | PTE  (* Page table entry *)
+  | PTE2 (* Page table entry of page table entry (non-writable) *)
+  | TLB  (* TLB key *)
+  | TAG  (* Tag for MTE *)
 
 type symbol =
   | Virtual of (string * string option) * int (* (symbol, optional tag), index *)

--- a/lib/fault.ml
+++ b/lib/fault.ml
@@ -21,7 +21,7 @@ module type I = sig
   type arch_global
   val pp_global : arch_global -> string
   val global_compare : arch_global -> arch_global -> int
-  val same_base : arch_global -> arch_global -> bool
+  val same_id_fault : arch_global -> arch_global -> bool
 end
 
 type 'loc atom =  (Proc.t * Label.t option) * 'loc
@@ -105,7 +105,7 @@ module Make(A:I) =
 
     let check_one_fatom ((p0,lbls0),x0,_)  ((p,lblo),x) =
       Proc.compare p p0 = 0 &&
-      A.same_base x x0 &&
+      A.same_id_fault x x0 &&
       begin match lblo with
       | None -> true
       | Some lbl -> Label.Set.mem lbl lbls0

--- a/lib/fault.mli
+++ b/lib/fault.mli
@@ -21,7 +21,8 @@ module type I = sig
   type arch_global
   val pp_global : arch_global -> string
   val global_compare : arch_global -> arch_global -> int
-  val same_base : arch_global -> arch_global -> bool
+(* Identifiers in faults are considered identical *)
+  val same_id_fault : arch_global -> arch_global -> bool
 end
 
 type 'loc atom =  (Proc.t * Label.t option) * 'loc

--- a/lib/op.ml
+++ b/lib/op.ml
@@ -82,7 +82,6 @@ type op1 =
   | UnSetXBits of int * int (* Unset x bits to the left from y*)
   | TLBLoc (* get TLB entry from location *)
   | PTELoc (* get PTE entry from location *)
-  | PhyLoc (* get PA from VA *)
   | AF (* get AF from PTE entry *)
   | SetAF (* set AF to 1 in PTE entry *)
   | DB (* get DB from PTE entry *)
@@ -110,7 +109,6 @@ let pp_op1 hexa o = match o with
 | UnSetXBits (nbBits, from) -> sprintf "unset %i bits to the left from %ith bit" nbBits from
 | TLBLoc -> "TLBloc"
 | PTELoc -> "PTEloc"
-| PhyLoc -> "Phyloc"
 | IsVirtual -> "IsVirtual"
 | AF -> "AF"
 | SetAF -> "SetAF"

--- a/lib/op.mli
+++ b/lib/op.mli
@@ -63,7 +63,6 @@ type op1 =
   | UnSetXBits of int * int
   | TLBLoc (* get TLB entry from location *)
   | PTELoc (* get PTE entry from location *)
-  | PhyLoc (* get PA from VA *)
   | AF (* get AF from PTE entry *)
   | SetAF (* set AF to 1 in PTE entry *)
   | DB (* get DB from PTE entry *)

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -348,8 +348,12 @@ module Make(Cst:Constant.S) = struct
       Warn.user_error "Illegal %s on %s" op_op (pp_v v)
   | Var _ -> raise Undetermined
 
-  let op_pteloc (a,_) = Symbolic (System (PTE,a))
-  let pteloc = op_pte_tlb "pteloc" op_pteloc
+  let pteloc v = match v with
+  | Val (Symbolic (Virtual ((a,_),_))) -> Val (Symbolic (System (PTE,a)))
+  | Val (Symbolic (System (PTE,a))) -> Val (Symbolic (System (PTE2,a)))
+  | Val (Concrete _|Label _|Tag _|Symbolic _|PteVal _) ->
+      Warn.user_error "Illegal pteloc on %s" (pp_v v)
+  | Var _ -> raise Undetermined
 
   let op_pte_val op_op op v = match v with
   | Val (PteVal a) -> Val (op a)
@@ -384,9 +388,6 @@ module Make(Cst:Constant.S) = struct
 
   let op_tlbloc (a,_) = Symbolic (System (TLB,a))
   let tlbloc = op_pte_tlb "tlbloc" op_tlbloc
-
-  let op_phyloc (a,_) = Symbolic (Physical (a,0))
-  let phyloc = op_pte_tlb "phyloc" op_phyloc
 
   let is_virtual v = match v with
   | Val c -> Constant.is_virtual c
@@ -430,7 +431,6 @@ module Make(Cst:Constant.S) = struct
           (fun s -> logand (lognot (mask_many nb k)) s)
     | TLBLoc -> tlbloc
     | PTELoc -> pteloc
-    | PhyLoc -> phyloc
     | IsVirtual -> is_virtual_v
     | AF -> afloc 
     | SetAF -> setaf 

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -156,6 +156,10 @@ module Make(Cst:Constant.S) = struct
     | (Val (PteVal _),Val (PteVal _))
       ->
         Val (Concrete (Scalar.of_int (compare  v1 v2)))
+    | (Val (PteVal _),Val cst)
+    | (Val cst,Val (PteVal _))
+        when Cst.eq cst Cst.zero ->
+          Val (Cst.one)
     | _,_
       ->
         binop Op.Sub Scalar.sub v1 v2

--- a/tools/alpha.ml
+++ b/tools/alpha.ml
@@ -184,8 +184,7 @@ struct
     let nopte_value () = Warn.user_error "No pteval_t value for %s" Sys.argv.(0)
 
     let collect_value f v k = match v with
-    | Symbolic (Virtual ((s,_),_))
-    | Symbolic (System (PTE,s))
+    | Symbolic (Virtual ((s,_),_)|System ((PTE|PTE2),s))
       -> f s k
     | Concrete _ -> k
     | Label _ -> nolabel_value ()
@@ -197,6 +196,7 @@ struct
     let map_value f v = match v with
     | Symbolic (Virtual ((s,t),o)) -> Symbolic (Virtual ((f s,t),o))
     | Symbolic (System (PTE,s)) ->  Symbolic (System (PTE,f s))
+    | Symbolic (System (PTE2,s)) ->  Symbolic (System (PTE2,f s))
     | Concrete _ -> v
     | Label _ -> nolabel_value ()
     | Tag _ -> notag_value ()


### PR DESCRIPTION
Handle accesses to the page table as ordinary, virtual, accesses. Caveats.
- Access to page table control is more than just page tables attributes.
- Altering the page table entry of page table pages is not supported.
Also notice that the mode is enabled dynamically by variant `-variant pte-squared`.