### PR TITLE
[test] Regression with warning and exit code

### DIFF
--- a/herd/tests/instructions/AArch64/A184.litmus
+++ b/herd/tests/instructions/AArch64/A184.litmus
@@ -1,0 +1,13 @@
+AArch64 A184
+(* LDXR/STXR Loop, test partial execution, with warnong on stderr *)
+{
+int x=1;
+0:X0=x;
+}
+  P0             ;
+L0:              ;   
+ LDXR W1,[X0]    ;
+ MOV W3,#2       ;
+ STXR W4,W3,[X0] ;
+ CBNZ W4,L0      ;
+forall (x=2)

--- a/herd/tests/instructions/AArch64/A184.litmus.expected
+++ b/herd/tests/instructions/AArch64/A184.litmus.expected
@@ -1,0 +1,10 @@
+Test A184 Required
+States 1
+[x]=2;
+Loop Ok
+Witnesses
+Positive: 3 Negative: 0
+Condition forall ([x]=2)
+Observation A184 Always 3 0
+Hash=79c44439d71d498715a5ee40615de31c
+

--- a/herd/tests/instructions/AArch64/A184.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64/A184.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A184.litmus", unrolling limit exceeded, legal outcomes may be missing.

--- a/internal/herd_catalogue_regression_test.ml
+++ b/internal/herd_catalogue_regression_test.ml
@@ -78,10 +78,10 @@ let herd_kinds_of_permutation flags shelf_dir litmuses p =
       flags.herd
   in
   match cmd litmuses with
-  | stdout, [] ->
+  | 0,stdout, [] ->
       let kind_of_log l = Log.(l.name, Option.get l.kind) in
       List.map kind_of_log (Log.of_string_list stdout)
-  | _, stderr ->
+  | _, _, stderr ->
       failwith (Printf.sprintf "Herd returned stderr: %s" (String.concat "\n" stderr))
 
 

--- a/internal/herd_diycross_regression_test.ml
+++ b/internal/herd_diycross_regression_test.ml
@@ -144,7 +144,7 @@ let promote_tests flags =
       flags.herd [l]
   in
   let outputs = List.map output_of_litmus litmus_paths in
-  let write_file (path, (lines,_)) =
+  let write_file (path, (_,lines,_)) =
     Filesystem.write_file path (fun o -> Channel.write_lines o lines) in
   List.combine expected_paths outputs |> List.iter write_file ;
   Filesystem.remove_recursive tmp_dir

--- a/internal/herd_diycross_regression_test.ml
+++ b/internal/herd_diycross_regression_test.ml
@@ -72,9 +72,12 @@ let run_tests flags =
   let tmp_dir = Filesystem.new_temp_dir () in
   let args = diycross_args flags.libdir flags.arch flags.relaxlists tmp_dir in
   Command.run flags.diycross args ;
-  let litmuses = List.filter TestHerd.is_litmus (list_dir tmp_dir) in
 
-  let expecteds = List.filter TestHerd.is_expected (list_dir flags.expected_dir) in
+  let litmuses =
+    List.filter TestHerd.is_litmus (list_dir tmp_dir) in
+
+  let expecteds =
+    List.filter TestHerd.is_expected (list_dir flags.expected_dir) in
   let expected_litmuses = List.map TestHerd.litmus_of_expected expecteds in
 
   let only_in_expected = without_members litmuses expected_litmuses in
@@ -100,7 +103,7 @@ let run_tests flags =
         ~conf:flags.conf
         ~variants:flags.variants
         ~libdir:flags.libdir
-        flags.herd l e "")
+        flags.herd l e "" "")
     (List.combine litmus_paths expected_paths)
   in
   let passed x = x in

--- a/internal/herd_regression_test.ml
+++ b/internal/herd_regression_test.ml
@@ -142,22 +142,25 @@ let promote_tests flags =
     let expected_failure = TestHerd.expected_failure_of_litmus l in
 
     match output_of_litmus l with
-    | [], [] ->
+    | 0, [], [] ->
         Printf.printf "Failed %s : Returned neither stdout nor stderr\n" l ;
         everything_ok := false
 
-    | out, [] ->
+    | 0, out, [] ->
         remove_if_exists expected_failure ;
         write_file expected out
 
-    | [], err ->
+    | r, [], err when r <> 0 ->
         remove_if_exists expected ;
         write_file expected_failure err
 
-    | out, err ->
+    | 0, out, err ->
        write_file expected out ;
        let expected_warn = TestHerd.expected_warn_of_litmus l in
        write_file expected_warn err
