### PR TITLE
Fix movk

### DIFF
--- a/herd/tests/instructions/AArch64/A91.litmus
+++ b/herd/tests/instructions/AArch64/A91.litmus
@@ -1,10 +1,14 @@
 AArch64 A91
-(* Tests movk, 32-bit, LSL 16 *)
+(* Tests movk 32 bits, all possible shift arguments *)
 
-{ 0:X0=131072; }
+{ 0:X0=0x20002; }
 
 P0;
-MOVK W0, #1, LSL #16;
-
-exists (0:X0=196608)
+MOV W1,W0            ;
+MOV W2,W0            ;
+MOVK W0, #1, LSL #0  ;
+MOVK W1, #1, LSL #16 ;
+MOVK W2, #1          ;
+locations [0:X0; 0:X1;0:X2;]
+exists (0:X0=0x20001 /\ 0:X1=0x10002 /\ 0:X2=0x20001)
 

--- a/herd/tests/instructions/AArch64/A91.litmus.expected
+++ b/herd/tests/instructions/AArch64/A91.litmus.expected
@@ -1,10 +1,10 @@
 Test A91 Allowed
 States 1
-0:X0=196608;
+0:X0=131073; 0:X1=65538; 0:X2=131073;
 Ok
 Witnesses
 Positive: 1 Negative: 0
-Condition exists (0:X0=196608)
+Condition exists (0:X0=131073 /\ 0:X1=65538 /\ 0:X2=131073)
 Observation A91 Always 1 0
-Hash=52b6fc4cba6308b913116525a1cd8152
+Hash=2a1f402d26f9b2377e76c626e65d2456
 

--- a/herd/tests/instructions/AArch64/A93.litmus
+++ b/herd/tests/instructions/AArch64/A93.litmus
@@ -1,10 +1,14 @@
 AArch64 A93
 (* Tests movk, 64-bit, LSL 32 *)
 
-{ 0:X0=8589934592; }
+{ uint64_t 0:X0=0x2000200020002; uint64_t 0:X1;}
 
 P0;
+MOVK X0, #1         ;
 MOVK X0, #1, LSL #32;
-
-exists (0:X0=12884901888)
+MOV X1,X0           ;
+MOVK X0, #1, LSL #16;
+MOVK X0, #1, LSL #48;
+locations [0:X1;]
+exists (0:X0=0x1000100010001 /\ 0:X1=0x2000100020001)
 

--- a/herd/tests/instructions/AArch64/A93.litmus.expected
+++ b/herd/tests/instructions/AArch64/A93.litmus.expected
@@ -1,10 +1,10 @@
 Test A93 Allowed
 States 1
-0:X0=12884901888;
+0:X0=281479271743489; 0:X1=562954248519681;
 Ok
 Witnesses
 Positive: 1 Negative: 0
-Condition exists (0:X0=12884901888)
+Condition exists (0:X0=281479271743489 /\ 0:X1=562954248519681)
 Observation A93 Always 1 0
-Hash=a0a635ad1cdd3c6247c74bc6470c7b54
+Hash=9a54718529cc132f96e50096c66ccc39
 


### PR DESCRIPTION
AArch64 `movk` instruction was wrong for both litmus and herd.
Should be fine by now, also changed two tests for a (slightly) more thorough check.
