### PR TITLE
[all] Split precision into MTE precision and Fault handling

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1029,13 +1029,12 @@ module Make
       let lift_fault_memtag mfault mm dir ii =
         if has_handler ii then
           fun ma ->
-            M.bind_ctrldata ma (fun _ -> mfault >>| set_elr_el1 ii) >>!
-            B.Fault dir
+            M.bind_ctrldata ma (fun _ -> mfault >>| set_elr_el1 ii) >>! B.Fault
         else
           let open Precision in
           match C.mte_precision,dir with
           | (Synchronous,_)|(Asymmetric,(Dir.R)) ->
-             fun ma ->  ma >>*= (fun _ -> mfault >>| set_elr_el1 ii) >>! B.Fault dir
+             fun ma ->  ma >>*= (fun _ -> mfault >>| set_elr_el1 ii) >>! B.Fault
           | (Asynchronous,_)|(Asymmetric,Dir.W) ->
              fun ma ->
              let set_tfsr = write_reg AArch64Base.tfsr V.one ii in
@@ -1059,11 +1058,11 @@ module Make
       let lift_kvm dir updatedb is_tag mop ma an ii mphy =
         let mfault ma a ft =
           if is_tag then
-            insert_commit_to_fault ma (fun _ -> mzero) (Some "Tag") ii >>! B.Fault dir
+            insert_commit_to_fault ma (fun _ -> mzero) (Some "Tag") ii >>! B.Fault
           else
             insert_commit_to_fault ma
               (fun _ -> mk_fault (Some a) dir an ii ft None) None ii >>|
-            set_elr_el1 ii >>! B.Fault dir in
+            set_elr_el1 ii >>! B.Fault in
         let maccess a ma =
           check_ptw ii.AArch64.proc dir updatedb is_tag a ma an ii
             ((let m = mop Access.PTE ma in
@@ -1090,7 +1089,7 @@ module Make
               (fun a_phy ma ->
                  delayed_check_tags a_virt (Some a_phy) ma ii
                    (fun ma -> ma >>= M.ignore >>= B.next1T)
-                   (fun ma -> ma >>! B.Fault dir)) in
+                   (fun ma -> ma >>! B.Fault)) in
           let cond_check_tag ma a_virt =
             (* Only read and check the tag if the attrs of the PTE
                allow it *)
@@ -1107,7 +1106,7 @@ module Make
                let ma = M.para_bind_output_right mtag_op (fun _ -> ma) in
                match tag_op with
                | B.Next _ -> mphy ma a_virt
-               | B.Fault _ ->
+               | B.Fault ->
                  let ft = Some FaultType.AArch64.TagCheck in
                  let mm = fun ma -> mphy ma a_virt in
                  let fault = lift_fault_memtag
@@ -2311,11 +2310,11 @@ module Make
                        (function
                          | B.Next _ ->
                            fun mstz -> mstz >>| do_stg >>= M.ignore >>= B.next1T
-                         | B.Fault _ ->
+                         | B.Fault ->
                            fun mstz ->  mstz >>| mstg >>= M.ignore >>= B.next1T
                          | _ ->
                            Warn.fatal "Unexpected return value do_stg")
-                 | B.Fault _ ->
+                 | B.Fault ->
                    fun mstg -> mstg
                  | _ -> Warn.fatal "Unexpected return value do_stz"))
             (M.delay_kont "do_stz" do_stz
@@ -2323,7 +2322,7 @@ module Make
                  | B.Next _ ->
                    (* Force the solver to drop this, already handled above *)
                    fun _ -> M.assertT V.zero B.nextT
-                 | B.Fault _ ->
+                 | B.Fault ->
                    fun mstz -> mstz
                  | _ -> Warn.fatal "Unexpected return value do_stz"))
         else
@@ -3039,7 +3038,7 @@ module Make
            let (>>!) = M.(>>!) in
            let ft = Some FaultType.AArch64.UndefinedInstruction in
            let m_fault = mk_fault None Dir.R Annot.N ii ft None in
-           m_fault >>| set_elr_el1 ii >>! B.Fault Dir.R
+           m_fault >>| set_elr_el1 ii >>! B.Fault
 (*  Cannot handle *)
         (* | I_BL _|I_BLR _|I_BR _|I_RET _ *)
         | (I_STG _|I_STZG _|I_STZ2G _) as i ->
