### PR TITLE
[herd,litmus] Add a new possibility for fault handling in `kvm` mode

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -803,9 +803,9 @@ module Make
       let lift_fault mfault mm = (* This is memtag fault handling *)
         let open Precision in
         match C.precision with
-        | Precise -> mfault >>! B.Exit
+        | Fatal -> mfault >>! B.Exit
         | Skip -> Warn.fatal "Memtag extension has no 'Skip' fault handling mode"
-        | Imprecise ->
+        | Handled ->
            (mfault >>| mm) >>= M.ignore >>= B.next1T
 
       let lift_memtag_phy mop a_virt ma ii =
@@ -845,9 +845,9 @@ module Make
             begin
               let open Precision in
               match C.precision with
-              | Precise -> B.Exit
+              | Fatal -> B.Exit
               | Skip -> B.Next []
-              | Imprecise -> B.ReExec
+              | Handled -> B.ReExec
             end in
         let maccess a ma =
           check_ptw ii.AArch64.proc dir updatedb a ma an ii

--- a/herd/opts.ml
+++ b/herd/opts.ml
@@ -42,7 +42,7 @@ let speedcheck = ref Speed.False
 let archcheck = ref true
 let optace = ref None
 let variant = ref (fun _ -> false)
-let precision = ref false
+let precision = ref Precision.default
 
 module OptS = struct
   include Variant

--- a/herd/opts.mli
+++ b/herd/opts.mli
@@ -41,7 +41,7 @@ val speedcheck : Speed.t ref
 val optace : OptAce.t option ref
 val archcheck : bool ref
 val variant : (Variant.t -> bool) ref
-val precision : bool ref
+val precision : Precision.t ref
 module OptS : ParseTag.OptS with type t = Variant.t
 val byte : MachSize.Tag.t ref
 val endian : Endian.t option ref

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -21,7 +21,7 @@ module type Config = sig
   val verbose : int
   val optace : OptAce.t
   val debug : Debug_herd.t
-  val precision : bool
+  val precision : Precision.t
   val variant : Variant.t -> bool
   val endian : Endian.t option
   module PC : PrettyConf.S

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -34,8 +34,7 @@ type t =
  (* Do not check (and reject early) mixed size tests in non-mixed-size mode *)
   | DontCheckMixed
   | MemTag           (* Memory Tagging *)
-  | TagCheckPrecise
-  | TagCheckUnprecise
+  | TagPrecise of Precision.t (* Fault handling *)
   | TooFar         (* Do not discard candidates with TooFar events *)
   | Morello
   | Neon
@@ -75,5 +74,4 @@ val get_default :  Archs.t -> t -> bool
 (* Get value for switchable variant *)
 val get_switch : Archs.t -> t -> (t -> bool) -> bool
 
-(* set precision *)
-val set_precision : bool ref -> t -> bool
+val set_precision : Precision.t ref -> t -> bool

--- a/lib/precision.ml
+++ b/lib/precision.ml
@@ -15,30 +15,30 @@
 (****************************************************************************)
 
 type t =
-  | Imprecise (* Do nothing special *)
-  | Precise   (* Jump to end of code *)
-  | Skip      (* Skip instruction *)
+  | Handled (* Do nothing special *)
+  | Fatal   (* Jump to end of code *)
+  | Skip    (* Skip instruction *)
 
-let default = Imprecise
+let default = Handled
 
-let tags =  ["imprecise"; "precise"; "faultToNext"; ]
+let tags =  ["handled"; "fatal"; "faultToNext"; ]
 
 let parse s = match s with
-  | "imprecise" -> Some Imprecise
-  | "precise" -> Some Precise
+  | "imprecise"|"handled" -> Some Handled
+  | "precise"|"fatal" -> Some Fatal
   | "faulttonext"|"skip" -> Some Skip
   | _ -> None
 
 let pp = function
-  | Imprecise -> "imprecise"
-  | Precise -> "precise"
-  | Skip -> "skip"
+  | Handled -> "handled"
+  | Fatal -> "fatal"
+  | Skip -> "faulToNext"
 
-let is_precise = function
-  | Precise -> true
-  | Imprecise|Skip -> false
+let is_fatal = function
+  | Fatal -> true
+  | Handled|Skip -> false
 
 let is_skip = function
   | Skip -> true
