### PR TITLE
[gen]  Enforce mixed-size overlapping accessses

### DIFF
--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -191,6 +191,8 @@ let applies_atom (a,_) d = match a,d with
    let compare_atom = compare
    let equal_atom a1 a2 = a1 = a2
 
+   let access_atom (_,m) = m
+
    let fold_mixed f r =
      if do_mixed then
        Mixed.fold_mixed
@@ -314,10 +316,10 @@ let applies_atom (a,_) d = match a,d with
    | _,_ ->
        if equal_atom a1 a2 then Some a1 else None
 
-   let overlap_atoms strict a1 a2 = match a1,a2 with
+   let overlap_atoms a1 a2 = match a1,a2 with
      | ((_,None),(_,_))|((_,_),(_,None)) -> true
      | ((_,Some sz1),(_,Some sz2)) ->
-         MachMixed.overlap strict sz1 sz2
+         MachMixed.overlap  sz1 sz2
 
    let neon_as_integers =
      let open SIMD in

--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -314,6 +314,11 @@ let applies_atom (a,_) d = match a,d with
    | _,_ ->
        if equal_atom a1 a2 then Some a1 else None
 
+   let overlap_atoms strict a1 a2 = match a1,a2 with
+     | ((_,None),(_,_))|((_,_),(_,None)) -> true
+     | ((_,Some sz1),(_,Some sz2)) ->
+         MachMixed.overlap strict sz1 sz2
+
    let neon_as_integers =
      let open SIMD in
      function

--- a/gen/BellArch_gen.ml
+++ b/gen/BellArch_gen.ml
@@ -129,6 +129,7 @@ let pp_atom a =  pp_annots a
 let compare_atom a1 a2 =
   Misc.list_compare String.compare a1 a2
 
+let access_atom _ = None
 
 let fold_annots eg f r =
   List.fold_left
@@ -195,7 +196,7 @@ let varatom_dir = match varatom with
 
 let merge_atoms a1 a2 = if a2 = a1 then Some a1 else None
 
-let overlap_atoms _ _ _ = true
+let overlap_atoms _ _ = true
 
 let atom_to_bank _ = Code.Ord
 

--- a/gen/BellArch_gen.ml
+++ b/gen/BellArch_gen.ml
@@ -195,6 +195,8 @@ let varatom_dir = match varatom with
 
 let merge_atoms a1 a2 = if a2 = a1 then Some a1 else None
 
+let overlap_atoms _ _ _ = true
+
 let atom_to_bank _ = Code.Ord
 
 let varatom_rmw = match varatom with

--- a/gen/CArch_gen.ml
+++ b/gen/CArch_gen.ml
@@ -57,6 +57,8 @@ let varatom_dir _d f = f None
 
 let merge_atoms a1 a2 = if a1=a2 then Some a1 else None
 
+let overlap_atoms _ _ _ = true
+
 let atom_to_bank _ = Code.Ord
 
 include NoMixed

--- a/gen/CArch_gen.ml
+++ b/gen/CArch_gen.ml
@@ -36,6 +36,8 @@ let applies_atom a d = match a,d with
 
 let compare_atom = Misc.polymorphic_compare
 
+let access_atom _ = None
+
 let pp_plain = Code.plain
 let pp_as_a = Some SC
 let pp_atom = pp_mem_order_short
@@ -57,7 +59,7 @@ let varatom_dir _d f = f None
 
 let merge_atoms a1 a2 = if a1=a2 then Some a1 else None
 
-let overlap_atoms _ _ _ = true
+let overlap_atoms _ _ = true
 
 let atom_to_bank _ = Code.Ord
 

--- a/gen/RISCVArch_gen.ml
+++ b/gen/RISCVArch_gen.ml
@@ -85,6 +85,10 @@ module Make
 
    let compare_atom = compare
 
+   let access_atom = function
+     | MO _|Atomic _ -> None
+     | Mixed m -> Some m
+
    let fold_mixed f k = Mixed.fold_mixed (fun  mix r -> f (Mixed mix) r) k
 
    let fold_mo f k =
@@ -115,10 +119,10 @@ module Make
 
    let merge_atoms a1 a2 = if a1=a2 then Some a1 else None
 
