### PR TITLE
[litmus] Explict handler for EL0 threads

### DIFF
--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -443,13 +443,6 @@ match name with
 (* System registers *)
 | "mrs"|"MRS" -> MRS
 | "msr"|"MSR" -> MSR
-| "ctr_el0"|"CTR_EL0" -> SYSREG A.CTR_EL0
-| "dciz_el0"|"DCIZ_EL0" -> SYSREG A.DCIZ_EL0
-| "mdccsr_el0"|"MDCCSR_EL0" -> SYSREG A.MDCCSR_EL0
-| "dbgdtr_el0"|"DBGDTR_EL0" -> SYSREG A.DBGDTR_EL0
-| "dbgdtrrx_el0"|"DBGDTRRX_EL0" -> SYSREG A.DBGDTRRX_EL0
-| "Dbgdtrtx_el0"|"DBGDTRTX_EL0" -> SYSREG A.DBGDTRTX_EL0
-| "elr_el1"|"ELR_EL1" -> SYSREG A.ELR_EL1
 | _ ->
     begin match A.parse_wreg name with
     | Some r -> ARCH_WREG r
@@ -473,7 +466,11 @@ match name with
                         | 'Q' -> ARCH_QREG r
                         | _ -> assert false
                         end
-                    | None -> NAME name
+                    | None ->
+                        begin match A.parse_sysreg name with
+                        | Some r -> SYSREG r
+                        | None -> NAME name
+                        end
                     end
                 end
             end

--- a/lib/procsUser.ml
+++ b/lib/procsUser.ml
@@ -30,3 +30,5 @@ let get info =
           | LexScan.Error ->
               Warn.user_error "'%s' is not a list of thread names" p
         end
+
+let is ps p = List.exists  (Proc.equal p) ps

--- a/lib/procsUser.mli
+++ b/lib/procsUser.mli
@@ -17,3 +17,6 @@
 (** List of threads in user mode *)
 
 val get : (string * string) list -> Proc.t list
+
+(* Is a particular proc in user mode? *)
+val is :  Proc.t list -> Proc.t -> bool

--- a/litmus/AArch64Arch_litmus.ml
+++ b/litmus/AArch64Arch_litmus.ml
@@ -86,14 +86,17 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
 
       let nop = I_NOP
 
-      let vector_table name =
+      let vector_table is_user name =
+        let el1h_sync,el0_sync_64 =
+          if is_user then "el1h_sync",name
+          else name,"el0_sync_64" in
         let ventry label k = ".align 7"::Printf.sprintf "b %s" label::k in
         let ( ** ) label k = ventry label k in
         "adr %0,2f"::"b 1f"::
          ".align 11"::"2:"::
          "el1t_sync" ** "el1t_irq" ** "el1t_fiq" ** "el1t_error"