-  | Imprecise|Precise -> false
-      
+  | Handled|Fatal -> false
+

--- a/lib/precision.ml
+++ b/lib/precision.ml
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2019-present Institut National de Recherche en Informatique et *)
+(* Copyright 2022-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -15,12 +15,30 @@
 (****************************************************************************)
 
 type t =
-  | Self (* Self modifying code *)
-  | Precise of Precision.t
+  | Imprecise (* Do nothing special *)
+  | Precise   (* Jump to end of code *)
+  | Skip      (* Skip instruction *)
 
-val tags : string list
-val parse : string -> t option
-val pp : t -> string
-val ok : t -> Archs.t -> bool
-val compare : t -> t -> int
-val set_precision : Precision.t ref -> t -> bool
+let default = Imprecise
+
+let tags =  ["imprecise"; "precise"; "faultToNext"; ]
+
+let parse s = match s with
+  | "imprecise" -> Some Imprecise
+  | "precise" -> Some Precise
+  | "faulttonext"|"skip" -> Some Skip
+  | _ -> None
+
+let pp = function
+  | Imprecise -> "imprecise"
+  | Precise -> "precise"
+  | Skip -> "skip"
+
+let is_precise = function
+  | Precise -> true
+  | Imprecise|Skip -> false
+
+let is_skip = function
+  | Skip -> true
+  | Imprecise|Precise -> false
+      

--- a/lib/precision.mli
+++ b/lib/precision.mli
@@ -17,14 +17,14 @@
 (** Reaction to faults, tag common to litmus and herd *)
 
 type t =
-  | Imprecise (* Do nothing special *)
-  | Precise   (* Jump to end of code *)
-  | Skip      (* Skip instruction *)
+  | Handled (* Do nothing special *)
+  | Fatal   (* Jump to end of code *)
+  | Skip    (* Skip instruction *)
 
 val default : t
 val tags : string list
 val parse : string -> t option
 val pp : t -> string
 
-val is_precise : t -> bool
+val is_fatal : t -> bool
 val is_skip : t -> bool

--- a/lib/precision.mli
+++ b/lib/precision.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2019-present Institut National de Recherche en Informatique et *)
+(* Copyright 2022-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,13 +14,17 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type t =
-  | Self (* Self modifying code *)
-  | Precise of Precision.t
+(** Reaction to faults, tag common to litmus and herd *)
 
+type t =
+  | Imprecise (* Do nothing special *)
+  | Precise   (* Jump to end of code *)
+  | Skip      (* Skip instruction *)
+
+val default : t
 val tags : string list
 val parse : string -> t option
 val pp : t -> string
-val ok : t -> Archs.t -> bool
-val compare : t -> t -> int
-val set_precision : Precision.t ref -> t -> bool
+
+val is_precise : t -> bool
+val is_skip : t -> bool

--- a/lib/testVariant.ml
+++ b/lib/testVariant.ml
@@ -24,12 +24,12 @@ module
         val compare : t -> t -> int
       end
       val info : MiscParser.info
-      val precision : bool
+      val precision : Precision.t
       val variant : Opt.t -> bool
-      val set_precision : bool ref -> Opt.t -> bool
+      val set_precision : Precision.t ref -> Opt.t -> bool
     end) : sig
       type t = Var.Opt.t
-      val precision : bool
+      val precision : Precision.t
       val variant : Var.Opt.t -> bool
     end= struct
       type t = Var.Opt.t

--- a/lib/testVariant.mli
+++ b/lib/testVariant.mli
@@ -23,12 +23,12 @@ module Make : functor
         val compare : t -> t -> int
       end
       val info : MiscParser.info
-      val precision : bool
+      val precision : Precision.t
       val variant : Opt.t -> bool
-      val set_precision : bool ref -> Opt.t -> bool
+      val set_precision : Precision.t ref -> Opt.t -> bool
     end) ->
       sig
         type t = Var.Opt.t
-        val precision : bool
+        val precision : Precision.t
         val variant : t -> bool
       end

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -297,7 +297,7 @@ type P.code = MiscParser.proc * A.pseudo list)
     open Constant
 
     let do_self = O.variant Variant_litmus.Self
