### PR TITLE
[lib] fix RISC-V aqrl assembly format

### DIFF
--- a/lib/RISCVBase.ml
+++ b/lib/RISCVBase.ml
@@ -270,7 +270,7 @@ let pp_mo = function
   | Rlx -> ""
   | Acq -> ".aq"
   | Rel -> ".rl"
-  | AcqRel -> ".aq.rl"
+  | AcqRel -> ".aqrl"
   | Sc -> ".sc"
 
 let pp_load w s mo = sprintf "l%s%s%s" (pp_width w) (pp_signed s) (pp_mo mo)


### PR DESCRIPTION
this should enable RISC-V amo related tests to build with gcc

Previously, herdtools generate amo instructions with format like `amoswap.w.aq.rl`, this mismatches with what `gcc` expects (`amoswap.w.aqrl`). This PR fixes this inconsistency.