+    | r, _, _  ->
+       Printf.printf "Failed %s : unexpected exit code %i\n" l r ;
+       everything_ok := false
   ) ;
   if not !everything_ok then begin
     Printf.printf "Some tests had errors\n" ;

--- a/internal/herd_regression_test.ml
+++ b/internal/herd_regression_test.ml
@@ -116,6 +116,7 @@ let run_tests flags =
       flags.herd l
       (TestHerd.expected_of_litmus l)
       (TestHerd.expected_failure_of_litmus l)
+      (TestHerd.expected_warn_of_litmus l)
   in
   let everything_passed = ref true in
   for_each_litmus_in_dir flags.litmus_dir (fun l ->
@@ -153,9 +154,10 @@ let promote_tests flags =
         remove_if_exists expected ;
         write_file expected_failure err
 
-    | _, _ ->
-        Printf.printf "Failed %s : Returned both stdout and stderr\n" l ;
-        everything_ok := false
+    | out, err ->
+       write_file expected out ;
+       let expected_warn = TestHerd.expected_warn_of_litmus l in
+       write_file expected_warn err
   ) ;
   if not !everything_ok then begin
     Printf.printf "Some tests had errors\n" ;

--- a/internal/lib/command.mli
+++ b/internal/lib/command.mli
@@ -41,3 +41,10 @@ val run :
   ?stdin:(out_channel -> unit) ->
   ?stdout:(in_channel -> unit) ->
   ?stderr:(in_channel -> unit) -> string -> string list -> unit
+
+(** Same as [run] above, does not raise [Error] on non-zero exit
+  * code. Returns exit code *)
+val run_status :
+  ?stdin:(out_channel -> unit) ->
+  ?stdout:(in_channel -> unit) ->
+  ?stderr:(in_channel -> unit) -> string -> string list -> int

--- a/internal/lib/testHerd.mli
+++ b/internal/lib/testHerd.mli
@@ -42,7 +42,7 @@ val run_herd :
   conf     : path option ->
   variants : string list ->
   libdir   : path ->
-    path -> path list -> stdout_lines * stdout_lines
+    path -> path list -> int * stdout_lines * stdout_lines
 
 (** [herd_output_matches_expected ~bell ~cat ~conf ~variants ~libdir herd
  *  litmus expected expected_failure expected_warn] runs the binary

--- a/internal/lib/testHerd.mli
+++ b/internal/lib/testHerd.mli
@@ -45,11 +45,16 @@ val run_herd :
     path -> path list -> stdout_lines * stdout_lines
 
 (** [herd_output_matches_expected ~bell ~cat ~conf ~variants ~libdir herd
- *  litmus expected expected_failure] runs the binary [herd] with a custom
- *  [libdir] on a [litmus] file, and compares the output with an [expected]
- *  file. If the run writes to stderr then we check [expected_failure]. If the
+ *  litmus expected expected_failure expected_warn] runs the binary
+ *  [herd] with a custom [libdir] on a [litmus] file,
+ *  and compares the output with an [expected] file.
+ *  If the run writes to stderr then we check [expected_failure]. If the
  *  contents of [expected_failure] match then it is an expected failure,
  *  otherwise it is an unexpected failure and will raise an Error.
+ *  If the run writes to both stdout and stderr, stdout is checked
+ *  against the [expected] file, while stderr is checked against
+ *  the [expected_warn] file. If any file is missing or differs,
+ *  an Error is raised. 
  *  Paths to [cat], [bell], and [conf] files, as well as [variants], can also
  *  be passed in. *)
 val herd_output_matches_expected :
@@ -58,7 +63,7 @@ val herd_output_matches_expected :
   conf     : path option ->
   variants : string list ->
   libdir   : path ->
-    path -> path -> path -> path -> bool
+    path -> path -> path -> path -> path  -> bool
 
 (** [is_litmus filename] returns whether the [filename] is a .litmus file. *)
 val is_litmus : path -> bool
@@ -77,3 +82,6 @@ val expected_failure_of_litmus : path -> path
 
 (** [litmus_of_expected_failure filename] returns the .litmus name for a given .litmus.expected-failure [filename]. *)
 val litmus_of_expected_failure : path -> path
+
+(** [expected_warn_of_litmus filename] returns the .litmus.expected-warn name for a given .litmus [filename]. *)
+val expected_warn_of_litmus : path -> path


### PR DESCRIPTION
This PR extends herd regression testing. Exit code are considered with 0 being successful run and not zero being failure. Additionally, standard output and standard error must be as follows:

- If success, then standard output must be non-empty and standard error can be empty or non-empty.
- If failure, then standard output must be empty and standard error must be  non-empty.

Non-empty out channels are checked against their references.