### PR TITLE
Parse SUB instruction in the 32-bit ARM lexer & parser

### DIFF
--- a/lib/ARMLexer.mll
+++ b/lib/ARMLexer.mll
@@ -45,6 +45,8 @@ rule token = parse
 | ':' { COLON }
 | "add" | "ADD"   { I_ADD }
 | "adds" | "ADDS"   { I_ADDS }
+| "sub" | "SUB"   { I_SUB }
+| "subs" | "SUBS"   { I_SUBS }
 | "and" | "AND"   { I_AND }
 | "ands" | "ANDS"   { I_ANDS }
 | "bne" | "BNE"   { I_BNE }

--- a/lib/ARMParser.mly
+++ b/lib/ARMParser.mly
@@ -31,7 +31,7 @@ module A = ARMBase
 
 /* Instruction tokens */
 
-%token I_ADD I_ADDS I_AND I_ANDS I_B I_BEQ I_BNE I_CMP I_MOV I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
+%token I_ADD I_ADDS I_SUB I_SUBS I_AND I_ANDS I_B I_BEQ I_BNE I_CMP I_MOV I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
 %token I_LDR I_LDREX I_LDRNE I_LDREQ I_STR I_STRNE I_STREQ I_STREX
 %token I_SY I_ST I_ISH I_ISHST I_NSH I_NSHST I_OSH I_OSHST
 %type <MiscParser.proc list * (ARMBase.parsedPseudo) list list> main
@@ -90,6 +90,14 @@ instr:
      { A.I_ADD3 (A.DontSetFlags,$2, $4, $6) }
   | I_ADDS reg COMMA reg COMMA reg
      { A.I_ADD3 (A.SetFlags,$2, $4, $6) }
+  | I_SUB reg COMMA reg COMMA k
+     { A.I_SUB (A.DontSetFlags,$2,$4,$6) }
+  | I_SUBS reg COMMA reg COMMA k
+     { A.I_SUB (A.SetFlags,$2,$4,$6) }
+  | I_SUB reg COMMA reg COMMA reg
+     { A.I_SUB3 (A.DontSetFlags,$2, $4, $6) }
+  | I_SUBS reg COMMA reg COMMA reg
+     { A.I_SUB3 (A.SetFlags,$2, $4, $6) }
   | I_AND reg COMMA reg COMMA k
      { A.I_AND (A.DontSetFlags,$2,$4,$6) }
   | I_ANDS reg COMMA reg COMMA k


### PR DESCRIPTION
Add support for `SUB` and `SUBS` instructions in the 32-bit ARM lexer & parser (which seem to be missing for some reason).