### PR TITLE
[herd,asl] Fix addition of symbolic constant and offset

### DIFF
--- a/lib/ASLOp.ml
+++ b/lib/ASLOp.ml
@@ -167,6 +167,8 @@ let do_op1 op cst =
       | Constant.Symbolic x ->
           if Misc.list_eq ( = ) positions all_64_bits_positions then
             Some (Constant.Symbolic x)
+          else if positions = [63] then
+            return_concrete (ASLScalar.zeros 1)
           else None
       | _ -> None)
   | BoolNot -> (


### PR DESCRIPTION
There were two problems, fixed as follows:
  + Slicing a symbolic constant with position [63] is now accepted and returns the bitvector `0`.
  + Converting a Z.t to an int is now performed by
     - Computing remainder by 2^64,
     - Followed by sign adjustement.