### PR TITLE
[herd,asl] aarch64-asl now uses asl scalars

### DIFF
--- a/asllib/bitvector.ml
+++ b/asllib/bitvector.ml
@@ -233,6 +233,14 @@ let to_z_signed ((sz, _) as bv) =
   let r = to_z_unsigned bv in
   if sgn = 0 then r else Z.sub r (Z.shift_left Z.one sz)
 
+let z63 = Z.shift_left Z.one 63
+let z64 = Z.shift_left Z.one 64
+
+let printable bv =
+  let z = to_z_signed bv in
+  if Z.geq z z63 then Z.sub z z64
+  else z
+
 let of_string s =
   let result = Buffer.create ((String.length s / 8) + 1) in
   let lengthr = ref 0 in

--- a/asllib/bitvector.mli
+++ b/asllib/bitvector.mli
@@ -76,6 +76,7 @@ val to_int64_signed : t -> int64
 
 val to_z_unsigned : t -> Z.t
 val to_z_signed : t -> Z.t
+val printable : t -> Z.t
 
 (* --------------------------------------------------------------------------*)
 (** {2 Operations on bitvectors} *)

--- a/herd/AArch64ASLParseTest.ml
+++ b/herd/AArch64ASLParseTest.ml
@@ -1,0 +1,61 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2023-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+module Make(Conf:RunTest.Config)(ModelConfig:MemCat.Config) = struct
+
+  let is_morello = Conf.variant Variant.Morello
+
+  module LexConfig = struct
+    let debug = Conf.debug.Debug_herd.lexer
+    let is_morello = is_morello
+  end
+
+  module ArchConfig = SemExtra.ConfigToArchConfig(Conf)
+
+  module AArch64ASLValue =
+    AArch64ASLValue.Make
+      (struct
+        let is_morello = is_morello
+      end)
+
+  module AArch64ASLArch =
+    AArch64Arch_herd.Make(ArchConfig)(AArch64ASLValue)
+
+  module AArch64ASLLexParse = struct
+    type instruction = AArch64ASLArch.parsedPseudo
+    type token = AArch64Parser.token
+    module Lexer = AArch64Lexer.Make(LexConfig)
+    let lexer = Lexer.token
+    let parser = AArch64Parser.main
+  end
+
+  let run dirty start_time name chan env splitted =
+    let module SemConf = struct
+        module C = Conf
+        let dirty = ModelConfig.dirty
+        let procs_user = ProcsUser.get splitted.Splitter.info
+      end in
+    let module AArch64ASLS =
+      AArch64ASLSem.Make(SemConf)(AArch64ASLValue) in
+    let module
+        AArch64ASLM = MemCat.Make(ModelConfig)(AArch64ASLS) in
+    let module P =
+      GenParser.Make (Conf) (AArch64ASLArch) (AArch64ASLLexParse) in
+    let module X =
+      RunTest.Make (AArch64ASLS) (P) (AArch64ASLM) (Conf) in
+    X.run dirty start_time name chan env splitted
+end
+

--- a/herd/AArch64ParseTest.ml
+++ b/herd/AArch64ParseTest.ml
@@ -60,12 +60,6 @@ module Make(Conf:RunTest.Config)(ModelConfig:MemCat.Config) = struct
             X.X.run
       end in
 
