### PR TITLE
[tools] Better management of arrays in tools

### DIFF
--- a/lib/lexSplit.mli
+++ b/lib/lexSplit.mli
@@ -20,5 +20,6 @@ val ints : string -> int list
 val strings : string -> string list
 val strings_spaces : string -> string list
 val words : string -> string list
+val split_array : string -> string list
 
 val pp_ints : int list -> string

--- a/lib/lexSplit.mll
+++ b/lib/lexSplit.mll
@@ -45,12 +45,51 @@ and words = parse
 | non_blank+ as w { w::words lexbuf }
 | eof { [] }
 
+and parse_array buff d = parse
+| '{'
+    {
+     Buffer.add_char buff '{' ;
+     parse_array buff (d+1) lexbuf
+   }
+| '}'
+    {
+     Buffer.add_char buff '}' ;
+     if d <= 0 then Buffer.contents buff
+     else parse_array buff (d-1) lexbuf
+   }
+| _ as c
+    {
+     Buffer.add_char buff c ;
+     parse_array buff d lexbuf
+   }
+| "" { raise Error }
+
+and array_elements = parse
+| blank* ',' blank* { array_elements lexbuf }
+| [^',''}']+ as lxm blank* { lxm :: array_elements lexbuf }
+| blank* '}' { [] }
+| '{'
+    {
+     let buff = Buffer.create 16 in
+     Buffer.add_char buff '{' ;
+     let elt = parse_array buff 0 lexbuf  in
+     elt :: array_elements lexbuf
+   }
+| ""  { raise Error }
+
+and split_array = parse
+| '{' { array_elements lexbuf }
+| ""  { raise Error }
 {
 
 let ints s = main (Lexing.from_string s)
 let strings s = strings (Lexing.from_string s)
 let strings_spaces s = strings_spaces (Lexing.from_string s)
 let words s = words (Lexing.from_string s)
+let split_array s =
+  try Lexing.from_string s |> split_array
+  with Error ->
+    Warn.fatal "Bad array syntax: %s\n" s
 
 let pp_ints xs = String.concat "," (List.map string_of_int xs)
 

--- a/tools/lexLog_tools.mll
+++ b/tools/lexLog_tools.mll
@@ -89,12 +89,20 @@ let norm_pteval s =
  + Other values need not being normalised
  *)
 
-let norm_value s =
+let norm_one_value s =
   assert (String.length s > 0) ;
   match s.[0] with
   | '(' -> norm_pteval s
-  | '0'..'9' -> to_xxx s
+  | '-'|'0'..'9' -> to_xxx s
   | _ ->  Constant.old2new s
+
+let rec norm_value s =
+  assert (String.length s > 0) ;
+  match s.[0] with
+  | '{' ->
+      let elts = List.map norm_value (LexSplit.split_array s) in
+      Printf.sprintf "{%s}" (String.concat "," elts)
+  | _ -> norm_one_value s
 
 let norm_loc s = Constant.old2new s
 

--- a/tools/logState.ml
+++ b/tools/logState.ml
@@ -479,16 +479,44 @@ module LC =
           else
             bds_assoc r loc
 
+(*
+ * Comparaison is string-based, except for integers, which are parsed.
+ * That way, radix is abstracted away.
+ *)
+
+      let rec value_eq vcond v =
+        let open Constant in
+        match vcond with
+        | Concrete _ ->
+            begin try
+              let i = Int64.of_string v in
+              ToolsConstant.eq vcond (Constant.Concrete i)
+            with Failure _ ->
+              Warn.fatal
+                "Comparing constant %s against integer"
+                v
+            end
+        | ConcreteVector vconds ->
+            let vs = LexSplit.split_array v in
+            value_eqs vconds vs
+        | _ ->
+            let vcond = ToolsConstant.pp false vcond in
+            Misc.string_eq vcond v
+
+      and value_eqs vconds vs = match vconds,vs with
+      | [],[] -> true
+      | ([],_)|(_,[])
+ (* Could be a failure, as arrays are of fixed length *)
+        -> false
+      | vcond::vconds,v::vs ->
+          value_eq vcond v && value_eqs vconds vs
+
       let state_mem st loc v =
         let open HashedState in
         let {S.e=bds; _;} = as_t st in
         let v_bound_pp =
           bds_assoc bds (ConstrGen.dump_rloc MiscParser.dump_location  loc) in
-        try (* Ints are treated differently to abstract away radix *)
-          let i = Int64.of_string v_bound_pp in
-          ToolsConstant.eq v (Constant.Concrete i)
-        with Failure _ ->
-          Misc.string_eq v_bound_pp (ToolsConstant.pp false v)
+        value_eq v v_bound_pp
 
       let state_eqloc st loc1 loc2 =
         let open HashedState in


### PR DESCRIPTION
Arrays were previously handled as strings in parsing, printing and comparison, resulting in printing inconsistencies and wrong comparisons in the case of arrays of integers.

Now, arrays are lexed as lists of their elements and integer elements are normalised and compared as integers.

The changes result in consistent output (all integers shown in hexadecimal when specified) and correct equality of arrays.