### PR TITLE
[asl,herd] Fix  the ADD/SUB immediate instructions implementation

### DIFF
--- a/herd/tests/instructions/AArch64.ASL/ADD01.litmus
+++ b/herd/tests/instructions/AArch64.ASL/ADD01.litmus
@@ -1,0 +1,10 @@
+AArch64 ADD01
+{
+0:X0=1;
+}
+  P0                ;
+ ADD W0,W0,#4095    ;
+ ADD W0,W0,#-4095   ;
+ ADD W0,W0,#1, LSL 12 ;
+ ADD W0,W0,#-1, LSL 12 ;
+forall 0:X0=1

--- a/herd/tests/instructions/AArch64.ASL/ADD01.litmus.expected
+++ b/herd/tests/instructions/AArch64.ASL/ADD01.litmus.expected
@@ -1,0 +1,10 @@
+Test ADD01 Required
+States 1
+0:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=1)
+Observation ADD01 Always 1 0
+Hash=2b82c69a7a95ea648ec61463afa60141
+

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1981,7 +1981,7 @@ let get_next =
 (* Check instruction validity, beyond parsing *)
 let mask12 = (1 lsl 12)-1
 
-let is_12bits k = k land mask12 = k
+let is_12bits_unsigned k = k land mask12 = k
 
 let is_valid i =
   match i with
@@ -1989,7 +1989,13 @@ let is_valid i =
   | I_OP3 (_,(ADD|SUB),ZR,_,K _,_)
     -> false
   | I_OP3 (_,(ADD|SUB|ADDS|SUBS),_,_,K k,(S_NOEXT|S_LSL (0|12)))
-    -> is_12bits (abs k)
+    ->
+(*
+ * Using either ADD or SUB the immediate constant size is 12 bits
+ *  unsigned + sign. In other words, sign is implemented by selecting
+ *  the adequate  instruction and the immediate constant is unsigned.
+ *)
+     is_12bits_unsigned (abs k)
   | I_OP3 (_,(ADD|SUB|ADDS|SUBS),_,_,K _,_)
     -> false
   | _ -> true

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1527,6 +1527,8 @@ let dump_parsedInstruction =
     {  compat = false; pp_k = MetaConst.pp_prefix "#";
        zerop = (fun k -> MetaConst.compare MetaConst.zero k = 0);
        k0 = K MetaConst.zero; }
+
+
 end
 
 (****************************)
@@ -1975,6 +1977,24 @@ let get_next =
   | I_EOR_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
   | I_LDXP _|I_STXP _|I_UDF _
     -> [Label.Next;]
+
+(* Check instruction validity, beyond parsing *)
+let mask12 = (1 lsl 12)-1
+
+let is_12bits k = k land mask12 = k
+
+let is_valid i =
+  match i with
+  | I_OP3 (_,(ADD|SUB|ADDS|SUBS),_,ZR,K _,_)
+  | I_OP3 (_,(ADD|SUB),ZR,_,K _,_)
+    -> false
+  | I_OP3 (_,(ADD|SUB|ADDS|SUBS),_,_,K k,(S_NOEXT|S_LSL (0|12)))
+    -> is_12bits (abs k)
+  | I_OP3 (_,(ADD|SUB|ADDS|SUBS),_,_,K _,_)
+    -> false
+  | _ -> true
+
+
 
 module PseudoI = struct
       type ins = instruction

--- a/lib/ARMBase.ml
+++ b/lib/ARMBase.ml
@@ -545,6 +545,8 @@ let get_next = function
   | I_BX _ -> [Label.Any]
   | I_BEQ lbl|I_BNE lbl|I_CB (_,_,lbl) -> [Label.Next; Label.To lbl]
 
