### PR TITLE
[herd] Fix AArch64Sem lift_memop for -variant vmsa,memtag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,16 @@ ets2-test:
 		$(REGRESSION_TEST_MODE)
 		@ echo "herd7 catalogue aarch64-ETS2 tests: OK"
 
+test.vmsa+mte:
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/AArch64.vmsa+mte \
+		-conf ./herd/tests/instructions/AArch64.vmsa+mte/vmsa+mte.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64 VMSA+MTE instructions tests: OK"
+
 test:: diy-test
 
 LDS:="Amo.Cas,Amo.LdAdd,Amo.LdClr,Amo.LdEor,Amo.LdSet"

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1131,7 +1131,7 @@ module Make
             begin
               if kvm then
                 let mphy = (fun ma a -> lift_memtag_phy a mop ma dir an ii) in
-                M.short3
+                M.short
                   (is_this_reg rA) (E.is_pred_txt (Some "color"))
                   (lift_kvm dir updatedb mop ma an ii mphy)
               else lift_memtag_virt mop ma dir an ii

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1132,7 +1132,7 @@ module Make
               if kvm then
                 let mphy = (fun ma a -> lift_memtag_phy a mop ma dir an ii) in
                 M.short3
-                  (is_this_reg rA) E.is_commit
+                  (is_this_reg rA) (E.is_pred_txt (Some "color"))
                   (lift_kvm dir updatedb mop ma an ii mphy)
               else lift_memtag_virt mop ma dir an ii
             end

--- a/herd/ASLAction.ml
+++ b/herd/ASLAction.ml
@@ -169,7 +169,7 @@ module Make (A : S) = struct
 
   (* Commits *)
   let is_bcc _action = false
-  let is_pred _action = false
+  let is_pred ?cond:_ _action = false
   let is_commit _action = false
 
   (* Unrolling control *)

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -39,7 +39,7 @@
    We use three main connecters here:
     - the classic data binder ( [>>=] )
     - a control binder ( [>>*=] or assimilate)
-    - a sequencing operator ( [M.aslseq] )
+    - a sequencing operator ( [M.para_bind_output_right] )
    And some specialized others:
     - the parallel operator ( [>>|] )
     - a choice operation
@@ -61,7 +61,7 @@
      output = 2.ouput (or 1.output if 2.output is None)
         same-ish with ctrl_output
 
-   - _seq_ binder (called [aslseq]):
+   - _seq_ binder (called [para_bind_output_right]):
      input = 1.input U 2.input
         same with data_input
      output = 2.output
@@ -114,7 +114,7 @@ module Make (C : Config) = struct
     module Mixed = M.Mixed (SZ)
 
     let ( let* ) = M.( >>= )
-    let ( let*| ) = M.aslseq
+    let ( let*| ) = M.para_bind_output_right
     let ( and* ) = M.( >>| )
     let return = M.unitT
     let ( >>= ) = M.( >>= )
@@ -696,7 +696,7 @@ module Make (C : Config) = struct
         let v_of_literal = v_of_literal
         let v_to_int = v_to_int
         let bind_data = M.( >>= )
-        let bind_seq = M.aslseq
+        let bind_seq = M.para_bind_output_right
         let bind_ctrl = M.bind_ctrl_seq_data
         let prod_par = M.( >>| )
         let appl_data m f = m >>= fun v -> return (f v)

--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -193,7 +193,7 @@ end = struct
   | Commit -> true
   | _ -> false
 
-  let is_pred _ = false
+  let is_pred ?cond:_ _ = false
 
   let is_commit = is_bcc
 

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -257,7 +257,7 @@ end = struct
 
 (* (No) commits *)
   let is_bcc _ = false
-  let is_pred _ = false
+  let is_pred ?cond:_ _ = false
   let is_commit _ = false
 
 (* Unrolling control *)

--- a/herd/JavaAction.ml
+++ b/herd/JavaAction.ml
@@ -191,7 +191,7 @@ end = struct
     | TooFar _ -> true
     | _ -> false
   let is_bcc _ = false
