### PR TITLE
[AArch64] aob relaxation

### DIFF
--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -12,7 +12,7 @@
  * Author: Will Deacon <will.deacon@arm.com>
  * Author: Jade Alglave <jade.alglave@arm.com>
  *
- * Copyright (C) 2016-2020, Arm Ltd.
+ * Copyright (C) 2016-2022, Arm Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -116,7 +116,7 @@ let dob = addr | data
 
 (* Atomic-ordered-before *)
 let aob = rmw
-	| [range(rmw)]; lrs; [A | Q]
+	| rmw; lrs; [A | Q]
 
 (* Barrier-ordered-before *)
 let bob = po; [dmb.full]; po


### PR DESCRIPTION
This change is a relaxation.

The second clause of Atomic-ordered-before was put in place to accommodate for
C++ ordering. However this clause need not be that strong to meet C++ and Arm
relaxes it as a consequence.

Motivation
-------------
The following behaviour:

AArch64 MP+rel+ctrl-rfi-rmw-rfiXA-R
{
0:X1=x; 0:X3=y;
1:X1=y; 1:X11=x; 1:X5=z;
}
P0 | P1 ;
MOV X0,#1 | LDR X0,[X1] ;
STR X0,[X1] | CMP X0,#1 ;
MOV X2,#1 | B.NE L0 ;
             | L0: ;
STLR X2,[X3] | STR X2,[X5] ;
             | LDXR X6, [X5] ;
             | STXR W7, X8, [X5];
             | LDAR X9,[X5] ;
             | LDR X10,[X11] ;
exists (1:X0=1 /\ 1:X10=0 /\ 1:X7=0)

is currently forbidden. This stems from the second clause of
Atomic-ordered-before, which was put in place to accommodate for C++ release
sequences.

However, this second clause need not be that strong to meet C++, and therefore
Arm relaxes it so that MP+rel+ctrl-rfi-rmw-rfiXA-R is allowed.

2. Changes to the Arm spec
-------------------------------
In Atomic-ordered-before, the clause which reads:

- RW1 is a write W1 generated by an atomic instruction or a successful
  Store-Exclusive instruction and RW2 is a read R2 generated by an instruction
  with Acquire or AcquirePC semantics such that R2 is a Local read successor of
  W1.

is relaxed to read:

- RW1 is a read (R1) generated by an atomic instruction (resp. a
  Load-Exclusive instruction) and RW2 is a read (R2) generated by an
instruction with Acquire or AcquirePC semantics such that R2 is a Local read
successor of the write W3 generated by the same atomic instruction as R1
(resp. the successful Store-Exclusive instruction paired with the
Load-Exclusive instruction which generated R1).

3. Changes to the AArch64 cat file
-----------------------------------
In aob, the clause which reads:
  | [range(rmw)]; lrs; [A | Q]

is relaxed to read:
  | rmw; lrs; [A | Q]