### PR TITLE
[asl][doc] fix make asldoc on empty version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ Version.ml:
 build: Version.ml | check-deps
 	dune build -j $(J) --profile $(DUNE_PROFILE)
 
-$(BENTO): | check-deps
+$(BENTO): Version.ml | check-deps
 	dune build -j $(J) --profile $(DUNE_PROFILE) $@
 
 install:


### PR DESCRIPTION
Fix `make asldoc` on an empty directory.