### PR TITLE
[asl] Rework local declarations left-hand side

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -31,12 +31,7 @@
 (** {2 Utils} *)
 
 type position = Lexing.position
-
-type 'a annotated = {
-  desc : 'a;
-  pos_start : position;
-  pos_end : position;
-}
+type 'a annotated = { desc : 'a; pos_start : position; pos_end : position }
 
 type identifier = string
 (** Type of local identifiers in the AST. *)
@@ -243,10 +238,28 @@ and lexpr = lexpr_desc annotated
 
 type local_decl_keyword = LDK_Var | LDK_Constant | LDK_Let
 
+(** A left-hand side of a declaration statement. In the following example of a
+    declaration statement, [(2, 3, 4): (integer, integer, integer {0..32})] is
+    the local declaration item:
+    {v
+      let (x, -, z): (integer, integer, integer {0..32}) = (2, 3, 4);
+    v}
+*)
 type local_decl_item =
-  | LDI_Var of identifier * ty option
-  | LDI_Discard of ty option
-  | LDI_Tuple of local_decl_item list * ty option
+  | LDI_Discard
+      (** [LDI_Discard] is the ignored [local_decl_item], for example used in:
+          {v let - = 42; v}. *)
+  | LDI_Var of identifier
+      (** [LDI_Var x] is the variable declaration of the variable [x], used for
+          example in: {v let x = 42; v}. *)
+  | LDI_Tuple of local_decl_item list
+      (** [LDI_Tuple ldis] is the tuple declarations of the items in [ldis],
+          used for example in: {v let (x, y, -, z) = (1, 2, 3, 4); v}
+
+          Note that a the list here must be at least 2 items long.
+      *)
+  | LDI_Typed of local_decl_item * ty
+      (** [LDI_Typed (ldi, t)] declares the item [ldi] with type [t]. *)
 
 (** Statements. Parametric on the type of literals in expressions. *)
 type for_direction = Up | Down
@@ -291,12 +304,7 @@ and catcher = identifier option * ty * stmt
 
 (** {2 Top-level declarations} *)
 
