### PR TITLE
[herd] Better rf matching for instruction fetch

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -186,7 +186,7 @@ module Make
 (* Fetch of an instruction, i.e., a read from a label *)
       let mk_fetch an loc v =
         let ac = Access.VIR in (* Instruction fetch seen as ordinary, non PTE, access *)
-        Act.Access (Dir.R, loc, v, an, AArch64.nexp_annot, MachSize.Word, ac)
+        Act.Access (Dir.R, loc, v, an, AArch64.nexp_ifetch, MachSize.Word, ac)
 
 (* Basic write, to register  *)
       let mk_write sz an anexp ac v loc =
@@ -453,10 +453,12 @@ module Make
           (A.Location_global a_pte) iiid
 
 
-      let op_of_set = function
-        | AArch64.AF -> AArch64Op.SetAF
-        | AArch64.DB -> AArch64Op.SetDB
-        | AArch64.Other|AArch64.AFDB -> assert false
+      let op_of_set =
+        let open AArch64 in
+        function
+        | AF -> AArch64Op.SetAF
+        | DB -> AArch64Op.SetDB
+        | IFetch|Other|AFDB -> assert false
 
       let do_test_and_set_bit combine cond set a_pte iiid =
         let nexp = AArch64.NExp set in

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -51,9 +51,6 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
       | NoRet -> true
       | _ -> false
 
-    let is_explicit annot = annot
-    let is_not_explicit annot = annot
-
     let ifetch_value_sets = []
 
     let barrier_sets =
@@ -80,6 +77,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
     let pp_explicit = function
     | Exp -> "Exp"
     | NExp -> ""
+
     let is_explicit_annot = function
       | Exp -> true
       | NExp -> false
@@ -87,6 +85,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
     and is_not_explicit_annot = function
       | NExp -> true
       | Exp -> false
+
+    and is_ifetch_annot _ = false
+
     let nexp_annot = NExp
     let exp_annot = Exp
 

--- a/herd/ASLAction.ml
+++ b/herd/ASLAction.ml
@@ -102,6 +102,7 @@ module Make (A : S) = struct
     | Access (_, A.Location_global _, _, _, _) -> true
     | _ -> false
 
+  let is_ifetch _ = false
   let is_tag _action = false
   let is_additional_mem _action = false
   let is_atomic _action = false

--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -109,6 +109,9 @@ end = struct
 
 
 (* None of those below *)
+
+  let is_ifetch _ = false
+
   let is_tag _ = false
 
   let is_additional_mem _ = false

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -169,6 +169,8 @@ end = struct
   | RMW (A.Location_global _,_,_,_,_) -> true
   | _ -> false
 
+  let is_ifetch _ = false
+
   let is_tag _ = false
 
   let is_additional_mem a = match a with

--- a/herd/JavaAction.ml
+++ b/herd/JavaAction.ml
@@ -86,6 +86,8 @@ end = struct
   | RMW (A.Location_global _,_,_,_,_) -> true
   | _ -> false
 
+  let is_ifetch _ = false
+
   let is_additional_mem _ = false
 
   let is_additional_mem_load _ = false

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -55,6 +55,7 @@ module type S = sig
   val is_mem_load : action ->  bool
   val is_additional_mem_load :  action -> bool (* trylock *)
   val is_mem : action -> bool
+  val is_ifetch : action -> bool
   val is_tag : action -> bool
   val is_additional_mem : action -> bool (* abstract memory actions, eg locks *)
   val is_atomic : action -> bool

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -85,6 +85,8 @@ val same_instance : event -> event -> bool
   val is_mem_load : event ->  bool
   val is_additional_mem_load : event ->  bool (* trylock... *)
   val is_mem : event -> bool
+(* Instruction fetch *)
+  val is_ifetch : event -> bool
 (* Page table access *)
   val is_pt : event -> bool
   val is_explicit : event -> bool
@@ -663,6 +665,8 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
     let is_mem_load e = Act.is_mem_load e.action
     let is_additional_mem_load e = Act.is_additional_mem_load e.action
     let is_mem e = Act.is_mem e.action
+    let is_ifetch e = Act.is_ifetch e.action
+
     let is_pt e = match Act.location_of e.action with
       | Some (A.Location_global (V.Val c)) -> Constant.is_pt c
       | _ -> false

--- a/herd/explicit.ml
+++ b/herd/explicit.ml
@@ -23,6 +23,7 @@ module type S = sig
   val nexp_annot : explicit
   val is_explicit_annot : explicit -> bool
   val is_not_explicit_annot : explicit -> bool
