### PR TITLE
[lib]: Added Void C Type

### DIFF
--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -346,8 +346,8 @@ end = struct
     | Some (A.V.Val (PteVal v)) -> V.is_zero (V.intToV v.PTEVal.db)
     | _ -> false
 
-  let read_pteaf0 act = af0_val (read_of act)
-  and read_ptedb0 act = db0_val (read_of act)
+  let val_pteaf0 act = af0_val (read_of act) || af0_val (written_of act)
+  and val_ptedb0 act = db0_val (read_of act) || db0_val (written_of act)
 
   let get_pteval act = match written_of act,read_of act with
   | None,None -> None
@@ -495,8 +495,8 @@ end = struct
         ("PTE",is_pt)::
         ("PTEINV",invalid_pte)::
         ("PTEV",valid_pte)::
-        ("PTEAF0",read_pteaf0)::
-        ("PTEDB0",read_ptedb0)::
+        ("PTEAF0",val_pteaf0)::
+        ("PTEDB0",val_ptedb0)::
         k
     else
       fun k -> k)

--- a/lib/CType.ml
+++ b/lib/CType.ml
@@ -27,7 +27,7 @@ type t =
   | Array of base * int
 
 let void = Base "void"
-let voidstar = Pointer (Base "void")
+let voidstar = Pointer void
 let word = Base "int"
 let quad = Base "int64_t"
 let int128 = Array ("int",4) (* Why not Base "int128_t"? *)


### PR DESCRIPTION
Kindly reviewed by @relokin 

Consider the C code fragment:
```
void *P0 (...) {
    ....
}
```
which is the (pthread friendly) format of concurrent C functions. We may
wish to generate this using diy, and so we would need to know to print a
void pointer type. This patch adds the `void` type in lib, which we can
later combine to generate such a code fragment.