### PR TITLE
[asl] (fix) correctly propagate ASL po

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -971,7 +971,9 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
                 ASLE.EventRel.of_pred mem_evts mem_evts (fun e1 e2 ->
                     ASLE.same_location e1 e2 && ASLE.EventRel.mem (e1, e2) po)
               in
-              let partial_po = ASLE.EventTransRel.to_transitive_rel es.ASLE.partial_po in
+              let partial_po =
+                ASLE.EventTransRel.to_implicitely_transitive_rel es.ASLE.partial_po in
+
               let conc =
                 {
                   ASLS.conc_zero with

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -971,12 +971,14 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
                 ASLE.EventRel.of_pred mem_evts mem_evts (fun e1 e2 ->
                     ASLE.same_location e1 e2 && ASLE.EventRel.mem (e1, e2) po)
               in
+              let partial_po = ASLE.EventTransRel.to_transitive_rel es.ASLE.partial_po in
               let conc =
                 {
                   ASLS.conc_zero with
                   ASLS.str = es;
                   ASLS.rfmap = rfm;
                   ASLS.po;
+                  ASLS.partial_po;
                   ASLS.pos;
                 }
               in

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -113,11 +113,11 @@ module Make (C : Config) = struct
   end = struct
     module Mixed = M.Mixed (SZ)
 
-    let ( let* ) = M.( >>= )
-    let ( let*| ) = M.para_bind_output_right
+    let ( let* ) = M.asl_data
+    let ( let*| ) = M.asl_seq
     let ( and* ) = M.( >>| )
     let return = M.unitT
-    let ( >>= ) = M.( >>= )
+    let ( >>= ) = M.asl_data
     let ( >>! ) = M.( >>! )
 
     (**************************************************************************)
@@ -254,10 +254,10 @@ module Make (C : Config) = struct
     (**************************************************************************)
 
     let choice (m1 : V.v M.t) (m2 : 'b M.t) (m3 : 'b M.t) : 'b M.t =
-      M.bind_ctrl_seq_data m1 (function
+      M.asl_ctrl m1 (function
         | V.Val (Constant.Concrete (ASLScalar.S_Bool b)) -> if b then m2 else m3
         | b ->
-            M.bind_ctrl_seq_data (to_int_signed b) (fun v -> M.choiceT v m2 m3))
+            M.asl_ctrl (to_int_signed b) (fun v -> M.choiceT v m2 m3))
 
     let binop =
       let open AST in

--- a/herd/libdir/asl.cat
+++ b/herd/libdir/asl.cat
@@ -32,14 +32,15 @@ let asl_iico_ctrl = iico_ctrl
 let asl_iico_data = iico_data
 let asl_rf_reg = rf-reg
 let asl_rf = rf
+(* Warning, partial_po is _implicitely_ transitive *)
 let asl_po = partial_po
 
 (* Working relations *)
 
 let aarch64 = NASLLocal * NASLLocal
 
-let asl_fr_reg = ([Rreg] ; asl_po ; [Wreg]) & loc (* loc extended to registers *)
-let asl_fr = ([R] ; asl_po ; [W]) & loc
+let asl_fr_reg =  inter_transitive (asl_po,[Rreg];loc;[Wreg]) (* loc extended to registers *)
+let asl_fr = inter_transitive (asl_po,[R] ; loc ; [W])
 
 let asl_data = asl_iico_data | asl_rf_reg
 let asl_deps = asl_data (* | asl_iico_ctrl *)

--- a/herd/memUtils.ml
+++ b/herd/memUtils.ml
@@ -56,7 +56,7 @@ module Make(S : SemExtra.S) = struct
       (do_po_strict es e1 e2) ||           (* e1 is po-before e2 *)
       (if do_po_strict es e2 e1 then false (* e2 is po-before e1 *)
        else (* e1 and e2 are from the same instruction *)
-       E.EventRel.mem_transitive (e1,e2) iico)
+       E.EventRel.exists_path (e1,e2) iico)
 
 (* Fence *)
   let po_fence_po po pred =

--- a/lib/InnerTransRel.ml
+++ b/lib/InnerTransRel.ml
@@ -17,6 +17,7 @@ module type S = sig
   val union6 : t -> t -> t -> t -> t -> t -> t
   val unions : t list -> t
   val to_transitive_rel : t -> Rel.t
+  val to_implicitely_transitive_rel : t -> Rel.t
 end
 
 module Make (O : MySet.OrderedType) :
@@ -101,4 +102,6 @@ module Make (O : MySet.OrderedType) :
     | li -> unions2 [] li |> unions
 
   let to_transitive_rel t = Rel.transitive_closure t.rel
+
+  let to_implicitely_transitive_rel t = t.rel
 end

--- a/lib/InnerTransRel.mli
+++ b/lib/InnerTransRel.mli
@@ -40,6 +40,9 @@ module type S = sig
 
   val to_transitive_rel : t -> Rel.t
   (** [to_transitive_rel t] is the InnerRel representation of t. *)
+
+  val to_implicitely_transitive_rel : t -> Rel.t
+  (** [to_implicitely_transitive_rel t] is a non-transitive representation of t. *)
 end
 
 module Make : functor (O : MySet.OrderedType) ->

--- a/lib/innerRel.mli
+++ b/lib/innerRel.mli
@@ -32,6 +32,7 @@ module type S =  sig
     val succs : elt0 -> map -> Elts.t
     val add : elt0 -> elt0 -> map -> map
     val subrel : map -> map -> bool
+    val exists_path : (elt0 * elt0) -> map -> bool
     val to_map : t -> map
     val of_map : map -> t
   end
@@ -51,7 +52,7 @@ module type S =  sig
 
 (* Are e1 and e2 related by the transitive closure of relation.
    Does not detect cycles *)
-  val mem_transitive : elt1 * elt2 -> t -> bool
+  val exists_path : elt1 * elt2 -> t -> bool
 
 (* Nodes reachable from node and set of nodes [argument included in result] *)
   val reachable : elt0 -> t -> Elts.t

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -1174,6 +1174,21 @@ module Make
     let oa_changes = check_two (fun w p -> not (U.same_oa w p))
     and at_least_one_writable = check_two U.writable2
 
+    (*
+     * The relation po is to interpreted as a transitive relation,
+     * this primitive is much more efficient when po+ is huge.
+     *)
+    let inter_transitive arg = match arg with
+      |  V.Tuple [V.Rel po; V.Rel loc; ] ->
+          let module ME = E.EventRel.M in
+          let m = ME.to_map  po in
+          let r =
+            E.EventRel.filter
+              (fun  p -> ME.exists_path p m)
+              loc in
+          V.Rel r
+      | _ -> arg_mismatch ()
+
     let add_primitives ks m =
       add_prims m
         [
@@ -1197,6 +1212,7 @@ module Make
          "domain",domain;
          "range",range;
          "fail",fail;
+         "inter_transitive", inter_transitive;
        ]
 
 


### PR DESCRIPTION
ASL partial po was not propagated to AArch64+ASL, which caused iico_order to be empty.
This fixes the SWP AArch64.ASL regression tests.