### PR TITLE
[AArch64 cat] Atomics strengthening

### DIFF
--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -120,7 +120,7 @@ let aob = rmw
 
 (* Barrier-ordered-before *)
 let bob = po; [dmb.full]; po
-        | po; ([A];amo;[L]); po
+        | [range([A];amo;[L])]; po 
 	| [L]; po; [A]
 	| [R\NoRet]; po; [dmb.ld]; po
 	| [A | Q]; po


### PR DESCRIPTION
Atomics with both acquire and release semantics currently act as a full barrier
in that they prevent a read or write program-order-before the atomic from being
reordered with a read or write program-order-after the atomic. However, a read
or write program-order-after the atomic is allowed to be reordered with the
write part of the atomic and a read or write program-order-before the atomic is
allowed to be reordered with the read part of the atomic. Arm deemed this
behaviour undesirable and the following change strengthen the memory model to
forbid it.

1. Motivation
-------------
The following behaviour:

AArch64 SB+CASAL+LDR
{
0:X1=x; 0:X3=y;
1:X1=y; 1:X3=x;
0:X4=0; 1:X4=0;
x=0; y=0;
}
P0               | P1                ;
MOV W0,#1        | MOV W0,#1         ;
CASAL W4,W0,[X1] | CASAL W4, W0,[X1] ;
LDR W2,[X3]      | LDR W2,[X3]       ;
exists
(0:X2=0 /\ 1:X2=0 /\ x=1 /\ y=1)

is currently allowed.

More precisely, the current definition of CASAL does not provide all of the
ordering guarantees that are provided by a similar instruction in another
architecture. The semantics of this other instruction have been used as the
basis for API routines in a mainstream operating system, and this has resulted
in a significant amount of existing code expecting stronger semantics than
currently provided by CASAL. This incompatibility requires extra barriers to be
inserted in the Arm version of these API routines, which results in more
ordering operations than is strictly necessary during these routines. Arm
proposes the following changes to provide semantics that match the expectation
of the API routines.

The proposed strengthening applies to all atomics (not just CAS) which bear the
annotation -AL, and does not apply to Load/Store exclusives.

This strengthening is aligned in principle with the fact that the following
behaviour is already forbidden by the architecture:

AArch64 SB+STR+CASAL+LDR2
{
0:X5=x; 0:X3=y;
1:X5=y; 1:X3=x;
0:X1=z; 1:X1=z;
0:X4=0; 1:X4=0;
x=0; y=0; z=0;
}
P0               | P1                ;
MOV W6,#1        | MOV W6,#1         ;
STR W6,[X5]      | STR W6,[X5]       ;
MOV W0,#1        | MOV W0,#1         ;
CASAL W4,W0,[X1] | CASAL W4, W0,[X1] ;
LDR W2,[X3]      | LDR W2,[X3]       ;
exists
(0:X2=0 /\ 1:X2=0 /\ x=1 /\ y=1 /\ z=1)

which is already forbidden by the following clause in the definition of
Barrier-ordered-before:

- RW1 appears in program order before an atomic instruction with both Acquire
  and Release semantics that appears in program order before RW2.

However it is worth noting that this strengthening would not forbid this
behaviour (note that in the following test the CAS instructions fail and
therefore do not store to memory):

AArch64 SB+STR+CASAL+LDR
{
0:X1=x; 0:X3=y;
1:X1=y; 1:X3=x;
0:X4=0; 1:X4=0;
x=0; y=0;
}
P0               | P1                ;
MOV W0,#1        | MOV W0,#1         ;
STR W0,[X1]      | STR W0,[X1]       ;
CASAL W4,W0,[X1] | CASAL W4, W0,[X1] ;
LDR W2,[X3]      | LDR W2,[X3]       ;
exists
(0:X2=0 /\ 1:X2=0 /\ x=1 /\ y=1)

Arm documentation change
------------------------
In Barrier-ordered-before, the clause which reads:

- RW1 appears in program order before an atomic instruction with both
  Acquire and Release semantics that appears in program order before
  RW2.

is strengthened to read:

- RW1 is a write W1 and is generated by an atomic instruction with
  both Acquire and Release semantics

Arm cat file change
-------------------
In bob, the clause which reads:

        | po; ([A];amo;[L]); po

is strengthened to read:

        | [range([A];amo;[L])]; po