### PR TITLE
[gen] Generate C atomic exchange.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -641,6 +641,27 @@ diy-test-mte::
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64.MTE diycross7 tests: OK"
 
+diy-test::  diy-test-C
+diy-test-C:
+	@ echo
+	$(HERD_DIYCROSS_REGRESSION_TEST) \
+		-j $(J) \
+		-herd-path $(HERD) \
+		-diycross-path $(DIYCROSS) \
+		-libdir-path ./herd/libdir \
+		-expected-dir ./herd/tests/diycross/C \
+		-conf ./herd/tests/diycross/C/C.cfg \
+		-diycross-arg -arch \
+                -diycross-arg C \
+		-diycross-arg [Rlx,Coe,Rlx],[Rlx,Rfe,Rlx],[Rlx,Fre,Rlx],[Rlx,Hat,Rlx] \
+                -diycross-arg PosRW,Fetch.Add,Exch \
+                -diycross-arg Rlx \
+                -diycross-arg PodW* \
+		-diycross-arg [Rlx,Coe,Rlx],[Rlx,Rfe,Rlx],[Rlx,Fre,Rlx] \
+                -diycross-arg Pod**,[Fetch.Add,Rlx,PodW*] \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 C diycross7 tests: OK"
+
 .PHONY: asl-pseudocode clean-asl-pseudocode
 asl-pseudocode: herd/libdir/asl-pseudocode/shared_pseudocode.asl
 herd/libdir/asl-pseudocode/shared_pseudocode.asl:

--- a/gen/CCompile_gen.ml
+++ b/gen/CCompile_gen.ml
@@ -161,22 +161,23 @@ module Make(O:Config) : Builder.S
               A.AtomicLoad (mo,eloc)
             else Warn.fatal "wrong memory order for load"
 
-      let excl_from omo loc v = match omo with
-      | None -> Warn.fatal "Non atomic RMW"
-      | Some mo ->
-          if A.applies_atom_rmw () omo omo then
-            A.AtomicExcl (mo,A.Load loc,v)
-          else
-            Warn.fatal "wrong memory order for atomic exchange"
+      let excl_from omo omo_w loc v = match omo,omo_w with
+      | (None,_)|(_, None) -> Warn.fatal "Non atomic RMW"
+      | Some _,Some _ ->
+          match A.tr_atom_rmw omo omo_w with
+          | Some mo ->
+              A.AtomicExcl (mo,A.Load loc,v)
+          | None ->
+              Warn.fatal "wrong memory order for atomic exchange"
 
       let compile_load st p mo loc =
         let r,st = alloc_reg p st in
         let i =  A.Decl (A.Plain A.deftype,r,Some (load_from No mo loc)) in
         r,i,st
 
-      let compile_excl st p mo loc v =
+      let compile_excl st p mo mo_w loc v =
         let r,st = alloc_reg p st in
-        let i =  A.Decl (A.Plain A.deftype,r,Some (excl_from mo loc v)) in
+        let i =  A.Decl (A.Plain A.deftype,r,Some (excl_from mo mo_w loc v)) in
         r,i,st
 
       let assertval pdp mo loc v =
@@ -184,10 +185,10 @@ module Make(O:Config) : Builder.S
           A.AssertVal(load_from pdp mo loc,v)
         else load_from pdp mo loc
 
-      let assert_excl v1 mo loc v2 =
+      let assert_excl v1 mo mo_w loc v2 =
         if O.cpp then
-          A.AssertVal(excl_from mo loc v2 ,v1)
-        else excl_from mo loc v2
+          A.AssertVal(excl_from mo mo_w loc v2 ,v1)
+        else excl_from mo mo_w loc v2
 
 
       let compile_load_assertvalue pdp v st p mo loc =
@@ -198,12 +199,12 @@ module Make(O:Config) : Builder.S
              Some (assertval pdp mo loc v)) in
         r,i,st
 
