### PR TITLE
[litmus] Klitmus x86 64

### DIFF
--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -19,6 +19,7 @@ module type Config = sig
   val cautious : bool
   val mode : Mode.t
   val asmcommentaslabel : bool
+  val noinline : bool
 end
 
 module type I = sig
@@ -546,7 +547,7 @@ module RegMap = A.RegMap)
               let x = Tmpl.dump_out_reg proc x in
               sprintf "%s *%s" (CType.dump ty) x) t.Tmpl.final in
         let params =  String.concat "," (params0@labels@addrs@ptes@phys@ptevals@cpys@outs) in
-        LangUtils.dump_code_def chan true proc params ;
+        LangUtils.dump_code_def chan O.noinline proc params ;
         do_dump
           args0
           (compile_init_val_fun ptevalEnv)
@@ -588,7 +589,7 @@ module RegMap = A.RegMap)
         sprintf "&_a->%s[_i]" (Tmpl.addr_cpy_name x proc)
 
       let compile_out_reg_call_std proc reg =
-        sprintf "&%s" (Tmpl.compile_out_reg proc reg)
+        sprintf "&_a->%s" (Tmpl.compile_out_reg proc reg)
 
       let compile_out_reg_call_kvm env proc reg =
         let ty =

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -1816,19 +1816,13 @@ module Make
               O.oi "int _stride = _a->_p->stride;"
             end ;
             let addrs = A.Out.get_addrs_only out in
-            (*
+            if not do_ascall then begin
               List.iter
-              (fun a ->
-              let t = find_global_type a env in
-              O.fi "%s *%s = _a->%s;" (dump_global_type t) a a)
-              addrs ;
-             *)
-            List.iter
-              (fun (r,t) ->
-                let name = A.Out.dump_out_reg  proc r in
-                O.fi "%s *%s = _a->%s;" (CType.dump t) name name)
-              outregs ;
-
+                (fun (r,t) ->
+                  let name = A.Out.dump_out_reg  proc r in
+                  O.fi "%s *%s = _a->%s;" (CType.dump t) name name)
+                outregs
+            end;
             let iloop =
               if Stride.some stride then begin
                 O.fi "for (int _j = _stride ; _j > 0 ; _j--) {" ;

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -122,6 +122,7 @@ module type Config = sig
   val limit : bool
   val sysarch : Archs.System.t
   val word : Word.t
+  val noinline : bool
 end
 
 module Top (OT:TopConfig) (Tar:Tar.S) : sig
@@ -444,6 +445,7 @@ end = struct
               | _ ->
                 Warn.fatal "no support for arch '%s'" (Archs.pp arch)
             end
+          let noinline = true
           end in
         let aux = function
           | `PPC ->


### PR DESCRIPTION
This PR improves klitmus, so that it can handle tests written in assembly. This is a straightforward technique to run tests free of compiler interference.