### PR TITLE
[gen] Generate  neon-test

### DIFF
--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -55,6 +55,50 @@ module Mixed =
 
 (* AArch64 has more atoms that others *)
 let bellatom = false
+module SIMD = struct
+
+  type atom = N1|N2|N3|N4
+
+  let fold_neon f r = f N1 (f N2 (f N3 (f N4 r)))
+
+  let nregs = function
+    | N1 -> 1
+    | N2 -> 2
+    | N3 -> 3
+    | N4 -> 4
+
+  let pp n = Printf.sprintf "N%i" (nregs n)
+
+  let initial sz =
+    let sz = if sz <= 0 then 1 else sz in
+    Array.make sz 0
+
+  let step n start v =
+    let start = start+1 in
+    let sz = nregs n in
+    let v = Array.copy v in
+    for k = 0 to sz-1 do
+      for i=0 to 3 do
+       let j = k+i*sz in
+       v.(j) <- start+k
+      done
+    done ;
+    v
+
+
+  let read n v =
+    let sz = nregs n in
+    let access r k = sz*k + r in
+    let rec reg r k =
+      if k >= 4 then []
+      else v.(access r k)::reg r (k+1) in
+    let rec regs r =
+      if r >= sz then []
+      else reg r 0::regs (r+1) in
+    regs 0
+
+end
+
 type atom_rw =  PP | PL | AP | AL
 type capa = Capability
 type capa_opt = capa option
@@ -63,7 +107,7 @@ type atom_pte =
   | Read|ReadAcq|ReadAcqPc
   | Set of w_pte
   | SetRel of w_pte
-type neon_sizes = N1 | N2 | N3 | N4
+type neon_sizes = SIMD.atom
 type atom_acc =
   | Plain of capa_opt | Acq of capa_opt | AcqPc of capa_opt | Rel of capa_opt
   | Atomic of atom_rw | Tag | CapaTag | CapaSeal | Pte of atom_pte | Neon of neon_sizes
@@ -109,11 +153,6 @@ let applies_atom (a,_) d = match a,d with
      | ReadAcqPc -> "Q"
      | Set set -> pp_w_pte set
      | SetRel set -> pp_w_pte set ^"L"
-   let pp_neon_size = function
-     | N1 -> "1"
-     | N2 -> "2"
-     | N3 -> "3"
-     | N4 -> "4"
 
    let pp_atom_acc = function
      | Atomic rw -> sprintf "X%s" (pp_atom_rw rw)
@@ -125,7 +164,7 @@ let applies_atom (a,_) d = match a,d with
      | CapaTag -> "Ct"
      | CapaSeal -> "Cs"
      | Pte p -> sprintf "Pte%s" (pp_atom_pte p)
-     | Neon n -> sprintf "N%s" (pp_neon_size n)
+     | Neon n -> SIMD.pp n
 
    let pp_atom (a,m) = match a with
    | Plain o ->
@@ -170,7 +209,6 @@ let applies_atom (a,_) d = match a,d with
      if do_morello then fun f r -> f CapaSeal (f CapaTag r)
      else fun _f r -> r
 
-   let fold_neon f r = f N1 (f N2 (f N3 (f N4 r)))
 
    let fold_acc_opt o f r =
      let r = f (Acq o) r in
@@ -182,7 +220,7 @@ let applies_atom (a,_) d = match a,d with
      let r = if mixed then r else fold_pte (fun p r -> f (Pte p) r) r in
      let r = fold_morello f r in
      let r = fold_tag f r in
-     let r = fold_neon (fun n -> f (Neon n)) r in
+     let r = SIMD.fold_neon (fun n -> f (Neon n)) r in
      let r = fold_acc_opt None f r in
      let r =
        if do_morello then
@@ -260,12 +298,20 @@ let applies_atom (a,_) d = match a,d with
    | _,_ ->
        if equal_atom a1 a2 then Some a1 else None
 
+   let neon_as_integers =
+     let open SIMD in
+     function
+     | N1 -> 4
+     | N2 -> 8
+     | N3 -> 12
+     | N4 -> 16
+
    let atom_to_bank = function
    | Tag,None -> Code.Tag
    | Pte _,None -> Code.Pte
    | CapaTag,None -> Code.CapaTag
    | CapaSeal,None -> Code.CapaSeal
-   | Neon _,None -> Code.VecReg
+   | Neon n,None -> Code.VecReg n
    | (Tag|CapaTag|CapaSeal|Pte _|Neon _),Some _ -> assert false
    | (Plain _|Acq _|AcqPc _|Rel _|Atomic (PP|PL|AP|AL)),_
       -> Code.Ord
@@ -325,11 +371,6 @@ let overwrite_value v ao w = match ao with
 
 
 (* Wide accesses *)
-   let neon_as_integers = function
-     | N1 -> 4
-     | N2 -> 8
-     | N3 -> 12
-     | N4 -> 16
 
    let as_integers a =
      Misc.seq_opt

--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -274,6 +274,7 @@ let applies_atom (a,_) d = match a,d with
 (**************)
 (* Mixed size *)
 (**************)
+
    let tr_value ao v = match ao with
    | None| Some (_,None) -> v
    | Some (_,Some (sz,_)) -> Mixed.tr_value sz v
@@ -303,6 +304,7 @@ let overwrite_value v ao w = match ao with
       ValsMixed.extract_value v sz o
   | Some (Pte _,Some _) -> assert false
 
+(* Page table entries *)
   let do_setpteval a f p =
     let open PTEVal in
     let f = match f with
