### PR TITLE
[gen] implementation of Ifetch annotation

### DIFF
--- a/gen/ARMArch_gen.ml
+++ b/gen/ARMArch_gen.ml
@@ -99,6 +99,7 @@ include NoEdge
         | _ -> false
 
       let pp_reg = pp_reg
+      let pp_i _ = assert false
       let free_registers = allowed_for_symb
       include NoSpecial
     end)

--- a/gen/BellArch_gen.ml
+++ b/gen/BellArch_gen.ml
@@ -106,6 +106,7 @@ module SIMD = NoSIMD
 type atom = string list
 
 let default_atom = [] (* Wrong, extract from bell file? *)
+let instr_atom = None
 
 let tr_dir = function
   | R -> BellName.r
@@ -115,7 +116,7 @@ let tr_dir = function
 let applies_atom = match bi with
 | None -> (fun a _d -> match a with [] -> true | _ -> false)
 | Some bi -> (fun a d -> BellModel.check_event (tr_dir d) a bi)
-
+let is_ifetch _ = false
 let pp_plain = "P"
 let pp_as_a = None
 
@@ -271,6 +272,7 @@ include
       let is_symbolic _ = false
 
       let pp_reg = pp_reg
+      let pp_i _ = assert false
       let free_registers = allowed_for_symb
       include NoSpecial
     end)

--- a/gen/CArch_gen.ml
+++ b/gen/CArch_gen.ml
@@ -28,12 +28,13 @@ module SIMD = NoSIMD
 type atom = MemOrder.t
 
 let default_atom = SC
+let instr_atom = None
 
 let applies_atom a d = match a,d with
 | (Acq|Acq_Rel|Con),W -> false
 | (Rel|Acq_Rel),R -> false
 | _,_ -> true
-
+let is_ifetch _ = false
 let compare_atom = Misc.polymorphic_compare
 
 include MachMixed.No
@@ -131,6 +132,7 @@ let location_compare loc1 loc2 = match loc1,loc2 with
 end
 
 let of_reg p r = Reg (p,r)
+let pp_i _ = assert false
 let of_loc loc = Loc (as_data loc)
 
 type tbase = TypBase.t

--- a/gen/MIPSArch_gen.ml
+++ b/gen/MIPSArch_gen.ml
@@ -101,6 +101,7 @@ include
         | Symbolic_reg _ -> true
         | _ -> false
       let pp_reg = pp_reg
+      let pp_i _ = assert false
       let free_registers = allowed_for_symb
       include NoSpecial
     end)

--- a/gen/PPCArch_gen.ml
+++ b/gen/PPCArch_gen.ml
@@ -110,6 +110,7 @@ module Make(C:Config)  =
             | Symbolic_reg _ -> true
             | _ -> false
           let pp_reg = pp_reg
+          let pp_i _ = assert false
           let free_registers = allowed_for_symb
           include NoSpecial
         end)

--- a/gen/RISCVArch_gen.ml
+++ b/gen/RISCVArch_gen.ml
@@ -51,6 +51,7 @@ module Make
    type atom = MO of mo | Atomic of mo * mo | Mixed of MachMixed.t
 
    let default_atom = Atomic (Rlx,Rlx)
+   let instr_atom = None
 
    let applies_atom a d = match a with
    | MO mo ->
@@ -62,7 +63,7 @@ module Make
        | Sc,_ -> assert false
        end
    | Atomic _|Mixed _ -> true
-
+   let is_ifetch _ = false
    let pp_plain = "P"
 
    let pp_as_a = None
@@ -225,6 +226,7 @@ include
         | _ -> false
 
       let pp_reg = pp_reg
+      let pp_i _ = assert false
 
       let free_registers = allowed_for_symb
       include NoSpecial

--- a/gen/X86Arch_gen.ml
+++ b/gen/X86Arch_gen.ml
@@ -27,11 +27,12 @@ module SIMD = NoSIMD
 type atom = Atomic
 
 let default_atom = Atomic
+let instr_atom = None
 
 let applies_atom a d = match a,d with
 | Atomic,W -> true
 | _,_ -> false