-(* START NOTWWW *)
-      if Conf.variant Variant.ASL then
-        let module Run =  Top(AArch64ASLSem.Make) in
-        Run.run dirty start_time name chan env splitted
-      else
-(* END NOTWWW *)
-        let module Run = Top(AArch64Sem.Make) in
-        Run.run dirty start_time name chan env splitted
+    let module Run = Top(AArch64Sem.Make) in
+    Run.run dirty start_time name chan env splitted
 end

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -162,9 +162,9 @@ module Make (C : Config) = struct
           M.restrict M.VC.[ Assign (v', Unop (op1, v)) ] >>! v'
       | v -> M.op1 op1 v
 
-    let to_bv = wrap_op1_symb_as_var (Op.ArchOp1 ASLValue.ToBV)
-    let to_int_unsigned = wrap_op1_symb_as_var (Op.ArchOp1 ASLValue.ToIntU)
-    let to_int_signed = wrap_op1_symb_as_var (Op.ArchOp1 ASLValue.ToIntS)
+    let to_bv = wrap_op1_symb_as_var (Op.ArchOp1 ASLOp.ToBV)
+    let to_int_unsigned = wrap_op1_symb_as_var (Op.ArchOp1 ASLOp.ToIntU)
+    let to_int_signed = wrap_op1_symb_as_var (Op.ArchOp1 ASLOp.ToIntS)
 
     (**************************************************************************)
     (* Special monad interations                                              *)
@@ -199,7 +199,7 @@ module Make (C : Config) = struct
 
     let binop =
       let open AST in
-      let to_bool op v1 v2 = op v1 v2 >>= M.op1 (Op.ArchOp1 ASLValue.ToBool) in
+      let to_bool op v1 v2 = op v1 v2 >>= M.op1 (Op.ArchOp1 ASLOp.ToBool) in
       let to_bv op v1 v2 = op v1 v2 >>= to_bv in
       let or_ v1 v2 =
         match (v1, v2) with
@@ -218,7 +218,7 @@ module Make (C : Config) = struct
       | BOR -> M.op Op.Or
       | DIV -> M.op Op.Div
       | MOD -> M.op Op.Rem
-      | DIVRM -> M.op (Op.ArchOp ASLValue.Divrm)
+      | DIVRM -> M.op (Op.ArchOp ASLOp.Divrm)
       | EOR -> M.op Op.Xor |> to_bv
       | EQ_OP -> M.op Op.Eq |> to_bool
       | GT -> M.op Op.Gt |> to_bool
@@ -240,7 +240,7 @@ module Make (C : Config) = struct
     let unop op =
       let open AST in
       match op with
-      | BNOT -> wrap_op1_symb_as_var (Op.ArchOp1 ASLValue.BoolNot)
+      | BNOT -> wrap_op1_symb_as_var (Op.ArchOp1 ASLOp.BoolNot)
       | NEG -> M.op Op.Sub V.zero
       | NOT -> wrap_op1_symb_as_var Op.Inv
 
@@ -272,7 +272,7 @@ module Make (C : Config) = struct
         let action = Act.Access (dir, loc, v, MachSize.Quad) in
         M.mk_singleton_es action (use_ii_with_poi ii poi) in
       if is_pstate x scope then
-        M.op1 (Op.ArchOp1 ASLValue.ToIntU) v >>= m
+        M.op1 (Op.ArchOp1 ASLOp.ToIntU) v >>= m
       else m v
 
     let on_write_identifier = on_access_identifier Dir.W
@@ -297,25 +297,25 @@ module Make (C : Config) = struct
       | V.Val (Constant.Frozen i) -> return (V.Var i)
       | v -> return v
 
-    let get_index i v = M.op1 (Op.ArchOp1 (ASLValue.GetIndex i)) v >>= unfreeze
+    let get_index i v = M.op1 (Op.ArchOp1 (ASLOp.GetIndex i)) v >>= unfreeze
 
     let set_index i v vec =
-      M.op (Op.ArchOp (ASLValue.SetIndex i)) vec (freeze v)
+      M.op (Op.ArchOp (ASLOp.SetIndex i)) vec (freeze v)
 
     let get_field name v =
-      M.op1 (Op.ArchOp1 (ASLValue.GetField name)) v >>= unfreeze
+      M.op1 (Op.ArchOp1 (ASLOp.GetField name)) v >>= unfreeze
 
     let set_field name v record =
-      M.op (Op.ArchOp (ASLValue.SetField name)) record (freeze v)
+      M.op (Op.ArchOp (ASLOp.SetField name)) record (freeze v)
 
     let read_from_bitvector positions bvs =
       let positions = Asllib.ASTUtils.slices_to_positions v_as_int positions in
-      let arch_op1 = ASLValue.BVSlice positions in
+      let arch_op1 = ASLOp.BVSlice positions in
       M.op1 (Op.ArchOp1 arch_op1) bvs
 
     let write_to_bitvector positions w v =
       let positions = Asllib.ASTUtils.slices_to_positions v_as_int positions in
-      M.op (Op.ArchOp (ASLValue.BVSliceSet positions)) v w
+      M.op (Op.ArchOp (ASLOp.BVSliceSet positions)) v w
 
     let concat_bitvectors bvs =
       let bvs =
@@ -332,7 +332,7 @@ module Make (C : Config) = struct
       | h :: t ->
           let folder acc v =
             let* acc = acc in
-            M.op (Op.ArchOp ASLValue.Concat) acc v
+            M.op (Op.ArchOp ASLOp.Concat) acc v
           in
           List.fold_left folder (return h) t
 

--- a/herd/constraints.ml
+++ b/herd/constraints.ml
@@ -307,11 +307,11 @@ module Make (C:Config) (A : Arch_herd.S) :
             ->
              mbox m (pp_rloc_no_brk tr m rloc) ^
              pp_equal m ^
-             mbox m (do_add_asm m (V.pp C.hexa v))
+             mbox m (do_add_asm m (V.pp C.hexa (V.printable v)))
           | LV (rloc,v) ->
              mbox m (pp_rloc tr m rloc) ^
              pp_equal m ^
-             mbox m (do_add_asm m (V.pp C.hexa v))
+             mbox m (do_add_asm m (V.pp C.hexa (V.printable v)))
           | LL (l1,l2) ->
               mbox m (pp_loc tr m l1) ^
               pp_equal m ^

--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -106,8 +106,12 @@ module Top (TopConf:RunTest.Config) = struct
          let module X = ARMParseTest.Make(Conf)(ModelConfig) in
          X.run dirty start_time name chan env splitted
       | `AArch64 ->
-         let module X = AArch64ParseTest.Make(Conf)(ModelConfig) in
-         X.run dirty start_time name chan env splitted
+         if Conf.variant Variant.ASL then
+           let module X = AArch64ASLParseTest.Make(Conf)(ModelConfig) in
+           X.run dirty start_time name chan env splitted
+         else
+           let module X = AArch64ParseTest.Make(Conf)(ModelConfig) in
+           X.run dirty start_time name chan env splitted
 
       | `X86 ->
          let module X = X86ParseTest.Make(Conf)(ModelConfig) in

--- a/herd/tests/instructions/AArch64.ASL/SXTW01.litmus
+++ b/herd/tests/instructions/AArch64.ASL/SXTW01.litmus
@@ -1,8 +1,9 @@
 AArch64 SXTW01
 {
+int64_t 0:X1;
 int 0:X0=0xffffffff;
 }
   P0                ;
  SXTW X1,W0         ;
 
-forall 0:X1=0xffffffffffffffff;
+forall 0:X1=-1

--- a/herd/tests/instructions/AArch64.ASL/SXTW01.litmus.expected
+++ b/herd/tests/instructions/AArch64.ASL/SXTW01.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:X1=-1)
 Observation SXTW01 Always 1 0
-Hash=13c7e8d148852e3009ca22a331457e59
+Hash=50be8eb6a78d3f344e6b9b551b92348d
 

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -236,7 +236,7 @@ module Make(O:Config)(M:XXXMem.S) =
 
       let check = check_prop test in
 
-      fun conc fsc (set_pp,vbpp) flags c ->
+      fun conc (st,flts) (set_pp,vbpp) flags c ->
         if not showtoofar && S.gone_toofar conc then
           { c with toofar = true; }
         else if do_observed && not (all_observed test conc) then c
@@ -246,6 +246,8 @@ module Make(O:Config)(M:XXXMem.S) =
           | Some flag -> not (Flag.Set.mem (Flag.Flag flag) flags)
         then c
         else
+          let st = A.map_state A.V.printable st in
+          let fsc = st,flts in
           let ok = check fsc in
           let show_exec =
             let open PrettyConf in

--- a/lib/AArch64ASLValue.ml
+++ b/lib/AArch64ASLValue.ml
@@ -16,10 +16,19 @@
 
 module Make (C : sig
   val is_morello : bool
-end) : Value.AArch64 = struct
-  type extra_op1 = ASLValue.ASLArchOp.op1
+end) : Value.AArch64ASL = struct
+  if C.is_morello then
+    Warn.fatal "-variant asl and -variant morello are not conmpatible" ;
   module AArch64I = AArch64Instr.Make (C)
