### PR TITLE
[lib] Implement shift_right (arithmetic) for Uint.Uint128

### DIFF
--- a/lib/tests/uint_test.ml
+++ b/lib/tests/uint_test.ml
@@ -304,6 +304,26 @@ let tests = [
     ) tests
   );
 
+  "Uint.Uint128.shift_right", (fun () ->
+    let open Uint in
+    let tests = [
+      "0x0", 3, "0x0" ;
+      "0x78", 3, "0xF" ;
+      "0x123456789ABCDEF000", 12, "0x123456789ABCDEF" ;
+      "0xA0000000000000123456789ABCDEF000", 12, "0xFFFA0000000000000123456789ABCDEF" ;
+    ] in
+
+    List.iter (fun (bits, shift, expected_bits) ->
+      let got = Uint128.shift_right (Uint128.of_string bits) shift in
+      let expected = Uint128.of_string expected_bits in
+      if Uint128.compare got expected <> 0 then
+        Test.fail (Printf.sprintf "%s: expected %s, got %s"
+          bits
+          (Uint128.to_string_hex expected)
+          (Uint128.to_string_hex got))
+    ) tests
+  );
+
   "Uint.Uint128.add", (fun () ->
     let open Uint in
     let tests = [

--- a/lib/uint.ml
+++ b/lib/uint.ml
@@ -216,8 +216,6 @@ module Uint128 = struct
     else
       Uint64.shift_left (snd a) (by-64), Uint64.zero
 
-  let shift_right _a _by = failwith "not implemented: shift_right"
-
   let shift_right_logical a by =
     if by < 0 then
       invalid_arg (Printf.sprintf "shift_right by negative: %i" by)
@@ -234,6 +232,20 @@ module Uint128 = struct
       Uint64.shift_right_logical (fst a) by, lower
     else
       Uint64.zero, Uint64.shift_right_logical (fst a) (by-64)
+
+  let shift_right a by =
+    let upper_bit = shift_left one (num_bits - 1) in
+    let has_msb = logand a upper_bit = upper_bit in
+    let rest = shift_right_logical a by in
+    if has_msb then
+      let rec upper_bits acc n =
+        match n with
+        | 0 -> acc
+        | n -> upper_bits (logor upper_bit (shift_right_logical acc 1)) (n-1)
+      in
+      logor rest (upper_bits upper_bit by)
+    else
+      rest
 
   let leading_zeros a =
     match a with


### PR DESCRIPTION
This PR implements `Uint.Uint128.shift_right`, the arithmetic right shift.

This PR does not block PR #161, but it does enable `-variant neon` and `-variant morello` to pass non-Neon / non-Morello regression tests that were using arithmetic right shift, e.g. [A63.litmus](https://github.com/herd/herdtools7/blob/3e395ed199f34354c3e3f4d8d66d951e0c6273b8/herd/tests/instructions/AArch64/A63.litmus).
