### PR TITLE
[gen]DC CVAU and IC IVAU relaxations

### DIFF
--- a/gen/ARMCompile_gen.ml
+++ b/gen/ARMCompile_gen.ml
@@ -393,6 +393,9 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | DMB o -> I_DMB o
         | DSB o -> I_DSB o
         | ISB -> I_ISB)],st
+    let emit_fence_dp st a init b f _ r _ =
+      let init,cs,st = emit_fence st a init b f in
+      Some r,init,cs,st
     let stronger_fence = DMB SY
 
     let do_check_load p st r e =

--- a/gen/BellCompile.ml
+++ b/gen/BellCompile.ml
@@ -201,6 +201,9 @@ let emit_rmw _ = assert false
 (**********)
 
     let emit_fence st _ init _ f =  init,[Instruction (Pfence f)],st
+    let emit_fence_dp st a init b f _ r _ =
+      let init,cs,st = emit_fence st a init b f in
+      Some r,init,cs,st
     let _emit_fence_tagged o a = Instruction (Pfence(Fence(a,o)))
 
     let stronger_fence = strong

--- a/gen/MIPSCompile_gen.ml
+++ b/gen/MIPSCompile_gen.ml
@@ -384,6 +384,9 @@ let emit_joker st init = None,init,[],st
 (* Fences *)
 
     let emit_fence st _ init _ f = init,[Instruction (match f with Sync -> SYNC)],st
+    let emit_fence_dp st a init b f _ r _ =
+      let init,cs,st = emit_fence st a init b f in
+      Some r,init,cs,st
     let stronger_fence = Sync
 
 (* Check load *)

--- a/gen/PPCCompile_gen.ml
+++ b/gen/PPCCompile_gen.ml
@@ -510,6 +510,9 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
          | PPC.LwSync -> PPC.Plwsync
          | PPC.ISync -> PPC.Pisync
          | PPC.Eieio -> PPC.Peieio)],st
+    let emit_fence_dp st a init b f _ r _ =
+      let init,cs,st = emit_fence st a init b f in
+      Some r,init,cs,st
     let stronger_fence = PPC.Sync
 
 (* Check load *)

--- a/gen/RISCVCompile_gen.ml
+++ b/gen/RISCVCompile_gen.ml
@@ -438,6 +438,9 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
 (**********)
 
     let emit_fence st _ init _ f = init,[Instruction (AV.FenceIns f)],st
+    let emit_fence_dp st a init b f _ r _ =
+      let init,cs,st = emit_fence st a init b f in
+      Some r,init,cs,st
     let stronger_fence = strong
 
         (* Dependencies *)

--- a/gen/X86Compile_gen.ml
+++ b/gen/X86Compile_gen.ml
@@ -155,6 +155,9 @@ struct
   let emit_fence st _ init _ f = match f with
     | MFence -> init,[X86.Instruction I_MFENCE],st
 
+  let emit_fence_dp st a init b f _ r _ =
+    let init,cs,st = emit_fence st a init b f in
+    Some r,init,cs,st
   let stronger_fence = MFence
 
   let emit_inc r = I_INC (Effaddr_rm32 (Rm32_reg r))

--- a/gen/X86_64Compile_gen.ml
+++ b/gen/X86_64Compile_gen.ml
@@ -426,6 +426,9 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
            [X86_64.Instruction (I_CLFLUSH (opt,Effaddr_rm64 ea))] in
          init,cs,st
 
+    let emit_fence_dp st a init b f _ r _ =
+      let init,cs,st = emit_fence st a init b f in
+      Some r,init,cs,st
     let stronger_fence = Fence MFENCE
 
     (* Check load *)

--- a/gen/XXXCompile_gen.mli
+++ b/gen/XXXCompile_gen.mli
@@ -64,6 +64,8 @@ module type S = sig
   val emit_fence : A.st -> Code.proc -> A.init -> C.node -> A.fence ->
     A.init * A.pseudo list * A.st
 
+  val emit_fence_dp : A.st -> Code.proc -> A.init -> C.node -> A.fence -> A.dp ->
+    A.reg -> C.node -> A.reg option * A.init * A.pseudo list * A.st
   val stronger_fence : A.fence
 
 (* Code additions *)

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -111,8 +111,8 @@ module Make(C:Builder.S)
 (*
   Now accept some internal with internal composition
  *)
-      | (Ws Int|Rf Int|Fr Int),(Dp (_,_,_)|Po (Diff,_,_))
-      | (Dp (_,_,_)|Po (Diff,_,_)),(Ws Int|Rf Int|Fr Int)
+      | (Ws Int|Rf Int|Fr Int|Insert _),(Dp (_,_,_)|Po (Diff,_,_))
+      | (Dp (_,_,_)|Po (Diff,_,_)),(Ws Int|Rf Int|Fr Int|Insert _)
       | Dp (_,Diff,_),Po (Diff,_,_)
       | Po (Diff,_,_),Dp (_,Diff,_)
       | Rf Int,Po (Same,_,_)

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -687,7 +687,12 @@ let remove_store n0 =
       if not (E.is_ext p.edge || E.is_po_or_fenced_joker p.edge || E.is_ext n.edge || E.is_po_or_fenced_joker n.edge) then begin
         Warn.fatal "Insert pseudo edge %s appears in-between  %s..%s (at least one neighbour must be an external edge)"
           (E.pp_edge m.edge)  (E.pp_edge p.edge)  (E.pp_edge n.edge)
