### PR TITLE
[tools] Implement option to negate final condition with mlog2cond

### DIFF
--- a/tools/mlog2cond.ml
+++ b/tools/mlog2cond.ml
@@ -26,6 +26,7 @@ let acceptempty = ref false
 let hexa = ref false
 let int32 = ref true
 let faulttype = ref true
+let neg = ref false
 
 let options =
   [
@@ -43,6 +44,8 @@ let options =
    ("-acceptempty", Arg.Bool (fun b -> acceptempty := b),
     sprintf
       "<bool> output empty conditions, default %b" !acceptempty);
+  ("-neg", Arg.Bool (fun b -> neg := b),
+    "<bool> negate final condition (default false)");
     CheckName.parse_hexa hexa;
     CheckName.parse_int32 int32;
     CheckName.parse_faulttype faulttype;
@@ -96,6 +99,7 @@ module LL =
 
 let acceptempty = !acceptempty
 let quant = if !forall then "forall" else "exists"
+let negate = if !neg then "~" else ""
 let zyva log =
   let test = match log with
   | None -> LL.read_chan "stdin" stdin
@@ -108,14 +112,14 @@ let zyva log =
 
   let pp_cond name bdss =
     let pp = pp_cond bdss in
-    sprintf "%s \"%s %s\"" name quant pp in
+    sprintf "%s \"%s%s %s\"" name negate quant pp in
 
   let dump_test chan t =
     let bdss = LS.get_bindings t.states in
     match bdss with
     | [] ->
         if acceptempty then
-          fprintf chan "%s \"%s false\"\n" t.tname quant
+          fprintf chan "%s \"%s%s false\"\n" t.tname negate quant
     | _ ->
         fprintf chan "%s\n" (pp_cond t.tname bdss) in
 


### PR DESCRIPTION
This commit implements the ability to negate the final condition when using mlog2cond7. 

The reason for implementing this is to catch cases where HW is completely unpredictable and breaks all the rules, such as memory/register corruption issues in HW. This would create a state that isn't included within the forbidden state of a litmus test, but we would still want to catch.

By negating the possible states from herd7 output (for forbidden tests), we would be able to catch the forbidden state as well as unpredictable states due to HW issues.

e.g.
Litmus test with following forbidden state:
`exists (1:X1=1 /\ 1:X2=1)`

has these possible states (from herd output)
`1:X1=1;1:X2=0;`
`1:X1=0;1:X2=1;`

we want as forbidden state
`~exists ((1:X1=1 /\ 1:X2=0) \/ (1:X1=0 /\ 1:X2=1))`

I tried to do this previously using recond7, however was unable to do it. If there is a way to get this result by using the current tools, please let me know!