@@ -321,11 +323,27 @@ let overwrite_value v ao w = match ao with
      | Pte f,None -> do_setpteval a f p
      | _ -> Warn.user_error "Atom %s is not a pteval write" (pp_atom a)
 
+
+(* Wide accesses *)
+   let neon_as_integers = function
+     | N1 -> 4
+     | N2 -> 8
+     | N3 -> 12
+     | N4 -> 16
+
+   let as_integers a =
+     Misc.seq_opt
+       (function
+        | (Neon n,_) -> Some (neon_as_integers n)
+        | _ -> None)
+       a
+
 (* End of atoms *)
 
 (**********)
 (* Fences *)
 (**********)
+
 type strength = Strong | Weak
 let fold_strength f r = f Strong (f Weak r)
 

--- a/gen/ARMArch_gen.ml
+++ b/gen/ARMArch_gen.ml
@@ -87,6 +87,7 @@ let pp_dp = function
 (*******)
 include OneRMW
 include NoEdge
+
   include
     ArchExtra_gen.Make
     (struct

--- a/gen/BellArch_gen.ml
+++ b/gen/BellArch_gen.ml
@@ -100,6 +100,9 @@ let pp_annot a = match a with
 
 (* No atoms yet *)
 let bellatom = true
+
+module SIMD = NoSIMD
+
 type atom = string list
 
 let default_atom = [] (* Wrong, extract from bell file? *)

--- a/gen/BellArch_gen.ml
+++ b/gen/BellArch_gen.ml
@@ -202,6 +202,8 @@ include NoMixed
 
 let set_pteval _ p _ = p
 
+include NoWide
+
 (* End of atoms *)
 
 (**********)

--- a/gen/CArch_gen.ml
+++ b/gen/CArch_gen.ml
@@ -23,6 +23,8 @@ open Code
 open MemOrder
 let bellatom = false
 
+module SIMD = NoSIMD
+
 type atom = MemOrder.t
 
 let default_atom = SC

--- a/gen/CArch_gen.ml
+++ b/gen/CArch_gen.ml
@@ -58,8 +58,10 @@ let merge_atoms a1 a2 = if a1=a2 then Some a1 else None
 let atom_to_bank _ = Code.Ord
 
 include NoMixed
+include NoWide
 
 let set_pteval _ p _ = p
+
 
 (* Fences, to be completed *)
 

--- a/gen/CCompile_gen.ml
+++ b/gen/CCompile_gen.ml
@@ -581,7 +581,21 @@ module Make(O:Config) : Builder.S
                 check_rec env (p+List.length c) xvs in
               c@cs,f@fs
 
-      let check_writes p cos = check_rec p cos
+      let check_writes env p cos =
+        let cos =
+          List.map
+            (fun (loc,vss) ->
+              let vss =
+                List.map
+                  (List.map
+                     (fun (v,obs) ->
+                       if Array.length v > 1 then
+                         Warn.fatal "No wide access in C" ;
+                       v.(0),obs))
+                  vss in
+              loc,vss)
+            cos in
+        check_rec env p cos
 
 (* Local check of coherence *)
 

--- a/gen/CCompile_gen.ml
+++ b/gen/CCompile_gen.ml
@@ -648,7 +648,7 @@ module Make(O:Config) : Builder.S
                    ((Load (of_reg p just_read),Eq,Const expected_v),
                     A.seqs [obs;is],
                     None)),
-              F.add_final p o n fs,
+              F.add_final (fun _ -> []) p o n fs,
               st
 
           | _ ->
@@ -658,7 +658,7 @@ module Make(O:Config) : Builder.S
               let obs,fs,st = observe_local st p fs n in
               A.seqs [i;obs;add_fence n is],
               (if not (U.do_poll n) then
-                F.add_final p o n fs
+                F.add_final (fun _ -> []) p o n fs
               else fs),
               st
           end
@@ -718,7 +718,7 @@ module Make(O:Config) : Builder.S
           let is,fs,st = do_compile_proc_check loc_writes st p ns in
           let obs,fs,st = observe_local_check st p fs n in
           fi (obs is),
-          (if true then F.add_final p o n fs
+          (if true then F.add_final (fun _ -> []) p o n fs
           else fs),
           st
 

--- a/gen/RISCVArch_gen.ml
+++ b/gen/RISCVArch_gen.ml
@@ -48,6 +48,8 @@ module Make
 
    let bellatom = false
 
+   module SIMD = NoSIMD
+
    type atom = MO of mo | Atomic of mo * mo | Mixed of MachMixed.t
 
    let default_atom = Atomic (Rlx,Rlx)

--- a/gen/RISCVArch_gen.ml
+++ b/gen/RISCVArch_gen.ml
@@ -38,6 +38,8 @@ module Make
          let fullmixed = C.moreedges
        end)
 
+   include NoWide
+
    let set_pteval _ p _ = p
 
 (*********)

--- a/gen/X86Arch_gen.ml
+++ b/gen/X86Arch_gen.ml
@@ -22,6 +22,8 @@ module ScopeGen = ScopeGen.NoGen
 
 let bellatom = false
 
+module SIMD = NoSIMD
+
 type atom = Atomic
 
 let default_atom = Atomic

--- a/gen/X86Arch_gen.ml
+++ b/gen/X86Arch_gen.ml
@@ -52,6 +52,7 @@ let varatom_dir _d f = f None
 let atom_to_bank _ = Code.Ord
 
 include NoMixed
+include NoWide
 
 let set_pteval _ p _ = p
 

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -135,6 +135,8 @@ module Make
       | Some ((Plain|Atomic|NonTemporal),Some (sz, o)) ->
           ValsMixed.extract_value v sz o
 
