### PR TITLE
[herd] Fix iico-data dependancy in CAS equal case

### DIFF
--- a/herd/event.ml
+++ b/herd/event.ml
@@ -1821,7 +1821,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
              wm.intra_causality_data)
           (EventRel.union4
              (EventRel.cartesian (get_output rn) input_rm)    (* D1 *)
-             (EventRel.cartesian output_rs input_wrs)         (* Ds1 *)
+             (EventRel.cartesian output_rm input_wrs)         (* Ds1 *)
              (EventRel.cartesian (get_output rn) input_wm)    (* Ds2 *)
              (EventRel.cartesian (maximals rt) input_wm));    (* Ds3 *)
         intra_causality_control =


### PR DESCRIPTION
In CAS, the `rs` register provides the compared value and receives the value read from memory.
In the equal case, where the value read from memory and the one in the `rs` register are equal, the `iico-data` dependency that provided data to the write in the `rs` register was coming fromthe `rs` register, instead of coming from the value read in memory.

This probably has no impact because the two values are equal, and there is `iico-ctrl` dependencies from both events.

For a simple `CAS` instruction, before we can see the `iico-data` arrow between the events `e` and `g`:

![CAS](https://user-images.githubusercontent.com/19175393/114463328-946dba80-9be4-11eb-8a7d-09e4bcf2f040.png)

After, the arrow is between the events `a` and `g` (the events names are the same, only the layout changes):

![CAS-modified](https://user-images.githubusercontent.com/19175393/114463472-c3842c00-9be4-11eb-89ce-0b62c4a55d9c.png)
