### PR TITLE
[litmus] Type neon registers

### DIFF
--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -290,7 +290,13 @@ let symb_reg_name = function
   | _ -> None
 
 let symb_reg r =  Symbolic_reg r
-let typeof _ = assert false
+
+let type_reg r =
+  let open CType in
+  match r with
+  | Vreg  (_,(n_elt,sz)) -> Array (TestType.tr_nbits sz,n_elt)
+  | _ -> Base "int"
+
 
 (************)
 (* Barriers *)

--- a/lib/ARMBase.ml
+++ b/lib/ARMBase.ml
@@ -102,7 +102,7 @@ let symb_reg_name = function
   | _ -> None
 
 let symb_reg r = Symbolic_reg r
-let typeof _ = assert false
+let type_reg _ = base_type
 
 (************)
 (* Barriers *)

--- a/lib/BellBase.ml
+++ b/lib/BellBase.ml
@@ -42,7 +42,7 @@ let symb_reg_name = function
   | _ -> None
 
 let symb_reg r = Symbolic_reg r
-let typeof _ = assert false
+let type_reg _ = base_type
 
 let parse_reg s =
   let len = String.length s in

--- a/lib/CBase.ml
+++ b/lib/CBase.ml
@@ -35,7 +35,7 @@ let symb_reg_name r =
   | _ -> None
 
 let symb_reg r = sprintf "%%%s" r
-let typeof _ = assert false
+let type_reg _ = base_type
 
 type 's t_reg =
   | T of 's Constant.t

--- a/lib/MIPSBase.ml
+++ b/lib/MIPSBase.ml
@@ -141,7 +141,7 @@ let symb_reg_name = function
   | _ -> None
 
 let symb_reg r = Symbolic_reg r
-let typeof _ = assert false
+let type_reg _ = base_type
 
 (************)
 (* Barriers *)

--- a/lib/PPCBase.ml
+++ b/lib/PPCBase.ml
@@ -131,7 +131,7 @@ let symb_reg_name = function
   | _ -> None
 
 let symb_reg r = Symbolic_reg r
-let typeof _ = assert false
+let type_reg _ = base_type
 
 let pp_ireg r =
   try List.assoc r iregs with

--- a/lib/RISCVBase.ml
+++ b/lib/RISCVBase.ml
@@ -110,7 +110,7 @@ let symb_reg_name = function
   | _ -> None
 
 let symb_reg r = Symbolic_reg r
-let typeof _ = assert false
+let type_reg _ = base_type
 
 (**********)
 (* Fences *)

--- a/lib/X86Base.ml
+++ b/lib/X86Base.ml
@@ -75,7 +75,7 @@ let symb_reg_name = function
   | _ -> None
 
 let symb_reg r = Symbolic_reg r
-let typeof _ = assert false
+let type_reg _ = base_type
 
 (************)
 (* Barriers *)

--- a/lib/X86_64Base.ml
+++ b/lib/X86_64Base.ml
@@ -217,7 +217,7 @@ let reg_size_to_uint = function
   | R32b -> "uint32_t"
   | R64b -> "uint64_t"
 
-let typeof = function
+let type_reg = function
   | Ireg (_, t) -> CType.Base (reg_size_to_uint t)
   | _ -> CType.Base "int"
 

--- a/lib/archBase.mli
+++ b/lib/archBase.mli
@@ -34,7 +34,7 @@ module type S = sig
   val reg_compare : reg -> reg -> int
   val symb_reg_name : reg -> string option
   val symb_reg : string -> reg
-  val typeof : reg -> CType.t
+  val type_reg : reg -> CType.t
 
   type barrier
   val pp_barrier            : barrier -> string

--- a/lib/testType.ml
+++ b/lib/testType.ml
@@ -67,3 +67,11 @@ let is_signed = function
 | "int128_t"
 | "intptr_t" -> true
 | _ -> false
+
+let tr_nbits = function
+| 8 -> "uint8_t"
+| 16 -> "uint16_t"
+| 32 -> "int"
+| 64 -> "uint64_t"
+| n -> Warn.fatal "No type for %d bits" n
+

--- a/lib/testType.mli
+++ b/lib/testType.mli
@@ -31,3 +31,5 @@ val size_of : MachSize.sz -> string -> MachSize.sz
 
 val is_signed : string -> bool
 
+val tr_nbits : int -> string
+

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -102,6 +102,7 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
     | CAst.Global _::xs -> count_procs xs
     | [] -> 0
 
-  let typeof _ = assert false
+  let type_reg r = CBase.type_reg r
+
   let features = []
 end

--- a/litmus/arch_litmus.mli
+++ b/litmus/arch_litmus.mli
@@ -60,8 +60,7 @@ module type Base = sig
 
   val find_in_state : location -> state -> V.v
   val pp_reg : reg -> string
-
-  val typeof : reg -> CType.t
+  val type_reg : reg -> CType.t
 
   val features : ((instruction -> bool) * string) list
 

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -63,7 +63,11 @@ module Generic (A : Arch_litmus.Base)
 
       let misc_to_c loc = function
         | TestType.TyDef when A.is_pte_loc loc -> pteval_t
-        | TestType.TyDef -> base
+        | TestType.TyDef ->
+           begin match loc with
+           | A.Location_reg (_,r) -> A.type_reg r
+           | A.Location_global _  -> base
+           end
         | TestType.TyDefPointer  -> pointer
         | TestType.Ty t -> Base t
         | TestType.Atomic t -> Atomic (Base t)

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -98,7 +98,6 @@ module Make
       val select_aligned : env -> (string * CType.t) list
 
 (* Some dump`ing stuff *)
-      val cast_reg_type : A.location -> string
       val register_type : 'loc ->  CType.t -> CType.t
       val fmt_outcome_as_list :
         T.t -> (CType.base -> string) -> A.RLocSet.t -> env
@@ -265,13 +264,6 @@ module Make
                 if is_aligned loc env then Some loc else None)
           env
 
-(* Format stuff *)
-      let cast_reg_type loc =
-        if A.arch = `X86_64 then
-          match loc with
-          | A.Location_reg (_,r) -> "(" ^ CType.dump (A.typeof r) ^ ")"
-          | _ -> ""
-        else ""
 
       let tr_out test = OutMapping.info_to_tr test.T.info
 


### PR DESCRIPTION
Varying default types for registers. For instance (AArch64), having `locations [0:V0.4S;]` will command printing the final value of vector register V0 of thread 0 as a array of four `int`s.