### PR TITLE
[gen] Fix problem in init section of generated tests.

### DIFF
--- a/gen/archExtra_gen.ml
+++ b/gen/archExtra_gen.ml
@@ -73,6 +73,10 @@ module type S = sig
   val ok_reg : st -> arch_reg * st
   val next_ok : st -> st
   val get_noks : st -> int
+
+  val add_type : location -> TypBase.t -> st -> st
+  val get_env : st -> TypBase.t LocMap.t
+
 end
 
 module Make(I:I) : S
@@ -171,14 +175,15 @@ with type arch_reg = I.arch_reg and type special = I.special
       { regs : arch_reg list ;
         map  : arch_reg StringMap.t ;
         specials : I.special list ;
-        noks : int ; }
-
+        noks : int ;
+        env : TypBase.t LocMap.t ; }
 
   let st0 =
     { regs = I.free_registers;
       map = StringMap.empty;
       specials = I.specials;
-      noks = 0; }
+      noks = 0;
+      env = LocMap.empty; }
 
   let alloc_reg st = match st.regs with
     | [] -> Warn.fatal "No more registers"
@@ -210,4 +215,8 @@ with type arch_reg = I.arch_reg and type special = I.special
   let ok_reg st = alloc_trashed_reg "ok" st
   let next_ok st = { st with noks = st.noks+1; }
   let get_noks st = st.noks
+
+  let add_type loc t st = { st with env = LocMap.add loc t st.env; }
+  let get_env st = st.env
+
 end

--- a/gen/archExtra_gen.ml
+++ b/gen/archExtra_gen.ml
@@ -67,11 +67,6 @@ module type S = sig
   val alloc_trashed_reg : string -> st -> arch_reg * st
   val alloc_loop_idx : string -> st -> arch_reg * st
 
-  val current_label : st -> int
-  val next_label : st -> int
-
-  val next_label_st : st -> st
-
   type special
   val alloc_special : st -> special * st
 
@@ -175,7 +170,6 @@ with type arch_reg = I.arch_reg and type special = I.special
   type st =
       { regs : arch_reg list ;
         map  : arch_reg StringMap.t ;
-        label : int ;
         specials : I.special list ;
         noks : int ; }
 
@@ -183,7 +177,6 @@ with type arch_reg = I.arch_reg and type special = I.special
   let st0 =
     { regs = I.free_registers;
       map = StringMap.empty;
-      label = 0;
       specials = I.specials;
       noks = 0; }
 
@@ -208,10 +201,6 @@ with type arch_reg = I.arch_reg and type special = I.special
 
   let alloc_trashed_reg k st = do_alloc_trashed_reg alloc_reg k st
   and alloc_loop_idx k st = do_alloc_trashed_reg alloc_last_reg k st
-
-  let current_label st = st.label
-  let next_label st = st.label+1
-  let next_label_st st = { st with label = st.label+1; }
 
   type special = I.special
   let alloc_special st = match st.specials with

--- a/gen/archExtra_gen.ml
+++ b/gen/archExtra_gen.ml
@@ -74,6 +74,10 @@ module type S = sig
 
   type special
   val alloc_special : st -> special * st
+
+  val ok_reg : st -> arch_reg * st
+  val next_ok : st -> st
+  val get_noks : st -> int
 end
 
 module Make(I:I) : S
@@ -172,13 +176,16 @@ with type arch_reg = I.arch_reg and type special = I.special
       { regs : arch_reg list ;
         map  : arch_reg StringMap.t ;
         label : int ;
-        specials : I.special list ; }
+        specials : I.special list ;
+        noks : int ; }
+
 
   let st0 =
     { regs = I.free_registers;
       map = StringMap.empty;
       label = 0;
-      specials = I.specials; }
+      specials = I.specials;
+      noks = 0; }
 
   let alloc_reg st = match st.regs with
     | [] -> Warn.fatal "No more registers"
@@ -210,4 +217,8 @@ with type arch_reg = I.arch_reg and type special = I.special
   let alloc_special st = match st.specials with
   | [] -> Warn.fatal "No more special registers"
   | r::rs -> r,{ st with specials = rs; }
+
+  let ok_reg st = alloc_trashed_reg "ok" st
+  let next_ok st = { st with noks = st.noks+1; }
+  let get_noks st = st.noks
 end

--- a/gen/code.ml
+++ b/gen/code.ml
@@ -55,6 +55,7 @@ let ok_str = "ok"
 let ok = Data ok_str
 
 let myok p n = Data (Printf.sprintf "ok%i%i" p n)
+let myok_proc p = Data (Printf.sprintf "ok%i" p)
 
 type v = int
 type proc = Proc.t

--- a/gen/code.mli
+++ b/gen/code.mli
@@ -29,6 +29,7 @@ val loc_none : loc
 val ok_str : string
 val ok : loc
 val myok : int -> int -> loc
+val myok_proc : int -> loc
 
 
 

