### PR TITLE
ASL now produces the correct graphs for main instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,17 @@ test-asl:
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 ASL instructions tests: OK"
 
+test:: test-pseudo-asl
+test-pseudo-asl:
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/ASL-pseudo-arch \
+		-conf ./herd/tests/instructions/ASL-pseudo-arch/pseudo-conf.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 ASL instructions tests on pseudo-architecture: OK"
+
 test-aarch64-asl: asl-pseudocode
 	@echo
 	$(HERD_REGRESSION_TEST) \

--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -98,6 +98,7 @@ type expr_desc =
   | E_Slice of expr * slice list
   | E_Cond of expr * expr * expr
   | E_GetField of expr * identifier * type_annot
+  | E_GetFields of expr * identifier list * type_annot
   | E_Record of ty * (identifier * expr) list * type_annot
   | E_Concat of expr list
   | E_Tuple of expr list
@@ -137,7 +138,6 @@ and type_desc =
   | T_String
   | T_Bool
   | T_Bits of bits_constraint * bitfields option
-  | T_Bit
   | T_Enum of identifier list
   | T_Tuple of ty list
   | T_Array of expr * ty
@@ -167,7 +167,7 @@ and bits_constraint =
   | BitWidth_Constrained of int_constraints
       (** Constrained directly by a constraint on its width. *)
 
-and bitfields = (slice list * identifier) list
+and bitfields = (identifier * slice list) list
 
 and typed_identifier = identifier * ty
 (** An identifier declared with its type. *)
@@ -185,6 +185,7 @@ type lexpr_desc =
   | LE_Typed of lexpr * ty
   | LE_Slice of lexpr * slice list
   | LE_SetField of lexpr * identifier * type_annot
+  | LE_SetFields of lexpr * identifier list * type_annot
   | LE_TupleUnpack of lexpr list
 
 and lexpr = lexpr_desc annotated

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -86,6 +86,7 @@ let used_identifiers, used_identifiers_stmt =
         List.fold_left use_slice acc args
     | E_Cond (e1, e2, e3) -> use_e (use_e (use_e acc e1) e3) e2
     | E_GetField (e, _, _ta) -> use_e acc e
+    | E_GetFields (e, _, _ta) -> use_e acc e
     | E_Record (_ty, li, _ta) -> List.fold_left use_field acc li
     | E_Concat es -> List.fold_left use_e acc es
     | E_Tuple es -> List.fold_left use_e acc es
@@ -132,6 +133,7 @@ let expr_of_lexpr : lexpr -> expr =
     | LE_Typed (le, t) -> E_Typed (map_desc aux le, t)
     | LE_Slice (le, args) -> E_Slice (map_desc aux le, args)
     | LE_SetField (le, x, ta) -> E_GetField (map_desc aux le, x, ta)
+    | LE_SetFields (le, x, ta) -> E_GetFields (map_desc aux le, x, ta)
     | LE_Ignore -> E_Var "-"
     | LE_TupleUnpack les -> E_Tuple (List.map (map_desc aux) les)
   in

--- a/asllib/Interpreter.mli
+++ b/asllib/Interpreter.mli
@@ -20,10 +20,10 @@
 module type S = sig
   module B : Backend.S
 
-  type body = B.value list -> B.value list B.m
+  type body = B.value B.m list -> B.value B.m list B.m
   type primitive = body AST.func_skeleton
 
