### PR TITLE
[AArch64 cat] Pick dependencies

### DIFF
--- a/catalogue/aarch64/cats/aarch64-v07.cat
+++ b/catalogue/aarch64/cats/aarch64-v07.cat
@@ -1,0 +1,168 @@
+(*
+ * The Armv8 Application Level Memory Model.
+ *
+ * This is a machine-readable, executable and formal artefact, which aims to be
+ * the latest stable version of the Armv8 memory model.
+ * If you have comments on the content of this file, please send an email to
+ * jade.alglave@arm.com, referring to version number:
+ * 814a6fc1610ec1a24f2cbd178e171966375626ac
+ * For a textual version of the model, see section B2.3 of the Armv8 ARM:
+ *   https://developer.arm.com/docs/ddi0487/latest/arm-architecture-reference-manual-armv8-for-armv8-a-architecture-profile
+ *
+ * Author: Will Deacon <will.deacon@arm.com>
+ * Author: Jade Alglave <jade.alglave@arm.com>
+ *
+ * Copyright (C) 2016-2022, Arm Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of ARM nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *)
+
+AArch64 "ARMv8 AArch64"
+catdep (* This option tells that the cat file computes dependencies *)
+
+(*
+ * Include the cos.cat file shipped with herd.
+ * This builds the co relation as a total order over writes to the same
+ * location and then consequently defines the fr relation using co and
+ * rf.
+ *)
+include "cos.cat"
+
+(*
+ * Include aarch64fences.cat to define barriers.
+ *)
+include "aarch64fences.cat"
+
+(*
+ * Include aarch64deps.cat to define dependencies.
+*)
+include "aarch64deps.cat"
+
+(* Show relations in generated diagrams *)
+include "aarch64show.cat"
+
+(*
+ * As a restriction of the model, all observers are limited to the same
+ * inner-shareable domain. Consequently, the ISH, OSH and SY barrier
+ * options are all equivalent to each other.
+ *)
+let dsb.full = DSB.ISH | DSB.OSH | DSB.SY
+let dsb.ld = DSB.ISHLD | DSB.OSHLD | DSB.LD
+let dsb.st = DSB.ISHST | DSB.OSHST | DSB.ST
+
+(*
+ * A further restriction is that standard litmus tests are unable to
+ * distinguish between DMB and DSB instructions, so the model treats
+ * them as equivalent to each other.
+ *)
+let dmb.full = DMB.ISH | DMB.OSH | DMB.SY | dsb.full
+let dmb.ld = DMB.ISHLD | DMB.OSHLD | DMB.LD | dsb.ld
+let dmb.st = DMB.ISHST | DMB.OSHST | DMB.ST | dsb.st
+
+(* Flag any use of shareability options, due to the restrictions above. *)
+flag ~empty (dmb.full | dmb.ld | dmb.st) \
+	    (DMB.SY | DMB.LD | DMB.ST | DSB.SY | DSB.LD | DSB.ST)
+	    as Assuming-common-inner-shareable-domain
+
+(* Intrinsic order *)
+let intrinsic = (iico_data|iico_ctrl)+
+
+(* Coherence-after *)
+let ca = fr | co
+
+(* Local read successor *)
+let lrs = [W]; (po-loc \ (po-loc;[W];po-loc)) ; [R]
+
+(* Local write successor *)
+let lws = po-loc; [W]
+
+(* Observed-by *)
+let obs = rfe | fre | coe
+
+(* Read-modify-write *)
+let rmw = lxsx | amo
+
+(* Dependency-ordered-before *)
+let dob = addr | data
+	| ctrl; [W]
+	| (ctrl | (addr; po)); [ISB]; po; [M]
+	| addr; po; [W]
+	| (addr | data); lrs
+show ctrl;[M] as ctrl
+
+(* Pick-ordered-before *)
+let pob = pick-dep; [W]
+        | (pick-ctrl-dep | pick-addr-dep; po); [ISB]; po; [M]
+        | pick-addr-dep; [M]; po; [W]
+
+(* Atomic-ordered-before *)
+let aob = rmw
+	| rmw; lrs; [A | Q]
+
+(* Barrier-ordered-before *)
+let bob = po; [dmb.full]; po
+        | [range([A];amo;[L])]; po 
+	| [L]; po; [A]
+	| [R\NoRet]; po; [dmb.ld]; po
+	| [A | Q]; po
+	| [W]; po; [dmb.st]; po; [W]
+	| po; [L]
+
+(* Tag-ordered-before *)
+let tob = [R & T]; iico_data; [PoD]; iico_ctrl; [M \ T]
+
+(* Locally-ordered-before *)
+let rec lob = lws; si
+            | dob
+            | pob
+            | aob
+            | bob
+            | tob
+            | lob; lob
+let pick-lob = pick-basic-dep; lob; [W]
+
+(* Ordered-before *)
+let rec ob = obs; si
+        | lob
+        | pick-lob
+	| ob; ob
+
+(* Tag-location-ordered *)
+let tlo = [R & T]; tob; loc; tob^-1; [R & T]
+
+(* Internal visibility requirement *)
+let po-loc =
+  let Exp = M\domain(tob) in
+  (po-loc & Exp*Exp) | (po & tlo)
+acyclic po-loc | ca | rf as internal
+
+(* External visibility requirement *)
+irreflexive ob as external
+
+(* Atomic: Basic LDXR/STXR constraint to forbid intervening writes. *)
+empty rmw & (fre; coe) as atomic

