### PR TITLE
[asl] Differentiate accessers with/without any args

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -313,7 +313,26 @@ and catcher = identifier option * ty * stmt
 
 (** {2 Top-level declarations} *)
 
-type subprogram_type = ST_Procedure | ST_Function | ST_Getter | ST_Setter
+type subprogram_type =
+  | ST_Procedure
+      (** A procedure is a subprogram without return type, called from a
+          statement. *)
+  | ST_Function
+      (** A function is a subprogram with a return type, called from an
+          expression. *)
+  | ST_Getter
+      (** A getter is a special function called with a syntax similar to
+          slices. *)
+  | ST_EmptyGetter
+      (** An empty getter is a special function called with a syntax similar to
+          a variable. *)
+  | ST_Setter
+      (** A setter is a special procedure called with a syntax similar to slice
+          assignment. *)
+  | ST_EmptySetter
+      (** An empty setter is a special procedure called with a syntax similar
+          to an assignment to a variable. *)
+
 type subprogram_body = SB_ASL of stmt | SB_Primitive
 
 type func = {

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -360,12 +360,17 @@ let pp_decl f =
     | ST_Getter ->
         fprintf f "@[<hv 4>getter %s%a [@,%a]%a@]" name pp_parameters parameters
           pp_args args pp_return_type_opt return_type
+    | ST_EmptyGetter ->
+        fprintf f "@[<hv 4>getter %s%a@]" name pp_return_type_opt return_type
     | ST_Setter ->
         let new_v, args =
           match args with [] -> assert false | h :: t -> (h, t)
         in
         fprintf f "@[<hv 4>setter %s%a [@,%a]@ = %a@]" name pp_parameters
           parameters pp_args args pp_typed_identifier new_v
+    | ST_EmptySetter ->
+        let new_v = match args with [ h ] -> h | _ -> assert false in
+        fprintf f "@[<hv 4>setter %s@ = %a]" name pp_typed_identifier new_v
   in
   let pp_body f = function
     | SB_ASL s -> pp_stmt f s

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -519,7 +519,7 @@ let subtype_opt == option(subtype)
 let opt_type_identifier == pair(IDENTIFIER, ty_opt)
 let return_type == ARROW; ty
 let params_opt == { [] } | braced(clist(opt_type_identifier))
-let access_args_opt == { [] } | bracketed(clist(typed_identifier))
+let access_args == bracketed(clist(typed_identifier))
 let func_args == plist(typed_identifier)
 let func_body == delimited(ioption(BEGIN), stmt_list, END)
 let ignored_or_identifier ==
@@ -550,30 +550,54 @@ let decl ==
             subprogram_type = ST_Procedure;
           }
         }
-    | GETTER; name=IDENTIFIER; ~=params_opt; ~=access_args_opt; ret=return_type;
+    | GETTER; name=IDENTIFIER; ~=params_opt; ~=access_args; ret=return_type;
         ~=func_body;
         {
           D_Func
             {
               name;
               parameters = params_opt;
-              args = access_args_opt;
+              args = access_args;
               return_type = Some ret;
               body = SB_ASL func_body;
               subprogram_type = ST_Getter;
             }
         }
-    | SETTER; name=IDENTIFIER; ~=params_opt; ~=access_args_opt; EQ; v=typed_identifier;
+    | GETTER; name=IDENTIFIER; ret=return_type; ~=func_body;
+        {
+          D_Func
+            {
+              name;
+              parameters = [];
+              args = [];
+              return_type = Some ret;
+              body = SB_ASL func_body;
+              subprogram_type = ST_EmptyGetter;
+            }
+        }
+    | SETTER; name=IDENTIFIER; ~=params_opt; ~=access_args; EQ; v=typed_identifier;
         ~=func_body;
         {
           D_Func
             {
               name;
               parameters = params_opt;
-              args = v :: access_args_opt;
+              args = v :: access_args;
               return_type = None;
               body = SB_ASL func_body;
               subprogram_type = ST_Setter;
+            }
+        }
+    | SETTER; name=IDENTIFIER; EQ; v=typed_identifier; ~=func_body;
+        {
+          D_Func
+            {
+              name;
+              parameters = [];
+              args = [ v ];
+              return_type = None;
+              body = SB_ASL func_body;
+              subprogram_type = ST_EmptySetter;
             }
         }
 

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -298,13 +298,15 @@ let pp_gdk f gdk =
   | GDK_Let -> "GDK_Let"
   | GDK_Var -> "GDK_Var"
 
-let pp_subprogram_type f st =
-  addb f
-    (match st with
-    | ST_Function -> "ST_Function"
-    | ST_Procedure -> "ST_Procedure"
-    | ST_Setter -> "ST_Setter"
-    | ST_Getter -> "ST_Getter")
+let subprogram_type_to_string = function
+  | ST_Function -> "ST_Function"
+  | ST_Procedure -> "ST_Procedure"
+  | ST_Setter -> "ST_Setter"
+  | ST_Getter -> "ST_Getter"
+  | ST_EmptyGetter -> "ST_EmptyGetter"
+  | ST_EmptySetter -> "ST_EmptySetter"
+
+let pp_subprogram_type f st = addb f (subprogram_type_to_string st)
 
 let pp_body f = function
   | SB_ASL s -> bprintf f "SB_ASL (%a)" pp_stmt s

--- a/asllib/Serialize.mli
+++ b/asllib/Serialize.mli
@@ -25,6 +25,8 @@
 
 open AST
 
+val subprogram_type_to_string : subprogram_type -> string
+
 type 'a printer = Buffer.t -> 'a -> unit
 (** Type of printers used here. *)
 