+  module ASLScalar = struct
+    include ASLScalar
+
+    let printable = function
+      | S_BitVector bv -> S_Int (Asllib.Bitvector.printable  bv)
+      | S_Bool b -> S_Int (if b then Z.one else Z.zero)
+      | S_Int i -> S_Int (printable_z i)
+  end
   module AArch64Cst = SymbConstant.Make (ASLScalar) (AArch64PteVal) (AArch64I)
-  module AArch64Op = AArch64Op.Make (ASLScalar)(ASLValue.ASLArchOp)
+  module AArch64Op = AArch64Op.Make(ASLScalar)(ASLOp)
   include SymbValue.Make (AArch64Cst) (AArch64Op)
 end

--- a/lib/AArch64ASLValue.ml
+++ b/lib/AArch64ASLValue.ml
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2022-present Institut National de Recherche en Informatique et *)
+(* Copyright 2021-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,31 +14,12 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Signatures of AArch64 "Sem" modules *)
-
-module type SubConfig = sig
-  include GenParser.Config
-  include Top_herd.CommonConfig
-  include Sem.Config
-
-  val libfind : string -> string
-  val byte : MachSize.Tag.t
+module Make (C : sig
+  val is_morello : bool
+end) : Value.AArch64 = struct
+  type extra_op1 = ASLValue.ASLArchOp.op1
+  module AArch64I = AArch64Instr.Make (C)
+  module AArch64Cst = SymbConstant.Make (ASLScalar) (AArch64PteVal) (AArch64I)
+  module AArch64Op = AArch64Op.Make (ASLScalar)(ASLValue.ASLArchOp)
+  include SymbValue.Make (AArch64Cst) (AArch64Op)
 end
-
-module type Config = sig
-  module C : SubConfig
-  val dirty : DirtyBit.t option
-  val procs_user : Proc.t list
-end
-
-module type Semantics =
-  Sem.Semantics
-  with type A.instruction = AArch64Base.instruction
-   and type A.parsedInstruction = AArch64Base.parsedInstruction
-   and type A.reg = AArch64Base.reg
-   and type 'ins A.kpseudo = 'ins AArch64Base.kpseudo
-
-module type MakeSemantics =
-  functor(C:Config) ->
-  functor(V:Value.AArch64) ->
-  Semantics with module A.V = V

--- a/lib/AArch64Op.ml
+++ b/lib/AArch64Op.ml
@@ -26,9 +26,16 @@ type 'op1 t =
   | Extra of 'op1
 
 module
-   Make(S:Scalar.S)
-   (Extra:ArchOp.S with type scalar = S.t) =
-  struct
+   Make
+     (S:Scalar.S)
+     (Extra:ArchOp.S with type scalar = S.t) : ArchOp.S
+   with type op = Extra.op
+    and type extra_op1 = Extra.op1
+    and type 'a constr_op1 = 'a t
+    and type scalar = S.t
+    and type pteval = AArch64PteVal.t
+    and type instr = AArch64Base.instruction
+  = struct
 
     type op = Extra.op
     type extra_op1 = Extra.op1

--- a/lib/AArch64Op.ml
+++ b/lib/AArch64Op.ml
@@ -14,7 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type t =
+type 'op1 t =
   | AF (* get AF from PTE entry *)
   | SetAF (* set AF to 1 in PTE entry *)
   | DB (* get DB from PTE entry *)
@@ -23,13 +23,21 @@ type t =
   | Valid (* get Valid bit from PTE entry *)
   | EL0 (* get EL0 bit from PTE entry *)
   | OA (* get OA from PTE entry *)
+  | Extra of 'op1
 
-module Make(S:Scalar.S) =
+module
+   Make(S:Scalar.S)
+   (Extra:ArchOp.S with type scalar = S.t) =
   struct
 
-    type op1 = t
+    type op = Extra.op
+    type extra_op1 = Extra.op1
+    type 'a constr_op1 = 'a t
+    type op1 = extra_op1 constr_op1
 
-    let pp_op1 _hexa = function
+    let pp_op = Extra.pp_op
+
+    let pp_op1 hexa = function
       | AF -> "AF"
       | SetAF -> "SetAF"
       | DB -> "DB"
@@ -38,7 +46,7 @@ module Make(S:Scalar.S) =
       | Valid -> "Valid"
       | EL0 -> "EL0"
       | OA -> "OA"
-
+      | Extra op1 -> Extra.pp_op1 hexa op1
 
     type scalar = S.t
     type pteval = AArch64PteVal.t
@@ -84,6 +92,18 @@ module Make(S:Scalar.S) =
       | PteVal {oa;_} -> Some (Symbolic (oa2symbol oa))
       | _ -> None
 
