### PR TITLE
[herd] Write a label to LR (X30) when it is possible

### DIFF
--- a/herd/branch.ml
+++ b/herd/branch.ml
@@ -40,7 +40,7 @@ module type S = sig
     (* Stop now *)
     | Exit
     (* Raise Fault *)
-    | Fault
+    | Fault of bds
     (* Return from Fault Handler *)
     | FaultRet of tgt
 
@@ -82,7 +82,7 @@ module Make(M:Monad.S) = struct
     (* Stop now *)
     | Exit
     (* Raise Fault *)
-    | Fault
+    | Fault of bds
     (* Return from Fault Handler *)
     | FaultRet of tgt
 

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -521,7 +521,8 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
             | Ld sz -> Some sz in
           let env =
             match branch with
-            | S.B.Next bds|S.B.Jump (_,bds)|S.B.IndirectJump (_,_,bds)  ->
+            | S.B.Next bds|S.B.Jump (_,bds)|S.B.IndirectJump (_,_,bds)
+            | B.Fault bds ->
                 List.fold_right
                   (fun (r,v) -> A.set_reg r v)
                   bds env
@@ -579,7 +580,7 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
           add_code re_exec fetch_proc proc env seen nexts
       | S.B.Jump (tgt,_) ->
           add_tgt re_exec true proc env seen addr tgt
-      | S.B.Fault ->
+      | S.B.Fault _ ->
           add_fault re_exec inst fetch_proc proc env seen addr nexts
       | S.B.FaultRet tgt ->
           add_tgt false true proc env seen addr tgt

--- a/herd/tests/instructions/AArch64.kvm/A018.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A018.litmus
@@ -1,0 +1,12 @@
+AArch64 A018
+{
+ [PTE(x)]=(valid:0);
+ [x]=1;
+ 0:X1=x;
+ 0:X2=(valid:1, oa:PA(x)); 0:X3=PTE(x);
+}
+ P0          | P0.F        ;
+L0:          | STR X2,[X3] ;
+ LDR W0,[X1] | DSB ISHST   ;
+             | ERET        ;
+forall(0:X0=1)

--- a/herd/tests/instructions/AArch64.kvm/A018.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A018.litmus.expected
@@ -1,0 +1,11 @@
+Test A018 Required
+States 1
+0:X0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Assuming-common-inner-shareable-domain
+Condition forall (0:X0=1)
+Observation A018 Always 1 0
+Hash=218f088f0c448c84eeeb7c12fcb86c43
+

--- a/herd/tests/instructions/AArch64.self/A017.litmus
+++ b/herd/tests/instructions/AArch64.self/A017.litmus
@@ -1,0 +1,13 @@
+AArch64 A017
+Stable=X30
+{
+ (* necessary to generate an initial write for P0:L1 *)
+ 0:X1=P0:L1;
+}
+ P0           ;
+ BL L0        ;
+L1:           ;
+ NOP          ;
+L0:           ;
+ LDR W0,[X30] ;
+forall(0:X0=instr:"NOP")

--- a/herd/tests/instructions/AArch64.self/A017.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/A017.litmus.expected
@@ -1,0 +1,10 @@
+Test A017 Required
+States 1
+0:X0=NOP;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=NOP)
+Observation A017 Always 1 0
+Hash=46b8ce018c9628c159332ad9f5900cf9
+

--- a/herd/tests/instructions/AArch64/A257.litmus
+++ b/herd/tests/instructions/AArch64/A257.litmus
@@ -1,0 +1,9 @@
+AArch64 A257
+Stable=X30
+{
+}
+ P0     ;
+ BL L0  ;
+L0:     ;
+locations[0:X30;]
+

--- a/herd/tests/instructions/AArch64/A257.litmus.expected
+++ b/herd/tests/instructions/AArch64/A257.litmus.expected
@@ -1,0 +1,10 @@
+Test A257 Required
+States 1
+0:X30=0:L0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation A257 Always 1 0
+Hash=acdb36c81923f38d3d34a02996cbc81c
+


### PR DESCRIPTION
In sequences where the label is know, rather than setting the LR with an internal address we use the label. This means that in certain cases (-variant=ifetch) we can use it to address the instruction in that label.