### PR TITLE
[litmus] Fix wrong register class for initialised stable registers

### DIFF
--- a/catalogue/aarch64/tests/@all
+++ b/catalogue/aarch64/tests/@all
@@ -41,3 +41,5 @@ MP+rel+CAS-ok-MRs-addr.litmus
 MP+rel+CAS-ok-bothRs-addr.litmus
 SB+CAS-rfi-addr+DMBSY.litmus
 SB+SWP-rfi-addr+DMBSY.litmus
+#Litmus testing
+STABLE.litmus

--- a/catalogue/aarch64/tests/STABLE.litmus
+++ b/catalogue/aarch64/tests/STABLE.litmus
@@ -1,0 +1,8 @@
+AArch64 STABLE
+Stable=X2
+(* Check that the initialisation of 0:X2 to 0 is not lost *)
+{}
+  P0        | P1        ;
+ MOV W0,W2  | MOV W2,#1 ;
+            | MOV W0,W2 ;
+forall 0:X0=0 /\ 1:X0=1

--- a/litmus/AArch64Arch_litmus.ml
+++ b/litmus/AArch64Arch_litmus.ml
@@ -74,7 +74,10 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
           | Vreg _ | SIMDreg _ | Zreg _ -> "=&w"
           | Preg _ | PMreg _ -> "=&Upl"
           | _ -> "=&r"
-        let reg_class_stable reg = match reg with
+
+        let check_init b s = (if b then "+" else "=&") ^ s
+
+        let reg_class_stable init reg = match reg with
           (* Certain Neon instructions do not affect the whole register, so we need to
              guarantee that unaffected parts are initialized to zero which basically means
              that we need to initialize whole register to zero. Several options have been
@@ -82,8 +85,8 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
              constraint "+" and the explicit initialization of the 'stable_*' variables.
              The same applies to SVE instruction with P/M (merging predicate) *)
           | Vreg _ | SIMDreg _  | Zreg _ -> "+w"
-          | Preg _ | PMreg _ -> "=&Upl"
-          | _ -> "=&r"
+          | Preg _ | PMreg _ -> check_init init "Upl"
+          | _ -> check_init init "r"
         let comment = comment
 
 (* t1 is declared (or inferred) type, t2 is type from instruction *)

--- a/litmus/ARMArch_litmus.ml
+++ b/litmus/ARMArch_litmus.ml
@@ -53,7 +53,7 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
           else if reg_compare r loop_idx = 0 then some "max_loop"
           else None
         let reg_class _ = "=&r"
-        let reg_class_stable _ = "=&r"
+        let reg_class_stable init _ = if init then "+r" else "=&r"
         let comment = comment
         let error t1 t2 =
           let open CType in

--- a/litmus/LISAArch_litmus.ml
+++ b/litmus/LISAArch_litmus.ml
@@ -42,7 +42,7 @@ module Make(V:Constant.S) = struct
         let reg_to_string = reg_to_string
         let internal_init _r _v = None
         let reg_class _ = ""
-        let reg_class_stable _ = ""
+        let reg_class_stable _ _ = ""
         let comment = comment
         let error t1 t2 =
           let open CType in

--- a/litmus/MIPSArch_litmus.ml
+++ b/litmus/MIPSArch_litmus.ml
@@ -45,7 +45,7 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
           else if reg_compare r loop_idx = 0 then some "max_loop"
 *)
         let reg_class _ = "=&r"
-        let reg_class_stable _ = "=&r"
+        let reg_class_stable init _ = if init then "+r" else "=&r"
         let comment = comment
         let error _ _ = false
         let warn _ _ = false

--- a/litmus/PPCArch_litmus.ml
+++ b/litmus/PPCArch_litmus.ml
@@ -86,7 +86,7 @@ module Make (O:Arch_litmus.Config)(V:Constant.S) = struct
           else if reg_compare r tb_addr1 = 0 then Some ("&_tb1","tb_t *")
           else None
         let reg_class _ = "=&r"
-        let reg_class_stable _ = "=&r"
+        let reg_class_stable init _ = if init then "+r" else "=&r"
         let comment = comment
         let error _ _ = false
         let warn _ _ = false

