### PR TITLE
[tools] Fix concurrent msum

### DIFF
--- a/tools/msum.ml
+++ b/tools/msum.ml
@@ -93,11 +93,10 @@ module Check =
   CheckName.Make
     (struct
       let verbose = verbose
-      let check v =  if npar <= 1 then v else []
-      let rename = check rename
-      let select = check select
-      let names = check names
-      let excl = check excl
+      let rename = rename
+      let select = select
+      let names = names
+      let excl = excl
     end)
 
 let fnames = match !logs with


### PR DESCRIPTION
As a consequence of the more rational partition of summed files (PR #297), some of the original input files may be merged at the very last step. Hence all calls to the effective merge function must apply the selection command line arguments such as `-excl <file>`.