### PR TITLE
[litmus] Klitmus fix

### DIFF
--- a/lib/Archs.mli
+++ b/lib/Archs.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2012-present Institut National de Recherche en Informatique et *)
+(* Copyright 2013-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,40 +14,58 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(*********************************)
-(* Dump or run a series of tests *)
-(*********************************)
+(** Implemented archituctures *)
 
-open Answer
+module System : sig
 
-module type Config = sig
-  val carch : Archs.System.t
-  val platform : string
-  val makevar : string list
-  val gcc : string
-  val stdio : bool
-  val index : string option
-  val crossrun : Crossrun.t
-  val adbdir : string
-  val sleep : int
-  val tarname : string
-  val driver : Driver.t
-  val cross : bool
-  val hexa : bool
-  val threadstyle : ThreadStyle.t
-  val asmcommentaslabel : bool
-  include RunUtils.CommonConfig
-  val mkopt : Option.opt -> Option.opt
-  val variant : Variant_litmus.t -> bool
-  val nocatch : bool
+  (* Native architectures *)
+    type arch = [
+    | `AArch64
+    | `ARM
+    | `MIPS
+    | `PPC
+    | `X86
+    | `RISCV
+    | `X86_64
+    ]
+
+  (* Native architecture may be unknown, some features
+     will notbe available *)
+    type t = [ arch | `Unknown ]
+
+    val tags : string list
+
+    val parse : string -> t option
+
+    val pp : t -> string
+
 end
 
+(* All implement architectures *)
+type t = [
+    System.arch
+  | `C
+  | `CPP
+  | `LISA
+  ]
 
-module type OneTest = sig
-  val from_file :
-      StringSet.t -> hash_env-> string -> out_channel -> answer
-end
+val tags : string list
 
-module Make :
-  functor (O:Config) -> functor(Tar : Tar.S) -> functor (CT : OneTest) ->
-  sig val from_files : string list -> unit end
+val parse : string -> t option
+val pp : t -> string
+
+val compare : t -> t -> int
+
+val  aarch64 : t
+val  arm : t
+val  mips : t
+val  ppc : t
+val  x86 : t
+val  riscv : t
+val  c : t
+val  cpp : t
+val  lisa : t
+val  x86_64 : t
+
+val get_sysarch : [< t ] ->  System.t -> System.t
+val check_carch : [< System.t ] -> System.arch

--- a/lib/splitter.mll
+++ b/lib/splitter.mll
@@ -78,7 +78,11 @@ and main start = parse
   ( ('\n'? as line) blank*'"'([^'"']* as doc) '"' blank*) ? (* '"' *)
   ';' ?
   { begin match line with Some _ -> incr_lineno lexbuf | None -> () end ;
-    let arch = Archs.lex arch in
+    let arch =
+      match Archs.parse arch with
+      | Some a -> a
+      | None ->
+        Warn.user_error "%s is not an implemented architecture" arch in
     let (info,init1,(init2,prog1)) = find_init [] lexbuf in
     let do_skip_comments = match arch with
     | `C|`CPP -> false (* We can't skip comments in C, because "(*" is legal and frequent syntax *)

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -56,11 +56,7 @@ module Make
 (* Arch dependant *)
 (******************)
 
-    module Insert =
-      ObjUtil.Insert
-        (struct
-          let sysarch = Cfg.sysarch
-        end)
+    module Insert = ObjUtil.Insert(Cfg)
 
     let memtype_possible = Insert.exists "klitmus_memory_type.c"
     let timebase_possible = Insert.exists "timebase.c"

--- a/litmus/klitmus.ml
+++ b/litmus/klitmus.ml
@@ -56,7 +56,7 @@ module KOption : sig
   val sharelocks : int option ref
   val delay : int ref
 
-  val carch : Archs.System.t option ref
+  val carch : Archs.System.t ref
   val set_carch : Archs.System.t -> unit
 end = struct
   include Option
@@ -69,7 +69,6 @@ end = struct
   let ccopts = ref []
   let sharelocks = ref None
   let delay = ref 256
-  let carch = ref (Some `X86_64)
 end
 
 open KOption
@@ -197,7 +196,7 @@ let () =
       let ccopts = !ccopts
       let sharelocks = !sharelocks
       let delay = !delay
-      let sysarch = Misc.as_some !carch
+      let carch = !carch
 (* tar stuff *)
       let tarname = KOption.get_tar ()
     end in

--- a/litmus/libdir/_ppc/timebase.c
+++ b/litmus/libdir/_ppc/timebase.c
@@ -1,0 +1,1 @@
+timebase64.c

--- a/litmus/objUtil.ml
+++ b/litmus/objUtil.ml
@@ -69,13 +69,14 @@ module Insert (O:InsertConfig) :
   struct
 
     let dir = match O.sysarch with
-    | `X86 -> "_x86"
-    | `X86_64 -> "_x86_64"
-    | `PPC -> "_ppc"
-    | `ARM -> "_arm"
-    | `MIPS -> "_mips"
-    | `AArch64 -> "_aarch64"
-    | `RISCV -> "_riscv"
+      | `X86 -> "_x86"
+      | `X86_64 -> "_x86_64"
+      | `PPC -> "_ppc"
+      | `ARM -> "_arm"
+      | `MIPS -> "_mips"
+      | `AArch64 -> "_aarch64"
+      | `RISCV -> "_riscv"
+      | `Unknown -> "_none"
 
     let find_lib src =
       let n1 = Filename.concat dir src in
@@ -114,7 +115,7 @@ module type Config = sig
   val driver : Driver.t
   val affinity : Affinity.t
   val arch : Archs.t
-  val carch   : Archs.System.t option
+  val sysarch   : Archs.System.t
   val mode : Mode.t
   val stdio : bool
   val platform : string
@@ -204,10 +205,7 @@ module Make(O:Config)(Tar:Tar.S) =
           let fnames = cpy' ~prf:"#define KVM 1" fnames "presi" "utils" ".c" in
           let fnames = cpy' ~prf:"#define KVM 1" fnames "presi" "utils" ".h" in
           let fnames = cpy fnames "kvm_timeofday" ".h" in
-          let sysarch = match Archs.get_sysarch O.arch O.carch with
-          | Some a -> a
-          | None -> assert false in
-          let module I = Insert(struct let sysarch = sysarch end) in
+          let module I = Insert(O) in
           I.copy "kvm_timeofday.c" Tar.outname ;
           I.copy "kvm-headers.h" Tar.outname ;
           fnames in

--- a/litmus/option.ml
+++ b/litmus/option.ml
@@ -169,7 +169,7 @@ let syncconst = 128
 let syncmacro = ref (-1)
 let xy = ref false
 let morearch = ref MoreArch.No
-let carch = ref None
+let carch = ref `Unknown
 let mode = ref Mode.Std
 let usearch = ref UseArch.Trad
 let precision = ref false
@@ -228,7 +228,7 @@ let get_word opt = opt.word
 let set_line w = replace_config (fun o ->  { o with line = w; })
 let get_line opt = opt.line
 
-let set_carch x = carch := Some x
+let set_carch x = carch := x
 
 (* More *)
 

--- a/litmus/option.mli
+++ b/litmus/option.mli
@@ -117,7 +117,7 @@ val xy : bool ref
 val morearch : MoreArch.t ref
 val pldw : bool ref
 val cacheflush : bool ref
-val carch : Archs.System.t option ref
+val carch : Archs.System.t ref
 val mode : Mode.t ref
 val usearch : UseArch.t ref
 val precision : bool ref

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -94,9 +94,7 @@ module Make
 
       let have_timebase =
         Cfg.is_tb &&
-        (timebase_possible ||
-        (Warn.user_error
-           "No timebase for arch %s" (Archs.pp  Cfg.sysarch)))
+        (timebase_possible || SkelUtil.no_timebase_error Cfg.sysarch)
 
       let have_cache = Insert.exists "cache.c"
 
@@ -383,19 +381,8 @@ module Make
       let lab_ext = if Cfg.numeric_labels then "" else "_lab"
 
       let dump_barrier_def () =
-        let fname =
-          function
-            | `PPC
-            | `X86
-            | `X86_64
-            | `ARM
-            | `MIPS
-            | `AArch64
-            | `RISCV
-              ->
-               sprintf "barrier%s.c" lab_ext
-            | _ -> assert false in
-        Insert.insert O.o (fname Cfg.sysarch)
+        let fname =  sprintf "barrier%s.c" lab_ext in
+        Insert.insert O.o fname
 
 (**************)
 (* Topologies *)

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -26,6 +26,15 @@ module type Config = sig
   val have_fault_handler : bool
 end
 
+let no_timebase_error sysarch =
+  match sysarch with
+  | #Archs.System.arch ->
+      Warn.user_error
+        "No timebase for arch %s" (Archs.System.pp sysarch)
+  | `Unknown ->
+      Warn.user_error
+        "Timebase not available for C without option -carch <arch>"
+
 type stat =
     { tags : string list ;
       name : string ;

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -39,7 +39,7 @@ module type Config = sig
   val ccopts : string list
   val sharelocks : int option
   val delay : int
-  val sysarch : Archs.System.t
+  val carch : Archs.System.t
 end
 
 module Top(O:Config)(Tar:Tar.S) = struct
@@ -80,7 +80,10 @@ module Top(O:Config)(Tar:Tar.S) = struct
       (Pseudo:PseudoAbstract.S) =
     struct
       module T = Test_litmus.Make(O)(A)(Pseudo)
-
+      module O = struct
+        include O
+        let sysarch = Archs.get_sysarch A.arch O.carch
+      end
       let dump source doc compiled =
         let outname = Tar.outname source in
         try

--- a/litmus/top_litmus.mli
+++ b/litmus/top_litmus.mli
@@ -58,7 +58,7 @@ module type CommonConfig = sig
   val pldw : bool
   val cacheflush : bool
   val morearch : MoreArch.t
-  val carch : Archs.System.t option
+  val carch : Archs.System.t
   val syncconst : int
   val numeric_labels : bool
   val kind : bool


### PR DESCRIPTION
Option `-carch <arch>` was not working properly.

Fixed by a more rational approach to combining the arch read from tests and the one given as an argument to `-carch`.
 