### PR TITLE
[all]: Added C support for non-storing expressions

### DIFF
--- a/herd/CSem.ml
+++ b/herd/CSem.ml
@@ -381,9 +381,12 @@ module
         | C.CastExpr e ->
             build_semantics_expr true e ii >>=
             fun _ ->  M.unitT (ii.A.program_order_index, next0)
-        | C.StoreReg(_,r,e) ->
+        | C.StoreReg(_,Some r,e) ->
             build_semantics_expr true e ii >>=
             fun v -> write_reg r v ii >>=
+              fun _ ->  M.unitT (ii.A.program_order_index, next0)
+        | C.StoreReg(_,None,e) ->
+            build_semantics_expr true e ii >>=
               fun _ ->  M.unitT (ii.A.program_order_index, next0)
         | C.StoreMem(loc,e,mo) ->
             (begin

--- a/herd/tests/instructions/C/C03.litmus
+++ b/herd/tests/instructions/C/C03.litmus
@@ -1,0 +1,9 @@
+C C03
+
+{}
+
+P0 (int* y) {
+  atomic_fetch_add_explicit(y,1,memory_order_seq_cst);
+}
+
+forall y=1

--- a/herd/tests/instructions/C/C03.litmus.expected
+++ b/herd/tests/instructions/C/C03.litmus.expected
@@ -1,0 +1,10 @@
+Test C03 Required
+States 1
+[y]=0x1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall ([y]=0x1)
+Observation C03 Always 1 0
+Hash=71a98e010b15b2b87bfe01c34e457390
+

--- a/jingle/CArch_jingle.ml
+++ b/jingle/CArch_jingle.ml
@@ -104,8 +104,10 @@ include Arch.MakeArch(struct
     end
     | DeclReg (_t,r),DeclReg(_t',r') (* when t = t' *) ->
         add_subs [Reg (sr_name r,r')] subs
-    | StoreReg (_ot,r,ex),StoreReg(_ot',r',ex') (* when ot = ot' *) ->
+    | StoreReg (_ot,Some r,ex),StoreReg(_ot',Some r',ex') (* when ot = ot' *) ->
         add_subs [Reg (sr_name r,r')] subs >>> fun subs ->
+        match_expr subs ex ex'
+    | StoreReg (_ot,None,ex),StoreReg(_ot',None,ex') (* when ot = ot' *) ->
         match_expr subs ex ex'
     | StoreMem(l,ex,mo),StoreMem(l',ex',mo') when mo=mo' ->
         match_location subs l l' >>> fun subs ->
@@ -207,10 +209,13 @@ include Arch.MakeArch(struct
           While (c,t,n)
       | CastExpr e ->
           expl_expr e >! fun e -> CastExpr e
-      | StoreReg(ot,r,e) ->
+      | StoreReg(ot,Some r,e) ->
           conv_reg r >> fun r ->
           expl_expr e >! fun e ->
-          StoreReg (ot,r,e)
+          StoreReg (ot,Some r,e)
+      | StoreReg(ot,None,e) ->
+          expl_expr e >! fun e ->
+          StoreReg (ot,None,e)
       | StoreMem(loc,e,mo) ->
           expl_expr loc >> fun loc ->
           expl_expr e >! fun e ->

--- a/jingle/cDumper.ml
+++ b/jingle/cDumper.ml
@@ -94,7 +94,8 @@ let list_loc prog =
     | While (e,i,_) -> expr (ins s i) e
     | DeclReg (_,r) ->  LocSet.add r s
     | CastExpr e -> expr s e
-    | StoreReg(_,r,e) ->  LocSet.add r (expr s e)
+    | StoreReg(_,Some r,e) ->  LocSet.add r (expr s e)
+    | StoreReg(_,None,e) -> expr s e
     | StoreMem(l,e,_) -> loc (expr s e) l
     | Lock (l,_)
     | Unlock (l,_) -> loc s l

--- a/lib/dune
+++ b/lib/dune
@@ -3,7 +3,7 @@
 
 
 (menhir (modules PPCParser) (flags  --fixed-exception))
-(menhir (modules CParser) (flags  --fixed-exception --explain))
+(menhir (modules CParser) (flags  --fixed-exception))
 (menhir (modules ARMParser) (flags  --fixed-exception))
 (menhir (modules MIPSParser) (flags  --fixed-exception))
 (menhir (modules X86Parser) (flags  --fixed-exception))

--- a/lib/dune
+++ b/lib/dune
@@ -3,7 +3,7 @@
 
 
 (menhir (modules PPCParser) (flags  --fixed-exception))
-(menhir (modules CParser) (flags  --fixed-exception))
+(menhir (modules CParser) (flags  --fixed-exception --explain))
 (menhir (modules ARMParser) (flags  --fixed-exception))
 (menhir (modules MIPSParser) (flags  --fixed-exception))
 (menhir (modules X86Parser) (flags  --fixed-exception))

--- a/tools/mlisa2c.ml
+++ b/tools/mlisa2c.ml
@@ -145,7 +145,7 @@ module Top(O:Config)(Out:OutTests.S) = struct
 
   let  tr_ins = function
     | Pld (r,a,(["once"]|[]|["acquire"] as an)) ->
-        StoreReg (Some CType.word,tr_reg r,tr_load (tr_an an) a)
+        StoreReg (Some CType.word,Some (tr_reg r),tr_load (tr_an an) a)
     | Pst (a,k,(["once"]|[]|["release"] as an)) -> tr_store (tr_an an) a k
     | Pfence (BellBase.Fence (["mb"|"rmb"|"wmb" as f],_)) -> tr_fence f
     | Pfence (BellBase.Fence (["sync"],None)) when O.action = Linux ->

--- a/tools/mlock.ml
+++ b/tools/mlock.ml
@@ -113,7 +113,7 @@ module Top(O:Config)(Out:OutTests.S) = struct
         let v = sprintf "d%i" nxt in
         nxt+1,StringSet.singleton v,
         StoreReg
-          (None,v,ECall ("xchg_acquire",[e;Const const_one]))
+          (None,Some v,ECall ("xchg_acquire",[e;Const const_one]))
     | Unlock (e,_)|PCall ("spin_unlock",[e]) ->
         let e = tr_expr e in
         nxt,StringSet.empty,


### PR DESCRIPTION
Consider the following test:

```
C C03

{}

P0 (int *y) {
  atomic_fetch_add_explicit(y,1,memory_order_seq_cst);
}

forall y=1
```
This test cannot be parsed, since the grammar expects the result of the expression to be written to a local register (e.g. `r0 = ...`)

This patch allows the above to be parsed and simulated under herd