### PR TITLE
[asl] Delay to runtime problematic values in constraint sets

### DIFF
--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -17,10 +17,18 @@ ASL Semantics Reference:
   $ aslref SemanticsRule.EBinopDIVBackendDefinedError.asl
   File SemanticsRule.EBinopDIVBackendDefinedError.asl, line 4,
     characters 10 to 17:
+  All values in constraints {0} would fail with op DIV, operation will always
+  fail.
+  File SemanticsRule.EBinopDIVBackendDefinedError.asl, line 4,
+    characters 10 to 17:
   ASL Typing error: Illegal application of operator DIV on types integer {3}
     and integer {0}
   [1]
   $ aslref --no-type-check SemanticsRule.EBinopDIVBackendDefinedError.asl
+  File SemanticsRule.EBinopDIVBackendDefinedError.asl, line 4,
+    characters 10 to 17:
+  All values in constraints {0} would fail with op DIV, operation will always
+  fail.
   ASL Dynamic error: Illegal application of operator DIV for values 3 and 0.
   [1]
   $ aslref SemanticsRule.EUnopAssert.asl

--- a/asllib/tests/division.t/run.t
+++ b/asllib/tests/division.t/run.t
@@ -4,18 +4,24 @@ Simple division checks:
 Division by zero:
 
   $ aslref static-div-zero.asl
+  File static-div-zero.asl, line 3, characters 19 to 26: All values in
+  constraints {0} would fail with op DIV, operation will always fail.
   File static-div-zero.asl, line 3, characters 19 to 26:
   ASL Typing error: Illegal application of operator DIV on types integer {6}
     and integer {0}
   [1]
 
   $ aslref static-divrm-zero.asl
+  File static-divrm-zero.asl, line 3, characters 19 to 28: All values in
+  constraints {0} would fail with op DIVRM, operation will always fail.
   File static-divrm-zero.asl, line 3, characters 19 to 28:
   ASL Typing error: Illegal application of operator DIVRM on types integer {6}
     and integer {0}
   [1]
 
   $ aslref static-mod-zero.asl
+  File static-mod-zero.asl, line 3, characters 19 to 26: All values in
+  constraints {0} would fail with op MOD, operation will always fail.
   File static-mod-zero.asl, line 3, characters 19 to 26:
   ASL Typing error: Illegal application of operator MOD on types integer {6}
     and integer {0}
@@ -24,25 +30,31 @@ Division by zero:
 Unsupported divisions (caught at type-checking time):
 
   $ aslref static-div-neg.asl
+  File static-div-neg.asl, line 3, characters 19 to 27: All values in
+  constraints {(- 3)} would fail with op DIV, operation will always fail.
   File static-div-neg.asl, line 3, characters 19 to 27:
   ASL Typing error: Illegal application of operator DIV on types integer {6}
     and integer {(- 3)}
   [1]
 
   $ aslref static-divrm-neg.asl
+  File static-divrm-neg.asl, line 3, characters 19 to 29: All values in
+  constraints {(- 3)} would fail with op DIVRM, operation will always fail.
   File static-divrm-neg.asl, line 3, characters 19 to 29:
   ASL Typing error: Illegal application of operator DIVRM on types integer {6}
     and integer {(- 3)}
   [1]
 
   $ aslref static-mod-neg.asl
+  File static-mod-neg.asl, line 3, characters 19 to 27: All values in
+  constraints {(- 3)} would fail with op MOD, operation will always fail.
   File static-mod-neg.asl, line 3, characters 19 to 27:
   ASL Typing error: Illegal application of operator MOD on types integer {6}
     and integer {(- 3)}
   [1]
 
   $ aslref static-div-undiv.asl
-  ASL Static error: Illegal application of operator DIV for values 5 and 3.
+  ASL Dynamic error: Illegal application of operator DIV for values 5 and 3.
   [1]
 
 For completeness, those operations are dynamic errors:
@@ -85,19 +97,16 @@ More complicated examples
 
 Fails because N typing cannot infer that N + 1 is strictly positive.
   $ aslref div-by-param.asl
-  File div-by-param.asl, line 3, characters 10 to 23:
-  ASL Typing error: Illegal application of operator DIV on types integer {5}
-    and integer {(N + 1)}
+  ASL Dynamic error: Illegal application of operator DIV for values 5 and 2.
   [1]
 
 Examples with multiple constraints in slices:
   $ aslref div-multi-slices.asl
 
   $ aslref div-multi-slices-zero.asl
