### PR TITLE
[herd] Implement Aarch64 instruction stz2g

### DIFF
--- a/herd/AArch64ParseTest.ml
+++ b/herd/AArch64ParseTest.ml
@@ -49,8 +49,16 @@ module Make(Conf:RunTest.Config)(ModelConfig:MemCat.Config) = struct
           end
           module AArch64S = MakeSem(AArch64SemConf)(V)
           module AArch64M = MemCat.Make(ModelConfig)(AArch64S)
-          module P =
+          module P0 =
             GenParser.Make (Conf) (AArch64) (AArch64LexParse)
+          module P =
+            struct
+              type pseudo = AArch64.pseudo
+              let parse chan splitted =
+                let tst = P0.parse chan splitted in
+                let () = AArch64.check tst in
+                tst
+            end
           module X = RunTest.Make (AArch64S) (P) (AArch64M) (Conf)
         end
 (*

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -96,12 +96,12 @@ end = struct
   let access_of_constant cst =
     let open Constant in
     match cst with
-    | Symbolic (Virtual _) -> VIR
-    | Symbolic (Physical _) -> PHY
+    | Symbolic (Virtual _) -> Access.VIR
+    | Symbolic (Physical _) -> Access.PHY
+    | Symbolic (TagAddr _) -> Access.TAG
     | Symbolic (System ((PTE|PTE2),_)) -> Access.PTE
     | Symbolic (System (TLB,_)) -> Access.TLB
-    | Symbolic (System (TAG,_)) -> Access.TAG
-    | Label _ -> VIR
+    | Label _ -> Access.VIR
     | Tag _
     | ConcreteVector _|Concrete _|ConcreteRecord _
     | PteVal _|Instruction _|Frozen _ as v
@@ -125,14 +125,14 @@ end = struct
     function
     | A.Location_reg _ -> REG
     | A.Location_global (V.Val (Symbolic (Virtual _))|V.Var _)
-      -> VIR
+      -> Access.VIR
     | A.Location_global (V.Val (Symbolic ((System ((PTE|PTE2),_))))) as loc
         ->
           if kvm then Access.PTE
           else Warn.fatal "PTE %s while -variant kvm is not active"
                  (A.pp_location loc)
     | A.Location_global (V.Val (Label(_,_)))
-      -> VIR
+      -> Access.VIR
     | A.Location_global v ->
         Warn.fatal
           "access_of_location_std on non-standard symbol '%s'"

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -1975,8 +1975,8 @@ let match_reg_events es =
        let a = Misc.as_some (E.global_loc_of e) in
        if not (U.is_aligned (S.type_env test) (S.size_env test) e) then begin
          if dbg then eprintf "UNALIGNED: %s\n" (E.pp_action e);
-         Warn.user_error "Unaligned or out-of-bound access: %s"
-           (A.V.pp_v a)
+         Warn.user_error "Unaligned or out-of-bound access: %s, %d bytes"
+           (A.V.pp_v a) (E.get_mem_size e |> MachSize.nbytes)
        end
 
 (* Check alignement in the mixed-size case.

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -294,7 +294,8 @@ module Make(C:Config) (A:Arch_herd.S) (Act:Action.S with module A = A)
       match sym with
       | Virtual sd -> is_non_mixed_symbol_virtual test sd
       | Physical (s,o) -> is_non_mixed_offset test s o
-      | System ((PTE|PTE2|TLB|TAG),_)  -> true
+      | TagAddr _
+      | System ((PTE|PTE2|TLB),_)  -> true
 
 (* Exported labels:
  *  1. Labels from init environments

--- a/herd/tests/instructions/AArch64.MTE/L00.litmus
+++ b/herd/tests/instructions/AArch64.MTE/L00.litmus
@@ -1,0 +1,14 @@
+AArch64 L00
+Variant=mixed,mte,sync
+{
+int x[6]={1,2,3,4,5,6};
+0:X1=x;
+0:X2=x:red;
+}
+ P0              ;
+ STZG  X2,[X1]   ;
+ MOV W0,#7       ;
+ STR W0,[X2]     ;
+ STR W0,[X1,#20] ; 
+forall x={7,0,0,0,5,7}
+

--- a/herd/tests/instructions/AArch64.MTE/L00.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/L00.litmus.expected
@@ -1,0 +1,10 @@
+Test L00 Required
+States 1
+x={7,0,0,0,5,7};
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (x={7,0,0,0,5,7})
+Observation L00 Always 1 0
+Hash=686ab9d457f82594fb739b04bbe5a40b
+

--- a/herd/tests/instructions/AArch64.MTE/L01.litmus
+++ b/herd/tests/instructions/AArch64.MTE/L01.litmus
@@ -1,0 +1,15 @@
+AArch64 S+dmb.sytt+addrpt
+Orig=DMB.SYdWWTT RfeTP DpAddrdWPT CoeTT
+Variant=mte,async
+(* Test is allowed in asynchronous mode, by lack of
+   iico_ctrl relation from tag test to read in P1 LDR *)
+{
+0:X0=x:blue; 0:X1=x:red; 0:X2=y:red; 0:X3=y:green;
+1:X0=y:red; 1:X3=x:red; 1:X4=x:green;
+}
+ P0          | P1                ;
+ STG X0,[X1] | LDR W1,[X0]       ;
+ DMB SY      | EOR W2,W1,W1      ;
+ STG X2,[X3] | ADD X5,X4,W2,SXTW ;
+             | STG X3,[X5]       ;
+exists (1:X1=0 /\ [tag(x)]=:blue /\ ~fault(P1,y))

--- a/herd/tests/instructions/AArch64.MTE/L01.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/L01.litmus.expected
@@ -1,0 +1,13 @@
+Test S+dmb.sytt+addrpt Allowed
+States 4
+1:X1=0; [tag(x)]=:blue;  ~Fault(P1,y);
+1:X1=0; [tag(x)]=:blue; Fault(P1,y:red,TagCheck);
+1:X1=0; [tag(x)]=:red;  ~Fault(P1,y);
+1:X1=0; [tag(x)]=:red; Fault(P1,y:red,TagCheck);
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (1:X1=0 /\ [tag(x)]=:blue /\ not (fault(P1,y)))
+Observation S+dmb.sytt+addrpt Sometimes 1 3
+Hash=e590f3a6e742d25cc38d360f8014889e
+

--- a/herd/tests/instructions/AArch64.MTE/L02.litmus
+++ b/herd/tests/instructions/AArch64.MTE/L02.litmus
@@ -1,0 +1,14 @@
+AArch64 L02
+Variant=mixed,mte,sync
+{
+int x[8]={1,2,3,4,5,6,7,8};
+0:X1=x;
+0:X2=x:red;
+}
+ P0              ;
+ STZ2G  X2,[X1]  ;
+ MOV W0,#9       ;
+ STR W0,[X2]     ;
+ STR W0,[X2,#28] ; 
+forall x={9,0,0,0,0,0,0,9}
+

--- a/herd/tests/instructions/AArch64.MTE/L02.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/L02.litmus.expected
@@ -1,0 +1,10 @@
+Test L02 Required
+States 1
+x={9,0,0,0,0,0,0,9};
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (x={9,0,0,0,0,0,0,9})
+Observation L02 Always 1 0
+Hash=ac1c69c0bcf4aad96545b4f61a6e329b
+

--- a/herd/tests/instructions/AArch64.MTE/L03.litmus
+++ b/herd/tests/instructions/AArch64.MTE/L03.litmus
@@ -1,0 +1,15 @@
+AArch64 L03
+(* Non-mixed test: STZG store zero in x,
+   neglecting overflow, to change? *)
+Variant=mte,sync
+{
+int x=1;
+0:X1=x:green;
+0:X2=x:red;
+}
+ P0             ;
+ MOV W0,#2      ;
+ STZG  X2,[X1]  ;
+ LDR W0,[X2]    ;
+forall 0:X0=0
+

--- a/herd/tests/instructions/AArch64.MTE/L03.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/L03.litmus.expected
@@ -1,0 +1,10 @@
+Test L03 Required
+States 1
+0:X0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=0)
+Observation L03 Always 1 0
+Hash=7ad8343d0a87a8209e1c5027acdd499a
+

--- a/herd/tests/instructions/AArch64.MTE/L04.litmus
+++ b/herd/tests/instructions/AArch64.MTE/L04.litmus
@@ -1,0 +1,17 @@
+AArch64 L04
+(* Check that tag addresses are based upon physical addresses *)
+Variant=vmsa,memtag,sync
+{
+[PTE(x)]=(oa:PA(y),attrs:(TaggedNormal));
+(* Notice, x is virtual notation, but initialise tag(PA(x)) *)
+[tag(x)]=:red;
+(* Idem, x is virtual, but initialise PA(x) *)
+int x=1;
+int y=2;
+0:X1=x;
+}
+
+  P0         ;
+ LDR W0,[X1] ;
+(* Reading PA(y) with the color of PA(y) *)
+forall 0:X0=2;

--- a/herd/tests/instructions/AArch64.MTE/L04.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/L04.litmus.expected
@@ -1,0 +1,11 @@
+Test L04 Required
+States 1
+0:X0=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition forall (0:X0=2)
+Observation L04 Always 1 0
+Hash=a8c2d90712b54d8c6d4bec4489b05034
+

--- a/herd/tests/instructions/AArch64.MTE/L05.litmus
+++ b/herd/tests/instructions/AArch64.MTE/L05.litmus
@@ -1,0 +1,12 @@
+AArch64 L05
+{
+int t[8] = {1,2,3,4,5,6,7,8};
+0:X1=t:green;
+0:X3=t:red;
+}
+  P0             ;
+ STZG X3,[X1]    ;
+ LDR W0,[X3,#12] ;
+ LDR W2,[X1,#16] ;
+locations [t;]
+forall 0:X0=0 /\ 0:X2=5

--- a/herd/tests/instructions/AArch64.MTE/L05.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.MTE/L05.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.MTE/L05.litmus": Array location and STZG instruction without -variant mixed (User error)

--- a/herd/tests/instructions/AArch64.MTE/L06.litmus
+++ b/herd/tests/instructions/AArch64.MTE/L06.litmus
@@ -1,0 +1,13 @@
+AArch64 L06
+Variant=mixed
+{
+int t[8] = {1,2,3,4,5,6,7,8};
+0:X1=t:green;
+0:X3=t:red;
+}
+  P0             ;
+ STZG X3,[X1]    ;
+ LDR W0,[X3,#12] ;
+ LDR W2,[X1,#16] ;
+locations [t;]
+forall 0:X0=0 /\ 0:X2=5

--- a/herd/tests/instructions/AArch64.MTE/L06.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/L06.litmus.expected
@@ -1,0 +1,10 @@
+Test L06 Required
+States 1
+0:X0=0; 0:X2=5; t={0,0,0,0,5,6,7,8};
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=0 /\ 0:X2=5)
+Observation L06 Always 1 0
+Hash=b92fca2f16c4739549786c669e41edc0
+

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -41,7 +41,6 @@ type t =
   | DontCheckMixed
 (* Tags *)
   | MemTag
-  | MTE
   | TagPrecise of Precision.t (* Fault handling *)
   | TooFar
   | Morello
@@ -189,7 +188,6 @@ let pp = function
   | DontCheckMixed -> "DontCheckMixed"
   | NotWeakPredicated -> "NotWeakPredicated"
   | MemTag -> "memtag"
-  | MTE -> "memtag"
   | TagPrecise p -> Precision.pp p
   | TooFar -> "TooFar"
   | Morello -> "Morello"

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -39,7 +39,6 @@ type t =
  (* Do not check (and reject early) mixed size tests in non-mixed-size mode *)
   | DontCheckMixed
   | MemTag           (* Memory Tagging, synonym of MTE *)
-  | MTE              (* Memory Tagging *)
   | TagPrecise of Precision.t (* Fault handling *)
   | TooFar         (* Do not discard candidates with TooFar events *)
   | Morello

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -558,6 +558,11 @@ include Arch.MakeArch(struct
         conv_reg r2 >> fun r2 ->
         conv_idx idx >! fun idx ->
         I_STZG (r1,r2,idx)
+    | I_STZ2G (r1,r2,idx) ->
+        conv_reg r1 >> fun r1 ->
+        conv_reg r2 >> fun r2 ->
+        conv_idx idx >! fun idx ->
+        I_STZ2G (r1,r2,idx)
     | I_LDG (r1,r2,k) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -329,6 +329,7 @@ match name with
 (* Memory Tagging *)
 | "stg"|"STG" -> STG
 | "stzg"|"STZG" -> STZG
+| "stz2g"|"STZ2G" -> STZ2G
 | "ldg"|"LDG" -> LDG
 (* Operations *)
 | "ubfm"|"UBFM" -> UBFM

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -123,7 +123,7 @@ let check_op3 op e =
 %token <AArch64Base.sysreg> SYSREG
 %token MRS MSR TST RBIT ABS
 %token REV16 REV32 REV REV64
-%token STG STZG LDG
+%token STG STZG STZ2G LDG
 %token ALIGND ALIGNU BUILD CHKEQ CHKSLD CHKTGD CLRTAG CPY CPYTYPE CPYVALUE CSEAL
 %token LDCT SEAL STCT UNSEAL
 %type <MiscParser.proc list * (AArch64Base.parsedPseudo) list list * MiscParser.extra_data> main
@@ -872,6 +872,11 @@ instr:
     {
       let r,idx = $4 in
       I_STZG ($2,r,idx)
+    }
+| STZ2G xreg COMMA mem_idx
+    {
+      let r,idx = $4 in
+      I_STZ2G ($2,r,idx)
     }
 | LDG xreg COMMA LBRK xreg k0 RBRK
    { I_LDG ($2,$5,$6) }

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -42,12 +42,24 @@ type syskind =
   | PTE  (* Page table entry *)
   | PTE2 (* Page table entry of page table entry (non-writable) *)
   | TLB  (* TLB key *)
-  | TAG  (* Tag for MTE *)
+
+(* 
+ * Tag location are based upon physical or virtual addresses.
+ * In effect the two kinds of tag locations cannot co-exists,
+ * as teh formet is for VMSA mode and the latter for
+ * ordinary model. However it is more convenient to carry
+ * the physsical or virtual status in the location itself.
+ *)
+
+type tagkind =
+  | PHY
+  | VIR
 
 type symbol =
   | Virtual of symbolic_data
   | Physical of string * int       (* symbol, index *)
-  | System of (syskind * string)   (* System memory *)
+  | TagAddr of tagkind * string * int
+  | System of syskind * string     (* System memory *)
 
 val get_index : symbol -> int option
 val pp_symbol_old : symbol -> string

--- a/lib/machSize.ml
+++ b/lib/machSize.ml
@@ -209,3 +209,11 @@ type lr_sc =
   | Ld of sz
   | St
   | No
+
+(* MTE granule *)
+
+let granule = S128
+
+let granule_nbytes = nbytes granule
+
+let granule_align x = (x / granule_nbytes) * granule_nbytes

--- a/lib/machSize.mli
+++ b/lib/machSize.mli
@@ -60,3 +60,9 @@ type lr_sc =
   | Ld of sz
   | St
   | No
+
+(* MTE granule *)
+
+val granule : sz
+val granule_nbytes : int
+val granule_align : int -> int

--- a/lib/pseudo.ml
+++ b/lib/pseudo.ml
@@ -52,6 +52,7 @@ module type S = sig
 
 (* Fold over instructions in code *)
   val fold_pseudo_code : ('a -> 'b -> 'a ) -> 'a -> 'b kpseudo list -> 'a
+  val exists_pseudo_code : ('ins -> bool) -> 'ins kpseudo list -> bool
 
 (* Fold/Map over labels *)
   val fold_labels : ('a -> Label.t -> 'a) -> 'a -> pseudo -> 'a
@@ -156,6 +157,7 @@ struct
   let pseudo_iter f ins = pseudo_fold (fun () ins -> f ins) () ins
 
   let fold_pseudo_code f = List.fold_left (pseudo_fold f)
+  let exists_pseudo_code p = List.exists (pseudo_exists p)
 
 (* Fold/Map over labels *)
 

--- a/lib/stateLexer.mll
+++ b/lib/stateLexer.mll
@@ -45,6 +45,7 @@ rule token = parse
 | '&' { AMPER }
 | ';' { SEMI }
 | ':' { COLON }
+| '+' { PLUS }
 | '[' { LBRK }
 | ']' { RBRK }
 | '('  { LPAR }
@@ -69,7 +70,7 @@ rule token = parse
 | "locations" { LOCATIONS }
 | "filter" { FILTER }
 | "fault"|"Fault" { FAULT }
-| "tag" { TOK_TAG }
+| "tag"|"TAG" { TOK_TAG }
 (* Distinguished  PteVal fields *)
 | "attrs"|"Attrs" { ATTRS }
 | "oa" { TOK_OA }

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1466,7 +1466,7 @@ module Make(V:Constant.S)(C:Config) =
          sprintf "msr %s,%s" (Misc.lowercase (pp_sysreg sr)) f in
        {empty_ins with
          memo; outputs=r; reg_env=add_type quad r;}::k
-    | I_STG _| I_STZG _|I_LDG _ ->
+    | I_STG _| I_STZG _|I_STZ2G _|I_LDG _ ->
         Warn.fatal "No litmus output for instruction %s"
           (dump_instruction ins)
     | I_ALIGND _|I_ALIGNU _|I_BUILD _|I_CHKEQ _|I_CHKSLD _|I_CHKTGD _|

--- a/tools/alpha.ml
+++ b/tools/alpha.ml
@@ -202,7 +202,7 @@ struct
     | Tag _ -> notag_value ()
     | PteVal _ -> nopte_value ()
     | Instruction _ -> noinstr_value ()
-    | Symbolic (Physical _|System ((TLB|TAG),_))
+    | Symbolic (Physical _|TagAddr _|System (TLB,_))
     | Frozen _
       -> assert false
 
@@ -220,7 +220,7 @@ struct
     | Tag _ -> notag_value ()
     | PteVal _ -> nopte_value ()
     | Instruction _ -> noinstr_value ()
-    | Frozen _|Symbolic (Physical _|System ((TLB|TAG),_))
+    | Frozen _|Symbolic (Physical _|TagAddr _|System (TLB,_))
       -> assert false
 
 


### PR DESCRIPTION
Adding the instruction revealed some shortcomings of the current MTE implementation. In particular, it is no longer realistic to assume that a complete array will never span over more than one granule, as the STZ2G instruction sets two granules.

The implementation is correct only in mixed-size mode, it is then an error to execute STZG  (resp. STZ2G)  on a memory location whose size is strictly less than one (resp. two) granules.

For instance, with the current granule size of 16 bytes, **herd** will fail on the following test:
```
AAArch64 TooSmall
Variant=mixed,mte
{
int x=1;
0:X1=x:green;
0:X2=x:red;
}
  P0           ;
 STZG X2,[X1]  ;
forall x=0
```
We have:
```
% herd7 TooSmall.litmus
Warning: File "TooSmall.litmus": Unaligned or out-of-bound access: x, 16 bytes (User error)
```

To reach granule size one has to declare an array:
```
AArch64 LargeEnough
Variant=mixed,mte
{
int64_t x[3] = {1,2,3};
0:X1=x:green;
0:X2=x:red;
}
  P0           ;
 STZG X2,[X1]  ;
forall x={0,0,3}
``` 
Now, the test is accepted,  yielding the final values of zero for `x[0]` and `x[1]`.

For backward compatibility `STZG` still operates in non-mixed mode, with the expected result of zeroing non-array locations, which is correct assuming that:
1. the size of non-array locations is less than one granule, and
2. different locations occupy different granules.

Finally, **herd** will fail, flagging an error, on tests that both have some array location and some S`TZG` instruction, regardless of whether `STZG` touches some array or not.
