### PR TITLE
[herd] Systematic delaying of failures.

### DIFF
--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -1664,15 +1664,22 @@ Monad type:
     (* Operations, no events generated, only equations *)
     (***************************************************)
 
+    let delay_op mk_c =
+      let v = V.fresh_var () in
+      make_one_monad v [VC.Assign (v, mk_c ())] E.empty_event_structure
+
     let any_op mk_v mk_c =
       try
         let v = mk_v () in
         make_one_monad v [] E.empty_event_structure
       with
-      | V.Undetermined
-        ->
-         let v = V.fresh_var () in
-         make_one_monad v [VC.Assign (v, mk_c ())] E.empty_event_structure
+      | V.Undetermined ->
+         (* Not ready yet add equation *)
+         delay_op mk_c
+      | exn ->
+         if C.debug.Debug_herd.exc then raise exn
+         (* Delay failure *)
+         else delay_op mk_c
 
     let op1 op v1 =
       any_op

--- a/herd/valconstraint.ml
+++ b/herd/valconstraint.ml
@@ -607,7 +607,9 @@ let get_failed cns =
              | _,_ -> sol,Assign (v,e)::eqs
            with
            | Contradiction|Misc.Timeout as exn -> raise exn
-           | exn -> (sol,Failed exn::eqs)
+           | exn ->
+              if C.debug.Debug_herd.exc then raise exn ;
+              (sol,Failed exn::eqs)
          end
 
     let topo_step cs (sol,eqs) =


### PR DESCRIPTION
The first phases of herd should behave as follows:

When some operation fails by raising some exception, the general rule is to delay the failure, hoping that the corresponding candidate execution will be eliminate when solving equations.

However, this behaviour may complicate debugging. Hence the command line option `-debug exception` replace it with immediately raising the exception.

This PR generalises the expected behaviour.

Notice that exceptions used for controlling herd engine (Undetermined, Contradiction and Timeout) follow their own rules