### PR TITLE
[All]: Add Arm Support for Several New Instructions

### DIFF
--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -55,12 +55,14 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
     module V = V
 
     let mem_access_size = function
-      | I_NOP | I_ADD _ | I_ADD3 _ | I_SUB _ | I_SUB3 _ | I_AND _
-      | I_B _ | I_BEQ _ | I_BNE _ | I_CB _ | I_CMPI _  | I_CMP _
-      | I_MOVI _ | I_MOV _ | I_XOR _ | I_DMB _ | I_DSB _ | I_ISB
+      | I_NOP | I_ADD _ | I_ADD3 _ | I_SUB _ | I_SUB3 _ | I_AND _ | I_ORR _
+      | I_B _ | I_BX _ |  I_BEQ _ | I_BNE _ | I_CB _ | I_CMPI _
+      | I_CMP _ | I_MOVI _ | I_MOV _ | I_MOVW _ | I_MOVT _ | I_XOR _
+      | I_DMB _ | I_DSB _ | I_ISB
       | I_SADD16 _ | I_SEL _
         -> None
       | I_LDR _ | I_LDREX _ | I_LDR3 _ | I_STR _ | I_STREX _ | I_STR3 _
+      | I_LDRO _ | I_LDM2 _ | I_LDM3 _ | I_LDRD _
         -> Some MachSize.Word
 
     include NoSemEnv

--- a/herd/tests/instructions/ARM/A003.litmus
+++ b/herd/tests/instructions/ARM/A003.litmus
@@ -1,4 +1,4 @@
-ARM SB004
+ARM A003
 
 (* classic SB004 test, should not see final state in outcomes*)
 {
@@ -10,4 +10,4 @@ ARM SB004
  STR R0,[R2]  | STR R0,[R2]  ;
  DMB ISH      | DMB ISH      ;
  LDR R1,[R3]  | LDR R1,[R3]  ;
-exists (0:R1=0 /\ 1:R1=0)
+~exists (0:R1=0 /\ 1:R1=0)

--- a/herd/tests/instructions/ARM/A003.litmus.expected
+++ b/herd/tests/instructions/ARM/A003.litmus.expected
@@ -1,12 +1,12 @@
-Test SB004 Allowed
+Test A003 Forbidden
 States 3
 0:R1=0; 1:R1=1;
 0:R1=1; 1:R1=0;
 0:R1=1; 1:R1=1;
-No
+Ok
 Witnesses
-Positive: 0 Negative: 3
-Condition exists (0:R1=0 /\ 1:R1=0)
-Observation SB004 Never 0 3
+Positive: 3 Negative: 0
+Condition ~exists (0:R1=0 /\ 1:R1=0)
+Observation A003 Never 0 3
 Hash=8bd18640a71f5f8da4d4f2fe719284e3
 

--- a/herd/tests/instructions/ARM/A004.litmus
+++ b/herd/tests/instructions/ARM/A004.litmus
@@ -1,0 +1,12 @@
+ARM A004
+
+(* Test ORR instruction arm*)
+{ 0:R2 = 1; 0:R5 = 1; 0:R8 = 0; 0:R11= 0; }
+
+P0;
+ORR R1, R2, #1;
+ORR R4, R5, #0;
+ORR R7, R8, #1;
+ORR R10,R11,#0;
+
+forall (0:R1 = 1 /\ 0:R4 = 1 /\ 0:R7 = 1 /\ 0:R10=0)

--- a/herd/tests/instructions/ARM/A004.litmus.expected
+++ b/herd/tests/instructions/ARM/A004.litmus.expected
@@ -1,0 +1,10 @@
+Test A004 Required
+States 1
+0:R1=1; 0:R4=1; 0:R7=1; 0:R10=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R1=1 /\ 0:R4=1 /\ 0:R7=1 /\ 0:R10=0)
+Observation A004 Always 1 0
+Hash=d39f5d16e08b32627e67fdebc98bc624
+

--- a/herd/tests/instructions/ARM/A005.litmus
+++ b/herd/tests/instructions/ARM/A005.litmus
@@ -1,0 +1,12 @@
+ARM A005
+
+Stable=R2,R3,R4,R5
+
+(*Test LDRD Instruction *)
+{ int x[2] = {1,1}; 0:R1 = x }
+
+P0;
+LDRD R2,R3,[R1];
+LDRD R4,[R1];
+
+forall (0:R2=1 /\ 0:R3=1 /\ 0:R4=1 /\ 0:R5=1)

--- a/herd/tests/instructions/ARM/A005.litmus.expected
+++ b/herd/tests/instructions/ARM/A005.litmus.expected
@@ -1,0 +1,10 @@
+Test A005 Required
+States 1
+0:R2=1; 0:R3=1; 0:R4=1; 0:R5=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R2=1 /\ 0:R3=1 /\ 0:R4=1 /\ 0:R5=1)
+Observation A005 Always 1 0
+Hash=7634bf6ce48a5ec0f06cfdcbe83bd2a2
+

--- a/herd/tests/instructions/ARM/A006.litmus
+++ b/herd/tests/instructions/ARM/A006.litmus
@@ -1,0 +1,10 @@
+ARM A006
+
+(*Tests parsing of IP register - otherwise known as R12*)
+{ 0:R12 = x; x=1}
+
+P0;
+LDR R1, [R12];
+LDR R2, [IP];
+
+forall (0:R1=1 /\ 0:R2=1)

--- a/herd/tests/instructions/ARM/A006.litmus.expected
+++ b/herd/tests/instructions/ARM/A006.litmus.expected
@@ -1,0 +1,10 @@
+Test A006 Required
+States 1
+0:R1=1; 0:R2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R1=1 /\ 0:R2=1)
+Observation A006 Always 1 0
+Hash=6df4dbc77a552cba2fdf46748d1e92d9
+

