### PR TITLE
[catalogue] Fix two MTE shelf files

### DIFF
--- a/catalogue/aarch64-MTE-mixed/shelf.py
+++ b/catalogue/aarch64-MTE-mixed/shelf.py
@@ -1,7 +1,7 @@
 record = "AArch64"
 
 cats = [
-    "cats/aarch64-MTE.cat",
+    "cats/aarch64.cat",
     ]
 
 cfgs = [

--- a/catalogue/aarch64-MTE-pick/shelf.py
+++ b/catalogue/aarch64-MTE-pick/shelf.py
@@ -1,7 +1,7 @@
 record = "AArch64-MTE-Pick"
 
 cats = [
-    "cats/aarch64-pick.cat",
+    "cats/aarch64.cat",
     ]
 
 cfgs = [


### PR DESCRIPTION
All MTE books in catalogue use the default aarch64.cat model