### PR TITLE
[litmus] Custom handler driver c

### DIFF
--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -31,6 +31,14 @@ let pp_proc (p,ao,f) =
     | None -> ""
     | Some a -> sprintf ":%s" (String.concat "," a))
 
+let count_procs prog =
+  List.fold_left
+    (fun n (((_,_,f):proc),_) ->
+      match f with
+      | Main -> n+1
+      | FaultHandler -> n)
+    0 prog
+
 type maybev = ParsedConstant.v
 
 type reg = string (* Registers not yet parsed *)

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -21,6 +21,7 @@ type func = Main | FaultHandler
 type proc = Proc.t * string list option * func
 
 val pp_proc : proc -> string
+val count_procs : (proc * 'c) list -> int
 
 (* Values just parsed *)
 type maybev = ParsedConstant.v

--- a/litmus/AArch64Arch_litmus.ml
+++ b/litmus/AArch64Arch_litmus.ml
@@ -86,4 +86,17 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
 
       let nop = I_NOP
 
+      let vector_table name =
+        let ventry label k = ".align 7"::Printf.sprintf "b %s" label::k in
+        let ( ** ) label k = ventry label k in
+        "adr %0,2f"::"b 1f"::
+         ".align 11"::"2:"::
+         "el1t_sync" ** "el1t_irq" ** "el1t_fiq" ** "el1t_error"
+         ** name ** "el1h_irq" ** "el1h_fiq" ** "el1h_error"
+         ** "el0_sync_64" ** "el0_irq_64" ** "el0_fiq_64" ** "el0_error_64"
+         ** "el0_sync_32" ** "el0_irq_32" ** "el0_fiq_32" ** "el0_error_32"
+         ** ["1:"]
+
+
+
 end

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1204,13 +1204,8 @@ module Make(V:Constant.S)(C:Config) =
 
     let kernel_mode = [{ empty_ins with memo="svc #471"}]
 
-    let fault_handler_prologue asmhandler =
-      map_ins
-        ("b 1f"::
-           (match asmhandler with
-            | Some p ->  [sprintf  "asm_handler%d:" p]
-            | None ->
-              [".globl el1h_sync"; "el1h_sync:";]))
+    let fault_handler_prologue p =
+      map_ins ["b 1f";sprintf  "asm_handler%d:" p]
 
     and fault_handler_epilogue =
       let ins =

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1207,9 +1207,14 @@ module Make(V:Constant.S)(C:Config) =
     let fault_handler_prologue p =
       map_ins ["b 1f";sprintf  "asm_handler%d:" p]
 
-    and fault_handler_epilogue =
+    and fault_handler_epilogue code =
       let ins =
-        if Precision.is_skip C.precision then
+        if
+          List.exists
+            (fun i -> i.memo = "eret")
+            code
+        then [] (* handler is complete *)
+        else if Precision.is_skip C.precision then
           [ "mrs %[tr0],elr_el1" ;
             "add %[tr0],%[tr0],#4" ;
             "msr elr_el1,%[tr0]" ;

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -77,10 +77,10 @@ module Make(V:Constant.S)(C:Config) =
 
 (* pretty prints barrel shifters *)
     let pp_shifter = function
-      | S_LSL(s) -> Printf.sprintf "LSL #%d" s
-      | S_LSR(s) -> Printf.sprintf "LSR #%d" s
-      | S_MSL(s) -> Printf.sprintf "MSL #%d" s
-      | S_ASR(s) -> Printf.sprintf "ASR #%d" s
+      | S_LSL(s) -> sprintf "LSL #%d" s
+      | S_LSR(s) -> sprintf "LSR #%d" s
+      | S_MSL(s) -> sprintf "MSL #%d" s
+      | S_ASR(s) -> sprintf "ASR #%d" s
       | S_SXTW -> "SXTW"
       | S_UXTW -> "UXTW"
       | S_NOEXT  -> ""
@@ -1181,6 +1181,17 @@ module Make(V:Constant.S)(C:Config) =
 (* Not that useful *)
     let emit_loop _k = assert false
 
+    let tr_ins ins =
+      match ins.[String.length ins-1] with
+      | ':' ->
+         let lab = String.sub ins 0 (String.length ins-1) in
+         { empty_ins with memo = ins; label = Some lab; }
+      | _ -> { empty_ins with memo = ins; }
+
+    let map_ins = List.map tr_ins
+
+    type ins = A.Out.ins
+
     let user_mode =
       let ins =
         ["msr sp_el0,%[sp_usr]";
@@ -1189,14 +1200,17 @@ module Make(V:Constant.S)(C:Config) =
          "msr spsr_el1,xzr";
          "eret";
          "9:"] in
-      List.map (fun s -> { empty_ins with memo=s;}) ins
+      map_ins ins
 
     let kernel_mode = [{ empty_ins with memo="svc #471"}]
 
-    let fault_handler_prologue =
-      [ { empty_ins with memo="b 1f"; };
-        { empty_ins with memo=".globl el1h_sync"; label=Some ""; };
-        { empty_ins with memo="el1h_sync:"; label=Some "el1h_sync"; } ]
+    let fault_handler_prologue asmhandler =
+      map_ins
+        ("b 1f"::
+           (match asmhandler with
+            | Some p ->  [sprintf  "asm_handler%d:" p]
+            | None ->
+              [".globl el1h_sync"; "el1h_sync:";]))
 
     and fault_handler_epilogue =
       let ins =
@@ -1212,7 +1226,7 @@ module Make(V:Constant.S)(C:Config) =
             "eret" ]
         else
           [ "eret" ] in
-      let ins = List.map (fun s -> { empty_ins with memo=s;}) ins in
+      let ins = map_ins ins in
       ins@[ {empty_ins with memo="1:"; label=Some "1"; } ]
 
     let compile_ins tr_lab ins k = match ins with

--- a/litmus/ARMArch_litmus.ml
+++ b/litmus/ARMArch_litmus.ml
@@ -58,4 +58,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop = I_NOP
+  let vector_table _ = []
 end

--- a/litmus/ARMCompile_litmus.ml
+++ b/litmus/ARMCompile_litmus.ml
@@ -207,9 +207,7 @@ module Make(V:Constant.S)(C:Config) =
       let memo = sprintf "%s %s" memo (emit_opt o) in
       { empty_ins with memo =memo; }
 
-    let user_mode = [] and kernel_mode = []
-
-    let fault_handler_prologue = [] and fault_handler_epilogue = []
+    include Handler.No(struct type ins = A.Out.ins end)
 
     let compile_ins tr_lab ins k = match ins with
     | I_NOP -> { empty_ins with memo = "nop"; }::k

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -113,7 +113,7 @@ module RegMap = A.RegMap)
 
       let dump_inputs args0 compile_val chan t trashed =
         let stable = RegSet.of_list t.Tmpl.stable in
