### PR TITLE
[asl][typing] Typing Reference Pre-Beta step 3

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1613,6 +1613,7 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
                     let+ () = check_type_satisfies e3 env t_e3 t in
                     (t, e3) |: TypingRule.EGetBitFieldTyped
                     (* End *))
+            (* Begin EGetTupleItem *)
             | T_Tuple tys ->
                 let index =
                   try Scanf.sscanf field_name "item%u" Fun.id
@@ -1621,7 +1622,10 @@ module Annotate (C : ANNOTATE_CONFIG) = struct
                 in
                 if 0 <= index && index < List.length tys then
                   (List.nth tys index, E_GetItem (e2, index) |> add_pos_from e)
-                else fatal_from e (Error.BadField (field_name, t_e2))
+                else
+                  fatal_from e (Error.BadField (field_name, t_e2))
+                  |: TypingRule.EGetTupleItem
+            (* End *)
             (* Begin EGetBadField *)
             | _ ->
                 fatal_from e (Error.BadField (field_name, t_e2))

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -57,6 +57,10 @@ Finally, $\neg\True\triangleq\False$ and $\neg\False\triangleq\True$.
 \hypertarget{def-identifier}{}
     $\Identifiers$ is the set of all ASL identifiers.
 
+\item
+\hypertarget{def-astlabels}{}
+    $\astlabels$ is the set of all ASL labels.
+
 % \item
 % \hypertarget{def-strings}{}
 %     $\Strings$ is the set of all ASL string literals.
@@ -481,7 +485,7 @@ allows us to deconstruct a given \func\ node by matching only the \textsf{body} 
 
 \hypertarget{def-astlabel}{}
 Recall that a subset of AST nodes are either labels or labelled tuples.
-The partial function $\astlabel$ returns the corresponding label, when it exists.
+The partial function $\astlabel$ returns the corresponding label $\vl\in\astlabels$, when it exists.
 For example, $\astlabel(\TBool) = \TBool$ and $\astlabel(\TNamed(\texttt{x})) = \TNamed$.
 
 \subsection{How to Parse Rules Efficiently}

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -194,7 +194,6 @@
 \newcommand\marray[0]{\texttt{m\_array}}
 \newcommand\mindex[0]{\texttt{m\_index}}
 \newcommand\varray[0]{\texttt{v\_array}}
-\newcommand\vindex[0]{\texttt{v\_index}}
 \newcommand\efields[0]{\texttt{e\_fields}}
 \newcommand\fields[0]{\texttt{fields}}
 \newcommand\vvfields[0]{\texttt{v\_fields}}

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -227,7 +227,7 @@
 \newcommand\vlength[0]{\texttt{v\_length}}
 \newcommand\vdiff[0]{\texttt{v\_diff}}
 \newcommand\etop[0]{\texttt{e\_top}}
-\newcommand\vvtop[0]{\texttt{v\_top}}
+\newcommand\vvsubtop[0]{\texttt{v\_top}}
 \newcommand\mtop[0]{\texttt{m\_top}}
 \newcommand\efactor[0]{\texttt{e\_factor}}
 \newcommand\mfactor[0]{\texttt{m\_factor}}
@@ -2450,7 +2450,7 @@ $\slices$.
     \item $\vs$ is the slice range between the
       expressions $\estart$ and $\etop$, that is, \\ $\SliceRange(\etop, \estart)$;
     \item evaluating $\etop$ in $\env$ is either $\Normal(\mtop, \envone)$ \ProseOrAbnormal;
-    \item $\mtop$ is a pair consisting of the native integer $\vvtop$ and execution graph $\vgone$;
+    \item $\mtop$ is a pair consisting of the native integer $\vvsubtop$ and execution graph $\vgone$;
     \item evaluating $\estart$ in $\envone$ is either $\Normal(\mstart, \newenv)$ \ProseOrAbnormal;
     \item $\mstart$ is a pair consisting of the native integer $\vstart$ and execution graph $\vgtwo$;
     \item $\vlength$ is the integer value \texttt{(v\_top - v\_start) + 1};
@@ -2470,10 +2470,10 @@ $\slices$.
 \begin{mathpar}
   \inferrule{
     \evalexpr{\env, \etop} \evalarrow \Normal(\mtop, \envone) \OrAbnormal\\\\
-    \mtop \eqname (\vvtop, \vgone)\\
+    \mtop \eqname (\vvsubtop, \vgone)\\
     \evalexpr{\envone, \estart} \evalarrow \Normal(\mstart, \newenv) \OrAbnormal\\\\
     \mstart \eqname (\vstart, \vgtwo)\\
-    \binoprel(\MINUS, \vvtop, \vstart) \evalarrow \vdiff\\
+    \binoprel(\MINUS, \vvsubtop, \vstart) \evalarrow \vdiff\\
     \binoprel(\PLUS, \nvint(1), \vdiff) \evalarrow \vlength\\
     \newg \eqdef \vgone \parallelcomp \vgtwo
   }

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -244,7 +244,6 @@
 \newcommand\wid[0]{\texttt{wid}}
 \newcommand\es[0]{\texttt{es}}
 \newcommand\ms[0]{\texttt{ms}}
-\newcommand\body[0]{\text{body}}
 \newcommand\vbody[0]{\texttt{body}}
 \newcommand\dir[0]{\texttt{dir}}
 \newcommand\catchers[0]{\texttt{catchers}}

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -223,7 +223,6 @@
 \newcommand\vstart[0]{\texttt{v\_start}}
 \newcommand\vend[0]{\texttt{v\_end}}
 \newcommand\estart[0]{\texttt{e\_start}}
-\newcommand\elength[0]{\texttt{e\_length}}
 \newcommand\mlength[0]{\texttt{m\_length}}
 \newcommand\vlength[0]{\texttt{v\_length}}
 \newcommand\vdiff[0]{\texttt{v\_diff}}

--- a/asllib/doc/ASLSyntaxReference.tex
+++ b/asllib/doc/ASLSyntaxReference.tex
@@ -397,9 +397,9 @@ We sometimes provide extra details to individual derivations by adding comments 
 
 \[
 \begin{array}{rcl}
-\decl &::=& \texttt{D\_Func}(\func)\\
-  & & \texttt{D\_GlobalStorage}(\globaldecl)\\
-  & & \texttt{D\_TypeDecl}(\identifier, \ty, (\identifier, \Field^*)?)\\
+\decl &::=& \DFunc(\func)\\
+  & & \DGlobalStorage(\globaldecl)\\
+  & & \DTypeDecl(\identifier, \ty, (\identifier, \Field^*)?)\\
   & & \ASTComment{The last component is for \texttt{with} fields.}\\
 \specification &::=& \decl^*\\
 \end{array}
@@ -455,6 +455,5 @@ which is utilized both for the type system and semantics:
   \torexpr(\texttt{LE\_Concat}([\vle_{1..k}], \Ignore)) &=& \texttt{E\_Concat}([i=1..k: \torexpr(\vle_i)])\\
 \end{array}
 \]
-
 
 \end{document}

--- a/asllib/doc/ASLSyntaxReference.tex
+++ b/asllib/doc/ASLSyntaxReference.tex
@@ -152,15 +152,15 @@ We sometimes provide extra details to individual derivations by adding comments 
 
 \[
 \begin{array}{rcl}
-\pattern &::=& \texttt{Pattern\_All} \\
-  &|& \texttt{Pattern\_Any}(\pattern^{*}) \\
-  &|& \texttt{Pattern\_Geq}(\expr) \\
-  &|& \texttt{Pattern\_Leq}(\expr) \\
-  &|& \texttt{Pattern\_Mask}(\texttt{bitmask\_lit}) \\
-  &|& \texttt{Pattern\_Not}(\pattern) \\
-  &|& \texttt{Pattern\_Range}(\overtext{\expr}{lower}, \overtext{\expr}{upper included})\\
-  &|& \texttt{Pattern\_Single}(\expr) \\
-  &|& \texttt{Pattern\_Tuple}(\pattern^{*}) \\
+\pattern &::=& \PatternAll \\
+  &|& \PatternAny(\pattern^{*}) \\
+  &|& \PatternGeq(\expr) \\
+  &|& \PatternLeq(\expr) \\
+  &|& \PatternMask(\texttt{bitmask\_lit}) \\
+  &|& \PatternNot(\pattern) \\
+  &|& \PatternRange(\overtext{\expr}{lower}, \overtext{\expr}{upper included})\\
+  &|& \PatternSingle(\expr) \\
+  &|& \PatternTuple(\pattern^{*}) \\
 \end{array}
 \]
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -69,7 +69,7 @@
 \newcommand\lcasat[0]{\models}
 \newcommand\Supers{\textsf{Supers}}
 \newcommand\bitfieldsincluded[0]{\hyperlink{def-bitfieldsincluded}{\texttt{bitfields\_included}}}
-\newcommand\instantiate[0]{\textsf{instantiate}}
+\newcommand\instantiate[0]{\texttt{instantiate}}
 \newcommand\canbeinitializedwith[0]{\texttt{can\_be\_initialized\_with}}
 \newcommand\getbitvectorwidth[0]{\texttt{get\_bitvector\_width}}
 \newcommand\findsubprogram[0]{\hyperlink{def-findsubprogram}{\texttt{find\_subprogram}}}
@@ -81,7 +81,10 @@
 \newcommand\pairstomap[0]{\hyperlink{def-pairstomap}{\texttt{pairs\_to\_map}}}
 \newcommand\annotatefieldinit[0]{\hyperlink{def-annotatefieldinit}{\texttt{annotate\_field\_init}}}
 \newcommand\annotatestaticconstrainedinteger[0]{\hyperlink{def-annotatestaticconstrainedinteger}{\texttt{annotate\_static\_constrained\_integer}}}
+\newcommand\checkstructurelabel[0]{\hyperlink{def-checkstructurelabel}{\texttt{check\_structure}}}
 \newcommand\checkstructureinteger[0]{\hyperlink{def-checkstructureinteger}{\texttt{check\_structure\_integer}}}
+\newcommand\checkstaticallyevaluable[0]{\hyperlink{def-checkstaticallyevaluable}{\texttt{check\_statically\_evaluable}}}
+\newcommand\storageispure[0]{\hyperlink{def-storageispure}{\texttt{storage\_is\_pure}}}
 
 % Symbolic equivalence testing macros
 \newcommand\typeequal[0]{\hyperlink{def-typeequal}{\texttt{type\_equal}}}
@@ -125,6 +128,8 @@
 \newcommand\typeclash[0]{\hyperlink{def-typeclashes}{type-clash}}
 \newcommand\constrainedinteger[0]{\hyperlink{def-checkconstrainedinteger}{constrained integer}}
 \newcommand\structureofinteger[0]{\hyperlink{def-checkstructureinteger}{structure of an integer}}
+\newcommand\staticallyevaluable[0]{\hyperlink{def-staticallyevaluable}{statically evaluable}}
+\newcommand\pure[0]{hyperlink{def-storageispure}{pure}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Type functions
@@ -135,10 +140,11 @@
 \newcommand\annotatetype[1]{\hyperlink{def-annotatetype}{\texttt{annotate\_type}}(#1)}
 \newcommand\annotateexpr[1]{\hyperlink{def-annotateexpr}{\texttt{annotate\_expr}}(#1)}
 \newcommand\annotateexprlist[1]{\hyperlink{def-annotateexprs}{\texttt{annotate\_exprs}}(#1)}
-\newcommand\annotatelexpr[1]{\textsf{annotate\_lexpr}(#1)}
-\newcommand\annotatearrayindex[0]{\textsf{annotate\_array\_index}}
-\newcommand\annotateslice[0]{\hyperlink{def-annotateslice}{\textsf{annotate\_slice}}}
-\newcommand\annotateslices[0]{\hyperlink{def-annotateslices}{\textsf{annotate\_slices}}}
+\newcommand\annotatelexpr[1]{\texttt{annotate\_lexpr}(#1)}
+\newcommand\annotatearrayindex[0]{\texttt{annotate\_array\_index}}
+\newcommand\annotateslice[0]{\hyperlink{def-annotateslice}{\texttt{annotate\_slice}}}
+\newcommand\annotateslices[0]{\hyperlink{def-annotateslices}{\texttt{annotate\_slices}}}
+\newcommand\annotatepattern[0]{\hyperlink{def-annotatepattern}{\texttt{annotate\_pattern}}}
 \newcommand\annotatelocaldeclitem[1]{\hyperlink{def-annotatelocaldeclitem}{\texttt{annotate\_local\_decl\_item}}(#1)}
 \newcommand\annotatestmt[1]{\texttt{annotate\_stmt}(#1)}
 \newcommand\annotateblock[1]{\texttt{annotate\_block}(#1)}
@@ -1730,7 +1736,7 @@ One of the following applies:
   \item All of the following apply (\textsc{conflicting\_type}):
   \begin{itemize}
     \item $\vt$ is not an integer type;
-    \item the result is a type error indicating that the type conflict.
+    \item the result is a type error indicating the type conflict.
   \end{itemize}
 \end{itemize}
 
@@ -3529,7 +3535,7 @@ All of the following apply:
 \begin{itemize}
   \item $\tty$ is the bit-vector type with width given by the expression
     $\ewidth$ and the bitfields given by $\bitfields$, that is, $\TBits(\ewidth, \bitfields)$;
-  \item annotating the statically-evaluable integer expression $\ewidth$ yields $\ewidthp$ \ProseOrTypeError;
+  \item annotating the \staticallyevaluable\  integer expression $\ewidth$ yields $\ewidthp$ \ProseOrTypeError;
   \item annotating the bitfields $\bitfields$ yields $\bitfieldsp$ \ProseOrTypeError;
   \item $\newty$ is the bit-vector type with width given by the expression
     $\ewidthp$ and the bitfields given by $\bitfieldsp$, that is, $\TBits(\ewidthp, \bitfieldsp)$
@@ -3646,7 +3652,7 @@ In the following example, all the uses of array types are valid:
   \annotatetype{\False, \tenv, \vt} \typearrow \vtp \OrTypeError\\\\
   \tododefine{get\_variable\_enum}(\tenv, \ve) \typearrow \langle \vs, \vi \rangle
 }{
-  \annotatetype{\Ignore, \tenv, \TArray(\ArrayLengthExpr(\ve), \vt)} \typearrow \TArray(\ArrayLengthEnum(\vs, \vi), \vtp)
+  \annotatetype{\tenv, \TArray(\ArrayLengthExpr(\ve), \vt)} \typearrow \TArray(\ArrayLengthEnum(\vs, \vi), \vtp)
 }
 \and
 \inferrule[expr\_not\_enum]{
@@ -3654,18 +3660,18 @@ In the following example, all the uses of array types are valid:
   \tododefine{get\_variable\_enum}(\tenv, \ve) \typearrow \None\\
   \tododefine{annotate\_static\_integer}(\tenv, \ve) \typearrow \vep \OrTypeError
 }{
-  \annotatetype{\Ignore, \tenv, \TArray(\ArrayLengthExpr(\ve), \vt)} \typearrow \TArray(\ArrayLengthExpr(\vep), \vtp)
+  \annotatetype{\tenv, \TArray(\ArrayLengthExpr(\ve), \vt)} \typearrow \TArray(\ArrayLengthExpr(\vep), \vtp)
 }
 \and
 \inferrule[index\_enum]{
   \annotatetype{\False, \tenv, \vt} \typearrow \vtp \OrTypeError\\\\
   \tty \eqdef \TNamed(\vs)\\
   \makeanonymous(\tenv, \tty) \typearrow \vt \OrTypeError\\\\
-  \checktrans{\astlabel(\vt) = \TEnum} \typearrow \True \OrTypeError\\\\
+  \checktrans{\astlabel(\vt) = \TEnum, \texttt{"ExpectedEnumeration"}} \typearrow \True \OrTypeError\\\\
   \vt \eqname \TEnum((\vli))\\
-  \checktrans{\equallength(\vli, \vi)} \typearrow \True \OrTypeError
+  \checktrans{\equallength(\vli, \vi), \texttt{"TypeConflict"}} \typearrow \True \OrTypeError
 }{
-  \annotatetype{\Ignore, , \tenv, \TArray(\ArrayLengthEnum(\vs, \vi), \vt)} \typearrow \\
+  \annotatetype{\tenv, \TArray(\ArrayLengthEnum(\vs, \vi), \vt)} \typearrow \\
   \TArray(\ArrayLengthEnum(\vs, \vi), \vtp)
 }
 \end{mathpar}
@@ -4402,7 +4408,7 @@ All of the following apply:
     \begin{itemize}
       \item $\slices$ consists of a single slice $\SliceSingle(\eindex)$;
       \item annotating the expression $\eindex$ in $\tenv$ yields $(\tindexp, \eindexp)$ \ProseOrTypeError;
-      \item determing the type of the array index for $\size$ in $\tenv$ via \\ $\typeofarraylength$
+      \item determining the type of the array index for $\size$ in $\tenv$ via \\ $\typeofarraylength$
       yields $\wantedtindex$;
       \item determining whether $\tindexp$ \typesatisfies\ $\wantedtindex$ yields $\True$ \ProseOrTypeError;
       \item $\vt$ is $\ttyp$;
@@ -4504,7 +4510,7 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \checktrans{\astlabel(\tty) = \TNamed} \typearrow \True \OrTypeError\\
+  \checktrans{\astlabel(\tty) = \TNamed, \texttt{"expected named type"}} \typearrow \True \OrTypeError\\
   \tstruct{\tenv, \tty} \typearrow\vtp \OrTypeError\\
   \astlabel(\vtp) \not\in \{\TRecord, \TException\}
 }
@@ -4536,7 +4542,7 @@ A§ll of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \checktrans{\astlabel(\tty) = \TNamed} \typearrow \True \OrTypeError\\
+  \checktrans{\astlabel(\tty) = \TNamed, \texttt{"expected named type"}} \typearrow \True \OrTypeError\\
   \tstruct(\tenv, \tty) \typearrow L(\fieldtypes) \OrTypeError\\\\
   L \in \{\TRecord, \TException\}\\
   \initializedfields \eqdef \{\name \;|\; (\name, \Ignore)\in\fields\}\\
@@ -4575,7 +4581,7 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \checktrans{\astlabel(\tty) = \TNamed} \typearrow \True \OrTypeError\\
+  \checktrans{\astlabel(\tty) = \TNamed, \texttt{"expected named type"}} \typearrow \True \OrTypeError\\
   \tstruct(\tenv, \tty) \typearrow L(\fieldtypes) \OrTypeError\\\\
   L \in \{\TRecord, \TException\}\\
   \initializedfields \eqdef \{\name \;|\; (\name, \Ignore)\in\fields\}\\
@@ -4598,7 +4604,7 @@ All of the following apply:
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
   \item $(\vteone, \vetwo)$ is the result of annotating $\veone$ in $\tenv$;
   \item $\vteone$ has an \underlyingtype\ of an exception or record type with fields $\fields$;
   \item $\fieldname$ is declared in $\fields$;
@@ -4632,7 +4638,7 @@ All of the following apply:
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
   \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
   \item \texttt{\vteone, $\vetwo$} is the result of annotating $\veone$ in $\tenv$;
   \item $\vteone$ has the structure of an exception or record type with fields $\fields$;
   \item $\vtetwo$ has the structure of an exception or record type with fields $\fields$;
@@ -4659,7 +4665,7 @@ $(\vt, \newe)$ and all of the following apply:
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
   \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
   \item $\vteone$ has the structure a bitvector type with bitfields $\bitfields$;
   \item $\vtetwo$ has the structure a bitvector type with bitfields $\bitfields$;
   \item $\fieldname$ is not declared in $\bitfields$;
@@ -4684,7 +4690,7 @@ $(\vt, \newe)$ and all of the following apply:
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
    \begin{itemize}
-   \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
    \item \texttt{\vteone, e2} is the result of annotating $\veone$ in $\tenv$;
    \item $\vteone$ does not have the structure of a record or an exception or a bitvector type;
    \item an error ``\texttt{Conflicting Types}'' is raised.
@@ -4708,14 +4714,14 @@ $(\vt, \newe)$ and all of the following apply:
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
   \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
   \item \texttt{\vteone, e2} is the result of annotating $\veone$ in $\tenv$;
   \item the \underlyingtype\ of $\vteone$ is a bitvector type with bitfields $\bitfields$;
   \item $\fieldname$ is declared in $\bitfields$;
   \item $\slices$ gives the slices corresponding to the bitfield $\fieldname$
     in \\ $\bitfields$;
-  \item \texttt{e3} denotes the slicing of the expression \vetwo by the slices $\slices$;
-  \item $(\vt, \newe)$ is the result of annotating \texttt{e3}.
+  \item $\vethree$ denotes the slicing of the expression \vetwo by the slices $\slices$;
+  \item $(\vt, \newe)$ is the result of annotating $\vethree$.
   \end{itemize}
 
   \subsection{Example}
@@ -4730,8 +4736,8 @@ $(\vt, \newe)$ and all of the following apply:
 \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo)\\
 \makeanonymous(\tenv, \vteone) \typearrow \TBits(\Ignore, \bitfields)\\
 \fieldname = \texttt{BitField\_Simple}(\Ignore, \slices) \in \bitfields\\
-\texttt{e3} = \ESlice(\vetwo, \slices)\\
-\annotateexpr{\tenv, \texttt{e3}} \typearrow (\vt, \newe)
+\vethree = \ESlice(\vetwo, \slices)\\
+\annotateexpr{\tenv, \vethree} \typearrow (\vt, \newe)
 }
 {\annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \newe)}
 \end{mathpar}
@@ -4745,14 +4751,14 @@ $(\vt, \newe)$ and all of the following apply:
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
   \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
   \item \texttt{\vteone, e2} is the result of annotating $\veone$ in $\tenv$;
   \item $\vteone$ has the structure of a bitvector type with bitfields $\bitfields$;
   \item $\fieldname$ is declared in $\bitfields$;
   \item $\slices$ gives the slices corresponding to the bitfield $\fieldname$ in \\
     $\bitfields$;
-  \item \texttt{e3} denotes the slicing of the expression \vetwo by the slices $\slices$;
-  \item \texttt{t4, e4} is the result of annotating \texttt{e3} in $\tenv$;
+  \item $\vethree$ denotes the slicing of the expression \vetwo by the slices $\slices$;
+  \item \texttt{t4, e4} is the result of annotating $\vethree$ in $\tenv$;
   \item $\bitfieldsp$ gives the bitfields corresponding to the bitfield $\fieldname$
     in $\bitfields$;
   \item $\vt$ is the bitvector type with the width of \texttt{t4} and the bitfields $\bitfieldsp$
@@ -4786,7 +4792,7 @@ $(\vt, \newe)$ and all of the following apply:
   \item \texttt{t\_e3,e3} is the result of annotating \texttt{\vetwo,slices} in $\tenv$;
   \item $\vt$ is the type corresponding to the bitfield $\fieldname$ in $\bitfields$;
   \item \texttt{t\_e3} \typesatisfies\  $\vt$ in $\tenv$;
-  \item $\newe$ is \texttt{e3}.
+  \item $\newe$ is $\vethree$.
   \end{itemize}
 
   \subsection{Example}
@@ -4800,10 +4806,10 @@ $(\vt, \newe)$ and all of the following apply:
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo)\\
   \makeanonymous(\tenv, \vteone) \typearrow \TBits(\Ignore, \bitfields)\\
   \fieldname = \texttt{BitField\_Type}(\Ignore, \slices, \vt) \in \bitfields\\
-  \annotateexpr{\ESlice(\vetwo, \slices)} \typearrow (\texttt{t\_e3}, \texttt{e3})\\
+  \annotateexpr{\ESlice(\vetwo, \slices)} \typearrow (\texttt{t\_e3}, \vethree)\\
   \typesat(\tenv, \texttt{t\_e3}, \vt)
 }
-{\annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \texttt{e3})}
+{\annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \vethree)}
 \end{mathpar}
 \end{emptyformal}
 
@@ -4826,7 +4832,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{}
 {
-  \annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \texttt{e3})
+  \annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \vethree)
 }
 \end{mathpar}
 \end{emptyformal}
@@ -5267,7 +5273,7 @@ The function
   \annotatestaticconstrainedinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
   \overname{\expr}{\vepp} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-annotates a statically-evaluable integer expression $\ve$ in the static environment $\tenv$
+annotates a \staticallyevaluable\  integer expression $\ve$ in the static environment $\tenv$
 and returns the annotated expression $\vepp$.
 A type error is returned, if one is detected.
 
@@ -5276,7 +5282,7 @@ All of the following apply:
 \begin{itemize}
   \item annotating the expression $\ve$ in $\tenv$ yields $ (\vt, \vep)$ \ProseOrTypeError;
   \item determining whether $\vt$ is a statically \constrainedinteger\ in $\tenv$ yields $\True$ \ProseOrTypeError;
-  \item determining whether $\vep$ is statically-evaluable in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item determining whether $\vep$ is \staticallyevaluable\  in $\tenv$ yields $\True$ \ProseOrTypeError;
   \item symbolically reducing the expression $\vep$ yields $\vepp$.
 \end{itemize}
 
@@ -5939,7 +5945,7 @@ All of the following apply:
 \begin{itemize}
   \item $\vs$ is a slice of length $\elength$ and offset $\eoffset$, that is, $\SliceLength(\eoffset, \elength)$;
   \item annotating the expression $\eoffset$ in $\tenv$ yields $(\toffset, \eoffsetp)$ \ProseOrTypeError;
-  \item annotating the statically-evaluable \constrainedinteger\ expression $\elength$ in $\tenv$ yields
+  \item annotating the \staticallyevaluable\ \constrainedinteger\ expression $\elength$ in $\tenv$ yields
   $\elength$ \ProseOrTypeError;
   \item determining whether $\toffset$ has the \structureofinteger\ yields $\True$ \ProseOrTypeError;
   \item $\vsp$ is the slice at offset $\eoffsetp$ and length $\elength'$, that is,\\
@@ -6050,8 +6056,16 @@ All of the following apply:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Patterns}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and one of the following applies:
+\hypertarget{def-annotatepattern}{}
+The function
+\[
+  \annotatepattern(
+    \overname{\staticenvs}{\tenv} \aslsep
+    \overname{\ty}{\vt} \aslsep
+    \overname{\pattern}{\vp}) \aslto \overname{\pattern}{\newp} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+annotates a pattern $\vp$ in a static environment $\tenv$ given a type $\vt$,
+resulting in a pattern $\newp$ or a type error, if one is detected, and one of the following applies:
 \begin{itemize}
 \item TypingRule.PAll (see \secref{TypingRule.PAll}),
 \item TypingRule.PAny (see \secref{TypingRule.PAny}),
@@ -6061,328 +6075,392 @@ Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt
 \item TypingRule.PRange (see \secref{TypingRule.PRange}),
 \item TypingRule.PSingle (see \secref{TypingRule.PSingle}),
 \item TypingRule.PMask (see \secref{TypingRule.PMask}),
-\item TypingRule.PTupleBadArity (see \secref{TypingRule.PTupleBadArity}),
-\item TypingRule.PTuple (see \secref{TypingRule.PTuple}),
-\item TypingRule.PTupleConflict (see \secref{TypingRule.PTupleConflict}),
+\item TypingRule.PTuple (see \secref{TypingRule.PTuple}).
 \end{itemize}
 
 \section{TypingRule.PAll \label{sec:TypingRule.PAll}}
 
-  \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern matching everything;
-   \item \texttt{new\_p} is \texttt{p}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vp$ is the pattern matching everything, that is, $\PatternAll$;
+  \item $\newp$ is $\vp$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\PAllBegin}{\PAllEnd}{../Typing.ml}
+\CodeSubsection{\PAllBegin}{\PAllEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{}
+{
+  \annotatepattern(\tenv, \vt, \PatternAll) \typearrow \PatternAll
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.PAny\label{sec:TypingRule.PAny}}
 
-  \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern which matches anything in a list $\vli$;
-   \item \texttt{new\_li} is the result of mapping the result of annotating \texttt{p} in $\tenv$ onto $\vli$;
-   \item \texttt{new\_p} is the pattern which matches anything in \texttt{new\_li}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+\item $\vp$ is the pattern which matches anything in a list $\vli$, that is, $\PatternAny(\vli)$;
+\item annotating each pattern in $\vli$ yields the list of annotated pattern $\newli$ \ProseOrTypeError;
+\item $\newp$ is the pattern which matches anything in $\newli$, that is, \\ $\PatternAny(\newli)$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\PAnyBegin}{\PAnyEnd}{../Typing.ml}
+\CodeSubsection{\PAnyBegin}{\PAnyEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \vl\in\vli: \annotatepattern(\tenv, \vt, \vl) \typearrow \vlp \OrTypeError\\\\
+  \newli \eqdef [\vl\in\vli: \vlp]
+}
+{
+  \annotatepattern(\tenv, \vt, \PatternAny(\vli)) \typearrow \PatternAny(\newli)
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.PGeq \label{sec:TypingRule.PGeq}}
 
-  \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern which matches anything greater than or equal to an expression $\ve$;
-   \item \texttt{t\_e, \vep} is the result of annotating $\ve$ in $\tenv$;
-   \item $\vep$ is a compile-time constant expression;
-   \item One of the following applies:
-     \begin{itemize}
-     \item All of the following apply:
-           \begin{itemize}
-           \item both $\vt$ and \texttt{t\_e} have the structure of an integer;
-           \item \texttt{new\_p} is the pattern which matches anything greater than or equal to $\vep$.
-           \end{itemize}
-     \item All of the following apply:
-           \begin{itemize}
-           \item both $\vt$ and \texttt{t\_e} have the structure of a real;
-           \item \texttt{new\_p} is the pattern which matches anything greater than or equal to $\vep$.
-           \end{itemize}
-     \item an error ``\texttt{Conflicting Types}'' is raised.
-     \end{itemize}
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+\item $\vp$ is the pattern which matches anything greater than or equal to an expression $\ve$,
+that is, $\PatternGeq(\ve)$;
+\item annotating the expression $\ve$ in $\tenv$ yields $(\vte, \vep)$ \ProseOrTypeError;
+\item determining whether $\vep$ is a \staticallyevaluable\ expression yields $\True$ \ProseOrTypeError;
+\item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$ \ProseOrTypeError;
+\item obtaining the \structure\ of $\vte$ in $\tenv$ yields $\testruct$ \ProseOrTypeError;
+\item $\vb$ is true if and only if $\vtstruct$ and $\testruct$ are both integer types or both real types;
+\item if $\vb$ is $\False$ a type error is returned (indicating that the types of $\vt$ and $\vte$
+      are inappropriate for the $\GEQ$ operator),
+which short-circuits the entire evaluation;
+\item $\newp$ is the pattern which matches anything greater than or equal to $\vep$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\PGeqBegin}{\PGeqEnd}{../Typing.ml}
+\CodeSubsection{\PGeqBegin}{\PGeqEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
+  \checkstaticallyevaluable(\tenv, \vep) \typearrow \True \OrTypeError\\\\
+  \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
+  \tstruct(\tenv, \vte) \typearrow \testruct \OrTypeError\\\\
+  {
+    \begin{array}{rl}
+      \vb \eqdef& \astlabel(\vtstruct) = \astlabel(\testruct)\ \land\\
+                & \astlabel(\vtstruct) \in \{\TInt, \TReal\}
+    \end{array}
+  }\\
+  \checktrans{\vb, \texttt{"BadTypesForBinop"}} \typearrow \True \OrTypeError
+}
+{
+  \annotatepattern(\tenv, \vt, \PatternGeq(\ve)) \typearrow \PatternGeq(\vep)
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
- \section{TypingRule.PLeq \label{sec:TypingRule.PLeq}}
+\section{TypingRule.PLeq \label{sec:TypingRule.PLeq}}
 
-  \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern which matches anything lesser than or equal to an expression $\ve$;
-   \item \texttt{t\_e, \vep} is the result of annotating $\ve$ in $\tenv$;
-   \item $\vep$ is a compile-time constant expression;
-   \item One of the following applies:
-     \begin{itemize}
-     \item All of the following apply:
-           \begin{itemize}
-           \item both $\vt$ and \texttt{t\_e} have the structure of an integer;
-           \item \texttt{new\_p} is the pattern which matches anything lesser than or equal to $\vep$.
-           \end{itemize}
-     \item All of the following apply:
-           \begin{itemize}
-           \item both $\vt$ and \texttt{t\_e} have the structure of a real;
-           \item \texttt{new\_p} is the pattern which matches anything lesser than or equal to $\vep$.
-           \end{itemize}
-     \item an error ``\texttt{Conflicting Types}'' is raised.
-     \end{itemize}
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+\item $\vp$ is the pattern which matches anything less than or equal to an expression $\ve$,
+that is, $\PatternLeq(\ve)$;
+\item annotating the expression $\ve$ in $\tenv$ yields $(\vte, \vep)$ \ProseOrTypeError;
+\item determining whether $\vep$ is a \staticallyevaluable\ expression yields $\True$ \ProseOrTypeError;
+\item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$ \ProseOrTypeError;
+\item obtaining the \structure\ of $\vte$ in $\tenv$ yields $\testruct$ \ProseOrTypeError;
+\item $\vb$ is true if and only if $\vtstruct$ and $\testruct$ are both integer types or both real types;
+\item if $\vb$ is $\False$ a type error is returned (indicating that the types of $\vt$ and $\vte$
+      are inappropriate for the $\LEQ$ operator),
+which short-circuits the entire evaluation;
+\item $\newp$ is the pattern which matches anything less than or equal to $\vep$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\PLeqBegin}{\PLeqEnd}{../Typing.ml}
+\CodeSubsection{\PLeqBegin}{\PLeqEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
+  \checkstaticallyevaluable(\tenv, \vep) \typearrow \True \OrTypeError\\\\
+  \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
+  \tstruct(\tenv, \vte) \typearrow \testruct \OrTypeError\\\\
+  {
+    \begin{array}{rl}
+      \vb \eqdef& \astlabel(\vtstruct) = \astlabel(\testruct)\ \land\\
+                & \astlabel(\vtstruct) \in \{\TInt, \TReal\}
+    \end{array}
+  }\\
+  \checktrans{\vb, \texttt{"BadTypesForBinop"}} \typearrow \True \OrTypeError
+}
+{
+  \annotatepattern(\tenv, \vt, \PatternLeq(\ve)) \typearrow \PatternLeq(\vep)
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.PNot \label{sec:TypingRule.PNot}}
 
-  \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern which matches the negation of a pattern \texttt{q};
-   \item \texttt{new\_q} is the result of annotating \texttt{q} in $\tenv$;
-   \item \texttt{new\_p} is pattern which matches the negation of \texttt{new\_q}.
-   \end{itemize}
+\subsection{Prose}
+Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern $\newp$ and all of the following apply:
+\begin{itemize}
+  \item $\vp$ is the pattern which matches the negation of a pattern $\vq$, that is, $\PatternNot(\vq)$;
+  \item annotating $\vq$ in $\tenv$ yields $\newq$ \ProseOrTypeError;
+  \item $\newp$ is pattern which matches the negation of $\newq$, that is, $\PatternLeq(\newq)$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\PNotBegin}{\PNotEnd}{../Typing.ml}
+\CodeSubsection{\PNotBegin}{\PNotEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotatepattern(\tenv, \vq) \typearrow \newq \OrTypeError
+}{
+  \annotatepattern(\tenv, \vt, \PatternNot(\vq)) \PatternNot \PatternLeq(\newq)
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.PRange \label{sec:TypingRule.PRange}}
 
-    \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern which matches anything within the range given by
-      expressions $\veone$ and \vetwo;
-   \item \texttt{\vteone, e1'} is the result of annotating $\veone$ in $\tenv$;
-   \item \texttt{\vtetwo, e2'} is the result of annotating $\vetwo$ in $\tenv$;
-   \item e1' and e2' are compile-time constant expressions;
-   \item One of the following applies:
-     \begin{itemize}
-     \item All of the following apply:
-           \begin{itemize}
-           \item both $\vteone$ and $\vtetwo$ have the structure of an integer;
-           \item \texttt{new\_p} is the pattern which matches anything within the range given by
-      expressions $\veonep$ and $\vetwop$.
-           \end{itemize}
-     \item All of the following apply:
-           \begin{itemize}
-           \item both $\vteone$ and $\vtetwo$ have the structure of a real;
-           \item \texttt{new\_p} is the pattern which matches anything within the range given by
-      expressions $\veonep$ and $\vetwop$.
-           \end{itemize}
-     \item an error ``\texttt{Conflicting Types}'' is raised.
-     \end{itemize}
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vp$ is the pattern which matches anything within the range given by
+  expressions $\veone$ and $\vetwo$, that is, $\PatternRange(\veone, \vetwo)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \veonep)$ \ProseOrTypeError;
+  \item annotating the expression $\vetwo$ in $\tenv$ yields $(\vtetwo, \vetwop)$ \ProseOrTypeError;
+  \item determining whether both $\veonep$ and $\vetwop$ are compile-time constant expressions yields $\True$ \ProseOrTypeError;
+  \item obtaining the \structure\ for $\vt$, $\vteone$, and $\vtetwo$ yields
+        $\vtstruct$, $\vteonestruct$, and $\vtetwostruct$, respectively \ProseOrTypeError;
+  \item a check the AST labels of $\vtstruct$, $\vteonestruct$, and $\vtetwostruct$ are all the same and are either
+        $\TInt$ or $\TReal$ yields $\True$. Otherwise, the result is a type error indicating that the types of
+        $\veone$, $\vetwo$ and the type $\vt$ are inappropriate for a range pattern, which short-circuits the entire evaluation.
+  \item $\newp$ is a range pattern with bounds $\veonep$ and $\vetwop$, that is, $\PatternRange(\veonep, \vetwop)$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\PRangeBegin}{\PRangeEnd}{../Typing.ml}
+\CodeSubsection{\PRangeBegin}{\PRangeEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \veonep) \OrTypeError\\
+  \annotateexpr{\tenv, \vetwo} \typearrow (\vtetwo, \vetwop) \OrTypeError\\
+  \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\
+  \tstruct(\tenv, \vteone) \typearrow \vteonestruct \OrTypeError\\
+  \tstruct(\tenv, \vtetwo) \typearrow \vtetwostruct \OrTypeError\\
+  {
+    \begin{array}{rl}
+      \vb \eqdef& \astlabel(\vtstruct) = \astlabel(\vteonestruct) = \astlabel(\vtetwostruct)\ \land\\
+                & \astlabel(\vtstruct) \in \{\TInt, \TReal\}
+    \end{array}
+  }\\
+  \checktrans{\vb, \texttt{"BadTypesForBinop"}} \typearrow \True \OrTypeError
+}{
+  \annotatepattern(\tenv, \vt, \PatternRange(\veone, \vetwo)) \typearrow \PatternRange(\veonep, \vetwop)
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.PSingle \label{sec:TypingRule.PSingle}}
 
-    \subsection{Prose}
-      Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-      \begin{itemize}
-        \item \texttt{p} is the pattern that matches the expression $\ve$;
-        \item \texttt{t\_e, \vep} is the result of annotating the expression $\ve$ in $\tenv$;
-        \item One of the following applies:
-          \begin{itemize}
-            \item All of the following apply:
-              \begin{itemize}
-                \item \texttt{t\_e} has the structure of the real type;
-                \item $\vt$ has the structure of the real type;
-              \end{itemize}
-            \item All of the following apply:
-              \begin{itemize}
-                \item \texttt{t\_e} has the structure of the boolean type;
-                \item $\vt$ has the structure of the boolean type;
-              \end{itemize}
-            \item All of the following apply:
-              \begin{itemize}
-                \item \texttt{t\_e} has the structure of an integer type;
-                \item $\vt$ has the structure of an integer type;
-              \end{itemize}
-            \item All of the following apply:
-              \begin{itemize}
-                \item \texttt{t\_e} has the structure of a bitvector type;
-                \item $\vt$ has the structure of a bitvector type;
-                \item the bitvector types \texttt{t\_e} and $\vt$ have the same length;
-              \end{itemize}
-            \item All of the following apply:
-              \begin{itemize}
-                \item \texttt{t\_e} has the structure of an enumeration type;
-                \item $\vt$ has the structure of an enumeration type;
-                \item the enumeration types \texttt{t\_e} and $\vt$ have the same literals;
-              \end{itemize}
-          \end{itemize}
-        \item \texttt{new\_p} is \texttt{p};
-      \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vp$ is the pattern that matches the expression $\ve$, that is, $\PatternSingle(\ve)$;
+  \item annotating the expression $\ve$ in $\tenv$ yields $(\vte, \vep)$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vt$ yields $\vtstruct$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vte$ yields $\testruct$ \ProseOrTypeError;
+  \item One of the following holds:
+  \begin{itemize}
+    \item All of the following apply (\textsc{t\_bool, t\_real, t\_int}):
+    \begin{itemize}
+      \item the labels of $\vtstruct$ and $\testruct$ are both either $\TBool$, $\TReal$, or $\TInt$ \ProseOrTypeError;
+    \end{itemize}
 
-  \subsection{Example}
+    \item All of the following apply (\textsc{t\_bits}):
+    \begin{itemize}
+      \item the labels of $\vtstruct$ and $\testruct$ are both $\TBits$ \ProseOrTypeError;
+      \item determining whether the bitwidths of $\vtstruct$ and $\testruct$ are equal yields $\True$ \ProseOrTypeError;
+    \end{itemize}
 
+    \item All of the following apply (\textsc{t\_enum}):
+    \begin{itemize}
+      \item the labels of $\vtstruct$ and $\testruct$ are both $\TEnum$ \ProseOrTypeError;
+      \item determining whether the lists of enumeration literals of $\vtstruct$ and $\testruct$ are equal yields $\True$ \ProseOrTypeError;
+    \end{itemize}
 
-    \CodeSubsection{\PSingleBegin}{\PSingleEnd}{../Typing.ml}
+    \item All of the following apply (\textsc{error}):
+    \begin{itemize}
+      \item determining whether the labels of $\vtstruct$ and $\testruct$ are the same yields $\True$ \ProseOrTypeError;
+      \item the label of $\vtstruct$ is not one of $\TBool$, $\TReal$, $\TInt$, $\TBits$, or $\TEnum$;
+      \item the result is a type error indicating that the types $\vt$ and $\vte$ are inappropriate for this pattern.
+    \end{itemize}
+  \end{itemize}
+  \item $\newp$ is the the pattern that matches the expression $\vep$, that is, $\PatternSingle(\vep)$.
+\end{itemize}
+
+\subsection{Example}
+
+\CodeSubsection{\PSingleBegin}{\PSingleEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[t\_bool, t\_real, t\_int]{
+  \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\
+  \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\
+  \tstruct(\tenv, \vte) \typearrow \testruct \OrTypeError\\
+  \checktrans{\astlabel(\vtstruct) = \astlabel(\testruct), \texttt{"BadTypesForBinop"}} \typearrow \True \OrTypeError\\\\
+  \astlabel(\vtstruct) \in \{\TBool, \TReal, \TInt\}
+}{
+  \annotatepattern(\tenv, \vt, \PatternSingle(\ve)) \typearrow \PatternSingle(\vep)
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[t\_bits]{
+  \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\
+  \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\
+  \tstruct(\tenv, \vte) \typearrow \vtestruct \OrTypeError\\
+  \astlabel(\vtstruct) = \astlabel(\testruct) = \TBits\\
+  \bitwidthequal(\tenv, \vtstruct, \testruct) \typearrow \vb\\
+  \checktrans{\vb, \texttt{"BitvectorsDifferentWidths"}} \typearrow \True \OrTypeError\\
+}{
+  \annotatepattern(\tenv, \vt, \PatternSingle(\ve)) \typearrow \PatternSingle(\vep)
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[t\_enum]{
+  \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\
+  \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\
+  \tstruct(\tenv, \vte) \typearrow \vtestruct \OrTypeError\\
+  \vtstruct \eqname \TEnum(\vlione)\\
+  \vtestruct \eqname \TEnum(\vlitwo)\\
+  \checktrans{\vlione = \vlitwo, \texttt{"EnumDifferentLabels"}} \typearrow \True \OrTypeError\\
+}{
+  \annotatepattern(\tenv, \vt, \PatternSingle(\ve)) \typearrow \PatternSingle(\vep)
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[error]{
+  \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\
+  \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\
+  \tstruct(\tenv, \vte) \typearrow \testruct \OrTypeError\\
+  \checktrans{\astlabel(\vtstruct) = \astlabel(\testruct), \texttt{"BadTypesForBinop"}} \typearrow \True \OrTypeError\\\\
+  \astlabel(\vtstruct) \in \{\TBool, \TReal, \TInt, \TBits, \TEnum\}
+}{
+  \annotatepattern(\tenv, \vt, \PatternSingle(\ve)) \typearrow \TypeErrorVal{TypeConflict}
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.PMask \label{sec:TypingRule.PMask}}
 
-  \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern which matches a mask \texttt{m};
-   \item $\vt$ has the structure of a bitvector type;
-   \item $\vn$ is the length of mask \texttt{m};
-   \item \texttt{t\_m} is the bitvector type of width $\vn$;
-   \item One of the following applies:
-     \item All of the following apply:
-       \begin{itemize}
-       \item $\vt$ \typesatisfies\  \texttt{t\_m};
-       \item \texttt{new\_p} is \texttt{p}.
-       \end{itemize}
-     \item an error ``\texttt{Conflicting Types}'' is raised.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+  \begin{itemize}
+  \item $\vp$ is the pattern which matches a mask $\vm$, that is, $\PatternMask(\vm)$;
+  \item determining whether $\vt$ has the structure of a bitvector type yields $\True$ \ProseOrTypeError;
+  \item $\vn$ is the length of mask $\vm$;
+  \item determining whether $\vt$ \typesatisfies\ the bitvector type of length $\vn$ \\
+        (that is, $\TBits(\vn, \emptylist)$), yields $\True$ \ProseOrTypeError;
+  \item $\newp$ is $\vp$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\PMaskBegin}{\PMaskEnd}{../Typing.ml}
+\CodeSubsection{\PMaskBegin}{\PMaskEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \checkstructurelabel(\tenv, \vt, \TBits) \typearrow \True \OrTypeError\\
+  \vn \eqdef |\vm|\\
+  \checktypesat(\tenv, \vt, \TBits(\vn, \emptylist)) \typearrow \True \OrTypeError
+}{
+  \annotatepattern(\tenv, \vt, \PatternMask(\vm)) \typearrow \PatternMask(\vm)
+}
+\end{mathpar}
 \end{emptyformal}
 
 \subsection{Comments}
   This is related to \identi{VMKF}.
 
-\section{TypingRule.PTupleBadArity \label{sec:TypingRule.PTupleBadArity}}
-
-  \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern which matches a tuple $\vli$;
-   \item $\vt$ has the type structure of a tuple type \texttt{ts};
-   \item \texttt{ts} is a list of different size to the size of $\vli$;
-   \item an error ``\texttt{Bad Arity}'' is raised.
-   \end{itemize}
-
-  \subsection{Example}
-
-
-    \CodeSubsection{\PTupleBadArityBegin}{\PTupleBadArityEnd}{../Typing.ml}
-
-\begin{emptyformal}
-    \subsection{Formally}
-\end{emptyformal}
-
-\isempty{\subsection{Comments}}
-
-
 \section{TypingRule.PTuple \label{sec:TypingRule.PTuple}}
 
-  \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern which matches a tuple $\vli$;
-   \item $\vt$ has the type structure of a tuple type \texttt{ts};
-   \item \texttt{ts} is a list of the same size as $\vli$;
-   \item \texttt{new\_li} is the result of annotating $\vli$ with \texttt{ts};
-   \item \texttt{new\_p} is the pattern which matches the tuple \texttt{new\_li}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+  \begin{itemize}
+  \item $\vp$ is the pattern which matches a tuple $\vli$, that is, $\PatternTuple(\vli)$;
+  \item obtaining the \structure\ of $\vt$ yields $\vtstruct$ \ProseOrTypeError;
+  \item determining whether $\vtstruct$ is a tuple type yields $\True$ \ProseOrTypeError;
+  \item $\vtstruct$ is a tuple type with list of tuple $\vts$;
+  \item determining whether $\vts$ is a list of the same size as $\vli$ yields $\True$ \ProseOrTypeError;
+  \item annotating each pattern in $\vli$ with the corresponding type in $\vts$ at each position $\vi$
+        yields a pattern $\vlip[\vi]$ \ProseOrTypeError;
+  \item $\newli$ is the list of annotated patterns $\vlip[\vi]$ at the same positions those of $\vli$;
+  \item $\newp$ is the pattern which matches the tuple $\newli$, that is, $\PatternTuple(\newli)$.
+  \end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\PTupleBegin}{\PTupleEnd}{../Typing.ml}
-
-\begin{emptyformal}
-    \subsection{Formally}
-\end{emptyformal}
-
-\isempty{\subsection{Comments}}
-
-
-\section{TypingRule.PTupleConflict \label{sec:TypingRule.PTupleConflict}}
-
-  \subsection{Prose}
-   Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern \texttt{new\_p} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{p} is the pattern which matches a tuple $\vli$;
-   \item $\vt$ has the type structure of a tuple type \texttt{ts};
-   \item \texttt{t\_struct} is not a tuple type;
-   \item an error ``\texttt{Conflicting Types}'' is raised.
-   \end{itemize}
-
-  \subsection{Example}
-
-
-    \CodeSubsection{\PTupleConflictBegin}{\PTupleConflictEnd}{../Typing.ml}
+\CodeSubsection{\PTupleBegin}{\PTupleEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\
+  \checktrans{\astlabel(\vtstruct) = \TTuple, \texttt{"TypeConflict"}} \typearrow \True \OrTypeError\\
+  \vtstruct \eqname \TTuple(\vts)\\
+  \checktrans{\equallength(\vli, \vts), \texttt{"BadArity"}} \typearrow \True \OrTypeError\\
+  \vi\in\listrange(\vli): \annotatepattern(\tenv, \vts[\vi], \vli[\vi]) \typearrow \vlip[i] \OrTypeError\\
+  \newli \eqdef \vi\in\listrange(\vli): \vlip[\vi]
+}{
+  \annotatepattern(\tenv, \vt, \PatternTuple(\vli)) \typearrow \PatternTuple(\newli)
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
@@ -6451,7 +6529,7 @@ All of the following apply:
 All of the following apply:
 \begin{itemize}
   \item $\ldi$ denotes a variable $\vx$, that is, $\LDIVar(\vx)$;
-  \item determing whether $\vx$ is not declared in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item determining whether $\vx$ is not declared in $\tenv$ yields $\True$ \ProseOrTypeError;
   \item $\newenv$ is $\tenv$ modified so that $\vx$ is locally declared of type $\tty$;
   \item $\newldi$ is the declaration of variable $\vx$.
 \end{itemize}
@@ -6485,9 +6563,10 @@ All of the following apply:
   and a type $\vt$, that is $\LDITyped(\ldip, \vt)$;
   \item annotating the type $\vt$ in $\tenv$ yields $\vtp$ \ProseOrTypeError;
   \item determining whether $\vtp$ can be initialized with $\tty$ in $\tenv$ yields $\True$ \ProseOrTypeError;
-  \item anotating the local declaration item $\ldip$ with the local declaration keyword $\ldk$, given
+  \item annotating the local declaration item $\ldip$ with the local declaration keyword $\ldk$, given
   the type $\vt$, in the environment $\tenv$, yields $(\newtenv,\newldip)$;
-  \item $\newldi$ is the local declaration denoting $\newldip$ and the type $\vtp$, that is, $\LDITyped(\newldip, \vtp)$.
+  \item $\newldi$ is the local declaration denoting $\newldip$ and the type $\vtp$, that is, \\
+  $\LDITyped(\newldip, \vtp)$.
 \end{itemize}
 
 \subsection{Example}
@@ -6523,9 +6602,10 @@ All of the following apply:
   \item annotating the local declaration items in $\ldis$ from right to left with their corresponding
   (that is, with the same index) types $t_{1..k}$ in $\tenv$,
   propagating static environments from one annotation to the next,
-  yields the local delcaration items $\ldip_{1..k}$ \ProseOrTypeError;
+  yields the local declaration items $\ldip_{1..k}$ \ProseOrTypeError;
   \item $\newtenv$ is the static environment yielded by annotating $\ldi_1$;
-  \item $\newldi$ is a tuple of local declaration items with $\ldip_{1..k}$, that is, $\LDITuple(\ldip_{1..k})$.
+  \item $\newldi$ is a tuple of local declaration items with $\ldip_{1..k}$, that is, \\
+  $\LDITuple(\ldip_{1..k})$.
 \end{itemize}
 
 \subsection{Example}
@@ -6538,9 +6618,9 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{
   \tstruct(\tenv, \tty) \typearrow \vtp \OrTypeError\\\\
-  \checktrans{\astlabel(\vtp) = \TTuple} \typearrow \True \OrTypeError\\\\
+  \checktrans{\astlabel(\vtp) = \TTuple, \texttt{"ExpectedTupleType"}} \typearrow \True \OrTypeError\\\\
   \vtp \eqname \TTuple([\vt_{1..n}])\\\\
-  \checktrans{k = n} \typearrow \True \OrTypeError\\\\
+  \checktrans{k = n, \texttt{"BadArity"}} \typearrow \True \OrTypeError\\\\
   \newtenv_k = \tenv\\
   i=k..1:
   \annotatelocaldeclitem{\newtenv_{i}, \ldi_{i}, \ldk, \vt_{i}} \typearrow (\newtenv_{i-1}, \ldip_i) \OrTypeError\\\\
@@ -9424,9 +9504,9 @@ tests whether literal $\vvone$ is $\vvtwo$ by equating them.
 We define the following rules to allow us asserting that a condition holds,
 returning a type error otherwise:
 \begin{mathpar}
-  \inferrule[check\_trans\_true]{}{ \checktrans{\True} \typearrow\True }
+  \inferrule[check\_trans\_true]{}{ \checktrans{\True, \texttt{<message>}} \typearrow\True }
   \and
-  \inferrule[check\_trans\_false]{}{ \checktrans{\False} \typearrow\TypeErrorVal{CheckFailed} }
+  \inferrule[check\_trans\_false]{}{ \checktrans{\False, \texttt{<message>}} \typearrow\TypeErrorVal{\texttt{<message>}} }
 \end{mathpar}
 
 \hypertarget{def-pairstomap}{}
@@ -9813,7 +9893,7 @@ One of the following applies:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule[okay]{
-  \tstruct(\vt) \typearrow \vtp \OrTypeError\\
+  \tstruct(\vt) \typearrow \vtp \OrTypeError\\\\
   \astlabel(\vtp) = \TInt
 }
 {
@@ -9826,6 +9906,149 @@ One of the following applies:
 }
 {
   \checkstructureinteger(\tenv, \vt) \typearrow \TypeErrorVal{ExpectedIntegerStructure}
+}
+\end{mathpar}
+
+\hypertarget{def-checkstructurelabel}{}
+\section{TypingRule.CheckStructure \label{sec:TypingRule.CheckStructure}}
+The function
+\[
+  \checkstructurelabel(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\astlabels}{\vl}) \aslto
+  \True \cup \TTypeError
+\]
+returns $\True$ is $\vt$ is has the \structure\ a of type corresponding to the AST label $\vl$ and a type error otherwise.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{okay}):
+  \begin{itemize}
+    \item determining the \structure\ of $\vt$ yields $\vtp$ \ProseOrTypeError;
+    \item $\vtp$ has the label $\vl$;
+    \item the result is $\True$;
+  \end{itemize}
+
+  \item All of the following apply (\textsc{error}):
+  \begin{itemize}
+    \item determining the \structure\ of $\vt$ yields $\vtp$ \ProseOrTypeError;
+    \item $\vtp$ does not have the label $\vl$;
+    \item the result is a type error indicating that $\vt$ was expected to have the \structure\ of a type with the AST label $\vl$.
+  \end{itemize}
+\end{itemize}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[okay]{
+  \tstruct(\vt) \typearrow \vtp \OrTypeError\\\\
+  \astlabel(\vtp) = \vl
+}
+{
+  \checkstructurelabel(\tenv, \vt, \vl) \typearrow \True
+}
+\and
+\inferrule[error]{
+  \tstruct(\vt) \typearrow \vtp\\
+  \astlabel(\vtp) \neq \vl
+}
+{
+  \checkstructurelabel(\tenv, \vt, \vl) \typearrow \TypeErrorVal{UnexpectedTypeStructure}
+}
+\end{mathpar}
+
+\hypertarget{def-storageispure}{}
+\section{TypingRule.StorageIsPure \label{sec:TypingRule.StorageIsPure}}
+The function
+\[
+  \storageispure(\overname{\staticenvs}{\tenv} \aslsep \overname{\identifier}{\vs}) \aslto
+  \overname{\Bool}{\vb} \cup \TTypeError
+\]
+$\vb$ is true if and only if the identifier $\vs$ corresponds to a \pure\ storage element
+in the static environment $\tenv$.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{local}):
+  \begin{itemize}
+    \item $\vs$ is a locally declared storage element;
+    \item $\vb$ is true if and only if $\vs$ is declared as a constant or as an immutable variable (\texttt{let}).
+  \end{itemize}
+
+  \item All of the following apply (\textsc{global}):
+  \begin{itemize}
+    \item $\vs$ is a globally declared storage element;
+    \item $\vb$ is true if and only if $\vs$ is declared as a constat, a configuration variable, or an immutable variable.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{error}):
+  \begin{itemize}
+    \item $\vs$ is not defined in the environment as a storage element;
+    \item the result is a type error indicating that $\vs$ is not defined as a storage element.
+  \end{itemize}
+\end{itemize}
+
+\CodeSubsection{\StorageIsPureBegin}{\StorageIsPureEnd}{../Typing.ml}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[local]{
+  L^\tenv.\localstoragetypes(\vs) = (\Ignore, \ldk)\\
+  \vb \eqdef \ldk \in \{\LDKConstant, \LDKLet\}
+}
+{
+  \storageispure(\tenv, \vs) \typearrow \vb
+}
+\and
+\inferrule[global]{
+  L^\tenv.\localstoragetypes(\vs) = \bot\\
+  G^\tenv.\globalstoragetypes(\vs) = (\Ignore, \gdk)\\
+  \vb \eqdef \gdk \in \{\GDKConstant, \GDKConfig, \GDKLet\}
+}
+{
+  \storageispure(\tenv, \vs) \typearrow \vb
+}
+\and
+\inferrule[error]{
+  L^\tenv.\localstoragetypes(\vs) = \bot\\
+  G^\tenv.\globalstoragetypes(\vs) = \bot
+}
+{
+  \storageispure(\tenv, \vs) \typearrow \TypeErrorVal{UndefinedIdentifier}
+}
+\end{mathpar}
+
+\hypertarget{def-checkstaticallyevaluable}{}
+\section{TypingRule.CheckStaticallyEvaluable \label{sec:TypingRule.CheckStaticallyEvaluable}}
+The function
+\[
+  \checkstaticallyevaluable(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
+  \True \cup \TTypeError
+\]
+returns $\True$ if $\ve$ is a \staticallyevaluable\ expression in the static environment $\tenv$ and a type error otherwise.
+
+\subsection{Prose}
+All of the following applies:
+\begin{itemize}
+  \item symbolically reducing $\ve$ in $\tenv$ yields $\veone$;
+  \item determining the set of used identifiers in $\veone$ yields $\useset$;
+  \item $\vb$ is true if and only if every identifier in $\useset$ is pure;
+  \item the result is $\True$ is $\vb$ is $\True$, otherwise it is a type error indicating that the expression
+  is not statically evaluable.
+\end{itemize}
+
+\CodeSubsection{\CheckStaticallyEvaluableBegin}{\CheckStaticallyEvaluableEnd}{../Typing.ml}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \tododefine{reduce\_expr}(\tenv, \ve) \typearrow \veone\\
+  \tododefine{use\_e}(\veone) \typearrow \useset\\
+  \id\in\useset: \storageispure(\tenv, \id) \typearrow \vb_\id\\
+  \vb \eqdef \bigwedge_{\id\in\useset} \vb_\id\\
+  \checktrans{\vb, \texttt{"NotStaticallyEvaluable"}} \typearrow \True \OrTypeError
+}
+{
+  \checkstaticallyevaluable(\tenv, \ve) \typearrow \True
 }
 \end{mathpar}
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -71,7 +71,8 @@
 \newcommand\bitfieldsincluded[0]{\hyperlink{def-bitfieldsincluded}{\texttt{bitfields\_included}}}
 \newcommand\instantiate[0]{\texttt{instantiate}}
 \newcommand\canbeinitializedwith[0]{\texttt{can\_be\_initialized\_with}}
-\newcommand\getbitvectorwidth[0]{\texttt{get\_bitvector\_width}}
+\newcommand\getbitvectorwidth[0]{\hyperlink{def-getbitvectorwidth}{\texttt{get\_bitvector\_width}}}
+\newcommand\checkbitsequalwidth[0]{\hyperlink{def-checkbitsequalwidth}{\texttt{check\_bits\_equal\_width}}}
 \newcommand\findsubprogram[0]{\hyperlink{def-findsubprogram}{\texttt{find\_subprogram}}}
 \newcommand\subprogramtypeclash[0]{\texttt{subprogram\_type\_clash}}
 \newcommand\hassubprogramtypeclash[0]{\texttt{subprogram\_type\_clash}}
@@ -79,6 +80,7 @@
 \newcommand\argsclash[0]{\texttt{args\_clash}}
 \newcommand\bitfieldgetname[0]{\hyperlink{def-bitfieldgetname}{\texttt{bitfield\_get\_name}}}
 \newcommand\pairstomap[0]{\hyperlink{def-pairstomap}{\texttt{pairs\_to\_map}}}
+\newcommand\assocopt[0]{\hyperlink{def-assocopt}{\texttt{assoc\_opt}}}
 \newcommand\annotatefieldinit[0]{\hyperlink{def-annotatefieldinit}{\texttt{annotate\_field\_init}}}
 \newcommand\annotatestaticconstrainedinteger[0]{\hyperlink{def-annotatestaticconstrainedinteger}{\texttt{annotate\_static\_constrained\_integer}}}
 \newcommand\checkstructurelabel[0]{\hyperlink{def-checkstructurelabel}{\texttt{check\_structure}}}
@@ -169,12 +171,13 @@
 \newcommand\evalexpr[1]{\texttt{eval\_expr}(#1)}
 \newcommand\evalconstraint[1]{\texttt{eval\_constraint}(#1)}
 \newcommand\annotateliteral[1]{\hyperlink{def-annotateliteral}{\texttt{annotate\_literal}}(#1)}
-\newcommand\exprequalcase[0]{\texttt{expr\_equal\_case}}
+\newcommand\exprequalcase[0]{\hyperlink{def-exprequalcase}{\texttt{expr\_equal\_case}}}
 \newcommand\exprequalnorm[0]{\texttt{expr\_equal\_norm}}
-\newcommand\slicesequal[0]{\texttt{slices\_equal}}
-\newcommand\sliceequal[0]{\texttt{slice\_equal}}
-\newcommand\constraintsequal[0]{\texttt{constraints\_equal}}
-\newcommand\constraintequal[0]{\texttt{constraint\_equal}}
+\newcommand\slicesequal[0]{\hyperlink{def-slicesequal}{\texttt{slices\_equal}}}
+\newcommand\sliceequal[0]{\hyperlink{def-sliceequal}{\texttt{slice\_equal}}}
+\newcommand\constraintsequal[0]{\hyperlink{def-constraintsequal}{\texttt{constraints\_equal}}}
+\newcommand\constraintequal[0]{\hyperlink{def-constraintequal}{\texttt{constraint\_equal}}}
+\newcommand\arraylengthequal[0]{\hyperlink{def-arraylengthequal}{\texttt{array\_length\_equal}}}
 \newcommand\literalequal[0]{\texttt{literal\_equal}}
 \newcommand\findcheckdeduce[0]{\hyperlink{def-findcheckdeduce}{\texttt{find\_check\_deduce}}}
 %\newcommand\renametyeqs[0]{\texttt{rename\_ty\_eqs}}
@@ -236,6 +239,8 @@
 \newcommand\veone[0]{\texttt{e1}}
 \newcommand\vetwo[0]{\texttt{e2}}
 \newcommand\vethree[0]{\texttt{e3}}
+\newcommand\vefour[0]{\texttt{e4}}
+\newcommand\vefive[0]{\texttt{e5}}
 \newcommand\vleone[0]{\texttt{le1}}
 \newcommand\vletwo[0]{\texttt{le2}}
 \newcommand\vtleone[0]{\texttt{t\_le1}}
@@ -626,8 +631,9 @@ function describes how to annotate an AST node, given its label, as follows:\beg
 \end{itemize}
 
 \paragraph{Shorthand Notations:}
-\newcommand\Elit[1]{\texttt{E}(#1)}
-We use the shorthand $\Elit{n}$ for the expression denoting the literal integer value $n$. That is, $\ELiteral(\lint(n))$.
+\hypertarget{def-elit}{}
+\newcommand\ELInt[1]{\hyperlink{def-elit}{\texttt{ELInt}}(#1)}
+We use the shorthand $\ELInt{n}$ for the expression denoting the literal integer value $n$. That is, $\ELiteral(\lint(n))$.
 
 \hypertarget{def-unconstrainedinteger}{}
 We use the shorthand notation $\unconstrainedinteger$ to denote the unconstrained integer type: $\TInt(\unconstrained)$.
@@ -2244,7 +2250,7 @@ One of the following applies:
     This is related to \identd{TRVR}.
 
 \section{TypingRule.SubtypeSatisfaction\label{sec:TypingRule.SubtypeSatisfaction}}
-\hypertarget{def-subtypesatisfies}{}
+\hypertarget{def-subtypesat}{}
 The predicate
 \[
   \subtypesat(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
@@ -2853,7 +2859,7 @@ We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is \typeequivalent\
   \typeequal(\tenv, \vt, \vs) \typearrow \False\\
   \vt \eqname \TArray(\widtht, \vtyt)\\
   \vs \eqname \TArray(\widths, \vtys)\\
-  \tododefine{array\_length\_equal}(\tenv, \widtht, \widths) \typearrow \True\\
+  \arraylengthequal(\tenv, \widtht, \widths) \typearrow \True\\
   \lca(\tenv, \vtyt, \vtys) \typearrow \vtone \OrTypeError
 }{
   \lca(\tenv, \vt, \vs) \typearrow \TArray(\widtht, \vtone)
@@ -2863,7 +2869,7 @@ We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is \typeequivalent\
   \typeequal(\tenv, \vt, \vs) \typearrow \False\\
   \vt \eqname \TArray(\widtht, \vtyt)\\
   \vs \eqname \TArray(\widths, \vtys)\\
-  \tododefine{array\_length\_equal}(\tenv, \widtht, \widths) \typearrow \False
+  \arraylengthequal(\tenv, \widtht, \widths) \typearrow \False
 }{
   \lca(\tenv, \vt, \vs) \typearrow \TypeErrorVal{NoLCA}
 }
@@ -3330,7 +3336,7 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[bits\_bool]{
   \op \in  \{\AND, \OR, \EOR\}\\
-  \tododefine{check\_bits\_equal\_width}(\tenv, \vtone, \vttwo) \typearrow \True \OrTypeError\\
+  \checkbitsequalwidth(\tenv, \vtone, \vttwo) \typearrow \True \OrTypeError\\
   \getbitvectorwidth(\tenv, \vtone) \typearrow \vw
 }{
   \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(\vw, \emptylist)
@@ -3387,7 +3393,7 @@ One of the following applies:
   \makeanonymous(\tenv, \vtone) \typearrow \vtoneanon \OrTypeError\\
   \astlabel(\vtoneanon) = \TBits\\
   \makeanonymous(\tenv, \vttwo) \typearrow \vttwoanon \OrTypeError\\
-  \tododefine{check\_bits\_equal\_width}(\tenv, \vtoneanon, \vttwoanon) \typearrow \True \OrTypeError
+  \checkbitsequalwidth(\tenv, \vtoneanon, \vttwoanon) \typearrow \True \OrTypeError
 }{
   \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
 }
@@ -4195,7 +4201,7 @@ In the following example, all the uses of bitvector types with bitfields are val
   \tododefine{disjoint\_slices\_to\_positions}(\tenv, \slicesone) \typearrow \positions \OrTypeError\\\\
   \tododefine{check\_positions\_in\_width}(\tenv, \slicesone, \width, \positions) \typearrow \True \OrTypeError\\
   \widthp \eqdef |\positions|\\
-  \tododefine{check\_bits\_equal\_width}(\TBits(\widthp, \emptylist), \vt) \typearrow \True \OrTypeError
+  \checkbitsequalwidth(\TBits(\widthp, \emptylist), \vt) \typearrow \True \OrTypeError
 }{
   \annotatebitfield(\tenv, \width, \BitFieldType(\name, \slices, \vt)) \typearrow \\
   \BitFieldType(\name, \slicesone, \vtp)
@@ -4827,7 +4833,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{
   \checktrans{\astlabel(\tty) = \TNamed, \texttt{"expected named type"}} \typearrow \True \OrTypeError\\
-  \tstruct{\tenv, \tty} \typearrow\vtp \OrTypeError\\
+  \tstruct{\tenv, \tty} \typearrow\vtp \OrTypeError\\\\
   \astlabel(\vtp) \not\in \{\TRecord, \TException\}
 }
 {
@@ -4884,7 +4890,7 @@ All of the following apply:
   \item $\tty$ is the name of a record or exception type with fields $\fieldtypes$;
   \item every field in $\fieldtypes$ is initialised by $\fields$;
   \item annotating the expressions in each field initializations in $\fields$ via \\
-  $\annotatefieldinit$ yields $\fieldsp$ \ProseOrTypeError;
+        $\annotatefieldinit$ yields $\fieldsp$ \ProseOrTypeError;
   \item $\vt$ is $\tty$;
   \item $\newe$ is the record expression with type $\tty$ and field initializers $\fieldsp$, that is, $\ERecord(\tty, \fieldsp)$;
 \end{itemize}
@@ -4920,12 +4926,13 @@ All of the following apply:
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
-  \item $(\vteone, \vetwo)$ is the result of annotating $\veone$ in $\tenv$;
-  \item $\vteone$ has an \underlyingtype\ of an exception or record type with fields $\fields$;
-  \item $\fieldname$ is declared in $\fields$;
-  \item $\vt$ is the type corresponding to $\fieldname$ in $\fields$;
-  \item $\newe$ is the access of field $\fieldname$ on expression $\vetwo$.
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$ \ProseOrTypeError;
+  \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$ \ProseOrTypeError;
+  % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$ \ProseOrTypeError;
+  \item $\vtetwo$ is either a record type or an exception type with fields $\fields$;
+  \item the field $\fieldname$ is associated with the type $\vt$ in $\fields$
+  \item $\newe$ is the access of field $\fieldname$ on the record or exception object $\vetwo$, that is, $\EGetField(\vetwo, \fieldname)$.
 \end{itemize}
 
 \subsection{Example}
@@ -4936,12 +4943,14 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\
-  \makeanonymous(\tenv, \vteone) \typearrow L(\fields) \OrTypeError\\
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
+  \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
+  % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\
+  \vtetwo \eqname L(\fields)\\
   L \in \{\TRecord, \TException\}\\
-  (\fieldname,\vt) \in \fields
+  \assocopt(\fields, \fieldname) \typearrow \langle \vt\rangle
 }{
-  \annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \EGetField(\fieldname, \vetwo))
+  \annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \EGetField(\vetwo, \fieldname))
 }
 \end{mathpar}
 \end{emptyformal}
@@ -4950,112 +4959,110 @@ All of the following apply:
 
 \section{TypingRule.EGetBadRecordField \label{sec:TypingRule.EGetBadRecordField}}
 
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
-  \item \texttt{\vteone, $\vetwo$} is the result of annotating $\veone$ in $\tenv$;
-  \item $\vteone$ has the structure of an exception or record type with fields $\fields$;
-  \item $\vtetwo$ has the structure of an exception or record type with fields $\fields$;
-  \item $\vtetwo$ is an Exception or a Record type with fields $\fields$;
-  \item $\fieldname$ is not declared in $\fields$;
-  \item an error ``\texttt{Bad Field}'' is raised.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$ \ProseOrTypeError;
+  \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$ \ProseOrTypeError;
+  % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$ \ProseOrTypeError;
+  \item $\vtetwo$ is either a record type or an exception type with fields $\fields$;
+  \item the field $\fieldname$ is not associated with any type in $\fields$
+  \item the result is a type error indicating the missing field.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\EGetBadRecordFieldBegin}{\EGetBadRecordFieldEnd}{../Typing.ml}
+\CodeSubsection{\EGetBadRecordFieldBegin}{\EGetBadRecordFieldEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
-
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\
+  \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\
+  % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\
+  \vtetwo \eqname L(\fields)\\
+  L \in \{\TRecord, \TException\}\\
+  \assocopt(\fields, \fieldname) \typearrow \None
+}{
+  \annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow \TypeErrorVal{FieldDoesNotExist}
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.EGetBadBitField \label{sec:TypingRule.EGetBadBitField}}
 
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
-  \item $\vteone$ has the structure a bitvector type with bitfields $\bitfields$;
-  \item $\vtetwo$ has the structure a bitvector type with bitfields $\bitfields$;
-  \item $\fieldname$ is not declared in $\bitfields$;
-  \item an error ``\texttt{Bad Field}'' is raised.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$ \ProseOrTypeError;
+  \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$ \ProseOrTypeError;
+  % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$ \ProseOrTypeError;
+  \item $\vtetwo$ is a bitvector type with bit fields $\bitfields$;
+  \item the field $\fieldname$ is not found in $\bitfields$
+  \item the result is a type error indicating the missing field.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\EGetBadBitFieldBegin}{\EGetBadBitFieldEnd}{../Typing.ml}
+\CodeSubsection{\EGetBadBitFieldBegin}{\EGetBadBitFieldEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
-
+\begin{mathpar}
+\inferrule{
+  \ve \eqname \EGetField(\veone, \fieldname)\\
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\
+  \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\
+  % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\
+  \vtetwo \eqname \TBits(\Ignore, \bitfields)\\
+  \tododefine{find\_bitfield}(\bitfields, \fieldname) \typearrow \None
+}{
+  \annotateexpr{\tenv, \ve} \typearrow \TypeErrorVal{FieldDoesNotExist}
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
-\section{TypingRule.EGetBadField \label{sec:TypingRule.EGetBadField}}
-
- \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-   \begin{itemize}
-   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
-   \item \texttt{\vteone, e2} is the result of annotating $\veone$ in $\tenv$;
-   \item $\vteone$ does not have the structure of a record or an exception or a bitvector type;
-   \item an error ``\texttt{Conflicting Types}'' is raised.
-   \end{itemize}
-
- \subsection{Example}
-
-
-    \CodeSubsection{\EGetBadFieldBegin}{\EGetBadFieldEnd}{../Typing.ml}
-
-\begin{emptyformal}
-    \subsection{Formally}
-
-\end{emptyformal}
-
-\isempty{\subsection{Comments}}
 
 \section{TypingRule.EGetBitField \label{sec:TypingRule.EGetBitField}}
 
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
-  \item \texttt{\vteone, e2} is the result of annotating $\veone$ in $\tenv$;
-  \item the \underlyingtype\ of $\vteone$ is a bitvector type with bitfields $\bitfields$;
-  \item $\fieldname$ is declared in $\bitfields$;
-  \item $\slices$ gives the slices corresponding to the bitfield $\fieldname$
-    in \\ $\bitfields$;
-  \item $\vethree$ denotes the slicing of the expression \vetwo by the slices $\slices$;
-  \item $(\vt, \newe)$ is the result of annotating $\vethree$.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$ \ProseOrTypeError;
+  \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$ \ProseOrTypeError;
+  % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$ \ProseOrTypeError;
+  \item $\vtetwo$ is a bitvector type with bit fields $\bitfields$;
+  \item $\fieldname$ is declared in $\bitfields$ with a slice list $\slices$, that is, \\ $\BitFieldSimple(\Ignore, \slices)$;
+  \item $\vethree$ denotes the slicing of the expression \vetwo\ by the slices $\slices$, that is, \\ $\ESlice(\vetwo, \slices)$;
+  \item annotating $\vethree$ in $\tenv$ yields $(\vt, \newe)$ \ProseOrTypeError.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\EGetBitFieldBegin}{\EGetBitFieldEnd}{../Typing.ml}
+\CodeSubsection{\EGetBitFieldBegin}{\EGetBitFieldEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-\annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo)\\
-\makeanonymous(\tenv, \vteone) \typearrow \TBits(\Ignore, \bitfields)\\
-\fieldname = \texttt{BitField\_Simple}(\Ignore, \slices) \in \bitfields\\
-\vethree = \ESlice(\vetwo, \slices)\\
-\annotateexpr{\tenv, \vethree} \typearrow (\vt, \newe)
+  \ve \eqname \EGetField(\veone, \fieldname)\\
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\
+  \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\
+  % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\
+  \vtetwo \eqname \TBits(\Ignore, \bitfields)\\
+  \tododefine{find\_bitfield}(\bitfields, \fieldname) \typearrow \langle \BitFieldSimple(\Ignore, \slices)\rangle\\
+  \vethree \eqdef \ESlice(\vetwo, \slices)\\
+  \annotateexpr{\tenv, \vethree} \typearrow (\vt, \newe) \OrTypeError
+}{
+  \annotateexpr{\tenv, \ve} \typearrow \typearrow (\vt, \newe)
 }
-{\annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \newe)}
 \end{mathpar}
 \end{emptyformal}
 
@@ -5063,55 +5070,66 @@ $(\vt, \newe)$ and all of the following apply:
 
 \section{TypingRule.EGetBitFieldNested \label{sec:TypingRule.EGetBitFieldNested}}
 
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$;
-  \item \texttt{\vteone, e2} is the result of annotating $\veone$ in $\tenv$;
-  \item $\vteone$ has the structure of a bitvector type with bitfields $\bitfields$;
-  \item $\fieldname$ is declared in $\bitfields$;
-  \item $\slices$ gives the slices corresponding to the bitfield $\fieldname$ in \\
-    $\bitfields$;
-  \item $\vethree$ denotes the slicing of the expression \vetwo by the slices $\slices$;
-  \item \texttt{t4, e4} is the result of annotating $\vethree$ in $\tenv$;
-  \item $\bitfieldsp$ gives the bitfields corresponding to the bitfield $\fieldname$
-    in $\bitfields$;
-  \item $\vt$ is the bitvector type with the width of \texttt{t4} and the bitfields $\bitfieldsp$
-  \item $\newe$ is \texttt{e4}.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$ \ProseOrTypeError;
+  \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$ \ProseOrTypeError;
+  % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$ \ProseOrTypeError;
+  \item $\vtetwo$ is a bitvector type with bit fields $\bitfields$;
+  \item $\fieldname$ is declared in $\bitfields$ with a slice list $\slices$ and nested bitfields $\bitfieldsp$, that is,
+        $\BitFieldNested(\Ignore, \slices, \bitfieldsp)$;
+  \item $\vethree$ denotes the slicing of the expression \vetwo\ by the slices $\slices$, that is, \\ $\ESlice(\vetwo, \slices)$;
+  \item annotating $\vethree$ in $\tenv$ yields $(\vtefour, \newe)$ \ProseOrTypeError;
+  \item $\vtefour$ is a bitvector type with length expression $\width$, that is, $\TBits(\width, \Ignore)$;
+  \item $\vt$ is a bitvector type with length expression $\width$ and bitfields $\bitfieldsp$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\EGetBitFieldNestedBegin}{\EGetBitFieldNestedEnd}{../Typing.ml}
+\CodeSubsection{\EGetBitFieldNestedBegin}{\EGetBitFieldNestedEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \ve \eqname \EGetField(\veone, \fieldname)\\
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
+  \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\
+  % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
+  \vtetwo \eqname \TBits(\Ignore, \bitfields)\\
+  \tododefine{find\_bitfield}(\bitfields, \fieldname) \typearrow \langle \BitFieldNested(\Ignore, \slices, \bitfieldsp)\rangle\\
+  \vethree \eqdef \ESlice(\vetwo, \slices)\\
+  \annotateexpr{\tenv, \vethree} \typearrow (\vtefour, \newe) \OrTypeError\\\\
+  \vtefour \eqname \TBits(\width, \Ignore)\\
+  \vt \eqdef \TBits(\width, \bitfieldsp)
+}{
+  \annotateexpr{\tenv, \ve} \typearrow (\vt, \newe)
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.EGetBitFieldTyped \label{sec:TypingRule.EGetBitFieldTyped}}
 
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes \texttt{e1, field\_name};
-  \item $(\vteone, \vetwo)$ is the result of annotating $\veone$ in $\tenv$;
-  \item $\vteone$ has the \underlyingtype\ of a bitvector with bitfields $\bitfields$;
-  \item $\fieldname$ is declared in $\bitfields$;
-  \item $\slices$ gives the slices corresponding to the bitfield $\fieldname$ in \\
-    $\bitfields$;
-  \item $\vt$ is the type associated with $\fieldname$ in $\bitfields$;
-  \item \texttt{t\_e3,e3} is the result of annotating \texttt{\vetwo,slices} in $\tenv$;
-  \item $\vt$ is the type corresponding to the bitfield $\fieldname$ in $\bitfields$;
-  \item \texttt{t\_e3} \typesatisfies\  $\vt$ in $\tenv$;
-  \item $\newe$ is $\vethree$.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$ \ProseOrTypeError;
+  \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$ \ProseOrTypeError;
+  % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$ \ProseOrTypeError;
+  \item $\vtetwo$ is a bitvector type with bit fields $\bitfields$;
+  \item $\fieldname$ is declared in $\bitfields$ with a slice list $\slices$ and typed-bitfield with type $vt$ that is,
+        $\BitFieldType(\Ignore, \slices, \vt)$;
+  \item $\vethree$ denotes the slicing of the expression \vetwo\ by the slices $\slices$, that is, \\ $\ESlice(\vetwo, \slices)$;
+  \item annotating $\vethree$ in $\tenv$ yields $(\vtefour, \newe)$ \ProseOrTypeError;
+  \item determining whether $\vtefour$ \typesatisfies\ $\vt$ yields $\True$ \ProseOrTypeError.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
 \CodeSubsection{\EGetBitFieldTypedBegin}{\EGetBitFieldTypedEnd}{../Typing.ml}
 
@@ -5119,13 +5137,18 @@ $(\vt, \newe)$ and all of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo)\\
-  \makeanonymous(\tenv, \vteone) \typearrow \TBits(\Ignore, \bitfields)\\
-  \fieldname = \texttt{BitField\_Type}(\Ignore, \slices, \vt) \in \bitfields\\
-  \annotateexpr{\ESlice(\vetwo, \slices)} \typearrow (\texttt{t\_e3}, \vethree)\\
-  \typesat(\tenv, \texttt{t\_e3}, \vt)
+  \ve \eqname \EGetField(\veone, \fieldname)\\
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
+  \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\
+  % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
+  \vtetwo \eqname \TBits(\Ignore, \bitfields)\\
+  \tododefine{find\_bitfield}(\bitfields, \fieldname) \typearrow \langle \BitFieldType(\Ignore, \slices, \vt)\rangle\\
+  \vethree \eqdef \ESlice(\vetwo, \slices)\\
+  \annotateexpr{\tenv, \vethree} \typearrow (\vtefour, \newe) \OrTypeError\\\\
+  \checktypesat(\tenv, \vtefour, \vt) \typearrow \True \OrTypeError
+}{
+  \annotateexpr{\tenv, \ve} \typearrow (\vt, \newe)
 }
-{\annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \vethree)}
 \end{mathpar}
 \end{emptyformal}
 
@@ -5136,7 +5159,15 @@ $(\vt, \newe)$ and all of the following apply:
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\ve$ denotes \texttt{e1, field\_name};
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$ \ProseOrTypeError;
+  \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$ \ProseOrTypeError;
+  % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$ \ProseOrTypeError;
+  \item $\vtetwo$ is tuple type with list of types $\tys$, that is, $\TTuple(\tys)$;
+  \item $\fieldname$ is an identifier with the prefix \texttt{item} and the constant $\vindex$;
+  \item determining whether $\vindex$ is between $0$ and the number of types in $\tys$, inclusive, yields $\True$ \ProseOrTypeError;
+  \item $\vt$ is the type at position $\vindex$ of $\tys$;
+  \item $\newe$ is the expression for obtaining the item at index $\vindex$ from the expression $\vetwo$, that is, $\EGetItem(\vetwo, \vindex)$.
 \end{itemize}
 
 \subsection{Example}
@@ -5146,9 +5177,52 @@ All of the following apply:
 \begin{emptyformal}
 \subsection{Formally}
 \begin{mathpar}
-\inferrule{}
-{
-  \annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \vethree)
+\inferrule{
+  \ve \eqname \EGetField(\veone, \fieldname)\\
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
+  \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\
+  % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
+  \vtetwo \eqname \TTuple(\tys)\\
+  \fieldname \eqname \texttt{"item<index>"}\\
+  \checktrans{0 \leq \vindex \leq |\tys|, \texttt{"IndexOutOfRange"}} \typearrow \True \OrTypeError\\\\
+  \vt \eqdef \tys[\vindex]\\
+  \newe \eqdef \EGetItem(\vetwo, \vindex)
+}{
+  \annotateexpr{\tenv, \ve} \typearrow (\vt, \newe)
+}
+\end{mathpar}
+\end{emptyformal}
+
+\isempty{\subsection{Comments}}
+
+\section{TypingRule.EGetBadField \label{sec:TypingRule.EGetBadField}}
+
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$ \ProseOrTypeError;
+  \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$ \ProseOrTypeError;
+  % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$ \ProseOrTypeError;
+  \item $\vtetwo$ is neither one of the following types: record, exception, bitvector, or tuple;
+  \item the result is an error indicating that the type of $\veone$ is inappropriate for accessing the field $\fieldname$.
+\end{itemize}
+
+ \subsection{Example}
+
+\CodeSubsection{\EGetBadFieldBegin}{\EGetBadFieldEnd}{../Typing.ml}
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \ve \eqname \EGetField(\veone, \fieldname)\\
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
+  \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\
+  % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
+  \astlabel(\vtetwo) \not\in \{\TRecord, \TException, \TBits, \TTuple\}
+}{
+  \annotateexpr{\tenv, \ve} \typearrow \TypeErrorVal{ConflictingTypes}
 }
 \end{mathpar}
 \end{emptyformal}
@@ -5157,26 +5231,25 @@ All of the following apply:
 
 \section{TypingRule.EConcatEmpty \label{sec:TypingRule.EConcatEmpty}}
 
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes the empty concatenation;
-  \item $\vt$ is \texttt{bits(0)};
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes the empty concatenation, that is, $\EConcat(\emptylist)$;
+  \item $\vt$ is a $0$-length bitvector with no bitfields, that is, $\TBits(\ELInt{0}, \emptylist)$;
   \item $\newe$ is $\ve$.
-  \end{itemize}
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\EConcatEmptyBegin}{\EConcatEmptyEnd}{../Typing.ml}
+\CodeSubsection{\EConcatEmptyBegin}{\EConcatEmptyEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-\inferrule{\ve = \EConcat(\emptylist)}
-{
-\annotateexpr{\tenv, \ve} \typearrow (\TBits(\texttt{BitWidth\_SingleExpr}(\Elit{0}, \emptylist)), \ve)
+\inferrule{
+  \ve = \EConcat(\emptylist)
+}{
+  \annotateexpr{\tenv, \ve} \typearrow (\TBits(\ELInt{0}, \emptylist), \ve)
 }
 \end{mathpar}
 \end{emptyformal}
@@ -5185,39 +5258,38 @@ $(\vt, \newe)$ and all of the following apply:
 
 \section{TypingRule.EConcat \label{sec:TypingRule.EConcat}}
 
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes the concatenation of a non-empty list of expressions $\vli$;
-  \item \texttt{ts, es} is the list of types and the list of corresponding expressions resulting from annotating each element of $\vli$ in $\tenv$;
-  \item all elements of \texttt{ts} have the structure of a bitvector type;
-  \item $\vw$ is the sum of the widths of the bitvector types in \texttt{ts};
-  \item $\vt$ is \texttt{bits(w)};
-  \item $\newe$ is the concatenation expression for \texttt{es}.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes the concatenation of a non-empty list of expressions $\vli$, that is, \\ $\EConcat(\vli)$;
+  \item $\vli$ is the list of expressions $\vle[i]$, for $i=1..k$;
+  \item annotating each expression $\vle[i]$ in $\tenv$, for $i=1..k$, yields $(\vt_i, \ve_i$) \ProseOrTypeError;
+  \item $\ves$ is the list of expressions $\ve_i$, for $i=1..k$;
+  \item obtaining the bitvector width of $\vt_i$ in $\tenv$, for $i=1..k$, yields $\vw_i$ \ProseOrTypeError;
+  \item $\widthsum_1$ is $\vw_1$;
+  \item $\widthsum_i$, for $i=2..k$, is obtained by reducing the expression that sums \\ $\widthsum_{i-1}$ with the width $\vw_i$;
+  \item $\vt$ is the bitvector of length $\widthsum_k$ and the empty bitfield list, that is, \\ $\TBits(\widthsum_k, \emptylist)$;
+  \item $\newe$ is the concatenation expression for $\ves$, that is, $\EConcat(\ves)$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\EConcatBegin}{\EConcatEnd}{../Typing.ml}
+\CodeSubsection{\EConcatBegin}{\EConcatEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
-\[
+\subsection{Formally}
+\begin{mathpar}
 \inferrule{
-\vli = [i=1..k: \texttt{el}_i]\\
-[\annotateexpr{\tenv, \texttt{el}_i} \typearrow (\ve_i, \vt_i)\;|\; i=1..k]\\
-\texttt{ts} = [i=1..k: \vt_i]\\
-\texttt{es} = [i=1..k: \ve_i]\\
-i=1..k: \astlabel(\tstruct(\tenv, \vt_i)) \typearrow \TBits\\
-\getbitvectorwidth(\tenv, \texttt{ts}) \typearrow \vw
+  i=1..k: \annotateexpr{\tenv, \vle[i]} \typearrow (\vt_i, \ve_i) \OrTypeError\\\\
+  \vts \eqdef [i=1..k: \vt_i]\\
+  \ves \eqdef [i=1..k: \ve_i]\\
+  i=1..k: \getbitvectorwidth(\tenv, \vt_i) \typearrow \vw_i \OrTypeError\\\\
+  \widthsum_1 \eqdef \vw_1\\
+  i=2..k: \tododefine{reduce\_expr}(\tenv, \EBinop(\PLUS, \widthsum_{i-1}, \vw_i)) \typearrow \widthsum_i
+}{
+  \annotateexpr{\tenv, \EConcat(\vli)} \typearrow (\TBits(\widthsum_k, \emptylist), \EConcat(\ves))
 }
-{
-\annotateexpr{\tenv, \EConcat(\vli)} \typearrow (\TBits(w, \emptylist)),
-\EConcat(\texttt{es}, \None)
-}
-\]
+\end{mathpar}
 \end{emptyformal}
 
 \subsection{Comments}
@@ -5227,40 +5299,28 @@ i=1..k: \astlabel(\tstruct(\tenv, \vt_i)) \typearrow \TBits\\
 expression that is unresolvable to an integer. For example:
     \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.EConcatUnresolvableToInteger.asl}
 
-
 \section{TypingRule.ETuple \label{sec:TypingRule.ETuple}}
 
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes a tuple $\vli$;
-  \item \texttt{ts, es} is the result of annotating in $\tenv$ each expression in $\vli$;
-  \item $\vt$ is \texttt{ts};
-  \item $\newe$ is \texttt{es}.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes a tuple expression with list of expressions $\vli$, that is, $ \ETuple(\vli)$;
+  \item annotating each expression $\vle[i]$ in $\tenv$, for $i=1..k$, yields $(\vt_i, \ve_i$) \ProseOrTypeError;
+  \item $\vt$ is the tuple type with list of types $\vt_i$, for $i=1..k$;
+  \item $\newe$ is tuple expression over list of expressions $\ve_i$, for $i=1..k$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\ETupleBegin}{\ETupleEnd}{../Typing.ml}
+\CodeSubsection{\ETupleBegin}{\ETupleEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule[Empty Tuple Expression]{}
-  {
-  \annotateexpr{\tenv, \ETuple([])} \typearrow (\TTuple([]), \ETuple([]))
-  }
-\and
 \inferrule{
-  \vli = [i=1..k: \texttt{el}_i]\\
-  [\annotateexpr{\tenv, \texttt{el}_i} \typearrow (\ve_i, \vt_i)\;|\; i=1..k]\\
-  \texttt{ts} = [i=1..k: \vt_i]\\
-  \texttt{es} = [i=1..k: \ve_i]
-}
-{
-\annotateexpr{\tenv, \ETuple(\vli)} \typearrow (\TTuple(\texttt{ts}), \ETuple(\texttt{es}))
+  i=1..k: \annotateexpr{\tenv, \vle[i]} \typearrow (\vt_i, \ve_i) \OrTypeError
+}{
+  \annotateexpr{\tenv, \ETuple(\vli)} \typearrow (\TTuple(\vt_{1..k}), \ETuple(\ve_{1..k}))
 }
 \end{mathpar}
 \end{emptyformal}
@@ -5269,28 +5329,29 @@ $(\vt, \newe)$ and all of the following apply:
 
 \section{TypingRule.EUnknown \label{sec:TypingRule.EUnknown}}
 
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes an expression \UNKNOWN\  of type $\tty$;
-  \item $\ttyp$ is the structure of $\tty$ in $\tenv$;
-  \item $\vt$ is $\tty$;
-  \item $\newe$ is an expression \UNKNOWN\  of type $\ttyp$.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes an expression \UNKNOWN\ of type $\tty$, that is, $\EUnknown(\tty)$;
+  \item annotating the type $\tty$ in $\tenv$ yields $\ttyone$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\ttyone$ in $\tenv$ yields $\ttytwo$ \ProseOrTypeError;
+  \item $\vt$ is $\ttyone$;
+  \item $\newe$ is an expression \UNKNOWN\ of type $\ttytwo$, that is, $\EUnknown(\ttytwo)$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\EUnknownBegin}{\EUnknownEnd}{../Typing.ml}
+\CodeSubsection{\EUnknownBegin}{\EUnknownEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \tstruct(\tenv, \tty) \typearrow \tty'
+  \annotatetype{\tenv, \tty} \typearrow \ttyone \OrTypeError\\
+  \tstruct(\tenv, \ttyone) \typearrow \ttytwo \OrTypeError
+}{
+  \annotateexpr{\tenv, \EUnknown(\tty)} \typearrow (\ttyone, \EUnknown(\ttytwo))
 }
-{\annotateexpr{\tenv, \EUnknown(\tty)} \typearrow (\tty, \EUnknown(\tty'))}
 \end{mathpar}
 \end{emptyformal}
 
@@ -5299,14 +5360,13 @@ $(\vt, \newe)$ and all of the following apply:
 \section{TypingRule.EPattern \label{sec:TypingRule.EPattern}}
 
 \subsection{Prose}
-The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
+All of the following apply:
 \begin{itemize}
-  \item $\ve$ denotes whether the expression $\vep$ matches \texttt{patterns};
-  \item $(\tep, \vepp)$ is the result of annotating $\vep$ in $\tenv$;
-  \item \texttt{patterns'} is the result of annotating $()\texttt{patterns}, \tep)$ in $\tenv$;
+  \item $\ve$ denotes whether the expression $\veone$ matches the pattern $\vpat$, that is, $\EPattern(\veone, \vpat)$;
+  \item annotating the expression $\veone$ in $\tenv$ yields $(\vtetwo, \vetwo)$ \ProseOrTypeError;
+  \item annotating the pattern $\vttwo$ in $\tenv$ yields $\vpatp$ \ProseOrTypeError;
   \item $\vt$ is $\TBool$;
-  \item $\newe$ denotes whether the expression $\vepp$ matches \texttt{patterns'}.
+  \item $\newe$ denotes whether the expression $\vetwo$ matches $\vpatp$, that is, $\EPattern(\vetwo, \vpatp)$.
 \end{itemize}
 
 \subsection{Example}
@@ -5315,6 +5375,14 @@ $(\vt, \newe)$ and all of the following apply:
 
 \begin{emptyformal}
 \subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \veone} \typearrow (\vtetwo, \vetwo) \OrTypeError\\
+  \annotatepattern(\tenv, \vtetwo) \typearrow \vpatp \OrTypeError
+}{
+  \annotateexpr{\tenv, \EPattern(\veone, \vpat)} \typearrow (\TBool, \EPattern(\vetwo, \vpatp))
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
@@ -5322,42 +5390,41 @@ $(\vt, \newe)$ and all of the following apply:
 \section{TypingRule.ATC \label{sec:TypingRule.ATC}}
 
 \subsection{Prose}
-The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ or a type error, and all of the following apply:
-  \begin{itemize}
+All of the following apply:
+\begin{itemize}
   \item $\ve$ denotes an asserting type conversion with expression $\vep$ and type $\tty$, that is $\EATC(\vep, \tty)$;
   \item annotating the expression $\vep$ in $\tenv$ yields $(\vt, \vepp)$ \ProseOrTypeError;
   \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$ \ProseOrTypeError;
   \item annotating the type $\tty$ in $\tenv$ yields $\tty'$ \ProseOrTypeError;
   \item obtaining the \structure\ of $\tty'$ in $\tenv$ yields $\vtystruct$ \ProseOrTypeError;
   \item One of the following applies:
-    \begin{itemize}
-    \item All of the following apply (\textsc{type\_equal}):
-    \begin{itemize}
-      \item determining whether $\vtstruct$ is equivalent to $\vtystruct$ in $\tenv$ \\ yields $\True$;
-      \item $\vt$ is $\tty'$ and $\newe$ is $\vepp$.
-    \end{itemize}
-    \item All of the following apply (\textsc{dynamic}):
-      \begin{itemize}
-        \item determining whether $\vtstruct$ is equivalent to $\vtystruct$ in $\tenv$ \\ yields $\False$,
-        meaning that an execution-time check that the expression $\vep$ evaluates to a value in the
-        dynamic domain of $\tty$ is required;
-        \item both $\vtstruct$ and $\vtystruct$ are bitevector types or integer types.
-        \item $\vt$ is $\vtp$ and $\newe$ is the asserting type conversion expression over $\vepp$ \\ and
-        $\vtystruct$, that is, $\EATC(\vepp, \vtystruct)$.
-     \end{itemize}
-   \item All of the following apply:
-     \begin{itemize}
-      \item determining whether $\vtstruct$ is equivalent to $\vtystruct$ in $\tenv$ \\ yields $\False$;
-      \item $\vtstruct$ and $\vtystruct$ are not both bitevector types or integer types.
-      \item a type error indicating the conflicting types is returned.
-     \end{itemize}
-   \end{itemize}
+  \begin{itemize}
+  \item All of the following apply (\textsc{type\_equal}):
+  \begin{itemize}
+    \item determining whether $\vtstruct$ is equivalent to $\vtystruct$ in $\tenv$ \\ yields $\True$;
+    \item $\vt$ is $\tty'$ and $\newe$ is $\vepp$.
   \end{itemize}
+  \item All of the following apply (\textsc{dynamic}):
+    \begin{itemize}
+      \item determining whether $\vtstruct$ is equivalent to $\vtystruct$ in $\tenv$ \\ yields $\False$,
+      meaning that an execution-time check that the expression $\vep$ evaluates to a value in the
+      dynamic domain of $\tty$ is required;
+      \item both $\vtstruct$ and $\vtystruct$ are bitevector types or integer types.
+      \item $\vt$ is $\vtp$ and $\newe$ is the asserting type conversion expression over $\vepp$ \\ and
+      $\vtystruct$, that is, $\EATC(\vepp, \vtystruct)$.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item determining whether $\vtstruct$ is equivalent to $\vtystruct$ in $\tenv$ \\ yields $\False$;
+    \item $\vtstruct$ and $\vtystruct$ are not both bitevector types or integer types.
+    \item a type error indicating the conflicting types is returned.
+    \end{itemize}
+  \end{itemize}
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-  \CodeSubsection{\ATCBegin}{\ATCEnd}{../Typing.ml}
+\CodeSubsection{\ATCBegin}{\ATCEnd}{../Typing.ml}
 
 \begin{emptyformal}
 \subsection{Formally}
@@ -5368,8 +5435,7 @@ $(\vt, \newe)$ or a type error, and all of the following apply:
   \annotatetype{\tenv, \tty} \typearrow \tty' \OrTypeError\\
   \tstruct(\tenv, \tty') \typearrow \vtystruct \OrTypeError\\
   \typeequal(\tenv, \vtstruct, \vtystruct) \typearrow \True
-}
-{
+}{
   \annotateexpr{\tenv, \EATC(\vep, \tty)} \typearrow (\tty', \vepp)
 }
 \end{mathpar}
@@ -5383,9 +5449,8 @@ $(\vt, \newe)$ or a type error, and all of the following apply:
   \typeequal(\tenv, \vtstruct, \vtystruct) \typearrow \False\\
   \vb \eqdef \astlabel(\vtstruct) = \astlabel(\vtystruct) \land
   \astlabel(\vtstruct) \in \{\TBits, \TInt \}\\
-  \vb = \True
-}
-{
+  \vb \eqdef \True
+}{
   \annotateexpr{\tenv, \EATC(\vep, \tty)} \typearrow (\vtp, \EATC(\vepp, \vtystruct))
 }
 \end{mathpar}
@@ -5400,8 +5465,7 @@ $(\vt, \newe)$ or a type error, and all of the following apply:
   \vb \eqdef \astlabel(\vtstruct) = \astlabel(\vtystruct) \land
   \astlabel(\vtstruct) \in \{\TBits, \TInt \}\\
   \vb = \False
-}
-{
+}{
   \annotateexpr{\tenv, \EATC(\vep, \tty)} \typearrow \TypeErrorVal{ATC}
 }
 \end{mathpar}
@@ -5439,23 +5503,23 @@ In the following example, we show several literals and their corresponding types
 \CodeSubsection{\LitBegin}{\LitEnd}{../Typing.ml}
 
 \begin{emptyformal}
-  \subsection{Formally}
-  \begin{mathpar}
-    \inferrule{}{\annotateliteral{\Elit{n}}\typearrow \TInt(\langle[\ConstraintExact(\Elit{n})]\rangle)}
-    \and
-    \inferrule{}{\annotateliteral{\eliteral{\lbool(\Ignore)}}\typearrow \TBool}
-    \and
-    \inferrule{}{\annotateliteral{\eliteral{\lreal(\Ignore)}}\typearrow \TReal}
-    \and
-    \inferrule{}{\annotateliteral{\eliteral{\lstring(\Ignore)}}\typearrow \TString}
-    \and
-    \inferrule{
-      \vl = \eliteral{\lbitvector(\bits)}\\
-      n \eqdef |\bits|
-    }{
-      \annotateliteral{\vl}\typearrow \TBits(\Elit{n}, \emptylist)
-    }
-  \end{mathpar}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{}{\annotateliteral{\ELInt{n}}\typearrow \TInt(\langle[\ConstraintExact(\ELInt{n})]\rangle)}
+\and
+\inferrule{}{\annotateliteral{\eliteral{\lbool(\Ignore)}}\typearrow \TBool}
+\and
+\inferrule{}{\annotateliteral{\eliteral{\lreal(\Ignore)}}\typearrow \TReal}
+\and
+\inferrule{}{\annotateliteral{\eliteral{\lstring(\Ignore)}}\typearrow \TString}
+\and
+\inferrule{
+  \vl = \eliteral{\lbitvector(\bits)}\\
+  n \eqdef |\bits|
+}{
+  \annotateliteral{\vl}\typearrow \TBits(\ELInt{n}, \emptylist)
+}
+\end{mathpar}
 \end{emptyformal}
 
 \section{TypingRule.ExpressionList \label{sec:TypingRule.ExpressionList}}
@@ -8901,6 +8965,7 @@ the respective Boolean value:
 The reason we define equality via rules is to allow using it as a short-circuiting premise.
 
 \section{TypingRule.ExprEqual}
+\hypertarget{def-exprequal}{}
 The function
 \[
   \exprequal(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\veone} \aslsep \overname{\expr}{\vetwo}) \rightarrow \overname{\{\True, \False\}}{\vb}
@@ -8921,7 +8986,7 @@ conservatively checks whether the expression $\veone$ is equivalent to the expre
 \end{emptyformal}
 
 \section{TypingRule.ExprEqualCase}
-
+\hypertarget{def-exprequalcase}{}
 The function
 \[
   \exprequalcase(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\veone} \aslsep \overname{\expr}{\vetwo})
@@ -9470,33 +9535,6 @@ multiplies two polynomials.
   }
 \end{mathpar}
 
-% let rec to_ir env (e : expr) : ir_expr =
-%     | E_Binop (SHL, e1, { desc = E_Literal (L_Int i2); _ }) ->
-%         let ir1 = to_ir env e1 and f2 = Z.pow Z.one (Z.to_int i2) in
-%         map_num
-%           (fun (Sum monos) -> Sum (MMap.map (fun c -> Z.mul c f2) monos))
-%           ir1
-%     | E_Binop (op, { desc = E_Literal l1; _ }, { desc = E_Literal l2; _ }) ->
-%         binop_values e op l1 l2 |> poly_of_val |> always
-%     | E_Unop (NEG, e0) -> e0 |> to_ir env |> map_num poly_neg
-%     | E_Cond (cond, e1, e2) ->
-%         let Disjunction ctnts, Disjunction nctnts = to_cond env cond
-%         and (Disjunction ir1) = to_ir env e1
-%         and (Disjunction ir2) = to_ir env e2 in
-%         let restrict ctnts (ctnts', p) = (ctnts_and ctnts ctnts', p) in
-%         let ir1' = ASTUtils.list_cross restrict ctnts ir1
-%         and ir2' = ASTUtils.list_cross restrict nctnts ir2 in
-%         Disjunction (ir1' @ ir2')
-%     | _ -> (
-%         let v =
-%           try static_eval env e
-%           with Error.ASLException { desc = UnsupportedExpr _; _ } ->
-%             raise NotYetImplemented
-%         in
-%         match v with
-%         | L_Int i -> poly_of_z i |> always
-%         | _ -> raise NotYetImplemented)
-
 \section{TypingRule.TypeEqual}
 \hypertarget{def-typeequal}{}
 The function
@@ -9852,6 +9890,37 @@ in environment $\tenv$.
       \slicesequal(\tenv, \SliceLength(\veoneone, \veonetwo), \SliceLength(\vetwoone, \vetwotwo)) \typearrow \vb
     }
   \end{mathpar}
+\end{emptyformal}
+
+\section{TypingRule.ArrayLengthEqual}
+\hypertarget{def-arraylengthequal}{}
+The function
+\[
+  \arraylengthequal(\overname{\arrayindex}{\vlone} \aslsep \overname{\arrayindex}{\vltwo}) \rightarrow \overname{\{\True, \False\}}{\vb}
+\]
+tests whether the array lengths $\vlone$ and $\vltwo$ are equivalent.
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[expr\_expr]{
+  \exprequal(\veone, \vetwo) \typearrow \vb
+}{
+  \arraylengthequal(\ArrayLengthExpr(\veone), \ArrayLengthExpr(\vetwo)) \typearrow \vb
+}
+\and
+\inferrule[enum\_enum]{
+  \vb \eqdef \vsone = \vstwo
+}{
+  \arraylengthequal(\ArrayLengthEnum(\vsone, \Ignore), \ArrayLengthEnum(\vstwo, \Ignore)) \typearrow \vb
+}
+\and
+\inferrule[different\_labels]{
+  \astlabel(\vlone) \neq \astlabel(\vltwo)
+}{
+  \arraylengthequal(\vlone, \vltwo) \typearrow \False
+}
+\end{mathpar}
 \end{emptyformal}
 
 \section{TypingRule.LiteralEqual}
@@ -10503,6 +10572,68 @@ All of the following applt:
 }
 {
   \getwellconstrainedstructure(\tenv, \vt) \typearrow \vtp
+}
+\end{mathpar}
+\end{emptyformal}
+
+\section{TypingRule.GetBitvectorWidth}
+\hypertarget{def-getbitvectorwidth}{}
+The function
+\[
+  \getbitvectorwidth(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt}) \aslto
+  \overname{\expr}{\ve} \cup \TTypeError
+\]
+returns the expression $\ve$, which represents the width of the bitvector type $\vt$,
+or a type error if $\vt$ is not a bitvector type or another type error is detected.
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[okay]{
+  \tstruct(\tenv, \vt) \typearrow \TBits(\ve, \Ignore) \OrTypeError
+}{
+  \getbitvectorwidth(\tenv, \vt) \typearrow \ve
+}
+\and
+\inferrule[error]{
+  \tstruct(\tenv, \vt) \typearrow \vtp\\
+  \astlabel(\vtp) \neq \TBits
+}{
+  \getbitvectorwidth(\tenv, \vt) \typearrow \TypeErrorVal{ExpectedBitvectorType}
+}
+\end{mathpar}
+\end{emptyformal}
+
+\section{TypingRule.CheckBitsEqualWidth}
+\hypertarget{def-checkbitsequalwidth}{}
+The function
+\[
+  \checkbitsequalwidth(
+    \overname{\staticenvs}{\tenv} \aslsep
+    \overname{\ty}{\vtone}) \aslsep
+    \overname{\ty}{\vttwo})\aslto
+  \True \cup \TTypeError
+\]
+tests whether the types $\vtone$ and $\vttwo$ are bitvector types of the same width.
+If the answer is positive, the result is $\True$. Otheriwe, the result is a type error.
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[true]{
+  \getbitvectorwidth(\tenv, \vtone) \typearrow \vn \OrTypeError\\
+  \getbitvectorwidth(\tenv, \vttwo) \typearrow \vm \OrTypeError\\
+  \bitwidthequal(\tenv, \vn, \vm) \typearrow \True
+}{
+  \checkbitsequalwidth(\tenv, \vtone, \vttwo) \typearrow \True
+}
+\and
+\inferrule[error]{
+  \getbitvectorwidth(\tenv, \vtone) \typearrow \vn \OrTypeError\\
+  \getbitvectorwidth(\tenv, \vttwo) \typearrow \vm \OrTypeError\\
+  \bitwidthequal(\tenv, \vn, \vm) \typearrow \False
+}{
+  \checkbitsequalwidth(\tenv, \vtone, \vttwo) \typearrow \TypeErrorVal{DifferentBitwidths}
 }
 \end{mathpar}
 \end{emptyformal}

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -48,10 +48,10 @@
 \newcommand\isnonprimitive[0]{\hyperlink{def-isnonprimitive}{\texttt{is\_non\_primitive}}}
 \newcommand\isprimitive[0]{\hyperlink{def-isprimitive}{\texttt{is\_primitive}}}
 
-\newcommand\isunconstrainedinteger[0]{\textsf{unconstrained\_integer}}
-\newcommand\isunderconstrainedinteger[0]{\textsf{under\_constrained\_integer}}
-\newcommand\iswellconstrainedinteger[0]{\textsf{well\_constrained\_integer}}
-\newcommand\unconstrainedinteger[0]{\textsf{unconstrained\_integer}}
+\newcommand\isunconstrainedinteger[0]{\hyperlink{def-isunconstrainedinteger}{\textsf{is\_unconstrained\_integer}}}
+\newcommand\isunderconstrainedinteger[0]{\hyperlink{def-isunderconstrainedinteger}{\textsf{is\_under\_constrained\_integer}}}
+\newcommand\iswellconstrainedinteger[0]{\hyperlink{def-iswellconstrainedinteger}{\textsf{is\_well\_constrained\_integer}}}
+\newcommand\unconstrainedinteger[0]{\hyperlink{def-unconstrainedinteger}{\textsf{unconstrained\_integer}}}
 
 \newcommand\checkconstrainedinteger[0]{\hyperlink{def-checkconstrainedinteger}{\texttt{check\_constrained\_integer}}}
 
@@ -65,8 +65,8 @@
 \newcommand\subtypesat[0]{\hyperlink{def-subtypesat}{\texttt{subtype\_satisfies}}}
 \newcommand\checktypesat[0]{\hyperlink{def-checktypesat}{\texttt{checked\_typesat}}}
 \newcommand\typeclashes[0]{\hyperlink{def-typeclashes}{\texttt{type\_clashes}}}
-\newcommand\lca[0]{\texttt{lowest\_common\_ancestor}}
-\newcommand\lcasat[0]{\models}
+\newcommand\lca[0]{\hyperlink{def-lowestcommonancestor}{\texttt{lowest\_common\_ancestor}}}
+\newcommand\namedlca[0]{\hyperlink{def-namedlowestcommonancestor}{\texttt{named\_lowest\_common\_ancestor}}}
 \newcommand\Supers{\textsf{Supers}}
 \newcommand\bitfieldsincluded[0]{\hyperlink{def-bitfieldsincluded}{\texttt{bitfields\_included}}}
 \newcommand\instantiate[0]{\texttt{instantiate}}
@@ -85,6 +85,9 @@
 \newcommand\checkstructureinteger[0]{\hyperlink{def-checkstructureinteger}{\texttt{check\_structure\_integer}}}
 \newcommand\checkstaticallyevaluable[0]{\hyperlink{def-checkstaticallyevaluable}{\texttt{check\_statically\_evaluable}}}
 \newcommand\storageispure[0]{\hyperlink{def-storageispure}{\texttt{storage\_is\_pure}}}
+\newcommand\negateconstraint[0]{\hyperlink{def-negateconstraint}{\texttt{negate\_constraint}}}
+\newcommand\getwellconstrainedstructure[0]{\hyperlink{def-getwellconstrainedstructure}{\texttt{get\_well\_constrained\_structure}}}
+\newcommand\towellconstrained[0]{\hyperlink{def-towellconstrained}{\texttt{to\_well\_constrained}}}
 
 % Symbolic equivalence testing macros
 \newcommand\typeequal[0]{\hyperlink{def-typeequal}{\texttt{type\_equal}}}
@@ -119,6 +122,7 @@
 \newcommand\underlyingtype[0]{\hyperlink{def-underlyingtype}{underlying type}}
 \newcommand\symbolicdomain[0]{\hyperlink{def-symbolicdomain}{symbolic domain}}
 \newcommand\typesatisfies[0]{\hyperlink{def-typesatisfies}{type-satisfies}}
+\newcommand\typesatisfy[0]{\hyperlink{def-typesatisfies}{type-satisfy}}
 \newcommand\checkedtypesatisfies[0]{\hyperlink{def-checktypesat}{checked-type-satisfies}}
 \newcommand\typesatisft[0]{\hyperlink{def-typesatisfies}{type-satisft}}
 \newcommand\subtypesatisfies[0]{\hyperlink{def-subtypesatisfies}{subtype-satisfies}}
@@ -130,6 +134,8 @@
 \newcommand\structureofinteger[0]{\hyperlink{def-checkstructureinteger}{structure of an integer}}
 \newcommand\staticallyevaluable[0]{\hyperlink{def-staticallyevaluable}{statically evaluable}}
 \newcommand\pure[0]{hyperlink{def-storageispure}{pure}}
+\newcommand\wellconstrainedstructure[0]{\hyperlink{def-getwellconstrainedstructure}{well-constrained structure}}
+\newcommand\namedlowestcommonancestor[0]{\hyperlink{def-namedlowestcommonancestor}{named lowest common ancestor}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Type functions
@@ -513,17 +519,24 @@ This is related to \identd{JRXM} and \identi{ZTMQ}.
   \end{itemize}
 The widths of bitvector storage elements are constrained integers.
 
+\hypertarget{def-isunconstrainedinteger}{}
+\hypertarget{def-isunderconstrainedinteger}{}
+\hypertarget{def-iswellconstrainedinteger}{}
 We define the following helper predicates to classify integer types:
 \[
-  \isunconstrainedinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt}) \aslto \Bool
+  \begin{array}{rcl}
+  \isunconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool\\
+  \isunderconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool\\
+  \iswellconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool
+  \end{array}
 \]
 
 We define the following shorthands for classifying integers:
 \[
   \begin{array}{rcl}
-  \isunconstrainedinteger(\tenv, \vt) &\triangleq& \vt = \TInt(\unconstrained)\\
-  \isunderconstrainedinteger(\tenv, \vt) &\triangleq& \vt = \TInt(\underconstrained)\\
-  \iswellconstrainedinteger(\tenv, \vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\wellconstrained\\
+  \isunconstrainedinteger(\vt) &\triangleq& \vt = \TInt(\unconstrained)\\
+  \isunderconstrainedinteger(\vt) &\triangleq& \vt = \TInt(\underconstrained)\\
+  \iswellconstrainedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\wellconstrained\\
 \end{array}
 \]
 
@@ -616,7 +629,8 @@ function describes how to annotate an AST node, given its label, as follows:\beg
 \newcommand\Elit[1]{\texttt{E}(#1)}
 We use the shorthand $\Elit{n}$ for the expression denoting the literal integer value $n$. That is, $\ELiteral(\lint(n))$.
 
-We use the shorthand notation $\unconstrainedinteger$ to denote the unconstrained integer type: $\TInt(\None)$.
+\hypertarget{def-unconstrainedinteger}{}
+We use the shorthand notation $\unconstrainedinteger$ to denote the unconstrained integer type: $\TInt(\unconstrained)$.
 
 Note that throughout this document we use $\tty$ to denote a type variable, which should not be confused with the abstract syntax variable $\ty$.
 
@@ -1791,6 +1805,8 @@ We define the following relations over types and operators:
   \item Checking adequacy of a binary operator for a pair of types (\secref{TypingRule.CheckBinop})
 \end{itemize}
 
+We also define the helper rule Typing.FindNamedLCA (\secref{Typing.FindNamedLCA}).
+
 \section{TypingRule.Subtype\label{sec:TypingRule.Subtype}}
 The \emph{subtype} relation is a partial order over \underline{named types}.
 The \emph{supertype} is the symmetric relation. That is, \tty\ is a supertype of \tsy\ if and only if \tsy\ is a subtype of \tty.
@@ -2576,150 +2592,154 @@ type-clashes with \texttt{A} and \texttt{B} then it is also the case that \textt
 This is related to \identd{VPZZ}, \identi{PQCT} and \identi{WZKM}.
 
 \section{TypingRule.LowestCommonAncestor \label{sec:TypingRule.LowestCommonAncestor}}
+\hypertarget{def-lowestcommonancestor}{}
 Annotating a conditional expression (see \secref{TypingRule.ECond}),
 requires finding a single type that can be used to annotate the results of both sub-expressions.
 The function
 \[
   \lca(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
-  \aslto \overname{\ty}{\tty}
+  \aslto \overname{\ty}{\tty} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 returns the \emph{lowest common ancestor} of types $\vt$ and $\vs$ in $\tenv$ --- $\tty$.
+The result is a type error if a lowest common ancestor does not exist or a type error is detected.
 
 \subsection{Prose}
-The lowest common ancestor of types $\vs$ and $\vt$ is $\tty$ and one of the following applies:
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{type\_equal}):
   \begin{itemize}
-  \item All of the following apply:
-    \begin{itemize}
-    \item $\vs$ and $\vt$ are the same type;
-    \item $\tty$ is $\vs$.
-    \end{itemize}
-
-  \item All of the following apply:
-    \begin{itemize}
-    \item $\vs$ and $\vt$ are both named types;
-    \item $\tty$ is a common supertype of $\vs$ and $\vt$;
-    \item $\tty$ is a subtype of all other common supertypes of $\vs$ and $\vt$.
-    \end{itemize}
-
-  \item All of the following apply:
-    \begin{itemize}
-    \item $\vs$ and $\vt$ both have the structure of array types with the same index type
-      and the same element types;
-
-    \item One of the following applies:
-      \begin{itemize}
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is a named type;
-        \item $\vt$ is an anonymous type;
-        \item $\tty$ is $\vs$.
-        \end{itemize}
-
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is an anonymous type;
-        \item $\vt$ is a named type;
-        \item $\tty$ is $\vt$.
-        \end{itemize}
-      \end{itemize}
-    \end{itemize}
-
-  \item All of the following apply:
-    \begin{itemize}
-    \item $\vs$ and $\vt$ both have the structure of tuple types with the same number of elements;
-    \item The types of the elements of $\vs$ type-satisfy the types of the elements of $\vt$;
-    \item The types of the elements of $\vt$ type-satisfy the types of the elements of $\vs$;
-    \item One of the following applies:
-
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is a named type;
-        \item $\vt$ is an anonymous type;
-        \item $\tty$ is $\vs$.
-        \end{itemize}
-
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is an anonymous type;
-        \item $\vt$ is a named type;
-        \item $\tty$ is $\vt$.
-        \end{itemize}
-
-     \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is an anonymous type;
-        \item $\vt$ is an anonymous type;
-	\item $\tty$ is the tuple type where the type of each element is the lowest common
-	  ancestor of the types of the corresponding elements of $\vs$ and $\vt$.
-        \end{itemize}
-    \end{itemize}
-
-  \item All of the following apply:
-    \begin{itemize}
-    \item $\vs$ and $\vt$ both have the structure of well-constrained integer types;
-    \item One of the following applies:
-      \begin{itemize}
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is a named type;
-        \item $\vt$ is an anonymous type;
-        \item $\tty$ is $\vs$.
-        \end{itemize}
-
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is an anonymous type;
-        \item $\vt$ is a named type;
-        \item $\tty$ is $\vt$.
-        \end{itemize}
-
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is an anonymous type;
-        \item $\vt$ is an anonymous type;
-	\item $\tty$ is the well-constrained integer type whose runtime domain is the union of the
-	  runtime domains of $\vs$ and $\vt$, for every dynamic environment.
-        \end{itemize}
-      \end{itemize}
-    \end{itemize}
-
-  \item All of the following apply:
-    \begin{itemize}
-    \item Either $\vs$ or $\vt$ have the structure of an unconstrained integer type;
-    \item One of the following applies:
-
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is a named type;
-        \item $\vs$ has the structure of an unconstrained integer type;
-        \item $\vt$ is an anonymous type;
-        \item $\tty$ is $\vs$.
-        \end{itemize}
-
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is an anonymous type;
-        \item $\vt$ is a named type;
-        \item $\vt$ has the structure of an unconstrained integer type;
-        \item $\tty$ is $\vt$.
-        \end{itemize}
-
-      \item All of the following apply:
-        \begin{itemize}
-        \item $\vs$ is an anonymous type;
-        \item $\vt$ is an anonymous type;
-	\item $\tty$ is the unconstrained integer type.
-        \end{itemize}
-    \end{itemize}
-
-  \item All of the following apply:
-    \begin{itemize}
-    \item Either $\vs$ or $\vt$ have the structure of an under-constrained integer type;
-    \item $\tty$ is the under-constrained integer type.
-    \end{itemize}
-
-  \item $\tty$ is undefined.
+    \item $\vt$ is \typeequal\ to $\vs$ in $\tenv$;
+    \item $\tty$ is $\vs$ (can as well be $\vt$).
   \end{itemize}
+
+  \item All of the following apply:
+  \begin{itemize}
+    \item $\vt$ is not \typeequal\ to $\vs$ in $\tenv$ and one of the following applies:
+
+    \item All of the following apply (\textsc{named\_subtype1}):
+    \begin{itemize}
+      \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
+      \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
+      \item there is no \namedlowestcommonancestor\ of $\namesubs$ and $\namesubt$ in $\tenv$;
+      \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$ \ProseOrTypeError;
+      \item obtaining the \underlyingtype\ of $\vt$ yields $\vanont$ \ProseOrTypeError;
+      \item obtaining the lowest common ancestor of $\vanons$ and $\vanont$ in $\tenv$ yields $\tty$ \ProseOrTypeError.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{named\_subtype2}):
+    \begin{itemize}
+      \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
+      \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
+      \item the \namedlowestcommonancestor\ of $\namesubs$ and $\namesubt$ in $\tenv$ is $\name$ \ProseOrTypeError;
+      \item $\tty$ is the named type with identifier $\name$, that is, $\TNamed(\name)$.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{one\_named1}):
+    \begin{itemize}
+      \item only one of $\vt$ or $\vs$ is a named type;
+      \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$ \ProseOrTypeError;
+      \item obtaining the \underlyingtype\ of $\vt$ yields $\vanont$ \ProseOrTypeError;
+      \item $\vanont$ is \typeequal\ to $\vanons$;
+      \item $\tty$ is
+    \end{itemize}
+
+    \item All of the following apply (\textsc{one\_named2}):
+    \begin{itemize}
+      \item only one of $\vt$ or $\vs$ is a named type;
+      \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$ \ProseOrTypeError;
+      \item obtaining the \underlyingtype\ of $\vt$ yields $\vanont$ \ProseOrTypeError;
+      \item $\vanont$ is not \typeequal\ to $\vanons$;
+      \item the lowest common ancestor of $\vanont$ and $\vanons$ in $\tenv$ is $\tty$ \ProseOrTypeError.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_int\_unconstrained}):
+    \begin{itemize}
+      \item at least one of $\vt$ or $\vs$ is an unconstrained integer type;
+      \item $\tty$ is the unconstrained integer type.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_int\_underconstrained}):
+    \begin{itemize}
+      \item at least one of $\vt$ or $\vs$ is an unconstrained integer type;
+      \item the \wellconstrained\ version of $\vt$ is $\vtone$;
+      \item the \wellconstrained\ version of $\vs$ is $\vsone$;
+      \item $\tty$ the lowest common ancestor of $\vtone$ and $\vsone$ in $\tenv$ is $\tty$ \ProseOrTypeError.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_int\_wellconstrained}):
+    \begin{itemize}
+      \item $\vt$ is a well-constrained integer type with constraints $\cst$;
+      \item $\vs$ is a well-constrained integer type with constraints $\css$;
+      \item $\tty$ is the well-constrained integer type with constraints $\cst \concat \css$.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_bits\_equal}):
+    \begin{itemize}
+      \item $\vt$ is a bitvector type with with length expression $\vet$, that is, $\TBits(\vet, \Ignore)$;
+      \item $\vs$ is a bitvector type with with length expression $\ves$, that is, $\TBits(\ves, \Ignore)$;
+      \item $\vet$ is equivalent to $\ves$ in $\tenv$;
+      \item $\tty$ is a bitvector type with legnth expression $\vet$ and an empty bitfield list, that is, $\TBits(\vet, \emptylist)$.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_bits\_not\_equal}):
+    \begin{itemize}
+      \item $\vt$ is a bitvector type with length expression $\vet$;
+      \item $\vs$ is a bitvector type with length expression $\ves$;
+      \item $\vet$ is equivalent to $\ves$ in $\tenv$;
+      \item the result is a type error indicating the lack of a lowest common ancestor.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_array\_equal}):
+    \begin{itemize}
+      \item $\vt$ is an array type with width expression $\widtht$ and element type $\vtyt$;
+      \item $\vs$ is an array type with width expression $\widths$ and element type $\vtys$;
+      \item $\widtht$ is equivalent to $\widths$ in $\tenv$;
+      \item the lowest common ancestor of $\vtyt$ and $\vtys$ is $\vtone$ \ProseOrTypeError;
+      \item $\tty$ is an array type with width expression $\widths$ and element type $\vtone$.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_array\_not\_equal}):
+    \begin{itemize}
+      \item $\vt$ is an array type with width expression $\widtht$ and element type $\vtyt$;
+      \item $\vs$ is an array type with width expression $\widths$ and element type $\vtys$;
+      \item $\widtht$ is not equivalent to $\widths$ in $\tenv$;
+      \item the result is a type error indicating the lack of a lowest common ancestor.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_tuple\_different\_length}):
+    \begin{itemize}
+      \item $\vt$ is a tuple type with type list $\vlit$;
+      \item $\vs$ is a tuple type with type list $\vlis$;
+      \item $\vlit$ and $vlis$ differ in their number of elements;
+      \item the result is a type error indicating the lack of a lowest common ancestor.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_tuple\_error}):
+    \begin{itemize}
+      \item $\vt$ is a tuple type with type list $\vlit$;
+      \item $\vs$ is a tuple type with type list $\vlis$;
+      \item $\vlit$ and $\vlis$ have the same number of elements;
+      \item there exists an index $\vi$ such that either $\vlit[\vi]$ does not \typesatisfy\ $\vlis[\vi]$ or vice versa;
+      \item the result is a type error indicating the lack of a lowest common ancestor.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_tuple}):
+    \begin{itemize}
+      \item $\vt$ is a tuple type with type list $\vlit$;
+      \item $\vs$ is a tuple type with type list $\vlis$;
+      \item $\vlit$ and $\vlis$ have the same number of elements;
+      \item for every index $\vi$, $\vlit[\vi]$ \typesatisfies\ $\vlis[\vi]$ and vice versa;
+      \item $\vli[\vi]$ is the of types lowest common ancestor of $\vlit[\vi]$ and $\vlis[\vi]$, for every position of $\vlit$;
+      \item $\tty$ is the tuple type with list of types $\vli$, that is, $\TTuple(\vli)$.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{labels}):
+    \begin{itemize}
+      \item either the AST labels of $\vt$ and $\vs$ are different, or one of them is $\TEnum$, $\TRecord$, or $\TException$;
+      \item the result is a type error indicating the lack of a lowest common ancestor.
+    \end{itemize}
+  \end{itemize}
+\end{itemize}
 
 \subsection{Example}
 
@@ -2727,164 +2747,174 @@ The lowest common ancestor of types $\vs$ and $\vt$ is $\tty$ and one of the fol
 
 \begin{emptyformal}
 \subsection{Formally}
-Since we do not impose a canonical representation on types (e.g., \texttt{Integer {1, 2}} is equivalence to \texttt{integer {1..2}}),
+Since we do not impose a canonical representation on types (e.g., \verb|Integer {1, 2}| is equivalence to \verb|integer {1..2}|),
 the lowest common ancestor is not unique.
-We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is type-equivalent to the lowest common ancestor of $\vt$ and $\vs$:
-\[
-  \typeequal(\tenv, \vtp, \lca(\tenv, \vt, \vs)) \enspace.
-\]
+We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is \typeequivalent\ to the lowest common ancestor of $\vt$ and $\vs$.
 
 \begin{mathpar}
-\inferrule[Lowest common ancestor reflexivity]{}{\lca(\tenv, \vt, \vt) = \vt}
-\and
-\inferrule[(The least common subtype, if one exists.)]{
-  \astlabel(\vt)=\astlabel(\vs)=\TNamed \\\\
-  \Supers(\vs) = \{\vsp \;|\; \subtypesrel(\tenv, \vs, \vsp)\}\\
-  \Supers(\vt) = \{\vtp \;|\; \subtypesrel(\tenv, \vt, \vtp)\}\\\\
-  \Supers(\vs) \cap \Supers(\vt) \neq \emptyset
+\inferrule[type\_equal]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \True
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \vs
 }
-{\lca(\tenv, \vt, \vs) = \min_{\subtypes} (\Supers(\vs) \cap \Supers(\vt))}
+\and
+\inferrule[named\_subtype1]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \namedlca(\tenv, \namesubs, \namesubt) \typearrow \None \OrTypeError\\
+  \makeanonymous(\tenv, \vs) \typearrow \vanons \OrTypeError\\
+  \makeanonymous(\tenv, \vt) \typearrow \vanont \OrTypeError\\
+  \lca(\tenv, \vanont, \vanons) \typearrow \tty \OrTypeError
+}{
+  \lca(\tenv, \TNamed(\namesubs), \TNamed(\namesubt)) \typearrow \tty
+}
+\and
+\inferrule[named\_subtype2]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \namedlca(\tenv, \namesubs, \namesubt) \typearrow \langle\name\rangle \OrTypeError\\
+}{
+  \lca(\tenv, \TNamed(\namesubs), \TNamed(\namesubt)) \typearrow \TNamed(\name)
+}
+\and
+\inferrule[one\_named1]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  (\astlabel(\vt) = \TNamed \lor \astlabel(\vs) = \TNamed)\\
+  \astlabel(\vt) \neq \astlabel(\vs)\\
+  \makeanonymous(\tenv, \vs) \typearrow \vanons \OrTypeError\\
+  \makeanonymous(\tenv, \vt) \typearrow \vanont \OrTypeError\\
+  \typeequal(\tenv, \vanont, \vanons) \typearrow \True\\
+  \tty \eqdef \choice{\astlabel(\vt) = \TNamed}{\vt}{\vs}
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \tty
+}
+\and
+\inferrule[one\_named2]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  (\astlabel(\vt) = \TNamed \lor \astlabel(\vs) = \TNamed)\\
+  \astlabel(\vt) \neq \astlabel(\vs)\\
+  \makeanonymous(\tenv, \vs) \typearrow \vanons \OrTypeError\\
+  \makeanonymous(\tenv, \vt) \typearrow \vanont \OrTypeError\\
+  \typeequal(\tenv, \vanont, \vanons) \typearrow \False\\
+  \lca(\tenv, \vanont, \vanons) \typearrow \tty \OrTypeError
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \tty
+}
 \end{mathpar}
 
-Rules for arrays:
 \begin{mathpar}
-\inferrule{\tstruct(\tenv, \vt) = \TArray(\vlt, \vtt) \\
-  \tstruct(\tenv, \vs) = \TArray(\vls, \vts) \\
-  \typeequal(\tenv, \vlt, \vls) \\
-  \typeequal(\tenv, \vtt, \vts) \\
-  \astlabel(\tstruct(\tenv, \vt)) = \TNamed \\
-  \isanonymous(\vs)
+\inferrule[t\_int\_unconstrained]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \isunconstrainedinteger(\vt) \lor \isunconstrainedinteger(\vs)
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \unconstrainedinteger
 }
-{\lca(\tenv, \vt, \vs) = \vt}
 \and
-\inferrule{\tstruct(\tenv, \vt) = \TArray(\vlt, \vtt) \\
-  \tstruct(\tenv, \vs) = \TArray(\vls, \vts) \\
-  \typeequal(\tenv, \vlt, \vls) \\
-  \typeequal(\tenv, \vtt, \vts) \\
-  \astlabel(\tstruct(\tenv, \vs)) = \TNamed \\
-  \isanonymous(\vt)
+\inferrule[t\_int\_underconstrained]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \isunderconstrainedinteger(\vt) \lor \isunderconstrainedinteger(\vs)\\
+  \towellconstrained(\tenv, \vt) \typearrow \vtone\\
+  \towellconstrained(\tenv, \vs) \typearrow \vsone\\
+  \lca(\tenv, \vtone, \vsone) \typearrow \tty \OrTypeError
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \tty
 }
-{\lca(\tenv, \vt, \vs) = \vs}
-\end{mathpar}
-
-Rules for tuples:
-\begin{mathpar}
-\inferrule{
-  \tstruct(\tenv, \vt) = \TTuple(\vt_{1..k}) \\
-  \tstruct(\tenv, \vs) = \TTuple(\vs_{1..k}) \\
-  i=1..k:\typesat(\tenv, \vs_i, \vt_i) \\
-  i=1..k:\typesat(\tenv, \vt_i, \vs_i) \\
-  \astlabel(\vt) = \TNamed \\
-  \isanonymous(\vs)
-}
-{\lca(\tenv, \vt, \vs) = \vt}
 \and
-\inferrule{
-  \tstruct(\tenv, \vt) = \TTuple(\vt_{1..k}) \\
-  \tstruct(\tenv, \vs) = \TTuple(\vs_{1..k}) \\
-  i=1..k:\typesat(\tenv, \vs_i, \vt_i) \\
-  i=1..k:\typesat(\tenv, \vt_i, \vs_i) \\
-  \astlabel(\vs) = \TNamed \\
-  \isanonymous(\vt)
-}
-{\lca(\tenv, \vt, \vs) = \vs}
-\and
-\inferrule{
-  \tstruct(\tenv, \vt) = \TTuple(\vt_{1..k}) \\
-  \tstruct(\tenv, \vs) = \TTuple(\vs_{1..k}) \\
-  i=1..k:\typesat(\tenv, \vs_i, \vt_i) \\
-  i=1..k:\typesat(\tenv, \vt_i, \vs_i) \\
-  \isanonymous(\vt)\\
-  \isanonymous(\vs)\\
-  i=1..k: \lca(\tenv, \vt_i, \vs_i)=\vz_i
-}
-{\lca(\tenv, \vt, \vs) = \TTuple(\vz_{1..k})}
-\end{mathpar}
-
-Rules for well-constrained integers:
-\begin{mathpar}
-\inferrule{
-  \iswellconstrainedinteger(\tstruct(\tenv, \vt))  \\
-  \iswellconstrainedinteger(\tstruct(\tenv, \vs))  \\
-  \astlabel(\vt) = \TNamed\\
-  \isanonymous(\vs)
-}
-{\lca(\tenv, \vt, \vs) = \vt}
-\and
-\inferrule{
-  \iswellconstrainedinteger(\tstruct(\tenv, \vt))  \\
-  \iswellconstrainedinteger(\tstruct(\tenv, \vs))  \\
-  \astlabel(\vs) = \TNamed\\
-  \isanonymous(\vt)
-}
-{\lca(\tenv, \vt, \vs) = \vs}
-\and
-\inferrule{
-  \iswellconstrainedinteger(\tstruct(\tenv, \vt))  \\
-  \iswellconstrainedinteger(\tstruct(\tenv, \vs))  \\
-  \astlabel(\vs) = \TNamed\\
-  \isanonymous(\vt)
-}
-{\lca(\tenv, \vt, \vs) = \vs}
-\and
-\inferrule[(We use + to denote the list concatenation.)]
+\inferrule[t\_int\_wellconstrained]
 {
-  \tstruct(\tenv, \vt) = \TInt(\langle \cst \rangle) \\
-  \tstruct(\tenv, \vs) = \TInt(\langle \css \rangle) \\
-  \isanonymous(\vt)\\
-  \isanonymous(\vs)}
-{\lca(\tenv, \vt, \vs) = \TInt(\langle \cst + \css \rangle)}
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \vt \eqname \TInt(\wellconstrained(\cst))\\
+  \vs \eqname \TInt(\wellconstrained(\css))
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \TInt(\wellconstrained(\cst \concat \css))
+}
 \end{mathpar}
 
-Rules for unconstrained integers:
 \begin{mathpar}
-\inferrule{
-  \astlabel(\vs) = \TNamed \\
-  \tstruct(\tenv, \vs) = \isunconstrainedinteger \\
-  \tstruct(\tenv, \vt) = \TInt(\Ignore) \\
-  \isanonymous(\tenv, \vt)
+\inferrule[t\_bits\_equal]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \vt \eqname \TBits(\vet, \Ignore)\\
+  \vs \eqname \TBits(\ves, \Ignore)\\
+  \exprequal(\tenv, \vet, \ves) \typearrow \True
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \TBits(\vet, \emptylist)
 }
-{\lca(\tenv, \vt, \vs) = \vs}
 \and
-\inferrule{
-  \astlabel(\vt) = \TNamed \\
-  \tstruct(\tenv, \vt) = \isunconstrainedinteger \\
-  \tstruct(\tenv, \vs) = \TInt(\Ignore) \\
-  \isanonymous(\tenv, \vs)
+\inferrule[t\_bits\_not\_equal]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \vt \eqname \TBits(\vet, \Ignore)\\
+  \vs \eqname \TBits(\ves, \Ignore)\\
+  \exprequal(\tenv, \vet, \ves) \typearrow \False
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \TypeErrorVal{NoLCA}
 }
-{\lca(\tenv, \vt, \vs) = \vt}
-\and
-\inferrule{
-  \isanonymous(\tenv, \vs) \\
-  \isanonymous(\tenv, \vt) \\
-  \tstruct(\tenv, \vt) = \TInt(\Ignore) \\
-  \tstruct(\tenv, \vt) = \TInt(\Ignore) \\
-  \tstruct(\tenv, \vs) = \isunconstrainedinteger \\
-}
-{\lca(\tenv, \vt, \vs) = \unconstrainedinteger}
-\and
-\inferrule{
-  \isanonymous(\tenv, \vs) \\
-  \isanonymous(\tenv, \vt) \\
-  \tstruct(\tenv, \vs) = \TInt(\Ignore) \\
-  \tstruct(\tenv, \vt) = \isunconstrainedinteger \\
-}
-{\lca(\tenv, \vt, \vs) = \unconstrainedinteger}
 \end{mathpar}
 
-Rules for underconstrained integers:
 \begin{mathpar}
-\inferrule{
-  \tstruct(\tenv, \vt) = \isunderconstrainedinteger \\
-  \tstruct(\tenv, \vs) = \TInt(\Ignore) \\
+\inferrule[t\_array\_equal]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \vt \eqname \TArray(\widtht, \vtyt)\\
+  \vs \eqname \TArray(\widths, \vtys)\\
+  \tododefine{array\_length\_equal}(\tenv, \widtht, \widths) \typearrow \True\\
+  \lca(\tenv, \vtyt, \vtys) \typearrow \vtone \OrTypeError
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \TArray(\widtht, \vtone)
 }
-{\lca(\tenv, \vt, \vs) = \isunderconstrainedinteger}
 \and
-\inferrule{
-  \tstruct(\tenv, \vs) = \isunderconstrainedinteger \\
-  \tstruct(\tenv, \vt) = \TInt(\Ignore) \\
+\inferrule[t\_array\_not\_equal]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \vt \eqname \TArray(\widtht, \vtyt)\\
+  \vs \eqname \TArray(\widths, \vtys)\\
+  \tododefine{array\_length\_equal}(\tenv, \widtht, \widths) \typearrow \False
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \TypeErrorVal{NoLCA}
 }
-{\lca(\tenv, \vt, \vs) = \isunderconstrainedinteger}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[t\_tuple\_different\_length]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \vt \eqname \TTuple(\vlit)\\
+  \vs \eqname \TTuple(\vlis)\\
+  \equallength(\vlit, \vlis) \typearrow \False
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \TypeErrorVal{NoLCA}
+}
+\and
+\inferrule[t\_tuple\_error]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \vt \eqname \TTuple(\vlit)\\
+  \vs \eqname \TTuple(\vlis)\\
+  \equallength(\vlit, \vlis) \typearrow \True\\
+  \vi\in\listrange(\vlit)\\
+  \typesat(\tenv, \vlit[\vi], \vlis[\vi]) \typearrow \vbone\\
+  \typesat(\tenv, \vlis[\vi], \vlit[\vi]) \typearrow \vbtwo\\
+  \vbone = \False \lor \vbtwo = \False
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \TypeErrorVal{NoLCA}
+}
+\and
+\inferrule[t\_tuple]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  \vt \eqname \TTuple(\vlit)\\
+  \vs \eqname \TTuple(\vlis)\\
+  \equallength(\vlit, \vlis) \typearrow \True\\
+  \vi\in\listrange(\vlit): \typesat(\tenv, \vlit[\vi], \vlis[\vi]) \typearrow \True\\
+  \vi\in\listrange(\vlit): \typesat(\tenv, \vlis[\vi], \vlit[\vi]) \typearrow \True\\
+  \vi\in\listrange(\vlit): \lca(\tenv, \vlit[\vi], \vlis[\vi]) \typearrow \vli[\vi] \OrTypeError\\
+  \vli \eqdef [\vi\in\listrange(\vlit): \vli[\vi]]
+}{
+  \lca(\tenv, \vt, \vs) \typearrow \TTuple(\vli)
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[labels]{
+  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
+  (\astlabel(\vt) \neq \astlabel(\vs)) \lor
+  \astlabel(\vt) \in \{\TEnum, \TRecord, \TException\}
+}
+{
+  \lca(\tenv, \vt, \vs) \typearrow \TypeErrorVal{NoLCA}
+}
 \end{mathpar}
 \end{emptyformal}
 
@@ -2902,76 +2932,66 @@ determines the result type of applying a unary operator when the type of its ope
 Similarly, we determine the negation of integer constraints.
 
 \subsection{Prose}
-  $\vt$ is the result of checking compatibility of a unary operator $\op$ with
-  type $\vtone$ and one of the following applies:
+One of the following applies:
+\begin{itemize}
+\item All of the following apply (\textsc{bnot\_t\_bool}):
   \begin{itemize}
-  \item All of the following apply (\textsc{bnot\_t\_bool}):
-    \begin{itemize}
-      \item $\op$ is $\BNOT$;
-      \item determining whether $\vtone$ \checkedtypesatisfies\ $\TBool$ yields $\True$ \ProseOrTypeError;
-      \item $\vt$ is $\TBool$;
-    \end{itemize}
-
-  \item All of the following apply (\textsc{neg\_t\_rel}):
-  \begin{itemize}
-    \item $\op$ is $\NEG$;
-    \item determining whether $\vtone$ \checkedtypesatisfies\ $\TReal$ yields $\True$ \ProseOrTypeError;
-    \item $\vt$ is $\TReal$;
+    \item $\op$ is $\BNOT$;
+    \item determining whether $\vtone$ \typesatisfies\ $\TBool$ yields $\True$ \ProseOrTypeError;
+    \item $\vs$ is $\TBool$;
   \end{itemize}
 
-  \item All of the following apply:
-    \begin{itemize}
-    \item $\op$ is $\NEG$;
-    \item One of the following applies:
-      \begin{itemize}
-      \item $\vtone$ \typesatisfies\  $\TInt$;
-      \item $\vtone$ \typesatisfies\  $\TReal$;
-      \end{itemize}
-     \item One of the following applies:
-       \begin{itemize}
-       \item All of the following apply:
-         \begin{itemize}
-         \item $\vtone$ has the structure of an unconstrained integer;
-         \item $\vt$ is an unconstrained integer;
-         \end{itemize}
-       \item All of the following apply:
-         \begin{itemize}
-         \item $\vtone$ has the structure of a \constrainedinteger;
-         \item $\vt$ is a \constrainedinteger\  whose constraint is ;
-         \end{itemize}
-       \end{itemize}
-    \end{itemize}
+\item All of the following apply (\textsc{neg\_error}):
+\begin{itemize}
+  \item $\op$ is $\NEG$;
+  \item determining whether $\vtone$ \typesatisfies\ $\TReal$ yields $\False$ \ProseOrTypeError;
+  \item determining whether $\vtone$ \typesatisfies\ $\TInt(\unconstrained)$ yields $\False$ \ProseOrTypeError;
+  \item the result is a type error indicating the $\NEG$ is appropriate only for \texttt{real} and \texttt{integer} types;
+\end{itemize}
 
-  \item All of the following apply:
-    \begin{itemize}
-    \item $\op$ is $\NEG$;
-    \item One of the following applies:
-      \begin{itemize}
-      \item $\vtone$ \typesatisfies\  $\TInt$;
-      \item $\vtone$ \typesatisfies\  $\TReal$;
-      \end{itemize}
-     \item One of the following applies:
-       \begin{itemize}
-       \item All of the following apply:
-         \begin{itemize}
-         \item $\vtone$ has the structure of an unconstrained integer;
-         \item $\vt$ is an unconstrained integer;
-         \end{itemize}
-       \item All of the following apply:
-         \begin{itemize}
-         \item $\vtone$ has the structure of a \constrainedinteger;
-         \item $\vt$ is a \constrainedinteger\  whose constraint is ;
-         \end{itemize}
-       \end{itemize}
-    \end{itemize}
+\item All of the following apply (\textsc{neg\_t\_rel}):
+\begin{itemize}
+  \item $\op$ is $\NEG$;
+  \item determining whether $\vtone$ \typesatisfies\ $\TReal$ yields $\True$ \ProseOrTypeError;
+  \item $\vs$ is $\TReal$;
+\end{itemize}
 
-  \item All of the following apply:
-    \begin{itemize}
-    \item $\op$ is $\NOT$;
-    \item $\vtone$ has the structure of a bitvector;
-    \item $\vt$ is $\vtone$.
-    \end{itemize}
+\item All of the following apply (\textsc{neg\_t\_int\_unconstrained}):
+\begin{itemize}
+  \item $\op$ is $\NEG$;
+  \item determining whether $\vtone$ \typesatisfies\ $\unconstrainedinteger$ yields $\True$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vt$ yields $\unconstrainedinteger$ \ProseOrTypeError;
+  \item $\vs$ is $\unconstrainedinteger$;
+\end{itemize}
+
+\item All of the following apply (\textsc{neg\_t\_int\_well\_constrained}):
+\begin{itemize}
+  \item $\op$ is $\NEG$;
+  \item determining whether $\vtone$ \typesatisfies\ $\unconstrainedinteger$ yields $\True$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vt$ yields the well-constrained integer type with constraints $\vcs$ \ProseOrTypeError;
+  \item negating the constraints in $\vcs$ (see $\negateconstraint$) yields $\vcsnew$;
+  \item $\vs$ is the well-constrained integer type with constraints $\vcsnew$, that is, \\
+  $\TInt(\wellconstrained(\vcsnew))$;
+\end{itemize}
+
+\item All of the following apply (\textsc{neg\_t\_int\_underconstrained}):
+\begin{itemize}
+  \item $\op$ is $\NEG$;
+  \item determining whether $\vtone$ \typesatisfies\ $\unconstrainedinteger$ yields $\True$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vt$ yields the underconstrained integer type with parameter $\vv$, that is,
+  $\TInt(\wellconstrained(\vv))$ \ProseOrTypeError;
+  \item converting $\TInt(\wellconstrained(\vv))$ to a well-constrained integer with an exact constraint expression for $\vv$
+  (see $\getwellconstrainedstructure$) yields $\vtone$;
+  \item obtaining the appropriate type for the unary operator $\NEG$ in $\tenv$ for $\vtone$ yields $\vs$.
+\end{itemize}
+
+\item All of the following apply (\textsc{not\_t\_bits}):
+  \begin{itemize}
+  \item $\op$ is $\NOT$;
+  \item $\vtone$ has the structure of a bitvector;
+  \item $\vt$ is $\vtone$.
   \end{itemize}
+\end{itemize}
 
 \subsection{Example}
 
@@ -2981,45 +3001,84 @@ Similarly, we determine the negation of integer constraints.
 \subsection{Formally}
 \begin{mathpar}
 \inferrule[bnot\_t\_bool]{
-  \checktypesat(\tenv, \vt, \TBool) \typearrow \True \OrTypeError\\
+  \checktypesat(\tenv, \vtone, \TBool) \typearrow \True \OrTypeError\\
 }{
-  \CheckUnop(\tenv, \BNOT, \vt) \typearrow \TBool
+  \CheckUnop(\tenv, \BNOT, \vtone) \typearrow \TBool
+}
+\end{mathpar}
+
+\hypertarget{def-negateconstraint}{}
+We now define the helper function
+\[
+  \negateconstraint(\intconstraint) \aslto \intconstraint
+\]
+which takes an integer constraint and returns the constraint that corresponds to the negation of all
+the values it represents:
+
+\begin{mathpar}
+\inferrule{}
+{
+  \negateconstraint(\ConstraintExact(\ve)) \typearrow \ConstraintExact(\EUnop(\MINUS, \ve))
 }
 \and
+\inferrule{}
+{
+  \negateconstraint(\ConstraintRange(\vvtop, \vbot)) \typearrow \\
+  \ConstraintRange(\EUnop(\MINUS, \vbot), \EUnop(\MINUS, \vvtop))
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[neg\_error]{
+  \typesat(\tenv, \vtone, \TInt(\unconstrained)) \typearrow \False \OrTypeError\\
+  \typesat(\tenv, \vtone, \TReal) \typearrow \False \OrTypeError\\
+}{
+  \CheckUnop(\tenv, \NEG, \vt) \typearrow \TypeErrorVal{InappropriateTypeForNeg}
+}
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[neg\_t\_real]{
-  \checktypesat(\tenv, \vt, \TReal) \typearrow \True \OrTypeError\\
+  \typesat(\tenv, \vtone, \TReal) \typearrow \True \OrTypeError
 }{
   \CheckUnop(\tenv, \NEG, \vt) \typearrow \TReal
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[neg\_t\_int\_unconstrained]{
-  \typesat(\tenv, \vt, \unconstrainedinteger)
+  \typesat(\tenv, \vtone, \unconstrainedinteger) \typearrow \vbone \OrTypeError\\
+  \tstruct(\tenv, \vtone) \typearrow \TInt(\unconstrained)\\
 }{
-  \CheckUnop(\tenv, \NEG, \vt) \typearrow \unconstrainedinteger
+  \CheckUnop(\tenv, \NEG, \vt) \typearrow \TInt(\unconstrained)
 }
 \end{mathpar}
 
-We define the following helper relations for negating integer constraints:
-\begin{mathpar}
-\inferrule[constraint\_exact]{}{\CheckUnop(\tenv, \NEG, \ConstraintExact(\ve)) \typearrow \ConstraintExact(\EUnop(\NEG, \ve))}
-\and
-\inferrule[constraint\_range]{}{\CheckUnop(\tenv, \NEG, \ConstraintRange(\ve1,\ve2)) \typearrow \\
- \ConstraintRange(\EUnop(\NEG, \ve2),\EUnop(\NEG, \ve1))}
-\end{mathpar}
-
-We now apply these relations to handle well-constrained integers:
 \begin{mathpar}
 \inferrule[neg\_t\_int\_well\_constrained]{
-  \typesat(\tenv, \vt, \TInt(\langle [c_{1..k}] \rangle)) \\
-  i=1..k: \CheckUnop(\NEG, c_i) : d_i
+  \typesat(\tenv, \vt, \unconstrainedinteger) \typearrow \True\\
+  \tstruct(\tenv, \vtone) \typearrow \TInt(\wellconstrained(\vcs))\\
+  \vc \in \vcs: \negateconstraint(\vc) \typearrow \vneg_\vc\\
+  \vcsnew \eqdef [\vc \in \vcs: \vneg_\vc]
 }{
-  \CheckUnop(\tenv, \NEG, \vt) \typearrow \TInt(\langle [d_{1..k}] \rangle)
+  \CheckUnop(\tenv, \NEG, \vt) \typearrow \TInt(\wellconstrained(\vcsnew))
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[neg\_t\_int\_underconstrained]{
+  \typesat(\tenv, \vt, \unconstrainedinteger) \typearrow \True\\
+  \tstruct(\tenv, \vtone) \typearrow \TInt(\underconstrained(\vv))\\
+  \getwellconstrainedstructure(\tenv, \vt) \typearrow \vtone\\
+  \CheckUnop(\tenv, \NEG, \vtone) \typearrow \vs
+}{
+  \CheckUnop(\tenv, \NEG, \vt) \typearrow \vs
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[not\_t\_bits]{
-    \astlabel(\tstruct(\tenv, \vt)) \typearrow \TBits
+  \checkstructurelabel(\tenv, \vt, \TBits) \typearrow \True \OrTypeError
 }{
   \CheckUnop(\tenv, \NOT, \vt) \typearrow \vt
 }
@@ -3040,165 +3099,216 @@ determines the result type $\vt$ of applying the binary operator $\op$
 to operands of type $\vtone$ and $\vttwo$ in the static environment $\tenv$,
 returning a type error, if one is detected.
 
-\subsection{Goal}
-Determine the result type of a binary operator, given the types of its operands.
-
 \subsection{Prose}
-  $\vt$ is the result of checking compatibility of a binary operator $\op$ with
-  types $\vtone$ and $\vttwo$ and one of the following applies:
+One of the following applies:
 \begin{itemize}
-  \item All of the following apply:
+  \item All of the following apply (\textsc{boolean}):
   \begin{itemize}
     \item $\op$ is $\AND$, $\OR$, $\EQOP$ or $\IMPL$;
-    \item $\vtone$ \typesatisfies\  $\TBool$;
-    \item $\vttwo$ \typesatisfies\  $\TBool$;
+    \item determining whether $\vtone$ \typesatisfies\ $\TBool$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+    \item determining whether $\vttwo$ \typesatisfies\ $\TBool$ in $\tenv$ yields $\True$ \ProseOrTypeError;
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item All of the following apply:
+  \item All of the following apply (\textsc{bits\_bool}):
   \begin{itemize}
     \item $\op$ is $\AND$, $\OR$, or $\EOR$;
-    \item $\vtone$ has the structure of a bitvector;
-    \item $\vttwo$ has the structure of a bitvector;
-    \item $\vtone$ and $\vttwo$ have the same bitvector width $\vw$;
-    \item $\vt$ is the bitvector type of width $\vw$.
+    \item checking whether $\vtone$ and $\vttwo$ have the \structure\ of bitvector types
+          of the same width in $\tenv$ yields $\True$ \ProseOrTypeError;
+    \item the bitvector width of $\vtone$ in $\tenv$ is $\vw$;
+    \item $\vt$ is the bitvector type of width $\vw$ and empty list of bitfields, that is, \\ $\TBits(\vw, \emptylist)$.
   \end{itemize}
 
-  \item All of the following apply:
+  \item All of the following apply (\textsc{plus\_minus\_error}):
   \begin{itemize}
     \item $\op$ is $\PLUS$ or $\MINUS$;
-    \item $\vtone$ has the structure of a bitvector of width $\vw$;
-    \item One of the following applies:
-    \begin{itemize}
-      \item All of the following apply:
-      \begin{itemize}
-        \item $\vttwo$ has the structure of a bitvector;
-        \item $\vtone$ and $\vttwo$ have the same bitvector width $\vw$;
-        \item $\vt$ is the bitvector type of width $\vw$.
-      \end{itemize}
-      \item $\vttwo$ \typesatisfies\  $\TInt$;
-    \end{itemize}
-    \item $\vt$ is the bitvector type of width $\vw$.
+    \item obtaining the \structure\ of $\vtone$ in $\tenv$ is $\vtonestruct$ \ProseOrTypeError;
+    \item $\vtonestruct$ is neither a bitvector type nor an integer type;
+    \item the result is a type error indicating that the type of $\vtone$ is inappropriate for $\op$.
   \end{itemize}
 
-  \item All of the following apply:
+  \item All of the following apply (\textsc{plus\_minus\_bits\_int}):
   \begin{itemize}
-    \item $\op$ is \EQOP\ or \NEQ;
-    \item One of the following applies:
-    \begin{itemize}
-      \item $\vtone$ is equal to $\vttwo$;
-      \item All of the following apply:
-      \begin{itemize}
-        \item $\vtone$ \typesatisfies\  $\TInt$;
-        \item $\vttwo$ \typesatisfies\  $\TInt$;
-      \end{itemize}
-      \item All of the following apply:
-      \begin{itemize}
-        \item $\vtone$ has the structure of a bitvector;
-        \item $\vttwo$ has the structure of a bitvector;
-        \item $\vtone$ and $\vttwo$ have the same bitvector width;
-      \end{itemize}
-      \item All of the following apply:
-      \begin{itemize}
-        \item $\vtone$ \typesatisfies\  $\TBool$;
-        \item $\vttwo$ \typesatisfies\  $\TBool$;
-      \end{itemize}
-      \item All of the following apply:
-      \begin{itemize}
-        \item $\vtone$ enumerates local declarations $\vlione$;
-        \item $\vttwo$ enumerates local declarations $\vlitwo$;
-        \item $\vlione$ equals $\vlitwo$;
-      \end{itemize}
-    \end{itemize}
+    \item $\op$ is $\PLUS$ or $\MINUS$;
+    \item obtaining the \structure\ of $\vtone$ in $\tenv$ is $\vtonestruct$ \ProseOrTypeError;
+    \item $\vtonestruct$ is a bitvector type;
+    \item $\vttwo$ \typesatisfies\ the unconstrained integer type in $\tenv$;
+    \item obtaining the bitwidth of $\vtone$ in $\tenv$ yields $\vw$.
+    \item $\vt$ is the bitvector type of width $\vw$ and empty list of bitfields, that is, \\ $\TBits(\vw, \emptylist)$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{plus\_minus\_bits\_bits}):
+  \begin{itemize}
+    \item $\op$ is $\PLUS$ or $\MINUS$;
+    \item obtaining the \structure\ of $\vtone$ in $\tenv$ is a bitvector of width $\veone$, that is,\\ $\TBits(\veone, \Ignore)$;
+    \item $\vttwo$ does not \typesatisfy\ the unconstrained integer type in $\tenv$
+    \item obtaining the \structure\ of $\vttwo$ in $\tenv$ is $\vttwostruct$ \ProseOrTypeError;
+    \item determining whether $\vttwostruct$ has a bitvector type yields $\True$ \ProseOrTypeError;
+    \item $\vttwostruct$ is a bitevector of width $\vwtwo$, that is, $\TBits(\vwtwo, \Ignore)$;
+    \item determining whether $\vwone$ and $\vwtwo$ are equal bitwidths yields $\vb$;
+    \item $\vb$ is $\True$ \ProseOrTypeError;
+    \item $\vt$ is the bitvector type of width $\vwone$ and empty list of bitfields, that is, \\ $\TBits(\vwone, \emptylist)$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{eq\_neq\_error}):
+  \begin{itemize}
+    \item $\op$ is either $\EQOP$ or $\NEQ$;
+    \item the \underlyingtype\ of $\vtone$ in $\tenv$ is $\vtoneanon$ \ProseOrTypeError;
+    \item the \underlyingtype\ of $\vttwo$ in $\tenv$ is $\vttwoanon$ \ProseOrTypeError;
+    \item the AST labels of $\vtoneanon$ and $\vttwoanon$ are different or one of them is not in
+          $\{\TInt, \TReal, \TBool, \TBits, \TEnum\}$;
+    \item the result is a type error indicating that the types of $\vtone$ and $\vttwo$ are inappropriate for $\op$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{eq\_neq\_bits}):
+  \begin{itemize}
+    \item $\op$ is either $\EQOP$ or $\NEQ$;
+    \item the \underlyingtype\ of $\vtone$ in $\tenv$ is $\vtoneanon$ \ProseOrTypeError;
+    \item $\vtoneanon$ is a bitvector type;
+    \item the \underlyingtype\ of $\vttwo$ in $\tenv$ is $\vttwoanon$ \ProseOrTypeError;
+    \item checking whether the bitwidth of $\vtoneanon$ and $\vttwoanon$ is the same yields $\True$ \ProseOrTypeError;
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item All of the following apply:
+  \item All of the following apply (\textsc{eq\_neq\_bool}):
   \begin{itemize}
-    \item $\op$ is \LEQ, \GEQ, \GT\ or \LT;
-    \item One of the following applies:
-    \begin{itemize}
-      \item All of the following apply:
-      \begin{itemize}
-        \item $\vtone$ \typesatisfies\  $\TInt$;
-        \item $\vttwo$ \typesatisfies\  $\TInt$;
-      \end{itemize}
-      \item All of the following apply:
-      \begin{itemize}
-        \item $\vtone$ \typesatisfies\  $\TReal$;
-        \item $\vttwo$ \typesatisfies\  $\TReal$;
-      \end{itemize}
-    \end{itemize}
-    \item $\vt$ is boolean.
+    \item $\op$ is either $\EQOP$ or $\NEQ$;
+    \item the \underlyingtype\ of $\vtone$ in $\tenv$ is $\TBool$ \ProseOrTypeError;
+    \item the \underlyingtype\ of $\vttwo$ in $\tenv$ is $\TBool$ \ProseOrTypeError;
+    \item checking whether $\vtoneanon$ \typesatisfies\ $\TBool$ yields $\True$ \ProseOrTypeError;
+    \item checking whether $\vttwoanon$ \typesatisfies\ $\TBool$ yields $\True$ \ProseOrTypeError;
+    \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item All of the following apply:
+  \item All of the following apply (\textsc{eq\_neq\_real}):
   \begin{itemize}
-    \item $\op$ is $\MUL$, $\DIV$, $\DIVRM$, $\MOD$, $\SHL$, $\SHR$, $\POW$, $\PLUS$ or $\MINUS$;
-    \item $\structone$ is the structure of $\vtone$;
-    \item $\structtwo$ is the structure of $\vttwo$;
-    \item One of the following applies:
-    \begin{itemize}
-      \item All of the following apply:
-      \begin{itemize}
-        \item $\vtone$ has the structure of an unconstrained integer;
-        \item $\vttwo$ has the structure of an integer;
-        \item $\vt$ is an unconstrained integer;
-      \end{itemize}
-      \item All of the following apply:
-      \begin{itemize}
-        \item $\vtone$ has the structure of an integer;
-        \item $\vttwo$ has the structure of an unconstrained integer;
-        \item $\vt$ is an unconstrained integer;
-      \end{itemize}
-      \item One of the following applies:
-      \begin{itemize}
-        \item One of the following applies:
-        \begin{itemize}
-          \item All of the following apply:
-          \begin{itemize}
-            \item $\vtone$ has the structure of an under-constrained integer;
-            \item $\vttwo$ has the structure of a constrained integer;
-            \item $\vt$ is an under-constrained integer;
-          \end{itemize}
-          \item All of the following apply:
-          \begin{itemize}
-            \item $\vtone$ has the structure of a constrained integer;
-            \item $\vttwo$ has the structure of an under-constrained integer;
-            \item $\vt$ is an under-constrained integer;
-          \end{itemize}
-        \end{itemize}
-        \item All of the following apply:
-        \begin{itemize}
-          \item $\vtone$ has the structure of a well-constrained integer;
-          \item $\vttwo$ has the structure of a well-constrained integer;
-	        \item $\vt$ is a constrained integer whose constraint is calculated by
-	        applying the operation $\op$ to all possible value pairs;
-        \end{itemize}
-        \item All of the following apply:
-        \begin{itemize}
-          \item $\vtone$ has the structure of $\TReal$;
-          \item $\vttwo$ has the structure of $\TReal$;
-          \item $\op$ is $\PLUS$, $\MINUS$ or $\MUL$;
-          \item $\vt$ is $\TReal$;
-        \end{itemize}
-        \item All of the following apply:
-        \begin{itemize}
-          \item $\vtone$ has the structure of $\TReal$;
-          \item $\vttwo$ has the structure of $\TInt$;
-          \item $\op$ is $\POW$;
-          \item $\vt$ is $\TReal$;
-        \end{itemize}
-      \end{itemize}
-    \end{itemize}
+    \item $\op$ is either $\EQOP$ or $\NEQ$;
+    \item the \underlyingtype\ of $\vtone$ in $\tenv$ is $\TReal$ \ProseOrTypeError;
+    \item the \underlyingtype\ of $\vttwo$ in $\tenv$ is $\TReal$ \ProseOrTypeError;
+    \item checking whether $\vtoneanon$ \typesatisfies\ $\TBool$ yields $\True$ \ProseOrTypeError;
+    \item checking whether $\vttwoanon$ \typesatisfies\ $\TBool$ yields $\True$ \ProseOrTypeError;
+    \item $\vt$ is $\TBool$.
+  \end{itemize}
 
-    \item All of the following apply:
-    \begin{itemize}
-      \item $\op$ is $\RDIV$;
-      \item $\vtone$ \typesatisfies\  $\TReal$;
-      \item $\vttwo$ \typesatisfies\  $\TReal$;
-      \item $\vt$ is $\TReal$.
-    \end{itemize}
+  \item All of the following apply (\textsc{eq\_neq\_string}):
+  \begin{itemize}
+    \item $\op$ is either $\EQOP$ or $\NEQ$;
+    \item the \underlyingtype\ of $\vtone$ in $\tenv$ is $\TString$ \ProseOrTypeError;
+    \item the \underlyingtype\ of $\vttwo$ in $\tenv$ is $\TString$ \ProseOrTypeError;
+    \item checking whether $\vtoneanon$ \typesatisfies\ $\TBool$ yields $\True$ \ProseOrTypeError;
+    \item checking whether $\vttwoanon$ \typesatisfies\ $\TBool$ yields $\True$ \ProseOrTypeError;
+    \item $\vt$ is $\TBool$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{eq\_neq\_enum}):
+  \begin{itemize}
+    \item $\op$ is either $\EQOP$ or $\NEQ$;
+    \item the \underlyingtype\ of $\vtone$ in $\tenv$ is $\TEnum(\vlione)$ \ProseOrTypeError;
+    \item the \underlyingtype\ of $\vttwo$ in $\tenv$ is $\\TEnum(\vlitwo)$ \ProseOrTypeError;
+    \item checking whether $\vlione$ is equal to $\vlitwo$ yields $\True$ \ProseOrTypeError;
+    \item $\vt$ is $\TBool$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{relational}):
+  \begin{itemize}
+    \item $\op$ is one of $\LT$, $\LEQ$, $\GT$, and $\GEQ$;
+    \item determining whether both $\vtone$ and $\vttwo$ \typesatisfy\ the unconstrained integer type in $\tenv$
+          or both $\vtone$ and $\vttwo$ \typesatisfy\ the \texttt{real} type in $\tenv$ yields $\True$ \ProseOrTypeError;
+    \item $\vt$ is $\TBool$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{arith\_error}):
+  \begin{itemize}
+    \item obtaining the \structure\ of $\vtone$ in $\tenv$ yields $\vtonestruct$ \ProseOrTypeError;
+    \item obtaining the \structure\ of $\vttwo$ in $\tenv$ yields $\vttwostruct$ \ProseOrTypeError;
+    \item the operator and the AST labels of $\vtonestruct$ and $\vttwostruct$ do not match any of the rows in the following table:\\
+    \begin{center}
+    \begin{tabular}{lll}
+      \op    & $\astlabel(\vtonestruct)$ & $\astlabel(\vttwostruct)$\\
+      \hline
+      \MUL   & \TInt  & \TInt\\
+      \DIV   & \TInt  & \TInt\\
+      \DIVRM & \TInt  & \TInt\\
+      \MOD   & \TInt  & \TInt\\
+      \SHL   & \TInt  & \TInt\\
+      \SHR   & \TInt  & \TInt\\
+      \POW   & \TInt  & \TInt\\
+      \PLUS  & \TInt  & \TInt\\
+      \MINUS & \TInt  & \TInt\\
+      \PLUS  & \TReal & \TReal\\
+      \MINUS & \TReal & \TReal\\
+      \MUL   & \TReal & \TReal\\
+      \RDIV  & \TReal & \TReal\\
+      \POW   & \TReal & \TInt\\
+    \end{tabular}
+  \end{center}
+    \item the result is a type error indicating that the types of $\vtone$ and $\vttwo$ are inappropriate for $\op$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{arith\_t\_int\_unconstrained1}, \textsc{arith\_t\_int\_unconstrained2}):
+  \begin{itemize}
+    \item $\op$ is one of $\{\MUL, \DIV, \DIVRM, \MOD, \SHL,  \SHR, \POW, \PLUS, \MINUS\}$;
+    \item the \wellconstrainedstructure\ of either $\vtone$ or $\vttwo$ in $\tenv$ is that of the unconstrained integer type;
+    \item $\vt$ is the unconstrained integer type;
+  \end{itemize}
+
+  \item All of the following apply (\textsc{arith\_t\_int\_wellconstrained1}):
+  \begin{itemize}
+    \item $\op$ is one of $\{\MUL, \POW, \PLUS, \MINUS\}$;
+    \item the \wellconstrainedstructure\ of either $\vtone$ in $\tenv$ is that of a well-constrained integer type with
+          constraints $\vcsone$;
+          \item the \wellconstrainedstructure\ of either $\vttwo$ in $\tenv$ is that of a well-constrained integer type with
+          constraints $\vcstwo$;
+    \item applying $\op$ to $\vcsone$ and $\vcstwo$ in $\tenv$ yields $\vcs$;
+    \item $\vt$ is the well-constrained integer type with constraints $\vcs$;
+  \end{itemize}
+
+  \item All of the following apply (\textsc{arith\_t\_int\_wellconstrained2}):
+  \begin{itemize}
+    \item $\op$ is one of $\{\DIVRM, \DIV, \MOD\}$;
+    \item the \wellconstrainedstructure\ of either $\vtone$ in $\tenv$ is that of a well-constrained integer type with
+          constraints $\vcsone$;
+          \item the \wellconstrainedstructure\ of either $\vttwo$ in $\tenv$ is that of a well-constrained integer type with
+          constraints $\vcstwo$;
+    \item checking whether $\vcstwo$ represents strictly-positive integers yields $\True$ \ProseOrTypeError;
+    \item applying $\op$ to $\vcsone$ and $\vcstwo$ in $\tenv$ yields $\vcs$;
+    \item $\vt$ is the well-constrained integer type with constraints $\vcs$;
+  \end{itemize}
+
+  \item All of the following apply (\textsc{arith\_t\_int\_wellconstrained3}):
+  \begin{itemize}
+    \item $\op$ is one of $\{\DIVRM, \DIV, \MOD\}$;
+    \item the \wellconstrainedstructure\ of either $\vtone$ in $\tenv$ is that of a well-constrained integer type with
+          constraints $\vcsone$;
+          \item the \wellconstrainedstructure\ of either $\vttwo$ in $\tenv$ is that of a well-constrained integer type with
+          constraints $\vcstwo$;
+    \item checking whether $\vcstwo$ represents non-negative integers yields $\True$ \ProseOrTypeError;
+    \item applying $\op$ to $\vcsone$ and $\vcstwo$ in $\tenv$ yields $\vcs$;
+    \item $\vt$ is the well-constrained integer type with constraints $\vcs$;
+  \end{itemize}
+
+  \item All of the following apply (\textsc{plus\_minus\_mul\_real}):
+  \begin{itemize}
+    \item $\op$ is one of $\{\PLUS, \MINUS, \MUL\}$;
+    \item obtaining the \structure\ of $\vtone$ in $\tenv$ yields $\TReal$;
+    \item obtaining the \structure\ of $\vttwo$ in $\tenv$ yields $\TReal$;
+    \item $\vt$ is $\TReal$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{pow\_real\_int}):
+  \begin{itemize}
+    \item $\op$ is one of $\{\PLUS, \MINUS, \MUL\}$;
+    \item obtaining the \structure\ of $\vtone$ in $\tenv$ yields $\TReal$;
+    \item obtaining the \structure\ of $\vttwo$ in $\tenv$ yields an integer type;
+    \item $\vt$ is $\TReal$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{rdiv}):
+  \begin{itemize}
+    \item $\op$ is one of $\{\RDIV\}$;
+    \item determining whether $\vtone$ \typesatisfies\ $\TReal$ yields $\True$ \ProseOrTypeError;
+    \item determining whether $\vttwo$ \typesatisfies\ $\TReal$ yields $\True$ \ProseOrTypeError;
+    \item $\vt$ is $\TReal$.
   \end{itemize}
 \end{itemize}
 
@@ -3209,116 +3319,242 @@ Determine the result type of a binary operator, given the types of its operands.
 \begin{emptyformal}
 \subsection{Formally}
 \begin{mathpar}
-\inferrule{
+\inferrule[boolean]{
   \op \in  \{\BAND, \BOR, \IMPL, \EQOP\}\\
-  \typesat(\tenv, \vt1, \TBool) \\
-  \typesat(\tenv, \vttwo, \TBool)
-}
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool}
-\and
-\inferrule{
+  \checktypesat(\tenv, \vt1, \TBool) \typearrow \True \OrTypeError\\
+  \checktypesat(\tenv, \vttwo, \TBool) \typearrow \True \OrTypeError
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[bits\_bool]{
   \op \in  \{\AND, \OR, \EOR\}\\
-  \tstruct(\tenv, \vtone) \typearrow \TBits(\vw, \Ignore) \\
-  \tstruct(\tenv, \vttwo) \typearrow \TBits(\vw', \Ignore) \\
-  \bitwidthequal(\tenv, \vw, \vw')
+  \tododefine{check\_bits\_equal\_width}(\tenv, \vtone, \vttwo) \typearrow \True \OrTypeError\\
+  \getbitvectorwidth(\tenv, \vtone) \typearrow \vw
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(\vw, \emptylist)
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(w_1, \emptylist)}
-\and
-\inferrule{
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[plus\_minus\_error]{
   \op \in  \{\PLUS, \MINUS\}\\
-  \tstruct(\tenv, \vtone) \typearrow \TBits(\vw, \Ignore) \\
-  \tstruct(\tenv, \vttwo) \typearrow \TBits(\vw', \Ignore) \\
-  \bitwidthequal(\tenv, \vw, \vw')
+  \tstruct(\tenv, \vtone) \typearrow \vtonestruct \OrTypeError\\\\
+  \astlabel(\vtonestruct) \not\in \{\TBits,\TInt\}\\
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TypeErrorVal{InappropriateTypeForPlusMinus}
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(w_1, \emptylist)}
 \and
-\inferrule{
+\inferrule[plus\_minus\_bits\_int]{
   \op \in  \{\PLUS, \MINUS\}\\
-  \tstruct(\tenv, \vtone) \typearrow \TBits(\vw, \Ignore) \\
-  \typesat(\tenv, \vttwo, \unconstrainedinteger)
+  \tstruct(\tenv, \vtone) \typearrow \vtonestruct \OrTypeError\\\\
+  \astlabel(\vtonestruct) = \TBits\\
+  \typesat(\tenv, \vttwo, \unconstrainedinteger) \typearrow \True\\
+  \getbitvectorwidth(\tenv, \vtone) \typearrow \vw\\
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(\vw, \emptylist)
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(\vw, \emptylist)}
+\and
+\inferrule[plus\_minus\_bits\_bits]{
+  \op \in  \{\PLUS, \MINUS\}\\
+  \tstruct(\tenv, \vtone) \typearrow \TBits(\vwone, \Ignore) \\
+  \typesat(\tenv, \vttwo, \unconstrainedinteger) \typearrow \False\\
+  \tstruct(\tenv, \vttwo) \typearrow \vttwostruct \OrTypeError\\\\
+  \checktrans{\astlabel(\vttwostruct)=\TBits, \texttt{"ExpectedBitvectorType"}} \typearrow \True \OrTypeError\\
+  \vttwostruct \eqname \TBits(\vwtwo, \Ignore)\\
+  \bitwidthequal(\tenv, \vwone, \vwtwo) \typearrow \vb\\
+  \checktrans{\vb, \texttt{"DifferentBitwidths"}} \typearrow \True \OrTypeError
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(\vwone, \emptylist)
+}
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[(This rule also handles the case of enumeration types.)]
-{\op \in  \{\EQOP, \NEQ\}}
-{\CheckBinop(\tenv, \op, \vt, \vt) \typearrow \TBool}
-\and
-\inferrule{
+\inferrule[eq\_neq\_error]
+{
   \op \in  \{\EQOP, \NEQ\}\\
-  \typesat(\tenv, \vtone, \unconstrainedinteger)\\
-  \typesat(\tenv, \vttwo, \unconstrainedinteger)
+  \makeanonymous(\tenv, \vtone) \typearrow \vtoneanon \OrTypeError\\
+  \makeanonymous(\tenv, \vttwo) \typearrow \vttwoanon \OrTypeError\\
+  (\astlabel(\vtoneanon) \neq \astlabel(\vttwoanon)) \lor
+  \astlabel(\vtone) \not\in \{\TInt, \TReal, \TBool, \TBits, \TEnum\}
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TypeErrorVal{InappropriateTypeForEQ}
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool}
 \and
-\inferrule{
+\inferrule[eq\_neq\_bits]{
   \op \in  \{\EQOP, \NEQ\}\\
-  \tstruct(\tenv, \vtone)\typearrow\TBits(\vw, \Ignore)\\
-  \tstruct(\tenv, \vttwo)\typearrow\TBits(\vw', \Ignore)\\
-  \bitwidthequal(\tenv, \vw, \vw')
+  \makeanonymous(\tenv, \vtone) \typearrow \vtoneanon \OrTypeError\\
+  \astlabel(\vtoneanon) = \TBits\\
+  \makeanonymous(\tenv, \vttwo) \typearrow \vttwoanon \OrTypeError\\
+  \tododefine{check\_bits\_equal\_width}(\tenv, \vtoneanon, \vttwoanon) \typearrow \True \OrTypeError
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool}
+\and
+\inferrule[eq\_neq\_bool]{
+  \op \in  \{\EQOP, \NEQ\}\\
+  \makeanonymous(\tenv, \vtone) \typearrow \TBool\\
+  \makeanonymous(\tenv, \vttwo) \typearrow \TBool\\
+  \checktypesat(\tenv, \vtoneanon, \TBool) \typearrow \True \OrTypeError\\
+  \checktypesat(\tenv, \vttwoanon, \TBool) \typearrow \True \OrTypeError
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+}
+\and
+\inferrule[eq\_neq\_real]{
+  \op \in  \{\EQOP, \NEQ\}\\
+  \makeanonymous(\tenv, \vtone) \typearrow \TReal\\
+  \makeanonymous(\tenv, \vttwo) \typearrow \TReal\\
+  \checktypesat(\tenv, \vtoneanon, \TReal) \typearrow \True \OrTypeError\\
+  \checktypesat(\tenv, \vttwoanon, \TReal) \typearrow \True \OrTypeError
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+}
+\and
+\inferrule[eq\_neq\_string]{
+  \op \in  \{\EQOP, \NEQ\}\\
+  \makeanonymous(\tenv, \vtone) \typearrow \TString\\
+  \makeanonymous(\tenv, \vttwo) \typearrow \TString\\
+  \checktypesat(\tenv, \vtoneanon, \TString) \typearrow \True \OrTypeError\\
+  \checktypesat(\tenv, \vttwoanon, \TString) \typearrow \True \OrTypeError
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+}
+\and
+\inferrule[eq\_neq\_enum]{
+  \op \in  \{\EQOP, \NEQ\}\\
+  \makeanonymous(\tenv, \vtone) \typearrow \TEnum(\vlione)\\
+  \makeanonymous(\tenv, \vttwo) \typearrow \TEnum(\vlitwo)\\
+  \checktrans{\vlione = \vlitwo, \texttt{"DifferentEnumLabels"}} \typearrow \True \OrTypeError
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+}
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule{
+\inferrule[relational]{
   \op \in  \{\LT, \LEQ, \GT, \GEQ\}\\
-  \typesat(\tenv, \vtone, \unconstrainedinteger)\\
-  \typesat(\tenv, \vttwo, \unconstrainedinteger)
+  \typesat(\tenv, \vtone, \unconstrainedinteger) \typearrow \vbone \OrTypeError\\
+  \typesat(\tenv, \vttwo, \unconstrainedinteger) \typearrow \vbtwo \OrTypeError\\
+  \typesat(\tenv, \vtone, \TReal) \typearrow \vbthree \OrTypeError\\
+  \typesat(\tenv, \vttwo, \TReal) \typearrow \vbfour \OrTypeError\\
+  \checktrans{\vbone \land \vbtwo \lor \vbthree \land \vbfour, \texttt{"InappropriateTypeForRel"}} \typearrow \True \OrTypeError
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \unconstrainedinteger}
-\and
-\inferrule{
-  \op \in  \{\LT, \LEQ, \GT, \GEQ\}\\
-  \typesat(\tenv, \vtone, \TReal)\\
-  \typesat(\tenv, \vttwo, \TReal)
-}
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TReal}
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule{
-  \op \in  \{\MUL, \DIV, \DIVRM, \MOD, \SHL,  \SHR, \POW, \PLUS, \MINUS\}\\
-  \tstruct(\tenv, \vtone) \typearrow \unconstrainedinteger\\
-  \astlabel(\tstruct(\tenv, \vttwo)) \typearrow \TInt
+\inferrule[arith\_error]{
+  \tstruct(\tenv, \vtone) \typearrow \vtonestruct \OrTypeError\\
+  \tstruct(\tenv, \vttwo) \typearrow \vttwostruct \OrTypeError\\
+  \vb \eqdef (\op, \astlabel(\vtonestruct), \astlabel(\vttwostruct)) \in
+  {
+    \left\{
+    \begin{array}{lclcl}
+      (\MUL   &,& \TInt  &,& \TInt)\\
+      (\DIV   &,& \TInt  &,& \TInt)\\
+      (\DIVRM &,& \TInt  &,& \TInt)\\
+      (\MOD   &,& \TInt  &,& \TInt)\\
+      (\SHL   &,& \TInt  &,& \TInt)\\
+      (\SHR   &,& \TInt  &,& \TInt)\\
+      (\POW   &,& \TInt  &,& \TInt)\\
+      (\PLUS  &,& \TInt  &,& \TInt)\\
+      (\MINUS &,& \TInt  &,& \TInt)\\
+      (\PLUS  &,& \TReal &,& \TReal)\\
+      (\MINUS &,& \TReal &,& \TReal)\\
+      (\MUL   &,& \TReal &,& \TReal)\\
+      (\RDIV  &,& \TReal &,& \TReal)\\
+      (\POW   &,& \TReal &,& \TInt)\\
+    \end{array}
+    \right\}
+  }\\\\
+  \neg\vb
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TypeErrorVal{InappropriateTypeForBinop}
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \unconstrainedinteger}
-\and
-\inferrule{
+\end{mathpar}
+
+The following two rules are not mutually exclusive, but both yield the same result when they are both active.
+\begin{mathpar}
+\inferrule[arith\_t\_int\_unconstrained1]{
   \op \in  \{\MUL, \DIV, \DIVRM, \MOD, \SHL,  \SHR, \POW, \PLUS, \MINUS\}\\
-  \astlabel(\tstruct(\tenv, \vtone)) \typearrow \TInt\\
-  \tstruct(\tenv, \vttwo) \typearrow \unconstrainedinteger
+  \getwellconstrainedstructure(\tenv, \vtone) \typearrow \unconstrainedinteger\\
+  \getwellconstrainedstructure(\tenv, \vttwo) \typearrow \TInt(\Ignore)\\
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \unconstrainedinteger
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \unconstrainedinteger}
 \and
-\inferrule{
+\inferrule[arith\_t\_int\_unconstrained2]{
   \op \in  \{\MUL, \DIV, \DIVRM, \MOD, \SHL,  \SHR, \POW, \PLUS, \MINUS\}\\
-  \tstruct(\tenv, \vtone) \typearrow \TInt(\langle \csone \rangle) \\
-  \tstruct(\tenv, \vttwo) \typearrow \TInt(\langle \cstwo \rangle)\\
+  \getwellconstrainedstructure(\tenv, \vtone) \typearrow \TInt(\Ignore)\\
+  \getwellconstrainedstructure(\tenv, \vttwo) \typearrow \unconstrainedinteger\\
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \unconstrainedinteger
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TInt(\constraintbinop(\csone, \cstwo))}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[arith\_t\_int\_wellconstrained1]{
+  \op \in  \{\MUL, \POW, \PLUS, \MINUS\}\\
+  \getwellconstrainedstructure(\tenv, \vtone) \typearrow \TInt(\wellconstrained(\vcsone))\\
+  \getwellconstrainedstructure(\tenv, \vttwo) \typearrow \TInt(\wellconstrained(\vcstwo))\\
+  \tododefine{constraints\_binop}(\tenv, \op, \vcsone, \vcstwo) \typearrow \vcs
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TInt(\wellconstrained(\vcs))
+}
 \and
-\inferrule{
+\inferrule[arith\_t\_int\_wellconstrained2]{
+  \op \in  \{\DIVRM, \DIV, \MOD\}\\
+  \getwellconstrainedstructure(\tenv, \vtone) \typearrow \TInt(\wellconstrained(\vcsone))\\
+  \getwellconstrainedstructure(\tenv, \vttwo) \typearrow \TInt(\wellconstrained(\vcstwo))\\
+  \tododefine{constraints\_is\_strict\_positive}(\vcstwo) \typearrow \vb\\
+  \checktrans{\vb, \texttt{"DenominatorMustBePositive"}} \typearrow \True \OrTypeError\\
+  \tododefine{constraints\_binop}(\tenv, \op, \vcsone, \vcstwo) \typearrow \vcs
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TInt(\wellconstrained(\vcs))
+}
+\and
+\inferrule[arith\_t\_int\_wellconstrained3]{
+  \op \in  \{\SHL, \SHR\}\\
+  \getwellconstrainedstructure(\tenv, \vtone) \typearrow \TInt(\wellconstrained(\vcsone))\\
+  \getwellconstrainedstructure(\tenv, \vttwo) \typearrow \TInt(\wellconstrained(\vcstwo))\\
+  \tododefine{constraints\_is\_non\_negative}(\vcstwo) \typearrow \vb\\
+  \checktrans{\vb, \texttt{"ShifterMustBeNonNegative"}} \typearrow \True \OrTypeError\\
+  \tododefine{constraints\_binop}(\tenv, \op, \vcsone, \vcstwo) \typearrow \vcs
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TInt(\wellconstrained(\vcs))
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[plus\_minus\_mul\_real]{
   \op \in  \{\PLUS, \MINUS, \MUL\}\\
   \tstruct(\tenv, \vtone) \typearrow \TReal\\
   \tstruct(\tenv, \vttwo) \typearrow \TReal
+}{
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TReal
 }
-{\CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TReal}
-\and
-\inferrule{
-  \tstruct(\tenv, \vtone) \typearrow \TReal\\
-  \astlabel(\tstruct(\tenv, \vttwo)) \typearrow \TInt
-}
-{\CheckBinop(\tenv, \POW, \vtone, \vttwo) \typearrow \TReal}
-\and
-\inferrule{
-  \typesat(\tenv, \vtone, \TReal)\\
-  \typesat(\tenv, \vttwo, \TReal)\\
-}
-{\CheckBinop(\tenv, \RDIV, \vtone, \vttwo) \typearrow \TReal}
 \end{mathpar}
 
+\begin{mathpar}
+\inferrule[pow\_real\_int]{
+  \tstruct(\tenv, \vtone) \typearrow \TReal\\
+  \astlabel(\tstruct(\tenv, \vttwo)) \typearrow \TInt
+}{
+  \CheckBinop(\tenv, \POW, \vtone, \vttwo) \typearrow \TReal
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[rdiv]{
+  \checktypesat(\tenv, \vtone, \TReal) \typearrow \True \OrTypeError\\
+  \checktypesat(\tenv, \vttwo, \TReal) \typearrow \True \OrTypeError\\
+}{
+  \CheckBinop(\tenv, \RDIV, \vtone, \vttwo) \typearrow \TReal
+}
+\end{mathpar}
 \end{emptyformal}
 
 \subsection{Comments}
@@ -3326,6 +3562,84 @@ Determine the result type of a binary operator, given the types of its operands.
   \identr{KFYS}, \identr{KXMR}, \identr{SQXN}, \identr{MRHT}, \identr{JGWF},
   \identr{TTGQ}, \identi{YHML}, \identi{YHRP}, \identi{VMZF}, \identi{YXSY},
   \identi{LGHJ}, \identi{RXLG}.
+
+\section{Typing.FindNamedLCA \label{sec:Typing.FindNamedLCA}}
+\hypertarget{def-namedlowestcommonancestor}{}
+The function
+\[
+  \namedlca(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
+  \aslto \overname{\ty}{\tty} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+returns the lowest common named super type --- $\tty$ --- of the types $\vt$ and $\vs$ in $\tenv$.
+
+\newcommand\supers[0]{\texttt{supers}}
+The helper function
+\[
+  \supers(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt})
+  \aslto \pow{\ty}
+\]
+returns the set of \emph{named supertypes} given via the $\subtypes$ function of the global environment:
+\[
+  \supers(\tenv, \vt) \triangleq
+  \begin{cases}
+    \{\vt\} \cup (\vs) & \text{ if }G^\tenv.\subtypes(\vt) = \vs\\
+    \{\vt\}  & \text{ otherwise } (G^\tenv.\subtypes(\vt) = \bot)\\
+  \end{cases}
+\]
+
+\subsection{Prose}
+One of the following holds:
+\begin{itemize}
+  \item $\vtsupers$ is in the set of named supertypes of $\vt$;
+  \item All of the following hold (\textsc{found}):
+  \begin{itemize}
+    \item $\vs$ is in $\vtsupers$;
+    \item $\tty$ is $\vs$;
+  \end{itemize}
+
+  \item All of the following hold (\textsc{super}):
+  \begin{itemize}
+    \item $\vs$ is not in $\vtsupers$;
+    \item $\vs$ has a named super type in $\tenv$ --- $\vsp$;
+    \item $\tty$ is the lowest common named supertype of $\vt$ and $\vsp$ in $\tenv$.
+  \end{itemize}
+
+  \item All of the following hold (\textsc{none}):
+  \begin{itemize}
+    \item $\vs$ is not in $\vtsupers$;
+    \item $\vs$ has no named super type in $\tenv$;
+    \item $\tty$ is $\None$.
+  \end{itemize}
+\end{itemize}
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[found]{
+  \supers(\tenv, \vt) \typearrow \vtsupers\\
+  \vs \in \vtsupers
+}{
+  \namedlca(\tenv, \vt, \vs) \typearrow \vs
+}
+\and
+\inferrule[super]{
+  \supers(\tenv, \vt) \typearrow \vtsupers\\
+  \vs \not\in \vtsupers\\
+  G^\tenv.\subtypes(\vs) = \vsp\\
+  \namedlca(\tenv, \vt, \vsp) \typearrow \tty
+}{
+  \namedlca(\tenv, \vt, \vs) \typearrow \tty
+}
+\and
+\inferrule[none]{
+  \supers(\tenv, \vt) \typearrow \vtsupers\\
+  \vs \not\in \vtsupers\\
+  G^\tenv.\subtypes(\vs) = \None
+}{
+  \namedlca(\tenv, \vt, \vs) \typearrow \None
+}
+\end{mathpar}
+\end{emptyformal}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of types \label{chap:typingoftypes}}
@@ -4194,7 +4508,7 @@ All of the following apply:
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\ve$ denotes a binary operation $\op$ over two expressions $\veone$ and $\vetwo$, that is, $\EBinop(\op, \veone, \vetwo)$;
+  \item $\ve$ denotes a binary operation $\op$ over two expressions $\veone$ and $\vetwo$, that is, \\ $\EBinop(\op, \veone, \vetwo)$;
   \item the result of annotating $\veone$ in $\tenv$ is $(\vtone, \veonep)$ \ProseOrTypeError;
   \item the result of annotating $\vetwo$ in $\tenv$ is $(\vttwo, \vetwop)$ \ProseOrTypeError;
   \item the result of checking compatibility of $\op$ with $\vtone$ and $\vttwo$ as per \secref{TypingRule.CheckBinop}
@@ -4213,8 +4527,9 @@ All of the following apply:
   \annotateexpr{\tenv, \veone} \typearrow (\vtone, \veone') \OrTypeError\\\\
   \annotateexpr{\tenv, \vetwo} \typearrow (\vttwo, \vetwo') \OrTypeError\\\\
   \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \vt \OrTypeError
-  }
-{\annotateexpr{\tenv, \EBinop(\op, \veone, \vetwo)} \typearrow (\vt, \EBinop(\op, \veone', \vetwo'))}
+}{
+  \annotateexpr{\tenv, \EBinop(\op, \veone, \vetwo)} \typearrow (\vt, \EBinop(\op, \veone', \vetwo'))
+}
 \end{mathpar}
 \end{emptyformal}
 
@@ -10115,6 +10430,82 @@ All of the following applies:
   \checkstaticallyevaluable(\tenv, \ve) \typearrow \True
 }
 \end{mathpar}
+
+\section{TypingRule.ToWellConstrained}
+\hypertarget{def-towellconstrained}{}
+The function
+\[
+  \towellconstrained(\overname{\ty}{\vt}) \aslto \overname{\ty}{\vtp}
+\]
+returns the well-constrained version of a type $\vt$ --- $\vtp$, which is defined as follows.
+
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{t\_int\_underconstrained}):
+  \begin{itemize}
+    \item $\vt$ is an underconstrained integer for the variable $\vv$;
+    \item $\vtp$ is the well-constrained integer constrained by the variable expression for $\vv$,
+    that is, $\TInt(\wellconstrained(\constraintexact(\EVar(\vv))))$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{t\_int\_other, other}):
+  \begin{itemize}
+    \item $\vt$ is not an underconstrained integer for the variable $\vv$;
+    \item $\vtp$ is $\vt$.
+  \end{itemize}
+\end{itemize}
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[t\_int\_underconstrained]{}
+{
+  \towellconstrained(\TInt(\underconstrained(\vv))) \typearrow\\ \TInt(\wellconstrained(\constraintexact(\EVar(\vv))))
+}
+\and
+\inferrule[t\_int\_other]{
+  \astlabel(\vi) \neq \underconstrained
+}
+{
+  \towellconstrained(\TInt(\vi)) \typearrow \vt
+}
+\and
+\inferrule[other]{
+  \astlabel(\vt) \neq \TInt
+}
+{
+  \towellconstrained(\vt) \typearrow \vt
+}
+\end{mathpar}
+\end{emptyformal}
+
+\section{TypingRule.GetWellConstrainedStructure}
+\hypertarget{def-getwellconstrainedstructure}{}
+The function
+\[
+  \getwellconstrainedstructure(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt})
+  \aslto \overname{\ty}{\vtp}
+\]
+returns the \wellconstrainedstructure\ of a type $\vt$ in a static environment $\tenv$ --- $\vtp$, which is defined as follows.
+
+All of the following applt:
+\begin{itemize}
+  \item the \structure\ of $\vt$ in $\tenv$ is $\vtone$ \ProseOrTypeError;
+  \item the well-constrained version of $\vtone$ is $\vtp$.
+\end{itemize}
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \tstruct(\tenv, \vt) \typearrow \vtone \OrTypeError\\\\
+  \towellconstrained(\vtone) \typearrow \vtp
+}
+{
+  \getwellconstrainedstructure(\tenv, \vt) \typearrow \vtp
+}
+\end{mathpar}
+\end{emptyformal}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \bibliographystyle{plain}

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -156,8 +156,9 @@
 \newcommand\annotatelocaldeclitemuninit[1]{\texttt{annotate\_local\_decl\_item\_uninit}(#1)}
 \newcommand\checkvarnotinenv[1]{\hyperlink{def-checkvarnotinenv}{\texttt{check\_var\_not\_in\_env}}(#1)}
 \newcommand\varinenv[1]{\hyperlink{def-varinenv}{\texttt{var\_in\_env}}(#1)}
-\newcommand\annotatesubprogram[1]{\texttt{annotate\_subprogram}(#1)}
-\newcommand\declaredecl[1]{\texttt{annotate\_decl}(#1)}
+\newcommand\annotatesubprogram[1]{\hyperlink{def-annotatesubprogram}{\texttt{annotate\_subprogram}}(#1)}
+\newcommand\annotatedecl[1]{\hyperlink{def-annotatedecl}{\texttt{annotate\_decl}}(#1)}
+\newcommand\declaredecl[1]{\hyperlink{def-declaredecl}{\texttt{declare\_decl}}(#1)}
 \newcommand\annotatespec[1]{\texttt{annotate\_spec}(#1)}
 \newcommand\evalexpr[1]{\texttt{eval\_expr}(#1)}
 \newcommand\evalconstraint[1]{\texttt{eval\_constraint}(#1)}
@@ -6715,19 +6716,19 @@ environment $\newenv$ and all of the following apply:
          \item All of the following apply:
            \begin{itemize}
            \item \texttt{ver} is ASLv1;
-           \item \texttt{env1} is $\tenv$;
+           \item $\tenvone$ is $\tenv$;
            \end{itemize}
          \item All of the following apply:
            \begin{itemize}
            \item \texttt{ver} is ASLv0;
-	   \item \texttt{env1} is the result of annotating undeclared variables by using
+	   \item $\tenvone$ is the result of annotating undeclared variables by using
 	      the first assignments to such variables as declarations;
            \end{itemize}
          \end{itemize}
 
-       \item $\vleone$ is the result of annotating \texttt{le} with \texttt{t\_e} in \texttt{env1};
+       \item $\vleone$ is the result of annotating \texttt{le} with \texttt{t\_e} in $\tenvone$;
        \item $\news$ is the assignment \texttt{le1 = e1};
-       \item $\newenv$ is \texttt{env1}.
+       \item $\newenv$ is $\tenvone$.
        \end{itemize}
     \end{itemize}
   \end{itemize}
@@ -6907,9 +6908,9 @@ environment $\newenv$ and all of the following apply:
    \begin{itemize}
    \item $\vs$ is a statement \texttt{s1; s2};
    \item \texttt{new\_s1, env1} is the result of annotating \texttt{s1} in $\tenv$;
-   \item \texttt{new\_s2, env2} is the result of annotating \texttt{s2} in \texttt{env1};
+   \item \texttt{new\_s2, env2} is the result of annotating \texttt{s2} in $\tenvone$;
    \item $\news$ is a then statement over two statements \texttt{new\_s1} and \texttt{new\_s2};
-   \item $\newenv$ is \texttt{env2}.
+   \item $\newenv$ is $\tenvtwo$.
    \end{itemize}
 
   \subsection{Example}
@@ -7033,7 +7034,7 @@ environment $\newenv$ and all of the following apply:
    \item \texttt{t\_e, e1} is the result of annotating $\ve$ in $\tenv$;
    \item \texttt{cases1, env1} is the result of annotating each case in \texttt{cases} given \texttt{t\_e};
    \item $\news$ is a case statement with expression $\veone$ and cases \texttt{cases1};
-   \item $\newenv$ is \texttt{env1}.
+   \item $\newenv$ is $\tenvone$.
    \end{itemize}
 
   \subsection{Example}
@@ -7635,8 +7636,7 @@ The function
   \overname{\langle \ty \rangle}{\rettyone})
 \end{array}
 \]
-
-Annotates the call to subprogram $\name$ with arguments $\vargs$,
+annotates the call to subprogram $\name$ with arguments $\vargs$,
 parameters $\eqs$, and call type $\calltype$, resulting in values for an annotated call ---
 $\nameone$, $\vargsone$, $\eqstwo$, $\rettyone$ --- or a type error if one is detected.
 
@@ -7892,63 +7892,58 @@ A type error is returned, if one is detected.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Subprograms}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-Annotating a subprogram $\vf$ in an environment $\tenv$
-(\texttt{annotate\_subprogram}) results in \texttt{f'}.
+\hypertarget{def-annotatesubprogram}{}
+The function
+\[
+  \annotatesubprogram{\overname{\staticenvs}{\tenv} \aslsep \overname{\func}{\vf}} \aslto \overname{\func}{\vfp}
+\]
+annotates a subprogram $\vf$ in an environment $\tenv$, resulting in an annotated subprogram $\vfp$,
+or a type error, if one is detected.
 
 \section{TypingRule.Subprogram \label{sec:TypingRule.Subprogram}}
 
-  \subsection{Prose}
-Annotating a subprogram $\vf$ in an environment $\tenv$
-(\texttt{annotate\_subprogram}) results in $\vf$, \texttt{new\_body} and all of
-the following apply:
- \begin{itemize}
-   \item \texttt{env1} is $\tenv$ modified to have an empty local
-     environment and a return type given by $\vf$;
-   \item \texttt{env2} is \texttt{env1} with every formal argument given by
-     $\vf$ declared as immutable with its type;
-   \item \texttt{env3} is \texttt{env2} modified to add explicit parameters
-     given by $\vf$;
-   \item \texttt{env4} is \texttt{env3} modified to resolve dependently typed
-     identifiers in the arguments given by $\vf$;
-   \item \texttt{env5} is \texttt{env4} modified to resolve dependently typed
-     identifiers in the result type given by $\vf$;
-   \item \texttt{body} is the body given by $\vf$;
-   \item \texttt{new\_body} is the result of annotating \texttt{body} in
-     \texttt{env5}.
-   \item \texttt{f'} is the function $\vf$ with \texttt{new\_body} substituted for \texttt{body}.
- \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vf$ is a $\func$ AST node subprogram body $\body$;
+  \item annotating the block $\body$ in $\tenv$ as per \secref{TypingRule.Block} yields $\newbody$ \ProseOrTypeError;
+  \item $\vfp$ is $\vf$ with the subprogram body substituted with $\newbody$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\SubprogramBegin}{\SubprogramEnd}{../Typing.ml}
+\CodeSubsection{\SubprogramBegin}{\SubprogramEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule{}{ \texttt{param\_type}(\None) = \isunconstrainedinteger }
-  \and
-  \inferrule{}{ \texttt{param\_type}(\langle\tty\rangle) = \tty }
-  \and
-  \inferrule{
-    \texttt{env1} = (G^\tenv, [\constantvalues \mapsto \lambda \id.\ \bot, \localstoragetypes \mapsto \lambda \id.\ \bot, \returntype = \vf.\returntype])\\
-    \vf.\text{args} = [i=1..k: (\va_i, \tty_i)]\\
-    i=1..k: \checkvarnotinenv{\texttt{env1}, \va_i}\\
-    \texttt{env2} = (G^\texttt{env1}, \texttt{env1}[\localstoragetypes \mapsto [i=1..k: \va_i \mapsto (\LDKLet, \tty_i)] )]\\
-    \vf.\text{parameters} = [j=1..n: (\vp_j, \tyopt_j)]\\
-    j=1..k: \checkvarnotinenv{\texttt{env2}, \vp_j}\\
-    \texttt{env3} = (G^\texttt{env2}, \texttt{env2}[\localstoragetypes \mapsto [j=1..n: \vp_i \mapsto (\LDKLet, \texttt{param\_type}(\tyopt_j))] )]\\
-    \texttt{env4} = \texttt{add\_dependently\_typed}(\texttt{env3}, \vf.\text{args})\\
-    \texttt{env5} = \texttt{resolve\_dependently\_typed\_in\_res}(\texttt{env4}, \vf.\text{return\_type})\\
-    \vf.\text{return\_type} = \texttt{SB\_ASL} \vs\\
-    \annotateblock{\texttt{env4}, \vs} \typearrow \texttt{new\_body}\\
-    (\Ignore, \name, \Ignore, \Ignore) \in G^\texttt{env5}.\subprogramrenamings(\vf.\name, [i=1..k: \tty_i])\\
-    \vf' = \vf[\text{body}\mapsto \texttt{new\_body}]
-  }
+\inferrule{
   {
-    \annotatesubprogram{\tenv, \vf} \typearrow \vf'
-  }
+    \begin{array}{rrcl}
+  \vf \eqname \{ & \funcname            &:& \id,\\
+                 & \funcparameters      &:& \vp,\\
+                 & \funcargs            &:& \vargs,\\
+                 & \funcbody            &:& \SBASL(\body),\\
+                 & \funcreturntype      &:& \vt,\\
+                 & \funcsubprogramtype  &:& \subprogramtype \\
+              \} &&&
+    \end{array}
+  }\\
+  \annotateblock{\tenv, \body} \typearrow \newbody \OrTypeError\\
+  {
+    \begin{array}{rrcl}
+  \vfp \eqdef \{ & \funcname            &:& \id,\\
+                 & \funcparameters      &:& \vp,\\
+                 & \funcargs            &:& \vargs,\\
+                 & \funcbody            &:& \SBASL(\newbody),\\
+                 & \funcreturntype      &:& \vt,\\
+                 & \funcsubprogramtype  &:& \subprogramtype \\
+              \} &&&
+    \end{array}
+  }\\
+}{
+  \annotatesubprogram{\tenv, \vf} \typearrow \vfp
+}
 \end{mathpar}
 \end{emptyformal}
 
@@ -7959,9 +7954,28 @@ This is related to \identi{GHGK}, \identr{HWTV}, \identr{SCHV}, \identr{VDPC},
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Global Declarations}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\hypertarget{def-declaredecl}{}
+\hypertarget{def-annotatedecl}{}
+The function
+\[
+  \annotatedecl{\overname{\staticenvs}{\tenv} \aslsep \overname{\decl}{\vd}}
+  \aslto \overname{\staticenvs}{\newtenv}
+\]
+annotates a global declaration $\vd$ in a static environment $\tenv$,
+resulting in an annotated declaration $\newd$ and a new environment $\newtenv$,
+which contains the declared element.
+A type error is returned, if one is detected.
 
-Declaring a global declaration $\vd$ in an environment $\tenv$ ($\declaredecl{\tenv, \vd}$)
-results in a new environment $\tenvp$, which contains the declared element, and one of the following applies:
+The function
+\[
+  \declaredecl{\overname{\staticenvs}{\tenv} \aslsep \overname{\decl}{\vd}}
+  \aslto \overname{\staticenvs}{\newtenv}
+\]
+adds a global declaration $\vd$ in a static environment $\tenv$,
+resulting in a new environment $\newtenv$, which contains the declared element.
+A type error is returned, if one is detected.
+
+One of the following applies:
 \begin{itemize}
   \item TypingRule.DeclareOneFunc (see \secref{TypingRule.DeclareOneFunc}).
   \item TypingRule.DeclareGlobalStorage (see \secref{TypingRule.DeclareGlobalStorage}).
@@ -7984,51 +7998,97 @@ in $\newenv$ and all of the following apply:
 
 \CodeSubsection{\DeclareOneFuncBegin}{\DeclareOneFuncEnd}{../Typing.ml}
 \begin{emptyformal}
-  \subsection{Formally}
-
-We define the helper rules \hassubprogramtypeclash, \argsclash, and subprogramclash\ to determined whether
-two subprogram clash in terms of their subprogram types and their lists of argument types,
-and then use them to annotate a subprogram declaration.
-
+\subsection{Formally}
 \begin{mathpar}
-\inferrule{}{\hassubprogramtypeclash(\tenv, \STFunction, \Ignore)}
-\and
-\inferrule{}{\hassubprogramtypeclash(\tenv, \Ignore, \STFunction)}
-\and
-\inferrule{}{\hassubprogramtypeclash(\tenv, \STProcedure, \Ignore)}
-\and
-\inferrule{}{\hassubprogramtypeclash(\tenv, \Ignore, \STProcedure)}
-\and
-\inferrule{}{\hassubprogramtypeclash(\tenv, \STGetter, \STGetter)}
-\and
-\inferrule{}{\hassubprogramtypeclash(\tenv, \STSetter, \STSetter)}
-\and
 \inferrule{
-  \texttt{t\_args1} = [i=1..k: (\Ignore, \vt_i)]\\
-  \texttt{s\_args1} = [i=1..k: (\Ignore, \vs_i)]\\
-  j \in 1..k\\
-  \typeclashes(\tenv, \vt_j, \vs_j)
-}
-{\argsclash(\tenv, \texttt{t\_args}, \texttt{s\_args})}
-\and
-\inferrule{
-  \argsclash(\vf.\subprogramtype, \texttt{g}.\subprogramtype)\\
-  \argsclash(\vf.\vargs, \texttt{g}.\vargs)\\
-}
-{ \subprogramclash(\vf, \texttt{g}) }
-\and
-\inferrule{
-  \name = \funcsig.\name\\
-  \texttt{same\_named} = G^\tenv.\subprogramrenamings(\name)\\
-  \texttt{fo} \in \texttt{same\_named}: \neg\subprogramclash(\tenv, \funcsig, \texttt{fo})\\
-  G' = G^\tenv.\subprogramrenamings[\name \mapsto \texttt{same\_named} \cup \{\funcsig\}]\\
-  G'' = G'.\subprograms[\name \mapsto \funcsig]\\
-  \newenv = (G'', L^\tenv)
+  {
+  \begin{array}{rrcl}
+    \funcsig \eqdef \{ & \funcname            &:& \name,\\
+                   & \funcparameters      &:& \vp,\\
+                   & \funcargs            &:& \vargs,\\
+                   & \funcbody            &:& \SBASL(\newbody),\\
+                   & \funcreturntype      &:& \vt,\\
+                   & \funcsubprogramtype  &:& \subprogramtype \\
+                \} &&&
+      \end{array}
+    }\\
+  \tododefine{add\_new\_func}(\tenv, \name, \vargs, \vp) \typearrow
+  (\tenvone, \namep) \OrTypeError\\
+  \checkvarnotinenv{\tenvone, \namep} \typearrow \True \OrTypeError\\\\
+  \tododefine{check\_setter\_has\_getter}(\tenvone, \funcsig) \typearrow \True \OrTypeError\\\\
+  {
+  \begin{array}{rrcl}
+    \funcsig \eqdef \{ & \funcname            &:& \namep,\\
+                   & \funcparameters      &:& \vp,\\
+                   & \funcargs            &:& \vargs,\\
+                   & \funcbody            &:& \SBASL(\newbody),\\
+                   & \funcreturntype      &:& \vt,\\
+                   & \funcsubprogramtype  &:& \subprogramtype \\
+                \} &&&
+      \end{array}
+    }\\
+    \tododefine{add\_subprogram}(\namep, \funcsigone, \tenvone) \typearrow \newtenv \OrTypeError
 }
 {
-  \declaredecl{\tenv, \funcsig} \typearrow G''
+  \declaredecl{\tenv, \funcsig} \typearrow (\newtenv, \funcsigone)
 }
 \end{mathpar}
+
+\begin{mathpar}
+\inferrule{
+  \vf \eqname \{\funcbody: \SBASL(\Ignore)\}\\
+  \tododefine{annotate\_and\_declare\_func}(\tenv, \vf) \typearrow (\newtenv, \vfone) \OrTypeError\\\\
+  \annotatesubprogram{\tenv, \vfone} \typearrow \vftwo \OrTypeError\\\\
+  \newd \eqdef \DFunc(\vftwo)
+}
+{
+  \annotatedecl{\tenv, \DFunc(\vf)} \typearrow (\newd, \newenv)
+}
+\end{mathpar}
+
+% We define the helper rules \hassubprogramtypeclash, \argsclash, and subprogramclash\ to determined whether
+% two subprogram clash in terms of their subprogram types and their lists of argument types,
+% and then use them to annotate a subprogram declaration.
+
+% \begin{mathpar}
+% \inferrule{}{\hassubprogramtypeclash(\tenv, \STFunction, \Ignore)}
+% \and
+% \inferrule{}{\hassubprogramtypeclash(\tenv, \Ignore, \STFunction)}
+% \and
+% \inferrule{}{\hassubprogramtypeclash(\tenv, \STProcedure, \Ignore)}
+% \and
+% \inferrule{}{\hassubprogramtypeclash(\tenv, \Ignore, \STProcedure)}
+% \and
+% \inferrule{}{\hassubprogramtypeclash(\tenv, \STGetter, \STGetter)}
+% \and
+% \inferrule{}{\hassubprogramtypeclash(\tenv, \STSetter, \STSetter)}
+% \and
+% \inferrule{
+%   \texttt{t\_args1} = [i=1..k: (\Ignore, \vt_i)]\\
+%   \texttt{s\_args1} = [i=1..k: (\Ignore, \vs_i)]\\
+%   j \in 1..k\\
+%   \typeclashes(\tenv, \vt_j, \vs_j)
+% }
+% {\argsclash(\tenv, \texttt{t\_args}, \texttt{s\_args})}
+% \and
+% \inferrule{
+%   \argsclash(\vf.\subprogramtype, \texttt{g}.\subprogramtype)\\
+%   \argsclash(\vf.\vargs, \texttt{g}.\vargs)\\
+% }
+% { \subprogramclash(\vf, \texttt{g}) }
+% \and
+% \inferrule{
+%   \name = \funcsig.\name\\
+%   \texttt{same\_named} = G^\tenv.\subprogramrenamings(\name)\\
+%   \texttt{fo} \in \texttt{same\_named}: \neg\subprogramclash(\tenv, \funcsig, \texttt{fo})\\
+%   G' = G^\tenv.\subprogramrenamings[\name \mapsto \texttt{same\_named} \cup \{\funcsig\}]\\
+%   G'' = G'.\subprograms[\name \mapsto \funcsig]\\
+%   \newenv = (G'', L^\tenv)
+% }
+% {
+%   \declaredecl{\tenv, \funcsig} \typearrow G''
+% }
+% \end{mathpar}
 \end{emptyformal}
 \subsection{Comments}
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -7479,38 +7479,45 @@ environment $\newenv$ and all of the following apply:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Blocks}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+The function
+\[
+  \annotateblock{\overname{\staticenvs}{\tenv} \aslsep \overname{\stmt}{\vs}} \aslto
+  \overname{\stmt}{\newstmt} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+annotates a block statement $\vs$ in static environment $\tenv$ and returns the annotated
+statement $\newstmt$ or a type error, if one is detected.
 
 \section{TypingRule.Block \label{sec:TypingRule.Block}}
 
-  \subsection{Prose}
-    Annotating a block $\vs$ in an environment $\tenv$, given a type
-\texttt{return\_type} \\ (\texttt{annotate\_block env return\_type s}), is the
-result of annotating the statement $\vs$ in $\tenv$.
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item annotating the statement $\vs$ in $\tenv$ yields $(\newstmt, \newtenv)$ \ProseOrTypeError;
+  \item the modified environment $\newtenv$ is dropped.
+\end{itemize}
 
-  \subsection{Example: TypingRule.Block0.asl}
+\subsection{Example: TypingRule.Block0.asl}
 \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.Block0.asl}
 
-
-    \CodeSubsection{\BlockBegin}{\BlockEnd}{../Typing.ml}
+\CodeSubsection{\BlockBegin}{\BlockEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule{
-    \annotatestmt{\tenv, \vs} \typearrow (\vsp, \Ignore)
-  }
-  {
-    \annotateblock{\tenv, \vs, \texttt{return\_type}} \typearrow \vsp
-  }
+\inferrule{
+  \annotatestmt{\tenv, \vs} \typearrow (\newstmt, \Ignore) \OrTypeError
+}{
+  \annotateblock{\tenv, \vs} \typearrow \newstmt
+}
 \end{mathpar}
 \end{emptyformal}
 
 \subsection{Comments}
-    A local identifier declared with var, let or constant is in scope
+A local identifier declared with var, let or constant is in scope
 from the point immediately after its declaration until the end of the
 immediately enclosing block.
 
-    From that follows that we can discard the environment at the end of
+From that follows that we can discard the environment at the end of
 an enclosing block.
 
     This is related to \identr{JBXQ}.

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -73,6 +73,9 @@
 \newcommand\hassubprogramtypeclash[0]{\texttt{subprogram\_type\_clash}}
 \newcommand\subprogramclash[0]{\texttt{subprogram\_clash}}
 \newcommand\argsclash[0]{\texttt{args\_clash}}
+\newcommand\bitfieldgetname[0]{\hyperlink{def-bitfieldgetname}{\texttt{bitfield\_get\_name}}}
+\newcommand\pairstomap[0]{\hyperlink{def-pairstomap}{\texttt{pairs\_to\_map}}}
+\newcommand\annotatefieldinit[0]{\hyperlink{def-annotatefieldinit}{\texttt{annotate\_field\_init}}}
 
 \newcommand\typeequal[0]{\hyperlink{def-typeequal}{\texttt{type\_equal}}}
 \newcommand\exprequal[0]{\hyperlink{def-exprequal}{\texttt{expr\_equal}}}
@@ -1812,6 +1815,7 @@ The predicate
 \]
 tests whether a type $\vt$ \emph{structurally-subtype-satisfies} a type $\vs$ is environment $\tenv$,
 returning the result $\vb$ or a type error, if one is detected.
+The function assumes that both $\vt$ and $\vs$ are well-typed according to \chapref{typingoftypes}.
 
 \subsection{Prose}
 One of the following applies:
@@ -2018,11 +2022,11 @@ For a list of typed fields $\fields$, we define the set of its field identifiers
 \]
 \hypertarget{def-fieldtype}{}
 We define the type associated with the field name $\id$ in a list of typed fields $\fields$,
-if there is one, as follows:
+if there is a unique one, as follows:
 \[
   \fieldtype(\fields, \id) \triangleq
   \begin{cases}
-  \vt  & \text{ if }(\id,\vt) \in \fields\\
+  \vt  & \text{ if }\{ \vtp \;|\; (\id,\vtp) \in \fields\} = \{\vt\}\\
   \bot & \text{ otherwise}
   \end{cases}
 \]
@@ -3236,7 +3240,7 @@ Determine the result type of a binary operator, given the types of its operands.
   \identi{LGHJ}, \identi{RXLG}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\chapter{Typing of types}
+\chapter{Typing of types \label{chap:typingoftypes}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \hypertarget{def-annotatetype}{}
 The function
@@ -3826,27 +3830,9 @@ All of the following apply:
 
 \begin{emptyformal}
 \subsection{Formally}
-\newcommand\getbitfieldname[0]{\texttt{get\_bitfield\_name}}
-We first define the helper function $\getbitfieldname : \bitfield \aslto \identifier$,
-which extracts the name of a bitfield:
-\begin{mathpar}
-  \inferrule[simple]{}{
-    \getbitfieldname(\BitFieldSimple(\name, \Ignore)) \typearrow \name
-  }
-  \and
-  \inferrule[nested]{}{
-    \getbitfieldname(\BitFieldNested(\name, \Ignore, \Ignore)) \typearrow \name
-  }
-  \and
-  \inferrule[type]{}{
-    \getbitfieldname(\BitFieldType(\name, \Ignore, \Ignore)) \typearrow \name
-  }
-\end{mathpar}
-
-Now the rule for annotating a list of bitfields is
 \begin{mathpar}
 \inferrule{
-  \names \eqdef [\field\in\fields: \getbitfieldname(\field)]\\
+  \names \eqdef [\field\in\fields: \bitfieldgetname(\field)]\\
   \checknoduplicates(\names) \typearrow \True \OrTypeError\\
   \reduceconstants{\tenv, \ewidth} \typearrow \lint(\vi) \OrTypeError\\
   \field\in\fields: \annotatebitfield(\tenv, \width, \field) \typearrow \newfield \OrTypeError\\
@@ -3899,6 +3885,7 @@ $\newe$ is an annotated expression, or a type error, and one of the following ap
 \item TypingRule.EGetBitField (see \secref{TypingRule.EGetBitField})
 \item TypingRule.EGetBitFieldNested (see \secref{TypingRule.EGetBitFieldNested})
 \item TypingRule.EGetBitFieldTyped (see \secref{TypingRule.EGetBitFieldTyped})
+\item TypingRule.EGetTupleItem (see \secref{TypingRule.EGetTupleItem})
 \item TypingRule.EConcatEmpty (see \secref{TypingRule.EConcatEmpty})
 \item TypingRule.EConcat (see \secref{TypingRule.EConcat})
 \item TypingRule.ETuple (see \secref{TypingRule.ETuple})
@@ -4446,7 +4433,6 @@ All of the following apply:
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
-
   This is related to \identr{WBCQ}.
 
 \section{TypingRule.EStructuredMissingField \label{sec:TypingRule.EStructuredMissingField}}
@@ -4469,10 +4455,11 @@ A§ll of the following apply:
 \begin{mathpar}
 \inferrule{
   \checktrans{\astlabel(\tty) = \TNamed} \typearrow \True \OrTypeError\\
-  \tstruct{\tenv, \tty} \typearrow L(\fieldtypes) \OrTypeError\\
+  \tstruct(\tenv, \tty) \typearrow L(\fieldtypes) \OrTypeError\\\\
   L \in \{\TRecord, \TException\}\\
-  (\name, \vtp)\in\fieldtypes: \vb_\name \eqdef (\name, \vtp) \in \fields\\
-  \vb = \bigwedge{(\name, \vtp)\in\fieldtypes} \vb_\name\\
+  \initializedfields \eqdef \{\name \;|\; (\name, \Ignore)\in\fields\}\\
+  \names \eqdef \fieldnames(\fieldtypes)\\
+  \vb \eqdef \initializedfields = \names\\
   \vb = \False
 }
 {
@@ -4492,10 +4479,15 @@ All of the following apply:
   \item $\ve$ denotes the record expression or an exception expression of type $\tty$ with fields $\fields$;
   \item $\tty$ is the name of a record or exception type with fields $\fieldtypes$;
   \item every field in $\fieldtypes$ is initialised by $\fields$;
-  \item annotating the field initializations via $\tododefine{annotate\_field\_init}$
-  yields $\fieldsp$ \ProseOrTypeError;
+  \item annotating the expressions in each field initializations in $\fields$ via \\
+  $\annotatefieldinit$ yields $\fieldsp$ \ProseOrTypeError;
   \item $\vt$ is $\tty$;
   \item $\newe$ is the record expression with type $\tty$ and field initializers $\fieldsp$, that is, $\ERecord(\tty, \fieldsp)$;
+\end{itemize}
+
+\subsection{Example}
+
+\CodeSubsection{\ERecordBegin}{\ERecordEnd}{../Typing.ml}
 
   % \item For each field named $\name$ associated with the expression $\vep$ in
   %   $\fieldtypes$, all of the following apply:
@@ -4507,23 +4499,20 @@ All of the following apply:
   %   \end{itemize}
   % \item $\vt$ is $\tty$;
   % \item $\newe$ is the record expression of type $\tty$ with fields $\fieldsp$.
-\end{itemize}
-
-\subsection{Example}
-
-\CodeSubsection{\ERecordBegin}{\ERecordEnd}{../Typing.ml}
 
 \begin{emptyformal}
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
   \checktrans{\astlabel(\tty) = \TNamed} \typearrow \True \OrTypeError\\
-  \tstruct{\tenv, \tty} \typearrow L(\fieldtypes) \OrTypeError\\
+  \tstruct(\tenv, \tty) \typearrow L(\fieldtypes) \OrTypeError\\\\
   L \in \{\TRecord, \TException\}\\
-  (\name, \vtp)\in\fieldtypes: \vb_\name \eqdef (\name, \vtp) \in \fields\\
-  \vb = \bigwedge{(\name, \vtp)\in\fieldtypes} \vb_\name\\
+  \initializedfields \eqdef \{\name \;|\; (\name, \Ignore)\in\fields\}\\
+  \names \eqdef \fieldnames(\fieldtypes)\\
+  \vb \eqdef \initializedfields = \names\\
   \vb = \True\\
-  \tododefine{annotate\_field\_init}(\tenv, \fields, \fieldtypes) \typearrow \fieldsp
+  (\name, \vep) \in \fields: \annotatefieldinit(\tenv, (\name, \vep), \fieldtypes) \typearrow (\name, \vepp) \OrTypeError\\
+  \fieldsp \eqdef [(\name, \vep) \in \fields : (\name, \vepp)]
 }
 {
   \annotateexpr{\tenv, \ERecord(\tty, \fields)} \typearrow (\tty, \ERecord(\tty, \fieldsp))
@@ -4548,14 +4537,12 @@ $(\vt, \newe)$ and all of the following apply:
   \item $\newe$ is the access of field \texttt{field\_name} on expression \vetwo.
   \end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\EGetRecordFieldBegin}{\EGetRecordFieldEnd}{../Typing.ml}
+\CodeSubsection{\EGetRecordFieldBegin}{\EGetRecordFieldEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
-
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
 \annotateexpr{\tenv, \veone} \typearrow (\texttt{t\_e1}, \vetwo)\\
@@ -4734,11 +4721,10 @@ $(\vt, \newe)$ and all of the following apply:
 
   \subsection{Example}
 
-
-    \CodeSubsection{\EGetBitFieldTypedBegin}{\EGetBitFieldTypedEnd}{../Typing.ml}
+\CodeSubsection{\EGetBitFieldTypedBegin}{\EGetBitFieldTypedEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\texttt{t\_e1}, \vetwo)\\
@@ -4748,6 +4734,30 @@ $(\vt, \newe)$ and all of the following apply:
   \typesat(\tenv, \texttt{t\_e3}, \vt)
 }
 {\annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \texttt{e3})}
+\end{mathpar}
+\end{emptyformal}
+
+\isempty{\subsection{Comments}}
+
+\section{TypingRule.EGetTupleItem \label{sec:TypingRule.EGetTupleItem}}
+
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes \texttt{e1, field\_name};
+\end{itemize}
+
+\subsection{Example}
+
+\CodeSubsection{\EGetTupleItemBegin}{\EGetTupleItemEnd}{../Typing.ml}
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{}
+{
+  \annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \texttt{e3})
+}
 \end{mathpar}
 \end{emptyformal}
 
@@ -9254,6 +9264,66 @@ returning a type error otherwise:
   \inferrule[check\_trans\_false]{}{ \checktrans{\False} \typearrow\TypeErrorVal{CheckFailed} }
 \end{mathpar}
 
+\hypertarget{def-pairstomap}{}
+\section{Converting a List of Pairs to a Map \label{sec:PairsToMap}}
+The parameteric function
+\[
+  \pairstomap(\overname{(\identifier\times T)^*}{\pairs}) \aslto \overname{(\identifier\partialto T)}{f} \cup \TTypeError
+\]
+converts a list of pairs --- $\pairs$ --- where each pair consists of an identifier and a value
+of type $T$ into a function mapping each identifier to its respective value in the list.
+If a duplicate identifier exists in $\pairs$ then a type error is returned.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{empty}):
+  \begin{itemize}
+    \item $\pairs$ is empty;
+    \item $f$ is the empty function.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{error}):
+  \begin{itemize}
+    \item there exist two different positions in the list where the identifier is the same;
+    \item the result is a type error indicating the existence of a duplicate identifier.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{okay}):
+  \begin{itemize}
+    \item all identifiers occurring in the list are unique;
+    \item $f$ is a function that associates to each identifier the value appearing with it in $\pairs$.
+  \end{itemize}
+\end{itemize}
+
+\begin{emptyformal}
+\begin{mathpar}
+\inferrule[empty]{}{ \pairstomap(\emptylist) \typearrow \emptyfunc }
+\and
+\inferrule[error]{
+  i,j \in 1..k\\
+  i \neq j\\
+  \id_i = \id_j
+}
+{
+  \pairstomap([i=1..k: (\id_i,t_i)]) \typearrow \TypeErrorVal{DuplicateIdentifier}
+}
+\and
+\inferrule[okay]{
+  \forall i,j \in 1..k. \id_i \neq \id_j\\
+  {
+  f \eqdef \lambda \id.\ \begin{cases}
+    t_i & \text{ if }i\in1..k \land \id = \id_i\\
+    \bot & \text{ otherwise}
+  \end{cases}
+  }
+}
+{
+  \pairstomap([i=1..k: (\id_i,t_i)]) \typearrow f
+}
+\end{mathpar}
+\end{emptyformal}
+
 \hypertarget{def-checknoduplicates}{}
 \section{TypingRule.CheckNoDuplicates \label{sec:TypingRule.CheckNoDuplicates}}
 The function
@@ -9296,6 +9366,88 @@ One of the following applies:
 {
   \checknoduplicates(\id_{1..k}) \typearrow \TypeErrorVal{DuplicateIdentifier}
 }
+\end{mathpar}
+\end{emptyformal}
+
+\hypertarget{def-annotatefieldinit}{}
+\section{Annotating Field Initializers}
+The function
+\[
+  \annotatefieldinit(
+    \overname{\staticenvs}{\tenv} \aslsep
+    \overname{(\identifier\times\expr)}{(\name, \vep)} \aslsep
+    \overname{\field^*}{\fieldtypes}
+  ) \aslto
+  \overname{(\identifier\times\expr)}{(\name, \vepp)}
+\]
+annotates a field initializers $(\name, \vep)$ in a record expression
+with list of fields $\fieldtypes$ and returns the annotated field initializer
+$(\name, \vepp)$. A type error is returned, if one is detected.
+
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item annotating the expression $\vep$ in $\tenv$ yields $(\vtp, \vepp)$ \ProseOrTypeError\\
+  \item One of the following applies:
+  \begin{itemize}
+    \item All of the following apply (\textsc{okay}):
+    \begin{itemize}
+      \item the unique type associated with $\name$ in $\fieldtypes$ is $\tspecp$;
+      \item determining whether $\vtp$ \typesatisfies\ $\tspecp$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+    \end{itemize}
+
+    \item All of the following apply (\textsc{error}):
+    \begin{itemize}
+      \item there is no type associated with $\name$ in $\fieldtypes$;
+      \item the result is a type error indicating that the field $\name$ does not exist.
+    \end{itemize}
+  \end{itemize}
+\end{itemize}
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[okay]{
+  \annotateexpr{\tenv, \vep} \typearrow (\vtp, \vepp) \OrTypeError\\\\
+  \fieldtype(\fieldtypes, \name) = \tspecp\\
+  \checktypesat(\tenv, \vtp, \tspecp) \typearrow \True \OrTypeError
+}{
+  \annotatefieldinit(\tenv, (\name, \vep), \fieldtypes) \typearrow (\name, \vepp)
+}
+\and
+\inferrule[error]{
+  \annotateexpr{\tenv, \vep} \typearrow (\vtp, \vepp) \OrTypeError\\\\
+  \fieldtype(\fieldtypes, \name) = \bot
+}{
+  \annotatefieldinit(\tenv, (\name, \vep), \fieldtypes) \typearrow \\
+  \TypeErrorVal{FieldDoesNotExist}
+}
+\end{mathpar}
+\end{emptyformal}
+
+\section{TypingRule.BitFieldGetName \label{sec:TypingRule.BitFieldGetName}}
+
+\hypertarget{def-bitfieldgetname}{}
+The function
+\[
+  \bitfieldgetname : \bitfield \aslto \identifier
+\]
+returns the name of a bitfield.
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+  \inferrule[simple]{}{
+    \bitfieldgetname(\BitFieldSimple(\name, \Ignore)) \typearrow \name
+  }
+  \and
+  \inferrule[nested]{}{
+    \bitfieldgetname(\BitFieldNested(\name, \Ignore, \Ignore)) \typearrow \name
+  }
+  \and
+  \inferrule[type]{}{
+    \bitfieldgetname(\BitFieldType(\name, \Ignore, \Ignore)) \typearrow \name
+  }
 \end{mathpar}
 \end{emptyformal}
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -34,6 +34,8 @@
 %\newcommand\ProseOrTypeError[0]{or a type error that short-circuits the entire rule}
 \newcommand\ProseOrTypeError[0]{\hyperlink{def-proseortypeerror}{$^{\TypeErrorConfig}$}}
 
+\newcommand\staticbinop[0]{\texttt{binop}}
+
 \newcommand\annotaterel[0]{\hyperlink{def-annotaterel}{\textsf{type}}}
 \newcommand\typearrow[0]{\xrightarrow{\annotaterel}}
 \newcommand\isbuiltinsingular[0]{\hyperlink{def-isbuiltinsingular}{\texttt{is\_builtin\_singular}}}
@@ -50,6 +52,8 @@
 \newcommand\isunderconstrainedinteger[0]{\textsf{under\_constrained\_integer}}
 \newcommand\iswellconstrainedinteger[0]{\textsf{well\_constrained\_integer}}
 \newcommand\unconstrainedinteger[0]{\textsf{unconstrained\_integer}}
+
+\newcommand\checkconstrainedinteger[0]{\hyperlink{def-checkconstrainedinteger}{\texttt{check\_constrained\_integer}}}
 
 \newcommand\staticeval[0]{\hyperlink{def-staticeval}{\texttt{static\_eval}}}
 \newcommand\isstaticallyevaluable[0]{\texttt{check\_statically\_evaluable}}
@@ -76,7 +80,10 @@
 \newcommand\bitfieldgetname[0]{\hyperlink{def-bitfieldgetname}{\texttt{bitfield\_get\_name}}}
 \newcommand\pairstomap[0]{\hyperlink{def-pairstomap}{\texttt{pairs\_to\_map}}}
 \newcommand\annotatefieldinit[0]{\hyperlink{def-annotatefieldinit}{\texttt{annotate\_field\_init}}}
+\newcommand\annotatestaticconstrainedinteger[0]{\hyperlink{def-annotatestaticconstrainedinteger}{\texttt{annotate\_static\_constrained\_integer}}}
+\newcommand\checkstructureinteger[0]{\hyperlink{def-checkstructureinteger}{\texttt{check\_structure\_integer}}}
 
+% Symbolic equivalence testing macros
 \newcommand\typeequal[0]{\hyperlink{def-typeequal}{\texttt{type\_equal}}}
 \newcommand\exprequal[0]{\hyperlink{def-exprequal}{\texttt{expr\_equal}}}
 \newcommand\bitwidthequal[0]{\hyperlink{def-bitwidthequal}{\texttt{bitwidth\_equal}}}
@@ -116,6 +123,8 @@
 \newcommand\typeequivalent[0]{\hyperlink{def-typeequal}{type-equivalent}}
 \newcommand\bitwidthequivalent[0]{\hyperlink{def-bitwidthequal}{bitwidth-equivalent}}
 \newcommand\typeclash[0]{\hyperlink{def-typeclashes}{type-clash}}
+\newcommand\constrainedinteger[0]{\hyperlink{def-checkconstrainedinteger}{constrained integer}}
+\newcommand\structureofinteger[0]{\hyperlink{def-checkstructureinteger}{structure of an integer}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Type functions
@@ -128,7 +137,8 @@
 \newcommand\annotateexprlist[1]{\hyperlink{def-annotateexprs}{\texttt{annotate\_exprs}}(#1)}
 \newcommand\annotatelexpr[1]{\textsf{annotate\_lexpr}(#1)}
 \newcommand\annotatearrayindex[0]{\textsf{annotate\_array\_index}}
-\newcommand\annotateslices[0]{\textsf{annotate\_slices}}
+\newcommand\annotateslice[0]{\hyperlink{def-annotateslice}{\textsf{annotate\_slice}}}
+\newcommand\annotateslices[0]{\hyperlink{def-annotateslices}{\textsf{annotate\_slices}}}
 \newcommand\annotatelocaldeclitem[1]{\hyperlink{def-annotatelocaldeclitem}{\texttt{annotate\_local\_decl\_item}}(#1)}
 \newcommand\annotatestmt[1]{\texttt{annotate\_stmt}(#1)}
 \newcommand\annotateblock[1]{\texttt{annotate\_block}(#1)}
@@ -1688,6 +1698,75 @@ The underlying type of \texttt{(integer, T2)} and \texttt{T3} is
 \end{emptyformal}
 \subsection{Comments}
 
+\section{TypingRule.CheckConstrainedInteger \label{sec:TypingRule.CheckConstrainedInteger}}
+\hypertarget{def-checkconstrainedinteger}{}
+The function
+\[
+  \checkconstrainedinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\tty}) \aslto \True \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+checks whether the type $\vt$ is a \constrainedinteger. If so, the result is $\True$, otherwise a type error is returned.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{well-constrained}):
+  \begin{itemize}
+    \item $\vt$ is a well-constrained integer;
+    \item the result is $\True$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{underconstrained}):
+  \begin{itemize}
+    \item $\vt$ is an underconstrained integer;
+    \item the result is $\True$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{unconstrained}):
+  \begin{itemize}
+    \item $\vt$ is an unconstrained integer;
+    \item the result is a type error indicating that a constrained integer type is expected.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{conflicting\_type}):
+  \begin{itemize}
+    \item $\vt$ is not an integer type;
+    \item the result is a type error indicating that the type conflict.
+  \end{itemize}
+\end{itemize}
+
+\subsection{Example}
+
+\CodeSubsection{\CheckConstrainedIntegerBegin}{\CheckConstrainedIntegerEnd}{../Typing.ml}
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[well-constrained]{}
+{
+  \checkconstrainedinteger(\tenv, \TInt(\wellconstrained(\Ignore))) \typearrow \True
+}
+\and
+\inferrule[underconstrained]{}
+{
+  \checkconstrainedinteger(\tenv, \TInt(\underconstrained(\Ignore))) \typearrow \True
+}
+\and
+\inferrule[unconstrained]{}
+{
+  \checkconstrainedinteger(\tenv, \TInt(\unconstrained(\Ignore))) \typearrow \\
+  \TypeErrorVal{ConstrainedIntegerExpected}
+}
+\and
+\inferrule[conflicting\_type]{
+  \astlabel(\vt) \neq \TInt
+}
+{
+  \checkconstrainedinteger(\tenv, \vt) \typearrow \TypeErrorVal{TypeConflict}
+}
+\end{mathpar}
+\end{emptyformal}
+\subsection{Comments}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Relations Over Types \label{chap:relationsovertypes}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2850,8 +2929,8 @@ Similarly, we determine the negation of integer constraints.
          \end{itemize}
        \item All of the following apply:
          \begin{itemize}
-         \item $\vtone$ has the structure of a constrained integer;
-         \item $\vt$ is a constrained integer whose constraint is ;
+         \item $\vtone$ has the structure of a \constrainedinteger;
+         \item $\vt$ is a \constrainedinteger\  whose constraint is ;
          \end{itemize}
        \end{itemize}
     \end{itemize}
@@ -2873,8 +2952,8 @@ Similarly, we determine the negation of integer constraints.
          \end{itemize}
        \item All of the following apply:
          \begin{itemize}
-         \item $\vtone$ has the structure of a constrained integer;
-         \item $\vt$ is a constrained integer whose constraint is ;
+         \item $\vtone$ has the structure of a \constrainedinteger;
+         \item $\vt$ is a \constrainedinteger\  whose constraint is ;
          \end{itemize}
        \end{itemize}
     \end{itemize}
@@ -3466,7 +3545,7 @@ In the following example, all the uses of bitvector types are valid:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \tododefine{annotate\_static\_constrained\_integer}(\tenv, \ewidth) \typearrow \ewidthp \OrTypeError\\
+  \annotatestaticconstrainedinteger(\tenv, \ewidth) \typearrow \ewidthp \OrTypeError\\
   \annotatebitfield(\tenv, \ewidthp) \typearrow \bitfieldsp \OrTypeError
 }{
   \annotatetype{\Ignore, \tenv, \TBits(\ewidth, \bitfields)} \typearrow \TBits(\ewidthp, \bitfieldsp)
@@ -3908,6 +3987,7 @@ We also define the following helper rules:
   \item TypingRule.Lit (\secref{TypingRule.Lit})
   \item TypingRule.ExpressionList (\secref{TypingRule.ExpressionList})
   \item TypingRule.TypingRule.ReduceSlicesToCall (\secref{TypingRule.ReduceSlicesToCall})
+  \item TypingRule.StaticConstrainedInteger (\secref{TypingRule.StaticConstrainedInteger})
 \end{itemize}
 
 \section{TypingRule.ELit \label{sec:TypingRule.ELit}}
@@ -5179,6 +5259,41 @@ One of the following applies:
 \end{mathpar}
 \end{emptyformal}
 
+\hypertarget{def-annotatestaticconstrainedinteger}{}
+\section{TypingRule.StaticConstrainedInteger \label{sec:TypingRule.StaticConstrainedInteger}}
+
+The function
+\[
+  \annotatestaticconstrainedinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
+  \overname{\expr}{\vepp} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+annotates a statically-evaluable integer expression $\ve$ in the static environment $\tenv$
+and returns the annotated expression $\vepp$.
+A type error is returned, if one is detected.
+
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item annotating the expression $\ve$ in $\tenv$ yields $ (\vt, \vep)$ \ProseOrTypeError;
+  \item determining whether $\vt$ is a statically \constrainedinteger\ in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item determining whether $\vep$ is statically-evaluable in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item symbolically reducing the expression $\vep$ yields $\vepp$.
+\end{itemize}
+
+\CodeSubsection{\StaticConstrainedIntegerBegin}{\StaticConstrainedIntegerEnd}{../Typing.ml}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \ve} \typearrow (\vt, \vep) \OrTypeError\\
+  \checkconstrainedinteger(\tenv, \vt) \typearrow \True \OrTypeError\\
+  \tododefine{check\_statically\_evaluable}(\tenv, \vep) \typearrow \True \OrTypeError\\
+  \tododefine{reduce\_expr}(\tenv, \vep) \typearrow \vepp
+}{
+  \annotatestaticconstrainedinteger(\tenv, \ve) \typearrow \vepp
+}
+\end{mathpar}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Left-Hand-Side Expressions}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -5756,9 +5871,18 @@ all of the following apply:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Slices \label{chap:typingslices}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\hypertarget{def-annotateslice}{}
+The function
+\[
+  \annotateslice(\overname{\staticenvs}{\tenv} \aslsep \overname{\slice}{\vs})
+  \aslto
+  \overname{\slice}{\vsp} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+annotates a slices $\vs$ in the static environment $\tenv$,
+resulting in an annotated slice $\vsp$.
+A type error is returned, if one is detected.
 
-Annotating a slice~\texttt{slice} in an environment $\tenv$
-(\texttt{annotate\_slice env slice}) results in the slicing of the pair \texttt{(offset,length)} and one of the following applies:
+One of the following applies:
 \begin{itemize}
 \item TypingRule.SliceSingle (see \secref{TypingRule.SliceSingle}),
 \item TypingRule.SliceLength (see \secref{TypingRule.SliceLength}),
@@ -5766,63 +5890,75 @@ Annotating a slice~\texttt{slice} in an environment $\tenv$
 \item TypingRule.SliceStar (see \secref{TypingRule.SliceStar}).
 \end{itemize}
 
+\hypertarget{def-annotateslices}{}
+The function
+\[
+  \annotateslices(\overname{\staticenvs}{\tenv} \aslsep \overname{\slice^*}{\slices})
+  \aslto
+  \overname{\slice^*}{\slicesp} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+annotates a list of slices $\slices$ in the static environment $\tenv$,
+resulting in an annotated list of slices $\slicesp$.
+A type error is returned, if one is detected.
+
+The relevant rule is given by:
+\begin{itemize}
+  \item TypingRule.Slices (see \secref{TypingRule.Slices})
+\end{itemize}
+
 \section{TypingRule.SliceSingle \label{sec:TypingRule.SliceSingle}}
 
-  \subsection{Prose}
-   Annotating a slice~\texttt{slice} in an environment $\tenv$
-(\texttt{annotate\_slice env slice}) results in the pair \texttt{(offset, length)} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{slice} gives an index \texttt{i};
-   \item \texttt{(offset, length)} is the result of applying TypingRule.SliceLength to \texttt{i, i+:1}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vs$ is a slice at index \vi, that is $\SliceSingle(\vi)$;
+  \item annotating the slice at offset $\vi$ of length $1$ yields $\vsp$ \ProseOrTypeError.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\SliceSingleBegin}{\SliceSingleEnd}{../Typing.ml}
+\CodeSubsection{\SliceSingleBegin}{\SliceSingleEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateslice(\SliceLength(\vi, \eliteral{1})) \typearrow \vsp \OrTypeError
+}{
+  \annotateslice(\tenv, \SliceSingle(\vi)) \typearrow \vsp
+}
+\end{mathpar}
 \end{emptyformal}
 
 \subsection{Comments}
-    \identr{GXKG}: The notation \texttt{b[i]} is syntactic sugar for \texttt{b[i +: 1]}.
+  \identr{GXKG}: The notation \texttt{b[i]} is syntactic sugar for \texttt{b[i +: 1]}.
 
 \section{TypingRule.SliceLength \label{sec:TypingRule.SliceLength}}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vs$ is a slice of length $\elength$ and offset $\eoffset$, that is, $\SliceLength(\eoffset, \elength)$;
+  \item annotating the expression $\eoffset$ in $\tenv$ yields $(\toffset, \eoffsetp)$ \ProseOrTypeError;
+  \item annotating the statically-evaluable \constrainedinteger\ expression $\elength$ in $\tenv$ yields
+  $\elength$ \ProseOrTypeError;
+  \item determining whether $\toffset$ has the \structureofinteger\ yields $\True$ \ProseOrTypeError;
+  \item $\vsp$ is the slice at offset $\eoffsetp$ and length $\elength'$, that is,\\
+   $\SliceLength(\eoffsetp, \elength')$.
+\end{itemize}
 
-  \subsection{Prose}
-   Annotating a slice~\texttt{slice} in an environment $\tenv$
-(\texttt{annotate\_slice env slice}) results in the pair \texttt{(offset,length)} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{slice} gives \texttt{offset} and \texttt{length};
-   \item \texttt{t\_offset, offset'} is the result of annotating \texttt{offset} in $\tenv$;
-   \item \texttt{t\_length, length'} is the result of annotating \texttt{length} in $\tenv$;
-   \item \texttt{t\_offset} has the structure of an integer type;
-   \item \texttt{t\_length} has the structure of an integer type;
-   \item \texttt{length} is statically evaluable.
-   \end{itemize}
+\subsection{Example}
 
-  \subsection{Example}
-
-
-    \CodeSubsection{\SliceLengthBegin}{\SliceLengthEnd}{../Typing.ml}
+\CodeSubsection{\SliceLengthBegin}{\SliceLengthEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
-\newcommand\eoffset[0]{\texttt{offset}}
-\newcommand\elength[0]{\texttt{length}}
-\newcommand\toffset[0]{\texttt{t\_offset}}
-\newcommand\tlength[0]{\texttt{t\_length}}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-\annotateexpr{\tenv, \eoffset} \typearrow (\toffset, \eoffset')\\
-\annotateexpr{\tenv, \elength} \typearrow (\tlength, \elength')\\
-\tstruct(\tenv, \toffset) \typearrow \TInt(\Ignore)\\
-\tstruct(\tenv, \tlength) \typearrow \TInt(\Ignore)\\
-\isstaticallyevaluable(\tenv, \elength)
-}
-{
-\annotateslices(\tenv, \texttt{Slice\_Length}(\eoffset, \elength)) \typearrow \texttt{Slice\_Length}(\eoffset, \elength')
+  \annotateexpr{\tenv, \eoffset} \typearrow (\toffset, \eoffsetp) \OrTypeError\\
+  \annotatestaticconstrainedinteger(\tenv, \elength) \typearrow \elengthp \OrTypeError\\
+  \checkstructureinteger(\tenv, \eoffsetp, \toffset) \typearrow \True \OrTypeError
+}{
+  \annotateslice(\tenv, \SliceLength(\eoffset, \elength)) \typearrow \SliceLength(\eoffsetp, \elength')
 }
 \end{mathpar}
 \end{emptyformal}
@@ -5831,51 +5967,85 @@ Annotating a slice~\texttt{slice} in an environment $\tenv$
 
 \section{TypingRule.SliceRange \label{sec:TypingRule.SliceRange}}
 
-  \subsection{Prose}
-      Annotating a slice~\texttt{slice} in an environment $\tenv$
-(\texttt{annotate\_slice env slice}) results in the pair \texttt{(offset,
-length)} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{slice} gives a range \texttt{(j, i)};
-   \item \texttt{pre\_length} is \texttt{i +: j-i+1};
-   \item \texttt{offset, length} is the result of applying the rule TypingRule.SliceLength to \texttt{i,pre\_length}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vs$ is a slice for the range \texttt{(j, i)}, that is $\SliceRange(\vj, \vi)$;
+  \item $\prelength$ is \texttt{i+:(j-i+1)};
+  \item annotating the slice at offset $\vi$ of length $\prelength$ yields $\vsp$ \ProseOrTypeError.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\SliceRangeBegin}{\SliceRangeEnd}{../Typing.ml}
+\CodeSubsection{\SliceRangeBegin}{\SliceRangeEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \staticbinop(\MINUS, \vi, \vi) \typearrow \prelengthp\\
+  \staticbinop(\PLUS, \prelengthp, \eliteral{1}) \typearrow \prelength\\
+  \annotateslice(\SliceLength(\vi, \prelength)) \typearrow \vsp \OrTypeError
+}{
+  \annotateslice(\tenv, \SliceRange(\vj, \vi)) \typearrow \vsp
+}
+\end{mathpar}
 \end{emptyformal}
 
 \subsection{Comments}
-    \identr{GXKG}: The notation \texttt{b[j:i]} is syntactic sugar for \texttt{b[i +: j-i+1]}.
+    \identr{GXKG}: The notation \texttt{b[j:i]} is syntactic sugar for \texttt{b[i+:(j-i+1)]}.
 
 \section{TypingRule.SliceStar \label{sec:TypingRule.SliceStar}}
 
-  \subsection{Prose}
-      Annotating a slice~\texttt{slice} in an environment $\tenv$
-(\texttt{annotate\_slice env slice}) results in the pair \texttt{(offset,
-length)} and all of the following apply:
-   \begin{itemize}
-   \item \texttt{slice} gives \texttt{(factor, pre\_length)};
-   \item \texttt{pre\_offset} is \texttt{factor * pre\_length};
-   \item \texttt{offset, length} is the result of applying the rule TypingRule.SliceLength to \texttt{(pre\_offset, pre\_length)}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vs$ is a slice \texttt{[factor *: pre\_length]}, that is, $\SliceStar(\factor, \prelength)$;
+  \item $\preoffset$ is $\factor * \prelength$;
+  \item annotating the slice at offset $\preoffset$ of length $\prelength$ yields $\vsp$ \ProseOrTypeError.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\SliceStarBegin}{\SliceStarEnd}{../Typing.ml}
+\CodeSubsection{\SliceStarBegin}{\SliceStarEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \staticbinop(\MUL, \factor, \prelength) \typearrow \preoffset\\
+  \annotateslice(\SliceLength(\preoffset, \prelength)) \typearrow \vsp \OrTypeError
+}{
+  \annotateslice(\tenv, \SliceStar(\factor, \prelength)) \typearrow \vsp
+}
+\end{mathpar}
 \end{emptyformal}
 
 \subsection{Comments}
     \identr{GXQG}: The notation \texttt{b[i *: n]} is syntactic sugar for \texttt{b[i*n +: n]}
+
+\section{TypingRule.Slices \label{sec:TypingRule.Slices}}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item annotating the slices in $\slices$ from left to right yields the list of annotated slices $\slicesp$ \ProseOrTypeError.
+\end{itemize}
+
+\subsection{Example}
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \vs\in\slices: \annotateslice(\tenv, \vs) \typearrow \vsp \OrTypeError\\\\
+  \slicesp = [\vs\in\slices: \vsp]
+}{
+  \annotateslices(\tenv, \slices) \typearrow \slicesp
+}
+\end{mathpar}
+\end{emptyformal}
+
+\subsection{Comments}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Patterns}
@@ -8012,7 +8182,7 @@ evaluates an expression $\ve$, from a subset of the set of all expressions, in e
   \inferrule[e\_binop]{
     \staticeval(\tenv, \veone) \typearrow \vvone\\
     \staticeval(\tenv, \vetwo) \typearrow \vvtwo\\
-    \binop(\op, \vvone, \vvtwo) \typearrow \vv
+    \staticbinop(\op, \vvone, \vvtwo) \typearrow \vv
   }
   {
     \staticeval(\tenv, \EBinop(\op, \veone, \vetwo)) \typearrow \vv
@@ -8826,7 +8996,7 @@ multiplies two polynomials.
   }
   \and
   \inferrule[ebinop\_literals]{
-    \binop(\op, \vlone, \vltwo) \typearrow k\\
+    \staticbinop(\op, \vlone, \vltwo) \typearrow k\\
     \vp \eqdef \Sum( \{ \Prod(\emptyfunc)\mapsto k \} )
   }
   {
@@ -9608,6 +9778,54 @@ One of the following applies:
 }
 {
   \typeofarraylength(\tenv, \ArrayLengthExpr(\ve)) \typearrow \TInt(\wellconstrained([\vc]))
+}
+\end{mathpar}
+
+\hypertarget{def-checkstructureinteger}{}
+\section{TypingRule.CheckStructureInteger \label{sec:TypingRule.CheckStructureInteger}}
+The function
+\[
+  \checkstructureinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt}) \aslto
+  \True \cup \TTypeError
+\]
+returns $\True$ is $\vt$ is has the \structure\ an integer type and a type error otherwise.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{okay}):
+  \begin{itemize}
+    \item determining the \structure\ of $\vt$ yields $\vtp$ \ProseOrTypeError;
+    \item $\vtp$ is an integer type;
+    \item the result is $\True$;
+  \end{itemize}
+
+  \item All of the following apply (\textsc{error}):
+  \begin{itemize}
+    \item determining the \structure\ of $\vt$ yields $\vtp$ \ProseOrTypeError;
+    \item $\vtp$ is not an integer type;
+    \item the result is a type error indicating that $\vt$ was expected to have the \structure\ of an integer.
+  \end{itemize}
+\end{itemize}
+
+\CodeSubsection{\CheckStructureIntegerBegin}{\CheckStructureIntegerEnd}{../Typing.ml}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[okay]{
+  \tstruct(\vt) \typearrow \vtp \OrTypeError\\
+  \astlabel(\vtp) = \TInt
+}
+{
+  \checkstructureinteger(\tenv, \vt) \typearrow \True
+}
+\and
+\inferrule[error]{
+  \tstruct(\vt) \typearrow \vtp\\
+  \astlabel(\vtp) \neq \TInt
+}
+{
+  \checkstructureinteger(\tenv, \vt) \typearrow \TypeErrorVal{ExpectedIntegerStructure}
 }
 \end{mathpar}
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -90,6 +90,7 @@
 \newcommand\negateconstraint[0]{\hyperlink{def-negateconstraint}{\texttt{negate\_constraint}}}
 \newcommand\getwellconstrainedstructure[0]{\hyperlink{def-getwellconstrainedstructure}{\texttt{get\_well\_constrained\_structure}}}
 \newcommand\towellconstrained[0]{\hyperlink{def-towellconstrained}{\texttt{to\_well\_constrained}}}
+\newcommand\annotatelebits[0]{\hyperlink{def-annotatelebits}{\texttt{annotate\_lebits}}}
 
 % Symbolic equivalence testing macros
 \newcommand\typeequal[0]{\hyperlink{def-typeequal}{\texttt{type\_equal}}}
@@ -148,7 +149,7 @@
 \newcommand\annotatetype[1]{\hyperlink{def-annotatetype}{\texttt{annotate\_type}}(#1)}
 \newcommand\annotateexpr[1]{\hyperlink{def-annotateexpr}{\texttt{annotate\_expr}}(#1)}
 \newcommand\annotateexprlist[1]{\hyperlink{def-annotateexprs}{\texttt{annotate\_exprs}}(#1)}
-\newcommand\annotatelexpr[1]{\texttt{annotate\_lexpr}(#1)}
+\newcommand\annotatelexpr[1]{\hyperlink{def-annotatelexpr}{\texttt{annotate\_lexpr}}(#1)}
 \newcommand\annotatearrayindex[0]{\texttt{annotate\_array\_index}}
 \newcommand\annotateslice[0]{\hyperlink{def-annotateslice}{\texttt{annotate\_slice}}}
 \newcommand\annotateslices[0]{\hyperlink{def-annotateslices}{\texttt{annotate\_slices}}}
@@ -5683,10 +5684,20 @@ All of the following apply:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Left-Hand-Side Expressions}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-Annotating a left-hand side expression~\texttt{le} in an environment $\tenv$, assuming \texttt{t\_e}
-to be the type of the corresponding right-hand-side (\texttt{annotate\_lexpr env le t\_e}),
-results in an annotated expression \texttt{new\_le} and one of the following applies:
+\hypertarget{def-annotatelexpr}{}
+The function
+\[
+  \annotatelexpr{
+    \overname{\staticenvs}{\tenv} \aslsep
+    \overname{\lexpr}{\vle} \aslsep
+    \overname{\ty}{\vte}} \aslto
+    \overname{\lexpr}{\newle} \cup \TTypeError
+\]
+annotates a left-hand side expression $\vle$ in an environment $\tenv$, assuming $\vle$
+to be the type of the corresponding right-hand-side expression,
+resulting in an annotated expression $\newle$.
+The result is a type error, if one is detected.
+One of the following applies:
 \begin{itemize}
 \item TypingRule.LEDiscard (see \secref{TypingRule.LEDiscard}),
 \item TypingRule.LELocalVar (see \secref{TypingRule.LELocalVar}),
@@ -5704,36 +5715,32 @@ results in an annotated expression \texttt{new\_le} and one of the following app
 \item TypingRule.LEConcat (see \secref{TypingRule.LEConcat}).
 \end{itemize}
 
+We also make use of the helper tule
+TypingRule.LEBits (see \secref{TypingRule.LEBits}).
+
+\hypertarget{def-rexpr}{}
 Some of the rules require viewing left-hand-side expressions as their corresponding right-hand side expressions.
 The correspondence is defined in the ASL Syntax Reference~\cite[Chapter 5]{ASLAbstractSyntaxReference}
 and given by the function $\torexpr : \lexpr \rightarrow \expr$.
 
 \section{TypingRule.LEDiscard \label{sec:TypingRule.LEDiscard}}
 
-  \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes an expression which can be discarded;
-   \item \texttt{new\_le} is \texttt{le}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+\item $\vle$ denotes an expression that can be discarded, that is, $\LEDiscard$;
+\item $\newle$ is $\vle$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LEDiscardBegin}{\LEDiscardEnd}{../Typing.ml}
+\CodeSubsection{\LEDiscardBegin}{\LEDiscardEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-\inferrule{
-  \vle = \texttt{LE\_Discard}\\
-  \newle \eqdef \vle
-}
-{
-  \annotatelexpr{\tenv, \vle, \vte} \typearrow \newle
+\inferrule{}{
+  \annotatelexpr{\tenv, \LEDiscard, \vte} \typearrow \vle
 }
 \end{mathpar}
 \end{emptyformal}
@@ -5742,33 +5749,29 @@ all of the following apply:
 
 \section{TypingRule.LELocalVar \label{sec:TypingRule.LELocalVar}}
 
-   \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes a local variable $\vx$;
-   \item $\vx$ is locally declared as a mutable variable of type $\tty$ in $\tenv$;
-   \item $\tty$ \typesatisfies\  \texttt{t\_e};
-   \item \texttt{new\_le} is \texttt{le}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes a local variable $\vx$, that is, $\LEVar(\vx)$;
+  \item $\vx$ is locally declared as a mutable variable of type $\tty$ in $\tenv$;
+  \item determining whether $\tty$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item $\newle$ is $\vle$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LELocalVarBegin}{\LELocalVarEnd}{../Typing.ml}
+\CodeSubsection{\LELocalVarBegin}{\LELocalVarEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \vle \eqname \texttt{LE\_Var}(\id)\\
+  \vle \eqname \LEVar(\vx)\\
   L^\tenv.\localstoragetypes(\id) = (\tty, \LDKVar)\\
-  \typesat(\tenv, \vte, \tty)\\
-  \newle \eqdef \vle
+  \checktypesat(\tenv, \vte, \tty) \typearrow \True \OrTypeError
+}{
+  \annotatelexpr{\tenv, \vle, \vte} \typearrow \vle
 }
-{ \annotatelexpr{\tenv, \vle, \vte} \typearrow \newle }
 \end{mathpar}
 
 \end{emptyformal}
@@ -5779,33 +5782,29 @@ all of the following apply:
 
 \section{TypingRule.LEGlobalVar \label{sec:TypingRule.LEGlobalVar}}
 
-  \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes a global variable $\vx$;
-   \item $\vx$ is globally declared as a variable of type $\tty$ in $\tenv$;
-   \item \texttt{t\_e} \typesatisfies\  $\tty$;
-   \item \texttt{new\_le} is \texttt{le}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes a local variable $\vx$, that is, $\LEVar(\vx)$;
+  \item $\vx$ is globally declared as a mutable variable of type $\tty$ in $\tenv$;
+  \item determining whether $\tty$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item $\newle$ is $\vle$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LEGlobalVarBegin}{\LEGlobalVarEnd}{../Typing.ml}
+\CodeSubsection{\LEGlobalVarBegin}{\LEGlobalVarEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \vle = \texttt{LE\_Var}(\id)\\
-  G^\tenv.\globalstoragetypes(\id) = (\vtp, \Ignore)\\
-  \typesat(\tenv, \vtp, \vte)\\
-  \newle = \vle
+  \vle \eqname \LEVar(\vx)\\
+  G^\tenv.\globalstoragetypes(\vx) = (\tty, \GDKVar)\\
+  \checktypesat(\tenv, \vte, \tty) \typearrow \True \OrTypeError
+ }{
+  \annotatelexpr{\tenv, \vle, \vte} \typearrow \newle
 }
-{ \annotatelexpr{\tenv, \vle, \vte} \typearrow \newle }
 \end{mathpar}
 \end{emptyformal}
 
@@ -5814,48 +5813,39 @@ all of the following apply:
 
 \section{TypingRule.LEDestructuring \label{sec:TypingRule.LEDestructuring}}
 
-  \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes a tuple \texttt{les};
-   \item \texttt{t\_e} has the structure of a tuple type \texttt{sub\_tys};
-   \item the elements of \texttt{sub\_tys} \typesatisfies\  the type of the elements of \texttt{les};
-   \item One of the following applies:
-     \begin{itemize}
-     \item All of the following apply:
-       \begin{itemize}
-       \item \texttt{les} and \texttt{sub\_tys} have the same length;
-       \item \texttt{new\_le} is the result of annotating \texttt{les} with \texttt{sub\_tys} in $\tenv$
-       \end{itemize}
-     \item All of the following apply:
-       \begin{itemize}
-       \item \texttt{les} and \texttt{sub\_tys} do not have the same length;
-       \item an error ``\texttt{Bad Arity LEDestructuring}'' is raised.
-       \end{itemize}
-     \end{itemize}
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes a tuple of left-hand-side expressions $\les$, that is, $\LEDestructuring(\les)$;
+  \item $\les$ is a list $\ve_{1..k}$;
+  \item $\vte$ is a tuple type $\subtys$;
+  \item determining whether $\les$ and $\subtys$ have the same length yields $\True$ \ProseOrTypeError;
+  \item $\subtys$ is the list of types $\vt_{1..k}$;
+  \item annotating the left-hand-side expression $\ve_i$ with the type $\vt_i$, for $i=1..k$, yields $\vep_i$ \ProseOrTypeError;
+  \item the list of expressions $\lesp$ is $\vep_i$, for $i=1..k$;
+  \item $\newle$  is the list of left-hand-side expressions $\lesp$, that is, $\LEDestructuring(\lesp)$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LEDestructuringBegin}{\LEDestructuringEnd}{../Typing.ml}
+\CodeSubsection{\LEDestructuringBegin}{\LEDestructuringEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \vle = \texttt{LE\_Destructuring}(\les)\\
-  \vte = \TTuple(\subtys)\\
-  \les = [\ve_{1..k}]\\
-  \subtys = [\vt_{1..k}]\\
-  i=1..k: \annotateexpr{\tenv, \ve_i,\vt_i} \typearrow \vep_i\\
-  \les' = [i=1..k: \vep_i]\\
-  \newle = \texttt{LE\_Destructuring}(\les')
+  \vle \eqname \LEDestructuring(\les)\\
+  \les \eqname [\ve_{1..k}]\\
+  \checktrans{\astlabel(\vle) = \TTuple, \texttt{"TupleExpected"}} \typearrow \True \OrTypeError\\\\
+  \vte \eqname \TTuple(\subtys)\\
+  \equallength(\les, \subtys) \typearrow \vb\\
+  \checktrans{\vb, \texttt{"DifferentLengths"}} \typearrow \True \OrTypeError\\\\
+  \subtys \eqname [\vt_{1..k}]\\
+  i=1..k: \annotatelexpr{\tenv, \ve_i,\vt_i} \typearrow \vep_i \OrTypeError\\
+  \lesp \eqname [i=1..k: \vep_i]
+}{
+  \annotatelexpr{\tenv, \vle, \vte} \typearrow \LEDestructuring(\lesp)
 }
-{ \annotatelexpr{\tenv, \vle, \vte} \typearrow \newle }
 \end{mathpar}
 \end{emptyformal}
 
@@ -5863,43 +5853,43 @@ all of the following apply:
 
 \section{TypingRule.LESlice \label{sec:TypingRule.LESlice}}
 
-  \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes the slicing of a left-hand-side expression $\vleone$ by the slices $\slices$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
-   \item \texttt{t\_le1} has the structure of a bitvector type;
-   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
-   \item \texttt{width} is the width of the slices $\slices$ in $\tenv$;
-   \item $\vt$ is the bitvector type of width \texttt{width};
-   \item \texttt{te} \typesatisfies\  $\vt$;
-   \item \texttt{slices2} is the result of annotating $\slices$ in $\tenv$;
-   \item \texttt{new\_le} is the slicing of $\vletwo$ by \texttt{slices2}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes the slicing of a left-hand-side expression $\vleone$ by the slices $\slices$, that is, $\LESlice(\vleone, \slices)$;
+  \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\
+        $(\vtleone, \Ignore)$ \ProseOrTypeError;
+  \item $\vtleone$ is a bitvector type;
+  \item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$ \ProseOrTypeError;
+  \item obtaining the width of the slices $\slices$ in $\tenv$ and simplifying them yields $\vwidth$;
+  \item $\vt$ is the bitvector type of width $\width$ and empty list of bitfields;
+  \item checking whether $\vte$ \typesatisfies\ $\vt$ yields $\True$ \ProseOrTypeError;
+  \item annotating $\slices$ in $\tenv$ yields $\slicestwo$ \ProseOrTypeError;
+  \item checking that the slices $\slicestwo$ are all disjoint yields $\True$ \ProseOrTypeError;
+  \item $\newle$ is the slicing of $\vletwo$ by $\slicestwo$, that is, $\LESlice(\vletwo, \slicestwo)$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LESliceBegin}{\LESliceEnd}{../Typing.ml}
+\CodeSubsection{\LESliceBegin}{\LESliceEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \vle = \leslice(\vleone, \slices)\\
   \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore)\\
-  \astlabel(\tstruct(\tenv, \vtleone)) \typearrow \TBits\\
+  \tstruct(\tenv, \vtleone) \typearrow \structtleone \OrTypeError\\
+  \astlabel(\structtleone) = \TBits\\
   \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo\\
-  \sliceswidth(\tenv, \slices) \typearrow \vwidth\\
-  \vt = \TBits(\texttt{BitWidth\_SingleExpr}(\vwidth, \emptylist))\\
-  \typesat(\tenv, \vt, \vte)\\
-  \texttt{slices2} = [\annotateslices(\tenv, \vs) \;|\; \vs \in \slices]\\
-  \newle = \leslice(\vletwo, \texttt{slices2})
-}
-{ \annotatelexpr{\tenv, \vle, \vte} \typearrow \newle
+  \sliceswidth(\tenv, \slices) \typearrow \widthp\\
+  \tododefine{reduce\_expr}(\widthp) \typearrow \vwidth\\
+  \vt \eqdef \TBits(\vwidth, \emptylist)\\
+  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\
+  \annotateslices(\tenv, \slices) \typearrow \slicestwo \OrTypeError\\
+  \tododefine{check\_disjoint\_slices}(\tenv, \slicestwo) \typearrow \True \OrTypeError\\
+  \newle \eqdef \LESlice(\vletwo, \slicestwo)
+}{
+  \annotatelexpr{\tenv, \overname{\LESlice(\vleone, \slices)}{\vle}, \vte} \typearrow \newle
 }
 \end{mathpar}
 \end{emptyformal}
@@ -5908,52 +5898,44 @@ all of the following apply:
 
 \section{TypingRule.LESetArray \label{sec:TypingRule.LESetArray}}
 
-  \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes the slicing of a left-hand-side expression $\vleone$ by the slices $\slices$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
-   \item \texttt{t\_le1} has the structure of an array type of size $\size$ and item type $\vt$;
-   \item \texttt{te} \typesatisfies\  $\vt$;
-   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
-  % ROMAN: The following is not what the code does so I replaced it with subsequent item.
-  %  \item One of the following applies:
-  %    \begin{itemize}
-  %    \item $\wantedtindex$ is an enumeration type of name $\size$;
-  %    \item $\wantedtindex$ is the type \texttt{integer {0..size-1}};
-  %    \end{itemize}
-  \item the expression $\size$ can be annotated with the type $\wantedtindex$;
-  \item $\slices$ is a single expression $\eindex$;
-   \item $(\tindexp, \eindexp)$ is the result of annotating $\eindex$ in $\tenv$;
-   \item $\wantedtindex$ \typesatisfies\  $\tindexp$, which guarantees that the index
-   is within the bounds of the array;
-   \item \texttt{new\_le} is an access to array $\vletwo$ at index $\eindexp$.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes the slicing of a left-hand-side expression $\vleone$ by the slices $\slices$, that is, $\LESlice(\vleone, \slices)$;
+  \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields an array type of size $\size$ and element type $\vt$, that is, $\TArray(\size, \vt)$ \ProseOrTypeError;
+  \item annotating the left-hand-side expression $\vleone$ with type $\vtleone$ in $\tenv$ yields $\vletwo$ \ProseOrTypeError;
+  \item determining that $\vte$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item determining whether $\slices$ is a single slice with index expression $\eindex$ yields $\True$ \ProseOrTypeError;
+  \item annotating the index pression $\eindex$ in $\tenv$ yields $(\tindexp, \eindexp)$ \ProseOrTypeError;
+  \item determining the array length type of $\size$ in $\tenv$ (via $\typeofarraylength$) yields $\wantedtindex$;
+  \item determining whether $\tindexp$ \typesatisfies\ $\wantedtindex$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item $\newle$ is an access to array $\vletwo$ at index $\eindexp$, that is, \\ $\LESetArray(\vletwo, \eindexp)$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LESetArrayBegin}{\LESetArrayEnd}{../Typing.ml}
+\CodeSubsection{\LESetArrayBegin}{\LESetArrayEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \vle = \leslice(\vleone, \slices)\\
-  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore)\\
-  \tstruct(\tenv, \vtleone) \typearrow \TArray(\size, \vt)\\
-  \typesat(\tenv, \vte, \vt)\\
-  \annotatelexpr{\tenv, \vleone} \typearrow \vletwo\\
-  \annotatearrayindex(\tenv, \size) \typearrow \wantedtindex\\
-  \slices = [\SliceSingle(\eindex)]\\
-  \annotateexpr{\tenv, \eindex} \typearrow (\tindex', \eindex')\\
-  \typesat(\tenv, \tindex', \wantedtindex)\\
-  \newle = \texttt{LS\_SetArray}(\vletwo, \eindex')
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\
+  \tstruct(\tenv, \vtleone) \typearrow \TArray(\size, \vt) \OrTypeError\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\
+  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\
+  \checktrans{|\slices| = 1, \texttt{"ArraySliceShouldBeSingleIndex"}} \typearrow \True \OrTypeError\\\\
+  \slices \eqname [\vs]\\
+  \checktrans{\astlabel(\vs) = \SliceSingle, \texttt{"ArraySliceShouldBeSingleIndex"}} \typearrow \True \OrTypeError\\\\
+  \vs \eqname \SliceSingle(\eindex)\\
+  \annotateexpr{\tenv, \eindex} \typearrow (\tindexp, \eindexp) \OrTypeError\\
+  \typeofarraylength(\tenv, \size) \typearrow \wantedtindex\\
+  \checktypesat(\tenv, \tindexp, \wantedtindex) \typearrow \True \OrTypeError\\
+  \newle \eqdef \LESetArray(\vletwo, \eindexp)
+}{
+  \annotatelexpr{\tenv, \overname{\LESlice(\vleone, \slices)}{\vle}, \vte} \typearrow \newle
 }
-{\annotatelexpr{\tenv, \vle, \vte} \typearrow \newle}
 \end{mathpar}
 \end{emptyformal}
 
@@ -5961,67 +5943,68 @@ all of the following apply:
 
 \section{TypingRule.LESetBadStructuredField \label{sec:TypingRule.LESetBadStructuredField}}
 
-  \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
-   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
-   \item \texttt{t\_le1} has the structure of an exception or a record type with fields $\fields$;
-   \item \texttt{field} is not declared in $\fields$;
-   \item an error ``\texttt{Bad Field}'' is raised.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
+  \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields $\vletwo$ \ProseOrTypeError;
+  \item the \structure\ of $\vtleone$ in $\tenv$ is either a record type or an exception type with list of fields $\fields$ \ProseOrTypeError;
+  \item $\field$ is not associated with any type in $\fields$;
+  \item the result is an error indicating that the field $\field$ is missing from the type of $\vleone$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LESetBadStructuredFieldBegin}{\LESetBadStructuredFieldEnd}{../Typing.ml}
+\CodeSubsection{\LESetBadStructuredFieldBegin}{\LESetBadStructuredFieldEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\
+  \tstruct(\tenv, \vtleone) \typearrow L(\fields) \OrTypeError\\
+  L \in \{\TException, \TRecord\}\\
+  \assocopt(\fields, \field) \typearrow \None
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \TypeErrorVal{MissingField}
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.LESetStructuredField \label{sec:TypingRule.LESetStructuredField}}
 
-    \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
-   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
-   \item \texttt{t\_le1} has the structure of an exception or a record type with fields $\fields$;
-   \item \texttt{field} is bound to type $\vt$ in $\fields$;
-   \item $\vt$ \typesatisfies\  \texttt{t\_e};
-   \item \texttt{new\_le} is the access to the field \texttt{field} in $\vletwo$.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes the access to the field named \texttt{field} in $\vleone$;
+  \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$ \ProseOrTypeError;
+  \item annotating the left-hand-side expression  $\vleone$ with type $\vtleone$ in $\tenv$ yields $\vletwo$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields either a record type or an exception type with fields $\fields$ \ProseOrTypeError;
+  \item the type associated with the field $\field$ in $\fields$ is $\vt$;
+  \item determining whether $\vte$ \typesatisfies\ $\vt$ yields $\True$ \ProseOrTypeError;
+  \item $\newle$ is the access to the field $\field$ in $\vletwo$, that is, $\LESetField(\vletwo, \field)$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LESetStructuredFieldBegin}{\LESetStructuredFieldEnd}{../Typing.ml}
+\CodeSubsection{\LESetStructuredFieldBegin}{\LESetStructuredFieldEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \vle = \texttt{LE\_SetField}(\vleone, \vfield)\\
-  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore)\\
-  \annotatelexpr{\tenv, \vleone} \typearrow \vletwo\\
-  L \in \{\TRecord, \TException\}\\
-  \tstruct(\tenv, \vtleone) \typearrow L(\{\vfield:t, \ldots\})\\
-  \typesat(\tenv, \vte, \vt)\\
-  \newle = \texttt{LE\_SetField}(\vletwo, \vfield)
-}
-{
-  \annotatelexpr{\tenv, \vle, \vte} \typearrow \newle
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\
+  \tstruct(\tenv, \vtleone) \typearrow L(\fields) \OrTypeError\\
+  L \in \{\TException, \TRecord\}\\
+  \assocopt(\fields, \field) \typearrow \langle\vt\rangle\\
+  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\\\
+  \newle \eqdef \LESetField(\vletwo, \field)
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \newle
 }
 \end{mathpar}
 \end{emptyformal}
@@ -6030,76 +6013,76 @@ all of the following apply:
 
 \section{TypingRule.LESetBadBitField \label{sec:TypingRule.LESetBadBitField}}
 
-    \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
-   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
-   \item \texttt{t\_le1} has the structure of a bitvector with bitfields $\bitfields$;
-   \item \texttt{field} is not declared in $\bitfields$;
-   \item an error ``\texttt{Bad Field}'' is raised.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
+  \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields $\vtleone$ \ProseOrTypeError;
+  \item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a bitvector type with bitfields \\ $\bitfields$, that is,
+        $\TBits(\Ignore, \bitfields)$ \ProseOrTypeError;
+  \item find whether a bitfield $\field$ exists in $\bitfields$ yields $\None$;
+  \item the result is a type error indicating that the field $\field$ is missing from the type of $\vleone$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
 
-    \CodeSubsection{\LESetBadBitFieldBegin}{\LESetBadBitFieldEnd}{../Typing.ml}
+\CodeSubsection{\LESetBadBitFieldBegin}{\LESetBadBitFieldEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\
+  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\
+  \tododefine{find\_bitfield\_opt}(\bitfields, \field) \typearrow \None
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \TypeErrorVal{MissingField}
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.LESetBitField \label{sec:TypingRule.LESetBitField}}
 
-    \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
-   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
-   \item \texttt{t\_le1} has the structure of a bitvector with bitfields $\bitfields$;
-   \item \texttt{field} is declared in $\bitfields$;
-   \item $\slices$ gives the slices corresponding to the bitfield \texttt{field} in
-      $\bitfields$;
-   \item $\vw$ is the width of $\slices$;
-   \item $\vt$ is the bitvector type of width $\vw$;
-   \item $\vt$ \typesatisfies\  \texttt{t\_e};
-   \item $\vletwo$ is the slicing of $\vleone$ by $\slices$;
-   \item \texttt{new\_le} is the result of annotating $\vletwo$ in $\tenv$.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+\item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
+\item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$ \ProseOrTypeError;
+\item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$ \ProseOrTypeError;
+\item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a bitvector type with with bitfields $\bitfields$ \ProseOrTypeError;
+\item looking for $\field$ in $\bitfields$ yields a bitfield with corresponding slices $\slices$, that is, $\BitFieldSimple(\Ignore, \slices)$;
+\item $\vw$ is the width of $\slices$;
+\item $\vt$ is defined as the bitvector type of width $\vw$ and empty list of bitfields, that is, $\TBits(\vw, \emptylist)$;
+\item checking whether $\vt$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+\item $\vletwo$ is defined as the slicing of $\vleone$ by $\slices$, that is, $\LESlice(\vleone, \slices)$;
+\item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields $\newle$ \ProseOrTypeError.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LESetBitFieldBegin}{\LESetBitFieldEnd}{../Typing.ml}
+\CodeSubsection{\LESetBitFieldBegin}{\LESetBitFieldEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule{
-    \vle \typearrow \texttt{LE\_SetField}(\vleone, \vfield)\\
-    \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore)\\
-    \annotatelexpr{\tenv, \vleone} \typearrow \vletwo\\
-    \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields)\\
-    \texttt{BitField\_Simpled}(\vfield, \vslices) \in \bitfields\\
-    \sliceswidth(\tenv, \vslices) \typearrow \vw\\
-    \vt = \TBits(\texttt{BitWidth\_SingleExpr(\vw), \bitfields})\\
-    \typesat(\tenv, \vte, \vt)\\
-    \vletwo = \texttt{LE\_Slice}(\vleone, \vslices)\\
-    \annotatelexpr{\vletwo, \vslices} \typearrow \newle
-  }
-  {
-    \annotatelexpr{\tenv, \vle, \vte} = \newle
-  }
+\inferrule{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\
+  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\
+  \tododefine{find\_bitfield\_opt}(\bitfields, \field) \typearrow \langle \BitFieldSimple(\Ignore, \slices) \rangle\\
+  \sliceswidth(\tenv, \vslices) \typearrow \vw\\
+  \vt \eqdef \TBits(\vw, \emptylist)\\
+  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\
+  \vletwo \eqdef \LESlice(\vleone, \slices)\\
+  \annotatelexpr{\tenv, \vletwo, \vte} \typearrow \newle \OrTypeError
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \newle
+}
 \end{mathpar}
 \end{emptyformal}
 
@@ -6107,49 +6090,42 @@ all of the following apply:
 
 \section{TypingRule.LESetBitFieldNested \label{sec:TypingRule.LESetBitFieldNested}}
 
-    \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
-   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
-   \item \texttt{t\_le1} has the structure of a bitvector with bitfields $\bitfields$;
-   \item $\slices$ gives the slices corresponding to the bitfield \texttt{field} in
-      $\bitfields$;
-   \item $\vw$ is the width of $\slices$;
-   \item $\bitfieldsp$ gives the bitfields corresponding to \texttt{field} in $\bitfields$;
-   \item $\vt$ is the bitvector type of width $\vw$ and bitfields $\bitfieldsp$;
-   \item $\vt$ \typesatisfies\  \texttt{t\_e};
-   \item $\vletwo$ is the slicing of $\vleone$ by $\slices$;
-   \item \texttt{new\_le} is the result of annotating $\vletwo$ in $\tenv$.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+\item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
+\item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$ \ProseOrTypeError;
+\item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$ \ProseOrTypeError;
+\item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a bitvector type with with bitfields $\bitfields$ \ProseOrTypeError;
+\item looking for $\field$ in $\bitfields$ yields a nested bitfield with corresponding slices $\slices$ and list of bitfields
+      $\bitfieldsp$, that is, \\ $\BitFieldNested(\Ignore, \slices, \bitfieldsp)$;
+\item $\vw$ is the width of $\slices$;
+\item $\vt$ is defined as the bitvector type of width $\vw$ and list of bitfields $\bitfieldsp$, that is, $\TBits(\vw, \bitfieldsp)$;
+\item checking whether $\vt$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+\item $\vletwo$ is defined as the slicing of $\vleone$ by $\slices$, that is, $\LESlice(\vleone, \slices)$;
+\item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields $\newle$ \ProseOrTypeError.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LESetBitFieldNestedBegin}{\LESetBitFieldNestedEnd}{../Typing.ml}
+\CodeSubsection{\LESetBitFieldNestedBegin}{\LESetBitFieldNestedEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule{
-    \vle = \texttt{LE\_SetField}(\vleone, \vfield)\\
-    \annotateexpr{\tenv, \torexpr(\vleone)} = (\vtleone, \Ignore)\\
-    \annotatelexpr{\tenv, \vleone} = \vletwo\\
-    \tstruct(\tenv, \vtleone) = \TBits(\Ignore, \bitfields)\\
-    \texttt{BitField\_Nested}(\vfield, \vslices, \bitfields') \in \bitfields\\
-    \sliceswidth(\tenv, \vslices) = \vw\\
-    \vt = \TBits(\texttt{BitWidth\_SingleExpr(w), \bitfields'})\\
-    \typesat(\tenv, \vte, \vt)\\
-    \vletwo = \texttt{LE\_Slice}(\vleone, \vslices)\\
-    \annotatelexpr{\vletwo, \vslices} \typearrow \newle
-  }
-  {
-    \annotatelexpr{\tenv, \vle, \vte} = \newle
-  }
+\inferrule{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\
+  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\
+  \tododefine{find\_bitfield\_opt}(\bitfields, \field) \typearrow \langle \BitFieldNested(\Ignore, \slices, \bitfieldsp) \rangle\\
+  \sliceswidth(\tenv, \vslices) \typearrow \vw\\
+  \vt \eqdef \TBits(\vw, \bitfieldsp)\\
+  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\
+  \vletwo \eqdef \LESlice(\vleone, \slices)\\
+  \annotatelexpr{\tenv, \vletwo, \vte} \typearrow \newle \OrTypeError
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \newle
+}
 \end{mathpar}
 \end{emptyformal}
 
@@ -6157,52 +6133,44 @@ all of the following apply:
 
 \section{TypingRule.LESetBitFieldTyped \label{sec:TypingRule.LESetBitFieldTyped}}
 
-    \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
-   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
-   \item \texttt{t\_le1} has the structure of a bitvector with bitfields $\bitfields$;
-   \item $\slices$ gives the slices corresponding to the bitfield \texttt{field} in
-      $\bitfields$;
-   \item $\vw$ is the width of $\slices$;
-   \item \texttt{t'} is the bitvector type of width $\vw$;
-   \item $\vt$ gives the type corresponding to the bitfield \texttt{field} in
-      $\bitfields$;
-   \item $\vt$ \typesatisfies\  \texttt{t'};
-   \item $\vt$ \typesatisfies\  \texttt{t\_e};
-   \item $\vletwo$ is the slicing of $\vleone$ by $\slices$;
-   \item \texttt{new\_le} is the result of annotating $\vletwo$ in $\tenv$.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
+  \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$ \ProseOrTypeError;
+  \item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a bitvector type with with bitfields $\bitfields$ \ProseOrTypeError;
+  \item looking for $\field$ in $\bitfields$ yields a typed bitfield with corresponding slices $\slices$ and a type $\vt$,
+        that is, \\ $\BitFieldType(\Ignore, \vslices, \vt))$;
+  \item $\vw$ is the width of $\slices$;
+  \item $\vtp$ is defined as the bitvector type of width $\vw$ and an empty list of bitfields, that is, $\TBits(\vw , \emptylist)$;
+  \item checking whether $\vtp$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item checking whether $\vt$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item $\vletwo$ is defined as the slicing of $\vleone$ by $\slices$, that is, $\LESlice(\vleone, \slices)$;
+  \item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields $\newle$ \ProseOrTypeError.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LESetBitFieldTypedBegin}{\LESetBitFieldTypedEnd}{../Typing.ml}
+\CodeSubsection{\LESetBitFieldTypedBegin}{\LESetBitFieldTypedEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule{
-    \vle = \texttt{LE\_SetField}(\vleone, \vfield)\\
-    \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore)\\
-    \annotatelexpr{\tenv, \vleone} \typearrow \vletwo\\
-    \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields)\\
-    \texttt{BitField\_Type}(\vfield, \vslices, \vt) \in \bitfields\\
-    \sliceswidth(\tenv, \vslices) \typearrow \vw\\
-    \vtp = \TBits(\texttt{BitWidth\_SingleExpr(w), \emptylist})\\
-    \typesat(\tenv, \vtp, \vt)\\
-    \typesat(\tenv, \vte, \vt)\\
-    \vletwo = \texttt{LE\_Slice}(\vleone, \vslices)\\
-    \annotatelexpr{\vletwo, \vslices} \typearrow \newle
-  }
-  {
-    \annotatelexpr{\tenv, \vle, \vte} \typearrow \newle
-  }
+\inferrule{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\
+  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\
+  \tododefine{find\_bitfield\_opt}(\bitfields, \field) \typearrow \langle \BitFieldType(\Ignore, \vslices, \vt) \rangle\\
+  \sliceswidth(\tenv, \vslices) \typearrow \vw\\
+  \vtp \eqdef \TBits(\vw , \emptylist)
+  \checktypesat(\tenv, \vtp, \vt) \typearrow \True \OrTypeError\\
+  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\
+  \vletwo \eqdef \LESlice(\vleone, \slices)\\
+  \annotatelexpr{\tenv, \vletwo, \vte} \typearrow \newle \OrTypeError
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \newle
+}
 \end{mathpar}
 \end{emptyformal}
 
@@ -6210,49 +6178,119 @@ all of the following apply:
 
 \section{TypingRule.LESetBadField \label{sec:TypingRule.LESetBadField}}
 
-    \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
-   \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
-   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
-   \item \texttt{t\_le1} does not have the structure of a record, or an exception or a bitvector type;
-   \item an error ``\texttt{Conflicting Types}'' is raised.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
+  \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$ \ProseOrTypeError;
+  \item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a type $\vt$ \ProseOrTypeError;
+  \item $\vt$ is neither a record type, an exception type, or a bitvector type;
+  \item the result is an error indicating that the type of $\vle$ conflicts with the requirements of a field access expression.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LESetBadFieldBegin}{\LESetBadFieldEnd}{../Typing.ml}
+\CodeSubsection{\LESetBadFieldBegin}{\LESetBadFieldEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\
+  \tstruct(\tenv, \vtleone) \typearrow \vt \OrTypeError\\
+  \astlabel(\vt) \not\in \{\TException, \TRecord, \TBits\}
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \TypeErrorVal{TypeConflict}
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.LEConcat \label{sec:TypingRule.LEConcat}}
 
-    \subsection{Prose}
-   Annotating~\texttt{le} in an environment $\tenv$, assuming
-\texttt{t\_e} to be the type of the corresponding right-hand-side
-(\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
-all of the following apply:
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes the concatenation of left-hand-side expressions $\les$, that is, \\ $\LEConcat(\les, \Ignore)$;
+  \item annotating the right-hand-side expression corresponding to $\vle$ in $\tenv$ yields \\ $(\vteeq, \Ignore)$ \ProseOrTypeError;
+  \item checking whether the bitwidth of $\vteeq$ equals the bitwidth of $\vte$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item $\les$ is the list of left-hand-side expressions $\vle_i$, for $i=1..k$;
+  \item annotating each left-hand-side expression $\vle_i$ as a bitvector-typed expression (via $\annotatelebits$)
+        yields the annotated left-hand-side expression $\vleone_i$ and corresponding bitwidth $\width_i$, for $i=1..k$;
+  \item $\lesone$ is defined as the list $\vleone_{1..k}$;
+  \item $\widths$ is defined as the list $\width_{1..k}$;
+  \item $\newle$ is the concatenation of left-hand-side expressions $\lesone$ with corresponding list of widths $\widths$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\LEConcatBegin}{\LEConcatEnd}{../Typing.ml}
+\CodeSubsection{\LEConcatBegin}{\LEConcatEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
-
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \vle \eqname \LEConcat(\les, \Ignore)\\
+  \annotateexpr{\tenv, \torexpr(\vle)} \typearrow (\vteeq, \Ignore) \OrTypeError\\
+  \checkbitsequalwidth(\tenv, \vteeq, \vte) \typearrow \True \OrTypeError\\
+  \les \eqname \vle_{1..k}\\
+  i=1..k: \annotatelebits(\tenv, \vle_i) \typearrow (\vleone_i, \width_i) \OrTypeError\\
+  \lesone \eqdef \vleone_{1..k}\\
+  \widths \eqdef \width_{1..k}
+}{
+  \annotatelexpr{\tenv, \vle, \vte} \typearrow \overname{\LEConcat(\lesone, \widths)}{\newle}
+}
+\end{mathpar}
 \end{emptyformal}
 
 \isempty{\subsection{Comments}}
+
+\section{TypingRule.LEBits \label{sec:TypingRule.LEBits}}
+\hypertarget{def-annotatelebits}{}
+The helper function
+\[
+  \annotatelebits(\overname{\staticenvs}{\tenv} \aslsep \overname{\lexpr}{\vle})
+  \aslto \overname{\lexpr}{\vleone} \times \overname{\N}{\width}
+\]
+annotates a left-hand-side expression $\vle$, which is checked to be of bitvector type
+with width $\width$,
+resulting in the annotated expression and $\width$, or a type error, if one is detected.
+
+All of the following apply:
+\begin{itemize}
+  \item annotating the right-hand-side expression corresponding to $\vle$ in $\tenv$ yields \\ $(\vteone, \Ignore)$ \ProseOrTypeError;
+  \item obtaining the \structure\ of $\vteone$ in $\tenv$ yields $\vteonestruct$ \ProseOrTypeError;
+  \item checking whether $\vteonestruct$ is a bitvector type yields $\True$ \ProseOrTypeError;
+  \item $\vteonestruct$ is a bitvector type with width $\ewidth$;
+  \item symbolically reducing $\ewidth$ to a literal yields $\vl$ \ProseOrTypeError;
+  \item checking whether $\vl$ is an integer literal yields $\True$ \ProseOrTypeError;
+  \item $\vl$ is the integer literal for the integer $\width$;
+  \item $\vtetwo$ is defined as the bitvector type of width given by $\width$ and an empty list of bitfields, that is,
+        $\TBits(\ELInt{\width}, \emptylist)$;
+  \item annotating the left-hand-side expression $\vtetwo$ in $\tenv$ yields $\vleone$ \ProseOrTypeError.
+\end{itemize}
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vteone, \Ignore) \OrTypeError\\
+  \tstruct(\tenv, \vteone) \typearrow \vteonestruct \OrTypeError\\
+  \checktrans{\astlabel(\vteonestruct) = \TBits, \texttt{"Expected Bitvector type"}} \typearrow \True \OrTypeError\\
+  \vteonestruct \eqname \TBits(\ewidth, \Ignore)\\
+  \reduceconstants{\tenv, \ewidth} \typearrow \vl\\
+  \checktrans{\astlabel(\vl) = \lint, \texttt{"Expected integer literal"}} \typearrow \True \OrTypeError\\
+  \vl \eqname \lint(\width)\\
+  \vtetwo \eqdef \TBits(\ELInt{\width}, \emptylist)\\
+  \annotatelexpr{\tenv, \vtetwo} \typearrow \vleone \OrTypeError
+}{
+  \annotatelebits(\tenv, \vle) \typearrow (\vleone, \width)
+}
+\end{mathpar}
+\end{emptyformal}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Slices \label{chap:typingslices}}
@@ -7077,7 +7115,7 @@ environment $\newenv$ and all of the following apply:
    \begin{itemize}
    \item $\vs$ is an assignment \texttt{le = re} under language version \texttt{ver};
    \item \texttt{t\_e, e1} is the result of annotating \texttt{re} in $\tenv$;
-   \item \texttt{reduced} is the result of inlining a setter call in \texttt{le};
+   \item \texttt{reduced} is the result of inlining a setter call in $\vle$;
    \item One of the following applies:
      \begin{itemize}
      \item All of the following apply:
@@ -7105,7 +7143,7 @@ environment $\newenv$ and all of the following apply:
            \end{itemize}
          \end{itemize}
 
-       \item $\vleone$ is the result of annotating \texttt{le} with \texttt{t\_e} in $\tenvone$;
+       \item $\vleone$ is the result of annotating $\vle$ with $\vte$ in $\tenvone$;
        \item $\news$ is the assignment \texttt{le1 = e1};
        \item $\newenv$ is $\tenvone$.
        \end{itemize}
@@ -7411,7 +7449,7 @@ environment $\newenv$ and all of the following apply:
    \begin{itemize}
    \item $\vs$ is a case statement with expression $\ve$ and cases \texttt{cases};
    \item \texttt{t\_e, e1} is the result of annotating $\ve$ in $\tenv$;
-   \item \texttt{cases1, env1} is the result of annotating each case in \texttt{cases} given \texttt{t\_e};
+   \item \texttt{cases1, env1} is the result of annotating each case in \texttt{cases} given $\vte$;
    \item $\news$ is a case statement with expression $\veone$ and cases \texttt{cases1};
    \item $\newenv$ is $\tenvone$.
    \end{itemize}
@@ -7714,8 +7752,8 @@ environment $\newenv$ and all of the following apply:
    \begin{itemize}
    \item $\vs$ is a throw statement with expression $\ve$;
    \item \texttt{t\_e,\vep} is the result of annotating $\ve$ in $\tenv$;
-   \item \texttt{t\_e} has the structure of an exception type;
-   \item $\news$ is a throw statement with expression $\vep$ and type \texttt{t\_e};
+   \item $\vte$ has the structure of an exception type;
+   \item $\news$ is a throw statement with expression $\vep$ and type $\vte$;
    \item $\newenv$ is $\tenv$.
    \end{itemize}
 
@@ -10637,6 +10675,28 @@ If the answer is positive, the result is $\True$. Otheriwe, the result is a type
 }
 \end{mathpar}
 \end{emptyformal}
+
+\section{AssocOpt}
+\hypertarget{def-assocopt}{}
+The function
+\[
+  \assocopt(\overname{(\identifier\times T)^*}{\vli} \aslsep \overname{\identifier}{\id}) \typearrow \langle \overname{T}{\vv} \rangle
+\]
+returns the value $\vv$ associated with the identifier $\id$ in the list of pairs $\vli$ or $\None$, if no such association exists.
+
+\begin{mathpar}
+\inferrule[not\_member]{
+  (\vx, \vv) \in \vli: vx \neq \id
+}{
+  \assocopt(\vli, \id) \typearrow \None
+}
+\and
+\inferrule[member]{
+  (\id, \vv) \in \vli
+}{
+  \assocopt(\vli, \id) \typearrow \langle \vv \rangle
+}
+\end{mathpar}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \bibliographystyle{plain}

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -129,7 +129,7 @@
 \newcommand\annotatelexpr[1]{\textsf{annotate\_lexpr}(#1)}
 \newcommand\annotatearrayindex[0]{\textsf{annotate\_array\_index}}
 \newcommand\annotateslices[0]{\textsf{annotate\_slices}}
-\newcommand\annotatelocaldeclitem[1]{\texttt{annotate\_local\_decl\_item}(#1)}
+\newcommand\annotatelocaldeclitem[1]{\hyperlink{def-annotatelocaldeclitem}{\texttt{annotate\_local\_decl\_item}}(#1)}
 \newcommand\annotatestmt[1]{\texttt{annotate\_stmt}(#1)}
 \newcommand\annotateblock[1]{\texttt{annotate\_block}(#1)}
 \newcommand\inlinesetter[1]{\texttt{setter\_should\_reduce\_to\_call\_s}(#1)}
@@ -138,7 +138,8 @@
 \newcommand\reduceconstants[1]{\texttt{reduce\_constants}(#1)}
 \newcommand\declarelocalconstant[1]{\texttt{declare\_local\_constant}(#1)}
 \newcommand\annotatelocaldeclitemuninit[1]{\texttt{annotate\_local\_decl\_item\_uninit}(#1)}
-\newcommand\checkvarnotinenv[1]{\texttt{check\_var\_not\_in\_env}(#1)}
+\newcommand\checkvarnotinenv[1]{\hyperlink{def-checkvarnotinenv}{\texttt{check\_var\_not\_in\_env}}(#1)}
+\newcommand\varinenv[1]{\hyperlink{def-varinenv}{\texttt{var\_in\_env}}(#1)}
 \newcommand\annotatesubprogram[1]{\texttt{annotate\_subprogram}(#1)}
 \newcommand\declaredecl[1]{\texttt{annotate\_decl}(#1)}
 \newcommand\annotatespec[1]{\texttt{annotate\_spec}(#1)}
@@ -159,6 +160,7 @@
 \newcommand\checknoduplicates[0]{\hyperlink{def-checknoduplicates}{\texttt{check\_no\_duplicates}}}
 \newcommand\reduceslicestocall[0]{\hyperlink{def-reduceslicestocall}{\texttt{reduce\_slices\_to\_call}}}
 \newcommand\typeofarraylength[0]{\hyperlink{def-typeofarraylength}{\texttt{type\_of\_array\_length}}}
+\newcommand\addlocal[0]{\hyperlink{def-addlocal}{\texttt{add\_local}}}
 
 % Symbolic domain subsumption
 \newcommand\symdom[0]{\hyperlink{def-symdom}{\textsf{sym\_dom}}}
@@ -403,7 +405,7 @@ Static environments, denoted as $\staticenvs$, are defined as follows (referring
 \begin{array}{rcl}
 \staticenvs 	          &\triangleq& \mathbb{G} \times \mathbb{L}\\
 \mathbb{G} 	            &\triangleq& \declaredtypes \times \constantvalues \times \globalstoragetypes\\
-  			                & & \times\ \subtypes \times \subprograms \times \subprogramrenamings\\
+  			                &          & \times\ \subtypes \times \subprograms \times \subprogramrenamings\\
 \mathbb{L} 	            &\triangleq& \constantvalues \times \localstoragetypes \times \returntype\\
 \hline
 \declaredtypes	        &\triangleq& \identifier \partialto \ty\\
@@ -4489,17 +4491,6 @@ All of the following apply:
 
 \CodeSubsection{\ERecordBegin}{\ERecordEnd}{../Typing.ml}
 
-  % \item For each field named $\name$ associated with the expression $\vep$ in
-  %   $\fieldtypes$, all of the following apply:
-  %   \begin{itemize}
-  %   \item $(\vtp,\vepp)$ is the result of annotating $\vep$ in $\tenv$;
-  %   \item $\tspecp$ is the type associated to $\name$ in $\fieldtypes$;
-  %   \item $\vtp$ \typesatisfies\  $\tspecp$ as per \secref{TypingRule.TypeSatisfaction};
-  %   \item $\fieldsp$ associates $\name$ to $\vepp$;
-  %   \end{itemize}
-  % \item $\vt$ is $\tty$;
-  % \item $\newe$ is the record expression of type $\tty$ with fields $\fieldsp$.
-
 \begin{emptyformal}
 \subsection{Formally}
 \begin{mathpar}
@@ -4524,18 +4515,16 @@ All of the following apply:
   This is related to \identr{WBCQ}.
 
 \section{TypingRule.EGetRecordField \label{sec:TypingRule.EGetRecordField}}
-
-  \subsection{Prose}
-  The result of annotating the expression $\ve$ in $\tenv$ is
-$(\vt, \newe)$ and all of the following apply:
-  \begin{itemize}
-  \item $\ve$ denotes the access of field \texttt{field\_name} on expression $\veone$;
-  \item \texttt{t\_e1, e2} is the result of annotating $\veone$ in $\tenv$;
-  \item \texttt{t\_e1} has an \underlyingtype\ of an exception or record type with fields $\fields$;
-  \item \texttt{field\_name} is declared in $\fields$;
-  \item $\vt$ is the type corresponding to \texttt{field\_name} in $\fields$;
-  \item $\newe$ is the access of field \texttt{field\_name} on expression \vetwo.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item $(\vteone, \vetwo)$ is the result of annotating $\veone$ in $\tenv$;
+  \item $\vteone$ has an \underlyingtype\ of an exception or record type with fields $\fields$;
+  \item $\fieldname$ is declared in $\fields$;
+  \item $\vt$ is the type corresponding to $\fieldname$ in $\fields$;
+  \item $\newe$ is the access of field $\fieldname$ on expression $\vetwo$.
+\end{itemize}
 
 \subsection{Example}
 
@@ -4545,12 +4534,13 @@ $(\vt, \newe)$ and all of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-\annotateexpr{\tenv, \veone} \typearrow (\texttt{t\_e1}, \vetwo)\\
-\makeanonymous(\tenv, \texttt{t\_e1}) \typearrow L(\fields)\\
-L \in \{\TRecord, \TException\}\\
-(\fieldname,\vt) \in \fields
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\
+  \makeanonymous(\tenv, \vteone) \typearrow L(\fields) \OrTypeError\\
+  L \in \{\TRecord, \TException\}\\
+  (\fieldname,\vt) \in \fields
+}{
+  \annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \EGetField(\fieldname, \vetwo))
 }
-{\annotateexpr{\tenv, \EGetField(\veone, \fieldname)} \typearrow (\vt, \EGetField(\fieldname, \vetwo))}
 \end{mathpar}
 \end{emptyformal}
 
@@ -4562,12 +4552,12 @@ L \in \{\TRecord, \TException\}\\
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
   \begin{itemize}
-  \item $\ve$ denotes the access of field \texttt{field\_name} on expression $\veone$;
-  \item \texttt{t\_e1, e2} is the result of annotating $\veone$ in $\tenv$;
-  \item \texttt{t\_e1} has the structure of an exception or record type with fields $\fields$;
-  \item \texttt{t\_e2} has the structure of an exception or record type with fields $\fields$;
-  \item \texttt{t\_e2} is an Exception or a Record type with fields $\fields$;
-  \item \texttt{field\_name} is not declared in $\fields$;
+  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item \texttt{\vteone, $\vetwo$} is the result of annotating $\veone$ in $\tenv$;
+  \item $\vteone$ has the structure of an exception or record type with fields $\fields$;
+  \item $\vtetwo$ has the structure of an exception or record type with fields $\fields$;
+  \item $\vtetwo$ is an Exception or a Record type with fields $\fields$;
+  \item $\fieldname$ is not declared in $\fields$;
   \item an error ``\texttt{Bad Field}'' is raised.
   \end{itemize}
 
@@ -4589,10 +4579,10 @@ $(\vt, \newe)$ and all of the following apply:
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
   \begin{itemize}
-  \item $\ve$ denotes the access of field \texttt{field\_name} on expression $\veone$;
-  \item \texttt{t\_e1} has the structure a bitvector type with bitfields $\bitfields$;
-  \item \texttt{t\_e2} has the structure a bitvector type with bitfields $\bitfields$;
-  \item \texttt{field\_name} is not declared in $\bitfields$;
+  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item $\vteone$ has the structure a bitvector type with bitfields $\bitfields$;
+  \item $\vtetwo$ has the structure a bitvector type with bitfields $\bitfields$;
+  \item $\fieldname$ is not declared in $\bitfields$;
   \item an error ``\texttt{Bad Field}'' is raised.
   \end{itemize}
 
@@ -4614,9 +4604,9 @@ $(\vt, \newe)$ and all of the following apply:
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
    \begin{itemize}
-   \item $\ve$ denotes the access of field \texttt{field\_name} on expression $\veone$;
-   \item \texttt{t\_e1, e2} is the result of annotating $\veone$ in $\tenv$;
-   \item \texttt{t\_e1} does not have the structure of a record or an exception or a bitvector type;
+   \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+   \item \texttt{\vteone, e2} is the result of annotating $\veone$ in $\tenv$;
+   \item $\vteone$ does not have the structure of a record or an exception or a bitvector type;
    \item an error ``\texttt{Conflicting Types}'' is raised.
    \end{itemize}
 
@@ -4638,11 +4628,11 @@ $(\vt, \newe)$ and all of the following apply:
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
   \begin{itemize}
-  \item $\ve$ denotes the access of field \texttt{field\_name} on expression $\veone$;
-  \item \texttt{t\_e1, e2} is the result of annotating $\veone$ in $\tenv$;
-  \item the \underlyingtype\ of \texttt{t\_e1} is a bitvector type with bitfields $\bitfields$;
-  \item \texttt{field\_name} is declared in $\bitfields$;
-  \item $\slices$ gives the slices corresponding to the bitfield \texttt{field\_name}
+  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item \texttt{\vteone, e2} is the result of annotating $\veone$ in $\tenv$;
+  \item the \underlyingtype\ of $\vteone$ is a bitvector type with bitfields $\bitfields$;
+  \item $\fieldname$ is declared in $\bitfields$;
+  \item $\slices$ gives the slices corresponding to the bitfield $\fieldname$
     in \\ $\bitfields$;
   \item \texttt{e3} denotes the slicing of the expression \vetwo by the slices $\slices$;
   \item $(\vt, \newe)$ is the result of annotating \texttt{e3}.
@@ -4657,8 +4647,8 @@ $(\vt, \newe)$ and all of the following apply:
     \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-\annotateexpr{\tenv, \veone} \typearrow (\texttt{t\_e1}, \vetwo)\\
-\makeanonymous(\tenv, \texttt{t\_e1}) \typearrow \TBits(\Ignore, \bitfields)\\
+\annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo)\\
+\makeanonymous(\tenv, \vteone) \typearrow \TBits(\Ignore, \bitfields)\\
 \fieldname = \texttt{BitField\_Simple}(\Ignore, \slices) \in \bitfields\\
 \texttt{e3} = \ESlice(\vetwo, \slices)\\
 \annotateexpr{\tenv, \texttt{e3}} \typearrow (\vt, \newe)
@@ -4675,15 +4665,15 @@ $(\vt, \newe)$ and all of the following apply:
   The result of annotating the expression $\ve$ in $\tenv$ is
 $(\vt, \newe)$ and all of the following apply:
   \begin{itemize}
-  \item $\ve$ denotes the access of field \texttt{field\_name} on expression $\veone$;
-  \item \texttt{t\_e1, e2} is the result of annotating $\veone$ in $\tenv$;
-  \item \texttt{t\_e1} has the structure of a bitvector type with bitfields $\bitfields$;
-  \item \texttt{field\_name} is declared in $\bitfields$;
-  \item $\slices$ gives the slices corresponding to the bitfield \texttt{field\_name} in \\
+  \item $\ve$ denotes the access of field $\fieldname$ on expression $\veone$;
+  \item \texttt{\vteone, e2} is the result of annotating $\veone$ in $\tenv$;
+  \item $\vteone$ has the structure of a bitvector type with bitfields $\bitfields$;
+  \item $\fieldname$ is declared in $\bitfields$;
+  \item $\slices$ gives the slices corresponding to the bitfield $\fieldname$ in \\
     $\bitfields$;
   \item \texttt{e3} denotes the slicing of the expression \vetwo by the slices $\slices$;
   \item \texttt{t4, e4} is the result of annotating \texttt{e3} in $\tenv$;
-  \item $\bitfieldsp$ gives the bitfields corresponding to the bitfield \texttt{field\_name}
+  \item $\bitfieldsp$ gives the bitfields corresponding to the bitfield $\fieldname$
     in $\bitfields$;
   \item $\vt$ is the bitvector type with the width of \texttt{t4} and the bitfields $\bitfieldsp$
   \item $\newe$ is \texttt{e4}.
@@ -4707,14 +4697,14 @@ $(\vt, \newe)$ and all of the following apply:
 $(\vt, \newe)$ and all of the following apply:
   \begin{itemize}
   \item $\ve$ denotes \texttt{e1, field\_name};
-  \item \texttt{t\_e1, e2} is the result of annotating $\veone$ in $\tenv$;
-  \item \texttt{t\_e1} has the \underlyingtype\ of a bitvector with bitfields $\bitfields$;
-  \item \texttt{field\_name} is declared in $\bitfields$;
-  \item $\slices$ gives the slices corresponding to the bitfield \texttt{field\_name} in \\
+  \item $(\vteone, \vetwo)$ is the result of annotating $\veone$ in $\tenv$;
+  \item $\vteone$ has the \underlyingtype\ of a bitvector with bitfields $\bitfields$;
+  \item $\fieldname$ is declared in $\bitfields$;
+  \item $\slices$ gives the slices corresponding to the bitfield $\fieldname$ in \\
     $\bitfields$;
-  \item $\vt$ is the type associated with \texttt{field\_name} in $\bitfields$;
-  \item \texttt{t\_e3,e3} is the result of annotating \texttt{e2,slices} in $\tenv$;
-  \item $\vt$ is the type corresponding to the bitfield \texttt{field\_name} in $\bitfields$;
+  \item $\vt$ is the type associated with $\fieldname$ in $\bitfields$;
+  \item \texttt{t\_e3,e3} is the result of annotating \texttt{\vetwo,slices} in $\tenv$;
+  \item $\vt$ is the type corresponding to the bitfield $\fieldname$ in $\bitfields$;
   \item \texttt{t\_e3} \typesatisfies\  $\vt$ in $\tenv$;
   \item $\newe$ is \texttt{e3}.
   \end{itemize}
@@ -4727,8 +4717,8 @@ $(\vt, \newe)$ and all of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \annotateexpr{\tenv, \veone} \typearrow (\texttt{t\_e1}, \vetwo)\\
-  \makeanonymous(\tenv, \texttt{t\_e1}) \typearrow \TBits(\Ignore, \bitfields)\\
+  \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo)\\
+  \makeanonymous(\tenv, \vteone) \typearrow \TBits(\Ignore, \bitfields)\\
   \fieldname = \texttt{BitField\_Type}(\Ignore, \slices, \vt) \in \bitfields\\
   \annotateexpr{\ESlice(\vetwo, \slices)} \typearrow (\texttt{t\_e3}, \texttt{e3})\\
   \typesat(\tenv, \texttt{t\_e3}, \vt)
@@ -5378,15 +5368,15 @@ all of the following apply:
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
    \begin{itemize}
-   \item \texttt{le} denotes the slicing of a left-hand-side expression \texttt{le1} by the slices $\slices$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to \texttt{le1} in $\tenv$;
+   \item \texttt{le} denotes the slicing of a left-hand-side expression $\vleone$ by the slices $\slices$;
+   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
    \item \texttt{t\_le1} has the structure of a bitvector type;
-   \item \texttt{le2} is the result of annotating \texttt{le1} in $\tenv$;
+   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
    \item \texttt{width} is the width of the slices $\slices$ in $\tenv$;
    \item $\vt$ is the bitvector type of width \texttt{width};
    \item \texttt{te} \typesatisfies\  $\vt$;
    \item \texttt{slices2} is the result of annotating $\slices$ in $\tenv$;
-   \item \texttt{new\_le} is the slicing of \texttt{le2} by \texttt{slices2}.
+   \item \texttt{new\_le} is the slicing of $\vletwo$ by \texttt{slices2}.
    \end{itemize}
 
   \subsection{Example}
@@ -5423,11 +5413,11 @@ all of the following apply:
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
    \begin{itemize}
-   \item \texttt{le} denotes the slicing of a left-hand-side expression \texttt{le1} by the slices $\slices$;
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to \texttt{le1} in $\tenv$;
+   \item \texttt{le} denotes the slicing of a left-hand-side expression $\vleone$ by the slices $\slices$;
+   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
    \item \texttt{t\_le1} has the structure of an array type of size $\size$ and item type $\vt$;
    \item \texttt{te} \typesatisfies\  $\vt$;
-   \item \texttt{le2} is the result of annotating \texttt{le1} in $\tenv$;
+   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
   % ROMAN: The following is not what the code does so I replaced it with subsequent item.
   %  \item One of the following applies:
   %    \begin{itemize}
@@ -5439,7 +5429,7 @@ all of the following apply:
    \item $(\tindexp, \eindexp)$ is the result of annotating $\eindex$ in $\tenv$;
    \item $\wantedtindex$ \typesatisfies\  $\tindexp$, which guarantees that the index
    is within the bounds of the array;
-   \item \texttt{new\_le} is an access to array \texttt{le2} at index $\eindexp$.
+   \item \texttt{new\_le} is an access to array $\vletwo$ at index $\eindexp$.
    \end{itemize}
 
   \subsection{Example}
@@ -5476,9 +5466,9 @@ all of the following apply:
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
    \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in \texttt{le1};
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to \texttt{le1} in $\tenv$;
-   \item \texttt{le2} is the result of annotating \texttt{le1} in $\tenv$;
+   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
+   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
+   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
    \item \texttt{t\_le1} has the structure of an exception or a record type with fields $\fields$;
    \item \texttt{field} is not declared in $\fields$;
    \item an error ``\texttt{Bad Field}'' is raised.
@@ -5503,13 +5493,13 @@ all of the following apply:
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
    \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in \texttt{le1};
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to \texttt{le1} in $\tenv$;
-   \item \texttt{le2} is the result of annotating \texttt{le1} in $\tenv$;
+   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
+   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
+   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
    \item \texttt{t\_le1} has the structure of an exception or a record type with fields $\fields$;
    \item \texttt{field} is bound to type $\vt$ in $\fields$;
    \item $\vt$ \typesatisfies\  \texttt{t\_e};
-   \item \texttt{new\_le} is the access to the field \texttt{field} in \texttt{le2}.
+   \item \texttt{new\_le} is the access to the field \texttt{field} in $\vletwo$.
    \end{itemize}
 
   \subsection{Example}
@@ -5545,9 +5535,9 @@ all of the following apply:
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
    \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in \texttt{le1};
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to \texttt{le1} in $\tenv$;
-   \item \texttt{le2} is the result of annotating \texttt{le1} in $\tenv$;
+   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
+   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
+   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
    \item \texttt{t\_le1} has the structure of a bitvector with bitfields $\bitfields$;
    \item \texttt{field} is not declared in $\bitfields$;
    \item an error ``\texttt{Bad Field}'' is raised.
@@ -5572,9 +5562,9 @@ all of the following apply:
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
    \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in \texttt{le1};
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to \texttt{le1} in $\tenv$;
-   \item \texttt{le2} is the result of annotating \texttt{le1} in $\tenv$;
+   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
+   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
+   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
    \item \texttt{t\_le1} has the structure of a bitvector with bitfields $\bitfields$;
    \item \texttt{field} is declared in $\bitfields$;
    \item $\slices$ gives the slices corresponding to the bitfield \texttt{field} in
@@ -5582,8 +5572,8 @@ all of the following apply:
    \item $\vw$ is the width of $\slices$;
    \item $\vt$ is the bitvector type of width $\vw$;
    \item $\vt$ \typesatisfies\  \texttt{t\_e};
-   \item \texttt{le2} is the slicing of \texttt{le1} by $\slices$;
-   \item \texttt{new\_le} is the result of annotating \texttt{le2} in $\tenv$.
+   \item $\vletwo$ is the slicing of $\vleone$ by $\slices$;
+   \item \texttt{new\_le} is the result of annotating $\vletwo$ in $\tenv$.
    \end{itemize}
 
   \subsection{Example}
@@ -5622,9 +5612,9 @@ all of the following apply:
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
    \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in \texttt{le1};
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to \texttt{le1} in $\tenv$;
-   \item \texttt{le2} is the result of annotating \texttt{le1} in $\tenv$;
+   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
+   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
+   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
    \item \texttt{t\_le1} has the structure of a bitvector with bitfields $\bitfields$;
    \item $\slices$ gives the slices corresponding to the bitfield \texttt{field} in
       $\bitfields$;
@@ -5632,8 +5622,8 @@ all of the following apply:
    \item $\bitfieldsp$ gives the bitfields corresponding to \texttt{field} in $\bitfields$;
    \item $\vt$ is the bitvector type of width $\vw$ and bitfields $\bitfieldsp$;
    \item $\vt$ \typesatisfies\  \texttt{t\_e};
-   \item \texttt{le2} is the slicing of \texttt{le1} by $\slices$;
-   \item \texttt{new\_le} is the result of annotating \texttt{le2} in $\tenv$.
+   \item $\vletwo$ is the slicing of $\vleone$ by $\slices$;
+   \item \texttt{new\_le} is the result of annotating $\vletwo$ in $\tenv$.
    \end{itemize}
 
   \subsection{Example}
@@ -5672,9 +5662,9 @@ all of the following apply:
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
    \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in \texttt{le1};
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to \texttt{le1} in $\tenv$;
-   \item \texttt{le2} is the result of annotating \texttt{le1} in $\tenv$;
+   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
+   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
+   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
    \item \texttt{t\_le1} has the structure of a bitvector with bitfields $\bitfields$;
    \item $\slices$ gives the slices corresponding to the bitfield \texttt{field} in
       $\bitfields$;
@@ -5684,8 +5674,8 @@ all of the following apply:
       $\bitfields$;
    \item $\vt$ \typesatisfies\  \texttt{t'};
    \item $\vt$ \typesatisfies\  \texttt{t\_e};
-   \item \texttt{le2} is the slicing of \texttt{le1} by $\slices$;
-   \item \texttt{new\_le} is the result of annotating \texttt{le2} in $\tenv$.
+   \item $\vletwo$ is the slicing of $\vleone$ by $\slices$;
+   \item \texttt{new\_le} is the result of annotating $\vletwo$ in $\tenv$.
    \end{itemize}
 
   \subsection{Example}
@@ -5725,9 +5715,9 @@ all of the following apply:
 (\texttt{annotate\_lexpr version env le t\_e}), results in \texttt{new\_le} and
 all of the following apply:
    \begin{itemize}
-   \item \texttt{le} denotes the access to the field named \texttt{field} in \texttt{le1};
-   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to \texttt{le1} in $\tenv$;
-   \item \texttt{le2} is the result of annotating \texttt{le1} in $\tenv$;
+   \item \texttt{le} denotes the access to the field named \texttt{field} in $\vleone$;
+   \item \texttt{t\_le1} is the type result of annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$;
+   \item $\vletwo$ is the result of annotating $\vleone$ in $\tenv$;
    \item \texttt{t\_le1} does not have the structure of a record, or an exception or a bitvector type;
    \item an error ``\texttt{Conflicting Types}'' is raised.
    \end{itemize}
@@ -6045,20 +6035,20 @@ Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt
    \begin{itemize}
    \item \texttt{p} is the pattern which matches anything within the range given by
       expressions $\veone$ and \vetwo;
-   \item \texttt{t\_e1, e1'} is the result of annotating $\veone$ in $\tenv$;
-   \item \texttt{t\_e2, e2'} is the result of annotating \vetwo in $\tenv$;
+   \item \texttt{\vteone, e1'} is the result of annotating $\veone$ in $\tenv$;
+   \item \texttt{\vtetwo, e2'} is the result of annotating $\vetwo$ in $\tenv$;
    \item e1' and e2' are compile-time constant expressions;
    \item One of the following applies:
      \begin{itemize}
      \item All of the following apply:
            \begin{itemize}
-           \item both \texttt{t\_e1} and \texttt{t\_e2} have the structure of an integer;
+           \item both $\vteone$ and $\vtetwo$ have the structure of an integer;
            \item \texttt{new\_p} is the pattern which matches anything within the range given by
       expressions $\veonep$ and $\vetwop$.
            \end{itemize}
      \item All of the following apply:
            \begin{itemize}
-           \item both \texttt{t\_e1} and \texttt{t\_e2} have the structure of a real;
+           \item both $\vteone$ and $\vtetwo$ have the structure of a real;
            \item \texttt{new\_p} is the pattern which matches anything within the range given by
       expressions $\veonep$ and $\vetwop$.
            \end{itemize}
@@ -6230,9 +6220,26 @@ Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Local Declarations}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\hypertarget{def-annotatelocaldeclitem}{}
+The function
+\[
+  \begin{array}{c}
+  \annotatelocaldeclitem{
+    \overname{\staticenvs}{\tenv} \aslsep
+    \overname{\localdeclkeyword}{\ldk} \aslsep
+    \overname{\localdeclitem}{\ldi} \aslsep
+    \overname{\ty}{\tty}
+   } \aslto\\
+  (\overname{\staticenvs}{\newtenv} \aslsep \overname{\localdeclitem}{\newldi})
+  \cup \overname{\TTypeError}{\TypeErrorConfig}
+  \end{array}
+\]
+annotates a local declaration item $\ldi$ with a local declaration keyword $\ldk$, given a type $\tty$,
+in a static environment $\tenv$ results in $(\newenv, \newldi)$ where $\newenv$ is the modified
+static environment and $\newldi$ is the annotated local declaration item.
+A type error is returned, if one is detected.
 
-Annotating a local declaration~\texttt{ldi} with a local declaration keyword \texttt{ldk}, given a type $\tty$, in an
-environment $\tenv$ (\annotatelocaldeclitem{\ldk, \ldi, \tty}) results in \texttt{new\_env, new\_ldi} and one of the following applies:
+One of the following applies:
 \begin{itemize}
 \item TypingRule.LDDiscard (see \secref{TypingRule.LDDiscard}),
 \item TypingRule.LDVar (see \secref{TypingRule.LDVar}),
@@ -6244,29 +6251,25 @@ This is related to \identr{YSPM}.
 
 \section{TypingRule.LDDiscard \label{sec:TypingRule.LDDiscard}}
 
-  \subsection{Prose}
-    Annotating a local declaration~\texttt{ldi} with a local declaration keyword \texttt{ldk}, given a type $\tty$, in
-an environment $\tenv$ results in \texttt{new\_env, new\_ldi} and all of
-the following apply:
-   \begin{itemize}
-   \item \texttt{ldi} is a local declaration which can be discarded;
-   \item $\newenv$ is $\tenv$;
-   \item \texttt{new\_ldi} is \texttt{ldi}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ldi$ is a local declaration which can be discarded, that is, $\LDIDiscard(\None)$;
+  \item $\newenv$ is $\tenv$;
+  \item $\newldi$ is $\ldi$.
+\end{itemize}
 
-  \subsection{Example}
-    \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDDiscard.asl}
+\subsection{Example}
+\VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDDiscard.asl}
 
-
-    \CodeSubsection{\LDDiscardBegin}{\LDDiscardEnd}{../Typing.ml}
+\CodeSubsection{\LDDiscardBegin}{\LDDiscardEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule{
-    \ldi = \texttt{LDI\_Discard}(\None)\\
-  }
-  {\annotatelocaldeclitem{\tenv, \ldi, \ldk, \tty} \typearrow (\tenv, \ldi)}
+\inferrule{}{
+  \annotatelocaldeclitem{\tenv, \LDIDiscard(\None), \ldk, \tty} \typearrow (\tenv, \ldi)
+}
 \end{mathpar}
 \end{emptyformal}
 
@@ -6274,34 +6277,29 @@ the following apply:
 
 \section{TypingRule.LDVar \label{sec:TypingRule.LDVar}}
 
-  \subsection{Prose}
-    Annotating a local declaration~\texttt{ldi} with a local declaration keyword \texttt{ldk}, given a type $\tty$, in
-an environment $\tenv$ results in \texttt{new\_env, new\_ldi} and all of
-the following apply:
-   \begin{itemize}
-   \item \texttt{ldi} denotes a variable $\vx$;
-   \item $\vx$ is not declared in $\tenv$;
-   \item $\newenv$ is $\tenv$ modified so that $\vx$ is locally declared of type $\tty$;
-   \item \texttt{new\_ldi} is the declaration of variable $\vx$ with type $\tty$.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ldi$ denotes a variable $\vx$, that is, $\LDIVar(\vx)$;
+  \item determing whether $\vx$ is not declared in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item $\newenv$ is $\tenv$ modified so that $\vx$ is locally declared of type $\tty$;
+  \item $\newldi$ is the declaration of variable $\vx$.
+\end{itemize}
 
-  \subsection{Example}
-    \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDVar.asl}
+\subsection{Example}
+\VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDVar.asl}
 
-
-    \CodeSubsection{\LDVarBegin}{\LDVarEnd}{../Typing.ml}
+\CodeSubsection{\LDVarBegin}{\LDVarEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule{
-    \ldi = \texttt{LDI\_Var}(\vx)\\
-    L^\tenv.\localstoragetypes(\vx) = \bot\\
-    \newtenv = (G^\tenv, L^\tenv.\localstoragetypes[\vx \mapsto (\tty, \ldk)])
-  }
-  {
-    \annotatelocaldeclitem{\tenv, \ldi, \ldk, \tty} \typearrow (\newtenv, \texttt{LDI\_Var}(\vx))
-  }
+\inferrule{
+  \checkvarnotinenv{\tenv, \vx} \typearrow \True \OrTypeError\\
+  \addlocal(\tenv, \vx, \ldk) \typearrow \newtenv
+}{
+  \annotatelocaldeclitem{\tenv, \LDIVar(\vx), \ldk, \tty} \typearrow (\newtenv, \LDIVar(\vx))
+}
 \end{mathpar}
 \end{emptyformal}
 
@@ -6310,37 +6308,34 @@ This is related to \identr{YSPM}, \identd{FXST}.
 
 \section{TypingRule.LDTyped\label{sec:TypingRule.LDTyped}}
 
-  \subsection{Prose}
-    Annotating a local declaration~\texttt{ldi} with a local declaration
-    keyword \texttt{ldk}, given a type $\tty$, in an
-    environment $\tenv$ results in \texttt{new\_env, new\_ldi} and all of
-    the following apply:
-    \begin{itemize}
-      \item \texttt{ldi} denotes a local declaration item \texttt{ldi'} and a type $\vt$;
-      \item $\vt$ can be initialized with $\tty$ in $\tenv$;
-      \item $\newenv$, \texttt{new\_ldi'} is the result of the annotation of
-        \texttt{ldi'} with the local declaration keyword \texttt{ldk}, given
-        the type $\vt$, in the environment $\tenv$;
-      \item \texttt{new\_ldi} is the local declaration denoting \texttt{new\_ldi'} and the type $\vt$.
-    \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ldi$ denotes a local declaration item $\ldip$ with local declaration keyword $\ldk$
+  and a type $\vt$, that is $\LDITyped(\ldip, \vt)$;
+  \item annotating the type $\vt$ in $\tenv$ yields $\vtp$ \ProseOrTypeError;
+  \item determining whether $\vtp$ can be initialized with $\tty$ in $\tenv$ yields $\True$ \ProseOrTypeError;
+  \item anotating the local declaration item $\ldip$ with the local declaration keyword $\ldk$, given
+  the type $\vt$, in the environment $\tenv$, yields $(\newtenv,\newldip)$;
+  \item $\newldi$ is the local declaration denoting $\newldip$ and the type $\vtp$, that is, $\LDITyped(\newldip, \vtp)$.
+\end{itemize}
 
-    \subsection{Example}
-      \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDTyped.asl}
+\subsection{Example}
+\VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDTyped.asl}
 
-
-      \CodeSubsection{\LDTypedBegin}{\LDTypedEnd}{../Typing.ml}
+\CodeSubsection{\LDTypedBegin}{\LDTypedEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \ldi = \texttt{LDI\_Typed}(\ldi', \vt)\\
-  \canbeinitializedwith(\tenv, \vt, \tty)\\
-  \annotatelocaldeclitem{\tenv, \ldi', \ldk, \vt} \typearrow (\newtenv, \newldi')\\
-  \newldi = \texttt{LDI\_Typed}(\newldi', \vt)\\
+  \annotatetype{\tenv, \vt} \typearrow \vtp \OrTypeError\\
+  \canbeinitializedwith(\tenv, \vtp, \tty) \typearrow \True \OrTypeError\\
+  \annotatelocaldeclitem{\tenv, \ldip, \ldk, \vtp} \typearrow (\newtenv, \newldip) \OrTypeError
 }
 {
-  \annotatelocaldeclitem{\tenv, \ldi, \ldk, \tty} \typearrow (\newtenv, \newldi)
+  \annotatelocaldeclitem{\tenv, \LDITyped(\ldip, \vt), \ldk, \tty} \typearrow \\
+  (\newtenv, \LDITyped(\newldip, \vtp))
 }
 \end{mathpar}
 \end{emptyformal}
@@ -6349,40 +6344,40 @@ This is related to \identr{YSPM}, \identd{FXST}.
 
 \section{TypingRule.LDTuple\label{sec:TypingRule.LDTuple}}
 
-  \subsection{Prose}
-    Annotating a local declaration~\texttt{ldi} with a local declaration keyword \texttt{ldk}, given a type $\tty$, in
-an environment $\tenv$ results in \texttt{new\_env, new\_ldi} and all of
-the following apply:
-  \begin{itemize}
-  \item \texttt{ldi} denotes a list \texttt{ldis};
-  \item $\tty$ has the structure of a tuple type of the same length as~\texttt{ldis};
-  \item $\newenv$ is $\tenv$ modified so that each element in \texttt{ldis} is annotated with the corresponding type in $\tty$;
-  \item \texttt{new\_ldi} is \texttt{ldis} where each element is declared with
-the corresponding type in  $\tty$.
-  \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ldi$ denotes a tuple of local declaration items $\ldi_{1..k}$, that is, $\LDITuple(\ldi_{1..k})$;
+  \item determining the \structure\ of $\tty$ in $\tenv$ yields $\vtp$ \ProseOrTypeError;
+  \item determining whether $\vtp$ is a tuple type with $k$ elements yields $\True$ \ProseOrTypeError;
+  \item annotating the local declaration items in $\ldis$ from right to left with their corresponding
+  (that is, with the same index) types $t_{1..k}$ in $\tenv$,
+  propagating static environments from one annotation to the next,
+  yields the local delcaration items $\ldip_{1..k}$ \ProseOrTypeError;
+  \item $\newtenv$ is the static environment yielded by annotating $\ldi_1$;
+  \item $\newldi$ is a tuple of local declaration items with $\ldip_{1..k}$, that is, $\LDITuple(\ldip_{1..k})$.
+\end{itemize}
 
-  \subsection{Example}
-    \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDTuple.asl}
+\subsection{Example}
+\VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDTuple.asl}
 
-
-    \CodeSubsection{\LDTupleBegin}{\LDTupleEnd}{../Typing.ml}
+\CodeSubsection{\LDTupleBegin}{\LDTupleEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \ldi = \texttt{LDI\_Tuple}(\ldis, \None)\\
-  \ldis = [\ldi_{1..k}]\\
-  \tstruct(\tenv, \tty) \typearrow \TTuple([\vt_{1..k}])\\
-  \newtenv_0 = \tenv\\
-  \annotatelocaldeclitem{\newtenv_0, \ldi_1, \ldk, \vt_1} \typearrow (\newtenv_1, \ldi_1)\\
-  \ldots\\
-  \annotatelocaldeclitem{\newtenv_{k-1}, \ldi_{k-1}, \ldk, \vt_{k-1}} \typearrow (\newtenv_k, \ldi_k)\\
-  \newtenv = \newtenv_k\\
-  \newldi = [\ldi_{1..k}]
-}
-{
-  \annotatelocaldeclitem{\tenv, \ldi, \ldk, \tty} \typearrow (\newtenv, \texttt{LDI\_Tuple}(\newldi, \None))
+  \tstruct(\tenv, \tty) \typearrow \vtp \OrTypeError\\\\
+  \checktrans{\astlabel(\vtp) = \TTuple} \typearrow \True \OrTypeError\\\\
+  \vtp \eqname \TTuple([\vt_{1..n}])\\\\
+  \checktrans{k = n} \typearrow \True \OrTypeError\\\\
+  \newtenv_k = \tenv\\
+  i=k..1:
+  \annotatelocaldeclitem{\newtenv_{i}, \ldi_{i}, \ldk, \vt_{i}} \typearrow (\newtenv_{i-1}, \ldip_i) \OrTypeError\\\\
+  \newtenv = \newtenv_0
+}{
+  \annotatelocaldeclitem{\tenv, \LDITuple(\ldi_{1..k}), \ldk, \tty} \typearrow \\
+  (\newtenv, \LDITuple(\ldip_{1..k}))
 }
 \end{mathpar}
 \end{emptyformal}
@@ -6480,7 +6475,7 @@ environment $\newenv$ and all of the following apply:
            \end{itemize}
          \end{itemize}
 
-       \item \texttt{le1} is the result of annotating \texttt{le} with \texttt{t\_e} in \texttt{env1};
+       \item $\vleone$ is the result of annotating \texttt{le} with \texttt{t\_e} in \texttt{env1};
        \item $\news$ is the assignment \texttt{le1 = e1};
        \item $\newenv$ is \texttt{env1}.
        \end{itemize}
@@ -7165,10 +7160,10 @@ Annotating statement $\vs$ in an environment $\tenv$
 (\texttt{annotate\_stmt env s}) results in a statement $\news$ and an
 environment $\newenv$ and all of the following apply:
    \begin{itemize}
-   \item $\vs$ is a declaration with local identifiers \texttt{ldi} and an expression $\ve$;
-   \item \texttt{t\_e,\vep} is the result of annotating $\ve$ in $\tenv$;
-   \item \texttt{env', ldi'} is the result of declaring the local identifiers of \texttt{ldi} in $\tenv$;
-   \item $\news$ is a declaration with \texttt{ldk}, \texttt{ldi'} and an expression $\vep$;
+   \item $\vs$ is a declaration with local identifiers $\ldi$ and an expression $\ve$;
+   \item $(\vte,\vep)$ is the result of annotating $\ve$ in $\tenv$;
+   \item $(\tenvp, \ldip)$ is the result of declaring the local identifiers of $\ldi$ in $\tenv$;
+   \item $\news$ is a declaration with $\ldk$, $\ldip$ and an expression $\vep$;
    \item $\newenv$ is $\tenvp$.
    \end{itemize}
 
@@ -7183,8 +7178,8 @@ environment $\newenv$ and all of the following apply:
     \vs = \SDecl(\LDKConstant, \ldi, \langle\ve\rangle)\\
     \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep)\\
     \reduceconstants{\tenv, \ve} \typearrow \vv\\
-    \declarelocalconstant{\tenv, \ldi} \typearrow (\tenv', \vte, \vv, \ldi')\\
-    \news = \SDecl(\LDKConstant, \ldi', \langle\vep\rangle)\\
+    \declarelocalconstant{\tenv, \ldi} \typearrow (\tenv', \vte, \vv, \ldip)\\
+    \news = \SDecl(\LDKConstant, \ldip, \langle\vep\rangle)\\
     \newtenv = \tenv'
   }
   {
@@ -7203,8 +7198,8 @@ Annotating statement $\vs$ in an environment $\tenv$
 (\texttt{annotate\_stmt env s}) results in a statement $\news$ and an
 environment $\newenv$ and all of the following apply:
    \begin{itemize}
-   \item $\vs$ is a declaration statement with local identifiers \texttt{ldi} and no initial expression;
-   \item \texttt{env', s'} is the result of annotating uninitialised local declarations \texttt{ldi} in $\tenv$;
+   \item $\vs$ is a declaration statement with local identifiers $\ldi$ and no initial expression;
+   \item \texttt{env', s'} is the result of annotating uninitialised local declarations $\ldi$ in $\tenv$;
    \item $\news$ is \texttt{s'};
    \item $\newenv$ is $\tenvp$.
    \end{itemize}
@@ -9448,6 +9443,86 @@ returns the name of a bitfield.
   \inferrule[type]{}{
     \bitfieldgetname(\BitFieldType(\name, \Ignore, \Ignore)) \typearrow \name
   }
+\end{mathpar}
+\end{emptyformal}
+
+\hypertarget{def-checkvarnotinenv}{}
+\hypertarget{def-varinenv}{}
+\section{TypingRule.CheckVarNotInEnv}
+The function
+\[
+  \varinenv{\overname{\staticenvs}{\tenv} \aslsep \overname{\identifier}{\id}}
+  \aslto \Bool
+\]
+determines whether an identifier $\id$ is declared in the static environment $\tenv$.
+
+The function
+\[
+  \checkvarnotinenv{\overname{\staticenvs}{\tenv} \aslsep \overname{\identifier}{\id}}
+  \aslto \True \cup \TTypeError
+\]
+is checks whether $\id$ is declared in $\tenv$. If it is, the result is a type error,
+and otherwise the result is $\True$.
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  {
+    \begin{array}{rl}
+  \vb \eqdef & L^\tenv.\localstoragetypes(\id) \neq \bot\ \lor\\
+             & G^\tenv.\globalstoragetypes(\id) \neq \bot \lor\\
+             & G^\tenv.\subprograms(\id) \neq \bot\ \lor\\
+             & G^\tenv.\declaredtypes(\id) \neq \bot
+  \end{array}
+}
+}
+{
+  \varinenv{\tenv, \id} \typearrow \vb
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[okay]{
+  \varinenv{\tenv, \id} \typearrow \False
+}
+{
+  \checkvarnotinenv{\tenv, \id} \typearrow \True
+}
+\and
+  \inferrule[error]{
+  \varinenv{\tenv, \id} \typearrow \True
+}
+{
+  \checkvarnotinenv{\tenv, \id} \typearrow \TypeErrorVal{AlreadyDeclared}
+}
+\end{mathpar}
+\end{emptyformal}
+
+\hypertarget{def-addlocal}{}
+\section{TypingRule.AddLocal \label{sec:TypingRule.AddLocal}}
+The function
+\[
+  \addlocal(
+    \overname{\staticenvs}{\tenv} \aslsep
+    \overname{\identifier}{\id} \aslsep
+    \overname{\localdeclkeyword}{\ldk})
+  \aslto
+  \overname{\staticenvs}{\newtenv}
+\]
+adds the identifier $\id$ as a local storage element with the local declaration keyword $\ldk$
+to the local environment of $\tenv$, resulting in the static environment $\newtenv$.
+
+\begin{emptyformal}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \newlocalstoragetypes \eqdef L^\tenv.\localstoragetypes[\id \mapsto (\tty, \ldk)]\\
+  \newtenv \eqdef (G^\tenv, L^\tenv[\localstoragetypes \mapsto \newlocalstoragetypes])
+}
+{
+  \addlocal(\tenv, \id, \ldk) \typearrow \newtenv
+}
 \end{mathpar}
 \end{emptyformal}
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -147,7 +147,7 @@
 \newcommand\annotatepattern[0]{\hyperlink{def-annotatepattern}{\texttt{annotate\_pattern}}}
 \newcommand\annotatelocaldeclitem[1]{\hyperlink{def-annotatelocaldeclitem}{\texttt{annotate\_local\_decl\_item}}(#1)}
 \newcommand\annotatestmt[1]{\texttt{annotate\_stmt}(#1)}
-\newcommand\annotateblock[1]{\texttt{annotate\_block}(#1)}
+\newcommand\annotateblock[1]{\hyperlink{def-annotateblock}{\texttt{annotate\_block}}(#1)}
 \newcommand\inlinesetter[1]{\texttt{setter\_should\_reduce\_to\_call\_s}(#1)}
 \newcommand\annotatecall[1]{\hyperlink{def-annotatecall}{\texttt{annotate\_call}}(#1)}
 \newcommand\annotatecatcher[1]{\texttt{annotate\_catcher}(#1)}
@@ -7479,6 +7479,7 @@ environment $\newenv$ and all of the following apply:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Blocks}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\hypertarget{def-annotateblock}{}
 The function
 \[
   \annotateblock{\overname{\staticenvs}{\tenv} \aslsep \overname{\stmt}{\vs}} \aslto
@@ -7525,11 +7526,21 @@ an enclosing block.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Catchers}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+The function
+\[
+  \annotatecatcher{
+    \overname{\staticenvs}{\tenv} \aslsep
+    (\overname{\langle\identifier\rangle}{\newopt} \times \overname{\ty}{\tty} \times \overname{\stmt}{\vstmt})
+  } \aslto
+  (\overname{\langle\identifier\rangle}{\newopt} \times \overname{\ty}{\ttyp} \times \overname{\stmt}{\newstmt})
+  \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+annotates a catcher given by the optional name of the matched exception --- $\newopt$ ---
+the exception type --- $\tty$ --- and the statement to execute upon catching the exception --- $\vstmt$.
+The result is the catcher with the same optional name --- $\newopt$, an annotated type $\ttyp$, and annotated statement $\newstmt$.
+The result is a type error, if one is detected.
 
-Annotating catchers \texttt{(name\_opt, ty, stmt)} in an environment
-$\tenv$ given a type \texttt{return\_type} (\texttt{annotate\_catchers env
-return\_type (name\_opt, ty, stmt)}) results in \texttt{(name\_opt, ty,
-new\_stmt)} and one of the following applies:
+One of the following applies:
 \begin{itemize}
 \item TypingRule.CatcherNone (see \secref{TypingRule.CatcherNone}),
 \item TypingRule.CatcherSome (see \secref{TypingRule.CatcherSome}).
@@ -7537,81 +7548,67 @@ new\_stmt)} and one of the following applies:
 
 \section{TypingRule.CatcherNone \label{sec:TypingRule.CatcherNone}}
 
-  \subsection{Prose}
-   Annotating catcher \texttt{(name\_opt, ty, stmt)} in an environment
-$\tenv$ given a type \texttt{return\_type} (\texttt{annotate\_catchers env
-return\_type (name\_opt, ty, stmt)}) results in \texttt{(name\_opt, ty,
-new\_stmt)} and all of the following apply:
-   \begin{itemize}
-   \item $\tty$ has the structure of an exception type;
-   \item $\newopt$ gives no name;
-   \item $\tenvp$ is $\tenv$;
-   \item $\newstmt$ is the result of annotating $\vstmt$ in $\tenvp$ with \texttt{return\_type}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item the catcher has no named identifier, that is, $(\None, \tty, \vstmt)$;
+  \item annotating the type $\tty$ in $\tenv$ yields $\ttyp$ \ProseOrTypeError;
+  \item determining whether $\ttyp$ has the \structure\ of an exception type yields $\True$ \ProseOrTypeError;
+  \item annotating the block $\vstmt$ in $\tenv$ yields $\newstmt$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\CatcherNoneBegin}{\CatcherNoneEnd}{../Typing.ml}
+\CodeSubsection{\CatcherNoneBegin}{\CatcherNoneEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule{
-    \astlabel(\tstruct(\tty)) = \TException\\
-    \newopt = \None\\
-    \tenv' = \tenv\\
-    \annotateblock{\tenv', \vstmt} \typearrow \newstmtp
-  }
-  {
-    \annotatecatcher{\tenv, \newopt, \tty, \vstmt} \typearrow (\newopt, \tty, \newstmtp)
-  }
+\inferrule{
+  \annotatetype{\tenv, \vt} \typearrow \ttyp \OrTypeError\\
+  \checkstructurelabel(\tenv, \ttyp, \TException) \typearrow \True \OrTypeError\\
+  \annotateblock{\tenv, \vstmt} \typearrow \newstmt \OrTypeError
+}
+{
+  \annotatecatcher{\tenv, (\None, \tty, \vstmt)} \typearrow (\None, \ttyp, \newstmt)
+}
 \end{mathpar}
 \end{emptyformal}
 
 \subsection{Comments}
-    This is related to \identr{SDJK}.
+  This is related to \identr{SDJK}.
 
 \section{TypingRule.CatcherSome \label{sec:TypingRule.CatcherSome}}
 
-  \subsection{Prose}
-   Annotating catcher \texttt{(name\_opt, ty, stmt)} in an environment
-$\tenv$ given a type \texttt{return\_type} (\texttt{annotate\_catchers env return\_type (name\_opt, ty, stmt)})
-results in \texttt{(name\_opt, ty, new\_stmt)} and all of the following apply:
-   \begin{itemize}
-   \item $\tty$ has the structure of an exception type;
-   \item $\newopt$ gives a name $\name$;
-   \item $\name$ is not already declared in $\tenv$;
-   \item $\name$ has type $\tty$ in $\tenv$; \todocomment{ROMAN: doesn't appear in the code}
-   \item $\tenvp$ is $\tenv$ modified to have $\name$ locally declared as immutable of type $\tty$;
-   \item $\newstmt$ is the result of annotating $\vstmt$ in $\tenvp$ with \texttt{return\_type}.
-   \end{itemize}
+\subsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item the catcher has a named identifier, that is, $(\langle\name\rangle, \tty, \vstmt)$;
+  \item annotating the type $\tty$ in $\tenv$ yields $\ttyp$ \ProseOrTypeError;
+  \item determining whether $\ttyp$ has the \structure\ of an exception type yields $\True$ \ProseOrTypeError;
+  \item the identifier $\name$ is not bound in $\tenv$;
+  \item binding $\name$ in the local environment of $\tenv$ with the type $\ttyp$ as an immutable variable
+        (that is, with the local declararion keyword $\LDKLet$), yields the static environment $\tenvp$;
+  \item annotating the block $\vstmt$ in $\tenvp$ yields $\newstmt$.
+\end{itemize}
 
-  \subsection{Example}
+\subsection{Example}
 
-
-    \CodeSubsection{\CatcherSomeBegin}{\CatcherSomeEnd}{../Typing.ml}
+\CodeSubsection{\CatcherSomeBegin}{\CatcherSomeEnd}{../Typing.ml}
 
 \begin{emptyformal}
-    \subsection{Formally}
+\subsection{Formally}
 \begin{mathpar}
-  \inferrule{
-    L^\tenv.\localstoragetypes(\id) = G^\tenv.\globalstoragetypes(\id) = G^\tenv.\subprograms(\id) = \bot
-  }
-  {
-    \checkvarnotinenv{\tenv, \id}
-  }
-  \and
-  \inferrule{
-    \astlabel(\tstruct(\tty)) = \TException\\
-    \newopt = \langle\name\rangle\\
-    \checkvarnotinenv{\tenv, \name}\\
-    \tenv' = (G^\tenv, L^\tenv.\localstoragetypes[\name \mapsto (\tty, \LDKLet)])\\
-    \annotateblock{\tenv', \vstmt} \typearrow \newstmtp
-  }
-  {
-    \annotatecatcher{\tenv, \newopt, \tty, \vstmt} \typearrow (\newopt, \tty, \newstmtp)
-  }
+\inferrule{
+  \annotatetype{\tenv, \vt} \typearrow \ttyp \OrTypeError\\
+  \checkstructurelabel(\tenv, \ttyp, \TException) \typearrow \True \OrTypeError\\\\
+  \checkvarnotinenv{\tenv, \name} \typearrow \True \OrTypeError\\\\
+  \addlocal(\tenv, \name, \ttyp, \LDKLet) \typearrow \tenvp\\
+  \annotateblock{\tenvp, \vstmt} \typearrow \newstmt \OrTypeError
+}
+{
+  \annotatecatcher{\tenv, (\langle\name\rangle, \tty, \vstmt)} \typearrow (\langle\name\rangle, \ttyp, \newstmt)
+}
 \end{mathpar}
 \end{emptyformal}
 

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -550,3 +550,12 @@
 \newcommand\newldip[0]{\texttt{new\_ldi'}}
 \newcommand\newldis[0]{\texttt{new\_ldis'}}
 \newcommand\newlocalstoragetypes[0]{\texttt{new\_local\_storagetypes}}
+\newcommand\eoffset[0]{\texttt{offset}}
+\newcommand\eoffsetp[0]{\texttt{offset'}}
+\newcommand\elength[0]{\texttt{length}}
+\newcommand\elengthp[0]{\texttt{length'}}
+\newcommand\toffset[0]{\texttt{t\_offset}}
+\newcommand\tlength[0]{\texttt{t\_length}}
+\newcommand\prelength[0]{\texttt{pre\_length}}
+\newcommand\prelengthp[0]{\texttt{pre\_length'}}
+\newcommand\preoffset[0]{\texttt{pre\_offset}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -335,6 +335,17 @@
 \newcommand\STEmptySetter[0]{\texttt{ST\_EmptySetter}}
 \newcommand\STProcedure[0]{\texttt{ST\_Procedure}}
 
+\newcommand\funcname[0]{\text{name}}
+\newcommand\funcparameters[0]{\text{parameters}}
+\newcommand\funcargs[0]{\text{args}}
+\newcommand\funcbody[0]{\text{body}}
+\newcommand\funcreturntype[0]{\text{return\_type}}
+\newcommand\funcsubprogramtype[0]{\text{subprogram\_type}}
+
+\newcommand\DFunc[0]{\text{D\_Func}}
+\newcommand\DGlobalStorage[0]{\text{D\_GlobalStorage}}
+\newcommand\DTypeDecl[0]{\text{D\_TypeDecl}}
+
 \newcommand\identifier[0]{\textsf{identifier}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -492,6 +503,9 @@
 \newcommand\structtwo[0]{\texttt{struct2}}
 \newcommand\newty[0]{\texttt{new\_ty}}
 \newcommand\tenvp[0]{\texttt{tenv'}}
+\newcommand\tenvthree[0]{\texttt{tenv3}}
+\newcommand\tenvfour[0]{\texttt{tenv4}}
+\newcommand\tenvfive[0]{\texttt{tenv5}}
 \newcommand\funcsig[0]{\texttt{func\_sig}}
 \newcommand\gsd[0]{\texttt{gsd}}
 \newcommand\decls[0]{\texttt{decls}}
@@ -572,3 +586,8 @@
 \newcommand\vteonestruct[0]{\texttt{t\_e1\_struct}}
 \newcommand\vtetwostruct[0]{\texttt{t\_e2\_struct}}
 \newcommand\vlip[0]{\texttt{li'}}
+\newcommand\vfp[0]{\texttt{f'}}
+\newcommand\body[0]{\texttt{body}}
+\newcommand\newbody[0]{\texttt{new\_body}}
+\newcommand\newd[0]{\texttt{new\_d}}
+\newcommand\funcsigone[0]{\texttt{func\_sig1}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -550,6 +550,7 @@
 \newcommand\slicesp[0]{\texttt{slices'}}
 \newcommand\tep[0]{\texttt{t\_e'}}
 \newcommand\structtep[0]{\texttt{struct\_t\_e'}}
+\newcommand\structtleone[0]{\texttt{struct\_t\_le1}}
 \newcommand\vargsp[0]{\texttt{args'}}
 \newcommand\eqsp[0]{\texttt{eqs'}}
 \newcommand\namep[0]{\texttt{name'}}
@@ -619,3 +620,7 @@
 \newcommand\ttytwo[0]{\texttt{ty2}}
 \newcommand\vpat[0]{\texttt{pat}}
 \newcommand\vpatp[0]{\texttt{pat'}}
+\newcommand\lesp[0]{\texttt{les'}}
+\newcommand\lesone[0]{\texttt{les1}}
+\newcommand\vteeq[0]{\texttt{t\_e\_eq}}
+\newcommand\vtleonestruct[0]{\texttt{t\_le1\_struct}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -543,3 +543,10 @@
 \newcommand\tspecp[0]{\texttt{t\_spec'}}
 \newcommand\pairs[0]{\texttt{pairs}}
 \newcommand\initializedfields[0]{\texttt{initialized\_fields}}
+\newcommand\vteone[0]{\texttt{t\_e1}}
+\newcommand\vtetwo[0]{\texttt{t\_e2}}
+\newcommand\vtethree[0]{\texttt{t\_e3}}
+\newcommand\ldip[0]{\texttt{ldi'}}
+\newcommand\newldip[0]{\texttt{new\_ldi'}}
+\newcommand\newldis[0]{\texttt{new\_ldis'}}
+\newcommand\newlocalstoragetypes[0]{\texttt{new\_local\_storagetypes}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -120,6 +120,7 @@
 \newcommand\Bool[0]{\hyperlink{def-bool}{\mathbb{B}}}
 \newcommand\Identifiers[0]{\hyperlink{def-identifier}{\mathbb{I}}}
 \newcommand\Strings[0]{\hyperlink{def-strings}{\mathbb{S}}}
+\newcommand\astlabels[0]{\hyperlink{def-astlabels}{\mathbb{L}}}
 
 \newcommand\pow[1]{\hyperlink{def-pow}{\mathcal{P}}(#1)}
 \newcommand\partialto[0]{\hyperlink{def-partialfunc}{\rightharpoonup}}
@@ -559,3 +560,15 @@
 \newcommand\prelength[0]{\texttt{pre\_length}}
 \newcommand\prelengthp[0]{\texttt{pre\_length'}}
 \newcommand\preoffset[0]{\texttt{pre\_offset}}
+\newcommand\newp[0]{\texttt{new\_p}}
+\newcommand\newq[0]{\texttt{new\_q}}
+\newcommand\newli[0]{\texttt{new\_li}}
+\newcommand\vlp[0]{\texttt{l'}}
+\newcommand\useset[0]{\texttt{use\_set}}
+\newcommand\gdk[0]{\texttt{gdk}}
+\newcommand\testruct[0]{\texttt{t\_e\_struct}}
+\newcommand\vtestruct[0]{\texttt{t\_e\_struct}}
+\newcommand\vq[0]{\texttt{q}}
+\newcommand\vteonestruct[0]{\texttt{t\_e1\_struct}}
+\newcommand\vtetwostruct[0]{\texttt{t\_e2\_struct}}
+\newcommand\vlip[0]{\texttt{li'}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -153,7 +153,7 @@
 \newcommand\BOR[0]{\texttt{BOR}} % Boolean or
 \newcommand\DIV[0]{\texttt{DIV}} % Integer division
 \newcommand\DIVRM[0]{\texttt{DIVRM}} % Inexact integer division, with rounding towards negative infinity.
-\newcommand\EOR[0]{\texttt{EOR}} % Bitvector bitwise exclusive or
+\newcommand\EOR[0]{\texttt{XOR}} % Bitvector bitwise exclusive or
 \newcommand\EQOP[0]{\texttt{EQ\_OP}} % Equality on two base values of same type
 \newcommand\GT[0]{\texttt{GT}} % Greater than for int or reals
 \newcommand\GEQ[0]{\texttt{GEQ}} % Greater or equal for int or reals
@@ -427,6 +427,7 @@
 \newcommand\op[0]{\texttt{op}}
 \newcommand\vx[0]{\texttt{x}}
 \newcommand\vb[0]{\texttt{b}}
+\newcommand\vbfour[0]{\texttt{b4}}
 \newcommand\ve[0]{\texttt{e}}
 \newcommand\vi[0]{\texttt{i}}
 \newcommand\vj[0]{\texttt{j}}
@@ -591,3 +592,22 @@
 \newcommand\newbody[0]{\texttt{new\_body}}
 \newcommand\newd[0]{\texttt{new\_d}}
 \newcommand\funcsigone[0]{\texttt{func\_sig1}}
+\newcommand\namesubs[0]{\texttt{name\_s}}
+\newcommand\namesubt[0]{\texttt{name\_t}}
+\newcommand\vstructt[0]{\texttt{struct\_t}}
+\newcommand\vstructs[0]{\texttt{struct\_s}}
+\newcommand\vcsnew[0]{\texttt{cs\_new}}
+\newcommand\vbot[0]{\texttt{bot}}
+\newcommand\vvtop[0]{\texttt{top}}
+\newcommand\vneg[0]{\texttt{neg}}
+\newcommand\vtonestruct[0]{\texttt{t1\_struct}}
+\newcommand\vttwostruct[0]{\texttt{t2\_struct}}
+\newcommand\vtoneanon[0]{\texttt{t1\_anon}}
+\newcommand\vttwoanon[0]{\texttt{t2\_anon}}
+\newcommand\vcsone[0]{\texttt{cs1}}
+\newcommand\vcstwo[0]{\texttt{cs2}}
+\newcommand\vanons[0]{\texttt{anon\_s}}
+\newcommand\vanont[0]{\texttt{anon\_t}}
+\newcommand\vet[0]{\texttt{e\_t}}
+\newcommand\ves[0]{\texttt{e\_s}}
+\newcommand\vtsupers[0]{\texttt{t\_supers}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -132,7 +132,7 @@
 \newcommand\terminateas[0]{\;\hyperlink{def-terminateas}{\sslash}\;}
 \newcommand\booltrans[1]{\hyperlink{def-booltrans}{\texttt{bool\_transition}(#1)}}
 \newcommand\booltransarrow[0]{\rightarrow}
-\newcommand\checktrans[1]{\hyperlink{def-checktrans}{\texttt{check\_transition}(#1)}}
+\newcommand\checktrans[1]{\hyperlink{def-checktrans}{\texttt{check}}(#1)}
 \newcommand\checktransarrow[0]{\rightarrow}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -224,6 +224,7 @@
 \newcommand\ECond[0]{\textsf{E\_Cond}}
 \newcommand\EGetArray[0]{\textsf{E\_GetArray}}
 \newcommand\EGetField[0]{\textsf{E\_GetField}}
+\newcommand\EGetItem[0]{\textsf{E\_GetItem}}
 \newcommand\EGetFields[0]{\textsf{E\_GetFields}}
 \newcommand\ERecord[0]{\textsf{E\_Record}}
 \newcommand\EConcat[0]{\textsf{E\_Concat}}
@@ -540,3 +541,5 @@
 \newcommand\tindexp[0]{\texttt{t\_index'}}
 \newcommand\fieldtypes[0]{\texttt{field\_types}}
 \newcommand\tspecp[0]{\texttt{t\_spec'}}
+\newcommand\pairs[0]{\texttt{pairs}}
+\newcommand\initializedfields[0]{\texttt{initialized\_fields}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -562,6 +562,8 @@
 \newcommand\vteone[0]{\texttt{t\_e1}}
 \newcommand\vtetwo[0]{\texttt{t\_e2}}
 \newcommand\vtethree[0]{\texttt{t\_e3}}
+\newcommand\vtefour[0]{\texttt{t\_e4}}
+\newcommand\vtefive[0]{\texttt{t\_e5}}
 \newcommand\ldip[0]{\texttt{ldi'}}
 \newcommand\newldip[0]{\texttt{new\_ldi'}}
 \newcommand\newldis[0]{\texttt{new\_ldis'}}
@@ -611,3 +613,9 @@
 \newcommand\vet[0]{\texttt{e\_t}}
 \newcommand\ves[0]{\texttt{e\_s}}
 \newcommand\vtsupers[0]{\texttt{t\_supers}}
+\newcommand\vindex[0]{\texttt{index}}
+\newcommand\widthsum[0]{\texttt{width\_sum}}
+\newcommand\ttyone[0]{\texttt{ty1}}
+\newcommand\ttytwo[0]{\texttt{ty2}}
+\newcommand\vpat[0]{\texttt{pat}}
+\newcommand\vpatp[0]{\texttt{pat'}}

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -37,6 +37,7 @@ type error_desc =
   | UnsupportedBinop of binop * literal * literal
   | UnsupportedUnop of unop * literal
   | UnsupportedExpr of expr
+  | InvalidExpr of expr
   | MismatchType of string * type_desc list
   | NotYetImplemented of string
   | ConflictingTypes of type_desc list * ty
@@ -109,6 +110,7 @@ let pp_error =
           (unop_to_string op) pp_literal v
     | UnsupportedExpr e ->
         fprintf f "ASL Error: Unsupported expression %a." pp_expr e
+    | InvalidExpr e -> fprintf f "ASL Error: invalid expression %a." pp_expr e
     | MismatchType (v, [ ty ]) ->
         fprintf f
           "ASL Execution error: Mismatch type:@ value %s does not belong to \

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -432,9 +432,7 @@ module TypingRule = struct
     | PRange
     | PSingle
     | PMask
-    | PTupleBadArity
     | PTuple
-    | PTupleConflict
     | LDDiscard
     | LDVar
     | LDTyped
@@ -580,9 +578,7 @@ module TypingRule = struct
     | PRange -> "PRange"
     | PSingle -> "PSingle"
     | PMask -> "PMask"
-    | PTupleBadArity -> "PTupleBadArity"
     | PTuple -> "PTuple"
-    | PTupleConflict -> "PTupleConflict"
     | LDDiscard -> "LDDiscardNone"
     | LDTyped -> "LDTyped"
     | LDVar -> "LDVar"

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -396,6 +396,7 @@ module TypingRule = struct
     | EGetBadRecordField
     | EGetBitFieldNested
     | EGetBitFieldTyped
+    | EGetTupleItem
     | EGetBitFields
     | EConcatEmpty
     | EConcat
@@ -539,6 +540,7 @@ module TypingRule = struct
     | EGetBadRecordField -> "EGetBadRecordField"
     | EGetBitFieldNested -> "EGetBitFieldNested"
     | EGetBitFieldTyped -> "EGetBitFieldTyped"
+    | EGetTupleItem -> "EGetTupleItem"
     | EGetBitFields -> "EGetBitFields"
     | EConcatEmpty -> "EConcatEmpty"
     | EConcat -> "EConcat"
@@ -689,6 +691,7 @@ module TypingRule = struct
       EGetBitField;
       EGetBitFieldNested;
       EGetBitFieldTyped;
+      EGetTupleItem;
       EGetBitFields;
       EUnknown;
       EPattern;


### PR DESCRIPTION
Work to get the ASL Typing Reference ready for another round of reviews on May 13th.
- [x] Introduction and background.
- [x] Domain of Values for Types 
- [x] Basic Type Attributes
- [x] Relations Over Types
- [x] Typing of bitfields
- [x] Typing of Types
- [x] Typing of Expressions
- [x] Typing of Left-Hand-Side Expressions
- [x] Typing of Slices
- [x] Typing of Patterns
- [x] Typing of Local Declarations
- [ ] Typing of Statements
- [x] Typing of Blocks
- [x] Typing of Catchers
- [ ] Typing of Subprogram Calls
- [x] Typing of Subprograms
- [ ] Typing of Global Declarations
- [ ] Typing of Specifications
- [ ] Static Evaluation
- [ ] Symbolic Subsumption Testing
- [ ] Symbolic Equivalence Testing
- [ ] Utility Relations
- [ ] Address existing feedback.