### PR TITLE
[litmus] klitmus, add option `-barrier no`.

### DIFF
--- a/litmus/KBarrier.ml
+++ b/litmus/KBarrier.ml
@@ -17,15 +17,17 @@
 
 (* Barrier option *)
 
-type t = User | TimeBase
+type t = User | TimeBase | No
 
-let tags = ["user"; "timebase";]
+let tags = ["user"; "timebase";"no"]
 
 let parse tag = match Misc.lowercase tag with
 | "user" -> Some User
 | "timebase"|"tb" -> Some TimeBase
+| "no"|"none" -> Some No
 | _ -> None
 
 let pp = function
 | User -> "user"
 | TimeBase  -> "timebase"
+| No -> "no"

--- a/litmus/KBarrier.mli
+++ b/litmus/KBarrier.mli
@@ -17,7 +17,7 @@
 
 (* Barrier option *)
 
-type t = User | TimeBase
+type t = User | TimeBase | No
 
 val tags : string list
 val parse : string -> t option

--- a/litmus/libdir/kbarrier-tb.txt
+++ b/litmus/libdir/kbarrier-tb.txt
@@ -16,7 +16,7 @@ static sense_t *alloc_sense(void) {
   return r;
 }
 
-static void barrier_init (sense_t *p) {
+static void sense_init (sense_t *p) {
   atomic_set(&(p->c),nthreads) ;
   p->sense = 0;
 }
@@ -24,7 +24,7 @@ static void barrier_init (sense_t *p) {
 static const int busy_n1_0 = 64*1024;
 static const int busy_n2_0 = 1024;
 
-static void barrier_wait(sense_t *p) {
+static void sense_wait(sense_t *p) {
   int sense = READ_ONCE(p->sense) ;
   int last ;
 


### PR DESCRIPTION
This option commands absence of synchronisation for the test loop. Intended use is debug.