### PR TITLE
[litmus] Klitmus memory type

### DIFF
--- a/lib/CGenParser_lib.ml
+++ b/lib/CGenParser_lib.ml
@@ -216,7 +216,7 @@ module Do
 		(* For computing hash, we must parse as litmus does.
                 This includes stripping away toplevel '*' of types *)
 		let prog = List.map CAstUtils.strip_pointers prog_litmus in
-		D.digest init prog all_locs)::info ; }
+		D.digest info init prog all_locs)::info ; }
         | Some _ -> parsed in
     parsed
 end

--- a/lib/CTestHash.ml
+++ b/lib/CTestHash.ml
@@ -57,9 +57,11 @@ module Make(P:Input)
         Digest.string pp
 
 
-      let digest init code observed =
+      let digest info init code observed =
         Digest.to_hex
           (Digest.string
-             (TestHash.digest_init debug init ^ digest_code code ^
-              digest_observed observed))
+             (String.concat ""
+                [TestHash.digest_info info; TestHash.digest_init debug init;
+                 digest_code code; digest_observed observed;]))
+
     end

--- a/lib/CTestHash.mli
+++ b/lib/CTestHash.mli
@@ -25,5 +25,7 @@ module type Input = sig
 end
 
 module Make(P:Input) : sig
-  val digest : MiscParser.state -> P.code list -> MiscParser.RLocSet.t -> string
+  val digest :
+    MiscParser.info -> MiscParser.state ->
+    P.code list -> MiscParser.RLocSet.t -> string
 end

--- a/lib/genParser.ml
+++ b/lib/genParser.ml
@@ -227,7 +227,7 @@ module Make
              let info = parsed.MiscParser.info in
              { parsed with
                MiscParser.info =
-               ("Hash",D.digest init prog all_locs)::info ; }
+               ("Hash",D.digest info init prog all_locs)::info ; }
         | Some _ -> parsed in
       parsed
            end

--- a/lib/lexScan.mli
+++ b/lib/lexScan.mli
@@ -19,4 +19,5 @@ exception Error
 
 val is_num : string -> bool
 val info : string -> (string * string) option
+val infos : string -> (string * string) list
 val procs : string -> Proc.t list

--- a/lib/lexScan.mll
+++ b/lib/lexScan.mll
@@ -38,6 +38,13 @@ and info_rule = parse
   { let p = key,value in Some p }
 | "" { None }
 
