### PR TITLE
Revert "[herd] Discard executions with wrong rf matching." and better solution.

### DIFF
--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -666,7 +666,7 @@ let () =
         | Misc.Fatal msg ->
             Warn.warn_always "%a: %s" Pos.pp_pos0 name msg ;
              check_exit seen
-        | Misc.UserError msg | Op.Illegal (_,msg) ->
+        | Misc.UserError msg ->
             begin if check_pos0 msg then
               Warn.warn_always "%s (User error)" msg
             else

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -736,7 +736,8 @@ let match_reg_events es =
                 let es = E.simplify_vars_in_event_structure sol es
                 and rfm = S.simplify_vars_in_rfmap sol rfm in
                 kont es rfm cs res
-          with Contradiction -> res  (* can be raised by add_mem_eqs *)
+          with
+          | Contradiction -> res  (* May also be raised by add_mem_eqs *)
           | e ->
               if C.debug.Debug_herd.top then begin
                 eprintf "Exception: %s\n%!" (Printexc.to_string e) ;
@@ -761,6 +762,8 @@ let match_reg_events es =
               Warn.warn_always
                 "unrolling too deep at label: %s" lbl;
               true
+          | VC.Failed _ -> (* Should not be here, eaten in solver *)
+             assert false
           | VC.Assign _ -> false)
           cs in
       if unroll_only then

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -736,11 +736,8 @@ let match_reg_events es =
                 let es = E.simplify_vars_in_event_structure sol es
                 and rfm = S.simplify_vars_in_rfmap sol rfm in
                 kont es rfm cs res
-          with (* First legitimately discard failing candidates *)
-          | Contradiction -> res  (* May be raised by add_mem_eqs *)
-          | Op.Illegal (Op.Op1 (Op.Mask _),_)  ->
-             res (* May result from wrong rf choice *)
-          | e -> (* Remaining cases are errors *)
+          with Contradiction -> res  (* can be raised by add_mem_eqs *)
+          | e ->
               if C.debug.Debug_herd.top then begin
                 eprintf "Exception: %s\n%!" (Printexc.to_string e) ;
                 let module PP = Pretty.Make(S) in

--- a/herd/tests/instructions/AArch64/A176.litmus
+++ b/herd/tests/instructions/AArch64/A176.litmus
@@ -1,0 +1,17 @@
+AArch64 A176
+(*
+  Test reading integer partially.
+  The trick allows enforcing alignement
+  constraint more stringent than
+  using type of smaller size.
+*)
+
+{
+  uint64_t x = 0x0000000100000002;
+  0:X2=x;
+}
+
+P0;
+  LDR W0, [X2];
+forall (0:X0=2)
+

--- a/herd/tests/instructions/AArch64/A176.litmus.expected
+++ b/herd/tests/instructions/AArch64/A176.litmus.expected
@@ -1,0 +1,10 @@
+Test A176 Required
+States 1
+0:X0=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=2)
+Observation A176 Always 1 0
+Hash=d37c9375e376d5c07b9b6cb64acf3480
+

--- a/herd/tests/instructions/AArch64/A177.litmus
+++ b/herd/tests/instructions/AArch64/A177.litmus
@@ -1,0 +1,11 @@
+AArch64 A177
+{
+  int *p = &x;
+  int x=1;
+  0:X2=p;
+}
+
+P0;
+  LDR W0,[X2];
+locations [0:X0;]
+

--- a/herd/tests/instructions/AArch64/A177.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/A177.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A177.litmus": Illegal operation mask32 on x (User error)

--- a/herd/tests/instructions/AArch64/A178.litmus
+++ b/herd/tests/instructions/AArch64/A178.litmus
@@ -1,0 +1,15 @@
+AArch64 A178
+(* Combine illegal load of address in 32bits register
+   and indirect access. Should fail *)
+{
+  int *p = &x;
+  int x=1;
+  0:X2=p;
+  1:X2=p;
+}
+
+  P0         | P1          ;
+ LDR X0,[X2] | LDR W0,[X2] ;
+ LDR W1,[X0] |             ;
+locations [0:X0; 0:X1;]
+

--- a/herd/tests/instructions/AArch64/A178.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/A178.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A178.litmus": Illegal operation mask32 on x (User error)

--- a/herd/tests/instructions/AArch64/A179.litmus
+++ b/herd/tests/instructions/AArch64/A179.litmus
@@ -1,0 +1,18 @@
+AArch64 A179
+(* Combine illegal load of address in 32bits register
+   and indirect access. Should fail *)
+{
+  int x = 1;
+  int64_t y = 2;
+  int *p = &x;
+  0:X2=p;
+  1:X2=p;
+  1:X1=y;
+  2:X2=p;
+}
+
+  P0         | P1          | P2          ;
+ LDR X0,[X2] | STR X1,[X2] | STR X2,[X2] ;
+ LDR W1,[X0] |             |             ;
+locations [0:X0; 0:X1;]
+

--- a/herd/tests/instructions/AArch64/A179.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/A179.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A179.litmus": Illegal operation mask32 on x (User error)

--- a/herd/tests/instructions/AArch64/A180.litmus
+++ b/herd/tests/instructions/AArch64/A180.litmus
@@ -1,0 +1,16 @@
+AArch64 A180
+(*
+Test A176 + indirection, should work
+*)
+
+{
+  uint64_t x = 0x0000000100000002;
+  uint64_t *p = &x;
+  0:X2=p;
+}
+
+P0;
+  LDR X2,[X2] ;
+  LDR W0,[X2] ;
+forall (0:X0=2)
+

