### PR TITLE
[gen]: Replace atomic_load gen with atomic_load_explicit

### DIFF
--- a/gen/CCompile_gen.ml
+++ b/gen/CCompile_gen.ml
@@ -857,8 +857,6 @@ module Make(O:Config) : Builder.S
         | AddZero (e,loc) ->
             sprintf "%s + (%s & 128)"
               (dump_exp e) (dump_loc_exp loc)
-        | AtomicLoad (MemOrder.SC,loc) ->
-            sprintf "atomic_load(%s)" (dump_exp loc)
         | AtomicLoad (mo,loc) ->
             sprintf "atomic_load_explicit(%s,%s)"
               (dump_exp loc) (dump_mem_order mo)
@@ -902,9 +900,6 @@ module Make(O:Config) : Builder.S
               (A.dump_typ t) (A.dump_reg r) (dump_exp e)
         | Store (loc,e) ->
             fx chan i "*%s = %s;" (dump_left_val loc) (dump_exp e)
-        | AtomicStore (MemOrder.SC,loc,e) ->
-            fx chan i "atomic_store(%s,%s);"
-              (dump_exp loc) (dump_exp e)
         | SetReg (r,e) ->
             fx chan i "%s = %s;" (A.dump_reg r) (dump_exp e)
         | AtomicStore (mo,loc,e) ->


### PR DESCRIPTION
`atomic_load(x)` is a shortcut for
`atomic_load_explicit(x,memory_order_seq_cst)`

diy generates `atomic_load(x)` calls, however herd does not accept
`atomic_load`, erroring with a message "Macro call atomic_load in CSem"

This patch ensures diy generates `atomic_load_explict(x, seq_cst)` instead
of `atomic_load` so that there is a greater match of tests generated by
diy and tests accepted by Herd