-         ** name ** "el1h_irq" ** "el1h_fiq" ** "el1h_error"
-         ** "el0_sync_64" ** "el0_irq_64" ** "el0_fiq_64" ** "el0_error_64"
+         ** el1h_sync ** "el1h_irq" ** "el1h_fiq" ** "el1h_error"
+         ** el0_sync_64 ** "el0_irq_64" ** "el0_fiq_64" ** "el0_error_64"
          ** "el0_sync_32" ** "el0_irq_32" ** "el0_fiq_32" ** "el0_error_32"
          ** ["1:"]
 

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1206,8 +1206,8 @@ module Make(V:Constant.S)(C:Config) =
 
     let user_prologue =
       ["mrs %[tr0],esr_el1";
-       "lsr %[tr0],%[tr0],#26";
-       "cmp %[tr0],#21";
+       "lsr %[tr0],%[tr0],#%[esr_el1_ec_shift]";
+       "cmp %[tr0],#%[esr_el1_ec_svc64]";
        "cset %[tr0],ne";
        "lsl %[tr0],%[tr0],#2";
        "adr %[tr1],2f";

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1204,10 +1204,25 @@ module Make(V:Constant.S)(C:Config) =
 
     let kernel_mode = [{ empty_ins with memo="svc #471"}]
 
-    let fault_handler_prologue p =
-      map_ins ["b 1f";sprintf  "asm_handler%d:" p]
+    let user_prologue =
+      ["mrs %[tr0],esr_el1";
+       "lsr %[tr0],%[tr0],#26";
+       "cmp %[tr0],#21";
+       "cset %[tr0],ne";
+       "lsl %[tr0],%[tr0],#2";
+       "adr %[tr1],2f";
+       "add %[tr1],%[tr1],%[tr0]";
+       "br %[tr1]";
+       "2:";
+       "b 1f";
+      ]
 
-    and fault_handler_epilogue code =
+    let fault_handler_prologue is_user p =
+      map_ins
+        ((fun k -> "b 1f"::sprintf  "asm_handler%d:" p::k)
+        (if is_user then user_prologue else []))
+
+    and fault_handler_epilogue is_user code =
       let ins =
         if
           List.exists
@@ -1220,10 +1235,12 @@ module Make(V:Constant.S)(C:Config) =
             "msr elr_el1,%[tr0]" ;
             "eret" ]
         else if Precision.is_fatal C.precision then
-          [ "mrs %[tr0],elr_el1" ;
-            "adr %[tr0],1f";
-            "msr elr_el1,%[tr0]";
-            "eret" ]
+          (if is_user then []
+           else
+             [ "mrs %[tr0],elr_el1" ;
+               "adr %[tr0],1f";
+               "msr elr_el1,%[tr0]";
+               "eret" ])
         else
           [ "eret" ] in
       let ins = map_ins ins in

--- a/litmus/ARMArch_litmus.ml
+++ b/litmus/ARMArch_litmus.ml
@@ -58,5 +58,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop = I_NOP
-  let vector_table _ = []
+  let vector_table _ _ = []
 end

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -507,10 +507,13 @@ module RegMap = A.RegMap)
             | _ -> false)
           t.Tmpl.init
 
-      let dump_fun chan args0 env globEnv _volatileEnv proc t =
+      let dump_fun ?(user=false) chan args0 env globEnv _volatileEnv proc t =
         let args0 = match t.Tmpl.fhandler with
           | [] -> args0
-          | _ -> { args0 with Template.trashed=["tr0"] } in
+          | _ ->
+             let trashed =
+               if user then ["tr0";"tr1";] else  ["tr0"] in
+             { args0 with Template.trashed=trashed; } in
         if debug then debug_globEnv globEnv ;
         let ptevalEnv = extract_ptevals t in
         let labels = Tmpl.get_labels t in

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -174,11 +174,15 @@ module RegMap = A.RegMap)
               let v = A.V.zero in
               dump_pair reg v::k)
             rem [] in
+        let consts =
+          List.map
+            (fun (tag,v) ->  sprintf "[%s] \"i\" (%s)" tag v)
+            args0.Template.constants in
         let args0 =
           List.map
             (fun (_,(tag,v)) -> sprintf "[%s] \"r\" (%s)" tag v)
             args0.Template.inputs in
-        let out =  (String.concat "," (args0@ins@rem)) in
+        let out =  (String.concat "," (consts@args0@ins@rem)) in
 (*        eprintf "IN: {%s}\n" out ; *)
         fprintf chan ":%s\n" out
 

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -106,5 +106,5 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
   let type_reg r = CBase.type_reg r
 
   let features = []
-  let vector_table _ = []
+  let vector_table _ _ = []
 end

--- a/litmus/CLang.ml
+++ b/litmus/CLang.ml
@@ -90,8 +90,8 @@ module Make(C:Config)(E:Extra) = struct
       (List.map
          (fun (x,ty) -> sprintf "%s -> %s" x (CType.debug ty))
          env)
