### PR TITLE
Further "-variant self" changes

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -67,7 +67,6 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64) :
       include ASLConf
 
       let byte = SZ.byte
-      let cache_type = TopConf.cache_type
       let dirty = TopConf.dirty
       let initwrites = false
     end
@@ -875,7 +874,6 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64) :
         let strictskip = true
         let through = Model.ThroughAll
         let cycles = StringSet.empty
-        let cache_type = TopConf.cache_type
         let dirty = TopConf.dirty
       end in
       let module ASL64M = MemCat.Make (MemConfig) (ASLS) in

--- a/herd/AArch64ParseTest.ml
+++ b/herd/AArch64ParseTest.ml
@@ -7,7 +7,7 @@ module Make(Conf:RunTest.Config)(ModelConfig:MemCat.Config) = struct
     let debug = Conf.debug.Debug_herd.lexer
   end
 
-  let run cache_type dirty start_time name chan env splitted =
+  let run dirty start_time name chan env splitted =
 
     let module Top (MakeSem:AArch64Sig.MakeSemantics) =
       struct
@@ -30,7 +30,6 @@ module Make(Conf:RunTest.Config)(ModelConfig:MemCat.Config) = struct
           module AArch64SemConf = struct
             module C = Conf
             let dirty = ModelConfig.dirty
-            let cache_type = ModelConfig.cache_type
             let procs_user = ProcsUser.get splitted.Splitter.info
           end
           module AArch64S = MakeSem(AArch64SemConf)(V)
@@ -64,9 +63,9 @@ module Make(Conf:RunTest.Config)(ModelConfig:MemCat.Config) = struct
 (* START NOTWWW *)
       if Conf.variant Variant.ASL then
         let module Run =  Top(AArch64ASLSem.Make) in
-        Run.run cache_type dirty start_time name chan env splitted
+        Run.run dirty start_time name chan env splitted
       else
 (* END NOTWWW *)
         let module Run = Top(AArch64Sem.Make) in
-        Run.run cache_type dirty start_time name chan env splitted
+        Run.run dirty start_time name chan env splitted
 end

--- a/herd/AArch64Sig.mli
+++ b/herd/AArch64Sig.mli
@@ -27,7 +27,6 @@ end
 
 module type Config = sig
   module C : SubConfig
-  val cache_type : CacheType.t option
   val dirty : DirtyBit.t option
   val procs_user : Proc.t list
 end

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -35,6 +35,8 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
     let is_explicit annot = annot
     let is_not_explicit annot = annot
 
