### PR TITLE
[gen] AArch64 refine register typing.

### DIFF
--- a/gen/archExtra_gen.ml
+++ b/gen/archExtra_gen.ml
@@ -62,6 +62,8 @@ module type S = sig
 (***********************)
 
   type st
+  val debug_env : st -> string
+
   val st0 : st
 
   val alloc_reg : st -> arch_reg * st
@@ -207,6 +209,10 @@ with type arch_reg = I.arch_reg and type special = I.special
         (* For fresh addresses *)
         next_addr : int; }
 
+  let debug_env st =
+    LocMap.pp_str
+      (fun loc t -> sprintf "%s->%s" (pp_location loc) (TypBase.pp t))
+      st.env
 
   let st0 =
     { regs = I.free_registers;

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h0+amo.casa.w0w0-pow0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h0+amo.casa.w0w0-pow0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=0x2020202 /\ 1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+dmb.syh2h0+amo.casa.w0w0-pow0w0 Never 0 3
-Hash=416263a3bccd6b84c56bb04d1e6450fe
+Hash=de0b51dd0baeae300ccb7bb64c89c67f
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h0+rmwa.w0w0-pow0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h0+rmwa.w0w0-pow0w0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=0x2020202 /\ 1:X3=0x0 /\ 1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+dmb.syh2h0+rmwa.w0w0-pow0w0 Never 0 6
-Hash=f6ca3e0076198c3398b739f36b2dc82c
+Hash=4314d60349bb069b9216fadcff66b408
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h2+amo.casa.w0w0-pow0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h2+amo.casa.w0w0-pow0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=0x2020202 /\ 1:X2=0x1010000 /\ 1:X4=0x0)
 Observation MP+dmb.syh2h2+amo.casa.w0w0-pow0w0 Never 0 3
-Hash=6242843f0052c5e78dd70a3d8778c667
+Hash=ccd1563306b43f28d7565b33bc2812c4
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h2+rmwa.w0w0-pow0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h2+rmwa.w0w0-pow0w0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=0x2020202 /\ 1:X3=0x0 /\ 1:X1=0x1010000 /\ 1:X4=0x0)
 Observation MP+dmb.syh2h2+rmwa.w0w0-pow0w0 Never 0 6
-Hash=6b9c1431baed5c4519f24543bae81280
+Hash=f56e96d5bea787face50423eb6acd80e
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+amo.casa.h0h0-poh0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+amo.casa.h0h0-poh0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=0x1010202 /\ 1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+dmb.syh2w0+amo.casa.h0h0-poh0w0 Never 0 3
-Hash=a4d1bfb7a54a88d64361142ea1c4bd33
+Hash=91643c1d02ebd53a9c3fb07ad22b176e
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+amo.casa.h2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+amo.casa.h2h2-poh2w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=0x2020101 /\ 1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+dmb.syh2w0+amo.casa.h2h2-poh2w0 Never 0 3
-Hash=80a38434ea5c829ac2f08847d2b4af1b
+Hash=a505ef52a19e87a874d77d613b2644a1
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+rmwa.h0h0-poh0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+rmwa.h0h0-poh0w0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=0x1010202 /\ 1:X3=0x0 /\ 1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+dmb.syh2w0+rmwa.h0h0-poh0w0 Never 0 6
-Hash=bca618348da6fd9888d33ee2f5339534
+Hash=270fab22a7c12a158aea69779324edf5
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+rmwa.h2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+rmwa.h2h2-poh2w0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=0x2020101 /\ 1:X4=0x0 /\ 1:X1=0x101 /\ 1:X5=0x0)
 Observation MP+dmb.syh2w0+rmwa.h2h2-poh2w0 Never 0 6
-Hash=8bd832784bc8b39b0bddf43c87f80f37
+Hash=c1d309c050670a2b353b7fcb7647db6b
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h0+amo.casa.w0w0-pow0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h0+amo.casa.w0w0-pow0h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=0x2020202 /\ 1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+dmb.syw0h0+amo.casa.w0w0-pow0h0 Never 0 3
-Hash=2550c85bb9bf226f6bc0e7bf0a25a21e
+Hash=012860ecc04db3a0c0cca4401aa0a718
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h0+rmwa.w0w0-pow0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h0+rmwa.w0w0-pow0h0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=0x2020202 /\ 1:X3=0x0 /\ 1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+dmb.syw0h0+rmwa.w0w0-pow0h0 Never 0 6
-Hash=0e693f113b4679af9251080d5392ba1a
+Hash=57a7bb49754c69116685b24f2ce72503
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h2+amo.casa.w0w0-pow0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h2+amo.casa.w0w0-pow0h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=0x2020202 /\ 1:X2=0x1010000 /\ 1:X4=0x0)
 Observation MP+dmb.syw0h2+amo.casa.w0w0-pow0h0 Never 0 3
