### PR TITLE
[asl] Rework inlining of getter/setters

### DIFF
--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -534,6 +534,8 @@ let case_to_conds : stmt -> stmt =
       S_Seq (assign, cases_to_cond x cases)
   | _ -> raise (Invalid_argument "case_to_conds")
 
+let slice_is_single = function Slice_Single _ -> true | _ -> false
+
 let slice_as_single = function
   | Slice_Single e -> e
   | _ -> raise @@ Invalid_argument "slice_as_single"

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -221,6 +221,7 @@ val scope_compare : scope -> scope -> int
 val lid_of_lexpr : lexpr -> local_decl_item option
 val expr_of_lexpr : lexpr -> expr
 val case_to_conds : stmt -> stmt
+val slice_is_single : slice -> bool
 val slice_as_single : slice -> expr
 
 val patch : src:AST.t -> patches:AST.t -> AST.t

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -423,7 +423,7 @@ let getter_decl ==
         let return_type = Some ty
         and args = []
         and body = SB_ASL body
-        and subprogram_type = ST_Getter
+        and subprogram_type = ST_EmptyGetter
         and parameters = [] in
         D_Func { name; args; return_type; body; parameters; subprogram_type }
       }
@@ -433,7 +433,7 @@ let getter_decl ==
         let return_type = Some ty
         and args = []
         and body = SB_ASL body
-        and subprogram_type = ST_Getter
+        and subprogram_type = ST_EmptyGetter
         and parameters = [] in
         D_Func { name; args; return_type; body; parameters; subprogram_type }
       }
@@ -451,10 +451,20 @@ let getter_decl ==
       ty; qualident; bracketed(clist(formal)); ioption(SEMICOLON); EOL
   )
 
-let setter_args == loption(bracketed(clist(sformal)))
+let setter_args == bracketed(clist(sformal))
 let setter_decl ==
   some (annotated (
-    name=qualident; args=setter_args; EQ; ~=ty; ~=ident; body=indented_block;
+    | name=qualident; EQ; ~=ty; ~=ident; body=indented_block;
+      {
+        let open AST in
+        let return_type = None
+        and parameters = []
+        and body = SB_ASL body
+        and subprogram_type = ST_EmptySetter
+        and args = [ (ident, ty) ] in
+        D_Func { name; args; return_type; body; parameters; subprogram_type }
+      }
+    | name=qualident; args=setter_args; EQ; ~=ty; ~=ident; body=indented_block;
       {
         let open AST in
         let return_type = None
@@ -466,7 +476,7 @@ let setter_decl ==
       }
   ))
   | unimplemented_decl (
-      qualident; setter_args; EQ; ty; ident; ioption(SEMICOLON); EOL
+      qualident; ioption(setter_args); EQ; ty; ident; ioption(SEMICOLON); EOL
     )
 
 let procedure_decl ==

--- a/asllib/tests/regressions.t/empty-getter-called-with-slices-2.asl
+++ b/asllib/tests/regressions.t/empty-getter-called-with-slices-2.asl
@@ -1,0 +1,11 @@
+getter f1 => boolean
+begin
+  return TRUE;
+end
+
+func main () => integer
+begin
+  let x = f1[];
+
+  return 0;
+end

--- a/asllib/tests/regressions.t/getter_sub_tuple.asl
+++ b/asllib/tests/regressions.t/getter_sub_tuple.asl
@@ -1,0 +1,19 @@
+type MyBV of bits(8) { [5] bitfield };
+
+getter F => MyBV
+begin
+  return Zeros(8) as MyBV;
+end
+
+setter F = v: MyBV
+begin
+  assert v[0] == '0';
+end
+
+func main () => integer
+begin
+  assert (F, 3).item0 == Zeros(8);
+
+  return 0;
+end
+

--- a/asllib/tests/regressions.t/getter_subfield.asl
+++ b/asllib/tests/regressions.t/getter_subfield.asl
@@ -1,0 +1,19 @@
+type MyBV of bits(8) { [5] bitfield };
+
+getter F => MyBV
+begin
+  return Zeros(8) as MyBV;
+end
+
+setter F = v: MyBV
+begin
+  assert v[0] == '0';
+end
+
+func main () => integer
+begin
+  assert F.bitfield == '0';
+
+  return 0;
+end
+

