### PR TITLE
[AArch64] Fixes for ctrl+HU and EXC-ENTRY-CSE to restore the intent

### DIFF
--- a/herd/libdir/aarch64hwreqs.cat
+++ b/herd/libdir/aarch64hwreqs.cat
@@ -72,7 +72,7 @@ let HU = W & PTE & Imp
 assert empty HU \ (AF | DB)
 
 (* CSE-ordered-before *)
-let EXC-ENTRY-CSE = if not "ExS" || "EIS" then EXC-ENTRY else {}
+let EXC-ENTRY-CSE = EXC-ENTRY
 let EXC-RET-CSE = if not "ExS" || "EOS" then EXC-RET else {}
 let CSE = ISB | EXC-ENTRY-CSE | EXC-RET-CSE
 let CSE-ob = [R & Exp]; ctrl; [CSE]; po?
@@ -136,4 +136,5 @@ let rec hw-reqs =
   | [R & PTE & Imp]; rmw; [HU]
   | [M & Exp]; po-loc; [TLBUncacheable & FAULT]
   | [R & Exp]; addr; [TLBI]
+  | [R & Exp]; ctrl; [HU]
   | hw-reqs; hw-reqs


### PR DESCRIPTION
The AArch64 cat model is being fixed to restore intent in two ways. Firstly, Exception Entry Effects are Context Synchronisation Events __unconditionally__. Secondly, it is a hardware requirement to preserve the ordering induced by a control dependency to a hardware update of a dirty bit.

The following litmus test, now forbidden, illustrates the `[R & Exp]; ctrl; [HU]` fix.

```
AArch64 LB-HD+dmb.ld+ctrl
TTHM=P1:HD
{
  x=0; z=0;
  PTE(x)=(oa:PA(x),db:0,dbm:1);
  0:X1=PTE(x);
  0:X3=z;
  1:X3=z; 1:X5=x;
}
P0          | P1            ;
LDR X0,[X1] |  LDR W2,[X3]  ;
DMB LD      |  CBNZ W2, L0  ;
MOV W2, #1  | L0:           ;
STR W2,[X3] |  MOV W4,#1    ;
            |  STR W4,[X5]  ;
exists 0:X0=(oa:PA(x),db:1,dbm:1) /\ 1:X2=1
```