### PR TITLE
[herd] kvm and mte combination

### DIFF
--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -293,20 +293,25 @@ Monad type:
 
     let bind_ctrl_first_outputs s f = data_comp E.bind_ctrl_first_outputs s f
 
-(* Tag check combinator *)
-    let check_tags : 'v t -> ('v -> 'v t) -> ('v -> 'v t) -> 'x t -> 'v t
-        = fun ma rtag comp commit ->
-          fun (eiid:eid) ->
-            let eiid,(aact) = ma eiid in
-            let a,acl,aes = Evt.as_singleton_nospecul aact in
-            let eiid,rtagact = rtag a eiid in
-            let eiid,commitact = commit eiid in
-            let tag,rtagcl,rtages = Evt.as_singleton_nospecul rtagact
-            and _,commitcl,commites = Evt.as_singleton_nospecul commitact in
-            let eiid,compact = comp tag eiid in
-            let vcomp,compcl,_ = Evt.as_singleton_nospecul compact in
-            let es = E.check_tags aes rtages commites in
-            eiid,(Evt.singleton (vcomp,acl@rtagcl@commitcl@compcl,es),None)
+
+(* Ad-hoc short-circuit *)
+
+    let short3 p1 p2 m =
+      fun eiid ->
+      let eiid,(acts,specs) = m eiid in
+      let acts =
+        Evt.map
+          (fun (v,cls,es) ->
+            let data3 =
+              let data = es.E.intra_causality_data in
+              let data3 =
+                E.EventRel.filter
+                  (fun (e1,e2) -> p1 e1 && p2 e2)
+                  (E.EventRel.transitive3 data) in
+              E.EventRel.union data data3 in
+            v,cls,{ es with E.intra_causality_data=data3; })
+      acts in
+       eiid,(acts,specs)
 
 (* Exchange combination *)
     let exch : 'a t -> 'a t -> ('a -> 'b t) ->  ('a -> 'c t) ->  ('b * 'c) t

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -184,6 +184,19 @@ Monad type:
     let delay (m:'a t) eiid =
       delay_kont "delay" m (fun v delayed -> unitT (v,delayed)) eiid
 
+    let set_standard_input_output m eiid =
+      let (eiid,(sact,sspec)) = m eiid in
+      let set_std (v,cl,es) =
+        let es =
+          { es with
+            E.input = None; data_input = None;
+            output = None; ctrl_output = None; } in
+        v,cl,es in
+      let set_stds = Evt.map set_std in
+      let sact = set_stds sact
+      and sspec = Misc.map_opt set_stds sspec in
+      eiid,(sact,sspec)
+      
     let (=**=) = E.(=**=)
     let (=*$=) = E.(=*$=)
     let (=$$=) = E.(=$$=)
@@ -225,11 +238,15 @@ Monad type:
 
     let data_input_next s f = data_comp E.data_input_next s f
 
+    let data_input_union s f = data_comp E.data_input_union s f
+
     let (>>==) : 'a t -> ('a -> 'b t) -> ('b) t
         = fun s f -> data_comp (=$$=) s f
 
     let (>>*=) : 'a t -> ('a -> 'b t) -> ('b) t
       = fun s f -> data_comp (=**=) s f
+
+    let control_input_union s f = data_comp E.control_input_union s f
 
     let (>>*==) : 'a t -> ('a -> 'b t) -> ('b) t
         = fun s f -> data_comp (=*$$=) s f

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -46,13 +46,21 @@ module type S =
     val delay_kont : string -> 'a t -> ('a ->  'a t -> 'b t) -> 'b t
     val delay : 'a t -> ('a * 'a t) t
 
-(* Data composition, entry for snd monad: minimals for iico_data *)
+    val set_standard_input_output : 'a t -> 'a t
+
+    (* Data composition, entry for snd monad: minimals for iico_data *)
     val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
