### PR TITLE
[gen] Fix some bugs related to AMO instructions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,9 +163,10 @@ arm-test::
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 ARM instructions tests: OK"
 
-test:: diy-test
+test::
 
-diy-test:
+diy-test:: diy-test-aarch64
+diy-test-aarch64:
 	@ echo
 	$(HERD_DIYCROSS_REGRESSION_TEST) \
 		-herd-path $(HERD) \
@@ -228,11 +229,12 @@ mte-test:
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 catalogue aarch64-MTE tests: OK"
 
-test:: diy-test-mixed
+test:: diy-test
 
 LDS:="Amo.Cas,Amo.LdAdd,Amo.LdClr,Amo.LdEor,Amo.LdSet"
 LDSPLUS:="LxSx",$(LDS)
 
+diy-test:: diy-test-mixed
 diy-test-mixed::
 	@ echo
 	$(HERD_DIYCROSS_REGRESSION_TEST) \
@@ -353,7 +355,7 @@ v64:
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64.mixed.v64 diycross7 tests: OK"
 
-test:: diy-store-test
+diy-test:: diy-store-test
 diy-store-test:
 	@ echo
 	$(HERD_DIYCROSS_REGRESSION_TEST) \
@@ -373,3 +375,30 @@ diy-store-test:
 		-diycross-arg 'Rfe,Fre,Coe' \
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64 diycross7.store tests: OK"
+
+diy-test:: diy-test-mte
+diy-test-mte::
+	@ echo
+	$(HERD_DIYCROSS_REGRESSION_TEST) \
+		-j $(J) \
+		-herd-path $(HERD) \
+		-diycross-path $(DIYCROSS) \
+		-libdir-path ./herd/libdir \
+		-expected-dir ./herd/tests/diycross/AArch64.MTE \
+		-conf ./herd/tests/diycross/AArch64.MTE/MTE.cfg \
+		-diycross-arg -arch \
+		-diycross-arg AArch64 \
+		-diycross-arg -variant \
+		-diycross-arg memtag \
+		-diycross-arg DMB.SYd*W \
+		-diycross-arg T,P \
+		-diycross-arg Rfe \
+		-diycross-arg A \
+		-diycross-arg Amo.LdAdd \
+		-diycross-arg L \
+		-diycross-arg PodW* \
+		-diycross-arg T,P \
+		-diycross-arg Coe,Rfe,Fre \
+		-diycross-arg T,P \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64.MTE diycross7 tests: OK"

--- a/herd/tests/diycross/AArch64.MTE/LB+dmb.sy+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/LB+dmb.sy+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+dmb.sy+amo.ldaddal-polp Allowed
+States 4
+0:X1=0; 1:X1=0; [y]=1;
+0:X1=0; 1:X1=1; [y]=3;
+0:X1=1; 1:X1=0; [y]=1;
+0:X1=1; 1:X1=1; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=3 /\ 0:X1=1 /\ 1:X1=1)
+Observation LB+dmb.sy+amo.ldaddal-polp Sometimes 1 3
+Hash=17bc6369fabbd03dc92fee1a469c1247
+

--- a/herd/tests/diycross/AArch64.MTE/LB+dmb.sy+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/LB+dmb.sy+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+dmb.sy+amo.ldaddal-polt Allowed
+States 4
+0:X1=0; 1:X1=0; [y]=1;  ~Fault(P0,x);
+0:X1=0; 1:X1=0; [y]=1; Fault(P0,x:red);
+0:X1=0; 1:X1=1; [y]=3;  ~Fault(P0,x);
+0:X1=0; 1:X1=1; [y]=3; Fault(P0,x:red);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=3 /\ 0:X1=0 /\ 1:X1=1 /\ not (fault(P0,x)))
+Observation LB+dmb.sy+amo.ldaddal-polt Sometimes 1 3
+Hash=d03abdfed2cd95ba87dc0d3549be20e0
+

--- a/herd/tests/diycross/AArch64.MTE/LB+dmb.sypt+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/LB+dmb.sypt+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+dmb.sypt+amo.ldaddal-polp Allowed
+States 4
+0:X1=0; 1:X1=0; [y]=1;  ~Fault(P1,y);
+0:X1=0; 1:X1=0; [y]=1; Fault(P1,y:red);
+0:X1=1; 1:X1=0; [y]=1;  ~Fault(P1,y);
+0:X1=1; 1:X1=0; [y]=1; Fault(P1,y:red);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=1 /\ 0:X1=1 /\ 1:X1=0 /\ not (fault(P1,y)))
+Observation LB+dmb.sypt+amo.ldaddal-polp Sometimes 1 3
+Hash=87309187ae3bab33ea58c7d5b4d190a0
+

