### PR TITLE
[litmus] Compilation of C litmus tests with no `-carch <arch>` option.

### DIFF
--- a/lib/Archs.mli
+++ b/lib/Archs.mli
@@ -27,7 +27,7 @@ module System : sig
     | `X86
     | `RISCV
     | `X86_64
-    ]
+   ]
 
   (* Native architecture may be unknown, some features
      will notbe available *)

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -84,6 +84,7 @@ module Make
       let have_fault_handler = false
       let do_stats = false
       let sysarch = Cfg.sysarch
+      let c11 = false
       let variant _ = false (* No variant (yet ?) *)
     end
 

--- a/litmus/dumpRun.ml
+++ b/litmus/dumpRun.ml
@@ -83,10 +83,6 @@ end = struct
   end
 
   let get_arch arch =
-    let arch = match arch with
-    | `C -> Archs.check_carch Cfg.carch
-    | `OpenCL | `CPP | `LISA | `JAVA | `ASL -> assert false
-    | #Archs.System.arch as a -> a in
     let opt = Option.get_default arch in
     let opt = Cfg.mkopt opt in
     let module M = struct

--- a/litmus/litmus.ml
+++ b/litmus/litmus.ml
@@ -162,7 +162,6 @@ let opts =
      "<line> add line at beginning of Makefile" ;
    argstring "-gcc" Option.gcc "<name> name of gcc" ;
    argbool "-c11" Option.c11 "enable the C11 standard";
-   argbool "-c11_fence" Option.c11_fence "enable the C11 standard";
    argboolo "-stdio" Option.stdio "use/do not use stdio";
    argbool "-ascall" Option.ascall "tested code is in a function";
    argstring "-linkopt" Option.linkopt "<flags> set gcc link option(s)" ;
@@ -298,11 +297,6 @@ let () =
       let makevar = !makevar
       let gcc = !gcc
       let c11 = !c11
-      let c11_fence =
-        let b = !c11_fence in
-        if b && not c11 then
-          Warn.fatal "The use of C11 fence cannot be enabled without C11 enabled (use -c11 true)";
-        b
       let stdio = match !stdio with
       | None ->
           begin match !mode with

--- a/litmus/option.ml
+++ b/litmus/option.ml
@@ -132,7 +132,6 @@ let speedcheck = ref Speedcheck.NoSpeed
 let makevar = ref []
 let gcc = ref "gcc"
 let c11 = ref false
-let c11_fence = ref false
 let ascall = ref false
 let stdio = ref None
 let linkopt = ref ""

--- a/litmus/option.mli
+++ b/litmus/option.mli
@@ -85,7 +85,6 @@ val speedcheck : Speedcheck.t ref
 val makevar : string list ref
 val gcc : string ref
 val c11 : bool ref
-val c11_fence : bool ref
 val ascall : bool ref
 val stdio : bool option ref
 val linkopt : string ref

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -139,6 +139,7 @@ module Make
         let have_fault_handler = have_fault_handler
         let do_stats = do_stats
         let sysarch = Cfg.sysarch
+        let c11 = Cfg.c11
         let variant = Cfg.variant
       end
 
@@ -249,7 +250,7 @@ module Make
       let dump_mbar_def () =
         O.o "" ;
         O.o "/* Full memory barrier */" ;
-        Insert.insert O.o "mbar.c" ; O.o "" ;
+        UD.dump_mbar_def () ;
         if not (Label.Full.Set.is_empty CfgLoc.label_init) then begin
           O.o "/* Code analysis */" ;
           O.o "#define SOME_LABELS 1" ;

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -60,7 +60,6 @@ module type Config = sig
   val pldw : bool
   val cacheflush : bool
   val c11 : bool
-  val c11_fence : bool
   val ascall : bool
   val variant : Variant_litmus.t -> bool
   val stdio : bool
@@ -275,6 +274,7 @@ module Make
         let have_fault_handler = false
         let do_stats = false
         let sysarch = Cfg.sysarch
+        let c11 = Cfg.c11
         let variant = Cfg.variant
       end
 
@@ -673,7 +673,7 @@ module Make
       let dump_mbar_def () =
         O.o "" ;
         O.o "/* Full memory barrier */" ;
-        Insert.insert O.o "mbar.c" ;
+        UD.dump_mbar_def () ;
         if Cfg.cautious then begin
           O.o "" ;
           O.o "inline static void mcautious(void) { mbar(); }" ;

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -55,7 +55,6 @@ module type CommonConfig = sig
   val makevar : string list
   val gcc : string
   val c11 : bool
-  val c11_fence : bool
   val ascall : bool
   val precision : Precision.t
   val variant : Variant_litmus.t -> bool
@@ -436,7 +435,9 @@ end = struct
           let sysarch =
             match arch,Archs.get_sysarch arch  OT.carch with
             | `C,`Unknown->
-                  Warn.fatal "Test %s not performed because -carch is not given but required while using C arch" tname
+                if not OT.c11 then
+                Warn.user_error "Test %s in C not performed, because no option -carch <arch> or -c11 true is present" tname ;
+                `Unknown
             | _,a -> a
           let noinline = true
           end in
@@ -596,7 +597,7 @@ end = struct
                       | `AArch64 -> AArch64Arch_litmus.comment
                       | `MIPS -> MIPSArch_litmus.comment
                       | `RISCV -> RISCVArch_litmus.comment
-                      | `Unknown -> assert false
+                      | `Unknown -> "#"
                       end
                end in
              let module X = Make'(Cfg)(Arch') in

--- a/litmus/top_litmus.mli
+++ b/litmus/top_litmus.mli
@@ -48,7 +48,6 @@ module type CommonConfig = sig
   val makevar : string list
   val gcc : string
   val c11 : bool
-  val c11_fence : bool
   val ascall : bool
   val precision : Precision.t
   val variant : Variant_litmus.t -> bool


### PR DESCRIPTION
It is now possible to compile C litmus tests without specifying a target architecture. However, in that case, the `-c11 true` option is mandatory. This simple feature is useful for a few quick, initial, tests on a new architecture, where a C11 compiler is available.