### PR TITLE
[lib]: fixed map_reg, fold_reg for kr instructions

### DIFF
--- a/herd/tests/instructions/AArch64.neon/V57.litmus
+++ b/herd/tests/instructions/AArch64.neon/V57.litmus
@@ -1,0 +1,9 @@
+AArch64 V57
+(* Tests 128-bit Neon pair loads with post-increment - register INVALID SYNTAX*)
+{
+}
+
+P0                    ;
+LDP Q0, Q1, [X0], Q2  ;
+
+forall(0:X1 = 0)

--- a/herd/tests/instructions/AArch64.neon/V57.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.neon/V57.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.neon/V57.litmus", line 7, characters 18-20: unexpected 'Q2' (in prog) (User error)

--- a/herd/tests/instructions/AArch64.neon/V58.litmus
+++ b/herd/tests/instructions/AArch64.neon/V58.litmus
@@ -1,0 +1,9 @@
+AArch64 V58
+(* Tests 128-bit Neon pair store with post-increment - register INVALID SYNTAX*)
+{
+}
+
+P0                    ;
+STP Q0, Q1, [X0], Q2  ;
+
+forall(0:X1 = 0)

--- a/herd/tests/instructions/AArch64.neon/V58.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.neon/V58.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.neon/V58.litmus", line 7, characters 18-20: unexpected 'Q2' (in prog) (User error)

--- a/herd/tests/instructions/AArch64/A127.litmus
+++ b/herd/tests/instructions/AArch64/A127.litmus
@@ -1,0 +1,9 @@
+AArch64 A127
+
+(* MOV value from symbolic register into concrete reg *)
+{ uint64_t X0; uint64_t %symbolic_reg = x; uint64_t x }
+
+P0;
+MOV X0, %symbolic_reg;
+
+exists (0:X0 = x)

--- a/herd/tests/instructions/AArch64/A127.litmus.expected
+++ b/herd/tests/instructions/AArch64/A127.litmus.expected
@@ -1,0 +1,10 @@
+Test A127 Allowed
+States 1
+0:X0=x;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=x)
+Observation A127 Always 1 0
+Hash=2b1331e0638ebbd02667eb17dc2b0e99
+

--- a/herd/tests/instructions/AArch64/A131.litmus
+++ b/herd/tests/instructions/AArch64/A131.litmus
@@ -1,0 +1,11 @@
+AArch64 A131
+
+Variant=memtag
+(* LDG value from symbolic register into concrete reg *)
+{ uint64_t X0; uint64_t %symbolic_reg = x:red; uint64_t x;
+  }
+
+P0;
+LDG X0, [X1, %symbolic_reg];
+
+exists (0:X0 = x:green)

--- a/herd/tests/instructions/AArch64/A131.litmus.expected
+++ b/herd/tests/instructions/AArch64/A131.litmus.expected
@@ -1,0 +1,10 @@
+Test A131 Allowed
+States 1
+0:X0=x:green;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition exists (0:X0=x:green)
+Observation A131 Always 1 0
+Hash=640076163c1a00de8b338f7fd283e76c
+

--- a/herd/tests/instructions/AArch64/A135.litmus
+++ b/herd/tests/instructions/AArch64/A135.litmus
@@ -1,0 +1,10 @@
+AArch64 A135
+
+(* tests STR when write-back value is RV - INVALID SYNTAX *)
+
+{ %symbolic_reg = x; int x = 1}
+
+P0;
+STR X1, [X2], %symbolic_reg;
+
+forall(x=0)

--- a/herd/tests/instructions/AArch64/A135.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/A135.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A135.litmus", line 8, characters 14-27: unexpected '%symbolic_reg' (in prog) (User error)

--- a/herd/tests/instructions/AArch64/A136.litmus
+++ b/herd/tests/instructions/AArch64/A136.litmus
@@ -1,0 +1,11 @@
+AArch64 A136
+
+Variant=morello
+(* tests ALIGND when value is RV - INVALID SYNTAX *)
+
+{ %symbolic_reg = x; int x = 1}
+
+P0;
+ALIGND C0, C1, %symbolic_reg;
+
+forall(x=0)