@@ -3104,7 +3103,7 @@ module Make
                           (Some "Invalid") in
                       commit_pred ii
                         >>*= fun () -> m_fault >>| set_elr_el1 ii
-                          >>! B.Fault Dir.R
+                          >>! B.Fault
                     end
         else do_build_semantics test inst ii
 

--- a/herd/branch.ml
+++ b/herd/branch.ml
@@ -40,7 +40,7 @@ module type S = sig
     (* Stop now *)
     | Exit
     (* Raise Fault *)
-    | Fault of Dir.dirn
+    | Fault
     (* Return from Fault Handler *)
     | FaultRet of tgt
 
@@ -82,7 +82,7 @@ module Make(M:Monad.S) = struct
     (* Stop now *)
     | Exit
     (* Raise Fault *)
-    | Fault of Dir.dirn
+    | Fault
     (* Return from Fault Handler *)
     | FaultRet of tgt
 

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -473,7 +473,8 @@ let () =
       | Some (Model.Generic _|Model.File _)|None -> OptAce.Iico
       | Some (Model.CAV12 _) -> OptAce.False
     let variant = !variant
-    let precision = !precision
+    let fault_handling = !fault_handling
+    let mte_precision = !mte_precision
     let byte = !byte
     let endian = !endian
     let outputdir = !outputdir

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -579,7 +579,7 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
           add_code re_exec fetch_proc proc env seen nexts
       | S.B.Jump (tgt,_) ->
           add_tgt re_exec true proc env seen addr tgt
-      | S.B.Fault _ ->
+      | S.B.Fault ->
           add_fault re_exec inst fetch_proc proc env seen addr nexts
       | S.B.FaultRet tgt ->
           add_tgt false true proc env seen addr tgt

--- a/herd/opts.ml
+++ b/herd/opts.ml
@@ -45,11 +45,14 @@ let speedcheck = ref Speed.False
 let archcheck = ref true
 let optace = ref None
 let variant = ref (fun _ -> false)
-let precision = ref Precision.default
+let fault_handling = ref Fault.Handling.default
+let mte_precision = ref Precision.default
 
 module OptS = struct
   include Variant
-  let setnow tag = set_precision precision tag
+  let setnow tag =
+    set_fault_handling fault_handling tag ||
+    set_mte_precision mte_precision tag
 end
 
 let byte = ref MachSize.Tag.Auto

--- a/herd/opts.mli
+++ b/herd/opts.mli
@@ -42,7 +42,8 @@ val speedcheck : Speed.t ref
 val optace : OptAce.t option ref
 val archcheck : bool ref
 val variant : (Variant.t -> bool) ref
-val precision : Precision.t ref
+val fault_handling : Fault.Handling.t ref
+val mte_precision : Precision.t ref
 module OptS : ParseTag.OptS with type t = Variant.t
 val byte : MachSize.Tag.t ref
 val endian : Endian.t option ref

--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -41,14 +41,17 @@ module Top (TopConf:RunTest.Config) = struct
         TestVariant.Make
           (struct
             module Opt = Variant
-            let set_precision = Variant.set_precision
             let info = splitted.Splitter.info
-            let precision = TopConf.precision
             let variant = TopConf.variant
+            let mte_precision = TopConf.mte_precision
+            let set_mte_precision = Variant.set_mte_precision
+            let fault_handling = TopConf.fault_handling
+            let set_fault_handling = Variant.set_fault_handling
           end)
       (* Override *)
       include TopConf
-      let precision = TestConf.precision
+      let fault_handling = TestConf.fault_handling
+      let mte_precision = TestConf.mte_precision
       let variant = TestConf.variant
     end in
     if Conf.check_name tname then begin
@@ -69,7 +72,7 @@ module Top (TopConf:RunTest.Config) = struct
                   (fun _ -> false), (fun _ -> false)
                | Some cache_type ->
                   cache_type.dic, cache_type.idc in
