### PR TITLE
[herd] Fixes for -variant vmsa,mte

### DIFF
--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -1472,6 +1472,8 @@ let match_reg_events es =
          | A.Location_global (V.Val (Symbolic (Physical (s,idx)))) ->
              let sym = { default_symbolic_data with name=s; offset=idx; } in
              A.of_symbolic_data sym
+         | A.Location_global (V.Val (Symbolic (TagAddr (PHY,s,o)))) ->
+             A.Location_global (V.Val (Symbolic (TagAddr (VIR,s,o))))
          | loc -> loc)
       else
         Misc.identity
@@ -1606,7 +1608,7 @@ let match_reg_events es =
       if kvm then
         let open Constant in
         fun loc -> match loc with
-        | A.Location_global (V.Val (Symbolic (Physical _ as sym1))) ->
+        | A.Location_global (V.Val (Symbolic (Physical _|TagAddr (PHY, _, _) as sym1))) ->
             let p oloc = match oloc with
             | A.Location_global (V.Val (Symbolic sym2)) ->
                 Constant.virt_match_phy sym2 sym1

--- a/herd/tests/instructions/AArch64.vmsa+mte/A007.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A007.litmus
@@ -1,0 +1,8 @@
+AArch64 A007
+{
+ 0:X0=x:red;
+ 0:X1=x;
+}
+ P0          ;
+ STG X0,[X1] ;
+forall([tag(x)]=:red)

--- a/herd/tests/instructions/AArch64.vmsa+mte/A007.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A007.litmus.expected
@@ -1,0 +1,11 @@
+Test A007 Required
+States 1
+[tag(x)]=:red;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition forall ([tag(x)]=:red)
+Observation A007 Always 1 0
+Hash=c6ef897bedbc9dcae809229c4d98e62d
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A008.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A008.litmus
@@ -1,0 +1,12 @@
+AArch64 A008
+{
+ [x]=1;
+ [PTE(x)]=(valid:0);
+ 0:X0=x; 0:X1=x:red;
+ 1:X1=(oa:PA(x),valid:1);
+ 1:X0=PTE(x);
+}
+ P0           | P1          ;
+L0:           | STR X1,[X0] ;
+ STZG X1,[X0] |             ;
+exists(fault(P0:L0,x,MMU:Translation) /\ [x]=0)

