### PR TITLE
[all]: Add Support for PowerPC instructions, tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,16 @@ test::
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64 C instructions tests: OK"
 
+test:: test-ppc
+test-ppc:
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/PPC \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 PPC instructions tests: OK"
+
 test:: test-asl
 test-asl:
 	@ echo

--- a/herd/PPCArch_herd.ml
+++ b/herd/PPCArch_herd.ml
@@ -61,16 +61,18 @@ module Make (C:Arch_herd.Config) (V:Value.S)
       | Pnop
       | Padd _ | Psub _ | Psubf _ | Por _
       | Pand _ | Pxor _ | Pmull _ | Pdiv _
-      | Paddi _ | Pori _ | Pandi _ | Pxori _ | Pmulli _
-      | Pli _ | Pb _ | Pbcc _ | Pcmpwi _ | Pcmpw _
+      | Paddi _ | Paddis _ | Pori _ | Pandi _ | Pxori _ | Pmulli _
+      | Prlwinm _ | Prlwimi _ | Pclrldi _
+      | Pli _ | Pb _ | Pbcc _ | Pcmpwi _ | Pcmpw _ | Plis _
       | Pmr _ | Psync | Peieio | Pisync | Plwsync
+      | Pcmplwi _ | Pextsw _
       | Pdcbf _ | Pblr | Pnor _ | Pneg _ | Pslw _
       | Psrawi _| Psraw _ | Pbl _ | Pmtlr _ | Pmflr _ | Pmfcr _
       | Plmw  _ | Pstmw _ | Pcomment _
         -> None
-      | Plwzu _ | Pstwu _ | Plwarx _ | Pstwcx _
+      | Plwzu _ | Plwa _ | Pstwu _ | Plwarx _ | Pstwcx _
         -> Some MachSize.Word
-      | Pload (sz,_,_,_) | Ploadx (sz,_,_,_)
+      | Pload (sz,_,_,_) | Ploadx (sz,_,_,_) | Plwax (sz,_,_,_)
       | Pstore (sz,_,_,_) | Pstorex (sz,_,_,_)
         -> Some sz
 

--- a/herd/tests/instructions/PPC/A000.litmus
+++ b/herd/tests/instructions/PPC/A000.litmus
@@ -1,0 +1,9 @@
+PPC A000
+
+(* Test CI works *)
+{}
+
+P0;
+nop;
+
+forall 0:r0 = 0

--- a/herd/tests/instructions/PPC/A000.litmus.expected
+++ b/herd/tests/instructions/PPC/A000.litmus.expected
@@ -1,0 +1,10 @@
+Test A000 Required
+States 1
+0:r0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r0=0)
+Observation A000 Always 1 0
+Hash=9697a8f62bb095c6209ec10f0eb77308
+

--- a/herd/tests/instructions/PPC/A001.litmus
+++ b/herd/tests/instructions/PPC/A001.litmus
@@ -1,0 +1,9 @@
+PPC A001
+
+(* Test LIS instruction *)
+{}
+
+P0;
+  lis r0, 1;
+
+forall 0:r0 = 0x10000

--- a/herd/tests/instructions/PPC/A001.litmus.expected
+++ b/herd/tests/instructions/PPC/A001.litmus.expected
@@ -1,0 +1,10 @@
+Test A001 Required
+States 1
+0:r0=65536;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r0=65536)
+Observation A001 Always 1 0
+Hash=505b36b29a59339a441f482c0294f18a
+

--- a/herd/tests/instructions/PPC/A002.litmus
+++ b/herd/tests/instructions/PPC/A002.litmus
@@ -1,0 +1,20 @@
+PPC A002
+
+(* test hwsync instr *)
+(*****************************************************************)
+(* Compiler:                                                     *)
+(* clang-11 -c -g -O3 -pthread --std=c11 --target=powerpc-linux-gnu*)
+(*****************************************************************)
+{ [P0_r0]=0;[P1_r0]=0;[x]=0;[y]=0;uint64_t %P0_P0_r0=P0_r0;uint64_t %P0_x=x;uint64_t %P0_y=y;uint64_t %P1_P1_r0=P1_r0;uint64_t %P1_x=x;uint64_t %P1_y=y }
+
+  P0                    |  P1                    ;
+   li r4,1              |   li r4,1              ;
+   stw r4,0(%P0_x)      |   stw r4,0(%P1_y)      ;
+   hwsync               |   hwsync               ;
+   lwz r3,0(%P0_y)      |   lwz r3,0(%P1_x)      ;
+   stw r3,0(%P0_P0_r0)  |   stw r3,0(%P1_P1_r0)  ;
+
+
+exists (P0_r0=0 /\ P1_r0=0)
+
+

--- a/herd/tests/instructions/PPC/A002.litmus.expected
+++ b/herd/tests/instructions/PPC/A002.litmus.expected
@@ -1,0 +1,12 @@
+Test A002 Allowed
+States 3
+[P0_r0]=0; [P1_r0]=1;
+[P0_r0]=1; [P1_r0]=0;
+[P0_r0]=1; [P1_r0]=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists ([P0_r0]=0 /\ [P1_r0]=0)
+Observation A002 Never 0 3
+Hash=d94e9aab81affd834e43c4085405e4c8
+

--- a/herd/tests/instructions/PPC/A003.litmus
+++ b/herd/tests/instructions/PPC/A003.litmus
@@ -1,0 +1,9 @@
+PPC A003
+
+(* Test Addis instruction*)
+{ int 0:r0 = 0 }
+
+P0;
+  addis r0, r0, 1;
+
+forall 0:r0 = 65536

--- a/herd/tests/instructions/PPC/A003.litmus.expected
+++ b/herd/tests/instructions/PPC/A003.litmus.expected
@@ -1,0 +1,10 @@
+Test A003 Required
+States 1
+0:r0=65536;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r0=65536)
+Observation A003 Always 1 0
+Hash=2c504c6ee49f6d9ef53d909c6f02bb64
+

