### PR TITLE
Add memtag() support for checking MTE tag locations in condition statements

### DIFF
--- a/gen/final.ml
+++ b/gen/final.ml
@@ -231,8 +231,13 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
       | S s -> s
       | P p -> PTEVal.pp p
 
-    let dump_atom r v =
-      sprintf "%s=%s" (C.A.pp_location_brk r) (dump_val v)
+    let dump_tag = function
+      | I i -> i
+      | _ -> Warn.fatal "Tags can only be of type integer"
+
+    let dump_atom r v = match Misc.tr_atag (C.A.pp_location r) with
+        | Some s -> sprintf "[tag(%s)]=%s" s (Code.add_tag "" (dump_tag v))
+        | None -> sprintf "%s=%s" (C.A.pp_location_brk r) (dump_val v)
 
     let dump_state fs =
       String.concat " /\\ "

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -114,7 +114,11 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           loc,
           List.map
             (*NOTYET*)
-            (List.map (fun (n,obs) -> n.C.C.evt.C.C.cell,obs))
+            (List.map (fun (n,obs) ->
+            let cells = if Misc.check_atag loc then
+              n.C.C.evt.C.C.tcell
+            else n.C.C.evt.C.C.cell in
+            cells,obs))
             ns)
 
 (******************)

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -409,7 +409,8 @@ let max_set = IntSet.max_elt
       else
         let vs =
           List.map
-            (List.map (fun (v,obs) -> v.(0),obs))
+            (Misc.filter_map (fun (v,obs) ->
+               if Array.length v > 0 then Some (v.(0),obs) else None ))
             vs in
         build_observers p i x vs in
 
@@ -417,8 +418,11 @@ let max_set = IntSet.max_elt
       let loc = A.Loc x in
       if StringMap.mem x env_wide then
         F.cons_vec loc v fs
-      else
-        F.cons_int (A.Loc x) v.(0) fs in
+      else if Array.length v > 0 then
+        (* For MTE locations, we may have only a tag write and not an *)
+        (* Ord write. We therefore need a length check here. *)
+        F.cons_int (A.Loc x) v.(0) fs
+      else fs in
 
     let add_look_loc loc v k =
       if (not (StringSet.mem loc atoms) && O.optcond) then k

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -95,7 +95,7 @@ let pp_symbol_old = function
   | System (TLB,s) -> Misc.add_tlb s
   | System (PTE,s) -> Misc.add_pte s
   | System (PTE2,s) -> Misc.add_pte (Misc.add_pte s)
-  | System (TAG,s) -> Misc.add_atag s
+  | System (TAG,s) -> sprintf "tag(%s)" s
 
 let pp_symbol = function
   | Virtual s -> pp_index (pp_symbolic_data s) s.offset
@@ -103,7 +103,7 @@ let pp_symbol = function
   | System (TLB,s) -> sprintf "TLB(%s)" s
   | System (PTE,s) -> sprintf "PTE(%s)" s
   | System (PTE2,s) -> sprintf "PTE(PTE(%s))" s
-  | System (TAG,s) -> Misc.add_atag s
+  | System (TAG,s) -> sprintf "tag(%s)" s
 
 let compare_symbol sym1 sym2 = match sym1,sym2 with
 | Virtual s1,Virtual s2 -> compare_symbolic_data s1 s2

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -256,6 +256,16 @@ let split_on_char c s =
     else do_rec k0 (k+1) in
   do_rec 0 0
 
