### PR TITLE
[lib]: Added mkdir -p helper function

### DIFF
--- a/lib/mySys.ml
+++ b/lib/mySys.ml
@@ -194,4 +194,7 @@ let mktmpdir () =
   mkdir name ;
   name
 
+(* does not destroy dir if you want to keep it around *)
+let mkdirp name = exec_stdout (sprintf "mkdir -p %s" name)
+
 let rmdir name = exec_stdout (sprintf "/bin/rm -rf %s" name)

--- a/lib/mySys.mli
+++ b/lib/mySys.mli
@@ -67,5 +67,6 @@ val cat_and_remove : string -> (string -> unit) -> unit
 val exec_stdout : string -> unit
 val exec : string -> (string -> unit) -> unit
 val mkdir : string -> unit
+val mkdirp : string -> unit
 val mktmpdir : unit -> string
 val rmdir : string -> unit


### PR DESCRIPTION
This function makes a linux call to `mkdir -p` to create a directory if it does not already exist.

I use this in a later commit and am uploading this first.