-type subprogram_type =
-  | ST_Procedure
-  | ST_Function
-  | ST_Getter
-  | ST_Setter
-
+type subprogram_type = ST_Procedure | ST_Function | ST_Getter | ST_Setter
 type subprogram_body = SB_ASL of stmt | SB_Primitive
 
 type func = {
@@ -311,11 +319,7 @@ type func = {
     functions, procedures and primitives. *)
 
 (** Declaration keyword for global storage elements. *)
-type global_decl_keyword =
-  | GDK_Constant
-  | GDK_Config
-  | GDK_Let
-  | GDK_Var
+type global_decl_keyword = GDK_Constant | GDK_Config | GDK_Let | GDK_Var
 
 type global_decl = {
   keyword : global_decl_keyword;

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -54,6 +54,9 @@ val annotated : 'a -> position -> position -> 'a annotated
 (** [annotated v start end] is [v] with location specified as from [start] to
     [end]. *)
 
+val desc : 'a annotated -> 'a
+(** [desc v] is [v.desc] *)
+
 val add_dummy_pos : 'a -> 'a annotated
 (** Add a dummy location annotation to a value. *)
 

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -226,23 +226,18 @@ let pp_for_direction = function Up -> "to" | Down -> "downto"
 
 let pp_local_decl_keyword f k =
   pp_print_string f
-    (match k with
-    | LDK_Var -> "var"
-    | LDK_Constant -> "constant"
-    | LDK_Let -> "let")
+  @@
+  match k with
+  | LDK_Var -> "var"
+  | LDK_Constant -> "constant"
+  | LDK_Let -> "let"
 
-let rec pp_local_decl_item f =
-  let pp_ty_opt f = function
-    | Some ty -> fprintf f ": @[%a@]" pp_ty ty
-    | None -> ()
-  in
-  function
-  | LDI_Discard ty_opt -> fprintf f "@[-%a@]" pp_ty_opt ty_opt
-  | LDI_Var (s, ty_opt) -> fprintf f "@[%s%a@]" s pp_ty_opt ty_opt
-  | LDI_Tuple (ldis, ty_opt) ->
-      fprintf f "@[(%a)%a@]"
-        (pp_comma_list pp_local_decl_item)
-        ldis pp_ty_opt ty_opt
+let rec pp_local_decl_item f = function
+  | LDI_Discard -> pp_print_string f "-"
+  | LDI_Var x -> pp_print_string f x
+  | LDI_Tuple ldis ->
+      fprintf f "@[(%a)@]" (pp_comma_list pp_local_decl_item) ldis
+  | LDI_Typed (ldi, t) -> fprintf f "@[%a: %a@]" pp_local_decl_item ldi pp_ty t
 
 let rec pp_stmt f s =
   match s.desc with

--- a/asllib/PP.mli
+++ b/asllib/PP.mli
@@ -64,6 +64,9 @@ val pp_slice_list : slice list printer
 val pp_int_constraints : int_constraint list printer
 (** Pretty-print a list of int constraints. *)
 
+val pp_local_decl_item : local_decl_item printer
+(** Pretty-print a local declaration item. *)
+
 val pp_t : t printer
 (** Print an AST from printer for a literal *)
 

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -232,13 +232,11 @@ let pp_local_decl_keyboard f k =
     | LDK_Let -> "LDK_Let")
 
 let rec pp_local_decl_item f = function
-  | LDI_Discard ty_opt -> bprintf f "LDI_Discard (%a)" (pp_option pp_ty) ty_opt
-  | LDI_Var (s, ty_opt) ->
-      bprintf f "LDI_Var (%S, %a)" s (pp_option pp_ty) ty_opt
-  | LDI_Tuple (ldis, ty_opt) ->
-      bprintf f "LDI_Tuple (%a, %a)"
-        (pp_list pp_local_decl_item)
-        ldis (pp_option pp_ty) ty_opt
+  | LDI_Discard -> addb f "LDI_Discard"
+  | LDI_Var s -> bprintf f "LDI_Var %S" s
+  | LDI_Typed (ldi, t) ->
+      bprintf f "LDI_Typed (%a, %a)" pp_local_decl_item ldi pp_ty t
+  | LDI_Tuple ldis -> bprintf f "LDI_Tuple %a" (pp_list pp_local_decl_item) ldis
 
 let rec pp_stmt =
   let pp_desc f = function

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -1663,11 +1663,11 @@ following applies:
 under an environment \texttt{env} is either \texttt{new\_env} or raises an
 error and one of the following applies:
 \begin{itemize}
-\item SemanticsRule.LDDiscard (see Section~\ref{sec:SemanticsRule.LDDiscard},
-\item SemanticsRule.LDVar (see Section~\ref{sec:SemanticsRule.LDVar},
-\item SemanticsRule.LDTypedVar (see Section~\ref{sec:SemanticsRule.LDTypedVar},
-\item SemanticsRule.LDTuple (see Section~\ref{sec:SemanticsRule.LDTuple},
-\item SemanticsRule.LDTypedTuple (see Section~\ref{sec:SemanticsRule.LDTypedTuple},
+  \item SemanticsRule.LDDiscard (see Section~\ref{sec:SemanticsRule.LDDiscard}),
+  \item SemanticsRule.LDVar (see Section~\ref{sec:SemanticsRule.LDVar}),
+  \item SemanticsRule.LDTyped (see Section~\ref{sec:SemanticsRule.LDTyped}),
+  \item SemanticsRule.LDTuple (see Section~\ref{sec:SemanticsRule.LDTuple}),
+  \item SemanticsRule.LDUninitialisedTyped (see Section~\ref{sec:SemanticsRule.LDUninitialisedTyped}),
 \end{itemize}
 
 \section{SemanticsRule.LDDiscard \label{sec:SemanticsRule.LDDiscard}}
@@ -1730,25 +1730,29 @@ local variable bound to value \texttt{m}.
 
 \isempty{\subsection{Comments}}
 
-\section{SemanticsRule.LDTypedVar \label{sec:SemanticsRule.LDTypedVar}}
+\section{SemanticsRule.LDTyped \label{sec:SemanticsRule.LDTyped}}
 
     \subsection{Prose}
 Evaluation of the local variables \texttt{ldi} under the environment
 \texttt{env} is \texttt{new\_env} and all of the following apply:
     \begin{itemize}
-    \item \texttt{ldi} is a variable \texttt{x} of type \texttt{ty};
-    \item \texttt{m\_init\_opt} is \texttt{None};
-    \item \texttt{new\_env} is \texttt{env} modified to declare \texttt{x} as a local variable bound to
-      the base value of \texttt{ty}.
+      \item \texttt{ldi} gives a local declaration item \texttt{ldi'} and a
+        type \texttt{t};
+        %
+      \item \texttt{m\_init\_opt} is a value \texttt{m};
+        %
+      \item \texttt{new\_env} is \texttt{env} modified after the evaluation of
+        \texttt{ldi'} with the initialisation value \texttt{m} in \texttt{env}.
+        %
     \end{itemize}
 
-    \subsection{Example: SemanticsRule.LDTypedVar.asl}
+    \subsection{Example: SemanticsRule.LDTyped.asl}
     In the program:
-    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.LDTypedVar.asl}
+    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.LDTyped.asl}
     \texttt{var x : integer;} binds \texttt{x} in \texttt{env} to the base value of \texttt{integer}.
 
   \subsection{Code}
-  \VerbatimInput[firstline=\LDTypedVarBegin, lastline=\LDTypedVarEnd]{../Interpreter.ml}
+  \VerbatimInput[firstline=\LDTypedBegin, lastline=\LDTypedEnd]{../Interpreter.ml}
 
 \begin{emptyformal}
   \subsection{Formally: sequential case}
@@ -1788,25 +1792,31 @@ evaluation of \texttt{3}) in \texttt{env}.
 
 \isempty{\subsection{Comments}}
 
-\section{SemanticsRule.LDTypedTuple \label{sec:SemanticsRule.LDTypedTuple}}
+\section{SemanticsRule.LDUninitialisedTyped\label{sec:SemanticsRule.LDUninitialisedTyped}}
 
     \subsection{Prose}
-Evaluation of the local variables \texttt{ldi} under the environment
-\texttt{env} is \texttt{new\_env} and all of the following apply:
+    Evaluation of the local declaration item \texttt{ldi} under the environment
+    \texttt{env} is \texttt{new\_env} and all of the following apply:
     \begin{itemize}
-    \item \texttt{ldi} gives a list of local variables \texttt{ldis} and a type \texttt{ty};
-    \item \texttt{m\_init\_opt} is \texttt{None};
-    \item \texttt{new\_env} is \texttt{env} modified to declare each element of \texttt{ldis} with type \texttt{ty}.
+      \item \texttt{ldi} gives a local declaration item \texttt{ldi'} and a
+        type \texttt{t};
+        %
+      \item \texttt{m\_init\_opt} is \texttt{None};
+        %
+      \item \texttt{m} is the base value of \texttt{t} in \texttt{env};
+        %
+      \item \texttt{new\_env} is \texttt{env} modified after the evaluation of
+        \texttt{ldi'} with the initialisation value \texttt{m} in \texttt{env}.
+        %
     \end{itemize}
 
-    \subsection{Example: SemanticsRule.LDTypedTuple.asl}
+    \subsection{Example: SemanticsRule.LDUninitialisedTyped.asl}
     In the program:
-    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.LDTypedTuple.asl}
-    \texttt{var (x,y,z) : integer;} binds \texttt{x}, \texttt{y} and \texttt{z} in \texttt{env} to the base value
-    of \texttt{integer}.
+    \VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTyped.asl}
+    \texttt{var x : integer;} binds \texttt{x} in \texttt{env} to the base value of \texttt{integer}.
 
   \subsection{Code}
-  \VerbatimInput[firstline=\LDTypedTupleBegin, lastline=\LDTypedTupleEnd]{../Interpreter.ml}
+  \VerbatimInput[firstline=\LDUninitialisedTypedBegin, lastline=\LDUninitialisedTypedEnd]{../Interpreter.ml}
 
 \begin{emptyformal}
   \subsection{Formally: sequential case}

--- a/asllib/doc/ASLSyntaxReference.tex
+++ b/asllib/doc/ASLSyntaxReference.tex
@@ -274,9 +274,30 @@ We sometimes provide extra details to individual derivations by adding comments 
 
 \[
 \begin{array}{rcl}
-\localdeclitem &::=& \texttt{LDI\_Var}(\identifier, \ty?)\\
-  &|& \texttt{LDI\_Discard}(\ty?)\\
-  &|& \texttt{LDI\_Tuple}(\localdeclitem^*, \ty?)\\
+  & & \ASTComment{A left-hand side of a declaration statement.}\\
+  & & \ASTComment{In the following example of a declaration statement:}\\
+  & & \ASTComment{\Verb|let (x, -, z): (integer, integer, integer \{0..32\}) = (2, 3, 4);|}\\
+  & & \ASTComment{\Verb|(x, -, z): (integer, integer, integer \{0..32\})| is the}\\
+  & & \ASTComment{local declaration item:}\\
+  \hline
+\localdeclitem &::=
+    & \texttt{LDI\_Discard}\\
+  & & \ASTComment{The ignored local declaration item, for example used in: \Verb!let - = 42;!.}\\
+  &|& \texttt{LDI\_Var}(\identifier)\\
+  & & \ASTComment{\texttt{LDI\_Var x} is the variable declaration of the variable \texttt{x}, used for example in:}\\
+  & & \ASTComment{\texttt{let x = 42;}.}\\
+  &|& \texttt{LDI\_Tuple}(\localdeclitem^*)\\
+  & & \ASTComment{\texttt{LDI\_Tuple ldis} is the tuple declarations of the items in \texttt{ldis},}\\
+  & & \ASTComment{used for example in: \texttt{let (x, y, -, z) = (1, 2, 3, 4);}}\\
+  & & \ASTComment{Note that a the list here must be at least 2 items long.}\\
+  &|& \texttt{LDI\_Typed}(\localdeclitem, \ty)\\
+  & & \ASTComment{\texttt{LDI\_Typed (ldi, t)} declares the item \texttt{ldi} with type \texttt{t}, used for example in:} \\
+  & & \ASTComment{\texttt{let x: integer = 4;}}
+\end{array}
+\]
+
+\[
+\begin{array}{rcl}
 \fordirection &::=& \texttt{Up} \;|\; \texttt{Down}\\
 \end{array}
 \]

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -4225,15 +4225,15 @@ Annotating a pattern \texttt{t} in an environment~\texttt{env} given a type \tex
 Annotating a local declaration~\texttt{ldi} with a local declaration keyword \texttt{ldk}, given a type~\texttt{ty}, in an
 environment~\texttt{env} (\annotatelocaldeclitem{\ldk, \ldi, \tty}) results in \texttt{new\_env, new\_ldi} and one of the following applies:
 \begin{itemize}
-\item TypingRule.LDDiscardNone (see Section~\ref{sec:TypingRule.LDDiscardNone}),
-\item TypingRule.LDDiscardSome (see Section~\ref{sec:TypingRule.LDDiscardSome}),
+\item TypingRule.LDDiscard (see Section~\ref{sec:TypingRule.LDDiscard}),
 \item TypingRule.LDVar (see Section~\ref{sec:TypingRule.LDVar}),
+\item TypingRule.LDTyped (see Section~\ref{sec:TypingRule.LDTyped}),
 \item TypingRule.LDTuple (see Section~\ref{sec:TypingRule.LDTuple}).
 \end{itemize}
 
 This is related to \identr{YSPM}.
 
-\section{TypingRule.LDDiscardNone \label{sec:TypingRule.LDDiscardNone}}
+\section{TypingRule.LDDiscard \label{sec:TypingRule.LDDiscard}}
 
   \subsection{Prose}
     Annotating a local declaration~\texttt{ldi} with a local declaration keyword \texttt{ldk}, given a type~\texttt{ty}, in
@@ -4241,15 +4241,15 @@ an environment~\texttt{env} results in \texttt{new\_env, new\_ldi} and all of
 the following apply:
    \begin{itemize}
    \item \texttt{ldi} is a local declaration which can be discarded;
-   \item \texttt{ldi} does not specify a type;
-   \item \texttt{new\_e} is \texttt{env};
+   \item \texttt{new\_env} is \texttt{env};
    \item \texttt{new\_ldi} is \texttt{ldi}.
    \end{itemize}
 
   \subsection{Example}
+    \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDDiscard.asl}
 
   \subsection{Code}
-    \VerbatimInput[firstline=\LDDiscardNoneBegin, lastline=\LDDiscardNoneEnd]{../Typing.ml}
+    \VerbatimInput[firstline=\LDDiscardBegin, lastline=\LDDiscardEnd]{../Typing.ml}
 
 \begin{emptyformal}
     \subsection{Formally}
@@ -4263,49 +4263,6 @@ the following apply:
 
 \isempty{\subsection{Comments}}
 
-\section{TypingRule.LDDiscardSome \label{sec:TypingRule.LDDiscardSome}}
-
-  \subsection{Prose}
-    Annotating a local declaration~\texttt{ldi} with a local declaration keyword \texttt{ldk}, given a type~\texttt{ty}, in
-an environment~\texttt{env} results in \texttt{new\_env, new\_ldi} and all of
-the following apply:
-   \begin{itemize}
-   \item \texttt{ldi} is a local declaration which can be discarded;
-   \item \texttt{ldi} specifies a type \texttt{t};
-   \item One of the following applies:
-     \begin{itemize}
-     \item All of the following apply:
-       \begin{itemize}
-       \item \texttt{t} can be initialised with \texttt{ty} in \texttt{env};
-       \item \texttt{new\_env} is \texttt{env};
-       \item \texttt{new\_ldi} is \texttt{ldi}.
-       \end{itemize}
-     \item All of the following apply:
-       \begin{itemize}
-       \item \texttt{t} cannot be initialised with \texttt{ty} in \texttt{env};
-       \item an error ``\texttt{Conflicting Types}'' is raised.
-       \end{itemize}
-     \end{itemize}
-   \end{itemize}
-
-  \subsection{Example}
-
-  \subsection{Code}
-    \VerbatimInput[firstline=\LDDiscardSomeBegin, lastline=\LDDiscardSomeEnd]{../Typing.ml}
-
-\begin{emptyformal}
-    \subsection{Formally}
-\[
-  \inferrule{
-    \ldi = \texttt{LDI\_Discard}(\langle\vt\rangle)\\
-    \canbeinitializedwith(\tenv, \vt, \tty)
-  }
-  {\annotatelocaldeclitem{\tenv, \ldi, \ldk, \tty} = (\tenv, \ldi)}
-\]
-\end{emptyformal}
-
-\isempty{\subsection{Comments}}
-
 \section{TypingRule.LDVar \label{sec:TypingRule.LDVar}}
 
   \subsection{Prose}
@@ -4313,26 +4270,14 @@ the following apply:
 an environment~\texttt{env} results in \texttt{new\_env, new\_ldi} and all of
 the following apply:
    \begin{itemize}
-   \item \texttt{ldi} denotes a variable \texttt{x} with an optional type \texttt{ty\_opt};
+   \item \texttt{ldi} denotes a variable \texttt{x};
    \item \texttt{x} is not declared in \texttt{env};
-   \item One of the following applies:
-     \begin{itemize}
-     \item All of the following apply:
-       \begin{itemize}
-       \item \texttt{ty\_opt} is \texttt{None};
-       \item \texttt{t} is \texttt{ty}
-       \end{itemize}
-     \item All of the following apply:
-       \begin{itemize}
-       \item \texttt{ty\_opt} is \texttt{Some t};
-       \item \texttt{t} can be initialized with \texttt{ty} in \texttt{env};
-       \end{itemize}
-     \end{itemize}
-   \item \texttt{new\_env} is \texttt{env} modified so that \texttt{x} is locally declared of type \texttt{t};
-   \item \texttt{new\_ldi} is the declaration of variable \texttt{x} with type \texttt{t}.
+   \item \texttt{new\_env} is \texttt{env} modified so that \texttt{x} is locally declared of type \texttt{ty};
+   \item \texttt{new\_ldi} is the declaration of variable \texttt{x} with type \texttt{ty}.
    \end{itemize}
 
   \subsection{Example}
+    \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDVar.asl}
 
   \subsection{Code}
     \VerbatimInput[firstline=\LDVarBegin, lastline=\LDVarEnd]{../Typing.ml}
@@ -4341,33 +4286,59 @@ the following apply:
     \subsection{Formally}
 \begin{mathpar}
   \inferrule{
-    \ldi = \texttt{LDI\_Var}(\vx, \tyopt)\\
+    \ldi = \texttt{LDI\_Var}(\vx)\\
     L^\tenv.\storagetypes(\vx) = \bot\\
-    \tyopt = \langle\rangle\\
-    \vt = \tty\\
-    \newenv = (G^\tenv, L^\tenv.\storagetypes[\vx \mapsto (\vt, \ldk)])
+    \newenv = (G^\tenv, L^\tenv.\storagetypes[\vx \mapsto (\tty, \ldk)])
   }
   {
-    \annotatelocaldeclitem{\tenv, \ldi, \ldk, \tty} = (\newenv, \texttt{LDI\_Var}(\vx, \langle\vt\rangle))
+    \annotatelocaldeclitem{\tenv, \ldi, \ldk, \tty} = (\newenv, \texttt{LDI\_Var}(\vx))
   }
-\and
-\inferrule{
-  \ldi = \texttt{LDI\_Var}(\vx, \tyopt)\\
-  L^\tenv.\storagetypes(\vx) = \bot\\
-  \tyopt = \langle\vt\rangle\\
-  \canbeinitializedwith(\tenv, \vt, \tty)\\
-  \newenv = (G^\tenv, L^\tenv.\storagetypes[x \mapsto (\vt, \ldk)])
-}
-{
-  \annotatelocaldeclitem{\tenv, \ldi, \ldk, \tty} = (\newenv, \texttt{LDI\_Var}(\vx, \langle\vt\rangle))
-}
 \end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 This is related to \identr{YSPM}, \identd{FXST}.
 
-\section{TypingRule.LDTuple \label{sec:TypingRule.LDTuple}}
+\section{TypingRule.LDTyped\label{sec:TypingRule.LDTyped}}
+
+  \subsection{Prose}
+    Annotating a local declaration~\texttt{ldi} with a local declaration
+    keyword \texttt{ldk}, given a type~\texttt{ty}, in an
+    environment~\texttt{env} results in \texttt{new\_env, new\_ldi} and all of
+    the following apply:
+    \begin{itemize}
+      \item \texttt{ldi} denotes a local declaration item \texttt{ldi'} and a type \texttt{t};
+      \item \texttt{t} can be initialized with \texttt{ty} in \texttt{env};
+      \item \texttt{new\_env}, \texttt{new\_ldi'} is the result of the annotation of
+        \texttt{ldi'} with the local declaration keyword \texttt{ldk}, given
+        the type~\texttt{t}, in the environment~\texttt{env};
+      \item \texttt{new\_ldi} is the local declaration denoting \texttt{new\_ldi'} and the type \texttt{t}.
+    \end{itemize}
+
+    \subsection{Example}
+      \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDTyped.asl}
+
+    \subsection{Code}
+      \VerbatimInput[firstline=\LDTypedBegin, lastline=\LDTypedEnd]{../Typing.ml}
+
+\begin{emptyformal}
+    \subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \ldi = \texttt{LDI\_Typed}(\ldi', \vt)\\
+  \canbeinitializedwith(\tenv, \vt, \tty)\\
+  \annotatelocaldeclitem{\tenv, \ldi', \ldk, \vt} = (\newenv, \newldi')\\
+  \newldi = \texttt{LDI\_Typed}(\newldi', \vt)\\
+}
+{
+  \annotatelocaldeclitem{\tenv, \ldi, \ldk, \tty} = (\newenv, \newldi)
+}
+\end{mathpar}
+\end{emptyformal}
+
+\isempty{\subsection{Comments}}
+
+\section{TypingRule.LDTuple\label{sec:TypingRule.LDTuple}}
 
   \subsection{Prose}
     Annotating a local declaration~\texttt{ldi} with a local declaration keyword \texttt{ldk}, given a type~\texttt{ty}, in
@@ -4375,7 +4346,6 @@ an environment~\texttt{env} results in \texttt{new\_env, new\_ldi} and all of
 the following apply:
   \begin{itemize}
   \item \texttt{ldi} denotes a list \texttt{ldis};
-  \item \texttt{ldi} does not specify a type;
   \item \texttt{ty} has the structure of a tuple type of the same length as~\texttt{ldis};
   \item \texttt{new\_env} is \texttt{env} modified so that each element in \texttt{ldis} is annotated with the corresponding type in \texttt{ty};
   \item \texttt{new\_ldi} is \texttt{ldis} where each element is declared with
@@ -4383,6 +4353,7 @@ the corresponding type in ~\texttt{ty}.
   \end{itemize}
 
   \subsection{Example}
+    \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDTuple.asl}
 
   \subsection{Code}
     \VerbatimInput[firstline=\LDTupleBegin, lastline=\LDTupleEnd]{../Typing.ml}

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -53,6 +53,7 @@ type error_desc =
   | UnexpectedSideEffect of string
   | UncaughtException of string
   | OverlappingSlices of slice list
+  | BadLDI of AST.local_decl_item
 
 type error = error_desc annotated
 
@@ -192,6 +193,8 @@ let pp_error =
     | OverlappingSlices slices ->
         fprintf f "ASL Typing error:@ overlapping slices@ @[%a@]." pp_slice_list
           slices
+    | BadLDI ldi ->
+        fprintf f "Unsupported declaration:@ @[%a@]." pp_local_decl_item ldi
     | BadReturnStmt (Some t) ->
         fprintf f
           "ASL Typing error:@ cannot@ return@ nothing@ from@ a@ function,@ an@ \

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -72,12 +72,9 @@ module SemanticsRule = struct
     | PTuple
     | LDDiscard
     | LDVar
-    | LDTypedVar
-    | LDUninitialisedVar
+    | LDTyped
     | LDTuple
-    | LDTypedTuple
-    | LDUninitialisedTuple
-    | LDUninitialisedTypedTuple
+    | LDUninitialisedTyped
     | SPass
     | SAssignCall
     | SAssignTuple
@@ -112,7 +109,7 @@ module SemanticsRule = struct
     | CatchOtherwise
     | CatchNone
     | CatchNoThrow
-    | TopLevel 
+    | TopLevel
 
   let to_string : t -> string = function
     | Lit -> "Lit"
@@ -163,12 +160,9 @@ module SemanticsRule = struct
     | PTuple -> "PTuple"
     | LDDiscard -> "LDDiscard"
     | LDVar -> "LDVar"
-    | LDTypedVar -> "LDTypedVar"
-    | LDUninitialisedVar -> "LDUninitialisedVar"
+    | LDTyped -> "LDTyped"
     | LDTuple -> "LDTuple"
-    | LDTypedTuple -> "LDTypedTuple"
-    | LDUninitialisedTuple -> "LDUninitialisedTuple"
-    | LDUninitialisedTypedTuple -> "LDUninitialisedTypedTuple"
+    | LDUninitialisedTyped -> "LDUninitialisedTyped"
     | SPass -> "SPass"
     | SAssignCall -> "SAssignCall"
     | SAssignTuple -> "SAssignTuple"
@@ -240,6 +234,11 @@ module SemanticsRule = struct
       LESetField;
       LESetFields;
       LEDestructuring;
+      LDDiscard;
+      LDVar;
+      LDTyped;
+      LDTuple;
+      LDUninitialisedTyped;
       SPass;
       SAssignCall;
       SAssignTuple;
@@ -309,7 +308,7 @@ module TypingRule = struct
     | PrimitiveType
     | Structure
     | Canonical
-    | Domain 
+    | Domain
     | Subtype
     | StructuralSubtypeSatisfaction
     | DomainSubtypeSatisfaction
@@ -383,16 +382,13 @@ module TypingRule = struct
     | PTupleBadArity
     | PTuple
     | PTupleConflict
-    | LDDiscardNone
-    | LDDiscardSome
-    | LDUninitialisedVar
-    | LDUninitialisedTypedVar
+    | LDDiscard
     | LDVar
-    | LDTypedVar
-    | LDUninitialisedTuple
-    | LDUninitialisedTypedTuple
+    | LDTyped
     | LDTuple
-    | LDTypedTuple
+    | LDUninitialisedVar
+    | LDUninitialisedTyped
+    | LDUninitialisedTuple
     | SPass
     | SAssignCall
     | SAssignTuple
@@ -492,13 +488,13 @@ module TypingRule = struct
     | LEGlobalVar -> "LEGlobalVar"
     | LESlice -> "LESlice"
     | LESetArray -> "LESetArray"
-    | LESetBadStructuredField -> "LESetBadStructuredField" 
-    | LESetStructuredField -> "LESetStructuredField" 
-    | LESetBadBitField -> "LESetBadBitField" 
-    | LESetBitField -> "LESetBitField" 
-    | LESetBitFieldNested -> "LESetBitFieldNested" 
-    | LESetBitFieldTyped -> "LESetBitFieldTyped" 
-    | LESetBadField -> "LESetBadField" 
+    | LESetBadStructuredField -> "LESetBadStructuredField"
+    | LESetStructuredField -> "LESetStructuredField"
+    | LESetBadBitField -> "LESetBadBitField"
+    | LESetBitField -> "LESetBitField"
+    | LESetBitFieldNested -> "LESetBitFieldNested"
+    | LESetBitFieldTyped -> "LESetBitFieldTyped"
+    | LESetBadField -> "LESetBadField"
     | LESetFields -> "LESetFields"
     | LEConcat -> "LEConcat"
     | LEDestructuring -> "LEDestructuring"
@@ -519,16 +515,13 @@ module TypingRule = struct
     | PTupleBadArity -> "PTupleBadArity"
     | PTuple -> "PTuple"
     | PTupleConflict -> "PTupleConflict"
-    | LDDiscardNone -> "LDDiscardNone"
-    | LDDiscardSome -> "LDDiscardSome"
+    | LDDiscard -> "LDDiscardNone"
+    | LDTyped -> "LDTyped"
     | LDVar -> "LDVar"
-    | LDTypedVar -> "LDTypedVar"
     | LDUninitialisedVar -> "LDUninitialisedVar"
-    | LDUninitialisedTypedVar -> "LDUninitialisedTypedVar"
+    | LDUninitialisedTyped -> "LDUninitialisedTyped"
     | LDTuple -> "LDTuple"
-    | LDTypedTuple -> "LDTypedTuple"
     | LDUninitialisedTuple -> "LDUninitialisedTuple"
-    | LDUninitialisedTypedTuple -> "LDUninitialisedTypedTuple"
     | SPass -> "SPass"
     | SAssignCall -> "SAssignCall"
     | SAssignTuple -> "SAssignTuple"
@@ -554,7 +547,7 @@ module TypingRule = struct
     | FUndefIdent -> "FUndefIdent"
     | FPrimitive -> "FPrimitive"
     | FBadArity -> "FBadArity"
-    | FCallBadArity -> "FCallBadArity" 
+    | FCallBadArity -> "FCallBadArity"
     | FCallSetter -> "FCallSetter"
     | FCallGetter -> "FCallGetter"
     | FCallMismatch -> "FCallMismatch"

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTyped.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTyped.asl
@@ -1,0 +1,9 @@
+func main () => integer
+begin
+
+  var x: integer = 42;
+
+  assert x == 42;
+
+  return 0;
+end

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTyped.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTyped.asl
@@ -1,0 +1,8 @@
+func main () => integer
+begin
+  var x: integer {3..42};
+
+  assert x == 3;
+
+  return 0;
+end

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -116,6 +116,11 @@ ASL Semantics Reference:
   $ aslref SemanticsRule.LDTypedTuple.asl
   $ aslref SemanticsRule.LDTypedVar.asl
   $ aslref SemanticsRule.LDUninitialisedTuple.asl
+  File SemanticsRule.LDUninitialisedTuple.asl, line 4, characters 2 to 33:
+  Unsupported declaration: (x: integer, y: boolean).
+  [1]
+  $ aslref SemanticsRule.LDTyped.asl
+  $ aslref SemanticsRule.LDUninitialisedTyped.asl
   $ aslref SemanticsRule.SAssign.asl
   $ aslref SemanticsRule.SCall.asl
   $ aslref SemanticsRule.SDeclNone.asl

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LDDiscard.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LDDiscard.asl
@@ -1,0 +1,9 @@
+func main () => integer
+begin
+
+  let - = 42;
+  let - = "abc";
+  let - = '101010';
+
+  return 0;
+end

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LDTuple.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LDTuple.asl
@@ -1,0 +1,10 @@
+type MyT of (integer, integer {0..4}, boolean);
+
+func main() => integer
+begin
+  let (x, -, y) = (5, 3, TRUE);
+
+  assert x == 5 && y;
+  return 0;
+end
+

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LDTyped.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LDTyped.asl
@@ -1,0 +1,17 @@
+type MyT of integer;
+
+func foo (t: MyT) => integer
+begin
+  return t as integer;
+end
+
+func main () => integer
+begin
+  let x: MyT = 42;
+  var z: MyT;
+
+  assert foo (x) == 42;
+  assert foo (z) == 0;
+
+  return 0;
+end

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LDVar.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LDVar.asl
@@ -1,0 +1,7 @@
+func main () => integer
+begin
+  let x = 3;
+  assert x == 3;
+
+  return 0;
+end

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -16,3 +16,7 @@ ASL Typing Reference:
   Some text
 //  $ aslref TypingRule.EConcatUnresolvableToInteger.asl
   $ aslref TypingRule.CheckBinOp.asl
+  $ aslref TypingRule.LDDiscard.asl
+  $ aslref TypingRule.LDVar.asl
+  $ aslref TypingRule.LDTyped.asl
+  $ aslref TypingRule.LDTuple.asl

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=c715e7c4a5a3271b19f9b323c02721a8
+Hash=a023a188698fa3fc3acae9c9efea9481
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=82aeb2622745b94637a9fc3e45f3e68f
+Hash=bad63763883ba8f1c18be47e445058b7
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=1e02a27a2a739f683785f4fa4c6511f0
+Hash=08ac824ad1d5a3d5dbf9fa693f5c9a3e
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=87f2446fe4ac9a104e12bf85a7468b9c
+Hash=b2e28d6e49641ae233d2956d903710ce
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=2b4b02656b5cff504ce2f191021521c2
+Hash=feba98e1370ea893b2c77debe00448ce
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=834c492fbd87287b6e837000a67f7763
+Hash=3fc04f3517e8479bed44f409d0dedc19
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=29682aaaa1d40e69fd9ce2eae04e62ba
+Hash=18387829b9a7e144f3edce911e403abb
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=1b86051f0efb2eab43e1dec70cbeb3ac
+Hash=7c82a9af991e52546d1756c9041ddd51
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=78469b990c234ce77cc797e480ca995a
+Hash=05bf9dc92c907b66ee01266504de89da
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=af682bc43118d2d9b7845dff4f8d7458
+Hash=6f93a3f6ee52feeaa91bc05848ff2839
 

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T1.0.a=1 /\ 0:T1.0.b=0)
 Observation MP-pseudo-arch Sometimes 1 3
-Hash=f57c035d750b97ed00d971863d5abcd9
+Hash=5bd61da3215f99b10e610248c4306853
 

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:a=1 /\ 0:b=0)
 Observation MP-pseudo-arch Sometimes 1 3
-Hash=34f4b7dfa78746f998b113b01263a1c7
+Hash=28f2f7b1857917d46e9aa32da040937d
 

--- a/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation for-toofar Always 3 0
-Hash=37c13375cc9843aa4ba398dd9f0f2650
+Hash=bdf94417ce4c7b956b6910b764c77c06
 

--- a/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation repeat-toofar Always 3 0
-Hash=03d0ca567f8d3075edd4cdef397c1093
+Hash=6d0fd9ae4324153159db65c51d0d8554
 

--- a/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation while-toofar Always 3 0
-Hash=20a391e0da73e5aa22c6dce5e83a1080
+Hash=731f4e3925abbb43595efd357da8e246
 

--- a/herd/tests/instructions/ASL/assign1.litmus.expected
+++ b/herd/tests/instructions/ASL/assign1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3)
 Observation assign1 Always 1 0
-Hash=7686ecba38a293ceef9a7808f7bc8bc4
+Hash=0d9f3f283c67ef841fc7dccb68d91a1f
 

--- a/herd/tests/instructions/ASL/assign2.litmus.expected
+++ b/herd/tests/instructions/ASL/assign2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c1=3 /\ 0:main.0.c2=5 /\ 0:main.0.c3=15 /\ 0:main.0.c4=3)
 Observation assign2 Always 1 0
-Hash=dd7c4426e5eb3fa57807c484f7ff6366
+Hash=aaa53896e6d13de835ab2d70f53ef265
 

--- a/herd/tests/instructions/ASL/assign3.litmus.expected
+++ b/herd/tests/instructions/ASL/assign3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.eq=1 /\ 0:main.0.ne=1 /\ 0:main.0.lt=1 /\ 0:main.0.al=1)
 Observation assign3 Always 1 0
-Hash=d9f7e56555440c8377cc65483857e831
+Hash=e3afb7916113d1e03a24fc4b6a2f82d0
 

--- a/herd/tests/instructions/ASL/bitfields1.litmus.expected
+++ b/herd/tests/instructions/ASL/bitfields1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.b=1 /\ 0:main.0.d=1 /\ 0:main.0.e=1)
 Observation bitfields1 Always 1 0