+    let exit _ = raise Exit
+    let toExtra cst = Constant.map Misc.identity exit exit cst
+    and fromExtra cst = Constant.map Misc.identity exit exit cst
+
+    let do_op op c1 c2 =
+      try
+        match Extra.do_op op (toExtra c1) (toExtra c2) with
+        | None -> None
+        | Some cst -> Some (fromExtra cst)
+      with Exit -> None
+
+
     let do_op1 = function
       | AF -> getaf
       | SetAF -> setaf
@@ -93,6 +113,14 @@ module Make(S:Scalar.S) =
       | Valid -> getvalid
       | EL0 -> getel0
       | OA -> getoa
+      | Extra op1 ->
+         fun cst ->
+           try
+             match Extra.do_op1 op1 (toExtra cst) with
+             | None -> None
+             | Some cst -> Some (fromExtra cst)
+           with Exit -> None
+
 
     let shift_address_right s c =
       let open Constant in

--- a/lib/AArch64Value.ml
+++ b/lib/AArch64Value.ml
@@ -19,6 +19,8 @@ module Make (C : sig
 end) : Value.AArch64 = struct
   module AArch64I = AArch64Instr.Make (C)
   module AArch64Cst = SymbConstant.Make (Int64Scalar) (AArch64PteVal) (AArch64I)
-  module AArch64Op = ArchOp.OnlyArchOp1 (AArch64Op.Make (Int64Scalar))
+  module NoCst = SymbConstant.Make (Int64Scalar) (PteVal.No) (AArch64I)
+  module NoArchOp = ArchOp.No(NoCst)
+  module AArch64Op = AArch64Op.Make(Int64Scalar)(NoArchOp)
   include SymbValue.Make (AArch64Cst) (AArch64Op)
 end

