### PR TITLE
[litmus] Klitmus nt

### DIFF
--- a/litmus/X86_64Compile_litmus.ml
+++ b/litmus/X86_64Compile_litmus.ml
@@ -14,7 +14,12 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-module Make(V:Constant.S)(O:Arch_litmus.Config) =
+module type Config = sig
+  val sse: bool
+  val reason : string
+end
+
+module Make(Cfg:Config)(V:Constant.S)(O:Arch_litmus.Config) =
   struct
     module A = X86_64Arch_litmus.Make(O)(V)
     open A
@@ -278,7 +283,9 @@ module Make(V:Constant.S)(O:Arch_litmus.Config) =
     | I_CMPXCHG (_, ea, r) as i-> cmpxchg (inst_string i) ea r
     | I_MOVNTI (sz,ea,r) -> movnti sz ea r
     | I_MOVD (sz,r,xmm) -> movd sz r xmm
-    | I_MOVNTDQA (xmm,ea) -> movntdqa xmm ea
+    | I_MOVNTDQA (xmm,ea) ->
+        if Cfg.sse then movntdqa xmm ea
+        else Warn.user_error "SSE not enabled for %s" Cfg.reason
 (* here I fail to know *)
     | I_CMOVC _ -> Warn.user_error "CMOVC ??"
 

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -256,7 +256,10 @@ module Top(O:Config)(Tar:Tar.S) = struct
       let parser = MiscParser.mach2generic X86_64Parser.main
     end
 
-    module XXXComp = X86_64Compile_litmus.Make(V)(OC)
+    module XXXComp =
+      X86_64Compile_litmus.Make
+        (struct let sse = false let reason = "klitmus" end)
+        (V)(OC)
 
     module Pseudo = LitmusUtils.Pseudo(A)
 

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -502,7 +502,15 @@ end = struct
                  let lexer = Lexer.token
                  let parser = MiscParser.mach2generic X86_64Parser.main
                end in
-             let module Compile = X86_64Compile_litmus.Make(V)(OC) in
+             let module X86_64Config = struct
+                 let sse =
+                   match OT.mode with
+                   | Mode.Kvm -> false
+                   | Mode.PreSi|Mode.Std -> true
+                 let reason = "-mode kvm"
+               end in
+             let module Compile =
+               X86_64Compile_litmus.Make(X86_64Config)(V)(OC) in
              let module X = Make(Cfg)(Arch')(LexParse)(Compile) in
              X.compile
           | `ARM ->


### PR DESCRIPTION
All tools now understand alignment constraints from test meta-data. Unfortunately it does not suffice to implement X86_64 `movntdqa` instruction for all tools as the kernel and kvm-unit-tests do not support SSE.