### PR TITLE
[herd] No spurious read alone

### DIFF
--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -651,6 +651,13 @@ Monad type:
           let f = (fun (vin, vcl, es) -> ((v, vin), vcl, es)) in
           (eiid1,(Evt.map f sact, Misc.app_opt (Evt.map f) spec))
 
+(* Assert a value *)
+    let assertT : 'A.V.v -> 'a t -> 'a t =
+      fun v m eiid ->
+      let eiid,(acts,spec) = m eiid in
+      let f (r,cs,es) = r,VC.Assign (v,VC.Atom V.one)::cs,es in
+      eiid,(Evt.map f acts,Misc.app_opt (Evt.map f) spec)
+
 (* Choosing dependant upon flag, notice that, once determined v is either one or zero *)
     let choiceT =
       fun v l r eiid ->

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -149,6 +149,7 @@ module type S =
     val discardT : 'a t -> unit t
     val addT : 'a -> 'b t -> ('a * 'b) t
 
+    val assertT : A.V.v -> 'a t -> 'a t
     val choiceT : A.V.v -> 'a t -> 'a t -> 'a t
     val condPredT : A.V.v -> unit t -> 'a t -> 'a t -> 'a t
     val condJumpT : A.V.v -> 'a code -> 'a code -> 'a code


### PR DESCRIPTION
This PR eliminates the failure case of spurious updates before calling the Cat interpreter.