### PR TITLE
[litmus] Fix logical proposition compilation to C.

### DIFF
--- a/herd/tests/instructions/AArch64/L014.litmus
+++ b/herd/tests/instructions/AArch64/L014.litmus
@@ -1,0 +1,20 @@
+AArch64 L014
+{
+x=0;
+0:X2=x;
+int64_t 0:X4;
+int32_t u[2]={-1,-1};
+uint8_t v[2]={-1,-1};
+0:X6=v;
+}
+
+  P0           ;
+MOV W0,#1      ;
+SUB W0,WZR,W0  ;
+STR W0,[X2]    ;
+SXTW X4,W0     ;
+MOV W3,#2      ;
+SUB W3,WZR,W3  ;
+STRB W3,[X6]   ;
+locations [x;0:X0;0:X4;u;v[0]]
+forall (0:X4=-1 /\ x=-1 /\ u[0]=4294967295 /\ v[1]=-1)

--- a/herd/tests/instructions/AArch64/L014.litmus.expected
+++ b/herd/tests/instructions/AArch64/L014.litmus.expected
@@ -1,0 +1,10 @@
+Test L014 Required
+States 1
+0:X0=-1; 0:X4=-1; u={-1,-1}; x=-1; u[0]=-1; v[0]=254; v[1]=255;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X4=-1 /\ x=-1 /\ u[0]=4294967295 /\ v[1]=-1)
+Observation L014 Always 1 0
+Hash=721604cf560cb9a64aa4869cc869b054
+

--- a/lib/CType.mli
+++ b/lib/CType.mli
@@ -55,3 +55,11 @@ val type_for_align : int -> t
 
 (* Type of array elements, fails if argument is not an array type *)
 val element_type : t -> t
+
+(* Is type integer signed? *)
+val signed : t -> bool
+
+(* Best effort to find size of integer types.
+   Return None when type is not an integer type or
+   when size is unclear. *)
+val base_size : t -> MachSize.sz option

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -100,7 +100,7 @@ module Make
         | CType.Base "atomic_t" ->  CType.Base "int"
         | t -> t in
         CType.dump (CType.strip_atomic t),CType.is_ptr t in
-      DC.fundef find_type cond
+      DC.fundef (U.cast_constant env) find_type cond
 
     let dump_cond_fun env test = do_dump_cond_fun env test.T.condition
 
@@ -113,7 +113,7 @@ module Make
         let find_type loc =
           let t = U.find_rloc_type loc env in
           CType.dump (CType.strip_atomic t),CType.is_ptr t in
-        DC.fundef_prop "filter_cond" find_type f
+        DC.fundef_prop "filter_cond" (U.cast_constant env) find_type f
 
 
     let is_srcu_struct t = match t with

--- a/litmus/compCond.mli
+++ b/litmus/compCond.mli
@@ -16,26 +16,27 @@
 
 module Make: functor (O:Indent.S) -> functor (I:CompCondUtils.I) ->
   sig
+    val fundef_prop :
+      string ->
+      (I.Loc.t -> I.C.V.v -> I.C.V.v) ->
+      (I.Loc.t -> string * bool) -> (* For types *)
+      I.C.prop -> unit
 
-      val fundef_prop :
-          string ->
-            (I.Loc.t -> string * bool) -> (* For types *)
-              I.C.prop -> unit
+    val fundef :
+      (I.Loc.t -> I.C.V.v -> I.C.V.v) ->
+      (I.Loc.t -> string * bool) -> (* For types *)
+      I.C.cond -> unit
 
-      val fundef :
-          (I.Loc.t -> string * bool) -> (* For types *)
-            I.C.cond -> unit
+    val fundef_onlog_prop :
+      string -> (I.Loc.t -> I.C.V.v -> I.C.V.v) -> I.C.prop -> unit
 
-      val fundef_onlog_prop : string -> I.C.prop -> unit
-
-      val fundef_onlog : I.C.cond -> unit
+    val fundef_onlog : (I.Loc.t -> I.C.V.v -> I.C.V.v) -> I.C.cond -> unit
 
     val funcall_prop :
-        string -> I.C.prop ->
-          (I.Loc.t -> string) -> (string -> string) -> string
+      string -> I.C.prop ->
+      (I.Loc.t -> string) -> (string -> string) -> string
 
     val funcall :
-        I.C.cond ->
-          (I.Loc.t -> string) -> (string -> string) -> string
-
+      I.C.cond ->
+      (I.Loc.t -> string) -> (string -> string) -> string
   end

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -804,12 +804,12 @@ module Make
         begin match test.T.filter with
         | None -> ()
         | Some f ->
-            DC.fundef_onlog_prop "filter_cond" f ;
+            DC.fundef_onlog_prop "filter_cond" (U.cast_constant env) f ;
             O.o "" ;
             ()
         end ;
         let cond = test.T.condition in
-        DC.fundef_onlog cond ;
+        DC.fundef_onlog (U.cast_constant env) cond ;
         ()
 
       let dump_cond_def env test =

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -887,15 +887,17 @@ module Make
           | u -> u in
         CType.dump u,CType.is_ptr t
 
+
       let do_dump_cond_fun env cond =
-        DC.fundef (find_rloc_type env) cond
+        DC.fundef (U.cast_constant env) (find_rloc_type env) cond
 
       let dump_cond_fun env test = do_dump_cond_fun env test.T.condition
 
       let dump_filter env test = match test.T.filter with
       | None -> ()
       | Some f ->
-          DC.fundef_prop "filter_cond" (find_rloc_type env) f
+          DC.fundef_prop
+            "filter_cond" (U.cast_constant env) (find_rloc_type env) f
 
       let dump_cond_fun_call test dump_loc dump_val =
         DC.funcall test.T.condition dump_loc dump_val


### PR DESCRIPTION
Due to "integer promotion" it is safer to convert constants so that they match the type (and sign) of scrutinized location.