### PR TITLE
[tools] Allow any name to be used as label for identifying faults

### DIFF
--- a/tools/lexLog_tools.mll
+++ b/tools/lexLog_tools.mll
@@ -231,7 +231,7 @@ and pline bds fs abs = parse
      let p = poolize loc v in
      pline (p::bds) fs abs lexbuf }
 | blank* fault blank*
-    '(' blank* ('P'? (num as proc)) (':' (label as lbl))? blank* ','
+    '(' blank* ('P'? (num as proc)) (':' (name as lbl))? blank* ','
      ((loc|new_loc) as loc) (':' alpha+)? blank* (* skip optional tag *)
       (',' [^')']*)?  (* skip optional comment *)
       ')' blank* ';'
@@ -240,7 +240,7 @@ and pline bds fs abs = parse
      let f = (to_proc proc,lbl),loc in
      let f = HashedFault.as_hashed f in
      pline bds (f::fs) abs lexbuf }
-| blank* '~' fault blank* '(' blank* ('P'? (num as proc)) (':' (label as lbl))? blank* ','
+| blank* '~' fault blank* '(' blank* ('P'? (num as proc)) (':' (name as lbl))? blank* ','
     ((loc|new_loc) as loc) blank* ')' blank* ';'
     {
      let loc = Constant.old2new loc in


### PR DESCRIPTION
For the litmus test below herd7 accepts any name as a label

AArch64 test
{
0:X2=x
}
 P0               ;
foo:              ;
 LDR X1,[X2]      ;
exists(fault(P0:foo,x))

However, tools like msum7 fail to parse the output from herd7.

$> herd7 test.litmus > test.out
$> msum7 test.out
File "test.out", line 3, character 0: Lex error pline
total nouts: 0.00M

Signed-off-by: Nikos Nikoleris <nikos.nikoleris@arm.com>