### PR TITLE
[dune] Fix `dune build` when no js_of_ocaml

### DIFF
--- a/defs-mini.sh
+++ b/defs-mini.sh
@@ -1,4 +1,0 @@
-set -o errexit
-
-VERSION=$(cat VERSION.txt)
-REV=$(git rev-parse HEAD 2>/dev/null || echo exported)

--- a/defs.sh
+++ b/defs.sh
@@ -1,16 +1,4 @@
 set -o errexit
 
-. ./defs-mini.sh
-
-cpdir () {
-  if [ "$#" -ne 2 ]
-  then
-    echo "Usage: cpdir <from> <to>"
-    exit 1
-  fi
-
-  local from="${1}"
-  local to="${2}"
-
-  rm -rf "${to}" && mkdir -p "${to}" && ( cd "${from}" && cp -r . "${to}" )
-}
+VERSION=$(cat VERSION.txt)
+REV=$(git rev-parse HEAD 2>/dev/null || echo exported)

--- a/dune
+++ b/dune
@@ -1,10 +1,17 @@
-(dirs :standard \ catalogue )
+(dirs :standard \ catalogue)
+
 (env
  (release
-(flags (:standard -w +a-3-4-9-29-33-41-45-60-67-70))))
+  (flags
+   (:standard -w +a-3-4-9-29-33-41-45-60-67-70))))
+
 (alias
-  (name zyva)
-  (deps (alias internal/all) (alias litmus/all) (alias herd/all)
-        (alias tools/all) (alias jingle/all) (alias gen/all)
-        (alias install)))
-(alias (name jerd) (deps (alias herd-www/all)))
+ (name default)
+ (deps
+   (alias install)
+   (alias internal/all)))
+
+(alias
+ (name jerd)
+ (deps
+  (alias herd-www/all)))

--- a/dune-build.sh
+++ b/dune-build.sh
@@ -17,5 +17,5 @@ set -x
 
 ./version-gen.sh "${prefix}"
 
-dune build --profile release @zyva
+dune build --profile release
 

--- a/dune-install.sh
+++ b/dune-install.sh
@@ -19,6 +19,19 @@ readonly libdir="${prefix}/share/herdtools7"
 
 . ./defs.sh
 
+cpdir () {
+  if [ "$#" -ne 2 ]
+  then
+    echo "Usage: cpdir <from> <to>"
+    exit 1
+  fi
+
+  local from="${1}"
+  local to="${2}"
+
+  rm -rf "${to}" && mkdir -p "${to}" && ( cd "${from}" && cp -r . "${to}" )
+}
+
 # Copy binaries
 dune install --prefix "${prefix}"
 

--- a/herd-www/dune
+++ b/herd-www/dune
@@ -1,11 +1,13 @@
-(copy_files (files ../herd/*.ml))
-(copy_files (files ../herd/*.mli))
-(executables
-  (names jerd)
+(copy_files (files ../herd/*.{ml,mli}))
+
+(executable
+  (name jerd)
   (modes js)
-  (libraries herdtools asllib)
+  (optional)
+  (libraries herdtools asllib js_of_ocaml)
   (preprocess (per_module
      ((pps js_of_ocaml-ppx) jerd)
      ((action (system "awk -f herd-www/notwww.awk %{input-file}"))
        AArch64ParseTest ParseTest Top_herd)))
   (modules_without_implementation AArch64Sig action arch_herd monad sem XXXMem))
+

--- a/herd/dune
+++ b/herd/dune
@@ -1,9 +1,11 @@
+(dirs :standard \ tests libdir)
+
 (rule (copy ../Version.ml Version.ml))
+
 (ocamllex lexConf_herd)
-(executables
-   (names
-   herd
-   )
-   (public_names herd7)
+
+(executable
+   (name herd)
+   (public_name herd7)
    (libraries unix herdtools)
    (modules_without_implementation AArch64Sig action arch_herd monad sem XXXMem))

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -18,8 +18,11 @@ install: ["sh" "./dune-install.sh" "%{prefix}%"]
 # @todo Add "build-test" field
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune"  {>= "1.6.3" }
+  "dune"  {>= "2.7" }
   "menhir" {>= "20200123"}
+]
+depopts: [
+  "js_of_ocaml-ppx"
 ]
 conflicts: ["ocaml-option-bytecode-only"]
 url {

--- a/version-gen.sh
+++ b/version-gen.sh
@@ -12,7 +12,7 @@ fi
 
 readonly libdir="${1}/share/herdtools7"
 
-. ./defs-mini.sh
+. ./defs.sh
 
 cat > Version.ml <<EOF
 (* GENERATED, DO NOT EDIT *)


### PR DESCRIPTION
This commit:
 1. Changes the alias `@default` of dune to simply `@install` and `internal/all`. This takes the place of the alias `@zyva` which is deleted. This doesn't change anything for people using the Makefile. The rationale behind this is:

    -  nothing else in the subdirectories needs to be built;
    - `herd-www` does not feature anything installable;
    - aliasing `@default` to `@install` was the behavior for `dune < 2.0.0` which just changed last week with #580;
    - the `make test` part that uses executables that are not installable and not in internal are built with `dune runtest`;
    - probably `make build` should not fail if `js_of_ocaml-ppx` is not installed, see 2.

 2. The preprocessing in `herd-www` with `js_of_ocaml-ppx` is now optional, which should not change anything in our configuration where `dune-build.sh` is doing the building job. Idem for the alias `@jerd`.
 3. `herdtools7.opam` now reflects the facts that:

    - `dune` is now required >= 2.7;
    - `js_of_ocaml-ppx` is an optional dependency.

 4. `defs-mini.sh` is deleted, as now `defs.sh` does not take far more time than `defs-mini.sh`. `cpdir` is moved to its only usage.

All these diffs happened while I was just trying to understand why `dune build` failed on my machine. I am not really attached to anything but I think that this is clearer than what was before.