### PR TITLE
[litmus] Fix two small bugs in litmus

### DIFF
--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -70,12 +70,16 @@ module RegMap = A.RegMap)
       module RegMap = Tmpl.RegMap
 
       let dump_clobbers chan clobs t =
+        let clobs =
+          clobs@List.map A.reg_to_string (t.Tmpl.all_clobbers@A.forbidden_regs)
+          |> StringSet.of_list
+        and stable =
+          List.map  A.reg_to_string t.Tmpl.stable |> StringSet.of_list in
+        let clobs = StringSet.diff clobs stable |> StringSet.elements in
         fprintf chan ":%s\n"
           (String.concat ","
              (List.map (fun s -> sprintf "\"%s\"" s)
-                ("cc"::"memory"::clobs@
-                 List.map A.reg_to_string
-                   (t.Tmpl.all_clobbers@A.forbidden_regs))))
+                ("cc"::"memory"::clobs)))
 
       let copy_name s = sprintf "_tmp_%s" s
 

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -86,6 +86,7 @@ module Make
       let sysarch = Cfg.sysarch
       let c11 = false
       let variant _ = false (* No variant (yet ?) *)
+      let ascall = true
     end
 
     module U = SkelUtil.Make(UCfg)(P)(A)(T)

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -94,8 +94,9 @@ module Make
 
     let do_label_init = Misc.consp CfgLoc.all_labels
 
-    let do_ascall = Cfg.ascall || Cfg.is_kvm || do_label_init ||
-                      Cfg.variant Variant_litmus.Self
+    let do_ascall =
+      Cfg.ascall || Cfg.is_kvm || do_label_init || CfgLoc.need_prelude
+      || Cfg.variant Variant_litmus.Self
 
     let do_precise = Precision.is_fatal Cfg.precision
 
@@ -160,6 +161,7 @@ module Make
         let sysarch = Cfg.sysarch
         let c11 = Cfg.c11
         let variant = Cfg.variant
+        let ascall = do_ascall
       end
 
       module U = SkelUtil.Make(UCfg)(P)(A)(T)
@@ -734,7 +736,8 @@ module Make
               if Cfg.hexa then "0x%" ^ fmt else "%" ^ fmt)
           locs env
 
-      let some_vars test = Misc.consp test.T.globals || some_labels test
+      let some_test_vars test = Misc.consp test.T.globals
+      let some_vars test = some_test_vars test || some_labels test
 
       let dump_outcomes env test =
         let rlocs = U.get_displayed_locs test
@@ -1811,7 +1814,7 @@ module Make
         O.oi "sense_t *_b = &_ctx->b;" ;
         O.oi "log_t *_log = &_ctx->out;" ;
         if some_ptr then O.oi "log_ptr_t *_log_ptr = &_ctx->out_ptr;" ;
-        if some_vars test then begin
+        if some_test_vars test then begin
           O.oi "vars_t *_vars = &_ctx->v;"
         end ;
         begin match test.T.globals with

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -105,11 +105,11 @@ module Make
 (* Options *)
       let do_self = Cfg.variant Variant_litmus.Self
       let do_label_init = not (Label.Full.Set.is_empty CfgLoc.label_init)
+
       let do_ascall =
         (* Self-modifing code or label constants in init section
            implies `-ascall true` mode *)
-        Cfg.ascall || do_self || do_label_init
-
+        Cfg.ascall || do_self || do_label_init || CfgLoc.need_prelude
       open Speedcheck
       let do_vp = Cfg.verbose_prelude
       let driver = Cfg.driver
@@ -278,6 +278,7 @@ module Make
         let sysarch = Cfg.sysarch
         let c11 = Cfg.c11
         let variant = Cfg.variant
+        let ascall = do_ascall
       end
 
       module U = SkelUtil.Make(UCfg)(P)(A)(T)

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -28,6 +28,7 @@ module type Config = sig
   val sysarch : Archs.System.t
   val c11 : bool
   val variant : Variant_litmus.t -> bool
+  val ascall : bool
 end
 
 let no_timebase_error sysarch =
@@ -550,15 +551,17 @@ module Make
 
       let get_instrs_final t = T.C.get_instrs t.T.condition
 
+      let nop_set =
+        match A.V.Instr.nop with
+        | None -> A.V.Instr.Set.empty
+        | Some nop -> A.V.Instr.Set.singleton nop
+
       let get_instrs_others t =
         A.V.Instr.Set.union3
           (get_instrs_init t) (get_instrs_final t)
           (if Cfg.variant Variant_litmus.Self then
             A.V.Instr.Set.of_list A.GetInstr.self_instrs
-          else
-            match A.V.Instr.nop with
-            | None -> A.V.Instr.Set.empty
-            | Some nop -> A.V.Instr.Set.singleton nop)
+          else nop_set)
 
       let all_instrs t =
         let from_code = T.from_labels t
@@ -621,6 +624,11 @@ module Make
             O.fi "ins_t %s;"pp
           end
 
+        let check_ascall () =
+          if not (Cfg.ascall) then
+            Warn.user_error
+              "Use option `-ascall true` for this test"
+
 (* Label constant initialisation *)
         let initialise_labels ptr label_init =
           let open OutUtils in
@@ -630,6 +638,7 @@ module Make
               label_init IntSet.empty in
           IntSet.iter
             (fun p ->
+              check_ascall () ;
               O.fi "size_t %s = prelude_size((ins_t *)code%i);"
                 (fmt_prelude p) p)
             procs ;
@@ -945,6 +954,7 @@ module Make
               match ps with
               | [] -> assert false
               | ((p,_),_)::_ ->
+                  check_ascall () ;
                   O.fi "size_t %s = prelude_size((ins_t *)code%i);"
                     (fmt_prelude p) p ;
                   List.iter


### PR DESCRIPTION
1. Remove stable registers from the  list of clobbers in inline asssembly. Otherwise gcc protests.
2. Silently switch the `ascall` setting to true when computing code prelude size at runtime is needed for any reason.

Example of a test that triggered the two errors, while compiled as `litmus7 -mach vougeot -o /tmp/A.tar  BLR.litmus`:
```
AArch64 BLR-BL
Stable=X30
{

}
  P0          ;
 MOV W0,#1    ;
 ADR X4,first ;
 BLR X4       ;
 BL first     ;
 B end        ;
first:        ;
 MOV X29,X30  ;
 BL snd       ;
 RET X29      ;
snd:          ;
 ADD W0,W0,W0 ;
 RET          ;
end:          ;

forall 0:X0=4 
```