### PR TITLE
[litmus] Change behaviour for full hash tables

### DIFF
--- a/litmus/libdir/_instance.c
+++ b/litmus/libdir/_instance.c
@@ -98,6 +98,7 @@ typedef struct global_t {
   /* All instance contexts */
   ctx_t ctx[NEXE] ; /* All test instance contexts */
   hash_t hash ;     /* Sum of outcomes */
+  int hash_ok;
 #ifdef STATS
   /* statistics */
   stats_t stats ;
@@ -129,6 +130,7 @@ static void init_global(global_t *g) {
     instance_init(&g->ctx[k],k,m) ;
     m += NVARS*LINESZ ;
   }
+  g->hash_ok = 1;
 }
 
 static void free_global(global_t *g) {

--- a/litmus/libdir/_main.c
+++ b/litmus/libdir/_main.c
@@ -113,7 +113,7 @@ int RUN(int argc,char **argv,FILE *out) {
   int nexe = glo_ptr->nexe ;
   hash_init(&glo_ptr->hash) ;
   for (int k=0 ; k < nexe ; k++) {
-    hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) ;
+    glo_ptr->hash_ok = hash_adds(&glo_ptr->hash,&glo_ptr->ctx[k].t) && glo_ptr->hash_ok ;
   }
 #ifdef OUT
   tsc_t total = timeofday()-start;

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1745,8 +1745,9 @@ module Make
               Indent.indent3 in
           O.ox id "int _cond = final_ok(final_cond(_log));" ;
           (* recorded outcome *)
-          O.fx id "hash_add(&_ctx->t,_log%s,1,_cond);"
+          O.fx id "int _added = hash_add(&_ctx->t,_log%s,1,_cond);"
             (if do_stats then ",_p" else "") ;
+          O.ox id "if (!_added && _g->hash_ok) _g->hash_ok = 0; // Avoid writing too much." ;
           (* Result and stats *)
           O.ox id "if (_cond) {" ;
           let nid = Indent.tab id in

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -884,6 +884,13 @@ module Make
               O.oi "emit_millions(tsc_millions(total));" ;
               O.oi "puts(\"\\n\");"
           end ;
+          begin match Cfg.mode with
+          | Mode.PreSi|Mode.Kvm ->
+             O.oi "if (!g->hash_ok) {" ;
+             EPF.fii "Warning: some hash table was full, some outcomes were not collected\n" [] ;
+             O.oi "}" ;
+          | Mode.Std -> ()
+          end ;
           if Cfg.exit_cond then O.oi "return cond;" ;
           O.o "}" ;
           O.o "" ;


### PR DESCRIPTION
Previous behaviour was exiting, which is not appropriate when the same executable performs several tests (mode `driver C`). New behaviour is going on and flagging a warning that the collection of outcomes is not complete.