--- a/herd/tests/instructions/AArch64.vmsa+mte/A008.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A008.litmus.expected
@@ -1,0 +1,13 @@
+Test A008 Allowed
+States 3
+[x]=0;  ~Fault(P0:L0,x,MMU:Translation);
+[x]=0; Fault(P0:L0,x,MMU:Translation);
+[x]=1; Fault(P0:L0,x,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 4
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition exists (fault(P0:L0,x,MMU:Translation) /\ [x]=0)
+Observation A008 Sometimes 1 4
+Hash=476835ada4ec0e0c73096d09264acc89
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A009.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A009.litmus
@@ -1,0 +1,13 @@
+AArch64 A009
+Variant=vmsa,mte,fatal,sync
+{
+ [x]=1;
+ [PTE(x)]=(valid:0);
+ 0:X0=x; 0:X1=x:red;
+ 1:X1=(oa:PA(x),valid:1);
+ 1:X0=PTE(x);
+}
+ P0           | P1          ;
+L0:           | STR X1,[X0] ;
+ STZG X1,[X0] |             ;
+exists(fault(P0:L0,x,MMU:Translation) /\ [tag(x)]=:red)

--- a/herd/tests/instructions/AArch64.vmsa+mte/A009.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A009.litmus.expected
@@ -1,0 +1,13 @@
+Test A009 Allowed
+States 3
+[tag(x)]=:green; Fault(P0:L0,x,MMU:Translation);
+[tag(x)]=:red;  ~Fault(P0:L0,x,MMU:Translation);
+[tag(x)]=:red; Fault(P0:L0,x,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 4
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition exists (fault(P0:L0,x,MMU:Translation) /\ [tag(x)]=:red)
+Observation A009 Sometimes 1 4
+Hash=280421b2e57a7340aa55ba5d655bde3b
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A010.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A010.litmus
@@ -1,0 +1,11 @@
+AArch64 A010
+{
+ [x]=1;
+ [tag(x)]=:green;
+ [PTE(x)]=(oa:PA(x),attrs:(Normal));
+ 0:X0=x:red;
+}
+ P0          ;
+L0:          ;
+ LDR W1,[X0] ;
+forall(0:X1=1 /\ ~fault(P0:L0,x,TagCheck))

--- a/herd/tests/instructions/AArch64.vmsa+mte/A010.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A010.litmus.expected
@@ -1,0 +1,11 @@
+Test A010 Required
+States 1
+0:X1=1;  ~Fault(P0:L0,x,TagCheck);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition forall (0:X1=1 /\ not (fault(P0:L0,x,TagCheck)))
+Observation A010 Always 1 0
+Hash=f1f7d09e33e99c0f6d5214cf37835072
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A011.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A011.litmus
@@ -1,0 +1,12 @@
+AArch64 A011
+{
+ [tag(x)]=:green;
+ [PTE(x)]=(oa:PA(x),db:1,attrs:(TaggedNormal));
+ 0:X0=x:red;
+ 1:X4=PTE(x); 1:X3=(oa:PA(x),db:0,attrs:(Normal));
+}
+ P0          | P1          ;
+ MOV W1,#1   | STR X3,[X4] ;
+L0:          |             ;
+ STR W1,[X0] |             ;
+exists([x]=1 /\ ~fault(P0:L0,x))

--- a/herd/tests/instructions/AArch64.vmsa+mte/A011.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A011.litmus.expected
@@ -1,0 +1,13 @@
+Test A011 Allowed
+States 3
+[x]=0; Fault(P0:L0,x:red,TagCheck);
+[x]=0; Fault(P0:L0,x:red,MMU:Permission);
+[x]=1;  ~Fault(P0:L0,x);
+Ok
+Witnesses
+Positive: 1 Negative: 2
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition exists ([x]=1 /\ not (fault(P0:L0,x)))
+Observation A011 Sometimes 1 2
+Hash=134d988c72472374b559eaf4c6a4fea8
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A012.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A012.litmus
@@ -1,0 +1,12 @@
+AArch64 A012
+{
+ [tag(x)]=:green;
+ [PTE(x)]=(oa:PA(x),db:0,attrs:(Normal));
+ 0:X0=x:red;
+ 1:X4=PTE(x); 1:X3=(oa:PA(x),db:1,attrs:(TaggedNormal));
+}
+ P0          | P1          ;
+ MOV W1,#1   | STR X3,[X4] ;
+ L0:         |             ;
+ STR W1,[X0] |             ;
+exists([x]=1 /\ ~fault(P0:L0,x))

--- a/herd/tests/instructions/AArch64.vmsa+mte/A012.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A012.litmus.expected
@@ -1,0 +1,13 @@
+Test A012 Allowed
+States 3
+[x]=0; Fault(P0:L0,x:red,TagCheck);
+[x]=0; Fault(P0:L0,x:red,MMU:Permission);
+[x]=1;  ~Fault(P0:L0,x);
+Ok
+Witnesses
+Positive: 1 Negative: 2
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition exists ([x]=1 /\ not (fault(P0:L0,x)))
+Observation A012 Sometimes 1 2
+Hash=3fce4d56177b06c14bfd934326a0645b
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A013.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A013.litmus
@@ -1,0 +1,12 @@
+AArch64 A013
+{
+ [tag(x)]=:green;
+ [PTE(x)]=(oa:PA(x),attrs:(TaggedNormal));
+ 0:X0=x:green;
+ 1:X4=PTE(x); 1:X3=(valid:0);
+}
+ P0          | P1          ;
+ MOV W1,#1   | STR X3,[X4] ;
+L0:          |             ;
+ STR W1,[X0] |             ;
+exists(fault(P0:L0,x,TagCheck))

--- a/herd/tests/instructions/AArch64.vmsa+mte/A013.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A013.litmus.expected
@@ -1,0 +1,11 @@
+Test A013 Allowed
+States 1
+  ~Fault(P0:L0,x,TagCheck);
+No
+Witnesses
+Positive: 0 Negative: 3
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition exists (fault(P0:L0,x,TagCheck))
+Observation A013 Never 0 3
+Hash=97ccf51bf223b3e722cb9f5529718041
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A014.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A014.litmus
@@ -1,0 +1,12 @@
+AArch64 A014
+{
+ [tag(x)]=:green;
+ [PTE(x)]=(oa:PA(x),attrs:(TaggedNormal));
+ 0:X0=x:green;
+ 1:X4=PTE(x); 1:X3=(oa:PA(x),af:0);
+}
+ P0          | P1          ;
+ MOV W1,#1   | STR X3,[X4] ;
+L0:          |             ;
+ STR W1,[X0] |             ;
+exists(fault(P0:L0,x,TagCheck))

--- a/herd/tests/instructions/AArch64.vmsa+mte/A014.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A014.litmus.expected
@@ -1,0 +1,11 @@
+Test A014 Allowed
+States 1
+  ~Fault(P0:L0,x,TagCheck);
+No
+Witnesses
+Positive: 0 Negative: 3
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition exists (fault(P0:L0,x,TagCheck))
+Observation A014 Never 0 3
+Hash=59d8a9b824c05e58c85797010cc158ea
+

--- a/herd/tests/instructions/AArch64.vmsa+mte/A015.litmus
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A015.litmus
@@ -1,0 +1,12 @@
+AArch64 A014
+{
+ [tag(x)]=:green;
+ [PTE(x)]=(oa:PA(x),af:0,attrs:(Normal));
+ 0:X0=x:red;
+ 1:X4=PTE(x); 1:X3=(oa:PA(x),attrs:(TaggedNormal));
+}
+ P0          | P1          ;
+ MOV W1,#1   | STR X3,[X4] ;
+L0:          |             ;
+ STR W1,[X0] |             ;
+exists([x]=1)

--- a/herd/tests/instructions/AArch64.vmsa+mte/A015.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A015.litmus.expected
@@ -1,0 +1,11 @@
+Test A014 Allowed
+States 1
+[x]=0;
+No
+Witnesses
+Positive: 0 Negative: 3
+Flag combining-vmsa-and-memtag-is-not-supported
+Condition exists ([x]=1)
+Observation A014 Never 0 3
+Hash=7241fe036f5d711341ead6574ec6f446
+

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -188,6 +188,9 @@ let oa2symbol oa =
 let virt_match_phy s1 s2 = match s1,s2 with
 | Virtual {name=s1; offset=i1;_},Physical (s2,i2) ->
     Misc.string_eq s1 s2 && Misc.int_eq i1 i2
+| TagAddr (VIR, s1, o1), TagAddr (PHY, s2, o2) ->
+    Misc.string_eq s1 s2 &&
+    Misc.int_eq (MachSize.granule_align o1) (MachSize.granule_align o2)
 | _,_ -> false
 
 module SC = struct


### PR DESCRIPTION
This PR fixes three different issues in herd7 when simulating with `-variant vmsa,mte`.
1. Tag locations in post-condition are Physical symbols when running with `-variant vmsa`.
2. Fixes the possible executions for `STZ{,2}G` when there is a fault.
3. Fixes `lift_kvm` to correctly handle cases where a checked instruction runs into a fault.

For the 3 fixes, this PR contributes unit tests that demonstrate the issue and serve as regressions after the fix is applied.