### PR TITLE
[lib/gen]: fixed __int128 parsing

### DIFF
--- a/gen/typBase.ml
+++ b/gen/typBase.ml
@@ -29,6 +29,7 @@ let tags =
    "int32_t"; "uint32_t";
    "int64_t"; "uint64_t";
    "int128_t"; "uint128_t";
+   "__int128"; "__uint128";
  ]
 
 let parse s = match s with
@@ -43,6 +44,8 @@ let parse s = match s with
 | "uint64_t" -> Some (Std (Unsigned,Quad))
 | "int128_t" -> Some (Std (Signed,S128))
 | "uint128_t" -> Some (Std (Unsigned,S128))
+| "__int128" -> Some (Std (Signed,S128))
+| "__uint128" -> Some (Std (Unsigned,S128))
 | _ -> None
 
 let pp = function
@@ -55,8 +58,8 @@ let pp = function
 | Std (Unsigned,Word) ->  "uint32_t"
 | Std (Signed,Quad) ->  "int64_t"
 | Std (Unsigned,Quad) ->  "uint64_t"
-| Std (Signed,S128) ->  "int128_t"
-| Std (Unsigned,S128) ->  "uint128_t"
+| Std (Signed,S128) ->  "__int128"
+| Std (Unsigned,S128) ->  "__uint128"
 | Pteval -> "pteval_t"
 
 

--- a/herd/tests/instructions/C/C08.litmus
+++ b/herd/tests/instructions/C/C08.litmus
@@ -1,0 +1,19 @@
+C C08
+
+(* Test to ensure diy generated tests are accepted by herd - int128*)
+
+{__int128 y; __int128 x;}
+
+P0 (volatile __int128* y,volatile __int128* x) {
+  __int128 r0 = *x;
+  atomic_thread_fence(memory_order_relaxed);
+  *y = 1;
+}
+
+P1 (volatile __int128* y,volatile __int128* x) {
+  __int128 r0 = *y;
+  atomic_thread_fence(memory_order_relaxed);
+  *x = 1;
+}
+
+exists (0:r0=1 /\ 1:r0=1)

--- a/herd/tests/instructions/C/C08.litmus.expected
+++ b/herd/tests/instructions/C/C08.litmus.expected
@@ -1,0 +1,13 @@
+Test C08 Allowed
+States 3
+0:r0=0x0; 1:r0=0x0;
+0:r0=0x0; 1:r0=0x1;
+0:r0=0x1; 1:r0=0x0;
+Undef
+Witnesses
+Positive: 0 Negative: 3
+Flag *undef*
+Condition exists (0:r0=0x1 /\ 1:r0=0x1)
+Observation C08 Never 0 3
+Hash=df8f2c22043bedfe26ba47135c84a3b0
+

--- a/herd/tests/instructions/C/C11.litmus
+++ b/herd/tests/instructions/C/C11.litmus
@@ -1,0 +1,19 @@
+C C11
+
+(* Test to ensure _Atomic __int128 x = 0; is parsed**)
+
+{__int128 y; __int128 x; _Atomic __int128 z = 0;}
+
+P0 (volatile __int128* y,volatile __int128* x) {
+  __int128 r0 = *x;
+  atomic_thread_fence(memory_order_relaxed);
+  *y = 1;
+}
+
+P1 (volatile __int128* y,volatile __int128* x) {
+  __int128 r0 = *y;
+  atomic_thread_fence(memory_order_relaxed);
+  *x = 1;
+}
+
+exists (0:r0=1 /\ 1:r0=1)

--- a/herd/tests/instructions/C/C11.litmus.expected
+++ b/herd/tests/instructions/C/C11.litmus.expected
@@ -1,0 +1,13 @@
+Test C11 Allowed
+States 3
+0:r0=0x0; 1:r0=0x0;
+0:r0=0x0; 1:r0=0x1;
+0:r0=0x1; 1:r0=0x0;
+Undef
+Witnesses
+Positive: 0 Negative: 3
+Flag *undef*
+Condition exists (0:r0=0x1 /\ 1:r0=0x1)
+Observation C11 Never 0 3
+Hash=fdb5bbc868eabfecbe24a5eeab655a7d
+

--- a/herd/tests/instructions/C/c.cfg
+++ b/herd/tests/instructions/C/c.cfg
@@ -1,2 +1,3 @@
 hexa true
 model herd/libdir/rc11.cat
+variant S128

--- a/lib/CLexer.mll
+++ b/lib/CLexer.mll
@@ -38,8 +38,10 @@ let tr_name s = match s with
 | "uint32_t"
 | "int64_t"
 | "uint64_t"
-| "__int128_t" (* this is the syntax of this type in llvm and gcc *)
-| "__uint128_t" (* same here*)
+| "__int128_t"
+| "__uint128_t"
+| "__int128" (* this is the syntax of this type in llvm and gcc *)
+| "__uint128" (* same here*)
 | "intptr_t"
 | "uintptr_t"
 (* Mutexes *)

