### PR TITLE
[RISCV]: Add support for RISCV instructions

### DIFF
--- a/gen/RISCVArch_gen.ml
+++ b/gen/RISCVArch_gen.ml
@@ -166,22 +166,27 @@ module Make
 
    let compare_fence = barrier_compare
 
-   let default = Fence (RW,RW)
+   let default = Fence (IORW,IORW)
    let strong = default
 
    let pp_fence f = Misc.capitalize (pp_barrier_dot f)
 
+   let add_iorw fold f k = fold f k |> f (Fence (IORW,IORW))
+
+   let do_fold_fence f = add_iorw do_fold_fence f
+   and fold_barrier f = add_iorw fold_barrier f
+   
    let fold_cumul_fences f k = do_fold_fence f k
    let fold_all_fences f k = fold_barrier f k
    let fold_some_fences = fold_all_fences
 
    let applies r d = match r,d with
-   | RW,_
-   | R,Code.R
-   | W,Code.W
+   | (IORW|RW),_
+   | (IR|R),Code.R
+   | (OW|W),Code.W
      -> true
-   | W,Code.R
-   | R,Code.W
+   | (W|OW),Code.R
+   | (R|IR),Code.W
      -> false
    | _ -> assert false
 

--- a/herd/tests/instructions/RISCV/A001.litmus
+++ b/herd/tests/instructions/RISCV/A001.litmus
@@ -1,0 +1,9 @@
+RISCV A001
+
+(*Test NOP instr *)
+{ x=0 }
+
+P0;
+nop;
+
+forall (x=0)

--- a/herd/tests/instructions/RISCV/A001.litmus.expected
+++ b/herd/tests/instructions/RISCV/A001.litmus.expected
@@ -1,0 +1,10 @@
+Test A001 Required
+States 1
+[x]=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall ([x]=0)
+Observation A001 Always 1 0
+Hash=c4a3be38342b6b819f0d792f2ec53119
+

--- a/herd/tests/instructions/RISCV/A003.litmus
+++ b/herd/tests/instructions/RISCV/A003.litmus
@@ -1,0 +1,10 @@
+RISCV A003
+
+(* Test SRLI Instruction*)
+
+{ 0:a0 = 4}
+
+P0;
+srli a0, a0, 1;
+
+forall 0:a0 = 2

--- a/herd/tests/instructions/RISCV/A003.litmus.expected
+++ b/herd/tests/instructions/RISCV/A003.litmus.expected
@@ -1,0 +1,10 @@
+Test A003 Required
+States 1
+0:x10=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:x10=2)
+Observation A003 Always 1 0
+Hash=0f76c62e95e0af150e8776b7b0859e14
+

--- a/herd/tests/instructions/RISCV/A004.litmus
+++ b/herd/tests/instructions/RISCV/A004.litmus
@@ -1,0 +1,10 @@
+RISCV A004
+
+(*test MV instruction*)
+{ 0:a1 = 1 }
+
+P0;
+MV a0, a1;
+
+forall 0:a0=1
+

--- a/herd/tests/instructions/RISCV/A004.litmus.expected
+++ b/herd/tests/instructions/RISCV/A004.litmus.expected
@@ -1,0 +1,10 @@
+Test A004 Required
+States 1
+0:x10=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:x10=1)
+Observation A004 Always 1 0
+Hash=e78e73fbb56c1ec96e58fdadbb61f9c0
+

--- a/herd/tests/instructions/RISCV/A005.litmus
+++ b/herd/tests/instructions/RISCV/A005.litmus
@@ -1,0 +1,10 @@
+RISCV A005
+
+(* Test NOP instruction*)
+{}
+
+P0;
+
+NOP;
+
+forall 0:a0=0

--- a/herd/tests/instructions/RISCV/A005.litmus.expected
+++ b/herd/tests/instructions/RISCV/A005.litmus.expected
@@ -1,0 +1,10 @@
+Test A005 Required
+States 1
+0:x10=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:x10=0)
+Observation A005 Always 1 0
+Hash=7dbd8e4fdafc2b299a8e4b02a379dcaa
+

--- a/herd/tests/instructions/RISCV/A006.litmus
+++ b/herd/tests/instructions/RISCV/A006.litmus
@@ -1,0 +1,9 @@
+RISCV A006
+
+(* Test sext.w instruction*)
+{ 0:a1 = 2}
+
+P0;
+sext.w a0, a1;
+
+forall 0:a0=2

--- a/herd/tests/instructions/RISCV/A006.litmus.expected
+++ b/herd/tests/instructions/RISCV/A006.litmus.expected
@@ -1,0 +1,10 @@
+Test A006 Required
+States 1
+0:x10=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:x10=2)
+Observation A006 Always 1 0
+Hash=b34f92984fa6bea21a79bed7c0a0765e
+

