### PR TITLE
[herd] Add `-view <viewer>` command line option.

### DIFF
--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -179,12 +179,18 @@ let options = [
   ("-suffix", Arg.String (fun s -> suffix := s),
    "<suf> add <suf> at the end of the base of generated files") ;
   parse_bool "-dumpes" Opts.dumpes "dump event structures";
+  begin let module ParseView = ParseTag.Make(View) in
+  ParseView.parse_opt "-view" PP.view
+    "fork specified viewer to show output graphs" end ;
   ( "-gv",
-    Arg.Unit (fun _ -> PP.gv := true),
-    "<non-default>  fork gv to show output graphs") ;
+    Arg.Unit (fun _ -> PP.view := Some View.GV),
+    "<non-default>  alias for -view gv") ;
   ( "-evince",
-    Arg.Unit (fun _ -> PP.evince := true),
-    "<non-default>  fork evince to show output graphs") ;
+    Arg.Unit (fun _ -> PP.view := Some View.Evince),
+    "<non-default>  alias for -view evince") ;
+  ( "-preview",
+    Arg.Unit (fun _ -> PP.view := Some View.Preview),
+    "<non-default>  alias for -view preview") ;
   ("-unroll",
    Arg.Int (fun x -> unroll := x),
    sprintf "<int> branch unrolling upper limit, default %i" !unroll);
@@ -550,8 +556,7 @@ let () =
       let verbose = verbose
       let dotmode = !PP.dotmode
       let dotcom = !PP.dotcom
-      let gv = !PP.gv
-      let evince = !PP.evince
+      let view = !PP.view
       let showevents = !PP.showevents
       let texmacros = !PP.texmacros
       let tikz = !PP.tikz

--- a/herd/lexConf_herd.mll
+++ b/herd/lexConf_herd.mll
@@ -41,6 +41,9 @@ let lex_tag_fun key parse tags set tag = match parse tag with
 let lex_tag key parse tags v tag =
   lex_tag_fun key parse tags (fun x -> v := x) tag
 
+let lex_tag_opt key parse tags v tag =
+  lex_tag_fun key parse tags (fun x -> v := Some x) tag
+
 let lex_bool_fun set arg =
   let x =
     try bool_of_string arg
@@ -129,9 +132,7 @@ let handle_key main key arg = match key with
     conds := !conds @ [arg]
 (* Behaviour control *)
 | "model"|"cat"  ->
-    lex_tag_fun
-       key Model.parse Model.tags
-       (fun x -> model := Some x) arg
+    lex_tag_opt key Model.parse Model.tags model arg
 | "bell" ->
     bell := Some arg
 | "macros" ->
@@ -140,10 +141,9 @@ let handle_key main key arg = match key with
     let module PV = ParseTag.MakeS(Opts.OptS) in
     PV.parse_tag_set "variant" variant arg
 | "machsize" ->
-     lex_tag "machsize" MachSize.Tag.parse MachSize.Tag.tags byte arg
+    lex_tag "machsize" MachSize.Tag.parse MachSize.Tag.tags byte arg
 | "endian" ->
-     lex_tag_fun "endian" Endian.parse Endian.tags
-        (fun t -> endian := Some t) arg
+     lex_tag_opt "endian" Endian.parse Endian.tags endian arg
 | "through" ->
     lex_tag
        "through" Model.parse_through Model.tags_through
@@ -155,8 +155,7 @@ let handle_key main key arg = match key with
 | "unroll" ->
     lex_int unroll arg
 | "optace" ->
-    lex_tag_fun
-       "optace" OptAce.parse OptAce.tags (fun b ->  optace := Some b) arg
+    lex_tag_opt "optace" OptAce.parse OptAce.tags optace arg
 | "archcheck" ->
     lex_bool archcheck arg
 | "initwrites" ->
@@ -192,15 +191,14 @@ let handle_key main key arg = match key with
      lex_tag "dotmode" PrettyConf.parse_dotmode PrettyConf.tags_dotmode
         PP.dotmode arg
 | "dotcom" ->
-     lex_tag_fun
+     lex_tag_opt
         "dotcom" PrettyConf.parse_dotcom
         PrettyConf.tags_dotmode
-        (fun x -> PP.dotcom := Some x)
-        arg
-| "gv" ->
-     lex_bool PP.gv arg
-| "evince" ->
-     lex_bool PP.evince arg
+        PP.dotcom arg
+| "view" ->
+     lex_tag_opt
+        "view" View.parse
+        View.tags PP.view arg
 | "showevents" ->
      lex_tag "showevents"
         PrettyConf.parse_showevents PrettyConf.tags_showevents

--- a/herd/opts.ml
+++ b/herd/opts.ml
@@ -80,8 +80,7 @@ module PP = struct
   open PrettyConf
   let dotmode =  ref Plain
   let dotcom = ref None
