### PR TITLE
[litmus] Add a cast onto "stable registers" initial values.

### DIFF
--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -384,7 +384,15 @@ module RegMap = A.RegMap)
                 (A.reg_to_string reg)
                 (match init_val reg t with
                 | None -> ""
-                | Some v -> sprintf " = %s" (compile_val v)))
+                | Some v ->
+                    begin
+                      match v with
+                      | Constant.Symbolic _ ->
+                          sprintf " = (%s)%s"
+                            (CType.dump ty) (compile_val v)
+                      | _ ->
+                          sprintf " = %s" (compile_val v)
+                    end))
           t.Tmpl.stable ;
 
         if O.cautious then begin


### PR DESCRIPTION
The cast fills  the gap from argument type (typically `* x_t`, when `x_t` is an array type) and register type (typically pointer to int).

Standard registers (_i.e._ non-stable) do not present the same difficulty because there is no C-level typing of inline assembly input and output.