### PR TITLE
Add LDA/LDAEX, STL,STLEX Instructions to ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,18 @@ arm-test::
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 ARM instructions tests: OK"
 
+aarch32-test::
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/AArch32 \
+		-conf ./herd/tests/instructions/AArch32/aarch32.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 ARM instructions tests: OK"
+
+test::aarch32-test
+
 test::
 
 diy-test:: diy-test-aarch64

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -15,6 +15,12 @@
 (****************************************************************************)
 
 (** Define ARM architecture *)
+module Types = struct
+  type annot =
+      A | L | X | XL | XA | N | NoRet
+  type lannot = annot
+  type explicit = Exp | NExp
+end
 
 module Make (C:Arch_herd.Config) (V:Value.S) =
   struct
@@ -23,15 +29,28 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
     let pp_barrier_short = pp_barrier
     let reject_mixed = false
 
-    type lannot = bool (* atomicity *)
+    include Types
     let get_machsize _ = V.Cst.Scalar.machsize (* No mixed size instruction *)
-    let empty_annot = false
+    let empty_annot = N
 
-    include Explicit.No
     include PteValSets.No
 
     let is_barrier b1 b2 = barrier_compare b1 b2 = 0
-    let is_atomic annot = annot
+    let is_atomic = function
+      | A | L | X | XL | XA | NoRet -> true
+      | _ -> false
+
+    let is_acquire = function
+      | A | XA -> true
+      | _ -> false
+    let is_release = function
+      | L | XL -> true
+      | _ -> false
+
+    let is_noreturn = function
+      | NoRet -> true
+      | _ -> false
+
     let is_explicit annot = annot
     let is_not_explicit annot = annot
 
@@ -47,13 +66,40 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     let cmo_sets = []
 
-    let annot_sets = ["X",is_atomic]
+    let annot_sets = [
+      "X", is_atomic;
+      "A",  is_acquire;
+      "L",  is_release;
+      "AL", is_acquire;
+      "NoRet", is_noreturn;
+    ]
+    let explicit_sets = [
+    ]
+    let pp_explicit = function
+    | Exp -> "Exp"
+    | NExp -> ""
+    let is_explicit_annot = function
+      | Exp -> true
+      | NExp -> false
+
+    and is_not_explicit_annot = function
+      | NExp -> true
+      | Exp -> false
+    let nexp_annot = NExp
+    let exp_annot = Exp
+
 
     let is_isync = is_barrier ISB
     let pp_isync = "isb"
 
-    let pp_annot annot =
-      if annot then "*" else ""
+    let pp_annot annot = match annot with
+      | A -> "Acq"
+      | L -> "Rel"
+      | XA -> "Acq*"
+      | XL -> "Rel*"
+      | NoRet -> "NoRet"
+      | N -> ""
+      | X -> "*"
 
     module V = V
 
@@ -65,6 +111,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
       | I_SADD16 _ | I_SEL _
         -> None
       | I_LDR _ | I_LDREX _ | I_LDR3 _ | I_STR _ | I_STREX _ | I_STR3 _
+      | I_STL _ | I_LDA _|I_LDAEX _|I_STLEX _
       | I_LDRO _ | I_LDM2 _ | I_LDM3 _ | I_LDRD _
         -> Some MachSize.Word
 

--- a/herd/libdir/aarch32.cat
+++ b/herd/libdir/aarch32.cat
@@ -9,10 +9,7 @@
  * https://developer.arm.com/documentation/ddi0487/
  *
  * Authors:
- * Will Deacon <will.deacon@arm.com>
- * Jade Alglave <jade.alglave@arm.com>
- * Nikos Nikoleris <nikos.nikoleris@arm.com>
- * Artem Khyzha <artem.khyzha@arm.com>
+ * Luke Geeson <luke.geeson@cs.ucl.ac.uk>
  *
  * Copyright (C) 2016-present, Arm Ltd.
  * All rights reserved.
@@ -44,68 +41,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *)
 
