### PR TITLE
[herd] New debug switch `-debug exception`

### DIFF
--- a/herd/debug_herd.ml
+++ b/herd/debug_herd.ml
@@ -29,6 +29,7 @@ type t = {
     mixed : bool ;
     files : bool ;
     timeout : bool ;
+    exc : bool ;
   }
 
 let tags =
@@ -44,7 +45,8 @@ let tags =
   "pretty";
   "mixed";
   "files";
-  "timeout"
+  "timeout";
+  "exception";
 ]
 
 let none =
@@ -61,6 +63,7 @@ let none =
    mixed = false ;
    files = false ;
    timeout = false ;
+   exc = false ;
  }
 
 let parse t tag = match tag with
@@ -76,4 +79,5 @@ let parse t tag = match tag with
   | "mixed" -> Some { t with mixed = true ;}
   | "files"|"file" -> Some { t with files = true ;}
   | "timeout" -> Some { t with timeout = true ;}
+  | "exception"|"exc" -> Some { t with exc = true ;}
   | _ -> None

--- a/herd/debug_herd.mli
+++ b/herd/debug_herd.mli
@@ -29,7 +29,7 @@ type t = {
   mixed : bool ;
   files : bool ;
   timeout : bool ;
-  }
+  exc : bool ;  }
 
 val none : t
 val tags : string list

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -43,7 +43,7 @@ and type evt_struct = E.event_structure) =
       Valconstraint.Make
         (struct
           let hexa = C.hexa
-          let debug = C.debug.Debug_herd.solver
+          let debug = C.debug
           let keep_failed_as_undetermined = C.variant Variant.ASL_AArch64
         end)
         (A)


### PR DESCRIPTION
This switch disables failure delaying and some exceptions handlers. As a result, exception backtraces are more informative.

**NB**: Exception backtraces are obtained by setting `OCAMLRUNPARAM=b` before herd command.