### PR TITLE
[herd] Mixed array

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,17 @@ test::
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64 instructions tests: OK"
 
+test:: test.mixed
+test.mixed:
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/AArch64.mixed \
+		-conf ./herd/tests/instructions/AArch64.mixed/mixed.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64 mixed instructions tests: OK"
+
 test::
 	@ echo
 	$(HERD_REGRESSION_TEST) \

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -108,10 +108,6 @@ module type S = sig
   val build_state : (location * (TestType.t * v)) list -> state
   val build_concrete_state : (location * int) list -> state
 
-(* Fails with user error when t is not an array type
-   or in case of out-of-bound access *)
-  val scale_array_reference : TestType.t -> location -> int -> location
-
   val state_is_empty : state -> bool
   val state_add : state -> location -> v -> state
   val state_add_if_undefined  : state -> location -> v -> state
@@ -507,7 +503,8 @@ module Make(C:Config) (I:I) : S with module I = I
         | TyDefPointer -> Some (MachSize.Word,1)
         | Pointer t -> Some (size_of_t t,1)
         | _ -> None
-
+(* Fails with user error when t is not an array type
+   or in case of out-of-bound access *)
       let scale_array_reference t loc os =
         let sz_elt,n_elts =
           match size_of_array t with

--- a/herd/tests/instructions/AArch64.mixed/M000.litmus.expected
+++ b/herd/tests/instructions/AArch64.mixed/M000.litmus.expected
@@ -1,10 +1,10 @@
 Test M000 Required
 States 1
-0:X1=131073; t={1,0,2,0}; t[0]=1; t[1]=0; t[2]=2;
+0:X1=0x20001; t={0x1,0x0,0x2,0x0}; t[0]=0x1; t[1]=0x0; t[2]=0x2;
 Ok
 Witnesses
 Positive: 1 Negative: 0
-Condition forall (t[0]=1 /\ t[1]=0 /\ t[2]=2 /\ 0:X1=131073)
+Condition forall (t[0]=0x1 /\ t[1]=0x0 /\ t[2]=0x2 /\ 0:X1=0x20001)
 Observation M000 Always 1 0
 Hash=17fa4fc37961f227ee4fd9d6623a3757
 

--- a/herd/tests/instructions/AArch64.mixed/mixed.cfg
+++ b/herd/tests/instructions/AArch64.mixed/mixed.cfg
@@ -1,0 +1,2 @@
+variant mixed
+hexa true


### PR DESCRIPTION
This PR fixes an issue resulting from the combination of `-variant mixed` and arrays. The optimised enumeration is wrong in that particular case. The fix consists in falling back to naive enumeration when some observed location is of array type.