--- a/herd/tests/instructions/ARM/A007.litmus
+++ b/herd/tests/instructions/ARM/A007.litmus
@@ -1,0 +1,11 @@
+ARM A007
+
+Stable=R1,R2
+
+(* Tests LDM (2-reg variant) *)
+{ int x[2] = {1,2}; 0:R0 = x}
+
+P0;
+  LDM R0, { R1, R2 };
+
+forall (0:R1 = 1 /\ 0:R2 = 2)

--- a/herd/tests/instructions/ARM/A007.litmus.expected
+++ b/herd/tests/instructions/ARM/A007.litmus.expected
@@ -1,0 +1,10 @@
+Test A007 Required
+States 1
+0:R1=1; 0:R2=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R1=1 /\ 0:R2=2)
+Observation A007 Always 1 0
+Hash=399610b45809d8bab38135a3b19eb9df
+

--- a/herd/tests/instructions/ARM/A008.litmus
+++ b/herd/tests/instructions/ARM/A008.litmus
@@ -1,0 +1,10 @@
+ARM A008
+
+Stable=R0,R1,R2,R3
+(* Tests LDM (3-reg variant) *)
+{ int x[3] = {1,2,3}; 0:R0 = x}
+
+P0;
+  LDM R0, { R1, R2, R3 };
+
+forall (0:R1 = 1 /\ 0:R2 = 2 /\ 0:R3 = 3)

--- a/herd/tests/instructions/ARM/A008.litmus.expected
+++ b/herd/tests/instructions/ARM/A008.litmus.expected
@@ -1,0 +1,10 @@
+Test A008 Required
+States 1
+0:R1=1; 0:R2=2; 0:R3=3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R1=1 /\ 0:R2=2 /\ 0:R3=3)
+Observation A008 Always 1 0
+Hash=0e45af57c624e78be7cd0fd317d7e51b
+

--- a/herd/tests/instructions/ARM/A009.litmus
+++ b/herd/tests/instructions/ARM/A009.litmus
@@ -1,0 +1,9 @@
+ARM A009
+
+(* Tests LDM (2-reg variant IB) *)
+{ int x[3] = {1,2,3}; 0:R0 = x}
+
+P0;
+  LDMIB R0, { R1, R2 };
+
+forall (0:R1 = 2/\ 0:R2 = 3)

--- a/herd/tests/instructions/ARM/A009.litmus.expected
+++ b/herd/tests/instructions/ARM/A009.litmus.expected
@@ -1,0 +1,10 @@
+Test A009 Required
+States 1
+0:R1=2; 0:R2=3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R1=2 /\ 0:R2=3)
+Observation A009 Always 1 0
+Hash=fe765959009fb1eacd7bee92c02fe8fb
+

--- a/herd/tests/instructions/ARM/A010.litmus
+++ b/herd/tests/instructions/ARM/A010.litmus
@@ -1,0 +1,9 @@
+ARM A010
+
+(* Test LDR Offset *)
+{ int x[2] = {1,2}; 0:R0=x }
+
+P0;
+  LDR R1, [R0,#4];
+
+forall (0:R1 = 2)

--- a/herd/tests/instructions/ARM/A010.litmus.expected
+++ b/herd/tests/instructions/ARM/A010.litmus.expected
@@ -1,0 +1,10 @@
+Test A010 Required
+States 1
+0:R1=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R1=2)
+Observation A010 Always 1 0
+Hash=81521a0db638f43dc567a84e7411beb8
+

--- a/herd/tests/instructions/ARM/A011.litmus
+++ b/herd/tests/instructions/ARM/A011.litmus
@@ -1,0 +1,9 @@
+ARM A011
+
+(* Test MOVT Instr - simply moving 1 into upper bits *)
+{ 0:R0 = 0 }
+
+P0;
+MOVT R0, #1;
+
+forall 0:R0=0x10000

--- a/herd/tests/instructions/ARM/A011.litmus.expected
+++ b/herd/tests/instructions/ARM/A011.litmus.expected
@@ -1,0 +1,10 @@
+Test A011 Required
+States 1
+0:R0=65536;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R0=65536)
+Observation A011 Always 1 0
+Hash=6c83921ab28398e13c6a9d52e8461687
+

--- a/herd/tests/instructions/ARM/A012.litmus
+++ b/herd/tests/instructions/ARM/A012.litmus
@@ -1,0 +1,10 @@
+ARM A012
+
+(* Test MOVT Instr - simply moving 0 into upper bits *)
+(* should be idempotent - NOP *)
+{ 0:R0 = 0}
+
+P0;
+MOVT R0, #0;
+
+forall 0:R0=0x00000

--- a/herd/tests/instructions/ARM/A012.litmus.expected
+++ b/herd/tests/instructions/ARM/A012.litmus.expected
@@ -1,0 +1,10 @@
+Test A012 Required
+States 1
+0:R0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R0=0)
+Observation A012 Always 1 0
+Hash=741ae0900c1ec08d09c13e59fa1e17fe
+

--- a/herd/tests/instructions/ARM/A013.litmus
+++ b/herd/tests/instructions/ARM/A013.litmus
@@ -1,0 +1,9 @@
+ARM A013
+
+(* MOVT implementation *)
+{ 0:R0 = 0}
+
+P0;
+MOVT R0, #48879;
+
+forall 0:R0=0xBEEF0000

--- a/herd/tests/instructions/ARM/A013.litmus.expected
+++ b/herd/tests/instructions/ARM/A013.litmus.expected
@@ -1,0 +1,10 @@
+Test A013 Required
+States 1
+0:R0=-1091633152;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R0=-1091633152)
+Observation A013 Always 1 0
+Hash=aaba0ae318cbd1d05439a68e1c7235f7
+

--- a/herd/tests/instructions/ARM/A015.litmus
+++ b/herd/tests/instructions/ARM/A015.litmus
@@ -1,0 +1,13 @@
+ARM A015
+
+Stable=IP
+
+(* Test BX instruction *)
+{ 0:R0 = P0:foo}
+
+P0;
+  BX R0;
+  MOV R1, #1;
+foo:        ;
+
+forall (0:R1 = 0)

