### PR TITLE
[all, aarch64] ABS instruction

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -244,6 +244,16 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
                   "datasize" ^= liti datasize;
                   "pos" ^= liti pos;
                 ] )
+      | I_ABS (v,rd,rn) ->
+         let datasize = variant_raw v in
+         Some
+           ("integer/arithmetic/unary/abs/ABS_32_dp_1src.opn",
+            stmt
+              [
+                "d" ^= reg rd;
+                "n" ^= reg rn;
+                "datasize" ^= liti datasize;
+              ])
       | I_UBFM (v,rd,rn,immr,imms)
       | I_SBFM (v,rd,rn,immr,imms) ->
          let datasize = variant_raw v in
@@ -691,6 +701,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
               | AddK i -> AddK i
               | AndK i -> AndK i
               | Inv -> Inv
+              | Abs -> Abs
               | Mask sz -> Mask sz
               | Sxt sz -> Sxt sz
               | TagLoc -> TagLoc

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -100,7 +100,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_STOPBH _| I_STP _| I_STP_P_SIMD _| I_STP_SIMD _| I_STR _
     | I_STR_P_SIMD _| I_STR_SIMD _| I_STRBH _| I_STUR_SIMD _| I_STXP _| I_STXR _
     | I_STXRBH _| I_STZG _| I_SWP _| I_SWPBH _| I_SXTW _| I_TLBI _| I_UBFM _
-    | I_UDF _| I_UNSEAL _ | I_ADDSUBEXT _
+    | I_UDF _| I_UNSEAL _ | I_ADDSUBEXT _ | I_ABS _
       -> true
 
     let is_cmodx_restricted_value =
@@ -251,7 +251,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_TBNZ(_,_,_,_) | I_TBZ (_,_,_,_) | I_MOVZ (_,_,_,_) | I_MOVK(_,_,_,_)
       | I_MOVN _
       | I_MOV (_, _, _)|I_SXTW (_, _)|I_OP3 (_, _, _, _, _)
-      | I_ADR (_, _)|I_RBIT (_, _, _)|I_FENCE _
+      | I_ADR (_, _)|I_RBIT (_, _, _)|I_ABS _|I_FENCE _
       | I_SBFM (_,_,_,_,_) | I_UBFM (_,_,_,_,_)
       | I_CSEL (_, _, _, _, _, _)|I_IC (_, _)|I_DC (_, _)|I_MRS (_, _)|I_MSR (_, _)
       | I_STG _ | I_STZG _ | I_LDG _
@@ -310,6 +310,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_OP3 (_,_,r,_,_)
       | I_ADR (r,_)
       | I_RBIT (_,r,_)
+      | I_ABS (_,r,_)
       | I_CSEL (_,r,_,_,_,_)
       | I_MRS (r,_)
       | I_UBFM (_,r,_,_,_) | I_SBFM (_,r,_,_,_)
@@ -375,7 +376,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_SWP _|I_SWPBH _|I_LDOP _
       | I_LDOPBH _|I_STOP _|I_STOPBH _
       | I_MOV _|I_MOVZ _|I_MOVN _|I_MOVK _|I_SXTW _
-      | I_OP3 _|I_ADR _|I_RBIT _|I_FENCE _
+      | I_OP3 _|I_ADR _|I_RBIT _|I_ABS _|I_FENCE _
       | I_CSEL _|I_IC _|I_DC _|I_TLBI _|I_MRS _|I_MSR _
       | I_STG _|I_STZG _|I_LDG _|I_UDF _
       | I_ADDSUBEXT _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2660,7 +2660,13 @@ module Make
             >>=  sxtw_op
             >>= fun v -> write_reg_dest rd v ii
             >>= nextSet rd
-
+        | I_ABS (v,rd,rs) ->
+           let sz = tr_variant v in
+           read_reg_ord_sz sz rs ii
+           >>= sxt_op sz
+           >>= M.op1 Op.Abs
+           >>=fun v -> write_reg_dest rd v ii
+           >>= nextSet rd
         | I_OP3(v,op,rd,rn,e) ->
            let margs =
              let sz = tr_variant v in

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -152,7 +152,9 @@ module Make (C : Config) = struct
         | L_Int i -> S_Int i |> concrete
         | L_Bool b -> S_Bool b |> concrete
         | L_BitVector bv -> S_BitVector bv |> concrete
