### PR TITLE
[all]: Add support for SVE fault tolerant instructions

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -111,12 +111,13 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_MOPL _
     | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
     | I_UADDV _
+    | I_LDNF1 _ | I_LDFF1SP _
     | I_LD1SP _ | I_LD2SP _ | I_LD3SP _ | I_LD4SP _
     | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
     | I_MOV_SV _
     | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
     | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
-    | I_DUP_SV _ | I_ADD_SV _ | I_PTRUE _
+    | I_DUP_SV _ | I_ADD_SV _ | I_PTRUE _ | I_SETFFR | I_RDFFR _
     | I_NEG_SV _ | I_MOVPRFX _
       -> true
 
@@ -272,6 +273,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD4 (rs,_,_,_) | I_LD4R (rs,_,_) | I_ST4 (rs,_,_,_)
       | I_LD4M (rs,_,_) | I_ST4M (rs,_,_) ->
           Some (simd_mem_access_size rs)
+      | I_LDNF1 (v,_,_,_,_) | I_LDFF1SP (v,_,_,_,_)
       | I_LD1SP (v,_,_,_,_) | I_ST1SP (v,_,_,_,_)
       | I_LD2SP (v,_,_,_,_) | I_ST2SP (v,_,_,_,_)
       | I_LD3SP (v,_,_,_,_) | I_ST3SP (v,_,_,_,_)
@@ -303,7 +305,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
       | I_UADDV _
       | I_MOV_SV _ | I_DUP_SV _ | I_ADD_SV _ | I_PTRUE _
-      | I_NEG_SV _ | I_MOVPRFX _
+      | I_NEG_SV _ | I_MOVPRFX _ | I_SETFFR | I_RDFFR _
       | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
       | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
           -> None
@@ -338,6 +340,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_NOP|I_TBZ _|I_TBNZ _
       | I_BL _ | I_BLR _ | I_RET _ | I_ERET | I_UDF _
       | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
