### PR TITLE
[herd] Dynamic indirect branch

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -334,18 +334,6 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_BL _ | I_BLR _ -> Some linkreg
       | _ -> None
 
-    let is_overwritable i =
-      match i with
-      | I_B _ | I_NOP -> true
-      | _ -> false
-
-    let instruction_to_value i =
-      match i with
-      | I_B lbl ->
-        Constant.Instruction(InstrLit.LIT_B(lbl))
-      | I_NOP -> Constant.Instruction(InstrLit.LIT_NOP)
-      | _ -> Warn.user_error "Functionality not implemented for -variant self: converting {%s} into a constant" (pp_instruction PPMode.Ascii i)
-
     include ArchExtra_herd.Make(C)
         (struct
           module V = V

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2384,7 +2384,7 @@ module Make
                             mfail
                    end
 
-      let build_semantics ii =
+      let build_semantics _ ii =
         M.addT (A.next_po_index ii.A.program_order_index)
           begin
             if self then check_self ii

--- a/herd/ARMSem.ml
+++ b/herd/ARMSem.ml
@@ -136,7 +136,7 @@ module
       | ARM.SetFlags -> write_flag ARM.Z Op.Eq v1 v2 ii
       | ARM.DontSetFlags -> M.unitT ()
 
-      let build_semantics ii =
+      let build_semantics _ ii =
         M.addT (A.next_po_index ii.A.program_order_index)
           begin match ii.A.inst with
           | ARM.I_NOP -> B.nextT

--- a/herd/BellSem.ml
+++ b/herd/BellSem.ml
@@ -125,7 +125,7 @@ module
       let tr_mov r op ii =
         (tr_op ii op) >>= (fun v -> write_reg r v ii)
 
-      let build_semantics ii =
+      let build_semantics _ ii =
         let build_semantics_inner ii =
           match ii.A.inst with
           | BellBase.Pnop -> B.nextT

--- a/herd/MIPSSem.ml
+++ b/herd/MIPSSem.ml
@@ -97,7 +97,7 @@ module
 
 (* Entry point *)
 
-      let build_semantics ii =
+      let build_semantics _ ii =
         M.addT (A.next_po_index ii.A.program_order_index)
           begin match ii.A.inst with
           | MIPS.NOP -> B.nextT

--- a/herd/PPCSem.ml
+++ b/herd/PPCSem.ml
@@ -201,7 +201,7 @@ module
         M.op1 Op.Not >>=
         fun v ->  commit ii >>= fun () -> B.bccT v lbl
 
-      let build_semantics ii =
+      let build_semantics _ ii =
         M.addT (A.next_po_index ii.A.program_order_index)
           begin match ii.A.inst with
           | PPC.Pnop -> B.nextT

--- a/herd/RISCVSem.ml
+++ b/herd/RISCVSem.ml
@@ -252,7 +252,7 @@ module
 (* Entry point *)
       let tr_sz = RISCV.tr_width
 
-      let build_semantics ii =
+      let build_semantics _ ii =
         M.addT (A.next_po_index ii.A.program_order_index)
           begin match ii.A.inst with
           | RISCV.OpI (op,r1,r2,k) ->

--- a/herd/X86Sem.ml
+++ b/herd/X86Sem.ml
@@ -168,7 +168,7 @@ module
             (write_loc_gen sz locked loc v_result ii >>|
             write_all_flags v_result V.zero ii) >>= B.next2T
 
-      let build_semantics ii =
+      let build_semantics _ ii =
         let rec build_semantics_inner locked ii =
           match ii.A.inst with
           |  X86.I_NOP -> B.nextT

--- a/herd/X86_64Sem.ml
+++ b/herd/X86_64Sem.ml
@@ -255,7 +255,7 @@ module
         M.mk_singleton_es
           (Act.Arch (X86_64.ArchAction.ClFlush (opt,a))) ii
 
-      let build_semantics ii =
+      let build_semantics _ ii =
         let rec build_semantics_inner locked ii =
           match ii.A.inst with
           | X86_64.I_NOP -> B.nextT

--- a/herd/arch_herd.mli
+++ b/herd/arch_herd.mli
@@ -23,6 +23,7 @@ module type S =
   sig
 
     include ArchBase.S
+
     val is_amo : instruction -> bool
     val pp_barrier_short : barrier -> string
     val reject_mixed : bool (* perform a check that rejects mixed-size tests *)

--- a/herd/branch.ml
+++ b/herd/branch.ml
@@ -32,6 +32,8 @@ module type S = sig
     | Jump of lbl
     (* if v is one, jump to address, otherwise continue in sequence *)
     | CondJump of v * lbl
+    (* Indirect Jump, with potential targets *)
+    | IndirectJump of v * Label.Full.Set.t
     (* Stop now *)
     | Exit
     (* Raise Fault *)
@@ -48,6 +50,8 @@ module type S = sig
   val nextSetT : reg -> v -> t monad
 (* Non-conditional branch *)
   val branchT : lbl ->  t monad
+(* Indirect branch *)
+  val  indirectBranchT : v -> Label.Full.Set.t -> t monad
 (* Conditional branch *)
   val bccT : v -> lbl -> t monad
   val faultRetT : lbl -> t monad
@@ -68,6 +72,8 @@ module Make(M:Monad.S) = struct
     | Jump of lbl
     (* if v is one, jump to address, otherwise continue in sequence *)
     | CondJump of v * lbl
+    (* Indirect Jump, with potential targets *)
+    | IndirectJump of v * Label.Full.Set.t
     (* Stop now *)
     | Exit
     (* Raise Fault *)
@@ -85,6 +91,7 @@ module Make(M:Monad.S) = struct
   let next4T ((((),()),()), ()) = nextT
   let nextSetT r v = M.unitT (Next [r,v])
   let branchT lbl = M.unitT (Jump lbl)
+  let indirectBranchT v lbls = M.unitT (IndirectJump (v,lbls))
   let bccT v lbl = M.unitT (CondJump (v,lbl))
   let faultRetT lbl = M.unitT (FaultRet lbl)
 end

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -461,9 +461,9 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
             (A.dump_instruction inst)
             (Label.Set.pp_str ","  Label.pp ii.A.labels) ;
         m ii in
-
+      let  sem_instr =  SM.build_semantics test in
       let rec add_next_instr re_exec fetch_proc proc env seen addr inst nexts =
-        wrap fetch_proc proc inst addr env SM.build_semantics >>> fun branch ->
+        wrap fetch_proc proc inst addr env sem_instr >>> fun branch ->
           let { A.regs=env; lx_sz=szo; fh_code } = env in
           let env =
             let env = A.kill_regs (A.killed inst) env in

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -537,8 +537,12 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
           add_lbl false true proc env seen addr lbl
       | S.B.CondJump (v,lbl) ->
           EM.condJumpT v
-            (add_lbl re_exec (not (V.is_var_determined v)) proc env seen addr lbl)
+            (add_lbl re_exec (not (V.is_var_determined v))
+               proc env seen addr lbl)
             (add_code re_exec fetch_proc proc env seen nexts)
+      | S.B.IndirectJump (v,lbls) ->
+         EM.indirectJumpT v lbls
+           (add_lbl re_exec true proc env seen addr)
       in
 
 (* Code monad returns a boolean. When false the code must be discarded.
@@ -1860,8 +1864,15 @@ let match_reg_events es =
                 let sz0 = E.get_mem_size e0 in
                 List.iter
                   (fun e ->
-                    if sz0 <> E.get_mem_size e then
-                      Warn.user_error "Illegal mixed-size test")
+                    let sz =  E.get_mem_size e in
+                    if sz0 <> sz then begin
+                      Printf.eprintf
+                        "Size mismatch %a vs. %a, ie %s vs. %s\n"
+                        E.debug_event e0
+                        E.debug_event e
+                        (MachSize.pp sz0) (MachSize.pp sz);
+                      Warn.user_error "Illegal mixed-size test"
+                    end)
                   es
             end)
           loc_mems
