### PR TITLE
[litmus] Remove some printf occurrences in mode `-stdio false`

### DIFF
--- a/litmus/libdir/_hash.c
+++ b/litmus/libdir/_hash.c
@@ -147,7 +147,11 @@ static void hash_add(hash_t *t,log_t *key, count_t c,int ok) {
     h++ ;
     h %= HASHSZ ;
   }
+#ifdef NOSTDIO
+  emit_string(stderr,"Hash table is full\n") ;
+#else
   fprintf(stderr,"Hash table is full\n") ;
+#endif
   exit(2) ;
 }
 

--- a/litmus/libdir/_main.c
+++ b/litmus/libdir/_main.c
@@ -66,7 +66,18 @@ int RUN(int argc,char **argv,FILE *out) {
   glo_ptr->nruns = d.max_run;
   glo_ptr->size = d.size_of_test;
   if (glo_ptr->verbose) {
+#ifdef NOSTDIO    
+    emit_string(stderr,prog);
+    emit_string(stderr,": n=");
+    emit_int(stderr,glo_ptr->nexe);
+    emit_string(stderr,", r=");
+    emit_int(stderr,glo_ptr->nruns);
+    emit_string(stderr,", s=");
+    emit_int(stderr,glo_ptr->size);
+    emit_string(stderr,"\n");    
+#else
     fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
+#endif
   }
   parse_param(prog,glo_ptr->parse,PARSESZ,p) ;
 #ifdef PRELUDE

--- a/litmus/libdir/_toh_nostdio.sh
+++ b/litmus/libdir/_toh_nostdio.sh
@@ -1,0 +1,8 @@
+FILE=$1
+cat <<EOF
+static void ass(FILE *out) {
+EOF
+sed -e 's|"|\\"|g' $1 | awk '{printf("  emit_string(out,\"%s\\n\");\n",$0) }'
+cat <<EOF
+}
+EOF

--- a/litmus/objUtil.ml
+++ b/litmus/objUtil.ml
@@ -169,7 +169,11 @@ module Make(O:Config)(Tar:Tar.S) =
       let fnames = [] in
       let fnames = match O.driver with
       | Driver.Shell -> fnames
-      | Driver.C|Driver.XCode -> cpy fnames "toh" ".sh" in
+      | Driver.C|Driver.XCode ->
+         if O.stdio then
+           cpy fnames "toh" ".sh"
+         else
+           cpy' fnames "toh_nostdio" "toh" ".sh" in
       let fnames = match O.arch with
         | `C ->
             if O.asmcommentaslabel then

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -173,9 +173,12 @@ module Make
           O.o "#include <assert.h>" ;
           O.o "#include <time.h>" ;
           O.o "#include <limits.h>" ;
-          O.o
-            (if Cfg.stdio then "#include <stdio.h>"
-            else "#include \"litmus_io.h\"") ;
+          if Cfg.stdio then begin
+            O.o "#include <stdio.h>"
+          end else begin
+            O.o "#include \"litmus_io.h\"" ;
+            O.o "#define NOSTDIO 1"                        
+          end ;
           O.o "#include \"litmus_rand.h\"" ;
           O.o "#include \"utils.h\"" ;
           if Cfg.c11 then O.o "#include <stdatomic.h>";

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -518,7 +518,7 @@ module Make
           dstring nice ;
           let xs = T.D.lines doc test.T.src in
           List.iter dstring xs ;
-          O.oi "fprintf(out,\"Generated assembler\\n\");" ;
+          dstring "Generated assembler" ;
           O.oi "ass(out);" ;
           O.o "}" ;
           O.o "" ;


### PR DESCRIPTION
This is not perfect as several occurrences of printf are still present.

However, for now,  no printf should be left in `-more presi`, as this mode is to be used when support is limited.