### PR TITLE
[gen] Fix Load Reserve Store Conditional effective address bug

### DIFF
--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -175,9 +175,10 @@ let applies_atom (a,_) d = match a,d with
        begin
          match m with
          | None -> prefix
-         | Some m -> if String.length prefix > 0
-           then sprintf "%s.%s" prefix (Mixed.pp_mixed m)
-           else Mixed.pp_mixed m
+         | Some m ->
+            if String.length prefix > 0
+            then sprintf "%s.%s" prefix (Mixed.pp_mixed m)
+            else Mixed.pp_mixed m
        end
    | _ ->
      let pp_acc = pp_atom_acc a in
@@ -242,7 +243,9 @@ let applies_atom (a,_) d = match a,d with
      if do_mixed then
        fold_acc true
          (fun acc r -> Mixed.fold_mixed (fun m r -> f (acc,Some m) r) r)
-         (fold_mixed f r)
+         (Mixed.fold_mixed
+            (fun m r -> f (Plain None,Some m) r)
+            r)
      else r
 
    let worth_final (a,_) = match a with
@@ -526,11 +529,46 @@ let fold_rmw f r =
   let r = fold_aop (fun op r -> f (StOp op) r) r in
   r
 
+(*
 let applies_atom_rmw rmw ar aw = match rmw,ar,aw with
-| (LrSc|Swp|Cas|LdOp _),(Some (Acq _,_)|None),(Some (Rel _,_)|None)
-| (StOp _),None,(Some (Rel _,_)|None)
+| (LrSc|Swp|Cas|LdOp _),
+  (Some ((Acq _|Plain _),_)|None),(Some ((Rel _|Plain _),_)|None)
+| (StOp _),None,(Some ((Rel _|Plain _),_)|None)
   -> true
 | _ -> false
+ *)
+
+let ok_rw ar aw =
+  match ar,aw with
+  | (Some ((Acq _|Plain _),_)|None),(Some ((Rel _|Plain _),_)|None)
+    -> true
+  | _ -> false
+
+let ok_w  ar aw =
+  match ar,aw with
+  | (Some (Plain _,_)|None),(Some ((Rel _|Plain _),_)|None)
+    -> true
+  | _ -> false
+
+let same_sz a1 a2 = match a1,a2 with
+  |(None,None)
+  |(None,Some (_,None))
+  |(Some (_,None),None)
+  |((Some (_,None),Some (_,None)))
+   -> true
+  | Some (_,Some sz1),Some (_,Some sz2) -> MachMixed.equal sz1 sz2
+  |(None,Some (_,Some _))
+  |(Some (_,Some _),None)
+  |(Some (_, None), Some (_, Some _))
+  |(Some (_,Some _),Some (_,None))
+   -> false
+
+let applies_atom_rmw rmw ar aw = match rmw with
+  | LrSc -> ok_rw ar aw
+  | Swp|Cas|LdOp _ ->
+     ok_rw ar aw && same_sz ar aw
+  | StOp _ ->
+     ok_w ar aw && same_sz ar aw
 
 let show_rmw_reg = function
 | StOp _ -> false

--- a/gen/machMixed.ml
+++ b/gen/machMixed.ml
@@ -24,6 +24,9 @@ open Endian
 type offset = int
 type t = sz * offset
 
+let equal (sz1,o1) (sz2,o2) =
+  MachSize.equal sz1 sz2 && Misc.int_eq o1 o2
+
 module Make(C:Config) = struct
 
   open Printf

--- a/gen/variant_gen.ml
+++ b/gen/variant_gen.ml
@@ -34,10 +34,12 @@ type t =
   | KVM
 (* Neon AArch64 extension *)
   | Neon
+(* Constrained Unpredictable *)
+  | ConstrainedUnpredictable
 
 let tags =
  ["AsAmo";"ConstsInInit";"Mixed";"FullMixed";"Self"; "MemTag";
-  "NoVolatile"; "Morello"; "kvm"; "Neon"; ]
+  "NoVolatile"; "Morello"; "kvm"; "Neon"; "ConstrainedUnpredictable"; ]
 
 let parse tag = match Misc.lowercase tag with
 | "asamo" -> Some AsAmo
@@ -50,6 +52,7 @@ let parse tag = match Misc.lowercase tag with
 | "morello" -> Some Morello
 | "kvm" -> Some KVM
 | "neon" -> Some Neon
+| "constrainedunpredictable"|"cu" -> Some ConstrainedUnpredictable
 | _ -> None
 
 let pp = function
@@ -63,3 +66,4 @@ let pp = function
   | Morello -> "Morello"
   | KVM -> "kvm"
   | Neon -> "Neon"
+  | ConstrainedUnpredictable -> "ConstrainedUnpredictable"

--- a/gen/variant_gen.mli
+++ b/gen/variant_gen.mli
@@ -34,6 +34,9 @@ type t =
   | KVM
 (* Neon AArch64 extension *)
   | Neon
+(* Constrained Unpredictable, ie generate tests thar may exhibit
+   such behaviours. Typically LDXR / STXR of different size or address. *)
+  | ConstrainedUnpredictable
 
 val tags : string list
 


### PR DESCRIPTION
This PR first fixes a long standing bug: the addresses of generated load exclusive/store exclusive were wrong when mixed size modifiers were present.

The PR also adopts a new default behaviour: load exclusive and store exclusive of a generated pair *must* access the same address with the same size.

The restriction is lifted by the options `-variant ConstrainedUnpredicatable` (can be abbreviated as `-variant CU`).