--- a/herd/tests/instructions/AArch64/A180.litmus.expected
+++ b/herd/tests/instructions/AArch64/A180.litmus.expected
@@ -1,0 +1,10 @@
+Test A180 Required
+States 1
+0:X0=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=2)
+Observation A180 Always 1 0
+Hash=2a5b695ffe83e16f770c91d384c0f8ba
+

--- a/herd/tests/instructions/AArch64/A181.litmus
+++ b/herd/tests/instructions/AArch64/A181.litmus
@@ -1,0 +1,20 @@
+AArch64 A181
+(*
+Test A176 + indirection, should work
+*)
+q
+{
+  int y = 1;
+  uint64_t x = 0x0000000100000002;
+  uint64_t *p = &x;
+  uint64_t *q = p;
+  0:X2=p;
+  1:X2=q;
+  1:X0=y;
+}
+
+ P0          | P1          ;
+ LDR X2,[X2] | LDR X4,[X2] ;
+ LDR W0,[X2] | STR X0,[X4] ;
+exists (0:X0=1)
+

--- a/herd/tests/instructions/AArch64/A181.litmus.expected
+++ b/herd/tests/instructions/AArch64/A181.litmus.expected
@@ -1,0 +1,11 @@
+Test A181 Allowed
+States 2
+0:X0=1;
+0:X0=2;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists (0:X0=1)
+Observation A181 Sometimes 1 1
+Hash=e6a2f1a84abc84eac6474de173a96510
+

--- a/herd/tests/instructions/AArch64/A182.litmus
+++ b/herd/tests/instructions/AArch64/A182.litmus
@@ -1,0 +1,17 @@
+AArch64 A182
+(*
+  Complex indrect store/load, should work
+*)
+q
+{
+  int x[2] = {1,1};
+  int *p = &x;
+  0:X2=p; 1:X2=p; 1:X4=x; 2:X2=p;
+}
+
+ P0          | P1           | P2          ;
+ LDR X2,[X2] | ADD X4,X4,#4 | LDR X2,[X2] ;
+ MOV W0,#2   | STR X4,[X2]  | LDR W0,[X2] ;
+ STR W0,[X2] |              |             ;
+locations [x;2:X0;]
+

--- a/herd/tests/instructions/AArch64/A182.litmus.expected
+++ b/herd/tests/instructions/AArch64/A182.litmus.expected
@@ -1,0 +1,13 @@
+Test A182 Required
+States 4
+2:X0=1; x={1,2};
+2:X0=1; x={2,1};
+2:X0=2; x={1,2};
+2:X0=2; x={2,1};
+Ok
+Witnesses
+Positive: 6 Negative: 0
+Condition forall (true)
+Observation A182 Always 6 0
+Hash=fda1400634ecec2e31432cf26175326e
+

--- a/herd/tests/instructions/AArch64/A183.litmus
+++ b/herd/tests/instructions/AArch64/A183.litmus
@@ -1,0 +1,17 @@
+AArch64 A183
+(*
+  Complex indrect store/load, should fail
+*)
+q
+{
+  int x[2] = {1,1};
+  int *p = &x;
+  0:X2=p; 1:X2=p; 1:X4=x; 2:X2=p;
+}
+
+ P0          | P1           | P2          ;
+ LDR X2,[X2] | ADD X4,X4,#4 | LDR X2,[X2] ;
+ MOV W0,#2   | STR X4,[X2]  | LDR W0,[X2] ;
+ STR W0,[X2] | STR X2,[X2]  |             ;
+locations [x;2:X0;]
+

--- a/herd/tests/instructions/AArch64/A183.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/A183.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A183.litmus": Illegal operation mask32 on x (User error)

--- a/lib/op.ml
+++ b/lib/op.ml
@@ -156,15 +156,3 @@ type op3 = If
 
 let pp_op3 o s1 s2 s3 = match o with
 | If -> sprintf "%s ? %s : %s" s1 s2 s3
-
-(***********************************)
-(* Specific "Illegal Op" exception *)
-(***********************************)
-
-type any_op = Op1 of op1 | Op of op | Op3 of op3
-
-exception Illegal of any_op * string
-
-let illegal op fmt =
-  ksprintf (fun msg -> raise (Illegal (op,msg)))  fmt
-

--- a/lib/op.mli
+++ b/lib/op.mli
@@ -90,13 +90,3 @@ val pp_op1 : bool -> op1 -> string
 type op3 = If
 
 val pp_op3 : op3 -> string -> string -> string ->  string
-
-(***********************************)
-(* Specific "Illegal Op" exception *)
-(***********************************)
-
-type any_op = Op1 of op1 | Op of op | Op3 of op3
-
-exception Illegal of any_op * string
-
-val illegal : any_op -> ('a , unit, string, 'b) format4 -> 'a

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -119,9 +119,8 @@ module Make(Cst:Constant.S) = struct
     | Val (Concrete i1) ->
         Val (Concrete (op i1))
     | Val (ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _ as x) ->
-       let pp = Op.pp_op1 true op_op in
-        Op.illegal  (Op.Op1 op_op) "Illegal operation %s on %s"
-          pp (Cst.pp_v x)
+        Warn.user_error "Illegal operation %s on %s"
+          (Op.pp_op1 true op_op) (Cst.pp_v x)
     | Var _ -> raise Undetermined
 
   let binop op_op op v1 v2 = match v1,v2 with


### PR DESCRIPTION
Reverts herd/herdtools7#184.

I guess I have a better solution: delaying exceptions in solver to let the opportunity for contradiction to show up.