### PR TITLE
[all]: Add Region parsing to C Parser

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -436,7 +436,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64) :
           filter = None;
           condition = ConstrGen.ExistsState (ConstrGen.And []);
           locations = [];
-          extra_data = MiscParser.empty_extra;
+          extra_data = MiscParser.empty_extra ;
         }
       in
       let name =

--- a/herd/tests/instructions/C/C12.litmus
+++ b/herd/tests/instructions/C/C12.litmus
@@ -1,0 +1,11 @@
+C C12
+
+{ int x = 0 }
+
+P0(int *x) {
+  *x = 1;
+}
+
+regions: x:PROP
+
+forall ( x = 1 )

--- a/herd/tests/instructions/C/C12.litmus.expected
+++ b/herd/tests/instructions/C/C12.litmus.expected
@@ -1,0 +1,10 @@
+Test C12 Required
+States 1
+[x]=0x1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall ([x]=0x1)
+Observation C12 Always 1 0
+Hash=17c3538e1d8870eb1bb0ac35f89243af
+

--- a/jingle/cDumper.ml
+++ b/jingle/cDumper.ml
@@ -176,10 +176,13 @@ let do_dump withinfo chan doc t =
     DumpUtils.dump_locations
       dump_location ParsedConstant.pp_v MiscParser.dump_fault_type t.MiscParser.locations in
   if locs <> "" then fprintf chan "%s\n" locs ;
-  begin match t.MiscParser.extra_data with
-	| MiscParser.NoExtra|MiscParser.CExtra _ -> ()
-	| MiscParser.BellExtra bi ->
-           fprintf chan "\n%s\n" (BellInfo.pp bi)
+  let extra = t.MiscParser.extra_data in
+  begin List.iter
+    (function
+	 | MiscParser.CExtra _ -> ()
+	 | MiscParser.BellExtra bi ->
+         fprintf chan "\n%s\n" (BellInfo.pp bi))
+    extra
   end ;
   fprintf chan "%s\n" (dump_constr t.MiscParser.condition) ;
   ()

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -142,7 +142,7 @@ let mk_instrp instr v r1 r2 ra ko kb =
 %%
 main:
 | semi_opt proc_list iol_list scopes_and_memory_map EOF
-   { $2,$3,MiscParser.BellExtra $4 }
+   { $2,$3,[MiscParser.BellExtra $4] }
 
 semi_opt:
 | { () }

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -176,7 +176,7 @@ let asl_generic_parser version lexer lexbuf =
   | Ok ast ->
       ( [ (0, None, MiscParser.Main) ],
         [ [ Instruction ast ] ],
-        MiscParser.NoExtra )
+        [] )
 
 module Instr = Instr.No (struct
   type instr = instruction

--- a/lib/BellCheck.ml
+++ b/lib/BellCheck.ml
@@ -245,10 +245,16 @@ module Make
             code)
         parsed.MiscParser.prog in
       let parsed = { parsed with MiscParser.prog; } in
-      let test_bi = parsed.MiscParser.extra_data in
-      let test_bi = match test_bi with
-      | MiscParser.BellExtra b -> b
-      | _ -> Warn.fatal "Error getting bell information from test" in
+      let test_bi =
+        let test_bi = parsed.MiscParser.extra_data in
+        begin match (List.map
+          (function
+           | MiscParser.BellExtra b -> b
+           | _ -> Warn.fatal "Error getting bell information from test")
+          test_bi) with
+          | [] -> assert false
+          | x::_ -> x
+        end in
       begin match test_bi.BellInfo.regions with
       | Some r -> check_regions r bi
       | _ -> ()
@@ -256,7 +262,7 @@ module Make
       let st = Misc.app_opt (fun st -> check_scopes st bi)  test_bi.BellInfo.scopes in
       let test_bi = { test_bi with BellInfo.scopes=st;} in
       let () = Misc.check_opt (fun lvls -> check_levels lvls bi)  test_bi.BellInfo.levels in
