### PR TITLE
[herd] Add an AArch64 test for ASR with a negative initial value

### DIFF
--- a/herd/tests/instructions/AArch64/A96.litmus
+++ b/herd/tests/instructions/AArch64/A96.litmus
@@ -1,0 +1,9 @@
+AArch64 A96
+(* Tests asr (immediate), negative initial value, right shift by 2 *)
+
+{ int64_t 0:X0 = -256; }
+
+P0;
+ASR X0, X0, #2;
+
+exists (0:X0=-64)

--- a/herd/tests/instructions/AArch64/A96.litmus.expected
+++ b/herd/tests/instructions/AArch64/A96.litmus.expected
@@ -1,0 +1,10 @@
+Test A96 Allowed
+States 1
+0:X0=-64;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=-64)
+Observation A96 Always 1 0
+Hash=7ca2b108bf266be0b0ed25d0887ebcd9
+


### PR DESCRIPTION
This PR adds a herd Instructions Test for `ASR` (Arithmetic Shift Right) on AArch64 to confirm that it performs _arithmetic_ and not _logical_ shifts for negative values.
