### PR TITLE
[all] Remove first, number of items, argument of `ConcreteVector`

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -158,7 +158,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
             get_rec (idx+1)
         else [] in
       let vs = get_rec 0 in
-      V.Val (Constant.ConcreteVector(nelem, vs))
+      V.Val (Constant.ConcreteVector vs)
 
     let simd_mem_access_size rs = match List.hd rs with
     | Vreg (_,(_,8)) -> MachSize.Byte

--- a/herd/CSem.ml
+++ b/herd/CSem.ml
@@ -138,9 +138,7 @@ module Make (Conf:Config)(V:Value.S)
               (Act.Lock (A.Location_global loc,Act.LockLinux Dir.W)) ii
 
       let rec build_semantics_expr is_data e ii : V.v M.t = match e with
-      | C.Const v ->
-          M.unitT (V.maybevToV v)
-
+      | C.Const v -> M.unitT (V.maybevToV v)
       | C.LoadReg r -> read_reg is_data r ii
       | C.LoadMem(loc,mo) ->
           let open MemOrderOrAnnot in

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -541,9 +541,17 @@ module Make(C:Config) (I:I) : S with module I = I
               (* where 1 is the sizeof the underlying primitive type *)
               (* e.g uint64_t -> 8 bytes, so the above is v, v+8, v+16 *)
               let vs = match v with
-              | I.V.Val (Constant.ConcreteVector (sz,vs))
-                  when Misc.int_eq sz total_size -> vs
-              | _ -> Warn.user_error "Unexpected scalar value %s, vector expected" (I.V.pp_v v) in
+                | I.V.Val (Constant.ConcreteVector vs) ->
+                   if Misc.int_eq (List.length vs) total_size then
+                     vs
+                   else
+                     Warn.user_error
+                       "Vector size mismatch, %s (exepected size %d)\n"
+                       (I.V.pp_v v) total_size
+                | _ ->
+                   Warn.user_error
+                     "Unexpected scalar value %s, vector expected"
+                     (I.V.pp_v v) in
               let locval = match global loc with
               | Some x -> x
               | _ -> Warn.user_error "Non-global vector assignment in init" in
@@ -715,7 +723,7 @@ module Make(C:Config) (I:I) : S with module I = I
                | I.V.Val c -> c
                | _ -> Warn.fatal "Non constant value in vector")
              locs in
-         I.V.Val (Constant.ConcreteVector (List.length cs,cs))
+         I.V.Val (Constant.ConcreteVector cs)
 
 
       (* Final (include faults) *)

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -161,7 +161,7 @@ module SymbolMap = MyMap.Make(SC)
 
 type 'scalar t =
   | Concrete of 'scalar
-  | ConcreteVector of int * 'scalar t list
+  | ConcreteVector of 'scalar t list
   | Symbolic  of symbol
   | Label of Proc.t * string     (* In code *)
   | Tag of string
@@ -169,15 +169,15 @@ type 'scalar t =
 
 let _debug = function
 | Concrete _ -> "Concrete _"
-| ConcreteVector (sz,_) -> sprintf "ConcreteVector (%d,_)" sz
+| ConcreteVector vs -> sprintf "ConcreteVector (%d,_)" (List.length vs)
 | Symbolic sym -> sprintf "Symbol %s" (pp_symbol sym)
 | Label (p,s) -> sprintf "Label (%s,%s)" (Proc.pp p) s
 | Tag s -> sprintf "Tag %s" s
 | PteVal p -> sprintf "PteVal %s" (PTEVal.pp p)
 
 let rec map_scalar f = function
-| Concrete  s -> Concrete (f s)
-| ConcreteVector (sz,cs) -> ConcreteVector (sz,List.map (map_scalar f) cs)
+| Concrete s -> Concrete (f s)
+| ConcreteVector cs -> ConcreteVector (List.map (map_scalar f) cs)
 | (Symbolic _|Label _ |Tag _|PteVal _) as c -> c
 
 let do_mk_virtual s = Virtual { default_symbolic_data with name=s; }
@@ -224,11 +224,11 @@ let old2new s =
    | None -> s
    end
 
