### PR TITLE
[herd] Fix iico, avoid generating some unwanted iico_data.

### DIFF
--- a/herd/event.ml
+++ b/herd/event.ml
@@ -289,7 +289,11 @@ val same_instance : event -> event -> bool
     -> event_structure -> event_structure -> event_structure option
 
 (* sequential composition, add data dependency *)
-  val (=*$=) :
+
+  val (=*$=) : (* second es entries are minimal evts for iico_data *)
+      event_structure -> event_structure -> event_structure option
+
+  val data_to_minimals : (* second es entries are minimal evts all iico *)
       event_structure -> event_structure -> event_structure option
 
 (* Identical, keep first event structure output as output... *)
@@ -1040,6 +1044,9 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
 
     let (=*$=) =
       check_disjoint (data_comp minimals_data sequence_data_output)
+
+    let data_to_minimals =
+      check_disjoint (data_comp minimals sequence_data_output)
 
     let (=$$=) =
       let out es1 es2 =

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -227,6 +227,8 @@ Monad type:
       assert (cl=[]) ;
       data_comp (E.bind_ctrl_avoid es.E.events) s f eiid
 
+    let bind_data_to_minimals s f =  data_comp E.data_to_minimals s f
+
 (* Triple composition *)
     let comp_comp comp_str m1 m2 m3 eiid =
       let eiid,(acts1,spec1) = m1 eiid in

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -43,15 +43,21 @@ module type S =
     val delay_kont : string -> 'a t -> ('a ->  'a t -> 'b t) -> 'b t
     val delay : 'a t -> ('a * 'a t) t
 
+(* Data composition, entry for snd monad: minimals for iico_data *)
     val (>>=) : 'a t -> ('a -> 'b t) -> ('b) t
+
     val (>>==) : 'a t -> ('a -> 'b t) -> ('b) t (* Output event stay in first arg *)
     val (>>*=) : 'a t -> ('a -> 'b t) -> ('b) t
     val (>>*==) : 'a t -> ('a -> 'b t) -> ('b) t (* Output event stay in first argument *)
     (* Control composition, avoid events from first argument) *)
     val bind_ctrl_avoid : 'c t -> 'a t -> ('a -> 'b t) -> 'b t
 
+    (* Data composition, entry for snd monad: minimals for complete iico *)
+    val bind_data_to_minimals : 'a t -> ('a -> 'b t) -> ('b) t
+
     (* Hybrid composition m1 m2 m3, m1 -ctrl-> m3 and m2 -data-> m3 *)
     val bind_ctrl_data : 'a t -> 'b t -> ('a -> 'b -> 'c t) -> 'c t
+
 
     val check_tags : 'v t -> ('v -> 'v t) -> ('v -> 'v t) -> 'x t -> 'v t
     val exch : 'a t -> 'a t -> ('a -> 'b t) ->  ('a -> 'c t) ->  ('b * 'c) t


### PR DESCRIPTION
The unwanted `iico_data` relations were from page table entry read to fault event, in the case when the access fails.