### PR TITLE
[all] Implement the AArch64 LDRSW instruction

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -90,7 +90,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_EOR_SIMD _| I_ERET| I_FENCE _| I_GC _| I_IC _| I_LD1 _| I_LD1M _| I_LD1R _
     | I_LD2 _| I_LD2M _| I_LD2R _| I_LD3 _| I_LD3M _| I_LD3R _| I_LD4 _| I_LD4M _
     | I_LD4R _| I_LDAR _| I_LDARBH _| I_LDCT _| I_LDG _| I_LDOP _| I_LDOPBH _
-    | I_LDP _| I_LDP_P_SIMD _| I_LDP_SIMD _| I_LDPSW _| I_LDR _| I_LDR_P_SIMD _
+    | I_LDP _| I_LDP_P_SIMD _| I_LDP_SIMD _| I_LDPSW _| I_LDR _
+    | I_LDRSW _ | I_LDR_P_SIMD _
     | I_LDR_SIMD _| I_LDRBH _| I_LDRS _| I_LDUR _| I_LDUR_SIMD _| I_LDXP _| I_MOV _
     | I_MOV_FG _| I_MOV_S _| I_MOV_TG _| I_MOV_V _| I_MOV_VE _| I_MOVI_S _
     | I_MOVI_V _| I_MOVK _| I_MOVZ _| I_MOVN _| I_MRS _| I_MSR _| I_OP3 _| I_RBIT _
@@ -217,7 +218,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | _ -> assert false (* Unsupported arrangement specifier *)
 
     let mem_access_size = function
-      | I_LDPSW _ -> Some (tr_variant V32)
+      | I_LDPSW _ | I_LDRSW _ -> Some MachSize.Word
       | I_LDR (v,_,_,_) | I_LDP (_,v,_,_,_,_,_) | I_LDXP (v,_,_,_,_)
       | I_LDUR (v,_,_,_)
       | I_STR (v,_,_,_) | I_STLR (v,_,_) | I_STXR (v,_,_,_,_)