-let mk_vec sz v =
-  assert (sz == (List.length v));
-  ConcreteVector (sz, v)
+let mk_vec sz vs =
+  assert (sz == (List.length vs));
+  ConcreteVector vs
 
-let mk_replicate sz v = ConcreteVector (sz, Misc.replicate sz v)
+let mk_replicate sz v = ConcreteVector (Misc.replicate sz v)
 
 let is_symbol = function
   | Symbolic _ -> true
@@ -243,7 +243,7 @@ let default_tag = Tag "green"
 
 let check_sym v =  match v with
 | Symbolic _|Label _|Tag _ as sym -> sym
-| Concrete _|ConcreteVector (_,_)|PteVal _ ->  assert false
+| Concrete _|ConcreteVector _|PteVal _ ->  assert false
 
 let is_virtual v = match v with
 | Symbolic (Virtual _) -> true

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -66,14 +66,14 @@ module SymbolMap : MyMap.S with type key = symbol
 (* Add scalars *)
 type 'scalar t =
   | Concrete of 'scalar
-  | ConcreteVector of int * 'scalar t list
+  | ConcreteVector of 'scalar t list
   | Symbolic  of symbol
   | Label of Proc.t * string     (* In code *)
   | Tag of string
   | PteVal of PTEVal.t
 
 (* Do nothing on non-scalar *)
-val map_scalar : ('scalar -> 'scalar) -> 'scalar t -> 'scalar t
+val map_scalar : ('a -> 'b) -> 'a t -> 'b t
 
 val mk_sym_virtual : string -> 'scalar t
 val mk_sym : string -> 'scalar t

--- a/lib/symbConstant.ml
+++ b/lib/symbConstant.ml
@@ -33,7 +33,7 @@ module Make(Scalar:Scalar.S) = struct
 
   let rec do_pp pp_symbol pp_scalar hexa = function
     | Concrete i -> pp_scalar hexa i
-    | ConcreteVector (_,vs) ->
+    | ConcreteVector vs ->
         let s =
           String.concat ","
             (List.map (do_pp pp_symbol pp_scalar hexa) vs)
@@ -51,7 +51,7 @@ module Make(Scalar:Scalar.S) = struct
 
   let rec compare c1 c2 = match c1,c2 with
   | Concrete i1, Concrete i2 -> Scalar.compare i1 i2
-  | ConcreteVector (_sz1, v1), ConcreteVector (_sz2, v2) ->
+  | ConcreteVector v1, ConcreteVector v2 ->
       Misc.list_compare compare v1 v2
   | Symbolic sym1,Symbolic sym2 -> compare_symbol sym1 sym2
   | Label (p1,s1),Label (p2,s2) ->
@@ -73,7 +73,7 @@ module Make(Scalar:Scalar.S) = struct
 
   let rec eq c1 c2 = match c1,c2 with
   | Concrete i1, Concrete i2 -> Scalar.compare i1 i2 = 0
-  | ConcreteVector (_,v1), ConcreteVector (_,v2) ->
+  | ConcreteVector v1, ConcreteVector v2 ->
       Misc.list_eq eq v1 v2
   | Symbolic s1, Symbolic s2 -> Constant.symbol_eq s1 s2
   | Label (p1,s1),Label (p2,s2) ->

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -80,7 +80,7 @@ module Make(Cst:Constant.S) = struct
   let rec tr_cst c = match c with
     | Symbolic _ | Label _ | Tag _ | PteVal _ as m -> m
     | Concrete s -> Concrete (Scalar.of_string s)
-    | ConcreteVector (sz,ms) -> ConcreteVector (sz,List.map tr_cst ms)
+    | ConcreteVector cs -> ConcreteVector (List.map tr_cst cs)
 
   let maybevToV c = Val (tr_cst c)
 

--- a/litmus/CSymbReg.ml
+++ b/litmus/CSymbReg.ml
@@ -34,13 +34,7 @@ with type v = A.V.v and type location = A.location
    type location = A.location
    type ('loc,'v) t = ('loc,'v, string CAst.t) MiscParser.r4
 