+      include NoWide
+
       let set_pteval _ p _ = p
 
             (**********)

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -40,6 +40,8 @@ module Make
 
       let bellatom = false
 
+      module SIMD = NoSIMD
+
       type atom_acc = Plain | Atomic | NonTemporal
 
       type atom = atom_acc * MachMixed.t option

--- a/gen/XXXCompile_gen.mli
+++ b/gen/XXXCompile_gen.mli
@@ -26,7 +26,7 @@ module type S = sig
 
 (* Load for observation *)
   val emit_obs :
-       Code.bank -> A.st -> Code.proc -> A.init -> string ->
+       A.SIMD.atom Code.bank -> A.st -> Code.proc -> A.init -> string ->
         A.reg * A.init * A.pseudo list * A.st
 
   val emit_obs_not_zero :

--- a/gen/atom.mli
+++ b/gen/atom.mli
@@ -35,4 +35,6 @@ module type S = sig
   val tr_value : atom option -> Code.v -> Code.v
   val overwrite_value : Code. v -> atom option -> Code.v -> Code.v
   val extract_value : Code. v -> atom option -> Code.v
+(* Typing of wide accesses as arrays of integers *)
+  val as_integers : atom option -> int option
 end

--- a/gen/atom.mli
+++ b/gen/atom.mli
@@ -14,8 +14,22 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
+module type SIMD = sig
+    type atom
+    val nregs : atom -> int
+    val pp : atom -> string
+
+    val initial : int -> int array
+    val step : atom -> int -> int array -> int array
+    val read : atom -> int array -> int list list
+end
+
 module type S = sig
   val bellatom : bool (* true if bell style atoms *)
+
+(* SIMD writes and reads *)
+  module SIMD : SIMD
+
   type atom
   val default_atom : atom
   val applies_atom : atom -> Code.dir -> bool
@@ -30,11 +44,12 @@ module type S = sig
   val varatom_dir : Code.dir -> (atom option -> 'a -> 'a) -> 'a -> 'a
   val merge_atoms : atom -> atom -> atom option
 (* Memory bank *)
-  val atom_to_bank : atom -> Code.bank
+  val atom_to_bank : atom -> SIMD.atom Code.bank
 (* Value computation, for mixed size *)
   val tr_value : atom option -> Code.v -> Code.v
   val overwrite_value : Code. v -> atom option -> Code.v -> Code.v
   val extract_value : Code. v -> atom option -> Code.v
 (* Typing of wide accesses as arrays of integers *)
   val as_integers : atom option -> int option
+
 end

--- a/gen/code.ml
+++ b/gen/code.ml
@@ -126,7 +126,7 @@ type info = (string * string) list
 let plain = "Na"
 
 (* Memory Space *)
-type bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg
+type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a
 
 let pp_bank = function
   | Ord -> "Ord"
@@ -134,7 +134,7 @@ let pp_bank = function
   | CapaTag -> "CapaTag"
   | CapaSeal -> "CapaSeal"
   | Pte -> "Pte"
-  | VecReg -> "VecReg"
+  | VecReg _ -> "VecReg"
 
 let tag_of_int  = function
   | 0 -> "green"
@@ -151,4 +151,8 @@ let add_tag s t = Printf.sprintf "%s:%s" s (tag_of_int t)
 
 let add_capability s t = Printf.sprintf "0xffffc0000:%s:%i" s (if t = 0 then 1 else 0)
 
-let add_vector v = Printf.sprintf "{%i,%i,%i,%i}" v.(0) v.(1) v.(2) v.(3)
+let add_vector hexa v =
+  let open Printf in
+  let pp = if hexa then sprintf "0x%x" else sprintf "%i" in
+  sprintf "{%s}"
+    (String.concat "," (List.map pp  v))

--- a/gen/code.mli
+++ b/gen/code.mli
@@ -83,12 +83,12 @@ type info = (string * string) list
 val plain : string
 
 (* Memory bank (for MTE, KVM)  *)
-type bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg
+type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a
 
-val pp_bank : bank -> string
+val pp_bank : 'a bank -> string
 
 val add_tag : string -> v -> string
 
 val add_capability : string -> v -> string
 
-val add_vector : int array -> string
+val add_vector : bool -> int list -> string

--- a/gen/compileCommon.ml
+++ b/gen/compileCommon.ml
@@ -32,6 +32,7 @@ module type S = sig
   module E : Edge.S
   with type fence = A.fence
   and type dp = A.dp
+  and module SIMD = A.SIMD
   and type atom = A.atom
   and type rmw = A.rmw
 
@@ -42,7 +43,11 @@ module type S = sig
   and type dp = A.dp
   and type edge = E.edge
 
-  module C : Cycle.S with type fence = A.fence and type edge=E.edge and type atom = A.atom
+  module C : Cycle.S
+   with type fence = A.fence
+   and type edge=E.edge
+   and module SIMD = A.SIMD
+   and type atom = A.atom
 
 end
 

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -1111,7 +1111,7 @@ let rec group_rec x ns = function
     do_rec n
 
 
-  let do_get_writes bank n =
+  let do_get_writes pbank n =
     let rec do_rec m =
       let k =
         if m.next == n then []
@@ -1120,15 +1120,18 @@ let rec group_rec x ns = function
       let k =  match e.dir with
       | Some W ->
           if
-            E.is_node m.edge.E.edge ||
-            m.evt.bank <> bank
+            E.is_node m.edge.E.edge || not (pbank m.evt.bank)
           then k else (e.loc,m)::k
       | None| Some R | Some J -> k in
       k in
     do_rec n
 
