### PR TITLE
[litmus] Fix storage class of some variable in C output

### DIFF
--- a/litmus/dumpRun.ml
+++ b/litmus/dumpRun.ml
@@ -696,9 +696,9 @@ let dump_c_cont xcode arch sources utils nts =
             (fun k sz ->
               let open Topology in
               O.o "" ;
-              O.f "const int *inst_%d;" k ;
-              O.f "const int *role_%d;" k ;
-              O.f "const char **group_%d;" k ;
+              O.f "extern const int *inst_%d;" k ;
+              O.f "extern const int *role_%d;" k ;
+              O.f "extern const char **group_%d;" k ;
               O.f "#define scansz_%d %d" k sz.scansz ;
               O.f "#define scanline_%d %d" k sz.scanline)
             m)

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -309,7 +309,7 @@ module Make
           O.o "" ;
           if do_precise then begin
             O.o "#define PRECISE 1" ;
-            O.o "ins_t *label_ret[NTHREADS];" ;
+            O.o "static ins_t *label_ret[NTHREADS];" ;
             O.o ""
           end else if do_skip then begin
             O.o "#define FAULT_SKIP 1" ;


### PR DESCRIPTION
Compilation on M1 (`-mode kvm`) reveals some small problems that had long been overlooked.