### PR TITLE
[gen] Some enhancements for `-variant kvm`  generators:

### DIFF
--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -538,10 +538,13 @@ let pp_fence f = match f with
 | Shootdown (d,op,sync) ->
    let tlbi = "TLBI" ^ pp_sync sync in
    sprintf "%s%s%s" tlbi
-     (add_dot TLBI.short_pp_op op) (add_dot pp_domain d)
+     (add_dot TLBI.short_pp_op op)
+     (match sync with
+      | NoSync -> ""
+      | Sync -> add_dot pp_domain d)
 
 let fold_cumul_fences f k =
-   do_fold_dmb_dsb C.moreedges (fun b k -> f (Barrier b) k) k
+   do_fold_dmb_dsb do_kvm C.moreedges (fun b k -> f (Barrier b) k) k
 
 let fold_shootdown =
   if do_kvm then
@@ -571,7 +574,7 @@ let fold_cachesync =
 let fold_all_fences f k =
   let k = fold_shootdown f k in
   let k = fold_cachesync f k in
-  fold_barrier C.moreedges (fun b k -> f (Barrier b) k) k
+  fold_barrier do_kvm C.moreedges (fun b k -> f (Barrier b) k) k
 
 
 let fold_some_fences f k =

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -173,7 +173,7 @@ and type rmw = F.rmw = struct
   let ()  = ignore (Cfg.naturalsize)
   let do_self = Cfg.variant Variant_gen.Self
   let do_mixed = Variant_gen.is_mixed Cfg.variant
-  let do_kvm = Cfg.variant Variant_gen.KVM
+  let do_kvm =  Variant_gen.is_kvm Cfg.variant
   let do_disjoint = Cfg.variant Variant_gen.MixedDisjoint
   let do_strict_overlap = Cfg.variant Variant_gen.MixedStrictOverlap
 

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -173,6 +173,7 @@ and type rmw = F.rmw = struct
   let ()  = ignore (Cfg.naturalsize)
   let do_self = Cfg.variant Variant_gen.Self
   let do_mixed = Variant_gen.is_mixed Cfg.variant
+  let do_kvm = Cfg.variant Variant_gen.KVM
   let do_disjoint = Cfg.variant Variant_gen.MixedDisjoint
   let do_strict_overlap = Cfg.variant Variant_gen.MixedStrictOverlap
 
@@ -723,7 +724,7 @@ let fold_tedges f r =
 
   let can_precede_dirs  x y = match x.edge,y.edge with
   | (Id,_)|(_,Id) -> true
-  | (Insert _,Insert _) -> false
+  | (Insert _,Insert _) -> do_kvm
   | _,_ ->
       begin match dir_tgt x,dir_src y with
       | (Irr,Irr) -> false

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -83,7 +83,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | _ -> false
 
     let barrier_sets =
-      do_fold_dmb_dsb true
+      do_fold_dmb_dsb false true
         (fun b k ->
           let tag = pp_barrier_dot b in
           (tag,is_barrier b)::k)

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -53,7 +53,7 @@ module Make
 
 (* Barrier pretty print *)
     let barriers =
-      let bs = AArch64Base.do_fold_dmb_dsb true (fun h t -> h::t) []
+      let bs = AArch64Base.do_fold_dmb_dsb false true (fun h t -> h::t) []
       in List.map
         (fun b ->
           { barrier = b;

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -349,22 +349,25 @@ type barrier =
   | DSB of mBReqDomain*mBReqTypes
   | ISB
 
-let fold_barrier_option more f k =
+let fold_barrier_option kvm more f k =
   if more then
     fold_domain
       (fun d k ->
         fold_type (fun t k -> f d t k) k)
       k
   else
+    let k =
+      if kvm then fold_type (fun t k -> f ISH t k) k
+      else k in
     fold_type (fun t k -> f SY t k) k
 
-let do_fold_dmb_dsb more f k =
-  fold_barrier_option more
+let do_fold_dmb_dsb kvm more f k =
+  fold_barrier_option kvm more
     (fun d t k -> f (DMB (d,t)) (f (DSB (d,t)) k))
     k
 
-let fold_barrier more f k =
-  let k = do_fold_dmb_dsb more f k in
+let fold_barrier kvm more f k =
+  let k = do_fold_dmb_dsb kvm more f k in
   let k = f ISB k in
   k
 


### PR DESCRIPTION
  + Simplify TLBI.ISH lexeme into TLBI (as there are no DSB,ISH here)
  + Option `-variant kvm`  defines .ISH fences.