### PR TITLE
[fix] [asl] Rename aslseq into aslref

### DIFF
--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -129,7 +129,7 @@ let parse_args () =
   let () =
     if !show_version then
       let () =
-        Printf.printf "aslseq version %s rev %s\n%!" Version.version Version.rev
+        Printf.printf "aslref version %s rev %s\n%!" Version.version Version.rev
       in
       exit 0
   in

--- a/asllib/dune
+++ b/asllib/dune
@@ -9,7 +9,7 @@
 
 (library
  (name asllib)
- (modules (:standard \ aslseq bundler))
+ (modules (:standard \ aslref bundler))
  (public_name herdtools7.asllib)
  (private_modules Parser0 Gparser0 Lexer0 SimpleLexer0 RepeatableLexer)
  (modules_without_implementation Backend AST)
@@ -19,10 +19,10 @@
 (documentation)
 
 (executable
- (name aslseq)
+ (name aslref)
  (public_name aslref)
  (libraries asllib)
- (modules aslseq))
+ (modules aslref))
 
 (executable
   (public_name aslbundler)

--- a/asllib/tests/asl.t/division.t
+++ b/asllib/tests/asl.t/division.t
@@ -8,4 +8,4 @@ Unsupported division:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl

--- a/asllib/tests/asl.t/run.t
+++ b/asllib/tests/asl.t/run.t
@@ -1,38 +1,38 @@
 Hello world should work:
 
-  $ aslseq hello_world.asl
+  $ aslref hello_world.asl
   Hello, world!
 
 Type-checking errors:
 
-  $ aslseq subtype-satisfaction-arrray-illegal.asl
+  $ aslref subtype-satisfaction-arrray-illegal.asl
   File subtype-satisfaction-arrray-illegal.asl, line 4, characters 0 to 36:
   ASL Typing error: a subtype of m was expected, provided array [10] of n.
   [1]
 
-  $ aslseq anonymous-types-example.asl
+  $ aslref anonymous-types-example.asl
   File anonymous-types-example.asl, line 21, characters 2 to 6:
   ASL Typing error: a subtype of pairT was expected,
     provided (integer {1}, T2).
   [1]
 
-  $ aslseq duplicate_function_args.asl
+  $ aslref duplicate_function_args.asl
   File duplicate_function_args.asl, line 1, character 0 to line 4, character 3:
   ASL Typing error: cannot declare already declared element "i".
   [1]
 
-  $ aslseq duplicate_record_fields.asl
+  $ aslref duplicate_record_fields.asl
   File duplicate_record_fields.asl, line 1, character 0 to line 5, character 2:
   ASL Typing error: cannot declare already declared element "i".
   [1]
 
-  $ aslseq duplicate_enumeration_items.asl
+  $ aslref duplicate_enumeration_items.asl
   File duplicate_enumeration_items.asl, line 1, characters 0 to 34:
   ASL Typing error: cannot declare already declared element "i".
   [1]
 
 Bad types:
-  $ aslseq overlapping-slices.asl
+  $ aslref overlapping-slices.asl
   File overlapping-slices.asl, line 1, character 0 to line 4, character 2:
   ASL Typing error: overlapping slices 10:0, 3+:2.
   [1]
@@ -44,7 +44,7 @@ Global ignored:
   > begin return 0; end
   > EOF
 
-  $ aslseq global_ignored.asl
+  $ aslref global_ignored.asl
   File global_ignored.asl, line 1, characters 8 to 13:
   ASL Typing error: Illegal application of operator / on types integer {3}
     and integer {0}
@@ -60,7 +60,7 @@ Constrained-type satisfaction:
   > end
   > EOF
 
-  $ aslseq type-sat.asl
+  $ aslref type-sat.asl
   File type-sat.asl, line 5, characters 2 to 3:
   ASL Typing error: a subtype of integer {8, 16} was expected,
     provided integer {8, 16, 32}.
@@ -75,19 +75,19 @@ Constrained-type satisfaction:
   > end
   > EOF
 
-  $ aslseq type-sat.asl
+  $ aslref type-sat.asl
   File type-sat.asl, line 5, characters 2 to 3:
   ASL Typing error: a subtype of integer {8, 16} was expected,
     provided integer.
   [1]
 
-  $ aslseq type_satisfaction_illegal_f3.asl
+  $ aslref type_satisfaction_illegal_f3.asl
   File type_satisfaction_illegal_f3.asl, line 9, characters 4 to 17:
   ASL Typing error: a subtype of integer {8, 16} was expected,
     provided integer.
   [1]
 
-  $ aslseq type_satisfaction_illegal_f4.asl
+  $ aslref type_satisfaction_illegal_f4.asl
   File type_satisfaction_illegal_f4.asl, line 9, characters 4 to 17:
   ASL Typing error: a subtype of integer {8, 16} was expected,
     provided integer {8..64}.
@@ -101,7 +101,7 @@ Constrained-type satisfaction:
   >    return;
   > end
 
-  $ aslseq type-sat.asl
+  $ aslref type-sat.asl
   File type-sat.asl, line 4, characters 2 to 29:
   ASL Typing error: a subtype of integer {2, 4} was expected,
     provided integer {}.
@@ -115,7 +115,7 @@ Constrained-type satisfaction:
   >   return;
   > end
 
-  $ aslseq type-sat.asl
+  $ aslref type-sat.asl
   File type-sat.asl, line 4, characters 2 to 29:
   ASL Typing error: a subtype of integer {2, 4} was expected,
     provided integer {}.
@@ -129,7 +129,7 @@ Runtime checks:
   >   return 0;
   > end
 
-  $ aslseq runtime-type-sat.asl
+  $ aslref runtime-type-sat.asl
   File runtime-type-sat.asl, line 3, characters 23 to 24:
   ASL Execution error: Mismatch type:
     value 2 does not belong to type integer {1}.

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -10,7 +10,7 @@ Bad fields
   > };
   > EOF
 