-   let overlap_atoms strict a1 a2 =
+   let overlap_atoms a1 a2 =
      match a1,a2 with
      | ((MO _|Atomic _),_)|(_,(MO _|Atomic _)) -> true
-     | Mixed m1,Mixed m2 -> MachMixed.overlap strict m1 m2
+     | Mixed m1,Mixed m2 -> MachMixed.overlap m1 m2
 
    let atom_to_bank _ = Code.Ord
 

--- a/gen/RISCVArch_gen.ml
+++ b/gen/RISCVArch_gen.ml
@@ -115,6 +115,11 @@ module Make
 
    let merge_atoms a1 a2 = if a1=a2 then Some a1 else None
 
+   let overlap_atoms strict a1 a2 =
+     match a1,a2 with
+     | ((MO _|Atomic _),_)|(_,(MO _|Atomic _)) -> true
+     | Mixed m1,Mixed m2 -> MachMixed.overlap strict m1 m2
+
    let atom_to_bank _ = Code.Ord
 
    let tr_value ao v = match ao with

--- a/gen/X86Arch_gen.ml
+++ b/gen/X86Arch_gen.ml
@@ -36,6 +36,8 @@ let compare_atom = compare
 
 let merge_atoms Atomic Atomic = Some Atomic
 
+let overlap_atoms _ _ _ = true
+
 let pp_plain = Code.plain
 
 let pp_as_a = None

--- a/gen/X86Arch_gen.ml
+++ b/gen/X86Arch_gen.ml
@@ -34,9 +34,11 @@ let applies_atom a d = match a,d with
 
 let compare_atom = compare
 
+let access_atom Atomic = None
+
 let merge_atoms Atomic Atomic = Some Atomic
 
-let overlap_atoms _ _ _ = true
+let overlap_atoms _ _ = true
 
 let pp_plain = Code.plain
 

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -56,6 +56,8 @@ module Make
 
       let compare_atom = compare
 
+      let access_atom (_,sz) = sz
+
       let pp_plain = Code.plain
 
       let pp_as_a = None
@@ -112,9 +114,9 @@ module Make
             check_nt a sz1
         | _,_ -> if a1=a2 then Some a1 else None
 
-      let overlap_atoms strict a1 a2 = match a1,a2 with
+      let overlap_atoms a1 a2 = match a1,a2 with
         | ((_,None),_)|(_,(_,None)) -> true
-        | (_,Some m1),(_,Some m2) -> MachMixed.overlap strict m1 m2
+        | (_,Some m1),(_,Some m2) -> MachMixed.overlap m1 m2
 
       let atom_to_bank _ = Code.Ord
 

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -112,6 +112,10 @@ module Make
             check_nt a sz1
         | _,_ -> if a1=a2 then Some a1 else None
 
+      let overlap_atoms strict a1 a2 = match a1,a2 with
+        | ((_,None),_)|(_,(_,None)) -> true
+        | (_,Some m1),(_,Some m2) -> MachMixed.overlap strict m1 m2
+
       let atom_to_bank _ = Code.Ord
 
 (**************)

--- a/gen/atom.mli
+++ b/gen/atom.mli
@@ -43,6 +43,8 @@ module type S = sig
   val worth_final : atom -> bool
   val varatom_dir : Code.dir -> (atom option -> 'a -> 'a) -> 'a -> 'a
   val merge_atoms : atom -> atom -> atom option
+(* boolean commands strict overlap check, ie no equality *)
+  val overlap_atoms : bool -> atom -> atom -> bool
 (* Memory bank *)
   val atom_to_bank : atom -> SIMD.atom Code.bank
 (* Value computation, for mixed size *)

--- a/gen/atom.mli
+++ b/gen/atom.mli
@@ -34,6 +34,7 @@ module type S = sig
   val default_atom : atom
   val applies_atom : atom -> Code.dir -> bool
   val compare_atom : atom -> atom -> int
+  val access_atom : atom -> MachMixed.t option
   val pp_plain : string
   val pp_as_a : atom option
   val pp_atom : atom -> string
@@ -43,8 +44,7 @@ module type S = sig
   val worth_final : atom -> bool
   val varatom_dir : Code.dir -> (atom option -> 'a -> 'a) -> 'a -> 'a
   val merge_atoms : atom -> atom -> atom option
