### PR TITLE
[gen] Fix diy tool when no prefix specified.

### DIFF
--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -317,8 +317,8 @@ module Make(C:Builder.S)
     let minint suff = c_minint 0 suff
 
 (* Prefix *)
-    let prefix_expanded =
-      List.flatten (List.map C.R.expand_relax_seq O.prefix)
+    let prefix_expanded = List.flatten (List.map C.R.expand_relax_seq O.prefix)
+
     let () =
       if O.verbose > 0 && O.prefix <> [] then begin
         eprintf "Prefixes:\n" ;
@@ -327,6 +327,7 @@ module Make(C:Builder.S)
             eprintf "  %s\n" (C.R.pp_relax_list rs))
           prefix_expanded
       end
+
     let prefixes = List.map edges_ofs prefix_expanded
 
     let rec mk_can_prefix = function

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -52,7 +52,10 @@ let parse_fences fs = List.fold_right parse_fence fs []
 
     type relax = C.R.relax
 
-    let prefix = List.map parse_relaxs O.prefix
+    let prefix =
+      match List.map parse_relaxs O.prefix with
+      | [] -> [[]] (* No prefix <=> one empty prefix *)
+      | pss -> pss
 
     let variant = O.variant
 


### PR DESCRIPTION
No prefix specified means one empty prefix, as it was the case before.
Before commit cdf4c6c95d98dfaa776ab14555af0eaae4e670ba of PR #343.