### PR TITLE
[internal] Parallel `herd_regression_test.exe` command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ test:: test.aarch64
 test.aarch64:
 	@ echo
 	$(HERD_REGRESSION_TEST) \
+		-j $(J) \
 		-herd-path $(HERD) \
 		-libdir-path ./herd/libdir \
 		-litmus-dir ./herd/tests/instructions/AArch64 \
@@ -210,6 +211,7 @@ test-pseudo-asl:
 test-aarch64-asl: asl-pseudocode
 	@echo
 	$(HERD_REGRESSION_TEST) \
+		-j $(J) \
 		-herd-path $(HERD) \
 		-libdir-path ./herd/libdir \
 		-litmus-dir ./herd/tests/instructions/AArch64.ASL \

--- a/internal/dune
+++ b/internal/dune
@@ -1,5 +1,5 @@
 (executables
  (names herd_catalogue_regression_test herd_diycross_regression_test
-   herd_regression_test lint_shelves herd_redirect)
+   herd_regression_test lint_shelves herd_redirect herd_test herd_promote)
  (libraries internal_lib)
  (modes native))

--- a/internal/herd_promote.ml
+++ b/internal/herd_promote.ml
@@ -1,0 +1,36 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2023-present Institut National de Recherche en Informatique et *)
+(* en Automatique, ARM Ltd and the authors. All rights reserved.            *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** A tool that runs herd and promotes its output as reference *)
+
+let () =
+  if false then
+    let xs = Array.to_list Sys.argv in
+    Printf.eprintf "%s\n%!" (String.concat " " xs)
+
+let litmus = Sys.argv.(Array.length Sys.argv -1)
+
+let rec to_list k =
+  if k+1 >= Array.length Sys.argv then []
+  else Sys.argv.(k)::to_list (k+1)
+
+let com = Sys.argv.(1)
+let args = to_list 2
+
+let () =
+  let st = TestHerd.run_herd_args com args litmus in
+  let ok = TestHerd.promote litmus st in
+  exit (if ok then 0 else 1)

--- a/internal/herd_regression_test.ml
+++ b/internal/herd_regression_test.ml
@@ -84,17 +84,17 @@ let for_each_litmus_in_dir dir f =
       for_each_remaining_litmus f
     )
 
-let remove_if_exists path =
-  if Sys.file_exists path then
-    Sys.remove path
-
-let write_file path lines =
-  Filesystem.write_file path (fun o -> Channel.write_lines o lines)
+let read_litmus_dir litmus_dir =
+  let litmuses = ref [] in
+  let () =
+    for_each_litmus_in_dir litmus_dir
+      (fun litmus -> litmuses :=  litmus :: !litmuses) in
+  List.rev !litmuses
 
 
 (* Commands. *)
 
-let show_tests flags =
+let show_tests_seq flags =
   let command_of_litmus l =
     TestHerd.herd_command ~bell:None ~cat:None
       ~conf:flags.conf
@@ -107,28 +107,83 @@ let show_tests flags =
     print_char '\n'
   )
 
-let run_tests flags =
-  let test_passes l =
-    TestHerd.herd_output_matches_expected ~bell:None ~cat:None
+let show_tests_par j flags =
+  let herd = flags.herd
+  and args =
+    TestHerd.herd_args
+      ~bell:None ~cat:None
       ~conf:flags.conf
       ~variants:flags.variants
-      ~libdir:flags.libdir
-      flags.herd l
+      ~libdir:flags.libdir ~timeout:None in
+  let herd_test =
+    Filename.concat (Filename.dirname Sys.argv.(0)) "herd_test.exe" in
+  let mapply = Filename.concat (Filename.dirname herd) "mapply7" in
+  let args = "-exit"::"true"::TestHerd.apply_args  herd_test j (herd::args) in
+  let litmuses = read_litmus_dir flags.litmus_dir in
+  let com = Command.command mapply  (args @ litmuses) in
+  Printf.printf "%s\n%!" com
+
+  let show_tests ?j flags =
+    match j with
+    | None -> show_tests_seq flags
+    | Some j -> show_tests_par j flags
+
+  let run_tests_seq flags =
+    let test_passes l =
+      TestHerd.herd_output_matches_expected ~bell:None ~cat:None
+        ~conf:flags.conf
+        ~variants:flags.variants
+        ~libdir:flags.libdir
+        flags.herd l
       (TestHerd.expected_of_litmus l)
       (TestHerd.expected_failure_of_litmus l)
       (TestHerd.expected_warn_of_litmus l)
   in
   let everything_passed = ref true in
   for_each_litmus_in_dir flags.litmus_dir (fun l ->
-    if not (test_passes l) then
+      if not (test_passes l) then
       everything_passed := false
-  ) ;
+    ) ;
   if not !everything_passed then begin
     Printf.printf "Some tests had errors\n" ;
     exit 1
   end
 