-  let get_ord_writes = do_get_writes Code.Ord
-  let get_pte_writes = do_get_writes Code.Pte
+  let get_ord_writes =
+    do_get_writes
+      (function Code.Ord|Code.VecReg _ -> true | _ -> false)
+
+  let get_pte_writes =
+    do_get_writes (function Code.Pte -> true | _ -> false)
 
   let get_observers n =
     let e = n.evt in

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -20,19 +20,21 @@ open Code
 module type S = sig
   type fence
   type edge
+  module SIMD : Atom.SIMD
   type atom
+
 
   type event =
       { loc : loc ; ord : int; tag : int;
         ctag : int; cseal : int; dep : int;
-        vecreg: int array;
-        v   : v ;
+        v   : v ; (* Value read or written *)
+        vecreg: v list list; (* Alternative for SIMD *)
         dir : dir option ;
         proc : Code.proc ;
         atom : atom option ;
         rmw : bool ;
-        cell : v ;
-        bank : Code.bank ;
+        cell : v array ; (* Content of memory, after event *)
+        bank : SIMD.atom Code.bank ;
         idx : int ;
         pte : PTEVal.t ; }
 
@@ -69,6 +71,12 @@ module type S = sig
   val find_non_pseudo : node -> node
   val find_non_pseudo_prev : node -> node
 
+(* Generic fold *)
+  val fold : (node -> 'a -> 'a) -> node -> 'a -> 'a
+
+(* Extract wide accesses from cycle. Size as number of integers *)
+  val get_wide : node -> int StringMap.t
+
 (* Re-extract edges out of cycle *)
   val extract_edges : node -> edge list
 
@@ -84,21 +92,17 @@ module type S = sig
 (* split cycle amoungst processors *)
   val split_procs : node -> node list list
 
-
 (* Return coherence orders *)
   val coherence : node -> (string * (node * IntSet.t) list list) list
+
 (* Return last pteval in pte accesses coherence *)
   val last_ptes : node -> (string * PTEVal.t) list
+
 (* All locations *)
   val get_globals : node -> string list
+
 (* All (modified) code labels *)
   val get_labels : node -> string list
-
-(* Generic fold *)
-  val fold : (node -> 'a -> 'a) -> node -> 'a -> 'a
-
-(* Extract wide accesses from cycle. Size as number of integers *)
-  val get_wide : node -> int StringMap.t
 
 end
 
@@ -113,7 +117,10 @@ module type Config = sig
 end
 
 module Make (O:Config) (E:Edge.S) :
-    S with type fence = E.fence and type edge = E.edge and type atom = E.atom
+    S with type fence = E.fence
+       and type edge = E.edge
+       and module SIMD = E.SIMD
+       and type atom = E.atom
 = struct
   let dbg = false
   let do_memtag = O.variant Variant_gen.MemTag
@@ -123,19 +130,20 @@ module Make (O:Config) (E:Edge.S) :
 
   type fence = E.fence
   type edge = E.edge
+  module SIMD = E.SIMD
   type atom = E.atom
 
   type event =
       { loc : loc ; ord : int; tag : int;
         ctag : int; cseal : int; dep : int;
-        vecreg: int array;
         v   : v ;
+        vecreg: v list list ;
         dir : dir option ;
         proc : Code.proc ;
         atom : atom option ;
         rmw : bool ;
-        cell : v ; (* value of cell at node... *)
-        bank : Code.bank ;
+        cell : v array ; (* value of cell at node exit *)
+        bank : SIMD.atom Code.bank ;
         idx : int ;
         pte : PTEVal.t ; }
 
@@ -144,9 +152,9 @@ module Make (O:Config) (E:Edge.S) :
   let evt_null =
     { loc=Code.loc_none ; ord=0; tag=0;
       ctag=0; cseal=0; dep=0;
-      vecreg= [|0;0;0;0|];
+      vecreg= [];
       v=(-1) ; dir=None; proc=(-1); atom=None; rmw=false;
-      cell=(-1); bank=Code.Ord; idx=(-1);
+      cell=[||]; bank=Code.Ord; idx=(-1);
       pte=pte_default; }
 
   let make_wsi idx loc = { evt_null with dir=Some W ; loc=loc; idx=idx; v=0;}
@@ -186,15 +194,18 @@ module Make (O:Config) (E:Edge.S) :
     else fun _ -> ""
 
   let debug_neon =
-    if do_neon then fun e ->
-      sprintf " (vecreg={%i,%i,%i,%i})" e.vecreg.(0) e.vecreg.(1) e.vecreg.(2) e.vecreg.(3)
+    if do_neon then
+      let pp_one = Code.add_vector O.hexa in
+      fun e ->
+      sprintf " (vecreg={%s})"
+        (String.concat "," (List.map pp_one e.vecreg))
     else fun _ -> ""
 
   let debug_evt e =
     let pp_v =
       match e.bank with
       | Pte -> PTEVal.pp e.pte
-      | (Ord|Tag|CapaTag|CapaSeal|VecReg) ->
+      | (Ord|Tag|CapaTag|CapaSeal|VecReg _) ->
           if O.hexa then sprintf "0x%x" e.v
           else sprintf "%i" e.v in
     sprintf "%s%s %s %s%s%s%s"
@@ -346,6 +357,44 @@ let is_real_edge e =  non_pseudo e && non_insert e
 
 let find_real_edge_prev = find_edge_prev is_real_edge
 
