### PR TITLE
[asl] Fix bitvector concatenation

### DIFF
--- a/asllib/tests/asl/required/concat01.asl
+++ b/asllib/tests/asl/required/concat01.asl
@@ -1,0 +1,21 @@
+func main() => integer
+begin
+  let o13 = Ones(13);
+  let o26 = [o13,o13];
+  assert o26 =='11111111111111111111111111';
+  let o5 = Ones(5);
+  let o11 = Ones(11);
+  let o16 = [o5,o11];
+  let p16 = [o11,o5];
+  assert o16 == p16;
+  let o15 = Ones(15);
+  let o20 = [o5,o15];
+  let p20 = [o15,o5];
+  assert o20 == p20;
+  let o8 = Ones(8);
+  let o6 = Ones(6);
+  let o14 = [o8,o6];
+  let p14 = [o6,o8];
+  assert o14 == p14;
+return 0;
+end

--- a/asllib/tests/asl/required/concat02.asl
+++ b/asllib/tests/asl/required/concat02.asl
@@ -1,0 +1,14 @@
+func main() => integer
+begin
+  let a = '01';
+  let b = '10';
+  let a5 = ['1',a,a];
+  let b14 = Replicate(b,7);
+  let b15 = ['0',b14];
+  let x20 = [b15,a5];
+  let a15 = ['1',Replicate(a,7)];
+  let b5 = ['0',b,b];
+  let y20 = [b5,a15];
+  assert x20 == y20;
+  return 0;
+end

--- a/asllib/tests/asl/required/concat03.asl
+++ b/asllib/tests/asl/required/concat03.asl
@@ -1,0 +1,8 @@
+func main() => integer
+begin
+  let a =  '11110000';
+  let b = '101';
+  let c = [a,b];
+  assert c == '11110000101';
+  return 0;
+end


### PR DESCRIPTION
Tests `concat01.asl` and `concat02.asl` were failing. Test `concat03.asl` was failing during development .

Tests are in `directory asllib/tests/asl/required/`