### PR TITLE
[herd] add support for asymmetric MTE fault variant

### DIFF
--- a/lib/precision.ml
+++ b/lib/precision.ml
@@ -25,8 +25,8 @@ let default = Handled
 let tags =  ["handled"; "fatal"; "loadsfatal"; "faultToNext"; ]
 
 let parse s = match s with
-  | "imprecise"|"handled" -> Some Handled
-  | "precise"|"fatal" -> Some Fatal
+  | "imprecise"|"handled"|"asynchronous"|"async" -> Some Handled
+  | "precise"|"fatal"|"synchronous"|"sync" -> Some Fatal
   | "loadsfatal"|"asymmetric"|"asym" -> Some LoadsFatal
   | "faulttonext"|"skip" -> Some Skip
   | _ -> None

--- a/lib/precision.ml
+++ b/lib/precision.ml
@@ -15,30 +15,33 @@
 (****************************************************************************)
 
 type t =
-  | Handled (* Do nothing special *)
-  | Fatal   (* Jump to end of code *)
-  | Skip    (* Skip instruction *)
+  | Handled      (* Do nothing special *)
+  | Fatal        (* Jump to end of code *)
+  | LoadsFatal   (* Only faults on loads jump to end of code, stores do nothing *)
+  | Skip         (* Skip instruction *)
 
 let default = Handled
 
-let tags =  ["handled"; "fatal"; "faultToNext"; ]
+let tags =  ["handled"; "fatal"; "loadsfatal"; "faultToNext"; ]
 
 let parse s = match s with
   | "imprecise"|"handled" -> Some Handled
   | "precise"|"fatal" -> Some Fatal
+  | "loadsfatal"|"asymmetric"|"asym" -> Some LoadsFatal
   | "faulttonext"|"skip" -> Some Skip
   | _ -> None
 
 let pp = function
   | Handled -> "handled"
   | Fatal -> "fatal"
+  | LoadsFatal -> "loadsfatal"
   | Skip -> "faulToNext"
 
 let is_fatal = function
   | Fatal -> true
-  | Handled|Skip -> false
+  | Handled|LoadsFatal|Skip -> false
 
 let is_skip = function
   | Skip -> true
-  | Handled|Fatal -> false
+  | Handled|Fatal|LoadsFatal -> false
 

--- a/lib/precision.mli
+++ b/lib/precision.mli
@@ -17,9 +17,10 @@
 (** Reaction to faults, tag common to litmus and herd *)
 
 type t =
-  | Handled (* Do nothing special *)
-  | Fatal   (* Jump to end of code *)
-  | Skip    (* Skip instruction *)
+  | Handled      (* Do nothing special *)
+  | Fatal        (* Jump to end of code *)
+  | LoadsFatal   (* Only faults on loads jump to end of code, stores do nothing *)
+  | Skip         (* Skip instruction *)
 
 val default : t
 val tags : string list


### PR DESCRIPTION
MTE provides an asymmetric mode for detecting tag check failures. In particular, when such a mode is configured, only tag checks for load operations are handled in a synchronous (precise) fashion, whereas stores happen asynchronously (imprecise).

This has implications on memory ordering, in that tag checks on loads need to abort execution on the given instruction, but the checks on stores complete asynchronously and the tag check may yet fail at some later time. This can result in different output states from a litmus test running in asymmetric mode depending on the orderings of loads/stores.

An example test that shows such properties is the following:

```
AArch64 MTE-asymmetric
{
0:X0=y:red; 0:X4=x:red; 0:X5=x:green; 0:X6=y:green;
}
 P0                 ;
 MOV W2,#1          ;
 STR W2,[X5]        ;
 STR W2,[X0]        ;
 LDR W3,[X6]        ;
 LDR W1,[X4]        ;
exists 0:X3=1 /\ 0:X1=0 /\ fault(P0,y) /\ fault (P0,x)
```

The following test is interesting, in that asymmetric mode allows the first two stores to retire before their tag check completes, but the subsequent tag checks on the final LDR of x will always give a synchronous fault. We can use the LDR on y to observe that the store has gone through successfully, but it also has another useful property in that the litmus test returns a single unique state per MTE fault mode.

The following pull requests implements the required logic to model asymmetric faults in herd7. Running the above litmus test through herd7 in the three modes (including the new asymmetric one) gives the following states:

Asymmetric (-variant memtag,asym):

```
States 1
0:X1=0; 0:X3=1; Fault(P0,x:red); Fault(P0,y:red);
Ok
Witnesses
Positive: 1 Negative: 0
```

Asynchronous (-variant memtag,async):

```
States 1
0:X1=1; 0:X3=1; Fault(P0,x:red); Fault(P0,y:red);
No
Witnesses
Positive: 0 Negative: 1
```

Synchronous (-variant memtag,sync):

```
States 1
0:X1=0; 0:X3=0; Fault(P0,y:red); ~Fault(P0,x);
No
Witnesses
Positive: 0 Negative: 1
```

As you can see, the condition clause is constructed in such a way in that the litmus test is only positive when ran in asymmetric mode.

This pull request also includes a commit to support optional semantics for the AArch64 naming of the MTE fault modes, allowing for sync/synchronous to be used in the place of the precise variant and async/asynchronous to be used in the place of imprecise. My main justification behind this is because the generic name that I came up with of loadsfatal is a bit ambiguous, whereas asymmetric at least matches the architectural name and therefore it seemed to make sense to add support for the equivalent for the other tag check modes. Happy to discuss any better ideas.