--- a/herd/tests/instructions/RISCV/A007.litmus
+++ b/herd/tests/instructions/RISCV/A007.litmus
@@ -1,0 +1,10 @@
+RISCV A007
+
+(* Test AUIPC Instr - not handled like ADRP in AArch64 - emit error *)
+{}
+
+P0;
+auipc a0, 2;
+
+forall 0:a0=1
+

--- a/herd/tests/instructions/RISCV/A007.litmus.expected-failure
+++ b/herd/tests/instructions/RISCV/A007.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/RISCV/A007.litmus": RISCV, instruction 'auipc x10,2' not handled

--- a/herd/tests/instructions/RISCV/A008.litmus
+++ b/herd/tests/instructions/RISCV/A008.litmus
@@ -1,0 +1,10 @@
+RISCV A008
+
+(* Test LUI instruction*)
+{ 0:a0 = 0 }
+
+P0;
+
+lui a0, 1;
+
+forall 0:a0=4096

--- a/herd/tests/instructions/RISCV/A008.litmus.expected
+++ b/herd/tests/instructions/RISCV/A008.litmus.expected
@@ -1,0 +1,10 @@
+Test A008 Required
+States 1
+0:x10=4096;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:x10=4096)
+Observation A008 Always 1 0
+Hash=cbbec4219a033fd342d02870f73a6390
+

--- a/herd/tests/instructions/RISCV/A009.litmus
+++ b/herd/tests/instructions/RISCV/A009.litmus
@@ -1,0 +1,14 @@
+RISCV A009
+
+(* Tests IORW,OW fence args*)
+
+{
+0:x6=x; 0:x8=y;
+1:x6=y; 1:x8=x;
+}
+ P0          | P1          ;
+ ori x5,x0,1 | ori x5,x0,1 ;
+ sw x5,0(x6) | sw x5,0(x6) ;
+ fence iorw,ow  | fence iorw,ow  ;
+ lw x7,0(x8) | lw x7,0(x8) ;
+exists (0:x7=0 /\ 1:x7=0)

--- a/herd/tests/instructions/RISCV/A009.litmus.expected
+++ b/herd/tests/instructions/RISCV/A009.litmus.expected
@@ -1,0 +1,13 @@
+Test A009 Allowed
+States 4
+0:x7=0; 1:x7=0;
+0:x7=0; 1:x7=1;
+0:x7=1; 1:x7=0;
+0:x7=1; 1:x7=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:x7=0 /\ 1:x7=0)
+Observation A009 Sometimes 1 3
+Hash=f95aa1e052d096511627b0dade178336
+

--- a/herd/tests/instructions/RISCV/A010.litmus
+++ b/herd/tests/instructions/RISCV/A010.litmus
@@ -1,0 +1,14 @@
+RISCV A010
+
+(* Test sext.w instruction*)
+{
+int64_t 0:a0;
+int64_t 0:a1 = 1;
+}
+
+P0;
+slli a1,a1,32 ;
+addi a1,a1,-1 ;
+sext.w a0, a1 ;
+
+forall 0:a0=-1

--- a/herd/tests/instructions/RISCV/A010.litmus.expected
+++ b/herd/tests/instructions/RISCV/A010.litmus.expected
@@ -1,0 +1,10 @@
+Test A010 Required
+States 1
+0:x10=-1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:x10=-1)
+Observation A010 Always 1 0
+Hash=daf8cf7d6a66c3e89619f2a337c0b3dd
+

--- a/herd/tests/instructions/RISCV/A05.litmus
+++ b/herd/tests/instructions/RISCV/A05.litmus
@@ -1,0 +1,12 @@
+RISCV A05
+{
+0:x6=x; 0:x8=y;
+1:x6=y; 1:x8=x;
+}
+ P0              | P1          ;
+ ori x5,x0,2     | ori x5,x0,1 ;
+ sw x5,0(x6)     | sw x5,0(x6) ;
+ fence iorw,iorw | fence w,w   ;
+ lw x7,0(x8)     | ori x7,x0,1 ;
+                 | sw x7,0(x8) ;
+~exists ([x]=2 /\ 0:x7=0)

--- a/herd/tests/instructions/RISCV/A05.litmus.expected
+++ b/herd/tests/instructions/RISCV/A05.litmus.expected
@@ -1,0 +1,12 @@
+Test A05 Forbidden
+States 3
+0:x7=0; [x]=1;
+0:x7=1; [x]=1;
+0:x7=1; [x]=2;
+Ok
+Witnesses
+Positive: 3 Negative: 0
+Condition ~exists ([x]=2 /\ 0:x7=0)
+Observation A05 Never 0 3
+Hash=76889daed926cd74375244e972cf9638
+

--- a/lib/RISCVLexer.mll
+++ b/lib/RISCVLexer.mll
@@ -25,12 +25,17 @@ open RISCVParser
   module LU = LexUtils.Make(O)
 
   let check_name = function