--- a/catalogue/aarch64/tests/LB+CAS-rfi-ctrl+DMBSY.litmus
+++ b/catalogue/aarch64/tests/LB+CAS-rfi-ctrl+DMBSY.litmus
@@ -3,13 +3,13 @@ AArch64 LB+CAS-rfi-ctrl+DMBSY
 0:X0=x; 0:X5=y;
 1:X1=y; 1:X3=x;
 }
-P0 | P1 ;
-MOV W1,#1 | ;
-MOV W2,#2 | LDR W0,[X1] ;
-CAS W1,W2,[X0] | DMB SY ;
-LDR W3,[X0] | MOV W2,#1 ;
-CBNZ W3,LC00 | STR W2,[X3] ;
-LC00: | ;
-MOV W4,#1 | ;
-STR W4,[X5] | ;
+P0             | P1          ;
+MOV W1,#1      | LDR W0,[X1] ;
+MOV W2,#2      | DMB SY      ;
+CAS W1,W2,[X0] | MOV W2,#1   ;
+LDR W3,[X0]    | STR W2,[X3] ;
+CBNZ W3,LC00   |             ;
+LC00:          |             ;
+MOV W4,#1      |             ;
+STR W4,[X5]    |             ;
 exists (x=2 /\ 0:X1=1 /\ 0:X3=2 /\ 1:X0=1)

--- a/catalogue/aarch64/tests/LB+CAS-rfi-ctrl+DMBSY.litmus
+++ b/catalogue/aarch64/tests/LB+CAS-rfi-ctrl+DMBSY.litmus
@@ -1,0 +1,15 @@
+AArch64 LB+CAS-rfi-ctrl+DMBSY
+{
+0:X0=x; 0:X5=y;
+1:X1=y; 1:X3=x;
+}
+P0 | P1 ;
+MOV W1,#1 | ;
+MOV W2,#2 | LDR W0,[X1] ;
+CAS W1,W2,[X0] | DMB SY ;
+LDR W3,[X0] | MOV W2,#1 ;
+CBNZ W3,LC00 | STR W2,[X3] ;
+LC00: | ;
+MOV W4,#1 | ;
+STR W4,[X5] | ;
+exists (x=2 /\ 0:X1=1 /\ 0:X3=2 /\ 1:X0=1)

--- a/catalogue/aarch64/tests/LB+rel+CAS.litmus
+++ b/catalogue/aarch64/tests/LB+rel+CAS.litmus
@@ -1,0 +1,11 @@
+AArch64 LB+rel+CAS
+{
+0:X1=x; 0:X3=y;
+1:X1=x; 1:X3=y;
+}
+P0 | P1 ;
+MOV W9, #1 | MOV W4, #1 ;
+LDR W0, [X3] | LDR W5, [X1] ;
+STLR W9, [X1] | AND W10, W5, #2 ;
+| CAS W10, W4, [X3] ;
+exists (1:X5=1 /\ 0:X0=1)

--- a/catalogue/aarch64/tests/LB+rel+CAS.litmus
+++ b/catalogue/aarch64/tests/LB+rel+CAS.litmus
@@ -3,9 +3,9 @@ AArch64 LB+rel+CAS
 0:X1=x; 0:X3=y;
 1:X1=x; 1:X3=y;
 }
-P0 | P1 ;
-MOV W9, #1 | MOV W4, #1 ;
-LDR W0, [X3] | LDR W5, [X1] ;
-STLR W9, [X1] | AND W10, W5, #2 ;
-| CAS W10, W4, [X3] ;
+P0            | P1                ;
+MOV W9, #1    | MOV W4, #1        ;
+LDR W0, [X3]  | LDR W5, [X1]      ;
+STLR W9, [X1] | AND W10, W5, #2   ;
+              | CAS W10, W4, [X3] ;
 exists (1:X5=1 /\ 0:X0=1)

