### PR TITLE
Initial commit for generating relaxations from a cat file.

### DIFF
--- a/gen/dune
+++ b/gen/dune
@@ -2,10 +2,10 @@
 (rule (copy ../Version.ml Version.ml))
 (executables
   (names
-    readRelax atoms diycross mexpand atomize diyone nexts classify diy norm
+    readRelax atoms diycross mexpand atomize diyone nexts classify diy norm mcat2config
   )
   (public_names
-     readRelax7 atoms7 diycross7 mexpand7 atomize7 diyone7 nexts7 classify7 diy7 norm7
+     readRelax7 atoms7 diycross7 mexpand7 atomize7 diyone7 nexts7 classify7 diy7 norm7 mcat2config7
   )
   (libraries herdtools unix)
   (modules_without_implementation archLoc archRun arch_gen atom autoInterpret builder fence XXXCompile_gen rmw))

--- a/gen/mcat2config.ml
+++ b/gen/mcat2config.ml
@@ -1,0 +1,666 @@
+(** Create a set of relaxations for diy using a cat file *)
+
+
+
+open Printf
+
+let prog =
+  if Array.length Sys.argv > 0 then
+    Filename.basename Sys.argv.(0)
+  else "cat2config7"
+
+module Make
+    (O:sig
+      val verbose : int
+      val lets_to_print : string list
+      val print_tree : bool
+    end) =
+  struct
+    module ML =
+      MyLib.Make
+        (struct
+          let includes = []
+          let env =  Some "HERDLIB"
+          let libdir = Filename.concat Version.libdir "herd"
+          let debug = O.verbose > 0
+        end)
+
+    module ParserConfig = struct
+      let debug = O.verbose > 1
+      let libfind = ML.find
+    end
+    module A =
+      AArch64Arch_gen.Make
+        (struct
+          include AArch64Arch_gen.Config
+          let moreedges = !Config.moreedges
+        end)
+    module E = Edge.Make(Edge.Config)(A:Fence.S)
+    (* 
+       ---------------------------------------------------------------
+       Custom types
+       ---------------------------------------------------------------
+       
+    *)
+    open Code
+    
+    exception Failed of string
+    exception Including of AST.ins list
+
+    type extr = Code.extr 
+    
+    type atom = A.atom
+  
+    type edge = E.edge
+    
+    type edge_node = {node_val: edge; branch_list: edge_node list}
+    
+    module Parser = ParseModel.Make(ParserConfig)
+      
+    type vars = 
+      | Op2 of AST.op2 
+      | Op1 of AST.op1 
+      | Empty 
+      | Var
+      | Annotation 
+      | T of E.tedge
+      | D of dir
+      | I of ie
+      | At of A.rmw
+      | An of atom
+      | Ext of extr
+      | Imp
+      | PTE
+      | Dd of extr*(atom option)
+
+    type node = {
+      varname : AST.var;
+      vartype : vars;
+      exp_list : node list;
+    }
+    let empty_node = {varname="";vartype=Empty;exp_list=[]}
+
+       (* 
+       ---------------------------------------------------------------
+       Entry point
+       --------------------------------------------------------------- *)
+    let rec get_ast fname =
+        let fname0,(_,_,ast)  = Parser.find_parse fname in
+        let tree = get_tree ast in
+        if O.print_tree then begin
+          pp_tree tree;
+          printf "\n\n\n";
+        end;
+        
+        pp_relaxations tree;
+        ()
+    
+       (* 
+       ---------------------------------------------------------------
+       Printing functions
+       --------------------------------------------------------------- 
+       *)
+
+    and pp_relaxations tree = 
+(* pretty printing relaxations *)
+      let open AST in
+      let rec f a = 
+        match a.vartype with
+        | Op2 Seq -> begin
+          let expl = a.exp_list in
+          try 
+            let edge = matcher expl in
+            let edge = listofnode edge in
+            let edge = List.map expand_fencedp edge in
+            List.iter (fun e -> 
+              match e with
+              | _::[] -> printf "%s " (String.concat "," (List.map E.pp_edge e))
+              | _::_ -> printf "[%s] " (String.concat "," (List.map E.pp_edge e))
+              | _ -> if O.verbose > 0 then printf "matching logic output invalid"
+              ) edge;
+          with 
+          | Failed a-> begin 
+            if O.verbose > 0 then printf "An unsupported item was passed to matcher function: %s\n" a;
+          end
+          | _ -> ();
+        end
+        | Var | T _ -> begin
+          let expl = [a] in
+          try 
+            let edge = matcher expl in
+            let edge = listofnode edge in
+            let edge = List.map expand_fencedp edge in
+            List.iter (fun e -> printf "%s " (String.concat "," (List.map E.pp_edge e))) edge;
+          with 
+          | Failed a-> begin 
+            if O.verbose > 0 then printf "An unsupported item was passed to matcher function: %s\n" a;
+          end
+          | _ -> ()
+        end
+        | Op2 Union -> List.iter f a.exp_list
+        | _ -> ()
+      in
+      try
+      List.iter (fun b -> 
+        let p = (List.find (fun a -> String.equal a.varname b) tree) in
+        f p
+        ) O.lets_to_print
+      with
+      | Not_found -> printf "let statements that were asked for are not in cat file\n";
+    
+    and pp_tree tree = 
+      let open AST in
+      let pp tr =
+        let rec f a = 
+          match a.vartype with
+          | Op2 Seq -> begin 
+            try
+            printf "\n|  ";
+            List.iter (printf "%s") (pp_seq a.exp_list)  
+            with 
+            | Failed s -> if O.verbose > 0 then printf "%s\n" s;
+            | _ -> if O.verbose > 0 then printf "Unknown fail";
+          end
+          | Op2 Union -> begin
+            List.iter f a.exp_list
+          end
+          | Op2 Inter -> begin
+            printf "[%s]" (String.concat "&" (List.map (fun a -> a.varname) a.exp_list));
+          end
+          | Op1 ToId -> begin 
+            printf "%s["  a.varname;
+            List.iter f a.exp_list;
+            printf "]"
+          end
+          | Var | T _-> begin
+            printf "%s " a.varname;
+          end
+          | _ -> begin 
+            raise (Failed (sprintf "NOT IMPLEMENTED: %s\n" a.varname))
+          end in
+        printf "\n\n\n(%s)\n" tr.varname ;
+        let rec ff a =
+          match a with
+          | h::t -> begin try f h; ff t
+          with
+          | Failed s -> if O.verbose > 0 then printf "%s\n" s;
+        end
+          | [] -> () in
+
+        ff tr.exp_list in
+      List.iter pp tree
+    
+    and pp_seq exp_l = 
+      let rec f s a =
+        match a with
+        | h::t -> begin
+          match h.vartype with 
+          | Var -> f (append_string s h.varname) t
+          | Op2 AST.Inter -> begin
+            f (append_string s (sprintf "[%s]" (String.concat "&"  (List.map (fun a -> List.hd (f [""] [a])) h.exp_list)))) t;
+          end
+          | Op2 _ -> f s (h.exp_list@t)
+          | Op1 _ -> f (f s h.exp_list) t
+          | Empty -> raise (Failed "Empty var")
+          | _ -> f (append_string s h.varname) t
+        end
+        | [] -> s  in 
+      f [""] exp_l
+
+    and append_string l ex = 
+      let rec f ll =
+        match ll with
+        | h::t -> (h^";"^ex)::(f t)
+        | [] -> [] in 
+      f l
+      (*
+    ------------------------------------------
+      Parse AST and make into custom type
+    ------------------------------------------   
+    *)
+    and get_ins ins =
+      let open AST in
+      match ins with
+      | Rec (_,bindl,_)
+      | Let (_, bindl) -> begin
+        try get_tags (List.hd bindl) with
+        | Failed s -> raise (Failed s)
+        | _ -> raise (Failed "unknown fail")
+      end
+      (* | Include (_,fname) -> 
+        let _,(_,_,ast)  = Parser.find_parse fname in
+        raise (Including ast) *)
+      | _ -> raise (Failed "instruction not supported\n" )
+    
+    and get_tags (_,varname, expression) = 
+      let open AST in
+      let varname = match varname with | Pvar str_var -> str_var | _ -> Some "" in
+      let varname = Option.get varname in
+      let ins, vartype = match expression with
+      | Op (_, op, expl) -> begin
+        match op with
+        | Union -> (List.map (get_vars varname) expl),Op2 AST.Union
+        | Seq -> (List.map (get_vars varname) expl),Op2 AST.Seq
+        | Inter -> (List.map (get_vars varname) expl),Op2 AST.Inter
+        | _ -> raise (Failed (sprintf "%s not supported\n " (pp_op2 op)))
+      end
+      | Var (_,_)-> [get_vars varname expression], Var
+      | _ -> raise (Failed (sprintf "operation not supported\n "))
+      in {varname=varname; exp_list=ins; vartype=vartype}
+
+    and get_vars varname expression = 
+      let open AST in
+      let rec f expr = 
+        match expr with
+        | Op (_, op, expl) -> begin
+          {varname=(pp_op2 op)^":";exp_list=(List.map f expl); vartype=Op2 op}
+        end
+        | Op1 (_, op, expl) -> {varname=(pp_op1 op)^":";exp_list=[f expl]; vartype=Op1 op}
+        | Var (_, var) ->
+          if (String.equal var varname) then {varname="recursive";exp_list=[];vartype=Empty}
+          else {varname=var;exp_list=[]; vartype=Var}
+        | App (_,exp1,exp2) -> {varname="App:";exp_list=(List.map f (exp1::[exp2]));vartype=Empty}
+        | _ -> {varname=("empty or: "^(pp_exp expr));exp_list=[];vartype=Empty} in
+      f expression
+(* 
+       ---------------------------------------------------------------
+       Expand sequences and replace non-primitive variables
+       --------------------------------------------------------------- 
+*)
+    and apply_expand ?(second) tree =
+      let f a = 
+        let tree = match second with
+        | None -> tree
+        | Some t -> t in
+        match a.vartype with
+        | Op2 AST.Seq | Op2 AST.Inter ->
+          {varname=a.varname;
+          vartype=Op2 AST.Union;
+          exp_list= expand tree {varname=a.varname;vartype=a.vartype;exp_list=unroll_inter a.exp_list}
+          }
+        | Op2 AST.Union | _ ->
+          {varname=a.varname;
+          vartype=Op2 AST.Union;
+          exp_list=List.concat (List.map (expand tree) a.exp_list)
+          } in
+      List.map f tree
+
+    and expand tree exp =
+    (* expand each element in a let statement, expanding unions and emplacing let statements*)
+      let exp_l = exp.exp_list in
+      let rec f a l  =
+        match a with
+        | h::t -> begin
+          match h.vartype with
+          | Op2 AST.Union -> 
+            List.concat (List.map (fun aa -> f (aa::t) l) h.exp_list)
+          | Op1 AST.ToId ->
+            List.concat (List.map (fun aa -> f  (aa::t) l) h.exp_list)
+          | Op2 AST.Inter ->
+            let hexp = unroll_inter h.exp_list in
+            let hexp = f hexp [{varname="Inter:";vartype=Op2 AST.Inter;exp_list=[]}] in
+            List.concat (List.map (fun a -> f t (extend_node l a)) hexp)
+          | Op2 AST.Seq -> 
+            f (h.exp_list@t) l
+          | Var ->
+            let br = check_lets tree h in
+            begin match br.vartype with 
+            | Var -> begin
+              let vtype = 
+                try match_var br with
+                | Failed _ -> Var
+                | _ -> Var in
+              f t (extend_node l {varname=br.varname;vartype=vtype;exp_list=[]})
+            end
+            | _ -> 
+              let bre = List.concat (List.map (expand tree) br.exp_list) in
+              f ({varname=br.varname;vartype=br.vartype;exp_list=bre}::t) l
+            end
+          | _ -> f t (extend_node l h)
+
+        end
+        | [] -> l in
+      match exp.vartype with
+      | Op2 AST.Seq -> f exp_l [{varname="Seq:";vartype=Op2 AST.Seq;exp_list=[]}]
+      | Op1 AST.ToId -> f exp_l [{varname="ToId:";vartype=Op1 AST.ToId;exp_list=[]}]
+      | Op2 AST.Inter -> f exp_l [{varname="Inter:";vartype=Op2 AST.Inter;exp_list=[]}]
+      | Var -> let br = check_lets tree exp in begin
+        match br.exp_list with
+        | [] -> 
+          let vtype = 
+            try match_var br with
+            | Failed _ -> Var
+            | _ -> Var in
+          [{varname=br.varname;vartype=vtype;exp_list=[]}]
+        | _::_ -> List.concat (List.map (expand tree) br.exp_list)
+      end
+      | _ -> [exp]
+      
+    and extend_node l ex =
+      let extend_expl ll = {varname=ll.varname;vartype=ll.vartype;exp_list=(ll.exp_list@[ex])} in 
+      List.map extend_expl l
+    
+    and check_lets tree var = 
+      let rec f tr =
+        match tr with
+        | h::t -> begin
+          if (String.equal h.varname var.varname) then begin
+            h 
+          end else f t
+        end
+        | [] -> var in
+      f tree
+
+    (*
+    ------------------------------------------
+      match cumulative edges
+    ------------------------------------------   
+    *)
+
+    and expand_fencedp el =
+    (* expand cumulative macros*)
+      let open E in
+      let rec f e l = 
+        match e with
+        | [] -> l
+        | h::[] -> h::l
+        | h::h2::t -> begin 
+          match [h.E.edge;h2.E.edge] with
+          |  [Dp (dp, sd, _);_] -> begin
+            match [h;h2] with
+            | [{E.edge=Dp ((A.D.CTRLISYNC,A.NoCsel),_,_); E.a1=a1; E.a2=_;};
+               {E.edge=Po (_,_,e2); E.a1=_; E.a2=a2;}] ->
+              {E.edge=Dp (dp,sd,e2); E.a1=a1; E.a2=a2}::(f t l)
+            | [{E.edge=Dp ((A.D.CTRL,_),_,_); a1=a1; a2=_;};
+               {E.edge=Fenced (A.Barrier A.ISB,_,_,e2); a1=_; a2=a2;}] ->
+              f ({E.edge=Dp ((A.D.CTRLISYNC,A.NoCsel),sd,e2); a1=a1; a2=a2}::t) l
+            | _ -> h::(f (h2::t) l)
+            end
+          | [Fenced (fence, sd, extr1, _);_ ]->begin
+            match [h;h2] with
+            | [{E.edge=Fenced _; a1=a1; a2=_;};
+                {E.edge=Po (_,_,e2); a1=_; a2=a2;}] ->
+              {E.edge=Fenced (fence,sd,extr1,e2); a1=a1; a2=a2}::(f t l)
+            | _ -> h::(f (h2::t) l)
+            end
+          | [(Po _);(Fenced (fence, sd, _, extr2))] ->begin
+            match [h;h2]@t with
+            | [{E.edge=Po (_,e1,_); a1=a1; a2=_;};
+               {E.edge=Fenced _; a1=_; a2=_;};
+               {E.edge=Po (_,_,e2); a1=_; a2=a2;}] ->
+              {E.edge=Fenced (fence,sd,e1,e2); a1=a1; a2=a2}::(f (List.tl t) l)
+            | [{E.edge=Po (_,e1,_); a1=a1; a2=_;};
+               {E.edge=Fenced _; a1=_; a2=a2;}] ->
+              {E.edge=Fenced (fence,sd,e1,extr2); a1=a1; a2=a2}::(f t l)
+            | _ -> h::(f (h2::t) l)
+          end
+          | _ -> f (h2::t) l
+        end
+      in f el []
+    
+      (*
+    ------------------------------------------
+      logic for matching
+      - parse letlines into edge type
+      - match sequences of edge's into single or composite relaxations
+    ------------------------------------------   
+    *)
+    
+    and matcher expl = 
+    (* translate letline sequences to E.edge type. 
+       using a recursive tree to represent the different ways each edge can be represented*)
+      let open AST in
+      let open E in
+      let rec f l prev = 
+        match l with 
+        | h::h2::t -> 
+        begin
+          let a1, a2, extr1, extr2 = extract_diratom prev h2 in
+          try 
+            let e a = match h.vartype with
+              | T (Po (_,_,_)) -> E.Po (a,extr1,extr2)
+              | T (Dp (dp, _, _)) -> E.Dp (dp,a,extr2)
+              | T (Fenced (fence,_,_,_)) -> E.Fenced (fence,a,extr1,extr2)
+              | _ -> raise (Failed "") in
+            List.map (fun a -> 
+                      {node_val={E.edge=e a;E.a1=a1;E.a2=a2};
+                      branch_list=f (h2::t) h}
+                      ) [Same; Diff]
+          with
+          | Failed _ -> match h.vartype with
+            | Op2 Inter -> 
+              begin try 
+                let h = match_inter h in
+                  f (h2::t) h
+              with
+                | Failed s -> raise (Failed s)
+                | _ -> raise (Failed "unknown failure in inter\n")
+              end
+            | Var -> raise (Failed (sprintf "Unknown Variable: %s\n" h.varname))
+            | _ -> f (h2::t) h
+        end
+        | h::[] -> 
+        begin 
+          let a1, a2, extr1, extr2 = extract_diratom prev empty_node in 
+          try
+            let e a = match h.vartype with
+            | T (Po (_,_,_)) -> E.Po (a,extr1,extr2)
+            | T (Dp (dp, _, _)) -> E.Dp (dp,a,extr2)
+            | T (Fenced (fence,_,_,_)) ->E.Fenced (fence,a,extr1,extr2)
+            | _ -> raise (Failed "") in
+            List.map (fun a -> 
+                      {node_val={E.edge= e a; E.a1=a1;E.a2=a2};
+                      branch_list=[]}
+                      ) [Same; Diff]
+          with
+            | Failed _ -> []
+            | _ -> raise (Failed "Unknown fail")
+        end
+        | [] -> raise (Failed "cannot provide empty list")
+      in f expl empty_node
+    
+    and listofnode nodel = 
+      let rec f node =
+        match node.branch_list with
+        | h::t ->
+          List.concat (List.map (fun a -> 
+                       List.map (fun b -> node.node_val::b)
+                       (f a)
+                       ) (h::t))
+        | [] -> [[node.node_val]] in
+      List.concat (List.map f nodel)
+    
+    and check_prev a = 
+      match a with
+      | Empty -> Some (A.Plain None,None)
+      | An b -> Some b
+      | Dd (_,an) -> an
+      | _ -> None
+    and check_if_dir a =
+      match a with
+      | D R ->  Dir R
+      | D W ->  Dir W
+      | Ext NoDir -> NoDir
+      | Dd (r,_) -> r
+      | _ -> Irr
+    
+    and match_inter a =
+      match a.exp_list with
+      | h::h2::h3::[] -> begin
+        match (check_if_dir h.vartype),h2.vartype,h3.vartype with
+        | Dir R, PTE, Imp -> {vartype= Dd (Dir R, Some (A.Pte A.Read, None));exp_list=[];varname="inter"}
+        | Dir R, An (A.Tag, None), Imp ->{vartype= Dd (Dir R, Some (A.Tag, None));exp_list=[];varname="inter"}
+        | _ -> raise (Failed "wrong inter")
+      end
+      | h::h2::[] -> raise (Failed "wrong inter")
+      | _ -> raise (Failed "wrong inter")
+    
+    and unroll_inter a = 
+    let open AST in
+      let f l =
+        match l.vartype with 
+        | Op2 Inter -> l.exp_list
+        | _ -> [l] in
+      List.concat (List.map f a)
+    
+    and extract_diratom prev next =
+      let extr1 = check_if_dir prev.vartype in
+      let extr2 = check_if_dir next.vartype in
+      
+      let a1 = check_prev prev.vartype in
+      let a2 = check_prev next.vartype in
+      let extr1 = check_dirfroma a1 extr1 in
+      let extr2 = check_dirfroma a2 extr2 in
+      a1,a2,extr1,extr2
+        
+    (*
+    ------------------------------------------
+    entry point for constructing tree
+    ------------------------------------------   
+    *)
+    and get_tree ast = 
+      let rec tree l = 
+        match l with
+        | h::t -> begin try
+          (get_ins h)::(tree t)
+        with
+          | Failed s -> begin 
+            if O.verbose > 0 then 
+              (printf "%s" s)
+          end;
+            (tree t)
+          | Including a -> tree (a@t)
+          | _ -> (tree t)
+        end
+        | [] -> [] in
+
+      let tree = apply_expand (tree ast) in
+      tree  
+    
+    (*
+    ------------------------------------------
+    helper functions
+    ------------------------------------------   
+    *)
+    and match_var v = 
+    (* Exp, Imp and PTE have been included as placeholders. rmw has not yet been included*)
+    let open A in
+    let open E in
+      match v.vartype with
+      | Var -> begin 
+        match v.varname with
+        | "R"-> D R
+        | "W" -> D W
+        | "M" -> Ext Irr
+        | "L" -> An (A.Rel None,None)
+        | "P" -> An (A.plain,None)
+        | "A" -> An (A.Acq None,None)
+        | "Q" -> An (A.AcqPc None,None)
+        | "T" -> An (A.Tag, None)
+        | "Exp" -> An (A.Pte Read, None)
+        | "Imp" -> Imp
+        | "PTE" -> PTE
+        | "po" -> T (Po (Same,Irr,Irr))
+        | "addr" -> T (Dp ((A.D.ADDR,A.NoCsel), Same, Irr))
+        | "ctrl" -> T (Dp ((A.D.CTRL,A.NoCsel), Same, Irr))
+        | "data" -> T (Dp ((A.D.DATA,A.NoCsel), Same, Irr))
+        | "DMB.ISH" -> T (Fenced (Barrier (DMB (ISH,FULL)) ,Same, Irr, Irr))
+        | "DMB.OSH" -> T (Fenced (Barrier (DMB (OSH,FULL)),Same, Irr, Irr)) 
+        | "DMB.SY" -> T (Fenced (Barrier (DMB (SY,FULL)),Same, Irr, Irr)) 
+        | "DSB.ISH" -> T (Fenced (Barrier (DSB (ISH,FULL)),Same, Irr, Irr)) 
+        | "DSB.OSH" -> T (Fenced (Barrier (DSB (OSH,FULL)),Same, Irr, Irr)) 
+        | "DSB.SY" -> T (Fenced (Barrier (DSB (SY,FULL)),Same, Irr, Irr))  
+        | "ISB" -> T (Fenced (Barrier (ISB),Same, Irr, Irr))  
+        | "rfi" -> T (Rf Int)
+        | "co" | "fr" -> T (Fr Int)
+        | _ -> raise (Failed (sprintf "variable not supported: %s\n" v.varname))
+      end
+      | _ -> v.vartype
+
+
+    and check_dirfroma letl a = 
+      match letl with
+      | Some (A.Acq None,None) | Some (A.AcqPc None,None) -> Dir R
+      | Some (A.Rel None,None) -> Dir W
+      | _ -> a
+
+    and pp_exp a = 
+      let open AST in 
+      match a with 
+      | Konst _ -> "Konst"
+      | Tag _ -> "Tag"
+      | Var _ -> "Var"
+      | Op1 _ -> "Op1"
+      | Op _ -> "Op"
+      | App _ -> "App"
+      | Bind _ -> "Bind"
+      | BindRec _  -> "BindRec"
+      | Fun _ -> "Fun"
+      | ExplicitSet _ -> "ExplicitSet"
+      | Match _ -> "Match"
+      | MatchSet _ -> "MatchSet"
+      | Try _ -> "Try"
+      | If _ -> "If"
+    
+    and pp_op2 a = 
+      let open AST in
+      match a with
+      | Union -> "Union"
+      | Inter -> "Inter"
+      | Diff -> "Diff"
+      | Seq -> "Seq"
+      | Cartesian -> "Cartesian"
+      | Add -> "Add"
+      | Tuple -> "Tuple"
+
+    and pp_op1 a = 
+      let open AST in 
+      match a with
+      | Plus -> "Plus"
+      | Star -> "Star"
+      | Opt -> "Opt"
+      | Comp -> "Comp"
+      | Inv -> "Inv"
+      | ToId -> "ToId"
+
+(*
+----------------------------------------------
+entry 
+----------------------------------------------   
+
+*)
+    let zyva name =
+      try get_ast name
+      with
+      | Misc.Fatal msg -> printf "ERROR %s\n%!" msg
+      | Misc.Exit -> ()
+  end
+
+let verbose = ref 0
+let lets_to_print = ref []
+let arg = ref []
+let print_tree = ref false
+let setarg name = arg := !arg @ [name]
+
+let opts =
+  [
+   "-v",Arg.Unit (fun () -> incr verbose), " be verbose";
+   "-let",Arg.String (fun s -> lets_to_print := !lets_to_print @ [s]),
+   "<statement> print out selected let statements";
+   "-tree",Arg.Unit (fun () -> print_tree := true), "print expanded cat file";
+  ]
+
+let () =
+  Arg.parse opts setarg
+    (sprintf "Usage: %s [options]* cats*" prog)
+
+
+module Z =
+  Make
+    (struct
+      let verbose = !verbose
+      let lets_to_print = !lets_to_print
+      let print_tree = !print_tree
+    end)
+
+let () = List.iter Z.zyva !arg ; exit 0