+let is_valid _ = true
+
 include Pseudo.Make
     (struct
       type ins = instruction

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -131,6 +131,8 @@ let map_addrs _ i = i
 let norm_ins i = i
 let get_next _ = assert false
 
+let is_valid _ = true
+
 include Pseudo.Make (struct
   type ins = instruction
   type pins = parsedInstruction

--- a/lib/BellBase.ml
+++ b/lib/BellBase.ml
@@ -227,6 +227,8 @@ let do_dump_instruction pk i = match i with
 
 let dump_instruction i = do_dump_instruction (sprintf "%i") i
 
+let is_valid _ = true
+
 include Pseudo.Make
     (struct
       type ins = instruction

--- a/lib/CBase.ml
+++ b/lib/CBase.ml
@@ -242,6 +242,8 @@ let map_addrs _f ins = ins
 let norm_ins ins = ins
 let get_next _ins = Warn.fatal "C get_next not implemented"
 
+let is_valid _ = true
+
 include Pseudo.Make
     (struct
       type ins = instruction

--- a/lib/JavaBase.ml
+++ b/lib/JavaBase.ml
@@ -168,6 +168,8 @@ let map_addrs _f ins              = ins
 let norm_ins ins                  = ins
 let get_next _ins                 = Warn.fatal "Java get_next not implemented"
 
+let is_valid _ = true
+
 include Pseudo.Make
   (struct
     type ins      = instruction

--- a/lib/MIPSBase.ml
+++ b/lib/MIPSBase.ml
@@ -348,6 +348,8 @@ let get_next = function
   | B lbl -> [Label.To lbl]
   | BC (_,_,_,lbl)|BCZ (_,_,lbl) -> [Label.Next; Label.To lbl;]
 
+let is_valid _ = true
+
 include Pseudo.Make
     (struct
       type ins = instruction

--- a/lib/PPCBase.ml
+++ b/lib/PPCBase.ml
@@ -663,8 +663,7 @@ let get_next = function
   |Pblr|Pmtlr _|Pmflr _|Pmfcr _ -> []
 
 
-(* Macros *)
-
+let is_valid _ = true
 
 include Pseudo.Make
     (struct

--- a/lib/RISCVBase.ml
+++ b/lib/RISCVBase.ml
@@ -430,6 +430,8 @@ let get_next = function
   | StoreConditional (_, _, _, _, _)|FenceIns _|Amo _
     -> [Label.Next;]
 
+let is_valid _ = true
+
 include Pseudo.Make
     (struct
       type ins = instruction

--- a/lib/X86Base.ml
+++ b/lib/X86Base.ml
@@ -544,6 +544,8 @@ let rec get_next = function
   | I_JMP lbl-> [Label.To lbl]
   | I_JCC (_,lbl) -> [Label.Next; Label.To lbl]
 
+let is_valid _ = true
+
 include Pseudo.Make
     (struct
       type ins = instruction

--- a/lib/X86_64Base.ml
+++ b/lib/X86_64Base.ml
@@ -682,6 +682,8 @@ let rec get_next = function
     | I_JCC (_,lbl) -> [Label.Next; Label.To lbl]
     | I_LOCK ins -> get_next ins
 
+let is_valid _ = true
+
 include Pseudo.Make
           (struct
             type ins = instruction

--- a/lib/archBase.mli
+++ b/lib/archBase.mli
@@ -78,6 +78,8 @@ module type S = sig
   (* Normalize instruction (for hashes) *)
   val norm_ins : instruction -> instruction
 
+  (* Check validity of instructions, beyond parsing *)
+  val is_valid : instruction -> bool
 
   include Pseudo.S
    with type ins = instruction

--- a/lib/genParser.ml
+++ b/lib/genParser.ml
@@ -122,9 +122,16 @@ module Make
       List.map (fun (p,code) -> p,expn code)
 
 (* Translation from parsed instruction to internal ones *)
+    let check_and_tr p =
+      let p = A.pseudo_parsed_tr p in
+      if A.pseudo_exists (fun p -> not (A.is_valid p)) p then
+        Warn.user_error "Illegal instruction '%s'"
+          (A.pseudo_dump A.dump_instruction p)
+      else p
+
     let parsed_tr prog =
       List.map
-        (List.map A.pseudo_parsed_tr)
+        (List.map check_and_tr)
         prog
 
 (***********)

--- a/lib/pseudo.ml
+++ b/lib/pseudo.ml
@@ -46,6 +46,8 @@ module type S = sig
 (* Lifting of fold/map *)
   val pseudo_map : ('a -> 'b) -> 'a kpseudo -> 'b kpseudo
   val pseudo_fold : ('a -> 'b -> 'a) -> 'a -> 'b kpseudo -> 'a
+  val pseudo_exists : ('a -> bool) -> 'a kpseudo -> bool
+  val pseudo_dump : ('a -> string) -> 'a kpseudo -> string
   val pseudo_iter : ('a -> unit) -> 'a kpseudo -> unit
 
 (* Fold over instructions in code *)
@@ -150,6 +152,7 @@ struct
     | Macro (_,_) -> assert false
 
   let pseudo_exists p = pseudo_fold (fun b i -> b || p i) false
+  let pseudo_dump dump = pseudo_fold (fun  _ i -> dump i) ""
   let pseudo_iter f ins = pseudo_fold (fun () ins -> f ins) () ins
 
   let fold_pseudo_code f = List.fold_left (pseudo_fold f)


### PR DESCRIPTION
This PR introduces a call to the  `A.is_valid` function just after test parsing, thereby providing the ability to check instructions beyond syntactic correctness early. For instance `ADD W0,WZR,#1` is illegal and is checked that way.

 + Instruction with negative constants are aliases. For instance,   `ADD W0,W0,#-1` is executed as `SUB W0,W0,#1`.
  + Using register `ZR` in some positions is not possible, as the encoded instruction reserve this place for the stack pointer. For instance `ADD W0,WZR,#1` is in fact illegal, was executed as `ADD W0,SP,#1` and was working by miracle.