### PR TITLE
[litmus]: Use 'Upl' constraint modifier for predicate register

### DIFF
--- a/litmus/AArch64Arch_litmus.ml
+++ b/litmus/AArch64Arch_litmus.ml
@@ -72,7 +72,7 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
 
         let reg_class reg = match reg with
           | Vreg _ | SIMDreg _ | Zreg _ -> "=&w"
-          | Preg _ | PMreg _ -> "=&Upa"
+          | Preg _ | PMreg _ -> "=&Upl"
           | _ -> "=&r"
         let reg_class_stable reg = match reg with
           (* Certain Neon instructions do not affect the whole register, so we need to
@@ -82,7 +82,7 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
              constraint "+" and the explicit initialization of the 'stable_*' variables.
              The same applies to SVE instruction with P/M (merging predicate) *)
           | Vreg _ | SIMDreg _  | Zreg _ -> "+w"
-          | Preg _ | PMreg _ -> "=&Upa"
+          | Preg _ | PMreg _ -> "=&Upl"
           | _ -> "=&r"
         let comment = comment
 


### PR DESCRIPTION
Constraint modifier we currently use for predicate register is

 `Upa` - Any of the SVE predicate registers (P0 to P15)

That made a trick so far, yet with GCC 14.1.0 it seems that register allocation happens top to bottom, yet most of SVE instructions we support allow predicate register only in a range P0 to P7. So build fails.

Let's work it around by using `Upl` constraint modifier for predicate register:

  `Upl` - One of the low eight SVE predicate registers (P0 to P7)