--- a/lib/CType.ml
+++ b/lib/CType.ml
@@ -71,7 +71,7 @@ let fmt10 = function
   | "uint32_t" -> Some (Macro  "PRIu32")
   | "int64_t" -> Some (Macro  "PRIi64")
   | "uint64_t" -> Some (Macro  "PRIu64")
-  | "int128_t" | "__int128_t" -> Some (Direct "lld")
+  | "int128_t" | "__int128" -> Some (Direct "lld")
   | "uint128_t" | "__uint128_t" -> Some (Direct "llu")
   | "intprt_t" -> Some (Macro "PRIiPTR")
   | "uintprt_t" -> Some (Macro "PRIuPTR")
@@ -89,7 +89,7 @@ let fmt16 = function
   | "uint32_t" -> Some (Macro  "PRIx32")
   | "int64_t" -> Some (Macro  "PRIx64")
   | "uint64_t" -> Some (Macro  "PRIx64")
-  | "int128_t" | "__int128_t"
+  | "int128_t" | "__int128"
   | "uint128_t" | "__uint128_t"
        -> Some (Direct "llx")
   | "intprt_t" -> Some (Macro "PRIxPTR")
@@ -164,7 +164,7 @@ let same_base t0 t1 = match t0,t1 with
     | ("int32_t","uint32_t")|("uint32_t","int32_t")
     | ("int64_t","uint64_t")|("uint64_t","int64_t")
     | ("int128_t", "uint128_t")|("uint128_t","int128_t")
-    | ("__int128_t", "__uint128_t")|("__uint128_t","__int128_t")
+    | ("__int128", "__uint128")|("__uint128","__int128")
       -> true
     | _,_ -> false
     end
@@ -181,7 +181,7 @@ let rec signed = function
   | Pointer _|Array _ -> false
   | Base
       ("atomic_t"|"int"|"char"|"long"|
-      "int8_t"|"int16_t"|"int32_t"|"int64_t"|"int128_t") -> true
+      "int8_t"|"int16_t"|"int32_t"|"int64_t"|"int128_t"|"__int128") -> true
  | Base _ -> false
 
 (* Best effort *)
@@ -192,7 +192,7 @@ let do_base_size =
   | "short"|"int16_t"|"uint16_t" -> Some Short
   | "int"|"int32_t"|"uint32_t" -> Some Word
   | "int64_t"|"uint64_t" -> Some Quad
-  | "int128_t"|"uint128_t" -> Some S128
+  | "int128_t"|"uint128_t"|"__int128"|"__uint128" -> Some S128
   | _ -> None
 
 let rec base_size t = match t with

--- a/lib/stateLexer.mll
+++ b/lib/stateLexer.mll
@@ -92,6 +92,8 @@ rule token = parse
 (* Memory Tagging *)
 | "*" { STAR }
 | '$' (digit+|alpha+) as name { DOLLARNAME name }
+| "__int128" as name { NAME name }
+| "__uint128" as name { NAME name }
 | '_' ? name as name { NAME name }
 | eof { EOF }
 | "<<" { error "<<" lexbuf }

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -213,6 +213,7 @@ atom_init:
 | ATOMIC typ=NAME loc=left_loc { loc,(Atomic typ,ParsedConstant.zero)}
 | loc=left_loc EQUAL i=instr  { (loc,(Ty "ins_t", mk_instr_val i)) }
 | NAME loc=left_loc EQUAL i=instr  { (loc,(Ty "ins_t", mk_instr_val i)) }
+| ATOMIC typ=NAME loc=left_loc EQUAL v=maybev { loc,(Atomic typ,v)}
 | typ=NAME loc=left_loc EQUAL v=maybev { (loc,(Ty typ,v))}
 | typ=NAME loc=left_loc EQUAL ATOMICINIT LPAR v=maybev RPAR
    { (loc,(Ty typ,v))}

--- a/lib/testType.ml
+++ b/lib/testType.ml
@@ -56,6 +56,7 @@ let size_of maximal = function
 | "short" | "int16_t" | "uint16_t" -> MachSize.Short
 | "int64_t" | "uint64_t" -> MachSize.Quad
 | "__int128_t" | "__uint128_t"
+| "__int128" | "__uint128"
 | "int128_t" | "uint128_t" -> MachSize.S128
 | "intptr_t" | "uintptr_t" | "pteval_t"
   -> maximal (* Maximal size = ptr size *)
@@ -68,6 +69,7 @@ let is_signed = function
 | "short"|"int16_t"
 | "int64_t"
 | "int128_t"
+| "__int128"
 | "intptr_t" -> true
 | _ -> false
 


### PR DESCRIPTION
Motivation: Test int128 programs generated by diy are not parsed by herd.

This patch fixes the following bugs in the int128 implementation:
- `diy7` did not parse `-type uint128_t`
- litmus tests with the initial state `_Atomic __int128 x = 0` did not parse
- `diy` generates C/C++ litmus tests using the `(u)int128_t` which not valid in LLVM/GCC. Instead we generate tests using `__(u)int128`.

A future patch will fix `herd` so that it accepts `__int128` data in AArch64 (It is conceptually a separate patch that deals with Semantics).

Tests are provided in this patch