--- a/herd/tests/diycross/AArch64.MTE/LB+dmb.sypt+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/LB+dmb.sypt+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+dmb.sypt+amo.ldaddal-polt Allowed
+States 4
+0:X1=0; 1:X1=0; [y]=1;  ~Fault(P1,y); ~Fault(P0,x);
+0:X1=0; 1:X1=0; [y]=1; Fault(P0,x:red); ~Fault(P1,y);
+0:X1=0; 1:X1=0; [y]=1; Fault(P0,x:red); Fault(P1,y:red);
+0:X1=0; 1:X1=0; [y]=1; Fault(P1,y:red); ~Fault(P0,x);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=1 /\ 0:X1=0 /\ 1:X1=0 /\ not (fault(P0,x) \/ fault(P1,y)))
+Observation LB+dmb.sypt+amo.ldaddal-polt Sometimes 1 3
+Hash=1678822dfd5adb60be5a14fd6abde5a8
+

--- a/herd/tests/diycross/AArch64.MTE/LB+dmb.sytp+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/LB+dmb.sytp+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,11 @@
+Test LB+dmb.sytp+amo.ldaddal-polp Allowed
+States 2
+0:X0=x:green; 1:X1=0; [y]=1;
+0:X0=x:green; 1:X1=1; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists ([y]=3 /\ 0:X0=x:green /\ 1:X1=1)
+Observation LB+dmb.sytp+amo.ldaddal-polp Sometimes 1 1
+Hash=35764c17e93b51902564b58bca616e90
+

--- a/herd/tests/diycross/AArch64.MTE/LB+dmb.sytp+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/LB+dmb.sytp+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+dmb.sytp+amo.ldaddal-polt Allowed
+States 4
+0:X0=x:green; 1:X1=0; [y]=1;
+0:X0=x:green; 1:X1=1; [y]=3;
+0:X0=x:red; 1:X1=0; [y]=1;
+0:X0=x:red; 1:X1=1; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=3 /\ 0:X0=x:red /\ 1:X1=1)
+Observation LB+dmb.sytp+amo.ldaddal-polt Sometimes 1 3
+Hash=b0710f9e71f1e8eb2f708e5d5cd210e6
+

--- a/herd/tests/diycross/AArch64.MTE/LB+dmb.sytt+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/LB+dmb.sytt+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,11 @@
+Test LB+dmb.sytt+amo.ldaddal-polp Allowed
+States 2
+0:X0=x:green; 1:X1=0; [y]=1;  ~Fault(P1,y);
+0:X0=x:green; 1:X1=0; [y]=1; Fault(P1,y:red);
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists ([y]=1 /\ 0:X0=x:green /\ 1:X1=0 /\ not (fault(P1,y)))
+Observation LB+dmb.sytt+amo.ldaddal-polp Sometimes 1 1
+Hash=89b43b02ede8882f386b8d8f6114b280
+

--- a/herd/tests/diycross/AArch64.MTE/LB+dmb.sytt+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/LB+dmb.sytt+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test LB+dmb.sytt+amo.ldaddal-polt Allowed
+States 4
+0:X0=x:green; 1:X1=0; [y]=1;  ~Fault(P1,y);
+0:X0=x:green; 1:X1=0; [y]=1; Fault(P1,y:red);
+0:X0=x:red; 1:X1=0; [y]=1;  ~Fault(P1,y);
+0:X0=x:red; 1:X1=0; [y]=1; Fault(P1,y:red);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=1 /\ 0:X0=x:red /\ 1:X1=0 /\ not (fault(P1,y)))
+Observation LB+dmb.sytt+amo.ldaddal-polt Sometimes 1 3
+Hash=16742ff0fc19815a0c23d536994a4002
+

--- a/herd/tests/diycross/AArch64.MTE/MP+dmb.sy+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/MP+dmb.sy+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+dmb.sy+amo.ldaddal-polp Allowed
+States 4
+1:X1=0; 1:X4=0; [y]=1;
+1:X1=0; 1:X4=1; [y]=1;
+1:X1=1; 1:X4=0; [y]=3;
+1:X1=1; 1:X4=1; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=3 /\ 1:X1=1 /\ 1:X4=0)
+Observation MP+dmb.sy+amo.ldaddal-polp Sometimes 1 3
+Hash=5dc5c187bcebd8248b69c1da91f5a5e3
+

