### PR TITLE
[asl] Typing v0.2

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -137,14 +137,12 @@ and type_desc =
   | T_Real
   | T_String
   | T_Bool
-  | T_Bits of bits_constraint * bitfields option
+  | T_Bits of bits_constraint * bitfields
   | T_Enum of identifier list
   | T_Tuple of ty list
   | T_Array of expr * ty
   | T_Record of typed_identifier list
   | T_Exception of typed_identifier list
-  | T_ZType of ty
-      (** A Z-type correcponds to a type with a possible null value.*)
   | T_Named of identifier  (** A type variable. *)
 
 and ty = type_desc annotated
@@ -182,7 +180,6 @@ and typed_identifier = identifier * ty
 type lexpr_desc =
   | LE_Ignore
   | LE_Var of identifier
-  | LE_Typed of lexpr * ty
   | LE_Slice of lexpr * slice list
   | LE_SetField of lexpr * identifier * type_annot
   | LE_SetFields of lexpr * identifier list * type_annot
@@ -190,13 +187,20 @@ type lexpr_desc =
 
 and lexpr = lexpr_desc annotated
 
+type local_decl_keyword = LDK_Var | LDK_Constant | LDK_Let
+
+type local_decl_item =
+  | LDI_Var of identifier * ty option
+  | LDI_Ignore of ty option
+  | LDI_Tuple of local_decl_item list * ty option
+
 (** Statements. Parametric on the type of literals in expressions. *)
 type for_direction = Up | Down
 
 type stmt_desc =
   | S_Pass
   | S_Then of stmt * stmt
-  | S_TypeDecl of identifier * ty
+  | S_Decl of local_decl_keyword * local_decl_item * expr option
   | S_Assign of lexpr * expr
   | S_Call of identifier * expr list * (identifier * expr) list
   | S_Return of expr option
@@ -227,6 +231,9 @@ type 'body func_skeleton = {
 type func = stmt func_skeleton
 (** Function types in the AST. For the moment, they represent getters, setters,
     functions, procedures and primitives. *)
+
+(** Declaration keyword for global storage elements. *)
+type global_decl_keyword = GDK_Constant | GDK_Config | GDK_Let | GDK_Var
 
 (** Declarations, ie. top level statement in a asl file. *)
 type decl =

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -1,18 +1,15 @@
 open AST
