### PR TITLE
[herd,litmus] Fix some glitches in integer printing.

### DIFF
--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -818,12 +818,14 @@ module Make(C:Config) (I:I) : S with module I = I
       (* Scalars are always for the same effective type,
          (V.Cst.Scalar.t). For printing a scalar of "external"
          type t, the value itself is changed, masking for unsigned
-         types, sign extension for signed types *)
+         types, sign extension for signed types. For hexadecimal priniting,
+         all type behave as unsigned.
+       *)
 
       let cast_for_pp_with_base b sc =
         let sz = size_of_t b in
         if sz = I.V.Cst.Scalar.machsize then sc
-        else if TestType.is_signed b then I.V.Cst.Scalar.sxt sz sc
+        else if TestType.is_signed b && not C.hexa then I.V.Cst.Scalar.sxt sz sc
         else I.V.Cst.Scalar.mask sz sc
 
       let cast_for_pp_with_type t =
@@ -836,7 +838,7 @@ module Make(C:Config) (I:I) : S with module I = I
       let pp_typed t v =
         let max_unsigned =
            MachSize.equal (mem_access_size_of_t t) I.V.Cst.Scalar.machsize
-          && not (signed_of_t t) in
+          && (not (signed_of_t t) || C.hexa) in
         let v = I.V.map_scalar (cast_for_pp_with_type t) v in
         if max_unsigned then I.V.pp_unsigned C.hexa v
         else I.V.pp C.hexa v

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -351,19 +351,22 @@ module Make
       | Indirect -> sprintf "_a->%s[_i]"
 
 (* Right value, all cases *)
-      let rec dump_a_v = function
-        | Concrete i ->  A.V.Scalar.pp  Cfg.hexa i
+      let rec do_dump_a_v hexa = function
+        | Concrete i ->  A.V.Scalar.pp  hexa i
         | Symbolic (Virtual {name=s;tag=None; offset=0;_}) ->
             dump_a_addr s
         | ConcreteVector vs ->
            let pps =
              List.map
-               (fun v -> sprintf "%s," (dump_a_v v))
+               (fun v -> sprintf "%s," (do_dump_a_v hexa v))
                vs in
            sprintf "{%s}" (String.concat "" pps)
         | Symbolic _|Label _|Tag _|PteVal _ -> assert false
         | Instruction _ ->
           Warn.fatal "FIXME: dump_a_v functionality for -variant self"
+
+      let dump_a_v = do_dump_a_v Cfg.hexa
+      and dump_a_v_dec = do_dump_a_v false
 
 (* Dump left & right values when context is available *)
 
@@ -1183,10 +1186,10 @@ module Make
             | (Indirect,Pointer _) ->
                 let load = U.do_load t (wrap addr) in
                 sprintf "%s != %s"
-                  load (dump_a_v v)
+                  load (dump_a_v_dec v)
             | Indirect,_ ->
                 let load = U.do_load t (wrap addr) in
-                sprintf "%s != %s" load (A.Out.dump_v v)
+                sprintf "%s != %s" load (dump_a_v_dec v)
             | (Direct,Array _) ->
                 let load = U.do_load t (wrap addr) in
                 sprintf "%s != %s"
@@ -1194,7 +1197,7 @@ module Make
             | (Direct,_) ->
                 let load = U.do_load t (wrap addr) in
                 sprintf "%s != %s"
-                  load (dump_a_v v) in
+                  load (dump_a_v_dec v) in
           List.iter
             (fun (s,t as x) -> match t with
             | Base "mtx_t" -> ()


### PR DESCRIPTION
More specifically:
  + `herd7 -hexa true` should print all integer as unsigned.
  + `litmus7` internal sanity  checks (cf. `check_globals`) are sometime wrong, probably dur to `int` promotion.
  + Final conditon printing ignore location types (a matter of aesthetics only?).