### PR TITLE
[ci] Specify version in opam install script

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           ocaml-compiler: 5.1
 
-      - run: opam install dune ocamlformat
+      - run: opam install dune ocamlformat.0.26.1
 
       - run: opam exec -- dune fmt


### PR DESCRIPTION
This fix the ci fails (e.g. [this one](https://github.com/herd/herdtools7/actions/runs/8829041632/job/24239220746?pr=802)).