### PR TITLE
[asl] Have first assignments in ASL version 0 behave as local declarations

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -224,11 +224,13 @@ type local_decl_item =
 (** Statements. Parametric on the type of literals in expressions. *)
 type for_direction = Up | Down
 
+type version = V0 | V1
+
 type stmt_desc =
   | S_Pass
   | S_Then of stmt * stmt
   | S_Decl of local_decl_keyword * local_decl_item * expr option
-  | S_Assign of lexpr * expr
+  | S_Assign of lexpr * expr * version
   | S_Call of identifier * expr list * (identifier * expr) list
   | S_Return of expr option
   | S_Cond of expr * stmt * stmt

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -197,7 +197,7 @@ let rec use_s acc s =
   | S_Pass | S_Return None -> acc
   | S_Then (s1, s2) -> use_s (use_s acc s1) s2
   | S_Assert e | S_Return (Some e) -> use_e acc e
-  | S_Assign (le, e) -> use_le (use_e acc e) le
+  | S_Assign (le, e, _) -> use_le (use_e acc e) le
   | S_Call (x, args, named_args) ->
       let acc = ISet.add x acc in
       let acc = use_fields acc named_args in

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -361,6 +361,16 @@ module Infix = struct
   let ( !$ ) i = expr_of_int i
 end
 
+let lid_of_lexpr =
+  let rec tr le =
+    match le.desc with
+    | LE_Ignore -> LDI_Ignore None
+    | LE_Var x -> LDI_Var (x, None)
+    | LE_TupleUnpack les ->
+       LDI_Tuple (List.map tr les,None)
+    | _ -> raise Exit  in
+  fun le -> try Some (tr le) with Exit -> None
+
 let expr_of_lexpr : lexpr -> expr =
   let rec aux le =
     match le.desc with

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -160,8 +160,12 @@ val bitwidth_equal :
 val scope_equal : scope -> scope -> bool
 val scope_compare : scope -> scope -> int
 
-val expr_of_lexpr : lexpr -> expr
 (** {1 Transformers} *)
+
+val lid_of_lexpr : lexpr -> local_decl_item option
+
+val expr_of_lexpr : lexpr -> expr
+
 
 val case_to_conds : stmt -> stmt
 val slice_as_single : slice -> expr

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -223,7 +223,7 @@ let rec pp_stmt f s =
   match s.desc with
   | S_Pass -> pp_print_string f "pass;"
   | S_Then (s1, s2) -> fprintf f "%a@ %a" pp_stmt s1 pp_stmt s2
-  | S_Assign (le, e) -> fprintf f "@[<h 2>%a =@ %a;@]" pp_lexpr le pp_expr e
+  | S_Assign (le, e, _) -> fprintf f "@[<h 2>%a =@ %a;@]" pp_lexpr le pp_expr e
   | S_Call (name, args, _) ->
       fprintf f "@[<hov 2>%s(%a);@]" name pp_expr_list args
   | S_Return (Some e) -> fprintf f "return %a;" pp_expr e

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -438,7 +438,7 @@ let storage_keyword ==
 let pass == { S_Pass }
 let unimplemented_stmt(x) == x ; pass
 
-let assign(x, y) == ~=x ; EQ ; ~=y ; <S_Assign>
+let assign(x, y) == ~=x ; EQ ; ~=y ; { S_Assign (x,y,V1) }
 
 let direction == | TO; { AST.Up } | DOWNTO; { AST.Down }
 
@@ -467,7 +467,8 @@ let stmt ==
       | RETURN; ~=ioption(expr);                             < S_Return >
       | x=IDENTIFIER; args=plist(expr); ~=nargs;             < S_Call   >
       | ASSERT; e=expr;                                      < S_Assert >
