### PR TITLE
[herd] Limits sc-per-location inner check to explicit accesses

### DIFF
--- a/herd/libdir/cos-no-opt.cat
+++ b/herd/libdir/cos-no-opt.cat
@@ -1,0 +1,18 @@
+"Generate co's"
+
+include "cross.cat"
+
+let invrf = rf^-1
+let cobase = co0
+with co from generate_cos(cobase)
+
+(* From now, co is a coherence order *)
+let coi = co & int
+let coe = co \ coi
+
+(* Compute fr *)
+let fr = (invrf ; co) \ id
+let fri = fr & int
+let fre = fr \ fri
+
+show co,fr

--- a/herd/libdir/cos-opt.cat
+++ b/herd/libdir/cos-opt.cat
@@ -3,21 +3,28 @@
 (* generates possible co's, optimized version *)
 
 (* co observations in test *)
+
 let invrf = rf^-1
 
+(* Relation pco is computed by herd7 code
+
 let obsco =
+  let po-loc = [Exp];po-loc;[Exp] in
   let ww = po-loc & (W * W)
   and rw = rf ; (po-loc & (R * W))
   and wr = ((po-loc & (W * R)) ; invrf) \ id
   and rr = (rf ; (po-loc & (R * R)) ; invrf) \ id in
   (ww|rw|wr|rr)
 
+let pco = obsco|co0
+*)
+
 (* The following applies to C only, where RMW is both R and W *)
 let rmwco =
   let _RMW = R & W in
   rf & (W * _RMW) (* co observation by atomicity *)
 
-let cobase = obsco|rmwco|co0
+let cobase = rmwco|pco
 
 (* Catch uniproc violations early *)
 acyclic cobase as ConsCo

--- a/herd/libdir/cos.cat
+++ b/herd/libdir/cos.cat
@@ -1,18 +1,7 @@
 "Generate co's"
 
-include "cross.cat"
-
-let invrf = rf^-1
-let cobase = co0
-with co from generate_cos(cobase)
-
-(* From now, co is a coherence order *)
-let coi = co & int
-let coe = co \ coi
-
-(* Compute fr *)
-let fr = (invrf ; co) \ id
-let fri = fr & int
-let fre = fr \ fri
-
-show co,fr
+if "cos-opt"
+  include "cos-opt.cat"
+else
+  include "cos-no-opt.cat"
+end

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -32,7 +32,11 @@ module Make
     let mixed = O.variant Variant.Mixed || morello
     let memtag = O.variant Variant.MemTag
     let kvm = O.variant Variant.Kvm
-
+    let optacetrue =
+      let open OptAce in
+      match O.optace with
+      | True -> true
+      | False|Iico -> false
     let bell_fname =  Misc.app_opt (fun (x,_) -> x) O.bell_model_info
     let bell_info = Misc.app_opt (fun (_,x) -> x) O.bell_model_info
 
@@ -60,7 +64,12 @@ module Make
       let doshow = S.O.PC.doshow
       let showraw = S.O.PC.showraw
       let symetric = S.O.PC.symetric
-      let variant = Misc.delay_parse O.variant Variant.parse
+      let variant =
+        let variant =
+          if optacetrue then
+            Misc.(|||) (Variant.equal Variant.CosOpt) O.variant
+          else O.variant in
+        Misc.delay_parse variant Variant.parse
     end
     module U = MemUtils.Make(S)
     module MU = ModelUtils.Make(O)(S)
@@ -303,7 +312,9 @@ module Make
                 E.EventRel.of_pred all_evts all_evts E.same_static_event
               end;
               "same-instance", lazy begin E.EventRel.of_pred all_evts all_evts E.same_instance end;
-              "equiv-spec", lazy begin Equiv.build (Lazy.force rf_reg) all_evts end;
+              "equiv-spec",
+                lazy begin Equiv.build (Lazy.force rf_reg) all_evts end;
+              "pco", lazy conc.S.pco;
             ]))) in
       let m =
         let spec = conc.S.str.E.speculated in

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -60,6 +60,8 @@ type t =
   | Exp
 (* Instruction-fetch support (AKA "self-modifying code" mode) *)
   | Self
+(* Have cat interpreter to optimise generation of co's *)
+  | CosOpt
 (* Test something *)
   | Test
 (* One hundred tests *)
@@ -73,7 +75,7 @@ let tags =
     Precision.tags @
    ["toofar"; "deps"; "morello"; "instances"; "noptebranch"; "pte2";
    "pte-squared"; "PhantomOnLoad"; "OptRfRMW"; "ConstrainedUnpredictable";
-   "exp"; "self"; "test"; "T[0-9][0-9]"]
+   "exp"; "self"; "cos-opt"; "test"; "T[0-9][0-9]"]
 
 let parse s = match Misc.lowercase s with
 | "success" -> Some Success
@@ -106,6 +108,7 @@ let parse s = match Misc.lowercase s with
 | "constrainedunpredictable"|"cu" -> Some ConstrainedUnpredictable
 | "exp" -> Some Exp
 | "self" -> Some Self
+| "cos-opt" -> Some CosOpt
 | "test" -> Some Test
 | s ->
    begin
@@ -155,10 +158,12 @@ let pp = function
   | ConstrainedUnpredictable -> "ConstrainedUnpredictable"
   | Exp -> "exp"
   | Self -> "self"
+  | CosOpt -> "cos-opt"
   | Test -> "test"
   | T n -> Printf.sprintf "T%02i" n
 
 let compare = compare
+let equal v1 v2 = compare v1 v2 = 0
 
 let get_default a v =
   try match v with

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -58,12 +58,15 @@ type t =
   | Exp
 (* Instruction-fetch support (AKA "self-modifying code" mode) *)
   | Self
+(* Have cat interpreter to optimise generation of co's *)
+  | CosOpt
 (* Test something *)
   | Test
 (* One hundred tests *)
   | T of int
 
 val compare : t -> t -> int
+val equal : t -> t -> bool
 val tags : string list
 val parse : string -> t option
 val pp : t -> string


### PR DESCRIPTION
That way, using optimisation `-optace true` should not changes output for models that include the `sc per-location` on explict accesses and not on some non-explicit accesses.