--- a/catalogue/aarch64/tests/MP+CAS-rfi-ctrl+acq.litmus
+++ b/catalogue/aarch64/tests/MP+CAS-rfi-ctrl+acq.litmus
@@ -1,0 +1,14 @@
+AArch64 MP+CAS-rfi-ctrl+acq
+{
+0:X0=x; 0:X4=y;
+1:X1=y; 1:X3=x;
+}
+P0 | P1 ;
+MOV W1,#0 | LDAR W0,[X1] ;
+MOV W2,#1 | LDR W2,[X3] ;
+CAS W1,W2,[X0] | ;
+CBNZ W1,out | ;
+MOV W3,#1 | ;
+STR W3,[X4] | ;
+out: | ;
+exists (x=1 /\ 1:X0=1 /\ 1:X2=0)

--- a/catalogue/aarch64/tests/MP+CAS-rfi-ctrl+acq.litmus
+++ b/catalogue/aarch64/tests/MP+CAS-rfi-ctrl+acq.litmus
@@ -3,12 +3,12 @@ AArch64 MP+CAS-rfi-ctrl+acq
 0:X0=x; 0:X4=y;
 1:X1=y; 1:X3=x;
 }
-P0 | P1 ;
-MOV W1,#0 | LDAR W0,[X1] ;
-MOV W2,#1 | LDR W2,[X3] ;
-CAS W1,W2,[X0] | ;
-CBNZ W1,out | ;
-MOV W3,#1 | ;
-STR W3,[X4] | ;
-out: | ;
+P0             | P1           ;
+MOV W1,#0      | LDAR W0,[X1] ;
+MOV W2,#1      | LDR W2,[X3]  ;
+CAS W1,W2,[X0] |              ;
+CBNZ W1,out    |              ;
+MOV W3,#1      |              ;
+STR W3,[X4]    |              ;
+out:           |              ;
 exists (x=1 /\ 1:X0=1 /\ 1:X2=0)

--- a/catalogue/aarch64/tests/MP+rel+CAS-addr.litmus
+++ b/catalogue/aarch64/tests/MP+rel+CAS-addr.litmus
@@ -4,12 +4,12 @@ z=1;
 0:X1=x; 0:X3=y;
 1:X1=x; 1:X3=y; 1:X8=z;
 }
-P0 | P1 ;
-MOV W0, #1 | LDR W0, [X1] ;
-STR W0, [X3] | MOV W5, W0 ;
+P0            | P1               ;
+MOV W0, #1    | LDR W0, [X1]     ;
+STR W0, [X3]  | MOV W5, W0       ;
 STLR W0, [X1] | CAS W0, W6, [X8] ;
-| LDR W0, [X8] ;
-| EOR X0, X0, X0 ;
-| ADD X3, X3, X0 ;
-| LDR W4, [X3] ;
+              | LDR W0, [X8]     ;
+              | EOR X0, X0, X0   ;
+              | ADD X3, X3, X0   ;
+              | LDR W4, [X3]     ;
 exists (1:X5=1 /\ 1:X4=0)

--- a/catalogue/aarch64/tests/MP+rel+CAS-addr.litmus
+++ b/catalogue/aarch64/tests/MP+rel+CAS-addr.litmus
@@ -1,0 +1,15 @@
+AArch64 MP+rel+CAS-addr
+{
+z=1;
+0:X1=x; 0:X3=y;
+1:X1=x; 1:X3=y; 1:X8=z;
+}
+P0 | P1 ;
+MOV W0, #1 | LDR W0, [X1] ;
+STR W0, [X3] | MOV W5, W0 ;
+STLR W0, [X1] | CAS W0, W6, [X8] ;
+| LDR W0, [X8] ;
+| EOR X0, X0, X0 ;
+| ADD X3, X3, X0 ;
+| LDR W4, [X3] ;
+exists (1:X5=1 /\ 1:X4=0)

--- a/catalogue/aarch64/tests/R+CAS+DMBLD.litmus
+++ b/catalogue/aarch64/tests/R+CAS+DMBLD.litmus
@@ -4,10 +4,10 @@ AArch64 R+CAS+DMBLD
 0:X1=x; 0:X2=y;
 1:X1=y; 1:X3=x;
 }
-P0 | P1 ;
-MOV W0,#1 | MOV W0,#2 ;
-STR W0,[X1] | STR W0,[X1] ;
-MOV W3,#0 | DMB SY ;
-MOV W4,#1 | LDR W2,[X3] ;
-CAS W3,W4,[X2] | ;
+P0             | P1          ;
+MOV W0,#1      | MOV W0,#2   ;
+STR W0,[X1]    | STR W0,[X1] ;
+MOV W3,#0      | DMB SY      ;
+MOV W4,#1      | LDR W2,[X3] ;
+CAS W3,W4,[X2] |             ;
 exists (y=2 /\ 0:X3=0 /\ 1:X2=0)