-      | ~=lexpr; EQ; ~=expr;                                 < S_Assign >
+      | le=lexpr; EQ; e=expr;
+          {  S_Assign (le,e,V1) }
       | ~=local_decl_keyword; ~=decl_item; EQ; ~=some(expr); < S_Decl   >
       | VAR; ldi=decl_item; e=ioption(EQ; expr);             { S_Decl (LDK_Var, ldi, e) }
       | REPEAT; ~=stmt_list; UNTIL; ~=expr;                  < S_Repeat >

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -506,7 +506,7 @@ let simple_stmt ==
 let assignment_stmt ==
   annotated (
     terminated_by(SEMICOLON,
-      | ~=lexpr; EQ; ~=expr; < AST.S_Assign >
+      | le=lexpr; EQ; e=expr; { AST.S_Assign (le,e,V0) }
       | ldi=typed_le_ldi; EQ; ~=expr;
         { AST.(S_Decl (LDK_Var, ldi, Some expr)) }
       | CONSTANT; ldi=typed_le_ldi; EQ; ~=expr;

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -214,7 +214,7 @@ let rec pp_stmt =
   let pp_desc f = function
     | S_Pass -> addb f "SPass"
     | S_Then (s1, s2) -> bprintf f "S_Then (%a, %a)" pp_stmt s1 pp_stmt s2
-    | S_Assign (le, e) -> bprintf f "S_Assign (%a, %a)" pp_lexpr le pp_expr e
+    | S_Assign (le, e, _v) -> bprintf f "S_Assign (%a, %a)" pp_lexpr le pp_expr e
     | S_Call (name, args, named_args) ->
         bprintf f "S_Call (%S, %a, %a)" name pp_expr_list args
           (pp_id_assoc pp_expr) named_args

--- a/asllib/StaticEnv.ml
+++ b/asllib/StaticEnv.ml
@@ -190,3 +190,9 @@ let add_subtype s t env =
     env with
     global = { env.global with subtypes = IMap.add s t env.global.subtypes };
   }
+
+let is_undefined name env =
+  not
+    (IMap.mem name env.local.storage_types
+     ||IMap.mem name env.global.storage_types)
+

--- a/asllib/StaticEnv.mli
+++ b/asllib/StaticEnv.mli
@@ -48,3 +48,4 @@ val add_type : identifier -> ty -> env -> env
 val add_global_constant : identifier -> literal -> env -> env
 val add_local : identifier -> ty -> local_decl_keyword -> env -> env
 val add_subtype : identifier -> identifier -> env -> env
+val is_undefined : identifier -> env -> bool

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1020,6 +1020,8 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
         (T_Bool |> here, E_Pattern (e', patterns) |> here)
     | E_GetArray _ -> assert false
 
+  exception Undef
+
   let rec annotate_lexpr env le t_e =
     let () =
       if false then
@@ -1242,7 +1244,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
         let s1, env = try_annotate_stmt env return_type s1 in
         let s2, env = try_annotate_stmt env return_type s2 in
         (S_Then (s1, s2) |> here, env)
-    | S_Assign (le, e) -> (
+    | S_Assign (le, e, ver) -> (
         let () =
           if false then
             Format.eprintf
@@ -1256,7 +1258,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
         | Some s -> (s, env)
         | None ->
             let le = annotate_lexpr env le t_e in
-            (S_Assign (le, e) |> here, env))
+            (S_Assign (le, e, ver) |> here, env))
     | S_Call (name, args, eqs) ->
         let name, args, eqs, ty =
           annotate_call (to_pos s) env name args eqs ST_Procedure
@@ -1426,9 +1428,9 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
       | None -> None
       | Some s ->
           let s1, _env1 =
-            S_Assign (le_x, to_expr sub_le) |> here |> annotate_stmt env None
+            S_Assign (le_x, to_expr sub_le,V1) |> here |> annotate_stmt env None
           and s2, _env2 =
-            S_Assign (old_le le_x, e) |> here |> annotate_stmt env None
+            S_Assign (old_le le_x, e,V1) |> here |> annotate_stmt env None
           in
           Some (s_then (s_then s1 s2) s)
     in

--- a/asllib/tests/asl/required/assign-v0.asl
+++ b/asllib/tests/asl/required/assign-v0.asl
@@ -1,0 +1,5 @@
+integer main()
+  x = 1;
+  (y,z) = (2,3);
+  assert x+y+z == 6;
+  return 0;

--- a/asllib/tests/asl/required/typing-assign-v0.asl
+++ b/asllib/tests/asl/required/typing-assign-v0.asl
@@ -1,0 +1,9 @@
+bits(N+N) Dup(bits(N) b)
+  return b : b;
+
+
+integer main()
+  x = 2;
+  b = Dup(Ones(x));
+  assert b == '1111';
+  return 0;

--- a/asllib/tests/asltests.ml
+++ b/asllib/tests/asltests.ml
@@ -5,8 +5,9 @@ let _dbg = false
 
 let process_test path () =
   let () = if _dbg then Format.eprintf "Processing %s: @." path in
-  let ast = build_ast_from_file path |> ASTUtils.no_primitive in
-
+  let ast,ver =
+    build_ast_from_file path |>
+    fun (ast,ver) -> ASTUtils.no_primitive ast,ver in
   (* First interprete it. *)
   let () = if _dbg then Format.eprintf "@[AST: %a@]@." PP.pp_t ast in
   let i, _ = Native.interprete `TypeCheck ast in
@@ -14,14 +15,18 @@ let process_test path () =
   let () = if _dbg then Format.eprintf "Ran successfully.@.@." in
 
   (* Then ensure that printed version is understandable by the parser. *)
-  let printed = PP.t_to_string ast in
-  let () = if false then Printf.eprintf "Printed:\n%s\n%!" printed in
-  let lexbuf = Lexing.from_string printed in
-  let ast = Parser.ast Lexer.token lexbuf |> ASTUtils.no_primitive in
-  let i, _ = Native.interprete `TypeCheck ast in
-  let () = assert (i = 0) in
-
-  ()
+  begin
+    match ver with
+    | `ASLv1 -> (* V1 only *)
+       let printed = PP.t_to_string ast in
+       let () = if false then Printf.eprintf "Printed:\n%s\n%!" printed in
+       let lexbuf = Lexing.from_string printed in
+       let ast = Parser.ast Lexer.token lexbuf |> ASTUtils.no_primitive in
+       let i, _ = Native.interprete `TypeCheck ast in
+       let () = assert (i = 0) in
+       ()
+    | _ -> ()
+  end
 
 let tests testdir =
   let process_filename filename =

--- a/asllib/tests/helpers.ml
+++ b/asllib/tests/helpers.ml
@@ -31,6 +31,11 @@ let exec_tests =
 let build_ast_from_file filename =
   match Builder.from_file_result `ASLv1 filename with
   | Error e ->
-      Format.eprintf "%a@." Error.pp_error e;
-      Error.fatal e
-  | Ok ast -> ast
+     begin
+       match Builder.from_file_result `ASLv0 filename with
+       | Ok ast -> ast,`ASLv0
+       | Error _ ->
+          Format.eprintf "%a@." Error.pp_error e;
+          Error.fatal e
+     end
+  | Ok ast -> ast,`ASLv1


### PR DESCRIPTION
In version V0, variable declaration is optional, this has consequences:
       + Typing is partial and some function calls may not get all their extra parameters.
       + Interpretation fails on first assignments of undeclared variables, flagging an "Undefined variable" error.

Fix this by considering first assignments of undeclared variables as declarations of (mutable) variables.