-
+let is_ifetch _ = false
 let compare_atom = compare
 
 include MachMixed.No
@@ -123,6 +124,7 @@ include
         | Symbolic_reg _ -> true
         | _ -> false
       let pp_reg = pp_reg
+      let pp_i _ = assert false
       let free_registers = allowed_for_symb
       include NoSpecial
     end)

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -47,12 +47,14 @@ module Make
       type atom = atom_acc * MachMixed.t option
 
       let default_atom = Atomic,None
+      let instr_atom = None
 
       let applies_atom a d = match a,d with
       | ((Atomic,_),Code.W)
       | (((Plain|NonTemporal),_),(Code.W|Code.R)) -> true
       | ((Atomic,_),Code.R)
       | (_,Code.J)-> false
+    let is_ifetch _ = false
 
       let compare_atom = compare
 
@@ -249,6 +251,7 @@ module Make
               | Symbolic_reg _ -> true
               | _ -> false
             let pp_reg = pp_reg
+            let pp_i _ = assert false
             let free_registers = allowed_for_symb
             type special = xmm
             let specials = xmms

--- a/gen/archExtra_gen.ml
+++ b/gen/archExtra_gen.ml
@@ -25,6 +25,7 @@ module type I = sig
 
   type special
   val specials : special list
+  val pp_i : int -> string
 end
 
 module type S = sig
@@ -38,6 +39,7 @@ module type S = sig
   val of_loc : Code.loc -> location
   val of_reg : Code.proc -> arch_reg -> location
 
+  val pp_i : int -> string
   val pp_location : location -> string
   val pp_location_brk : location -> string
   val location_compare : location -> location -> int
@@ -111,6 +113,8 @@ with type arch_reg = I.arch_reg and type special = I.special
         if I.is_symbolic r then I.pp_reg r
         else sprintf "%i:%s" i (I.pp_reg r)
     | Loc loc -> sprintf "[%s]" (pp_symbol loc)
+
+  let pp_i = I.pp_i
 
   let location_compare loc1 loc2 = match loc1,loc2 with
   | Reg _,Loc _ -> -1

--- a/gen/archLoc.mli
+++ b/gen/archLoc.mli
@@ -25,4 +25,5 @@ module type S = sig
   val location_compare : location -> location -> int
   val pp_location : location -> string
   val pp_location_brk : location -> string
+  val pp_i : int -> string
 end

--- a/gen/atom.mli
+++ b/gen/atom.mli
@@ -33,7 +33,9 @@ module type S = sig
 
   type atom
   val default_atom : atom
+  val instr_atom : atom option
   val applies_atom : atom -> Code.dir -> bool
+  val is_ifetch : atom option -> bool
   val compare_atom : atom -> atom -> int
   val get_access_atom : atom option -> MachMixed.t option
   val set_access_atom : atom option -> MachMixed.t -> atom option

--- a/gen/code.ml
+++ b/gen/code.ml
@@ -165,7 +165,7 @@ type info = (string * string) list
 let plain = "Na"
 
 (* Memory Space *)
-type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a | Pair
+type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a | Pair | Instr
 
 let pp_bank = function
   | Ord -> "Ord"
@@ -175,6 +175,7 @@ let pp_bank = function
   | Pte -> "Pte"
   | VecReg _ -> "VecReg"
   | Pair -> "Pair"
+  | Instr -> "Instr"
 
 let tag_of_int  = function
   | 0 -> "green"

--- a/gen/code.mli
+++ b/gen/code.mli
@@ -90,7 +90,7 @@ type info = (string * string) list
 val plain : string
 
 (* Memory bank (for MTE, KVM)  *)
-type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a | Pair
+type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a | Pair | Instr
 
 val pp_bank : 'a bank -> string
 

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -29,6 +29,7 @@ module type S = sig
         ctag : int; cseal : int; dep : int ;
         v   : v ; (* Value read or written *)
         vecreg: v list list ; (* Alternative for SIMD *)
+        ins : int ;
         dir : dir option ;
         proc : Code.proc ;
         atom : atom option ;
