### PR TITLE
[herd]: Demote result of Neon register read for `FMOV`

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -3367,8 +3367,8 @@ module Make
               fun v -> write_reg_neon_rep (neon_sz r1) r1 v ii)
         | I_FMOV_TG(_,r1,_,r2) ->
             check_neon inst;
-            !(read_reg_neon false r2 ii >>=
-              fun v -> write_reg r1 v ii)
+            read_reg_neon false r2 ii >>= demote
+            >>= fun v -> write_reg_dest r1 v ii >>= nextSet r1
         | I_MOV_VE(r1,i1,r2,i2) ->
             check_neon inst;
             !(read_reg_neon_elem false r2 i2 ii >>=

--- a/herd/tests/instructions/AArch64.neon/V70.litmus
+++ b/herd/tests/instructions/AArch64.neon/V70.litmus
@@ -1,0 +1,11 @@
+AArch64 V70
+{
+ int x=1;
+ 0:X0=x; 0:X3=y;
+}
+P0                    ;
+LDR S1,[X3];
+FMOV W1,S1            ;
+LDR W2,[X0,W1,SXTW]   ;
+
+forall 0:X2=1

--- a/herd/tests/instructions/AArch64.neon/V70.litmus.expected
+++ b/herd/tests/instructions/AArch64.neon/V70.litmus.expected
@@ -1,0 +1,10 @@
+Test V70 Required
+States 1
+0:X2=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=1)
+Observation V70 Always 1 0
+Hash=0e93be9471bfe31656ec91878a8f2670
+


### PR DESCRIPTION
Consider litmus test

```
AArch64 V70
{
 int x=1;
 0:X0=x; 0:X3=y;
}
P0                 ;
LDR S1,[X3]        ;
FMOV W1,S1         ;
LDR W2,[X0,W1,SXTW];

forall 0:X2=1
```

Currently `herd7` would refuse to run the test with

```
Warning: File "V70.litmus": operation sxt non-existent for wide integers
```

The reason is that `W1` holds `wide` integer value from `S1` which blocks `sxt` operation. General purpose registers don't require `wide` integer and work pretty well with `narrow` one, so `demote` result of Neon register read for `FMOV`