### PR TITLE
C driver for KVM

### DIFF
--- a/litmus/libdir/_aarch64/kvm.c.rules
+++ b/litmus/libdir/_aarch64/kvm.c.rules
@@ -1,19 +1,20 @@
 clean:
-	/bin/rm -f *.o *.s *.t *.elf *.flat *~ $(H)
-
-cleansource:
-	/bin/rm -f *.o *.c *.h *.s *~
+	/bin/rm -f *.o *.s *.t *.elf *.flat *~ *.t $(H)
 
 %.s: %.c
-	$(GCC) $(GCCOPTS) -S $<
+	$(GCC) -DASS $(GCCOPTS) -S $<
+
 %.o: %.c
-%.o: %.s
 	$(GCC) $(GCCOPTS) -c -o $@ $<
+
 %.t: %.s
 	awk -f show.awk $< > $@
 
+%.h: %.t
+	sh toh.sh $< > $@
+        
 %.elf: LDFLAGS = -nostdlib -pie -n
-%.elf: %.o utils.o kvm_timeofday.o $(FLATLIBS) $(SRCDIR)/arm/flat.lds $(cstart.o)
+run.elf: run.o $(OBJ) utils.o kvm_timeofday.o $(FLATLIBS) $(SRCDIR)/arm/flat.lds $(cstart.o)
 	$(GCC) $(CFLAGS) -c -o $(@:.elf=.aux.o) $(SRCDIR)/lib/auxinfo.c \
 		-DPROGNAME=\"$(@:.elf=.flat)\" -DAUXFLAGS=$(AUXFLAGS)
 	$(LD) $(LDFLAGS) -o $@ -T $(SRCDIR)/arm/flat.lds \

--- a/litmus/libdir/_aarch64/kvm.rules
+++ b/litmus/libdir/_aarch64/kvm.rules
@@ -1,9 +1,3 @@
-
-EXE=$(SRC:.c=.flat)
-T=$(SRC:.c=.t)
-
-all: $(EXE) $(T)
-
 clean:
 	/bin/rm -f *.o *.s *.t *.flat *~
 

--- a/litmus/libdir/_aarch64/kvm_user_stacks.c
+++ b/litmus/libdir/_aarch64/kvm_user_stacks.c
@@ -4,7 +4,7 @@
 
 #define USER_MODE 1
 
-void back_to_el1(struct pt_regs *regs,unsigned int esr) {
+static void back_to_el1(struct pt_regs *regs,unsigned int esr) {
   regs->pstate |= 0b0101;
 }
 

--- a/litmus/libdir/_hash.c
+++ b/litmus/libdir/_hash.c
@@ -23,30 +23,18 @@ typedef struct {
   int ok ;
 } entry_t ;
 
-#ifdef KVM
-static void pp_entry(entry_t *p, int verbose, const char **group) ;
-#else
 static void pp_entry(FILE *out,entry_t *p, int verbose, const char **group) ;
-#endif
 
 typedef struct {
   int nhash ;
   entry_t t[HASHSZ] ;
 } hash_t ;
 
-#ifdef KVM
-static void pp_hash(hash_t *t,int verbose,const char **group) {
-#else
 static void pp_hash(FILE *fp,hash_t *t,int verbose,const char **group) {
-#endif
   for (int k = 0 ; k < HASHSZ ; k++) {
     entry_t *p = t->t+k ;
     if (p->c > 0) {
-#ifdef KVM
-      pp_entry(p,verbose,group) ;
-#else
       pp_entry(fp,p,verbose,group) ;
-#endif
     }
   }
 }

--- a/litmus/libdir/_main.c
+++ b/litmus/libdir/_main.c
@@ -26,13 +26,10 @@ static zyva_t arg[AVAIL];
 static pthread_t th[AVAIL];
 #endif
 
-#ifdef KVM
-int RUN(int argc,char **argv) ;
-int RUN(int argc,char **argv) {
-  feature_check();
-#else
 int RUN(int argc,char **argv,FILE *out) ;
 int RUN(int argc,char **argv,FILE *out) {
+#ifdef KVM
+  feature_check();
 #endif
 #ifdef OUT
   opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, mode_random, };
@@ -52,9 +49,7 @@ int RUN(int argc,char **argv,FILE *out) {
   }
   parse_param(prog,global.parse,PARSESZ,p) ;
 #ifdef PRELUDE
-#ifndef KVM
   prelude(out) ;
-#endif
 #endif
   tsc_t start = timeofday();
 #endif
@@ -85,11 +80,7 @@ int RUN(int argc,char **argv,FILE *out) {
       p_false += e->c;
     }
   }
-#ifdef KVM
-  postlude(&global,p_true,p_false,total);
-#else
   postlude(out,&global,p_true,p_false,total);
-#endif
 #endif
   return EXIT_SUCCESS;
 }
@@ -98,9 +89,7 @@ int RUN(int argc,char **argv,FILE *out) {
 int main (int argc,char **argv) {
 #ifdef KVM
   litmus_init();
-  return RUN(argc,argv) ;
-#else
-  return RUN(argc,argv,stdout) ;
 #endif
+  return RUN(argc,argv,stdout) ;
 }
 #endif

--- a/litmus/libdir/_presi.h
+++ b/litmus/libdir/_presi.h
@@ -19,6 +19,9 @@
 #include <stdint.h>
 #ifdef KVM
 #include <libcflat.h>
+typedef void FILE;
+#define stdout NULL
+#define stderr NULL
 #define fprintf(stderr,...) printf(__VA_ARGS__)
 #else
 #include <pthread.h>

--- a/litmus/libdir/_x86_64/kvm.rules
+++ b/litmus/libdir/_x86_64/kvm.rules
@@ -1,9 +1,3 @@
-
-EXE=$(SRC:.c=.flat)
-T=$(SRC:.c=.t)
-
-all: $(EXE) $(T)
-
 clean:
 	/bin/rm -f *.o *.s *.t *.elf *.flat *~
 

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -532,11 +532,8 @@ module Make
           begin match Cfg.mode with
           | Mode.Std ->
               O.f "static %s postlude(FILE *out,cmd_t *cmd,hist_t *hist,count_t p_true,count_t p_false,tsc_t total) {" t
-          | Mode.PreSi ->
+          | Mode.PreSi|Mode.Kvm ->
               O.f "static %s postlude(FILE *out,global_t *g,count_t p_true,count_t p_false,tsc_t total) {" t ;
-              O.oi "hash_t *hash = &g->hash ;"
-          | Mode.Kvm ->
-              O.f "static %s postlude(global_t *g,count_t p_true,count_t p_false,tsc_t total) {" t ;
               O.oi "hash_t *hash = &g->hash ;"
           end ;
 (* Print header *)
@@ -554,12 +551,9 @@ module Make
           | Mode.Std ->
               pp_nstates "finals_outs(hist->outcomes)" ;
               O.oi "just_dump_outcomes(out,hist);"
-          | Mode.PreSi ->
+          | Mode.PreSi|Mode.Kvm ->
               pp_nstates "hash->nhash" ;
-              O.oi "pp_hash(out,hash,g->verbose > 1,g->group);"
-          | Mode.Kvm ->
-              pp_nstates "hash->nhash" ;
-              O.oi "pp_hash(hash,g->verbose > 1,g->group);" ;
+              O.oi "pp_hash(out,hash,g->verbose > 1,g->group);" ;
               ()
           end ;
 (* Print condition and witnesses *)


### PR DESCRIPTION
Implement C driver for KVM mode.

Combining options `-mode kvm` and `-driver C` yields one executable file (`run.flat`). Once adapted, this technique should prove convenient for bare metal experiments.