@@ -147,6 +148,7 @@ module Make (O:Config) (E:Edge.S) :
         ctag : int; cseal : int; dep : int;
         v   : v ;
         vecreg: v list list ;
+        ins : int ;
         dir : dir option ;
         proc : Code.proc ;
         atom : atom option ;
@@ -163,7 +165,7 @@ module Make (O:Config) (E:Edge.S) :
     { loc=Code.loc_none ; ord=0; tag=0;
       ctag=0; cseal=0; dep=0;
       vecreg= [];
-      v=(-1) ; dir=None; proc=(-1); atom=None; rmw=false;
+      v=(-1) ; ins=0;dir=None; proc=(-1); atom=None; rmw=false;
       cell=[||]; tcell=[||];
       bank=Code.Ord; idx=(-1);
       pte=pte_default; }
@@ -222,7 +224,7 @@ module Make (O:Config) (E:Edge.S) :
     let pp_v =
       match e.bank with
       | Pte -> PteVal.pp e.pte
-      | (Ord|Pair|Tag|CapaTag|CapaSeal|VecReg _) -> debug_val e.v in
+      | (Ord|Pair|Tag|CapaTag|CapaSeal|VecReg _|Instr) -> debug_val e.v in
     sprintf "%s%s %s %s%s%s%s%s"
       (debug_dir e.dir)
       (debug_atom e.atom)
@@ -376,9 +378,6 @@ let non_pseudo e = E.is_non_pseudo e.E.edge
 let find_non_pseudo m = find_edge non_pseudo m
 let find_non_pseudo_prev m = find_edge_prev non_pseudo m
 
-let is_real_edge e =  non_pseudo e && non_insert_store e
-
-let find_real_edge_prev = find_edge_prev is_real_edge
 
 (* generic scan *)
   let fold f m k =
@@ -452,9 +451,10 @@ let make_loc n =
   if n < locs_len then locs.(n)
   else Printf.sprintf "x%02i" (n-locs_len)
 
-let next_loc e ((loc0,lab0),vs) = match e.E.edge with
-| E.Irf _|E.Ifr _ -> Code (sprintf "Lself%02i" lab0),((loc0,lab0+1),vs)
-| _ -> Code.Data (make_loc loc0),((loc0+1,lab0),vs)
+let next_loc e ((loc0,lab0),vs) = match E.is_fetch e with
+| true -> Code (sprintf "Lself%02i" lab0),((loc0,lab0+1),vs)
+| _ ->
+  Code.Data (make_loc loc0),((loc0+1,lab0),vs)
 
 let same_loc e = match E.loc_sd e with
     | Same -> true
@@ -482,7 +482,7 @@ module CoSt = struct
   let create ?(init=0) sz =
     let map  =
       M.add Tag init <<  M.add CapaTag init <<
-      M.add CapaSeal init << M.add Ord init <! M.empty
+      M.add CapaSeal init << M.add Ord init << M.add Instr init <! M.empty
     and co_cell = Array.make (if sz <= 0 then 1 else sz) init in
     { map; co_cell;  }
 
@@ -702,25 +702,30 @@ let remove_store n0 =
 (* Set locations of events *)
 (***************************)
 
-  let is_non_fetch_and_same e =
-    is_real_edge e && same_loc e && not (E.is_fetch e)
+  let is_read_same_nonfetch m =
+    let check n = (n != m && (loc_compare n.evt.loc  m.evt.loc) = 0 && n.evt.dir = Some R &&
+                  not (E.is_ifetch n.edge.E.a1)) in
+    try ignore (find_node_prev (fun n -> check n) m); true
+    with Not_found -> false
 
   let check_fetch n0 =
     let rec do_rec m =
