### PR TITLE
[herd] Fix load-reserve store-conditional pairs computation

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -37,6 +37,10 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
     let exp_annot = Exp
     let nexp_annot = NExp Other
 
+    let is_explicit_annot = function
+      | Exp -> true
+      | NExp _ -> false
+
     let is_barrier b1 b2 = barrier_compare b1 b2 = 0
 
     let is_speculated = function

--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -116,6 +116,9 @@ end = struct
   (* Unimplemented *)
   let is_implicit_pte_read _ = assert false
 
+  (* All accesses are explicit *)
+  let is_explicit _ = true
+
   let is_atomic a = match a with
   | Access (_,_,_,true,_,_) ->
       assert (is_mem a); true

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -178,8 +178,10 @@ end = struct
   (* Unimplemented *)
   let is_implicit_pte_read _ = assert false
 
-        (* The following definition of is_atomic
-           is quite arbitrary. *)
+  (* All accesses are explicit *)
+  let is_explicit _ = true
+
+  (* The following definition of is_atomic is quite arbitrary. *)
 
   let old_is_atomic a = match a with
   | Access (_,A.Location_global _,_,AN _,_,_) -> false

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -63,6 +63,7 @@ module type S = sig
   val get_mem_dir : action -> Dir.dirn
   val get_mem_size : action -> MachSize.sz
   val is_implicit_pte_read : action -> bool
+  val is_explicit : action ->bool
 
 (* relative to the registers of the given proc *)
   val is_reg_store : action -> A.proc -> bool

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -86,6 +86,7 @@ val same_instance : event -> event -> bool
   val is_mem : event -> bool
 (* Page table access *)
   val is_pt : event -> bool
+  val is_explicit : event -> bool
 (* Tag memory access *)
   val is_tag : event -> bool
   val is_mem_physical : event -> bool
@@ -579,6 +580,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
     let is_pt e = match Act.location_of e.action with
       | Some (A.Location_global (V.Val c)) -> Constant.is_pt c
       | _ -> false
+    let is_explicit e = Act.is_explicit e.action
     let is_tag e = Act.is_tag e.action
     let is_mem_physical e =
       let open Constant in

--- a/herd/explicit.ml
+++ b/herd/explicit.ml
@@ -21,6 +21,7 @@ module type S = sig
   type explicit
   val exp_annot : explicit
   val nexp_annot : explicit
+  val is_explicit_annot : explicit -> bool
   val pp_explicit : explicit -> string
   val explicit_sets : (string * (explicit -> bool)) list
 end
@@ -29,6 +30,7 @@ module No = struct
   type explicit = unit
   let exp_annot = ()
   let nexp_annot = ()
+  let is_explicit_annot _ = true
   let pp_explicit _ = ""
   let explicit_sets = []
 end

--- a/herd/explicit.mli
+++ b/herd/explicit.mli
@@ -21,6 +21,7 @@ module type S = sig
   type explicit
   val exp_annot : explicit
   val nexp_annot : explicit
+  val is_explicit_annot : explicit -> bool
   val pp_explicit : explicit -> string
   val explicit_sets : (string * (explicit -> bool)) list
 end

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -364,6 +364,13 @@ end = struct
   | Access (R,_,_,_,_,_,Access.PTE) -> true
   | _ -> false
 
+  let lift_explicit_predicate p act = match act with
+    | Access(_,_,_,_,e,_,_)|Amo (_,_,_,_,e,_,_) -> p e
+    | Arch a -> p (A.ArchAction.get_explicit a)
+    | _ -> false
+
+  let is_explicit = lift_explicit_predicate A.is_explicit_annot
+
 (* relative to the registers of the given proc *)
   let is_reg_store a (p:int) = match a with
   | Access (W,A.Location_reg (q,_),_,_,_,_,_) -> p = q
@@ -462,11 +469,8 @@ end = struct
     and esets =
       List.map
         (fun (tag,p) ->
-          let p act = match act with
-          | Access(_,_,_,_,e,_,_)|Amo (_,_,_,_,e,_,_) -> p e
-          | Arch a -> p (A.ArchAction.get_explicit a)
-          | _ -> false
-          in tag,p) A.explicit_sets
+          let p = lift_explicit_predicate p in
+          tag,p) A.explicit_sets
 
     and lsets =
       List.map

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -1232,14 +1232,17 @@ let match_reg_events es =
           let rs,ws = List.partition E.is_load atms in
           List.fold_left
             (fun k r ->
+              let exp = E.is_explicit r in
               List.fold_left
                 (fun k w ->
                   if
                     S.atomic_pair_allowed r w &&
                     U.is_before_strict es r w &&
+                    E.is_explicit w = exp &&
                     not
                       (E.EventSet.exists
                          (fun e ->
+                           E.is_explicit e = exp &&
                            U.is_before_strict es r e &&
                            U.is_before_strict es e w)
                          all)


### PR DESCRIPTION
The pairing of load-reserve and store-conditional  instructions was too weak in the kvm case., due to the presence of non-explicit atomic accesses in-between. Those non-explicit accesses are emitted when hardware is responsible for updating some fields of page table entries, such as af.
