### PR TITLE
implement support for ifetch as an annotation

### DIFF
--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -162,7 +162,7 @@ let applies_atom (a,_) d = match a,d with
 | Rel _,W
 | Pte (Read|ReadAcq|ReadAcqPc),R
 | Pte (Set _|SetRel _),W
-| Ifetch, R
+| Ifetch, W
 | (Plain _|Atomic _|Tag|CapaTag|CapaSeal|Neon _|Pair _),(R|W)
   -> true
 | _ -> false
@@ -213,7 +213,7 @@ let is_ifetch a = match a with
      | Neon n -> SIMD.pp n
      | Pair (opt,idx)
        -> sprintf "Pa%s%s" (pp_pair_opt opt) (pp_pair_idx idx)
-     | Ifetch -> "{Ifetch}"
+     | Ifetch -> "I"
 
    let pp_atom (a,m) = match a with
    | Plain o ->

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1232,7 +1232,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | R,Some (Acq _,None) ->
             let r,init,cs,st = LDAR.emit_load st p init loc  in
             Some r,init,cs,st
-        | R, Some (Ifetch, _) -> Warn.fatal "something went wrong"
+        | R, Some (Ifetch, _) -> Warn.fatal "Ifetch annotation did not create code location"
         | R,Some (Acq a,Some (sz,o)) ->
             let module L =
               LOAD

--- a/gen/BellArch_gen.ml
+++ b/gen/BellArch_gen.ml
@@ -115,7 +115,7 @@ let tr_dir = function
 let applies_atom = match bi with
 | None -> (fun a _d -> match a with [] -> true | _ -> false)
 | Some bi -> (fun a d -> BellModel.check_event (tr_dir d) a bi)
-
+let is_ifetch _ = false
 let pp_plain = "P"
 let pp_as_a = None
 

--- a/gen/CArch_gen.ml
+++ b/gen/CArch_gen.ml
@@ -33,7 +33,7 @@ let applies_atom a d = match a,d with
 | (Acq|Acq_Rel|Con),W -> false
 | (Rel|Acq_Rel),R -> false
 | _,_ -> true
-
+let is_ifetch _ = false
 let compare_atom = Misc.polymorphic_compare
 
 include MachMixed.No

--- a/gen/RISCVArch_gen.ml
+++ b/gen/RISCVArch_gen.ml
@@ -62,7 +62,7 @@ module Make
        | Sc,_ -> assert false
        end
    | Atomic _|Mixed _ -> true
-
+   let is_ifetch _ = false
    let pp_plain = "P"
 
    let pp_as_a = None

--- a/gen/X86Arch_gen.ml
+++ b/gen/X86Arch_gen.ml
@@ -31,7 +31,7 @@ let default_atom = Atomic
 let applies_atom a d = match a,d with
 | Atomic,W -> true
 | _,_ -> false
-
+let is_ifetch _ = false
 let compare_atom = compare
 
 include MachMixed.No

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -53,6 +53,7 @@ module Make
       | (((Plain|NonTemporal),_),(Code.W|Code.R)) -> true
       | ((Atomic,_),Code.R)
       | (_,Code.J)-> false
+    let is_ifetch _ = false
 
       let compare_atom = compare
 

--- a/gen/atom.mli
+++ b/gen/atom.mli
@@ -33,6 +33,7 @@ module type S = sig
   type atom
   val default_atom : atom
   val applies_atom : atom -> Code.dir -> bool
+  val is_ifetch : atom option -> bool
   val compare_atom : atom -> atom -> int
   val get_access_atom : atom option -> MachMixed.t option
   val set_access_atom : atom option -> MachMixed.t -> atom option

--- a/gen/code.ml
+++ b/gen/code.ml
@@ -165,7 +165,7 @@ type info = (string * string) list
 let plain = "Na"
 
 (* Memory Space *)
-type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a | Pair
+type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a | Pair | Instr
 
 let pp_bank = function
   | Ord -> "Ord"
