### PR TITLE
[litmus] Workaround against some brittle printf implementations.

### DIFF
--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -90,6 +90,7 @@ module Make
           let emitprintf = true
           let ctr = Fmt.I64
           let no_file = false
+          let brittle = false
         end)(O)
     module UD = U.Dump(O)(EPF)
 

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -101,6 +101,7 @@ module Make
             let emitprintf = Cfg.stdio
             let ctr = Fmt.I32
             let no_file = Cfg.is_kvm
+            let brittle = Cfg.is_kvm
           end)(O)
 
       let timebase_possible =

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -281,6 +281,7 @@ module Make
             let emitprintf = Cfg.stdio
             let ctr = Fmt.I64
             let no_file = false
+            let brittle = false
           end)(O)
       module UD = U.Dump(O)(EPF)
 


### PR DESCRIPTION
 Some printf implementations fail on long strings. As a workaround we avoid printf when all output consists of strings. 