-Hash=3524f6886fc0fc66d88a3b92e53d35fc
+Hash=ce2a7c8ea6503ba5f9bc7011832e680e
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h2+rmwa.w0w0-pow0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h2+rmwa.w0w0-pow0h0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=0x2020202 /\ 1:X3=0x0 /\ 1:X1=0x1010000 /\ 1:X4=0x0)
 Observation MP+dmb.syw0h2+rmwa.w0w0-pow0h0 Never 0 6
-Hash=e96134dc2032a9bdd4fa8d41597aeb43
+Hash=d49dfe5d923bb3de9524ebe4e9e110f3
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+amo.casa.h0h0-poh0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+amo.casa.h0h0-poh0h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=0x1010202 /\ 1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+dmb.syw0w0+amo.casa.h0h0-poh0h0 Never 0 3
-Hash=7a8fd52a3cab10dd824e9f115067864d
+Hash=9f7ea35957b7fcaa3c120cad7b8ed304
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+amo.casa.h2h2-poh2h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+amo.casa.h2h2-poh2h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=0x2020101 /\ 1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+dmb.syw0w0+amo.casa.h2h2-poh2h0 Never 0 3
-Hash=ffa5eb8ebd16c59d4f3374cfab584ba6
+Hash=27e2a650c1b171931160eba3ded2ec7c
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+rmwa.h0h0-poh0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+rmwa.h0h0-poh0h0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=0x1010202 /\ 1:X3=0x0 /\ 1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+dmb.syw0w0+rmwa.h0h0-poh0h0 Never 0 6
-Hash=ffa4655ba6cb546439d7bf11649c35a4
+Hash=8f27065e5163d82a74b4a257910b7e7c
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+rmwa.h2h2-poh2h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+rmwa.h2h2-poh2h0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=0x2020101 /\ 1:X4=0x0 /\ 1:X1=0x101 /\ 1:X5=0x0)
 Observation MP+dmb.syw0w0+rmwa.h2h2-poh2h0 Never 0 6
-Hash=c2dec65c826175a54bd6ad30ae5fb95e
+Hash=cd0a3cd53085724a3a66d61c5f6b517b
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0a.h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0a.h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.h0a.h0 Never 0 3
-Hash=30aef0c404be89ab7adf585e54213ca7
+Hash=41fc5a689f77a5c23f9393b6c2cb4896
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0a.h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0a.h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.h0a.h2 Never 0 3
-Hash=afc7cac644628bbacb15d092b70d8de5
+Hash=8de643fb5b90da65ad92e848a4b2570e
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0a.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0a.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.h0a.w0 Never 0 3
-Hash=9a5a6af1d80b94e2c458fc651e20a528
+Hash=1862ded9f722e8f60b4434fec8aabba8
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.h0h0 Never 0 3
-Hash=a95c693ff8dca4aa3b58de9d4b5ef088
+Hash=c3449c21e2e9ce5b8e582e9b836e188d
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.h0h2 Never 0 3
-Hash=d2d8cb855ea085fafd0f13464cf163ee
+Hash=b7d9b5073dd9ee074027423267c81c94
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.h0w0 Never 0 3
-Hash=bf4543fd599d3e2fa1d37288356f7bef
+Hash=c4b667f290f4e99e22a96574e513cb53
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2a.h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2a.h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+pow0l.w0+addra.h2a.h0 Never 0 3
-Hash=f560e376a692368da5bb64dda7bfd0b2
+Hash=31632baf6d38bb2294e87044a3e612b8
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2a.h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2a.h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+pow0l.w0+addra.h2a.h2 Never 0 3
-Hash=1691088c6f9c7ddd080a130894cd704f
+Hash=091ec43cf285fbb3920292a5ca8242c3
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2a.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2a.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+pow0l.w0+addra.h2a.w0 Never 0 3
-Hash=d4d41950eb5c9da33c0819c4fdf5ab98
+Hash=c8955a305a8a68ec6e6e63e867e0a88e
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+pow0l.w0+addra.h2h0 Never 0 3
-Hash=34f3604ec514f5985cb7d3f40991f657
+Hash=d7922d1ea5934f9b498235f4a98c508f
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+pow0l.w0+addra.h2h2 Never 0 3
-Hash=45da975faacbb60670ef034845ebff43
+Hash=945ecc6d139f35b751dd49327c5cc49c
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.h2w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101 /\ 1:X4=0x0)
 Observation MP+pow0l.w0+addra.h2w0 Never 0 3
