### PR TITLE
[ARM]: Add ARM instructions

### DIFF
--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -114,6 +114,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
         -> None
       | I_LDR _ | I_LDREX _ | I_LDR3 _ | I_STR _ | I_STREX _ | I_STR3 _
       | I_STL _ | I_LDA _|I_LDAEX _|I_STLEX _
+      | I_STR3_S _| I_LDR3_S _
       | I_LDRO _ | I_LDM2 _ | I_LDM3 _ | I_LDRD _
         -> Some MachSize.Word
 

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -107,7 +107,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     let mem_access_size = function
       | I_NOP | I_ADD _ | I_ADD3 _ | I_SUB _ | I_SUB3 _ | I_AND _ | I_ORR _
-      | I_B _ | I_BX _ |  I_BEQ _ | I_BNE _ | I_CB _ | I_CMPI _
+      | I_B _ | I_BX _ |  I_BEQ _ | I_BNE _ | I_CB _ | I_CMPI _ | I_ANDC _
       | I_CMP _ | I_MOVI _ | I_MOV _ | I_MOVW _ | I_MOVT _ | I_XOR _
       | I_DMB _ | I_DSB _ | I_ISB
       | I_SADD16 _ | I_SEL _

--- a/herd/ARMSem.ml
+++ b/herd/ARMSem.ml
@@ -245,6 +245,13 @@ module
                    >>|
                    write_flags set vres (V.intToV 0) ii))
                 >>= B.next2T
+          | ARM.I_ANDC (c,rd,rs,rs2) ->
+              let andc ii = ((read_reg_ord rs ii) >>| (read_reg_ord rs2 ii)
+                 >>=
+               (fun (v1,v2) -> M.op Op.And v1 v2)
+                 >>=
+               (fun vres -> write_reg rd vres ii)) in
+              checkZ andc c ii
           | ARM.I_ORR (set,rd,rs,v) ->
               ((read_reg_ord  rs ii)
                  >>=

--- a/herd/ARMSem.ml
+++ b/herd/ARMSem.ml
@@ -468,16 +468,16 @@ module
           | ARM.I_MOVI (rt, i, c) ->
               let movi ii =  write_reg  rt (V.intToV i) ii in
               checkZ movi c ii
-          | ARM.I_MOVW (rt, k) ->
+          | ARM.I_MOVW (rt, k, c) ->
               assert (MachSize.is_imm16 k);
               let movi ii =  write_reg  rt (V.intToV k) ii in
-              checkZ movi ARM.AL ii
-          | ARM.I_MOVT (rt, k) ->
+              checkZ movi c ii
+          | ARM.I_MOVT (rt, k, c) ->
               assert (MachSize.is_imm16 k);
               let movi ii =
                 M.op1 (Op.LeftShift 16) (V.intToV k)
                 >>= fun k -> write_reg  rt k ii in
-              checkZ movi ARM.AL ii
+              checkZ movi c ii
           | ARM.I_XOR (set,r3,r1,r2) ->
               (((read_reg_ord  r1 ii) >>| (read_reg_ord r2 ii))
                  >>=

--- a/herd/ARMSem.ml
+++ b/herd/ARMSem.ml
@@ -384,6 +384,17 @@ module
                     (read_mem nat_sz vaddr ii) >>=
                     (fun v -> write_reg  rt v ii))) in
               checkZ ldr3 c ii
+          |  ARM.I_LDR3_S (rt,rn,rm,ARM.S_LSL k, c) ->
+              let ldr3 ii =
+                ((read_reg_ord  rn ii) >>| (read_reg_ord  rm ii))
+                  >>=
+                (fun (vn,vm) ->
+                  (M.op1 (Op.LeftShift k) vm)
+                  >>= fun vm -> (M.add vn vm) >>=
+                  (fun vaddr ->
+                    (read_mem nat_sz vaddr ii) >>=
+                    (fun v -> write_reg  rt v ii))) in
+              checkZ ldr3 c ii
           |  ARM.I_STR (rt,rn,c) ->
               let str ii =
                 ((read_reg_ord  rn ii) >>| (read_reg_data  rt ii))
@@ -408,6 +419,17 @@ module
                    >>=
                  (fun (vm,(vn,vt)) ->
                    (M.add vn vm) >>=
+                   (fun a ->
+                     (write_mem nat_sz a vt ii)))) in
+              checkZ str3 c ii
+          |  ARM.I_STR3_S (rt,rn,rm,ARM.S_LSL k, c) ->
+              let str3 ii =
+                (((read_reg_ord  rm ii) >>|
+                ((read_reg_ord  rn ii) >>|
+                (read_reg_data  rt ii)))
+                   >>=
+                 (fun (vm,(vn,vt)) -> (M.op1 (Op.LeftShift k) vm)
+                   >>= fun vm -> (M.add vn vm) >>=
                    (fun a ->
                      (write_mem nat_sz a vt ii)))) in
               checkZ str3 c ii

