### PR TITLE
[Asl] Support C-style comments

### DIFF
--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -32,3 +32,18 @@
   File print.asl, line 1, characters 32 to 33:
   ASL Error: Unknown symbol.
   [1]
+
+C-Style comments
+  $ cat >comments.asl <<EOF
+  > func /* this is a /* test */ main () => integer
+  > begin /*
+  > let's try a multi-line comment /*
+  > which finishes here */ constant msg = "/* a comment inside a string? */"; /* another comment
+  > that finishes somewhere **/ print (msg); // but not here! */
+  > return 0; /* oh a new one */
+  > // /* when in a commented line, it doesn't count!
+  > end
+
+  $ aslref comments.asl
+  /* a comment inside a string? */
+


### PR DESCRIPTION
This depends/conflicts with PR #774, or at least with the patch I have submitted in #783. For ease of conflict resolution, I have cherry-picked my patch onto this PR.

This PR implements C-Style comments, without nesting, as required.