-        | L_Real _f -> Warn.fatal "Cannot use reals yet."
+        | L_Real _f ->
+           Printf.eprintf "real: %s\n%!" (Q.to_string _f) ;
+           Warn.fatal "Cannot use reals yet."
         | L_String _f -> Warn.fatal "Cannot strings in herd yet."
       in
       fun v -> V.Val (tr v)
@@ -751,7 +753,7 @@ module Make (C : Config) = struct
                AST.(
                  fun d ->
                    match d.desc with
-                   | D_Func { name = "Zeros" | "Ones" | "Replicate"; _ } ->
+                   | D_Func { name = "Zeros" | "Ones" | "Replicate" | "Abs" ; _ } ->
                        false
                    | _ -> true)
                shared [@warning "-40-42"])

--- a/herd/tests/instructions/AArch64/L091.litmus
+++ b/herd/tests/instructions/AArch64/L091.litmus
@@ -1,0 +1,8 @@
+AArch64 L091
+{ 0:X1=0x80000000;}
+  P0           ;
+ ABS W2,W1     ;
+ MOV W3,#1     ;
+ SUB W3,WZR,W3 ;
+ ABS W4,W3     ;
+locations [0:X2;0:X3;0:X4;]

--- a/herd/tests/instructions/AArch64/L091.litmus.expected
+++ b/herd/tests/instructions/AArch64/L091.litmus.expected
@@ -1,0 +1,10 @@
+Test L091 Required
+States 1
+0:X2=-2147483648; 0:X3=-1; 0:X4=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation L091 Always 1 0
+Hash=fe66543cddeef0354b07bed04c66085f
+

--- a/herd/tests/instructions/AArch64/L092.litmus
+++ b/herd/tests/instructions/AArch64/L092.litmus
@@ -1,0 +1,9 @@
+AArch64 L092
+{
+0:X1=6;
+}
+
+  P0              ;
+ NEG W2,W1,LSL 2  ;
+ ABS W3,W2        ;
+forall 0:X2=-24 /\ 0:X3=24

