### PR TITLE
[herd] Actions that depend on arch.

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -225,9 +225,17 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
         end)
 
-
     module MemType = MemoryType.No
 
-    module ArchAction = ArchAction.No
+    module NoConf = struct
+      type v = V.v
+      type loc = location
+      type value_set = V.ValueSet.t
+      type solution = V.solution
+      type arch_lannot = lannot
+      type arch_explicit = explicit
+    end
+
+    module ArchAction = ArchAction.No(NoConf)
 
   end

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -225,5 +225,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
         end)
 
+
     module MemType = MemoryType.No
+
+    module ArchAction = ArchAction.No
+
   end

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -82,6 +82,15 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     module MemType=MemoryType.No
 
-    module ArchAction = ArchAction.No
+    module NoConf = struct
+      type v = V.v
+      type loc = location
+      type value_set = V.ValueSet.t
+      type solution = V.solution
+      type arch_lannot = lannot
+      type arch_explicit = explicit
+    end
+
+    module ArchAction = ArchAction.No(NoConf)
 
   end

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -82,4 +82,6 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     module MemType=MemoryType.No
 
+    module ArchAction = ArchAction.No
+
   end

--- a/herd/ARMSem.ml
+++ b/herd/ARMSem.ml
@@ -82,18 +82,18 @@ module Make (C:Sem.Config)(V:Value.S)
 
       let write_reg r v ii =
         M.mk_singleton_es
-          (Act.Access (Dir.W, (A.Location_reg (ii.A.proc,r)), v, false, ARM.exp_annot, reg_sz, Act.A_REG))
+          (Act.Access (Dir.W, (A.Location_reg (ii.A.proc,r)), v, false, ARM.exp_annot, reg_sz, Access.REG))
           ii
 
       let write_mem sz a v ii  =
         M.mk_singleton_es
-          (Act.Access (Dir.W, A.Location_global a, v, false, (), sz, Act.A_VIR))
+          (Act.Access (Dir.W, A.Location_global a, v, false, (), sz, Access.VIR))
           ii
 
       let write_mem_atomic sz a v resa ii =
         let eq = [M.VC.Assign (a,M.VC.Atom resa)] in
         M.mk_singleton_es_eq
-          (Act.Access (Dir.W, A.Location_global a, v, true, (), sz, Act.A_VIR))
+          (Act.Access (Dir.W, A.Location_global a, v, true, (), sz, Access.VIR))
           eq ii
 
       let write_flag r o v1 v2 ii =

--- a/herd/ARMSem.ml
+++ b/herd/ARMSem.ml
@@ -309,4 +309,5 @@ module Make (C:Sem.Config)(V:Value.S)
       let spurious_setaf _ = assert false
 
     end
+
   end

--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -205,11 +205,9 @@ end = struct
   let undetermined_vars_in_action a =
     match a with
     | Access (_,l,v,_,_,_) ->
-        let undet_loc = match A.undetermined_vars_in_loc l with
-        | None -> V.ValueSet.empty
-        | Some v -> V.ValueSet.singleton v in
-        if V.is_var_determined v then undet_loc
-        else V.ValueSet.add v undet_loc
+        V.ValueSet.union
+          (A.undetermined_vars_in_loc l)
+          (V.undetermined_vars v)
     | Barrier _|Commit|TooFar -> V.ValueSet.empty
 
   let simplify_vars_in_action soln a =

--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -107,20 +107,11 @@ end = struct
   | Access (_,A.Location_global _,_,_,_,_)   -> true
   | _ -> false
 
-  let is_pt a = match a with
-    | Access (_,A.Location_global (A.V.Val c),_,_,_,_)   ->
-        Constant.is_pt c
-    | _ -> false
 
 (* None of those below *)
   let is_tag _ = false
-  let is_mem_physical a = let open Constant in match a with
-  | Access (_,A.Location_global (V.Val (Symbolic (Physical _))),_,_,_,_)   -> true
-  | _ -> false
 
   let is_additional_mem _ = false
-
-  let is_PA_val _ = false
 
   (* Unimplemented *)
   let is_implicit_pte_read _ = assert false

--- a/herd/BellArch_herd.ml
+++ b/herd/BellArch_herd.ml
@@ -51,6 +51,4 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
 
     module MemType=MemoryType.No
 
-    module ArchAction = ArchAction.No
-
   end

--- a/herd/BellArch_herd.ml
+++ b/herd/BellArch_herd.ml
@@ -51,4 +51,6 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
 
     module MemType=MemoryType.No
 
+    module ArchAction = ArchAction.No
+
   end

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -351,30 +351,20 @@ end = struct
     match a with
     | Access (_,l,v,_,_,_)
     | SRCU (l,_,Some v) ->
