### PR TITLE
[herd] Fix double neg fault

### DIFF
--- a/herd/tests/instructions/AArch64.kvm/A017.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A017.litmus
@@ -1,0 +1,17 @@
+AArch64 A017
+variant=fatal
+{
+int x=1 ;
+[PTE(x)]=(valid:0);
+1:X0=x;
+0:X0=PTE(x);
+0:X1=(oa:PA(x),db:0);
+0:X2=(oa:PA(x));
+}
+ P0          | P1         ;
+ STR X1,[X0] | MOV W1,#1  ;
+ STR X2,[X0] |L0:         ;
+             | STR W1,[X0];
+locations [fault(P1:L0,x,MMU:Translation);]
+(* Fix a glitch: line  "~Fault(P1:L0,x,MMU:Translation);"
+   was occuring twice in output *)

--- a/herd/tests/instructions/AArch64.kvm/A017.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A017.litmus.expected
@@ -1,0 +1,11 @@
+Test A017 Required
+States 2
+  ~Fault(P1:L0,x,MMU:Translation);
+ Fault(P1:L0,x,MMU:Translation);
+Ok
+Witnesses
+Positive: 3 Negative: 0
+Condition forall (true)
+Observation A017 Always 3 0
+Hash=83f44c15d73037901c1a990dcd68f0a4
+

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -362,9 +362,9 @@ module Make(O:Config)(M:XXXMem.S) =
           A.FaultSet.filter
             (fun flt ->
               A.FaultAtomSet.exists
-                (fun ((p,lab),loc,_ftype) ->
-                  A.check_one_fatom flt ((p,lab),loc,None)) test.Test_herd.ffaults) in
-
+                (fun ((p,lab),loc,ftype) ->
+                  A.check_one_fatom flt ((p,lab),loc,ftype))
+                test.Test_herd.ffaults) in
 
       let final_state_restrict_locs test fsc =
         let dlocs = S.displayed_rlocations test

--- a/lib/fault.ml
+++ b/lib/fault.ml
@@ -70,6 +70,8 @@ module type S = sig
   module FaultSet : MySet.S with type elt = fault
 
   type fatom = (loc_global,fault_type) atom
+
+  val pp_fatom : fatom -> string
   val check_one_fatom : fault -> fatom -> bool
   val check_fatom : FaultSet.t -> fatom -> bool
   module FaultAtomSet : MySet.S with type elt = fatom
@@ -123,6 +125,8 @@ module Make(A:I) =
         end)
 
     type fatom = (loc_global,fault_type) atom
+
+    let pp_fatom = pp_fatom A.pp_global A.pp_fault_type
 
     let check_one_fatom ((p0,lbls0),x0,ftype0,_)  ((p,lblo),x,ftype) =
       Proc.compare p p0 = 0 &&

--- a/lib/fault.mli
+++ b/lib/fault.mli
@@ -53,6 +53,8 @@ module type S = sig
   module FaultSet : MySet.S with type elt = fault
 
   type fatom = (loc_global,fault_type) atom
+
+  val pp_fatom : fatom -> string
   val check_one_fatom : fault -> fatom -> bool
   val check_fatom : FaultSet.t -> fatom -> bool
 


### PR DESCRIPTION
Fix a glitch : some lines in outcomes with negative faults were printed more than once.

The root cause is the introduction of fault types in negative faults matching. More precisely, when the pattern contains some fault type A, and that there are two outcomes that are almost identical, except that  one has fault of type B and the other has no fault, then two identical lines with ~fault(...,A) were printed. The fix consists in discarding  the outcome with the fault of type B, as the observation of this fault is in fact not specified.

This PR  complements PR #473.