### PR TITLE
[litmus] Rename mmu_get_pte to follow_pte

### DIFF
--- a/litmus/libdir/_aarch64/kvm-headers.h
+++ b/litmus/libdir/_aarch64/kvm-headers.h
@@ -24,7 +24,7 @@
 #define LITMUS_PAGE_SIZE PAGE_SIZE
 
 static inline pteval_t *litmus_tr_pte(void *p) {
-  return mmu_get_pte(mmu_idmap, (uintptr_t)p);
+  return follow_pte(mmu_idmap, (uintptr_t)p);
 }
 
 static inline void litmus_flush_tlb(void *p) {


### PR DESCRIPTION
This is necessary after the upstream change:

https://gitlab.com/kvm-unit-tests/kvm-unit-tests/-/commit/25ea27e9b9be5d27bc1d682d201c39274586e488