### PR TITLE
[lib]: added mk_sym_with_index helper function

### DIFF
--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -278,6 +278,12 @@ let do_mk_sym sym = match Misc.tr_pte sym with
 let mk_sym_virtual s = Symbolic (do_mk_virtual s)
 let mk_sym s = Symbolic (do_mk_sym s)
 
+let mk_sym_with_index s i =
+  Symbolic
+    (Virtual
+      {default_symbolic_data
+      with name=s; offset=i})
+
 let as_virtual s =
   if Misc.is_pte s || Misc.is_physical s || Misc.is_atag s then
     Warn.user_error "Non-virtual id %s" s ;

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -102,6 +102,7 @@ val map :
 
 val mk_sym_virtual : string -> ('scalar,'pte,'instr) t
 val mk_sym : string -> ('scalar,'pte,'instr) t
+val mk_sym_with_index : string -> int -> ('scalar, 'pte, 'instr) t
 val mk_sym_pte : string -> ('scalar,'pte,'instr) t
 val mk_sym_pte2 : string -> ('scalar,'pte,'instr) t
 val mk_sym_pa : string -> ('scalar,'pte,'instr) t


### PR DESCRIPTION
This patch adds a helper function used in a later commit. `mk_sym_with_index` allows us to create symbolic location `v` with a specified offset `i`