### PR TITLE
[herd] Refactor DC and IC actions into a common CMO

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1934,13 +1934,13 @@ module Make
 
       (* Data cache operations *)
       let dc_loc op a ii =
-        let mk_act loc = Act.DC (op,Some loc) in
+        let mk_act loc = Act.CMO (AArch64.CMO.DC op,Some loc) in
         let loc = A.Location_global a in
         M.mk_singleton_es (mk_act loc) ii
 
       let do_dc op rd ii =
         if AArch64Base.DC.sw op then
-          M.mk_singleton_es (Act.DC (op, None)) ii >>= B.next1T
+          M.mk_singleton_es (Act.CMO (AArch64.CMO.DC op, None)) ii >>= B.next1T
         else begin
             (* TODO: The size for DC should be a cache line *)
             let mop _ac a = dc_loc op a ii in
@@ -1959,13 +1959,13 @@ module Make
 
       let do_ic op rd ii =
         if AArch64Base.IC.all op then (* IC IALLU *)
-          M.mk_singleton_es (Act.IC (op, None)) ii >>= B.next1T
+          M.mk_singleton_es (Act.CMO (AArch64.CMO.IC op, None)) ii >>= B.next1T
         else
         begin (* IC IVAU *)
           read_reg_ord rd ii
           >>= fun a ->
             let loc = A.Location_global a in
-            let act = Act.IC (op,Some loc) in
+            let act = Act.CMO (AArch64.CMO.IC op,Some loc) in
             M.mk_singleton_es act ii
           >>= B.next1T
         end

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -44,6 +44,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
        "DSB.ST",is_barrier (DSB ST);
        "ISB", is_barrier ISB;
      ]
+
+    let cmo_sets = []
+
     let annot_sets = ["X",is_atomic]
 
     let is_isync = is_barrier ISB
@@ -116,4 +119,6 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
       let pp_isync = "isb"
 
     end
+
+    module CMO = Cmo.No
   end

--- a/herd/BellArch_herd.ml
+++ b/herd/BellArch_herd.ml
@@ -56,4 +56,5 @@ module Make
 
     module Barrier = AllBarrier.No(struct type a = barrier end)
 
+    module CMO = Cmo.No
 end

--- a/herd/GenericArch_herd.ml
+++ b/herd/GenericArch_herd.ml
@@ -57,4 +57,6 @@ module Make (B : ArchBaseHerd) (C : Arch_herd.Config) (V : Value.S) = struct
   module Barrier = AllBarrier.No (struct
     type a = barrier
   end)
+
+  module CMO = Cmo.No
 end

--- a/herd/JavaArch_herd.ml
+++ b/herd/JavaArch_herd.ml
@@ -46,4 +46,5 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
 
   module MemType=MemoryType.No
   module Barrier = AllBarrier.No(struct type a = barrier end)
+  module CMO = Cmo.No
 end

--- a/herd/MIPSArch_herd.ml
+++ b/herd/MIPSArch_herd.ml
@@ -32,6 +32,9 @@ module Make
     let is_atomic annot = annot
 
     let barrier_sets = ["SYNC",(function Sync -> true);]
+
+    let cmo_sets = []
+
     let annot_sets = ["X", is_atomic]
 
     include Explicit.No
@@ -92,4 +95,5 @@ module Make
 
     end
 
+    module CMO = Cmo.No
   end

--- a/herd/PPCArch_herd.ml
+++ b/herd/PPCArch_herd.ml
@@ -39,6 +39,8 @@ module Make (C:Arch_herd.Config) (V:Value.S)
        "EIEIO",is_barrier Eieio;
      ]
 
+    let cmo_sets = []
+
     let annot_sets = ["X",is_atomic]
 
     let is_isync = is_barrier Isync
@@ -118,4 +120,5 @@ module Make (C:Arch_herd.Config) (V:Value.S)
 
     end
 
+    module CMO = Cmo.No
   end

--- a/herd/RISCVArch_herd.ml
+++ b/herd/RISCVArch_herd.ml
@@ -78,6 +78,8 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
           (tag,pred)::k)
         []
 
+    let cmo_sets = []
+
     let annot_sets =
       ["X", is_atomic; "Acq", is_acquire; "Rel", is_release;
        "AcqRel",is_acquire_release;"Sc",is_sc]
@@ -143,4 +145,5 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     module Barrier = AllBarrier.No(struct type a = barrier end)
 
+    module CMO = Cmo.No
   end

--- a/herd/X86Arch_herd.ml
+++ b/herd/X86Arch_herd.ml
@@ -43,6 +43,8 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
        "LFENCE",is_barrier Lfence;
      ]
 
