### PR TITLE
[asl] Added StaticInterpreter.mli

### DIFF
--- a/asllib/StaticInterpreter.ml
+++ b/asllib/StaticInterpreter.ml
@@ -23,10 +23,9 @@
 open AST
 open ASTUtils
 module SEnv = StaticEnv
+module TypingRule = Instrumentation.TypingRule
 
-type env = SEnv.env
-
-let fatal = Error.fatal
+let ( |: ) = Instrumentation.TypingNoInstr.use_with
 let fatal_from = Error.fatal_from
 let unsupported_expr e = fatal_from e Error.(UnsupportedExpr (Static, e))
 
@@ -80,7 +79,7 @@ let rec static_eval (env : SEnv.env) : expr -> literal =
         if b then expr_ e1 else expr_ e2
     | _ -> unsupported_expr e
   in
-  expr_
+  expr_ |: TypingRule.StaticEval
 
 and slices_to_positions env =
   let check_positive e x =

--- a/asllib/StaticInterpreter.mli
+++ b/asllib/StaticInterpreter.mli
@@ -20,17 +20,19 @@
 (* herdtools7 github repository.                                              *)
 (******************************************************************************)
 
-(** The Typing module is yet a single-entry-point module. It only exports the
-    function [annotate_ast] which fills type-annotations holes in the AST.
-    It should provide enough information to disambiguate any type-dependent
-    behaviour. *)
+(** Static Interpretation of Expressions. *)
 
-type strictness = [ `Silence | `Warn | `TypeCheck ]
-(** Possible strictness of type-checking. *)
+exception StaticEvaluationUnknown
 
-val type_check_ast :
-  strictness -> AST.t -> StaticEnv.env -> AST.t * StaticEnv.env
-(** Typechecks the AST, and returns an AST with type inference holes filled.
+val static_eval : StaticEnv.env -> AST.expr -> AST.literal
+(** [static_eval env e] statically evaluates [e] in [env] into a literal.
+    @raise ASLException if the a type error is detected or the expression is
+        not one of the following: [E_Literal], [E_Var], [E_Binop], [E_Unop],
+        [E_Slice], or [E_Cond].
+    @raise UnsupportedExpr if the given expression cannot evaluate to a literal.
+*)
 
-    @raise Error.ASLException if the AST does not type-check.
+val slices_to_positions : StaticEnv.env -> AST.slice list -> int list
+(** [slices_to_positions slices] statically evaluates [slices] and, unless a type error
+    is detected, returns a list of indices represented by them.
 *)

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -30,6 +30,7 @@ let ( |: ) = Instrumentation.TypingNoInstr.use_with
 let fatal_from = Error.fatal_from
 let undefined_identifier pos x = fatal_from pos (Error.UndefinedIdentifier x)
 let invalid_expr e = fatal_from e (Error.InvalidExpr e)
+let unsupported_expr e = Error.fatal_from e Error.(UnsupportedExpr (Static, e))
 
 let conflict pos expected provided =
   fatal_from pos (Error.ConflictingTypes (expected, provided))

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -487,6 +487,7 @@ module TypingRule = struct
     | TBitFields
     | ReduceSlicesToCall
     | TypeOfArrayLength
+    | StaticEval
 
   let to_string : t -> string = function
     | BuiltinSingularType -> "BuiltinSingularType"
@@ -631,6 +632,7 @@ module TypingRule = struct
     | TBitFields -> "TBitFields"
     | ReduceSlicesToCall -> "ReduceSlicesToCall"
     | TypeOfArrayLength -> "TypeOfArrayLength"
+    | StaticEval -> "StaticEval"
 
   let pp f r = to_string r |> Format.pp_print_string f
 
@@ -757,6 +759,7 @@ module TypingRule = struct
       TBitFields;
       ReduceSlicesToCall;
       TypeOfArrayLength;
+      StaticEval;
     ]
 
   let all_nb = List.length all


### PR DESCRIPTION
This is in order to avoid shadowing definitions from Instrumentation and to be able to mark code in StaticInterpreter.ml for typing rules. 
Marked static_eval with the new TypingRule.StaticEval