### PR TITLE
[asl] Small adjustments to ease ASL program generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ Version.ml:
 build: Version.ml | check-deps
 	dune build -j $(J) --profile release
 
+doc: Version.ml | check-deps
+	dune build -j $(J) --profile release @doc
+
 install:
 	sh ./dune-install.sh $(PREFIX)
 

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -125,7 +125,7 @@ let rec pp_expr f e =
       fprintf f "@[<hv>%a {@ %a@;<1 -2>}@]" pp_ty ty (pp_comma_list pp_one) li
   | E_Concat es -> fprintf f "@[<hv 2>[%a]@]" pp_expr_list es
   | E_Tuple es -> fprintf f "@[<hv 2>(%a)@]" pp_expr_list es
-  | E_Unknown ty -> fprintf f "@[<h>UNKNOWN ::@ %a@]" pp_ty ty
+  | E_Unknown ty -> fprintf f "@[<h>UNKNOWN :@ %a@]" pp_ty ty
   | E_Pattern (e, p) -> fprintf f "@[<hv 2>%a@ IN %a@]" pp_expr e pp_pattern p
 
 and pp_expr_list f = pp_comma_list pp_expr f
@@ -207,7 +207,7 @@ and pp_bits_constraint f = function
       fprintf f "@[{%a}@]" pp_int_constraints int_constraint
   | BitWidth_ConstrainedFormType ty -> fprintf f "- : %a" pp_ty ty
 
-let pp_typed_identifier f (name, ty) = fprintf f "%s::%a" name pp_ty ty
+let pp_typed_identifier f (name, ty) = fprintf f "@[%s:@ %a@]" name pp_ty ty
 
 let rec pp_lexpr f le =
   match le.desc with
@@ -234,7 +234,7 @@ let pp_local_decl_keyword f k =
 
 let rec pp_local_decl_item f =
   let pp_ty_opt f = function
-    | Some ty -> fprintf f "@ :: @[%a@]" pp_ty ty
+    | Some ty -> fprintf f ": @[%a@]" pp_ty ty
     | None -> ()
   in
   function
@@ -327,9 +327,9 @@ let pp_decl f =
     | { name; keyword; ty = None; initial_value = Some e } ->
         fprintf f "%a %s@ = %a" pp_gdk keyword name pp_expr e
     | { name; keyword; ty = Some t; initial_value = Some e } ->
-        fprintf f "%a %s@ :: %a@ = %a" pp_gdk keyword name pp_ty t pp_expr e
+        fprintf f "%a %s:@ %a@ = %a" pp_gdk keyword name pp_ty t pp_expr e
     | { name; keyword; ty = Some t; initial_value = None } ->
-        fprintf f "%a %s@ :: %a" pp_gdk keyword name pp_ty t
+        fprintf f "%a %s:@ %a" pp_gdk keyword name pp_ty t
     | { name = _; keyword = _; ty = None; initial_value = None } -> assert false
   in
   let pp_func_sig f

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -96,7 +96,7 @@ let pp_literal f = function
   | L_Bool false -> pp_print_string f "FALSE"
   | L_Real r ->
       if Q.den r = Z.one then fprintf f "%a.0" Z.pp_print (Q.num r)
-      else Q.pp_print f r
+      else pp_print_float f (Q.to_float r)
   | L_BitVector bv -> Bitvector.pp_t f bv
   | L_String s -> fprintf f "%S" s
 

--- a/asllib/StaticEnv.ml
+++ b/asllib/StaticEnv.ml
@@ -30,6 +30,7 @@ type global = {
 type local = {
   constants_values : literal IMap.t;
   storage_types : (ty * local_decl_keyword) IMap.t;
+  return_type: ty option;
 }
 
 type env = { global : global; local : local }
@@ -52,11 +53,13 @@ module PPEnv = struct
       (PP.pp_print_seq ~pp_sep pp_print_string)
       (ISet.to_seq s)
 
-  let pp_local f { constants_values; storage_types } =
-    fprintf f "@[<v 2>Local with:@ - @[constants:@ %a@]@ - @[storage:@ %a@]@]"
+  let pp_local f { constants_values; storage_types; return_type } =
+    fprintf f "@[<v 2>Local with:@ - @[constants:@ %a@]@ - @[storage:@ %a@]@ - @[return type:@ %a@]@]"
       (pp_map PP.pp_literal) constants_values
       (pp_map (fun f (t, _) -> PP.pp_ty f t))
       storage_types
+      (pp_print_option ~none:(fun f () -> fprintf f "none") PP.pp_ty)
+      return_type
 
   let pp_subprogram f func_sig =
     fprintf f "@[<hov 2>%a@ -> %a@]"
@@ -112,7 +115,9 @@ let empty_global =
   }
 
 (** An empty local static env. *)
