### PR TITLE
[litmus] Simple implementation of explicit handlers from EL0.

### DIFF
--- a/litmus/AArch64Arch_litmus.ml
+++ b/litmus/AArch64Arch_litmus.ml
@@ -86,20 +86,27 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
 
       let nop = I_NOP
 
+      let user_handler_clobber = "x29"
+      let user_handler_clobbers = [ user_handler_clobber; ]
+
       let vector_table is_user name =
         let el1h_sync,el0_sync_64 =
           if is_user then "el1h_sync",name
           else name,"el0_sync_64" in
-        let ventry label k = ".align 7"::Printf.sprintf "b %s" label::k in
+        let ventry label k = ".align 7"::Printf.sprintf "b %s" label::k
+        and wentry _label k =
+          ".align 7"
+          ::Printf.sprintf "br %s" user_handler_clobber
+          ::k in
         let ( ** ) label k = ventry label k in
+        let ( *** ) label k =
+          if is_user then wentry label k else ventry label k in
         "adr %0,2f"::"b 1f"::
          ".align 11"::"2:"::
          "el1t_sync" ** "el1t_irq" ** "el1t_fiq" ** "el1t_error"
          ** el1h_sync ** "el1h_irq" ** "el1h_fiq" ** "el1h_error"
-         ** el0_sync_64 ** "el0_irq_64" ** "el0_fiq_64" ** "el0_error_64"
+         ** el0_sync_64 *** "el0_irq_64" ** "el0_fiq_64" ** "el0_error_64"
          ** "el0_sync_32" ** "el0_irq_32" ** "el0_fiq_32" ** "el0_error_32"
          ** ["1:"]
-
-
 
 end

--- a/litmus/ARMArch_litmus.ml
+++ b/litmus/ARMArch_litmus.ml
@@ -58,5 +58,6 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop = I_NOP
-  let vector_table _ _ = []
+
+  include HardwareExtra.No
 end

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -71,11 +71,11 @@ module RegMap = A.RegMap)
       module RegSet = Tmpl.RegSet
       module RegMap = Tmpl.RegMap
 
-      let dump_clobbers chan t =
+      let dump_clobbers chan clobs t =
         fprintf chan ":%s\n"
           (String.concat ","
              (List.map (fun s -> sprintf "\"%s\"" s)
-                ("cc"::"memory"::
+                ("cc"::"memory"::clobs@
                  List.map A.reg_to_string
                    (t.Tmpl.all_clobbers@A.forbidden_regs))))
 
@@ -424,7 +424,7 @@ module RegMap = A.RegMap)
           dump_fh chan proc t.Tmpl.fhandler ;
         dump_outputs args0 compile_addr compile_out_reg chan proc t trashed ;
         dump_inputs args0 compile_val chan t trashed ;
-        dump_clobbers chan t  ;
+        dump_clobbers chan args0.Template.clobbers t  ;
         fprintf chan ");\n" ;
         after_dump compile_out_reg chan indent proc t env;
         ()

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -106,5 +106,6 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
   let type_reg r = CBase.type_reg r
 
   let features = []
-  let vector_table _ _ = []
+
+  include HardwareExtra.No
 end

--- a/litmus/LISAArch_litmus.ml
+++ b/litmus/LISAArch_litmus.ml
@@ -54,5 +54,6 @@ module Make(V:Constant.S) = struct
       end)
   let features = []
   let nop = Pnop
-  let vector_table _ _ = []
+
+  include HardwareExtra.No
 end

--- a/litmus/MIPSArch_litmus.ml
+++ b/litmus/MIPSArch_litmus.ml
@@ -51,5 +51,6 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop = NOP
-  let vector_table _ _ = []
+
+  include HardwareExtra.No
 end

--- a/litmus/PPCArch_litmus.ml
+++ b/litmus/PPCArch_litmus.ml
@@ -91,5 +91,6 @@ module Make (O:Arch_litmus.Config)(V:Constant.S) = struct
 
   let features = []
   let nop = Pnop