-      let p = find_real_edge_prev m.prev in
-      if E.is_fetch m.edge then begin
-        if E.is_fetch p.edge && find_real_edge_prev p.prev != m then
-          Warn.user_error "Bad consecutive fetches [%s] => [%s]"
-            (str_node p) (str_node m)
-      end ;
-      if
-        E.is_fetch p.edge && is_non_fetch_and_same m.edge ||
-        E.is_fetch m.edge && is_non_fetch_and_same p.edge
-      then begin
-        Warn.user_error "Ambiguous Data/Code location es [%s] => [%s]"
-          (str_node p) (str_node m)
-      end ;
-      if m.next != n0 then do_rec m.next in
+      (* ensure Instr read is followed or preceded by plain read to same location*)
+      begin match m.evt.loc, m.evt.dir with
+        | Code.Code _, Some R when not (E.is_ifetch m.edge.E.a1) ->
+            if is_read_same_nonfetch m then begin
+              Printf.printf "%s" (str_node m);
+              Warn.user_error "Multiple ifetch reads to same code location"
+              end;
+        | Code.Code _, Some R when E.is_ifetch m.edge.E.a1 ->
+            if not (is_read_same_nonfetch m) then begin
+             Warn.user_error "Reading from label that doesn't exist [%s]" (str_node m)
+            end;
+        | Code.Code _, Some W when not (E.is_ifetch m.edge.E.a1) ->
+          Warn.user_error "Writing non-instruction value to code location: [%s]" (str_node m)
+        | _ -> ();
+        end;
+        if m.next != n0 then do_rec m.next in
   do_rec n0
 
 (* Loc is changing *)
@@ -729,7 +734,14 @@ let set_diff_loc st n0 =
     let loc,st =
       if same_loc p.edge then begin
         p.evt.loc,st
-      end else next_loc m.edge st in
+      end
+    else
+      let n1 = try
+        (* check if new location needs to be ifetch *)
+        find_node
+          (fun n -> (if not (same_loc n.prev.edge) then raise Not_found); E.is_ifetch n.edge.E.a1 ) m.next
+        with Not_found -> m in
+      next_loc n1.edge st in
     m.evt <- { m.evt with loc=loc ; bank=E.atom_to_bank m.evt.atom; } ;
 (*    eprintf "LOC SET: %a [p=%a]\n%!" debug_node m debug_node p; *)
     if m.store != nil then begin
@@ -816,6 +828,11 @@ let set_same_loc st n0 =
             let ctag = CoSt.get_co st CapaTag in
             let cseal = CoSt.get_co st CapaSeal in
             n.evt <- { n.evt with ord=ord; ctag=ctag; cseal=cseal; }
+          end
+        else begin
+          let instr = CoSt.get_co st Instr in
+          n.evt <- { n.evt with ins=instr}
+        end
 (*
           else if do_neon then (* set both fields, it cannot harm *)
             let ord = get_co st Ord in
@@ -823,7 +840,6 @@ let set_same_loc st n0 =
             let vecreg = [|v;v;v;v;|] in
             n.evt <- { n.evt with ord=ord; vecreg=vecreg; }
 *)
-          end
         end ;
         begin match n.evt.dir with
         | Some W ->
@@ -831,7 +847,7 @@ let set_same_loc st n0 =
             | Data _ ->
                 let bank = n.evt.bank in
                 begin match bank with
-                | Ord ->
+                | Ord | Instr ->
                    let st = set_write_val_ord st n in
                    do_set_write_val next_x_ok st pte_val ns
                 | Pair ->
@@ -885,7 +901,15 @@ let set_same_loc st n0 =
                    do_set_write_val (!next_x_pred || next_x_ok) st pte_val ns
                 end
             | Code _ ->
-               do_set_write_val next_x_ok st pte_val ns
+              let bank = n.evt.bank in
+                begin match bank with
+              | Instr ->
+                  let st = CoSt.next_co st bank in
+                  let v = CoSt.get_co st bank in
+                  n.evt <- { n.evt with ins = v;} ;
+                  do_set_write_val next_x_ok st pte_val ns
+               | _ -> do_set_write_val next_x_ok st pte_val ns
+            end
             end
         | Some (R|J) |None -> do_set_write_val next_x_ok st pte_val ns
         end
@@ -1000,6 +1024,8 @@ let do_set_read_v =
                 n.evt <- { n.evt with v = CoSt.get_co st bank; }
             | Pte ->
                 n.evt <- { n.evt with pte = pte_cell; }
