### PR TITLE
[herd] Introduce and use the new `ToInteger` operator

### DIFF
--- a/catalogue/aarch64-VMSA/shelf.py
+++ b/catalogue/aarch64-VMSA/shelf.py
@@ -11,10 +11,9 @@ cfgs = [
 illustrative_tests = [
     "tests/MP-pte.litmus",
     "tests/load-valid.litmus",
-    "tests/LDRxaf0-invalid.litmus",    
+    "tests/LDRxaf0-invalid.litmus",
     "tests/miniMarc03.litmus",
-# Cannot compare pte any longer, got to fix.
-#    "tests/coRW-DB.litmus",
+    "tests/coRW-DB.litmus",
     "tests/coRR-pte9.litmus",
     "tests/V2I.litmus",
     "tests/STRva-STRpte2.litmus",

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -911,9 +911,9 @@ module Make
         let ( ---> ) f i = ( read_sign_bit f ) << i in
         (* Computation of nz flags *)
         let compute_nz =
-          let compute_z2 = ( res === V.zero ) << 1 in
+          let compute_z = ( res === V.zero ) << 1 in
           let compute_n = read_sign_bit res in
-          compute_z2 || compute_n
+          compute_z || compute_n
         in
         (* Operation specific computations
            For specific formulae, see Hacker's Delight, 2-13.*)
@@ -921,6 +921,8 @@ module Make
         | ADD | EOR | ORR | SUB | AND | ASR | LSR | LSL | BIC -> None
         | ANDS | BICS -> Some compute_nz
         | ADDS ->
+            let x = make_op Op.ToInteger x res
+            and y = make_op Op.ToInteger y (fun _ _ _ -> mzero) in
             let compute_c = ((x & y) || ((x || y) & !res)) ---> 2 in
             let compute_v = ((res + x) & (res + y)) ---> 3 in
             Some (compute_nz || compute_c || compute_v)
@@ -936,6 +938,8 @@ module Make
             This gives the following formula, which seems to produce the same
             results as hardware:
           *)
+            let x = make_op Op.ToInteger x res
+            and y = make_op Op.ToInteger y (fun _ _ _ -> mzero) in
             let compute_c = ((x & !y) || ((x || !y) & !res)) ---> 2 in
             let compute_v = ((x + y) & (res + x)) ---> 3 in
             Some (compute_nz || compute_c || compute_v)

--- a/lib/op.ml
+++ b/lib/op.ml
@@ -33,6 +33,7 @@ type op =
   | SetTag
   | SquashMutable
   | CheckPerms of string
+  | ToInteger
 
 let pp_op o =
   match o with
@@ -74,6 +75,7 @@ let pp_op o =
   | CapaSetTag -> "capasettag"
   | SquashMutable -> "squashmutable"
   | CheckPerms perms -> sprintf "checkcapa:%s" perms
+  | ToInteger -> "ToInteger"
 
 let is_infix = function
   | Add|Sub|Mul|Div|And|Or|Xor|ShiftLeft
@@ -83,6 +85,7 @@ let is_infix = function
   | ClrPerm|CpyType|CSeal|Cthi|Seal|SetValue
   | CapaSub|CapaSubs|CapaSetTag|Unseal
   | Max|Min|SetTag|SquashMutable|CheckPerms _
+  | ToInteger
     -> false
 
 let pp_ptx_cmp_op = function

--- a/lib/op.mli
+++ b/lib/op.mli
@@ -40,6 +40,10 @@ type op =
   | SetTag
   | SquashMutable
   | CheckPerms of string
+(* Change non-integer to integer given as second argument.
+ * If argument is integer, it is left as is.
+ *)
+  | ToInteger
 
 val pp_op : op -> string
 

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -725,6 +725,13 @@ module
   | Val cst -> Warn.user_error "Illegal capastrip on %s" (Cst.pp_v cst)
   | Var _ -> raise Undetermined
 
+  let optointeger v1 v2 =
+    match v1,v2 with
+    | Val (Concrete _),_ -> v1
+    | (Var _,_)|(_,Var _) -> raise Undetermined
+    | Val _,Val (Concrete _) -> v2
+    | _,_ ->
+       Warn.user_error "Illegal ToInteger on %s and %s" (pp_v v1) (pp_v v2)
   let op1 op =
     let open! Cst.Scalar in
     match op with
@@ -824,6 +831,7 @@ module
   | CapaSetTag -> binop_cs_c op (fun c x -> Cst.Scalar.set_tag (scalar_to_bool x) c)
   | SquashMutable -> fun v1 v2 -> binop_cs_cs op cap_squash_post_load_cap v2 v1
   | CheckPerms perms -> binop_cs_cs_c op (check_perms perms)
+  | ToInteger -> optointeger
 
   let op3 If v1 v2 v3 = match v1 with
   | Val (Concrete x) -> if scalar_to_bool x then v2 else v3


### PR DESCRIPTION
`ToInteger(v1,v2)` yields v1 when v1 is an integer constant or v2 when when v1 is a non-integer constant and v2 is an integer constant. Notice that, when v1 is non-integer the operator fails when v2 is not an integer either.

This operator is used for the computation of flags not to fail when comparison is applied to non-integer constants
 such as symbols or page table entries. Of course the N,C and V flags may not be correct w.r.t. hardware in those cases. However the Z flag is correct.