### PR TITLE
[herd] Add `-timeout <sec>` option.

### DIFF
--- a/herd/dune
+++ b/herd/dune
@@ -5,5 +5,5 @@
    herd
    )
    (public_names herd7)
-   (libraries herdtools)
+   (libraries unix herdtools)
    (modules_without_implementation AArch64Barrier ARMBarrier action arch_herd BellBarrier  MIPSBarrier monad PPCBarrier sem X86Barrier X86_64Barrier XXXMem))

--- a/herd/itimer.ml
+++ b/herd/itimer.ml
@@ -1,0 +1,34 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2021-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+let start timeout =
+  match timeout with
+  | None -> ()
+  | Some t ->
+      let open Unix in
+      let it =
+        {it_value=t; it_interval=0.0;} in
+      ignore (setitimer ITIMER_VIRTUAL it)
+
+and stop timeout =
+  match timeout with
+  | None -> ()
+  | Some _ ->
+      let open Unix in
+      let it =
+        {it_value=0.0; it_interval=0.0;} in
+      ignore (setitimer ITIMER_VIRTUAL it)
+

--- a/herd/itimer.mli
+++ b/herd/itimer.mli
@@ -1,0 +1,27 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2021-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Simple interface to interval timer in virtual processor time *)
+
+(** [start timeout] start interval for the given period.
+  * Argument timeout is an option, if [None] do nothing,
+  * otherwise the option specifies the timer period *)
+val start : float option -> unit
+
+(** [stop timeout] stop interval timer.
+  * Argument timeout is an option, if [None] do nothing,
+  * otherwise stop timer *)
+val stop : float option -> unit

--- a/herd/lexConf_herd.mll
+++ b/herd/lexConf_herd.mll
@@ -114,6 +114,8 @@ let handle_key main key arg = match key with
 | "suffix" ->  suffix := arg
 | "include" ->
    includes := !includes @ [arg]
+| "timeout" ->
+   lex_float_opt timeout arg
 (* Change input *)
 | "names" ->
     names := !names @ [arg]

--- a/herd/opts.ml
+++ b/herd/opts.ml
@@ -27,6 +27,7 @@ let verbose = ref 0
 let libdir = ref (Filename.concat Version.libdir "herd")
 let includes = ref []
 let exit_if_failed = ref false
+let timeout = ref None
 let debug = ref Debug_herd.none
 let names = ref []
 let excl = ref []

--- a/herd/opts.mli
+++ b/herd/opts.mli
@@ -26,6 +26,7 @@ val verbose : int ref
 val libdir : string ref
 val includes : string list ref
 val exit_if_failed : bool ref
+val timeout : float option ref
 val debug : Debug_herd.t ref
 val names : string list ref
 val excl : string list ref

--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -62,6 +62,7 @@ module Top (TopConf:Config) = struct
 
       let run dirty start_time filename chan env splitted =
         try
+
           let parsed = P.parse chan splitted in
 
           (* Additional checks *)
@@ -101,7 +102,7 @@ module Top (TopConf:Config) = struct
               end)(M) in
           T.run start_time test ;
           env
-          with TestHash.Seen -> env
+        with TestHash.Seen -> env
     end
 
   module SP =
@@ -529,7 +530,10 @@ module Top (TopConf:Config) = struct
     end else env
 
 (* Enter here... *)
+
   let from_file name env =
+    (* Interval timer will be stopped just before output, see top_herd *)
+    Itimer.start TopConf.timeout ;
     let start_time = Sys.time () in
     Misc.input_protect (do_from_file start_time env name) name
 end

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -17,6 +17,7 @@
 (** Top level loop : execute test according to model *)
 
 module type CommonConfig = sig
+  val timeout : float option
   val candidates : bool
   val show : PrettyConf.show
   val nshow : int option
@@ -446,6 +447,9 @@ module Make(O:Config)(M:XXXMem.S) =
         let tname = test.Test_herd.name.Name.name in
         let is_bad = has_bad_execs c in
         if not O.badexecs &&  is_bad then raise Exit ;
+(* Stop interval timer *)
+        Itimer.stop O.timeout ;
+(* Now output *)
         printf "Test %s %s\n" tname (C.dump_as_kind cstr) ;
 (**********)
 (* States *)


### PR DESCRIPTION
The new option specifies a timeout in seconds.
When active, no test will take more than `<sec>`
seconds of processor time.

Notice:
 * Tests interrupted by timeout yield no output at all,
 * Timeout out applies to each test individually when
   herd executes several tests.