### PR TITLE
[litmus] Use the defined noinline keyword in Kvm mode

### DIFF
--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -548,7 +548,7 @@ module RegMap = A.RegMap)
               let x = Tmpl.dump_out_reg proc x in
               sprintf "%s *%s" (CType.dump ty) x) t.Tmpl.final in
         let params =  String.concat "," (params0@labels@addrs@ptes@phys@ptevals@cpys@outs) in
-        LangUtils.dump_code_def chan O.noinline proc params ;
+        LangUtils.dump_code_def chan O.noinline O.mode proc params ;
         do_dump
           args0
           (compile_init_val_fun ptevalEnv)

--- a/litmus/CLang.ml
+++ b/litmus/CLang.ml
@@ -110,7 +110,7 @@ module Make(C:Config)(E:Extra) = struct
            (fun (ty,v) -> sprintf "%s %s" ty v)
            defs) in
     (* Function prototype  *)
-    LangUtils.dump_code_def chan E.noinline proc params ;
+    LangUtils.dump_code_def chan E.noinline C.mode proc params ;
     (* body *)
     dump_start chan "  " proc ;
     CTarget.out_code chan t.CTarget.code ;

--- a/litmus/LISALang.ml
+++ b/litmus/LISALang.ml
@@ -123,7 +123,7 @@ module Make(V:Constant.S) = struct
       match p with
       | [] -> "void"
       | _::_ -> String.concat "," p in
-    LangUtils.dump_code_def chan false proc params ;
+    LangUtils.dump_code_def chan false Mode.Std proc params ;
     do_dump
       (checkVal compile_val_fun)
       compile_addr_fun

--- a/litmus/langUtils.ml
+++ b/litmus/langUtils.ml
@@ -26,10 +26,13 @@ let code_fun proc = sprintf "code%i" proc
 let code_fun_cpy proc = sprintf "_code%i" proc
 let code_fun_type proc =  code_fun proc ^ "_t"
 
-let dump_code_def chan noinline proc params =
+let dump_code_def chan noinline mode proc params =
   fprintf chan "typedef void (*%s)(%s);\n\n" (code_fun_type proc) params ;
   fprintf chan "%sstatic void %s(%s) {\n"
-    (if noinline then "__attribute__ ((noinline))"
+    (if noinline then
+       match mode with
+       | Mode.Kvm -> "noinline "
+       | _ -> "__attribute__((noinline)) "
     else "")
     (code_fun proc) params
 

--- a/litmus/langUtils.mli
+++ b/litmus/langUtils.mli
@@ -21,5 +21,5 @@ val end_comment : string -> int -> string
 val code_fun : int -> string
 val code_fun_cpy : int -> string
 val code_fun_type : int -> string
-val dump_code_def : out_channel -> bool -> int -> string -> unit
+val dump_code_def : out_channel -> bool -> Mode.t -> int -> string -> unit
 val dump_code_call : out_channel -> string -> string -> string -> unit

--- a/litmus/libdir/_presi.h
+++ b/litmus/libdir/_presi.h
@@ -23,6 +23,11 @@ typedef void FILE;
 #define stdout NULL
 #define stderr NULL
 #define fprintf(stderr,...) printf(__VA_ARGS__)
+
+#ifndef noinline
+#define noinline __attribute__((noinline))
+#endif
+
 #else
 #include <pthread.h>
 #endif


### PR DESCRIPTION
A recent change in kvm-unit-tests defines noinline as
__attribute__((noinline)) and as a result existing
__attribute__((noinline)) are getting substituted by the C
preprocesssor and lead to compiler errors.

This change fixes the uses of __attribute__((noinline)) while making
sure that the litmus7 remains compatible with older version of
kvm-unit-tests.

Signed-off-by: Nikos Nikoleris <nikos.nikoleris@arm.com>