-Hash=ceb87893a6b10e5ae73816d1b14d6953
+Hash=d88a3ed7f10ad72863aa4fe89c1db71c
 

--- a/herd/tests/instructions/ASL/case1.litmus.expected
+++ b/herd/tests/instructions/ASL/case1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=1 /\ 0:main.0.b=0)
 Observation case1 Always 1 0
-Hash=b72cd2c49ee840f6fbf86cc05725dfe7
+Hash=ca9213c67bd107502ed624239097a3a9
 

--- a/herd/tests/instructions/ASL/data-return-01.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-01.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation no Always 1 0
-Hash=5da0340771cc185a709739b90678d914
+Hash=cfeb7ae07276d6e8a04733aa33876374
 

--- a/herd/tests/instructions/ASL/data-return-02.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-02.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation no Always 1 0
-Hash=5ed94b7a767ba1c2769a924c3a511514
+Hash=44a820db1ee5c547e5253c133523e154
 

--- a/herd/tests/instructions/ASL/double-load.litmus.expected
+++ b/herd/tests/instructions/ASL/double-load.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.three=3)
 Observation double-load Always 1 0
-Hash=4dda8e42f0a7df3dad9d1ede277b54b5
+Hash=8b40dcd093993302678ed709b1314bb3
 

--- a/herd/tests/instructions/ASL/for1.litmus.expected
+++ b/herd/tests/instructions/ASL/for1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.s=110)
 Observation for1 Always 1 0
