### PR TITLE
[litmus] Recognize Irf and Ifr lexemes in affinity meta-data

### DIFF
--- a/litmus/lexAffinity.mll
+++ b/litmus/lexAffinity.mll
@@ -38,8 +38,8 @@ let num = digit+
 
 rule coms = parse
 | space+ { coms lexbuf }
-| "Fr"|"Iff"   { Fr :: coms lexbuf }
-| "Rf"|"Fif"   { Rf :: coms lexbuf }
+| "Fr"|"Iff"|"Irf"  { Fr :: coms lexbuf }
+| "Rf"|"Fif"|"Ifr"  { Rf :: coms lexbuf }
 | "Ws"|"Co"    { Ws :: coms lexbuf }
 | "Hat"  { Hat :: coms lexbuf }
 | eof    { [] }


### PR DESCRIPTION
Irf and Ifr and more easy to remember for
rf and fr where the read is instruction
fetch (`-variant self` mode).