### PR TITLE
[litmus]: Use the ‘&’ constraint modifier in aarch64's reg_class_stable

### DIFF
--- a/litmus/AArch64Arch_litmus.ml
+++ b/litmus/AArch64Arch_litmus.ml
@@ -82,8 +82,8 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
              constraint "+" and the explicit initialization of the 'stable_*' variables.
              The same applies to SVE instruction with P/M (merging predicate) *)
           | Vreg _ | SIMDreg _  | Zreg _ -> "+w"
-          | Preg _ | PMreg _ -> "=Upa"
-          | _ -> "=r"
+          | Preg _ | PMreg _ -> "=&Upa"
+          | _ -> "=&r"
         let comment = comment
 
 (* t1 is declared (or inferred) type, t2 is type from instruction *)


### PR DESCRIPTION
Consider following example litmus test

```
AArch64 T
stable=x12
{
0:X0=x;
}
P0              ;
MOV X12,XZR     ;
LDR X1,[X0,X12] ;
```
which `litmus7` transforms into

```
register int64_t stable_x12 asm("x12");
asm __volatile__ (
"\n"
"#START _litmus_P0\n"
"#_litmus_P0_0\n\t"
"mov %[x12],xzr\n"
"#_litmus_P0_1\n\t"
"ldr %[x1],[%[x0],%[x12]]\n"
"#END _litmus_P0\n"
:[x1] "=&r" (trashed_x1),[x12] "=r" (stable_x12)
:[x0] "r" (&_a->x[_i])
:"cc","memory"
);

```
When build with with GCC 14.1.0 result code seems reuse `x12` as base register

```
 cc:   aa1f03ec        mov     x12, xzr
 d0:   f86c6980        ldr     x0, [x12, x12]
```

The way to fix that is to use the ‘&’ constraint modifier on stable reg as well so output operands not overlap an input.