-        let undet_loc = match A.undetermined_vars_in_loc l with
-        | None -> V.ValueSet.empty
-        | Some v -> V.ValueSet.singleton v in
-        if V.is_var_determined v then undet_loc
-        else V.ValueSet.add v undet_loc
+        V.ValueSet.union
+          (A.undetermined_vars_in_loc l)
+          (V.undetermined_vars v)
     | RMW(l,v1,v2,_,_) ->
-        let undet_loc = match A.undetermined_vars_in_loc l with
-        | None -> V.ValueSet.empty
-        | Some v -> V.ValueSet.singleton v in
-        let undet_loc =
-          (if V.is_var_determined v1 then undet_loc
-          else V.ValueSet.add v1 undet_loc) in
-        let undet_loc =
-          (if V.is_var_determined v2 then undet_loc
-          else V.ValueSet.add v2 undet_loc) in
-        undet_loc
+        V.ValueSet.union3
+          (A.undetermined_vars_in_loc l)
+          (V.undetermined_vars v1)
+          (V.undetermined_vars v2)
     | TryLock (l)
     | Lock(l,_)
     | Unlock (l,_)
     | ReadLock (l,_)
     | SRCU(l,_,None) ->
-        (match A.undetermined_vars_in_loc l with
-        | None -> V.ValueSet.empty
-        | Some v -> V.ValueSet.singleton v)
+        A.undetermined_vars_in_loc l
     | Fence _|TooFar -> V.ValueSet.empty
 
   let simplify_vars_in_action soln a =

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -169,19 +169,11 @@ end = struct
   | RMW (A.Location_global _,_,_,_,_) -> true
   | _ -> false
 
-  let is_pt _ = false
   let is_tag _ = false
-
-  let is_mem_physical a = let open Constant in match a with
-  | Access (_,A.Location_global (V.Val (Symbolic (Physical _))),_,_,_,_)
-  | RMW (A.Location_global (V.Val (Symbolic (Physical _))),_,_,_,_) -> true
-  | _ -> false
 
   let is_additional_mem a = match a with
   | Lock _|Unlock _|TryLock _|ReadLock _ -> true
   | _ -> false
-
-  let is_PA_val _ = false
 
   (* Unimplemented *)
   let is_implicit_pte_read _ = assert false

--- a/herd/CArch_herd.ml
+++ b/herd/CArch_herd.ml
@@ -44,4 +44,6 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
 
     module MemType=MemoryType.No
 
+    module ArchAction = ArchAction.No
+
 end

--- a/herd/CArch_herd.ml
+++ b/herd/CArch_herd.ml
@@ -44,6 +44,4 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
 
     module MemType=MemoryType.No
 
-    module ArchAction = ArchAction.No
-
 end

--- a/herd/MIPSArch_herd.ml
+++ b/herd/MIPSArch_herd.ml
@@ -65,6 +65,15 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     module MemType=MemoryType.No
 
-    module ArchAction = ArchAction.No
+    module NoConf = struct
+      type v = V.v
+      type loc = location
+      type value_set = V.ValueSet.t
+      type solution = V.solution
+      type arch_lannot = lannot
+      type arch_explicit = explicit
+    end
+
+    module ArchAction = ArchAction.No(NoConf)
 
   end

--- a/herd/MIPSArch_herd.ml
+++ b/herd/MIPSArch_herd.ml
@@ -65,4 +65,6 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     module MemType=MemoryType.No
 
+    module ArchAction = ArchAction.No
+
   end

--- a/herd/MIPSSem.ml
+++ b/herd/MIPSSem.ml
@@ -73,17 +73,17 @@ module Make (C:Sem.Config)(V:Value.S)
       | _ ->
           M.mk_singleton_es
             (Act.Access
-               (Dir.W, (A.Location_reg (ii.A.proc,r)), v, false, (), nat_sz, Act.A_REG))
+               (Dir.W, (A.Location_reg (ii.A.proc,r)), v, false, (), nat_sz, Access.REG))
             ii
 
       let write_mem sz a v ii  =
         M.mk_singleton_es
-          (Act.Access (Dir.W, A.Location_global a, v, false, (), sz, Act.A_VIR)) ii
+          (Act.Access (Dir.W, A.Location_global a, v, false, (), sz, Access.VIR)) ii
 
       let write_mem_atomic sz a v resa ii =
         let eq = [M.VC.Assign (a,M.VC.Atom resa)] in
         M.mk_singleton_es_eq
-          (Act.Access (Dir.W, A.Location_global a, v, true, (), sz, Act.A_VIR))
+          (Act.Access (Dir.W, A.Location_global a, v, true, (), sz, Access.VIR))
           eq ii
 
       let create_barrier b ii =

--- a/herd/PPCArch_herd.ml
+++ b/herd/PPCArch_herd.ml
@@ -89,4 +89,6 @@ module Make (C:Arch_herd.Config) (V:Value.S)
 
     module MemType=MemoryType.No
 