@@ -1959,7 +1970,9 @@ let match_reg_events es =
                   check_symbolic_locations test es ;
                   if self then check_ifetch_limitations test es owls ;
                   if (mixed && not unaligned) then check_aligned test es ;
-                  if A.reject_mixed && not (mixed || memtag || morello) then
+                  if A.reject_mixed
+                     && not (mixed || memtag || morello)
+                  then
                     check_sizes test es ;
                   if C.debug.Debug_herd.solver && C.verbose > 0 then begin
                     let module PP = Pretty.Make(S) in

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -194,6 +194,8 @@ module type S =
     val choiceT : A.V.v -> 'a t -> 'a t -> 'a t
     val condPredT : A.V.v -> unit t -> 'a t -> 'a t -> 'a t
     val condJumpT : A.V.v -> 'a code -> 'a code -> 'a code
+    val indirectJumpT :
+      A.V.v -> Label.Full.Set.t -> (Label.t -> 'a code) -> 'a code
 
     val altT : 'a t -> 'a t -> 'a t
 

--- a/herd/sem.mli
+++ b/herd/sem.mli
@@ -29,7 +29,8 @@ module type Semantics =
     val atomic_pair_allowed : event -> event -> bool
 (* Instruction semantics, highly arch dependant *)
     module Mixed(SZ:ByteSize.S) : sig
-      val build_semantics : A.inst_instance_id -> (A.program_order_index * branch) M.t
+      val build_semantics :
+        test -> A.inst_instance_id -> (A.program_order_index * branch) M.t
       val spurious_setaf : A.V.v -> unit M.t
     end
   end

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -77,6 +77,9 @@ module type S = sig
   val displayed_rlocations : test -> rloc_set
   val is_non_mixed_symbol : test -> Constant.symbol -> bool
 
+(* "Exported" labels, i.e. labels that can find their way to registers *)
+  val get_exported_labels : test -> Label.Full.Set.t
+
   type event = E.event
   type event_structure = E.event_structure
   type event_set = E.EventSet.t
@@ -285,6 +288,44 @@ module Make(C:Config) (A:Arch_herd.S) (Act:Action.S with module A = A)
       | Virtual sd -> is_non_mixed_symbol_virtual test sd
       | Physical (s,o) -> is_non_mixed_offset test s o
       | System ((PTE|PTE2|TLB|TAG),_)  -> true
+
+(* Exported labels:
+ * Labels from init environments ( + transfered to registers?)                   *)
+    let get_exported_labels (test:test) =
+      let open Test_herd in
+      let init =
+        let { init_state=st; _ } = test in
+        A.state_fold
+          (fun _ v k ->
+            match v with
+            | V.Val cst ->
+               begin
+                 match Constant.as_label cst with
+                 | Some lbl -> Label.Full.Set.add lbl k
+                 | None -> k
+               end
+            | V.Var _ -> k)
+          st Label.Full.Set.empty
+      and code =
+        let { nice_prog=prog; _ } = test in
+        List.fold_left
+          (fun k (p,code) ->
+            List.fold_left
+              (fun k i ->
+                A.pseudo_fold
+                  (fun k i ->
+                    match A.V.Cst.Instr.get_exported_label i with
+                    | None -> k
+                    | Some lbl ->
+                       Label.Full.Set.add (MiscParser.proc_num p,lbl) k)
+                  k i)
+              k code)
+          Label.Full.Set.empty prog in
+     Label.Full.Set.union init code
+
+(**********)
+(* Events *)
+(**********)
 
     type event = E.event
 

--- a/herd/tests/instructions/AArch64.self/S11.litmus
+++ b/herd/tests/instructions/AArch64.self/S11.litmus
@@ -8,5 +8,4 @@ AArch64 S11
   BR X2          ;
   MOV X0, #1     ;
 L0:              ;
-locations [0:X0; 0:X30;]
 forall (0:X0=0)

--- a/herd/tests/instructions/AArch64.self/S11.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S11.litmus.expected
@@ -1,0 +1,10 @@
+Test S11 Required
+States 1
+0:X0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=0)
+Observation S11 Always 1 0
+Hash=fcc1e5d4ee75340562e126e03098c057
+