--- a/litmus/RISCVArch_litmus.ml
+++ b/litmus/RISCVArch_litmus.ml
@@ -40,7 +40,7 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
         let reg_to_string = reg_to_string
         let internal_init _r _v = None
         let reg_class _ = "=&r"
-        let reg_class_stable _ = "=&r"
+        let reg_class_stable init _r = if init then "+w" else "=&r"
         let comment = comment
         let error _t1 _t2 = false
         and warn _t1 _t2 = false

--- a/litmus/X86Arch_litmus.ml
+++ b/litmus/X86Arch_litmus.ml
@@ -49,15 +49,21 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
           if reg_compare r loop_idx = 0 then Some ("max_loop","int")
           else None
 
-        let reg_class = function
+        let do_reg_class = function
           (* as some instructions have eax as implicit argument,
              we must allocate our EAX to machine %eax *)
-          | EAX -> "=&a"
+          | EAX -> "a"
           (* esi and edi implicit for MOVSD *)
-          | ESI -> "=&S"
-          | EDI -> "=&D"
-          | _ -> "=&r"
-        let reg_class_stable r = reg_class r
+          | ESI -> "S"
+          | EDI -> "D"
+          | _ -> "r"
+
+        let reg_class r = "=&" ^ do_reg_class r
+
+        let reg_class_stable init r =
+          (if init then "+" else "=&")
+          ^ do_reg_class r
+
         let comment = comment
         let error _ _ = false
         let warn _ _ = false

--- a/litmus/X86_64Arch_litmus.ml
+++ b/litmus/X86_64Arch_litmus.ml
@@ -45,19 +45,24 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
         let reg_to_string = reg_to_string
         let internal_init _ _ = None
 
-        let reg_class r=
-          match r with
+        let do_reg_class =
+          function
           (* as some instructions have eax as implicit argument,
              we must allocate our EAX to machine %eax
-          | Ireg RAX -> "=&a"
+          | Ireg RAX -> "a"
           (* esi and edi implicit for MOVSD *)
-          | Ireg RSI -> "=&S"
-          | Ireg RDI -> "=&D" *)
-          | Ireg (AX, _) -> "=&a"
-          | Ireg (_, R8bH) -> "=&Q"
-          | XMM _ -> "=&x"
-          | _ -> "=&r"
-        let reg_class_stable r = reg_class r
+          | Ireg RSI -> "S"
+          | Ireg RDI -> "D" *)
+          | Ireg (AX, _) -> "a"
+          | Ireg (_, R8bH) -> "Q"
+          | XMM _ -> "x"
+          | _ -> "r"
+
+        let reg_class r = "=&" ^ do_reg_class r 
+
+        let reg_class_stable init r =
+          (if init then "+" else "=&")
+          ^ do_reg_class r
         let comment = comment
         let error _ _ = false
         let warn _ _ = false

--- a/litmus/archExtra_litmus.ml
+++ b/litmus/archExtra_litmus.ml
@@ -25,7 +25,7 @@ module type I = sig
   val reg_to_string  : arch_reg -> string
   val internal_init : arch_reg -> string option -> (string * string) option
   val reg_class : arch_reg -> string
-  val reg_class_stable : arch_reg -> string
+  val reg_class_stable : bool -> arch_reg -> string
   val comment : string
   val error : CType.t -> CType.t -> bool
   val warn : CType.t -> CType.t -> bool


### PR DESCRIPTION
When given as output parameters to gcc inline assembly templates, _initialised_ stable registers should have constraint "+" (and not "=") for their initialisation not to be overlooked by gcc.

Here is an example of the difference between initialised and non-initialised stable registers:
```
AArch64 L
Stable=X2
{}
  P0        | P1        ;
 MOV W0,W2  | MOV W2,#1 ;
            | MOV W0,W2 ;
forall 0:X0=0 /\ 1:X0=1
```
The `X2` register of `P0` is implicitly initialised to zero, while  the content of  `P1:X2` is overwritten by `P1` first instruction.
 + For `P0` the output constraint `=` is not adequate. Such a constraint would allow **gcc** _not_ to  emit initialisation code. And **gcc** does behave that way.
 + For `P1` he output constraint `=` is adequate, as the register `P1:X2` is overwritten before being read.