### PR TITLE
[asl-carpenter] Introducing the ASLCarpenter testing tool

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -1269,8 +1269,9 @@ module Make (B : Backend.S) (C : Config) = struct
           | Some i -> i
         in
         L_BitVector (Bitvector.zeros length) |> lit
-    | T_Enum li ->
-        IMap.find (List.hd li) env.global.static.constants_values |> lit
+    | T_Enum li -> (
+        try IMap.find (List.hd li) env.global.static.constants_values |> lit
+        with Not_found -> fatal_from t Error.TypeInferenceNeeded)
     | T_Int UnConstrained -> L_Int Z.zero |> lit
     | T_Int (UnderConstrained _) ->
         failwith "Cannot request the base value of a under-constrained integer."

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1862,8 +1862,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
             let env', ldi' = annotate_local_decl_item_uninit s env ldi in
             (S_Decl (LDK_Var, ldi', None) |> here, env') |: TypingRule.SDeclNone
         | (LDK_Constant | LDK_Let), None ->
-            (* by construction in Parser. *)
-            assert false)
+            fatal_from s UnrespectedParserInvariant)
     (* End *)
     (* Begin SThrowSome *)
     | S_Throw (Some (e, _)) ->

--- a/asllib/carpenter/ASTEnums.ml
+++ b/asllib/carpenter/ASTEnums.ml
@@ -1,0 +1,427 @@
+(****************************************************************************************************************)
+(*  SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>  *)
+(*  SPDX-License-Identifier: BSD-3-Clause                                                                       *)
+(****************************************************************************************************************)
+
+let filter_none li = List.filter_map Fun.id li
+
+module Make (C : Config.S) = struct
+  open Asllib
+  open AST
+  open Feat
+  open Enum
+
+  let annot desc = ASTUtils.add_dummy_pos desc
+
+  (* Util not to forget to pay ==> make payment mandatory on recursion. *)
+  let fix f = Fix.Memoize.Int.fix (fun blah -> f (pay blah))
+  let enum_from_seq seq = seq |> Seq.map just |> Seq.fold_left ( ++ ) empty
+  let rec payn n thing = if n <= 0 then thing else payn (n - 1) (pay thing)
+
+  let scaled_finite li =
+    let rec loop acc = function
+      | [] -> acc
+      | h :: t -> loop (just h ++ pay acc) t
+    in
+    match li with [] -> empty | h :: t -> loop (just h) t
+
+  let unops : unop enum = scaled_finite [ NEG; BNOT; NOT ]
+
+  let iterated (op : 'a -> 'a -> 'a) (li : 'a list) : 'a =
+    let rec double_add acc = function
+      | [] -> acc
+      | [ x ] -> x :: acc
+      | x1 :: x2 :: t -> double_add (op x1 x2 :: acc) t
+    in
+    let rec iterated = function
+      | [] -> raise (Invalid_argument "iterated op")
+      | [ x ] -> x
+      | _ :: _ :: _ as li -> double_add [] li |> iterated
+    in
+    iterated li
+
+  let oneof li = iterated sum li
+  let option e = just None ++ pay (map Option.some e)
+  let tuple3 x y z = x ** y ** z |> map (fun (x, (y, z)) -> (x, y, z))
+  let nonempty_list x = x ** list x |> map (fun (x, li) -> x :: li)
+
+  let binops : binop enum =
+    [
+      (if C.Syntax.plus then Some PLUS else None);
+      (if C.Syntax.and_ then Some AND else None);
+      (if C.Syntax.band then Some BAND else None);
+      (if C.Syntax.beq then Some BEQ else None);
+      (if C.Syntax.bor then Some BOR else None);
+      (if C.Syntax.div then Some DIV else None);
+      (if C.Syntax.eor then Some EOR else None);
+      (if C.Syntax.eq_op then Some EQ_OP else None);
+      (if C.Syntax.gt then Some GT else None);
+      (if C.Syntax.geq then Some GEQ else None);
+      (if C.Syntax.impl then Some IMPL else None);
+      (if C.Syntax.lt then Some LT else None);
+      (if C.Syntax.leq then Some LEQ else None);
+      (if C.Syntax.mod_ then Some MOD else None);
+      (if C.Syntax.minus then Some MINUS else None);
+      (if C.Syntax.mul then Some MUL else None);
+      (if C.Syntax.neq then Some NEQ else None);
+      (if C.Syntax.or_ then Some OR else None);
+      (if C.Syntax.rdiv then Some RDIV else None);
+      (if C.Syntax.shl then Some SHL else None);
+      (if C.Syntax.shr then Some SHR else None);
+    ]
+    |> filter_none |> scaled_finite
+
+  let ints : int enum = fun i -> IFSeq.up (~-i + 1) i
+  let uints : int enum = fun i -> IFSeq.up 0 i
+  let nuints : int enum = fun i -> if i > 0 then IFSeq.up 1 i else IFSeq.empty
+
+  let literals : literal enum =
+    let l_ints = map (fun i -> L_Int (Z.of_int i)) ints
+    and l_bools = finite [ L_Bool true; L_Bool false ]
+    and l_reals = map (fun (i, j) -> L_Real Q.(i // j)) (uints ** nuints)
+    and l_bvs =
+      map
+        (fun s -> L_BitVector (Bitvector.of_string ("'" ^ s ^ "'")))
+        (fix (fun ss -> just "" ++ map (( ^ ) "0") ss ++ map (( ^ ) "1") ss))
+    and l_strings =
+      finite [ L_String "This is a string"; L_String "This is another string" ]
+    in
+    [
+      (if C.Syntax.l_int then Some l_ints else None);
+      (if C.Syntax.l_bool then Some l_bools else None);
+      (if C.Syntax.l_real then Some l_reals else None);
+      (if C.Syntax.l_bitvector then Some l_bvs else None);
+      (if C.Syntax.l_string then Some l_strings else None);
+    ]
+    |> filter_none |> oneof
+
+  let _make_vari i = "x" ^ string_of_int i
+  let vars : identifier enum = finite [ "x"; "y" ] ++ pay (map _make_vari uints)
+  let char_names = '_' :: List.init 26 Char.(fun i -> i + code 'a' |> chr)
+  let list1 enum = enum ** list enum |> map (fun (x, xs) -> x :: xs) |> pay
+
+  let list2 enum =
+    (enum ** enum) ** list enum
+    |> map (fun ((x, y), xs) -> x :: y :: xs)
+    |> pay |> pay
+
+  let names : identifier enum =
+    let make li = li |> List.to_seq |> String.of_seq in
+    list1 (scaled_finite char_names) |> map make
+
+  let non_rec_ty =
+    let t_string = just T_String
+    and t_bool = just T_Bool
+    and t_real = just T_Real in
+    oneof [ t_string; t_bool; t_real ]
+
+  let t_named s = T_Named s |> annot
+
+  let slices exprs : slice list enum =
+    let slice_single =
+      let make_slice_single e = Slice_Single e in
+      exprs |> map make_slice_single
+    and slice_range =
+      let make_slice_range (e1, e2) = Slice_Range (e1, e2) in
+      exprs ** exprs |> map make_slice_range
+    and slice_length =
+      let make_slice_length (e1, e2) = Slice_Length (e1, e2) in
+      exprs ** exprs |> map make_slice_length
+    and slice_star =
+      let make_slice_star (e1, e2) = Slice_Star (e1, e2) in
+      exprs ** exprs |> map make_slice_star
+    in
+    [
+      (if C.Syntax.slice_single then Some slice_single else None);
+      (if C.Syntax.slice_range then Some slice_range else None);
+      (if C.Syntax.slice_length then Some slice_length else None);
+      (if C.Syntax.slice_star then Some slice_star else None);
+    ]
+    |> filter_none |> oneof |> list1
+
+  let exprs : expr enum =
+    fix @@ fun exprs ->
+    let e_unops =
+      let make_unop (op, expr) = E_Unop (op, expr) in
+      unops ** exprs |> map make_unop
+    and e_ctc =
+      let make_e_ctc (e, s) = E_CTC (e, t_named s) in
+      exprs ** names |> map make_e_ctc
+    and e_binops =
+      let make_binop (op, (e1, e2)) = E_Binop (op, e1, e2) in
+      binops ** exprs ** exprs |> map make_binop
+    and e_literals =
+      let make_literal v = E_Literal v in
+      literals |> map make_literal
+    and e_vars =
+      let make_var s = E_Var s in
+      vars |> map make_var
+    and e_conds =
+      let make_cond (e1, (e2, e3)) = E_Cond (e1, e2, e3) in
+      exprs ** exprs ** exprs |> map make_cond
+    and e_slices =
+      let make_slices (e, slices) = E_Slice (e, slices) in
+      exprs ** slices exprs |> map make_slices
+    and e_call =
+      let make_e_call (name, args) = E_Call (name, args, []) in
+      names ** list exprs |> map make_e_call
+    and e_get_array =
+      let make_e_get_array (e1, e2) = E_GetArray (e1, e2) in
+      exprs ** exprs |> map make_e_get_array
+    and e_get_field =
+      let make_e_get_field (e, name) = E_GetField (e, name) in
+      exprs ** names |> map make_e_get_field
+    and e_get_fields =
+      let make_e_get_fields (e, names) = E_GetFields (e, names) in
+      exprs ** list2 names |> map make_e_get_fields
+    and e_record =
+      let make_record (name, fields) = E_Record (t_named name, fields) in
+      names ** list (names ** exprs) |> map make_record
+    and e_concat =
+      let make_concat es = E_Concat es in
+      list1 exprs |> map make_concat
+    and e_tuple =
+      let make_tuple es = E_Tuple es in
+      list2 exprs |> map make_tuple
+    and e_unknown =
+      let make_unknown name = E_Unknown (t_named name) in
+      names |> map make_unknown
+    and e_pattern = empty (* TODO *) in
+    [
+      (if C.Syntax.e_unop then Some e_unops else None);
+      (if C.Syntax.e_binop then Some e_binops else None);
+      (if C.Syntax.e_literal then Some e_literals else None);
+      (if C.Syntax.e_var then Some e_vars else None);
+      (if C.Syntax.e_cond then Some e_conds else None);
+      (if C.Syntax.e_slice then Some e_slices else None);
+      (if C.Syntax.e_ctc then Some e_ctc else None);
+      (if C.Syntax.e_call then Some e_call else None);
+      (if C.Syntax.e_getarray then Some e_get_array else None);
+      (if C.Syntax.e_getfield then Some e_get_field else None);
+      (if C.Syntax.e_getfields then Some e_get_fields else None);
+      (if C.Syntax.e_record then Some e_record else None);
+      (if C.Syntax.e_concat then Some e_concat else None);
+      (if C.Syntax.e_tuple then Some e_tuple else None);
+      (if C.Syntax.e_unknown then Some e_unknown else None);
+      (if C.Syntax.e_pattern then Some e_pattern else None);
+    ]
+    |> filter_none |> oneof |> map annot
+
+  let slices = slices exprs
+
+  let tys =
+    fix @@ fun tys ->
+    let t_string = just T_String
+    and t_bool = just T_Bool
+    and t_real = just T_Real
+    and t_integer =
+      let make_t_integer cs = T_Int (WellConstrained cs) in
+      let cntt_range =
+        let make_cntt_range (e1, e2) = Constraint_Range (e1, e2) in
+        exprs ** exprs |> map make_cntt_range
+      and cntt_single =
+        let make_cntt_single e = Constraint_Exact e in
+        exprs |> map make_cntt_single
+      in
+      just (T_Int UnConstrained)
+      ++ (list1 (cntt_range ++ cntt_single) |> map make_t_integer)
+    and t_tuple =
+      let make_t_tuple li = T_Tuple li in
+      list2 tys |> map make_t_tuple
+    and t_record =
+      let make_t_record li = T_Record li in
+      names ** tys |> list |> map make_t_record
+    and t_bits =
+      let make_t_bits e = T_Bits (e, []) in
+      exprs |> map make_t_bits |> pay
+    and t_enum =
+      let make_t_enum ss = T_Enum ss in
+      nonempty_list names |> map make_t_enum
+    and t_named =
+      let make_t_named s = T_Named s in
+      names |> map make_t_named
+    in
+    [
+      (if C.Syntax.t_int then Some t_integer else None);
+      (if C.Syntax.t_string then Some t_string else None);
+      (if C.Syntax.t_bool then Some t_bool else None);
+      (if C.Syntax.t_real then Some t_real else None);
+      (if C.Syntax.t_bits then Some t_bits else None);
+      (if C.Syntax.t_tuple then Some t_tuple else None);
+      (if C.Syntax.t_record then Some t_record else None);
+      (if C.Syntax.t_named then Some t_named else None);
+      (if C.Syntax.t_enum then Some t_enum else None);
+    ]
+    |> filter_none |> oneof |> map annot
+
+  let lexprs : lexpr enum =
+    fix @@ fun lexprs ->
+    let le_vars =
+      let make_var s = LE_Var s in
+      vars |> map make_var
+    and le_ignore = just LE_Discard
+    and le_concat =
+      let make_le_concat les = LE_Concat (les, None) in
+      list1 lexprs |> map make_le_concat
+    and le_fields =
+      let make_le_field (le, s) = LE_SetFields (le, s) in
+      lexprs ** list2 names |> map make_le_field
+    and le_field =
+      let make_le_field (le, s) = LE_SetField (le, s) in
+      lexprs ** names |> map make_le_field
+    and le_destructuring =
+      let make_destructuring les = LE_Destructuring les in
+      list2 lexprs |> map make_destructuring
+    and le_set_array =
+      let make_le_set_array (le, e) = LE_SetArray (le, e) in
+      lexprs ** exprs |> map make_le_set_array
+    and le_slices =
+      let make_le_slices (le, slices) = LE_Slice (le, slices) in
+      lexprs ** slices |> map make_le_slices
+    in
+    [
+      (if C.Syntax.le_var then Some le_vars else None);
+      (if C.Syntax.le_discard then Some le_ignore else None);
+      (if C.Syntax.le_concat then Some le_concat else None);
+      (if C.Syntax.le_setfield then Some le_field else None);
+      (if C.Syntax.le_setfields then Some le_fields else None);
+      (if C.Syntax.le_destructuring then Some le_destructuring else None);
+      (if C.Syntax.le_setarray then Some le_set_array else None);
+      (if C.Syntax.le_slice then Some le_slices else None);
+    ]
+    |> filter_none |> oneof |> map annot
+
+  let ldks = scaled_finite [ LDK_Constant; LDK_Var; LDK_Let ]
+
+  let ldis =
+    fix @@ fun ldis ->
+    let ldi_discard = just LDI_Discard
+    and ldi_var =
+      let make_ldi_var s = LDI_Var s in
+      vars |> map make_ldi_var
+    and ldi_tuple =
+      let make_ldi_tuple ldis = LDI_Tuple ldis in
+      list2 ldis |> map make_ldi_tuple
+    and ldi_typed =
+      let make_ldi_typed (ldi, ty) = LDI_Typed (ldi, ty) in
+      ldis ** tys |> map make_ldi_typed
+    in
+    [
+      (if C.Syntax.ldi_discard then Some ldi_discard else None);
+      (if C.Syntax.ldi_var then Some ldi_var else None);
+      (if C.Syntax.ldi_typed then Some ldi_typed else None);
+      (if C.Syntax.ldi_tuple then Some ldi_tuple else None);
+    ]
+    |> filter_none |> oneof
+
+  let stmt_lists (stmts : stmt enum) : stmt enum =
+    list stmts |> map ASTUtils.stmt_from_list
+
+  let _make_mains_of_stmts =
+    let make_main stmt =
+      let name = "main"
+      and args = []
+      and parameters = []
+      and subprogram_type = ST_Function
+      and body = SB_ASL stmt
+      and return_type = Some ASTUtils.integer in
+      [
+        D_Func { body; name; args; parameters; return_type; subprogram_type }
+        |> annot;
+      ]
+    in
+    map make_main
+
+  let stmts : stmt enum =
+    fix @@ fun stmts ->
+    let block = stmt_lists stmts in
+    let s_assigns =
+      let make_assign (le, e) = S_Assign (le, e, V1) in
+      lexprs ** exprs |> map make_assign
+    and s_conds =
+      let make_cond (e, (s1, s2)) = S_Cond (e, s1, s2) in
+      exprs ** block ** block |> map make_cond
+    and s_assert =
+      let make_assert e = S_Assert e in
+      exprs |> map make_assert
+    and s_call =
+      let make_s_call (name, args) = S_Call (name, args, []) in
+      names ** list exprs |> map make_s_call
+    and s_return =
+      let make_s_return expr = S_Return expr in
+      option exprs |> map make_s_return
+    and s_decl =
+      let make_s_decl (ldk, (ldi, expr_opt)) = S_Decl (ldk, ldi, expr_opt) in
+      ldks ** ldis ** option exprs |> map make_s_decl
+    and s_for =
+      let make_s_for (name, (e1, (d, (e2, s)))) = S_For (name, e1, d, e2, s) in
+      names ** exprs ** finite [ Up; Down ] ** exprs ** block |> map make_s_for
+    and s_while =
+      let make_s_while (e, s) = S_While (e, s) in
+      exprs ** block |> map make_s_while |> pay
+    and s_repeat =
+      let make_s_repeat (s, e) = S_Repeat (s, e) in
+      block ** exprs |> map make_s_repeat |> pay
+    and s_throw =
+      let make_s_throw opt = S_Throw opt in
+      option (exprs ** option tys) |> map make_s_throw |> pay
+    and s_try =
+      let make_s_try (s, (catchers, s_opt)) = S_Try (s, catchers, s_opt) in
+      let catcher = tuple3 (option names) tys block in
+      block ** list catcher ** option block |> map make_s_try |> pay
+    in
+    [
+      (if C.Syntax.s_assign then Some s_assigns else None);
+      (if C.Syntax.s_cond then Some s_conds else None);
+      (if C.Syntax.s_call then Some s_call else None);
+      (if C.Syntax.s_assert then Some s_assert else None);
+      (if C.Syntax.s_return then Some s_return else None);
+      (if C.Syntax.s_decl then Some s_decl else None);
+      (if C.Syntax.s_for then Some s_for else None);
+      (if C.Syntax.s_while then Some s_while else None);
+      (if C.Syntax.s_repeat then Some s_repeat else None);
+      (if C.Syntax.s_throw then Some s_throw else None);
+      (if C.Syntax.s_try then Some s_try else None);
+    ]
+    |> filter_none |> oneof |> map annot
+
+  let mains : AST.t enum = _make_mains_of_stmts (stmt_lists stmts)
+
+  let no_double_none a b =
+    let a = pay (map Option.some a) and b = pay (map Option.some b) in
+    (a ** b) ++ (a ** just None) ++ (just None ** b)
+
+  let gdks = scaled_finite [ GDK_Config; GDK_Let; GDK_Constant; GDK_Var ]
+
+  let decls =
+    let d_func =
+      let make_func (name, (body, (return_type, (args, subprogram_type)))) =
+        let parameters = [] and body = SB_ASL body in
+        D_Func { name; parameters; args; body; return_type; subprogram_type }
+      in
+      let args = vars ** tys in
+      let subpgm_types =
+        let setters = nonempty_list args ** just ST_Setter in
+        let with_args typ = list args ** just typ in
+        [
+          payn 3 setters;
+          payn 2 (with_args ST_Getter);
+          pay (with_args ST_Procedure);
+          with_args ST_Function;
+        ]
+        |> oneof
+      in
+      names ** stmt_lists stmts ** option tys ** subpgm_types |> map make_func
+    and d_global_storage =
+      let make_global_decl (keyword, (name, (ty, initial_value))) =
+        D_GlobalStorage { keyword; name; ty; initial_value }
+      in
+      gdks ** vars ** no_double_none tys exprs |> map make_global_decl
+    and d_type_decl =
+      let make_type_decl (name, ty) = D_TypeDecl (name, ty, None) in
+      names ** tys |> map make_type_decl
+    in
+    d_func ++ d_global_storage ++ d_type_decl |> map annot
+
+  let asts = list decls
+end

--- a/asllib/carpenter/BInterp.ml
+++ b/asllib/carpenter/BInterp.ml
@@ -1,0 +1,204 @@
+(****************************************************************************************************************)
+(*  SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>  *)
+(*  SPDX-License-Identifier: BSD-3-Clause                                                                       *)
+(****************************************************************************************************************)
+
+type binterp_interface = {
+  binterp_in : out_channel;
+  binterp_out : in_channel;
+  base_pickled : string;
+  pid : int;
+}
+
+(* Triggers character level stderr logging - to use with caution. *)
+let _dbg = false
+
+let _log_src =
+  Logs.Src.create ~doc:"BInterp Ex Runner for carpenter" "carpenter.binterp"
+
+let debug logs = Logs.debug ~src:_log_src logs
+let info logs = Logs.info ~src:_log_src logs
+
+let exception_regex =
+  Re.compile
+    Re.(
+      seq
+        [
+          bol;
+          alt
+            [
+              str "Syntax error"; str "Exception"; seq [ rep any; str "error" ];
+            ];
+          rep space;
+          rep any;
+          stop;
+        ])
+
+let parse_output output_std =
+  match Re.Seq.matches exception_regex output_std () with
+  | Seq.Nil ->
+      debug (fun m -> m "Output did not match regex.");
+      Ok ()
+  | Seq.Cons (h, _) ->
+      debug (fun m -> m "Output matched regex.");
+      Error h
+
+let until_prompt =
+  let rec loop iter in_channel =
+    match input_char in_channel with
+    | '\n' -> on_new_line iter in_channel
+    | c ->
+        iter c;
+        loop iter in_channel
+  and on_new_line iter in_channel =
+    match input_char in_channel with
+    | '>' -> on_chevron iter in_channel
+    | c ->
+        iter '\n';
+        iter c;
+        loop iter in_channel
+  and on_chevron iter in_channel =
+    match input_char in_channel with
+    | ' ' -> ()
+    | c ->
+        iter '\n';
+        iter '>';
+        iter c;
+        loop iter in_channel
+  and entry_point iter in_channel =
+    match input_char in_channel with
+    | '>' -> on_chevron iter in_channel
+    | c ->
+        iter c;
+        loop iter in_channel
+  in
+  fun iter in_channel ->
+    if _dbg then Printf.eprintf "Waiting for prompt ...\n%!";
+    try entry_point iter in_channel with End_of_file -> ()
+
+let get_until_prompt state =
+  if _dbg then Printf.eprintf "Getting output: \"%!";
+  let buf = Buffer.create 16 in
+  let iter c = Buffer.add_char buf c in
+  let iter =
+    if _dbg then (fun c ->
+      Printf.eprintf "%c%!" c;
+      iter c)
+    else iter
+  in
+  until_prompt iter state.binterp_out;
+  if _dbg then Printf.eprintf "\".\n%!";
+  Buffer.contents buf
+
+let ignore_until_prompt state =
+  if _dbg then Printf.eprintf "Ignoring output: \"%!";
+  let iter = if _dbg then fun c -> Printf.eprintf "%c%!" c else fun _c -> () in
+  until_prompt iter state.binterp_out;
+  if _dbg then Printf.eprintf "\".\n%!"
+
+let run_command state cmd =
+  debug (fun m -> m "Running command %S" cmd);
+  let oc = state.binterp_in in
+  output_string oc cmd;
+  output_char oc '\n';
+  flush oc;
+  ()
+
+let run_command_and_ignore state cmd =
+  run_command state cmd;
+  ignore_until_prompt state;
+  ()
+
+let run_command_and_get_output state cmd =
+  run_command state cmd;
+  let output = get_until_prompt state in
+  debug (fun m -> m "Got output from command: %S." output);
+  output
+
+let run_commands_and_ignore state cmds =
+  List.iter (run_command_and_ignore state) cmds
+
+let prepare_binterp_state state =
+  info (fun m -> m "Start preparing BInterp initial state.");
+  ignore_until_prompt state;
+  run_commands_and_ignore state
+    [ ":set asl=1.0"; ":pickle " ^ state.base_pickled ];
+  info (fun m -> m "Finished preparing BInterp initial state.");
+  ()
+
+let reset_binterp_state state =
+  debug (fun m -> m "Start resetting BInterp state.");
+  run_commands_and_ignore state [ ":reset"; ":unpickle " ^ state.base_pickled ];
+  debug (fun m -> m "Finished resetting BInterp state.");
+  ()
+
+let quit_binterp state () =
+  info (fun m -> m "Start quitting BInterp.");
+  debug (fun m -> m "Removing %s" state.base_pickled);
+  Sys.remove state.base_pickled;
+  run_command state ":quit";
+  debug (fun m -> m "Waiting for BInterp to quit.");
+  let _pid', _status = UnixLabels.waitpid ~mode:[] state.pid in
+  debug (fun m -> m "BInterp quitted. Removing pipes.");
+  close_out state.binterp_in;
+  close_in state.binterp_out;
+  info (fun m -> m "BInterp quitted.");
+  ()
+
+let create_binterp binterp_path =
+  info (fun m -> m "Spawning new BInterp thread from %s." binterp_path);
+  let base_pickled = Filename.temp_file "binterp-base-state" ".tmp" in
+  debug (fun m -> m "BInterp initial state will be pickled at %s." base_pickled);
+  let open UnixLabels in
+  let stdin, binterp_in =
+    let i, o = pipe () in
+    (i, out_channel_of_descr o)
+  and stdout, stderr, binterp_out =
+    let i, o = pipe () in
+    (o, dup o, in_channel_of_descr i)
+  and prog = binterp_path
+  and args = [||] in
+  let pid = create_process ~prog ~args ~stdin ~stdout ~stderr in
+  info (fun m -> m "BInterp process spawned.");
+  debug (fun m -> m "BInterp thread spawned with PID %d." pid);
+  { binterp_out; binterp_in; base_pickled; pid }
+
+let with_binterp binterp_path f =
+  let state = create_binterp binterp_path in
+  Fun.protect ~finally:(quit_binterp state) @@ fun () ->
+  prepare_binterp_state state;
+  f state
+
+let run_one state type_only asl_file =
+  debug (fun m -> m "BInterp loading file at %s." asl_file);
+  let output = run_command_and_get_output state (":load " ^ asl_file) in
+  let parsed_output = parse_output output in
+  match (type_only, parsed_output) with
+  | true, _ | _, Error _ ->
+      debug (fun m ->
+          if type_only then m "BInterp loaded file."
+          else
+            m
+              "Error while type-checking. BInterp runner will not execute this \
+               file.");
+      reset_binterp_state state;
+      parsed_output
+  | false, Ok () ->
+      debug (fun m -> m "File type-checked successfully, running it.");
+      let output =
+        run_command_and_get_output state
+          "assert main () == 0; print(\"\\\\n\");"
+      in
+      debug (fun m -> m "File ran.");
+      reset_binterp_state state;
+      parse_output output
+
+let run_one_ast state type_only ast =
+  let asl_file, out = Filename.open_temp_file "gen-ast" ".asl" in
+  debug (fun m -> m "Writing ast at %s" asl_file);
+  let fmt = Format.formatter_of_out_channel out in
+  Asllib.PP.pp_t fmt ast;
+  Format.pp_print_flush fmt ();
+  close_out out;
+  debug (fun m -> m "Done.");
+  run_one state type_only asl_file

--- a/asllib/carpenter/README.md
+++ b/asllib/carpenter/README.md
@@ -1,0 +1,56 @@
+# ASL Carpenter
+
+Carpenter is an AST generator for ASL, working in two different modes:
+
+1. Enumeration of all ASTs by increasing size;
+2. Random generation of ASTs following type-checking constraints.
+
+Both modes support constraints on syntax nodes available, and on execution or
+type-checking rules used by ASLRef to execute it.
+
+It can also serve as a fuzzing tool, or a mass execution tool.
+
+## Installation
+
+Dependencies:
+```bash
+opam install dune menhir qcheck zarith re feat fix cmdliner logs
+```
+
+Then:
+```bash
+dune build asllib/carpenter
+```
+
+## Usage
+
+See `dune exec carpenter -- --help` for a detailed view of options.
+
+Generating 10 tests and writing them in the `tmp` directory (which is supposed
+to exist):
+```bash
+dune exec carpenter -- generate random -o tmp --small 10
+```
+
+Executing them:
+```bash
+dune exec carpenter -- execute $(find tmp -name "$(date +"%Y-%m-%dT%H")*.asl")
+```
+This should print a list of results for each file, for example:
+```
+// results for file: tmp/2024-03-19T10:51:29-0000.asl
+Error: ASL Error: Mismatched use of return value from call to 'main'
+// end of results for file: tmp/2024-03-19T10:51:29-0000.asl
+
+...
+```
+
+Fuzzing ASLRef on itself on 1000 tests:
+```bash
+dune exec carpenter -- fuzz enum -o tmp 1000
+```
+If this does not print anything and returns with a normal exit code, everything
+is fine; otherwise, you've found a bug in carpenter or in ASLRef!
+
+
+

--- a/asllib/carpenter/RandomAST.ml
+++ b/asllib/carpenter/RandomAST.ml
@@ -1,0 +1,1030 @@
+(****************************************************************************************************************)
+(*  SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>  *)
+(*  SPDX-License-Identifier: BSD-3-Clause                                                                       *)
+(****************************************************************************************************************)
+
+open Asllib
+open AST
+open ASTUtils
+open QCheck2.Gen
+
+let _dbg = false
+let annot desc = ASTUtils.add_dummy_pos desc
+
+type 'a gen = 'a QCheck2.Gen.t
+type 'a sgen = 'a QCheck2.Gen.sized
+type env = StaticEnv.env
+
+let filter li = List.filter_map Fun.id li
+let filter_oneof li = filter li |> oneof
+let filter_oneofl li = filter li |> oneofl
+let protected_oneofl = function [] -> None | li -> Some (oneofl li)
+let protected_oneof = function [] -> None | li -> Some (oneof li)
+let protected_filter_oneofl li = filter li |> protected_oneofl
+let protected_filter_oneof li = filter li |> protected_oneof
+let names = string_size ~gen:(char_range 'a' 'z') (1 -- 20)
+let pay n = if n <= 0 then 0 else n - 1
+
+let rec ensure_satisfies p t =
+  let* v = t in
+  if p v then return v else ensure_satisfies p t
+
+let bind f t = t >>= f
+let mapo f t = Option.map (map f) t
+let ( >|== ) t f = mapo f t
+let ( let** ) t f = Option.map (bind f) t
+
+module Untyped (C : Config.S) = struct
+  let unop : unop gen option =
+    [
+      (if C.Syntax.neg then Some NEG else None);
+      (if C.Syntax.not then Some NOT else None);
+      (if C.Syntax.bnot then Some BNOT else None);
+    ]
+    |> protected_filter_oneofl
+
+  let binop : binop gen option =
+    [
+      (if C.Syntax.plus then Some PLUS else None);
+      (if C.Syntax.and_ then Some AND else None);
+      (if C.Syntax.band then Some BAND else None);
+      (if C.Syntax.beq then Some BEQ else None);
+      (if C.Syntax.bor then Some BOR else None);
+      (if C.Syntax.div then Some DIV else None);
+      (if C.Syntax.divrm then Some DIVRM else None);
+      (if C.Syntax.eor then Some EOR else None);
+      (if C.Syntax.eq_op then Some EQ_OP else None);
+      (if C.Syntax.gt then Some GT else None);
+      (if C.Syntax.geq then Some GEQ else None);
+      (if C.Syntax.impl then Some IMPL else None);
+      (if C.Syntax.lt then Some LT else None);
+      (if C.Syntax.leq then Some LEQ else None);
+      (if C.Syntax.mod_ then Some MOD else None);
+      (if C.Syntax.minus then Some MINUS else None);
+      (if C.Syntax.mul then Some MUL else None);
+      (if C.Syntax.neq then Some NEQ else None);
+      (if C.Syntax.or_ then Some OR else None);
+      (if C.Syntax.pow then Some POW else None);
+      (if C.Syntax.rdiv then Some RDIV else None);
+      (if C.Syntax.shl then Some SHL else None);
+      (if C.Syntax.shr then Some SHR else None);
+    ]
+    |> protected_filter_oneofl
+
+  let literal : literal gen option =
+    let l_int = small_nat >|= fun i -> L_Int (Z.of_int i)
+    and l_bool = bool >|= fun b -> L_Bool b
+    and l_real = float >|= fun r -> L_Real (Q.of_float r)
+    and l_bv =
+      let bit = oneofa [| '0'; '1' |] in
+      string_of bit >|= fun s ->
+      L_BitVector (Bitvector.of_string ("'" ^ s ^ "'"))
+    and l_string = string_small_of printable >|= fun s -> L_String s in
+    [
+      (if C.Syntax.l_int then Some l_int else None);
+      (if C.Syntax.l_bool then Some l_bool else None);
+      (if C.Syntax.l_bitvector then Some l_bv else None);
+      (if C.Syntax.l_real then Some l_real else None);
+      (if C.Syntax.l_string then Some l_string else None);
+    ]
+    |> protected_filter_oneof
+
+  let ty_basic =
+    let t_bool = T_Bool |> annot |> pure
+    and t_integer = T_Int UnConstrained |> annot |> pure
+    and t_real = T_Real |> annot |> pure
+    and t_string = T_String |> annot |> pure
+    and t_named =
+      let+ name = names in
+      T_Named name |> annot
+    in
+    [
+      (if C.Syntax.t_bool then Some t_bool else None);
+      (if C.Syntax.t_int then Some t_integer else None);
+      (if C.Syntax.t_real then Some t_real else None);
+      (if C.Syntax.t_named then Some t_named else None);
+      (if C.Syntax.t_string then Some t_string else None);
+    ]
+    |> protected_filter_oneof
+
+  let slices expr =
+    let slice_single n =
+      let+ e = expr n in
+      Slice_Single e
+    and slice_range n =
+      let* n1, n2 = Nat.split2 n in
+      let+ e1 = expr n1 and+ e2 = expr n2 in
+      Slice_Range (e1, e2)
+    and slice_length n =
+      let* n1, n2 = Nat.split2 n in
+      let+ e1 = expr n1 and+ e2 = expr n2 in
+      Slice_Length (e1, e2)
+    and slice_star n =
+      let* n1, n2 = Nat.split2 n in
+      let+ e1 = expr n1 and+ e2 = expr n2 in
+      Slice_Star (e1, e2)
+    in
+    let slice n =
+      [
+        (if C.Syntax.slice_single then Some (slice_single n) else None);
+        (if C.Syntax.slice_range then Some (slice_range n) else None);
+        (if C.Syntax.slice_length then Some (slice_length n) else None);
+        (if C.Syntax.slice_star then Some (slice_star n) else None);
+      ]
+      |> filter_oneof
+    in
+    fun n ->
+      if n >= 1 then Nat.list_sized slice (n - 1)
+      else slice_single n >|= fun x -> [ x ]
+
+  let expr : expr sgen =
+    let e_literal = literal >|== fun l -> E_Literal l |> annot in
+    let e_var = names >|= fun s -> E_Var s |> annot in
+    let e_tuple expr n = Nat.list_sized expr n >|= fun li -> E_Tuple li |> annot
+    and e_binop expr n =
+      let** op = binop in
+      let* n1, n2 = Nat.split2 n in
+      let+ e1 = expr n1 and+ e2 = expr n2 in
+      E_Binop (op, e1, e2) |> annot
+    and e_unop expr n =
+      let** op = unop in
+      let+ e = expr n in
+      E_Unop (op, e) |> annot
+    and e_cond expr n =
+      let* n1, n2, n3 = Nat.split3 n in
+      let+ e1 = expr n1 and+ e2 = expr n2 and+ e3 = expr n3 in
+      E_Cond (e1, e2, e3) |> annot
+    and e_slice expr n =
+      let* n1, n2 = Nat.split2 n in
+      let+ e = expr n1 and+ slices = slices expr n2 in
+      E_Slice (e, slices) |> annot
+    in
+    fix @@ fun expr n ->
+    let n = pay n in
+    [
+      (if C.Syntax.e_literal then e_literal else None);
+      (if C.Syntax.e_var then Some e_var else None);
+      (if C.Syntax.e_unop && n >= 0 then e_unop expr n else None);
+      (if C.Syntax.e_binop && n >= 2 then e_binop expr n else None);
+      (if C.Syntax.e_tuple && n >= 2 then Some (e_tuple expr n) else None);
+      (if C.Syntax.e_cond && n >= 3 then Some (e_cond expr n) else None);
+      (if C.Syntax.e_slice && n >= 1 then Some (e_slice expr n) else None);
+    ]
+    |> filter
+    |> function
+    | [] -> failwith "cannot construct expressions"
+    | li -> oneof li
+
+  let slices n = slices expr n
+
+  let ctnt : int_constraint sgen option =
+    let exact n =
+      let+ e = expr n in
+      Constraint_Exact e
+    and range n =
+      let* n1, n2 = Nat.split2 n in
+      let+ e1 = expr n1 and+ e2 = expr n2 in
+      Constraint_Range (e1, e2)
+    in
+    [
+      (if C.Syntax.constraint_exact then Some exact else None);
+      (if C.Syntax.constraint_range then Some range else None);
+    ]
+    |> filter
+    |> function
+    | [] -> None
+    | li ->
+        Some
+          (fun n ->
+            let n = pay n in
+            List.map (fun sgen -> sgen n) li |> oneof)
+
+  let ty : ty sgen =
+    let field ty n = pair names (ty n) in
+    let fields ty n = Nat.list_sized (field ty) n in
+    let t_tuple ty n =
+      let+ li = Nat.list_sized ty n in
+      T_Tuple li |> annot
+    and t_record ty n =
+      let+ li = fields ty n in
+      T_Record li |> annot
+    and t_exception ty n =
+      let+ li = fields ty n in
+      T_Exception li |> annot
+    and t_enum n =
+      let+ names = list_repeat n names in
+      T_Enum names |> annot
+    and t_int n =
+      Fun.flip Option.map ctnt @@ fun ctnt ->
+      let+ ctnts = Nat.list_sized ctnt n in
+      T_Int (WellConstrained ctnts) |> annot
+    and t_bits n =
+      let+ width = expr n and+ bitfields = pure [] (* TODO *) in
+      T_Bits (width, bitfields) |> annot
+    in
+    fix @@ fun ty n ->
+    let n = pay n in
+    [
+      ty_basic;
+      (if C.Syntax.t_int && n >= 1 then t_int n else None);
+      (if C.Syntax.t_bits then Some (t_bits n) else None);
+      (if C.Syntax.t_record && n >= 2 then Some (t_record ty n) else None);
+      (if C.Syntax.t_enum && n >= 2 then Some (t_enum n) else None);
+      (if C.Syntax.t_tuple && n >= 2 then Some (t_tuple ty n) else None);
+      (if C.Syntax.t_exception && n >= 2 then Some (t_exception ty n) else None);
+    ]
+    |> function
+    | [] -> failwith "cannot construct types"
+    | li -> filter_oneof li
+
+  let ldi : local_decl_item sgen =
+    let ldi_ignore = return LDI_Discard
+    and ldi_var =
+      let+ name = names in
+      LDI_Var name
+    and ldi_typed ldis n =
+      let* n1, n2 = Nat.split2 n in
+      let+ ldi = ldis n1 and+ ty = ty n2 in
+      LDI_Typed (ldi, ty)
+    and ldi_tuple ldi n =
+      let+ li = Nat.list_sized ldi n in
+      LDI_Tuple li
+    in
+    fix @@ fun ldi n ->
+    let n = pay n in
+    [
+      (if C.Syntax.ldi_var then Some ldi_var else None);
+      (if C.Syntax.ldi_discard then Some ldi_ignore else None);
+      (if C.Syntax.ldi_typed then Some (ldi_typed ldi n) else None);
+      (if C.Syntax.ldi_tuple && n >= 2 then Some (ldi_tuple ldi n) else None);
+    ]
+    |> filter_oneof
+
+  let ldk = oneofa [| LDK_Var; LDK_Constant; LDK_Let |]
+
+  let lexpr : lexpr sgen =
+    let le_ignore = LE_Discard |> annot |> pure
+    and le_var = names >|= fun s -> LE_Var s |> annot
+    and le_set_field lexpr n =
+      let+ le = lexpr n and+ name = names in
+      LE_SetField (le, name) |> annot
+    and le_set_fields lexpr n =
+      let* n1, n2 = Nat.split2 n in
+      let+ le = lexpr n1 and+ names = list_repeat n2 names in
+      LE_SetFields (le, names) |> annot
+    and le_destructuring lexpr n =
+      let+ les = Nat.list_sized lexpr n in
+      LE_Destructuring les |> annot
+    and le_slice lexpr n =
+      let* n1, n2 = Nat.split2 n in
+      let+ le = lexpr n1 and+ slices = slices n2 in
+      LE_Slice (le, slices) |> annot
+    and le_setarray lexpr n =
+      let* n1, n2 = Nat.split2 n in
+      let+ le = lexpr n1 and+ e = expr n2 in
+      LE_SetArray (le, e) |> annot
+    in
+    fix @@ fun lexpr n ->
+    let n = pay n in
+    [
+      (if C.Syntax.le_discard then Some le_ignore else None);
+      (if C.Syntax.le_var then Some le_var else None);
+      (if C.Syntax.le_setfield then Some (le_set_field lexpr n) else None);
+      (if C.Syntax.le_setfields && n >= 2 then Some (le_set_fields lexpr n)
+       else None);
+      (if C.Syntax.le_destructuring && n >= 1 then
+         Some (le_destructuring lexpr n)
+       else None);
+      (if C.Syntax.le_slice && n >= 1 then Some (le_slice lexpr n) else None);
+      (if C.Syntax.le_setarray && n >= 1 then Some (le_setarray lexpr n)
+       else None);
+    ]
+    |> filter_oneof
+
+  let stmt : stmt sgen =
+    let s_block stmt n = Nat.list_sized stmt n >|= ASTUtils.stmt_from_list in
+    let s_cond stmt n =
+      let* n1, n2, n3 = Nat.split3 n in
+      let+ e1 = expr n1 and+ s2 = s_block stmt n2 and+ s3 = s_block stmt n3 in
+      S_Cond (e1, s2, s3) |> annot
+    in
+    let s_decl n =
+      let* n1, n2 = Nat.split2 n in
+      let+ e = expr n1 |> option and+ ldi = ldi n2 and+ ldk = ldk in
+      S_Decl (ldk, ldi, e) |> annot
+    in
+    let s_assert n =
+      let+ e = expr n in
+      S_Assert e |> annot
+    in
+    let s_assign n =
+      let* n1, n2 = Nat.split2 n in
+      let+ le = lexpr n1 and+ e = expr n2 in
+      S_Assign (le, e, V1) |> annot
+    in
+    fix @@ fun stmt n ->
+    let n = pay n in
+    [
+      (if C.Syntax.s_assert then Some (s_assert n) else None);
+      (if C.Syntax.s_cond && n >= 2 then Some (s_cond stmt n) else None);
+      (if C.Syntax.s_decl && n >= 3 then Some (s_decl n) else None);
+      (if C.Syntax.s_assign && n >= 2 then Some (s_assign n) else None);
+    ]
+    |> filter_oneof
+
+  let gdk = oneofa [| GDK_Constant; GDK_Config; GDK_Let; GDK_Var |]
+
+  let subprogram_type =
+    oneofa [| ST_Procedure; ST_Function; ST_Getter; ST_Setter |]
+
+  let decl : decl sgen =
+    let type_decl n =
+      let+ ty = ty n and+ name = names in
+      D_TypeDecl (name, ty, None) |> annot
+    and global_decl n =
+      let* n1, n2 = Nat.split2 n in
+      let+ name = names
+      and+ keyword = gdk
+      and+ ty = ty n1 |> option
+      and+ initial_value = expr n2 |> option in
+      D_GlobalStorage { name; keyword; ty; initial_value } |> annot
+    and func n =
+      let* n1, n2, n3 = Nat.split3 n in
+      let parameters = [] in
+      let+ name = names
+      and+ args = Nat.list_sized (fun n -> pair names (ty n)) n1
+      and+ body = stmt n2 >|= fun s -> SB_ASL s
+      and+ return_type = ty n3 |> option
+      and+ subprogram_type = subprogram_type in
+      D_Func { name; parameters; args; body; return_type; subprogram_type }
+      |> annot
+    in
+    fun n ->
+      [ type_decl n ]
+      |> (if n >= 2 then List.cons (global_decl n) else Fun.id)
+      |> (if n >= 3 then List.cons (func n) else Fun.id)
+      |> oneof
+
+  let ast : AST.t sgen = Nat.list_sized decl
+end
+
+module Typed (C : Config.S) = struct
+  module Untyped = Untyped (C)
+
+  let can_construct_literal env ty = Types.is_singular env ty
+  let add_with f acc elt = acc + f elt
+
+  let list_sum ?(init = 0) (f : 'a -> int) (li : 'a list) : int =
+    List.fold_left (add_with f) init li
+
+  let rec minimal_direct_fuel_ty env ty =
+    let () =
+      if _dbg && true then
+        Format.eprintf "Getting minimal_direct_fuel of %a@." PP.pp_ty ty
+    in
+    match (Types.make_anonymous env ty).desc with
+    | T_Int _ | T_Bool | T_Bits _ | T_Enum _ | T_Real | T_String -> 1
+    | T_Named _ -> assert false
+    | T_Array _ -> 1000000000
+    | T_Tuple li -> list_sum ~init:2 (minimal_direct_fuel_ty env) li
+    | T_Record fields | T_Exception fields ->
+        list_sum ~init:2 (fun (_, ty) -> minimal_direct_fuel_ty env ty) fields
+
+  let literal ty : literal gen =
+    match ty.desc with
+    | T_Named _ -> failwith "Not yet implemented: named types."
+    | T_Int _ -> small_nat >|= fun i -> L_Int (Z.of_int i)
+    | T_Bool -> bool >|= fun b -> L_Bool b
+    | T_Real -> float >|= fun r -> L_Real (Q.of_float (Float.abs r))
+    | T_String -> string_small_of printable >|= fun s -> L_String s
+    | T_Bits _ ->
+        let+ n = small_nat and+ i = nat in
+        L_BitVector (Bitvector.of_int_sized n i)
+    | _ -> failwith "Cannot construct a literal of this type"
+
+  let fresh_name env =
+    ensure_satisfies (fun s -> StaticEnv.is_undefined s env) names
+
+  let t_bits : ty gen =
+    let+ width = small_nat in
+    T_Bits (E_Literal (L_Int (Z.of_int width)) |> annot, []) |> annot
+
+  let slice expr env n : slice gen =
+    let n = pay n in
+    let* n1, n2 = Nat.split2 n in
+    let int n = expr (env, integer, n) in
+    [
+      (if C.Syntax.slice_single then Some (int n >|= fun e -> Slice_Single e)
+       else None);
+      (if C.Syntax.slice_range then
+         Some (pair (int n1) (int n2) >|= fun (e1, e2) -> Slice_Range (e1, e2))
+       else None);
+      (if C.Syntax.slice_range then
+         Some (pair (int n1) (int n2) >|= fun (e1, e2) -> Slice_Length (e1, e2))
+       else None);
+      (if C.Syntax.slice_range then
+         Some (pair (int n1) (int n2) >|= fun (e1, e2) -> Slice_Star (e1, e2))
+       else None);
+    ]
+    |> filter_oneof
+
+  let slices expr env = Nat.list_sized_non_empty (slice expr env)
+
+  let expr : env -> ty -> expr sgen =
+    let e_literal ty =
+      match ty.desc with
+      | T_Enum li -> oneofl li >|= fun s -> E_Var s |> annot
+      | _ -> literal ty >|= fun l -> E_Literal l |> annot
+    in
+    let e_var env ty =
+      let folder name (t, _) vars =
+        if Types.structural_subtype_satisfies env t ty then
+          (E_Var name |> annot) :: vars
+        else vars
+      in
+      []
+      |> ASTUtils.IMap.fold folder env.StaticEnv.local.storage_types
+      |> ASTUtils.IMap.fold folder env.StaticEnv.global.storage_types
+      |> protected_oneofl
+    in
+    let e_cond expr env ty n =
+      let min = minimal_direct_fuel_ty env ty in
+      if n <= min * 2 then None
+      else
+        Some
+          (let* n1 = min -- n in
+           let* n2 = min -- (n - min) in
+           let+ e1 = expr (env, ty, n1)
+           and+ e2 = expr (env, ty, n2)
+           and+ e_cond = expr (env, boolean, n - n1 - n2) in
+           E_Cond (e_cond, e1, e2) |> annot)
+    in
+    let e_ctc expr env ty ty_anon n =
+      match ty.desc with
+      | T_Int _ ->
+          Some
+            (let+ e' = expr (env, T_Int UnConstrained |> annot, n) in
+             E_CTC (e', ty) |> annot)
+      | T_Named _ when Types.is_singular env ty_anon ->
+          Some (expr (env, ty_anon, n - 1))
+      | _ -> None
+    in
+    let e_call expr env ty n =
+      let funcs =
+        ASTUtils.IMap.fold
+          (fun name func_sig funcs ->
+            match func_sig.return_type with
+            | Some t ->
+                if
+                  Types.structural_subtype_satisfies env t ty
+                  && List.length func_sig.args <= n
+                then (name, func_sig) :: funcs
+                else funcs
+            | _ -> funcs)
+          env.StaticEnv.global.subprograms []
+      in
+      let one_func (name, func_sig) =
+        let* arg_sizes = Nat.split ~size:(List.length func_sig.args) n in
+        let+ args =
+          List.map2 (fun (_, ty) n -> expr (env, ty, n)) func_sig.args arg_sizes
+          |> flatten_l
+        in
+        E_Call (name, args, []) |> annot
+      in
+      protected_oneofl funcs |> Option.map (bind one_func)
+    in
+    let can_construct_binop ty =
+      match ty.desc with
+      | T_Int _ | T_Real | T_Bits _ | T_Bool -> true
+      | _ -> false
+    in
+    let e_binop expr env ty n =
+      let* n1, n2 = Nat.split2 n in
+      let* op, t1, t2 =
+        match ty.desc with
+        | T_Int _ ->
+            [| PLUS; MINUS; MUL; DIV; DIVRM; MOD; SHL; SHR; POW |]
+            |> oneofa
+            |> map (fun op -> (op, integer, integer))
+        | T_Bool ->
+            [
+              [| BAND; BOR; BEQ; IMPL |] |> oneofa
+              |> map (fun op -> (op, boolean, boolean));
+              (let+ op = [| EQ_OP; NEQ |] |> oneofa
+               and+ t = [| integer; boolean; real |] |> oneofa in
+               (op, t, t));
+              (let+ op = [| LEQ; GEQ; GT; LT |] |> oneofa
+               and+ t = [| integer; real |] |> oneofa in
+               (op, t, t));
+            ]
+            |> oneof
+        | T_Real ->
+            [| PLUS; MINUS; MUL |] |> oneofa |> map (fun op -> (op, real, real))
+        | T_Bits _ ->
+            [
+              [| AND; OR; EOR |] |> oneofa |> map (fun op -> (op, ty, ty));
+              [| PLUS; MINUS |] |> oneofa |> map (fun op -> (op, ty, integer));
+            ]
+            |> oneof
+        | _ -> assert false
+      in
+      let+ e1 = expr (env, t1, n1) and+ e2 = expr (env, t2, n2) in
+      E_Binop (op, e1, e2) |> annot
+    in
+    let can_construct_unop ty =
+      match ty.desc with
+      | T_Int _ | T_Real | T_Bool | T_Bits _ -> true
+      | _ -> false
+    in
+    let e_unop expr env ty n =
+      let op =
+        match ty.desc with
+        | T_Int _ | T_Real -> NEG
+        | T_Bits _ -> NOT
+        | T_Bool -> BNOT
+        | _ -> assert false
+      in
+      expr (env, ty, n) >|= fun e -> E_Unop (op, e) |> annot
+    in
+    let e_tuple expr env ty n =
+      match ty.desc with
+      | T_Tuple li ->
+          let size = List.length li in
+          if size > n then None
+          else
+            Some
+              (let* sizes = Nat.split ~size n in
+               List.map2 (fun ty n -> expr (env, ty, n)) li sizes |> flatten_l
+               >|= fun li -> E_Tuple li |> annot)
+      | _ -> None
+    in
+    let e_record expr env ty fields n =
+      let* sizes = Nat.split ~size:(List.length fields) n in
+      List.map2
+        (fun (name, ty) n -> expr (env, ty, n) >|= fun e -> (name, e))
+        fields sizes
+      |> flatten_l
+      >|= fun fields -> E_Record (ty, fields) |> annot
+    in
+    let e_get_array = (* TODO *) None in
+    let e_get_fields = (* TODO *) None in
+    let e_pattern = (* TODO *) None in
+    let e_unknown ty = E_Unknown ty |> annot |> pure |> Option.some in
+    let is_bits ty = match ty.desc with T_Bits _ -> true | _ -> false in
+    let e_slices expr env n : expr gen =
+      let* n2 = 1 -- n in
+      let n1 = n - n2 in
+      let+ e' =
+        let* t = t_bits in
+        expr (env, t, n1)
+      and+ slices = slices expr env n2 in
+      E_Slice (e', slices) |> annot
+    in
+    let e_get_field expr env ty n : expr gen option =
+      let field_folder new_ty acc (field_name, field_ty) =
+        if Types.structural_subtype_satisfies env field_ty ty then
+          (let+ e' = expr (env, new_ty, n) in
+           E_GetField (e', field_name) |> annot)
+          :: acc
+        else acc
+      in
+      let type_folder name ty' acc : expr gen list =
+        let ty' = Types.make_anonymous env ty' in
+        match ty'.desc with
+        | T_Record fields | T_Exception fields ->
+            let new_ty = T_Named name |> annot in
+            if minimal_direct_fuel_ty env ty' <= n then
+              List.fold_left (field_folder new_ty) acc fields
+            else acc
+        | _ -> acc
+      in
+      IMap.fold type_folder env.StaticEnv.global.declared_types [] |> function
+      | [] -> None
+      | li -> Some (oneof li)
+    in
+    let e_concat expr env n : expr gen =
+      Nat.list_sized_non_empty (fun n -> t_bits >>= fun t -> expr (env, t, n)) n
+      >|= fun li -> E_Concat li |> annot
+    in
+    let expr' =
+      fix @@ fun expr (env, ty, n) ->
+      let () =
+        if _dbg then Printf.eprintf "Generating an expr of size %d\n%!" n
+      in
+      let n = pay n in
+      let ty_anon = Types.make_anonymous env ty in
+      [
+        (if C.Syntax.e_literal && can_construct_literal env ty_anon then
+           Some (e_literal ty_anon)
+         else None);
+        (if C.Syntax.e_unknown then e_unknown ty else None);
+        (if C.Syntax.e_getarray then e_get_array else None);
+        (if C.Syntax.e_getfields then e_get_fields else None);
+        (if C.Syntax.e_pattern then e_pattern else None);
+        (if C.Syntax.e_var then e_var env ty else None);
+        (if C.Syntax.e_call then e_call expr env ty n else None);
+        (if C.Syntax.e_binop && n >= 1 && can_construct_binop ty_anon then
+           Some (e_binop expr env ty_anon n)
+         else None);
+        (if C.Syntax.e_unop && can_construct_unop ty_anon then
+           Some (e_unop expr env ty_anon n)
+         else None);
+        (if C.Syntax.e_tuple && n >= 1 then e_tuple expr env ty_anon n else None);
+        (if C.Syntax.e_slice && n >= 1 && is_bits ty_anon then
+           Some (e_slices expr env n)
+         else None);
+        (if C.Syntax.e_concat && n >= 2 && is_bits ty_anon then
+           Some (e_concat expr env n)
+         else None);
+        (if C.Syntax.e_ctc then e_ctc expr env ty ty_anon n else None);
+        (if C.Syntax.e_record && n >= 2 then
+           match (ty_anon.desc, ty.desc) with
+           | (T_Record fields | T_Exception fields), T_Named _
+             when List.length fields <= n ->
+               Some (e_record expr env ty fields n)
+           | _ -> None
+         else None);
+        (if C.Syntax.e_cond && n >= 3 then e_cond expr env ty n else None);
+        (if C.Syntax.e_getfield && n >= 1 then e_get_field expr env ty n
+         else None);
+      ]
+      |> filter
+      |> function
+      | [] ->
+          if _dbg || false then
+            Format.eprintf "@[<2>Cannot construct with fuel %d type@ %a@]@." n
+              PP.pp_ty ty;
+          expr (env, ty, minimal_direct_fuel_ty env ty)
+      | li ->
+          let res = oneof li in
+          let () = if _dbg then Printf.eprintf "Generated expr.\n%!" in
+          res
+    in
+
+    fun env ty n -> expr' (env, ty, n)
+
+  let slices = slices (fun (env, ty, n) -> expr env ty n)
+
+  let fields_maxed ty env ~max n =
+    let* ns = Nat.list_sized_min_no_gen 1 n in
+    let rec loop i max prevs = function
+      | [] -> return prevs
+      | n :: ns ->
+          let* ty = ty (false, env, Some (max + i - n), n) and* name = string in
+          let prevs = (name, ty) :: prevs
+          and max = max - minimal_direct_fuel_ty env ty in
+          loop (succ i) max prevs ns
+    in
+    loop 0 max [] ns
+
+  let fields_unbounded ty env n =
+    Nat.list_sized_non_empty (fun n -> pair names (ty (false, env, None, n))) n
+
+  let fields env ty = function
+    | Some max -> fields_maxed ty env ~max
+    | None -> fields_unbounded ty env
+
+  let ty : bool -> env -> ?max:int -> ty sgen =
+    let t_bool = T_Bool |> annot |> pure
+    and t_integer env max n : ty gen =
+      let cnt_exact =
+        if C.Syntax.constraint_exact then
+          Option.some @@ fun n ->
+          let+ e = expr env integer n in
+          Constraint_Exact e
+        else None
+      and cnt_range =
+        if C.Syntax.constraint_range then
+          Option.some @@ fun n ->
+          let* n1, n2 = Nat.split2 n in
+          let+ e1 = expr env integer n1 and+ e2 = expr env integer n2 in
+          Constraint_Range (e1, e2)
+        else None
+      in
+      let cnt =
+        [ cnt_exact; cnt_range ] |> filter |> function
+        | [] -> None
+        | li -> Some (fun n -> List.map (fun gen -> gen n) li |> oneof)
+      in
+      let cnts = Option.map Nat.list_sized_non_empty cnt in
+      [
+        Some (T_Int UnConstrained |> annot |> pure);
+        (if n >= 1 && max = None then
+           Fun.flip Option.map cnts @@ fun cnts ->
+           let+ cnts = cnts n in
+           T_Int (WellConstrained cnts) |> annot
+         else None);
+      ]
+      |> filter_oneof
+    and t_real = T_Real |> annot |> pure
+    and t_tuple ty env max n =
+      let+ fields = fields env ty max n in
+      T_Tuple (List.map snd fields) |> annot
+    and t_record ty env max n =
+      let+ fields = fields env ty max n in
+      T_Record fields |> annot
+    and t_exception ty env max n =
+      let+ fields = fields env ty max n in
+      T_Exception fields |> annot
+    and t_enum n =
+      let+ names = list_repeat n names in
+      T_Enum names |> annot
+    and t_named env max =
+      let folder name ty' prevs =
+        let ty = T_Named name |> annot in
+        match max with
+        | None -> ty :: prevs
+        | Some max ->
+            if minimal_direct_fuel_ty env ty' <= max then ty :: prevs else prevs
+      in
+      IMap.fold folder env.StaticEnv.global.declared_types []
+      |> protected_oneofl
+    and t_array = None (* TODO *) in
+    let ty' =
+      fix @@ fun ty (is_decl, env, max, n) ->
+      let () = if _dbg then Printf.eprintf "Generating ty of size %d\n%!" n in
+      let n = pay n in
+      [
+        (if C.Syntax.t_bool then Some t_bool else None);
+        (if C.Syntax.t_int then Some (t_integer env max n) else None);
+        (if C.Syntax.t_real then Some t_real else None);
+        (if C.Syntax.t_bits then Some t_bits else None);
+        (if C.Syntax.t_array then t_array else None);
+        (if C.Syntax.t_record && n >= 1 && is_decl then
+           Some (t_record ty env max n)
+         else None);
+        (if C.Syntax.t_exception && n >= 1 && is_decl then
+           Some (t_exception ty env max n)
+         else None);
+        (if C.Syntax.t_enum && n >= 1 && is_decl then Some (t_enum n) else None);
+        (if C.Syntax.t_tuple && n > 2 && is_decl then
+           Some (t_tuple ty env max n)
+         else None);
+        (if C.Syntax.t_named then t_named env max else None);
+      ]
+      |> filter_oneof
+      |>
+      if _dbg then (fun res ->
+        Printf.eprintf "type generated.\n%!";
+        res)
+      else Fun.id
+    in
+    fun is_decl env ?max n -> ty' (is_decl, env, max, n)
+
+  let lexpr : env -> ty -> lexpr sgen =
+    let lexpr' =
+      let le_discard = LE_Discard |> annot |> pure
+      and le_var env ty =
+        let folder name (t, _) vars =
+          if Types.structural_subtype_satisfies env t ty then
+            (LE_Var name |> annot) :: vars
+          else vars
+        in
+        []
+        |> ASTUtils.IMap.fold folder env.StaticEnv.local.storage_types
+        |> ASTUtils.IMap.fold folder env.StaticEnv.global.storage_types
+        |> protected_oneofl
+      and le_tuple lexpr env ty n =
+        match ty.desc with
+        | T_Tuple li ->
+            let size = List.length li in
+            if n < size then None
+            else
+              Some
+                (let* sizes = Nat.split ~size n in
+                 List.map2 (fun ty n -> lexpr (env, ty, n)) li sizes
+                 |> flatten_l
+                 >|= fun li -> LE_Destructuring li |> annot)
+        | _ -> None
+      and le_set_field lexpr env ty n =
+        let field_folder new_ty acc (field_name, field_ty) =
+          if Types.structural_subtype_satisfies env field_ty ty then
+            (let+ le' = lexpr (env, new_ty, n) in
+             LE_SetField (le', field_name) |> annot)
+            :: acc
+          else acc
+        in
+        let type_folder name ty' acc : lexpr gen list =
+          let ty' = Types.make_anonymous env ty' in
+          match ty'.desc with
+          | T_Record fields | T_Exception fields ->
+              let new_ty = T_Named name |> annot in
+              if minimal_direct_fuel_ty env ty' <= n then
+                List.fold_left (field_folder new_ty) acc fields
+              else acc
+          | _ -> acc
+        in
+        IMap.fold type_folder env.StaticEnv.global.declared_types [] |> function
+        | [] -> None
+        | li -> Some (oneof li)
+      and le_concat lexpr env ty n =
+        match ty.desc with
+        | T_Bits _ ->
+            Some
+              ( Nat.list_sized_non_empty
+                  (fun n -> t_bits >>= fun t -> lexpr (env, t, n))
+                  n
+              >|= fun li -> LE_Concat (li, None) |> annot )
+        | _ -> None
+      and le_slices lexpr env ty n =
+        match ty.desc with
+        | T_Bits _ ->
+            Some
+              (let* n2 = 1 -- n in
+               let n1 = n - n2 in
+               let+ le' = lexpr (env, ty, n1) and+ slices = slices env n2 in
+               LE_Slice (le', slices) |> annot)
+        | _ -> None
+      in
+      fix @@ fun lexpr (env, ty, n) ->
+      let () =
+        if _dbg then Printf.eprintf "Generating lexpr of size %d\n%!" n
+      in
+      let n = pay n in
+      let ty_anon = Types.make_anonymous env ty in
+      [
+        (if C.Syntax.le_discard then Some le_discard else None);
+        (if C.Syntax.le_var then le_var env ty_anon else None);
+        (if C.Syntax.le_concat then le_tuple lexpr env ty_anon n else None);
+        (if C.Syntax.le_setfield && n >= 1 then le_set_field lexpr env ty_anon n
+         else None);
+        (if C.Syntax.le_concat && n >= 1 then le_concat lexpr env ty_anon n
+         else None);
+        (if C.Syntax.le_slice && n >= 1 then le_slices lexpr env ty_anon n
+         else None);
+      ]
+      |> filter_oneof
+    in
+    fun env ty n -> lexpr' (env, ty, n)
+
+  let stmt : env -> (stmt * env) sgen =
+    let s_block stmt env n =
+      if n <= 0 then pure (S_Pass |> annot, env)
+      else
+        let* n_elements = 1 -- n in
+        let* sizes = Nat.split ~size:n_elements n in
+        let* env, prevs =
+          List.fold_left
+            (fun m n ->
+              let* env, prevs = m in
+              let* s, env = stmt (env, n) in
+              return (env, s :: prevs))
+            (pure (env, []))
+            sizes
+        in
+        let s = List.rev prevs |> stmt_from_list in
+        return (s, env)
+    in
+    let s_assert env n =
+      let+ e = expr env boolean n in
+      (S_Assert e |> annot, env)
+    in
+    let s_assign env n =
+      let* n1 = 1 -- (n / 3) in
+      let* ty = ty false env ~max:n1 n1 in
+      let min = minimal_direct_fuel_ty env ty in
+      let* n2 = min -- (n - min) in
+      let n3 = n - n1 - n2 in
+      let+ le = lexpr env ty n2 and+ e = expr env ty n3 in
+      (S_Assign (le, e, V1) |> annot, env)
+    in
+    let s_decl env n =
+      let* n1, n2 = Nat.split2 n in
+      let* ty = ty false env ~max:n2 n1 in
+      let+ e = expr env ty n2
+      and+ ldk = Untyped.ldk
+      and+ name = fresh_name env in
+      ( S_Decl (ldk, LDI_Typed (LDI_Var name, ty), Some e) |> annot,
+        StaticEnv.add_local name ty ldk env )
+    in
+    let s_return env n =
+      match env.StaticEnv.local.return_type with
+      | Some t ->
+          let+ e = expr env t n in
+          (S_Return (Some e) |> annot, env)
+      | None -> pure (S_Return None |> annot, env)
+    in
+    let s_cond stmt env n =
+      let* n1, n2, n3 = Nat.split3 n in
+      let+ e1 = expr env boolean n1
+      and+ s2, _env2 = stmt (env, n2)
+      and+ s3, _env3 = stmt (env, n3) in
+      (S_Cond (e1, s2, s3) |> annot, env)
+    in
+    let stmt' =
+      fix @@ fun stmt (env, n) ->
+      let () =
+        if _dbg then Printf.eprintf "Generating a stmt of size %d\n%!" n
+      in
+      let n = pay n in
+      [
+        (if C.Syntax.s_decl then Some (s_decl env n) else None);
+        (if C.Syntax.s_assert then Some (s_assert env n) else None);
+        (if C.Syntax.s_return then Some (s_return env n) else None);
+        (if C.Syntax.s_pass then Some (s_block stmt env n) else None);
+        (if C.Syntax.s_assign && n >= 3 then Some (s_assign env n) else None);
+        (if C.Syntax.s_cond && n >= 3 then Some (s_cond stmt env n) else None);
+      ]
+      |> filter_oneof
+    in
+    fun env n -> stmt' (env, n)
+
+  let decl : env -> (decl * env) sgen =
+    let type_decl env n : (decl * env) gen =
+      let+ ty = ty true env n and+ name = fresh_name env in
+      (D_TypeDecl (name, ty, None) |> annot, StaticEnv.add_type name ty env)
+    and global_decl env n : (decl * env) gen =
+      let* n1, n2 = Nat.split2 n in
+      let* ty = ty false env ~max:n2 n1 in
+      let+ name = fresh_name env
+      and+ keyword = Untyped.gdk
+      and+ initial_value = expr env ty n2 |> option in
+      ( D_GlobalStorage { name; keyword; ty = Some ty; initial_value } |> annot,
+        StaticEnv.add_global_storage name ty keyword env )
+    and func env n : (decl * env) gen =
+      let* n2 = int_bound ((n / 2) + 1) in
+      let* n3 = int_bound ((n / 4) + 1) in
+      let n1 = n - n2 - n3 in
+      let parameters = [] in
+      let* return_type = ty false env n3 |> option in
+      let env' =
+        StaticEnv.
+          { global = env.global; local = empty_local_return_type return_type }
+      in
+      let* args, env' =
+        let* n_args = int_bound n2 in
+        let* arg_sizes = Nat.split ~size:n_args n2 in
+        List.fold_left
+          (fun acc n ->
+            let* prevs, env = acc in
+            let+ name = fresh_name env and+ ty = ty false env n in
+            ((name, ty) :: prevs, StaticEnv.add_local name ty LDK_Let env))
+          (pure ([], env'))
+          arg_sizes
+      in
+      let+ name = names
+      and+ (body : subprogram_body) =
+        stmt env' n1 >|= fun (s, _env') -> SB_ASL s
+      and+ subprogram_type =
+        match return_type with
+        | Some _ -> oneofa [| ST_Function; ST_Getter |]
+        | None ->
+            if List.length args > 0 then oneofa [| ST_Procedure; ST_Setter |]
+            else pure ST_Procedure
+      in
+      let func_sig =
+        { name; parameters; args; body; return_type; subprogram_type }
+      in
+      (D_Func func_sig |> annot, StaticEnv.add_subprogram name func_sig env)
+    in
+    fun env n ->
+      let () =
+        if _dbg then Printf.eprintf "Generating a decl of size %d\n%!" n
+      in
+      let n = pay n in
+      [ type_decl env n ]
+      |> (if n >= 2 then List.cons (global_decl env n) else Fun.id)
+      |> (if n >= 3 then List.cons (func env n) else Fun.id)
+      |> oneof
+
+  let main =
+    let parameters = []
+    and args = []
+    and return_type = Some integer
+    and subprogram_type = ST_Procedure
+    and name = "main" in
+    fun env n ->
+      let n = pay n in
+      let env' =
+        StaticEnv.
+          { global = env.global; local = empty_local_return_type return_type }
+      in
+      let+ body = stmt env' n >|= fun (s, _env') -> SB_ASL s in
+      let func_sig =
+        { name; parameters; args; body; return_type; subprogram_type }
+      in
+      D_Func func_sig |> annot
+
+  let ast : AST.t sgen = function
+    | 0 -> pure []
+    | n ->
+        let () =
+          if _dbg then Printf.eprintf "Generating ast of size %d\n%!" n
+        in
+        let* n_main = 1 -- ((n + 4) / 5) in
+        let n = n - n_main in
+        let* n_decl = if n = 0 then pure 0 else 1 -- ((n + 4) / 5) in
+        let* sizes = Nat.split ~size:n_decl n in
+        let* decls, env =
+          List.fold_left
+            (fun acc n ->
+              let* prevs, env = acc in
+              let+ d, env = decl env n in
+              (d :: prevs, env))
+            (return ([], StaticEnv.empty))
+            sizes
+        in
+        let+ main = main env n_main in
+        let () = if _dbg then Printf.eprintf "Generated ast.\n%!" in
+        List.rev (main :: decls)
+end

--- a/asllib/carpenter/comparator.ml
+++ b/asllib/carpenter/comparator.ml
@@ -1,0 +1,76 @@
+(****************************************************************************************************************)
+(*  SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>  *)
+(*  SPDX-License-Identifier: BSD-3-Clause                                                                       *)
+(****************************************************************************************************************)
+
+let _log_src =
+  Logs.Src.create ~doc:"Comparaison between different interpreter results."
+    "carpenter.comparator"
+
+let set_log_level = Logs.Src.set_level _log_src
+let info f = Logs.info ~src:_log_src f
+let debug f = Logs.debug ~src:_log_src f
+
+let get_ref_result ast =
+  let open Asllib in
+  try
+    match Native.interprete `TypeCheck ~instrumentation:false ast with
+    | 0, _ -> Ok ()
+    | i, _ -> Error ("Bad return code: " ^ string_of_int i)
+  with
+  | Error.ASLException e -> Error (Error.error_to_string e)
+  | e ->
+      let msg =
+        Printf.sprintf "ASLRef failed with uncaught error: %s."
+          (Printexc.to_string e)
+      in
+      failwith msg
+
+let get_ref_result_instr =
+  let open Asllib in
+  let open Native in
+  let module B = Instrumentation.SemanticsSingleSetBuffer in
+  let module C : Interpreter.Config = struct
+    let type_checking_strictness = `TypeCheck
+    let unroll = 0
+
+    module Instr = Instrumentation.SemMake (B)
+  end in
+  let module I = NativeInterpreter (C) in
+  fun ast ->
+    let ast = List.rev_append Native.primitive_decls ast in
+    B.reset ();
+    let res =
+      try
+        match I.run ast with
+        | NV_Literal (L_Int z) when Z.equal z Z.zero -> Ok ()
+        | NV_Literal (L_Int z) -> Error ("Bad return code: " ^ Z.to_string z)
+        | _ -> Error "Bad return code (not integer)."
+      with
+      | Error.ASLException e -> Error (Error.error_to_string e)
+      | e ->
+          let msg =
+            Printf.sprintf "ASLRef failed with uncaught error: %s."
+              (Printexc.to_string e)
+          in
+          Error msg
+    in
+    (res, B.get ())
+
+let compare_results ~ref_result ~binterp_result =
+  match (ref_result, binterp_result) with
+  | Ok (), Ok () ->
+      debug (fun m -> m "Executions successful --> probably no mismatch.");
+      true
+  | Error ref_s, Error binterp_s ->
+      debug (fun m ->
+          m "Error comparison between %S and %S. Considered true.\n%!" ref_s
+            binterp_s);
+      true (* TODO *)
+  | _ ->
+      debug (fun m -> m "Result mismatch --> probable discrepancy.");
+      false
+
+let compare_with_ref ast binterp_result =
+  let ref_result = get_ref_result ast in
+  compare_results ~ref_result ~binterp_result

--- a/asllib/carpenter/config.ml
+++ b/asllib/carpenter/config.ml
@@ -1,0 +1,543 @@
+(****************************************************************************************************************)
+(*  SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>  *)
+(*  SPDX-License-Identifier: BSD-3-Clause                                                                       *)
+(****************************************************************************************************************)
+
+module type Syntax = sig
+  val bnot : bool
+  val neg : bool
+  val not : bool
+  val and_ : bool
+  val band : bool
+  val beq : bool
+  val bor : bool
+  val div : bool
+  val divrm : bool
+  val eor : bool
+  val eq_op : bool
+  val gt : bool
+  val geq : bool
+  val impl : bool
+  val lt : bool
+  val leq : bool
+  val mod_ : bool
+  val minus : bool
+  val mul : bool
+  val neq : bool
+  val or_ : bool
+  val plus : bool
+  val pow : bool
+  val rdiv : bool
+  val shl : bool
+  val shr : bool
+  val l_int : bool
+  val l_bool : bool
+  val l_real : bool
+  val l_bitvector : bool
+  val l_string : bool
+  val e_literal : bool
+  val e_var : bool
+  val e_ctc : bool
+  val e_binop : bool
+  val e_unop : bool
+  val e_call : bool
+  val e_slice : bool
+  val e_cond : bool
+  val e_getarray : bool
+  val e_getfield : bool
+  val e_getfields : bool
+  val e_record : bool
+  val e_concat : bool
+  val e_tuple : bool
+  val e_unknown : bool
+  val e_pattern : bool
+  val pattern_all : bool
+  val pattern_any : bool
+  val pattern_geq : bool
+  val pattern_leq : bool
+  val pattern_mask : bool
+  val pattern_not : bool
+  val pattern_range : bool
+  val pattern_single : bool
+  val pattern_tuple : bool
+  val slice_single : bool
+  val slice_range : bool
+  val slice_length : bool
+  val slice_star : bool
+  val t_int : bool
+  val t_bits : bool
+  val t_real : bool
+  val t_string : bool
+  val t_bool : bool
+  val t_enum : bool
+  val t_tuple : bool
+  val t_array : bool
+  val t_record : bool
+  val t_exception : bool
+  val t_named : bool
+  val constraint_exact : bool
+  val constraint_range : bool
+  val unconstrained : bool
+  val wellconstrained : bool
+  val underconstrained : bool
+  val bitfield_simple : bool
+  val bitfield_nested : bool
+  val bitfield_type : bool
+  val le_discard : bool
+  val le_var : bool
+  val le_slice : bool
+  val le_setarray : bool
+  val le_setfield : bool
+  val le_setfields : bool
+  val le_destructuring : bool
+  val le_concat : bool
+  val ldk_var : bool
+  val ldk_let : bool
+  val ldk_constant : bool
+  val ldi_discard : bool
+  val ldi_var : bool
+  val ldi_tuple : bool
+  val ldi_typed : bool
+  val up : bool
+  val down : bool
+  val s_pass : bool
+  val s_seq : bool
+  val s_decl : bool
+  val s_assign : bool
+  val s_call : bool
+  val s_return : bool
+  val s_cond : bool
+  val s_case : bool
+  val s_assert : bool
+  val s_for : bool
+  val s_while : bool
+  val s_repeat : bool
+  val s_throw : bool
+  val s_try : bool
+  val s_print : bool
+  val st_procedure : bool
+  val st_function : bool
+  val st_getter : bool
+  val st_setter : bool
+end
+
+module type S = sig
+  module Syntax : Syntax
+end
+
+module All : Syntax = struct
+  let bnot = true
+  let neg = true
+  let not = true
+  let and_ = true
+  let band = true
+  let beq = true
+  let bor = true
+  let div = true
+  let divrm = true
+  let eor = true
+  let eq_op = true
+  let gt = true
+  let geq = true
+  let impl = true
+  let lt = true
+  let leq = true
+  let mod_ = true
+  let minus = true
+  let mul = true
+  let neq = true
+  let or_ = true
+  let plus = true
+  let pow = true
+  let rdiv = true
+  let shl = true
+  let shr = true
+  let l_int = true
+  let l_bool = true
+  let l_real = true
+  let l_bitvector = true
+  let l_string = true
+  let e_literal = true
+  let e_var = true
+  let e_ctc = true
+  let e_binop = true
+  let e_unop = true
+  let e_call = true
+  let e_slice = true
+  let e_cond = true
+  let e_getarray = true
+  let e_getfield = true
+  let e_getfields = true
+  let e_record = true
+  let e_concat = true
+  let e_tuple = true
+  let e_unknown = true
+  let e_pattern = true
+  let pattern_all = true
+  let pattern_any = true
+  let pattern_geq = true
+  let pattern_leq = true
+  let pattern_mask = true
+  let pattern_not = true
+  let pattern_range = true
+  let pattern_single = true
+  let pattern_tuple = true
+  let slice_single = true
+  let slice_range = true
+  let slice_length = true
+  let slice_star = true
+  let t_int = true
+  let t_bits = true
+  let t_real = true
+  let t_string = true
+  let t_bool = true
+  let t_enum = true
+  let t_tuple = true
+  let t_array = true
+  let t_record = true
+  let t_exception = true
+  let t_named = true
+  let constraint_exact = true
+  let constraint_range = true
+  let unconstrained = true
+  let wellconstrained = true
+  let underconstrained = true
+  let bitfield_simple = true
+  let bitfield_nested = true
+  let bitfield_type = true
+  let le_discard = true
+  let le_var = true
+  let le_slice = true
+  let le_setarray = true
+  let le_setfield = true
+  let le_setfields = true
+  let le_destructuring = true
+  let le_concat = true
+  let ldk_var = true
+  let ldk_let = true
+  let ldk_constant = true
+  let ldi_discard = true
+  let ldi_var = true
+  let ldi_tuple = true
+  let ldi_typed = true
+  let up = true
+  let down = true
+  let s_pass = true
+  let s_seq = true
+  let s_decl = true
+  let s_assign = true
+  let s_call = true
+  let s_return = true
+  let s_cond = true
+  let s_case = true
+  let s_assert = true
+  let s_for = true
+  let s_while = true
+  let s_repeat = true
+  let s_throw = true
+  let s_try = true
+  let s_print = true
+  let st_procedure = true
+  let st_function = true
+  let st_getter = true
+  let st_setter = true
+end
+
+module Stable : Syntax = struct
+  include All
+
+  let e_unknown = false
+  let e_getarray = false
+  let le_setarray = false
+end
+
+let default_config =
+  (module struct
+    module Syntax = Stable
+  end : S)
+
+module Parse = struct
+  module Tbl = Hashtbl.Make (String)
+
+  let default_hashtbl =
+    let tbl : bool Tbl.t = Tbl.create 128 in
+    let () =
+      [
+        ("bnot", true);
+        ("neg", true);
+        ("not", true);
+        ("and", true);
+        ("band", true);
+        ("beq", true);
+        ("bor", true);
+        ("div", true);
+        ("divrm", true);
+        ("eor", true);
+        ("eq_op", true);
+        ("gt", true);
+        ("geq", true);
+        ("impl", true);
+        ("lt", true);
+        ("leq", true);
+        ("mod", true);
+        ("minus", true);
+        ("mul", true);
+        ("neq", true);
+        ("or", true);
+        ("plus", true);
+        ("pow", true);
+        ("rdiv", true);
+        ("shl", true);
+        ("shr", true);
+        ("l_int", true);
+        ("l_bool", true);
+        ("l_real", true);
+        ("l_bitvector", true);
+        ("l_string", true);
+        ("e_literal", true);
+        ("e_var", true);
+        ("e_ctc", true);
+        ("e_binop", true);
+        ("e_unop", true);
+        ("e_call", true);
+        ("e_slice", true);
+        ("e_cond", true);
+        ("e_getarray", true);
+        ("e_getfield", true);
+        ("e_getfields", true);
+        ("e_record", true);
+        ("e_concat", true);
+        ("e_tuple", true);
+        ("e_unknown", true);
+        ("e_pattern", true);
+        ("pattern_all", true);
+        ("pattern_any", true);
+        ("pattern_geq", true);
+        ("pattern_leq", true);
+        ("pattern_mask", true);
+        ("pattern_not", true);
+        ("pattern_range", true);
+        ("pattern_single", true);
+        ("pattern_tuple", true);
+        ("slice_single", true);
+        ("slice_range", true);
+        ("slice_length", true);
+        ("slice_star", true);
+        ("t_int", true);
+        ("t_bits", true);
+        ("t_real", true);
+        ("t_string", true);
+        ("t_bool", true);
+        ("t_enum", true);
+        ("t_tuple", true);
+        ("t_array", true);
+        ("t_record", true);
+        ("t_exception", true);
+        ("t_named", true);
+        ("constraint_exact", true);
+        ("constraint_range", true);
+        ("unconstrained", true);
+        ("wellconstrained", true);
+        ("underconstrained", true);
+        ("bitfield_simple", true);
+        ("bitfield_nested", true);
+        ("bitfield_type", true);
+        ("le_discard", true);
+        ("le_var", true);
+        ("le_slice", true);
+        ("le_setarray", true);
+        ("le_setfield", true);
+        ("le_setfields", true);
+        ("le_destructuring", true);
+        ("le_concat", true);
+        ("ldk_var", true);
+        ("ldk_let", true);
+        ("ldk_constant", true);
+        ("ldi_discard", true);
+        ("ldi_var", true);
+        ("ldi_tuple", true);
+        ("ldi_typed", true);
+        ("up", true);
+        ("down", true);
+        ("s_pass", true);
+        ("s_seq", true);
+        ("s_decl", true);
+        ("s_assign", true);
+        ("s_call", true);
+        ("s_return", true);
+        ("s_cond", true);
+        ("s_case", true);
+        ("s_assert", true);
+        ("s_for", true);
+        ("s_while", true);
+        ("s_repeat", true);
+        ("s_throw", true);
+        ("s_try", true);
+        ("s_print", true);
+        ("st_procedure", true);
+        ("st_function", true);
+        ("st_getter", true);
+        ("st_setter", true);
+      ]
+      |> List.to_seq |> Tbl.add_seq tbl
+    in
+    tbl
+
+  let of_hashtbl tbl =
+    let module M = struct
+      let bnot = Tbl.find tbl "bnot"
+      let neg = Tbl.find tbl "neg"
+      let not = Tbl.find tbl "not"
+      let and_ = Tbl.find tbl "and"
+      let band = Tbl.find tbl "band"
+      let beq = Tbl.find tbl "beq"
+      let bor = Tbl.find tbl "bor"
+      let div = Tbl.find tbl "div"
+      let divrm = Tbl.find tbl "divrm"
+      let eor = Tbl.find tbl "eor"
+      let eq_op = Tbl.find tbl "eq_op"
+      let gt = Tbl.find tbl "gt"
+      let geq = Tbl.find tbl "geq"
+      let impl = Tbl.find tbl "impl"
+      let lt = Tbl.find tbl "lt"
+      let leq = Tbl.find tbl "leq"
+      let mod_ = Tbl.find tbl "mod"
+      let minus = Tbl.find tbl "minus"
+      let mul = Tbl.find tbl "mul"
+      let neq = Tbl.find tbl "neq"
+      let or_ = Tbl.find tbl "or"
+      let plus = Tbl.find tbl "plus"
+      let pow = Tbl.find tbl "pow"
+      let rdiv = Tbl.find tbl "rdiv"
+      let shl = Tbl.find tbl "shl"
+      let shr = Tbl.find tbl "shr"
+      let l_int = Tbl.find tbl "l_int"
+      let l_bool = Tbl.find tbl "l_bool"
+      let l_real = Tbl.find tbl "l_real"
+      let l_bitvector = Tbl.find tbl "l_bitvector"
+      let l_string = Tbl.find tbl "l_string"
+      let e_literal = Tbl.find tbl "e_literal"
+      let e_var = Tbl.find tbl "e_var"
+      let e_ctc = Tbl.find tbl "e_ctc"
+      let e_binop = Tbl.find tbl "e_binop"
+      let e_unop = Tbl.find tbl "e_unop"
+      let e_call = Tbl.find tbl "e_call"
+      let e_slice = Tbl.find tbl "e_slice"
+      let e_cond = Tbl.find tbl "e_cond"
+      let e_getarray = Tbl.find tbl "e_getarray"
+      let e_getfield = Tbl.find tbl "e_getfield"
+      let e_getfields = Tbl.find tbl "e_getfields"
+      let e_record = Tbl.find tbl "e_record"
+      let e_concat = Tbl.find tbl "e_concat"
+      let e_tuple = Tbl.find tbl "e_tuple"
+      let e_unknown = Tbl.find tbl "e_unknown"
+      let e_pattern = Tbl.find tbl "e_pattern"
+      let pattern_all = Tbl.find tbl "pattern_all"
+      let pattern_any = Tbl.find tbl "pattern_any"
+      let pattern_geq = Tbl.find tbl "pattern_geq"
+      let pattern_leq = Tbl.find tbl "pattern_leq"
+      let pattern_mask = Tbl.find tbl "pattern_mask"
+      let pattern_not = Tbl.find tbl "pattern_not"
+      let pattern_range = Tbl.find tbl "pattern_range"
+      let pattern_single = Tbl.find tbl "pattern_single"
+      let pattern_tuple = Tbl.find tbl "pattern_tuple"
+      let slice_single = Tbl.find tbl "slice_single"
+      let slice_range = Tbl.find tbl "slice_range"
+      let slice_length = Tbl.find tbl "slice_length"
+      let slice_star = Tbl.find tbl "slice_star"
+      let t_int = Tbl.find tbl "t_int"
+      let t_bits = Tbl.find tbl "t_bits"
+      let t_real = Tbl.find tbl "t_real"
+      let t_string = Tbl.find tbl "t_string"
+      let t_bool = Tbl.find tbl "t_bool"
+      let t_enum = Tbl.find tbl "t_enum"
+      let t_tuple = Tbl.find tbl "t_tuple"
+      let t_array = Tbl.find tbl "t_array"
+      let t_record = Tbl.find tbl "t_record"
+      let t_exception = Tbl.find tbl "t_exception"
+      let t_named = Tbl.find tbl "t_named"
+      let constraint_exact = Tbl.find tbl "constraint_exact"
+      let constraint_range = Tbl.find tbl "constraint_range"
+      let unconstrained = Tbl.find tbl "unconstrained"
+      let wellconstrained = Tbl.find tbl "wellconstrained"
+      let underconstrained = Tbl.find tbl "underconstrained"
+      let bitfield_simple = Tbl.find tbl "bitfield_simple"
+      let bitfield_nested = Tbl.find tbl "bitfield_nested"
+      let bitfield_type = Tbl.find tbl "bitfield_type"
+      let le_discard = Tbl.find tbl "le_discard"
+      let le_var = Tbl.find tbl "le_var"
+      let le_slice = Tbl.find tbl "le_slice"
+      let le_setarray = Tbl.find tbl "le_setarray"
+      let le_setfield = Tbl.find tbl "le_setfield"
+      let le_setfields = Tbl.find tbl "le_setfields"
+      let le_destructuring = Tbl.find tbl "le_destructuring"
+      let le_concat = Tbl.find tbl "le_concat"
+      let ldk_var = Tbl.find tbl "ldk_var"
+      let ldk_let = Tbl.find tbl "ldk_let"
+      let ldk_constant = Tbl.find tbl "ldk_constant"
+      let ldi_discard = Tbl.find tbl "ldi_discard"
+      let ldi_var = Tbl.find tbl "ldi_var"
+      let ldi_tuple = Tbl.find tbl "ldi_tuple"
+      let ldi_typed = Tbl.find tbl "ldi_typed"
+      let up = Tbl.find tbl "up"
+      let down = Tbl.find tbl "down"
+      let s_pass = Tbl.find tbl "s_pass"
+      let s_seq = Tbl.find tbl "s_seq"
+      let s_decl = Tbl.find tbl "s_decl"
+      let s_assign = Tbl.find tbl "s_assign"
+      let s_call = Tbl.find tbl "s_call"
+      let s_return = Tbl.find tbl "s_return"
+      let s_cond = Tbl.find tbl "s_cond"
+      let s_case = Tbl.find tbl "s_case"
+      let s_assert = Tbl.find tbl "s_assert"
+      let s_for = Tbl.find tbl "s_for"
+      let s_while = Tbl.find tbl "s_while"
+      let s_repeat = Tbl.find tbl "s_repeat"
+      let s_throw = Tbl.find tbl "s_throw"
+      let s_try = Tbl.find tbl "s_try"
+      let s_print = Tbl.find tbl "s_print"
+      let st_procedure = Tbl.find tbl "st_procedure"
+      let st_function = Tbl.find tbl "st_function"
+      let st_getter = Tbl.find tbl "st_getter"
+      let st_setter = Tbl.find tbl "st_setter"
+    end in
+    (module struct
+      module Syntax = M
+    end : S)
+
+  (** [iteri_lines filename cont] calls [cont lineno line] for every line in
+      the file.
+
+      If [cont lineno line], it interrupts the iteration without any error
+      message. *)
+  let iter_lines filename cont =
+    let chan = Scanf.Scanning.from_file filename in
+    let rec loop () =
+      Scanf.bscanf chan "%l%[^\n]\n" (fun lineno line -> cont (lineno + 1) line);
+      loop ()
+    in
+    try loop () with End_of_file -> ()
+
+  let of_file filename =
+    let eprintf = Printf.eprintf in
+    let update_tbl tbl lineno name value =
+      let () = if false then eprintf "Scanned line: %s <-- %B\n" name value in
+      let name = String.lowercase_ascii name in
+      if Tbl.mem tbl name then Tbl.replace tbl name value
+      else eprintf "Ignoring line %d: unknown key %S.\n%!" lineno name
+    in
+    let parse_one_line tbl lineno line =
+      let () = if false then eprintf "Scanned line: %S\n" line in
+      try Scanf.sscanf line "%s %_[=:] %B" (update_tbl tbl lineno) with
+      | Scanf.Scan_failure s ->
+          eprintf "Config file scanning failure at line %d: %s\n%!" lineno s
+      | End_of_file ->
+          if String.length line > 0 then
+            eprintf "Ignoring unparsable line %d: %S\n%!" lineno line
+    in
+    let tbl = Tbl.copy default_hashtbl in
+    if false then eprintf "Scanning config from file %S.\n" filename;
+    iter_lines filename (parse_one_line tbl);
+    if false then eprintf "End parsing.\n";
+    of_hashtbl tbl
+end

--- a/asllib/carpenter/dune
+++ b/asllib/carpenter/dune
@@ -1,0 +1,16 @@
+(library
+ (name carpenter_lib)
+ (flags
+  (:standard -w -40-42-44-48))
+ (modules :standard \ main)
+ (optional)
+ (libraries herdtools7.asllib qcheck-core zarith re feat fix logs))
+
+(executable
+ (public_name carpenter)
+ (name main)
+ (flags
+  (:standard -w -40-42-44-48))
+ (modules main)
+ (optional)
+ (libraries cmdliner carpenter_lib logs.cli))

--- a/asllib/carpenter/main.ml
+++ b/asllib/carpenter/main.ml
@@ -1,0 +1,472 @@
+(****************************************************************************************************************)
+(*  SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>  *)
+(*  SPDX-License-Identifier: BSD-3-Clause                                                                       *)
+(****************************************************************************************************************)
+
+open Carpenter_lib
+open Asllib
+
+type 'a target = Itself | BInterp of 'a
+
+let pp_target fmt = function
+  | Itself -> Format.fprintf fmt "no"
+  | BInterp s -> Format.fprintf fmt "BInterp at %s" s
+
+let isatty chan = Unix.descr_of_out_channel chan |> Unix.isatty
+let progress_frequency = 1
+
+let print_progress should_progress =
+  if should_progress then fun i n ->
+    if i mod progress_frequency == 0 then Printf.eprintf "\r%d/%d%!" i n else ()
+  else fun _i _n -> ()
+
+let hide_progress should_progress () =
+  if should_progress then
+    Printf.eprintf "\r                                          \r%!"
+
+let setup_logs lvl =
+  let open Logs in
+  set_level lvl;
+  set_reporter (format_reporter ());
+  debug (fun m ->
+      m "Logs initialized at level %a" (Format.pp_print_option pp_level) lvl);
+  ()
+
+let setup_random =
+  let print seed = Printf.printf "SEED: 0x%x\n%!" seed in
+  fun print_seed ->
+    let open Random in
+    function
+    | None ->
+        self_init ();
+        if print_seed then (
+          let seed = bits64 () |> Int64.to_int in
+          print seed;
+          init seed)
+    | Some seed ->
+        if print_seed then print seed;
+        init seed
+
+(* --------------------------------------------------------------------------
+                                Do the real work
+   --------------------------------------------------------------------------*)
+
+let print_ast filename ast =
+  Logs.info (fun m -> m "Printing AST in %s" filename);
+  let oc = open_out filename in
+  let fmt = Format.formatter_of_out_channel oc in
+  PP.pp_t fmt ast;
+  Format.pp_print_flush fmt ();
+  close_out oc
+
+let filename =
+  let timestamp =
+    let open Unix in
+    let now = localtime (time ()) in
+    Printf.sprintf "%d-%02d-%02dT%02d:%02d:%02d" (1900 + now.tm_year)
+      (now.tm_mon + 1) now.tm_mday now.tm_hour now.tm_min now.tm_sec
+  in
+  fun o i -> Printf.sprintf "%s-%04d.asl" timestamp i |> Filename.concat o
+
+let print_one progress o n i ast =
+  print_progress progress i n;
+  print_ast (filename o i) ast
+
+let filter_instr = function
+  | Some i ->
+      fun ast ->
+        Logs.debug (fun m -> m "@[<v>Generated AST:@ %a@]" PP.pp_t ast);
+        let _res, used_rules = Comparator.get_ref_result_instr ast in
+        let res = List.mem i used_rules in
+        if not res then
+          Logs.debug (fun m ->
+              m "Did not use rule %a. Ignoring."
+                Instrumentation.SemanticsRule.pp i);
+        res
+  | None -> Fun.const true
+
+let random_asts (small : bool) config : AST.t Seq.t =
+  let asts =
+    let module Generator = RandomAST.Typed ((val config : Config.S)) in
+    let open QCheck2.Gen in
+    let sizes = if small then small_nat else nat in
+    sized_size sizes Generator.ast
+  in
+  let gen_one =
+    let rand = Random.State.make_self_init () in
+    fun () -> QCheck2.Gen.generate1 ~rand asts
+  in
+  Seq.forever gen_one
+
+let smallests_asts config : AST.t Seq.t =
+  let module IFSeq = Feat.Enum.IFSeq in
+  let module Enums = ASTEnums.Make ((val config : Config.S)) in
+  let asts_of_size n = IFSeq.to_seq (Enums.asts n) Seq.empty in
+  Seq.flat_map asts_of_size (Seq.ints 0)
+
+let generalized_generate asts (config, instr, o, progress) n =
+  asts config
+  |> Seq.filter (filter_instr instr)
+  |> Seq.take n
+  |> Seq.iteri (print_one progress o n);
+  hide_progress progress ()
+
+let generate_enum c = generalized_generate smallests_asts c
+let generate_random small c = generalized_generate (random_asts small) c
+
+let generalized_fuzz (asts : 'a Seq.t) (on_ast : 'a -> AST.t option) progress o
+    n =
+  let do_one (i, counter) ast =
+    print_progress progress i n;
+    match on_ast ast with
+    | None -> (succ i, counter)
+    | Some ast ->
+        Logs.info (fun m -> m "Discrepancy found.");
+        let filename = filename o counter in
+        print_ast filename ast;
+        (succ i, succ counter)
+  in
+  let _i = asts |> Seq.take n |> Seq.fold_left do_one (0, 0) in
+  hide_progress progress ()
+
+let random_trees config small =
+  let asts =
+    let module Generator = RandomAST.Typed ((val config : Config.S)) in
+    let open QCheck2.Gen in
+    let sizes = if small then small_int else int in
+    sized_size sizes Generator.ast
+  in
+  let gen_one () = QCheck2.Gen.generate_tree asts in
+  Seq.forever gen_one
+
+let read_files files =
+  List.to_seq files
+  |> Seq.filter_map (fun file ->
+         try Some (Builder.from_file `ASLv1 file) with _ -> None)
+
+let get_ref_result instr ast =
+  match instr with
+  | Some i ->
+      let res, used_rules = Comparator.get_ref_result_instr ast in
+      (res, List.mem i used_rules)
+  | None -> (Comparator.get_ref_result ast, true)
+
+let on_ast_itself instr _type_only ast =
+  Logs.debug (fun m -> m "@[Trying a new AST:@ %a@]" PP.pp_t ast);
+  try
+    match get_ref_result instr ast with
+    | _, false -> None
+    | Error msg, true ->
+        if String.starts_with ~prefix:"Uncaught exception" msg then Some ast
+        else None
+    | Ok (), true -> None
+  with _ -> Some ast
+
+let on_ast_binterp binterp instr type_only ast =
+  Logs.debug (fun m -> m "Analyzing generated AST with BInterp.");
+  let ref_result, instr_match =
+    match instr with
+    | Some i ->
+        let res, used_rules = Comparator.get_ref_result_instr ast in
+        (res, List.mem i used_rules)
+    | None -> (Comparator.get_ref_result ast, true)
+  in
+  if not instr_match then None
+  else
+    let binterp_result = BInterp.run_one_ast binterp type_only ast in
+    if Comparator.compare_results ~ref_result ~binterp_result then None
+    else Some ast
+
+let with_on_ast target f =
+  match target with
+  | Itself -> f on_ast_itself
+  | BInterp binterp_path ->
+      BInterp.with_binterp binterp_path @@ fun binterp ->
+      f (on_ast_binterp binterp)
+
+let rec on_ast_tree on_ast ast_tree =
+  let ast = QCheck2.Tree.root ast_tree in
+  match on_ast ast with
+  | None -> None
+  | Some ast1 ->
+      (* Generate all the children *)
+      QCheck2.Tree.children ast_tree
+      |> (* Lazily execute them *)
+      Seq.map (on_ast_tree on_ast)
+      |> (* Append at the end our previous error *)
+      Fun.flip Seq.append (Seq.return (Some ast1))
+      |> (* Find the first child that has an error. *)
+      Seq.find_map Fun.id
+
+let fuzz small (config, instr, type_only, target, o, progress) n =
+  with_on_ast target @@ fun on_ast ->
+  generalized_fuzz (random_asts small config) (on_ast instr type_only) progress
+    o n
+
+let bet (config, instr, type_only, target, o, progress) n =
+  with_on_ast target @@ fun on_ast ->
+  generalized_fuzz (smallests_asts config) (on_ast instr type_only) progress o n
+
+let quickcheck small (config, instr, type_only, target, o, progress) n =
+  with_on_ast target @@ fun on_ast ->
+  let on_ast = on_ast_tree (on_ast instr type_only) in
+  generalized_fuzz (random_trees config small) on_ast progress o n
+
+let fuzz_files (_config, instr, type_only, target, o, progress) files =
+  with_on_ast target @@ fun on_ast ->
+  generalized_fuzz (read_files files) (on_ast instr type_only) progress o
+    (List.length files + 1)
+
+let execute () type_only target files =
+  let open Format in
+  let log_result res =
+    printf "%a@\n"
+      (pp_print_result
+         ~ok:(fun f () -> pp_print_string f "ok")
+         ~error:(fun f s -> fprintf f "Error: %s" s))
+      res
+  in
+  let on_filename run file =
+    printf "// results for file: %s@\n" file;
+    file |> run |> log_result;
+    printf "// end of results for file: %s@\n@\n" file
+  in
+  match target with
+  | Itself ->
+      let on_file file =
+        file |> Asllib.Builder.from_file `ASLv1 |> Comparator.get_ref_result
+      in
+      List.iter (on_filename on_file) files
+  | BInterp binterp_path ->
+      BInterp.with_binterp binterp_path @@ fun binterp ->
+      List.iter (on_filename (BInterp.run_one binterp type_only)) files
+
+(* --------------------------------------------------------------------------
+                            Command line interface
+   --------------------------------------------------------------------------*)
+
+module Cmd = struct
+  open Cmdliner
+
+  (* ----------------------------------------------------------------------- *)
+  (* Arguments *)
+
+  let o =
+    let doc = "Output directory." in
+    let docs = Manpage.s_common_options in
+    Arg.(
+      value & opt dir "." & info [ "o"; "output-dir" ] ~docv:"DIR" ~doc ~docs)
+
+  let n =
+    let doc = "Number of test to generate." in
+    Arg.(required & pos 0 (some int) None & info [] ~docv:"N" ~doc)
+
+  let files =
+    let doc = "Files to run." in
+    Arg.(value & pos_all non_dir_file [] & info [] ~docv:"FILES" ~doc)
+
+  let instr =
+    let doc =
+      "Instrument ASLRef execution and filter-out ASTs that do not need \
+       $(docv) to execute."
+    and docs = Manpage.s_common_options
+    and docv = "RULE"
+    and parse s =
+      try Ok (Instrumentation.SemanticsRule.of_string s)
+      with Not_found -> Error ("Cannot find instrumentation rule " ^ s)
+    and print = Instrumentation.SemanticsRule.pp in
+    let open Arg in
+    let c = some & conv' ~docv (parse, print) in
+    value & opt c None & info [ "instrument"; "rule" ] ~docs ~docv ~doc
+
+  let binterp_path =
+    let doc = "Path for the BInterp executable." in
+    let docs = Manpage.s_common_options in
+    let binterp c =
+      let make_binterp s = BInterp s in
+      let parse s = Arg.conv_parser c s |> Result.map make_binterp
+      and print = pp_target in
+      Arg.conv (parse, print)
+    in
+    let open Arg in
+    value
+    & opt (binterp non_dir_file) Itself
+    & info [ "binterp" ] ~docv:"BINTERP" ~doc ~docs
+
+  let type_only =
+    let doc = "Only test the type-checker and do not run the ASTs." in
+    let docs = Manpage.s_common_options in
+    Arg.(value & flag & info [ "type-only" ] ~doc ~docs)
+
+  let small =
+    let doc = "Generate ASTs of smaller sizes." in
+    Arg.(value & flag & info [ "small" ] ~doc)
+
+  let log_level =
+    let docs = Manpage.s_common_options in
+    Logs_cli.level ~docs ()
+
+  let print_seed =
+    let doc = "Print seed before running." in
+    let docs = Manpage.s_common_options in
+    Arg.(value & flag & info [ "print-seed" ] ~doc ~docs)
+
+  let seed =
+    let doc =
+      "Set seed to $(docv) before running. If absent, uses system-dependant \
+       random sources (e.g. /dev/urandom if available)."
+    and docs = Manpage.s_common_options
+    and docv = "SEED" in
+    Arg.(value & opt (some int) None & info [ "seed" ] ~doc ~docs ~docv)
+
+  let config =
+    let doc = "File to parse to set generation properties."
+    and docs = Manpage.s_common_options
+    and docv = "CONFIG_FILE" in
+    Arg.(
+      value
+      & opt (some non_dir_file) None
+      & info [ "c"; "config"; "config-file" ] ~doc ~docs ~docv)
+
+  let progress =
+    let open Arg in
+    let docv = "PROGRESS" and docs = Manpage.s_common_options in
+    let progress =
+      let doc =
+        "Show a progress number as output. (default to true on a tty)"
+      in
+      (true, info [ "progress" ] ~doc ~docs ~docv)
+    and no_progress =
+      let doc =
+        "Do not show a progress number as output. (default to false on a tty)"
+      in
+      (false, info [ "no-progress" ] ~doc ~docs ~docv)
+    in
+    let default = isatty stderr in
+    value & vflag default [ progress; no_progress ]
+
+  (* -----------------------------------------------------------------------*)
+  (* Terms *)
+
+  let setup_logs = Term.(const setup_logs $ log_level)
+  let setup_random = Term.(const setup_random $ print_seed $ seed)
+
+  let common_options =
+    let make_config = function
+      | Some f -> Config.Parse.of_file f
+      | None -> Config.default_config
+    in
+    let make () () progress config instr o =
+      (make_config config, instr, o, progress)
+    in
+    Term.(
+      const make $ setup_logs $ setup_random $ progress $ config $ instr $ o)
+
+  let generate_random =
+    Term.(const generate_random $ small $ common_options $ n)
+
+  let generate_enum = Term.(const generate_enum $ common_options $ n)
+
+  let fuzzing_options =
+    let t type_only binterp_path (config, instr, o, progress) =
+      (config, instr, type_only, binterp_path, o, progress)
+    in
+    Term.(const t $ type_only $ binterp_path $ common_options)
+
+  let fuzz = Term.(const fuzz $ small $ fuzzing_options $ n)
+  let bet = Term.(const bet $ fuzzing_options $ n)
+  let quickcheck = Term.(const quickcheck $ small $ fuzzing_options $ n)
+  let fuzz_files = Term.(const fuzz_files $ fuzzing_options $ files)
+
+  let execute =
+    Term.(const execute $ setup_logs $ type_only $ binterp_path $ files)
+
+  (* -----------------------------------------------------------------------*)
+  (* Commands *)
+
+  let cmd_default =
+    let help _o = `Help (`Auto, None) in
+    Term.(const help $ common_options |> ret)
+
+  let cmd_fuzz_default =
+    let help _ = `Help (`Auto, Some "fuzz") in
+    Term.(const help $ fuzzing_options |> ret)
+
+  let cmd_generate_random =
+    let doc = "Generate N randoms ASTs and write them to DIR." in
+    let info = Cmd.info "random" ~doc in
+    Cmd.v info generate_random
+
+  let cmd_generate_enum =
+    let doc = "Generate the N smallest ASTs and write them to DIR." in
+    let info = Cmd.info "enum" ~doc in
+    Cmd.v info generate_enum
+
+  let cmd_generate =
+    let doc = "ASL programs generation." in
+    let info = Cmd.info "generate" ~doc in
+    let default = cmd_default in
+    Cmd.group ~default info [ cmd_generate_random; cmd_generate_enum ]
+
+  let cmd_fuzz_random =
+    let doc = "Fuzz BInterp w.r.t. ASLRef using randomly generated ASTs." in
+    let info = Cmd.info "random" ~doc in
+    Cmd.v info fuzz
+
+  let cmd_fuzz_enum =
+    let doc =
+      "Fuzz BInterp w.r.t. ASLRef using an enumeration of ASTs of increasing \
+       size."
+    in
+    let info = Cmd.info "enum" ~doc in
+    Cmd.v info bet
+
+  let cmd_fuzz_quickcheck =
+    let doc =
+      "QuickCheck style fuzzing for BInterp w.r.t. ASLRef using randomly \
+       generated ASTs. Once a discrepancy is found, the tool will iterate over \
+       all the possible sub-trees until it finds a local minima for the \
+       discrepancy"
+    in
+    let info = Cmd.info "quickcheck" ~doc in
+    Cmd.v info quickcheck
+
+  let cmd_fuzz_files =
+    let doc =
+      "Fuzz on the tests passed as command line. Usual filters apply.\n\n\
+       Current limitation: files will be reprocessed by ASLRef before passed \
+       to any other interpreter, so any test that is not parsable by ASLRef \
+       will be ignored."
+    in
+    let info = Cmd.info "files" ~doc in
+    Cmd.v info fuzz_files
+
+  let cmd_fuzz =
+    let doc = "Fuzz BInterp w.r.t. ASLRef." in
+    let info = Cmd.info "fuzz" ~doc in
+    let default = cmd_fuzz_default in
+    Cmd.group ~default info
+      [ cmd_fuzz_random; cmd_fuzz_enum; cmd_fuzz_quickcheck; cmd_fuzz_files ]
+
+  let cmd_execute =
+    let doc = "Execute tests with BInterp." in
+    let info = Cmd.info "execute" ~doc in
+    Cmd.v info execute
+
+  let cmd =
+    let doc = "Test generation and fuzzing for ASL."
+    and man =
+      let config_file_text =
+        "Configuration for the generated ASTs. Mostly constrains the generated \
+         AST by removing/allowing certain constructors."
+      in
+      [ `Blocks [ `S Manpage.s_files; `I ("CONFIG_FILE", config_file_text) ] ]
+    in
+    let info = Cmd.info "carpenter" ~doc ~man in
+    let default = cmd_default in
+    Cmd.group ~default info [ cmd_generate; cmd_fuzz; cmd_execute ]
+
+  let main () = Cmd.eval cmd
+end
+
+let () = exit (Cmd.main ())

--- a/asllib/carpenter/nat.ml
+++ b/asllib/carpenter/nat.ml
@@ -1,0 +1,77 @@
+(****************************************************************************************************************)
+(*  SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>  *)
+(*  SPDX-License-Identifier: BSD-3-Clause                                                                       *)
+(****************************************************************************************************************)
+
+open QCheck2.Gen
+
+(** Module adapted from [random_generator.Gen.Nat] *)
+
+let split2 n =
+  let+ k = int_bound n in
+  (k, n - k)
+
+(** Builds a random subset of size [size] of the interval [start, limit]. *)
+let subset ~size start limit =
+  let stop = limit + 1 in
+  let range = stop - start in
+  if not (0 <= size && size <= range) then invalid_arg "Gen.Nat.subset";
+  (* The algorithm below is attributed to Floyd, see for example
+     https://eyalsch.wordpress.com/2010/04/01/random-sample/
+     https://math.stackexchange.com/questions/178690
+  *)
+  let module ISet = Set.Make (Int) in
+  let rec fill set i =
+    if i = stop then return set
+    else
+      let* pos = start -- i in
+      let choice = if ISet.mem pos set then i else pos in
+      fill (ISet.add choice set) (i + 1)
+  in
+  let+ set = fill ISet.empty (stop - size) in
+  ISet.elements set
+
+let pos_split ~size:k n =
+  (* To split n into n{0}+n{1}+..+n{k-1}, we draw distinct "boundaries"
+     b{-1}..b{k-1}, with b{-1}=0 and b{k-1} = n
+     and the k-1 intermediate boundaries b{0}..b{k-2}
+     chosen randomly distinct in [1;n-1].
+
+     Then each n{i} is defined as b{i}-b{i-1}. *)
+  let+ b = subset ~size:(k - 1) 1 (n - 1) in
+  let b = Array.of_list b in
+  List.init k (fun i ->
+      if i = 0 then b.(0)
+      else if i = k - 1 then n - b.(i - 1)
+      else b.(i) - b.(i - 1))
+
+let split ~size:k n =
+  if k > n then raise (Invalid_argument "split");
+  match k with
+  | 0 -> pure []
+  | 1 -> pure [ n ]
+  | 2 ->
+      let+ k, k' = split2 n in
+      [ k; k' ]
+  | _ ->
+      let+ ns = pos_split ~size:k (n + k) in
+      List.map (fun v -> v - 1) ns
+
+let split3 n =
+  split ~size:3 n >|= function
+  | [ n1; n2; n3 ] -> (n1, n2, n3)
+  | _ -> assert false
+
+let list_sized_min_no_gen ?(fun_name = "list_sized_min_no_gen") min size =
+  if min > size then raise (Invalid_argument fun_name);
+  let* length = min -- size in
+  split ~size:length size
+
+let list_sized_min ?(fun_name = "list_sized_min") min elt size =
+  let* sizes = list_sized_min_no_gen ~fun_name min size in
+  List.map elt sizes |> flatten_l
+
+let list_sized elt size = list_sized_min ~fun_name:"list_sized" 0 elt size
+
+let list_sized_non_empty elt size =
+  list_sized_min ~fun_name:"list_sized_non_empty" 1 elt size

--- a/asllib/carpenter/test/aslref.ml
+++ b/asllib/carpenter/test/aslref.ml
@@ -1,0 +1,61 @@
+(****************************************************************************************************************)
+(*  SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>  *)
+(*  SPDX-License-Identifier: BSD-3-Clause                                                                       *)
+(****************************************************************************************************************)
+
+let check_no_strange_error ast =
+  let open Asllib in
+  try
+    let _ = Native.interprete `TypeCheck ~instrumentation:false ast in
+    true
+  with
+  | Error.ASLException _ -> true
+  | _ -> false
+
+let no_strange_error ast =
+  let open Asllib in
+  try
+    let _ = Native.interprete `TypeCheck ~instrumentation:false ast in
+    ()
+  with
+  | Error.ASLException _ -> ()
+  | e ->
+      Format.eprintf "@[<v 2>Found an error with:@ %a@]@." PP.pp_t ast;
+      raise e
+
+module C = struct
+  module Syntax = struct
+    include Carpenter_lib.Config.Stable
+
+    let s_while = false
+    let s_repeat = false
+  end
+end
+
+module RandomTypedAST = Carpenter_lib.RandomAST.Typed (C)
+module EnumAST = Carpenter_lib.ASTEnums.Make (C)
+
+let no_unsupported_error_random =
+  QCheck2.Test.make ~count:1000 ~name:"aslref doesn't raise strange errors"
+    ~print:Asllib.PP.t_to_string
+    (QCheck2.Gen.sized RandomTypedAST.ast)
+    check_no_strange_error
+
+let () =
+  if false then
+    QCheck_runner.run_tests ~long:true [ no_unsupported_error_random ] |> exit
+
+let no_unsupported_error_enum () =
+  let count = Z.of_int 10000 in
+  let module IFSeq = Feat.IFSeq in
+  let rec loop n count acc =
+    let seq = EnumAST.asts n in
+    let len = IFSeq.length seq in
+    if Z.leq len count then
+      loop (succ n) Z.(sub count len) (IFSeq.to_seq seq acc)
+    else IFSeq.sample (Z.to_int count) seq acc
+  in
+  let alls = loop 0 count Seq.empty in
+  Seq.iter no_strange_error alls
+
+let () = no_unsupported_error_enum ()

--- a/asllib/carpenter/test/dune
+++ b/asllib/carpenter/test/dune
@@ -1,0 +1,5 @@
+(test
+ (name aslref)
+ (modules aslref)
+ (enabled_if %{lib-available:qcheck})
+ (libraries carpenter_lib feat qcheck asllib))

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -55,6 +55,7 @@ type error_desc =
   | OverlappingSlices of slice list
   | BadLDI of AST.local_decl_item
   | BadRecursiveDecls of identifier list
+  | UnrespectedParserInvariant
 
 type error = error_desc annotated
 
@@ -200,6 +201,7 @@ let pp_error =
         fprintf f "ASL Typing error:@ multiple recursive declarations:@ @[%a@]"
           (pp_comma_list (fun f -> fprintf f "%S"))
           decls
+    | UnrespectedParserInvariant -> fprintf f "Parser invariant broke."
     | BadReturnStmt (Some t) ->
         fprintf f
           "ASL Typing error:@ cannot@ return@ nothing@ from@ a@ function,@ an@ \
@@ -210,3 +212,8 @@ let pp_error =
 
 let error_to_string = Format.asprintf "%a" pp_error
 let eprintln = Format.eprintf "@[<2>%a@]@." pp_error
+
+let () =
+  Printexc.register_printer @@ function
+  | ASLException e -> Some (error_to_string e)
+  | _ -> None

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
-(dirs :standard \ catalogue)
+(dirs :standard \ catalogue carpenter)
 
 (env
  (release

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -12,8 +12,8 @@ bug-reports: "http://github.com/herd/herdtools7/issues/"
 doc: "http://diy.inria.fr/doc/index.html"
 dev-repo: "git+https://github.com/herd/herdtools7.git"
 license: "CECILL-B"
-build: ["sh" "./dune-build.sh" "%{prefix}%"]
-install: ["sh" "./dune-install.sh" "%{prefix}%"]
+build: [make "build" "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
 # @todo Add "build-doc" field
 # @todo Add "build-test" field
 depends: [


### PR DESCRIPTION
This PR introduces carpenter, an AST generator for ASL, working in two modes:
 - Enumerating all possible ASTs by increasing size
 - Randomly generating ASTs that respect some type-checking constraints

It can also work as a fuzzing tool, and as an execution tool for ASLRef.

Building and installing it is completely optional.