### PR TITLE
[herd] Fix loop

### DIFF
--- a/herd/CSem.ml
+++ b/herd/CSem.ml
@@ -59,7 +59,7 @@ module Make (Conf:Config)(V:Value.S)
       let no_mo = MOorAN.AN []
       let mo_as_anmo mo = MOorAN.MO mo
 
-      let mk_toofar ii = M.mk_singleton_es (Act.TooFar) ii
+      let mk_toofar msg ii = M.mk_singleton_es (Act.TooFar msg) ii
 
       let read_loc is_data mo =
         M.read_loc is_data (fun loc v -> Act.Access (Dir.R, loc, v, mo, false, nat_sz))
@@ -366,7 +366,7 @@ module Make (Conf:Config)(V:Value.S)
               let else_branch = M.unitT (ii.A.program_order_index, B.Next)
               and then_branch =
                 if n >= Conf.unroll then
-                  mk_toofar ii >>= fun () -> M.unitT (ii.A.program_order_index, B.Exit)
+                  mk_toofar "While" ii >>= fun () -> M.unitT (ii.A.program_order_index, B.Exit)
                 else
                   build_semantics {ii with A.inst = t} >>> fun (prog_order, _branch) ->
                   build_semantics

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -96,7 +96,7 @@ module type S = sig
   val is_pod : action -> bool
 
 (* Unrolling control *)
-  val toofar : action
+  val toofar : string -> action
   val is_toofar : action -> bool
 
 (********************)

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -57,7 +57,6 @@ module type S = sig
       proc       : proc;
       program_order_index   : program_order_index;
       inst : I.arch_instruction;
-      unroll_count : int; (* number of loop unrollings *)
       labels : Label.Set.t;
       env : reg_state ;
     }
@@ -279,7 +278,6 @@ module Make(C:Config) (I:I) : S with module I = I
           proc       : proc;
           program_order_index   : program_order_index;
           inst : I.arch_instruction ;
-          unroll_count: int; (* number of loop unrollings *)
           labels : Label.Set.t ;
           env : reg_state ;
         }

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -1515,9 +1515,8 @@ Monad type:
 
     let eqT : V.v -> V.v -> unit t = assign
 
-    let tooFar _msg v = unitT v
-    let tooFarcode _msg v = unitcodeT v
-
+    let tooFar msg ii v =
+      forceT v (mk_singleton_es (E.Act.toofar msg) ii)
 
     type evt_struct = E.event_structure
     type output = VC.cnstrnts * evt_struct

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -168,8 +168,7 @@ module type S =
 
     val altT : 'a t -> 'a t -> 'a t
 
-    val tooFar : string -> 'a -> 'a t
-    val tooFarcode : string -> 'a -> 'a code
+    val tooFar : string -> E.A.inst_instance_id -> 'v -> 'v t
 
     (**********************************************************)
     (* A few action instruction instance -> monad constructors *)

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -226,12 +226,13 @@ module Make(O:Config)(M:XXXMem.S) =
       S.E.EventSet.subset loads obs
 
 (* Called by model simulator in case of success *)
-    let model_kont loop ochan test do_restrict cstr =
+    let model_kont ochan test do_restrict cstr =
 
       let check = check_prop test in
 
       fun conc fsc (set_pp,vbpp) flags c ->
-        if not showtoofar && loop && S.gone_toofar conc then { c with toofar = true; }
+        if not showtoofar && S.gone_toofar conc then
+          { c with toofar = true; }
         else if do_observed && not (all_observed test conc) then c
         else if
           match O.throughflag with
@@ -362,7 +363,7 @@ module Make(O:Config)(M:XXXMem.S) =
         AM.state_restrict_locs O.outcomereads dlocs tenv senv fsc,
         restrict_faults flts in
 
-      let { MC.event_structures=rfms; loop_present=loop; } =
+      let { MC.event_structures=rfms;  } =
         MC.glommed_event_structures test in
 (* Open *)
       let ochan = open_dot test in
@@ -392,12 +393,12 @@ module Make(O:Config)(M:XXXMem.S) =
         let call_model conc =
           check_test
             conc kfail
-            (model_kont loop ochan test final_state_restrict_locs cstr) in
+            (model_kont ochan test final_state_restrict_locs cstr) in
       let c =
         if O.statelessrc11
         then let module SL = Slrc11.Make(struct include MC let skipchecks = O.skipchecks end) in
              SL.check_event_structure test rfms kfail (fun _ c -> c)
-          (model_kont loop ochan test final_state_restrict_locs cstr) start
+          (model_kont ochan test final_state_restrict_locs cstr) start
         else
         try iter_rfms test rfms call_model (fun c -> c) start
         with

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -491,12 +491,16 @@ module Make(O:Config)(M:XXXMem.S) =
         if O.candidates then
           printf "Candidates %s %i\n" tname (c.cfail+c.cands) ;
 (* Auto info or Hash only*)
-          List.iter
-            (fun (k,v) ->
-              if Misc.string_eq k "Hash" then
-                printf "%s=%s\n" k v)
-            test.Test_herd.info ;
-        print_newline ()
+        List.iter
+          (fun (k,v) ->
+            if Misc.string_eq k "Hash" then
+              printf "%s=%s\n" k v)
+          test.Test_herd.info ;
+        print_newline () ;
+        if c.toofar then
+          Warn.warn_always
+            "File \"%s\", unrolling limit exceeded, legal outcomes may be missing."
+            test.Test_herd.name.Name.file
       end with Exit -> () ;
       ()
   end

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -151,7 +151,7 @@ module Make(O:Config)(M:XXXMem.S) =
 
 
 (* rfmap generation and processing, from pre-candidates *)
-    let iter_rfms test rfms kont kont_loop k =
+    let iter_rfms test rfms kont k =
       let kont =
         if O.verbose > 0 then
           fun conc k ->
@@ -163,7 +163,7 @@ module Make(O:Config)(M:XXXMem.S) =
         List.fold_left
           (fun res (_i,cs,es) ->
             MC.calculate_rf_with_cnstrnts test es cs
-              kont kont_loop res)
+              kont res)
           k rfms in
       k
 
@@ -400,7 +400,7 @@ module Make(O:Config)(M:XXXMem.S) =
              SL.check_event_structure test rfms kfail (fun _ c -> c)
           (model_kont ochan test final_state_restrict_locs cstr) start
         else
-        try iter_rfms test rfms call_model (fun c -> c) start
+        try iter_rfms test rfms call_model start
         with
         | Over c -> c
         | e ->


### PR DESCRIPTION
Fix detection of insufficient loop unrolling. Pruned executions are now excluded from final display as they should (unless `-variant toofar` is specified).