-  let is_pred _ = false
+  let is_pred ?cond:_ _ = false
   let is_commit _ = false
 
   include Explicit.NoAction

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -93,7 +93,7 @@ module type S = sig
 
 (* Commits *)
   val is_bcc : action -> bool
-  val is_pred : action -> bool
+  val is_pred : ?cond:string option -> action -> bool
   val is_commit : action -> bool
 
 (* Unrolling control *)

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -290,6 +290,7 @@ val same_instance : event -> event -> bool
 (* Event structure output ports *)
 (********************************)
   val debug_output : out_channel -> event_structure -> unit
+  val debug_event_structure : out_channel -> event_structure -> unit
 
 (********************************)
 (* Instruction+code composition *)
@@ -998,6 +999,16 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
       fprintf chan "(i=%a, o=%a)"
         debug_opt (es.input,get_dinput,es)
         debug_opt (es.output,get_output,es)
+
+    let debug_event_structure chan es =
+      fprintf chan "(\n" ;
+      fprintf chan "\tevents: %a\n" debug_events es.events ;
+      fprintf chan "\tinput: %a\n" debug_opt (es.input,get_dinput,es) ;
+      fprintf chan "\toutput: %a\n" debug_opt (es.output,get_output,es) ;
+      fprintf chan "\tiico_data: %a\n" debug_rel es.intra_causality_data ;
+      fprintf chan "\tiico_ctrl: %a\n" debug_rel es.intra_causality_control ;
+      fprintf chan "\tpo: %a\n" debug_rel (let _,rel = es.po in rel) ;
+      fprintf chan ")\n"
 
     let get_ctrl_output es = match es.ctrl_output with
     | None -> maximals es

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -131,6 +131,7 @@ val same_instance : event -> event -> bool
 (* Commit *)
   val is_bcc : event -> bool
   val is_pred : event -> bool
+  val is_pred_txt : string option -> event -> bool
   val is_commit : event -> bool
 
 (* Too much unrolling *)
@@ -691,6 +692,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
 (* Commits *)
     let is_bcc e = Act.is_bcc e.action
     let is_pred e = Act.is_pred e.action
+    let is_pred_txt cond e = Act.is_pred ~cond e.action
     let is_commit e = Act.is_commit e.action
 
 (*  Unrolling control *)

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -967,7 +967,7 @@ Monad type:
 
     let cseq : 'a t -> ('a -> 'b t) -> 'b t = fun s f ->  data_comp (+|+) s f
 
-    let aslseq : 'a t -> ('a -> 'b t) -> 'b t =
+    let para_bind_output_right : 'a t -> ('a -> 'b t) -> 'b t =
       fun s f -> data_comp E.para_output_right s f
 
     type poi = int

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -1712,4 +1712,10 @@ Monad type:
         | Some v -> (eiid, v)
       in
       new_m
+
+    let debugT (s : string) (m : 'a t) : 'a t
+      = fun eiid ->
+        let eiid,(evts,specs) = m eiid in
+        List.iter (fun (_,_,es) -> eprintf "%s%a" s E.debug_event_structure es) (Evt.elements evts) ;
+        eiid,(evts,specs)
   end

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -320,20 +320,19 @@ Monad type:
     let bind_order s f = data_comp E.bind_order s f
 
 (* Ad-hoc short-circuit *)
-    let short3 p1 p2 m =
+    let short p1 p2 m =
       fun eiid ->
       let eiid,(acts,specs) = m eiid in
       let acts =
         Evt.map
           (fun (v,cls,es) ->
-            let data3 =
-              let data = es.E.intra_causality_data in
-              let data3 =
-                E.EventRel.filter
-                  (fun (e1,e2) -> p1 e1 && p2 e2)
-                  (E.EventRel.transitive3 data) in
-              E.EventRel.union data data3 in
-            v,cls,{ es with E.intra_causality_data=data3; })
+             let data =
+               let data =
+                 E.EventRel.filter
+                   (fun (e1,e2) -> p1 e1 && p2 e2)
+                   (E.EventRel.cartesian es.E.events es.E.events) in
+               E.EventRel.union es.E.intra_causality_data data in
+            v,cls,{ es with E.intra_causality_data=data; })
       acts in
        eiid,(acts,specs)
 

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -1476,6 +1476,10 @@ Monad type:
             | A.Location_global (V.Val (Symbolic (System (PTE,s)))) ->
                 let v = expand_pteval loc v in
                 (loc,v)::env,(virt,StringSet.add s pte)