-      { parsed with MiscParser.extra_data = MiscParser.BellExtra test_bi; }
+      { parsed with MiscParser.extra_data = [MiscParser.BellExtra test_bi;] }
 
     let check = match C.info with
     | None -> Misc.identity

--- a/lib/CGenParser_lib.ml
+++ b/lib/CGenParser_lib.ml
@@ -44,12 +44,12 @@ module type LexParse = sig
   val deep_lexer : Lexing.lexbuf -> token
   val deep_parser :
         (Lexing.lexbuf -> token) -> Lexing.lexbuf ->
-	  pseudo list CAst.test list
+	  pseudo list CAst.test list * MiscParser.extra_data
 
   val shallow_lexer : Lexing.lexbuf -> token
   val shallow_parser :
         (Lexing.lexbuf -> token) -> Lexing.lexbuf ->
-	  string CAst.t list
+	  string CAst.t list * MiscParser.extra_data
 
   type macro
   val macros_parser :
@@ -129,9 +129,9 @@ module Do
     let init =
       I.call_parser_loc "init"
 		      chan init_loc SL.token StateParser.init in
-    let prog =
+    let prog,_ =
       I.call_parser_loc "prog" chan prog_loc L.deep_lexer L.deep_parser in
-    let prog_litmus =
+    let prog_litmus,data_litmus =
       I.call_parser_loc "prog_litmus" chan prog_loc L.shallow_lexer L.shallow_parser in
     (* Add parameter passsing as inits *)
     let full_init =
@@ -193,7 +193,7 @@ module Do
         filter = filter;
         condition = final;
         locations = locs;
-        extra_data = MiscParser.CExtra params;
+        extra_data = (MiscParser.CExtra params)::data_litmus;
       } in
     let name  = name.Name.name in
     let parsed =

--- a/lib/CLexer.mll
+++ b/lib/CLexer.mll
@@ -26,6 +26,7 @@ let tr_name s = match s with
 | "volatile" -> VOLATILE
 | "const" -> CONST
 | "_Atomic" -> ATOMIC
+| "atomic" -> ATOMIC_BASE
 | "char" -> CHAR
 | "int" -> INT
 | "long" -> LONG
@@ -95,7 +96,7 @@ let tr_name s = match s with
 | "__atomic_add_unless" -> UNDERATOMICADDUNLESS
 | "atomic_add_unless" -> ATOMICADDUNLESS
 (* Others *)
-| x -> IDENTIFIER x
+| x -> NAME x
 }
 
 let digit = ['0'-'9']
@@ -111,6 +112,7 @@ rule token deep = parse
 | '-' ? num as x { CONSTANT x }
 | 'P' (num as x) { PROC (int_of_string x) }
 | ';' { SEMI }
+| ':' { COLON }
 | ',' { COMMA }
 | '|' { PIPE }
 | '*' { STAR }
@@ -139,7 +141,8 @@ rule token deep = parse
 | ">=" { GE }
 | "constvar:" (name as s) { CONSTVAR s }
 | "codevar:" (name as s) { CODEVAR s }
-| '%' name as s { IDENTIFIER s }
+| '%' name as s { NAME s }
+| "regions" { REGIONS }
 | name as x   { tr_name x  }
 | eof { EOF }
 | "" { LexMisc.error "C lexer" lexbuf }

--- a/lib/JavaGenParser_lib.ml
+++ b/lib/JavaGenParser_lib.ml
@@ -180,7 +180,7 @@ struct
         filter = filter;
         condition = final;
         locations = locs;
-        extra_data = MiscParser.NoExtra
+        extra_data = []
       } in
 
     let name  = name.Name.name in

--- a/lib/LISAParser.mly
+++ b/lib/LISAParser.mly
@@ -37,7 +37,7 @@ open Bell
 
 main:
 | semi_opt proc_list iol_list scopes_and_memory_map EOF
-   { $2,$3, MiscParser.BellExtra $4 }
+   { $2,$3, [MiscParser.BellExtra $4] }
 
 semi_opt:
 | { () }

