### PR TITLE
Generate Neon scalars

### DIFF
--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -60,9 +60,10 @@ module Mixed =
 let bellatom = false
 module SIMD = struct
 
-  type atom = NeP|Ne1|Ne2|Ne3|Ne4|Ne2i|Ne3i|Ne4i|NePa|NePaN
+  type atom = NeP|NeAcqPc|NeRel|Ne1|Ne2|Ne3|Ne4|Ne2i|Ne3i|Ne4i|NePa|NePaN
 
   let fold_neon f r = r |>
+    f NeAcqPc |> f NeRel |>
     f NeP |>
     f NePa |> f NePaN |>
     f Ne1 |> f Ne2 |> f Ne3 |> f Ne4 |>
@@ -78,7 +79,7 @@ module SIMD = struct
   let nelements = function
     | Ne1|Ne2|Ne2i|Ne3|Ne3i|Ne4|Ne4i -> 4
     | NePa|NePaN -> 2
-    | NeP -> 1
+    | NeP | NeAcqPc | NeRel -> 1
 
   let pp_opt = function
     | Ne2i | Ne3i | Ne4i -> "i"
@@ -88,9 +89,11 @@ module SIMD = struct
     match n with
     | Ne1 | Ne2 | Ne3 | Ne4 | Ne2i | Ne3i | Ne4i ->
        Printf.sprintf "Ne%i%s" (nregs n) (pp_opt n)
-    | NePa -> Printf.sprintf "NePa"
-    | NePaN -> Printf.sprintf "NePaN"
-    | NeP -> Printf.sprintf "NeP"
+    | NePa -> "NePa"
+    | NePaN -> "NePaN"
+    | NeP -> "NeP"
+    | NeAcqPc -> "NeQ"
+    | NeRel -> "NeL"
 
   let initial sz =
     let sz = if sz <= 0 then 1 else sz in
@@ -105,7 +108,8 @@ module SIMD = struct
       for i=0 to el-1 do
         let j = match n with
           | Ne2i | Ne3i | Ne4i -> k+i*sz
-          | NeP | NePa | NePaN | Ne1 | Ne2 | Ne3 | Ne4 -> i+k*el
+          | NeP | NeAcqPc | NeRel | NePa | NePaN
+          | Ne1 | Ne2 | Ne3 | Ne4 -> i+k*el
         in
        v.(j) <- start+k
       done
@@ -117,7 +121,8 @@ module SIMD = struct
     let sz = nregs n in
     let access r k = match n with
       | Ne2i | Ne3i | Ne4i -> sz*k + r
-      | NeP | NePa | NePaN | Ne1 | Ne2 | Ne3 | Ne4 -> el*r + k
+      | NeP | NeAcqPc | NeRel | NePa | NePaN
+      | Ne1 | Ne2 | Ne3 | Ne4 -> el*r + k
     in
     let rec reg r k =
       if k >= el then []
@@ -187,6 +192,8 @@ let default_atom = Atomic PP,None
 let instr_atom = Some (Instr,None)
 
 let applies_atom (a,_) d = match a,d with
+| Neon SIMD.NeAcqPc,W
+| Neon SIMD.NeRel,R -> false
 | Acq _,R
 | AcqPc _,R
 | Rel _,W
@@ -447,7 +454,7 @@ let is_ifetch a = match a with
    let neon_as_integers =
      let open SIMD in
      function
-     | NeP -> 1
+     | NeP | NeAcqPc | NeRel -> 1
      | NePa | NePaN -> 2
      | Ne1 -> 4
      | Ne2 | Ne2i -> 8

--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -60,21 +60,34 @@ module Mixed =
 let bellatom = false
 module SIMD = struct
 
-  type atom = Ne1|Ne2|Ne3|Ne4|Ne2i|Ne3i|Ne4i
+  type atom = Ne1|Ne2|Ne3|Ne4|Ne2i|Ne3i|Ne4i|NePa|NePaN
 
-  let fold_neon f r = f Ne1 (f Ne2 (f Ne3 (f Ne4 (f Ne2i (f Ne3i (f Ne4i r))))))
+  let fold_neon f r = r |>
+    f NePa |> f NePaN |>
+    f Ne1 |> f Ne2 |> f Ne3 |> f Ne4 |>
+    f Ne2i |> f Ne3i |> f Ne4i
 
   let nregs = function
     | Ne1 -> 1
     | Ne2 | Ne2i -> 2
     | Ne3 | Ne3i -> 3
     | Ne4 | Ne4i -> 4
+    | _ -> 1
+
+  let nelements = function
+    | Ne1|Ne2|Ne2i|Ne3|Ne3i|Ne4|Ne4i -> 4
+    | NePa|NePaN -> 2
 
   let pp_opt = function
     | Ne2i | Ne3i | Ne4i -> "i"
     | _ -> ""
 
-  let pp n = Printf.sprintf "Ne%i%s" (nregs n) (pp_opt n)
+  let pp n =
+    match n with
+    | Ne1 | Ne2 | Ne3 | Ne4 | Ne2i | Ne3i | Ne4i ->
+       Printf.sprintf "Ne%i%s" (nregs n) (pp_opt n)
+    | NePa -> Printf.sprintf "NePa"
+    | NePaN -> Printf.sprintf "NePaN"
 
   let initial sz =
     let sz = if sz <= 0 then 1 else sz in
@@ -82,13 +95,14 @@ module SIMD = struct
 
   let step n start v =
     let start = start+1 in
+    let el = nelements n in
     let sz = nregs n in
     let v = Array.copy v in
     for k = 0 to sz-1 do
-      for i=0 to 3 do
+      for i=0 to el-1 do
         let j = match n with
           | Ne2i | Ne3i | Ne4i -> k+i*sz
-          | Ne1  | Ne2 | Ne3 | Ne4 -> i+k*4
+          | NePa | NePaN | Ne1 | Ne2 | Ne3 | Ne4 -> i+k*el
         in
        v.(j) <- start+k
       done
@@ -96,13 +110,14 @@ module SIMD = struct
     v
 
   let read n v =
+    let el = nelements n in
     let sz = nregs n in
     let access r k = match n with
       | Ne2i | Ne3i | Ne4i -> sz*k + r
-      | Ne1 | Ne2 | Ne3 | Ne4 -> 4*r + k
+      | NePa | NePaN | Ne1 | Ne2 | Ne3 | Ne4 -> el*r + k
     in
     let rec reg r k =
-      if k >= 4 then []
+      if k >= el then []
       else v.(access r k)::reg r (k+1) in
     let rec regs r =
       if r >= sz then []
@@ -152,13 +167,13 @@ type atom_pte =
   | Set of  WPTESet.t
   | SetRel of  WPTESet.t
 
-type neon_sizes = SIMD.atom
+type neon_opt = SIMD.atom
 
 type pair_idx = Both
 
 type atom_acc =
   | Plain of capa_opt | Acq of capa_opt | AcqPc of capa_opt | Rel of capa_opt
-  | Atomic of atom_rw | Tag | CapaTag | CapaSeal | Pte of atom_pte | Neon of neon_sizes
+  | Atomic of atom_rw | Tag | CapaTag | CapaSeal | Pte of atom_pte | Neon of neon_opt
   | Pair of pair_opt * pair_idx | Instr
 
 let  plain = Plain None
@@ -429,6 +444,7 @@ let is_ifetch a = match a with
    let neon_as_integers =
      let open SIMD in
      function
+     | NePa | NePaN -> 2
      | Ne1 -> 4
      | Ne2 | Ne2i -> 8
      | Ne3 | Ne3i -> 12

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -80,7 +80,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       and get_reg_list n st =
         let open SIMD in
         match n with
-        | Ne1 | NePa | NePaN | NeP ->
+        | Ne1 | NePa | NePaN | NeP | NeAcqPc | NeRel ->
            let r,st = next_vreg st in (r,[]),st
         | Ne2 | Ne2i -> call_rec Ne1 st
         | Ne3 | Ne3i -> call_rec Ne2 st
@@ -619,6 +619,25 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         r,init,pseudo csA@cs,st
     end
 
+    module LDAPUR = struct
+      let emit_load_reg st init rA =
+        let r,st = next_scalar_reg st in
+        let ldur = [I_LDAPUR_SIMD(A64.VSIMD32,r,rA,None)] in
+        let rX,st = next_reg st in
+        let fmov = [I_FMOV_TG(A64.V32,rX,A64.VSIMD32,r)] in
+        rX,init,lift_code (ldur@fmov),st
+
+      let emit_load st p init loc =
+        let rA,init,st = U.next_init st p init loc in
+        emit_load_reg st init rA
+
+      let emit_load_idx v st p init loc ridx =
+        let rA,init,st = U.next_init st p init loc in
+        let rA,csA,st = do_sum_addr v st rA ridx in
+        let r,init,cs,st = emit_load_reg st init rA in
+        r,init,pseudo csA@cs,st
+    end
+
     module LDG = struct
       let emit_load st p init x =
         let rA,st = next_reg st in
@@ -864,7 +883,33 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let adds = [add_simd r1 rB]in
         let stur = [I_STUR_SIMD(A64.VSIMD32,to_scalar r1,rA,None)] in
         init,lift_code(dup@movi@adds@stur),st
+    end
 
+    module STLUR = struct
+      let emit_store_reg st init rA v =
+        let r,st = next_vreg st in
+        let movi = [movi_reg r v] in
+        let stlur = [I_STLUR_SIMD(A64.VSIMD32,to_scalar r,rA,None)] in
+        init,lift_code(movi@stlur),st
+
+      let emit_store st p init loc v =
+        let rA,init,st = U.next_init st p init loc in
+        emit_store_reg st init rA v
+
+      let emit_store_idx vdep st p init loc ridx v =
+        let rA,init,st = U.next_init st p init loc in
+        let rA,csA,st = do_sum_addr vdep st rA ridx in
+        let init,cs,st = emit_store_reg st init rA v in
+        init,pseudo csA@cs,st
+
+      let emit_store_dep vdep st init rA v =
+        let rB,st = next_vreg st in
+        let dup = [I_DUP (rB,A64.V32,vdep)] in
+        let r1,st = next_vreg st in
+        let movi = [movi_reg r1 v] in
+        let adds = [add_simd r1 rB]in
+        let stlur = [I_STLUR_SIMD(A64.VSIMD32,to_scalar r1,rA,None)] in
+        init,lift_code(dup@movi@adds@stlur),st
     end
 
     module STG = struct
@@ -1304,6 +1349,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       r,init,cs@cs2,st
     | Code.VecReg n ->
        let emit_load = match n with
+         | SIMD.NeAcqPc -> LDAPUR.emit_load
          | SIMD.NeP -> LDUR.emit_load
          | SIMD.NePa  -> LDP.emit_load A64.TT
          | SIMD.NePaN -> LDP.emit_load A64.NT
@@ -1422,6 +1468,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | R,Some (CapaSeal,Some _) -> assert false
         | R,Some (Neon n, None) ->
            let emit_load = match n with