-Hash=547dcad1f71da783fd7d1115075a1b89
+Hash=0b30f76456762ea67e7ad4fa2bd168f6
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0a.h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0a.h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.w0a.h0 Never 0 3
-Hash=50ed64a1cf1afbb38f29b33612795fc6
+Hash=a04e784efce3d045069124b7df0d5701
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0a.h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0a.h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.w0a.h2 Never 0 3
-Hash=f694465d0799493f56755aa74fd1a629
+Hash=cfbcd08438689ab3aea1b5ce0df34ec6
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0a.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0a.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.w0a.w0 Never 0 3
-Hash=cf4badf0e28a55c41acea787c4eda838
+Hash=68f4145d7e6baf46cf119f735743589f
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.w0h0 Never 0 3
-Hash=da38059884dd0af35dc05e4f5312c299
+Hash=c4489e2f59d8f51892eb69bc92d2999b
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.w0h2 Never 0 3
-Hash=0925096f2764297f5971843a526af381
+Hash=f7555940c122588ca4c4186fbe495c74
 

--- a/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/MP+pow0l.w0+addra.w0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+pow0l.w0+addra.w0w0 Never 0 3
-Hash=117fe32f4764fd7bf9537188d2f07d99
+Hash=4eda68aab0a341a9a993c604cee0b7d9
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h0h0 Never 0 3
-Hash=b38a7ac177050aefb9ceecdc298b3137
+Hash=7cf2ce0664822ea76c2e5df5d04e8280
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h0h2 Never 0 3
-Hash=33519bdd2f8ee94bfe18ca5b6d47c0b5
+Hash=0c59aafca70db6bb3d80b21206d7213a
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0l.h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0l.h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h0l.h0 Never 0 3
-Hash=ea83c5929bc56fa1ea6f99257359e731
+Hash=5d1deb5807b07c7224dbd77e5e828006
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0l.h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0l.h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h0l.h2 Never 0 3
-Hash=b4b19ca43f956c7fd3fe7fc053ccb863
+Hash=1970a2e842521b11274d44a41ff95b00
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h0l.w0 Never 0 3
-Hash=9c68e4e8edc6764d52e491af119f399b
+Hash=4220b7bcc0db14732a0871da696c54d8
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h0w0 Never 0 3
-Hash=82e45725c96b12302bd60627ff2afb41
+Hash=2bbd59fe96d67e8c0b2ea3cbb5599efe
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h2h0 Never 0 3
-Hash=b5c76efa2a7fa92038f9ea9749096735
+Hash=084f30805de9fe14136adbeb727edee3
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h2h2 Never 0 3
-Hash=566ba1ec3ca77ceed540350e4521f5e1
+Hash=408a178f2c8ed8df9331aa698016c825
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2l.h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2l.h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h2l.h0 Never 0 3
-Hash=bec923ab0b6f12bb9755a32ab8724f9d
+Hash=1ab9cabd68e83c3009449de8d6355c28
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2l.h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2l.h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h2l.h2 Never 0 3
-Hash=f2d29c22c4eb10d8523c39382a4fe75c
+Hash=82336db1414d661a4476bf707538295a
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h2l.w0 Never 0 3
-Hash=6cbd130e7f0ed14dcf8e3528f4a4d207
+Hash=066f61dd1dd83557b8d41d3a8a9b2cce
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.h2w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+addra.h2w0 Never 0 3
-Hash=01f4cd452b06a02d7bd711071273276b
+Hash=029265acf486078ae32a953b8dbc7fdd
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+addra.w0h0 Never 0 3
-Hash=a11f22ac0828d3b950de0b313c9f569f
+Hash=0ed2f9b82f64a0cd39bb2025a83081d3
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+addra.w0h2 Never 0 3
-Hash=d7bc16eaad2ddeff920472f81e7060d6
+Hash=87c3f37ff51a532730d81f31dcc01b22
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0l.h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0l.h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+addra.w0l.h0 Never 0 3
-Hash=1d3dc02bc3e41cfece6f0981b797a052
+Hash=8fd4ae149b876a64fcc1812bc5cd7b2d
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0l.h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0l.h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+addra.w0l.h2 Never 0 3
-Hash=8b86db78e0bc58e7ca78481ab47e9be1
+Hash=459256ecd797b0a505ae6a875a045060
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+addra.w0l.w0 Never 0 3
-Hash=f6502df0027e0cf770dda2cc2f5c7aa8
+Hash=5dcbc935bf445df61bb73c351cd4a846
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+addra.w0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+addra.w0w0 Never 0 3
-Hash=9c9c3a68ccda8a4c342e1c0eebae987f
+Hash=63285f16a74ae74e54762e3095d894e4
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h0h0 Never 0 3
-Hash=ef8bfd334a2af135eb17549ccbf60ee5
+Hash=8aeca24cd3c4a538e8bc9df7f569c75d
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h0h2 Never 0 3
-Hash=b27c59e90ce3bdf5bef9b5f2df5e652e
+Hash=00e31210c6758092a902c810256af53e
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0l.h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0l.h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h0l.h0 Never 0 3
-Hash=5899eba1fb11d28cca46db4bb02ed7b0
+Hash=a919f0de7bedf98f3755fcfa2212de23
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0l.h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0l.h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h0l.h2 Never 0 3
-Hash=c95eca3a829f488a4b49ba83c60dee2b
+Hash=f724ae899fed56e67be30d0ee8e4c3ad
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h0l.w0 Never 0 3
-Hash=e0aff31348876054bf9fb9b49bc88f55
+Hash=2d5296cfe4d93aae06e830a714d74468
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h0w0 Never 0 3
-Hash=076e5e7eb8ffda3b2d2c6902809482ff
+Hash=6e7a69051a8b7c762269c3a08dfcc699
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h2h0 Never 0 3
-Hash=55519d3866f91aa67a90928c9724673f
+Hash=5185516d969d586f3643ad30c9b084f5
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h2h2 Never 0 3
-Hash=816143a271b1b2da2b3e499beca69f3b
+Hash=0ca72953407e193ead820106c2bf4ffe
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2l.h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2l.h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h2l.h0 Never 0 3
-Hash=e4a7468c8d5154a9a2189908c0e05429
+Hash=d787f10d3459133305ec2d27f479074e
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2l.h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2l.h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h2l.h2 Never 0 3
-Hash=4aa43d0be9e30608ead1f1904485e0d7
+Hash=dfaa8228035b54c0152819274ee22c8e
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h2l.w0 Never 0 3
-Hash=8e13ced5f604648895f30b7577f4d8a7
+Hash=ac6277657c490276d038cf351255b269
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.h2w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x101)
 Observation S+pow0l.w0+dataa.h2w0 Never 0 3