-   let maybevToV =
-     let open Constant in
-     let rec f mv = match mv with
-     | Symbolic _|Label _|Tag _|PteVal _ as sym -> sym
-     | Concrete s -> Concrete (A.V.Scalar.of_string s)
-     | ConcreteVector (sz,vs) -> ConcreteVector (sz,List.map f vs) in
-     f
+   let maybevToV = Constant.map_scalar A.V.Scalar.of_string
 
 (******************************************************)
 (* All those to substitute symbolic regs by real ones *)

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -324,7 +324,7 @@ module Make
       let open Constant in
       match v with
       | Concrete i -> A.V.Scalar.pp Cfg.hexa i
-       | ConcreteVector (_,vs)->
+       | ConcreteVector vs->
           let pp_vs = List.map dump_a_v vs in
           sprintf "{%s}" (String.concat "," pp_vs) (* list initializer syntax *)
       | Symbolic (Virtual {name=s;tag=None;cap=0L;offset=0;_})-> dump_a_addr s

--- a/litmus/archExtra_litmus.ml
+++ b/litmus/archExtra_litmus.ml
@@ -35,6 +35,7 @@ module type S = sig
 
   module I : I
 
+  val maybevToV : ParsedConstant.v -> I.V.Scalar.t Constant.t
   val comment : string (* ASM comment to use *)
 
   module RegSet : MySet.S with type elt = I.arch_reg
@@ -82,6 +83,8 @@ module Make(O:Config)(I:I) : S with module I = I
   | None -> I.comment
 
   module I = I
+
+  let maybevToV c = Constant.map_scalar I.V.Scalar.of_string c
 
   module RegSet =
     MySet.Make

--- a/litmus/compCond.ml
+++ b/litmus/compCond.ml
@@ -50,7 +50,7 @@ module Make (O:Indent.S) (I:CompCondUtils.I) =
         let rec dump_prop p = match p with
         | Atom (LV (loc,v)) ->
             begin match v with
-            | Constant.ConcreteVector (_,vs) ->
+            | Constant.ConcreteVector vs ->
                 O.fprintf "(%s)" (dump_vec loc vs)
             | _ ->
                 O.fprintf "%s == %s"

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -55,7 +55,7 @@ module Generic (A : Arch_litmus.Base)
 
       let typeof = function
         | Constant.Concrete _ -> base
-        | Constant.ConcreteVector (sz,_) -> base_array sz
+        | Constant.ConcreteVector vs -> base_array (List.length vs)
         | Constant.Symbolic _ -> pointer
         | Constant.Label _ -> code_pointer
         | Constant.Tag _ -> tag

--- a/litmus/constr.ml
+++ b/litmus/constr.ml
@@ -100,7 +100,7 @@ module RLocSet = A.RLocSet =
             let rec f v k = match v with
             | Symbolic (Virtual {name=s;offset=0;tag=None;_}) -> Strings.add s k
             | Concrete _|PteVal _ -> k
-            | ConcreteVector (_,vs) ->
+            | ConcreteVector vs ->
                 List.fold_right f vs k
             | Label _|Symbolic _|Tag _ -> assert false in
             f v k

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1294,7 +1294,7 @@ module Make
             match at with
             | Array (t,sz) ->
                 begin match v with
-                | Constant.ConcreteVector (_,ws) ->
+                | Constant.ConcreteVector ws ->
                     let rec init_rec k ws =
                       if k < sz then begin
                           let w,ws = match ws with

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -347,7 +347,7 @@ module Make
         | Concrete i ->  A.V.Scalar.pp  Cfg.hexa i
         | Symbolic (Virtual {name=s;tag=None; offset=0;_}) ->
             dump_a_addr s
-        | ConcreteVector (_,vs) ->
+        | ConcreteVector vs ->
            let pps =
              List.map
                (fun v -> sprintf "%s," (dump_a_v v))

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -181,7 +181,7 @@ module Make(O:Config)(A:I) =
                       | Some s -> s::k
                       | None -> k
                       end
-                  | ConcreteVector (_,vs) ->
+                  | ConcreteVector vs ->
                       List.fold_right f vs k
                   | Concrete _|Label _|Tag _|PteVal _ -> k in
                   f v k)
