### PR TITLE
[herd,asl] Fix inversion of ADD and ADDS semantics.

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -278,8 +278,8 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
            | _ -> assert false
          and fname =
            match op with
-           | ADD -> "ADDS_32_addsub_shift.opn"
-           | ADDS -> "ADD_32_addsub_shift.opn"
+           | ADD -> "ADD_32_addsub_shift.opn"
+           | ADDS -> "ADDS_32_addsub_shift.opn"
            | SUB ->  "SUB_32_addsub_shift.opn"
            | SUBS ->  "SUBS_32_addsub_shift.opn"
            | AND ->  "AND_32_log_shift.opn"


### PR DESCRIPTION
There are still difficulties. with NZCV flags. The following test. crashes:
```
AArch64 T
{
int x=1;
0:X8=x;
}

 P0           ;
MOV W0,#1     ;
LDR W1,[X8]   ;
ADDS W2,W1,W0 ;
ADDS W2,W1,W0 ;
locations [0:X2;]
```