+            | A.Location_global (V.Val (Symbolic (System (TAG,s)))) ->
+              let s = V.pp_v (V.Val (Symbolic (Physical (s,0)))) in
+              let loc = A.Location_global (V.Val (Symbolic (System (TAG,s)))) in
+              (loc,v)::env,maps
             | A.Location_global (V.Val (Symbolic (Physical _|Virtual _))) ->
                 Warn.user_error "herd cannot handle initialisation of '%s'"
                   (A.pp_location loc)

--- a/herd/libdir/aarch64memattrs.cat
+++ b/herd/libdir/aarch64memattrs.cat
@@ -95,6 +95,7 @@ let OuterCacheability-conflict = (PTEOuter-write-back & PTEOuter-write-through)
 assert empty OuterCacheability-conflict as Invalid-Outer-Cacheability
 
 let PTENormal = try PTENormal with emptyset
+let PTETaggedNormal = try PTETaggedNormal with emptyset
 
 (*** Common attributes ***)
 let PTEXS = try PTEXS with emptyset
@@ -107,7 +108,7 @@ assert empty MemoryType-conflict as Invalid-Memory-Type
 
 (* No other memory attribute is allowed *)
 let PTEMemAttr = try PTEMemAttr with emptyset
-let PTEAll-Valid-Mem-Attr = PTENormal
+let PTEAll-Valid-Mem-Attr = PTENormal | PTETaggedNormal
                     | PTENon-shareable | PTEInner-shareable | PTEOuter-shareable
                     | PTEInner-write-back | PTEInner-write-through | PTEInner-non-cacheable
                     | PTEOuter-write-back | PTEOuter-write-through | PTEOuter-non-cacheable
@@ -128,8 +129,12 @@ let PTEInner-write-back = PTEInner-write-back
 let PTEOuter-write-back = PTEOuter-write-back
                         | (PTE \ (PTEDevice | PTEOuter-write-through | PTEOuter-non-cacheable))
 
+let ISH-WB = PTEInner-shareable & PTEInner-write-back & PTEOuter-write-back
+
 (* Default Memory Type *)
+let PTETaggedNormal = PTETaggedNormal | (if "memtag" then ISH-WB else 0)
 let PTENormal = PTENormal
               | PTENon-shareable | PTEInner-shareable | PTEOuter-shareable
               | PTEInner-write-back | PTEInner-write-through | PTEInner-non-cacheable
               | PTEOuter-write-back | PTEOuter-write-through | PTEOuter-non-cacheable
+let PTENormal = if "memtag" then PTENormal \ ISH-WB else PTENormal

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -457,8 +457,9 @@ end = struct
   | Commit (Bcc,_) -> true
   | _ -> false
 
-  let is_pred a = match a with
-  | Commit (Pred,_) -> true
+  let is_pred ?(cond=None) = function
+  | Commit (Pred, cond0) ->
+    Option.is_none cond || Option.equal String.equal cond cond0
   | _ -> false
 
   let is_exc_return a = match a with

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -104,11 +104,10 @@ module type S =
     (* Same as [>>=] but with order deps instead of data between the arguments. *)
     val bind_order : 'a t -> ('a -> 'b t) -> 'b t
 
