### PR TITLE
[litmus] Fix for printing the name of "nop" argument.

### DIFF
--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -57,11 +57,11 @@ module Make(O:Config)(V:Constant.S) = struct
   | Concrete _ -> V.pp O.hexa v
   | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=0;}) -> dump_addr a
   | ConcreteVector _ -> V.pp O.hexa v
+  | Instruction _ -> Misc.lowercase (V.pp O.hexa v)
   | Tag _
   | Symbolic _
   | Label _
   | PteVal _
-  | Instruction _
     -> assert false
 
   let dump_v_kvm v = match v with


### PR DESCRIPTION
When NOP is given as an initial value, it gets tranalated into a "nop" argument. We manage to print it as the lowercase varsion of the instruction dump. Really a fix that won't resist adding more instructions as initial values.

This PR is inspired by PR #467 by @artkhyzha.