-(* boolean commands strict overlap check, ie no equality *)
-  val overlap_atoms : bool -> atom -> atom -> bool
+  val overlap_atoms : atom -> atom -> bool
 (* Memory bank *)
   val atom_to_bank : atom -> SIMD.atom Code.bank
 (* Value computation, for mixed size *)

--- a/gen/diyone.ml
+++ b/gen/diyone.ml
@@ -109,10 +109,10 @@ module Make(O:Config) (M:Builder.S) =
           let nprocs = Normer.get_nprocs es in
           let scope =  get_scope nprocs in
           match name with
-          | None -> dump_stdout ?scope (M.E.resolve_edges es)
+          | None -> dump_stdout ?scope es
           | Some name ->
               let name = add_suffix name in
-              dump_file name ?scope (M.E.resolve_edges es)
+              dump_file name ?scope es
 
     module P = LineUtils.Make(M.E)
 

--- a/gen/machAtom.ml
+++ b/gen/machAtom.ml
@@ -50,6 +50,10 @@ module Make(C:Config) = struct
 
   let compare_atom = compare
 
+  let access_atom = function
+    | Atomic|Reserve -> None
+    | Mixed m -> Some m
+
   let fold_mixed f r = Mixed.fold_mixed (fun mix r -> f (Mixed mix) r) r
   let fold_non_mixed f r =  f Reserve (f Atomic r)
 
@@ -66,9 +70,9 @@ module Make(C:Config) = struct
 
   let merge_atoms a1 a2 = if a1 = a2 then Some a1 else None
 
-  let overlap_atoms strict a1 a2 = match a1,a2 with
+  let overlap_atoms a1 a2 = match a1,a2 with
     | ((Atomic|Reserve),_)|(_,(Atomic|Reserve)) -> true
-    | Mixed sz1,Mixed sz2 -> MachMixed.overlap strict sz1 sz2
+    | Mixed sz1,Mixed sz2 -> MachMixed.overlap  sz1 sz2
 
 (* Single memory bank *)
   let atom_to_bank _ = Code.Ord

--- a/gen/machAtom.ml
+++ b/gen/machAtom.ml
@@ -66,6 +66,10 @@ module Make(C:Config) = struct
 
   let merge_atoms a1 a2 = if a1 = a2 then Some a1 else None
 
+  let overlap_atoms strict a1 a2 = match a1,a2 with
+    | ((Atomic|Reserve),_)|(_,(Atomic|Reserve)) -> true
+    | Mixed sz1,Mixed sz2 -> MachMixed.overlap strict sz1 sz2
+
 (* Single memory bank *)
   let atom_to_bank _ = Code.Ord
 

--- a/gen/machMixed.ml
+++ b/gen/machMixed.ml
@@ -32,10 +32,9 @@ let disjoint (l1,h1) (l2,h2) =
 
 let tr (sz,o) = (o,o+MachSize.nbytes sz)
 
-let overlap strict a1 a2 =
+let overlap a1 a2 =
   let i1 = tr a1 and i2 = tr a2 in
-  not (disjoint i1 i2) &&
-  (not (strict && equal a1 a2))
+  not (disjoint i1 i2)
 
 module Make(C:Config) = struct
 

--- a/gen/machMixed.ml
+++ b/gen/machMixed.ml
@@ -27,6 +27,16 @@ type t = sz * offset
 let equal (sz1,o1) (sz2,o2) =
   MachSize.equal sz1 sz2 && Misc.int_eq o1 o2
 
+let disjoint (l1,h1) (l2,h2) =
+   l1 < l2 && h1 <= l2 || l2 < l1 && h2 <= l1
+
+let tr (sz,o) = (o,o+MachSize.nbytes sz)
+
+let overlap strict a1 a2 =
+  let i1 = tr a1 and i2 = tr a2 in
+  not (disjoint i1 i2) &&
+  (not (strict && equal a1 a2))
+
 module Make(C:Config) = struct
 
   open Printf
@@ -68,6 +78,7 @@ module type ValsConfig = sig
 end
 
 module Vals(C:ValsConfig) = struct
+
   let correct_offset = match C.endian with
   | Little -> fun _ o -> o
   | Big ->

--- a/gen/machMixed.mli
+++ b/gen/machMixed.mli
@@ -24,8 +24,7 @@ type t = MachSize.sz * offset
 
 val equal : t -> t -> bool
 
