### PR TITLE
Added new XOR token to reflect change in LRM

### DIFF
--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -51,7 +51,7 @@ let tr_name s = match s with
 | "elsif"         -> ELSIF
 | "end"           -> END
 | "enumeration"   -> ENUMERATION
-| "EOR"           -> EOR
+| "EOR" | "XOR"   -> EOR
 | "exception"     -> EXCEPTION
 | "FALSE"         -> BOOL_LIT false
 | "for"           -> FOR

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckBinOp.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckBinOp.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+  var a: bits(10);
+  var b: bits(10);
+  var c: bits(10) = a XOR b; // Check that XOR operator is recognized by the lexer.
+  return 0;
+end

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -17,3 +17,4 @@ ASL Typing Reference:
     0 arguments expected and 1 provided
   [1]
 //  $ aslref TypingRule.EConcatUnresolvableToInteger.asl
+  $ aslref TypingRule.CheckBinOp.asl


### PR DESCRIPTION
Added a new keyword "XOR", which is mapped to the token EOR.

Added a new test.

Test plan: 
---------
asllib/tests/ASLTypingReference.t$ aslref --no-exec --type-check-strict TypingRule.CheckBinOp.asl
$ dune runtest asllib
$ make test-aarch64-asl
$ make test