### PR TITLE
[all]: Rework Neon load/store and load/store pair

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -582,7 +582,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let emit_load_reg temporal st init rA =
         let r1,st = next_vreg st in
         let r2,st = next_vreg st in
-        let ldp = [I_LDP_SIMD(temporal,A64.VSIMD32,to_scalar r1,to_scalar r2,rA,0)] in
+        let ldp = [I_LDP_SIMD(temporal,A64.VSIMD32,to_scalar r1,to_scalar r2,rA,(0,A64.Idx))] in
         let r3,st = next_vreg st in
         let add = [I_ADD_SIMD (r3,r1,r2)] in
         let rX,st = next_reg st in
@@ -603,7 +603,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     module LDUR = struct
       let emit_load_reg st init rA =
         let r,st = next_scalar_reg st in
-        let ldur = [I_LDUR_SIMD(A64.VSIMD32,r,rA,None)] in
+        let ldur = [I_LDUR_SIMD(A64.VSIMD32,r,rA,0)] in
         let rX,st = next_reg st in
         let fmov = [I_FMOV_TG(A64.V32,rX,A64.VSIMD32,r)] in
         rX,init,lift_code (ldur@fmov),st
@@ -622,7 +622,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     module LDAPUR = struct
       let emit_load_reg st init rA =
         let r,st = next_scalar_reg st in
-        let ldur = [I_LDAPUR_SIMD(A64.VSIMD32,r,rA,None)] in
+        let ldur = [I_LDAPUR_SIMD(A64.VSIMD32,r,rA,0)] in
         let rX,st = next_reg st in
         let fmov = [I_FMOV_TG(A64.V32,rX,A64.VSIMD32,r)] in
         rX,init,lift_code (ldur@fmov),st
@@ -834,7 +834,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let r1,st = next_vreg st in
         let r2,st = next_vreg st in
         let movi = List.mapi (fun i r -> movi_reg r (v+i)) [r1;r2] in
-        let stp = [I_STP_SIMD(temporal,A64.VSIMD32,to_scalar r1,to_scalar r2,rA,0)] in
+        let stp = [I_STP_SIMD(temporal,A64.VSIMD32,to_scalar r1,to_scalar r2,rA,(0,A64.Idx))] in
         init,pseudo movi@pseudo stp,st
 
       let emit_store n st p init loc v =
@@ -854,7 +854,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let r2,st = next_vreg st in
         let movi = List.mapi (fun i r -> movi_reg r (v+i)) [r1;r2] in
         let adds = List.map (fun v -> add_simd v rB) [r1;r2] in
-        let stp = [I_STP_SIMD(temporal,A64.VSIMD32,to_scalar r1,to_scalar r2,rA,0)] in
+        let stp = [I_STP_SIMD(temporal,A64.VSIMD32,to_scalar r1,to_scalar r2,rA,(0,A64.Idx))] in
         init,lift_code(dup@movi@adds@stp),st
     end
 
@@ -862,7 +862,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let emit_store_reg st init rA v =
         let r,st = next_vreg st in
         let movi = [movi_reg r v] in
-        let stur = [I_STUR_SIMD(A64.VSIMD32,to_scalar r,rA,None)] in
+        let stur = [I_STUR_SIMD(A64.VSIMD32,to_scalar r,rA,0)] in
         init,lift_code(movi@stur),st
 
       let emit_store st p init loc v =
@@ -881,7 +881,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let r1,st = next_vreg st in
         let movi = [movi_reg r1 v] in
         let adds = [add_simd r1 rB]in
-        let stur = [I_STUR_SIMD(A64.VSIMD32,to_scalar r1,rA,None)] in
+        let stur = [I_STUR_SIMD(A64.VSIMD32,to_scalar r1,rA,0)] in
         init,lift_code(dup@movi@adds@stur),st
     end
 
@@ -889,7 +889,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let emit_store_reg st init rA v =
         let r,st = next_vreg st in
         let movi = [movi_reg r v] in
-        let stlur = [I_STLUR_SIMD(A64.VSIMD32,to_scalar r,rA,None)] in
+        let stlur = [I_STLUR_SIMD(A64.VSIMD32,to_scalar r,rA,0)] in
         init,lift_code(movi@stlur),st
 
       let emit_store st p init loc v =
@@ -908,7 +908,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         let r1,st = next_vreg st in
         let movi = [movi_reg r1 v] in
         let adds = [add_simd r1 rB]in
