### PR TITLE
[asldoc] New or fixed transliterations

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -580,7 +580,7 @@ module Make (B : Backend.S) (C : Config) = struct
     in
     choice (in_values v ty) true false
   (* End *)
- 
+
   (* Evaluation of Left-Hand-Side Expressions *)
   (* ---------------------------------------- *)
 
@@ -603,8 +603,8 @@ module Make (B : Backend.S) (C : Config) = struct
             return_normal env |: SemanticsRule.LEGlobalVar
         (* End *)
         | NotFound -> (
-          match ver with
-          (* Begin LEUndefIdentOne *)
+            match ver with
+            (* Begin LEUndefIdentOne *)
             | V1 ->
                 fatal_from le @@ Error.UndefinedIdentifier x
                 |: SemanticsRule.LEUndefIdentV1
@@ -685,31 +685,31 @@ module Make (B : Backend.S) (C : Config) = struct
     let eval_one env = function
       (* Begin SliceSingle *)
       | Slice_Single e ->
-          let** v, new_env = eval_expr env e in
-          return_normal ((v, one), new_env) |: SemanticsRule.SliceSingle
+          let** start, new_env = eval_expr env e in
+          return_normal ((start, one), new_env) |: SemanticsRule.SliceSingle
       (* End *)
       (* Begin SliceLength *)
-      | Slice_Length (ebot, elength) ->
-          let*^ vbot, env_b = eval_expr env ebot in
-          let*^ vlength, env_lb = eval_expr env_b elength in
-          let* vbot = vbot and* vlength = vlength in
-          return_normal ((vbot, vlength), env_lb) |: SemanticsRule.SliceLength 
+      | Slice_Length (e_start, e_length) ->
+          let*^ start, env1 = eval_expr env e_start in
+          let*^ length, new_env = eval_expr env1 e_length in
+          let* start = start and* length = length in
+          return_normal ((start, length), new_env) |: SemanticsRule.SliceLength
       (* End *)
       (* Begin SliceRange *)
-      | Slice_Range (etop, ebot) ->
-          let*^ vtop, env_t = eval_expr env etop in
-          let*^ vbot, env_tb = eval_expr env_t ebot in
-          let* vtop = vtop and* vbot = vbot in
-          let* length = B.binop MINUS vtop vbot >>= B.binop PLUS one in
-          return_normal ((vbot, length), env_tb) |: SemanticsRule.SliceRange  
+      | Slice_Range (e_top, e_start) ->
+          let*^ v_top, env1 = eval_expr env e_top in
+          let*^ start, new_env = eval_expr env1 e_start in
+          let* v_top = v_top and* start = start in
+          let* length = B.binop MINUS v_top start >>= B.binop PLUS one in
+          return_normal ((start, length), new_env) |: SemanticsRule.SliceRange
       (* End *)
       (* Begin SliceStar *)
-      | Slice_Star (efactor, elength) ->
-          let*^ vfactor, env_f = eval_expr env efactor in
-          let*^ vlength, env_lf = eval_expr env_f elength in
-          let* vfactor = vfactor and* vlength = vlength in
-          let* vbot = B.binop MUL vfactor vlength in
-          return_normal ((vbot, vlength), env_lf) |: SemanticsRule.SliceStar 
+      | Slice_Star (e_factor, e_length) ->
+          let*^ v_factor, env1 = eval_expr env e_factor in
+          let*^ length, new_env = eval_expr env1 e_length in
+          let* v_factor = v_factor and* length = length in
+          let* start = B.binop MUL v_factor length in
+          return_normal ((start, length), new_env) |: SemanticsRule.SliceStar
       (* End *)
     in
     fold_par_list eval_one env
@@ -801,7 +801,7 @@ module Make (B : Backend.S) (C : Config) = struct
           let**| env = envm in
           eval_local_decl s ldi' env (Some vm)
         in
-        List.fold_left2 folder (return_normal env) ldis liv 
+        List.fold_left2 folder (return_normal env) ldis liv
         |: SemanticsRule.LDTuple
     (* Begin LDTypedTuple *)
     | LDI_Tuple (_ldis, Some ty), None ->
@@ -935,7 +935,7 @@ module Make (B : Backend.S) (C : Config) = struct
         let* () = B.on_write_identifier name scope v in
         return (Throwing (Some ((v, name, scope), t), new_env))
         |: SemanticsRule.SThrowSomeTyped
-    (* Begin SThrowSome *)  
+    (* Begin SThrowSome *)
     | S_Throw (Some (_e, None)) ->
         fatal_from s Error.TypeInferenceNeeded |: SemanticsRule.SThrowSome
     (* End *)
@@ -1071,7 +1071,7 @@ module Make (B : Backend.S) (C : Config) = struct
         match List.find_opt (catcher_matches v_ty) catchers with
         (* If any catcher matches the exception type: *)
         | Some catcher -> (
-          (* Begin Catch *)
+            (* Begin Catch *)
             match catcher with
             | None, _e_ty, s ->
                 eval_block env1 s
@@ -1268,7 +1268,7 @@ module Make (B : Backend.S) (C : Config) = struct
         in
         List.init length (Fun.const v) |> B.create_vector
 
-(* Begin TopLevel *)
+  (* Begin TopLevel *)
   let run_typed_env env (ast : B.ast) (static_env : StaticEnv.env) : B.value m =
     let*| env = build_genv env eval_expr_sef base_value static_env ast in
     let*| res = eval_func env "main" dummy_annotated [] [] in

--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -759,14 +759,14 @@ module Make (B : Backend.S) (C : Config) = struct
     (* Begin PMask *)
     | Pattern_Mask m ->
         let bv bv = L_BitVector bv |> B.v_of_literal in
-        let m_set = Bitvector.mask_set m |> bv
-        and m_unset = Bitvector.mask_unset m |> bv
-        and m_specified = Bitvector.mask_specified m |> bv in
+        let m_set = Bitvector.mask_set m
+        and m_unset = Bitvector.mask_unset m in
+        let m_specified = Bitvector.logor m_set m_unset in
         let* nv = B.unop NOT v in
-        let* v_set = B.binop AND m_set v
-        and* v_unset = B.binop AND m_unset nv in
+        let* v_set = B.binop AND (bv m_set) v
+        and* v_unset = B.binop AND (bv m_unset) nv in
         let* v_set_or_unset = B.binop OR v_set v_unset in
-        B.binop EQ_OP v_set_or_unset m_specified |: SemanticsRule.PMask
+        B.binop EQ_OP v_set_or_unset (bv m_specified) |: SemanticsRule.PMask
     (* Begin PTuple *)
     | Pattern_Tuple ps ->
         let n = List.length ps in

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -40,17 +40,17 @@ An environment is what the semantics operates over: a structure
 which amongst other things associates values to variables.
 Intuitively, the evaluation of a program makes an initial
 environment evolve, with new values as given by the operations
-of the program. Environments map names to variables and subprograms. 
+of the program. Environments map names to variables and subprograms.
 
 \section{Variables}
 Variables have two different possible scopes: global to the whole program which
 come with an initial value and cannot be declared inside a subprogram, or local
 to a subprogram. Global variables are initialised at the start of the evaluation
-of the program.  
+of the program.
 
 \section{Functions}
 Functions are declared statically: they are declared before the start of the
-program and are not values, thus a subprogram call uses directly a function name. 
+program and are not values, thus a subprogram call uses directly a function name.
 
 Formally, an environment $E \in \mathcal{E}$ is a pair of a binding from global
 variable names to their value, and a binding from local variable names to their
@@ -127,7 +127,7 @@ of the statement (see Chapter~\ref{chap:eval_stmt});
 \item \texttt{eval\_catchers} evaluates catchers (see Chapter~\ref{chap:eval_catchers});
 \item \texttt{eval\_func} evaluates subprograms: it takes an
 environment, a subprogram name and its arguments, and returns a
-list of the return values of the subprogram (see Chapter~\ref{chap:eval_func}). 
+list of the return values of the subprogram (see Chapter~\ref{chap:eval_func}).
 \end{itemize}
 
 \chapter{Reading guide}
@@ -142,7 +142,7 @@ Section~\ref{sec:SemanticsRule.Binop} respectively.
 Each rule is presented using the following template:
 \begin{itemize}
 \item a Prose paragraph gives the rule in English, and corresponds as much as possible to the code of the reference implementation ASLRef given at \url{~/herdtools7/asllib};
-\item one or several Example, which as much as possible are also given as regression tests in \url{~/herdtools7/asllib/tests/ASLSemanticsReference.t} 
+\item one or several Example, which as much as possible are also given as regression tests in \url{~/herdtools7/asllib/tests/ASLSemanticsReference.t}
 \item a Code paragraph which gives a verbatim of the corresponding implementation in the interpreter of ASLRef \url{~/herdtools7/asllib/Interpreter.ml};
 \item a Formal paragraph for the sequential case, which gives a formal
 definition of the rule: the sequential case essentially gives the same
@@ -175,7 +175,7 @@ quantified. For example the two following definitions are equivalent:
 \chapter{Evaluation of Expressions \label{chap:eval_expr}}
 
 \texttt{eval\_expr} specifies how to evaluate an expression \texttt{e} in an
-environment \texttt{env}. 
+environment \texttt{env}.
 
 Evaluation of the expression \texttt{e} under an environment \texttt{env} is
 either a value \texttt{v} together with a potentially updated
@@ -227,7 +227,7 @@ environment \texttt{new\_env}, or an error, and one of the following applies:
 \begin{formal}
   \subsection{Formally: sequential case}
   The evaluation of a literal value \texttt{v} associates any environment
-\texttt{env} to itself coupled with \texttt{v}: 
+\texttt{env} to itself coupled with \texttt{v}:
 
 \begin{align}
   \interp{\texttt{v}}(\texttt{env}) & \triangleq \left\{ (\texttt{v}, \texttt{env}) \right\}
@@ -267,17 +267,17 @@ environment \texttt{new\_env}, or an error, and one of the following applies:
 \begin{formal}
   \subsection{Formally: sequential case}
   The evaluation of a variable \texttt{x} in an environment \texttt{env} that maps \texttt{x} to \texttt{v}
-  is the tuple $(\texttt{v},\texttt{env})$: 
+  is the tuple $(\texttt{v},\texttt{env})$:
   \begin{align}
   \interp{\texttt{x}}(\texttt{env}) & \triangleq \left\{ (\texttt{env}[\texttt{x}], \texttt{env})) \right\}
   \label{eq:sem-seq-var}
-  \end{align} 
- 
+  \end{align}
+
   \subsection{Formally: concurrent case}
   \begin{align}
   \interp{x}(\texttt{env}) & \triangleq \left\{ (\texttt{env}[\texttt{x}], \texttt{env}, \texttt{R(x)}) \right\}
   \label{eq:sem-conc-var}
-  \end{align} 
+  \end{align}
 \end{formal}
 
   \subsection{Comments}
@@ -305,7 +305,7 @@ environment \texttt{new\_env}, or an error, and one of the following applies:
 
 %  \subsection{Example: SemanticsRuleEGlobalVarError.asl}
 %    The program:
-%    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.EGlobalVarError.asl} 
+%    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.EGlobalVarError.asl}
 %    raises a type error because \texttt{x} is already declared locally in
 %    \texttt{stdlib.asl}.
 
@@ -317,13 +317,13 @@ environment \texttt{new\_env}, or an error, and one of the following applies:
   \begin{align}
   \interp{\texttt{x}}(\texttt{env}) & \triangleq \left\{ (\texttt{env}[\texttt{x}], \texttt{env})) \right\}
   \label{eq:sem-seq-var}
-  \end{align} 
- 
+  \end{align}
+
   \subsection{Formally: concurrent case}
   \begin{align}
   \interp{\texttt{x}}(\texttt{env}) & \triangleq \left\{ (\texttt{env}[\texttt{x}], \texttt{env}, \texttt{R(x)}) \right\}
   \label{eq:sem-conc-var}
-  \end{align} 
+  \end{align}
 \end{formal}
 
 \isempty{\subsection{Comments}}
@@ -340,14 +340,14 @@ environment \texttt{new\_env}, or an error, and one of the following applies:
 
   \subsection{Example: SemanticsRule.EUndefIdent.asl}
     The program:
-    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.EUndefIdent.asl} 
+    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.EUndefIdent.asl}
     raises an \texttt{Undefined Identifier} error: the variable \texttt{y} is
     undefined in the environment where $\mathtt{x}$ is bound to $\mathtt{42}$.
 
   \subsection{Code}
   \VerbatimInput[firstline=\EUndefIdentBegin, lastline=\EUndefIdentEnd]{../Interpreter.ml}
 
-\begin{emptyformal} 
+\begin{emptyformal}
   \subsection{Formally: sequential case}
 
   \subsection{Formally: concurrent case}
@@ -390,7 +390,7 @@ e1 then e2 else false} (see Section~\ref{sec:SemanticsRule.ECond}).
   \texttt{(res,new\_env)} and all of the following apply:
   \begin{itemize}
   \item \texttt{e} denotes a disjunction over two expressions \texttt{e1} and \texttt{e2};
