### PR TITLE
[all] Accept "TTD" as a synomym for "PTE"

### DIFF
--- a/lib/stateLexer.mll
+++ b/lib/stateLexer.mll
@@ -74,7 +74,7 @@ rule token = parse
 | "attrs"|"Attrs" { ATTRS }
 | "oa" { TOK_OA }
 (* PTW keywords *)
-| "PTE" { TOK_PTE }
+| "PTE"|"TTD" { TOK_PTE }
 | "PA"  { TOK_PA }
 (* Typing *)
 | "_Atomic" { ATOMIC }

--- a/tools/lexLog_tools.mll
+++ b/tools/lexLog_tools.mll
@@ -124,7 +124,7 @@ let fault = (['f''F'] "ault")
 let reg = name
 let loc = name | ('$' (alpha+|digit+))
 let new_loc =
-(("PTE"|"PA") ' '* '(' ' '* (name| "PTE" ' '* '(' ' '* name ' '* ')') ' '* ')')
+(("PTE"|"TTD"|"PA") ' '* '(' ' '* (name| ("PTE"|"TTD") ' '* '(' ' '* name ' '* ')') ' '* ')')
 | ("tag" ' '* '(' ' '* (name ' '* ')'))
 let name_off = name ['-''+'] (num|hexanum)
 let instr = "instr:" '"' [^'"']* '"'


### PR DESCRIPTION
A quick lex-level hack to enable running tools on some recent tests.