### PR TITLE
[all] Add frozen symbolic values as constants

### DIFF
--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -709,7 +709,8 @@ module Make(C:Config) (I:I) : S with module I = I
           | Location_global
               (I.V.Val
                  (Concrete _|ConcreteVector _
-                 |Label _|Instruction _|Tag _|PteVal _))
+                 |Label _|Instruction _|Frozen _
+                 |Tag _|PteVal _))
             ->
               Warn.user_error
                 "Very strange location (look_address) %s\n"
@@ -805,7 +806,7 @@ module Make(C:Config) (I:I) : S with module I = I
              (fun loc ->
                match look loc with
                | I.V.Val c -> c
-               | _ -> Warn.fatal "Non constant value in vector")
+               | I.V.Var v -> I.V.freeze v)
              locs in
          I.V.Val (Constant.ConcreteVector cs)
 

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -102,9 +102,11 @@ end = struct
     | Symbolic (System (TAG,_)) -> Access.TAG
     | Label _ -> VIR
     | Tag _
-    | ConcreteVector _|Concrete _|PteVal _|Instruction _ as v ->
-        Warn.fatal "access_of_constant %s as an address"
-          (V.pp_v (V.Val v)) (* assert false *)
+    | ConcreteVector _|Concrete _
+    | PteVal _|Instruction _|Frozen _ as v
+      ->
+       Warn.fatal "access_of_constant %s as an address"
+         (V.pp_v (V.Val v)) (* assert false *)
 
 
 (* precondition: v is a constant symbol *)
@@ -636,7 +638,11 @@ end = struct
           let open Constant in
           function
           | Some (A.V.Val (PteVal v)) -> Some v
-          | Some (A.V.Val (ConcreteVector _|Concrete _|Symbolic _|Label (_, _)|Tag _|Instruction _))
+          | Some
+              (A.V.Val
+                 (ConcreteVector _|Concrete _|Symbolic _
+                  |Label (_, _)|Tag _|Instruction _
+                  |Frozen _))
           | None
             -> None
           | Some (A.V.Var _) ->

