### PR TITLE
implement the ability to use the J direction

### DIFF
--- a/gen/code.ml
+++ b/gen/code.ml
@@ -112,7 +112,7 @@ let do_fold_extr withj f r =
   let r = f (Dir W) (f (Dir R) (f Irr r)) in
   if withj then f (Dir J) r
   else r
-let fold_extr f r = do_fold_extr false f r
+let fold_extr f r = do_fold_extr true f r
 let fold_sd_extr f = fold_sd (fun sd -> fold_extr (fun e -> f sd e))
 let fold_sd_extr_extr f =
   fold_sd_extr (fun sd e1 -> fold_extr (fun e2 -> f sd e1 e2))


### PR DESCRIPTION
The intention of this PR is to allow for the use of the J direction in the diy generator in order to take advantage of the ability to Insert Barriers without specifying direction.

for example, this would allow for the generation of the following relaxation test:

```
diyone7 -arch AArch64 "PodWJ ISB PosJW Coe PodWR Fre" 
AArch64 A
"PodWJ ISB PosJW Coe PodWR Fre"
Generator=diyone7 (version 7.56+03)
Com=Co Fr
Orig=PodWJ ISB PosJW Coe PodWR Fre
{
0:X1=x; 0:X3=y;
1:X1=y; 1:X2=x;
}
 P0          | P1          ;
 MOV W0,#1   | MOV W0,#2   ;
 STR W0,[X1] | STR W0,[X1] ;
 ISB                  | LDR W3,[X2] ;
 MOV W2,#1   |             ;
 STR W2,[X3] |             ;
exists ([y]=2 /\ 1:X3=0)
```

I am aware this test can also be generated by using `diyone7 -arch AArch64 "ISBdWW Coe PodWR Fre" ` However it would be interesting to be able to use the syntax with the J direction.

As far as i can tell, there is currently no way to activate the J direction other than this, however it is entirely possible that I missed something.