-    (* Very ad-hoc transformation, [short3 p1 p2 s],
-     * add relation r;r;r where r is intra_causality_data,
-     *  with starting event(s) selected by p1 and final one(s) by p2
-     *)
-    val short3 : (E.event -> bool) -> (E.event -> bool) -> 'a t -> 'a t
+    val short : (E.event -> bool) -> (E.event -> bool) -> 'a t -> 'a t
+    (** [short p1 p2 s] adds iico_causality_data relations to [s].
+        New relation start from all events in [s] that satisfy [p1]
+        and finish on all events in [s] that satisfy [p2]. *)
 
     (* Another ad-hoc transformation. [upOneRW p m]
      * Let r be iico_data, e1 and e2 be events s.t. p is true, e1 is 1 read e2 is a write,

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -218,12 +218,11 @@ module type S =
         [s] and the result of [f], like [cseq]. Unlike [cseq] the output of
         the resulting event structure is set to the result of [f]. *)
 
-(*
- *Sequence of memorory events by iico_order.
- * Notice that the combinator is otherwise similar
- * to ``>>|`.
- *)
     val seq_mem : 'a t -> 'b t -> ('a * 'b) t
+    (** [seq_mem s1 s2] returns a composition of the event structures
+        of [s1] and [s2] where in addition to the existing relations,
+        every memory event in [s1] is iico_order before every memory
+        event in [s2] *)
 
     val (|*|)   : bool code -> unit code -> unit code   (* Cross product *)
 (*    val lockT : 'a t -> 'a t *)

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -195,12 +195,6 @@ module type S =
         'loc t -> 'v t -> 'v t -> ('loc -> 'v -> unit t) -> unit t
     val stu : 'a t -> 'a t -> ('a -> unit t) -> (('a * 'a) -> unit t) -> unit t
 
-    (* Same as [>>|], but binding style. *)
-    val cseq : 'a t -> ('a -> 'b t) -> 'b t
-
-    (* Same as [cseq], but output on right argument. *)
-    val aslseq : 'a t -> ('a -> 'b t) -> 'b t
-
     type poi = int
 
     val add_instr :
@@ -214,6 +208,16 @@ module type S =
     val para_input_right : 'a t -> 'b t -> ('a * 'b)  t (* Input in second argument *)
     val (>>::) : 'a t -> 'a list t -> 'a list t
     val (|||) : unit t -> unit t -> unit t
+
+    val cseq : 'a t -> ('a -> 'b t) -> 'b t
+    (** [cseq s1 s2] similar to [>>|], but binding style. *)
+
+    val para_bind_output_right : 'a t -> ('a -> 'b t) -> 'b t
+    (** [para_bind_output_right s f] returns a parallel composition of
+        the event structures of [s] and the result of [f] where the
+        input of the new event structure is the union of the inputs of
+        [s] and the result of [f], like [cseq]. Unlike [cseq] the output of
+        the resulting event structure is set to the result of [f]. *)
 
 (*
  *Sequence of memorory events by iico_order.

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -241,6 +241,11 @@ module type S =
 
     val tooFar : string -> E.A.inst_instance_id -> 'v -> 'v t
 
+    val debugT : string -> 'a t -> 'a t
+    (** [debugT str s] prints [str] followed by a string
+        representation of the input event structure [s], and returns
+        the input [s] without making any changes to it *)
+
     (**********************************************************)
     (* A few action instruction instance -> monad constructors *)
     (**********************************************************)

--- a/herd/tests/instructions/AArch64.vmsa+mte/A001.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A001.litmus
@@ -1,0 +1,11 @@
+AArch64 A001
+{
+ [PTE(x)]=(oa:PA(x),attrs:(TaggedNormal));
+ 0:X0=x:green;
+}
+ P0          ;
+ MOV W1,#1   ;
+L0:          ;
+ STR W1,[X0] ;
+locations[fault(P0:L0,x);]
+forall([x]=1)

--- a/herd/tests/instructions/AArch64.vmsa+mte/A001.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A001.litmus.expected
@@ -1,0 +1,11 @@
+Test A001 Required
+States 1
+[x]=1;  ~Fault(P0:L0,x);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition forall ([x]=1)
+Observation A001 Always 1 0
+Hash=15101ca2a5774fd3ea63c508af175bc5
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A002.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A002.litmus
@@ -1,0 +1,10 @@
+AArch64 A002
+{
+ [PTE(x)]=(valid:0);
+ 0:X0=x:green;
+}
+ P0          ;
+ MOV W1,#1   ;
+L0:          ;
+ STR W1,[X0] ;
+forall([x]=0 /\ fault(P0:L0,x,MMU:Translation))

--- a/herd/tests/instructions/AArch64.vmsa+mte/A002.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A002.litmus.expected
@@ -1,0 +1,11 @@
+Test A002 Required
+States 1
+[x]=0; Fault(P0:L0,x:green,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition forall ([x]=0 /\ fault(P0:L0,x,MMU:Translation))
+Observation A002 Always 1 0
+Hash=28724503810e0526ec2b6e8518813c37
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A003.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A003.litmus
@@ -1,0 +1,10 @@
+AArch64 A003
+{
+ [PTE(x)]=(db:0,attrs:(Normal));
+ 0:X0=x:green;
+}
+ P0          ;
+ MOV W1,#1   ;
+L0:          ;
+ STR W1,[X0] ;
+forall([x]=0 /\ fault(P0:L0,x,MMU:Permission))

--- a/herd/tests/instructions/AArch64.vmsa+mte/A003.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A003.litmus.expected
@@ -1,0 +1,11 @@
+Test A003 Required
+States 1
+[x]=0; Fault(P0:L0,x:green,MMU:Permission);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition forall ([x]=0 /\ fault(P0:L0,x,MMU:Permission))
+Observation A003 Always 1 0
+Hash=e7bf1b4fe19ba1d138df90036a21cbe5
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A004.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A004.litmus
@@ -1,0 +1,10 @@
+AArch64 A004
+{
+ [PTE(x)]=(oa:PA(x),attrs:(TaggedNormal));
+ 0:X0=x:red;
+}
+ P0          ;
+ MOV W1,#1   ;
+L0:          ;
+ STR W1,[X0] ;
+forall([x]=0 /\ fault(P0:L0,x,TagCheck))

--- a/herd/tests/instructions/AArch64.vmsa+mte/A004.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A004.litmus.expected
@@ -1,0 +1,11 @@
+Test A004 Required
+States 1
+[x]=0; Fault(P0:L0,x:red,TagCheck);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition forall ([x]=0 /\ fault(P0:L0,x,TagCheck))
+Observation A004 Always 1 0
+Hash=bf45c6a8a3dec235d4ba99539f6e2979
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A005.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A005.litmus
@@ -1,0 +1,10 @@
+AArch64 A005
+{
+ [PTE(x)]=(oa:PA(x),db:0,attrs:(TaggedNormal));
+ 0:X0=x:red;
+}
+ P0          ;
+ MOV W1,#1   ;
+L0:          ;
+ STR W1,[X0] ;
+forall([x]=0 /\ fault(P0:L0,x,MMU:Permission))

--- a/herd/tests/instructions/AArch64.vmsa+mte/A005.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A005.litmus.expected
@@ -1,0 +1,11 @@
+Test A005 Required
+States 1
+[x]=0; Fault(P0:L0,x:red,MMU:Permission);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition forall ([x]=0 /\ fault(P0:L0,x,MMU:Permission))
+Observation A005 Always 1 0
+Hash=fe308bb85bd50ea32864c623d03c6b2a
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A006.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A006.litmus
@@ -1,0 +1,11 @@
+AArch64 A006
+{
+ [PTE(x)]=(oa:PA(x),attrs:(Normal));
+ 0:X0=x:red;
+}
+  P0          ;
+  MOV W1,#1   ;
+ L0:          ;
+  STR W1,[X0] ;
+locations[fault(P0:L0,x);]
+forall([x]=1)

--- a/herd/tests/instructions/AArch64.vmsa+mte/A006.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A006.litmus.expected
@@ -1,0 +1,11 @@
+Test A006 Required
+States 1
+[x]=1;  ~Fault(P0:L0,x);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition forall ([x]=1)
+Observation A006 Always 1 0
+Hash=7a7266deb5d908ed212b3f3d1182f155
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/vmsa+mte.cfg
+++ b/herd/tests/instructions/AArch64.vmsa+mte/vmsa+mte.cfg
@@ -1,0 +1,1 @@
+variant memtag,precise,vmsa

--- a/lib/AArch64Op.ml
+++ b/lib/AArch64Op.ml
@@ -23,6 +23,7 @@ type 'op1 t =
   | Valid (* get Valid bit from PTE entry *)
   | EL0 (* get EL0 bit from PTE entry *)
   | OA (* get OA from PTE entry *)
+  | Tagged (* get Tag attribute from PTE entry *)
   | Extra of 'op1
 
 module
@@ -53,6 +54,7 @@ module
       | Valid -> "Valid"
       | EL0 -> "EL0"
       | OA -> "OA"
+      | Tagged -> "Tagged"
       | Extra op1 -> Extra.pp_op1 hexa op1
 
     type scalar = S.t
@@ -93,6 +95,8 @@ module
 
     let getel0 = op_get_pteval (fun p -> p.el0 <> 0)
 
+    let gettagged = op_get_pteval (fun p -> Attrs.mem "TaggedNormal" p.attrs)
+
     let getoa v =
       let open Constant in
       match v with
@@ -120,6 +124,7 @@ module
       | Valid -> getvalid
       | EL0 -> getel0
       | OA -> getoa
+      | Tagged -> gettagged
       | Extra op1 ->
          fun cst ->
            try

--- a/lib/AArch64PteVal.ml
+++ b/lib/AArch64PteVal.ml
@@ -29,6 +29,8 @@ module Attrs = struct
   let pp a = StringSet.pp_str ", " Misc.identity a
   let as_list a = StringSet.elements a
   let of_list l = StringSet.of_list l
+
+  let mem = StringSet.mem
 end
 
 

--- a/lib/AArch64PteVal.mli
+++ b/lib/AArch64PteVal.mli
@@ -24,6 +24,7 @@ module Attrs : sig
   val pp : t -> string
   val as_list : t -> string list
   val of_list : string list -> t
+  val mem : string -> t -> bool
 end
 
 type t = {

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -88,7 +88,8 @@ type symbol =
 let get_index = function
   | Virtual s -> Some s.offset
   | Physical (_,o) -> Some o
-  | System _ -> None
+  | System (PTE, _ | PTE2, _ |TAG, _) -> Some 0
+  | System (TLB, _) -> None
 
 let pp_index base o = match o with
 | 0 -> base

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -473,8 +473,10 @@ module
   let capatagloc = op_tagged "capatagloc" (op_tagloc Misc.add_ctag)
 
   let tagloc v =  match v with
-  | Val (Symbolic (Virtual {name=a;_}|Physical (a,_))) ->
+  | Val (Symbolic (Virtual {name=a;_})) ->
        Val (Symbolic (System (TAG,a)))
+  | Val (Symbolic (Physical _)) ->
+    Val (Symbolic (System (TAG,pp_v v)))
   | Val
         (Concrete _|ConcreteRecord _|ConcreteVector _
         |Symbolic (System _)|Label _


### PR DESCRIPTION
This change modifies the semantics of the translation (-variant vmsa) for checked memory instructions when MTE is enabled (-variant memtag). In short, for a checked memory instruction that performs a tag check prior to the explicit memory event, it allows the tag check operation to have its own translation (read of the PTE followed by a branching decision), separate from the translation that happens and leads to the explicit memory event.

In addition, this PR implements a debugT monadic operation.

Signed-off-by: Nikos Nikoleris <nikos.nikoleris@arm.com>