### PR TITLE
[herd7] Comparing labels with integers

### DIFF
--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -280,7 +280,7 @@ module
     match v1,v2 with
     | (Val (Tag _),Val (Tag _))
     | (Val (Symbolic _),Val (Symbolic _))
-    | (Val (Label _),Val (Label _))
+    | (Val (Label _), Val _) | (Val _,Val (Label _))
     | (Val (PteVal _),Val (PteVal _))
     | (Val (Instruction _),Val (Instruction _))
       ->


### PR DESCRIPTION
The objective of this PR is to resolve issue #646. In that issue we are looking at the following litmus test:

```
AArch64 CMP-int-vs-label
{
ins_t *y;
0:X0=y;
}
 P0           ;
 ADR X4,L0   ;
 STR X4,[X0] ;
 DMB LD      ;
 LDR X1,[X0] ;
 CMP X1,X4   ;
 CSET W5,NE  ;
L0:          ; 
 NOP         ;
locations [0:X1;0:X4]
forall (0:X5=0)
```

What happens is that there is a candidate execution, where the `LDR` reads from the initial state. In that candidate execution, `CMP` ends up comparing `0` (the initial value) and `P0:L0`, at which point `herd7` crashes with a user error. This is not a correct behaviour, because the model will filter out such an execution as violating the internal visibility axioms, and only well-behaving executions (comparing `P0:L0` read from memory to the constant `P0:L0`) will remain.

To resolve the issue, this PR simply extends the functionality of the comparisons to enable comparing `0` and `P0:L0`.