### PR TITLE
[asl] Improvements

### DIFF
--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -85,8 +85,7 @@ let pp_literal f = function
   | L_Bool true -> pp_print_string f "TRUE"
   | L_Bool false -> pp_print_string f "FALSE"
   | L_Real r ->
-      if Q.den r = Z.one then fprintf f "%a.0" Z.pp_print (Q.num r)
-      else Q.pp_print f r
+      fprintf f "(%a.0 / %a.0)" Z.pp_print (Q.num r) Z.pp_print (Q.den r)
   | L_BitVector bv -> Bitvector.pp_t f bv
   | L_String s -> fprintf f "%S" s
 
@@ -115,7 +114,7 @@ let rec pp_expr f e =
       fprintf f "@[<hv>%a {@ %a@;<1 -2>}@]" pp_ty ty (pp_comma_list pp_one) li
   | E_Concat es -> fprintf f "@[<hv 2>[%a]@]" pp_expr_list es
   | E_Tuple es -> fprintf f "@[<hv 2>(%a)@]" pp_expr_list es
-  | E_Unknown ty -> fprintf f "@[<h>UNKNOWN ::@ %a@]" pp_ty ty
+  | E_Unknown ty -> fprintf f "@[<h>UNKNOWN :@ %a@]" pp_ty ty
   | E_Pattern (e, p) -> fprintf f "@[<hv 2>%a@ IN %a@]" pp_expr e pp_pattern p
 
 and pp_expr_list f = pp_comma_list pp_expr f
@@ -197,7 +196,7 @@ and pp_bits_constraint f = function
       fprintf f "@[{%a}@]" pp_int_constraints int_constraint
   | BitWidth_ConstrainedFormType ty -> fprintf f "- : %a" pp_ty ty
 
-let pp_typed_identifier f (name, ty) = fprintf f "%s::%a" name pp_ty ty
+let pp_typed_identifier f (name, ty) = fprintf f "@[%s:@ %a@]" name pp_ty ty
 
 let rec pp_lexpr f le =
   match le.desc with
@@ -224,7 +223,7 @@ let pp_local_decl_keyword f k =
 
 let rec pp_local_decl_item f =
   let pp_ty_opt f = function
-    | Some ty -> fprintf f "@ :: @[%a@]" pp_ty ty
+    | Some ty -> fprintf f ": @[%a@]" pp_ty ty
     | None -> ()
   in
   function
@@ -317,9 +316,9 @@ let pp_decl f =
     | { name; keyword; ty = None; initial_value = Some e } ->
         fprintf f "%a %s@ = %a" pp_gdk keyword name pp_expr e
     | { name; keyword; ty = Some t; initial_value = Some e } ->
-        fprintf f "%a %s@ :: %a@ = %a" pp_gdk keyword name pp_ty t pp_expr e
+        fprintf f "%a %s:@ %a@ = %a" pp_gdk keyword name pp_ty t pp_expr e
     | { name; keyword; ty = Some t; initial_value = None } ->
-        fprintf f "%a %s@ :: %a" pp_gdk keyword name pp_ty t
+        fprintf f "%a %s:@ %a" pp_gdk keyword name pp_ty t
     | { name = _; keyword = _; ty = None; initial_value = None } -> assert false
   in
   let pp_func_sig f

--- a/asllib/StaticEnv.ml
+++ b/asllib/StaticEnv.ml
@@ -20,6 +20,7 @@ type global = {
 type local = {
   constants_values : literal IMap.t;
   storage_types : (ty * local_decl_keyword) IMap.t;
+  return_type: ty option;
 }
 
 type env = { global : global; local : local }
@@ -42,11 +43,13 @@ module PPEnv = struct
       (PP.pp_print_seq ~pp_sep pp_print_string)
       (ISet.to_seq s)
 
-  let pp_local f { constants_values; storage_types } =
-    fprintf f "@[<v 2>Local with:@ - @[constants:@ %a@]@ - @[storage:@ %a@]@]"
+  let pp_local f { constants_values; storage_types; return_type } =
+    fprintf f "@[<v 2>Local with:@ - @[constants:@ %a@]@ - @[storage:@ %a@]@ - @[return type:@ %a@]@]"
       (pp_map PP.pp_literal) constants_values
       (pp_map (fun f (t, _) -> PP.pp_ty f t))
       storage_types
+      (pp_print_option ~none:(fun f () -> fprintf f "none") PP.pp_ty)
+      return_type
 
   let pp_subprogram f func_sig =
     fprintf f "@[<hov 2>%a@ -> %a@]"
@@ -102,7 +105,9 @@ let empty_global =
   }
 
 (** An empty local static env. *)