-  let vector_table _ _ = []
+
+  include HardwareExtra.No
 end

--- a/litmus/RISCVArch_litmus.ml
+++ b/litmus/RISCVArch_litmus.ml
@@ -30,5 +30,6 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop = INop
-  let vector_table _ _ = []
+
+  include HardwareExtra.No
 end

--- a/litmus/X86Arch_litmus.ml
+++ b/litmus/X86Arch_litmus.ml
@@ -63,5 +63,6 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop =  I_NOP
-  let vector_table _ _ = []
+
+  include HardwareExtra.No
 end

--- a/litmus/X86_64Arch_litmus.ml
+++ b/litmus/X86_64Arch_litmus.ml
@@ -62,5 +62,6 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
       end)
   let features = []
   let nop =  I_NOP
-  let vector_table _ _ = []
+
+  include HardwareExtra.No
 end

--- a/litmus/arch_litmus.mli
+++ b/litmus/arch_litmus.mli
@@ -64,6 +64,7 @@ module type Base = sig
   val type_reg : reg -> CType.t
 
   val features : ((instruction -> bool) * string) list
+  val user_handler_clobbers : string list
   val vector_table : bool -> string -> string list
 
 end
@@ -102,5 +103,6 @@ module type S =
 
     val features : ((instruction -> bool) * string) list
     val nop : instruction
-    val vector_table : bool -> string -> string list
+
+    include HardwareExtra.S
   end

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -420,6 +420,8 @@ type P.code = MiscParser.proc * A.pseudo list)
     | A.Symbolic _ (*no symbolic in litmus *)
     | A.Macro _ -> assert false
 
+    let first_label = if is_pte then C.max_handler_label else 0
+
     let lblmap_code no =
       let rec do_rec cm = function
         | [] -> cm
@@ -427,14 +429,14 @@ type P.code = MiscParser.proc * A.pseudo list)
             let cm = lblmap_pseudo no cm i in
             do_rec cm code in
       fun code co ->
-        let (_,m) as cm = do_rec (0,Label.Map.empty) code in
+        let (_,m) as cm = do_rec (first_label,Label.Map.empty) code in
         match co with
         | None -> m
         | Some code ->
            let _,m = do_rec cm code in
            m
 
-    (*******************************)
+(*******************************)
 (* Count specific instructions *)
 (*******************************)
 
@@ -511,12 +513,16 @@ type P.code = MiscParser.proc * A.pseudo list)
          code,fhandler
 
     let compile_code proc no user code fhandler =
+      let has_handler = Misc.is_some fhandler in
       let code,fhandler_c = compile_pseudo_code no code fhandler in
       let code =
         if O.timeloop > 0 then C.emit_loop code
         else code in
       let code =
-        if user then C.user_mode@code@C.kernel_mode
+        if user then
+          C.user_mode has_handler proc
+          @code
+          @C.kernel_mode has_handler
         else code
       and fhandler =
         match fhandler with

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -649,9 +649,8 @@ type P.code = MiscParser.proc * A.pseudo list)
             let is_user = ProcsUser.is procs_user proc in
             let (code,fhandler),addrs =
               try
-                let (_,_,c) = List.find (fun (p,_,_) -> Proc.equal p proc) fhandlers in
-                if is_user then
-                  Warn.warn_always "Process %d running in userspace with fault handler" proc ;
+                let (_,_,c) =
+                  List.find (fun (p,_,_) -> Proc.equal p proc) fhandlers in
                 let addrs = G.Set.union (extract_addrs c) addrs in
                 let code,fhandler =
                   compile_code proc esc is_user code (Some c) in

--- a/litmus/handler.mli
+++ b/litmus/handler.mli
@@ -19,8 +19,13 @@
 module type S = sig
   type ins
 