-        let all = Tmpl.all_regs t.Tmpl.code t.Tmpl.final in
+        let all = Tmpl.all_regs_in_tmpl t in
         let init_set =
             (List.fold_right
                (fun (reg,_) -> RegSet.add reg) t.Tmpl.init RegSet.empty) in
@@ -191,7 +191,8 @@ module RegMap = A.RegMap)
         let final = RegSet.of_list t.Tmpl.final in
         if debug then
           eprintf "P%i: stable={%s}, final={%s}, all={%s}\n"
-            proc (pp_regs stable) (pp_regs final) (pp_regs (Tmpl.all_regs t.Tmpl.code t.Tmpl.final));
+            proc (pp_regs stable) (pp_regs final)
+            (pp_regs (Tmpl.all_regs_in_tmpl t));
         let outs =
           String.concat ","
             (List.fold_right

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -106,4 +106,5 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
   let type_reg r = CBase.type_reg r
 
   let features = []
+  let vector_table _ = []
 end

--- a/litmus/CTarget.ml
+++ b/litmus/CTarget.ml
@@ -40,6 +40,7 @@ let compile_presi_out_ptr_reg proc reg =
 
 let get_nrets _ = 0
 let get_nnops _ = 0
+let has_asmhandler _ = false
 
 let get_addrs_only t = List.map fst t.inputs
 let get_addrs t = get_addrs_only t,[]

--- a/litmus/CTarget.mli
+++ b/litmus/CTarget.mli
@@ -34,6 +34,7 @@ val compile_presi_out_reg : int -> arch_reg -> string
 val compile_presi_out_ptr_reg : int -> arch_reg -> string
 val get_nrets : t -> int
 val get_nnops : t -> int
+val has_asmhandler : t -> bool
 val get_addrs_only : t -> string list
 val get_addrs : t -> string list * string list
 val out_code : out_channel -> code -> unit

--- a/litmus/Handler.ml
+++ b/litmus/Handler.ml
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* Copyright 2022-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,16 +14,24 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-module type S = sig
-  module A : Arch_litmus.S
+(** Arch dependent code for exception handlers *)
 
-  val is_ret : A.instruction -> bool
-  val is_nop : A.instruction -> bool
-  val extract_addrs : A.instruction -> Global_litmus.Set.t
-  val stable_regs : A.instruction -> A.RegSet.t
-  val emit_loop : A.Out.ins list -> A.Out.ins list
-  include Handler.S with type ins = A.Out.ins
-  val compile_ins :
-      (Label.t -> string) ->
-        A.instruction ->  A.Out.ins list -> A.Out.ins list
+module type S = sig
+  type ins
+
+  val user_mode : ins list
+  val kernel_mode : ins list
+
+  val fault_handler_prologue : int option -> ins list
+  val fault_handler_epilogue : ins list
+end
+
+module No(A:sig type ins end) =
+struct
+  type ins = A.ins
+
+  let user_mode = [] and kernel_mode = []
+
+  let fault_handler_prologue _ = []
+  let fault_handler_epilogue = []
 end

--- a/litmus/Handler.mli
+++ b/litmus/Handler.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* Copyright 2022-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,16 +14,16 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-module type S = sig
-  module A : Arch_litmus.S
+(** Arch dependent code for exception handlers *)
 
-  val is_ret : A.instruction -> bool
-  val is_nop : A.instruction -> bool
-  val extract_addrs : A.instruction -> Global_litmus.Set.t
-  val stable_regs : A.instruction -> A.RegSet.t
-  val emit_loop : A.Out.ins list -> A.Out.ins list
-  include Handler.S with type ins = A.Out.ins
-  val compile_ins :
-      (Label.t -> string) ->
-        A.instruction ->  A.Out.ins list -> A.Out.ins list
+module type S = sig
+  type ins
+
+  val user_mode : ins list
+  val kernel_mode : ins list
+
+  val fault_handler_prologue : Proc.t option -> ins list
+  val fault_handler_epilogue : ins list
 end
+
+module No(A:sig type ins end) : S with type ins = A.ins

--- a/litmus/LISAArch_litmus.ml
+++ b/litmus/LISAArch_litmus.ml
@@ -54,4 +54,5 @@ module Make(V:Constant.S) = struct
       end)
   let features = []
   let nop = Pnop
