### PR TITLE
[build] Specify 1.13 as the minimal version for zarith

### DIFF
--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune"  {>= "2.7" }
   "menhir" {>= "20200123"}
-  "zarith" {>= "1.10"}
+  "zarith" {>= "1.13"}
   "conf-which"
 ]
 conflicts: ["ocaml-option-bytecode-only"]


### PR DESCRIPTION
Some convenient functions such as `of_int64_unsigned` are introduced by this recent version.
