### PR TITLE
[herd, asl] Add a partial po field to account for ASL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ REGRESSION_TEST_MODE = test
 # REGRESSION_TEST_MODE = promote
 # REGRESSION_TEST_MODE = show
 
+DUNE_PROFILE = release
+
 DIYCROSS                      = _build/install/default/bin/diycross7
 HERD                          = _build/install/default/bin/herd7
 HERD_REGRESSION_TEST          = _build/default/internal/herd_regression_test.exe
@@ -30,7 +32,7 @@ Version.ml:
 	sh ./version-gen.sh $(PREFIX)
 
 build: Version.ml | check-deps
-	dune build -j $(J) --profile release
+	dune build -j $(J) --profile $(DUNE_PROFILE)
 
 install:
 	sh ./dune-install.sh $(PREFIX)
@@ -67,7 +69,7 @@ test:: dune-test
 
 dune-test:
 	@ echo
-	dune runtest --profile=release
+	dune runtest --profile=$(DUNE_PROFILE)
 
 test:: test.aarch64
 test.aarch64:

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1313,7 +1313,6 @@ module Make
         get_ea_idx rs k ii >>== fun v -> write_reg_dest rs v ii
 
       let get_ea_reg rs _v ri sext s ii =
-        let open AArch64Base.MemExt in
         read_reg_ord rs ii >>| (read_reg_ord ri ii >>= memext_sext sext s)
         >>= fun (v1,v2) -> M.add v1 v2
 

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -695,9 +695,9 @@ module Make (C : Config) = struct
         let v_of_int = V.intToV
         let v_of_literal = v_of_literal
         let v_to_int = v_to_int
-        let bind_data = M.( >>= )
-        let bind_seq = M.para_bind_output_right
-        let bind_ctrl = M.bind_ctrl_seq_data
+        let bind_data = M.asl_data
+        let bind_seq = M.asl_seq
+        let bind_ctrl = M.asl_ctrl
         let prod_par = M.( >>| )
         let appl_data m f = m >>= fun v -> return (f v)
         let choice = choice

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -265,6 +265,8 @@ Monad type:
     let (>>==) : 'a t -> ('a -> 'b t) -> ('b) t
         = fun s f -> data_comp (=$$=) s f
 
+    let asl_data s f = data_comp E.data_po_seq s f
+
     let (>>*=) : 'a t -> ('a -> 'b t) -> ('b) t
       = fun s f -> data_comp (=**=) s f
 
@@ -283,6 +285,8 @@ Monad type:
       data_comp (E.bind_ctrl_avoid es.E.events) s f eiid
 
     let bind_ctrl_seq_data s f = data_comp E.bind_ctrl_sequence_data s f
+
+    let asl_ctrl s f = data_comp E.bind_ctrl_sequence_data_po s f
 
     let bind_data_to_minimals s f =  data_comp E.data_to_minimals s f
 
@@ -969,6 +973,9 @@ Monad type:
     let para_bind_output_right : 'a t -> ('a -> 'b t) -> 'b t =
       fun s f -> data_comp E.para_output_right s f
 
+    let asl_seq : 'a t -> ('a -> 'b t) -> 'b t =
+      fun s f -> data_comp E.para_po_seq_output_right s f
+
     type poi = int
 
 (************************************************)
@@ -1089,7 +1096,7 @@ Monad type:
 
     (* Build event structure from event set *)
 
-    let do_trivial es = { E.empty_event_structure with E.events = es ; }
+    let do_trivial es = E.from_events es
 
     (* Build event structure from action and instruction instance *)
 
@@ -1381,7 +1388,6 @@ Monad type:
         | _ -> false
 
       let is_instrloc a =
-        let open Constant in
         match a with
         | V.Val (Constant.Label _) -> true
         | _ -> false

--- a/herd/libdir/asl.cat
+++ b/herd/libdir/asl.cat
@@ -32,13 +32,14 @@ let asl_iico_ctrl = iico_ctrl
 let asl_iico_data = iico_data
 let asl_rf_reg = rf-reg
 let asl_rf = rf
+let asl_po = partial_po
 
 (* Working relations *)
 
 let aarch64 = NASLLocal * NASLLocal
 