+    let ifetch_value_sets = []
+
     let barrier_sets =
       [
        "DMB",is_barrier (DMB SY);

--- a/herd/MIPSArch_herd.ml
+++ b/herd/MIPSArch_herd.ml
@@ -31,6 +31,8 @@ module Make
     let empty_annot = false
     let is_atomic annot = annot
 
+    let ifetch_value_sets = []
+
     let barrier_sets = ["SYNC",(function Sync -> true);]
 
     let cmo_sets = []

--- a/herd/PPCArch_herd.ml
+++ b/herd/PPCArch_herd.ml
@@ -31,6 +31,8 @@ module Make (C:Arch_herd.Config) (V:Value.S)
     let is_atomic annot = annot
     let is_barrier b1 b2 = barrier_compare b1 b2 = 0
 
+    let ifetch_value_sets = []
+
     let barrier_sets =
       [
        "SYNC",is_barrier Sync;

--- a/herd/RISCVArch_herd.ml
+++ b/herd/RISCVArch_herd.ml
@@ -70,6 +70,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
       | X (Rlx|Rel|Acq|AcqRel)| P (Rlx|Rel|Acq|AcqRel) -> false
 
     let is_barrier b = fun c -> barrier_compare b c = 0
+
+    let ifetch_value_sets = []
+
     let barrier_sets =
       fold_barrier
         (fun f k ->

--- a/herd/X86Arch_herd.ml
+++ b/herd/X86Arch_herd.ml
@@ -36,6 +36,8 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
     let is_atomic annot = annot
     let is_barrier b1 b2 = barrier_compare b1 b2 = 0
 
+    let ifetch_value_sets = []
+
     let barrier_sets =
       [
        "MFENCE",is_barrier Mfence;

--- a/herd/X86_64Arch_herd.ml
+++ b/herd/X86_64Arch_herd.ml
@@ -40,6 +40,8 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
       | Plain|Atomic -> false
     let is_barrier b1 b2 = barrier_compare b1 b2 = 0
 
+    let ifetch_value_sets = []
+
     let barrier_sets =
       [
         "MFENCE",is_barrier MFENCE;

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -328,7 +328,7 @@ module Make(C:Config) (I:I) : S with module I = I
          When variant -self is enabled, it fails trying to convert a branch
          instruction to a label into a branch-with-offset representation. *)
       let convert_if_imm_branch _ _ _ _ i =
-        if C.variant Variant.Self then
+        if C.variant Variant.Ifetch then
           Warn.fatal "Functionality %s not implemented for -variant self" "convert_if_imm_branch"
         else
           i

--- a/herd/model.ml
+++ b/herd/model.ml
@@ -88,7 +88,6 @@ module type Config = sig
   val optace : OptAce.t
   val libfind : string -> string
   val variant : Variant.t -> bool
-  val cache_type : CacheType.t option
   val dirty : DirtyBit.t option
 end
 

--- a/herd/model.mli
+++ b/herd/model.mli
@@ -53,7 +53,6 @@ module type Config = sig
   val optace : OptAce.t
   val libfind : string -> string
   val variant : Variant.t -> bool
-  val cache_type : CacheType.t option
   val dirty : DirtyBit.t option
 end
 

--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -61,6 +61,18 @@ module Top (TopConf:RunTest.Config) = struct
           Conf.archcheck arch Conf.libfind Conf.variant Conf.model in
 
       let cache_type = CacheType.get splitted.Splitter.info in
+      let variant_patched_with_cache_type =
+         let dic_pred, idc_pred =
+            let open CacheType in
+               match cache_type with
+               | None ->
+                  (fun _ -> false), (fun _ -> false)
+               | Some cache_type ->
+                  cache_type.dic, cache_type.idc in
+         Misc.(|||) Conf.variant (function 
+            | Variant.DIC -> dic_pred 0
+            | Variant.IDC -> idc_pred 0
+            | _ -> false) in
       let dirty = DirtyBit.get splitted.Splitter.info in
 
       let module ModelConfig = struct
@@ -81,48 +93,47 @@ module Top (TopConf:RunTest.Config) = struct
         let cycles = Conf.cycles
         let optace = Conf.optace
         let libfind = Conf.libfind
-        let variant = Conf.variant
+        let variant = variant_patched_with_cache_type
         let dirty = dirty
-        let cache_type = cache_type
         let statelessrc11 = Conf.statelessrc11
       end in
       let module ArchConfig = SemExtra.ConfigToArchConfig(Conf) in
       match arch with
       | `PPC ->
          let module X = PPCParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
       | `ARM ->
          let module X = ARMParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
       | `AArch64 ->
          let module X = AArch64ParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
 
       | `X86 ->
          let module X = X86ParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
       | `X86_64 ->
          let module X = X86_64ParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
       | `MIPS ->
          let module X = MIPSParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
       | `RISCV ->
          let module X = RISCVParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
       | `C ->
          let module X = CParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
       | `JAVA ->
          let module X = JAVAParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
       | `LISA ->
          let module X = LISAParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
 (* START NOTWWW *)
       | `ASL ->
          let module X = ASLParseTest.Make(Conf)(ModelConfig) in
-         X.run cache_type dirty start_time name chan env splitted
+         X.run dirty start_time name chan env splitted
 (* END NOTWWW *)
       | arch -> Warn.fatal "no support for arch '%s'" (Archs.pp arch)
     end else env

--- a/herd/runTest.ml
+++ b/herd/runTest.ml
@@ -35,7 +35,6 @@ module type Config = sig
 end
 
 type runfun =
-  CacheType.t option ->
   DirtyBit.t option ->
   float (* start time *) ->
   string (* file name *) ->
@@ -54,7 +53,7 @@ module Make
     (C:Config) =
   struct
     module T = Test_herd.Make(S.A)
-     let run cache_type dirty start_time filename chan env splitted =
+     let run dirty start_time filename chan env splitted =
       try
          let parsed = P.parse chan splitted in
         let name = splitted.Splitter.name in
@@ -86,7 +85,6 @@ module Make
             (struct
               include C
               let byte = sz
-              let cache_type = cache_type
               let dirty = dirty
             end)(M) in
         T.run start_time test ;

--- a/herd/runTest.mli
+++ b/herd/runTest.mli
@@ -37,7 +37,6 @@ module type Config = sig
 end
 
 type runfun =
-  CacheType.t option ->
   DirtyBit.t option ->
   float (* start time *) ->
   string (* file name *) ->

--- a/herd/tests/instructions/AArch64.self/A007.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/A007.litmus.expected
@@ -1,0 +1,11 @@
+Test A007 Allowed
+States 2
+0:X2=1;
+0:X2=2;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists (0:X2=1)
+Observation A007 Sometimes 1 1
+Hash=77032c0be8690b2b66d8c9f20e2a5363
+

--- a/herd/tests/instructions/AArch64.self/A007.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.self/A007.litmus.expected-failure
@@ -1,1 +1,0 @@
-Warning: File "./herd/tests/instructions/AArch64.self/A007.litmus": Instruction L1:ADD W2,W2,#1 cannot be overwritten (User error)

--- a/herd/tests/instructions/AArch64.self/A010.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/A010.litmus.expected
@@ -1,0 +1,11 @@
+Test A010 Allowed
+States 2
+0:X2=1;
+0:X2=2;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists (0:X2=1)
+Observation A010 Sometimes 1 1
+Hash=77b235b3243a7010216394415245557e
+

--- a/herd/tests/instructions/AArch64.self/A010.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.self/A010.litmus.expected-failure
@@ -1,1 +1,0 @@
-Warning: File "./herd/tests/instructions/AArch64.self/A010.litmus": Instruction L1:ADD W2,W2,#1 cannot be overwritten (User error)

--- a/herd/tests/instructions/AArch64.self/A013.litmus
+++ b/herd/tests/instructions/AArch64.self/A013.litmus
@@ -1,0 +1,16 @@
+AArch64 A013
+{
+ 0:X0=instr:"NOP"; 0:X1=P0:Lself00;
+ 0:X3=P0:L0;
+}
+P0            ;
+ LDR W2,[X3]  ;
+L0:           ;
+ B L1         ;
+ NOP          ;
+L1:           ;
+              ;
+ STR W0,[X1]  ;
+Lself00:      ;
+ B Lout       ;
+Lout:         ;

--- a/herd/tests/instructions/AArch64.self/A013.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/A013.litmus.expected
@@ -1,0 +1,10 @@
+Test A013 Required
+States 1
+
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (true)
+Observation A013 Always 2 0
+Hash=2709172bb2cddf652d30338fd2804dea
+

--- a/herd/tests/instructions/AArch64.self/A014.litmus
+++ b/herd/tests/instructions/AArch64.self/A014.litmus
@@ -1,0 +1,16 @@
+AArch64 A014
+{
+ 0:X1=P0:Lself00;
+ 0:X3=P0:L0;
+}
+P0            ;
+ LDR W2,[X3]  ;
+L0:           ;
+ B L1         ;
+ NOP          ;
+L1:           ;
+              ;
+ STR W2,[X1]  ;
+Lself00:      ;
+ B Lout       ;
+Lout:         ;

--- a/herd/tests/instructions/AArch64.self/A014.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.self/A014.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.self/A014.litmus": Segmentation fault (kidding, address 0x2728 does not point to code) (User error)

--- a/herd/tests/instructions/AArch64.self/A015.litmus
+++ b/herd/tests/instructions/AArch64.self/A015.litmus
@@ -1,0 +1,11 @@
+AArch64 A015
+{
+  0:X0=NOP;0:X1=P0:Lself00; 0:X9=0;
+}
+P0                 ;
+L0:L1: STR W0,[X1];
+Lself00:    ;
+ B Lout     ;
+ MOV W9,#1  ;
+Lout:       ;
+exists 0:X9=0

--- a/herd/tests/instructions/AArch64.self/A015.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/A015.litmus.expected
@@ -1,0 +1,11 @@
+Test A015 Allowed
+States 2
+0:X9=0;
+0:X9=1;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists (0:X9=0)
+Observation A015 Sometimes 1 1
+Hash=6630f9344320cf27835f71f1bc488e31
+

--- a/herd/tests/instructions/AArch64.self/A016.litmus
+++ b/herd/tests/instructions/AArch64.self/A016.litmus
@@ -1,0 +1,13 @@
+AArch64 A016
+{
+  0:X1=P0:Lself00; 0:X9=0;
+  0:X2=P1:Lsrc;
+}
+P0          | P1;
+ LDR W0,[X2]| B Lout1 ;
+ STR W0,[X1]| L2: B Lout1;
+Lself00:    | L1:L0:Lsrc: NOP;
+ B Lout     |  NOP   ;
+ MOV W9,#1  |  NOP   ;
+Lout:       | Lout1: ;
+exists 0:X9=0

--- a/herd/tests/instructions/AArch64.self/A016.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/A016.litmus.expected
@@ -1,0 +1,11 @@
+Test A016 Allowed
+States 2
+0:X9=0;
+0:X9=1;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists (0:X9=0)
+Observation A016 Sometimes 1 1
+Hash=4030de5673678c66761560ccadc0ba40
+

--- a/herd/tests/instructions/AArch64.self/S23.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S23.litmus.expected
@@ -1,0 +1,11 @@
+Test S23 Required
+States 2
+t={1,3};
+t={3,2};
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (true)
+Observation S23 Always 2 0
+Hash=b5828ee8a20d1f9c72c22257755f5515
+

--- a/herd/tests/instructions/AArch64.self/S23.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.self/S23.litmus.expected-failure
@@ -1,1 +1,0 @@
-Warning: File "./herd/tests/instructions/AArch64.self/S23.litmus": Instruction L0:STR W1,[X2,#4] cannot be overwritten (User error)

--- a/herd/tests/instructions/AArch64.self/self.cfg
+++ b/herd/tests/instructions/AArch64.self/self.cfg
@@ -1,3 +1,3 @@
-variant self
+variant ifetch
 unroll 1
 cat cos.cat

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -40,7 +40,6 @@ end
 module type Config = sig
   include CommonConfig
   val byte : MachSize.sz
-  val cache_type : CacheType.t option
   val dirty : DirtyBit.t option
 end
 

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -69,7 +69,10 @@ type t =
 (* Perform experiment *)
   | Exp
 (* Instruction-fetch support (AKA "self-modifying code" mode) *)
-  | Self
+  | Ifetch
+(* CacheType features *)
+  | DIC
+  | IDC
 (* Have cat interpreter to optimise generation of co's *)
   | CosOpt
 (* Test something *)
@@ -131,7 +134,9 @@ let parse s = match Misc.lowercase s with
 | "optrfrmw" -> Some OptRfRMW
 | "constrainedunpredictable"|"cu" -> Some ConstrainedUnpredictable
 | "exp" -> Some Exp
-| "self" -> Some Self
+| "ifetch"|"self" -> Some Ifetch
+| "dic" -> None
+| "idc" -> None
 | "cos-opt" -> Some CosOpt
 | "test" -> Some Test
 | "asl" -> Some ASL
@@ -193,7 +198,9 @@ let pp = function
   | OptRfRMW -> "OptRfRMW"
   | ConstrainedUnpredictable -> "ConstrainedUnpredictable"
   | Exp -> "exp"
-  | Self -> "self"
+  | Ifetch -> "ifetch"
+  | DIC -> "dic"
+  | IDC -> "idc"
   | CosOpt -> "cos-opt"
   | Test -> "test"
   | T n -> Printf.sprintf "T%02i" n

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -67,7 +67,10 @@ type t =
 (* Perform experiment *)
   | Exp
 (* Instruction-fetch support (AKA "self-modifying code" mode) *)
-  | Self
+  | Ifetch
+(* CacheType features *)
+  | DIC
+  | IDC
 (* Have cat interpreter to optimise generation of co's *)
   | CosOpt
 (* Test something *)

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -2253,13 +2253,6 @@ let loop_idx = Internal 4
 
 let hash_pteval p = AArch64PteVal.pp_hash (AArch64PteVal.tr p)
 
-(* For performance reasons, overwritable sites are limited *)
-let is_overwritable = function
-  |I_NOP| I_B _|I_BC _|I_BL _|I_CBNZ _
-  |I_CBZ _|I_FENCE ISB|I_TBNZ _|I_TBZ _
-   -> true
-  | _ -> false
-
 (*
  * The set of overwriting instruction is more extensive.
  * Only branches to explicit labels are excluded, as their direct
@@ -2273,7 +2266,6 @@ let can_overwrite =
   | I_BC (_,Lbl _)
   | I_BL (Lbl _)
   | I_CBNZ (_,_,Lbl _) | I_CBZ (_,_,Lbl _)
-  | I_FENCE ISB
   | I_TBNZ (_,_,_,Lbl _)
   | I_TBZ (_,_,_,Lbl _)
     -> false
@@ -2283,7 +2275,6 @@ let can_overwrite =
 let get_exported_label = function
   | I_ADR (_,BranchTarget.Lbl lbl) -> Some lbl
   | _ -> None
-
 
 module
   MakeInstr
@@ -2316,8 +2307,7 @@ module
     | I_NOP -> true
     | _ -> false
 
-  let is_overwritable = is_overwritable
-  and can_overwrite =  can_overwrite
+  let can_overwrite =  can_overwrite
   and get_exported_label = get_exported_label
 
   module Set =

--- a/lib/cacheType.mli
+++ b/lib/cacheType.mli
@@ -14,6 +14,9 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
+(* DIC and IDC are set per proc for legacy reasons:
+ * they are used to compute hashes of litmus tests
+ *)
 type t =
   {
      dic : Proc.t -> bool;

--- a/lib/instr.ml
+++ b/lib/instr.ml
@@ -22,8 +22,9 @@ module type S = sig
   val tr : InstrLit.t -> t
   val nop : t option
   val is_nop : t -> bool
-  val is_overwritable : t -> bool
+
   val can_overwrite : t -> bool
+
   val get_exported_label : t -> Label.t option
 
   module Set : MySet.S with type elt = t
@@ -42,7 +43,6 @@ module No (I:sig type instr end) = struct
     fail ("litteral instruction " ^ InstrLit.pp i)
   let nop = None
   let is_nop _ = fail "is_nop"
-  let is_overwritable _ = false
   let can_overwrite _ = false
   let get_exported_label _ = None
 
@@ -74,7 +74,6 @@ module
       fail ("litteral instruction " ^ InstrLit.pp i)
     let nop = Some I.nop
     let is_nop i = eq i I.nop
-    let is_overwritable _ = false
     let can_overwrite _ = false
     let get_exported_label _ = None
 

--- a/lib/instr.mli
+++ b/lib/instr.mli
@@ -23,7 +23,7 @@ module type S = sig
   val tr : InstrLit.t -> t
   val nop : t option
   val is_nop : t -> bool
-  val is_overwritable : t -> bool
+
   val can_overwrite : t -> bool
   val get_exported_label : t -> Label.t option
 

--- a/lib/pseudo.ml
+++ b/lib/pseudo.ml
@@ -270,13 +270,13 @@ struct
     let rec do_rec addr code k =
       match code with
       | [] -> k
-      | Label (lbl,_)::rem ->
+      | Label (lbl,pseudoi)::rem ->
           let full_lbl = (p,lbl) in
           let k =
            if Label.Full.Set.mem full_lbl lbls then
              add_next_instr m addr full_lbl code k
            else k in
-          do_rec addr rem k
+          do_rec addr (pseudoi::rem) k
       | Instruction ins::rem ->
          do_rec (addr+I.size_of_ins ins)  rem k
       | Nop::rem -> do_rec addr rem k

--- a/lib/symbConstant.ml
+++ b/lib/symbConstant.ml
@@ -64,4 +64,5 @@ module Make
     | Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _ | Label _|Tag _|PteVal _
     | Frozen _
       -> false
+
 end


### PR DESCRIPTION
This is a PR aiming to make a few adjustments to the tools in relation to the ifetch functionality:
1. The set of ifetch accesses that need to be subject to CMODX rules is exported into cat.
2. Previously, ISB instructions were prevented from overwriting instructions -- this limitation is removed.
3. The support for DIC/IDC features is being changed. There has been feedback suggesting that the ifetch model will want to support those as globally enabled flags. To this end, these features are being implemented as variants, but the previously suggested syntax of using "CacheType" field is being preserved. Hence, the logic for this support is somewhat special.
4. The "self" semantics of AArch64 instructions drops the check for whether the instruction "is_overwriteable". It has been introduced for optimisation purposes, but presently the gains are minimal -- on the one hand. On the other, for running tests taking advantage of CMODX, this checks needs to be removed. Therefore, this PR suggests removing it (and, perhaps, reintroduce it via a flag once optimisation becomes necessary).
