### PR TITLE
[herd] Replace `I` by `IW` in cat files.

### DIFF
--- a/herd/libdir/c11_base.cat
+++ b/herd/libdir/c11_base.cat
@@ -13,7 +13,7 @@ include "c11_cos.cat"
 include "c11_los.cat"
 
 
-let asw = I * (M \ I)
+let asw = IW * (M \ IW)
 let sb = po
 let mo = co
 

--- a/herd/libdir/simple-c11.cat
+++ b/herd/libdir/simple-c11.cat
@@ -16,7 +16,7 @@ let crel_id = toid(CREL)
 let cacq_id = toid(CACQ)
 let sc_id = toid(SC)
 
-let asw = I * (M \ I)
+let asw = IW * (M \ IW)
 
 include "filters.cat"
 include "cos.cat"

--- a/herd/libdir/stdlib.cat
+++ b/herd/libdir/stdlib.cat
@@ -77,5 +77,3 @@ let map f =
   do_map
 
 let LKW = try LKW with emptyset
-
-show (si \ id) \ (I * I) as si


### PR DESCRIPTION
This commit fixes a regression by completing commit 9076daa680e4ea550d135837f3940dc9c3e9ed38.