-let asl_fr_reg = ([Rreg] ; po ; [Wreg]) & loc (* loc extended to registers *)
-let asl_fr = ([R] ; po ; [W]) & loc
+let asl_fr_reg = ([Rreg] ; asl_po ; [Wreg]) & loc (* loc extended to registers *)
+let asl_fr = ([R] ; asl_po ; [W]) & loc
 
 let asl_data = asl_iico_data | asl_rf_reg
 let asl_deps = asl_data (* | asl_iico_ctrl *)
@@ -73,7 +74,7 @@ show [DATA] as debug_data
 
 (* Tests *)
 
-acyclic (aarch64_intrinsic | po) as asl_determinism
+acyclic (aarch64_intrinsic | asl_po) as asl_determinism
 
 
 (* Display *)

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -241,6 +241,12 @@ module Make
                   relevant e1 && relevant e2 &&
                  not (E.same_instance e1 e2))))
           conc.S.po in
+      let partial_po =
+        lazy (
+          E.EventRel.filter_nodes relevant
+            conc.S.partial_po
+        )
+      in
       let id =
         lazy begin
           E.EventRel.of_list
@@ -316,7 +322,8 @@ module Make
                   (fun (r,w) -> E.po_eq r w)
                   conc.S.atomic_load_store
               end;
-              "po", lazy  po;
+              "po", lazy po;
+              "partial_po", partial_po;
               "depend", lazy (Lazy.force pr).S.depend;
               "success", lazy (Lazy.force pr).S.success;
               "rf", lazy (Lazy.force pr).S.rf;

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -1780,6 +1780,7 @@ let match_reg_events es =
       (* We can build those now *)
       let evts = es.E.events in
       let po_iico = U.po_iico es in
+      let partial_po = E.EventTransRel.to_transitive_rel es.E.partial_po in
       let ppoloc = make_ppoloc po_iico evts in
       let store_load_vbf = store_load rfm
       and init_load_vbf = init_load es rfm in
@@ -1863,6 +1864,7 @@ let match_reg_events es =
                    rfmap = rfm ;
                    fs = fsc ;
                    po = po_iico ;
+                   partial_po = partial_po;
                    pos = ppoloc ;
                    pco = pco ;
 
@@ -1880,6 +1882,7 @@ let match_reg_events es =
                      rfmap = rfm ;
                      fs = fsc ;
                      po = po_iico ;
+                     partial_po = partial_po ;
                      pos = ppoloc ;
                      pco = pco ;
 

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -66,6 +66,10 @@ module type S =
     val data_input_next : 'a t -> ('a -> 'b t) -> 'b t
  (* Input to both args *)
     val data_input_union : 'a t -> ('a -> 'b t) -> 'b t
+
+    (* Same as [>>=] but sequences partial_po *)
+    val asl_data : 'a t -> ('a -> 'b t) -> 'b t
+
     val (>>==) : 'a t -> ('a -> 'b t) -> 'b t (* Output events stay in first arg *)
 
 (* Control composition *)
@@ -86,6 +90,9 @@ module type S =
     (* Control compoisition, but output events might be in first event if
        second is empty. *)
     val bind_ctrl_seq_data : 'a t -> ('a -> 'b t) -> 'b t
+
+    (* Similar as [bind_ctrl_seq_data] but sequences partial_po *)
+    val asl_ctrl : 'a t -> ('a -> 'b t) -> 'b t
 
     (* Hybrid composition m1 m2 m3, m1 -ctrl+data-> m3 and m2 -data-> m3.
        ctrl+data -> ctrl from maximal commit evts + data from
@@ -217,6 +224,13 @@ module type S =
         input of the new event structure is the union of the inputs of
         [s] and the result of [f], like [cseq]. Unlike [cseq] the output of
         the resulting event structure is set to the result of [f]. *)
