### PR TITLE
[asl][typing] Typing ASL literals

### DIFF
--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -98,7 +98,7 @@ let hex_alpha = ['a'-'f' 'A'-'F']
 let hex_lit = '0' 'x' (digit | hex_alpha) ('_' | digit | hex_alpha)*
 let real_lit = digit ('_' | digit)* '.' digit ('_' | digit)*
 let alpha = ['a'-'z' 'A'-'Z']
-let string_lit = '"' [^ '"']* '"'
+let string_chars = ([^ '"' '\\'] | ('\\' ['n' 't' '"' '\\']))*
 let bits = ['0' '1' 'z' ' ']*
 let mask = ['0' '1' 'x' ' ']*
 let identifier = (alpha | '_') (alpha|digit|'_')*
@@ -110,7 +110,7 @@ rule token = parse
     | int_lit as lxm           { INT_LIT(Z.of_string lxm)         }
     | hex_lit as lxm           { INT_LIT(Z.of_string lxm)         }
     | real_lit as lxm          { REAL_LIT(Q.of_string lxm)        }
-    | '"' ([^ '"']* as lxm) '"' { STRING_LIT(lxm)                 }
+    | '"' (string_chars as lxm) '"' { STRING_LIT(lxm)             }
     | '\'' (bits as lxm) '\''  { bitvector_lit lxm                }
     | '\'' (mask as lxm) '\''  { mask_lit lxm                     }
     | '!'                      { BNOT                             }

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -98,13 +98,15 @@ let rename_ty_eqs : (AST.identifier * AST.expr) list -> AST.ty -> AST.ty
         T_Int (Some constraints) |> add_pos_from_st ty
     | _ -> ty
 
-let infer_value = function
+(* Begin Lit *)
+let annotate_literal = function
   | L_Int _ as v -> T_Int (Some [ Constraint_Exact (literal v) ])
   | L_Bool _ -> T_Bool
   | L_Real _ -> T_Real
   | L_String _ -> T_String
   | L_BitVector bv ->
       Bitvector.length bv |> expr_of_int |> t_bits_bitwidth
+(* End *)
 
 exception ConstraintMinMaxTop
 
@@ -978,8 +980,8 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     in
     let here x = add_pos_from e x in
     match e.desc with
-    (* Begin Lit *)
-    | E_Literal v -> (infer_value v |> here, e) |: TypingRule.Lit
+    (* Begin ELit *)
+    | E_Literal v -> (annotate_literal v |> here, e) |: TypingRule.ELit
     (* End *)
     (* Begin CTC *)
     | E_CTC (e', t') ->
@@ -2287,7 +2289,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     | { keyword = GDK_Constant; initial_value = Some e; ty = None; name }
       ->
         let v = reduce_constants env e in
-        let t = infer_value v |> add_pos_from e in
+        let t = annotate_literal v |> add_pos_from e in
         declare_const loc name t v env
     | {
      keyword = GDK_Constant;
@@ -2296,7 +2298,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
      name;
     } ->
         let v = reduce_constants env e in
-        let t = infer_value v |> add_pos_from e in
+        let t = annotate_literal v |> add_pos_from e in
         if Types.type_satisfies env t ty then
           declare_const loc name ty v env
         else conflict e [ ty.desc ] t

--- a/asllib/Typing.mli
+++ b/asllib/Typing.mli
@@ -25,8 +25,6 @@
     It should provide enough information to disambiguate any type-dependent
     behaviour. *)
 
