### PR TITLE
[lib] SymbValue.unop operates only on Concrete values

### DIFF
--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -123,12 +123,9 @@ module Make(Cst:Constant.S) = struct
     let tag = if Scalar.get_tag a then 0x200000000 else 0 in
     Scalar.to_int (Scalar.shift_right_logical a 95) lor tag
 
-  (* Concrete -> Concrete
-     Symbolic -> Symbolic *)
   let unop op_op op v1 = match v1 with
-    | Val (Concrete i1) -> Val (Concrete (op i1))
-    | Val (Symbolic (Virtual ({cap=c;_} as s))) ->
-        Val (Symbolic (Virtual {s with cap=capa_to_bin (op (bin_to_capa c))}))
+    | Val (Concrete i1) ->
+        Val (Concrete (op i1))
     | Val (ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _ as x) ->
         Warn.user_error "Illegal operation %s on %s"
           (Op.pp_op1 true op_op) (Cst.pp_v x)

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -137,11 +137,11 @@ module Make(Cst:Constant.S) = struct
   (* NB: These may perform arithmetic on the capability of a Symbolic Virtual
    *     value, instead of the value itself. *)
 
-  let bin_to_capa c =
+  let scalar_of_cap c =
     let tag = c land 0x200000000 <> 0 in
     Scalar.set_tag tag (Scalar.shift_left (Scalar.of_int c) 95)
 
-  let capa_to_bin a =
+  let cap_of_scalar a =
     let tag = if Scalar.get_tag a then 0x200000000 else 0 in
     Scalar.to_int (Scalar.shift_right_logical a 95) lor tag
 
@@ -151,7 +151,7 @@ module Make(Cst:Constant.S) = struct
     | Val (Concrete i) ->
         Val (Concrete (op i))
     | Val (Symbolic (Virtual {cap=c;_})) ->
-        Val (Concrete (op (bin_to_capa c)))
+        Val (Concrete (op (scalar_of_cap c)))
     | Val cst ->
         Warn.user_error "Illegal operation %s on %s"
           (Op.pp_op1 true op_op) (Cst.pp_v cst)
@@ -162,7 +162,7 @@ module Make(Cst:Constant.S) = struct
   let binop_cs_c op_op op v1 v2 = match v1,v2 with
   | (Val (Concrete i1),Val (Concrete i2)) -> Val (Concrete (op i1 i2))
   | (Val (Symbolic (Virtual ({cap=c;_} as s))),Val (Concrete i)) ->
-      Val (Symbolic (Virtual {s with cap=capa_to_bin (op (bin_to_capa c) i)}))
+      Val (Symbolic (Virtual {s with cap=cap_of_scalar (op (scalar_of_cap c) i)}))
   | Val cst1,Val cst2 ->
         Warn.user_error "Illegal operation %s on %s and %s"
           (Op.pp_op op_op) (Cst.pp_v cst1) (Cst.pp_v cst2)
@@ -174,7 +174,7 @@ module Make(Cst:Constant.S) = struct
   let binop_c_cs op_op op v1 v2 = match v1,v2 with
   | (Val (Concrete i1),Val (Concrete i2)) -> Val (Concrete (op i1 i2))
   | (Val (Concrete i),Val (Symbolic (Virtual {cap=c;_}))) ->
-      Val (Concrete (op i (bin_to_capa c)))
+      Val (Concrete (op i (scalar_of_cap c)))
   | Val cst1,Val cst2 ->
         Warn.user_error "Illegal operation %s on %s and %s"
           (Op.pp_op op_op) (Cst.pp_v cst1) (Cst.pp_v cst2)
@@ -190,13 +190,13 @@ module Make(Cst:Constant.S) = struct
   let binop_cs_cs op_op op v1 v2 = match v1,v2 with
   | (Val (Concrete i1),Val (Concrete i2)) -> Val (Concrete (op i1 i2))
   | (Val (Concrete i),Val (Symbolic (Virtual {cap=c;_}))) ->
-      Val (Concrete (op i (bin_to_capa c)))
+      Val (Concrete (op i (scalar_of_cap c)))
   | (Val (Symbolic (Virtual ({cap=c;_} as s))),Val (Concrete i)) ->
-      mk_val_virtual {s with cap=capa_to_bin (op (bin_to_capa c) i)}
+      mk_val_virtual {s with cap=cap_of_scalar (op (scalar_of_cap c) i)}
   | (Val (Symbolic (Virtual ({cap=c1;_} as s))),
      Val (Symbolic (Virtual {cap=c2;_}))) ->
       mk_val_virtual