-  \item \texttt{(res,new\_env)} is the result of the evaluation of \texttt{if 
+  \item \texttt{(res,new\_env)} is the result of the evaluation of \texttt{if
 e1 then true else e2} (see Section~\ref{sec:SemanticsRule.ECond}).
   \end{itemize}
 
@@ -471,7 +471,7 @@ Evaluation of the expression \texttt{e} under environment \texttt{env} is \textt
 
 \begin{formal}
   \subsection{Formally: sequential case}
-  
+
   \begin{align}
   \interp{\texttt{e1} + \texttt{e2}} (\texttt{env}) & \triangleq
     \left\{ (v, \texttt{new\_env}) \st{}
@@ -484,7 +484,7 @@ Evaluation of the expression \texttt{e} under environment \texttt{env} is \textt
     \end{aligned}
     \right\}
   \label{eq:sem-seq-plus}
-  \end{align} 
+  \end{align}
 
   \subsection{Formally: concurrent case}
   For the ordering constraints, the different arguments of a n-ary subprogram
@@ -501,7 +501,7 @@ are considered computed in parallel:
     \end{aligned}
     \right\}
   \label{eq:sem-conc-plus}
-  \end{align} 
+  \end{align}
 \end{formal}
 
 \subsection{Comments}
@@ -580,7 +580,7 @@ evaluate either \texttt{3} or \texttt{Return42()} depending on how
 
   \subsection{Example: SemanticsRule.ESlice.asl}
     In the program:
-    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.ESlice.asl}    
+    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.ESlice.asl}
     the expression \texttt{'11110000'[5:2]} evaluates to the value \texttt{'1100'}.
 
   \subsection{Code}
@@ -655,7 +655,7 @@ evaluate either \texttt{3} or \texttt{Return42()} depending on how
 
   \subsection{Example: SemanticsRule.EGetArrayTooSmall.asl}
     The program:
-    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.EGetArrayTooSmall.asl} 
+    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.EGetArrayTooSmall.asl}
     raises a typing error since we are trying to access index \texttt{3} of an array
     which has indexes \texttt{0}, \texttt{1} and \texttt{2} only.
 
@@ -686,7 +686,7 @@ evaluate either \texttt{3} or \texttt{Return42()} depending on how
 
   \subsection{Example: SemanticsRule.ERecord.asl}
     In the program:
-    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.ERecord.asl} 
+    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.ERecord.asl}
     the expression \texttt{MyRecordType { a=3, b=42 }} evaluates to the value \texttt{{a:
 3, b: 42}}.
 
@@ -832,10 +832,10 @@ evaluate either \texttt{3} or \texttt{Return42()} depending on how
 \begin{formal}
   \subsection{Formally: sequential case}
 
-  \begin{align}  
+  \begin{align}
   \interp{\syntt{unknown:}\ t} (E) & \triangleq \left\{ (v, E) \st{} v \in{} D(t) \right\}
-  \label{eq:sem-seq-unknown}  
-  \end{align}  
+  \label{eq:sem-seq-unknown}
+  \end{align}
 
   \subsection{Formally: concurrent case}
 
@@ -899,14 +899,14 @@ evaluate either \texttt{3} or \texttt{Return42()} depending on how
               \item \texttt{b} is \texttt{true};
               \item \texttt{res} is \texttt{v};
               \item \texttt{new\_env} is \texttt{new\_env}
-              \end{itemize} 
+              \end{itemize}
         \item All of the following apply:
               \begin{itemize}
               \item \texttt{b} is \texttt{false};
-              \item a type error is raised. 
-              \end{itemize} 
-        \end{itemize}   
-  \end{itemize} 
+              \item a type error is raised.
+              \end{itemize}
+        \end{itemize}
+  \end{itemize}
 
   \subsection{Example: SemanticsRule.CTCValue.asl}
   \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.CTCValue.asl}
@@ -920,7 +920,7 @@ evaluate either \texttt{3} or \texttt{Return42()} depending on how
 
 \begin{emptyformal}
   \subsection{Formally: sequential case}
-  
+
   \subsection{Formally: concurrent case}
 \end{emptyformal}
 
@@ -1208,12 +1208,12 @@ of the following apply:
 \isempty{\subsection{Comments}}
 
 \chapter{Evaluation of Slices \label{chap:eval_slices}}
-\texttt{eval\_slices env slices} is the list of pair \texttt{(i\_n, l\_n)} that
+\texttt{eval\_slices env slices} is the list of pair \texttt{(start\_n, length\_n)} that
 corresponds to the start (included) and the length of each slice in
 \texttt{slices}.
 
 Evaluation of the slice \texttt{s} under environment \texttt{env} is
-\texttt{(res,new\_env)}, or an error, and one of the following applies:
+\texttt{((start, length), new\_env)}, or an error, and one of the following applies:
 \begin{itemize}
 \item SemanticsRule.SliceSingle (see Section~\ref{sec:SemanticsRule.SliceSingle}),
 \item SemanticsRule.SliceLength (see Section~\ref{sec:SemanticsRule.SliceLength}),
@@ -1224,14 +1224,15 @@ Evaluation of the slice \texttt{s} under environment \texttt{env} is
 \section{SemanticsRule.SliceSingle \label{sec:SemanticsRule.SliceSingle}}
 
   \subsection{Prose}
-  The result of evaluation is \texttt{(res, new\_env)} and all
+  The result of evaluation is \texttt{((start, length), new\_env)} and all
 of the following apply:
   \begin{itemize}
-  \item \texttt{e} is an expression;
-  \item \texttt{v} is the result of evaluation of the expression~\texttt{e} in the environment \texttt{env};
-  \item \texttt{new\_env} is the environment \texttt{env} modified after evaluation of the expression~\texttt{e};
-  \item \texttt{res} is \texttt{(v, one)};
-  \item \texttt{new\_env} is \texttt{new\_env}.
+    \item \texttt{s} is the single expression \texttt{e};
+    \item \texttt{start} is the result of evaluation of the expression~\texttt{e}
+      in the environment \texttt{env};
+    \item \texttt{new\_env} is the environment \texttt{env} modified after
+      evaluation of the expression~\texttt{e};
+    \item \texttt{length} is the integer value 1.
   \end{itemize}
 
   \subsection{Example: SemanticsRule.SliceSingle.asl}
@@ -1254,15 +1255,18 @@ of the following apply:
 \section{SemanticsRule.SliceLength \label{sec:SemanticsRule.SliceLength}}
 
   \subsection{Prose}
-  The result of evaluation is \texttt{(res, new\_env)} and all of the following
+  The result of evaluation is \texttt{((start, length), new\_env)} and all of the following
 apply:
   \begin{itemize}
-  \item \texttt{ebot} and \texttt{elength} are two expressions;
-  \item \texttt{vbot} is the result of evaluation of the expression~\texttt{ebot} in the environment \texttt{env}; 
-  \item \texttt{env\_b} is the environment \texttt{env} modified after evaluation of the expression~\texttt{ebot}; 
-  \item \texttt{env\_lb} is the environment \texttt{env\_b} modified after evaluation of the expression~\texttt{elength};
-  \item \texttt{res} is \texttt{(vbot, length)};
-  \item \texttt{new\_env} is \texttt{env\_lb}.
+    \item \texttt{s} is the slice which starts at expression~\texttt{e\_start} with length~\texttt{e\_length};
+    \item \texttt{start} is the result of evaluation of the
+      expression~\texttt{e\_start} in the environment \texttt{env};
+    \item \texttt{env\_1} is the environment \texttt{env} modified after
+      evaluation of the expression~\texttt{e\_start};
+    \item \texttt{length} is the result of evaluation of the
+      expression~\texttt{e\_length} in the environment \texttt{env\_1};
+    \item \texttt{new\_env} is the environment \texttt{env\_1} modified after
+      evaluation of the expression~\texttt{e\_length}.
   \end{itemize}
 
   \subsection{Example: SemanticsRule.SliceLength.asl}
@@ -1284,16 +1288,19 @@ apply:
 \section{SemanticsRule.SliceRange \label{sec:SemanticsRule.SliceRange}}
 
   \subsection{Prose}
-  The result of evaluation is \texttt{(res, new\_env)} and all of the following apply:
+  The result of evaluation is \texttt{((start, length), new\_env)} and all of the following apply:
   \begin{itemize}
-  \item \texttt{etop} and \texttt{ebot} are two expressions;
-  \item \texttt{vtop} is the result of evaluation of the expression~\texttt{etop} in the environment \texttt{env}; 
-  \item \texttt{env\_t} is the environment \texttt{env} modified after evaluation of the expression~\texttt{etop}; 
-  \item \texttt{vbot} is the result of evaluation of the expression~\texttt{ebot} in the environment \texttt{env\_t}; 
-  \item \texttt{env\_bt} is the environment \texttt{env\_t} modified after evaluation of the expression~\texttt{ebot}; 
-  \item \texttt{length} is \texttt{(vtop - vbot) + 1};
-  \item \texttt{res} is \texttt{(vbot, length)};
-  \item \texttt{new\_env} is \texttt{env\_tb}.
+    \item \texttt{s} is the slice range between the
+      expressions~\texttt{e\_start} and~\texttt{e\_top};
+    \item \texttt{v\_top} is the result of evaluation of the
+      expression~\texttt{e\_top} in the environment \texttt{env};
+    \item \texttt{env\_1} is the environment \texttt{env} modified after
+      evaluation of the expression~\texttt{e\_top};
+    \item \texttt{start} is the result of evaluation of the
+      expression~\texttt{e\_start} in the environment \texttt{env\_1};
+    \item \texttt{new\_env} is the environment \texttt{env\_1} modified after
+      evaluation of the expression~\texttt{e\_start};
+    \item \texttt{length} is the integer value \texttt{(vtop - start) + 1};
   \end{itemize}
 
   \subsection{Example: SemanticsRule.SliceRange.asl}
@@ -1315,16 +1322,22 @@ apply:
 \section{SemanticsRule.SliceStar \label{sec:SemanticsRule.SliceStar}}
 
   \subsection{Prose}
-  The result of evaluation is \texttt{(res, new\_env)} and all of the following
+  The result of evaluation is \texttt{((start, length), new\_env)} and all of the following
 apply:
   \begin{itemize}
-  \item \texttt{efactor} and \texttt{elength} are two expressions;
-  \item \texttt{vfactor} is the result of evaluation of the expression~\texttt{efactor} in the environment \texttt{env}; 
-  \item \texttt{env\_f} is the environment \texttt{env} modified after evaluation of the expression~\texttt{efactor}; 
-  \item \texttt{env\_lf} is the environment \texttt{env\_f} modified after evaluation of the expression~\texttt{elength};
-  \item \texttt{vbot} is \texttt{vfactor} $\times$ \texttt{vlength};
-  \item \texttt{res} is \texttt{(vbot, length)};
-  \item \texttt{new\_env} is \texttt{env\_lf}.
+    \item \texttt{s} is the slice with factor given by the
+      expression~\texttt{e\_factor} and length given by the
+      expression~\texttt{e\_length};
+    \item \texttt{v\_factor} is the result of evaluation of the
+      expression~\texttt{e\_factor} in the environment \texttt{env};
+    \item \texttt{env\_1} is the environment \texttt{env} modified after
+      evaluation of the expression~\texttt{e\_factor};
+    \item \texttt{length} is the result of evaluation of the
+      expression~\texttt{e\_length} in the environment \texttt{env\_1};
+    \item \texttt{new\_env} is the environment \texttt{env\_1} modified after
+      evaluation of the expression~\texttt{e\_length};
+    \item \texttt{start} is the integer value
+      $\texttt{v\_factor} \times \texttt{length}$.
   \end{itemize}
 
 
@@ -1367,7 +1380,7 @@ following applies:
   \subsection{Prose}
   Evaluation of the pattern \texttt{p} under environment \texttt{env} with
   respect to value \texttt{v} is \texttt{b} and all of the following apply:
-  \begin{itemize}  
+  \begin{itemize}
   \item \texttt{p} is the pattern which matches everything;
   \item \texttt{b} is the boolean value \texttt{true}.
   \end{itemize}
@@ -1480,7 +1493,7 @@ following applies:
       \item \texttt{b'} is the result of the evaluation of the pattern \texttt{p'} under environment \texttt{env} with respect to the value \texttt{v};
       \item \texttt{b} is the boolean negation of \texttt{b'}.
     \end{itemize}
- 
+
     \subsection{Example: SemanticsRule.PNotTRUE.asl}
     \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.PNotTRUE.asl}
 
@@ -1824,26 +1837,26 @@ environment \texttt{env} is either a \texttt{Throwing}, an interruption
 \texttt{Returning vs} or a new environment \texttt{new\_env}. Formally, one of
 the following applies:
 \begin{itemize}
