### PR TITLE
[tools] Enhance mprog7 functionality,

### DIFF
--- a/jingle/arch.ml
+++ b/jingle/arch.ml
@@ -376,7 +376,7 @@ end
 
 module DefaultDumper(A:ArchBase.S) = struct
   type pseudo = A.pseudo
-  include SimpleDumper.Make
+  include SimpleDumper.Make(struct let compat = false end)
       (struct
         module A = A
 

--- a/lib/archDump.mli
+++ b/lib/archDump.mli
@@ -33,6 +33,7 @@ module type S = sig
   type instruction
 
   val dump_instruction : instruction -> string
+  val dump_instruction_hash : instruction -> string
 
   include Pseudo.Types
    with type ins = instruction

--- a/lib/simpleDumper.ml
+++ b/lib/simpleDumper.ml
@@ -36,7 +36,7 @@ module type I = sig
 end
 
 
-module Make(I:I) :
+module Make(O:sig val compat : bool end)(I:I) :
 CoreDumper.S with
   type test =
          (I.state, (MiscParser.proc * I.A.pseudo list) list, I.prop, I.location,
@@ -47,9 +47,13 @@ CoreDumper.S with
   open Printf
   open I
 
+  let dump_instruction =
+    if O.compat then A.dump_instruction_hash
+    else A.dump_instruction
+
   let rec fmt_io io = match io with
   | A.Nop -> ""
-  | A.Instruction ins -> A.dump_instruction ins
+  | A.Instruction ins -> dump_instruction ins
   | A.Label (lbl,io) -> lbl ^ ": " ^ fmt_io io
   | A.Symbolic s -> "codevar:"^s
   | A.Macro (f,regs) ->

--- a/tools/dumper.ml
+++ b/tools/dumper.ml
@@ -16,7 +16,7 @@
 
 module Make(A:Arch_tools.S) = struct
   include
-      SimpleDumper.Make
+      SimpleDumper.Make(struct let compat = false end)
       (struct
         module A = A
 

--- a/tools/dumperMiscParser.ml
+++ b/tools/dumperMiscParser.ml
@@ -18,13 +18,14 @@
 
 module type Opt = sig
   val hexa : bool
+  val compat : bool
 end
 
 module Make(Opt:Opt)(A:ArchBase.S) : CoreDumper.S
   with type test =  A.pseudo MiscParser.t
 = struct
   include
-   SimpleDumper.Make
+   SimpleDumper.Make(Opt)
       (struct
 
         module A = A

--- a/tools/mprog.ml
+++ b/tools/mprog.ml
@@ -27,6 +27,7 @@ module Top
          val ascommands : bool
          val texmacros : bool
          val hexa : bool
+         val compat : bool
          val outputdir : string option
          val mode : OutMode.t
          val transpose : bool
@@ -252,6 +253,7 @@ let args = ref []
 let verbose = ref 0
 let texmacros = ref false
 let hexa = ref false
+let compat = ref false
 let outputdir = ref None
 let mode = ref OutMode.LaTeX
 let transpose = ref false
@@ -263,6 +265,8 @@ let opts =
    (sprintf "<bool> use latex macros in output, default %b" !texmacros);
    "-hexa", Arg.Bool (fun b -> hexa := b),
    (sprintf "<bool> hexadecimal output, default %b" !hexa);
+   "-compat", Arg.Bool (fun b -> compat := b),
+   (sprintf "<bool> backward compatible output (used for hashes), default %b" !hexa);
    begin let module P = ParseTag.Make(OutMode) in
    P.parse "-mode" mode "output mode" end ;
    "-transpose", Arg.Bool (fun b -> transpose := b),
@@ -291,6 +295,7 @@ module X =
       let ascommands = false
       let texmacros = !texmacros
       let hexa = !hexa
+      let compat = !compat
       let outputdir = !outputdir
       let mode = !mode
       let transpose = !transpose


### PR DESCRIPTION
The tools accepts the new command line option `-compat <bool>`. The new behaviour can be useful to find the reason why some hash has changed.