### PR TITLE
[all] Implementing AArch64 wide multiplication instructions.

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -359,6 +359,21 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
              "datasize" ^= liti datasize;
              "extend_type" ^= var extend_type;
              "shift" ^= liti shift;])
+      | I_MOPL (sop,rd,rn,rm,ra) ->
+         let fname =
+           let open MOPLExt in
+           match sop with
+           | Signed,ADD -> "SMADDL_64WA_dp_3src.opn"
+           | Signed,SUB -> "SMSUBL_64WA_dp_3src.opn"
+           | Unsigned,ADD -> "UMADDL_64WA_dp_3src.opn"
+           | Unsigned,SUB -> "UMSUBL_64WA_dp_3src.opn" in
+         Some
+           ("integer/arithmetic/mul/widening/32-64/" ^ fname,
+            stmt
+              ["d" ^= reg rd;
+               "n" ^= reg rn;
+               "m" ^= reg rm;
+               "a" ^= reg ra;])
       | I_OP3
          (v,
           (ADD|ADDS|SUB|SUBS|AND|ANDS|BIC|BICS|EOR|EON|ORN|ORR as op),

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -100,7 +100,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_STOPBH _| I_STP _| I_STP_P_SIMD _| I_STP_SIMD _| I_STR _
     | I_STR_P_SIMD _| I_STR_SIMD _| I_STRBH _| I_STUR_SIMD _| I_STXP _| I_STXR _
     | I_STXRBH _| I_STZG _| I_SWP _| I_SWPBH _| I_SXTW _| I_TLBI _| I_UBFM _
-    | I_UDF _| I_UNSEAL _ | I_ADDSUBEXT _ | I_ABS _ | I_REV _
+    | I_UDF _| I_UNSEAL _ | I_ADDSUBEXT _ | I_ABS _ | I_REV _ | I_MOPL _
       -> true
 
     let is_cmodx_restricted_value =
@@ -263,7 +263,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_MOV_V _ | I_MOV_VE _ | I_MOV_S _ | I_MOV_TG _ | I_MOV_FG _
       | I_MOVI_S _ | I_MOVI_V _
       | I_EOR_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
-      | I_UDF _ | I_ADDSUBEXT _
+      | I_UDF _ | I_ADDSUBEXT _ | I_MOPL _
           -> None
 
     let all_regs =
@@ -316,6 +316,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_MRS (r,_)
       | I_UBFM (_,r,_,_,_) | I_SBFM (_,r,_,_,_)
       | I_ADDSUBEXT (_,_,r,_,_,_)
+      | I_MOPL (_,r,_,_,_)
         -> [r]
       | I_MSR (sr,_)
         -> [(SysReg sr)]
@@ -380,7 +381,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_OP3 _|I_ADR _|I_RBIT _|I_ABS _|I_REV _|I_FENCE _
       | I_CSEL _|I_IC _|I_DC _|I_TLBI _|I_MRS _|I_MSR _
       | I_STG _|I_STZG _|I_LDG _|I_UDF _
-      | I_ADDSUBEXT _
+      | I_ADDSUBEXT _|I_MOPL _
         -> MachSize.No
 
     include ArchExtra_herd.Make(C)

--- a/herd/tests/instructions/AArch64/L098.litmus
+++ b/herd/tests/instructions/AArch64/L098.litmus
@@ -1,0 +1,33 @@
+AArch64 L098
+{
+0:X1=128;
+0:X2=15;
+int64_t 0:X3;
+int64_t 0:X4;
+int64_t 0:X5;
+int64_t 0:X6;
+int64_t 0:X7;
+int64_t 0:X8;
+int64_t 0:X9;
+}
+  P0                 ;
+ SMULL X3,W2,W1      ;
+ SMADDL X3,W2,W1,X3  ;
+ MOV W1,#-1          ;
+ SMADDL X4,W2,W1,X3  ;
+ SMNEGL X5,W1,W1     ;
+ UMULL X6,W1,W1      ;
+ SMSUBL X7,W2,W1,X3  ;
+ ADD W1,W1,W1        ;
+ MOV X10,1           ;
+ UMSUBL X8,W1,W1,X10 ;
+ SMSUBL X9,W1,W1,X10 ;
+
+forall
+ 0:X3=3840 /\
+ 0:X4=3825 /\
+ 0:X5=-1 /\
+ 0:X6=-8589934591 /\
+ 0:X7=3855 /\
+ 0:X8=17179869181 /\
+ 0:X9=-3

--- a/herd/tests/instructions/AArch64/L098.litmus.expected
+++ b/herd/tests/instructions/AArch64/L098.litmus.expected
@@ -1,0 +1,10 @@
+Test L098 Required
+States 1
+0:X3=3840; 0:X4=3825; 0:X5=-1; 0:X6=-8589934591; 0:X7=3855; 0:X8=17179869181; 0:X9=-3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X3=3840 /\ 0:X4=3825 /\ 0:X5=-1 /\ 0:X6=-8589934591 /\ 0:X7=3855 /\ 0:X8=17179869181 /\ 0:X9=-3)
+Observation L098 Always 1 0
+Hash=69c9422977f390fc9590d51103553311
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -446,6 +446,12 @@ include Arch.MakeArch(struct
         conv_reg r3 >> fun r3 ->
         Ext.expl e >! fun e ->
         I_ADDSUBEXT (v1,op,r1,r2,(v3,r3),e)
+    | I_MOPL (sop,r1,r2,r3,r4) ->
+        conv_reg r1 >> fun r1 ->
+        conv_reg r2 >> fun r2 ->
+        conv_reg r3 >> fun r3 ->
+        conv_reg r4 >! fun r4 ->
+        I_MOPL (sop,r1,r2,r3,r4)
     | I_OP3 (a,b,r1,r2,e) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -374,6 +374,14 @@ match name with
 | "adds"|"ADDS" -> TOK_ADDS
 | "neg"|"NEG" -> TOK_NEG
 | "negs"|"NEGS" -> TOK_NEGS
+| "smaddl"|"SMADDL" -> MOPL AArch64Base.MOPLExt.(Signed,ADD)
+| "smsubl"|"SMSUBL" -> MOPL AArch64Base.MOPLExt.(Signed,SUB)
+| "umaddl"|"UMADDL" -> MOPL AArch64Base.MOPLExt.(Unsigned,ADD)
+| "umsubl"|"UMSUBL" -> MOPL AArch64Base.MOPLExt.(Unsigned,SUB)
+| "smull"|"SMULL" -> MOPLZ AArch64Base.MOPLExt.(Signed,ADD)
+| "smnegl"|"SMNEGL" -> MOPLZ AArch64Base.MOPLExt.(Signed,SUB)
+| "umull"|"UMULL" -> MOPLZ AArch64Base.MOPLExt.(Unsigned,ADD)
+| "umnegl"|"UMNEGL" -> MOPLZ AArch64Base.MOPLExt.(Unsigned,SUB)
 (* Morello *)
 | "alignd"|"ALIGND" -> ALIGND
 | "alignu"|"ALIGNU" -> ALIGNU

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -85,6 +85,8 @@ let mk_instrp instr v r1 r2 ra ko kb =
 %token <AArch64Base.gc> GC
 %token TOK_ADD TOK_ADDS TOK_SUB TOK_SUBS
 %token TOK_NEG TOK_NEGS
+%token <AArch64Base.MOPLExt.sop> MOPLZ
+%token <AArch64Base.MOPLExt.sop> MOPL
 %token CSEL CSINC CSINV CSNEG CSET CSETM CINC
 %token TOK_DMB TOK_DSB TOK_ISB
 %token TOK_SY TOK_ST TOK_LD
@@ -1225,6 +1227,12 @@ instr:
   { I_ADDSUBEXT (V64,$1,$2,$4,$6,$8) }
 | tok_add_sub_ext wreg COMMA wreg COMMA wreg COMMA add_sub_ext
   { I_ADDSUBEXT (V32, $1, $2, $4, (V32, $6), $8) }
+
+(* Multiplication, special forms *)
+| MOPLZ xreg COMMA wreg COMMA wreg
+    { I_MOPL ($1,$2,$4,$6,ZR) }
+| MOPL xreg COMMA wreg COMMA wreg COMMA xreg
+    { I_MOPL ($1,$2,$4,$6,$8) }
 
 (* Aliases of SUB *)
 | CMP wreg COMMA op_ext_w


### PR DESCRIPTION
Those instructions multiply two 32bit quantities resulting in a 64bit quantity. Additionally, the multiplication can be signed or unsigned. Moreover the multiplication result is added to or subtracted from another 64bit quantity.

For instance: considering signed multiplication and addition:
```
AArch64 MUL

{
int64_t 0:X1=1;
0:X2=2;
0:X3=3;
int64_t 0:X4;
int64_t 0:X5;
}
  P0                ;
 SMADDL X4,W3,W2,X1 ;
 SMULL X5,W3,W2     ;
forall 0:X4=7 /\ 0:X5=6
```
We have 3\*2+1 = 7 and 3\*2+0 = 6. The alias `SMULL` stands for `SADDL` with the last register being the zero register `XZR`. 
