### PR TITLE
[AArch64 cat] Adjust pick-dtrm definition to restore intent

### DIFF
--- a/catalogue/aarch64-pick/shelf.py
+++ b/catalogue/aarch64-pick/shelf.py
@@ -66,4 +66,6 @@ illustrative_tests = [
     "tests/T15-datadep-corrected.litmus",
     "tests/LB+rel+pick-by-csel.litmus",
     "tests/LB+rel+CSEL-CSEL.litmus",
+    "tests/LB-ldxr-stxr-rel.litmus",
+    "tests/LB-swp-rel.litmus",
 ]

--- a/catalogue/aarch64-pick/tests/LB-ldxr-stxr-rel.litmus
+++ b/catalogue/aarch64-pick/tests/LB-ldxr-stxr-rel.litmus
@@ -1,0 +1,14 @@
+AArch64 LB-ldxr-stxr-rel
+{
+0:X1=x; 0:X3=y; 0:X10=z;
+1:X1=y; 1:X3=x;
+}
+ P0                 | P1           ;
+ LDR W0,[X1]        | LDR W0,[X1]  ;
+ LDXR W12,[X10]     | MOV W2,#1    ;
+ STXR W11,W0,[X10]  | STLR W2,[X3] ;
+ EOR W22, W12, W12  |              ;
+ ADD W2, W22, #1    |              ;
+ STR W2,[X3]        |              ;
+exists
+(0:X0=1 /\ 1:X0=1) /\ [z]=1

--- a/catalogue/aarch64-pick/tests/LB-swp-rel.litmus
+++ b/catalogue/aarch64-pick/tests/LB-swp-rel.litmus
@@ -1,0 +1,13 @@
+AArch64 LB-swp-rel
+{
+0:X1=x; 0:X3=y; 0:X10=z;
+1:X1=y; 1:X3=x;
+}
+ P0                 | P1           ;
+ LDR W0,[X1]        | LDR W0,[X1]  ;
+ SWP W0, W12, [X10] |              ; 
+ EOR W22, W12, W12  |              ; 
+ ADD W2, W22, #1    | MOV W2,#1    ;
+ STR W2,[X3]        | STLR W2,[X3] ;
+exists
+(0:X0=1 /\ 1:X0=1)

--- a/catalogue/aarch64-pick/tests/desired-kinds.txt
+++ b/catalogue/aarch64-pick/tests/desired-kinds.txt
@@ -54,3 +54,5 @@ T15-corrected             Forbid
 T15-datadep-corrected     Forbid
 LB+rel+pick-by-csel       Forbid
 LB+rel+CSEL-CSEL          Forbid
+LB-swp-rel                Allow
+LB-ldxr-stxr-rel          Allow

--- a/herd/libdir/aarch64deps.cat
+++ b/herd/libdir/aarch64deps.cat
@@ -59,7 +59,7 @@ let addr = (basic-dep; [ADDR]; iico_data+; [M | TLBI]) \ same-instance
 let ctrl = (basic-dep; [BCC]; po) \ same-instance
 
 (** Pick dependencies *)
-let pick-dtrm = (dtrm|iico_ctrl|iico_order)+
+let pick-dtrm = (dtrm|iico_ctrl)+
 
 let pick-basic-dep =
    [R|Rreg];  pick-dtrm?

--- a/herd/tests/instructions/AArch64/L035.litmus.expected
+++ b/herd/tests/instructions/AArch64/L035.litmus.expected
@@ -1,12 +1,13 @@
 Test L035 Allowed
-States 3
+States 4
 1:X1=0; [x]=1;
 1:X1=0; [x]=2;
 1:X1=1; [x]=1;
-No
+1:X1=1; [x]=2;
+Ok
 Witnesses
-Positive: 0 Negative: 3
+Positive: 1 Negative: 3
 Condition exists (1:X1=1 /\ [x]=2)
-Observation L035 Never 0 3
+Observation L035 Sometimes 1 3
 Hash=8975a8afb190cd7edcfaa831305de569
 