-
-  let dump_fun chan _args0 env globEnv _envVolatile proc t =
+  let dump_fun ?user chan _args0 env globEnv _envVolatile proc t =
+    assert (Misc.is_none user) ;
     if dbg then
       begin
         let pp = pp_env globEnv in

--- a/litmus/LISAArch_litmus.ml
+++ b/litmus/LISAArch_litmus.ml
@@ -54,5 +54,5 @@ module Make(V:Constant.S) = struct
       end)
   let features = []
   let nop = Pnop
-  let vector_table _ = []
+  let vector_table _ _ = []
 end

--- a/litmus/LISALang.ml
+++ b/litmus/LISALang.ml
@@ -100,7 +100,8 @@ module Make(V:Constant.S) = struct
 
   and compile_out_reg_fun p r = sprintf "*%s" (Tmpl.dump_out_reg p r)
 
-  let dump_fun chan _args0 env globEnv _volatileEnv proc t =
+  let dump_fun ?user chan _args0 env globEnv _volatileEnv proc t =
+    assert (Misc.is_none user) ;
     let addrs_proc = A.Out.get_addrs_only t in
     let addrs =
       List.map

--- a/litmus/MIPSArch_litmus.ml
+++ b/litmus/MIPSArch_litmus.ml
@@ -51,5 +51,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop = NOP
-  let vector_table _ = []
+  let vector_table _ _ = []
 end

--- a/litmus/PPCArch_litmus.ml
+++ b/litmus/PPCArch_litmus.ml
@@ -91,5 +91,5 @@ module Make (O:Arch_litmus.Config)(V:Constant.S) = struct
 
   let features = []
   let nop = Pnop
-  let vector_table _ = []
+  let vector_table _ _ = []
 end

--- a/litmus/RISCVArch_litmus.ml
+++ b/litmus/RISCVArch_litmus.ml
@@ -30,5 +30,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop = INop
-  let vector_table _ = []
+  let vector_table _ _ = []
 end

--- a/litmus/X86Arch_litmus.ml
+++ b/litmus/X86Arch_litmus.ml
@@ -63,5 +63,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop =  I_NOP
-  let vector_table _ = []
+  let vector_table _ _ = []
 end

--- a/litmus/X86_64Arch_litmus.ml
+++ b/litmus/X86_64Arch_litmus.ml
@@ -62,5 +62,5 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop =  I_NOP
-  let vector_table _ = []
+  let vector_table _ _ = []
 end

--- a/litmus/arch_litmus.mli
+++ b/litmus/arch_litmus.mli
@@ -64,7 +64,7 @@ module type Base = sig
   val type_reg : reg -> CType.t
 
   val features : ((instruction -> bool) * string) list
-  val vector_table : string -> string list
+  val vector_table : bool -> string -> string list
 
 end
 
@@ -102,5 +102,5 @@ module type S =
 
     val features : ((instruction -> bool) * string) list
     val nop : instruction
-    val vector_table : string -> string list
+    val vector_table : bool -> string -> string list
   end

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -640,12 +640,12 @@ type P.code = MiscParser.proc * A.pseudo list)
             let nnops = count_nop code in
             let addrs = extract_addrs code in
             let stable = stable_regs code in
-            let is_user = (List.exists (Proc.equal proc) procs_user) in
+            let is_user = ProcsUser.is procs_user proc in
             let (code,fhandler),addrs =
               try
                 let (_,_,c) = List.find (fun (p,_,_) -> Proc.equal p proc) fhandlers in
                 if is_user then
-                  Warn.user_error "Process %d running in userspace cannot have fault handler" proc ;
+                  Warn.warn_always "Process %d running in userspace with fault handler" proc ;
                 let addrs = G.Set.union (extract_addrs c) addrs in
                 let code,fhandler =
                   compile_code proc esc is_user code (Some c) in

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -528,8 +528,8 @@ type P.code = MiscParser.proc * A.pseudo list)
              | C|Shell -> proc
              | XCode ->
              Warn.user_error "No custom handler for XCode" in
