### PR TITLE
[catalogue] Fix litmus7 warnings for aarch64-mixed

### DIFF
--- a/catalogue/aarch64-mixed/README.md
+++ b/catalogue/aarch64-mixed/README.md
@@ -21,19 +21,7 @@ Running with litmus7
     % make
     % sh ./run.sh
 
-> **_NOTE:_** litmus7 and the C compiler might emit warnings for the tests:
-> - CoRW2+posq0q0+q0.litmus,
-> - CoRW2+posq0q0+q0.litmus,
-> - CoRW2+posw0w0+w0.litmus,
-> - LB+dmb.sy+data-wsi-wsi+MIXED.litmus,
-> - LB+dmb.sy+data-wsi-wsi+MIXED.litmus,
-> - MP+QAmo+AcqAmo.litmus,
-> - MP+QAmo+AcqAmo.litmus,
-> - MP+QAmo+AcqAmo.litmus,
-> - MP+dmb.syw0w4+dataw4w4-rfiw4q0.litmus,
-> - MP+dmb.syw0w4+dataw4w4-rfiw4q0.litmus,
-> - MP+dmb.syw0w4+dataw4w4-rfiw4q0.litmus,
-> - MP+popl.w0-posl.w0q0+poa.w4p.litmus, and
-> - MP+popl.w0-posl.w0q0+poa.w4p.litmus.
+> **_NOTE:_** litmus7 might emit warnings for the following test:
+> - LB+dmb.sy+data-wsi-wsi+MIXED.limus.
 >
-> These are known and do not affect the correctness of these tests.
+> These are known and do not affect the correctness of the tests.

--- a/catalogue/aarch64-mixed/tests/CoRW2+posq0q0+q0.litmus
+++ b/catalogue/aarch64-mixed/tests/CoRW2+posq0q0+q0.litmus
@@ -6,11 +6,12 @@ Safe=Rfeq0P Wseq0P PosRWq0P
 Prefetch=
 Com=Rf Ws
 Orig=Rfeq0q0 PosRWq0q0 Wseq0q0
+Hash=aa59de9fd2278715ec88dec45fc08a95
 {
 uint64_t x; uint64_t 1:X3; uint64_t 1:X0;
 
-0:X0=0x101010101010101; 0:X1=x;
-1:X1=x; 1:X2=0x202020202020202;
+uint64_t 0:X0=0x101010101010101; 0:X1=x;
+1:X1=x; uint64_t 1:X2=0x202020202020202;
 }
  P0          | P1          ;
  STR X0,[X1] | LDR X0,[X1] ;

--- a/catalogue/aarch64-mixed/tests/CoRW2+posw0w0+w0.litmus
+++ b/catalogue/aarch64-mixed/tests/CoRW2+posw0w0+w0.litmus
@@ -6,8 +6,9 @@ Safe=Rfew0P Wsew0P PosRWw0P
 Prefetch=
 Com=Rf Ws
 Orig=Rfew0w0 PosRWw0w0 Wsew0w0