--- a/gen/compileCommon.ml
+++ b/gen/compileCommon.ml
@@ -69,17 +69,19 @@ module Make(C:Config) (A:Arch_gen.S) = struct
   module C = Cycle.Make(Conf)(E)
 (* Big constant *)
   let kbig = 128
-
 (* Postlude *)
 
   let mk_postlude emit_store_reg st p init cs =
     if A.get_noks st > 0  then
       let ok,st = A.ok_reg st in
+(* Add explict `int` type for `ok<n>` variables *)
       let ok_loc = Code.as_data (Code.myok_proc p) in
+      let st = A.add_type (A.Loc ok_loc) TypBase.Int st in
       let init,cs_store,st = emit_store_reg st p init ok_loc ok in
       let csok = A.Label (Label.last p,A.Nop)::cs_store in
-(* Explicit initialisation implies int type *)
+(* Add explict initialvalue of zero for `ok<n>` variables *)
       (A.Loc ok_loc,Some (A.S "0"))::init,cs@csok,st
     else
       init,cs,st
+
 end

--- a/gen/compileCommon.ml
+++ b/gen/compileCommon.ml
@@ -43,6 +43,7 @@ module type S = sig
   and type edge = E.edge
 
   module C : Cycle.S with type fence = A.fence and type edge=E.edge and type atom = A.atom
+
 end
 
 module Make(C:Config) (A:Arch_gen.S) = struct
@@ -68,4 +69,17 @@ module Make(C:Config) (A:Arch_gen.S) = struct
   module C = Cycle.Make(Conf)(E)
 (* Big constant *)
   let kbig = 128
+
+(* Postlude *)
+
+  let mk_postlude emit_store_reg st p init cs =
+    if A.get_noks st > 0  then
+      let ok,st = A.ok_reg st in
+      let ok_loc = Code.as_data (Code.myok_proc p) in
+      let init,cs_store,st = emit_store_reg st p init ok_loc ok in
+      let csok = A.Label (Label.last p,A.Nop)::cs_store in
+(* Explicit initialisation implies int type *)
+      (A.Loc ok_loc,Some (A.S "0"))::init,cs@csok,st
+    else
+      init,cs,st
 end

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -539,7 +539,7 @@ let max_set = IntSet.max_elt
           i,code@c,F.add_final_loc p r (Code.add_capability x v) f,st
       | Data x,Pte ->
           do_add_local_check_pte avoid_ptes st p i code f lst x
-      | Code _,_ -> i,code,f,st            
+      | Code _,_ -> i,code,f,st
     else i,code,f,st
 
 (******************************************)
@@ -554,14 +554,19 @@ let max_set = IntSet.max_elt
     in
     do_rec lab []
 
-  let gather_final_oks p lab =
+  let gather_final_oks p st lab =
+    let npairs = A.get_noks st in
+    let k =
+      if npairs > 0 then
+        [A.Loc (as_data (Code.myok_proc p)),IntSet.singleton npairs]
+      else [] in
     let oks = list_of_init_ok_locs p lab in
     let rec do_rec oks k =
       match oks with
       | [] -> k
       | ok::oks -> let k' = (ok,IntSet.singleton 1)::k
       in do_rec oks k'
-    in do_rec oks []
+    in do_rec oks k
 
   let do_memtag = O.variant Variant_gen.MemTag
   let do_morello = O.variant Variant_gen.Morello
@@ -599,7 +604,7 @@ let max_set = IntSet.max_elt
                 | Avoid|Accept|Enforce|Three|Four|Infinity ->
                     add_co_local_check_pte no_local_ptes n st p i c f in
           let i,c,st = Comp.postlude st p i c in
-          let foks = gather_final_oks p (A.current_label st) in
+          let foks = gather_final_oks p st (A.current_label st) in
           let i,cs,(ms,fs),ios = do_rec (p+1) i ns in
           let io = U.io_of_thread n in
           i,c::cs,(C.union_map m ms,F.add_int_sets (f@fs) foks),io::ios in

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -545,28 +545,12 @@ let max_set = IntSet.max_elt
 (******************************************)
 (* Compile cycle, ie generate test proper *)
 (******************************************)
-  let list_of_init_ok_locs p lab =
-    let rec do_rec i k =
-      match i with
-      | 0 -> k
-      | n -> let k' = (A.Loc (as_data (Code.myok p (n-1))))::k
-      in do_rec (i-1) k'
-    in
-    do_rec lab []
 
-  let gather_final_oks p st lab =
+  let gather_final_oks p st =
     let npairs = A.get_noks st in
-    let k =
-      if npairs > 0 then
-        [A.Loc (as_data (Code.myok_proc p)),IntSet.singleton npairs]
-      else [] in
-    let oks = list_of_init_ok_locs p lab in
-    let rec do_rec oks k =
-      match oks with
-      | [] -> k
-      | ok::oks -> let k' = (ok,IntSet.singleton 1)::k
-      in do_rec oks k'
-    in do_rec oks k
+    if npairs > 0 then
+      [A.Loc (as_data (Code.myok_proc p)),IntSet.singleton npairs]
+    else []
 
   let do_memtag = O.variant Variant_gen.MemTag
   let do_morello = O.variant Variant_gen.Morello