+    module ArchAction = ArchAction.No
+
   end

--- a/herd/PPCArch_herd.ml
+++ b/herd/PPCArch_herd.ml
@@ -89,6 +89,15 @@ module Make (C:Arch_herd.Config) (V:Value.S)
 
     module MemType=MemoryType.No
 
-    module ArchAction = ArchAction.No
+    module NoConf = struct
+      type v = V.v
+      type loc = location
+      type value_set = V.ValueSet.t
+      type solution = V.solution
+      type arch_lannot = lannot
+      type arch_explicit = explicit
+    end
+
+    module ArchAction = ArchAction.No(NoConf)
 
   end

--- a/herd/PPCSem.ml
+++ b/herd/PPCSem.ml
@@ -76,16 +76,16 @@ module Make (C:Sem.Config)(V:Value.S)
 
       let write_reg r v ii =
         M.mk_singleton_es
-          (Act.Access (Dir.W, (A.Location_reg (ii.A.proc,r)), v, false, (), nat_sz,Act.A_REG)) ii
+          (Act.Access (Dir.W, (A.Location_reg (ii.A.proc,r)), v, false, (), nat_sz,Access.REG)) ii
 
       let do_write_mem sz ato a v ii =
         if mixed then
           Mixed.write_mixed sz
-            (fun sz loc v -> Act.Access (Dir.W, loc , v, ato, (), sz, Act.A_VIR))
+            (fun sz loc v -> Act.Access (Dir.W, loc , v, ato, (), sz, Access.VIR))
             a v ii
         else
           M.mk_singleton_es
-            (Act.Access (Dir.W, A.Location_global a, v, ato, (), sz, Act.A_VIR)) ii
+            (Act.Access (Dir.W, A.Location_global a, v, ato, (), sz, Access.VIR)) ii
 
       let write_mem sz a v ii = do_write_mem sz false a v ii
       let write_mem_atomic sz a v ii = do_write_mem sz true a v ii
@@ -109,7 +109,7 @@ module Make (C:Sem.Config)(V:Value.S)
           [M.VC.Assign (a, M.VC.Atom ar);
            M.VC.Assign (rr,M.VC.Atom V.one)] in
         M.mk_singleton_es_eq
-          (Act.Access (Dir.W, A.Location_global a, v, true, (), sz, Act.A_VIR)) (* a rr ar *) eq ii
+          (Act.Access (Dir.W, A.Location_global a, v, true, (), sz, Access.VIR)) (* a rr ar *) eq ii
 
       let read_addr a ii = read_mem a ii
       let read_addr_res a ii = read_mem_atomic a ii

--- a/herd/RISCVArch_herd.ml
+++ b/herd/RISCVArch_herd.ml
@@ -127,4 +127,6 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     module MemType=MemoryType.No
 
+    module ArchAction = ArchAction.No
+
   end

--- a/herd/RISCVArch_herd.ml
+++ b/herd/RISCVArch_herd.ml
@@ -127,6 +127,15 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     module MemType=MemoryType.No
 
-    module ArchAction = ArchAction.No
+    module NoConf = struct
+      type v = V.v
+      type loc = location
+      type value_set = V.ValueSet.t
+      type solution = V.solution
+      type arch_lannot = lannot
+      type arch_explicit = explicit
+    end
+
+    module ArchAction = ArchAction.No(NoConf)
 
   end

--- a/herd/RISCVSem.ml
+++ b/herd/RISCVSem.ml
@@ -128,7 +128,7 @@ module Make (C:Sem.Config)(V:Value.S)
 
       let write_loc_annot sz an loc v ii =
         M.mk_singleton_es
-          (Act.Access (Dir.W, loc, v, an, (), sz, Act.A_VIR))
+          (Act.Access (Dir.W, loc, v, an, (), sz, Access.VIR))
           ii
 
       let do_write_reg mk r v ii = match r with
@@ -136,7 +136,7 @@ module Make (C:Sem.Config)(V:Value.S)
       | _ ->
           mk
             (Act.Access
-               (Dir.W, (A.Location_reg (ii.A.proc,r)), v, plain, (), nat_sz, Act.A_REG))
+               (Dir.W, (A.Location_reg (ii.A.proc,r)), v, plain, (), nat_sz, Access.REG))
             ii
 
       let write_reg = do_write_reg M.mk_singleton_es
@@ -149,11 +149,11 @@ module Make (C:Sem.Config)(V:Value.S)
       let do_write_mem sz an a v ii  =
         if mixed then
           Mixed.write_mixed sz
-            (fun sz a v -> Act.Access (Dir.W, a, v, an, (), sz, Act.A_VIR))
+            (fun sz a v -> Act.Access (Dir.W, a, v, an, (), sz, Access.VIR))
             a v ii
         else
           M.mk_singleton_es