--- a/herd/tests/instructions/AArch64.self/S11.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.self/S11.litmus.expected-failure
@@ -1,1 +1,0 @@
-Warning: File "./herd/tests/instructions/AArch64.self/S11.litmus": unsupported argument for the indirect branch instruction BR X2 (must be a statically known label)

--- a/herd/tests/instructions/AArch64.self/S12.litmus
+++ b/herd/tests/instructions/AArch64.self/S12.litmus
@@ -6,7 +6,10 @@ AArch64 S12
     P0           ;
   LDR X2, [X1]   ;
   BLR X2         ;
-  MOV X0, #1     ;
+  ADD W0,W0,#1   ;
+  B L1           ;
 L0:              ;
-locations [0:X0; 0:X30;]
-forall (0:X0=0)
+  MOV W0,#1      ;
+  RET            ;
+L1:              ;
+forall (0:X0=2)

--- a/herd/tests/instructions/AArch64.self/S12.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S12.litmus.expected
@@ -1,0 +1,10 @@
+Test S12 Required
+States 1
+0:X0=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=2)
+Observation S12 Always 1 0
+Hash=e560b8b2a90cc1dcdea4dea559c59773
+

--- a/herd/tests/instructions/AArch64.self/S12.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.self/S12.litmus.expected-failure
@@ -1,1 +1,0 @@
-Warning: File "./herd/tests/instructions/AArch64.self/S12.litmus": unsupported argument for the indirect branch instruction BLR X2 (must be a statically known label)