+    let cmo_sets = []
+
     let annot_sets = ["X",is_atomic]
 
     include Explicit.No
@@ -106,4 +108,5 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
 
     end
 
+    module CMO = Cmo.No
   end

--- a/herd/X86_64Arch_herd.ml
+++ b/herd/X86_64Arch_herd.ml
@@ -47,6 +47,8 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
         "LFENCE",is_barrier LFENCE;
       ]
 
+    let cmo_sets = []
+
     let annot_sets = ["X",is_atomic; "NT",is_nt;]
 
     include Explicit.No
@@ -172,4 +174,5 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
 
     end
 
+    module CMO = Cmo.No
   end

--- a/herd/arch_herd.mli
+++ b/herd/arch_herd.mli
@@ -57,4 +57,6 @@ module type S =
     module MemType:MemoryType.S
 
     module Barrier:AllBarrier.S with type a = barrier
+
+    module CMO:Cmo.S
   end

--- a/herd/cmo.ml
+++ b/herd/cmo.ml
@@ -2,9 +2,9 @@
 (*                           the diy toolsuite                              *)
 (*                                                                          *)
 (* Jade Alglave, University College London, UK.                             *)
-(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(* Luc Maranget, INRIA Paris, France.                                       *)
 (*                                                                          *)
-(* Copyright 2015-present Institut National de Recherche en Informatique et *)
+(* Copyright 2023-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -13,40 +13,13 @@
 (* license as circulated by CEA, CNRS and INRIA at the following URL        *)
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
-module Make (C:Arch_herd.Config) (V:Value.S) = struct
-  include CBase
-  (* Not so simple, should consider expressions... *)
-  let is_amo _ = assert false
 
-  let pp_barrier_short = pp_barrier
-  let reject_mixed = false
-  let mem_access_size _ = None
+module type S = sig
+  type t
+  val pp : t -> string option -> string
+end
 
-  include NoSemEnv
-
-  module V = V
-
-  include NoLevelNorTLBI
-
-  include ArchExtra_herd.Make(C)
-      (struct
-        module V = V
-        let endian = endian
-
-        type arch_reg = reg
-        let pp_reg = pp_reg
-        let reg_compare = reg_compare
-
-        let fromto_of_instr _ = None
-
-        let get_val _ v = v
-
-        module FaultType=FaultType.No
-      end)
-
-    module MemType=MemoryType.No
-
-    module Barrier = AllBarrier.No(struct type a = barrier end)
-
-    module CMO = Cmo.No
+module No = struct
+  type t = unit
+  let pp _ _ = assert false
 end

--- a/herd/cmo.mli
+++ b/herd/cmo.mli
@@ -2,9 +2,9 @@
 (*                           the diy toolsuite                              *)
 (*                                                                          *)
 (* Jade Alglave, University College London, UK.                             *)
-(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(* Luc Maranget, INRIA Paris, France.                                       *)
 (*                                                                          *)
-(* Copyright 2015-present Institut National de Recherche en Informatique et *)
+(* Copyright 2023-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -13,40 +13,10 @@
 (* license as circulated by CEA, CNRS and INRIA at the following URL        *)
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
-module Make (C:Arch_herd.Config) (V:Value.S) = struct
-  include CBase
-  (* Not so simple, should consider expressions... *)
-  let is_amo _ = assert false
 
-  let pp_barrier_short = pp_barrier
-  let reject_mixed = false
-  let mem_access_size _ = None
-
-  include NoSemEnv
-
-  module V = V
-
-  include NoLevelNorTLBI
-
-  include ArchExtra_herd.Make(C)
-      (struct
-        module V = V
-        let endian = endian
-
-        type arch_reg = reg
-        let pp_reg = pp_reg
-        let reg_compare = reg_compare
-
-        let fromto_of_instr _ = None
-
-        let get_val _ v = v
-
-        module FaultType=FaultType.No
-      end)
-
-    module MemType=MemoryType.No
-
-    module Barrier = AllBarrier.No(struct type a = barrier end)
-
-    module CMO = Cmo.No
+module type S = sig
+  type t
+  val pp : t -> string option -> string
 end
+
+module No : S with type t=unit


### PR DESCRIPTION
This patches creates an architecture independent CMO action and uses it to encapsulate the DC and IC events (for AArch64). In parallel, it cleans up the relevant eventsets for AArch64, and similarly to what herd does for barriers, every DC and IC instruction will raise an eponymous event (a dc.cvau,Xt will raise a DC.CVAU event, etc).