--- a/herd/tests/instructions/PPC/A004.litmus
+++ b/herd/tests/instructions/PPC/A004.litmus
@@ -1,0 +1,9 @@
+PPC A004
+
+(* Test NOP *)
+{}
+
+P0;
+nop;
+
+forall 0:r0 = 0

--- a/herd/tests/instructions/PPC/A004.litmus.expected
+++ b/herd/tests/instructions/PPC/A004.litmus.expected
@@ -1,0 +1,10 @@
+Test A004 Required
+States 1
+0:r0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r0=0)
+Observation A004 Always 1 0
+Hash=9697a8f62bb095c6209ec10f0eb77308
+

--- a/herd/tests/instructions/PPC/A005.litmus
+++ b/herd/tests/instructions/PPC/A005.litmus
@@ -1,0 +1,15 @@
+PPC A005
+
+(* Test LWA *)
+{
+   0:r1 = x;
+   x = -1;
+   int64_t 0:r0;
+   int64_t 0:r2;
+}
+P0;
+  lwa r0, 0(r1) ;
+  lwz r2, 0(r1) ;
+
+forall 0:r0 = -1 /\ 0:r2 <> -1
+

--- a/herd/tests/instructions/PPC/A005.litmus.expected
+++ b/herd/tests/instructions/PPC/A005.litmus.expected
@@ -1,0 +1,10 @@
+Test A005 Required
+States 1
+0:r0=-1; 0:r2=4294967295;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r0=-1 /\ not (0:r2=-1))
+Observation A005 Always 1 0
+Hash=3277c7026d4d160c200e872073551105
+

--- a/herd/tests/instructions/PPC/A006.litmus
+++ b/herd/tests/instructions/PPC/A006.litmus
@@ -1,0 +1,12 @@
+PPC A006
+
+(* Test LWAX instruction*)
+{ 0:r0 = 0; 0:r1 = x; uint32_t x = 0xffffffff;
+  int64_t 0:r2;
+  int64_t 0:r3; }
+P0;
+  lwax r2, r0, r1;
+  lwzx r3, r0, r1;
+
+forall 0:r2 = -1 /\ 0:r3 = 0xffffffff
+

--- a/herd/tests/instructions/PPC/A006.litmus.expected
+++ b/herd/tests/instructions/PPC/A006.litmus.expected
@@ -1,0 +1,10 @@
+Test A006 Required
+States 1
+0:r2=-1; 0:r3=4294967295;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r2=-1 /\ 0:r3=4294967295)
+Observation A006 Always 1 0
+Hash=110e6b64a73ded4540e9d15080165799
+

--- a/herd/tests/instructions/PPC/A007.litmus
+++ b/herd/tests/instructions/PPC/A007.litmus
@@ -1,0 +1,33 @@
+PPC A007
+
+Variant=telechat
+
+(* test blr *)
+(*****************************************************************)
+(* Compiler:                                                     *)
+(* powerpc64le-linux-gnu-gcc-10 -c -g -O1 -pthread --std=c11 -ffreestanding -mabi=elfv1 -fno-section-anchors*)
+(*****************************************************************)
+
+{
+  [P0_r0]=0;[P1_r0]=0;[x]=0;[y]=0;
+  0:r0 = x; 0:r1 = y; 0:r2 = P0_r0;
+  1:r0 = y; 1:r1 = x; 1:r2 = P1_r0;
+}
+  P0                    |  P1                     ;
+   hwsync               |   hwsync                ;
+   lwz r9,0(r0)         |   lwz r9,0(r0)          ;
+   cmpw r9,r9           |   cmpw r9,r9            ;
+   b   L0x18            |   b   L0x6c             ;
+  L0x18: isync          |  L0x6c: isync           ;
+   clrldi r9,r9,32      |   extsw r10, r9         ;
+   lwsync               |   cmpwi r9,1            ;
+   hwsync               |   beq  L0x8c            ;
+   li r8,1              |  L0x7c:                 ;
+   stw r8,0(r1)         |   stw r10,0(r2)         ;
+   stw r9,0(r2)         |   blr                ;
+                        |  L0x8c:                 ;
+                        |   li r8,1               ;
+                        |   stw r8,0(r1)          ;
+                        |   b   L0x7c             ;
+
+exists not (P0_r0=1 /\ P1_r0=1)

--- a/herd/tests/instructions/PPC/A007.litmus.expected
+++ b/herd/tests/instructions/PPC/A007.litmus.expected
@@ -1,0 +1,11 @@
+Test A007 Allowed
+States 2
+[P0_r0]=0; [P1_r0]=0;
+[P0_r0]=0; [P1_r0]=1;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition exists (not ([P0_r0]=1 /\ [P1_r0]=1))
+Observation A007 Always 2 0
+Hash=4bbfcab3f0e8578a8c6e2411b8ff4d44
+

--- a/herd/tests/instructions/PPC/A008.litmus
+++ b/herd/tests/instructions/PPC/A008.litmus
@@ -1,0 +1,16 @@
+PPC A008
+
+(* test extsw *)
+{
+int x = -1   ;
+0:r2=x;
+int64_t 0:r0 ;
+0:r1 = -1    ;
+
+}
+
+P0;
+  lwz r1,0(r2) ;
+  extsw r0, r1 ;
+
+forall 0:r0 = -1

--- a/herd/tests/instructions/PPC/A008.litmus.expected
+++ b/herd/tests/instructions/PPC/A008.litmus.expected
@@ -1,0 +1,10 @@
+Test A008 Required
+States 1
+0:r0=-1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r0=-1)
+Observation A008 Always 1 0
+Hash=7b0b324d482e93f41e11de3342bea580
+

