### PR TITLE
[tools] Add `-faulttype` option to tools that read logs

### DIFF
--- a/lib/checkName.ml
+++ b/lib/checkName.ml
@@ -44,6 +44,11 @@ let parse_int32 int32 =
   "-int32", Arg.Bool (fun b -> int32 := b),
   (Printf.sprintf "<bool> integer in logs are 32 bits wide, default %b" !int32)
 
+let parse_faulttype ft =
+   ("-faulttype", Arg.Bool (fun b -> ft := b),
+    Printf.sprintf
+      "<bool> consider fault types, default %b" !ft);
+
 module
   Make
     (I:sig

--- a/lib/checkName.mli
+++ b/lib/checkName.mli
@@ -22,7 +22,7 @@ val parse_rename : string list ref ->  Arg.key * Arg.spec * Arg.doc
 val parse_excl : string list ref ->  Arg.key * Arg.spec * Arg.doc
 val parse_hexa : bool ref ->  Arg.key * Arg.spec * Arg.doc
 val parse_int32 : bool ref ->  Arg.key * Arg.spec * Arg.doc
-
+val parse_faulttype : bool ref -> Arg.key * Arg.spec * Arg.doc
 module Make :
   functor
    (I:sig

--- a/tools/lexLog_tools.mli
+++ b/tools/lexLog_tools.mli
@@ -21,6 +21,7 @@ module type Config = sig
   val hexa : bool
   val int32 : bool
   val acceptBig : bool
+  val faulttype : bool
 end
 
 module Make(O:Config) : sig

--- a/tools/lexLog_tools.mll
+++ b/tools/lexLog_tools.mll
@@ -25,6 +25,7 @@ module type Config = sig
   val hexa : bool
   val int32 : bool
   val acceptBig : bool
+  val faulttype : bool
 end
 
 module Make(O:Config) = struct
@@ -240,7 +241,10 @@ and pline bds fs abs = parse
       ')' blank* ';'
     {
      let loc = Constant.old2new loc in
-     let ftype = match ftype with Some "kvm" -> None | _ -> ftype in
+     let ftype =
+       if O.faulttype then
+         match ftype with Some "kvm" -> None | _ -> ftype
+       else None in
      let f = (to_proc proc,lbl),loc,ftype in
      let f = HashedFault.as_hashed f in
      pline bds (f::fs) abs lexbuf }

--- a/tools/mcmp.ml
+++ b/tools/mcmp.ml
@@ -29,6 +29,7 @@ module type Opt = sig
   val ok : string -> bool
   val pos : string option
   val neg : string option
+  val faulttype : bool
 end
 
 module Make(O:Opt) = struct
@@ -42,12 +43,12 @@ module Make(O:Opt) = struct
         let hexa = false
         let int32 = true
         let acceptBig = true
+        let faulttype = O.faulttype
       end)
 
   module LS = LogState.Make(O)
 
   let read_logs fnames = LL.read_names_simple fnames
-
 
   let cmp_logs fname t1 t2 = match fname with
   | Some fname ->
@@ -96,6 +97,8 @@ let pos = ref None
 let neg = ref None
 let quiet = ref false
 let same = ref false
+let faulttype = ref true
+
 let options =
   [
    ("-v", Arg.Unit (fun _ -> incr verbose),
@@ -113,6 +116,7 @@ let options =
    CheckName.parse_select select;
    CheckName.parse_names names;
    CheckName.parse_excl excl;
+   CheckName.parse_faulttype faulttype;
  ]
 let logs = ref []
 
@@ -144,6 +148,7 @@ module M =
       let ok = Check.ok
       let pos = !pos
       let neg = !neg
+      let faulttype = !faulttype
     end)
 
 let f1,f2 = match !logs with

--- a/tools/mcompare.ml
+++ b/tools/mcompare.ml
@@ -58,6 +58,7 @@ type runopts =
      opt_cond : bool ;
      hexa : bool ;
      int32 : bool ;
+     faulttype : bool ;
    }
 
 let default_runopts =
@@ -91,6 +92,7 @@ let default_runopts =
    opt_cond = false;
    hexa = false;
    int32 = true;
+   faulttype = true;
  }
 
 let runopts = default_runopts
@@ -105,6 +107,11 @@ let options =
   [
   ("-v", Arg.Unit (fun _ -> incr verb),
    "<non-default> show various diagnostics, repeat to increase verbosity");
+   ("-faulttype",
+    Arg.Bool
+      (delay_ro (fun b ro -> { ro with faulttype = b})),
+    sprintf
+      "<bool> consider fault types, default %b" default_runopts.faulttype);
    ("-big", Arg.Bool (fun b -> acceptBig := b),
     sprintf
       " <bool> do not discard test with many states, default %b" !acceptBig);
@@ -301,6 +308,7 @@ module type Config = sig
   val hexa : bool
   val int32 : bool
   val acceptBig : bool
+  val faulttype : bool
 end
 
 module Verbose = struct let verbose = !verb end
@@ -367,6 +375,7 @@ module Config = struct
   let hexa = runopts.hexa
   let int32 = runopts.int32
   let acceptBig = !acceptBig
+  let faulttype = runopts.faulttype
 end
 
 (************)

--- a/tools/mdiff.ml
+++ b/tools/mdiff.ml
@@ -44,6 +44,8 @@ let parse_act r =
   "-act", Arg.String (fun s -> r := act_of_string s),
   "<diff|intersect> either diff or intersect the logs, default diff"
 
+let faulttype = ref true
+
 let options =
   let open CheckName in
   [
@@ -58,6 +60,7 @@ let options =
    parse_select select; parse_names names;
    parse_excl excl;
    parse_act act;
+   parse_faulttype faulttype;
   ]
 
 let prog =
@@ -86,6 +89,7 @@ let verbose = !verbose
 let hexa = !hexa
 let int32 = !int32
 let emptyok = !emptyok
+let faulttype = !faulttype
 
 let log1,log2 = match !logs with
 | [log1;log2;] -> log1,log2
@@ -111,6 +115,7 @@ module LL =
       let hexa = hexa
       let int32 = int32
       let acceptBig = false
+      let faulttype = faulttype
     end)
 
 let readlog log = match log with

