### PR TITLE
[herd] Restore MMU fault types removed by an earlier commit

### DIFF
--- a/lib/faultType.ml
+++ b/lib/faultType.ml
@@ -57,6 +57,9 @@ module AArch64 = struct
       "MMU", [MMU Translation;
               MMU AccessFlag;
               MMU Permission];
+      "Translation", [MMU Translation];
+      "AccessFlag", [MMU AccessFlag];
+      "Permission", [MMU Permission];
       "TagCheck", [TagCheck];
       "IllegalInstruction",[IllegalInstruction];
     ]


### PR DESCRIPTION
Signed-off-by: Nikos Nikoleris <nikos.nikoleris@arm.com>