### PR TITLE
[asl] Fix build for dune<3.0

### DIFF
--- a/asllib/tests/dune
+++ b/asllib/tests/dune
@@ -8,7 +8,7 @@
   (modes native)
   (modules asltests)
   (libraries asllib test_helpers)
-  (deps (glob_files asl/required/*.asl) %{test} ../libdir/stdlib.asl)
+  (deps (glob_files asl/required/*.asl) asltests.ml ../libdir/stdlib.asl)
   (action
     (setenv ASL_LIBDIR %{project_root}/asllib/libdir
       (run %{test} asl/required))))

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
-(ignored_subdirs (herd-www))
+(dirs :standard \ herd-www)
 (env
  (release
 (flags (:standard -w +a-3-4-9-29-33-41-45-60-67-70))))

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.4)
+(lang dune 1.6)
 (name herdtools7)
 (using menhir 2.0)

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -1,8 +1,7 @@
 opam-version: "2.0"
 name: "herdtools7"
-version: "7.56+02~dev"
+version: "7.56+04~dev"
 synopsis: "The herdtools suite for simulating and studying weak memory models"
-description: ""
 maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
 authors: [
   "Luc Maranget <Luc.Maranget@inria.fr>"
@@ -12,13 +11,17 @@ homepage: "http://diy.inria.fr/"
 bug-reports: "http://github.com/herd/herdtools7/issues/"
 doc: "http://diy.inria.fr/doc/index.html"
 dev-repo: "git+https://github.com/herd/herdtools7.git"
+license: "CECILL-B"
 build: ["sh" "./dune-build.sh" "%{prefix}%"]
 install: ["sh" "./dune-install.sh" "%{prefix}%"]
 # @todo Add "build-doc" field
 # @todo Add "build-test" field
 depends: [
-  "ocaml" {>= "4.05.0"}
-  "dune"  {>= "1.4" }
-  "ocamlfind" { build }
-  "menhir" {>= "20180530"}
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.6.3" }
+  "menhir" {>= "20200123"}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
+url {
+  src: "https://github.com/herd/herdtools7/"
+}


### PR DESCRIPTION
Questions that need answer before merging:
 - [x] Should we stop supporting dune<1.6 when it is not compatible with ocaml>=4.08 ?
 - [x] `asllib` with this patch is still not building with dune=1.6.0 for a reason that I don't really understand (see later comment).
 - [x] Fix deprecated dune usage with dune>=1.6.3