-\item SemanticsRule.SPass (see Section~\ref{sec:SemanticsRule.SPass}), 
-\item SemanticsRule.SAssign (see Section~\ref{sec:SemanticsRule.SAssign}), 
-\item SemanticsRule.SAssignCall (see Section~\ref{sec:SemanticsRule.SAssignCall}), 
-\item SemanticsRule.SAssignTuple (see Section~\ref{sec:SemanticsRule.SAssignTuple}), 
-\item SemanticsRule.SReturnNone (see Section~\ref{sec:SemanticsRule.SReturnNone}), 
-\item SemanticsRule.SReturnOne (see Section~\ref{sec:SemanticsRule.SReturnOne}), 
-\item SemanticsRule.SReturnSome (see Section~\ref{sec:SemanticsRule.SReturnSome}), 
-\item SemanticsRule.SSeq (see Section~\ref{sec:SemanticsRule.SSeq}), 
-\item SemanticsRule.SCall (see Section~\ref{sec:SemanticsRule.SCall}), 
-\item SemanticsRule.SCond (see Section~\ref{sec:SemanticsRule.SCond}), 
-\item SemanticsRule.SCase (see Section~\ref{sec:SemanticsRule.SCase}), 
-\item SemanticsRule.SAssert (see Section~\ref{sec:SemanticsRule.SAssert}), 
-\item SemanticsRule.SWhile (see Section~\ref{sec:SemanticsRule.SWhile}), 
-\item SemanticsRule.SRepeat (see Section~\ref{sec:SemanticsRule.SRepeat}), 
-\item SemanticsRule.SFor (see Section~\ref{sec:SemanticsRule.SFor}), 
-\item SemanticsRule.SThrowNone (see Section~\ref{sec:SemanticsRule.SThrowNone}), 
-\item SemanticsRule.SThrowSomeTyped (see Section~\ref{sec:SemanticsRule.SThrowSomeTyped}), 
-\item SemanticsRule.STry (see Section~\ref{sec:SemanticsRule.STry}), 
-\item SemanticsRule.SDeclSome (see Section~\ref{sec:SemanticsRule.SDeclSome}), 
-\item SemanticsRule.SDeclNone (see Section~\ref{sec:SemanticsRule.SDeclNone}). 
+\item SemanticsRule.SPass (see Section~\ref{sec:SemanticsRule.SPass}),
+\item SemanticsRule.SAssign (see Section~\ref{sec:SemanticsRule.SAssign}),
+\item SemanticsRule.SAssignCall (see Section~\ref{sec:SemanticsRule.SAssignCall}),
+\item SemanticsRule.SAssignTuple (see Section~\ref{sec:SemanticsRule.SAssignTuple}),
+\item SemanticsRule.SReturnNone (see Section~\ref{sec:SemanticsRule.SReturnNone}),
+\item SemanticsRule.SReturnOne (see Section~\ref{sec:SemanticsRule.SReturnOne}),
+\item SemanticsRule.SReturnSome (see Section~\ref{sec:SemanticsRule.SReturnSome}),
+\item SemanticsRule.SSeq (see Section~\ref{sec:SemanticsRule.SSeq}),
+\item SemanticsRule.SCall (see Section~\ref{sec:SemanticsRule.SCall}),
+\item SemanticsRule.SCond (see Section~\ref{sec:SemanticsRule.SCond}),
+\item SemanticsRule.SCase (see Section~\ref{sec:SemanticsRule.SCase}),
+\item SemanticsRule.SAssert (see Section~\ref{sec:SemanticsRule.SAssert}),
+\item SemanticsRule.SWhile (see Section~\ref{sec:SemanticsRule.SWhile}),
+\item SemanticsRule.SRepeat (see Section~\ref{sec:SemanticsRule.SRepeat}),
+\item SemanticsRule.SFor (see Section~\ref{sec:SemanticsRule.SFor}),
+\item SemanticsRule.SThrowNone (see Section~\ref{sec:SemanticsRule.SThrowNone}),
+\item SemanticsRule.SThrowSomeTyped (see Section~\ref{sec:SemanticsRule.SThrowSomeTyped}),
+\item SemanticsRule.STry (see Section~\ref{sec:SemanticsRule.STry}),
+\item SemanticsRule.SDeclSome (see Section~\ref{sec:SemanticsRule.SDeclSome}),
+\item SemanticsRule.SDeclNone (see Section~\ref{sec:SemanticsRule.SDeclNone}).
 \end{itemize}
 
 \section{SemanticsRule.SPass \label{sec:SemanticsRule.SPass}}
@@ -1869,13 +1882,13 @@ the following applies:
   \begin{align}
   \interp{\syntt{pass}} (\texttt{env}) & \triangleq \{ (\bot, \texttt{env}) \}
   \label{eq:sem-seq-spass}
-\end{align} 
+\end{align}
 
   \subsection{Formally: concurrent case}
   \begin{align}
   \interp{\syntt{pass}} (\texttt{env}) & \triangleq \{ (\bot, \texttt{env}, \varnothing) \}
   \label{eq:sem-conc-spass}
-  \end{align} 
+  \end{align}
 \end{formal}
 
 \isempty{\subsection{Comments}}
@@ -1927,7 +1940,7 @@ the following applies:
   Evaluation of the statement \texttt{s} under environment \texttt{env} is
 \texttt{new\_env} and all of the following apply:
   \begin{itemize}
-  \item \texttt{s} gives a left-hand-side tuple expression \texttt{les} and a subprogram call \texttt{(name, args, named\_args)}; 
+  \item \texttt{s} gives a left-hand-side tuple expression \texttt{les} and a subprogram call \texttt{(name, args, named\_args)};
   \item \texttt{vs} is the list of values resulting from the evaluation of the subprogram call;
   \item \texttt{env'} is the environment resulting from modifying \texttt{env} after the evaluation of the subprogram call;
   \item \texttt{new\_env} is the result of modifying \texttt{env'} after assigning each values in \texttt{vs} to the elements of the tuple \texttt{les}.
@@ -1954,7 +1967,7 @@ the following applies:
   Evaluation of the statement \texttt{s} under environment \texttt{env} is
 \texttt{new\_env} and all of the following apply:
   \begin{itemize}
-  \item \texttt{s} gives a left-hand-side tuple expression \texttt{les} and a tuple expression \texttt{exprs}; 
+  \item \texttt{s} gives a left-hand-side tuple expression \texttt{les} and a tuple expression \texttt{exprs};
   \item \texttt{vs} is the list of values resulting from the evaluation of \texttt{exprs};
   \item \texttt{env'} is the environment resulting from modifying \texttt{env} after the evaluation of \texttt{exprs};
   \item \texttt{new\_env} is the result of modifying \texttt{env'} after assigning each values in \texttt{vs} to the elements of the tuple \texttt{les}.
@@ -1988,7 +2001,7 @@ Evaluation of the statement \texttt{s} under environment \texttt{env} is
 
     \subsection{Example: SReturnNoneReturn.asl}
     The program:
-    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.SReturnNone.asl} 
+    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.SReturnNone.asl}
     exits the current procedure.
 
   \subsection{Code}
@@ -2056,13 +2069,13 @@ Evaluation of the statement \texttt{s} under environment \texttt{env} is
   \begin{align}
   \interp{\syntt{return}\ e} (E) & \triangleq \interp{e} (E)
   \label{eq:sem-seq-sreturn}
-  \end{align} 
+  \end{align}
 
   \subsection{Formally: concurrent case}
   \begin{align}
   \interp{\syntt{return}\ e} (E) & \triangleq \interp{e} (E)
   \label{eq:sem-conc-sreturn}
-  \end{align} 
+  \end{align}
 \end{formal}
 
 \isempty{\subsection{Comments}}
@@ -2194,7 +2207,7 @@ graphs produced by their interpretations:
       \syntt{else}\ s_2\ \syntt{end}
     \end{array}} (E) \triangleq
     % \interp{\ife{e}{s_1}{s_2}} (E) & \triangleq
-      \left\{ (v?, E'') \st{} \ 
+      \left\{ (v?, E'') \st{} \
       \begin{aligned}
         & (b, E') \in \interp{e} (E)
         \\ \text{and}\ &
@@ -2219,7 +2232,7 @@ graphs produced by their interpretations:
       \syntt{then}\ s_1\\
       \syntt{else}\ s_2\ \syntt{end}
     \end{array}} (E) \triangleq
-      \left\{ (v, E'', S'') \st{} \ 
+      \left\{ (v, E'', S'') \st{} \
       \begin{aligned}
         & (b, E', S) \in \interp{e} (E)
         \\ \text{and}\ &
@@ -2253,7 +2266,7 @@ graphs produced by their interpretations:
 
     \subsection{Example: SemanticsRule.SCase.asl}
     The program:
-    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.SCase.asl} 
+    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.SCase.asl}
     uses the second \texttt{when} clause because \texttt{3} is less than \texttt{42}.
 
   \subsection{Code}
@@ -2367,7 +2380,7 @@ graphs produced by their interpretations:
     \begin{itemize}
     \item \texttt{s} is a \texttt{for} statement;
     \item \texttt{s} gives \texttt{(id,e1,dir,e2,s)};
-    \item \texttt{new\_env} is \texttt{env} modified after evaluation of the \texttt{for} loop \texttt{(id,e1,dir,e2,s)} as per Section~\ref{sec:SemanticsRule.For}. 
+    \item \texttt{new\_env} is \texttt{env} modified after evaluation of the \texttt{for} loop \texttt{(id,e1,dir,e2,s)} as per Section~\ref{sec:SemanticsRule.For}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.SFor.asl}
@@ -2398,7 +2411,7 @@ graphs produced by their interpretations:
 
     \subsection{Example: SemanticsRule.SThrowNone.asl}
     The program:
-    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.SThrowNone.asl} 
+    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.SThrowNone.asl}
     throws a ``\texttt{MyException}'' exception.
 
   \subsection{Code}
@@ -2502,7 +2515,7 @@ graphs produced by their interpretations:
     \begin{itemize}
     \item \texttt{s} is a declaration \texttt{(ldi, None)};
     \item \texttt{new\_env} is \texttt{env} modified after evaluation of the local declaration
-      \texttt{ldi env None} as per Chapter~\ref{chap:eval_local_decl}. 
+      \texttt{ldi env None} as per Chapter~\ref{chap:eval_local_decl}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.SDeclNone.asl}
@@ -2522,7 +2535,7 @@ graphs produced by their interpretations:
 \isempty{\subsection{Comments}}
 
 \chapter{Evaluation of Blocks \label{chap:eval_block}}
- 
+
 \section{SemanticsRule.Block \label{sec:SemanticsRule.Block}}
 
     \subsection{Prose}
@@ -2533,7 +2546,7 @@ graphs produced by their interpretations:
 variable bindings of \texttt{env} with the updated values of
 \texttt{block\_env'}.
     \end{itemize}
- 
+
     \subsection{Example: SemanticsRule.Block.asl}
     In the program:
     \VerbatimInput{\testdir/SemanticsRule.Block.asl}
@@ -2580,7 +2593,7 @@ determined by \texttt{is\_while} and one of the following applies:
     \item All of the following apply:
       \begin{itemize}
       \item \texttt{cond\_m} evaluates to \texttt{false};
-      \item \texttt{new\_env} is \texttt{env}---the loop is exited. 
+      \item \texttt{new\_env} is \texttt{env}---the loop is exited.
       \end{itemize}
     \item All of the following apply:
       \begin{itemize}
@@ -2941,7 +2954,7 @@ One of the following applies:
     \end{aligned}
     \right\}
   \label{eq:sem-seq-fcall}
-  \end{align} 
+  \end{align}
 
   \subsection{Formally: concurrent case}
   For $i$ ranging implicitly from 1 to $n$ included, a call to a subprogram $f$
@@ -3000,7 +3013,7 @@ One of the following applies:
 
 \begin{emptyformal}
   \subsection{Formally: sequential case}
-  
+
   \subsection{Formally: concurrent case}
 \end{emptyformal}
 

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -1347,8 +1347,9 @@ apply:
 \chapter{Evaluation of Patterns \label{chap:eval_pattern}}
 \texttt{eval\_pattern env pos v p} determines if \texttt{v} matches the pattern \texttt{p}.
 
-Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-\texttt{(res,new\_env)}, or an error, and one of the following applies:
+Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+respect to value \texttt{v} is \texttt{b}, or an error, and one of the
+following applies:
 \begin{itemize}
 \item SemanticsRule.PAll (see Section~\ref{sec:SemanticsRule.PAll})
 \item SemanticsRule.PAny (see Section~\ref{sec:SemanticsRule.PAny})
@@ -1364,13 +1365,11 @@ Evaluation of the pattern \texttt{p} under environment \texttt{env} is
 \section{SemanticsRule.PAll \label{sec:SemanticsRule.PAll}}
 
   \subsection{Prose}
-  Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-  \texttt{(res,new\_env)} and all of the following apply:
+  Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+  respect to value \texttt{v} is \texttt{b} and all of the following apply:
   \begin{itemize}  
   \item \texttt{p} is the pattern which matches everything;
-  \item \texttt{res} is a value \texttt{v};
-  \item \texttt{v} is \texttt{true};
-  \item \texttt{new\_env} is \texttt{env}.
+  \item \texttt{b} is the boolean value \texttt{true}.
   \end{itemize}
 
   \subsection{Example: SemanticsRule.PAll.asl}
@@ -1390,15 +1389,12 @@ Evaluation of the pattern \texttt{p} under environment \texttt{env} is
 \section{SemanticsRule.PAny \label{sec:SemanticsRule.PAny}}
 
     \subsection{Prose}