@@ -175,6 +175,7 @@ let pp_bank = function
   | Pte -> "Pte"
   | VecReg _ -> "VecReg"
   | Pair -> "Pair"
+  | Instr -> "Instr"
 
 let tag_of_int  = function
   | 0 -> "green"

--- a/gen/code.mli
+++ b/gen/code.mli
@@ -90,7 +90,7 @@ type info = (string * string) list
 val plain : string
 
 (* Memory bank (for MTE, KVM)  *)
-type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a | Pair
+type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a | Pair | Instr
 
 val pp_bank : 'a bank -> string
 

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -582,6 +582,18 @@ let patch_edges n =
   let merge_annotations m =
       let rec do_rec n =
         let e = n.edge in
+        match e.E.edge with
+        | E.Fr ie -> if E.is_ifetch e.E.a1 then begin
+          n.edge <- {e with E.a1=None; };
+          n.edge <- {e with E.edge=E.Ifr ie; };
+        end
+        else ();
+        | E.Rf ie -> if E.is_ifetch e.E.a2 then begin
+          n.edge <- {e with E.a2=None; };
+          n.edge <- {e with E.edge=E.Irf ie; };
+        end
+        else ();
+        | _ -> ();
         if non_insert_store e then begin
           let p = find_non_insert_store_prev n.prev in
           if O.verbose > 0 then Printf.eprintf "Merge p=%a, n=%a\n"
@@ -1281,7 +1293,7 @@ let rec group_rec x ns = function
           if
             E.is_node m.edge.E.edge || not (pbank m.evt.bank)
           then k else (e.loc,m)::k
-      | None| Some R | Some J -> k in
+      | None| Some R | Some J-> k in
       if m.store == nil then k
       else begin
         let e = m.store.evt in

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -452,13 +452,10 @@ let make_loc n =
   if n < locs_len then locs.(n)
   else Printf.sprintf "x%02i" (n-locs_len)
 
-let next_loc e ((loc0,lab0),vs) = match e.E.edge with
-| (E.Irf _|E.Ifr _) -> Code (sprintf "Lself%02i" lab0),((loc0,lab0+1),vs)
+let next_loc e ((loc0,lab0),vs) = match E.is_fetch e with
+| true -> Code (sprintf "Lself%02i" lab0),((loc0,lab0+1),vs)
 | _ -> 
-  if (E.is_ifetch e.E.a1 || E.is_ifetch e.E.a2) then
-    Code (sprintf "Lself%02i" lab0),((loc0,lab0+1),vs)
-  else
-    Code.Data (make_loc loc0),((loc0+1,lab0),vs)
+  Code.Data (make_loc loc0),((loc0+1,lab0),vs)
 
 let same_loc e = match E.loc_sd e with
     | Same -> true

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -748,8 +748,9 @@ let fold_tedges f r =
   | Rf _|Fr _|Ws _|Irf _|Ifr _|Leave _|Back _| Hat -> true
   | _ -> false
 
-  let is_fetch e = match e.edge with
-  | Irf _|Ifr _ -> true
+  let is_fetch e = match e.edge,is_ifetch e.a1,is_ifetch e.a2 with
+  | Irf _,_,_|Ifr _,_,_
+  | Rf _,true,_| Fr _,_,true -> true
   | _ -> false
 
   let compat_atoms a1 a2 = match F.merge_atoms a1 a2 with

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -43,6 +43,7 @@ module type S = sig
   val set_pteval :
     atom option -> PteVal.t -> (unit -> string) -> PteVal.t
   val merge_atoms : atom -> atom -> atom option
+  val is_ifetch : atom option -> bool
   val atom_to_bank : atom option -> SIMD.atom Code.bank
   val strong : fence
   val pp_fence : fence -> string
@@ -208,7 +209,7 @@ and type rmw = F.rmw = struct
   | Some a,Dir d -> F.applies_atom a d
 
   let merge_atoms = F.merge_atoms