-    val data_input_next : 'a t -> ('a -> 'b t) -> 'b t (* Input to second arg *)
+ (* Input to second arg *)
+    val data_input_next : 'a t -> ('a -> 'b t) -> 'b t
+ (* Input to both args *)
+    val data_input_union : 'a t -> ('a -> 'b t) -> 'b t
     val (>>==) : 'a t -> ('a -> 'b t) -> 'b t (* Output events stay in first arg *)
 
 (* Control composition *)
     val (>>*=) : 'a t -> ('a -> 'b t) -> 'b t
+(* Input is union of both arg inputs *)
+    val control_input_union :  'a t -> ('a -> 'b t) -> 'b t
+
     val (>>*==) : 'a t -> ('a -> 'b t) -> 'b t (* Output events stay in first argument *)
     val bind_control_set_data_input_first :
       'a t -> ('a -> 'b t) -> 'b t (* Data input fixed in first argumst *)

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -85,7 +85,12 @@ module type S =
     (* Identical control dep only, all output from firtst argument *)
     val bind_ctrl_first_outputs : 'a t -> ('a -> 'b t) -> 'b t
 
-    val check_tags : 'v t -> ('v -> 'v t) -> ('v -> 'v t) -> 'x t -> 'v t
+    (* Very ad-hoc transformation, [short3 p1 p2 s],
+     * add relation r;r;r where r is intra_causality_data,
+     *  with starting event(s) selected by p1 and final one(s) by p2       
+     *)
+    val short3 : (E.event -> bool) -> (E.event -> bool) -> 'a t -> 'a t
+       
     val exch : 'a t -> 'a t -> ('a -> 'b t) ->  ('a -> 'c t) ->  ('b * 'c) t
 
 (*

--- a/lib/innerRel.ml
+++ b/lib/innerRel.ml
@@ -124,6 +124,7 @@ module type S =  sig
 
 (* Sequence composition of relation *)
   val sequence : t-> t -> t
+  val transitive3 : t -> t
   val sequences : t list -> t
 
 (* Equivalence classes, applies to any relation.
@@ -673,15 +674,23 @@ and module Elts = MySet.Make(O) =
 (* Sequence *)
 (************)
 
-    let sequence r1 r2 =
-      let m2 = M.to_map r2 in
+    let append_map r m =
       fold
         (fun (e1,e2) ->
           Elts.fold
             (fun e3 -> add (e1,e3))
-            (M.succs e2 m2))
-        r1 empty
+            (M.succs e2 m))
+        r empty
 
+
+    let sequence r1 r2 =
+      let m2 = M.to_map r2 in
+      append_map r1 m2
+
+    let transitive3 r =
+      let m = M.to_map r in
+      append_map (append_map r m) m
+      
     let rec seq_rec rs = match rs with
     | []|[_] as rs -> rs
     | r1::r2::rs -> sequence r1 r2::seq_rec rs

--- a/lib/innerRel.mli
+++ b/lib/innerRel.mli
@@ -124,7 +124,8 @@ module type S =  sig
   val remove_transitive_edges : t -> t
 
 (* Sequence composition of relation *)
-  val sequence : t-> t -> t
+  val sequence : t -> t -> t
+  val transitive3 : t -> t (* returns r;r;r *)
   val sequences : t list -> t
 
 (* Equivalence classes, applies to symetric relations only (unchecked) *)


### PR DESCRIPTION
This PR implement combining the memory tag extension and kvm. Result looks satisfactory, some internal dependency links are not perfect though.

As an important side benefit of the PR, dependencies are now similar in both modes. Consider the case of a simple store instruction:
```
AArch64 MTE-W
{
0:X0=x;
}
  P0         ;
 MOV W1,#1   ;
 STR W1,[X0] ;
forall [x]=1
```

The `0:R[W1]1` event (data port read of the store)  does not depend on the validity test  (PTE check or color check respectively) in both modes.

A potential follow-up would be a similar rewriting of the morello mode. Then, the `lift_mem_op` function could get rid of its `mv` argument.