### PR TITLE
[gen] reject generation if -relax cannot provide cycles

### DIFF
--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -684,9 +684,13 @@ module Make(C:Builder.S)
       List.iter (fun r -> fprintf chan "%s\n" (pp_relax r)) rs
 
     let secret_gen relax safe reject n =
+      let r_nempty = not (relax = []) in
       let relax = expand_relaxs C.ppo relax
       and safe = expand_relaxs C.ppo safe
       and reject = expand_relaxs C.ppo reject in
+      if relax = [] then if r_nempty then begin
+        Warn.fatal "relaxations provided in relaxlist could not be used to generate cycles"
+      end ;
       if O.verbose > 0 then begin
         eprintf "** Relax0 **\n" ;
         debug_rs stderr relax ;

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -684,11 +684,11 @@ module Make(C:Builder.S)
       List.iter (fun r -> fprintf chan "%s\n" (pp_relax r)) rs
 
     let secret_gen relax safe reject n =
-      let r_nempty = not (relax = []) in
+      let r_nempty = Misc.consp relax in
       let relax = expand_relaxs C.ppo relax
       and safe = expand_relaxs C.ppo safe
       and reject = expand_relaxs C.ppo reject in
-      if relax = [] then if r_nempty then begin
+      if Misc.nilp relax then if r_nempty then begin
         Warn.fatal "relaxations provided in relaxlist could not be used to generate cycles"
       end ;
       if O.verbose > 0 then begin


### PR DESCRIPTION
This patch rejects generation of cycle when -safe and -relax are used in a configuration file, but relaxations in -relax cannot generate cycles.

Currently, the generator still generates cycles from the safe list if this is the case.
an example of where this can occur is:
`diy7 -cycleonly true -arch AArch64 -safe "DMB.SYd** Rfe Fre Coe" -relax "[PodRR,PodWR]"`

The reason for this patch is that in our current flow, some composite relaxations are automatically generated to go into `-relax`, Occasionally junk relaxations are accidentally created (e.g. [PodRR, PodWR]), which cannot provide cycles, however the generator will still use relaxations in -safe. 

This patch introduces a fail safe to stop this behaviour.