+  let vector_table _ = []
 end

--- a/litmus/LISACompile.ml
+++ b/litmus/LISACompile.ml
@@ -86,9 +86,7 @@ module Make(V:Constant.S) =
             let m,i = compile_roi roi in
             add_par (reg_to_string r ^ "+" ^ m),r::i,[r,type_vo vo]
 
-    let user_mode = [] and kernel_mode = []
-
-    let fault_handler_prologue = [] and fault_handler_epilogue = []
+    include Handler.No(struct type ins = A.Out.ins end)
 
     let compile_ins tr_lab ins k =
     match ins with

--- a/litmus/LISALang.ml
+++ b/litmus/LISALang.ml
@@ -45,7 +45,7 @@ module Make(V:Constant.S) = struct
         dump_ins (k+1) ts in
 (* Prefix *)
     let reg_env = Tmpl.get_reg_env A.I.error A.I.warn t in
-    let all_regs = Tmpl.all_regs t.Tmpl.code t.Tmpl.final in
+    let all_regs = Tmpl.all_regs_in_tmpl t in
     let init =
       List.fold_left (fun m (r,v) -> RegMap.add r v m)
         RegMap.empty

--- a/litmus/MIPSArch_litmus.ml
+++ b/litmus/MIPSArch_litmus.ml
@@ -51,4 +51,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop = NOP
+  let vector_table _ = []
 end

