### PR TITLE
[all] Implement morello capacities with int64.

### DIFF
--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -458,7 +458,7 @@ module Make(C:Config) (I:I) : S with module I = I
                 (fun i v ->
                   let s = I.V.pp false locval in
                   let tag = None in
-                  let cap = 0 in
+                  let cap = 0L in
                   let sym_data =
                     { Constant.name=s ;
                       tag=tag ;

--- a/lib/CapabilityConstant.ml
+++ b/lib/CapabilityConstant.ml
@@ -34,6 +34,9 @@ module CapabilityScalar = struct
     tag, Uint128.of_string y
   let of_int x = false, Uint128.of_int x
   let to_int (_,x) = Uint128.to_int x
+  let of_int64 x = false,Uint128.of_int64 x
+  let to_int64 (_,x) = Uint128.to_int64 x
+
   let compare (t1,x1) (t2,x2) =
     match Uint128.compare x1 x2 with
     | 0 -> compare t1 t2

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -17,7 +17,7 @@
 (** Constants, both symbolic (ie addresses) and concrete (eg integers)  *)
 
 type tag = string option
-type cap = int
+type cap = Int64.t
 type offset = int
 
 (* Symbolic location metadata*)

--- a/lib/int32Constant.ml
+++ b/lib/int32Constant.ml
@@ -51,6 +51,9 @@ module Int32Scalar = struct
        let m = shift_left one (nb-1) in
        sub (logxor v m) m
 
+  let of_int64 _ = assert false
+  let to_int64 _ = assert false
+
   let get_tag _ = assert false
   let set_tag _ = assert false
 end

--- a/lib/int64Constant.ml
+++ b/lib/int64Constant.ml
@@ -49,6 +49,9 @@ module Int64Scalar = struct
        let m = shift_left one (nb-1) in
        sub (logxor v m) m
 
+  let of_int64 = Misc.identity
+  let to_int64 = Misc.identity
+
   let get_tag _ = assert false
   let set_tag _ = assert false
 end

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -272,6 +272,7 @@ let pos_of_string s =
 (***************)
 
 let string_as_int s = try int_of_string s with Failure _ -> assert false
+let string_as_int64 s = try Int64.of_string s with Failure _ -> assert false
 
 let string_of_intkm s =
   let len = String.length s in

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -93,6 +93,7 @@ val pos_of_string : string -> (float * float) option
 
 (* Generalize int parsing *)
 val string_as_int : string -> int
+val string_as_int64 : string -> Int64.t
 val string_of_intkm : string -> int option
 val explode : string -> char list
 

--- a/lib/parsedConstant.ml
+++ b/lib/parsedConstant.ml
@@ -22,8 +22,12 @@ module StringScalar = struct
 
   let of_string s = s
   let compare = String.compare
+
   let to_int k = int_of_string k
   let of_int i = Printf.sprintf "%i" i
+  let to_int64 = Int64.of_string
+  let of_int64 = Int64.to_string
+
   let pp _ s = s
 
   let op1 name  _ = Warn.fatal "unary operation '%s' on parsed constant" name

--- a/lib/scalar.mli
+++ b/lib/scalar.mli
@@ -25,8 +25,12 @@ module type S = sig
 
   val of_string : string -> t
   val pp : bool -> t -> string
+
   val of_int : int -> t
   val to_int : t -> int (* Hum *)
+
+  val of_int64 : int64 -> t
+  val to_int64 : t -> int64 (* Hum *)
 
   val compare : t -> t -> int
 

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -138,12 +138,14 @@ module Make(Cst:Constant.S) = struct
    *     value, instead of the value itself. *)
 
   let scalar_of_cap c =
-    let tag = c land 0x200000000 <> 0 in
-    Scalar.set_tag tag (Scalar.shift_left (Scalar.of_int c) 95)
+    let tag = not (Int64.equal (Int64.logand c 0x200000000L) 0L) in
+    Scalar.set_tag tag (Scalar.shift_left (Scalar.of_int64 c) 95)
 
   let cap_of_scalar a =
-    let tag = if Scalar.get_tag a then 0x200000000 else 0 in
-    Scalar.to_int (Scalar.shift_right_logical a 95) lor tag
+    let tag = if Scalar.get_tag a then 0x200000000L else 0L in
+    Int64.logor
+      (Scalar.to_int64 (Scalar.shift_right_logical a 95))
+      tag
 
   (* Concrete -> Concrete
      Symbolic -> Concrete *)
@@ -738,7 +740,7 @@ module Make(Cst:Constant.S) = struct
     else v1
 
   let capastrip v = match v with
-  | Val (Symbolic (Virtual s)) -> mk_val_virtual {s with cap=0}
+  | Val (Symbolic (Virtual s)) -> mk_val_virtual {s with cap=0L}
   | Val cst -> Warn.user_error "Illegal capastrip on %s" (Cst.pp_v cst)
   | Var _ -> raise Undetermined
 

--- a/lib/uint.ml
+++ b/lib/uint.ml
@@ -347,6 +347,14 @@ module Uint128 = struct
     else
       Uint64.zero, Uint64.of_int i
 
+  let to_int64 (_,lo) = lo
+
+  let of_int64 i =
+    let hi =
+      if Int64.compare i 0L < 0 then Uint64.max_int else Uint64.zero in
+    hi,i
+
+
   let to_string a =
     let ten = of_int 10 in
     let string_of_digit q =

--- a/lib/uint.mli
+++ b/lib/uint.mli
@@ -96,6 +96,8 @@ module Uint128 : sig
 
   include S with type t := t
 
+  val to_int64 : t -> Int64.t
+  val of_int64 : Int64.t -> t
   val of_uint64 : Uint64.t -> t
   val of_uint32 : Uint32.t -> t
   val of_uint16 : Uint16.t -> t

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -32,7 +32,7 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
     let open Constant in
     function
       | Concrete i -> "addr_" ^ V.Scalar.pp O.hexa i
-      | Symbolic (Virtual {name=s; tag=None; cap=0;_ })-> s
+      | Symbolic (Virtual {name=s; tag=None; cap=0L;_ })-> s
       | Label _|Symbolic _|Tag _|ConcreteVector _| PteVal _ -> assert false
 
   module Internal = struct

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -299,7 +299,7 @@ module Make
        | ConcreteVector (_,vs)->
           let pp_vs = List.map dump_a_v vs in
           sprintf "{%s}" (String.concat "," pp_vs) (* list initializer syntax *)
-      | Symbolic (Virtual {name=s;tag=None;cap=0;offset=0;_})-> dump_a_addr s
+      | Symbolic (Virtual {name=s;tag=None;cap=0L;offset=0;_})-> dump_a_addr s
       | Label _ ->
           Warn.user_error "No label value for klitmus"
       | Symbolic _|Tag _| PteVal _ ->

--- a/litmus/global_litmus.ml
+++ b/litmus/global_litmus.ml
@@ -41,7 +41,7 @@ let as_addr = function
 let tr_symbol =
   let open Constant in
   function
-    | Virtual {name=s; tag=None; cap=0; offset=0;} -> Addr s
+    | Virtual {name=s; tag=None; cap=0L; offset=0;} -> Addr s
     | Physical (s,0) -> Phy s
     | System (PTE,s) -> Pte s
     | c ->  Warn.fatal "litmus cannot handle symbol '%s'" (pp_symbol c)

--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -55,7 +55,7 @@ module Make(O:Config)(V:Constant.S) = struct
 
   let dump_v_std v = match v with
   | Concrete _ -> V.pp O.hexa v
-  | Symbolic (Virtual {name=a;tag=None;cap=0;offset=0;}) -> dump_addr a
+  | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=0;}) -> dump_addr a
   | ConcreteVector _ -> V.pp O.hexa v
   | Tag _
   | Symbolic _


### PR DESCRIPTION
The change should allow compilation on 32bits platforms,
solving issue #154.

Notice that Uint.Uint64.t may be a more natural choice.
However, this would hinder using the syntactical features
of int64.