### PR TITLE
[herd] New ADDR set for address ports

### DIFF
--- a/herd/tests/instructions/AArch64/L041.litmus
+++ b/herd/tests/instructions/AArch64/L041.litmus
@@ -1,0 +1,12 @@
+AArch64 L041
+Orig=DSB.STdWR Fre DSB.STdWR Fre
+{
+0:X1=x; 0:X2=y;
+1:X1=y; 1:X2=x;
+}
+ P0          | P1          ;
+ MOV W0,#1   | MOV W0,#1   ;
+ STR W0,[X1] | STR W0,[X1] ;
+ DSB ST      | DSB ST      ;
+ LDR W3,[X2] | LDR W3,[X2] ;
+exists (0:X3=0 /\ 1:X3=0)

--- a/herd/tests/instructions/AArch64/L041.litmus.expected
+++ b/herd/tests/instructions/AArch64/L041.litmus.expected
@@ -1,0 +1,12 @@
+Test L041 Allowed
+States 3
+0:X3=0; 1:X3=1;
+0:X3=1; 1:X3=0;
+0:X3=1; 1:X3=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:X3=0 /\ 1:X3=0)
+Observation L041 Never 0 3
+Hash=b3943926fd253c62a988c8b6a25ddfdd
+

--- a/herd/tests/instructions/AArch64/L042.litmus
+++ b/herd/tests/instructions/AArch64/L042.litmus
@@ -1,0 +1,15 @@
+AArch64 L042
+Orig=PodWWPL RfeLP Amo.StAdd PodWR DpCtrlIsbdR Fre
+{
+0:X1=x; 0:X3=y;
+1:X0=y; 1:X2=z; 1:X4=x;
+}
+ P0           | P1            ;
+ MOV W0,#1    | MOV W1,#2     ;
+ STR W0,[X1]  | STADD W1,[X0] ;
+ MOV W2,#1    | LDR W3,[X2]   ;
+ STLR W2,[X3] | CBNZ W3,LC00  ;
+              | LC00:         ;
+              | ISB           ;
+              | LDR W5,[X4]   ;
+exists ([y]=3 /\ 1:X5=0)

--- a/herd/tests/instructions/AArch64/L042.litmus.expected
+++ b/herd/tests/instructions/AArch64/L042.litmus.expected
@@ -1,0 +1,13 @@
+Test L042 Allowed
+States 4
+1:X5=0; [y]=1;
+1:X5=0; [y]=3;
+1:X5=1; [y]=1;
+1:X5=1; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=3 /\ 1:X5=0)
+Observation L042 Sometimes 1 3
+Hash=77ba8b7ac2e6669181b14fb41b16d743
+

--- a/herd/tests/instructions/AArch64/L043.litmus
+++ b/herd/tests/instructions/AArch64/L043.litmus
@@ -1,0 +1,15 @@
+AArch64 L043
+Orig=PodWWPL RfeLP Amo.Swp PodWR DpCtrlIsbdR Fre
+{
+0:X1=x; 0:X3=y;
+1:X0=y; 1:X3=z; 1:X5=x;
+}
+ P0           | P1             ;
+ MOV W0,#1    | MOV W2,#2      ;
+ STR W0,[X1]  | SWP W2,W1,[X0] ;
+ MOV W2,#1    | LDR W4,[X3]    ;
+ STLR W2,[X3] | CBNZ W4,LC00   ;
+              | LC00:          ;
+              | ISB            ;
+              | LDR W6,[X5]    ;
+exists ([y]=2 /\ 1:X1=1 /\ 1:X6=0)

--- a/herd/tests/instructions/AArch64/L043.litmus.expected
+++ b/herd/tests/instructions/AArch64/L043.litmus.expected
@@ -1,0 +1,13 @@
+Test L043 Allowed
+States 4
+1:X1=0; 1:X6=0; [y]=1;
+1:X1=0; 1:X6=1; [y]=1;
+1:X1=1; 1:X6=0; [y]=2;
+1:X1=1; 1:X6=1; [y]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=2 /\ 1:X1=1 /\ 1:X6=0)
+Observation L043 Sometimes 1 3
+Hash=9359b760dad505f9b96c16d567fce7b5
+

--- a/herd/tests/instructions/AArch64/L044.litmus
+++ b/herd/tests/instructions/AArch64/L044.litmus
@@ -1,0 +1,12 @@
+AArch64 L044
+Orig=DMB.SYdRW Rfe Amo.StAdd PodWR Amo.LdAdd Rfe
+{
+0:X0=x; 0:X3=y;
+1:X0=y; 1:X2=x;
+}
+ P0          | P1               ;
+ LDR W1,[X0] | MOV W1,#2        ;
+ DMB SY      | STADD W1,[X0]    ;
+ MOV W2,#1   | MOV W4,#1        ;
+ STR W2,[X3] | LDADD W4,W3,[X2] ;
+exists ([y]=3 /\ 0:X1=1 /\ 1:X3=0)

--- a/herd/tests/instructions/AArch64/L044.litmus.expected
+++ b/herd/tests/instructions/AArch64/L044.litmus.expected
@@ -1,0 +1,13 @@
+Test L044 Allowed
+States 4
+0:X1=0; 1:X3=0; [y]=1;
+0:X1=0; 1:X3=0; [y]=3;
+0:X1=1; 1:X3=0; [y]=1;
+0:X1=1; 1:X3=0; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=3 /\ 0:X1=1 /\ 1:X3=0)
+Observation L044 Sometimes 1 3
+Hash=9ca718f5ba365c0e44825e7454237415
+

--- a/herd/tests/instructions/AArch64/L045.litmus
+++ b/herd/tests/instructions/AArch64/L045.litmus
@@ -1,0 +1,12 @@
+AArch64 L045
+Orig=DMB.SYdRW Rfe Amo.Swp PodWR Amo.LdAdd Rfe
+{
+0:X0=x; 0:X3=y;
+1:X0=y; 1:X3=x;
+}
+ P0          | P1               ;
+ LDR W1,[X0] | MOV W2,#2        ;
+ DMB SY      | SWP W2,W1,[X0]   ;
+ MOV W2,#1   | MOV W5,#1        ;
+ STR W2,[X3] | LDADD W5,W4,[X3] ;
+exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1 /\ 1:X4=0)

--- a/herd/tests/instructions/AArch64/L045.litmus.expected
+++ b/herd/tests/instructions/AArch64/L045.litmus.expected
@@ -1,0 +1,13 @@
+Test L045 Allowed
+States 4
+0:X1=0; 1:X1=0; 1:X4=0; [y]=1;
+0:X1=0; 1:X1=1; 1:X4=0; [y]=2;
+0:X1=1; 1:X1=0; 1:X4=0; [y]=1;
+0:X1=1; 1:X1=1; 1:X4=0; [y]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1 /\ 1:X4=0)
+Observation L045 Sometimes 1 3
+Hash=b554dbbcf6abfbb3161a8c7ca301e99b
+


### PR DESCRIPTION
Previous definition of address ports, which are crucial to addr dependencies, was a bit too loose. The new definition considers that the address ports of an instruction are the read _register_ effects that are not data ports.