### PR TITLE
[diy7] output generated number of tests to stderr when option -stdout true

### DIFF
--- a/gen/dumpAll.ml
+++ b/gen/dumpAll.ml
@@ -445,7 +445,7 @@ module Make(Config:Config)(T:Builder.S)
               Version.version Version.rev ;
             let res =  gen (check_dump all_chan check) empty_t in
             flush stderr ;
-            printf
+            print
               "Generator produced %d tests\n%!"
               res.ntests ;
             if


### PR DESCRIPTION
all that was needed was a simple change, changing printf to print as the print variable is already defined previously to change depending on Config.stdout (line 440)