+            | Instr ->
+                n.evt <- { n.evt with ins = CoSt.get_co st bank; }
             end ;
             do_rec st cell pte_cell ns
         | Some W ->
@@ -1007,6 +1033,7 @@ let do_set_read_v =
               match bank with
               | Tag|CapaTag|CapaSeal ->
                  CoSt.set_co st bank n.evt.v
+              |Instr -> CoSt.set_co st bank n.evt.ins
               | Pte|Ord|Pair|VecReg _ ->
                  st in
             do_rec st
@@ -1014,9 +1041,9 @@ let do_set_read_v =
                | Ord|Pair|VecReg _ ->
                   if Code.is_data n.evt.loc then n.evt.cell
                   else cell
-               | Tag|CapaTag|CapaSeal|Pte -> cell)
+               | Tag|CapaTag|CapaSeal|Pte|Instr -> cell)
               (match bank with
-               | Ord|Pair|Tag|CapaTag|CapaSeal|VecReg _ -> pte_cell
+               | Ord|Pair|Tag|CapaTag|CapaSeal|VecReg _|Instr -> pte_cell
                | Pte -> n.evt.pte)
               ns
         | None | Some J ->
@@ -1090,7 +1117,7 @@ let finish n =
             (fun (loc,(v,_pte)) -> sprintf "%s -> 0x%x"
                 (Code.pp_loc loc) v) vs))
   end ;
-  if O.variant Variant_gen.Self then check_fetch n ;
+  if O.variant Variant_gen.Self then check_fetch n;
   initvals
 
 
@@ -1302,7 +1329,7 @@ let rec group_rec x ns = function
   let get_ord_writes =
     let open Code in
     do_get_writes (* Not so sure about capacity here... *)
-      (function Ord|Tag|VecReg _|Pair -> true | CapaTag|CapaSeal|Pte -> false)
+      (function Ord|Tag|VecReg _|Pair|Instr -> true | CapaTag|CapaSeal|Pte -> false)
 
   let get_pte_writes =
     do_get_writes (function Code.Pte -> true | _ -> false)

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -120,7 +120,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           let open C.E in
           match e.C.E.edge with
           | Rf _ | Fr _ | Ws _ | Hat
-          | Back _|Leave _|Irf _|Ifr _ -> true
+          | Back _|Leave _ -> true
           | Rmw rmw -> C.A.show_rmw_reg rmw
           | Po _ | Fenced _ | Dp _ ->
               begin match C.E.loc_sd e with
@@ -186,6 +186,9 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
                 Some (S (Code.add_tag (Code.as_data evt.C.C.loc) evt.C.C.v))
             | Code.Pte ->
                 Some (P evt.C.C.pte)
+            | Code.Instr ->
+              let s = C.A.pp_i evt.C.C.ins in
+              Some (S s)
             end
         | Some Code.W ->
            assert (evt.C.C.bank = Code.Ord || evt.C.C.bank = Code.CapaSeal) ;

--- a/gen/genUtils.ml
+++ b/gen/genUtils.ml
@@ -89,7 +89,7 @@ module Make(Cfg:Config)(A:Arch_gen.S)
        let emit_pteval  st p init v = next_const st p init (A.P v)
 
        let emit_nop st p init nop =
-         let rA,init,st = next_const st p init (S nop) in
+         let rA,init,st = next_const st p init (S ("instr:\""^nop^"\"")) in
          rA,init,st
 
        let emit_mov st p init v = match emit_const st p init v with

--- a/gen/machAtom.ml
+++ b/gen/machAtom.ml
@@ -33,12 +33,14 @@ module Make(C:Config) = struct
   type atom = hidden_atom
 
   let default_atom = Atomic
+  let instr_atom = None
 
   open Code
 
   let applies_atom a d = match a,d with
   | Reserve,W -> false
   | _,_ -> true
+  let is_ifetch _ = false
 
   let pp_plain = Code.plain
   let pp_as_a = None

--- a/gen/namer.ml
+++ b/gen/namer.ml
@@ -64,10 +64,6 @@ module Make
          | Leave c -> Some ("["^pp_com c)
          | Back c -> Some (pp_com c^"]")
          | Insert f -> Some (sprintf "[%s]" (Misc.lowercase (A.pp_fence f)))