--- a/herd/tests/instructions/AArch64.self/S13.litmus
+++ b/herd/tests/instructions/AArch64.self/S13.litmus
@@ -1,4 +1,5 @@
 AArch64 S13
+Stable=X0
 {
 [x]=P1:L1;
 0:X0=0;     0:X1=x;
@@ -6,12 +7,11 @@ AArch64 S13
 }
     P0           |   P1;
   LDR X2,[X1]    |   STR X2,[X1];
-  BR X2          |   B L0        ;
+  BLR X2         |   B L0        ;
                  | L1:           ;
-                 |   ADD X0,X0,#1;
-                 |   RET         ;
+                 |   ADD W0,W0,#1;
                  | L2:           ;
-                 |   ADD X0,X0,#1;
+                 |   ADD W0,W0,#1;
                  |   RET         ;
                  | L0:           ;
 forall (0:X0=1 \/ 0:X0=2)

--- a/herd/tests/instructions/AArch64.self/S13.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S13.litmus.expected
@@ -1,0 +1,11 @@
+Test S13 Required
+States 2
+0:X0=1;
+0:X0=2;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (0:X0=1 \/ 0:X0=2)
+Observation S13 Always 2 0
+Hash=f16cfb44fbd6372cf1b443fa042b4d90
+

--- a/herd/tests/instructions/AArch64.self/S13.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.self/S13.litmus.expected-failure
@@ -1,1 +1,0 @@
-Warning: File "./herd/tests/instructions/AArch64.self/S13.litmus": unsupported argument for the indirect branch instruction BR X2 (must be a statically known label)

--- a/herd/tests/instructions/AArch64.self/S14.litmus
+++ b/herd/tests/instructions/AArch64.self/S14.litmus
@@ -1,4 +1,5 @@
 AArch64 S14