+    | "nop" | "NOP" -> NOP
+    | "ret" | "RET" -> RET
+    | "mv" | "MV" -> MV
     | "addi" -> OPI ADDI
     | "slti" -> OPI SLTI
     | "sltiu" -> OPI SLTIU
     | "andi" -> OPI ANDI
     | "ori" -> OPI ORI
     | "li"  -> LI
+    | "la" -> LA
+    | "lui" -> LUI
     | "xori" -> OPI XORI
     | "slli" -> OPI SLLI
     | "srli" -> OPI SRLI
@@ -74,6 +79,8 @@ open RISCVParser
     | "sh" -> STORE (Half,Rlx)
     | "sw" -> STORE (Word,Rlx)
     | "sd"   -> STORE (Double,Rlx)
+
+    | "auipc" -> AUIPC
 
 (* Limited memory order on ordinary load and store *)
     | "lb.aq" -> LOAD (Byte,Signed,Acq)
@@ -190,6 +197,8 @@ open RISCVParser
     | "amomin.d.aq.rl"|"amomin.d.aqrl" ->  AMO (AMOMIN,Double,AcqRel)
     | "amomaxu.d.aq.rl"|"amomaxu.d.aqrl" -> AMO (AMOMAXU,Double,AcqRel)
     | "amominu.d.aq.rl"|"amominu.d.aqrl" ->  AMO (AMOMINU,Double,AcqRel)
+(* Sign extension*)
+    | "sext.w" -> EXT (Signed,Word)
 
 (* Fences *)
 | "fence" -> FENCE

--- a/litmus/RISCVCompile_litmus.ml
+++ b/litmus/RISCVCompile_litmus.ml
@@ -60,6 +60,18 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
         memo = sprintf "%s %s,%s,%i" memo fmt1 fmt2 k ;
         inputs=r2; outputs=r1; }
 
+    let lui r1 k =
+      let fmt1,r1 = tr_1o r1 in
+      { empty_ins with
+        memo = sprintf "lui %s,%i" fmt1 k ;
+        outputs=r1; }
+
+    let op1regsA memo r1 lbl =
+      let fmt1,r1 = tr_1o r1 in
+      { empty_ins with
+        memo = sprintf "%s %s,%s" memo fmt1 lbl ;
+        inputs=[]; outputs=r1; }
+
     let op3regs memo r1 r2 r3 =
       let fmt1,r1 = tr_1o r1
       and fmt2,fmt3,r2r3 = tr_2i r2 r3 in
@@ -67,20 +79,34 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
         memo = sprintf "%s %s,%s,%s" memo fmt1 fmt2 fmt3;
         inputs=r2r3; outputs=r1; }
 
+    let ext memo r1 r2 =
+      let fmt1,r1 = tr_1o r1
+      and fmt2,r2 = tr_1i r2 in
+      { empty_ins with
+        memo = sprintf "%s %s,%s" memo fmt1 fmt2 ;
+        inputs=r2; outputs=r1; }
+
     let emit_loop _ins = assert false
 
     include Handler.No(struct type ins = A.Out.ins end)
 
     let compile_ins tr_lab ins k = match ins with
     | A.INop -> { empty_ins with memo="nop"; }::k
+    | A.Ret -> { empty_ins with memo="ret"; }::k
+    | A.OpI2 (A.LUI,r1,i) ->
+        lui r1 i::k
     | A.OpI (op,r1,r2,i) ->
         op2regsI (A.pp_opi op) r1 r2 i::k
+    | A.OpA (op,r1,lbl) ->
+        op1regsA (A.pp_opa op) r1 lbl::k
     | OpIW (op,r1,r2,i) ->
         op2regsI (A.pp_opiw op) r1 r2 i::k
     | Op (op,r1,r2,r3) ->
         op3regs (A.pp_op op) r1 r2 r3::k
     | OpW (op,r1,r2,r3) ->
         op3regs (A.pp_opw op) r1 r2 r3::k
+    | Ext (_,_,r1,r2) ->
+        ext "sext.w" r1 r2::k
     | J lbl ->
         { empty_ins with
           memo = sprintf "j %s" (A.Out.dump_label (tr_lab lbl));
@@ -114,6 +140,7 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
       { empty_ins with
         memo =  sprintf "%s %s,%s,0(%s)" (A.pp_sc w mo) fmt1 fmt2 fmt3;
         outputs=r1; inputs=r2r3; }::k
+  | AUIPC (_,_) -> Warn.fatal "auipc not Supported in litmus"
   | Amo (op,w,mo,r1,r2,r3) ->
       let fmt1,r1 = tr_1o r1
       and fmt2,fmt3,r2r3 = tr_2i r2 r3 in


### PR DESCRIPTION
This patch adds support for RISCV instructions I have encountered whilst testing compilers. Motivations are in the commits for each one.

Tests are included which all pass in herd, but I do not have RISCV hardware so I cannot test litmus - I am trying to figure out how to run tests on QEMU.