### PR TITLE
[litmus] Handle array constructs.

### DIFF
--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -153,9 +153,7 @@ module Generic (A : Arch_litmus.Base)
               ignore (A.LocMap.find loc env) ;
               env
             with Not_found ->  A.LocMap.add loc (typeof v) env end
-        | LV (Deref _,_) ->
-            prerr_endline "TODO" ;
-            assert false
+        | LV (Deref _,_)
         | LL _|FF _ -> env
 
       let type_final final env =
@@ -168,7 +166,7 @@ module Generic (A : Arch_litmus.Base)
         let open LocationsItem in
         List.fold_left
           (fun env i -> match i with
-          | Loc (ConstrGen.Loc loc,t) ->              
+          | Loc (ConstrGen.Loc loc,t) ->
               begin try
                 ignore (A.LocMap.find loc env) ; env
               with

--- a/litmus/libdir/_utils.c
+++ b/litmus/libdir/_utils.c
@@ -1329,7 +1329,7 @@ double tsc_millions(tsc_t t) {
 /* String handling */
 /*******************/
 
-int find_string(char *t[], int sz, char *s) {
+int find_string(const char *t[], int sz, const char *s) {
   for (int k = 0 ; k < sz ; k++) {
     if (strcmp(t[k],s) == 0) return k ;
   }

--- a/litmus/libdir/_utils.h
+++ b/litmus/libdir/_utils.h
@@ -277,6 +277,6 @@ double tsc_ratio(tsc_t t1, tsc_t t2) ;
 double tsc_millions(tsc_t t) ;
 
 /* String utilities */
-int find_string(char *t[],int sz,char *s) ;
+int find_string(const char *t[],int sz,const char *s) ;
 
 #endif


### PR DESCRIPTION
Handling of array constructs by litmus had been delayed. This PR restores identity of behaviour between the herd and litmus tools.

It also fixes a few missing `const` qualifiers in C code.