--- a/herd/tests/instructions/ARM/A015.litmus.expected
+++ b/herd/tests/instructions/ARM/A015.litmus.expected
@@ -1,0 +1,10 @@
+Test A015 Required
+States 1
+0:R1=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R1=0)
+Observation A015 Always 1 0
+Hash=a9ec21f13bd133372402c68bc771bc63
+

--- a/jingle/arch.ml
+++ b/jingle/arch.ml
@@ -115,6 +115,10 @@ module MakeCommon(A:Base) = struct
     let r,st = f st in
     g r,st
 
+  let (>!!) f g = fun st ->
+    let rs,stt = List.split (List.map f st) in
+    List.map g rs,stt
+
   let mapT f =
     let rec map_rec = function
       | [] -> unitT []

--- a/lib/ARMBase.ml
+++ b/lib/ARMBase.ml
@@ -64,12 +64,30 @@ let regs =
    R10, "R10" ;
    R11, "R11" ;
    R12, "R12" ;
+   R12, "IP" ;
    SP, "SP" ;
    LR, "LR" ;
    PC, "PC" ;
    Z, "Z" ;
    RESADDR, "RESADDR" ;
  ]
+
+(* this is used by instructions which load registers in pairs*)
+(* by specifying Rd1, and implicitly loading Rd2 - see LDRD  *)
+let next_reg = function
+  | R0 -> R1
+  | R1 -> R2 ;
+  | R2 -> R3 ;
+  | R3 -> R4 ;
+  | R4 -> R5 ;
+  | R5 -> R6 ;
+  | R6 -> R7 ;
+  | R7 -> R8 ;
+  | R8 -> R9 ;
+  | R9 -> R10 ;
+  | R10 -> R11 ;
+  | R11 -> R12 ;
+  | _ -> assert false
 
 let to_parse =
   List.filter
@@ -86,7 +104,7 @@ let parse_list =
        regs)
 
 let parse_reg s =
-  try Some (List.assoc s parse_list)
+  try Some (List.assoc (Misc.uppercase s) parse_list)
   with Not_found -> None
 
 let pp_reg r = match r with
@@ -172,13 +190,17 @@ type setflags = SetFlags | DontSetFlags
 
 type condition = NE | EQ | AL (* ALWAYS *)
 
+type increment = NO | IB
+
 type 'k kinstruction =
   | I_NOP
   | I_ADD of setflags * reg * reg * 'k
   | I_ADD3 of setflags * reg * reg * reg
+  | I_BX of reg
   | I_SUB of setflags * reg * reg * 'k
   | I_SUB3 of setflags * reg * reg * reg
   | I_AND of setflags * reg * reg * 'k
+  | I_ORR of setflags * reg * reg * 'k
   | I_B of lbl
   | I_BEQ of lbl
   | I_BNE of lbl (* Was maybeVal ??? *)
@@ -187,12 +209,18 @@ type 'k kinstruction =
   | I_CMP of reg * reg
   | I_LDR of reg * reg * condition
   | I_LDREX of reg * reg
+  | I_LDRO of reg * reg * 'k * condition
+  | I_LDM2 of reg * reg * reg * increment
+  | I_LDM3 of reg * reg * reg * reg * increment
+  | I_LDRD of reg * reg * reg * 'k option
   | I_LDR3 of reg * reg * reg * condition
   | I_STR of reg * reg * condition
   | I_STR3 of reg * reg * reg * condition
   | I_STREX of reg * reg * reg * condition
   | I_MOVI of reg * 'k * condition
   | I_MOV of reg * reg * condition
+  | I_MOVW of reg * 'k
+  | I_MOVT of reg * 'k
   | I_XOR of setflags * reg * reg * reg
   | I_DMB of barrier_option
   | I_DSB of barrier_option
@@ -239,9 +267,21 @@ let do_pp_instruction m =
     ","^ "[" ^ pp_reg rn ^ "]" in
   let ppi_rrm opcode rt rn =  ppi_rrmc opcode rt rn AL in
 
+  let pp_memom opcode = function
+  | NO -> opcode
+  | IB -> opcode ^ "IB" in
+
+  let ppi_rr_multiple opcode rt rs i =
+    pp_memom opcode i ^ " " ^ pp_reg rt ^ ", {" ^
+        (String.concat "," (List.map pp_reg rs)) ^ "}"in
+
   let ppi_rrrmc opcode rt ri rn c =
     pp_memoc opcode c^" "^pp_reg rt ^ ","^
     "[" ^ pp_reg ri ^ "," ^ pp_reg rn ^ "]" in
+
+  let ppi_rrkmc opcode rt ri k =
+    opcode ^" "^pp_reg rt ^ ","^
+    "[" ^ pp_reg ri ^ "," ^ m.pp_k k ^ "]" in
 
   let ppi_strex opcode rt rn rm c =
      pp_memoc opcode c^" "^pp_reg rt ^ ","^
@@ -261,6 +301,7 @@ let do_pp_instruction m =
   | I_SUB(s,rt,rn,v) -> ppi_rri "SUB" s rt rn v
   | I_SUB3 (s,r1,r2,r3) -> ppi_rrr "SUB" s r1 r2 r3
   | I_AND(s,rt,rn,v) -> ppi_rri "AND" s rt rn v
+  | I_ORR(s,rt,rn,v) -> ppi_rri "ORR" s rt rn v
   | I_B v -> "B " ^ pp_lbl v
   | I_BEQ(v) -> "BEQ "^ pp_lbl v
   | I_BNE(v) -> "BNE "^ pp_lbl v
@@ -268,15 +309,25 @@ let do_pp_instruction m =
       sprintf "CB%sZ" (if n then "N" else "") ^
       " " ^ pp_reg r ^ "," ^ pp_lbl lbl
   | I_CMPI (r,v) -> ppi_ri "CMP" r v
+  | I_BX r -> "BX " ^ (pp_reg r)
   | I_CMP (r1,r2) -> ppi_rr "CMP" r1 r2
   | I_LDREX(rt,rn) -> ppi_rrm "LDREX" rt rn
