### PR TITLE
[litmus] Cleanup the code that handles labels for ifetch and faults

### DIFF
--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -613,15 +613,12 @@ module RegMap = A.RegMap)
         match O.mode,do_self with
         | Mode.Std,false ->
            sprintf "_a->%s" (fmt_lbl_var p lbl)
-        | (Mode.PreSi|Mode.Kvm),false ->
-           sprintf "_g->lbl.%s" (fmt_lbl_var p lbl)
         | Mode.Std,true ->
            sprintf "&_a->%s[_i*_a->%s+_a->%s+%s]"
              (fmt_code p) (fmt_code_size p)
              (fmt_prelude p) (fmt_lbl_offset p lbl)
-        | (Mode.PreSi|Mode.Kvm),true ->
-           sprintf "(ins_t *)_vars->%s+_vars->%s+%s"
-             (fmt_code p) (fmt_prelude p) (fmt_lbl_offset p lbl)
+        | (Mode.PreSi|Mode.Kvm),_ ->
+           sprintf "_vars->labels.%s" (fmt_lbl_var p lbl)
 
       let compile_instr_call i = AL.GetInstr.instr_name i
       let indirect_star =

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -810,6 +810,8 @@ module A.FaultType = A.FaultType)
             extra_data ;_
           } = t in
       let procs_user = ProcsUser.get info in
+      if Misc.consp procs_user && do_self && is_pte then
+        Warn.user_error "litmus7 cannot handle -variant self -mode kvm when there are processes in userspace" ;
       let initenv = List.map (fun (loc,(_,v)) -> loc,v) init in
       let observed = Generic.all_observed final filter locs in
       let ty_env1 = Generic.build_type_env init final filter locs

--- a/litmus/libdir/_instance.c
+++ b/litmus/libdir/_instance.c
@@ -47,6 +47,7 @@ static void instance_init(ctx_t *p, int id, intmax_t *mem) {
   interval_init((int *)&p->ind,N) ;
 #ifdef SOME_VARS
   vars_init(&p->v,mem);
+  labels_init(&p->v);
 #endif
 }
 
@@ -75,10 +76,6 @@ typedef struct global_t {
   /* Topology */
   const int *inst, *role ;
   const char **group ;
-#ifdef SOME_LABELS
-  /* Some labels as constants */
-  code_labels_t lbl;
-#endif
   /* memory */
   intmax_t *mem ;
   /* Cache control */
@@ -114,9 +111,6 @@ static void init_global(global_t *g) {
   g->inst = inst;
   g->role = role;
   g->group = group;
-#ifdef SOME_LABELS
-  code_labels_init(&g->lbl);
-#endif
 #ifdef ACTIVE
   g->active = active;
 #endif


### PR DESCRIPTION
This PR implements an optimization identified while reviewing PR#589. Also, it removes some code duplication in how litmus7 uses labels to find the location of an instruction, for the purposes of recording a fault and reading from/writing to an instruction.