--- a/catalogue/aarch64/tests/R+CAS+DMBLD.litmus
+++ b/catalogue/aarch64/tests/R+CAS+DMBLD.litmus
@@ -1,0 +1,13 @@
+AArch64 R+CAS+DMBLD
+"PodWR Amo.Cas Coe DMB.SYdWR Fre"
+{
+0:X1=x; 0:X2=y;
+1:X1=y; 1:X3=x;
+}
+P0 | P1 ;
+MOV W0,#1 | MOV W0,#2 ;
+STR W0,[X1] | STR W0,[X1] ;
+MOV W3,#0 | DMB SY ;
+MOV W4,#1 | LDR W2,[X3] ;
+CAS W3,W4,[X2] | ;
+exists (y=2 /\ 0:X3=0 /\ 1:X2=0)

--- a/catalogue/aarch64/tests/R+CAS-rfi-ctrl+DMBST.litmus
+++ b/catalogue/aarch64/tests/R+CAS-rfi-ctrl+DMBST.litmus
@@ -1,0 +1,16 @@
+AArch64 R+CAS-rfi-ctrl+DMBST
+"Amo.Cas Rfi DpCtrldW Coe DMB.STdWW Rfe"
+{
+0:X0=x; 0:X5=y;
+1:X1=y; 1:X3=x;
+}
+P0 | P1 ;
+MOV W1,#1 | MOV W0,#2 ;
+MOV W2,#2 | STR W0,[X1] ;
+CAS W1,W2,[X0] | DMB ST ;
+LDR W3,[X0] | MOV W2,#1 ;
+CBNZ W3,LC00 | STR W2,[X3] ;
+LC00: | ;
+MOV W4,#1 | ;
+STR W4,[X5] | ;
+exists (x=2 /\ y=2 /\ 0:X1=1 /\ 0:X3=2)

--- a/catalogue/aarch64/tests/R+CAS-rfi-ctrl+DMBST.litmus
+++ b/catalogue/aarch64/tests/R+CAS-rfi-ctrl+DMBST.litmus
@@ -4,13 +4,13 @@ AArch64 R+CAS-rfi-ctrl+DMBST
 0:X0=x; 0:X5=y;
 1:X1=y; 1:X3=x;
 }
-P0 | P1 ;
-MOV W1,#1 | MOV W0,#2 ;
-MOV W2,#2 | STR W0,[X1] ;
-CAS W1,W2,[X0] | DMB ST ;
-LDR W3,[X0] | MOV W2,#1 ;
-CBNZ W3,LC00 | STR W2,[X3] ;
-LC00: | ;
-MOV W4,#1 | ;
-STR W4,[X5] | ;
+P0             | P1          ;
+MOV W1,#1      | MOV W0,#2   ;
+MOV W2,#2      | STR W0,[X1] ;
+CAS W1,W2,[X0] | DMB ST      ;
+LDR W3,[X0]    | MOV W2,#1   ;
+CBNZ W3,LC00   | STR W2,[X3] ;
+LC00:          |             ;
+MOV W4,#1      |             ;
+STR W4,[X5]    |             ;
 exists (x=2 /\ y=2 /\ 0:X1=1 /\ 0:X3=2)

--- a/catalogue/aarch64/tests/SB+CAS-rfi-addr+DMBSY.litmus
+++ b/catalogue/aarch64/tests/SB+CAS-rfi-addr+DMBSY.litmus
@@ -1,0 +1,16 @@
+AArch64 SB+CAS-rfi-addr+DMBSY
+"PodWR Amo.Cas Rfi DpAddrdR Fre DMB.SYdWR Fre"
+{
+0:X1=x; 0:X2=y; 0:X8=z;
+1:X1=z; 1:X3=x;
+}
+P0 | P1 ;
+MOV W0,#1 | MOV W0,#1 ;
+STR W0,[X1] | STR W0,[X1] ;
+MOV W3,#0 | DMB SY ;
+MOV W4,#1 | LDR W2,[X3] ;
+CAS W3,W4,[X2] | ;
+LDR W5,[X2] | ;
+EOR W6,W5,W5 | ;
+LDR W7,[X8,W6,SXTW] | ;
+exists (0:X3=0 /\ 0:X5=1 /\ 0:X7=0 /\ 1:X2=0)

--- a/catalogue/aarch64/tests/SB+CAS-rfi-addr+DMBSY.litmus
+++ b/catalogue/aarch64/tests/SB+CAS-rfi-addr+DMBSY.litmus
@@ -4,13 +4,13 @@ AArch64 SB+CAS-rfi-addr+DMBSY
 0:X1=x; 0:X2=y; 0:X8=z;
 1:X1=z; 1:X3=x;
 }
