### PR TITLE
[gen] implement DC CVAU and IC IVAU relaxations

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1616,14 +1616,14 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         with Not_found ->
           Warn.user_error "No code write before CacheSync"
         end
-    | DI t -> 
+    | DI (t,dirloc) ->
       let loc = begin
-        try
-          C.find_prev_code_write n
-        with Not_found -> 
-          match n.C.evt.C.loc with
-          | Data loc -> loc
-          | Code lab -> lab
+        let n0 = match dirloc with
+        | Next -> C.find_non_pseudo n
+        | Prev -> C.find_non_pseudo_prev n in
+        match n0.C.evt.C.loc with
+        | Data loc -> loc
+        | Code lab -> lab
         end
         in
         let r,init,st = U.next_init st p init loc in

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -111,8 +111,8 @@ module Make(C:Builder.S)
 (*
   Now accept some internal with internal composition
  *)
-      | (Ws Int|Rf Int|Fr Int),(Dp (_,_,_)|Po (Diff,_,_))
-      | (Dp (_,_,_)|Po (Diff,_,_)),(Ws Int|Rf Int|Fr Int)
+      | (Ws Int|Rf Int|Fr Int|Insert _),(Dp (_,_,_)|Po (Diff,_,_))
+      | (Dp (_,_,_)|Po (Diff,_,_)),(Ws Int|Rf Int|Fr Int|Insert _)
       | Dp (_,Diff,_),Po (Diff,_,_)
       | Po (Diff,_,_),Dp (_,Diff,_)
       | Rf Int,Po (Same,_,_)

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -714,8 +714,8 @@ let remove_store n0 =
             (str_node p) (str_node m)
       end ;
       if
-        E.is_fetch p.edge && is_non_fetch_and_same m.edge ||
-        E.is_fetch m.edge && is_non_fetch_and_same p.edge
+        E.is_fetch p.edge && is_non_fetch_and_same m.edge && find_real_edge_prev p.prev != m ||
+        E.is_fetch m.edge && is_non_fetch_and_same p.edge && find_node (fun a -> is_real_edge a.edge) m.next != p
       then begin
         Warn.user_error "Ambiguous Data/Code location es [%s] => [%s]"
           (str_node p) (str_node m)
@@ -729,7 +729,10 @@ let set_diff_loc st n0 =
     let loc,st =
       if same_loc p.edge then begin
         p.evt.loc,st
-      end else next_loc m.edge st in
+      end else begin
+        let medge = (find_node (fun a -> non_pseudo a.edge) m).edge in
+        next_loc medge st
+      end in
     m.evt <- { m.evt with loc=loc ; bank=E.atom_to_bank m.evt.atom; } ;
 (*    eprintf "LOC SET: %a [p=%a]\n%!" debug_node m debug_node p; *)
     if m.store != nil then begin

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -687,7 +687,12 @@ let remove_store n0 =
       if not (E.is_ext p.edge || E.is_po_or_fenced_joker p.edge || E.is_ext n.edge || E.is_po_or_fenced_joker n.edge) then begin
         Warn.fatal "Insert pseudo edge %s appears in-between  %s..%s (at least one neighbour must be an external edge)"
           (E.pp_edge m.edge)  (E.pp_edge p.edge)  (E.pp_edge n.edge)
-      end
+      end;
+      match p.edge.E.edge with 
+      | (E.Rf Ext | E.Irf Ext | E.Fr Ext| E.Ifr Ext) ->
+        Warn.fatal "Insert pseudo edge %s appears after external communication edge %s"
+        (E.pp_edge m.edge) (E.pp_edge p.edge)
+      | _ -> ()
     end ;
     if m.next != n0 then do_rec m.next in
   do_rec n0 ;

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -730,7 +730,7 @@ let fold_tedges f r =
   let can_precede_dirs  x y = match x.edge,y.edge with
   | (Store,Store) -> false
   | (Id,_)|(_,Id)|(Store,_)|(_,Store) -> true
-  | (Insert _,Insert _) -> do_kvm
+  | (Insert _,Insert _) -> do_kvm || do_self
   | _,_ ->
       begin match dir_tgt x,dir_src y with
       | (Irr,Irr) -> false

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -377,6 +377,9 @@ type barrier =
 type syncType = 
   | DC_CVAU
   | IC_IVAU
+type dirloc =
+  | Next
+  | Prev
 let fold_barrier_option kvm more f k =
   if more then
     fold_domain

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -374,6 +374,9 @@ type barrier =
   | DSB of mBReqDomain*mBReqTypes
   | ISB
 
+type syncType = 
+  | DC_CVAU
+  | IC_IVAU
 let fold_barrier_option kvm more f k =
   if more then
     fold_domain


### PR DESCRIPTION
This PR implements the ability to generate tests using DC CVAU and IC IVAU as relaxations. These relaxations can have the location they act on defined using `p` for previous and `n` for next. That is, with `p` they will use the location of the previous memory event, and with `n` they will use the next one.

This PR also implements some changes to how Insert relaxations are dealt with in diy7 to generate more tests using DC CVAU and IC IVAU. An example test can be seen below:

```
"PodWW DC.CVAUp DSB.ISH IC.IVAUp DSB.ISH ISB Rfe PodRR Ifre"
Cycle=Rfe PodRR Ifre PodWW DC.CVAUp DSB.ISH IC.IVAUp DSB.ISH ISB
Relax=[Ifre,PodWW,DC.CVAUp,DSB.ISH,IC.IVAUp,DSB.ISH,ISB]
Safe=Rfe PodRR
Generator=diy7 (version 7.56+03)
Com=Rf Ifr
Orig=PodWW DC.CVAUp DSB.ISH IC.IVAUp DSB.ISH ISB Rfe PodRR Ifre
{
0:X0=NOP; 0:X1=P1:Lself00; 0:X3=x;
1:X0=x;
}
 P0          | P1          ;
 STR W0,[X1] | LDR W1,[X0] ;
 DC CVAU,X1  | Lself00:    ;
 DSB ISH     | B L00       ;
 IC IVAU,X1  | MOV W2,#2   ;
 DSB ISH     | B L01       ;
 ISB         | L00:        ;
 MOV W2,#1   | MOV W2,#1   ;
 STR W2,[X3] | L01:        ;
exists (1:X1=1 /\ 1:X2=1)
```