### PR TITLE
[litmus] KVM, AArch64 Default is no HW managment of HA and HD bits.

### DIFF
--- a/litmus/libdir/_aarch64/kvm-headers.h
+++ b/litmus/libdir/_aarch64/kvm-headers.h
@@ -23,8 +23,6 @@
 
 #define LITMUS_PAGE_SIZE PAGE_SIZE
 
-static inline void litmus_init(void) {}
-
 static inline pteval_t *litmus_tr_pte(void *p) {
   return mmu_get_pte(mmu_idmap, (uintptr_t)p);
 }
@@ -317,3 +315,15 @@ inline static void set_hahd_bits(uint64_t v) {
   uint64_t n = (old & ~msk)|(v << 39);
   set_tcr_el1(n);
 }
+
+inline static void reset_hahd_bits(void) {
+  uint64_t hafdbs = get_hafdbs();
+  if (hafdbs == 0b0001) {
+    set_ha_bit(0);
+  } else if (hafdbs == 0b0010) {
+    set_hahd_bits(0b00);
+  }
+}
+
+static inline void litmus_init(void) { reset_hahd_bits(); }
+

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1802,6 +1802,14 @@ module Make
         O.oi "init_global(g,id);" ;
 (*        O.oi "if (g->do_scan) scan(id,g); else choose(id,g);" ; *)
         O.oi "choose(id,g);" ;
+        if Cfg.is_kvm then begin
+          match Cfg.driver,db with
+          | Driver.C,Some _ -> (* Reset for next test *)
+              O.oi "reset_hahd_bits();"
+          | ((Driver.XCode|Driver.Shell),_)
+          | (_,None)
+            -> ()
+        end ;
         if not Cfg.is_kvm then begin
           O.oi "return NULL;"
         end ;


### PR DESCRIPTION
As a consequence control of HW management is disabled initially , and reset to disabled after each test that enable it
for the C driver that performs several tests in sequence.