### PR TITLE
[herd] Introduce the `aarch32.cat` model

### DIFF
--- a/herd/libdir/aarch32.cat
+++ b/herd/libdir/aarch32.cat
@@ -1,0 +1,7 @@
+AArch32
+catdep
+
+let DMB.SY = DMB
+let DSB.SY = DSB
+include "aarch64.cat"
+

--- a/herd/libdir/aarch64util.cat
+++ b/herd/libdir/aarch64util.cat
@@ -57,6 +57,7 @@ let DB = try DB with emptyset
 let MMU = try MMU with emptyset
 let Translation = try Translation with emptyset
 let AccessFlag = try AccessFlag with emptyset
+let TagCheck = try TagCheck with emptyset
 
 (*
  * Include the cos.cat file shipped with herd.


### PR DESCRIPTION
This model is the default AArch64 mode `aarch64.cat`, slightly adapted to for ARM code.