+  | I_LDM2(rt,r1,r2,i) -> ppi_rr_multiple "LDM" rt [r1; r2] i
+  | I_LDM3(rt,r1,r2,r3,i) -> ppi_rr_multiple "LDM" rt [r1;r2;r3] i
   | I_LDR(rt,rn,c) -> ppi_rrmc "LDR" rt rn c
+  | I_LDRD(rd1,rd2,rn,Some k) -> sprintf "LDRD %s, %s, [%s, %s]"
+      (pp_reg rd1) (pp_reg rd2) (pp_reg rn) (m.pp_k k)
+  | I_LDRD(rd1,rd2,rn,None) -> sprintf "LDRD %s, %s, [%s]"
+      (pp_reg rd1) (pp_reg rd2) (pp_reg rn)
   | I_LDR3(rt,rn,rm,c) -> ppi_rrrmc "LDR" rt rn rm c
+  | I_LDRO(rt,rn,k,_) -> ppi_rrkmc "LDR" rt rn k
   | I_STR(rt,rn,c) -> ppi_rrmc "STR" rt rn c
   | I_STR3(rt,rn,rm,c) -> ppi_rrrmc "STR" rt rn rm c
   | I_STREX(rt,rn,rm,c) -> ppi_strex "STREX" rt rn rm c
   | I_MOVI(r,i,c) -> ppi_ric "MOV" r i c
   | I_MOV(r1,r2,c) -> ppi_rrc "MOV" r1 r2 c
+  | I_MOVW(r1,k) -> "MOVW " ^ (pp_reg r1) ^ ", " ^ (m.pp_k k)
+  | I_MOVT(r1,k) -> "MOVT " ^ (pp_reg r1) ^ ", " ^ (m.pp_k k)
   | I_XOR(s,r1,r2,r3) -> ppi_rrr "EOR" s r1 r2 r3
   | I_DMB o -> pp_barrier_ins "DMB" o
   | I_DSB o -> pp_barrier_ins "DSB" o
@@ -317,13 +368,17 @@ let fold_regs (f_reg,f_sreg) =
   | I_ADD (_,r1, r2, _)
   | I_SUB (_,r1, r2, _)
   | I_AND (_,r1, r2, _)
+  | I_ORR (_,r1, r2, _)
   | I_LDR (r1, r2, _)
   | I_LDREX (r1, r2)
+  | I_LDRO (r1, r2,_,_)
   | I_STR (r1, r2, _)
   | I_MOV (r1, r2, _)
   | I_CMP (r1,r2)
       -> fold_reg r2 (fold_reg r1 c)
   | I_LDR3 (r1, r2, r3, _)
+  | I_LDRD (r1, r2, r3, _)
+  | I_LDM2 (r1, r2, r3,_)
   | I_ADD3 (_, r1, r2, r3)
   | I_SUB3 (_, r1, r2, r3)
   | I_STR3 (r1, r2, r3, _)
@@ -332,8 +387,12 @@ let fold_regs (f_reg,f_sreg) =
   | I_SADD16 (r1, r2, r3)
   | I_SEL (r1, r2, r3)
       -> fold_reg r3 (fold_reg r2 (fold_reg r1 c))
+  | I_LDM3 (r1, r2, r3,r4,_)
+      -> fold_reg r4 (fold_reg r3 (fold_reg r2 (fold_reg r1 c)))
+  | I_BX r
   | I_CMPI (r, _)
   | I_MOVI (r, _, _)
+  | I_MOVW (r,_) | I_MOVT (r,_)
   | I_CB (_,r,_)
       -> fold_reg r c
   | I_NOP
@@ -360,20 +419,28 @@ let map_regs f_reg f_symb =
   | I_SUB (s,r1, r2, k) -> I_SUB (s,map_reg r1, map_reg r2, k)
   | I_SUB3 (s,r1, r2, r3) -> I_SUB3 (s,map_reg r1, map_reg r2, map_reg r3)
   | I_AND (s,r1, r2, k) -> I_AND (s,map_reg r1, map_reg r2, k)
+  | I_ORR (s,r1, r2, k) -> I_ORR (s,map_reg r1, map_reg r2, k)
   | I_NOP
   | I_B _
   | I_BEQ _
   | I_BNE _ -> ins
+  | I_BX r -> I_BX (map_reg r)
   | I_CB (n,r,lbl) -> I_CB (n,map_reg r,lbl)
   | I_CMPI (r, k) -> I_CMPI (map_reg r, k)
   | I_CMP (r1, r2) -> I_CMP (map_reg r1, map_reg r2)
   | I_LDREX (r1, r2) -> I_LDREX (map_reg r1, map_reg r2)
+  | I_LDRO (r1, r2,k,c) -> I_LDRO (map_reg r1, map_reg r2,k,c)
   | I_LDR (r1, r2, c) -> I_LDR (map_reg r1, map_reg r2, c)
   | I_LDR3 (r1, r2, r3, c) -> I_LDR3 (map_reg r1, map_reg r2, map_reg r3, c)
+  | I_LDRD (r1, r2, r3, k) -> I_LDRD (map_reg r1, map_reg r2, map_reg r3, k)
+  | I_LDM2 (r1,r2,r3,i) -> I_LDM2 (map_reg r1, map_reg r2, map_reg r3,i)
+  | I_LDM3 (r1,r2,r3,r4,i) -> I_LDM3 (map_reg r1, map_reg r2, map_reg r3,map_reg r4, i)
   | I_STR (r1, r2, c) -> I_STR (map_reg r1, map_reg r2, c)
   | I_STR3 (r1, r2, r3, c) -> I_STR3 (map_reg r1, map_reg r2, map_reg r3, c)
   | I_STREX (r1, r2, r3, c) -> I_STREX (map_reg r1, map_reg r2, map_reg r3, c)
   | I_MOVI (r, k, c) -> I_MOVI (map_reg r, k, c)