-
+  let is_ifetch = F.is_ifetch
   let atom_to_bank = function
     | None -> Ord
     | Some a -> F.atom_to_bank a

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -748,9 +748,10 @@ let fold_tedges f r =
   | Rf _|Fr _|Ws _|Irf _|Ifr _|Leave _|Back _| Hat -> true
   | _ -> false
 
-  let is_fetch e = match e.edge,is_ifetch e.a1,is_ifetch e.a2 with
-  | Irf _,_,_|Ifr _,_,_
-  | Rf _,true,_| Fr _,_,true -> true
+  let is_fetch e = match e.edge with
+  | Irf _|Ifr _ -> true
+  | Rf _ -> is_ifetch e.a1
+  | Fr _ -> is_ifetch e.a2
   | _ -> false
 
   let compat_atoms a1 a2 = match F.merge_atoms a1 a2 with

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -186,6 +186,11 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
                 Some (S (Code.add_tag (Code.as_data evt.C.C.loc) evt.C.C.v))
             | Code.Pte ->
                 Some (P evt.C.C.pte)
+            | Code.Instr ->
+              let s = match evt.C.C.ins with
+              | 1 -> "instr:\"NOP\""
+              | _ -> Warn.user_error "invalid value with instruction store" in
+              Some (S s)
             end
         | Some Code.W ->
            assert (evt.C.C.bank = Code.Ord || evt.C.C.bank = Code.CapaSeal) ;

--- a/gen/genUtils.ml
+++ b/gen/genUtils.ml
@@ -89,7 +89,7 @@ module Make(Cfg:Config)(A:Arch_gen.S)
        let emit_pteval  st p init v = next_const st p init (A.P v)
 
        let emit_nop st p init nop =
-         let rA,init,st = next_const st p init (S nop) in
+         let rA,init,st = next_const st p init (S ("instr:\""^nop^"\"")) in
          rA,init,st
 
        let emit_mov st p init v = match emit_const st p init v with

--- a/gen/machAtom.ml
+++ b/gen/machAtom.ml
@@ -39,6 +39,7 @@ module Make(C:Config) = struct
   let applies_atom a d = match a,d with
   | Reserve,W -> false
   | _,_ -> true
+  let is_ifetch _ = false
 
   let pp_plain = Code.plain
   let pp_as_a = None

--- a/gen/normaliser.ml
+++ b/gen/normaliser.ml
@@ -311,7 +311,7 @@ module Make : functor (C:Config) -> functor (E:Edge.S) ->
         let r =
           match d with
           | Code.W -> W
-          | Code.R ->
+          | Code.R->
               begin match e.CE.edge.E.edge with
               | E.Ifr _ -> F
               | _ ->

--- a/gen/normaliser.ml
+++ b/gen/normaliser.ml
@@ -311,7 +311,7 @@ module Make : functor (C:Config) -> functor (E:Edge.S) ->
         let r =
           match d with
           | Code.W -> W
-          | Code.R->
+          | Code.R ->
               begin match e.CE.edge.E.edge with
               | E.Ifr _ -> F
               | _ ->

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -309,8 +309,8 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
       | _,_,_ -> false
 
     let fetch_val n =
-      match n.C.C.prev.C.C.edge.C.E.edge, n.C.C.edge.C.E.edge with
-      | C.E.Irf _,_ -> 2
-      | _,C.E.Ifr _ -> 1
-      | _,_ -> 0
+      match n.C.C.prev.C.C.edge.C.E.edge, n.C.C.edge.C.E.edge, (List.for_all C.E.is_ifetch [n.C.C.edge.C.E.a1; n.C.C.edge.C.E.a2]) with
+      | C.E.Irf _,_,_ | C.E.Rf _,_,true-> 2
+      | _,C.E.Ifr _,_ | _,C.E.Fr _,true -> 1
+      | _,_,_ -> 0
   end

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -309,7 +309,8 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
       | _,_,_ -> false
 
     let fetch_val n =