--- a/herd/tests/instructions/AArch64/L037.litmus.expected
+++ b/herd/tests/instructions/AArch64/L037.litmus.expected
@@ -1,12 +1,13 @@
 Test L037 Allowed
-States 3
+States 4
 1:X1=0; 1:X5=0; 1:X7=0;
 1:X1=0; 1:X5=0; 1:X7=1;
+1:X1=1; 1:X5=0; 1:X7=0;
 1:X1=1; 1:X5=0; 1:X7=1;
-No
+Ok
 Witnesses
-Positive: 0 Negative: 3
+Positive: 1 Negative: 3
 Condition exists (1:X1=1 /\ 1:X7=0 /\ 1:X5=0)
-Observation L037 Never 0 3
+Observation L037 Sometimes 1 3
 Hash=d36d2236545d29f0d2fd0edd2231a306
 

--- a/herd/tests/instructions/AArch64/L038.litmus.expected
+++ b/herd/tests/instructions/AArch64/L038.litmus.expected
@@ -1,12 +1,13 @@
 Test L038 Allowed
-States 3
+States 4
 1:X1=0; [x]=1;
 1:X1=0; [x]=2;
 1:X1=1; [x]=1;
-No
+1:X1=1; [x]=2;
+Ok
 Witnesses
-Positive: 0 Negative: 3
+Positive: 1 Negative: 3
 Condition exists (1:X1=1 /\ [x]=2)
-Observation L038 Never 0 3
+Observation L038 Sometimes 1 3
 Hash=c3cc8c9b6c039efe45c1cf847ca493b5
 

--- a/herd/tests/instructions/AArch64/L040.litmus.expected
+++ b/herd/tests/instructions/AArch64/L040.litmus.expected
@@ -1,12 +1,13 @@
 Test L040 Allowed
-States 3
+States 4
 1:X1=0; 1:X2=0; 1:X7=0;
 1:X1=0; 1:X2=0; 1:X7=1;
+1:X1=1; 1:X2=0; 1:X7=0;
 1:X1=1; 1:X2=0; 1:X7=1;
-No
+Ok
 Witnesses
-Positive: 0 Negative: 3
+Positive: 1 Negative: 3
 Condition exists (1:X1=1 /\ 1:X7=0 /\ 1:X2=0)
-Observation L040 Never 0 3
+Observation L040 Sometimes 1 3
 Hash=dd881259f50938615cb6e1bbd5a58350
 


### PR DESCRIPTION
In aarch64deps.cat, the definition of Pick-Dependencies-Through-Registers-and-Memory (pick-dtrm) erroneously referenced iico_order. This entails that the following test LB-swp-rel was forbidden, against the architectural intent:

```
AArch64 LB-swp-rel
{
0:X1=x; 0:X3=y; 0:X10=z;
1:X1=y; 1:X3=x;
}
 P0                 | P1           ;
 LDR W0,[X1]        | LDR W0,[X1]  ;
 SWP W0, W12, [X10] |              ;
 EOR W22, W12, W12  |              ;
 ADD W2, W22, #1    | MOV W2,#1    ;
 STR W2,[X3]        | STLR W2,[X3] ;
exists
(0:X0=1 /\ 1:X0=1)
```

Indeed the following sibling test LB-ldxr-stxr-rel was and still is correctly allowed:

```
AArch64 LB-ldxr-stxr-rel
{
0:X1=x; 0:X3=y; 0:X10=z;
1:X1=y; 1:X3=x;
}
 P0                 | P1           ;
 LDR W0,[X1]        | LDR W0,[X1]  ;
 LDXR W12,[X10]     | MOV W2,#1    ;
 STXR W11,W0,[X10]  | STLR W2,[X3] ;
 EOR W22, W12, W12  |              ;
 ADD W2, W22, #1    |              ;
 STR W2,[X3]        |              ;
exists
(0:X0=1 /\ 1:X0=1) /\ [z]=1
```

This change brings LB-swp-rel and LB-ldxr-stxr-rel on par with one another.