-Hash=659bca3b64399896295553e23ac2e299
+Hash=316a29bab762f6668b7a668ec82e8b5f
 

--- a/herd/tests/instructions/ASL/func1.litmus.expected
+++ b/herd/tests/instructions/ASL/func1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3 /\ 0:main.0.y=3)
 Observation func1 Always 1 0
-Hash=15bb901219b326fc62c8a3000cd370cc
+Hash=ca1d8420ebeaca67553105a02dd97998
 

--- a/herd/tests/instructions/ASL/func2.litmus.expected
+++ b/herd/tests/instructions/ASL/func2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=4 /\ 0:X_set.0.internal_i=2 /\ 0:X_set.0.internal_v=3)
 Observation func02 Always 1 0
-Hash=38444a377cb6e8b842f4efbcaa7496ad
+Hash=a4619d29930f354054548263b37a7157
 

--- a/herd/tests/instructions/ASL/func3.litmus.expected
+++ b/herd/tests/instructions/ASL/func3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=3 /\ 0:main.0.b=3 /\ 0:main.0.c=7 /\ 0:f3_storage=12 /\ 0:f4_storage=15)
 Observation func3 Always 1 0
-Hash=2a111feb89295e265a4090c25f30dcec
+Hash=cb6e6a505cb6b4f5c9871de2286705f0
 