-            (Act.Access (Dir.W, A.Location_global a, v, an, (), sz, Act.A_VIR))
+            (Act.Access (Dir.W, A.Location_global a, v, an, (), sz, Access.VIR))
             ii
 
       let write_mem sz an = do_write_mem sz (RISCV.P an)
@@ -163,12 +163,12 @@ module Make (C:Sem.Config)(V:Value.S)
       let write_mem_conditional sz an a v resa ii =
         if  lrscdiffok then
           (M.mk_singleton_es_eq
-             (Act.Access (Dir.W, A.Location_global a, v, RISCV.X an, (), sz,Act.A_VIR)) [] ii >>|
+             (Act.Access (Dir.W, A.Location_global a, v, RISCV.X an, (), sz,Access.VIR)) [] ii >>|
              M.neqT resa V.zero) >>! () (* resa = zero <-> no matching load reserve *)
         else
           let eq = [M.VC.Assign (a,M.VC.Atom resa)] in
           M.mk_singleton_es_eq
-            (Act.Access (Dir.W, A.Location_global a, v, RISCV.X an, (), sz,Act.A_VIR)) eq ii
+            (Act.Access (Dir.W, A.Location_global a, v, RISCV.X an, (), sz,Access.VIR)) eq ii
 
       let write_mem_atomic sz an = do_write_mem sz (RISCV.X an)
 
@@ -217,14 +217,14 @@ module Make (C:Sem.Config)(V:Value.S)
               (ra >>| rv) >>=
               (fun (loc,vstore) ->
                 M.read_loc false
-                  (fun loc v -> Act.Amo (loc,v,vstore,X an,(),sz,Act.A_VIR))
+                  (fun loc v -> Act.Amo (loc,v,vstore,X an,(),sz,Access.VIR))
                   (A.Location_global loc) ii) >>= fun r -> write_reg rd r ii
           | _ ->
               (ra >>| rv) >>=
               (fun (loc,v) ->
                 M.fetch (tr_opamo op) v
                   (fun v vstored ->
-                    Act.Amo (A.Location_global loc,v,vstored,RISCV.X an,(),sz,Act.A_VIR))
+                    Act.Amo (A.Location_global loc,v,vstored,RISCV.X an,(),sz,Access.VIR))
                   ii)  >>=  fun v -> write_reg rd v ii
         else match specialX0,op,rd,rv with
         | true,AMOSWAP,Ireg X0,_ ->

--- a/herd/X86Arch_herd.ml
+++ b/herd/X86Arch_herd.ml
@@ -78,4 +78,6 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
 
     module MemType=MemoryType.No
 
+    module ArchAction = ArchAction.No
+
   end

--- a/herd/X86Arch_herd.ml
+++ b/herd/X86Arch_herd.ml
@@ -78,6 +78,15 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
 
     module MemType=MemoryType.No
 
-    module ArchAction = ArchAction.No
+    module NoConf = struct
+      type v = V.v
+      type loc = location
+      type value_set = V.ValueSet.t
+      type solution = V.solution
+      type arch_lannot = lannot
+      type arch_explicit = explicit
+    end
+
+    module ArchAction = ArchAction.No(NoConf)
 
   end

--- a/herd/X86Sem.ml
+++ b/herd/X86Sem.ml
@@ -75,12 +75,12 @@ module Make (C:Sem.Config)(V : Value.S)
       let write_loc_gen sz locked loc v ii = match loc with
       |  A.Location_global _ ->
           M.mk_singleton_es
-            (Act.Access (Dir.W, loc, v, locked, (), sz, Act.A_VIR))
+            (Act.Access (Dir.W, loc, v, locked, (), sz, Access.VIR))
             ii
       | _ ->
           M.mk_singleton_es
             (Act.Access
-               (Dir.W, loc, v, locked, (), nat_sz, Act.A_VIR))
+               (Dir.W, loc, v, locked, (), nat_sz, Access.VIR))
             ii
 
       let write_loc sz loc v ii =
@@ -91,17 +91,17 @@ module Make (C:Sem.Config)(V : Value.S)
 
       let write_reg r v ii =
         M.mk_singleton_es
-          (Act.Access (Dir.W, (A.Location_reg (ii.A.proc,r)), v, false, (), nat_sz, Act.A_REG))
+          (Act.Access (Dir.W, (A.Location_reg (ii.A.proc,r)), v, false, (), nat_sz, Access.REG))
           ii
 
       let write_mem sz a v ii  =
         M.mk_singleton_es
-          (Act.Access (Dir.W, A.Location_global a, v, false, (), sz, Act.A_VIR))
+          (Act.Access (Dir.W, A.Location_global a, v, false, (), sz, Access.VIR))
           ii
 
       let write_mem_atomic sz a v ii =
         M.mk_singleton_es