-Hash=2ab3c175956576dd828923f20bc6fdb8
+Hash=f6270616ea6426a6d2547179d4801603
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+dataa.w0h0 Never 0 3
-Hash=39a2d6d5ba09a06d1bd76cc940fb6552
+Hash=d31b4543b010996ab04a68fe5622c604
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+dataa.w0h2 Never 0 3
-Hash=4327a0409212df3da4512f833379947f
+Hash=b54835d3e75d9c5a366528377d01e1b8
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0l.h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0l.h0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+dataa.w0l.h0 Never 0 3
-Hash=dfee13b553970370501946f3c2f32eb4
+Hash=b4f5dc7c9c4e5aaca3147bd75c085e3e
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0l.h2.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0l.h2.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+dataa.w0l.h2 Never 0 3
-Hash=4f3b69abe11f65c2b0167517ffa8a428
+Hash=447ce817964803ccca7c86ef38ce9f4a
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+dataa.w0l.w0 Never 0 3
-Hash=2ff3cad71a46b0fd4086aac304e369be
+Hash=468a696b7d772416bc7689b9d8b4970d
 

--- a/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v32/S+pow0l.w0+dataa.w0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x2020202 /\ 1:X1=0x1010101)
 Observation S+pow0l.w0+dataa.w0w0 Never 0 3
