### PR TITLE
[gen] Add support for Neon

### DIFF
--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -503,7 +503,9 @@ include
 
       let pp_reg = pp_reg
       let free_registers = allowed_for_symb
-      include NoSpecial
+
+      type special = reg
+      let specials = vregs
     end)
 
 end

--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -34,6 +34,7 @@ let do_tag = C.variant Variant_gen.MemTag
 let do_morello = C.variant Variant_gen.Morello
 let do_kvm = C.variant Variant_gen.KVM
 
+let do_neon = C.variant Variant_gen.Neon
 open Code
 open Printf
 
@@ -62,9 +63,10 @@ type atom_pte =
   | Read|ReadAcq|ReadAcqPc
   | Set of w_pte
   | SetRel of w_pte
+type neon_sizes = N1 | N2 | N3 | N4
 type atom_acc =
   | Plain of capa_opt | Acq of capa_opt | AcqPc of capa_opt | Rel of capa_opt
-  | Atomic of atom_rw | Tag | CapaTag | CapaSeal | Pte of atom_pte
+  | Atomic of atom_rw | Tag | CapaTag | CapaSeal | Pte of atom_pte | Neon of neon_sizes
 
 type atom = atom_acc * MachMixed.t option
 
@@ -107,6 +109,11 @@ let applies_atom (a,_) d = match a,d with
      | ReadAcqPc -> "Q"
      | Set set -> pp_w_pte set
      | SetRel set -> pp_w_pte set ^"L"
+   let pp_neon_size = function
+     | N1 -> "1"
+     | N2 -> "2"
+     | N3 -> "3"
+     | N4 -> "4"
 
    let pp_atom_acc = function
      | Atomic rw -> sprintf "X%s" (pp_atom_rw rw)
@@ -118,6 +125,7 @@ let applies_atom (a,_) d = match a,d with
      | CapaTag -> "Ct"
      | CapaSeal -> "Cs"
      | Pte p -> sprintf "Pte%s" (pp_atom_pte p)
+     | Neon n -> sprintf "N%s" (pp_neon_size n)
 
    let pp_atom (a,m) = match a with
    | Plain o ->
@@ -162,6 +170,8 @@ let applies_atom (a,_) d = match a,d with
      if do_morello then fun f r -> f CapaSeal (f CapaTag r)
      else fun _f r -> r
 
+   let fold_neon f r = f N1 (f N2 (f N3 (f N4 r)))
+
    let fold_acc_opt o f r =
      let r = f (Acq o) r in
      let r = f (AcqPc o) r in
@@ -172,6 +182,7 @@ let applies_atom (a,_) d = match a,d with
      let r = if mixed then r else fold_pte (fun p r -> f (Pte p) r) r in
      let r = fold_morello f r in
      let r = fold_tag f r in
+     let r = fold_neon (fun n -> f (Neon n)) r in
      let r = fold_acc_opt None f r in
      let r =
        if do_morello then
@@ -192,7 +203,7 @@ let applies_atom (a,_) d = match a,d with
 
    let worth_final (a,_) = match a with
      | Atomic _ -> true
-     | Acq _|AcqPc _|Rel _|Plain _|Tag|CapaTag|CapaSeal|Pte _ -> false
+     | Acq _|AcqPc _|Rel _|Plain _|Tag|CapaTag|CapaSeal|Pte _|Neon _ -> false
 
 
 
@@ -255,7 +266,7 @@ let applies_atom (a,_) d = match a,d with
    | CapaTag,None -> Code.CapaTag
    | CapaSeal,None -> Code.CapaSeal
    | (Tag|CapaTag|CapaSeal|Pte _),Some _ -> assert false
-   | (Plain _|Acq _|AcqPc _|Rel _|Atomic (PP|PL|AP|AL)),_
+   | (Plain _|Acq _|AcqPc _|Rel _|Atomic (PP|PL|AP|AL)|Neon _),_
       -> Code.Ord
 
 
@@ -275,9 +286,9 @@ let applies_atom (a,_) d = match a,d with
 
 let overwrite_value v ao w = match ao with
 | None