--- a/asllib/tests/regressions.t/empty-getter-called-with-slices.asl
+++ b/asllib/tests/regressions.t/empty-getter-called-with-slices.asl
@@ -1,0 +1,11 @@
+getter f1 => integer
+begin
+  return 0;
+end
+
+func main () => integer
+begin
+  let x = f1[];
+
+  return 0;
+end

--- a/asllib/tests/regressions.t/empty-setter-called-with-slices.asl
+++ b/asllib/tests/regressions.t/empty-setter-called-with-slices.asl
@@ -1,0 +1,16 @@
+getter f1 => integer
+begin
+  return 4;
+end
+
+setter f1 = v: integer
+begin
+  pass;
+end
+
+func main () => integer
+begin
+  f1[] = 4;
+  
+  return 0;
+end

--- a/asllib/tests/regressions.t/empty-setter-nonempty-getter.asl
+++ b/asllib/tests/regressions.t/empty-setter-nonempty-getter.asl
@@ -1,0 +1,14 @@
+getter f1[] => integer
+begin
+  return 3;
+end
+
+setter f1 = v: integer
+begin
+  pass;
+end
+
+func main () => integer
+begin
+  return 0;
+end

--- a/asllib/tests/regressions.t/func3.asl
+++ b/asllib/tests/regressions.t/func3.asl
@@ -8,14 +8,24 @@ begin
   assert v == 3;
 end
 
+getter f1b => integer
+begin
+  return 4;
+end
+
+setter f1b = v : integer
+begin
+  assert v == 4;
+end
+
 getter f2[x:integer] => integer
 begin
-  return f1 + x;
+  return f1b + x;
 end
 
 setter f2[x:integer] = v : integer
 begin
-  f1 = 3 * (v - x);
+  f1b = 4 * (v - x);
 end
 
 getter f3[x:integer] => integer
@@ -32,15 +42,16 @@ end
 func main() => integer
 begin
   f1[] = f1[];
-  f1 = f1;
-  let a = f1;
+  // f1 = f1; // Illegal because f1 is not an empty setter/getter
+  f1b = f1b;
+  let a = f1[];
   assert a == 3;
-  assert f1 == 3;
+  assert f1[] == 3;
   let b = f1[];
   assert b == 3;
   assert 3 == f1[];
   let c = f2[4];
-  assert c == 7;
+  assert c == 8;
 
   f2[5] = 6;
   f3[12] = 13;

--- a/asllib/tests/regressions.t/nonempty-getter-called-without-slices.asl
+++ b/asllib/tests/regressions.t/nonempty-getter-called-without-slices.asl
@@ -1,0 +1,11 @@
+getter f1[] => integer
+begin
+  return 4;
+end
+
+func main () => integer
+begin
+  let x = f1;
+
+  return 0;
+end

--- a/asllib/tests/regressions.t/nonempty-setter-called-without-slices.asl
+++ b/asllib/tests/regressions.t/nonempty-setter-called-without-slices.asl
@@ -1,0 +1,16 @@
+getter f1[] => integer
+begin
+  return 4;
+end
+
+setter f1[] = v: integer
+begin
+  pass;
+end
+
+func main () => integer
+begin
+  f1 = 4;
+  
+  return 0;
+end

--- a/asllib/tests/regressions.t/nonempty-setter-empty-getter.asl
+++ b/asllib/tests/regressions.t/nonempty-setter-empty-getter.asl
@@ -1,0 +1,14 @@
+getter f1 => integer
+begin
+  return 3;
+end
+
+setter f1[] = v: integer
+begin
+  pass;
+end
+
+func main () => integer
+begin
+  return 0;
+end

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -311,3 +311,33 @@ Base values
   ASL Execution error: base value of empty type integer {N..M}
   [1]
 
+Empty getters/setters
+  $ aslref empty-getter-called-with-slices.asl
+  File empty-getter-called-with-slices.asl, line 8, characters 10 to 14:
+  ASL Error: Mismatched use of return value from call to 'f1'
+  [1]
+  $ aslref nonempty-getter-called-without-slices.asl
+  File nonempty-getter-called-without-slices.asl, line 8, characters 10 to 12:
+  ASL Error: Mismatched use of return value from call to 'f1'
+  [1]
+  $ aslref empty-setter-nonempty-getter.asl
+  File empty-setter-nonempty-getter.asl, line 6, character 0 to line 9,
+    character 3:
+  ASL Typing error: setter "f1" does not have a corresponding getter of
+    signature  -> integer
+  [1]
+  $ aslref nonempty-setter-empty-getter.asl
+  File nonempty-setter-empty-getter.asl, line 6, character 0 to line 9,
+    character 3:
+  ASL Typing error: setter "f1" does not have a corresponding getter of
+    signature  -> integer
+  [1]
+  $ aslref empty-setter-called-with-slices.asl
+  File empty-setter-called-with-slices.asl, line 13, characters 2 to 6:
+  ASL Error: Mismatched use of return value from call to 'f1'
+  [1]
+  $ aslref nonempty-setter-called-without-slices.asl
+  File nonempty-setter-called-without-slices.asl, line 13, characters 2 to 4:
+  ASL Error: Mismatched use of return value from call to 'f1'
+  [1]
+


### PR DESCRIPTION
This PR implements checks that differentiate accessers with from without `[]`.
For example:
```
getter f1[] => integer
begin return 0; end

getter f2 => integer
begin return 0; end

func main () => integer
begin
  let x = f1[];
  let x = f2;

  return 0;
end
```
Before this PR, the two syntaxes could be used without distinction.

Also fixes a bug on `make test-aarch64-asl`.