### PR TITLE
A ad-hoc fix for litmus7 with "-variant self"

### DIFF
--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -57,11 +57,11 @@ module Make(O:Config)(V:Constant.S) = struct
   | Concrete _ -> V.pp O.hexa v
   | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=0;}) -> dump_addr a
   | ConcreteVector _ -> V.pp O.hexa v
+  | Instruction _ -> String.lowercase (V.pp false v)
   | Tag _
   | Symbolic _
   | Label _
   | PteVal _
-  | Instruction _
     -> assert false
 
   let dump_v_kvm v = match v with

--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -57,7 +57,7 @@ module Make(O:Config)(V:Constant.S) = struct
   | Concrete _ -> V.pp O.hexa v
   | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=0;}) -> dump_addr a
   | ConcreteVector _ -> V.pp O.hexa v
-  | Instruction _ -> String.lowercase (V.pp false v)
+  | Instruction _ -> Misc.lowercase (V.pp false v)
   | Tag _
   | Symbolic _
   | Label _


### PR DESCRIPTION
There is an issue with running litmus7 with “-variant self”. Upon running any litmus test, litmus7 complains at:
```
# litmus7 -variant self any-test.litmus -o any-test.tar
File "any-test.litmus" exception File "litmus/outUtils.ml", line 65, characters 7-13: Assertion failed
```
This is because a certain function is told to “assert false” when printing instructions.

This is an extremely ad-hoc attempt to get litmus7 running. Essentially, it just lets `litmus7` print `"nop"` in the place it needs to: when passing an `inst_t` variable storing the `NOP` instruction to the Assembly block in `codeX` functions.