### PR TITLE
[herd] Fix C parser

### DIFF
--- a/lib/CParser.mly
+++ b/lib/CParser.mly
@@ -168,6 +168,7 @@ annot:
 annot_base :
 | LOCK       { "lock" }
 | UNLOCK     { "unlock" }
+| ATOMIC_BASE { "atomic" }
 | NAME { $1 }
 
 


### PR DESCRIPTION
As `atomic` is now a keyword and is also part of annotations (arguments of internal linux model primitives), change annotation parsing accordingly, Fixes regression introduced by PR #522.