+  | I_MOVW (r, k) -> I_MOVW (map_reg r, k)
+  | I_MOVT (r, k) -> I_MOVT (map_reg r, k)
   | I_MOV (r1, r2, c) -> I_MOV (map_reg r1, map_reg r2, c)
   | I_XOR (s,r1, r2, r3) -> I_XOR (s,map_reg r1, map_reg r2, map_reg r3)
   | I_DMB _
@@ -400,15 +467,22 @@ let get_next = function
   | I_SUB _
   | I_SUB3 _
   | I_AND _
+  | I_ORR _
   | I_CMPI _
   | I_CMP _
   | I_LDR _
+  | I_LDM2 _
+  | I_LDM3 _
   | I_LDREX _
+  | I_LDRO _
+  | I_LDRD _
   | I_LDR3 _
   | I_STR _
   | I_STR3 _
   | I_STREX _
   | I_MOVI _
+  | I_MOVW _
+  | I_MOVT _
   | I_MOV _
   | I_XOR _
   | I_DMB _
@@ -418,6 +492,7 @@ let get_next = function
   | I_SEL _
     -> [Label.Next]
   | I_B lbl -> [Label.To lbl]
+  | I_BX _ -> [Label.Any]
   | I_BEQ lbl|I_BNE lbl|I_CB (_,_,lbl) -> [Label.Next; Label.To lbl]
 
 include Pseudo.Make
@@ -430,8 +505,15 @@ include Pseudo.Make
         | I_ADD (c,r1,r2,k) ->  I_ADD (c,r1,r2,MetaConst.as_int k)
         | I_SUB (c,r1,r2,k) ->  I_SUB (c,r1,r2,MetaConst.as_int k)
         | I_AND (c,r1,r2,k) ->  I_AND (c,r1,r2,MetaConst.as_int k)
+        | I_ORR (c,r1,r2,k) ->  I_ORR (c,r1,r2,MetaConst.as_int k)
+        | I_LDRO (r1,r2,k,c) ->  I_LDRO (r1,r2,MetaConst.as_int k,c)
+        | I_LDRD (r1,r2,r3,Some k) ->  I_LDRD (r1,r2,r3,Some (MetaConst.as_int k))
+        | I_LDRD (r1,r2,r3,None) ->  I_LDRD (r1,r2,r3,None)
+        | I_BX r -> I_BX r
         | I_CMPI (r,k) -> I_CMPI (r,MetaConst.as_int k)
         | I_MOVI (r,k,c) -> I_MOVI (r,MetaConst.as_int k,c)
+        | I_MOVW (r,k) -> I_MOVW (r,MetaConst.as_int k)
+        | I_MOVT (r,k) -> I_MOVT (r,MetaConst.as_int k)
         | I_NOP
         | I_ADD3 _
         | I_SUB3 _
@@ -441,6 +523,8 @@ include Pseudo.Make
         | I_CB _
         | I_CMP _
         | I_LDR _
+        | I_LDM2 _
+        | I_LDM3 _
         | I_LDREX _
         | I_LDR3 _
         | I_STR _
@@ -463,13 +547,17 @@ include Pseudo.Make
         | I_SUB _
         | I_SUB3 _
         | I_AND _
+        | I_ORR _
         | I_B _
+        | I_BX _
         | I_BEQ _
         | I_BNE _
         | I_CB _
         | I_CMPI _
         | I_CMP _
         | I_MOVI _
+        | I_MOVW _
+        | I_MOVT _
         | I_MOV _
         | I_XOR _
         | I_DMB _
@@ -479,12 +567,18 @@ include Pseudo.Make
         | I_SEL _
           -> 0
         | I_LDR _
+        | I_LDM2 _
         | I_LDREX _
+        | I_LDRO _
         | I_LDR3 _
         | I_STR _
         | I_STR3 _
         | I_STREX _
             -> 1
+        | I_LDM3 _
+            -> 3
+        | I_LDRD _
+            -> 2
 
 
       let fold_labels k f = function
@@ -510,4 +604,10 @@ let get_id_and_list _i = Warn.fatal "get_id_and_list is only for Bell"
 
 let hash_pteval _ = assert false
 
-module Instr = Instr.No(struct type instr = instruction end)
+module Instr =
+  Instr.WithNop
+    (struct
+      type instr = instruction
+      let nop = I_NOP
+      let compare = compare
+    end)

--- a/lib/ARMLexer.mli
+++ b/lib/ARMLexer.mli
@@ -18,4 +18,5 @@
 
 module Make : functor(O:LexUtils.Config) -> sig
   val token : Lexing.lexbuf -> ARMParser.token
+  val check_name : string -> ARMParser.token
 end

--- a/lib/ARMLexer.mll
+++ b/lib/ARMLexer.mll
@@ -21,6 +21,58 @@ open LexMisc
 open ARMParser
 module ARM = ARMBase
 module LU = LexUtils.Make(O)
