### PR TITLE
[herd,asl] Fix duplicated execution of catcher statement

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -1109,11 +1109,12 @@ module Make (B : Backend.S) (C : Config) = struct
          - [m] if [m] is [Throwing (Some _, _)]
          - [Throwing (Some to_throw, g)] if  [m] is [Throwing (None, g)] *)
     (* Begin RethrowImplicit *)
-    let rethrow_implicit (v, v_ty) res =
-      B.bind_seq res @@ function
+    let rethrow_implicit (v, v_ty) s_m =
+      B.bind_seq s_m @@ function
       | Throwing (None, env_throw1) ->
           Throwing (Some (v, v_ty), env_throw1) |> return
-      | _ -> res |: SemanticsRule.RethrowImplicit
+      | (Normal _ | Throwing (Some _, _)) as res ->
+          return res |: SemanticsRule.RethrowImplicit
       (* End *)
     in
     (* [catcher_matches t c] returns true if the catcher [c] match the raised

--- a/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus
@@ -1,0 +1,27 @@
+ASL catch-exec-twice
+
+(*
+ * Ilustrate a bug: the catcher statement was executed twice.
+ * As a consequence, the debug message was repeated.
+ *)
+
+{}
+
+type Bonga of exception;
+
+func g() => integer
+begin
+  try
+    throw Bonga {};
+  catch
+    when Bonga =>
+      let coucou = 11 ;
+      print(coucou);
+  end
+  return 0;
+end
+
+func main() => integer
+begin  
+  return g();
+end

--- a/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus.expected
@@ -1,0 +1,11 @@
+11
+Test catch-exec-twice Required
+States 1
+
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation catch-exec-twice Always 1 0
+Hash=e2ccef50c20e18585263b6038016a1a4
+

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus
@@ -1,0 +1,57 @@
+ASL throw-propagate
+
+(*
+ * Test various control paths involving exceptions.
+ *)
+
+{}
+
+var z = 0;
+var t = 2;
+var aa=1;
+
+type Coucou of exception;
+type Bonga of exception;
+
+func f() => integer
+begin
+  z = 2;
+  if SomeBoolean() then
+    throw Coucou {};
+  else
+    return 1;
+  end
+end
+
+func g() => integer
+begin
+  var a = 0;
+  let b = SomeBoolean();
+  try
+    a = f();
+    if b then throw Coucou {}; end
+    t = 2;
+    if SomeBoolean() then throw Bonga {}; end
+    return a;
+  catch
+    when Coucou => if SomeBoolean() then a = 0; throw Coucou {}; end
+    when Bonga => if SomeBoolean() then a=0; throw Coucou {}; end
+  end
+  return a;
+end
+
+func main() => integer
+begin
+  var y = 0;
+  try
+    y = g();
+    return 0;
+  catch
+    when Coucou => return 0;
+  end
+end
+
+locations [0:main.0.y;]
+forall 0:z=2 /\ 0:t=2 /\
+  ((0:g.0.a = 0 /\ 0:main.0.y = 0)
+  \/ (0:g.0.a = 1 /\ 0:main.0.y = 1))

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus.expected
@@ -1,0 +1,11 @@
+Test throw-propagate Required
+States 2
+0:g.0.a=0; 0:t=2; 0:main.0.y=0; 0:z=2;
+0:g.0.a=1; 0:t=2; 0:main.0.y=1; 0:z=2;
+Ok
+Witnesses
+Positive: 9 Negative: 0
+Condition forall (0:z=2 /\ 0:t=2 /\ (0:g.0.a=0 /\ 0:main.0.y=0 \/ 0:g.0.a=1 /\ 0:main.0.y=1))
+Observation throw-propagate Always 9 0
+Hash=7e431a79fe279db315abc4c8b9396bf5
+


### PR DESCRIPTION
Fix double execution of matched catcher statement. Here is an illustrative test:
```
ASL catch-exec-twice

{}

type Bonga of exception;

func g() => integer
begin
  try
    throw Bonga {};
  catch
    when Bonga =>
      let coucou = 11 ;
      __DEBUG__(coucou);
  end
  return 0;
end

func main() => integer
begin  
  return g();
end
```
Due to the implementation of the "_implicit re-throw_" mechanism, the catcher statement `let coucou = 11; __DEBUG__(coucou);` was executed twice, resulting in printing the debug message twice.

The bug originates  in a non-linear usage of a monad argument, similarly to PR #909, #902 and #899. 