--- a/asllib/tests/regressions.t/getter_subfields.asl
+++ b/asllib/tests/regressions.t/getter_subfields.asl
@@ -1,0 +1,19 @@
+type MyBV of bits(8) { [5] b1, [4] b2 };
+
+getter F => MyBV
+begin
+  return Zeros(8) as MyBV;
+end
+
+setter F = v: MyBV
+begin
+  assert v[0] == '0';
+end
+
+func main () => integer
+begin
+  assert F.[b1, b2] == '00';
+
+  return 0;
+end
+

--- a/asllib/tests/regressions.t/getter_subslice.asl
+++ b/asllib/tests/regressions.t/getter_subslice.asl
@@ -1,0 +1,19 @@
+type MyBV of bits(8) { [5] bitfield };
+
+getter F => MyBV
+begin
+  return Zeros(8) as MyBV;
+end
+
+setter F = v: MyBV
+begin
+  assert v[0] == '0';
+end
+
+func main () => integer
+begin
+  assert F.bitfield == '0';
+
+  return 0;
+end
+

--- a/asllib/tests/regressions.t/pstate-exp.asl
+++ b/asllib/tests/regressions.t/pstate-exp.asl
@@ -1,0 +1,112 @@
+// Experimental implementation of PSTATE as two independant variables.
+
+type ProcState of bits(8) {
+  [0] N,
+  [1] Z,
+  [2] C,
+  [3] V,
+  [7] SomethingElse,
+};
+
+var _PSTATE : ProcState;
+var _NZCV : ProcState;
+
+func isNZCV(n:integer) => boolean
+begin
+  return 0 <= n && n < 4 ;
+end
+
+getter PSTATE[] => ProcState
+begin
+ return _PSTATE;
+end
+
+setter PSTATE[] = v : ProcState
+begin
+  _PSTATE = v;
+end
+
+getter PSTATE[n:integer] => bits(1)
+begin
+  if isNZCV(n) then
+    return _NZCV[n];
+  else
+    return _PSTATE[n];
+  end
+end
+
+setter PSTATE[n:integer] = v : bits(1)
+begin
+  if isNZCV(n) then
+    _NZCV[n] = v;
+  else
+    _PSTATE[n] = v;
+  end
+end
+
+
+getter PSTATE[n:integer,m:integer] => bits(2)
+begin
+  if isNZCV(n) && isNZCV(m) then
+    return _NZCV[n,m];
+  else
+    return _PSTATE[n,m];
+  end
+end
+
+setter PSTATE[n:integer,m:integer] = v : bits(2)
+begin
+  if isNZCV(n) && isNZCV(m) then
+    _NZCV[n,m] = v;
+  else
+    _PSTATE[n,m] = v;
+  end
+end
+
+getter PSTATE[n:integer,m:integer,o:integer] => bits(3)
+begin
+  if isNZCV(n) && isNZCV(m) && isNZCV(o) then
+    return _NZCV[n,m,o];
+  else
+    return _PSTATE[n,m,o];
+  end
+end
+
+setter PSTATE[n:integer,m:integer,o:integer] = v : bits(3)
+begin
+  if isNZCV(n) && isNZCV(m) && isNZCV(o) then
+    _NZCV[n,m,o] = v;
+  else
+    _PSTATE[n,m,o] = v;
+  end
+end
+
+getter PSTATE[n:integer,m:integer,o:integer,p:integer] => bits(4)
+begin
+  if isNZCV(n) && isNZCV(m) && isNZCV(o) && isNZCV(p) then
+    return _NZCV[n,m,o,p];
+  else
+    return _PSTATE[n,m,o,p];
+  end
+end
+
+setter PSTATE[n:integer,m:integer,o:integer,p:integer] = v : bits(4)
+begin
+  if isNZCV(n) && isNZCV(m) && isNZCV(o) && isNZCV(p) then
+    _NZCV[n,m,o,p] = v;
+  else
+    _PSTATE[n,m,o,p] = v;
+  end
+end
+
+func main () => integer
+begin
+  let - = PSTATE[];
+  let - = PSTATE.N;
+  let - = PSTATE.[N, Z];
+  PSTATE[] = UNKNOWN: ProcState;
+  PSTATE.N = '1';
+  PSTATE.[N, Z] = '00';
+
+  return 0;
+end

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -240,7 +240,7 @@ UnderConstrained integers:
   $ aslref record-getfields.asl
 
   $ aslref integer-accessed-bitvector.asl