-      let compile_excl_assertvalue v1 st p mo loc v2 =
+      let compile_excl_assertvalue v1 st p mo mo_w loc v2 =
         let r,st = alloc_reg p st in
         let i =
           A.Decl
             (A.Plain A.deftype,r,
-             Some (assert_excl v1 mo loc v2)) in
+             Some (assert_excl v1 mo mo_w loc v2)) in
         r,i,st
 
 
@@ -268,8 +269,9 @@ module Make(O:Config) : Builder.S
             let v = n.C.next.C.evt.C.v in
             let loc = A.Loc loc in
             let mo = e.C.atom in
+            let mo_w = n.C.next.C.evt.C.atom in
             let r,i,st =
-              compile_excl_assertvalue e.C.v st p mo loc v in
+              compile_excl_assertvalue e.C.v st p mo mo_w loc v in
             Some r,i,st
         | (Some W|None),_ -> None,A.Nop,st
         | (Some J,_)|(_,Code _) -> assert false
@@ -694,15 +696,16 @@ module Make(O:Config) : Builder.S
             | Some R,Data x ->
                 let vw = n.C.next.C.evt.C.v
                 and mo = e.C.atom
+                and mo_w = n.C.next.C.evt.C.atom
                 and loc = A.Loc x
                 and v = e.C.v in
                 if O.cpp then
-                  let ce = A.Const v,A.Eq,assert_excl vw mo loc v in
+                  let ce = A.Const v,A.Eq,assert_excl vw mo mo_w loc v in
                   None,
                   (fun ins -> A.If (ce,add_fence n ins,load_checked_not)),
                   st
                 else
-                  let r,i,st = compile_excl st p mo loc vw in
+                  let r,i,st = compile_excl st p mo mo_w loc vw in
                   let ce = A.Const v,A.Eq,A.Load (A.Reg (p,r)) in
                   Some r,
                   (fun ins ->

--- a/gen/CCompile_gen.ml
+++ b/gen/CCompile_gen.ml
@@ -161,12 +161,19 @@ module Make(O:Config) : Builder.S
               A.AtomicLoad (mo,eloc)
             else Warn.fatal "wrong memory order for load"
 
-      let excl_from omo omo_w loc v = match omo,omo_w with
+      let exch_from rmw omo omo_w loc v = match omo,omo_w with
       | (None,_)|(_, None) -> Warn.fatal "Non atomic RMW"
       | Some _,Some _ ->
           match A.tr_atom_rmw omo omo_w with
           | Some mo ->
-              A.AtomicExcl (mo,A.Load loc,v)
+              begin
+                match rmw.E.edge with
+                | E.Rmw A.Exch ->
+                    A.AtomicExch (mo,A.Load loc,v)
+                | E.Rmw A.Add ->
+                    A.AtomicFetchOp (mo,A.Load loc,v)
+                | _ -> assert false
+              end
           | None ->
               Warn.fatal "wrong memory order for atomic exchange"
 
@@ -175,9 +182,10 @@ module Make(O:Config) : Builder.S
         let i =  A.Decl (A.Plain A.deftype,r,Some (load_from No mo loc)) in
         r,i,st
 
-      let compile_excl st p mo mo_w loc v =
+      let compile_exch rmw st p mo mo_w loc v =
         let r,st = alloc_reg p st in
-        let i =  A.Decl (A.Plain A.deftype,r,Some (excl_from mo mo_w loc v)) in
+        let i =
+          A.Decl (A.Plain A.deftype,r,Some (exch_from rmw mo mo_w loc v)) in
         r,i,st
 
       let assertval pdp mo loc v =
@@ -185,10 +193,10 @@ module Make(O:Config) : Builder.S
           A.AssertVal(load_from pdp mo loc,v)
         else load_from pdp mo loc
 
-      let assert_excl v1 mo mo_w loc v2 =
+      let assert_exch rmw v1 mo mo_w loc v2 =
         if O.cpp then
-          A.AssertVal(excl_from mo mo_w loc v2 ,v1)
-        else excl_from mo mo_w loc v2
+          A.AssertVal(exch_from rmw mo mo_w loc v2 ,v1)
+        else exch_from rmw mo mo_w loc v2
 
 
       let compile_load_assertvalue pdp v st p mo loc =
@@ -199,12 +207,12 @@ module Make(O:Config) : Builder.S
              Some (assertval pdp mo loc v)) in
         r,i,st
 
