### PR TITLE
[tools] Normalise pteval's in mprog output

### DIFF
--- a/lib/AArch64PteVal.ml
+++ b/lib/AArch64PteVal.ml
@@ -152,6 +152,10 @@ let tr p =
     { r with attrs; } in
   r
 
+let pp_norm p =
+  let n = tr p in
+  pp_v n
+
 let lex_compare c1 c2 x y  = match c1 x y with
 | 0 -> c2 x y
 | r -> r

--- a/lib/AArch64PteVal.mli
+++ b/lib/AArch64PteVal.mli
@@ -56,6 +56,8 @@ val is_default : t -> bool
 
 (* Finish parsing *)
 val tr : ParsedPteVal.t -> t
+val pp_norm : ParsedPteVal.t -> string
+
 
 (* Pretty print pp [hexa]  *)
 val pp : bool -> t -> string  (* Default field not printed *)

--- a/lib/parsedConstant.ml
+++ b/lib/parsedConstant.ml
@@ -34,3 +34,4 @@ let pp_v_old v = Constant.pp_old Misc.identity ParsedPteVal.pp v
 
 (* Hexa parameter ignored... *)
 let pp _hexa = pp_v
+let pp_norm _hexa pp_pteval =  Constant.pp Misc.identity pp_pteval

--- a/lib/parsedConstant.mli
+++ b/lib/parsedConstant.mli
@@ -35,3 +35,6 @@ val pp_v_old : v -> string
 
 (* Hexa parameter ignored... *)
 val pp : bool (* hexa *) -> v -> string
+
+(* Pass specific printer for pteval's *)
+val pp_norm : bool -> (ParsedPteVal.t -> string) -> v -> string

--- a/lib/pteVal.ml
+++ b/lib/pteVal.ml
@@ -27,6 +27,7 @@ module type S = sig
   val pp_v : t -> string
   val pp_hash : t -> string
   val tr : ParsedPteVal.t -> t
+  val pp_norm : ParsedPteVal.t -> string
 
   val eq : t -> t -> bool
   val compare : t -> t -> int
@@ -60,6 +61,7 @@ module No= struct
     let pp_v _ = assert false
     let pp_hash _ = assert false
     let tr _ = assert false
+    let pp_norm _ = assert false
 
     let eq _ _ = assert false
     let compare _ _ = assert false

--- a/lib/pteVal.mli
+++ b/lib/pteVal.mli
@@ -27,6 +27,7 @@ module type S = sig
   val pp_v : t -> string
   val pp_hash : t -> string
   val tr : ParsedPteVal.t -> t
+  val pp_norm : ParsedPteVal.t -> string
 
   val eq : t -> t -> bool
   val compare : t -> t -> int

--- a/tools/archExtra_tools.ml
+++ b/tools/archExtra_tools.ml
@@ -15,7 +15,11 @@
 (****************************************************************************)
 
 
-module Make (O:sig val hexa : bool end)(A:ArchBase.S) = struct
+module
+  Make
+    (O:sig val hexa : bool end)
+    (A:ArchBase.S)(Pte:PteVal.S)
+  = struct
   include A
 
   module RegSet =
@@ -37,7 +41,7 @@ module Make (O:sig val hexa : bool end)(A:ArchBase.S) = struct
   let one = ParsedConstant.one
   let symbToV =  ParsedConstant.nameToV
   let maybevToV c = c
-  let pp_v = ParsedConstant.pp O.hexa
+  let pp_v = ParsedConstant.pp_norm O.hexa Pte.pp_norm
 
   type global = ParsedConstant.v
   let maybevToGlobal c = c

--- a/tools/archExtra_tools.mli
+++ b/tools/archExtra_tools.mli
@@ -17,7 +17,9 @@
 
 module Make :
     functor (O : sig val hexa : bool end) ->
-      functor (A:ArchBase.S) -> Arch_tools.S
+      functor (A:ArchBase.S) ->
+        functor (Pte:PteVal.S) ->
+          Arch_tools.S
 with type instruction = A.instruction
 and type reg = A.reg
 and type 'ins kpseudo = 'ins A.kpseudo

--- a/tools/madd.ml
+++ b/tools/madd.ml
@@ -31,7 +31,7 @@ module Top
           hash : string option; }
     end
 
-    module Make(A:ArchBase.S) = struct
+    module Make(A:ArchBase.S)(Pte:PteVal.S) = struct
 
       let zyva name parsed =
 	let tname = name.Name.name in

--- a/tools/mhash.ml
+++ b/tools/mhash.ml
@@ -51,7 +51,7 @@ module Top
           map : string -> string; }
     end
 
