### PR TITLE
[herd] Bound total number of spurious updates.

### DIFF
--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -272,7 +272,8 @@ let options = [
   "-showone",
   Arg.Bool (fun b -> if b then nshow := Some 1),
   "<bool> alias for -nshow 1";
-
+  parse_int_opt
+    "-maxphantom" maxphantom "maximum phantom update (per variable)";
   "-statelessrc11",
   Arg.Bool (fun b -> if b then statelessrc11 := true),
   "<bool> enable stateless RC11 model checking, use with -variant normw, SC check can be skipped";
@@ -508,7 +509,7 @@ let () =
     let badexecs = !badexecs
     let badflag = !badflag
     let throughflag = !throughflag
-
+    let maxphantom = !maxphantom
     let statelessrc11 = !statelessrc11
 
     let check_name = Check.ok

--- a/herd/opts.ml
+++ b/herd/opts.ml
@@ -71,7 +71,7 @@ let dumpes = ref false
 let outputdir = ref PrettyConf.NoOutputdir
 let dumplem = ref false
 let dumptex = ref false
-
+let maxphantom= ref None
 let statelessrc11 = ref false
 
 (* Pretty printing configuration, deserves its own module *)

--- a/herd/opts.mli
+++ b/herd/opts.mli
@@ -65,7 +65,7 @@ val suffix : string ref
 val dumpes : bool ref
 val dumplem : bool ref
 val dumptex : bool ref
-
+val maxphantom : int option ref
 val statelessrc11 : bool ref
 
 (* Pretty printing configuration, deserves its own module *)


### PR DESCRIPTION
    New command-line option `-maxphantom <n>` limits the number
    of spurious updates, `<n>` included.