### PR TITLE
[asl] Emit a write event for every global storage declaration

### DIFF
--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -41,6 +41,13 @@ let pp_pos f { pos_start; pos_end; _ } =
         pos_start;
     pp_close_box f ())
 
+let pp_pos_str withpos =
+  let buf = Buffer.create 16 in
+  let fmt =  Format.formatter_of_buffer buf in
+  let () = pp_pos fmt withpos in
+  let () = pp_print_flush fmt () in
+  Buffer.contents buf
+  
 let binop_to_string : binop -> string = function
   | AND -> "AND"
   | BAND -> "&&"

--- a/asllib/PP.mli
+++ b/asllib/PP.mli
@@ -12,6 +12,7 @@ val pp_print_seq : ?pp_sep:unit printer -> 'a printer -> 'a Seq.t printer
 (** Re-exported from stdlib 4.12, print q sequence from its elements. *)
 
 val pp_pos : 'a annotated printer
+val pp_pos_str : 'a annotated -> string
 (** Print a position. *)
 
 (** {1 AST pretty-printers} *)

--- a/herd/tests/instructions/ASL/globals.litmus
+++ b/herd/tests/instructions/ASL/globals.litmus
@@ -1,0 +1,15 @@
+ASL globals
+
+{ }
+
+let b = '11' ;
+var x : integer = 2;
+
+func main() => integer
+begin
+  assert (x == 2);
+  x = 3;
+  x = x+UInt(b);
+  assert (x == 6);  
+  return 0 ;
+end

--- a/herd/tests/instructions/ASL/globals.litmus.expected
+++ b/herd/tests/instructions/ASL/globals.litmus.expected
@@ -1,0 +1,10 @@
+Test globals Required
+States 1
+
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation globals Always 1 0
+Hash=6dcf6dce7ad064b4c82933f04025ef79
+


### PR DESCRIPTION
Before this PR the following test could not be executed:
```
ASL T
{ }

var x : integer = 1;

func main() => integer
begin
  let y = x;
  return 0;
end
```
Executing `herd7 T.litmus` yielded:
```
Contradiction on reg 0:x: 1 vs. 0

Fatal: File "T.litmus" Adios
Fatal error: exception File "herd/mem.ml", line 820, characters 16-22: Assertion failed
```
Namely,  the read event of `x` emitted by the interpreter for executing `let y = x`, of which value is one, could not match the default initial write event of `x`  (value zero).