### PR TITLE
[lherd] Optimised  rf pruning for atomic pairs.

### DIFF
--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -52,6 +52,8 @@ type t =
   | PTE2
 (* Count maximal number of phantom updates by looking at loads *)
   | PhantomOnLoad
+(* Optimise Rf enumeration leading to rmw *)
+  | OptRfRMW
 (* Perform experiment *)
   | Exp
 
@@ -61,7 +63,7 @@ let tags =
    "mixed";"dontcheckmixed";"weakpredicated"; "memtag";
    "tagcheckprecise"; "tagcheckunprecise"; "precise"; "imprecise";
    "toofar"; "deps"; "morello"; "instances"; "noptebranch"; "pte2";
-   "pte-squared"; "PhantomOnLoad";
+   "pte-squared"; "PhantomOnLoad"; "OptRfRMW";
    "exp"; ]
 
 let parse s = match Misc.lowercase s with
@@ -93,6 +95,7 @@ let parse s = match Misc.lowercase s with
 | "noptebranch"|"nobranch" -> Some NoPteBranch
 | "pte2" | "pte-squared" -> Some PTE2
 | "phantomonload" -> Some PhantomOnLoad
+| "optrfrmw" -> Some OptRfRMW
 | "exp" -> Some Exp
 | _ -> None
 
@@ -125,6 +128,7 @@ let pp = function
   | NoPteBranch -> "NoPteBranch"
   | PTE2 -> "pte-squared"
   | PhantomOnLoad -> "PhantomOnLoad"
+  | OptRfRMW -> "OptRfRMW"
   | Exp -> "exp"
 
 let compare = compare

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -50,6 +50,8 @@ type t =
   | PTE2
 (* Generate extra spurious updates based upon load on pte. *)
   | PhantomOnLoad
+(* Optimise Rf enumeration leading to rmw *)
+  | OptRfRMW
 (* Perform experiment *)
   | Exp
 

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -382,6 +382,10 @@ let rec for_all_strict p = function
 let exists_exists p xss =
   List.exists (fun xs -> List.exists p xs) xss
 
+let rec exists_pair p xs = match xs with
+| [] -> false
+| x::xs -> List.exists (p x) xs || exists_pair p xs
+
 let nsplit n xs =
   let rec combine xs yss = match yss with
   | [] -> xs,yss

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -129,6 +129,9 @@ val for_all_strict : ('a -> bool) -> 'a list -> bool
 (* List.exists on list of list *)
 val exists_exists : ('a -> bool) -> 'a list list -> bool
 
+(* Does a pair in list satisfy predicate ? *)
+val exists_pair : ('a -> 'a -> bool) -> 'a list -> bool
+
 (* split a list into n list of as much as possible equal length *)
 val nsplit : int -> 'a list -> 'a list list
 


### PR DESCRIPTION
This optional optimisation is commanded by the variant `-variant OptRfRMW`. It consists in pruning candidates whose rf relation is such that one rf edge targets more than one load engaged in a atomic (rmw) pair. Namely, those should be discarded later by any cat model that performs atomicity check.