--- a/jingle/CArch_jingle.ml
+++ b/jingle/CArch_jingle.ml
@@ -153,7 +153,10 @@ include Arch.MakeArch(struct
 
     let rec expl_expr = let open Constant in function
       | Const(Symbolic (Virtual {name=s;_})) -> find_cst s >! fun k -> Const k
-      | Const(Concrete _|ConcreteVector _|Label _|Tag _|Symbolic _|PteVal _|Instruction _)
+      | Const
+          (Concrete _|ConcreteVector _|Label _
+           |Tag _|Symbolic _|PteVal _
+           |Instruction _|Frozen _)
         as e -> unitT e
       | LoadReg r -> conv_reg r >! fun r -> LoadReg r
       | LoadMem (loc,mo) -> expl_expr loc >! fun loc -> LoadMem (loc,mo)

--- a/lib/CBase.ml
+++ b/lib/CBase.ml
@@ -246,8 +246,10 @@ include Pseudo.Make
         let open Constant in
         function
           | Const(Concrete _|ConcreteVector _) as k -> k
-          | Const (Symbolic _|Label _|Tag _|PteVal _|Instruction _ as v) ->
-              Warn.fatal "No constant '%s' allowed" (ParsedConstant.pp_v v)
+          | Const
+              (Symbolic _|Label _|Tag _
+              |PteVal _|Instruction _|Frozen _ as v) ->
+             Warn.fatal "No constant '%s' allowed" (ParsedConstant.pp_v v)
           | LoadReg _ as l -> l
           | LoadMem (l,mo) ->
               LoadMem (parsed_expr_tr l,mo)

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -172,6 +172,7 @@ type ('scalar,'pte,'instr) t =
   | Tag of string
   | PteVal of 'pte
   | Instruction of 'instr
+  | Frozen of int
 
 let rec compare scalar_compare pteval_compare instr_compare c1 c2 =
   match c1,c2 with
@@ -185,13 +186,16 @@ let rec compare scalar_compare pteval_compare instr_compare c1 c2 =
   | Tag t1,Tag t2 -> String.compare t1 t2
   | PteVal p1,PteVal p2 -> pteval_compare p1 p2
   | Instruction i1,Instruction i2 -> instr_compare i1 i2
-  | (Concrete _,(ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _|Instruction _))
-  | (ConcreteVector _,(Symbolic _|Label _|Tag _|PteVal _|Instruction _))
-  | (Symbolic _,(Label _|Tag _|PteVal _|Instruction _))
-  | (Label _,(Tag _|PteVal _|Instruction _))
-  | (Tag _,(PteVal _|Instruction _))
-  | (PteVal _,Instruction _)
+  | Frozen i1,Frozen i2 -> Int.compare i1 i2
+  | (Concrete _,(ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _|Instruction _|Frozen _))
+  | (ConcreteVector _,(Symbolic _|Label _|Tag _|PteVal _|Instruction _|Frozen _))
+  | (Symbolic _,(Label _|Tag _|PteVal _|Instruction _|Frozen _))
+  | (Label _,(Tag _|PteVal _|Instruction _|Frozen _))
+  | (Tag _,(PteVal _|Instruction _|Frozen _))
+  | (PteVal _,(Instruction _|Frozen _))
+  | (Instruction _,Frozen _)
     -> -1
+  | (Frozen _,(Instruction _|PteVal _|Tag _|Label _|Symbolic _|ConcreteVector _|Concrete _))
   | (Instruction _,(PteVal _|Tag _|Label _|Symbolic _|ConcreteVector _|Concrete _))
   | (PteVal _,(Tag _|Label _|Symbolic _|ConcreteVector _|Concrete _))
   | (Tag _,(Label _|Symbolic _|ConcreteVector _|Concrete _))
@@ -210,13 +214,15 @@ let rec eq scalar_eq pteval_eq instr_eq c1 c2 = match c1,c2 with
   | Tag t1,Tag t2 -> Misc.string_eq t1 t2
   | PteVal p1,PteVal p2 -> pteval_eq p1 p2
   | Instruction i1,Instruction i2 -> instr_eq i1 i2
-  | (Instruction _,(Symbolic _|Concrete _|ConcreteVector _|Label _|Tag _|PteVal _))
-  | (PteVal _,(Symbolic _|Concrete _|ConcreteVector _|Label _|Tag _|Instruction _))
-  | (ConcreteVector _,(Symbolic _|Label _|Tag _|Concrete _|PteVal _|Instruction _))
-  | (Concrete _,(Symbolic _|Label _|Tag _|ConcreteVector _|PteVal _|Instruction _))
-  | (Symbolic _,(Concrete _|Label _|Tag _|ConcreteVector _|PteVal _|Instruction _))
-  | (Label _,(Concrete _|Symbolic _|Tag _|ConcreteVector _|PteVal _|Instruction _))
-  | (Tag _,(Concrete _|Symbolic _|Label _|ConcreteVector _|PteVal _|Instruction _))
+  | Frozen i1,Frozen i2 -> Misc.int_eq i1 i2
+  | (Frozen _,(Instruction _|Symbolic _|Concrete _|ConcreteVector _|Label _|Tag _|PteVal _))
+  | (Instruction _,(Symbolic _|Concrete _|ConcreteVector _|Label _|Tag _|PteVal _|Frozen _))
+  | (PteVal _,(Symbolic _|Concrete _|ConcreteVector _|Label _|Tag _|Instruction _|Frozen _))
+  | (ConcreteVector _,(Symbolic _|Label _|Tag _|Concrete _|PteVal _|Instruction _|Frozen _))
+  | (Concrete _,(Symbolic _|Label _|Tag _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
+  | (Symbolic _,(Concrete _|Label _|Tag _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
+  | (Label _,(Concrete _|Symbolic _|Tag _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
+  | (Tag _,(Concrete _|Symbolic _|Label _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
     -> false
 
 let rec mk_pp pp_symbol pp_scalar pp_pteval pp_instr = function
@@ -231,6 +237,7 @@ let rec mk_pp pp_symbol pp_scalar pp_pteval pp_instr = function
     | Tag s -> sprintf ":%s" s
     | PteVal p -> pp_pteval p
     | Instruction i -> pp_instr i
+    | Frozen i -> sprintf "S%i" i (* Same as for symbolic values? *)
 
 let pp pp_scalar pp_pteval pp_instr =
   mk_pp pp_symbol pp_scalar pp_pteval pp_instr
@@ -245,20 +252,20 @@ let _debug = function
 | Tag s -> sprintf "Tag %s" s
 | PteVal _ -> "PteVal"
 | Instruction i -> sprintf "Instruction %s" (InstrLit.pp i)
-
+| Frozen i -> sprintf "Frozen %i" i
 
 let rec map_scalar f = function
-| (Symbolic _|Label _ |Tag _|PteVal _|Instruction _) as c -> c
+| (Symbolic _|Label _ |Tag _|PteVal _|Instruction _|Frozen _) as c -> c
 | Concrete s -> Concrete (f s)
 | ConcreteVector cs -> ConcreteVector (List.map (map_scalar f) cs)
 
 let rec map_label f = function
   | Label (p,lbl) -> Label (p,f lbl)
   | ConcreteVector cs -> ConcreteVector (List.map (map_label f) cs)
-  | Symbolic _|Concrete _ |Tag _|PteVal _|Instruction _ as m -> m
+  | Symbolic _|Concrete _ |Tag _|PteVal _|Instruction _|Frozen _ as m -> m
 
 let rec map f_scalar f_pteval f_instr = function
-| Symbolic _ | Label _ | Tag _ as m -> m
+| Symbolic _ | Label _ | Tag _ | Frozen _ as m -> m
 | PteVal p -> PteVal (f_pteval p)
 | Instruction i -> Instruction (f_instr i)
 | Concrete s -> Concrete (f_scalar s)
@@ -323,14 +330,14 @@ let mk_replicate sz v = ConcreteVector (Misc.replicate sz v)
 
 let is_symbol = function
   | Symbolic _ -> true
-  | Concrete _|ConcreteVector _|Label _|Tag _| PteVal _|Instruction _ -> false
+  | Concrete _|ConcreteVector _|Label _|Tag _| PteVal _|Instruction _|Frozen _ -> false
 
 let is_label = function
   | Label _ -> true
-  | Concrete _|ConcreteVector _|Symbolic _|Tag _ |PteVal _|Instruction _ -> false
+  | Concrete _|ConcreteVector _|Symbolic _|Tag _ |PteVal _|Instruction _|Frozen _ -> false
 let as_label = function
   | Label (p,lbl) -> Some (p,lbl)
-  | Concrete _|ConcreteVector _|Symbolic _|Tag _ |PteVal _|Instruction _
+  | Concrete _|ConcreteVector _|Symbolic _|Tag _ |PteVal _|Instruction _|Frozen _
     -> None
 
 let is_non_mixed_symbol = function
@@ -342,7 +349,7 @@ let default_tag = Tag "green"
 
 let check_sym v =  match v with
 | Symbolic _|Label _|Tag _ as sym -> sym
-| Concrete _|ConcreteVector _|PteVal _|Instruction _ ->  assert false
+| Concrete _|ConcreteVector _|PteVal _|Instruction _|Frozen _ ->  assert false
 
 let is_virtual v = match v with
 | Symbolic (Virtual _) -> true

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -73,6 +73,7 @@ type ('scalar,'pte,'instr) t =
   | Tag of string
   | PteVal of 'pte
   | Instruction of 'instr
+  | Frozen of int (* Frozen symbolic value *)
 
 val compare :
   ('scalar -> 'scalar -> int) ->

--- a/lib/symbConstant.ml
+++ b/lib/symbConstant.ml
@@ -55,11 +55,13 @@ module Make
 (* For building code symbols. *)
   let vToName = function
     | Symbolic s-> Constant.as_address s
-    | Concrete _|ConcreteVector _ | Label _|Tag _|PteVal _|Instruction _
+    | Concrete _|ConcreteVector _ | Label _|Tag _
+    | PteVal _|Instruction _|Frozen _
         -> assert false
 
   let is_nop = function
     | Instruction i -> Instr.is_nop i
     | Symbolic _|Concrete _|ConcreteVector _ | Label _|Tag _|PteVal _
+    | Frozen _
       -> false
 end

--- a/lib/value.mli
+++ b/lib/value.mli
@@ -45,7 +45,10 @@ module type S =
 (* produce a fresh variable *)
       val fresh_var : unit -> v
       val from_var : csym -> v
+
+(* Back to constants *)
       val as_symbol : v -> string
+      val freeze : csym -> Cst.v
 
 (* Equality (for constraint solver) is possible *)
       val equalityPossible : v -> v -> bool

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -500,7 +500,7 @@ module RegMap = A.RegMap)
         | PteVal p ->
             let idx = find_pteval_index p ptevalEnv in
             add_pteval idx
-        | Tag _ -> assert false
+        | Tag _|Frozen _ -> assert false
 
       let compile_init_val_fun = compile_val_fun
 

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -37,7 +37,9 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
     function
       | Concrete i -> "addr_" ^ V.Scalar.pp O.hexa i
       | Symbolic (Virtual {name=s; tag=None; cap=0L;_ })-> s
-      | Label _|Symbolic _|Tag _|ConcreteVector _| PteVal _|Instruction _ -> assert false
+      | Label _|Symbolic _|Tag _|ConcreteVector _
+      | PteVal _|Instruction _|Frozen _
+        -> assert false
 
   module Internal = struct
     type arch_reg = reg

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -340,6 +340,7 @@ module Make
           Warn.user_error "No tag, indexed access, nor pteval for klitmus"
       | Instruction _ ->
           Warn.fatal "FIXME: dump_a_v functionality for -variant self"
+      | Frozen _ -> assert false
 
     let is_align_effective mts env s =
       U.is_aligned s env && Misc.is_none (Misc.Simple.assoc_opt s mts)

--- a/litmus/LISALang.ml
+++ b/litmus/LISALang.ml
@@ -94,7 +94,7 @@ module Make(V:Constant.S) = struct
     | Tag _ -> Warn.user_error "No tag in LISA"
     | PteVal _ -> Warn.user_error "No pteval in LISA"
     | Instruction _ -> Warn.user_error "No instruction value in LISA"
-
+    | Frozen _ -> assert false
 
   and compile_addr_fun x = sprintf "*%s" x
 

--- a/litmus/archExtra_litmus.ml
+++ b/litmus/archExtra_litmus.ml
@@ -119,9 +119,12 @@ module Make(O:Config)(I:I) : S with module I = I
     let open Constant in
     match c with
     | Symbolic sym -> Global_litmus.tr_symbol sym
-    | Tag _|Concrete _|ConcreteVector _|Label _|PteVal _|Instruction _ ->
-        Warn.fatal "Constant %s cannot be translated to a litmus adress"
-          (ParsedConstant.pp O.hexa c)
+    | Tag _|Concrete _|ConcreteVector _
+    | Label _|PteVal _|Instruction _
+    | Frozen _
+      ->
+       Warn.fatal "Constant %s cannot be translated to a litmus adress"
+         (ParsedConstant.pp O.hexa c)
 
   module Out =
     Template.Make

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -65,6 +65,7 @@ module Generic
         | Constant.Tag _ -> tag
         | Constant.PteVal _ -> pteval_t
         | Constant.Instruction _ -> ins_t
+        | Constant.Frozen _ -> assert false
 
       let misc_to_c loc = function
         | TestType.TyDef when A.is_pte_loc loc -> pteval_t
@@ -388,7 +389,8 @@ module A.FaultType = A.FaultType)
           | Constant.Label (_,lbl) ->
               Label.Set.add lbl k
           |Concrete _|ConcreteVector _
-          |Symbolic _|Tag _|PteVal _|Instruction _
+          |Symbolic _|Tag _|PteVal _
+          |Instruction _|Frozen _
            -> k)
         Label.Set.empty init
 

--- a/litmus/constr.ml
+++ b/litmus/constr.ml
@@ -107,7 +107,8 @@ module RLocSet = A.RLocSet and module FaultType = A.FaultType =
             | Concrete _|PteVal _|Instruction _ -> k
             | ConcreteVector vs ->
                 List.fold_right f vs k
-            | Label _|Symbolic _|Tag _ -> assert false in
+            | Label _|Symbolic _|Tag _|Frozen _
+              -> assert false in
             f v k
       | LL _|FF _ -> k
 

--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -64,6 +64,7 @@ module Make(O:Config)(V:Constant.S) = struct
   | Symbolic _
   | Label _
   | PteVal _
+  | Frozen _
     -> assert false
 
   let dump_v_kvm v = match v with

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1429,7 +1429,7 @@ module Make
               | Tag _|Symbolic _ ->
                   Warn.user_error "Litmus cannot handle this initial value %s"
                     (A.V.pp_v v)
-              | PteVal _ -> assert false
+              | PteVal _|Frozen _ -> assert false
               | Instruction _ -> Warn.fatal "FIXME: dump_run_thread functionality for -variant self"
               in
             match at with

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -368,7 +368,7 @@ module Make
                (fun v -> sprintf "%s," (dump_a_v v))
                vs in
            sprintf "{%s}" (String.concat "" pps)
-        | Symbolic _|Tag _|PteVal _ -> assert false
+        | Symbolic _|Tag _|PteVal _|Frozen _ -> assert false
         | Label _ ->
             Warn.user_error
               "Labels cannot be used as initial values of memory locations"

--- a/litmus/switch.ml
+++ b/litmus/switch.ml
@@ -137,7 +137,9 @@ module Make (O:Indent.S) (I:CompCondUtils.I) :
     | Concrete i ->
         let vs = try M.find loc m with Not_found -> ScalarSet.empty in
         M.add loc (ScalarSet.add i vs) m
-    | ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _|Instruction _ -> raise Cannot
+    |ConcreteVector _|Symbolic _|Label _|Tag _
+    |PteVal _|Instruction _|Frozen _
+     -> raise Cannot
 
 
     let rec collect m = function

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -202,8 +202,9 @@ module Make(O:Config)(A:I) =
                       end
                   | ConcreteVector vs ->
                       List.fold_right f vs k
-                  | Concrete _|Label _|Tag _|PteVal _|Instruction _ ->
-                     k in
+                  |Concrete _|Label _|Tag _
+                  |PteVal _|Instruction _|Frozen _
+                   -> k in
                   f v k)
                 [] init)) in
       StringSet.elements set

--- a/tools/alpha.ml
+++ b/tools/alpha.ml
@@ -196,7 +196,9 @@ struct
     | Tag _ -> notag_value ()
     | PteVal _ -> nopte_value ()
     | Instruction _ -> noinstr_value ()
-    | Symbolic (Physical _|System ((TLB|TAG),_)) -> assert false
+    | Symbolic (Physical _|System ((TLB|TAG),_))
+    | Frozen _
+      -> assert false
 
 
     let rec map_value f v = match v with
@@ -210,7 +212,8 @@ struct
     | Tag _ -> notag_value ()
     | PteVal _ -> nopte_value ()
     | Instruction _ -> noinstr_value ()
-    | Symbolic (Physical _|System ((TLB|TAG),_)) -> assert false
+    | Frozen _|Symbolic (Physical _|System ((TLB|TAG),_))
+      -> assert false
 
 
     let collect_pseudo f =

--- a/tools/logConstr.ml
+++ b/tools/logConstr.ml
@@ -31,7 +31,9 @@ let rec tr_v v =
   match v with
   | Concrete i -> Concrete (Int64.of_string i)
   | ConcreteVector vs -> ConcreteVector (List.map tr_v vs)
-  | Symbolic _|Label _|Tag _|PteVal _|Instruction _ as sym -> sym
+  | Symbolic _|Label _|Tag _
+  | PteVal _|Instruction _|Frozen _
+    as w -> w
 
 let tr_atom = function
   | LV(loc,v) ->  LV(loc,tr_v v)


### PR DESCRIPTION
Symbolic values are instrumental to herd first phases, before determining concrete values.

In some circumstances, such as a in the final state of a LB+datas test with no OOTA provision, symbolic values can find their way to later stages. Then, it may be convenient to "freeze" them as constants. The transformation currently applies when symbolic values are stored in constant vectors in final values.

Consider the following test:
```
AArch64 LB+data+pairs
{
int64_t x[2]; int64_t y[2];
0:X0=x; 0:X3=y;
1:X0=y; 1:X3=x;
}
 P0             | P1             ;
 LDP X1,X2,[X0] | LDP X1,X2,[X0] ;
 STP X2,X1,[X3] | STP X2,X1,[X3] ;
locations [x;y;]
```
Previous versions of herd with command line `herd7 -cat cos.cat` were failing. Now we have:
```
Test LB+data+pairs Required
States 4
x={0,0}; y={0,0};
x={0,S8}; y={S8,0};
x={S7,0}; y={0,S7};
x={S7,S8}; y={S8,S7};
Ok
...
```
The last line `x={S7,S8}; y={S8,S7};` corresponds to complete out-of-thin air behaviour.