### PR TITLE
[herd] Add -dumpallfaults argument

### DIFF
--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -910,9 +910,14 @@ module Make(C:Config) (I:I) : S with module I = I
                     | Some lbl -> Label.Set.singleton lbl in
                   (" ~" ^ pp_fault (((p,tr_lbl),loc,ftype,None)) ^ ";")::k)
               fobs [] in
-          let flts = FaultSet.filter
-                       (fun f -> FaultAtomSet.exists (fun f0 -> check_one_fatom f f0) fobs)
-                       flts in
+          let flts =
+            if !Opts.dumpallfaults then
+              flts
+            else
+              FaultSet.filter
+                (fun f -> FaultAtomSet.exists
+                    (fun f0 -> check_one_fatom f f0) fobs)
+                flts in
           pp_st ^ " " ^
           FaultSet.pp_str " "  (fun f -> pp_fault f ^ ";")  flts ^
           String.concat "" noflts

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -285,6 +285,9 @@ let options = [
   "-statelessrc11",
   Arg.Bool (fun b -> if b then statelessrc11 := true),
   "<bool> enable stateless RC11 model checking, use with -variant normw, SC check can be skipped";
+  "-dumpallfaults",
+  Arg.Bool (fun b -> dumpallfaults := b),
+  "Dump final states with all faults that that happenned regardless of the post-condition";
 
 (************************)
 (* Control dot pictures *)
@@ -521,6 +524,7 @@ let () =
     let throughflag = !throughflag
     let maxphantom = !maxphantom
     let statelessrc11 = !statelessrc11
+    let dumpallfaults = !dumpallfaults
 
     let check_name = Check.ok
     let check_rename = Check.rename_opt

--- a/herd/lexConf_herd.mll
+++ b/herd/lexConf_herd.mll
@@ -166,6 +166,9 @@ let handle_key main key arg = match key with
      lex_bool badexecs arg
 | "badflag" ->
      lex_string_opt badflag arg
+| "dumpallfaults" ->
+   lex_bool dumpallfaults arg
+
 (* Control output *)
 | "show" ->
     lex_tag "show"

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -1463,7 +1463,7 @@ let match_reg_events es =
           | _,_ -> k)
           rfm test.Test_herd.init_state in
       st,
-      if A.FaultAtomSet.is_empty test.Test_herd.ffaults then
+      if A.FaultAtomSet.is_empty test.Test_herd.ffaults && not !Opts.dumpallfaults then
         A.FaultSet.empty
       else
         E.EventSet.fold

--- a/herd/opts.ml
+++ b/herd/opts.ml
@@ -77,6 +77,7 @@ let dumplem = ref false
 let dumptex = ref false
 let maxphantom= ref None
 let statelessrc11 = ref false
+let dumpallfaults = ref false
 
 (* Pretty printing configuration, deserves its own module *)
 module PP = struct

--- a/herd/opts.mli
+++ b/herd/opts.mli
@@ -69,6 +69,7 @@ val dumplem : bool ref
 val dumptex : bool ref
 val maxphantom : int option ref
 val statelessrc11 : bool ref
+val dumpallfaults : bool ref
 
 (* Pretty printing configuration, deserves its own module *)
 module PP : sig

--- a/herd/runTest.ml
+++ b/herd/runTest.ml
@@ -30,6 +30,7 @@ module type Config = sig
   include Sem.Config
 
   val statelessrc11 : bool
+  val dumpallfaults : bool
   val byte : MachSize.Tag.t
 end
 

--- a/herd/runTest.mli
+++ b/herd/runTest.mli
@@ -32,6 +32,7 @@ module type Config = sig
   include Sem.Config
 
   val statelessrc11 : bool
+  val dumpallfaults : bool
   val byte : MachSize.Tag.t
 end
 

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -34,6 +34,7 @@ module type CommonConfig = sig
   include Mem.CommonConfig
   val statelessrc11 : bool
   val skipchecks : StringSet.t
+  val dumpallfaults : bool
 end
 
 module type Config = sig
@@ -356,7 +357,9 @@ module Make(O:Config)(M:XXXMem.S) =
       let cstr = T.find_our_constraint test in
 
       let restrict_faults =
-        if A.FaultAtomSet.is_empty test.Test_herd.ffaults then
+        if !Opts.dumpallfaults then
+          Fun.id
+        else if A.FaultAtomSet.is_empty test.Test_herd.ffaults then
           fun _ -> A.FaultSet.empty
         else
           A.FaultSet.filter


### PR DESCRIPTION
This change adds a new argument that changes herd7 behaviour to reports all faults that have occured in an execution. This is regardless of the post-condition of the test and whether it includes the relevant fault atom. For example, for the test:

```
AArch64 LDRaf0-noHA
{
 [PTE(x)]=(af:0);
 [x]=1;
 0:X1=x;
}
 P0          ;
 LDR W2,[X1] ;
exists(0:X2=1)
```
```
$> herd7 -variant vmsa,fatal LDRaf0-noHA.litmus
Test LDRaf0-noHA Allowed
States 1
0:X2=0;
No
Witnesses
Positive: 0 Negative: 1
Condition exists (0:X2=1)
Observation LDRaf0-noHA Never 0 1
Time LDRaf0-noHA 0.01
Hash=4699e00b11f34b7adf65ba97458fdb7f
```
Whereas with the new argument:
```
$> herd7 -variant vmsa,fatal -dumpallfaults true LDRaf0-noHA.litmus est LDRaf0-noHA Allowed
States 1
0:X2=0; Fault(P0,x,MMU:AccessFlag);
No
Witnesses
Positive: 0 Negative: 1
Condition exists (0:X2=1)
Observation LDRaf0-noHA Never 0 1
Time LDRaf0-noHA 0.01
Hash=4699e00b11f34b7adf65ba97458fdb7f
```