### PR TITLE
[gen] Fix init

### DIFF
--- a/gen/archExtra_gen.ml
+++ b/gen/archExtra_gen.ml
@@ -73,6 +73,10 @@ module type S = sig
   val ok_reg : st -> arch_reg * st
   val next_ok : st -> st
   val get_noks : st -> int
+
+  val add_type : location -> TypBase.t -> st -> st
+  val get_env : st -> TypBase.t LocMap.t
+
 end
 
 module Make(I:I) : S
@@ -171,14 +175,15 @@ with type arch_reg = I.arch_reg and type special = I.special
       { regs : arch_reg list ;
         map  : arch_reg StringMap.t ;
         specials : I.special list ;
-        noks : int ; }
-
+        noks : int ;
+        env : TypBase.t LocMap.t ; }
 
   let st0 =
     { regs = I.free_registers;
       map = StringMap.empty;
       specials = I.specials;
-      noks = 0; }
+      noks = 0;
+      env = LocMap.empty; }
 
   let alloc_reg st = match st.regs with
     | [] -> Warn.fatal "No more registers"
@@ -210,4 +215,8 @@ with type arch_reg = I.arch_reg and type special = I.special
   let ok_reg st = alloc_trashed_reg "ok" st
   let next_ok st = { st with noks = st.noks+1; }
   let get_noks st = st.noks
+
+  let add_type loc t st = { st with env = LocMap.add loc t st.env; }
+  let get_env st = st.env
+
 end

--- a/gen/compileCommon.ml
+++ b/gen/compileCommon.ml
@@ -69,17 +69,19 @@ module Make(C:Config) (A:Arch_gen.S) = struct
   module C = Cycle.Make(Conf)(E)
 (* Big constant *)
   let kbig = 128
-
 (* Postlude *)
 
   let mk_postlude emit_store_reg st p init cs =
     if A.get_noks st > 0  then
       let ok,st = A.ok_reg st in
+(* Add explict `int` type for `ok<n>` variables *)
       let ok_loc = Code.as_data (Code.myok_proc p) in
+      let st = A.add_type (A.Loc ok_loc) TypBase.Int st in
       let init,cs_store,st = emit_store_reg st p init ok_loc ok in
       let csok = A.Label (Label.last p,A.Nop)::cs_store in
-(* Explicit initialisation implies int type *)
+(* Add explict initialvalue of zero for `ok<n>` variables *)
       (A.Loc ok_loc,Some (A.S "0"))::init,cs@csok,st
     else
       init,cs,st
+
 end

--- a/gen/typBase.ml
+++ b/gen/typBase.ml
@@ -60,6 +60,26 @@ let pp = function
 | Pteval -> "pteval_t"
 
 
+let sign_equal s1 s2 = match s1,s2 with
+| (Unsigned,Unsigned)
+| (Signed,Signed)
+  -> true
+| (Unsigned,Signed)
+| (Signed,Unsigned)
+  -> false
+
+let equal t1 t2 = match t1,t2 with
+| (Int,Int)
+| (Pteval,Pteval)
+  -> true
+| (Std (s1,sz1),Std (s2,sz2))
+  -> sign_equal s1 s2 && MachSize.equal sz1 sz2
+| ((Int|Pteval),Std _)
+| (Std _,(Int|Pteval))
+| (Int,Pteval)
+| (Pteval,Int)
+  -> false
+
 let default = Int
 let is_default = function
   | Int -> true

--- a/gen/typBase.mli
+++ b/gen/typBase.mli
@@ -25,6 +25,8 @@ val parse : string -> t option
 
 val pp : t -> string
 
+val equal : t -> t -> bool
+
 val default : t
 val is_default : t -> bool
 

--- a/lib/machSize.ml
+++ b/lib/machSize.ml
@@ -159,6 +159,8 @@ let compare sz1 sz2 = match sz1,sz2 with
 | (S128,Quad)
     -> 1
 
+let equal sz1 sz2 = compare sz1 sz2 = 0
+
 let less_than_or_equal sz1 sz2 = compare sz1 sz2 <= 0
 
 module Set =

--- a/lib/machSize.mli
+++ b/lib/machSize.mli
@@ -33,6 +33,7 @@ val get_off : sz -> sz -> int list
 val get_off_reduced : sz -> sz -> int list
 
 val compare : sz -> sz -> int
+val equal : sz -> sz -> bool
 
 (* Smaller of two *)
 val less_than_or_equal : sz -> sz -> bool

--- a/lib/myMap.ml
+++ b/lib/myMap.ml
@@ -28,9 +28,13 @@ module type S = sig
 (* find with a default value *)
   val safe_find : 'a -> key -> 'a t -> 'a
 
+(* union from stdlib *)
+   val union_std : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
 (* map union *)
   val union : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
   val unions : ('a -> 'a -> 'a) -> 'a t list -> 'a t
+
 
 (* filter bindings according to ket predicate *)
   val filter : (key -> bool) -> 'a t -> 'a t
@@ -59,6 +63,8 @@ module Make(O:Set.OrderedType) : S with type key = O.t =
         m
 
     let safe_find d k m = try find k m with Not_found -> d
+
+    let union_std = union
 
     let union u m1 m2 =
       fold


### PR DESCRIPTION
This PR solves an incompatibility in generated tests  between `ok<n>` variables (counting successful events) and explicit types for tests (option`-type <t>`, useful for mixed-size tests). 

Namely, variables `ok<n>` are of type `int`, regardless of test type.