-| Some ((Atomic _|Acq _|AcqPc _|Rel _|Plain _|Tag|CapaTag|CapaSeal|Pte _),None)
+| Some ((Atomic _|Acq _|AcqPc _|Rel _|Plain _|Tag|CapaTag|CapaSeal|Pte _|Neon _),None)
   -> w (* total overwrite *)
-| Some ((Atomic _|Acq _|AcqPc _|Rel _|Plain _),Some (sz,o)) ->
+| Some ((Atomic _|Acq _|AcqPc _|Rel _|Plain _|Neon _),Some (sz,o)) ->
     ValsMixed.overwrite_value v sz o w
 | Some ((Tag|CapaTag|CapaSeal|Pte _),Some _) ->
     assert false
@@ -286,8 +297,8 @@ let overwrite_value v ao w = match ao with
   | None
   | Some
       ((Atomic _|Acq _|AcqPc _|Rel _|Plain _
-        |Tag|CapaTag|CapaSeal|Pte _),None) -> v
-  | Some ((Atomic _|Acq _|AcqPc _|Rel _|Plain _|Tag|CapaTag|CapaSeal),Some (sz,o)) ->
+        |Tag|CapaTag|CapaSeal|Pte _|Neon _),None) -> v
+  | Some ((Atomic _|Acq _|AcqPc _|Rel _|Plain _|Tag|CapaTag|CapaSeal|Neon _),Some (sz,o)) ->
       ValsMixed.extract_value v sz o
   | Some (Pte _,Some _) -> assert false
 

--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -78,7 +78,7 @@ let applies_atom (a,_) d = match a,d with
 | Rel _,W
 | Pte (Read|ReadAcq|ReadAcqPc),R
 | Pte (Set _|SetRel _),W
-| (Plain _|Atomic _|Tag|CapaTag|CapaSeal),(R|W)
+| (Plain _|Atomic _|Tag|CapaTag|CapaSeal|Neon _),(R|W)
   -> true
 | _ -> false
 

--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -265,7 +265,7 @@ let applies_atom (a,_) d = match a,d with
    | Pte _,None -> Code.Pte
    | CapaTag,None -> Code.CapaTag
    | CapaSeal,None -> Code.CapaSeal
-   | (Tag|CapaTag|CapaSeal|Pte _),Some _ -> assert false
+   | (Tag|CapaTag|CapaSeal|Pte _|Neon _),Some _ -> assert false
    | (Plain _|Acq _|AcqPc _|Rel _|Atomic (PP|PL|AP|AL)|Neon _),_
       -> Code.Ord
 

--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -265,8 +265,9 @@ let applies_atom (a,_) d = match a,d with
    | Pte _,None -> Code.Pte
    | CapaTag,None -> Code.CapaTag
    | CapaSeal,None -> Code.CapaSeal
+   | Neon _,None -> Code.VecReg
    | (Tag|CapaTag|CapaSeal|Pte _|Neon _),Some _ -> assert false
-   | (Plain _|Acq _|AcqPc _|Rel _|Atomic (PP|PL|AP|AL)|Neon _),_
+   | (Plain _|Acq _|AcqPc _|Rel _|Atomic (PP|PL|AP|AL)),_
       -> Code.Ord
 
 

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -529,6 +529,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let r,init,cs,st = emit_load_mixed MachSize.S128 0 st p init x in
       let cs2 = lift_code [gctype r r] in
       r,init,cs@cs2,st
+    | Code.VecReg -> LDN.emit_load N1
     let emit_obs_not_value = OBS.emit_load_not_value
     let emit_obs_not_eq = OBS.emit_load_not_eq
     let emit_obs_not_zero = OBS.emit_load_not_zero

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -49,6 +49,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
 (* Utilities *)
     let next_reg x = A64.alloc_reg x
+    let next_vreg x = A64.alloc_special x
     let pseudo = List.map (fun i -> Instruction i)
 
     let tempo1 st = A.alloc_trashed_reg "T1" st (* May be used for address  *)
@@ -443,7 +444,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     module LDN = struct
       let emit_load n st p init x =
-        let rA,st = next_reg st in
+        let rA,st = next_vreg st in
         let rB,init,st = U.next_init st p init x in
         rA,init,lift_code [ldn n rA rB],st
     end
@@ -616,7 +617,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         init,pseudo [stn n rA rB],st
 
       let emit_store n st p init x =
