### PR TITLE
[all] Implement AArch64 "reverse bytes" instructions

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -263,7 +263,32 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
                 "d" ^= reg rd;
                 "n" ^= reg rn;
                 "datasize" ^= liti datasize;
-              ])
+           ])
+    (*
+     * Does not work, because instruction code uses the Elem
+     * setter `Elem[..] = ...`. This setter relies on passing argument
+     * by reference.
+     *)
+(*
+      | I_REV (rv,rd,rn) ->
+         let datasize = variant_of_rev rv |> variant_raw in
+         let csz = container_size rv |> MachSize.nbits in
+         Printf.eprintf "REV: sz=%i, csz=%i\n%!" datasize csz ;
+         let fname =
+           match rv with
+           | RV16 _ -> "REV16_32_dp_1src.opn"
+           | RV32 -> "REV32_64_dp_1src.opn"
+           | RV64 _ -> "REV_32_dp_1src.opn" in
+         Some
+           ("/integer/arithmetic/rev/" ^ fname,
+            stmt
+              [
+                "d" ^= reg rd;
+                "n" ^= reg rn;
+                "datasize" ^= liti datasize;
+                "container_size" ^= liti csz;
+           ])
+ *)
       | I_UBFM (v,rd,rn,immr,imms)
       | I_SBFM (v,rd,rn,immr,imms) ->
          let datasize = variant_raw v in
@@ -715,6 +740,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
               | Mask sz -> Mask sz
               | Sxt sz -> Sxt sz
               | Rbit sz -> Rbit sz
+              | RevBytes (csz,sz) -> RevBytes (csz,sz)
               | TagLoc -> TagLoc
               | CapaTagLoc -> CapaTagLoc
               | TagExtract -> TagExtract

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -100,7 +100,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_STOPBH _| I_STP _| I_STP_P_SIMD _| I_STP_SIMD _| I_STR _
     | I_STR_P_SIMD _| I_STR_SIMD _| I_STRBH _| I_STUR_SIMD _| I_STXP _| I_STXR _
     | I_STXRBH _| I_STZG _| I_SWP _| I_SWPBH _| I_SXTW _| I_TLBI _| I_UBFM _
-    | I_UDF _| I_UNSEAL _ | I_ADDSUBEXT _ | I_ABS _
+    | I_UDF _| I_UNSEAL _ | I_ADDSUBEXT _ | I_ABS _ | I_REV _
       -> true
 
     let is_cmodx_restricted_value =
@@ -251,7 +251,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_TBNZ(_,_,_,_) | I_TBZ (_,_,_,_) | I_MOVZ (_,_,_,_) | I_MOVK(_,_,_,_)
       | I_MOVN _
       | I_MOV (_, _, _)|I_SXTW (_, _)|I_OP3 (_, _, _, _, _)
-      | I_ADR (_, _)|I_RBIT (_, _, _)|I_ABS _|I_FENCE _
+      | I_ADR (_, _)|I_RBIT (_, _, _)|I_ABS _|I_REV _|I_FENCE _
       | I_SBFM (_,_,_,_,_) | I_UBFM (_,_,_,_,_)
       | I_CSEL (_, _, _, _, _, _)|I_IC (_, _)|I_DC (_, _)|I_MRS (_, _)|I_MSR (_, _)
       | I_STG _ | I_STZG _ | I_LDG _
@@ -311,6 +311,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_ADR (r,_)
       | I_RBIT (_,r,_)
       | I_ABS (_,r,_)
+      | I_REV (_,r,_)
       | I_CSEL (_,r,_,_,_,_)
       | I_MRS (r,_)
       | I_UBFM (_,r,_,_,_) | I_SBFM (_,r,_,_,_)
@@ -376,7 +377,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_SWP _|I_SWPBH _|I_LDOP _
       | I_LDOPBH _|I_STOP _|I_STOPBH _
       | I_MOV _|I_MOVZ _|I_MOVN _|I_MOVK _|I_SXTW _
