### PR TITLE
[litmus] Fix presi

### DIFF
--- a/litmus/libdir/_instance.c
+++ b/litmus/libdir/_instance.c
@@ -173,6 +173,10 @@ static void set_role(global_t *g,thread_ctx_t *c,int part) {
     c->ctx = NULL ;
     c->role = -1 ;
   }
+#ifdef KVM  
+#ifdef HAVE_FAULT_HANDLER
   set_fault_vector(c->role);
+#endif
+#endif
   barrier_wait(&g->gb) ;
 }

--- a/litmus/libdir/_x86_64/kvm-headers.h
+++ b/litmus/libdir/_x86_64/kvm-headers.h
@@ -48,3 +48,9 @@ static inline pteval_t *litmus_tr_pte(void *p) {
 static inline void litmus_flush_tlb(void *_p) {
   flush_tlb();
 }
+
+/* For AArch64, this performs BBM, not needed for X86_64, as
+   no PTE change is performed. Yet? */
+static inline pteval_t litmus_set_pte_safe(void *q,pteval_t *p,pteval_t x) {
+  return litmus_set_pte(p,x);
+}


### PR DESCRIPTION
Updates to `-mode presi` that follow `-mode kvm` evolution (in particular PR #406).