### PR TITLE
[herd] Fix machsize

### DIFF
--- a/herd/tests/instructions/AArch64.mixed/M001.litmus
+++ b/herd/tests/instructions/AArch64.mixed/M001.litmus
@@ -1,0 +1,11 @@
+AArch64 M001
+(* Test elementary size computation (also scanning initialisations) *)
+{
+uint8_t t[4]={ 0,0,0,0 };
+0:X2=t;
+}
+  P0          ;
+SUB W0,WZR,#1 ;
+STR W0,[X2]   ;
+locations [t;]
+

--- a/herd/tests/instructions/AArch64.mixed/M001.litmus.expected
+++ b/herd/tests/instructions/AArch64.mixed/M001.litmus.expected
@@ -1,0 +1,10 @@
+Test M001 Required
+States 1
+t={0xff,0xff,0xff,0xff};
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation M001 Always 1 0
+Hash=ef9722c1da3e04d6c03dc83ceed7adc2
+

--- a/lib/testType.ml
+++ b/lib/testType.ml
@@ -24,6 +24,8 @@ type t =
   | TyArray of string * int
   | Atomic of string
 
+let default = "int"
+
 let pp = function
   | TyDef -> "TyDef"
   | TyDefPointer -> "TyDefPointer"

--- a/lib/testType.mli
+++ b/lib/testType.mli
@@ -22,6 +22,9 @@ type t =
   | TyArray of string * int
   | Atomic of string
 
+(* Default base type (i.e. int) *)
+val default : string
+
 val pp : t -> string
 
 val is_array : t -> bool


### PR DESCRIPTION
In mixed size mode with default option `-machsize auto`, initialisations have to be scanned to compute elementary memory size access.
