### PR TITLE
[tools] Add a flag to mdiff7 to change diff behavior, -act

### DIFF
--- a/tools/matrix.mli
+++ b/tools/matrix.mli
@@ -33,13 +33,6 @@ module type Config = sig
 end
 
 
-(* Goes nowhere else *)
-(*
-val one_line : string -> cell
-val one_lines : string list -> column
-val one_liness : string list list -> matrix
-*)
-
 (*****************)
 (* Simple Build  *)
 (*****************)


### PR DESCRIPTION
This PR re-enables the log intersection behavior of `mdiff7`. This used to be done with the binary `minter7`, which was removed in commit e9362dd8c2262412bd879971cc2a69c4257ccdd6.