-      let compile_excl_assertvalue v1 st p mo mo_w loc v2 =
+      let compile_exch_assertvalue rmw v1 st p mo mo_w loc v2 =
         let r,st = alloc_reg p st in
         let i =
           A.Decl
             (A.Plain A.deftype,r,
-             Some (assert_excl v1 mo mo_w loc v2)) in
+             Some (assert_exch rmw v1 mo mo_w loc v2)) in
         r,i,st
 
 
@@ -271,7 +279,7 @@ module Make(O:Config) : Builder.S
             let mo = e.C.atom in
             let mo_w = n.C.next.C.evt.C.atom in
             let r,i,st =
-              compile_excl_assertvalue e.C.v st p mo mo_w loc v in
+              compile_exch_assertvalue n.C.edge e.C.v st p mo mo_w loc v in
             Some r,i,st
         | (Some W|None),_ -> None,A.Nop,st
         | (Some J,_)|(_,Code _) -> assert false
@@ -700,12 +708,12 @@ module Make(O:Config) : Builder.S
                 and loc = A.Loc x
                 and v = e.C.v in
                 if O.cpp then
-                  let ce = A.Const v,A.Eq,assert_excl vw mo mo_w loc v in
+                  let ce = A.Const v,A.Eq,assert_exch n.C.edge vw mo mo_w loc v in
                   None,
                   (fun ins -> A.If (ce,add_fence n ins,load_checked_not)),
                   st
                 else
-                  let r,i,st = compile_excl st p mo mo_w loc vw in
+                  let r,i,st = compile_exch n.C.edge st p mo mo_w loc vw in
                   let ce = A.Const v,A.Eq,A.Load (A.Reg (p,r)) in
                   Some r,
                   (fun ins ->
@@ -863,10 +871,15 @@ module Make(O:Config) : Builder.S
         | AtomicLoad (mo,loc) ->
             sprintf "atomic_load_explicit(%s,%s)"
               (dump_exp loc) (dump_mem_order mo)
-        | AtomicExcl (MemOrder.SC,loc,v) ->
+        | AtomicExch (MemOrder.SC,loc,v) ->
             sprintf "atomic_exchange(%s,%i)" (dump_exp loc) v
-        | AtomicExcl (mo,loc,v) ->
+        | AtomicExch (mo,loc,v) ->
             sprintf "atomic_exchange_explicit(%s,%i,%s)"
+              (dump_exp loc) v (dump_mem_order mo)
+        | AtomicFetchOp (MemOrder.SC,loc,v) ->
+            sprintf "atomic_fetch_add(%s,%i)" (dump_exp loc) v
+        | AtomicFetchOp (mo,loc,v) ->
+            sprintf "atomic_fetch_add_explicit(%s,%i,%s)"
               (dump_exp loc) v (dump_mem_order mo)
         | Deref (Load _ as e) -> sprintf "*%s" (dump_exp e)
         | Deref e -> sprintf "*(%s)" (dump_exp e)
@@ -1027,8 +1040,11 @@ module Make(O:Config) : Builder.S
         | AtomicLoad (mo,loc) ->
             sprintf "%s.load(%s)"
               (dump_exp loc) (dump_mem_order mo)
-        | AtomicExcl (mo,loc,v) ->
+        | AtomicExch (mo,loc,v) ->
             sprintf "%s.exchange(%i,%s)"
+              (dump_exp loc) v (dump_mem_order mo)
+       | AtomicFetchOp (mo,loc,v) ->
+            sprintf "%s.fetch_add(%i,%s)"
               (dump_exp loc) v (dump_mem_order mo)
         | Deref (Load _ as e) -> sprintf "*%s" (dump_exp e)
         | Deref e -> sprintf "*(%s)" (dump_exp e)

--- a/herd/lexConf_herd.mll
+++ b/herd/lexConf_herd.mll
@@ -119,6 +119,12 @@ let handle_key main key arg = match key with
    includes := !includes @ [arg]
 | "timeout" ->
    lex_float_opt timeout arg
+| "debug" ->
+    begin
+      match Debug_herd.parse !debug arg with
+      | Some t -> debug := t
+      | None -> error (sprintf "bad argument for key debug: '%s'" arg)
+    end
 (* Change input *)
 | "names" ->
     names := !names @ [arg]
@@ -275,10 +281,9 @@ let handle_key main key arg = match key with
       List.map
         (fun f ->
           try float_of_string f
-          with _ -> error "bad argument for keyt shift: '%s' arg")
+          with _ -> error "bad argument for key shift: '%s' arg")
         fs in
     PP.shift := Array.of_list fs
