### PR TITLE
[ci] Add optionnal workflow to run make test

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -1,0 +1,41 @@
+name: build & make test
+
+on:
+  pull_request:
+  # push:
+  workflow_dispatch:
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+permissions: read-all
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          # - macos-latest # Very slow
+          - ubuntu-latest
+          # - windows-latest # Unsupported?
+        ocaml-compiler:
+          - "4.08.1"
+          - "5.1"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@v4
+
+      - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install . --deps-only --with-test
+
+      - run: opam exec -- make build
+
+      - run: opam exec -- make test


### PR DESCRIPTION
This workflows run `make test` with the following ocaml versions: `5.1` and `4.08.1`, on both `macos` and `ubuntu`. It is triggers manually, or once a week for master.

This PR is rebased on #800 to make the test pass.

It has also been tested with the following:
 - use of ocaml.4.10+ only Stdlib values, workflow with ocaml.4.8 fails
 - warnings only on ocaml.5.0+ Stdlib, workflow with ocaml.5.1 fails
 - no warning on neither, both workflows pass

A few notes:
1. no workflow is shown on this PR as manually dispatched workflows can only be used once merged on master.
2. We can easily activate automatic runs of this CI on every push on branches, or various different triggers.
3. I only used 2 versions of ocaml because I believe it is enough for a day to day use, but we can extend it with different versions if needed, same for the operating systems.