+and infos_rule = parse
+| "" { [] }
+| blank+|',' { infos_rule lexbuf }
+| (name as x) blank* ':' blank* (name as info)
+   { (x,info)::infos_rule lexbuf }
+| "" { raise Error }
+
 and procs_rule = parse
 | 'P' (digit+ as p)
 { let p = try int_of_string p with _ -> assert false in
@@ -48,5 +55,6 @@ and procs_rule = parse
 {
 let is_num s = num_rule (Lexing.from_string s)
 let info s = info_rule (Lexing.from_string s)
+let infos s = infos_rule (Lexing.from_string s)
 let procs s = procs_rule (Lexing.from_string s)
 }

--- a/lib/memoryType.ml
+++ b/lib/memoryType.ml
@@ -21,6 +21,8 @@ module type S = sig
   val emit : t -> string (* Emit in code *)
 
   val parse : MiscParser.info -> t Misc.Simple.bds
+  (* Cache flush neeed after initialisation *)
+  val need_flush : t Misc.Simple.bds -> bool
 end
 
 module X86_64 = struct
@@ -65,6 +67,9 @@ module X86_64 = struct
              i
          end in
     Misc.Simple.map parse_t ps
+
+  let need_flush =
+    List.exists (fun (_,m) -> match m with WC -> true | _ -> false)
 end
 
 module No = struct
@@ -76,5 +81,7 @@ module No = struct
   let emit = pp
 
   let parse _ = []
+
+  let need_flush _ = false
 
 end

--- a/lib/memoryType.ml
+++ b/lib/memoryType.ml
@@ -66,7 +66,12 @@ module X86_64 = struct
              "'%s' is not a proper specificaton of X86_64 memory types"
              i
          end in
-    Misc.Simple.map parse_t ps
+    List.fold_right
+      (fun (key,tok) k ->
+        match parse_t tok with
+        | WB -> k
+        | m -> (key,m)::k)
+      ps []
 
   let need_flush =
     List.exists (fun (_,m) -> match m with WC -> true | _ -> false)

--- a/lib/memoryType.ml
+++ b/lib/memoryType.ml
@@ -35,12 +35,15 @@ module X86_64 = struct
 
   let emit m = Printf.sprintf "PAT_%s" (pp m)
 
+  let _ = WP (* Silence warning 37 *)
+
   let parse_t = function
     | "UC" -> UC
     | "WC" -> WC
     | "WT" -> WT
-    | "WP" -> WP
     | "WB" -> WB
+    | "WP" as s ->
+       Warn.fatal "%s memory type  is not implemented" s
     | s ->
        Warn.fatal "'%s' is not a X86_64 memory type" s
 

--- a/lib/memoryType.ml
+++ b/lib/memoryType.ml
@@ -1,0 +1,77 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2021-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(************************************** UC**************************************)
+
+(* Memory types of global variables *)
+module type S = sig
+  type t
+  val pp : t -> string (* Pretty print *)
+  val emit : t -> string (* Emit in code *)
+
+  val parse : MiscParser.info -> t Misc.Simple.bds
+end
+
+module X86_64 = struct
+  type t = UC | WC | WT | WP | WB
+
+  let pp = function
+    | UC -> "UC"
+    | WC -> "WC"
+    | WT -> "WT"
+    | WP -> "WP"
+    | WB -> "WB"
+
+  let emit m = Printf.sprintf "PAT_%s" (pp m)
+
+  let parse_t = function
+    | "UC" -> UC
+    | "WC" -> WC
+    | "WT" -> WT
+    | "WP" -> WP
+    | "WB" -> WB
+    | s ->
+       Warn.fatal "'%s' is not a X86_64 memory type" s
+
+  let parse infos =
+    let open MiscParser in
+    let info =
+      match get_info_on_info mt_key infos with
+      | None -> get_info_on_info memory_type_key infos
+      | Some _ as r -> r in
+    let ps =
+      match info with
+      | None -> []
+      | Some i ->
+         begin
+           try LexScan.infos i
+         with LexScan.Error ->
+           Warn.fatal
+             "'%s' is not a proper specificaton of X86_64 memory types"
+             i
+         end in
+    Misc.Simple.map parse_t ps
+end
+
+module No = struct
+
+  type t = unit
+
+  let pp () = ""
+
+  let emit = pp
+
+  let parse _ = []
+
+end

--- a/lib/memoryType.mli
+++ b/lib/memoryType.mli
@@ -1,0 +1,28 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2021-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(************************************** UC**************************************)
+
+(* Memory types of global variables *)
+module type S = sig
+  type t
+  val pp : t -> string (* Pretty print *)
+  val emit : t -> string (* Emit in code *)
+
+  val parse : MiscParser.info -> t Misc.Simple.bds
+end
+
+module X86_64 : S
+
+module No : S

--- a/lib/memoryType.mli
+++ b/lib/memoryType.mli
@@ -21,6 +21,8 @@ module type S = sig
   val emit : t -> string (* Emit in code *)
 
   val parse : MiscParser.info -> t Misc.Simple.bds
+  (* Cache flush neeed after initialisation *)
+  val need_flush : t Misc.Simple.bds -> bool
 end
 
 module X86_64 : S

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -727,12 +727,14 @@ module Simple = struct
 
   type 'a bds = (string * 'a) list
 
-  let assoc (k:string) env =
+  let assoc (k:string) =
     let rec find_rec = function
       | [] -> raise Not_found
       | (k0,v)::env ->
           if k0 = k then v else find_rec env in
-    find_rec env
+    find_rec
+
+  let assoc_opt k env = try Some (assoc k env) with Not_found -> None
 
   let mem (y:string) xs = List.exists (fun x -> x=y) xs
 
@@ -740,6 +742,7 @@ module Simple = struct
     try ignore (assoc k env) ; true
     with Not_found -> false
 
+  let map f env = List.map (fun (k,v) -> k,f v) env
 end
 
 (*************)

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -251,8 +251,10 @@ module Simple : sig
   type 'a bds = (string * 'a) list
 
   val assoc : string -> 'a bds -> 'a
+  val assoc_opt : string -> 'a bds -> 'a option
   val mem : string -> string list -> bool
   val mem_assoc : string -> 'a bds -> bool
+  val map : ('a -> 'b) -> 'a bds -> 'b bds
 end
 
 (*************)

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -204,6 +204,7 @@ let mach2generic parser lexer buff =
     procs,code,NoExtra
 
 (* Info keys *)