-
 | "edgemerge" ->
     lex_bool PP.edgemerge arg
 | _ ->

--- a/herd/tests/diycross/C/C.cfg
+++ b/herd/tests/diycross/C/C.cfg
@@ -1,0 +1,2 @@
+conf cpp11.cfg
+cat rc11.cat

--- a/herd/tests/diycross/C/LB+fetch.addrlxrlx-porlxrlxs.litmus.expected
+++ b/herd/tests/diycross/C/LB+fetch.addrlxrlx-porlxrlxs.litmus.expected
@@ -1,0 +1,12 @@
+Test LB+fetch.addrlxrlx-porlxrlxs Allowed
+States 3
+0:r0=0; 1:r0=0; [x]=1; [y]=1;
+0:r0=0; 1:r0=1; [x]=1; [y]=3;
+0:r0=1; 1:r0=0; [x]=3; [y]=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists ([x]=3 /\ [y]=3 /\ 0:r0=1 /\ 1:r0=1)
+Observation LB+fetch.addrlxrlx-porlxrlxs Never 0 3
+Hash=fe66b6eadbe105fba30116ad60a70bd6
+

--- a/herd/tests/diycross/C/LB+porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/LB+porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,12 @@
+Test LB+porlxrlx+fetch.addrlxrlx-porlxrlx Allowed
+States 3
+0:r0=0; 1:r0=0; [y]=1;
+0:r0=0; 1:r0=1; [y]=3;
+0:r0=1; 1:r0=0; [y]=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists ([y]=3 /\ 0:r0=1 /\ 1:r0=1)
+Observation LB+porlxrlx+fetch.addrlxrlx-porlxrlx Never 0 3
+Hash=431a6363ef1a57fdce2ffe6286ca7cbd
+

--- a/herd/tests/diycross/C/LB+porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/LB+porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,14 @@
+Test LB+porlxrlx+posWrlxrlx-porlxrlx Allowed
+States 5
+0:r0=0; 1:r0=0; [y]=1;
+0:r0=0; 1:r0=0; [y]=2;
+0:r0=0; 1:r0=1; [y]=2;
+0:r0=1; 1:r0=0; [y]=1;
+0:r0=1; 1:r0=0; [y]=2;
+No
+Witnesses
+Positive: 0 Negative: 5
+Condition exists ([y]=2 /\ 0:r0=1 /\ 1:r0=1)
+Observation LB+porlxrlx+posWrlxrlx-porlxrlx Never 0 5
+Hash=eecfc8f12b0ef73a3912bcc452ac4aab
+

--- a/herd/tests/diycross/C/LB+porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/LB+porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,12 @@
+Test LB+porlxrlx+rmwrlxrlx-porlxrlx Allowed
+States 3
+0:r0=0; 1:r0=0; [y]=1;
+0:r0=0; 1:r0=1; [y]=2;
+0:r0=1; 1:r0=0; [y]=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists ([y]=2 /\ 0:r0=1 /\ 1:r0=1)
+Observation LB+porlxrlx+rmwrlxrlx-porlxrlx Never 0 3
+Hash=478ba61f055e14380ab54ae40f9735e7
+