+(* generic scan *)
+  let fold f m k =
+    let rec fold_rec n k =
+      let k = f n k
+      and nxt = n.next in
+      if nxt == m then k
+      else fold_rec nxt k in
+    fold_rec m k
+
+(* Get size (as integers) from annotations *)
+
+  let as_integers n = match n.evt.loc with
+      | Data loc ->
+         begin
+           match E.as_integers n.edge with
+           | Some sz -> Some (loc,sz)
+           | None -> None
+         end
+      | Code _ -> None
+
+  let get_wide_list ns =
+    List.fold_left
+      (fun k n ->
+        match as_integers n with
+        | Some (_,n) -> max n k
+        | None -> k)
+    0 ns
+
+  let get_wide m =
+    fold
+      (fun n k ->
+        match as_integers n with
+        | Some (loc,sz) ->
+           let sz0 = StringMap.safe_find 0 loc k in
+           StringMap.add loc (max sz0 sz) k
+        | None-> k)
+    m StringMap.empty
+
 (* Add events in nodes *)
 
 module Env = Map.Make(String)
@@ -379,23 +428,63 @@ let diff_loc e = not (same_loc e)
 let same_proc e = E.get_ie e = Int
 let diff_proc e = E.get_ie e = Ext
 
+
 (* Coherence definition *)
-module CoSt = MyMap.Make(struct type t = Code.bank let compare = compare end)
 
-let co_st_0  = CoSt.add Ord 0 (CoSt.add Tag 0 (CoSt.add CapaTag 0 (CoSt.add CapaSeal 0 (CoSt.add VecReg 0 CoSt.empty))))
-let co_st_1  = CoSt.add Ord 1 (CoSt.add Tag 1 (CoSt.add CapaTag 1 (CoSt.add CapaSeal 1 (CoSt.add VecReg 1 CoSt.empty))))
-let start_co _ = co_st_1
+module CoSt = struct
 
-let get_co st bank =
-  try CoSt.find bank st with Not_found -> assert false
+  module M =
+    MyMap.Make
+      (struct type t = E.SIMD.atom Code.bank let compare = compare end)
 
-let set_co st bank v = match bank with
-| Pte -> st
-| _  -> CoSt.add bank v st
+  type t = { map : int M.t; co_cell : int array; }
 
-let next_co st bank =
-  let v = get_co st bank in
-  CoSt.add bank (v+1) st
+  let (<<) f g = fun x -> f (g x)
+  and (<!) f x = f x
+
+  let create sz =
+    let map  =
+      M.add Tag 0 <<  M.add CapaTag 0 <<
+      M.add CapaSeal 0 << M.add Ord 0 <! M.empty
+    and co_cell = Array.make (if sz <= 0 then 1 else sz) 0 in
+    { map; co_cell;  }
+
+  let find_no_fail key map =
+    try M.find key map with Not_found -> assert false
+
+  let get_co st bank = find_no_fail bank st.map
+
+  let set_co st bank v =
+    let b = match bank with VecReg _ -> Ord | _ -> bank in
+    { st with map=M.add b v st.map; }
+
+  let get_cell st = st.co_cell
+
+  let set_cell st e = match e.bank with
+    | Ord ->
+       let old = st.co_cell.(0) in
+       let cell = E.overwrite_value old e.atom e.v in
+       let co_cell = Array.copy st.co_cell in
+       co_cell.(0) <- cell ;
+       {e with cell=co_cell;},{ st with co_cell; }
+    | _ -> e,st
+
+  let next_co st bank =
+   match bank with
+   | VecReg n ->
+      let v = find_no_fail Ord st.map in
+      { st with map=M.add Ord (v+E.SIMD.nregs n) st.map; }
+   | _ ->
+      let v = find_no_fail bank st.map in
+      { st with map=M.add bank (v+1) st.map; }
+
+  let step_simd st n =
+    let fst = find_no_fail Ord st.map in
+    let lst = fst+E.SIMD.nregs n in
+    { co_cell=E.SIMD.step n fst st.co_cell;
+      map=M.add Ord lst st.map;}
+
+end
 
 let pte_val_init loc = match loc with
 | Code.Data loc when do_kvm -> PTEVal.default loc
@@ -607,28 +696,25 @@ let set_same_loc st n0 =
 
   let tr_value e v = E.tr_value e.atom v
 
-  let set_cell n old =
-    let e = n.evt in
-    let e = { e with cell=E.overwrite_value old e.atom e.v} in
-    n.evt <- e
-
-  let rec do_set_write_val old next pte_val = function
+  let rec do_set_write_val st pte_val = function
     | [] -> ()
     | n::ns ->
         begin if Code.is_data n.evt.loc then
           begin if do_memtag then
-            let tag = get_co old Tag in
+            let tag = CoSt.get_co st Tag in
             n.evt <- { n.evt with tag=tag; }
           else if do_morello then
-            let ord = get_co old Ord in
-            let ctag = get_co old CapaTag in
-            let cseal = get_co old CapaSeal in
+            let ord = CoSt.get_co st Ord in
+            let ctag = CoSt.get_co st CapaTag in
+            let cseal = CoSt.get_co st CapaSeal in
             n.evt <- { n.evt with ord=ord; ctag=ctag; cseal=cseal; }
-          else if do_neon then
-            let ord = get_co old Ord in
-            let v = get_co old VecReg in
+(*
+          else if do_neon then (* set both fields, it cannot harm *)
+            let ord = get_co st Ord in
+            let v = get_co st VecReg in
             let vecreg = [|v;v;v;v;|] in
             n.evt <- { n.evt with ord=ord; vecreg=vecreg; }
+*)
           end
         end ;
         begin match n.evt.dir with
