### PR TITLE
[asl] Remove special cases in interpreter

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -347,4 +347,8 @@ type t = decl list
    ------------------------------------------------------------------------- *)
 
 (** A scope is an unique identifier of the calling site. *)
-type scope = Scope_Local of identifier * uid | Scope_Global
+type scope =
+  | Scope_Local of identifier * uid
+      (** Local scope of a function given by its name and an uid of the call *)
+  | Scope_Global of bool
+      (** Global runtime scope, with whether it was during initialization or not *)

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -579,15 +579,15 @@ let rec subst_expr substs e =
 
 let scope_equal s1 s2 =
   match (s1, s2) with
-  | Scope_Global, Scope_Global -> true
-  | Scope_Global, _ | _, Scope_Global -> false
+  | Scope_Global _, Scope_Global _ -> true
+  | Scope_Global _, _ | _, Scope_Global _ -> false
   | Scope_Local (n1, i1), Scope_Local (n2, i2) -> i1 == i2 && String.equal n1 n2
 
 let scope_compare s1 s2 =
   match (s1, s2) with
-  | Scope_Global, Scope_Global -> 0
-  | Scope_Global, _ -> -1
-  | _, Scope_Global -> 1
+  | Scope_Global _, Scope_Global _ -> 0
+  | Scope_Global _, _ -> -1
+  | _, Scope_Global _ -> 1
   | Scope_Local (n1, i1), Scope_Local (n2, i2) ->
       let n = Int.compare i1 i2 in
       if n != 0 then n else String.compare n1 n2

--- a/asllib/Interpreter.mli
+++ b/asllib/Interpreter.mli
@@ -47,9 +47,6 @@ module type Config = sig
 
   val unroll : int
   (** Loop unrolling threshold *)
-
-  val experimental : bool
-  (** Advanced behaviour *)
 end
 
 module Make (B : Backend.S) (C : Config) : S with module B = B

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -375,7 +375,6 @@ let interprete strictness ?instrumentation ?static_env ast =
   let module C : Interpreter.Config = struct
     let type_checking_strictness = strictness
     let unroll = 0
-    let experimental = false
 
     module Instr = Instrumentation.SemMake (B)
   end in

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -393,5 +393,5 @@ let pp_version f version =
   @@ match version with `ASLv0 -> "ASLv0" | `ASLv1 -> "ASLv1" | `Any -> "any"
 
 let pp_scope f = function
-  | Scope_Global -> pp_print_string f "global scope"
+  | Scope_Global _ -> pp_print_string f "global scope"
   | Scope_Local (name, i) -> fprintf f "%s(%d)" name i

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -797,7 +797,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
       let init =
         let global_loc name =
           ASLS.A.Location_reg
-            (ii.A.proc, ASLBase.ASLLocalId (Asllib.AST.Scope_Global, name))
+            (ii.A.proc, ASLBase.ASLLocalId (Asllib.AST.Scope_Global true, name))
         in
         let st =
           List.fold_left

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -326,16 +326,16 @@ module Make (C : Config) = struct
       if is_experimental then
         fun x scope ->
           match (x, scope) with
-          | "_NZCV", AST.Scope_Global -> true
+          | "_NZCV", AST.Scope_Global false -> true
           | _ -> false
       else
         fun x scope ->
           match (x, scope) with
-          | "PSTATE", AST.Scope_Global -> true
+          | "PSTATE", AST.Scope_Global false -> true
           | _ -> false
 
     let is_resaddr x scope =
-      match (x, scope) with "RESADDR", AST.Scope_Global -> true | _ -> false
+      match (x, scope) with "RESADDR", AST.Scope_Global false -> true | _ -> false
 
     let loc_of_scoped_id ii x scope =
       if is_nzcv x scope then
@@ -757,8 +757,6 @@ module Make (C : Config) = struct
         let unroll =
           match C.unroll with None -> Opts.unroll_default `ASL | Some u -> u
 
-        let experimental = is_experimental
-
         module Instr = Asllib.Instrumentation.SemanticsNoInstr
       end in
       let module ASLInterpreter = Asllib.Interpreter.Make (ASLBackend) (Config)
@@ -837,7 +835,7 @@ module Make (C : Config) = struct
           (fun loc v env ->
             let open ASLBase in
             match loc with
-            | A.Location_reg (_, ASLLocalId (AST.Scope_Global, name)) ->
+            | A.Location_reg (_, ASLLocalId (AST.Scope_Global _, name)) ->
                 (name, v) :: env
             | _ -> env)
           t.Test_herd.init_state []

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -43,7 +43,7 @@ type scope = Asllib.AST.scope
 let pp_scope =
   let open Asllib.AST in
   function
-  | Scope_Global -> ""
+  | Scope_Global _ ->  ""
   | Scope_Local (enclosure, call_nb) ->
       Printf.sprintf "%s.%d." enclosure call_nb
 
@@ -82,7 +82,6 @@ let is_pc = function ArchReg A64B.PC -> true | _ -> false
 let to_arch_reg = function ASLLocalId _ -> assert false | ArchReg r -> r
 let to_reg r = ArchReg r
 let main_scope = ("main", 0)
-let default_scope = Asllib.AST.Scope_Global
 
 let parse_local_id =
   let ( let* ) = Option.bind in
@@ -95,6 +94,7 @@ let parse_local_id =
   let regexp =
     Str.regexp {|\([A-Za-z0-9_-]+\)\.\([0-9]+\)\.\([A-Za-z0-9_-]+\)|}
   in
+  let default_scope = Asllib.AST.Scope_Global true in
   fun s ->
     if Str.string_match regexp s 0 then
       let* x1 = find_opt 1 s and* x2 = find_opt 2 s and* x3 = find_opt 3 s in


### PR DESCRIPTION
In `asllib/Interpeter.ml`, the global variables `NZCV` and `RESADDR` are treated differently from the rest: they do not create initial write events.

This PR removes this behavior by being a bit more subtle with the global scope: it now caries a boolean that says whether or not this is a initialization of the variable or not.

This makes the special case of `NZCV` and `RESADDR` being complitely handled in `ASLSem.ml`. 