### PR TITLE
[herd]: Fix address generation for STG, LDG and friends

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2255,7 +2255,7 @@ module Make
         end
 
       let ldg rt rn k ii =
-        let ma = get_ea rn (AArch64.K k) AArch64.S_NOEXT ii in
+        let ma = get_ea rn (AArch64.K k) (AArch64.S_LSL MachSize.granule_log2bytes) ii in
         let do_ldg a_virt ac ma =
           let ( let* ) = (>>=) in
           let _do_ldg a =
@@ -2277,7 +2277,7 @@ module Make
       type double = Once|Twice
 
       let stg d rt rn k ii =
-        let ma = get_ea rn (AArch64.K k) AArch64.S_NOEXT ii
+        let ma = get_ea rn (AArch64.K k) (AArch64.S_LSL MachSize.granule_log2bytes) ii
         and mv = read_reg_data MachSize.Quad rt ii >>= tag_extract in
         let do_stg ac ma mv =
           let __do_stg a v =
@@ -2313,7 +2313,7 @@ module Make
                  M.op1 (Op.AddK MachSize.granule_nbytes) a
                  >>= fun a -> do_write_mem sz Annot.N aexp  ac a v ii in
                (mop1 >>| mop2) >>! () in
-        let ma = get_ea rn (AArch64.K k) AArch64.S_NOEXT ii >>= loc_extract in
+        let ma = get_ea rn (AArch64.K k) (AArch64.S_LSL MachSize.granule_log2bytes) ii >>= loc_extract in
         lift_memop rn Dir.W true false (* Unchecked *)
           (fun ac ma mv ->
             if Access.is_physical ac then begin

--- a/herd/tests/instructions/AArch64.MTE/B009.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B009.litmus
@@ -1,0 +1,13 @@
+AArch64 B009
+{
+int x[8]={1,2,3,4,5,6,7,8};
+
+0:X0=x:green; 0:X1=x:red;
+}
+P0                ;
+STG X1,[X0,#1]    ;
+DSB SY            ;
+MOV W2,#9         ;
+STR W2,[X0,#16]   ;
+
+forall fault(P0,x)

--- a/herd/tests/instructions/AArch64.MTE/B009.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B009.litmus.expected
@@ -1,0 +1,10 @@
+Test B009 Required
+States 1
+ Fault(P0,x:green+16,TagCheck);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0,x))
+Observation B009 Always 1 0
+Hash=a0049bcae76b7e6c49f320a8c62b6b8b
+

--- a/herd/tests/instructions/AArch64.MTE/B010.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B010.litmus
@@ -1,0 +1,13 @@
+AArch64 B010
+{
+int x[8]={1,2,3,4,5,6,7,8};
+
+0:X0=x:green; 0:X1=x:red;
+}
+P0                ;
+STG X1,[X0,#1]    ;
+DSB SY            ;
+MOV W2,#9         ;
+STR W2,[X0,#12]   ;
+
+forall ~fault(P0,x)

--- a/herd/tests/instructions/AArch64.MTE/B010.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B010.litmus.expected
@@ -1,0 +1,10 @@
+Test B010 Required
+States 1
+  ~Fault(P0,x);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (not (fault(P0,x)))
+Observation B010 Always 1 0
+Hash=96b31e9a3d4696c3cc7ba14e1aa59685
+

--- a/herd/tests/instructions/AArch64.MTE/B011.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B011.litmus
@@ -1,0 +1,13 @@
+AArch64 B011
+{
+int x[8]={1,2,3,4,5,6,7,8};
+
+0:X0=x:green; 0:X1=x:red;
+}
+P0                ;
+STG X1,[X0,#1]    ;
+DSB SY            ;
+MOV W2,#9         ;
+STR W2,[X1]       ;
+
+forall fault(P0,x)

--- a/herd/tests/instructions/AArch64.MTE/B011.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B011.litmus.expected
@@ -1,0 +1,10 @@
+Test B011 Required
+States 1
+ Fault(P0,x:red,TagCheck);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0,x))
+Observation B011 Always 1 0
+Hash=8cade37cdb9933f54d962504c55ec46f
+

--- a/herd/tests/instructions/AArch64.MTE/B012.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B012.litmus
@@ -1,0 +1,13 @@
+AArch64 B012
+{
+int x[8]={1,2,3,4,5,6,7,8};
+
+0:X0=x:green; 0:X1=x:red;
+}
+P0                ;
+STG X1,[X0,#1]    ;
+DSB SY            ;
+MOV W2,#9         ;
+STR W2,[X1,#16]    ;
+
+forall ~fault(P0,x)

--- a/herd/tests/instructions/AArch64.MTE/B012.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B012.litmus.expected
@@ -1,0 +1,10 @@
+Test B012 Required
+States 1
+  ~Fault(P0,x);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (not (fault(P0,x)))
+Observation B012 Always 1 0
+Hash=d24bc3e60702c74ece0d92df2985281b
+

--- a/herd/tests/instructions/AArch64.MTE/B013.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B013.litmus
@@ -1,0 +1,14 @@
+AArch64 B013
+{
+int x[8]={1,2,3,4,5,6,7,8};
+
+0:X0=x:green; 0:X1=x:red;
+}
+P0                ;
+STG X1,[X0,#1]    ;
+DSB SY            ;
+LDG X2,[X0]       ;
+LDG X3,[X0,#1]    ;
+SUB X3,X3,#16     ;
+
+forall 0:X2=x:green /\ 0:X3=x:red

--- a/herd/tests/instructions/AArch64.MTE/B013.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B013.litmus.expected
@@ -1,0 +1,10 @@
+Test B013 Required
+States 1
+0:X2=x:green; 0:X3=x:red;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=x:green /\ 0:X3=x:red)
+Observation B013 Always 1 0
+Hash=61e3ccc9a6795411106ff0b5f9ca313a
+

--- a/lib/machSize.ml
+++ b/lib/machSize.ml
@@ -45,6 +45,13 @@ let nbytes = function
   | Quad -> 8
   | S128 -> 16
 
+let log2bytes = function
+  | Byte -> 0
+  | Short -> 1
+  | Word -> 2
+  | Quad -> 3
+  | S128 -> 4
+
 let nbits sz = nbytes sz * 8
 
 (* check is 16 bit immediate *)
@@ -215,5 +222,7 @@ type lr_sc =
 let granule = S128
 
 let granule_nbytes = nbytes granule
+
+let granule_log2bytes = log2bytes granule
 
 let granule_align x = (x / granule_nbytes) * granule_nbytes

--- a/lib/machSize.mli
+++ b/lib/machSize.mli
@@ -65,4 +65,5 @@ type lr_sc =
 
 val granule : sz
 val granule_nbytes : int
+val granule_log2bytes : int
 val granule_align : int -> int


### PR DESCRIPTION
The address used for these instructions is calculated from the base register and an immediate signed offset scaled by the Tag granule.