### PR TITLE
[herd] Safer init env

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -28,13 +28,12 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     let pp_barrier_short = pp_barrier
     let reject_mixed = true
 
-    type annot = A | XA | L | XL | X | N | Q | XQ | NoRet | T | S
+    type annot = A | XA | L | XL | X | N | Q | XQ | NoRet | S
     type nexp =  AF|DB|AFDB|Other
     type explicit = Exp | NExp of nexp
     type lannot = annot
 
     let empty_annot = N
-    let tag_annot = T
     let exp_annot = Exp
     let nexp_annot = NExp Other
 
@@ -70,10 +69,6 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | L | XL -> true
       | _ -> false
 
-    let is_tag = function
-      | T -> true
-      | _ -> false
-
     let is_explicit = function
       | Exp -> true
       | _ -> false
@@ -100,7 +95,6 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       "Q",  is_acquire_pc;
       "L",  is_release;
       "NoRet", is_noreturn;
-      "T", is_tag;
       "S", is_speculated;
     ]
 
@@ -148,7 +142,6 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | X -> "*"
       | N -> ""
       | NoRet -> "NoRet"
-      | T -> "Tag"
       | S -> "^s"
 
     let pp_explicit = function

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -540,7 +540,7 @@ module Make
         | Q|XQ -> XQ
         | L|XL -> XL
         | X|N  -> X
-        |NoRet|T|S -> X (* Does it occur? *)
+        |NoRet|S -> X (* Does it occur? *)
 
       let an_pte =
         let open AArch64 in
@@ -549,7 +549,7 @@ module Make
         | Q|XQ -> Q
         | L|XL -> L
         | X|N -> N
-        | NoRet|T|S -> N
+        | NoRet|S -> N
 
 
       let check_ptw proc dir updatedb a_virt ma an ii mdirect mok mfault =

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -311,11 +311,6 @@ end = struct
   | Fence (MO mo) -> mo=target
   | _ -> false
 
-  let fence_matches target a = match a with
-  | Fence (AN [a]) -> a=target
-  | _ -> false
-
-
 (* Architecture-specific sets *)
 
   let arch_sets = [
@@ -331,9 +326,6 @@ end = struct
     "RLX", mo_matches MemOrder.Rlx;
     "CON", mo_matches MemOrder.Con;
  (* For C11 RCU, Linux RCU implemented with bell file !! *)
-    "Sync-rcu", fence_matches "sync-rcu";
-    "Rcu-lock", fence_matches "rcu-lock";
-    "Rcu-unlock", fence_matches "rcu-unlock";
     "A",old_is_atomic;
     "NA",(fun a -> not (old_is_atomic a));
     "annot", (fun a -> match a with

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -520,9 +520,9 @@ end = struct
     ("FAULT",is_fault)::
     ("TLBI",is_inv)::
     ("DC",is_dc)::
-    ("IC",is_ic)::
-    ("CI",is_ci)::
-    ("C",is_c)::("I",is_i)::
+    ("DC-IC",is_ic)::
+    ("DC-CI",is_ci)::
+    ("DC-C",is_c)::("DC-I",is_i)::
     ("no-loc", fun a -> Misc.is_none (location_of a))::
     (if kvm then
       fun k ->

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -337,7 +337,6 @@ module Make
                  "SPEC", is_spec;
                  "EXEC", (fun e -> not (is_spec e));
                  "AMO",E.is_amo;
-                 "I", E.is_mem_store_init;
                  "SPURIOUS", E.is_spurious;
                  "IW", E.is_mem_store_init;
                  "FW",

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -527,14 +527,22 @@ module Make
       f_rec sets
 
 (* Go on *)
-    let add_vals mk =
-      List.fold_right (fun (k,v) -> StringMap.add k (mk v))
+    let add_vals_once mk =
+      List.fold_right
+        (fun (k,v) m ->
+          if StringMap.mem k m then
+            Warn.warn_always
+              "redefining key '%s' in cat interpreter initial environment"
+              k ;
+          StringMap.add k (mk v) m)
 
     let env_from_ienv (sets,rels) =
       let vals =
-        add_vals (fun v -> lazy (Set (Lazy.force v))) sets StringMap.empty in
+        add_vals_once
+          (fun v -> lazy (Set (Lazy.force v))) sets StringMap.empty in
       let vals =
-        add_vals (fun v -> lazy (Rel (Lazy.force v))) rels vals in
+        add_vals_once
+          (fun v -> lazy (Rel (Lazy.force v))) rels vals in
       { env_empty with vals; }
 
 (* Primitive added internally to actual env *)


### PR DESCRIPTION
Check names clashes in the Cat interpreter initial environment, find some, fix them.