--- a/herd/tests/instructions/ARM/A020.litmus
+++ b/herd/tests/instructions/ARM/A020.litmus
@@ -1,0 +1,11 @@
+ARM A020
+
+(* TEST LDR/STR Barrel Shifters*)
+
+{ int v[2] = {1,2}; 0:R1 = v; 0:R3 = 1; int y[2] = {0,0}; 0:R4 = y }
+
+P0;
+LDR R2, [R1, R3, lsl #2];
+STR R2, [R4, R3, lsl #2];
+
+forall (0:R2 = 2 /\ v[1] = 2)

--- a/herd/tests/instructions/ARM/A020.litmus.expected
+++ b/herd/tests/instructions/ARM/A020.litmus.expected
@@ -1,0 +1,10 @@
+Test A020 Required
+States 1
+0:R2=2; v[1]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R2=2 /\ v[1]=2)
+Observation A020 Always 1 0
+Hash=53b68e1cf3bc79ce492882ea4fe72ade
+

--- a/herd/tests/instructions/ARM/A021.litmus
+++ b/herd/tests/instructions/ARM/A021.litmus
@@ -1,0 +1,12 @@
+ARM A021
+
+(* Test MOVEQ/MOVTEQ instruction *)
+
+{ int R1=0; int R2 = 0; 0:R3=1}
+
+P0;
+  CMP R3, #1;
+  MOVWEQ R1, #2;
+  MOVTEQ R2, #2;
+
+forall (0:R1=2 /\ 0:R2=0x20000)

--- a/herd/tests/instructions/ARM/A021.litmus.expected
+++ b/herd/tests/instructions/ARM/A021.litmus.expected
@@ -1,0 +1,10 @@
+Test A021 Required
+States 1
+0:R1=2; 0:R2=131072;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R1=2 /\ 0:R2=131072)
+Observation A021 Always 1 0
+Hash=1763ed3b82a8cec323ea12c101f0a09f
+

--- a/herd/tests/instructions/ARM/A022.litmus
+++ b/herd/tests/instructions/ARM/A022.litmus
@@ -1,0 +1,12 @@
+ARM A022
+
+(* Test ANDEQ *)
+{ 0:R1 = 1 }
+
+P0;
+CMP R1, #1;
+ANDEQ R0, R0, R0; (*nop*)
+ANDEQ R2, R1, R1;
+
+forall 0:R2=1
+

--- a/herd/tests/instructions/ARM/A022.litmus.expected
+++ b/herd/tests/instructions/ARM/A022.litmus.expected
@@ -1,0 +1,10 @@
+Test A022 Required
+States 1
+0:R2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R2=1)
+Observation A022 Always 1 0
+Hash=443e6e22e08983d431e8e9b0068c1a9c
+

--- a/herd/tests/instructions/ARM/A023.litmus
+++ b/herd/tests/instructions/ARM/A023.litmus
@@ -1,0 +1,10 @@
+ARM A023
+
+(*Parse Frame Pointer reg*)
+
+{}
+
+P0;
+MOV R0, FP;
+
+forall 0:R0=0

--- a/herd/tests/instructions/ARM/A023.litmus.expected
+++ b/herd/tests/instructions/ARM/A023.litmus.expected
@@ -1,0 +1,10 @@
+Test A023 Required
+States 1
+0:R0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:R0=0)
+Observation A023 Always 1 0
+Hash=a5d34ed41a70bbc7d0424aec76dd2ea5
+