--- a/herd/tests/instructions/AArch64/L092.litmus.expected
+++ b/herd/tests/instructions/AArch64/L092.litmus.expected
@@ -1,0 +1,10 @@
+Test L092 Required
+States 1
+0:X2=-24; 0:X3=24;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=-24 /\ 0:X3=24)
+Observation L092 Always 1 0
+Hash=f1a80d976e83bde8a704e682d8c25f7e
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -327,7 +327,13 @@ include Arch.MakeArch(struct
         find_lab lbl >! fun lbl ->
         I_ADR (r,lbl)
     | I_RBIT (v,r1,r2) ->
-        conv_reg r1 >> fun r1 -> conv_reg r2 >! fun r2 -> I_RBIT (v,r1,r2)
+       conv_reg r1 >> fun r1 ->
+       conv_reg r2 >! fun r2 ->
+       I_RBIT (v,r1,r2)
+    | I_ABS (v,r1,r2) ->
+       conv_reg r1 >> fun r1 ->
+       conv_reg r2 >! fun r2 ->
+       I_ABS (v,r1,r2)
     | I_LDAR(a,b,r1,r2) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >! fun r2 ->

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -119,6 +119,10 @@ let pp_hash m = match m with
 
 let pp_k m v = pp_hash m ^ string_of_int v
 
+(*
+ * The boolean `compat` specifies backward comparibility.
+ * Backward compatibility is important for preserving hashes.
+ *)
 type 'k basic_pp =
   { compat : bool; pp_k : 'k -> string; zerop : 'k -> bool; k0 : 'k kr }
 
@@ -847,7 +851,7 @@ module OpExt = struct (* Third argumen tabnd extension of operations *)
     | LSL _
     | LSR _
     | ASR _
-     | ROR _
+    | ROR _
       -> false
 
   let pp_shift m = function
@@ -1626,6 +1630,10 @@ let pp_k_nz k = if m.zerop k then "" else "," ^ m.pp_k k in
        (Ext.pp_ext m ext)
   | I_OP3 (v,SUBS,ZR,r,e) ->
      pp_op2 "CMP" v r e
+  | I_OP3 (v,SUB,r,ZR,(OpExt.Reg _ as e)) when not m.compat ->
+     pp_op2 "NEG" v r e
+  | I_OP3 (v,SUBS,r,ZR,(OpExt.Reg _ as e)) when not m.compat ->
+     pp_op2 "NEGS" v r e
   | I_OP3 (v,ANDS,ZR,r,e) ->
       pp_op2 "TST" v r e
   | I_OP3 (v,ORN,r,ZR,e) ->

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1120,6 +1120,7 @@ type 'k kinstruction =
   | I_OP3 of variant * op * reg * reg * 'k OpExt.ext
   | I_ADR of reg * lbl
   | I_RBIT of variant * reg * reg
+  | I_ABS of variant * reg * reg
 (* Barrier *)
   | I_FENCE of barrier
 (* Conditional select *)
@@ -1637,6 +1638,8 @@ let pp_k_nz k = if m.zerop k then "" else "," ^ m.pp_k k in
        (pp_xreg r) (pp_label lbl)
   | I_RBIT (v,rd,rs) ->
       sprintf "RBIT %s,%s" (pp_vreg v rd) (pp_vreg v rs)
+  | I_ABS (v,rd,rs) ->
+      sprintf "ABS %s,%s" (pp_vreg v rd) (pp_vreg v rs)
 (* Barrier *)
   | I_FENCE b ->
       pp_barrier b
@@ -1752,7 +1755,7 @@ let fold_regs (f_regs,f_sregs) =
   | I_SXTW (r1,r2) | I_LDARBH (_,_,r1,r2) | I_LDRS (_,_,r1,r2)
   | I_SBFM (_,r1,r2,_,_) | I_UBFM (_,r1,r2,_,_)
   | I_STOP (_,_,_,r1,r2) | I_STOPBH (_,_,_,r1,r2)
-  | I_RBIT (_,r1,r2) | I_LDUR (_, r1, r2, _)
+  | I_RBIT (_,r1,r2) | I_ABS (_,r1,r2) | I_LDUR (_, r1, r2, _)
   | I_CHKEQ (r1,r2) | I_CLRTAG (r1,r2) | I_GC (_,r1,r2) | I_LDCT (r1,r2)
   | I_STCT (r1,r2)
   | I_LDR_P_SIMD (_,r1,r2,_) | I_STR_P_SIMD (_,r1,r2,_)
@@ -2053,6 +2056,8 @@ let map_regs f_reg f_symb =
       I_ADR (map_reg r,lbl)
   | I_RBIT (v,r1,r2) ->
       I_RBIT (v,map_reg r1,map_reg r2)
+  | I_ABS (v,r1,r2) ->
+      I_ABS (v,map_reg r1,map_reg r2)
 (* Conditinal select *)
   | I_CSEL (v,r1,r2,r3,c,op) ->
       I_CSEL (v,map_reg r1,map_reg r2,map_reg r3,c,op)
@@ -2147,6 +2152,7 @@ let get_next =
   | I_STOPBH _
   | I_ADR _
   | I_RBIT _
+  | I_ABS _
   | I_IC _
   | I_DC _
   | I_TLBI _
@@ -2383,6 +2389,7 @@ module PseudoI = struct
         | I_STOPBH _
         | I_ADR _
         | I_RBIT _
+        | I_ABS _
         | I_IC _
         | I_DC _
         | I_TLBI _
@@ -2535,6 +2542,7 @@ module PseudoI = struct
         | I_CSEL _
         | I_ADR _
         | I_RBIT _
+        | I_ABS _
 (*        | I_TLBI (_,ZR) *)
         | I_MRS _ | I_MSR _
         | I_ALIGND _| I_ALIGNU _|I_BUILD _|I_CHKEQ _|I_CHKSLD _|I_CHKTGD _

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -368,6 +368,8 @@ match name with
 | "subs"|"SUBS" -> TOK_SUBS
 | "add"|"ADD" -> TOK_ADD
 | "adds"|"ADDS" -> TOK_ADDS
+| "neg"|"NEG" -> TOK_NEG
+| "negs"|"NEGS" -> TOK_NEGS
 (* Morello *)
 | "alignd"|"ALIGND" -> ALIGND
 | "alignu"|"ALIGNU" -> ALIGNU

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -335,6 +335,7 @@ match name with
 | "movk"|"MOVK" -> MOVK
 | "adr"|"ADR" -> ADR
 | "rbit"|"RBIT" -> RBIT
+| "abs"|"ABS" -> ABS
 | "cmp"|"CMP" -> CMP
 | "tst"|"TST" -> TST
 (* Three argument opcodes factorized *)

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -84,6 +84,7 @@ let mk_instrp instr v r1 r2 ra ko kb =
 %token <AArch64Base.sc> SC
 %token <AArch64Base.gc> GC
 %token TOK_ADD TOK_ADDS TOK_SUB TOK_SUBS
+%token TOK_NEG TOK_NEGS
 %token CSEL CSINC CSINV CSNEG CSET CSETM CINC
 %token TOK_DMB TOK_DSB TOK_ISB
 %token TOK_SY TOK_ST TOK_LD
@@ -316,15 +317,21 @@ op_ext_imm:
 | k COMMA TOK_LSL k
     { OpExt.Imm ($1,$4) }
 
-op_ext_w:
-| op_ext_imm { $1 }
+%inline op_ext_reg_w:
 | wreg op_ext_shift0
+    { OpExt.Reg ($1,$2) }
+
+%inline op_ext_w:
+| op_ext_imm { $1 }
+| op_ext_reg_w { $1 }
+
+%inline op_ext_reg_x:
+| xreg op_ext_shift0
     { OpExt.Reg ($1,$2) }
 
 %inline op_ext_x:
 | op_ext_imm { $1 }
-| xreg op_ext_shift0
-    { OpExt.Reg ($1,$2) }
+| op_ext_reg_x { $1 }
 
 op_ext_c:
 | op_ext_imm { $1 }
@@ -1218,7 +1225,7 @@ instr:
 | tok_add_sub_ext wreg COMMA wreg COMMA wreg COMMA add_sub_ext
   { I_ADDSUBEXT (V32, $1, $2, $4, (V32, $6), $8) }
 
-
+(* Aliases of SUB *)
 | CMP wreg COMMA op_ext_w
   { I_OP3 (V32,SUBS,ZR,$2,$4) }
 | CMP xreg COMMA op_ext_x
@@ -1227,6 +1234,14 @@ instr:
   { I_ADDSUBEXT (V32,Ext.SUBS,ZR,$2,(V32,$4),$6) }
 | CMP xreg COMMA wxreg COMMA add_sub_ext
   { I_ADDSUBEXT (V64,Ext.SUBS,ZR,$2,$4,$6) }
+| TOK_NEG wreg COMMA  op_ext_reg_w
+  { I_OP3 (V32,SUB,$2,ZR,$4) }
+| TOK_NEG xreg COMMA  op_ext_reg_x
+  { I_OP3 (V64,SUB,$2,ZR,$4) }
+| TOK_NEGS wreg COMMA  op_ext_reg_w
+  { I_OP3 (V32,SUBS,$2,ZR,$4) }
+| TOK_NEGS xreg COMMA  op_ext_reg_x
+  { I_OP3 (V64,SUBS,$2,ZR,$4) }
 
 | TST wreg COMMA op_ext_w
   { I_OP3 (V32,ANDS,ZR,$2,$4) }

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -127,7 +127,7 @@ let mk_instrp instr v r1 r2 ra ko kb =
 %token <AArch64Base.DC.op> DC_OP
 %token <AArch64Base.TLBI.op> TLBI_OP
 %token <AArch64Base.sysreg> SYSREG
-%token MRS MSR TST RBIT
+%token MRS MSR TST RBIT ABS
 %token STG STZG LDG
 %token ALIGND ALIGNU BUILD CHKEQ CHKSLD CHKTGD CLRTAG CPY CPYTYPE CPYVALUE CSEAL
 %token LDCT SEAL STCT UNSEAL
@@ -1237,6 +1237,12 @@ instr:
   { I_RBIT (V32,$2,$4) }
 | RBIT xreg COMMA xreg
   { I_RBIT (V64,$2,$4) }
+
+| ABS wreg COMMA wreg
+  { I_ABS (V32,$2,$4) }
+| ABS xreg COMMA xreg
+  { I_ABS (V64,$2,$4) }
+
 /* Morello */
 | ALIGND creg COMMA creg COMMA k
   { I_ALIGND ($2,$4,$6) }

--- a/lib/ASLScalar.ml
+++ b/lib/ASLScalar.ml
@@ -172,6 +172,10 @@ let lognot = function
   | S_Bool b -> S_Bool (not b)
   | S_BitVector bv -> S_BitVector (BV.lognot bv)
 
+let abs = function
+  | S_Int i -> S_Int (Z.abs i)
+  | s -> Warn.fatal "ASLScalar invalid op: %s abs" (pp false s)
+
 let shift_left = function
   | S_Int i -> fun k -> S_Int (Z.shift_left i k)
   | s1 -> Warn.fatal "ASLScalar invalid op: %s shift_left" (pp false s1)

--- a/lib/capabilityScalar.ml
+++ b/lib/capabilityScalar.ml
@@ -74,6 +74,8 @@ let pp_unsigned = pp (* Hum *)
 
 let lt v1 v2 = compare v1 v2 < 0
 let le v1 v2 = compare v1 v2 <= 0
+let abs v = if lt v zero then sub zero v else v
+
 let mask sz =
   let open MachSize in
   match sz with

--- a/lib/int128.ml
+++ b/lib/int128.ml
@@ -27,6 +27,8 @@ module Int128 = struct
 
   let is_neg (ah,_) = BaseUint64.has_top_bit_set ah
 
+  let abs x = if is_neg x then chsgn x else x
+
   let compare a b =
     match is_neg a,is_neg b with
     | true,true -> compare b a

--- a/lib/int128Scalar.ml
+++ b/lib/int128Scalar.ml
@@ -54,6 +54,7 @@ let sxt sz v = match sz with
 let shift_right_logical = Int128.shift_right_logical
 let shift_left = Int128.shift_left
 let lognot = Int128.lognot
+let abs = Int128.abs
 let logxor = Int128.logxor
 let logand = Int128.logand
 let logor = Int128.logor
@@ -71,6 +72,7 @@ let of_int = Int128.of_int
 let of_string = Int128.of_string
 let one = Int128.one
 let zero = Int128.zero
+
 type t = Int128.t
 
 let get_tag _ = assert false

--- a/lib/op.ml
+++ b/lib/op.ml
@@ -115,6 +115,7 @@ type 'aop op1 =
   | Mask of MachSize.sz
   | Sxt of MachSize.sz
   | Inv
+  | Abs
   | TagLoc       (* Get tag memory location from location *)
   | CapaTagLoc
   | TagExtract   (* Extract tag from tagged location *)
@@ -143,6 +144,7 @@ let pp_op1 hexa pp_aop o = match o with
 | AddK i  -> (if hexa then sprintf "+[0x%x]" else sprintf "+[%i]") i
 | AndK i  -> sprintf "&[%s]" i
 | Inv -> "~"
+| Abs -> "abs"
 | Mask sz  -> sprintf "mask%02i" (MachSize.nbits sz)
 | Sxt sz -> sprintf "sxt%02i" (MachSize.nbits sz)
 | TagLoc ->  "tagloc"

--- a/lib/op.mli
+++ b/lib/op.mli
@@ -69,6 +69,7 @@ type 'aop op1 =
   | Mask of MachSize.sz
   | Sxt of MachSize.sz (* Sign extension *)
   | Inv          (* Logical not or inverse *)
+  | Abs          (* Absolute value *)
   | TagLoc       (* Get tag memory location from location *)
   | CapaTagLoc
   | TagExtract   (* Extract tag from tagged location *)

--- a/lib/scalar.mli
+++ b/lib/scalar.mli
@@ -48,6 +48,7 @@ module type S = sig
   val logand : t -> t -> t
   val logxor : t -> t -> t
   val lognot : t -> t
+  val abs : t -> t
   val shift_left : t -> int -> t
   val shift_right_logical : t -> int -> t
   val shift_right_arithmetic : t -> int -> t

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -822,6 +822,7 @@ module
     | Mask sz -> maskop op sz
     | Sxt sz -> sxtop op sz
     | Inv -> unop op Cst.Scalar.lognot
+    | Abs -> unop op Cst.Scalar.abs
     | TagLoc -> tagloc
     | CapaTagLoc -> capatagloc
     | TagExtract -> tagextract

--- a/lib/uint128Scalar.ml
+++ b/lib/uint128Scalar.ml
@@ -33,6 +33,7 @@ let pp_unsigned = pp (* Hum *)
 
 let lt v1 v2 = compare v1 v2 < 0
 let le v1 v2 = compare v1 v2 <= 0
+let abs _ = Warn.fatal "Uint128 absolute value not implemented"
 let bit_at k v = Uint128.logand v (Uint128.shift_left Uint128.one k)
 let mask sz =
   let open MachSize in

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1043,6 +1043,7 @@ module Make(V:Constant.S)(C:Config) =
 
     let movr = do_movr "mov"
     and rbit = do_movr "rbit"
+    and abs = do_movr "abs"
     and movz = do_movz (fun _ -> []) (* No input *) "movz"
     and movn = do_movz (fun _ -> []) (* No input *) "movn"
     and movk = do_movz Misc.identity (* Part of register preserved *) "movk"
@@ -1321,6 +1322,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_MOVK (v,rd,i,os) -> movk  v rd i os::k
     | I_ADR (r,lbl) -> adr tr_lab r lbl::k
     | I_RBIT (v,rd,rs) -> rbit v rd rs::k
+    | I_ABS (v,rd,rs) -> abs v rd rs::k
     | I_SXTW (r1,r2) -> sxtw r1 r2::k
     | I_SBFM (v,r1,r2,k1,k2) -> xbfm "sbfm" v r1 r2 k1 k2::k
     | I_UBFM (v,r1,r2,k1,k2) -> xbfm "ubfm" v r1 r2 k1 k2::k

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1098,13 +1098,16 @@ module Make(V:Constant.S)(C:Config) =
 
     let memo_of_op op = Misc.lowercase (pp_op op)
 
-    let mvn v r1 r2 s =
-      let memo = "mvn" in
+    let op2 memo v r1 r2 s =
       let r1,f1 = do_arg1o v r1 0 and r2,f2 = do_arg1i v r2 0 in
       { empty_ins with
         memo=sprintf "%s %s,%s%s" memo f1 f2 (pp_op_ext_shift s);
         inputs=r2;
         outputs=r1; reg_env = add_v v (r1@r2);}
+
+    let mvn = op2 "movn"
+    and neg = op2  "neg"
+    and negs = op2 "negs"
 
     let op3 v op rD rN e =
       let memo = memo_of_op op
@@ -1327,6 +1330,8 @@ module Make(V:Constant.S)(C:Config) =
     | I_SBFM (v,r1,r2,k1,k2) -> xbfm "sbfm" v r1 r2 k1 k2::k
     | I_UBFM (v,r1,r2,k1,k2) -> xbfm "ubfm" v r1 r2 k1 k2::k
     | I_OP3 (v,SUBS,ZR,r,e) -> cmp v r e::k
+    | I_OP3 (v,SUB,r1,ZR,OpExt.Reg (r2,s)) -> neg v r1 r2 s::k
+    | I_OP3 (v,SUBS,r1,ZR,OpExt.Reg (r2,s)) -> negs v r1 r2 s::k
     | I_ADDSUBEXT (v,Ext.SUBS,ZR,r2,vr3,e) -> cmp_ext v r2  vr3 e::k
     | I_OP3 (v,ANDS,ZR,r,e) -> tst v r e::k
     | I_OP3 (v,ORN,r1,ZR,OpExt.Reg (r2,s)) -> mvn v r1 r2 s::k


### PR DESCRIPTION
Implementation of the AArch64 `ABS`  instruction (absolute value). We also seize the opportunity to implement the `NEG` and `NEGS` aliases.

The following litmus test illustrates the new (pseudo-)instructions:
```
AArch64 ABS
{
0:X1=6;
}

  P0        ;
 NEG W2,W1  ;
 ABS W3,W2  ;
forall 0:X2=-6 /\ 0:X3=6
```