-P0 | P1 ;
-MOV W0,#1 | MOV W0,#1 ;
-STR W0,[X1] | STR W0,[X1] ;
-MOV W3,#0 | DMB SY ;
-MOV W4,#1 | LDR W2,[X3] ;
-CAS W3,W4,[X2] | ;
-LDR W5,[X2] | ;
-EOR W6,W5,W5 | ;
-LDR W7,[X8,W6,SXTW] | ;
+P0                  | P1          ;
+MOV W0,#1           | MOV W0,#1   ;
+STR W0,[X1]         | STR W0,[X1] ;
+MOV W3,#0           | DMB SY      ;
+MOV W4,#1           | LDR W2,[X3] ;
+CAS W3,W4,[X2]      |             ;
+LDR W5,[X2]         |             ;
+EOR W6,W5,W5        |             ;
+LDR W7,[X8,W6,SXTW] |             ;
 exists (0:X3=0 /\ 0:X5=1 /\ 0:X7=0 /\ 1:X2=0)

--- a/catalogue/aarch64/tests/SB+SWP-rfi-addr+DMBSY.litmus
+++ b/catalogue/aarch64/tests/SB+SWP-rfi-addr+DMBSY.litmus
@@ -4,14 +4,14 @@ AArch64 SB+SWP-rfi-addr+DMBSY
 0:X1=x; 0:X2=y; 0:X8=z;
 1:X1=z; 1:X3=x;
 }
-P0 | P1 ;
-MOV W0,#1 | MOV W0,#1 ;
-STR W0,[X1] | STR W0,[X1] ;
-MOV W4,#1 | DMB SY ;
-SWP W4,W3,[X2] | LDR W2,[X3] ;
-LDR W5,[X2] | ;
-EOR W6,W5,W5 | ;
-LDR W7,[X8,W6,SXTW] | ;
+P0                  | P1          ;
+MOV W0,#1           | MOV W0,#1   ;
+STR W0,[X1]         | STR W0,[X1] ;
+MOV W4,#1           | DMB SY      ;
+SWP W4,W3,[X2]      | LDR W2,[X3] ;
+LDR W5,[X2]         |             ;
+EOR W6,W5,W5        |             ;
+LDR W7,[X8,W6,SXTW] |             ;
 exists (0:X3=0 /\ 0:X5=1 /\ 0:X7=0 /\ 1:X2=0)
 
 

--- a/catalogue/aarch64/tests/SB+SWP-rfi-addr+DMBSY.litmus
+++ b/catalogue/aarch64/tests/SB+SWP-rfi-addr+DMBSY.litmus
@@ -1,0 +1,17 @@
+AArch64 SB+SWP-rfi-addr+DMBSY
+"PodWR Amo.Swp Rfi DpAddrdR Fre DMB.SYdWR Fre"
+{
+0:X1=x; 0:X2=y; 0:X8=z;
+1:X1=z; 1:X3=x;
+}
+P0 | P1 ;
+MOV W0,#1 | MOV W0,#1 ;
+STR W0,[X1] | STR W0,[X1] ;
+MOV W4,#1 | DMB SY ;
+SWP W4,W3,[X2] | LDR W2,[X3] ;
+LDR W5,[X2] | ;
+EOR W6,W5,W5 | ;
+LDR W7,[X8,W6,SXTW] | ;
+exists (0:X3=0 /\ 0:X5=1 /\ 0:X7=0 /\ 1:X2=0)
+
+

--- a/catalogue/aarch64/tests/kinds.txt
+++ b/catalogue/aarch64/tests/kinds.txt
@@ -2,7 +2,7 @@
 2+2W+dmb.sys   Forbidden
 2+2W           Allowed
 CAS+data1      Allowed
-CAS+data2      Forbidden
+CAS+data2      Allowed 
 LB+BEQ4        Forbidden
 LB+CSEL4       Allowed
 LB+dmb.sy+po   Allowed
@@ -29,3 +29,8 @@ S              Allowed
 SB+dmb.sy+po   Allowed
 SB+dmb.sys     Forbidden
 SB             Allowed
+LB+rel+CAS     Forbidden
+MP+rel+CAS-addr Allowed
+MP+rel+CSEL     Allowed
+MP+rel+CSEL-data Forbidden
+MP+rel+CSEL-addr Allowed 

--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -110,9 +110,15 @@ let rmw = lxsx | amo
 (* Dependency-ordered-before *)
 let dob = addr | data
 	| ctrl; [W]
-	| (ctrl | (addr; po)); [ISB]; po; [R]
+	| (ctrl | (addr; po)); [ISB]; po; [M]
 	| addr; po; [W]
 	| (addr | data); lrs