-    module Make(A:ArchBase.S) = struct
+    module Make(A:ArchBase.S)(Pte:PteVal.S) = struct
 
       let zyva name parsed =
 	let tname = name.Name.name in

--- a/tools/mmixer.ml
+++ b/tools/mmixer.ml
@@ -26,8 +26,8 @@ module Top (Opt:MixOption.S) = struct
       end
 
 
-      module Make(A:ArchBase.S) = struct
-        module Arch=ArchExtra_tools.Make(Opt)(A)
+      module Make(A:ArchBase.S)(Pte:PteVal.S) = struct
+        module Arch=ArchExtra_tools.Make(Opt)(A)(Pte)
         module D = Dumper.Make(Arch)
         module M = MixMerge.Make(Opt)(Arch)
         module Alloc = SymbReg.Make(Arch)

--- a/tools/mprog.ml
+++ b/tools/mprog.ml
@@ -41,7 +41,7 @@ module Top
     end
 
     (* Transpose dump *)
-    module Transpose(A:ArchBase.S) = struct
+    module Transpose(A:ArchBase.S)(Pte:PteVal.S) = struct
 
       module D =
         TransposeDumper.Make
@@ -175,7 +175,7 @@ module Top
     (*************)
 
     (* No alloc *)
-    module Text(A:ArchBase.S) = struct
+    module Text(A:ArchBase.S)(Pte:PteVal.S) = struct
       module D = DumperMiscParser.Make(O)(A)
 
       let zyva = match O.outputdir with
@@ -192,8 +192,8 @@ module Top
     end
 
     (* Some alloc *)
-    module TextAlloc(A:ArchBase.S) = struct
-      module Arch = ArchExtra_tools.Make(O)(A)
+    module TextAlloc(A:ArchBase.S)(Pte:PteVal.S) = struct
+      module Arch = ArchExtra_tools.Make(O)(A)(Pte)
       module Alloc = SymbReg.Make(Arch)
       module D = Dumper.Make(Arch)
 
@@ -213,8 +213,8 @@ module Top
 
     end
 
-    module Latex(A:ArchBase.S) = struct
-      module Arch = ArchExtra_tools.Make(O)(A)
+    module Latex(A:ArchBase.S)(Pte:PteVal.S) = struct
+      module Arch = ArchExtra_tools.Make(O)(A)(Pte)
       module M = PrettyProg.Make(O)(Arch)
       module Alloc = SymbReg.Make(Arch)
 

--- a/tools/mrcu.ml
+++ b/tools/mrcu.ml
@@ -44,7 +44,7 @@ module Top
 
     module Dec = struct let hexa = false end
     module P = GenParser.Make(GenParser.DefaultConfig)(LISA)(LISALexParse)
-    module A = ArchExtra_tools.Make(Dec)(LISA)
+    module A = ArchExtra_tools.Make(Dec)(LISA)(PteVal.No)
     module Alloc = SymbReg.Make(A)
 
     module D = Dumper.Make(A)

--- a/tools/mselect.ml
+++ b/tools/mselect.ml
@@ -37,7 +37,7 @@ module Top
     end
 
 
-    module Make(A:ArchBase.S) = struct
+    module Make(A:ArchBase.S)(Pte:PteVal.S) = struct
 
       let zyva name parsed =
         let prog = parsed.MiscParser.prog in

--- a/tools/msort.ml
+++ b/tools/msort.ml
@@ -61,7 +61,7 @@ module Top
 
     exception NotOk
 
-    module Make(A:ArchBase.S) = struct
+    module Make(A:ArchBase.S)(Pte:PteVal.S) = struct
 
       let default_cost pgm =
         let nprocs = List.length pgm in

--- a/tools/testInfo.ml
+++ b/tools/testInfo.ml
@@ -35,7 +35,7 @@ module T = struct
           t1 t2
 end
 
-module Make(A:ArchBase.S) = struct
+module Make(A:ArchBase.S)(Pte:PteVal.S) = struct
 
   let zyva name parsed =
     let tname = name.Name.name in

--- a/tools/testInfo.mli
+++ b/tools/testInfo.mli
@@ -24,7 +24,7 @@ module T : sig
 end
 
 (* Extract information out of parsed test *)
-module Make(A:ArchBase.S) : sig
+module Make(A:ArchBase.S)(Pte:PteVal.S) : sig
   val zyva : Name.t -> A.pseudo MiscParser.t -> T.t
 end
 