-(*
- * Include default definitions for sets that are undefined without
- * -variant vmsa
-*)
-let PTE = try PTE with emptyset
-let PTEV = try PTEV with emptyset
-let PTEINV = try PTEINV with emptyset
-let inv-domain = try inv-domain with 0
-let AF = try AF with emptyset
-let DB = try DB with emptyset
-let MMU = try MMU with emptyset
-let Translation = try Translation with emptyset
-let AccessFlag = try AccessFlag with emptyset
-let TagCheck = try TagCheck with emptyset
+AArch32
+catdep
 
-(*
- * Include the cos.cat file shipped with herd.
- * This builds the co relation as a total order over writes to the same
- * location and then consequently defines the fr relation using co and
- * rf.
- *)
-let AFtoDB = same-instance & ((AF\DB) * (DB\AF))
-let co0=co0 | AFtoDB
-
-include "cos.cat"
-
-(*
- * Include aarch64fences.cat to define barriers.
- *)
-include "aarch64fences.cat"
-
-(*
- * Include aarch64deps.cat to define dependencies.
- *)
-include "aarch64deps.cat"
-
-(*
- * Include aarch64bbm.cat to define relations on Break-Before-Make semantics.
- *)
-include "aarch64bbm.cat"
-
-(* Show relations in generated diagrams *)
-include "aarch64show.cat"
-
-(* Helper functions *)
-procedure included(r1, r2) =
-  empty r1 \ r2
-end
-
-procedure equal(r1, r2) =
-  call included(r1, r2)
-  call included(r2, r1)
-end
-
-(* Intervening write *)
-let intervening-write(r) = r; [W]; r
-
-(* Properties of single-copy atomic accesses *)
-let sca-class = [M & Exp]; sm; [M & Exp]
-
-(* Renaming default herd names *)
-let Imp = NExp
-let SPONTANEOUS = SPURIOUS
-let inv-scope = inv-domain
-let TTD = PTE
+let DMB.SY = DMB
+let DSB.SY = DSB
+include "aarch64.cat"

--- a/herd/tests/instructions/AArch32/A016.litmus
+++ b/herd/tests/instructions/AArch32/A016.litmus
@@ -1,0 +1,17 @@
+ARM A016
+
+{
+0:R1=x; 1:R1=x;
+0:R3=y; 1:R3=y;
+}
+
+ P0               | P1            ;
+ MOV R0, #1       | MOV R2, #1    ;
+ L0:              | STL  R2, [R3] ;
+ LDAEX R6, [R1]   | LDA  R0, [R1] ;
+ STLEX R4,R0,[R1] | ;
+ CMP R4, #0       | ;
+ BNE L0           | ; 
+ LDA R2, [R3]     | ;
+
+exists(0:R2=0 /\ 1:R0=0)

--- a/herd/tests/instructions/AArch32/A016.litmus.expected
+++ b/herd/tests/instructions/AArch32/A016.litmus.expected
@@ -1,0 +1,12 @@
+Test A016 Allowed
+States 3
+0:R2=0; 1:R0=1;
+0:R2=1; 1:R0=0;
+0:R2=1; 1:R0=1;
+Loop No
+Witnesses
+Positive: 0 Negative: 9
+Condition exists (0:R2=0 /\ 1:R0=0)
+Observation A016 Never 0 9
+Hash=f9537c416b340c5c1d7afc4295df5253
+

--- a/herd/tests/instructions/AArch32/A016.litmus.expected-warn
+++ b/herd/tests/instructions/AArch32/A016.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch32/A016.litmus", unrolling limit exceeded, legal outcomes may be missing.

--- a/herd/tests/instructions/AArch32/A017.litmus
+++ b/herd/tests/instructions/AArch32/A017.litmus
@@ -1,0 +1,18 @@
+ARM A017
+
+{
+0:R1=x; 1:R1=x;
+0:R3=y; 1:R3=y;
+}
+
+ P0               | P1            ;
+ MOV R0, #1       | MOV R2, #1    ;
+ L0:              | STL  R2, [R3] ;
+ LDAEX R6, [R1]   | LDA  R0, [R1] ;
+ STLEX R4,R0,[R1] | ;
+ CMP R4, #0       | ;
+ BNE L0           | ;
+ LDR R2, [R3]     | ;
+ DMB ISH          | ;
+
+exists(0:R2=0 /\ 1:R0=0)