--- a/litmus/MIPSCompile_litmus.ml
+++ b/litmus/MIPSCompile_litmus.ml
@@ -111,9 +111,7 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
 
     let emit_loop _k = assert false
 
-    let user_mode = [] and kernel_mode = []
-
-    let fault_handler_prologue = [] and fault_handler_epilogue = []
+    include Handler.No(struct type ins = A.Out.ins end)
 
     let compile_ins tr_lab ins k = match ins with
     | NOP -> { empty_ins with memo = "nop"; }::k

--- a/litmus/PPCArch_litmus.ml
+++ b/litmus/PPCArch_litmus.ml
@@ -91,4 +91,5 @@ module Make (O:Arch_litmus.Config)(V:Constant.S) = struct
 
   let features = []
   let nop = Pnop
+  let vector_table _ = []
 end

--- a/litmus/PPCCompile_litmus.ml
+++ b/litmus/PPCCompile_litmus.ml
@@ -219,9 +219,7 @@ module Make(V:Constant.S)(C:Config) =
           cmpwi loop_idx 0;
           bcc tr_nolab Gt lbl1; ]
 
-    let user_mode = [] and kernel_mode = []
-
-    let fault_handler_prologue = [] and fault_handler_epilogue = []
+    include Handler.No(struct type ins = A.Out.ins end)
 
     let do_compile_ins tr_lab ins k = match tr_ins ins with
     | Pnop -> { empty_ins with memo="nop"; }::k

--- a/litmus/RISCVArch_litmus.ml
+++ b/litmus/RISCVArch_litmus.ml
@@ -30,4 +30,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop = INop
+  let vector_table _ = []
 end

--- a/litmus/RISCVCompile_litmus.ml
+++ b/litmus/RISCVCompile_litmus.ml
@@ -67,9 +67,7 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
 
     let emit_loop _ins = assert false
 
-    let user_mode = [] and kernel_mode = []
-
-    let fault_handler_prologue = [] and fault_handler_epilogue = []
+    include Handler.No(struct type ins = A.Out.ins end)
 
     let compile_ins tr_lab ins k = match ins with
     | A.INop -> { empty_ins with memo="nop"; }::k

--- a/litmus/X86Arch_litmus.ml
+++ b/litmus/X86Arch_litmus.ml
@@ -63,4 +63,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop =  I_NOP
+  let vector_table _ = []
 end

--- a/litmus/X86Compile_litmus.ml
+++ b/litmus/X86Compile_litmus.ml
@@ -234,9 +234,7 @@ module Make(V:Constant.S)(O:Arch_litmus.Config) =
        emit_lbl lbl2;
        jcc no_tr C_GT lbl1;]
 
-    let user_mode = [] and kernel_mode = []
-
-    let fault_handler_prologue = [] and fault_handler_epilogue = []
+    include Handler.No(struct type ins = A.Out.ins end)
 
     let rec do_compile_ins tr_lab ins = match ins with
     | I_NOP ->

--- a/litmus/X86_64Arch_litmus.ml
+++ b/litmus/X86_64Arch_litmus.ml
@@ -62,4 +62,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop =  I_NOP
+  let vector_table _ = []
 end

--- a/litmus/X86_64Compile_litmus.ml
+++ b/litmus/X86_64Compile_litmus.ml
@@ -260,9 +260,7 @@ module Make(Cfg:Config)(V:Constant.S)(O:Arch_litmus.Config) =
       in
            Misc.lowercase inst_str
 