@@ -638,28 +724,29 @@ let set_same_loc st n0 =
                 let bank = n.evt.bank in
                 begin match bank with
                 | Ord ->
-                    n.evt <- { n.evt with v =  tr_value n.evt (get_co next Ord); } ;
-                    (* Writing Ord resets morello tag *)
-                    let old = set_co old CapaTag evt_null.ctag in
-                    let next = next_co (set_co next CapaTag evt_null.ctag) CapaTag in
-                    set_cell n (get_co old Ord) ;
-                    do_set_write_val
-                      (set_co old bank n.evt.cell)
-                      (if E.is_node n.edge.E.edge then next
-                       else next_co next Ord)
-                      pte_val ns
+                   let st = CoSt.next_co st Ord in
+                   let v = CoSt.get_co st Ord in
+                   n.evt <- { n.evt with v = tr_value n.evt v; } ;
+                   (* Writing Ord resets morello tag *)
+                   let st = CoSt.set_co st CapaTag evt_null.ctag in
+                   let e,st = CoSt.set_cell st n.evt in
+                   n.evt <- e ;
+                   do_set_write_val st pte_val ns
                 | Tag|CapaTag|CapaSeal ->
-                    let v =  get_co next Tag in
-                    n.evt <- { n.evt with v = v; } ;
-                    do_set_write_val (set_co old bank v)
-                      (next_co next bank) pte_val ns
-                | VecReg ->
-                    let v = get_co next bank in
-                    n.evt <- { n.evt with v = v; } ;
-                    set_cell n (get_co old Ord) ;
-                    do_set_write_val
-                      (set_co old bank v)
-                      (next_co next bank) pte_val ns
+                   let st = CoSt.next_co st bank in
+                   let v = CoSt.get_co st bank in
+                   n.evt <- { n.evt with v = v; } ;
+                   do_set_write_val st pte_val ns
+                | VecReg a ->
+                   let st = CoSt.step_simd st a in
+                   let cell = CoSt.get_cell st in
+                   let vecreg  = E.SIMD.read a cell in
+                   let v =
+                     match vecreg with
+                       | (v::_)::_ -> v
+                       | _ -> assert false in
+                   n.evt <- { n.evt with vecreg; cell;v;} ;
+                   do_set_write_val st pte_val ns
                 | Pte ->
                     let pte_val =
                       if do_kvm then begin
@@ -678,12 +765,12 @@ let set_same_loc st n0 =
                         E.set_pteval n.evt.atom pte_val next_loc
                       end else pte_val in
                     n.evt <- { n.evt with pte = pte_val; } ;
-                    do_set_write_val old next pte_val ns
+                    do_set_write_val st pte_val ns
                 end
             | Code _ ->
-                do_set_write_val old next pte_val ns
+               do_set_write_val st pte_val ns
             end
-        | (Some R) | Some J |None ->  do_set_write_val old next pte_val ns
+        | Some R | Some J |None -> do_set_write_val st pte_val ns
         end
 
   let set_all_write_val nss =
@@ -691,8 +778,8 @@ let set_same_loc st n0 =
       (fun ns -> match ns with
       | [] -> ()
       | n::_ ->
-          do_set_write_val
-            co_st_0 (start_co ns) (pte_val_init n.evt.loc) ns)
+         let sz = get_wide_list ns in
+         do_set_write_val (CoSt.create sz) (pte_val_init n.evt.loc) ns)
       nss
 
   let set_write_v n =
@@ -736,37 +823,46 @@ let set_dep_v nss =
 (* TODO: this is wrong for Store CR's: consider Rfi Store PosRR *)
 let set_read_v n cell =
   let e = n.evt in
-  let v = E.extract_value cell e.atom in
+  let v = E.extract_value cell.(0) e.atom in
 (* eprintf "SET READ: cell=0x%x, v=0x%x\n" cell v ; *)
   let e = { e with v=v; } in
   n.evt <- e
 (*  eprintf "AFTER %a\n" debug_node n *)
 
 let do_set_read_v =
-
+  (* st keeps track of tags, cell and pte_cell are the current
+     state of memory *)
   let rec do_rec st cell pte_cell = function
-    | [] -> cell,pte_cell
+    | [] -> cell.(0),pte_cell
     | n::ns ->
+        let bank = n.evt.bank in
         begin match n.evt.dir with
         | Some R ->
-            begin match  n.evt.bank with
+            begin match bank with
             | Ord ->
-                set_read_v n cell
-            | Tag|CapaTag|CapaSeal|VecReg as bank ->
-                n.evt <- { n.evt with v = get_co st bank; }
+               set_read_v n cell
+            | VecReg a ->
+               let v = E.SIMD.read a cell in
+               n.evt <- { n.evt with vecreg=v; }
+            | Tag|CapaTag|CapaSeal ->
+                n.evt <- { n.evt with v = CoSt.get_co st bank; }
             | Pte ->
-                n.evt <- { n.evt with pte =  pte_cell; }
+                n.evt <- { n.evt with pte = pte_cell; }
             end ;
             do_rec st cell pte_cell ns
         | Some W ->
-            let st = set_co st n.evt.bank n.evt.v in
-            let bank = n.evt.bank in
+            let st =
+              match bank with
+              | Tag|CapaTag|CapaSeal ->
+                 CoSt.set_co st bank n.evt.v
+              | Pte|Ord|VecReg _ ->
+                 st in
             do_rec st
               (match bank with
-               | Ord -> n.evt.cell
-               | Tag|CapaTag|CapaSeal|Pte|VecReg -> cell)
+               | Ord|VecReg _ -> n.evt.cell
+               | Tag|CapaTag|CapaSeal|Pte -> cell)
               (match bank with
-               | Ord|Tag|CapaTag|CapaSeal|VecReg -> pte_cell
+               | Ord|Tag|CapaTag|CapaSeal|VecReg _ -> pte_cell
                | Pte -> n.evt.pte)
               ns
         | None | Some J ->