-  Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-  \texttt{(res,new\_env)} and all of the following apply:
+  Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+  respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-    \item \texttt{p} is a list of patterns \texttt{li\_patterns};
-    \item \texttt{res} is a value \texttt{v};
-    \item \texttt{v} is a record of values \texttt{li\_values};
-    \item at least one value in \texttt{li\_values} matches the corresponding
-pattern in \texttt{li\_patterns} in \texttt{env};
-    \item \texttt{new\_env} is \texttt{env}.
+      \item \texttt{p} is a list of patterns \texttt{ps};
+      \item \texttt{bs} is the list resulting of the evaluation of the patterns in \texttt{ps} under environment \texttt{env} with respect to value \texttt{v};
+      \item \texttt{b} is the disjunction of the values in \texttt{bs}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PAnyTRUE.asl}
@@ -1421,13 +1417,12 @@ pattern in \texttt{li\_patterns} in \texttt{env};
 \section{SemanticsRule.PGeq \label{sec:SemanticsRule.PGeq}}
 
     \subsection{Prose}
-   Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-  \texttt{(res,new\_env)} and all of the following apply:
+    Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+    respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-    \item \texttt{p} is a side-effect-free expression \texttt{e};
-    \item \texttt{res} is a value \texttt{v};
-    \item \texttt{v} is greater than or equal to the evaluation of \texttt{e} in \texttt{env};
-    \item \texttt{new\_env} is \texttt{env}.
+      \item \texttt{p} is the condition being greater or equal than the side-effect-free expression \texttt{e};
+      \item \texttt{v'} is the side-effect-free evaluation of \texttt{e} in \texttt{env};
+      \item \texttt{b} is the boolean value of whether \texttt{v} is greater or equal to \texttt{v'}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PGeqTRUE.asl}
@@ -1450,13 +1445,12 @@ pattern in \texttt{li\_patterns} in \texttt{env};
 \section{SemanticsRule.PLeq \label{sec:SemanticsRule.PLeq}}
 
     \subsection{Prose}
-   Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-  \texttt{(res,new\_env)} and all of the following apply:
+    Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+    respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-    \item \texttt{p} is a side-effect-free expression \texttt{e};
-    \item \texttt{res} is a value \texttt{v};
-    \item \texttt{v} is less than or equal to the evaluation of \texttt{e} in \texttt{env};
-    \item \texttt{new\_env} is \texttt{env}.
+      \item \texttt{p} is the condition being less or equal than the side-effect-free expression \texttt{e};
+      \item \texttt{v'} is the side-effect-free evaluation of \texttt{e} in \texttt{env};
+      \item \texttt{b} is the boolean value of whether \texttt{v} is less or equal to \texttt{v'}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PLeqTRUE.asl}
@@ -1479,14 +1473,12 @@ pattern in \texttt{li\_patterns} in \texttt{env};
 \section{SemanticsRule.PNot \label{sec:SemanticsRule.PNot}}
 
     \subsection{Prose}
-   Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-  \texttt{(res,new\_env)} and all of the following apply:
+    Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+    respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-    \item \texttt{p} is a list of patterns \texttt{li\_patterns};
-    \item \texttt{res} is a value \texttt{v};
-    \item \texttt{v} is a record of values \texttt{li\_values};
-    \item each value in \texttt{li\_values} does not match the corresponding pattern in \texttt{li\_patterns} in \texttt{env};
-    \item \texttt{new\_env} is \texttt{env}.
+      \item \texttt{p} is the negation of the pattern \texttt{p'};
+      \item \texttt{b'} is the result of the evaluation of the pattern \texttt{p'} under environment \texttt{env} with respect to the value \texttt{v};
+      \item \texttt{b} is the boolean negation of \texttt{b'}.
     \end{itemize}
  
     \subsection{Example: SemanticsRule.PNotTRUE.asl}
@@ -1509,14 +1501,15 @@ pattern in \texttt{li\_patterns} in \texttt{env};
 \section{SemanticsRule.PRange \label{sec:SemanticsRule.PRange}}
 
     \subsection{Prose}
-   Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-  \texttt{(res,new\_env)} and all of the following apply:
+  Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+  respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-    \item \texttt{p} is two side-effect-free expressions \texttt{e1} and \texttt{e2};
-    \item \texttt{res} is a value \texttt{v};
-    \item \texttt{v} is greater than or equal to \texttt{e1} in \texttt{env};
-    \item \texttt{v} is lesser than or equal to \texttt{e2} in \texttt{env};
-    \item \texttt{new\_env} is \texttt{env}.
+      \item \texttt{p} is the condition of being between two side-effect-free expressions \texttt{e1} and \texttt{e2};
+      \item \texttt{v1} is the side-effect-free evaluation of \texttt{e1} in \texttt{env};
+      \item \texttt{v2} is the side-effect-free evaluation of \texttt{e2} in \texttt{env};
+      \item \texttt{b1} is the boolean value of whether \texttt{v} is greater or equal to \texttt{v1}.
+      \item \texttt{b2} is the boolean value of whether \texttt{v} is less or equal to \texttt{v2}.
+      \item \texttt{b} is the boolean conjunction of \texttt{b1} and \texttt{b2}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PRangeTRUE.asl}
@@ -1539,13 +1532,12 @@ pattern in \texttt{li\_patterns} in \texttt{env};
 \section{SemanticsRule.PSingle \label{sec:SemanticsRule.PSingle}}
 
     \subsection{Prose}
-   Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-  \texttt{(res,new\_env)} and all of the following apply:
+  Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+  respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-    \item \texttt{p} is a side-effect-free expression \texttt{e};
-    \item \texttt{res} is a value \texttt{v};
-    \item \texttt{v} is the result of the evaluation of \texttt{e} in \texttt{env};
-    \item \texttt{new\_env} is \texttt{env}.
+      \item \texttt{p} is the condition of being equal to the side-effect-free expression \texttt{e};
+      \item \texttt{v'} is the side-effect-free evaluation of \texttt{e} in environment \texttt{env}.
+      \item \texttt{b} is the boolean value of whether \texttt{v} is equal to \texttt{v'}
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PSingleTRUE.asl}
@@ -1568,13 +1560,25 @@ pattern in \texttt{li\_patterns} in \texttt{env};
 \section{SemanticsRule.PMask \label{sec:SemanticsRule.PMask}}
 
     \subsection{Prose}
-   Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-  \texttt{(res,new\_env)} and all of the following apply:
+    Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+    respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-    \item \texttt{p} is a mask \texttt{m};
-    \item \texttt{res} is a value \texttt{v};
-    \item \texttt{v} is a bitvector that matches the mask \texttt{m};
-    \item \texttt{new\_env} is \texttt{env}.
+      \item \texttt{p} is a mask \texttt{m};
+      \item \texttt{m\_set} is the bitvector value with bit set where \texttt{m}
+        requires bit set;
+      \item \texttt{m\_unset} is the bitvector value with bit set where
+        \texttt{m} requires bit unset;
+      \item \texttt{m\_specified} is the bitvector value with bit set where
+        \texttt{m} requires bit set or unset;
+      \item \texttt{nv} is the bitwise negation of \texttt{v};
+      \item \texttt{v\_set} is the bitwise conjunction of \texttt{m\_set} and
+        \texttt{v};
+      \item \texttt{v\_unset} is the bitwise conjunction of \texttt{m\_unset} and
+        \texttt{nv};
+      \item \texttt{v\_set\_or\_unset} is the bitwise disjunction of
+        \texttt{v\_set} and \texttt{v\_unset};
+      \item \texttt{b} is the boolean value of the bitwise equality of
+        \texttt{v\_set\_or\_unset} and \texttt{m\_specified}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PMaskTRUE.asl}
@@ -1597,13 +1601,16 @@ pattern in \texttt{li\_patterns} in \texttt{env};
 \section{SemanticsRule.PTuple \label{sec:SemanticsRule.PTuple}}
 
     \subsection{Prose}
-   Evaluation of the pattern \texttt{p} under environment \texttt{env} is
-  \texttt{(res,new\_env)} and all of the following apply: 
+    Evaluation of the pattern \texttt{p} under environment \texttt{env} with
+    respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-    \item \texttt{p} gives a list of patterns \texttt{li};
-    \item \texttt{res} is a value \texttt{v};
-    \item each element in \texttt{v} matches the corresponding pattern in the list \texttt{li} in \texttt{env};
-    \item \texttt{new\_env} is \texttt{env}.
+      \item \texttt{p} gives a list of patterns \texttt{ps} of length $n$;
+      \item \texttt{v} gives a tuple of values \texttt{vs} of length $n$;
+      \item for all $1 \leq i \leq n$, $\texttt{b}_i$ is the evaluation result
+        of $\texttt{p}_i$ with respect to the value $\texttt{v}_i$ in
+        environment \texttt{env};
+      \item \texttt{bs} is the list of all $\texttt{b}_i$ for $1 \leq i \leq n$;
+      \item \texttt{b} is the conjunction of the boolean values of \texttt{bs}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PTupleTRUE.asl}

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -1237,7 +1237,8 @@ of the following apply:
   \subsection{Example: SemanticsRule.SliceSingle.asl}
   In the program:
     \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.SliceSingle.asl}
-  \texttt{2} evaluates to \texttt{(2, 1)}.
+  the slice \texttt{[2]} evaluates to \texttt{(2, 1)}, i.\,e.\ the slice of
+  length 1 starting at index 2.
 
   \subsection{Code}
   \VerbatimInput[firstline=\SliceSingleBegin, lastline=\SliceSingleEnd]{../Interpreter.ml}
@@ -2170,7 +2171,7 @@ graphs produced by their interpretations:
     \subsection{Example: SemanticsRule.SCond.asl}
     The program:
     \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.SCond.asl}
-    prints ``\texttt{3}''.
+    does not raise any Assertion Error.
 
   \subsection{Code}
   \VerbatimInput[firstline=\SCondBegin, lastline=\SCondEnd]{../Interpreter.ml}
@@ -2446,7 +2447,7 @@ graphs produced by their interpretations:
     \subsection{Example: SemanticsRule.STry.asl}
     The program:
     \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.STry.asl}
-    prints ``\texttt{3}''.
+    does not raise any Assertion error, and the program terminates with the exit code 0.
 
   \subsection{Code}
   \VerbatimInput[firstline=\STryBegin, lastline=\STryEnd]{../Interpreter.ml}
@@ -2550,6 +2551,16 @@ is defined before the block and hence still exists after the block.
 
 \chapter{Evaluation of Loops \label{chap:eval_loops}}
 
+The evaluation of loop is a common part of the evaluation of multiple loop
+statements.
+%
+For example, the semantic rule \emph{Loop} is used by the semantic rule
+\emph{SWhile} at Section~\ref{sec:SemanticsRule.SWhile} and the semantic rule
+\emph{SRepeat} at Section~\ref{sec:SemanticsRule.SRepeat}.
+%
+The semantic rule \emph{For} is only used by the semantic rule \emph{SFor} at
+Section~\ref{sec:SemanticsRule.SFor}.
+
 \section{SemanticsRule.Loop \label{sec:SemanticsRule.Loop}}
 \texttt{eval\_loop is\_while env e\_cond body} evaluates \texttt{body} in
 \texttt{env}: this is either an interruption \texttt{Returning vs}, a
@@ -2578,7 +2589,8 @@ eventually leading to exiting the loop;
     \subsection{Example: SemanticsRule.Loop.asl}
     The program:
     \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.Loop.asl}
-    prints ``\texttt{0123}''.
+    does not raise any Assertion Error and the program terminates with exit
+    code 0.
 
     \subsection{Code}
     \VerbatimInput[firstline=\LoopBegin, lastline=\LoopEnd]{../Interpreter.ml}
@@ -2620,7 +2632,7 @@ applies:
     \subsection{Example: SemanticsRule.For.asl}
     The program:
     \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.For.asl}
-    prints ``\texttt{3}''.
+    does not raise any assertion error, and the program terminates with exit-code 0.
 
     \subsection{Code}
     \VerbatimInput[firstline=\ForBegin, lastline=\ForEnd]{../Interpreter.ml}

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -1381,8 +1381,9 @@ following applies:
   Evaluation of the pattern \texttt{p} under environment \texttt{env} with
   respect to value \texttt{v} is \texttt{b} and all of the following apply:
   \begin{itemize}
-  \item \texttt{p} is the pattern which matches everything;
-  \item \texttt{b} is the boolean value \texttt{true}.
+    \item \texttt{p} is the pattern which matches everything, and therefore
+      matches \texttt{v};
+    \item \texttt{b} is the boolean value \texttt{true}.
   \end{itemize}
 
   \subsection{Example: SemanticsRule.PAll.asl}
@@ -1433,9 +1434,12 @@ following applies:
     Evaluation of the pattern \texttt{p} under environment \texttt{env} with
     respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-      \item \texttt{p} is the condition being greater or equal than the side-effect-free expression \texttt{e};