+             | SIMD.NeRel -> Warn.fatal "No laod release"
+             | SIMD.NeAcqPc -> LDAPUR.emit_load
              | SIMD.NeP -> LDUR.emit_load
              | SIMD.NePa  -> LDP.emit_load A64.TT
              | SIMD.NePaN -> LDP.emit_load A64.NT
@@ -1513,6 +1561,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | W,Some (CapaSeal,Some _) -> assert false
         | W,Some (Neon n, None) ->
            let emit_store = match n with
+             | SIMD.NeAcqPc -> Warn.fatal "No store acquirePc"
+             | SIMD.NeRel -> STLUR.emit_store
              | SIMD.NeP -> STUR.emit_store
              | SIMD.NePa  -> STP.emit_store A64.TT
              | SIMD.NePaN -> STP.emit_store A64.NT
@@ -1870,6 +1920,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | R,Some (CapaSeal,Some _) -> assert false
           | R,Some (Neon n,None) ->
               let emit_load_idx = match n with
+                | SIMD.NeRel -> Warn.fatal "No laod release"
+                | SIMD.NeAcqPc -> LDAPUR.emit_load_idx
                 | SIMD.NeP -> LDUR.emit_load_idx
                 | SIMD.NePa -> LDP.emit_load_idx A64.TT
                 | SIMD.NePaN -> LDP.emit_load_idx A64.NT
@@ -2007,6 +2059,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | W,Some (CapaSeal,Some _) -> assert false
           | W,Some (Neon n,None) ->
              let emit_store_idx = match n with
+               | SIMD.NeAcqPc -> Warn.fatal "No store acquirePc"
+               | SIMD.NeRel -> STLUR.emit_store_idx
                | SIMD.NeP -> STUR.emit_store_idx
                | SIMD.NePa ->  STP.emit_store_idx A64.TT
                | SIMD.NePaN -> STP.emit_store_idx A64.NT
@@ -2207,6 +2261,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | Some (Neon n,None) ->
              let rA,init,st = U.next_init st p init loc in
              let emit_store_dep = match n with
+               | SIMD.NeAcqPc -> Warn.fatal "No store acquirePc"
+               | SIMD.NeRel -> STLUR.emit_store_dep
                | SIMD.NeP -> STUR.emit_store_dep
                | SIMD.NePa ->  STP.emit_store_dep A64.TT
                | SIMD.NePaN -> STP.emit_store_dep A64.NT

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -53,17 +53,17 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let r2,x = next_reg x in
       r1,r2,x
 
-    let next_vreg x = A64.alloc_special x
-    let next_scalar_reg x =
-      let r,x = A64.alloc_special x in
-      let r = match r with
+    let to_scalar r = match r with
         | Vreg (r,(_,8)) -> A64.SIMDreg r
         | Vreg (r,(_,16)) -> A64.SIMDreg r
         | Vreg (r,(_,32)) -> A64.SIMDreg r
         | Vreg (r,(_,64)) -> A64.SIMDreg r
         | _ -> assert false (* ? *)
-      in
-      r,x
+
+    let next_vreg x = A64.alloc_special x
+    let next_scalar_reg x =
+      let r,x = next_vreg x in
+      to_scalar r,x
 
     let pseudo = List.map (fun i -> Instruction i)
 
@@ -80,11 +80,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       and get_reg_list n st =
         let open SIMD in
         match n with
-        | Ne1 ->
+        | Ne1 | NePa | NePaN ->
            let r,st = next_vreg st in (r,[]),st
         | Ne2 | Ne2i -> call_rec Ne1 st
         | Ne3 | Ne3i -> call_rec Ne2 st
-        | Ne4 | Ne4i -> call_rec Ne3 st in
+        | Ne4 | Ne4i -> call_rec Ne3 st
+      in
       fun n st ->
         let (r,rs),st = get_reg_list n st in
         (r,rs),A.set_friends r rs st
@@ -235,6 +236,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Ne2i -> I_LD2M (rs,rt,K 0)
       | Ne3i -> I_LD3M (rs,rt,K 0)
       | Ne4i -> I_LD4M (rs,rt,K 0)
+      | _ -> assert false
 
     let ldr_mixed_idx v r1 r2 idx sz  =
       let idx = MemExt.v2idx_reg v idx in
@@ -274,6 +276,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Ne2i -> I_ST2M (rs,rt,K 0)
       | Ne3i -> I_ST3M (rs,rt,K 0)
       | Ne4i -> I_ST4M (rs,rt,K 0)
+      | _ -> assert false
 
     let stxr_sz t sz r1 r2 r3 =
       let open MachSize in
@@ -573,6 +576,30 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         r,init,pseudo csA@cs,st
     end
 
+
+    module LDP = struct
+
+      let emit_load_reg temporal st init rA =
+        let r1,st = next_vreg st in
+        let r2,st = next_vreg st in
+        let ldp = [I_LDP_SIMD(temporal,A64.VSIMD32,to_scalar r1,to_scalar r2,rA,0)] in
+        let r3,st = next_vreg st in
+        let add = [I_ADD_SIMD (r3,r1,r2)] in
+        let rX,st = next_reg st in
+        let fmov = [I_FMOV_TG(A64.V32,rX,A64.VSIMD32,to_scalar r3)] in
+        rX,init,lift_code (ldp@add@fmov),st
+
+      let emit_load t st p init loc =
+        let rA,init,st = U.next_init st p init loc in
+        emit_load_reg t st init rA
+
+      let emit_load_idx t v st p init loc ridx =
+        let rA,init,st = U.next_init st p init loc in
+        let rA,csA,st = do_sum_addr v st rA ridx in
+        let r,init,cs,st = emit_load_reg t st init rA in
+        r,init,pseudo csA@cs,st
+    end
+
     module LDG = struct
       let emit_load st p init x =
         let rA,st = next_reg st in
@@ -762,6 +789,35 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let adds = List.map (fun v -> add_simd v rB) (r::rs) in
         let stn = [stn n (r::rs) rA] in
         init,lift_code(dup@movi@adds@stn),st
+    end
+
+    module STP = struct
+      let emit_store_reg temporal st init rA v =
+        let r1,st = next_vreg st in
+        let r2,st = next_vreg st in
+        let movi = List.mapi (fun i r -> movi_reg r (v+i)) [r1;r2] in
+        let stp = [I_STP_SIMD(temporal,A64.VSIMD32,to_scalar r1,to_scalar r2,rA,0)] in
+        init,pseudo movi@pseudo stp,st
+
+      let emit_store n st p init loc v =
+        let rA,init,st = U.next_init st p init loc in
+        emit_store_reg n st init rA v
+
+      let emit_store_idx n vdep st p init loc ridx v =
+        let rA,init,st = U.next_init st p init loc in
+        let rA,csA,st = do_sum_addr vdep st rA ridx in
+        let init,cs,st = emit_store_reg n st init rA v in
+        init,pseudo csA@cs,st
+
+      let emit_store_dep temporal vdep st init rA v =
+        let rB,st = next_vreg st in
+        let dup = [I_DUP (rB,A64.V32,vdep)] in
+        let r1,st = next_vreg st in
+        let r2,st = next_vreg st in
+        let movi = List.mapi (fun i r -> movi_reg r (v+i)) [r1;r2] in
+        let adds = List.map (fun v -> add_simd v rB) [r1;r2] in
+        let stp = [I_STP_SIMD(temporal,A64.VSIMD32,to_scalar r1,to_scalar r2,rA,0)] in
+        init,lift_code(dup@movi@adds@stp),st
     end
 
     module STG = struct
@@ -1199,7 +1255,13 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let r,init,cs,st = emit_load_mixed MachSize.S128 0 st p init x in
       let cs2 = lift_code [gctype r r] in
       r,init,cs@cs2,st
-    | Code.VecReg n -> LDN.emit_load n
+    | Code.VecReg n ->
+       let emit_load = match n with
+         | SIMD.NePa  -> LDP.emit_load A64.TT
+         | SIMD.NePaN -> LDP.emit_load A64.NT
+         | _ -> LDN.emit_load n
+       in
+       emit_load
     | Code.Pair -> emit_ldp Pa Both
 
 
@@ -1311,7 +1373,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             Some r,init,cs@lift_code [gctype r r],st
         | R,Some (CapaSeal,Some _) -> assert false
         | R,Some (Neon n, None) ->
-            let r,init,cs,st = LDN.emit_load n st p init loc in
+           let emit_load = match n with
+             | SIMD.NePa  -> LDP.emit_load A64.TT
+             | SIMD.NePaN -> LDP.emit_load A64.NT
+             | _ -> LDN.emit_load n
+           in
+           let r,init,cs,st = emit_load st p init loc in
             Some r,init,cs,st
         | R,Some (Neon _,Some _) -> assert false
         | R,Some (Pair (opt,idx),None) ->
@@ -1396,8 +1463,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             None,init,csi@cs@lift_code [str_mixed MachSize.S128 0 rB rA],st
         | W,Some (CapaSeal,Some _) -> assert false
         | W,Some (Neon n, None) ->
-           let init,cs,st =
-             STN.emit_store n st p init loc e.C.v in
+           let emit_store = match n with
+             | SIMD.NePa  -> STP.emit_store A64.TT
+             | SIMD.NePaN -> STP.emit_store A64.NT
+             | _ -> STN.emit_store n
+           in
+           let init,cs,st = emit_store st p init loc e.C.v in
            None,init,cs,st
         | W,Some (Neon _,Some _) -> assert false
         end
@@ -1748,7 +1819,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               Some rB,init,cs@lift_code [ldr_mixed rB rA MachSize.S128 0; gctype rB rB],st
           | R,Some (CapaSeal,Some _) -> assert false
           | R,Some (Neon n,None) ->
-              let rB,init,cs,st = LDN.emit_load_idx n vdep st p init loc r2 in
+              let emit_load_idx = match n with
+                | SIMD.NePa -> LDP.emit_load_idx A64.TT
+                | SIMD.NePaN -> LDP.emit_load_idx A64.NT
+                | _ -> LDN.emit_load_idx n
+              in
+              let rB,init,cs,st = emit_load_idx vdep st p init loc r2 in
               Some rB,init,pseudo cs0@cs,st
           | R,Some (Pair (opt,idx),None) ->
               let r,init,cs,st =
@@ -1879,7 +1955,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               csi@csi2@cs@lift_code [str_mixed MachSize.S128 0 rC rB],st
           | W,Some (CapaSeal,Some _) -> assert false
           | W,Some (Neon n,None) ->
-              let init,cs,st = STN.emit_store_idx n vdep st p init loc r2 e.C.v in
+             let emit_store_idx = match n with
+               | SIMD.NePa ->  STP.emit_store_idx A64.TT
+               | SIMD.NePaN -> STP.emit_store_idx A64.NT
+               | _ -> STN.emit_store_idx n
+             in
+             let init,cs,st = emit_store_idx vdep st p init loc r2 e.C.v in
               None,init,pseudo cs0@cs,st
           | W,Some (Neon _,Some _) -> assert false
           | J,_ -> emit_joker st init
