### PR TITLE
[herd] Minor user-interface suggestions for herd

### DIFF
--- a/herd/test_herd.ml
+++ b/herd/test_herd.ml
@@ -152,6 +152,14 @@ module Make(A:Arch_herd.S) =
          } = t in
 
       let prog,starts,rets = Load.load nice_prog in
+      (* ensure labels in the init list are present in the body of the test*)
+      List.iter (fun (_,(_,v)) ->
+        match v with
+        | A.V.Val (Constant.Label (p,s)) -> begin
+          if not (Label.Map.mem s prog) then 
+            Warn.user_error
+              "Label %s not found on P%d, yet it is used in the initialization list" s p end
+        | _ -> ()) init ;
       let entry_points =
         let instr2labels =
           let one_label lbl addr res =

--- a/herd/tests/instructions/AArch64/AK004.litmus
+++ b/herd/tests/instructions/AArch64/AK004.litmus
@@ -1,0 +1,7 @@
+AArch64 AK004
+{
+0:X5=P0:Lself00;
+}
+ P0         ;
+ MOV X4,X5  ;
+locations [0:X4]

--- a/herd/tests/instructions/AArch64/AK004.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/AK004.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/AK004.litmus": Label Lself00 not found on P0, yet it is used in the initialization list (User error)

--- a/herd/tests/instructions/AArch64/AK005.litmus
+++ b/herd/tests/instructions/AArch64/AK005.litmus
@@ -1,0 +1,11 @@
+AArch64 AK005
+{
+0:X0=NOP; 0:X1=P0:Lself00;
+}
+ P0          ;
+ STR W0,[X1] ;
+ Lself00:    ;
+  B Lself01  ;
+ MOV X2,#1  ;
+ Lself01:    ;
+exists (0:X2=0)

--- a/herd/tests/instructions/AArch64/AK005.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/AK005.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64/AK005.litmus": Store to P0:Lself00 requires ifetch functionality. Please use `-variant ifetch` as an argument to herd7 to enable it. (User error)


### PR DESCRIPTION
This PR implements two very simple safeguards, both ifetch-specific in nature.

Firstly, whenever there is a label in the initialization list, raise a user error if it is not actually present in the code of the litmus test. This already is marked as an error if there is a load or a store with such an undefined location, but the following test, for instance, is still possible:

```
AArch64 AK004
{
0:X5=P0:Lself00;
}
 P0         ;
 MOV X4,X5  ;
locations [0:X4]
```

To remove a possibility of confusing errors in litmus tests, this PR inserts a simple check into `test_herd.ml` to ensure all labels in the precondition are actually defined.

Secondly, whenever there is a store into a label, raise a user error and inform the user that they may want to use `-variant ifetch`.

```
AArch64 AK005
{
0:X0=NOP; 0:X1=P0:Lself00;
}
 P0          ;
 STR W0,[X1] ;
 Lself00:    ;
  B Lself01  ;
 MOV X2, #1  ;
 Lself01:    ;
exists (0:X2=0)
```

```
Warning: File "./herd/tests/instructions/AArch64/AK005.litmus": Store to P0:Lself00 requires ifetch functionality. Please use `-variant ifetch` as an argument to herd7 to enable it. (User error)
```