-        let rA,st = next_reg st in
+        let rA,st = next_vreg st in
         let init,cs,st = emit_store_reg n st p init x rA in
         init,pseudo [movi_reg rA]@cs,st
     end

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1029,7 +1029,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let r,init,cs,st = emit_load_mixed MachSize.S128 0 st p init loc in
             Some r,init,cs@lift_code [gctype r r],st
         | R,Some (CapaSeal,Some _) -> assert false
-        | R,Some (Neon n, _) -> let r,init,cs,st = LDN.emit_load n st p init loc in Some r,init,cs,st
+        | R,Some (Neon n, None) -> let r,init,cs,st = LDN.emit_load n st p init loc in Some r,init,cs,st
+        | R,Some (Neon _,Some _) -> assert false
         | W,None ->
             let init,cs,st = STR.emit_store st p init loc e.v None evt_null in
             None,init,cs,st
@@ -1097,7 +1098,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let init,cs,st = emit_str_addon st p init rB rA (Some Capability) {e with cseal = e.v} in
             None,init,csi@cs@lift_code [str_mixed MachSize.S128 0 rB rA],st
         | W,Some (CapaSeal,Some _) -> assert false
-        | W,Some (Neon n, _) -> let init,cs,st = STN.emit_store n st p init loc in None,init,cs,st
+        | W,Some (Neon n, None) -> let init,cs,st = STN.emit_store n st p init loc in None,init,cs,st
+        | W,Some (Neon _,Some _) -> assert false
         end
 
     let emit_exch st p init er ew =

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -152,11 +152,11 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let ldaxr r1 r2 = I_LDAR (vloc,AX,r1,r2)
     let sxtw r1 r2 = I_SXTW (r1,r2)
     let do_ldr_idx v1 v2 r1 r2 idx = I_LDR (v1,r1,r2,RV (v2,idx),S_NOEXT)
-    let ldn n r1 r2 = match n with
-    | N1 -> I_LD1M ([r1],r2,K 0)
-    | N2 -> I_LD2M ([r1],r2,K 0)
-    | N3 -> I_LD3M ([r1],r2,K 0)
-    | N4 -> I_LD4M ([r1],r2,K 0)
+    let ldn n rs rt = match n with
+    | N1 -> I_LD1M (rs,rt,K 0)
+    | N2 -> I_LD2M (rs,rt,K 0)
+    | N3 -> I_LD3M (rs,rt,K 0)
+    | N4 -> I_LD4M (rs,rt,K 0)
 
 
     let ldr_mixed_idx v r1 r2 idx sz  =
@@ -188,11 +188,11 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let str_idx = do_str_idx vloc
     let stxr r1 r2 r3 = I_STXR (vloc,YY,r1,r2,r3)
     let stlxr r1 r2 r3 = I_STXR (vloc,LY,r1,r2,r3)
-    let stn n r1 r2 = match n with
-    | N1 -> I_ST1M ([r1],r2,K 0)
-    | N2 -> I_ST2M ([r1],r2,K 0)
-    | N3 -> I_ST3M ([r1],r2,K 0)
-    | N4 -> I_ST4M ([r1],r2,K 0)
+    let stn n rs rt = match n with
+    | N1 -> I_ST1M (rs,rt,K 0)
+    | N2 -> I_ST2M (rs,rt,K 0)
+    | N3 -> I_ST3M (rs,rt,K 0)
+    | N4 -> I_ST4M (rs,rt,K 0)
 
     let stxr_sz t sz r1 r2 r3 =
       let open MachSize in
@@ -443,10 +443,19 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         end)
 
     module LDN = struct
+
+      let emit_vregs n st =
+        let rec get_reg_list n rs st = match n with
+        | N1 -> let r,st = next_vreg st in (rs@[r]),st
+        | N2 -> let r,st = next_vreg st in get_reg_list N1 (rs@[r]) st
+        | N3 -> let r,st = next_vreg st in get_reg_list N2 (rs@[r]) st
+        | N4 -> let r,st = next_vreg st in get_reg_list N3 (rs@[r]) st
+        in get_reg_list n [] st
+
       let emit_load n st p init x =
