### PR TITLE
[asl][fix] Use anonymous types before static analysis

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -465,6 +465,10 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     | _ -> conflict loc [ default_t_bits ] t
 
   let check_structure_integer loc env t () =
+    let () =
+      if false then
+        Format.eprintf "Checking that %a is an integer.@." PP.pp_ty t
+    in
     match (Types.get_structure env t).desc with
     | T_Int _ -> ()
     | _ -> conflict loc [ integer' ] t
@@ -723,7 +727,12 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
          if it fails.
        TODO: check them
     *)
-    let rec tr_one = function
+    let rec tr_one s =
+      let () =
+        if false then
+          Format.eprintf "Annotating slice %a@." PP.pp_slice_list [ s ]
+      in
+      match s with
       (* Begin SliceSingle *)
       | Slice_Single i ->
           (* LRM R_GXKG:

--- a/asllib/tests/asl.t/named-types-in-slices.asl
+++ b/asllib/tests/asl.t/named-types-in-slices.asl
@@ -1,0 +1,15 @@
+type pagros of integer{1,2,4,8,16};
+
+var ones = Ones(64);
+
+func f(sz:pagros) => bits(sz)
+begin
+  return ones[sz-1:0];
+end
+
+func main() => integer
+begin
+  let x = f(8);
+  DEBUG(x);
+  return 0;
+end

--- a/asllib/tests/asl.t/run.t
+++ b/asllib/tests/asl.t/run.t
@@ -184,3 +184,6 @@ UnderConstrained integers:
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {5}.
   [1]
+
+  $ aslref named-types-in-slices.asl
+  File named-types-in-slices.asl, line 13, characters 8 to 9: x -> '11111111'

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -351,6 +351,7 @@ module Domain = struct
         raise StaticEvaluationTop
 
   and of_type env ty =
+    let ty = make_anonymous env ty in
     match ty.desc with
     | T_Bool -> D_Bool
     | T_String -> D_String
@@ -370,8 +371,7 @@ module Domain = struct
           D_Bits (FromSyntax [ Constraint_Exact width ]))
     | T_Array _ | T_Exception _ | T_Record _ | T_Tuple _ ->
         failwith "Unimplemented: domain of a non singular type."
-    | T_Named _ ->
-        failwith "Cannot construct a domain of a non-structural type."
+    | T_Named _ -> assert false (* make anonymous *)
 
   let mem v d =
     match (v, d) with


### PR DESCRIPTION
A bug reported by @maranget.

The following test did not type-check:

```
type pagros of integer{1,2,4,8,16};

var ones = Ones(64);

func f(sz:pagros) => bits(sz)
begin
  return ones[sz-1:0];
end

func main() => integer
begin
  let x = f(8);
  DEBUG(x);
  return 0;
end
```

The cause was the use of named types inside slices, which were not correctly
handled. This has been fixed.

This PR is not a systematic fix nor a complete survey of correct handling of
named types.

The reported test has been added to the regression test set, and is now
accepted by the type-checker.