-      | I_OP3 _|I_ADR _|I_RBIT _|I_ABS _|I_FENCE _
+      | I_OP3 _|I_ADR _|I_RBIT _|I_ABS _|I_REV _|I_FENCE _
       | I_CSEL _|I_IC _|I_DC _|I_TLBI _|I_MRS _|I_MSR _
       | I_STG _|I_STZG _|I_LDG _|I_UDF _
       | I_ADDSUBEXT _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2761,7 +2761,13 @@ module Make
            >>= M.op1 Op.Abs
            >>=fun v -> write_reg_dest rd v ii
            >>= nextSet rd
-        | I_OP3(v,op,rd,rn,e) ->
+        | I_REV (rv,rd,rs) ->
+           let sz = variant_of_rev rv |> tr_variant in
+           read_reg_ord_sz sz rs ii
+           >>= M.op1 (Op.RevBytes (container_size rv,sz))
+           >>= fun v -> write_reg_dest rd v ii
+           >>= nextSet rd
+           | I_OP3(v,op,rd,rn,e) ->
            let margs =
              let sz = tr_variant v in
              let mn = read_reg_ord_sz sz rn ii in

--- a/herd/tests/instructions/AArch64/L094.litmus
+++ b/herd/tests/instructions/AArch64/L094.litmus
@@ -1,0 +1,12 @@
+AArch64 L094
+{
+uint32_t 0:X1=0x87654321;
+uint32_t 0:X2;
+uint64_t 0:X3=0xfedcba87654321;
+uint64_t 0:X4;
+}
+  P0       ;
+ REV W2,W1 ;
+ REV X4,X3 ;
+
+forall 0:X2=0x21436587 /\ 0:X4=0x21436587badcfe00

--- a/herd/tests/instructions/AArch64/L094.litmus.expected
+++ b/herd/tests/instructions/AArch64/L094.litmus.expected
@@ -1,0 +1,10 @@
+Test L094 Required
+States 1
+0:X2=558065031; 0:X4=2396871060321271296;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=558065031 /\ 0:X4=2396871060321271296)
+Observation L094 Always 1 0
+Hash=f55c35e3f34db34069f12a61d6abd1d3
+

--- a/herd/tests/instructions/AArch64/L095.litmus
+++ b/herd/tests/instructions/AArch64/L095.litmus
@@ -1,0 +1,13 @@
+AArch64 L095
+{
+uint32_t 0:X1=0x87654321;
+uint32_t 0:X2;
+uint64_t 0:X3=0xfedcba87654321;
+uint64_t 0:X4;
+}
+  P0         ;
+ REV16 W2,W1 ;
+ REV16 X4,X3 ;
+
+forall 0:X2=0x65872143 /\ 0:X4=0xfe00badc65872143;
+

--- a/herd/tests/instructions/AArch64/L095.litmus.expected
+++ b/herd/tests/instructions/AArch64/L095.litmus.expected
@@ -1,0 +1,10 @@
+Test L095 Required
+States 1
+0:X2=1703354691; 0:X4=18302834341392621891;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=1703354691 /\ 0:X4=-143909732316929725)
+Observation L095 Always 1 0
+Hash=23b492a35abf95f36f070f9d77e32f08
+

--- a/herd/tests/instructions/AArch64/L096.litmus
+++ b/herd/tests/instructions/AArch64/L096.litmus
@@ -1,0 +1,10 @@
+AArch64 L096
+{
+uint64_t 0:X3=0xfedcba87654321;
+uint64_t 0:X4;
+}
+  P0         ;
+ REV32 X4,X3 ;
+
+forall 0:X4=0xbadcfe0021436587
+

--- a/herd/tests/instructions/AArch64/L096.litmus.expected
+++ b/herd/tests/instructions/AArch64/L096.litmus.expected
@@ -1,0 +1,10 @@
+Test L096 Required
+States 1
+0:X4=13464916262442460551;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X4=-4981827811267091065)
+Observation L096 Always 1 0
+Hash=fe0a2adb127e165e26778c56716e669d
+

