### PR TITLE
[herd] Add cat support for logical operations on variants

### DIFF
--- a/lib/AST.mli
+++ b/lib/AST.mli
@@ -69,9 +69,15 @@ and pat = Pvar of pat0 | Ptuple of pat0 list
 
 and pat0 = var option
 
+and variant_cond =
+  | Variant of string
+  | OpNot of variant_cond
+  | OpAnd of variant_cond * variant_cond
+  | OpOr of variant_cond * variant_cond
+
 and cond =
 | Eq of exp * exp | Subset of exp * exp | In of exp * exp
-| Variant of string
+| VariantCond of variant_cond
 
 and clause = string * exp
 
@@ -101,7 +107,7 @@ type ins =
 (*For bell files*)
   | Events of TxtLoc.t * var * exp list * bool (* define default *)
 (*Conditional, on variant as a string, avoiding dependency on herd/variant.ml *)
-  | IfVariant of TxtLoc.t * string * ins list * ins list
+  | IfVariant of TxtLoc.t * variant_cond * ins list * ins list
 
 and insclause = string * ins list
 

--- a/lib/ASTUtils.ml
+++ b/lib/ASTUtils.ml
@@ -81,7 +81,7 @@ and free_cond c = match c with
 | Subset (e1,e2)
 | In (e1,e2)
   -> StringSet.union (free e1) (free e2)
-| Variant _ -> StringSet.empty
+| VariantCond _ -> StringSet.empty
 
 and frees es = StringSet.unions (List.map free es)
 

--- a/lib/modelLexer.mll
+++ b/lib/modelLexer.mll
@@ -63,6 +63,7 @@ module LU = LexUtils.Make(O)
     (* for bell files *)
     | "instructions" -> INSTRUCTIONS
     | "default" -> DEFAULT
+    | "not" -> LNOT
     | x -> VAR x
 
 
@@ -108,6 +109,7 @@ rule token f = parse
 | '|'   { f Operator "|" ; UNION }
 | "||"  { f Operator "||" ; ALT }
 | '&'   { f Operator "&" ; INTER }
+| "&&"  { f Operator "&&" ; LAND }
 | '*'   { f Operator "*" ; STAR }
 | '~'   { f Operator "~" ; COMP }
 | '+'   { f Operator "+" ; PLUS }

--- a/lib/modelParser.mly
+++ b/lib/modelParser.mly
@@ -48,6 +48,7 @@ let tuple_pat = function
 %token INCLUDE
 %token LPAR RPAR BEGIN END LACC RACC LBRAC RBRAC
 %token EMPTY UNDERSCORE SUBSET
+%token LNOT LAND
 %token ALT SEMI UNION INTER COMMA DIFF PLUSPLUS
 %token STAR PLUS OPT INV COMP HAT
 %token LET REC AND WHEN ACYCLIC IRREFLEXIVE TESTEMPTY EQUAL
@@ -69,6 +70,10 @@ let tuple_pat = function
 %right INTER
 %nonassoc STAR PLUS OPT COMP
 %nonassoc HAT
+%left ALT
+%left LAND
+%nonassoc LNOT
+
 %%
 
 main:
@@ -251,11 +256,15 @@ cond:
 | exp EQUAL exp  { Eq ($1,$3) }
 | exp SUBSET exp { Subset ($1,$3) }
 | exp IN exp     { In ($1,$3) }
-| variant        { Variant $1 }
+| variant        { VariantCond $1 }
 
 variant:
-| VARIANT STRING { $2 }
-| STRING { $1 }
+| VARIANT STRING { Variant $2 }
+| STRING { Variant $1 }
+| LNOT variant { OpNot $2 }
+| variant LAND variant { OpAnd ($1,$3) }
+| variant ALT variant { OpOr ($1,$3) }
+| LPAR variant RPAR { $2 }
 
 simple:
 | EMPTY { Konst (mk_loc $loc,Empty RLN) }


### PR DESCRIPTION
This change adds support for the logical operators '&&', '||' and 'not' in statements where the condition was previously a variant. This way, where previously we could use clauses of the form:

if VARIANT then ... else ...

now, we can use clauses of the form:

if VARIANT_COND then ... else ...

where VARIANT_COND is a VARIANT or a logical operation on multiple VARIANTs using the defined operators.

Signed-off-by: Nikos Nikoleris <nikos.nikoleris@arm.com>