@@ -604,7 +588,7 @@ let max_set = IntSet.max_elt
                 | Avoid|Accept|Enforce|Three|Four|Infinity ->
                     add_co_local_check_pte no_local_ptes n st p i c f in
           let i,c,st = Comp.postlude st p i c in
-          let foks = gather_final_oks p st (A.current_label st) in
+          let foks = gather_final_oks p st in
           let i,cs,(ms,fs),ios = do_rec (p+1) i ns in
           let io = U.io_of_thread n in
           i,c::cs,(C.union_map m ms,F.add_int_sets (f@fs) foks),io::ios in

--- a/gen/typBase.ml
+++ b/gen/typBase.ml
@@ -60,6 +60,26 @@ let pp = function
 | Pteval -> "pteval_t"
 
 
+let sign_equal s1 s2 = match s1,s2 with
+| (Unsigned,Unsigned)
+| (Signed,Signed)
+  -> true
+| (Unsigned,Signed)
+| (Signed,Unsigned)
+  -> false
+
+let equal t1 t2 = match t1,t2 with
+| (Int,Int)
+| (Pteval,Pteval)
+  -> true
+| (Std (s1,sz1),Std (s2,sz2))
+  -> sign_equal s1 s2 && MachSize.equal sz1 sz2
+| ((Int|Pteval),Std _)
+| (Std _,(Int|Pteval))
+| (Int,Pteval)
+| (Pteval,Int)
+  -> false
+
 let default = Int
 let is_default = function
   | Int -> true

--- a/gen/typBase.mli
+++ b/gen/typBase.mli
@@ -25,6 +25,8 @@ val parse : string -> t option
 
 val pp : t -> string
 
+val equal : t -> t -> bool
+
 val default : t
 val is_default : t -> bool
 

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -31,9 +31,8 @@ let next_label s =
   incr lab_count ;
   sprintf "%s%02i" s x
 
-let fail p i = sprintf "Fail%i%i" p i
-and exit p i = sprintf "Exit%i%i" p i
-and last p = sprintf "End%i" p
+let last p = sprintf "End%i" p
+
 type next = Any | Next | To of t
 
 module Set = StringSet

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -33,7 +33,7 @@ let next_label s =
 
 let fail p i = sprintf "Fail%i%i" p i
 and exit p i = sprintf "Exit%i%i" p i
-
+and last p = sprintf "End%i" p
 type next = Any | Next | To of t
 
 module Set = StringSet

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -25,6 +25,7 @@ val next_label : string -> t
 
 val fail : int -> int -> t
 val exit : int -> int -> t
+val last : int -> t
 
 type next = Any | Next | To of t
 

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -23,8 +23,6 @@ val compare : t -> t -> int
 val reset : unit -> unit
 val next_label : string -> t
 
-val fail : int -> int -> t
-val exit : int -> int -> t
 val last : int -> t
 
 type next = Any | Next | To of t

--- a/lib/machSize.ml
+++ b/lib/machSize.ml
@@ -159,6 +159,8 @@ let compare sz1 sz2 = match sz1,sz2 with
 | (S128,Quad)
     -> 1
 
+let equal sz1 sz2 = compare sz1 sz2 = 0
+
 let less_than_or_equal sz1 sz2 = compare sz1 sz2 <= 0
 
 module Set =

--- a/lib/machSize.mli
+++ b/lib/machSize.mli
@@ -33,6 +33,7 @@ val get_off : sz -> sz -> int list
 val get_off_reduced : sz -> sz -> int list
 
 val compare : sz -> sz -> int
+val equal : sz -> sz -> bool
 
 (* Smaller of two *)
 val less_than_or_equal : sz -> sz -> bool

--- a/lib/myMap.ml
+++ b/lib/myMap.ml
@@ -28,9 +28,13 @@ module type S = sig
 (* find with a default value *)
   val safe_find : 'a -> key -> 'a t -> 'a
 
+(* union from stdlib *)
+   val union_std : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
 (* map union *)
   val union : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
   val unions : ('a -> 'a -> 'a) -> 'a t list -> 'a t
+
 
 (* filter bindings according to ket predicate *)
   val filter : (key -> bool) -> 'a t -> 'a t
@@ -59,6 +63,8 @@ module Make(O:Set.OrderedType) : S with type key = O.t =
         m
 
     let safe_find d k m = try find k m with Not_found -> d
+
+    let union_std = union
 
     let union u m1 m2 =
       fold


### PR DESCRIPTION
When type is explicit (option `-type <t>`), some locations were declared more than once, which herd and litmus do not accept. The fix is not adding type to variables that are initialised explicitly.