-        let stlur = [I_STLUR_SIMD(A64.VSIMD32,to_scalar r1,rA,None)] in
+        let stlur = [I_STLUR_SIMD(A64.VSIMD32,to_scalar r1,rA,0)] in
         init,lift_code(dup@movi@adds@stlur),st
     end
 

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -90,16 +90,16 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_EOR_SIMD _| I_ERET| I_FENCE _| I_GC _| I_IC _| I_LD1 _| I_LD1M _| I_LD1R _ | I_LDAP1 _
     | I_LD2 _| I_LD2M _| I_LD2R _| I_LD3 _| I_LD3M _| I_LD3R _| I_LD4 _| I_LD4M _
     | I_LD4R _| I_LDAR _| I_LDARBH _| I_LDCT _| I_LDG _| I_LDOP _| I_LDOPBH _
-    | I_LDP _| I_LDP_P_SIMD _| I_LDP_SIMD _| I_LDPSW _| I_LDR _
-    | I_LDRSW _ | I_LDR_P_SIMD _ | I_LDAPUR_SIMD _
-    | I_LDR_SIMD _| I_LDRBH _| I_LDRS _| I_LDUR _| I_LDUR_SIMD _| I_LDXP _| I_MOV _ | I_FMOV_TG _
+    | I_LDP _| I_LDP_SIMD _| I_LDPSW _| I_LDR _
+    | I_LDRSW _ | I_LDR_SIMD _ | I_LDAPUR_SIMD _
+    | I_LDRBH _| I_LDRS _| I_LDUR _| I_LDUR_SIMD _| I_LDXP _| I_MOV _ | I_FMOV_TG _
     | I_ADDV _| I_DUP _ | I_MOV_FG _| I_MOV_S _| I_MOV_TG _| I_MOV_V _| I_MOV_VE _| I_MOVI_S _
     | I_MOVI_V _| I_MOVK _| I_MOVZ _| I_MOVN _| I_MRS _| I_MSR _| I_OP3 _| I_RBIT _
     | I_RET _
     | I_SBFM _| I_SC _| I_SEAL _| I_ST1 _| I_STL1 _| I_ST1M _| I_ST2 _| I_ST2M _| I_ST3 _
     | I_ST3M _| I_ST4 _| I_ST4M _| I_STCT _| I_STG _| I_STLR _| I_STLRBH _| I_STOP _
-    | I_STOPBH _| I_STP _| I_STP_P_SIMD _| I_STP_SIMD _| I_STR _ | I_STLUR_SIMD _
-    | I_STR_P_SIMD _| I_STR_SIMD _| I_STRBH _| I_STUR_SIMD _| I_STXP _| I_STXR _
+    | I_STOPBH _| I_STP _| I_STP_SIMD _| I_STR _ | I_STLUR_SIMD _
+    | I_STR_SIMD _| I_STRBH _| I_STUR_SIMD _| I_STXP _| I_STXR _
     | I_STXRBH _| I_STZG _| I_STZ2G _
     | I_SWP _| I_SWPBH _| I_SXTW _| I_TLBI _| I_UBFM _
     | I_UDF _| I_UNSEAL _ | I_ADDSUBEXT _ | I_ABS _ | I_REV _ | I_EXTR _
@@ -229,10 +229,10 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDOP (_,v,_,_,_,_) | I_STOP (_,v,_,_,_) ->
           Some (tr_variant v)
       | I_STZG _|I_STZ2G _ -> Some MachSize.granule
-      | I_LDR_SIMD (v,_,_,_,_) | I_LDR_P_SIMD (v,_,_,_)
-      | I_LDP_SIMD (_,v,_,_,_,_) | I_LDP_P_SIMD (_,v,_,_,_,_)
-      | I_STR_SIMD (v,_,_,_,_) | I_STR_P_SIMD (v,_,_,_)
-      | I_STP_SIMD (_,v,_,_,_,_) | I_STP_P_SIMD (_,v,_,_,_,_)
+      | I_LDR_SIMD (v,_,_,_)
+      | I_LDP_SIMD (_,v,_,_,_,_)
+      | I_STR_SIMD (v,_,_,_)
+      | I_STP_SIMD (_,v,_,_,_,_)
       | I_LDUR_SIMD (v,_,_,_) | I_STUR_SIMD (v,_,_,_)
       | I_LDAPUR_SIMD (v,_,_,_) | I_STLUR_SIMD (v,_,_,_) ->
           Some (tr_simd_variant v)
@@ -344,10 +344,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD3R _|I_LD4 _|I_LD4M _|I_LD4R _
       | I_ST1 _|I_ST1M _|I_ST2 _|I_ST2M _
       | I_ST3 _|I_ST3M _|I_ST4 _|I_ST4M _
-      | I_LDP_P_SIMD _|I_STP_P_SIMD _
       | I_LDP_SIMD _|I_STP_SIMD _
