### PR TITLE
[internal] Sexp module can parse Dune's line comments

### DIFF
--- a/internal/lib/tests/sexp_test.ml
+++ b/internal/lib/tests/sexp_test.ml
@@ -17,9 +17,11 @@
 let tests = [
   "Sexp.of_dune_file", (fun () ->
     let dune o =
-      Printf.fprintf o "(tests" ;
-      Printf.fprintf o "  (names a_test b_test)" ;
-      Printf.fprintf o "  (libraries lib))" ;
+      Printf.fprintf o "; comment\n" ;
+      Printf.fprintf o "(tests;comment\n" ;
+      Printf.fprintf o "  (names a_test b_test)\n" ;
+      Printf.fprintf o "  (libraries lib))\n" ;
+      Printf.fprintf o "; trailing comment" ;
       close_out o
     in
 


### PR DESCRIPTION
This PR allows the `binaries_of_dune` script to parse `dune` files that use line comments.

From [sexplib](https://github.com/janestreet/sexplib#comments), "line comments" start with `;` and end with a newline.