### PR TITLE
[herd] fix adr herd self

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1037,7 +1037,7 @@ module Make
               mk_fault (Some a) dir an ii ft (Some msg)) ii  >>! B.Exit in
         M.delay_kont "morello" ma
           (fun a ma ->
-            (* Notice: virtual access only, beaause morello # kvm *)
+            (* Notice: virtual access only, because morello # kvm *)
             let mok ma mv = mop Access.VIR ma mv in
             check_morello_tag a ma mv
               (fun ma mv ->
@@ -2474,20 +2474,29 @@ module Make
         | I_MOVK(var,rd,k,os) ->
             movk var rd k os ii >>= nextSet rd
         | I_ADR (r,tgt) ->
-           let lbl = 
+           let lbl =
              let open BranchTarget in
              match tgt with
-             | Lbl lbl -> lbl
+             | Lbl lbl -> Some lbl
              | Offset o ->
-              begin
-              let a = ii.A.addr + o in
-              let lbls = test.Test_herd.entry_points a in
-              match Label.norm lbls with
-              | Some lbl -> lbl
-              | None -> assert false
-              end in
-           let v = ii.A.addr2v lbl in
-           write_reg_dest r v ii >>= nextSet r
+                begin
+                  let a = ii.A.addr + o in
+                  let lbls = test.Test_herd.entry_points a in
+                  Label.norm lbls
+                end in
+           begin
+             match lbl with
+             | Some lbl ->
+                let v = ii.A.addr2v lbl in
+                write_reg_dest r v ii >>= nextSet r
+             | None ->
+                (* Delay error,  only a poor fix.
+                   A complete possible fix would be
+                   having code addresses as values *)
+                M.failT
+                  (Misc.Fatal "Overwriting  with ADR, cannot handle")
+                  B.Exit
+           end
 
         | I_SXTW(rd,rs) ->
             read_reg_ord_sz MachSize.Word rs ii

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -152,7 +152,13 @@ Monad type:
 
     let warnT msg (v : 'a) : 'a t =
       fun eiid_next ->
-        eiid_next, (Evt.singleton (v, [VC.Warn msg], E.empty_event_structure), None)
+      eiid_next,
+      (Evt.singleton (v, [VC.Warn msg], E.empty_event_structure), None)
+
+    let failT (e:exn) (v : 'a) : 'a t =
+      fun eiid_next ->
+      eiid_next,
+      (Evt.singleton (v, [VC.Failed e], E.empty_event_structure), None)
 
     let ignore _ = unitT ()
 

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -47,6 +47,7 @@ module type S =
     val zerocodeT        : 'a code
     val unitT        : 'a -> 'a t
     val warnT : string -> 'a -> 'a t
+    val failT : exn -> 'a -> 'a t
     val ignore : 'a -> unit t
     val unitcodeT        : 'a -> 'a code
     val failcodeT        : exn -> 'a -> 'a code

--- a/herd/tests/instructions/AArch64.self/S25.litmus
+++ b/herd/tests/instructions/AArch64.self/S25.litmus
@@ -1,0 +1,23 @@
+AArch64 S25
+(* Some of the latter discarded candidate execution
+   trigger a delayed error. More precisely, herd cannot
+   hander overwriting MOV W6,W4 with ADR X3.+4, because there
+   is no label on target. *)
+{
+ins_t 0:X4=instr:"BL .+8";
+0:X1=P0:L0;
+ins_t 0:X0;
+ins_t 0:X2;
+ins_t 0:X6;
+}
+  P0         ;
+L0:          ;
+ ADR X3,L1   ;
+L1:          ;
+ MOV W6,W4   ;
+ LDR W0,[X1] ;
+ LDR W2,[X3] ;
+locations [0:X0;0:X2;0:X6;]
+
+ 
+

--- a/herd/tests/instructions/AArch64.self/S25.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S25.litmus.expected
@@ -1,0 +1,11 @@
+Test S25 Required
+States 1
+0:X0=instr:"ADR X3,.+4"; 0:X2=instr:"MOV W6,W4"; 0:X6=instr:"BL .+8";
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Assuming-no-two-modified-instructions-are-on-the-same-cache-line
+Condition forall (true)
+Observation S25 Always 1 0
+Hash=353531dc6e6299b14776426e2440091c
+

--- a/herd/tests/instructions/AArch64.self/S26.litmus
+++ b/herd/tests/instructions/AArch64.self/S26.litmus
@@ -1,0 +1,24 @@
+AArch64 S26
+(* Some of the latter discarded candidate execution
+   trigger a delayed error. More precisely, herd cannot
+   hander overwriting MOV W6,W4 with ADR X3.+8, because there
+   is no label on target. *)
+{
+0:X0=P0:L0;
+0:X1=P0:L1;
+ins_t 0:X5;
+0:X2=1;
+}
+  P0         ;
+ LDR W4,[X0] ;
+ B .+8       ;
+L0:          ;  
+ ADR X3,L1   ;
+ STR W4,[X1] ;
+L1:          ;
+ MOV W6,W2   ;
+ LDR W5,[X1] ;
+locations [0:X5;0:X6;]
+
+ 
+

--- a/herd/tests/instructions/AArch64.self/S26.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.self/S26.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.self/S26.litmus": Overwriting  with ADR, cannot handle

--- a/herd/tests/instructions/AArch64.self/S27.litmus
+++ b/herd/tests/instructions/AArch64.self/S27.litmus
@@ -1,0 +1,23 @@
+AArch64 S27
+(* Similar to S26, yielding no error, because
+   ADDR X3,.+0 miraculously correspong to label L1 when
+   after instruction at L1 is overwritten *)
+{
+0:X0=P0:L0;
+0:X1=P0:L1;
+ins_t 0:X5;
+0:X2=1;
+}
+  P0         ;
+ LDR W4,[X0] ;
+ B .+8       ;
+L0:          ;  
+ ADR X3,L0   ;
+ STR W4,[X1] ;
+L1:          ;
+ MOV W6,W2   ;
+ LDR W5,[X1] ;
+locations [0:X5;0:X6;]
+
+ 
+

--- a/herd/tests/instructions/AArch64.self/S27.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S27.litmus.expected
@@ -1,0 +1,13 @@
+Test S27 Required
+States 2
+0:X5=instr:"ADR X3,.+0"; 0:X6=0;
+0:X5=instr:"ADR X3,.+0"; 0:X6=1;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Flag Assuming-no-two-modified-instructions-are-on-the-same-cache-line
+Flag violates-CMODX-requirements
+Condition forall (true)
+Observation S27 Always 2 0
+Hash=dafd07478617c823bca682aaa6e8d197
+


### PR DESCRIPTION
In mode `-variant self` overwriting an instruction with an `ADR` instruction whose second argument is not pointing to a labeled instruction always resulted in an `assert false` failure. We improve in two directions:
  + The failure is delayed, so as it disappears if the corresponding execution candidate is discarded.
  + More specific error message.