-Hash=469e3dab30dbbf966de6aa9ffc35a72e
+Hash=fb82861d31d12aab2e57a6dfb4d1baad
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0a.q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0a.q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101010101010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.q0a.q0 Never 0 3
-Hash=725bf5f2edffec127749795db152f564
+Hash=090589129d526ecc4d7c48bce349786b
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0a.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0a.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101010101010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.q0a.w0 Never 0 3
-Hash=4c931795e6ea7ab62633a1698164759b
+Hash=e03a8aa7124f8ec167c81a482485e170
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0a.w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0a.w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101010101010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.q0a.w4 Never 0 3
-Hash=4b0ed039985e9f951df06bd833f2c829
+Hash=8bff3afda1f44f0fe3dfacda4b77d897
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101010101010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.q0q0 Never 0 3
-Hash=d0f0a95f6ecd9bdf448188d8a6aa293f
+Hash=fea7dd8f94832567a3338364392fbfdf
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101010101010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.q0w0 Never 0 3
-Hash=fc7c2af1e612f4b288ebefbda3af560c
+Hash=f85a10ed439afc7bc2ff2119aca0cfea
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.q0w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x101010101010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.q0w4 Never 0 3
-Hash=2ba5d92e868a2b454fe78d23d729096f
+Hash=680b80f1040f297a5b165ff5a03c2d05
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0a.q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0a.q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.w0a.q0 Never 0 3
-Hash=5b32087a38b6220d91b3142a66d6b940
+Hash=f07ddeb5f27987799f96f675568187be
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0a.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0a.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.w0a.w0 Never 0 3
-Hash=2529622c9eb47ebbb5adeaa7ec5b9885
+Hash=716f90e5ff1326a6dd81a4b78617eab9
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0a.w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0a.w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.w0a.w4 Never 0 3
-Hash=19ff967986b462cca94888a2199a04ff
+Hash=9a1212ee9f57eabf3deebec9d6921fc1
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.w0q0 Never 0 3
-Hash=a4f210967639e3747eab468ec3bc286c
+Hash=56a5440a101b852025af951ccc004f05
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.w0w0 Never 0 3
-Hash=19fab5430342bdc628f26d0d63b54994
+Hash=dfd864dda068c223f3c7393a67edb1b9
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w0w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X3=0x0)
 Observation MP+poq0l.q0+addra.w0w4 Never 0 3
-Hash=afeca8df5c8c5389d3a4b885e74a8963
+Hash=2c4e2990abdc84d2501faf4f112e3035
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4a.q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4a.q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X4=0x0)
 Observation MP+poq0l.q0+addra.w4a.q0 Never 0 3
-Hash=d7301fe6e633af81e3d4766e81234162
+Hash=b388e7b1022fc93cccbc3714962f112d
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4a.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4a.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X4=0x0)
 Observation MP+poq0l.q0+addra.w4a.w0 Never 0 3
-Hash=ff50d33b8a3dcaf1f11f44be99a494b6
+Hash=9359d47a4925a54c07b6d2d3efadbba2
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4a.w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4a.w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X4=0x0)
 Observation MP+poq0l.q0+addra.w4a.w4 Never 0 3
-Hash=ad099811b3e0b4bb137d88b74bf08f39
+Hash=607ef7bd4bc5dbd65c4f22370cc9de3b
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X4=0x0)
 Observation MP+poq0l.q0+addra.w4q0 Never 0 3
-Hash=a83d0ea8921df2a47a0d0d49d4b1a7a4
+Hash=a030aeda49ae4bd444c829f1ba25e46b
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X4=0x0)
 Observation MP+poq0l.q0+addra.w4w0 Never 0 3
-Hash=873d756888523a49d0d907faac97453a
+Hash=c6e980137542f0912132cb1b1a9945c5
 

--- a/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/MP+poq0l.q0+addra.w4w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X1=0x1010101 /\ 1:X4=0x0)
 Observation MP+poq0l.q0+addra.w4w4 Never 0 3
