### PR TITLE
[fix][asl] Fix compilation with ocaml 4.

### DIFF
--- a/asllib/tests/toposort.ml
+++ b/asllib/tests/toposort.ml
@@ -1,3 +1,5 @@
+[@@@warning "-44-40"]
+
 let ( <-- ) a b = (a, b)
 
 module ISet = Set.Make (Int)
@@ -25,9 +27,16 @@ let from_edges =
         (fun v -> IMap.update v (function None -> Some ISet.empty | s -> s))
         nodes succ_map
     in
-    (ISet.to_list nodes, fun v -> IMap.find v succ_map |> ISet.to_list)
+    (ISet.elements nodes, fun v -> IMap.find v succ_map |> ISet.elements)
 
-module TS = Asllib.TopoSort.Make (Int)
+(* Compatibility layer around Int. *)
+module I = struct
+  let hash : int -> int = Hashtbl.hash [@@warning "-32"]
+
+  include Int
+end
+
+module TS = Asllib.TopoSort.Make (I)
 
 let print_fold os () =
   Format.(


### PR DESCRIPTION
Error introduced by #787 

I have now installed a switch with ocaml 4.10 so I'll be able to test that back. However, there are no switches available for my machine for 4.08.2 so I'm planning to add a ci job to test that on demand (EDIT, it is PR #801).