### PR TITLE
[litmus] Add support for speedcheck parameter for -mode presi

### DIFF
--- a/litmus/libdir/_instance.c
+++ b/litmus/libdir/_instance.c
@@ -35,16 +35,18 @@ typedef struct {
   sense_t b;
   param_t p;
   int ind[N]; /* Indirection for role shuffle */
+  int stop_now;
 } ctx_t ;
 
 
 static void instance_init(ctx_t *p, int id, intmax_t *mem) {
-  p->id = id ;
-  p->mem = mem ;
-  hash_init(&p->t) ;
-  log_init(&p->out) ;
-  barrier_init(&p->b,N) ;
-  interval_init((int *)&p->ind,N) ;
+  p->id = id;
+  p->mem = mem;
+  hash_init(&p->t);
+  log_init(&p->out);
+  barrier_init(&p->b,N);
+  interval_init((int *)&p->ind,N);
+  p->stop_now = 0;
 #ifdef SOME_VARS
   vars_init(&p->v,mem);
   labels_init(&p->v);
@@ -103,6 +105,10 @@ typedef struct global_t {
   /* statistics */
   stats_t stats ;
 #endif
+  /* Support for early exit when postcondition is observed */
+  int speedcheck ;
+  /* Flag to exit when postcondition is observed - only when speedcheck is enabled */
+  int stop_now ;
 } global_t ;
 
 

--- a/litmus/libdir/_main.c
+++ b/litmus/libdir/_main.c
@@ -59,7 +59,7 @@ int RUN(int argc,char **argv,FILE *out) {
 #else
   const int delta_tb = 0;
 #endif
-  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, };
+  opt_t def = { 0, NUMBER_OF_RUN, SIZE_OF_TEST, AVAIL, NEXE, delta_tb, 0, 0 };
   opt_t d = def;
   char *prog = argv[0];
   char **p = parse_opt(argc,argv,&def,&d);
@@ -94,6 +94,8 @@ int RUN(int argc,char **argv,FILE *out) {
     fprintf(stderr,"%s: n=%d, r=%d, s=%d\n",prog,glo_ptr->nexe,glo_ptr->nruns,glo_ptr->size);
 #endif
   }
+  glo_ptr->speedcheck = d.speedcheck;
+  glo_ptr->stop_now = 0;
   parse_param(prog,glo_ptr->parse,PARSESZ,p);
 #ifdef PRELUDE
   prelude(out);

--- a/litmus/libdir/_presi.c
+++ b/litmus/libdir/_presi.c
@@ -174,6 +174,10 @@ static void usage_opt(char *prog,opt_t *d) {
   if (d->delay > 0) {
     fprintf(stderr,"  -tb <n> time base delay  (default %d)\n",d->delay) ;
   }
+  if (d->speedcheck >= 0) {
+      fprintf(stderr,"  +sc    stop as soon as possible%s\n", d->speedcheck ? " (default)" : "") ;
+      fprintf(stderr,"  -sc    run test completely%s\n", !d->speedcheck ? " (default)" : "") ;
+  }
   fprintf(stderr,"  +fix    do not shuffle threads\n");
   exit(2) ;
 }
@@ -221,6 +225,10 @@ char **parse_opt(int argc,char **argv,opt_t *d, opt_t *p) {
       if (p->delay < 1) p->delay = 1 ;
     } else if (strcmp(*argv,"+fix") == 0) {
       p->fix = 1 ;
+    } else if (strcmp(*argv,"+sc") == 0) {
+      p->speedcheck = 1;
+    } else if (strcmp(*argv,"-sc") == 0) {
+      p->speedcheck = 0;
     } else usage_opt(prog,d);
   }
 }

--- a/litmus/libdir/_presi.h
+++ b/litmus/libdir/_presi.h
@@ -99,6 +99,7 @@ typedef struct {
   int avail ;
   int n_exe ;
   int delay ;
+  int speedcheck ;
   int fix ;
 } opt_t ;
 

--- a/litmus/libdir/_utils.c
+++ b/litmus/libdir/_utils.c
@@ -476,7 +476,7 @@ static void usage(char *prog, cmd_t *d) {
   }
   if (d->speedcheck >= 0) {
     log_error("  +sc     stop as soon as possible%s\n",d->speedcheck ? " (default)" : "") ;
-    log_error("  -sc     run test completly%s\n",!d->speedcheck ? " (default)" : "") ;
+    log_error("  -sc     run test completely%s\n",!d->speedcheck ? " (default)" : "") ;
   }
   if (!d->fix) {
     log_error("  +fix    fix thread launch order\n") ;


### PR DESCRIPTION
This change adds support for the speedcheck parameter for -mode presi. This was already supported in -mode std. The user can provide the parameter "+sc" which will force the exit to as soon as the post-condition is observed.