### PR TITLE
[gen] Resurrect the `Store` pseudo-edge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ test::
 		-conf ./herd/tests/instructions/AArch64.MTE/mte.cfg \
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64 MTE instructions tests: OK"
-	  
+
 test::
 	@ echo
 	$(HERD_REGRESSION_TEST) \
@@ -157,7 +157,6 @@ diy-test:
 		-diycross-arg 'Rfe,Fre,Coe' \
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64 diycross7 tests: OK"
-
 
 J=4
 test:: cata-test
@@ -329,3 +328,24 @@ v64:
 		-diycross-arg Coe,Fre \
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64.mixed.v64 diycross7 tests: OK"
+
+test:: diy-store-test
+diy-store-test:
+	@ echo
+	$(HERD_DIYCROSS_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-diycross-path $(DIYCROSS) \
+		-libdir-path ./herd/libdir \
+		-expected-dir ./herd/tests/diycross/AArch64.store \
+		-diycross-arg -obs \
+		-diycross-arg four \
+		-diycross-arg -arch \
+		-diycross-arg AArch64 \
+		-diycross-arg 'Fenced**' \
+		-diycross-arg 'Rfe,Fre,Coe' \
+		-diycross-arg 'DpAddrdR,DpDatadW' \
+		-diycross-arg 'Pos**' \
+		-diycross-arg 'Store' \
+		-diycross-arg 'Rfe,Fre,Coe' \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64 diycross7.store tests: OK"

--- a/gen/diyone.ml
+++ b/gen/diyone.ml
@@ -135,10 +135,16 @@ module Make(O:Config) (M:Builder.S) =
         let pp_rs = List.map LexUtil.split pp_rs in
         let pp_rs = List.concat pp_rs in
         let rs = List.map M.R.parse_relax pp_rs in
+        if O.verbose > 0 then
+          Printf.eprintf
+            "Parsed relaxs: %s\n" (M.R.pp_relax_list rs) ;
         let es =
           List.fold_right
             (fun r k -> M.R.edges_of r @ k)
             rs [] in
+        if O.verbose > 0 then
+          Printf.eprintf
+            "Parsed edges: %s\n" (M.E.pp_edges es) ;
         match es with
         | [] ->
             let dump_names =

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -122,7 +122,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
               | Code.Same -> true
               | Code.Diff -> false
               end
-          |Insert _|Node _ -> false
+          |Insert _|Store|Node _ -> false
           | Id -> assert false in
         (fun n ->
           let p = C.C.find_non_pseudo_prev n.C.C.prev in

--- a/gen/namer.ml
+++ b/gen/namer.ml
@@ -68,6 +68,7 @@ module Make
          | Irf Int -> Some "irfi"
          | Ifr Ext -> Some "ifre"
          | Ifr Int -> Some "ifri"
+         | Store -> Some "store"
          | Node _ -> assert false
          | _ -> None
 
@@ -76,14 +77,14 @@ module Make
            -> true
          |Rf _|Ws _|Fr _
          |Id|Hat|Leave _|Back _
-         |Insert _|Node _|Rmw _|Irf _|Ifr _
+         |Insert _|Store|Node _|Rmw _|Irf _|Ifr _
            -> false
        and ambiguous_source = function
          | Po _|Fenced _
            -> true
          |Dp _| Rf _|Ws _|Fr _
          |Id|Hat|Leave _|Back _
-         |Insert _|Node _|Rmw _|Irf _|Ifr _
+         |Insert _|Store|Node _|Rmw _|Irf _|Ifr _
            -> false
 
        let plain  = Misc.lowercase (A.pp_plain)

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -136,8 +136,8 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
     let io_of_thread n = match n with
     | []|[_] -> None
     | n0::rem ->
-        let n0 = C.C.find_non_insert n0
-        and n1 = C.C.find_non_insert_prev (Misc.last rem) in
+        let n0 = C.C.find_non_insert_store n0
+        and n1 = C.C.find_non_insert_store_prev (Misc.last rem) in
         Some (io_of_node n0,io_of_node n1)
 
     let io_of_detour _n = None

--- a/herd/tests/diycross/AArch64.store/LB+dmb.sy+addrR-pos-store.litmus.expected
+++ b/herd/tests/diycross/AArch64.store/LB+dmb.sy+addrR-pos-store.litmus.expected
@@ -1,0 +1,14 @@
+Test LB+dmb.sy+addrR-pos-store Allowed
+States 5
+0:X1=0; 1:X1=0; 1:X3=1; [x]=2;
+0:X1=0; 1:X1=1; 1:X3=1; [x]=2;
+0:X1=1; 1:X1=0; 1:X3=1; [x]=2;
+0:X1=1; 1:X1=1; 1:X3=1; [x]=2;
+0:X1=2; 1:X1=0; 1:X3=1; [x]=2;
+No
+Witnesses
+Positive: 0 Negative: 5
+Condition exists ([x]=2 /\ 0:X1=2 /\ 1:X1=1 /\ 1:X3=0)
+Observation LB+dmb.sy+addrR-pos-store Never 0 5
+Hash=9ca8ccdd3aeb0efee0960d544096c5aa
+

--- a/herd/tests/diycross/AArch64.store/LB+dmb.sy+dataW-pos-store.litmus.expected
+++ b/herd/tests/diycross/AArch64.store/LB+dmb.sy+dataW-pos-store.litmus.expected
@@ -1,0 +1,15 @@
+Test LB+dmb.sy+dataW-pos-store Allowed
+States 6
+0:X1=0; 1:X1=0; [x]=3;
+0:X1=0; 1:X1=1; [x]=3;
+0:X1=1; 1:X1=0; [x]=3;
+0:X1=2; 1:X1=0; [x]=3;
+0:X1=2; 1:X1=1; [x]=3;
+0:X1=3; 1:X1=0; [x]=3;
+No
+Witnesses
+Positive: 0 Negative: 6
+Condition exists ([x]=3 /\ 0:X1=3 /\ 1:X1=1)
+Observation LB+dmb.sy+dataW-pos-store Never 0 6
+Hash=46dd84898474c77fc610d54a530de7f7
+

--- a/herd/tests/diycross/AArch64.store/MP+dmb.sy+addrR-pos-store.litmus.expected
+++ b/herd/tests/diycross/AArch64.store/MP+dmb.sy+addrR-pos-store.litmus.expected
@@ -1,0 +1,15 @@
+Test MP+dmb.sy+addrR-pos-store Allowed
+States 6
+1:X1=0; 1:X3=1; 1:X5=1; [x]=1;
+1:X1=0; 1:X3=1; 1:X5=1; [x]=2;
+1:X1=0; 1:X3=1; 1:X5=2; [x]=2;
+1:X1=0; 1:X3=2; 1:X5=2; [x]=2;
+1:X1=1; 1:X3=1; 1:X5=1; [x]=1;
+1:X1=1; 1:X3=2; 1:X5=2; [x]=2;
+No
+Witnesses
+Positive: 0 Negative: 6
+Condition exists ([x]=2 /\ 1:X1=1 /\ 1:X3=0 /\ 1:X5=1)
+Observation MP+dmb.sy+addrR-pos-store Never 0 6
+Hash=87fa6a4609f1907b491f1563f5314d5a
+

--- a/herd/tests/diycross/AArch64.store/MP+dmb.sy+dataW-pos-store.litmus.expected
+++ b/herd/tests/diycross/AArch64.store/MP+dmb.sy+dataW-pos-store.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+dmb.sy+dataW-pos-store Allowed
+States 4
+1:X1=0; 1:X4=1; [x]=1;
+1:X1=0; 1:X4=1; [x]=3;
+1:X1=0; 1:X4=3; [x]=3;
+1:X1=1; 1:X4=1; [x]=1;
+No
+Witnesses
+Positive: 0 Negative: 6
+Condition exists ([x]=3 /\ 1:X1=1 /\ 1:X4=2)
+Observation MP+dmb.sy+dataW-pos-store Never 0 6
+Hash=471054350ce898ada2aa9f86be28b15e
+

--- a/herd/tests/diycross/AArch64.store/S+dmb.sy+addrR-pos-store.litmus.expected
+++ b/herd/tests/diycross/AArch64.store/S+dmb.sy+addrR-pos-store.litmus.expected
@@ -1,0 +1,14 @@
+Test S+dmb.sy+addrR-pos-store Allowed
+States 5
+1:X1=0; 1:X3=1; [x]=2;
+1:X1=0; 1:X3=1; [x]=3;
+1:X1=0; 1:X3=3; [x]=2;
+1:X1=1; 1:X3=1; [x]=2;
+1:X1=1; 1:X3=3; [x]=2;
+No
+Witnesses
+Positive: 0 Negative: 6
+Condition exists ([x]=3 /\ 1:X1=1 /\ 1:X3=0)
+Observation S+dmb.sy+addrR-pos-store Never 0 6
+Hash=b02e1f5e5cc2f56cffc34792b3ef7c76
+

--- a/herd/tests/diycross/AArch64.store/S+dmb.sy+dataW-pos-store.litmus.expected
+++ b/herd/tests/diycross/AArch64.store/S+dmb.sy+dataW-pos-store.litmus.expected
@@ -1,0 +1,12 @@
+Test S+dmb.sy+dataW-pos-store Allowed
+States 3
+1:X1=0; [x]=3;
+1:X1=0; [x]=4;
+1:X1=1; [x]=3;
+No
+Witnesses
+Positive: 0 Negative: 6
+Condition exists ([x]=4 /\ 1:X1=1)
+Observation S+dmb.sy+dataW-pos-store Never 0 6
+Hash=9b9f360bfb20364426a9d2e633d7a612
+


### PR DESCRIPTION
The `Store` pseudo-edge was removed by commit  7c5461b4bf51da90aca8540343b85c91bff78436 about 4 years ago.

The `Store` pseudo-edge produces a store to location common to the previous and following edges. This store appears at thread code start.

For instance:
```
% diyone7 -arch AArch64 FencedWW Rfe DpAddrdR PosRR Store Fre
AArch64 A
"DMB.SYdWW Rfe DpAddrdR PosRR Store Fre"
Generator=diyone7 (version 7.56+02~dev)
Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
Com=Rf Fr
Orig=DMB.SYdWW Rfe DpAddrdR PosRR Store Fre
{
0:X1=x; 0:X3=y;
1:X0=y; 1:X4=x;
}
 P0          | P1                  ;
 MOV W0,#2   | MOV W6,#1           ;
 STR W0,[X1] | STR W6,[X4]         ;
 DMB SY      | LDR W1,[X0]         ;
 MOV W2,#1   | EOR W2,W1,W1        ;
 STR W2,[X3] | LDR W3,[X4,W2,SXTW] ;
             | LDR W5,[X4]         ;
exists ([x]=2 /\ 1:X1=1 /\ 1:X3=0 /\ 1:X5=1)
```
Generates an interesting test where the load by P1 from [x] to W3 is delayed; while the next load by P1 from [x] to W5 is not. Additionally, and this is the purpose of the `Store` pseudo-edge, there are two stores to x, one of which is candidate for store forwarding,