-  File integer-accessed-bitvector.asl, line 4, characters 2 to 3:
+  File integer-accessed-bitvector.asl, line 4, characters 2 to 6:
   ASL Typing error: a subtype of bits(-) was expected, provided integer.
   [1]
 
@@ -352,12 +352,13 @@ Base values
 
 Empty getters/setters
   $ aslref empty-getter-called-with-slices.asl
-  File empty-getter-called-with-slices.asl, line 8, characters 10 to 14:
-  ASL Error: Mismatched use of return value from call to 'f1'
+  $ aslref empty-getter-called-with-slices-2.asl
+  File empty-getter-called-with-slices-2.asl, line 8, characters 10 to 14:
+  ASL Typing error: boolean does not subtype any of: integer, bits(-).
   [1]
   $ aslref nonempty-getter-called-without-slices.asl
   File nonempty-getter-called-without-slices.asl, line 8, characters 10 to 12:
-  ASL Error: Mismatched use of return value from call to 'f1'
+  ASL Error: Undefined identifier: 'f1'
   [1]
   $ aslref empty-setter-nonempty-getter.asl
   File empty-setter-nonempty-getter.asl, line 6, character 0 to line 9,
@@ -373,9 +374,42 @@ Empty getters/setters
   [1]
   $ aslref empty-setter-called-with-slices.asl
   File empty-setter-called-with-slices.asl, line 13, characters 2 to 6:
-  ASL Error: Mismatched use of return value from call to 'f1'
+  ASL Typing error: a subtype of bits(-) was expected, provided integer.
   [1]
   $ aslref nonempty-setter-called-without-slices.asl
   File nonempty-setter-called-without-slices.asl, line 13, characters 2 to 4:
-  ASL Error: Mismatched use of return value from call to 'f1'
+  ASL Error: Undefined identifier: 'f1'
   [1]
+  $ aslref setter_subfield.asl
+  $ aslref setter_sub_tuple.asl
+  $ aslref setter_subslice.asl
+  $ aslref getter_subfield.asl
+  $ aslref getter_sub_tuple.asl
+  $ aslref getter_subslice.asl
+  $ aslref getter_subfields.asl
+  $ aslref setter_bitfields.asl
+  $ aslref pstate-exp.asl --type-check-warn
+  File pstate-exp.asl, line 60, characters 10 to 11:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 60, characters 10 to 11:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 62, characters 12 to 13:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 62, characters 12 to 13:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 78, characters 10 to 11:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 78, characters 10 to 11:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 80, characters 12 to 13:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 80, characters 12 to 13:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 96, characters 10 to 11:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 96, characters 10 to 11:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 98, characters 12 to 13:
+  ASL Static Error: Unsupported expression n.
+  File pstate-exp.asl, line 98, characters 12 to 13:
+  ASL Static Error: Unsupported expression n.

--- a/asllib/tests/regressions.t/setter_bitfields.asl
+++ b/asllib/tests/regressions.t/setter_bitfields.asl
@@ -1,0 +1,27 @@
+type MyBV of bits(8) { [5] bitfield };
+
+getter F[] => MyBV
+begin
+  return Zeros(8) as MyBV;
+end
+
+getter F[field: integer] => bit
+begin
+  assert field == 5;
+  return Ones(1);
+end
+
+setter F[field: integer] = v: bit
+begin
+  assert field == 5;
+  assert v == '0';
+end
+
+func main () => integer
+begin
+  assert F.bitfield == '1';
+  F.bitfield = '0';
+
+  return 0;
+end
+

