### PR TITLE
[tools] Add short summaries to various tools

### DIFF
--- a/tools/mapply.ml
+++ b/tools/mapply.ml
@@ -254,6 +254,16 @@ let pp_mode = function
 
 let set_mode tag = mode := parse_mode tag
 
+let usage = String.concat "\n" [
+  Printf.sprintf "Usage: %s [options] [<token> ...]" (Filename.basename Sys.argv.(0)) ;
+  "" ;
+  "Apply a command to every non-option token on the command-line. If none are" ;
+  "provided, tokens are read from stdin. Tokens that start with `@` are" ;
+  "interpreted as filepaths, and the lines of the file are read as tokens." ;
+  "" ;
+  "Options:" ;
+]
+
 let () =
   Arg.parse
     ["-v", Arg.Unit (fun () -> incr verbose)," be verbose";
@@ -266,7 +276,7 @@ let () =
      sprintf
        "(buff|file) use either internal buffers or files for comunication, default %s" (pp_mode !mode);]
     (fun arg -> args := arg :: !args)
-    ""
+    usage
 
 let names = !args
 

--- a/tools/mdiff.ml
+++ b/tools/mdiff.ml
@@ -49,7 +49,7 @@ let options =
   ]
 
 let prog =
-  if Array.length Sys.argv > 0 then Sys.argv.(0)
+  if Array.length Sys.argv > 0 then (Filename.basename Sys.argv.(0))
   else "mdiff"
 
 type act = Diff | Inter
@@ -63,12 +63,18 @@ let act =
   | "minter"|"minter7" -> Inter
   | _ -> assert false
 
+let usage = String.concat "\n" [
+  Printf.sprintf "Usage: %s [options] <path/to/log-1> <path/to/log-2>" prog ;
+  "" ;
+  "List the differing observed states for each test within 2 log files." ;
+  "" ;
+  "Options:" ;
+]
+
 let () =
   Arg.parse options
     (fun s -> logs := !logs @ [s])
-    (sprintf "Usage %s [options]* log1 log2
-log1 log2 are log file names.
-Options are:" prog)
+    usage
 
 let excl = !excl
 let select = !select

--- a/tools/mlog2cond.ml
+++ b/tools/mlog2cond.ml
@@ -47,15 +47,22 @@ let options =
   ]
 
 let prog =
-  if Array.length Sys.argv > 0 then Sys.argv.(0)
+  if Array.length Sys.argv > 0 then (Filename.basename Sys.argv.(0))
   else "mlog2cond"
+
+let usage = String.concat "\n" [
+  Printf.sprintf "Usage: %s [options] [path/to/log]" prog ;
+  "" ;
+  "Extract the condition from a single log file. If one is not provided on the" ;
+  "command-line, it will be read from stdin." ;
+  "" ;
+  "Options:" ;
+]
 
 let () =
   Arg.parse options
     (fun s -> logs := !logs @ [s])
-    (sprintf "Usage %s [options]* [log]
-log is a log file names.
-Options are:" prog)
+    usage
 
 let verbose = !verbose
 let hexa = !hexa

--- a/tools/recond.ml
+++ b/tools/recond.ml
@@ -293,10 +293,18 @@ let opts =
       !toexists;
   ]
 
+let usage = String.concat "\n" [
+  Printf.sprintf "Usage: %s [options] [<path/to/test> ...]" nprog ;
+  "" ;
+  "Update the condition of one or more litmus test files." ;
+  "" ;
+  "Options:" ;
+]
+
 let () =
   Arg.parse opts
     (fun a -> args := a :: !args)
-    (sprintf "Usage %s [options] [test]*" prog)
+    usage
 
 (* Read names *)
 module Check =


### PR DESCRIPTION
This PR adds short summaries to the usage message for the following tools:

- `mapply7`.
- `mdiff7`.
- `mlog2cond`.
- `recond7`.
