### PR TITLE
[herd] Add support for custom fault handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,17 @@ test::
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64 variant -self instructions tests: OK"
 
+test:: test.kvm
+test.kvm:
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/AArch64.kvm \
+		-conf ./herd/tests/instructions/AArch64.kvm/kvm.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64 KVM instructions tests: OK"
+
 test::
 	@ echo
 	$(HERD_REGRESSION_TEST) \

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -217,7 +217,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDOPBH (_,v,_,_,_,_) | I_STOPBH (_,v,_,_,_) ->
           Some (bh_to_sz v)
       | I_NOP|I_B _|I_BR _|I_BC (_, _)|I_CBZ (_, _, _)
-      | I_CBNZ (_, _, _)|I_BL _|I_BLR _|I_RET _|I_LDAR (_, _, _, _)
+      | I_CBNZ (_, _, _)|I_BL _|I_BLR _|I_RET _|I_ERET|I_LDAR (_, _, _, _)
       | I_TBNZ(_,_,_,_) | I_TBZ (_,_,_,_) | I_MOVZ (_,_,_,_) | I_MOVK(_,_,_,_)
       | I_MOV (_, _, _)|I_SXTW (_, _)|I_OP3 (_, _, _, _, _, _)
       | I_ADR (_, _)|I_RBIT (_, _, _)|I_FENCE _
@@ -248,7 +248,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_FENCE _
       | I_IC _|I_DC _|I_TLBI _
       | I_NOP|I_TBZ _|I_TBNZ _
-      | I_BL _ | I_BLR _ | I_RET _
+      | I_BL _ | I_BLR _ | I_RET _ | I_ERET
         -> [] (* For -variant self only ? *)
       | I_LDR (_,r,_,_,_)|I_LDRBH (_,r,_,_,_)
       | I_LDUR (_,r,_,_)
@@ -297,7 +297,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_STXR _|I_STXRBH _ | I_STXP _ -> MachSize.St
       | I_LDAR (_, (AA|AQ), _, _)|I_LDARBH (_, (AA|AQ), _, _)
       | I_NOP|I_B _|I_BR _|I_BC _|I_CBZ _|I_CBNZ _
-      | I_TBNZ _|I_TBZ _|I_BL _|I_BLR _|I_RET _
+      | I_TBNZ _|I_TBZ _|I_BL _|I_BLR _|I_RET _|I_ERET
       | I_LDR _|I_LDUR _|I_LD1 _
       | I_LD1M _|I_LD1R _|I_LD2 _|I_LD2M _
       | I_LD2R _|I_LD3 _|I_LD3M _|I_LD3R _

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -221,7 +221,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_TBNZ(_,_,_,_) | I_TBZ (_,_,_,_) | I_MOVZ (_,_,_,_) | I_MOVK(_,_,_,_)
       | I_MOV (_, _, _)|I_SXTW (_, _)|I_OP3 (_, _, _, _, _, _)
       | I_ADR (_, _)|I_RBIT (_, _, _)|I_FENCE _
-      | I_CSEL (_, _, _, _, _, _)|I_IC (_, _)|I_DC (_, _)|I_MRS (_, _)
+      | I_CSEL (_, _, _, _, _, _)|I_IC (_, _)|I_DC (_, _)|I_MRS (_, _)|I_MSR (_, _)
       | I_STG _ | I_STZG _ | I_LDG _
       | I_ALIGND _| I_ALIGNU _|I_BUILD _|I_CHKEQ _|I_CHKSLD _|I_CHKTGD _
       | I_CLRTAG _|I_CPYTYPE _|I_CPYVALUE _|I_CSEAL _|I_GC _|I_LDCT _|I_SEAL _
@@ -265,6 +265,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_CSEL (_,r,_,_,_,_)
       | I_MRS (r,_)
         -> [r]
+      | I_MSR (sr,_)
+        -> [(SysReg sr)]
       | I_LDR_P (_,r1,r2,_) | I_LDP (_,_,r1,r2,_,_)
       | I_LDPSW (r1,r2,_,_) | I_LDXP (_,_,r1,r2,_)
         -> [r1;r2;]
@@ -321,7 +323,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDOPBH _|I_STOP _|I_STOPBH _
       | I_MOV _|I_MOVZ _|I_MOVK _|I_SXTW _
       | I_OP3 _|I_ADR _|I_RBIT _|I_FENCE _
-      | I_CSEL _|I_IC _|I_DC _|I_TLBI _|I_MRS _
+      | I_CSEL _|I_IC _|I_DC _|I_TLBI _|I_MRS _|I_MSR _
       | I_STG _|I_STZG _|I_LDG _
         -> MachSize.No
 

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -249,9 +249,9 @@ module Make
         else write_reg_sz_sxt
 
 (* Emit commit event *)