@@ -775,7 +871,10 @@ let do_set_read_v =
   fun ns -> match ns with
   | []   -> assert false
   | n::_ ->
-      do_rec co_st_0 0
+     let sz = get_wide_list ns in
+     let st = CoSt.create sz in
+     let cell = CoSt.get_cell st in
+      do_rec st cell
         (pte_val_init n.evt.loc)
         ns
 
@@ -1116,24 +1215,5 @@ let rec group_rec x ns = function
     get_rec
       (fun loc k -> match loc with Code loc -> loc::k | Data _ -> k)
       m
-(* generic scan *)
-  let fold f m k =
-    let rec fold_rec n k =
-      let k = f n k
-      and nxt = n.next in
-      if nxt == m then k
-      else fold_rec nxt k in
-    fold_rec m k
-
-(* Get size (as integers) from annotations *)
-  let get_wide m =
-    fold
-      (fun n k ->
-      match n.evt.loc,E.as_integers n.edge with
-      | Data loc,Some sz ->
-         let sz0 = StringMap.safe_find 0 loc k in
-         StringMap.add loc (max sz0 sz) k
-      | _,_ -> k)
-    m StringMap.empty
 
 end

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -25,6 +25,9 @@ module type S = sig
 
   type fence
   type dp
+
+  module SIMD : Atom.SIMD
+
   type atom
   type rmw
 
@@ -34,7 +37,7 @@ module type S = sig
   val extract_value : Code.v -> atom option -> Code.v
   val set_pteval : atom option -> PTEVal.t -> (unit -> string) -> PTEVal.t
   val merge_atoms : atom -> atom -> atom option
-  val atom_to_bank : atom option -> Code.bank
+  val atom_to_bank : atom option -> SIMD.atom Code.bank
   val strong : fence
   val pp_fence : fence -> string
 
@@ -147,6 +150,7 @@ module Make(Cfg:sig val variant : Variant_gen.t -> bool end)(F:Fence.S) : S
 with
 type fence = F.fence
 and type dp = F.dp
+and module SIMD = F.SIMD
 and type atom = F.atom
 and type rmw = F.rmw = struct
   let do_self = Cfg.variant Variant_gen.Self
@@ -155,6 +159,9 @@ and type rmw = F.rmw = struct
 
   type fence = F.fence
   type dp = F.dp
+
+  module SIMD = F.SIMD
+
   type atom = F.atom
   type rmw = F.rmw
 

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -76,6 +76,7 @@ module type S = sig
 
   val pp_tedge : tedge -> string
   val pp_atom_option : atom option -> string
+
   val debug_edge : edge -> string
   val pp_edge : edge -> string
   val compare_atomo : atom option -> atom option -> int
@@ -108,6 +109,9 @@ module type S = sig
 (* More detailed *)
   type full_ie = IE of ie | LeaveBack
   val get_full_ie : edge -> full_ie
+
+(* If source atom implies wide access, size of access as integers *)
+  val as_integers : edge -> int option
 
 (* Can e1 target event direction be the same as e2 source event? *)
   val can_precede : edge -> edge -> bool
@@ -643,6 +647,7 @@ and do_set_src d e = match e with
   | Leave _|Back _ -> LeaveBack
   | _ -> IE (get_ie e)
 
+  let as_integers e = F.as_integers e.a1
 
   let can_precede_dirs  x y = match x.edge,y.edge with
   | (Id,Id) -> false

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -44,6 +44,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
     val add_final_loc :
         Code.proc -> C.A.arch_reg -> string -> fenv -> fenv
     val cons_int :   C.A.location -> int -> fenv -> fenv
+    val cons_vec : C.A.location -> int array -> fenv -> fenv
     val cons_pteval :   C.A.location -> PTEVal.t -> fenv -> fenv
     val cons_int_set :  (C.A.location * IntSet.t) -> fenv -> fenv
     val add_int_sets : fenv -> (C.A.location * IntSet.t) list -> fenv
@@ -141,6 +142,10 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
       (loc,VSet.singleton (S v))::finals
 
     let cons_int loc i fs = (loc,VSet.singleton (I i))::fs
+
+    let cons_vec loc t fs =
+      let vec = Code.add_vector O.hexa (Array.to_list t) in
+      (loc,VSet.singleton (S vec))::fs
 
     let cons_pteval loc p fs = (loc,VSet.singleton (P p))::fs
 

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -24,6 +24,14 @@ end
 
 module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
   sig
+
+(* During compilation of cycle, final state is a
+   pair eventmap * fenv, where
+    + fenv associates locations to final values;
+    + eventmap maps one event to the register
+      written by the node. This is useful only
+      for simulating execution in `-cond unicond` mode *)
+
     type vset
     type fenv = (C.A.location * vset) list
     type eventmap = C.A.location C.C.EventMap.t
@@ -39,9 +47,24 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
     val cons_pteval :   C.A.location -> PTEVal.t -> fenv -> fenv
     val cons_int_set :  (C.A.location * IntSet.t) -> fenv -> fenv
     val add_int_sets : fenv -> (C.A.location * IntSet.t) list -> fenv