--- a/lib/dune
+++ b/lib/dune
@@ -3,7 +3,6 @@
 
 
 (menhir (modules PPCParser) (flags  --fixed-exception))
-(menhir (modules CParser) (flags  --fixed-exception))
 (menhir (modules ARMParser) (flags  --fixed-exception))
 (menhir (modules MIPSParser) (flags  --fixed-exception))
 (menhir (modules X86Parser) (flags  --fixed-exception))
@@ -24,6 +23,10 @@
 (menhir (modules scopeRules scopeParser)
   (merge_into scopeParser)
    (flags  --fixed-exception))
+
+(menhir (modules scopeRules BellExtraRules CParser)
+  (merge_into CParser)
+  (flags  --fixed-exception))
 
 (library
  (name herdtools)

--- a/lib/genParser.ml
+++ b/lib/genParser.ml
@@ -181,7 +181,7 @@ module Make
          filter = filter;
          condition = final;
          locations = locs;
-         extra_data ;
+         extra_data = extra_data ;
        } in
       let name  = name.Name.name in
       let parsed =

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -175,12 +175,13 @@ type info = (string * string) list
 
 (* Some source files contain addditionnal information *)
 
-type extra_data =
-  | NoExtra
+type extra_param =
   | CExtra of CAst.param list list
   | BellExtra of BellInfo.test
 
-let empty_extra = NoExtra
+type extra_data = extra_param list
+
+let empty_extra = []
 
 type ('i, 'p, 'prop, 'loc, 'v, 'ftype) result =
     { info : info ;
@@ -212,7 +213,7 @@ type 'pseudo t = (state, (proc * 'pseudo list) list, prop, location, maybev, fau
 
 let mach2generic parser lexer buff =
     let procs,code = parser lexer buff in
-    procs,code,NoExtra
+    procs,code,[]
 
 (* Info keys *)
 

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -75,10 +75,11 @@ type info = (string * string) list
 
 (* Some source files contain additional information *)
 
-type extra_data =
-  | NoExtra
+type extra_param =
   | CExtra of CAst.param list list
   | BellExtra of BellInfo.test
+
+type extra_data = extra_param list
 
 val empty_extra : extra_data
 

--- a/lib/outStd.ml
+++ b/lib/outStd.ml
@@ -25,6 +25,7 @@ type t = No | Out
 let open_all () = No
 let open_file _ = Out
 let close _ = ()
+let remove _ = ()
 
 let put_char out c = match out with
 | No -> ()

--- a/lib/outTar.ml
+++ b/lib/outTar.ml
@@ -25,6 +25,7 @@ module Make(O:Tar.Option) = struct
   let open_all () = do_open "@all"
   let open_file name = do_open name
   let close chan = close_out chan
+  let remove name = MySys.remove (T.outname name)
   let put_char = output_char
   let fprintf chan fmt = Printf.fprintf chan fmt
   let tar = T.tar

--- a/lib/outTests.mli
+++ b/lib/outTests.mli
@@ -20,6 +20,7 @@ module type S = sig
   val open_all : unit -> t
   val open_file : string -> t
   val close : t -> unit
+  val remove : string ->  unit
   val put_char : t -> char -> unit
   val fprintf : t -> ('a, out_channel, unit) format -> 'a
   val tar : unit -> unit

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -838,8 +838,8 @@ module A.FaultType = A.FaultType)
       let bellinfo =
         let open MiscParser in
         match extra_data with
