### PR TITLE
[lib]: Fixed constant pretty printing with offsets

### DIFF
--- a/herd/tests/instructions/AArch64.neon/V43.litmus.expected
+++ b/herd/tests/instructions/AArch64.neon/V43.litmus.expected
@@ -1,6 +1,6 @@
 Test V43 Required
 States 1
-0:X0=x+4; [y]=1; [z]=2;
+0:X0=x[4]; [y]=1; [z]=2;
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.neon/V46.litmus.expected
+++ b/herd/tests/instructions/AArch64.neon/V46.litmus.expected
@@ -1,6 +1,6 @@
 Test V46 Required
 States 1
-0:X0=x+8; 0:X1=32;
+0:X0=x[8]; 0:X1=32;
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.neon/V47.litmus.expected
+++ b/herd/tests/instructions/AArch64.neon/V47.litmus.expected
@@ -1,6 +1,6 @@
 Test V47 Required
 States 1
-0:X0=x+8; 0:X2=32;
+0:X0=x[8]; 0:X2=32;
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -92,7 +92,7 @@ let get_index = function
 
 let pp_index base o = match o with
 | 0 -> base
-| i -> sprintf "%s+%i" base i
+| i -> sprintf "%s[%i]" base i
 
 let pp_symbol_old = function
   | Virtual s -> pp_index (pp_symbolic_data s) s.offset
@@ -277,6 +277,13 @@ let do_mk_sym sym = match Misc.tr_pte sym with
 
 let mk_sym_virtual s = Symbolic (do_mk_virtual s)
 let mk_sym s = Symbolic (do_mk_sym s)
+
+let mk_sym_with_index s i =
+  Symbolic
+    (Virtual
+       {default_symbolic_data
+       with name=s; offset=i})
+
 
 let as_virtual s =
   if Misc.is_pte s || Misc.is_physical s || Misc.is_atag s then

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -106,6 +106,7 @@ val mk_sym_pte : string -> ('scalar,'pte,'instr) t
 val mk_sym_pte2 : string -> ('scalar,'pte,'instr) t
 val mk_sym_pa : string -> ('scalar,'pte,'instr) t
 val old2new : string -> string
+val mk_sym_with_index : string -> int -> ('scalar,'pte,'instr) t
 
 val mk_vec : int -> ('scalar,'pte,'instr) t list -> ('scalar,'pte,'instr) t
 val mk_replicate : int -> ('scalar,'pte,'instr) t -> ('scalar,'pte,'instr) t


### PR DESCRIPTION
This patch fixes the pretty printing of tests which offset symbolic addresses.

It also adds a helper function to make a symbolic location with an offset (which is used in a later patch)