-      let commit_bcc ii = M.mk_singleton_es (Act.Commit (true,None)) ii
+      let commit_bcc ii = M.mk_singleton_es (Act.Commit (Act.Bcc,None)) ii
       and commit_pred_txt txt ii =
-        M.mk_singleton_es (Act.Commit (false,txt)) ii
+        M.mk_singleton_es (Act.Commit (Act.Pred,txt)) ii
 
       let commit_pred ii = commit_pred_txt None ii
 
@@ -1703,7 +1703,11 @@ module Make
              | M.A.V.Val(Constant.Label (_, l)) -> B.branchT l
              | _ ->
                 Warn.fatal "Cannot determine ERET target" in
-           read_reg_ord AArch64.elr_el1 ii >>= eret_to_addr
+           let commit_eret ii =
+             M.mk_singleton_es (Act.Commit (Act.ExcReturn,None)) ii in
+           commit_eret ii >>=
+             fun () -> read_reg_ord AArch64.elr_el1 ii >>=
+             eret_to_addr
 
         | I_CBZ(_,r,l) ->
             (read_reg_ord r ii)

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2259,6 +2259,11 @@ module Make
       | I_STXP (v,t,r1,r2,r3,r4) ->
             stxp (tr_variant v) t r1 r2 r3 r4 ii
       (*  Cannot handle *)
+        | I_MSR (sreg,xt) ->
+           read_reg_ord_sz MachSize.Quad xt ii
+           >>= fun v -> write_reg_dest (SysReg sreg) v ii
+           >>= nextSet (SysReg sreg)
+(*  Cannot handle *)
         | (I_RBIT _|I_MRS _|I_LDP _|I_STP _
         (* | I_BL _|I_BLR _|I_BR _|I_RET _ *)
         | I_LD1M _|I_ST1M _) as i ->

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1705,6 +1705,9 @@ module Make
             read_reg_ord r ii
             >>= do_indirect_jump i
 
+        | I_ERET ->
+           read_reg_ord AArch64.elr_el1 ii >>= do_indirect_jump ii.A.inst
+
         | I_CBZ(_,r,l) ->
             (read_reg_ord r ii)
               >>= is_zero

--- a/herd/ARMSem.ml
+++ b/herd/ARMSem.ml
@@ -195,15 +195,15 @@ module Make (C:Sem.Config)(V:Value.S)
           | ARM.I_B lbl -> B.branchT lbl
           | ARM.I_BEQ (lbl) ->
               read_reg_ord ARM.Z ii >>=
-              fun v -> commit true ii >>= fun () -> B.bccT v lbl
+              fun v -> commit Act.Bcc ii >>= fun () -> B.bccT v lbl
           | ARM.I_BNE (lbl) ->
               read_reg_ord ARM.Z ii >>=
-              fun v -> flip_flag v >>= fun vneg -> commit true ii >>=
+              fun v -> flip_flag v >>= fun vneg -> commit Act.Bcc ii >>=
                 fun () -> B.bccT vneg lbl
           | ARM.I_CB (n,r,lbl) ->
               let cond = if n then is_not_zero else is_zero in
               read_reg_ord r ii >>= cond >>=