@@ -2073,7 +2154,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | Some (CapaSeal,Some _) -> assert false
           | Some (Neon n,None) ->
              let rA,init,st = U.next_init st p init loc in
-             let init,cs,st = STN.emit_store_dep n r2 st init rA e.C.v in
+             let emit_store_dep = match n with
+               | SIMD.NePa ->  STP.emit_store_dep A64.TT
+               | SIMD.NePaN -> STP.emit_store_dep A64.NT
+               | _ -> STN.emit_store_dep n
+             in
+             let init,cs,st = emit_store_dep r2 st init rA e.C.v in
              None,init,cs2@cs,st
           | Some (Neon _,Some _) -> assert false
           | Some (Pair (opt,idx),None) ->

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -96,7 +96,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_ADDV _| I_DUP _ | I_MOV_FG _| I_MOV_S _| I_MOV_TG _| I_MOV_V _| I_MOV_VE _| I_MOVI_S _
     | I_MOVI_V _| I_MOVK _| I_MOVZ _| I_MOVN _| I_MRS _| I_MSR _| I_OP3 _| I_RBIT _
     | I_RET _
-    | I_SBFM _| I_SC _| I_SEAL _| I_ST1 _| I_ST1M _| I_ST2 _| I_ST2M _| I_ST3 _
+    | I_SBFM _| I_SC _| I_SEAL _| I_ST1 _| I_STL1 _| I_ST1M _| I_ST2 _| I_ST2M _| I_ST3 _
     | I_ST3M _| I_ST4 _| I_ST4M _| I_STCT _| I_STG _| I_STLR _| I_STLRBH _| I_STOP _
     | I_STOPBH _| I_STP _| I_STP_P_SIMD _| I_STP_SIMD _| I_STR _ | I_STLUR_SIMD _
     | I_STR_P_SIMD _| I_STR_SIMD _| I_STRBH _| I_STUR_SIMD _| I_STXP _| I_STXR _
@@ -237,7 +237,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDAPUR_SIMD (v,_,_,_) | I_STLUR_SIMD (v,_,_,_) ->
           Some (tr_simd_variant v)
       | I_LD1 (rs,_,_,_) | I_LD1R (rs,_,_) | I_ST1 (rs,_,_,_)
-      | I_LDAP1 (rs,_,_,_)
+      | I_LDAP1 (rs,_,_,_) | I_STL1 (rs,_,_,_)
       | I_LD1M (rs,_,_) | I_ST1M (rs,_,_)
       | I_LD2 (rs,_,_,_) | I_LD2R (rs,_,_) | I_ST2 (rs,_,_,_)
       | I_LD2M (rs,_,_) | I_ST2M (rs,_,_)
@@ -338,6 +338,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDXP (_,_,r1,r2,_)
         -> [r1;r2;]
       | I_LDAP1 _
+      | I_STL1 _
       | I_LD1 _|I_LD1M _|I_LD1R _|I_LD2 _
       | I_LD2M _|I_LD2R _|I_LD3 _|I_LD3M _
       | I_LD3R _|I_LD4 _|I_LD4M _|I_LD4R _
@@ -372,7 +373,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDR _|I_LDRSW _|I_LDRS _|I_LDUR _|I_LD1 _|I_LDAP1 _
       | I_LD1M _|I_LD1R _|I_LD2 _|I_LD2M _
       | I_LD2R _|I_LD3 _|I_LD3M _|I_LD3R _
-      | I_LD4 _|I_LD4M _|I_LD4R _|I_ST1 _
+      | I_LD4 _|I_LD4M _|I_LD4R _|I_ST1 _|I_STL1 _
       | I_ST1M _|I_ST2 _|I_ST2M _|I_ST3 _
       | I_ST3M _|I_ST4 _|I_ST4M _
       | I_LDP_P_SIMD _|I_STP_P_SIMD _

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -235,8 +235,9 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_STP_SIMD (_,v,_,_,_,_) | I_STP_P_SIMD (_,v,_,_,_,_)
       | I_LDUR_SIMD (v,_,_,_) | I_STUR_SIMD (v,_,_,_) ->
           Some (tr_simd_variant v)
-      | I_LD1 (r,_,_,_) | I_LD1R (r,_,_) | I_ST1 (r,_,_,_) ->
+      | I_LD1R (r,_,_) ->
           Some (simd_mem_access_size [r])
+      | I_LD1 (rs,_,_,_) | I_ST1 (rs,_,_,_)
       | I_LD1M (rs,_,_) | I_ST1M (rs,_,_)
       | I_LD2 (rs,_,_,_) | I_LD2R (rs,_,_) | I_ST2 (rs,_,_,_)
       | I_LD2M (rs,_,_) | I_ST2M (rs,_,_)

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -235,9 +235,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_STP_SIMD (_,v,_,_,_,_) | I_STP_P_SIMD (_,v,_,_,_,_)
       | I_LDUR_SIMD (v,_,_,_) | I_STUR_SIMD (v,_,_,_) ->
           Some (tr_simd_variant v)
-      | I_LD1R (r,_,_) ->
-          Some (simd_mem_access_size [r])
-      | I_LD1 (rs,_,_,_) | I_ST1 (rs,_,_,_)
+      | I_LD1 (rs,_,_,_) | I_LD1R (rs,_,_) | I_ST1 (rs,_,_,_)
       | I_LD1M (rs,_,_) | I_ST1M (rs,_,_)
       | I_LD2 (rs,_,_,_) | I_LD2R (rs,_,_) | I_ST2 (rs,_,_,_)
       | I_LD2M (rs,_,_) | I_ST2M (rs,_,_)

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -87,7 +87,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_ADD_SIMD _| I_ADD_SIMD_S _| I_ADR _| I_ALIGND _| I_ALIGNU _| I_BC _
     | I_BLR _| I_BR _| I_BUILD _| I_CAS _| I_CASBH _| I_CASP _| I_CHKEQ _| I_CHKSLD _
     | I_CHKTGD _| I_CLRTAG _| I_CPYTYPE _| I_CPYVALUE _| I_CSEAL _| I_CSEL _| I_DC _
-    | I_EOR_SIMD _| I_ERET| I_FENCE _| I_GC _| I_IC _| I_LD1 _| I_LD1M _| I_LD1R _
+    | I_EOR_SIMD _| I_ERET| I_FENCE _| I_GC _| I_IC _| I_LD1 _| I_LD1M _| I_LD1R _ | I_LDAP1 _
     | I_LD2 _| I_LD2M _| I_LD2R _| I_LD3 _| I_LD3M _| I_LD3R _| I_LD4 _| I_LD4M _
     | I_LD4R _| I_LDAR _| I_LDARBH _| I_LDCT _| I_LDG _| I_LDOP _| I_LDOPBH _
     | I_LDP _| I_LDP_P_SIMD _| I_LDP_SIMD _| I_LDPSW _| I_LDR _
@@ -237,6 +237,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDAPUR_SIMD (v,_,_,_) | I_STLUR_SIMD (v,_,_,_) ->
           Some (tr_simd_variant v)
       | I_LD1 (rs,_,_,_) | I_LD1R (rs,_,_) | I_ST1 (rs,_,_,_)
+      | I_LDAP1 (rs,_,_,_)
       | I_LD1M (rs,_,_) | I_ST1M (rs,_,_)
       | I_LD2 (rs,_,_,_) | I_LD2R (rs,_,_) | I_ST2 (rs,_,_,_)
       | I_LD2M (rs,_,_) | I_ST2M (rs,_,_)
@@ -336,6 +337,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
         -> [(SysReg sr)]
       | I_LDXP (_,_,r1,r2,_)
         -> [r1;r2;]
+      | I_LDAP1 _
       | I_LD1 _|I_LD1M _|I_LD1R _|I_LD2 _
       | I_LD2M _|I_LD2R _|I_LD3 _|I_LD3M _
       | I_LD3R _|I_LD4 _|I_LD4M _|I_LD4R _
@@ -367,7 +369,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_NOP|I_B _|I_BR _|I_BC _|I_CBZ _|I_CBNZ _
       | I_TBNZ _|I_TBZ _|I_BL _|I_BLR _|I_RET _|I_ERET
       | I_UBFM _ | I_SBFM _
-      | I_LDR _|I_LDRSW _|I_LDRS _|I_LDUR _|I_LD1 _
+      | I_LDR _|I_LDRSW _|I_LDRS _|I_LDUR _|I_LD1 _|I_LDAP1 _
       | I_LD1M _|I_LD1R _|I_LD2 _|I_LD2M _
       | I_LD2R _|I_LD3 _|I_LD3M _|I_LD3R _
       | I_LD4 _|I_LD4M _|I_LD4R _|I_ST1 _

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -98,7 +98,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_RET _
     | I_SBFM _| I_SC _| I_SEAL _| I_ST1 _| I_ST1M _| I_ST2 _| I_ST2M _| I_ST3 _
     | I_ST3M _| I_ST4 _| I_ST4M _| I_STCT _| I_STG _| I_STLR _| I_STLRBH _| I_STOP _
-    | I_STOPBH _| I_STP _| I_STP_P_SIMD _| I_STP_SIMD _| I_STR _
+    | I_STOPBH _| I_STP _| I_STP_P_SIMD _| I_STP_SIMD _| I_STR _ | I_STLUR_SIMD _
     | I_STR_P_SIMD _| I_STR_SIMD _| I_STRBH _| I_STUR_SIMD _| I_STXP _| I_STXR _
     | I_STXRBH _| I_STZG _| I_STZ2G _
     | I_SWP _| I_SWPBH _| I_SXTW _| I_TLBI _| I_UBFM _
@@ -234,7 +234,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_STR_SIMD (v,_,_,_,_) | I_STR_P_SIMD (v,_,_,_)
       | I_STP_SIMD (_,v,_,_,_,_) | I_STP_P_SIMD (_,v,_,_,_,_)
       | I_LDUR_SIMD (v,_,_,_) | I_STUR_SIMD (v,_,_,_)
-      | I_LDAPUR_SIMD (v,_,_,_)  ->
+      | I_LDAPUR_SIMD (v,_,_,_) | I_STLUR_SIMD (v,_,_,_) ->
           Some (tr_simd_variant v)
       | I_LD1 (rs,_,_,_) | I_LD1R (rs,_,_) | I_ST1 (rs,_,_,_)
       | I_LD1M (rs,_,_) | I_ST1M (rs,_,_)
@@ -345,7 +345,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDP_SIMD _|I_STP_SIMD _
       | I_LDR_SIMD _|I_LDR_P_SIMD _
       | I_STR_SIMD _|I_STR_P_SIMD _
-      | I_LDUR_SIMD _|I_LDAPUR_SIMD _|I_STUR_SIMD _|I_MOV_VE _
+      | I_LDUR_SIMD _|I_LDAPUR_SIMD _|I_STUR_SIMD _|I_STLUR_SIMD _
+      | I_MOV_VE _
       | I_MOV_V _|I_MOV_TG _|I_MOV_FG _
       | I_MOV_S _|I_MOVI_V _|I_MOVI_S _
       | I_EOR_SIMD _|I_ADD_SIMD _|I_ADD_SIMD_S _
