### PR TITLE
[herd] Discard executions with wrong rf matching.

### DIFF
--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -666,7 +666,7 @@ let () =
         | Misc.Fatal msg ->
             Warn.warn_always "%a: %s" Pos.pp_pos0 name msg ;
              check_exit seen
-        | Misc.UserError msg ->
+        | Misc.UserError msg | Op.Illegal (_,msg) ->
             begin if check_pos0 msg then
               Warn.warn_always "%s (User error)" msg
             else

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -736,8 +736,11 @@ let match_reg_events es =
                 let es = E.simplify_vars_in_event_structure sol es
                 and rfm = S.simplify_vars_in_rfmap sol rfm in
                 kont es rfm cs res
-          with Contradiction -> res  (* can be raised by add_mem_eqs *)
-          | e ->
+          with (* First legitimately discard failing candidates *)
+          | Contradiction -> res  (* May be raised by add_mem_eqs *)
+          | Op.Illegal (Op.Op1 (Op.Mask _),_)  ->
+             res (* May result from wrong rf choice *)
+          | e -> (* Remaining cases are errors *)
               if C.debug.Debug_herd.top then begin
                 eprintf "Exception: %s\n%!" (Printexc.to_string e) ;
                 let module PP = Pretty.Make(S) in

--- a/lib/op.ml
+++ b/lib/op.ml
@@ -156,3 +156,15 @@ type op3 = If
 
 let pp_op3 o s1 s2 s3 = match o with
 | If -> sprintf "%s ? %s : %s" s1 s2 s3
+
+(***********************************)
+(* Specific "Illegal Op" exception *)
+(***********************************)
+
+type any_op = Op1 of op1 | Op of op | Op3 of op3
+
+exception Illegal of any_op * string
+
+let illegal op fmt =
+  ksprintf (fun msg -> raise (Illegal (op,msg)))  fmt
+

--- a/lib/op.mli
+++ b/lib/op.mli
@@ -90,3 +90,13 @@ val pp_op1 : bool -> op1 -> string
 type op3 = If
 
 val pp_op3 : op3 -> string -> string -> string ->  string
+
+(***********************************)
+(* Specific "Illegal Op" exception *)
+(***********************************)
+
+type any_op = Op1 of op1 | Op of op | Op3 of op3
+
+exception Illegal of any_op * string
+
+val illegal : any_op -> ('a , unit, string, 'b) format4 -> 'a

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -119,8 +119,9 @@ module Make(Cst:Constant.S) = struct
     | Val (Concrete i1) ->
         Val (Concrete (op i1))
     | Val (ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _ as x) ->
-        Warn.user_error "Illegal operation %s on %s"
-          (Op.pp_op1 true op_op) (Cst.pp_v x)
+       let pp = Op.pp_op1 true op_op in
+        Op.illegal  (Op.Op1 op_op) "Illegal operation %s on %s"
+          pp (Cst.pp_v x)
     | Var _ -> raise Undetermined
 
   let binop op_op op v1 v2 = match v1,v2 with


### PR DESCRIPTION
Some executions fail during the solver phase because a pair
of memory write and read are not matched properly. For instance
one may match a pte write with a 32bits read. Such execution
is better discared than trigerring herd failure.

This is attempted by introducing a specific exception for
operation failure and catching it around calls to solver
in its "memory" phase. For now only masking operation failure
are handled that way.