### PR TITLE
[litmus] Implement the "telechat" variant

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2078,6 +2078,8 @@ module Make
            >>= fun () -> read_reg_ord r ii
            >>= do_indirect_jump test [AArch64Base.linkreg,v_ret] i ii
 
+        | I_RET None when C.variant Variant.Telechat ->
+           M.unitT B.Exit
         | I_RET ro as i ->
             let r = match ro with
             | None -> AArch64Base.linkreg

--- a/lib/label.ml
+++ b/lib/label.ml
@@ -34,6 +34,7 @@ let next_label s =
   sprintf "%s%02i" s x
 
 let last p = sprintf "End%i" p
+and return p = sprintf "Lret%i" p
 
 type next = Any | Next | To of t
 

--- a/lib/label.mli
+++ b/lib/label.mli
@@ -25,6 +25,7 @@ val reset : unit -> unit
 val next_label : string -> t
 
 val last : int -> t
+val return : int -> t
 
 type next = Any | Next | To of t
 

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -42,6 +42,8 @@ module Make(V:Constant.S)(C:Config) =
       | A.I_NOP -> true
       | _ -> false
 
+    let branch lbl = A.I_B (BranchTarget.Lbl lbl)
+
 (* No addresses in code *)
     let extract_addrs _ins = Global_litmus.Set.empty
 

--- a/litmus/ARMCompile_litmus.ml
+++ b/litmus/ARMCompile_litmus.ml
@@ -26,10 +26,11 @@ module Make(V:Constant.S)(C:Config) =
     open A.Out
     open Printf
 
-    let is_ret _ = assert false
+    let is_ret _ = false
     and is_nop = function
       | A.I_NOP -> true
       | _ -> false
+    let branch lbl = I_B lbl
 
 (* No addresses in code *)
     let extract_addrs _ins = Global_litmus.Set.empty

--- a/litmus/LISACompile.ml
+++ b/litmus/LISACompile.ml
@@ -22,8 +22,9 @@ module Make(V:Constant.S) =
     open CType
     open Printf
 
-    let is_ret _ = assert false
+    let is_ret _ = false
     and is_nop _ = assert false
+    and branch lbl = Pbranch (None,lbl,[])
 
 (***************************************************)
 (* Extract explicit [symbolic] addresses from code *)

--- a/litmus/MIPSCompile_litmus.ml
+++ b/litmus/MIPSCompile_litmus.ml
@@ -21,10 +21,12 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
     open A.Out
     open Printf
 
-    let is_ret _ = assert false
+    let is_ret _ = false
     and is_nop = function
       | A.NOP -> true
       | _ -> false
+
+    let branch lbl = B lbl
 
 (* No addresses in code *)
     let extract_addrs _ins = Global_litmus.Set.empty

--- a/litmus/PPCCompile_litmus.ml
+++ b/litmus/PPCCompile_litmus.ml
@@ -29,10 +29,15 @@ module Make(V:Constant.S)(C:Config) =
     open A.Out
     open Printf
 
-    let is_ret _ = assert false
+    let is_ret = function
+      | Pblr -> true
+      | _ -> false
+
     and is_nop = function
       | A.Pnop -> true
       | _ -> false
+
+    let branch lbl = Pb lbl
 
 (* Ready for template compilation *)
     let op3regs memo set rD rA rB =

--- a/litmus/RISCVCompile_litmus.ml
+++ b/litmus/RISCVCompile_litmus.ml
@@ -21,10 +21,12 @@ module Make(V:Constant.S)(C:Arch_litmus.Config) =
     open A.Out
     open Printf
 
-    let is_ret _ = assert false
+    let is_ret _ = false
     and is_nop = function
       | A.INop -> true
       | _ -> false
+
+    let branch lbl = J lbl
 
 (* No addresses in code *)
     let extract_addrs _ins = Global_litmus.Set.empty

--- a/litmus/X86Compile_litmus.ml
+++ b/litmus/X86Compile_litmus.ml
@@ -21,10 +21,12 @@ module Make(V:Constant.S)(O:Arch_litmus.Config) =
     open A.Out
     open Printf
 
-    let is_ret _ = assert false
+    let is_ret _ = false
     let is_nop = function
       | A.I_NOP -> true
       | _ -> false
+
+    let branch lbl = I_JMP lbl
 
 (* Not so nice..., the price of code sharing of
    symbConst.ml with memevents *)

--- a/litmus/X86_64Compile_litmus.ml
+++ b/litmus/X86_64Compile_litmus.ml
@@ -32,6 +32,7 @@ module Make(Cfg:Config)(V:Constant.S)(O:Arch_litmus.Config) =
     let is_nop = function
       | A.I_NOP -> true
       | _ -> false
+    let branch lbl = I_JMP lbl
 
 (***************************************************)
 (* Extract explicit [symbolic] addresses from code *)

--- a/litmus/XXXCompile_litmus.mli
+++ b/litmus/XXXCompile_litmus.mli
@@ -19,6 +19,7 @@ module type S = sig
 
   val is_ret : A.instruction -> bool
   val is_nop : A.instruction -> bool
+  val branch : Label.t -> A.instruction
   val extract_addrs : A.instruction -> Global_litmus.Set.t
   val stable_regs : A.instruction -> A.RegSet.t
   val emit_loop : A.Out.ins list -> A.Out.ins list

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -20,16 +20,18 @@ type t =
   | S128 (* 128 bit signed ints*)
   | Mixed (* Ignored *)
   | Vmsa  (* Checked *)
+  | Telechat (* Telechat idiosyncrasies *)
 
 let compare = compare
 
-let tags = "s128"::"self"::"mixed"::"vmsa"::Precision.tags
+let tags = "s128"::"self"::"mixed"::"vmsa"::"telechat"::Precision.tags
 
 let parse s = match Misc.lowercase s with
 | "s128" -> Some S128
 | "self" -> Some Self
 | "mixed" -> Some Mixed
 | "vmsa"|"kvm" -> Some Vmsa
+| "telechat" -> Some Telechat
 | tag ->
    Misc.app_opt (fun p -> Precise p) (Precision.parse tag)
 
@@ -38,6 +40,8 @@ let pp = function
   | Mixed -> "mixed"
   | S128 -> "s128"
   | Vmsa -> "vmsa"
+  | Telechat -> "telechat"
+
   | Precise p -> Precision.pp p
 
 let ok v a = match v,a with

--- a/litmus/variant_litmus.mli
+++ b/litmus/variant_litmus.mli
@@ -20,6 +20,8 @@ type t =
   | S128 (* 128 bit signed ints*)
   | Mixed (* Ignored *)
   | Vmsa  (* Checked *)
+  | Telechat (* Telechat idiosyncrasies *)
+
 
 val tags : string list
 val parse : string -> t option


### PR DESCRIPTION
This variant specifies "telechat" idiosyncrasies for litmus

At the moment the one idiosyncrasy implemented consists in assimilating "return" instructions to "jump to end of code". Thereby, litmus and herd have compatible behaviours.