### PR TITLE
[litmus] Inserting synchronisation barrier definition for RISCV.

### DIFF
--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -392,8 +392,10 @@ module Make
             | `X86_64
             | `ARM
             | `MIPS
-            | `AArch64 ->
-                sprintf "barrier%s.c" lab_ext
+            | `AArch64
+            | `RISCV
+              ->
+               sprintf "barrier%s.c" lab_ext
             | _ -> assert false in
         Insert.insert O.o (fname Cfg.sysarch)
 


### PR DESCRIPTION
For some reason,  the case was absent in `preSi.ml`.

Notice that the barrier is coded in C, not in assembly
as this is the case for most other architectures.