-        {s with cap=capa_to_bin (op (bin_to_capa c1) (bin_to_capa c2))}
+        {s with cap=cap_of_scalar (op (scalar_of_cap c1) (scalar_of_cap c2))}
   | Val cst1,Val cst2 ->
         Warn.user_error "Illegal operation %s on %s and %s"
           (Op.pp_op op_op) (Cst.pp_v cst1) (Cst.pp_v cst2)
@@ -210,11 +210,11 @@ module Make(Cst:Constant.S) = struct
   let binop_cs_cs_c op_op op v1 v2 = match v1,v2 with
   | (Val (Concrete i1),Val (Concrete i2)) -> Val (Concrete (op i1 i2))
   | (Val (Concrete i),Val (Symbolic (Virtual {cap=c;_}))) ->
-      Val (Concrete (op i (bin_to_capa c)))
+      Val (Concrete (op i (scalar_of_cap c)))
   | (Val (Symbolic (Virtual {cap=c;_})),Val (Concrete i)) ->
-      Val (Concrete (op (bin_to_capa c) i))
+      Val (Concrete (op (scalar_of_cap c) i))
   | (Val (Symbolic (Virtual {cap=c1;_})),Val (Symbolic (Virtual {cap=c2;_}))) ->
-      Val (Concrete (op (bin_to_capa c1) (bin_to_capa c2)))
+      Val (Concrete (op (scalar_of_cap c1) (scalar_of_cap c2)))
   | Val cst1,Val cst2 ->
         Warn.user_error "Illegal operation %s on %s and %s"
           (Op.pp_op op_op) (Cst.pp_v cst1) (Cst.pp_v cst2)
@@ -611,10 +611,10 @@ module Make(Cst:Constant.S) = struct
   let capaadd v1 v2 = match v1,v2 with
     | (Val (Symbolic (Virtual ({cap=c;offset=o;_} as s))),Val (Concrete i)) ->
         let i = Scalar.to_int i in
-        let c = bin_to_capa c in
+        let c = scalar_of_cap c in
         let tagclear = cap_is_sealed c in
         let c = Scalar.set_tag (Scalar.get_tag c && not tagclear) c in
-        mk_val_virtual {s with cap=capa_to_bin c;offset=o+i}
+        mk_val_virtual {s with cap=cap_of_scalar c;offset=o+i}
     | (Val (Concrete c)),(Val (Concrete increment)) -> (* General case *)
         let result = Scalar.logor (hi64 c) (lo64 (Scalar.add c increment)) in
         (* NB: bounds check skipped *)
@@ -701,7 +701,7 @@ module Make(Cst:Constant.S) = struct
 
   let setvalue v1 v2 = match v1,v2 with
     | (Val (Symbolic (Virtual {cap=c;_})),Val (Concrete i)) ->
-        let c = bin_to_capa c in
+        let c = scalar_of_cap c in
         Val (Concrete (do_setvalue c i))
     | (Val (Concrete i1)),(Val (Concrete i2)) ->
         Val (Concrete (do_setvalue i1 i2))


### PR DESCRIPTION
This PR limits the number of `Op`s that implicitly act on a `Symbolic Virtual` value's capability.

This restores the behavior prior to commit ef79f22 for the majority of operations.

This change means that some tests unsupported by mixed-mode will fail with a meaningful error message with `-variant mixed`, and won't silently corrupt results with `-variant morello`:

Before:

```sh
% herd7 -variant mixed herd/tests/instructions/AArch64/A139.litmus
Fatal: File "herd/tests/instructions/AArch64/A139.litmus" Adios
Fatal error: exception File "lib/int64Constant.ml", line 53, characters 18-24: Assertion failed

% herd7 -variant morello herd/tests/instructions/AArch64/A139.litmus
Test A139 Allowed
States 1
0:X0=0;
No
Witnesses
Positive: 0 Negative: 1
Condition exists (0:X0=42)
Observation A139 Never 0 1
Time A139 0.00
Hash=ded8edfb3172de2fb6b478285dda7ccc
```

After:

```sh
% herd7 -variant mixed herd/tests/instructions/AArch64/A139.litmus
Warning: File "herd/tests/instructions/AArch64/A139.litmus": Illegal operation &[0xffffffff] on x (User error)

% herd7 -variant morello herd/tests/instructions/AArch64/A139.litmus
Warning: File "herd/tests/instructions/AArch64/A139.litmus": Illegal operation &[0xffffffff] on x (User error)
```

This commit was tested by generating tests using `diy7` at commit d6cf705 (current HEAD), generating expected output using `herd_regression_test promote`, and testing this commit against that output.

This doesn't remove implicit capability arithmetic completely from `SymbValue`, but it does limit the scope to just Morello-specific ops.

This PR also:
- Separates the Morello and non-Morello operation wrappers.
- Renames 2 conversion functions, `capa_to_bin` and `bin_to_capa` to `cap_of_scalar` and `scalar_of_cap`, respectively.