--- a/herd/tests/diycross/C/LB+posWrlxrlx-porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/LB+posWrlxrlx-porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,14 @@
+Test LB+posWrlxrlx-porlxrlx+fetch.addrlxrlx-porlxrlx Allowed
+States 5
+0:r0=0; 1:r0=0; [x]=1; [y]=1;
+0:r0=0; 1:r0=0; [x]=2; [y]=1;
+0:r0=0; 1:r0=1; [x]=1; [y]=3;
+0:r0=0; 1:r0=1; [x]=2; [y]=3;
+0:r0=1; 1:r0=0; [x]=2; [y]=1;
+No
+Witnesses
+Positive: 0 Negative: 5
+Condition exists ([x]=2 /\ [y]=3 /\ 0:r0=1 /\ 1:r0=1)
+Observation LB+posWrlxrlx-porlxrlx+fetch.addrlxrlx-porlxrlx Never 0 5
+Hash=2c8aa4cfdfb4ba7e167a051222ddebbf
+

--- a/herd/tests/diycross/C/LB+rmwrlxrlx-porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/LB+rmwrlxrlx-porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,12 @@
+Test LB+rmwrlxrlx-porlxrlx+fetch.addrlxrlx-porlxrlx Allowed
+States 3
+0:r0=0; 1:r0=0; [x]=1; [y]=1;
+0:r0=0; 1:r0=1; [x]=1; [y]=3;
+0:r0=1; 1:r0=0; [x]=2; [y]=1;
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists ([x]=2 /\ [y]=3 /\ 0:r0=1 /\ 1:r0=1)
+Observation LB+rmwrlxrlx-porlxrlx+fetch.addrlxrlx-porlxrlx Never 0 3
+Hash=811fb70431f64f24aae74f0a36b5f2a2
+

--- a/herd/tests/diycross/C/MP+porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/MP+porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+porlxrlx+fetch.addrlxrlx-porlxrlx Allowed
+States 4
+1:r0=0; 1:r1=0; [y]=1;
+1:r0=0; 1:r1=1; [y]=1;
+1:r0=1; 1:r1=0; [y]=3;
+1:r0=1; 1:r1=1; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=3 /\ 1:r0=1 /\ 1:r1=0)
+Observation MP+porlxrlx+fetch.addrlxrlx-porlxrlx Sometimes 1 3
+Hash=c09fadf6d368461066b2797070475866
+

--- a/herd/tests/diycross/C/MP+porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/MP+porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,15 @@
+Test MP+porlxrlx+posWrlxrlx-porlxrlx Allowed
+States 6
+1:r0=0; 1:r1=0; [y]=1;
+1:r0=0; 1:r1=0; [y]=2;
+1:r0=0; 1:r1=1; [y]=1;
+1:r0=0; 1:r1=1; [y]=2;
+1:r0=1; 1:r1=0; [y]=2;
+1:r0=1; 1:r1=1; [y]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 5
+Condition exists ([y]=2 /\ 1:r0=1 /\ 1:r1=0)
+Observation MP+porlxrlx+posWrlxrlx-porlxrlx Sometimes 1 5
+Hash=b40d62540270ba77271169f203d43c0a
+

--- a/herd/tests/diycross/C/MP+porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/MP+porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test MP+porlxrlx+rmwrlxrlx-porlxrlx Allowed
+States 4
+1:r0=0; 1:r1=0; [y]=1;
+1:r0=0; 1:r1=1; [y]=1;
+1:r0=1; 1:r1=0; [y]=2;
+1:r0=1; 1:r1=1; [y]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=2 /\ 1:r0=1 /\ 1:r1=0)
+Observation MP+porlxrlx+rmwrlxrlx-porlxrlx Sometimes 1 3
+Hash=926567c64bc6cd2c9a5c0ab3cda54d0e
+

