### PR TITLE
[herd,asl] Fix asl throw

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -268,7 +268,9 @@ module Make (B : Backend.S) (C : Config) = struct
   let bind_env m f =
     B.delay m (function
       | Normal (_v, env) -> fun m -> f (discard_exception m >=> fst, env)
-      | Throwing (v, g) -> Throwing (v, g) |> return |> Fun.const)
+      | Throwing _ as res ->
+          (* Do not discard [m], otherwise events are lost *)
+          fun m -> m >>= fun _ -> return res)
 
   let ( let*^ ) = bind_env
 

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus
@@ -1,0 +1,30 @@
+ASL throw-assign
+
+(*
+ * Catches bug, monad additional info was discarded
+ * when exception is raised in assignment right hand side.
+ * See PR #909.
+ *)
+
+{}
+
+var z = 0;
+
+type Coucou of exception;
+
+func f() => integer
+begin
+  z = 2;
+  throw Coucou {};
+end
+
+func main() => integer
+begin
+  try
+    z = f();
+  catch
+    when Coucou => return 0;
+  end
+end
+
+forall 0:z=2

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus.expected
@@ -1,0 +1,10 @@
+Test throw-assign Required
+States 1
+0:z=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:z=2)
+Observation throw-assign Always 1 0
+Hash=6eb71cec069704438643f4863954e32d
+


### PR DESCRIPTION
 Monad argument was discarded bin the monad combinator `bind_env` when an exception was raised.

As for PR #902 and #899, any monad argument to combinators has to be used linearly. Here is a test that illustrates the bug:
```
ASL throw-assign

{}

var z = 0;

type Coucou of exception;

func f() => integer
begin
  z = 2;
  throw Coucou {};
end

func main() => integer
begin
  try
    z = f();
  catch
    when Coucou => return 0;
  end
end

forall 0:z=2
```
Before the fix the events related to the global assignment `z = 2` were discarded and the final value of `z` was zero.