-
 module ISet = Set.Make (String)
 
 module IMap : sig
   include Map.S with type key = identifier
 
   val of_list : (key * 'a) list -> 'a t
-
 end = struct
   include Map.Make (String)
 
   let of_list li =
     List.fold_left (fun acc (key, value) -> add key value acc) empty li
-
 end
 
 let dummy_pos = Lexing.dummy_pos
@@ -29,6 +26,31 @@ let map_desc_st f thing = f thing |> add_pos_from_st thing
 let add_pos_from pos desc = { pos with desc }
 let with_pos_from pos { desc; _ } = add_pos_from pos desc
 let map_desc f thing = f thing |> add_pos_from thing
+
+let list_equal equal li1 li2 =
+  li1 == li2 || (List.compare_lengths li1 li2 = 0 && List.for_all2 equal li1 li2)
+
+let rec list_compare cmp l1 l2 =
+  (* List.compare available >= 4.12 *)
+  match (l1, l2) with
+  | [], [] -> 0
+  | [], _ :: _ -> -1
+  | _ :: _, [] -> 1
+  | a1 :: l1, a2 :: l2 ->
+      let c = cmp a1 a2 in
+      if c <> 0 then c else list_compare cmp l1 l2
+
+(* Straight out of stdlib v5.0 *)
+let list_fold_left_map f accu l =
+  let rec aux accu l_accu = function
+    | [] -> (accu, List.rev l_accu)
+    | x :: l ->
+        let accu, x = f accu x in
+        aux accu (x :: l_accu) l
+  in
+  aux accu [] l
+
+let pair_equal f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 
 let map2_desc f thing1 thing2 =
   {
@@ -72,34 +94,37 @@ let slices_to_positions as_int =
   in
   fun positions -> List.map one_slice positions |> List.flatten
 
+let rec use_e acc e =
+  match e.desc with
+  | E_Literal _ -> acc
+  | E_Typed (e, _) -> use_e acc e
+  | E_Var x -> ISet.add x acc
+  | E_Binop (_op, e1, e2) -> use_e (use_e acc e2) e1
+  | E_Unop (_op, e) -> use_e acc e
+  | E_Call (x, args, named_args) ->
+      let acc = ISet.add x acc in
+      let acc = List.fold_left use_field acc named_args in
+      List.fold_left use_e acc args
+  | E_Slice (e, args) ->
+      let acc = use_e acc e in
+      List.fold_left use_slice acc args
+  | E_Cond (e1, e2, e3) -> use_e (use_e (use_e acc e1) e3) e2
+  | E_GetField (e, _, _ta) -> use_e acc e
+  | E_GetFields (e, _, _ta) -> use_e acc e
+  | E_Record (_ty, li, _ta) -> List.fold_left use_field acc li
+  | E_Concat es -> List.fold_left use_e acc es
+  | E_Tuple es -> List.fold_left use_e acc es
+  | E_Unknown _ -> acc
+  | E_Pattern (e, _p) -> use_e acc e
+
+and use_field acc (_, e) = use_e acc e
+
+and use_slice acc = function
+  | Slice_Single e -> use_e acc e
+  | Slice_Length (e1, e2) | Slice_Range (e1, e2) -> use_e (use_e acc e1) e2
+
 let used_identifiers, used_identifiers_stmt =
-  let rec use_e acc e =
-    match e.desc with
-    | E_Literal _ -> acc
-    | E_Typed (e, _) -> use_e acc e
-    | E_Var x -> ISet.add x acc
-    | E_Binop (_op, e1, e2) -> use_e (use_e acc e2) e1
-    | E_Unop (_op, e) -> use_e acc e
-    | E_Call (x, args, named_args) ->
-        let acc = ISet.add x acc in
-        let acc = List.fold_left use_field acc named_args in
-        List.fold_left use_e acc args
-    | E_Slice (e, args) ->
-        let acc = use_e acc e in
-        List.fold_left use_slice acc args
-    | E_Cond (e1, e2, e3) -> use_e (use_e (use_e acc e1) e3) e2
-    | E_GetField (e, _, _ta) -> use_e acc e
-    | E_GetFields (e, _, _ta) -> use_e acc e
-    | E_Record (_ty, li, _ta) -> List.fold_left use_field acc li
-    | E_Concat es -> List.fold_left use_e acc es
-    | E_Tuple es -> List.fold_left use_e acc es
-    | E_Unknown _ -> acc
-    | E_Pattern (e, _p) -> use_e acc e
-  and use_field acc (_, e) = use_e acc e
-  and use_slice acc = function
-    | Slice_Single e -> use_e acc e
-    | Slice_Length (e1, e2) | Slice_Range (e1, e2) -> use_e (use_e acc e1) e2
-  and use_s acc s =
+  let rec use_s acc s =
     match s.desc with
     | S_Pass | S_Return None -> acc
     | S_Then (s1, s2) -> use_s (use_s acc s1) s2
@@ -111,11 +136,10 @@ let used_identifiers, used_identifiers_stmt =
         List.fold_left use_e acc args
     | S_Cond (e, s1, s2) -> use_s (use_s (use_e acc e) s2) s1
     | S_Case (e, cases) -> List.fold_left use_case (use_e acc e) cases
-    | S_TypeDecl _ -> acc
-    | S_For (_,e1,_,e2,s) ->
-        use_s (use_e (use_e acc e1) e2) s
-    | S_While (e,s) | S_Repeat (s,e) ->
-        use_s (use_e acc e) s
+    | S_For (_, e1, _, e2, s) -> use_s (use_e (use_e acc e1) e2) s
+    | S_While (e, s) | S_Repeat (s, e) -> use_s (use_e acc e) s
+    | S_Decl (_, _, Some e) -> use_e acc e
+    | S_Decl (_, _, None) -> acc
   and use_case acc { desc = _p, stmt; _ } = use_s acc stmt
   and use_le acc _le = acc
   and use_decl acc = function
@@ -129,6 +153,125 @@ let canonical_fields li =
   let compare (x, _) (y, _) = String.compare x y in
   List.sort compare li
 
+let rec value_equal v1 v2 =
+  match (v1, v2) with
+  | V_Bool b1, V_Bool b2 -> b1 = b2
+  | V_Int i1, V_Int i2 -> i1 = i2
+  | V_Real f1, V_Real f2 -> f1 = f2
+  | V_BitVector bv1, V_BitVector bv2 -> Bitvector.equal bv1 bv2
+  | V_Exception fs1, V_Exception fs2 | V_Record fs1, V_Record fs2 ->
+      List.compare_lengths fs1 fs2 = 0
+      &&
+      let fs1 = canonical_fields fs1 and fs2 = canonical_fields fs2 in
+      let field_equal (x1, v1) (x2, v2) =
+        String.equal x1 x2 && value_equal v1 v2
+      in
+      List.for_all2 field_equal fs1 fs2
+  | V_Tuple vs1, V_Tuple vs2 ->
+      List.compare_lengths vs1 vs2 = 0 && List.for_all2 value_equal vs1 vs2
+  | _ -> false
+
+let rec expr_equal eq e1 e2 =
+  e1 == e2 || eq e1 e2
+  ||
+  match (e1.desc, e2.desc) with
+  | E_Binop (o1, e11, e21), E_Binop (o2, e12, e22) ->
+      o1 = o2 && expr_equal eq e11 e12 && expr_equal eq e21 e22
+  | E_Binop _, _ | _, E_Binop _ -> false
+  | E_Call (x1, args1, _), E_Call (x2, args2, _) ->
+      String.equal x1 x2 && list_equal (expr_equal eq) args1 args2
+  | E_Call _, _ | _, E_Call _ -> false
+  | E_Concat li1, E_Concat li2 -> list_equal (expr_equal eq) li1 li2
+  | E_Concat _, _ | _, E_Concat _ -> false
+  | E_Cond (e11, e21, e31), E_Cond (e12, e22, e32) ->
+      expr_equal eq e11 e12 && expr_equal eq e21 e22 && expr_equal eq e31 e32
+  | E_Cond _, _ | _, E_Cond _ -> false
+  | E_Slice (e1, slices1), E_Slice (e2, slices2) ->
+      expr_equal eq e1 e2 && slices_equal eq slices1 slices2
+  | E_Slice _, _ | _, E_Slice _ -> false
+  | E_GetField (e1', f1, _), E_GetField (e2', f2, _) ->
+      String.equal f1 f2 && expr_equal eq e1' e2'
+  | E_GetField _, _ | _, E_GetField _ -> false
+  | E_GetFields (e1', f1s, _), E_GetFields (e2', f2s, _) ->
+      list_equal String.equal f1s f2s && expr_equal eq e1' e2'
+  | E_GetFields _, _ | _, E_GetFields _ -> false
+  | E_Pattern _, _ | E_Record _, _ -> assert false
+  | E_Literal v1, E_Literal v2 -> value_equal v1 v2
+  | E_Literal _, _ | _, E_Literal _ -> false
+  | E_Tuple li1, E_Tuple li2 -> list_equal (expr_equal eq) li1 li2
+  | E_Tuple _, _ | _, E_Tuple _ -> false
+  | E_Typed (e1, t1), E_Typed (e2, t2) ->
+      expr_equal eq e1 e2 && type_equal eq t1 t2
+  | E_Typed _, _ | _, E_Typed _ -> false
+  | E_Unop (o1, e1), E_Unop (o2, e2) -> o1 = o2 && expr_equal eq e1 e2
+  | E_Unop _, _ | _, E_Unop _ -> false
+  | E_Unknown _, _ | _, E_Unknown _ -> false
+  | E_Var s1, E_Var s2 -> String.equal s1 s2
+  | E_Var _, _ (* | _, E_Var _ *) -> false
+
+and slices_equal eq slices1 slices2 =
+  list_equal (slice_equal eq) slices1 slices2
+
+and slice_equal eq slice1 slice2 =
+  slice1 == slice2
+  ||
+  match (slice1, slice2) with
+  | Slice_Single e1, Slice_Single e2 -> expr_equal eq e1 e2
+  | Slice_Range (e11, e21), Slice_Range (e12, e22)
+  | Slice_Length (e11, e21), Slice_Length (e12, e22) ->
+      expr_equal eq e11 e12 && expr_equal eq e21 e22
+  | _ -> false
+
+and constraint_equal eq c1 c2 =
+  c1 == c2
+  ||
+  match (c1, c2) with
+  | Constraint_Exact e1, Constraint_Exact e2 -> expr_equal eq e1 e2
+  | Constraint_Range (e11, e21), Constraint_Range (e12, e22) ->
+      expr_equal eq e11 e12 && expr_equal eq e21 e22
+  | _ -> false
+
+and constraints_equal eq cs1 cs2 =
+  cs1 == cs2 || list_equal (constraint_equal eq) cs1 cs2
+
+and type_equal eq t1 t2 =
+  t1.desc == t2.desc
+  ||
+  match (t1.desc, t2.desc) with
+  | T_Bool, T_Bool
+  | T_Real, T_Real
+  | T_String, T_String
+  | T_Int None, T_Int None ->
+      true
+  | T_Int (Some c1), T_Int (Some c2) -> constraints_equal eq c1 c2
+  | T_Bits (w1, bf1), T_Bits (w2, bf2) ->
+      bitwidth_equal eq w1 w2 && bitfields_equal eq bf1 bf2
+  | T_Array (l1, t1), T_Array (l2, t2) ->
+      expr_equal eq l1 l2 && type_equal eq t1 t2
+  | T_Named s1, T_Named s2 -> String.equal s1 s2
+  | T_Enum li1, T_Enum li2 ->
+      (* TODO: order of fields? *) list_equal String.equal li1 li2
+  | T_Exception f1, T_Exception f2 | T_Record f1, T_Record f2 ->
+      list_equal
+        (pair_equal String.equal (type_equal eq))
+        (canonical_fields f1) (canonical_fields f2)
+  | T_Tuple ts1, T_Tuple ts2 -> list_equal (type_equal eq) ts1 ts2
+  | _ -> false
+
+and bitwidth_equal eq w1 w2 =
+  w1 == w2
+  ||
+  match (w1, w2) with
+  | BitWidth_Constrained c1, BitWidth_Constrained c2 ->
+      constraints_equal eq c1 c2
+  | BitWidth_ConstrainedFormType t1, BitWidth_ConstrainedFormType t2 ->
+      type_equal eq t1 t2
+  | BitWidth_Determined e1, BitWidth_Determined e2 -> expr_equal eq e1 e2
+  | _ -> false
+
+and bitfields_equal eq bf1 bf2 =
+  bf1 == bf2 || (list_equal (pair_equal String.equal (slices_equal eq))) bf1 bf2
+
 let literal v = E_Literal v |> add_dummy_pos
 let var_ x = E_Var x |> add_dummy_pos
 let binop op = map2_desc (fun e1 e2 -> E_Binop (op, e1, e2))
@@ -137,7 +280,6 @@ let expr_of_lexpr : lexpr -> expr =
   let rec aux le =
     match le.desc with
     | LE_Var x -> E_Var x
-    | LE_Typed (le, t) -> E_Typed (map_desc aux le, t)
     | LE_Slice (le, args) -> E_Slice (map_desc aux le, args)
     | LE_SetField (le, x, ta) -> E_GetField (map_desc aux le, x, ta)
     | LE_SetFields (le, x, ta) -> E_GetFields (map_desc aux le, x, ta)
@@ -191,7 +333,7 @@ let num_args = function
   | 0 -> Fun.id
   | n -> fun name -> name ^ "-" ^ string_of_int n
 
-let default_t_bits = T_Bits (BitWidth_Constrained [], None)
+let default_t_bits = T_Bits (BitWidth_Constrained [], [])
 
 let patch ~src ~patches =
   (* Size considerations:
@@ -209,3 +351,74 @@ let patch ~src ~patches =
   in
   let filter d = not (ISet.mem (identifier_of_decl d) to_remove) in
   src |> List.filter filter |> List.rev_append patches
+
+let list_cross f li1 li2 =
+  List.fold_left
+    (fun xys x -> List.fold_left (fun xys' y -> f x y :: xys') xys li2)
+    [] li1
+  |> List.rev
+
+exception FailedConstraintOp
+
+let constraint_binop op =
+  let do_op c1 c2 =
+    match (c1, c2) with
+    | Constraint_Exact e1, Constraint_Exact e2 ->
+        Constraint_Exact (binop op e1 e2)
+    | _ -> raise_notrace FailedConstraintOp
+  in
+  fun cs1 cs2 -> try list_cross do_op cs1 cs2 with FailedConstraintOp -> []
+
+let rec subst_expr substs e =
+  (* WARNING: only subst runtime vars. *)
+  let tr e = subst_expr substs e in
+  add_pos_from_st e
+  @@
+  match e.desc with
+  | E_Var s -> (
+      match List.assoc_opt s substs with None -> e.desc | Some e' -> e'.desc)
+  | E_Binop (op, e1, e2) -> E_Binop (op, tr e1, tr e2)
+  | E_Concat es -> E_Concat (List.map tr es)
+  | E_Cond (e1, e2, e3) -> E_Cond (tr e1, tr e2, tr e3)
+  | E_Call (x, args, ta) -> E_Call (x, List.map tr args, ta)
+  | E_GetField (e, x, ta) -> E_GetField (tr e, x, ta)
+  | E_GetFields (e, fields, ta) -> E_GetFields (tr e, fields, ta)
+  | E_Literal _ -> e.desc
+  | E_Pattern (e, ps) -> E_Pattern (tr e, ps)
+  | E_Record (t, fields, ta) ->
+      E_Record (t, List.map (fun (x, e) -> (x, tr e)) fields, ta)
+  | E_Slice (e, slices) -> E_Slice (tr e, slices)
+  | E_Tuple es -> E_Tuple (List.map tr es)
+  | E_Typed (e, t) -> E_Typed (tr e, t)
+  | E_Unknown _ -> e.desc
+  | E_Unop (op, e) -> E_Unop (op, tr e)
+
+let dag_fold (def : AST.decl -> identifier) (use : AST.decl -> ISet.t)
+    (folder : AST.decl -> 'a -> 'a) (ast : AST.t) : 'a -> 'a =
+  let def_use_map =
+    List.fold_left
+      (fun def_use_map d ->
+        let x = def d and use_set = use d in
+        IMap.update x
+          (function
+            | None -> Some ([ d ], use_set)
+            | Some (li, use_set') -> Some (d :: li, ISet.union use_set use_set'))
+          def_use_map)
+      IMap.empty ast
+  in
+  let rec loop s (seen, acc) =
+    if not (ISet.mem s seen) then
+      let li, use_set = IMap.find s def_use_map in
+      let seen, acc = ISet.fold loop use_set (seen, acc) in
+      let acc = List.fold_left (Fun.flip folder) acc li in
+      let seen = ISet.add s seen in
+      (seen, acc)
+    else (seen, acc)
+  in
+  fun acc ->
+    let _seen, acc =
+      List.fold_left
+        (fun (seen, acc) d -> loop (def d) (seen, acc))
+        (ISet.empty, acc) ast
+    in
+    acc

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -1,12 +1,10 @@
 open AST
-
 module ISet : Set.S with type elt = identifier
 
 module IMap : sig
   include Map.S with type key = identifier
 
   val of_list : (key * 'a) list -> 'a t
-
 end
 
 val dummy_pos : Lexing.position
@@ -33,12 +31,29 @@ val stmt_from_list : stmt list -> stmt
 val mask_from_set_bits_positions : int -> int list -> string
 val inv_mask : string -> string
 val slices_to_positions : ('a -> int) -> ('a * 'a) list -> int list
+val use_e : ISet.t -> expr -> ISet.t
 val used_identifiers : decl list -> ISet.t
 val used_identifiers_stmt : stmt -> ISet.t
 val canonical_fields : (String.t * 'a) list -> (String.t * 'a) list
 val literal : value -> expr
 val var_ : identifier -> expr
 val binop : binop -> expr -> expr -> expr
+val list_equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+val list_compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+
+val list_fold_left_map :
+  ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
+
+val list_cross : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+val expr_equal : (expr -> expr -> bool) -> expr -> expr -> bool
+val value_equal : value -> value -> bool
+val slice_equal : (expr -> expr -> bool) -> slice -> slice -> bool
+val slices_equal : (expr -> expr -> bool) -> slice list -> slice list -> bool
+val type_equal : (expr -> expr -> bool) -> ty -> ty -> bool
+
+val bitwidth_equal :
+  (expr -> expr -> bool) -> bits_constraint -> bits_constraint -> bool
+
 val expr_of_lexpr : lexpr -> expr
 val fresh_var : string -> string
 val big_union : expr list -> expr
@@ -53,3 +68,28 @@ val default_t_bits : type_desc
 
 val patch : src:AST.t -> patches:AST.t -> AST.t
 (** [patch ~src ~patches] replaces in [src] the global identifiers defined by [patches]. *)
+
+val constraint_binop :
+  binop -> int_constraints -> int_constraints -> int_constraints
+
+val subst_expr : (identifier * expr) list -> expr -> expr
+(** [subst_expr substs e] replaces the variables used inside [e] by their
+    associated expression in [substs], if any.
+
+    Warning: constants and statically-evaluated parts are not changed, for
+    example:
+      [E_Slice (E_Var "y", [Slice_Single (E_Var "y")])]
+    will become after [subst_expr [("y", E_Var "x")]]:
+      [E_Slice (E_Var "x", [Slice_Single (E_Var "y")])]
+*)
+
+val dag_fold :
+  (decl -> identifier) ->
+  (decl -> ISet.t) ->
+  (decl -> 'a -> 'a) ->
+  t ->
+  'a ->
+  'a
+(** [dag_fold def use folder ast a] is [a |> f d_1 |> ... f d_n] where [d_i]
+    spawns all declarations in AST, but in an order such that [use]/[def]
+    relations are respected. *)

--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -83,7 +83,6 @@ let tr_name s = match s with
 | "where"         -> WHERE
 | "while"         -> WHILE
 | "with"          -> WITH
-| "ztype"         -> ZTYPE
 | x               -> IDENTIFIER x
 
 }

--- a/asllib/PP.mli
+++ b/asllib/PP.mli
@@ -2,6 +2,8 @@ open AST
 
 type 'a printer = Format.formatter -> 'a -> unit
 
+(* Available from 4.12.0 *)
+val pp_print_seq : ?pp_sep:unit printer -> 'a printer -> 'a Seq.t printer
 val pp_pos : 'a annotated printer
 
 val pp_value : value printer

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -23,7 +23,7 @@
     let open AST in
     T_Bits (
       BitWidth_Determined (E_Literal (V_Int 1) |> ASTUtils.add_dummy_pos),
-      None)
+      [])
 %}
 
 %token <string> IDENTIFIER STRING_LIT MASK_LIT
@@ -200,7 +200,7 @@ let decl ==
 let annotated(x) == desc = x; { AST.{ desc; pos_start=$symbolstartpos; pos_end=$endpos }}
 
 let unimplemented_decl(x) == x; { None }
-let unimplemented_ty(x) == x; { AST.(T_Bits (BitWidth_Determined (E_Literal (V_Int 0) |> ASTUtils.add_dummy_pos), None)) }
+let unimplemented_ty(x) == x; { AST.(T_Bits (BitWidth_Determined (E_Literal (V_Int 0) |> ASTUtils.add_dummy_pos), [])) }
 
 
 let type_decl ==
@@ -252,7 +252,7 @@ let ty_non_tuple ==
   | BOOLEAN;  { AST.T_Bool      }
   | ~=tident; < AST.T_Named     >
   | BIT;      { t_bit           }
-  | BITS; e=pared(expr); { AST.(T_Bits (AST.BitWidth_Determined e, None)) }
+  | BITS; e=pared(expr); { AST.(T_Bits (AST.BitWidth_Determined e, [])) }
   (* | tident; pared(clist(expr)); <> *)
 
   | unimplemented_ty (
@@ -271,6 +271,8 @@ let tident ==
 let typeident == typeid
 let typeid == ident
 let ident == IDENTIFIER
+let ident_plus_record == ident | RECORD; { "record" }
+
 let qualident ==
     | q=QUALIFIER; DOT; i=ident; { q ^ "_" ^ i }
     | ident
@@ -468,30 +470,24 @@ let simple_stmt ==
 let assignment_stmt ==
   annotated (
     terminated_by(SEMICOLON,
-      |                       ~=lexpr; EQ; ~=expr; < AST.S_Assign >
-      |                ~=typed_le_var; EQ; ~=expr; < AST.S_Assign >
-      | CONSTANT;      ~=typed_le_var; EQ; ~=expr; < AST.S_Assign >
-      | CONSTANT; ~=annotated(le_var); EQ; ~=expr; < AST.S_Assign >
-    )
-  )
-  | t=annotated(ty_non_tuple); li=nclist(annotated(ident)); SEMICOLON;
-      {
-        let one_var x =
-          let le = AST.LE_Var x.AST.desc |> ASTUtils.add_pos_from x in
-          let e = AST.E_Unknown t |> ASTUtils.add_pos_from x in
-          AST.S_Assign (le, e) |> ASTUtils.add_pos_from x
-        in
-        List.map one_var li |> ASTUtils.stmt_from_list
-      }
+      | ~=lexpr; EQ; ~=expr; < AST.S_Assign >
+      | ldi=typed_le_ldi; EQ; ~=expr;
+        { AST.(S_Decl (LDK_Var, ldi, Some expr)) }
+      | CONSTANT; ldi=typed_le_ldi; EQ; ~=expr;
+        { AST.(S_Decl (LDK_Let, ldi, Some expr)) }
+      | CONSTANT; x=ident; EQ; ~=expr;
+        { AST.(S_Decl (LDK_Let, LDI_Var (x, None), Some expr)) }
+      | t=annotated(ty_non_tuple); li=nclist(~=ident; ~=none; < AST.LDI_Var >);
+          { AST.(S_Decl (LDK_Var, LDI_Tuple (li, Some t), None)) }
+      ))
 
+let none == { None }
 let le_var == ~=qualident; < AST.LE_Var >
 let lexpr_ignore == { AST.LE_Ignore }
 let unimplemented_lexpr(x) == x; lexpr_ignore
 
-let typed_le_var ==
-  annotated (
-    t=annotated(ty_non_tuple); le=annotated(le_var); { AST.LE_Typed (le, t) }
-  )
+let typed_le_ldi ==
+  t=annotated(ty_non_tuple); x=ident_plus_record; { AST.LDI_Var (x, Some t) }
 
 let lexpr :=
   annotated (

--- a/asllib/StaticInterpreter.ml
+++ b/asllib/StaticInterpreter.ml
@@ -1,13 +1,19 @@
 open AST
+open ASTUtils
+module SEnv = Env.Static
+open SEnv.Types
 
+let _test = false
 let fatal = Error.fatal
 let fatal_from = Error.fatal_from
+
+exception NotYetImplemented
 
 let value_as_int pos = function
   | V_Int i -> i
   | v -> fatal_from pos (Error.MismatchType (v, [ T_Int None ]))
 
-let binop pos op v1 v2 =
+let binop_values pos op v1 v2 =
   match (op, v1, v2) with
   (* int -> int -> int *)
   | PLUS, V_Int v1, V_Int v2 -> V_Int (v1 + v2)
@@ -43,26 +49,30 @@ let binop pos op v1 v2 =
   (* bits -> bits -> bits *)
   | EQ_OP, V_BitVector b1, V_BitVector b2 -> V_Bool (Bitvector.equal b1 b2)
   | NEQ, V_BitVector b1, V_BitVector b2 -> V_Bool (not @@ Bitvector.equal b1 b2)
+  | OR, V_BitVector b1, V_BitVector b2 -> V_BitVector (Bitvector.logor b1 b2)
   | _ -> fatal_from pos (Error.UnsupportedBinop (op, v1, v2))
 
-let unop pos op v =
+let unop_values pos op v =
   match (op, v) with
   | NEG, V_Int i -> V_Int ~-i
   | NEG, V_Real r -> V_Real ~-.r
   | BNOT, V_Bool b -> V_Bool (not b)
+  | NOT, V_BitVector bv -> V_BitVector (Bitvector.lognot bv)
   | _ -> fatal_from pos (Error.UnsupportedUnop (op, v))
 
-let rec static_eval (env : string -> value) : expr -> value =
+let rec static_eval (env : env) : expr -> value =
   let rec expr_ e =
     match e.desc with
     | E_Literal v -> v
-    | E_Var x -> env x
+    | E_Var x -> (
+        try SEnv.lookup_constants env x
+        with Not_found -> Error.fatal_from e (Error.UndefinedIdentifier x))
     | E_Binop (op, e1, e2) ->
         let v1 = expr_ e1 and v2 = expr_ e2 in
-        binop e op v1 v2
+        binop_values e op v1 v2
     | E_Unop (op, e) ->
         let v = expr_ e in
-        unop e op v
+        unop_values e op v
     | E_Slice (e', slices) ->
         let bv =
           match expr_ e' with
@@ -90,3 +100,663 @@ and slices_to_positions env =
         interval ptop plength
   in
   fun slices -> slices |> List.map slice_to_positions |> List.concat
+
+module Normalize = struct
+  type atom = identifier
+  type 'a disjunction = Disjunction of 'a list
+
+  module AtomOrdered = struct
+    type t = atom
+
+    let compare = String.compare
+  end
+
+  module AMap = Map.Make (AtomOrdered)
+
+  type monomial = Prod of int AMap.t
+
+  module MonomialOrdered = struct
+    type t = monomial
+
+    let compare (Prod ms1) (Prod ms2) = AMap.compare Int.compare ms1 ms2
+  end
+
+  module MMap = struct
+    include Map.Make (MonomialOrdered)
+
+    (* Available from 4.11.0 *)
+    let filter_map f m =
+      fold
+        (fun key v r -> match f key v with None -> r | Some v -> add key v r)
+        m empty
+  end
+
+  type polynomial = Sum of int MMap.t
+
+  type sign =
+    | Null
+    | StrictPositive
+    | Positive
+    | Negative
+    | StrictNegative
+    | NotNull
+
+  module PolynomialOrdered = struct
+    type t = polynomial
+
+    let compare (Sum p1) (Sum p2) = MMap.compare Int.compare p1 p2
+  end
+
+  module PMap = Map.Make (PolynomialOrdered)
+
+  type ctnts = Conjunction of sign PMap.t | Bottom
+  type ir_expr = (ctnts * polynomial) disjunction
+  (* Wanted invariants for (e : ir_expr) :
+     ⋁ {c | (c, d) ∈ e } <=> true                           (I₂)
+     ∀ (cᵢ, eᵢ), (cⱼ, eⱼ) ∈ e, i != j => cⱼ ∩ cⱼ = ∅        (I₃)
+  *)
+
+  (* ----------------------------------------------------------------------- *)
+  (* Printers *)
+
+  let pp_mono f (Prod mono, factor) =
+    let open Format in
+    let mono = AMap.filter (fun _ p -> p != 0) mono in
+    if AMap.is_empty mono then pp_print_int f factor
+    else (
+      pp_open_hbox f ();
+      let pp_sep f () = fprintf f "@ \u{d7} " in
+      if factor != 1 then (
+        pp_print_int f factor;
+        pp_sep f ());
+      PP.pp_print_seq ~pp_sep
+        (fun f (x, p) ->
+          pp_print_string f x;
+          match p with
+          | 1 -> ()
+          | 2 -> pp_print_string f "\u{b2}"
+          | _ -> fprintf f "^%d" p)
+        f (AMap.to_seq mono);
+      pp_close_box f ())
+
+  let pp_poly f (Sum poly) =
+    let open Format in
+    let poly = MMap.filter (fun _ f -> f != 0) poly in
+    if MMap.is_empty poly then pp_print_string f "0"
+    else (
+      pp_open_hvbox f 2;
+      let pp_sep f () = fprintf f "@ + " in
+      PP.pp_print_seq ~pp_sep pp_mono f (MMap.to_seq poly);
+      pp_close_box f ())
+
+  let pp_sign f s =
+    let s =
+      match s with
+      | Null -> "= 0"
+      | NotNull -> "!= 0"
+      | StrictPositive -> "> 0"
+      | Positive -> "\u{2265} 0"
+      | Negative -> "\u{2264} 0"
+      | StrictNegative -> "< 0"
+    in
+    Format.pp_print_string f s
+
+  let pp_ctnt f (p, s) =
+    let open Format in
+    fprintf f "@[<h>%a@ %a@]" pp_poly p pp_sign s
+
+  let pp_ctnts f =
+    let open Format in
+    function
+    | Bottom -> pp_print_string f "\u{22a5}"
+    | Conjunction m ->
+        if PMap.is_empty m then pp_print_string f "\u{22a4}"
+        else
+          let pp_sep f () = fprintf f "@ \u{2227} " in
+          fprintf f "@[<hov 2>%a@]"
+            (PP.pp_print_seq ~pp_sep pp_ctnt)
+            (PMap.to_seq m)
+
+  let pp_ctnts_and_poly f (ctnts, p) =
+    Format.fprintf f "@[<2>%a@ -> %a@]" pp_ctnts ctnts pp_poly p
+
+  let pp_ir f (Disjunction li) =
+    let open Format in
+    fprintf f "@[<v 2>%a@]"
+      (pp_print_list ~pp_sep:pp_print_space pp_ctnts_and_poly)
+      li
+
+  (* ----------------------------------------------------------------------- *)
+  (* Constructors *)
+
+  let disjunction map = Disjunction map
+  let ctnts_true : ctnts = Conjunction PMap.empty
+  let ctnts_false : ctnts = Bottom
+  let always e = Disjunction [ (ctnts_true, e) ]
+  let mono_one = Prod AMap.empty
+  let mono_of_var s = Prod (AMap.singleton s 1)
+  let poly_zero = Sum MMap.empty
+  let poly_of_var s = Sum (MMap.singleton (mono_of_var s) 1)
+  let poly_of_int i = Sum (MMap.singleton mono_one i)
+  let poly_neg (Sum monos) = Sum (MMap.map ( ~- ) monos)
+
+  let sign_not = function
+    | NotNull -> Null
+    | Null -> NotNull
+    | Positive -> StrictNegative
+    | Negative -> StrictPositive
+    | StrictPositive -> Negative
+    | StrictNegative -> Positive
+
+  exception ConjunctionBottomInterrupt
+
+  let sign_and _p s1 s2 =
+    match (s1, s2) with
+    | Null, Null
+    | Null, Positive
+    | Positive, Null
+    | Negative, Null
+    | Null, Negative
+    | Negative, Positive
+    | Positive, Negative ->
+        Some Null
+    | StrictPositive, StrictPositive
+    | StrictPositive, Positive
+    | Positive, StrictPositive
+    | Positive, NotNull
+    | NotNull, Positive
+    | StrictPositive, NotNull
+    | NotNull, StrictPositive ->
+        Some StrictPositive
+    | Positive, Positive -> Some Positive
+    | Negative, Negative -> Some Negative
+    | NotNull, NotNull -> Some NotNull
+    | StrictNegative, StrictNegative
+    | StrictNegative, Negative
+    | Negative, StrictNegative
+    | Negative, NotNull
+    | NotNull, Negative
+    | NotNull, StrictNegative
+    | StrictNegative, NotNull ->
+        Some StrictNegative
+    | Null, NotNull
+    | NotNull, Null
+    | Negative, StrictPositive
+    | StrictPositive, Negative
+    | StrictNegative, Positive
+    | Positive, StrictNegative
+    | Null, StrictPositive
+    | StrictPositive, Null
+    | Null, StrictNegative
+    | StrictNegative, Null
+    | StrictNegative, StrictPositive
+    | StrictPositive, StrictNegative ->
+        raise_notrace ConjunctionBottomInterrupt
+
+  let constant_satisfies c s =
+    match s with
+    | Null -> c = 0
+    | NotNull -> c != 0
+    | Positive -> c >= 0
+    | StrictPositive -> c > 0
+    | Negative -> c <= 0
+    | StrictNegative -> c <= 0
+
+  let ctnts_of_bool b = if b then ctnts_true else ctnts_false
+
+  let ctnts_not = function
+    | Bottom -> ctnts_true
+    | Conjunction ctnts -> (
+        try Conjunction (PMap.map sign_not ctnts)
+        with ConjunctionBottomInterrupt -> Bottom)
+
+  let sign_compare = Stdlib.compare
+  let mono_compare = MonomialOrdered.compare
+  let poly_compare (Sum p1) (Sum p2) = MMap.compare Int.compare p1 p2
+
+  let ctnts_compare cs1 cs2 =
+    match (cs1, cs2) with
+    | Bottom, Bottom -> 0
+    | Bottom, _ -> 1
+    | _, Bottom -> -1
+    | Conjunction ctnts1, Conjunction ctnts2 ->
+        PMap.compare sign_compare ctnts1 ctnts2
+
+  let ir_compare (Disjunction li1) (Disjunction li2) =
+    ASTUtils.list_compare
+      (fun (cs1, p1) (cs2, p2) ->
+        let n = ctnts_compare cs1 cs2 in
+        if n = 0 then poly_compare p1 p2 else n)
+      li1 li2
+
+  let add_mono_to_poly =
+    let updater factor = function
+      | None -> Some factor
+      | Some f ->
+          let f' = f + factor in
+          if f' = 0 then None else Some f'
+    in
+    fun mono factor -> MMap.update mono (updater factor)
+
+  let add_polys : polynomial -> polynomial -> polynomial =
+   fun (Sum monos1) (Sum monos2) ->
+    Sum (MMap.union (fun _mono c1 c2 -> Some (c1 + c2)) monos1 monos2)
+
+  let mult_monos : monomial -> monomial -> monomial =
+   fun (Prod map1) (Prod map2) ->
+    Prod (AMap.union (fun _ p1 p2 -> Some (p1 + p2)) map1 map2)
+
+  let mult_polys : polynomial -> polynomial -> polynomial =
+   fun (Sum monos1) (Sum monos2) ->
+    Sum
+      (MMap.fold
+         (fun m1 f1 ->
+           MMap.fold
+             (fun m2 f2 -> add_mono_to_poly (mult_monos m1 m2) (f1 * f2))
+             monos2)
+         monos1 MMap.empty)
+
+  let ctnts_and : ctnts -> ctnts -> ctnts =
+   fun c1 c2 ->
+    match (c1, c2) with
+    | Bottom, _ | _, Bottom -> Bottom
+    | Conjunction ctnts1, Conjunction ctnts2 -> (
+        try Conjunction (PMap.union sign_and ctnts1 ctnts2)
+        with ConjunctionBottomInterrupt -> Bottom)
+
+  let restrict (Disjunction ctntss1) (Disjunction li2) =
+    Disjunction
+      (ASTUtils.list_cross
+         (fun ctnts1 (ctnts2, e2) -> (ctnts_and ctnts1 ctnts2, e2))
+         ctntss1 li2)
+
+  let disjunction_or (Disjunction li1) (Disjunction li2) =
+    Disjunction (li1 @ li2)
+
+  let cross_num (Disjunction li1) (Disjunction li2) f =
+    let on_pair (ctnts1, e1) (ctnts2, e2) =
+      (ctnts_and ctnts1 ctnts2, f e1 e2)
+    in
+    Disjunction (ASTUtils.list_cross on_pair li1 li2)
+
+  let map_num f (Disjunction li1) =
+    Disjunction (List.map (fun (ctnt, e) -> (ctnt, f e)) li1)
+
+  let disjunction_cross f (Disjunction li1) (Disjunction li2) =
+    Disjunction (ASTUtils.list_cross f li1 li2)
+
+  let ir_to_cond sign (Disjunction li2) =
+    Disjunction
+      (List.map
+         (fun (ctnts, p) ->
+           ctnts_and (Conjunction (PMap.singleton p sign)) ctnts)
+         li2)
+
+  let rec to_ir env (e : expr) : ir_expr =
+    match e.desc with
+    | E_Literal (V_Int i) -> poly_of_int i |> always
+    | E_Var s ->
+        (match ASTUtils.IMap.find_opt s env.global.constants_values with
+        | Some (V_Int i) -> poly_of_int i
+        | Some _ -> poly_of_var s
+        | None -> (
+            match ASTUtils.IMap.find_opt s env.local.constants_values with
+            | Some (V_Int i) -> poly_of_int i
+            | _ -> poly_of_var s))
+        |> always
+    | E_Binop (PLUS, e1, e2) ->
+        let ir1 = to_ir env e1 and ir2 = to_ir env e2 in
+        cross_num ir1 ir2 add_polys
+    | E_Binop (MINUS, e1, e2) ->
+        let e2 = E_Unop (NEG, e2) |> ASTUtils.add_pos_from_st e2 in
+        E_Binop (PLUS, e1, e2) |> ASTUtils.add_pos_from_st e |> to_ir env
+    | E_Binop (MUL, e1, e2) ->
+        let ir1 = to_ir env e1 and ir2 = to_ir env e2 in
+        cross_num ir1 ir2 mult_polys
+    | E_Unop (NEG, e0) -> e0 |> to_ir env |> map_num poly_neg
+    | E_Cond (cond, e1, e2) ->
+        let Disjunction ctnts, Disjunction nctnts = to_cond env cond
+        and (Disjunction ir1) = to_ir env e1
+        and (Disjunction ir2) = to_ir env e2 in
+        let restrict ctnts (ctnts', p) = (ctnts_and ctnts ctnts', p) in
+        let ir1' = ASTUtils.list_cross restrict ctnts ir1
+        and ir2' = ASTUtils.list_cross restrict nctnts ir2 in
+        Disjunction (ir1' @ ir2')
+    | _ -> (
+        let v =
+          try static_eval env e
+          with Error.ASLException { desc = UnsupportedExpr _; _ } ->
+            raise NotYetImplemented
+        in
+        match v with
+        | V_Int i -> poly_of_int i |> always
+        | _ -> raise NotYetImplemented)
+
+  and to_cond env (e : expr) : ctnts disjunction * ctnts disjunction =
+    let ( ||| ) = disjunction_or in
+    let ( &&& ) = disjunction_cross ctnts_and in
+    match e.desc with
+    | E_Literal (V_Bool b) ->
+        (Disjunction [ ctnts_of_bool b ], Disjunction [ ctnts_of_bool (not b) ])
+    | E_Binop (BAND, e1, e2) ->
+        let ctnts1, nctnts1 = to_cond env e1
+        and ctnts2, nctnts2 = to_cond env e2 in
+        (ctnts1 &&& ctnts2, nctnts1 ||| nctnts2)
+    | E_Binop (BOR, e1, e2) ->
+        let ctnts1, nctnts1 = to_cond env e1
+        and ctnts2, nctnts2 = to_cond env e2 in
+        (ctnts1 ||| ctnts2, nctnts1 &&& nctnts2)
+    | E_Binop (EQ_OP, e1, e2) ->
+        let e' = E_Binop (MINUS, e1, e2) |> ASTUtils.add_pos_from_st e in
+        let ir = to_ir env e' in
+        (ir_to_cond Null ir, ir_to_cond NotNull ir)
+    | E_Cond (cond, e1, e2) ->
+        let ctnts_cond, nctnts_cond = to_cond env cond
+        and ctnts1, nctnts1 = to_cond env e1
+        and ctnts2, nctnts2 = to_cond env e2 in
+        ( ctnts_cond &&& ctnts1 ||| (nctnts_cond &&& ctnts2),
+          nctnts_cond ||| nctnts1 &&& (ctnts_cond ||| nctnts2) )
+    | _ -> raise NotYetImplemented
+
+  (* ----------------------------------------------------------------------- *)
+  (* Destructors *)
+  (* ----------- *)
+
+  let loc = dummy_annotated
+  let e_of_int i = V_Int i |> literal
+  let zero = e_of_int 0
+  let one = e_of_int 1
+  let cannot_happen_expr = zero
+  let e_true = V_Bool true |> literal
+  let e_false = V_Bool true |> literal
+  let e_var s = E_Var s |> add_pos_from loc
+
+  let e_band e1 e2 =
+    if e1 == e_true then e2 else if e2 == e_true then e1 else binop BAND e1 e2
+
+  let e_cond e1 e2 e3 = E_Cond (e1, e2, e3) |> add_pos_from loc
+
+  let monomial_to_expr (Prod map) =
+    let ( ** ) e1 e2 =
+      if e1 = one then e2 else if e2 = one then e1 else binop MUL e1 e2
+    in
+    let rec ( ^^ ) e = function
+      | 0 -> one
+      | 1 -> e
+      | 2 -> e ** e
+      | 3 -> e ** e ** e
+      | 4 -> e ** e ** e ** e
+      | n ->
+          let e' = e ^^ (n / 2) in
+          if n mod 2 = 0 then e' ** e' else e' ** e' ** e
+    in
+    AMap.fold (fun s p e -> (e_var s ^^ p) ** e) map
+
+  let polynomial_to_expr (Sum map) =
+    let ( ++ ) e1 e2 =
+      if e1 == zero then e2 else if e2 == zero then e1 else binop PLUS e1 e2
+    in
+    MMap.fold (fun m c e -> monomial_to_expr m (e_of_int c) ++ e) map zero
+
+  let sign_to_binop = function
+    | Null -> EQ_OP
+    | NotNull -> NEQ
+    | StrictPositive -> LT
+    | Positive -> LEQ
+    | Negative -> GEQ
+    | StrictNegative -> GT
+
+  let sign_to_expr sign e = binop (sign_to_binop sign) zero e
+
+  let ctnt_to_expr (Sum p) sign =
+    let c = try MMap.find mono_one p with Not_found -> 0
+    and p = Sum (MMap.remove mono_one p) in
+    binop (sign_to_binop sign) (e_of_int ~-c) (polynomial_to_expr p)
+
+  let ctnts_to_expr : ctnts -> expr option = function
+    | Bottom -> None
+    | Conjunction map ->
+        Some
+          (PMap.fold
+             (fun p sign e -> e_band (ctnt_to_expr p sign) e)
+             map e_true)
+
+  let of_ir : ir_expr -> expr = function
+    | Disjunction [] -> zero
+    | Disjunction [ (Conjunction map, p) ] when PMap.is_empty map ->
+        polynomial_to_expr p
+    | Disjunction [ (_, _) ] -> assert false
+    | Disjunction map ->
+        let map = List.rev map in
+        List.fold_left
+          (fun e (ctnts, p) ->
+            match ctnts_to_expr ctnts with
+            | None -> e
+            | Some cond -> e_cond cond (polynomial_to_expr p) e)
+          cannot_happen_expr map
+
+  let reduce_mono (Prod _) factor = if factor == 0 then None else Some factor
+
+  let rec int_exp x = function
+    | 0 -> 1
+    | 1 -> x
+    | 2 -> x * x
+    | 3 -> x * x * x
+    | n ->
+        let r = int_exp x (n / 2) in
+        let r2 = r * r in
+        if n mod 2 == 0 then r2 else r2 * x
+
+  type affectation = atom * int * polynomial option
+  type affectations = affectation list
+
+  let subst_mono (affectations : affectations) (Prod m) factor =
+    let m, factor =
+      List.fold_left
+        (fun (m, f) (a, v, _) ->
+          match AMap.find_opt a m with
+          | None -> (m, f)
+          | Some power -> (AMap.remove a m, f * int_exp v power))
+        (m, factor) affectations
+    in
+    (Prod m, factor)
+
+  let subst_poly (affectations : affectations) (Sum map as poly) =
+    Sum
+      (MMap.fold
+         (fun mono factor ->
+           let affectations =
+             List.filter
+               (function _, _, Some p -> poly_compare p poly != 0 | _ -> true)
+               affectations
+           in
+           let mono, factor = subst_mono affectations mono factor in
+           if factor != 0 then add_mono_to_poly mono factor else Fun.id)
+         map MMap.empty)
+
+  let reduce_poly affectations : polynomial -> polynomial =
+   fun (Sum ms) ->
+    Sum (ms |> MMap.filter_map reduce_mono) |> subst_poly affectations
+
+  let poly_get_constant_opt (Sum p) =
+    if MMap.is_empty p then Some 0
+    else if MMap.cardinal p = 1 then MMap.find_opt mono_one p
+    else None
+
+  let ctnt_is_trivial p s =
+    match poly_get_constant_opt p with
+    | Some c ->
+        if constant_satisfies c s then true
+        else raise_notrace ConjunctionBottomInterrupt
+    | None -> false
+
+  let reduce_ctnts affectations : ctnts -> ctnts = function
+    | Bottom -> Bottom
+    | Conjunction ctnts -> (
+        try
+          Conjunction
+            (PMap.fold
+               (fun p s ->
+                 let p = reduce_poly affectations p in
+                 if ctnt_is_trivial p s then Fun.id
+                 else
+                   PMap.update p (function
+                     | None -> Some s
+                     | Some s' -> sign_and p s s'))
+               ctnts PMap.empty)
+        with ConjunctionBottomInterrupt -> Bottom)
+
+  let poly_get_linear (Sum ms) =
+    let ms = MMap.filter (fun _ f -> f != 0) ms in
+    let n = MMap.cardinal ms in
+    if false && n > 2 then None
+    else
+      let exception NotLinear in
+      let mono_get_linear (Prod m) =
+        match AMap.bindings m |> List.filter (fun (_, p) -> p != 0) with
+        | [] -> None
+        | [ (x, 1) ] -> Some x
+        | [ (_, 0) ] -> assert false
+        | [ (_, _) ] -> raise NotLinear
+        | _ :: _ :: _ -> raise NotLinear
+      in
+      let o, c =
+        try
+          MMap.fold
+            (fun mono factor o ->
+              match (o, mono_get_linear mono) with
+              | (o, c), None -> (o, c - factor)
+              | (None, c), Some x -> (Some x, c)
+              | (Some x, _), Some x' ->
+                  assert (not (String.equal x x'));
+                  raise_notrace NotLinear)
+            ms (None, 0)
+        with NotLinear -> (None, 0)
+      in
+      match o with
+      | None ->
+          if c != 0 then raise_notrace ConjunctionBottomInterrupt else None
+      | Some x -> Some (x, c)
+
+  let deduce_equations : ctnts -> ctnts * affectations = function
+    | Bottom -> (Bottom, [])
+    | Conjunction map as ctnts -> (
+        try
+          let affectations =
+            PMap.fold
+              (fun p s affectations ->
+                if s != Null then affectations
+                else
+                  match poly_get_linear p with
+                  | None -> affectations
+                  | Some (s, i) -> (s, i, Some p) :: affectations)
+              map []
+          in
+          (reduce_ctnts affectations ctnts, affectations)
+        with ConjunctionBottomInterrupt -> (Bottom, []))
+
+  let ctnts_get_trivial_opt = function
+    | Bottom -> Some false
+    | Conjunction li -> (
+        try if PMap.for_all ctnt_is_trivial li then Some true else None
+        with ConjunctionBottomInterrupt -> Some false)
+
+  let reduce (Disjunction ir) =
+    Disjunction
+      ( ir
+      |> List.filter_map (fun (ctnts, p) ->
+             let ctnts, affectations = deduce_equations ctnts in
+             match ctnts with
+             | Bottom -> None
+             | Conjunction _ as c -> Some (c, reduce_poly affectations p))
+      |> fun li ->
+        List.fold_right
+          (fun (ctnts, p) acc ->
+            match ctnts_get_trivial_opt ctnts with
+            | Some true -> [ (ctnts_true, p) ]
+            | Some false -> acc
+            | None -> (ctnts, p) :: acc)
+          li [] )
+
+  let normalize (env : env) (e : expr) : expr =
+    e |> to_ir env |> reduce |> of_ir
+
+  let free_variables (Disjunction li) =
+    let mono_free (Prod map) = AMap.fold (fun s _ -> ISet.add s) map in
+    let poly_free (Sum map) = MMap.fold (fun m _ -> mono_free m) map in
+    let ctnt_free p _s = poly_free p in
+    let ctnts_free = function
+      | Bottom -> Fun.id
+      | Conjunction map -> PMap.fold ctnt_free map
+    in
+    List.fold_left
+      (fun acc (ctnts, p) -> acc |> poly_free p |> ctnts_free ctnts)
+      ISet.empty li
+
+  let equal_mod_branches (Disjunction li1) (Disjunction li2) =
+    let to_cond (ctnts1, p1) (ctnts2, p2) =
+      let equality =
+        let p = add_polys p1 (poly_neg p2) in
+        Conjunction (PMap.singleton p Null)
+      in
+      let ctnts = ctnts_and ctnts1 ctnts2 in
+      let ctnts, affectations = deduce_equations ctnts in
+      let affectations =
+        List.map (fun (x, v, _) -> (x, v, None)) affectations
+      in
+      let () =
+        if false then
+          Format.eprintf
+            "@[<hv 2>Equality between@ %a@ and %a @ gave affectations %a@.@]"
+            pp_ctnts_and_poly (ctnts1, p1) pp_ctnts_and_poly (ctnts2, p2)
+            Format.(
+              pp_print_list ~pp_sep:pp_print_space (fun f (x, d, _) ->
+                  fprintf f "%s/%d" x d))
+            affectations
+      in
+      match ctnts with
+      | Bottom -> Bottom
+      | Conjunction _ ->
+          let equality' = reduce_ctnts affectations equality in
+          let () =
+            if false then Format.eprintf "@[Gave %a@.@]" pp_ctnts equality'
+          in
+          equality'
+    in
+    list_cross to_cond li1 li2
+    |> List.for_all (function
+         | Bottom -> false
+         | Conjunction m -> PMap.is_empty m)
+end
+
+let equal_in_env env e1 e2 =
+  let dbg = false in
+  let open Normalize in
+  let () =
+    if dbg then
+      Format.eprintf "@[<hv 2>Are %a@ and %a@ equal?@]@ " PP.pp_expr e1
+        PP.pp_expr e2
+  in
+  try
+    let ir1 = to_ir env e1 |> reduce and ir2 = to_ir env e2 |> reduce in
+    let () =
+      if dbg then
+        Format.eprintf "@[Reducing them to@ %a@ and %a.@]@ " Normalize.pp_ir ir1
+          Normalize.pp_ir ir2
+    in
+    let res = equal_mod_branches ir1 ir2 in
+    let () =
+      if dbg then if res then Format.eprintf "YES@." else Format.eprintf "NO@."
+    in
+    res
+  with NotYetImplemented ->
+    let () = if dbg then Format.eprintf "Cannot answer this question yet." in
+    false
+
+let statically_free_variables env e =
+  let open Normalize in
+  try to_ir env e |> reduce |> free_variables
+  with NotYetImplemented -> ASTUtils.ISet.empty
+
+let bitwidth_statically_equal_in_env env =
+  ASTUtils.bitwidth_equal (equal_in_env env)

--- a/asllib/Typing.mli
+++ b/asllib/Typing.mli
@@ -3,7 +3,9 @@
     It should provide enough information to disambiguate any type-dependent
     behaviour. *)
 
-val annotate_ast : AST.t -> AST.t
+val infer_value : AST.value -> AST.type_desc
+
+val annotate_ast : AST.t -> Env.Static.env -> AST.t * Env.Static.env
 (** Annotate is a typing inference function for an ASL AST. It does not type check.
 
     @raise Error.ASLException if the Inferrence is blocked, for example when
@@ -13,7 +15,8 @@ val annotate_ast : AST.t -> AST.t
 type strictness = [ `Silence | `Warn | `TypeCheck ]
 (** Possible strictness of type-checking. *)
 
-val type_check_ast : strictness -> AST.t -> AST.t
+val type_check_ast :
+  strictness -> AST.t -> Env.Static.env -> AST.t * Env.Static.env
 (** Typechecks the AST, and returns an AST with type inference holes filled.
 
     @raise Error.ASLException if the AST does not type-checks.

--- a/asllib/aslseq.ml
+++ b/asllib/aslseq.ml
@@ -157,8 +157,9 @@ let () =
 
   let () =
     if args.print_typed then
-      let annotated_ast =
-        or_exit (fun () -> Typing.type_check_ast args.strictness ast)
+      let annotated_ast, _ =
+        or_exit (fun () ->
+            Typing.type_check_ast args.strictness ast Env.Static.empty)
       in
       Format.printf "@[<v 2>Typed AST:@ %a@]@." PP.pp_t annotated_ast
   in

--- a/asllib/env.ml
+++ b/asllib/env.ml
@@ -1,0 +1,275 @@
+open AST
+open ASTUtils
+
+type func_sig = {
+  declared_name : string;
+  args : (identifier * ty) list;
+  return_type : ty option;
+}
+(** Type signature for functions, some kind of an arrow type, with added
+    informations. *)
+
+let ast_func_to_func_sig : 'a AST.func_skeleton -> func_sig = function
+  | { name = declared_name; args; return_type; parameters = _; body = _ } ->
+      { declared_name; args; return_type }
+
+(** Static environments and utils. *)
+module Static = struct
+  module Types = struct
+    type global = {
+      declared_types : ty IMap.t;  (** Maps a type name t to its declaration. *)
+      constants_values : value IMap.t;
+          (** Maps a global constant name to its value. *)
+      storage_types : (ty * global_decl_keyword) IMap.t;
+          (** Maps global declared storage elements to their types. *)
+      subtypes : identifier IMap.t;
+          (** Maps an identifier s to its parent in the subtype relation. *)
+      subprograms : func_sig IMap.t;
+          (** Maps each subprogram runtime name to its signature. *)
+      subprogram_renamings : ISet.t IMap.t;
+          (** Maps each subprogram declared name to the equivalence class of all
+          the subprogram runtime names that were declared with this name. *)
+    }
+    (** Store all the global environment information at compile-time. *)
+
+    type local = {
+      constants_values : value IMap.t;
+          (** Maps a local constant to its value. *)
+      storage_types : (ty * local_decl_keyword) IMap.t;
+          (** Maps an locally declared names to their type. *)
+    }
+    (** Store all the local environment information at compile-time. *)
+
+    type env = { global : global; local : local }
+    (** The static environment type. *)
+  end
+
+  include Types
+
+  module PPEnv = struct
+    open Format
+
+    let pp_map pp_elt f m =
+      let pp_sep f () = fprintf f ",@ " in
+      let pp_one f (key, elt) =
+        fprintf f "@[<h 2>%s |-> @[%a@]@]" key pp_elt elt
+      in
+      fprintf f "@[<hv 2>{@ %a}@]"
+        (PP.pp_print_seq ~pp_sep pp_one)
+        (IMap.to_seq m)
+
+    let pp_iset f s =
+      let pp_sep f () = fprintf f ",@ " in
+      fprintf f "@[<hv 2>{@ %a}@]"
+        (PP.pp_print_seq ~pp_sep pp_print_string)
+        (ISet.to_seq s)
+
+    let pp_local f { constants_values; storage_types } =
+      fprintf f "@[<v 2>Local with:@ - @[constants:@ %a@]@ - @[storage:@ %a@]@]"
+        (pp_map PP.pp_value) constants_values
+        (pp_map (fun f (t, _) -> PP.pp_ty f t))
+        storage_types
+
+    let pp_subprogram f func_sig =
+      fprintf f "@[<hov 2>%a@ -> %a@]"
+        (pp_print_list ~pp_sep:pp_print_space PP.pp_typed_identifier)
+        func_sig.args (pp_print_option PP.pp_ty) func_sig.return_type
+
+    let pp_global f
+        {
+          constants_values;
+          storage_types;
+          declared_types;
+          subtypes;
+          subprograms;
+          subprogram_renamings;
+        } =
+      fprintf f
+        "@[<v 2>Global with:@ - @[constants:@ %a@]@ - @[storage:@ %a@]@ - \
+         @[types:@ %a@]@ - @[subtypes:@ %a@]@ - @[subprograms:@ %a@] - \
+         @[subprogram_renamings:@ %a@]@]"
+        (pp_map PP.pp_value) constants_values
+        (pp_map (fun f (t, _) -> PP.pp_ty f t))
+        storage_types (pp_map PP.pp_ty) declared_types (pp_map pp_print_string)
+        subtypes (pp_map pp_subprogram) subprograms (pp_map pp_iset)
+        subprogram_renamings
+
+    let pp_env f { global; local } =
+      fprintf f "@[<v 2>Env with:@ - %a@ - %a@]" pp_local local pp_global global
+  end
+
+  (** An empty global static environment. *)
+  let empty_global =
+    {
+      declared_types = IMap.empty;
+      constants_values = IMap.empty;
+      storage_types = IMap.empty;
+      subtypes = IMap.empty;
+      subprograms = IMap.empty;
+      subprogram_renamings = IMap.empty;
+    }
+
+  (** An empty local static env. *)
+  let empty_local =
+    { constants_values = IMap.empty; storage_types = IMap.empty }
+
+  (** An empty static env. *)
+  let empty = { local = empty_local; global = empty_global }
+
+  (** [lookup x env] is the value of x as defined in environment.
+
+      @raise Not_found if it is not defined inside. *)
+  let lookup_constants env x =
+    try IMap.find x env.local.constants_values
+    with Not_found -> IMap.find x env.global.constants_values
+
+  let mem_constants env x =
+    IMap.mem x env.global.constants_values
+    || IMap.mem x env.local.constants_values
+
+  let add_subprogram name func_sig env =
+    {
+      env with
+      global =
+        {
+          env.global with
+          subprograms = IMap.add name func_sig env.global.subprograms;
+        };
+    }
+
+  let add_global_storage x ty gdk env =
+    {
+      env with
+      global =
+        {
+          env.global with
+          storage_types = IMap.add x (ty, gdk) env.global.storage_types;
+        };
+    }
+
+  let add_type x ty env =
+    {
+      env with
+      global =
+        {
+          env.global with
+          declared_types = IMap.add x ty env.global.declared_types;
+        };
+    }
+
+  let add_global_constant name v env =
+    {
+      env with
+      global =
+        {
+          env.global with
+          constants_values = IMap.add name v env.global.constants_values;
+        };
+    }
+
+  let add_local x ty ldk env =
+    {
+      env with
+      local =
+        {
+          env.local with
+          storage_types = IMap.add x (ty, ldk) env.local.storage_types;
+        };
+    }
+end
+
+module type RunTimeConf = sig
+  type v
+  type primitive
+
+  val unroll : int
+end
+
+module RunTime (C : RunTimeConf) = struct
+  module Types = struct
+    (** Internal representation for subprograms. *)
+    type func =
+      | Func of int ref * AST.func
+          (** A function has an index that keeps a unique calling index. *)
+      | Primitive of C.primitive
+          (** A primitive is just given by its type passed as argument. *)
+
+    type global = {
+      static : Static.global;
+          (** Keeps a trace of the static env for reference. *)
+      storage : C.v IMap.t;  (** Global declared storage elements. *)
+      funcs : func IMap.t;
+          (** Declared subprograms, maps called identifier to their code. *)
+    }
+
+    type int_stack = int list
+    (** Stack of ints, for limiting loop unrolling *)
+
+    type local = {
+      storage : C.v IMap.t;
+      scope : identifier * int;
+      unroll : int_stack;
+    }
+
+    type env = { global : global; local : local }
+  end
+
+  include Types
+
+  let empty_local = { storage = IMap.empty; scope = ("", 0); unroll = [] }
+  let empty_scoped scope = { empty_local with scope }
+
+  let empty_global =
+    { static = Static.empty_global; storage = IMap.empty; funcs = IMap.empty }
+
+  let empty = { global = empty_global; local = empty_local }
+
+  (* --------------------------------------------------------------------------*)
+  (* Loop unrolling controls. *)
+
+  (** [tick_push env] is [env] with [C.unroll] pushed on its unrolling stack. *)
+  let tick_push env =
+    let unroll = C.unroll :: env.local.unroll in
+    { env with local = { env.local with unroll } }
+
+  (** [tick_push_bis env] is [env] with [C.unroll -1] pushed on its unrolling
+      stack. *)
+  let tick_push_bis env =
+    let unroll = (C.unroll - 1) :: env.local.unroll in
+    { env with local = { env.local with unroll } }
+
+  (** [tick_pop env] is [env] with removed the unrolling stack first element. *)
+  let tick_pop env =
+    match env.local.unroll with
+    | [] -> assert false
+    | _ :: unroll -> { env with local = { env.local with unroll } }
+
+  (** [tick_decr env] decrements the unrolling stack of env and returns
+      wheather it has poped something or not. *)
+  let tick_decr env =
+    match env.local.unroll with
+    | [] -> assert false
+    | x :: xs ->
+        let x = x - 1 in
+        if x <= 0 then
+          let unroll = xs in
+          (true, { env with local = { env.local with unroll } })
+        else
+          let unroll = x :: xs in
+          (false, { env with local = { env.local with unroll } })
+
+  (* --------------------------------------------------------------------------*)
+  (* Assignments utils *)
+
+  let add_local x v env =
+    {
+      env with
+      local = { env.local with storage = IMap.add x v env.local.storage };
+    }
+
+  let remove_local x env =
+    {
+      env with
+      local = { env.local with storage = IMap.remove x env.local.storage };
+    }
+end

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -20,6 +20,11 @@ type error_desc =
   | TooManyCallCandidates of string * ty list
   | BadTypesForBinop of binop * ty * ty
   | CircularDeclarations of string
+  | UnpureExpression of expr
+  | UnreconciableTypes of ty * ty
+  | AssignToImmutable of string
+  | AlreadyDeclaredIdentifier of string
+  | BadReturnStmt of ty option
 
 type error = error_desc annotated
 
@@ -129,7 +134,31 @@ let pp_error =
         fprintf f
           "ASL Evaluation error: circular definition of constants, including \
            %S."
-          x);
+          x
+    | UnpureExpression e ->
+        fprintf f
+          "ASL Typing error:@ a pure expression was expected,@ found@ %a"
+          pp_expr e
+    | UnreconciableTypes (t1, t2) ->
+        fprintf f
+          "ASL Typing error:@ cannot@ find@ a@ common@ ancestor@ to@ those@ \
+           two@ types@ %a@ and@ %a."
+          pp_ty t1 pp_ty t2
+    | AssignToImmutable x ->
+        fprintf f
+          "ASL Typing error:@ cannot@ assign@ to@ immutable@ storage@ %S." x
+    | AlreadyDeclaredIdentifier x ->
+        fprintf f
+          "ASL Typing error:@ cannot@ declare@ already@ declared@ element@ %S."
+          x
+    | BadReturnStmt None ->
+        fprintf f
+          "ASL Typing error:@ cannot@ return@ something@ from@ a@ procedure@."
+    | BadReturnStmt (Some t) ->
+        fprintf f
+          "ASL Typing error:@ cannot@ return@ nothing@ from@ a@ function,@ an@ \
+           expression@ of@ type@ %a@ is@ expected."
+          pp_ty t);
     pp_close_box f ();
     pp_close_box f ()
 

--- a/asllib/gparser0.ml
+++ b/asllib/gparser0.ml
@@ -155,10 +155,20 @@ let as_chunks = true
 
 let ast (lexer : lexbuf -> token) (lexbuf : lexbuf) : AST.t =
   if as_chunks then
+    let fname = lexbuf.Lexing.lex_curr_p.Lexing.pos_fname in
     let asts =
       Seq.fold_left
-        (fun k chunk ->
-          let ast = ast_chunk (Lexing.from_string chunk) in
+        (fun k (start, chunk) ->
+          if false then
+            Printf.eprintf "Chunk (line %d, file %s) ***\n%s\n***\n%!" start
+              fname chunk;
+          let lexbuf = Lexing.from_string chunk in
+          let lcp = lexbuf.Lexing.lex_curr_p in
+          let lcp =
+            { lcp with Lexing.pos_fname = fname; Lexing.pos_lnum = start }
+          in
+          let lexbuf = { lexbuf with lex_curr_p = lcp } in
+          let ast = ast_chunk lexbuf in
           ast :: k)
         [] (Splitasl.split lexbuf)
     in

--- a/asllib/splitasl.mli
+++ b/asllib/splitasl.mli
@@ -16,4 +16,4 @@
 
 (** Split (ASL) lexbuffer at "// =======..." limits *)
 
-val split : Lexing.lexbuf -> string Seq.t
+val split : Lexing.lexbuf -> (int * string) Seq.t

--- a/asllib/tests/asl/required/assign1.asl
+++ b/asllib/tests/asl/required/assign1.asl
@@ -1,5 +1,5 @@
 func main()
 begin
-    x = 3;
+    let x = 3;
     assert x == 3;
 end

--- a/asllib/tests/asl/required/bitfields.asl
+++ b/asllib/tests/asl/required/bitfields.asl
@@ -14,8 +14,9 @@ end
 
 func set_first(bv::MyBitVector, b::bits(1)) => MyBitVector
 begin
-  bv.first = b;
-  return bv;
+  var bv_bis = bv;
+  bv_bis.first = b;
+  return bv_bis;
 end
 
 func get_first_three(bv::MyBitVector) => bits(3)

--- a/asllib/tests/asl/required/bitvectors.asl
+++ b/asllib/tests/asl/required/bitvectors.asl
@@ -1,6 +1,6 @@
 func main()
 begin
-  let a = '101';
+  var a = '101';
   let b = a[1, 0];
   a[0] = '0';
 

--- a/asllib/tests/asl/required/func1.asl
+++ b/asllib/tests/asl/required/func1.asl
@@ -5,8 +5,8 @@ end
 
 func main()
 begin
-    x = 3;
-    y = f(x);
+    let x = 3;
+    let y = f(x);
     assert x == 3;
     assert y == 3;
 end

--- a/asllib/tests/asl/required/func2.asl
+++ b/asllib/tests/asl/required/func2.asl
@@ -5,14 +5,14 @@ end
 
 setter X_set[i::integer] = v::integer
 begin
-    internal_i = i;
-    internal_v = v;
+    let internal_i = i;
+    let internal_v = v;
 end
 
 func main()
 begin
     X_set[2] = 3;
-    x = X_get[4];
+    let x = X_get[4];
 
     assert x == 4;
 end

--- a/asllib/tests/asl/required/func3.asl
+++ b/asllib/tests/asl/required/func3.asl
@@ -28,13 +28,13 @@ func main()
 begin
   f1[] = f1[];
   f1 = f1;
-  a = f1;
+  let a = f1;
   assert a == 3;
   assert f1 == 3;
-  b = f1[];
+  let b = f1[];
   assert b == 3;
   assert 3 == f1[];
-  c = f2[4];
+  let c = f2[4];
   assert c == 7;
 
   f2[5] = 6;

--- a/asllib/tests/asl/required/patterns.asl
+++ b/asllib/tests/asl/required/patterns.asl
@@ -1,0 +1,23 @@
+func example_5_3 ()
+begin
+  // let expr_A = '111' IN {'1xx'};                    //  TRUE
+  // assert expr_A;
+  // let expr_B = '111' IN {'0xx'};                    //  FALSE
+  // assert !expr_B;
+  let expr_C = 3 IN {2,3,4};                        //  TRUE
+  assert expr_C;
+  let expr_D = 1 IN {2,3,4};                        //  FALSE
+  assert !expr_D;
+  let expr_E = 3 IN {1..10};                        //  TRUE
+  assert expr_E;
+  let expr_F = 3 IN {<= 10};                        //  TRUE
+  assert expr_F;
+  let expr_G = 3 IN !{1,2,4};                       //  TRUE
+  assert expr_G;
+
+end
+
+func main ()
+begin
+  example_5_3 ();
+end

--- a/asllib/tests/asl/required/records.asl
+++ b/asllib/tests/asl/required/records.asl
@@ -31,14 +31,16 @@ end
 
 func incr_subfieldB(obj::MyRecord) => MyRecord
 begin
-  obj.fieldB.subfieldB = obj.fieldB.subfieldB + 1;
-  return obj;
+  var obj2 = obj;
+  obj2.fieldB.subfieldB = obj2.fieldB.subfieldB + 1;
+  return obj2;
 end
 
-func set_fieldC(obj::MyRecord, val::SomeOtherType) => MyRecord
+func set_fieldC(obj::MyRecord, val::integer) => MyRecord
 begin
-  obj.fieldC = val;
-  return obj;
+  var obj2 = obj;
+  obj2.fieldC = val;
+  return obj2;
 end
 
 func build_and_access()

--- a/asllib/tests/asl/required/stdlib.asl
+++ b/asllib/tests/asl/required/stdlib.asl
@@ -7,6 +7,7 @@ begin
   assert Min (2, 3) == 2;
   assert Max (2, 3) == 3;
 
+  assert Replicate('01',3) == '010101';
   assert Zeros(3) == '000';
   assert Zeros(8) == '00000000';
 

--- a/asllib/tests/dune
+++ b/asllib/tests/dune
@@ -10,13 +10,16 @@
   (libraries asllib test_helpers)
   (deps (glob_files asl/required/*.asl) asltests.ml ../libdir/stdlib.asl)
   (action
-    (setenv ASL_LIBDIR %{project_root}/asllib/libdir
+    (setenv ASL_LIBDIR %{project_root}/asllib/libdir/
       (run %{test} asl/required))))
 
 (tests
-  (names static bitvector)
-  (modules static bitvector)
+  (names static bitvector types)
+  (modules static bitvector types)
   (modes native)
   (deps (:standard ../libdir/stdlib.asl))
-  (libraries asllib test_helpers))
+  (libraries asllib test_helpers)
+  (action 
+    (setenv ASL_LIBDIR %{project_root}/asllib/libdir/
+      (run %{test} -e))))
 

--- a/asllib/tests/helpers.ml
+++ b/asllib/tests/helpers.ml
@@ -1,5 +1,15 @@
 open Asllib
 
+module Infix = struct
+  open AST
+
+  let ( !! ) e = ASTUtils.add_dummy_pos e
+  let ( !$ ) i = !!(E_Literal (V_Int i))
+  let ( !% ) x = !!(E_Var x)
+  let integer = !!(T_Int None)
+  let boolean = !!T_Bool
+end
+
 let exec_tests =
   let exec_one_test any_failed (name, f) =
     let on_fail e =

--- a/asllib/tests/static.ml
+++ b/asllib/tests/static.ml
@@ -1,11 +1,12 @@
 open Asllib
 open AST
+open ASTUtils
 open Test_helpers.Helpers
+open Test_helpers.Helpers.Infix
+
+let _dbg = false
 
 let build_consts () =
-  let ( !! ) e = ASTUtils.add_dummy_pos e in
-  let ( !$ ) i = !!(E_Literal (V_Int i)) in
-  let ( !% ) x = !!(E_Var x) in
   let values =
     [ ("c1", !$3); ("c2", !!(E_Slice (!%"c1", [ Slice_Range (!$3, !$0) ]))) ]
   in
@@ -26,4 +27,96 @@ let build_consts () =
   let _ = Native.interprete `TypeCheck ast in
   ()
 
-let () = exec_tests [ ("build_consts", build_consts) ]
+let normalize () =
+  let do_one (e1, e2, env) =
+    let e1' = StaticInterpreter.Normalize.normalize env e1 in
+    let e2' = StaticInterpreter.Normalize.normalize env e2 in
+    let () =
+      if _dbg then Format.eprintf "%a ---> %a@." PP.pp_expr e1 PP.pp_expr e1'
+    in
+    let () =
+      if _dbg then Format.eprintf "%a ---> %a@." PP.pp_expr e2 PP.pp_expr e2'
+    in
+    assert (StaticInterpreter.equal_in_env env e1 e2)
+  in
+
+  List.iter do_one
+    [
+      (binop MINUS !$4 !$2, !$2, Env.Static.empty);
+      ( binop PLUS (binop MINUS !%"N" !%"m") (binop MINUS !%"m" !$1),
+        binop MINUS !%"N" !$1,
+        Env.Static.empty );
+    ]
+
+let fpzero_example () =
+  let ( -~ ) = binop MINUS and ( ==~ ) = binop EQ_OP and ( +~ ) = binop PLUS in
+  let e =
+    !!(E_Cond (!%"N" ==~ !$16, !$5, !!(E_Cond (!%"N" ==~ !$32, !$8, !$11))))
+  in
+  let f = !%"N" -~ e -~ !$1 in
+  let res = !$1 +~ e +~ f in
+
+  let env =
+    let open Env.Static in
+    add_local "N" integer LDK_Let empty
+  in
+
+  let () =
+    if _dbg then
+      let e' = StaticInterpreter.Normalize.normalize env e in
+      Format.eprintf "%a ---> %a@." PP.pp_expr e PP.pp_expr e'
+  in
+  let () =
+    if _dbg then
+      let f' = StaticInterpreter.Normalize.normalize env f in
+      Format.eprintf "%a ---> %a@." PP.pp_expr f PP.pp_expr f'
+  in
+  let () =
+    if _dbg then
+      let res' = StaticInterpreter.Normalize.normalize env res in
+      Format.eprintf "%a ---> %a@." PP.pp_expr res PP.pp_expr res'
+  in
+
+  assert (StaticInterpreter.equal_in_env env !%"N" res)
+
+let[@warning "-44"] normalize_affectations () =
+  let open StaticInterpreter.Normalize in
+  let affectations = [ ("x", 3, None); ("y", 7, None) ] in
+  let m_1 = Prod AMap.empty in
+  let m_1', f_1' = subst_mono affectations m_1 1 in
+  assert (mono_compare m_1' m_1 = 0 && f_1' = 1);
+
+  let m_x = Prod (AMap.singleton "x" 1) in
+  let m_x', f_x' = subst_mono affectations m_x 1 in
+  assert (mono_compare m_x' m_1 = 0 && f_x' = 3);
+
+  let m_xy = Prod (AMap.singleton "x" 1 |> AMap.add "y" 1) in
+  let m_xy', f_xy' = subst_mono affectations m_xy 1 in
+  assert (mono_compare m_xy' m_1 = 0 && f_xy' = 21);
+
+  let p_1 = Sum (MMap.singleton m_1 1) in
+  let p_x = Sum (MMap.singleton m_x 1) in
+  let p_x_1 = add_polys p_1 p_x in
+  let p_xy_1 = Sum (MMap.singleton m_xy 1 |> MMap.add m_1 1) in
+
+  let p_1' = subst_poly affectations p_1 in
+  let p_x' = subst_poly affectations p_x in
+  let p_x_1' = subst_poly affectations p_x_1 in
+  let p_xy_1' = subst_poly affectations p_xy_1 in
+
+  assert (poly_compare p_1 p_1 = 0);
+  assert (poly_compare p_1' p_1 = 0);
+  assert (poly_compare p_x' (poly_of_int 3) = 0);
+  assert (poly_compare p_x_1' (poly_of_int 4) = 0);
+  assert (poly_compare p_xy_1' (poly_of_int 22) = 0);
+
+  ()
+
+let () =
+  exec_tests
+    [
+      ("build_consts", build_consts);
+      ("static.normalize", normalize);
+      ("static.fpzero_example", fpzero_example);
+      ("static.normalize_affectations", normalize_affectations);
+    ]

--- a/asllib/tests/types.ml
+++ b/asllib/tests/types.ml
@@ -1,0 +1,180 @@
+open Asllib
+open ASTUtils
+open AST
+open Test_helpers.Helpers
+open Test_helpers.Helpers.Infix
+open Asllib.Types
+
+let empty_env = Env.Static.empty
+
+let env_with_n =
+  let open Env.Static in
+  add_local "N" integer LDK_Let empty
+
+let builtin_examples () =
+  let assert_is_builtin_singular t =
+    assert (is_builtin_singular !!t);
+    assert (not (is_builtin_aggregate !!t));
+    assert (is_builtin !!t);
+    assert (is_anonymous !!t);
+    ()
+  in
+  let assert_is_builtin_aggregate t =
+    assert (is_builtin_aggregate !!t);
+    assert (not (is_builtin_singular !!t));
+    assert (is_builtin !!t);
+    assert (is_anonymous !!t)
+  in
+
+  (* Builtin singulars *)
+  List.iter assert_is_builtin_singular
+    [
+      T_Int None;
+      T_Int (Some [ Constraint_Exact !$3 ]);
+      T_Real;
+      T_String;
+      T_Bool;
+      T_Enum [];
+      T_Enum [ "Something"; "Something Else" ];
+      T_Bits (BitWidth_Determined !$0, []);
+      T_Bits (BitWidth_Determined !$3, [ ("Something", [ Slice_Single !$0 ]) ]);
+    ];
+
+  (* Builtin aggregate *)
+  List.iter assert_is_builtin_aggregate
+    [
+      T_Tuple [];
+      T_Tuple [ !!T_Real; !!T_String ];
+      T_Record [];
+      T_Record [ ("a", !!T_Real); ("B", !!(T_Int None)) ];
+      T_Exception [];
+      T_Exception [ ("a", !!T_Real); ("B", !!(T_Int None)) ];
+    ];
+
+  (* Not builtin *)
+  assert (is_named !!(T_Named "type_x"));
+  assert (not (is_builtin !!(T_Named "type_x")));
+  assert (not (is_anonymous !!(T_Named "type_x")));
+
+  ()
+
+let structure_example () =
+  (* type T1 of integer; *)
+  let t1 = !!(T_Named "T1") in
+  (* type T2 of (integer, T1); *)
+  let t2_def = !!(T_Tuple [ integer; t1 ]) in
+  let t2 = !!(T_Named "T2") in
+  let env =
+    let open Env.Static in
+    add_type "T1" integer empty |> add_type "T2" t2_def
+  in
+  (* the named type `T1` whose structure is integer *)
+  assert (is_named t1);
+  assert ((get_structure env t1).desc = integer.desc);
+  (* the named type `T2` whose structure is (integer, integer) *)
+  assert (is_named t2);
+  assert ((get_structure env t2).desc = T_Tuple [ integer; integer ]);
+  (* Note that (integer, T1) is non-primitive since it uses T1 *)
+  assert (is_non_primitive t2_def);
+  (* the named (hence non-primitive) type `T1` *)
+  assert (is_non_primitive t1);
+
+  (* anonymous primitive type `integer` *)
+  assert (is_primitive integer);
+  assert (is_anonymous integer);
+
+  (* the anonymous non-primitive type `(integer, T1)` whose structure is `(integer, integer)` *)
+  assert (is_anonymous t2_def);
+  assert (is_non_primitive t2_def);
+  assert ((get_structure env t2).desc = T_Tuple [ integer; integer ]);
+
+  ()
+
+let subtype_examples () =
+  let bits_4 = !!(T_Bits (BitWidth_Determined !$4, [])) in
+  let bits_2_4 =
+    !!(T_Bits
+         ( BitWidth_Constrained [ Constraint_Exact !$2; Constraint_Exact !$4 ],
+           [] ))
+  in
+
+  assert (not (subtype_satisfies empty_env bits_2_4 bits_4));
+
+  let bits_btifields =
+    !!(T_Bits (BitWidth_Determined !$4, [ ("a", [ Slice_Single !$3 ]) ]))
+  in
+
+  assert (domain_subtype_satisfies empty_env bits_btifields bits_btifields);
+
+  let bits_n = !!(T_Bits (BitWidth_Determined !%"N", [])) in
+  let bits_n_1 = !!(T_Bits (BitWidth_Determined (binop MUL !%"N" !$1), [])) in
+
+  assert (domain_subtype_satisfies env_with_n bits_n bits_n_1);
+  assert (structural_subtype_satisfies env_with_n bits_n bits_n_1);
+  assert (subtype_satisfies env_with_n bits_n bits_n_1);
+
+  ()
+
+let type_examples () =
+  let bits_4 = !!(T_Bits (BitWidth_Determined !$4, [])) in
+  let bits_n = !!(T_Bits (BitWidth_Determined !%"N", [])) in
+  let bits_n' = !!(T_Bits (BitWidth_Determined !%"N", [])) in
+
+  assert (type_satisfies env_with_n bits_n bits_n');
+
+  assert (not (type_satisfies empty_env !!T_Bool integer));
+  assert (not (type_satisfies empty_env bits_4 integer));
+  assert (type_satisfies empty_env integer integer);
+  assert (type_satisfies empty_env bits_4 bits_4);
+  assert (type_satisfies empty_env !!T_Bool !!T_Bool);
+
+  ()
+
+let lca_examples () =
+  let bits_4 = !!(T_Bits (BitWidth_Determined !$4, [])) in
+  let bits_2 = !!(T_Bits (BitWidth_Determined !$2, [])) in
+
+  assert (lowest_common_ancestor empty_env bits_4 bits_2 = None);
+
+  let integer_4 = !!(T_Int (Some [ Constraint_Exact !$4 ])) in
+  let integer_2 = !!(T_Int (Some [ Constraint_Exact !$2 ])) in
+
+  let lca = lowest_common_ancestor empty_env integer_4 integer_2 in
+  assert (Option.is_some lca);
+  let lca = Option.get lca in
+  let domain = Asllib.Types.Domain.of_type empty_env lca in
+
+  assert (Asllib.Types.Domain.mem (V_Int 2) domain);
+  assert (Asllib.Types.Domain.mem (V_Int 4) domain);
+
+  ()
+
+let type_clashes () =
+  let bits_4 = !!(T_Bits (BitWidth_Determined !$4, [])) in
+  let bits_2 = !!(T_Bits (BitWidth_Determined !$2, [])) in
+  let bits_m = !!(T_Bits (BitWidth_Determined !%"M", [])) in
+
+  let integer_4 = !!(T_Int (Some [ Constraint_Exact !$4 ])) in
+  let integer_2 = !!(T_Int (Some [ Constraint_Exact !$2 ])) in
+
+  assert (not (type_clashes empty_env bits_4 integer_4));
+  assert (not (type_clashes empty_env integer bits_2));
+  assert (type_clashes empty_env integer integer_4);
+  assert (type_clashes empty_env integer_2 integer_4);
+  assert (type_clashes empty_env bits_m bits_m);
+
+  assert (type_clashes empty_env integer integer);
+  assert (type_clashes empty_env boolean boolean);
+
+  ()
+
+let () =
+  exec_tests
+    [
+      ("types.builtin_examples", builtin_examples);
+      ("types.structure_example", structure_example);
+      ("types.subtype_example", subtype_examples);
+      ("types.lca_example", lca_examples);
+      ("types.types_examples", type_examples);
+      ("types.type_clashes", type_clashes);
+    ]

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -1,0 +1,570 @@
+open AST
+open ASTUtils
+module SEnv = Env.Static
+open SEnv.Types
+
+let undefined_identifier pos x =
+  Error.fatal_from pos (Error.UndefinedIdentifier x)
+
+let thing_equal astutil_equal env =
+  astutil_equal (StaticInterpreter.equal_in_env env)
+
+let expr_equal = thing_equal expr_equal
+let type_equal = thing_equal type_equal
+let bitwidth_equal = thing_equal bitwidth_equal
+let slices_equal = thing_equal slices_equal
+
+(* --------------------------------------------------------------------------*)
+
+let get_structure (env : env) : ty -> ty =
+  (* TODO: rethink to have physical equality when structural equality? *)
+  (* TODO: memoize? *)
+  let rec get ty =
+    let () =
+      if false then Format.eprintf "@[Getting structure of %a.@]@." PP.pp_ty ty
+    in
+    let with_pos = add_pos_from ty in
+    match ty.desc with
+    | T_Named x -> (
+        match IMap.find_opt x env.global.declared_types with
+        | None -> undefined_identifier ty x
+        | Some ty -> get ty)
+    | T_Int _ | T_Real | T_String | T_Bool | T_Bits _ | T_Enum _ -> ty
+    | T_Tuple subtypes -> T_Tuple (List.map get subtypes) |> with_pos
+    | T_Array (e, t) -> T_Array (e, get t) |> with_pos
+    | T_Record fields -> T_Record (get_fields fields) |> with_pos
+    | T_Exception fields -> T_Exception (get_fields fields) |> with_pos
+  and get_fields fields =
+    let one_field (name, t) = (name, get t) in
+    let fields = List.map one_field fields in
+    canonical_fields fields
+  in
+
+  get
+
+(* The builtin singular types are:
+   • integer
+   • real
+   • string
+   • boolean
+   • bits
+   • bit
+   • enumeration
+*)
+let is_builtin_singular ty =
+  match ty.desc with
+  | T_Real | T_String | T_Bool | T_Bits _ | T_Enum _ | T_Int _ -> true
+  | _ -> false
+
+(* The builtin aggregate types are:
+   • tuple
+   • array
+   • record
+   • exception
+*)
+let is_builtin_aggregate ty =
+  match ty.desc with
+  | T_Tuple _ | T_Array _ | T_Record _ | T_Exception _ -> true
+  | _ -> false
+
+let is_builtin ty = is_builtin_singular ty || is_builtin_aggregate ty
+let is_named ty = match ty.desc with T_Named _ -> true | _ -> false
+
+(* A named type is singular if it has the structure of a singular type,
+   otherwise it is aggregate. *)
+let is_singular env ty =
+  is_builtin_singular ty
+  || (is_named ty && get_structure env ty |> is_builtin_singular)
+
+(* A named type is singular if it has the structure of a singular type,
+   otherwise it is aggregate. *)
+let is_aggregate env ty =
+  is_builtin_aggregate ty
+  || (is_named ty && get_structure env ty |> is_builtin_aggregate)
+
+let is_anonymous ty = not (is_named ty)
+
+let rec is_non_primitive ty =
+  match ty.desc with
+  | T_Real | T_String | T_Bool | T_Bits _ | T_Enum _ | T_Int _ -> false
+  | T_Named _ -> true
+  | T_Tuple li -> List.exists is_non_primitive li
+  | T_Array (_, ty) -> is_non_primitive ty
+  | T_Record fields | T_Exception fields ->
+      List.exists (fun (_, ty) -> is_non_primitive ty) fields
+
+let is_primitive ty = not (is_non_primitive ty)
+
+module Domain = struct
+  module IntSet = Set.Make (Int)
+
+  (* Pretty inefficient. Use diets instead?
+     See https://web.engr.oregonstate.edu/~erwig/papers/Diet_JFP98.pdf
+     or https://github.com/mirage/ocaml-diet
+  *)
+  type int_set = Finite of IntSet.t | Top
+
+  type t =
+    | D_Bool
+    | D_String
+    | D_Real
+    | D_Symbols of ISet.t  (** The domain of an enum is a set of symbols *)
+    | D_Int of int_set
+    | D_Bits of int_set  (** The domain of a bitvector is given by its width. *)
+
+  let rec add_interval_to_intset acc bot top =
+    if bot > top then acc
+    else add_interval_to_intset (IntSet.add bot acc) (bot + 1) top
+
+  let pp_int_set f =
+    let open Format in
+    function
+    | Top -> pp_print_string f "ℤ"
+    | Finite set ->
+        fprintf f "@[{@,%a}@]"
+          (PP.pp_print_seq ~pp_sep:pp_print_space pp_print_int)
+          (IntSet.to_seq set)
+
+  let pp f =
+    let open Format in
+    function
+    | D_Bool -> pp_print_string f "𝔹"
+    | D_String -> pp_print_string f "𝕊"
+    | D_Real -> pp_print_string f "ℚ"
+    | D_Symbols li ->
+        fprintf f "@[{@,%a}@]"
+          (PP.pp_print_seq ~pp_sep:pp_print_space pp_print_string)
+          (ISet.to_seq li)
+    | D_Int set -> pp_int_set f set
+    | D_Bits set -> fprintf f "@[#bits(%a)@]" pp_int_set set
+
+  exception StaticEvaluationTop
+
+  let eval (env : env) (e : expr) =
+    let v =
+      let e =
+        try StaticInterpreter.Normalize.normalize env e
+        with StaticInterpreter.NotYetImplemented -> e
+      in
+      try StaticInterpreter.static_eval env e
+      with Error.ASLException { desc = Error.UndefinedIdentifier _; _ } ->
+        raise_notrace StaticEvaluationTop
+    in
+    match v with
+    | V_Int i -> i
+    | _ ->
+        failwith
+          "Type error? Cannot use an expression that is not an int in a \
+           constraint."
+
+  let add_constraint_to_intset env acc = function
+    | Constraint_Exact e -> IntSet.add (eval env e) acc
+    | Constraint_Range (bot, top) ->
+        let bot = eval env bot and top = eval env top in
+        add_interval_to_intset acc bot top
+
+  let int_set_of_int_constraints env constraints =
+    try
+      Finite
+        (List.fold_left (add_constraint_to_intset env) IntSet.empty constraints)
+    with StaticEvaluationTop -> Top
+
+  let rec int_set_of_bits_width env = function
+    | BitWidth_Determined e -> (
+        try Finite (IntSet.singleton (eval env e))
+        with StaticEvaluationTop -> Top)
+    | BitWidth_ConstrainedFormType ty -> (
+        match of_type env ty with
+        | D_Bits is | D_Int is -> is
+        | _ ->
+            failwith
+              "An bit width cannot be constrained from a type that is neither \
+               a bitvector nor an integer.")
+    | BitWidth_Constrained constraints ->
+        int_set_of_int_constraints env constraints
+
+  and of_type env ty =
+    match ty.desc with
+    | T_Bool -> D_Bool
+    | T_String -> D_String
+    | T_Real -> D_Real
+    | T_Enum li -> D_Symbols (ISet.of_list li)
+    | T_Int None -> D_Int Top
+    | T_Int (Some constraints) ->
+        D_Int (int_set_of_int_constraints env constraints)
+    | T_Bits (width, _) -> D_Bits (int_set_of_bits_width env width)
+    | T_Array _ | T_Exception _ | T_Record _ | T_Tuple _ ->
+        failwith "Unimplemented: domain of a non singular type."
+    | T_Named _ ->
+        failwith "Cannot construct a domain of a non-structural type."
+
+  let mem v d =
+    match (v, d) with
+    | V_Bool _, D_Bool | V_Real _, D_Real -> true
+    | V_Bool _, _ | V_Real _, _ | _, D_Bool | _, D_Real -> false
+    | V_BitVector _, D_Bits Top -> true
+    | V_BitVector bv, D_Bits (Finite intset) ->
+        IntSet.mem (Bitvector.length bv) intset
+    | V_BitVector _, _ | _, D_Bits _ -> false
+    | V_Int _, D_Int Top -> true
+    | V_Int i, D_Int (Finite intset) -> IntSet.mem i intset
+    | V_Int _, _ | _, D_Int _ -> false
+    | V_Tuple _, _ | V_Exception _, _ | V_Record _, _ ->
+        failwith "Unimplemented: domain of non-singular type."
+
+  let equal d1 d2 =
+    match (d1, d2) with
+    | D_Bool, D_Bool | D_String, D_String | D_Real, D_Real -> true
+    | D_Symbols s1, D_Symbols s2 -> ISet.equal s1 s2
+    | D_Bits Top, D_Bits Top | D_Int Top, D_Int Top -> true
+    | D_Int (Finite is1), D_Int (Finite is2)
+    | D_Bits (Finite is1), D_Bits (Finite is2) ->
+        IntSet.equal is1 is2
+    | _ -> false
+
+  let compare _d1 _d2 = assert false
+
+  let is_subset d1 d2 =
+    match (d1, d2) with
+    | D_Bool, D_Bool | D_String, D_String | D_Real, D_Real -> true
+    | D_Symbols s1, D_Symbols s2 -> ISet.subset s1 s2
+    | D_Int _, D_Int Top -> true
+    | D_Int Top, D_Int _ -> false
+    | D_Int (Finite is1), D_Int (Finite is2) -> IntSet.subset is1 is2
+    | D_Bits _, D_Bits Top -> true
+    | D_Bits Top, D_Bits _ -> false
+    | D_Bits (Finite is1), D_Bits (Finite is2) -> IntSet.subset is1 is2
+    | _ -> false
+end
+
+let rec subtypes_names env s1 s2 =
+  if String.equal s1 s2 then true
+  else
+    match IMap.find_opt s1 env.global.subtypes with
+    | None -> false
+    | Some s1' -> subtypes_names env s1' s2
+
+let subtypes env t1 t2 =
+  match (t1.desc, t2.desc) with
+  | T_Named s1, T_Named s2 -> subtypes_names env s1 s2
+  | _ -> false
+
+let rec structural_subtype_satisfies env t s =
+  (* A type T subtype-satisfies type S if and only if all of the following
+     conditions hold: *)
+  let s_struct = get_structure env s and t_struct = get_structure env t in
+  match (s_struct.desc, t_struct.desc) with
+  (* If S has the structure of an integer type then T must have the structure
+     of an integer type. *)
+  | T_Int _, T_Int _ -> true
+  | T_Int _, _ -> false
+  (* If S has the structure of a real type then T must have the structure of a
+     real type. *)
+  | T_Real, T_Real -> true
+  | T_Real, _ -> false
+  (* If S has the structure of a string type then T must have the structure of
+     a string type. *)
+  | T_String, T_String -> true
+  | T_String, _ -> false
+  (* If S has the structure of a boolean type then T must have the structure of
+     a boolean type. *)
+  | T_Bool, T_Bool -> true
+  | T_Bool, _ -> false
+  (* If S has the structure of an enumeration type then T must have the
+     structure of an enumeration type with exactly the same enumeration
+     literals. *)
+  | T_Enum li_s, T_Enum li_t -> list_equal String.equal li_s li_t
+  | T_Enum _, _ -> false
+  (*
+    • If S has the structure of a bitvector type with determined width then
+      either T must have the structure of a bitvector type of the same
+      determined width or T must have the structure of a bitvector type with
+      undetermined width.
+    • If S has the structure of a bitvector type with undetermined width then T
+      must have the structure of a bitvector type.
+    • If S has the structure of a bitvector type which has bitfields then T
+      must have the structure of a bitvector type of the same width and for
+      every bitfield in S there must be a bitfield in T of the same name, width
+      and offset, whose type type-satisfies the bitfield in S.
+  *)
+  | T_Bits (w_s, bf_s), T_Bits (w_t, bf_t) -> (
+      (match (w_s, w_t) with
+      | BitWidth_Determined e_s, BitWidth_Determined e_t ->
+          expr_equal env e_s e_t
+      | BitWidth_Determined _, _ -> false
+      | BitWidth_Constrained _, _ -> true
+      | _ -> true)
+      &&
+      match (bf_s, bf_t) with
+      | [], _ -> true
+      | _, [] -> false
+      | bfs_s, bfs_t ->
+          w_s = w_t
+          &&
+          let bf_equal (name_s, slices_s) (name_t, slices_t) =
+            String.equal name_s name_t && slices_equal env slices_s slices_t
+          in
+          let mem_bf bfs_t bf_s = List.exists (bf_equal bf_s) bfs_t in
+          List.for_all (mem_bf bfs_t) bfs_s)
+  | T_Bits _, _ -> false
+  (* If S has the structure of an array type with elements of type E then T
+     must have the structure of an array type with elements of type E, and T
+     must have the same element indices as S.
+     TODO: this is probably wrong, or a bad approximation. *)
+  | T_Array (length_s, ty_s), T_Array (length_t, ty_t) ->
+      expr_equal env length_s length_t && type_equal env ty_s ty_t
+  | T_Array _, _ -> false
+  (* If S has the structure of a tuple type then T must have the structure of
+     a tuple type with same number of elements as S, and each element in T
+     must type-satisfy the corresponding element in S.*)
+  | T_Tuple li_s, T_Tuple li_t ->
+      List.compare_lengths li_s li_t = 0
+      && List.for_all2 (type_satisfies env) li_t li_s
+  | T_Tuple _, _ -> false
+  (* If S has the structure of an exception type then T must have the structure
+     of an exception type with at least the same fields (each with the same
+     type) as S.
+     If S has the structure of a record type then T must have the structure of
+     a record type with at least the same fields (each with the same type) as
+     S.
+     TODO: order of fields? *)
+  | T_Exception fields_s, T_Exception fields_t
+  | T_Record fields_s, T_Record fields_t ->
+      List.compare_lengths fields_s fields_t = 0
+      && List.for_all2 ( = ) fields_s fields_t
+  | T_Exception _, _ | T_Record _, _ -> false (* A structure cannot be a name *)
+  | T_Named _, _ -> assert false
+
+and domain_subtype_satisfies env t s =
+  let s_struct = get_structure env s in
+  match s_struct.desc with
+  | T_Named _ ->
+      (* Cannot happen *)
+      assert false
+      (* If S does not have the structure of an aggregate type or bitvector type
+         then the domain of T must be a subset of the domain of S. *)
+  | T_Tuple _ | T_Array _ | T_Record _ | T_Exception _ -> true
+  | T_Real | T_String | T_Bool | T_Enum _ | T_Int _ ->
+      Domain.(
+        is_subset (of_type env (get_structure env t)) (of_type env s_struct))
+  | T_Bits (width_s, _) -> (
+      (* If either S or T have the structure of a bitvector type with
+         undetermined width then the domain of T must be a subset of the domain
+         of S. *)
+      (* Implicitely, T must have the structure of a bitvector. *)
+      let t_struct = get_structure env t in
+      match (width_s, t_struct.desc) with
+      | BitWidth_Constrained _, T_Bits _ | _, T_Bits (BitWidth_Constrained _, _)
+        ->
+          Domain.(is_subset (of_type env s_struct) (of_type env t_struct))
+      | BitWidth_Determined _, T_Bits (BitWidth_Determined _, _) ->
+          Domain.(
+            is_subset (of_type env (get_structure env t)) (of_type env s_struct))
+      | _ -> false)
+
+and subtype_satisfies env t s =
+  structural_subtype_satisfies env t s && domain_subtype_satisfies env t s
+
+and type_satisfies env t s =
+  (* Type T type-satisfies type S if and only if at least one of the following
+     conditions holds: *)
+  (* T is a subtype of S *)
+  subtypes env t s
+  (* T subtype-satisfies S and at least one of S or T is an anonymous type *)
+  || ((is_anonymous t || is_anonymous s) && subtype_satisfies env t s)
+  ||
+  (* T is an anonymous bitvector with no bitfields and S has the structure of a
+     bitvector (with or without bitfields) of the same width as T. *)
+  (* Here I interprete "same width" as statically the same width, otherwise
+     it's strange. *)
+  match (t.desc, (get_structure env s).desc) with
+  | T_Bits (width_t, []), T_Bits (width_s, _) ->
+      bitwidth_equal env width_t width_s
+  | _ -> false
+
+let rec type_clashes env t s =
+  (*
+   Definition VPZZ:
+   A type T type-clashes with S if any of the following hold:
+      • they both have the structure of integers
+      • they both have the structure of reals
+      • they both have the structure of strings
+      • they both have the structure of enumeration types with the same
+        enumeration literals
+      • they both have the structure of bit vectors
+      • they both have the structure of arrays whose element types type-clash
+      • they both have the structure of tuples of the same length whose
+        corresponding element types type-clash
+      • S is either a subtype or a supertype of T *)
+  (* We will add a rule for boolean and boolean. *)
+  (subtypes env s t || subtypes env t s)
+  ||
+  let s_struct = get_structure env s and t_struct = get_structure env t in
+  match (s_struct.desc, t_struct.desc) with
+  | T_Int _, T_Int _
+  | T_Real, T_Real
+  | T_String, T_String
+  | T_Bits _, T_Bits _
+  | T_Bool, T_Bool ->
+      true
+  | T_Enum li_s, T_Enum li_t -> list_equal String.equal li_s li_t
+  | T_Array (_, ty_s), T_Array (_, ty_t) -> type_clashes env ty_s ty_t
+  | T_Tuple li_s, T_Tuple li_t ->
+      List.compare_lengths li_s li_t = 0
+      && List.for_all2 (type_clashes env) li_s li_t
+  | _ -> false
+
+let subprogram_clashes env f1 f2 =
+  (* Two subprograms clash if all of the following hold:
+      • they have the same name
+      • they are the same kind of subprogram
+      • they have the same number of formal arguments
+      • every formal argument in one type-clashes with the corresponding formal
+        argument in the other
+
+     TODO: they are the same kind of subprogram
+  *)
+  String.equal f1.name f2.name
+  && List.compare_lengths f1.args f2.args = 0
+  && List.for_all2
+       (fun (_, t1) (_, t2) -> type_clashes env t1 t2)
+       f1.args f2.args
+
+let supertypes_set (env : env) =
+  let rec aux acc x =
+    let acc = ISet.add x acc in
+    match IMap.find_opt x env.global.subtypes with
+    | Some x' -> aux acc x'
+    | None -> acc
+  in
+  aux ISet.empty
+
+let find_named_lowest_common_supertype env x1 x2 =
+  (* TODO: Have a better algorithm? This is in O(h * log h) because set
+     insertions are in O (log h), where h is the max height of the subtype
+     tree. Wikipedia says it is in O(h) generally, and it can be precomputed,
+     in which case it becomes O(1). *)
+  let set1 = supertypes_set env x1 in
+  let rec aux x =
+    if ISet.mem x set1 then Some x
+    else
+      match IMap.find_opt x env.global.subtypes with
+      | None -> None
+      | Some x' -> aux x'
+  in
+  aux x2
+
+let rec lowest_common_ancestor env s t =
+  (* The lowest common ancestor of types S and T is: *)
+  (* • If S and T are the same type: S (or T). *)
+  if type_equal env s t then Some s
+  else
+    match (s.desc, t.desc) with
+    | T_Named name_s, T_Named name_t -> (
+        (* If S and T are both named types: the (unique) common supertype of S
+           and T that is a subtype of all other common supertypes of S and T. *)
+        match find_named_lowest_common_supertype env name_s name_t with
+        | None -> None
+        | Some name -> Some (T_Named name |> add_dummy_pos))
+    | _ -> (
+        let struct_s = get_structure env s and struct_t = get_structure env t in
+        match (struct_s.desc, struct_t.desc) with
+        | T_Array (l_s, t_s), T_Array (l_t, t_t)
+          when type_equal env t_s t_t && expr_equal env l_s l_t -> (
+            (* If S and T both have the structure of array types with the same
+               index type and the same element types:
+                – If S is a named type and T is an anonymous type: S
+                – If S is an anonymous type and T is a named type: T *)
+            match (s.desc, t.desc) with
+            | T_Named _, T_Named _ -> assert false
+            | T_Named _, _ -> Some s
+            | _, T_Named _ -> Some t
+            | _ -> assert false)
+        | T_Tuple li_s, T_Tuple li_t
+          when List.compare_lengths li_s li_t = 0
+               && List.for_all2 (type_satisfies env) li_s li_t
+               && List.for_all2 (type_satisfies env) li_t li_s -> (
+            (* If S and T both have the structure of tuple types with the same
+               number of elements and the types of elements of S type-satisfy the
+               types of the elements of T and vice-versa:
+                – If S is a named type and T is an anonymous type: S
+                – If S is an anonymous type and T is a named type: T
+                – If S and T are both anonymous types: the tuple type with the
+                  type of each element the lowest common ancestor of the types of
+                  the corresponding elements of S and T. *)
+            match (s.desc, t.desc) with
+            | T_Named _, T_Named _ -> assert false
+            | T_Named _, _ -> Some s
+            | _, T_Named _ -> Some t
+            | _ ->
+                let maybe_ancestors =
+                  List.map2 (lowest_common_ancestor env) li_s li_t
+                in
+                let ancestors = List.filter_map Fun.id maybe_ancestors in
+                if List.compare_lengths ancestors li_s = 0 then
+                  Some (add_dummy_pos (T_Tuple ancestors))
+                else None)
+        | T_Int (Some []), _ ->
+            (* TODO: This is pretty bizarre. Maybe revisit LRM? *)
+            (* If either S or T have the structure of an under-constrained
+               integer type: the under-constrained integer type. *)
+            Some s
+        | _, T_Int (Some []) ->
+            (* TODO: This is pretty bizarre. Maybe revisit LRM? *)
+            (* If either S or T have the structure of an under-constrained
+               integer type: the under-constrained integer type. *)
+            Some t
+        | T_Int (Some cs_s), T_Int (Some cs_t) -> (
+            (* Implicit: cs_s and cs_t are non-empty, see patterns above. *)
+            (* If S and T both have the structure of well-constrained integer
+               types:
+               – If S is a named type and T is an anonymous type: S
+               – If T is an anonymous type and S is a named type: T
+               – If S and T are both anonymous types: the well-constrained
+                 integer type with domain the union of the domains of S and T.
+            *)
+            match (s.desc, t.desc) with
+            | T_Named _, T_Named _ -> assert false
+            | T_Named _, _ -> Some s
+            | _, T_Named _ -> Some t
+            | _ ->
+                (* TODO: simplify domains ? If domains use a form of diets,
+                   this could be more efficient. *)
+                Some (add_dummy_pos (T_Int (Some (cs_s @ cs_t)))))
+        | T_Int None, _ -> (
+            (* Here S has the structure of an unconstrained integer type. *)
+            (* TODO: This is pretty bizarre. Maybe revisit LRM? *)
+            (* TODO: typo in the LRM, corrected here, on point 2 S and T have
+               been swapped. *)
+            (* If either S or T have the structure of an unconstrained integer
+               type:
+               – If S is a named type with the structure of an unconstrained
+                 integer type and T is an anonymous type: S
+               – If T is an anonymous type and S is a named type with the
+                 structure of an unconstrained integer type: T
+               – If S and T are both anonymous types: the unconstrained integer
+                 type. *)
+            match (s.desc, t.desc) with
+            | T_Named _, T_Named _ -> assert false
+            | T_Named _, _ -> Some s
+            | _, T_Named _ -> assert false
+            | _, _ -> Some (add_dummy_pos (T_Int None)))
+        | _, T_Int None -> (
+            (* Here T has the structure of an unconstrained integer type. *)
+            (* TODO: This is pretty bizarre. Maybe revisit LRM? *)
+            (* TODO: typo in the LRM, corrected here, on point 2 S and T have
+               been swapped. *)
+            (* If either S or T have the structure of an unconstrained integer
+               type:
+               – If S is a named type with the structure of an unconstrained
+                 integer type and T is an anonymous type: S
+               – If T is an anonymous type and S is a named type with the
+                 structure of an unconstrained integer type: T
+               – If S and T are both anonymous types: the unconstrained integer
+                 type. *)
+            match (s.desc, t.desc) with
+            | T_Named _, T_Named _ -> assert false
+            | T_Named _, _ -> assert false
+            | _, T_Named _ -> Some t
+            | _, _ -> Some (add_dummy_pos (T_Int None)))
+        | _ -> None)

--- a/asllib/types.mli
+++ b/asllib/types.mli
@@ -1,0 +1,107 @@
+(** Type Algebra *)
+
+(**
+   Types are defined as {!AST.ty}. This should map pretty-well with the current
+   version of the Language Reference Manual.
+*)
+
+open AST
+
+(** {1 Predicates on types} *)
+
+val is_builtin : ty -> bool
+val is_builtin_singular : ty -> bool
+val is_builtin_aggregate : ty -> bool
+
+(** Note that a builtin type is either builtin aggregate or builtin singular. *)
+
+val is_singular : Env.Static.env -> ty -> bool
+val is_aggregate : Env.Static.env -> ty -> bool
+
+(** Note that a type is either singular or aggregate. *)
+
+val is_named : ty -> bool
+(** Types declared using the [type] syntax. *)
+
+val is_anonymous : ty -> bool
+(** Those not declared using †he [type] syntax. *)
+
+(** Note that a type is either builtin, named or anonymous. *)
+
+val is_primitive : ty -> bool
+(** Types that only use the builtin types. *)
+
+val is_non_primitive : ty -> bool
+(** Types that are named types or which make use of named types.
+
+    Usually for all [ty]: {[
+      is_non_primitive ty = not (is_primitive ty)
+    ]}
+*)
+
+(** {1 Relations on types} *)
+
+(** {2 Type transformations} *)
+
+val get_structure : Env.Static.env -> ty -> ty
+(** The structure of a type is the primitive type that can hold the same
+    values. *)
+
+(** {2 Domains} *)
+
+(** The domain of a type is the set of values which storagbe element of that type may hold. *)
+module Domain : sig
+  type t
+  (** Abstract value set. *)
+
+  val pp : Format.formatter -> t -> unit
+  (** A printer for the domain type. *)
+
+  val of_type : Env.Static.env -> ty -> t
+  (** Construct the domain of a type. *)
+
+  val mem : AST.value -> t -> bool
+  (** [mem v d] is true if and only if [v] is in [d]. *)
+
+  val equal : t -> t -> bool
+  (** Wheather two domains are equal. *)
+
+  val compare : t -> t -> int option
+  (** The inclusion order on domains.
+
+      It is a partial order. *)
+end
+
+(** {2 Orders on types} *)
+
+val subtype_satisfies : Env.Static.env -> ty -> ty -> bool
+(** Subtype-satisfation as per Definition TRVR. *)
+
+val domain_subtype_satisfies : Env.Static.env -> ty -> ty -> bool
+val structural_subtype_satisfies : Env.Static.env -> ty -> ty -> bool
+
+val type_satisfies : Env.Static.env -> ty -> ty -> bool
+(** Type-satisfation as per Rule FMXK. *)
+
+val type_clashes : Env.Static.env -> ty -> ty -> bool
+(** Type-clashing relation.
+
+    Notes:
+      - T subtype-satisfies S implies T and S type-clash
+      - This is a equivalence relation
+
+    As par Definition VPZZ.
+*)
+
+val subprogram_clashes :
+  Env.Static.env -> 'a func_skeleton -> 'b func_skeleton -> bool
+(** Subprogram clashing relation.
+
+    As per Definition BTBR.
+*)
+
+val lowest_common_ancestor : Env.Static.env -> ty -> ty -> ty option
+(** Lowest common ancestor.
+
+    As per Rule YZHM.
+*)

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -100,7 +100,9 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64) :
     let decode_inst ii =
       let open Asllib.AST in
       let with_pos desc = Asllib.ASTUtils.add_dummy_pos desc in
-      let ( ^= ) x e = S_Assign (LE_Var x |> with_pos, e) |> with_pos in
+      let ( ^= ) x e =
+        S_Decl (LDK_Let, LDI_Var (x, None), Some e) |> with_pos
+      in
       let lit v = E_Literal v |> with_pos in
       let liti i = lit (V_Int i) in
       let litb b = lit (V_Bool b) in
@@ -436,7 +438,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64) :
           filter = None;
           condition = ConstrGen.ExistsState (ConstrGen.And []);
           locations = [];
-          extra_data = MiscParser.empty_extra ;
+          extra_data = MiscParser.empty_extra;
         }
       in
       let name =

--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -194,14 +194,15 @@ func PhysMemRead(
   accdesc::AccessDescriptor
 ) => (PhysMemRetStatus, bits(8*size))
 begin
-  value = read_memory (desc.vaddress, size*8);
-  ret_status = PhysMemRetStatus {
+  let value = read_memory (desc.vaddress, size*8);
+  let ret_status = PhysMemRetStatus {
     statuscode = Fault_None,
     extflag = '0',
     merrorstate = ErrorState_CE,  // ??
     store64bstatus = Zeros(64)
   };
-  return (ret_status, value);
+  assert size == 8;
+  return (ret_status, (value as bits((8*size))));
 end
 
 func HaveAArch32() => boolean

--- a/herd/libdir/asl-pseudocode/patches.asl
+++ b/herd/libdir/asl-pseudocode/patches.asl
@@ -1,6 +1,3 @@
-
-
-
 // GenMPAMatEL()
 // =============
 // Returns MPAMinfo for the specified EL.
@@ -55,12 +52,6 @@ func ELStateUsingAArch32K(el::bits(2), secure::boolean) => (boolean, boolean)
 begin
     return (TRUE, FALSE);
 end
-
-func SignExtend(x::bits(M), N::integer) => bits(N)
-begin
-  return sign_extend (x, N);
-end
-
 
 // ProcState
 // =========

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=7bc77a96e738a6f52b5a9721522f61fe
+Hash=3e0c7fc2f077331d7a7e97baafe217fa
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=f9a3add915f2fb761d3a2c557d6c7b1b
+Hash=e97e3c93fc2c698b81a0959164e2adba
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=bb7c97bd88c78edab3ddab591d5fc7ca
+Hash=c7374fbc019940b77bbe06e31c7afa16
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=7e1d806aede38cf408ad9e0a683d6bac
+Hash=b7178cd347ce6564680b771a83a2d657
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=f56f1369368fae158c7901bd88ecd0dc
+Hash=2fcd39d87bb3197892aa70bbf50f13cd
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=289a7cc89440223df8a76ae3c3cc488d
+Hash=9630799b26c295fe07ea292e8321273c
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=f64480b389dbe846d6cebf0a3938e445
+Hash=4ec5522c61c7e67458d7beb2335d22fe
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=b8272a3b8633a947baddfa6f326e8f0f
+Hash=a5b6ede945a64abff3266c74e0033fb9
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=bd8788cbfd01ca7b0a3d57f62d05c2b6
+Hash=a6e54e9e7abe03e62cb7ecf0df6657a7
 

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T1.0.a=1 /\ 0:T1.0.b=0)
 Observation MP-pseudo-arch Sometimes 1 3
-Hash=3d982cc6a47946c116558731c8717e40
+Hash=a0a903a542cb6b4df17cdc6ba4028433
 

--- a/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation for-toofar Always 3 0
-Hash=00d905a292b3570c8c0b9db3730c0e31
+Hash=c135f5f60b37d999ac2d7d638b120762
 

--- a/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation repeat-toofar Always 3 0
-Hash=a9fe742e84b4416ea3c7af1a584e0004
+Hash=980b1cf019ee1359fb6e1f5fcae7c54b
 

--- a/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation while-toofar Always 3 0
-Hash=86819245101076b2c307999d38623c84
+Hash=376bb73da40e0398abb8fd17703186f7
 

--- a/herd/tests/instructions/ASL/assign3.litmus.expected
+++ b/herd/tests/instructions/ASL/assign3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.eq=1 /\ 0:main.0.ne=1 /\ 0:main.0.lt=1 /\ 0:main.0.al=1)
 Observation assign3 Always 1 0
-Hash=3591ed48e9d67096c29902db3e606d31
+Hash=2884fbcd954865be9ee14d5486c9b570
 

--- a/herd/tests/instructions/ASL/bitfields1.litmus
+++ b/herd/tests/instructions/ASL/bitfields1.litmus
@@ -27,12 +27,12 @@ end
 
 func main()
 begin
-  a = constructor('10101');
-  b = if get_b(a) == '010' then 1 else 0;
-  c = set_e(a, '0');
-  c_c = c.c;
-  d = if c.e == '0' then 1 else 0;
-  e = if c.c == '00101' then 1 else 0;
+  let a = constructor('10101');
+  let b = if get_b(a) == '010' then 1 else 0;
+  let c = set_e(a, '0');
+  let c_c = c.c;
+  let d = if c.e == '0' then 1 else 0;
+  let e = if c.c == '00101' then 1 else 0;
 end
 
 forall (

--- a/herd/tests/instructions/ASL/bitfields1.litmus.expected
+++ b/herd/tests/instructions/ASL/bitfields1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.b=1 /\ 0:main.0.d=1 /\ 0:main.0.e=1)
 Observation bitfields1 Always 1 0
-Hash=092228a59e1733ef11f95ec05b7cdd4c
+Hash=0434769dd7c9b297a5fc756004c81c95
 

--- a/herd/tests/instructions/ASL/data-return-01.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-01.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation no Always 1 0
-Hash=406034acbf6eb233a26bf86a891223f4
+Hash=d6b53bfd4ca3160bdcfc3be512804839
 

--- a/herd/tests/instructions/ASL/data-return-02.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-02.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation no Always 1 0
-Hash=9a66830089e793e8b5ea6fee18965f19
+Hash=fd16cbc38a50de0b8225d688a97fd9be
 

--- a/herd/tests/instructions/ASL/double-load.litmus.expected
+++ b/herd/tests/instructions/ASL/double-load.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.three=3)
 Observation double-load Always 1 0
-Hash=ebe0136cc0600caba641c117c0440bf7
+Hash=5614c5941e5a217f69aeb936c7ba6d66
 

--- a/herd/tests/instructions/ASL/func1.litmus
+++ b/herd/tests/instructions/ASL/func1.litmus
@@ -9,8 +9,8 @@ end
 
 func main()
 begin
-    x = 3;
-    y = f(x);
+    let x = 3;
+    let y = f(x);
 end
 
 forall (

--- a/herd/tests/instructions/ASL/func1.litmus.expected
+++ b/herd/tests/instructions/ASL/func1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3 /\ 0:main.0.y=3)
 Observation func1 Always 1 0
-Hash=db045a75e772e195f85eba17bbcfc950
+Hash=cc0ffc94a40b070dd49e16122553a22b
 

--- a/herd/tests/instructions/ASL/func2.litmus
+++ b/herd/tests/instructions/ASL/func2.litmus
@@ -10,14 +10,14 @@ end
 
 setter X_set[i::integer] = v::integer
 begin
-    internal_i = i;
-    internal_v = v;
+    let internal_i = i;
+    let internal_v = v;
 end
 
 func main()
 begin
     X_set[2] = 3;
-    x = X_get[4];
+    let x = X_get[4];
 end
 
 forall (

--- a/herd/tests/instructions/ASL/func2.litmus.expected
+++ b/herd/tests/instructions/ASL/func2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=4 /\ 0:setter-X_set.0.internal_i=2 /\ 0:setter-X_set.0.internal_v=3)
 Observation func02 Always 1 0
-Hash=ee9c109573a475846bab2aa25c81881d
+Hash=e8c462c15c918f9649214b8b05eb04ff
 

--- a/herd/tests/instructions/ASL/func3.litmus
+++ b/herd/tests/instructions/ASL/func3.litmus
@@ -26,21 +26,21 @@ end
 
 setter f3[x::integer] = v :: integer
 begin
-  f3_internal = x;
+  let f3_internal = x;
 end
 
 setter f4[x::integer] = v :: integer
 begin
-  f4_internal = v;
+  let f4_internal = v;
 end
 
 func main()
 begin
   f1[] = f1[];
   f1 = f1;
-  a = f1;
-  b = f1[];
-  c = f2[4];
+  let a = f1;
+  let b = f1[];
+  let c = f2[4];
   f2[5] = 6;
   f3[12] = 13;
   f4[14] = 15;

--- a/herd/tests/instructions/ASL/func3.litmus.expected
+++ b/herd/tests/instructions/ASL/func3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=3 /\ 0:main.0.b=3 /\ 0:main.0.c=7 /\ 0:setter-f3.0.f3_internal=12 /\ 0:setter-f4.0.f4_internal=15)
 Observation func3 Always 1 0
-Hash=50da29c641338694570a3f3fd84b1d83
+Hash=1e9626861cfc27ae3817d881367cb951
 

--- a/herd/tests/instructions/ASL/func4.litmus
+++ b/herd/tests/instructions/ASL/func4.litmus
@@ -20,9 +20,9 @@ end
 
 func main()
 begin
-  a = f();
-  b = f(1);
-  c = f(2, 3);
+  let a = f();
+  let b = f(1);
+  let c = f(2, 3);
 end
 
 forall (

--- a/herd/tests/instructions/ASL/func4.litmus.expected
+++ b/herd/tests/instructions/ASL/func4.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=0 /\ 0:main.0.b=1 /\ 0:main.0.c=5)
 Observation func4 Always 1 0
-Hash=abd5f234c5cb20b251585c2ebec3f3f2
+Hash=09083f3a2637e1ba93aff6c1f30fa030
 

--- a/herd/tests/instructions/ASL/write_mem.litmus.expected
+++ b/herd/tests/instructions/ASL/write_mem.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 0 Negative: 1
 Condition forall ([x]=3)
 Observation write-mem Never 0 1
-Hash=e5cf6f5fa120d1d6472eb18e535acb3d
+Hash=ae0e986d3d0cc754dc7dafb3b8721c27
 

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -80,6 +80,8 @@ type t =
   | ASL
   | ASL_AArch64
   | ASLVersion of [ `ASLv0 | `ASLv1 ]
+(* ASL Typing control *)
+  | ASLType of [`Warn|`Silence|`TypeCheck]
 (* Signed Int128 types *)
   | S128
 
@@ -91,7 +93,8 @@ let tags =
     Precision.tags @
    ["toofar"; "deps"; "morello"; "instances"; "noptebranch"; "pte2";
    "pte-squared"; "PhantomOnLoad"; "OptRfRMW"; "ConstrainedUnpredictable";
-   "exp"; "self"; "cos-opt"; "test"; "T[0-9][0-9]"; "asl"; "S128"]
+    "exp"; "self"; "cos-opt"; "test"; "T[0-9][0-9]"; "asl"; "S128";
+    "ASLType+Warn";    "ASLType+Silence"; "ASLType+Check";]
 
 let parse s = match Misc.lowercase s with
 | "success" -> Some Success
@@ -135,6 +138,9 @@ let parse s = match Misc.lowercase s with
 | "asl_aarch64" | "aslaarch64" | "asl+aarch64" -> Some ASL_AArch64
 | "aslv0" | "asl0" | "asl_0" -> Some (ASLVersion `ASLv0)
 | "aslv1" | "asl1" | "asl_1" -> Some (ASLVersion `ASLv1)
+| "asltype+warn" -> Some (ASLType `Warn)
+| "asltype+silence"-> Some (ASLType `Silence)
+| "asltype+check"  -> Some (ASLType `TypeCheck)
 | "s128" -> Some S128
 | s ->
    begin
@@ -196,6 +202,9 @@ let pp = function
   | ASLVersion `ASLv0 -> "ASLv0"
   | ASLVersion `ASLv1 -> "ASLv1"
   | S128 -> "S128"
+  | ASLType `Warn -> "ASLType+Warn"
+  | ASLType `Silence -> "ASLType+Silence"
+  | ASLType `TypeCheck -> "ASLType+Check"
 
 let compare = compare
 let equal v1 v2 = compare v1 v2 = 0

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -81,6 +81,8 @@ type t =
   | ASL_AArch64 
   (* When using aarch ASL, use ASL version v0 or v1 *)
   | ASLVersion of [ `ASLv0 | `ASLv1 ] 
+(* ASL Typing control *)
+  | ASLType of [`Warn|`Silence|`TypeCheck]
 (* Signed Int128 types *)
   | S128
 

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -135,7 +135,6 @@ include Pseudo.Make (struct
 
   let parsed_tr ast = ast
   let get_naccesses _ = -1
-
   let size_of_ins _ = 4
   let fold_labels k _f _i = k
   let map_labels _f i = i
@@ -173,10 +172,7 @@ let asl_generic_parser version lexer lexbuf =
     Asllib.Builder.from_lexer_lexbuf ~ast_type:`Ast version lexer lexbuf
   with
   | Error e -> raise (Misc.Fatal (Asllib.Error.error_to_string e))
-  | Ok ast ->
-      ( [ (0, None, MiscParser.Main) ],
-        [ [ Instruction ast ] ],
-        [] )
+  | Ok ast -> ([ (0, None, MiscParser.Main) ], [ [ Instruction ast ] ], [])
 
 module Instr = Instr.No (struct
   type instr = instruction


### PR DESCRIPTION
This PR brings:

- [x] An implementation of the type algebra and relations in `asllib/Types.ml`
- [x] Use of this type-algebra for type-checking in `asllib/Typing.ml`
- [x] Implementation of an expression reduction algorithm in `asllib/StaticInterpreter.ml`
- [x] Use of a shared environment type defined in `asllib/env.ml`
- [x] Enforce far more type-checking rules, such as immutable storage elements.