### PR TITLE
[litmus] klitmus, more precise synchronisation barrier.

### DIFF
--- a/litmus/klitmus.ml
+++ b/litmus/klitmus.ml
@@ -54,6 +54,8 @@ module KOption : sig
   val affinity : KAffinity.t ref
   val ccopts : string list ref
   val sharelocks : int option ref
+  val delay : int ref
+
   val carch : Archs.System.t option ref
   val set_carch : Archs.System.t -> unit
 end = struct
@@ -66,6 +68,7 @@ end = struct
   let affinity = ref KAffinity.No
   let ccopts = ref []
   let sharelocks = ref None
+  let delay = ref 256
   let carch = ref (Some `X86_64)
 end
 
@@ -100,6 +103,9 @@ let opts =
    PStride.parse "-stride" KOption.stride "stride for scanning memory" ;
    begin let module P = ParseTag.Make(KBarrier)  in
    P.parse "-barrier" KOption.barrier "synchronisation barrier style" end;
+   "-delay", Arg.Int (fun i -> KOption.delay := i),
+   sprintf
+     "set timebase delay (default %i)" !KOption.delay;
 (* number if shared spinlocks and srcu_struct *)
    "-share_locks", arginto KOption.sharelocks,
      "<n> number of spinlock_t's and srcu)_structs to share between test instances (default, do not share)";
@@ -190,6 +196,7 @@ let () =
       let pad = !pad
       let ccopts = !ccopts
       let sharelocks = !sharelocks
+      let delay = !delay
       let sysarch = Misc.as_some !carch
 (* tar stuff *)
       let tarname = KOption.get_tar ()

--- a/litmus/libdir/kbarrier-tb.txt
+++ b/litmus/libdir/kbarrier-tb.txt
@@ -3,6 +3,9 @@
 typedef struct {
   atomic_t c;
   int sense;
+#ifdef TIMEBASE
+  tb_t tb;
+#endif
 } sense_t;
 
 static void free_sense(sense_t *p) {
@@ -32,6 +35,9 @@ static void sense_wait(sense_t *p) {
   last = atomic_dec_and_test(&(p->c)) ;
   smp_mb() ;
   if (last) {
+#ifdef TIMEBASE
+  p->tb = read_timebase();
+#endif
     atomic_set(&p->c,nthreads) ;
     smp_mb() ;
     WRITE_ONCE(p->sense,1-sense);
@@ -49,4 +55,10 @@ static void sense_wait(sense_t *p) {
     }
     smp_mb() ;
   }
+#ifdef TIMEBASE
+  tb_t limit = p->tb + delay_tb;
+  for ( ; ; ) {
+    if (read_timebase() >= limit) break;
+  }
+#endif
 }

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -38,6 +38,7 @@ module type Config = sig
   val pad : int
   val ccopts : string list
   val sharelocks : int option
+  val delay : int
   val sysarch : Archs.System.t
 end
 


### PR DESCRIPTION
Barrier "tb" now use the time stamp counter, if available.
Delay is first set statically by option `-delay <N>`. It can
be changed at launch time with the kernel module style
command line option `delay_tb=<N>`.