-      | I_LDR_SIMD _|I_LDR_P_SIMD _
-      | I_STR_SIMD _|I_STR_P_SIMD _
+      | I_LDR_SIMD _|I_STR_SIMD _
       | I_LDUR_SIMD _|I_LDAPUR_SIMD _|I_STUR_SIMD _|I_STLUR_SIMD _
       | I_MOV_VE _
       | I_MOV_V _|I_MOV_TG _|I_MOV_FG _
@@ -376,10 +374,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD4 _|I_LD4M _|I_LD4R _|I_ST1 _|I_STL1 _
       | I_ST1M _|I_ST2 _|I_ST2M _|I_ST3 _
       | I_ST3M _|I_ST4 _|I_ST4M _
-      | I_LDP_P_SIMD _|I_STP_P_SIMD _
       | I_LDP_SIMD _|I_STP_SIMD _
-      | I_LDR_SIMD _|I_LDR_P_SIMD _
-      | I_STR_SIMD _|I_STR_P_SIMD _
+      | I_LDR_SIMD _|I_STR_SIMD _
       | I_LDUR_SIMD _|I_LDAPUR_SIMD _|I_STUR_SIMD _|I_STLUR_SIMD _
       | I_MOV_VE _
       | I_MOV_V _|I_MOV_TG _|I_MOV_FG _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2511,7 +2511,6 @@ module Make
             ldrs sz (tr_variant v) rd rs e ii
         | I_LDUR(var,rd,rs,k) ->
             let sz = tr_variant var in
-            let k = match k with Some k -> k | None -> 0 in
             ldr sz rd rs (MemExt.k2idx k) ii
         | I_LDAR(var,t,rd,rs) ->
             let sz = tr_variant var in

--- a/herd/tests/instructions/AArch64/A19.litmus.expected
+++ b/herd/tests/instructions/AArch64/A19.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:X0=2)
 Observation A19 Always 1 0
