### PR TITLE
[herd] Opt env

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -207,6 +207,61 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
       | I_EOR_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
           -> None
 
+    let all_regs =
+      all_gprs@vregs (* Should be enough, only those are tracked *)
+
+    let opt_env = true
+
+    let killed i =
+      match i with
+      | I_B _| I_BR _
+      | I_BC _ | I_CBZ _ | I_CBNZ _
+      | I_STP _ | I_STR _ | I_STLR _
+      | I_STRBH _ | I_STLRBH _
+      | I_STOP _ | I_STOPBH _
+      | I_FENCE _
+      | I_IC _|I_DC _|I_TLBI _
+      | I_NOP|I_TBZ _|I_TBNZ _
+        -> []
+      | I_BL _ | I_BLR _ | I_RET _
+        -> all_regs
+      | I_LDR (_,r,_,_,_)|I_LDRBH (_,r,_,_)
+      | I_LDUR (_,r,_,_)
+      | I_LDR_P (_,r,_,_)
+      | I_LDAR (_,_,r,_) |I_LDARBH (_,_,r,_)
+      | I_SWP (_,_,_,r,_) | I_SWPBH (_,_,_,r,_)
+      | I_STXR (_,_,r,_,_) | I_STXRBH (_,_,r,_,_)
+      | I_CAS (_,_,r,_,_) | I_CASBH (_,_,r,_,_)
+      | I_LDOP (_,_,_,_,r,_) | I_LDOPBH (_,_,_,_,r,_)
+      | I_MOV (_,r,_) | I_MOVZ (_,r,_,_) | I_MOVK (_,r,_,_)
+      | I_SXTW (r,_)
+      | I_OP3 (_,_,r,_,_,_)
+      | I_ADDR (r,_)
+      | I_RBIT (_,r,_)
+      | I_CSEL (_,r,_,_,_,_)
+      | I_MRS (r,_)
+          -> [r]
+      | I_LD1 _|I_LD1M _|I_LD1R _|I_LD2 _
+      | I_LD2M _|I_LD2R _|I_LD3 _|I_LD3M _
+      | I_LD3R _|I_LD4 _|I_LD4M _|I_LD4R _
+      | I_ST1 _|I_ST1M _|I_ST2 _|I_ST2M _
+      | I_ST3 _|I_ST3M _|I_ST4 _|I_ST4M _
+      | I_LDP_P_SIMD _|I_STP_P_SIMD _
+      | I_LDP_SIMD _|I_STP_SIMD _
+      | I_LDR_SIMD _|I_LDR_P_SIMD _
+      | I_STR_SIMD _|I_STR_P_SIMD _
+      | I_LDUR_SIMD _|I_STUR_SIMD _|I_MOV_VE _
+      | I_MOV_V _|I_MOV_TG _|I_MOV_FG _
+      | I_MOV_S _|I_MOVI_V _|I_MOVI_S _
+      | I_EOR_SIMD _|I_ADD_SIMD _|I_ADD_SIMD_S _
+      | I_LDP _|I_ALIGND _|I_ALIGNU _
+      | I_BUILD _|I_CHKEQ _|I_CHKSLD _|I_CHKTGD _|I_CLRTAG _
+      | I_CPYTYPE _|I_CPYVALUE _|I_CSEAL _|I_GC _
+      | I_LDCT _|I_SC _|I_SEAL _|I_STCT _
+      | I_UNSEAL _|I_STG _|I_STZG _|I_LDG _
+        ->
+         all_regs (* safe approximation *)
+
     include ArchExtra_herd.Make(C)
         (struct
           module V = V

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -62,6 +62,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
       | I_LDR _ | I_LDREX _ | I_LDR3 _ | I_STR _ | I_STREX _ | I_STR3 _
         -> Some MachSize.Word
 
+    let opt_env = false
+    let killed _ = []
+
     include NoLevelNorTLBI
 
     include ArchExtra_herd.Make(C)

--- a/herd/BellArch_herd.ml
+++ b/herd/BellArch_herd.ml
@@ -26,6 +26,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
   let reject_mixed = false
   let mem_access_size _ = None
 
+  let opt_env = false
+  let killed _ = []
+
   module V = V
 
   include NoLevelNorTLBI

--- a/herd/CArch_herd.ml
+++ b/herd/CArch_herd.ml
@@ -21,6 +21,8 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
   let pp_barrier_short = pp_barrier
   let reject_mixed = false
   let mem_access_size _ = None
+  let opt_env = false
+  let killed _ = []
 
   module V = V
 

--- a/herd/MIPSArch_herd.ml
+++ b/herd/MIPSArch_herd.ml
@@ -45,6 +45,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 (* Technically wrong, but it does not matter as there is no mixed-size *)
     let mem_access_size _ = None
 
+    let opt_env = false
+    let killed _ = []
+
     include NoLevelNorTLBI
 
     include ArchExtra_herd.Make(C)

--- a/herd/PPCArch_herd.ml
+++ b/herd/PPCArch_herd.ml
@@ -69,6 +69,9 @@ module Make (C:Arch_herd.Config) (V:Value.S)
       | Pstore (sz,_,_,_) | Pstorex (sz,_,_,_)
         -> Some sz
 
+    let opt_env = false
+    let killed _ = []
+
     include NoLevelNorTLBI
 
     include ArchExtra_herd.Make(C)

--- a/herd/RISCVArch_herd.ml
+++ b/herd/RISCVArch_herd.ml
@@ -107,6 +107,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
       | Amo (_,w,_,_,_,_)
         -> Some (tr_width w)
 
+    let opt_env = false
+    let killed _ = []
+
     include  NoLevelNorTLBI
 
     include ArchExtra_herd.Make(C)

--- a/herd/X86Arch_herd.ml
+++ b/herd/X86Arch_herd.ml
@@ -57,6 +57,9 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
 (* Technically wrong, but it does not matter as there is no mixed-size *)
     let mem_access_size _ = None
 
+    let opt_env = false
+    let killed _ = []
+
 
     include NoLevelNorTLBI
 

--- a/herd/X86_64Arch_herd.ml
+++ b/herd/X86_64Arch_herd.ml
@@ -86,6 +86,8 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
       | I_MOVNTI (sz,_,_)  | I_MOVD (sz,_,_)
         -> Some (inst_size_to_mach_size sz)
 
+    let opt_env = false
+    let killed _ = []
 
     (********************)
     (* global locations *)

--- a/herd/arch_herd.mli
+++ b/herd/arch_herd.mli
@@ -28,6 +28,9 @@ module type S =
     val reject_mixed : bool (* perform a check that rejects mixed-size tests *)
     val mem_access_size : instruction -> MachSize.sz option
 
+    val opt_env : bool (* environemnt optimisation is available *)
+    val killed : instruction -> reg list
+
     module V : Value.S
     include ArchExtra_herd.S with module I.V = V
     and type I.arch_reg = reg

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -663,9 +663,9 @@ Monad type:
 (* Choosing dependant upon flag, notice that, once determined v is either one or zero *)
     let choiceT =
       fun v l r eiid ->
-        if V.is_var_determined v then
+        if V.is_var_determined v then begin
           if V.is_zero v  then r eiid else l eiid
-        else
+        end else
           let (eiid, (lact,lspec)) = l eiid in
           assert (lspec = None);
           let (eiid, (ract,rspec)) = r eiid in
@@ -985,7 +985,13 @@ Monad type:
     let do_read_loc is_data mk_action loc iiid = fun eiid ->
       (* It is important to call V.fresh_var
          for every _complete_ call of read_loc *)
-      let v = V.fresh_var () in
+      let v = match iiid,loc with
+          | E.IdSome {A.env=env; _},A.Location_reg (_,r) ->
+             begin match A.look_reg r env with
+             | Some v -> v
+             | None -> V.fresh_var ()
+             end
+          | _ -> V.fresh_var () in
       let m =
         do_make_one_event_structure_data is_data (mk_action loc v) iiid ++
         make_one_monad v [] in


### PR DESCRIPTION
This PR introduces the "environment" optimisation for herd. An environment for register values is maintained during code monad generation. Then, reading a register whose value is known yields this value. instead of the default fresh variable. As a result one may anticipate on choices and reduce the number of generated candidate executions.

This should in particular be beneficial for anticipating whether a location is a virtual or page table location.