### PR TITLE
[herd,asl] Fix transmission of data ports from ASL to AArch64

### DIFF
--- a/herd/libdir/asl.cat
+++ b/herd/libdir/asl.cat
@@ -83,7 +83,7 @@ show asl_iico_ctrl, asl_iico_data, asl_rf_reg
 show iico_ctrl, iico_data, rf, rf-reg
 *)
 
-show AArch64
+show AArch64,AArch64_DATA
 show aarch64_iico_ctrl, aarch64_iico_data, aarch64_iico_order
 
 


### PR DESCRIPTION
The fix is simple: the showing of event set `AArch64_DATA` was missing in file `asl.cat`.

Notice that "showing" sets and relations is a flexible mean to transmit them from ASL to AArch64.

Also notice that `asl.cat` already showed the identity _relation_ over the same event set as `AArch64_DATA`. We leave it, as it apparently does not harm.