### PR TITLE
[www] Add dependency on zarith_stubs_js

### DIFF
--- a/herd-www/README.md
+++ b/herd-www/README.md
@@ -13,11 +13,11 @@ Compilation and installation
 ============================
 
 Dependencies.
-- ocaml, dune, js_of_ocaml, js_of_ocaml-ppx.
+- ocaml, dune, menhir, js_of_ocaml, js_of_ocaml-ppx, zarith_stubs_js
 
 Install all those with opam!
 ```
-% opam install dune js_of_ocaml js_of_ocaml-ppx
+% opam install dune menhir js_of_ocaml js_of_ocaml-ppx  zarith_stubs_js
 ```
 
 Build

--- a/herd-www/dune
+++ b/herd-www/dune
@@ -4,7 +4,7 @@
   (name jerd)
   (modes js)
   (optional)
-  (libraries herdtools js_of_ocaml)
+  (libraries herdtools js_of_ocaml zarith_stubs_js)
   (preprocess (per_module
      ((pps js_of_ocaml-ppx) jerd)
      ((action (system "awk -f herd-www/notwww.awk %{input-file}"))


### PR DESCRIPTION
As long as ASL is not used, this dependency should be useless.

However, some zarith initialisation function is apparently called at startup, which enforces this new dependency.