-Hash=28dedffbe6217b5181148529ad4515f1
+Hash=d3cdaeb0db2ef8fe33b0f99e28767185
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0l.q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0l.q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+addra.q0l.q0 Never 0 3
-Hash=3efb042a528309287c1e83de33ec102e
+Hash=e52525e19de0c7841cf070c32bd95e34
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+addra.q0l.w0 Never 0 3
-Hash=e558132476f95a0ef6b020fa4f42d1c1
+Hash=7c7bb55b5dbf2138b7f9985d7d479ea8
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0l.w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0l.w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+addra.q0l.w4 Never 0 3
-Hash=e59ecb7233f9449f798e3df6f77ee0ee
+Hash=c3b3d9f9dc291ece956cb43edd5cdd98
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+addra.q0q0 Never 0 3
-Hash=2e9cc5b59b9b71b734e0795742a57c1c
+Hash=a5ac21f79d5f46486ec7f0c57d6e21de
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+addra.q0w0 Never 0 3
-Hash=433ea9ca5a46171939b768746feb190d
+Hash=0c3d2abfed6b1ea81109da38fe8c214a
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.q0w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+addra.q0w4 Never 0 3
-Hash=dee8519c89d84a26ca2a9bb83ae28f05
+Hash=f4c09220ed7b9b5a794227cddcdfc865
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0l.q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0l.q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w0l.q0 Never 0 3
-Hash=c1bcb112101172c257929c8c8af95776
+Hash=d4b7a9f8f1d502c54a47cc0e7ff60a96
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w0l.w0 Never 0 3
-Hash=b8ab075a5441724d4c307885e7dea1d7
+Hash=9f427d437c33d686d2e4b7b6402bd10d
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0l.w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0l.w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w0l.w4 Never 0 3
-Hash=f506e388df4f29113c512fab4a5dcf4b
+Hash=b25f5702f2785a928e5eb46709534cbb
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w0q0 Never 0 3
-Hash=c3377d78d2985c1bb78200b610da13ff
+Hash=674eccb230f0f1a927bf26ce21f7f644
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w0w0 Never 0 3
-Hash=44cfcb1b050be33f43a9d7bff0646655
+Hash=9d9480490922de56ed6c0d695ef17003
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w0w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w0w4 Never 0 3
-Hash=3385c7dcaddc97e4b79d04e95c662137
+Hash=6ebe561d90486575385587f65702a9a6
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4l.q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4l.q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w4l.q0 Never 0 3
-Hash=886a2d06c83fd12af3e9d17a136410d4
+Hash=7c575e2bb2f265c6a5dc7547949fe4e3
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w4l.w0 Never 0 3
-Hash=6284056cfabb87cbf469341d48b4594d
+Hash=0d7c232985911261c36d4c6013bb763b
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4l.w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4l.w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w4l.w4 Never 0 3
-Hash=7e9dae5b401415822207cc038804819a
+Hash=99168bb23f3fc44694a6c89509ed2454
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w4q0 Never 0 3
-Hash=ecc29a8ab4341b843b7f115ea81b0856
+Hash=3d3867495a84616e3c472f2c8947b24c
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w4w0 Never 0 3
-Hash=0194d2009e29583c0036ac8384291dcf
+Hash=4c932bfa691e36a7d7e196afbfd34d41
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+addra.w4w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+addra.w4w4 Never 0 3
-Hash=1cf30d917dff8c690d89729b6454311a
+Hash=2dca01a3017b63cfcf5ce9eb1a0ab6d3
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0l.q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0l.q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+dataa.q0l.q0 Never 0 3
-Hash=8822be4f19c57452b52e44f2031c79a9
+Hash=f865fde5c559ca6fcca85828216562c0
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+dataa.q0l.w0 Never 0 3
-Hash=459c13c283dc2a5e4e0900e8ebac1742
+Hash=ca5496fa8fdf52c580a3456f7390d261
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0l.w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0l.w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+dataa.q0l.w4 Never 0 3
-Hash=8fcb646795c6946517625ae2c788ca52
+Hash=d7cca9502887edd99a40a13a10bed9c7
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+dataa.q0q0 Never 0 3
-Hash=60c2201c6bca6b797f40c45d8bde0b74
+Hash=e8de8adb0e2c0e3e803619d655124781
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+dataa.q0w0 Never 0 3
-Hash=1af4704f783bf691e752758e4ebde861
+Hash=12061da7f38ee5834d7532db78ee1c61
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.q0w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x101010101010101)
 Observation S+poq0l.q0+dataa.q0w4 Never 0 3
-Hash=85d75cf5bc66ee2af7a6b31b238618ec
+Hash=60b1cf50dd7fd91c0e9e2282c324f8f5
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0l.q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0l.q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w0l.q0 Never 0 3
-Hash=4eb1852299f7a3cbb68e291c443263f8
+Hash=252eb6a87976c24086b9d882bb0487cc
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w0l.w0 Never 0 3
-Hash=af3ee5b746e00d983b3ba70c57be4e5e
+Hash=a573ed5bc193d5ef11224455c72b985d
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0l.w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0l.w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w0l.w4 Never 0 3
-Hash=ca257839793cc0c6fed0aeffc4ac7324
+Hash=f82ede56f7e928badd245f3389054b35
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w0q0 Never 0 3
-Hash=311b82087e091f30d610f9e13939938c
+Hash=4e73661fd824bd869bf67e98ce043b30
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w0w0 Never 0 3
-Hash=711119b1c60487199ec1f500abce5674
+Hash=bc58189978c4c511d372375555fa8c03
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w0w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w0w4 Never 0 3
-Hash=bf0106dd2ea98401bedc248c22163718
+Hash=3165ae4824098a75ec1f377f2954cdfa
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4l.q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4l.q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w4l.q0 Never 0 3
-Hash=617de4119f13b37cc4980a8a0422225b
+Hash=7b186adc7154dd5b42ba934c9a48d8a6
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4l.w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4l.w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w4l.w0 Never 0 3
-Hash=4ba22808efba7dc877454659f76e4350
+Hash=2d64a0d1a9a6cb088fadc37450958bdb
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4l.w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4l.w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w4l.w4 Never 0 3
-Hash=f88f786fe82b9d92043eb306811dbe4c
+Hash=11e47efbc01fe6973eb2ad9b33eb646b
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4q0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4q0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w4q0 Never 0 3
-Hash=c67c89c33a765515587b8a55bf75ebdd
+Hash=6795b240af17854f8399b403bc88d1e8
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4w0.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w4w0 Never 0 3
-Hash=4c7a317bcf20e31141d0514e8a1df61d
+Hash=e0f37df8080301fd5839189a9f9e29ca
 