-          (Act.Access (Dir.W, A.Location_global a, v, true, (), sz, Act.A_VIR))
+          (Act.Access (Dir.W, A.Location_global a, v, true, (), sz, Access.VIR))
           ii
 
       let write_loc_atomic sz loc v ii =

--- a/herd/X86_64Arch_herd.ml
+++ b/herd/X86_64Arch_herd.ml
@@ -112,4 +112,6 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
 
     module MemType=MemoryType.X86_64
 
+    module ArchAction = ArchAction.No
+
   end

--- a/herd/X86_64Arch_herd.ml
+++ b/herd/X86_64Arch_herd.ml
@@ -112,6 +112,15 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
 
     module MemType=MemoryType.X86_64
 
-    module ArchAction = ArchAction.No
+    module NoConf = struct
+      type v = V.v
+      type loc = location
+      type value_set = V.ValueSet.t
+      type solution = V.solution
+      type arch_lannot = lannot
+      type arch_explicit = explicit
+    end
+
+    module ArchAction = ArchAction.No(NoConf)
 
   end

--- a/herd/access.mli
+++ b/herd/access.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* Copyright 2021-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,38 +14,13 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Basic arch, ie with no definition of what a global location is *)
+(** All sorts of accesses, redundant with symbol hidden in location,
+   when symbol is known, which may not be the case *)
 
-module type Config = ArchExtra_herd.Config
+type t = REG | VIR | PHY | PTE | TLB | TAG | PHY_PTE
 
+val pp : t -> string
 
-module type S =
-  sig
+val is_physical : t -> bool
 
-    include ArchBase.S
-    val is_amo : instruction -> bool
-    val pp_barrier_short : barrier -> string
-    val reject_mixed : bool (* perform a check that rejects mixed-size tests *)
-    val mem_access_size : instruction -> MachSize.sz option
-
-    module V : Value.S
-    include ArchExtra_herd.S with module I.V = V
-    and type I.arch_reg = reg
-    and type I.arch_instruction = instruction
-
-(* Levels are abstract, for AArch64, they are E0 to E3 *)
-    type level
-    val levels : level list
-    val pp_level : level -> string
-
-    module TLBI :
-    sig
-      type op
-      val pp_op : op -> string
-      val is_at_level : level -> op -> bool
-      val inv_all : op -> bool
-    end
-
-    module MemType:MemoryType.S
-
-  end
+val compatible : t -> t -> bool

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -55,16 +55,13 @@ module type S = sig
   val is_mem_load : action ->  bool
   val is_additional_mem_load :  action -> bool (* trylock *)
   val is_mem : action -> bool
-  val is_pt : action -> bool
   val is_tag : action -> bool
-  val is_mem_physical : action -> bool
   val is_additional_mem : action -> bool (* abstract memory actions, eg locks *)
   val is_atomic : action -> bool
   val is_fault : action -> bool
   val to_fault : action -> A.fault option
   val get_mem_dir : action -> Dir.dirn
   val get_mem_size : action -> MachSize.sz
-  val is_PA_val : A.V.v -> bool
   val is_implicit_pte_read : action -> bool
 
 (* relative to the registers of the given proc *)

--- a/herd/archAction.ml
+++ b/herd/archAction.ml
@@ -18,11 +18,59 @@
 
 module type S = sig
   type t
+  type v
+  type loc
+  type value_set
+  type solution
+  type arch_lannot
+  type arch_explicit
 
   val pp : t -> string
+
+  val get_lannot : t -> arch_lannot
+  val get_explicit : t ->  arch_explicit
+  val value_of : t -> v option
+  val read_of : t -> v option
+  val written_of : t -> v option
+  val location_of : t -> loc option
+  val is_store : t -> bool
+  val is_load : t -> bool
+  val is_atomic : t -> bool
+  val get_size: t -> MachSize.sz
+  val undetermined_vars : t -> value_set
+  val simplify_vars : solution -> t -> t
 end
 
-module No = struct
+module type NoConf = sig
+  type v
+  type loc
+  type value_set
+  type solution
+  type arch_lannot
+  type arch_explicit
+end
+
+module No(C:NoConf) = struct
   type t
+  type v = C.v
+  type loc = C.loc
+  type value_set = C.value_set
+  type solution = C.solution
+  type arch_lannot = C.arch_lannot
+  type arch_explicit = C.arch_explicit
+
   let pp _ = assert false
+
+  let get_lannot _ = assert false
+  let get_explicit _ = assert false
+  let value_of _ = assert false
+  let read_of _ = assert false
+  let written_of _ = assert false
+  let location_of _ = assert false
+  let is_store _ = assert false
+  let is_load _ = assert false
+  let is_atomic _ = assert false
+  let get_size _ = assert false
+  let undetermined_vars _ = assert false
+  let simplify_vars _ = assert false
 end