-(* Boolean argument commands strict overlap check (i.e. different) *)
-val overlap : bool -> t -> t -> bool
+val overlap : t -> t -> bool
 
 module Make :
   functor (C:Config) ->

--- a/gen/machMixed.mli
+++ b/gen/machMixed.mli
@@ -1,0 +1,54 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2015-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+module type Config = sig
+  val naturalsize : MachSize.sz option
+  val fullmixed : bool
+end
+
+type offset = int
+type t = MachSize.sz * offset
+
+val equal : t -> t -> bool
+
+(* Boolean argument commands strict overlap check (i.e. different) *)
+val overlap : bool -> t -> t -> bool
+
+module Make :
+  functor (C:Config) ->
+  sig
+
+    val pp_mixed : t -> string
+
+    val fold_mixed : (t -> 'a -> 'a) -> 'a -> 'a
+
+    val tr_value : MachSize.sz -> int -> int
+  end
+
+module type ValsConfig = sig
+  val naturalsize : unit -> MachSize.sz
+  val endian : Endian.t
+end
+
+module Vals :
+  functor(C:ValsConfig) ->
+  sig
+    val overwrite_value :
+      int (* old *) -> MachSize.sz -> offset -> int (* write *) -> int
+
+    val extract_value : int -> MachSize.sz -> offset -> int
+
+  end

--- a/gen/variant_gen.ml
+++ b/gen/variant_gen.ml
@@ -22,6 +22,10 @@ type t =
   | Mixed
 (* Lift the default restriction of mixed-size annotation to depth one *)
   | FullMixed
+(* Allow non-overlapping mixed accesses *)
+  | MixedDisjoint
+(* Require strict overlap *)
+  | MixedStrictOverlap
 (* Self-modifying code *)
   | Self
 (* MTE = Memory tagging *)
@@ -38,14 +42,18 @@ type t =
   | ConstrainedUnpredictable
 
 let tags =
- ["AsAmo";"ConstsInInit";"Mixed";"FullMixed";"Self"; "MemTag";
-  "NoVolatile"; "Morello"; "kvm"; "Neon"; "ConstrainedUnpredictable"; ]
+  ["AsAmo";"ConstsInInit";
+   "Mixed";"FullMixed";"MixedDisjoint"; "MixedStrictOverlap";
+   "Self"; "MemTag";
+   "NoVolatile"; "Morello"; "kvm"; "Neon"; "ConstrainedUnpredictable"; ]
 
 let parse tag = match Misc.lowercase tag with
 | "asamo" -> Some AsAmo
 | "constsininit" -> Some ConstsInInit
 | "mixed" -> Some Mixed
 | "fullmixed" -> Some FullMixed
+| "mixeddisjoint"|"disjoint" -> Some MixedDisjoint
+| "mixedstrictoverlap"|"strictoverlap" -> Some MixedStrictOverlap
 | "self" -> Some Self
 | "memtag" -> Some MemTag
 | "novolatile" -> Some NoVolatile
@@ -60,6 +68,8 @@ let pp = function
   | ConstsInInit -> "ConstsInInit"
   | Mixed -> "Mixed"
   | FullMixed -> "FullMixed"
+  | MixedDisjoint -> "MixedDisjoint"
+  | MixedStrictOverlap -> "MixedStrictOverlap"
   | Self -> "Self"
   | MemTag -> "MemTag"
   | NoVolatile -> "NoVolatile"

--- a/gen/variant_gen.mli
+++ b/gen/variant_gen.mli
@@ -22,6 +22,10 @@ type t =
   | Mixed
 (* Lift the default restriction of mixed-size annotation to depth one *)
   | FullMixed
+(* Allow non-overlapping mixed accesses *)
+  | MixedDisjoint
+(* Require strict overlap *)
+  | MixedStrictOverlap
 (* Self-modifying code *)
   | Self
 (* MTE = Memory tagging *)


### PR DESCRIPTION
By default non-overlapping mixed-size accesses across relaxations
with identical source and target locations are discarded.

Some variants command further control:
  + `-variant MixedDisjoint` disable overlap check
  + `-variant MixedStrictOverlap` strengthen overlap check by
    rejecting identical accesses.
