### PR TITLE
[asl] Allow static eval of constants to fail

### DIFF
--- a/asllib/tests/asl.t/constant-zeros.asl
+++ b/asllib/tests/asl.t/constant-zeros.asl
@@ -1,0 +1,8 @@
+constant z = Zeros(15);
+
+func main () => integer
+begin
+  assert z == '000000000000000';
+
+  return 0;
+end

--- a/asllib/tests/asl.t/run.t
+++ b/asllib/tests/asl.t/run.t
@@ -31,6 +31,8 @@ Type-checking errors:
   ASL Typing error: cannot declare already declared element "i".
   [1]
 
+  $ aslref constant-zeros.asl
+
 Bad types:
   $ aslref overlapping-slices.asl
   File overlapping-slices.asl, line 1, character 0 to line 4, character 2:


### PR DESCRIPTION
This PR allows the use of more complex initialization expressions for constants.

They still need to be checked for immutability, but that depends on #787, so will be done in a sub-sequent PR.