### PR TITLE
[herd] Get rid of the last two occurrences of cat variable `I`

### DIFF
--- a/herd/libdir/aarch64util.cat
+++ b/herd/libdir/aarch64util.cat
@@ -100,10 +100,6 @@ end
 (* Intervening write *)
 let intervening-write(r) = r; [W]; r
 
-(* Properties of single-copy atomic accesses *)
-let si = sm
-show (sm \ id) \ (I * I) as si
-
 (* Renaming default herd names *)
 let Imp = NExp
 let SPONTANEOUS = SPURIOUS

--- a/herd/libdir/c11_cos.cat
+++ b/herd/libdir/c11_cos.cat
@@ -4,7 +4,7 @@ include "cross.cat"
 
 let invrf = rf^-1
 let mobase = co0
-with mo from generate_orders(W&(A|I),mobase)
+with mo from generate_orders(W&(A|IW),mobase)
 
 (* From now, mo is a coherence order *)
 let moi = mo & int


### PR DESCRIPTION
Occurrences of `I` (for the set of initial writes) in cat files are deleted or replaced by `IW`.