### PR TITLE
[asl] Fix let binding of tuples

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -834,7 +834,8 @@ module Make (B : Backend.S) (C : Config) = struct
     (* Begin LDTuple *)
     | LDI_Tuple ldis, Some m ->
         let n = List.length ldis in
-        let liv = List.init n (fun i -> m >>= B.get_index i) in
+        let* vm = m in
+        let liv = List.init n (fun i -> B.return vm >>= B.get_index i) in
         let folder envm ldi1 vm =
           let**| env = envm in
           eval_local_decl s ldi1 env (Some vm)

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -139,10 +139,17 @@ module Make (C : Config) = struct
     (* Values handling                                                        *)
     (**************************************************************************)
 
+    (*
+     * Non-resolved values are "frozen" into constants.
+     * Useful for storing them into vector of constants.
+     * Notice: such "constants" are usable only when
+     * extracted from vectors.
+     * See `unfreeze` below.
+     *)
+
     let as_constant = function
       | V.Val c -> c
-      | V.Var _ as v ->
-          Warn.fatal "Cannot convert value %s into constant" (V.pp_v v)
+      | V.Var id -> Constant.Frozen id
 
     let v_unknown_of_type ~eval_expr_sef:(_: Asllib.AST.expr -> V.v M.t) _t =
       return (V.fresh_var ())

--- a/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus
@@ -1,0 +1,24 @@
+ASL frozen-tuple-arg
+
+(*
+ * This tests was leading to a runtime error
+ * because the pair construction failed.
+ *    This is no longer the case, as non-resolved
+ *  values such as the ones created by reading from
+ *  memory are now "frozen" when used as tuple arguments.
+ *)
+
+{
+x=15;
+0:X0=x;
+}
+
+func main() => integer
+begin
+  let x = read_register(0);  
+  let (a,b) = (1,UInt(read_memory(x,32)));
+  let c = a+b;
+  return 0;
+end
+
+forall 0:main.0.c=16

--- a/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
@@ -1,0 +1,10 @@
+Test frozen-tuple-arg Required
+States 1
+0:main.0.c=16;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:main.0.c=16)
+Observation frozen-tuple-arg Always 1 0
+Hash=1d585fd238fa54d4a8ea46e941ea74ca
+

--- a/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus
@@ -1,0 +1,19 @@
+ASL return-tuple
+
+{
+
+}
+
+func f() => (integer, integer)
+begin
+  return (1,2);
+end
+
+func main() => integer
+begin
+  let (a,b) = f();
+  let c = a+b;
+  return 0;
+end
+
+forall 0:main.0.c=3

--- a/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
@@ -1,0 +1,10 @@
+Test return-tuple Required
+States 1
+0:main.0.c=3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:main.0.c=3)
+Observation return-tuple Always 1 0
+Hash=d66f7dbadc7ed730e48c0d87e6750350
+


### PR DESCRIPTION
Fix various problems related to tuple bindings.
- [X] Cyclic program order.
- [X] Impossibility to transmit non-determined value from tuple construction to binding.

Two tests that illustrate the fixed problems are also added.

- Cyclic program order:
```
ASL return-tuple

{

}

func f() => (integer, integer)
begin
  return (1,2);
end

func main() => integer
begin
  let (a,b) = f();
  let c = a+b;
  return 0;
end

forall 0:main.0.c=3
```
Before the fix, this test yielded no execution at all, because if the cyclic `po` introduced while evaluating `let (a,b) = f();`.
- Creating tuples with non-resolved arguments:
```
ASL frozen-tuple-arg

{
x=15;
0:X0=x;
}

func main() => integer
begin
  let x = read_register(0);  
  let (a,b) = (1,UInt(read_memory(x,32)));
  let c = a+b;
  return 0;
end

forall 0:main.0.c=16
```
Before the fix, evaluation of `let (a,b) = (1,UInt(read_memory(x,32)));` was failing because the `read_memory` primitive returns a non-resolved value, resulting in a pair whose second argument is a non-resolved value.