### PR TITLE
[tools] Fix two glitches in dumper

### DIFF
--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -162,7 +162,7 @@ let dump_state_atom is_global dump_loc dump_val (loc,(t,v)) =
   | Pointer t ->
       sprintf "%s *%s=%s" t (dump_loc loc) (dump_val v)
   | TyArray (t,sz) ->
-      sprintf "%s %s[%i]" t (dump_loc loc) sz
+      sprintf "%s %s[%i]=%s" t (dump_loc loc) sz (dump_val v)
 
 (* Packed result *)
 type info = (string * string) list

--- a/tools/prettyProg.ml
+++ b/tools/prettyProg.ml
@@ -255,26 +255,28 @@ module Make(O:Config)(A:Arch_tools.S) =
           | TyArray _|Atomic _ -> Warn.fatal "Array/Atomic type not implemented...")
       ^ "\\hline \\end{tabular}\n"
 
-    let zero = Constant.Concrete "0"
+    let is_zero = function
+      | Constant.Concrete "0" -> true
+      | _ -> false
 
     let pp_initial_state_flat sc =
       let non_zero_constraints =
         Misc.option_map
 	  (fun (l,(_,v))->
-	    if ParsedConstant.compare v zero = 0 then None
-	    else
+            if is_zero v then None
+            else
               let ppv =
                 if O.texmacros then "\\asm{" ^ pp_v v ^"}"
                 else "\\mbox{" ^ pp_v v ^ "}" in
               Some (" \\mbox{"^ pp_location l ^
-                    "} \\mathord{=} " ^ ppv ^" "))
+                      "} \\mathord{=} " ^ ppv ^" "))
 	  sc in (* That will do *)
       match non_zero_constraints with
       | [] -> None
       | _ ->
           let has_zero =
             List.exists
-              (fun (_,(_,v)) -> ParsedConstant.compare v zero = 0)
+              (fun (_,(_,v)) -> is_zero v)
               sc in
           Some
             begin


### PR DESCRIPTION
  + Avoid untimely call to purposely failing ParsedConstant.compare in latex dumper.
  + Fix oversight in array definition dumping.