--- a/tools/mfilter.ml
+++ b/tools/mfilter.ml
@@ -28,6 +28,7 @@ let conds = ref []
 let inverse = ref false
 let hexa = ref false
 let int32 = ref true
+let faulttype = ref true
 
 let options =
   let open CheckName in
@@ -43,6 +44,7 @@ let options =
   ("-conds",
     Arg.String (fun s -> conds := !conds @ [s]),
    "<name> specify condition to apply to outcomes, can be repeated") ;
+  parse_faulttype faulttype;
   ]
 
 let prog =
@@ -71,6 +73,7 @@ let log = match !logs with
     eprintf "%s takes at most one argument\n" prog ;
     exit 2
 let inverse = !inverse
+let faulttype = !faulttype
 
 module Verbose = struct let verbose = verbose end
 
@@ -95,6 +98,7 @@ module LL =
       let hexa = hexa
       let int32 = int32
       let acceptBig = true
+      let faulttype = faulttype
     end)
 
 module D =

--- a/tools/mlog2cond.ml
+++ b/tools/mlog2cond.ml
@@ -25,6 +25,7 @@ let optcond = ref false
 let acceptempty = ref false
 let hexa = ref false
 let int32 = ref true
+let faulttype = ref true
 
 let options =
   [
@@ -44,6 +45,7 @@ let options =
       "<bool> output empty conditions, default %b" !acceptempty);
     CheckName.parse_hexa hexa;
     CheckName.parse_int32 int32;
+    CheckName.parse_faulttype faulttype;
   ]
 
 let prog =
@@ -89,6 +91,7 @@ module LL =
       let hexa = hexa
       let int32 = int32
       let acceptBig = false
+      let faulttype = !faulttype
     end)
 
 let acceptempty = !acceptempty

--- a/tools/mlog2name.ml
+++ b/tools/mlog2name.ml
@@ -61,6 +61,7 @@ module LL =
       let hexa = false
       let int32 = true
       let acceptBig = true
+      let faulttype = true
     end)
 
 let add_name =

--- a/tools/moutcomes.ml
+++ b/tools/moutcomes.ml
@@ -26,7 +26,7 @@ let names = ref []
 let excl = ref []
 let hexa = ref false
 let int32 = ref true
-
+let faulttype = ref true
 let options =
   let open CheckName in
   [
@@ -40,6 +40,7 @@ let options =
      parse_select select;
      parse_names names;
      parse_excl excl;
+     parse_faulttype faulttype;
   ]
 
 let prog =
@@ -66,6 +67,7 @@ let log = match !logs with
 | _ ->
     eprintf "%s takes at most one argument\n" prog ;
     exit 2
+let faulttype = !faulttype
 
 module Verbose = struct let verbose = verbose end
 
@@ -85,6 +87,7 @@ module LL =
       let hexa = hexa
       let int32 = int32
       let acceptBig = true
+      let faulttype = faulttype
     end)
 
 

--- a/tools/msum.ml
+++ b/tools/msum.ml
@@ -28,6 +28,7 @@ let npar = ref 1
 let hexa = ref false
 let int32 = ref true
 let nargs = ref 64
+let faulttype = ref true
 
 let options =
   let open CheckName in
@@ -43,6 +44,7 @@ let options =
    parse_hexa hexa; parse_int32 int32;
    parse_rename rename;
    parse_select select; parse_names names; parse_excl excl;
+   parse_faulttype faulttype;
  ]
 
 let prog =
@@ -69,6 +71,7 @@ let excl = !excl
 let verbose = !verbose
 let hexa = !hexa
 let int32 = !int32
+let faulttype = !faulttype
 
 module Verbose = struct let verbose = verbose end
 
@@ -122,6 +125,7 @@ module LL =
       let hexa = hexa
       let int32 = int32
       let acceptBig = false
+      let faulttype = faulttype
     end)
 
 module D =

--- a/tools/mtopos.ml
+++ b/tools/mtopos.ml
@@ -25,6 +25,7 @@ module type Config = sig
   val ok : string -> bool
   val hexa : bool
   val int32 : bool
+  val faulttype : bool
 end
 
 module Make(O:Config) = struct
@@ -38,6 +39,7 @@ module Make(O:Config) = struct
         let hexa = O.hexa
         let int32 = O.int32
         let acceptBig = false
+        let faulttype = O.faulttype
       end)
 
   module LS = LogState.Make(O)
@@ -66,6 +68,7 @@ let names = ref []
 let select = ref []
 let verbose = ref 0
 let shownames = ref true
+let faulttype = ref true
 let log = ref None
 
 let options =
@@ -76,6 +79,7 @@ let options =
    ("-shownames", Arg.Bool (fun b -> shownames := b),
     (sprintf "<bool> show test names in output, default %b" !shownames));
    parse_select select; parse_names names;
+   parse_faulttype faulttype;
  ]
 
 let prog =
@@ -109,6 +113,7 @@ module Config = struct
   let ok = Check.ok
   let hexa = false
   let int32 = true
+  let faulttype = !faulttype
 end
 
 module X = Make(Config)


### PR DESCRIPTION
Command line option `-faulttype <bool>` commands reading of fault types in logs. When false, fault types are ignored, restoring old behaviour (_i.e._ before PR #457 ). Default is true.