### PR TITLE
[herd,litmus] Variant `asl+exp` implies variant `asl`

### DIFF
--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -298,5 +298,10 @@ let set_sve_length r = function
           Warn.fatal
             "Constant %d is not a valid SVE vector length (multiple of 128 between 128 and 2048)" n in
       n in
-    r := n ; SVE
-  | tag -> tag
+    r := n ; Some SVE
+  | _ -> None
+
+
+let check_tag = function
+| ASLExperimental -> [ASL;ASLExperimental;]
+| tag -> [tag]

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -120,4 +120,5 @@ val get_switch : Archs.t -> t -> (t -> bool) -> bool
 
 val set_mte_precision : Precision.t ref -> t -> bool
 val set_fault_handling : Fault.Handling.t ref -> t -> bool
-val set_sve_length : int ref -> t -> t
+val set_sve_length : int ref -> t -> t option
+val check_tag : t -> t list

--- a/lib/parseTag.mli
+++ b/lib/parseTag.mli
@@ -38,9 +38,9 @@ module type OptS = sig
   val setnow : t -> bool
   (** Examine tag for immediate action, returns true if action performed *)
 
-  val reducetag : t -> t
-  (** Examine tag for immediate action, returns a tag wihch may
-      or may noy be the tag argument. *)
+  val reducetag : t -> t list
+  (** Examine tag for immediate action, returns a tag list 
+      which may or may not include the tag argument. *)
 end
 
 module MakeS : functor (O:OptS) -> sig
@@ -55,7 +55,8 @@ module type SArg = sig
 
   val set_fault_handling :  Fault.Handling.t ref -> t -> bool
   val set_mte_precision : Precision.t ref -> t -> bool
-  val set_sve_length : int ref -> t -> t
+  val set_sve_length : int ref -> t -> t option
+  val check_tag : t -> t list
 end
 
 module type RefsArg = sig

--- a/litmus/litmus.ml
+++ b/litmus/litmus.ml
@@ -69,7 +69,7 @@ let opts =
      let module Opt = struct
        include Variant_litmus
        let setnow tag = set_fault_handling fault_handling tag
-       let reducetag tag = tag
+       let reducetag = check_tag
      end in
      let module P = ParseTag.MakeS(Opt) in
    P.parse "-variant" Option.variant "select a variation" end ;

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -65,4 +65,6 @@ let set_fault_handling r = function
 
 let set_mte_precision _ _ = false
 
-let set_sve_length _ = Misc.identity
+let set_sve_length _ _ = None
+
+let check_tag tag = [tag]

--- a/litmus/variant_litmus.mli
+++ b/litmus/variant_litmus.mli
@@ -28,6 +28,8 @@ val parse : string -> t option
 val pp : t -> string
 val ok : t -> Archs.t -> bool
 val compare : t -> t -> int
+
 val set_fault_handling : Fault.Handling.t ref -> t -> bool
 val set_mte_precision : Precision.t ref -> t -> bool
-val set_sve_length : int ref -> t -> t
+val set_sve_length : int ref -> t -> t option
+val check_tag : t -> t list


### PR DESCRIPTION
Now, `-variant asl+exp` suffices, in place of `-variant asl,asl+exp`.