-        let rA,st = next_vreg st in
+        let rs,st = emit_vregs n st in
         let rB,init,st = U.next_init st p init x in
-        rA,init,lift_code [ldn n rA rB],st
+        (List.hd rs),init,lift_code [ldn n rs rB],st
     end
 
     module LDG = struct
@@ -612,14 +621,25 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         end)
 
     module STN = struct
-      let emit_store_reg n st p init x rA =
+      let emit_store_reg n st p init x rs =
         let rB,init,st = U.next_init st p init x in
-        init,pseudo [stn n rA rB],st
+        init,pseudo [stn n rs rB],st
+
+      let emit_vregs n st =
+        let rec get_reg_list n rs st = match n with
+        | N1 -> let r,st = next_vreg st in (rs@[r]),st
+        | N2 -> let r,st = next_vreg st in get_reg_list N1 (rs@[r]) st
+        | N3 -> let r,st = next_vreg st in get_reg_list N2 (rs@[r]) st
+        | N4 -> let r,st = next_vreg st in get_reg_list N3 (rs@[r]) st
+        in get_reg_list n [] st
+
+      let emit_movis rs = List.map (fun r -> movi_reg r) rs
 
       let emit_store n st p init x =
-        let rA,st = next_vreg st in
-        let init,cs,st = emit_store_reg n st p init x rA in
-        init,pseudo [movi_reg rA]@cs,st
+        let rs,st = emit_vregs n st in
+        let mvs = emit_movis rs in
+        let init,cs,st = emit_store_reg n st p init x rs in
+        init,pseudo mvs@cs,st
     end
 
     module STG = struct

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -150,6 +150,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let ldaxr r1 r2 = I_LDAR (vloc,AX,r1,r2)
     let sxtw r1 r2 = I_SXTW (r1,r2)
     let do_ldr_idx v1 v2 r1 r2 idx = I_LDR (v1,r1,r2,RV (v2,idx),S_NOEXT)
+    let ldn n r1 r2 = match n with
+    | N1 -> I_LD1M ([r1],r2,K 0)
+    | N2 -> I_LD2M ([r1],r2,K 0)
+    | N3 -> I_LD3M ([r1],r2,K 0)
+    | N4 -> I_LD4M ([r1],r2,K 0)
+
 
     let ldr_mixed_idx v r1 r2 idx sz  =
       let open MachSize in
@@ -428,6 +434,13 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           let load vr = wrap_st (do_ldr vr)
           let load_idx v1 v2 st rA rB idx = [do_ldr_idx v1 v2 rA rB idx],st
         end)
+
+    module LDN = struct
+      let emit_load n st p init x =
+        let rA,st = next_reg st in
+        let rB,init,st = U.next_init st p init x in
+        rA,init,lift_code [ldn n rA rB],st
+    end
 
     module LDG = struct
       let emit_load st p init x =
@@ -978,6 +991,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let r,init,cs,st = emit_load_mixed MachSize.S128 0 st p init loc in
             Some r,init,cs@lift_code [gctype r r],st
         | R,Some (CapaSeal,Some _) -> assert false
+        | R,Some (Neon n, _) -> let r,init,cs,st = LDN.emit_load n st p init loc in Some r,init,cs,st
         | W,None ->
             let init,cs,st = STR.emit_store st p init loc e.v None evt_null in
             None,init,cs,st
@@ -1045,6 +1059,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let init,cs,st = emit_str_addon st p init rB rA (Some Capability) {e with cseal = e.v} in
             None,init,csi@cs@lift_code [str_mixed MachSize.S128 0 rB rA],st
         | W,Some (CapaSeal,Some _) -> assert false
+        | W,Some (Neon _, _) -> assert false
         end
 
     let emit_exch st p init er ew =

--- a/gen/code.ml
+++ b/gen/code.ml
@@ -126,7 +126,7 @@ type info = (string * string) list
 let plain = "Na"
 
 (* Memory Space *)
-type bank = Ord | Tag | CapaTag | CapaSeal | Pte
+type bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg
 
 let pp_bank = function
   | Ord -> "Ord"
@@ -134,6 +134,7 @@ let pp_bank = function
   | CapaTag -> "CapaTag"
   | CapaSeal -> "CapaSeal"
   | Pte -> "Pte"
