### PR TITLE
[asl] New public name "aslref" for the aslseq tool.

### DIFF
--- a/asllib/aslseq.ml
+++ b/asllib/aslseq.ml
@@ -85,9 +85,15 @@ let parse_args () =
   in
 
   let anon_fun s = target_files := s :: !target_files in
+  let prog =
+    if Array.length (Sys.argv) > 0 then Filename.basename Sys.argv.(0)
+    else "aslref" in
+
   let usage_msg =
-    "ASL parser and interpreter.\n\nUSAGE:\n\taslseq [OPTIONS] [FILE]\n"
-  in
+    Printf.sprintf
+      "ASL parser and interpreter.\n\nUSAGE:\n\t%s [OPTIONS] [FILE]\n"
+      prog
+    in
   let () = Arg.parse speclist anon_fun usage_msg in
 
   let strictness =

--- a/asllib/dune
+++ b/asllib/dune
@@ -19,7 +19,8 @@
 (documentation)
 
 (executable
- (public_name aslseq)
+ (name aslseq)
+ (public_name aslref)
  (libraries asllib)
  (modules aslseq))
 


### PR DESCRIPTION
The tool aslseq is now installed as "aslref". That way, changes are minimal.