### PR TITLE
Undefined Instructions

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1611,10 +1611,8 @@ module Make
       let make_label_value proc lbl_str =
         A.V.cstToV (Constant.Label (proc, lbl_str))
 
-      let read_loc_instr v ii =
-        let loc_instr =
-          A.Location_global (make_label_value ii.A.fetch_proc v) in
-        M.read_loc false (mk_fetch AArch64.N) loc_instr ii
+      let read_loc_instr a ii =
+        M.read_loc false (mk_fetch AArch64.N) a ii
 
 (*********************)
 (* Branches *)
@@ -1663,19 +1661,46 @@ module Make
             else begin
               match Label.norm ii.A.labels with
               | Some hd ->
+                  let a_v = make_label_value ii.A.fetch_proc hd in
+                  let a =
+                    A.Location_global (make_label_value ii.A.fetch_proc hd) in
                   let b_val =
                     A.V.cstToV (A.instruction_to_value ii.A.inst) in
-                  M.altT  (
+                  let nop_val =
+                    A.V.cstToV (A.instruction_to_value I_NOP) in
+                  read_loc_instr a ii
+                  >>= fun v ->
+                    let b_cond = M.op Op.Eq v b_val in
+                    let nop_cond = M.op Op.Eq v nop_val in
+                    b_cond >>*= fun cond -> M.choiceT cond (
+                      commit_pred ii
+                      >>*= fun () -> (M.mk_singleton_es (Act.NoAction) ii)
+                      >>= fun () -> B.branchT l
+                    )(
+                      nop_cond >>*= fun cond -> M.choiceT cond (
+                        commit_pred ii
+                        >>*= fun () ->(M.mk_singleton_es (Act.NoAction) ii)
+                        >>= B.next1T
+                      )(
+                        let (>>!) = M.(>>!) in
+                        let m_fault = mk_fault a_v Dir.F AArch64.N ii (Some "Invalid") in
+                        commit_pred ii
+                        >>*= fun () -> m_fault
+                        >>| set_elr_el1 ii
+                        >>! B.Fault Dir.F
+                      )
+                    )
+                  (* M.altT  (
                     read_loc_instr hd ii
                     >>= M.eqT b_val
                     >>= fun () -> (M.mk_singleton_es (Act.NoAction) ii)
                     >>= fun () -> B.branchT l
-                  ) (
+                  )(
                     read_loc_instr hd ii
-                    >>= M.neqT b_val
+                    >>= M.eqT nop_val
                     >>= fun () -> (M.mk_singleton_es (Act.NoAction) ii)
                     >>= B.next1T
-                  )
+                  ) *)
               | None -> B.branchT l
             end
 

--- a/herd/CAV12.ml
+++ b/herd/CAV12.ml
@@ -308,11 +308,11 @@ module Make
                 if diff_proc p then
                   let open E in
                   match get_mem_dir x, get_mem_dir y with
-                  | (Dir.R|Dir.F),(Dir.R|Dir.F) -> assert false
-                  | (Dir.R|Dir.F),Dir.W ->
+                  | Dir.R,Dir.R -> assert false
+                  | Dir.R,Dir.W ->
                       ({ SE.nature = SE.Exe ; event = x ; },
                        { SE.nature = SE.Prop (get_proc x) ; event = y ; })::k
-                  | Dir.W,(Dir.R|Dir.F) ->
+                  | Dir.W,Dir.R ->
                       ({ SE.nature = SE.Prop (get_proc y) ; event = x ; },
                        { SE.nature = SE.Exe ; event = y ; })::k
                   | Dir.W,Dir.W ->

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -467,8 +467,13 @@ module Make(C:Config) (I:I) : S with module I = I
                 (pp_symbol sym1) (pp_symbol sym2)
 
         let same_id_fault v1 v2 = match v1,v2 with
-          | I.V.Val (Symbolic sym1),I.V.Val (Symbolic sym2)
+          | I.V.Val (Symbolic sym1), I.V.Val (Symbolic sym2)
             -> same_sym_fault sym1 sym2
+          | I.V.Val (Constant.Label (_, l1)),I.V.Val (Constant.Label (_, l2))
+            -> Misc.string_eq l1 l2
+          | I.V.Val (Symbolic _), I.V.Val (Constant.Label (_, _))
+          | I.V.Val (Constant.Label (_, _)), I.V.Val (Symbolic _)
+            -> false
           | _,_
             ->
               Warn.fatal

--- a/herd/dir.ml
+++ b/herd/dir.ml
@@ -14,6 +14,6 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type dirn = R | W | F
+type dirn = R | W
 
-let pp_dirn d = match d with R -> "R" | W -> "W" | F -> "F"
+let pp_dirn d = match d with R -> "R" | W -> "W"

--- a/herd/dir.mli
+++ b/herd/dir.mli
@@ -16,6 +16,6 @@
 
 (** Directions for memory accesses: read or write. *)
 
-type dirn = R | W | F
+type dirn = R | W
 
 val pp_dirn : dirn -> string

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -226,7 +226,6 @@ end = struct
 
   let read_of a = match a with
   | Access (R,_,v,_,_,_,_)
-  | Access (F,_,v,_,_,_,_)
   | Amo (_,v,_,_,_,_,_)
     -> Some v
   | Arch a -> A.ArchAction.read_of a
@@ -239,7 +238,7 @@ end = struct
   | Amo (_,_,v,_,_,_,_)
     -> Some v
   | Arch a -> A.ArchAction.written_of a
-  | Access (R, _, _, _,_,_,_) | Access (F, _, _, _,_,_,_)
+  | Access (R, _, _, _,_,_,_)
   | Barrier _|Commit _|Fault _
   | TooFar _|Inv _|DC _|IC _|NoAction
     -> None
