### PR TITLE
[Makefile] Add a test-all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ check-deps::
 # Tests.
 TIMEOUT=16.0
 
+test-all:: test
 test:: | build
 
 test:: dune-test
@@ -378,6 +379,7 @@ mte-test:
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 catalogue aarch64-MTE tests: OK"
 
+test-all:: vmsa-test
 vmsa-test:
 	@ echo
 	$(HERD_CATALOGUE_REGRESSION_TEST) \
@@ -390,6 +392,7 @@ vmsa-test:
 		$(REGRESSION_TEST_MODE)
 		@ echo "herd7 catalogue aarch64-VMSA tests: OK"
 
+test-all:: ets2-test
 ets2-test:
 	@ echo
 	$(HERD_CATALOGUE_REGRESSION_TEST) \


### PR DESCRIPTION
The Makefile used to offer an option to run all tests. As we added more tests, the overhead for running all tests becomes non-trivial. More notably, the vmsa-test and ets2-test targets include more litmus tests than any other. In addition, the fact that make test is invoked in the precommit hook makes it crucial that make test terminates as quickly as possible. This commit adds another target test-all which is inclusive of all tests.