### PR TITLE
[herd] Define `Exp` and `NExp` sets for all architectures

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -41,6 +41,10 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | Exp -> true
       | NExp _ -> false
 
+    and is_not_explicit_annot = function
+      | NExp _ -> true
+      | Exp -> false
+
     let is_barrier b1 b2 = barrier_compare b1 b2 = 0
 
     let is_speculated = function
@@ -69,13 +73,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | L | XL -> true
       | _ -> false
 
-    let is_explicit = function
-      | Exp -> true
-      | _ -> false
-    and is_not_explicit = function
-      | NExp _-> true
-      | _ -> false
-    and is_af = function (* Setting of access flag *)
+    let is_af = function (* Setting of access flag *)
       | NExp (AF|AFDB)-> true
       | _ -> false
     and is_db = function (* Setting of dirty bit flag *)
@@ -99,8 +97,6 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     ]
 
     let explicit_sets = [
-      "Exp", is_explicit;
-      "NExp", is_not_explicit;
       "AF", is_af;
       "DB", is_db;
     ]

--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -117,7 +117,7 @@ end = struct
   let is_pte_access _ = assert false
 
   (* All accesses are explicit *)
-  let is_explicit _ = true
+  include Explicit.NoAction
 
   let is_atomic a = match a with
   | Access (_,_,_,true,_,_) ->

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -179,7 +179,7 @@ end = struct
   let is_pte_access _ = assert false
 
   (* All accesses are explicit *)
-  let is_explicit _ = true
+  include Explicit.NoAction
 
   (* The following definition of is_atomic is quite arbitrary. *)
 

--- a/herd/JavaAction.ml
+++ b/herd/JavaAction.ml
@@ -183,7 +183,7 @@ end = struct
 
   let arch_rels = []
   let arch_dirty = []
-  let is_explicit _ = true
+
   let is_fault _ = false
   let is_tag _ = false
   let toofar msg = TooFar msg
@@ -194,6 +194,7 @@ end = struct
   let is_pred _ = false
   let is_commit _ = false
 
+  include Explicit.NoAction
 
   let annot_in_list _ _ = false
 

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -64,6 +64,7 @@ module type S = sig
   val get_mem_size : action -> MachSize.sz
   val is_pte_access : action -> bool
   val is_explicit : action ->bool
+  val is_not_explicit : action ->bool
 
 (* relative to the registers of the given proc *)
   val is_reg_store : action -> A.proc -> bool

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -88,6 +88,7 @@ val same_instance : event -> event -> bool
 (* Page table access *)
   val is_pt : event -> bool
   val is_explicit : event -> bool
+  val is_not_explicit : event -> bool
 (* Tag memory access *)
   val is_tag : event -> bool
   val is_mem_physical : event -> bool
@@ -603,6 +604,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
       | Some (A.Location_global (V.Val c)) -> Constant.is_pt c
       | _ -> false
     let is_explicit e = Act.is_explicit e.action
+    let is_not_explicit e = Act.is_not_explicit e.action
     let is_tag e = Act.is_tag e.action
     let is_mem_physical e =
       let open Constant in

--- a/herd/explicit.ml
+++ b/herd/explicit.ml
@@ -22,15 +22,24 @@ module type S = sig
   val exp_annot : explicit
   val nexp_annot : explicit
   val is_explicit_annot : explicit -> bool
+  val is_not_explicit_annot : explicit -> bool
   val pp_explicit : explicit -> string
   val explicit_sets : (string * (explicit -> bool)) list
 end
 
+(* Default setting: all accesses are explicit *)
 module No = struct
   type explicit = unit
   let exp_annot = ()
   let nexp_annot = ()
   let is_explicit_annot _ = true
+  let is_not_explicit_annot _ = false
   let pp_explicit _ = ""
   let explicit_sets = []
+end
+
+(* Default setting, action level *)
+module NoAction = struct
+  let is_explicit _ = true
+  and is_not_explicit _ = false
 end

--- a/herd/explicit.mli
+++ b/herd/explicit.mli
@@ -22,8 +22,16 @@ module type S = sig
   val exp_annot : explicit
   val nexp_annot : explicit
   val is_explicit_annot : explicit -> bool
+  val is_not_explicit_annot : explicit -> bool
   val pp_explicit : explicit -> string
   val explicit_sets : (string * (explicit -> bool)) list
 end
 
+(* Default setting: all accesses are explicit *)
 module No : S with type explicit=unit
+
+(* Default setting, action level *)
+module NoAction : sig
+  val is_explicit :'act -> bool
+  val is_not_explicit :'act -> bool
+end

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -409,6 +409,7 @@ end = struct
     | _ -> false
 
   let is_explicit = lift_explicit_predicate A.is_explicit_annot
+  and is_not_explicit = lift_explicit_predicate A.is_not_explicit_annot
 
 (* relative to the registers of the given proc *)
   let is_reg_store a (p:int) = match a with

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -332,6 +332,8 @@ module Make
              (are_memtypes
                 ["R", E.is_mem_load;
                  "W", E.is_mem_store;
+                 "Exp", E.is_explicit;
+                 "NExp", E.is_not_explicit;
                  "Rreg", E.is_reg_load_any;
                  "Wreg", E.is_reg_store_any;
                  "SPEC", is_spec;


### PR DESCRIPTION
Those sets were defined for AArch64 only before. However the concept of explicit and non-explicit accesses looks generic and may appear in any model. Consider for instance "sc-per-location" for explicit accesses.

Of course, the default is for all accesses to be explicit.