### PR TITLE
[AArch64,ARM]: Indirect Branches working for GCC tests.

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2026,10 +2026,12 @@ module Make
            match v with
            | M.A.V.Var(_) as v ->
               let lbls = get_exported_labels test in
-              if Label.Full.Set.is_empty lbls then
-                Warn.fatal
-                  "Could find no potential target for indirect branch %s \
-                   (potential targets are statically known labels)" (AArch64.dump_instruction i)
+              if Label.Full.Set.is_empty lbls  then begin
+                if C.variant Variant.Telechat then M.unitT () >>! B.Exit
+                else
+                  Warn.fatal "Could find no potential target for indirect branch %s \
+                    (potential targets are statically known labels)" (AArch64.dump_instruction i)
+                end
               else
                 commit_bcc ii
                 >>= fun () -> B.indirectBranchT v lbls bds

--- a/herd/tests/instructions/AArch64/A253.litmus
+++ b/herd/tests/instructions/AArch64/A253.litmus
@@ -1,0 +1,26 @@
+AArch64 A253
+
+Variant=telechat
+
+{ [P1_r0]=0;[x]=0;[y]=0; uint64_t %P0_x=x;
+  uint64_t %P0_y=y; uint64_t %P1_P1_r0=P1_r0;
+  uint64_t %P1_x=x;uint64_t %P1_y=y }
+(*****************************************************************)
+(* Compiler:                                                     *)
+(* aarch64-linux-gnu-gcc -c -g  -O2 -pthread --std=c11 -fno-section-anchors*)
+(*                                                               *)
+(*****************************************************************)
+P0                 |  P1                    ;
+ MOVZ W1,#2        |   LDR W1,[X%P1_y]      ;
+ STLR W1,[X%P0_x]  |   CMP W1,#1            ;
+ MOVZ W1,#1        |   B.EQ L0x5c           ;
+ STR W1,[X%P0_y]   |   STR W1,[X%P1_P1_r0]  ;
+ RET               |   RET                  ;
+                   |  L0x5c:                ;
+                   |   MOVZ W2,#1           ;
+                   |   STLR W2,[X%P1_x]     ;
+                   |   STR W1,[X%P1_P1_r0]  ;
+                   |   RET                  ;
+
+exists ([x]=2 /\ P1_r0=1)
+

--- a/herd/tests/instructions/AArch64/A253.litmus.expected
+++ b/herd/tests/instructions/AArch64/A253.litmus.expected
@@ -1,0 +1,12 @@
+Test A253 Allowed
+States 3
+[P1_r0]=0; [x]=2;
+[P1_r0]=1; [x]=1;
+[P1_r0]=1; [x]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 2
+Condition exists ([x]=2 /\ [P1_r0]=1)
+Observation A253 Sometimes 1 2
+Hash=9947775663b21929c5c41a619489515c
+

--- a/herd/tests/instructions/ARM/A024.litmus
+++ b/herd/tests/instructions/ARM/A024.litmus
@@ -1,0 +1,25 @@
+ARM A024
+
+Variant=telechat
+{ [P1_r0]=0;[x]=0;[y]=0;
+  %P0_x=x;%P0_y=y;
+  %P1_P1_r0=P1_r0;
+  %P1_x=x;%P1_y=y }
+(*****************************************************************)
+(* Compiler:                                                     *)
+(* arm-linux-gnueabi-gcc-10 -c -g -O2 -march=armv7-a --std=c11 -fno-section-anchors*)
+(*****************************************************************)
+  P0               |  P1                   ;
+   MOV R0,#2       |   LDR R2,[%P1_y]      ;
+   MOV R1,#1       |   CMP R2,#1           ;
+   DMB ISH         |   BEQ L0x5c           ;
+   STR R0,[%P0_x]  |  L0x48:               ;
+   STR R1,[%P0_y]  |   STR R2,[%P1_P1_r0]  ;
+   BX LR           |   BX LR               ;
+                   |  L0x5c:               ;
+                   |   DMB ISH             ;
+                   |   STR R2,[%P1_x]      ;
+                   |   B L0x48             ;
+
+
+exists ([x]=2 /\ P1_r0=1)

--- a/herd/tests/instructions/ARM/A024.litmus.expected
+++ b/herd/tests/instructions/ARM/A024.litmus.expected
@@ -1,0 +1,12 @@
+Test A024 Allowed
+States 3
+[P1_r0]=0; [x]=2;
+[P1_r0]=1; [x]=1;
+[P1_r0]=1; [x]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 2
+Condition exists ([x]=2 /\ [P1_r0]=1)
+Observation A024 Sometimes 1 2
+Hash=c8a63d379ba2a30b8fd50dffe39a7ebc
+


### PR DESCRIPTION
 Fix ARM indirect branch to handle rets

      Consider the following litmus test - emitted by GCC:
      ```
      ARM A024

      Variant=telechat
      { [P1_r0]=0;[x]=0;[y]=0;
        %P0_x=x;%P0_y=y;
        %P1_P1_r0=P1_r0;
        %P1_x=x;%P1_y=y }
      (*****************************************************************)
      (* Compiler:                                                     *)
      (* arm-linux-gnueabi-gcc-10 -c -g -O2 -march=armv7-a --std=c11 -fno-section-anchors*)
      (*****************************************************************)
        P0               |  P1                   ;
         MOV R0,#2       |   LDR R2,[%P1_y]      ;
         MOV R1,#1       |   CMP R2,#1           ;
         DMB ISH         |   BEQ L0x5c           ;
         STR R0,[%P0_x]  |  L0x48:               ;
         STR R1,[%P0_y]  |   STR R2,[%P1_P1_r0]  ;
         BX LR           |   BX LR               ;
                         |  L0x5c:               ;
                         |   DMB ISH             ;
                         |   STR R2,[%P1_x]      ;
                         |   B L0x48             ;

      exists ([x]=2 /\ P1_r0=1)
      ```
      The RET is used in two places to jump around, and eventually exit.
      Currently this test does not work - we fix indirect branches to enable.
      this

This patch fixes this for RETs in AArch64 and BX in ARM. Guarded by the telechat variant of herd, introduced in a prior work