### PR TITLE
[litmus] Explicit affinity control for `-mode presi`

### DIFF
--- a/litmus/dumpParams.ml
+++ b/litmus/dumpParams.ml
@@ -27,13 +27,13 @@ module Make (O:Config) =
   struct
     open Printf
 
+    let avail = match O.avail with None -> 1 | Some n -> n
+
     let dump out =
       let dump_def var x = out (sprintf "#define %s %s" var x) in
       dump_def "SIZE_OF_TEST" (sprintf "%i" O.size) ;
       dump_def "NUMBER_OF_RUN" (sprintf "%i" O.runs) ;
-      dump_def "AVAIL"
-        (match O.avail with
-        | None -> "1" | Some n -> sprintf "%i" n) ;
+      dump_def "AVAIL" (sprintf "%i" avail) ;
       begin match O.mode with
       | Mode.Std ->
           begin

--- a/litmus/libdir/_aarch64/cache.c
+++ b/litmus/libdir/_aarch64/cache.c
@@ -20,11 +20,12 @@ inline static void cache_flush(void *p) {
 #endif
 }
 
-
 inline static void cache_touch(void *p) {
   asm __volatile__ ("prfm pldl1keep,[%[p]]" :: [p] "r" (p) : "memory");
 }
 
+#ifdef CACHE_TOUCH_STORE
 inline static void cache_touch_store(void *p) {
   asm __volatile__ ("prfm pstl1keep,[%[p]]" :: [p] "r" (p) : "memory");
 }
+#endif

--- a/litmus/libdir/aarch64.cfg
+++ b/litmus/libdir/aarch64.cfg
@@ -1,0 +1,11 @@
+#ODROID-C2
+size_of_test = 10k
+number_of_run = 100
+avail = 4
+limit = true
+memory = direct
+stride = 1
+carch = AArch64
+barrier = userfence
+smt = 4
+smt_mode = seq

--- a/litmus/litmus.ml
+++ b/litmus/litmus.ml
@@ -320,9 +320,8 @@ let () =
       let targetos = !targetos
       let platform = "_linux"
       let affinity = match !mode with
-      | Mode.Std -> !affinity
-      | Mode.PreSi -> Affinity.Scan
-      | Mode.Kvm -> Affinity.No
+      | Mode.Std|Mode.PreSi -> !affinity
+      | Mode.Kvm -> Affinity.No (* No effinity ever in kvm mode *)
       let logicalprocs = !logicalprocs
       let linkopt = !linkopt
       let barrier = !barrier

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -653,6 +653,7 @@ module Make
         | true ->  O.o "#define CACHE_FLUSH 1" ;
         | false -> ()
         end ;
+        O.o "#define CACHE_TOUCH_STORE 1" ;
         Insert.insert O.o "cache.c"
 
       let do_dump_cache_def = match Cfg.preload with

--- a/litmus/topology.ml
+++ b/litmus/topology.ml
@@ -53,6 +53,17 @@ let () =
 
   let smt = set_ifnone 1 smt
   let nsockets = set_ifnone 1 nsockets
+
+  let smt,nsockets =
+    if smt*nsockets  > avail then
+      avail,1
+    else smt,nsockets
+
+  let () =
+    if avail mod smt != 0 || (avail/smt) mod nsockets != 0 then
+      Warn.user_error
+        "Non compliant topology: avail=%d, smt=%d, nsockets=%d\n"                      avail smt nsockets
+
   let ncores = avail / smt
   let cores_in_sock = ncores / nsockets
   let ninst =  avail / nthreads


### PR DESCRIPTION
Affinity is no longer enabled by default for the "presi" mode.
    
However, affinity behavior  significantly departs  from standard  mode. In "presi" mode, system threads are first started started, which later are allocated changing test threads according to declared topology.
    
Affinity concerns system threads, which are mapped onto logical cores by following the `incr1` policy, whatever affinity policy is specified. Nevertheless, system thread allocation to logical cores can be changed by using the `-procs <ints>` setting.
    
As a motivation for this change, mode "presi" is now available on MacOS (with affinity disabled) and the mode can be run with no affinity control or with custom logical core mappings on platforms that provide affinity control.

The also include a few unrelated changes  intended to silence warnings.
