### PR TITLE
[gen] New setting to control metadata output

### DIFF
--- a/gen/config.ml
+++ b/gen/config.ml
@@ -53,6 +53,7 @@ let variant = ref (fun (_:Variant_gen.t) -> false)
 let rejects = ref None
 let stdout = ref false
 let cycleonly = ref false
+let metadata = ref true
 
 let info = ref ([]:MiscParser.info)
 let add_info_line line = match LexScan.info line with
@@ -214,6 +215,8 @@ let common_specs () =
   ("-nooptcond", Arg.Clear optcond, "do not optimize conditions")::
   ("-optcoherence", Arg.Set optcoherence, " optimize coherence")::
   ("-nooptcoherence", Arg.Clear optcoherence, "do not optimize coherence (default)")::
+  ("-metadata",Arg.Bool (fun b -> metadata := b),
+   sprintf "output metadata, default %b" !metadata)::
   ("-info",Arg.String add_info_line,"add metadata to generated test(s)")::
   ("-moreedges", Arg.Bool (fun b -> moreedges := b),
    Printf.sprintf

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -248,6 +248,7 @@ let () =
     let lowercase = !Config.lowercase
     let stdout = if !Config.cycleonly then true else !Config.stdout
     let cycleonly = !Config.cycleonly
+    let metadata = !Config.metadata
 (* Specific *)
     open Config
     let choice = !Config.mode

--- a/gen/diycross.ml
+++ b/gen/diycross.ml
@@ -186,6 +186,7 @@ let () =
       let lowercase = !Config.lowercase
       let stdout = if !Config.cycleonly then true else !Config.stdout
       let cycleonly = !Config.cycleonly
+      let metadata = !Config.metadata
 (* Specific *)
       let varatom = !Config.varatom
       let same_loc =

--- a/gen/diyone.ml
+++ b/gen/diyone.ml
@@ -234,6 +234,7 @@ let () =
     let hexa = !Config.hexa
     let stdout = if !Config.cycleonly then true else !Config.stdout
     let cycleonly = !Config.cycleonly
+    let metadata = !Config.metadata
 (* Specific *)
     let norm = !norm
     let cpp = cpp

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -37,6 +37,7 @@ module type Config = sig
   val hexa : bool
   val variant : Variant_gen.t -> bool
   val cycleonly: bool
+  val metadata : bool
 end
 
 module Make (O:Config) (Comp:XXXCompile_gen.S) : Builder.S
@@ -932,11 +933,13 @@ let fmt_cols =
 
   let dump_test_channel_full chan t =
     fprintf chan "%s %s\n" (Archs.pp A.arch) t.name ;
-    if t.com <>  "" then fprintf chan "\"%s\"\n" t.com ;
-    List.iter
-      (fun (k,v) -> fprintf chan "%s=%s\n" k v)
-      t.info ;
-    Hint.dump O.hout t.name t.info ;
+    if O.metadata then begin
+      if t.com <>  "" then fprintf chan "\"%s\"\n" t.com ;
+      List.iter
+        (fun (k,v) -> fprintf chan "%s=%s\n" k v)
+        t.info ;
+      Hint.dump O.hout t.name t.info
+    end ;
     dump_init chan t.init t.env ;
     dump_code chan t.prog ;
     begin match t.scopes with


### PR DESCRIPTION
The new command line option `-metadata false` command _not_ to output the usual metadata or info fields in generated tests. The default, `-metadata true` corresponds to previous behaviour.