### PR TITLE
Generalise the type of PTE locations and add support for recursive PTEs

### DIFF
--- a/herd/access.ml
+++ b/herd/access.ml
@@ -14,21 +14,17 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type t = REG | VIR | PHY | PTE | TLB | TAG | PHY_PTE
+type t = REG | VIR | PHY | TLB | TAG
 
 let pp = function
   | REG -> "REG"
   | VIR -> "VIR"
   | PHY -> "PHY"
-  | PTE -> "PTE"
   | TLB -> "TLB"
   | TAG -> "TAG"
-  | PHY_PTE -> "PHY_PTE"
 
 let is_physical = function
-  | PHY|PHY_PTE -> true
-  | REG|VIR|PTE|TLB|TAG -> false
+  | PHY -> true
+  | REG|VIR|TLB|TAG -> false
 
-let compatible k1 k2 = match k1,k2 with
-  | ((PTE|PHY_PTE),(PTE|PHY_PTE)) -> true
-  | _,_ -> k1=k2
+let compatible k1 k2 = k1=k2

--- a/herd/access.mli
+++ b/herd/access.mli
@@ -17,7 +17,7 @@
 (** All sorts of accesses, redundant with symbol hidden in location,
    when symbol is known, which may not be the case *)
 
-type t = REG | VIR | PHY | PTE | TLB | TAG | PHY_PTE
+type t = REG | VIR | PHY | TLB | TAG
 
 val pp : t -> string
 

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -627,7 +627,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
     let is_additional_mem_load e = Act.is_additional_mem_load e.action
     let is_mem e = Act.is_mem e.action
     let is_pt e = match Act.location_of e.action with
-      | Some (A.Location_global (V.Val c)) -> Constant.is_pt c
+      | Some (A.Location_global (V.Val c)) -> Constant.is_pte c
       | _ -> false
     let is_explicit e = Act.is_explicit e.action
     let is_not_explicit e = Act.is_not_explicit e.action

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -585,14 +585,14 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
             if C.variant Variant.PhantomOnLoad then
               let look_pt rloc k = match rloc with
                 | ConstrGen.Loc (A.Location_global (V.Val c as vloc))
-                when Constant.is_pt c -> vloc::k
+                     when Constant.is_pte c -> vloc::k
                 | _ -> k in
               A.RLocSet.fold look_pt test.Test_herd.observed []
             else (* One spurious update per variable not accessed initially *)
               let add_setaf0 k (loc,v) =
                 match loc with
                 | A.Location_global (V.Val c as vloc) ->
-                   if Constant.is_pt c then
+                   if Constant.is_pte c then
                      match v with
                      | V.Val (Constant.PteVal p)
                            when not (V.Cst.PteVal.is_af p) ->

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -284,7 +284,7 @@ module Make(C:Config) (A:Arch_herd.S) (Act:Action.S with module A = A)
       match sym with
       | Virtual sd -> is_non_mixed_symbol_virtual test sd
       | Physical (s,o) -> is_non_mixed_offset test s o
-      | System ((PTE|PTE2|TLB|TAG),_)  -> true
+      | System ((TLB|TAG),_)  -> true
 
     type event = E.event
 

--- a/herd/tests/instructions/AArch64.kvm/A012.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A012.litmus
@@ -1,0 +1,8 @@
+AArch64 A012
+{
+ [PTE(x)]=(oa:PTE(x));
+ 0:X1=x;
+}
+ P0          ;
+ LDR X0,[X1] ;
+forall(0:X0=(oa:PTE(x)))

--- a/herd/tests/instructions/AArch64.kvm/A012.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A012.litmus.expected
@@ -1,0 +1,10 @@
+Test A012 Required
+States 1
+0:X0=(oa:PTE(x));
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=(oa:PTE(x)))
+Observation A012 Always 1 0
+Hash=556e05a2a13c6548340864f6a60c26ad
+

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -39,8 +39,6 @@ val default_symbolic_data : symbolic_data
 (* Various kinds of system memory *)
 
 type syskind =
-  | PTE  (* Page table entry *)
-  | PTE2 (* Page table entry of page table entry (non-writable) *)
   | TLB  (* TLB key *)
   | TAG  (* Tag for MTE *)
 
