### PR TITLE
[herd] Asl bool condition

### DIFF
--- a/herd/tests/instructions/ASL/unknown-integer.litmus
+++ b/herd/tests/instructions/ASL/unknown-integer.litmus
@@ -1,0 +1,30 @@
+ASL UnknownInteger
+
+variant = ASL
+(*
+  Variant ASL implies that candidates with
+  unresolved equations are not rejected.
+  Without it, evaluatong this tests results
+  in zero execution.
+*)
+
+{}
+
+func random_integer () => integer
+begin
+  return (UNKNOWN :: integer);
+end
+
+func main () => integer
+begin
+  var x: integer;
+  let y = random_integer ();
+  if y == 0 then
+    x = 1;
+  else
+    x = 0;
+  end
+  return 0;
+end
+
+locations [0:main.0.x;]

--- a/herd/tests/instructions/ASL/unknown-integer.litmus.expected
+++ b/herd/tests/instructions/ASL/unknown-integer.litmus.expected
@@ -1,0 +1,11 @@
+Test UnknownInteger Required
+States 2
+0:main.0.x=0;
+0:main.0.x=1;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (true)
+Observation UnknownInteger Always 2 0
+Hash=ed993d2e5e2767aeaae40022aabc1627
+

--- a/herd/tests/instructions/ASL/unknown.litmus
+++ b/herd/tests/instructions/ASL/unknown.litmus
@@ -1,6 +1,12 @@
 ASL Unknown
-variant = ASL
-(* Variant ASL to allow unresolved variables in result. *)
+
+(* variant = ASL *)
+(*
+  Variant ASL allows unresolved equations.
+  Deleted as the new implementation of 'if'
+  now assigns condition to TRUE or FALSE,
+  depending upon the selected branch.
+*)
 
 {}
 
@@ -11,9 +17,9 @@ end
 
 func main () => integer
 begin
-  var x: boolean;
-
-  if random_bool () then
+  var x: integer;
+  let b = random_bool ();
+  if b then
     x = 1;
   else
     x = 0;
@@ -22,4 +28,4 @@ begin
   return 0;
 end
 
-locations [0: main.0.x]
+locations [0:main.0.x; 0:main.0.b;]

--- a/herd/tests/instructions/ASL/unknown.litmus.expected
+++ b/herd/tests/instructions/ASL/unknown.litmus.expected
@@ -1,11 +1,11 @@
 Test Unknown Required
 States 2
-0:main.0.x=0;
-0:main.0.x=1;
+0:main.0.b=FALSE; 0:main.0.x=0;
+0:main.0.b=TRUE; 0:main.0.x=1;
 Ok
 Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation Unknown Always 2 0
-Hash=e9207fd12ef12177972a17e0c8a08546
+Hash=c0f43ab99032e03a9007bb4c2eeccc8b
 


### PR DESCRIPTION
The choice operator of the "concurrent" ASL interpreted now assigns unresolved condition  to TRUE or FALSE depending on the selected branch.

As a result the "SomeBoolean" primitive can now reduce to a simple non-resolved variable and could have been replaced by the construct `UNKNOWN : boolean`. Typically the following running **herd7** on the following test will result in two outcomes with values `0` and `1` for `x`. Moreover the final values of `b` are `FALSE` and `TRUE`, respectively.
```
ASL U
{}

func main() => integer
begin
  var x = 0;
  let b = UNKNOWN : boolean;
  if b then
    x = 1;
  end
  return 0;
end

locations [0:main.0.x;]
```
Previously, the same result could be achieved by adding option `-variant ASL` or by replacing the `UNKNOWN` expression by a primitive call `SomeBoolean ()`.

Unfortunately this "complete" resolution does not succeed in general. See the example `herd/tests/instructions/ASL/unknown-integer.litmus` for instance.