-    let user_mode = [] and kernel_mode = []
-
-    let fault_handler_prologue = [] and fault_handler_epilogue = []
+    include Handler.No(struct type ins = A.Out.ins end)
 
     let rec do_compile_ins tr_lab ins = match ins with
     | I_NOP ->

--- a/litmus/arch_litmus.mli
+++ b/litmus/arch_litmus.mli
@@ -64,6 +64,7 @@ module type Base = sig
   val type_reg : reg -> CType.t
 
   val features : ((instruction -> bool) * string) list
+  val vector_table : string -> string list
 
 end
 
@@ -101,5 +102,5 @@ module type S =
 
     val features : ((instruction -> bool) * string) list
     val nop : instruction
-
+    val vector_table : string -> string list
   end

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -629,7 +629,7 @@ type P.code = MiscParser.proc * A.pseudo list)
                 let asmhandler =
                   let open Driver in
                   match O.driver with
-                  | C|Shell -> Some proc
+                  | C|Shell -> proc
                   | XCode ->
                      Warn.user_error "No custom handler for XCode" in
                 C.fault_handler_prologue asmhandler@code@C.fault_handler_epilogue,addrs

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -673,7 +673,7 @@ type P.code = MiscParser.proc * A.pseudo list)
           let stable =
                A.RegSet.inter
                  (A.RegSet.union stable stable_info)
-                 (A.Out.all_regs code final) in
+                 (A.Out.all_regs code fhandler final) in
           let stable = A.RegSet.elements stable in
           proc,
           { init ;

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -610,8 +610,6 @@ type P.code = MiscParser.proc * A.pseudo list)
         else Label.Set.empty in
       let mains,fhandlers =
         List.partition (fun (_,func,_) -> func=MiscParser.Main) code in