@@ -376,7 +377,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDP_SIMD _|I_STP_SIMD _
       | I_LDR_SIMD _|I_LDR_P_SIMD _
       | I_STR_SIMD _|I_STR_P_SIMD _
-      | I_LDUR_SIMD _|I_LDAPUR_SIMD _|I_STUR_SIMD _|I_MOV_VE _
+      | I_LDUR_SIMD _|I_LDAPUR_SIMD _|I_STUR_SIMD _|I_STLUR_SIMD _
+      | I_MOV_VE _
       | I_MOV_V _|I_MOV_TG _|I_MOV_FG _
       | I_MOV_S _|I_MOVI_V _|I_MOVI_S _
       | I_ADDV _| I_DUP _ | I_FMOV_TG _

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -91,7 +91,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_LD2 _| I_LD2M _| I_LD2R _| I_LD3 _| I_LD3M _| I_LD3R _| I_LD4 _| I_LD4M _
     | I_LD4R _| I_LDAR _| I_LDARBH _| I_LDCT _| I_LDG _| I_LDOP _| I_LDOPBH _
     | I_LDP _| I_LDP_P_SIMD _| I_LDP_SIMD _| I_LDPSW _| I_LDR _
-    | I_LDRSW _ | I_LDR_P_SIMD _
+    | I_LDRSW _ | I_LDR_P_SIMD _ | I_LDAPUR_SIMD _
     | I_LDR_SIMD _| I_LDRBH _| I_LDRS _| I_LDUR _| I_LDUR_SIMD _| I_LDXP _| I_MOV _ | I_FMOV_TG _
     | I_ADDV _| I_DUP _ | I_MOV_FG _| I_MOV_S _| I_MOV_TG _| I_MOV_V _| I_MOV_VE _| I_MOVI_S _
     | I_MOVI_V _| I_MOVK _| I_MOVZ _| I_MOVN _| I_MRS _| I_MSR _| I_OP3 _| I_RBIT _
@@ -233,7 +233,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDP_SIMD (_,v,_,_,_,_) | I_LDP_P_SIMD (_,v,_,_,_,_)
       | I_STR_SIMD (v,_,_,_,_) | I_STR_P_SIMD (v,_,_,_)
       | I_STP_SIMD (_,v,_,_,_,_) | I_STP_P_SIMD (_,v,_,_,_,_)
-      | I_LDUR_SIMD (v,_,_,_) | I_STUR_SIMD (v,_,_,_) ->
+      | I_LDUR_SIMD (v,_,_,_) | I_STUR_SIMD (v,_,_,_)
+      | I_LDAPUR_SIMD (v,_,_,_)  ->
           Some (tr_simd_variant v)
       | I_LD1 (rs,_,_,_) | I_LD1R (rs,_,_) | I_ST1 (rs,_,_,_)
       | I_LD1M (rs,_,_) | I_ST1M (rs,_,_)
@@ -344,7 +345,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDP_SIMD _|I_STP_SIMD _
       | I_LDR_SIMD _|I_LDR_P_SIMD _
       | I_STR_SIMD _|I_STR_P_SIMD _
-      | I_LDUR_SIMD _|I_STUR_SIMD _|I_MOV_VE _
+      | I_LDUR_SIMD _|I_LDAPUR_SIMD _|I_STUR_SIMD _|I_MOV_VE _
       | I_MOV_V _|I_MOV_TG _|I_MOV_FG _
       | I_MOV_S _|I_MOVI_V _|I_MOVI_S _
       | I_EOR_SIMD _|I_ADD_SIMD _|I_ADD_SIMD_S _
@@ -375,7 +376,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDP_SIMD _|I_STP_SIMD _
       | I_LDR_SIMD _|I_LDR_P_SIMD _
       | I_STR_SIMD _|I_STR_P_SIMD _
-      | I_LDUR_SIMD _|I_STUR_SIMD _|I_MOV_VE _
+      | I_LDUR_SIMD _|I_LDAPUR_SIMD _|I_STUR_SIMD _|I_MOV_VE _
       | I_MOV_V _|I_MOV_TG _|I_MOV_FG _
       | I_MOV_S _|I_MOVI_V _|I_MOVI_S _
       | I_ADDV _| I_DUP _ | I_FMOV_TG _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1888,6 +1888,7 @@ module Make
         write_reg_neon_sz sz rd v ii
 
       let simd_ldr = do_simd_ldr  Annot.N
+      let simd_ldar = do_simd_ldr  Annot.Q
 
       let do_simd_str an sz rs rd kr s ii =
         get_ea rs kr s ii >>|
@@ -2624,6 +2625,11 @@ module Make
             k = K (match k with Some k -> k | None -> 0) in
             (get_ea rA k S_NOEXT ii >>= fun addr ->
             simd_ldr access_size addr r1 ii) >>= B.next1T
+        | I_LDAPUR_SIMD(var,r1,rA,k) ->
+            let access_size = tr_simd_variant var and
+            k = K (match k with Some k -> k | None -> 0) in
+            (get_ea rA k S_NOEXT ii >>= fun addr ->
+            simd_ldar access_size addr r1 ii) >>= B.next1T
         | I_STR_SIMD(var,r1,rA,kr,s) ->
             let access_size = tr_simd_variant var in
             simd_str access_size rA r1 kr s ii

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1899,6 +1899,7 @@ module Make
           do_write_mem sz an aexp Access.VIR addr v ii >>= B.next1T
 
       let simd_str = do_simd_str Annot.N
+      let simd_stlr = do_simd_str Annot.L
 
       let simd_str_p sz rs rd k ii =
         read_reg_ord rs ii >>|
@@ -2640,6 +2641,10 @@ module Make
             let access_size = tr_simd_variant var and
             k = K (match k with Some k -> k | None -> 0) in
             simd_str access_size rA r1 k S_NOEXT ii
+        | I_STLUR_SIMD(var,r1,rA,k) ->
+            let access_size = tr_simd_variant var and
+            k = K (match k with Some k -> k | None -> 0) in
+            simd_stlr access_size rA r1 k S_NOEXT ii
         | I_LDP_SIMD(tnt,var,r1,r2,r3,k) ->
             get_ea_idx r3 k ii >>= fun addr ->
             simd_ldp tnt var addr r1 r2 ii

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2575,10 +2575,7 @@ module Make
             !!!(read_reg_ord rA ii >>= fun addr ->
             (mem_ss (load_elem MachSize.S128 i) addr rs ii >>|
             post_kr rA addr kr ii))
-        | I_LD1R(r1,rA,kr) ->
-            !!(read_reg_ord rA ii >>= fun addr ->
-            (load_elem_rep MachSize.S128 r1 addr ii >>|
-            post_kr rA addr kr ii))
+        | I_LD1R(rs,rA,kr)
         | I_LD2R(rs,rA,kr)
         | I_LD3R(rs,rA,kr)
         | I_LD4R(rs,rA,kr) ->

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2568,10 +2568,7 @@ module Make
             !(simd_op ADD MachSize.Quad r1 r2 r3 ii)
 
         (* Neon loads and stores *)
-        | I_LD1(r1,i,rA,kr) ->
-            !!(read_reg_ord rA ii >>= fun addr ->
-            (load_elem MachSize.S128 i r1 addr ii >>|
-            post_kr rA addr kr ii))
+        | I_LD1(rs,i,rA,kr)
         | I_LD2(rs,i,rA,kr)
         | I_LD3(rs,i,rA,kr)
         | I_LD4(rs,i,rA,kr) ->
@@ -2598,10 +2595,7 @@ module Make
             !!(read_reg_ord rA ii >>= fun addr ->
             (load_m addr rs ii >>|
             post_kr rA addr kr ii))
-        | I_ST1(r1,i,rA,kr) ->
-            !!(read_reg_ord rA ii >>= fun addr ->
-            (store_elem i r1 addr ii >>|
-            post_kr rA addr kr ii))
+        | I_ST1(rs,i,rA,kr)
         | I_ST2(rs,i,rA,kr)
         | I_ST3(rs,i,rA,kr)
         | I_ST4(rs,i,rA,kr) ->

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2142,10 +2142,13 @@ module Make
         do_read_mem_ret access_size Annot.N aexp Access.VIR addr ii >>= fun v ->
         write_reg_neon_rep sz r v ii
 
-      let store_elem i r addr ii =
+      let do_store_elem an i r addr ii =
         let access_size = AArch64.simd_mem_access_size [r] in
         read_reg_neon_elem true r i ii >>= fun v ->
-        write_mem access_size aexp Access.VIR addr v ii
+        do_write_mem access_size an aexp Access.VIR addr v ii
+
+      let store_elem = do_store_elem Annot.N
+      let store_elem_stlr = do_store_elem Annot.L
 
      (* Single structure memory access *)
       let mem_ss memop addr rs ii =
@@ -2600,6 +2603,10 @@ module Make
         | I_LD4M(rs,rA,kr) ->
             !!(read_reg_ord rA ii >>= fun addr ->
             (load_m addr rs ii >>|
+            post_kr rA addr kr ii))
+        | I_STL1(rs,i,rA,kr) ->
+            !!!(read_reg_ord rA ii >>= fun addr ->
+            (mem_ss (store_elem_stlr i) addr rs ii >>|
             post_kr rA addr kr ii))
         | I_ST1(rs,i,rA,kr)
         | I_ST2(rs,i,rA,kr)

--- a/herd/tests/instructions/AArch64.neon/V65.litmus
+++ b/herd/tests/instructions/AArch64.neon/V65.litmus
@@ -1,0 +1,10 @@
+AArch64 V65
+(* Tests LDAP1/STL1 single structure with 64 bit lanes *)
+{
+uint64_t x=1; uint64_t y;
+0:X0=x; 0:X1=y;
+}
+ P0                   ;
+ LDAP1 {V0.D}[1],[X0] ;
+ STL1 {V0.D}[1],[X1]  ;
+forall(y=1)

--- a/herd/tests/instructions/AArch64.neon/V65.litmus.expected
+++ b/herd/tests/instructions/AArch64.neon/V65.litmus.expected
@@ -1,0 +1,10 @@
+Test V65 Required
+States 1
+[y]=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall ([y]=1)
+Observation V65 Always 1 0
+Hash=7b6eb8f377ec0aaadc98fc925703166f
+

--- a/herd/tests/instructions/AArch64.neon/V66.litmus
+++ b/herd/tests/instructions/AArch64.neon/V66.litmus
@@ -1,0 +1,10 @@
+AArch64 V66
+(* Tests LDAPUR/STLUR single structure with 32 bit lanes *)
+{
+int x=1; int y;
+0:X0=x; 0:X1=y;
+}
+ P0             ;
+ LDAPUR S0,[X0] ;
+ STLUR S0,[X1]  ;
+forall(y=1)