+  let filter_map f =
+    let rec aux accu = function
+      | [] -> List.rev accu
+      | x :: l ->
+          match f x with
+          | None -> aux accu l
+          | Some v -> aux (v :: accu) l
+    in
+    aux []
+
 (********************)
 (* Position parsing *)
 (********************)

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -89,6 +89,7 @@ val capitalize : string -> string
 (* Backward compatibility *)
 val find_opt : ('a -> bool) -> 'a list -> 'a option
 val split_on_char : char -> string -> string list
+val filter_map : ('a -> 'b option) -> 'a list -> 'b list
 (* Float pair (position) parsint *)
 val pos_of_string : string -> (float * float) option
 

--- a/lib/stateLexer.mll
+++ b/lib/stateLexer.mll
@@ -68,6 +68,7 @@ rule token = parse
 | "locations" { LOCATIONS }
 | "filter" { FILTER }
 | "fault"|"Fault" { FAULT }
+| "tag" { TOK_TAG }
 | "attrs"|"Attrs" { ATTRS }
 (* PTW keywords *)
 | "PTE" { TOK_PTE }

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -24,6 +24,9 @@ open ConstrGen
 let mk_sym_tag s t =
   Symbolic (Virtual {default_symbolic_data with name=s;tag=Some t;})
 
+let mk_sym_tagloc s =
+  Symbolic (System (TAG, s))
+
 let mk_sym_morello p s t =
   let p_int = Misc.string_as_int64 p in
   if
@@ -65,6 +68,7 @@ let mk_lab p s = Label (p,s)
 %token ATOMICINIT
 %token ATTRS
 %token TOK_PTE TOK_PA
+%token TOK_TAG
 
 %token PTX_REG_DEC
 %token <string> PTX_REG_TYPE
@@ -107,6 +111,7 @@ location_global:
 | TOK_PTE LPAR TOK_PTE LPAR NAME RPAR RPAR { Constant.mk_sym_pte2 $5 }
 | TOK_PA LPAR NAME RPAR { Constant.mk_sym_pa $3 }
 | NAME COLON NAME { mk_sym_tag $1 $3 }
+| TOK_TAG LPAR NAME RPAR { mk_sym_tagloc $3 }
 (* TODO: have MTE and Morello tags be usable at the same time? *)
 | NUM COLON NAME COLON NUM {mk_sym_morello $1 $3 $5}
 | NAME COLON NUM { mk_sym_morello "0" $1 $3 }


### PR DESCRIPTION
This change addressing the issues highlighted by issue #68 by adding a new memtag(x) syntax for accessing the physical tag of a given location x.

The herd support for this is built upon the already existing LV (LocationValue) and LL (LocationLocation) comparison operators present in herdtools, with memtag(x) just being syntactical sugar for x.atag, along with logic added to effectively returning a global location for x with the tag updated to the latest physical value. This then allows for direct comparison against the right hand side value/location in the expression, where it was already possible to express a tagged location (e.g. x:red).

The generator changes to support this include tracking of tag writes for a given cycle, and outputting write values into the condition statement, mirroring exactly what happens for Ord writes in non-MTE cycles.

Example tests:

```
$ diyone7 -arch AArch64 Rfe PodRW CoeTT PodWW -variant memtag
AArch64 A
"Rfe PodRWPT CoeTT PodWWTP"
Generator=diyone7 (version 7.56+02~dev)
Prefetch=0:x=F,0:y=W,1:y=F,1:x=W
Com=Co Rf
Orig=Rfe PodRWPT CoeTT PodWWTP
{
0:X0=x:green; 0:X2=y:red; 0:X3=y:green;
1:X0=y:blue; 1:X1=y:red; 1:X3=x:green;
}
 P0          | P1          ;
 LDR W1,[X0] | STG X0,[X1] ;
 STG X2,[X3] | MOV W2,#1   ;
             | STR W2,[X3] ;
exists (memtag(y)=y:blue /\ 0:X1=1)
```

Herd:

```
Test A Allowed
States 4
0:X1=0; memtag(y)=y:blue;
0:X1=0; memtag(y)=y:red;
0:X1=1; memtag(y)=y:blue;
0:X1=1; memtag(y)=y:red;
Ok
Witnesses
Positive: 1 Negative: 3
Condition exists (memtag(y)=y:blue /\ 0:X1=1) Observation A Sometimes 1 3 Time A 0.03
Hash=8af8bfa05aa732a2f75b38098e77a261

```
Equivalent non-MTE cycle

```
AArch64 A
"Rfe PodRW Coe PodWW"
Generator=diyone7 (version 7.56+02~dev)
Prefetch=0:x=F,0:y=W,1:y=F,1:x=W
Com=Co Rf
Orig=Rfe PodRW Coe PodWW
{
0:X0=x; 0:X3=y;
1:X1=y; 1:X3=x;
}
 P0          | P1          ;
 LDR W1,[X0] | MOV W0,#2   ;
 MOV W2,#1   | STR W0,[X1] ;
 STR W2,[X3] | MOV W2,#1   ;
             | STR W2,[X3] ;
exists ([y]=2 /\ 0:X1=1)
```

Case where new syntax helps generation of a useful forbidden test:

```
$ diyone7 -arch AArch64 -variant memtag "DMB.STdWWTT CoeTL PodWWLL PodWRLA Amo.CasAP CoePT"
AArch64 A
"DMB.STdWWTT CoeTL PodWWLL PodWRLA Amo.CasAP CoePT"
Generator=diyone7 (version 7.56+02~dev)
Prefetch=0:x=F,0:y=W,1:y=F,1:x=W
Com=Co Co
Orig=DMB.STdWWTT CoeTL PodWWLL PodWRLA Amo.CasAP CoePT
{
0:X0=x:red; 0:X1=x:green; 0:X2=y:red; 0:X3=y:green;
1:X1=y:red; 1:X3=z:green; 1:X4=x:green;
}
 P0          | P1              ;
 STG X0,[X1] | MOV W0,#1       ;
 DMB ST      | STLR W0,[X1]    ;
 STG X2,[X3] | MOV W2,#1       ;
             | STLR W2,[X3]    ;
             | MOV W5,#0       ;
             | MOV W6,#1       ;
             | CASA W5,W6,[X4] ;
exists (memtag(x)=x:red /\ [y]=1 /\ 1:X5=0) /\ ~(fault (P1,x) \/ fault (P1,y))
```

Herd:

```
Test A Allowed
States 2
1:X5=0; [y]=1; memtag(x)=x:red; Fault(P1,x:green); ~Fault(P1,y); 1:X5=0; [y]=1; memtag(x)=x:red; Fault(P1,x:green); Fault(P1,y:red); No Witnesses
Positive: 0 Negative: 4
Condition exists (memtag(x)=x:red /\ [y]=1 /\ 1:X5=0 /\ not (fault(P1,x) \/ fault(P1,y))) Observation A Never 0 4 Time A 0.07
Hash=583c73647e814999245078a77264fa77

```
Compared to old generation:

```
Test A Allowed
States 4
1:X5=0; [y]=1;  ~Fault(P1,y); ~Fault(P1,x); 1:X5=0; [y]=1; Fault(P1,x:green); ~Fault(P1,y); 1:X5=0; [y]=1; Fault(P1,x:green); Fault(P1,y:red); 1:X5=0; [y]=1; Fault(P1,y:red); ~Fault(P1,x); Ok Witnesses
Positive: 1 Negative: 3
Condition exists ([y]=1 /\ 1:X5=0 /\ not (fault(P1,x) \/ fault(P1,y))) Observation A Sometimes 1 3 Time A 0.06 Hash=cbea9795a448570de810e82d4f6ed75d
```