### PR TITLE
[gen] Add -minrelax <n> option to the diy tool.

### DIFF
--- a/doc/gen.tex
+++ b/doc/gen.tex
@@ -1539,6 +1539,10 @@ separated list of candidate relaxations.
 In mix mode, upper bound on the number of different candidate
 relaxations tested together.
 Default is~$100$
+\item[{\tt -minrelax <n>}]
+In mix mode, lower bound on the number of different candidate
+relaxations tested together.
+Default is~$1$. Bounds are included: `-minrelax 3 -maxrelax 3` produces tests from cycles with exactly three different candidate relaxations. Notice that each of the different canidate relaxations can be repeated.
 \item[{\tt -safe <relax-list>}] Set safe list. Default is empty.
 \item[{\tt -mode (critical|sc|free|uni)}]
 Control generation  of cycles, default~\opt{sc}.

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -24,6 +24,7 @@ module type AltConfig = sig
   val max_ins : int
   val mix : bool
   val max_relax : int
+  val min_relax : int
   val choice : check
   type relax
   val prefix : relax list list
@@ -465,7 +466,8 @@ module Make(C:Builder.S)
           call_rec prefix
             (fun po_safe suff k ->
               let rs = extract_relaxs suff in
-              if List.length rs > O.max_relax then k
+              let nrs = List.length rs in
+              if nrs > O.max_relax || nrs < O.min_relax then k
               else f rs po_safe suff k)
             aset po_safe in
 
@@ -507,7 +509,8 @@ module Make(C:Builder.S)
       | [] ->
           no_relax safe n [] k
       | _  ->
-          if O.mix && O.max_relax > 1 then
+         if O.mix && O.max_relax < 1 then k (* Let us stay logical *)
+          else if O.mix && O.max_relax > 1 then
             all_relax k
           else
             choose_relax relax k

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -22,6 +22,8 @@ module type AltConfig = sig
   include DumpAll.Config
   val upto : bool
   val max_ins : int
+  val mix : bool
+  val max_relax : int
   val choice : check
   type relax
   val prefix : relax list list
@@ -463,7 +465,7 @@ module Make(C:Builder.S)
           call_rec prefix
             (fun po_safe suff k ->
               let rs = extract_relaxs suff in
-              if List.length rs > !Config.max_relax then k
+              if List.length rs > O.max_relax then k
               else f rs po_safe suff k)
             aset po_safe in
 
@@ -505,7 +507,7 @@ module Make(C:Builder.S)
       | [] ->
           no_relax safe n [] k
       | _  ->
-          if !Config.mix && !Config.max_relax > 1 then
+          if O.mix && O.max_relax > 1 then
             all_relax k
           else
             choose_relax relax k

--- a/gen/config.ml
+++ b/gen/config.ml
@@ -37,6 +37,7 @@ let mix = ref false
 let max_ins = ref 4
 let eprocs = ref false
 let max_relax = ref 100
+let min_relax = ref 1
 type 'a cumul = Empty | All | Set of 'a
 let cumul = ref All
 let poll = ref false
@@ -283,7 +284,9 @@ let speclist () =
     sprintf
       "<bool> mix relaxations when several are given (default %b)" !mix)::
    ("-maxrelax",   Arg.Int (fun n -> mix := true ; max_relax := n),
-    sprintf "<n> test relaxation together up to <n> (default %i). Implies -mix true " !max_relax)::
+    sprintf "<n> test  up to <n> different relaxations together (default %i). Implies -mix true " !max_relax)::
+   ("-minrelax",   Arg.Int (fun n -> mix := true ; min_relax := n),
+    sprintf "<n> test relaxations considering <n> or more different relaxations (default %i). Implies -mix true " !max_relax)::
    ("-safe", Arg.String (fun s -> safes := Some s),
     "<relax-list> specify a safe list")::
    ("-relaxlist", Arg.String (fun s -> safes := Some s),

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -53,6 +53,7 @@ let parse_fences fs = List.fold_right parse_fence fs []
     type relax = C.R.relax
     let mix = !Config.mix
     let max_relax = !Config.max_relax
+    let min_relax = !Config.min_relax
 
     let prefix =
       match List.map parse_relaxs O.prefix with

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -51,6 +51,8 @@ let parse_fences fs = List.fold_right parse_fence fs []
     include O
 
     type relax = C.R.relax
+    let mix = !Config.mix
+    let max_relax = !Config.max_relax
 
     let prefix =
       match List.map parse_relaxs O.prefix with


### PR DESCRIPTION
The new option defines a lower bound for the number of _different_ relaxation candidates that are tested together in `-mix true` mode. It complements the `-maxrelax <n>` options.  Notice that lower and upper bounds are included. As consequence, one tests exactly two candidate relaxations together with `-minrelax 2 -maxrelax 2`.