-         | Irf Ext -> Some "irfe"
-         | Irf Int -> Some "irfi"
-         | Ifr Ext -> Some "ifre"
-         | Ifr Int -> Some "ifri"
          | Store -> Some "store"
          | Node _ -> assert false
          | _ -> None
@@ -77,14 +73,14 @@ module Make
            -> true
          |Rf _|Ws _|Fr _
          |Id|Hat|Leave _|Back _
-         |Insert _|Store|Node _|Rmw _|Irf _|Ifr _
+         |Insert _|Store|Node _|Rmw _
            -> false
        and ambiguous_source = function
          | Po _|Fenced _
            -> true
          |Dp _| Rf _|Ws _|Fr _
          |Id|Hat|Leave _|Back _
-         |Insert _|Store|Node _|Rmw _|Irf _|Ifr _
+         |Insert _|Store|Node _|Rmw _
            -> false
 
        let plain  = Misc.lowercase (A.pp_plain)

--- a/gen/normaliser.ml
+++ b/gen/normaliser.ml
@@ -159,7 +159,7 @@ module Make : functor (C:Config) -> functor (E:Edge.S) ->
 
 (* Notice, do not halt on stores... *)
       let ext_com e = match e.E.edge with
-      | E.Rf Ext|E.Fr Ext|E.Ws Ext|E.Hat|E.Irf Ext|E.Ifr Ext -> true
+      | E.Rf Ext|E.Fr Ext|E.Ws Ext|E.Hat -> true
       | _ -> false
 
 (* Find skipping Leave/Back *)
@@ -311,15 +311,7 @@ module Make : functor (C:Config) -> functor (E:Edge.S) ->
         let r =
           match d with
           | Code.W -> W
-          | Code.R ->
-              begin match e.CE.edge.E.edge with
-              | E.Ifr _ -> F
-              | _ ->
-                  begin match e.CE.prev.CE.edge.E.edge with
-                  | E.Irf _ -> F
-                  | _ -> R
-                  end
-              end
+          | Code.R -> R
           | Code.J -> J in
         if debug then
           eprintf "%s[%s] -> %s\n"

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -225,7 +225,6 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           | Fr _|Leave CFr|Back CFr -> "Fr"
           | Rf _|Leave CRf|Back CRf -> "Rf"
           | Ws _|Leave CWs|Back CWs -> "Co"
-          | Irf _ -> "Irf" | Ifr _ -> "Ifr"
           | _ -> assert false)
         nss
 
@@ -298,7 +297,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
            | None -> false
            | Some m -> not (m == n || C.C.po_pred m n)
          end
-    | Ord|Pair|Tag|CapaTag|CapaSeal|VecReg _ ->
+    | Ord|Pair|Tag|CapaTag|CapaSeal|VecReg _|Instr ->
         check_edge n.C.C.edge.C.E.edge && not (is_load_init n.C.C.evt)
 
 (* Poll for value is possible *)
@@ -309,8 +308,9 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
       | _,_,_ -> false
 
     let fetch_val n =
-      match n.C.C.prev.C.C.edge.C.E.edge, n.C.C.edge.C.E.edge with
-      | C.E.Irf _,_ -> 2
-      | _,C.E.Ifr _ -> 1
-      | _,_ -> 0
+      let n = C.C.find_node (fun n -> C.E.is_com n.C.C.edge) n.C.C.prev in
+      match n.C.C.edge.C.E.edge with
+      | C.E.Rf _-> 2
+      | C.E.Fr _ -> 1
+      | _ -> 0
   end

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -362,7 +362,10 @@ let pp_reg r = match r with
 | Vreg _ -> pp_simd_vector_reg r
 | SIMDreg _ -> pp_simd_scalar_reg vvrs r
 | _ -> pp_xreg r
-
+let pp_i n = match n with
+  | 1 -> "instr:\"NOP\""
+  | 0 -> "instr:\"B .+12\""
+  | _ -> Warn.fatal "instruction currently not supported"
 let pp_wreg r = match r with
 | Symbolic_reg r -> "W%" ^ r
 | Internal i -> Printf.sprintf "i%i" i