-  File div-multi-slices-zero.asl, line 6, characters 10 to 17:
-  ASL Typing error: Illegal application of operator DIV on types
-    integer {2, 4, 8} and integer {0, 1, 2}
-  [1]
+  File div-multi-slices-zero.asl, line 6, characters 10 to 17: Warning:
+  Removing some values that would fail with op DIV from constraint set
+  {0, 1, 2} gave {1, 2}. Continuing with this constraint set.
 
 Example with constant:
 

--- a/herd/tests/instructions/AArch64.ASL/ADD01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/ADD01.litmus.expected-warn
@@ -1,0 +1,16 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/ADD02.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/ADD02.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/ADDEXT001.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/ADDEXT001.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/ADDEXT002.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/ADDEXT002.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/ASR00.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/ASR00.litmus.expected-warn
@@ -1,0 +1,12 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH01.litmus.expected-warn
@@ -1,0 +1,16 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH02.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH02.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH03.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH03.litmus.expected-warn
@@ -1,0 +1,8 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH04.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH04.litmus.expected-warn
@@ -1,0 +1,24 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH05.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH05.litmus.expected-warn
@@ -1,0 +1,12 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH06.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH06.litmus.expected-warn
@@ -1,0 +1,8 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH07.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH07.litmus.expected-warn
@@ -1,0 +1,20 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH08.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH08.litmus.expected-warn
@@ -1,0 +1,24 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH09.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH09.litmus.expected-warn
@@ -1,0 +1,32 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/BRANCH10.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/BRANCH10.litmus.expected-warn
@@ -1,0 +1,36 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/CAS01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/CAS01.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/CAS02.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/CAS02.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/CAS03.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/CAS03.litmus.expected-warn
@@ -1,0 +1,8 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/CAS04.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/CAS04.litmus.expected-warn
@@ -1,0 +1,24 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/CSEL01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/CSEL01.litmus.expected-warn
@@ -1,0 +1,8 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/CSEL02.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/CSEL02.litmus.expected-warn
@@ -1,0 +1,8 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/CSET.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/CSET.litmus.expected-warn
@@ -1,0 +1,20 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/EXTR00.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/EXTR00.litmus.expected-warn
@@ -1,0 +1,16 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/FENCES.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/FENCES.litmus.expected-warn
@@ -1,0 +1,32 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDADD00.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDADD00.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDADD01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDADD01.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDADD02.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDADD02.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDAPR.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDAPR.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDAR.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDAR.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDEOR00.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDEOR00.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDR01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDR01.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDR02.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDR02.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDR03.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDR03.litmus.expected-warn
@@ -1,0 +1,8 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDSMIN00.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDSMIN00.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDSMIN01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDSMIN01.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LDUMIN00.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LDUMIN00.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LOGI01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LOGI01.litmus.expected-warn
@@ -1,0 +1,20 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/LXSX.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/LXSX.litmus.expected-warn
@@ -1,0 +1,12 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/MOV.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/MOV.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/MOVI01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/MOVI01.litmus.expected-warn
@@ -1,0 +1,12 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/MOVI02.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/MOVI02.litmus.expected-warn
@@ -1,0 +1,12 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/MP01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/MP01.litmus.expected-warn
@@ -1,0 +1,24 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/NOP.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/NOP.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/ROR00.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/ROR00.litmus.expected-warn
@@ -1,0 +1,16 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/STCLR00.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/STCLR00.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/STLR.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/STLR.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/STR01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/STR01.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/STR02.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/STR02.litmus.expected-warn
@@ -1,0 +1,8 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/STR03.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/STR03.litmus.expected-warn
@@ -1,0 +1,12 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/SWP+SAME.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/SWP+SAME.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/SWP+TWO.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/SWP+TWO.litmus.expected-warn
@@ -1,0 +1,8 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/SWP.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/SWP.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.

--- a/herd/tests/instructions/AArch64.ASL/SXTW01.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.ASL/SXTW01.litmus.expected-warn
@@ -1,0 +1,4 @@
+File ./herd/libdir/asl-pseudocode/shared_pseudocode.asl, line 10960,
+  characters 19 to 26:
+Warning: Removing some values that would fail with op << from constraint set
+{-1..6} gave {0..6}. Continuing with this constraint set.


### PR DESCRIPTION
In ASL, division by zero or shift by negative values are dynamic errors.
However, what should happen when trying to apply such operation to a constraint set?

For example, what should be the type of `c` in:
```
var a: integer {4, 6, 8, 10};
var b: integer {0, 1, 2};
var c: a DIV b;
```

This PR says that the type of `c`, for the purpose of type-checking is the result of all non-faulting division between the constraints of `a` and the constraints of `b`, hence: `integer {2, 3, 4, 5, 6, 8, 10}`.
The removal of `0` from the right hand side of `DIV` is implemented here as a warning to the user.