--- a/gen/mcat2config.ml
+++ b/gen/mcat2config.ml
@@ -4,712 +4,828 @@
 open Printf
 
 let prog =
-  if Array.length Sys.argv > 0 then
-    Filename.basename Sys.argv.(0)
+  if Array.length Sys.argv > 0 then Filename.basename Sys.argv.(0)
   else "cat2config7"
 
-module Make
-    (O:sig
-      val verbose : int
-      val lets_to_print : string list
-      val print_tree : bool
-    end) =
-  struct
-    module ML =
-      MyLib.Make
-        (struct
-          let includes = []
-          let env =  Some "HERDLIB"
-          let libdir = Filename.concat Version.libdir "herd"
-          let debug = O.verbose > 0
-        end)
+module Make (O : sig
+  val verbose : int
+  val lets_to_print : string list
+  val print_tree : bool
+end) =
+struct
+  module ML = MyLib.Make (struct
+    let includes = []
+    let env = Some "HERDLIB"
+    let libdir = Filename.concat Version.libdir "herd"
+    let debug = O.verbose > 0
+  end)
 
-    module ParserConfig = struct
-      let debug = O.verbose > 1
-      let libfind = ML.find
-    end
-    module A =
-      AArch64Arch_gen.Make
-        (struct
-          include AArch64Arch_gen.Config
-          let moreedges = !Config.moreedges
-        end)
-    module E = Edge.Make(Edge.Config)(A:Fence.S)
-    (* 
-       ---------------------------------------------------------------
-       Custom types
-       ---------------------------------------------------------------
-       
-    *)
-    open Code
-    
-    exception NotImplemented of string
-    exception Skip of string
+  module ParserConfig = struct
+    let debug = O.verbose > 1
+    let libfind = ML.find
+  end
 
