### PR TITLE
[AArch64] Adjustments to the VMSA model in sync with Arm ARM J.a

### DIFF
--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -52,16 +52,16 @@ include "aarch64hwreqs.cat"
 let ca = fr | co
 
 (* Observed-by *)
-let obs = ([M & Exp | R & T & Imp]; (rf | ca); [M & Exp | R & T & Imp]) & ext
+let obs = ([Exp & M | Imp & T & R]; (rf | ca); [Exp & M | Imp & T & R]) & ext
 
 (* TLBI-after *)
 include "tlbi-after.cat"
-with tlbi-after from (pte-tlbi-pairs hw-reqs)
+with tlbi-after from (ttd-tlbi-pairs hw-reqs)
 
 (* TTD-read-ordered-before *)
 let TTD-read-ordered-before =
-  tlbi-after; [TLBI]; po; [dsb.full]; po; [~(M&Imp)]
-  | (if "ETS2" then tlbi-after; [TLBI]; po; [dsb.full]; po; [M & PTE & Imp] else 0)
+  tlbi-after; [TLBI]; po; [dsb.full]; po; [~(Imp & M)]
+  | (if "ETS2" then tlbi-after; [TLBI]; po; [dsb.full]; po; [Imp & TTD & M] else 0)
 
 (* TLBI-Ordered-Before *)
 let tlbi-ob =
@@ -71,23 +71,27 @@ let tlbi-ob =
 
 (* TLBI-Coherence-After *)
 let tlbi-ca =
-   [TLBI]; tlbi-after; [R & PTE & Imp]; ca; [W & PTE]
+   [TLBI]; tlbi-after; [Imp & TTD & R]; ca; [W]
 
 (* TLBUncacheable-Predecessor *)
 let TLBuncacheable-pred =
-  [range([TLBUncacheable & FAULT]; tr-ib^-1)]; ca \ intervening-write(ca); [W & PTE & Exp]
+  [range([TLBUncacheable & FAULT]; tr-ib^-1)]; ca \ intervening-write(ca); [Exp & W]
 
 (* Hardware-Update-Predecessor *)
 let HU-pred =
-  [PTE]; ca \ intervening-write(ca); [HU]
+  ca \ intervening-write(ca); [HU]
+
+(* Hazard-Ordered-Before *)
+let haz-ob =
+  [Exp & R]; po-loc; [Exp & R]; fre; [Exp & W]
 
 (* Ordered-before *)
 let rec ob =
      hw-reqs
-    | [R & Exp]; po-loc; [R & Exp]; fre ; [W & Exp]; si
+    | haz-ob
 
-    | obs; si
-    | [PTE & Imp]; rf | rf; [PTE & Imp]
+    | obs; sca-class?
+    | [Imp & TTD]; rf | rf; [Imp & TTD]
     | TLBuncacheable-pred
     | HU-pred
     | [HU]; co | co; [HU]
@@ -101,15 +105,15 @@ let rec ob =
 irreflexive ob as external
 
 (* Internal visibility requirements *)
-irreflexive [R & Exp]; (po-loc | rmw); [W & Exp]; rfi; [R & Exp] as coRW1-Exp
-irreflexive [R & T & Imp]; po-loc; [W & T & Exp]; rfi; [R & T & Imp] as coRW1-MTE
-irreflexive [W & Exp]; po-loc; [W & Exp]; (ca & int); [W & Exp] as coWW-Exp
-irreflexive [W & Exp]; po-loc; [R & Exp]; (ca & int); [W & Exp] as coWR-Exp
-irreflexive [W & Exp & T]; po-loc; [R & Imp & T]; (ca & int) as coWR-MTE
+irreflexive [Exp & R]; (po-loc | rmw); [Exp & W]; rfi; [Exp & R] as coRW1-Exp
+irreflexive [Imp & T & R]; po-loc; [Exp & T & W]; rfi; [Imp & T & R] as coRW1-MTE
+irreflexive [Exp & W]; po-loc; [Exp & W]; (ca & int); [Exp & W] as coWW-Exp
+irreflexive [Exp & W]; po-loc; [Exp & R]; (ca & int); [Exp & W] as coWR-Exp
+irreflexive [Exp & T & W]; po-loc; [Imp & T & R]; (ca & int) as coWR-MTE
 
 (* Atomic: LDXR/STXR, AMO and HU constraint to forbid intervening writes. *)