+show ctrl;[M] as ctrl
+
+(* Pick-ordered-before *)
+let pob = pick-dep; [W]
+        | (pick-ctrl-dep | pick-addr-dep; po); [ISB]; po; [M]
+        | pick-addr-dep; [M]; po; [W]
 
 (* Atomic-ordered-before *)
 let aob = rmw
@@ -128,23 +134,26 @@ let bob = po; [dmb.full]; po
 	| po; [L]
 
 (* Tag-ordered-before *)
-let tob = [R & T]; intrinsic; [M \ T]
+let tob = [R & T]; iico_data; [PoD]; iico_ctrl; [M \ T]
 
 (* Locally-ordered-before *)
 let rec lob = lws; si
             | dob
+            | pob
             | aob
             | bob
             | tob
             | lob; lob
+let pick-lob = pick-basic-dep; lob; [W]
 
 (* Ordered-before *)
 let rec ob = obs; si
         | lob
+        | pick-lob
 	| ob; ob
 
 (* Tag-location-ordered *)
-let tlo = [R & T]; intrinsic; loc; intrinsic^-1; [R & T]
+let tlo = [R & T]; tob; loc; tob^-1; [R & T]
 
 (* Internal visibility requirement *)
 let po-loc =

--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -7,8 +7,7 @@
  * jade.alglave@arm.com, referring to version number:
  * 814a6fc1610ec1a24f2cbd178e171966375626ac
  * For a textual version of the model, see section B2.3 of the Armv8 ARM:
- *   https://developer.arm.com/docs/ddi0487/latest/arm-architecture-reference-manual-armv8-for-armv8-a-architecture-profile
- *
+ * https://developer.arm.com/documentation/ddi0487/ha/ 
  * Author: Will Deacon <will.deacon@arm.com>
  * Author: Jade Alglave <jade.alglave@arm.com>
  *

--- a/herd/libdir/aarch64deps.cat
+++ b/herd/libdir/aarch64deps.cat
@@ -7,11 +7,11 @@
  * jade.alglave@arm.com, referring to version number:
  * 814a6fc1610ec1a24f2cbd178e171966375626ac
  * For a textual version of the model, see section B2.3 of the Armv8 ARM:
- *   https://developer.arm.com/docs/ddi0487/latest/arm-architecture-reference-manual-armv8-for-armv8-a-architecture-profile
+ *   https://developer.arm.com/docs/dtri0487/latest/arm-architecture-reference-manual-armv8-for-armv8-a-architecture-profile
  *
  * Author: Jade Alglave <jade.alglave@arm.com>
  *
- * Copyright (C) 2016-2020, Arm Ltd.
+ * Copyright (C) 2016-2022, Arm Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,31 +40,39 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *)
+catdep (* This option tells that the cat file computes dependencies *)
 
-(* Intrinsic order *)
-let intrinsic = (iico_data|iico_ctrl)+
-
-(* Dependency through register *)
-let rf-reg-no-stxr =
+(* Dependency through registers and memory *)
+let rec dtrm = 
   rf-reg \ ([W & range(lxsx)];rf-reg)
+  | rfi
+  | iico_data 
+  | dtrm; dtrm
 
-let dd =
-  let r = (rf-reg-no-stxr | intrinsic)* in
-  r;rf-reg-no-stxr;r
+let Reg=~M | ~PoD
+(** Data, Address and Control dependencies *)
+let ADDR=NDATA
+let basic-dep =
+   [R|Rreg]; dtrm?
+let data = basic-dep; [DATA]; iico_data; [W]
+let addr = basic-dep; [ADDR]; iico_data; [M]
+let ctrl = basic-dep; [PoD]; po
 
-(* The relation to-PoD is a dependency through register
-   to a point of divergence*)
-let to-PoD = [R]; dd; [PoD]
-
-(** Data and Address dependencies *)
-let data = [R]; dd; [DATA]; intrinsic; [W]
-let addrW = [R]; dd; [NDATA]; intrinsic; [W]
-let addrR =
- let dd-no-interv-PoD = dd \ (to-PoD;dd) in
- [R]; dd-no-interv-PoD; [NDATA]; intrinsic; [R]
-let addr = addrW | addrR
-
-(** Control dependencies *)
-let ctrl = to-PoD; po
+(** Pick dependencies *)
+let pick-basic-dep =
+   [R|Rreg]; dtrm?; [Reg]; iico_ctrl; [Reg]; dtrm? 
+let pick-addr-dep =
+   pick-basic-dep; [ADDR]; iico_data; [M]
+let pick-data-dep =
+   pick-basic-dep; [DATA]; iico_data; [W]
+let pick-ctrl-dep =
+   pick-basic-dep; [PoD]; po
+let pick-dep =
+( 
+   pick-basic-dep | 
+   pick-addr-dep  | 
+   pick-data-dep  |
+   pick-ctrl-dep  
+)
 
 include "aarch64show.cat"