-         Misc.(|||) Conf.variant (function 
+         Misc.(|||) Conf.variant (function
             | Variant.DIC -> dic_pred 0
             | Variant.IDC -> idc_pred 0
             | _ -> false) in

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -21,7 +21,8 @@ module type Config = sig
   val verbose : int
   val optace : OptAce.t
   val debug : Debug_herd.t
-  val precision : Precision.t
+  val fault_handling : Fault.Handling.t
+  val mte_precision : Precision.t
   val variant : Variant.t -> bool
   val endian : Endian.t option
   val unroll : int option

--- a/herd/tests/diycross/AArch64.MTE/MTE.cfg
+++ b/herd/tests/diycross/AArch64.MTE/MTE.cfg
@@ -1,4 +1,4 @@
-variant memtag
+variant memtag,async
 #All tests should be allowed when model is relaxed.
 skipchecks external
 graph cluster
@@ -23,4 +23,3 @@ unshow dd,intrinsic
 labelbox true
 doshow fr,co,rmw
 unshow dmb.sy,dmb.st,dmb.ld,ca,dsb.sy,isb
-

--- a/herd/tests/instructions/AArch64.MTE/B005.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B005.litmus
@@ -1,0 +1,9 @@
+AArch64 B005
+Variant=mte,sync,faultToNext
+{
+ 0:X1=x:red;
+}
+ P0          ;
+ LDR W0,[X1] ;
+ MOV W2,#1   ;
+forall(0:X2=1)

--- a/herd/tests/instructions/AArch64.MTE/B005.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B005.litmus.expected
@@ -1,0 +1,10 @@
+Test B005 Required
+States 1
+0:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=1)
+Observation B005 Always 1 0
+Hash=92ce7c8ed051bc37bffd09f2abe7bb5d
+

--- a/herd/tests/instructions/AArch64.MTE/B006.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B006.litmus
@@ -1,0 +1,10 @@
+AArch64 B006
+Variant=mte,sync,handled
+{
+ 0:X1=x:red;
+ 1:X0=x:red; 1:X1=x;
+}
+ P0          | P1          ;
+ LDR W0,[X1] | STG X0,[X1] ;
+ MOV W2,#1   |             ;
+forall(0:X2=1)

--- a/herd/tests/instructions/AArch64.MTE/B006.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B006.litmus.expected
@@ -1,0 +1,10 @@
+Test B006 Required
+States 1
+0:X2=1;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (0:X2=1)
+Observation B006 Always 2 0
+Hash=bb89dcef73943ae09ecb778349f34a6b
+

--- a/herd/tests/instructions/AArch64.MTE/B007.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B007.litmus
@@ -1,0 +1,11 @@
+AArch64 B007
+Variant=mte,asym,fatal
+{
+ 0:X1=x:red;
+ 1:X1=x:red;
+}
+ P0          |  P1         ;
+ LDR W0,[X1] | MOV W0,#2   ;
+ MOV W2,#1   | STR W0,[X1] ;
+             | MOV W2,#1   ;
+forall(0:X2=0 /\ 1:X2=1)

--- a/herd/tests/instructions/AArch64.MTE/B007.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B007.litmus.expected
@@ -1,0 +1,10 @@
+Test B007 Required
+States 1
+0:X2=0; 1:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=0 /\ 1:X2=1)
+Observation B007 Always 1 0
+Hash=a8f826b9b17927e1c9b398a95db3fd99
+

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -39,7 +39,8 @@ type t =
  (* Do not check (and reject early) mixed size tests in non-mixed-size mode *)
   | DontCheckMixed
   | MemTag           (* Memory Tagging, synonym of MTE *)
-  | TagPrecise of Precision.t (* Fault handling *)
+  | MTEPrecision of Precision.t (* MTE tag mismatch handling *)
+  | FaultHandling of Fault.Handling.t (* Fault handling *)
   | TooFar         (* Do not discard candidates with TooFar events *)
   | Morello
   | Neon
@@ -79,11 +80,11 @@ type t =
   | T of int
 (* ASL Processing *)
   (* In AArch64 arch, use ASL to interprete AArch64 instructions when possible. *)
-  | ASL 
+  | ASL
   (* While interpreting ASL litmus test, include AArch64 shared pseudocode. *)
-  | ASL_AArch64 
+  | ASL_AArch64
   (* When using aarch ASL, use ASL version v0 or v1 *)