-Hash=513393febe8e91d350053aa3ce4fb159
+Hash=137ab50692552983823fd94b6906256f
 

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -170,9 +170,7 @@ include Arch.MakeArch(struct
         | Some(x),Some(_) -> Some(x)
         | _ -> None end  >>>
         add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')]
-    | I_LDUR(_,r1,r2,None),I_LDUR(_,r1',r2',None)
-      -> add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')] subs
-    | I_LDUR(_,r1,r2,Some(k)),I_LDUR(_,r1',r2',Some(k'))
+    | I_LDUR(_,r1,r2,k),I_LDUR(_,r1',r2',k')
       ->
         match_kr subs (K k) (K k') >>>
         add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')]
@@ -431,15 +429,11 @@ include Arch.MakeArch(struct
         conv_reg r2 >> fun r2 ->
         MemExt.expl e >! fun e ->
         I_LDRS(v,r1,r2,e)
-    | I_LDUR(a,r1,r2,Some(k)) ->
+    | I_LDUR(a,r1,r2,k) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->
         find_cst k >! fun k ->
-        I_LDUR(a,r1,r2,Some(k))
-    | I_LDUR(a,r1,r2,None) ->
-        conv_reg r1 >> fun r1 ->
-        conv_reg r2 >! fun r2 ->
-        I_LDUR(a,r1,r2,None)
+        I_LDUR(a,r1,r2,k)
     | I_LDP(t,a,r1,r2,r3,idx) ->
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >> fun r2 ->

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -659,10 +659,9 @@ include Arch.MakeArch(struct
     | I_ST2 _ | I_ST2M _
     | I_ST3 _ | I_ST3M _
     | I_ST4 _ | I_ST4M _
-    | I_LDP_SIMD _ | I_LDP_P_SIMD _
-    | I_STP_SIMD _ | I_STP_P_SIMD _
-    | I_LDR_SIMD _ | I_LDR_P_SIMD _
-    | I_STR_SIMD _ | I_STR_P_SIMD _
+    | I_LDP_SIMD _
+    | I_STP_SIMD _
+    | I_LDR_SIMD _ | I_STR_SIMD _
     | I_LDUR_SIMD _ | I_LDAPUR_SIMD _
     | I_STUR_SIMD _ | I_STLUR_SIMD _
     | I_ADDV _ | I_DUP _ | I_FMOV_TG _

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1096,7 +1096,7 @@ type 'k kinstruction =
 (* Load and Store *)
   | I_LDR of variant * reg * reg * 'k MemExt.ext
   | I_LDRSW of reg * reg * 'k MemExt.ext
-  | I_LDUR of variant * reg * reg * 'k option
+  | I_LDUR of variant * reg * reg * 'k
 (* Neon Extension Load and Store*)
   | I_LD1 of reg list * int * reg * 'k kr
   | I_LDAP1 of reg list * int * reg * 'k kr
@@ -1482,10 +1482,8 @@ let do_pp_instruction m =
       pp_mem_ext "LDRSW" V64 r1 r2 idx
   | I_LDRS ((v,bh),r1,r2,idx) ->
      pp_mem_ext (ldrs_memo bh) v r1 r2 idx
-  | I_LDUR (_,r1,r2,None) ->
-      sprintf "LDUR %s, [%s]" (pp_reg r1) (pp_reg r2)
-  | I_LDUR (_,r1,r2,Some(k)) ->
-      sprintf "LDUR %s, [%s, %s]" (pp_reg r1) (pp_reg r2) (m.pp_k k)
+  | I_LDUR (_,r1,r2,k) ->
+      sprintf "LDUR %s, [%s%s]" (pp_reg r1) (pp_reg r2) (pp_kr false false (K k))
   | I_LDP (t,v,r1,r2,r3,idx) ->
       pp_memp (ldp_memo t) v r1 r2 r3 idx
   | I_LDPSW (r1,r2,r3,idx) ->
@@ -2555,9 +2553,7 @@ module PseudoI = struct
         | I_LDR (v,r1,r2,idx) -> I_LDR (v,r1,r2,ext_tr idx)
         | I_LDRSW (r1,r2,idx) -> I_LDRSW (r1,r2,ext_tr idx)
         | I_LDRS (v,r1,r2,idx) -> I_LDRS (v,r1,r2,ext_tr idx)
-
-        | I_LDUR (v,r1,r2,None) -> I_LDUR (v,r1,r2,None)
-        | I_LDUR (v,r1,r2,Some(k)) -> I_LDUR (v,r1,r2,Some(k_tr k))
+        | I_LDUR (v,r1,r2,k) -> I_LDUR (v,r1,r2,k_tr k)
         | I_LDP (t,v,r1,r2,r3,idx) -> I_LDP (t,v,r1,r2,r3,idx_tr idx)
         | I_LDPSW (r1,r2,r3,idx) -> I_LDPSW (r1,r2,r3,idx_tr idx)
         | I_STP (t,v,r1,r2,r3,idx) -> I_STP (t,v,r1,r2,r3,idx_tr idx)

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -247,10 +247,6 @@ k:
 | NUM  { MetaConst.Int $1 }
 | META { MetaConst.Meta $1 }
 
-k0_opt:
-| { None }
-| COMMA k { Some $2}
-
 k0:
 | { MetaConst.zero }
 | COMMA k=k { k }
@@ -519,7 +515,7 @@ instr:
   { let (v, s) = $2 and (ra,ext) = $4 in I_LDRS ((v,B),s,ra,ext) }
 | LDRSH reg COMMA mem_ea
   { let (v, s) = $2 and (ra,ext) = $4 in I_LDRS ((v,H),s,ra,ext) }
-| LDUR reg COMMA LBRK cxreg k0_opt RBRK
+| LDUR reg COMMA LBRK cxreg k0 RBRK
   { let v,r = $2 in I_LDUR (v,r,$5,$6)}
 
 | instr=ldp_instr r1=wreg COMMA r2=wreg COMMA ea=mem_idx

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1256,8 +1256,7 @@ module Make(V:Constant.S)(C:Config) =
 (* Load and Store *)
     | I_LDR (v,r1,r2,idx) -> load "ldr" v r1 r2 idx::k
     | I_LDRSW (r1,r2,idx) -> load "ldrsw" V64 r1 r2 idx::k
-    | I_LDUR (v,r1,r2,Some(k')) -> load "ldur" v r1 r2 (MemExt.k2idx k')::k
-    | I_LDUR (v,r1,r2,None) -> load "ldur" v r1 r2 (MemExt.k2idx 0)::k
+    | I_LDUR (v,r1,r2,k') -> load "ldur" v r1 r2 (MemExt.k2idx k')::k
     | I_LDP (t,v,r1,r2,r3,idx) ->
         load_pair (ldp_memo t) v r1 r2 r3 idx::k
     | I_LDPSW (r1,r2,r3,idx) ->


### PR DESCRIPTION
Currently Neon load/store is split in two instructions: one for handling immediate/register offset and another for handling post-index variant. The similar applies to Neon load/store pair. Note, missing support for pre-index variant for Neon load/store.

Let's refactor those instructions to take advantage of existing infrastructure for handling addressing modes. That removes need for special instruction for post-index variant and as a bonus naturally brings support for pre-index variant for Neon load/store.