--- a/herd/archAction.ml
+++ b/herd/archAction.ml
@@ -14,40 +14,15 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Basic arch, ie with no definition of what a global location is *)
+(** Action that are arch specific *)
 
-module type Config = ArchExtra_herd.Config
+module type S = sig
+  type t
 
+  val pp : t -> string
+end
 
-module type S =
-  sig
-
-    include ArchBase.S
-    val is_amo : instruction -> bool
-    val pp_barrier_short : barrier -> string
-    val reject_mixed : bool (* perform a check that rejects mixed-size tests *)
-    val mem_access_size : instruction -> MachSize.sz option
-
-    module V : Value.S
-    include ArchExtra_herd.S with module I.V = V
-    and type I.arch_reg = reg
-    and type I.arch_instruction = instruction
-
-(* Levels are abstract, for AArch64, they are E0 to E3 *)
-    type level
-    val levels : level list
-    val pp_level : level -> string
-
-    module TLBI :
-    sig
-      type op
-      val pp_op : op -> string
-      val is_at_level : level -> op -> bool
-      val inv_all : op -> bool
-    end
-
-    module MemType:MemoryType.S
-
-    module ArchAction : ArchAction.S
-
-  end
+module No = struct
+  type t
+  let pp _ = assert false
+end

--- a/herd/archAction.ml
+++ b/herd/archAction.ml
@@ -36,6 +36,7 @@ module type S = sig
   val is_store : t -> bool
   val is_load : t -> bool
   val get_size: t -> MachSize.sz
+  val get_kind : t -> Access.t
   val undetermined_vars : t -> value_set
   val simplify_vars : solution -> t -> t
 end
@@ -69,6 +70,7 @@ module No(C:NoConf) = struct
   let is_store _ = assert false
   let is_load _ = assert false
   let get_size _ = assert false
+  let get_kind _ = assert false
   let undetermined_vars _ = assert false
   let simplify_vars _ = assert false
 end

--- a/herd/archAction.ml
+++ b/herd/archAction.ml
@@ -39,6 +39,7 @@ module type S = sig
   val get_kind : t -> Access.t
   val undetermined_vars : t -> value_set
   val simplify_vars : solution -> t -> t
+  val sets : (string * (t -> bool)) list
 end
 
 module type NoConf = sig
@@ -73,4 +74,6 @@ module No(C:NoConf) = struct
   let get_kind _ = assert false
   let undetermined_vars _ = assert false
   let simplify_vars _ = assert false
+
+  let sets = []
 end

--- a/herd/archAction.ml
+++ b/herd/archAction.ml
@@ -35,7 +35,6 @@ module type S = sig
   val location_of : t -> loc option
   val is_store : t -> bool
   val is_load : t -> bool
-  val is_atomic : t -> bool
   val get_size: t -> MachSize.sz
   val undetermined_vars : t -> value_set
   val simplify_vars : solution -> t -> t
@@ -63,13 +62,12 @@ module No(C:NoConf) = struct
 
   let get_lannot _ = assert false
   let get_explicit _ = assert false
-  let value_of _ = assert false
   let read_of _ = assert false
   let written_of _ = assert false
+  let value_of _ = assert false
   let location_of _ = assert false
   let is_store _ = assert false
   let is_load _ = assert false
-  let is_atomic _ = assert false
   let get_size _ = assert false
   let undetermined_vars _ = assert false
   let simplify_vars _ = assert false

--- a/herd/constraints.ml
+++ b/herd/constraints.ml
@@ -165,7 +165,7 @@ module Make (C:Config) (A : Arch_herd.S) :
             List.map
               (fun col ->
                 let vs = List.map (fun (_,v) -> v) col in
-                A.VSet.cardinal (A.VSet.of_list vs))
+                V.ValueSet.cardinal (V.ValueSet.of_list vs))
               mt in
           let rec best_rec k (kb,b as p) = function
             | [] -> kb
@@ -207,10 +207,10 @@ module Make (C:Config) (A : Arch_herd.S) :
           List.fold_left
             (fun m (v,ps) ->
               let pss =
-                try A.VMap.find v m
+                try V.ValueMap.find v m
                 with Not_found -> [] in
-              A.VMap.add v (ps::pss) m)
-            A.VMap.empty ps
+              V.ValueMap.add v (ps::pss) m)
+            V.ValueMap.empty ps
 
         let rec compile_cond m =
           let k = best_col m in
@@ -220,12 +220,12 @@ module Make (C:Config) (A : Arch_herd.S) :
           | [] -> assert false
           | (_,[])::_ ->
               Or
