### PR TITLE
[build] Improve build time in ./version-gen.sh

### DIFF
--- a/defs-mini.sh
+++ b/defs-mini.sh
@@ -1,0 +1,4 @@
+set -o errexit
+
+VERSION=$(cat VERSION.txt)
+REV=$(git rev-parse HEAD 2>/dev/null || echo exported)

--- a/defs.sh
+++ b/defs.sh
@@ -1,5 +1,7 @@
 set -o errexit
 
+. ./defs-mini.sh
+
 # Extract binary names from dune files.
 binaries_of_dune () {
   local readonly kind="${1}"; shift
@@ -53,6 +55,3 @@ cpdir () {
 
   rm -rf "${to}" && mkdir -p "${to}" && ( cd "${from}" && cp -r . "${to}" )
 }
-
-VERSION=$(cat VERSION.txt)
-REV=$(git rev-parse HEAD 2>/dev/null || echo exported)

--- a/version-gen.sh
+++ b/version-gen.sh
@@ -12,7 +12,7 @@ fi
 
 readonly libdir="${1}/share/herdtools7"
 
-. ./defs.sh
+. ./defs-mini.sh
 
 cat > Version.ml <<EOF
 (* GENERATED, DO NOT EDIT *)


### PR DESCRIPTION
Gains 2s in every `make build` by making `./version.sh` instant.

This PR just divides `defs.sh` into two parts:
 - `defs-mini.sh` which just defines what are needed by `version-gen.sh`, viz. `$REV` and `$VERSION`.
 - `defs.sh` that parse dune files to find executables, using `defs-mini.sh`, and which is used by the other shell scripts

Before:
```shell
$ time ./version-gen.sh $HOME
./version-gen.sh $HOME  1.27s user 0.47s system 92% cpu 1.870 total
```

After:
```sh
$ time ./version-gen.sh $HOME
./version-gen.sh $HOME  0.01s user 0.02s system 67% cpu 0.043 total
```