--- a/herd/tests/diycross/C/RR+RW+fetch.addrlxrlx-porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RR+RW+fetch.addrlxrlx-porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RR+RW+fetch.addrlxrlx-porlxrlx+posWrlxrlx-porlxrlx Allowed
+States 4
+0:r0=0; 0:r1=0; 1:r0=0; [x]=1;
+0:r0=0; 0:r1=1; 1:r0=0; [x]=1;
+0:r0=1; 0:r1=0; 1:r0=0; [x]=3;
+0:r0=1; 0:r1=1; 1:r0=0; [x]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([x]=3 /\ 0:r0=1 /\ 0:r1=0 /\ 1:r0=0)
+Observation RR+RW+fetch.addrlxrlx-porlxrlx+posWrlxrlx-porlxrlx Sometimes 1 3
+Hash=e07dd4e2489838a059d51126f6329dcc
+

--- a/herd/tests/diycross/C/RR+RW+fetch.addrlxrlx-porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RR+RW+fetch.addrlxrlx-porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RR+RW+fetch.addrlxrlx-porlxrlx+rmwrlxrlx-porlxrlx Allowed
+States 4
+0:r0=0; 0:r1=0; 1:r0=0; [x]=1;
+0:r0=0; 0:r1=1; 1:r0=0; [x]=1;
+0:r0=1; 0:r1=0; 1:r0=0; [x]=3;
+0:r0=1; 0:r1=1; 1:r0=0; [x]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([x]=3 /\ 0:r0=1 /\ 0:r1=0 /\ 1:r0=0)
+Observation RR+RW+fetch.addrlxrlx-porlxrlx+rmwrlxrlx-porlxrlx Sometimes 1 3
+Hash=3d32ac24b8757f7a7cf9c73e5555f5f9
+

--- a/herd/tests/diycross/C/RR+RW+fetch.addrlxrlx-porlxrlxs.litmus.expected
+++ b/herd/tests/diycross/C/RR+RW+fetch.addrlxrlx-porlxrlxs.litmus.expected
@@ -1,0 +1,13 @@
+Test RR+RW+fetch.addrlxrlx-porlxrlxs Allowed
+States 4
+0:r0=0; 0:r1=0; 1:r0=0; [x]=1;
+0:r0=0; 0:r1=1; 1:r0=0; [x]=1;
+0:r0=1; 0:r1=0; 1:r0=0; [x]=3;
+0:r0=1; 0:r1=1; 1:r0=0; [x]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([x]=3 /\ 0:r0=1 /\ 0:r1=0 /\ 1:r0=0)
+Observation RR+RW+fetch.addrlxrlx-porlxrlxs Sometimes 1 3
+Hash=82a15e023cea24dfc8be55f259634f94
+

--- a/herd/tests/diycross/C/RR+RW+porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RR+RW+porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RR+RW+porlxrlx+fetch.addrlxrlx-porlxrlx Allowed
+States 4
+0:r0=0; 0:r1=0; 1:r0=0;
+0:r0=0; 0:r1=1; 1:r0=0;
+0:r0=1; 0:r1=0; 1:r0=0;
+0:r0=1; 0:r1=1; 1:r0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:r0=1 /\ 0:r1=0 /\ 1:r0=0)
+Observation RR+RW+porlxrlx+fetch.addrlxrlx-porlxrlx Sometimes 1 3
+Hash=0dd4d9924b61866ac0f5ca42b65d5bfb
+

--- a/herd/tests/diycross/C/RR+RW+porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RR+RW+porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RR+RW+porlxrlx+posWrlxrlx-porlxrlx Allowed
+States 4
+0:r0=0; 0:r1=0; 1:r0=0;
+0:r0=0; 0:r1=1; 1:r0=0;
+0:r0=1; 0:r1=0; 1:r0=0;
+0:r0=1; 0:r1=1; 1:r0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:r0=1 /\ 0:r1=0 /\ 1:r0=0)
+Observation RR+RW+porlxrlx+posWrlxrlx-porlxrlx Sometimes 1 3
+Hash=06098fb2bd372cb6f864350eadd7c59c
+

