### PR TITLE
[herd] KVM, no branch for direct access

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -863,14 +863,15 @@ module Make
            (* mv is read new value from reg, not important
               as this code is not executed in morello mode *)
           (fun ac ma mv ->
-            let ma = append_commit ma ii in
+            let is_phy = Act.is_physical ac in
+            let ma = if is_phy then append_commit ma ii else ma in
              M.altT
               (let read_mem a = do_read_mem_ret sz an aexp ac a ii in
-               M.aarch64_cas_no ma read_rs write_rs read_mem M.neqT)
+               M.aarch64_cas_no is_phy ma read_rs write_rs read_mem M.neqT)
               (let read_rt = mv
                and read_mem a = rmw_amo_read sz rmw ac a ii
                and write_mem a v = rmw_amo_write sz rmw ac a v ii in
-               M.aarch64_cas_ok  ma read_rs read_rt write_rs
+               M.aarch64_cas_ok is_phy ma read_rs read_rt write_rs
                  read_mem write_mem M.eqT))
           (to_perms "rw" sz) (read_reg_ord rn ii) (read_reg_data sz rt ii)
         an ii

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -363,13 +363,15 @@ val same_instance : event -> event -> bool
             event_structure
 
   val aarch64_cas_no :
-            event_structure -> event_structure -> event_structure ->
-            event_structure ->  event_structure
+    bool -> (* Physical memory access *)
+    event_structure -> event_structure -> event_structure ->
+    event_structure ->  event_structure
 
   val aarch64_cas_ok :
-        event_structure -> event_structure -> event_structure ->
-          event_structure ->  event_structure ->  event_structure ->
-            event_structure
+    bool -> (* Physical memory access *)
+    event_structure -> event_structure -> event_structure ->
+    event_structure ->  event_structure ->  event_structure ->
+    event_structure
 
   val aarch64_cas_ok_morello :
         event_structure -> event_structure -> event_structure ->
@@ -1732,9 +1734,8 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
                                        (wmem.aligned) ;}
 
 (* AArch64 CAS, failure *)
-    let aarch64_cas_no rn rs wrs rm =
-      let output_rn = maximals rn
-      and output_rs = maximals rs
+    let aarch64_cas_no is_phy rn rs wrs rm =
+      let output_rs = maximals rs
       and output_rm = maximals rm
       and input_wrs = minimals wrs
       and input_rm = minimals rm in
@@ -1756,14 +1757,18 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
              wrs.intra_causality_data
              rm.intra_causality_data)
           (EventRel.union
-             (EventRel.cartesian output_rn input_rm)    (* D1 *)
-             (EventRel.cartesian output_rm input_wrs)); (* Df1 *)
+             (EventRel.cartesian (get_output rn) input_rm) (* D1 *)
+             (EventRel.cartesian output_rm input_wrs));    (* Df1 *)
         intra_causality_control =
-        EventRel.union6
-          rn.intra_causality_control rs.intra_causality_control
-          wrs.intra_causality_control rm.intra_causality_control
-          (EventRel.cartesian output_rs input_wrs)      (* C1 *)
-          (EventRel.cartesian output_rm input_wrs);     (* C2 *)
+          (if is_branching && is_phy then
+             EventRel.union
+               (EventRel.cartesian (maximal_commits rn) input_rm)
+           else Misc.identity)
+            (EventRel.union6
+               rn.intra_causality_control rs.intra_causality_control
+               wrs.intra_causality_control rm.intra_causality_control
+               (EventRel.cartesian output_rs input_wrs)      (* C1 *)
+               (EventRel.cartesian output_rm input_wrs));    (* C2 *)
         control =
         EventRel.union4 rn.control rs.control rm.control wrs.control;
         data_ports =
@@ -1786,9 +1791,8 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
       }
 
 (* AArch64 CAS, success *)
-    let aarch64_cas_ok rn rs rt wrs rm wm =
-      let output_rn = maximals rn
-      and output_rs = maximals rs
+    let aarch64_cas_ok is_phy rn rs rt wrs rm wm =
+      let output_rs = maximals rs
       and output_rm = maximals rm
       and input_wrs = minimals wrs
       and input_rm = minimals rm
@@ -1816,10 +1820,10 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
              rm.intra_causality_data
              wm.intra_causality_data)
           (EventRel.union4
-             (EventRel.cartesian output_rn input_rm)       (* D1 *)
-             (EventRel.cartesian output_rs input_wrs)      (* Ds1 *)
-             (EventRel.cartesian output_rn input_wm)       (* Ds2 *)      
-             (EventRel.cartesian (maximals rt) input_wm)); (* Ds3 *)
+             (EventRel.cartesian (get_output rn) input_rm)    (* D1 *)
+             (EventRel.cartesian output_rs input_wrs)         (* Ds1 *)
+             (EventRel.cartesian (get_output rn) input_wm)    (* Ds2 *)
+             (EventRel.cartesian (maximals rt) input_wm));    (* Ds3 *)
         intra_causality_control =
         EventRel.union
           (EventRel.union6
@@ -1829,10 +1833,14 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
              wrs.intra_causality_control
              rm.intra_causality_control
              wm.intra_causality_control)
