### PR TITLE
Extend the syntax of faults to include a proposition

### DIFF
--- a/herd/constraints.ml
+++ b/herd/constraints.ml
@@ -36,8 +36,6 @@ module type S = sig
   type constr = prop ConstrGen.constr
 
 (* Does loc appears in constr ? *)
-  val loc_in : A.location -> constr -> bool
-
   val foralltrue : constr
 
   module Mixed : functor (SZ: ByteSize.S) -> sig
@@ -87,31 +85,6 @@ module Make (C:Config) (A : Arch_herd.S) :
         type constr = prop ConstrGen.constr
 
         let foralltrue = ForallStates ptrue
-
-        let loc_in_atom loc = function
-          | LL (l1,l2) ->
-              A.location_compare l1 loc = 0 ||
-              A.location_compare l2 loc = 0
-          | LV (l,_) ->
-              A.location_compare (loc_of_rloc l) loc = 0
-          | FF (_,x) ->
-              A.location_compare
-                (A.Location_global x)
-                loc = 0
-
-        let rec loc_in_prop loc p = match p with
-        | Atom a -> loc_in_atom loc a
-        | Not p -> loc_in_prop loc p
-        | And ps|Or ps -> loc_in_props loc ps
-        | Implies (p1,p2) ->
-            loc_in_prop loc p1 || loc_in_prop loc p2
-
-        and loc_in_props loc =  List.exists (loc_in_prop loc)
-
-        let loc_in loc c = match c with
-        | ForallStates p
-        | ExistsState p
-        | NotExistsState p -> loc_in_prop loc p
 
         module Mixed (SZ : ByteSize.S) = struct
           module AM = A.Mixed(SZ)

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -306,7 +306,7 @@ end = struct
     | Access _|Amo _|Commit _|Barrier _ | TooFar | Inv _ | DC _|Arch _ -> false
 
   let to_fault = function
-    | Fault (i,A.Location_global x,msg) -> Some ((i.A.proc,i.A.labels),x,msg)
+    | Fault (i,A.Location_global x,msg) -> Some ((i.A.proc,i.A.labels),x,A.rstate_empty,msg)
     | Fault _|Access _|Amo _|Commit _|Barrier _ |TooFar|Inv _|DC _|Arch _
       -> None
 

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -351,7 +351,7 @@ module Make(O:Config)(M:XXXMem.S) =
           A.FaultSet.filter
             (fun flt ->
               A.FaultAtomSet.exists
-                (fun f -> A.check_one_fatom flt f) test.Test_herd.ffaults)
+                (fun f -> A.check_one_fatom (fun _ _ -> true) flt f) test.Test_herd.ffaults)
         else fun _ -> A.FaultSet.empty in
 
       let final_state_restrict_locs test fsc =

--- a/jingle/mapping.ml
+++ b/jingle/mapping.ml
@@ -298,13 +298,16 @@ module Make(C:Config) = struct
             k)
         src.init [] in
 
