### PR TITLE
[herd] Partially restore program-order for events from the same instruction

### DIFF
--- a/herd/BellMem.ml
+++ b/herd/BellMem.ml
@@ -49,6 +49,7 @@ module S = S
           MachModelChecker.Make
             (struct
               let m = m
+              let wide_po = false
               include O
              end)(S) in
         X.check_event_structure test

--- a/herd/CMem.ml
+++ b/herd/CMem.ml
@@ -44,6 +44,7 @@ module Make
             MachModelChecker.Make
               (struct
                 let m = m
+                let wide_po = true
                 include O
               end)(S) in
         X.check_event_structure test

--- a/herd/MemCat.ml
+++ b/herd/MemCat.ml
@@ -43,6 +43,7 @@ module S = S
            MachModelChecker.Make
              (struct
                let m = m
+               let wide_po = false
                include O
              end)(S) in
          X.check_event_structure test

--- a/herd/MemWithCav12.ml
+++ b/herd/MemWithCav12.ml
@@ -52,6 +52,7 @@ module Make
             (struct
               let m = m
               let bell_model_info = None
+              let wide_po = false
               include ModelConfig
              end)(S) in
         X.check_event_structure test

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -19,6 +19,8 @@
 module type Config = sig
   val m : AST.t
   val bell_model_info : (string * BellModel.info) option
+(* Include events from the same instance in po, essential for the LKMM *)
+  val wide_po : bool
   include Model.Config
 end
 
@@ -225,8 +227,13 @@ module Make
       let po =
         choose_spec
           Misc.identity
-          (E.EventRel.filter (fun (e1,e2) -> relevant e1 && relevant e2 &&
-                                               not (E.same_instance e1 e2)))
+          (E.EventRel.filter
+             (if O.wide_po then
+                (fun (e1,e2) -> relevant e1 && relevant e2)
+              else
+                (fun (e1,e2) ->
+                  relevant e1 && relevant e2 &&
+                 not (E.same_instance e1 e2))))
           conc.S.po in
       let id =
         lazy begin

--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -379,7 +379,7 @@ module Top (TopConf:Config) = struct
           let parser      = JavaParser.main
         end in
         let module JavaS  = JavaSem.Make(Conf)(Int64Value) in
-        let module JavaM  = MemCat.Make(ModelConfig)(JavaS) in
+        let module JavaM  = CMem.Make(ModelConfig)(JavaS) in
         let module P      = JavaGenParser_lib.Make (Conf) (Java) (JavaLexParse) in
         let module X      = Make (JavaS) (P) (NoCheck) (JavaM) (Conf) in
 


### PR DESCRIPTION
This feature is crucial for the LKMM and relevant for all high-level languages, where "instructions"  are composite. The feature is now controlled by configuring the `MachModelChecker` module