### PR TITLE
[litmus] Accept `-variant vmsa`

### DIFF
--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -228,8 +228,13 @@ end = struct
           Warn.user_error
             "variant %s does not apply to arch %s"
             (Variant_litmus.pp v)
-            (Archs.pp a)
-
+            (Archs.pp a) ;
+        let v = Variant_litmus.Vmsa in
+        if O.variant v && O.mode != Mode.Kvm then
+          Warn.user_error
+            "(optional) variant %s not compatible with mode %s"
+            (Variant_litmus.pp v)
+            (Mode.pp O.mode)
 
       let limit_ok nprocs = match O.avail with
         | None|Some 0 -> true

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -19,15 +19,17 @@ type t =
   | Precise of Precision.t
   | S128 (* 128 bit signed ints*)
   | Mixed (* Ignored *)
+  | Vmsa  (* Checked *)
 
 let compare = compare
 
-let tags = "s128"::"self"::"mixed"::Precision.tags
+let tags = "s128"::"self"::"mixed"::"vmsa"::Precision.tags
 
 let parse s = match Misc.lowercase s with
 | "s128" -> Some S128
 | "self" -> Some Self
 | "mixed" -> Some Mixed
+| "vmsa"|"kvm" -> Some Vmsa
 | tag ->
    Misc.app_opt (fun p -> Precise p) (Precision.parse tag)
 
@@ -35,6 +37,7 @@ let pp = function
   | Self -> "self"
   | Mixed -> "mixed"
   | S128 -> "s128"
+  | Vmsa -> "vmsa"
   | Precise p -> Precision.pp p
 
 let ok v a = match v,a with

--- a/litmus/variant_litmus.mli
+++ b/litmus/variant_litmus.mli
@@ -19,6 +19,7 @@ type t =
   | Precise of Precision.t
   | S128 (* 128 bit signed ints*)
   | Mixed (* Ignored *)
+  | Vmsa  (* Checked *)
 
 val tags : string list
 val parse : string -> t option


### PR DESCRIPTION
The one effect is checking that option `-mode kvm` is given.