-                (A.VMap.fold
+                (V.ValueMap.fold
                    (fun v _ k -> Atom (LV (loc,v))::k)
                    m [])
           | _ ->
               Or
-                (A.VMap.fold
+                (V.ValueMap.fold
                    (fun v m k -> And [Atom (LV (loc,v));compile_cond m]::k)
                    m [])
 

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -563,9 +563,15 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
     let is_mem_load e = Act.is_mem_load e.action
     let is_additional_mem_load e = Act.is_additional_mem_load e.action
     let is_mem e = Act.is_mem e.action
-    let is_pt e = Act.is_pt e.action
+    let is_pt e = match Act.location_of e.action with
+      | Some (A.Location_global (V.Val c)) -> Constant.is_pt c
+      | _ -> false
     let is_tag e = Act.is_tag e.action
-    let is_mem_physical e =  Act.is_mem_physical e.action
+    let is_mem_physical e =
+      let open Constant in
+      match Act.location_of e.action with
+      | Some (A.Location_global (V.Val (Symbolic (Physical _)))) -> true
+      | _ -> false
     let is_additional_mem e = Act.is_additional_mem e.action
     let is_atomic e = Act.is_atomic e.action
     let to_fault e = Act.to_fault e.action

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -288,7 +288,7 @@ Monad type:
 (* Exchange combination *)
 (* NB: first boolean -> physical memory access *)
     let swp_or_amo : bool -> Op.op option -> ('loc t) ->
-      ('loc -> A.V.v t) -> A.V.v t -> ('loc -> A.V.v -> unit t) -> (A.V.v -> unit t)
+      ('loc -> V.v t) -> V.v t -> ('loc -> V.v -> unit t) -> (V.v -> unit t)
         -> unit t  = fun is_phy op rloc rmem rreg wmem wreg ->
           fun eiid ->
         let eiid,(locm,spec) = rloc eiid in
@@ -555,11 +555,11 @@ Monad type:
       altT
         (riscv_sc false
            read_res read_data read_addr cancel_res
-           (write_result A.V.one)
+           (write_result V.one)
            (fun _a _resa _v -> unitT ()))
         (riscv_sc true
            read_res read_data read_addr cancel_res
-           (write_result A.V.zero)
+           (write_result V.zero)
            write_mem)
 
 (* stu combinator *)
@@ -1206,19 +1206,19 @@ Monad type:
                 else a::glob,tag
             | A.Location_reg _ -> p)
             ([],[]) env in
-        let tag_set = A.VSet.of_list tag in
+        let tag_set = V.ValueSet.of_list tag in
         let env =
           List.fold_left
             (fun env a ->
               if not (is_pteloc a) then
               begin
                 let atag =  V.op1 Op.TagLoc a in
-                if A.VSet.mem atag tag_set then env
+                if V.ValueSet.mem atag tag_set then env
                 else begin
                   if dbg then
                     eprintf "Tag %s for %s defaulting\n"
-                      (A.V.pp_v atag) (A.V.pp_v a) ;
-                  (A.Location_global atag,A.V.Val (Constant.default_tag))::env
+                      (V.pp_v atag) (V.pp_v a) ;
+                  (A.Location_global atag,V.Val (Constant.default_tag))::env
                 end
               end
               else env)
@@ -1239,7 +1239,7 @@ Monad type:
       let debug_env env =
         String.concat ", "
           (List.map
-             (fun (loc,v) -> sprintf "%s -> %s" (A.pp_location loc) (A.V.pp_v v))
+             (fun (loc,v) -> sprintf "%s -> %s" (A.pp_location loc) (V.pp_v v))
              env)
 
       let val_of_pteval p = V.Val (Constant.PteVal p)
@@ -1255,7 +1255,7 @@ Monad type:
         | _ ->
             Warn.user_error
               "Cannot initialize %s with %s"
-              (A.pp_location loc ) (A.V.pp C.hexa v)
+              (A.pp_location loc ) (V.pp C.hexa v)
 
       let pte_loc s =
         let open Constant in
@@ -1337,7 +1337,7 @@ Monad type:
                       A.look_size size_env s
                   | _ -> def_size in
                 let eiid,ew =
-                  let v = A.V.map_scalar (A.V.Cst.Scalar.mask sz) v in
+                  let v = V.map_scalar (V.Cst.Scalar.mask sz) v in
                   make_one_init_event
                     (E.Act.mk_init_write loc sz v) eiid in
                 match A.symbolic_data loc with
@@ -1346,7 +1346,7 @@ Monad type:
                       if morello then
                         let eiid,em =
                           morello_init_tag
-                            s (A.V.op1 Op.CapaGetTag v) eiid in
+                            s (V.op1 Op.CapaGetTag v) eiid in
                         eiid,(em::[ew])
                       else eiid,[ew] in
                     (eiid,ews@es)
@@ -1362,7 +1362,7 @@ Monad type:
       let debug_env env =
         String.concat "; "
           (List.map
-             (fun (loc,v) -> A.pp_location loc ^ " -> " ^ A.V.pp_v v)
+             (fun (loc,v) -> A.pp_location loc ^ " -> " ^ V.pp_v v)
              env)
 
       let initwrites_mixed env size_env =
@@ -1377,7 +1377,7 @@ Monad type:
                 let open Constant in
                 match loc with
                 | A.Location_global
-                  (A.V.Val
+                  (V.Val
                      (Symbolic
                         (Virtual
                            {name=s;offset=_;_})) as a)
@@ -1400,7 +1400,7 @@ Monad type:
                       if morello then
                         let eiid,em =
                           morello_init_tag
-                            s (A.V.op1 Op.CapaGetTag v)
+                            s (V.op1 Op.CapaGetTag v)
                             eiid in
                         eiid,em::ews
                       else eiid,ews in

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -237,12 +237,6 @@ end = struct
     -> Constant.is_pt c
   | _ -> false
 
-  let is_mem_physical a = let open Constant in match a with
-  | Access (_,A.Location_global (V.Val (Symbolic (Physical _))),_,_,_,_,_)
-  | Amo (A.Location_global (V.Val (Symbolic (Physical _))),_,_,_,_,_,_)
-    -> true
-  | _ -> false
-
   let is_additional_mem _ = false
 
   let is_atomic a = match a with
@@ -293,10 +287,6 @@ end = struct
   let get_mem_size a = match a with
   | Access (_,A.Location_global _,_,_,_,sz,_) -> sz
   | _ -> assert false
-
-  let is_PA_val = let open Constant in function
-    | (A.V.Val (Symbolic (Physical _))) -> true
-    | _ -> false
 
   let is_PA_access = function
     | Access (_,_,_,_,_,_,(A_PHY|A_PHY_PTE))

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -468,6 +468,16 @@ end = struct
       List.map
         (fun lvl -> A.pp_level lvl,is_at_level lvl)
         A.levels
+
+    and aasets =
+      List.map
+        (fun (tag,p) ->
+          let p act = match act with
+            | Arch act -> p act
+            | _ -> false in
+          tag,p)
+      A.ArchAction.sets
+
     in
     ("T",is_tag)::
     ("FAULT",is_fault)::
@@ -486,7 +496,7 @@ end = struct
         k
     else
       fun k -> k)
-      (bsets @ asets @ esets @ lsets)
+      (bsets @ asets @ esets @ lsets @ aasets)
 
   let arch_rels =
     if kvm then

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -570,8 +570,8 @@ let match_reg_events es =
       begin
         let loc1 = get_loc e1
         and loc2 = get_loc e2 in
-        let ov1 =  A.undetermined_vars_in_loc loc1
-        and ov2 =  A.undetermined_vars_in_loc loc2 in
+        let ov1 =  A.undetermined_vars_in_loc_opt loc1
+        and ov2 =  A.undetermined_vars_in_loc_opt loc2 in
         match ov1,ov2 with
         | None,None -> E.same_location e1 e2
         | (Some _,None)|(None,Some _)

--- a/herd/valconstraint.ml
+++ b/herd/valconstraint.ml
@@ -177,7 +177,7 @@ and type state = A.state =
     | V.Val _ -> t
     | V.Var x -> Part.add t x
 
-    let add_var_loc t loc = match A.undetermined_vars_in_loc loc with
+    let add_var_loc t loc = match A.undetermined_vars_in_loc_opt loc with
     | None -> t
     | Some v -> add_var  t v
 

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -860,8 +860,8 @@ module Make(Cst:Constant.S) = struct
     let compare = compare
   end
 
-
   module ValueSet = MySet.Make(OrderedValue)
+  module ValueMap = MyMap.Make(OrderedValue)
 
   module OrderedVar = struct
     type t = csym
@@ -875,6 +875,10 @@ module Make(Cst:Constant.S) = struct
   let is_var_determined v = match v with
   | Var _ -> false
   | Val _ -> true
+
+  let undetermined_vars v = match v with
+  | Var _ -> ValueSet.singleton v
+  | Val _ -> ValueSet.empty
 
   let determined_val v = match v with
   | Var _ -> None

--- a/lib/value.mli
+++ b/lib/value.mli
@@ -83,11 +83,13 @@ module type S =
       val op3 : Op.op3 -> v -> v -> v -> v
 
       module ValueSet : MySet.S with type elt = v
+      module ValueMap : MyMap.S with type key = v
       module Solution : Map.S with type key = csym
 
       type solution = v Solution.t
 
       val is_var_determined : v -> bool
+      val undetermined_vars : v -> ValueSet.t
       val determined_val : v -> Cst.v option
       val simplify_var : solution -> v -> v
 


### PR DESCRIPTION
This PR introduces infrastructure for arch-dependent actions. Next step may be using the infrastructure for various existing actions that are in fact arch-dependent.

The infrastructure is used to implement X86_64 cache line flush events.