### PR TITLE
[herd,aarch64] ignore VMSA semantics for explicit accesses to labels

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1074,13 +1074,16 @@ module Make
               fire_spurious_af dir a m) >>= M.ignore >>= B.next1T)
             mphy
             mfault in
-        M.delay_kont "6" ma
-          (if pte2 then maccess
-           else
+        M.delay_kont "6" ma (
+          if pte2 then maccess
+          else
              fun a ma ->
              match Act.access_of_location_std (A.Location_global a) with
-             | Access.VIR|Access.PTE -> maccess a ma
-             | ac -> mop ac ma >>= M.ignore >>= B.next1T)
+             | Access.VIR|Access.PTE when not (A.V.is_instrloc a) ->
+                 maccess a ma
+             | ac ->
+                 mop ac ma >>= M.ignore >>= B.next1T
+        )
 
       let lift_morello mop perms ma mv dir an ii =
         let mfault msg ma mv =

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -554,6 +554,10 @@ module
 
   let is_virtual_v v =  if is_virtual v then one else zero
 
+  let is_instrloc v = match v with
+  | Val c -> Constant.is_label c
+  | Var _ -> false
+
   let is_instr_v =
     function
     | Val (Constant.Instruction _) -> one

--- a/lib/value.mli
+++ b/lib/value.mli
@@ -97,6 +97,8 @@ module type S =
       val is_virtual : v -> bool
       val as_virtual : v -> string option
 
+      val is_instrloc : v -> bool
+
       val op1 : op1_t -> v -> v
       val op : op_t -> v -> v -> v
       val op3 : Op.op3 -> v -> v -> v -> v


### PR DESCRIPTION
This PR aims to prevent creating of implicit TTD effects when building the semantics for loads and stores to instruction locations.

Consider the following litmus test:
```
AArch64 MP.FR+dmb.st+po
{
TTD(x)=(oa:PA(x),valid:0);
0:X0=NOP; 0:X1=P1:Lself; 0:X4=(oa:PA(x),valid:1); 0:X5=TTD(x);
          1:X1=P1:Lself; 1:X3=x;
}
P0           | P1            ;
STR X4,[X5]  | Lself:        ;
DMB ST       |   B Lnext     ;
STR W0,[X1]  |   MOV W9,#1   ;
             | Lnext:        ;
             |   LDR W2,[X3] ;
exists 1:X9=1 /\ fault(P1,x)
```

Currently it cannot be run with `herd7`, because the VMSA semantics for  `STR W0,[X1]` will create effects that `machModelChecker.ml` will then incorrectly process. This PR aims to disable the VMSA semantics for such accesses, which will allow studying straightforward interactions between the ifetch and the vmsa extensions to the memory model.