### PR TITLE
[all] Simplification of pair instruction address fields.

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1173,6 +1173,8 @@ module Make
 
       let get_ea_noext rs kr ii = get_ea rs kr AArch64.S_NOEXT ii
 
+      let get_ea_idx rs k ii = get_ea rs (AArch64.K k) AArch64.S_NOEXT ii
+
       let add_size a sz = M.add a (V.intToV (MachSize.nbytes sz))
 
       let post_kr rA addr kr ii =
@@ -1190,7 +1192,7 @@ module Make
           (fun ac a -> do_read_mem sz AArch64.N aexp ac rd a ii)
           (get_ea rs kr s ii) ii
 
-      and ldp sz rd1 rd2 rs kr ii =
+      and ldp sz rd1 rd2 rs k ii =
         do_ldr rs sz AArch64.N
           (fun ac a ->
             do_read_mem sz AArch64.N aexp ac rd1 a ii >>|
@@ -1198,9 +1200,9 @@ module Make
               add_size a sz >>=
               fun a -> do_read_mem sz AArch64.N aexp ac rd2 a ii
             end)
-          (get_ea_noext rs kr ii) ii
+          (get_ea_idx rs k ii) ii
 
-      and ldpsw rd1 rd2 rs kr ii =
+      and ldpsw rd1 rd2 rs k ii =
         let mem_sz =  MachSize.Word in
         do_ldr rs MachSize.Word AArch64.N
           (fun ac a ->
@@ -1211,7 +1213,7 @@ module Make
                 fun a -> do_read_mem_sxt mem_sz AArch64.N aexp ac rd2 a ii
               end
             end)
-          (get_ea_noext rs kr ii) ii
+          (get_ea_idx rs k ii) ii
 
       and ldxp sz t rd1 rd2 rs ii =
         let open AArch64 in
@@ -1300,7 +1302,7 @@ module Make
 
       and stp =
         let (>>>) = M.data_input_next in
-        fun sz rs1 rs2 rd kr ii ->
+        fun sz rs1 rs2 rd k ii ->
         do_str rd
           (fun ac a _ ii ->
             (read_reg_data sz rs1 ii >>> fun v ->
@@ -1309,7 +1311,7 @@ module Make
                read_reg_data sz rs2 ii >>> fun v ->
                do_write_mem sz AArch64.N aexp ac a v ii))
           sz AArch64.N
