### PR TITLE
[litmus] Restore preSi mode.

### DIFF
--- a/litmus/libdir/_hash.c
+++ b/litmus/libdir/_hash.c
@@ -37,7 +37,7 @@ typedef struct {
 #ifdef KVM
 static void pp_hash(hash_t *t,int verbose,const char **group) {
 #else
-static void pp_hash(FILE *fp,hash_t *t,int verbose,constchar **group) {
+static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
 #endif
   for (int k = 0 ; k < HASHSZ ; k++) {
     entry_t *p = t->t+k ;

--- a/litmus/libdir/_litmus_io.c
+++ b/litmus/libdir/_litmus_io.c
@@ -15,7 +15,7 @@
 /****************************************************************************/
 #include "litmus_io.h"
 
-void emit_string(FILE *out,char *s) {
+void emit_string(FILE *out,const char *s) {
   char c ;
   while ((c = *s++)) emit_char(out,c);
 }

--- a/litmus/libdir/_litmus_io.h
+++ b/litmus/libdir/_litmus_io.h
@@ -19,7 +19,7 @@
 #include <stdint.h>
 #include "platform_io.h"
 
-void emit_string(FILE *out,char *s) ;
+void emit_string(FILE *out,const char *s) ;
 
 void emit_int_uns(FILE *out,unsigned int x) ;
 void emit_int_hex(FILE *out,unsigned int x) ;

--- a/litmus/libdir/x86_64.cfg
+++ b/litmus/libdir/x86_64.cfg
@@ -6,3 +6,6 @@ avail=0
 affinity = incr0
 ascall = true
 carch=X86_64
+# Standard Intel parameters
+smt=2
+smtmode=end

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -683,12 +683,13 @@ module Make
 (* Topology *)
 
 
-      let dump_topology test =
+      let dump_topology doc test =
         let n = T.get_nprocs test in
         let module Topo =
           Topology.Make
             (struct
               let verbose = Cfg.verbose
+              let name = doc
               let nthreads = n
               let avail = match Cfg.avail with
               | None -> 0
@@ -2953,7 +2954,7 @@ module Make
         dump_header test ;
         dump_read_timebase () ;
         dump_threads test ;
-        if mk_dsa test then dump_topology test ;
+        if mk_dsa test then dump_topology doc test ;
         let cpys = dump_def_ctx env test in
         dump_filter env test ;
         dump_cond_fun env test ;

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -521,7 +521,7 @@ module Make
           | Mode.Std ->
               O.f "static %s postlude(FILE *out,cmd_t *cmd,hist_t *hist,count_t p_true,count_t p_false,tsc_t total) {" t
           | Mode.PreSi ->
-              O.f "static %s postl sude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {" t ;
+              O.f "static %s postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {" t ;
               O.oi "hash_t *hash = &g->hash ;"
           | Mode.Kvm ->
               O.f "static %s postlude(global_t *g,count_t p_true,count_t p_false,tsc_t total) {" t ;


### PR DESCRIPTION
- Handle some const and volatile qualifiers,
  so as to avoid C compiler warnings.
- Fail (warn) at litime time when not not enough cores
  are are available.
- Accept decent default values when topology is unspecified.