### PR TITLE
[herd] Restore the `cos-opt.cat` file as it was.

### DIFF
--- a/herd/libdir/cos-ok-opt.cat
+++ b/herd/libdir/cos-ok-opt.cat
@@ -3,21 +3,28 @@
 (* generates possible co's, optimized version *)
 
 (* co observations in test *)
+
 let invrf = rf^-1
 
+(* Relation pco is computed by herd7 code
+
 let obsco =
+  let po-loc = [Exp];po-loc;[Exp] in
   let ww = po-loc & (W * W)
   and rw = rf ; (po-loc & (R * W))
   and wr = ((po-loc & (W * R)) ; invrf) \ id
   and rr = (rf ; (po-loc & (R * R)) ; invrf) \ id in
   (ww|rw|wr|rr)
 
+let pco = obsco|co0
+*)
+
 (* The following applies to C only, where RMW is both R and W *)
 let rmwco =
   let _RMW = R & W in
   rf & (W * _RMW) (* co observation by atomicity *)
 
-let cobase = obsco|rmwco|co0
+let cobase = rmwco|pco
 
 (* Catch uniproc violations early *)
 acyclic cobase as ConsCo

--- a/herd/libdir/cos.cat
+++ b/herd/libdir/cos.cat
@@ -1,7 +1,7 @@
 "Generate co's"
 
 if "cos-opt"
-  include "cos-opt.cat"
+  include "cos-ok-opt.cat"
 else
   include "cos-no-opt.cat"
 end


### PR DESCRIPTION
Some models (namely the LKMM model) use cos-opt.cat directly. Those models cannot include the new co's generator that _requires_ relation `pco` to be computed, which in turn needs option `-optace true`.

Notice that the optmised co's computation introduced by PR #430 is still working, with `cos-opt.cat` now being named `cos-ok-opt.cat`.