-val infer_value : AST.literal -> AST.type_desc
-
 type strictness = [ `Silence | `Warn | `TypeCheck ]
 (** Possible strictness of type-checking. *)
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -74,6 +74,7 @@
 \newcommand\annotatesubprogram[1]{\texttt{annotate\_subprogram}(#1)}
 \newcommand\declaredecl[1]{\texttt{annotate\_decl}(#1)}
 \newcommand\annotatespec[1]{\texttt{annotate\_spec}(#1)}
+\newcommand\annotateliteral[1]{\texttt{annotate\_literal}(#1)}
 
 \newcommand\tenv[0]{\texttt{env}}
 \newcommand\newenv[0]{\texttt{new\_env}}
@@ -83,6 +84,7 @@
 \newcommand\va[0]{\texttt{a}}
 \newcommand\vc[0]{\texttt{c}}
 \newcommand\vf[0]{\texttt{f}}
+\newcommand\vl[0]{\texttt{l}}
 \newcommand\vp[0]{\texttt{p}}
 \newcommand\vo[0]{\texttt{o}}
 \newcommand\vx[0]{\texttt{x}}
@@ -929,7 +931,7 @@ we use the notation $\emptylist_N$ to name the parameter.
   This is related to \identd{BMGM}, \identr{PHRL}, \identr{PZNR},
   \identr{RLQP}, \identr{LYDS}, \identr{SVDJ}, \identi{WLPJ}, \identr{FWMM},
   \identi{WPWL}, \identi{CDVY}, \identi{KFCR}, \identi{BBQR}, \identr{ZWGH},
-  \identr{DKGQ}, \identr{DHZT}, \identi{HSWR}.
+  \identr{DKGQ}, \identr{DHZT}, \identi{HSWR}, \identd{YZBQ}.
 
 \section{Constrained Types}
 
@@ -1062,7 +1064,7 @@ ROMAN: This rule doesn't exist in the code. Also, it is redundant, since it just
 \section{TypingRule.StructuralSubtypeSatisfaction\label{sec:TypingRule.SubtypeSatisfaction}}
 
 \subsection{Prose}
-\texttt{t} structurally-subtype-satisfies \texttt{s} in environment \tenv, if one of the following applies:
+Type \texttt{t} structurally-subtype-satisfies type \texttt{s} in environment \tenv, if one of the following applies:
   \begin{itemize}
   \item All of the following apply:
     \begin{itemize}
@@ -2175,7 +2177,7 @@ an environment \tenv.  Formally, the result of annotating the expression
 \texttt{e} in \tenv\ is either the pair \texttt{t, new\_e}, where \texttt{t} is a type and
 \texttt{new\_e} is a rewritten expression, or an error, and one of the following applies:
 \begin{itemize}
-\item TypingRule.Lit (see Section~\ref{sec:TypingRule.Lit});
+\item TypingRule.ELit (see Section~\ref{sec:TypingRule.ELit});
 \item TypingRule.ELocalVarConstant (see Section~\ref{sec:TypingRule.ELocalVarConstant})
 \item TypingRule.ELocalVar (see Section~\ref{sec:TypingRule.ELocalVar})
 \item TypingRule.EGlobalVarConstant (see Section~\ref{sec:TypingRule.EGlobalVarConstant})
@@ -2212,37 +2214,71 @@ The annotation rewrites the input expression in the following cases, making the 
   \item Slicing expressions that correspond to array accesses are replaced with array access expressions.
 \end{itemize}
 
+
 \section{TypingRule.Lit \label{sec:TypingRule.Lit}}
+
+Annotating literals is done via the function $\annotateliteral{\cdot}$,
+which we use in this chapter as well as in subsequent chapters.
+
+\subsection{Prose}
+The result of annotating a literal expression \texttt{l} is \texttt{t} and one of the following apply:
+\begin{itemize}
+\item \texttt{l} is an integer literal \texttt{n} and \texttt{t} is the well-constrained integer type, constraining
+its set to the single value \texttt{n};
+\item \texttt{l} is a Boolean literal and \texttt{t} is the Boolean type;
+\item \texttt{l} is a real literal and \texttt{t} is the real type;
+\item \texttt{l} is a string literal and \texttt{t} is the string type; 
+\item \texttt{l} is a bitvector literal of length \texttt{n} and \texttt{t} is the bitvector type of fixed width \texttt{n}.
+\end{itemize}
+
+\subsection{Example: TypingRule.Lit.asl}
+In the following example, we show several literals and their corresponding types in comments:
+\VerbatimInput{../tests/ASLTypingReference.t/TypingRule.Lit.asl}
+
+\subsection{Code}
+\VerbatimInput[firstline=\LitBegin, lastline=\LitEnd]{../Typing.ml}
+
+\begin{emptyformal}
+\subsection{Formally}
+
+\begin{mathpar}
+\inferrule{}{\annotateliteral{\Elit{n}}= \TInt(\langle[\texttt{Constraint\_Exact}(\Elit{n})]\rangle)}
+\and
+\inferrule{}{\annotateliteral{\eliteral{\lbool(\Ignore)}}= \TBool}
+\and
+\inferrule{}{\annotateliteral{\eliteral{\lreal(\Ignore)}}= \TReal}
+\and
+\inferrule{}{\annotateliteral{\eliteral{\lstring(\Ignore)}}= \TString}
+\and
+\inferrule{\vl = \eliteral{\lbitvector(b_{1..n})}}
+{\annotateliteral{\vl}= \TBits(\texttt{Bitwidth\_SingleExpr}(\Elit{n}), \emptylist)}
+\end{mathpar}
+
+\end{emptyformal}
+
+\section{TypingRule.ELit \label{sec:TypingRule.ELit}}
 
   \subsection{Prose}
   The result of annotating the expression \texttt{e} in \texttt{env} is
 \texttt{t,new\_e} and all of the following apply:
   \begin{itemize}
   \item \texttt{e} is a literal expression \texttt{v};
-  \item \texttt{t} is the type of \texttt{v} determined by the syntactic label of \texttt{v};
+  \item \texttt{t} is the type of the literal \texttt{v};
   \item \texttt{new\_e} is \texttt{e}.
   \end{itemize}
 
   \subsection{Example}
 
   \subsection{Code}
-  \VerbatimInput[firstline=\LitBegin, lastline=\LitEnd]{../Typing.ml}
+  \VerbatimInput[firstline=\ELitBegin, lastline=\ELitEnd]{../Typing.ml}
 
 \begin{emptyformal}
   \subsection{Formally}
-  
 \begin{mathpar}
-\inferrule{\ve = \Elit{n}}{\annotateexpr{\tenv, \ve}= (\TInt(\langle[\texttt{Constraint\_Exact}(\Elit{n})]\rangle), \ve)}
-\and
-\inferrule{\ve = \eliteral{\lbool(\Ignore)}}{\annotateexpr{\tenv, \ve}= (\TBool, \ve)}
-\and
-\inferrule{\ve = \eliteral{\lreal(\Ignore)}}{\annotateexpr{\tenv, \ve}= (\TReal, \ve)}
-\and
-\inferrule{\ve = \eliteral{\lstring(\Ignore)}}{\annotateexpr{\tenv, \ve}= (\TString, \ve)}
-\and
-\inferrule{\ve = \eliteral{\lbitvector(b_{1..n})}}
-{\annotateexpr{\tenv, \ve}= (\TBits(\texttt{Bitwidth\_SingleExpr}(\Elit{n}), \emptylist), \ve)}
+\inferrule{\ve \in \literal \\ \vt = \annotateliteral{\ve} \\ \newe = \tenv}
+{\annotateexpr{\tenv, \ve} = (\vt, \newe)}
 \end{mathpar}
+
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
@@ -5703,7 +5739,7 @@ and then use them to annotate a subprogram declaration.
   \texttt{new\_env} = (G'', L^\tenv)
 }
 {
-  \declaredecl(\tenv, \texttt{func\_sig}) = G''
+  \declaredecl{\tenv, \texttt{func\_sig}} = G''
 }
 \end{mathpar}
 \end{emptyformal}
@@ -5778,11 +5814,12 @@ in \texttt{new\_env} and one of the following applies:
 \begin{emptyformal}
   \subsection{Formally}
 \newcommand\gsd[0]{\texttt{gsd}}
+
 \begin{mathpar}
   \inferrule[Case 1]{
     \gsd = \{\textsf{keyword} : \texttt{GDK\_Constant}, \textsf{initial\_value} : \langle \ve \rangle, \textsf{ty} : \langle\rangle, \textsf{name}:\name \}\\
     \vv = \texttt{reduce\_constants}(\tenv, \ve)\\
-    \vt = \texttt{type\_of\_literal}(\vv)\\
+    \vt = \annotateliteral{\vv}\\
     \newenv = \texttt{declare\_const}(\tenv, \name, \vt, \vv)
   }
   { \declaredecl{\tenv, \gsd} = \newenv }
@@ -5790,7 +5827,7 @@ in \texttt{new\_env} and one of the following applies:
   \inferrule[Case 2]{
     \gsd = \{\textsf{keyword} : \texttt{GDK\_Constant}, \textsf{initial\_value} : \langle \ve \rangle, \textsf{ty} : \langle\tty\rangle, \textsf{name}:\name \}\\
     \vv = \texttt{reduce\_constants}(\tenv, \ve)\\
-    \vt = \texttt{type\_of\_literal}(\vv)\\
+    \vt = \annotateliteral{\vv}\\
     \typesat(\tenv, \vt, \tty)\\
     \newenv = \texttt{declare\_const}(\tenv, \name, \tty, \vv)
   }

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -10,8 +10,8 @@
 (* This material covers both ASLv0 (viz, the existing ASL pseudocode language *)
 (* which appears in the Arm Architecture Reference Manual) and ASLv1, a new,  *)
 (* experimental, and as yet unreleased version of ASL.                        *)
-(* This material is work in progress, more precisely at pre-Alpha quality as  *)
-(* per Arm’s quality standards.                                               *)
+(* This material is work in progress, more precisely at pre-Alpha quaElity as  *)
+(* per Arm’s quaElity standards.                                               *)
 (* In particular, this means that it would be premature to base any           *)
 (* production tool development on this material.                              *)
 (* However, any feedback, question, query and feature request would be most   *)
@@ -320,7 +320,7 @@ module TypingRule = struct
     | LowestCommonAncestor
     | CheckUnop
     | CheckBinop
-    | Lit
+    | ELit
     | CTC
     | ELocalVarConstant
     | ELocalVar
@@ -457,7 +457,7 @@ module TypingRule = struct
     | CheckUnop -> "CheckUnop"
     | CheckBinop -> "CheckBinop"
     | LowestCommonAncestor -> "LowestCommonAncestor"
-    | Lit -> "Lit"
+    | ELit -> "ELit"
     | CTC -> "CTC"
     | ELocalVarConstant -> "ELocalVarConstant"
     | ELocalVar -> "ELocalVar"
@@ -597,7 +597,7 @@ module TypingRule = struct
       CheckUnop;
       CheckBinop;
       LowestCommonAncestor;
-      Lit;
+      ELit;
       CTC;
       ELocalVarConstant;
       ELocalVar;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.Lit.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.Lit.asl
@@ -1,0 +1,16 @@
+func main () => integer
+begin
+  var n1 = 5; // type: integer{5}
+  var n2 = 1_000__000; // type integer(1000000)
+  var n4 = 0xa_b_c_d_e_f__A__B__C__D__E__F__0___12345567890;
+           // type integer(53170898287292728730499578000)
+  var btrue = TRUE; // type: boolean
+  var bfalse = FALSE; // type: boolean
+  var rzero = 1234567890.0123456789; // type: real(1234567890.0123456789)
+  var s1 = "hello\\world \n\t \"here I am \""; // type: string
+  // var s1 = "hello\\world \n\t \"here I am \""; // type: string
+  var s2 = ""; // type: string
+  var bv1 = '11 01'; // type: bits(4)
+  var bv2 = ''; // type: bits(0)
+  return 0;
+end

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -18,3 +18,4 @@ ASL Typing Reference:
   [1]
 //  $ aslref TypingRule.EConcatUnresolvableToInteger.asl
   $ aslref TypingRule.CheckBinOp.asl
+  $ aslref TypingRule.Lit.asl


### PR DESCRIPTION
Separated the annotation of literals from annotation expressions, since the first is reused in other chapters.
Fixed the lexer for strings.