--- a/herd/tests/diycross/AArch64.MTE/MP+dmb.sy+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/MP+dmb.sy+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,11 @@
+Test MP+dmb.sy+amo.ldaddal-polt Allowed
+States 2
+1:X1=0; 1:X3=x:green; [y]=1;
+1:X1=1; 1:X3=x:green; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists ([y]=3 /\ 1:X1=1 /\ 1:X3=x:green)
+Observation MP+dmb.sy+amo.ldaddal-polt Sometimes 1 1
+Hash=185683e89e9d791c8aa40bccb3ecc364
+

--- a/herd/tests/diycross/AArch64.MTE/MP+dmb.sypt+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/MP+dmb.sypt+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+dmb.sypt+amo.ldaddal-polp Allowed
+States 4
+1:X1=0; 1:X4=0; [y]=1;  ~Fault(P1,y);
+1:X1=0; 1:X4=0; [y]=1; Fault(P1,y:red);
+1:X1=0; 1:X4=1; [y]=1;  ~Fault(P1,y);
+1:X1=0; 1:X4=1; [y]=1; Fault(P1,y:red);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=1 /\ 1:X1=0 /\ 1:X4=0 /\ not (fault(P1,y)))
+Observation MP+dmb.sypt+amo.ldaddal-polp Sometimes 1 3
+Hash=6faf62fa651f6c4c98c4d5f3c2b380ea
+

--- a/herd/tests/diycross/AArch64.MTE/MP+dmb.sypt+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/MP+dmb.sypt+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,11 @@
+Test MP+dmb.sypt+amo.ldaddal-polt Allowed
+States 2
+1:X1=0; 1:X3=x:green; [y]=1;  ~Fault(P1,y);
+1:X1=0; 1:X3=x:green; [y]=1; Fault(P1,y:red);
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists ([y]=1 /\ 1:X1=0 /\ 1:X3=x:green /\ not (fault(P1,y)))
+Observation MP+dmb.sypt+amo.ldaddal-polt Sometimes 1 1
+Hash=9b6058dae5ff2ee1392680b3206be720
+

--- a/herd/tests/diycross/AArch64.MTE/MP+dmb.sytp+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/MP+dmb.sytp+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+dmb.sytp+amo.ldaddal-polp Allowed
+States 4
+1:X1=0; 1:X4=0; [y]=1;  ~Fault(P1,x);
+1:X1=0; 1:X4=0; [y]=1; Fault(P1,x:green);
+1:X1=1; 1:X4=0; [y]=3;  ~Fault(P1,x);
+1:X1=1; 1:X4=0; [y]=3; Fault(P1,x:green);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=3 /\ 1:X1=1 /\ 1:X4=0 /\ not (fault(P1,x)))
+Observation MP+dmb.sytp+amo.ldaddal-polp Sometimes 1 3
+Hash=e3e470b75006d9ccf4635f3d73e234b9
+

--- a/herd/tests/diycross/AArch64.MTE/MP+dmb.sytp+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/MP+dmb.sytp+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+dmb.sytp+amo.ldaddal-polt Allowed
+States 4
+1:X1=0; 1:X3=x:green; [y]=1;
+1:X1=0; 1:X3=x:red; [y]=1;
+1:X1=1; 1:X3=x:green; [y]=3;
+1:X1=1; 1:X3=x:red; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=3 /\ 1:X1=1 /\ 1:X3=x:green)
+Observation MP+dmb.sytp+amo.ldaddal-polt Sometimes 1 3
+Hash=31e288332fabd4a60afc236bdef9e38a
+

--- a/herd/tests/diycross/AArch64.MTE/MP+dmb.sytt+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/MP+dmb.sytt+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+dmb.sytt+amo.ldaddal-polp Allowed
+States 4
+1:X1=0; 1:X4=0; [y]=1;  ~Fault(P1,y); ~Fault(P1,x);
+1:X1=0; 1:X4=0; [y]=1; Fault(P1,x:green); ~Fault(P1,y);
+1:X1=0; 1:X4=0; [y]=1; Fault(P1,x:green); Fault(P1,y:red);
+1:X1=0; 1:X4=0; [y]=1; Fault(P1,y:red); ~Fault(P1,x);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=1 /\ 1:X1=0 /\ 1:X4=0 /\ not (fault(P1,x) \/ fault(P1,y)))
+Observation MP+dmb.sytt+amo.ldaddal-polp Sometimes 1 3
+Hash=3545f816e5ace9ece8ab98f7ceb07273
+

