### PR TITLE
[herd,litmus] Introduce NZCV argument to the MRS and MSR instructions

### DIFF
--- a/herd/libdir/asl-pseudocode/csel.asl
+++ b/herd/libdir/asl-pseudocode/csel.asl
@@ -1,17 +1,17 @@
 // We do not yet support bitfield reading, so we have to do this instead
-func PSTATE_N()
+func PSTATE_V()
   return read_pstate_nzcv() AND 1
 endfunc
 
-func PSTATE_Z()
+func PSTATE_C()
   return (read_pstate_nzcv() AND 2) >> 1
 endfunc
 
-func PSTATE_C()
+func PSTATE_Z()
   return (read_pstate_nzcv() AND 4) >> 2
 endfunc
 
-func PSTATE_V()
+func PSTATE_N()
   return (read_pstate_nzcv() AND 8) >> 3
 endfunc
 

--- a/herd/tests/instructions/AArch64.ASL/CSEL02.litmus
+++ b/herd/tests/instructions/AArch64.ASL/CSEL02.litmus
@@ -1,0 +1,15 @@
+AArch64 CSEL02
+(* Basic csel, without really a condition check *)
+
+{
+    0: X1 = 3;
+    0: X2 = 4;
+    0: X8 = 8;
+    0: X9 = 9
+}
+
+P0 ;
+CMP X8, X9;
+CSEL X3, X1, X2, MI ;
+
+forall (0: X3 = 3)

--- a/herd/tests/instructions/AArch64.ASL/CSEL02.litmus.expected
+++ b/herd/tests/instructions/AArch64.ASL/CSEL02.litmus.expected
@@ -1,0 +1,10 @@
+Test CSEL02 Required
+States 1
+0:X3=3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X3=3)
+Observation CSEL02 Always 1 0
+Hash=8a42bc6397f293907681f3d2c0d28bff
+

--- a/herd/tests/instructions/AArch64/L053.litmus
+++ b/herd/tests/instructions/AArch64/L053.litmus
@@ -1,0 +1,10 @@
+AArch64 L053
+{
+uint64_t 0:X0;
+}
+  P0         ;
+CMP W1,#0    ;
+MRS X0,NZCV  ;
+LSR X0,X0,28 ;
+forall 0:X0=6
+

--- a/herd/tests/instructions/AArch64/L053.litmus.expected
+++ b/herd/tests/instructions/AArch64/L053.litmus.expected
@@ -1,0 +1,10 @@
+Test L053 Required
+States 1
+0:X0=6;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=6)
+Observation L053 Always 1 0
+Hash=5a3bec73cfa34fff8da1035d9efa1ad8
+

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -64,7 +64,7 @@ type sysreg =
   CTR_EL0 | DCIZ_EL0 |
   MDCCSR_EL0 | DBGDTR_EL0 |
   DBGDTRRX_EL0 | DBGDTRTX_EL0 |
-  ELR_EL1 | ESR_EL1
+  ELR_EL1 | ESR_EL1 | SYS_NZCV
 
 let sysregs = [
     CTR_EL0, "CTR_EL0";
@@ -75,6 +75,7 @@ let sysregs = [
     DBGDTRTX_EL0, "DBGDTRTX_EL0";
     ELR_EL1, "ELR_EL1";
     ESR_EL1, "ESR_EL1";
+    SYS_NZCV, "NZCV";
   ]
 
 type reg =


### PR DESCRIPTION
Notice that both the name "NZCV" and the semantics of the `MRS Xt,NZCV` and `MSR NZCV,Xt` instructions suggest that bit "N" is the high order bit, bit "Z" is the next bit etc. This entails changing the previous encoding, where "N" was the low order bit of an ad-hoc register that represents the N, Z, C and B bits of PSTATE.

As a tribute to how code was written, changes are minimal.