### PR TITLE
[herd,asl] Update of asl-pseudocode to 2023-09 version

### DIFF
--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -524,6 +524,7 @@ let assignment_stmt ==
         { AST.(S_Decl (LDK_Let, ldi, Some expr)) }
       | CONSTANT; x=ident; EQ; ~=expr;
         { AST.(S_Decl (LDK_Let, LDI_Var (x, None), Some expr)) }
+      | CONSTANT; ldi=ldi_tuple ; EQ; e=expr; { AST.S_Decl (LDK_Let,ldi,Some e) }
       | t=annotated(ty_non_tuple); li=nclist(~=ident; ~=none; < AST.LDI_Var >);
           { AST.(S_Decl (LDK_Var, LDI_Tuple (li, Some t), None)) }
       ))
@@ -550,6 +551,15 @@ let lexpr :=
       | bracketed(nclist(lexpr)); <>
     )
   )
+let ldi :=
+   | MINUS; { AST.LDI_Ignore None }
+   | x=ident_plus_record; { AST.LDI_Var (x,None) }
+   | ldi_tuple
+
+let ldi_tuple := ldis=pared(nnclist(ldi)); { AST.LDI_Tuple  (ldis,None) }
+
+
+
 
 let simple_if_stmt ==
     annotated (
@@ -658,4 +668,3 @@ let binop ==
   | abinop
   | LT         ; { AST.LT     }
   | GT         ; { AST.GT     }
-

--- a/herd/libdir/asl-pseudocode/Makefile
+++ b/herd/libdir/asl-pseudocode/Makefile
@@ -8,11 +8,11 @@ BUNDLER_ARGS := -vv $(BUNDLER_JOBS)
 BUNDLER := bundler.py
 BUNDLER_CMD := $(PYTHON) $(BUNDLER) $(BUNDLER_ARGS)
 
-BASE_URL := https://developer.arm.com/-/media/developer/products/architecture/armv9-a-architecture/2023-06/
+BASE_URL := https://developer.arm.com/-/media/developer/products/architecture/armv9-a-architecture/2023-09/
 
-ISA_A64_NAME := ISA_A64_xml_A_profile-2023-06
-ISA_A32_NAME := ISA_AArch32_xml_A_profile-2023-06
-REGS_NAME := SysReg_xml_A_profile-2023-06
+ISA_A64_NAME := ISA_A64_xml_A_profile-2023-09
+ISA_A32_NAME := ISA_AArch32_xml_A_profile-2023-09
+REGS_NAME := SysReg_xml_A_profile-2023-09
 
 TARGETS := $(ISA_A64_NAME) $(ISA_A32_NAME) $(REGS_NAME)
 TARGETS_TAR_GZ := $(addsuffix .tar.gz,$(TARGETS))

--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -321,6 +321,7 @@ type Feature of enumeration {
     FEAT_CMOW,
     FEAT_CNTSC,
     FEAT_CONSTPACFIELD,
+    FEAT_CPA2,
     FEAT_CRC32,
     FEAT_CSSC,
     FEAT_D128,

--- a/herd/libdir/asl-pseudocode/patches.asl
+++ b/herd/libdir/asl-pseudocode/patches.asl
@@ -90,3 +90,13 @@ type ProcState of bits(64) {
 };
 
 var PSTATE : ProcState;
+
+// GenerateAddress()
+// =================
+// Generate and address by adding a pointer with an offset and returning the result.
+// If FEAT_CPA2 is implemented, the pointer arithmetic is checked.
+// LUC simplify because failur of slice operatin on symbolic address.
+func GenerateAddress(base:bits(64), offset:bits(64), accdesc:AccessDescriptor) => bits(64)
+begin
+  return base + offset;
+end


### PR DESCRIPTION
Minimal changes are performed:
  + Concrete syntax "const _tuple_ = _expr_;" is parsed as a let declaration (ASL V0, sors de ce corps).
  + Add FEAT_CPA2 to the feature enumrration
  + Alternative definition of `GenerateAddress` in `patch.asl` for avoiding illegal slicing of symbolic address by pointer arithmetic checks.