-          (EventRel.union4
+          (EventRel.union5
+             (if is_branching && is_phy then
+                EventRel.cartesian (maximal_commits rn)
+                  (EventSet.union input_rm input_wm)
+              else EventRel.empty)
              (EventRel.cartesian output_rs input_wrs)  (* C1 *)
              (EventRel.cartesian output_rm input_wrs)  (* C2 *)
-             (EventRel.cartesian output_rs input_wm)   (* Cs1 *) 
+             (EventRel.cartesian output_rs input_wm)   (* Cs1 *)
              (EventRel.cartesian output_rm input_wm)); (* Cs2 *)
         control =
         (EventRel.union6

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -460,6 +460,7 @@ Monad type:
 
 (* AArch64 failed cas *)
     let aarch64_cas_no
+        (is_physical:bool)
         (read_rn:'loc t) (read_rs:'v t)
         (write_rs:'v-> unit t)
         (read_mem: 'loc -> 'v t)
@@ -477,12 +478,13 @@ Monad type:
       let (),cl_ne,eseq =  Evt.as_singleton_nospecul nem in
       assert (E.is_empty_event_structure eseq) ;
       let es =
-        E.aarch64_cas_no es_rn es_rs es_wrs es_rm in
+        E.aarch64_cas_no is_physical es_rn es_rs es_wrs es_rm in
       let cls = cl_a@cl_cv@cl_rm@cl_wrs@cl_ne  in
       eiid,(Evt.singleton ((),cls,es), None)
 
 (* AArch64 successful cas *)
     let aarch64_cas_ok
+        (is_physical:bool)
         (read_rn:'loc t) (read_rs:'v t) (read_rt: 'v t)
         (write_rs:'v-> unit t)
         (read_mem: 'loc -> 'v t) (write_mem: 'loc -> 'v -> unit t)
@@ -508,7 +510,7 @@ Monad type:
             let (),cl_eq,eseq =  Evt.as_singleton_nospecul eqm in
             assert (E.is_empty_event_structure eseq) ;
             let es =
-              E.aarch64_cas_ok es_rn es_rs es_rt es_wrs es_rm es_wm in
+              E.aarch64_cas_ok is_physical es_rn es_rs es_rt es_wrs es_rm es_wm in
             let cls = cl_a@cl_cv@cl_nv@cl_rm@cl_wm@cl_wrs@cl_eq  in
             eiid,Evt.add ((),cls,es) acts)
           acts_rn (eiid,Evt.empty) in

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -42,6 +42,8 @@ module Make (C:Config) (A : A) : sig
 
   type access_t = A_REG | A_VIR | A_PHY | A_PTE | A_TLB | A_TAG | A_PHY_PTE
 
+  val is_physical : access_t -> bool
+
   type action =
     | Access of Dir.dirn * A.location * A.V.v * A.lannot * A.explicit * MachSize.sz * access_t
     | Barrier of A.barrier
@@ -74,6 +76,10 @@ end = struct
   let kvm = C.variant Variant.Kvm
 
   type access_t = A_REG | A_VIR | A_PHY | A_PTE | A_TLB | A_TAG | A_PHY_PTE
+
+  let is_physical = function
+    | A_PHY|A_PHY_PTE -> true
+    | A_REG|A_VIR|A_PTE|A_TLB|A_TAG -> false
 
   let access_of_constant cst =
     let open Constant in

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -108,11 +108,13 @@ module type S =
                 unit t
 
     val aarch64_cas_no :
+      bool -> (* physical access *)
         'loc t -> 'v t ->
           ('v -> unit t) -> ('loc -> 'v t) ->
             ('v -> 'v -> unit t) -> unit t
 
     val aarch64_cas_ok :
+      bool -> (* physical access *)
         'loc t -> 'v t -> 'v t ->
           ('v -> unit t) -> ('loc -> 'v t) -> ('loc -> 'v -> unit t) ->
             ('v -> 'v -> unit t) -> unit t

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -64,13 +64,15 @@ module type S =
   from read_register to write_register.
   The dependency from read_mem to write_mem is iico_ctrl for swp
   and iico_data for amo_strict.
+
+  First bool argument <=> physical access.
 *)
-    val swp : ('loc t) ->
+    val swp : bool -> ('loc t) ->
       ('loc -> A.V.v t) -> A.V.v t (* read reg *) ->
         ('loc -> A.V.v -> unit t) ->  (A.V.v -> unit t) (* Write reg *)
           -> unit t
 
-    val amo_strict : Op.op -> ('loc t) ->
+    val amo_strict : bool -> Op.op -> ('loc t) ->
       ('loc -> A.V.v t) -> A.V.v t (* read reg *) ->
         ('loc -> A.V.v -> unit t) ->  (A.V.v -> unit t) (* Write reg *)
           -> unit t

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -376,11 +376,11 @@ module Make(Cst:Constant.S) = struct
 
   let eq v1 v2 = match v1,v2 with
   | Var i1,Var i2 when Misc.int_eq i1 i2 -> one
-  | Val (Symbolic _|Label _|Tag _|ConcreteVector _ as s1),Val (Symbolic _|Label _|Tag _|ConcreteVector _ as s2) ->
+  | Val (Symbolic _|Label _|Tag _|PteVal _|ConcreteVector _ as s1),Val (Symbolic _|Label _|Tag _|PteVal _|ConcreteVector _ as s2) ->
       bool_to_v Cst.eq s1 s2
 (* Assume concrete and others always to differ *)
-  | (Val (Symbolic _|Label _|Tag _|ConcreteVector _), Val (Concrete _))
-  | (Val (Concrete _), Val (Symbolic _|Label _|Tag _|ConcreteVector _)) -> zero
+  | (Val (Symbolic _|Label _|Tag _|ConcreteVector _|PteVal _), Val (Concrete _))
+  | (Val (Concrete _), Val (Symbolic _|Label _|Tag _|ConcreteVector _|PteVal _)) -> zero
   | _,_ ->
       binop
         Op.Eq


### PR DESCRIPTION
Do not emit branching events in the direct access to memory case.

When memory accesses involve page table walk, a branching event is inserted between page table read and
(physical) memory access(es). For direct accesses, such as page table access without variant `pte2`, those
branching events are superfluous.