### PR TITLE
[internal_lib] Detect Python version in Shelf module

### DIFF
--- a/internal/lib/command.mli
+++ b/internal/lib/command.mli
@@ -16,7 +16,17 @@
 
 (** Utilities for running commands. *)
 
-exception Error of string
+type error = {
+  binary : string ;
+  args   : string list ;
+  status : Unix.process_status ;
+}
+
+exception Error of error
+
+(** [string_of_error e] returns a human-readable representation of an error
+ *  [e]. *)
+val string_of_error : error -> string
 
 (** [command bin args] returns a fully escaped command line for running the
  *  binary [bin] with arguments [args]. *)

--- a/internal/lib/shelf.ml
+++ b/internal/lib/shelf.ml
@@ -81,7 +81,11 @@ let list_of_file path key =
   in
   let lines = ref [] in
   let read_lines c = lines := Channel.read_lines c in
-  Command.run ~stdin:script ~stdout:read_lines "python" [] ;
+  begin try
+    Command.run ~stdin:script ~stdout:read_lines "python" []
+  with
+    Command.Error e -> failwith (Command.string_of_error e)
+  end ;
   (* Sorted for stability / comparability. *)
   List.sort String.compare !lines
 

--- a/internal/lib/testHerd.ml
+++ b/internal/lib/testHerd.ml
@@ -98,7 +98,7 @@ let herd_output_matches_expected herd libdir litmus expected expected_failure =
     | _,_ -> (* Herd returned both output and errors *)
       Printf.printf "Failed %s : %s and %s exist, only one expected\n" litmus expected expected_failure ; false
   with
-    Command.Error msg -> Printf.printf "Failed %s : %s \n" litmus msg ; false
+    Command.Error e -> Printf.printf "Failed %s : %s \n" litmus (Command.string_of_error e) ; false
 
 
 let is_litmus path = Filename.check_suffix path ".litmus"


### PR DESCRIPTION
This PR changes the `Shelf` parser to automatically detect available Python versions.

It also enriches the `Command.Error` exception with an `error` record type.
