### PR TITLE
[herd] Demote scalar offsets before sign extending them.

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2713,7 +2713,9 @@ module Make
             (ma >>| mo >>| read_reg_scalable true r ii >>= fun ((base,offsets),v) ->
               let op idx =
                 let store =
-                  (scalable_getlane offsets idx esize >>= memext_sext e k >>= fun o ->
+                  (scalable_getlane offsets idx esize
+                   (* Warning: no sign extension on wide scalars *)
+                   >>= demote >>= memext_sext e k >>= fun o ->
                     M.add o base) >>|
                     (scalable_getlane v idx esize >>= demote)
                   >>= fun (addr,v) -> write_mem sz aexp Access.VIR addr v ii in

--- a/herd/tests/instructions/AArch64.sve/V30.litmus
+++ b/herd/tests/instructions/AArch64.sve/V30.litmus
@@ -1,0 +1,26 @@
+AArch64 V30
+(* Write scatter. In particular, test sign extension *)
+Variant=sve:512
+{
+int t[4];
+uint8_t u[8];
+int v[4];
+0:X0=t;
+0:X1=u;
+0:X2=v;
+}
+  P0              ;
+ INDEX Z0.S,#0,#1 ;
+ INDEX Z1.S,#2,#2 ;
+ PTRUE P0.S,VL4   ;
+ ST1W {Z1.S},P0,[X0,Z0.S,SXTW #2] ;
+ INDEX Z1.D,#0,#2 ;
+ PTRUE P0.D,VL4  ;
+ ST1B {Z1.D},P0,[X1,Z1.D] ;
+ ADD X2,X2,#16;
+ INDEX Z0.S,#1,#1   ;
+ INDEX Z1.S,#-1,#-1 ;
+ PTRUE P0.S,VL4   ;
+ ST1W {Z0.S},P0,[X2,Z1.S,SXTW #2] ;
+
+forall t={2,4,6,8} /\ u={0,0,2,0,4,0,6,0} /\ v={4,3,2,1}

--- a/herd/tests/instructions/AArch64.sve/V30.litmus.expected
+++ b/herd/tests/instructions/AArch64.sve/V30.litmus.expected
@@ -1,0 +1,11 @@
+Test V30 Required
+States 1
+t={2,4,6,8}; u={0,0,2,0,4,0,6,0}; v={4,3,2,1};
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Scalable-Vector-Extensions-is-work-in-progress
+Condition forall (t={2,4,6,8} /\ u={0,0,2,0,4,0,6,0} /\ v={4,3,2,1})
+Observation V30 Always 1 0
+Hash=ea0982ad9093c09519535eb5fbd35b38
+


### PR DESCRIPTION
Fix a small bug found by testing the implemented scatter store instruction.