-        | NoExtra|CExtra _ -> None
-        | BellExtra i -> Some i in
+        | [BellExtra i] -> Some i
+        | _ -> None in
       let code_typed = type_outs ty_env1 code in
       let flocs,ffaults = LocationsItem.locs_and_faults locs in
         { T.init = initenv ;

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -193,7 +193,7 @@ module Top(O:Config)(Tar:Tar.S) = struct
       type token = CParser.token
       module CL = CLexer.Make(struct let debug = false end)
       let lexer = CL.token false
-      let parser = CParser.shallow_main
+      let parser lexer buf = fst (CParser.shallow_main lexer buf)
     end
     module Pseudo =
       struct

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -336,7 +336,7 @@ end = struct
         type token = CParser.token
         module CL = CLexer.Make(struct let debug = false end)
         let lexer = CL.token false
-        let parser = CParser.shallow_main
+        let parser lexer buf = fst (CParser.shallow_main lexer buf)
       end
 
       module A' = CArch_litmus.Make(O)

--- a/tools/CDumper.ml
+++ b/tools/CDumper.ml
@@ -77,7 +77,7 @@ end = struct
           Out.fprintf chan "%s=%s\n" k i)
       t.info ;
     Out.fprintf chan "\n{%s}\n\n" (dump_state  t.init) ;
-    begin match t.extra_data with
+    let print chan extra = begin match extra with
     | CExtra pss ->
         List.iter2
           (fun ((i,_,_),code) ps ->
@@ -92,7 +92,9 @@ end = struct
             Out.fprintf chan "}\n")
           t.prog pss
     | _ -> ()
-    end ;
+    end in
+    let extras = t.extra_data in
+    List.iter (print chan) extras;
     let locs = DumpUtils.dump_locations dump_loc ParsedConstant.pp_v dump_fault_type t.locations in
     if locs <> "" then Out.fprintf chan "%s\n" locs ;
     begin match t.filter with

--- a/tools/mlisa2c.ml
+++ b/tools/mlisa2c.ml
@@ -188,7 +188,8 @@ module Top(O:Config)(Out:OutTests.S) = struct
 
 
   let do_tr p =
-    { p with prog = tr_prog p.prog; extra_data=CExtra (tr_extra p.prog);}
+    { p with prog = tr_prog p.prog;
+      extra_data=[CExtra (tr_extra p.prog)]; }
 
   let tr_test idx_out name parsed =
     let fname = name.Name.file in

--- a/tools/mlock.ml
+++ b/tools/mlock.ml
@@ -57,11 +57,13 @@ module Top(O:Config)(Out:OutTests.S) = struct
 
   let changed = ref false
 
+  exception NotChanged
+
   let not_changed name =
     if O.verbose > 0 then
       Warn.fatal "test %s unchanged, no output" name.Name.name
     else
-      raise Misc.Exit
+      raise NotChanged
 
 (**********)
 (* Expand *)
@@ -378,22 +380,28 @@ module Top(O:Config)(Out:OutTests.S) = struct
     tr_ins
 
 (* Parsed *)
+
   let tr_params = match O.action with
   | Action.Lock  -> lock_params
   | Expand -> List.map expand_params
   | Once -> fun pss -> pss
 
-  let tr_parsed tr_ins name t = match t.extra_data with
-  | CExtra pss ->
-      changed := false ;
-      let prog =
-        List.map
-          (fun (i,code) -> i,List.map (CBase.pseudo_map tr_ins) code)
-          t.prog in
-      if not !changed then not_changed name ;
-      let extra_data = CExtra (tr_params pss) in
-      { t with extra_data; prog;}
-  | NoExtra|BellExtra _ -> assert false
+  let tr_extra_data =
+    List.map
+      (function
+        | CExtra pss -> CExtra (tr_params pss)
+        | BellExtra _ as data -> data)
+
+  let tr_parsed tr_ins name t =
+    let tr_prog prog =
+     changed := false ;
+     let prog =
+       List.map
+        (fun (i,code) -> i,List.map (CBase.pseudo_map tr_ins) code)
+        prog in
+     if not !changed then not_changed name ;
+    prog in
+    { t with prog = tr_prog t.prog; extra_data = tr_extra_data t.extra_data; }
 
 (* Name *)
   let tr_name0 = match O.action with
@@ -418,45 +426,56 @@ module Top(O:Config)(Out:OutTests.S) = struct
       with Invalid_argument _ -> assert false in
     let base = sprintf "%s.litmus" (tr_name0 base) in
     let out = Out.open_file base in
