### PR TITLE
[asl] DEBUG statement

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -245,6 +245,7 @@ type stmt_desc =
           represent the implicit throw, such as [throw;]. *)
   | S_Try of stmt * catcher list * stmt option
       (** The stmt option is the optional otherwise guard. *)
+  | S_Debug of expr
 
 and stmt = stmt_desc annotated
 and case_alt = (pattern * stmt) annotated

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -213,6 +213,7 @@ let rec use_s acc s =
   | S_Try (s, catchers, None) -> use_catchers (use_s acc s) catchers
   | S_Try (s, catchers, Some s') ->
       use_catchers (use_s (use_s acc s') s) catchers
+  | S_Debug e -> use_e acc e
 
 and use_case acc { desc = _p, stmt; _ } = use_s acc stmt
 and use_le acc _le = acc

--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -726,6 +726,12 @@ module Make (B : Backend.S) (C : Config) = struct
     | S_Decl (_dlk, ldi, None) ->
         let**| env = eval_local_decl s ldi env None in
         continue env
+    | S_Debug e ->
+        let* v = eval_expr_sef env e in
+        let () =
+          Format.eprintf "@[@<2>%a:@ @[%a@]@ ->@ %s@]@."
+            PP.pp_pos e PP.pp_expr e (B.debug_value v) in
+        continue env
 
   and eval_block env stm =
     let block_env = IEnv.push_scope env in

--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -39,6 +39,7 @@ let tr_name s = match s with
 | "catch"         -> CATCH
 | "config"        -> CONFIG
 | "constant"      -> CONSTANT
+| "debug"|"DEBUG" -> DEBUG
 | "DIV"           -> DIV
 | "do"            -> DO
 | "downto"        -> DOWNTO

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -279,6 +279,7 @@ let rec pp_stmt f s =
       fprintf f "@[<2>try@ %a@ catch@ @[<v 2>%a@]@ end@]" pp_stmt s
         (pp_print_list ~pp_sep:pp_print_space pp_catcher)
         catchers
+  | S_Debug e -> fprintf f "@[<2>debug@ %a;@]" pp_expr e
 
 and pp_catcher f (name, ty, s) =
   match name with

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -65,7 +65,8 @@ let make_ldi_tuple xs ty =
   ------------------------------------------------------------------------- *)
 
 %token AND ARRAY ARROW AS ASSERT BAND BEGIN BEQ BIT BITS BNOT BOOLEAN BOR CASE
-%token CATCH COLON COLON_COLON COMMA CONCAT CONFIG CONSTANT DIV DO DOT DOWNTO
+%token CATCH COLON COLON_COLON COMMA CONCAT CONFIG CONSTANT
+%token DEBUG DIV DO DOT DOWNTO
 %token ELSE ELSIF END ENUMERATION EOF EOR EQ EQ_OP EXCEPTION FOR FUNC GEQ
 %token GETTER GT IF IMPL IN INTEGER LBRACE LBRACKET LEQ LET LPAR LT MINUS MOD
 %token MUL NEQ NOT OF OR OTHERWISE PASS PLUS PLUS_COLON POW PRAGMA RBRACE
@@ -467,6 +468,7 @@ let stmt ==
       | RETURN; ~=ioption(expr);                             < S_Return >
       | x=IDENTIFIER; args=plist(expr); ~=nargs;             < S_Call   >
       | ASSERT; e=expr;                                      < S_Assert >
+      | DEBUG; e=expr;                                       < S_Debug >
       | le=lexpr; EQ; e=expr;
           {  S_Assign (le,e,V1) }
       | ~=local_decl_keyword; ~=decl_item; EQ; ~=some(expr); < S_Decl   >

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -52,6 +52,7 @@
 %token COMMA
 %token CONSTANT
 %token CONSTRAINED_UNPRED
+%token DEBUG
 %token DEDENT
 %token DIV
 %token DO
@@ -489,6 +490,7 @@ let simple_stmt ==
     | ~=qualident; ~=pared(clist(expr)); ~=nargs; < AST.S_Call >
     | RETURN; ~=ioption(expr);                    < AST.S_Return >
     | ASSERT; ~=expr;                             < AST.S_Assert >
+    | DEBUG; ~=expr;                              < AST.S_Debug >
 
     | unimplemented_stmts (
       | UNPREDICTABLE; ioption(pared(<>)); <>

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -242,6 +242,7 @@ let rec pp_stmt =
     | S_Try (s, catchers, otherwise) ->
         bprintf f "S_Try (%a, %a, %a)" pp_stmt s (pp_list pp_catcher) catchers
           (pp_option pp_stmt) otherwise
+    | S_Debug _ -> ()
   in
   fun f s -> pp_annotated pp_desc f s
 

--- a/asllib/SimpleLexer0.mll
+++ b/asllib/SimpleLexer0.mll
@@ -62,6 +62,7 @@ let names_to_tokens = [
   ( "case", CASE );
   ( "catch", CATCH );
   ( "constant", CONSTANT );
+  ( "DEBUG", DEBUG );
   ( "do", DO );
   ( "downto", DOWNTO );
   ( "else", ELSE );
@@ -109,6 +110,7 @@ let string_of_token = function
   | CATCH -> "catch"
   | CONSTANT -> "constant"
   | CONSTRAINED_UNPRED -> "CONSTRAINED_UNPREDICTABLE"
+  | DEBUG -> "DEBUG"
   | DIV -> "DIV"
   | DO -> "do"
   | DOWNTO -> "downto"

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1433,6 +1433,9 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
         in
         let catchers = List.map (annotate_catcher env return_type) catchers in
         (S_Try (s', catchers, otherwise) |> here, env)
+    | S_Debug e ->
+       let _t_e, e = annotate_expr env e in
+       (S_Debug e |> here, env)
 
   and annotate_catcher env return_type (name_opt, ty, stmt) =
     let+ () = check_structure_exception ty env ty in


### PR DESCRIPTION
`DEBUG e;` prints the value of `e` to standard error.

One can use keyword `debug`  in ASLv1.