-      \item \texttt{v'} is the side-effect-free evaluation of \texttt{e} in \texttt{env};
-      \item \texttt{b} is the boolean value of whether \texttt{v} is greater or equal to \texttt{v'}.
+      \item \texttt{p} is the condition corresponding to being greater or equal
+        than the side-effect-free expression \texttt{e};
+      \item \texttt{v'} is the side-effect-free evaluation of \texttt{e} in
+        \texttt{env};
+      \item \texttt{b} is the boolean value corresponding to whether \texttt{v}
+        is greater or equal to \texttt{v'}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PGeqTRUE.asl}
@@ -1461,9 +1465,12 @@ following applies:
     Evaluation of the pattern \texttt{p} under environment \texttt{env} with
     respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-      \item \texttt{p} is the condition being less or equal than the side-effect-free expression \texttt{e};
-      \item \texttt{v'} is the side-effect-free evaluation of \texttt{e} in \texttt{env};
-      \item \texttt{b} is the boolean value of whether \texttt{v} is less or equal to \texttt{v'}.
+      \item \texttt{p} is the condition corresponding to being less or equal
+        than the side-effect-free expression \texttt{e};
+      \item \texttt{v'} is the side-effect-free evaluation of \texttt{e} in
+        \texttt{env};
+      \item \texttt{b} is the boolean value corresponding to whether \texttt{v}
+        is less or equal to \texttt{v'}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PLeqTRUE.asl}
@@ -1490,7 +1497,9 @@ following applies:
     respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
       \item \texttt{p} is the negation of the pattern \texttt{p'};
-      \item \texttt{b'} is the result of the evaluation of the pattern \texttt{p'} under environment \texttt{env} with respect to the value \texttt{v};
+      \item \texttt{b'} is the result of the evaluation of the pattern
+        \texttt{p'} under environment \texttt{env} with respect to the value
+        \texttt{v};
       \item \texttt{b} is the boolean negation of \texttt{b'}.
     \end{itemize}
 
@@ -1517,12 +1526,19 @@ following applies:
   Evaluation of the pattern \texttt{p} under environment \texttt{env} with
   respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-      \item \texttt{p} is the condition of being between two side-effect-free expressions \texttt{e1} and \texttt{e2};
-      \item \texttt{v1} is the side-effect-free evaluation of \texttt{e1} in \texttt{env};
-      \item \texttt{v2} is the side-effect-free evaluation of \texttt{e2} in \texttt{env};
-      \item \texttt{b1} is the boolean value of whether \texttt{v} is greater or equal to \texttt{v1}.
-      \item \texttt{b2} is the boolean value of whether \texttt{v} is less or equal to \texttt{v2}.
-      \item \texttt{b} is the boolean conjunction of \texttt{b1} and \texttt{b2}.
+      \item \texttt{p} is the condition corresponding to being greater or equal
+        to \texttt{e1}, and lesser or equal to \texttt{e2};
+      \item \texttt{e1} and \texttt{e2} are side-effect-free expressions;
+      \item \texttt{v1} is the side-effect-free evaluation of \texttt{e1} in
+        \texttt{env};
+      \item \texttt{v2} is the side-effect-free evaluation of \texttt{e2} in
+        \texttt{env};
+      \item \texttt{b1} is the boolean value corresponding to whether
+        \texttt{v} is greater or equal to \texttt{v1}.
+      \item \texttt{b2} is the boolean value corresponding to whether
+        \texttt{v} is less or equal to \texttt{v2}.
+      \item \texttt{b} is the boolean conjunction of \texttt{b1} and
+        \texttt{b2}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PRangeTRUE.asl}
@@ -1548,9 +1564,12 @@ following applies:
   Evaluation of the pattern \texttt{p} under environment \texttt{env} with
   respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-      \item \texttt{p} is the condition of being equal to the side-effect-free expression \texttt{e};
-      \item \texttt{v'} is the side-effect-free evaluation of \texttt{e} in environment \texttt{env}.
-      \item \texttt{b} is the boolean value of whether \texttt{v} is equal to \texttt{v'}
+      \item \texttt{p} is the condition corresponding to being equal to the
+        side-effect-free expression \texttt{e};
+      \item \texttt{v'} is the side-effect-free evaluation of \texttt{e} in
+        environment \texttt{env};
+      \item \texttt{b} is the boolean value corresponding to whether \texttt{v}
+        is equal to \texttt{v'}.
     \end{itemize}
 
     \subsection{Example: SemanticsRule.PSingleTRUE.asl}
@@ -1576,13 +1595,15 @@ following applies:
     Evaluation of the pattern \texttt{p} under environment \texttt{env} with
     respect to value \texttt{v} is \texttt{b} and all of the following apply:
     \begin{itemize}
-      \item \texttt{p} is a mask \texttt{m};
-      \item \texttt{m\_set} is the bitvector value with bit set where \texttt{m}
-        requires bit set;
-      \item \texttt{m\_unset} is the bitvector value with bit set where
-        \texttt{m} requires bit unset;
-      \item \texttt{m\_specified} is the bitvector value with bit set where
-        \texttt{m} requires bit set or unset;
+      \item \texttt{p} is a mask \texttt{m} of length $n$ (with spaces removed);
+      \item \texttt{m\_set} is the bitvector value of length $n$ with bit set
+        at index $i$ if the mask requires a bit set at index $i$, i.\,e.\
+        $\texttt{m}[i] = '1'$;
+      \item \texttt{m\_unset} is the bitvector value of length $n$ with bit set
+        at index $i$ if the mask requires a bit unset at index $i$, i.\,e.\
+        $\texttt{m}[i] = '0'$;
+      \item \texttt{m\_specified} is the bitwise disjunction of \texttt{m\_set}
+        and \texttt{m\_unset};
       \item \texttt{nv} is the bitwise negation of \texttt{v};
       \item \texttt{v\_set} is the bitwise conjunction of \texttt{m\_set} and
         \texttt{v};

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -556,7 +556,24 @@ may hold.
 \section{TypingRule.Subtype}
 
   \subsection{Prose}
-    The subtype relation is a partial order.
+  A type \texttt{t1} subtypes a type \texttt{t2} in the environment
+  \texttt{env} if and only if one of the following applies:
+  \begin{itemize}
+    \item All of the following apply:
+      \begin{itemize}
+        \item \texttt{t1} is a named type;
+        \item \texttt{t2} is a named type;
+        \item \texttt{t1} and \texttt{t2} are the same type.
+      \end{itemize}
+    \item All of the following apply:
+      \begin{itemize}
+        \item \texttt{t1} is a named type;
+        \item \texttt{t2} is a named type;
+        \item \texttt{t1} is declared as a subtype of \texttt{t1'} in \texttt{env};
+        \item \texttt{t1'} is a subtype of \texttt{t2} in \texttt{env}.
+      \end{itemize}
+  \end{itemize}
+  The subtype relation is a partial order.
 
   \subsection{Example}
 
@@ -3899,9 +3916,8 @@ following apply:
   Annotating the call to subprogram \texttt{name} with call type \texttt{call\_type} (\texttt{annotate\_call}) results in an error and
   one of the following apply:
   \begin{itemize}
-    \item All of the following apply:
-      \begin{itemize}
-        \item \texttt{call\_type} is a function or a getter;
+    \item All of the following apply: \begin{itemize} \item \texttt{call\_type}
+          is a function or a getter;
         \item \texttt{name} is bound in \texttt{env} a subprogram without a return-type;
         \item A ``Mismatched return value'' error is raised.
       \end{itemize}

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -33,7 +33,7 @@ github repository.
 \chapter{Preamble}
 
 \section{Abstract Syntax}
-An \emph{abstract syntax tree} (AST, for short) represents an ASL program as a labelled tree. 
+An \emph{abstract syntax tree} (AST, for short) represents an ASL program as a labelled tree.
 The ASL Abstract Syntax is given in~\cite{ASLAbstractSyntaxReference}.
 
 \section{Environments}
@@ -67,7 +67,7 @@ inspect the label of node and the type annotations on the children of the node
 
 Not all conditions are type judgements. Some conditions are expressed in terms
 of the auxiliary attributes mentioned above. We define these in the next
-chapter. 
+chapter.
 
 A \emph{typing system} is a set of typing rules. More than one rule can be
 associated with a given node label, but they are exclusive---at most one rule
@@ -106,7 +106,7 @@ This aims to encompass LRM 7.4.2. R\_VDPC.
 \chapter{Reading guide}
 
 The definition of each \texttt{annotation\_<label>} function is given by a number of
-rules, which follow the possible shapes the \texttt{label} can have. For 
+rules, which follow the possible shapes the \texttt{label} can have. For
 example, an expression can be a literal, or a binary operator, amongst other
 things. Each of those has its own evaluation rule: TypingRule.Lit in
 Section~\ref{sec:TypingRule.Lit}, Typing.Binop in
@@ -222,7 +222,7 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
     \item \texttt{t} is singular;
     \item \texttt{t} is aggregate.
     \end{itemize}
-    
+
     \subsection{Example}
 
     \subsection{Code}
@@ -239,8 +239,8 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
 \end{formal}
 
 \isempty{\subsection{Comments}}
-	   
-\section{TypingRule.NamedType \label{sec:TypingRule.NamedType} } 
+
+\section{TypingRule.NamedType \label{sec:TypingRule.NamedType} }
 
     \subsection{Prose}
     A named type is a type which is declared using the \texttt{type} syntax.
@@ -264,8 +264,8 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
 
 \section{TypingRule.AnonymousType \label{sec:TypingRule.AnonymousType}}
 
-    \subsection{Prose} 
-    An anonymous type is a type which is not declared using the type syntax. 
+    \subsection{Prose}
+    An anonymous type is a type which is not declared using the type syntax.
 
     \subsection{Example}
 
@@ -295,7 +295,7 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
       \item \texttt{t} is a named type;
       \item \texttt{t\_struct} is the structure of \texttt{t};
       \item \texttt{t\_struct} is a builtin singular.
-      \end{itemize} 
+      \end{itemize}
     \end{itemize}
 
     \subsection{Example}
@@ -310,7 +310,7 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
 	      t \in \ty \rulespace \texttt{is\_builtin}(t) \vdash& \texttt{is\_singular}(t)\\
 	      t \in \ty \rulespace \texttt{is\_named}(t) \rulespace \texttt{is\_builtin\_aggregate}(\texttt{t\_struct}(t)) \vdash& \texttt{is\_singular}(t)\\
 	      \end{array}
-	    \]      
+	    \]
 
 %    TODO: define $\texttt{t\_struct}(t)$.  see TypingRule.Structure?
 \end{formal}
@@ -328,7 +328,7 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
       \begin{itemize}
       \item \texttt{t} is a named type;
       \item \texttt{t\_struct} is the structure of \texttt{t};
-      \item \texttt{t\_struct} is a builtin aggregate. 
+      \item \texttt{t\_struct} is a builtin aggregate.
       \end{itemize}
     \end{itemize}
 
@@ -352,7 +352,7 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
 
 \section{TypingRule.NonPrimitiveType}
 
-    \subsection{Prose} 
+    \subsection{Prose}
     A type \texttt{t} is non-primitive if one of the following applies:
     \begin{itemize}
     \item \texttt{t} is a named type;
@@ -364,7 +364,7 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
     \item All of the following apply:
       \begin{itemize}
       \item \texttt{t} is an array of type \texttt{ty}
-      \item \texttt{ty} is non-primitive; 
+      \item \texttt{ty} is non-primitive;
       \end{itemize}
     \item All of the following apply:
       \begin{itemize}
@@ -393,7 +393,7 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
 
 \section{TypingRule.PrimitiveType}
 
-    \subsection{Prose} 
+    \subsection{Prose}
     A type \texttt{t} is primitive if it is not non-primitive.
 
     \subsection{Example}
@@ -422,7 +422,7 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
         \begin{itemize}
         \item All of the following apply:
           \begin{itemize}
-          \item \texttt{x} is not declared in the global environment; 
+          \item \texttt{x} is not declared in the global environment;
           \item an error ``\texttt{Undefined Identifier}'' is raised;
           \end{itemize}
         \item All of the following apply:
@@ -439,26 +439,34 @@ omitted in type declarations, as it is the case for \texttt{Not\_found}.
       \end{itemize}
     \item All of the following apply:
       \begin{itemize}
-      \item \texttt{ty} is a tuple with \texttt{subtypes};
-      \item \texttt{t\_struct} is a tuple with the structure of each element in \texttt{subtypes};
+      \item \texttt{ty} is a tuple type with \texttt{tys};
+      \item \texttt{t\_struct} is a tuple type with the structure of each element in \texttt{tys};
       \end{itemize}
     \item All of the following apply:
       \begin{itemize}
-      \item \texttt{ty} is an array with \texttt{t};
-      \item \texttt{t\_struct} is an array with the structure of \texttt{t};
+        \item \texttt{ty} is an array type of length \texttt{e} with element type
+          \texttt{t};
+        \item \texttt{t\_struct} is an array type with of length \texttt{e}
+          with element type the structure of \texttt{t};
       \end{itemize}
     \item All of the following apply:
       \begin{itemize}
-      \item \texttt{ty} is a record with \texttt{fields};
-      \item \texttt{t\_struct} is a record with ;
+        \item \texttt{ty} is a record type with fields \texttt{fields};
+        \item \texttt{fields} associates a name $x$ to a type $t_x$;
+        \item \texttt{fields'} associates to each name $x$ of \texttt{fields}
+          to the structure of $t_x$;
+        \item \texttt{t\_struct} is a record type with fields \texttt{fields'}.
       \end{itemize}
     \item All of the following apply:
       \begin{itemize}
-      \item \texttt{ty} is an exception with \texttt{fields};
-      \item \texttt{t\_struct} is a record with ;
+        \item \texttt{ty} is an exception type with fields \texttt{fields};
+        \item \texttt{fields} associates a name $x$ to a type $t_x$;
+        \item \texttt{fields'} associates to each name $x$ of \texttt{fields}
+          to the structure of $t_x$;
+        \item \texttt{t\_struct} is an exception type with fields \texttt{fields'}.
       \end{itemize}
     \end{itemize}
-      
+
     \subsection{Example}
     In this example:
     \texttt{type T1 of integer;} is the named type \texttt{T1}
@@ -491,7 +499,7 @@ whose structure is \texttt{integer}.
 \end{emptyformal}
     \subsection{Comments}
     The structure of a type is the primitive type it is equivalent to such that
-    it can hold the same values. 
+    it can hold the same values.
 
     This aims to encompass LRM Section 7.1.2 D\_FXQV.
 
@@ -499,7 +507,7 @@ whose structure is \texttt{integer}.
 
   \subsection{Prose}
   The domain of a type is the set of values which storage elements of that type
-may hold. 
+may hold.
 
   \subsection{Example}
   The domain of \texttt{integer} is the infinite set of all integers.
@@ -524,14 +532,14 @@ may hold.
 
 \subsection{Prose}
   \begin{itemize}
-  \item A constrained type is a type whose definition depends on an expression, e.g. certain integers and bitvectors. 
+  \item A constrained type is a type whose definition depends on an expression, e.g. certain integers and bitvectors.
   \item A type which is not constrained is unconstrained.
   \item A constrained type with a non-empty constraint is well-constrained.
   \item An under-constrained integer type is an implicit type of a subprogram parameter.
   \end{itemize}
 
   \subsection{Example}
-    Bitvector storage element’s widths are constrained integers.  
+    Bitvector storage element’s widths are constrained integers.
 
   \subsection{Code}
     \VerbatimInput[firstline=\ConstrainedBegin, lastline=\ConstrainedEnd]{../AST.mli}
@@ -545,7 +553,7 @@ may hold.
 
 \chapter{Type Satisfaction and Related Notions}
 
-\section{TypingRule.Subtype} 
+\section{TypingRule.Subtype}
 
   \subsection{Prose}
     The subtype relation is a partial order.
@@ -554,7 +562,7 @@ may hold.
 
   \subsection{Code}
     \VerbatimInput[firstline=\SubtypeBegin, lastline=\SubtypeEnd]{../types.ml}
-  
+
 \begin{emptyformal}
     \subsection{Formally}
 \end{emptyformal}
@@ -562,7 +570,7 @@ may hold.
 \newcommand\super[0]{\textit{super}}
 	  \newcommand\subtype[0]{\sqsubseteq}
 
-	  To model subtyping, we define the function 
+	  To model subtyping, we define the function
 	  \[
 	  \super : \identifier \rightarrow \identifier \cup {\bot} \enspace,
 	  \]
@@ -571,23 +579,23 @@ may hold.
 	  We define the subtyping relation between two named types in a given environment as follows:
 	  \[
 	  \begin{array}{rl}
-	  a, b \in \identifier & (G,L) \vdash \texttt{T\_Named(a)} \subtype \texttt{T\_Named(a)} \\  
-	  a, b \in \identifier \rulespace G.\super(a) = b  & 
+	  a, b \in \identifier & (G,L) \vdash \texttt{T\_Named(a)} \subtype \texttt{T\_Named(a)} \\
+	  a, b \in \identifier \rulespace G.\super(a) = b  &
 	  (G,L) \vdash \texttt{T\_Named(a)} \subtype \texttt{T\_Named(b)}
 	  \end{array}
 	  \]
-	  
+
   \subsection{Comments}
-  Since the subtype relation is a partial order, it is reflexive, viz, 
+  Since the subtype relation is a partial order, it is reflexive, viz,
   every type is also a subtype of itself.
 
   Since the subtype relation is a partial order, it is transitive, viz, if A is
   a subtype of B and B is a subtype of C then A is a subtype of C.
- 
+
   As a consequence, there is no need to declare the reflexive and transitive
   subtype relations explicitly. All other subtype relations must be explicitly
   declared.
- 
+
   Since the subtype relation is a partial order, it is antisymmetric. Therefore
   it is an error if all of the following apply:
   \begin{itemize}
@@ -632,7 +640,7 @@ may hold.
     \begin{itemize}
     \item \texttt{S} has the structure of a real type;
     \item \texttt{T} has the structure of a real type.
-    \end{itemize} 
+    \end{itemize}
 
   \item All of the following apply:
     \begin{itemize}
@@ -648,7 +656,7 @@ may hold.
 
   \item All of the following apply:
     \begin{itemize}
-    \item \texttt{S} has the structure of an enumeration type; 
+    \item \texttt{S} has the structure of an enumeration type;
     \item \texttt{T} has the structure of an enumeration type;
     \item \texttt{S} and \texttt{T} have the same enumeration literals.
     \end{itemize}
@@ -666,7 +674,7 @@ may hold.
   \item All of the following apply:
     \begin{itemize}
     \item \texttt{S} has the structure of a bitvector type with undetermined width;
-    \item \texttt{T} has the structure of a bitvector type. 
+    \item \texttt{T} has the structure of a bitvector type.
     \end{itemize}
 
   \item All of the following apply:
@@ -695,7 +703,7 @@ may hold.
     \item \texttt{T} has the same number of elements as \texttt{S};
     \item for each element \texttt{e} in \texttt{S} there is an element \texttt{e'} in \texttt{T} and \texttt{e'}
       type-satisfies \texttt{e}.
-    \end{itemize}  
+    \end{itemize}
 
   \item All of the following apply:
     \begin{itemize}
@@ -765,7 +773,7 @@ may hold.
     \begin{itemize}
     \item \texttt{T} structural-subtype-satisfies \texttt{S};
     \item \texttt{T} domain-subtype-satisfies \texttt{S}.
-    \end{itemize} 
+    \end{itemize}
 
   \subsection{Example}
 
@@ -782,7 +790,7 @@ may hold.
 \section{TypingRule.TypeSatisfaction \label{sec:TypingRule.TypeSatisfaction}}
 
 \subsection{Prose}
- 
+
 \texttt{T} type-satisfies \texttt{S} if one of the following applies:
  \begin{itemize}
  \item \texttt{T} is a subtype of \texttt{S};
@@ -814,7 +822,7 @@ may hold.
     \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.TypeSatisfaction2.asl}
     \texttt{pair = (1, dataAsInt);} is legal since the right-hand-side has anonymous,
     primitive type \texttt{(integer, integer)}.
- 
+
 \subsection{Example: TypingRule.TypeSatisfaction3.asl}
     In the program:
     \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.TypeSatisfaction3.asl}
@@ -833,7 +841,7 @@ may hold.
   Since the subtype relation is a partial order, it is reflexive. Therefore
   every type \texttt{T} is a subtype of itself, and as a consequence, every type \texttt{T}
   type-satisfies itself.
-  
+
   This aims to encompass LRM Section 7.3.2 R\_FMXK and I\_NLFD.
 
 \section{TypingRule.CanAssignTo \label{sec:TypingRule.CanAssignTo}}
@@ -843,8 +851,8 @@ may hold.
   \begin{itemize}
   \item neither \texttt{S} nor \texttt{T} has the structure of the under-constrained integer type;
   \item \texttt{T} type-satisfies \texttt{S}.
-  \end{itemize} 
- 
+  \end{itemize}
+
   \subsection{Example}
 
   \subsection{Code}
@@ -959,7 +967,7 @@ may hold.
         \item \texttt{S} is an anonymous type;
         \item \texttt{T} is an anonymous type;
 	\item \texttt{ty} is the tuple type where the type of each element is the lowest common
-	  ancestor of the types of the corresponding elements of \texttt{S} and \texttt{T}. 
+	  ancestor of the types of the corresponding elements of \texttt{S} and \texttt{T}.
         \end{itemize}
     \end{itemize}
 
@@ -987,7 +995,7 @@ may hold.
         \item \texttt{S} is an anonymous type;
         \item \texttt{T} is an anonymous type;
 	\item \texttt{ty} is the well-constrained integer type whose domain is the union of the
-	  domains of \texttt{S} and \texttt{T}.      
+	  domains of \texttt{S} and \texttt{T}.
         \end{itemize}
       \end{itemize}
     \end{itemize}
@@ -1017,14 +1025,14 @@ may hold.
         \begin{itemize}
         \item \texttt{S} is an anonymous type;
         \item \texttt{T} is an anonymous type;
-	\item \texttt{ty} is the unconstrained integer type. 
+	\item \texttt{ty} is the unconstrained integer type.
         \end{itemize}
     \end{itemize}
 
   \item All of the following apply:
     \begin{itemize}
     \item Either \texttt{S} or \texttt{T} have the structure of an under-constrained integer type;
-    \item \texttt{ty} is the under-constrained integer type. 
+    \item \texttt{ty} is the under-constrained integer type.
     \end{itemize}
 
   \item \texttt{ty} is undefined.
@@ -1063,7 +1071,7 @@ may hold.
     \item \texttt{op} is \texttt{NEG};
     \item One of the following applies:
       \begin{itemize}
-      \item \texttt{t1} type-satisfies \texttt{integer}; 
+      \item \texttt{t1} type-satisfies \texttt{integer};
       \item \texttt{t1} type-satisfies \texttt{real};
       \end{itemize}
      \item One of the following applies:
@@ -1079,7 +1087,7 @@ may hold.
          \item \texttt{t} is a constrained integer whose constraint is ;
          \end{itemize}
        \end{itemize}
-    \end{itemize}  
+    \end{itemize}
 
   \item All of the following apply:
     \begin{itemize}
@@ -1111,7 +1119,7 @@ may hold.
 \begin{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \texttt{op} is \texttt{AND}, \texttt{OR}, \texttt{EQ} or \texttt{IMPL}; 
+    \item \texttt{op} is \texttt{AND}, \texttt{OR}, \texttt{EQ} or \texttt{IMPL};
     \item \texttt{t1} type-satisfies \texttt{boolean};
     \item \texttt{t2} type-satisfies \texttt{boolean};
     \item \texttt{t} is \texttt{boolean}.
@@ -1145,7 +1153,7 @@ may hold.
       \item All of the following apply:
         \begin{itemize}
         \item \texttt{t1} type-satisfies \texttt{integer};
-        \item \texttt{t2} type-satisfies \texttt{integer}; 
+        \item \texttt{t2} type-satisfies \texttt{integer};
         \end{itemize}
       \item All of the following apply:
         \begin{itemize}
@@ -1160,14 +1168,14 @@ may hold.
         \end{itemize}
       \item All of the following apply:
         \begin{itemize}
-        \item \texttt{t1} enumerates local declarations \texttt{li1}; 
+        \item \texttt{t1} enumerates local declarations \texttt{li1};
         \item \texttt{t2} enumerates local declarations \texttt{li2};
         \item \texttt{li1} equals \texttt{li2};
         \end{itemize}
       \end{itemize}
     \item \texttt{t} is \texttt{boolean}.
     \end{itemize}
-   
+
   \item All of the following apply:
     \begin{itemize}
     \item \texttt{op} is \texttt{LEQ}, \texttt{GEQ}, \texttt{GT} or \texttt{LT};
@@ -1207,7 +1215,7 @@ may hold.
         \item \texttt{t} is an unconstrained integer;
         \end{itemize}
       \item One of the following applies:
-       \begin{itemize} 
+       \begin{itemize}
        \item All of the following apply:
           \begin{itemize}
           \item \texttt{t1} has the structure of an under-constrained integer;
@@ -1253,7 +1261,7 @@ may hold.
        \item \texttt{t} is \texttt{real};
        \end{itemize}
      \end{itemize}
-   \end{itemize} 
+   \end{itemize}
 
   \item All of the following apply:
     \begin{itemize}
@@ -1263,7 +1271,7 @@ may hold.
     \end{itemize}
 \end{itemize}
 
-  \subsection{Example} 
+  \subsection{Example}
 
   \subsection{Code}
     \VerbatimInput[firstline=\CheckUnopBegin, lastline=\CheckUnopEnd]{../Typing.ml}
@@ -1332,8 +1340,8 @@ an environment \texttt{env}.  Formally, the result of annotating the expression
   \subsection{Example}
 
   \subsection{Code}
-  \VerbatimInput[firstline=\LitBegin, lastline=\LitEnd]{../Typing.ml}  
- 
+  \VerbatimInput[firstline=\LitBegin, lastline=\LitEnd]{../Typing.ml}
+
 \begin{emptyformal}
   \subsection{Formally}
 \end{emptyformal}
@@ -1344,7 +1352,7 @@ an environment \texttt{env}.  Formally, the result of annotating the expression
 
   \subsection{Prose}
   The result of annotating the expression \texttt{e} in \texttt{env} is
-\texttt{t,new\_env} and all of the following apply:  
+\texttt{t,new\_env} and all of the following apply:
   \begin{itemize}
   \item \texttt{e} denotes a variable \texttt{x};
   \item \texttt{x} is bound to a local constant~\texttt{v} of type \texttt{ty} in the local environment given by \texttt{env};
@@ -1355,7 +1363,7 @@ an environment \texttt{env}.  Formally, the result of annotating the expression
   \subsection{Example}
 
   \subsection{Code}
-  \VerbatimInput[firstline=\ELocalVarConstantBegin, lastline=\ELocalVarConstantEnd]{../Typing.ml}  
+  \VerbatimInput[firstline=\ELocalVarConstantBegin, lastline=\ELocalVarConstantEnd]{../Typing.ml}
 
 \begin{emptyformal}
   \subsection{Formally}
@@ -1367,10 +1375,10 @@ an environment \texttt{env}.  Formally, the result of annotating the expression
 
   \subsection{Prose}
   The result of annotating the expression \texttt{e} in \texttt{env} is
-\texttt{t,new\_env} and all of the following apply: 
+\texttt{t,new\_env} and all of the following apply:
   \begin{itemize}
   \item \texttt{e} denotes a variable \texttt{x};
-  \item \texttt{x} is not bound to a local constant; 
+  \item \texttt{x} is not bound to a local constant;
   \item \texttt{x} has type \texttt{ty} in the local environment given by \texttt{env};
   \item \texttt{t} is \texttt{ty};
   \item \texttt{new\_env} is \texttt{e}.
@@ -1379,7 +1387,7 @@ an environment \texttt{env}.  Formally, the result of annotating the expression
   \subsection{Example}
 
   \subsection{Code}
-  \VerbatimInput[firstline=\ELocalVarBegin, lastline=\ELocalVarEnd]{../Typing.ml}  
+  \VerbatimInput[firstline=\ELocalVarBegin, lastline=\ELocalVarEnd]{../Typing.ml}
 
 \begin{emptyformal}
   \subsection{Formally}
@@ -1391,7 +1399,7 @@ an environment \texttt{env}.  Formally, the result of annotating the expression
 
   \subsection{Prose}
   The result of annotating the expression \texttt{e} in \texttt{env} is
-\texttt{t,new\_env} and all of the following apply: 
+\texttt{t,new\_env} and all of the following apply:
   \begin{itemize}
   \item \texttt{e} denotes a variable \texttt{x};
   \item \texttt{x} is bound to a global constant~\texttt{v} of type \texttt{ty} in the global environment given by \texttt{env};
@@ -1701,7 +1709,7 @@ expression.
 \subsection{Comments}
   This aims to encompass LRM Section 5.5 R\_WBCQ.
 
- 
+
 \section{TypingRule.EGetRecordField \label{sec:TypingRule.EGetRecordField}}
 
   \subsection{Prose}
@@ -2007,7 +2015,7 @@ expression that is unresolvable to an integer. For example:
 
   \subsection{Code}
     \VerbatimInput[firstline=\EPatternBegin, lastline=\EPatternEnd]{../Typing.ml}
-        
+
 \begin{emptyformal}
     \subsection{Formally}
 \end{emptyformal}
@@ -2047,7 +2055,7 @@ expression that is unresolvable to an integer. For example:
   \subsection{Example}
 
   \subsection{Code}
-  \VerbatimInput[firstline=\CTCBegin, lastline=\CTCEnd]{../Typing.ml}   
+  \VerbatimInput[firstline=\CTCBegin, lastline=\CTCEnd]{../Typing.ml}
 
 \begin{emptyformal}
   \subsection{Formally}
@@ -2093,7 +2101,7 @@ all of the following apply:
   \subsection{Example}
 
   \subsection{Code}
-    \VerbatimInput[firstline=\LEDiscardBegin, lastline=\LEDiscardEnd]{../Typing.ml} 
+    \VerbatimInput[firstline=\LEDiscardBegin, lastline=\LEDiscardEnd]{../Typing.ml}
 
 \begin{emptyformal}
     \subsection{Formally}
@@ -2118,7 +2126,7 @@ all of the following apply:
   \subsection{Example}
 
   \subsection{Code}
-    \VerbatimInput[firstline=\LELocalVarBegin, lastline=\LELocalVarEnd]{../Typing.ml} 
+    \VerbatimInput[firstline=\LELocalVarBegin, lastline=\LELocalVarEnd]{../Typing.ml}
 
 \begin{emptyformal}
     \subsection{Formally}
@@ -2139,11 +2147,11 @@ all of the following apply:
    \item \texttt{t\_e} can be assigned to \texttt{ty};
    \item \texttt{new\_le} is \texttt{le}.
    \end{itemize}
- 
+
   \subsection{Example}
 
   \subsection{Code}
-    \VerbatimInput[firstline=\LEGlobalVarBegin, lastline=\LEGlobalVarEnd]{../Typing.ml} 
+    \VerbatimInput[firstline=\LEGlobalVarBegin, lastline=\LEGlobalVarEnd]{../Typing.ml}
 
 \begin{emptyformal}
     \subsection{Formally}
@@ -2206,7 +2214,7 @@ all of the following apply:
    \item \texttt{slices2} is the result of annotating \texttt{slices} in \texttt{env};
    \item \texttt{new\_le} is the slicing of \texttt{le2} by \texttt{slices2}.
    \end{itemize}
- 
+
   \subsection{Example}
 
   \subsection{Code}
@@ -2239,7 +2247,7 @@ all of the following apply:
    \item \texttt{slices} is a single expression \texttt{e\_index};
    \item \texttt{t\_index', e\_index'} is the result of annotating \texttt{e\_index} in \texttt{env};
    \item \texttt{wanted\_t\_index} can be assigned to \texttt{t\_index'};
-   \item \texttt{new\_le} is an access to array \texttt{le2} at index \texttt{e\_index'}.  
+   \item \texttt{new\_le} is an access to array \texttt{le2} at index \texttt{e\_index'}.
    \end{itemize}
 
   \subsection{Example}
@@ -2293,7 +2301,7 @@ all of the following apply:
    \item \texttt{le2} is the result of annotating \texttt{le1} in \texttt{env};
    \item \texttt{t\_le1} has the structure of an exception or a record type with fields \texttt{fields};
    \item \texttt{field} is bound to type \texttt{t} in \texttt{fields};
-   \item \texttt{t} can be assigned to \texttt{t\_e}; 
+   \item \texttt{t} can be assigned to \texttt{t\_e};
    \item \texttt{new\_le} is the access to the field \texttt{field} in \texttt{le2}.
    \end{itemize}
 
@@ -2321,7 +2329,7 @@ all of the following apply:
    \item \texttt{le2} is the result of annotating \texttt{le1} in \texttt{env};
    \item \texttt{t\_le1} has the structure of a bitvector with bitfields \texttt{bitfields};
    \item \texttt{field} is not declared in \texttt{bitfields};
-   \item an error ``\texttt{Bad Field}'' is raised.  
+   \item an error ``\texttt{Bad Field}'' is raised.
    \end{itemize}
 
   \subsection{Example}
@@ -2469,7 +2477,7 @@ all of the following apply:
 \texttt{t\_e} to be the type of the corresponding right-hand-side
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
-     
+
   \subsection{Example}
 
   \subsection{Code}
@@ -2498,7 +2506,7 @@ length)} and one of the following applies:
   \subsection{Prose}
    Annotating slices~\texttt{slices} in an environment~\texttt{env}
 (\texttt{annotate\_slices env slices}) results in the pair \texttt{(offset,
-length)} and all of the following apply: 
+length)} and all of the following apply:
    \begin{itemize}
    \item \texttt{slices} gives an index \texttt{i};
    \item \texttt{(offset, length)} is the result of applying TypingRule.SliceLength to \texttt{i, i+:1}.
@@ -2523,7 +2531,7 @@ length)} and all of the following apply:
 (\texttt{annotate\_slices env slices}) results in the pair \texttt{(offset,
 length)} and all of the following apply:
    \begin{itemize}
-   \item \texttt{slices} gives \texttt{offset} and \texttt{length}; 
+   \item \texttt{slices} gives \texttt{offset} and \texttt{length};
    \item \texttt{t\_offset, offset'} is the result of annotating \texttt{offset} in \texttt{env};
    \item \texttt{t\_length, length'} is the result of annotating \texttt{length} in \texttt{env};
    \item \texttt{t\_offset} has the structure of an integer type;
@@ -2653,7 +2661,7 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
    Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \texttt{t} (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
    \begin{itemize}
    \item \texttt{p} is the pattern which matches anything greater than or equal to an expression \texttt{e};
-   \item \texttt{t\_e, e'} is the result of annotating \texttt{e} in \texttt{env}; 
+   \item \texttt{t\_e, e'} is the result of annotating \texttt{e} in \texttt{env};
    \item \texttt{e'} is a compile-time constant expression;
    \item One of the following applies:
      \begin{itemize}
@@ -2666,7 +2674,7 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
            \begin{itemize}
            \item both \texttt{t} and \texttt{t\_e} have the structure of a real;
            \item \texttt{new\_p} is the pattern which matches anything greater than or equal to \texttt{e'}.
-           \end{itemize} 
+           \end{itemize}
      \item an error ``\texttt{Conflicting Types}'' is raised.
      \end{itemize}
    \end{itemize}
@@ -2688,7 +2696,7 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
    Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \texttt{t} (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
    \begin{itemize}
    \item \texttt{p} is the pattern which matches anything lesser than or equal to an expression \texttt{e};
-   \item \texttt{t\_e, e'} is the result of annotating \texttt{e} in \texttt{env}; 
+   \item \texttt{t\_e, e'} is the result of annotating \texttt{e} in \texttt{env};
    \item \texttt{e'} is a compile-time constant expression;
    \item One of the following applies:
      \begin{itemize}
@@ -2716,14 +2724,14 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
- 
+
 \section{TypingRule.PNot \label{sec:TypingRule.PNot}}
 
   \subsection{Prose}
    Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \texttt{t} (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
    \begin{itemize}
    \item \texttt{p} is the pattern which matches the negation of a pattern \texttt{q};
-   \item \texttt{new\_q} is the result of annotating \texttt{q} in \texttt{env}; 
+   \item \texttt{new\_q} is the result of annotating \texttt{q} in \texttt{env};
    \item \texttt{new\_p} is pattern which matches the negation of \texttt{new\_q}.
    \end{itemize}
 
@@ -2737,7 +2745,7 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
- 
+
 \section{TypingRule.PRange \label{sec:TypingRule.PRange}}
 
     \subsection{Prose}
@@ -2747,7 +2755,7 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
       expressions \texttt{e1} and \texttt{e2};
    \item \texttt{t\_e1, e1'} is the result of annotating \texttt{e1} in \texttt{env};
    \item \texttt{t\_e2, e2'} is the result of annotating \texttt{e2} in \texttt{env};
-   \item e1' and e2' are compile-time constant expressions; 
+   \item e1' and e2' are compile-time constant expressions;
    \item One of the following applies:
      \begin{itemize}
      \item All of the following apply:
@@ -2776,7 +2784,7 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
- 
+
 \section{TypingRule.PSingle \label{sec:TypingRule.PSingle}}
 
     \subsection{Prose}
@@ -2865,7 +2873,7 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
    \item \texttt{p} is the pattern which matches a tuple \texttt{li};
    \item \texttt{t} has the type structure of a tuple type \texttt{ts};
    \item \texttt{ts} is a list of different size to the size of \texttt{li};
-   \item an error ``\texttt{Bad Arity}'' is raised. 
+   \item an error ``\texttt{Bad Arity}'' is raised.
    \end{itemize}
 
   \subsection{Example}
@@ -2887,7 +2895,7 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
    \begin{itemize}
    \item \texttt{p} is the pattern which matches a tuple \texttt{li};
    \item \texttt{t} has the type structure of a tuple type \texttt{ts};
-   \item \texttt{ts} is a list of the same size as \texttt{li};  
+   \item \texttt{ts} is a list of the same size as \texttt{li};
    \item \texttt{new\_li} is the result of annotating \texttt{li} with \texttt{ts};
    \item \texttt{new\_p} is the pattern which matches the tuple \texttt{new\_li}.
    \end{itemize}
@@ -2912,7 +2920,7 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
    \item \texttt{p} is the pattern which matches a tuple \texttt{li};
    \item \texttt{t} has the type structure of a tuple type \texttt{ts};
    \item \texttt{t\_struct} is not a tuple type;
-   \item an error ``\texttt{Conflicting Types}'' is raised. 
+   \item an error ``\texttt{Conflicting Types}'' is raised.
    \end{itemize}
 
   \subsection{Example}
@@ -3046,10 +3054,10 @@ the following apply:
   \item \texttt{ldi} denotes a list \texttt{ldis};
   \item \texttt{ldi} does not specify a type;
   \item \texttt{ty} has the structure of a tuple type of the same length as~\texttt{ldis};
-  \item \texttt{new\_env} is \texttt{env} modified so that each element in \texttt{ldis} is annotated with the corresponding type in \texttt{ty}; 
+  \item \texttt{new\_env} is \texttt{env} modified so that each element in \texttt{ldis} is annotated with the corresponding type in \texttt{ty};
   \item \texttt{new\_ldi} is \texttt{ldis} where each element is declared with
 the corresponding type in ~\texttt{ty}.
-  \end{itemize} 
+  \end{itemize}
 
   \subsection{Example}
 
@@ -3127,7 +3135,7 @@ environment \texttt{new\_env} and all of the following apply:
        \item \texttt{reduced} gives a statement \texttt{s};
        \item \texttt{new\_s} is \texttt{s};
        \item \texttt{new\_env} is \texttt{env}.
-       \end{itemize}     
+       \end{itemize}
 
      \item All of the following apply:
        \begin{itemize}
@@ -3145,7 +3153,7 @@ environment \texttt{new\_env} and all of the following apply:
 	   \item \texttt{env1} is the result of annotating undeclared variables by using
 	      the first assignments to such variables as declarations;
            \end{itemize}
-         \end{itemize} 
+         \end{itemize}
 
        \item \texttt{le1} is the result of annotating \texttt{le} with \texttt{t\_e} in \texttt{env1};
        \item \texttt{new\_s} is the assignment \texttt{le1 = e1};
@@ -3172,7 +3180,7 @@ Annotating statement~\texttt{s} in an environment~\texttt{env}
 (\texttt{annotate\_stmt env s}) results in a statement \texttt{new\_s} and an
 environment \texttt{new\_env} and all of the following apply:
    \begin{itemize}
-   \item \texttt{s} is a \texttt{return} statement with no value and no return type; 
+   \item \texttt{s} is a \texttt{return} statement with no value and no return type;
    \item \texttt{new\_s} is a \texttt{return} statement with no value;
    \item the enclosing subprogram does not have a \texttt{return} type (it is either a setter
       or a procedure);
@@ -3226,7 +3234,7 @@ environment \texttt{new\_env} and all of the following apply:
 
 \subsection{Comments}
     This aims to encompass LRM Section 7.4.3 R\_FTPK.
-    
+
 \section{TypingRule.SReturnSome \label{sec:TypingRule.SReturnSome}}
 
   \subsection{Prose}
@@ -3243,7 +3251,7 @@ environment \texttt{new\_env} and all of the following apply:
        \begin{itemize}
        \item \texttt{t\_e'} type-satisfies \texttt{t};
        \item \texttt{new\_s} is a \texttt{return} statement with value \texttt{e'};
-       \item \texttt{new\_env} is \texttt{env}. 
+       \item \texttt{new\_env} is \texttt{env}.
        \end{itemize}
      \item an error ``\texttt{Conflicting Types}'' is raised.
      \end{itemize}
@@ -3325,7 +3333,7 @@ environment \texttt{new\_env} and all of the following apply:
      \begin{itemize}
      \item All of the following apply:
        \begin{itemize}
-       \item \texttt{t\_cond} type-satisfies \texttt{t\_bool}; 
+       \item \texttt{t\_cond} type-satisfies \texttt{t\_bool};
        \item \texttt{s1'} is the result of annotating \texttt{s1} in \texttt{env};
        \item \texttt{s2'} is the result of annotating \texttt{s2} in \texttt{env};
        \item \texttt{new\_s} is the condition \texttt{e\_cond} with two statements \texttt{s1'} and \texttt{s2'};
@@ -3372,7 +3380,7 @@ environment \texttt{new\_env} and all of the following apply:
 
 \subsection{Comments}
     This aims to encompass LRM Section 7.4.3 R\_WGSY.
-  
+
 \section{TypingRule.SAssert \label{sec:TypingRule.SAssert}}
 
   \subsection{Prose}
@@ -3385,7 +3393,7 @@ environment \texttt{new\_env} and all of the following apply:
    \item One of the following applies:
      \item All of the following apply:
        \begin{itemize}
-       \item \texttt{t\_e'} type-satisfies \texttt{t\_bool};  
+       \item \texttt{t\_e'} type-satisfies \texttt{t\_bool};
        \item \texttt{new\_s} is an assert statement with expression \texttt{e'};
        \item \texttt{new\_env} is \texttt{env}.
        \end{itemize}
@@ -3404,7 +3412,7 @@ environment \texttt{new\_env} and all of the following apply:
 \subsection{Comments}
     This aims to encompass LRM Section 7.4.3 R\_JQYF
 
-    
+
 \section{TypingRule.SWhile \label{sec:TypingRule.SWhile}}
 
   \subsection{Prose}
@@ -3417,7 +3425,7 @@ environment \texttt{new\_env} and all of the following apply:
    \item One of the following applies:
      \item All of the following apply:
        \begin{itemize}
-       \item \texttt{t} type-satisfies \texttt{t\_bool}; 
+       \item \texttt{t} type-satisfies \texttt{t\_bool};
        \item \texttt{s2} is the result of annotating \texttt{s1} in \texttt{env};
        \item \texttt{new\_s} is a \texttt{while} statement with expression \texttt{e2} and statement block \texttt{s2};
        \item \texttt{new\_env} is \texttt{env}.
@@ -3451,7 +3459,7 @@ environment \texttt{new\_env} and all of the following apply:
      \begin{itemize}
      \item All of the following apply:
        \begin{itemize}
-       \item \texttt{t} type-satisfies \texttt{t\_bool}; 
+       \item \texttt{t} type-satisfies \texttt{t\_bool};
        \item \texttt{new\_s} is a \texttt{repeat} statement with expression \texttt{e2} and statement block \texttt{s2};
        \item \texttt{new\_env} is \texttt{env}.
        \end{itemize}
@@ -3563,7 +3571,7 @@ environment \texttt{new\_env} and all of the following apply:
 
 \subsection{Comments}
     This aims to encompass LRM Section 7.4.3 R\_VTJW.
- 
+
 
 \section{TypingRule.SThrowNone \label{sec:TypingRule.SThrowNone}}
 
@@ -3695,12 +3703,12 @@ environment \texttt{new\_env} and all of the following apply:
 \chapter{Typing of Blocks}
 
 \section{TypingRule.Block \label{sec:TypingRule.Block}}
-    
+
   \subsection{Prose}
     Annotating a block \texttt{s} in an environment \texttt{env}, given a type
 \texttt{return\_type} (\texttt{annotate\_block env return\_type s}, is the
 result of annotating the statement \texttt{s} in \texttt{env}.
-   
+
   \subsection{Example: TypingRule.Block0.asl}
 \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.Block0.asl}
 
@@ -3718,7 +3726,7 @@ immediately enclosing block.
 
     From that follows that we can discard the environment at the end of
 an enclosing block.
- 
+
 
 \chapter{Typing of Catchers}
 Annotating catchers \texttt{(name\_opt, ty, stmt)} in an environment
@@ -3729,7 +3737,7 @@ new\_stmt)} and one of the following applies:
 \item TypingRule.CatcherNone (see Section~\ref{sec:TypingRule.CatcherNone}),
 \item TypingRule.CatcherSome (see Section~\ref{sec:TypingRule.CatcherSome}).
 \end{itemize}
-   
+
 \section{TypingRule.CatcherNone \label{sec:TypingRule.CatcherNone}}
 
   \subsection{Prose}
@@ -3798,7 +3806,7 @@ args, eqs2, ret\_ty1)} or an error is raised and one of the following applies:
 
 \section{TypingRule.FCallBadArity \label{sec:TypingRule.FCallBadArity}}
 
-  \subsection{Prose} 
+  \subsection{Prose}
   Annotating the call to subprogram \texttt{name} with arguments \texttt{args}
 and parameters \texttt{eqs} (\texttt{annotate\_call}) results in
 \texttt{(name1, args, eqs2, ret\_ty1)} or an error is raised and all of the
@@ -3922,7 +3930,7 @@ the following apply:
    \item \texttt{body} is the body given by \texttt{f};
    \item \texttt{new\_body} is the result of annotating \texttt{body} in
      \texttt{env5}.
- \end{itemize} 
+ \end{itemize}
 
   \subsection{Example}
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -3794,8 +3794,8 @@ new\_stmt)} and all of the following apply:
 
 \chapter{Typing of Subprogram Calls}
 
-Annotating the call to subprogram \texttt{name} with arguments \texttt{args} and
-parameters \texttt{eqs} (\texttt{annotate\_call}) results in \texttt{(name1,
+Annotating the call to subprogram \texttt{name} with arguments \texttt{args},
+parameters \texttt{eqs}, and call type \texttt{call\_type} (\texttt{annotate\_call}) results in \texttt{(name1,
 args, eqs2, ret\_ty1)} or an error is raised and one of the following applies:
 \begin{itemize}
 \item TypingRule.FCallBadArity (see Section~\ref{sec:TypingRule.FCallBadArity}),
@@ -3831,9 +3831,10 @@ following apply:
 \section{TypingRule.FCallGetter \label{sec:TypingRule.FCallGetter}}
 
   \subsection{Prose}
-  Annotating the call to subprogram \texttt{name} with arguments \texttt{args}
-and parameters \texttt{eqs} (\texttt{annotate\_call}) results in
-\texttt{(name1, args, eqs2, ret\_ty1)} or an error is raised and all of the following apply:
+  Annotating the call to subprogram \texttt{name} with arguments \texttt{args},
+  parameters \texttt{eqs}, and call-type \texttt{call\_type}
+  (\texttt{annotate\_call}) results in \texttt{(name1, args, eqs2, ret\_ty1)}
+  or an error is raised and all of the following apply:
    \begin{itemize}
    \item \texttt{caller\_arg\_types, arg1} is the result of annotating \texttt{args} in \texttt{env};
    \item \texttt{name} is bound in \texttt{env} to a subprogram with argument types
@@ -3841,7 +3842,7 @@ and parameters \texttt{eqs} (\texttt{annotate\_call}) results in
    \item \texttt{eqs2} is \texttt{eqs1} appended with the equations deduced by
      using the types of the actual arguments \texttt{caller\_arg\_types} to
      defined parameters in \texttt{callee\_arg\_types};
-   \item \texttt{call\_type} is either a subprogram or a getter type;
+   \item \texttt{call\_type} is either a function or a getter type;
    \item \texttt{ret\_ty1} is the result of renaming \texttt{ty} in \texttt{eqs2}.
    \end{itemize}
 
@@ -3860,10 +3861,10 @@ and parameters \texttt{eqs} (\texttt{annotate\_call}) results in
 \section{TypingRule.FCallSetter \label{sec:TypingRule.FCallSetter}}
 
   \subsection{Prose}
-  Annotating the call to subprogram \texttt{name} with arguments \texttt{args}
-  and parameters \texttt{eqs} (\texttt{annotate\_call}) results in
-  \texttt{(name1, args, eqs2, ret\_ty1)} or an error is raised and all of the
-  following apply:
+  Annotating the call to subprogram \texttt{name} with arguments \texttt{args},
+  parameters \texttt{eqs}, and call-type \texttt{call\_type}
+  (\texttt{annotate\_call}) results in \texttt{(name1, args, eqs2, ret\_ty1)}
+  or an error is raised and all of the following apply:
   \begin{itemize}
     \item \texttt{caller\_arg\_types, arg1} is the result of annotating
       \texttt{args} in \texttt{env};
@@ -3895,6 +3896,22 @@ and parameters \texttt{eqs} (\texttt{annotate\_call}) results in
 \section{TypingRule.FCallMismatch \label{sec:TypingRule.FCallMismatch}}
 
   \subsection{Prose}
+  Annotating the call to subprogram \texttt{name} with call type \texttt{call\_type} (\texttt{annotate\_call}) results in an error and
+  one of the following apply:
+  \begin{itemize}
+    \item All of the following apply:
+      \begin{itemize}
+        \item \texttt{call\_type} is a function or a getter;
+        \item \texttt{name} is bound in \texttt{env} a subprogram without a return-type;
+        \item A ``Mismatched return value'' error is raised.
+      \end{itemize}
+    \item All of the following apply:
+      \begin{itemize}
+        \item \texttt{call\_type} is a procedure or a setter;
+        \item \texttt{name} is bound in \texttt{env} a subprogram with a return type;
+        \item A ``Mismatched return value'' error is raised.
+      \end{itemize}
+  \end{itemize}
 
   \subsection{Example}
 

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -14,7 +14,7 @@ no-empty:
 
 CONTROL=ifempty.tex ifformal.tex control.tex
 
-ASLAbstractSyntaxReference.pdf: ASLAbstractSyntaxReference.tex
+ASLAbstractSyntaxReference.pdf: $(CONTROL) ASLASTLines.tex ASLAbstractSyntaxReference.tex
 	$(LATEX) -pdf ASLAbstractSyntaxReference.tex
 
 ASLSemanticsReference.pdf: $(CONTROL) ASLAbstractSyntaxReference.pdf ASLSemanticsReference.tex ASLSemanticsLines.tex

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ESlice.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ESlice.asl
@@ -1,8 +1,8 @@
 func main () => integer
 begin
 
-  let x = ['11110000'[5:2]];
-  assert x == '1100';
+  let x = ['11110000'[6:3]];
+  assert x == '1110';
 
   return 0;
 end 

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -391,9 +391,10 @@ let rec subtypes_names env s1 s2 =
     | Some s1' -> subtypes_names env s1' s2
 
 let subtypes env t1 t2 =
-  match (t1.desc, t2.desc) with
+  (match (t1.desc, t2.desc) with
   | T_Named s1, T_Named s2 -> subtypes_names env s1 s2
-  | _ -> false |: TypingRule.Subtype
+  | _ -> false)
+  |: TypingRule.Subtype
 (* End Subtype *)
 
 let rec bitfields_included env bfs1 bfs2 =


### PR DESCRIPTION
This PR implements the following:

- [x] Fix `make all` in `asllib/doc`
- [x] Transliterations of `TypingRule.Subtype`, `TypingRule.MismatchCall`
- [x] Fix transliterations of  `TypingRule.GetStructure` and corresponding
  `asllib/types.ml` code
- [x] Fix transliterations of patterns (complete rewrite) and corresponding
  code
- [x] Fix transliterations of slices (mainly renamings and refactos)

