### PR TITLE
[asl] Make Print a full statement.

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -272,7 +272,9 @@ type stmt_desc =
           represent the implicit throw, such as [throw;]. *)
   | S_Try of stmt * catcher list * stmt option
       (** The stmt option is the optional otherwise guard. *)
-  | S_Debug of expr
+  | S_Print of { args : expr list; debug : bool }
+      (** A call to print, as an explicit node as it does not require
+          type-checking. *)
 
 and stmt = stmt_desc annotated
 and case_alt = (pattern * stmt) annotated

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -243,7 +243,7 @@ let rec use_s acc s =
   | S_Try (s, catchers, None) -> use_catchers (use_s acc s) catchers
   | S_Try (s, catchers, Some s') ->
       use_catchers (use_s (use_s acc s') s) catchers
-  | S_Debug e -> use_e acc e
+  | S_Print { args; debug = _ } -> List.fold_left use_e acc args
 
 and use_case acc { desc = _p, stmt; _ } = use_s acc stmt
 and use_le acc _le = acc
@@ -697,7 +697,7 @@ let rename_locals map_name ast =
     | S_Throw (Some (e, t)) -> S_Throw (Some (map_e e, Option.map map_t t))
     | S_Throw None -> s.desc
     | S_Try (_, _, _) -> failwith "Not yet implemented: offscate try"
-    | S_Debug e -> S_Debug (map_e e)
+    | S_Print { args; debug } -> S_Print { args = List.map map_e args; debug }
   and map_le le =
     map_desc_st' le @@ function
     | LE_Discard -> le.desc

--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -68,6 +68,7 @@ let tr_name s = match s with
 | "otherwise"     -> OTHERWISE
 | "pass"          -> PASS
 | "pragma"        -> PRAGMA
+| "print"         -> PRINT
 | "real"          -> REAL
 | "record"        -> RECORD
 | "repeat"        -> REPEAT

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -304,7 +304,10 @@ let rec pp_stmt f s =
       fprintf f "@[<2>try@ %a@ catch@ @[<v 2>%a@]@ end@]" pp_stmt s
         (pp_print_list ~pp_sep:pp_print_space pp_catcher)
         catchers
-  | S_Debug e -> fprintf f "@[<2>debug@ %a;@]" pp_expr e
+  | S_Print { args; debug = false } ->
+      fprintf f "@[<2>print(%a);@]" (pp_comma_list pp_expr) args
+  | S_Print { args; debug = true } ->
+      fprintf f "@[<2>DEBUG@ %a;@]" (pp_comma_list pp_expr) args
 
 and pp_catcher f (name, ty, s) =
   match name with

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -71,7 +71,7 @@ let make_ty_decl_subtype (x, s) =
 %token DOT DOWNTO ELSE ELSIF END ENUMERATION EOF EOR EQ EQ_OP EXCEPTION FOR
 %token FUNC GEQ GETTER GT IF IMPL IN INTEGER LBRACE LBRACKET LEQ LET LPAR LT
 %token MINUS MOD MUL NEQ NOT OF OR OTHERWISE PASS PLUS PLUS_COLON POW PRAGMA
-%token RBRACE RBRACKET RDIV REAL RECORD REPEAT RETURN RPAR STAR_COLON
+%token PRINT RBRACE RBRACKET RDIV REAL RECORD REPEAT RETURN RPAR STAR_COLON
 %token SEMI_COLON SETTER SHL SHR SLICING STRING SUBTYPES THEN THROW TO TRY TYPE
 %token UNKNOWN UNTIL VAR WHEN WHERE WHILE WITH
 
@@ -463,9 +463,9 @@ let stmt ==
       | RETURN; ~=ioption(expr);                             < S_Return >
       | x=IDENTIFIER; args=plist(expr); ~=nargs;             < S_Call   >
       | ASSERT; e=expr;                                      < S_Assert >
-      | DEBUG; e=expr;                                       < S_Debug >
-      | le=lexpr; EQ; e=expr;
-          {  S_Assign (le,e,V1) }
+      | PRINT; args=plist(expr);                             { S_Print { args; debug = false } }
+      | DEBUG; args=plist(expr);                             { S_Print { args; debug = true } }
+      | le=lexpr; EQ; e=expr;                                {  S_Assign (le,e,V1) }
       | ~=local_decl_keyword; ~=decl_item; EQ; ~=some(expr); < S_Decl   >
       | VAR; ldi=decl_item; e=ioption(EQ; expr);             { S_Decl (LDK_Var, ldi, e) }
       | REPEAT; ~=stmt_list; UNTIL; ~=expr;                  < S_Repeat >

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -504,7 +504,7 @@ let simple_stmt ==
     | ~=qualident; ~=pared(clist(expr)); ~=nargs; < AST.S_Call >
     | RETURN; ~=ioption(expr);                    < AST.S_Return >
     | ASSERT; ~=expr;                             < AST.S_Assert >
-    | DEBUG; ~=expr;                              < AST.S_Debug >
+    | DEBUG; e=expr;                              { AST.S_Print { args = [ e ]; debug = true } }
 
     | unimplemented_stmts (
       | UNPREDICTABLE; ioption(pared(<>)); <>

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -273,7 +273,9 @@ let rec pp_stmt =
     | S_Try (s, catchers, otherwise) ->
         bprintf f "S_Try (%a, %a, %a)" pp_stmt s (pp_list pp_catcher) catchers
           (pp_option pp_stmt) otherwise
-    | S_Debug _ -> ()
+    | S_Print { args; debug } ->
+        bprintf f "S_Print { args = %a; debug = %B }" (pp_list pp_expr) args
+          debug
   in
   fun f s -> pp_annotated pp_desc f s
 

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1930,9 +1930,12 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
         (S_Try (s'', catchers', otherwise') |> here, env)
         |: TypingRule.STry
     (* End *)
-    | S_Debug e ->
-        let _t_e, e' = annotate_expr env e in
-        (S_Debug e' |> here, env) |: TypingRule.SDebug
+    | S_Print { args; debug } ->
+        let args' =
+          List.map (fun e -> annotate_expr env e |> snd) args
+        in
+        (S_Print { args = args'; debug } |> here, env)
+        |: TypingRule.SDebug
 
   and annotate_catcher env (name_opt, ty, stmt) =
     let+ () = check_structure_exception ty env ty in

--- a/asllib/tests/asl.t/run.t
+++ b/asllib/tests/asl.t/run.t
@@ -186,4 +186,4 @@ UnderConstrained integers:
   [1]
 
   $ aslref named-types-in-slices.asl
-  File named-types-in-slices.asl, line 13, characters 8 to 9: x -> '11111111'
+  File named-types-in-slices.asl, line 13, characters 2 to 11: x -> '11111111'

--- a/asllib/tests/print.t
+++ b/asllib/tests/print.t
@@ -1,0 +1,27 @@
+  $ cat >print.asl <<EOF
+  > func main () => integer begin
+  >   print ("Wow", 2, 3.14, "some other string");
+  >   print ("no type-checking");
+  >   print (32);
+  >   return 0;
+  > end
+
+  $ aslref print.asl
+  Wow 2 3.14 some other string
+  no type-checking
+  32
+
+  $ cat >print.asl <<EOF
+  > func main () => integer begin
+  >   print ("Wow", 2 + 3.14, "some other string");
+  >   print ("no type-checking");
+  >   print (32);
+  >   return 0;
+  > end
+
+  $ aslref print.asl
+  File print.asl, line 2, characters 16 to 24:
+  ASL Typing error: Illegal application of operator + on types integer {2}
+    and real
+  [1]
+


### PR DESCRIPTION
This simplifies the type-system, as the declaration of `print` was not supported by the current type-system: a very permissive version of it should accept any number of arguments of any type.