+
+(* Standard function to record an association from register
+   to expected value:
+   Call is `add_final get_friends proc reg node (map,fenv)`,
+   where:
+     + get_friends returns the "friends of register",
+       friends are registers whose expected value is
+       identical. Those may stem from instructions that
+       write into several registers.
+     + proc is a thread identifier.
+     + reg is a register option, when None nothing happens.
+     + node is the current node.
+     + (map,env) is the old final structure.
+*)
     val add_final :
-        Code.proc -> C.A.arch_reg option -> C.C.node ->
-          eventmap * fenv -> eventmap * fenv
+      (C.A.arch_reg -> C.A.arch_reg list) ->
+      Code.proc -> C.A.arch_reg option -> C.C.node ->
+      eventmap * fenv -> eventmap * fenv
 
     type faults = (Proc.t * StringSet.t) list
     type final
@@ -114,7 +137,8 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
     let add_final_pte p r v finals = (C.A.of_reg p r,VSet.singleton (P v))::finals
 
     let add_final_loc p r v finals =
-      (C.A.of_reg p r,VSet.singleton (S v))::finals
+      let loc = C.A.of_reg p r in
+      (loc,VSet.singleton (S v))::finals
 
     let cons_int loc i fs = (loc,VSet.singleton (I i))::fs
 
@@ -127,7 +151,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
 
     let prev_value = fun v -> v-1
 
-    let add_final p o n finals = match o with
+    let add_final get_friends p o n finals = match o with
     | Some r ->
         let m,fs = finals in
         let evt = n.C.C.evt in
@@ -139,7 +163,8 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
             | Code.Ord ->
                 Some (I evt.C.C.v)
             | Code.VecReg ->
-                Some (S (Code.add_vector evt.C.C.vecreg))
+                let vec =Code.add_vector evt.C.C.vecreg in
+                Some (S vec)
             | Code.Tag ->
                 Some (S (Code.add_tag (Code.as_data evt.C.C.loc) evt.C.C.v))
             | Code.Pte ->
@@ -149,8 +174,12 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
         | None|Some Code.J -> None in
         if show_in_cond n then match v with
         | Some v ->
-            C.C.EventMap.add n.C.C.evt (C.A.of_reg p r) m,
-            (C.A.of_reg p r,VSet.singleton v)::fs
+           let add_to_fs r fs =
+             (C.A.of_reg p r,VSet.singleton v)::fs in
+           let m = C.C.EventMap.add n.C.C.evt (C.A.of_reg p r) m
+           and fs =
+             add_to_fs r (List.fold_right add_to_fs (get_friends r) fs) in
+           m,fs
         | None -> finals
         else finals
     | None -> finals

--- a/gen/machAtom.ml
+++ b/gen/machAtom.ml
@@ -93,4 +93,6 @@ module Make(C:Config) = struct
   | None| Some (Atomic|Reserve) -> v
   | Some (Mixed (sz,o)) ->
       ValsMixed.extract_value v sz o
+
+  include NoWide
 end

--- a/gen/machAtom.ml
+++ b/gen/machAtom.ml
@@ -27,6 +27,8 @@ module Make(C:Config) = struct
 
   let bellatom = false
 
+  module SIMD = NoSIMD
+
   type hidden_atom = Atomic | Reserve | Mixed of MachMixed.t
   type atom = hidden_atom
 

--- a/gen/noSIMD.ml
+++ b/gen/noSIMD.ml
@@ -1,0 +1,23 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2021-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+type atom = unit
+let nregs () = 0
+let pp () = ""
+
+let initial _ = [||]
+let step () _ _ = [||]
+let read () _ = []

--- a/gen/noSIMD.mli
+++ b/gen/noSIMD.mli
@@ -1,0 +1,17 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2021-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+include Atom.SIMD

--- a/gen/noWide.ml
+++ b/gen/noWide.ml
@@ -1,0 +1,17 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2021-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+let as_integers _ = None

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -26,7 +26,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
   sig
 (* Coherence utilities *)
     type cos0 =  (string * (C.C.node * IntSet.t) list list) list
-    type cos = (string * (Code.v * IntSet.t) list list) list
+    type cos = (string * (Code.v array * IntSet.t) list list) list
     val pp_coherence : cos0 -> unit
     val last_map : cos0 -> C.C.event StringMap.t
     val compute_cos : cos0 ->  cos
@@ -49,7 +49,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
   struct
 
     type cos0 =  (string * (C.C.node * IntSet.t) list list) list
-    type cos = (string * (Code.v * IntSet.t) list list) list
+    type cos = (string * (Code.v array * IntSet.t) list list) list
 
     open Printf
     open Code
@@ -114,7 +114,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           loc,
           List.map
             (*NOTYET*)
-            (List.map (fun (n,obs) -> n.C.C.evt.C.C.cell.(0),obs))
+            (List.map (fun (n,obs) -> n.C.C.evt.C.C.cell,obs))
             ns)
 
 (******************)

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -241,7 +241,7 @@ let get_fence n =
               let call_add =
                 StringSet.mem loc loc_writes  && not (U.do_poll n) in
               if call_add then
-                F.add_final p o n finals
+                F.add_final (A.get_friends st) p o n finals
               else begin
                 finals
               end


### PR DESCRIPTION
This PR first completes PR #160 (Neon support for generators), by computing adequate types for locations that are subject to wide accesses, as performed by neon instructions.

It also provides the following improvements:
 + Abstract SIMD operations so as to make them arch dependent.
  + AArch64: SIMD instructions store values n,n+1,... in different "lanes". Previously, teh same value was written to all lanes.
  + Fix `-obs local` mode for SIMD.
  + Simplify value setting code in cycle.ml.
  + Partially check coherence order.
