### PR TITLE
[litmus] Basic type checking for RISCV

### DIFF
--- a/lib/CType.ml
+++ b/lib/CType.ml
@@ -29,6 +29,8 @@ type t =
 
 let void = Base "void"
 let voidstar = Pointer void
+let byte = Base "int8_t"
+let half = Base "int16_t"
 let word = Base "int"
 let quad = Base "int64_t"
 let int32x4_t = Base "int32x4_t"

--- a/lib/CType.mli
+++ b/lib/CType.mli
@@ -29,6 +29,8 @@ type t =
 
 val void : t
 val voidstar : t
+val byte : t
+val half : t
 val word : t
 val quad : t
 val int32x4_t : t

--- a/litmus/RISCVArch_litmus.ml
+++ b/litmus/RISCVArch_litmus.ml
@@ -42,8 +42,30 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
         let reg_class _ = "=&r"
         let reg_class_stable _ = "=&r"
         let comment = comment
-        let error _t1 _t2 = false
-        and warn _t1 _t2 = false
+
+        let error t1 t2 =
+          let open CType in
+(*          Printf.eprintf "Error %s and %s\n" (debug t1) (debug t2) ; *)
+          match t1,t2 with
+          | (Base
+               ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"),
+             Pointer _)
+          | (Pointer _,
+             Base ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"))  ->
+              true
+
+          | _ -> false
+
+        let warn t1 t2 =
+          let open CType in
+          match t1,t2 with
+          | Base ("ins_t"|"int"|"int32_t"|"uint32_t"
+                  |"int16_t"|"uint16_t"
+                  |"int8_t"|"uint8_t"),
+            Base ("ins_t"|"int"|"int32_t"|"uint32_t") -> false
+          | (Base "int",_)|(_,Base "int") -> true
+          | _ -> false
+
       end)
   let features = []
   let nop = INop


### PR DESCRIPTION
Reject programs that use a register as an address
and a scalar of size <= sizeof(int32_t).