--- a/herd/tests/instructions/PPC/A009.litmus
+++ b/herd/tests/instructions/PPC/A009.litmus
@@ -1,0 +1,11 @@
+PPC A009
+
+(* test CLRLDI instr *)
+{ int 0:r11 = 0x0; int 0:r31 = 1; 0:r9 = 1 }
+
+P0;
+  clrldi r11, r31, 32;
+  clrldi r9, r9, 32;
+
+forall 0:r11 = 1 /\ 0:r9 = 1
+

--- a/herd/tests/instructions/PPC/A009.litmus.expected
+++ b/herd/tests/instructions/PPC/A009.litmus.expected
@@ -1,0 +1,10 @@
+Test A009 Required
+States 1
+0:r9=1; 0:r11=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r11=1 /\ 0:r9=1)
+Observation A009 Always 1 0
+Hash=9ef5fe48464d5cf42d6e263e7ef93ef6
+

--- a/herd/tests/instructions/PPC/A010.litmus
+++ b/herd/tests/instructions/PPC/A010.litmus
@@ -1,0 +1,12 @@
+PPC A010
+
+(* Test Cmplwi instr *)
+{ 0:r0 = 2 }
+
+P0;
+  cmplwi r0, 2;
+  beq L1;
+  addi r0, r0, 1;
+L1: nop;
+
+forall 0:r0=2

--- a/herd/tests/instructions/PPC/A010.litmus.expected
+++ b/herd/tests/instructions/PPC/A010.litmus.expected
@@ -1,0 +1,10 @@
+Test A010 Required
+States 1
+0:r0=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r0=2)
+Observation A010 Always 1 0
+Hash=7805d6e30c2a9168bf4783dee83e383c
+

--- a/herd/tests/instructions/PPC/A011.litmus
+++ b/herd/tests/instructions/PPC/A011.litmus
@@ -1,0 +1,9 @@
+PPC A011
+
+(* Test rlwinm and wlwimi instructions *)
+{}
+
+P0;
+  rlwinm r3, r4, 5, 0, 31;
+
+forall 0:r3 = 0

--- a/herd/tests/instructions/PPC/A011.litmus.expected
+++ b/herd/tests/instructions/PPC/A011.litmus.expected
@@ -1,0 +1,10 @@
+Test A011 Required
+States 1
+0:r3=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r3=0)
+Observation A011 Always 1 0
+Hash=a2b925fb3895cf50fe0e96ae5027f3b0
+

--- a/herd/tests/instructions/PPC/A013.litmus
+++ b/herd/tests/instructions/PPC/A013.litmus
@@ -1,0 +1,13 @@
+PPC A013
+
+(* Test rlwinm and wlwimi instructions *)
+{
+uint64_t 0:r6;
+}
+
+P0;
+li r4,-1                 ;
+rlwinm r3, r4, 4, 30, 31 ;
+rlwinm r5, r4, 0, 30, 31 ;
+rlwinm r6, r4, 16, 0, 15 ;
+forall 0:r3 = 3 /\ 0:r5=3 /\ 0:r6=0xffff0000

--- a/herd/tests/instructions/PPC/A013.litmus.expected
+++ b/herd/tests/instructions/PPC/A013.litmus.expected
@@ -1,0 +1,10 @@
+Test A013 Required
+States 1
+0:r3=3; 0:r5=3; 0:r6=4294901760;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r3=3 /\ 0:r5=3 /\ 0:r6=4294901760)
+Observation A013 Always 1 0
+Hash=a6da7ef7ad3e3bdd4024b9716a455478
+

--- a/herd/tests/instructions/PPC/A014.litmus
+++ b/herd/tests/instructions/PPC/A014.litmus
@@ -1,0 +1,16 @@
+PPC A014
+(* Test ROT32 vs ROT64 *)
+{
+0:r3=0xaaaaaaaaaaaaaaaa;
+0:r5=0xaaaaaaaaaaaaaaaa;
+0:r6=0xaaaaaaaaaaaaaaaa;
+}
+
+P0;
+li r4,-1                 ;
+rlwimi r3, r4, 4, 30, 31 ;
+rlwimi r5, r4, 0, 30, 31 ;
+rlwimi r6, r4, 16, 0, 15 ;
+locations [0:r3; 0:r5; 0:r6;]
+
+

--- a/herd/tests/instructions/PPC/A014.litmus.expected
+++ b/herd/tests/instructions/PPC/A014.litmus.expected
@@ -1,0 +1,10 @@
+Test A014 Required
+States 1
+0:r3=-1431655765; 0:r5=-1431655765; 0:r6=-21846;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation A014 Always 1 0
+Hash=f5fd1f3a6656a0390699cb32c0ad1af0
+

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -91,6 +91,8 @@ type t =
   | Strict
 (* Semi-strict interpretation of variant, e.g. -variant asl,warn *)
   | Warn