-let empty_local = { constants_values = IMap.empty; storage_types = IMap.empty }
+let empty_local = { constants_values = IMap.empty; storage_types = IMap.empty; return_type = None }
+
+let empty_local_return_type return_type = { empty_local with return_type }
 
 (** An empty static env. *)
 let empty = { local = empty_local; global = empty_global }

--- a/asllib/StaticEnv.mli
+++ b/asllib/StaticEnv.mli
@@ -32,6 +32,7 @@ type local = {
   constants_values : literal IMap.t;  (** Maps a local constant to its value. *)
   storage_types : (ty * local_decl_keyword) IMap.t;
       (** Maps an locally declared names to their type. *)
+  return_type : ty option (** Local return type, [None] for procedures, global constants, or setters. *)
 }
 (** Store all the local environment information at compile-time. *)
 
@@ -43,6 +44,7 @@ val pp_env : Format.formatter -> env -> unit
 val pp_global : Format.formatter -> global -> unit
 val empty_global : global
 val empty_local : local
+val empty_local_return_type : ty option -> local
 val empty : env
 val lookup_constants : env -> identifier -> literal
 val type_of : env -> identifier -> ty

--- a/asllib/StaticInterpreter.ml
+++ b/asllib/StaticInterpreter.ml
@@ -24,14 +24,18 @@ let value_as_int pos = function
       fatal_from pos
         (Error.MismatchType (PP.literal_to_string v, [ T_Int None ]))
 
-let is_positive z = Z.sign z != 0
+let is_positive z = Z.sign z != -1
 let is_strict_positive z = Z.sign z = 1
+let bv_same_length b1 b2 = Bitvector.(length b1 = length b2)
 
 let exp_real q z =
