### PR TITLE
herd: Linux: add atomic_andnot()

### DIFF
--- a/lib/CLexer.mll
+++ b/lib/CLexer.mll
@@ -121,6 +121,7 @@ rule token deep = parse
 | '-' { SUB }
 | '^' { XOR }
 | '&' { LAND }
+| "~" { NOT }
 | '(' { LPAR }
 | ')' { RPAR }
 | '{' { if deep then LBRACE else begin

--- a/lib/CParser.mly
+++ b/lib/CParser.mly
@@ -51,7 +51,7 @@ open MemOrderOrAnnot
 %token <string> CONSTANT
 %token SEMI EQ EQ_OP NEQ_OP LT LE GT GE
 %token XOR PIPE
-%token LAND
+%token LAND NOT
 %token ADD SUB
 %token DIV
 %token IF ELSE WHILE
@@ -163,6 +163,7 @@ atomic_op:
 | LAND { Op.And }
 | XOR { Op.Xor }
 | PIPE { Op.Or }
+| LAND NOT { Op.AndNot2 }
 
 annot:
 | annot_base  { $1 }


### PR DESCRIPTION
Implement `atomic_andnot()` for the linux kernel. `&~` has been chosen to represent this atomic operation and added to the C lexer. AndNot2 is already implemented so we can use it directly.

Testing
-------

`+atomic_andnot(V,X) { __atomic_op(X,&~,V); }`
was added to the linux-kernel.def in the kernel tree and the following litmus test was run:
```
C andnot

{ atomic_t u = ATOMIC_INIT(7)}

P0(atomic_t *u)
{

        atomic_andnot(3, u);
        smp_mb();
        r1 = READ_ONCE(*u);
}

exists (0:r1=4)
```
This is doing:
```
u = 7;
u &= ~3;
```
which would clear the bit number 0 and 1 in 7 and that would mean the result should be 4:
```
Test andnot Allowed
States 1
0:r1=4;
Ok
Witnesses
Positive: 1 Negative: 0
Condition exists (0:r1=4)
Observation andnot Always 1 0
```