@@ -103,7 +101,6 @@ val map :
 val mk_sym_virtual : string -> ('scalar,'pte,'instr) t
 val mk_sym : string -> ('scalar,'pte,'instr) t
 val mk_sym_pte : string -> ('scalar,'pte,'instr) t
-val mk_sym_pte2 : string -> ('scalar,'pte,'instr) t
 val mk_sym_pa : string -> ('scalar,'pte,'instr) t
 val old2new : string -> string
 
@@ -127,7 +124,7 @@ val as_symbolic_data : ('scalar,'pte,'instr) t -> symbolic_data option
 val of_symbolic_data : symbolic_data -> ('scalar,'pte,'instr) t
 
 val as_pte : ('scalar,'pte,'instr) t -> ('scalar,'pte,'instr) t option
-val is_pt : ('scalar,'pte,'instr)  t -> bool
+val is_pte : ('scalar,'pte,'instr) t -> bool
 
 module type S =  sig
 

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -266,10 +266,11 @@ let add_oa_if_none loc p =
   try
     let oa =
       match loc with
-      | Location_global (Symbolic (System (Constant.PTE,s))) ->
-         OutputAddress.PHY s
-      | Location_global (Symbolic (System (Constant.PTE2,s))) ->
-         OutputAddress.PTE s
+      | Location_global (Symbolic (Virtual s)) ->
+         begin match Misc.tr_pte s.name with
+           | Some s -> OutputAddress.PHY s
+           | None -> raise Exit
+         end
       | _ -> raise Exit in
     let p = ParsedPteVal.add_oa_if_none oa p in
     Constant.PteVal p

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -109,7 +109,6 @@ reg:
 location_global:
 | NAME { Constant.mk_sym $1  }
 | TOK_PTE LPAR NAME RPAR { Constant.mk_sym_pte  $3 }
-| TOK_PTE LPAR TOK_PTE LPAR NAME RPAR RPAR { Constant.mk_sym_pte2 $5 }
 | TOK_PA LPAR NAME RPAR { Constant.mk_sym_pa $3 }
 | NAME COLON NAME { mk_sym_tag $1 $3 }
 | TOK_TAG LPAR NAME RPAR { mk_sym_tagloc $3 }

--- a/litmus/global_litmus.ml
+++ b/litmus/global_litmus.ml
@@ -48,7 +48,6 @@ let tr_symbol =
   function
     | Virtual {name=s; tag=None; cap=0L; offset=0;} -> Addr s
     | Physical (s,0) -> Phy s
-    | System (PTE,s) -> Pte s
     | c ->  Warn.fatal "litmus cannot handle symbol '%s'" (pp_symbol c)
 
 type u = t

--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -65,7 +65,6 @@ module Make(O:Config)(V:Constant.S) = struct
     -> assert false
 
   let dump_v_kvm v = match v with
-  | Symbolic (System (PTE,a)) -> sprintf "_vars->%s" (Misc.add_pte a)
   | Symbolic (Physical (a,0)) -> sprintf "_vars->saved_%s" (Misc.add_pte a)
   | _ -> V.pp_v v
 

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -206,12 +206,7 @@ module Make(O:Config)(A:I) =
           | _ -> None)
         init addrs
 
-    let get_ptes_only {init; ptes; _} =
-      get_gen
-        (function
-          | System (PTE,s) -> Some s
-          | _ -> None)
-        init ptes
+    let get_ptes_only _ = [] (* FIXME *)
 
     let get_phys_only {init; _} =
       get_gen

--- a/tools/alpha.ml
+++ b/tools/alpha.ml
@@ -188,7 +188,7 @@ struct
     let noinstr_value () = Warn.user_error "No instruction value for %s" Sys.argv.(0)
 
     let rec collect_value f v k = match v with
-    | Symbolic (Virtual {name=s;_}|System ((PTE|PTE2),s)) -> f s k
+    | Symbolic (Virtual {name=s;_}) -> f s k
     | Concrete _ -> k
     | ConcreteVector vs ->
        List.fold_left (fun k v -> collect_value f v k) k vs
@@ -201,8 +201,6 @@ struct
 
     let rec map_value f v = match v with
     | Symbolic (Virtual sym) -> Symbolic (Virtual {sym with name=f sym.name; })
-    | Symbolic (System (PTE,s)) ->  Symbolic (System (PTE,f s))
-    | Symbolic (System (PTE2,s)) ->  Symbolic (System (PTE2,f s))
     | Concrete _ -> v
     | ConcreteVector vs ->
        ConcreteVector (List.map (map_value f) vs)


### PR DESCRIPTION
This PR is an attempt to unify the locations for PTEs and normal data. Previously, `herd7` treated PTE locations as special `System` locations and this PR changes that to make them regular `Physical` locations which can be mapped into `Virtual` locations too. As a result, we can now simulate tests with recursive PTEs as shown in the two regression tests. Internally, we make the convention, that the location of the PTE of `Virtual` location `x` is the `Physical` location `pte_x` (PTE(x) in the syntax of a litmus test).

Unfortunately this PR is not ready, but as I will be on leave for the next month, I wanted to share my progress. There are three issues that I am aware of:

- Spurious AF updates are not working. For example, `catalogue/aarch64-VMSA/tests/LDRaf0-HA.litmus` will show one execution instead of two, the one with the spurious update is missing.
- Simulation time has significantly increased for some tests. The problem seems to be that PTE are now regular virtual/physical locations and therefore the solver has many more possible solutions to explore.
- I haven't tested litmus

Any feedback will be very welcome!