### PR TITLE
[litmus] Fix build for Neon test with -mem indirect

### DIFF
--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -1193,6 +1193,10 @@ module Make
                 let load = U.do_load t (wrap addr) in
                 sprintf "%s != %s"
                   load (dump_a_v v)
+            | (Indirect,Array _) ->
+                let load = U.do_load t (wrap addr) in
+                sprintf "%s != %s"
+                  load (sprintf "%s_values[_j]" a)
             | Indirect,_ ->
                 let load = U.do_load t (wrap addr) in
                 sprintf "%s != %s" load (A.Out.dump_v v)


### PR DESCRIPTION
Build for Neon test with `-mem indirect` fails with

```
N.c: In function ‘check_globals’:
N.c:200:55: error: expected expression before ‘{’ token
  200 |       if (rand_bit(&(_a->seed)) && (mem_y[_i])[_j] != {0,0,0,0}) fatal("A, check_globals failed");
      |                                                       ^
N.c:204:55: error: expected expression before ‘{’ token
  204 |       if (rand_bit(&(_a->seed)) && (mem_x[_i])[_j] != {0,0,0,0}) fatal("A, check_globals failed");
      |                                                       ^
N.c:202:9: warning: unused variable ‘x_values’ [-Wunused-variable]
  202 |     x_t x_values = {0,0,0,0,};
      |         ^~~~~~~~
N.c:198:9: warning: unused variable ‘y_values’ [-Wunused-variable]
  198 |     y_t y_values = {0,0,0,0,};
      |         ^~~~~~~~
```
We have almost everything to make it build except `{x,y}_values` are not used where they should be - let's fix that.