+
+let check_name name =
+match name with
+| "add" | "ADD" -> I_ADD
+| "adds" | "ADDS"   -> I_ADDS
+| "bx" | "BX" -> I_BX
+| "sub" | "SUB"   -> I_SUB
+| "subs" | "SUBS" -> I_SUBS
+| "and" | "AND"   -> I_AND
+| "orr" | "ORR"   -> I_ORR
+| "ands" | "ANDS"   -> I_ANDS
+| "bne" | "BNE"   -> I_BNE
+| "beq" | "BEQ"   -> I_BEQ
+| "cbz" | "CBZ"   -> I_CBZ
+| "cbnz" | "CBNZ"   -> I_CBNZ
+| "cmp" | "CMP"   -> I_CMP
+| "ldr" | "LDR"   -> I_LDR
+| "ldm" | "LDM"   -> I_LDM
+| "ldrd" | "LDRD"   -> I_LDRD
+| "ldmib" | "LDMIB"   -> I_LDMIB
+| "ldrex" | "LDREX"   -> I_LDREX
+| "ldrne" | "LDRNE"   -> I_LDRNE
+| "ldreq" | "LDREQ"   -> I_LDREQ
+| "str" | "STR"   -> I_STR
+| "strne" | "STRNE"   -> I_STRNE
+| "streq" | "STREQ"   -> I_STREQ
+| "strex" | "STREX" -> I_STREX
+| "mov" | "MOV"   -> I_MOV
+| "movw" | "MOVW" -> I_MOVW
+| "movt" | "MOVT" -> I_MOVT
+| "movne" | "MOVNE"   -> I_MOVNE
+| "moveq" | "MOVEQ"   -> I_MOVEQ
+| "xor" | "XOR"   -> I_XOR
+| "eor" | "EOR"   -> I_XOR
+| "eors" | "EORS" -> I_XOR
+| "dmb" | "DMB"   -> I_DMB
+| "dsb" | "DSB"   -> I_DSB
+| "isb" | "ISB"   -> I_ISB
+| "b" | "B" -> I_B
+| "sy" | "SY" -> I_SY
+| "st" | "ST" -> I_ST
+| "ish" | "ISH" -> I_ISH
+| "ishst" | "ISHST" -> I_ISHST
+| "nsh" | "NSH" -> I_NSH
+| "nshst" | "NSHST" -> I_NSHST
+| "osh" | "OSH" -> I_OSH
+| "oshst" | "OSHST" -> I_OSHST
+| _  -> begin match ARM.parse_reg name with
+  | Some r -> ARCH_REG r
+  | None -> NAME name
+  end
+
 }
 let digit = [ '0'-'9' ]
 let alpha = [ 'a'-'z' 'A'-'Z']
@@ -42,49 +94,11 @@ rule token = parse
 | '|' { PIPE }
 | '[' { LBRK }
 | ']' { RBRK }
+| '{' { LPAREN }
+| '}' { RPAREN }
 | ':' { COLON }
-| "add" | "ADD"   { I_ADD }
-| "adds" | "ADDS"   { I_ADDS }
-| "sub" | "SUB"   { I_SUB }
-| "subs" | "SUBS"   { I_SUBS }
-| "and" | "AND"   { I_AND }
-| "ands" | "ANDS"   { I_ANDS }
-| "bne" | "BNE"   { I_BNE }
-| "beq" | "BEQ"   { I_BEQ }
-| "cbz" | "CBZ"   { I_CBZ }
-| "cbnz" | "CBNZ"   { I_CBNZ }
-| "cmp" | "CMP"   { I_CMP }
-| "ldr" | "LDR"   { I_LDR }
-| "ldrex" | "LDREX"   { I_LDREX }
-| "ldrne" | "LDRNE"   { I_LDRNE }
-| "ldreq" | "LDREQ"   { I_LDREQ }
-| "str" | "STR"   { I_STR }
-| "strne" | "STRNE"   { I_STRNE }
-| "streq" | "STREQ"   { I_STREQ }
-| "strex" | "STREX" { I_STREX }
-| "mov" | "MOV"   { I_MOV }
-| "movne" | "MOVNE"   { I_MOVNE }
-| "moveq" | "MOVEQ"   { I_MOVEQ }
-| "xor" | "XOR"   { I_XOR }
-| "eor" | "EOR"   { I_XOR }
-| "eors" | "EORS"   { I_XOR }
-| "dmb" | "DMB"   { I_DMB }
-| "dsb" | "DSB"   { I_DSB }
-| "isb" | "ISB"   { I_ISB }
-| "b" | "B" { I_B }
-| "sy" | "SY" { I_SY }
-| "st" | "ST" { I_ST }
-| "ish" | "ISH" { I_ISH }
-| "ishst" | "ISHST" { I_ISHST }
-| "nsh" | "NSH" { I_NSH }
-| "nshst" | "NSHST" { I_NSHST }
-| "osh" | "OSH" { I_OSH }
-| "oshst" | "OSHST" { I_OSHST }
 | "codevar:" (name as x) { CODEVAR x }
-| name as x
-  { match ARM.parse_reg x with
-  | Some r -> ARCH_REG r
-  | None -> NAME x }
+| name as x { check_name x }
 | eof { EOF }
 | ""  { error "ARM lexer" lexbuf }
 

--- a/lib/ARMParser.mly
+++ b/lib/ARMParser.mly
@@ -27,12 +27,12 @@ module A = ARMBase
 %token <string> CODEVAR
 %token <int> PROC
 
-%token SEMI COMMA PIPE COLON LBRK RBRK
+%token SEMI COMMA PIPE COLON LBRK RBRK LPAREN RPAREN
 
 /* Instruction tokens */
 
-%token I_ADD I_ADDS I_SUB I_SUBS I_AND I_ANDS I_B I_BEQ I_BNE I_CMP I_MOV I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
-%token I_LDR I_LDREX I_LDRNE I_LDREQ I_STR I_STRNE I_STREQ I_STREX
+%token I_ADD I_ADDS I_BX I_SUB I_SUBS I_AND I_ORR I_ANDS I_B I_BEQ I_BNE I_CMP I_MOV I_MOVW I_MOVT I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
+%token I_LDR I_LDREX I_LDRNE I_LDREQ I_LDRD I_LDM I_LDMIB I_STR I_STRNE I_STREQ I_STREX
 %token I_SY I_ST I_ISH I_ISHST I_NSH I_NSHST I_OSH I_OSHST
 %type <MiscParser.proc list * (ARMBase.parsedPseudo) list list> main
 %start  main
@@ -90,6 +90,8 @@ instr:
      { A.I_ADD3 (A.DontSetFlags,$2, $4, $6) }
   | I_ADDS reg COMMA reg COMMA reg
      { A.I_ADD3 (A.SetFlags,$2, $4, $6) }
+  | I_BX reg
+     { A.I_BX $2 }
   | I_SUB reg COMMA reg COMMA k
      { A.I_SUB (A.DontSetFlags,$2,$4,$6) }
   | I_SUBS reg COMMA reg COMMA k
@@ -100,6 +102,8 @@ instr:
      { A.I_SUB3 (A.SetFlags,$2, $4, $6) }
   | I_AND reg COMMA reg COMMA k
      { A.I_AND (A.DontSetFlags,$2,$4,$6) }
