### PR TITLE
[herd] Simplify hardware management of AF and DB bits.

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -600,12 +600,9 @@ module Make
               | Dir.W ->
                  if hd && updatedb then
                    add_setbits
-                     (m_op Op.And (is_zero ipte.af_v) (is_zero ipte.db_v))
-                     "af:0 && db:0"
-                     set_afdb
-                     (add_setbits
-                        (is_zero ipte.db_v) "db:0" set_db
-                        (add_setbits (is_zero ipte.af_v) "af:0" set_af m))
+                     (m_op Op.Or (is_zero ipte.af_v) (is_zero ipte.db_v))
+                     "af:0 || db:0"
+                     set_afdb m
                  else if ha then
                    add_setbits (is_zero ipte.af_v) "af:0" set_af m
                  else m


### PR DESCRIPTION
If complete hardware management of AF and DB bits is active,
and that at least one of the bits is unset, then both bits
are set in one operation.

Previously, four cases were considered, depending on both bits being unset,
exactly one bit being unset, or none. The three "active" case performing
minimal operations. Logic is this simplified at the (small)
price of setting bits that may already be set.