+  val is_ifetch_annot : explicit -> bool
   val pp_explicit : explicit -> string
   val explicit_sets : (string * (explicit -> bool)) list
 end
@@ -34,6 +35,7 @@ module No = struct
   let nexp_annot = ()
   let is_explicit_annot _ = true
   let is_not_explicit_annot _ = false
+  let is_ifetch_annot _ = false
   let pp_explicit _ = ""
   let explicit_sets = []
 end

--- a/herd/explicit.mli
+++ b/herd/explicit.mli
@@ -23,6 +23,7 @@ module type S = sig
   val nexp_annot : explicit
   val is_explicit_annot : explicit -> bool
   val is_not_explicit_annot : explicit -> bool
+  val is_ifetch_annot : explicit -> bool
   val pp_explicit : explicit -> string
   val explicit_sets : (string * (explicit -> bool)) list
 end

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -281,6 +281,11 @@ end = struct
   | Arch a -> is_mem_arch_action a
   | _ -> false
 
+  let is_ifetch a = match a with
+  | Access (R,A.Location_global _,_,_,exp,_,_) ->
+     A.is_ifetch_annot exp
+  | _ -> false
+
   let is_pt a = match a with
   | Access (_,A.Location_global (A.V.Val c),_,_,_,_,_)
   | Amo (A.Location_global (A.V.Val c),_,_,_,_,_,_)

--- a/herd/tests/instructions/AArch64.self/S28.litmus
+++ b/herd/tests/instructions/AArch64.self/S28.litmus
@@ -1,0 +1,12 @@
+AArch64 S28
+{
+0:X2=NOP;
+0:X1=P1:L0;
+}
+  P0         | P1           ;
+ STR W2,[X1] |L0:           ;
+             | B L1         ;
+             | ADD W2,W2,#1 ;
+             |L1:           ;
+             | ADD W2,W2,#2 ;
+exists 1:X2=3

--- a/herd/tests/instructions/AArch64.self/S28.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S28.litmus.expected
@@ -1,0 +1,11 @@
+Test S28 Allowed
+States 2
+1:X2=2;
+1:X2=3;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists (1:X2=3)
+Observation S28 Sometimes 1 1
+Hash=67619acbffb4c487f2a597a5337e9e6c
+

--- a/herd/tests/instructions/AArch64.self/S29.litmus
+++ b/herd/tests/instructions/AArch64.self/S29.litmus
@@ -1,0 +1,13 @@
+AArch64 S29
+{
+0:X2=NOP;
+0:X0=p;
+[p]=P1:L0;
+}
+  P0         | P1           ;
+ LDR X1,[X0] |L0:           ;
+ STR W2,[X1] | B L1         ;
+             | ADD W2,W2,#1 ;
+             |L1:           ;
+             | ADD W2,W2,#2 ;
+exists 1:X2=3

--- a/herd/tests/instructions/AArch64.self/S29.litmus.expected
+++ b/herd/tests/instructions/AArch64.self/S29.litmus.expected
@@ -1,0 +1,11 @@
+Test S29 Allowed
+States 2
+1:X2=2;
+1:X2=3;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists (1:X2=3)
+Observation S29 Sometimes 1 1
+Hash=1aa81afc46710352152cc1b5fb403941
+

--- a/herd/tests/instructions/AArch64/AK005.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64/AK005.litmus.expected-failure
@@ -1,1 +1,2 @@
-Warning: File "./herd/tests/instructions/AArch64/AK005.litmus": Store to P0:Lself00 requires ifetch functionality. Please use `-variant ifetch` as an argument to herd7 to enable it. (User error)
+Warning: File "./herd/tests/instructions/AArch64/AK005.litmus": Store to P0:Lself00 requires instruction fetch functionality.
+Please use `-variant self` as an argument to herd7 to enable it. (User error)

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -180,6 +180,7 @@ maybev_list:
 maybev_label:
 | maybev { $1 }
 | PROC COLON NAME { mk_lab $1 $3 }
+| NUM COLON NAME { mk_lab (Misc.string_as_int $1) $3 }
 
 %inline location_reg:
 | PROC COLON reg  {Location_reg ($1,$3)}


### PR DESCRIPTION
Matching of writes with instruction loads was too limited as stores with non-determined addresses were forgotten. This PR fixes this, also seizing the opportunity to fix a two minor glitches:
1. Characterise the instruction fetch loads with a specific annotation.
2. Extend parsing of label constants