--- a/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4w4.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.v64/S+poq0l.q0+dataa.w4w4.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=0x202020202020202 /\ 1:X1=0x1010101)
 Observation S+poq0l.q0+dataa.w4w4 Never 0 3
-Hash=c8be6fb41faf9c6561b7d13d5140dd1d
+Hash=bc2a58ed254c2ad84705e671b19d80e7
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0 Sometimes 1 7
-Hash=a40233e0f85e51464788d23a65b47477
+Hash=e5533e40eea441f80bf2c4513e209bba
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x5050303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0 Sometimes 1 7
-Hash=9a060aaec82889243fb6868216163109
+Hash=016d429d4e57100dbd868f1beb645c16
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0 Sometimes 1 7
-Hash=b781a85622a8d2a34cab838c2e343b32
+Hash=6421a0178c732d8800708e9a89ae40c9
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x1010303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0 Sometimes 1 7
-Hash=5389d30d50b19a81aa8c7bf6c6f7ffd7
+Hash=2d32e2719decefacb88ec36c2d478dd6
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.cash0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0 Sometimes 1 7
-Hash=c4306196baaaaab5578ed5f7178c15fe
+Hash=99d179980b1d3ffec9fe15ddf2b73b1e
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0 Sometimes 1 7
-Hash=bf94567763a9b3e9f042e81943223c29
+Hash=c54d948abf5930dcbe86bc4142753aff
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x5050303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0 Sometimes 1 7
-Hash=744a8b2876e07052cf9ab895552fd2ec
+Hash=470bfc908e25f77c861cd1298b20d9ad
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0 Sometimes 1 7
-Hash=aa1ca9975d7bcb335f834adc4e1d895e
+Hash=8417ea2188865d550e7c41197fa7be5c
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x1010303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0 Sometimes 1 7
-Hash=004c4562b0c7998161c46a0aee43f3d4
+Hash=0180ea90e0087fb7bcf545da8d49058c
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldaddh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0 Sometimes 1 7
-Hash=f0e3f0d687cf8671a9c3a102d76e3e8a
+Hash=bf481e989d27dcd111a1fc9fcc49e346
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 2 Negative: 6
 Condition exists ([y]=0x3030202 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0 Sometimes 2 6
-Hash=3509b0351f4f0c79f16a1d6538d5c7a8
+Hash=0a85d394b286c36d20c563878fffa5b4
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 2 Negative: 6
 Condition exists ([y]=0x5050202 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0 Sometimes 2 6
-Hash=c496a6ef5acf77ce9421948f71624742
+Hash=9b64ed5f3ac2115f14954647f8040024
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 2 Negative: 6
 Condition exists ([y]=0x202 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0 Sometimes 2 6
-Hash=ec3c6225ff5868ff79c837e549145a61
+Hash=9f60969ee4761bf3657901c328d99a82
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 2 Negative: 6
 Condition exists ([y]=0x1010202 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0 Sometimes 2 6
-Hash=a372350be69abe9bb0329bfb6200ac2a
+Hash=b9d95dea6e91842dc42b616f8d3c6111
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
@@ -11,5 +11,5 @@ Witnesses
 Positive: 2 Negative: 6
 Condition exists ([y]=0x3030202 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldclrh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0 Sometimes 2 6
-Hash=52e430ff352c072aea83919bef508bbe
+Hash=73341d186d9dc6aa0b7eef1643eb9c24
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0 Sometimes 1 7
-Hash=204a119a2678d8b6099a2ad0ac418100
+Hash=75d826526eda76443e756504e0b39b06
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x5050303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0 Sometimes 1 7
-Hash=d5c7fda5b9b9b793795c3d6106043e24
+Hash=219aee1d9c84878520026218902604a0
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0 Sometimes 1 7
-Hash=f93197914c04ae383c27cddd73de789d
+Hash=77e9d1fca9d523e08eddffecc225e13c
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x1010303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0 Sometimes 1 7
-Hash=f337d735aec59c6c2cf082c48e759cd8
+Hash=a96c6ed5b0f41298537bfdee5d75eec7
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldeorh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0 Sometimes 1 7
-Hash=465a878c141b77ad9cf2b3ab5bdec6c0
+Hash=1f4738a7086fe13180bb2dcb3983be8e
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0 Sometimes 1 7
-Hash=a2fbd45f85e0e0a94c17c0062e08a64a
+Hash=f97e329187de5a3598bda40f6d1a5a4a
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x5050303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0 Sometimes 1 7
-Hash=fbe773f400a5d45e0fe76df5a942d969
+Hash=f95ae27bb711ad6fe1387080260459ab
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0 Sometimes 1 7
-Hash=6cf34fe9cf2fc5588ffa73ba1e8008a9
+Hash=b500f3d55942d3d408568573c7f4b0ab
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x1010303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0 Sometimes 1 7
-Hash=c44c072d93e03d8da81e086907620f57
+Hash=58d357ae3364f20884b118abef6c97c2
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
@@ -13,5 +13,5 @@ Witnesses
 Positive: 1 Negative: 7
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X1=0x0 /\ 1:X4=0x202 /\ 1:X7=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+amo.ldseth0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0 Sometimes 1 7
-Hash=b997b914d7dabf87dd9bbe274d7b029b
+Hash=f2b611d2a0aef6e2b11015db4a12baf5
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0.litmus.expected
@@ -19,5 +19,5 @@ Witnesses
 Positive: 1 Negative: 13
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X3=0x0 /\ 1:X1=0x0 /\ 1:X5=0x202 /\ 1:X8=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.cash2h2-poh2w0 Sometimes 1 13
-Hash=fc5e1c1ede529d7bd50db583f572cfbc
+Hash=c6a1aff6350811ed74fa89bd3a085b78
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0.litmus.expected
@@ -19,5 +19,5 @@ Witnesses
 Positive: 1 Negative: 13
 Condition exists ([y]=0x5050303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X3=0x0 /\ 1:X1=0x0 /\ 1:X5=0x202 /\ 1:X8=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldaddh2h2-poh2w0 Sometimes 1 13
-Hash=6173122f3fc5d7efb7ef45b584277f40
+Hash=5212a612c0cd38b9b70803f84782c412
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0.litmus.expected
@@ -19,5 +19,5 @@ Witnesses
 Positive: 1 Negative: 13
 Condition exists ([y]=0x303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X3=0x0 /\ 1:X1=0x0 /\ 1:X5=0x202 /\ 1:X8=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldclrh2h2-poh2w0 Sometimes 1 13
-Hash=7f96100353a2f9c0ec155087937914ac
+Hash=f81de79e3e08868ad968f82155d2fc02
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0.litmus.expected
@@ -19,5 +19,5 @@ Witnesses
 Positive: 1 Negative: 13
 Condition exists ([y]=0x1010303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X3=0x0 /\ 1:X1=0x0 /\ 1:X5=0x202 /\ 1:X8=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldeorh2h2-poh2w0 Sometimes 1 13
-Hash=319ef335f1bacf7e89793ba995c8d225
+Hash=6fb9a1713b31744f0b45a632066126d8
 

--- a/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed/RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0.litmus.expected
@@ -19,5 +19,5 @@ Witnesses
 Positive: 1 Negative: 13
 Condition exists ([y]=0x3030303 /\ 0:X1=0x0 /\ 0:X3=0x0 /\ 1:X3=0x0 /\ 1:X1=0x0 /\ 1:X5=0x202 /\ 1:X8=0x0)
 Observation RR+RR+amo.ldsetw0w0-pow0w0+rmwh0h0-rfih0w0-amo.staddw0w0-rfiw0h2-amo.ldseth2h2-poh2w0 Sometimes 1 13
-Hash=de138703293984b42beb031f27a41a4f
+Hash=c435428406ad6d3243b8c8ff10eb8b14
 

--- a/lib/machSize.ml
+++ b/lib/machSize.ml
@@ -178,6 +178,10 @@ let pred = function
   | Quad -> Word
   | S128 -> Quad
 
+let at_least_word = function
+  | Quad|S128 as sz -> sz
+  | Word|Short|Byte -> Word
+
 module Tag = struct
 
   type t = Auto | Size of sz

--- a/lib/machSize.mli
+++ b/lib/machSize.mli
@@ -44,6 +44,9 @@ val min : sz -> sz -> sz
 
 val pred : sz -> sz
 
+(* Promote sizes lower then word to word *)
+val at_least_word : sz -> sz
+
 module Tag : sig
   type t = Auto | Size of sz
   val tags : string list


### PR DESCRIPTION
1. Type stored registers
2. Type destination register of loads.

Some contradictions remain when a register is loaded as W and used as X
(c.f. data and address dependencies)