-  let gv = ref false
-  let evince = ref false
+  let view = ref None
   let showevents = ref NonRegEvents
   let texmacros = ref false
   let tikz = ref false

--- a/herd/opts.mli
+++ b/herd/opts.mli
@@ -74,8 +74,7 @@ module PP : sig
   open PrettyConf
   val dotmode : dotmode ref
   val dotcom : dotcom option ref
-  val evince : bool ref
-  val gv : bool ref
+  val view : View.t option ref
   val showevents : showevents ref
   val texmacros : bool ref
   val tikz : bool ref

--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -183,7 +183,7 @@ module Top (TopConf:Config) = struct
           begin match Conf.outputdir with
           | PrettyConf.StdoutOutput | PrettyConf.Outputdir _ -> true
           | _ -> false
-          end || Conf.PC.gv || Conf.PC.evince || Conf.variant Variant.MemTag
+          end || Misc.is_some Conf.PC.view || Conf.variant Variant.MemTag
               || Conf.variant Variant.Morello
         let through = Conf.through
         let debug = Conf.debug.Debug_herd.barrier

--- a/herd/prettyConf.ml
+++ b/herd/prettyConf.ml
@@ -104,8 +104,7 @@ module type S = sig
   val debug : bool
   val verbose : int
   val dotcom : dotcom option
-  val gv : bool
-  val evince : bool
+  val view : View.t option
   val dotmode : dotmode
   val showevents : showevents
   val texmacros : bool

--- a/herd/prettyConf.mli
+++ b/herd/prettyConf.mli
@@ -63,8 +63,7 @@ module type S = sig
   val debug : bool
   val verbose : int
   val dotcom : dotcom option
-  val gv : bool
-  val evince : bool
+  val view : View.t option
   val dotmode : dotmode
   val showevents : showevents
   val texmacros : bool

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -172,14 +172,18 @@ module Make(O:Config)(M:XXXMem.S) =
     let open_dot test =
       match O.outputdir with
       | PrettyConf.NoOutputdir ->
-          if S.O.PC.gv || S.O.PC.evince then
+         begin
+           match S.O.PC.view with
+           | Some _ ->
             begin try
               let f,chan = Filename.open_temp_file "herd" ".dot" in
               Some (chan,f)
             with  Sys_error msg ->
               W.warn "Cannot create temporary file: %s" msg ;
               None
-            end else None
+            end
+           | None -> None
+         end
       | PrettyConf.StdoutOutput ->
          let fname = Test_herd.basename test in
          fprintf stdout "\nDOTBEGIN %s\n" fname;
@@ -380,7 +384,7 @@ module Make(O:Config)(M:XXXMem.S) =
               (fun (_i,_cs,es) -> PP.dump_es chan test es)
               rfms ;
             close_dot ochan ;
-            if S.O.PC.gv || S.O.PC.evince then begin
+            if Misc.is_some S.O.PC.view then begin
               let module SH = Show.Make(S.O.PC) in
               SH.show_file fname
             end ;

--- a/herd/view.ml
+++ b/herd/view.ml
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* Copyright 2022-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,16 +14,17 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Show dot files as Postscript, controlled by '-view viewer' option *)
-module Generator : functor (O:PrettyConf.S) -> sig
-  val generator : string
-end
+type t = GV | Evince | Preview
 
-module Make : functor (O:PrettyConf.S)  -> sig
-(* Fork a gv window to show that file *)
-val show_file : string -> unit
+let tags = ["gv"; "evince"; "preview"; ]
 
-(* Idem, but show the graph produced by the argument function *)
-val show : (out_channel -> unit) -> unit
+let parse tag = match Misc.lowercase tag with
+| "gv" -> Some GV
+| "evince" -> Some Evince
+| "preview" -> Some Preview
+| _ -> None
 
-end
+let pp = function
+  | GV -> "gv"
+  | Evince -> "evince"
+  | Preview -> "preview"

--- a/herd/view.mli
+++ b/herd/view.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2010-present Institut National de Recherche en Informatique et *)
+(* Copyright 2022-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,16 +14,10 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Show dot files as Postscript, controlled by '-view viewer' option *)
-module Generator : functor (O:PrettyConf.S) -> sig
-  val generator : string
-end
+(** 'view' tags, command display of images *)
 
-module Make : functor (O:PrettyConf.S)  -> sig
-(* Fork a gv window to show that file *)
-val show_file : string -> unit
+type t = GV | Evince | Preview
 
-(* Idem, but show the graph produced by the argument function *)
-val show : (out_channel -> unit) -> unit
-
-end
+val tags : string list
+val parse : string -> t option
+val pp : t -> string


### PR DESCRIPTION
This option commands the tool used for displaying execution diagrams. Recognised viewers are gv, evince and preview. Options `-gv` and `-evince` are kept for backward compatibility.