+Hash=d711bd8003386b79a274ae374c0d60bb
 {
-uint64_t x; uint64_t 1:X3; uint64_t 1:X0;
+uint64_t x; uint64_t 1:X3;
 
 0:X0=0x1010101; 0:X1=x;
 1:X1=x; 1:X2=0x2020202;

--- a/catalogue/aarch64-mixed/tests/LB+dmb.sy+data-wsi-wsi+MIXED.litmus
+++ b/catalogue/aarch64-mixed/tests/LB+dmb.sy+data-wsi-wsi+MIXED.litmus
@@ -1,13 +1,14 @@
 AArch64 LB+dmb.sy+data-wsi-wsi+MIXED
+Hash=0d984121bcaab0fc91193d879309712b
 {
-uint64_t y; uint64_t x; uint64_t 1:X0; uint64_t 0:X0;
+uint64_t y; uint64_t x; uint64_t 1:X0;
 0:X1=x; 0:X3=y;
 1:X1=y; 1:X3=x;
 }
  P0          | P1           ;
  LDR W0,[X1] | LDR X0,[X1]  ;
- DMB SY      | EOR X2,X0,X0 ;
- MOV X2,#1   | ADD X2,X2,#1 ;
+ DMB SY      | EOR W2,W0,W0 ;
+ MOV X2,#1   | ADD W2,W2,#1 ;
  STR X2,[X3] | STR W2,[X3,#4]  ;
              | MOV X4,#2    ;
              | STR X4,[X3]  ;

--- a/catalogue/aarch64-mixed/tests/MP+QAmo+AcqAmo.litmus
+++ b/catalogue/aarch64-mixed/tests/MP+QAmo+AcqAmo.litmus
@@ -1,8 +1,9 @@
 AArch64 MP+QAmo+AcqAmo
+Hash=d29be02eee3b8843aec5acac62c17d53
 {
-uint64_t x; uint64_t 1:X2; uint64_t 1:X0;
+uint64_t x;
 
-0:X0=0x101010101010101; 0:X1=x;
+uint64_t 0:X0=0x101010101010101; 0:X1=x;
 1:X1=x; 1:X4=0x02020202
 }
  P0             | P1              ;

--- a/catalogue/aarch64-mixed/tests/MP+dmb.syw0w4+dataw4w4-rfiw4q0.litmus
+++ b/catalogue/aarch64-mixed/tests/MP+dmb.syw0w4+dataw4w4-rfiw4q0.litmus
@@ -7,15 +7,16 @@ Generator=diy7 (version 7.52)
 Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
 Com=Rf Fr
 Orig=DMB.SYdWWw0w4 Rfew4w4 DpDatadWw4w4 Rfiw4q0 Freq0w0
+Hash=3090f26ac74e2921289e67333ad45eb4
 {
-uint64_t y; uint64_t x; uint64_t 1:X5; uint64_t 1:X0;
+uint64_t y; uint64_t x; uint64_t 1:X5;
 
 0:X0=0x2020202; 0:X1=x; 0:X2=0x1010101; 0:X3=y;
 1:X1=y; 1:X2=0x1010101; 1:X4=x;
 }
  P0             | P1             ;
  STR W0,[X1]    | LDR W0,[X1,#4] ;
- DMB SY         | EOR X3,X0,X0   ;
+ DMB SY         | EOR W3,W0,W0   ;
  STR W2,[X3,#4] | ADD W3,W3,W2   ;
                 | STR W3,[X4,#4] ;
                 | LDR X5,[X4]    ;

--- a/catalogue/aarch64-mixed/tests/MP+popl.w0-posl.w0q0+poa.w4p.litmus
+++ b/catalogue/aarch64-mixed/tests/MP+popl.w0-posl.w0q0+poa.w4p.litmus
@@ -4,10 +4,11 @@ Generator=diyone7 (version 7.54+02(dev))
 Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
 Com=Rf Fr
 Orig=PodWWPL.w0 PosWWL.w0q0 Rfeq0A.w4 PodRRA.w4P Fre
+Hash=6b21a7d904eb132d698172f5f3184853
 {
-uint64_t y; uint64_t x; uint64_t 1:X3; uint64_t 1:X0;
+uint64_t y; uint64_t x; uint64_t 1:X3;
 
-0:X1=x; 0:X2=0x1010101; 0:X3=y; 0:X4=0x202020202020202;
+0:X1=x; 0:X2=0x1010101; 0:X3=y; uint64_t 0:X4=0x202020202020202;
 1:X1=y; 1:X4=x;
 }
  P0           | P1           ;


### PR DESCRIPTION
litmus7 and the compiler used for the source code produced by litmus7 emits warnings for some of the tests in aarch64-mixed catalogue.

In most cases, the type of the register is declared incorrectly (for example, uint64_t instead of uint32_t). In other cases, we need to trancate a register from 64bit to 32bit.

This commit fix these warnings. There should be no change to the semantics of any of these tests and for this reason their hash is changed to match that of the previous version of the tests.

There is one warning which is benign:

Warning: File "./tests/LB+dmb.sy+data-wsi-wsi+MIXED.litmus" Register x0 has different types: <int64_t> and <int>

In this case, litmus7 is being a little pedantic. gcc seems to be fine with its code.