### PR TITLE
[action] Use dev profile for CI

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -41,6 +41,6 @@ jobs:
 
       - run: opam install . --deps-only --with-test
 
-      - run: opam exec -- make build
+      - run: opam exec -- make build DUNE_PROFILE=dev
 
-      - run: opam exec -- make test
+      - run: opam exec -- make test DUNE_PROFILE=dev

--- a/dune
+++ b/dune
@@ -3,7 +3,10 @@
 (env
  (release
   (flags
-   (:standard -w +a-3-4-9-29-33-41-45-60-67-70))))
+   (:standard -w +a-3-4-9-29-33-41-45-60-67-70)))
+ (dev
+  (flags
+   (:standard -warn-error +A -w +a-3-4-9-29-33-41-45-60-67-70))))
 
 (alias
  (name default)


### PR DESCRIPTION
Using our "dev" profile will trigger some error whenever our "release" flags a warning. As a result, warnings will not reach production code...