### PR TITLE
[format] Bump ocamlformat to a version compatible with ocaml 5.2

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -28,6 +28,6 @@ jobs:
         with:
           ocaml-compiler: 5.1
 
-      - run: opam install dune ocamlformat.0.26.1
+      - run: opam install dune ocamlformat.0.26.2
 
       - run: opam exec -- dune fmt

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version = 0.26.1
+version = 0.26.2
 disable = true


### PR DESCRIPTION
Ocamlformat version 0.26.1 is not compatible with ocaml 5.2 ([source](https://github.com/ocaml/opam-repository/blob/master/packages/ocamlformat/ocamlformat.0.26.1/opam)), but ocaml version 0.26.2 is ([source](https://github.com/ocaml/opam-repository/blob/master/packages/ocamlformat/ocamlformat.0.26.2/opam)), so as the bump is trivial (no diff on any source file), we can bump it to this version.