### PR TITLE
[herd] The `^-1` (inverse) CAT operator works on pairs

### DIFF
--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -1282,6 +1282,7 @@ module Make
             | Unv -> Unv
             | Rel r -> Rel (E.EventRel.inverse r)
             | ClassRel r -> ClassRel (ClassRel.inverse r)
+            | Pair (v1,v2) -> Pair (v2,v1)
             | v -> error_rel env.EV.silent (get_loc e) v
             end
         | Op1 (_,ToId,e) ->


### PR DESCRIPTION
"Pairs" are the result `p` of relation matching by pattern `p ++ r`. The operator swaps pair components.