### PR TITLE
Litmus minor clean-ups

### DIFF
--- a/litmus/libdir/_hash.c
+++ b/litmus/libdir/_hash.c
@@ -151,11 +151,7 @@ static void hash_add(hash_t *t,log_t *key, param_t *v,count_t c,int ok) {
     h++ ;
     h %= HASHSZ ;
   }
-#ifdef KVM
-  printf("Hash table is full\n") ;
-#else
   fprintf(stderr,"Hash table is full\n") ;
-#endif
   exit(2) ;
 }
 

--- a/litmus/libdir/_instance.c
+++ b/litmus/libdir/_instance.c
@@ -104,6 +104,9 @@ static global_t global  =
 #ifdef ACTIVE
     active,
 #endif
+    0,
+    SIZE_OF_TEST, NUMBER_OF_RUN, NEXE, NOCCS,
+    0,
   };
 
 static void init_global(global_t *g,int id) {

--- a/litmus/libdir/_instance.c
+++ b/litmus/libdir/_instance.c
@@ -65,9 +65,6 @@ typedef struct global_t {
   /* Command-line parameter */
   param_t *param ;
   parse_param_t *parse ;
-#ifdef KVM
-  int volatile over;
-#endif
   /* Topology */
   const int *inst, *role ;
   const char **group ;
@@ -97,9 +94,6 @@ typedef struct global_t {
 
 static global_t global  =
   { &param, &parse[0],
-#ifdef KVM
-    0,
-#endif
     inst, role, group, mem,
 #ifdef ACTIVE
     active,

--- a/litmus/libdir/_main.c
+++ b/litmus/libdir/_main.c
@@ -44,7 +44,6 @@ int RUN(int argc,char **argv,FILE *out) {
   if (n_exe < 1) n_exe = 1 ;
   global.verbose = d.verbose;
   global.nexe = n_exe;
-  global.noccs = NOCCS ;
   global.nruns = d.max_run;
   global.size = d.size_of_test;
   global.do_scan = d.mode == mode_scan ;
@@ -62,13 +61,6 @@ int RUN(int argc,char **argv,FILE *out) {
 #endif
 #endif
   tsc_t start = timeofday();
-#else
-  global.verbose = 0 ;
-  global.nexe = NEXE ;
-  global.noccs = NOCCS ;
-  global.nruns = NUMBER_OF_RUN ;
-  global.size = SIZE_OF_TEST ;
-  global.do_scan = 0;
 #endif
   for (int id=0; id < AVAIL ; id++) {
     arg[id].id = id;

--- a/litmus/libdir/_main.c
+++ b/litmus/libdir/_main.c
@@ -48,11 +48,7 @@ int RUN(int argc,char **argv,FILE *out) {
   global.size = d.size_of_test;
   global.do_scan = d.mode == mode_scan ;
   if (global.verbose) {
-#ifdef KVM
-    printf("%s: n=%d, r=%d, s=%d, %s\n",prog,global.nexe,global.nruns,global.size,global.do_scan ? "+sp" : "+rp");
-#else
     fprintf(stderr,"%s: n=%i, r=%i, s=%i, %s\n",prog,global.nexe,global.nruns,global.size,global.do_scan ? "+sp" : "+rp");
-#endif
   }
   parse_param(prog,global.parse,PARSESZ,p) ;
 #ifdef PRELUDE

--- a/litmus/libdir/_main.c
+++ b/litmus/libdir/_main.c
@@ -63,11 +63,8 @@ int RUN(int argc,char **argv,FILE *out) {
     arg[id].g = &global;
   }
 #ifdef KVM
-  /* "spawn" downwards as id 0 is not asynchornous */
   init_labels();
-  global.over = 0 ;
-  for (int id = AVAIL-1 ; id >= 0 ; id--) on_cpu_async(id,zyva,&arg[id]);
-  while (global.over < AVAIL) mdelay(500);
+  on_cpus(zyva, arg);
 #else
   for (int id=0; id < AVAIL ; id++) launch(&th[id],zyva,&arg[id]);
   for (int id=0; id < AVAIL ; id++) join(&th[id]);

--- a/litmus/libdir/_presi.c
+++ b/litmus/libdir/_presi.c
@@ -13,10 +13,10 @@
 /* license as circulated by CEA, CNRS and INRIA at the following URL        */
 /* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
 /****************************************************************************/
+#include <stdlib.h>
 #ifdef KVM
 #include <libcflat.h>
 #else
-#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <pthread.h>
@@ -78,38 +78,6 @@ static long my_pow10(int p,long x) {
   }
   return r ;
 }
-#ifdef KVM
-/* NB: Radix is ignored, will be ten anyway. */
-static long strtol(char *ptr,char **q,int radix10) {
-    long acc = 0;
-    char *s = ptr;
-    int neg, c;
-
-    while (*s == ' ' || *s == '\t')
-        s++;
-    if (*s == '-'){
-        neg = 1;
-        s++;
-    } else {
-        neg = 0;
-        if (*s == '+')
-            s++;
-    }
-
-    while (*s) {
-        if (*s < '0' || *s > '9')
-            break;
-        c = *s - '0';
-        acc = acc * 10 + c;
-        s++;
-    }
-    if (q) *q = s ;
-    if (neg)
-        acc = -acc;
-
-    return acc;
-}
-#endif
 
 static int do_argint(char *p, char **q) {
   long r =  strtol(p,q,10) ;

--- a/litmus/libdir/_presi.c
+++ b/litmus/libdir/_presi.c
@@ -29,8 +29,6 @@
 
 
 #ifdef KVM
-#define fprintf(stderr,fmt,...) printf(fmt, __VA_ARGS__)
-
 static int errno = 0 ;
 static const int ERANGE = 1 ;
 static const char *strerror(int e) { return "ERROR"; }

--- a/litmus/libdir/_presi.h
+++ b/litmus/libdir/_presi.h
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #ifdef KVM
 #include <libcflat.h>
+#define fprintf(stderr,...) printf(__VA_ARGS__)
 #else
 #include <pthread.h>
 #endif

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1760,8 +1760,15 @@ module Make
         O.o "} zyva_t;" ;
         O.o "" ;
         O.f "static void %szyva(void *_a) {" (k_nkvm "*") ;
-        O.oi "zyva_t *a = (zyva_t*)_a;" ;
-        O.oi "int id = a->id;" ;
+        if Cfg.is_kvm then begin
+            O.oi "int id = smp_processor_id();" ;
+            O.oi "if (id >= AVAIL) return;" ;
+            O.oi "zyva_t *a = (zyva_t*)_a + id;" ;
+          end
+        else begin
+            O.oi "zyva_t *a = (zyva_t*)_a;" ;
+            O.oi "int id = a->id;" ;
+          end;
         O.oi "global_t *g = a->g;" ;
         if Cfg.is_kvm then begin
           match db with
@@ -1796,10 +1803,7 @@ module Make
         O.oi "init_global(g,id);" ;
 (*        O.oi "if (g->do_scan) scan(id,g); else choose(id,g);" ; *)
         O.oi "choose(id,g);" ;
-        if Cfg.is_kvm then begin
-          O.oi "mbar();" ;
-          O.oi "atomic_inc_fetch(&g->over);"
-        end else begin
+        if not Cfg.is_kvm then begin
           O.oi "return NULL;"
         end ;
         O.o "}" ;

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1672,23 +1672,14 @@ module Make
         O.o "static void choose(int id,global_t *g) {" ;
         O.oi "param_t *q = g->param;" ;
         O.oi "thread_ctx_t c; c.id = c.seed = id;" ;
+        O.oi "st_t seed = 0;" ;
         O.o "" ;
-        O.oi "if (q->part >=0) {" ;
-        O.oii "set_role(g,&c,q->part);";
-        O.oii "for (int nrun = 0; nrun < g->nruns ; nrun++) {" ;
-        O.oiii
-            "if (g->verbose>1) fprintf(stderr, \"Run %i of %i\\r\", nrun, g->nruns);";
-        O.oiii "choose_params(g,&c,q->part);" ;
-        O.oii "}" ;
-        O.oi "} else {" ;
-        O.oii "st_t seed = 0;" ;
-        O.oii "for (int nrun = 0; nrun < g->nruns ; nrun++) {" ;
-        O.oiii
-          "if (g->verbose>1) fprintf(stderr, \"Run %i of %i\\r\", nrun, g->nruns);";
-        O.oiii "int part = rand_k(&seed,SCANSZ);" ;
-        O.oiii "set_role(g,&c,part);";
-        O.oiii "choose_params(g,&c,part);" ;
-        O.oii "}" ;
+        O.oi "for (int nrun = 0; nrun < g->nruns ; nrun++) {" ;
+        O.oii
+          "if (g->verbose>1) fprintf(stderr, \"Run %i of %i\\r\", nrun, g->nruns);" ;
+        O.oii "int part = q->part >= 0 ? q->part : rand_k(&seed,SCANSZ);" ;
+        O.oii "set_role(g,&c,part);";
+        O.oii "choose_params(g,&c,part);" ;
         O.oi "}" ;
         O.o "}" ;
         O.o ""

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1676,19 +1676,15 @@ module Make
         O.oi "if (q->part >=0) {" ;
         O.oii "set_role(g,&c,q->part);";
         O.oii "for (int nrun = 0; nrun < g->nruns ; nrun++) {" ;
-        if not Cfg.is_kvm then begin
-          O.oiii
-            "if (g->verbose>1) fprintf(stderr, \"Run %i of %i\\r\", nrun, g->nruns);"
-        end ;
+        O.oiii
+            "if (g->verbose>1) fprintf(stderr, \"Run %i of %i\\r\", nrun, g->nruns);";
         O.oiii "choose_params(g,&c,q->part);" ;
         O.oii "}" ;
         O.oi "} else {" ;
         O.oii "st_t seed = 0;" ;
         O.oii "for (int nrun = 0; nrun < g->nruns ; nrun++) {" ;
-        if not Cfg.is_kvm then begin
-          O.oiii
-            "if (g->verbose>1) fprintf(stderr, \"Run %i of %i\\r\", nrun, g->nruns);"
-        end ;
+        O.oiii
+          "if (g->verbose>1) fprintf(stderr, \"Run %i of %i\\r\", nrun, g->nruns);";
         O.oiii "int part = rand_k(&seed,SCANSZ);" ;
         O.oiii "set_role(g,&c,part);";
         O.oiii "choose_params(g,&c,part);" ;


### PR DESCRIPTION
Hi Luc,

These are some minor clean-ups. I wanted to remove unnecessary functions, use more of the kvm-unit-tests API and avoid some #ifdefs. Feel free reject any of them as they don't fix any bug in particular.

As a more general note, what do you think about moving some of the C code to .c file rather than generating from ocaml? We can also create different versions of some functions to avoid #ifdefs and/or avoid their dynamic generation (for example `postlude` and `postlude_kvm`).

Nikos