### PR TITLE
[catalogue] Remove reference to removed file demo/cats/anarchy.cat

### DIFF
--- a/catalogue/demo/shelf.py
+++ b/catalogue/demo/shelf.py
@@ -7,7 +7,6 @@ bells = [
 ]
 
 cats = [
-    "cats/anarchy.cat",
     "cats/x86.cat",
     "cats/arm.cat",
     "cats/ptx.cat",


### PR DESCRIPTION
This PR removes a reference to a file `catalogue/demo/cats/anarchy.cat`, which was removed in commit 14b60172beeb54d2690dea69b1bb1b9051e3c064.
This dangling reference was causing the `lint-shelves` pre-commit check to fail; this PR means that all pre-commit checks now pass.
