### PR TITLE
[herd] Add support for AArch64 TFSR_ELx in async MTE

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1013,8 +1013,9 @@ module Make
              fun ma ->  ma >>*= (fun _ -> mfault >>! B.Exit)
           | (Handled,_)|(LoadsFatal,Dir.W) ->
              fun ma ->
+             let set_tfsr = write_reg AArch64Base.tfsr V.one ii in
              let (>>) = M.bind_ctrl_first_outputs in
-             let ma = ma >> (fun a -> mfault >>! a) in
+             let ma = ma >> (fun a -> (set_tfsr >>| mfault) >>! a) in
              mm ma >>! B.Next []
           | Skip,_ ->
              fun _ ->

--- a/herd/tests/instructions/AArch64.MTE/B004.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B004.litmus
@@ -1,0 +1,9 @@
+AArch64 B004
+Variant=async
+{
+ 0:X1=x:red
+}
+ P0          ;
+ MOV W0,#1   ;
+ STR W0,[X1] ;
+forall([x]=1 /\ 0:TFSR_ELx=1)

--- a/herd/tests/instructions/AArch64.MTE/B004.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B004.litmus.expected
@@ -1,0 +1,10 @@
+Test B004 Required
+States 1
+0:TFSR_ELx=1; [x]=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall ([x]=1 /\ 0:TFSR_ELx=1)
+Observation B004 Always 1 0
+Hash=a8708b099b5f95ad916f70e33c905ffc
+


### PR DESCRIPTION
This PR adds support for register `TFSR_ELx` for async MTE. When an async fault happens due to a tag mismatch we set the 0 bit of register `TFSR_ELx`. Note that we define `TFSR_ELx` which is a generic name for the registers `TFSR_EL01` `TFSR_EL1` etc. This is intentional and in order to avoid being specific about the exception level that the test runs in. For the test:

```
AArch64 B004
Variant=async
{
 0:X1=x:red
}
 P0          ;
 MOV W0,#1   ;
 STR W0,[X1] ;
forall([x]=1 /\ 0:TFSR_ELx=1)
```

The semantics are shown in this graph:

![image](https://github.com/herd/herdtools7/assets/224592/08772214-2d91-48e0-913d-da8d993850be)