--- a/herd/tests/instructions/AArch64/A136.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/A136.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A136.litmus", line 9, characters 15-28: unexpected '%symbolic_reg' (in prog) (User error)

--- a/herd/tests/instructions/AArch64/A137.litmus
+++ b/herd/tests/instructions/AArch64/A137.litmus
@@ -1,0 +1,11 @@
+AArch64 A137
+
+Variant=morello
+(* tests ALIGNU when value is RV - INVALID SYNTAX *)
+
+{ %symbolic_reg = x; int x = 1}
+
+P0;
+ALIGNU C0, C1, %symbolic_reg;
+
+forall(x=0)

--- a/herd/tests/instructions/AArch64/A137.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/A137.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A137.litmus", line 9, characters 15-28: unexpected '%symbolic_reg' (in prog) (User error)

--- a/herd/tests/instructions/AArch64/A138.litmus
+++ b/herd/tests/instructions/AArch64/A138.litmus
@@ -1,0 +1,11 @@
+AArch64 A138
+
+Variant=memtag
+(* STG value from symbolic register into concrete reg INVALID SYNTAX *)
+{ uint64_t X0 = x; uint64_t x:red = 1; %symbolic_reg = 0;
+  }
+
+P0;
+STG X0, [X1, %symbolic_reg];
+
+exists (0:X0 = x:green)

--- a/herd/tests/instructions/AArch64/A138.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/A138.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A138.litmus", line 9, characters 13-26: unexpected '%symbolic_reg' (in prog) (User error)

--- a/herd/tests/instructions/AArch64/A140.litmus
+++ b/herd/tests/instructions/AArch64/A140.litmus
@@ -1,0 +1,11 @@
+AArch64 A140
+
+Variant=memtag
+(* STZG value from symbolic register into concrete reg INVALID SYNTAX *)
+{ uint64_t X0 = x; uint64_t x:red = 1; %symbolic_reg = 0;
+  }
+
+P0;
+STZG X0, [X1, %symbolic_reg];
+
+exists (0:X0 = x:green)

--- a/herd/tests/instructions/AArch64/A140.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/A140.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/A140.litmus", line 9, characters 14-27: unexpected '%symbolic_reg' (in prog) (User error)

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -733,9 +733,9 @@ instr:
 | SWPALH wreg COMMA wreg COMMA  LBRK cxreg zeroopt RBRK
   { I_SWPBH (H,RMW_AL,$2,$4,$7) }
 /* Memory Tagging */
-| STG xreg COMMA LBRK xreg kr0_no_shift RBRK
+| STG xreg COMMA LBRK xreg k0_no_shift RBRK
   { I_STG ($2,$5,$6) }
-| STZG xreg COMMA LBRK xreg kr0_no_shift RBRK
+| STZG xreg COMMA LBRK xreg k0_no_shift RBRK
   { I_STZG ($2,$5,$6) }
 | LDG xreg COMMA LBRK xreg kr0_no_shift RBRK
   { I_LDG ($2,$5,$6) }


### PR DESCRIPTION
Consider the following test (herd/tests/instructions/AArch64/A127):
```
AArch64 A127

(* MOV value from symbolic register into concrete reg *)
{ uint64_t X0; uint64_t %symbolic_reg = x; uint64_t x }

P0;
MOV X0, %symbolic_reg;

exists (0:X0 = x)
```
This fails when run in herd as `map_reg` and `fold_reg` are not implemented for `I_MOV` when the second argument (of type `'k kr`) is a register value (`RV`).

This patch fixes this. I have added tests for this which pass in herd and litmus on an Apple M1 machine.

Additionally I considered all other AArch64 instructions that have a `kr` element in their type and fixed those so they pass in both herd7, precisely for:

`LDG`, `STZG`, `STG`, `LDP_SIMD`, `STP_SIMD`, `LDP_SIMD`, `STR`, `ALIGND`, and `ALIGNU`

The tests I added for these instructions pass in herd, however I could not run them all in litmus as it requires hardware with MTE (I do not have) and litmus doesn't support the memtag variant anyway (not related to this commit).

As far as I am able to tell - this patch is complete and tested