-  val user_mode : ins list
-  val kernel_mode : ins list
+  (* Strictly greater than any label in handler *)
+  val max_handler_label : int
+
+  (* Emit code to and from user mode,
+     boolean argument signals explicit handler *)
+  val user_mode : bool -> Proc.t -> ins list
+  val kernel_mode : bool -> ins list
 
   (* First boolean argument reflects user mode *)
   val fault_handler_prologue : bool -> Proc.t -> ins list

--- a/litmus/hardwareExtra.ml
+++ b/litmus/hardwareExtra.ml
@@ -14,27 +14,16 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Arch dependent code for exception handlers *)
+(** Additional hardware features *)
 
-module type S = sig
-  type ins
 
-  val max_handler_label : int
-
-  val user_mode : bool -> Proc.t -> ins list
-  val kernel_mode : bool -> ins list
-
-  val fault_handler_prologue : bool -> int -> ins list
-  val fault_handler_epilogue : bool -> ins list -> ins list
+module type S  = sig
+  val user_handler_clobbers : string list
+  val vector_table : bool -> string -> string list
 end
 
-module No(A:sig type ins end) =
-struct
-  type ins = A.ins
-
-  let max_handler_label = 0
-  let user_mode _ _ = [] and kernel_mode _ = []
-
-  let fault_handler_prologue _ _ = assert false
-  let fault_handler_epilogue _ _ = assert false
+module No = struct
+  let user_handler_clobbers = []
+  let vector_table _ _ = []
 end
+              

--- a/litmus/hardwareExtra.mli
+++ b/litmus/hardwareExtra.mli
@@ -14,27 +14,12 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Arch dependent code for exception handlers *)
+(** Additional hardware features *)
 
-module type S = sig
-  type ins
-
-  val max_handler_label : int
-
-  val user_mode : bool -> Proc.t -> ins list
-  val kernel_mode : bool -> ins list
-
-  val fault_handler_prologue : bool -> int -> ins list
-  val fault_handler_epilogue : bool -> ins list -> ins list
+module type S  = sig
+  val user_handler_clobbers : string list
+  val vector_table : bool -> string -> string list
 end
 
-module No(A:sig type ins end) =
-struct
-  type ins = A.ins
-
-  let max_handler_label = 0
-  let user_mode _ _ = [] and kernel_mode _ = []
-
-  let fault_handler_prologue _ _ = assert false
-  let fault_handler_epilogue _ _ = assert false
-end
+module No : S
+              

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1331,13 +1331,12 @@ module Make
           if user then
             { trashed=["tr0"];
               inputs=[(CType.word,"cpu"),("sp_usr","user_stack[cpu]")];
-              constants=
-                begin
-                  if A.Out.has_asmhandler out then
-                    ["esr_el1_ec_svc64","ESR_EL1_EC_SVC64";
-                     "esr_el1_ec_shift","ESR_EL1_EC_SHIFT";]
-                  else []
-                end; }
+              constants=[];
+              clobbers=
+                if A.Out.has_asmhandler out then
+                  A.user_handler_clobbers
+                else [];
+            }
           else no_extra_args in
         Lang.dump_fun ~user
           O.out args0 myenv global_env envVolatile proc out

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -50,9 +50,10 @@ end
 type extra_args =
   { trashed: string list;
     inputs: ((CType.t * string) * (string * string)) list;
-    constants: (string * string) list; }
+    constants: (string * string) list;
+    clobbers: string list; }
 
-let no_extra_args = { trashed=[]; inputs=[]; constants=[];}
+let no_extra_args = { trashed=[]; inputs=[]; constants=[]; clobbers=[]; }
 
 module type S = sig
   module V : Constant.S


### PR DESCRIPTION
Explicit handlers for EL0 threads are slightly tricky because there is only one slot for two functionalities: execute explicit handler and return to EL1 at end of thread code. This question is solved by using a branch-to-register instruction as handler code and by setting the register according to intended target code.