### PR TITLE
[asl] Fix the non-determinstic ASL primitive `somebool`

### DIFF
--- a/herd/tests/instructions/ASL-pseudo-arch/non-determinsitic.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/non-determinsitic.litmus
@@ -1,0 +1,21 @@
+ASL non-deterministic
+
+{ }
+
+// Non deterministically returns 1 or 2
+func g() => integer
+begin
+  let b = SomeBoolean();
+  if b then
+    return 1;
+  end
+  return 2;
+end
+
+func main() => integer
+begin
+  let z = g();
+  return 0;
+end
+
+locations [0:main.0.z;]

--- a/herd/tests/instructions/ASL-pseudo-arch/non-determinsitic.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/non-determinsitic.litmus.expected
@@ -1,0 +1,11 @@
+Test non-deterministic Required
+States 2
+0:main.0.z=1;
+0:main.0.z=2;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (true)
+Observation non-deterministic Always 2 0
+Hash=a1fe6ee8fcbd420fe4e92404821ba498
+


### PR DESCRIPTION
Before, the evaluation of the `somebool` primitive by "ASLSem" was yielding no candidate, because of some unsolved equations. Now, we have two candidates, as expected.

As an example the following litmus test now yields two candidates:
```
ASL non-deterministic

{ }

// Non deterministically returns 1 or 2
func g() => integer
begin
  let b = SomeBoolean();
  if b then
    return 1;
  end
  return 2;
end

func main() => integer
begin
  let z = g();
  return 0;
end

locations [0:main.0.z;]
```