--- a/herd/tests/diycross/AArch64.MTE/MP+dmb.sytt+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/MP+dmb.sytt+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+dmb.sytt+amo.ldaddal-polt Allowed
+States 4
+1:X1=0; 1:X3=x:green; [y]=1;  ~Fault(P1,y);
+1:X1=0; 1:X3=x:green; [y]=1; Fault(P1,y:red);
+1:X1=0; 1:X3=x:red; [y]=1;  ~Fault(P1,y);
+1:X1=0; 1:X3=x:red; [y]=1; Fault(P1,y:red);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=1 /\ 1:X1=0 /\ 1:X3=x:green /\ not (fault(P1,y)))
+Observation MP+dmb.sytt+amo.ldaddal-polt Sometimes 1 3
+Hash=9b64e5f5eb3c140d70336e29c6d375a1
+

--- a/herd/tests/diycross/AArch64.MTE/MTE.cfg
+++ b/herd/tests/diycross/AArch64.MTE/MTE.cfg
@@ -1,0 +1,26 @@
+variant memtag
+#All tests should be allowed when model is relaxed.
+skipchecks external
+graph cluster
+squished true
+showevents noregs
+withbox true
+labelbox true
+fontsize 12
+xscale 2.0
+yscale 1.5
+arrowsize 0.8
+splines spline
+pad 0.1
+doshow data
+doshow addr
+edgeattr iico_data,color,violetred
+edgeattr iico_ctrl,color,lightblue
+edgeattr rmw,color,indigo
+edgeattr rf-reg,color,red3
+withbox true
+unshow dd,intrinsic
+labelbox true
+doshow fr,co,rmw
+unshow dmb.sy,dmb.st,dmb.ld,ca,dsb.sy,isb
+

--- a/herd/tests/diycross/AArch64.MTE/S+dmb.sy+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/S+dmb.sy+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sy+amo.ldaddal-polp Allowed
+States 4
+1:X1=0; [x]=1; [y]=1;
+1:X1=0; [x]=2; [y]=1;
+1:X1=1; [x]=1; [y]=3;
+1:X1=1; [x]=2; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([x]=2 /\ [y]=3 /\ 1:X1=1)
+Observation S+dmb.sy+amo.ldaddal-polp Sometimes 1 3
+Hash=ac31d6fe1185d8d544d2c220fa02ccb6
+

--- a/herd/tests/diycross/AArch64.MTE/S+dmb.sy+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/S+dmb.sy+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sy+amo.ldaddal-polt Allowed
+States 4
+1:X1=0; [x]=1; [y]=1;  ~Fault(P0,x);
+1:X1=0; [x]=1; [y]=1; Fault(P0,x:red);
+1:X1=1; [x]=1; [y]=3;  ~Fault(P0,x);
+1:X1=1; [x]=1; [y]=3; Fault(P0,x:red);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([x]=1 /\ [y]=3 /\ 1:X1=1 /\ not (fault(P0,x)))
+Observation S+dmb.sy+amo.ldaddal-polt Sometimes 1 3
+Hash=fc144829a130dfafd143834b20f10285
+

--- a/herd/tests/diycross/AArch64.MTE/S+dmb.sypt+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/S+dmb.sypt+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sypt+amo.ldaddal-polp Allowed
+States 4
+1:X1=0; [x]=1; [y]=1;  ~Fault(P1,y);
+1:X1=0; [x]=1; [y]=1; Fault(P1,y:red);
+1:X1=0; [x]=2; [y]=1;  ~Fault(P1,y);
+1:X1=0; [x]=2; [y]=1; Fault(P1,y:red);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([x]=2 /\ [y]=1 /\ 1:X1=0 /\ not (fault(P1,y)))
+Observation S+dmb.sypt+amo.ldaddal-polp Sometimes 1 3
+Hash=e9d45b526e1b489b2325fab6e114e48c
+