-          (get_ea_noext rd kr ii)
+          (get_ea_idx rd k ii)
           (M.unitT V.zero)
           ii
 

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -259,18 +259,16 @@ include Arch.MakeArch(struct
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >! fun r2 ->
         I_LDUR(a,r1,r2,None)
-    | I_LDP(t,a,r1,r2,r3,kr) ->
+    | I_LDP(t,a,r1,r2,r3,k) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->
-        conv_reg r3 >> fun r3 ->
-        expl_kr kr  >! fun kr ->
-        I_LDP(t,a,r1,r2,r3,kr)
-    | I_LDPSW(r1,r2,r3,kr) ->
+        conv_reg r3 >! fun r3 ->
+        I_LDP(t,a,r1,r2,r3,k)
+    | I_LDPSW(r1,r2,r3,k) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->
-        conv_reg r3 >> fun r3 ->
-        expl_kr kr  >! fun kr ->
-        I_LDPSW(r1,r2,r3,kr)
+        conv_reg r3 >! fun r3 ->
+        I_LDPSW(r1,r2,r3,k)
     | I_LDXP(t,a,r1,r2,r3) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->
@@ -282,12 +280,11 @@ include Arch.MakeArch(struct
         conv_reg r3 >> fun r3 ->
         find_cst k >! fun k ->
         I_LDP_P(t,a,r1,r2,r3,k)
-    | I_STP(t,a,r1,r2,r3,kr) ->
+    | I_STP(t,a,r1,r2,r3,k) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->
-        conv_reg r3 >> fun r3 ->
-        expl_kr kr >! fun kr ->
-        I_STP(t,a,r1,r2,r3,kr)
+        conv_reg r3 >! fun r3 ->
+        I_STP(t,a,r1,r2,r3,k)
     | I_STP_P(t,a,r1,r2,r3,k) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -246,9 +246,13 @@ k:
 | NUM  { MetaConst.Int $1 }
 | META { MetaConst.Meta $1 }
 
-k0:
+k0_opt:
 | { None }
 | COMMA k { Some $2}
+
+k0:
+| { MetaConst.zero }
+| COMMA k=k { k }
 
 kr:
 | k { K $1 }
@@ -270,12 +274,14 @@ kr0:
 | { K (MetaConst.zero), S_NOEXT }
 | COMMA kr_shift_address { $2 }
 
+/*
 kr0_no_shift:
 | { K (MetaConst.zero) }
 | COMMA k { K $2 }
 | COMMA xreg { RV (V64,$2) }
 | COMMA wreg { RV (V32,$2) }
 | COMMA wreg COMMA TOK_SXTW { RV (V32,$2) }
+*/
 
 kx0_no_shift:
 | { K (MetaConst.zero) }
@@ -286,12 +292,14 @@ k0_no_shift:
 | { K (MetaConst.zero) }
 | COMMA k { K $2 }
 
+/*
 kr0_no_shift_opt:
 | { None }
 | COMMA k { Some (K $2) }
 | COMMA xreg { Some (RV (V64,$2)) }
 | COMMA wreg { Some (RV (V32,$2)) }
 | COMMA wreg COMMA TOK_SXTW { Some (RV (V32,$2)) }
+*/
 
 /* Beware: for w-indexed accesses SXTW is considered always present.
    Far from ideal, one simple to get correct assembly output for
@@ -318,32 +326,34 @@ zeroopt:
 
 ldp_instr:
 | LDP
-  { (fun v r1 r2 r3 kr -> I_LDP (TT,v,r1,r2,r3,kr)) }
+  { (fun v r1 r2 r3 k -> I_LDP (TT,v,r1,r2,r3,k)) }
 | LDNP
-  { (fun v r1 r2 r3 kr -> I_LDP (NT,v,r1,r2,r3,kr)) }
+  { (fun v r1 r2 r3 k -> I_LDP (NT,v,r1,r2,r3,k)) }
 
 ldp_simd_instr:
 | LDP
   { ( fun v r1 r2 r3 k0 k0' ->
       match k0',k0 with
-      | Some post,K k when k = MetaConst.zero ->
-        I_LDP_P_SIMD (TT,v,r1,r2,r3,post)
-      | None,K k -> I_LDP_SIMD (TT,v,r1,r2,r3,k)
+      | Some post,None ->
+          I_LDP_P_SIMD (TT,v,r1,r2,r3,post)
+      | None,Some k -> I_LDP_SIMD (TT,v,r1,r2,r3,k)
+      | None,None -> I_LDP_SIMD (TT,v,r1,r2,r3,MetaConst.zero)
       | _,_ -> assert false
     )}
 | LDNP
   { ( fun v r1 r2 r3 k0 k0' ->
       match k0', k0 with
-      | None,K k -> I_LDP_SIMD (NT,v,r1,r2,r3,k)
+      | None,Some k -> I_LDP_SIMD (NT,v,r1,r2,r3,k)
+      | None,None -> I_LDP_SIMD (NT,v,r1,r2,r3,MetaConst.zero)
       | _,_-> assert false
 
     )}
 
 stp_instr:
 | STP
-  { (fun v r1 r2 r3 kr -> I_STP (TT,v,r1,r2,r3,kr)) }
+  { (fun v r1 r2 r3 k -> I_STP (TT,v,r1,r2,r3,k)) }
 | STNP
-  { (fun v r1 r2 r3 kr -> I_STP (NT,v,r1,r2,r3,kr)) }
+  { (fun v r1 r2 r3 k -> I_STP (NT,v,r1,r2,r3,k)) }
 
 stp_simd_instr:
 | STP
@@ -420,7 +430,7 @@ instr:
   { let v,r = $2 in I_TBZ (v,r,MetaConst.Int $4,$6) }
 /* Memory */
 /* must differentiate between regular and post-indexed load */
-| LDR reg COMMA LBRK cxreg kr0 RBRK k0
+| LDR reg COMMA LBRK cxreg kr0 RBRK k0_opt
   { let v,r    = $2 in
     let kr, os = $6 in
     match $8 with
@@ -428,33 +438,33 @@ instr:
       I_LDR_P (v,r,$5,post)
     | _ ->
       I_LDR (v,r,$5,kr,os) }
-| LDUR reg COMMA LBRK cxreg k0 RBRK
+| LDUR reg COMMA LBRK cxreg k0_opt RBRK
   { let v,r = $2 in I_LDUR (v,r,$5,$6)}
-| ldp_instr wreg COMMA wreg COMMA LBRK cxreg kr0_no_shift_opt RBRK k0
+| ldp_instr wreg COMMA wreg COMMA LBRK cxreg k0_opt RBRK k0_opt
   { match ($8, $10) with
     | Some s, None -> $1 V32 $2 $4 $7 s
     | None, Some p -> I_LDP_P (TT, V32, $2, $4, $7, p)
-    | None, None -> $1 V32 $2 $4 $7 (K (MetaConst.zero))
+    | None, None -> $1 V32 $2 $4 $7 MetaConst.zero
     | _,_ -> raise Parsing.Parse_error }
-| ldp_instr xreg COMMA xreg COMMA LBRK cxreg kr0_no_shift_opt RBRK k0
+| ldp_instr xreg COMMA xreg COMMA LBRK cxreg k0_opt RBRK k0_opt
   { match ($8, $10) with
     | Some s, None -> $1 V64 $2 $4 $7 s
     | None, Some p -> I_LDP_P (TT, V64, $2, $4, $7, p)
-    | None, None -> $1 V64 $2 $4 $7 (K (MetaConst.zero))
+    | None, None -> $1 V64 $2 $4 $7 MetaConst.zero
     | _,_ -> raise Parsing.Parse_error }
-| stp_instr wreg COMMA wreg COMMA LBRK cxreg kr0_no_shift_opt RBRK k0
+| stp_instr wreg COMMA wreg COMMA LBRK cxreg k0_opt RBRK k0_opt
   { match ($8, $10) with
     | Some s, None -> $1 V32 $2 $4 $7 s
     | None, Some p -> I_STP_P (TT, V32, $2, $4, $7, p)
-    | None, None -> $1 V32 $2 $4 $7 (K (MetaConst.zero))
+    | None, None -> $1 V32 $2 $4 $7 MetaConst.zero
     | _,_ -> raise Parsing.Parse_error }
-| stp_instr xreg COMMA xreg COMMA LBRK cxreg kr0_no_shift_opt RBRK k0
+| stp_instr xreg COMMA xreg COMMA LBRK cxreg k0_opt RBRK k0_opt
   { match ($8, $10) with
     | Some s, None -> $1 V64 $2 $4 $7 s
     | None, Some p -> I_STP_P (TT, V64, $2, $4, $7, p)
-    | None, None -> $1 V64 $2 $4 $7 (K (MetaConst.zero))
+    | None, None -> $1 V64 $2 $4 $7 MetaConst.zero
     | _,_ -> raise Parsing.Parse_error }
-| LDPSW xreg COMMA xreg COMMA LBRK cxreg kr0_no_shift RBRK
+| LDPSW xreg COMMA xreg COMMA LBRK cxreg k0 RBRK
   { I_LDPSW ($2,$4,$7,$8) }
 | LDXP wreg COMMA wreg COMMA LBRK cxreg RBRK
   { I_LDXP (V32,XP,$2,$4,$7) }
@@ -504,7 +514,7 @@ instr:
   { I_LDARBH (B,AQ,$2,$5) }
 | LDAPRH wreg COMMA LBRK cxreg RBRK
   { I_LDARBH (H,AQ,$2,$5) }
-| STR reg COMMA LBRK cxreg kr0 RBRK k0
+| STR reg COMMA LBRK cxreg kr0 RBRK k0_opt
   { let (v,r)   = $2 in
     match $6, $8 with
     (* post-indexed writes do not have shifters *)
@@ -573,19 +583,19 @@ instr:
    { I_ST4 ($2, $3, $6, $8) }
 | ST4 vregs4 COMMA LBRK xreg RBRK kx0_no_shift
    { I_ST4M ($2, $5, $7) }
-| ldp_simd_instr sreg COMMA sreg COMMA LBRK xreg k0_no_shift RBRK k0
+| ldp_simd_instr sreg COMMA sreg COMMA LBRK xreg k0_opt RBRK k0_opt
   { $1 VSIMD32 $2 $4 $7 $8 $10 }
-| ldp_simd_instr dreg COMMA dreg COMMA LBRK xreg k0_no_shift RBRK k0
+| ldp_simd_instr dreg COMMA dreg COMMA LBRK xreg k0_opt RBRK k0_opt
   { $1 VSIMD64 $2 $4 $7 $8 $10 }
-| ldp_simd_instr qreg COMMA qreg COMMA LBRK xreg k0_no_shift RBRK k0
+| ldp_simd_instr qreg COMMA qreg COMMA LBRK xreg k0_opt RBRK k0_opt
   { $1 VSIMD128 $2 $4 $7 $8 $10 }
-| stp_simd_instr sreg COMMA sreg COMMA LBRK xreg k0_no_shift RBRK k0
+| stp_simd_instr sreg COMMA sreg COMMA LBRK xreg k0_no_shift RBRK k0_opt
   { $1 VSIMD32 $2 $4 $7 $8 $10 }
-| stp_simd_instr dreg COMMA dreg COMMA LBRK xreg k0_no_shift RBRK k0
+| stp_simd_instr dreg COMMA dreg COMMA LBRK xreg k0_no_shift RBRK k0_opt
   { $1 VSIMD64 $2 $4 $7 $8 $10 }
-| stp_simd_instr qreg COMMA qreg COMMA LBRK xreg k0_no_shift RBRK k0
+| stp_simd_instr qreg COMMA qreg COMMA LBRK xreg k0_no_shift RBRK k0_opt
   { $1 VSIMD128 $2 $4 $7 $8 $10 }
-| LDR scalar_regs COMMA LBRK xreg kr0 RBRK k0
+| LDR scalar_regs COMMA LBRK xreg kr0 RBRK k0_opt
   { let v,r    = $2 in
     let kr, os = $6 in
     match $8 with
@@ -593,10 +603,10 @@ instr:
       I_LDR_P_SIMD (v,r,$5,post)
     | _ ->
       I_LDR_SIMD (v,r,$5,kr,os) }
-| LDUR scalar_regs COMMA LBRK xreg k0 RBRK
+| LDUR scalar_regs COMMA LBRK xreg k0_opt RBRK
   { let v,r = $2 in
     I_LDUR_SIMD (v, r, $5, $6) }
-| STR scalar_regs COMMA LBRK xreg kr0 RBRK k0
+| STR scalar_regs COMMA LBRK xreg kr0 RBRK k0_opt
   { let v,r    = $2 in
     let kr, os = $6 in
     match $8 with
@@ -604,7 +614,7 @@ instr:
       I_STR_P_SIMD (v,r,$5,post)
     | _ ->
       I_STR_SIMD (v,r,$5,kr,os) }
-| STUR scalar_regs COMMA LBRK xreg k0 RBRK
+| STUR scalar_regs COMMA LBRK xreg k0_opt RBRK
   { let v,r = $2 in
     I_STUR_SIMD (v, r, $5, $6) }
 | MOV vreg INDEX COMMA vreg INDEX
@@ -735,20 +745,11 @@ instr:
   { I_SWPBH (H,RMW_AL,$2,$4,$7) }
 /* Memory Tagging */
 | STG xreg COMMA LBRK xreg k0 RBRK
-  { let k = match $6 with
-    | Some k -> k
-    | None -> MetaConst.zero in
-      I_STG ($2,$5,k) }
+   { I_STG ($2,$5,$6) }
 | STZG xreg COMMA LBRK xreg k0 RBRK
-  { let k = match $6 with
-    | Some k -> k
-    | None -> MetaConst.zero in
-      I_STZG ($2,$5,k) }
+   { I_STZG ($2,$5,$6) }
 | LDG xreg COMMA LBRK xreg k0 RBRK
-  { let k = match $6 with
-    | Some k -> k
-    | None -> MetaConst.zero in
-      I_LDG ($2,$5,k) }
+   { I_LDG ($2,$5,$6) }
 
 /* Fetch and ADD */
 | LDADD wreg COMMA wreg COMMA  LBRK cxreg zeroopt RBRK

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -291,68 +291,47 @@ module Make(V:Constant.S)(C:Config) =
     | V128 -> assert false
 
     let load_pair memo v rD1 rD2 rA kr = match v,kr with
-    | V32,K 0 ->
+    | V32,0 ->
         { empty_ins with
           memo= sprintf "%s ^wo0,^wo1,[^i0]" memo;
           inputs=[rA];
           outputs=[rD1;rD2;];
           reg_env=[(rA,voidstar);(rD1,word);(rD2,word);]; }
-    | V32,K k ->
+    | V32,k ->
         { empty_ins with
           memo= sprintf "%s ^wo0,^wo1,[^i0,#%i]" memo k;
           inputs=[rA];
           outputs=[rD1;rD2;];
           reg_env=[(rA,voidstar);(rD1,word);(rD2,word);];}
-    | V32,RV (V32,rB) ->
-        { empty_ins with
-          memo=memo^ " ^wo0,^wo1,[^i0,^wi1,sxtw]";
-          inputs=[rA; rB];
-          outputs=[rD1;rD2;];
-          reg_env=[(rA,voidstar); (rB,word); (rD1,word);(rD2,word);]; }
-    | V64,K 0 ->
+    | V64,0 ->
         { empty_ins with
           memo=memo ^ sprintf " ^o0,^o1,[^i0]";
           inputs=[rA];
           outputs=[rD1;rD2;];
           reg_env=[rA,voidstar;(rD1,quad);(rD2,quad);]; }
-    | V64,K k ->
+    | V64,k ->
         { empty_ins with
           memo=memo ^ sprintf " ^o0,^o1,[^i0,#%i]" k;
           inputs=[rA];
           outputs=[rD1;rD2;];
           reg_env=[rA,voidstar; (rD1,quad);(rD2,quad);]; }
-    | V64,RV (V64,rB) ->
-        { empty_ins with
-          memo=memo^ " ^o0,^o1,[^i0,^i1]";
-          inputs=[rA; rB];
-          outputs=[rD1;rD2;];
-          reg_env=[rA,voidstar;rB,quad;(rD1,quad);(rD2,quad)]; }
-    | V64,RV (V32,rB) ->
-        { empty_ins with
-          memo=memo^ " ^o0,^o1,[^i0,^wi1,sxtw]";
-          inputs=[rA; rB];
-          outputs=[rD1;rD2;];
-          reg_env=[rA,voidstar;rB,word;(rD1,quad);(rD2,quad);]; }
-    | V32,RV (V64,_) -> assert false
-    | V128,_
-    | _,RV (V128,_) -> assert false
+    | V128,_ -> assert false
 
     let ldpsw rD1 rD2 rA kr =
       let memo = "ldpsw" in
       match kr with
-      | K 0 ->
+      | 0 ->
          { empty_ins with
            memo=memo ^ " ^o0,^o1,[^i0]";
            inputs=[rA];
            outputs=[rD1;rD2;];
            reg_env=[rA,voidstar;(rD1,quad);(rD2,quad);]; }
-      | K k ->
+      | k ->
          { empty_ins with
           memo=memo ^ sprintf " ^o0,^o1,[^i0,#%i]" k;
           inputs=[rA];
           outputs=[rD1;rD2;];
           reg_env=[rA,voidstar; (rD1,quad);(rD2,quad);]; }
-      | _ -> assert false
 
     let loadx_pair memo v rD1 rD2 rA = match v with
       | V32 ->
@@ -386,51 +365,31 @@ module Make(V:Constant.S)(C:Config) =
 
 
     let store_pair memo v rD1 rD2 rA kr = match v,kr with
-    | V32,K 0 ->
+    | V32,0 ->
         { empty_ins with
           memo= sprintf "%s ^wi1,^wi2,[^i0]" memo;
           inputs=[rA;rD1;rD2;];
           outputs=[];
           reg_env=[(rA,voidstar);(rD1,word);(rD2,word);]; }
-    | V32,K k ->
+    | V32,k ->
         { empty_ins with
           memo= sprintf "%s ^wi1,^wi2,[^i0,#%i]" memo k;
           inputs=[rA;rD1;rD2;];
           outputs=[];
           reg_env=[(rA,voidstar);(rD1,word);(rD2,word);];}
-    | V32,RV (V32,rB) ->
-        { empty_ins with
-          memo=memo^ " ^wi2,^wi3,[^i0,^wi1,sxtw]";
-          inputs=[rA;rB;rD1;rD2;];
-          outputs=[];
-          reg_env=[(rA,voidstar); (rB,word); (rD1,word);(rD2,word);]; }
-    | V64,K 0 ->
+    | V64,0 ->
         { empty_ins with
           memo=memo ^ sprintf " ^i1,^i2,[^i0]";
           inputs=[rA;rD1;rD2;];
           outputs=[];
           reg_env=[rA,voidstar;(rD1,quad);(rD2,quad);]; }
-    | V64,K k ->
+    | V64,k ->
         { empty_ins with
           memo=memo ^ sprintf " ^i1,^i2,[^i0,#%i]" k;
           inputs=[rA;rD1;rD2;];
           outputs=[];
           reg_env=[rA,voidstar; (rD1,quad);(rD2,quad);]; }
-    | V64,RV (V64,rB) ->
-        { empty_ins with
-          memo=memo^ " ^i2,^i3,[^i0,^i1]";
-          inputs=[rA; rB;rD1;rD2;];
-          outputs=[];
-          reg_env=[rA,voidstar;rB,quad;(rD1,quad);(rD2,quad)]; }
-    | V64,RV (V32,rB) ->
-        { empty_ins with
-          memo=memo^ " ^i2,^i3,[^i0,^wi1,sxtw]";
-          inputs=[rA; rB;rD1;rD2;];
-          outputs=[];
-          reg_env=[rA,voidstar;rB,word;(rD1,quad);(rD2,quad);]; }
-    | V32,RV (V64,_) -> assert false
-    | V128,_
-    | _,RV (V128,_) -> assert false
+    | V128,_ -> assert false
 
     let storex_pair memo v rs rt1 rt2 rn =
       match v with


### PR DESCRIPTION
Instruction `LDP`, `STP` and `LPDSW` are simplified, avoiding non-implemented addressing modes.

This is an extension of PR #540.