### PR TITLE
[herd] PoD set  restricted to branch conditional events

### DIFF
--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -328,7 +328,7 @@ module Make
              (List.map
                 (fun (k,p) -> k,lazy (E.EventSet.filter p evts))
                 ["C", E.is_commit;
-                 "PoD", E.is_pod;
+                 "PoD", E.is_commit_bcc;
                  "F", E.is_barrier;
                  "DATA", is_data_port;
                  "NDATA", (fun e -> not (is_data_port e));])) in


### PR DESCRIPTION
This changes the definition of the ctrl relation in `aarch64dep.cat`.
Namely, internal "commit" events should not impact on the ctrl
dependency relation between venets generated by different instructions.