@@ -217,7 +217,7 @@ module Make(O:Config)(A:I) =
         (fun k (_,v) ->
           let rec f v k = match v with
           | Label (p,s) -> (p,s)::k
-          | ConcreteVector (_,vs) ->
+          | ConcreteVector vs ->
               List.fold_right f vs k
           | Concrete _|Symbolic _|Tag _|PteVal _ -> k
           in f v k)

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -151,13 +151,7 @@ module Top(O:Config)(Tar:Tar.S) = struct
           (struct
             include A
             type v = V.v
-            let maybevToV c =
-              let open  Constant in
-              let rec f c = match c with
-              | Concrete i ->  Concrete (V.Scalar.of_string i)
-              | ConcreteVector (sz,vs) -> ConcreteVector (sz, List.map f vs)
-              | Symbolic _|Label _|Tag _|PteVal _ as sym -> sym in
-                f c
+            let maybevToV = A.maybevToV
             type global = Global_litmus.t
             let maybevToGlobal = A.tr_global
           end)
@@ -291,13 +285,7 @@ module Top(O:Config)(Tar:Tar.S) = struct
     module AllocArch = struct
         include A
         type v = A.V.v
-        let maybevToV c =
-          let open Constant in
-          let rec f c = match c with
-          | Tag _|Symbolic _|Label _|PteVal _ as sym -> sym
-          | Concrete i -> Concrete (A.V.Scalar.of_string i)
-          | ConcreteVector (sz,vs) -> ConcreteVector (sz, List.map f vs) in
-          f c
+        let maybevToV = A.maybevToV
         type global = Global_litmus.t
         let maybevToGlobal = A.tr_global
       end

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -315,13 +315,7 @@ end = struct
       module AllocArch = struct
         include A
         type v = A.V.v
-        let maybevToV c =
-          let open Constant in
-          let rec f c = match c with
-          | Tag _|Symbolic _|Label _|PteVal _ as sym -> sym
-          | Concrete i -> Concrete (A.V.Scalar.of_string i)
-          | ConcreteVector (sz,vs) -> ConcreteVector (sz, List.map f vs) in
-          f c
+        let maybevToV = A.maybevToV
         type global = Global_litmus.t
         let maybevToGlobal = A.tr_global
       end

--- a/tools/alpha.ml
+++ b/tools/alpha.ml
@@ -189,7 +189,7 @@ struct
     let rec collect_value f v k = match v with
     | Symbolic (Virtual {name=s;_}|System ((PTE|PTE2),s)) -> f s k
     | Concrete _ -> k
-    | ConcreteVector (_,vs) ->
+    | ConcreteVector vs ->
        List.fold_left (fun k v -> collect_value f v k) k vs
     | Label _ -> nolabel_value ()
     | Tag _ -> notag_value ()
@@ -202,8 +202,8 @@ struct
     | Symbolic (System (PTE,s)) ->  Symbolic (System (PTE,f s))
     | Symbolic (System (PTE2,s)) ->  Symbolic (System (PTE2,f s))
     | Concrete _ -> v
-    | ConcreteVector (n,vs) ->
-       ConcreteVector (n,List.map (map_value f) vs)
+    | ConcreteVector vs ->
+       ConcreteVector (List.map (map_value f) vs)
     | Label _ -> nolabel_value ()
     | Tag _ -> notag_value ()
     | PteVal _ -> nopte_value ()

--- a/tools/logConstr.ml
+++ b/tools/logConstr.ml
@@ -30,7 +30,7 @@ let rec tr_v v =
   let open Constant in
   match v with
   | Concrete i -> Concrete (Int64.of_string i)
-  | ConcreteVector (sz,vs) -> ConcreteVector (sz,List.map tr_v vs)
+  | ConcreteVector vs -> ConcreteVector (List.map tr_v vs)
   | Symbolic _|Label _|Tag _|PteVal _ as sym -> sym
 
 let tr_atom = function


### PR DESCRIPTION
Number of items is easily reconstructed as the length of the item list.