### PR TITLE
[lib]: LDXP Pretty Printing

### DIFF
--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1117,7 +1117,7 @@ let do_pp_instruction m =
 
   let pp_ldxp memo v r1 r2 r3 =
     pp_memo memo ^ " "
-    ^ pp_wreg r1 ^","
+    ^ (if m.compat then pp_wreg r1 else pp_vreg v r1) ^","
     ^ pp_vreg v r2 ^ ",["
     ^ pp_xreg r3 ^ "]" in
 


### PR DESCRIPTION
Consider the instruction `LDXP X1, X2, [X3]`

When printed using `pp_ldxp` in `lib/AArch64Base` the first register is printed as an `W`reg when it should be printed as an `X` reg.

This patch amends pretty printing to this effect.
Side effect: Hashes in tests are updated