-let empty_local = { constants_values = IMap.empty; storage_types = IMap.empty }
+let empty_local = { constants_values = IMap.empty; storage_types = IMap.empty; return_type = None }
+
+let empty_local_return_type return_type = { empty_local with return_type }
 
 (** An empty static env. *)
 let empty = { local = empty_local; global = empty_global }

--- a/asllib/StaticEnv.mli
+++ b/asllib/StaticEnv.mli
@@ -42,6 +42,7 @@ type local = {
   constants_values : literal IMap.t;  (** Maps a local constant to its value. *)
   storage_types : (ty * local_decl_keyword) IMap.t;
       (** Maps an locally declared names to their type. *)
+  return_type : ty option (** Local return type, [None] for procedures, global constants, or setters. *)
 }
 (** Store all the local environment information at compile-time. *)
 
@@ -53,6 +54,7 @@ val pp_env : Format.formatter -> env -> unit
 val pp_global : Format.formatter -> global -> unit
 val empty_global : global
 val empty_local : local
+val empty_local_return_type : ty option -> local
 val empty : env
 val lookup_constants : env -> identifier -> literal
 val type_of : env -> identifier -> ty

--- a/herd/dune
+++ b/herd/dune
@@ -4,8 +4,18 @@
 
 (ocamllex lexConf_herd)
 
+(library
+  (name herdlib)
+  (modules :standard \ herd)
+  (libraries unix herdtools)
+  (public_name herdtools7.herdlib)
+  (modules_without_implementation AArch64Sig action arch_herd monad sem XXXMem))
+
 (executable
    (name herd)
    (public_name herd7)
-   (libraries unix herdtools)
-   (modules_without_implementation AArch64Sig action arch_herd monad sem XXXMem))
+   (modules herd)
+   (libraries herdlib))
+
+(documentation)
+

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -17,6 +17,7 @@
 (** Entry point to Herd  *)
 
 open Printf
+open Herdlib
 open Archs
 open Opts
 

--- a/herd/rc11.ml
+++ b/herd/rc11.ml
@@ -1,3 +1,5 @@
+[@@@warning "-40-42"]
+
 open Printf
 
 module type Cfg = sig
@@ -65,7 +67,7 @@ module Make (O:Cfg)(S:Sem.Semantics)
         let rmw = conc.S.atomic_load_store in
 
         let aux = fun x ->
-          try List.assoc x S.E.Act.arch_sets with Not_found -> fun x -> true in
+          try List.assoc x S.E.Act.arch_sets with Not_found -> fun _x -> true in
 
         let rlx = aux "RLX" in
         let acq = aux "ACQ" in

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -12,10 +12,11 @@ bug-reports: "http://github.com/herd/herdtools7/issues/"
 doc: "http://diy.inria.fr/doc/index.html"
 dev-repo: "git+https://github.com/herd/herdtools7.git"
 license: "CECILL-B"
-build: ["sh" "./dune-build.sh" "%{prefix}%"]
-install: ["sh" "./dune-install.sh" "%{prefix}%"]
-# @todo Add "build-doc" field
-# @todo Add "build-test" field
+build: [
+  [make "build" "PREFIX=%{prefix}%"]
+  [make "test" "PREFIX=%{prefix}%"] {with-test}
+]
+install: [make "install" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune"  {>= "2.7" }

--- a/lib/dune
+++ b/lib/dune
@@ -32,5 +32,6 @@
  (name herdtools)
  (wrapped false)
  (libraries str asllib zarith)
+ (public_name herdtools7.herdtools)
  (modules_without_implementation sign outTests AST CAst Scalar archBase archDump
    PPMode name value))


### PR DESCRIPTION
This PR fixes:
 - some pretty-print are outdated;
 - move the return type of a function into the local environment to ease the generation of code that returns the correct type.

This PR comes after #694, because I need the fix to `herdtools7.opam`.