### PR TITLE
[herd] Introduce Monad.S.map

### DIFF
--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -134,6 +134,10 @@ Monad type:
       let eid', (evt, evt_spec) = m eid in
       (eid', (Evt.map f evt, Option.map (Evt.map f) evt_spec))
 
+    let map (m : 'a t) (f: 'a -> 'b): 'b t =
+      let f_elt (a, ctnts, event_graph) = (f a, ctnts, event_graph) in
+      map_elt f_elt m
+
  (* Code monad slight differs as regardes agument *)
  (* Threading by instruction instance identifier and event id proper *)
 

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -55,6 +55,9 @@ module type S =
     val delay_kont : string -> 'a t -> ('a ->  'a t -> 'b t) -> 'b t
     val delay : 'a t -> ('a * 'a t) t
 
+    (** [map t f] applies [f] on [t]'s values, without touching the graphs. *)
+    val map : 'a t -> ('a -> 'b) -> 'b t
+
     val set_standard_input_output : 'a t -> 'a t
 
     (* [restrict constraints] is an empty monad with the constraints [constraints] *)


### PR DESCRIPTION
Following discussions with colleagues, I found that there should be a `map` operator in the monad module signature.

This handy small function should prove useful when we today would use a binder with a function that does not create a graph. For example, adding an immediate value to another.

As usual, I have not implemented any use for this, as I am not sure this will get accepted. They will come in subsequent PRs.