### PR TITLE
[litmus] Add support for custom fault handlers

### DIFF
--- a/herd/loader.ml
+++ b/herd/loader.ml
@@ -77,7 +77,7 @@ struct
   let load prog =
     let rec load_iter num = function
     | [] -> Label.Map.empty,[],IntMap.empty,num
-    | ((proc,_),code)::prog ->
+    | ((proc,_,_),code)::prog ->
       let addr = 1000 * (proc+1) in
       let mem,starts,rets,new_num = load_iter num prog in
       let fin_mem,start,fin_rets,fin_num = load_code proc addr mem rets new_num code in

--- a/herd/test_herd.ml
+++ b/herd/test_herd.ml
@@ -165,7 +165,7 @@ module Make(A:Arch_herd.S) =
       let proc_info =
         let m =
           List.fold_left
-            (fun m ((p,ao),_) -> match ao with
+            (fun m ((p,ao,_),_) -> match ao with
             | None -> m
             | Some ans ->
                 List.fold_left

--- a/jingle/cDumper.ml
+++ b/jingle/cDumper.ml
@@ -145,7 +145,7 @@ let extract_decl init i prog =
 
 let code init prog =
   let open CAst in
-  List.map (fun ((i,_),p) ->
+  List.map (fun ((i,_,_),p) ->
 	    let params = get_params init i in
 	    let decls =  extract_decl init i (unwrap_pseudo p)
 	    in Test { proc = i;

--- a/jingle/mapping.ml
+++ b/jingle/mapping.ml
@@ -231,7 +231,7 @@ module Make(C:Config) = struct
     (pseudo_p,env)
 
   let reg_mapping =
-    List.map (fun ((i,_),(b,_)) ->
+    List.map (fun ((i,_,_),(b,_)) ->
       (i,
        (List.map (fun (sr,tr) ->
          (Source.pp_reg sr,Target.pp_reg tr))
@@ -239,7 +239,7 @@ module Make(C:Config) = struct
 
   let addr_init =
     let open MiscParser in
-    List.fold_left (fun acc ((i,_),(b,_)) ->
+    List.fold_left (fun acc ((i,_,_),(b,_)) ->
       acc@
       (List.map (fun (sa,tr) ->
         (Location_reg(i,Target.pp_reg tr),

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -484,6 +484,8 @@ rule token = parse
 | '#'? ('-' ? num as x) { NUM (int_of_string x) }
 | 'P' (num as x)
     { PROC (int_of_string x) }
+| 'P' (num as x) ".F"
+    { PROCFH (int_of_string x) }
 | ['w''W']'%' (name as name) { SYMB_WREG name }
 | ['x''X']?'%' (name as name) { SYMB_XREG name }
 | ['c''C']?'%' (name as name) { SYMB_CREG name }

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -108,7 +108,7 @@ let check_op3 op kr =
 %token STG STZG LDG
 %token ALIGND ALIGNU BUILD CHKEQ CHKSLD CHKTGD CLRTAG CPY CPYTYPE CPYVALUE CSEAL
 %token LDCT SEAL STCT UNSEAL
-%type <(int * string list option) list * (AArch64Base.parsedPseudo) list list * MiscParser.extra_data> main
+%type <MiscParser.proc list * (AArch64Base.parsedPseudo) list list * MiscParser.extra_data> main
 %type <AArch64Base.parsedPseudo list> instr_option_seq
 
 %start  main

--- a/lib/ARMParser.mly
+++ b/lib/ARMParser.mly
@@ -51,7 +51,7 @@ semi_opt:
 
 proc_list:
 | ps=separated_nonempty_list(PIPE,PROC) SEMI
-    { List.map (fun p -> p,None) ps }
+    { List.map (fun p -> p,None,MiscParser.Main) ps }
 
 iol_list :
 |  instr_option_list SEMI

--- a/lib/CGenParser_lib.ml
+++ b/lib/CGenParser_lib.ml
@@ -167,7 +167,7 @@ module Do
             fname in
         List.map (L.macros_expand ms) in
 
-    let prog =  List.map (fun p -> (p.CAst.proc,None),expand_body p.CAst.body) prog in
+    let prog =  List.map (fun p -> (p.CAst.proc,None,MiscParser.Main),expand_body p.CAst.body) prog in
 (*
     List.iter
       (fun (p,code) ->

--- a/lib/MIPSParser.mly
+++ b/lib/MIPSParser.mly
@@ -52,7 +52,7 @@ semi_opt:
 
 proc_list:
 | ps=separated_nonempty_list(PIPE,PROC) SEMI
-  { List.map (fun p -> p,None) ps }
+  { List.map (fun p -> p,None,MiscParser.Main) ps }
 
 iol_list :
 |  instr_option_list SEMI

--- a/lib/PPCParser.mly
+++ b/lib/PPCParser.mly
@@ -61,7 +61,7 @@ main:
 
 proc_list:
 | ps=separated_nonempty_list(PIPE,PROC) SEMI
-  { List.map (fun p -> p,None) ps }
+  { List.map (fun p -> p,None,MiscParser.Main) ps }
 
 semi_opt:
 | { () }

--- a/lib/RISCVParser.mly
+++ b/lib/RISCVParser.mly
@@ -63,7 +63,7 @@ semi_opt:
 
 proc_list:
 | ps=separated_nonempty_list(PIPE,PROC) SEMI
-  { List.map (fun p -> p,None) ps }
+  { List.map (fun p -> p,None,MiscParser.Main) ps }
 
 iol_list :
 |  instr_option_list SEMI

--- a/lib/X86Parser.mly
+++ b/lib/X86Parser.mly
@@ -47,8 +47,8 @@ semi_opt:
 | SEMI { () }
 
 proc_list:
-| PROC SEMI  {[$1,None]}
-| PROC PIPE proc_list  { ($1,None)::$3 }
+| PROC SEMI  {[$1,None,MiscParser.Main]}
+| PROC PIPE proc_list  { ($1,None,MiscParser.Main)::$3 }
 
 iol_list :
 |  instr_option_list SEMI

--- a/lib/X86_64Parser.mly
+++ b/lib/X86_64Parser.mly
@@ -60,8 +60,8 @@ semi_opt:
 | SEMI { () }
 
 proc_list:
-| PROC SEMI  {[$1,None]}
-| PROC PIPE proc_list  { ($1,None)::$3 }
+| PROC SEMI  {[$1,None,MiscParser.Main]}
+| PROC PIPE proc_list  { ($1,None,MiscParser.Main)::$3 }
 
 iol_list :
 |  instr_option_list SEMI

--- a/lib/genParser.ml
+++ b/lib/genParser.ml
@@ -88,13 +88,21 @@ module Make
 (************************)
 
     let check_procs procs =
-      Misc.iteri
-        (fun k (p,_) ->
-          if k <> p then
-            Warn.fatal "Processes must be P0, P1, ...")
-        procs
+      let rec iter_rec i xs = match xs with
+        | [] -> ()
+        | (p,_,MiscParser.Main)::xs ->
+           if i = p then
+             iter_rec (i + 1) xs
+           else
+             Warn.fatal "Processes must be P0, P1, ..."
+        | (p,_,MiscParser.FaultHandler)::xs ->
+           if i >= p then
+             iter_rec i xs
+           else
+             Warn.fatal "Fault Handler for an undefined process"
+      in iter_rec 0 procs
 
- let check_regs procs = U.check_regs (List.map fst procs)
+ let check_regs procs = U.check_regs (List.map (fun (p,_,_) -> p) procs)
 
 (*******************)
 (* Macro expansion *)

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -18,11 +18,15 @@
 
 open Printf
 
-type proc = int * string list option
+type func = Main | FaultHandler
+type proc = Proc.t * string list option * func
 
-let pp_proc (p,ao) =
+let pp_proc (p,ao,f) =
   sprintf
-    "P%i%s" p
+    "P%i%s%s" p
+    (match f with
+     | Main -> ""
+     | FaultHandler -> ".F")
     (match ao with
     | None -> ""
     | Some a -> sprintf ":%s" (String.concat "," a))

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -17,7 +17,8 @@
 (** The basic types of architectures and semantics, just parsed *)
 
 (* Processor name with optional annotations *)
-type proc = int * string list option
+type func = Main | FaultHandler
+type proc = Proc.t * string list option * func
 
 val pp_proc : proc -> string
 

--- a/lib/procRules.mly
+++ b/lib/procRules.mly
@@ -16,13 +16,16 @@
 (****************************************************************************)
 %}
 
+%token <int> PROCFH
+
 %%
 
 proc_annot:
 | COLON os=separated_list(COMMA,NAME) { os }
 
 proc_annotated:
-| p=PROC os=option(proc_annot) { p,os }
+| p=PROCFH os=option(proc_annot) { p,os,MiscParser.FaultHandler }
+| p=PROC os=option(proc_annot) { p,os,MiscParser.Main }
 
 %public proc_list:
 | separated_nonempty_list(PIPE,proc_annotated) SEMI { $1 }

--- a/lib/symbReg.ml
+++ b/lib/symbReg.ml
@@ -223,7 +223,7 @@ and type pseudo = A.pseudo
     (* Perform allocation of symbolic registers to real ones *)
     let envs =
       List.map2
-	(fun ((p,_),_) (regs_p,symbs_p) ->
+	(fun ((p,_,_),_) (regs_p,symbs_p) ->
 	  let regs_cstr =
 	    ProcRegSet.fold
 	      (fun (q,reg) k ->

--- a/litmus/ARMCompile_litmus.ml
+++ b/litmus/ARMCompile_litmus.ml
@@ -209,6 +209,8 @@ module Make(V:Constant.S)(C:Config) =
 
     let user_mode = [] and kernel_mode = []
 
+    let fault_handler_prologue = [] and fault_handler_epilogue = []
+
     let compile_ins tr_lab ins k = match ins with
     | I_NOP -> { empty_ins with memo = "nop"; }::k
 (* Arithmetic *)

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -113,7 +113,7 @@ module RegMap = A.RegMap)
 
       let dump_inputs args0 compile_val chan t trashed =
         let stable = RegSet.of_list t.Tmpl.stable in
-        let all = Tmpl.all_regs t in
+        let all = Tmpl.all_regs t.Tmpl.code t.Tmpl.final in
         let init_set =
             (List.fold_right
                (fun (reg,_) -> RegSet.add reg) t.Tmpl.init RegSet.empty) in
@@ -191,7 +191,7 @@ module RegMap = A.RegMap)
         let final = RegSet.of_list t.Tmpl.final in
         if debug then
           eprintf "P%i: stable={%s}, final={%s}, all={%s}\n"
-            proc (pp_regs stable) (pp_regs final) (pp_regs (Tmpl.all_regs t));
+            proc (pp_regs stable) (pp_regs final) (pp_regs (Tmpl.all_regs t.Tmpl.code t.Tmpl.final));
         let outs =
           String.concat ","
             (List.fold_right

--- a/litmus/CTarget.ml
+++ b/litmus/CTarget.ml
@@ -45,3 +45,5 @@ let get_addrs_only t = List.map fst t.inputs
 let get_addrs t = get_addrs_only t,[]
 
 let out_code chan code = Printf.fprintf chan "%s\n" code
+
+let has_fault_handler _ = false

--- a/litmus/CTarget.mli
+++ b/litmus/CTarget.mli
@@ -37,3 +37,4 @@ val get_nnops : t -> int
 val get_addrs_only : t -> string list
 val get_addrs : t -> string list * string list
 val out_code : out_channel -> code -> unit
+val has_fault_handler : t -> bool

--- a/litmus/LISACompile.ml
+++ b/litmus/LISACompile.ml
@@ -86,8 +86,9 @@ module Make(V:Constant.S) =
             let m,i = compile_roi roi in
             add_par (reg_to_string r ^ "+" ^ m),r::i,[r,type_vo vo]
 
-    let user_mode = []
-    and kernel_mode = []
+    let user_mode = [] and kernel_mode = []
+
+    let fault_handler_prologue = [] and fault_handler_epilogue = []
 
     let compile_ins tr_lab ins k =
     match ins with

--- a/litmus/LISALang.ml
+++ b/litmus/LISALang.ml
@@ -45,7 +45,7 @@ module Make(V:Constant.S) = struct
         dump_ins (k+1) ts in
 (* Prefix *)
     let reg_env = Tmpl.get_reg_env A.I.error A.I.warn t in
-    let all_regs = Tmpl.all_regs t in
+    let all_regs = Tmpl.all_regs t.Tmpl.code t.Tmpl.final in
     let init =
       List.fold_left (fun m (r,v) -> RegMap.add r v m)
         RegMap.empty

--- a/litmus/MIPSCompile_litmus.ml
+++ b/litmus/MIPSCompile_litmus.ml
@@ -113,6 +113,8 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
 
     let user_mode = [] and kernel_mode = []
 
+    let fault_handler_prologue = [] and fault_handler_epilogue = []
+
     let compile_ins tr_lab ins k = match ins with
     | NOP -> { empty_ins with memo = "nop"; }::k
     | LI (r,i) -> li r i::k

--- a/litmus/PPCCompile_litmus.ml
+++ b/litmus/PPCCompile_litmus.ml
@@ -221,6 +221,8 @@ module Make(V:Constant.S)(C:Config) =
 
     let user_mode = [] and kernel_mode = []
 
+    let fault_handler_prologue = [] and fault_handler_epilogue = []
+
     let do_compile_ins tr_lab ins k = match tr_ins ins with
     | Pnop -> { empty_ins with memo="nop"; }::k
     | Pmr (rD,rS) -> mr rD rS::k

--- a/litmus/RISCVCompile_litmus.ml
+++ b/litmus/RISCVCompile_litmus.ml
@@ -69,6 +69,8 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
 
     let user_mode = [] and kernel_mode = []
 
+    let fault_handler_prologue = [] and fault_handler_epilogue = []
+
     let compile_ins tr_lab ins k = match ins with
     | A.INop -> { empty_ins with memo="nop"; }::k
     | A.OpI (op,r1,r2,i) ->

--- a/litmus/X86Compile_litmus.ml
+++ b/litmus/X86Compile_litmus.ml
@@ -236,6 +236,8 @@ module Make(V:Constant.S)(O:Arch_litmus.Config) =
 
     let user_mode = [] and kernel_mode = []
 
+    let fault_handler_prologue = [] and fault_handler_epilogue = []
+
     let rec do_compile_ins tr_lab ins = match ins with
     | I_NOP ->
         { empty_ins with memo = "nop"; }

--- a/litmus/X86_64Compile_litmus.ml
+++ b/litmus/X86_64Compile_litmus.ml
@@ -262,6 +262,8 @@ module Make(Cfg:Config)(V:Constant.S)(O:Arch_litmus.Config) =
 
     let user_mode = [] and kernel_mode = []
 
+    let fault_handler_prologue = [] and fault_handler_epilogue = []
+
     let rec do_compile_ins tr_lab ins = match ins with
     | I_NOP ->
         { empty_ins with memo = "nop"; }

--- a/litmus/XXXCompile_litmus.mli
+++ b/litmus/XXXCompile_litmus.mli
@@ -24,6 +24,8 @@ module type S = sig
   val emit_loop : A.Out.ins list -> A.Out.ins list
   val user_mode : A.Out.ins list
   val kernel_mode : A.Out.ins list
+  val fault_handler_prologue : A.Out.ins list
+  val fault_handler_epilogue : A.Out.ins list
   val compile_ins :
       (Label.t -> string) ->
         A.instruction ->  A.Out.ins list -> A.Out.ins list

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -752,7 +752,7 @@ type P.code = MiscParser.proc * A.pseudo list)
             StringMap.empty (InfoAlign.parse ps)
         with Not_found -> StringMap.empty in
       let ty_env = ty_env1,ty_env2 in
-      let code = List.map (fun ((p,_),c) -> p,c) code in
+      let code = List.map (fun ((p,_,_f),c) -> p,c) code in
       let label_init = A.get_label_init initenv in
       let code =
         if do_self || is_pte || Misc.consp label_init then

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -767,7 +767,7 @@ type P.code = MiscParser.proc * A.pseudo list)
           let rs =
             List.fold_left
               (fun k r -> match A.parse_reg r with
-              | None -> Warn.warn_always "'%s' i snot a register" r ; k
+              | None -> Warn.warn_always "'%s' is not a register" r ; k
               | Some r -> r::k)
               [] rs in
           A.RegSet.of_list rs in

--- a/litmus/language.ml
+++ b/litmus/language.ml
@@ -26,7 +26,7 @@ module type S = sig
     CType.t RegMap.t ->
     (string * CType.t) list ->
     string list ->
-    int ->
+    Proc.t ->
     t ->
     unit
 
@@ -39,7 +39,7 @@ module type S = sig
     CType.t RegMap.t ->
     ((string * CType.t) list * (string * CType.t) list) ->
     string list ->
-    int ->
+    Proc.t ->
     t ->
     unit
 
@@ -50,7 +50,7 @@ module type S = sig
     CType.t RegMap.t ->
     ((string * CType.t) list * (string * CType.t) list) ->
     string list ->
-    int ->
+    Proc.t ->
     t ->
     unit
 end

--- a/litmus/libdir/_show.awk
+++ b/litmus/libdir/_show.awk
@@ -1,2 +1,2 @@
 /START _litmus_P/ { print $0 }
-/_litmus_P[0-9]+_[0-9]+/ { getline; print $0 ; }
+/_litmus_P[0-9]+(\.F)?_[0-9]+/ { getline; print $0 ; }

--- a/litmus/litmusUtils.ml
+++ b/litmus/litmusUtils.ml
@@ -74,13 +74,13 @@ module Pseudo(A:Arch_litmus.S) = struct
     let pp = List.map dump_prog prog in
     Misc.pp_prog chan pp
 
-  let rec find_code p = function
+  let rec find_code p func = function
     | [] -> assert false
-    | ((q,_),is)::rem ->
-        if Misc.int_eq p q then is else find_code p rem
+    | ((q,_,f),is)::rem ->
+        if Proc.equal p q && f = func then is else find_code p func rem
 
-  let find_offset code p lbl =
-    let is = find_code p code in
+  let find_offset code p f lbl =
+    let is = find_code p f code in
     A.find_offset lbl is
 
   let code_exists p (_,c) = A.code_exists p c

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1581,7 +1581,7 @@ module Make
               | None ->
                   O.fii "labels.%s = (ins_t *) &&CODE%d;" (tag_code f) p
               | Some lbl ->
-                  let off = U.find_label_offset p lbl test in
+                  let off = U.find_label_offset p MiscParser.Main lbl test in
                   O.fii "labels.%s = ((ins_t *)&&CODE%d) + %d;" (tag_code f) p off)
               faults ;
             O.oi "}" ;
@@ -1662,7 +1662,7 @@ module Make
               List.iter
                 (fun ((p,lbl),_ as f) ->
                   let lbl = Misc.as_some lbl in
-                  let off = U.find_label_offset p lbl test+1 in (* +1 because of added inital nop *)
+                  let off = U.find_label_offset p MiscParser.Main lbl test+1 in (* +1 because of added inital nop *)
                   let lhs = sprintf "labels.%s" (tag_code f)
                   and rhs =
                     sprintf "((ins_t *)%s)+find_ins(nop,(ins_t *)%s,0)+%d"

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -279,6 +279,8 @@ module Make
       and tag_log f =  SkelUtil.dump_fatom_tag A.V.pp_v_old f
       and dump_addr_idx s = sprintf "_idx_%s" s
 
+      let has_custom_fault_handlers test =
+        List.exists (fun (_p,(code,_)) -> A.Out.has_fault_handler code) test.T.code
 
       let dump_fault_handler doc test =
         if have_fault_handler then begin
@@ -1286,6 +1288,8 @@ module Make
           (_vars,inits) (proc,(out,(_outregs,envVolatile)))  =
         let user_mode = List.exists (Proc.equal proc) procs_user in
         if dbg then eprintf "P%i: inits={%s}\n" proc (String.concat "," inits) ;
+        if Misc.consp faults && has_custom_fault_handlers test then
+          Warn.user_error "Post condition cannot check for faults when using custom fault handlers" ;
         let have_faults = have_fault_handler && Misc.consp faults in
         let my_regs = U.select_proc proc env in
         let addrs = A.Out.get_addrs_only out in (* accessed in code *)

--- a/litmus/pseudoAbstract.mli
+++ b/litmus/pseudoAbstract.mli
@@ -18,7 +18,7 @@ module type S = sig
   type ins
   type code
 
-  val find_offset : code list -> int -> string -> int
+  val find_offset : code list -> Proc.t -> MiscParser.func -> string -> int
   val dump_prog : code -> string list
   val print_prog : out_channel -> code list -> unit
   val dump_prog_lines : code list -> string list

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -133,7 +133,7 @@ module Make
       val pte_in_outs : env -> T.t -> bool
       val ptr_pte_in_outs : env -> T.t -> bool
       val get_faults : T.t -> A.V.v Fault.atom list
-      val find_label_offset : Proc.t -> string -> T.t -> int
+      val find_label_offset : Proc.t -> MiscParser.func -> string -> T.t -> int
 
 (* Instructions *)
       val do_store : CType.t -> string -> string -> string
@@ -445,9 +445,9 @@ module Make
         and inf = test.T.ffaults in
         inc@inf
 
-      let find_label_offset p lbl test =
+      let find_label_offset p f lbl test =
         try
-          T.find_offset test.T.src.MiscParser.prog p lbl
+          T.find_offset test.T.src.MiscParser.prog p f lbl
         with Not_found ->
           let v = Constant.Label (p,lbl) in
           Warn.user_error "Non-existant label %s" (A.V.pp_v v)
@@ -537,7 +537,7 @@ module Make
           match lbls with
           | [] -> ()
           | _::_ ->
-              let find p lbl = find_label_offset p lbl test in
+              let find p lbl = find_label_offset p MiscParser.Main lbl test in
               List.iter
                 (fun (p,lbl) ->
                   let off = find p lbl in

--- a/litmus/target.mli
+++ b/litmus/target.mli
@@ -28,4 +28,5 @@ module type S = sig
   val addr_cpy_name : string -> int -> string
   val dump_v : V.v -> string
   val dump_init_val : V.v -> string
+  val has_fault_handler : t -> bool
 end

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -120,6 +120,8 @@ module type S = sig
       (CType.t -> CType.t -> bool)-> (* fail *)
         (CType.t -> CType.t -> bool)->  (* warn *)
           t -> CType.t RegMap.t
+
+  val has_fault_handler : t -> bool
 end
 
 module Make(O:Config)(A:I) =
@@ -416,4 +418,5 @@ module Make(O:Config)(A:I) =
           m tst.code in
       m
 
+    let has_fault_handler t = t.fhandler <> []
   end

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -80,6 +80,7 @@ module type S = sig
       stable : arch_reg list; (* stable registers, ie must be self-allocated by gcc *)
       final : arch_reg list ;
       code : ins list;
+      fhandler : ins list ;
       name : Name.t ;
       all_clobbers : arch_reg list;
       nrets : int ; (* number of return instruction in code *)
@@ -158,6 +159,7 @@ module Make(O:Config)(A:I) =
         stable : arch_reg list;
         final : arch_reg list ;
         code : ins list;
+        fhandler : ins list ;
         name : Name.t ;
         all_clobbers : arch_reg list;
         nrets : int ; nnops : int ;

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -113,7 +113,7 @@ module type S = sig
   module RegSet : MySet.S with type elt = arch_reg
   module RegMap : MyMap.S with type key = arch_reg
 
-  val all_regs : t -> RegSet.t
+  val all_regs : ins list -> arch_reg list -> RegSet.t
   val trashed_regs : t -> RegSet.t
   val get_reg_env :
       (CType.t -> CType.t -> bool)-> (* fail *)
@@ -359,10 +359,10 @@ module Make(O:Config)(A:I) =
     module RegSet = A.RegSet
     module RegMap = A.RegMap
 
-    let all_regs t =
+    let all_regs code final =
       let all_ins ins =
         RegSet.union (RegSet.of_list (ins.inputs@ins.outputs)) in
-      List.fold_right all_ins t.code  (RegSet.of_list t.final)
+      List.fold_right all_ins code  (RegSet.of_list final)
 
 
     let trashed_regs t =

--- a/litmus/test_litmus.ml
+++ b/litmus/test_litmus.ml
@@ -37,7 +37,7 @@ module type S = sig
   type t =
     { init : A.state ;
       info : MiscParser.info ;
-      code : (int * (A.Out.t * (A.reg type_env * env_volatile))) list ;
+      code : (Proc.t * (A.Out.t * (A.reg type_env * env_volatile))) list ;
       condition : C.cond ;
       filter : C.prop option ;
       globals : string type_env ;
@@ -55,7 +55,7 @@ module type S = sig
     with
       type test =  (A.fullstate, P.code list, C.prop, A.location, A.V.v)  MiscParser.result
 
-  val find_offset : P.code list -> int -> string -> int
+  val find_offset : P.code list -> Proc.t -> MiscParser.func -> string -> int
   val code_exists : (P.ins -> bool) -> t -> bool
 end
 
@@ -79,7 +79,7 @@ struct
   type t =
     { init : A.state ;
       info : MiscParser.info ;
-      code : (int * (A.Out.t * (A.reg type_env * env_volatile))) list ;
+      code : (Proc.t * (A.Out.t * (A.reg type_env * env_volatile))) list ;
       condition : C.cond ;
       filter : C.prop option ;
       globals : string type_env ; (* Virtual addresses only *)
@@ -133,7 +133,7 @@ struct
           end)
     end
 
-  let find_offset code p lbl = P.find_offset code p lbl
+  let find_offset = P.find_offset
 
   let code_exists p t =
     let src = t.src in

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -423,6 +423,7 @@ end = struct
           let asmcomment = OT.asmcomment
           let hexa = OT.hexa
           let mode = OT.mode
+          let precision = TestConf.precision
         end in
         let module Cfg = struct
           include OT

--- a/tools/CDumper.ml
+++ b/tools/CDumper.ml
@@ -78,7 +78,7 @@ end = struct
     begin match t.extra_data with
     | CExtra pss ->
         List.iter2
-          (fun ((i,_),code) ps ->
+          (fun ((i,_,_),code) ps ->
             Out.fprintf chan "\nP%i(%s) {\n" i (dump_params ps) ;
             List.iter
               (fun pseudo ->

--- a/tools/alpha.ml
+++ b/tools/alpha.ml
@@ -157,7 +157,7 @@ struct
 
   let rec alpha_prog ma mt apcs pcs = match apcs,pcs with
   | _,[] -> [],ProcRegMap.empty
-  | [],((p,_) as id,c)::pcs ->
+  | [],((p,_,_) as id,c)::pcs ->
       let c,cm =
         alpha_code
           (A.ProcMap.safe_find A.RegSet.empty p ma)
@@ -165,7 +165,7 @@ struct
           [] c in
       let pcs,m = alpha_prog ma mt [] pcs in
       (id,c)::pcs,add_reg_map p cm m
-  | (_,ac)::apcs,((p,_) as id,c)::pcs ->
+  | (_,ac)::apcs,((p,_,_) as id,c)::pcs ->
       let c,cm =
         alpha_code
           (A.ProcMap.safe_find A.RegSet.empty p ma)

--- a/tools/collectRegs.ml
+++ b/tools/collectRegs.ml
@@ -64,7 +64,7 @@ module Make(A:Arch_tools.S) = struct
   let collect t =
     let m =
       List.fold_left
-        (fun m ((p,_),cs) ->
+        (fun m ((p,_,_),cs) ->
           A.ProcMap.add p (collect_code cs) m)
         A.ProcMap.empty t.prog in
     let m = collect_state t.init m in

--- a/tools/mixMerge.ml
+++ b/tools/mixMerge.ml
@@ -168,7 +168,7 @@ end =
 
     let shift_constr k = ConstrGen.map_constr (shift_atom k)
 
-    let shift_prog k prog =  List.map (fun ((i,ao),code) -> (i+k,ao),code) prog
+    let shift_prog k prog =  List.map (fun ((i,ao,func),code) -> (i+k,ao,func),code) prog
 
     let shift k t =
       { t with

--- a/tools/mixPerm.ml
+++ b/tools/mixPerm.ml
@@ -41,9 +41,9 @@ end =
 
     let perm_prog p prog =
       let n = Array.length p in
-      let t = Array.make n ((-1,None),[]) in
+      let t = Array.make n ((-1,None,MiscParser.Main),[]) in
       List.iter
-        (fun ((i,ao),code) -> let idx = p.(i) in t.(idx) <- (idx,ao),code)
+        (fun ((i,ao,f),code) -> let idx = p.(i) in t.(idx) <- (idx,ao,f),code)
         prog ;
       Array.to_list t
 

--- a/tools/mlock.ml
+++ b/tools/mlock.ml
@@ -433,7 +433,7 @@ module Top(O:Config)(Out:OutTests.S) = struct
                 changed := false ;
                 let prog =
                   List.map
-                    (fun ((i,_) as proc,ps) ->
+                    (fun ((i,_,_) as proc,ps) ->
                       let vs,ps = expand_pseudo_code ps in
                       StringSet.fold (fun v k -> Location_reg (i,v)::k) vs [],
                       (proc,ps))

--- a/tools/mrcu.ml
+++ b/tools/mrcu.ml
@@ -210,7 +210,8 @@ module Top
       let tr_test n m u v s c free =
         let rec tr_rec st = function
           | [] -> []
-          | ((p,_) as id,ps)::rem ->
+          | ((p,_,f) as id,ps)::rem ->
+              assert (f = MiscParser.Main) ;
               let st,ps = tr n m u v s c p st ps in
               (id,ps)::tr_rec st rem in
         fun t ->

--- a/tools/prettyProg.ml
+++ b/tools/prettyProg.ml
@@ -138,10 +138,13 @@ module Make(O:Config)(A:Arch_tools.S) =
       let pp_ao = function
         | None -> ""
         | Some a -> ":" ^ String.concat "," a in
-      let pp_proc s chan (p,ao) =
+      let pp_f = function
+        | MiscParser.Main -> ""
+        | MiscParser.FaultHandler -> ".f" in
+      let pp_proc s chan (p,ao,f) =
         let th =
-          if O.texmacros then sprintf "\\myth{%i%s}" p (pp_ao ao)
-          else sprintf "Thread %i%s" p (pp_ao ao) in
+          if O.texmacros then sprintf "\\myth{%i%s%s}" p (pp_ao ao) (pp_f f)
+          else sprintf "Thread %i%s%s" p (pp_ao ao) (pp_f f) in
         fprintf chan
           "\\multicolumn{1}{%sc|}{\\makebox[%s][c]{%s}}"
           s width th in

--- a/tools/transposeDumper.ml
+++ b/tools/transposeDumper.ml
@@ -91,7 +91,7 @@ end = struct
     (* Procs *)
     let prog = t.prog in
     List.iter
-      (fun ((p,_) as proc,code) ->
+      (fun ((p,_,_) as proc,code) ->
         dump_sep chan (MiscParser.pp_proc proc) ;
         begin match dump_proc_state p code t.init with
         | Some st ->


### PR DESCRIPTION
This PR adds support for custom fault handlers in litmus. The fault handler appears in the litmus test as a separate thread. For example:

```
AArch64 MP+dmb.st+RfaultR
Variant=precise
{
[PTE(z)]=(oa:PA(z),valid:0);

0:X1=x; 0:X3=y;
1:X1=y; 1:X3=x; 1:X4=z;
}
 P0          | P1           | P1.F        ;
 MOV W0,#1   | LDR W0,[X1]  | LDR W5,[X3] ;
 STR W0,[X1] |L0:           |             ;
 DMB ST      | LDR W2,[X4]  |             ;
 MOV W2,#1   |              |             ;
 STR W2,[X3] |              |             ;
exists(1:X0=1 /\ 1:X5=0)
```

The fault handler uses the same registers as the main thread. As a result, the initialization can set registers for the fault handler and the post-condition can specify tests for the values of registers as a result of the execution of the fault handler. For the time being and due to the way kvm-unit-tests sets fault (exception) handlers, litmus can supports tests with only one fault handler. 