--- a/herd/tests/instructions/ASL/func4.litmus.expected
+++ b/herd/tests/instructions/ASL/func4.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=0 /\ 0:main.0.b=1 /\ 0:main.0.c=5)
 Observation func4 Always 1 0
-Hash=a826b39775246c83bca5a3d791d3c4b8
+Hash=8c5775438e2dbe02bcc8ef741d205196
 

--- a/herd/tests/instructions/ASL/records.litmus.expected
+++ b/herd/tests/instructions/ASL/records.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3)
 Observation records Always 1 0
-Hash=f3d911f23166a7c959cbcfec667b8961
+Hash=856cae0e1c9c2d32fff336c1dddaf1c3
 

--- a/herd/tests/instructions/ASL/unknown.litmus.expected
+++ b/herd/tests/instructions/ASL/unknown.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation Unknown Always 2 0
-Hash=2980ed8035a721c2030158cdc20e97b3
+Hash=e9207fd12ef12177972a17e0c8a08546
 

--- a/herd/tests/instructions/ASL/while1.litmus.expected
+++ b/herd/tests/instructions/ASL/while1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.y=6 /\ 0:main.0.x=0)
 Observation while1 Always 1 0
-Hash=193f2cda09ce53c915ccfef369729417
+Hash=849d4d95d874a74ae168d54bf2ca0110
 