-    Misc.output_protect_close Out.close
-      (fun out ->
-        let name = tr_name name in
-        let parsed = match O.action with
-        | Action.Lock ->
-            opt_locks (tr_parsed lock_ins name parsed)
-        | Once ->
-            tr_parsed once_ins name parsed
-        | Expand ->
-            begin match parsed.extra_data with
-            | CExtra extra ->
-                let extra_data = CExtra (tr_params extra) in
-                changed := false ;
-                let prog =
-                  List.map
-                    (fun ((i,_,_) as proc,ps) ->
-                      let vs,ps = expand_pseudo_code ps in
-                      StringSet.fold (fun v k -> Location_reg (i,v)::k) vs [],
-                      (proc,ps))
-                    parsed.prog in
-                if not !changed then not_changed name ;
-                let locss,prog = List.split prog in
-                let filter =
-                  let open ConstrGen in
-                  And
-                    (List.map
-                       (fun vs ->
-                         And
-                           (List.map
-                              (fun loc -> Atom (LV (Loc loc,const_zero)))
-                              vs))
-                       locss) in
-                { parsed with prog; extra_data; filter=Some filter;}
-            | NoExtra | BellExtra _ -> assert false
-            end in
-        dump out name parsed ;
-        Out.fprintf idx_out "%s\n" base)
-      out ;
-    ()
+    try
+      Misc.output_protect_close Out.close
+        (fun out ->
+          let name = tr_name name in
+          let parsed = match O.action with
+            | Action.Lock ->
+               opt_locks (tr_parsed lock_ins name parsed)
+            | Once ->
+               tr_parsed once_ins name parsed
+            | Expand ->
+               let extra_data = tr_extra_data parsed.extra_data in
+               changed := false ;
+               let prog =
+                 List.map
+                   (fun ((i,_,_) as proc,ps) ->
+                     let vs,ps = expand_pseudo_code ps in
+                     StringSet.fold (fun v k -> Location_reg (i,v)::k) vs [],
+                     (proc,ps))
+                   parsed.prog in
+               if not !changed then not_changed name ;
+               let locss,prog = List.split prog in
+               let filter =
+                 let open ConstrGen in
+                 let old =
+                   match parsed.filter with
+                   | Some p -> fun q -> And [q;p]
+                   | None -> Misc.identity
+                 and q =
+                   And
+                     (List.map
+                        (fun vs ->
+                          And
+                            (List.map
+                               (fun loc -> Atom (LV (Loc loc,const_zero)))
+                               vs))
+                        locss) in
+                 old q in
+               { parsed with prog;
+                             extra_data;
+                             filter=Some filter;} in
+          dump out name parsed ;
+          Out.fprintf idx_out "%s\n" base)
+        out ;
+      ()
+    with
+    | NotChanged ->
+       Out.remove base
+    | e ->
+       Out.remove base ;
+       raise e
 
   module LexConf  = struct
     let debug = O.verbose > 2

--- a/tools/transposeDumper.ml
+++ b/tools/transposeDumper.ml
@@ -105,11 +105,16 @@ end = struct
         List.iter (fun i -> fprintf chan "%s\n" (fmt_io i)) code ;
         ())
       prog ;
-    begin match t.extra_data with
-    | NoExtra|CExtra _ -> ()
-    | BellExtra bi ->
-        dump_sep chan "Scope" ;
-        fprintf chan "%s" (BellInfo.pp bi)
+    let extra = t.extra_data in
+    begin
+      List.iter
+        (function
+         | CExtra _ -> ()
+         | BellExtra bi ->
+           dump_sep chan "Scope" ;
+           fprintf chan "%s" (BellInfo.pp bi))
+        extra;
+      ()
     end ;
     (* Conditions *)
     dump_sep chan "Check" ;


### PR DESCRIPTION
Add region/scope parsing to C parser, made extra data list

This patch allows us to add region and scope information to C tests.
This also changes the extra_data parameter to store a list of data
so we can pass multiple things into the test.

For C tests, extra_data is where metadata about shared data is stored as
well as region information - we need to preserve both