-      match n.C.C.prev.C.C.edge.C.E.edge, n.C.C.edge.C.E.edge, (List.for_all C.E.is_ifetch [n.C.C.edge.C.E.a1; n.C.C.edge.C.E.a2]) with
+      let has_I = List.exists C.E.is_ifetch [n.C.C.prev.C.C.edge.C.E.a1; n.C.C.edge.C.E.a2] in
+      match n.C.C.prev.C.C.edge.C.E.edge, n.C.C.edge.C.E.edge, has_I with
       | C.E.Irf _,_,_ | C.E.Rf _,_,true-> 2
       | _,C.E.Ifr _,_ | _,C.E.Fr _,true -> 1
       | _,_,_ -> 0

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -298,7 +298,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
            | None -> false
            | Some m -> not (m == n || C.C.po_pred m n)
          end
-    | Ord|Pair|Tag|CapaTag|CapaSeal|VecReg _ ->
+    | Ord|Pair|Tag|CapaTag|CapaSeal|VecReg _|Instr ->
         check_edge n.C.C.edge.C.E.edge && not (is_load_init n.C.C.evt)
 
 (* Poll for value is possible *)

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -250,9 +250,13 @@ let get_fence n =
               begin match o with
               | None   -> finals (* Code write *)
               | Some r -> (* fetch! *)
+                    match n.C.prev.C.edge.E.edge, n.C.edge.E.edge, E.is_ifetch n.C.prev.C.edge.E.a2, E.is_ifetch n.C.edge.E.a1 with
+                    |E.Rf _,_,true,_| _,E.Fr _,true,_ -> F.add_final (A.get_friends st) p o n finals
+                    | _,_,_,_-> begin
                   let m,fenv =  finals in
                   m,F.add_final_v p r (IntSet.singleton (U.fetch_val n))
                     fenv
+                    end
               end),
           st
       end
@@ -581,7 +585,7 @@ let max_set = IntSet.max_elt
     let lst = Misc.last ns in
     if U.check_here lst then
       match lst.C.evt.C.loc,lst.C.evt.C.bank with
-      | Data x,(Ord|Pair) -> (* TODO check for -obs local mode and pairs *)
+      | Data x,(Ord|Pair|Instr) -> (* TODO check for -obs local mode and pairs *)
          let nxt = lst.C.next.C.evt in
          let bank = nxt.C.bank in
          begin match bank with


### PR DESCRIPTION
This PR introduces the use of Ifetch as an annotation. This would allow for Ifetch to be used in a similar way to T, A, L etc and be placed in between relaxations to apply an ifetch. 

This change is only syntactic and is intended only to do the following: Ifetch Fre -> Ifre or Ifetch Rfe -> Irfe

The use of Ifetch as an annotation would look as follows:
```
diyone7 -arch AArch64 "PodWW DSB.ISHsWR DSB.ISHdRW Rfe DSB.ISHdRW PodWR {Ifetch} Fre" -moreedges true -variant Self
AArch64 A
"PodWW DSB.ISHsWR DSB.ISHdRW Rfe DSB.ISHdRW PodWRP{Ifetch} Ifre{Ifetch}P"
Generator=diyone7 (version 7.56+03)
Com=Rf Ifr
Orig=PodWW DSB.ISHsWR DSB.ISHdRW Rfe DSB.ISHdRW PodWRP{Ifetch} Ifre{Ifetch}P
{
0:X0=NOP; 0:X1=P1:Lself00; 0:X3=x; 0:X6=y;
1:X0=y; 1:X3=z;
}
 P0          | P1          ;
 STR W0,[X1] | LDR W1,[X0] ;
 MOV W2,#1   | DSB ISH     ;
 STR W2,[X3] | MOV W2,#1   ;
 DSB ISH     | STR W2,[X3] ;
 LDR W4,[X3] | Lself00:    ;
 DSB ISH     | B L00       ;
 MOV W5,#1   | MOV W4,#2   ;
 STR W5,[X6] | B L01       ;
             | L00:        ;
             | MOV W4,#1   ;
             | L01:        ;
exists (0:X4=1 /\ 1:X1=1 /\ 1:X4=1)
```