+  | I_ORR reg COMMA reg COMMA k
+     { A.I_ORR (A.DontSetFlags,$2,$4,$6) }
   | I_ANDS reg COMMA reg COMMA k
      { A.I_AND (A.SetFlags,$2,$4,$6) }
   | I_B NAME
@@ -123,6 +127,8 @@ instr:
      { A.I_LDR ($2,$5,A.AL) }
   | I_LDR reg COMMA LBRK reg COMMA reg RBRK
      { A.I_LDR3 ($2,$5,$7,A.AL) }
+  | I_LDR reg COMMA LBRK reg COMMA k RBRK
+     { A.I_LDRO ($2,$5,$7,A.AL) }
   | I_LDRNE reg COMMA reg
      { A.I_LDR ($2,$4,A.NE) }
   | I_LDRNE reg COMMA LBRK reg RBRK
@@ -139,6 +145,24 @@ instr:
      { A.I_LDREX ($2,$4) }
   | I_LDREX reg COMMA LBRK reg RBRK
      { A.I_LDREX ($2,$5) }
+  (* 2-reg and 3-reg variants of LDM for now *)
+  | I_LDM reg COMMA LPAREN reg COMMA reg RPAREN
+     { A.I_LDM2 ($2, $5, $7, A.NO) }
+  | I_LDMIB reg COMMA LPAREN reg COMMA reg RPAREN
+     { A.I_LDM2 ($2, $5, $7, A.IB) }
+  | I_LDM reg COMMA LPAREN reg COMMA reg COMMA reg RPAREN
+     { A.I_LDM3 ($2, $5, $7, $9, A.NO) }
+  (* LDRD syntax comes in two forms - LDRD Rd1, Rd2, [Ra] and *)
+  (* LDRD Rd1, [Ra] - in both cases LDRD requires Rd2 is Rd(1+1) *)
+  (* so the second register can be and is omitted e.g  by GCC-10*)
+  | I_LDRD reg COMMA reg COMMA LBRK reg RBRK
+     { A.I_LDRD ($2,$4,$7,None) }
+  | I_LDRD reg COMMA LBRK reg RBRK
+     { A.I_LDRD ($2,A.next_reg $2,$5,None) }
+  | I_LDRD reg COMMA reg COMMA LBRK reg COMMA k RBRK
+     { A.I_LDRD ($2,$4,$7,Some $9) }
+  | I_LDRD reg COMMA LBRK reg COMMA k RBRK
+     { A.I_LDRD ($2,A.next_reg $2,$5,Some $7) }
 /* Store */
   | I_STR reg COMMA reg
      { A.I_STR ($2,$4,A.AL) }
@@ -173,6 +197,10 @@ instr:
      { A.I_MOV ($2,$4,A.NE) }
   | I_MOVEQ reg COMMA reg
      { A.I_MOV ($2,$4,A.EQ) }
+  | I_MOVW reg COMMA k
+     { A.I_MOVW ($2,$4)}
+  | I_MOVT reg COMMA k
+     { A.I_MOVT ($2,$4)}
   | I_XOR reg COMMA reg COMMA reg
      { A.I_XOR (A.DontSetFlags,$2,$4,$6) }
   | I_XORS reg COMMA reg COMMA reg

--- a/lib/instr.ml
+++ b/lib/instr.ml
@@ -54,3 +54,34 @@ module No (I:sig type instr end) = struct
       end)
 end
 
+module
+  WithNop
+    (I:sig
+         type instr
+         val nop : instr
+         val compare : instr -> instr -> int
+       end) =
+  struct
+    type t = I.instr
+
+    let fail msg =
+      Warn.fatal "Functionality %s not implemented for -variant self" msg
+
+    let compare = I.compare
+    let eq i1 i2 = I.compare i1 i2 = 0
+    let pp _ = fail ""
+    let tr i =
+      fail ("litteral instruction " ^ InstrLit.pp i)
+    let nop = Some I.nop
+    let is_nop i = eq i I.nop
+    let is_overwritable _ = false
+    let can_overwrite _ = false
+    let get_exported_label _ = None
+
+    module Set =
+      MySet.Make
+        (struct
+          type t = I.instr
+          let compare = I.compare
+        end)
+  end

--- a/lib/instr.mli
+++ b/lib/instr.mli
@@ -31,3 +31,12 @@ module type S = sig
 end
 
 module No : functor (I:sig type instr end) -> S with type t = I.instr
+
+module WithNop :
+functor
+  (I:sig
+       type instr
+       val nop : instr
+       val compare : instr -> instr -> int
+     end)
+-> S with type t = I.instr

--- a/litmus/ARMArch_litmus.ml
+++ b/litmus/ARMArch_litmus.ml
@@ -55,14 +55,70 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
         let reg_class _ = "=&r"
         let reg_class_stable _ = "=&r"
         let comment = comment
-        let error _ _ = false
-        let warn _ _ = false
+        let error t1 t2 =
+          let open CType in
+(*          Printf.eprintf "Error %s and %s\n" (debug t1) (debug t2) ; *)
+          match t1,t2 with
+          | (Base
+               ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"),
+             Pointer _)
+          | (Pointer _,
+             Base ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"))  ->
+              true
+
+          | _ -> false
+        let warn t1 t2 =
+          let open CType in
+          match t1,t2 with
+          | Base ("ins_t"|"int"|"int32_t"|"uint32_t"
+                  |"int16_t"|"uint16_t"
+                  |"int8_t"|"uint8_t"),
+            Base ("ins_t"|"int"|"int32_t"|"uint32_t") -> false
+          | (Base "int",_)|(_,Base "int") -> true
+          | _ -> false
       end)
   let features = []
   let nop = I_NOP
 
   include HardwareExtra.No
 
