### PR TITLE
[all]: Add Load Signed Byte/Half Immediate/Register Instructions

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -211,7 +211,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD4 (rs,_,_,_) | I_LD4R (rs,_,_) | I_ST4 (rs,_,_,_)
       | I_LD4M (rs,_,_) | I_ST4M (rs,_,_) ->
           Some (simd_mem_access_size rs)
-      | I_LDRBH (v,_,_,_,_) | I_LDARBH (v,_,_,_)
+      | I_LDRBH (v,_,_,_,_) | I_LDARBH (v,_,_,_) | I_LDRS (_,v,_,_)
       | I_STRBH (v,_,_,_,_) | I_STLRBH (v,_,_) | I_STXRBH (v,_,_,_,_)
       | I_CASBH (v,_,_,_,_) | I_SWPBH (v,_,_,_,_)
       | I_LDOPBH (_,v,_,_,_,_) | I_STOPBH (_,v,_,_,_) ->
@@ -251,6 +251,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_BL _ | I_BLR _ | I_RET _ | I_ERET
         -> [] (* For -variant self only ? *)
       | I_LDR (_,r,_,_,_)|I_LDRBH (_,r,_,_,_)
+      | I_LDRS (_,_,r,_)
       | I_LDUR (_,r,_,_)
       | I_LDAR (_,_,r,_) |I_LDARBH (_,_,r,_)
       | I_SWP (_,_,_,r,_) | I_SWPBH (_,_,_,r,_)
@@ -294,6 +295,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     let get_lx_sz = function
       | I_LDAR (var,(XX|AX),_,_)|I_LDXP (var,_,_,_,_) -> MachSize.Ld (tr_variant var)
       | I_LDARBH (bh,(XX|AX),_,_) -> MachSize.Ld (bh_to_sz bh)
+      | I_LDRS (var,_,_,_) -> MachSize.Ld (tr_variant var)
       | I_STXR _|I_STXRBH _ | I_STXP _ -> MachSize.St
       | I_LDAR (_, (AA|AQ), _, _)|I_LDARBH (_, (AA|AQ), _, _)
       | I_NOP|I_B _|I_BR _|I_BC _|I_CBZ _|I_CBNZ _

--- a/herd/tests/instructions/AArch64/A24.litmus
+++ b/herd/tests/instructions/AArch64/A24.litmus
@@ -1,0 +1,11 @@
+AArch64 A24
+
+(* Tests ldrsb instruction *)
+{ int64_t 0:X0 =1; 0:X1 = x; int8_t x = 127; }
+
+P0;
+  LDRSB X0, [X1];
+  MOV X2, #1;
+  ADD X0, X0, X2;
+
+forall (0:X0=128 /\ [x]=127)

--- a/herd/tests/instructions/AArch64/A24.litmus.expected
+++ b/herd/tests/instructions/AArch64/A24.litmus.expected
@@ -1,0 +1,10 @@
+Test A24 Required
+States 1
+0:X0=128; [x]=127;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=128 /\ [x]=127)
+Observation A24 Always 1 0
+Hash=0cc381c605cf2eb655154d31987318ae
+

--- a/herd/tests/instructions/AArch64/A25.litmus
+++ b/herd/tests/instructions/AArch64/A25.litmus
@@ -1,0 +1,11 @@
+AArch64 A25
+
+(* Tests ldrsh instruction *)
+{ int64_t 0:X0 = 1; 0:X1 = x; int16_t x = 65535; }
+
+P0;
+  LDRSH X0, [X1];
+  MOV X2, #1;
+  ADD X0, X0, X2;
+
+exists (0:X0 = 65536)

--- a/herd/tests/instructions/AArch64/A25.litmus.expected
+++ b/herd/tests/instructions/AArch64/A25.litmus.expected
@@ -1,0 +1,10 @@
+Test A25 Allowed
+States 1
+0:X0=0;
+No
+Witnesses
+Positive: 0 Negative: 1
+Condition exists (0:X0=65536)
+Observation A25 Never 0 1
+Hash=9ec1aadd808402a3c54362081a9a7e21
+

--- a/herd/tests/instructions/AArch64/A26.litmus
+++ b/herd/tests/instructions/AArch64/A26.litmus
@@ -1,0 +1,15 @@
+AArch64 A26
+
+{
+  0:X1 = x;
+  int8_t x = -1;
+  int64_t 0:X4;
+  int64_t 0:X6;
+}
+
+P0;
+  LDRSB W0,[X1] ;
+  MOV X4,X0     ;
+  LDRB W2,[X1]  ;
+  MOV X6,X2     ;
+forall (0:X0=-1 /\ 0:X2=255 /\ 0:X4=4294967295 /\ 0:X6=255)

--- a/herd/tests/instructions/AArch64/A26.litmus.expected
+++ b/herd/tests/instructions/AArch64/A26.litmus.expected
@@ -1,0 +1,10 @@
+Test A26 Required
+States 1
+0:X0=-1; 0:X2=255; 0:X4=4294967295; 0:X6=255;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=-1 /\ 0:X2=255 /\ 0:X4=4294967295 /\ 0:X6=255)
+Observation A26 Always 1 0
+Hash=15ee72abb5d901119b6ff48bf8054b79
+