--- a/tools/toolParse.ml
+++ b/tools/toolParse.ml
@@ -25,18 +25,18 @@ end
 
 module Top
     (T:sig type t end) (* Return type, must be abstracted *)
-    (B: functor(A:ArchBase.S)->
+    (B: functor(A:ArchBase.S)-> functor (Pte:PteVal.S) ->
       (sig val zyva : Name.t -> A.pseudo MiscParser.t -> T.t end)) :
 sig
   val from_file : string -> T.t
 end = struct
 
   module Make
-      (A:ArchBase.S)
+      (A:ArchBase.S)(Pte:PteVal.S)
       (L:GenParser.LexParse with type instruction = A.parsedPseudo) =
     struct
       module P = GenParser.Make(GenParser.DefaultConfig)(A)(L)
-      module X = B(A)
+      module X = B(A)(Pte)
 
 
       let zyva chan splitted =
@@ -57,7 +57,7 @@ end = struct
 	  let lexer = L.token
 	  let parser = MiscParser.mach2generic PPCParser.main
         end in
-        let module X = Make (PPC) (PPCLexParse) in
+        let module X = Make (PPC) (PteVal.No) (PPCLexParse) in
         X.zyva chan splitted
     | `X86 ->
         let module X86 = X86Base in
@@ -69,7 +69,7 @@ end = struct
 	  let lexer = L.token
 	  let parser = MiscParser.mach2generic X86Parser.main
         end in
-        let module X = Make (X86) (X86LexParse) in
+        let module X = Make (X86)  (PteVal.No) (X86LexParse) in
         X.zyva chan splitted
     | `X86_64 ->
         let module X86_64 = X86_64Base in
@@ -81,7 +81,7 @@ end = struct
 	  let lexer = L.token
 	  let parser = MiscParser.mach2generic X86_64Parser.main
         end in
-        let module X = Make (X86_64) (X86_64LexParse) in
+        let module X = Make (X86_64) (PteVal.No) (X86_64LexParse) in
         X.zyva chan splitted
     | `ARM ->
         let module ARM = ARMBase in
@@ -93,7 +93,7 @@ end = struct
 	  let lexer = L.token
 	  let parser = MiscParser.mach2generic ARMParser.main
         end in
-        let module X = Make (ARM) (ARMLexParse) in
+        let module X = Make (ARM)  (PteVal.No) (ARMLexParse) in
         X.zyva chan splitted
     | `AArch64 ->
         let module AArch64 =
@@ -106,7 +106,7 @@ end = struct
 	  let lexer = L.token
 	  let parser = (*MiscParser.mach2generic*) AArch64Parser.main
         end in
-        let module X = Make (AArch64) (AArch64LexParse) in
+        let module X = Make (AArch64) (AArch64PteVal) (AArch64LexParse) in
         X.zyva chan splitted
     | `MIPS ->
         let module MIPS = MIPSBase in
@@ -118,7 +118,7 @@ end = struct
 	  let lexer = L.token
 	  let parser = MiscParser.mach2generic MIPSParser.main
         end in
-        let module X = Make (MIPS) (MIPSLexParse) in
+        let module X = Make (MIPS) (PteVal.No) (MIPSLexParse) in
         X.zyva chan splitted
     | `RISCV ->
         let module RISCV = RISCVBase in
@@ -130,7 +130,7 @@ end = struct
 	  let lexer = L.token
 	  let parser = MiscParser.mach2generic RISCVParser.main
         end in
-        let module X = Make (RISCV) (RISCVLexParse) in
+        let module X = Make (RISCV) (PteVal.No) (RISCVLexParse) in
         X.zyva chan splitted
     | `LISA ->
         let module Bell = BellBase in
@@ -142,7 +142,7 @@ end = struct
 	  let lexer = L.token
 	  let parser = LISAParser.main
         end in
-        let module X = Make (Bell) (BellLexParse) in
+        let module X = Make (Bell) (PteVal.No) (BellLexParse) in
         X.zyva chan splitted
 
     | `JAVA 
@@ -164,7 +164,7 @@ end = struct
           let macros_expand _ i = i
         end in
         let module P = CGenParser_lib.Make(CGenParser_lib.DefaultConfig)(C)(L) in
-        let module X = B(C) in
+        let module X = B(C)(PteVal.No) in
         let name =  splitted.Splitter.name in
         let parsed = P.parse chan splitted in
         X.zyva name parsed
@@ -182,7 +182,7 @@ end
 
 module Tops
     (T:sig type t end) (* Return type, must be abstracted *)
-    (B: functor(A:ArchBase.S)->
+    (B: functor(A:ArchBase.S)-> functor(Pte:PteVal.S)->
       (sig val zyva : (Name.t * A.pseudo MiscParser.t) list -> T.t end)) :
     sig
       val from_files : string list -> T.t
@@ -229,11 +229,11 @@ module Tops
 
 (* Code shared for machine arch's *)
       module Make
-          (A:ArchBase.S)
+          (A:ArchBase.S)(Pte:PteVal.S)
           (L:GenParser.LexParse with type instruction = A.parsedPseudo) =
         struct
           module P = GenParser.Make(GenParser.DefaultConfig)(A)(L)
-          module X = B(A)
+          module X = B(A)(Pte)
 
           include
             Util
@@ -257,7 +257,7 @@ module Tops
 	      let lexer = L.token
 	      let parser = MiscParser.mach2generic PPCParser.main
             end in
-            let module X = Make (PPC) (PPCLexParse) in
+            let module X = Make (PPC) (PteVal.No) (PPCLexParse) in
             X.zyva
         | `X86 ->
             let module X86 = X86Base in
@@ -269,7 +269,7 @@ module Tops
 	      let lexer = L.token
 	      let parser = MiscParser.mach2generic X86Parser.main
             end in
-            let module X = Make (X86) (X86LexParse) in
+            let module X = Make (X86) (PteVal.No) (X86LexParse) in
             X.zyva
         | `X86_64 ->
             let module X86_64 = X86_64Base in
@@ -281,7 +281,7 @@ module Tops
 	      let lexer = L.token
 	      let parser = MiscParser.mach2generic X86_64Parser.main
             end in
-            let module X = Make (X86_64) (X86_64LexParse) in
+            let module X = Make (X86_64)  (PteVal.No) (X86_64LexParse) in
             X.zyva
         | `ARM ->
             let module ARM = ARMBase in
@@ -293,7 +293,7 @@ module Tops
 	      let lexer = L.token
 	      let parser = MiscParser.mach2generic ARMParser.main
             end in
-            let module X = Make (ARM) (ARMLexParse) in
+            let module X = Make (ARM) (PteVal.No) (ARMLexParse) in
             X.zyva
         | `AArch64 ->
             let module AArch64 =
@@ -306,7 +306,7 @@ module Tops
 	      let lexer = L.token
 	      let parser =  (*MiscParser.mach2generic*) AArch64Parser.main
             end in
-            let module X = Make (AArch64) (AArch64LexParse) in
+            let module X = Make (AArch64) (AArch64PteVal) (AArch64LexParse) in
             X.zyva
         | `MIPS ->
             let module MIPS = MIPSBase in
@@ -318,7 +318,7 @@ module Tops
 	      let lexer = L.token
 	      let parser = MiscParser.mach2generic MIPSParser.main
             end in
-            let module X = Make (MIPS) (MIPSLexParse) in
+            let module X = Make (MIPS)  (PteVal.No) (MIPSLexParse) in
             X.zyva
         | `LISA ->
             let module Bell = BellBase in
@@ -329,7 +329,7 @@ module Tops
 	      let lexer = L.token
 	      let parser = LISAParser.main
             end in
-            let module X = Make (Bell) (BellLexParse) in
+            let module X = Make (Bell)  (PteVal.No) (BellLexParse) in
             X.zyva
 
         | `JAVA 
@@ -352,7 +352,7 @@ module Tops
             end in
 
             let module P = CGenParser_lib.Make(CGenParser_lib.DefaultConfig)(C)(L) in
-            let module X = B(C) in
+            let module X = B(C) (PteVal.No) in
 
             let module U =
               Util

--- a/tools/toolParse.mli
+++ b/tools/toolParse.mli
@@ -20,7 +20,7 @@
 
 module Top :
     functor (T:sig type t end) -> (* Return type, must be abstracted *)
-      functor (B: functor(A:ArchBase.S) ->
+      functor (B: functor(A:ArchBase.S) -> functor (Pte:PteVal.S) ->
         (sig val zyva : Name.t -> A.pseudo MiscParser.t -> T.t end)) ->
 sig
   val from_file : string -> T.t
@@ -28,7 +28,7 @@ end
 
 module Tops :
     functor (T:sig type t end) -> (* Return type, must be abstracted *)
-      functor (B: functor(A:ArchBase.S) ->
+      functor (B: functor(A:ArchBase.S) -> functor (Pte:PteVal.S) ->
         (sig val zyva : ( Name.t * A.pseudo MiscParser.t) list -> T.t end)) ->
 sig
   val from_files : string list -> T.t


### PR DESCRIPTION
Normalisation applies for options `-mode text -alloc true`.