### PR TITLE
[herd] Add debug message at cat model interpretation start

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -1138,7 +1138,8 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
 
         let libfind = ASLConf.libfind
       end) in
-      Model.Generic (P.parse fname)
+      let fname,m = P.find_parse fname in
+      Model.Generic (fname,m)
 
     let is_strict = C.variant Variant.Strict
     let is_warn = C.variant Variant.Warn && not is_strict

--- a/herd/BellMem.ml
+++ b/herd/BellMem.ml
@@ -44,10 +44,11 @@ module S = S
     module S = S
 
     let check_event_structure test = match O.model with
-    | Generic m ->
+    | Generic (fname,m) ->
         let module X =
           MachModelChecker.Make
             (struct
+              let fname = fname
               let m = m
               let wide_po = false
               include O

--- a/herd/CMem.ml
+++ b/herd/CMem.ml
@@ -39,10 +39,11 @@ module Make
     module S = S
 
     let check_event_structure test = match O.model with
-    | Generic m ->
+    | Generic (fname,m) ->
         let module X =
             MachModelChecker.Make
               (struct
+                let fname = fname
                 let m = m
                 let wide_po = true
                 include O

--- a/herd/MemCat.ml
+++ b/herd/MemCat.ml
@@ -38,10 +38,11 @@ module S = S
     let model = O.model
 
     let check_event_structure test = match O.model with
-      | Generic m ->
+      | Generic (fname,m) ->
          let module X =
            MachModelChecker.Make
              (struct
+               let fname = fname
                let m = m
                let wide_po = false
                include O

--- a/herd/MemWithCav12.ml
+++ b/herd/MemWithCav12.ml
@@ -46,10 +46,11 @@ module Make
             end)
             (S) in
         X.check_event_structure test
-    | Generic m ->
+    | Generic (fname,m) ->
         let module X =
           MachModelChecker.Make
             (struct
+              let fname = fname
               let m = m
               let bell_model_info = None
               let wide_po = false

--- a/herd/getModel.ml
+++ b/herd/getModel.ml
@@ -16,7 +16,7 @@
 
 let check_arch_model a m =
   match m with
-  | Model.Generic (o,_,_) ->
+  | Model.Generic (_,(o,_,_)) ->
       begin match o.ModelOption.arch with
       | None -> m
       | Some b ->
@@ -40,7 +40,8 @@ let parse archcheck arch libfind variant model =
             include LexUtils.Default
             let libfind = libfind
           end) in
-      Model.Generic (P.parse fname)
+      let fname,ast = P.find_parse fname in
+      Model.Generic (fname,ast)
   | _ -> m in
   if archcheck then check_arch_model arch m
   else m

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -394,8 +394,8 @@ let model,model_opts = match !model with
 | Some (Model.File fname) ->
     let module P = ParseModel.Make(ParserConfig) in
     begin try
-      let (b,_,_) as r = P.parse fname in
-      Some (Model.Generic r),b
+      let (fname,((b,_,_) as r)) = P.find_parse fname in
+      Some (Model.Generic (fname,r)),b
     with
     | Misc.Fatal msg -> eprintf "%s: %s\n" prog msg ; exit 2
     | Misc.Exit ->

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -17,6 +17,7 @@
 (** Check an event structure against a machine model *)
 
 module type Config = sig
+  val fname : string
   val m : AST.t
   val bell_model_info : (string * BellModel.info) option
 (* Include events from the same instance in po, essential for the LKMM *)
@@ -229,6 +230,11 @@ module Make
       let all_evts =  conc.S.str.E.events in
       let evts =
         choose_spec Misc.identity (E.EventSet.filter relevant) all_evts in
+      let () =
+        if O.debug then
+          Printf.eprintf
+            "Cat run, fname=%s, nevts=%d\n%!"
+            O.fname (E.EventSet.cardinal evts) in
       let mem_evts = lazy (E.EventSet.filter E.is_mem evts) in
       let po =
         choose_spec

--- a/herd/model.ml
+++ b/herd/model.ml
@@ -24,7 +24,7 @@ type jade_opt = { jstrongst : bool;}
 type t =
   | File of string (* To convey model filename *)
   | CAV12 of cav12_opt
-  | Generic of AST.t
+  | Generic of string * AST.t (* filename X ast *)
 
 let tags =
   [
@@ -49,7 +49,7 @@ let pp = function
   | CAV12 {cord=true; strongst=false;} ->"cav12_lightst"
   | CAV12 {cord=false; strongst=false;} ->"cav12_nocord_lightst"
   | File fname -> fname
-  | Generic (opts,name,_) ->
+  | Generic (_,(opts,name,_)) ->
       sprintf "Generic%s(%s)"
         (ModelOption.pp opts) name
 

--- a/herd/model.mli
+++ b/herd/model.mli
@@ -23,7 +23,7 @@ type jade_opt = { jstrongst : bool;}
 type t =
   | File of string (* To convey model filename *)
   | CAV12 of cav12_opt
-  | Generic of AST.t
+  | Generic of string * AST.t (* Filename X ast *)
 
 val tags : string list
 val parse : string -> t option


### PR DESCRIPTION
Simply one more debug message at cat interpretation start, commanded by option `-debug model`.