-empty (rmw & (fr; co)) \ (([Exp]; rmw; [Exp]) & (fri ; [W & Exp]; coi)) as atomic
+empty (rmw & (fr; co)) \ (([Exp]; rmw; [Exp]) & (fri ; [Exp & W]; coi)) as atomic
 
 (* Break Before Make *)
-let BBM = ([PTEV]; ca; [PTEINV]; co; [PTEV])
-flag ~empty (PTE-update-needsBBM & ~BBM) as requires-BBM
+let BBM = ([TTDV]; ca; [TTDINV]; co; [TTDV])
+flag ~empty (TTD-update-needsBBM & ~BBM) as requires-BBM

--- a/herd/libdir/aarch64bbm.cat
+++ b/herd/libdir/aarch64bbm.cat
@@ -82,3 +82,7 @@ let PTE-OA-update-writable = PTE-OA-update &
 let PTE-update-needsBBM = ([PTEV]; ca \ (ca; [PTEV]; ca); [PTEV]) &
   (PTE-MT-update | PTE-SH-update | PTE-ICH-update | PTE-OCH-update | PTE-DT-update
   | PTE-OA-update)
+
+let TTDV = PTEV
+let TTDINV = PTEINV
+let TTD-update-needsBBM = PTE-update-needsBBM

--- a/herd/libdir/aarch64hwreqs.cat
+++ b/herd/libdir/aarch64hwreqs.cat
@@ -48,11 +48,11 @@ include "aarch64util.cat"
 
 (* Translation-intrinsically-before *)
 let tr-ib =
-  [R & PTE & Imp]; iico_data; [B]; iico_ctrl; [M & Exp | MMU & FAULT]
+  [Imp & TTD & R]; iico_data; [B]; iico_ctrl; [Exp & M | MMU & FAULT]
 
 (* Notions of Same Location - PA, VA, and including Fault Effects *)
-let PTE-same-oa =  same-oa(PTE*PTE)
-let same-loc = loc | tr-ib^-1; PTE-same-oa; tr-ib
+let TTD-same-oa =  same-oa(TTD*TTD)
+let same-loc = loc | tr-ib^-1; TTD-same-oa; tr-ib
 let po-loc = po & same-loc
 
 let va-loc = (tr-ib; same-low-order-bits; tr-ib^-1) & loc
@@ -65,17 +65,17 @@ let lrs = [W]; (po-loc \ intervening-write(po-loc)) ; [R]
 let lws = [M]; po-loc; [W | MMU & FAULT]
 
 (* Tag-Check-Intrinsically-Before *)
-let tc-ib = [R & T & Imp]; iico_data; [B]; iico_ctrl; [(W & Exp) \ T | TagCheck & FAULT]
+let tc-ib = [Imp & T & R]; iico_data; [B]; iico_ctrl; [(Exp & W) \ T | TagCheck & FAULT]
 
-(* HW PTE Updates permitted only for the AF or DB *)
-let HU = W & PTE & Imp
+(* HW TTD Updates permitted only for the AF or DB *)
+let HU = Imp & TTD & W
 assert empty HU \ (AF | DB)
 
 (* CSE-ordered-before *)
 let EXC-ENTRY-CSE = EXC-ENTRY
 let EXC-RET-CSE = if not "ExS" || "EOS" then EXC-RET else {}
 let CSE = ISB | EXC-ENTRY-CSE | EXC-RET-CSE
-let CSE-ob = [R & Exp]; ctrl; [CSE]; po?
+let CSE-ob = [Exp & R]; ctrl; [CSE]; po?
 
 (* Dependency-ordered-before *)
 let dob = addr | data
@@ -88,7 +88,7 @@ let dob = addr | data
 (* Pick-ordered-before *)
 let pob = [Exp]; (pick-dep; [W]
         | (pick-ctrl-dep | pick-addr-dep; [Exp]; po); [CSE]; po; [M]
-        | pick-addr-dep; [M & Exp]; po; [W])
+        | pick-addr-dep; [Exp & M]; po; [W])
 
 (* Atomic-ordered-before *)
 let aob = rmw
@@ -97,11 +97,11 @@ let aob = rmw
 (* DSB-ordered-before *)
 let DSB-ob =
  [M]; po; [dsb.full]; po; [~(M&Imp)]
- | (if "ETS2" then [M]; po; [dsb.full]; po; [M & PTE & Imp] else 0)
+ | (if "ETS2" then [M]; po; [dsb.full]; po; [Imp & TTD & M] else 0)
  | [(R&Exp)\NoRet]; po; [dsb.ld]; po; [~(M&Imp)]