### PR DESCRIPTION
This change is a relaxation.

Arm has investigated the weakening of its dependency definitions, in particular
the notion of control dependency. In light of this investigation, Arm has
decided to keep its notion of control dependency strong, but proposes to
introduce a new notion of dependency, called "Pick dependency". Pick
dependencies allow for very targetted ordering, and it is hoped that this will
enable optimisations.

See also: https://www.spinics.net/lists/kernel/msg4028862.html
and the attached tech report entitled "The Ballad of Dependencies".

Motivation
-------------

At the moment the behaviour MP+rel+CAS-addr:
```
AArch64 MP+rel+CAS-addr
{
z=1;
0:X1=x; 0:X3=y;
1:X1=x; 1:X3=y; 1:X8=z;
}
P0           | P1               ;
MOV W0,#1    | LDR W0, [X1]     ;
STR W0,[X3]  | MOV W5, W0       ;
STLR W0,[X1] | CAS W0, W6, [X8] ;
             | LDR W0, [X8]     ;
             | EOR X0, X0, X0   ;
             | ADD X3, X3, X0   ;
             | LDR W4, [X3]     ;
exists (1:X5=1 /\ 1:X4=0)
```
is Forbidden by the architecture.
Arm would like to weaken this to allow the behaviour.

The reason for MP+rel-CAS-addr being currently Forbidden is as follows:

1. there is a Data dependency on P1 from the Memory read Effect of LDR W0,[X1]
(event c) to the Memory write Effect of CAS W0,W6,[X8] (event e)
2. there is a read-from on P1 from the Memory write Effect of CAS W0,W6,[X8]
(event e) to the Memory read Effect of LDR W0,[X8] (event f) - in other words
the Memory read Effect of LDR W0,[X8] (event f) is a Local read successor of
the Memory write Effect of CAS W0,W6,[X8] (event e)
3. there is an Address dependency on P1 from the Memory read Effect of LDR
W0,[X8] (event f) to the Memory read Effect of LDR W4,[X3] (event g).

Points 1 and 2 combined impose order between the Memory read Effect of LDR
W0,[X1] (event c) to the Memory read Effect of LDR W0,[X8] (event f), because
data; rfi is in dob. In the text of the Arm ARM this corresponds to the clause:
(*)
RW2 is a Local read successor R2 of a write W3 and there is an Address
dependency or a Data dependency from R1 to W3.


A way forward to allow this behaviour would be to decide that there is no
ordering altogether between the Memory read Effect of LDR W0,[X1] (event c) to
the Memory write Effect of CAS W0,W6,[X8] (event e). However, this would lead
to allowing LB+rel+CAS, which must be Forbidden:
```
AArch64 LB+rel+CAS
{
0:X1=x; 0:X3=y;
1:X1=x; 1:X3=y;
}
P0           | P1                ;
MOV W9, #1   | MOV W4, #1        ;
LDR W0, [X3] | LDR W5, [X1]      ;
STLR W9, [X1]| AND W10, W5, #2   ;
             | CAS W10, W4, [X3] ;
exists (1:X5=1 /\ 0:X0=1)
```
To accommodate for MP+rel+CAS-addr being Allowed as desired, and LB+rel+CAS
still being Forbidden, Arm proposes to create a new type of dependency (called
"Pick dependency"), such that:
- Pick dependencies are not subjected to the clause (*) above, hence will
  not impose order in the case of MP+rel+CAS-addr
- Pick dependencies provide order in the case of LB+rel+CAS

Interestingly, this should not prescribe ordering in the litmus test
MP+rel+CSEL for example.

Therefore CSEL instructions should not provide similar ordering to branch
instructions. However this highlights again the need for a new dependency
notion, as the litmus test MP+rel+CSEL-data must be ordered.

As in the CAS case, the nature of that new dependency notion is interesting.
Indeed the test MP+rel+CSEL-addr should be allowed, which in turn entails that
this new dependency cannot be a Data dependency, as otherwise the LDR W1,[X2]
and the LDR W9,[X10,X8,SXTW] would be ordered.

Arm proposes that CAS and CSEL create Pick dependencies.

Tests
--------

AArch64 MP+CAS-rfi-ctrl+acq
{
0:X0=x; 0:X4=y;
1:X1=y; 1:X3=x;
}
 P0 | P1 ;
 MOV W1,#0 | LDAR W0,[X1] ;
 MOV W2,#1 | LDR W2,[X3] ;
 CAS W1,W2,[X0] | ;
 CBNZ W1,out | ;
 MOV W3,#1 | ;
 STR W3,[X4] | ;
