### PR TITLE
[herd] RISC-V Ztso extension memory model

### DIFF
--- a/herd/libdir/riscv-tso-defs.cat
+++ b/herd/libdir/riscv-tso-defs.cat
@@ -33,7 +33,8 @@ let AcqRel = AcqRel|Sc (* Compat *)
 let AQ = (Acq|AcqRel)
 and RL = (Rel|AcqRel)
 let AMO = try AMO with (R & W) (* Compat *)
-let RCsc = (Acq|Rel|AcqRel) & (AMO|X)
+(* All AMO ops have RCsc annotations *)
+let RCsc = (Acq|Rel|AcqRel|AMO) & (AMO|X)
 (*************)
 (* ppo rules *)
 (*************)
@@ -55,6 +56,10 @@ and r11 = [M];ctrl;[W]
 (* Pipeline Dependencies *)
 and r12 = [M];(addr|data);[W];rfi;[R]
 and r13 = [M];addr;[M];po;[W]
+(* All loads have RCpc Acquire *)
+and r14 = [R];po;[M]
+(* All stores have RCpc Release *)
+and r15 = [M];po;[W]
 
 let ppo =
   r1
@@ -70,3 +75,5 @@ let ppo =
 | r11
 | r12
 | r13
+| r14
+| r15

--- a/herd/libdir/riscv-tso-defs.cat
+++ b/herd/libdir/riscv-tso-defs.cat
@@ -1,0 +1,72 @@
+(*****************************************)
+(* The RISCV Instruction set manual v2.3 *)
+(*****************************************)
+
+
+(*************)
+(* Utilities *)
+(*************)
+
+let fence.r.r = [R];fencerel(Fence.r.r);[R]
+let fence.r.w = [R];fencerel(Fence.r.w);[W]
+let fence.r.rw = [R];fencerel(Fence.r.rw);[M]
+let fence.w.r = [W];fencerel(Fence.w.r);[R]
+let fence.w.w = [W];fencerel(Fence.w.w);[W]
+let fence.w.rw = [W];fencerel(Fence.w.rw);[M]
+let fence.rw.r = [M];fencerel(Fence.rw.r);[R]
+let fence.rw.w = [M];fencerel(Fence.rw.w);[W]
+let fence.rw.rw = [M];fencerel(Fence.rw.rw);[M]
+let fence.tso =
+  let f = fencerel(Fence.tso) in
+  ([W];f;[W]) | ([R];f;[M])
+
+let fence =
+  fence.r.r | fence.r.w | fence.r.rw |
+  fence.w.r | fence.w.w | fence.w.rw |
+  fence.rw.r | fence.rw.w | fence.rw.rw |
+  fence.tso
+
+
+let po-loc-no-w = po-loc \ (po-loc?;[W];po-loc)
+let rsw = rf^-1;rf
+let AcqRel = AcqRel|Sc (* Compat *)
+let AQ = (Acq|AcqRel)
+and RL = (Rel|AcqRel)
+let AMO = try AMO with (R & W) (* Compat *)
+let RCsc = (Acq|Rel|AcqRel) & (AMO|X)
+(*************)
+(* ppo rules *)
+(*************)
+
+(* Overlapping-Address Orderings *)
+let r1 = [M];po-loc;[W]
+and r2 = ([R];po-loc-no-w;[R]) \ rsw
+and r3 = [AMO|X];rfi;[R]
+(* Explicit Synchronization *)
+and r4 = fence
+and r5 = [AQ];po;[M]
+and r6 = [M];po;[RL]
+and r7 = [RCsc];po;[RCsc]
+and r8 = rmw
+(* Syntactic Dependencies *)
+and r9 = [M];addr;[M]
+and r10 = [M];data;[W]
+and r11 = [M];ctrl;[W]
+(* Pipeline Dependencies *)
+and r12 = [M];(addr|data);[W];rfi;[R]
+and r13 = [M];addr;[M];po;[W]
+
+let ppo =
+  r1
+| r2
+| r3
+| r4
+| r5
+| r6
+| r7
+| r8
+| r9
+| r10
+| r11
+| r12
+| r13

--- a/herd/libdir/riscv-tso.cat
+++ b/herd/libdir/riscv-tso.cat
@@ -1,0 +1,28 @@
+RISCV "Risc V partial order model"
+
+(*****************************************)
+(* The RISCV Instruction set manual v2.3 *)
+(*****************************************)
+
+(***************)
+(* Definitions *)
+(***************)
+
+(* Define ppo *)
+include "riscv-defs.cat"
+
+(* Compute coherence relation *)
+include "cos-opt.cat"
+
+(**********)
+(* Axioms *)
+(**********)
+
+(* Sc per location *)
+acyclic co|rf|fr|po-loc as Coherence
+
+(* Main model axiom *)
+acyclic co|rfe|fr|ppo as Model
+
+(* Atomicity axiom *)
+empty rmw & (fre;coe) as Atomic

--- a/herd/libdir/riscv-tso.cat
+++ b/herd/libdir/riscv-tso.cat
@@ -1,4 +1,4 @@
-RISCV "Risc V partial order model"
+RISCV "Risc V partial order model with zTSO extension"
 
 (*****************************************)
 (* The RISCV Instruction set manual v2.3 *)
@@ -9,7 +9,7 @@ RISCV "Risc V partial order model"
 (***************)
 
 (* Define ppo *)
-include "riscv-defs.cat"
+include "riscv-tso-defs.cat"
 
 (* Compute coherence relation *)
 include "cos-opt.cat"


### PR DESCRIPTION
RISC-V defines its Ztso extension as equivalent to RVWMO, but with
three adjustments [1]:

 1. All load operations behave as if they have an acquire-RCpc annotation
 2. All store operations behave as if they have a release-RCpc annotation.
 3. All AMOs behave as if they have both acquire-RCsc and release-RCsc annotations.

As such, AMO ops have been added to the RCsc definition, and
acquire/release RCpc annotations are implemented in line with page 16 of
the 1995 paper "Shared Memory Consistency Models: A Tutorial"[2].

This is a tentative implementation and may need edits in order to
be accurate/mergeable. Feedback is welcome.

[1] https://github.com/riscv/riscv-isa-manual/blob/c9a172ff2245824b0c55b234a3bb45664394d038/src/ztso.tex#L12-L17
[2] https://www.hpl.hp.com/techreports/Compaq-DEC/WRL-95-7.pdf