+  | VecReg -> "VecReg"
 
 let tag_of_int  = function
   | 0 -> "green"
@@ -149,3 +150,5 @@ let tag_of_int  = function
 let add_tag s t = Printf.sprintf "%s:%s" s (tag_of_int t)
 
 let add_capability s t = Printf.sprintf "0xffffc0000:%s:%i" s (if t = 0 then 1 else 0)
+
+let add_vector v = Printf.sprintf "{%i,%i,%i,%i}" v v v v

--- a/gen/code.ml
+++ b/gen/code.ml
@@ -151,4 +151,4 @@ let add_tag s t = Printf.sprintf "%s:%s" s (tag_of_int t)
 
 let add_capability s t = Printf.sprintf "0xffffc0000:%s:%i" s (if t = 0 then 1 else 0)
 
-let add_vector v = Printf.sprintf "{%i,%i,%i,%i}" v v v v
+let add_vector v = Printf.sprintf "{%i,%i,%i,%i}" v.(0) v.(1) v.(2) v.(3)

--- a/gen/code.mli
+++ b/gen/code.mli
@@ -83,10 +83,12 @@ type info = (string * string) list
 val plain : string
 
 (* Memory bank (for MTE, KVM)  *)
-type bank = Ord | Tag | CapaTag | CapaSeal | Pte
+type bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg
 
 val pp_bank : bank -> string
 
 val add_tag : string -> v -> string
 
 val add_capability : string -> v -> string
+
+val add_vector : v -> string

--- a/gen/code.mli
+++ b/gen/code.mli
@@ -91,4 +91,4 @@ val add_tag : string -> v -> string
 
 val add_capability : string -> v -> string
 