-  let num = Q.num q and den = Q.den q in
-  let i = Z.to_int z in
-  let res_num = Z.pow num i and res_den = Z.pow den i in
-  Q.(res_num /// res_den)
+  if Q.sign q = 0 then Q.zero
+  else
+    let q, z = if is_positive z then (q, z) else (Q.inv q, Z.neg z) in
+    let num = Q.num q and den = Q.den q in
+    let i = Z.to_int z in
+    let res_num = Z.pow num i and res_den = Z.pow den i in
+    Q.(res_num /// res_den)
 
 let binop_values pos op v1 v2 =
   match (op, v1, v2) with
@@ -44,13 +48,13 @@ let binop_values pos op v1 v2 =
   | DIVRM, L_Int v1, L_Int v2 when is_strict_positive v2 ->
       L_Int (Z.fdiv v1 v2) (* Division rounded towards minus infinity. *)
   | MOD, L_Int v1, L_Int v2 when is_strict_positive v2 ->
-      L_Int (Z.sub v1 (Z.mul v2 (Z.fdiv v1 v2)))
+      L_Int Z.(sub v1 (mul v2 (fdiv v1 v2)))
       (* We cannot use any rem function in Z as we need the rounded towards minus infinity reminder. *)
-  | POW, L_Int v1, L_Int v2 -> L_Int (Z.pow v1 (Z.to_int v2))
+  | POW, L_Int v1, L_Int v2 when is_positive v2 -> L_Int Z.(pow v1 (to_int v2))
   | SHL, L_Int v1, L_Int v2 when is_positive v2 ->
-      L_Int (Z.shift_left v1 (Z.to_int v2))
+      L_Int Z.(shift_left v1 (to_int v2))
   | SHR, L_Int v1, L_Int v2 when is_positive v2 ->
-      L_Int (Z.shift_right v1 (Z.to_int v2))
+      L_Int Z.(shift_right v1 (to_int v2))
   (* int -> int -> bool*)
   | EQ_OP, L_Int v1, L_Int v2 -> L_Bool (Z.equal v1 v2)
   | NEQ, L_Int v1, L_Int v2 -> L_Bool (not (Z.equal v1 v2))
@@ -79,31 +83,30 @@ let binop_values pos op v1 v2 =
   | GEQ, L_Real v1, L_Real v2 -> L_Bool (Q.geq v1 v2)
   | GT, L_Real v1, L_Real v2 -> L_Bool (Q.gt v1 v2)
   (* bits -> bits -> bool *)
-  | EQ_OP, L_BitVector b1, L_BitVector b2 -> L_Bool (Bitvector.equal b1 b2)
-  | NEQ, L_BitVector b1, L_BitVector b2 -> L_Bool (not @@ Bitvector.equal b1 b2)
+  | EQ_OP, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
+      L_Bool (Bitvector.equal b1 b2)
+  | NEQ, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
+      L_Bool (not @@ Bitvector.equal b1 b2)
   (* bits -> bits -> bits *)
-  | OR, L_BitVector b1, L_BitVector b2 -> L_BitVector (Bitvector.logor b1 b2)
-  | AND, L_BitVector b1, L_BitVector b2 -> L_BitVector (Bitvector.logand b1 b2)
-  | EOR, L_BitVector b1, L_BitVector b2 -> L_BitVector (Bitvector.logxor b1 b2)
-  | PLUS, L_BitVector b1, L_BitVector b2
-    when Bitvector.length b1 = Bitvector.length b2 ->
+  | OR, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
+      L_BitVector (Bitvector.logor b1 b2)
+  | AND, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
+      L_BitVector (Bitvector.logand b1 b2)
+  | EOR, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
+      L_BitVector (Bitvector.logxor b1 b2)
+  | PLUS, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
       L_BitVector
-        (Bitvector.of_z (Bitvector.length b1)
-           (Z.add (Bitvector.to_z_unsigned b1) (Bitvector.to_z_unsigned b2)))
-  | MINUS, L_BitVector b1, L_BitVector b2
-    when Bitvector.length b1 = Bitvector.length b2 ->
+        Bitvector.(
+          of_z (length b1) (Z.add (to_z_unsigned b1) (to_z_unsigned b2)))
+  | MINUS, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
       L_BitVector
-        (Bitvector.of_z (Bitvector.length b1)
-           (Z.sub (Bitvector.to_z_unsigned b1) (Bitvector.to_z_unsigned b2)))
+        Bitvector.(
+          of_z (length b1) (Z.sub (to_z_unsigned b1) (to_z_unsigned b2)))
   (* bits -> integer -> bits *)
   | PLUS, L_BitVector b1, L_Int z2 ->
-      L_BitVector
-        (Bitvector.of_z (Bitvector.length b1)
-           (Z.add (Bitvector.to_z_unsigned b1) z2))
+      L_BitVector Bitvector.(of_z (length b1) (Z.add (to_z_unsigned b1) z2))
   | MINUS, L_BitVector b1, L_Int z2 ->
-      L_BitVector
-        (Bitvector.of_z (Bitvector.length b1)
-           (Z.sub (Bitvector.to_z_unsigned b1) z2))
+      L_BitVector Bitvector.(of_z (length b1) (Z.sub (to_z_unsigned b1) z2))
   (* Failure *)
   | _ -> fatal_from pos (Error.UnsupportedBinop (op, v1, v2))
 
@@ -142,7 +145,7 @@ let rec static_eval (env : SEnv.env) : expr -> literal =
         let bv =
           match expr_ e' with
           | L_Int i -> Bitvector.of_z (pos_max + 1) i
-          | L_BitVector bv -> bv
+          | L_BitVector bv when Bitvector.length bv > pos_max -> bv
           | v ->
               fatal_from e
               @@ Error.MismatchType
@@ -164,7 +167,11 @@ let rec static_eval (env : SEnv.env) : expr -> literal =
   expr_
 
 and slices_to_positions env =
-  let eval_to_int e = static_eval env e |> value_as_int e in
+  let check_positive e x =
+    if x >= 0 then x
+    else fatal_from e @@ Error.MismatchType (string_of_int x, [ T_Int None ])
+  in
+  let eval_to_int e = static_eval env e |> value_as_int e |> check_positive e in
   let slice_to_positions =
     let interval top len = List.init len (( - ) top) in
     function

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1472,7 +1472,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     let env, ldi = annotate_local_decl_item loc env t_e LDK_Constant ldi in
     (add_constants env ldi, ldi)
 
-  let rec annotate_stmt env return_type s =
+  let rec annotate_stmt env s =
     let () =
       if false then
         match s.desc with
@@ -1483,8 +1483,8 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     match s.desc with
     | S_Pass -> (s, env) |: TypingRule.SPass
     | S_Then (s1, s2) ->
-        let new_s1, env1 = try_annotate_stmt env return_type s1 in
-        let new_s2, env2 = try_annotate_stmt env1 return_type s2 in
+        let new_s1, env1 = try_annotate_stmt env s1 in
+        let new_s2, env2 = try_annotate_stmt env1 s2 in
         (S_Then (new_s1, new_s2) |> here, env2) |: TypingRule.SThen
     | S_Assign (le, e, ver) ->
         (let () =
@@ -1549,9 +1549,9 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
         (* Rule PHNZ: A return statement appearing in a getter or function
            requires a return value expression that type-satisfies the return
            type of the subprogram. *)
-        (match (return_type, e_opt) with
+        (match (env.local.return_type, e_opt) with
         | None, Some _ | Some _, None ->
-            fatal_from s (Error.BadReturnStmt return_type)
+            fatal_from s (Error.BadReturnStmt env.local.return_type)
             |: TypingRule.SReturnOne
         | None, None -> (S_Return None |> here, env) |: TypingRule.SReturnNone
         | Some t, Some e ->
@@ -1568,15 +1568,15 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     | S_Cond (e, s1, s2) ->
         let t_cond, e_cond = annotate_expr env e in
         let+ () = check_type_satisfies e_cond env t_cond t_bool in
-        let s1' = try_annotate_block env return_type s1 in
-        let s2' = try_annotate_block env return_type s2 in
+        let s1' = try_annotate_block env s1 in
+        let s2' = try_annotate_block env s2 in
         (S_Cond (e_cond, s1', s2') |> here, env) |: TypingRule.SCond
     | S_Case (e, cases) ->
         let t_e, e1 = annotate_expr env e in
         let annotate_case (acc, env) case =
           let p, s = case.desc in
           let p1 = annotate_pattern e1 env t_e p in
-          let s1 = try_annotate_block env return_type s in
+          let s1 = try_annotate_block env s in
           (add_pos_from_st case (p1, s1) :: acc, env)
         in
         let cases1, env1 = List.fold_left annotate_case ([], env) cases in
@@ -1588,10 +1588,10 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     | S_While (e1, s1) ->
         let t, e2 = annotate_expr env e1 in
         let+ () = check_type_satisfies e2 env t t_bool in
-        let s2 = try_annotate_block env return_type s1 in
+        let s2 = try_annotate_block env s1 in
         (S_While (e2, s2) |> here, env) |: TypingRule.SWhile
     | S_Repeat (s1, e1) ->
-        let s2 = try_annotate_block env return_type s1 in
+        let s2 = try_annotate_block env s1 in
         let t, e2 = annotate_expr env e1 in
         let+ () = check_type_satisfies e2 env t t_bool in
         (S_Repeat (s2, e2) |> here, env) |: TypingRule.SRepeat
@@ -1625,7 +1625,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
         let s'' =
           let+ () = check_var_not_in_env s' env id in
           let env' = add_local id ty LDK_Let env in
-          try_annotate_block env' return_type s'
+          try_annotate_block env' s'
         in
         (S_For (id, e1', dir, e2', s'') |> here, env) |: TypingRule.SFor
     | S_Decl (ldk, ldi, e_opt) -> (
@@ -1653,17 +1653,17 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
         (* TODO: verify that this is allowed? *)
         (s, env) |: TypingRule.SThrowNone
     | S_Try (s', catchers, otherwise) ->
-        let s'' = try_annotate_block env return_type s' in
+        let s'' = try_annotate_block env s' in
         let otherwise' =
-          Option.map (try_annotate_block env return_type) otherwise
+          Option.map (try_annotate_block env) otherwise
         in
-        let catchers' = List.map (annotate_catcher env return_type) catchers in
+        let catchers' = List.map (annotate_catcher env) catchers in
         (S_Try (s'', catchers', otherwise') |> here, env) |: TypingRule.STry
     | S_Debug e ->
         let _t_e, e' = annotate_expr env e in
         (S_Debug e' |> here, env) |: TypingRule.SDebug
 
-  and annotate_catcher env return_type (name_opt, ty, stmt) =
+  and annotate_catcher env (name_opt, ty, stmt) =
     let+ () = check_structure_exception ty env ty in
     let env' =
       match name_opt with
@@ -1672,10 +1672,10 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
           let+ () = check_var_not_in_env stmt env name in
           add_local name ty LDK_Let env |: TypingRule.CatcherSome
     in
-    let new_stmt = try_annotate_block env' return_type stmt in
+    let new_stmt = try_annotate_block env' stmt in
     (name_opt, ty, new_stmt)
 
-  and try_annotate_block env return_type s =
+  and try_annotate_block env s =
     (*
         See rule JFRD:
            A local identifier declared with var, let or constant is in scope
@@ -1685,11 +1685,11 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
         From that follows that we can discard the environment at the end of an
         enclosing block.
     *)
-    best_effort s (fun _ -> annotate_stmt env return_type s |> fst)
+    best_effort s (fun _ -> annotate_stmt env s |> fst)
     |: TypingRule.Block
 
-  and try_annotate_stmt env return_type s =
-    best_effort (s, env) (fun _ -> annotate_stmt env return_type s)
+  and try_annotate_stmt env s =
+    best_effort (s, env) (fun _ -> annotate_stmt env s)
 
   and setter_should_reduce_to_call_s env le e : stmt option =
     let () =
@@ -1708,9 +1708,9 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
       | Some s ->
           let s1, _env1 =
             S_Assign (le_x, to_expr sub_le, V1)
-            |> here |> annotate_stmt env None
+            |> here |> annotate_stmt env
           and s2, _env2 =
-            S_Assign (old_le le_x, e, V1) |> here |> annotate_stmt env None
+            S_Assign (old_le le_x, e, V1) |> here |> annotate_stmt env
           in
           Some (s_then (s_then s1 s2) s)
     in
@@ -1750,7 +1750,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
   let annotate_func loc (env : env) (f : 'p AST.func) : 'p AST.func =
     let () = if false then Format.eprintf "Annotating %s.@." f.name in
     (* Build typing local environment. *)
-    let env1 = { env with local = empty_local } in
+    let env1 = { env with local = empty_local_return_type f.return_type } in
     let env2 =
       let one_arg env1 (x, ty) =
         let+ () = check_var_not_in_env loc env1 x in
@@ -1803,7 +1803,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     let body =
       match f.body with SB_ASL body -> body | SB_Primitive _ -> assert false
     in
-    let new_body = try_annotate_block env5 f.return_type body in
+    let new_body = try_annotate_block env5 body in
     (* Optionnally rename the function if needs be *)
     let name =
       let args = List.map snd f.args in

--- a/asllib/bitvector.ml
+++ b/asllib/bitvector.ml
@@ -406,7 +406,7 @@ let extract_slice (_length_src, data_src) positions =
     let () = List.iteri copy_bit_here positions in
     remask (length, Bytes.unsafe_to_string result)
   with Invalid_argument msg ->
-    raise (Invalid_argument (Printf.sprintf "exract_sliced (%s)" msg))
+    raise (Invalid_argument (Printf.sprintf "extract_sliced (%s)" msg))
 
 let write_slice (length_dst, data_dst) (length_src, data_src) positions =
   let min x y = if x <= y then x else y in


### PR DESCRIPTION
- [x] The return type of a function is now stored in the local environment. This allows cleaner code in type-checking, and type-guided AST generation is simplified.
- [x] Binary operations using zarith or bitvectors are now very less likely to break. Bugs found with carpenter.
- [x] Code printing for floats is now fixed and use a floating division to ensure no precision loss.