### PR TITLE
Herd typed print

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -726,14 +726,11 @@ module Make
 (* Memory instructions *)
 (***********************)
 
-(* compute sign extension (32 -> 64 bits) *)
-      let sxtw_op v =
-        let m = V.op1 (Op.LeftShift 31) V.one in
-        M.op Op.Xor v m
-        >>= fun v -> M.op Op.Sub v m        
+(* compute signed and unsized extension (32 -> 64 bits) *)
+      let sxtw_op = M.op1 (Op.Sxt MachSize.Word)
 
-      let uxtw_op = M.op1 (Op.AndK "0xffffffff")
-                         
+      and uxtw_op = M.op1 (Op.Mask MachSize.Word)
+
 (* Apply a shift as monadic op *)
       let shift s =
         let open AArch64Base in

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -610,7 +610,8 @@ module Make(C:Config) (I:I) : S with module I = I
               try begin match t with
               | TestType.Ty b ->
                  let sz = size_of_t b in
-                 sxt_v sz v
+                 if TestType.is_signed b then sxt_v sz v
+                 else I.V.op1 (Op.Mask sz) v
               | _ -> v
                   end with Misc.Fatal _ -> v in
             ConstrGen.dump_rloc (do_dump_location tr) l ^

--- a/herd/tests/instructions/AArch64/L011.litmus
+++ b/herd/tests/instructions/AArch64/L011.litmus
@@ -1,0 +1,14 @@
+AArch64 L011
+{
+int8_t x=-1;
+int16_t y=-2;
+int32_t z=-16;
+0:X2=x; int8_t 0:X1;
+0:X4=y; int32_t 0:X3;
+0:X6=z; int32_t 0:X5;
+}
+  P0         ;
+LDRB W1,[X2] ;
+LDRH W3,[X4] ;
+LDR  W5,[X6] ; 
+locations [0:X1;0:X3;0:X5;]

--- a/herd/tests/instructions/AArch64/L011.litmus.expected
+++ b/herd/tests/instructions/AArch64/L011.litmus.expected
@@ -1,0 +1,10 @@
+Test L011 Required
+States 1
+0:X1=-1; 0:X3=65534; 0:X5=-16;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation L011 Always 1 0
+Hash=caaab570971f758d0730f0cb4ab42d45
+

