### PR TITLE
[herd,asl] Avoid name clashes between stdlib.asl and other libraries

### DIFF
--- a/asllib/builder.ml
+++ b/asllib/builder.ml
@@ -156,3 +156,27 @@ let stdlib =
 
 let with_stdlib ast =
   List.rev_append (Lazy.force stdlib |> ASTUtils.no_primitive) ast
+
+let extract_name k d =
+  let open AST in
+  match d.desc with
+  | D_Func {name;_}
+    -> name::k
+  | D_TypeDecl _ ->
+     prerr_string  "Type declaration in stdlib.asl" ;
+     exit 1
+  | D_GlobalStorage _ ->
+     prerr_string "Storage declaration in stdlib.asl" ;
+     exit 1
+
+
+let is_stdlib_name =
+  let module StringSet = Set.Make(String) in
+  let set =
+    lazy
+      begin
+        let extract_names ds =
+          List.fold_left extract_name [] ds |> StringSet.of_list in
+        Lazy.force stdlib |> extract_names
+      end in
+  fun name -> StringSet.mem name (Lazy.force set)

--- a/asllib/builder.mli
+++ b/asllib/builder.mli
@@ -25,3 +25,4 @@ val from_file_multi_version :
 
 val stdlib : unit AST.t Lazy.t
 val with_stdlib : 'a AST.t -> 'a AST.t
+val is_stdlib_name : AST.identifier -> bool

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -749,12 +749,16 @@ module Make (C : Config) = struct
           and custom_implems = build `ASLv1 "implementations.asl"
           and shared = build `ASLv0 "shared_pseudocode.asl" in
           let shared =
+            (*
+             * For Some reason, do not clash with
+             * stdlib definitions that will be loaded later.
+             *)
             (List.filter
                AST.(
                  fun d ->
                    match d.desc with
-                   | D_Func { name = "Zeros" | "Ones" | "Replicate" | "Abs" ; _ } ->
-                       false
+                   | D_Func { name;_} ->
+                      not (Asllib.Builder.is_stdlib_name name)
                    | _ -> true)
                shared [@warning "-40-42"])
           in


### PR DESCRIPTION

Function defined by ASL standard library take precedence, given file loading  order this means that definitions that would clash with those of the ASL standard library have to be removed at some point. A (partial) static test is replaced by a dynamic one.

Followup to PR #715.