--- a/herd/tests/instructions/AArch32/A017.litmus.expected
+++ b/herd/tests/instructions/AArch32/A017.litmus.expected
@@ -1,0 +1,14 @@
+Test A017 Allowed
+States 4
+0:R2=0; 1:R0=0;
+0:R2=0; 1:R0=1;
+0:R2=1; 1:R0=0;
+0:R2=1; 1:R0=1;
+Loop Ok
+Witnesses
+Positive: 3 Negative: 9
+Flag Assuming-common-inner-shareable-domain
+Condition exists (0:R2=0 /\ 1:R0=0)
+Observation A017 Sometimes 3 9
+Hash=ecb3d7f444cf1f6f6954389197887144
+

--- a/herd/tests/instructions/AArch32/A017.litmus.expected-warn
+++ b/herd/tests/instructions/AArch32/A017.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch32/A017.litmus", unrolling limit exceeded, legal outcomes may be missing.

--- a/herd/tests/instructions/AArch32/A018.litmus
+++ b/herd/tests/instructions/AArch32/A018.litmus
@@ -1,0 +1,18 @@
+ARM A018
+
+{
+0:R1=x; 1:R1=x;
+0:R3=y; 1:R3=y;
+}
+
+ P0               | P1            ;
+ MOV R0, #1       | MOV R2, #1    ;
+ L0:              | STL  R2, [R3] ;
+ LDAEX R6, [R1]   | LDA  R0, [R1] ;
+ STLEX R4,R0,[R1] | ;
+ CMP R4, #0       | ;
+ BNE L0           | ;
+ LDREX R2, [R3]   | ;
+ DMB ISH          | ;
+
+exists(0:R2=0 /\ 1:R0=0)

--- a/herd/tests/instructions/AArch32/A018.litmus.expected
+++ b/herd/tests/instructions/AArch32/A018.litmus.expected
@@ -1,0 +1,14 @@
+Test A018 Allowed
+States 4
+0:R2=0; 1:R0=0;
+0:R2=0; 1:R0=1;
+0:R2=1; 1:R0=0;
+0:R2=1; 1:R0=1;
+Loop Ok
+Witnesses
+Positive: 3 Negative: 9
+Flag Assuming-common-inner-shareable-domain
+Condition exists (0:R2=0 /\ 1:R0=0)
+Observation A018 Sometimes 3 9
+Hash=3d5fb7cad4c9bc287ca8875afd5d42ec
+

--- a/herd/tests/instructions/AArch32/A018.litmus.expected-warn
+++ b/herd/tests/instructions/AArch32/A018.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch32/A018.litmus", unrolling limit exceeded, legal outcomes may be missing.

--- a/herd/tests/instructions/AArch32/A019.litmus
+++ b/herd/tests/instructions/AArch32/A019.litmus
@@ -1,0 +1,19 @@
+ARM A019
+
+{
+0:R1=x; 1:R1=x;
+0:R3=y; 1:R3=y;
+}
+
+ P0               | P1            ;
+ MOV R0, #1       | MOV R2, #1    ;
+ L0:              | STL  R2, [R3] ;
+ LDAEX R6, [R1]   | LDA  R0, [R1] ;
+ STLEX R4,R0,[R1] | ;
+ CMP R4, #0       | ;
+ BNE L0           | ;
+ DMB ISH          | ;
+ LDREX R2, [R3]   | ;
+ DMB ISH          | ;
+
+exists(0:R2=0 /\ 1:R0=0)

--- a/herd/tests/instructions/AArch32/A019.litmus.expected
+++ b/herd/tests/instructions/AArch32/A019.litmus.expected
@@ -1,0 +1,13 @@
+Test A019 Allowed
+States 3
+0:R2=0; 1:R0=1;
+0:R2=1; 1:R0=0;
+0:R2=1; 1:R0=1;
+Loop No
+Witnesses
+Positive: 0 Negative: 9
+Flag Assuming-common-inner-shareable-domain
+Condition exists (0:R2=0 /\ 1:R0=0)
+Observation A019 Never 0 9
+Hash=0d88387a17be7a964ab6c4e969f60e5d
+

