### PR TITLE
Lkmm making rmw barriers explicit

### DIFF
--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -34,6 +34,10 @@ type t =
   | SwitchDepScResult  (* Switch dependency from address read to sc result register,  aarch64 *)
   | LrScDiffOk      (* Lr/Sc paired to <> addresses may succeed (!) *)
   | NotWeakPredicated (* NOT "Weak" predicated instructions, not performing non-selected events, aarch64 *)
+  | LKMMVersion of [
+        `lkmmv1 (* Legacy mode, e.g., wrapp rmw[Mb] instructions with explicit Mb fences *)
+      | `lkmmv2 (* Avoid wrapping rmw[Mb] instructions with explicit Mb fences and adding noreturn tags *)
+    ]
 (* Mixed size *)
   | Mixed
   | Unaligned
@@ -109,7 +113,7 @@ type t =
 let tags =
   ["success";"instr";"specialx0";"normw";"acqrelasfence";"backcompat";
    "fullscdepend";"splittedrmw";"switchdepscwrite";"switchdepscresult";"lrscdiffok";
-   "mixed";"dontcheckmixed";"weakpredicated"; "memtag";"vmsa";"kvm";]@
+   "mixed";"dontcheckmixed";"weakpredicated"; "lkmmv1"; "lkmmv2"; "memtag";"vmsa";"kvm";]@
     Precision.tags @ Fault.Handling.tags @
    ["toofar"; "deps"; "morello"; "instances"; "noptebranch"; "pte2";
    "pte-squared"; "PhantomOnLoad"; "OptRfRMW"; "ConstrainedUnpredictable";
@@ -133,6 +137,8 @@ let parse s = match Misc.lowercase s with
 | "unaligned" -> Some Unaligned
 | "dontcheckmixed" -> Some DontCheckMixed
 | "notweakpredicated"|"notweakpred" -> Some NotWeakPredicated
+| "lkmmv1" -> Some (LKMMVersion `lkmmv1)
+| "lkmmv2" -> Some (LKMMVersion `lkmmv2)
 | "tagmem"|"memtag"|"mte" -> Some MemTag
 | "toofar" -> Some TooFar
 | "morello" -> Some Morello
@@ -227,6 +233,8 @@ let pp = function
   | Unaligned -> "unaligned"
   | DontCheckMixed -> "DontCheckMixed"
   | NotWeakPredicated -> "NotWeakPredicated"
+  | LKMMVersion `lkmmv1 -> "lkmmv1"
+  | LKMMVersion `lkmmv2 -> "lkmmv2"
   | MemTag -> "memtag"
   | MTEPrecision p -> Precision.pp p
   | FaultHandling p -> Fault.Handling.pp p

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -33,7 +33,11 @@ type t =
   | SwitchDepScResult    (* Switch dependency from address read to sc result write, riscv,aarch64 *)
   | LrScDiffOk      (* Lr/Sc paired to <> addresses may succeed (!) *)
   | NotWeakPredicated (* NOT "Weak" predicated instructions, not performing non-selected events, aarch64 *)
-(* Mixed size *)
+  | LKMMVersion of [
+        `lkmmv1 (* Legacy mode (wrapp rmw[Mb] instructions with explicit Mb fences, add noreturn tags) *)
+      | `lkmmv2 (* Avoid wrapping rmw[Mb] instructions with explicit Mb fences and adding noreturn tags *)
+    ]
+ (* Mixed size *)
   | Mixed
   | Unaligned
  (* Do not check (and reject early) mixed size tests in non-mixed-size mode *)

--- a/jingle/CArch_jingle.ml
+++ b/jingle/CArch_jingle.ml
@@ -190,11 +190,11 @@ include Arch.MakeArch(struct
           expl_expr loc >> fun loc ->
           expl_expr e   >! fun e ->
           AtomicOpReturn (loc,op,e,ret,a)
-      | AtomicAddUnless (loc,u,a,rb) ->
+      | AtomicAddUnless (loc,u,e,rb,a) ->
           expl_expr loc >> fun loc ->
           expl_expr u >> fun u ->
-          expl_expr a >! fun a ->
-          AtomicAddUnless (loc,u,a,rb)
+          expl_expr e >! fun e ->
+          AtomicAddUnless (loc,u,e,rb,a)
       | ExpSRCU (e,a) -> expl_expr e >! fun e -> ExpSRCU (e,a) in
 
     let rec expl_instr =  function
@@ -229,10 +229,10 @@ include Arch.MakeArch(struct
     | PCall (f,es) ->
         mapT expl_expr es >! fun es ->
         PCall (f,es)
-    | AtomicOp(e1,op,e2) ->
+    | AtomicOp(e1,op,e2,a) ->
         expl_expr e1 >> fun e1 ->
         expl_expr e2 >! fun e2 ->
-        AtomicOp (e1,op,e2)
+        AtomicOp (e1,op,e2,a)
     | InstrSRCU (e,a,oe) ->
         expl_expr e >> fun e ->
         optT expl_expr oe >! fun oe ->

--- a/jingle/cDumper.ml
+++ b/jingle/cDumper.ml
@@ -82,7 +82,7 @@ let list_loc prog =
     | Exchange(l,e,_) -> loc (expr s e) l
     | Fetch(l,_,e,_) -> loc (expr s e) l
     | ECall (_,es) -> List.fold_left expr s es
-    | AtomicAddUnless(e1,e2,e3,_)
+    | AtomicAddUnless(e1,e2,e3,_,_)
     | CmpExchange (e1,e2,e3,_)
     | ECas (e1,e2,e3,_,_,_) -> expr (expr (expr s e1) e2) e3
     | TryLock (e,_)|IsLocked (e,_)|ExpSRCU(e,_) -> expr s e in
@@ -102,7 +102,7 @@ let list_loc prog =
     | PCall (_,es) ->
         List.fold_left expr s es
     | Fence _|Symb _ -> s
-    | AtomicOp(e1,_,e2) -> expr (expr s e1) e2
+    | AtomicOp(e1,_,e2,_) -> expr (expr s e1) e2
     | InstrSRCU(e,_,None) -> expr s e
     | InstrSRCU(e,_,Some f) -> expr (expr s f) e
   in

--- a/lib/CLexer.mll
+++ b/lib/CLexer.mll
@@ -94,7 +94,6 @@ let tr_name s = match s with
 | "__atomic_op_return" -> UNDERATOMICOPRETURN
 | "__atomic_fetch_op" -> UNDERATOMICFETCHOP
 | "__atomic_add_unless" -> UNDERATOMICADDUNLESS
-| "atomic_add_unless" -> ATOMICADDUNLESS
 (* Others *)
 | x -> NAME x
 }

--- a/tools/mlock.ml
+++ b/tools/mlock.ml
@@ -104,8 +104,8 @@ module Top(O:Config)(Out:OutTests.S) = struct
         CmpExchange (tr_expr loc,tr_expr o,tr_expr n,a)
     | AtomicOpReturn (loc,op,u,ret,a) ->
         AtomicOpReturn (tr_expr loc,op,tr_expr u,ret,a)
-    | AtomicAddUnless (loc,a,u,retbool) ->
-        AtomicAddUnless (tr_expr loc,tr_expr a,tr_expr u,retbool)
+    | AtomicAddUnless (loc,e,u,retbool,a) ->
+        AtomicAddUnless (tr_expr loc,tr_expr e,tr_expr u,retbool,a)
     | ExpSRCU(eloc,a) ->
         ExpSRCU(tr_expr eloc,a) in
 
@@ -148,10 +148,10 @@ module Top(O:Config)(Out:OutTests.S) = struct
         let ec = tr_expr ec in
         let nxt,vs,it = tr_ins nxt it in
         nxt,vs,While (ec,it,n)
-    | AtomicOp (loc,op,e) ->
+    | AtomicOp (loc,op,e,a) ->
         let loc = tr_expr loc
         and e = tr_expr e in
-        nxt,StringSet.empty,AtomicOp(loc,op,e)
+        nxt,StringSet.empty,AtomicOp(loc,op,e,a)
     | InstrSRCU(eloc,a,oe) ->
         let eloc = tr_expr eloc in
         let oe = Misc.app_opt tr_expr oe in
@@ -225,7 +225,7 @@ module Top(O:Config)(Out:OutTests.S) = struct
     -> StringSet.union (expr_read e1) (expr_read e2)
   | ECas (e1,e2,e3,_,_,_)
   | CmpExchange(e1,e2,e3,_)
-  | AtomicAddUnless (e1,e2,e3,_) ->
+  | AtomicAddUnless (e1,e2,e3,_,_) ->
       StringSet.union3 (expr_read e1) (expr_read e2) (expr_read e3)
 
   and exprs_read es = StringSet.unions (List.map expr_read es)
@@ -283,7 +283,7 @@ module Top(O:Config)(Out:OutTests.S) = struct
     | PCall (_,es) ->
         let s = exprs_read es in
         add_locks s i
-    | AtomicOp (loc,_,e) ->
+    | AtomicOp (loc,_,e,_) ->
         let s1 = expr_read loc and s2 = expr_read e in
         let s = StringSet.union s1 s2 in
         add_locks s i in
@@ -338,8 +338,8 @@ module Top(O:Config)(Out:OutTests.S) = struct
         CmpExchange (tr_expr loc,tr_expr o,tr_expr n,a)
     | AtomicOpReturn (loc,op,e,ret,a) ->
         AtomicOpReturn (tr_expr loc,op,tr_expr e,ret,a)
-    | AtomicAddUnless (loc,a,u,retbool) ->
-        AtomicAddUnless (tr_expr loc,tr_expr a,tr_expr u,retbool)
+    | AtomicAddUnless (loc,e,u,retbool,a) ->
+        AtomicAddUnless (tr_expr loc,tr_expr e,tr_expr u,retbool,a)
     | ExpSRCU(e,a) ->
         ExpSRCU(tr_expr e,a)
 
@@ -375,7 +375,7 @@ module Top(O:Config)(Out:OutTests.S) = struct
         | _ -> StoreMem (e1,e2,a)
         end
     | PCall (f,es) -> PCall (f,tr_exprs es)
-    | AtomicOp (loc,op,e) -> AtomicOp(tr_expr loc,op,tr_expr e)
+    | AtomicOp (loc,op,e,a) -> AtomicOp(tr_expr loc,op,tr_expr e,a)
     | InstrSRCU(eloc,a,oe) -> InstrSRCU(tr_expr eloc,a,Misc.app_opt tr_expr oe) in
     tr_ins
 


### PR DESCRIPTION
This PR implements the changes discussed in [1,2]

The idea is to
- change herd7's source code to avoid explicitly creating Mb fences before and after RMWs
- propagate Mb tags from RMW to the corresponding read and writes
- update the lkmm model to enforce the ordering that is now missing due to the removed fences.

I tested the changes using the scripts from the kernel (`tools/memory-model/scripts`) and I do get the expected results.

I also added a test case showing that the first two cases alone are not enough and indeed the model needs to be updated.

I have a few open questions and thus the DRAFT status
- do my changes affect other parts of the source code I am not aware of?
- do we need to update the bell file to allow `mb` in `RMW` instructions as mentioned in [3]? I would expect so, but I still get the correct results without this change
- does the code looks ok? can we do further simplifications? This is my first experience with OCaml. While the changes have the impact I expect, I am not sure this is the best way to achieve the points from above.

NOTE: the proposed changes in the cat file are not final. I just used one of the alternatives discussed in the mailing list. 

[1] https://lkml.org/lkml/2024/4/4/1236
[2] https://lkml.org/lkml/2024/5/15/1026
[3] https://lkml.org/lkml/2024/5/21/357