### PR TITLE
[asl] Memory accesses of various width

### DIFF
--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -445,6 +445,7 @@ module Make (C : Config) = struct
       let lit x = E_Literal (L_Int (Z.of_int x)) |> with_pos in
       let bv x = T_Bits (BitWidth_SingleExpr x, []) |> with_pos in
       let bv_var x = bv @@ var x in
+      let bv_arg1 = bv_var "arg_1" in
       let bv_N = bv_var "N" in
       let bv_lit x = bv @@ lit x in
       let bv_64 = bv_lit 64 in
@@ -456,10 +457,11 @@ module Make (C : Config) = struct
         arity_two "write_register" [ bv_64; reg ] return_zero
           (write_register ii_env)
         |> __POS_OF__ |> here;
-        arity_two "read_memory" [ bv_64; integer ] (return_one bv_64)
+        arity_two "read_memory" [ bv_64 ; integer ]
+          (return_one (bv_arg1))
           (read_memory ii_env)
         |> __POS_OF__ |> here;
-        build_primitive "write_memory" [ bv_64; integer; bv_64 ] return_zero
+        build_primitive "write_memory" [ bv_64; integer; bv_arg1 ] return_zero
           (write_memory ii_env)
         |> __POS_OF__ |> here;
         arity_zero "PSTATE"

--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -202,7 +202,6 @@ begin
     merrorstate = ErrorState_CE,  // ??
     store64bstatus = Zeros(64)
   };
-  assert size == 8;
   return (ret_status, (value as bits((8*size))));
 end
 

--- a/herd/tests/instructions/AArch64.ASL/CSEL01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/CSEL01.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: No ASL implemention for instruction CMP X8,X9

--- a/herd/tests/instructions/AArch64.ASL/CSEL02.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/CSEL02.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: No ASL implemention for instruction CMP X8,X9

--- a/herd/tests/instructions/AArch64.ASL/LDR02.litmus
+++ b/herd/tests/instructions/AArch64.ASL/LDR02.litmus
@@ -1,0 +1,8 @@
+AArch64 LDR02
+{
+int x = 1 ;
+0:X1=x;
+}
+  P0         ;
+ LDR W0,[X1] ;
+forall 0:X0=1

--- a/herd/tests/instructions/AArch64.ASL/LDR02.litmus.expected
+++ b/herd/tests/instructions/AArch64.ASL/LDR02.litmus.expected
@@ -1,0 +1,10 @@
+Test LDR02 Required
+States 1
+0:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=1)
+Observation LDR02 Always 1 0
+Hash=64feb72405036040a5ab3924aca0feb9
+

--- a/herd/tests/instructions/AArch64.ASL/STR02.litmus
+++ b/herd/tests/instructions/AArch64.ASL/STR02.litmus
@@ -1,0 +1,10 @@
+AArch64 STR02
+{
+int x = 0 ;
+0:X1=x;
+}
+
+  P0         ;
+ MOV W0,#1   ;
+ STR W0,[X1] ;
+forall [x]=1

--- a/herd/tests/instructions/AArch64.ASL/STR02.litmus.expected
+++ b/herd/tests/instructions/AArch64.ASL/STR02.litmus.expected
@@ -1,0 +1,10 @@
+Test STR02 Required
+States 1
+[x]=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall ([x]=1)
+Observation STR02 Always 1 0
+Hash=b0e9cabd5402db054215ea5c67974e00
+

--- a/herd/tests/instructions/AArch64.ASL/asl.cfg
+++ b/herd/tests/instructions/AArch64.ASL/asl.cfg
@@ -1,1 +1,1 @@
-variant asl
+variant asl,warn

--- a/herd/tests/instructions/ASL/double-load.litmus
+++ b/herd/tests/instructions/ASL/double-load.litmus
@@ -1,8 +1,8 @@
 ASL double-load
 
 {
-  x = 3;
-  y = x;
+  int x = 3;
+  int *y = x;
   0: X1 = y;
 }
 
@@ -10,7 +10,7 @@ func main() => integer
 begin
   let addr_y = read_register(1);
   let addr_x = read_memory (addr_y, 64);
-  let data_x = read_memory (addr_x, 64);
+  let data_x = read_memory (addr_x, 32);
   let three = UInt (data_x);
 
   return 0;

--- a/herd/tests/instructions/ASL/double-load.litmus.expected
+++ b/herd/tests/instructions/ASL/double-load.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.three=3)
 Observation double-load Always 1 0
-Hash=a7d3d6a0dd48722daaadb0583cdff754
+Hash=9474d4e9319ca71dc0d5e83c40cf7977
 

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -87,7 +87,10 @@ type t =
   | ASLType of [`Warn|`Silence|`TypeCheck]
 (* Signed Int128 types *)
   | S128
-
+(* Strict interpretation of variant, e.g. -variant asl,strict *)
+  | Strict
+(* Semi-strict interpretation of variant, e.g. -variant asl,warn *)
+  | Warn
 
 let tags =
   ["success";"instr";"specialx0";"normw";"acqrelasfence";"backcompat";
@@ -96,8 +99,8 @@ let tags =
     Precision.tags @
    ["toofar"; "deps"; "morello"; "instances"; "noptebranch"; "pte2";
    "pte-squared"; "PhantomOnLoad"; "OptRfRMW"; "ConstrainedUnpredictable";
-    "exp"; "self"; "cos-opt"; "test"; "T[0-9][0-9]"; "asl"; "S128";
-    "ASLType+Warn";    "ASLType+Silence"; "ASLType+Check";]
+    "exp"; "self"; "cos-opt"; "test"; "T[0-9][0-9]"; "asl"; "strict";
+    "warn"; "S128"; "ASLType+Warn";    "ASLType+Silence"; "ASLType+Check";]
 
 let parse s = match Misc.lowercase s with
 | "success" -> Some Success
@@ -147,6 +150,8 @@ let parse s = match Misc.lowercase s with
 | "asltype+silence"-> Some (ASLType `Silence)
 | "asltype+check"  -> Some (ASLType `TypeCheck)
 | "s128" -> Some S128
+| "strict" -> Some Strict
+| "warn" -> Some Warn
 | s ->
    begin
      match Precision.parse s with
@@ -209,6 +214,8 @@ let pp = function
   | ASLVersion `ASLv0 -> "ASLv0"
   | ASLVersion `ASLv1 -> "ASLv1"
   | S128 -> "S128"
+  | Strict -> "strict"
+  | Warn -> "warn"
   | ASLType `Warn -> "ASLType+Warn"
   | ASLType `Silence -> "ASLType+Silence"
   | ASLType `TypeCheck -> "ASLType+Check"

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -88,6 +88,10 @@ type t =
   | ASLType of [`Warn|`Silence|`TypeCheck]
 (* Signed Int128 types *)
   | S128
+(* Strict interpretation of variant, e.g. -variant asl,strict *)
+  | Strict
+(* Semi-strict interpretation of variant, e.g. -variant asl,warn *)
+  | Warn
 
 val compare : t -> t -> int
 val equal : t -> t -> bool


### PR DESCRIPTION
At the moment, tested accesses are the 32bits ones: `LDR W0,[X1]`, `STR W0,[X1]`.

The PR also includes two new variants `-variant warn` (warn if some feature is not implemented) and `-variant strict` (fail if some feature is not implemented). At the moment those variants apply to the ASL variant of AArch64.