-  $ aslseq bad-types.asl
+  $ aslref bad-types.asl
   File bad-types.asl, line 1, character 0 to line 4, character 2:
   ASL Typing error: cannot declare already declared element "a".
   [1]
@@ -23,7 +23,7 @@ Overlapping slices
   > };
   > EOF
 
-  $ aslseq bad-types.asl
+  $ aslref bad-types.asl
   File bad-types.asl, line 1, character 0 to line 4, character 2:
   ASL Typing error: overlapping slices 10:0, 3+:2.
   [1]
@@ -36,7 +36,7 @@ Bad slices
   > };
   > EOF
 
-  $ aslseq bad-types.asl
+  $ aslref bad-types.asl
   File bad-types.asl, line 1, character 0 to line 4, character 2:
   ASL Typing error: Cannot extract from bitvector of length 12 slices 14:12.
   [1]
@@ -48,7 +48,7 @@ Bad slices
   > };
   > EOF
 
-  $ aslseq bad-types.asl
+  $ aslref bad-types.asl
   File bad-types.asl, line 1, character 0 to line 4, character 2:
   ASL Typing error: Cannot extract from bitvector of length 12 slices (- 2)+:1.
   [1]
@@ -63,7 +63,7 @@ Bad slices
   > };
   > EOF
 
-  $ aslseq bad-types.asl
+  $ aslref bad-types.asl
   File bad-types.asl, line 1, character 0 to line 7, character 2:
   ASL Typing error: Cannot extract from bitvector of length 3 slices 10:8.
   [1]

--- a/asllib/tests/division.t
+++ b/asllib/tests/division.t
@@ -8,7 +8,7 @@ Division by zero:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   File div.asl, line 3, characters 19 to 26:
   ASL Typing error: Illegal application of operator DIV on types integer {6}
     and integer {0}
@@ -22,7 +22,7 @@ Division by zero:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   File div.asl, line 3, characters 19 to 28:
   ASL Typing error: Illegal application of operator DIVRM on types integer {6}
     and integer {0}
@@ -36,7 +36,7 @@ Division by zero:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   File div.asl, line 3, characters 19 to 26:
   ASL Typing error: Illegal application of operator MOD on types integer {6}
     and integer {0}
@@ -52,7 +52,7 @@ Unsupported divisions (caught at time-checking time):
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   File div.asl, line 3, characters 19 to 27:
   ASL Typing error: Illegal application of operator DIV on types integer {6}
     and integer {(- 3)}
@@ -66,7 +66,7 @@ Unsupported divisions (caught at time-checking time):
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   File div.asl, line 3, characters 19 to 29:
   ASL Typing error: Illegal application of operator DIVRM on types integer {6}
     and integer {(- 3)}
@@ -80,7 +80,7 @@ Unsupported divisions (caught at time-checking time):
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   File div.asl, line 3, characters 19 to 27:
   ASL Typing error: Illegal application of operator MOD on types integer {6}
     and integer {(- 3)}
@@ -96,7 +96,7 @@ The following error is a runtime error because we don't know how to catch those 
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   ASL Execution error: Illegal application of operator DIV for values 5 and 3.
   [1]
 
@@ -112,7 +112,7 @@ For completeness, those operations are runtime errors:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   ASL Execution error: Illegal application of operator DIV for values 6 and -3.
   [1]
 
@@ -126,7 +126,7 @@ For completeness, those operations are runtime errors:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   ASL Execution error: Illegal application of operator DIVRM for values 6
     and -3.
   [1]
@@ -141,7 +141,7 @@ For completeness, those operations are runtime errors:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   ASL Execution error: Illegal application of operator MOD for values 6 and -3.
   [1]
 
@@ -155,7 +155,7 @@ For completeness, those operations are runtime errors:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   ASL Execution error: Illegal application of operator DIV for values 5 and 3.
   [1]
 
@@ -174,7 +174,7 @@ More complicated examples:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   ASL Execution error: Illegal application of operator DIV for values 5 and 0.
   [1]
 
@@ -191,7 +191,7 @@ More complicated examples:
   > end
   > EOF
 
-  $ aslseq div.asl
+  $ aslref div.asl
   ASL Execution error: Illegal application of operator DIV for values 5 and 2.
   [1]
 
@@ -206,7 +206,7 @@ Example from asltools:
   >   let x = glob_a DIV glob_b;
   > end
 
-  $ aslseq div.asl
+  $ aslref div.asl
   File div.asl, line 6, characters 10 to 27:
   ASL Typing error: Illegal application of operator DIV on types
     integer {2, 4, 8} and integer {0, 1, 2}

--- a/asllib/tests/dune
+++ b/asllib/tests/dune
@@ -25,4 +25,4 @@
       (run %{test} -e))))
 
 (cram
-  (deps %{bin:aslseq}))
+  (deps %{bin:aslref}))


### PR DESCRIPTION
`grep aslseq` does not return anything anymore.