--- a/herd/tests/diycross/AArch64.MTE/S+dmb.sypt+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/S+dmb.sypt+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sypt+amo.ldaddal-polt Allowed
+States 4
+1:X1=0; [x]=1; [y]=1;  ~Fault(P1,y); ~Fault(P0,x);
+1:X1=0; [x]=1; [y]=1; Fault(P0,x:red); ~Fault(P1,y);
+1:X1=0; [x]=1; [y]=1; Fault(P0,x:red); Fault(P1,y:red);
+1:X1=0; [x]=1; [y]=1; Fault(P1,y:red); ~Fault(P0,x);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([x]=1 /\ [y]=1 /\ 1:X1=0 /\ not (fault(P0,x) \/ fault(P1,y)))
+Observation S+dmb.sypt+amo.ldaddal-polt Sometimes 1 3
+Hash=7f918b600dafb66778128e36ebffacbd
+

--- a/herd/tests/diycross/AArch64.MTE/S+dmb.sytp+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/S+dmb.sytp+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sytp+amo.ldaddal-polp Allowed
+States 4
+1:X1=0; [y]=1; [tag(x)]=:red;  ~Fault(P1,x);
+1:X1=0; [y]=1; [tag(x)]=:red; Fault(P1,x:green);
+1:X1=1; [y]=3; [tag(x)]=:red;  ~Fault(P1,x);
+1:X1=1; [y]=3; [tag(x)]=:red; Fault(P1,x:green);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([tag(x)]=:red /\ [y]=3 /\ 1:X1=1 /\ not (fault(P1,x)))
+Observation S+dmb.sytp+amo.ldaddal-polp Sometimes 1 3
+Hash=1584470bb16be5b8c59c856576584bf7
+

--- a/herd/tests/diycross/AArch64.MTE/S+dmb.sytp+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/S+dmb.sytp+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sytp+amo.ldaddal-polt Allowed
+States 4
+1:X1=0; [y]=1; [tag(x)]=:blue;
+1:X1=0; [y]=1; [tag(x)]=:red;
+1:X1=1; [y]=3; [tag(x)]=:blue;
+1:X1=1; [y]=3; [tag(x)]=:red;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([tag(x)]=:blue /\ [y]=3 /\ 1:X1=1)
+Observation S+dmb.sytp+amo.ldaddal-polt Sometimes 1 3
+Hash=935319150350fb5621f087696e8ab7e8
+

--- a/herd/tests/diycross/AArch64.MTE/S+dmb.sytt+amo.ldaddal-polp.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/S+dmb.sytt+amo.ldaddal-polp.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sytt+amo.ldaddal-polp Allowed
+States 4
+1:X1=0; [y]=1; [tag(x)]=:red;  ~Fault(P1,y); ~Fault(P1,x);
+1:X1=0; [y]=1; [tag(x)]=:red; Fault(P1,x:green); ~Fault(P1,y);
+1:X1=0; [y]=1; [tag(x)]=:red; Fault(P1,x:green); Fault(P1,y:red);
+1:X1=0; [y]=1; [tag(x)]=:red; Fault(P1,y:red); ~Fault(P1,x);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([tag(x)]=:red /\ [y]=1 /\ 1:X1=0 /\ not (fault(P1,x) \/ fault(P1,y)))
+Observation S+dmb.sytt+amo.ldaddal-polp Sometimes 1 3
+Hash=d58df4fc5dbc47469494c72325885498
+

--- a/herd/tests/diycross/AArch64.MTE/S+dmb.sytt+amo.ldaddal-polt.litmus.expected
+++ b/herd/tests/diycross/AArch64.MTE/S+dmb.sytt+amo.ldaddal-polt.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sytt+amo.ldaddal-polt Allowed
+States 4
+1:X1=0; [y]=1; [tag(x)]=:blue;  ~Fault(P1,y);
+1:X1=0; [y]=1; [tag(x)]=:blue; Fault(P1,y:red);
+1:X1=0; [y]=1; [tag(x)]=:red;  ~Fault(P1,y);
+1:X1=0; [y]=1; [tag(x)]=:red; Fault(P1,y:red);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([tag(x)]=:blue /\ [y]=1 /\ 1:X1=0 /\ not (fault(P1,y)))
+Observation S+dmb.sytt+amo.ldaddal-polt Sometimes 1 3
+Hash=a4e30010d224cb17e7372b451ea77e35
+


### PR DESCRIPTION
They were two problems:

1. Memory cell value after the AMO was wrong. This was due to `set_tcell` altering the cell value in state `st`. As far as memtag variant is concerned, there is no reason to do so, as the generated `STG` instruction does not write to the memory location and only change the tag memory. Fixed  in `cycle.ml`.
2. Locations were not adjusted with current tag but with initial tag `0` instead. Fixed in `AArch64Compile_gen.ml`.