-let promote_tests flags =
+let do_run_test_par wrapper j flags =
+  let wrapper = Filename.concat (Filename.dirname Sys.argv.(0)) wrapper in
+  let _dbg = false in
+  let herd = flags.herd
+  and args =
+    TestHerd.herd_args
+      ~bell:None ~cat:None
+      ~conf:flags.conf
+      ~variants:flags.variants
+      ~libdir:flags.libdir ~timeout:None in
+  let mapply = Filename.concat (Filename.dirname herd) "mapply7" in
+  let args = "-exit"::"true"::TestHerd.apply_args  wrapper j (herd::args) in
+  let () =
+    if _dbg then
+      Printf.eprintf "Mapply arguments '%s'\n%!" (String.concat " " args) in
+  let litmuses = read_litmus_dir flags.litmus_dir in
+  let () =
+    if _dbg then
+      let com = Command.command mapply  (args @ litmuses) in
+      Printf.eprintf "Wil run: %s\n%!" com in
+  let st = Command.run_status mapply  (args @ litmuses) in
+  if st <> 0 then begin
+    Printf.printf "Some tests had errors\n" ;
+    exit 1
+  end
+
+let run_test_par = do_run_test_par "herd_test.exe"
+
+let run_tests ?j flags =
+  match j with
+  | None -> run_tests_seq flags
+  | Some j -> run_test_par j flags
+
+
+let promote_tests_seq flags =
   let output_of_litmus l =
     TestHerd.run_herd ~bell:None ~cat:None
       ~conf:flags.conf
@@ -137,35 +192,22 @@ let promote_tests flags =
       flags.herd [l]
   in
   let everything_ok = ref true in
-  for_each_litmus_in_dir flags.litmus_dir (fun l ->
-    let expected = TestHerd.expected_of_litmus l in
-    let expected_failure = TestHerd.expected_failure_of_litmus l in
-
-    match output_of_litmus l with
-    | 0, [], [] ->
-        Printf.printf "Failed %s : Returned neither stdout nor stderr\n" l ;
-        everything_ok := false
-
-    | 0, out, [] ->
-        remove_if_exists expected_failure ;
-        write_file expected out
-
-    | r, [], err when r <> 0 ->
-        remove_if_exists expected ;
-        write_file expected_failure err
-
-    | 0, out, err ->
-       write_file expected out ;
-       let expected_warn = TestHerd.expected_warn_of_litmus l in
-       write_file expected_warn err
-    | r, _, _  ->
-       Printf.printf "Failed %s : unexpected exit code %i\n" l r ;
-       everything_ok := false
-  ) ;
+  for_each_litmus_in_dir flags.litmus_dir
+    (fun litmus ->
+      let ok =
+        TestHerd.promote litmus (output_of_litmus litmus) in
+      if not ok then everything_ok := false) ;
   if not !everything_ok then begin
     Printf.printf "Some tests had errors\n" ;
     exit 1
   end
+
+let promote_test_par = do_run_test_par "herd_promote.exe"
+
+let promote_tests ?j flags =
+  match j with
+  | None -> promote_tests_seq flags
+  | Some j -> promote_test_par j flags
 
 
 let usage = String.concat "\n" [
@@ -188,10 +230,12 @@ let () =
   (* Optional arguments. *)
   let conf = ref None in
   let variants = ref [] in
+  let j = ref None in
 
   let anon_args = ref [] in
 
   let options = [
+    Args.npar j;
     Args.is_file ("-herd-path",   Arg.Set_string herd,           "path to herd binary") ;
     Args.is_dir  ("-libdir-path", Arg.Set_string libdir,         "path to herd libdir") ;
     Args.is_dir  ("-litmus-dir",  Arg.Set_string litmus_dir,     "path to directory of .litmus files to test against") ;
@@ -219,9 +263,10 @@ let () =
     litmus_dir = !litmus_dir ;
     conf = !conf ;
     variants = !variants ;
-  } in
+    } in
+  let j = !j in
   match !anon_args with