--- a/herd/tests/instructions/AArch64/A27.litmus
+++ b/herd/tests/instructions/AArch64/A27.litmus
@@ -1,0 +1,15 @@
+AArch64 A27
+
+{
+  0:X1 = x;
+  int16_t x = -1;
+  int64_t 0:X4;
+  int64_t 0:X6;
+}
+
+P0;
+  LDRSH W0,[X1] ;
+  MOV X4,X0     ;
+  LDRH W2,[X1]  ;
+  MOV X6,X2     ;
+forall (0:X0=-1 /\ 0:X2=65535 /\ 0:X4=4294967295 /\ 0:X6=65535)

--- a/herd/tests/instructions/AArch64/A27.litmus.expected
+++ b/herd/tests/instructions/AArch64/A27.litmus.expected
@@ -1,0 +1,10 @@
+Test A27 Required
+States 1
+0:X0=-1; 0:X2=65535; 0:X4=4294967295; 0:X6=65535;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=-1 /\ 0:X2=65535 /\ 0:X4=4294967295 /\ 0:X6=65535)
+Observation A27 Always 1 0
+Hash=93cac7fe5e426154009293d2e2d87ea4
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -80,6 +80,8 @@ include Arch.MakeArch(struct
       ->
         match_kr subs (K k) (K k') >>>
         add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')]
+    | I_LDRS(_,_,r1,r2),I_LDRS(_,_,r1',r2')
+      -> add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')] subs
     | I_LDR(_,r1,r2,kr,s),I_LDR(_,r1',r2',kr',s')
     | I_STR(_,r1,r2,kr,s),I_STR(_,r1',r2',kr',s')
     | I_STRBH(_,r1,r2,kr,s),I_STRBH(_,r1',r2',kr',s')
@@ -256,6 +258,10 @@ include Arch.MakeArch(struct
         find_shift s >> fun s ->
         expl_kr kr >! fun kr ->
         I_LDRBH(a,r1,r2,kr,s)
+    | I_LDRS(a,var,r1,r2) ->
+        conv_reg r1 >> fun r1 ->
+        conv_reg r2 >! fun r2 ->
+        I_LDRS(a,var,r1,r2)
     | I_STR(a,r1,r2,kr,s) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -71,6 +71,8 @@ match name with
 | "stnp"|"STNP" -> STNP
 | "ldrb"|"LDRB" -> LDRB
 | "ldrh"|"LDRH" -> LDRH
+| "ldrsb"|"LDRSB" -> LDRSB
+| "ldrsh"|"LDRSH" -> LDRSH
 | "ldar"|"LDAR" -> LDAR
 | "ldarb"|"LDARB" -> LDARB
 | "ldarh"|"LDARH" -> LDARH

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -55,6 +55,7 @@ let check_op3 op kr =
 %token B BR BEQ BNE BGE BGT BLE BLT CBZ CBNZ EQ NE GE GT LE LT TBZ TBNZ
 %token BL BLR RET ERET
 %token LDR LDP LDNP LDPSW STP STNP LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
+%token LDRSB LDRSH
 %token LD1 LD1R LD2 LD2R LD3 LD3R LD4 LD4R ST1 ST2 ST3 ST4 STUR /* Neon load/store */
 %token CMP MOV MOVZ MOVK MOVI ADR
 %token  LDAR LDARB LDARH LDAPR LDAPRB LDAPRH  LDXR LDXRB LDXRH LDAXR LDAXRB LDAXRH LDXP LDAXP
@@ -418,6 +419,10 @@ instr:
   { let (kr, s) = $6 in A.I_LDRBH (A.B,$2,$5,kr,s) }
 | LDRH wreg COMMA LBRK cxreg kr0 RBRK
   { let (kr, s) = $6 in A.I_LDRBH (A.H,$2,$5,kr,s) }
+| LDRSB reg COMMA LBRK cxreg RBRK
+  { let (v, s) = $2 in A.I_LDRS (v,A.B,s,$5) }
+| LDRSH reg COMMA LBRK cxreg RBRK
+  { let (v, s) = $2 in A.I_LDRS (v,A.H,s,$5) }
 | LDAR reg COMMA LBRK cxreg RBRK
   { let v,r = $2 in A.I_LDAR (v,A.AA,r,$5) }
 | LDARB wreg COMMA LBRK cxreg RBRK

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1278,6 +1278,8 @@ module Make(V:Constant.S)(C:Config) =
         storex_pair (Misc.lowercase (stxp_memo t)) v r1 r2 r3 r4::k
     | I_LDRBH (B,r1,r2,kr,s) -> load "ldrb" V32 r1 r2 kr (default_shift kr s)::k
     | I_LDRBH (H,r1,r2,kr,s) -> load "ldrh" V32 r1 r2 kr (default_shift kr s)::k
+    | I_LDRS (var,B,r1,r2) -> load "ldrsb" var r1 r2 (K 0) (default_shift (K 0) S_NOEXT)::k
+    | I_LDRS (var,H,r1,r2) -> load "ldrsh" var r1 r2 (K 0) (default_shift (K 0) S_NOEXT)::k
     | I_LDAR (v,t,r1,r2) -> load (ldr_memo t) v r1 r2 k0 S_NOEXT::k
     | I_LDARBH (bh,t,r1,r2) -> load (ldrbh_memo bh t) V32 r1 r2 k0 S_NOEXT::k
     | I_STR (v,r1,r2,kr, s) -> store "str" v r1 r2 kr s::k


### PR DESCRIPTION
This patch adds support for the LDRSB/H AArch64 Instructions