-val add_vector : v -> string
+val add_vector : int array -> string

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -25,7 +25,7 @@ module type S = sig
   type event =
       { loc : loc ; ord : int; tag : int;
         ctag : int; cseal : int; dep : int;
-        vecreg: int;
+        vecreg: int array;
         v   : v ;
         dir : dir option ;
         proc : Code.proc ;
@@ -124,7 +124,7 @@ module Make (O:Config) (E:Edge.S) :
   type event =
       { loc : loc ; ord : int; tag : int;
         ctag : int; cseal : int; dep : int;
-        vecreg: int;
+        vecreg: int array;
         v   : v ;
         dir : dir option ;
         proc : Code.proc ;
@@ -140,7 +140,7 @@ module Make (O:Config) (E:Edge.S) :
   let evt_null =
     { loc=Code.loc_none ; ord=0; tag=0;
       ctag=0; cseal=0; dep=0;
-      vecreg=0;
+      vecreg= [|0;0;0;0|];
       v=(-1) ; dir=None; proc=(-1); atom=None; rmw=false;
       cell=(-1); bank=Code.Ord; idx=(-1);
       pte=pte_default; }
@@ -183,7 +183,7 @@ module Make (O:Config) (E:Edge.S) :
 
   let debug_neon =
     if do_neon then fun e ->
-      sprintf " (vecreg=%i)" e.vecreg
+      sprintf " (vecreg={%i,%i,%i,%i})" e.vecreg.(0) e.vecreg.(1) e.vecreg.(2) e.vecreg.(3)
     else fun _ -> ""
 
   let debug_evt e =
@@ -621,7 +621,8 @@ let set_same_loc st n0 =
             let cseal = get_co old CapaSeal in
             n.evt <- { n.evt with ord=ord; ctag=ctag; cseal=cseal; }
           else if do_neon then
-            let vecreg = get_co old VecReg in
+            let v = get_co old VecReg in
+            let vecreg = [|v;v;v;v;|] in
             n.evt <- { n.evt with vecreg=vecreg; }
           end
         end ;

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -25,6 +25,7 @@ module type S = sig
   type event =
       { loc : loc ; ord : int; tag : int;
         ctag : int; cseal : int; dep : int;
+        vecreg: int;
         v   : v ;
         dir : dir option ;
         proc : Code.proc ;
@@ -114,6 +115,7 @@ module Make (O:Config) (E:Edge.S) :
   let do_memtag = O.variant Variant_gen.MemTag
   let do_morello = O.variant Variant_gen.Morello
   let do_kvm = O.variant Variant_gen.KVM
+  let do_neon = O.variant Variant_gen.Neon
 
   type fence = E.fence
   type edge = E.edge
@@ -122,6 +124,7 @@ module Make (O:Config) (E:Edge.S) :
   type event =
       { loc : loc ; ord : int; tag : int;
         ctag : int; cseal : int; dep : int;
+        vecreg: int;
         v   : v ;
         dir : dir option ;
         proc : Code.proc ;
@@ -137,6 +140,7 @@ module Make (O:Config) (E:Edge.S) :
   let evt_null =
     { loc=Code.loc_none ; ord=0; tag=0;
       ctag=0; cseal=0; dep=0;
+      vecreg=0;
       v=(-1) ; dir=None; proc=(-1); atom=None; rmw=false;
       cell=(-1); bank=Code.Ord; idx=(-1);
       pte=pte_default; }
@@ -177,18 +181,23 @@ module Make (O:Config) (E:Edge.S) :
       sprintf " (ord=%i) (ctag=%i) (cseal=%i) (dep=%i)" e.ord e.ctag e.cseal e.dep
     else fun _ -> ""
 
+  let debug_neon =
+    if do_neon then fun e ->
+      sprintf " (vecreg=%i)" e.vecreg
+    else fun _ -> ""
+
   let debug_evt e =
     let pp_v =
       match e.bank with
       | Pte -> PTEVal.pp e.pte
-      | (Ord|Tag|CapaTag|CapaSeal) ->
+      | (Ord|Tag|CapaTag|CapaSeal|VecReg) ->
           if O.hexa then sprintf "0x%x" e.v
           else sprintf "%i" e.v in
-    sprintf "%s%s %s %s%s%s"
+    sprintf "%s%s %s %s%s%s%s"
       (debug_dir e.dir)
       (debug_atom e.atom)
       (Code.pp_loc e.loc)
-      pp_v (debug_tag e) (debug_morello e)
+      pp_v (debug_tag e) (debug_morello e) (debug_neon e)
 
   let debug_edge = E.pp_edge
 
@@ -369,8 +378,8 @@ let diff_proc e = E.get_ie e = Ext
 (* Coherence definition *)
 module CoSt = MyMap.Make(struct type t = Code.bank let compare = compare end)
 
-let co_st_0  = CoSt.add Ord 0 (CoSt.add Tag 0 (CoSt.add CapaTag 0 (CoSt.add CapaSeal 0 CoSt.empty)))
-let co_st_1  = CoSt.add Ord 1 (CoSt.add Tag 1 (CoSt.add CapaTag 1 (CoSt.add CapaSeal 1 CoSt.empty)))
+let co_st_0  = CoSt.add Ord 0 (CoSt.add Tag 0 (CoSt.add CapaTag 0 (CoSt.add CapaSeal 0 (CoSt.add VecReg 0 CoSt.empty))))
+let co_st_1  = CoSt.add Ord 1 (CoSt.add Tag 1 (CoSt.add CapaTag 1 (CoSt.add CapaSeal 1 (CoSt.add VecReg 1 CoSt.empty))))
 let start_co _ = co_st_1
 
 let get_co st bank =
@@ -611,6 +620,9 @@ let set_same_loc st n0 =
             let ctag = get_co old CapaTag in
             let cseal = get_co old CapaSeal in
             n.evt <- { n.evt with ord=ord; ctag=ctag; cseal=cseal; }
+          else if do_neon then
+            let vecreg = get_co old VecReg in
+            n.evt <- { n.evt with vecreg=vecreg; }
           end
         end ;
         begin match n.evt.dir with
@@ -632,6 +644,11 @@ let set_same_loc st n0 =
                       pte_val ns
                 | Tag|CapaTag|CapaSeal ->
                     let v =  get_co next Tag in
+                    n.evt <- { n.evt with v = v; } ;
+                    do_set_write_val (set_co old bank v)
+                      (next_co next bank) pte_val ns
+                | VecReg ->
+                    let v = get_co next bank in
                     n.evt <- { n.evt with v = v; } ;
                     do_set_write_val (set_co old bank v)
                       (next_co next bank) pte_val ns
@@ -727,7 +744,7 @@ let do_set_read_v =
             begin match  n.evt.bank with
             | Ord ->
                 set_read_v n cell
-            | Tag|CapaTag|CapaSeal as bank ->
+            | Tag|CapaTag|CapaSeal|VecReg as bank ->
                 n.evt <- { n.evt with v = get_co st bank; }
             | Pte ->
                 n.evt <- { n.evt with pte =  pte_cell; }
@@ -739,9 +756,9 @@ let do_set_read_v =
             do_rec st
               (match bank with
                | Ord -> n.evt.cell
-               | Tag|CapaTag|CapaSeal|Pte -> cell)
+               | Tag|CapaTag|CapaSeal|Pte|VecReg -> cell)
               (match bank with
-               | Ord|Tag|CapaTag|CapaSeal -> pte_cell
+               | Ord|Tag|CapaTag|CapaSeal|VecReg -> pte_cell
                | Pte -> n.evt.pte)
               ns
         | None | Some J ->

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -621,9 +621,10 @@ let set_same_loc st n0 =
             let cseal = get_co old CapaSeal in
             n.evt <- { n.evt with ord=ord; ctag=ctag; cseal=cseal; }
           else if do_neon then
+            let ord = get_co old Ord in
             let v = get_co old VecReg in
             let vecreg = [|v;v;v;v;|] in
-            n.evt <- { n.evt with vecreg=vecreg; }
+            n.evt <- { n.evt with ord=ord; vecreg=vecreg; }
           end
         end ;
         begin match n.evt.dir with
@@ -651,7 +652,9 @@ let set_same_loc st n0 =
                 | VecReg ->
                     let v = get_co next bank in
                     n.evt <- { n.evt with v = v; } ;
-                    do_set_write_val (set_co old bank v)
+                    set_cell n (get_co old Ord) ;
+                    do_set_write_val
+                      (set_co old bank v)
                       (next_co next bank) pte_val ns
                 | Pte ->
                     let pte_val =

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -138,12 +138,14 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
             | Code.CapaSeal
             | Code.Ord ->
                 Some (I evt.C.C.v)
+            | Code.VecReg ->
+                Some (S (Code.add_vector evt.C.C.v))
             | Code.Tag ->
                 Some (S (Code.add_tag (Code.as_data evt.C.C.loc) evt.C.C.v))
             | Code.Pte ->
                 Some (P evt.C.C.pte)
             end
-        | Some Code.W -> assert (evt.C.C.bank = Code.Ord || evt.C.C.bank = Code.CapaSeal) ; Some (I (prev_value evt.C.C.v))
+        | Some Code.W -> assert (evt.C.C.bank = Code.Ord || evt.C.C.bank = Code.CapaSeal || evt.C.C.bank == Code.VecReg) ; Some (I (prev_value evt.C.C.v))
         | None|Some Code.J -> None in
         if show_in_cond n then match v with
         | Some v ->

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -139,7 +139,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
             | Code.Ord ->
                 Some (I evt.C.C.v)
             | Code.VecReg ->
-                Some (S (Code.add_vector evt.C.C.v))
+                Some (S (Code.add_vector evt.C.C.vecreg))
             | Code.Tag ->
                 Some (S (Code.add_tag (Code.as_data evt.C.C.loc) evt.C.C.v))
             | Code.Pte ->

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -280,7 +280,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
     let check_here n = match n.C.C.evt.C.C.bank with
     | Pte ->
         Misc.is_some (find_next_pte_write n)
-    | Ord|Tag|CapaTag|CapaSeal ->
+    | Ord|Tag|CapaTag|CapaSeal|VecReg ->
         check_edge n.C.C.edge.C.E.edge && not (is_load_init n.C.C.evt)
 
 (* Poll for value is possible *)

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -539,6 +539,10 @@ let max_set = IntSet.max_elt
           i,code@c,F.add_final_loc p r (Code.add_capability x v) f,st
       | Data x,Pte ->
           do_add_local_check_pte avoid_ptes st p i code f lst x
+      | Data x,VecReg ->
+          let v = lst.C.next.C.evt.C.v in
+          let r,i,c,st = Comp.emit_obs VecReg st p i x in
+          i,code@c,F.add_final_loc p r (Code.add_vector v) f,st
       | Code _,_ -> i,code,f,st
     else i,code,f,st
 

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -540,7 +540,7 @@ let max_set = IntSet.max_elt
       | Data x,Pte ->
           do_add_local_check_pte avoid_ptes st p i code f lst x
       | Data x,VecReg ->
-          let v = lst.C.next.C.evt.C.v in
+          let v = lst.C.next.C.evt.C.vecreg in
           let r,i,c,st = Comp.emit_obs VecReg st p i x in
           i,code@c,F.add_final_loc p r (Code.add_vector v) f,st
       | Code _,_ -> i,code,f,st

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -559,6 +559,7 @@ let max_set = IntSet.max_elt
   let do_memtag = O.variant Variant_gen.MemTag
   let do_morello = O.variant Variant_gen.Morello
   let do_kvm = O.variant Variant_gen.KVM
+  let do_neon = O.variant Variant_gen.Neon
 
   let compile_cycle ok n =
     let open Config in
@@ -640,6 +641,7 @@ let max_set = IntSet.max_elt
         let globals = C.get_globals n in
         let typ = if do_morello
           then TypBase.Std (TypBase.Unsigned,MachSize.S128)
+          else if do_neon then TypBase.Std (TypBase.Unsigned,MachSize.S128)
           else O.typ in
         let env =
           List.fold_left

--- a/gen/variant_gen.ml
+++ b/gen/variant_gen.ml
@@ -32,6 +32,8 @@ type t =
   | Morello
 (* Explicit virtual memory *)
   | KVM
+(* Neon AArch64 extension *)
+  | Neon
 
 let tags =
  ["AsAmo";"ConstsInInit";"Mixed";"FullMixed";"Self"; "MemTag";
@@ -47,6 +49,7 @@ let parse tag = match Misc.lowercase tag with
 | "novolatile" -> Some NoVolatile
 | "morello" -> Some Morello
 | "kvm" -> Some KVM
+| "neon" -> Some Neon
 | _ -> None
 
 let pp = function
@@ -59,3 +62,4 @@ let pp = function
   | NoVolatile -> "NoVolatile"
   | Morello -> "Morello"
   | KVM -> "kvm"
+  | Neon -> "Neon"

--- a/gen/variant_gen.ml
+++ b/gen/variant_gen.ml
@@ -37,7 +37,7 @@ type t =
 
 let tags =
  ["AsAmo";"ConstsInInit";"Mixed";"FullMixed";"Self"; "MemTag";
-  "NoVolatile"; "Morello"; "kvm"; ]
+  "NoVolatile"; "Morello"; "kvm"; "Neon"; ]
 
 let parse tag = match Misc.lowercase tag with
 | "asamo" -> Some AsAmo

--- a/gen/variant_gen.mli
+++ b/gen/variant_gen.mli
@@ -32,6 +32,8 @@ type t =
   | Morello
 (* Explicit virtual memory *)
   | KVM
+(* Neon AArch64 extension *)
+  | Neon
 
 val tags : string list
 

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -90,7 +90,7 @@ let vec_regs =
   V28; V29; V30; V31;
 ]
 
-let vregs = List.map (fun v -> Vreg (v,(8,8))) vec_regs
+let vregs = List.map (fun v -> Vreg (v,(4,32))) vec_regs
 
 let linkreg = Ireg R30
 

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -90,6 +90,8 @@ let vec_regs =
   V28; V29; V30; V31;
 ]
 
+let vregs = List.map (fun v -> Vreg (v,(8,8))) vec_regs
+
 let linkreg = Ireg R30
 
 let cgprs =


### PR DESCRIPTION
This PR adds basic support for the Neon extension.
The user can use the annotation `N1` to `N4` to ask diy to emit Neon instructions.

Current limitations:
- Memory sizes are limited to `uint128`, which could be exceeded by larger instructions (e.g. `st4`). This could be updated to use a larger array type.
- The final condition generated only covers 1 non-sc case. There are several, and some of the generalised final conditions become quite complex. A rough document on the generalised conditions can be found [here](https://docs.google.com/document/d/16jE5fCFCWA1JuSffHELIPbFwOb6Ek13NaGeCtL2Y3p4/edit?usp=sharing).