-    let map_lv_ll =
+    let rec map_atom =
       ConstrGen.(function
         | LV(l,v) -> LV(conv_rloc map l,v)
         | LL(l1,l2) -> LL(conv_loc map l1,conv_loc map l2)
-        | FF (_,x) as a -> ignore (Constant.check_sym x) ; a) in
-    let condition = ConstrGen.map_constr map_lv_ll src.condition
-    and filter = Misc.app_opt (ConstrGen.map_prop map_lv_ll) src.filter in
+        | FF (_,x,None) as a -> ignore (Constant.check_sym x) ; a
+        | FF (p,x,Some prop) ->
+           ignore (Constant.check_sym x);
+           FF(p,x,Some (ConstrGen.map_prop map_atom prop))) in
+    let condition = ConstrGen.map_constr map_atom src.condition
+    and filter = Misc.app_opt (ConstrGen.map_prop map_atom) src.filter in
     let locations =
       LocationsItem.map_locs (fun loc -> conv_loc map loc) src.locations in
     { info = (OutMapping.key,dump_map map)::src.info;

--- a/lib/constrGen.mli
+++ b/lib/constrGen.mli
@@ -41,18 +41,18 @@ val match_rloc :
 type ('loc,'v) atom =
   | LV of 'loc rloc * 'v
   | LL of 'loc * 'loc
-  | FF of 'v Fault.atom
+  | FF of ('v,('loc,'v) prop) Fault.atom
+
+and ('l,'v) prop =
+  | Atom of ('l,'v) atom
+  | Not of  ('l,'v) prop
+  | And of  ('l,'v) prop list
+  | Or of  ('l,'v) prop list
+  | Implies of  ('l,'v) prop * ('l,'v) prop
 
 val dump_atom :
     ('loc -> string) ->  ('loc -> string) -> ('c Constant.t -> string) ->
       ('loc,'c Constant.t) atom -> string
-
-type ('loc,'v) prop =
-  | Atom of ('loc, 'v) atom
-  | Not of ('loc,'v) prop
-  | And of ('loc,'v) prop list
-  | Or of ('loc,'v) prop list
-  | Implies of ('loc,'v) prop * ('loc,'v) prop
 
 type 'prop constr =
     ForallStates of 'prop

--- a/lib/dumpUtils.ml
+++ b/lib/dumpUtils.ml
@@ -27,7 +27,7 @@ let dump_locations dump_location dump_v env = match env with
     | Ty t -> sprintf "%s %s;" (dump_location loc) t
     | Pointer t -> sprintf "%s %s*;" (dump_location loc) t
     | TyArray _|Atomic _ -> assert false (* No arrays nor atomics here *)
-    and dump_fault f = sprintf "%s;" (Fault.pp_fatom dump_v f) in
+    and dump_fault f = sprintf "%s;" (Fault.pp_fatom dump_v (fun _ -> "") f) in
     let dump_item i =
       let open LocationsItem in
       match i with

--- a/lib/dumpUtils.mli
+++ b/lib/dumpUtils.mli
@@ -15,6 +15,6 @@
 (****************************************************************************)
 
 val dump_locations :
- ('loc -> string) -> ('v -> string) -> ('loc ,'v) LocationsItem.t list -> string
+ ('loc -> string) -> ('v -> string) -> ('loc,'v) LocationsItem.t list -> string
 
 val dump_state : ('bd -> string) -> 'bd list list -> string list

--- a/lib/fault.ml
+++ b/lib/fault.ml
@@ -19,44 +19,63 @@ open Printf
 
 module type I = sig
   type arch_global
+  type prop
+  type frstate
   val pp_global : arch_global -> string
   val global_compare : arch_global -> arch_global -> int
   val same_id_fault : arch_global -> arch_global -> bool
+  val frstate_compare : frstate -> frstate -> int
 end
 
-type 'loc atom =  (Proc.t * Label.t option) * 'loc
+type ('loc,'prop) atom =  (Proc.t * Label.t option) * 'loc * 'prop option
 
-let pp_gen f pp_lbl pp_loc (lbl,x) =
-  sprintf "%s(%s,%s)" f (pp_lbl lbl) (pp_loc x)
+let pp_gen f pp_lbl pp_loc pp_prop (lbl,x,prop) =
+  let prop =
+    match prop with
+    | Some p -> "," ^ (pp_prop p)
+    | None -> ""
+  in
+  sprintf "%s(%s,%s%s)" f (pp_lbl lbl) (pp_loc x) (prop)
 
-let pp_fatom pp_loc =
+let pp_fatom pp_loc pp_prop =
   pp_gen "fault"
     (fun (p,lbl) -> match lbl with
     | None -> Proc.pp p
     | Some lbl -> sprintf "%s:%s" (Proc.pp p) (Label.pp lbl))
-    pp_loc
+    pp_loc pp_prop
 
-let atom_compare compare ((p1,lbl1),v1) ((p2,lbl2),v2) = match Proc.compare p1 p2 with
-| 0 ->
-    begin match Misc.opt_compare String.compare lbl1 lbl2 with
-    | 0 -> compare v1 v2
-    | r -> r
-    end
-| r -> r
+let pp_fatom_noprop pp_loc (lbl,x,_) =
+  let pp_lbl (p,lbl) =
+      match lbl with
+      | None -> Proc.pp p
+      | Some lbl -> sprintf "%s:%s" (Proc.pp p) (Label.pp lbl)
+  in
+  sprintf "fault(%s,%s)" (pp_lbl lbl) (pp_loc x)
 
-let map_value f (p,v) = (p,f v)
+let atom_compare compare ((p1,lbl1),v1,_prop1) ((p2,lbl2),v2,_prop2) =
+  match Proc.compare p1 p2 with
+  | 0 ->
+     begin match Misc.opt_compare String.compare lbl1 lbl2 with
+     | 0 -> compare v1 v2
+     | r -> r
+     end
+  | r -> r
+
+let map_value f (p,v,prop) = (p,f v,prop)
 
 module type S = sig
 
   type loc_global
+  type prop
+  type rstate
 
-  type fault = (Proc.t * Label.Set.t) * loc_global * string option
-  val pp_fault : fault -> string
+  type fault = (Proc.t * Label.Set.t) * loc_global * rstate * string option
+  val pp_fault : (rstate -> string) -> fault -> string
   module FaultSet : MySet.S with type elt = fault
 
-  type fatom = loc_global atom
-  val check_one_fatom : fault -> fatom -> bool
-  val check_fatom : FaultSet.t -> fatom -> bool
+  type fatom = (loc_global,prop) atom
+  val check_one_fatom : (prop option -> rstate -> bool) -> fault -> fatom -> bool
+  val check_fatom : (prop option -> rstate -> bool) -> FaultSet.t -> fatom -> bool
   module FaultAtomSet : MySet.S with type elt = fatom
 
 end
@@ -65,7 +84,10 @@ module Make(A:I) =
   struct
 
     type loc_global = A.arch_global
-    type fault = (Proc.t * Label.Set.t) * loc_global * string option
+    type prop = A.prop
+    type rstate = A.frstate
+
+    type fault = (Proc.t * Label.Set.t) * loc_global * rstate * string option
 
     let pp_lbl (p,lbl) = match Label.Set.as_small 1 lbl with
     | Some [] ->  Proc.pp p
@@ -75,21 +97,32 @@ module Make(A:I) =
           (Label.Set.pp_str "," Label.pp lbl)
 
 
-    let pp_fault (lbl,x,msg) = match msg with
-    | Some msg ->
-        sprintf "Fault(%s,%s,%s)" (pp_lbl lbl) (A.pp_global x) msg
-    | None ->
-        sprintf "Fault(%s,%s)" (pp_lbl lbl) (A.pp_global x)
+    let pp_fault pp_rstate (lbl,x,rstate,msg) =
+      let msg =
+        match msg with
+        | Some msg ->
+           sprintf ",%s" msg
+        | None ->
+           "" in
+      let rstate =
+        match pp_rstate rstate with
+        | "" -> ""
+        | _ as s -> sprintf ";(%s\b)" s in
+      sprintf "Fault(%s,%s%s%s)" (pp_lbl lbl) (A.pp_global x) rstate msg
 
 
     let compare_lbl (p1,lbl1) (p2,lbl2) = match Proc.compare p1 p2 with
     | 0 -> Label.Set.compare lbl1 lbl2
     | r -> r
 
-    let compare (lbl1,x1,msg1) (lbl2,x2,msg2) = match compare_lbl lbl1 lbl2 with
+    let compare (lbl1,x1,rst1,msg1) (lbl2,x2,rst2,msg2) = match compare_lbl lbl1 lbl2 with
     | 0 ->
       begin match A.global_compare x1 x2 with
-      | 0 -> Misc.opt_compare String.compare msg1 msg2
+      | 0 ->
+         begin match Misc.opt_compare String.compare msg1 msg2 with
+         | 0 -> A.frstate_compare rst1 rst2
+         | r -> r
+         end
       | r -> r
       end
     | r -> r
@@ -101,26 +134,26 @@ module Make(A:I) =
           let compare = compare
         end)
 
-    type fatom = loc_global atom
+    type fatom = (loc_global,prop) atom
 
-    let check_one_fatom ((p0,lbls0),x0,_)  ((p,lblo),x) =
+    let check_one_fatom check_prop (((p0,lbls0),x0,rstate,_):fault) (((p,lblo),x,prop):fatom) =
       Proc.compare p p0 = 0 &&
       A.same_id_fault x x0 &&
       begin match lblo with
       | None -> true
-      | Some lbl -> Label.Set.mem lbl lbls0
-      end
+      | Some lbl -> Label.Set.mem lbl lbls0 end &&
+      check_prop prop rstate
 
-    let check_fatom flts a =
+    let check_fatom check_prop flts a =
       FaultSet.exists
-        (fun flt -> check_one_fatom flt a)
+        (fun flt -> check_one_fatom check_prop flt a)
         flts
 
     module FaultAtomSet =
       MySet.Make
         (struct
           type t = fatom
-          let compare ((p0,lbl0),x0)  ((p1,lbl1),x1) =
+          let compare ((p0,lbl0),x0,_prop0)  ((p1,lbl1),x1,_prop) =
             match Proc.compare p0 p1 with
             | 0 ->
                 begin match Misc.opt_compare Label.compare lbl0 lbl1 with

--- a/lib/fault.mli
+++ b/lib/fault.mli
@@ -19,35 +19,41 @@
 
 module type I = sig
   type arch_global
+  type prop
+  type frstate
   val pp_global : arch_global -> string
   val global_compare : arch_global -> arch_global -> int
 (* Identifiers in faults are considered identical *)
   val same_id_fault : arch_global -> arch_global -> bool
+  val frstate_compare : frstate -> frstate -> int
 end
 
-type 'loc atom =  (Proc.t * Label.t option) * 'loc
+type ('loc,'prop) atom =  (Proc.t * Label.t option) * 'loc * 'prop option
 
-val pp_fatom : ('loc -> string) -> 'loc atom -> string
+val pp_fatom : ('loc -> string) -> ('v -> string) -> ('loc,'v) atom -> string
+val pp_fatom_noprop : ('loc -> string) -> ('loc,'v) atom -> string
 
-val atom_compare : ('loc -> 'loc -> int) -> 'loc atom -> 'loc atom -> int
+val atom_compare : ('loc -> 'loc -> int) -> ('loc,'prop) atom -> ('loc,'prop) atom -> int
 
-val map_value : ('v -> 'w) -> 'v atom -> 'w atom
+val map_value : ('v -> 'w) -> ('v,'prop) atom -> ('w,'prop) atom
 
 module type S = sig
 
   type loc_global
+  type prop
+  type rstate
 
-  type fault = (Proc.t * Label.Set.t) * loc_global * string option
-  val pp_fault : fault -> string
+  type fault = (Proc.t * Label.Set.t) * loc_global * rstate * string option
+  val pp_fault : (rstate -> string) -> fault -> string
 
   module FaultSet : MySet.S with type elt = fault
 
-  type fatom = loc_global atom
-  val check_one_fatom : fault -> fatom -> bool
-  val check_fatom : FaultSet.t -> fatom -> bool
+  type fatom = (loc_global,prop) atom
+  val check_one_fatom : (prop option -> rstate -> bool) -> fault -> fatom -> bool
+  val check_fatom : (prop option -> rstate -> bool) -> FaultSet.t -> fatom -> bool
 
   module FaultAtomSet : MySet.S with type elt = fatom
 
 end
 
-module Make : functor (A:I) -> S with type loc_global := A.arch_global
+module Make : functor (A:I) -> S with type loc_global := A.arch_global and type prop := A.prop and type rstate := A.frstate

--- a/lib/genParser.ml
+++ b/lib/genParser.ml
@@ -203,9 +203,9 @@ module Make
                 let map_atom = function
                   | LV (loc,v) -> LV (map_rloc loc,v)
                   | LL (loc1,loc2) ->  LL (map_loc loc1,map_loc loc2)
-                  | FF (p,x) ->
+                  | FF (p,x,prop) ->
                       begin match map_loc (Location_global x) with
-                      | Location_global x -> FF (p,x)
+                      | Location_global x -> FF (p,x,prop)
                       | _ -> assert false
                       end
                 in

--- a/lib/locationsItem.mli
+++ b/lib/locationsItem.mli
@@ -14,7 +14,11 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type ('loc,'v) t = Loc of 'loc ConstrGen.rloc * TestType.t | Fault of 'v Fault.atom
+type ('loc,'v) fault_atom = ('v,('loc,'v) ConstrGen.prop) Fault.atom
+
+type ('loc, 'v) t =
+| Loc of 'loc ConstrGen.rloc * TestType.t
+| Fault of ('loc,'v) fault_atom
 
 val fold_loc : ('loc -> 'r -> 'r) -> ('loc,'v) t -> 'r -> 'r
 val fold_locs : ('loc -> 'r -> 'r) -> ('loc,'v) t list -> 'r -> 'r
@@ -26,4 +30,4 @@ val map_loc : ('loc -> 'a) -> ('loc,'v) t -> ('a,'v) t
 val map_locs : ('loc -> 'a) -> ('loc,'v) t list -> ('a,'v) t list
 
 val locs_and_faults :
-  ('loc, 'v) t list -> ('loc ConstrGen.rloc list * 'v Fault.atom list)
+  ('loc,'v) t list -> ('loc ConstrGen.rloc list * ('loc,'v)fault_atom list)

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -241,8 +241,8 @@ fault_loc:
 | TOK_PTE LPAR name=NAME RPAR { Constant.mk_sym_pte name }
 
 fault:
-| FAULT LPAR lbl COMMA fault_loc RPAR { ($3,$5) }
-
+| FAULT LPAR lbl COMMA fault_loc RPAR { ($3,$5,None) }
+| FAULT LPAR lbl COMMA fault_loc COMMA prop RPAR { ($3,$5,Some $7) }
 
 loc_item:
 | rloc_typ { let a,t = $1 in LocationsItem.Loc (a,t) }
@@ -383,7 +383,6 @@ atom_prop:
    Delitng it is not a real problem by symetry of equal */
 /* | loc1=location_reg  equal loc2=loc_brk
     { Atom (LL (loc1,loc2)) } */
-| fault { Atom (FF $1) }
 
 prop:
 | TRUE
@@ -392,6 +391,8 @@ prop:
     {Or []}
 | atom_prop
     { $1 }
+| fault
+    { Atom (FF $1) }
 | NOT prop
     {Not $2}
 | prop AND prop

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -112,7 +112,7 @@ module Make
             type location = A.location
             type t = A.rlocation
             let compare = A.rlocation_compare
-            let dump loc = "_" ^ A.dump_rloc_tag loc
+            let dump _f loc = "_" ^ A.dump_rloc_tag loc
             let dump_fatom d a = "_" ^ SkelUtil.dump_fatom_tag d a
           end
         end)

--- a/litmus/compCondUtils.mli
+++ b/litmus/compCondUtils.mli
@@ -20,8 +20,8 @@ module type X = sig
   type location
   type t = location ConstrGen.rloc
   val compare : t -> t -> int
-  val dump : t -> string
-  val dump_fatom : ('v -> string) -> 'v Fault.atom -> string
+  val dump : ('v,'prop) Fault.atom option -> t -> string
+  val dump_fatom : ('v -> string) -> ('v,'prop) Fault.atom -> string
 end
 
 module type I = sig

--- a/litmus/constr.ml
+++ b/litmus/constr.ml
@@ -29,6 +29,7 @@ module type S = sig
 
   type prop = (location,V.v) ConstrGen.prop
   type cond = prop ConstrGen.constr
+  type fault = (V.v,prop) Fault.atom
 
 (* List of read locations *)
   val locations : cond -> LocSet.t
@@ -41,7 +42,7 @@ module type S = sig
   val location_values_prop : prop -> string list
 
 (* All faults *)
-  val get_faults : cond -> V.v Fault.atom list
+  val get_faults : cond -> fault list
 
 end
 
@@ -63,6 +64,7 @@ module RLocSet = A.RLocSet =
 
     type prop = (location,V.v) ConstrGen.prop
     type cond = prop ConstrGen.constr
+    type fault = (V.v,prop) Fault.atom
 
     let locations_atom a r =
       match a with
@@ -115,7 +117,8 @@ module RLocSet = A.RLocSet =
       Strings.elements locs
 
     module F = struct
-      type t = A.V.v Fault.atom
+      type prop = (A.location,A.V.v) ConstrGen.prop
+      type t = (A.V.v,prop) Fault.atom
       let compare = Fault.atom_compare A.V.compare
     end
 

--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -32,6 +32,7 @@ let fmt_pte_tag x = Misc.add_pte x
 let fmt_pte_kvm x = sprintf "_vars->%s" (fmt_pte_tag x)
 let fmt_phy_tag x = "saved_" ^ Misc.add_pte x
 let fmt_phy_kvm x = sprintf "_vars->%s" (fmt_phy_tag x)
+let fmt_fault_vars x = sprintf "_vars->%s" (fmt_phy_tag x)
 
 (* Value (address) output *)
 module type Config = sig

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -213,6 +213,25 @@ module Make
 (***************************************)
 (* Various inclusions from C utilities *)
 (***************************************)
+      (************)
+      (* Outcomes *)
+      (************)
+
+      let does_pad t =
+        let open CType in
+        match t with
+        | Pointer _
+        | Array (("int"|"int32_t"|"uint32_t"|"int64_t"|"uint64_t"),_)
+        | Base ("int"|"int32_t"|"uint32_t"|"int64_t"|"uint64_t") -> true
+        | _ -> false
+
+      let dump_loc_tag_coded loc =  sprintf "%s_idx" (A.dump_loc_tag loc)
+
+      let dump_rloc_tag_coded loc =  sprintf "%s_idx" (A.dump_rloc_tag loc)
+
+      let choose_dump_rloc_tag rloc env =
+        if U.is_rloc_ptr rloc env then dump_rloc_tag_coded rloc
+        else  A.dump_rloc_tag rloc
 
 (* Time base *)
       let dump_read_timebase () =
@@ -236,17 +255,102 @@ module Make
 (* Fault handler *)
       let filter_fault_lbls =
         List.filter
-          (fun ((_,o),_) -> Misc.is_some o)
+          (fun ((_,o),_,_) -> Misc.is_some o)
 
       let tag_seen f =
         sprintf "see_%s" (SkelUtil.dump_fatom_tag A.V.pp_v_old f)
-      and tag_code ((p,lbl),_) = sprintf "code_P%d%s" p
+      and tag_code ((p,lbl),_,_) = sprintf "code_P%d%s" p
           (match lbl with None -> assert false | Some lbl -> "_" ^ lbl)
       and tag_log f =  SkelUtil.dump_fatom_tag A.V.pp_v_old f
       and dump_addr_idx s = sprintf "_idx_%s" s
 
+      let fault_prop_fmt_var var f =
+        SkelUtil.dump_fatom_tag (fun _ -> var) f
 
-      let dump_fault_handler doc test =
+      let fault_prop_get_types_locs env f =
+        let rlocs = match f with
+          | (_,_,Some prop) -> T.C.rlocations_prop prop
+          | _ -> A.RLocSet.empty in
+        A.RLocSet.fold
+          (fun loc k -> (U.find_rloc_type loc env,loc)::k)
+          rlocs []
+
+      let fault_prop_iter_vars env f fault =
+        let fields = fault_prop_get_types_locs env fault in
+        List.iter
+          (fun (t,rloc) ->
+            if CType.is_ptr t then
+              let name = dump_loc_tag_coded (ConstrGen.loc_of_rloc rloc) in
+              let name = fault_prop_fmt_var name fault in
+              f "int" name
+            else
+              match rloc with
+              | ConstrGen.Loc (A.Location_global a as loc) ->
+                 let ctype = SkelUtil.dump_global_type (G.as_addr a) t in
+                 let name = fault_prop_fmt_var (A.dump_loc_tag loc) fault in
+                 f ctype name
+              | _ ->
+                 let ctype = CType.dump t in
+                 let name = fault_prop_fmt_var (A.dump_rloc_tag rloc) fault in
+                 f ctype name)
+          fields
+
+      let fault_prop_declare_vars env fault =
+        fault_prop_iter_vars env (fun t n -> O.fi "%s %s;" t n) fault
+
+      let fault_prop_init_vars env fault =
+        fault_prop_iter_vars env (fun _ n -> O.fi "p->%s = 0;" n) fault
+
+      let fault_prop_read_vars env indent fault =
+        let rlocs = match fault with
+          | (_,_,Some prop) -> T.C.rlocations_prop prop
+          | _ -> A.RLocSet.empty in
+        A.RLocSet.iter
+          (fun loc ->
+            let tag = A.dump_rloc_tag loc in
+            match U.find_rloc_type loc env with
+            | Array (_,sz) ->
+               O.fx indent
+                 "for (int _j = 0 ; _j < %i ; _j++) sf->%s[_j] = vars_ptr[i]->%s[_j];"
+                 sz (fault_prop_fmt_var tag fault) tag
+            | _ ->
+               let lhs = sprintf "sf->%s" (fault_prop_fmt_var tag fault)
+               and rhs =
+                 let open ConstrGen in
+                 match loc with
+                 | Deref (v,i) ->
+                    sprintf "vars_ptr[i]->%s[%d]" (A.dump_loc_tag v) i
+                 | _ -> "*(vars_ptr[i])->"^tag in
+               O.fx indent "%s = %s;" lhs rhs)
+          rlocs
+
+      let fault_prop_save_vars env f =
+        let rlocs = match f with
+          | (_,_,Some prop) -> T.C.rlocations_prop prop
+          | _ -> A.RLocSet.empty in
+        A.RLocSet.iter
+          (fun loc ->
+            let tag = fault_prop_fmt_var (A.dump_rloc_tag loc) f in
+            match U.find_rloc_type loc env with
+            | Array (_,sz) ->
+               O.fii
+                 "for (int _j = 0 ; _j < %i ; _j++) %s[_j] = %s[_j];"
+                 sz (OutUtils.fmt_presi_index tag) tag
+            | _ ->
+               let lhs =
+                 (if U.is_rloc_ptr loc env then
+                    OutUtils.fmt_presi_ptr_index
+                  else OutUtils.fmt_presi_index) tag
+               and rhs =
+                 let open ConstrGen in
+                 match loc with
+                 | Deref (v,i) ->
+                    sprintf "%s[%d]" (A.dump_loc_tag v) i
+                 | _ -> tag in
+               O.fii "%s = _ctx->f.%s;" lhs rhs)
+          rlocs
+
+      let dump_fault_handler doc test env =
         if have_fault_handler then begin
           O.o "/* Fault Handling */" ;
           O.o "#define HAVE_FAULT_HANDLER 1" ;
@@ -306,6 +410,7 @@ module Make
               end ;
               O.o "typedef struct {" ;
               O.fi "int %s;" (String.concat "," (List.map tag_seen faults)) ;
+              List.iter (fault_prop_declare_vars env) faults ;
               O.o "} see_fault_t;" ;
               O.o "" ;
               if do_dynalloc then begin
@@ -327,7 +432,10 @@ module Make
               O.o "" ;
               O.o "static void init_see_fault(see_fault_t *p) {" ;
               List.iter
-                (fun f -> O.fi "p->%s = 0;" (tag_seen f))
+                (fun f ->
+                  O.fi "p->%s = 0;" (tag_seen f);
+                  fault_prop_init_vars env f;
+                )
                 faults ;
               O.o "}" ;
               O.o "" ;
@@ -341,23 +449,24 @@ module Make
               O.oi "see_fault_t *sf = see_fault[i];" ;
               O.oi "switch (w->proc) {" ;
               Misc.group_iter
-                (fun ((p,_),_) ((q,_),_) -> Misc.int_eq p q)
-                (fun ((p,_),_) fs ->
+                (fun ((p,_),_,_) ((q,_),_,_) -> Misc.int_eq p q)
+                (fun ((p,_),_,_) fs ->
                   O.fi "case %d: {" p ;
                   Misc.group_iteri
-                    (fun (_,v) (_,w) -> A.V.compare v w = 0)
-                    (fun k (_,v) fs ->
+                    (fun (_,v,_) (_,w,_) -> A.V.compare v w = 0)
+                    (fun k (_,v,_) fs ->
                       let prf = if k > 0 then "else if" else "if"
                       and test =
                         sprintf "idx_loc == %s"
                           (dump_addr_idx (A.V.pp_v_old v)) in
                       O.fii "%s (%s) {" prf test ;
-                      let no_lbl ((_,o),_) = Misc.is_none o in
+                      let no_lbl ((_,o),_,_) = Misc.is_none o in
                       let no,fs = List.partition no_lbl fs in
                       begin match no with
                       | [] -> ()
                       | f::_ ->
                           O.fiii "atomic_inc_fetch(&sf->%s);" (tag_seen f) ;
+                          fault_prop_read_vars env Indent.indent3 f;
                       end ;
                       List.iteri
                         (fun k f  ->
@@ -365,7 +474,8 @@ module Make
                           and test = sprintf "pc == labels.%s" (tag_code f)
                           and act =  sprintf "atomic_inc_fetch(&sf->%s)" (tag_seen f) in
                           O.fiii "%s (%s) {" prf test ;
-                          O.fiv "%s;" act)
+                          O.fiv "%s;" act;
+                          fault_prop_read_vars env Indent.indent4 f;)
                         fs ;
                       if Misc.consp fs then O.fiii "}" ;
                       O.fii "}")
@@ -519,26 +629,6 @@ module Make
           ()
         end
 
-(************)
-(* Outcomes *)
-(************)
-
-      let does_pad t =
-        let open CType in
-        match t with
-        | Pointer _
-        | Array (("int"|"int32_t"|"uint32_t"|"int64_t"|"uint64_t"),_)
-        | Base ("int"|"int32_t"|"uint32_t"|"int64_t"|"uint64_t") -> true
-        | _ -> false
-
-      let dump_loc_tag_coded loc =  sprintf "%s_idx" (A.dump_loc_tag loc)
-
-      let dump_rloc_tag_coded loc =  sprintf "%s_idx" (A.dump_rloc_tag loc)
-
-      let choose_dump_rloc_tag rloc env =
-        if U.is_rloc_ptr rloc env then dump_rloc_tag_coded rloc
-        else  A.dump_rloc_tag rloc
-
 (* Collected locations *)
 
       let fmt_outcome test env locs =
@@ -608,8 +698,8 @@ module Make
         begin match faults with
         | [] -> ()
         | fs ->
-            O.fi "int %s;"
-              (String.concat "," (List.map tag_log fs))
+            O.fi "int %s;" (String.concat "," (List.map tag_log fs));
+            List.iter (fault_prop_declare_vars env) fs
         end ;
         if pad  then O.oi "uint32_t _pad;" ;
         O.o "} log_t;" ;
@@ -701,56 +791,58 @@ module Make
           O.o ""
         end ;
         O.o "/* Dump of outcome */" ;
-        O.o "static void pp_log(FILE *chan,log_t *p) {"  ;
-        let fmt = fmt_outcome test env rlocs
-        and args =
-          A.RLocSet.map_list
-            (fun rloc -> match U.find_rloc_type rloc env with
-            | Pointer _ ->
-                None,
-                [sprintf "pretty_addr[p->%s]" (dump_rloc_tag_coded rloc)]
-            | Array (_,sz) ->
-                let tag = A.dump_rloc_tag rloc in
-                let rec pp_rec k =
-                  if k >= sz then []
-                  else
-                    sprintf "p->%s[%i]" tag k::pp_rec (k+1) in
-                None,pp_rec 0
-            | Base "pteval_t" ->
-                let v = sprintf "p->%s" (A.dump_rloc_tag rloc) in
-                let fs =
-                  sprintf "pretty_addr_physical[unpack_oa(%s)]" v::
-                  List.map
-                    (fun f -> sprintf "unpack_%s(%s)" f v)
-                    ["af";"db";"dbm";"valid";"el0";] in
-                Some v,fs
-            | _ ->
-                None,[sprintf "p->%s" (A.dump_rloc_tag rloc)])
-            rlocs in
-        let fst = ref true in
-        List.iter2
-          (fun (p1,p2) (as_whole,arg) ->
-            let prf = if !fst then "" else " " in
-            fst := false ;
-            match as_whole with
-            | Some as_whole -> (* Assuming a pteval_t *)
-                O.fi "if (%s == NULL_PACKED) {" as_whole ;
-                EPF.fii ~out:"chan"
-                  "%s;" ["\""^prf^p1^"="^(if Cfg.hexa then "0x0" else "0")^"\""] ;
-                O.oi "} else {" ;
-                let oa,rem = match arg with
-                  | oa::rem -> oa,rem
-                  | [] -> assert false
-                and oa_fmt,rem_fmt = match p2 with
-                  | o::oa::rem -> o^oa,rem
-                  | _ -> assert false in
-                EPF.fii ~out:"chan" (sprintf "%s%s=%s" prf p1 oa_fmt) [oa] ;
-                let ds =
-                  let open PTEVal in
-                  let p = prot_default in
-                  let ds = [p.af; p.db; p.dbm; p.valid;p.el0;] in
-                  List.map (sprintf "%i") ds in
-                let rec do_rec ds fs fmts = match ds,fs,fmts with
+        O.o "static void pp_log(%slog_t *p,log_t *p) {" ;
+        let dump_rlocs prefix rlocs =
+          let fmt = fmt_outcome test env rlocs
+          and args =
+            A.RLocSet.map_list
+              (fun rloc ->
+                match U.find_rloc_type rloc env with
+                | Pointer _ ->
+                   None,
+                   [sprintf "pretty_addr[%s%s]" prefix (dump_rloc_tag_coded rloc)]
+                | Array (_,sz) ->
+                   let tag = A.dump_rloc_tag rloc in
+                   let rec pp_rec k =
+                     if k >= sz then []
+                     else
+                       sprintf "%s%s[%i]" prefix tag k::pp_rec (k+1) in
+                   None,pp_rec 0
+                | Base "pteval_t" ->
+                   let v = sprintf "%s%s" prefix (A.dump_rloc_tag rloc) in
+                   let fs =
+                     sprintf "pretty_addr_physical[unpack_oa(%s)]" v::
+                       List.map
+                         (fun f -> sprintf "unpack_%s(%s)" f v)
+                         ["af";"db";"dbm";"valid";"el0";] in
+                   Some v,fs
+                | _ ->
+                   None,[sprintf "%s%s" prefix (A.dump_rloc_tag rloc)])
+              rlocs in
+          let fst = ref true in
+          List.iter2
+            (fun (p1,p2) (as_whole,arg) ->
+              let prf = if !fst then "" else " " in
+              fst := false ;
+              match as_whole with
+              | Some as_whole -> (* Assuming a pteval_t *)
+                 O.fi "if (%s == NULL_PACKED) {" as_whole ;
+                 EPF.fii ~out:"chan"
+                   "%s;" ["\""^prf^p1^"="^(if Cfg.hexa then "0x0" else "0")^"\""] ;
+                 O.oi "} else {" ;
+                 let oa,rem = match arg with
+                   | oa::rem -> oa,rem
+                   | [] -> assert false
+                 and oa_fmt,rem_fmt = match p2 with
+                   | o::oa::rem -> o^oa,rem
+                   | _ -> assert false in
+                 EPF.fii ~out:"chan" (sprintf "%s%s=%s" prf p1 oa_fmt) [oa] ;
+                 let ds =
+                   let open PTEVal in
+                   let p = prot_default in
+                   let ds = [p.af; p.db; p.dbm; p.valid;p.el0;] in
+                   List.map (sprintf "%i") ds in
+                 let rec do_rec ds fs fmts = match ds,fs,fmts with
                   | [],[],[c] ->
                       let c = sprintf "\"%s\"" (String.escaped c) in
                       EPF.fii ~out:"chan" "%s;" [c]
@@ -760,12 +852,14 @@ module Make
                       do_rec ds fs fmts
                   |_ ->  (* All, defaults, arguments and formats agree *)
                      assert false in
-                do_rec ds rem rem_fmt ;
-                O.oi "}"
-            | None ->
-                let p2 = String.concat "" p2 in
-                EPF.fi ~out:"chan" (sprintf "%s%s=%s;" prf p1 p2) arg)
-          fmt args ;
+                 do_rec ds rem rem_fmt ;
+                 O.oi "}"
+              | None ->
+                 let p2 = String.concat "" p2 in
+                 EPF.fi ~out:"chan" (sprintf "%s%s=%s;" prf p1 p2) arg)
+            fmt args ;
+        in
+        dump_rlocs "p->" rlocs;
         begin match faults with
         | [] -> () (* Would output 'printf("");', which gcc may reject. *)
         | _::_ ->
@@ -801,6 +895,11 @@ module Make
           | f::fs ->
               let tag = tag_log f in
               O.fii "p->%s == q->%s &&" tag tag ;
+              O.fii "(p->%s ? (" tag;
+              let check_var _ n = O.fiii "p->%s == q->%s &&" n n in
+              fault_prop_iter_vars env check_var f;
+              O.fiii "1";
+              O.fii ") : 1) &&";
               do_eq_faults fs in
         let rec do_rec = function
           | [] -> do_eq_faults faults
@@ -839,9 +938,12 @@ module Make
                 type location = A.location
                 type t = location ConstrGen.rloc
                 let compare = A.rlocation_compare
-                let dump rloc = sprintf "p->%s" (choose_dump_rloc_tag rloc env)
-                let dump_fatom dump a =
-                  sprintf "p->%s" (SkelUtil.dump_fatom_tag dump a)
+                let dump fo rloc = match fo with
+                  | Some f -> sprintf "p->%s%s"
+                                (SkelUtil.dump_fatom_tag (fun _ -> "") f)
+                                (choose_dump_rloc_tag rloc env)
+                  | None ->  sprintf "p->%s" (choose_dump_rloc_tag rloc env)
+                let dump_fatom dump a = sprintf "p->%s" (SkelUtil.dump_fatom_tag dump a)
               end
             end) in
 
@@ -1379,9 +1481,11 @@ module Make
 (* Collect faults *)
         if Cfg.is_kvm then begin
           List.iter
-            (fun ((p,_),_ as f) ->
-              if Proc.compare proc p = 0 then
-                O.fii "_log->%s = _ctx->f.%s?1:0;" (tag_log f) (tag_seen f))
+            (fun ((p,_),_,_ as f) ->
+              if Proc.compare proc p = 0 then begin
+                  O.fii "_log->%s = _ctx->f.%s?1:0;" (tag_log f) (tag_seen f);
+                  fault_prop_save_vars env f
+                end)
             faults
         end ;
 (* Synchronise *)
@@ -1514,7 +1618,7 @@ module Make
         | _::_ ->
             O.oi "if (_c->role == 0 && _c->inst == 0) {" ;
             List.iter
-              (fun ((p,lbl),_ as f) -> match lbl with
+              (fun ((p,lbl),_,_ as f) -> match lbl with
               | None ->
                   O.fii "labels.%s = (ins_t *) &&CODE%d;" (tag_code f) p
               | Some lbl ->
@@ -1597,7 +1701,7 @@ module Make
               O.o "static void init_labels(void) {" ;
               O.oi "ins_t nop = getnop();" ;
               List.iter
-                (fun ((p,lbl),_ as f) ->
+                (fun ((p,lbl),_,_ as f) ->
                   let lbl = Misc.as_some lbl in
                   let off = U.find_label_offset p lbl test+1 in (* +1 because of added inital nop *)
                   let lhs = sprintf "labels.%s" (tag_code f)
@@ -1935,7 +2039,7 @@ module Make
         let env = U.build_env test in
         let stats = get_stats test in
         let some_ptr = dump_outcomes env test in
-        dump_fault_handler doc test ;
+        dump_fault_handler doc test env ;
         dump_cond_def env test ;
         dump_parameters env test ;
         dump_hash_def doc.Name.name env test ;

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -870,7 +870,7 @@ module Make
               type location = A.location
               type t = A.rlocation
               let compare = A.rlocation_compare
-              let dump = dump_rloc_param
+              let dump _f l = dump_rloc_param l
               let dump_fatom d a = SkelUtil.dump_fatom_tag d a
             end
           end)

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -64,7 +64,7 @@ let rec nitems t = match t with
 | Volatile t|Atomic t|Const t -> nitems t
 | Base _|Pointer _ -> 1
 
-let dump_fatom_tag d ((p,lbl),v) =
+let dump_fatom_tag d ((p,lbl),v,_prop) =
   sprintf "fault_P%d%s_%s" p (match lbl with None -> "" | Some lbl -> "_" ^ lbl) (d v)
 
 let dump_pteval_flags s p =
@@ -117,7 +117,7 @@ module Make
         T.t -> (CType.base -> string) -> A.RLocSet.t -> env
         -> (string * string list) list
       val fmt_outcome : T.t -> (CType.base -> string) -> A.RLocSet.t -> env -> string
-      val fmt_faults : A.V.v Fault.atom list -> string
+      val fmt_faults : (A.V.v,'prop) Fault.atom list -> string
 
 (* Globals *)
       exception NotGlobal
@@ -137,7 +137,7 @@ module Make
       val is_rloc_pte : A.rlocation -> env -> bool
       val pte_in_outs : env -> T.t -> bool
       val ptr_pte_in_outs : env -> T.t -> bool
-      val get_faults : T.t -> A.V.v Fault.atom list
+      val get_faults : T.t -> T.C.fault list
       val find_label_offset : Proc.t -> string -> T.t -> int
 
 (* Instructions *)
@@ -341,7 +341,7 @@ module Make
       let fmt_faults fs =
         String.concat ""
           (List.map
-             (fun f -> sprintf " %s%s;" "%s" (Fault.pp_fatom A.V.pp_v f))
+             (fun f -> sprintf " %s%s;" "%s" (Fault.pp_fatom A.V.pp_v (fun _ -> "") f))
              fs)
 
 (* Locations *)

--- a/litmus/switch.ml
+++ b/litmus/switch.ml
@@ -285,7 +285,7 @@ module Make (O:Indent.S) (I:CompCondUtils.I) :
         let rhs = Array.of_list rhs in
         let t = Array.make (Array.length rhs) [] in
         List.iter (fun (i,j) -> t.(j) <- i :: t.(j)) cs ;
-        O.fx i "switch (%s) {" (I.Loc.dump loc) ;
+        O.fx i "switch (%s) {" (I.Loc.dump None loc) ;
         for k = 0 to Array.length t-1 do
           if k <> d then begin
             dump_cases i t.(k) ;

--- a/litmus/test_litmus.ml
+++ b/litmus/test_litmus.ml
@@ -33,6 +33,8 @@ module type S = sig
 
   type 'a type_env = ('a * CType.t) list
   type env_volatile = string list
+  type prop = (A.location,A.V.v) ConstrGen.prop
+  type fault = (A.V.v,prop) Fault.atom
 
   type t =
     { init : A.state ;
@@ -42,7 +44,7 @@ module type S = sig
       filter : C.prop option ;
       globals : string type_env ;
       flocs : A.location ConstrGen.rloc list ;
-      ffaults : A.V.v Fault.atom list;
+      ffaults : fault list;
       global_code : string list;
       src : src ;
       type_env : CType.t A.LocMap.t * CType.t StringMap.t ;
@@ -75,6 +77,8 @@ struct
          MiscParser.result
 
   type env_volatile = string list
+  type prop = (A.location,A.V.v) ConstrGen.prop
+  type fault = (A.V.v,prop) Fault.atom
 
   type t =
     { init : A.state ;
@@ -84,7 +88,7 @@ struct
       filter : C.prop option ;
       globals : string type_env ; (* Virtual addresses only *)
       flocs : A.location ConstrGen.rloc list ;
-      ffaults : A.V.v Fault.atom list;
+      ffaults : fault list;
       global_code : string list;
       src : src ;
       type_env : CType.t A.LocMap.t * CType.t StringMap.t ;

--- a/tools/alpha.ml
+++ b/tools/alpha.ml
@@ -64,12 +64,15 @@ struct
 
   let collect_state_atom (loc,_) = collect_location loc
 
-  let collect_atom a regs =
+  let rec collect_atom a regs =
     let open ConstrGen in
     match a with
     | LV (rloc,_) -> collect_rloc rloc regs
     | LL (loc1,loc2) ->  collect_location loc1 (collect_location loc2 regs)
-    | FF (_,x) -> collect_location (A.Location_global x) regs
+    | FF (_,x,None) -> collect_location (A.Location_global x) regs
+    | FF (_,x,Some p) ->
+       ConstrGen.fold_prop collect_atom p
+         (collect_location (A.Location_global x) regs)
 
   let collect_state st = List.fold_right collect_state_atom st
 
@@ -80,7 +83,11 @@ struct
     List.fold_right
       (fun i -> match i with
       | Loc (l,_) -> ConstrGen.fold_rloc collect_location l
-      | Fault (_,x) -> collect_location (A.Location_global x))
+      | Fault (_,x,None) -> collect_location (A.Location_global x)
+      | Fault (_,x,Some p) ->
+         (fun regs ->
+           ConstrGen.fold_prop collect_atom p
+             (collect_location (A.Location_global x) regs)))
 
 (***************************)
 (* Alpha conversion proper *)
@@ -113,7 +120,7 @@ struct
     match a with
     | LV (rloc,v) -> LV (alpha_rloc f rloc,v)
     | LL (loc1,loc2) -> LL (alpha_location f loc1,alpha_location f loc2)
-    | FF (_,x) -> ignore (Constant.check_sym x) ; a
+    | FF (_,x,_) -> ignore (Constant.check_sym x) ; a
 
   let alpha_state_atom f (loc,x) = alpha_location f loc,x
 
@@ -124,7 +131,7 @@ struct
     List.map
       (function
         | Loc (x,t) -> Loc (alpha_rloc f x,t)
-        | Fault (_,x) as a -> ignore (Constant.check_sym x); a)
+        | Fault (_,x,_) as a -> ignore (Constant.check_sym x); a)
 
   let alpha_constr f = ConstrGen.map_constr (alpha_atom f)
 
@@ -247,7 +254,7 @@ struct
           collect_rloc f rloc (collect_value f v k)
       | LL (loc1,loc2) ->
           collect_location f loc1 (collect_location f loc2 k)
-      | FF (_,x) ->
+      | FF (_,x,_) ->
           collect_location f (A.Location_global x) k
 
     let map_state_atom f (loc,(t,v)) = map_location f loc,(t,map_value f v)
@@ -263,7 +270,7 @@ struct
           LV (my_map_rloc f rloc,map_value f v)
       | LL (loc1,loc2) ->
           LL (map_location f loc1,map_location f loc2)
-      | FF(p,x) -> FF (p,map_global f x)
+      | FF(p,x,prop) -> FF (p,map_global f x,prop)
 
     let collect_state f = List.fold_right (collect_state_atom f)
 
@@ -280,7 +287,7 @@ struct
       List.map
         (function
           | Loc (x,t) -> Loc (my_map_rloc f x,t)
-          | Fault (p,x)-> Fault (p,map_global f x))
+          | Fault (p,x,prop) -> Fault (p,map_global f x,prop))
 
     module StringSet = MySet.Make(String)
 

--- a/tools/logState.ml
+++ b/tools/logState.ml
@@ -447,7 +447,7 @@ module LC =
       let state_fault st f =
         let open HashedFaults in
         let {HashedState.S.f=fs; _;} = HashedState.as_t st in
-        let (p0,lbl0),v0 = f in
+        let (p0,lbl0),v0,_prop0 = f in
         let eq_label = match lbl0 with
         | None -> fun _ -> true
         | Some lbl0 ->

--- a/tools/mixMerge.ml
+++ b/tools/mixMerge.ml
@@ -159,12 +159,12 @@ end =
       List.map
         (function
           | Loc (l,v) -> Loc (shift_rloc k l,v)
-          | Fault ((i,lbls),x) -> Fault ((i+k,lbls),x))
+          | Fault ((i,lbls),x,prop) -> Fault ((i+k,lbls),x,prop))
 
     let shift_atom k a = match a with
     | LV (l,v) ->  LV (shift_rloc k l,v)
     | LL (a,b) -> LL (shift_location k a,shift_location k b)
-    | FF ((i,lbls),x) -> FF ((i+k,lbls),x)
+    | FF ((i,lbls),x,prop) -> FF ((i+k,lbls),x,prop)
 
     let shift_constr k = ConstrGen.map_constr (shift_atom k)
 

--- a/tools/mixPerm.ml
+++ b/tools/mixPerm.ml
@@ -35,7 +35,7 @@ end =
     let perm_atom p a = match a with
     | LV (loc,v) -> LV (perm_rloc p loc,v)
     | LL (l1,l2) -> LL (perm_location p l1,perm_location p l2)
-    | FF ((i,lbls),x) -> FF ((p.(i),lbls),x)
+    | FF ((i,lbls),x,prop) -> FF ((p.(i),lbls),x,prop)
 
     let perm_constr p = ConstrGen.map_constr (perm_atom p)
 

--- a/tools/mproj.ml
+++ b/tools/mproj.ml
@@ -55,7 +55,7 @@ struct
         if MiscParser.LocSet.mem loc locs then p else And []
     | Atom (LV (Deref _,_)) ->
         prerr_endline "TODO" ; assert false
-    | Atom (FF (_,x)) ->
+    | Atom (FF (_,x,_)) ->
         let loc = MiscParser.Location_global (Constant.check_sym x) in
         if MiscParser.LocSet.mem loc locs then p else And []
     | Or ps ->

--- a/tools/prettyProg.ml
+++ b/tools/prettyProg.ml
@@ -301,6 +301,24 @@ module Make(O:Config)(A:Arch_tools.S) =
 
 
       let arg =
+        let rec pp_atom = function
+          | LV (loc,v) ->
+             let pp_loc =
+               match loc,v with
+               | (Deref _,_)
+               | (_,Constant.ConcreteVector _)
+                 -> pp_location
+               | _ -> pp_location_brk in
+             pp_mbox (ConstrGen.dump_rloc pp_loc loc) ^
+               pp_equal ^
+                 pp_mbox (pp_asm_v v)
+          | LL (l1,l2) ->
+             pp_mbox (pp_location_brk l1) ^
+             pp_equal ^
+             pp_mbox (pp_location_brk l2) ;
+          | FF f ->
+             pp_mbox (Fault.pp_fatom pp_asm_v (ConstrGen.prop_to_string pp_atom) f)
+        in
         { ConstrGen.pp_true = "\\top" ;
           pp_false = "\\perp" ;
           pp_not = "\\neg" ;
@@ -308,24 +326,7 @@ module Make(O:Config)(A:Arch_tools.S) =
           pp_or = "\\vee" ;
           pp_implies = "\\Righarrow" ;
           pp_mbox = sprintf "\\mbox{%s}" ;
-          pp_atom = fun a ->
-            match a with
-            | LV (loc,v) ->
-                let pp_loc =
-                  match loc,v with
-                  | (Deref _,_)
-                  | (_,Constant.ConcreteVector _)
-                    -> pp_location
-                  | _ -> pp_location_brk in
-              pp_mbox (ConstrGen.dump_rloc pp_loc loc) ^
-              pp_equal ^
-              pp_mbox (pp_asm_v v)
-          | LL (l1,l2) ->
-              pp_mbox (pp_location_brk l1) ^
-              pp_equal ^
-              pp_mbox (pp_location_brk l2) ;
-          | FF f ->
-              pp_mbox (Fault.pp_fatom pp_asm_v f)
+          pp_atom = pp_atom
         }
 
       let enddollar = sprintf "$%s$"

--- a/tools/transposeDumper.ml
+++ b/tools/transposeDumper.ml
@@ -28,11 +28,11 @@ module type I = sig
   val dump_global_state : prog -> state -> string
   val dump_proc_state : int -> A.pseudo list -> state -> string option
 
-  type prop
+  type location
+  type prop = (location, v) ConstrGen.prop
   val dump_prop : prop -> string
   val dump_constr : prop ConstrGen.constr -> string
 
-  type location
   val dump_location : location -> string
 
 end
@@ -130,7 +130,7 @@ end = struct
                    fprintf chan "%s %s*; " (dump_rloc loc) t
                |  TestType.TyArray _|TestType.Atomic _ -> assert false
                end
-           | Fault f -> fprintf chan "%s; " (Fault.pp_fatom I.dump_v f))
+           | Fault f -> fprintf chan "%s; " (Fault.pp_fatom I.dump_v I.dump_prop f))
           locs ;
         fprintf chan "]\n"
     end ;


### PR DESCRIPTION
Currently a fault is specified as

fault(Pn,Ln,Loc)

This patch extends the notation to include an optional proposition:

fault(Pn,Ln,Loc,Prop)

This proposition will be checked from the context of the fault handler if and when it is invoked. This proposition is not as general and can only include conditions on the values of memory variables (no registers, or faults). In the current version, we're not restoring the values the pte values and the locations in the fault's proposition have to be readable.