### PR TITLE
[asl][typing] Typing ASL literals + correctly scan escapes in strings

### DIFF
--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -104,14 +104,43 @@ let bits = ['0' '1' 'z' ' ']*
 let mask = ['0' '1' 'x' ' ']*
 let identifier = (alpha | '_') (alpha|digit|'_')*
 
-rule token = parse
+(*
+   We are not using [Scanf.unescape] because:
+     - [Scanf.unescaped] basically follows the lexical conventions of OCaml,
+       while we follow the lexical conventions of ASL;
+     - if they were to diverge, we would have to re-implement it
+     - they do not support the same escape sequences:
+       - ASL supports only [\\], [\"], [\n], [\t]
+       - From OCaml Manual:
+            escape-sequence	::=	\ (\ ∣ " ∣ ' ∣ n ∣ t ∣ b ∣ r ∣ space)
+              ∣	 \ (0…9) (0…9) (0…9)
+              ∣	 \x (0…9 ∣ A…F ∣ a…f) (0…9 ∣ A…F ∣ a…f)
+              ∣	 \o (0…3) (0…7) (0…7)
+     - using [unescaped] is not very explicit
+     - We would still need lexing character by character because ocamllex
+       cannot match negatively on the two string character that escape the end
+       of a string literal.
+*)
+rule escaped_string_chars acc = parse
+  | 'n'  { Buffer.add_char acc '\n'; string_lit acc lexbuf }
+  | 't'  { Buffer.add_char acc '\t'; string_lit acc lexbuf }
+  | '"'  { Buffer.add_char acc '"'; string_lit acc lexbuf }
+  | '\\' { Buffer.add_char acc '\\'; string_lit acc lexbuf }
+  | [^ 'n' 't' '"' '\\'] { raise LexerError }
+
+and string_lit acc = parse
+  | '"'   { STRING_LIT (Buffer.contents acc) }
+  | '\\'  { escaped_string_chars acc lexbuf }
+  | [^ '"' '\\']+ as lxm { Buffer.add_string acc lxm; string_lit acc lexbuf }
+
+and token = parse
     | '\n'                     { Lexing.new_line lexbuf; token lexbuf }
     | [' ''\t''\r']+           { token lexbuf                     }
     | "//" [^'\n']*            { token lexbuf                     }
     | int_lit as lxm           { INT_LIT(Z.of_string lxm)         }
     | hex_lit as lxm           { INT_LIT(Z.of_string lxm)         }
     | real_lit as lxm          { REAL_LIT(Q.of_string lxm)        }
-    | '"' ([^ '"']* as lxm) '"' { STRING_LIT(lxm)                 }
+    | '"'                      { string_lit (Buffer.create 16) lexbuf }
     | '\'' (bits as lxm) '\''  { bitvector_lit lxm                }
     | '\'' (mask as lxm) '\''  { mask_lit lxm                     }
     | '!'                      { BNOT                             }

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -102,12 +102,14 @@ let rename_ty_eqs : (AST.identifier * AST.expr) list -> AST.ty -> AST.ty =
         T_Int (WellConstrained constraints) |> add_pos_from_st ty
     | _ -> ty
 
-let infer_value = function
+(* Begin Lit *)    
+let annotate_literal = function
   | L_Int _ as v -> integer_exact' (literal v)
   | L_Bool _ -> T_Bool
   | L_Real _ -> T_Real
   | L_String _ -> T_String
   | L_BitVector bv -> Bitvector.length bv |> expr_of_int |> t_bits_bitwidth
+(* End *)
 
 exception ConstraintMinMaxTop
 
@@ -930,8 +932,8 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     let () = if false then Format.eprintf "@[Annotating %a@]@." PP.pp_expr e in
     let here x = add_pos_from e x in
     match e.desc with
-    (* Begin Lit *)
-    | E_Literal v -> (infer_value v |> here, e) |: TypingRule.Lit
+    (* Begin ELit *)
+    | E_Literal v -> (annotate_literal v |> here, e) |: TypingRule.ELit
     (* End *)
     (* Begin CTC *)
     | E_CTC (e', t') ->
@@ -2143,11 +2145,11 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
     match gsd with
     | { keyword = GDK_Constant; initial_value = Some e; ty = None; name } ->
         let v = reduce_constants env e in
-        let t = infer_value v |> add_pos_from e in
+        let t = annotate_literal v |> add_pos_from e in
         declare_const loc name t v env
     | { keyword = GDK_Constant; initial_value = Some e; ty = Some ty; name } ->
         let v = reduce_constants env e in
-        let t = infer_value v |> add_pos_from e in
+        let t = annotate_literal v |> add_pos_from e in
         if Types.type_satisfies env t ty then declare_const loc name ty v env
         else conflict e [ ty.desc ] t
     | { keyword = GDK_Constant | GDK_Let; initial_value = None; _ } ->

--- a/asllib/Typing.mli
+++ b/asllib/Typing.mli
@@ -25,8 +25,6 @@
     It should provide enough information to disambiguate any type-dependent
     behaviour. *)
 
-val infer_value : AST.literal -> AST.type_desc
-
 type strictness = [ `Silence | `Warn | `TypeCheck ]
 (** Possible strictness of type-checking. *)
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -73,6 +73,7 @@
 \newcommand\annotatesubprogram[1]{\texttt{annotate\_subprogram}(#1)}
 \newcommand\declaredecl[1]{\texttt{annotate\_decl}(#1)}
 \newcommand\annotatespec[1]{\texttt{annotate\_spec}(#1)}
+\newcommand\annotateliteral[1]{\texttt{annotate\_literal}(#1)}
 
 \newcommand\tenv[0]{\texttt{env}}
 \newcommand\newenv[0]{\texttt{new\_env}}
@@ -82,6 +83,7 @@
 \newcommand\va[0]{\texttt{a}}
 \newcommand\vc[0]{\texttt{c}}
 \newcommand\vf[0]{\texttt{f}}
+\newcommand\vl[0]{\texttt{l}}
 \newcommand\vp[0]{\texttt{p}}
 \newcommand\vo[0]{\texttt{o}}
 \newcommand\vx[0]{\texttt{x}}
@@ -309,8 +311,8 @@ The expression $[i=1..k: V(i)]$, denotes the list $[V(1),\ldots,V(k)]$.
 The definition of each \texttt{annotation\_<label>} function is given by a number of
 rules, which follow the possible shapes the \texttt{label} can have. For
 example, an expression can be a literal, or a binary operator, amongst other
-things. Each of those has its own evaluation rule: TypingRule.Lit in
-Section~\ref{sec:TypingRule.Lit}, Typing.Binop in
+things. Each of those has its own evaluation rule: TypingRule.ELit in
+Section~\ref{sec:TypingRule.ELit}, Typing.Binop in
 Section~\ref{sec:TypingRule.Binop} respectively.
 
 Each rule is presented using the following template:
@@ -928,7 +930,7 @@ we use the notation $\emptylist_N$ to name the parameter.
   This is related to \identd{BMGM}, \identr{PHRL}, \identr{PZNR},
   \identr{RLQP}, \identr{LYDS}, \identr{SVDJ}, \identi{WLPJ}, \identr{FWMM},
   \identi{WPWL}, \identi{CDVY}, \identi{KFCR}, \identi{BBQR}, \identr{ZWGH},
-  \identr{DKGQ}, \identr{DHZT}, \identi{HSWR}.
+  \identr{DKGQ}, \identr{DHZT}, \identi{HSWR}, \identd{YZBQ}.
 
 \section{Constrained Types}
 
@@ -2143,7 +2145,7 @@ an environment \tenv.  Formally, the result of annotating the expression
 \texttt{e} in \tenv\ is either the pair \texttt{t, new\_e}, where \texttt{t} is a type and
 \texttt{new\_e} is a rewritten expression, or an error, and one of the following applies:
 \begin{itemize}
-\item TypingRule.Lit (see Section~\ref{sec:TypingRule.Lit});
+\item TypingRule.ELit (see Section~\ref{sec:TypingRule.ELit});
 \item TypingRule.ELocalVarConstant (see Section~\ref{sec:TypingRule.ELocalVarConstant})
 \item TypingRule.ELocalVar (see Section~\ref{sec:TypingRule.ELocalVar})
 \item TypingRule.EGlobalVarConstant (see Section~\ref{sec:TypingRule.EGlobalVarConstant})
@@ -2182,38 +2184,62 @@ The annotation rewrites the input expression in the following cases, making the 
 
 \section{TypingRule.Lit \label{sec:TypingRule.Lit}}
 
-  \subsection{Prose}
-  The result of annotating the expression \texttt{e} in \texttt{env} is
-\texttt{t,new\_e} and all of the following apply:
-  \begin{itemize}
-  \item \texttt{e} is a literal expression \texttt{v};
-  \item \texttt{t} is the type of \texttt{v} determined by the syntactic label of \texttt{v};
-  \item \texttt{new\_e} is \texttt{e}.
-  \end{itemize}
+Annotating literals is done via the function $\annotateliteral{\cdot}$,
+which we use in this chapter as well as in subsequent chapters.
+This is a helper rule for TypingRule.ELit.
+\subsection{Prose}
+The result of annotating a literal \texttt{l} is \texttt{t} and one of the following apply:
+\begin{itemize}
+\item \texttt{l} is an integer literal \texttt{n} and \texttt{t} is the well-constrained integer type, constraining
+its set to the single value \texttt{n};
+\item \texttt{l} is a Boolean literal and \texttt{t} is the Boolean type;
+\item \texttt{l} is a real literal and \texttt{t} is the real type;
+\item \texttt{l} is a string literal and \texttt{t} is the string type; 
+\item \texttt{l} is a bitvector literal of length \texttt{n} and \texttt{t} is the bitvector type of fixed width \texttt{n}.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example: TypingRule.Lit.asl}
+In the following example, we show several literals and their corresponding types in comments:
+\VerbatimInput{../tests/ASLTypingReference.t/TypingRule.Lit.asl}
 
   \subsection{Code}
   \VerbatimInput[firstline=\LitBegin, lastline=\LitEnd]{../Typing.ml}
 
 \begin{emptyformal}
   \subsection{Formally}
-  
-\begin{mathpar}
-\inferrule{\ve = \Elit{n}}{\annotateexpr{\tenv, \ve}= (\TInt(\langle[\texttt{Constraint\_Exact}(\Elit{n})]\rangle), \ve)}
-\and
-\inferrule{\ve = \eliteral{\lbool(\Ignore)}}{\annotateexpr{\tenv, \ve}= (\TBool, \ve)}
-\and
-\inferrule{\ve = \eliteral{\lreal(\Ignore)}}{\annotateexpr{\tenv, \ve}= (\TReal, \ve)}
-\and
-\inferrule{\ve = \eliteral{\lstring(\Ignore)}}{\annotateexpr{\tenv, \ve}= (\TString, \ve)}
-\and
-\inferrule{\ve = \eliteral{\lbitvector(b_{1..n})}}
-{\annotateexpr{\tenv, \ve}= (\TBits(\texttt{Bitwidth\_SingleExpr}(\Elit{n}), \emptylist), \ve)}
-\end{mathpar}
+  \begin{mathpar}
+    \inferrule{}{\annotateliteral{\Elit{n}}= \TInt(\langle[\texttt{Constraint\_Exact}(\Elit{n})]\rangle)}
+    \and
+    \inferrule{}{\annotateliteral{\eliteral{\lbool(\Ignore)}}= \TBool}
+    \and
+    \inferrule{}{\annotateliteral{\eliteral{\lreal(\Ignore)}}= \TReal}
+    \and
+    \inferrule{}{\annotateliteral{\eliteral{\lstring(\Ignore)}}= \TString}
+    \and
+    \inferrule{\vl = \eliteral{\lbitvector(b_{1..n})}}
+    {\annotateliteral{\vl}= \TBits(\texttt{Bitwidth\_SingleExpr}(\Elit{n}), \emptylist)}
+  \end{mathpar}
 \end{emptyformal}
 
-\isempty{\subsection{Comments}}
+\section{TypingRule.ELit \label{sec:TypingRule.ELit}}
+  \subsection{Prose}
+  The result of annotating the expression \texttt{e} in \texttt{env} is
+\texttt{t,new\_e} and all of the following apply:
+  \begin{itemize}
+  \item \texttt{e} is a literal expression \texttt{v};
+  \item \texttt{t} is the type of the literal \texttt{v};
+  \item \texttt{new\_e} is \texttt{e}.
+  \end{itemize}
+  \subsection{Example}
+  \subsection{Code}
+  \VerbatimInput[firstline=\ELitBegin, lastline=\ELitEnd]{../Typing.ml}
+\begin{emptyformal}
+  \subsection{Formally}
+\begin{mathpar}
+\inferrule{\ve \in \literal \\ \vt = \annotateliteral{\ve} \\ \newe = \tenv}
+{\annotateexpr{\tenv, \ve} = (\vt, \newe)}
+\end{mathpar}
+\end{emptyformal}
 
 \section{TypingRule.ELocalVarConstant \label{sec:TypingRule.ELocalVarConstant}}
 
@@ -5722,7 +5748,7 @@ in \texttt{new\_env} and one of the following applies:
   \inferrule[Case 1]{
     \gsd = \{\textsf{keyword} : \texttt{GDK\_Constant}, \textsf{initial\_value} : \langle \ve \rangle, \textsf{ty} : \langle\rangle, \textsf{name}:\name \}\\
     \vv = \texttt{reduce\_constants}(\tenv, \ve)\\
-    \vt = \texttt{type\_of\_literal}(\vv)\\
+    \vt = \annotateliteral{\vv}\\
     \newenv = \texttt{declare\_const}(\tenv, \name, \vt, \vv)
   }
   { \declaredecl{\tenv, \gsd} = \newenv }
@@ -5730,7 +5756,7 @@ in \texttt{new\_env} and one of the following applies:
   \inferrule[Case 2]{
     \gsd = \{\textsf{keyword} : \texttt{GDK\_Constant}, \textsf{initial\_value} : \langle \ve \rangle, \textsf{ty} : \langle\tty\rangle, \textsf{name}:\name \}\\
     \vv = \texttt{reduce\_constants}(\tenv, \ve)\\
-    \vt = \texttt{type\_of\_literal}(\vv)\\
+    \vt = \annotateliteral{\vv}\\
     \typesat(\tenv, \vt, \tty)\\
     \newenv = \texttt{declare\_const}(\tenv, \name, \tty, \vv)
   }

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -318,7 +318,7 @@ module TypingRule = struct
     | LowestCommonAncestor
     | CheckUnop
     | CheckBinop
-    | Lit
+    | ELit
     | CTC
     | ELocalVarConstant
     | ELocalVar
@@ -451,7 +451,7 @@ module TypingRule = struct
     | CheckUnop -> "CheckUnop"
     | CheckBinop -> "CheckBinop"
     | LowestCommonAncestor -> "LowestCommonAncestor"
-    | Lit -> "Lit"
+    | ELit -> "ELit"
     | CTC -> "CTC"
     | ELocalVarConstant -> "ELocalVarConstant"
     | ELocalVar -> "ELocalVar"
@@ -587,7 +587,7 @@ module TypingRule = struct
       CheckUnop;
       CheckBinop;
       LowestCommonAncestor;
-      Lit;
+      ELit;
       CTC;
       ELocalVarConstant;
       ELocalVar;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.Lit.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.Lit.asl
@@ -1,0 +1,15 @@
+func main () => integer
+begin
+  var n1 = 5; // type: integer{5}
+  var n2 = 1_000__000; // type integer{1000000}
+  var n4 = 0xa_b_c_d_e_f__A__B__C__D__E__F__0___12345567890;
+           // type integer{53170898287292728730499578000}
+  var btrue = TRUE; // type: boolean
+  var bfalse = FALSE; // type: boolean
+  var rzero = 1234567890.0123456789; // type: real
+  var s1 = "hello\\world \n\t \"here I am \""; // type: string
+  var s2 = ""; // type: string
+  var bv1 = '11 01'; // type: bits(4)
+  var bv2 = ''; // type: bits(0)
+  return 0;
+end

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -20,3 +20,4 @@ ASL Typing Reference:
   $ aslref TypingRule.LDVar.asl
   $ aslref TypingRule.LDTyped.asl
   $ aslref TypingRule.LDTuple.asl
+  $ aslref TypingRule.Lit.asl

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -1,0 +1,34 @@
+  $ cat >print.asl <<EOF
+  > constant msg = "old pond\\nfrog leaps in\\nwater's sound";
+  > func main () => integer begin print(msg); return 0; end
+  $ aslref print.asl
+  old pond
+  frog leaps in
+  water's sound
+  $ cat >print.asl <<EOF
+  > constant msg = "old pond\\n\\tfrog\\tleaps in\\nwater's\\tsound";
+  > func main () => integer begin print(msg); return 0; end
+  $ aslref print.asl
+  old pond
+  	frog	leaps in
+  water's	sound
+  $ cat >print.asl <<EOF
+  > constant msg = "Check out this haiku:\\n\\t\\"old pond\\n\\tfrog leaps in\\n\\twater's sound\\"";
+  > func main () => integer begin print(msg); return 0; end
+  $ aslref print.asl
+  Check out this haiku:
+  	"old pond
+  	frog leaps in
+  	water's sound"
+  $ cat >print.asl <<EOF
+  > constant msg = "Something with \\\\ backslashes.";
+  > func main () => integer begin print(msg); return 0; end
+  $ aslref print.asl
+  Something with \ backslashes.
+  $ cat >print.asl <<EOF
+  > constant msg = "Something with \\p bad characters.";
+  > func main () => integer begin print(msg); return 0; end
+  $ aslref print.asl
+  File print.asl, line 1, characters 32 to 33:
+  ASL Error: Unknown symbol.
+  [1]


### PR DESCRIPTION
Corrected scanning escape sequences in strings.
Added a new lexer.t test.
Renamed `infer_value` to `annotate_literal`.
Formalized `annotate_literal` in the typing reference. Added a new test for literals.