### PR TITLE
[litmus] Correctly handle MTE precision and fix -variant ifetch

### DIFF
--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1807,7 +1807,7 @@ module Make
         O.oi "sense_t *_b = &_ctx->b;" ;
         O.oi "log_t *_log = &_ctx->out;" ;
         if some_ptr then O.oi "log_ptr_t *_log_ptr = &_ctx->out_ptr;" ;
-        if some_test_vars test then begin
+        if some_test_vars test || do_self then begin
           O.oi "vars_t *_vars = &_ctx->v;"
         end ;
         begin match test.T.globals with

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -52,4 +52,4 @@ let set_fault_handling r = function
 | FaultHandling p -> r := p ; true
 | _ -> false
 
-let set_mte_precision _ _ = assert false
+let set_mte_precision _ _ = false


### PR DESCRIPTION
This change makes two small fixes which are necessary to run:
* Tests that specify the fault handling variant as part of the test, for example:

$> litmus7 -a 4 -mach kvm-aarch64 -o ~/kvm-unit-tests/t catalogue/aarch64-faults/tests/3faults.litmus

* Tests that use the -variant self and do not use any memory locations, for example:

$> litmus7 -a 4 -mach kvm-aarch64 -o ~/kvm-unit-tests/t catalogue/aarch64-ifetch/tests/UDF+2FH.litmus