-           C.fault_handler_prologue asmhandler
-           @fhandler_c@C.fault_handler_epilogue fhandler_c in
+           C.fault_handler_prologue user asmhandler
+           @fhandler_c@C.fault_handler_epilogue user fhandler_c in
       code,fhandler
 
 

--- a/litmus/handler.ml
+++ b/litmus/handler.ml
@@ -22,8 +22,8 @@ module type S = sig
   val user_mode : ins list
   val kernel_mode : ins list
 
-  val fault_handler_prologue : int -> ins list
-  val fault_handler_epilogue : ins list -> ins list
+  val fault_handler_prologue : bool -> int -> ins list
+  val fault_handler_epilogue : bool -> ins list -> ins list
 end
 
 module No(A:sig type ins end) =
@@ -32,6 +32,6 @@ struct
 
   let user_mode = [] and kernel_mode = []
 
-  let fault_handler_prologue _ = []
-  let fault_handler_epilogue _ = []
+  let fault_handler_prologue _ _ = assert false
+  let fault_handler_epilogue _ _ = assert false
 end

--- a/litmus/handler.mli
+++ b/litmus/handler.mli
@@ -22,8 +22,9 @@ module type S = sig
   val user_mode : ins list
   val kernel_mode : ins list
 
-  val fault_handler_prologue : Proc.t -> ins list
-  val fault_handler_epilogue : ins list -> ins list
+  (* First boolean argument reflects user mode *)
+  val fault_handler_prologue : bool -> Proc.t -> ins list
+  val fault_handler_epilogue : bool -> ins list -> ins list
 end
 
 module No(A:sig type ins end) : S with type ins = A.ins

--- a/litmus/language.ml
+++ b/litmus/language.ml
@@ -19,8 +19,8 @@ module type S = sig
   module RegMap : MyMap.S with type key = arch_reg
   type t
 
-(* Function dump *)
   val dump_fun :
+    ?user:bool ->
     out_channel ->
     Template.extra_args ->
     CType.t RegMap.t ->

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1315,6 +1315,7 @@ module Make
 (* Thread code, as functions *)
       let dump_thread_code
             procs_user env (proc,(out,(_outregs,envVolatile)))  =
+        Printf.eprintf "Code: %i, %b\n" proc (A.Out.has_asmhandler out) ;
         let myenv = U.select_proc proc env
         and global_env = U.select_global env in
         let global_env =
@@ -1330,7 +1331,14 @@ module Make
           let open Template in
           if user then
             { trashed=["tr0"];
-              inputs=[(CType.word,"cpu"),("sp_usr","user_stack[cpu]")];}
+              inputs=[(CType.word,"cpu"),("sp_usr","user_stack[cpu]")];
+              constants=
+                begin
+                  if A.Out.has_asmhandler out then
+                    ["esr_el1_ec_svc64","ESR_EL1_EC_SVC64";
+                     "esr_el1_ec_shift","ESR_EL1_EC_SHIFT";]
+                  else []
+                end; }
           else no_extra_args in
         Lang.dump_fun ~user
           O.out args0 myenv global_env envVolatile proc out

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -49,9 +49,10 @@ end
 
 type extra_args =
   { trashed: string list;
-    inputs: ((CType.t * string) * (string * string)) list; }
+    inputs: ((CType.t * string) * (string * string)) list;
+    constants: (string * string) list; }
 
-let no_extra_args = { trashed=[]; inputs=[];}
+let no_extra_args = { trashed=[]; inputs=[]; constants=[];}
 
 module type S = sig
   module V : Constant.S


### PR DESCRIPTION
This PR extends the implementation of explicit handlers to EL0.

One of the difficulty to solve is for the actual handler to discriminate between a fault and the final `svc` call. In the first case the user supplied handler should be executed; while in the latter case, a simple branch to end of code should be performed, thereby leaving the exception level at EL1.