--- a/asllib/tests/regressions.t/setter_sub_tuple.asl
+++ b/asllib/tests/regressions.t/setter_sub_tuple.asl
@@ -1,0 +1,26 @@
+type MyBV of bits(8) { [5] bitfield };
+
+getter F => MyBV
+begin
+  return Zeros(8) as MyBV;
+end
+
+setter F = v: MyBV
+begin
+  assert v[0] == '0';
+end
+
+func foo () => (bit, integer)
+begin
+  return ('0', 1);
+end
+
+func main () => integer
+begin
+  var x = 0;
+  (F.bitfield, x) = foo();
+  assert x == 1;
+
+  return 0;
+end
+

--- a/asllib/tests/regressions.t/setter_subfield.asl
+++ b/asllib/tests/regressions.t/setter_subfield.asl
@@ -1,0 +1,19 @@
+type MyBV of bits(8) { [5] bitfield };
+
+getter F => MyBV
+begin
+  return Zeros(8) as MyBV;
+end
+
+setter F = v: MyBV
+begin
+  assert v[0] == '0';
+end
+
+func main () => integer
+begin
+  F.bitfield = '0';
+
+  return 0;
+end
+

--- a/asllib/tests/regressions.t/setter_subslice.asl
+++ b/asllib/tests/regressions.t/setter_subslice.asl
@@ -1,0 +1,19 @@
+type MyBV of bits(8) { [5] bitfield };
+
+getter F => MyBV
+begin
+  return Zeros(8) as MyBV;
+end
+
+setter F = v: MyBV
+begin
+  assert v[0] == '0';
+end
+
+func main () => integer
+begin
+  assert F[5] == '0';
+
+  return 0;
+end
+

--- a/asllib/tests/regressions.t/single-slice.asl
+++ b/asllib/tests/regressions.t/single-slice.asl
@@ -1,0 +1,7 @@
+func main () => integer
+begin
+  constant A = Zeros(4);
+  let b = A[UInt('1')*2+:2];
+
+  return 0;
+end

--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -526,12 +526,12 @@ end
 
 // =============================================================================
 
-getter _PC [] => bits(64)
+getter _PC => bits(64)
 begin
   return read_pc();
 end
 
-setter _PC [] = value :: bits(64)
+setter _PC = value :: bits(64)
 begin
   write_pc(value);
 end

--- a/herd/tests/instructions/ASL/func3.litmus
+++ b/herd/tests/instructions/ASL/func3.litmus
@@ -16,12 +16,12 @@ end
 
 getter f2[x::integer] => integer
 begin
-  return f1 + x;
+  return f1[] + x;
 end
 
 setter f2[x::integer] = v :: integer
 begin
-  f1 = v + x;
+  f1[] = v + x;
 end
 
 var f3_storage: integer = -1;
@@ -50,8 +50,8 @@ end
 func main() => integer
 begin
   f1[] = f1[];
-  f1 = f1;
-  let a = f1;
+  // f1 = f1; // Illegal 
+  let a = f1[];
   let b = f1[];
   let c = f2[4];
   f2[5] = 6;

--- a/herd/tests/instructions/ASL/func3.litmus.expected
+++ b/herd/tests/instructions/ASL/func3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=3 /\ 0:main.0.b=3 /\ 0:main.0.c=7 /\ 0:f3_storage=12 /\ 0:f4_storage=15)
 Observation func3 Always 1 0
-Hash=abadec8362acae880905ce92a87369ba
+Hash=8d4e08d099c18ddc4920d02995f828cd
 


### PR DESCRIPTION
This PR improves the handling of getters and setters to support all wanted behaviours.

The only strange case is the following:
```
getter F => bits(3)
begin return '000'; end

func main () => integer
begin
  let -: bits(0) = F[];

  return 0;
end
```
Which now passes, as it's permitted to have 0-length bitvectors.