@@ -295,9 +296,12 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_BL _ | I_BLR _ | I_RET _ | I_ERET | I_UDF _
         -> [] (* For -variant self only ? *)
       | I_LDR (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
+      | I_LDRSW (r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
       | I_LDRBH (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
         -> [r1;r2;]
-      | I_LDR (_,r,_,_)|I_LDRBH (_,r,_,_)
+      | I_LDR (_,r,_,_)
+      | I_LDRSW (r,_,_)
+      | I_LDRBH (_,r,_,_)
       | I_LDRS (_,_,r,_)
       | I_LDUR (_,r,_,_)
       | I_LDAR (_,_,r,_) |I_LDARBH (_,_,r,_)
@@ -353,7 +357,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_NOP|I_B _|I_BR _|I_BC _|I_CBZ _|I_CBNZ _
       | I_TBNZ _|I_TBZ _|I_BL _|I_BLR _|I_RET _|I_ERET
       | I_UBFM _ | I_SBFM _
-      | I_LDR _|I_LDUR _|I_LD1 _
+      | I_LDR _|I_LDRSW _|I_LDUR _|I_LD1 _
       | I_LD1M _|I_LD1R _|I_LD2 _|I_LD2M _
       | I_LD2R _|I_LD3 _|I_LD3M _|I_LD3R _
       | I_LD4 _|I_LD4M _|I_LD4R _|I_ST1 _

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -242,7 +242,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD4 (rs,_,_,_) | I_LD4R (rs,_,_) | I_ST4 (rs,_,_,_)
       | I_LD4M (rs,_,_) | I_ST4M (rs,_,_) ->
           Some (simd_mem_access_size rs)
-      | I_LDRBH (v,_,_,_) | I_LDARBH (v,_,_,_) | I_LDRS (_,v,_,_)
+      | I_LDRBH (v,_,_,_) | I_LDARBH (v,_,_,_) | I_LDRS ((_,v),_,_,_)
       | I_STRBH (v,_,_,_) | I_STLRBH (v,_,_) | I_STXRBH (v,_,_,_,_)
       | I_CASBH (v,_,_,_,_) | I_SWPBH (v,_,_,_,_)
       | I_LDOPBH (_,v,_,_,_,_) | I_STOPBH (_,v,_,_,_) ->
@@ -296,13 +296,14 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_BL _ | I_BLR _ | I_RET _ | I_ERET | I_UDF _
         -> [] (* For -variant self only ? *)
       | I_LDR (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
-      | I_LDRSW (r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
       | I_LDRBH (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
+      | I_LDRSW (r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
+      | I_LDRS (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
         -> [r1;r2;]
       | I_LDR (_,r,_,_)
       | I_LDRSW (r,_,_)
       | I_LDRBH (_,r,_,_)
-      | I_LDRS (_,_,r,_)
+      | I_LDRS (_,r,_,_)
       | I_LDUR (_,r,_,_)
       | I_LDAR (_,_,r,_) |I_LDARBH (_,_,r,_)
       | I_SWP (_,_,_,r,_) | I_SWPBH (_,_,_,r,_)
@@ -351,13 +352,12 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     let get_lx_sz = function
       | I_LDAR (var,(XX|AX),_,_)|I_LDXP (var,_,_,_,_) -> MachSize.Ld (tr_variant var)
       | I_LDARBH (bh,(XX|AX),_,_) -> MachSize.Ld (bh_to_sz bh)
-      | I_LDRS (var,_,_,_) -> MachSize.Ld (tr_variant var)
       | I_STXR _|I_STXRBH _ | I_STXP _ -> MachSize.St
       | I_LDAR (_, (AA|AQ), _, _)|I_LDARBH (_, (AA|AQ), _, _)
       | I_NOP|I_B _|I_BR _|I_BC _|I_CBZ _|I_CBNZ _
       | I_TBNZ _|I_TBZ _|I_BL _|I_BLR _|I_RET _|I_ERET
       | I_UBFM _ | I_SBFM _
-      | I_LDR _|I_LDRSW _|I_LDUR _|I_LD1 _
+      | I_LDR _|I_LDRSW _|I_LDRS _|I_LDUR _|I_LD1 _
       | I_LD1M _|I_LD1R _|I_LD2 _|I_LD2M _
       | I_LD2R _|I_LD3 _|I_LD3M _|I_LD3R _
       | I_LD4 _|I_LD4M _|I_LD4R _|I_ST1 _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1330,10 +1330,12 @@ module Make
         write_reg rA new_addr ii
 
 (* Ordinary loads *)
-      let ldr sz rd rs e ii =
+      let ldr ?(sxt=false) sz rd rs e ii =
         let open AArch64Base in
         let open MemExt in
-        let mop ac a = do_read_mem sz Annot.N aexp ac rd a ii in
+        let mop ac a =
+          (if sxt then do_read_mem_sxt else do_read_mem)
+            sz Annot.N aexp ac rd a ii in
         match e with
         | Imm (k,Idx) ->
            do_ldr rs sz Annot.N mop (get_ea_idx rs k ii) ii
@@ -1354,6 +1356,8 @@ module Make
                  (fun ac a ->
                    read_mem_postindexed a_virt sz Annot.N aexp ac rd rs k a ii)
                  ma ii)
+
+      let ldrsw rd rs e ii = ldr ~sxt:true MachSize.Word rd rs e ii
 
       module LoadPair
           (Read:
@@ -2396,6 +2400,8 @@ module Make
         | I_LDR(var,rd,rs,e) ->
             let sz = tr_variant var in
             ldr sz rd rs e ii
+        | I_LDRSW(rd,rs,e) ->
+            ldrsw rd rs e ii
         | I_LDRBH (bh, rd, rs, e) ->
             let sz = bh_to_sz bh in
             ldr sz rd rs e ii

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -89,12 +89,21 @@ module Make
       let (>>!) = M.(>>!)
       let (>>::) = M.(>>::)
 
+      let sxt_op sz =  M.op1 (Op.Sxt sz)
+      and uxt_op sz =
+        match sz with
+        | MachSize.Quad when not morello  -> M.unitT
+        | _ ->
+           M.op1 (Op.Mask sz)
+      let sxtw_op = sxt_op MachSize.Word
+      and uxtw_op = uxt_op MachSize.Word
+
       let mask32 ty m =
         let open AArch64Base in
         match ty with
-        | V32 -> fun v -> M.op1 (Op.Mask MachSize.Word) v >>= m
+        | V32 -> fun v -> uxtw_op v >>= m
         | V64 when not morello -> m
-        | V64 -> fun v -> M.op1 (Op.Mask MachSize.Quad) v >>= m
+        | V64 -> fun v -> uxt_op MachSize.Quad v >>= m
         | V128 -> m
 
       let is_zero v = M.op Op.Eq v V.zero
@@ -160,7 +169,7 @@ module Make
       | MachSize.S128 -> read_reg_morello is_data r ii
       | MachSize.Quad when not morello || not is_data -> read_reg is_data r ii
       | MachSize.Quad|MachSize.Word|MachSize.Short|MachSize.Byte ->
-          read_reg is_data r ii >>= fun v -> M.op1 (Op.Mask sz) v
+          read_reg is_data r ii >>= uxt_op sz
 
       let read_reg_ord = read_reg_sz quad false
       let read_reg_ord_sz sz = read_reg_sz sz false
@@ -215,7 +224,7 @@ module Make
         | AArch64Base.Vreg(vr',_) -> (AArch64Base.SIMDreg vr')
         | _ -> assert false in
           (* Clear unused register bits (zero extend) *)
-          M.op1 (Op.Mask sz) v >>= fun v ->
+          uxt_op sz v >>= fun v ->
           let location = A.Location_reg (ii.A.proc,vr) in
           M.write_loc (mk_write MachSize.S128 Annot.N aexp Access.REG v) location ii
 
@@ -242,17 +251,19 @@ module Make
             M.op1 (op sz) v >>= fun v -> write_reg r v ii
 
       let write_reg_sz = do_write_reg_sz (fun sz -> Op.Mask sz)
-      and write_reg_sz_sxt = do_write_reg_sz (fun sz -> Op.Sxt sz)
+
+      let write_reg_op op sz r v ii =
+        match r with
+        | AArch64.ZR -> M.unitT ()
+        | _ ->
+           match sz with
+           | MachSize.S128 -> write_reg_morello r v ii
+           | MachSize.Quad|MachSize.Word|MachSize.Short|MachSize.Byte ->
+              op v >>= fun v -> write_reg r v ii
 
       let write_reg_sz_non_mixed =
         if mixed then fun _sz -> write_reg
         else write_reg_sz
-
-      and write_reg_sz_non_mixed_sxt =
-        if mixed then
-          fun sz r v ii ->
-          M.op1 (Op.Sxt sz) v >>= fun v -> write_reg r v ii
-        else write_reg_sz_sxt
 
 (* Emit commit event *)
       let commit_bcc ii = M.mk_singleton_es (Act.Commit (Act.Bcc,None)) ii
@@ -745,15 +756,12 @@ module Make
         else m a
 
 (* Save value read in register rd *)
-      let do_read_mem sz an anexp ac rd a ii =
+      let do_read_mem_op op sz an anexp ac rd a ii =
         do_read_mem_ret sz an anexp ac a ii
-        >>= fun v -> write_reg_sz_non_mixed sz rd v ii
+        >>= fun v -> write_reg_op op sz rd v ii
         >>= fun () -> B.nextT
 
-      and do_read_mem_sxt sz an anexp ac rd a ii =
-        do_read_mem_ret sz an anexp ac a ii
-        >>= fun v -> write_reg_sz_non_mixed_sxt sz rd v ii
-        >>= fun () -> B.nextT
+      let do_read_mem sz  = do_read_mem_op (M.op1 (Op.Mask sz)) sz
 
       let read_mem_acquire sz = do_read_mem sz Annot.A
       let read_mem_acquire_pc sz = do_read_mem sz Annot.Q
@@ -771,11 +779,11 @@ module Make
       (* Post-Indexed load immediate.
          Note: a (effective address) can be physical address,
          while postindex must apply to virtual address. *)
-      let read_mem_postindexed a_virt sz an anexp ac rd rs k a ii =
+      let read_mem_postindexed a_virt op sz an anexp ac rd rs k a ii =
         let m a =
           begin
             (M.add a_virt (V.intToV k) >>= fun b -> write_reg rs b ii)
-            >>| do_read_mem sz an anexp ac rd a ii
+            >>| do_read_mem_op op sz an anexp ac rd a ii
           end >>= fun ((),r) -> M.unitT r in
         if morello then
           M.op1 Op.CapaStrip a >>= m
@@ -1224,11 +1232,7 @@ module Make
         | 0 -> M.unitT
         | _ -> M.op1 op
 
-      let sxt_op sz =  M.op1 (Op.Sxt sz)
-      and uxt_op sz =  M.op1 (Op.Mask sz)
-      let sxtw_op = sxt_op MachSize.Word
-      and uxtw_op = uxt_op MachSize.Word
-      and lsl_op k = do_shift (Op.LeftShift k) k
+      let  lsl_op k = do_shift (Op.LeftShift k) k
       and lsr_op sz k v =
         uxt_op sz v >>= do_shift (Op.LogicalRightShift k) k
       and asr_op sz k v =
@@ -1330,12 +1334,11 @@ module Make
         write_reg rA new_addr ii
 
 (* Ordinary loads *)
-      let ldr ?(sxt=false) sz rd rs e ii =
+      let ldr0 op sz rd rs e ii =
         let open AArch64Base in
         let open MemExt in
         let mop ac a =
-          (if sxt then do_read_mem_sxt else do_read_mem)
-            sz Annot.N aexp ac rd a ii in
+          do_read_mem_op op sz Annot.N aexp ac rd a ii in
         match e with
         | Imm (k,Idx) ->
            do_ldr rs sz Annot.N mop (get_ea_idx rs k ii) ii
@@ -1349,15 +1352,31 @@ module Make
             * of the "read memory" monad, which thus departs
             * from the ordinary `do_read_mem`.
             *)
-           M.delay_kont "ldr_p"
+           M.delay_kont "ldr_postindex"
              (read_reg_ord rs ii)
              (fun a_virt ma ->
                do_ldr rs sz Annot.N
                  (fun ac a ->
-                   read_mem_postindexed a_virt sz Annot.N aexp ac rd rs k a ii)
+                   read_mem_postindexed
+                     a_virt op sz Annot.N aexp ac rd rs k a ii)
                  ma ii)
 
-      let ldrsw rd rs e ii = ldr ~sxt:true MachSize.Word rd rs e ii
+      let ldr sz = ldr0 (uxt_op sz) sz
+      and ldrsw rd rs e ii =
+        let sz = MachSize.Word in
+        ldr0 (sxt_op sz) sz rd rs e ii
+      and ldrs sz var =
+        (*
+         * Load signed - sign extends to either 32 or 64 bit value
+         * load either 8 or 16 bit value (sz),
+         * then sign extend based on register size (var)
+         *)
+        let op = match var with
+          | MachSize.Quad -> sxt_op sz
+          | MachSize.Word ->
+             fun v -> sxt_op sz v >>=  uxt_op MachSize.Word
+          | _ -> assert false in
+        ldr0 op sz
 
       module LoadPair
           (Read:
@@ -1433,7 +1452,7 @@ module Make
         let module LDPSW =
           LoadPair
             (struct
-              let read_mem = do_read_mem_sxt
+              let read_mem = do_read_mem_op sxtw_op
             end) in
         LDPSW.ldp AArch64.Pa MachSize.Word
 
@@ -1566,18 +1585,7 @@ module Make
         | AArch64.PreIdx ->
             stp_wback sz an rs1 rs2 rd k false ii
 
-      (* Load signed - sign extends to either 32 or 64 bit value*)
-      let ldrs sz var rd rs kr s ii =
-        (* load either 8 or 16 bit value (sz),
-        then sign extend based on register size (var) *)
-        do_ldr rs sz Annot.N
-          (fun ac a -> do_read_mem_ret sz Annot.N aexp ac a ii
-            >>= M.op1 (Op.Sxt sz)
-            >>= fun v2 -> write_reg_sz_non_mixed
-              (AArch64.tr_variant var) rd v2 ii)
-          (get_ea rs kr s ii) ii
-
-      and stlr sz rs rd ii =
+      let stlr sz rs rd ii =
         do_str rd (do_write_mem sz Annot.L aexp) sz Annot.L
           (read_reg_ord rd ii) (read_reg_data sz rs ii) ii
 
@@ -2405,9 +2413,9 @@ module Make
         | I_LDRBH (bh, rd, rs, e) ->
             let sz = bh_to_sz bh in
             ldr sz rd rs e ii
-        | I_LDRS (v, bh, rd, rs) ->
+        | I_LDRS ((v, bh), rd, rs, e) ->
             let sz = bh_to_sz bh in
-            ldrs sz v rd rs (AArch64.K 0) S_NOEXT ii
+            ldrs sz (tr_variant v) rd rs e ii
         | I_LDUR(var,rd,rs,k) ->
             let sz = tr_variant var in
             let k = match k with Some k -> k | None -> 0 in

--- a/herd/tests/instructions/AArch64/L099.litmus
+++ b/herd/tests/instructions/AArch64/L099.litmus
@@ -1,0 +1,23 @@
+AArch64 L099
+{
+int x=-7;
+0:X0=x;
+int64_t 0:X5;
+int64_t 0:X2;
+int64_t 0:X6;
+int64_t 0:X4;
+0:X9=0;
+}
+  P0                  ;
+LDR W1,[X0]           ;
+ADD X5,X5,W1,UXTW     ;
+LDRSW X2,[X0]         ;
+LDR W3,[X0,W9,UXTW]   ;
+ADD X6,X6,W3,UXTW     ;
+LDRSW X4,[X0,W9,SXTW] ;
+locations [0:X5;0:X2;0:X6;0:X4;]
+forall
+  0:X2=-7 /\
+  0:X4=-7 /\
+  0:X5=4294967289 /\
+  0:X6=4294967289

--- a/herd/tests/instructions/AArch64/L099.litmus.expected
+++ b/herd/tests/instructions/AArch64/L099.litmus.expected
@@ -1,0 +1,10 @@
+Test L099 Required
+States 1
+0:X2=-7; 0:X4=-7; 0:X5=4294967289; 0:X6=4294967289;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=-7 /\ 0:X4=-7 /\ 0:X5=4294967289 /\ 0:X6=4294967289)
+Observation L099 Always 1 0
+Hash=5615a168ee3d6a9bc72df5a2e1932833
+

--- a/herd/tests/instructions/AArch64/L100.litmus
+++ b/herd/tests/instructions/AArch64/L100.litmus
@@ -1,0 +1,12 @@
+AArch64 L100
+{
+int x=-7;
+0:X0=x;
+int64_t 0:X1;
+}
+  P0          ;
+LDRSW X1,[X0] ;
+forall 0:X1=-7
+
+
+

--- a/herd/tests/instructions/AArch64/L100.litmus.expected
+++ b/herd/tests/instructions/AArch64/L100.litmus.expected
@@ -1,0 +1,10 @@
+Test L100 Required
+States 1
+0:X1=-7;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=-7)
+Observation L100 Always 1 0
+Hash=73ed83cc72f02e2df95b5adc8205c25c
+

--- a/herd/tests/instructions/AArch64/L101.litmus
+++ b/herd/tests/instructions/AArch64/L101.litmus
@@ -1,0 +1,25 @@
+AArch64 L101
+{
+int64_t x=-7;
+int16_t y=-7;
+int8_t  z[3]={-7,-5,-3};
+0:X0=x;
+0:X8=y;
+0:X9=z;
+int64_t 0:X2=0;
+int64_t 0:X1;
+int64_t 0:X3;
+int64_t 0:X4;
+int64_t 0:X5;
+}
+  P0                   ;
+LDRSW X1,[X0,X2,LSL 2] ;
+LDRSH W3,[X8,X2,LSL 1] ;
+LDRSB X4,[X9],#2       ;
+LDRSB X5,[X9,#-1]!     ;
+locations [0:X1;0:X3;0:X4;0:X5;]
+forall
+  0:X1=-7 /\
+  0:X3=4294967289 /\
+  0:X4=-7 /\
+  0:X5=-5

--- a/herd/tests/instructions/AArch64/L101.litmus.expected
+++ b/herd/tests/instructions/AArch64/L101.litmus.expected
@@ -1,0 +1,10 @@
+Test L101 Required
+States 1
+0:X1=-7; 0:X3=4294967289; 0:X4=-7; 0:X5=-5;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=-7 /\ 0:X3=4294967289 /\ 0:X4=-7 /\ 0:X5=-5)
+Observation L101 Always 1 0
+Hash=2a330e983837edea58b958262a92c30c
+

--- a/herd/tests/instructions/AArch64/L102.litmus
+++ b/herd/tests/instructions/AArch64/L102.litmus
@@ -1,0 +1,18 @@
+AArch64 L102
+{
+int x[4] = {-1,-2,-3,-2};
+0:X0=x;
+int64_t 0:X2;
+int64_t 0:X3;
+int64_t 0:X4;
+}
+  P0                   ;
+MOV W1,#-7             ;
+STR W1,[X0],#12        ;
+LDRSW X3,[X0],#4       ;
+LDRSW X4,[X0,X3,LSL 2] ;
+LDRSW X2,[X0,#-16]!    ;
+forall 0:X2=-7 /\ 0:X3=-2 /\ 0:X4=-3
+
+
+

--- a/herd/tests/instructions/AArch64/L102.litmus.expected
+++ b/herd/tests/instructions/AArch64/L102.litmus.expected
@@ -1,0 +1,10 @@
+Test L102 Required
+States 1
+0:X2=-7; 0:X3=-2; 0:X4=-3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=-7 /\ 0:X3=-2 /\ 0:X4=-3)
+Observation L102 Always 1 0
+Hash=f44678c331ca2a4a17b9d20f5a5aac42
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -386,6 +386,11 @@ include Arch.MakeArch(struct
         conv_reg r2 >> fun r2 ->
         MemExt.expl e >! fun e ->
         I_LDR(a,r1,r2,e)
+    | I_LDRSW(r1,r2,e) ->
+        conv_reg r1 >> fun r1 ->
+        conv_reg r2 >> fun r2 ->
+        MemExt.expl e >! fun e ->
+        I_LDRSW(r1,r2,e)
     | I_LDUR(a,r1,r2,Some(k)) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -172,8 +172,9 @@ include Arch.MakeArch(struct
       ->
         match_kr subs (K k) (K k') >>>
         add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')]
-    | I_LDRS(_,_,r1,r2),I_LDRS(_,_,r1',r2')
-      -> add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')] subs
+    | I_LDRSW (r1,r2,e),I_LDRSW (r1',r2',e')
+    | I_LDRS((_,B),r1,r2,e),I_LDRS((_,B),r1',r2',e')
+    | I_LDRS((_,H),r1,r2,e),I_LDRS((_,H),r1',r2',e')
     | I_LDR(_,r1,r2,e),I_LDR(_,r1',r2',e')
     | I_STR(_,r1,r2,e),I_STR(_,r1',r2',e')
       ->
@@ -391,6 +392,11 @@ include Arch.MakeArch(struct
         conv_reg r2 >> fun r2 ->
         MemExt.expl e >! fun e ->
         I_LDRSW(r1,r2,e)
+    | I_LDRS(v,r1,r2,e) ->
+        conv_reg r1 >> fun r1 ->
+        conv_reg r2 >> fun r2 ->
+        MemExt.expl e >! fun e ->
+        I_LDRS(v,r1,r2,e)
     | I_LDUR(a,r1,r2,Some(k)) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->
@@ -431,10 +437,6 @@ include Arch.MakeArch(struct
         conv_reg r2 >> fun r2 ->
         MemExt.expl e >! fun e ->
         I_LDRBH(a,r1,r2,e)
-    | I_LDRS(a,var,r1,r2) ->
-        conv_reg r1 >> fun r1 ->
-        conv_reg r2 >! fun r2 ->
-        I_LDRS(a,var,r1,r2)
     | I_STR(a,r1,r2,e) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1011,6 +1011,8 @@ let pp_bh = function
   | B -> "B"
   | H -> "H"
 
+let ldrs_memo bh = "LDRS" ^ pp_bh bh
+
 let bh_to_sz = function
   | B -> MachSize.Byte
   | H -> MachSize.Short
@@ -1134,7 +1136,7 @@ type 'k kinstruction =
   | I_UNSEAL of reg * reg * reg
 (* Idem for bytes and half words *)
   | I_LDRBH of bh * reg * reg * 'k MemExt.ext
-  | I_LDRS of variant * bh * reg * reg
+  | I_LDRS of (variant * bh) * reg * reg * 'k MemExt.ext
   | I_LDARBH of bh * ld_type * reg * reg
   | I_STRBH of bh * reg * reg * 'k MemExt.ext
   | I_STLRBH of bh * reg * reg
@@ -1451,6 +1453,8 @@ let pp_k_nz k = if m.zerop k then "" else "," ^ m.pp_k k in
       pp_mem_idx "LDR" v r1 r2 idx
   | I_LDRSW (r1,r2,idx) ->
       pp_mem_idx "LDRSW" V64 r1 r2 idx
+  | I_LDRS ((v,bh),r1,r2,idx) ->
+     pp_mem_idx (ldrs_memo bh) v r1 r2 idx
   | I_LDUR (_,r1,r2,None) ->
       sprintf "LDUR %s, [%s]" (pp_reg r1) (pp_reg r2)
   | I_LDUR (_,r1,r2,Some(k)) ->
@@ -1467,8 +1471,6 @@ let pp_k_nz k = if m.zerop k then "" else "," ^ m.pp_k k in
       pp_mem (ldrbh_memo bh t)  V32 r1 r2 m.k0
   | I_LDXP (v,t,r1,r2,r3) ->
       pp_ldxp (ldxp_memo t) v r1 r2 r3
-  | I_LDRS (v,bh,r1,r2) ->
-      sprintf "%s %s,[%s]" ("LDRS"^pp_bh bh) (pp_vreg v r1) (pp_xreg r2)
   | I_STR (v,r1,r2,idx) ->
       pp_mem_idx "STR" v r1 r2 idx
   | I_STLR (v,r1,r2) ->
@@ -1816,7 +1818,7 @@ let fold_regs (f_regs,f_sregs) =
   | I_MOV (_,r1,kr)
     -> fold_reg r1 (fold_kr kr c)
   | I_LDAR (_,_,r1,r2) | I_STLR (_,r1,r2) | I_STLRBH (_,r1,r2)
-  | I_SXTW (r1,r2) | I_LDARBH (_,_,r1,r2) | I_LDRS (_,_,r1,r2)
+  | I_SXTW (r1,r2) | I_LDARBH (_,_,r1,r2)
   | I_SBFM (_,r1,r2,_,_) | I_UBFM (_,r1,r2,_,_)
   | I_STOP (_,_,_,r1,r2) | I_STOPBH (_,_,_,r1,r2)
   | I_RBIT (_,r1,r2) | I_ABS (_,r1,r2)
@@ -1837,7 +1839,8 @@ let fold_regs (f_regs,f_sregs) =
     -> fold_reg r1 (fold_reg r2 (fold_kr kr c))
   | I_OP3 (_,_,r1,r2,e)
     -> fold_reg r1 (fold_reg r2 (fold_op_ext e c))
-  | I_LDR (_,r1,r2,idx) | I_LDRSW (r1,r2,idx)  | I_STR (_,r1,r2,idx)
+  | I_LDR (_,r1,r2,idx) | I_LDRSW (r1,r2,idx)
+  | I_LDRS (_,r1,r2,idx) | I_STR (_,r1,r2,idx)
   | I_LDRBH (_,r1,r2,idx) | I_STRBH (_,r1,r2,idx)
     -> fold_reg r1 (fold_reg r2 (fold_idx idx c))
   | I_LD1M (rs,r2,kr)
@@ -1934,6 +1937,8 @@ let map_regs f_reg f_symb =
      I_LDR (v,map_reg r1,map_reg r2,map_idx idx)
   | I_LDRSW (r1,r2,idx) ->
      I_LDRSW (map_reg r1,map_reg r2,map_idx idx)
+  | I_LDRS (v,r1,r2,idx) ->
+     I_LDRS (v,map_reg r1,map_reg r2,map_idx idx)
   | I_LDRBH (v,r1,r2,idx) ->
      I_LDRBH (v,map_reg r1,map_reg r2,map_idx idx)
   | I_LDUR (v,r1,r2,k) ->
@@ -1950,8 +1955,6 @@ let map_regs f_reg f_symb =
      I_LDARBH (bh,t,map_reg r1,map_reg r2)
   | I_LDXP (v,t,r1,r2,r3) ->
      I_LDXP (v,t,map_reg r1,map_reg r2,map_reg r3)
-  | I_LDRS (v,bh,r1,r2) ->
-     I_LDRS (v,bh,map_reg r1,map_reg r2)
   | I_STR (v,r1,r2,idx) ->
       I_STR (v,map_reg r1,map_reg r2,map_idx idx)
   | I_STRBH (v,r1,r2,idx) ->
@@ -2189,6 +2192,7 @@ let get_next =
   | I_NOP
   | I_LDR _
   | I_LDRSW _
+  | I_LDRS _
   | I_LDUR _
   | I_LDP _
   | I_LDPSW _
@@ -2196,7 +2200,6 @@ let get_next =
   | I_STR _
   | I_LDAR _
   | I_LDARBH _
-  | I_LDRS _
   | I_STLR _
   | I_STLRBH _
   | I_STXR _
@@ -2445,7 +2448,6 @@ module PseudoI = struct
         | I_ERET
         | I_LDAR _
         | I_LDARBH _
-        | I_LDRS _
         | I_STLR _
         | I_STLRBH _
         | I_STXR _
@@ -2480,6 +2482,7 @@ module PseudoI = struct
             as keep -> keep
         | I_LDR (v,r1,r2,idx) -> I_LDR (v,r1,r2,idx_tr idx)
         | I_LDRSW (r1,r2,idx) -> I_LDRSW (r1,r2,idx_tr idx)
+        | I_LDRS (v,r1,r2,idx) -> I_LDRS (v,r1,r2,idx_tr idx)
         | I_LDUR (v,r1,r2,None) -> I_LDUR (v,r1,r2,None)
         | I_LDUR (v,r1,r2,Some(k)) -> I_LDUR (v,r1,r2,Some(k_tr k))
         | I_LDP (t,v,r1,r2,r3,k,md) -> I_LDP (t,v,r1,r2,r3,k_tr k,md)

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -81,6 +81,7 @@ match name with
 | "tbz" | "TBZ" -> TBZ
 (* Memory *)
 | "ldr"|"LDR" -> LDR
+| "ldrsw"|"LDRSW" -> LDRSW
 | "ldur"|"LDUR" -> LDUR
 | "ldp"|"LDP" -> LDP
 | "ldpsw"|"LDPSW" -> LDPSW

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -73,7 +73,7 @@ let mk_instrp instr v r1 r2 ra ko kb =
 %token TOK_CS TOK_CC TOK_MI TOK_PL TOK_VS TOK_VC TOK_HI TOK_LS TOK_AL
 %token BEQ BNE BGE BGT BLE BLT BCS BCC BMI BPL BVS BVC BHI BLS BAL
 %token BL BLR RET ERET
-%token LDR LDP LDNP LDPSW LDIAPP STP STNP STILP
+%token LDR LDRSW LDP LDNP LDPSW LDIAPP STP STNP STILP
 %token LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
 %token LDRSB LDRSH
 %token LD1 LD1R LD2 LD2R LD3 LD3R LD4 LD4R ST1 ST2 ST3 ST4 STUR /* Neon load/store */
@@ -561,6 +561,8 @@ instr:
 /* Memory */
 | LDR wxreg COMMA mem_ea
   { let (v,r)   = $2 and (ra,ext) = $4 in I_LDR (v,r,ra,ext) }
+| LDRSW xreg COMMA mem_ea
+  { let r = $2 and (ra,ext) = $4 in I_LDRSW (r,ra,ext) }
 | LDUR reg COMMA LBRK cxreg k0_opt RBRK
   { let v,r = $2 in I_LDUR (v,r,$5,$6)}
 

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -563,6 +563,10 @@ instr:
   { let (v,r)   = $2 and (ra,ext) = $4 in I_LDR (v,r,ra,ext) }
 | LDRSW xreg COMMA mem_ea
   { let r = $2 and (ra,ext) = $4 in I_LDRSW (r,ra,ext) }
+| LDRSB reg COMMA mem_ea
+  { let (v, s) = $2 and (ra,ext) = $4 in I_LDRS ((v,B),s,ra,ext) }
+| LDRSH reg COMMA mem_ea
+  { let (v, s) = $2 and (ra,ext) = $4 in I_LDRS ((v,H),s,ra,ext) }
 | LDUR reg COMMA LBRK cxreg k0_opt RBRK
   { let v,r = $2 in I_LDUR (v,r,$5,$6)}
 
@@ -599,10 +603,6 @@ instr:
   { let (ra,idx) = $4 in I_LDRBH (B,$2,ra,idx) }
 | LDRH wreg COMMA mem_ea
   { let ra,idx = $4 in I_LDRBH (H,$2,ra,idx) }
-| LDRSB reg COMMA LBRK cxreg RBRK
-  { let (v, s) = $2 in I_LDRS (v,B,s,$5) }
-| LDRSH reg COMMA LBRK cxreg RBRK
-  { let (v, s) = $2 in I_LDRS (v,H,s,$5) }
 | LDAR reg COMMA LBRK cxreg RBRK
   { let v,r = $2 in I_LDAR (v,AA,r,$5) }
 | LDARB wreg COMMA LBRK cxreg RBRK

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1276,8 +1276,8 @@ module Make(V:Constant.S)(C:Config) =
         storex_pair (Misc.lowercase (stxp_memo t)) v r1 r2 r3 r4::k
     | I_LDRBH (B,r1,r2,idx) -> load "ldrb" V32 r1 r2 idx::k
     | I_LDRBH (H,r1,r2,idx) -> load "ldrh" V32 r1 r2 idx::k
-    | I_LDRS (var,B,r1,r2) -> load "ldrsb" var r1 r2 MemExt.zero::k
-    | I_LDRS (var,H,r1,r2) -> load "ldrsh" var r1 r2 MemExt.zero::k
+    | I_LDRS ((var,bh),r1,r2,idx) ->
+       load (ldrs_memo bh |> Misc.lowercase)  var r1 r2 idx::k
     | I_LDAR (v,t,r1,r2) -> load (ldr_memo t) v r1 r2 MemExt.zero::k
     | I_LDARBH (bh,t,r1,r2) -> load (ldrbh_memo bh t) V32 r1 r2 MemExt.zero::k
     | I_STR (v,r1,r2,idx) -> store "str" v r1 r2 idx::k

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -292,7 +292,7 @@ module Make(V:Constant.S)(C:Config) =
          let i,fi = do_arg1i v rB 1 in
          { empty_ins with
            memo=
-             sprintf "%s ^%s,[^i0,%s,%s,#%d]"
+             sprintf "%s ^%s,[^i0,%s,%s #%d]"
                memo fd fi (pp_mem_sext se) k;
            inputs=[rA]@i;
            outputs=[rD];
@@ -1261,6 +1261,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_TBZ (v,r,k2,lbl) -> tbz tr_lab "tbz" v r k2 lbl::k
 (* Load and Store *)
     | I_LDR (v,r1,r2,idx) -> load "ldr" v r1 r2 idx::k
+    | I_LDRSW (r1,r2,idx) -> load "ldrsw" V64 r1 r2 idx::k
     | I_LDUR (v,r1,r2,Some(k')) -> load "ldur" v r1 r2 (MemExt.k2idx k')::k
     | I_LDUR (v,r1,r2,None) -> load "ldur" v r1 r2 (MemExt.k2idx 0)::k
     | I_LDP (t,v,r1,r2,r3,kr,md) ->


### PR DESCRIPTION
This instruction loads a 32bit quantity, sign-extends it to a 64bit quantity, and stores it in a X register.

Example:
```
AArch64 LDRSW
{
int x=-7;
0:X0=x;
int64_t 0:X1;
}
  P0          ;
LDRSW X1,[X0] ;
forall 0:X1=-7
```
Sign has been carried from the memory cell to the register.