+
 let hash_key =  "Hash"
 and stable_key = "Stable"
 and align_key = "Align"
@@ -214,14 +215,25 @@ and el0_key = "el0"
 and memory_type_key = "MemoryType"
 and mt_key = "MT"
 
-let low_hash = "hash"
+let key_match k1 k2 =
+  let len1 = String.length k1 in
+  let len2 = String.length k2 in
+  Misc.int_eq len1 len2 &&
+    begin
+      let len = len1 in
+      let rec do_rec k =
+        if k >= len then true
+        else
+          Misc.char_uppercase k1.[k] = Misc.char_uppercase k2.[k]
+          && do_rec (k+1) in
+      do_rec 0
+    end
 
 let get_info_on_info key =
-  let key = Misc.lowercase key in
   let rec find = function
     | [] -> None
     | (k,v)::rem ->
-        if Misc.string_eq (Misc.lowercase k) key then Some v
+        if key_match k key then Some v
         else find rem in
   find
 
@@ -230,7 +242,7 @@ let get_hash p = get_info_on_info hash_key p.info
 
 let rec set_hash_rec h = function
   | [] -> [hash_key,h]
-  | (k,_)::rem when Misc.string_eq (Misc.lowercase k) low_hash -> (k,h)::rem
+  | (k,_)::rem when key_match hash_key k -> (k,h)::rem
   | p::rem -> p::set_hash_rec h rem
 
 let set_hash p h = { p with info = set_hash_rec  h p.info; }

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -211,6 +211,9 @@ and tthm_key = "TTHM"
 and variant_key = "Variant"
 and user_key = "user"
 and el0_key = "el0"
+and memory_type_key = "MemoryType"
+and mt_key = "MT"
+
 let low_hash = "hash"
 
 let get_info_on_info key =

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -229,6 +229,10 @@ let key_match k1 k2 =
       do_rec 0
     end
 
+let digested_keys = [memory_type_key; mt_key;]
+
+let digest_mem k = List.exists (key_match k) digested_keys
+
 let get_info_on_info key =
   let rec find = function
     | [] -> None

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -118,14 +118,19 @@ val el0_key : string
 val memory_type_key : string
 val mt_key : string
 
