### PR TITLE
[litmus] Shared topology arrays for `-mode presi`.

### DIFF
--- a/lib/simpleDumper.ml
+++ b/lib/simpleDumper.ml
@@ -34,7 +34,7 @@ end
 
 
 module Make(I:I) :
-CoreDumper.S with 
+CoreDumper.S with
   type test =
     (I.state, (MiscParser.proc * I.A.pseudo list) list, I.prop, I.location,I.v)
       MiscParser.result

--- a/litmus/dumpRun.ml
+++ b/litmus/dumpRun.ml
@@ -529,8 +529,11 @@ let dump_c xcode names =
 
 
 let dump_c_cont xcode arch sources utils nts =
-  let shared_topology = is_kvm && Cfg.alloc = Alloc.Dynamic in
+  let shared_topology = Cfg.alloc = Alloc.Dynamic in
   let sources = List.map Filename.basename  sources in
+  let utils =
+    if shared_topology then utils@["topology.c"]
+    else utils in
 (* Makefile *)
   let infile = not xcode in
   Misc.output_protect

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -77,7 +77,7 @@ module Make
       let do_stats = not do_dynalloc
       let do_inlined = (* inline topology description *)
         match Cfg.mode,Cfg.driver with
-        | Mode.Kvm,Driver.C -> not do_dynalloc
+        | (Mode.Kvm|Mode.PreSi),Driver.C -> not do_dynalloc
         | _,_ -> true
 
       open CType
@@ -164,8 +164,7 @@ module Make
           O.o "#define KVM 1" ;
           O.o "#include <libcflat.h>" ;
           O.o "#include \"kvm-headers.h\"" ;
-          O.o "#include \"utils.h\"" ;
-          if not do_inlined then O.o "#include \"topology.h\""
+          O.o "#include \"utils.h\""
         end else begin
           O.o "#include <stdlib.h>" ;
           O.o "#include <inttypes.h>" ;
@@ -184,6 +183,7 @@ module Make
             O.o "#include \"affinity.h\""
           end
         end ;
+        if not do_inlined then O.o "#include \"topology.h\"" ;
         O.o "" ;
         O.o "typedef uint32_t count_t;" ;
         O.o "#define PCTR PRIu32" ;
@@ -433,7 +433,9 @@ module Make
 (**************)
 (* Topologies *)
 (**************)
-      let is_active = not Cfg.is_kvm
+      let is_active = match Cfg.alloc with
+        | Alloc.Dynamic -> false
+        | Alloc.Static|Alloc.Before -> not Cfg.is_kvm
 
       let dbg = false
 
@@ -513,6 +515,7 @@ module Make
           O.f "#define group group_%d" n;
           O.f "#define SCANSZ scansz_%d" n ;
           O.f "#define SCANLINE scanline_%d" n ;
+          O.o "" ;
           ()
         end
 


### PR DESCRIPTION
Those arrays are now shared with options `-driver C` and `-alloc dynamic`.