### PR TITLE
[herd,asl] Add litmus filename in front of ASL error messages when executing AArch64 tests

### DIFF
--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -73,6 +73,9 @@ type error = error_desc annotated
 
 exception ASLException of error
 
+(* This error resulted from AArch64 test execution in ASL mode *)
+exception AArch64ASLException of error
+
 type 'a result = ('a, error) Result.t
 
 let fatal e = raise (ASLException e)

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -639,6 +639,12 @@ let () =
            if dbg_exc then raise exc ;
            Warn.warn_always "%s" (Asllib.Error.error_to_string e);
            check_exit seen
+        | Asllib.Error.AArch64ASLException e as exc ->
+          (* Add litmus filename *)
+           if dbg_exc then raise exc ;
+           Warn.warn_always "%a:\n%s"
+             Pos.pp_pos0 name (Asllib.Error.error_to_string e);
+           check_exit seen
         | e ->
            Printf.eprintf "\nFatal: %a Adios\n" Pos.pp_pos0 name ;
            raise e)


### PR DESCRIPTION
Convenient when executing batches of AArch64 tests of which some fail.