### PR TITLE
[herd] Add support for assertions in cat

### DIFF
--- a/lib/AST.mli
+++ b/lib/AST.mli
@@ -79,7 +79,7 @@ and binding = TxtLoc.t * pat * exp
 
 type do_test = Acyclic | Irreflexive | TestEmpty
 type test = Yes of do_test | No of do_test
-type test_type = Flagged | UndefinedUnless | Check
+type test_type = Flagged | UndefinedUnless | Check | Assert
 type app_test = TxtLoc.t * pos * test * exp * string option
 type is_rec = IsRec | IsNotRec
 

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -168,7 +168,7 @@ module Make
 
     let check_through test_type ok = match test_type with
     | Check ->  U.check_through ok
-    | UndefinedUnless|Flagged -> ok
+    | UndefinedUnless|Flagged|Assert -> ok
 
 
 (*  Model interpret *)
@@ -2474,7 +2474,7 @@ module Make
                           then show_cycle st tst ;
                           if ok then
                             match test_type with
-                            | Check|UndefinedUnless -> kont st res
+                            | Check|UndefinedUnless|Assert -> kont st res
                             | Flagged ->
                                 begin match name with
                                 | None ->
@@ -2503,7 +2503,15 @@ module Make
                               | UndefinedUnless ->
                                   kont {st with flags=Flag.Set.add Flag.Undef st.flags;} res
                               | Flagged -> kont st res
-                            end
+                              | Assert ->
+                                 let a = match name with
+                                   | None ->
+                                      "(unknown)"
+                                   | Some name ->
+                                      name
+                                 in
+                                 Warn.user_error "%s assertion failed, check input test." a
+                              end
                           end else begin
                             W.warn "Skipping check %s" (Misc.as_some name) ;
                             kont st res

--- a/lib/modelLexer.mll
+++ b/lib/modelLexer.mll
@@ -40,6 +40,7 @@ module LU = LexUtils.Make(O)
     | "in" -> IN
     | "undefined_unless" -> REQUIRES (* jade: deprecated?, indeed but still here ! *)
     | "flag" -> FLAG
+    | "assert" -> ASSERT
     | "include" -> INCLUDE
     | "variant" -> VARIANT
     | "begin" -> BEGIN

--- a/lib/modelParser.mly
+++ b/lib/modelParser.mly
@@ -54,7 +54,7 @@ let tuple_pat = function
 %token SHOW UNSHOW AS FUN IN PROCEDURE CALL FORALL DO FROM
 %token TRY INSTRUCTIONS DEFAULT IF THEN ELSE
 %token VARIANT
-%token REQUIRES FLAG
+%token REQUIRES FLAG ASSERT
 %token ARROW
 %token ENUM DEBUG MATCH WITH
 %token CATDEP
@@ -181,6 +181,7 @@ test_type:
 |          { Check }
 | REQUIRES { UndefinedUnless }
 | FLAG     { Flagged }
+| ASSERT   { Assert }
 
 optional_name:
 |        { None }


### PR DESCRIPTION
Typically rules specified in cat files limit allowed executions of a
litmus test. This patch adds support for also turning the same rules
into assertions that exit the simulation with an error message.

Signed-off-by: Nikos Nikoleris <nikos.nikoleris@arm.com>