-  | ASLVersion of [ `ASLv0 | `ASLv1 ] 
+  | ASLVersion of [ `ASLv0 | `ASLv1 ]
 (* ASL Typing control *)
   | ASLType of [`Warn|`Silence|`TypeCheck]
 (* Signed Int128 types *)
@@ -107,4 +108,5 @@ val get_default :  Archs.t -> t -> bool
 (* Get value for switchable variant *)
 val get_switch : Archs.t -> t -> (t -> bool) -> bool
 
-val set_precision : Precision.t ref -> t -> bool
+val set_mte_precision : Precision.t ref -> t -> bool
+val set_fault_handling : Fault.Handling.t ref -> t -> bool

--- a/lib/fault.ml
+++ b/lib/fault.ml
@@ -169,3 +169,48 @@ module Make(A:I) =
             | r -> r
         end)
   end
+
+module Handling : sig
+  type t =
+    | Handled
+    | Fatal
+    | Skip
+
+  val default : t
+  val tags : string list
+  val parse : string -> t option
+  val pp : t -> string
+
+  val is_fatal : t -> bool
+  val is_skip : t -> bool
+end
+=
+struct
+  type t =
+    | Handled
+    | Fatal
+    | Skip
+
+  let default = Fatal
+
+  let tags =  ["handled"; "fatal"; "faultToNext"; ]
+
+  let parse = function
+    | "imprecise"|"handled" -> Some Handled
+    | "precise"|"fatal" -> Some Fatal
+    | "faulttonext"|"skip" -> Some Skip
+    | _ -> None
+
+  let pp = function
+    | Handled -> "handled"
+    | Fatal -> "fatal"
+    | Skip -> "faulToNext"
+
+  let is_fatal = function
+    | Fatal -> true
+    | Handled | Skip -> false
+
+  let is_skip = function
+    | Skip -> true
+    | Fatal | Handled -> false
+end

--- a/lib/fault.mli
+++ b/lib/fault.mli
@@ -63,3 +63,20 @@ module type S = sig
 end
 
 module Make : functor (A:I) -> S with type loc_global := A.arch_global and type fault_type := A.fault_type
+
+(** Reaction to faults common to litmus and herd when the test doesn't specify a fault handler *)
+module Handling : sig
+  type t =
+    | Handled      (** After a fault retry the faulting instruction *)
+    | Fatal        (** After a fault exit the execution *)
+    | Skip         (** After a fault skip the faulting instruction *)
+
+
+  val default : t
+  val tags : string list
+  val parse : string -> t option
+  val pp : t -> string
+
+  val is_fatal : t -> bool
+  val is_skip : t -> bool
+end

--- a/lib/precision.ml
+++ b/lib/precision.ml
@@ -15,33 +15,21 @@
 (****************************************************************************)
 
 type t =
-  | Handled      (* Do nothing special *)
-  | Fatal        (* Jump to end of code *)
-  | LoadsFatal   (* Only faults on loads jump to end of code, stores do nothing *)
-  | Skip         (* Skip instruction *)
+  | Synchronous
+  | Asynchronous
+  | Asymmetric
 
-let default = Handled
+let default = Synchronous
 
-let tags =  ["handled"; "fatal"; "loadsfatal"; "faultToNext"; ]
+let tags =  [ "synchronous"; "sync"; "asynchronous"; "async"; "asymmetric"; "asym" ]
 
-let parse s = match s with
-  | "imprecise"|"handled"|"asynchronous"|"async" -> Some Handled
-  | "precise"|"fatal"|"synchronous"|"sync" -> Some Fatal
-  | "loadsfatal"|"asymmetric"|"asym" -> Some LoadsFatal
-  | "faulttonext"|"skip" -> Some Skip
+let parse = function
+  | "synchronous"|"sync" -> Some Synchronous
+  | "asynchronous"|"async" -> Some Asynchronous
+  | "asymmetric"|"asym" -> Some Asymmetric
   | _ -> None
 
 let pp = function
-  | Handled -> "handled"
-  | Fatal -> "fatal"
-  | LoadsFatal -> "loadsfatal"
-  | Skip -> "faulToNext"
-
-let is_fatal = function
-  | Fatal -> true
-  | Handled|LoadsFatal|Skip -> false
-
-let is_skip = function
-  | Skip -> true
-  | Handled|Fatal|LoadsFatal -> false
-
+  | Synchronous -> "synchronous"
+  | Asynchronous -> "asynchronous"
+  | Asymmetric -> "asymmetric"

--- a/lib/precision.mli
+++ b/lib/precision.mli
@@ -14,18 +14,18 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Reaction to faults, tag common to litmus and herd *)
+(** Reaction to tag mismatches common to litmus and herd *)
 
 type t =
-  | Handled      (* Do nothing special *)
-  | Fatal        (* Jump to end of code *)
-  | LoadsFatal   (* Only faults on loads jump to end of code, stores do nothing *)
-  | Skip         (* Skip instruction *)
+  | Synchronous  (** The fault raises a synchronous exception. (MTE) *)
+  | Asynchronous (** The fault doesn't raise a synchronous exception. (MTE) *)
+  | Asymmetric
+  (** An attempt to read from a location with a mismatched tag raises
+      a synchronous exception and an attempt to write from a location
+      with a mismatched tag, records the mismatch and allows the write
+      to happen. (MTE) *)
 
 val default : t
 val tags : string list
 val parse : string -> t option
 val pp : t -> string
-
-val is_fatal : t -> bool
-val is_skip : t -> bool

--- a/lib/testVariant.ml
+++ b/lib/testVariant.ml
@@ -24,17 +24,21 @@ module
         val compare : t -> t -> int
       end
       val info : MiscParser.info
-      val precision : Precision.t
       val variant : Opt.t -> bool
-      val set_precision : Precision.t ref -> Opt.t -> bool
+      val mte_precision : Precision.t
+      val set_mte_precision : Precision.t ref -> Opt.t -> bool
+      val fault_handling : Fault.Handling.t
+      val set_fault_handling : Fault.Handling.t ref -> Opt.t -> bool
     end) : sig
       type t = Var.Opt.t
-      val precision : Precision.t
+      val mte_precision : Precision.t
+      val fault_handling : Fault.Handling.t
       val variant : Var.Opt.t -> bool
     end= struct
       type t = Var.Opt.t
 
-      let pref = ref Var.precision
+      let mte_pref = ref Var.mte_precision
+      let fault_href = ref Var.fault_handling
       and vref = ref Var.variant
 
       let () =
@@ -47,13 +51,16 @@ module
             let tags = LexSplit.strings_spaces tags in
             let module Opt = struct
               include Var.Opt
-              let setnow = Var.set_precision pref
+              let setnow t =
+                Var.set_fault_handling fault_href t ||
+                Var.set_mte_precision mte_pref t
             end in
             let module P = ParseTag.MakeS(Opt) in
             try
               List.iter (P.parse_tag_set "variant" vref) tags
             with Arg.Bad msg ->  Warn.user_error "%s" msg
 
-      let precision = !pref
+      let mte_precision = !mte_pref
+      let fault_handling = !fault_href
       let variant = !vref
     end

--- a/lib/testVariant.mli
+++ b/lib/testVariant.mli
@@ -23,12 +23,15 @@ module Make : functor
         val compare : t -> t -> int
       end
       val info : MiscParser.info
-      val precision : Precision.t
       val variant : Opt.t -> bool
-      val set_precision : Precision.t ref -> Opt.t -> bool
+      val mte_precision : Precision.t
+      val set_mte_precision : Precision.t ref -> Opt.t -> bool
+      val fault_handling : Fault.Handling.t
+      val set_fault_handling : Fault.Handling.t ref -> Opt.t -> bool
     end) ->
       sig
         type t = Var.Opt.t
-        val precision : Precision.t
+        val mte_precision : Precision.t
+        val fault_handling : Fault.Handling.t
         val variant : t -> bool
       end

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -22,7 +22,7 @@ module type Config = sig
   val asmcomment : string option
   val hexa : bool
   val mode : Mode.t
-  val precision : Precision.t
+  val precision : Fault.Handling.t
 end
 
 module Make(V:Constant.S)(C:Config) =
@@ -1267,12 +1267,12 @@ module Make(V:Constant.S)(C:Config) =
             (fun i -> i.memo = "eret")
             code
         then [] (* handler is complete *)
-        else if Precision.is_skip C.precision then
+        else if Fault.Handling.is_skip C.precision then
           [ "mrs %[tr0],elr_el1" ;
             "add %[tr0],%[tr0],#4" ;
             "msr elr_el1,%[tr0]" ;
             "eret" ]
-        else if Precision.is_fatal C.precision then
+        else if Fault.Handling.is_fatal C.precision then
           (if is_user then []
            else
              [ "adr %[tr0],0f";

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -19,7 +19,7 @@ module type Config = sig
   val timeloop : int
   val barrier : Barrier.t
   val mode : Mode.t
-  val precision : Precision.t
+  val precision : Fault.Handling.t
   val variant : Variant_litmus.t -> bool
   val driver : Driver.t
 end
@@ -29,7 +29,7 @@ module Default = struct
   let timeloop = 0
   let barrier = Barrier.UserFence
   let mode = Mode.Std
-  let precision = Precision.default
+  let precision = Fault.Handling.default
   let variant _ = false
   let driver = Driver.Shell
 end
@@ -303,7 +303,7 @@ module A.FaultType = A.FaultType)
     open Constant
 
     let do_self = O.variant Variant_litmus.Self
-    and do_precise = Precision.is_fatal O.precision
+    and do_precise = Fault.Handling.is_fatal O.precision
     let is_pte =
       let open Mode in
       match O.mode with

--- a/litmus/litmus.ml
+++ b/litmus/litmus.ml
@@ -68,7 +68,7 @@ let opts =
    begin
      let module Opt = struct
        include Variant_litmus
-       let setnow tag = set_precision precision tag
+       let setnow tag = set_fault_handling fault_handling tag
      end in
      let module P = ParseTag.MakeS(Opt) in
    P.parse "-variant" Option.variant "select a variation" end ;
@@ -305,7 +305,8 @@ let () =
           end
       | Some b -> b
       let ascall = !ascall
-      let precision = !precision
+      let fault_handling = !fault_handling
+      let mte_precision = Precision.Synchronous
       let variant = !variant
       let nocatch = false
       let crossrun = match !mode,!crossrun with

--- a/litmus/option.ml
+++ b/litmus/option.ml
@@ -170,7 +170,7 @@ let morearch = ref MoreArch.No
 let carch = ref `Unknown
 let mode = ref Mode.Std
 let usearch = ref UseArch.Trad
-let precision = ref Precision.default
+let fault_handling = ref Fault.Handling.default
 let variant = ref (fun _ -> false)
 
 (* Arch dependent options *)

--- a/litmus/option.mli
+++ b/litmus/option.mli
@@ -118,7 +118,7 @@ val cacheflush : bool ref
 val carch : Archs.System.t ref
 val mode : Mode.t ref
 val usearch : UseArch.t ref
-val precision : Precision.t ref
+val fault_handling : Fault.Handling.t ref
 val variant : (Variant_litmus.t -> bool) ref
 
 (* Arch dependent option *)

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -43,7 +43,7 @@ module type Config = sig
   val cacheflush : bool
   val exit_cond : bool
   include DumpParams.Config
-  val precision : Precision.t
+  val precision : Fault.Handling.t
   val variant : Variant_litmus.t -> bool
 end
 
@@ -98,7 +98,7 @@ module Make
       Cfg.ascall || Cfg.is_kvm || do_label_init || CfgLoc.need_prelude
       || Cfg.variant Variant_litmus.Self
 
-    let do_precise = Precision.is_fatal Cfg.precision
+    let do_precise = Fault.Handling.is_fatal Cfg.precision
 
     let do_dynalloc =
         let open Alloc in
@@ -364,7 +364,7 @@ module Make
              Insert.insert O.o "instruction.h" ;
              O.o "" ;
              begin
-               let open Precision in
+               let open Fault.Handling in
                match Cfg.precision with
                | Fatal ->
                   O.o "#define PRECISE 1" ;
@@ -373,8 +373,6 @@ module Make
                   O.o "#define FAULT_SKIP 1" ;
                   O.o ""
                | Handled -> ()
-               | LoadsFatal ->
-                  Warn.user_error "No asymetric mode for litmus kvm variant"
              end ;
 
              let insert_ins_ops () =

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -56,7 +56,8 @@ module type CommonConfig = sig
   val gcc : string
   val c11 : bool
   val ascall : bool
-  val precision : Precision.t
+  val fault_handling : Fault.Handling.t
+  val mte_precision : Precision.t
   val variant : Variant_litmus.t -> bool
   val nocatch : bool
   val stdio : bool
@@ -115,7 +116,7 @@ module type Config = sig
   val noccs : int
   val timelimit : float option
   val check_nstates : string -> int option
-  val precision : Precision.t
+  val fault_handling : Fault.Handling.t
   (* End of additions *)
   include Skel.Config
   include Run_litmus.Config
@@ -404,9 +405,11 @@ end = struct
           TestVariant.Make
             (struct
               module Opt = Variant_litmus
-              let set_precision = Variant_litmus.set_precision
               let info = splitted.Splitter.info
-              let precision = OT.precision
+              let mte_precision = OT.mte_precision
+              let set_mte_precision = Variant_litmus.set_mte_precision
+              let fault_handling = OT.fault_handling
+              let set_fault_handling = Variant_litmus.set_fault_handling
               let variant = OT.variant
             end) in
         (* Then call appropriate compiler, depending upon arch *)
@@ -430,11 +433,11 @@ end = struct
           let asmcomment = OT.asmcomment
           let hexa = OT.hexa
           let mode = OT.mode
-          let precision = TestConf.precision
+          let precision = TestConf.fault_handling
         end in
         let module Cfg = struct
           include OT
-          let precision = TestConf.precision
+          let precision = TestConf.fault_handling
           let variant = TestConf.variant
           include ODep
           let debuglexer = debuglexer

--- a/litmus/top_litmus.mli
+++ b/litmus/top_litmus.mli
@@ -49,7 +49,8 @@ module type CommonConfig = sig
   val gcc : string
   val c11 : bool
   val ascall : bool
-  val precision : Precision.t
+  val fault_handling : Fault.Handling.t
+  val mte_precision : Precision.t
   val variant : Variant_litmus.t -> bool
   val nocatch : bool
   val stdio : bool

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -16,7 +16,7 @@
 
 type t =
   | Self (* Self modifying code *)
-  | Precise of Precision.t
+  | FaultHandling of Fault.Handling.t
   | S128 (* 128 bit signed ints*)
   | Mixed (* Ignored *)
   | Vmsa  (* Checked *)
@@ -24,7 +24,7 @@ type t =
 
 let compare = compare
 
-let tags = "s128"::"self"::"mixed"::"vmsa"::"telechat"::Precision.tags
+let tags = "s128"::"self"::"mixed"::"vmsa"::"telechat"::Fault.Handling.tags
 
 let parse s = match Misc.lowercase s with
 | "s128" -> Some S128
@@ -33,7 +33,7 @@ let parse s = match Misc.lowercase s with
 | "vmsa"|"kvm" -> Some Vmsa
 | "telechat" -> Some Telechat
 | tag ->
-   Misc.app_opt (fun p -> Precise p) (Precision.parse tag)
+   Misc.app_opt (fun p -> FaultHandling p) (Fault.Handling.parse tag)
 
 let pp = function
   | Self -> "self"
@@ -42,12 +42,14 @@ let pp = function
   | Vmsa -> "vmsa"
   | Telechat -> "telechat"
 
-  | Precise p -> Precision.pp p
+  | FaultHandling p -> Fault.Handling.pp p
 
 let ok v a = match v,a with
 | Self,`AArch64 -> true
 | _,_ -> false
 
-let set_precision r tag = match tag with
-| Precise p -> r := p ; true
+let set_fault_handling r = function
+| FaultHandling p -> r := p ; true
 | _ -> false
+
+let set_mte_precision _ _ = assert false

--- a/litmus/variant_litmus.mli
+++ b/litmus/variant_litmus.mli
@@ -16,7 +16,7 @@
 
 type t =
   | Self (* Self modifying code *)
-  | Precise of Precision.t
+  | FaultHandling of Fault.Handling.t
   | S128 (* 128 bit signed ints*)
   | Mixed (* Ignored *)
   | Vmsa  (* Checked *)
@@ -28,4 +28,5 @@ val parse : string -> t option
 val pp : t -> string
 val ok : t -> Archs.t -> bool
 val compare : t -> t -> int
-val set_precision : Precision.t ref -> t -> bool
+val set_fault_handling : Fault.Handling.t ref -> t -> bool
+val set_mte_precision : Precision.t ref -> t -> bool


### PR DESCRIPTION
Prior to this patch, the tools were using a unified concept of Precision which was used to decide how to act on an MTE tag mismatch (raise an exception or set the TFSR_ELx) and how to handle a fault (exception). This patch splits the precision into two different arguments, the MTE precision and the fault handling mode.