### PR TITLE
[litmus] Fix control flow for liveness

### DIFF
--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -149,8 +149,8 @@ module Make(O:Config)(A:I) =
     type flow = Any | Next | Branch of string | Disp of int
 
     let add_next b = match b with
-      | Next|Any|Disp _ -> [b;]
-      | Branch _ -> [Next; b;]
+      | Next|Any-> [b;]
+      | Branch _|Disp _ -> [Next; b;]
 
     type ins =
         { memo:string ; inputs:arch_reg list ;  outputs:arch_reg list;


### PR DESCRIPTION
The bug was considering that conditional branches with displacement arguments were behaving as always taken --- In other words, the "Next" control flow information was ignored for those instructions, resulting in wrong live-in information and finally missing initialisations.

Bug discovered on this test:
```
AArch64 A
{
int 1:X2=0;
0:X0=x;
1:X0=x;
}

 P0          |  P1          ;
             |L1:           ;
 MOV W1,#1   | LDR W1,[X0]  ;
 STR W1,[X0] | CBZ W1,.-4   ;
             | ADD W2,W2,#2 ;
locations [1:X2;]
forall 1:X2=2
```
The litmus tool was not issuing an initialisation of the register `1:X2` resulting in random results.