### PR TITLE
[asl] Remove useless definition of `_PC` as a variable

### DIFF
--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -670,9 +670,6 @@ begin
   primitive_dsb(MBReqDomainToInteger(domain),MBReqTypesToInteger(types));
 end
 
-// Branches
-var _PC : bits(64);
-
 // Hint_Branch()
 // =============
 // Report the hint passed to BranchTo() and BranchToAddr(), for consideration when processing


### PR DESCRIPTION
Having a variable and getter/setter with the same name is useless and may even prove illegal in the future.