- | (if "ETS2" then [(R & Exp) \ NoRet]; po; [dsb.ld]; po; [M & PTE & Imp] else 0)
+ | (if "ETS2" then [(Exp & R) \ NoRet]; po; [dsb.ld]; po; [Imp & TTD & M] else 0)
  | [W&Exp]; po; [dsb.st]; po; [~(M&Imp)]
- | (if "ETS2" then [W & Exp]; po; [dsb.st]; po; [M & PTE & Imp] else 0)
+ | (if "ETS2" then [Exp & W]; po; [dsb.st]; po; [Imp & TTD & M] else 0)
 
 (* Barrier-ordered-before *)
 let bob = po; [dmb.full]; po
@@ -113,7 +113,7 @@ let bob = po; [dmb.full]; po
         | po; [L]
 
 (* Locally-ordered-before *)
-let rec lob = lws; si
+let rec lob = lws; sca-class?
             | dob
             | pob
             | aob
@@ -127,14 +127,14 @@ let TLBUncacheable = MMU & (Translation | AccessFlag)
 let rec hw-reqs =
   tr-ib
   | tc-ib
-  | [M & Exp | R & T & Imp]; (lob | pick-lob); [M & Exp | R & T & Imp | FAULT & (TagCheck | MMU)]
-  | (if "ETS2" then [M & Exp]; po; [TLBUncacheable & FAULT]; tr-ib^-1; [R & Imp & PTE] else 0)
+  | [Exp & M | Imp & T & R]; (lob | pick-lob); [Exp & M | Imp & T & R | FAULT & (TagCheck | MMU)]
+  | (if "ETS2" then [Exp & M]; po; [TLBUncacheable & FAULT]; tr-ib^-1; [Imp & TTD & R] else 0)
   | DSB-ob
   | CSE-ob
   | [CSE]; po
-  | [R & PTE & Imp]; po-loc; [W & PTE]
-  | [R & PTE & Imp]; rmw; [HU]
-  | [M & Exp]; po-loc; [TLBUncacheable & FAULT]
-  | [R & Exp]; addr; [TLBI]
-  | [R & Exp]; ctrl; [HU]
+  | [Imp & TTD & R]; po-loc; [W]
+  | [Imp & TTD & R]; rmw; [HU]
+  | [Exp & M]; po-loc; [TLBUncacheable & FAULT]
+  | [Exp & R]; addr; [TLBI]
+  | [Exp & R]; ctrl; [HU]
   | hw-reqs; hw-reqs

--- a/herd/libdir/aarch64util.cat
+++ b/herd/libdir/aarch64util.cat
@@ -100,8 +100,11 @@ end
 (* Intervening write *)
 let intervening-write(r) = r; [W]; r
 
+(* Properties of single-copy atomic accesses *)
+let sca-class = [M & Exp]; sm; [M & Exp]
+
 (* Renaming default herd names *)
 let Imp = NExp
 let SPONTANEOUS = SPURIOUS
 let inv-scope = inv-domain
-
+let TTD = PTE

--- a/herd/libdir/tlbi-after.cat
+++ b/herd/libdir/tlbi-after.cat
@@ -63,10 +63,12 @@ let CTLBI = TLBI & domain(po; [dsb.full])
 
 (* Compute all possible R&PTE <-> TLBI orders *)
 let all-pte-tlbi =
-  [R&PTE&Imp]; inv-scope; [CTLBI]
+  [Imp & PTE & R]; inv-scope; [CTLBI]
 
 let pte-tlbi-pairs rel =
     let all-pairs = all-pte-tlbi in
     let no-choice = rel & (all-pairs | all-pairs^-1) in
     let need-choosing = all-pairs \ (no-choice | no-choice^-1) in
     add_both_choices ({no-choice},need-choosing)
+
+let ttd-tlbi-pairs = pte-tlbi-pairs


### PR DESCRIPTION
This PR performs the following adjustments:
* Gives a name to a relation already included into `ob` (`haz-ob`)
* Removes several redundant endpoint constraints in relations (for instance, in `tlbi-ca`)
* Renames the relation `si` into `sca-class` and refines its use in `lob` and `ob`
* Renames occurrences of the `PTE` set into `TTD`
* Reorders endpoint constraints from, say, `R & PTE & Imp` into `Imp & TTD & R`