+val key_match : string -> string -> bool
+
+(* Meta-data included in digest ? *)
+val digest_mem : string -> bool
+
 (* Extract hash *)
 val get_hash : ('i, 'p, 'c, 'loc, 'v) result -> string option
 val set_hash :
     ('i, 'p, 'c, 'loc, 'v) result -> string ->
       ('i, 'p, 'c, 'loc, 'v) result
 
+
 (* Extract meta information from key *)
-val key_match : string -> string -> bool
 
 val get_info_on_info : string -> (string * string) list -> string option
 

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -125,6 +125,8 @@ val set_hash :
       ('i, 'p, 'c, 'loc, 'v) result
 
 (* Extract meta information from key *)
+val key_match : string -> string -> bool
+
 val get_info_on_info : string -> (string * string) list -> string option
 
 val get_info :  ('i, 'p, 'c, 'loc, 'v) result -> string -> string option

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -115,6 +115,8 @@ val tthm_key : string
 val variant_key : string
 val user_key : string
 val el0_key : string
+val memory_type_key : string
+val mt_key : string
 
 (* Extract hash *)
 val get_hash : ('i, 'p, 'c, 'loc, 'v) result -> string option

--- a/lib/testHash.mli
+++ b/lib/testHash.mli
@@ -37,6 +37,9 @@ val check_env : env -> string -> string -> string -> env
 val digest_init :
   (string -> string -> unit) (* debug *) -> MiscParser.state -> string
 
+(* Digest of meta-data (shared with C digests) *)
+val digest_info : MiscParser.info -> string
+
 module Make :
   functor (A:ArchBase.S) -> sig
     type init = MiscParser.state
@@ -44,5 +47,5 @@ module Make :
     type rlocations = MiscParser.RLocSet.t
 
     val refresh_labels : string -> prog -> prog
-    val digest : init -> prog -> rlocations -> string
+    val digest : MiscParser.info -> init -> prog -> rlocations -> string
   end

--- a/litmus/CGenParser_litmus.ml
+++ b/litmus/CGenParser_litmus.ml
@@ -176,7 +176,7 @@ let check_regs = GenParserUtils.check_regs
       let parsed =
         match MiscParser.get_hash parsed with
         | None ->
-            MiscParser.set_hash parsed (D.digest init prog all_locs)
+            MiscParser.set_hash parsed (D.digest info init prog all_locs)
         | Some _ ->
             parsed in
       parsed

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -689,6 +689,14 @@ let dump_zyva tname env test =
   let fmt =
     "Condition " ^ U.pp_cond test ^ " is %svalidated\n" in
   O.fii "seq_printf(m,%S,%s?\"\":\"NOT \");" fmt ok_expr ;
+  List.iter
+    (fun (k,i) ->
+      if
+        MiscParser.key_match MiscParser.mt_key k
+        ||         MiscParser.key_match MiscParser.memory_type_key k
+      then
+        O.fii "seq_printf(m,\"%%s=%%s\\n\",%S,%S);" k i)
+    test.T.info ;
   begin match U.get_info MiscParser.hash_key test with
   | None -> ()
   | Some h ->

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -516,6 +516,7 @@ module Make
       | TimeBase ->
           O.oi "barrier_init(_a->barrier);"
       end ;
+      if MemType.need_flush mts then O.oi "klitmus_flush_caches();" ;
       O.o "}" ;
       O.o "" ;
       ()

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -33,12 +33,14 @@ module type Config = sig
   val barrier : KBarrier.t
   val affinity : KAffinity.t
   val sharelocks : int option
+  val sysarch : Archs.System.t
 end
 
 module Make
     (Cfg:Config)
     (P:sig type code end)
     (A:Arch_litmus.Base)
+    (MemType:MemoryType.S)
     (T:Test_litmus.S with type P.code = P.code and module A = A)
     (O:Indent.S)
     (Lang:Language.S
@@ -48,6 +50,18 @@ module Make
       val dump : Name.t -> T.t -> unit
     end =
   struct
+
+(******************)
+(* Arch dependant *)
+(******************)
+
+    module Insert =
+      ObjUtil.Insert
+        (struct
+          let sysarch = Cfg.sysarch
+        end)
+
+    let memtype_possible = Insert.exists "klitmus_memory_type.c"
 
 (*************)
 (* Utilities *)
@@ -123,6 +137,7 @@ module Make
     and is_spinlock_t t = match t with
     | CType.Base "spinlock_t" -> true
     | _ -> false
+
 (***********)
 (* Headers *)
 (***********)
@@ -305,7 +320,7 @@ module Make
       | Symbolic _|Tag _| PteVal _ ->
           Warn.user_error "No tag, indexed access, nor pteval for klitmus"
 
-    let dump_ctx env test =
+    let dump_ctx mts env test =
       O.o "/****************/" ;
       O.o "/* Affinity     */" ;
       O.o "/****************/" ;
@@ -355,6 +370,11 @@ module Make
       end ;
       O.o "static ctx_t **ctx;" ;
       O.o "" ;
+      begin match mts with
+      | _::_ ->
+         Insert.insert O.o "klitmus_memory_type.c"
+      | _ -> ()
+      end ;
       if List.exists (fun (_,t) -> is_srcu_struct(t)) test.T.globals
       then begin
         O.o "static void cleanup_srcu_structs(struct srcu_struct *p,int sz) {" ;
@@ -362,9 +382,12 @@ module Make
         O.o "}" ;
         O.o ""
       end ;
-      O.o "static void free_ctx(ctx_t *p) { " ;
+      let sz = if Misc.consp mts then ",size_t sz" else "" in
+      O.f "static void free_ctx(ctx_t *p%s) { " sz ;
       O.oi "if (p == NULL) return;" ;
-      let free tag = O.fi "if (p->%s) kfree(p->%s);" tag tag in
+      let free tag = O.fi "if (p->%s) kfree(p->%s);" tag tag
+      and free_mt tag =
+        O.fi "if (p->%s) klitmus_free_pat(p->%s,sz);" tag tag in
       List.iter
         (fun (s,t) ->
           if is_srcu_struct t then begin
@@ -374,7 +397,9 @@ module Make
             O.fii "kfree(p->%s);" s ;
             O.oi "}"
           end else begin
-            free s
+            match Misc.Simple.assoc_opt s mts with
+            | None -> free s
+            | Some _ -> free_mt s
           end)
         test.T.globals ;
       iter_all_outs
@@ -395,6 +420,11 @@ module Make
       O.oi "if (!r) { return NULL; }" ;
       let alloc sz tag =
         O.fi "r->%s = kmalloc(sizeof(r->%s[0])*%s,GFP_KERNEL);" tag tag sz;
+        O.fi "if (!r->%s) { return NULL; }" tag
+      and alloc_mt mt sz tag =
+        let mt = MemType.emit mt in
+        O.fi "r->%s = klitmus_alloc_pat(%s,sizeof(r->%s[0])*%s);"
+          tag mt tag sz;
         O.fi "if (!r->%s) { return NULL; }" tag in
       List.iter
         (fun (s,t) ->
@@ -421,7 +451,9 @@ module Make
                 let sz = do_spinsize "sz" in
                 alloc sz s
               end else
-                alloc "sz" s)
+                match Misc.Simple.assoc_opt s mts with
+                | None -> alloc "sz" s
+                | Some mt -> alloc_mt mt "sz" s)
         test.T.globals ;
       iter_all_outs
         (fun proc (reg,_) ->
@@ -713,7 +745,7 @@ let dump_proc tname _test =
 (* Init, Exit and friends *)
 (**************************)
 
-let dump_init_exit _test =
+let dump_init_exit has_memtype _test =
   O.o "static int __init" ;
   O.o "litmus_init(void) {" ;
   O.oi "int err=0;" ;
@@ -746,7 +778,8 @@ let dump_init_exit _test =
   O.oi "init_waitqueue_head(wq);" ;
   O.oi "return 0; " ;
   O.o "clean_ctx:" ;
-  O.oi "for (int k=0 ; k < ninst ; k++) free_ctx(ctx[k]);" ;
+  let free_ctx_sz = if has_memtype then ",size" else "" in
+  O.fi "for (int k=0 ; k < ninst ; k++) free_ctx(ctx[k]%s);" free_ctx_sz;
   O.oi "kfree(ctx);" ;
   O.o  "clean_online:" ;
   O.oi "kfree(online);" ;
@@ -758,7 +791,7 @@ let dump_init_exit _test =
 
   O.o "static void __exit" ;
   O.o "litmus_exit(void) {" ;
-  O.oi "for (int k=0 ; k < ninst ; k++) free_ctx(ctx[k]);" ;
+  O.fi "for (int k=0 ; k < ninst ; k++) free_ctx(ctx[k]%s);" free_ctx_sz;
   O.oi "kfree(ctx);" ;
   O.oi "kfree(online);" ;
   O.oi "remove_proc_entry(\"litmus\",NULL);" ;
@@ -778,17 +811,19 @@ let dump name test =
   ObjUtil.insert_lib_file O.o "header.txt" ;
   let tname = name.Name.name in
   let env = U.build_env test in
+  let mts = if memtype_possible then MemType.parse test.T.info else [] in
+  let has_memtype = Misc.consp mts in
   dump_header () ;
   dump_params tname test ;
   dump_outs env test ;
   dump_barrier_def () ;
-  dump_ctx env test ;
+  dump_ctx mts env test ;
   dump_threads tname env test ;
   dump_filter env test ;
   dump_cond_fun env test ;
   dump_zyva tname env test ;
   dump_proc tname test ;
-  dump_init_exit test ;
+  dump_init_exit has_memtype test ;
   ()
 
 

--- a/litmus/klitmus.ml
+++ b/litmus/klitmus.ml
@@ -54,6 +54,8 @@ module KOption : sig
   val affinity : KAffinity.t ref
   val ccopts : string list ref
   val sharelocks : int option ref
+  val carch : Archs.System.t option ref
+  val set_carch : Archs.System.t -> unit
 end = struct
   include Option
   let stride = ref (KStride.St 1)
@@ -64,6 +66,7 @@ end = struct
   let affinity = ref KAffinity.No
   let ccopts = ref []
   let sharelocks = ref None
+  let carch = ref (Some `X86_64)
 end
 
 open KOption
@@ -110,6 +113,9 @@ let opts =
        let i = if i >=0 then i else 0 in
        KOption.affinity := KAffinity.Incr i),
    "<n> alias for -affinity incr<n>" ;
+   begin let module P = ParseTag.Make(Archs.System) in
+   P.parse_withfun "-carch"
+     KOption.set_carch "Target architechture (C arch only)" None end ;
 (********)
 (* Misc *)
 (********)
@@ -184,6 +190,7 @@ let () =
       let pad = !pad
       let ccopts = !ccopts
       let sharelocks = !sharelocks
+      let sysarch = Misc.as_some !carch
 (* tar stuff *)
       let tarname = KOption.get_tar ()
     end in

--- a/litmus/libdir/_x86_64/klitmus_memory_type.c
+++ b/litmus/libdir/_x86_64/klitmus_memory_type.c
@@ -2,17 +2,17 @@
 /*  IA32 memory types */
 /**********************/
 
-/* Those x86 specific prototypes are not available in linux-headers package */
+#include <linux/mm.h>
 
+/* Those x86 specific prototypes were not found in linux-headers package */
 int set_memory_uc(unsigned long addr,int numpages);
 int set_memory_wc(unsigned long addr,int numpages);
-int set_memory_wt(unsigned long addr,int numpages);
-int set_memory_wp(unsigned long addr,int numpages);
 int set_memory_wb(unsigned long addr,int numpages);
+int set_pages_array_wt(struct page **pages,int numpages);
 
 typedef enum { PAT_UC, PAT_WC, PAT_WT, PAT_WP, PAT_WB, } pat_t ;
 
-static size_t npages(size_t sz) {
+static size_t opages(size_t sz) {
   size_t r=0 ; size_t max=PAGE_SIZE;
   while (sz > max) {
     max *= 2; r++;
@@ -23,31 +23,40 @@ static size_t npages(size_t sz) {
 static int klitmus_set_memory(pat_t pat, unsigned long addr, int numpages) {
   switch (pat) {
   case PAT_UC:
-    return set_memory_uc(addr, numpages);
+    return set_memory_uc(addr,numpages);
   case PAT_WC:
-    return set_memory_wc(addr, numpages);
+    return set_memory_wc(addr,numpages);
   case PAT_WT:
-    return set_memory_wt(addr, numpages);
-  case PAT_WP:
-    return set_memory_wp(addr, numpages);
+    {
+      struct page **pages = kmalloc_array(sizeof(*pages),numpages,GFP_KERNEL);
+      if (!pages) return -1;
+      for (int k=0 ; k < numpages ; k++) {
+        pages[k] = virt_to_page(addr);
+        addr += PAGE_SIZE;
+      }
+      int ret = set_pages_array_wt(pages,numpages);
+      kfree(pages);
+      return ret ;
+    }
   case PAT_WB:
-    return set_memory_wb(addr, numpages);
+    return set_memory_wb(addr,numpages);
+  case PAT_WP:
   default:
     return -1; /* Should not happen */
   }
 }
 
 static void klitmus_free_pat(void *p,size_t sz) {
-  int np = npages(sz);
-  (void)set_memory_wb((unsigned long)p,1 << np);
-  free_pages((unsigned long)p,np);
+  int op = opages(sz);
+  (void)set_memory_wb((unsigned long)p,1 << op);
+  free_pages((unsigned long)p,op);
 }
 
 static void *klitmus_alloc_pat(pat_t pat, size_t sz) {
-  int np = npages(sz);
-  void *r = (void *)__get_free_pages(GFP_KERNEL,np);
+  int op = opages(sz);
+  void *r = (void *)__get_free_pages(GFP_KERNEL,op);
   if (!r) return r;
-  if (klitmus_set_memory(pat,(unsigned long)r,1 << np)) {
+  if (klitmus_set_memory(pat,(unsigned long)r,1 << op)) {
     klitmus_free_pat(r,sz);
     return NULL;
   }

--- a/litmus/libdir/_x86_64/klitmus_memory_type.c
+++ b/litmus/libdir/_x86_64/klitmus_memory_type.c
@@ -62,3 +62,7 @@ static void *klitmus_alloc_pat(pat_t pat, size_t sz) {
   }
   return r;
 }
+
+inline static void klitmus_flush_caches(void) {
+  asm __volatile__ ("wbinvd" ::: "memory");
+}

--- a/litmus/libdir/_x86_64/klitmus_memory_type.c
+++ b/litmus/libdir/_x86_64/klitmus_memory_type.c
@@ -1,0 +1,55 @@
+/**********************/
+/*  IA32 memory types */
+/**********************/
+
+/* Those x86 specific prototypes are not available in linux-headers package */
+
+int set_memory_uc(unsigned long addr,int numpages);
+int set_memory_wc(unsigned long addr,int numpages);
+int set_memory_wt(unsigned long addr,int numpages);
+int set_memory_wp(unsigned long addr,int numpages);
+int set_memory_wb(unsigned long addr,int numpages);
+
+typedef enum { PAT_UC, PAT_WC, PAT_WT, PAT_WP, PAT_WB, } pat_t ;
+
+static size_t npages(size_t sz) {
+  size_t r=0 ; size_t max=PAGE_SIZE;
+  while (sz > max) {
+    max *= 2; r++;
+  }
+  return r;
+}
+
+static int klitmus_set_memory(pat_t pat, unsigned long addr, int numpages) {
+  switch (pat) {
+  case PAT_UC:
+    return set_memory_uc(addr, numpages);
+  case PAT_WC:
+    return set_memory_wc(addr, numpages);
+  case PAT_WT:
+    return set_memory_wt(addr, numpages);
+  case PAT_WP:
+    return set_memory_wp(addr, numpages);
+  case PAT_WB:
+    return set_memory_wb(addr, numpages);
+  default:
+    return -1; /* Should not happen */
+  }
+}
+
+static void klitmus_free_pat(void *p,size_t sz) {
+  int np = npages(sz);
+  (void)set_memory_wb((unsigned long)p,1 << np);
+  free_pages((unsigned long)p,np);
+}
+
+static void *klitmus_alloc_pat(pat_t pat, size_t sz) {
+  int np = npages(sz);
+  void *r = (void *)__get_free_pages(GFP_KERNEL,np);
+  if (!r) return r;
+  if (klitmus_set_memory(pat,(unsigned long)r,1 << np)) {
+    klitmus_free_pat(r,sz);
+    return NULL;
+  }
+  return r;
+}

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -38,6 +38,7 @@ module type Config = sig
   val pad : int
   val ccopts : string list
   val sharelocks : int option
+  val sysarch : Archs.System.t
 end
 
 module Top(O:Config)(Tar:Tar.S) = struct
@@ -70,7 +71,7 @@ module Top(O:Config)(Tar:Tar.S) = struct
       else exit_not_compiled fname
 
 
-  module Utils(A:Arch_litmus.Base)
+  module Utils(A:Arch_litmus.Base)(MemType:MemoryType.S)
       (Lang:Language.S
       with type arch_reg = A.Out.arch_reg
       and type t = A.Out.t
@@ -86,7 +87,7 @@ module Top(O:Config)(Tar:Tar.S) = struct
             (fun chan ->
               let module Out =
                 Indent.Make(struct let hexa = O.hexa let out = chan end) in
-              let module S = KSkel.Make(O)(Pseudo)(A)(T)(Out)(Lang) in
+              let module S = KSkel.Make(O)(Pseudo)(A)(MemType)(T)(Out)(Lang) in
               S.dump doc compiled)
             outname
         with e ->
@@ -137,7 +138,7 @@ module Top(O:Config)(Tar:Tar.S) = struct
       module LISAComp = LISACompile.Make(V)
       module Pseudo = LitmusUtils.Pseudo(A)
       module Lang = LISALang.Make(V)
-      module Utils = Utils(A)(Lang)(Pseudo)
+      module Utils = Utils(A)(MemoryType.No)(Lang)(Pseudo)
       module P = GenParser.Make(OX)(A)(LexParse)
       module T = Utils.T
 
@@ -207,7 +208,7 @@ module Top(O:Config)(Tar:Tar.S) = struct
           let simple = true
           let out_ctx s = "_a->" ^ s
         end)
-    module Utils = Utils(A)(Lang)(Pseudo)
+    module Utils = Utils(A)(MemoryType.X86_64)(Lang)(Pseudo)
     module T = Utils.T
     module P = CGenParser_litmus.Make(OX)(Pseudo)(A)(LexParse)
     module CComp =


### PR DESCRIPTION
This PR implements IA-32 memory type specifications for `klitmus7`. Namely, changing memory types is doable from a kernel module and probably much more involved from user code.

Memory type specifications are given as  meta-data with key `MT` (or `MemoryType`) and values being list of pairs `<var>:<spec>`, where `<spec>` are IA-32 memory types `WC`, `UC`,  etc.

For instance here is test SB operating on uncached locations:
```
C SB+UC
MT=x:UC y:UC

{}

P0 (volatile int* y,volatile int* x) {
  *x = 1;
  int r0 = *y;
}

P1 (volatile int* y,volatile int* x) {
  *y = 1;
  int r0 = *x;
}

exists (0:r0=0 /\ 1:r0=0)
```