--- a/herd/tests/instructions/AArch64/L012.litmus
+++ b/herd/tests/instructions/AArch64/L012.litmus
@@ -1,0 +1,11 @@
+AArch64 L012
+{
+int v[3] = { 1,2,3 };
+0:X2=v;
+}
+  P0 ;
+LDR W0,[X2]    ;
+LDR W1,[X2,#8] ;
+STR W0,[X2,#8] ;
+STR W1,[X2]    ;
+locations [v;]

--- a/herd/tests/instructions/AArch64/L012.litmus.expected
+++ b/herd/tests/instructions/AArch64/L012.litmus.expected
@@ -1,0 +1,10 @@
+Test L012 Required
+States 1
+v={3,2,1};
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation L012 Always 1 0
+Hash=f0b0d81e632ea180c4605e1e7620937b
+

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -453,7 +453,9 @@ module Make(O:Config)(M:XXXMem.S) =
         A.StateSet.pp stdout ""
           (fun chan st ->
             fprintf chan "%s\n"
-              (A.do_dump_final_state test.Test_herd.ffaults tr_out st))
+              (A.do_dump_final_state
+                 test.Test_herd.type_env test.Test_herd.ffaults
+                 tr_out st))
           finals ;
 (* Condition result *)
         let ok = check_cond test c in

--- a/lib/CapabilityConstant.ml
+++ b/lib/CapabilityConstant.ml
@@ -75,6 +75,14 @@ module CapabilityScalar = struct
 
   let get_tag (t,_) = t
   let set_tag t (_,x) = t, x
+
+  let sxt sz v = match sz with
+    | MachSize.S128 -> v
+    | _ ->
+      let t,v = mask sz v in
+      let nb = MachSize.nbits sz in
+      let m = Uint128.shift_left Uint128.one (nb-1) in
+      t,Uint128.sub (Uint128.logxor v m) m
 end
 
 include SymbConstant.Make(CapabilityScalar)

--- a/lib/int32Constant.ml
+++ b/lib/int32Constant.ml
@@ -41,6 +41,16 @@ module Int32Scalar = struct
     | Quad -> Warn.fatal "make 32 value with quad mask"
     | S128 -> Warn.fatal "make 32 value with s128 mask"
 
+  let sxt sz v =
+    let open MachSize in
+    match sz with
+    | S128|Quad|Word -> v
+    | _ ->
+       let v = mask sz v in
+       let nb = nbits sz in
+       let m = shift_left one (nb-1) in
+       sub (logxor v m) m
+
   let get_tag _ = assert false
   let set_tag _ = assert false
 end

--- a/lib/int64Constant.ml
+++ b/lib/int64Constant.ml
@@ -39,6 +39,16 @@ module Int64Scalar = struct
     | Quad -> fun v -> v
     | S128 -> Warn.fatal "make 64 value with s128 mask"
 
+  let sxt sz v =
+    let open MachSize in
+    match sz with
+    | S128|Quad -> v
+    | _ ->
+       let v = mask sz v in
+       let nb = nbits sz in
+       let m = shift_left one (nb-1) in
+       sub (logxor v m) m
+
   let get_tag _ = assert false
   let set_tag _ = assert false
 end

--- a/lib/op.ml
+++ b/lib/op.ml
@@ -92,10 +92,10 @@ type op1 =
   | ReadBit of int
   | LeftShift of int
   | LogicalRightShift of int
-  | SignExtendWord of int
   | AddK of int
   | AndK of string
   | Mask of MachSize.sz
+  | Sxt of MachSize.sz
   | Inv
   | TagLoc       (* Get tag memory location from location *)
   | CapaTagLoc
@@ -125,11 +125,11 @@ let pp_op1 hexa o = match o with
 | ReadBit i -> sprintf "readbit%i" i
 | LeftShift i -> sprintf "<<[%i]" i
 | LogicalRightShift i -> sprintf ">>>[%i]" i
-| SignExtendWord i -> sprintf "sxtw %i" i
 | AddK i  -> (if hexa then sprintf "+[0x%x]" else sprintf "+[%i]") i
 | AndK i  -> sprintf "&[%s]" i
 | Inv -> "~"
 | Mask sz  -> sprintf "mask%02i" (MachSize.nbits sz)
+| Sxt sz -> sprintf "sxt%02i" (MachSize.nbits sz)
 | TagLoc ->  "tagloc"
 | CapaTagLoc -> "capatagloc"
 | TagExtract -> "tagextract"

--- a/lib/op.mli
+++ b/lib/op.mli
@@ -56,10 +56,10 @@ type op1 =
   | ReadBit of int
   | LeftShift of int
   | LogicalRightShift of int
-  | SignExtendWord of int
   | AddK of int
   | AndK of string
   | Mask of MachSize.sz
+  | Sxt of MachSize.sz (* Sign extension *)
   | Inv          (* Logical not or inverse *)
   | TagLoc       (* Get tag memory location from location *)
   | CapaTagLoc

--- a/lib/parsedConstant.ml
+++ b/lib/parsedConstant.ml
@@ -46,6 +46,8 @@ module StringScalar = struct
   let le = op2 "(<=)"
   let mask sz = op1 (Op.pp_op1 false (Op.Mask sz))
 
+  let sxt sz v = op1 (Printf.sprintf "sxt(%s)" (MachSize.pp sz)) v
+
   let get_tag _ = assert false
   let set_tag _ = assert false
 end

--- a/lib/scalar.mli
+++ b/lib/scalar.mli
@@ -47,6 +47,8 @@ module type S = sig
   val lt : t -> t -> bool
   val le : t -> t -> bool
   val mask : MachSize.sz -> t -> t
+(* Sign extension to size of t *)
+  val sxt : MachSize.sz -> t -> t
   val get_tag : t -> bool
   val set_tag : bool -> t -> t
 end

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -311,6 +311,8 @@ module Make(Cst:Constant.S) = struct
   | Val (Tag _) -> v (* tags are small enough for any mask be idempotent *)
   | _ ->  unop op (Scalar.mask sz) v
 
+  and sxtop op sz v = unop op (Scalar.sxt sz) v
+
   and shift_right_logical v1 v2 = match v1,v2 with
   | Val (Symbolic (Virtual {name=s;_})),Val (Concrete v) when
       Scalar.compare v (Scalar.of_int 12) = 0 ->
@@ -504,8 +506,8 @@ module Make(Cst:Constant.S) = struct
   let as_virtual v = match v with
   | Val c -> Constant.as_virtual c
   | Var _ -> raise Undetermined
-  let is_virtual_v v =  if is_virtual v then one else zero
 
+  let is_virtual_v v =  if is_virtual v then one else zero
 
   let andnot x1 x2 =
     Scalar.logand x1 (Scalar.lognot x2)
@@ -751,11 +753,10 @@ module Make(Cst:Constant.S) = struct
         unop  op (fun s -> Scalar.shift_left s k)
     | LogicalRightShift k ->
         unop op (fun s -> Scalar.shift_right_logical s k)
-    | SignExtendWord _ ->
-        Warn.fatal "sxtw op not implemented yet"
     | AddK k -> add_konst k
     | AndK k -> unop op (fun s -> Scalar.logand s (Scalar.of_string k))
     | Mask sz -> maskop op sz
+    | Sxt sz -> sxtop op sz
     | Inv -> unop op Scalar.lognot
     | TagLoc -> tagloc
     | CapaTagLoc -> capatagloc

--- a/lib/testType.ml
+++ b/lib/testType.ml
@@ -57,3 +57,13 @@ let size_of maximal = function
 | "intptr_t" | "uintptr_t" | "pteval_t"
   -> maximal (* Maximal size = ptr size *)
 | t -> Warn.fatal "Cannot find the size of type %s" t
+
+let is_signed = function
+| "int"|"long"
+| "int32_t"
+| "char"|"int8_t"
+| "short"|"int16_t"
+| "int64_t"
+| "int128_t"
+| "intptr_t" -> true
+| _ -> false

--- a/lib/testType.ml
+++ b/lib/testType.ml
@@ -31,14 +31,18 @@ let pp = function
   | Atomic s -> sprintf "Atomic<%s>" s
   | Pointer s -> sprintf "Pointer<%s>" s
   | TyArray (s,sz) -> sprintf "TyArray<%s,%i>" s sz
-                    
+
 let is_array = function
   | TyArray _ -> true
   | _       -> false
 
 let get_array_primitive_ty = function
-  | TyArray (ty,_) -> ty
-  | _ -> assert false
+  | TyArray (ty,_)
+  | Pointer ty
+    ->  ty
+  | TyDef -> "int"
+  | t ->
+     Warn.user_error "Array of pointer type expected, found %s" (pp t)
 
 (* Simplified typing, size only, integer types only *)
 let size_of maximal = function

--- a/lib/testType.mli
+++ b/lib/testType.mli
@@ -29,3 +29,5 @@ val get_array_primitive_ty :t -> string
 
 val size_of : MachSize.sz -> string -> MachSize.sz
 
+val is_signed : string -> bool
+


### PR DESCRIPTION
Use type for printing values in outcomes. This applies mostly to signed integers, which have to be sign-extended to to machine size, and to locations of arrays type, which are now printed as arrays.
 