--- a/herd/tests/instructions/AArch64/L097.litmus
+++ b/herd/tests/instructions/AArch64/L097.litmus
@@ -1,0 +1,10 @@
+AArch64 L097
+{
+uint64_t 0:X3=0xfedcba87654321;
+uint64_t 0:X4;
+}
+  P0         ;
+ REV64 X4,X3 ;
+
+forall 0:X4=0x21436587badcfe00
+

--- a/herd/tests/instructions/AArch64/L097.litmus.expected
+++ b/herd/tests/instructions/AArch64/L097.litmus.expected
@@ -1,0 +1,10 @@
+Test L097 Required
+States 1
+0:X4=2396871060321271296;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X4=2396871060321271296)
+Observation L097 Always 1 0
+Hash=46001174e70c8ea3c01326bf03d1c1b8
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -334,6 +334,10 @@ include Arch.MakeArch(struct
        conv_reg r1 >> fun r1 ->
        conv_reg r2 >! fun r2 ->
        I_ABS (v,r1,r2)
+    | I_REV (v,r1,r2) ->
+       conv_reg r1 >> fun r1 ->
+       conv_reg r2 >! fun r2 ->
+       I_REV (v,r1,r2)
     | I_LDAR(a,b,r1,r2) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >! fun r2 ->

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -334,11 +334,15 @@ match name with
 | "movn"|"MOVN" -> MOVN
 | "movk"|"MOVK" -> MOVK
 | "adr"|"ADR" -> ADR
+| "rev16"|"REV16" -> REV16
+| "rev32"|"REV32" -> REV32
+| "rev64"|"REV64" -> REV64
+| "rev"|"REV" -> REV
 | "rbit"|"RBIT" -> RBIT
 | "abs"|"ABS" -> ABS
 | "cmp"|"CMP" -> CMP
 | "tst"|"TST" -> TST
-(* Three argument opcodes factorized *)
+(* Those operations are factorized *)
 | "eor"|"EOR" -> OP A.EOR
 | "eon"|"EON" -> OP A.EOR
 | "orr"|"ORR" -> OP A.ORR

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -129,6 +129,7 @@ let mk_instrp instr v r1 r2 ra ko kb =
 %token <AArch64Base.TLBI.op> TLBI_OP
 %token <AArch64Base.sysreg> SYSREG
 %token MRS MSR TST RBIT ABS
+%token REV16 REV32 REV REV64
 %token STG STZG LDG
 %token ALIGND ALIGNU BUILD CHKEQ CHKSLD CHKTGD CLRTAG CPY CPYTYPE CPYVALUE CSEAL
 %token LDCT SEAL STCT UNSEAL
@@ -1252,6 +1253,19 @@ instr:
   { I_RBIT (V32,$2,$4) }
 | RBIT xreg COMMA xreg
   { I_RBIT (V64,$2,$4) }
+
+| REV16 wreg COMMA wreg
+  { I_REV (RV16 AArch64Base.V32,$2,$4) }
+| REV16 xreg COMMA xreg
+  { I_REV (RV16 AArch64Base.V64,$2,$4) }
+| REV32 xreg COMMA xreg
+  { I_REV (RV32,$2,$4) }
+| REV64 xreg COMMA xreg
+  { I_REV (RV64 AArch64Base.V64 ,$2,$4) }
+| REV wreg COMMA wreg
+  { I_REV (RV64 AArch64Base.V32,$2,$4) }
+| REV xreg COMMA xreg
+  { I_REV (RV64 AArch64Base.V64,$2,$4) }
 
 | ABS wreg COMMA wreg
   { I_ABS (V32,$2,$4) }

--- a/lib/op.ml
+++ b/lib/op.ml
@@ -117,6 +117,7 @@ type 'aop op1 =
   | Rbit of MachSize.sz
   | Inv
   | Abs
+  | RevBytes of MachSize.sz * MachSize.sz
   | TagLoc       (* Get tag memory location from location *)
   | CapaTagLoc
   | TagExtract   (* Extract tag from tagged location *)
@@ -149,6 +150,8 @@ let pp_op1 hexa pp_aop o = match o with
 | Mask sz  -> sprintf "mask%02i" (MachSize.nbits sz)
 | Sxt sz -> sprintf "sxt%02i" (MachSize.nbits sz)
 | Rbit sz -> sprintf "rbit%02i" (MachSize.nbits sz)
+| RevBytes (csz,sz) ->
+   sprintf "rev-%02i-%02i" (MachSize.nbits csz) (MachSize.nbits sz)
 | TagLoc ->  "tagloc"
 | CapaTagLoc -> "capatagloc"
 | TagExtract -> "tagextract"

--- a/lib/op.mli
+++ b/lib/op.mli
@@ -71,6 +71,7 @@ type 'aop op1 =
   | Rbit of MachSize.sz (* Reverse bits *)
   | Inv          (* Logical not or inverse *)
   | Abs          (* Absolute value *)
+  | RevBytes of MachSize.sz * MachSize.sz (* Reverse Bytes *)
   | TagLoc       (* Get tag memory location from location *)
   | CapaTagLoc
   | TagExtract   (* Extract tag from tagged location *)

--- a/lib/rbit.mli
+++ b/lib/rbit.mli
@@ -19,15 +19,19 @@
 module type I = sig
     type t
     val zero : t
+    val one : t
+    val pp : bool -> t -> string
     val shift_left : t  -> int -> t
     val shift_right_logical : t -> int -> t
     val bit_at : int -> t -> t
     val logor : t -> t -> t
-  end
+    val mask : MachSize.sz -> t -> t
+end
 
 module Make :
   functor (I:I)
   ->
   sig
     val rbit : MachSize.sz -> I.t -> I.t
+    val revbytes : MachSize.sz -> MachSize.sz -> I.t -> I.t
   end

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -827,6 +827,9 @@ module
     | Rbit sz ->
        let module R = Rbit.Make(Cst.Scalar) in
        unop op (R.rbit sz)
+    | RevBytes (csz,sz) ->
+       let module R = Rbit.Make(Cst.Scalar) in
+       unop op (R.revbytes csz sz)
     | Inv -> unop op Cst.Scalar.lognot
     | Abs -> unop op Cst.Scalar.abs
     | TagLoc -> tagloc

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1047,7 +1047,10 @@ module Make(V:Constant.S)(C:Config) =
     and movz = do_movz (fun _ -> []) (* No input *) "movz"
     and movn = do_movz (fun _ -> []) (* No input *) "movn"
     and movk = do_movz Misc.identity (* Part of register preserved *) "movk"
-
+    and rev rv =
+      let memo = Misc.lowercase (memo_of_rev rv)
+      and v = variant_of_rev rv in
+      do_movr memo v
 
     let sxtw r1 r2 =
       { empty_ins with
@@ -1326,6 +1329,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_ADR (r,lbl) -> adr tr_lab r lbl::k
     | I_RBIT (v,rd,rs) -> rbit v rd rs::k
     | I_ABS (v,rd,rs) -> abs v rd rs::k
+    | I_REV (v,rd,rs) -> rev v rd rs::k
     | I_SXTW (r1,r2) -> sxtw r1 r2::k
     | I_SBFM (v,r1,r2,k1,k2) -> xbfm "sbfm" v r1 r2 k1 k2::k
     | I_UBFM (v,r1,r2,k1,k2) -> xbfm "ubfm" v r1 r2 k1 k2::k


### PR DESCRIPTION
Implement the REV instruction, as well as its variants REV16, REV32, REV64. LItmus test example:
```
AArch64 L094
{
uint32_t 0:X1=0x87654321;
uint32_t 0:X2;
uint64_t 0:X3=0xfedcba87654321;
uint64_t 0:X4;
}
  P0       ;
 REV W2,W1 ;
 REV X4,X3 ;

forall 0:X2=0x21436587 /\ 0:X4=0x21436587badcfe00
```