--- a/litmus/lexAffinity.mll
+++ b/litmus/lexAffinity.mll
@@ -38,8 +38,8 @@ let num = digit+
 
 rule coms = parse
 | space+ { coms lexbuf }
-| "Fr"|"Iff"|"Irf"  { Fr :: coms lexbuf }
-| "Rf"|"Fif"|"Ifr"  { Rf :: coms lexbuf }
+| "Fr"|"Iff"  { Fr :: coms lexbuf }
+| "Rf"|"Fif"  { Rf :: coms lexbuf }
 | "Ws"|"Co"    { Ws :: coms lexbuf }
 | "Hat"  { Hat :: coms lexbuf }
 | eof    { [] }


### PR DESCRIPTION
This PR implements a new syntax for generating Ifetch tests, using a new annotation. The I annotation is used to represent explicit memory events to instruction locations (i.e. LDR and STR of an instruction stored at a location identified by a label). This PR also introduces the possibility of generating explicit reads of an instruction. With this new implementation, Ifetch sequences are generated by using the plain annotation with a read to a Code location.

example tests:
```
diyone7 -arch AArch64 -variant self "RfeII Pod** Rfe Pod** FrePI"
AArch64 A
"RfeII PodRWIP Rfe PodRR FrePI"
Generator=diyone7 (version 7.56+03)
Com=Rf Rf Fr
Orig=RfeII PodRWIP Rfe PodRR FrePI
{
0:X0=instr:"NOP"; 0:X1=P2:Lself00;
1:X0=P2:Lself00; 1:X3=x;
2:X0=x;
}
 P0          | P1          | P2          ;
 STR W0,[X1] | LDR W1,[X0] | LDR W1,[X0] ;
             | MOV W2,#1   | Lself00:    ;
             | STR W2,[X3] | B L00       ;
             |             | MOV W2,#2   ;
             |             | B L01       ;
             |             | L00:        ;
             |             | MOV W2,#1   ;
             |             | L01:        ;
exists (1:X1=instr:"NOP" /\ 2:X1=1 /\ 2:X2=1)
```

```
diyone7 -arch AArch64 -variant self "RfeIP Pod** Rfe Pod** FreII"
AArch64 A
"RfeIP PodRW Rfe PodRRPI FreII"
Generator=diyone7 (version 7.56+03)
Com=Rf Rf Fr
Orig=RfeIP PodRW Rfe PodRRPI FreII
{
0:X0=instr:"NOP"; 0:X1=P1:Lself00;
1:X2=x;
2:X0=x; 2:X2=P1:Lself00;
}
 P0          | P1          | P2          ;
 STR W0,[X1] | Lself00:    | LDR W1,[X0] ;
             | B L00       | LDR W3,[X2] ;
             | MOV W0,#2   |             ;
             | B L01       |             ;
             | L00:        |             ;
             | MOV W0,#1   |             ;
             | L01:        |             ;
             | MOV W1,#1   |             ;
             | STR W1,[X2] |             ;
exists (1:X0=2 /\ 2:X1=1 /\ 2:X3=instr:"B .+12")
```

```
diyone7 -arch AArch64 -variant self "Pod** RfeIP Pod** FrePI"
AArch64 A
"PodWWII RfeIP PodRR FrePI"
Generator=diyone7 (version 7.56+03)
Com=Rf Fr
Orig=PodWWII RfeIP PodRR FrePI
{
0:X0=instr:"NOP"; 0:X1=P1:Lself00; 0:X2=P1:Lself01;
}
 P0          | P1        ;
 STR W0,[X1] | Lself01:  ;
 STR W0,[X2] | B L00     ;
             | MOV W0,#2 ;
             | B L01     ;
             | L00:      ;
             | MOV W0,#1 ;
             | L01:      ;
             | Lself00:  ;
             | B L02     ;
             | MOV W1,#2 ;
             | B L03     ;
             | L02:      ;
             | MOV W1,#1 ;
             | L03:      ;
exists (1:X0=2 /\ 1:X1=1)
```