@@ -270,7 +269,7 @@ end = struct
   | _ -> false
 
   let is_mem_load a = match a with
-  | Access ((R|F),A.Location_global _,_,_,_,_,_)
+  | Access (R,A.Location_global _,_,_,_,_,_)
   | Amo (A.Location_global _,_,_,_,_,_,_)
     -> true
   | Arch a ->
@@ -316,9 +315,17 @@ end = struct
     | Inv _ -> true
     | Access _|Amo _|Commit _|Barrier _|Fault _|TooFar _|DC _|IC _|Arch _|NoAction -> false
 
-  let is_ifetch a = match a with
-    | Access (F,_,_,_,_,_,_)  -> true
-    | _ -> false
+  let is_label a = match a with
+  | Access (_,A.Location_global (A.V.Val c),_,_,_,_,_)
+  | Amo (A.Location_global (A.V.Val c),_,_,_,_,_,_)
+    -> Constant.is_label c
+  | Arch a ->
+     begin
+       match A.ArchAction.location_of a with
+       | Some (A.Location_global (A.V.Val c)) -> Constant.is_label c
+       | _ -> false
+     end
+  | _ -> false
 
   let is_dc = function
     | DC _ -> true
@@ -428,11 +435,11 @@ end = struct
   let is_store a = match a with
   | Access (W,_,_,_,_,_,_)|Amo _ -> true
   | Arch a -> A.ArchAction.is_load a
-  | Access ((R|F),_,_,_,_,_,_) | Barrier _ | Commit _
+  | Access (R,_,_,_,_,_,_) | Barrier _ | Commit _
   | Fault _ | TooFar _ | Inv _ | DC _ | IC _ | NoAction -> false
 
   let is_load a = match a with
-  | Access ((R|F),_,_,_,_,_,_) | Amo _ -> true
+  | Access (R,_,_,_,_,_,_) | Amo _ -> true
   | Arch a -> A.ArchAction.is_store a
   | Access (W,_,_,_,_,_,_) | Barrier _ | Commit _ | Fault _ | TooFar _ | Inv _
   | DC _| IC _ | NoAction -> false
@@ -545,7 +552,8 @@ end = struct
 
     and ifetch_sets =
       if self then
-        ("IF",is_ifetch)::[]
+        (* ("IF",is_ifetch)::[] *)
+        ("INSTR",is_label)::[]
       else []
 
     in

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -519,7 +519,7 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
         | None, false ->
            let open Precision in
            match C.precision,dir with
-           | Fatal,_ | LoadsFatal,(Dir.R|Dir.F) -> EM.unitcodeT true
+           | Fatal,_ | LoadsFatal,Dir.R -> EM.unitcodeT true
            | Skip,_ -> add_code false fetch_proc proc env seen nexts
            | Handled,_ | LoadsFatal,Dir.W ->
               add_next_instr true fetch_proc proc env seen addr inst nexts
@@ -1206,7 +1206,7 @@ let match_reg_events es =
           | Dir.W ->
               let old = StringMap.safe_find [] x ws in
               rs,StringMap.add x ((g,idx,sz,es)::old) ws
-          | Dir.R | Dir.F -> (g,x,idx,sz,es)::rs,ws)
+          | Dir.R -> (g,x,idx,sz,es)::rs,ws)
           ([],StringMap.empty) ms in
       let ws =
         StringMap.map

--- a/herd/memUtils.ml
+++ b/herd/memUtils.ml
@@ -477,7 +477,7 @@ let lift_proc_info i evts =
     let add e1 e2 d1 d2 k =
       match d1, d2 with
       | Dir.W,Dir.W -> E.EventRel.add (e1,e2) k
-      | (Dir.R|Dir.F),(Dir.R|Dir.F) ->
+      | Dir.R,Dir.R ->
           begin match
             find_source rfmap e1,
             find_source rfmap e2
@@ -488,14 +488,14 @@ let lift_proc_info i evts =
           | S.Init,_ -> k
           | _,S.Init -> raise Exit
           end
-      | (Dir.R|Dir.F),Dir.W ->
+      | Dir.R,Dir.W ->
           begin match
             find_source rfmap e1
           with
           | S.Store w1 -> E.EventRel.add (w1,e2) k
           | S.Init -> k
           end
-      | Dir.W,(Dir.R|Dir.F) ->
+      | Dir.W,Dir.R ->
           begin match
             find_source rfmap e2
           with

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -371,6 +371,8 @@ arrayspec:
 | LBRK loc=location_global RBRK { Location_global loc }
 
 atom_prop:
+| loc=location EQUAL TOK_NOP
+  {Atom (LV (Loc loc,(mk_instr_val "NOP")))}
 | location equal maybev {Atom (LV (Loc $1,$3))}
 | loc=loc_brk equal v=maybev
    {Atom (LV (Loc loc,v))}


### PR DESCRIPTION
This PR attempts to sketch out a very ad-hoc support for instruction aborts. Namely, when a "B" instruction gets overwritten by a value different from "NOP", herd7 is expected to create a fault.

The intention is to, essentially, have a flow:
* read the instruction from memory
* check if it is "valid" (currently, checks if it is NOP or B), and
** if yes, execute it
** if no, trigger a fault

The expected intrinsic orderings are: [IFETCH]; iico_data; [B]; iico_ctrl; [FAULT | the rest of the instruction].

Currently known limitation: in addition to the desired orderings, there is a redundant "iico_data" edge: [IFETCH]; iico_data; [FAULT | the rest of the instruction].