--- a/herd/tests/diycross/C/RR+RW+porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RR+RW+porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RR+RW+porlxrlx+rmwrlxrlx-porlxrlx Allowed
+States 4
+0:r0=0; 0:r1=0; 1:r0=0;
+0:r0=0; 0:r1=1; 1:r0=0;
+0:r0=1; 0:r1=0; 1:r0=0;
+0:r0=1; 0:r1=1; 1:r0=0;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:r0=1 /\ 0:r1=0 /\ 1:r0=0)
+Observation RR+RW+porlxrlx+rmwrlxrlx-porlxrlx Sometimes 1 3
+Hash=49a67c88ff40855bd9c3d5ce7f41507a
+

--- a/herd/tests/diycross/C/RR+WR+fetch.addrlxrlx-porlxrlx+porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RR+WR+fetch.addrlxrlx-porlxrlx+porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RR+WR+fetch.addrlxrlx-porlxrlx+porlxrlx Allowed
+States 4
+0:r0=0; 0:r1=0; 1:r0=0;
+0:r0=0; 0:r1=0; 1:r0=1;
+0:r0=0; 0:r1=1; 1:r0=0;
+0:r0=0; 0:r1=1; 1:r0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:r0=0 /\ 0:r1=0 /\ 1:r0=0)
+Observation RR+WR+fetch.addrlxrlx-porlxrlx+porlxrlx Sometimes 1 3
+Hash=5611301eed53e6e00bcfa42ba5efd519
+

--- a/herd/tests/diycross/C/RR+WR+posWrlxrlx-porlxrlx+porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RR+WR+posWrlxrlx-porlxrlx+porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RR+WR+posWrlxrlx-porlxrlx+porlxrlx Allowed
+States 4
+0:r0=0; 0:r1=0; 1:r0=0;
+0:r0=0; 0:r1=0; 1:r0=1;
+0:r0=0; 0:r1=1; 1:r0=0;
+0:r0=0; 0:r1=1; 1:r0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:r0=0 /\ 0:r1=0 /\ 1:r0=0)
+Observation RR+WR+posWrlxrlx-porlxrlx+porlxrlx Sometimes 1 3
+Hash=a29a1365ace5bbef91ba2882f5d7c56e
+

--- a/herd/tests/diycross/C/RR+WR+rmwrlxrlx-porlxrlx+porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RR+WR+rmwrlxrlx-porlxrlx+porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RR+WR+rmwrlxrlx-porlxrlx+porlxrlx Allowed
+States 4
+0:r0=0; 0:r1=0; 1:r0=0;
+0:r0=0; 0:r1=0; 1:r0=1;
+0:r0=0; 0:r1=1; 1:r0=0;
+0:r0=0; 0:r1=1; 1:r0=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:r0=0 /\ 0:r1=0 /\ 1:r0=0)
+Observation RR+WR+rmwrlxrlx-porlxrlx+porlxrlx Sometimes 1 3
+Hash=54912e3b81a1713124ee05c0778e22b0
+

--- a/herd/tests/diycross/C/RW+WR+fetch.addrlxrlx-porlxrlx+porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RW+WR+fetch.addrlxrlx-porlxrlx+porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RW+WR+fetch.addrlxrlx-porlxrlx+porlxrlx Allowed
+States 4
+0:r0=0; 1:r0=0; [y]=1;
+0:r0=0; 1:r0=0; [y]=2;
+0:r0=0; 1:r0=1; [y]=1;
+0:r0=0; 1:r0=1; [y]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=2 /\ 0:r0=0 /\ 1:r0=0)
+Observation RW+WR+fetch.addrlxrlx-porlxrlx+porlxrlx Sometimes 1 3
+Hash=680377353a537d48e0c206257fb46ddc
+

--- a/herd/tests/diycross/C/RW+WR+posWrlxrlx-porlxrlx+porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RW+WR+posWrlxrlx-porlxrlx+porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RW+WR+posWrlxrlx-porlxrlx+porlxrlx Allowed
+States 4
+0:r0=0; 1:r0=0; [y]=1;
+0:r0=0; 1:r0=0; [y]=2;
+0:r0=0; 1:r0=1; [y]=1;
+0:r0=0; 1:r0=1; [y]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=2 /\ 0:r0=0 /\ 1:r0=0)
+Observation RW+WR+posWrlxrlx-porlxrlx+porlxrlx Sometimes 1 3
+Hash=0f6030b24414f3b2ea9ae76b840a2bfe
+