-  | "show" :: [] -> show_tests flags
-  | "test" :: [] -> run_tests flags
-  | "promote" :: [] -> promote_tests flags
+  | "show" :: [] -> show_tests ?j flags
+  | "test" :: [] -> run_tests ?j flags
+  | "promote" :: [] -> promote_tests ?j flags
   | _ -> exit_with_error "Must provide one command of: show, test, promote"

--- a/internal/herd_test.ml
+++ b/internal/herd_test.ml
@@ -1,0 +1,48 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2023-present Institut National de Recherche en Informatique et *)
+(* en Automatique, ARM Ltd and the authors. All rights reserved.            *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** A tool that runs herd and compares its output against reference files *)
+
+let () =
+  if false then
+    let xs = Array.to_list Sys.argv in
+    Printf.eprintf "%s\n%!" (String.concat " " xs)
+
+let litmus = Sys.argv.(Array.length Sys.argv -1)
+
+let rec to_list k =
+  if k+1 >= Array.length Sys.argv then []
+  else Sys.argv.(k)::to_list (k+1)
+
+let com = Sys.argv.(1)
+let args = to_list 2
+
+let () =
+  let expected = TestHerd.expected_of_litmus litmus
+  and expected_failure = TestHerd.expected_failure_of_litmus litmus
+  and expected_warn = TestHerd.expected_warn_of_litmus litmus in
+  if
+    TestHerd.herd_args_output_matches_expected com args litmus
+    expected expected_failure expected_warn
+  then
+    exit 0
+  else begin
+    let () =
+      if false then
+        Printf.printf "Test not ok: %s %s\n%!"
+          (String.concat " " (com::args)) litmus in
+    exit 1
+  end

--- a/internal/lib/command.ml
+++ b/internal/lib/command.ml
@@ -87,7 +87,10 @@ let do_run must_succeed ?stdin:in_f ?stdout:out_f ?stderr:err_f bin args =
         let fd, i = in_pipe false in
         fd, (fun _ -> Unix.close fd ; f i), (fun _ -> close_in i)
   in
-
+  let () =
+    if false then
+      Printf.printf "Running %s %s\n%!"
+        bin (String.concat " " args) in
   let pid =
     Fun.protect
       ~finally:(fun _ -> close_in_pipe () ; close_out_pipe () ; close_err_pipe ())

--- a/internal/lib/testHerd.mli
+++ b/internal/lib/testHerd.mli
@@ -76,6 +76,15 @@ val run_herd :
      path -> ?j:int -> ?timeout:float ->
      path list -> int * string list * string list
 
+(** [run_herd_args herd args litmus] similar in functionality  to
+  * [run_herd] above but different as regards interface:
+  *   1. Command-line options are given as a list of strings;
+  *   2. One litmus test only is given as argument.
+  *)
+val run_herd_args :
+  path -> string list -> path ->
+    int * string list * string list
+
 (** [run_herd_concurrent ~bell ~cat ~conf ~variants ~libdir herd j litmuses]
  *  Similar to [run_herd] except that output is stored into files specific
  *  to each test: [litmus].out and [litmus].err. *)
@@ -113,6 +122,13 @@ val herd_output_matches_expected :
   libdir   : path ->
     path -> path -> path -> path -> path  -> bool
 
+(** [herd_args_output_mathes_expected herd args litmus
+  *  expected expected_failure expected_warn] has the same functionality
+  *  as [herd_output_matches_expected] above but a different interface,
+  *   as command line options are given as the list [args]. *)
+val herd_args_output_matches_expected :
+  path -> string list -> path -> path -> path -> path  -> bool
+
 (** [is_litmus filename] returns whether the [filename] is a .litmus file. *)
 val is_litmus : path -> bool
 
@@ -133,3 +149,8 @@ val litmus_of_expected_failure : path -> path
 
 (** [expected_warn_of_litmus filename] returns the .litmus.expected-warn name for a given .litmus [filename]. *)
 val expected_warn_of_litmus : path -> path
+
+(** [promote  litmus result] it is assumed that result is the result of running the test [litmus].
+  * Promote [result] as the reference for test [litmus]. If anyrging is wrong, return [false].
+  *)
+val promote : path -> (int * string list * string list) -> bool


### PR DESCRIPTION
The internal command now accepts and completely implements the command line option `-j <n>`, resulting in parallel execution limited to at most `<n>`  concurrent agents.