### PR TITLE
[asl] Change type of index in for loop

### DIFF
--- a/asllib/tests/typing.t/TPositive8-1.asl
+++ b/asllib/tests/typing.t/TPositive8-1.asl
@@ -1,0 +1,8 @@
+func tpositive8b ()
+begin
+    // NOTE: this test is not supported by ASLRef.
+    for i = 100 as integer {8,16} to 110 as integer {0,31} do
+        let testK : integer {8..31} = i;
+    end
+end
+

--- a/asllib/tests/typing.t/TPositive8.asl
+++ b/asllib/tests/typing.t/TPositive8.asl
@@ -3,21 +3,20 @@
 ////////////////////////////////////////////////////////////////////////////////
 func positive8(N : integer {0..15}, M : integer {7,15})
 begin
-    // Loop iterators are constrained integers with the constranints based on the constraints (not the values) of the range
     for i = 0 to 7 do
-        // i has type integer {0..7} because the type of the start index is integer {0} and the end is integer {7}
+        // i has type integer {0..7}
         let testA : integer {0..7} = i;
     end
     for i = 7 downto 0 do
-        // i has type integer {0..7} because the type of the start index is integer {7} and the end is integer {0}
+        // i has type integer {0..7}
         let testB : integer {0..7} = i;
     end
     for i = 0 to N do
-        // i has type integer {0..15} because the type of the start index is integer {0} and the max value in the domain of N is 15
+        // i has type integer {0..N}
         let testC : integer {0..15} = i;
     end
     for i = 0 to M do
-        // i has type integer {0..15} because the type of the start index is integer {0} and the max value in the domain of M is 15
+        // i has type integer {0..M}
         let testD : integer {0..15} = i;
     end
     for i = N downto 0 do
@@ -27,21 +26,16 @@ begin
         let testF : integer {0..15} = i;
     end
     for i = N to 31 do
-        let testG : integer {0..31} = i; // i has type integer {0..31} as the min value in the domain of N is 0
+        let testG : integer {0..31} = i; // i has type integer {N..31}
     end
     for i = M to 31 do
-        let testH : integer {7..31} = i; // i has type integer {7..31} as the min value in the domain of M is 7
+        let testH : integer {7..31} = i; // i has type integer {M..31}
     end
     for i = 31 downto N do
         let testI : integer {0..31} = i;
     end
     for i = 31 downto M do
         let testJ : integer {7..31} = i;
-    end
-    // NOTE: testK is required to be legal staticaly, but the ATC's will fail at runtime if this code is reached
-    for i = 100 as integer {8,16} to 110 as integer {0,31} do
-        let testK : integer {8..31} = i; // i has type integer {8..31} as the min value of the domain of the start
-                                         // expression is 8, and the max value of the domain of the end expression is 31.
     end
 end
 

--- a/asllib/tests/typing.t/run.t
+++ b/asllib/tests/typing.t/run.t
@@ -111,6 +111,15 @@ Named types
 
 Loops
   $ aslref --no-exec TPositive8.asl
+  File TPositive8.asl, line 16, characters 8 to 40:
+  ASL Typing error: a subtype of integer {0..15} was expected,
+    provided integer {0..N}.
+  [1]
+  $ aslref --no-exec TPositive8-1.asl
+  File TPositive8-1.asl, line 5, characters 8 to 40:
+  ASL Typing error: a subtype of integer {8..31} was expected,
+    provided integer {100..110}.
+  [1]
   $ aslref --no-exec TNegative8-0.asl
   File TNegative8-0.asl, line 5, characters 8 to 40:
   ASL Typing error: a subtype of integer {0..7} was expected, provided integer.


### PR DESCRIPTION
This PR changes the type of the index in a for loop. Before it was a complex operation to determine the maximum and the minimum of the bounds of the loop. Now the type of `i` in `for i = a to b` is simply:
 - `integer {a..b}` if `a` and `b` are well-constrained;
 - the unconstrained integer type otherwise.

`TPositive8` is now split in two:
- `TPositive8` keeps the bulk of the test. ASLRef does not report any error on this part after #926. For now, it still report a type error.
- ASLRef reports a type error on `TPositive8-1`.