--- a/lib/ASLOp.ml
+++ b/lib/ASLOp.ml
@@ -1,0 +1,166 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2023-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+
+type op =
+  | Divrm
+  | SetIndex of int
+  | SetField of string
+  | Concat
+  | BVSliceSet of int list
+
+(* No extra operation *)
+type extra_op1
+
+type 'a constr_op1 =
+  | GetIndex of int
+  | GetField of string
+  | BVSlice of int list
+  | ToIntU
+  | ToIntS
+  | ToBool
+  | ToBV
+  | BoolNot
+
+type op1 = extra_op1 constr_op1
+
+type scalar = ASLScalar.t
+type pteval = PteVal.ASL.t
+type instr = ASLBase.Instr.t
+type cst = (scalar, pteval, instr) Constant.t
+
+let pp_op = function
+  | Divrm -> "DIVRM"
+  | SetIndex i -> Printf.sprintf "Set[%d]" i
+  | SetField x -> Printf.sprintf "Set[%S]" x
+  | Concat -> "Concat"
+  | BVSliceSet positions ->
+     Printf.sprintf "SliceSet[%s]"
+     @@ String.concat ", "
+     @@ List.map string_of_int positions
+
+let pp_op1 _hexa = function
+  | GetIndex i -> Printf.sprintf "Get[%d]" i
+  | GetField x -> Printf.sprintf "Get[%S]" x
+  | BVSlice positions ->
+     Printf.sprintf "Slice[%s]" @@ String.concat ", "
+     @@ List.map string_of_int positions
+  | ToIntU -> "ToIntU"
+  | ToIntS -> "ToIntS"
+  | ToBool -> "ToBool"
+  | ToBV -> "ToBV"
+  | BoolNot -> "BoolNot"
+
+let ( let* ) = Option.bind
+let return_concrete s = Some (Constant.Concrete s)
+let as_concrete = function Constant.Concrete v -> Some v | _ -> None
+
+let as_concrete_vector = function
+  | Constant.ConcreteVector v -> Some v
+  | _ -> None
+
+let as_concrete_record = function
+  | Constant.ConcreteRecord v -> Some v
+  | _ -> None
+
+let all_64_bits_positions = List.init 64 (( - ) 63)
+
+let list_set n =
+  let rec list_set acc n elt = function
+    | [] -> None
+    | _ :: t when n == 0 -> Some (List.rev acc @ (elt :: t))
+    | h :: t -> list_set (h :: acc) (n - 1) elt t
+  in
+  list_set [] n
+
+let do_op op c1 c2 =
+  match op with
+  | Divrm ->
+     let* s1 = as_concrete c1 in
+     let* s2 = as_concrete c2 in
+     let* s = ASLScalar.try_divrm s1 s2 in
+     return_concrete s
+  | SetIndex i ->
+     let* vec = as_concrete_vector c1 in
+     let* vec' = list_set i c2 vec in
+     Some (Constant.ConcreteVector vec')
+  | SetField x ->
+     let* record = as_concrete_record c1 in
+     if StringMap.mem x record then
+       let record' = StringMap.add x c2 record in
+       Some (Constant.ConcreteRecord record')
+     else None
+  | Concat ->
+     let* s1 = as_concrete c1 in
+     let* s2 = as_concrete c2 in
+     let* s = ASLScalar.try_concat s1 s2 in
+     return_concrete s
+  | BVSliceSet positions ->
+     let* s1 = as_concrete c1 in
+     let* s2 = as_concrete c2 in
+     let* s = ASLScalar.try_write_slice positions s1 s2 in
+     return_concrete s
+
+let do_op1 op cst =
+  match op with
+  | GetIndex i ->
+     let* vec = as_concrete_vector cst in
+     List.nth_opt vec i
+  | GetField x ->
+        let* record = as_concrete_record cst in
+        StringMap.find_opt x record
+    | ToIntS -> (
+      match cst with
+      | Constant.Concrete s ->
+         ASLScalar.convert_to_int_signed s |> return_concrete
+      | Constant.Symbolic _ -> Some cst
+      | _ -> None)
+    | ToIntU -> (
+      match cst with
+      | Constant.Concrete s ->
+         ASLScalar.convert_to_int_unsigned s |> return_concrete
+      | Constant.Symbolic _ -> Some cst
+      | _ -> None)
+    | ToBV -> (
+      match cst with
+      | Constant.Concrete s -> ASLScalar.convert_to_bv s |> return_concrete
+      | Constant.Symbolic _ -> Some cst
+      | _ -> None)
+    | ToBool ->
+       let* s = as_concrete cst in
+       return_concrete (ASLScalar.convert_to_bool s)
+    | BVSlice positions -> (
+      match cst with
+      | Constant.Concrete s ->
+         let* s' = ASLScalar.try_extract_slice s positions in
+         return_concrete s'
+      | Constant.Symbolic x ->
+         if Misc.list_eq ( = ) positions all_64_bits_positions then
+           Some (Constant.Symbolic x)
+         else None
+      | _ -> None)
+    | BoolNot -> (
+      let open Constant in
+      let open ASLScalar in
+      match cst with
+      | Concrete (S_Bool b) -> return_concrete (S_Bool (not b))
+      | _ -> None)
+
+let shift_address_right _ _ = None
+let orop _ _ = None
+let andnot2 _ _ = None
+let andop _ _ = None
+let mask _ _ = None

--- a/lib/ASLValue.ml
+++ b/lib/ASLValue.ml
@@ -1,7 +1,3 @@
-module ASLConstant = SymbConstant.Make (ASLScalar) (PteVal.No) (ASLBase.Instr)
-module ASLPteVal = ASLConstant.PteVal
-module ASLInstr = ASLConstant.Instr
-
 type asl_op =
   | Divrm
   | SetIndex of int
@@ -9,7 +5,9 @@ type asl_op =
   | Concat
   | BVSliceSet of int list
 
-type asl_op1 =
+type asl_extra_op1
+
+type 'a asl_constr_op1 =
   | GetIndex of int
   | GetField of string
   | BVSlice of int list
@@ -18,6 +16,11 @@ type asl_op1 =
   | ToBool
   | ToBV
   | BoolNot
+
+module ASLConstant = SymbConstant.Make (ASLScalar) (PteVal.No) (ASLBase.Instr)
+module ASLPteVal = ASLConstant.PteVal
+module ASLInstr = ASLConstant.Instr
+
 (*
    A note on ASL ArchOps
    ---------------------
@@ -31,7 +34,8 @@ type asl_op1 =
 module ASLArchOp :
   ArchOp.S
     with type op = asl_op
-     and type op1 = asl_op1
+     and type extra_op1 = asl_extra_op1
+     and type 'a constr_op1 = 'a asl_constr_op1
      and type scalar = ASLScalar.t
      and type pteval = ASLPteVal.t
      and type instr = ASLInstr.t
@@ -41,7 +45,10 @@ module ASLArchOp :
   type instr = ASLInstr.t
   type cst = ASLConstant.v
   type op = asl_op
-  type op1 = asl_op1
+
+  type extra_op1 = asl_extra_op1
+  type 'a constr_op1 = 'a asl_constr_op1
+  type op1 = extra_op1 constr_op1
 
   let pp_op = function
     | Divrm -> "DIVRM"

--- a/lib/ASLValue.ml
+++ b/lib/ASLValue.ml
@@ -1,177 +1,23 @@
-type asl_op =
-  | Divrm
-  | SetIndex of int
-  | SetField of string
-  | Concat
-  | BVSliceSet of int list
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2023-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
 
-type asl_extra_op1
 
-type 'a asl_constr_op1 =
-  | GetIndex of int
-  | GetField of string
-  | BVSlice of int list
-  | ToIntU
-  | ToIntS
-  | ToBool
-  | ToBV
-  | BoolNot
-
-module ASLConstant = SymbConstant.Make (ASLScalar) (PteVal.No) (ASLBase.Instr)
-module ASLPteVal = ASLConstant.PteVal
-module ASLInstr = ASLConstant.Instr
-
-(*
-   A note on ASL ArchOps
-   ---------------------
-
-   The following implementation of operations on values don't have any effects
-   on symbolics values. This is to mimic herd's semantics. This matches the
-   implementation of translation from ASL equations to AArch64 equations where
-   those operations are dropped.
- *)
-
-module ASLArchOp :
-  ArchOp.S
-    with type op = asl_op
-     and type extra_op1 = asl_extra_op1
-     and type 'a constr_op1 = 'a asl_constr_op1
-     and type scalar = ASLScalar.t
-     and type pteval = ASLPteVal.t
-     and type instr = ASLInstr.t
-     and type cst = ASLConstant.v = struct
-  type scalar = ASLScalar.t
-  type pteval = ASLPteVal.t
-  type instr = ASLInstr.t
-  type cst = ASLConstant.v
-  type op = asl_op
-
-  type extra_op1 = asl_extra_op1
-  type 'a constr_op1 = 'a asl_constr_op1
-  type op1 = extra_op1 constr_op1
-
-  let pp_op = function
-    | Divrm -> "DIVRM"
-    | SetIndex i -> Printf.sprintf "Set[%d]" i
-    | SetField x -> Printf.sprintf "Set[%S]" x
-    | Concat -> "Concat"
-    | BVSliceSet positions ->
-        Printf.sprintf "SliceSet[%s]"
-        @@ String.concat ", "
-        @@ List.map string_of_int positions
-
-  let pp_op1 _hexa = function
-    | GetIndex i -> Printf.sprintf "Get[%d]" i
-    | GetField x -> Printf.sprintf "Get[%S]" x
-    | BVSlice positions ->
-        Printf.sprintf "Slice[%s]" @@ String.concat ", "
-        @@ List.map string_of_int positions
-    | ToIntU -> "ToIntU"
-    | ToIntS -> "ToIntS"
-    | ToBool -> "ToBool"
-    | ToBV -> "ToBV"
-    | BoolNot -> "BoolNot"
-
-  let ( let* ) = Option.bind
-  let return_concrete s = Some (Constant.Concrete s)
-  let as_concrete = function Constant.Concrete v -> Some v | _ -> None
-
-  let as_concrete_vector = function
-    | Constant.ConcreteVector v -> Some v
-    | _ -> None
-
-  let as_concrete_record = function
-    | Constant.ConcreteRecord v -> Some v
-    | _ -> None
-
-  let all_64_bits_positions = List.init 64 (( - ) 63)
-
-  let list_set =
-    let rec list_set acc n elt = function
-      | [] -> None
-      | _ :: t when n == 0 -> Some (List.rev acc @ (elt :: t))
-      | h :: t -> list_set (h :: acc) (n - 1) elt t
-    in
-    list_set []
-
-  let do_op op c1 c2 =
-    match op with
-    | Divrm ->
-        let* s1 = as_concrete c1 in
-        let* s2 = as_concrete c2 in
-        let* s = ASLScalar.try_divrm s1 s2 in
-        return_concrete s
-    | SetIndex i ->
-        let* vec = as_concrete_vector c1 in
-        let* vec' = list_set i c2 vec in
-        Some (Constant.ConcreteVector vec')
-    | SetField x ->
-        let* record = as_concrete_record c1 in
-        if StringMap.mem x record then
-          let record' = StringMap.add x c2 record in
-          Some (Constant.ConcreteRecord record')
-        else None
-    | Concat ->
-        let* s1 = as_concrete c1 in
-        let* s2 = as_concrete c2 in
-        let* s = ASLScalar.try_concat s1 s2 in
-        return_concrete s
-    | BVSliceSet positions ->
-        let* s1 = as_concrete c1 in
-        let* s2 = as_concrete c2 in
-        let* s = ASLScalar.try_write_slice positions s1 s2 in
-        return_concrete s
-
-  let do_op1 op cst =
-    match op with
-    | GetIndex i ->
-        let* vec = as_concrete_vector cst in
-        List.nth_opt vec i
-    | GetField x ->
-        let* record = as_concrete_record cst in
-        StringMap.find_opt x record
-    | ToIntS -> (
-        match cst with
-        | Constant.Concrete s ->
-            ASLScalar.convert_to_int_signed s |> return_concrete
-        | Constant.Symbolic _ -> Some cst
-        | _ -> None)
-    | ToIntU -> (
-        match cst with
-        | Constant.Concrete s ->
-            ASLScalar.convert_to_int_unsigned s |> return_concrete
-        | Constant.Symbolic _ -> Some cst
-        | _ -> None)
-    | ToBV -> (
-        match cst with
-        | Constant.Concrete s -> ASLScalar.convert_to_bv s |> return_concrete
-        | Constant.Symbolic _ -> Some cst
-        | _ -> None)
-    | ToBool ->
-        let* s = as_concrete cst in
-        return_concrete (ASLScalar.convert_to_bool s)
-    | BVSlice positions -> (
-        match cst with
-        | Constant.Concrete s ->
-            let* s' = ASLScalar.try_extract_slice s positions in
-            return_concrete s'
-        | Constant.Symbolic x ->
-            if Misc.list_eq ( = ) positions all_64_bits_positions then
-              Some (Constant.Symbolic x)
-            else None
-        | _ -> None)
-    | BoolNot -> (
-        let open Constant in
-        let open ASLScalar in
-        match cst with
-        | Concrete (S_Bool b) -> return_concrete (S_Bool (not b))
-        | _ -> None)
-
-  let shift_address_right _ _ = None
-  let orop _ _ = None
-  let andnot2 _ _ = None
-  let andop _ _ = None
-  let mask _ _ = None
+module ASLScalar = struct
+  include ASLScalar
+  let printable c = c
 end
-
-module V = SymbValue.Make (ASLConstant) (ASLArchOp)
+module ASLConstant = SymbConstant.Make (ASLScalar) (PteVal.ASL) (ASLBase.Instr)
+module V = SymbValue.Make (ASLConstant) (ASLOp)

--- a/lib/CapabilityValue.ml
+++ b/lib/CapabilityValue.ml
@@ -18,10 +18,12 @@ module Make (C : sig
   val is_morello : bool
 end) : Value.AArch64 = struct
   module AArch64Instr = AArch64Instr.Make (C)
-  module CapOp = ArchOp.OnlyArchOp1 (AArch64Op.Make (CapabilityScalar))
-
-  include
-    SymbValue.Make
-      (SymbConstant.Make (CapabilityScalar) (AArch64PteVal) (AArch64Instr))
-         (CapOp)
+  module AArch64Constant =
+    SymbConstant.Make (CapabilityScalar) (AArch64PteVal) (AArch64Instr)
+  module NoCst =
+    SymbConstant.Make (CapabilityScalar) (PteVal.No) (AArch64Instr)
+  module NoArchOp = ArchOp.No(NoCst)
+  type extra_op1 = NoArchOp.op1
+  module CapOp = AArch64Op.Make (CapabilityScalar)(NoArchOp)
+  include SymbValue.Make(AArch64Constant)(CapOp)
 end

--- a/lib/CapabilityValue.ml
+++ b/lib/CapabilityValue.ml
@@ -23,7 +23,6 @@ end) : Value.AArch64 = struct
   module NoCst =
     SymbConstant.Make (CapabilityScalar) (PteVal.No) (AArch64Instr)
   module NoArchOp = ArchOp.No(NoCst)
-  type extra_op1 = NoArchOp.op1
   module CapOp = AArch64Op.Make (CapabilityScalar)(NoArchOp)
   include SymbValue.Make(AArch64Constant)(CapOp)
 end

--- a/lib/archOp.ml
+++ b/lib/archOp.ml
@@ -18,7 +18,9 @@
 
 module type S = sig
   type op
-  type op1
+  type extra_op1
+  type 'a constr_op1
+  type op1 = extra_op1 constr_op1
 
   val pp_op : op -> string
   val pp_op1 : bool (* hexa *) -> op1 -> string
@@ -48,7 +50,8 @@ module type S = sig
   val mask : cst -> MachSize.sz -> cst option
 end
 
-type no_arch_op1
+type no_extra_op1
+type 'a no_constr_op1
 type no_arch_op
 
 module No (Cst : Constant.S) :
@@ -57,10 +60,13 @@ module No (Cst : Constant.S) :
      and type pteval = Cst.PteVal.t
      and type instr = Cst.Instr.t
      and type op = no_arch_op
-     and type op1 = no_arch_op1
+     and type extra_op1 = no_extra_op1
+     and type 'a constr_op1 = 'a no_constr_op1
 = struct
   type op = no_arch_op
-  type op1 = no_arch_op1
+  type extra_op1 = no_extra_op1
+  type 'a constr_op1 = 'a no_constr_op1
+  type op1 = extra_op1 constr_op1
 
   let pp_op _ = assert false
   let pp_op1 _hexa _ = assert false
@@ -80,7 +86,9 @@ module No (Cst : Constant.S) :
 end
 
 module type S1 = sig
-  type op1
+  type extra_op1
+  type 'a constr_op1
+  type op1 = extra_op1 constr_op1
 
   val pp_op1 : bool (* hexa *) -> op1 -> string
 
@@ -99,7 +107,8 @@ end
 
 module OnlyArchOp1 (A : S1) :
   S
-    with type op1 = A.op1
+    with type extra_op1 = A.extra_op1
+     and type 'a constr_op1 = 'a A.constr_op1
      and type scalar = A.scalar
      and type pteval = A.pteval
      and type instr = A.instr

--- a/lib/capabilityScalar.ml
+++ b/lib/capabilityScalar.ml
@@ -36,6 +36,8 @@ let to_int (_,x) = Uint128.to_int x
 let of_int64 x = false,Uint128.of_int64 x
 let to_int64 (_,x) = Uint128.to_int64 x
 
+let printable c = c
+
 let compare (t1,x1) (t2,x2) =
   match Uint128.compare x1 x2 with
   | 0 -> compare t1 t2

--- a/lib/int128Scalar.ml
+++ b/lib/int128Scalar.ml
@@ -16,6 +16,8 @@
 
 include Int128
 
+let printable c = c
+
 let shift_right_arithmetic = Int128.shift_right
 
 let addk x k = match k with

--- a/lib/int32Scalar.ml
+++ b/lib/int32Scalar.ml
@@ -16,6 +16,8 @@
 
 include Int32
 
+let printable c = c
+
 let shift_right_arithmetic = Int32.shift_right
 
 let addk x k = match k with

--- a/lib/int64Scalar.ml
+++ b/lib/int64Scalar.ml
@@ -17,6 +17,8 @@
 
 include Int64
 
+let printable c = c
+
 let shift_right_arithmetic = Int64.shift_right
 
 let addk x k = match k with

--- a/lib/pteVal.ml
+++ b/lib/pteVal.ml
@@ -78,3 +78,5 @@ module No = struct
     let as_physical _ = None
     let as_flags _ = None
 end
+
+module ASL = No

--- a/lib/pteVal.ml
+++ b/lib/pteVal.ml
@@ -51,30 +51,30 @@ module type S = sig
   val as_flags : t -> string option
 end
 
-module No= struct
-    type t
+module No = struct
+    type t = unit
 
-    let default _ = assert false
-    let of_pte _ = assert false
-    let is_default _ = assert false
-    let pp _ _ = assert false
-    let pp_v _ = assert false
-    let pp_hash _ = assert false
-    let tr _ = assert false
-    let pp_norm _ = assert false
+    let default _ = ()
+    let of_pte _ = ()
+    let is_default _ = true
+    let pp _ _ = "()"
+    let pp_v _ = "()"
+    let pp_hash _ = "()"
+    let tr _ = ()
+    let pp_norm _ = "()"
 
-    let eq _ _ = assert false
-    let compare _ _ = assert false
+    let eq _ _ = true
+    let compare _ _ = 0
 
-    let is_af _ = assert false
+    let is_af _ = false
 
-    let same_oa _ _ = assert false
-    let writable _ _ _ = assert false
-    let get_attrs _ = assert false
+    let same_oa _ _ = false
+    let writable _ _ _ = false
+    let get_attrs _ = []
 
     let fields = []
     let default_fields = []
-    let dump_pack _ _ = assert false
+    let dump_pack _ _ = "()"
     let as_physical _ = None
     let as_flags _ = None
 end

--- a/lib/pteVal.mli
+++ b/lib/pteVal.mli
@@ -53,3 +53,4 @@ module type S = sig
 end
 
 module No : S
+module ASL : S

--- a/lib/scalar.mli
+++ b/lib/scalar.mli
@@ -34,6 +34,7 @@ module type S = sig
   val of_int64 : int64 -> t
   val to_int64 : t -> int64 (* Hum *)
 
+  val printable : t -> t
   val compare : t -> t -> int
   val equal : t -> t -> bool
 

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -27,7 +27,9 @@ module
   module Cst = Cst
 
   type arch_op = ArchOp.op
-  type arch_op1 = ArchOp.op1
+  type arch_extra_op1 = ArchOp.extra_op1
+  type 'a arch_constr_op1 = 'a ArchOp.constr_op1
+  type arch_op1 = arch_extra_op1 arch_constr_op1
 
   let pp_arch_op = ArchOp.pp_op
   let pp_arch_op1 = ArchOp.pp_op1

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -70,6 +70,11 @@ module
   let pp_v =  do_pp Cst.pp_v
   let pp_v_old =  do_pp Cst.pp_v_old
 
+  let printable = function
+    | Val (c) ->
+       Val (Constant.map_scalar Cst.Scalar.printable c)
+    | v -> v
+
   let equalityPossible v1 v2 =
     match (v1,v2) with
     | Val x1,Val x2 -> Cst.compare x1 x2 = 0

--- a/lib/symbValue.mli
+++ b/lib/symbValue.mli
@@ -18,13 +18,15 @@
 
 module Make : functor
   (Cst : Constant.S)
-  (ArchOp : ArchOp.S
-              with type scalar = Cst.Scalar.t
-               and type pteval = Cst.PteVal.t
-               and type instr = Cst.Instr.t)
+  (ArchOp :
+     ArchOp.S
+   with type scalar = Cst.Scalar.t
+    and type pteval = Cst.PteVal.t
+    and type instr = Cst.Instr.t)
   ->
   Value.S
     with module Cst = Cst
-     and type arch_op = ArchOp.op
+     and module Cst.Scalar = Cst.Scalar
      and type arch_extra_op1 = ArchOp.extra_op1
      and type 'a arch_constr_op1 = 'a ArchOp.constr_op1
+     and type arch_op = ArchOp.op

--- a/lib/symbValue.mli
+++ b/lib/symbValue.mli
@@ -26,4 +26,5 @@ module Make : functor
   Value.S
     with module Cst = Cst
      and type arch_op = ArchOp.op
-     and type arch_op1 = ArchOp.op1
+     and type arch_extra_op1 = ArchOp.extra_op1
+     and type 'a arch_constr_op1 = 'a ArchOp.constr_op1

--- a/lib/uint128Scalar.ml
+++ b/lib/uint128Scalar.ml
@@ -17,6 +17,8 @@
 open Uint
 include Uint128
 
+let printable c = c
+
 let shift_right_arithmetic = Uint128.shift_right
 
 let addk x k = match k with

--- a/lib/uint128Value.ml
+++ b/lib/uint128Value.ml
@@ -18,10 +18,11 @@ module Make (C : sig
   val is_morello : bool
 end) : Value.AArch64 = struct
   module AArch64Instr = AArch64Instr.Make (C)
-
   module AArch64Cst =
     SymbConstant.Make (Uint128Scalar) (AArch64PteVal) (AArch64Instr)
-
-  module AArch64Op = ArchOp.OnlyArchOp1 (AArch64Op.Make (Uint128Scalar))
+  module NoCst =
+    SymbConstant.Make (Uint128Scalar) (PteVal.No)(AArch64Instr)
+  module NoArchOp = ArchOp.No(NoCst)
+  module AArch64Op = AArch64Op.Make (Uint128Scalar)(NoArchOp)
   include SymbValue.Make (AArch64Cst) (AArch64Op)
 end

--- a/lib/value.mli
+++ b/lib/value.mli
@@ -18,12 +18,12 @@
 
 module type S =
     sig
-
 (* Constants, notice that they include symbolic "rigid" constants *)
       module Cst : Constant.S
-
       type arch_op
-      type arch_op1 (* Arch specific operations *)
+      type arch_extra_op1
+      type 'a arch_constr_op1 (* Arch specific operations *)
+      type arch_op1 = arch_extra_op1 arch_constr_op1
 
       val pp_arch_op : arch_op -> string
       val pp_arch_op1 : bool -> arch_op1 -> string
@@ -112,7 +112,9 @@ module type S =
       val map_csym : (csym -> v) -> v -> v
     end
 
-module type AArch64 = S
+module type AArch64 = sig
+  include S
   with type Cst.PteVal.t = AArch64PteVal.t
   and type Cst.Instr.t = AArch64Base.instruction
-  and type arch_op1 = AArch64Op.t
+  and type 'a arch_constr_op1 = 'a AArch64Op.t
+end

--- a/lib/value.mli
+++ b/lib/value.mli
@@ -47,6 +47,11 @@ module type S =
       val pp : bool (* hexa *) -> v -> string
       val pp_unsigned : bool (* hexa *) -> v -> string
 
+(* Some architecture may somehow normalize values before
+   printing them. *)
+      val printable : v -> v
+
+
 (* produce a fresh variable *)
       val fresh_var : unit -> v
       val from_var : csym -> v
@@ -112,9 +117,14 @@ module type S =
       val map_csym : (csym -> v) -> v -> v
     end
 
-module type AArch64 = sig
-  include S
+module type AArch64 =
+  S
   with type Cst.PteVal.t = AArch64PteVal.t
   and type Cst.Instr.t = AArch64Base.instruction
   and type 'a arch_constr_op1 = 'a AArch64Op.t
-end
+
+module type AArch64ASL =
+  AArch64
+  with type Cst.Scalar.t = ASLScalar.t
+  and type arch_op = ASLOp.op
+  and type arch_extra_op1 = ASLOp.op1


### PR DESCRIPTION
The AArch64-ASL architecture (_i.e._ AArch64 with `-variant asl`) now uses ASL scalars --- _i.e._ arbitrary precision integers, boolean and bitvectors. On important advantage is that equations unsolved at the ASL level can now be integrated almost as is into AArch64 equations for being solved later.

~~Not perfect though, as the final contents of some locations are sometimes printed as bitivectors:~~ Fixed.
```
AArch64 STR
{
0:X1=x;
int x;
}
  P0        ;
MOV W0,#24  ;
STR W0,[X1] ;
locations [x;]
```
Sample run:
```
% herd7 -variant ASL STR.litmus
Test STR Required
States 1
[x]='00000000000000000000000000011000';
Ok
Witnesses
Positive: 1 Negative: 0
Condition forall (true)
Observation STR Always 1 0
Time STR 0.68
Hash=a29f64fdcce32b5956fd2a67f0dbfb44

```