--- a/herd/tests/instructions/AArch64.neon/V66.litmus.expected
+++ b/herd/tests/instructions/AArch64.neon/V66.litmus.expected
@@ -1,0 +1,10 @@
+Test V66 Required
+States 1
+[y]=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall ([y]=1)
+Observation V66 Always 1 0
+Hash=5d98d6e849d5a50e323705f8e6866979
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -663,7 +663,8 @@ include Arch.MakeArch(struct
     | I_STP_SIMD _ | I_STP_P_SIMD _
     | I_LDR_SIMD _ | I_LDR_P_SIMD _
     | I_STR_SIMD _ | I_STR_P_SIMD _
-    | I_LDUR_SIMD _ | I_LDAPUR_SIMD _ | I_STUR_SIMD _
+    | I_LDUR_SIMD _ | I_LDAPUR_SIMD _
+    | I_STUR_SIMD _ | I_STLUR_SIMD _
     | I_ADDV _ | I_DUP _ | I_FMOV_TG _
     | I_MOV_V _ | I_MOV_VE _ | I_MOV_S _
     | I_MOV_FG _ | I_MOV_TG _

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -651,7 +651,7 @@ include Arch.MakeArch(struct
         conv_reg r2 >! fun r2 ->
         I_STCT(r1,r2)
     (* Neon Extension *)
-    | I_LD1 _ | I_LD1M _ | I_LD1R _
+    | I_LD1 _ | I_LD1M _ | I_LD1R _ | I_LDAP1 _
     | I_LD2 _ | I_LD2M _ | I_LD2R _
     | I_LD3 _ | I_LD3M _ | I_LD3R _
     | I_LD4 _ | I_LD4M _ | I_LD4R _

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -655,7 +655,7 @@ include Arch.MakeArch(struct
     | I_LD2 _ | I_LD2M _ | I_LD2R _
     | I_LD3 _ | I_LD3M _ | I_LD3R _
     | I_LD4 _ | I_LD4M _ | I_LD4R _
-    | I_ST1 _ | I_ST1M _
+    | I_ST1 _ | I_ST1M _ | I_STL1 _
     | I_ST2 _ | I_ST2M _
     | I_ST3 _ | I_ST3M _
     | I_ST4 _ | I_ST4M _

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -663,7 +663,7 @@ include Arch.MakeArch(struct
     | I_STP_SIMD _ | I_STP_P_SIMD _
     | I_LDR_SIMD _ | I_LDR_P_SIMD _
     | I_STR_SIMD _ | I_STR_P_SIMD _
-    | I_LDUR_SIMD _ | I_STUR_SIMD _
+    | I_LDUR_SIMD _ | I_LDAPUR_SIMD _ | I_STUR_SIMD _
     | I_ADDV _ | I_DUP _ | I_FMOV_TG _
     | I_MOV_V _ | I_MOV_VE _ | I_MOV_S _
     | I_MOV_FG _ | I_MOV_TG _

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1102,6 +1102,7 @@ type 'k kinstruction =
   | I_LD4M of reg list * reg * 'k kr
   | I_LD4R of reg list * reg * 'k kr
   | I_ST1 of reg list * int * reg * 'k kr
+  | I_STL1 of reg list * int * reg * 'k kr
   | I_ST1M of reg list * reg * 'k kr
   | I_ST2 of reg list * int * reg * 'k kr
   | I_ST2M of reg list * reg * 'k kr
@@ -1548,6 +1549,8 @@ let do_pp_instruction m =
       pp_vmem_r_m "LD4R" rs r2 kr
   | I_ST1 (rs,i,r2,kr) ->
       pp_vmem_s "ST1" rs i r2 kr
+  | I_STL1 (rs,i,r2,kr) ->
+      pp_vmem_s "STL1" rs i r2 kr
   | I_ST1M (rs,r2,kr) ->
       pp_vmem_r_m "ST1" rs r2 kr
   | I_ST2 (rs,i,r2,kr) ->
@@ -1906,7 +1909,7 @@ let fold_regs (f_regs,f_sregs) =
   | I_LD2 (rs,_,r2,kr) | I_LD2M (rs,r2,kr) | I_LD2R (rs,r2,kr)
   | I_LD3 (rs,_,r2,kr) | I_LD3M (rs,r2,kr) | I_LD3R (rs,r2,kr)
   | I_LD4 (rs,_,r2,kr) | I_LD4M (rs,r2,kr) | I_LD4R (rs,r2,kr)
-  | I_ST1 (rs,_,r2,kr) | I_ST1M (rs,r2,kr)
+  | I_ST1 (rs,_,r2,kr) | I_ST1M (rs,r2,kr) | I_STL1 (rs,_,r2,kr)
   | I_ST2 (rs,_,r2,kr) | I_ST2M (rs,r2,kr)
   | I_ST3 (rs,_,r2,kr) | I_ST3M (rs,r2,kr)
   | I_ST4 (rs,_,r2,kr) | I_ST4M (rs,r2,kr)
@@ -2060,6 +2063,8 @@ let map_regs f_reg f_symb =
       I_LD4R (List.map map_reg rs,map_reg r2,map_kr kr)
   | I_ST1 (rs,i,r2,kr) ->
       I_ST1 (List.map map_reg rs,i,map_reg r2,map_kr kr)
+  | I_STL1 (rs,i,r2,kr) ->
+      I_STL1 (List.map map_reg rs,i,map_reg r2,map_kr kr)
   | I_ST1M (rs,r2,kr) ->
       I_ST1M (List.map map_reg rs,map_reg r2,map_kr kr)
   | I_ST2 (rs,i,r2,kr) ->
@@ -2322,7 +2327,7 @@ let get_next =
   | I_LD2 _ | I_LD2M _ | I_LD2R _
   | I_LD3 _ | I_LD3M _ | I_LD3R _
   | I_LD4 _ | I_LD4M _ | I_LD4R _
-  | I_ST1 _ | I_ST1M _
+  | I_ST1 _ | I_ST1M _ | I_STL1 _
   | I_ST2 _ | I_ST2M _
   | I_ST3 _ | I_ST3M _
   | I_ST4 _ | I_ST4M _
@@ -2616,6 +2621,7 @@ module PseudoI = struct
         | I_LD4M (rs,r2,kr) -> I_LD4M (rs,r2,kr_tr kr)
         | I_LD4R (rs,r2,kr) -> I_LD4R (rs,r2,kr_tr kr)
         | I_ST1 (rs,i,r2,kr) -> I_ST1 (rs,i,r2,kr_tr kr)
+        | I_STL1 (rs,i,r2,kr) -> I_STL1 (rs,i,r2,kr_tr kr)
         | I_ST1M (rs,r2,kr) -> I_ST1M (rs,r2,kr_tr kr)
         | I_ST2 (rs,i,r2,kr) -> I_ST2 (rs,i,r2,kr_tr kr)
         | I_ST2M (rs,r2,kr) -> I_ST2M (rs,r2,kr_tr kr)
@@ -2672,7 +2678,7 @@ module PseudoI = struct
         | I_STG _ | I_LDG _
         | I_LDR_SIMD _ | I_STR_SIMD _
         | I_LD1 _ | I_LD1R _ | I_LDAP1 _
-        | I_ST1 _
+        | I_ST1 _ | I_STL1 _
         | I_LDUR_SIMD _ | I_LDAPUR_SIMD _
         | I_STUR_SIMD _ | I_STLUR_SIMD _
         | I_TLBI (_,_)

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1119,6 +1119,7 @@ type 'k kinstruction =
   | I_LDUR_SIMD of simd_variant * reg * reg * 'k option
   | I_LDAPUR_SIMD of simd_variant * reg * reg * 'k option
   | I_STUR_SIMD of simd_variant * reg * reg * 'k option
+  | I_STLUR_SIMD of simd_variant * reg * reg * 'k option
   | I_ADDV of simd_variant * reg * reg
   | I_DUP of reg * variant * reg
   | I_FMOV_TG of variant * reg * simd_variant * reg
@@ -1590,6 +1591,10 @@ let do_pp_instruction m =
       sprintf "STUR %s,[%s]" (pp_vsimdreg v r1) (pp_reg r2)
   | I_STUR_SIMD (v,r1,r2,Some(k)) ->
       sprintf "STUR %s,[%s,%s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
+  | I_STLUR_SIMD (v,r1,r2,None) ->
+      sprintf "STLUR %s,[%s]" (pp_vsimdreg v r1) (pp_reg r2)
+  | I_STLUR_SIMD (v,r1,r2,Some(k)) ->
+      sprintf "STLUR %s,[%s,%s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
   | I_ADDV (v,r1,r2) ->
       sprintf "ADDV %s,%s" (pp_vsimdreg v r1) (pp_simd_vector_reg r2)
   | I_DUP (r1,v,r2) ->
@@ -1879,7 +1884,8 @@ let fold_regs (f_regs,f_sregs) =
   | I_FMOV_TG (_,r1,_,r2)
   | I_DUP (r1,_,r2)
   | I_ADDV (_,r1,r2)
-  | I_LDUR_SIMD (_,r1,r2,_) | I_LDAPUR_SIMD (_,r1,r2,_) | I_STUR_SIMD (_,r1,r2,_)
+  | I_LDUR_SIMD (_,r1,r2,_) | I_LDAPUR_SIMD (_,r1,r2,_)
+  | I_STUR_SIMD (_,r1,r2,_) | I_STLUR_SIMD (_,r1,r2,_)
   | I_LDG (r1,r2,_) | I_STZG (r1,r2,_)
   | I_STZ2G (r1,r2,_) | I_STG (r1,r2,_)
   | I_ALIGND (r1,r2,_) | I_ALIGNU (r1,r2,_)
@@ -2085,6 +2091,8 @@ let map_regs f_reg f_symb =
       I_LDAPUR_SIMD (v,map_reg r1, map_reg r2,k)
   | I_STUR_SIMD (v,r1,r2,k) ->
       I_STUR_SIMD (v,map_reg r1, map_reg r2,k)
+  | I_STLUR_SIMD (v,r1,r2,k) ->
+      I_STLUR_SIMD (v,map_reg r1, map_reg r2,k)
   | I_ADDV (v,r1,r2) ->
       I_ADDV (v,map_reg r1,map_reg r2)
   | I_DUP (r1,v,r2) ->
@@ -2317,7 +2325,8 @@ let get_next =
   | I_STP_P_SIMD _ | I_STP_SIMD _
   | I_LDR_SIMD _ | I_LDR_P_SIMD _
   | I_STR_SIMD _ | I_STR_P_SIMD _
-  | I_LDUR_SIMD _ | I_LDAPUR_SIMD _ | I_STUR_SIMD _
+  | I_LDUR_SIMD _ | I_LDAPUR_SIMD _
+  | I_STUR_SIMD _ | I_STLUR_SIMD _
   | I_ADDV _ | I_DUP _ | I_FMOV_TG _
   | I_MOV_VE _ | I_MOV_V _ | I_MOV_TG _ | I_MOV_FG _
   | I_MOV_S _
@@ -2622,6 +2631,8 @@ module PseudoI = struct
         | I_LDAPUR_SIMD (v,r1,r2,Some(k)) -> I_LDAPUR_SIMD (v,r1,r2,Some(k_tr k))
         | I_STUR_SIMD (v,r1,r2,None) -> I_STUR_SIMD (v,r1,r2,None)
         | I_STUR_SIMD (v,r1,r2,Some(k)) -> I_STUR_SIMD (v,r1,r2,Some(k_tr k))
+        | I_STLUR_SIMD (v,r1,r2,None) -> I_STLUR_SIMD (v,r1,r2,None)
+        | I_STLUR_SIMD (v,r1,r2,Some(k)) -> I_STLUR_SIMD (v,r1,r2,Some(k_tr k))
         | I_MOVI_V (r,k,s) -> I_MOVI_V (r,k_tr k,ap_shift k_tr s)
         | I_MOVI_S (v,r,k) -> I_MOVI_S (v,r,k_tr k)
         | I_EOR_SIMD (r1,r2,r3) -> I_EOR_SIMD (r1,r2,r3)
@@ -2656,7 +2667,8 @@ module PseudoI = struct
         | I_LDR_SIMD _ | I_STR_SIMD _
         | I_LD1 _ | I_LD1R _
         | I_ST1 _
-        | I_LDUR_SIMD _ | I_LDAPUR_SIMD _ | I_STUR_SIMD _
+        | I_LDUR_SIMD _ | I_LDAPUR_SIMD _
+        | I_STUR_SIMD _ | I_STLUR_SIMD _
         | I_TLBI (_,_)
           -> 1
         | I_LDP _|I_LDPSW _|I_STP _|I_LDXP _|I_STXP _

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1401,7 +1401,7 @@ let do_pp_instruction m =
   let pp_smemp memo v r1 r2 ra k =
     pp_memo memo ^ " " ^ pp_vsimdreg v r1 ^ "," ^ pp_vsimdreg v r2 ^
     ",[" ^ pp_xreg ra ^ (if m.compat
-      then pp_kr false false (K k) else m.pp_k k)  ^ "]" in
+      then pp_kr false false (K k) else "," ^ m.pp_k k)  ^ "]" in
 
   let pp_vmem_shift memo r k s =
     pp_memo memo ^ " " ^ pp_simd_vector_reg r ^ "," ^ m.pp_k k ^

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1090,7 +1090,7 @@ type 'k kinstruction =
 (* Neon Extension Load and Store*)
   | I_LD1 of reg list * int * reg * 'k kr
   | I_LD1M of reg list * reg * 'k kr
-  | I_LD1R of reg * reg * 'k kr
+  | I_LD1R of reg list * reg * 'k kr
   | I_LD2 of reg list * int * reg * 'k kr
   | I_LD2M of reg list * reg * 'k kr
   | I_LD2R of reg list * reg * 'k kr
@@ -1521,8 +1521,8 @@ let do_pp_instruction m =
       pp_vmem_s "LD1" rs i r2 kr
   | I_LD1M (rs,r2,kr) ->
       pp_vmem_r_m "LD1" rs r2 kr
-  | I_LD1R (r1, r2, kr) ->
-      pp_vmem_r_m "LD1R" [r1] r2 kr
+  | I_LD1R (rs, r2, kr) ->
+      pp_vmem_r_m "LD1R" rs r2 kr
   | I_LD2 (rs,i,r2,kr) ->
       pp_vmem_s "LD2" rs i r2 kr
   | I_LD2M (rs,r2,kr) ->
@@ -1880,7 +1880,6 @@ let fold_regs (f_regs,f_sregs) =
   | I_ALIGND (r1,r2,_) | I_ALIGNU (r1,r2,_)
     -> fold_reg r1 (fold_reg r2 c)
   | I_MRS (r,sr) | I_MSR (sr,r) -> fold_reg (SysReg sr) (fold_reg r c)
-  | I_LD1R (r1,r2,kr)
   | I_LDR_SIMD (_,r1,r2,kr,_) | I_STR_SIMD(_,r1,r2,kr,_)
     -> fold_reg r1 (fold_reg r2 (fold_kr kr c))
   | I_OP3 (_,_,r1,r2,e)
@@ -1889,7 +1888,7 @@ let fold_regs (f_regs,f_sregs) =
   | I_LDRS (_,r1,r2,idx) | I_STR (_,r1,r2,idx)
   | I_LDRBH (_,r1,r2,idx) | I_STRBH (_,r1,r2,idx)
     -> fold_reg r1 (fold_reg r2 (fold_idx idx c))
-  | I_LD1 (rs,_,r2,kr) | I_LD1M (rs,r2,kr)
+  | I_LD1 (rs,_,r2,kr) | I_LD1M (rs,r2,kr) | I_LD1R (rs,r2,kr)
   | I_LD2 (rs,_,r2,kr) | I_LD2M (rs,r2,kr) | I_LD2R (rs,r2,kr)
   | I_LD3 (rs,_,r2,kr) | I_LD3M (rs,r2,kr) | I_LD3R (rs,r2,kr)
   | I_LD4 (rs,_,r2,kr) | I_LD4M (rs,r2,kr) | I_LD4R (rs,r2,kr)
@@ -2023,8 +2022,8 @@ let map_regs f_reg f_symb =
       I_LD1 (List.map map_reg rs, i, map_reg r2, map_kr kr)
   | I_LD1M (rs,r2,kr) ->
       I_LD1M (List.map map_reg rs,map_reg r2,map_kr kr)
-  | I_LD1R (r1,r2,kr) ->
-      I_LD1R (map_reg r1,map_reg r2,map_kr kr)
+  | I_LD1R (rs,r2,kr) ->
+      I_LD1R (List.map map_reg rs,map_reg r2,map_kr kr)
   | I_LD2 (rs,i,r2,kr) ->
       I_LD2 (List.map map_reg rs,i,map_reg r2,map_kr kr)
   | I_LD2M (rs,r2,kr) ->
@@ -2584,7 +2583,7 @@ module PseudoI = struct
         | I_ALIGNU (r1,r2,k) -> I_ALIGNU (r1,r2,k_tr k)
         | I_LD1 (rs,i,r2,kr) -> I_LD1 (rs,i,r2,kr_tr kr)
         | I_LD1M (rs,r2,kr) -> I_LD1M (rs,r2,kr_tr kr)
-        | I_LD1R (r1,r2,kr) -> I_LD1R (r1,r2,kr_tr kr)
+        | I_LD1R (rs,r2,kr) -> I_LD1R (rs,r2,kr_tr kr)
         | I_LD2 (rs,i,r2,kr) -> I_LD2 (rs,i,r2,kr_tr kr)
         | I_LD2M (rs,r2,kr) -> I_LD2M (rs,r2,kr_tr kr)
         | I_LD2R (rs,r2,kr) -> I_LD2R (rs,r2,kr_tr kr)

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1089,6 +1089,7 @@ type 'k kinstruction =
   | I_LDUR of variant * reg * reg * 'k option
 (* Neon Extension Load and Store*)
   | I_LD1 of reg list * int * reg * 'k kr
+  | I_LDAP1 of reg list * int * reg * 'k kr
   | I_LD1M of reg list * reg * 'k kr
   | I_LD1R of reg list * reg * 'k kr
   | I_LD2 of reg list * int * reg * 'k kr
@@ -1521,6 +1522,8 @@ let do_pp_instruction m =
 (* Neon Extension Load and Store *)
   | I_LD1 (rs,i,r2,kr) ->
       pp_vmem_s "LD1" rs i r2 kr
+  | I_LDAP1 (rs,i,r2,kr) ->
+      pp_vmem_s "LDAP1" rs i r2 kr
   | I_LD1M (rs,r2,kr) ->
       pp_vmem_r_m "LD1" rs r2 kr
   | I_LD1R (rs, r2, kr) ->
@@ -1899,7 +1902,7 @@ let fold_regs (f_regs,f_sregs) =
   | I_LDRS (_,r1,r2,idx) | I_STR (_,r1,r2,idx)
   | I_LDRBH (_,r1,r2,idx) | I_STRBH (_,r1,r2,idx)
     -> fold_reg r1 (fold_reg r2 (fold_idx idx c))
-  | I_LD1 (rs,_,r2,kr) | I_LD1M (rs,r2,kr) | I_LD1R (rs,r2,kr)
+  | I_LD1 (rs,_,r2,kr) | I_LD1M (rs,r2,kr) | I_LD1R (rs,r2,kr) | I_LDAP1 (rs,_,r2,kr)
   | I_LD2 (rs,_,r2,kr) | I_LD2M (rs,r2,kr) | I_LD2R (rs,r2,kr)
   | I_LD3 (rs,_,r2,kr) | I_LD3M (rs,r2,kr) | I_LD3R (rs,r2,kr)
   | I_LD4 (rs,_,r2,kr) | I_LD4M (rs,r2,kr) | I_LD4R (rs,r2,kr)
@@ -2031,6 +2034,8 @@ let map_regs f_reg f_symb =
 (* Neon Extension Loads and Stores *)
   | I_LD1 (rs,i,r2,kr) ->
       I_LD1 (List.map map_reg rs, i, map_reg r2, map_kr kr)
+  | I_LDAP1 (rs,i,r2,kr) ->
+      I_LDAP1 (List.map map_reg rs, i, map_reg r2, map_kr kr)
   | I_LD1M (rs,r2,kr) ->
       I_LD1M (List.map map_reg rs,map_reg r2,map_kr kr)
   | I_LD1R (rs,r2,kr) ->
@@ -2313,7 +2318,7 @@ let get_next =
   | I_ALIGND _| I_ALIGNU _|I_BUILD _|I_CHKEQ _|I_CHKSLD _|I_CHKTGD _|I_CLRTAG _
   | I_CPYTYPE _|I_CPYVALUE _|I_CSEAL _|I_GC _|I_LDCT _|I_SC _|I_SEAL _|I_STCT _
   | I_UNSEAL _
-  | I_LD1 _ | I_LD1M _ | I_LD1R _
+  | I_LD1 _ | I_LD1M _ | I_LD1R _ | I_LDAP1 _
   | I_LD2 _ | I_LD2M _ | I_LD2R _
   | I_LD3 _ | I_LD3M _ | I_LD3R _
   | I_LD4 _ | I_LD4M _ | I_LD4R _
@@ -2598,6 +2603,7 @@ module PseudoI = struct
         | I_ALIGND (r1,r2,k) -> I_ALIGND (r1,r2,k_tr k)
         | I_ALIGNU (r1,r2,k) -> I_ALIGNU (r1,r2,k_tr k)
         | I_LD1 (rs,i,r2,kr) -> I_LD1 (rs,i,r2,kr_tr kr)
+        | I_LDAP1 (rs,i,r2,kr) -> I_LDAP1 (rs,i,r2,kr_tr kr)
         | I_LD1M (rs,r2,kr) -> I_LD1M (rs,r2,kr_tr kr)
         | I_LD1R (rs,r2,kr) -> I_LD1R (rs,r2,kr_tr kr)
         | I_LD2 (rs,i,r2,kr) -> I_LD2 (rs,i,r2,kr_tr kr)
@@ -2665,7 +2671,7 @@ module PseudoI = struct
         | I_LDRBH _ | I_STRBH _ | I_STXRBH _ | I_IC _ | I_DC _
         | I_STG _ | I_LDG _
         | I_LDR_SIMD _ | I_STR_SIMD _
-        | I_LD1 _ | I_LD1R _
+        | I_LD1 _ | I_LD1R _ | I_LDAP1 _
         | I_ST1 _
         | I_LDUR_SIMD _ | I_LDAPUR_SIMD _
         | I_STUR_SIMD _ | I_STLUR_SIMD _

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1578,13 +1578,13 @@ let do_pp_instruction m =
   | I_STR_P_SIMD (v,r1,r2,k) ->
       pp_smem_post "STR" v r1 r2 k
   | I_LDUR_SIMD (v,r1,r2,None) ->
-      sprintf "LDUR %s, [%s]" (pp_vsimdreg v r1) (pp_reg r2)
+      sprintf "LDUR %s,[%s]" (pp_vsimdreg v r1) (pp_reg r2)
   | I_LDUR_SIMD (v,r1,r2,Some(k)) ->
-      sprintf "LDUR %s, [%s, %s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
+      sprintf "LDUR %s,[%s,%s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
   | I_STUR_SIMD (v,r1,r2,None) ->
-      sprintf "STUR %s, [%s]" (pp_vsimdreg v r1) (pp_reg r2)
+      sprintf "STUR %s,[%s]" (pp_vsimdreg v r1) (pp_reg r2)
   | I_STUR_SIMD (v,r1,r2,Some(k)) ->
-      sprintf "STUR %s, [%s, %s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
+      sprintf "STUR %s,[%s,%s]" (pp_vsimdreg v r1) (pp_reg r2) (m.pp_k k)
   | I_ADDV (v,r1,r2) ->
       sprintf "ADDV %s,%s" (pp_vsimdreg v r1) (pp_simd_vector_reg r2)
   | I_DUP (r1,v,r2) ->

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -83,6 +83,7 @@ match name with
 | "ldr"|"LDR" -> LDR
 | "ldrsw"|"LDRSW" -> LDRSW
 | "ldur"|"LDUR" -> LDUR
+| "ldapur"|"LDAPUR" -> LDAPUR
 | "ldp"|"LDP" -> LDP
 | "ldpsw"|"LDPSW" -> LDPSW
 | "ldnp"|"LDNP" -> LDNP

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -125,6 +125,7 @@ match name with
 | "stlxp"| "STLXP" -> STLXP
 (* Neon Extension Memory *)
 | "ld1" | "LD1" -> LD1
+| "ldap1" | "LDAP1" -> LDAP1
 | "ld1r" | "LD1R" -> LD1R
 | "ld2" | "LD2" -> LD2
 | "ld2r" | "LD2R" -> LD2R

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -133,6 +133,7 @@ match name with
 | "ld4" | "LD4" -> LD4
 | "ld4r" | "LD4R" -> LD4R
 | "stur" | "STUR" -> STUR
+| "stlur" | "STLUR" -> STLUR
 | "st1" | "ST1" -> ST1
 | "st2" | "ST2" -> ST2
 | "st3" | "ST3" -> ST3

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -135,6 +135,7 @@ match name with
 | "ld4r" | "LD4R" -> LD4R
 | "stur" | "STUR" -> STUR
 | "stlur" | "STLUR" -> STLUR
+| "stl1" | "STL1" -> STL1
 | "st1" | "ST1" -> ST1
 | "st2" | "ST2" -> ST2
 | "st3" | "ST3" -> ST3

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -212,13 +212,13 @@ vreg:
 | ARCH_VREG { $1 }
 
 vregs:
-| vregs1 { [$1] }
+| vregs1 { $1 }
 | vregs2 { $1 }
 | vregs3 { $1 }
 | vregs4 { $1 }
 
 vregs1:
-| LCRL vreg RCRL { $2 }
+| LCRL vreg RCRL { [$2] }
 
 vregs2:
 | LCRL vreg COMMA vreg RCRL { [$2;$4] }
@@ -657,11 +657,11 @@ instr:
   { I_STXRBH (H,LY,$2,$4,$7) }
    /* Neon extension Memory */
 | LD1 vregs1 INDEX COMMA LBRK xreg RBRK kx0_no_shift
-  { I_LD1 ([$2], $3, $6, $8) }
+  { I_LD1 ($2, $3, $6, $8) }
 | LD1 vregs COMMA LBRK xreg RBRK kx0_no_shift
   { I_LD1M ($2, $5, $7) }
 | LD1R vregs1 COMMA LBRK xreg RBRK kx0_no_shift
-  { I_LD1R ([$2], $5, $7) }
+  { I_LD1R ($2, $5, $7) }
 | LD2 vregs2 INDEX COMMA LBRK xreg RBRK kx0_no_shift
   { I_LD2 ($2, $3, $6, $8) }
 | LD2 vregs2 COMMA LBRK xreg RBRK kx0_no_shift
@@ -681,7 +681,7 @@ instr:
 | LD4R vregs4 COMMA LBRK xreg RBRK kx0_no_shift
    { I_LD4R ($2, $5, $7) }
 | ST1 vregs1 INDEX COMMA LBRK xreg RBRK kx0_no_shift
-   { I_ST1 ([$2], $3, $6, $8) }
+   { I_ST1 ($2, $3, $6, $8) }
 | ST1 vregs COMMA LBRK xreg RBRK kx0_no_shift
    { I_ST1M ($2, $5, $7) }
 | ST2 vregs2 INDEX COMMA LBRK xreg RBRK kx0_no_shift

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -70,7 +70,7 @@ let check_op3 op e =
 %token LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
 %token LDRSB LDRSH
 %token LD1 LD1R LD2 LD2R LD3 LD3R LD4 LD4R ST1 ST2 ST3 ST4 STUR /* Neon load/store */
-%token ADDV DUP FMOV LDAPUR
+%token ADDV DUP FMOV LDAPUR STLUR
 %token CMP MOV MOVZ MOVN MOVK MOVI ADR MVN
 %token  LDAR LDARB LDARH LDAPR LDAPRB LDAPRH  LDXR LDXRB LDXRH LDAXR LDAXRB LDAXRH LDXP LDAXP
 %token STXR STXRB STXRH STLXR STLXRB STLXRH STXP STLXP
@@ -733,6 +733,9 @@ instr:
 | STUR scalar_regs COMMA LBRK xreg k0_opt RBRK
   { let v,r = $2 in
     I_STUR_SIMD (v, r, $5, $6) }
+| STLUR scalar_regs COMMA LBRK xreg k0_opt RBRK
+  { let v,r = $2 in
+    I_STLUR_SIMD (v, r, $5, $6) }
 | ADDV breg COMMA vreg
   {  I_ADDV (VSIMD8, $2, $4) }
 | ADDV hreg COMMA vreg

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -661,7 +661,7 @@ instr:
 | LD1 vregs COMMA LBRK xreg RBRK kx0_no_shift
   { I_LD1M ($2, $5, $7) }
 | LD1R vregs1 COMMA LBRK xreg RBRK kx0_no_shift
-  { I_LD1R ($2, $5, $7) }
+  { I_LD1R ([$2], $5, $7) }
 | LD2 vregs2 INDEX COMMA LBRK xreg RBRK kx0_no_shift
   { I_LD2 ($2, $3, $6, $8) }
 | LD2 vregs2 COMMA LBRK xreg RBRK kx0_no_shift

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -69,7 +69,7 @@ let check_op3 op e =
 %token LDR LDRSW LDP LDNP LDPSW LDIAPP STP STNP STILP
 %token LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
 %token LDRSB LDRSH
-%token LD1 LD1R LD2 LD2R LD3 LD3R LD4 LD4R ST1 ST2 ST3 ST4 STUR /* Neon load/store */
+%token LD1 LD1R LDAP1 LD2 LD2R LD3 LD3R LD4 LD4R ST1 ST2 ST3 ST4 STUR /* Neon load/store */
 %token ADDV DUP FMOV LDAPUR STLUR
 %token CMP MOV MOVZ MOVN MOVK MOVI ADR MVN
 %token  LDAR LDARB LDARH LDAPR LDAPRB LDAPRH  LDXR LDXRB LDXRH LDAXR LDAXRB LDAXRH LDXP LDAXP
@@ -658,6 +658,11 @@ instr:
    /* Neon extension Memory */
 | LD1 vregs1 INDEX COMMA LBRK xreg RBRK kx0_no_shift
   { I_LD1 ($2, $3, $6, $8) }
+| LDAP1 vregs1 INDEX COMMA LBRK xreg RBRK
+  { match List.hd $2 with
+    | Vreg(_,(0,64)) -> I_LDAP1 ($2, $3, $6, K (MetaConst.zero))
+    | _ -> assert false
+  }
 | LD1 vregs COMMA LBRK xreg RBRK kx0_no_shift
   { I_LD1M ($2, $5, $7) }
 | LD1R vregs1 COMMA LBRK xreg RBRK kx0_no_shift

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -657,7 +657,7 @@ instr:
   { I_STXRBH (H,LY,$2,$4,$7) }
    /* Neon extension Memory */
 | LD1 vregs1 INDEX COMMA LBRK xreg RBRK kx0_no_shift
-  { I_LD1 ($2, $3, $6, $8) }
+  { I_LD1 ([$2], $3, $6, $8) }
 | LD1 vregs COMMA LBRK xreg RBRK kx0_no_shift
   { I_LD1M ($2, $5, $7) }
 | LD1R vregs1 COMMA LBRK xreg RBRK kx0_no_shift
@@ -681,7 +681,7 @@ instr:
 | LD4R vregs4 COMMA LBRK xreg RBRK kx0_no_shift
    { I_LD4R ($2, $5, $7) }
 | ST1 vregs1 INDEX COMMA LBRK xreg RBRK kx0_no_shift
-   { I_ST1 ($2, $3, $6, $8) }
+   { I_ST1 ([$2], $3, $6, $8) }
 | ST1 vregs COMMA LBRK xreg RBRK kx0_no_shift
    { I_ST1M ($2, $5, $7) }
 | ST2 vregs2 INDEX COMMA LBRK xreg RBRK kx0_no_shift

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -69,7 +69,7 @@ let check_op3 op e =
 %token LDR LDRSW LDP LDNP LDPSW LDIAPP STP STNP STILP
 %token LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
 %token LDRSB LDRSH
-%token LD1 LD1R LDAP1 LD2 LD2R LD3 LD3R LD4 LD4R ST1 ST2 ST3 ST4 STUR /* Neon load/store */
+%token LD1 LD1R LDAP1 LD2 LD2R LD3 LD3R LD4 LD4R STL1 ST1 ST2 ST3 ST4 STUR /* Neon load/store */
 %token ADDV DUP FMOV LDAPUR STLUR
 %token CMP MOV MOVZ MOVN MOVK MOVI ADR MVN
 %token  LDAR LDARB LDARH LDAPR LDAPRB LDAPRH  LDXR LDXRB LDXRH LDAXR LDAXRB LDAXRH LDXP LDAXP
@@ -687,6 +687,11 @@ instr:
    { I_LD4R ($2, $5, $7) }
 | ST1 vregs1 INDEX COMMA LBRK xreg RBRK kx0_no_shift
    { I_ST1 ($2, $3, $6, $8) }
+| STL1 vregs1 INDEX COMMA LBRK xreg RBRK
+  { match List.hd $2 with
+    | Vreg(_,(0,64)) -> I_STL1 ($2, $3, $6,  K (MetaConst.zero))
+    | _ -> assert false
+  }
 | ST1 vregs COMMA LBRK xreg RBRK kx0_no_shift
    { I_ST1M ($2, $5, $7) }
 | ST2 vregs2 INDEX COMMA LBRK xreg RBRK kx0_no_shift

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -70,7 +70,7 @@ let check_op3 op e =
 %token LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
 %token LDRSB LDRSH
 %token LD1 LD1R LD2 LD2R LD3 LD3R LD4 LD4R ST1 ST2 ST3 ST4 STUR /* Neon load/store */
-%token ADDV DUP FMOV
+%token ADDV DUP FMOV LDAPUR
 %token CMP MOV MOVZ MOVN MOVK MOVI ADR MVN
 %token  LDAR LDARB LDARH LDAPR LDAPRB LDAPRH  LDXR LDXRB LDXRH LDAXR LDAXRB LDAXRH LDXP LDAXP
 %token STXR STXRB STXRH STLXR STLXRB STLXRH STXP STLXP
@@ -719,6 +719,9 @@ instr:
 | LDUR scalar_regs COMMA LBRK xreg k0_opt RBRK
   { let v,r = $2 in
     I_LDUR_SIMD (v, r, $5, $6) }
+| LDAPUR scalar_regs COMMA LBRK xreg k0_opt RBRK
+  { let v,r = $2 in
+    I_LDAPUR_SIMD (v, r, $5, $6) }
 | STR scalar_regs COMMA LBRK xreg kr0 RBRK k0_opt
   { let v,r    = $2 in
     let kr, os = $6 in

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1374,6 +1374,8 @@ module Make(V:Constant.S)(C:Config) =
     | I_STR_P_SIMD (v,r1,r2,k1) -> store_simd_p v r1 r2 k1::k
     | I_LDUR_SIMD (v,r1,r2,Some(k1)) -> load_simd "ldur" v r1 r2 (K k1) S_NOEXT::k
     | I_LDUR_SIMD (v,r1,r2,None) -> load_simd "ldur" v r1 r2 (K 0) S_NOEXT::k
+    | I_LDAPUR_SIMD (v,r1,r2,Some(k1)) -> load_simd "ldapur" v r1 r2 (K k1) S_NOEXT::k
+    | I_LDAPUR_SIMD (v,r1,r2,None) -> load_simd "ldapur" v r1 r2 (K 0) S_NOEXT::k
     | I_STUR_SIMD (v,r1,r2,Some(k1)) -> store_simd "stur" v r1 r2 (K k1) S_NOEXT::k
     | I_STUR_SIMD (v,r1,r2,None) -> store_simd "stur" v r1 r2 (K 0) S_NOEXT::k
     | I_ADDV (v,r1,r2) -> addv_simd v r1 r2::k

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1378,6 +1378,8 @@ module Make(V:Constant.S)(C:Config) =
     | I_LDAPUR_SIMD (v,r1,r2,None) -> load_simd "ldapur" v r1 r2 (K 0) S_NOEXT::k
     | I_STUR_SIMD (v,r1,r2,Some(k1)) -> store_simd "stur" v r1 r2 (K k1) S_NOEXT::k
     | I_STUR_SIMD (v,r1,r2,None) -> store_simd "stur" v r1 r2 (K 0) S_NOEXT::k
+    | I_STLUR_SIMD (v,r1,r2,Some(k1)) -> store_simd "stlur" v r1 r2 (K k1) S_NOEXT::k
+    | I_STLUR_SIMD (v,r1,r2,None) -> store_simd "stlur" v r1 r2 (K 0) S_NOEXT::k
     | I_ADDV (v,r1,r2) -> addv_simd v r1 r2::k
     | I_DUP (r1,v,r2) -> dup_simd_v r1 v r2::k
     | I_FMOV_TG (v1,r1,v2,r2) -> fmov_simd_tg v1 r1 v2 r2::k

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -48,16 +48,15 @@ module Make(V:Constant.S)(C:Config) =
     let extract_addrs _ins = Global_litmus.Set.empty
 
     let stable_regs _ins = match _ins with
-    | I_LD1M (rs,_,_)
+    | I_LD1 (rs,_,_,_) | I_LD1M (rs,_,_)
     | I_LD2 (rs,_,_,_) | I_LD2M (rs,_,_) | I_LD2R (rs,_,_)
     | I_LD3 (rs,_,_,_) | I_LD3M (rs,_,_) | I_LD3R (rs,_,_)
     | I_LD4 (rs,_,_,_) | I_LD4M (rs,_,_) | I_LD4R (rs,_,_)
-    | I_ST1M (rs,_,_)
+    | I_ST1 (rs,_,_,_) | I_ST1M (rs,_,_)
     | I_ST2 (rs,_,_,_) | I_ST2M (rs,_,_)
     | I_ST3 (rs,_,_,_) | I_ST3M (rs,_,_)
     | I_ST4 (rs,_,_,_) | I_ST4M (rs,_,_) ->
         A.RegSet.of_list rs
-    | I_LD1 (r,_,_,_) -> A.RegSet.of_list [r]
     | I_MOV_FG (r,_,_,_) -> A.RegSet.of_list [r]
     | I_MOV_VE (r,_,_,_) -> A.RegSet.of_list [r]
     | _ ->  A.RegSet.empty
@@ -1341,7 +1340,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_SWP (v,rmw,r1,r2,r3) -> swp (swp_memo rmw) v r1 r2 r3::k
     | I_SWPBH (bh,rmw,r1,r2,r3) -> swp (swpbh_memo bh rmw) V32 r1 r2 r3::k
 (* Neon Extension Load and Store *)
-    | I_LD1 (r1,i,r2,kr) -> load_simd_s "ld1" [r1] i r2 kr::k
+    | I_LD1 (rs,i,r2,kr) -> load_simd_s "ld1" rs i r2 kr::k
     | I_LD1M (rs,r2,kr) -> load_simd_m "ld1" rs r2 kr::k
     | I_LD1R (r1,r2,kr) -> load_simd_m "ld1r" [r1] r2 kr::k
     | I_LD2 (rs,i,r2,kr) -> load_simd_s "ld2" rs i r2 kr::k
@@ -1353,7 +1352,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_LD4 (rs,i,r2,kr) -> load_simd_s "ld4" rs i r2 kr::k
     | I_LD4M (rs,r2,kr) -> load_simd_m "ld4" rs r2 kr::k
     | I_LD4R (rs,r2,kr) -> load_simd_m "ld4r" rs r2 kr::k
-    | I_ST1 (r1,i,r2,kr) -> store_simd_s "st1" [r1] i r2 kr::k
+    | I_ST1 (rs,i,r2,kr) -> store_simd_s "st1" rs i r2 kr::k
     | I_ST1M (rs,r2,kr) -> store_simd_m "st1" rs r2 kr::k
     | I_ST2 (rs,i,r2,kr) -> store_simd_s "st2" rs i r2 kr::k
     | I_ST2M (rs,r2,kr) -> store_simd_m "st2" rs r2 kr::k

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1355,6 +1355,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_LD4M (rs,r2,kr) -> load_simd_m "ld4" rs r2 kr::k
     | I_LD4R (rs,r2,kr) -> load_simd_m "ld4r" rs r2 kr::k
     | I_ST1 (rs,i,r2,kr) -> store_simd_s "st1" rs i r2 kr::k
+    | I_STL1 (rs,i,r2,kr) -> store_simd_s "stl1" rs i r2 kr::k
     | I_ST1M (rs,r2,kr) -> store_simd_m "st1" rs r2 kr::k
     | I_ST2 (rs,i,r2,kr) -> store_simd_s "st2" rs i r2 kr::k
     | I_ST2M (rs,r2,kr) -> store_simd_m "st2" rs r2 kr::k

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1342,7 +1342,7 @@ module Make(V:Constant.S)(C:Config) =
 (* Neon Extension Load and Store *)
     | I_LD1 (rs,i,r2,kr) -> load_simd_s "ld1" rs i r2 kr::k
     | I_LD1M (rs,r2,kr) -> load_simd_m "ld1" rs r2 kr::k
-    | I_LD1R (r1,r2,kr) -> load_simd_m "ld1r" [r1] r2 kr::k
+    | I_LD1R (rs,r2,kr) -> load_simd_m "ld1r" rs r2 kr::k
     | I_LD2 (rs,i,r2,kr) -> load_simd_s "ld2" rs i r2 kr::k
     | I_LD2M (rs,r2,kr) -> load_simd_m "ld2" rs r2 kr::k
     | I_LD2R (rs,r2,kr) -> load_simd_m "ld2r" rs r2 kr::k

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -48,6 +48,7 @@ module Make(V:Constant.S)(C:Config) =
     let extract_addrs _ins = Global_litmus.Set.empty
 
     let stable_regs _ins = match _ins with
+    | I_LDAP1 (rs,_,_,_)
     | I_LD1 (rs,_,_,_) | I_LD1M (rs,_,_)
     | I_LD2 (rs,_,_,_) | I_LD2M (rs,_,_) | I_LD2R (rs,_,_)
     | I_LD3 (rs,_,_,_) | I_LD3M (rs,_,_) | I_LD3R (rs,_,_)
@@ -1340,6 +1341,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_SWP (v,rmw,r1,r2,r3) -> swp (swp_memo rmw) v r1 r2 r3::k
     | I_SWPBH (bh,rmw,r1,r2,r3) -> swp (swpbh_memo bh rmw) V32 r1 r2 r3::k
 (* Neon Extension Load and Store *)
+    | I_LDAP1 (rs,i,r2,kr) -> load_simd_s "ldap1" rs i r2 kr::k
     | I_LD1 (rs,i,r2,kr) -> load_simd_s "ld1" rs i r2 kr::k
     | I_LD1M (rs,r2,kr) -> load_simd_m "ld1" rs r2 kr::k
     | I_LD1R (rs,r2,kr) -> load_simd_m "ld1r" rs r2 kr::k


### PR DESCRIPTION
Hi All,

I've been adding capability to generate Neon load/store pair instruction and Neon load/store scalar (including ordered variants `LDAPUR` and `STLUR`). Generator now accepts new psudo relaxations:
- `NePa` for Neon `LDP`/`STP`
- `NePaN` for Neon `LDNP`/`STNP`
- `NeP` for Neon `LDUR`/`STUR` instructions
- `NeQ` and `NeL` for Neon `LDAPUR` and `STLUR` correspondingly

Additionally, identified some places for improvements and added support for Neon `LDAP1` and `STL1` in `herd` and `litmus`. 

Please, note that new Neon ordered instructions might not be supported by compilers yet. 