-      end
+      end;
+      match p.edge.E.edge with 
+      | (E.Rf Ext | E.Fr Ext) ->
+        Warn.fatal "Insert pseudo edge %s appears after external communication edge %s"
+        (E.pp_edge m.edge) (E.pp_edge p.edge)
+      | _ -> ()
     end ;
     if m.next != n0 then do_rec m.next in
   do_rec n0 ;

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -719,7 +719,7 @@ let fold_tedges f r =
   let can_precede_dirs  x y = match x.edge,y.edge with
   | (Store,Store) -> false
   | (Id,_)|(_,Id)|(Store,_)|(_,Store) -> true
-  | (Insert _,Insert _) -> do_kvm
+  | (Insert _,Insert _) -> do_kvm || do_self
   | _,_ ->
       begin match dir_tgt x,dir_src y with
       | (Irr,Irr) -> false

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -215,9 +215,15 @@ let get_fence n =
                    fs is))
             chk loc_writes st p ro_prev init ns
       | E.Insert f ->
+          let ro_prev,init,cs,st, n1 = match ro_prev with
+          | No  -> let init, cs, st = Comp.emit_fence st p init n f in
+              None, init, cs, st, n
+          | Yes (dp,r1,n1) ->
+            let ro_prev,init,cs,st =
+              Comp.emit_fence_dp st p init n f dp r1 n1 in
+              ro_prev,init,cs,st, n1 in
           let init,is,finals,st =
-            compile_proc pref chk loc_writes st p ro_prev init ns in
-          let init,cs,st = Comp.emit_fence st p init n f in
+            compile_proc pref chk loc_writes st p (edge_to_prev_load ro_prev n1) init ns in
           init,cs@is,finals,st
       | _ ->
           let o,init,i,st = emit_access ro_prev st p init n in

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -437,6 +437,12 @@ type barrier =
   | DSB of mBReqDomain*mBReqTypes
   | ISB
 
+type syncType = 
+  | DC_CVAU
+  | IC_IVAU
+type dirloc =
+  | Next
+  | Prev
 let fold_barrier_option kvm more f k =
   if more then
     fold_domain


### PR DESCRIPTION
This pull request implements the ability to generate DC CVAU and IC IVAU instructions as a fence instruction. This allows the user to implement these instructions with more fine-grain control into litmus tests.

This PR also implements the ability for dependencies to be generated before Insert relaxations.

The relaxations for DC CVAU and IC IVAU are:
```
DC.CVAU<n/p>
IC.IVAU<n/p>
```
where `n` and `p` allow the user to choose whether DC/IC act on the `p`revious location or the `n`ext location

examples that couldn't be generated previously:
```
diyone7 -moreedges true -arch AArch64 -variant self "PodWW DC.CVAUp DMB.ISH Rfe PodRR DSB.ISH IC.IVAUn DSB.ISH ISB Ifre"
AArch64 A
"PodWW DC.CVAUp DMB.ISH Rfe PodRR DSB.ISH IC.IVAUn DSB.ISH ISB Ifre"
Generator=diyone7 (version 7.56+03)
Com=Rf Ifr
Orig=PodWW DC.CVAUp DMB.ISH Rfe PodRR DSB.ISH IC.IVAUn DSB.ISH ISB Ifre
{
0:X0=NOP; 0:X1=P1:Lself00; 0:X3=x;
1:X0=x; 1:X2=P1:Lself00;
}
 P0          | P1          ;
 STR W0,[X1] | LDR W1,[X0] ;
 DC CVAU,X1  | DSB ISH     ;
 DMB ISH     | IC IVAU,X2  ;
 MOV W2,#1   | DSB ISH     ;
 STR W2,[X3] | ISB         ;
             | Lself00:    ;
             | B L00       ;
             | MOV W3,#2   ;
             | B L01       ;
             | L00:        ;
             | MOV W3,#1   ;
             | L01:        ;
exists (1:X1=1 /\ 1:X3=1)
```
```
diyone7 -moreedges true -arch AArch64 -variant self "[DpCtrlIsbdR DC.CVAUn DSB.ISH IC.IVAUn DSB.ISH ISB Ifre] DMB.ISHdWW Rfe"
AArch64 A
"DpCtrlIsbdR DC.CVAUn DSB.ISH IC.IVAUn DSB.ISH ISB Ifre DMB.ISHdWW Rfe"
Generator=diyone7 (version 7.56+03)
Com=Ifr Rf
Orig=DpCtrlIsbdR DC.CVAUn DSB.ISH IC.IVAUn DSB.ISH ISB Ifre DMB.ISHdWW Rfe
{
0:X0=x; 0:X2=P0:Lself00;
1:X0=NOP; 1:X1=P0:Lself00; 1:X3=x;
}
 P0           | P1          ;
 LDR W1,[X0]  | STR W0,[X1] ;
 CBNZ W1,LC00 | DMB ISH     ;
 LC00:        | MOV W2,#1   ;
 ISB          | STR W2,[X3] ;
 DC CVAU,X2   |             ;
 DSB ISH      |             ;
 IC IVAU,X2   |             ;
 DSB ISH      |             ;
 ISB          |             ;
 Lself00:     |             ;
 B L01        |             ;
 MOV W3,#2    |             ;
 B L02        |             ;
 L01:         |             ;
 MOV W3,#1    |             ;
 L02:         |             ;
exists (0:X1=1 /\ 0:X3=1)
```