-    and do_precise = Precision.is_precise O.precision
+    and do_precise = Precision.is_fatal O.precision
     let is_pte =
       let open Mode in
       match O.mode with

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -19,7 +19,7 @@ module type Config = sig
   val timeloop : int
   val barrier : Barrier.t
   val mode : Mode.t
-  val precision : bool
+  val precision : Precision.t
   val variant : Variant_litmus.t -> bool
 end
 
@@ -28,7 +28,7 @@ module Default = struct
   let timeloop = 0
   let barrier = Barrier.UserFence
   let mode = Mode.Std
-  let precision = false
+  let precision = Precision.default
   let variant _ = false
 end
 
@@ -297,7 +297,7 @@ type P.code = MiscParser.proc * A.pseudo list)
     open Constant
 
     let do_self = O.variant Variant_litmus.Self
-    and do_precise = O.precision
+    and do_precise = Precision.is_precise O.precision
     let is_pte =
       let open Mode in
       match O.mode with

--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -8,6 +8,10 @@ static void fault_handler(struct pt_regs *regs,unsigned int esr) {
   record_fault(w,read_elr_el1(),read_far());
 #ifdef PRECISE
   regs->pc = (u64)label_ret[w->proc];
+#else
+#ifdef FAULT_SKIP
+  regs->pc += 4;
+#endif
 #endif
 }
 

--- a/litmus/option.ml
+++ b/litmus/option.ml
@@ -172,7 +172,7 @@ let morearch = ref MoreArch.No
 let carch = ref `Unknown
 let mode = ref Mode.Std
 let usearch = ref UseArch.Trad
-let precision = ref false
+let precision = ref Precision.default
 let variant = ref (fun _ -> false)
 
 (* Arch dependent options *)

--- a/litmus/option.mli
+++ b/litmus/option.mli
@@ -120,7 +120,7 @@ val cacheflush : bool ref
 val carch : Archs.System.t ref
 val mode : Mode.t ref
 val usearch : UseArch.t ref
-val precision : bool ref
+val precision : Precision.t ref
 val variant : (Variant_litmus.t -> bool) ref
 
 (* Arch dependent option *)

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -71,7 +71,7 @@ module Make
     let do_ascall =
       Cfg.ascall || Cfg.is_kvm || Misc.consp CfgLoc.label_init
 
-    let do_precise = Precision.is_precise Cfg.precision
+    let do_precise = Precision.is_fatal Cfg.precision
     and do_skip = Precision.is_skip Cfg.precision
 
     let do_dynalloc =

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -57,7 +57,7 @@ module type CommonConfig = sig
   val c11 : bool
   val c11_fence : bool
   val ascall : bool
-  val precision : bool
+  val precision : Precision.t
   val variant : Variant_litmus.t -> bool
   val nocatch : bool
   val stdio : bool
@@ -116,7 +116,7 @@ module type Config = sig
   val noccs : int
   val timelimit : float option
   val check_nstates : string -> int option
-  val precision : bool
+  val precision : Precision.t
   (* End of additions *)
   include Skel.Config
   include Run_litmus.Config

--- a/litmus/top_litmus.mli
+++ b/litmus/top_litmus.mli
@@ -50,7 +50,7 @@ module type CommonConfig = sig
   val c11 : bool
   val c11_fence : bool
   val ascall : bool
-  val precision : bool
+  val precision : Precision.t
   val variant : Variant_litmus.t -> bool
   val nocatch : bool
   val stdio : bool


### PR DESCRIPTION
The new possibility `-variant skip` or `-variant faultToNext`
transfers control to the next instruction once fault is handled.
By _handled_ one means:
 + For herd, a fault event is generated.
 + For litmus, scaffold handler is called (once).

As a reminder here are the other imlemented behaviours:
 + `-variant precise`, control is transferred at end of thread code.
 + `-variant imprecise`. Litmus: litmus: adopt default return from handler
    behaviour, _i.e._ re-execute the faulty instruction. Herd:
    emit fault and re-execute instruction. The instruction is not allowed
    to fault again, _i.e._ prune number of consecutive faults to one.

The PR also introduce new names: `-variant precise` becomes `-variant fatal` and `-variant imprecise` becomes `-variant handled`. New names are still recognised in options and metadata arguments.