out: | ;
exists (x=1 /\ 1:X0=1 /\ 1:X2=0)

AArch64 R+CAS-rfi-ctrl+DMBST
"Amo.Cas Rfi DpCtrldW Coe DMB.STdWW Rfe"
{
0:X0=x; 0:X5=y;
1:X1=y; 1:X3=x;
}
 P0 | P1 ;
 MOV W1,#1 | MOV W0,#2 ;
 MOV W2,#2 | STR W0,[X1] ;
 CAS W1,W2,[X0] | DMB ST ;
 LDR W3,[X0] | MOV W2,#1 ;
 CBNZ W3,LC00 | STR W2,[X3] ;
 LC00: | ;
 MOV W4,#1 | ;
 STR W4,[X5] | ;
exists (x=2 /\ y=2 /\ 0:X1=1 /\ 0:X3=2)

AArch64 LB+CAS-rfi-ctrl+DMBSY
{
0:X0=x; 0:X5=y;
1:X1=y; 1:X3=x;
}
 P0 | P1 ;
 MOV W1,#1 | ;
 MOV W2,#2 | LDR W0,[X1] ;
 CAS W1,W2,[X0] | DMB SY ;
 LDR W3,[X0] | MOV W2,#1 ;
 CBNZ W3,LC00 | STR W2,[X3] ;
 LC00: | ;
 MOV W4,#1 | ;
 STR W4,[X5] | ;
exists (x=2 /\ 0:X1=1 /\ 0:X3=2 /\ 1:X0=1)

AArch64 R+CAS+DMBLD
"PodWR Amo.Cas Coe DMB.SYdWR Fre"
{
0:X1=x; 0:X2=y;
1:X1=y; 1:X3=x;
}
 P0 | P1 ;
 MOV W0,#1 | MOV W0,#2 ;
 STR W0,[X1] | STR W0,[X1] ;
 MOV W3,#0 | DMB SY ;
 MOV W4,#1 | LDR W2,[X3] ;
 CAS W3,W4,[X2] | ;
exists (y=2 /\ 0:X3=0 /\ 1:X2=0)

AArch64 SB+CAS-rfi-addr+DMBSY
"PodWR Amo.Cas Rfi DpAddrdR Fre DMB.SYdWR Fre"
{
0:X1=x; 0:X2=y; 0:X8=z;
1:X1=z; 1:X3=x;
}
 P0 | P1 ;
 MOV W0,#1 | MOV W0,#1 ;
 STR W0,[X1] | STR W0,[X1] ;
 MOV W3,#0 | DMB SY ;
 MOV W4,#1 | LDR W2,[X3] ;
 CAS W3,W4,[X2] | ;
 LDR W5,[X2] | ;
 EOR W6,W5,W5 | ;
 LDR W7,[X8,W6,SXTW] | ;
exists (0:X3=0 /\ 0:X5=1 /\ 0:X7=0 /\ 1:X2=0)

AArch64 SB+SWP-rfi-addr+DMBSY
"PodWR Amo.Swp Rfi DpAddrdR Fre DMB.SYdWR Fre"
{
0:X1=x; 0:X2=y; 0:X8=z;
1:X1=z; 1:X3=x;
}
 P0 | P1 ;
 MOV W0,#1 | MOV W0,#1 ;
 STR W0,[X1] | STR W0,[X1] ;
 MOV W4,#1 | DMB SY ;
 SWP W4,W3,[X2] | LDR W2,[X3] ;
 LDR W5,[X2] | ;
 EOR W6,W5,W5 | ;
 LDR W7,[X8,W6,SXTW] | ;
exists (0:X3=0 /\ 0:X5=1 /\ 0:X7=0 /\ 1:X2=0)

AArch64 MP+rel+CAS-addr
{
z=1;
0:X1=x; 0:X3=y;
1:X1=x; 1:X3=y; 1:X8=z;
}
P0 | P1 ;
MOV W0, #1 | LDR W0, [X1] ;
STR W0, [X3] | MOV W5, W0 ;
STLR W0, [X1] | CAS W0, W6, [X8] ;
               | LDR W0, [X8] ;
               | EOR X0, X0, X0 ;
               | ADD X3, X3, X0 ;
               | LDR W4, [X3] ;
exists (1:X5=1 /\ 1:X4=0)

AArch64 LB+rel+CAS
{
0:X1=x; 0:X3=y;
1:X1=x; 1:X3=y;
}
P0 | P1 ;
MOV W9, #1 | MOV W4, #1 ;
LDR W0, [X3] | LDR W5, [X1] ;
STLR W9, [X1] | AND W10, W5, #2 ;
              | CAS W10, W4, [X3] ;
exists (1:X5=1 /\ 0:X0=1)