### PR TITLE
[herd] One read for all

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -28,7 +28,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
     let reject_mixed = true
 
     type annot = A | XA | L | XL | X | N | Q | NoRet | T | S
-    type nexp =  AF|DB|Other
+    type nexp =  AF|DB|AFDB|Other
     type explicit = Exp | NExp of nexp
     type lannot = annot
 
@@ -80,10 +80,10 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
       | NExp _-> true
       | _ -> false
     and is_af = function (* Setting of access flag *)
-      | NExp AF-> true
+      | NExp (AF|AFDB)-> true
       | _ -> false
     and is_db = function (* Setting of dirty bit flag *)
-      | NExp DB -> true
+      | NExp (DB|AFDB) -> true
       | _ -> false
 
     let barrier_sets =
@@ -130,6 +130,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
       | NExp Other-> "NExp"
       | NExp AF-> "NExpAF"
       | NExp DB-> "NExpDB"
+      | NExp AFDB-> "NExpAFDB"
     module V = V
 
     let neon_mask esize =

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -389,7 +389,7 @@ module Make
       let op_of_set = function
         | AArch64.AF -> Op.SetAF
         | AArch64.DB -> Op.SetDB
-        | AArch64.Other -> assert false
+        | AArch64.Other|AArch64.AFDB -> assert false
 
       let do_test_and_set_bit combine cond set a_pte iiid =
         let nexp = AArch64.NExp set in

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -141,8 +141,6 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
     let check_mixed =  not (C.variant Variant.DontCheckMixed)
     let do_deps = C.variant Variant.Deps
     let kvm = C.variant Variant.Kvm
-    let phantom =
-      kvm && Variant.get_switch A.arch Variant.SwitchPhantom C.variant
 
 (*****************************)
 (* Event structure generator *)
@@ -374,11 +372,9 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
 
       let af0 =
         if
-          begin match C.dirty with
+          match C.dirty with
           | None -> false
           | Some t -> t.DirtyBit.some_ha || t.DirtyBit.some_hd
-          end &&
-          phantom
         then begin
             if C.variant Variant.PhantomOnLoad then
               let look_pt rloc k = match rloc with

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -50,8 +50,7 @@ type t =
   | NoPteBranch
 (* Pte-Squared: all accesses through page table, including PT accesses *)
   | PTE2
-(* Switch "phantom" mode for setting the AF bit by hardware *)
-  | SwitchPhantom
+(* Count maximal number of phantom updates by looking at loads *)
   | PhantomOnLoad
 (* Perform experiment *)
   | Exp
@@ -62,7 +61,7 @@ let tags =
    "mixed";"dontcheckmixed";"weakpredicated"; "memtag";
    "tagcheckprecise"; "tagcheckunprecise"; "precise"; "imprecise";
    "toofar"; "deps"; "morello"; "instances"; "noptebranch"; "pte2";
-   "pte-squared"; "switchphantom"; "PhantomOnLoad";
+   "pte-squared"; "PhantomOnLoad";
    "exp"; ]
 
 let parse s = match Misc.lowercase s with
@@ -93,7 +92,6 @@ let parse s = match Misc.lowercase s with
 | "ets" -> Some ETS
 | "noptebranch"|"nobranch" -> Some NoPteBranch
 | "pte2" | "pte-squared" -> Some PTE2
-| "switchphantom" -> Some SwitchPhantom
 | "phantomonload" -> Some PhantomOnLoad
 | "exp" -> Some Exp
 | _ -> None
@@ -126,7 +124,6 @@ let pp = function
   | ETS -> "ets"
   | NoPteBranch -> "NoPteBranch"
   | PTE2 -> "pte-squared"
-  | SwitchPhantom -> "SwitchPhantom"
   | PhantomOnLoad -> "PhantomOnLoad"
   | Exp -> "exp"
 
@@ -143,11 +140,6 @@ let get_default a v =
       begin match a with
       | `AArch64 -> false
       | _ -> true
-      end
-  | SwitchPhantom ->
-      begin match a with
-      | `AArch64 -> true
-      | _ -> raise Exit
       end
   | _ -> raise Exit
   with Exit -> Warn.fatal "No default for variant %s" (pp v)

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -48,8 +48,6 @@ type t =
   | NoPteBranch
 (* Pte-Squared: all accesses through page table, including PT accesses *)
   | PTE2
-(* Switch "phantom" mode for setting the AF bit by hardware *)
-  | SwitchPhantom
 (* Generate extra spurious updates based upon load on pte. *)
   | PhantomOnLoad
 (* Perform experiment *)


### PR DESCRIPTION
This PR implements single read page table walk. AF and DB write are performed as write of some RMW of which read is the common page table walk read. Notice that the other purpose of this table walk read is to retrieve physical address and permissions.