--- a/herd/tests/diycross/C/RW+WR+rmwrlxrlx-porlxrlx+porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/RW+WR+rmwrlxrlx-porlxrlx+porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test RW+WR+rmwrlxrlx-porlxrlx+porlxrlx Allowed
+States 4
+0:r0=0; 1:r0=0; [y]=1;
+0:r0=0; 1:r0=0; [y]=2;
+0:r0=0; 1:r0=1; [y]=1;
+0:r0=0; 1:r0=1; [y]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([y]=2 /\ 0:r0=0 /\ 1:r0=0)
+Observation RW+WR+rmwrlxrlx-porlxrlx+porlxrlx Sometimes 1 3
+Hash=c778d9a88fba14a89e795b879b80f3d2
+

--- a/herd/tests/diycross/C/S+porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/S+porlxrlx+fetch.addrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test S+porlxrlx+fetch.addrlxrlx-porlxrlx Allowed
+States 4
+1:r0=0; [x]=1; [y]=1;
+1:r0=0; [x]=2; [y]=1;
+1:r0=1; [x]=1; [y]=3;
+1:r0=1; [x]=2; [y]=3;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([x]=2 /\ [y]=3 /\ 1:r0=1)
+Observation S+porlxrlx+fetch.addrlxrlx-porlxrlx Sometimes 1 3
+Hash=036bab568a042fa8b875e724054a54d6
+

--- a/herd/tests/diycross/C/S+porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/S+porlxrlx+posWrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,15 @@
+Test S+porlxrlx+posWrlxrlx-porlxrlx Allowed
+States 6
+1:r0=0; [x]=1; [y]=1;
+1:r0=0; [x]=1; [y]=2;
+1:r0=0; [x]=2; [y]=1;
+1:r0=0; [x]=2; [y]=2;
+1:r0=1; [x]=1; [y]=2;
+1:r0=1; [x]=2; [y]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 5
+Condition exists ([x]=2 /\ [y]=2 /\ 1:r0=1)
+Observation S+porlxrlx+posWrlxrlx-porlxrlx Sometimes 1 5
+Hash=aeba8df0705685bf4a5b3309ce3e8110
+

--- a/herd/tests/diycross/C/S+porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
+++ b/herd/tests/diycross/C/S+porlxrlx+rmwrlxrlx-porlxrlx.litmus.expected
@@ -1,0 +1,13 @@
+Test S+porlxrlx+rmwrlxrlx-porlxrlx Allowed
+States 4
+1:r0=0; [x]=1; [y]=1;
+1:r0=0; [x]=2; [y]=1;
+1:r0=1; [x]=1; [y]=2;
+1:r0=1; [x]=2; [y]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists ([x]=2 /\ [y]=2 /\ 1:r0=1)
+Observation S+porlxrlx+rmwrlxrlx-porlxrlx Sometimes 1 3
+Hash=c113916b80d46fa5e3f7ee7fc2bea61e
+


### PR DESCRIPTION
The `Rmw` or `Exch` edge produces a primitive call `atomic_exchange_explicit(...,<mo>)`, while `Fetch.Add` will produce a prinitive call to `atomic_fetch_add_explicit(...,<mo>)`.

The memory_order `<mo>` depends on the combination of anotations `<ar>` and `<aw>` from the sequence
`<ar> Rmw <aw>` with:
  + `Sc Rmw Sc` yields `memory_order_seq_cst`
  + `Rlx Rmw Rlx` yields `memory_order_relaxed`
  + `Acq Rmw Rlx` yields `memory_order_acquire`
  + `Rlx Rmw Rel` yields `memory_order_release`
  + `Acq Rmw Rel` yields `memory_order_acq_rel`

Other sequences yield a fatal error.

Try for instance: `diyone7 -arch C Acq Rmw Rel PodWW Rfe PodRW Rlx Rfe`