-              fun v -> commit true ii >>= fun () -> B.bccT v lbl
+              fun v -> commit Act.Bcc ii >>= fun () -> B.bccT v lbl
           | ARM.I_CMPI (r,v) ->
               ((read_reg_ord  r ii)
                  >>=

--- a/herd/MIPSSem.ml
+++ b/herd/MIPSSem.ml
@@ -90,7 +90,7 @@ module Make (C:Sem.Config)(V:Value.S)
         M.mk_singleton_es (Act.Barrier b) ii
 
       let commit ii =
-        M.mk_singleton_es (Act.Commit (true,None)) ii
+        M.mk_singleton_es (Act.Commit (Act.Bcc,None)) ii
 
 (* Entry point *)
 

--- a/herd/PPCSem.ml
+++ b/herd/PPCSem.ml
@@ -100,7 +100,7 @@ module Make (C:Sem.Config)(V:Value.S)
         M.mk_singleton_es (Act.Barrier b) ii
 
       let commit ii =
-        M.mk_singleton_es (Act.Commit (true,None)) ii
+        M.mk_singleton_es (Act.Commit (Act.Bcc,None)) ii
 
       let write_addr a v ii =  write_mem a v ii
 

--- a/herd/RISCVSem.ml
+++ b/herd/RISCVSem.ml
@@ -175,7 +175,7 @@ module Make (C:Sem.Config)(V:Value.S)
 
       let create_barrier b ii = M.mk_singleton_es (Act.Barrier b) ii
 
-      let commit ii = M.mk_singleton_es (Act.Commit (true,None)) ii
+      let commit ii = M.mk_singleton_es (Act.Commit (Act.Bcc,None)) ii
 
 (* Compute amo semantics anotations from syntactic  ones,
    Notice that Sc is exclusively semantics, cf. assert false below *)

--- a/herd/branch.ml
+++ b/herd/branch.ml
@@ -34,8 +34,8 @@ module type S = sig
     | CondJump of v * lbl
     (* Stop now *)
     | Exit
-    (* Re-execute instruction *)
-    | ReExec
+    (* Raise Fault *)
+    | Fault of Dir.dirn
 
 (* Next instruction in sequence *)
   val nextT : t monad
@@ -67,8 +67,8 @@ module Make(M:Monad.S) = struct
     | CondJump of v * lbl
     (* Stop now *)
     | Exit
-    (* Re-execute instruction *)
-    | ReExec
+    (* Raise Fault *)
+    | Fault of Dir.dirn
 
 (* Utilities *)
 

--- a/herd/loader.ml
+++ b/herd/loader.ml
@@ -39,50 +39,49 @@ struct
   type start_points = A.start_points
   type return_labels = A.return_labels
 
-  let rec load_code proc addr mem rets link_num = function
-    | [] -> mem,[],rets,link_num
+  let rec load_code proc addr mem rets = function
+    | [] -> mem,[],rets
     | ins::code ->
-      load_ins proc addr mem rets link_num code ins
+      load_ins proc addr mem rets code ins
 
-  and load_ins proc addr mem rets link_num code = fun x ->
+  and load_ins proc addr mem rets code = fun x ->
     match x with
     | A.Nop ->
-      load_code proc addr mem rets link_num code
+      load_code proc addr mem rets code
     | A.Instruction ins ->
       if Misc.is_some (A.is_link ins) then
-        let new_mem,start,new_rets,new_num =
-          load_code proc (addr+4) mem rets (link_num+1) code in
-        let lbl = Printf.sprintf "##%d" link_num in
+        let new_mem,start,new_rets =
+          load_code proc (addr+4) mem rets code in
+        let lbl = Printf.sprintf "##%d" addr in
         let newer_mem =
-            if Label.Map.mem lbl new_mem then
-              Warn.user_error
-                "Label %s cannot be created, since it is reserved internally" lbl ;
-            Label.Map.add lbl (proc,start) new_mem in
+          if Label.Map.mem lbl new_mem then
+            Warn.user_error
+              "Label %s cannot be created, since it is reserved internally" lbl ;
+          Label.Map.add lbl (proc,start) new_mem in
         let newer_rets = IntMap.add addr lbl new_rets in
-        newer_mem,(addr,ins)::start,newer_rets,new_num
+        newer_mem,(addr,ins)::start,newer_rets
       else
-        let mem,start,new_rets,new_num =
-          load_code proc (addr+4) mem rets link_num code in
-        mem,(addr,ins)::start,new_rets,new_num
+        let mem,start,new_rets =
+          load_code proc (addr+4) mem rets code in
+        mem,(addr,ins)::start,new_rets
     | A.Label (lbl,ins) ->
-        let mem,start,new_rets,new_num =
-          load_ins proc addr mem rets link_num code ins in
+        let mem,start,new_rets =
+          load_ins proc addr mem rets code ins in
         if Label.Map.mem lbl mem then
           Warn.user_error
             "Label %s occurs more that once" lbl ;
-        Label.Map.add lbl (proc,start) mem,start,new_rets,new_num
+        Label.Map.add lbl (proc,start) mem,start,new_rets
     | A.Symbolic _
     | A.Macro (_,_) -> assert false
 
   let load prog =
-    let rec load_iter num = function
-    | [] -> Label.Map.empty,[],IntMap.empty,num
+    let rec load_iter = function
+    | [] -> Label.Map.empty,[],IntMap.empty
     | ((proc,_,_),code)::prog ->
       let addr = 1000 * (proc+1) in
-      let mem,starts,rets,new_num = load_iter num prog in
-      let fin_mem,start,fin_rets,fin_num = load_code proc addr mem rets new_num code in
-      fin_mem,(proc,start)::starts,fin_rets,fin_num in
-    let mem, starts, rets, _ = load_iter 0 prog in
-    mem, starts, rets
+      let mem,starts,rets = load_iter prog in
+      let fin_mem,start,fin_rets = load_code proc addr mem rets code in
+      fin_mem,(proc,start)::starts,fin_rets in
+    load_iter prog
 
 end

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -59,7 +59,8 @@ module Make (C:Config) (A : A) : sig
 (* Atomic modify, (location,value read, value written, annotation *)
     | Amo of A.location * A.V.v * A.V.v * A.lannot * A.explicit * MachSize.sz * Access.t
 (* NB: Amo used in some arch only (e.g., Arm, RISCV) *)
-    | Fault of A.inst_instance_id * A.location * Dir.dirn * A.lannot * string option
+(* bool (fifth) argument is true when modeling fault handler entry *)
+    | Fault of A.inst_instance_id * A.location * Dir.dirn * A.lannot * bool * string option
 (* Unrolling control *)
     | TooFar of string
 (* TLB Invalidate event, operation (for print and level), address, if any.
@@ -144,7 +145,7 @@ end = struct
     | Amo of
         A.location * A.V.v * A.V.v * A.lannot * A.explicit *
         MachSize.sz * Access.t
-    | Fault of A.inst_instance_id * A.location * Dir.dirn * A.lannot * string option
+    | Fault of A.inst_instance_id * A.location * Dir.dirn * A.lannot * bool * string option
     | TooFar of string
     | Inv of A.TLBI.op * A.location option
     | DC of AArch64Base.DC.op * A.location option
@@ -188,8 +189,9 @@ end = struct
         (A.pp_explicit exp_an)
         (A.pp_location loc) (MachSize.pp_short sz)
         (V.pp C.hexa v1) (V.pp C.hexa v2)
-  | Fault (ii,loc,d,an,msg) ->
-      Printf.sprintf "Fault(proc:%s,poi:%s,%s,loc:%s%s%s)"
+  | Fault (ii,loc,d,an,handler,msg) ->
+     Printf.sprintf "%s(proc:%s,poi:%s,%s,loc:%s%s%s)"
+        (if handler then "ExcEntry" else "Fault")
         (A.pp_proc ii.A.proc)
         (A.pp_prog_order_index ii.A.program_order_index)
         (pp_dirn d)
@@ -245,7 +247,7 @@ end = struct
   let location_of a = match a with
   | Access (_, l, _,_,_,_,_)
   | Amo (l,_,_,_,_,_,_)
-  | Fault (_,l,_,_,_)
+  | Fault (_,l,_,_,_,_)
   | Inv (_,Some l)
   | DC(_,Some l)
   | IC(_,Some l)
@@ -346,15 +348,21 @@ end = struct
       -> false
 
   let is_faulting_read = function
-    | Fault (_,_,Dir.R,_,_) -> true
+    | Fault (_,_,Dir.R,_,_,_) -> true
     | _ -> false
 
   let is_faulting_write = function
-    | Fault (_,_,Dir.W,_,_) -> true
+    | Fault (_,_,Dir.W,_,_,_) -> true
     | _ -> false
 
+  let is_exc_entry = function
+    | Fault (_,_,_,_,true,_) -> true
+    | Fault _ | Access _ | Amo _ | Commit _ | Barrier _ | TooFar _ | Inv _
+    | DC _ | IC _ | Arch _ | NoAction
+      -> false
+
   let to_fault = function
-    | Fault (i,A.Location_global x,_,_,msg) -> Some ((i.A.proc,i.A.labels),x,msg)
+    | Fault (i,A.Location_global x,_,_,_,msg) -> Some ((i.A.proc,i.A.labels),x,msg)
     | Fault _ | Access _ | Amo _ | Commit _ | Barrier _ | TooFar _ | Inv _
     | DC _ | IC _ | Arch _ | NoAction
       -> None
@@ -510,7 +518,7 @@ end = struct
         (fun (tag,p) ->
           let p act = match act with
           | Access(_,_,_,annot,_,_,_)|Amo (_,_,_,annot,_,_,_)
-          | Fault (_,_,_,annot,_)-> p annot
+          | Fault (_,_,_,annot,_,_)-> p annot
           | Arch a -> p (A.ArchAction.get_lannot a)
           | _ -> false
           in tag,p) A.annot_sets
@@ -544,6 +552,7 @@ end = struct
     ("FAULT",is_fault)::
     ("FAULT-RD",is_faulting_read)::
     ("FAULT-WR",is_faulting_write)::
+    ("EXC-ENTRY",is_exc_entry)::
     ("EXC-RET",is_exc_return)::
     ("TLBI",is_inv)::
     ("DC",is_dc)::
@@ -676,9 +685,9 @@ end = struct
         let v1 = V.simplify_var soln v1 in
         let v2 = V.simplify_var soln v2 in
         Amo (loc,v1,v2,an,exp_an,sz,t)
-    | Fault (ii,loc,d,a,msg) ->
+    | Fault (ii,loc,d,a,h,msg) ->
         let loc = A.simplify_vars_in_loc soln loc in
-        Fault(ii,loc,d,a,msg)
+        Fault(ii,loc,d,a,h,msg)
     | Inv (op,oloc) ->
         let oloc = Misc.app_opt (A.simplify_vars_in_loc soln) oloc in
         Inv (op,oloc)

--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -57,7 +57,8 @@ module Top (TopConf:Config) = struct
          sig
            val check : S.A.pseudo MiscParser.t -> S.A.pseudo MiscParser.t
          end)
-      (M:XXXMem.S with module S = S) =
+      (M:XXXMem.S with module S = S)
+      (C:Config) =
     struct
       module T = Test_herd.Make(S.A)
 
@@ -97,7 +98,7 @@ module Top (TopConf:Config) = struct
           let module T =
             Top_herd.Make
               (struct
-                include TopConf
+                include C
                 let byte = sz
                 let dirty = dirty
               end)(M) in
@@ -212,7 +213,7 @@ module Top (TopConf:Config) = struct
           let module PPCS = PPCSem.Make(Conf)(Int64Value) in
           let module PPCM = PPCMem.Make(ModelConfig)(PPCS) in
           let module P = GenParser.Make (Conf) (PPC) (PPCLexParse) in
-          let module X = Make (PPCS) (P) (NoCheck) (PPCM) in
+          let module X = Make (PPCS) (P) (NoCheck) (PPCM) (Conf) in
           X.run dirty start_time name chan env splitted
       | `ARM ->
           let module ARM = ARMArch_herd.Make(ArchConfig)(Int32Value) in
@@ -226,7 +227,7 @@ module Top (TopConf:Config) = struct
           let module ARMS = ARMSem.Make(Conf)(Int32Value) in
           let module ARMM = ARMMem.Make(ModelConfig)(ARMS) in
           let module P = GenParser.Make (Conf) (ARM) (ARMLexParse) in
-          let module X = Make (ARMS) (P) (NoCheck) (ARMM) in
+          let module X = Make (ARMS) (P) (NoCheck) (ARMM) (Conf) in
           X.run dirty start_time name chan env splitted
       | `AArch64 ->
          let module
@@ -272,7 +273,7 @@ module Top (TopConf:Config) = struct
 
              module P = GenParser.Make (Conf) (AArch64) (AArch64LexParse)
 
-             module X = Make (AArch64S) (P) (AArch64C) (AArch64M)
+             module X = Make (AArch64S) (P) (AArch64C) (AArch64M) (Conf)
 
              let run = X.run
          end in
@@ -301,7 +302,7 @@ module Top (TopConf:Config) = struct
           let module X86S = X86Sem.Make(Conf)(Int32Value) in
           let module X86M = X86Mem.Make(ModelConfig)(X86S) in
           let module P = GenParser.Make (Conf) (X86) (X86LexParse) in
-          let module X = Make (X86S) (P) (NoCheck) (X86M) in
+          let module X = Make (X86S) (P) (NoCheck) (X86M) (Conf) in
           X.run dirty start_time name chan env splitted
 
       | `X86_64 ->
@@ -316,7 +317,7 @@ module Top (TopConf:Config) = struct
           let module X86_64S = X86_64Sem.Make(Conf)(Int64Value) in
           let module X86_64M = X86_64Mem.Make(ModelConfig)(X86_64S) in
           let module P = GenParser.Make(Conf)(X86_64)(X86_64LexParse) in
-          let module X = Make(X86_64S)(P)(NoCheck)(X86_64M) in
+          let module X = Make(X86_64S)(P)(NoCheck)(X86_64M)(Conf) in
           X.run dirty start_time name chan env splitted
 
 
@@ -332,7 +333,7 @@ module Top (TopConf:Config) = struct
           let module MIPSS = MIPSSem.Make(Conf)(Int64Value) in
           let module MIPSM = MIPSMem.Make(ModelConfig)(MIPSS) in
           let module P = GenParser.Make (Conf) (MIPS) (MIPSLexParse) in
-          let module X = Make (MIPSS) (P) (NoCheck) (MIPSM) in
+          let module X = Make (MIPSS) (P) (NoCheck) (MIPSM) (Conf) in
           X.run dirty start_time name chan env splitted
 
       | `RISCV ->
@@ -347,7 +348,7 @@ module Top (TopConf:Config) = struct
           let module RISCVS = RISCVSem.Make(Conf)(Int64Value) in
           let module RISCVM = RISCVMem.Make(ModelConfig)(RISCVS) in
           let module P = GenParser.Make (Conf) (RISCV) (RISCVLexParse) in
-          let module X = Make (RISCVS) (P) (NoCheck) (RISCVM) in
+          let module X = Make (RISCVS) (P) (NoCheck) (RISCVM) (Conf) in
           X.run dirty start_time name chan env splitted
       | `C ->
           let module C = CArch_herd.Make(ArchConfig)(Int64Value) in
@@ -369,7 +370,7 @@ module Top (TopConf:Config) = struct
           let module CS = CSem.Make(Conf)(Int64Value) in
           let module CM = CMem.Make(ModelConfig)(CS) in
           let module P = CGenParser_lib.Make (Conf) (C) (CLexParse) in
-          let module X = Make (CS) (P) (NoCheck) (CM) in
+          let module X = Make (CS) (P) (NoCheck) (CM) (Conf) in
           X.run dirty start_time name chan env splitted
       | `CPP as arch -> Warn.fatal "no support for arch '%s'" (Archs.pp arch)
       | `LISA ->
@@ -398,7 +399,7 @@ module Top (TopConf:Config) = struct
                 let tr_compat = Bell.tr_compat
               end) in
           let module P = GenParser.Make (Conf) (Bell) (BellLexParse) in
-          let module X = Make (BellS) (P) (BellC) (BellM) in
+          let module X = Make (BellS) (P) (BellC) (BellM) (Conf) in
           X.run dirty start_time name chan env splitted
     end else env
 

--- a/herd/tests/instructions/AArch64.kvm/A001.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A001.litmus
@@ -1,0 +1,12 @@
+AArch64 A001
+Variant=fatal
+{
+x=1;
+[PTE(x)]=(oa:PA(x),valid:0);
+0:X1=x;
+0:X2=0;
+}
+ P0          ;
+ LDR W0,[X1] ;
+ MOV W2, #1  ;
+forall (0:X0=0 /\ 0:X2=0)

--- a/herd/tests/instructions/AArch64.kvm/A001.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A001.litmus.expected
@@ -1,0 +1,10 @@
+Test A001 Required
+States 1
+0:X0=0; 0:X2=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=0 /\ 0:X2=0)
+Observation A001 Always 1 0
+Hash=b4f76ddaf0ec77a089ddb069cb87815f
+

--- a/herd/tests/instructions/AArch64.kvm/A002.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A002.litmus
@@ -1,0 +1,12 @@
+AArch64 A002
+Variant=skip
+{
+x=1;
+[PTE(x)]=(oa:PA(x),valid:0);
+0:X1=x;
+0:X2=0;
+}
+ P0          ;
+ LDR W0,[X1] ;
+ MOV W2, #1  ;
+forall (0:X0=0 /\ 0:X2=1)

--- a/herd/tests/instructions/AArch64.kvm/A002.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A002.litmus.expected
@@ -1,0 +1,10 @@
+Test A002 Required
+States 1
+0:X0=0; 0:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=0 /\ 0:X2=1)
+Observation A002 Always 1 0
+Hash=b4f76ddaf0ec77a089ddb069cb87815f
+

--- a/herd/tests/instructions/AArch64.kvm/A003.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A003.litmus
@@ -1,0 +1,14 @@
+AArch64 A003
+Variant=handled
+{
+x=1;
+[PTE(x)]=(oa:PA(x),valid:0);
+0:X1=x;
+0:X2=0;
+1:X0=(oa:PA(x),valid:1);
+1:X1=PTE(x)
+}
+ P0          | P1          ;
+ LDR W0,[X1] | STR X0,[X1] ;
+ MOV W2, #1  |             ;
+ forall(0:X0=1 /\ 0:X2=1)

--- a/herd/tests/instructions/AArch64.kvm/A003.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A003.litmus.expected
@@ -1,0 +1,10 @@
+Test A003 Required
+States 1
+0:X0=1; 0:X2=1;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (0:X0=1 /\ 0:X2=1)
+Observation A003 Always 2 0
+Hash=0f2847d5367fde735ca5ae4a6e03cd9b
+

--- a/herd/tests/instructions/AArch64.kvm/A004.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A004.litmus
@@ -1,0 +1,10 @@
+AArch64 A004
+Variant=fatal
+{
+[PTE(x)]=(oa:PA(x),valid:0);
+0:X1=x;
+}
+ P0          ;
+L0:          ;
+ LDR W0,[X1] ;
+ forall(fault(P0:L0,x))

--- a/herd/tests/instructions/AArch64.kvm/A004.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A004.litmus.expected
@@ -1,0 +1,10 @@
+Test A004 Required
+States 1
+ Fault(P0:L0,x);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0:L0,x))
+Observation A004 Always 1 0
+Hash=abfed1dff47d259c77dbd4bc5cef0cc5
+

--- a/herd/tests/instructions/AArch64.kvm/A005.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A005.litmus
@@ -1,0 +1,12 @@
+AArch64 A005
+{
+[x]=1;
+[PTE(x)]=(oa:PA(x),valid:0);
+0:X1=x;
+}
+ P0          | P0.F           ;
+ LDR W0,[X1] | MOV W2,#1      ;
+L0:          | ADR X4,L0      ;
+ MOV W3,#1   | MSR ELR_EL1,X4 ;
+             | ERET           ;
+ forall(0:X0=0 /\ 0:X2=1 /\ 0:X3=1)

--- a/herd/tests/instructions/AArch64.kvm/A005.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A005.litmus.expected
@@ -1,0 +1,10 @@
+Test A005 Required
+States 1
+0:X0=0; 0:X2=1; 0:X3=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=0 /\ 0:X2=1 /\ 0:X3=1)
+Observation A005 Always 1 0
+Hash=63fe95c5d285e45a9e941fb36d381f70
+

--- a/herd/tests/instructions/AArch64.kvm/kvm.cfg
+++ b/herd/tests/instructions/AArch64.kvm/kvm.cfg
@@ -1,0 +1,2 @@
+variant kvm
+

--- a/herd/tests/instructions/AArch64.self/S06.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S06.litmus.expected
@@ -1,6 +1,6 @@
 Test S06 Required
 States 1
-0:X0=0; 0:X30=0:##1000;
+0:X0=0; 0:X30=0:##10000;
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.self/S06.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S06.litmus.expected
@@ -1,6 +1,6 @@
 Test S06 Required
 States 1
-0:X0=0; 0:X30=0:##0;
+0:X0=0; 0:X30=0:##1000;
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -118,7 +118,7 @@ include Arch.MakeArch(struct
       | K k ->
           find_cst k >! fun k -> K k in
     function
-    | (I_FENCE _|I_NOP|I_RET None) as i -> unitT i
+    | (I_FENCE _|I_NOP|I_RET None|I_ERET) as i -> unitT i
     | I_B l ->
         find_lab l >! fun l -> I_B l
     | I_BR r ->

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -324,6 +324,7 @@ include Arch.MakeArch(struct
     | I_TLBI (op,r) ->
         conv_reg r >! fun r -> I_TLBI (op,r)
     | I_MRS (r,sr) -> conv_reg r >! fun r -> I_MRS (r,sr)
+    | I_MSR (sr,r) -> conv_reg r >! fun r -> I_MSR (sr,r)
     | I_STG (r1,r2,kr) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -751,6 +751,7 @@ type 'k kinstruction =
   | I_TBZ of variant * reg * 'k * lbl
   | I_BL of lbl | I_BLR of reg
   | I_RET of reg option
+  | I_ERET
 (* Load and Store *)
   | I_LDR of variant * reg * reg * 'k kr * 'k s
   | I_LDUR of variant * reg * reg * 'k option
@@ -1111,6 +1112,8 @@ let do_pp_instruction m =
       "RET"
   | I_RET (Some r) ->
       sprintf "RET %s" (pp_xreg r)
+  | I_ERET ->
+     "ERET"
 
 (* Load and Store *)
   | I_LDR (v,r1,r2,k,S_NOEXT) ->
@@ -1411,7 +1414,7 @@ let fold_regs (f_regs,f_sregs) =
   | RV (_,r) -> fold_reg r y in
 
   fun c ins -> match ins with
-  | I_NOP | I_B _ | I_BC _ | I_BL _ | I_FENCE _ | I_RET None
+  | I_NOP | I_B _ | I_BC _ | I_BL _ | I_FENCE _ | I_RET None | I_ERET
     -> c
   | I_CBZ (_,r,_) | I_CBNZ (_,r,_) | I_BLR r | I_BR r | I_RET (Some r)
   | I_MOV (_,r,_) | I_MOVZ (_,r,_,_) | I_MOVK (_,r,_,_)
@@ -1496,6 +1499,7 @@ let map_regs f_reg f_symb =
   | I_FENCE _
   | I_BL _
   | I_RET None
+  | I_ERET
     -> ins
   | I_CBZ (v,r,lbl) ->
       I_CBZ (v,map_reg r,lbl)
@@ -1747,7 +1751,7 @@ let get_next = function
   | I_TBZ (_,_,_,lbl)
   | I_BL lbl
     -> [Label.Next; Label.To lbl;]
-  | I_BLR _|I_BR _|I_RET _ -> [Label.Any]
+  | I_BLR _|I_BR _|I_RET _ |I_ERET -> [Label.Any]
   | I_NOP
   | I_LDR _
   | I_LDUR _
@@ -1839,6 +1843,7 @@ include Pseudo.Make
         | I_BL _
         | I_BLR _
         | I_RET _
+        | I_ERET
         | I_LDAR _
         | I_LDARBH _
         | I_STLR _
@@ -1984,6 +1989,7 @@ include Pseudo.Make
         | I_B _ | I_BR _
         | I_BL _ | I_BLR _
         | I_RET _
+        | I_ERET
         | I_BC _
         | I_CBZ _
         | I_CBNZ _

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -441,6 +441,7 @@ match name with
     A.TLBI.(TLBI_OP {typ=VMALLS12; level=A.E1; domain=No; })
 (* System registers *)
 | "mrs"|"MRS" -> MRS
+| "msr"|"MSR" -> MSR
 | "ctr_el0"|"CTR_EL0" -> SYSREG A.CTR_EL0
 | "dciz_el0"|"DCIZ_EL0" -> SYSREG A.DCIZ_EL0
 | "mdccsr_el0"|"MDCCSR_EL0" -> SYSREG A.MDCCSR_EL0

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -447,6 +447,7 @@ match name with
 | "dbgdtr_el0"|"DBGDTR_EL0" -> SYSREG A.DBGDTR_EL0
 | "dbgdtrrx_el0"|"DBGDTRRX_EL0" -> SYSREG A.DBGDTRRX_EL0
 | "Dbgdtrtx_el0"|"DBGDTRTX_EL0" -> SYSREG A.DBGDTRTX_EL0
+| "elr_el1"|"ELR_EL1" -> SYSREG A.ELR_EL1
 | _ ->
     begin match A.parse_wreg name with
     | Some r -> ARCH_WREG r

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -44,6 +44,7 @@ match name with
 | "bl"  | "BL"  -> BL
 | "blr"  | "BLR"  -> BLR
 | "ret"  | "RET" -> RET
+| "eret"  | "ERET" -> ERET
 | "ne"  | "NE"  -> NE
 | "eq"  | "EQ"  -> EQ
 | "ge"  | "GE"  -> GE

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -53,7 +53,7 @@ let check_op3 op kr =
 /* Instructions */
 %token NOP HINT HLT
 %token B BR BEQ BNE BGE BGT BLE BLT CBZ CBNZ EQ NE GE GT LE LT TBZ TBNZ
-%token BL BLR RET
+%token BL BLR RET ERET
 %token LDR LDP LDNP LDPSW STP STNP LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
 %token LD1 LD1R LD2 LD2R LD3 LD3R LD4 LD4R ST1 ST2 ST3 ST4 STUR /* Neon load/store */
 %token CMP MOV MOVZ MOVK MOVI ADR
@@ -363,6 +363,7 @@ instr:
 | BLR xreg { A.I_BLR $2 }
 | RET  { A.I_RET None }
 | RET xreg { A.I_RET (Some $2) }
+| ERET { A.I_ERET }
 | BEQ label_addr { A.I_BC (A.EQ,$2) }
 | BNE label_addr { A.I_BC (A.NE,$2) }
 | BLE NAME { A.I_BC (A.LE,$2) }

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -104,7 +104,7 @@ let check_op3 op kr =
 %token <AArch64Base.DC.op> DC_OP
 %token <AArch64Base.TLBI.op> TLBI_OP
 %token <AArch64Base.sysreg> SYSREG
-%token MRS TST RBIT
+%token MRS MSR TST RBIT
 %token STG STZG LDG
 %token ALIGND ALIGNU BUILD CHKEQ CHKSLD CHKTGD CLRTAG CPY CPYTYPE CPYVALUE CSEAL
 %token LDCT SEAL STCT UNSEAL
@@ -1123,6 +1123,8 @@ instr:
 /* System register */
 | MRS xreg COMMA SYSREG
   { A.I_MRS ($2,$4) }
+| MSR SYSREG COMMA xreg
+  { A.I_MSR ($2,$4) }
 
 fenceopt:
 | SY

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1374,6 +1374,12 @@ module Make(V:Constant.S)(C:Config) =
           sprintf "mrs %s,%s" f (Misc.lowercase (pp_sysreg sr)) in
         {empty_ins with
          memo; outputs=r; reg_env=add_type quad r;}::k
+    | I_MSR (sr,r) ->
+       let r,f = arg1 "xzr" (fun s -> "^o"^s) r in
+       let memo =
+         sprintf "msr %s,%s" (Misc.lowercase (pp_sysreg sr)) f in
+       {empty_ins with
+         memo; outputs=r; reg_env=add_type quad r;}::k
     | I_STG _| I_STZG _|I_LDG _ ->
         Warn.fatal "No litmus output for instruction %s"
           (dump_instruction ins)

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1224,6 +1224,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_BLR r -> blr r::k
     | I_RET None -> { empty_ins with memo="ret"; }::k
     | I_RET (Some r) -> ret r::k
+    | I_ERET -> { empty_ins with memo="eret"; }::k
     | I_BC (c,lbl) -> bcc tr_lab c lbl::k
     | I_CBZ (v,r,lbl) -> cbz tr_lab "cbz" v r lbl::k
     | I_CBNZ (v,r,lbl) -> cbz tr_lab "cbnz" v r lbl::k


### PR DESCRIPTION
On AArch64 `elr_el1` determines the point at which the fault handler should return to. This means that when an instruction faults we should have an additional event that writes  a label of the current instruction or the instruction address to `elr_el1`. Then, at the end of the fault handler (or otherwise when we execute `eret`), we should jump to the instruction that `elr_el1` points to.