-  val run : AST.t -> primitive list -> B.value list B.m
+  val run : AST.t -> primitive list -> unit B.m
   (** [run spec_lib ast] runs the function main of the ast, in an
       environment build from the ast and spec_lib.
       The primitives signatures will be passed by the interpreter to the type-

--- a/asllib/Native.mli
+++ b/asllib/Native.mli
@@ -22,4 +22,4 @@ module NativeBackend :
 
 module NativeInterpreter : Interpreter.S with module B = NativeBackend
 
-val interprete : AST.t -> AST.value list
+val interprete : AST.t -> unit

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -105,6 +105,8 @@ let rec pp_expr f e =
       fprintf f "@[<hv>@[<h>if %a@ then@]@;<1 2>%a@ else@;<1 2>%a@]" pp_expr e1
         pp_expr e2 pp_expr e3
   | E_GetField (e, x, _ta) -> fprintf f "@[%a@,.%s@]" pp_expr e x
+  | E_GetFields (e, xs, _ta) ->
+      fprintf f "@[%a@,.[@[%a@]]@]" pp_expr e (pp_comma_list pp_print_string) xs
   | E_Record (ty, li, _ta) ->
       let pp_one f (x, e) = fprintf f "@[<h>%s =@ %a@]" x pp_expr e in
       fprintf f "@[<hv>%a {@;<1 2>%a@,}@]" pp_ty ty (pp_comma_list pp_one) li
@@ -141,12 +143,11 @@ and pp_ty f t =
       fprintf f "@[integer {%a}@]" pp_int_constraints int_constraint
   | T_Real -> pp_print_string f "real"
   | T_String -> pp_print_string f "string"
-  | T_Bit -> pp_print_string f "bit"
   | T_Bool -> pp_print_string f "boolean"
   | T_Bits (bits_constraint, None) ->
       fprintf f "@[bits(%a)@]" pp_bits_constraint bits_constraint
   | T_Bits (bits_constraint, Some fields) ->
-      let pp_bitfield f (slices, name) =
+      let pp_bitfield f (name, slices) =
         fprintf f "@[<h>[%a]@ %s@]" pp_slice_list slices name
       in
       fprintf f "bits (%a)@ {@[<hv 1>@,%a@]@,}" pp_bits_constraint
@@ -192,6 +193,10 @@ let rec pp_lexpr f le =
   | LE_Typed (le, ty) -> fprintf f "%a :: %a" pp_lexpr le pp_ty ty
   | LE_Slice (le, args) -> fprintf f "%a[%a]" pp_lexpr le pp_slice_list args
   | LE_SetField (le, x, _ta) -> fprintf f "@[%a@,.%s@]" pp_lexpr le x
+  | LE_SetFields (le, li, _ta) ->
+      fprintf f "@[%a@,.@[[%a]@]@]" pp_lexpr le
+        (pp_comma_list pp_print_string)
+        li
   | LE_Ignore -> pp_print_string f "-"
   | LE_TupleUnpack les -> fprintf f "@[( %a )@]" (pp_comma_list pp_lexpr) les
 

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -97,6 +97,8 @@ let rec pp_expr =
         bprintf f "E_Cond (%a, %a, %a)" pp_expr e1 pp_expr e2 pp_expr e3
     | E_GetField (e, x, _ta) ->
         bprintf f "E_GetField (%a, %S, None)" pp_expr e x
+    | E_GetFields (e, x, _ta) ->
+        bprintf f "E_GetFields (%a, %a, None)" pp_expr e (pp_list pp_string) x
     | E_Record (ty, li, _ta) ->
         bprintf f "E_Record (%a, %a, None)" pp_ty ty (pp_id_assoc pp_expr) li
     | E_Concat es ->
@@ -142,11 +144,10 @@ and pp_ty =
     | T_Bool -> addb f "T_Bool"
     | T_Bits (bits_constraint, fields) ->
         let pp_fields =
-          pp_option @@ pp_list @@ pp_pair pp_slice_list pp_string
+          pp_option @@ pp_list @@ pp_pair pp_string pp_slice_list
         in
         bprintf f "T_Bits (%a, %a)" pp_bits_constraint bits_constraint pp_fields
           fields
-    | T_Bit -> addb f "T_Bit"
     | T_Enum enum_type_desc ->
         addb f "T_Enum ";
         pp_list pp_string f enum_type_desc
@@ -190,7 +191,10 @@ let rec pp_lexpr =
     | LE_Slice (le, args) ->
         bprintf f "LE_Slice (%a, %a)" pp_lexpr le pp_slice_list args
     | LE_SetField (le, x, _ta) ->
-        bprintf f "LE_SetField (%a, %S, None)" pp_lexpr le x
+        bprintf f "LE_Set_Field (%a, %S, None)" pp_lexpr le x
+    | LE_SetFields (le, x, _ta) ->
+        bprintf f "LE_SetFields (%a, %a, None)" pp_lexpr le (pp_list pp_string)
+          x
     | LE_Ignore -> addb f "LE_Ignore"
     | LE_TupleUnpack les ->
         addb f "LE_TupleUnpack ";

--- a/asllib/backend.mli
+++ b/asllib/backend.mli
@@ -58,6 +58,10 @@ module type S = sig
   (** Monadic bind operation. but that only pass internal interpreter data.
       This should not create any data-dependency. *)
 
+  val bind_ctrl : 'a m -> ('a -> 'b m) -> 'b m
+  (** Monadic bind operation, but that creates a control dependency between the\
+      first argument and the result of the second one. *)
+
   val prod : 'a m -> 'b m -> ('a * 'b) m
   (** Monadic product operation, two monads are combined "in parrallel".*)
 

--- a/asllib/bitvector.ml
+++ b/asllib/bitvector.ml
@@ -71,6 +71,15 @@ let create_data_bytes length =
   let n = length / 8 and m = length mod 8 in
   Bytes.create (if m = 0 then n else n + 1)
 
+(** [String.for_all] taken directly out of stdlib version 4.13 . *)
+let string_for_all p s =
+  let n = String.length s in
+  let rec loop i =
+    if i = n then true
+    else if p (String.unsafe_get s i) then loop (succ i)
+    else false in
+  loop 0
+
 (* --------------------------------------------------------------------------
 
                               Printers and conversions
@@ -169,8 +178,7 @@ let of_string s =
   else ();
   (length, Buffer.contents result)
 
-let of_int s =
-  let length = Sys.int_size - 1 in
+let of_int_sized length s =
   let n = length / 8 and m = length mod 8 in
   let result = Bytes.make (if m = 0 then n else n + 1) char_0 in
   for i = 0 to n - 1 do
@@ -182,6 +190,8 @@ let of_int s =
     Bytes.set result n (Char.chr c)
   else ();
   (length, Bytes.unsafe_to_string result)
+
+let of_int = of_int_sized (Sys.int_size - 1)
 
 let of_int64 s =
   let result = create_data_bytes 64 in
@@ -386,3 +396,7 @@ let ones length =
 
 let zero = zeros 1
 let one = ones 1
+
+let is_zeros bv =
+  let _length, data = remask bv in
+  string_for_all (( = ) char_0) data

--- a/asllib/bitvector.mli
+++ b/asllib/bitvector.mli
@@ -35,6 +35,11 @@ val of_int : int -> t
     corresponds to [i] in little-endian, i.e. index 0 (for slicing operations
     corresponds to [i mod 2]. *)
 
+val of_int_sized : int -> int -> t
+(** [of_int n i] is the bitvector of length [n] that corresponds to [i] in
+    little-endian, i.e. index 0 (for slicing operations corresponds to
+    [i mod 2]. *)
+
 val of_int64 : int64 -> t
 (** [of_int i] is the bitvector of length 64 that corresponds to [i] in
     little-endian, i.e. index 0 (for slicing operations corresponds to
@@ -98,3 +103,6 @@ val ones : int -> t
 
 val zeros : int -> t
 (** [zeros n] is a bitvector of length [n] without any bit set. *)
+
+val is_zeros : t -> bool
+(** [is_zeros bv] is true if every bit of bv is unset. *)

--- a/asllib/dune
+++ b/asllib/dune
@@ -11,7 +11,7 @@
  (modules (:standard \ asli bundler))
  (private_modules Parser0 Gparser0 Lexer0 SimpleLexer0 RepeatableLexer)
  (modules_without_implementation Backend AST)
- (flags -w -40-42)
+ (flags (:standard -w -40-42))
  (libraries menhirLib))
 
 (executable

--- a/herd/ASLParseTest.ml
+++ b/herd/ASLParseTest.ml
@@ -17,7 +17,7 @@
 module Make (Conf : RunTest.Config) (ModelConfig : MemCat.Config) = struct
   module ArchConfig = SemExtra.ConfigToArchConfig (Conf)
   module ASLS = ASLSem.Make (Conf)
-  module ASLA = ASLS.ASL64AH
+  module ASLA = ASLS.A
 
   module ASLLexParse = struct
     type instruction = ASLA.parsedPseudo

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -562,7 +562,7 @@ module Make(C:Config) (I:I) : S with module I = I
             | _ -> k)
           st RegMap.empty
 
-      let look_reg r st = try Some (RegMap.find r st) with Not_found -> None
+      let look_reg r st = RegMap.find_opt r st
       let set_reg r v st = RegMap.add r v st
       let kill_regs rs st =  List.fold_right RegMap.remove rs st
       let fold_reg_state = RegMap.fold

--- a/herd/libdir/asl-pseudo-arch.cat
+++ b/herd/libdir/asl-pseudo-arch.cat
@@ -1,0 +1,12 @@
+(* Pseudo-architecture to test ASL dependencies *)
+
+(* 
+   Principle: this peudo-architecture is made to be able to discirminate
+   asl-dependencies in very short litmus tests (in constrast to the full shared
+   aarch64 pseudocode included in an AArch64 litmus test).
+ *)
+
+
+acyclic iico_data | iico_ctrl | rf-reg | rf
+
+

--- a/herd/libdir/asl-pseudocode/.gitignore
+++ b/herd/libdir/asl-pseudocode/.gitignore
@@ -4,3 +4,5 @@ other-instrs
 shared_pseudocode.asl
 notice.html
 *.log
+ISA_A64_xml_A_profile-2022-12
+ISA_A64_xml_A_profile-2022-12.tar.gz

--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -238,3 +238,70 @@ func ClearExclusiveByAddress(paddress :: FullAddress, processorid :: integer, si
 begin
   pass;
 end
+
+
+getter _R [n :: integer] => bits(64)
+begin
+  return read_register(n);
+end
+
+setter _R [n :: integer] = value :: bits(64)
+begin
+  write_register(n, value);
+end
+
+type SCTLRType of bits(64) {
+  [0] M,
+  [1] A,
+  [2] C,
+  [3] SA,
+  [4] SA0,
+  [5] CP15BEN,
+  [6] nAA,
+  [7] ITD,
+  [8] SED,
+  [9] UMA,
+  [10] EnRCTX,
+  [11] EOS,
+  [12] I,
+  [13] EnDB,
+  [14] DZE,
+  [15] UCT,
+  [16] nTWI,
+  [17] RES0,
+  [18] nTWE,
+  [19] WXN,
+  [20] TSCXT,
+  [21] IESB,
+  [22] EIS,
+  [23] SPAN,
+  [24] EOE,
+  [25] EE,
+  [26] UCI,
+  [27] EnDA,
+  [28] nTSLMD,
+  [29] LSMAOE,
+  [30] EnIB,
+  [31] EnIA,
+
+  [35] BT0,
+  [36] BT1,
+  [37] ITFSB,
+  [39:38] TCF0,
+  [41:40] TCF,
+  [42] ATA0,
+  [43] ATA,
+  [44] DSSBS,
+  [45] TWEDEn,
+  [49:46] TWEDEL,
+
+  [54] EnASR,
+  [55] EnAS0,
+  [56] EnALS,
+  [57] EPAN,
+};
+
+getter SCTLR_EL1[] => SCTLRType
+begin
+  return Zeros(64);
+end

--- a/herd/libdir/asl-pseudocode/patches.asl
+++ b/herd/libdir/asl-pseudocode/patches.asl
@@ -55,3 +55,50 @@ func ELStateUsingAArch32K(el::bits(2), secure::boolean) => (boolean, boolean)
 begin
     return (TRUE, FALSE);
 end
+
+func SignExtend(x::bits(M), N::integer) => bits(N)
+begin
+  return sign_extend (x, N);
+end
+
+
+// ProcState
+// =========
+// Armv8 processor state bits.
+// There is no significance to the field order.
+
+type ProcState of bits(64) {
+    [3] N,        // Negative condition flag
+    [2] Z,        // Zero condition flag
+    [1] C,        // Carry condition flag
+    [0] V,        // Overflow condition flag
+    [3] D,        // Debug mask bit                     [AArch64 only]
+    [5] A,        // SError interrupt mask bit
+    [6] I,        // IRQ mask bit
+    [7] F,        // FIQ mask bit
+    [8] EXLOCK,   // Lock exception return state
+    [9] PAN,      // Privileged Access Never Bit        [v8.1]
+    [10] UAO,      // User Access Override               [v8.2]
+    [11] DIT,      // Data Independent Timing            [v8.4]
+    [12] TCO,      // Tag Check Override                 [v8.5, AArch64 only]
+    [13] PM,       // PMU exception Mask
+    [14] PPEND,     // synchronous PMU exception to be observed
+    [16:15] BTYPE,    // Branch Type                        [v8.5]
+    [17] ZA,       // Accumulation array enabled         [SME]
+    [18] SM,       // Streaming SVE mode enabled         [SME]
+    [19] ALLINT,   // Interrupt mask bit
+    [20] SS,       // Software step bit
+    [21] IL,       // Illegal Execution state bit
+    [23:22] EL,       // Exception level
+    [24] nRW,      // Execution state: 0=AArch64, 1=AArch32
+    [25] SP,       // Stack pointer select: 0=SP0, 1=SPx [AArch64 only]
+    [26] Q,        // Cumulative saturation flag         [AArch32 only]
+    [30:27] GE,       // Greater than or Equal flags        [AArch32 only]
+    [31] SSBS,     // Speculative Store Bypass Safe
+    [39:32] IT,       // If-then bits, RES0 in CPSR         [AArch32 only]
+    [40] J,        // J bit, RES0                        [AArch32 only, RES0 in SPSR and CPSR]
+    [41] T,        // T32 bit, RES0 in CPSR              [AArch32 only]
+    [42] E,        // Endianness bit                     [AArch32 only]
+    [47:42] M         // Mode field                         [AArch32 only]
+};
+

--- a/herd/libdir/asl.cat
+++ b/herd/libdir/asl.cat
@@ -29,33 +29,11 @@ ASL
 
 let NASLLocal = (M | Wreg | Rreg) \ ASLLocal
 let ASLDATA = DATA
-let ASLNDATA = NDATA
 
 let asl_iico_ctrl = iico_ctrl
 let asl_iico_data = iico_data
 let asl_rf_reg = rf-reg
 let asl_rf = rf
-
-(*****************************************************************************)
-(*                                                                           *)
-(*                                   Utils                                   *)
-(*                                                                           *)
-(*****************************************************************************)
-
-(* Sets manipulation *)
-let map = fun f -> fun S ->
-    match S with
-    || {} -> {}
-    || p ++ S -> (f p) ++ (map f S)
-end
-
-(* Pair manipulation *)
-let fst (a, b) = a
-let snd (a, b) = b
-
-(* domain(rel) --rel--> codomain(rel) *)
-let domain rel = map fst rel
-let codomain rel = map snd rel
 
 (*****************************************************************************)
 (*                                                                           *)
@@ -69,12 +47,12 @@ let asl_fr_reg = ([Rreg] ; po ; [Wreg]) & loc (* loc extended to registers *)
 let asl_fr = ([R] ; po ; [W]) & loc
 
 let asl_data = asl_iico_data | asl_rf_reg
-let asl_deps = asl_data | asl_iico_ctrl
+let asl_deps = asl_data (* | asl_iico_ctrl *)
 let asl_deps_restricted = id | (asl_deps ; ([ASLLocal] ; asl_deps)+)
 
 let aarch64_iico_data = ( asl_deps_restricted ; asl_data+ ) & aarch64
 
-(* Here we do need asl_iico_data after the asl_iico_ctrl as the asl_iico_ctrl 
+(* Here we do need asl_iico_data after the asl_iico_ctrl as the asl_iico_ctrl
     does not propagate inside an asl statement *)
 let aarch64_iico_ctrl = ( asl_deps_restricted ; asl_iico_ctrl ; asl_iico_data* ) & aarch64
 
@@ -92,18 +70,15 @@ let aarch64_intrinsic = aarch64_iico_ctrl | aarch64_iico_data | aarch64_iico_ord
 let AArch64 = NASLLocal
 
 (* DATA and NDATA *)
-let to_data = (asl_deps_restricted ; [DATA] ; asl_iico_data ) & aarch64
-let to_ndata = (asl_deps_restricted ; [NDATA] ; asl_iico_data ) & aarch64
+let to_data = (asl_deps_restricted ; [DATA] ; asl_iico_data ; [W | Wreg]) & aarch64
 
-let Aarch64_DATA = NASLLocal & domain (to_data)
-show [Aarch64_DATA] as AArch64_DATA
-
-let Aarch64_NDATA = NASLLocal & domain (to_ndata)
-show [Aarch64_NDATA] as AArch64_NDATA
+let AArch64_DATA = NASLLocal & domain (to_data)
+show [AArch64_DATA] as AArch64_DATA
+show [DATA] as debug_data
 
 (* TODO *)
 (* B = write to PC *)
-(* BCC = codomain(aarch64_iico_ctrl) & B *)
+(* BCC = range(aarch64_iico_ctrl) & B *)
 (* Pred = BranchTo(VBAR something) ??? *)
 (* F = call to (data memory ?) barrier *)
 

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -34,8 +34,8 @@ module Make
     let mixed = O.variant Variant.Mixed || morello
     let memtag = O.variant Variant.MemTag
     let kvm = O.variant Variant.VMSA
-    let asl = O.variant Variant.ASL
     let self = O.variant Variant.Self
+    let asl = S.A.arch = `ASL
     let optacetrue =
       let open OptAce in
       match O.optace with

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -80,6 +80,10 @@ module type S =
     (* Data composition, entry for snd monad: minimals for complete iico *)
     val bind_data_to_minimals : 'a t -> ('a -> 'b t) -> ('b) t
 
+    (* Control compoisition, but output events might be in first event if
+       second is empty. *)
+    val bind_ctrl_seq_data : 'a t -> ('a -> 'b t) -> 'b t
+
     (* Hybrid composition m1 m2 m3, m1 -ctrl+data-> m3 and m2 -data-> m3.
        ctrl+data -> ctrl from maximal commit evts + data from
        monad output *)
@@ -93,6 +97,9 @@ module type S =
 
     (* Identical control dep only, all output from firtst argument *)
     val bind_ctrl_first_outputs : 'a t -> ('a -> 'b t) -> 'b t
+
+    (* Same as [>>=] but with order deps instead of data between the arguments. *)
+    val bind_order : 'a t -> ('a -> 'b t) -> 'b t
 
     (* Very ad-hoc transformation, [short3 p1 p2 s],
      * add relation r;r;r where r is intra_causality_data,
@@ -182,7 +189,13 @@ module type S =
     val aarch64_cas_ok_morello :
         'loc t -> 'v t -> 'v t -> ('loc -> 'v -> unit t) -> unit t
     val stu : 'a t -> 'a t -> ('a -> unit t) -> (('a * 'a) -> unit t) -> unit t
+
+    (* Same as [>>|], but binding style. *)
     val cseq : 'a t -> ('a -> 'b t) -> 'b t
+
+    (* Same as [cseq], but output on right argument. *)
+    val aslseq : 'a t -> ('a -> 'b t) -> 'b t
+
     type poi = int
 
     val add_instr :
@@ -250,6 +263,9 @@ module type S =
     val fetch :
         A.V.op_t -> A.V.v -> (A.V.v -> A.V.v -> E.action) ->
           A.inst_instance_id -> A.V.v t
+
+    (* [as_data_port m] flags all events in [m] as data. *)
+    val as_data_port : 'a t -> 'a t
 
     (**********************)
     (* Morello extensions *)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus
@@ -1,0 +1,33 @@
+ASL LB-pseudo-arch
+
+{
+  x = 0;
+  y = 0;
+  0: X1= x;
+  0: X2= y;
+}
+
+constant one :: bits(64) = 1[63:0];
+
+func T0(x::bits(64), y:: bits(64))
+begin
+  let x0 = UInt(read_memory(x, 64));
+  write_memory(y, 64, one);
+end
+
+func T1(x::bits(64), y:: bits(64))
+begin
+  let x1 = UInt(read_memory(y, 64));
+  write_memory(x, 64, one);
+end
+
+func main()
+begin
+  let x = read_register(1);
+  let y = read_register(2);
+
+  T0(x, y);
+  T1(x, y);
+end
+
+exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
@@ -1,0 +1,13 @@
+Test LB-pseudo-arch Allowed
+States 4
+0:T0.0.x0=0; 0:T1.0.x1=0;
+0:T0.0.x0=0; 0:T1.0.x1=1;
+0:T0.0.x0=1; 0:T1.0.x1=0;
+0:T0.0.x0=1; 0:T1.0.x1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
+Observation LB-pseudo-arch Sometimes 1 3
+Hash=7bc77a96e738a6f52b5a9721522f61fe
+

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus
@@ -1,0 +1,37 @@
+ASL LB-pseudo-arch
+
+{
+  x = 0;
+  y = 0;
+  0: X1= x;
+  0: X2= y;
+}
+
+constant one :: bits(64) = 1[63:0];
+
+func T0(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(x, 64);
+  let x0 = UInt(read);
+  let data = one OR (read EOR read);
+  write_memory(y, 64, data);
+end
+
+func T1(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(y, 64);
+  let x1 = UInt(read);
+  let data = one OR (read EOR read);
+  write_memory(x, 64, data);
+end
+
+func main()
+begin
+  let x = read_register(1);
+  let y = read_register(2);
+
+  T0(x, y);
+  T1(x, y);
+end
+
+exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
@@ -1,0 +1,12 @@
+Test LB-pseudo-arch Allowed
+States 3
+0:T0.0.x0=0; 0:T1.0.x1=0;
+0:T0.0.x0=0; 0:T1.0.x1=1;
+0:T0.0.x0=1; 0:T1.0.x1=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
+Observation LB-pseudo-arch Never 0 3
+Hash=f9a3add915f2fb761d3a2c557d6c7b1b
+

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus
@@ -1,0 +1,35 @@
+ASL LB-pseudo-arch
+
+{
+  x = 0;
+  y = 0;
+  0: X1= x;
+  0: X2= y;
+}
+
+constant one :: bits(64) = 1[63:0];
+
+func T0(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(x, 64);
+  let x0 = UInt(read);
+  let data = one OR (read EOR read);
+  write_memory(y, 64, data);
+end
+
+func T1(x::bits(64), y:: bits(64))
+begin
+  let x1 = UInt(read_memory(y, 64));
+  write_memory(x, 64, one);
+end
+
+func main()
+begin
+  let x = read_register(1);
+  let y = read_register(2);
+
+  T0(x, y);
+  T1(x, y);
+end
+
+exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
@@ -1,0 +1,13 @@
+Test LB-pseudo-arch Allowed
+States 4
+0:T0.0.x0=0; 0:T1.0.x1=0;
+0:T0.0.x0=0; 0:T1.0.x1=1;
+0:T0.0.x0=1; 0:T1.0.x1=0;
+0:T0.0.x0=1; 0:T1.0.x1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
+Observation LB-pseudo-arch Sometimes 1 3
+Hash=bb7c97bd88c78edab3ddab591d5fc7ca
+

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus
@@ -1,0 +1,42 @@
+ASL LB-pseudo-arch
+
+{
+  x = 0;
+  y = 0;
+  0: X1= x;
+  0: X2= y;
+}
+
+constant one :: bits(64) = 1[63:0];
+
+func T0(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(x, 64);
+  let x0 = UInt(read);
+  let data = one OR (read EOR read);
+  write_memory(y, 64, data);
+end
+
+func f(read::bits(64)) => bits(64)
+begin
+  return one;
+end
+
+func T1(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(y, 64);
+  let x1 = UInt(read);
+  let data = f(read);
+  write_memory(x, 64, data);
+end
+
+func main()
+begin
+  let x = read_register(1);
+  let y = read_register(2);
+
+  T0(x, y);
+  T1(x, y);
+end
+
+exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
@@ -1,0 +1,13 @@
+Test LB-pseudo-arch Allowed
+States 4
+0:T0.0.x0=0; 0:T1.0.x1=0;
+0:T0.0.x0=0; 0:T1.0.x1=1;
+0:T0.0.x0=1; 0:T1.0.x1=0;
+0:T0.0.x0=1; 0:T1.0.x1=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
+Observation LB-pseudo-arch Sometimes 1 3
+Hash=7e1d806aede38cf408ad9e0a683d6bac
+

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus
@@ -1,0 +1,42 @@
+ASL LB-pseudo-arch
+
+{
+  x = 0;
+  y = 0;
+  0: X1= x;
+  0: X2= y;
+}
+
+constant one :: bits(64) = 1[63:0];
+
+func T0(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(x, 64);
+  let x0 = UInt(read);
+  let data = one OR (read EOR read);
+  write_memory(y, 64, data);
+end
+
+func f(read::bits(64)) => bits(64)
+begin
+  return read[63:0] OR one;
+end
+
+func T1(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(y, 64);
+  let x1 = UInt(read);
+  let data = f(read);
+  write_memory(x, 64, data);
+end
+
+func main()
+begin
+  let x = read_register(1);
+  let y = read_register(2);
+
+  T0(x, y);
+  T1(x, y);
+end
+
+exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
@@ -1,0 +1,12 @@
+Test LB-pseudo-arch Allowed
+States 3
+0:T0.0.x0=0; 0:T1.0.x1=0;
+0:T0.0.x0=0; 0:T1.0.x1=1;
+0:T0.0.x0=1; 0:T1.0.x1=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
+Observation LB-pseudo-arch Never 0 3
+Hash=f56f1369368fae158c7901bd88ecd0dc
+

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus
@@ -1,0 +1,37 @@
+ASL LB-pseudo-arch
+
+{
+  x = 0;
+  y = 0;
+  0: X1= x;
+  0: X2= y;
+}
+
+constant one :: bits(64) = 1[63:0];
+
+func T0(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(x, 64);
+  let x0 = UInt(read);
+  let data = one OR (read EOR read);
+  write_memory(y, 64, data);
+end
+
+func T1(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(y, 64);
+  let x1 = UInt(read);
+  let data = if read == one then one else one;
+  write_memory(x, 64, data);
+end
+
+func main()
+begin
+  let x = read_register(1);
+  let y = read_register(2);
+
+  T0(x, y);
+  T1(x, y);
+end
+
+exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
@@ -1,0 +1,12 @@
+Test LB-pseudo-arch Allowed
+States 3
+0:T0.0.x0=0; 0:T1.0.x1=0;
+0:T0.0.x0=0; 0:T1.0.x1=1;
+0:T0.0.x0=1; 0:T1.0.x1=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
+Observation LB-pseudo-arch Never 0 3
+Hash=f64480b389dbe846d6cebf0a3938e445
+

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus
@@ -1,0 +1,39 @@
+ASL LB-pseudo-arch
+
+{
+  x = 0;
+  y = 0;
+  0: X1= x;
+  0: X2= y;
+}
+
+constant one :: bits(64) = 1[63:0];
+
+func T0(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(x, 64);
+  let x0 = UInt(read);
+  let data = one OR (read EOR read);
+  write_memory(y, 64, data);
+end
+
+func T1(x::bits(64), y:: bits(64))
+begin
+  let x1 = UInt(read_memory(y, 64));
+  if x1 == 1 then
+    write_memory(x, 64, one);
+  else
+    write_memory(x, 64, one);
+  end
+end
+
+func main()
+begin
+  let x = read_register(1);
+  let y = read_register(2);
+
+  T0(x, y);
+  T1(x, y);
+end
+
+exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
@@ -1,0 +1,12 @@
+Test LB-pseudo-arch Allowed
+States 3
+0:T0.0.x0=0; 0:T1.0.x1=0;
+0:T0.0.x0=0; 0:T1.0.x1=1;
+0:T0.0.x0=1; 0:T1.0.x1=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
+Observation LB-pseudo-arch Never 0 3
+Hash=b8272a3b8633a947baddfa6f326e8f0f
+

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus
@@ -1,0 +1,44 @@
+ASL LB-pseudo-arch
+
+{
+  x = 0;
+  y = 0;
+  0: X1= x;
+  0: X2= y;
+}
+
+constant one :: bits(64) = 1[63:0];
+
+func T0(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(x, 64);
+  let x0 = UInt(read);
+  let data = one OR (read EOR read);
+  write_memory(y, 64, data);
+end
+
+func T1(x::bits(64), y:: bits(64))
+begin
+  let read = read_memory(y, 64);
+  let x1 = UInt(read);
+
+  var data :: bits(64);
+  if x1 == one then
+    data = one;
+  else
+    data = one;
+  end
+
+  write_memory(x, 64, data);
+end
+
+func main()
+begin
+  let x = read_register(1);
+  let y = read_register(2);
+
+  T0(x, y);
+  T1(x, y);
+end
+
+exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
@@ -1,0 +1,12 @@
+Test LB-pseudo-arch Allowed
+States 3
+0:T0.0.x0=0; 0:T1.0.x1=0;
+0:T0.0.x0=0; 0:T1.0.x1=1;
+0:T0.0.x0=1; 0:T1.0.x1=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
+Observation LB-pseudo-arch Never 0 3
+Hash=bd8788cbfd01ca7b0a3d57f62d05c2b6
+

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus
@@ -1,0 +1,33 @@
+ASL MP-pseudo-arch
+
+{
+  x = 0;
+  y = 0;
+  0: X1= x;
+  0: X2= y;
+}
+
+constant one :: bits(64) = 1[63:0];
+
+func T0(x::bits(64), y:: bits(64))
+begin
+  write_memory(x, 64, one);
+  write_memory(y, 64, one);
+end
+
+func T1(x::bits(64), y:: bits(64))
+begin
+  let a = UInt(read_memory(y, 64));
+  let b = UInt(read_memory(x, 64));
+end
+
+func main()
+begin
+  let x = read_register(1);
+  let y = read_register(2);
+
+  T0(x, y);
+  T1(x, y);
+end
+
+exists (0: T1.0.a = 1 /\ 0: T1.0.b = 0)

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
@@ -1,0 +1,13 @@
+Test MP-pseudo-arch Allowed
+States 4
+0:T1.0.a=0; 0:T1.0.b=0;
+0:T1.0.a=0; 0:T1.0.b=1;
+0:T1.0.a=1; 0:T1.0.b=0;
+0:T1.0.a=1; 0:T1.0.b=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:T1.0.a=1 /\ 0:T1.0.b=0)
+Observation MP-pseudo-arch Sometimes 1 3
+Hash=3d982cc6a47946c116558731c8717e40
+

--- a/herd/tests/instructions/ASL-pseudo-arch/pseudo-conf.cfg
+++ b/herd/tests/instructions/ASL-pseudo-arch/pseudo-conf.cfg
@@ -1,0 +1,1 @@
+model asl-pseudo-arch.cat

--- a/herd/tests/instructions/ASL/bitfields1.litmus.expected
+++ b/herd/tests/instructions/ASL/bitfields1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.b=1 /\ 0:main.0.d=1 /\ 0:main.0.e=1)
 Observation bitfields1 Always 1 0
-Hash=591c4772abae5be93adf9986187dff78
+Hash=092228a59e1733ef11f95ec05b7cdd4c
 

--- a/herd/tests/instructions/ASL/data-return-01.litmus
+++ b/herd/tests/instructions/ASL/data-return-01.litmus
@@ -1,0 +1,14 @@
+ASL no data return
+
+{}
+
+func f(x::integer) => integer
+begin
+  return 3;
+end
+
+func main()
+begin
+  let a = f (3);
+end
+

--- a/herd/tests/instructions/ASL/data-return-01.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-01.litmus.expected
@@ -1,0 +1,10 @@
+Test no Required
+States 1
+
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation no Always 1 0
+Hash=406034acbf6eb233a26bf86a891223f4
+

--- a/herd/tests/instructions/ASL/data-return-02.litmus
+++ b/herd/tests/instructions/ASL/data-return-02.litmus
@@ -1,0 +1,15 @@
+ASL no data return
+
+{}
+
+func f(x::integer) => integer
+begin
+  let y = x;
+  return 3;
+end
+
+func main()
+begin
+  let a = f (3);
+end
+

--- a/herd/tests/instructions/ASL/data-return-02.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-02.litmus.expected
@@ -1,0 +1,10 @@
+Test no Required
+States 1
+
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation no Always 1 0
+Hash=9a66830089e793e8b5ea6fee18965f19
+

--- a/herd/tests/instructions/ASL/double-load.litmus
+++ b/herd/tests/instructions/ASL/double-load.litmus
@@ -1,0 +1,17 @@
+ASL double-load
+
+{
+  x = 3;
+  y = x;
+  0: X1 = y;
+}
+
+func main()
+begin
+  let addr_y = read_register(1);
+  let addr_x = read_memory (addr_y, 64);
+  let data_x = read_memory (addr_x, 64);
+  let three = UInt (data_x);
+end
+
+forall (0: main.0.three = 3)

--- a/herd/tests/instructions/ASL/double-load.litmus.expected
+++ b/herd/tests/instructions/ASL/double-load.litmus.expected
@@ -1,0 +1,10 @@
+Test double-load Required
+States 1
+0:main.0.three=3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:main.0.three=3)
+Observation double-load Always 1 0
+Hash=ebe0136cc0600caba641c117c0440bf7
+

--- a/herd/tests/instructions/ASL/records.litmus.expected
+++ b/herd/tests/instructions/ASL/records.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3)
 Observation records Always 1 0
-Hash=233a5100c41236c84593158c263419d7
+Hash=a2e9d389b113ba8a92ecd932fc77850a
 

--- a/herd/tests/instructions/ASL/write_mem.litmus
+++ b/herd/tests/instructions/ASL/write_mem.litmus
@@ -1,0 +1,12 @@
+ASL write-mem
+
+{ 0: X1 = x; 0: X2 = 3; x = 0 }
+
+func main()
+begin
+  let address = read_register (1);
+  let data = read_register (2);
+  write_memory(address, 64, data);
+end
+
+forall (x = 3)

--- a/herd/tests/instructions/ASL/write_mem.litmus.expected
+++ b/herd/tests/instructions/ASL/write_mem.litmus.expected
@@ -1,0 +1,10 @@
+Test write-mem Required
+States 1
+[x]='0000000000000000000000000000000000000000000000000000000000000011';
+No
+Witnesses
+Positive: 0 Negative: 1
+Condition forall ([x]=3)
+Observation write-mem Never 0 1
+Hash=e5cf6f5fa120d1d6472eb18e535acb3d
+

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -78,6 +78,7 @@ type t =
   | T of int
 (* ASL processing *)
   | ASL
+  | ASL_AArch64
   | ASLVersion of [ `ASLv0 | `ASLv1 ]
 (* Signed Int128 types *)
   | S128
@@ -131,6 +132,7 @@ let parse s = match Misc.lowercase s with
 | "cos-opt" -> Some CosOpt
 | "test" -> Some Test
 | "asl" -> Some ASL
+| "asl_aarch64" | "aslaarch64" | "asl+aarch64" -> Some ASL_AArch64
 | "aslv0" | "asl0" | "asl_0" -> Some (ASLVersion `ASLv0)
 | "aslv1" | "asl1" | "asl_1" -> Some (ASLVersion `ASLv1)
 | "s128" -> Some S128
@@ -190,6 +192,7 @@ let pp = function
   | Test -> "test"
   | T n -> Printf.sprintf "T%02i" n
   | ASL -> "ASL"
+  | ASL_AArch64 -> "ASL+AArch64"
   | ASLVersion `ASLv0 -> "ASLv0"
   | ASLVersion `ASLv1 -> "ASLv1"
   | S128 -> "S128"

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -75,8 +75,12 @@ type t =
 (* One hundred tests *)
   | T of int
 (* ASL Processing *)
-  | ASL
-  | ASLVersion of [ `ASLv0 | `ASLv1 ]
+  (* In AArch64 arch, use ASL to interprete AArch64 instructions when possible. *)
+  | ASL 
+  (* While interpreting ASL litmus test, include AArch64 shared pseudocode. *)
+  | ASL_AArch64 
+  (* When using aarch ASL, use ASL version v0 or v1 *)
+  | ASLVersion of [ `ASLv0 | `ASLv1 ] 
 (* Signed Int128 types *)
   | S128
 

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -86,7 +86,7 @@ let parse_reg s =
   | None, _ -> parse_local_id s
 
 (** A list of supported AArch64 registers. *)
-let arch_regs = AArch64Base.NZCV :: List.map fst AArch64Base.xregs
+let gregs = List.map fst AArch64Base.xregs
 
 let pp_reg = function
   | ASLLocalId (scope, x) -> pp_scope scope ^ "." ^ x

--- a/lib/ASLValue.ml
+++ b/lib/ASLValue.ml
@@ -22,6 +22,7 @@ module ASLArchOp = struct
     | BVSlice of int list
     | ToInt
     | ToBool
+    | ToBV
 
   let pp_op1 hexa = function
     | Set (i, v) -> Printf.sprintf "Set(%d, %s)" i (ASLConstant.pp hexa v)
@@ -31,6 +32,7 @@ module ASLArchOp = struct
         @@ List.map string_of_int positions
     | ToInt -> "ToInt"
     | ToBool -> "ToBool"
+    | ToBV -> "ToBV"
 
   let do_op1 =
     let ( let* ) = Option.bind in
@@ -53,6 +55,11 @@ module ASLArchOp = struct
       | ToInt -> (
           match cst with
           | Constant.Concrete s -> ASLScalar.convert_to_int s |> return_concrete
+          | Constant.Symbolic _ -> Some cst
+          | _ -> None)
+      | ToBV -> (
+          match cst with
+          | Constant.Concrete s -> ASLScalar.convert_to_bv s |> return_concrete
           | Constant.Symbolic _ -> Some cst
           | _ -> None)
       | ToBool ->

--- a/lib/lexSplit.mll
+++ b/lib/lexSplit.mll
@@ -21,7 +21,7 @@ exception Error
 let blank = [' ''\n''\r''\t']
 let non_blank = [^' ''\n''\r''\t']
 let digit = ['0'-'9']
-let printable = ['0'-'9''a'-'z''A'-'Z'':']
+let printable = [^' ''\n''\r''\t'',']
 rule main = parse
 | ',' | blank+  { main lexbuf }
 | digit+ as lxm { int_of_string lxm :: main lexbuf }


### PR DESCRIPTION
Main diffs on non ASL stuff:
 - variants now accepts all sorts of characters, now just separated by commas.
 - add a new variants for using ASL with AArch64 shared pseudocode loaded.
 - add a few combinators in `monad.mli`, either to do simple bindings, or to do low level stuff edits on the `event_structure`.
 - Refacto a bit on `eventsMonad`

Main new features on the ASL side:
 - Add a new way of executing ASL litmus tests by loading all the shared AArch64 pseudocode
 - Fix monadic bindings used in the interpreter and now get the wanted dependency graphs
 - Functions and primitives now take monads and return monads, this fixes problems while evaluating functions. Function calls have now the same semantics as would have their inlined \alpha-reduced code.
 - Introduce new tests for ASL pseudocode by passing them into a very simple architecture. This allows data- and control- dependency graphs to be tested.
 - Improve translation of executions from ASL to AArch64. This translation is currently not-tested, so I'm not very confident on its correctness for strange bits extraction.