### PR TITLE
[AArch64 MTE] Relaxing Tag-Ordered-Before for Loads

### DIFF
--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -133,7 +133,7 @@ let bob = po; [dmb.full]; po
 	| po; [L]
 
 (* Tag-ordered-before *)
-let tob = [R & T]; iico_data; [PRED]; iico_ctrl; [M \ T]
+let tob = [R & T]; iico_data; [PRED]; iico_ctrl; [W \ T]
 
 (* Locally-ordered-before *)
 let rec lob = lws; si


### PR DESCRIPTION
The architecture defines a relation called Tag-Ordered-Before for Checked instructions, between the Tag-Check-Read Effect and the Memory Effect generated by that instruction, if any. This Tag-Ordered-Before relation is currently required to be maintained for all Checked instructions. Feedback indicates that Tag-Ordered-Before being maintained for loads is unnecessary for software.

The definition of Tag-ordered-before in Section B2.3 of the spec is changed to read:

If ARMv8.5-MemTag is implemented, a Memory Tag-Check-read R1 is Tag-ordered-before a Checked Memory Write effect W2 generated by the same instruction if and only if all of the following apply:
- there is an Intrinsic data dependendency from R1 to a Conditional-Branching effect B3 generated by the same instruction as R1;
- there is an Intrinsic control dependency from the Conditional-Branching effect B3 to W2.