### PR TITLE
[diy7] support for stdout and cycle only output

### DIFF
--- a/gen/config.ml
+++ b/gen/config.ml
@@ -253,7 +253,7 @@ let common_specs () =
    ("-no", Arg.String (fun s -> no := Some s),
      "<fname> do not generate tests for these cycles")::
   ("-stdout", Arg.Bool (fun b ->  stdout := b),
-    "output to stdout (default false)")::
+    "output to stdout. If Cycleonly is true, then this is implied to be true. (default false)")::
   ("-cycleonly", Arg.Bool (fun b ->  cycleonly := b),
     "output only cycle, i.e. no litmus body (default false)")::
   []

--- a/gen/config.ml
+++ b/gen/config.ml
@@ -51,6 +51,8 @@ let bell = ref None
 let scope = ref Scope.No
 let variant = ref (fun (_:Variant_gen.t) -> false)
 let rejects = ref None
+let stdout = ref false
+let cycleonly = ref false
 
 let info = ref ([]:MiscParser.info)
 let add_info_line line = match LexScan.info line with
@@ -250,6 +252,10 @@ let common_specs () =
      sprintf "<i> size of integer added to base name that yield test names (default %i)" !fmt)::
    ("-no", Arg.String (fun s -> no := Some s),
      "<fname> do not generate tests for these cycles")::
+  ("-stdout", Arg.Bool (fun b ->  stdout := b),
+    "output to stdout (default false)")::
+  ("-cycleonly", Arg.Bool (fun b ->  cycleonly := b),
+    "output only cycle, i.e. no litmus body (default false)")::
   []
 
 let numeric = ref true

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -239,6 +239,8 @@ let () =
     let addnum = !Config.addnum
     let numeric = !Config.numeric
     let lowercase = !Config.lowercase
+    let stdout = !Config.stdout
+    let cycleonly = !Config.cycleonly
 (* Specific *)
     open Config
     let choice = !Config.mode

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -239,7 +239,7 @@ let () =
     let addnum = !Config.addnum
     let numeric = !Config.numeric
     let lowercase = !Config.lowercase
-    let stdout = !Config.stdout
+    let stdout = if !Config.cycleonly then true else !Config.stdout
     let cycleonly = !Config.cycleonly
 (* Specific *)
     open Config

--- a/gen/diycross.ml
+++ b/gen/diycross.ml
@@ -183,7 +183,9 @@ let () =
       let sufname = !Config.sufname
       let addnum = !Config.addnum
       let numeric = !Config.numeric
-     let lowercase = !Config.lowercase
+      let lowercase = !Config.lowercase
+      let stdout = !Config.stdout
+      let cycleonly = !Config.cycleonly
 (* Specific *)
       let varatom = !Config.varatom
       let same_loc =

--- a/gen/diycross.ml
+++ b/gen/diycross.ml
@@ -184,7 +184,7 @@ let () =
       let addnum = !Config.addnum
       let numeric = !Config.numeric
       let lowercase = !Config.lowercase
-      let stdout = !Config.stdout
+      let stdout = if !Config.cycleonly then true else !Config.stdout
       let cycleonly = !Config.cycleonly
 (* Specific *)
       let varatom = !Config.varatom

--- a/gen/diyone.ml
+++ b/gen/diyone.ml
@@ -232,7 +232,7 @@ let () =
     let neg = !Config.neg
     let typ = !Config.typ
     let hexa = !Config.hexa
-    let stdout = !Config.stdout
+    let stdout = if !Config.cycleonly then true else !Config.stdout
     let cycleonly = !Config.cycleonly
 (* Specific *)
     let norm = !norm

--- a/gen/diyone.ml
+++ b/gen/diyone.ml
@@ -232,6 +232,8 @@ let () =
     let neg = !Config.neg
     let typ = !Config.typ
     let hexa = !Config.hexa
+    let stdout = !Config.stdout
+    let cycleonly = !Config.cycleonly
 (* Specific *)
     let norm = !norm
     let cpp = cpp

--- a/gen/dumpAll.ml
+++ b/gen/dumpAll.ml
@@ -288,7 +288,8 @@ module Make(Config:Config)(T:Builder.S)
             (fun chan -> T.dump_test_channel chan t)
             src ;
 (* And litmus file name in @all file *)
-        fprintf all_chan "%s\n" src ;
+        if not Config.stdout then
+          fprintf all_chan "%s\n" src ;
         if Config.verbose > 0 then eprintf "Test: %s\n" n ;
 (*    printf "%s: %s\n" n (pp_edges cycle.orig) ; *)
         { res with ntests = res.ntests+1; }

--- a/gen/dumpAll.mli
+++ b/gen/dumpAll.mli
@@ -29,6 +29,7 @@ module type Config = sig
   val cpp : bool
   val scope : Scope.t
   val info : MiscParser.info
+  val stdout: bool
 end
 
 module Make(Config:Config) (T:Builder.S) : sig

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -929,7 +929,7 @@ let fmt_cols =
   let dump_test_channel chan t =
     if O.cycleonly then
       if t.com <> "" then
-        fprintf chan "%s\n" t.com
+        fprintf chan "%s: %s\n" t.name t.com
       else
        Warn.fatal "-cycleonly=true requested but no cycle generated"
     else

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -36,6 +36,7 @@ module type Config = sig
   val typ : TypBase.t
   val hexa : bool
   val variant : Variant_gen.t -> bool
+  val cycleonly: bool
 end
 
 module Make (O:Config) (Comp:XXXCompile_gen.S) : Builder.S
@@ -908,7 +909,7 @@ let fmt_cols =
     let pp = fmt_cols code in
     Misc.pp_prog chan pp
 
-  let dump_test_channel chan t =
+  let dump_test_channel_full chan t =
     fprintf chan "%s %s\n" (Archs.pp A.arch) t.name ;
     if t.com <>  "" then fprintf chan "\"%s\"\n" t.com ;
     List.iter
@@ -924,6 +925,15 @@ let fmt_cols =
     end ;
     F.dump_final chan t.final ;
     ()
+  
+  let dump_test_channel chan t =
+    if O.cycleonly then
+      if t.com <> "" then
+        fprintf chan "%s\n" t.com
+      else
+       Warn.fatal "-cycleonly=true requested but no cycle generated"
+    else
+      dump_test_channel_full chan t
 
   let num_labels =
 


### PR DESCRIPTION
This PR implements support for 2 new options. 
-stdout allows the user to output litmus tests to stdout
-cycleonly allows the user to output only the cycle name of a test and not the main body.

This code was written with support from @murzinv