+
+    val asl_seq : 'a t -> ('a -> 'b t) -> 'b t
+    (** [asl_seq s f] returns a parallel composition of [s] and the result of
+        [f] where the input of the new event structure is the union of the
+        inputs of [s] and the result of [f], like [cseq] and
+        [para_bind_output_right]. Unlike the later, a [partial_po] arrow is put
+        between the two structures. *)
 
     val seq_mem : 'a t -> 'b t -> ('a * 'b) t
     (** [seq_mem s1 s2] returns a composition of the event structures

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -168,6 +168,7 @@ type concrete =
      rfmap : rfmap ;           (* rfmap *)
      fs    : state * A.FaultSet.t ;           (* final state *)
      po  : event_rel ;         (* program order (in fact po + iico) *)
+     partial_po : event_rel ;
      pos : event_rel ;         (* Same location same processor accesses *)
 (* Write serialization precursor ie uniproc induced constraints over writes *)
      pco : event_rel ;
@@ -446,6 +447,7 @@ type concrete =
      rfmap : rfmap ;           (* rfmap *)
      fs    : state * A.FaultSet.t ;           (* final state *)
      po : event_rel ;
+     partial_po : event_rel ;
      pos : event_rel ;      (* Same location same processor accesses *)
      pco : event_rel ;
 (* View before relation deduced from rfmaps *)
@@ -460,6 +462,7 @@ type concrete =
        str = E.empty_event_structure ;
        rfmap = RFMap.empty ;
        fs = A.state_empty,A.FaultSet.empty;
+       partial_po = E.EventRel.empty;
        po = E.EventRel.empty ;
        pos = E.EventRel.empty ;
        pco = E.EventRel.empty ;

--- a/herd/slrc11.ml
+++ b/herd/slrc11.ml
@@ -862,6 +862,7 @@ module Make (M:Cfg)
                      po = E.EventRel.empty;
                      pos = E.EventRel.empty;
                      pco = E.EventRel.empty;
+                     partial_po = E.EventRel.empty;
 
                      store_load_vbf = E.EventRel.empty;
                      init_load_vbf = E.EventRel.empty;

--- a/lib/InnerTransRel.ml
+++ b/lib/InnerTransRel.ml
@@ -1,0 +1,104 @@
+module type S = sig
+  type elt
+
+  module Set : MySet.S with type elt = elt
+  module Rel : InnerRel.S with type elt0 = elt and module Elts = Set
+
+  type t = { input : Set.t; rel : Rel.t; output : Set.t }
+
+  val empty : t
+  val from_nodes : Set.t -> t
+  val map_nodes : (elt -> elt) -> t -> t
+  val seq : t -> t -> t
+  val union : t -> t -> t
+  val union3 : t -> t -> t -> t
+  val union4 : t -> t -> t -> t -> t
+  val union5 : t -> t -> t -> t -> t -> t
+  val union6 : t -> t -> t -> t -> t -> t -> t
+  val unions : t list -> t
+  val to_transitive_rel : t -> Rel.t
+end
+
+module Make (O : MySet.OrderedType) :
+  S
+    with type elt = O.t
+     and module Set = MySet.Make(O)
+     and module Rel = InnerRel.Make(O) = struct
+  module Set = MySet.Make (O)
+  module Rel = InnerRel.Make (O)
+
+  type elt = O.t
+  type t = { input : Set.t; rel : Rel.t; output : Set.t }
+
+  let empty = { input = Set.empty; rel = Rel.empty; output = Set.empty }
+  let from_nodes events = { input = events; rel = Rel.empty; output = events }
+
+  let map_nodes f { input; rel; output } =
+    {
+      input = Set.map f input;
+      rel = Rel.map_nodes f rel;
+      output = Set.map f output;
+    }
+
+  let seq t1 t2 =
+    assert (not (Set.is_empty t1.output));
+    assert (not (Set.is_empty t2.input));
+    {
+      input = t1.input;
+      rel = Rel.union3 t1.rel t2.rel (Rel.cartesian t1.output t2.input);
+      output = t2.output;
+    }
+
+  let union t1 t2 =
+    {
+      input = Set.union t1.input t2.input;
+      rel = Rel.union t1.rel t2.rel;
+      output = Set.union t1.output t2.output;
+    }
+
+  let union3 t1 t2 t3 =
+    {
+      input = Set.union3 t1.input t2.input t3.input;
+      rel = Rel.union3 t1.rel t2.rel t3.rel;
+      output = Set.union3 t1.output t2.output t3.output;
+    }
+
+  let union4 t1 t2 t3 t4 =
+    {
+      input = Set.union4 t1.input t2.input t3.input t4.input;
+      rel = Rel.union4 t1.rel t2.rel t3.rel t4.rel;
+      output = Set.union4 t1.output t2.output t3.output t4.output;
+    }
+
+  let union5 t1 t2 t3 t4 t5 =
+    {
+      input = Set.union5 t1.input t2.input t3.input t4.input t5.input;
+      rel = Rel.union5 t1.rel t2.rel t3.rel t4.rel t5.rel;
+      output = Set.union5 t1.output t2.output t3.output t4.output t5.output;
+    }
+
+  let union6 t1 t2 t3 t4 t5 t6 =
+    {
+      input = Set.union6 t1.input t2.input t3.input t4.input t5.input t6.input;
+      rel = Rel.union6 t1.rel t2.rel t3.rel t4.rel t5.rel t6.rel;
+      output =
+        Set.union6 t1.output t2.output t3.output t4.output t5.output t6.output;
+    }
+
+  (* Dichotomic implementation of iterated union. *)
+
+  (* [unions2 acc [l1; l2; ...; l2n]] is the list
+     [[union l1 l2; union l3 l4; ... union l2n-1 l2n]]. *)
+  let rec unions2 acc = function
+    | [] -> acc
+    | [ h ] -> h :: acc
+    | h1 :: h2 :: t -> unions2 (union h1 h2 :: acc) t
+
+  (* [unions li] calls [unions2] on [li] until it only has one element. *)
+  let rec unions = function
+    | [] -> empty
+    | [ h ] -> h
+    | li -> unions2 [] li |> unions
+
+  let to_transitive_rel t = Rel.transitive_closure t.rel
+end

--- a/lib/InnerTransRel.mli
+++ b/lib/InnerTransRel.mli
@@ -1,0 +1,49 @@
+(** Implements a transitive relation. *)
+
+module type S = sig
+  (** Output module. *)
+
+  type elt
+  (** Type of nodes in this relation. *)
+
+  module Set : MySet.S with type elt = elt
+  module Rel : InnerRel.S with type elt0 = elt and module Elts = Set
+
+  type t = { input : Set.t; rel : Rel.t; output : Set.t }
+  (** Represents a transitive relation.
+
+      Note that users should not use this representation to build their
+      relation, but they should rely on the constructor [from_nodes] and the
+      [union] and [seq] operations.
+  *)
+
+  val empty : t
+  (** The empty relation. *)
+
+  val from_nodes : Set.t -> t
+  (** Builds a transitive relation with those nodes and no edges. *)
+
+  val map_nodes : (elt -> elt) -> t -> t
+  (** maps on nodes, does not affect edges. *)
+
+  val seq : t -> t -> t
+  (** Sequential operation: every element of t1 is before every element of t2. *)
+
+  val union : t -> t -> t
+  (** Parallel composition, union of graphs. *)
+
+  val union3 : t -> t -> t -> t
+  val union4 : t -> t -> t -> t -> t
+  val union5 : t -> t -> t -> t -> t -> t
+  val union6 : t -> t -> t -> t -> t -> t -> t
+  val unions : t list -> t
+
+  val to_transitive_rel : t -> Rel.t
+  (** [to_transitive_rel t] is the InnerRel representation of t. *)
+end
+
+module Make : functor (O : MySet.OrderedType) ->
+  S
+    with type elt = O.t
+     and module Set = MySet.Make(O)
+     and module Rel = InnerRel.Make(O)

--- a/lib/innerRel.mli
+++ b/lib/innerRel.mli
@@ -39,6 +39,10 @@ module type S =  sig
 (* All elements related *)
   val nodes : t -> Elts.t
 
+(* Operations on nodes, ie all elements related *)
+  val filter_nodes : (elt0 -> bool) -> t -> t
+  val map_nodes: (elt0 -> elt0) -> t -> t
+
 (* Inverse *)
   val inverse : t -> t
 


### PR DESCRIPTION
The main goal of this pr can be summarized by the following test:
```
ASL test-po
{}

func main () => integer begin
  let y = 0;
  let x = y + y; // Here

  return 0;
end
```

We want the two reads to `y` to not be related by `po`. This is not possible with herd as of today, because the program order is considered a total order on the effects of a thread.

This PR introduce the possibilities for an architecture to use a partial program order.

This is done by adding a field inside the `event_structure` graph, and adding new combinators that edit specially this fields.

That results in the following graph being produced for the above test:
![test-po dot](https://github.com/herd/herdtools7/assets/19175393/d8fb2ae1-f07d-4ebd-b418-6d767f573874)
We can see that there is no `partial_po` arrow between _b_ and _c_ when there is a `po` one. 