-  module GetInstr = GetInstr.No(struct type instr=instruction end)
+  module GetInstr = struct
+
+      type t = instruction
+
+      let self_instrs = [I_NOP; ]
+
+      let lower_instr i = Misc.lowercase (dump_instruction i)
+
+      let instr_name i =
+        MyName.name_as_symbol (Misc.skip_spaces (lower_instr i))
+
+      let fun_name i = sprintf "get%s" (instr_name i)
+
+      let dump_instr dump = function
+        | Constant.Instruction i -> instr_name i
+        | v -> dump v
+
+      module Make(O:Indent.S) = struct
+      let dump i =
+        O.f "static ins_t %s(void) {" (fun_name i) ;
+        O.oi "ins_t *x1;" ;
+        O.oi "ins_t r;" ;
+        O.oi "asm __volatile__ (" ;
+        O.fii "%S" "adr %[x1],0f\n\t" ;
+        O.fii "%S" "ldr %[x2],[%[x1]]\n\t" ;
+        O.fii "%S" "b 1f\n" ;
+        O.fii "%S" "0:\n\t" ;
+        O.fii "\"%s\\n\"" (lower_instr i) ;
+        O.fii "%S" "1:\n" ;
+        O.oii ":[x1] \"=&r\" (x1),[x2] \"=&r\" (r)" ;
+        O.oii ":" ;
+        O.oii ": \"cc\", \"memory\"" ;
+        O.o ");" ;
+        O.oi "return r;" ;
+        O.o "}" ;
+        O.o ""
+    end
+  end
 
 end

--- a/litmus/libdir/_arm/instruction.h
+++ b/litmus/libdir/_arm/instruction.h
@@ -1,0 +1,1 @@
+typedef uint32_t ins_t; /* Type of instructions */

--- a/litmus/libdir/pi2-nofp.cfg
+++ b/litmus/libdir/pi2-nofp.cfg
@@ -7,7 +7,7 @@ stride = 1
 memory = direct
 affinity = incr0
 force_affinity = true
-ccopts = -march=armv7-a -O2
+ccopts = -march=armv7-a -O0 -marm
 carch = ARM
 limit = true
 ascall = true

--- a/litmus/libdir/pi2.cfg
+++ b/litmus/libdir/pi2.cfg
@@ -7,6 +7,7 @@ stride = 1
 memory = direct
 affinity = incr0
 force_affinity = true
-ccopts = -march=armv7-a -O2
+ccopts = -march=armv7-a+fp -O0 -marm
 carch = ARM
 limit = true
+ascall = true


### PR DESCRIPTION
Motivation: I wish to test the compilation targeting Armv7, as such I add several new instructions and code improvements to bring the ARM Parser in line with the AArch64 parser. Each commit is as follows (with tests):
- Add MOVW,MOVT, BX, put instruction tokens in check_name (like AArch64Parser)
- Add LDR Offset instruction
- Add LDM Instruction Support
- Add Arm IP register support
- Add LDRD Instruction support
- Add ORR Instruction support

In each case regression tests are added and unless stated below, all pass in herd and litmus.

Thank you to Nikos for kindly letting me use his Raspberry Pi 2 to test these patches.
- Test A009 does not compile using litmus, as the Raspberry Pi 2 does not support the instruction. I cannot test this.
- Test A015 is a work in progress as it causes a core dump, and I do not understand why.

Interestingly the following tests produce strange and rather unusual behaviour on the Raspberry Pi when run under litmus. I wonder if there is a hardware bug in the implementation of `MOVT`. Consider the following litmus test:
```
ARM A012
{ 0:R0 = 0 }

P0;
  MOVT R0, #0;

forall 0:R0=0x0
```
That is, we expect the `MOVT` to move 0 into the top _move top_ 16 bits of register `R0`.

When run using litmus on the Raspberry Pi 2, we get the following strange output:
```
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
% Results for herd/tests/instructions/ARM/A012.litmus %
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
ARM A012

{
 0:R0=0x0;
}
 P0          ;
 MOVT R0, #0 ;

forall (0:R0=0x0)
Generated assembler
#START _litmus_P0
        movt r2,#0
Test A012 Required
Histogram (16384 states)
60    :>0:R0=0x0;
60    *>0:R0=0x4;
60    *>0:R0=0x8;
60    *>0:R0=0xc;
60    *>0:R0=0x10;
60    *>0:R0=0x14;
...
...
...
60    *>0:R0=0xfff0;
60    *>0:R0=0xfff4;
60    *>0:R0=0xfff8;
60    *>0:R0=0xfffc;
No

Witnesses
Positive: 60, Negative: 999940
Condition forall (0:R0=0x0) is NOT validated
Hash=741ae0900c1ec08d09c13e59fa1e17fe
Observation A012 Sometimes 60 999940
Time A012 194.56
```
It appears to be counting up in steps of 4 bits at a time - each execution is writing a different number to `R0`. Very strange! I did not expect such a simple MOV instruction to do this. It is not clear if the `0` has been moved into the top 16 bits of this example either. Let us try another test to see if the `MOVT` moves 1 into the top 16 bits:
```
ARM A011
{ 0:R0 = 0 }

P0;
  MOVT R0, #1;

forall 0:R0=0x10000
```
This produces the following output using Litmus on the raspberry pi 2:
```
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
% Results for herd/tests/instructions/ARM/A011.litmus %
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
ARM A011

{
 0:R0=0x0;
}
 P0          ;
 MOVT R0, #1 ;

forall (0:R0=0x10000)
Generated assembler
#START _litmus_P0
        movt r2,#1
Test A011 Required
Histogram (16384 states)
60    :>0:R0=0x10000;
60    *>0:R0=0x10004;
60    *>0:R0=0x10008;
...
...
...
60    *>0:R0=0x1fff4;
60    *>0:R0=0x1fff8;
60    *>0:R0=0x1fffc;
No

Witnesses
Positive: 60, Negative: 999940
Condition forall (0:R0=0x10000) is NOT validated
Hash=6c83921ab28398e13c6a9d52e8461687
Observation A011 Sometimes 60 999940
Time A011 192.14
```
So it appears that yes `1` is indeed moved into the top 16-bits of `R0`, however the lower 16 bits are still  being written two by many other executions. It is not clear to me why this is the case - this feels like a hardware bug.

Please let me know what you think.
Thanks
Luke