+      | I_SETFFR
         -> [] (* For -variant self only ? *)
       | I_LDR (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
       | I_LDRBH (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
@@ -372,16 +375,18 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_FMOV_TG (_,r,_,_)
       | I_WHILELT (r,_,_,_) | I_WHILELE (r,_,_,_) | I_WHILELO (r,_,_,_) | I_WHILELS (r,_,_,_)
       | I_UADDV (_,r,_,_)
-      | I_MOV_SV (r,_,_)
+      | I_MOV_SV (r,_,_) | I_RDFFR (r,_)
       | I_DUP_SV (r,_,_) | I_ADD_SV (r,_,_) | I_PTRUE (r,_)
       | I_NEG_SV (r,_,_) | I_MOVPRFX (r,_,_)
       | I_INDEX_SI (r,_,_,_) | I_INDEX_IS (r,_,_,_) | I_INDEX_SS (r,_,_,_) | I_INDEX_II (r,_,_)
       | I_RDVL (r,_) | I_ADDVL (r,_,_) | I_CNT_INC_SVE (_,r,_,_)
+      | I_LDNF1 (_,r,_,_,_)
         -> [r]
       | I_MSR (sr,_)
         -> [(SysReg sr)]
       | I_LDXP (_,_,r1,r2,_)
         -> [r1;r2;]
+      | I_LDFF1SP (_,rs,_,_,_)
       | I_LD1SP (_,rs,_,_,_)
       | I_LD2SP (_,rs,_,_,_)
       | I_LD3SP (_,rs,_,_,_)
@@ -449,9 +454,10 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_ADDSUBEXT _|I_MOPL _
       | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
       | I_UADDV _
+      | I_LDNF1 _ | I_LDFF1SP _
       | I_LD1SP _ | I_LD2SP _ | I_LD3SP _ | I_LD4SP _
       | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
-      | I_ADD_SV _ | I_PTRUE _
+      | I_ADD_SV _ | I_PTRUE _ | I_SETFFR | I_RDFFR _
       | I_NEG_SV _ | I_MOVPRFX _
       | I_MOV_SV _ | I_DUP_SV _
       | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _

--- a/herd/tests/instructions/AArch64.sve/V28.litmus
+++ b/herd/tests/instructions/AArch64.sve/V28.litmus
@@ -1,0 +1,11 @@
+AArch64 V28
+{}
+P0               ;
+MOV Z0.S,#1      ;
+PTRUE P0.S,VL2   ;
+SETFFR           ;
+RDFFR P1.B,P0/Z  ;
+UADDV D2,P1,Z0.S ;
+
+forall 0:V2.4S={2,0,0,0}
+

--- a/herd/tests/instructions/AArch64.sve/V28.litmus.expected
+++ b/herd/tests/instructions/AArch64.sve/V28.litmus.expected
@@ -1,0 +1,11 @@
+Test V28 Required
+States 1
+0:V2.4S={2,0,0,0};
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Scalable-Vector-Extensions-is-work-in-progress
+Condition forall (0:V2.4S={2,0,0,0})
+Observation V28 Always 1 0
+Hash=b9acf152c7bad27dd72291dbcd60e586
+

--- a/herd/tests/instructions/AArch64.sve/V29.litmus
+++ b/herd/tests/instructions/AArch64.sve/V29.litmus
@@ -1,0 +1,9 @@
+AArch64 V29
+{}
+P0               ;
+MOV Z0.S,#1      ;
+PTRUE P0.S,VL2   ;
+RDFFR P1.B,P0/Z  ;
+UADDV D2,P1,Z0.S ;
+
+forall 0:V2.4S={0,0,0,0}

--- a/herd/tests/instructions/AArch64.sve/V29.litmus.expected
+++ b/herd/tests/instructions/AArch64.sve/V29.litmus.expected
@@ -1,0 +1,11 @@
+Test V29 Required
+States 1
+0:V2.4S={0,0,0,0};
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Scalable-Vector-Extensions-is-work-in-progress
+Condition forall (0:V2.4S={0,0,0,0})
+Observation V29 Always 1 0
+Hash=2033f7d41b7302ac5ca7f6ff86df7236
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -668,9 +668,10 @@ include Arch.MakeArch(struct
     (* Scalable Vector Extension *)
     | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
     | I_UADDV _ | I_DUP_SV _ | I_ADD_SV _ | I_NEG_SV _ | I_MOVPRFX _
+    | I_LDNF1 _ | I_LDFF1SP _
     | I_LD1SP _ | I_LD2SP _ | I_LD3SP _ | I_LD4SP _
     | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
-    | I_MOV_SV _ | I_PTRUE _
+    | I_MOV_SV _ | I_PTRUE _ | I_SETFFR | I_RDFFR _
     | I_INDEX_SI _ | I_INDEX_IS _  | I_INDEX_SS _ | I_INDEX_II _
     | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
         -> Warn.fatal "SVE instructions are not implemented yet"

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -151,6 +151,16 @@ match name with
 | "whilelo" | "WHILELO" -> WHILELO
 | "whilels" | "WHILELS" -> WHILELS
 | "uaddv" | "UADDV" -> UADDV
+| "rdffr" | "RDFFR" -> RDFFR
+| "setffr" | "SETFFR" -> SETFFR
+| "ldnf1b" | "LDNF1B" -> LDFF1B
+| "ldnf1h" | "LDNF1H" -> LDFF1H
+| "ldnf1w" | "LDNF1W" -> LDFF1W
+| "ldnf1d" | "LDNF1D" -> LDFF1D
+| "ldff1b" | "LDFF1B" -> LDFF1B
+| "ldff1h" | "LDFF1H" -> LDFF1H
+| "ldff1w" | "LDFF1W" -> LDFF1W
+| "ldff1d" | "LDFF1D" -> LDFF1D
 | "ld1b" | "LD1B" -> LD1B
 | "ld1h" | "LD1H" -> LD1H
 | "ld1w" | "LD1W" -> LD1W


### PR DESCRIPTION
SVE adds instructions which can suppresses memory fault, specifically:

 - Load first-fault
 - Load non-fault
 - Auxiliary instructions to inspect First Fault Register (FFR)