### PR TITLE
[gen] Fix constant loading (MOV instruction) for Morello.

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -78,7 +78,15 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | S128 -> V128
 
     let mov r i = I_MOV (vloc,r,K i)
-    let mov_mixed sz r i = let v = sz2v sz in I_MOV (v,r,i)
+
+    let mov_mixed sz r i =
+      let sz =
+        let open MachSize in
+        match sz with
+        | S128 -> Quad (* MOV C?,#X is not recognized *)
+        | Byte|Short|Word|Quad -> sz in
+      let v = sz2v sz in I_MOV (v,r,i)
+
     let mov_reg_addr r1 r2 =  I_MOV (V64,r1,RV (V64,r2))
     let mov_reg r1 r2 = I_MOV (vloc,r1,RV (vloc,r2))
     let mov_reg_mixed sz r1 r2 = let v = sz2v sz in I_MOV (v,r1,RV (v,r2))


### PR DESCRIPTION
MOV Cn,#i is not recognized by (herd) parser. Such instructions
were nevertheless emitted by generators for stores with
annotation Pc. As stores with annotation Lc command emission
of MOV Xn,#i, which herd accepts, we adopt the same behaviour.

For instance, old behaviour of command `diyone7 -arch AArch64 -variant morello -cond observe -oneloc Pc PosWW Pc Coe` yielded:
```
AArch64 A
"PosWWPcPc CoePcPc"
Generator=diyone7 (version 7.56+02~dev)
Com=Co
Orig=PosWWPcPc CoePcPc
{
uint128_t x;

0:X1=0xffffc0000:x:1;
}
 P0          ;
 MOV C0,#1   ;
 STR C0,[X1] ;
 MOV C2,#2   ;
 STR C2,[X1] ;
locations [x;]
```
Where instructions `MOV C0,#1` and `MOV C2,#1` are not accepted. New behaviour is:
```
AArch64 A
"PosWWPcPc CoePcPc"
Generator=diyone7 (version 7.56+02~dev)
Com=Co
Orig=PosWWPcPc CoePcPc
{
uint128_t x;

0:X1=0xffffc0000:x:1;
}
 P0          ;
 MOV X0,#1   ;
 STR C0,[X1] ;
 MOV X2,#2   ;
 STR C2,[X1] ;
locations [x;]
```