--- a/herd/tests/instructions/AArch32/A019.litmus.expected-warn
+++ b/herd/tests/instructions/AArch32/A019.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch32/A019.litmus", unrolling limit exceeded, legal outcomes may be missing.

--- a/herd/tests/instructions/AArch32/aarch32.cfg
+++ b/herd/tests/instructions/AArch32/aarch32.cfg
@@ -1,0 +1,1 @@
+model herd/libdir/aarch32.cat

--- a/jingle/ARMArch_jingle.ml
+++ b/jingle/ARMArch_jingle.ml
@@ -73,12 +73,15 @@ let match_instr subs pattern instr = match pattern,instr with
   | I_CMPI(r,MetaConst.Int i),I_CMPI(r',i') when i=i' ->
      add_subs [Reg(sr_name r,r')] subs
   | I_CMP(r1,r2),I_CMP(r1',r2')
+  | I_LDA(r1,r2),I_LDA(r1',r2')
+  | I_LDAEX(r1,r2),I_LDAEX(r1',r2')
   | I_LDREX(r1,r2),I_LDREX(r1',r2') ->
       add_subs
         [Reg(sr_name r1,r1');Reg(sr_name r2,r2')]
         subs
   | I_LDR(r1,r2,c),I_LDR(r1',r2',c')
   | I_STR(r1,r2,c),I_STR(r1',r2',c')
+  | I_STL(r1,r2,c),I_STL(r1',r2',c')
   | I_MOV(r1,r2,c),I_MOV(r1',r2',c') when c=c' ->
       add_subs
         [Reg(sr_name r1,r1');Reg(sr_name r2,r2')]
@@ -86,6 +89,10 @@ let match_instr subs pattern instr = match pattern,instr with
   | I_LDR3(r1,r2,r3,c),I_LDR3(r1',r2',r3',c')
   | I_STR3(r1,r2,r3,c),I_STR3(r1',r2',r3',c')
   | I_STREX(r1,r2,r3,c),I_STREX(r1',r2',r3',c') when c=c' ->
+      add_subs
+        [Reg(sr_name r1,r1'); Reg(sr_name r2,r2'); Reg(sr_name r3,r3')]
+        subs
+  | I_STLEX(r1,r2,r3),I_STLEX(r1',r2',r3') ->
       add_subs
         [Reg(sr_name r1,r1'); Reg(sr_name r2,r2'); Reg(sr_name r3,r3')]
         subs
@@ -175,6 +182,14 @@ let match_instr subs pattern instr = match pattern,instr with
           conv_reg r1 >> fun r1 ->
           conv_reg r2 >! fun r2 ->
           I_LDREX(r1,r2)
+      | I_LDAEX(r1,r2) ->
+          conv_reg r1 >> fun r1 ->
+          conv_reg r2 >! fun r2 ->
+          I_LDAEX(r1,r2)
+      | I_LDA(r1,r2) ->
+          conv_reg r1 >> fun r1 ->
+          conv_reg r2 >! fun r2 ->
+          I_LDA(r1,r2)
       | I_LDR(r1,r2,c) ->
           conv_reg r1 >> fun r1 ->
           conv_reg r2 >! fun r2 ->
@@ -210,6 +225,10 @@ let match_instr subs pattern instr = match pattern,instr with
           conv_reg r1 >> fun r1 ->
           conv_reg r2 >! fun r2 ->
           I_STR(r1,r2,c)
+      | I_STL(r1,r2,c) ->
+          conv_reg r1 >> fun r1 ->
+          conv_reg r2 >! fun r2 ->
+          I_STL(r1,r2,c)
       | I_MOV(r1,r2,c) ->
           conv_reg r1 >> fun r1 ->
           conv_reg r2 >! fun r2 ->
@@ -229,6 +248,11 @@ let match_instr subs pattern instr = match pattern,instr with
           conv_reg r2 >> fun r2 ->
           conv_reg r3 >! fun r3 ->
           I_STREX(r1,r2,r3,c)
+      | I_STLEX(r1,r2,r3) ->
+          conv_reg r1 >> fun r1 ->
+          conv_reg r2 >> fun r2 ->
+          conv_reg r3 >! fun r3 ->
+          I_STLEX(r1,r2,r3)
       | I_MOVI(r,v,c) ->
           conv_reg r >> fun r ->
           find_cst v >! fun v ->

--- a/lib/ARMLexer.mll
+++ b/lib/ARMLexer.mll
@@ -42,12 +42,16 @@ match name with
 | "ldrd" | "LDRD"   -> I_LDRD
 | "ldmib" | "LDMIB"   -> I_LDMIB
 | "ldrex" | "LDREX"   -> I_LDREX
+| "ldaex" | "LDAEX"   -> I_LDAEX
 | "ldrne" | "LDRNE"   -> I_LDRNE
 | "ldreq" | "LDREQ"   -> I_LDREQ
+| "lda" | "LDA" -> I_LDA
 | "str" | "STR"   -> I_STR
 | "strne" | "STRNE"   -> I_STRNE
 | "streq" | "STREQ"   -> I_STREQ
 | "strex" | "STREX" -> I_STREX
+| "stlex" | "STLEX" -> I_STLEX
+| "stl" | "STL" -> I_STL
 | "mov" | "MOV"   -> I_MOV
 | "movw" | "MOVW" -> I_MOVW
 | "movt" | "MOVT" -> I_MOVT

--- a/lib/ARMParser.mly
+++ b/lib/ARMParser.mly
@@ -32,7 +32,7 @@ module A = ARMBase
 /* Instruction tokens */
 
 %token I_ADD I_ADDS I_BX I_SUB I_SUBS I_AND I_ORR I_ANDS I_B I_BEQ I_BNE I_CMP I_MOV I_MOVW I_MOVT I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
-%token I_LDR I_LDREX I_LDRNE I_LDREQ I_LDRD I_LDM I_LDMIB I_STR I_STRNE I_STREQ I_STREX
+%token I_LDR I_LDREX I_LDRNE I_LDREQ I_LDRD I_LDM I_LDMIB I_STR I_STRNE I_STREQ I_STREX I_LDA I_STL I_LDAEX I_STLEX
 %token I_SY I_ST I_ISH I_ISHST I_NSH I_NSHST I_OSH I_OSHST
 %type <MiscParser.proc list * (ARMBase.parsedPseudo) list list> main
 %start  main
@@ -145,6 +145,10 @@ instr:
      { A.I_LDREX ($2,$4) }
   | I_LDREX reg COMMA LBRK reg RBRK
      { A.I_LDREX ($2,$5) }
+  | I_LDAEX reg COMMA LBRK reg RBRK
+     { A.I_LDAEX ($2,$5) }
+  | I_LDA reg COMMA LBRK reg RBRK
+     { A.I_LDA ($2, $5)}
   (* 2-reg and 3-reg variants of LDM for now *)
   | I_LDM reg COMMA LPAREN reg COMMA reg RPAREN
      { A.I_LDM2 ($2, $5, $7, A.NO) }
@@ -184,6 +188,10 @@ instr:
      { A.I_STR3 ($2,$5,$7,A.EQ) }
   | I_STREX reg COMMA reg COMMA LBRK reg RBRK
      { A.I_STREX ($2,$4,$7,A.AL) }
+  | I_STL reg COMMA LBRK reg RBRK
+     { A.I_STL ($2, $5,A.AL) }
+  | I_STLEX reg COMMA reg COMMA LBRK reg RBRK
+     { A.I_STLEX ($2,$4,$7) }
 /* MOVE */
   | I_MOV reg COMMA k
      { A.I_MOVI ($2,$4,A.AL) }

--- a/litmus/ARMCompile_litmus.ml
+++ b/litmus/ARMCompile_litmus.ml
@@ -113,6 +113,13 @@ module Make(V:Constant.S)(C:Config) =
         inputs = [r2] ;
         outputs = [r1] ; cond=is_cond c; }
 
+    let lda r1 r2 =
+      let memo = sprintf "%s" "lda" in
+      { empty_ins with
+        memo = sprintf "%s ^o0,[^i0]" memo ;
+        inputs = [r2] ;
+        outputs = [r1] ; }
+
     let ldm2 ra r1 r2 i =
       let memo = sprintf "%s%s" "ldm" (pp_incr i) in
       { empty_ins with
@@ -151,6 +158,13 @@ module Make(V:Constant.S)(C:Config) =
         inputs = [r2] ;
         outputs = [r1]; }
 
+    let ldaex r1 r2 =
+      let memo = "ldaex" in
+      { empty_ins with
+        memo = sprintf "%s ^o0,[^i0]" memo ;
+        inputs = [r2] ;
+        outputs = [r1]; }
+
     let ldr3 c r1 r2 r3 =
       let memo = sprintf "%s%s" "ldr" (pp_cond c) in
       { empty_ins with
@@ -164,6 +178,21 @@ module Make(V:Constant.S)(C:Config) =
         memo = sprintf "%s ^i0,[^i1]" memo ;
         inputs = [r1;r2] ;
         outputs = [] ; cond=is_cond c; }
+
+    let stl s c r1 r2 =
+      let memo = sprintf "%s%s" s (pp_cond c) in
+      { empty_ins with
+        memo = sprintf "%s ^i0,[^i1]" memo ;
+        inputs = [r1;r2] ;
+        outputs = [] ; cond=is_cond c; }
+
+    let stlex r1 r2 r3 =
+      let memo = sprintf "%s" "stlex"  in
+       { empty_ins with
+        memo = sprintf "%s ^o0,^i0,[^i1]" memo ;
+        inputs = [r2;r3] ;
+        outputs = [r1] ; }
+
 
     let str3 c r1 r2 r3 =
       let memo = sprintf "%s%s" "str" (pp_cond c) in
@@ -283,13 +312,17 @@ module Make(V:Constant.S)(C:Config) =
     | I_MOV (r1,r2, c) -> mov c r1 r2::k
 (* Memory *)
     | I_LDR (r1, r2, c) ->  ldr2 c r1 r2::k
+    | I_LDA (r1, r2) ->  lda r1 r2::k
     | I_LDM2 (ra, r1, r2,i) ->  ldm2 ra r1 r2 i::k
     | I_LDM3 (ra, r1, r2, r3, i) ->  ldm3 ra r1 r2 r3 i::k
     | I_LDRD (r1, r2, r3, os) ->  ldrd r1 r2 r3 os::k
     | I_LDRO (r1, r2, k1, c) ->  ldr2k c r1 r2 k1::k
     | I_LDREX (r1, r2) ->  ldrex r1 r2::k
+    | I_LDAEX (r1, r2) ->  ldaex r1 r2::k
     | I_LDR3 (r1, r2, r3, c) ->  ldr3 c r1 r2 r3::k
     | I_STR (r1, r2, c) ->  str2 c r1 r2::k
+    | I_STL (r1, r2, c) ->  stl "STL" c r1 r2::k
+    | I_STLEX (r1, r2, r3) ->  stlex r1 r2 r3::k
     | I_STR3 (r1, r2, r3, c) ->  str3 c r1 r2 r3::k
     | I_STREX (r1, r2, r3, c) ->  strex c r1 r2 r3::k
 (* Comparisons and branches *)


### PR DESCRIPTION
This patch is required to assist Arm's Compiler team.

We wish to test the compilation of AArch32 code. In particular Load Acquire/Store Release (exclusive) instructions.

This patch adds `LDA{EX}` (register) and `STL{EX}` register.

Tests are provided.

This is a work in progress as:
- ~~I am testing these additions on AArch32 hardware (using litmus) as we speak.~~ Validated on Graviton 3
- ~~herd produces incorrect results under the arm.cat model (I have made changes to support acquire/release(exclusive) semantics but the outcomes of `A019` is allowed when it should be forbidden. @maranget do you have any advice on what I may have missed?~~ FIXED