### PR TITLE
[ARM]: Added DMB ISH to arm model

### DIFF
--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -38,6 +38,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
     let barrier_sets =
       [
        "DMB",is_barrier (DMB SY);
+       "DMB.ISH",is_barrier (DMB ISH);
        "DSB",is_barrier (DSB SY);
        "DMB.ST",is_barrier (DMB ST);
        "DSB.ST",is_barrier (DSB ST);

--- a/herd/libdir/arm.cat
+++ b/herd/libdir/arm.cat
@@ -42,7 +42,7 @@ let dsb.st=dsb.st & WW
 
 
 (* Common, all arm barriers are strong *)
-let strong = dmb|dsb|dmb.st|dsb.st
+let strong = dmb|dsb|dmb.st|dsb.st|dmb.ish
 let light = 0
 
 include "ppc-checks.cat"

--- a/herd/libdir/armfences.cat
+++ b/herd/libdir/armfences.cat
@@ -4,9 +4,10 @@ ARMFences
 let dmb.st = try fencerel(DMB.ST) with 0
 let dsb.st = try fencerel(DSB.ST) with 0
 let dmb = try fencerel(DMB) with 0
+let dmb.ish = try fencerel(DMB.ISH) with 0
 let dsb = try fencerel(DSB) with 0
 let isb = try fencerel(ISB) with 0
-show dmb.st,dsb.st,dmb,dsb
+show dmb.st,dsb.st,dmb,dsb,dmb.ish
 
 (* Dependencies *)
 show data,addr

--- a/herd/tests/instructions/ARM/A003.litmus
+++ b/herd/tests/instructions/ARM/A003.litmus
@@ -1,0 +1,13 @@
+ARM SB004
+
+(* classic SB004 test, should not see final state in outcomes*)
+{
+0:R2=x; 0:R3=y;
+1:R2=y; 1:R3=x;
+}
+ P0           | P1           ;
+ MOV R0,#1    | MOV R0,#1    ;
+ STR R0,[R2]  | STR R0,[R2]  ;
+ DMB ISH      | DMB ISH      ;
+ LDR R1,[R3]  | LDR R1,[R3]  ;
+exists (0:R1=0 /\ 1:R1=0)

--- a/herd/tests/instructions/ARM/A003.litmus.expected
+++ b/herd/tests/instructions/ARM/A003.litmus.expected
@@ -1,0 +1,12 @@
+Test SB004 Allowed
+States 3
+0:R1=0; 1:R1=1;
+0:R1=1; 1:R1=0;
+0:R1=1; 1:R1=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:R1=0 /\ 1:R1=0)
+Observation SB004 Never 0 3
+Hash=8bd18640a71f5f8da4d4f2fe719284e3
+


### PR DESCRIPTION
Consider the following store buffering litmus test.
The final state should be forbidden under the arm model.
This patch updates the arm model so that the final state is not
observed.
```
{
0:R2=x; 0:R3=y;
1:R2=y; 1:R3=x;
}
 P0           | P1           ;
 MOV R0,#1    | MOV R0,#1    ;
 STR R0,[R2]  | STR R0,[R2]  ;
 DMB ISH      | DMB ISH      ;
 LDR R1,[R3]  | LDR R1,[R3]  ;
exists (0:R1=0 /\ 1:R1=0)
```