--- a/herd/tests/instructions/ASL/while2.litmus.expected
+++ b/herd/tests/instructions/ASL/while2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.z=0 /\ 0:main.0.x=2)
 Observation while2 Always 1 0
-Hash=968e2f0d100ac029a4e05e268b4c556a
+Hash=2eb5f6cd592177bb3d1fdfed1227ddc0
 

--- a/herd/tests/instructions/ASL/write_mem.litmus.expected
+++ b/herd/tests/instructions/ASL/write_mem.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 0 Negative: 1
 Condition forall ([x]=3)
 Observation write-mem Never 0 1
-Hash=9d74694f89ddef7aa64aafe24419956b
+Hash=c11f2b9d829c7ae25bb3dff4816ca530
 


### PR DESCRIPTION
This commit rework the way local declaration are represented to make the type indications a full constructor of the type `local_declaration_item`, and removes them of the other constructors.
For example, `let x: integer = 4;`, the local declaration item was previously `LDI_Var ("x", Some integer)`, and is now `LDI_Typed (LDI_Var "x", integer)`.
This makes both the typing and semantics rules simpler and more explicit.

This commits also brings transliteration with examples of the new abstract syntax, the semantics rules and the typing rules handling local declaration items.

While the concrete syntax stays the same, the AST can now represents strange things, for example:
```
var x: integer : boolean;
```
(note that this example cannot be constructed by the parser).

However, the conflicts that arrise from this new possibilities could also happen with the previous AST, but in more intricate ways, for example:
```
var (x: integer, -): (boolean, boolean);
```

How to solve those conflicts and how to handle them was not explicit nor straight-forward as the AST was complex with a lot of cases. With this new AST, reasonning on the various cases is simplified and solutions are often simple.

Fix #766.