+Stable=X0
 {
 [x]=P1:L1;
 0:X0=0;     0:X1=x;

--- a/herd/tests/instructions/AArch64.self/S14.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S14.litmus.expected
@@ -1,0 +1,11 @@
+Test S14 Required
+States 2
+0:X0=1;
+0:X0=2;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (0:X0=1 \/ 0:X0=2)
+Observation S14 Always 2 0
+Hash=f5745b75390974982880b367237ad016
+

--- a/herd/tests/instructions/AArch64.self/S14.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.self/S14.litmus.expected-failure
@@ -1,1 +1,0 @@
-Warning: File "./herd/tests/instructions/AArch64.self/S14.litmus": unsupported argument for the indirect branch instruction BLR X2 (must be a statically known label)

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -2075,16 +2075,18 @@ let loop_idx = Internal 4
 
 let hash_pteval p = AArch64PteVal.pp_hash (AArch64PteVal.tr p)
 
-let is_overwritable =
-  function
-  | I_NOP | I_B _
-    -> true
+let is_overwritable = function
+  | I_NOP | I_B _  -> true
   | _ -> false
 
-let can_overwrite =
-    function
-    | I_NOP -> true
-    | _ -> false
+let can_overwrite = function
+  | I_NOP -> true
+  | _ -> false
+
+let get_exported_label = function
+  | I_ADR (_,lbl) -> Some lbl
+  | _ -> None
+
 
 module MakeInstr(C:sig val is_morello:bool end) = struct
 
@@ -2108,5 +2110,5 @@ module MakeInstr(C:sig val is_morello:bool end) = struct
 
   let is_overwritable = is_overwritable
   and can_overwrite =  can_overwrite
-
+  and get_exported_label = get_exported_label
 end

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -322,6 +322,10 @@ let is_symbol = function
 let is_label = function
   | Label _ -> true
   | Concrete _|ConcreteVector _|Symbolic _|Tag _ |PteVal _|Instruction _ -> false
+let as_label = function
+  | Label (p,lbl) -> Some (p,lbl)
+  | Concrete _|ConcreteVector _|Symbolic _|Tag _ |PteVal _|Instruction _
+    -> None
 
 let is_non_mixed_symbol = function
   | Virtual {offset=idx;_}
@@ -359,6 +363,7 @@ let as_pte v = match v with
 let is_pt v = match v with
 | Symbolic (System ((PTE|PTE2),_)) -> true
 | _ -> false
+
 
 module type S =  sig
 

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -112,6 +112,8 @@ val mk_replicate : int -> ('scalar,'pte,'instr) t -> ('scalar,'pte,'instr) t
 
 val is_symbol : ('scalar,'pte,'instr) t -> bool
 val is_label : ('scalar,'pte,'instr) t -> bool
+(* Extract label, if any *)
+val as_label :  ('scalar,'pte,'instr)  t -> Label.Full.full option
 
 val is_non_mixed_symbol : symbol -> bool
 
@@ -128,6 +130,8 @@ val of_symbolic_data : symbolic_data -> ('scalar,'pte,'instr) t
 
 val as_pte : ('scalar,'pte,'instr) t -> ('scalar,'pte,'instr) t option
 val is_pt : ('scalar,'pte,'instr)  t -> bool
+
+
 
 module type S =  sig
 

--- a/lib/instr.ml
+++ b/lib/instr.ml
@@ -22,7 +22,8 @@ module type S = sig
   val tr : InstrLit.t -> t
   val is_nop : t -> bool
   val is_overwritable : t -> bool
-  val can_overwrite : t -> bool    
+  val can_overwrite : t -> bool
+  val get_exported_label : t -> Label.t option
 end
 
 module No (I:sig type instr end) = struct
@@ -39,6 +40,6 @@ module No (I:sig type instr end) = struct
   let is_nop _ = fail "is_nop"
   let is_overwritable _ = false
   let can_overwrite _ = false
-
+  let get_exported_label _ = None
 end                    
                                      

--- a/lib/instr.mli
+++ b/lib/instr.mli
@@ -24,6 +24,7 @@ module type S = sig
   val is_nop : t -> bool
   val is_overwritable : t -> bool
   val can_overwrite : t -> bool
+  val get_exported_label : t -> Label.t option
 end
 
 module No : functor (I:sig type instr end) -> S with type t = I.instr

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -21,6 +21,8 @@ open Printf
 type func = Main | FaultHandler
 type proc = Proc.t * string list option * func
 
+let proc_num (p,_,_) = p
+
 let pp_proc (p,ao,f) =
   sprintf
     "P%i%s%s" p

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -20,6 +20,7 @@
 type func = Main | FaultHandler
 type proc = Proc.t * string list option * func
 
+val proc_num : proc -> Proc.t
 val pp_proc : proc -> string
 val count_procs : (proc * 'c) list -> int
 

--- a/lib/pseudo.ml
+++ b/lib/pseudo.ml
@@ -39,7 +39,7 @@ module type S = sig
 
   include Types
 
-(* Lifting of Oufold/map *)
+(* Lifting of fold/map *)
   val pseudo_map : ('a -> 'b) -> 'a kpseudo -> 'b kpseudo
   val pseudo_fold : ('a -> 'b -> 'a) -> 'a -> 'b kpseudo -> 'a
   val pseudo_iter : ('a -> unit) -> 'a kpseudo -> unit


### PR DESCRIPTION
This PR implements indirect branches. That is, for AArch64, the `BR Reg` and `BLR Reg` instructions are now accepted when the value of the register `Reg` is not statically known.