### PR TITLE
[lib] Add new record constants

### DIFF
--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -727,7 +727,7 @@ module Make(C:Config) (I:I) : S with module I = I
                 (pp_location loc)
           | Location_global
               (I.V.Val
-                 (Concrete _|ConcreteVector _
+                 (Concrete _|ConcreteVector _|ConcreteRecord _
                  |Label _|Instruction _|Frozen _
                  |Tag _|PteVal _))
             ->

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -102,7 +102,7 @@ end = struct
     | Symbolic (System (TAG,_)) -> Access.TAG
     | Label _ -> VIR
     | Tag _
-    | ConcreteVector _|Concrete _
+    | ConcreteVector _|Concrete _|ConcreteRecord _
     | PteVal _|Instruction _|Frozen _ as v
       ->
        Warn.fatal "access_of_constant %s as an address"
@@ -612,7 +612,7 @@ end = struct
           | Some (A.V.Val (PteVal v)) -> Some v
           | Some
               (A.V.Val
-                 (ConcreteVector _|Concrete _|Symbolic _
+                 (ConcreteVector _|Concrete _|Symbolic _|ConcreteRecord _
                   |Label (_, _)|Tag _|Instruction _
                   |Frozen _))
           | None

--- a/jingle/CArch_jingle.ml
+++ b/jingle/CArch_jingle.ml
@@ -154,7 +154,7 @@ include Arch.MakeArch(struct
     let rec expl_expr = let open Constant in function
       | Const(Symbolic (Virtual {name=s;_})) -> find_cst s >! fun k -> Const k
       | Const
-          (Concrete _|ConcreteVector _|Label _
+          (Concrete _|ConcreteVector _|Label _|ConcreteRecord _
            |Tag _|Symbolic _|PteVal _
            |Instruction _|Frozen _)
         as e -> unitT e

--- a/lib/CBase.ml
+++ b/lib/CBase.ml
@@ -253,7 +253,7 @@ include Pseudo.Make
         function
           | Const(Concrete _|ConcreteVector _) as k -> k
           | Const
-              (Symbolic _|Label _|Tag _
+              (Symbolic _|Label _|Tag _|ConcreteRecord _
               |PteVal _|Instruction _|Frozen _ as v) ->
              Warn.fatal "No constant '%s' allowed" (ParsedConstant.pp_v v)
           | LoadReg _ as l -> l

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -164,11 +164,12 @@ end
 module SymbolSet = MySet.Make(SC)
 module SymbolMap = MyMap.Make(SC)
 
-type ('scalar,'pte,'instr) t =
+type ('scalar, 'pte, 'instr) t =
   | Concrete of 'scalar
-  | ConcreteVector of ('scalar,'pte,'instr) t list
-  | Symbolic  of symbol
-  | Label of Proc.t * string     (* In code *)
+  | ConcreteVector of ('scalar, 'pte, 'instr) t list
+  | ConcreteRecord of ('scalar, 'pte, 'instr) t StringMap.t
+  | Symbolic of symbol
+  | Label of Proc.t * string
   | Tag of string
   | PteVal of 'pte
   | Instruction of 'instr
@@ -180,6 +181,9 @@ let rec compare scalar_compare pteval_compare instr_compare c1 c2 =
   | ConcreteVector v1, ConcreteVector v2 ->
      Misc.list_compare
        (compare scalar_compare pteval_compare instr_compare) v1 v2
+  | ConcreteRecord li1, ConcreteRecord li2 ->
+     StringMap.compare
+       (compare scalar_compare pteval_compare instr_compare) li1 li2
   | Symbolic sym1,Symbolic sym2 -> compare_symbol sym1 sym2
   | Label (p1,s1),Label (p2,s2) ->
       Misc.pair_compare Proc.compare String.compare (p1,s1) (p2,s2)
@@ -187,20 +191,22 @@ let rec compare scalar_compare pteval_compare instr_compare c1 c2 =
   | PteVal p1,PteVal p2 -> pteval_compare p1 p2
   | Instruction i1,Instruction i2 -> instr_compare i1 i2
   | Frozen i1,Frozen i2 -> Int.compare i1 i2
-  | (Concrete _,(ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _|Instruction _|Frozen _))
-  | (ConcreteVector _,(Symbolic _|Label _|Tag _|PteVal _|Instruction _|Frozen _))
+  | (Concrete _,(ConcreteRecord _|ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _|Instruction _|Frozen _))
+  | (ConcreteVector _,(ConcreteRecord _|Symbolic _|Label _|Tag _|PteVal _|Instruction _|Frozen _))
+  | (ConcreteRecord _,(Symbolic _|Label _|Tag _|PteVal _|Instruction _|Frozen _))
   | (Symbolic _,(Label _|Tag _|PteVal _|Instruction _|Frozen _))
   | (Label _,(Tag _|PteVal _|Instruction _|Frozen _))
   | (Tag _,(PteVal _|Instruction _|Frozen _))
   | (PteVal _,(Instruction _|Frozen _))
   | (Instruction _,Frozen _)
     -> -1
-  | (Frozen _,(Instruction _|PteVal _|Tag _|Label _|Symbolic _|ConcreteVector _|Concrete _))
-  | (Instruction _,(PteVal _|Tag _|Label _|Symbolic _|ConcreteVector _|Concrete _))
-  | (PteVal _,(Tag _|Label _|Symbolic _|ConcreteVector _|Concrete _))
-  | (Tag _,(Label _|Symbolic _|ConcreteVector _|Concrete _))
-  | (Label _,(Symbolic _|ConcreteVector _|Concrete _))
-  | (Symbolic _,(ConcreteVector _|Concrete _))
+  | (Frozen _,(Instruction _|PteVal _|Tag _|Label _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (Instruction _,(PteVal _|Tag _|Label _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (PteVal _,(Tag _|Label _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (Tag _,(Label _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (Label _,(Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (Symbolic _,(ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (ConcreteRecord _,(ConcreteVector _|Concrete _))
   | (ConcreteVector _,Concrete _)
     -> 1
 
@@ -208,6 +214,8 @@ let rec eq scalar_eq pteval_eq instr_eq c1 c2 = match c1,c2 with
   | Concrete i1, Concrete i2 -> scalar_eq i1 i2
   | ConcreteVector v1, ConcreteVector v2 ->
      Misc.list_eq (eq scalar_eq pteval_eq instr_eq) v1 v2
+  | ConcreteRecord li1, ConcreteRecord li2 ->
+    StringMap.equal (eq scalar_eq pteval_eq instr_eq) li1 li2
   | Symbolic s1, Symbolic s2 -> symbol_eq s1 s2
   | Label (p1,s1),Label (p2,s2) ->
       Misc.string_eq  s1 s2 && Misc.int_eq p1 p2
@@ -215,29 +223,41 @@ let rec eq scalar_eq pteval_eq instr_eq c1 c2 = match c1,c2 with
   | PteVal p1,PteVal p2 -> pteval_eq p1 p2
   | Instruction i1,Instruction i2 -> instr_eq i1 i2
   | Frozen i1,Frozen i2 -> Misc.int_eq i1 i2
-  | (Frozen _,(Instruction _|Symbolic _|Concrete _|ConcreteVector _|Label _|Tag _|PteVal _))
-  | (Instruction _,(Symbolic _|Concrete _|ConcreteVector _|Label _|Tag _|PteVal _|Frozen _))
-  | (PteVal _,(Symbolic _|Concrete _|ConcreteVector _|Label _|Tag _|Instruction _|Frozen _))
-  | (ConcreteVector _,(Symbolic _|Label _|Tag _|Concrete _|PteVal _|Instruction _|Frozen _))
-  | (Concrete _,(Symbolic _|Label _|Tag _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
-  | (Symbolic _,(Concrete _|Label _|Tag _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
-  | (Label _,(Concrete _|Symbolic _|Tag _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
-  | (Tag _,(Concrete _|Symbolic _|Label _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
+  | (Frozen _,(Instruction _|Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Label _|Tag _|PteVal _))
+  | (Instruction _,(Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Label _|Tag _|PteVal _|Frozen _))
+  | (PteVal _,(Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Label _|Tag _|Instruction _|Frozen _))
+  | (ConcreteRecord _,(ConcreteVector _|Symbolic _|Label _|Tag _|Concrete _|PteVal _|Instruction _|Frozen _))
+  | (ConcreteVector _,(ConcreteRecord _|Symbolic _|Label _|Tag _|Concrete _|PteVal _|Instruction _|Frozen _))
+  | (Concrete _,(Symbolic _|Label _|Tag _|ConcreteRecord _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
+  | (Symbolic _,(Concrete _|Label _|Tag _|ConcreteRecord _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
+  | (Label _,(Concrete _|Symbolic _|Tag _|ConcreteRecord _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
+  | (Tag _,(Concrete _|Symbolic _|Label _|ConcreteRecord _|ConcreteVector _|PteVal _|Instruction _|Frozen _))
     -> false
 
 let rec mk_pp pp_symbol pp_scalar pp_pteval pp_instr = function
-    | Concrete i -> pp_scalar i
-    | ConcreteVector vs ->
-        let s =
-          String.concat ","
-            (List.map (mk_pp pp_symbol pp_scalar pp_pteval pp_instr) vs)
-        in sprintf "{%s}" s
-    | Symbolic sym -> pp_symbol sym
-    | Label (p,lbl)  -> sprintf "%i:%s" p lbl
-    | Tag s -> sprintf ":%s" s
-    | PteVal p -> pp_pteval p
-    | Instruction i -> pp_instr i
-    | Frozen i -> sprintf "S%i" i (* Same as for symbolic values? *)
+  | Concrete i -> pp_scalar i
+  | ConcreteVector vs ->
+      let s =
+        String.concat ","
+          (List.map (mk_pp pp_symbol pp_scalar pp_pteval pp_instr) vs)
+      in
+      sprintf "{%s}" s
+  | ConcreteRecord vs ->
+      let b = Buffer.create 10 in
+      Buffer.add_char b '{';
+      StringMap.iter
+        (fun name c ->
+          Printf.bprintf b "%s:%s," name
+            (mk_pp pp_symbol pp_scalar pp_pteval pp_instr c))
+        vs;
+      Buffer.add_char b '}';
+      Buffer.contents b
+  | Symbolic sym -> pp_symbol sym
+  | Label (p, lbl) -> sprintf "%i:%s" p lbl
+  | Tag s -> sprintf ":%s" s
+  | PteVal p -> pp_pteval p
+  | Instruction i -> pp_instr i
+  | Frozen i -> sprintf "S%i" i (* Same as for symbolic values? *)
 
 let pp pp_scalar pp_pteval pp_instr =
   mk_pp pp_symbol pp_scalar pp_pteval pp_instr
@@ -245,32 +265,41 @@ and pp_old pp_scalar pp_pteval pp_instr =
   mk_pp pp_symbol_old  pp_scalar pp_pteval pp_instr
 
 let _debug = function
-| Concrete _ -> "Concrete _"
-| ConcreteVector vs -> sprintf "ConcreteVector (%d,_)" (List.length vs)
-| Symbolic sym -> sprintf "Symbol %s" (pp_symbol sym)
-| Label (p,s) -> sprintf "Label (%s,%s)" (Proc.pp p) s
-| Tag s -> sprintf "Tag %s" s
-| PteVal _ -> "PteVal"
-| Instruction i -> sprintf "Instruction %s" (InstrLit.pp i)
-| Frozen i -> sprintf "Frozen %i" i
+  | Concrete _ -> "Concrete _"
+  | ConcreteVector vs -> sprintf "ConcreteVector (%d,_)" (List.length vs)
+  | ConcreteRecord vs ->
+      "ConcreteRecord (" ^ (StringMap.pp_str (fun key _v -> key) vs) ^ ")"
+  | Symbolic sym -> sprintf "Symbol %s" (pp_symbol sym)
+  | Label (p, s) -> sprintf "Label (%s,%s)" (Proc.pp p) s
+  | Tag s -> sprintf "Tag %s" s
+  | PteVal _ -> "PteVal"
+  | Instruction i -> sprintf "Instruction %s" (InstrLit.pp i)
+  | Frozen i -> sprintf "Frozen %i" i
 
 let rec map_scalar f = function
-| (Symbolic _|Label _ |Tag _|PteVal _|Instruction _|Frozen _) as c -> c
-| Concrete s -> Concrete (f s)
-| ConcreteVector cs -> ConcreteVector (List.map (map_scalar f) cs)
+  | Concrete s -> Concrete (f s)
+  | ConcreteVector cs -> ConcreteVector (List.map (map_scalar f) cs)
+  | ConcreteRecord cs -> ConcreteRecord (StringMap.map (map_scalar f) cs)
+  | (Symbolic _ | Label _ | Tag _ | PteVal _ | Instruction _ | Frozen _) as c ->
+      c
 
 let rec map_label f = function
-  | Label (p,lbl) -> Label (p,f lbl)
+  | Label (p, lbl) -> Label (p, f lbl)
   | ConcreteVector cs -> ConcreteVector (List.map (map_label f) cs)
-  | Symbolic _|Concrete _ |Tag _|PteVal _|Instruction _|Frozen _ as m -> m
+  | ConcreteRecord cs -> ConcreteRecord (StringMap.map (map_label f) cs)
+  | (Symbolic _ | Concrete _ | Tag _ | PteVal _ | Instruction _ | Frozen _) as m
+    ->
+      m
 
 let rec map f_scalar f_pteval f_instr = function
-| Symbolic _ | Label _ | Tag _ | Frozen _ as m -> m
-| PteVal p -> PteVal (f_pteval p)
-| Instruction i -> Instruction (f_instr i)
-| Concrete s -> Concrete (f_scalar s)
-| ConcreteVector cs ->
-   ConcreteVector (List.map (map f_scalar f_pteval f_instr) cs)
+  | (Symbolic _ | Label _ | Tag _ | Frozen _) as m -> m
+  | PteVal p -> PteVal (f_pteval p)
+  | Instruction i -> Instruction (f_instr i)
+  | Concrete s -> Concrete (f_scalar s)
+  | ConcreteVector cs ->
+      ConcreteVector (List.map (map f_scalar f_pteval f_instr) cs)
+  | ConcreteRecord cs ->
+      ConcreteRecord (StringMap.map (map f_scalar f_pteval f_instr) cs)
 
 let do_mk_virtual s = Virtual { default_symbolic_data with name=s; }
 
@@ -330,15 +359,21 @@ let mk_replicate sz v = ConcreteVector (Misc.replicate sz v)
 
 let is_symbol = function
   | Symbolic _ -> true
-  | Concrete _|ConcreteVector _|Label _|Tag _| PteVal _|Instruction _|Frozen _ -> false
+  | Concrete _ | ConcreteVector _ | ConcreteRecord _ | Label _ | Tag _
+  | PteVal _ | Instruction _ | Frozen _ ->
+      false
 
 let is_label = function
   | Label _ -> true
-  | Concrete _|ConcreteVector _|Symbolic _|Tag _ |PteVal _|Instruction _|Frozen _ -> false
+  | Concrete _ | ConcreteVector _ | ConcreteRecord _ | Symbolic _ | Tag _
+  | PteVal _ | Instruction _ | Frozen _ ->
+      false
+
 let as_label = function
-  | Label (p,lbl) -> Some (p,lbl)
-  | Concrete _|ConcreteVector _|Symbolic _|Tag _ |PteVal _|Instruction _|Frozen _
-    -> None
+  | Label (p, lbl) -> Some (p, lbl)
+  | Concrete _ | ConcreteVector _ | ConcreteRecord _ | Symbolic _ | Tag _
+  | PteVal _ | Instruction _ | Frozen _ ->
+      None
 
 let is_non_mixed_symbol = function
   | Virtual {offset=idx;_}
@@ -347,9 +382,12 @@ let is_non_mixed_symbol = function
 
 let default_tag = Tag "green"
 
-let check_sym v =  match v with
-| Symbolic _|Label _|Tag _ as sym -> sym
-| Concrete _|ConcreteVector _|PteVal _|Instruction _|Frozen _ ->  assert false
+let check_sym v =
+  match v with
+  | (Symbolic _ | Label _ | Tag _) as sym -> sym
+  | Concrete _ | ConcreteVector _ | ConcreteRecord _ | PteVal _ | Instruction _
+  | Frozen _ ->
+      assert false
 
 let is_virtual v = match v with
 | Symbolic (Virtual _) -> true

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -64,16 +64,20 @@ val virt_match_phy : symbol (* virt *) -> symbol (* phy *)-> bool
 module SymbolSet : MySet.S with type elt = symbol
 module SymbolMap : MyMap.S with type key = symbol
 
-(* Add scalars *)
-type ('scalar,'pte,'instr) t =
-  | Concrete of 'scalar
-  | ConcreteVector of ('scalar,'pte,'instr) t list
-  | Symbolic  of symbol
-  | Label of Proc.t * string     (* In code *)
+(** [(s, p, i) t] is the type of constants with [s] the type of scalars, [p]
+    the type of page table entries, and [i] the type of instructions. *)
+type ('scalar, 'pte, 'instr) t =
+  | Concrete of 'scalar  (** A scalar, e.g. 3. *)
+  | ConcreteVector of ('scalar, 'pte, 'instr) t list
+      (** A vector of constants, e.g. [[3, x, NOP]]. *)
+  | ConcreteRecord of ('scalar, 'pte, 'instr) t StringMap.t
+      (** A record of constants, e.g. [{ addr: x; instr: NOP; index: 3 }] *)
+  | Symbolic of symbol  (** A symbolic constant, e.g. [x] *)
+  | Label of Proc.t * string  (** A label in code. *)
   | Tag of string
-  | PteVal of 'pte
-  | Instruction of 'instr
-  | Frozen of int (* Frozen symbolic value *)
+  | PteVal of 'pte  (** A page table entry. *)
+  | Instruction of 'instr  (** An instruction. *)
+  | Frozen of int (** Frozen symbolic value. *)
 
 val compare :
   ('scalar -> 'scalar -> int) ->

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -635,16 +635,9 @@ module Simple = struct
 
   type 'a bds = (string * 'a) list
 
-  let assoc (k:string) =
-    let rec find_rec = function
-      | [] -> raise Not_found
-      | (k0,v)::env ->
-          if k0 = k then v else find_rec env in
-    find_rec
-
-  let assoc_opt k env = try Some (assoc k env) with Not_found -> None
-
-  let mem (y:string) xs = List.exists (fun x -> x=y) xs
+  let assoc = List.assoc
+  let assoc_opt = List.assoc_opt
+  let mem = List.mem
 
   let mem_assoc (k:string) env =
     try ignore (assoc k env) ; true

--- a/lib/myMap.ml
+++ b/lib/myMap.ml
@@ -40,9 +40,10 @@ module type S = sig
   val filter : (key -> bool) -> 'a t -> 'a t
 
 (* List bindings *)
-  val bindings : 'a t -> (key * 'a) list
   val add_bindings : (key * 'a) list -> 'a t -> 'a t
   val from_bindings :  (key * 'a) list -> 'a t
+
+  val fold_values : ('a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
 end
 
 module Make(O:Set.OrderedType) : S with type key = O.t =
@@ -84,9 +85,12 @@ module Make(O:Set.OrderedType) : S with type key = O.t =
         (fun k v r -> if p k then add k v r else r)
         m empty
 
-    let bindings m = fold (fun k v xs -> (k,v)::xs) m []
     let add_bindings bds m =
       List.fold_left (fun m (k,v) -> add k v m) m bds
+
     let from_bindings bds = add_bindings bds empty
 
+    let fold_values fold_value =
+      let fold_binding _key v acc = fold_value v acc in
+      fun t acc -> fold fold_binding t acc
   end

--- a/lib/symbConstant.ml
+++ b/lib/symbConstant.ml
@@ -55,13 +55,13 @@ module Make
 (* For building code symbols. *)
   let vToName = function
     | Symbolic s-> Constant.as_address s
-    | Concrete _|ConcreteVector _ | Label _|Tag _
+    | Concrete _|ConcreteVector _|ConcreteRecord _| Label _|Tag _
     | PteVal _|Instruction _|Frozen _
         -> assert false
 
   let is_nop = function
     | Instruction i -> Instr.is_nop i
-    | Symbolic _|Concrete _|ConcreteVector _ | Label _|Tag _|PteVal _
+    | Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _ | Label _|Tag _|PteVal _
     | Frozen _
       -> false
 end

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -126,7 +126,7 @@ module
   let bit_at k = function
     | Val (Concrete v) -> Val (Concrete (Cst.Scalar.bit_at k v))
     | Val
-        (ConcreteVector _|Symbolic _|Label _|
+        (ConcreteVector _|ConcreteRecord _|Symbolic _|Label _|
          Tag _|PteVal _|Instruction _|Frozen _ as x)
       ->
         Warn.user_error "Illegal operation on %s" (Cst.pp_v x)
@@ -138,7 +138,7 @@ module
   match v1 with
     | Val (Concrete i1) ->
         Val (Concrete (op i1))
-    | Val (ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _|Frozen _ as x) ->
+    | Val (ConcreteVector _|ConcreteRecord _|Symbolic _|Label _|Tag _|PteVal _|Frozen _ as x) ->
         Warn.user_error "Illegal operation %s on %s"
           (pp_unop op_op) (Cst.pp_v x)
     | Val (Instruction _ as x) ->
@@ -298,7 +298,7 @@ module
   | Val (Symbolic (Virtual ({offset=i;_} as s))) ->
     Val (Symbolic (Virtual {s with offset=i+k}))
   | Val (Symbolic (Physical (s,i))) -> Val (Symbolic (Physical (s,i+k)))
-  | Val (ConcreteVector _|Symbolic (System _)|Label _|Tag _|PteVal _|Instruction _|Frozen _ as c) ->
+  | Val (ConcreteVector _|ConcreteRecord _|Symbolic (System _)|Label _|Tag _|PteVal _|Instruction _|Frozen _ as c) ->
       Warn.user_error "Illegal addition on constants %s +%d" (Cst.pp_v c) k
   | Var _ -> raise Undetermined
 
@@ -450,7 +450,7 @@ module
   |  Val (Symbolic (Virtual ({offset=o;_} as a))) -> Val (op a o)
   |  Val (Symbolic (Physical _|System _)
           |Concrete _|Label _
-          |Tag _|ConcreteVector _
+          |Tag _|ConcreteRecord _|ConcreteVector _
           |PteVal _|Instruction _
           |Frozen _)
      -> Warn.user_error "Illegal tagged operation %s on %s" op_op (pp_v v)
@@ -465,7 +465,7 @@ module
   | Val (Symbolic (Virtual {name=a;_}|Physical (a,_))) ->
        Val (Symbolic (System (TAG,a)))
   | Val
-        (Concrete _|ConcreteVector _
+        (Concrete _|ConcreteRecord _|ConcreteVector _
         |Symbolic (System _)|Label _
         |Tag _|PteVal _
         |Instruction _|Frozen _)
@@ -478,7 +478,7 @@ module
     | Val (Symbolic (Physical _|System _)) -> false
     | Var _
     | Val
-        (Concrete _|ConcreteVector _
+        (Concrete _|ConcreteRecord _|ConcreteVector _
         |Label _|Tag _
         |PteVal _|Instruction _
         |Frozen _)
@@ -499,7 +499,7 @@ module
   let op_pte_tlb op_op op v = match v with
   |  Val (Symbolic (Virtual s)) -> Val (op s)
   |  Val
-       (Concrete _|ConcreteVector _
+       (Concrete _|ConcreteRecord _|ConcreteVector _
        |Label _|Tag _
        |Symbolic _|PteVal _
        |Instruction _|Frozen _)
@@ -511,7 +511,7 @@ module
   | Val (Symbolic (Virtual {name=a;_})) -> Val (Symbolic (System (PTE,a)))
   | Val (Symbolic (System (PTE,a))) -> Val (Symbolic (System (PTE2,a)))
   | Val
-      (Concrete _|ConcreteVector _
+      (Concrete _|ConcreteRecord _|ConcreteVector _
       |Label _|Tag _
       |Symbolic _|PteVal _
       |Instruction _|Frozen _)
@@ -523,7 +523,7 @@ module
   | Val (Symbolic (Virtual {offset=o;_}|Physical (_,o))) -> intToV o
   | Val (Symbolic (System ((PTE|PTE2|TLB|TAG),_))) -> zero
   | Val
-      (Concrete _|ConcreteVector _
+      (Concrete _|ConcreteRecord _|ConcreteVector _
       |Label _|Tag _
       |PteVal _|Instruction _
       |Frozen _) ->
@@ -896,7 +896,7 @@ module
   let op3 If v1 v2 v3 = match v1 with
   | Val (Concrete x) -> if scalar_to_bool x then v2 else v3
   | Val
-      (ConcreteVector _|Symbolic _
+      (ConcreteVector _|ConcreteRecord _|Symbolic _
       |Label _|Tag _
       |PteVal _|Instruction _
       | Frozen _ as s) ->

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -508,7 +508,7 @@ module RegMap = A.RegMap)
         | PteVal p ->
             let idx = find_pteval_index p ptevalEnv in
             add_pteval idx
-        | Tag _|Frozen _ -> assert false
+        | Tag _|Frozen _ | ConcreteRecord _ -> assert false
 
       let compile_init_val_fun = compile_val_fun
 

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -37,7 +37,7 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
     function
       | Concrete i -> "addr_" ^ V.Scalar.pp O.hexa i
       | Symbolic (Virtual {name=s; tag=None; cap=0L;_ })-> s
-      | Label _|Symbolic _|Tag _|ConcreteVector _
+      | Label _|Symbolic _|Tag _|ConcreteVector _|ConcreteRecord _
       | PteVal _|Instruction _|Frozen _
         -> assert false
 

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -334,6 +334,8 @@ module Make
           let pp_vs = List.map dump_a_v vs in
           sprintf "{%s}" (String.concat "," pp_vs) (* list initializer syntax *)
       | Symbolic (Virtual {name=s;tag=None;cap=0L;offset=0;_})-> dump_a_addr s
+      | ConcreteRecord _ ->
+          Warn.user_error "No record value for klitmus"
       | Label _ ->
           Warn.user_error "No label value for klitmus"
       | Symbolic _|Tag _| PteVal _ ->

--- a/litmus/LISALang.ml
+++ b/litmus/LISALang.ml
@@ -94,6 +94,7 @@ module Make(V:Constant.S) = struct
     | Tag _ -> Warn.user_error "No tag in LISA"
     | PteVal _ -> Warn.user_error "No pteval in LISA"
     | Instruction _ -> Warn.user_error "No instruction value in LISA"
+    | ConcreteRecord _ -> Warn.user_error "No record values in LISA"
     | Frozen _ -> assert false
 
   and compile_addr_fun x = sprintf "*%s" x

--- a/litmus/archExtra_litmus.ml
+++ b/litmus/archExtra_litmus.ml
@@ -119,7 +119,7 @@ module Make(O:Config)(I:I) : S with module I = I
     let open Constant in
     match c with
     | Symbolic sym -> Global_litmus.tr_symbol sym
-    | Tag _|Concrete _|ConcreteVector _
+    | Tag _|Concrete _|ConcreteVector _|ConcreteRecord _
     | Label _|PteVal _|Instruction _
     | Frozen _
       ->

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -65,7 +65,7 @@ module Generic
         | Constant.Tag _ -> tag
         | Constant.PteVal _ -> pteval_t
         | Constant.Instruction _ -> ins_t
-        | Constant.Frozen _ -> assert false
+        | Constant.Frozen _ | Constant.ConcreteRecord _ -> assert false
 
       let misc_to_c loc = function
         | TestType.TyDef when A.is_pte_loc loc -> pteval_t
@@ -378,7 +378,7 @@ module A.FaultType = A.FaultType)
           match v with
           | Constant.Label (_,lbl) ->
               Label.Set.add lbl k
-          |Concrete _|ConcreteVector _
+          |Concrete _|ConcreteVector _|ConcreteRecord _
           |Symbolic _|Tag _|PteVal _
           |Instruction _|Frozen _
            -> k)

--- a/litmus/constr.ml
+++ b/litmus/constr.ml
@@ -107,6 +107,8 @@ module RLocSet = A.RLocSet and module FaultType = A.FaultType =
             | Concrete _|PteVal _|Instruction _ -> k
             | ConcreteVector vs ->
                 List.fold_right f vs k
+            | ConcreteRecord vs ->
+                StringMap.fold_values f vs k
             | Label _|Symbolic _|Tag _|Frozen _
               -> assert false in
             f v k

--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -60,6 +60,7 @@ module Make(O:Config)(V:Constant.S) = struct
   | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=0;}) -> dump_addr a
   | ConcreteVector _ -> V.pp O.hexa v
   | Instruction _ -> Misc.lowercase (V.pp false v)
+  | ConcreteRecord _
   | Tag _
   | Symbolic _
   | Label _

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1472,6 +1472,8 @@ module Make
               | Concrete i -> A.V.Scalar.pp Cfg.hexa i
               | ConcreteVector _ ->
                   Warn.fatal "Vector used as scalar"
+              | ConcreteRecord _ ->
+                  Warn.fatal "Record used as scalar"
               | Symbolic (Virtual {name=s; tag=None; offset=0; _}) ->
                   sprintf "(%s)_vars->%s" (CType.dump at) s
               | Label _ ->

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -368,7 +368,7 @@ module Make
                (fun v -> sprintf "%s," (dump_a_v v))
                vs in
            sprintf "{%s}" (String.concat "" pps)
-        | Symbolic _|Tag _|PteVal _|Frozen _ -> assert false
+        | Symbolic _|Tag _|PteVal _|Frozen _|ConcreteRecord _ -> assert false
         | Label _ ->
             Warn.user_error
               "Labels cannot be used as initial values of memory locations"

--- a/litmus/switch.ml
+++ b/litmus/switch.ml
@@ -137,7 +137,7 @@ module Make (O:Indent.S) (I:CompCondUtils.I) :
     | Concrete i ->
         let vs = try M.find loc m with Not_found -> ScalarSet.empty in
         M.add loc (ScalarSet.add i vs) m
-    |ConcreteVector _|Symbolic _|Label _|Tag _
+    |ConcreteVector _|Symbolic _|Label _|Tag _|ConcreteRecord _
     |PteVal _|Instruction _|Frozen _
      -> raise Cannot
 

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -204,6 +204,8 @@ module Make(O:Config)(A:I) =
                       end
                   | ConcreteVector vs ->
                       List.fold_right f vs k
+                  | ConcreteRecord vs ->
+                    StringMap.fold_values f vs k
                   |Concrete _|Label _|Tag _
                   |PteVal _|Instruction _|Frozen _
                    -> k in

--- a/tools/alpha.ml
+++ b/tools/alpha.ml
@@ -196,6 +196,8 @@ struct
     | Concrete _ -> k
     | ConcreteVector vs ->
        List.fold_left (fun k v -> collect_value f v k) k vs
+    | ConcreteRecord vs ->
+      StringMap.fold_values (collect_value f) vs k
     | Label _ -> nolabel_value ()
     | Tag _ -> notag_value ()
     | PteVal _ -> nopte_value ()
@@ -212,6 +214,8 @@ struct
     | Concrete _ -> v
     | ConcreteVector vs ->
        ConcreteVector (List.map (map_value f) vs)
+    | ConcreteRecord vs ->
+       ConcreteRecord (StringMap.map (map_value f) vs)
     | Label _ -> nolabel_value ()
     | Tag _ -> notag_value ()
     | PteVal _ -> nopte_value ()

--- a/tools/logConstr.ml
+++ b/tools/logConstr.ml
@@ -31,6 +31,7 @@ let rec tr_v v =
   match v with
   | Concrete i -> Concrete (Int64.of_string i)
   | ConcreteVector vs -> ConcreteVector (List.map tr_v vs)
+  | ConcreteRecord vs -> ConcreteRecord (StringMap.map tr_v vs)
   | Symbolic _|Label _|Tag _
   | PteVal _|Instruction _|Frozen _
     as w -> w


### PR DESCRIPTION
This PR adds a new type of constants: records!

Those records are just a variation over vectors: instead of being a list of other constants, they map labels (`string`s) to other constants.

They will be used to implement records and exceptions in ASL.