+(* Telechat variant - implements unconditional branches as exit, and any other optional quirks*)
+  | Telechat
 
 let tags =
   ["success";"instr";"specialx0";"normw";"acqrelasfence";"backcompat";
@@ -152,6 +154,7 @@ let parse s = match Misc.lowercase s with
 | "s128" -> Some S128
 | "strict" -> Some Strict
 | "warn" -> Some Warn
+| "telechat" -> Some Telechat
 | s ->
    begin
      match Precision.parse s with
@@ -219,6 +222,7 @@ let pp = function
   | ASLType `Warn -> "ASLType+Warn"
   | ASLType `Silence -> "ASLType+Silence"
   | ASLType `TypeCheck -> "ASLType+Check"
+  | Telechat -> "telechat"
 
 let compare = compare
 let equal v1 v2 = compare v1 v2 = 0

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -92,6 +92,7 @@ type t =
   | Strict
 (* Semi-strict interpretation of variant, e.g. -variant asl,warn *)
   | Warn
+  | Telechat
 
 val compare : t -> t -> int
 val equal : t -> t -> bool

--- a/lib/PPCBase.ml
+++ b/lib/PPCBase.ml
@@ -167,7 +167,8 @@ let pp_reg r =
 
 let parse_list =
   List.map (fun (r,s) -> s,Ireg r) iregs @
-  List.map (fun (r,s) -> s,Freg r) fregs
+  List.map (fun (r,s) -> s,Freg r) fregs @
+  [("lr",LR)]
 
 let parse_reg s =
   let s = Misc.lowercase s in
@@ -241,17 +242,21 @@ type 'k kinstruction =
 
 (* cr0 seting is implicit... *)
   | Paddi of reg*reg*'k (* no *)
+  | Paddis of reg*reg*'k (* no *)
   | Pandi of reg*reg*'k (* yes *)
   | Pori of reg*reg*'k  (* no *)
   | Pxori of reg*reg*'k (* no *)
   | Pmulli of  reg*reg*'k (* no *)
 
   | Pli of reg*'k
+  | Plis of reg*'k
   | Pb of lbl
   | Pbcc of cond * lbl
   | Pcmpwi of crfindex * reg*'k
+  | Pcmplwi of crfindex * reg*'k
   | Pcmpw of crfindex * reg*reg
   | Plwzu of reg * 'k * reg
+  | Plwa of reg * 'k * reg
   | Pmr of reg * reg
   | Pstwu of reg * 'k * reg
   | Plwarx of reg*reg*reg (* load word and reserve indexed *)
@@ -259,6 +264,7 @@ type 'k kinstruction =
 (* Mixed size load and store, just added at the moment *)
   | Pload of MachSize.sz * reg * 'k * reg
   | Ploadx of MachSize.sz * reg * reg * reg
+  | Plwax of MachSize.sz * reg * reg * reg
   | Pstore of MachSize.sz * reg * 'k * reg
   | Pstorex of MachSize.sz * reg * reg * reg
 (* Fence instructions *)
@@ -283,6 +289,11 @@ type 'k kinstruction =
   | Pstmw of reg * 'k * reg
   | Pcomment of string
   | Pmfcr of reg (* read condition register *)
+  (*rotate*)
+  | Prlwinm of reg * reg * 'k * 'k * 'k
+  | Prlwimi of reg * reg * 'k * 'k * 'k
+  | Pclrldi of reg * reg * 'k
+  | Pextsw of reg * reg
 
 type instruction = int kinstruction
 
@@ -299,6 +310,10 @@ let ppi_imm_index_mode pp_idx opcode r1 d r2 =
 
 let ppi_imm_instr pp_k opcode r1 r2 v =
   opcode^" "^pp_reg r1 ^ ","^pp_reg r2 ^ ","^pp_k v
+
+let ppi_imm3_instr pp_k opcode r1 r2 v1 v2 v3 =
+  opcode^" "^pp_reg r1 ^ ","^pp_reg r2 ^ ","^pp_k v1
+  ^", "^pp_k v2^","^pp_k v3
 
 let ppi_imm_instr_memo pp_k opcode set r1 r2 v =
   let memo = match set with
@@ -359,21 +374,31 @@ let do_pp_instruction pp_k i = match i with
 | Pdiv(set,rD,rA,rB) -> pp_op3 "divw" set rD rA rB
 
 | Paddi(rD,rA,simm) -> ppi_imm_instr pp_k "addi" rD rA simm
+| Paddis(rD,rA,simm) -> ppi_imm_instr pp_k "addis" rD rA simm
 | Pori(rD,rA,simm) -> ppi_imm_instr pp_k "ori" rD rA simm
 | Pxori(rD,rA,simm) -> ppi_imm_instr pp_k "xori" rD rA simm
 | Pandi(rD,rA,simm) -> ppi_imm_instr pp_k "andi." rD rA simm
 | Pmulli(rD,rA,simm) -> ppi_imm_instr pp_k "mulli" rD rA simm
+| Prlwinm(rD,rA,s1,s2,s3) -> ppi_imm3_instr pp_k "rlwinm" rD rA s1 s2 s3
+| Prlwimi(rD,rA,s1,s2,s3) -> ppi_imm3_instr pp_k "rlwimi" rD rA s1 s2 s3
+| Pclrldi(rD,rA,s1) -> ppi_imm_instr pp_k "clrldi" rD rA s1
+| Pextsw(rD,rA) -> "extsw " ^ (pp_reg rD) ^ ", " ^ (pp_reg rA)
 
 | Pli(rD,v) -> ppi_ri pp_k "li" rD v
+| Plis(rD,v) -> ppi_ri pp_k "lis" rD v
 | Pcmpwi (0,rS,v) -> ppi_ri pp_k "cmpwi" rS v
+| Pcmplwi (0,rS,v) -> ppi_ri pp_k "cmplwi" rS v
 | Pcmpwi (crf,rS,v) ->
     "cmpwi" ^ " " ^pp_crf crf ^ "," ^ pp_reg rS  ^ "," ^ pp_k v
+| Pcmplwi (crf,rS,v) ->
+    "cmplwi" ^ " " ^pp_crf crf ^ "," ^ pp_reg rS  ^ "," ^ pp_k v
 | Pb lbl -> "b   " ^ lbl
 | Pbcc(cond, lbl) -> "b"^pp_cond cond ^ "  " ^ lbl
 | Pcmpw(0,rA,rB) -> ppi_rr "cmpw" rA rB
 | Pcmpw(crf,rA,rB) ->
     "cmpw" ^ " " ^pp_crf crf ^ "," ^ pp_reg rA  ^ "," ^ pp_reg rB
 | Plwzu(rD,d,rA) -> ppi_imm_index_mode pp_k "lwzu" rD d rA
+| Plwa(rD,d,rA) -> ppi_imm_index_mode pp_k "lwa" rD d rA
 | Pmr (rD,rS) -> ppi_rr "mr" rD rS
 | Pstwu(rS,d,rA) -> ppi_imm_index_mode pp_k "stwu" rS d rA
 | Plwarx(rD,rA,rB) -> ppi_index_mode "lwarx" rD rA rB
@@ -385,6 +410,7 @@ let do_pp_instruction pp_k i = match i with
 
 | Pload (sz,rD,d,rA) ->  ppi_imm_index_mode pp_k (memo_load sz) rD d rA
 | Ploadx (sz,rD,rA,rB) ->  ppi_index_mode (memo_loadx sz) rD rA rB
+| Plwax (_,rD,rA,rB) ->  ppi_index_mode "lwax" rD rA rB
 | Pstore (sz,rS,d,rA) ->  ppi_imm_index_mode pp_k (memo_store sz) rS d rA
 | Pstorex (sz,rS,rA,rB) ->  ppi_index_mode (memo_storex sz) rS rA rB
 
@@ -446,6 +472,7 @@ let fold_regs (f_reg,f_sreg) =
   | Plwarx (r1,r2,r3)
   | Pstwcx (r1,r2,r3)
   | Ploadx (_,r1,r2,r3)
+  | Plwax (_,r1,r2,r3)
   | Pstorex (_,r1,r2,r3)
   | Pnor (_,r1,r2,r3)
   | Pslw (_,r1,r2,r3)
@@ -453,12 +480,18 @@ let fold_regs (f_reg,f_sreg) =
     -> fold_reg r3 (fold_reg r2 (fold_reg r1 (y_reg,y_sreg)))
 	(* Two *)
   | Paddi (r1,r2,_)
+  | Paddis (r1,r2,_)
+  | Prlwinm (r1,r2,_,_,_)
+  | Prlwimi (r1,r2,_,_,_)
+  | Pclrldi (r1,r2,_)
+  | Pextsw (r1,r2)
   | Pori (r1,r2,_)
   | Pandi (r1,r2,_)
   | Pxori (r1,r2,_)
   | Pmulli (r1,r2,_)
   | Pcmpw (_,r1,r2)
   | Plwzu (r1,_,r2)
+  | Plwa (r1,_,r2)
   | Pmr (r1,r2)
   | Pdcbf (r1,r2)
   | Pstwu (r1,_,r2)
@@ -469,7 +502,9 @@ let fold_regs (f_reg,f_sreg) =
     ->  fold_reg r2 (fold_reg r1 (y_reg,y_sreg))
 	(* One *)
   | Pli (r1,_)
+  | Plis (r1,_)
   | Pcmpwi (_,r1,_)
+  | Pcmplwi (_,r1,_)
   | Pmtlr r1
   | Pmflr r1
   | Pmfcr r1
@@ -526,6 +561,8 @@ let map_regs f_reg f_symb =
       map3 (fun (r1,r2,r3) -> Pdiv (set,r1,r2,r3)) r1 r2 r3
   | Ploadx (sz,r1,r2,r3) ->
       map3 (fun (r1,r2,r3) -> Ploadx (sz,r1,r2,r3)) r1 r2 r3
+  | Plwax (sz,r1,r2,r3) ->
+      map3 (fun (r1,r2,r3) -> Plwax (sz,r1,r2,r3)) r1 r2 r3
   | Pstorex (sz,r1,r2,r3) ->
       map3 (fun (r1,r2,r3) -> Pstorex (sz,r1,r2,r3)) r1 r2 r3
   | Plwarx (r1,r2,r3) ->
@@ -542,6 +579,8 @@ let map_regs f_reg f_symb =
 (* Two *)
   | Paddi (r1,r2,v) ->
       map2 (fun (r1,r2) -> Paddi (r1,r2,v)) r1 r2
+  | Paddis (r1,r2,v) ->
+      map2 (fun (r1,r2) -> Paddis (r1,r2,v)) r1 r2
   | Pori (r1,r2,v) ->
       map2 (fun (r1,r2) -> Pori (r1,r2,v)) r1 r2
   | Pandi (r1,r2,v) ->
@@ -552,10 +591,20 @@ let map_regs f_reg f_symb =
       map2 (fun (r1,r2) -> Pmulli (r1,r2,v)) r1 r2
   | Pcmpw (crf,r1,r2) ->
       map2 (fun (r1,r2) -> Pcmpw (crf,r1,r2)) r1 r2
+  | Prlwinm (r1,r2,v1,v2,v3) ->
+      map2 (fun (r1,r2) -> Prlwinm (r1,r2,v1,v2,v3)) r1 r2
+  | Prlwimi (r1,r2,v1,v2,v3) ->
+      map2 (fun (r1,r2) -> Prlwimi (r1,r2,v1,v2,v3)) r1 r2
+  | Pclrldi (r1,r2,v1) ->
+      map2 (fun (r1,r2) -> Pclrldi (r1,r2,v1)) r1 r2
+  | Pextsw (r1,r2) ->
+      map2 (fun (r1,r2) -> Pextsw (r1,r2)) r1 r2
   | Pload (sz,r1,cst,r2) ->
       map2 (fun (r1,r2) -> Pload (sz,r1,cst,r2)) r1 r2
   | Plwzu (r1,cst,r2) ->
       map2 (fun (r1,r2) -> Plwzu (r1,cst,r2)) r1 r2
+  | Plwa (r1,cst,r2) ->
+      map2 (fun (r1,r2) -> Plwa (r1,cst,r2)) r1 r2
   | Pmr (r1,r2) ->
       map2 (fun (r1,r2) -> Pmr (r1,r2)) r1 r2
   | Pdcbf (r1,r2) ->
@@ -572,8 +621,12 @@ let map_regs f_reg f_symb =
 	(* One *)
   | Pli (r1,v) ->
       Pli (map_reg r1,v)
+  | Plis (r1,v) ->
+      Plis (map_reg r1,v)
   | Pcmpwi (crf,r1,v) ->
       Pcmpwi (crf,map_reg r1,v)
+  | Pcmplwi (crf,r1,v) ->
+      Pcmplwi (crf,map_reg r1,v)
   | Pmtlr r ->
       Pmtlr (map_reg r)
   | Pmflr r ->
@@ -605,22 +658,25 @@ let map_addrs _f ins = ins
 let norm_ins ins = match ins with
   | Pload(Quad,r1,cst,r2) -> Pload(Word,r1,cst,r2)
   | Ploadx(Quad,r1,r2,r3) -> Ploadx(Word,r1,r2,r3)
+  | Plwax(Quad,r1,r2,r3) -> Plwax(Word,r1,r2,r3)
   | Pstore(Quad,r1,cst,r2) -> Pstore(Word,r1,cst,r2)
   | Pstorex(Quad,r1,r2,r3) -> Pstorex(Word,r1,r2,r3)
   | Pnop
   | Pload ((Byte|Short|Word),_,_,_)
   | Ploadx ((Byte|Short|Word),_,_,_)
+  | Plwax ((Byte|Short|Word),_,_,_)
   | Pstore ((Byte|Short|Word),_,_,_)
   | Pstorex ((Byte|Short|Word),_,_,_)
   | Pb _ | Pbcc (_,_)
   | Pdcbf (_, _)
   | Pstwcx (_, _, _)|Plwarx (_, _, _)
   | Pstwu (_,_,_)|Pmr (_, _)
-  | Plwzu (_,_,_)|Pcmpw (_, _, _)
-  | Pcmpwi (_, _, _)|Pli (_, _)
+  | Plwzu (_,_,_)|Plwa _|Pcmpw (_, _, _)
+  | Pcmpwi (_, _, _)|Pli (_, _)|Plis (_,_) | Pcmplwi (_,_,_)
   | Pmulli (_, _, _)|Pxori (_, _, _)|Pori (_, _, _)
-  | Pandi (_, _, _)|Paddi (_, _, _)|Pdiv (_, _, _, _)
-  | Pmull (_, _, _, _)|Pxor (_, _, _, _)
+  | Pandi (_, _, _)|Paddi (_, _, _)|Paddis _|Pdiv (_, _, _, _)
+  | Pmull (_, _, _, _)|Pxor (_, _, _, _)|Prlwinm (_,_,_,_,_)
+  | Prlwimi (_,_,_,_,_) | Pclrldi (_,_,_) | Pextsw (_,_)
   | Pand (_, _, _, _)|Por (_, _, _, _)
   | Psub (_, _, _, _)| Psubf (_, _, _, _)|Padd (_, _, _, _)
   | Plwsync|Pisync|Peieio|Psync
@@ -631,6 +687,7 @@ let norm_ins ins = match ins with
   | Plmw _|Pstmw _
           -> ins
   | Pload (S128, _, _, _)|Ploadx (S128, _, _, _)|Pstore (S128, _, _, _)
+  | Plwax (S128, _, _, _)
   | Pstorex (S128, _, _, _) -> assert false
 
 let is_data r1 i = match i with
@@ -644,13 +701,15 @@ let get_next = function
   | Pnop
   | Padd _ | Psub (_, _, _, _)|Psubf (_, _, _, _)
   | Por (_, _, _, _)|Pand (_, _, _, _)|Pxor (_, _, _, _)
-  |Pmull (_, _, _, _)|Pdiv (_, _, _, _)|Paddi (_, _, _)
+  |Pmull (_, _, _, _)|Pdiv (_, _, _, _)|Paddi (_, _, _)|Prlwinm (_,_,_,_,_)
+  |Paddis _ |Prlwimi (_,_,_,_,_) | Pclrldi (_,_,_) | Pextsw _
   | Pandi (_, _, _)|Pori (_, _, _)|Pxori (_, _, _)|Pmulli (_, _, _)
-  |Pli (_, _)
+  |Pli (_, _)|Plis(_,_)
   |Pcmpwi (_, _, _)|Pcmpw (_, _, _)|Plwzu(_,_,_)
-  |Pmr (_, _)|Pstwu(_,_,_)
+  |Plwa _
+  |Pmr (_, _)|Pstwu(_,_,_)| Pcmplwi (_,_,_)
   |Plwarx (_, _, _)|Pstwcx (_, _, _)
-  |Pload _|Ploadx _|Pstore _|Pstorex _
+  |Pload _|Ploadx _|Pstore _|Pstorex _| Plwax _
   |Psync|Peieio|Pisync|Plwsync
   |Pdcbf (_, _)|Pnor (_, _, _, _)|Pneg (_, _, _)
   |Pslw (_, _, _, _)|Psrawi (_, _, _, _)|Psraw (_, _, _, _)
@@ -673,13 +732,22 @@ include Pseudo.Make
 
       let parsed_tr = function
 	| Pli (r, k) -> Pli(r,MetaConst.as_int k)
+	| Plis (r, k) -> Plis(r,MetaConst.as_int k)
 	| Pmulli (r1, r2, k) -> Pmulli(r1,r2,MetaConst.as_int k)
 	| Pxori (r1, r2, k) -> Pxori(r1,r2,MetaConst.as_int k)
 	| Pori (r1, r2, k) -> Pori(r1,r2,MetaConst.as_int k)
 	| Pandi (r1, r2, k) -> Pandi(r1,r2,MetaConst.as_int k)
 	| Paddi (r1, r2, k) -> Paddi(r1,r2,MetaConst.as_int k)
+	| Paddis (r1, r2, k) -> Paddis(r1,r2,MetaConst.as_int k)
+	| Prlwinm (r1, r2, k1,k2,k3) -> Prlwinm(r1,r2,MetaConst.as_int k1,
+      MetaConst.as_int k2, MetaConst.as_int k3)
+	| Prlwimi (r1, r2, k1,k2,k3) -> Prlwimi(r1,r2,MetaConst.as_int k1,
+      MetaConst.as_int k2, MetaConst.as_int k3)
+	| Pclrldi (r1, r2, k1) -> Pclrldi(r1,r2,MetaConst.as_int k1)
 	| Pcmpwi (i, r, k) -> Pcmpwi(i,r,MetaConst.as_int k)
+	| Pcmplwi (i, r, k) -> Pcmplwi(i,r,MetaConst.as_int k)
 	| Plwzu (r1,k,r2) -> Plwzu(r1,MetaConst.as_int k,r2)
+	| Plwa (r1,k,r2) -> Plwa(r1,MetaConst.as_int k,r2)
 	| Pstwu (r1,k,r2) -> Pstwu(r1,MetaConst.as_int k,r2)
 	| Pload (s,r1,k,r2) -> Pload(s,r1,MetaConst.as_int k,r2)
 	| Pstore(s,r1,k,r2) -> Pstore(s,r1,MetaConst.as_int k,r2)
@@ -688,7 +756,7 @@ include Pseudo.Make
 	| Pstmw (r1,k,r2) -> Pstmw(r1,MetaConst.as_int k,r2)
 
         | Pnop
-	| Ploadx (_,_,_,_)
+	| Ploadx (_,_,_,_) | Pextsw(_,_) | Plwax (_,_,_,_)
 	| Pstorex (_,_,_,_)
 	| Pb _ | Pbcc (_,_)
 	| Pdcbf (_, _)
@@ -718,14 +786,21 @@ include Pseudo.Make
         | Pdiv _
 (* cr0 seting is implicit... *)
         | Paddi _
+        | Paddis _
+        | Prlwinm _
+        | Prlwimi _
+        | Pclrldi _
+        | Pextsw _
         | Pandi _
         | Pori _
         | Pxori _
         | Pmulli _
         | Pli _
+        | Plis _
         | Pb _
         | Pbcc _
         | Pcmpwi _
+        | Pcmplwi _
         | Pcmpw _
         | Pmr _
         | Psync
@@ -746,10 +821,11 @@ include Pseudo.Make
         | Pcomment _
           -> 0
         | Plwzu _
+        | Plwa _
         | Pstwu _
         | Plwarx _
         | Pstwcx _
-        | Pload _|Ploadx _|Pstore _|Pstorex _
+        | Pload _|Ploadx _|Pstore _|Pstorex _| Plwax _
           -> 1
         |Plmw (_r1,_,_)
         |Pstmw (_r1,_,_)
@@ -764,10 +840,12 @@ include Pseudo.Make
         | Pdcbf (_, _)
         | Pstwcx (_, _, _)|Plwarx (_, _, _)
         | Pstwu(_,_,_)|Pmr (_, _)
-        | Plwzu(_,_,_)|Pcmpw (_, _, _)
-        | Pcmpwi (_, _, _)|Pli (_, _)
+        | Plwzu(_,_,_)|Plwa _|Pcmpw (_, _, _)
+        | Pcmpwi (_, _, _)|Pli (_, _)|Plis (_,_) | Pcmplwi (_,_,_)
         | Pmulli (_, _, _)|Pxori (_, _, _)|Pori (_, _, _)
-        | Pandi (_, _, _)|Paddi (_, _, _)|Pdiv (_, _, _, _)
+        | Pandi (_, _, _)|Paddi (_, _, _)|Paddis _|Pdiv (_, _, _, _)
+        | Prlwinm (_,_,_,_,_) | Prlwimi (_,_,_,_,_)
+        | Pclrldi (_,_,_) | Pextsw (_,_)
         | Pmull (_, _, _, _)|Pxor (_, _, _, _)
         | Pand (_, _, _, _)|Por (_, _, _, _)
         | Psub (_, _, _, _)| Psubf (_, _, _, _)|Padd (_, _, _, _)
@@ -777,7 +855,7 @@ include Pseudo.Make
         | Pbl _ | Pblr | Pmtlr _ | Pmflr _ | Pmfcr _
         | Pcomment _
         | Plmw _|Pstmw _
-        | Pload _|Ploadx _|Pstore _|Pstorex _
+        | Pload _|Ploadx _|Pstore _|Pstorex _ | Plwax _
           -> k
 
 
@@ -790,12 +868,14 @@ include Pseudo.Make
         | Pbcc (cc,lab) -> Pbcc (cc,as_string_fun f lab)
         | Pnop
         | Pdcbf (_, _)
-        | Pstwcx (_, _, _)|Plwarx (_, _, _)
+        | Pstwcx (_, _, _)|Plwarx (_, _, _) | Plwax (_,_,_,_)
         | Pstwu(_,_,_)|Pmr (_, _)
-        | Plwzu(_,_,_)|Pcmpw (_, _, _)
-        | Pcmpwi (_, _, _)|Pli (_, _)
+        | Plwzu(_,_,_)|Plwa _|Pcmpw (_, _, _)
+        | Pcmpwi (_, _, _)|Pli (_, _)|Plis (_,_) | Pcmplwi (_,_,_)
         | Pmulli (_, _, _)|Pxori (_, _, _)|Pori (_, _, _)
-        | Pandi (_, _, _)|Paddi (_, _, _)|Pdiv (_, _, _, _)
+        | Pandi (_, _, _)|Paddi (_, _, _)|Paddis _|Pdiv (_, _, _, _)
+        | Prlwinm (_,_,_,_,_) | Prlwimi (_,_,_,_,_)
+        | Pclrldi (_,_,_) | Pextsw (_,_)
         | Pmull (_, _, _, _)|Pxor (_, _, _, _)
         | Pand (_, _, _, _)|Por (_, _, _, _)
         | Psub (_, _, _, _)| Psubf (_, _, _, _)|Padd (_, _, _, _)
@@ -888,12 +968,15 @@ let lock regs k = match regs with
     Label (loop,Nop)::
     Instruction (Pload (Word,sym,0,addr))::
     Instruction (Pcmpwi (0,sym,0))::
+    Instruction (Pcmplwi (0,sym,0))::
     Instruction (Pbcc (Ne,loop))::
     Label (atom,Nop)::
     Instruction (Plwarx (sym,r0,addr))::
     Instruction (Pcmpwi (0,sym,0))::
+    Instruction (Pcmplwi (0,sym,0))::
     Instruction (Pbcc (Ne,loop))::
     Instruction (Pli (sym,1))::
+    Instruction (Plis (sym,1))::
     Instruction (Pstwcx (sym,r0 ,addr))::
     Instruction (Pbcc (Ne,loop))::
     Instruction (Pisync)::
@@ -904,6 +987,7 @@ let unlock regs k = match regs with
 | [addr] ->
     Instruction (Plwsync)::
     Instruction (Pli (sym,0))::
+    Instruction (Plis (sym,0))::
     Instruction (Pstore (Word,sym,0,addr))::
     k
 | _ -> Warn.fatal "UNLOCK takes one reg argument (address)"
@@ -913,6 +997,7 @@ let setflag regs k = match regs with
 | [addr] ->
     Instruction (Plwsync)::
     Instruction (Pli (sym,1))::
+    Instruction (Plis (sym,1))::
     Instruction (Pstore (Word,sym,0,addr))::k
 | _ -> Warn.fatal "SF takes one reg argument (address)"
 
@@ -932,6 +1017,7 @@ let readflagloop regs k = match regs with
     Label (loop,Nop)::
     Instruction (Pload (Word,sym,0,addr))::
     Instruction (Pcmpwi (0,sym,0))::
+    Instruction (Pcmplwi (0,sym,0))::
     Instruction (Pbcc (Eq,loop))::
     Instruction (Pisync)::k
 | _ -> Warn.fatal "RFL takes one reg argument (address)"

--- a/lib/PPCLexer.mll
+++ b/lib/PPCLexer.mll
@@ -45,7 +45,9 @@ rule token = parse
 | '(' { LPAR }
 | ')' { RPAR }
 | "codevar:" (name as x) { CODEVAR x }
+| "nop" { NOP }
 | "addi" { ADDI }
+| "addis" { ADDIS }
 | "subi" { SUBI }
 | "add"  { ADD }
 | "add."  { ADDDOT }
@@ -55,7 +57,9 @@ rule token = parse
 | "subf." { SUBFDOT }
 | "cmpwi" { CMPWI }
 | "cmpw" {CMPW}
+| "cmplwi" { CMPLWI }
 | "li"   { LI }
+| "lis" { LIS }
 | "xor" { XOR }
 | "xor." { XORDOT }
 | "xori" { XORI }
@@ -86,6 +90,8 @@ rule token = parse
 | "stwu" { STWU }
 | "stwx" { STWX }
 | "lwarx" { LWARX }
+| "lwa" { LWA }
+| "lwax" { LWAX }
 | "stwcx." { STWCX }
 | "std" { STD }
 | "ld"  { LD }
@@ -95,6 +101,7 @@ rule token = parse
 | "eieio" { EIEIO }
 | "isync" { ISYNC }
 | "lwsync" { LWSYNC }
+| "hwsync" { HWSYNC }
 | "dcbf" { DCBF }
 | "b" { B }
 | "beq" { BEQ }
@@ -120,6 +127,10 @@ rule token = parse
 | "mfcr"  { MFCR }
 | "stmw"  { STMW }
 | "lmw"  { LMW }
+| "rlwinm" { RLWINM }
+| "rlwimi" { RLWIMI }
+| "clrldi" { CLRLDI }
+| "extsw" { EXTSW }
 | "com"   { COMMENT}
 
 | name as x

--- a/litmus/PPCArch_litmus.ml
+++ b/litmus/PPCArch_litmus.ml
@@ -60,6 +60,8 @@ module Make (O:Arch_litmus.Config)(V:Constant.S) = struct
   let reg_to_string r = match r with
   | Ireg r -> ireg_to_string r
   | Internal i -> sprintf "i%i" i
+  | LR -> "LR" (* Needed for BLR *)
+  | Symbolic_reg _ -> assert false
   | _ -> assert false
 
   include

--- a/litmus/libdir/_ppc/instruction.h
+++ b/litmus/libdir/_ppc/instruction.h
@@ -1,0 +1,1 @@
+typedef uint32_t ins_t; /* Type of instructions */

--- a/litmus/libdir/ppc-qemu.cfg
+++ b/litmus/libdir/ppc-qemu.cfg
@@ -1,14 +1,14 @@
-size_of_test = 5k
+size_of_test = 10k
 number_of_run = 200
 avail = 2
 limit = true
 memory = direct
 stride = 1
 affinity = none
-word = w64
 #Cross compilation
 gcc = powerpc64-linux-gnu-gcc
+ccopts = -mbig
 linkopt = -static
 #crossrun
 crossrun = qemu:qemu-ppc64
-carch = RISCV
+carch = PPC


### PR DESCRIPTION
Motivation: we wish to test compilation targeting IBM PowerPC. To do so, we must add new instructions and tests. This PR adds:
- Testing for PPC instructions
- Lis instruction
- HWSYNC fence
- rlwinm and rlwimi instructions
- cmplwi instruction
- addis instruction
- lwa instruction
- nop instruction
- clrldi instruction
- extsw instruction
- fixes blr instruction
- lwax instruction
- Adds a PPC QEMU config
- adds a litmus ppc instruction.h
- emits get_instr in litmus so PPC compiles.

All tests pass in herd, and under litmus QEMU PPC emulation

