### PR TITLE
[ifetch] Use CacheType parameters in hashes

### DIFF
--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -240,7 +240,7 @@ let key_match k1 k2 =
       do_rec 0
     end
 
-let digested_keys = [memory_type_key; mt_key;]
+let digested_keys = [memory_type_key; mt_key; cache_type_key; ]
 
 let digest_mem k = List.exists (key_match k) digested_keys
 


### PR DESCRIPTION
This PR is to ensure that tests featuring different DIC/IDC requirements have different hashes.