-      if fhandlers <> [] && O.driver = Driver.C then
-        Warn.warn_always "The C driver has experimental support for custom fault handlers" ;
       let outs =
         List.map
           (fun (proc,_,code) ->

--- a/litmus/dumpRun.ml
+++ b/litmus/dumpRun.ml
@@ -189,7 +189,8 @@ let run_tests names out_chan =
             | None -> ()
             | Some exp -> fprintf exp "%s\n" name
             end ;
-            a,(doc::docs),(src::srcs),cycles,hash_env,IntSet.add nt nts
+            a,(doc::docs),(src::srcs),cycles,hash_env,
+            IntSet.add nt nts
         | Absent a -> a,docs,srcs,cycles,hash_env,nts
         | Interrupted (a,e) ->
             let msg =  match e with
@@ -436,18 +437,19 @@ let dump_c xcode names =
     (fun out_chan ->
       let module O = Indent.Make(struct let hexa = Cfg.hexa let out = out_chan end) in
       O.o "#include <stdlib.h>" ;
-      begin match Cfg.mode with
-      | Mode.Std|Mode.PreSi ->
-         if Cfg.stdio then
-           O.o "#include <stdio.h>"
-         else
-           O.o "#include \"litmus_io.h\"" ;
-         if Cfg.sleep > 0 then  O.o "#include <unistd.h>"
-      | Mode.Kvm ->
-         O.o "#include \"kvm-headers.h\"" ;
-         O.o "#include \"utils.h\"" ;
-         if Cfg.sleep > 0 then
-           O.o "#include <asm/delay.h>"
+      begin
+        match Cfg.mode with
+        | Mode.Std|Mode.PreSi ->
+           if Cfg.stdio then
+             O.o "#include <stdio.h>"
+           else
+             O.o "#include \"litmus_io.h\"" ;
+           if Cfg.sleep > 0 then  O.o "#include <unistd.h>"
+        | Mode.Kvm ->
+           O.o "#include \"kvm-headers.h\"" ;
+           O.o "#include \"utils.h\"" ;
+           if Cfg.sleep > 0 then
+             O.o "#include <asm/delay.h>"
       end ;
       begin match Cfg.threadstyle with
       | ThreadStyle.Cached -> O.o "extern void set_pool(void);"
@@ -455,7 +457,8 @@ let dump_c xcode names =
       end ;
       O.o "" ;
       O.o "/* Declarations of tests entry points */" ;
-      let arch,docs,srcs,utils,nts = run_tests names out_chan in
+      let arch,docs,srcs,utils,nts =
+        run_tests names out_chan in
       let module C = struct
         include Cfg
         include (val (get_arch arch) : ArchConf)
@@ -556,7 +559,7 @@ let dump_c_cont xcode arch sources utils nts =
   let shared_topology = Cfg.alloc = Alloc.Dynamic in
   let sources = List.map Filename.basename  sources in
   let utils =
-    if shared_topology then utils@["topology.c"]
+    if shared_topology then utils@[Tar.outname "topology.c"]
     else utils in
 (* Makefile *)
   let infile = not xcode in

--- a/litmus/handler.ml
+++ b/litmus/handler.ml
@@ -23,7 +23,7 @@ module type S = sig
   val kernel_mode : ins list
 
   val fault_handler_prologue : int -> ins list
-  val fault_handler_epilogue : ins list
+  val fault_handler_epilogue : ins list -> ins list
 end
 
 module No(A:sig type ins end) =
@@ -33,5 +33,5 @@ struct
   let user_mode = [] and kernel_mode = []
 
   let fault_handler_prologue _ = []
-  let fault_handler_epilogue = []
+  let fault_handler_epilogue _ = []
 end

--- a/litmus/handler.ml
+++ b/litmus/handler.ml
@@ -22,8 +22,16 @@ module type S = sig
   val user_mode : ins list
   val kernel_mode : ins list
 
-  val fault_handler_prologue : Proc.t option -> ins list
+  val fault_handler_prologue : int -> ins list
   val fault_handler_epilogue : ins list
 end
 
-module No(A:sig type ins end) : S with type ins = A.ins
+module No(A:sig type ins end) =
+struct
+  type ins = A.ins
+
+  let user_mode = [] and kernel_mode = []
+
+  let fault_handler_prologue _ = []
+  let fault_handler_epilogue = []
+end

--- a/litmus/handler.mli
+++ b/litmus/handler.mli
@@ -23,7 +23,7 @@ module type S = sig
   val kernel_mode : ins list
 
   val fault_handler_prologue : Proc.t -> ins list
-  val fault_handler_epilogue : ins list
+  val fault_handler_epilogue : ins list -> ins list
 end
 
 module No(A:sig type ins end) : S with type ins = A.ins

--- a/litmus/handler.mli
+++ b/litmus/handler.mli
@@ -22,16 +22,8 @@ module type S = sig
   val user_mode : ins list
   val kernel_mode : ins list
 
-  val fault_handler_prologue : int option -> ins list
+  val fault_handler_prologue : Proc.t -> ins list
   val fault_handler_epilogue : ins list
 end
 
-module No(A:sig type ins end) =
-struct
-  type ins = A.ins
-
-  let user_mode = [] and kernel_mode = []
-
-  let fault_handler_prologue _ = []
-  let fault_handler_epilogue = []
-end
+module No(A:sig type ins end) : S with type ins = A.ins

--- a/litmus/libdir/_aarch64/asmhandler.c
+++ b/litmus/libdir/_aarch64/asmhandler.c
@@ -1,0 +1,8 @@
+static void exceptions_init_test(void *p) {
+  asm __volatile__ (
+"msr vbar_el1,%0\n\t"
+"isb\n"
+:
+: "r" (p)
+);
+}

--- a/litmus/libdir/_instance.c
+++ b/litmus/libdir/_instance.c
@@ -173,5 +173,6 @@ static void set_role(global_t *g,thread_ctx_t *c,int part) {
     c->ctx = NULL ;
     c->role = -1 ;
   }
+  set_fault_vector(c->role);
   barrier_wait(&g->gb) ;
 }

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -766,7 +766,10 @@ module Make
               EPF.fi fmt ["total / 1000000.0"] ;
               O.oi "fflush(out);"
           | Mode.Kvm ->
-              if Cfg.have_fault_handler then O.oi "pp_faults();" ;
+              if
+                Cfg.have_fault_handler
+                && not (T.has_asmhandler test)
+              then O.oi "pp_faults();" ;
               let s = sprintf "Time %s "  doc.Name.name in
               O.fi "puts(%S);" s ;
               O.oi "emit_double(tsc_millions(total));" ;

--- a/litmus/target.mli
+++ b/litmus/target.mli
@@ -22,6 +22,7 @@ module type S = sig
 
   val get_nrets : t -> int
   val get_nnops : t -> int
+  val has_asmhandler : t -> bool
   val get_addrs_only : t -> string list
   val get_addrs : t -> string list * string list
   val dump_out_reg : int -> arch_reg -> string

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -90,6 +90,7 @@ module type S = sig
 
   val get_nrets : t -> int
   val get_nnops : t -> int
+  val has_asmhandler : t -> bool
   val get_addrs_only : t -> string list
   val get_phys_only : t -> string list
   val get_addrs : t -> string list * string list (* addresses X ptes *)
@@ -171,6 +172,7 @@ module Make(O:Config)(A:I) =
 
     let get_nrets t = t.nrets
     and get_nnops t = t.nnops
+    and has_asmhandler t = Misc.consp t.fhandler
 
     (* Generic function to extract some symbols *)
     let get_gen tr init addrs =

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -115,7 +115,8 @@ module type S = sig
   module RegSet : MySet.S with type elt = arch_reg
   module RegMap : MyMap.S with type key = arch_reg
 
-  val all_regs : ins list -> arch_reg list -> RegSet.t
+  val all_regs : ins list -> ins list -> arch_reg list -> RegSet.t
+  val all_regs_in_tmpl : t -> RegSet.t
   val trashed_regs : t -> RegSet.t
   val get_reg_env :
       (CType.t -> CType.t -> bool)-> (* fail *)
@@ -365,11 +366,13 @@ module Make(O:Config)(A:I) =
     module RegSet = A.RegSet
     module RegMap = A.RegMap
 
-    let all_regs code final =
+    let all_regs code fhandler final =
       let all_ins ins =
         RegSet.union (RegSet.of_list (ins.inputs@ins.outputs)) in
-      List.fold_right all_ins code  (RegSet.of_list final)
+      let k = List.fold_right all_ins code  (RegSet.of_list final) in
+      List.fold_right all_ins fhandler  k
 
+    let all_regs_in_tmpl t = all_regs t.code t.fhandler t.final
 
     let trashed_regs t =
       let trashed_ins ins = RegSet.union (RegSet.of_list ins.outputs) in

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -178,7 +178,8 @@ module Top(O:Config)(Tar:Tar.S) = struct
       module Comp = Compile.Make (Compile.Default)(A)(T)(LISAComp)
 
       let compile fname =
-        Utils.compile P.parse List.length Comp.compile (allocate fname)
+        Utils.compile
+          P.parse MiscParser.count_procs Comp.compile (allocate fname)
           fname
     end
 

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -324,7 +324,7 @@ end = struct
         let allocate parsed =
           let module Alloc = SymbReg.Make(AllocArch) in
           Alloc.allocate_regs parsed in
-        Utils.compile P.parse List.length Comp.compile allocate
+        Utils.compile P.parse MiscParser.count_procs Comp.compile allocate
     end
 
 


### PR DESCRIPTION
This PR attempts implementing custom fault handlers in mode `-driver C`. This is a followup to PR #401. The technique is quite different as it consists in having one vector table per per test thread. As a consequence default vector table entries are made global with the following patch: [0001-PATCH-arm64-Make-default-vector-table-entries-global-bis.patch.txt](https://github.com/herd/herdtools7/files/9133153/0001-PATCH-arm64-Make-default-vector-table-entries-global-bis.patch.txt)