### PR TITLE
[herd] Add a new event set TLBUncacheable

### DIFF
--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -244,6 +244,6 @@ end = struct
      "Ftotal",is_total_barrier;]
 
   let arch_rels = []
-  let arch_dirty = []
+  let arch_pte_sets = []
 
 end

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -334,7 +334,7 @@ end = struct
   ]
 
   let arch_rels = []
-  and arch_dirty = []
+  and arch_pte_sets = []
 
   let is_isync _ = raise Misc.NoIsync
   let pp_isync = "???"

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -29,8 +29,7 @@ module type S = sig
 (* Some architecture-specific sets and relations, with their definitions *)
   val arch_sets : (string * (action -> bool)) list
   val arch_rels : (string * (action -> action -> bool)) list
-(* To be deprecated *)
-  val arch_dirty : (string * (DirtyBit.my_t -> action -> bool)) list
+  val arch_pte_sets : (string * (DirtyBit.my_t -> action -> bool)) list
 
 (* control fence *)
   val is_isync : action -> bool

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -26,7 +26,7 @@ module type A = sig
   val pp_annot : lannot -> string
   include Explicit.S
   val pteval_sets : (string * (V.Cst.PteVal.t -> bool)) list
-  val dirty_sets : (string * (DirtyBit.my_t -> V.Cst.PteVal.t -> bool)) list
+  val pteval_pred_sets : (string * (DirtyBit.my_t -> V.Cst.PteVal.t -> bool)) list
 
   val is_atomic : lannot -> bool
   val is_isync : barrier -> bool
@@ -598,7 +598,7 @@ end = struct
       [("inv-domain",inv_domain_act); ("alias",alias_act);]
     else []
 
-  let arch_dirty =
+  let arch_pte_sets =
     if kvm then
       let check_pred f d  =
         fun act ->
@@ -607,7 +607,7 @@ end = struct
           | None -> false
           | Some pteval -> f d pteval) in
       List.map
-        (fun (key,f) -> key,check_pred f) A.dirty_sets
+        (fun (key,f) -> key,check_pred f) A.pteval_pred_sets
     else []
 
   let is_isync act = match act with

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -385,7 +385,7 @@ module Make
              E.Act.arch_sets) in
     let m = (* To be deprecated *)
       if kvm then
-          let mevt = match I.get_set m "PTEV" with
+          let mevt = match I.get_set m "PTE" with
             | Some mevt -> mevt
             | None -> (* Must exists *) assert false in
           I.add_sets m
@@ -411,7 +411,7 @@ module Make
                           a d e.E.action)
                      (Lazy.force mevt)
                  end)
-               E.Act.arch_dirty)
+               E.Act.arch_pte_sets)
         else m in
 (* Override arch specific fences *)
       let m =

--- a/herd/pteValSets.ml
+++ b/herd/pteValSets.ml
@@ -16,5 +16,5 @@
 
 module No = struct
   let pteval_sets = []
-  let dirty_sets = []
+  let pteval_pred_sets = []
 end


### PR DESCRIPTION
The Arm architecture permits TLBs to cache a PTE when it doesn't cause
a Translation fault or an Access flag fault.

Signed-off-by: Nikos Nikoleris <nikos.nikoleris@arm.com>