### PR TITLE
[lib]: fixed LDUR pretty printing bug

### DIFF
--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1085,7 +1085,7 @@ let do_pp_instruction m =
   | I_LDUR (_,r1,r2,None) ->
       sprintf "LDUR %s, [%s]" (pp_reg r1) (pp_reg r2)
   | I_LDUR (_,r1,r2,Some(k)) ->
-      sprintf "LDUR %s, [%s, #%s]" (pp_reg r1) (pp_reg r2) (m.pp_k k)
+      sprintf "LDUR %s, [%s, %s]" (pp_reg r1) (pp_reg r2) (m.pp_k k)
   | I_LDR_P (v,r1,r2,k) ->
       pp_mem_post "LDR" v r1 r2 k
   | I_LDP (t,v,r1,r2,r3,k) ->
@@ -1176,11 +1176,11 @@ let do_pp_instruction m =
   | I_LDUR_SIMD (v,r1,r2,None) ->
       sprintf "LDUR %s, [%s]" (pp_vsimdreg v r1) (pp_reg r2)
   | I_LDUR_SIMD (v,r1,r2,Some(k)) ->
-      sprintf "LDUR %s, [%s, #%s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
+      sprintf "LDUR %s, [%s, %s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
   | I_STUR_SIMD (v,r1,r2,None) ->
       sprintf "STUR %s, [%s]" (pp_vsimdreg v r1) (pp_reg r2)
   | I_STUR_SIMD (v,r1,r2,Some(k)) ->
-      sprintf "STUR %s, [%s, #%s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
+      sprintf "STUR %s, [%s, %s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
   | I_MOV_VE (r1,i1,r2,i2) ->
       pp_vrivri "MOV" r1 i1 r2 i2
   | I_MOV_V (r1,r2) ->


### PR DESCRIPTION
The current code for LDUR (and `LDUR/STUR_SIMD`) offset prints the instruction as:
```
LDUR X0,[X1, ##4]
```

This patch removes the erroneous `#`


=========================================================
Pre-reviewed by @relokin  in https://github.com/lukeg101/herdtools7/pull/9

regression tests pass.