--- a/jingle/ARMArch_jingle.ml
+++ b/jingle/ARMArch_jingle.ml
@@ -51,6 +51,7 @@ let match_instr subs pattern instr = match pattern,instr with
       add_subs
         [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')]
         subs
+  | I_ANDC(_,r1,r2,r3), I_ANDC(_,r1',r2',r3')
   | I_ADD3(_,r1,r2,r3),I_ADD3(_,r1',r2',r3')
   | I_SUB3(_,r1,r2,r3),I_SUB3(_,r1',r2',r3')
   | I_XOR(_,r1,r2,r3),I_XOR(_,r1',r2',r3') ->
@@ -144,6 +145,11 @@ let match_instr subs pattern instr = match pattern,instr with
           fun r1 -> conv_reg r2 >>
           fun r2 -> find_cst v >!
           fun v -> I_AND(f,r1,r2,v)
+      | I_ANDC(c,r1,r2,r3) ->
+          conv_reg r1 >>
+          fun r1 -> conv_reg r2 >>
+          fun r2 -> conv_reg r3 >!
+          fun r3 -> I_ANDC(c,r1,r2,r3)
       | I_ORR(f,r1,r2,v) ->
           conv_reg r1 >>
           fun r1 -> conv_reg r2 >>

--- a/jingle/ARMArch_jingle.ml
+++ b/jingle/ARMArch_jingle.ml
@@ -110,8 +110,8 @@ let match_instr subs pattern instr = match pattern,instr with
         subs
   | I_MOVI(r,MetaConst.Int i,c),I_MOVI(r',i',c') when i=i' && c=c' ->
       add_subs [Reg(sr_name r,r')] subs
-  | I_MOVW(r,MetaConst.Int i),I_MOVW(r',i')
-  | I_MOVT(r,MetaConst.Int i),I_MOVT(r',i') when i=i' ->
+  | I_MOVW(r,MetaConst.Int i,c),I_MOVW(r',i',c')
+  | I_MOVT(r,MetaConst.Int i,c),I_MOVT(r',i',c') when i=i' && c=c' ->
       add_subs [Reg(sr_name r,r')] subs
   | I_DMB b,I_DMB b'
   | I_DSB b,I_DSB b' when b = b' ->
@@ -282,14 +282,14 @@ let match_instr subs pattern instr = match pattern,instr with
           conv_reg r >> fun r ->
           find_cst v >! fun v ->
           I_MOVI(r,v,c)
-      | I_MOVW(r,v) ->
+      | I_MOVW(r,v,c) ->
           conv_reg r >> fun r ->
           find_cst v >! fun v ->
-          I_MOVW(r,v)
-      | I_MOVT(r,v) ->
+          I_MOVW(r,v,c)
+      | I_MOVT(r,v,c) ->
           conv_reg r >> fun r ->
           find_cst v >! fun v ->
-          I_MOVT(r,v)
+          I_MOVT(r,v,c)
       | I_NOP
       | I_DMB _
       | I_DSB _

--- a/jingle/ARMArch_jingle.ml
+++ b/jingle/ARMArch_jingle.ml
@@ -62,6 +62,13 @@ let match_instr subs pattern instr = match pattern,instr with
       add_subs
         [Reg(sr_name r1,r1'); Reg(sr_name r2,r2'); Reg(sr_name r3,r3')]
         subs
+  | I_LDR3_S(r1,r2,r3,S_LSL (MetaConst.Int k),c),
+    I_LDR3_S(r1',r2',r3',S_LSL k',c')
+  | I_STR3_S(r1,r2,r3,S_LSL (MetaConst.Int k),c),
+    I_STR3_S(r1',r2',r3',S_LSL k',c') when k = k' && c = c' ->
+      add_subs
+        [Reg(sr_name r1,r1'); Reg(sr_name r2,r2'); Reg(sr_name r3,r3')]
+        subs
   | I_B l,I_B l'
   | I_BEQ l,I_BEQ l'
   | I_BNE l,I_BNE l' ->
@@ -243,6 +250,18 @@ let match_instr subs pattern instr = match pattern,instr with
           conv_reg r2 >> fun r2 ->
           conv_reg r3 >! fun r3 ->
           I_STR3(r1,r2,r3,c)
+      | I_STR3_S(r1,r2,r3,S_LSL k,c) ->
+          conv_reg r1 >> fun r1 ->
+          conv_reg r2 >> fun r2 ->
+          conv_reg r3 >> fun r3 ->
+          find_cst k >! fun k ->
+          I_STR3_S(r1,r2,r3,S_LSL k,c)
+      | I_LDR3_S(r1,r2,r3,S_LSL k,c) ->
+          conv_reg r1 >> fun r1 ->
+          conv_reg r2 >> fun r2 ->
+          conv_reg r3 >> fun r3 ->
+          find_cst k >! fun k ->
+          I_LDR3_S(r1,r2,r3,S_LSL k,c)
       | I_STREX(r1,r2,r3,c) ->
           conv_reg r1 >> fun r1 ->
           conv_reg r2 >> fun r2 ->

--- a/lib/ARMBase.ml
+++ b/lib/ARMBase.ml
@@ -229,8 +229,8 @@ type 'k kinstruction =
   | I_STLEX of reg * reg * reg
   | I_MOVI of reg * 'k * condition
   | I_MOV of reg * reg * condition
-  | I_MOVW of reg * 'k
-  | I_MOVT of reg * 'k
+  | I_MOVW of reg * 'k * condition
+  | I_MOVT of reg * 'k * condition
   | I_XOR of setflags * reg * reg * reg
   | I_DMB of barrier_option
   | I_DSB of barrier_option
@@ -355,8 +355,8 @@ let do_pp_instruction m =
   | I_STLEX(rt,rn,rm) -> ppi_strex "STLEX" rt rn rm AL
   | I_MOVI(r,i,c) -> ppi_ric "MOV" r i c
   | I_MOV(r1,r2,c) -> ppi_rrc "MOV" r1 r2 c
-  | I_MOVW(r1,k) -> "MOVW " ^ (pp_reg r1) ^ ", " ^ (m.pp_k k)
-  | I_MOVT(r1,k) -> "MOVT " ^ (pp_reg r1) ^ ", " ^ (m.pp_k k)
+  | I_MOVW(r1,k,c) -> pp_memoc "MOVW" c ^ (pp_reg r1) ^ ", " ^ (m.pp_k k)
+  | I_MOVT(r1,k,c) -> pp_memoc "MOVT " c ^ (pp_reg r1) ^ ", " ^ (m.pp_k k)
   | I_XOR(s,r1,r2,r3) -> ppi_rrr "EOR" s r1 r2 r3
   | I_DMB o -> pp_barrier_ins "DMB" o
   | I_DSB o -> pp_barrier_ins "DSB" o
@@ -428,7 +428,7 @@ let fold_regs (f_reg,f_sreg) =
   | I_BX r
   | I_CMPI (r, _)
   | I_MOVI (r, _, _)
-  | I_MOVW (r,_) | I_MOVT (r,_)
+  | I_MOVW (r,_,_) | I_MOVT (r,_,_)
   | I_CB (_,r,_)
       -> fold_reg r c
   | I_NOP
@@ -481,8 +481,8 @@ let map_regs f_reg f_symb =
   | I_STREX (r1, r2, r3, c) -> I_STREX (map_reg r1, map_reg r2, map_reg r3, c)
   | I_STL (r1, r2, c) -> I_STL (map_reg r1, map_reg r2, c)
   | I_MOVI (r, k, c) -> I_MOVI (map_reg r, k, c)
-  | I_MOVW (r, k) -> I_MOVW (map_reg r, k)
-  | I_MOVT (r, k) -> I_MOVT (map_reg r, k)
+  | I_MOVW (r, k,c) -> I_MOVW (map_reg r, k,c)
+  | I_MOVT (r, k,c) -> I_MOVT (map_reg r, k,c)
   | I_MOV (r1, r2, c) -> I_MOV (map_reg r1, map_reg r2, c)
   | I_XOR (s,r1, r2, r3) -> I_XOR (s,map_reg r1, map_reg r2, map_reg r3)
   | I_STLEX (r1, r2, r3) -> I_STLEX (map_reg r1, map_reg r2, map_reg r3)
@@ -567,8 +567,8 @@ include Pseudo.Make
         | I_BX r -> I_BX r
         | I_CMPI (r,k) -> I_CMPI (r,MetaConst.as_int k)
         | I_MOVI (r,k,c) -> I_MOVI (r,MetaConst.as_int k,c)
-        | I_MOVW (r,k) -> I_MOVW (r,MetaConst.as_int k)
-        | I_MOVT (r,k) -> I_MOVT (r,MetaConst.as_int k)
+        | I_MOVW (r,k,c) -> I_MOVW (r,MetaConst.as_int k,c)
+        | I_MOVT (r,k,c) -> I_MOVT (r,MetaConst.as_int k,c)
         | I_NOP
         | I_ADD3 _
         | I_SUB3 _

--- a/lib/ARMBase.ml
+++ b/lib/ARMBase.ml
@@ -32,7 +32,7 @@ type reg =
   | R4 | R5 | R6 | R7
   | R8 | R9 | R10 | R11
   | R12
-  | SP | LR | PC
+  | SP | LR | PC | FP
 
   | Z  (* condition flags *)
 
@@ -68,6 +68,7 @@ let regs =
    R12, "R12" ;
    R12, "IP" ;
    SP, "SP" ;
+   FP, "FP" ;
    LR, "LR" ;
    PC, "PC" ;
    Z, "Z" ;
@@ -385,7 +386,7 @@ let fold_regs (f_reg,f_sreg) =
 
   let fold_reg reg (y_reg,y_sreg) = match reg with
   | R0 | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8
-  | R9 | R10 | R11 | R12 | SP | LR | PC | Z | RESADDR ->  f_reg reg y_reg,y_sreg
+  | R9 | R10 | R11 | R12 | SP | FP | LR | PC | Z | RESADDR ->  f_reg reg y_reg,y_sreg
   | Symbolic_reg reg -> y_reg,f_sreg reg y_sreg
   | Internal _ -> y_reg,y_sreg in
 
@@ -440,7 +441,7 @@ let map_regs f_reg f_symb =
 
   let map_reg  reg = match reg with
   | R0 | R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8
-  | R9 | R10 | R11 | R12 | SP | LR | PC | Z | RESADDR -> f_reg reg
+  | R9 | R10 | R11 | R12 | SP | FP | LR | PC | Z | RESADDR -> f_reg reg
   | Symbolic_reg reg -> f_symb reg
   | Internal _ -> reg in
 

--- a/lib/ARMBase.ml
+++ b/lib/ARMBase.ml
@@ -203,6 +203,7 @@ type 'k kinstruction =
   | I_SUB of setflags * reg * reg * 'k
   | I_SUB3 of setflags * reg * reg * reg
   | I_AND of setflags * reg * reg * 'k
+  | I_ANDC of condition * reg * reg * reg
   | I_ORR of setflags * reg * reg * 'k
   | I_B of lbl
   | I_BEQ of lbl
@@ -321,6 +322,8 @@ let do_pp_instruction m =
   | I_SUB(s,rt,rn,v) -> ppi_rri "SUB" s rt rn v
   | I_SUB3 (s,r1,r2,r3) -> ppi_rrr "SUB" s r1 r2 r3
   | I_AND(s,rt,rn,v) -> ppi_rri "AND" s rt rn v
+  | I_ANDC(c,rt,rn,v) -> sprintf "%s %s, %s, %s" (pp_memoc "AND" c)
+    (pp_reg rt) (pp_reg rn) (pp_reg v)
   | I_ORR(s,rt,rn,v) -> ppi_rri "ORR" s rt rn v
   | I_B v -> "B " ^ pp_lbl v
   | I_BEQ(v) -> "BEQ "^ pp_lbl v
@@ -405,6 +408,7 @@ let fold_regs (f_reg,f_sreg) =
   | I_MOV (r1, r2, _)
   | I_CMP (r1,r2)
       -> fold_reg r2 (fold_reg r1 c)
+  | I_ANDC (_,r1, r2, r3)
   | I_LDR3 (r1, r2, r3, _)
   | I_LDR3_S (r1, r2, r3, _,_)
   | I_LDRD (r1, r2, r3, _)
@@ -471,6 +475,7 @@ let map_regs f_reg f_symb =
   | I_LDM3 (r1,r2,r3,r4,i) -> I_LDM3 (map_reg r1, map_reg r2, map_reg r3,map_reg r4, i)
   | I_STR (r1, r2, c) -> I_STR (map_reg r1, map_reg r2, c)
   | I_STR3 (r1, r2, r3, c) -> I_STR3 (map_reg r1, map_reg r2, map_reg r3, c)
+  | I_ANDC (c,r1, r2, r3) -> I_ANDC (c, map_reg r1, map_reg r2, map_reg r3)
   | I_STR3_S (r1, r2, r3, c,s) -> I_STR3_S (map_reg r1, map_reg r2, map_reg r3, c,s)
   | I_LDR3_S (r1, r2, r3, s,c) -> I_LDR3_S (map_reg r1, map_reg r2, map_reg r3, s,c)
   | I_STREX (r1, r2, r3, c) -> I_STREX (map_reg r1, map_reg r2, map_reg r3, c)
@@ -505,6 +510,7 @@ let get_next = function
   | I_SUB _
   | I_SUB3 _
   | I_AND _
+  | I_ANDC _
   | I_ORR _
   | I_CMPI _
   | I_CMP _
@@ -549,6 +555,7 @@ include Pseudo.Make
         | I_ADD (c,r1,r2,k) ->  I_ADD (c,r1,r2,MetaConst.as_int k)
         | I_SUB (c,r1,r2,k) ->  I_SUB (c,r1,r2,MetaConst.as_int k)
         | I_AND (c,r1,r2,k) ->  I_AND (c,r1,r2,MetaConst.as_int k)
+        | I_ANDC (c,r1,r2,r3) ->  I_ANDC (c,r1,r2,r3)
         | I_ORR (c,r1,r2,k) ->  I_ORR (c,r1,r2,MetaConst.as_int k)
         | I_LDRO (r1,r2,k,c) ->  I_LDRO (r1,r2,MetaConst.as_int k,c)
         | I_LDRD (r1,r2,r3,Some k) ->  I_LDRD (r1,r2,r3,Some (MetaConst.as_int k))
@@ -599,6 +606,7 @@ include Pseudo.Make
         | I_SUB _
         | I_SUB3 _
         | I_AND _
+        | I_ANDC _
         | I_ORR _
         | I_B _
         | I_BX _

--- a/lib/ARMLexer.mll
+++ b/lib/ARMLexer.mll
@@ -60,6 +60,8 @@ match name with
 | "movt" | "MOVT" -> I_MOVT
 | "movne" | "MOVNE"   -> I_MOVNE
 | "moveq" | "MOVEQ"   -> I_MOVEQ
+| "movteq" | "MOVTEQ" -> I_MOVTEQ
+| "movweq" | "MOVWEQ" -> I_MOVWEQ
 | "xor" | "XOR"   -> I_XOR
 | "eor" | "EOR"   -> I_XOR
 | "eors" | "EORS" -> I_XOR

--- a/lib/ARMLexer.mll
+++ b/lib/ARMLexer.mll
@@ -72,6 +72,7 @@ match name with
 | "nshst" | "NSHST" -> I_NSHST
 | "osh" | "OSH" -> I_OSH
 | "oshst" | "OSHST" -> I_OSHST
+| "lsl" | "LSL" -> S_LSL
 | _  -> begin match ARM.parse_reg name with
   | Some r -> ARCH_REG r
   | None -> NAME name

--- a/lib/ARMLexer.mll
+++ b/lib/ARMLexer.mll
@@ -25,6 +25,8 @@ module LU = LexUtils.Make(O)
 let check_name name =
 match name with
 | "add" | "ADD" -> I_ADD
+| "push" | "PUSH" -> I_PUSH
+| "pop" | "POP" -> I_POP
 | "adds" | "ADDS"   -> I_ADDS
 | "bx" | "BX" -> I_BX
 | "sub" | "SUB"   -> I_SUB

--- a/lib/ARMLexer.mll
+++ b/lib/ARMLexer.mll
@@ -34,6 +34,7 @@ match name with
 | "and" | "AND"   -> I_AND
 | "orr" | "ORR"   -> I_ORR
 | "ands" | "ANDS"   -> I_ANDS
+| "andeq" | "ANDEQ"   -> I_ANDEQ
 | "bne" | "BNE"   -> I_BNE
 | "beq" | "BEQ"   -> I_BEQ
 | "cbz" | "CBZ"   -> I_CBZ

--- a/lib/ARMParser.mly
+++ b/lib/ARMParser.mly
@@ -31,7 +31,7 @@ module A = ARMBase
 
 /* Instruction tokens */
 
-%token I_ADD I_ADDS I_BX I_SUB I_SUBS I_AND I_ORR I_ANDS I_B I_BEQ I_BNE I_CMP I_MOV I_MOVW I_MOVT I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
+%token I_ADD I_ADDS I_BX I_SUB I_SUBS I_AND I_ORR I_ANDS I_ANDEQ I_B I_BEQ I_BNE I_CMP I_MOV I_MOVW I_MOVT I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
 %token I_LDR I_LDREX I_LDRNE I_LDREQ I_LDRD I_LDM I_LDMIB I_STR I_STRNE I_STREQ I_STREX I_LDA I_STL I_LDAEX I_STLEX I_PUSH I_POP
 %token I_SY I_ST I_ISH I_ISHST I_NSH I_NSHST I_OSH I_OSHST
 %token S_LSL
@@ -110,6 +110,9 @@ instr:
      { A.I_ORR (A.DontSetFlags,$2,$4,$6) }
   | I_ANDS reg COMMA reg COMMA k
      { A.I_AND (A.SetFlags,$2,$4,$6) }
+  | I_ANDEQ reg COMMA reg COMMA reg
+     { (* This is historically used as a NOP when regs are the same*)
+       if $2 = $4 && $4 = $6 then A.I_NOP else A.I_ANDC (A.EQ,$2,$4,$6) }
   | I_B NAME
      { A.I_B $2 }
   | I_BNE NAME

--- a/lib/ARMParser.mly
+++ b/lib/ARMParser.mly
@@ -32,7 +32,7 @@ module A = ARMBase
 /* Instruction tokens */
 
 %token I_ADD I_ADDS I_BX I_SUB I_SUBS I_AND I_ORR I_ANDS I_B I_BEQ I_BNE I_CMP I_MOV I_MOVW I_MOVT I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
-%token I_LDR I_LDREX I_LDRNE I_LDREQ I_LDRD I_LDM I_LDMIB I_STR I_STRNE I_STREQ I_STREX I_LDA I_STL I_LDAEX I_STLEX
+%token I_LDR I_LDREX I_LDRNE I_LDREQ I_LDRD I_LDM I_LDMIB I_STR I_STRNE I_STREQ I_STREX I_LDA I_STL I_LDAEX I_STLEX I_PUSH I_POP
 %token I_SY I_ST I_ISH I_ISHST I_NSH I_NSHST I_OSH I_OSHST
 %token S_LSL
 %type <MiscParser.proc list * (ARMBase.parsedPseudo) list list> main
@@ -162,6 +162,14 @@ instr:
      { A.I_LDM2 ($2, $5, $7, A.IB) }
   | I_LDM reg COMMA LPAREN reg COMMA reg COMMA reg RPAREN
      { A.I_LDM3 ($2, $5, $7, $9, A.NO) }
+  | I_PUSH LPAREN reg RPAREN
+     { A.I_NOP }
+  | I_PUSH LPAREN reg COMMA reg RPAREN
+     { A.I_NOP }
+  | I_POP LPAREN reg COMMA reg RPAREN
+     { A.I_NOP }
+  | I_POP LPAREN reg RPAREN
+     { A.I_NOP }
   (* LDRD syntax comes in two forms - LDRD Rd1, Rd2, [Ra] and *)
   (* LDRD Rd1, [Ra] - in both cases LDRD requires Rd2 is Rd(1+1) *)
   (* so the second register can be and is omitted e.g  by GCC-10*)

--- a/lib/ARMParser.mly
+++ b/lib/ARMParser.mly
@@ -32,7 +32,7 @@ module A = ARMBase
 /* Instruction tokens */
 
 %token I_ADD I_ADDS I_BX I_SUB I_SUBS I_AND I_ORR I_ANDS I_ANDEQ I_B I_BEQ I_BNE I_CMP I_MOV I_MOVW I_MOVT I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
-%token I_LDR I_LDREX I_LDRNE I_LDREQ I_LDRD I_LDM I_LDMIB I_STR I_STRNE I_STREQ I_STREX I_LDA I_STL I_LDAEX I_STLEX I_PUSH I_POP
+%token I_LDR I_LDREX I_LDRNE I_LDREQ I_LDRD I_LDM I_LDMIB I_STR I_STRNE I_STREQ I_STREX I_LDA I_STL I_LDAEX I_STLEX I_PUSH I_POP I_MOVWEQ I_MOVTEQ
 %token I_SY I_ST I_ISH I_ISHST I_NSH I_NSHST I_OSH I_OSHST
 %token S_LSL
 %type <MiscParser.proc list * (ARMBase.parsedPseudo) list list> main
@@ -225,9 +225,13 @@ instr:
   | I_MOVEQ reg COMMA reg
      { A.I_MOV ($2,$4,A.EQ) }
   | I_MOVW reg COMMA k
-     { A.I_MOVW ($2,$4)}
+     { A.I_MOVW ($2,$4,A.AL)}
+  | I_MOVWEQ reg COMMA k
+     { A.I_MOVW ($2,$4,A.EQ) }
   | I_MOVT reg COMMA k
-     { A.I_MOVT ($2,$4)}
+     { A.I_MOVT ($2,$4,A.AL)}
+  | I_MOVTEQ reg COMMA k
+     { A.I_MOVT ($2,$4,A.EQ)}
   | I_XOR reg COMMA reg COMMA reg
      { A.I_XOR (A.DontSetFlags,$2,$4,$6) }
   | I_XORS reg COMMA reg COMMA reg

--- a/lib/ARMParser.mly
+++ b/lib/ARMParser.mly
@@ -34,6 +34,7 @@ module A = ARMBase
 %token I_ADD I_ADDS I_BX I_SUB I_SUBS I_AND I_ORR I_ANDS I_B I_BEQ I_BNE I_CMP I_MOV I_MOVW I_MOVT I_MOVNE I_MOVEQ I_XOR I_XORS I_DMB I_DSB I_ISB I_CBZ I_CBNZ
 %token I_LDR I_LDREX I_LDRNE I_LDREQ I_LDRD I_LDM I_LDMIB I_STR I_STRNE I_STREQ I_STREX I_LDA I_STL I_LDAEX I_STLEX
 %token I_SY I_ST I_ISH I_ISHST I_NSH I_NSHST I_OSH I_OSHST
+%token S_LSL
 %type <MiscParser.proc list * (ARMBase.parsedPseudo) list list> main
 %start  main
 
@@ -81,6 +82,9 @@ k:
 | NUM  { MetaConst.Int $1 }
 | META { MetaConst.Meta $1 }
 
+shift:
+  | COMMA S_LSL k { A.S_LSL $3 }
+
 instr:
   | I_ADD reg COMMA reg COMMA k
      { A.I_ADD (A.DontSetFlags,$2,$4,$6) }
@@ -127,6 +131,8 @@ instr:
      { A.I_LDR ($2,$5,A.AL) }
   | I_LDR reg COMMA LBRK reg COMMA reg RBRK
      { A.I_LDR3 ($2,$5,$7,A.AL) }
+  | I_LDR reg COMMA LBRK reg COMMA reg shift RBRK
+     { A.I_LDR3_S ($2,$5,$7,$8,A.AL) }
   | I_LDR reg COMMA LBRK reg COMMA k RBRK
      { A.I_LDRO ($2,$5,$7,A.AL) }
   | I_LDRNE reg COMMA reg
@@ -174,6 +180,8 @@ instr:
      { A.I_STR ($2,$5,A.AL) }
   | I_STR reg COMMA LBRK reg COMMA reg RBRK
      { A.I_STR3 ($2,$5,$7,A.AL) }
+  | I_STR reg COMMA LBRK reg COMMA reg shift RBRK
+     { A.I_STR3_S ($2,$5,$7,$8,A.AL) }
   | I_STRNE reg COMMA reg
      { A.I_STR ($2,$4,A.NE) }
   | I_STRNE reg COMMA LBRK reg RBRK

--- a/litmus/ARMCompile_litmus.ml
+++ b/litmus/ARMCompile_litmus.ml
@@ -66,6 +66,14 @@ module Make(V:Constant.S)(C:Config) =
         inputs=[rA; rB];
         outputs=[rD]; cond=is_cond c; }
 
+    let andc c rD rA rB =
+      let memo =
+        sprintf "and%s" (pp_cond c) in
+      { empty_ins with
+        memo=memo^ " ^o0,^i0,^i1";
+        inputs=[rA; rB];
+        outputs=[rD]; cond=is_cond c; }
+
     let op2regsI memo s c rD rA i =
       let memo =
         sprintf "%s%s%s"
@@ -316,6 +324,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_AND (s,r1, r2, i) ->  op2regsI "and" s AL r1 r2 i::k
     | I_ORR (s,r1, r2, i) ->  op2regsI "orr" s AL r1 r2 i::k
     | I_ADD3 (s,r1, r2, r3) ->  op3regs "add" s AL r1 r2 r3::k
+    | I_ANDC (c,r1, r2, r3) ->  andc c r1 r2 r3::k
     | I_SADD16 (r1, r2, r3) ->  op3regs "sadd16" DontSetFlags AL r1 r2 r3::k
     | I_SEL (r1, r2, r3) ->  op3regs "sel" DontSetFlags AL r1 r2 r3::k
     | I_SUB3 (s,r1, r2, r3) ->  op3regs "sub" s AL r1 r2 r3::k

--- a/litmus/ARMCompile_litmus.ml
+++ b/litmus/ARMCompile_litmus.ml
@@ -172,6 +172,13 @@ module Make(V:Constant.S)(C:Config) =
         inputs = [r2;r3] ;
         outputs = [r1] ; cond=is_cond c; }
 
+    let ldr3_s r1 r2 r3 k c =
+      let memo = sprintf "%s%s" "ldr" (pp_cond c) in
+      { empty_ins with
+        memo = sprintf "%s ^o0,[^i0,^i1,lsl #%i]" memo k ;
+        inputs = [r2;r3] ;
+        outputs = [r1] ; }
+
     let str2 c r1 r2 =
       let memo = sprintf "%s%s" "str" (pp_cond c) in
       { empty_ins with
@@ -200,6 +207,14 @@ module Make(V:Constant.S)(C:Config) =
         memo = sprintf "%s ^i0,[^i1,^i2]" memo ;
         inputs = [r1;r2;r3] ;
         outputs = [] ; cond=is_cond c; }
+
+    let str3_s c r1 r2 r3 k =
+      let memo = sprintf "%s%s" "str" (pp_cond c) in
+      { empty_ins with
+        memo = sprintf "%s ^i0,[^i1,^i2, lsl #%i]" memo k ;
+        inputs = [r1;r2;r3] ;
+        outputs = [] ; cond=is_cond c; }
+
 
     let strex  c r1 r2 r3 =
       let memo = sprintf "%s%s" "strex" (pp_cond c) in
@@ -320,10 +335,12 @@ module Make(V:Constant.S)(C:Config) =
     | I_LDREX (r1, r2) ->  ldrex r1 r2::k
     | I_LDAEX (r1, r2) ->  ldaex r1 r2::k
     | I_LDR3 (r1, r2, r3, c) ->  ldr3 c r1 r2 r3::k
+    | I_LDR3_S (r1, r2, r3, S_LSL k2,c) ->  ldr3_s r1 r2 r3 k2 c::k
     | I_STR (r1, r2, c) ->  str2 c r1 r2::k
     | I_STL (r1, r2, c) ->  stl "STL" c r1 r2::k
     | I_STLEX (r1, r2, r3) ->  stlex r1 r2 r3::k
     | I_STR3 (r1, r2, r3, c) ->  str3 c r1 r2 r3::k
+    | I_STR3_S (r1, r2, r3, S_LSL k2, c) ->  str3_s c r1 r2 r3 k2::k
     | I_STREX (r1, r2, r3, c) ->  strex c r1 r2 r3::k
 (* Comparisons and branches *)
     | I_CMPI (r1, i) -> cmpi r1 i::k

--- a/litmus/ARMCompile_litmus.ml
+++ b/litmus/ARMCompile_litmus.ml
@@ -91,15 +91,15 @@ module Make(V:Constant.S)(C:Config) =
         inputs = [] ;
         outputs = [r1]; cond=is_cond c; }
 
-    let movw r1 i =
-      let memo = "movw" in
+    let movw c r1 i =
+      let memo = sprintf "movw%s" (pp_cond c) in
       { empty_ins with
         memo = sprintf "%s ^o0,#%i" memo i ;
         inputs = [] ;
         outputs = [r1]; }
 
-    let movt r1 i =
-      let memo = "movt" in
+    let movt c r1 i =
+      let memo = sprintf "movt%s" (pp_cond c) in
       { empty_ins with
         memo = sprintf "%s ^o0,#%i" memo i ;
         inputs = [r1] ;
@@ -331,8 +331,8 @@ module Make(V:Constant.S)(C:Config) =
     | I_XOR (s,r1, r2, r3) -> op3regs "eor" s AL r1 r2 r3::k
 (* Moves *)
     | I_MOVI (r, i, c) -> movi c r i::k
-    | I_MOVW (r, i) -> movw r i::k
-    | I_MOVT (r, i) -> movt r i::k
+    | I_MOVW (r, i, c) -> movw c r i::k
+    | I_MOVT (r, i, c) -> movt c r i::k
     | I_MOV (r1,r2, c) -> mov c r1 r2::k
 (* Memory *)
     | I_LDR (r1, r2, c) ->  ldr2 c r1 r2::k


### PR DESCRIPTION
This patch adds new instructions including:
- LDR/STR Barrel shifter
- ARM Push/POP + FP Register
- ANDEQ
- MOVWEQ MOVTEQ

Tests are provided and tested on a Raspberry Pi2. This patch set is ready to go 