-    type extr = Code.extr 
-    
-    type atom = A.atom
-  
-    type edge = E.edge
-    
-    type edge_node = {node_val: edge; branch_list: edge_node list}
-    
-    module Parser = ParseModel.Make(ParserConfig)
+  module A = AArch64Arch_gen.Make (struct
+    include AArch64Arch_gen.Config
 
-    type 'a union = Union of 'a list
-    type 'a sequence = Sequence of 'a list
-    type 'a intersection =  Intersection of 'a list
-    type var = string
-      (*
+    let moreedges = !Config.moreedges
+  end)
+
+  module E = Edge.Make (Edge.Config) ((A : Fence.S))
+
+  (*
+      ---------------------------------------------------------------
+      Custom types
+      ---------------------------------------------------------------
+  *)
+  open Code
+
+  exception NotImplemented of string
+  exception Skip of string
+
+  type extr = Code.extr
+  type atom = A.atom
+  type edge = E.edge
+  type edge_node = { node_val : edge; branch_list : edge_node list }
+
+  module Parser = ParseModel.Make (ParserConfig)
+
+  type 'a union = Union of 'a list
+  type 'a sequence = Sequence of 'a list
+  type 'a intersection = Intersection of 'a list
+  type var = string
+  (*
        ir is used to represent the let statements
        each let statement consists of a union of sequences. Each sequence is a list of intersections
        where single variables are represented as intersections of length 1
       *)
-    type ir = var intersection sequence union
-      (* let_statements is the list of all let statements in an AST*)
-    type let_statements = (string * ir) list
 
-    type edge_ir =
+  type ir = var intersection sequence union
+  (* let_statements is the list of all let statements in an AST*)
+
+  type let_statements = (string * ir) list
+
+  type edge_ir =
     | Tedge of E.tedge * string
     | D of dir * string
     | Atom of atom * string
     | Empty of string
     | Imp of string
     | PTE of string
-    | D_atom of extr*(atom option) * string
+    | D_atom of extr * atom option * string
     | Ext of extr * string
     | Lrs of string
 
-    (*
+  (*
     ------------------------------------------
     helper functions
     ------------------------------------------
     *)
-    let match_var v: edge_ir union =
-      (* Exp, Imp and PTE have been included as placeholders. *)
-      let open A in
-      let open E in
-      let matching =
-        match v with
-        | "R"-> [D (R, v)]
-        | "W" -> [D (W, v)]
-        | "M" -> [Ext (Irr, v)]
-        | "L" -> [Atom ((A.Rel None,None), v)]
-        | "P" -> [Atom ((A.plain,None), v)]
-        | "A" -> [Atom ((A.Acq None,None), v)]
-        | "Q" -> [Atom ((A.AcqPc None,None), v)]
-        | "T" -> [Atom ((A.Tag, None), v)]
-        | "Exp" -> [Atom ((A.Pte Read, None), v)]
-        | "Imp" -> [Imp v]
-        | "PTE" -> [PTE v]
-        | "po" -> [Tedge ((Po (Same,Irr,Irr)), v)]
-        | "lrs" -> [Lrs v ]
-        | "addr" -> [Tedge ((Dp ((A.D.ADDR,A.NoCsel), Same, Irr)), v)]
-        | "ctrl" -> [Tedge ((Dp ((A.D.CTRL,A.NoCsel), Same, Irr)), v)]
-        | "data" -> [Tedge ((Dp ((A.D.DATA,A.NoCsel), Same, Irr)), v)]
-        | "DMB.ISH" -> [Tedge ((Fenced (Barrier (DMB (ISH,FULL)) ,Same, Irr, Irr)), v)]
-        | "DMB.OSH" -> [Tedge ((Fenced (Barrier (DMB (OSH,FULL)),Same, Irr, Irr)), v) ]
-        | "DMB.SY" -> [Tedge ((Fenced (Barrier (DMB (SY,FULL)),Same, Irr, Irr)), v) ]
-        | "DSB.ISH" -> [Tedge ((Fenced (Barrier (DSB (ISH,FULL)),Same, Irr, Irr)), v)]
-        | "DSB.OSH" -> [Tedge ((Fenced (Barrier (DSB (OSH,FULL)),Same, Irr, Irr)), v) ]
-        | "DSB.SY" -> [Tedge ((Fenced (Barrier (DSB (SY,FULL)),Same, Irr, Irr)), v)  ]
-        | "ISB" -> [Tedge ((Fenced (Barrier (ISB),Same, Irr, Irr)), v)  ]
-        | "rfi" -> [Tedge ((Rf Int), v)]
-        | "lxsx" -> [Tedge (Rmw A.LrSc, "lrsc")]
-        | "co" -> [
-          Tedge ((Ws Int), v);
-          Tedge ((Ws Ext), v)
-        ]
-        | "fr" -> [
-          Tedge ((Fr Int), v);
-          Tedge ((Fr Ext), v)
-        ]
-        | "fri" -> [Tedge ((Fr Int), v)]
-        | "fre" -> [Tedge ((Fr Ext), v)]
-        | "rfe" -> [Tedge ((Rf Ext), v)]
-        | "coe" -> [Tedge ((Ws Ext), v)]
-        | "coi" -> [Tedge ((Ws Int), v)]
-        | "amo" -> [
-          Tedge (Rmw A.Swp, "Amo.Swp");
-          Tedge (Rmw A.Cas, "Amo.Cas");
+  let lxsx = [ Tedge (Rmw A.LrSc, "lrsc") ]
 
-          Tedge (Rmw (LdOp A_ADD), "Amo.LdAdd");
-          Tedge (Rmw (LdOp A_EOR), "Amo.LdEor");
-          Tedge (Rmw (LdOp A_SET), "Amo.LdSet");
-          Tedge (Rmw (LdOp A_CLR), "Amo.LdClr");
+  let amo =
+    [
+      Tedge (Rmw A.Swp, "Amo.Swp");
+      Tedge (Rmw A.Cas, "Amo.Cas");
+      Tedge (Rmw (LdOp A_ADD), "Amo.LdAdd");
+      Tedge (Rmw (LdOp A_EOR), "Amo.LdEor");
+      Tedge (Rmw (LdOp A_SET), "Amo.LdSet");
+      Tedge (Rmw (LdOp A_CLR), "Amo.LdClr");
+      Tedge (Rmw (StOp A_ADD), "Amo.StAdd");
+      Tedge (Rmw (StOp A_EOR), "Amo.StEor");
+      Tedge (Rmw (StOp A_SET), "Amo.StSet");
+      Tedge (Rmw (StOp A_CLR), "Amo.StClr");
+    ]
 
-          Tedge (Rmw (StOp A_ADD), "Amo.StAdd");
-          Tedge (Rmw (StOp A_EOR), "Amo.StEor");
-          Tedge (Rmw (StOp A_SET), "Amo.StSet");
-          Tedge (Rmw (StOp A_CLR), "Amo.StClr")
-        ]
-        | _ -> [Empty v]
-      in Union matching
+  let match_var v : edge_ir union =
+    (* Exp, Imp and PTE have been included as placeholders. *)
+    let open A in
+    let open E in
+    let matching =
+      match v with
+      | "R" -> [ D (R, v) ]
+      | "W" -> [ D (W, v) ]
+      | "M" -> [ Ext (Irr, v) ]
+      | "L" -> [ Atom ((A.Rel None, None), v) ]
+      | "P" -> [ Atom ((A.plain, None), v) ]
+      | "A" -> [ Atom ((A.Acq None, None), v) ]
+      | "Q" -> [ Atom ((A.AcqPc None, None), v) ]
+      | "T" -> [ Atom ((A.Tag, None), v) ]
+      | "Exp" -> [ Atom ((A.Pte Read, None), v) ]
+      | "Imp" -> [ Imp v ]
+      | "PTE" -> [ PTE v ]
+      | "po" -> [ Tedge (Po (Same, Irr, Irr), v) ]
+      | "lrs" -> [ Lrs v ]
+      | "addr" -> [ Tedge (Dp ((A.D.ADDR, A.NoCsel), Same, Irr), v) ]
+      | "ctrl" -> [ Tedge (Dp ((A.D.CTRL, A.NoCsel), Same, Irr), v) ]
+      | "data" -> [ Tedge (Dp ((A.D.DATA, A.NoCsel), Same, Irr), v) ]
+      | "DMB.ISH" ->
+          [ Tedge (Fenced (Barrier (DMB (ISH, FULL)), Same, Irr, Irr), v) ]
+      | "DMB.ISHLD" ->
+          [ Tedge (Fenced (Barrier (DMB (ISH, LD)), Same, Irr, Irr), v) ]
+      | "DMB.ISHST" ->
+          [ Tedge (Fenced (Barrier (DMB (ISH, ST)), Same, Irr, Irr), v) ]
+      | "DMB.OSH" ->
+          [ Tedge (Fenced (Barrier (DMB (OSH, FULL)), Same, Irr, Irr), v) ]
+      | "DMB.OSHLD" ->
+          [ Tedge (Fenced (Barrier (DMB (OSH, LD)), Same, Irr, Irr), v) ]
+      | "DMB.OSHST" ->
+          [ Tedge (Fenced (Barrier (DMB (OSH, ST)), Same, Irr, Irr), v) ]
+      | "DMB.SY" ->
+          [ Tedge (Fenced (Barrier (DMB (SY, FULL)), Same, Irr, Irr), v) ]
+      | "DMB.LD" ->
+          [ Tedge (Fenced (Barrier (DMB (SY, LD)), Same, Irr, Irr), v) ]
+      | "DMB.ST" ->
+          [ Tedge (Fenced (Barrier (DMB (SY, ST)), Same, Irr, Irr), v) ]
+      | "DSB.ISH" ->
+          [ Tedge (Fenced (Barrier (DSB (ISH, FULL)), Same, Irr, Irr), v) ]
+      | "DSB.ISHLD" ->
+          [ Tedge (Fenced (Barrier (DSB (ISH, LD)), Same, Irr, Irr), v) ]
+      | "DSB.ISHST" ->
+          [ Tedge (Fenced (Barrier (DSB (ISH, ST)), Same, Irr, Irr), v) ]
+      | "DSB.OSH" ->
+          [ Tedge (Fenced (Barrier (DSB (OSH, FULL)), Same, Irr, Irr), v) ]
+      | "DSB.OSHLD" ->
+          [ Tedge (Fenced (Barrier (DSB (OSH, LD)), Same, Irr, Irr), v) ]
+      | "DSB.OSHST" ->
+          [ Tedge (Fenced (Barrier (DSB (OSH, ST)), Same, Irr, Irr), v) ]
+      | "DSB.SY" ->
+          [ Tedge (Fenced (Barrier (DSB (SY, FULL)), Same, Irr, Irr), v) ]
+      | "DSB.LD" ->
+          [ Tedge (Fenced (Barrier (DSB (SY, LD)), Same, Irr, Irr), v) ]
+      | "DSB.ST" ->
+          [ Tedge (Fenced (Barrier (DSB (SY, ST)), Same, Irr, Irr), v) ]
+      | "ISB" -> [ Tedge (Fenced (Barrier ISB, Same, Irr, Irr), v) ]
+      | "rfi" -> [ Tedge (Rf Int, v) ]
+      | "lxsx" -> lxsx
+      | "co" -> [ Tedge (Ws Int, v); Tedge (Ws Ext, v) ]
+      | "fr" -> [ Tedge (Fr Int, v); Tedge (Fr Ext, v) ]
+      | "fri" -> [ Tedge (Fr Int, v) ]
+      | "fre" -> [ Tedge (Fr Ext, v) ]
+      | "rfe" -> [ Tedge (Rf Ext, v) ]
+      | "coe" -> [ Tedge (Ws Ext, v) ]
+      | "coi" -> [ Tedge (Ws Int, v) ]
+      | "amo" -> amo
+      | "rmw" -> lxsx @ amo
+      | _ -> [ Empty v ]
+    in
+    Union matching
 
-    let check_dirfroma letl a =
-      match letl with
-      | Some (A.Acq None,None) | Some (A.AcqPc None,None) -> Dir R
-      | Some (A.Rel None,None) -> Dir W
-      | _ -> a
+  let check_dirfroma letl a =
+    match letl with
+    | Some (A.Acq None, None) | Some (A.AcqPc None, None) -> Dir R
+    | Some (A.Rel None, None) -> Dir W
+    | _ -> a
 
-    let pp_exp a =
-      let open AST in
-      match a with
-      | Konst _ -> "Konst"
-      | Tag _ -> "Tag"
-      | Var _ -> "Var"
-      | Op1 _ -> "Op1"
-      | Op _ -> "Op"
-      | App _ -> "App"
-      | Bind _ -> "Bind"
-      | BindRec _  -> "BindRec"
-      | Fun _ -> "Fun"
-      | ExplicitSet _ -> "ExplicitSet"
-      | Match _ -> "Match"
-      | MatchSet _ -> "MatchSet"
-      | Try _ -> "Try"
-      | If _ -> "If"
+  let pp_exp a =
+    let open AST in
+    match a with
+    | Konst _ -> "Konst"
+    | Tag _ -> "Tag"
+    | Var _ -> "Var"
+    | Op1 _ -> "Op1"
+    | Op _ -> "Op"
+    | App _ -> "App"
+    | Bind _ -> "Bind"
+    | BindRec _ -> "BindRec"
+    | Fun _ -> "Fun"
+    | ExplicitSet _ -> "ExplicitSet"
+    | Match _ -> "Match"
+    | MatchSet _ -> "MatchSet"
+    | Try _ -> "Try"
+    | If _ -> "If"
 
-    let pp_op2 a =
-      let open AST in
-      match a with
-      | Union -> "Union"
-      | Inter -> "Inter"
-      | Diff -> "Diff"
-      | Seq -> "Seq"
-      | Cartesian -> "Cartesian"
-      | Add -> "Add"
-      | Tuple -> "Tuple"
+  let pp_op2 a =
+    let open AST in
+    match a with
+    | Union -> "Union"
+    | Inter -> "Inter"
+    | Diff -> "Diff"
+    | Seq -> "Seq"
+    | Cartesian -> "Cartesian"
+    | Add -> "Add"
+    | Tuple -> "Tuple"
 
-    let pp_op1 a =
-      let open AST in
-      match a with
-      | Plus -> "Plus"
-      | Star -> "Star"
-      | Opt -> "Opt"
-      | Comp -> "Comp"
-      | Inv -> "Inv"
-      | ToId -> "ToId"
+  let pp_op1 a =
+    let open AST in
+    match a with
+    | Plus -> "Plus"
+    | Star -> "Star"
+    | Opt -> "Opt"
+    | Comp -> "Comp"
+    | Inv -> "Inv"
+    | ToId -> "ToId"
 
-    let pp_edge_ir a =
-      match a with
-      | Tedge _ -> "tedge"
-      | D _ -> "D"
-      | Atom _ -> "Atom"
-      | Empty _ -> "Empty"
-      | Imp _ -> "Imp"
-      | PTE _ -> "PTE"
-      | D_atom _ -> "D_atom"
-      | Ext _ -> "ext"
-      | Lrs _ -> "lrs"
+  let pp_edge_ir a =
+    match a with
+    | Tedge _ -> "tedge"
+    | D _ -> "D"
+    | Atom _ -> "Atom"
+    | Empty _ -> "Empty"
+    | Imp _ -> "Imp"
+    | PTE _ -> "PTE"
+    | D_atom _ -> "D_atom"
+    | Ext _ -> "ext"
+    | Lrs _ -> "lrs"
 
-    let empty_expr = Empty ""
+  let empty_expr = Empty ""
 
-    (* ir, sequence and inter helper functions*)
-    let make_sequence expl =
-      Sequence expl
-    let intersection_singleton exp =
-      Intersection [exp]
-    let concatenate_sequences (Sequence s1) (Sequence s2) =
-      Sequence (s1@s2)
-    let ir_single_inter: var intersection -> ir = fun inter -> Union [ Sequence [ inter ] ]
-    let ir_single_var: var -> ir = fun var -> ir_single_inter (Intersection [ var ])
-    let union_concat_map (f: 'a -> 'b union) (Union xs: 'a union): 'b union =
-      let f' x = let Union ys = f x in ys in
-      Union (Misc.concat_map f' xs)
-    let union_map f (Union xs): 'b union =
-      let f' x = let ys = f x in ys in
-      Union (List.map f' xs)
-    let rec union_fold_cross l f =
+  let get_option_list l =
+    let f a = match a with Some x -> [ x ] | None -> [] in
+    Misc.concat_map f l
+
+  let get_option a = List.hd (match a with Some x -> [ x ] | None -> [])
+
+  (* ir, sequence and inter helper functions*)
+  let make_sequence expl = Sequence expl
+  let intersection_singleton exp = Intersection [ exp ]
+  let concatenate_sequences (Sequence s1) (Sequence s2) = Sequence (s1 @ s2)
+
+  let ir_single_inter : var intersection -> ir =
+   fun inter -> Union [ Sequence [ inter ] ]
+
+  let ir_single_var : var -> ir =
+   fun var -> ir_single_inter (Intersection [ var ])
+
+  let union_concat_map (f : 'a -> 'b union) (Union xs : 'a union) : 'b union =
+    let f' x =
+      let (Union ys) = f x in
+      ys
+    in
+    Union (Misc.concat_map f' xs)
+
+  let union_map f (Union xs) : 'b union =
+    let f' x =
+      let ys = f x in
+      ys
+    in
+    Union (List.map f' xs)
+
+  let rec union_fold_cross l f =
+    match l with
+    | [] -> [ [] ]
+    | hd :: tl ->
+        let (Union expanded_hd) = f hd in
+        let expanded_tl = union_fold_cross tl f in
+        Misc.concat_map
+          (fun hd_item ->
+            List.map (fun tl_item -> hd_item :: tl_item) expanded_tl)
+          expanded_hd
+
+  let rec fold_cross l f =
+    match l with
+    | [] -> [ [] ]
+    | hd :: tl ->
+        let expanded_hd = f hd in
+        let expanded_tl = fold_cross tl f in
+        Misc.concat_map
+          (fun hd_item ->
+            List.map (fun tl_item -> hd_item :: tl_item) expanded_tl)
+          expanded_hd
+
+  let match_inter (Union expl) =
+    match expl with
+    | [ h; h2 ] -> (
+        match (h, h2) with
+        | D (R, _), Atom ((A.Tag, None), _) ->
+            D_atom (Dir R, Some (A.Tag, None), "tag read")
+        | _ -> raise (NotImplemented "inter not implemented in matcher"))
+    | [ h; h2; h3 ] -> (
+        match (h, h2, h3) with
+        | D (R, _), PTE _, Imp _ ->
+            D_atom (Dir R, Some (A.Pte A.Read, None), "ImpPTE Read")
+        | D (R, _), Atom ((A.Tag, None), _), Imp _ ->
+            D_atom (Dir R, Some (A.Tag, None), "ImpTag Read")
+        | _ -> raise (NotImplemented "inter not implemented in matcher"))
+    | _ -> raise (NotImplemented "inter not implemented in matcher")
+
+  let unroll_inter expr : var intersection =
+    let open AST in
+    let rec f l =
       match l with
-        | [] -> [[]]
-        | hd::tl ->
-          let Union expanded_hd = f hd in
-          let expanded_tl = union_fold_cross tl f in
-          Misc.concat_map (fun hd_item ->
-            List.map (fun tl_item ->
-              hd_item::tl_item
-            ) (expanded_tl)
-          ) (expanded_hd)
-
-    let rec fold_cross l f =
-      match l with
-        | [] -> [[]]
-        | hd::tl ->
-          let expanded_hd = f hd in
-          let expanded_tl = fold_cross tl f in
-          Misc.concat_map (fun hd_item ->
-            List.map (fun tl_item ->
-              hd_item::tl_item
-            ) (expanded_tl)
-          ) (expanded_hd)
-    let match_inter (Union expl) =
-      match expl with
-      | h::h2::[] -> begin
-        match h,h2 with
-        | D (R,_), Atom ((A.Tag, None),_) -> D_atom (Dir R, Some (A.Tag, None), "tag read")
-        | _ -> raise (NotImplemented "inter not implemented in matcher")
-      end
-      | h::h2::h3::[] -> begin
-        match h,h2,h3 with
-        | D (R,_), PTE _, Imp _ -> D_atom (Dir R, Some (A.Pte A.Read, None), "ImpPTE Read")
-        | D (R,_), Atom ((A.Tag, None),_), Imp _->D_atom (Dir R, Some (A.Tag, None), "ImpTag Read")
-        | _ -> raise (NotImplemented "inter not implemented in matcher")
-      end
-      | _ -> raise (NotImplemented "inter not implemented in matcher")
-
-    let unroll_inter expr : var intersection =
-      let open AST in
-        let rec f l =
-          match l with
-          | Op (_,Inter, expl) -> Misc.concat_map f expl
-          | Var (_,var) -> [var]
-          | _ -> raise (Misc.Fatal "operation in intersection not supported") in
-        match expr with
-        | Op (_,Inter, exp) -> Intersection (Misc.concat_map f exp)
-        | _ -> raise (Misc.Fatal "non intersection passed to unroll inter function")
-      (*
+      | Op (_, Inter, expl) -> Misc.concat_map f expl
+      | Var (_, var) -> [ var ]
+      | _ -> raise (Misc.Fatal "operation in intersection not supported")
+    in
+    match expr with
+    | Op (_, Inter, exp) -> Intersection (Misc.concat_map f exp)
+    | _ -> raise (Misc.Fatal "non intersection passed to unroll inter function")
+  (*
     ------------------------------------------
       Parse AST and make into custom type
     ------------------------------------------   
     *)
-    let get_ins ins =
-      (* Returns the name and expression of the given AST instruction
-      Inputs:
-        - ins: the AST instruction to extract the name and expression from
-      Outputs:
-        - varname: the name of the instruction, as AST.pat
-        - expression: the expression of the instruction, as AST.exp
-      Side effects: None
-      *)
-      let open AST in
-      match ins with
-      | Rec (_,(_,Pvar (Some varname),expression) :: _,_)
-      | Let (_, (_,Pvar (Some varname),expression) :: _) -> varname,expression
-      | _ -> raise (NotImplemented "instruction not supported" )
 
-    let expand_var tree (a,var) =
-      (* compare a single AST variable and compare to all let statements. If a match is found, return that expression*)
-        let open AST in
-        let is_var (name, _) = String.equal name var in
-        match List.find_opt is_var tree with
-        | Some (_,exp) -> exp
-        | None -> Var (a,var)
-    let rec inline_vars varname tree expression =
-      (*identify any vars that are defined as let statements and implement them into AST*)
-      let open AST in
-      match expression with
-      | Op (a, op, expl) ->
-        Op (a, op, List.map (inline_vars varname tree) expl)
-      | Op1 (a, op, exp) -> Op1 (a, op, inline_vars varname tree exp)
-      | Var (a, var) -> begin
+  let get_ins ins =
+    (* Returns the name and expression of the given AST instruction
+       Inputs:
+         - ins: the AST instruction to extract the name and expression from
+       Outputs:
+         - varname: the name of the instruction, as AST.pat
+         - expression: the expression of the instruction, as AST.exp
+       Side effects: None
+    *)
+    let open AST in
+    match ins with
+    | Rec (_, (_, Pvar (Some varname), expression) :: _, _)
+    | Let (_, (_, Pvar (Some varname), expression) :: _) ->
+        (varname, expression)
+    | _ -> raise (Skip "instruction not supported")
+
+  let expand_var tree (a, var) =
+    (* compare a single AST variable and compare to all let statements. If a match is found, return that expression*)
+    let open AST in
+    let is_var (name, _) = String.equal name var in
+    match List.find_opt is_var tree with
+    | Some (_, exp) -> exp
+    | None -> Var (a, var)
+
+  let rec inline_vars varname tree expression =
+    (*identify any vars that are defined as let statements and implement them into AST*)
+    let open AST in
+    match expression with
+    | Op (a, op, expl) ->
+        Some
+          (Op (a, op, get_option_list (List.map (inline_vars varname tree) expl)))
+    | Op1 (a, op, exp) ->
+        Some (Op1 (a, op, get_option (inline_vars varname tree exp)))
+    | Var (a, var) -> (
         (* checking a variable against the name of its let statement allows
            for the removal of recursive definitions*)
-        if (String.equal var varname) then expression
-        else
-        let br = expand_var tree (a,var) in
-        match br with
-          | Var (_,_) -> br
-          | Op (_, _, _) -> inline_vars varname tree br
-          | _ -> expression
-      end
-      | App (_,exp1,exp2) -> begin
+        match List.find_opt (fun a -> String.equal var a) varname with
+        | Some _ -> None
+        | None -> (
+            let br = expand_var tree (a, var) in
+            match br with
+            | Var (_, _) -> Some br
+            | Op (_, _, _) -> inline_vars (var :: varname) tree br
+            | _ -> Some expression))
+    | App (_, exp1, exp2) -> (
         match exp1 with
-        | Var ( _, "range") ->inline_vars varname tree exp2
-        | _ -> raise (Misc.Fatal "functions other than range currently not supported")
-        end
-      | _ -> raise (Misc.Fatal (sprintf "%s: expression not supported" (pp_exp expression)) )
+        | Var (_, "range") -> inline_vars varname tree exp2
+        | _ ->
+            raise
+              (Misc.Fatal "functions other than range currently not supported"))
+    | _ ->
+        raise
+          (Misc.Fatal
+             (sprintf "%s: expression not supported" (pp_exp expression)))
 
-    let rec apply_match_var a : edge_ir union =
-      match a with
-      | Intersection (h::[]) -> begin (* single variables *)
+  let rec apply_match_var a : edge_ir union =
+    match a with
+    | Intersection (h :: []) ->
+        (* single variables *)
         match_var h
-      end
-      | Intersection (h::t) -> begin (* Intersections *)
-        let inter_list = union_map intersection_singleton (Union (h::t)) in
+    | Intersection (h :: t) ->
+        (* Intersections *)
+        let inter_list = union_map intersection_singleton (Union (h :: t)) in
         let new_inters = union_map apply_match_var inter_list in
         union_map match_inter new_inters
-      end
-      | _ -> raise (Misc.Fatal "cannot have empty intersection")
+    | _ -> raise (Misc.Fatal "cannot have empty intersection")
 
-    let var_to_edge tree =
-      (* translate variables in let statements to edge_ir type
-        Inputs:
-          - tree: list of let statemenets
-        Outputs: list of let statements with var replaced by edge_ir in the ir type
-      *)
-      let edges_of_sequence expl =
-        (fun (Sequence seq) ->
-          try
-            Union (List.map make_sequence (union_fold_cross seq apply_match_var))
-          with
-          | NotImplemented msg | Skip msg  -> if O.verbose > 0 then eprintf "%s" msg; Union []
-        )
-        expl in
-      let edges_of_union let_name =
-        let (name,p) = (List.find (fun (name,_) -> String.equal name let_name) tree) in
-        name, union_concat_map edges_of_sequence p in
-      try
-        List.map edges_of_union O.lets_to_print
-      with
-      | Not_found -> raise (Misc.Fatal (sprintf "let statements that were asked for are not in cat file"))
+  let var_to_edge tree =
+    (* translate variables in let statements to edge_ir type
+       Inputs:
+         - tree: list of let statemenets
+       Outputs: list of let statements with var replaced by edge_ir in the ir type
+    *)
+    let edges_of_sequence expl =
+      (fun (Sequence seq) ->
+        try
+          Union (List.map make_sequence (union_fold_cross seq apply_match_var))
+        with Skip msg ->
+          if O.verbose > 0 then eprintf "%s" msg;
+          Union [])
+        expl
+    in
+    let edges_of_union let_name =
+      let name, p =
+        List.find (fun (name, _) -> String.equal name let_name) tree
+      in
+      (name, union_concat_map edges_of_sequence p)
+    in
+    try List.map edges_of_union O.lets_to_print
+    with Not_found ->
+      raise
+        (Misc.Fatal
+           (sprintf "let statements that were asked for are not in cat file"))
 
-      (*
+  (*
        ---------------------------------------------------------------
        Expand sequences and replace non-primitive variables
        --------------------------------------------------------------- 
 *)
-    let rec apply_expand tree : let_statements =
-      (* Expand operations in AST and translate AST to internal representation
-      Input:
-      - tree : (var * AST.exp) list
-      Output:
-      - let_statements : (var * ir) list
-       *)
-      let f (name, instr) =
-        match instr with
-        | AST.Op (_,AST.Seq,_) | AST.Op (_,AST.Inter,_) ->
-          name, expand instr
-        | AST.Op (_,AST.Union,expl) ->
-          name, union_concat_map expand (Union expl)
-        | _ -> raise (Misc.Fatal (sprintf "Expression not supported: %s" (pp_exp instr)))
-        in
-      List.map f tree
-    and expand_expression input_item : ir =
-      (* Expand a chosen expression, unrolling intersections, expanding unions and extracting variables from operations
-        Inputs:
-        - input_item: expression to expand (AST.exp)
-        Output: 
-        - list of var intersection lists. each var intersection list represents a sequence
-        *)
-      let open AST in
-      match input_item with
-      | Op (_,AST.Union, expl) -> union_concat_map expand_expression (Union expl)  (* union of variables *)
-      | Op1 (_,AST.ToId, expl) -> expand_expression expl
-      | Op (_,AST.Inter, _) -> ir_single_inter (unroll_inter input_item)
-      | Op (_,AST.Seq, expl) -> expand_list expl
-      | Op (_,AST.Diff, expl) -> expand_expression (List.hd expl)
-      (* here, I am assuming that the edge matched in match_var is not included in the diff*)
-      | App (_,_,exp) -> expand_expression exp
-      | Var (_,var) -> ir_single_var var
-      | _ -> raise (Misc.Fatal (sprintf "Expression not supported: %s" (pp_exp input_item)))
+  let rec apply_expand tree : let_statements =
+    (* Expand operations in AST and translate AST to internal representation
+       Input:
+       - tree : (var * AST.exp) list
+       Output:
+       - let_statements : (var * ir) list
+    *)
+    let f (name, instr) =
+      match instr with
+      | AST.Op (_, AST.Seq, _) | AST.Op (_, AST.Inter, _) -> (name, expand instr)
+      | AST.Op (_, AST.Union, expl) ->
+          (name, union_concat_map expand (Union expl))
+      | _ ->
+          raise
+            (Misc.Fatal (sprintf "Expression not supported: %s" (pp_exp instr)))
+    in
+    List.map f tree
 
-    and expand_list input_item : ir =
-      (* apply a fold_cross to a list of AST expressions, preserving their order and calling expand_expression on each expression
-      Inputs: 
-      - input_item, list of AST expressions. represents a sequence or intersection of variables
-      Output: 
-      - A list of var intersection lists, each var intersection list represents either a sequence of intersections or a single intersection
-      *)
-      match input_item with
-      | [] -> Union [Sequence[]]
-      | hd::tl ->
-          let expanded_hd = expand_expression hd in
-          let expanded_tl = expand_list tl in
-          union_concat_map (fun hd_item ->
-            union_map (fun tl_item ->
-              concatenate_sequences hd_item tl_item
-            ) expanded_tl
-          ) expanded_hd
+  and expand_expression input_item : ir =
+    (* Expand a chosen expression, unrolling intersections, expanding unions and extracting variables from operations
+       Inputs:
+       - input_item: expression to expand (AST.exp)
+       Output:
+       - list of var intersection lists. each var intersection list represents a sequence
+    *)
+    let open AST in
+    match input_item with
+    | Op (_, AST.Union, expl) ->
+        union_concat_map expand_expression (Union expl) (* union of variables *)
+    | Op1 (_, AST.ToId, expl) -> expand_expression expl
+    | Op (_, AST.Inter, _) -> ir_single_inter (unroll_inter input_item)
+    | Op (_, AST.Seq, expl) -> expand_list expl
+    | Op (_, AST.Diff, expl) -> expand_expression (List.hd expl)
+    (* here, I am assuming that the edge matched in match_var is not included in the diff*)
+    | App (_, _, exp) -> expand_expression exp
+    | Var (_, var) -> ir_single_var var
+    | _ ->
+        raise
+          (Misc.Fatal
+             (sprintf "Expression not supported: %s" (pp_exp input_item)))
 
-    and expand exp : ir =
-      (* construct a list of sequences using the expanded output from expand_list
-      Inputs: 
-      - exp AST expression to be expanded
-      Output: 
-      - list of sequences
-      *)
-      (* let open AST in *)
-      try
-        match exp with
-        | Op (_,AST.Union, expl) -> union_concat_map expand (Union expl)
-        | Op (_,AST.Inter, expl) -> expand_list expl
-        | Op (_,AST.Seq, expl) -> expand_list expl
-        | Op1 (_,ToId, expl) -> expand expl
-        | Var (_,var) -> ir_single_var var
-        | Op1 (_,a, _) -> raise (Misc.Fatal (sprintf "Expression not supported: %s " (pp_op1 a)))
-        | Op (_,a,_) -> raise (Misc.Fatal (sprintf "Expression not supported: %s" (pp_op2 a)))
-        | _ -> raise (Misc.Fatal (sprintf "Expression not supported: %s" (pp_exp exp)))
-      with
-      | NotImplemented s | Skip s  -> if O.verbose > 0 then eprintf "%s\n" s; Union []
-      | Misc.Fatal s -> raise (Misc.Fatal ("Fail in expand:"^s))
+  and expand_list input_item : ir =
+    (* apply a fold_cross to a list of AST expressions, preserving their order and calling expand_expression on each expression
+       Inputs:
+       - input_item, list of AST expressions. represents a sequence or intersection of variables
+       Output:
+       - A list of var intersection lists, each var intersection list represents either a sequence of intersections or a single intersection
+    *)
+    match input_item with
+    | [] -> Union [ Sequence [] ]
+    | hd :: tl ->
+        let expanded_hd = expand_expression hd in
+        let expanded_tl = expand_list tl in
+        union_concat_map
+          (fun hd_item ->
+            union_map
+              (fun tl_item -> concatenate_sequences hd_item tl_item)
+              expanded_tl)
+          expanded_hd
 
-    (*
+  and expand exp : ir =
+    (* construct a list of sequences using the expanded output from expand_list
+       Inputs:
+       - exp AST expression to be expanded
+       Output:
+       - list of sequences
+    *)
+    (* let open AST in *)
+    try
+      match exp with
+      | Op (_, AST.Union, expl) -> union_concat_map expand (Union expl)
+      | Op (_, AST.Inter, expl) -> expand_list expl
+      | Op (_, AST.Seq, expl) -> expand_list expl
+      | Op1 (_, ToId, expl) -> expand expl
+      | Var (_, var) -> ir_single_var var
+      | Op1 (_, a, _) ->
+          raise
+            (Misc.Fatal (sprintf "Expression not supported: %s " (pp_op1 a)))
+      | Op (_, a, _) ->
+          raise (Misc.Fatal (sprintf "Expression not supported: %s" (pp_op2 a)))
+      | _ ->
+          raise
+            (Misc.Fatal (sprintf "Expression not supported: %s" (pp_exp exp)))
+    with
+    | Skip s ->
+        if O.verbose > 0 then eprintf "%s\n" s;
+        Union []
+    | NotImplemented s | Misc.Fatal s ->
+        raise (Misc.Fatal ("Fail in expand:" ^ s))
+
+  (*
     ------------------------------------------
       match cumulative edges
     ------------------------------------------   
     *)
 
-    let expand_fencedp el =
+  let expand_fencedp el =
     (* expand cumulative macros
        Inputs:
        - el: list of edges to expand
        Outputs:
        - expanded list of edges
-       *)
-      let open E in
-      let rec f e l = 
-        match e with
-        | [] -> l
-        | h::[] -> h::l
-        | h::h2::t -> begin 
-          match [h.E.edge;h2.E.edge] with
-          |  [Dp (dp, sd, _);_] -> begin
-            match [h;h2] with
-            | [{E.edge=Dp ((A.D.CTRLISYNC,A.NoCsel),_,_); E.a1=a1; E.a2=_;};
-               {E.edge=Po (_,_,e2); E.a1=_; E.a2=a2;}] ->
-              {E.edge=Dp (dp,sd,e2); E.a1=a1; E.a2=a2}::(f t l)
-            | [{E.edge=Dp ((A.D.CTRL,_),_,_); a1=a1; a2=_;};
-               {E.edge=Fenced (A.Barrier A.ISB,_,_,e2); a1=_; a2=a2;}] ->
-              f ({E.edge=Dp ((A.D.CTRLISYNC,A.NoCsel),sd,e2); a1=a1; a2=a2}::t) l
-            | _ -> h::(f (h2::t) l)
-            end
-          | [Fenced (fence, sd, extr1, _);_ ]->begin
-            match [h;h2] with
-            | [{E.edge=Fenced _; a1=a1; a2=_;};
-                {E.edge=Po (_,_,e2); a1=_; a2=a2;}] ->
-              {E.edge=Fenced (fence,sd,extr1,e2); a1=a1; a2=a2}::(f t l)
-            | _ -> h::(f (h2::t) l)
-            end
-          | [(Po _);(Fenced (fence, sd, _, extr2))] ->begin
-            match [h;h2]@t with
-            | [{E.edge=Po (_,e1,_); a1=a1; a2=_;};
-               {E.edge=Fenced _; a1=_; a2=_;};
-               {E.edge=Po (_,_,e2); a1=_; a2=a2;}] ->
-              {E.edge=Fenced (fence,sd,e1,e2); a1=a1; a2=a2}::(f (List.tl t) l)
-            | [{E.edge=Po (_,e1,_); a1=a1; a2=_;};
-               {E.edge=Fenced _; a1=_; a2=a2;}] ->
-              {E.edge=Fenced (fence,sd,e1,extr2); a1=a1; a2=a2}::(f t l)
-            | _ -> h::(f (h2::t) l)
-          end
-          | [(Po _);(Rmw _)] ->begin
-            match [h;h2] with
-            | [{E.edge=Po (sd,_,_); a1=a1; a2=poa2;};
-              {E.edge=Rmw a; a1=_; a2=a2;}] ->
-                if (A.applies_atom_rmw a poa2 a2) then
-                  {E.edge=Po (sd,Irr,Irr); a1=a1; a2=None;}::{E.edge=Rmw a; a1=poa2; a2=a2;}::(f t l)
-                else raise (Skip "atoms not applied correctly for rmw")
-            | _ -> h::(f (h2::t) l)
-              end
-          | _ -> h::(f (h2::t) l)
-        end
-      in f el []
-    
-      (*
+    *)
+    let open E in
+    let rec f e l =
+      match e with
+      | [] -> l
+      | h :: [] -> h :: l
+      | h :: h2 :: t -> (
+          match [ h.E.edge; h2.E.edge ] with
+          | [ Dp (dp, sd, _); _ ] -> (
+              match [ h; h2 ] with
+              | [
+               { E.edge = Dp ((A.D.CTRLISYNC, A.NoCsel), _, _); E.a1; E.a2 = _ };
+               { E.edge = Po (_, _, e2); E.a1 = _; E.a2 };
+              ] ->
+                  { E.edge = Dp (dp, sd, e2); E.a1; E.a2 } :: f t l
+              | [
+               { E.edge = Dp ((A.D.CTRL, _), _, _); a1; a2 = _ };
+               { E.edge = Fenced (A.Barrier A.ISB, _, _, e2); a1 = _; a2 };
+              ] ->
+                  f
+                    ({ E.edge = Dp ((A.D.CTRLISYNC, A.NoCsel), sd, e2); a1; a2 }
+                    :: t)
+                    l
+              | _ -> h :: f (h2 :: t) l)
+          | [ Fenced (fence, sd, extr1, _); _ ] -> (
+              match [ h; h2 ] with
+              | [
+               { E.edge = Fenced _; a1; a2 = _ };
+               { E.edge = Po (_, _, e2); a1 = _; a2 };
+              ] ->
+                  { E.edge = Fenced (fence, sd, extr1, e2); a1; a2 } :: f t l
+              | _ -> h :: f (h2 :: t) l)
+          | [ Po _; Fenced (fence, sd, _, extr2) ] -> (
+              match [ h; h2 ] @ t with
+              | [
+               { E.edge = Po (_, e1, _); a1; a2 = _ };
+               { E.edge = Fenced _; a1 = _; a2 = _ };
+               { E.edge = Po (_, _, e2); a1 = _; a2 };
+              ] ->
+                  { E.edge = Fenced (fence, sd, e1, e2); a1; a2 }
+                  :: f (List.tl t) l
+              | [
+               { E.edge = Po (_, e1, _); a1; a2 = _ };
+               { E.edge = Fenced _; a1 = _; a2 };
+              ] ->
+                  { E.edge = Fenced (fence, sd, e1, extr2); a1; a2 } :: f t l
+              | _ -> h :: f (h2 :: t) l)
+          | [ Po _; Rmw _ ] -> (
+              match [ h; h2 ] with
+              | [
+               { E.edge = Po (sd, _, _); a1; a2 = poa2 };
+               { E.edge = Rmw a; a1 = _; a2 };
+              ] ->
+                  if A.applies_atom_rmw a poa2 a2 then
+                    { E.edge = Po (sd, Irr, Irr); a1; a2 = None }
+                    :: { E.edge = Rmw a; a1 = poa2; a2 }
+                    :: f t l
+                  else raise (Skip "atoms not applied correctly for rmw")
+              | _ -> h :: f (h2 :: t) l)
+          | _ -> h :: f (h2 :: t) l)
+    in
+    f el []
+
+  (*
     ------------------------------------------
       logic for matching
       - parse letlines into edge type
       - match sequences of edge's into single or composite relaxations
     ------------------------------------------   
     *)
-    let listofnode nodel =
+  let listofnode nodel =
     (*translate edge_node list into edge list list for printing
       *)
-      let rec f node =
-        match node.branch_list with
-        | h::t ->
-          Misc.concat_map (fun a ->
-                      List.map (fun b -> node.node_val::b)
-                      (f a)
-                      ) (h::t)
-        | [] -> [[node.node_val]] in
-      Misc.concat_map f nodel
+    let rec f node =
+      match node.branch_list with
+      | h :: t ->
+          Misc.concat_map
+            (fun a -> List.map (fun b -> node.node_val :: b) (f a))
+            (h :: t)
+      | [] -> [ [ node.node_val ] ]
+    in
+    Misc.concat_map f nodel
 
-    let check_prev a =
-      match a with
-      | Empty _ -> None
-      | Atom (b,_) -> Some b
-      | D_atom (_,an,_) -> an
-      | _ -> None
-    let check_if_dir a =
-      match a with
-      | D (a,_) ->  Dir a
-      | Ext (NoDir,_) -> NoDir
-      | D_atom (r,_,_) -> r
-      | _ -> Irr
+  let check_prev a =
+    match a with
+    | Empty _ -> None
+    | Atom (b, _) -> Some b
+    | D_atom (_, an, _) -> an
+    | _ -> None
 
-    let extract_diratom prev next =
-      let extr1 = check_if_dir prev in
-      let extr2 = check_if_dir next in
+  let check_if_dir a =
+    match a with
+    | D (a, _) -> Dir a
+    | Ext (NoDir, _) -> NoDir
+    | D_atom (r, _, _) -> r
+    | _ -> Irr
 
-      let a1 = check_prev prev in
-      let a2 = check_prev next in
-      let extr1 = check_dirfroma a1 extr1 in
-      let extr2 = check_dirfroma a2 extr2 in
-      a1,a2,extr1,extr2
-    let matcher (Sequence expl:edge_ir sequence) =
+  let extract_diratom prev next =
+    let extr1 = check_if_dir prev in
+    let extr2 = check_if_dir next in
+
+    let a1 = check_prev prev in
+    let a2 = check_prev next in
+    let extr1 = check_dirfroma a1 extr1 in
+    let extr2 = check_dirfroma a2 extr2 in
+    (a1, a2, extr1, extr2)
+
+  let matcher (Sequence expl : edge_ir sequence) =
     (* translate expressions to E.edge type. Expand edges to include Same and Diff
         Inputs:
         - expl: sequence of expressions to create edge / edge list for
         Outputs:
         - tree of edge nodes, representing all possible edge sequences*)
-      let open AST in
-      let open E in
-      let match_edge h prev h2 branch_list =
-        let a1, a2, extr1, extr2 = extract_diratom prev h2 in
-        let e = match h with
-        | Tedge (Po (_,_,_),_) -> [E.Po(Same,extr1,extr2);E.Po(Diff,extr1,extr2)]
-        | Tedge (Dp (dp, _, _),_) -> [E.Dp (dp,Same,extr2);E.Dp (dp,Diff,extr2)]
-        | Tedge (Fenced (fence,_,_,_),_) -> [E.Fenced (fence,Same,extr1,extr2);E.Fenced (fence,Diff,extr1,extr2)]
-        | Tedge ((Rf ie), _) -> [E.Rf ie]
-        | Tedge ((Fr ie), _) -> [E.Fr ie]
-        | Tedge ((Ws ie), _) -> [E.Ws ie]
-        | Tedge (Rmw rmw,_) ->
-          if (A.applies_atom_rmw rmw a1 a2) then [Rmw rmw]
-          else []
-        | _ -> [] in
-        match e with
-        | [] -> branch_list None
-        | _ -> List.map (fun a -> E.{ node_val = { edge = a ; a1 ; a2 }; branch_list = branch_list a2 }) e in
-      let rec f (l:edge_ir list) prev =
-        match l with
-        | Empty v :: _ -> raise (NotImplemented (sprintf "variable not implemented in matcher: %s" v))
-        | (Lrs _ as h) :: h2 :: t ->
-          let a1, a2, _, _ = extract_diratom prev h2 in
+    let open AST in
+    let open E in
+    let match_edge h prev h2 branch_list =
+      let a1, a2, extr1, extr2 = extract_diratom prev h2 in
+      let e =
+        match h with
+        | Tedge (Po (_, _, _), _) ->
+            [ E.Po (Same, extr1, extr2); E.Po (Diff, extr1, extr2) ]
+        | Tedge (Dp (dp, _, _), _) ->
+            [ E.Dp (dp, Same, extr2); E.Dp (dp, Diff, extr2) ]
+        | Tedge (Fenced (fence, _, _, _), _) ->
             [
-              {
-                node_val = E.{ edge = Po (Same, Dir W, Dir R); a1; a2 };
-                branch_list = f (h2 :: t) h;
-              };
+              E.Fenced (fence, Same, extr1, extr2);
+              E.Fenced (fence, Diff, extr1, extr2);
             ]
-        | h::h2::t ->
-          let branch_list a2 =
-            if a2 = None then f (h2 :: t) h
-            else f t h
-          in
+        | Tedge (Rf ie, _) -> [ E.Rf ie ]
+        | Tedge (Fr ie, _) -> [ E.Fr ie ]
+        | Tedge (Ws ie, _) -> [ E.Ws ie ]
+        | Tedge (Rmw rmw, _) ->
+            if A.applies_atom_rmw rmw a1 a2 then [ Rmw rmw ] else []
+        | _ -> []
+      in
+      match e with
+      | [] -> branch_list None
+      | _ ->
+          List.map
+            (fun a ->
+              E.
+                {
+                  node_val = { edge = a; a1; a2 };
+                  branch_list = branch_list a2;
+                })
+            e
+    in
+    let rec f (l : edge_ir list) prev =
+      match l with
+      | Empty v :: _ ->
+          raise
+            (NotImplemented
+               (sprintf "variable not implemented in matcher: %s" v))
+      | (Lrs _ as h) :: h2 :: t ->
+          let a1, a2, _, _ = extract_diratom prev h2 in
+          [
+            {
+              node_val = E.{ edge = Po (Same, Dir W, Dir R); a1; a2 };
+              branch_list = f (h2 :: t) h;
+            };
+          ]
+      | h :: h2 :: t ->
+          let branch_list a2 = if a2 = None then f (h2 :: t) h else f t h in
           match_edge h prev h2 branch_list
-        | h::[] -> match_edge h prev empty_expr (fun _ -> [])
-        | [] -> []
-      in f expl empty_expr
-    
+      | h :: [] -> match_edge h prev empty_expr (fun _ -> [])
+      | [] -> []
+    in
+    f expl empty_expr
 
-        
-    (*
+  (*
     ------------------------------------------
     entry point for constructing tree
     ------------------------------------------   
     *)
-    let ast_to_ir ast : let_statements =
-      let map_ast f l =
-        List.fold_left
+  let ast_to_ir ast : let_statements =
+    let map_ast f l =
+      List.fold_left
         (fun acc a ->
-          try
-            f a::acc
-          with
-          | NotImplemented s | Skip s  -> if O.verbose > 0 then (eprintf "%s\n" s);
-              acc)
-        [] l in
-      let tree_base = map_ast get_ins ast in
-      let map_vars = map_ast (
-        if O.print_tree then
-          fun (varname, expression) -> varname, inline_vars varname tree_base expression
-        else
-          fun (varname, expression) ->
-          match List.find_opt (fun name -> String.equal name varname) O.lets_to_print with
-          | Some _ -> varname, inline_vars varname tree_base expression
-          | None -> raise (Skip (sprintf "no let statements found for: %s\n" varname))
-        ) tree_base in
-      apply_expand map_vars
-    
-      (*
+          try f a :: acc
+          with NotImplemented s | Skip s ->
+            if O.verbose > 0 then eprintf "%s\n" s;
+            acc)
+        [] l
+    in
+    let tree_base = map_ast get_ins ast in
+    let map_vars =
+      map_ast
+        (if O.print_tree then fun (varname, expression) ->
+           (varname, get_option (inline_vars [ varname ] tree_base expression))
+         else fun (varname, expression) ->
+           match
+             List.find_opt
+               (fun name -> String.equal name varname)
+               O.lets_to_print
+           with
+           | Some _ ->
+               ( varname,
+                 get_option (inline_vars [ varname ] tree_base expression) )
+           | None ->
+               raise
+                 (Skip (sprintf "no let statements found for: %s\n" varname)))
+        tree_base
+    in
+    apply_expand map_vars
+
+  (*
       ---------------------------------------------------------------
       Printing functions
       ---------------------------------------------------------------
       *)
-    let pp_relaxations (tree : let_statements) =
-      (* Pretty prints the given list of let statements as DIY relaxations
-        Inputs:
-          - tree: the list of let statements to pretty print, of type ast
-        Outputs: None
-        Side effects: Prints the DIY relaxation to the console
-      *)
-      let tree = var_to_edge tree in
-      let f expl =
-        try
-          let edge = matcher expl in
-          let edge = listofnode edge in
-          let edge = List.map expand_fencedp edge in
-          List.iter (fun e ->
-            match e with
-            | _::[] -> printf "%s " (String.concat "," (List.map E.pp_edge e))
-            | _::_ -> printf "[%s] " (String.concat "," (List.map E.pp_edge e))
-            | [] -> raise (Misc.Fatal "Cannot have empty edge")
-            ) edge;
-        with
-          | NotImplemented msg | Skip msg -> if O.verbose > 0 then eprintf "%s\n" msg;
-      in
-      try
-      List.iter (fun b ->
-        let (_,p) = (List.find (fun (name,_) -> String.equal name b) tree) in
-        let Union p = p in
-        List.iter f p
-        ) O.lets_to_print
-      with
-      | Not_found -> raise (Misc.Fatal "let statements that were asked for are not in cat file")
-
-    let pp_tree (tree: let_statements) : unit =
-      (* This function takes a list of let statements, in the form
-      of string * expression, and prints the expanded tree of the cat file.
-      Inputs:
-        - tree: A list of let statements, as ast type.
-      Outputs:
-        - None
-      Side effects: The function prints the expanded tree of the cat file.
+  let pp_relaxations (tree : let_statements) =
+    (* Pretty prints the given list of let statements as DIY relaxations
+       Inputs:
+         - tree: the list of let statements to pretty print, of type ast
+       Outputs: None
+       Side effects: Prints the DIY relaxation to the console
     *)
-      let pp_intersection (Intersection exp) =
-        match exp with
-        | h::[] -> h;
-        | h::t -> sprintf "(%s)" (String.concat "&" (h::t));
-        | [] -> raise (Misc.Fatal "Intersection cannot have an empty list") in
-      let pp_sequence (Sequence expl) =
-        String.concat ";" (List.map pp_intersection expl) in
-      let pp (name, Union ins) =
-        printf "\n\n(%s)\n  |" name;
-        printf "%s" (String.concat "\n  |" (List.map pp_sequence ins)); in
-      List.iter pp tree
-(*
+    let tree = var_to_edge tree in
+    let f expl =
+      try
+        let edge = matcher expl in
+        let edge = listofnode edge in
+        let edge = List.map expand_fencedp edge in
+        List.iter
+          (fun e ->
+            match e with
+            | _ :: [] -> printf "%s " (String.concat "," (List.map E.pp_edge e))
+            | _ :: _ ->
+                printf "[%s] " (String.concat "," (List.map E.pp_edge e))
+            | [] -> raise (Misc.Fatal "Cannot have empty edge"))
+          edge
+      with Skip msg -> if O.verbose > 0 then eprintf "%s\n" msg
+    in
+    try
+      List.iter
+        (fun b ->
+          let _, p = List.find (fun (name, _) -> String.equal name b) tree in
+          let (Union p) = p in
+          List.iter f p)
+        O.lets_to_print
+    with Not_found ->
+      raise
+        (Misc.Fatal "let statements that were asked for are not in cat file")
+
+  let pp_tree (tree : let_statements) : unit =
+    (* This function takes a list of let statements, in the form
+       of string * expression, and prints the expanded tree of the cat file.
+       Inputs:
+         - tree: A list of let statements, as ast type.
+       Outputs:
+         - None
+       Side effects: The function prints the expanded tree of the cat file.
+    *)
+    let pp_intersection (Intersection exp) =
+      match exp with
+      | h :: [] -> h
+      | h :: t -> sprintf "(%s)" (String.concat "&" (h :: t))
+      | [] -> raise (Misc.Fatal "Intersection cannot have an empty list")
+    in
+    let pp_sequence (Sequence expl) =
+      String.concat ";" (List.map pp_intersection expl)
+    in
+    let pp (name, Union ins) =
+      printf "\n\n(%s)\n  |" name;
+      printf "%s" (String.concat "\n  |" (List.map pp_sequence ins))
+    in
+    List.iter pp tree
+
+  (*
 ----------------------------------------------
 entry point
 ----------------------------------------------   
 
 *)
-    let zyva name =
-      try
-        let _,(_,_,ast)  = Parser.find_parse name in
-        let tree = ast_to_ir ast in
-        if O.print_tree then begin
-          pp_tree tree;
-          printf "\n\n\n"
-        end;
-        pp_relaxations tree;
-      with
-      | Misc.Fatal msg -> printf "ERROR %s\n%!" msg
-      | Misc.Exit -> ()
-  end
+  let zyva name =
+    try
+      let _, (_, _, ast) = Parser.find_parse name in
+      let tree = ast_to_ir ast in
+      if O.print_tree then (
+        pp_tree tree;
+        printf "\n\n\n");
+      pp_relaxations tree
+    with
+    | NotImplemented msg -> printf "\n\nNot Implemented Error: %s\n%!" msg
+    | Misc.Fatal msg -> printf "\n\nFatal Error: %s\n%!" msg
+    | Misc.Exit -> ()
+end
 
 let verbose = ref 0
 let lets_to_print = ref []
 let arg = ref []
-let setarg name = arg := !arg @ [name]
+let setarg name = arg := !arg @ [ name ]
 
 let opts =
   [
-   "-v",Arg.Unit (fun () -> incr verbose), " be verbose";
-   "-let",Arg.String (fun s -> lets_to_print := !lets_to_print @ [s]),
-   "<statement> print out selected let statements";
+    ("-v", Arg.Unit (fun () -> incr verbose), " be verbose");
+    ( "-let",
+      Arg.String (fun s -> lets_to_print := !lets_to_print @ [ s ]),
+      "<statement> print out selected let statements" );
   ]
 
+let () = Arg.parse opts setarg (sprintf "Usage: %s [options]* cats*" prog)
+
+module Z = Make (struct
+  let verbose = !verbose
+  let lets_to_print = !lets_to_print
+  let print_tree = if verbose > 0 then true else false
+end)
+
 let () =
-  Arg.parse opts setarg
-    (sprintf "Usage: %s [options]* cats*" prog)
-
-
-module Z =
-  Make
-    (struct
-      let verbose = !verbose
-      let lets_to_print = !lets_to_print
-      let print_tree = if verbose > 0 then true else false
-    end)
-
-let () = List.iter Z.zyva !arg ; exit 0
+  List.iter Z.zyva !arg;
+  exit 0

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -917,3 +917,14 @@ let group_by_int get_key env =
        (IntMap.fold
           (fun _ env_p k -> List.rev env_p::k)
           m []))
+
+
+(* concat_map function taken from List module in the stdlib. Function only appears in Ocaml 4.10
+   , implemented in misc so that the codebase can still compile with Ocaml 4.08.1*)
+let concat_map f l =
+  let rec aux f acc = function
+    | [] -> List.rev acc
+    | x :: l ->
+        let xs = f x in
+        aux f (List.rev_append xs acc) l
+  in aux f [] l

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -343,3 +343,7 @@ val mix : int -> int -> int -> int
 (*********************************)
 
 val group_by_int : ('k -> int option) -> ('k * 'v) list -> ('k * 'v) list list
+
+
+
+val concat_map : ('a -> 'b list) -> 'a list -> 'b list


### PR DESCRIPTION
This commit introduces a new tool to generate relaxations from a cat file; this is still a work in progress. Any and all feedback would be appreciated!

The tool takes as input a cat file and then tries to translate each let statement into a list of relaxations, where the user can choose which let statements to output.

In order to use the tool, a user can use the command `mcat2config7` and must then specify a cat file. 
With the option `-tree`, the cat file let statements will all be expanded and this will be represented. 
Using the option `-let` the user can choose what let statements to print relaxations for.
e.g. `mcat2compare7 -tree -let ob`

The tool works as follows:
- Parse AST of cat file
- Expand Unions within a let statement
- If a let statement has a variable that corresponds to a let statement, implement that and expand
- translate variables from cat to type edge (from edge.ml)
- Match cumulative relaxations
- Print

Currently, in the stage where variables are translated to edges, there are still many edges unimplemented. 
In the expansion of the cat file logic, some instructions are also not yet implemented, i.e. Diff, add, Inv, Opt etc.

I will be implementing these in the following patches, however I am making a draft PR in order to get some feedback on the general logic of the tool before implementing everything.
I have tried to make my functions easy to understand, however this might not have succeeded in all places. If there's anything that doesn't make sense then I can clarify or change it to be more understandable.

any feedback would be appreciated