### PR TITLE
Memattrs fixes

### DIFF
--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -114,7 +114,7 @@ end = struct
   let is_additional_mem _ = false
 
   (* Unimplemented *)
-  let is_implicit_pte_read _ = assert false
+  let is_pte_access _ = assert false
 
   (* All accesses are explicit *)
   let is_explicit _ = true

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -176,7 +176,7 @@ end = struct
   | _ -> false
 
   (* Unimplemented *)
-  let is_implicit_pte_read _ = assert false
+  let is_pte_access _ = assert false
 
   (* All accesses are explicit *)
   let is_explicit _ = true

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -62,7 +62,7 @@ module type S = sig
   val to_fault : action -> A.fault option
   val get_mem_dir : action -> Dir.dirn
   val get_mem_size : action -> MachSize.sz
-  val is_implicit_pte_read : action -> bool
+  val is_pte_access : action -> bool
   val is_explicit : action ->bool
 
 (* relative to the registers of the given proc *)

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -373,8 +373,8 @@ end = struct
         | _ -> None
         end
 
-  let is_implicit_pte_read = function
-  | Access (R,_,_,_,_,_,Access.PTE) -> true
+  let is_pte_access = function
+  | Access (_,_,_,_,_,_,Access.PTE) -> true
   | _ -> false
 
   let lift_explicit_predicate p act = match act with

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -352,35 +352,38 @@ module Make
                  "NDATA", (fun e -> not (is_data_port e));])) in
       let m =
         if kvm then begin
+            let attrs_of_evt e =
+              let pteval_v =
+                match E.read_of e with
+                | Some _ as v -> v
+                | _ -> E.written_of e in
+              let open Constant in
+              match pteval_v with
+              | Some (S.A.V.Val (PteVal v)) ->
+                 S.A.V.Cst.PteVal.get_attrs v
+              | _ -> assert false in
             let pte_accesses =
               E.EventSet.filter
                 (fun e -> E.Act.is_pte_access e.E.action)
                 (Lazy.force mem_evts) in
+            let attr_evts =
+              E.EventSet.filter
+                (fun e -> (attrs_of_evt e) <> []) pte_accesses in
             let evts_map =
               E.EventSet.fold
                 (fun e evts_map ->
-                  let pteval_v =
-                    match E.read_of e with
-                    | Some _ as v -> v
-                    | _ -> E.written_of e
-                  in
-                  let attrs =
-                    let open Constant in
-                    match pteval_v with
-                    | Some (S.A.V.Val (PteVal v)) ->
-                        S.A.V.Cst.PteVal.get_attrs v
-                    | _ -> assert false in
                   List.fold_right
                     (fun attr evts_map ->
                       let evts_w_attr =
                         StringMap.safe_find E.EventSet.empty attr evts_map in
                       let evts_w_attr = E.EventSet.add e evts_w_attr in
                       let evts_map = StringMap.add attr evts_w_attr evts_map in
-                      evts_map) attrs evts_map)
+                      evts_map) (attrs_of_evt e) evts_map)
                 pte_accesses StringMap.empty in
+            let s = [("PTEMemAttr", lazy attr_evts)] in
             I.add_sets m
               (StringMap.fold
-                 (fun k v l -> ("PTE" ^ k, lazy v) :: l) evts_map [])
+                 (fun k v l -> ("PTE" ^ k, lazy v) :: l) evts_map s)
           end else m in
       let m =
         I.add_sets m

--- a/lib/AArch64PteVal.ml
+++ b/lib/AArch64PteVal.ml
@@ -22,9 +22,7 @@ module Attrs = struct
   (* By default we assume the attributes of the memory malloc would
      return on Linux. This is architecture specific, however, for now,
      translation is supported only for AArch64. *)
-  let default =
-    StringSet.of_list
-      [ "Normal" ; "Inner-shareable"; "Inner-write-back"; "Outer-write-back" ]
+  let default = StringSet.empty
 
   let compare a1 a2 = StringSet.compare a1 a2
   let eq a1 a2 = StringSet.equal a1 a2


### PR DESCRIPTION
Two minor fixes for handling memory attributes.
* create PTE* events for all PTE accesses: implicit/explicit and read/write.
* Introduce one more event PTEMemAttr, a catch all event for all PTE accesses which have one more memory attributes defined.