### PR TITLE
Updates to 'ASL Typing Refernce'

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -195,7 +195,7 @@ and int_constraints =
   | WellConstrained of int_constraint list
       (** An integer type constrained from ASL syntax: it is the union of each
           constraint in the list. *)
-  | UnderConstrained of uid * identifier
+  | Parameterized of uid * identifier
       (** An under-constrained integer, the default type for parameters of
           function at compile time, with a unique identifier and the variable
           bearing its name. *)

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -214,7 +214,7 @@ and use_slices slices = use_list use_slice slices
 and use_ty t =
   match t.desc with
   | T_Named s -> ISet.add s
-  | T_Int (UnConstrained | UnderConstrained _)
+  | T_Int (UnConstrained | Parameterized _)
   | T_Enum _ | T_Bool | T_Real | T_String ->
       Fun.id
   | T_Int (WellConstrained cs) -> use_constraints cs
@@ -404,8 +404,7 @@ and type_equal eq t1 t2 =
   | T_String, T_String
   | T_Int UnConstrained, T_Int UnConstrained ->
       true
-  | T_Int (UnderConstrained (i1, _)), T_Int (UnderConstrained (i2, _)) ->
-      i1 == i2
+  | T_Int (Parameterized (i1, _)), T_Int (Parameterized (i2, _)) -> i1 == i2
   | T_Int (WellConstrained c1), T_Int (WellConstrained c2) ->
       constraints_equal eq c1 c2
   | T_Bits (w1, bf1), T_Bits (w2, bf2) ->
@@ -725,7 +724,7 @@ let rename_locals map_name ast =
   and map_t t =
     map_desc_st' t @@ function
     | T_Real | T_String | T_Bool | T_Enum _ | T_Named _
-    | T_Int (UnConstrained | UnderConstrained _) ->
+    | T_Int (UnConstrained | Parameterized _) ->
         t.desc
     | T_Int (WellConstrained cs) -> T_Int (WellConstrained (map_cs cs))
     | T_Bits (e, bitfields) -> T_Bits (map_e e, bitfields)

--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -567,14 +567,14 @@ module Make (B : Backend.S) (C : Config) = struct
     let rec in_values v ty =
       match ty.desc with
       | T_Int UnConstrained -> m_true
-      | T_Int (UnderConstrained _) ->
+      | T_Int (Parameterized _) ->
           (* This cannot happen, because:
              1. Forgetting now about named types, or any kind of compound types,
                 you cannot ask: [expr as ty] if ty is the unconstrained integer
                 because there is no syntax for it.
              2. You cannot construct a type that is an alias for the
-                underconstrained integer type.
-             3. You cannot put the underconstrained integer type in a compound
+                parameterized integer type.
+             3. You cannot put the parameterized integer type in a compound
                 type.
           *)
           fatal_from loc Error.UnrespectedParserInvariant
@@ -1324,8 +1324,8 @@ module Make (B : Backend.S) (C : Config) = struct
         try IMap.find (List.hd li) env.global.static.constant_values |> lit
         with Not_found -> fatal_from t Error.TypeInferenceNeeded)
     | T_Int UnConstrained -> m_zero
-    | T_Int (UnderConstrained _) ->
-        failwith "Cannot request the base value of a under-constrained integer."
+    | T_Int (Parameterized _) ->
+        failwith "Cannot request the base value of a parameterized integer."
     | T_Int (WellConstrained []) ->
         failwith
           "A well constrained integer cannot have an empty list of constraints."

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -304,8 +304,7 @@ module NativeBackend = struct
         (WellConstrained ((Constraint_Exact e | Constraint_Range (e, _)) :: _))
       ->
         eval_expr_sef e
-    | T_Int (UnderConstrained (_, x)) ->
-        eval_expr_sef (E_Var x |> add_pos_from ty)
+    | T_Int (Parameterized (_, x)) -> eval_expr_sef (E_Var x |> add_pos_from ty)
     | T_Int (WellConstrained []) -> assert false
     | T_Bits (e, _) -> (
         match eval_expr_sef e with

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -163,7 +163,7 @@ and pp_ty f t =
   | T_Int UnConstrained -> pp_print_string f "integer"
   | T_Int (WellConstrained cs) ->
       fprintf f "@[integer {%a}@]" pp_int_constraints cs
-  | T_Int (UnderConstrained (_uid, var)) -> fprintf f "@[integer {%s}@]" var
+  | T_Int (Parameterized (_uid, var)) -> fprintf f "@[integer {%s}@]" var
   | T_Real -> pp_print_string f "real"
   | T_String -> pp_print_string f "string"
   | T_Bool -> pp_print_string f "boolean"

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -208,7 +208,7 @@ and pp_int_constraints f = function
   | WellConstrained cs ->
       addb f "WellConstrained ";
       pp_list pp_int_constraint f cs
-  | UnderConstrained (i, x) -> bprintf f "UnderConstrained (%d, %S)" i x
+  | Parameterized (i, x) -> bprintf f "Parameterized (%d, %S)" i x
 
 let rec pp_lexpr =
   let pp_desc f = function

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -550,9 +550,9 @@ $\textsf{name}$, $\textsf{parameters}$, $\textsf{args}$, $\textsf{body}$, $\text
 The notation $\{ \textsf{body}:\SBASL(\texttt{body}),\ \textsf{args}:\texttt{arg\_decls}, \ldots \}$
 allows us to deconstruct a given \func\ node by matching only the \textsf{body} and \textsf{args} fields.
 
-\hypertarget{def-astlabel}{}
 Recall that a subset of AST nodes are either labels or labelled tuples.
-The partial function $\astlabel$ returns the corresponding label $\vl\in\astlabels$, when it exists.
+\hypertarget{def-astlabel}{}
+The partial function $\astlabel$ returns the label $\vl\in\astlabels$ an AST node, when it exists.
 For example, $\astlabel(\TBool) = \TBool$ and $\astlabel(\TNamed(\texttt{x})) = \TNamed$.
 
 \subsection{How to Parse Rules Efficiently}

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -41,6 +41,7 @@
 \newcommand\isanonymous[0]{\hyperlink{def-isanonymous}{\texttt{is\_anonymous}}}
 \newcommand\issingular[0]{\hyperlink{def-issingular}{\texttt{is\_singular}}}
 \newcommand\isaggregate[0]{\hyperlink{def-isaggregate}{\texttt{is\_aggregate}}}
+\newcommand\isstructured[0]{\hyperlink{def-isstructured}{\texttt{is\_structured}}}
 \newcommand\isnonprimitive[0]{\hyperlink{def-isnonprimitive}{\texttt{is\_non\_primitive}}}
 \newcommand\isprimitive[0]{\hyperlink{def-isprimitive}{\texttt{is\_primitive}}}
 
@@ -201,6 +202,7 @@
 \newcommand\ELInt[1]{\hyperlink{def-elint}{\texttt{ELInt}}(#1)}
 
 % Glossary
+\newcommand\structuredtype[0]{\hyperlink{def-structuredtype}{structured type}}
 \newcommand\structure[0]{\hyperlink{def-structure}{structure}}
 \newcommand\underlyingtype[0]{\hyperlink{def-underlyingtype}{underlying type}}
 \newcommand\symbolicdomain[0]{\hyperlink{def-symbolicdomain}{symbolic domain}}
@@ -1063,7 +1065,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
 
   \item All of the following apply (\textsc{t\_structured}):
   \begin{itemize}
-    \item $\vt$ is either a record type or an exception type with typed fields $(\id_i, \vt_i$, for $i=1..k$, that is $L([i=1..k: (\id_i,\vt_i))]$
+    \item $\vt$ is a \structuredtype\ with typed fields $(\id_i, \vt_i$, for $i=1..k$, that is $L([i=1..k: (\id_i,\vt_i))]$
     where $L\in\{\TRecord, \TException\}$;
     \item the domain of each type $\vt_i$ is $D_i$, for $i=1..k$;
     \item $\vd$ is the set containing all native records where $\id_i$ is mapped to a value taken from $D_i$.
@@ -1080,26 +1082,26 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
 \subsection{Formally}
 
 \begin{mathpar}
-\inferrule[t\_bool]{}{ \dynamicdomain(\env, \TBool) = \tbool }
+\inferrule[t\_bool]{}{ \dynamicdomain(\env, \overname{\TBool}{\vt}) = \overname{\tbool}{\vd} }
 \and
-\inferrule[t\_string]{}{ \dynamicdomain(\env, \TString) = \tstring }
+\inferrule[t\_string]{}{ \dynamicdomain(\env, \overname{\TString}{\vt}) = \overname{\tstring}{\vd} }
 \and
-\inferrule[t\_real]{}{ \dynamicdomain(\env, \TReal) = \treal }
+\inferrule[t\_real]{}{ \dynamicdomain(\env, \overname{\TReal}{\vt}) = \overname{\treal}{\vd} }
 \and
 \inferrule[t\_enumeration]{}{
-  \dynamicdomain(\env, \TEnum(\id_{1..k})) = \{\nvint(1),\ldots,\nvint(k)\}
+  \dynamicdomain(\env, \overname{\TEnum(\id_{1..k})}{\vt}) = \overname{\{\nvint(1),\ldots,\nvint(k)\}}{\vd}
 }
 \end{mathpar}
 
 \begin{mathpar}
   \inferrule[t\_int\_unconstrained]{}{
-  \dynamicdomain(\env, \TInt(\unconstrained)) = \tint
+  \dynamicdomain(\env, \overname{\TInt(\unconstrained)}{\vt}) = \overname{\tint}{\vd}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[t\_int\_well\_constrained]{}{
-  \dynamicdomain(\env, \TInt(\wellconstrained(\vc_{1..k}))) = \bigcup_{i=1}^k \dynamicdomain(\env, \vc_i)
+  \dynamicdomain(\env, \overname{\TInt(\wellconstrained(\vc_{1..k}))}{\vt}) = \overname{\bigcup_{i=1}^k \dynamicdomain(\env, \vc_i)}{\vd}
 }
 \end{mathpar}
 
@@ -1107,13 +1109,13 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
 \inferrule[constraint\_exact\_okay]{
   \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(n), \Ignore)
 }{
-  \dynamicdomain(\env, \ConstraintExact(\ve)) = \{ \nvint(n) \}
+  \dynamicdomain(\env, \overname{\ConstraintExact(\ve)}{\vc}) = \overname{\{ \nvint(n) \}}{\vd}
 }
 \and
 \inferrule[constraint\_exact\_dynamic\_error]{
   \evalexprsef{\env, \ve} \evalarrow \ErrorConfig
 }{
-  \dynamicdomain(\env, \ConstraintExact(\ve)) = \emptyset
+  \dynamicdomain(\env, \overname{\ConstraintExact(\ve)}{\vc}) = \overname{\emptyset}{\vd}
 }
 \end{mathpar}
 
@@ -1122,20 +1124,20 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
   \evalexprsef{\env, \veone} \evalarrow \Normal(\nvint(a), \Ignore)\\
   \evalexprsef{\env, \vetwo} \evalarrow \Normal(\nvint(b), \Ignore)
 }{
-  \dynamicdomain(\env, \ConstraintRange(\veone, \vetwo)) = \{ \nvint(n) \;|\;  a \leq n \land n \leq b\}
+  \dynamicdomain(\env, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) = \overname{\{ \nvint(n) \;|\;  a \leq n \land n \leq b\}}{\vd}
 }
 \and
 \inferrule[constraint\_range\_dynamic\_error1]{
   \evalexprsef{\env, \veone} \evalarrow \ErrorConfig
 }{
-  \dynamicdomain(\env, \ConstraintRange(\veone, \vetwo)) = \emptyset
+  \dynamicdomain(\env, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[constraint\_range\_dynamic\_error2]{
   \evalexprsef{\env, \veone} \evalarrow \Normal(\Ignore, \Ignore)\\
   \evalexprsef{\env, \vetwo} \evalarrow \ErrorConfig
 }{
-  \dynamicdomain(\env, \ConstraintRange(\veone, \vetwo)) = \emptyset
+  \dynamicdomain(\env, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) = \overname{\emptyset}{\vd}
 }
 \end{mathpar}
 
@@ -1145,7 +1147,7 @@ in the \emph{local dynamic environment} of $\denv$.
   \inferrule[t\_int\_underconstrained]{
   L^\denv(\id) = \nvint(n)
 }{
-  \dynamicdomain(\env, \TInt(\underconstrained(\id))) = \{ \nvint(n) \}
+  \dynamicdomain(\env, \overname{\TInt(\underconstrained(\id))}{\vt}) = \overname{\{ \nvint(n) \}}{\vd}
 }
 \end{mathpar}
 
@@ -1153,27 +1155,27 @@ in the \emph{local dynamic environment} of $\denv$.
 \inferrule[t\_bits\_dynamic\_error]{
   \evalexprsef{\env, \ve} \evalarrow \ErrorConfig
 }{
-  \dynamicdomain(\env, \TBits(\ve, \Ignore)) = \emptyset
+  \dynamicdomain(\env, \overname{\TBits(\ve, \Ignore)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_bits\_negative\_width\_error]{
   \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
   k < 0
 }{
-  \dynamicdomain(\env, \TBits(\ve, \Ignore)) = \emptyset
+  \dynamicdomain(\env, \overname{\TBits(\ve, \Ignore)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_bits\_empty]{
   \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(0), \Ignore)
 }{
-  \dynamicdomain(\env, \TBits(\ve, \Ignore)) = \{ \nvbitvector(\emptylist) \}
+  \dynamicdomain(\env, \overname{\TBits(\ve, \Ignore)}{\vt}) = \overname{\{ \nvbitvector(\emptylist) \}}{\vd}
 }
 \and
 \inferrule[t\_bits\_non\_empty]{
   \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
   k > 0
 }{
-  \dynamicdomain(\env, \TBits(\ve, \Ignore)) = \{ \nvbitvector(\vb_{1..k}) \;|\; \vb_1,\ldots,\vb_k \in \{0,1\} \}
+  \dynamicdomain(\env, \overname{\TBits(\ve, \Ignore)}{\vt}) = \overname{\{ \nvbitvector(\vb_{1..k}) \;|\; \vb_1,\ldots,\vb_k \in \{0,1\} \}}{\vd}
 }
 \end{mathpar}
 
@@ -1181,8 +1183,8 @@ in the \emph{local dynamic environment} of $\denv$.
 \inferrule[t\_tuple]{
   i=1..k: \dynamicdomain(\env, \vt_i) = D_i
 }{
-  \dynamicdomain(\env, \TTuple(\vt_{1..k})) =
-  \{ \nvvector{\vv_{1..k}} \;|\; \vv_i \in D_i \}
+  \dynamicdomain(\env, \overname{\TTuple(\vt_{1..k})}{\vt}) =
+  \overname{\{ \nvvector{\vv_{1..k}} \;|\; \vv_i \in D_i \}}{\vd}
 }
 \end{mathpar}
 
@@ -1190,22 +1192,22 @@ in the \emph{local dynamic environment} of $\denv$.
 \inferrule[t\_array\_dynamic\_error]{
   \evalexprsef{\env, \ve} \evalarrow \ErrorConfig
 }{
-  \dynamicdomain(\env, \TArray(\ve, \vtone)) = \emptyset
+  \dynamicdomain(\env, \overname{\TArray(\ve, \vtone)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_array\_negative\_length\_error]{
   \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
   k < 0
 }{
-  \dynamicdomain(\env, \TArray(\ve, \vtone)) = \emptyset
+  \dynamicdomain(\env, \overname{\TArray(\ve, \vtone)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_array\_okay]{
   \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
   \dynamicdomain(\env, \vtone) = D_\vtone
 }{
-  \dynamicdomain(\env, \TArray(\ve, \vtone)) =
-  \{ \nvvector{\vv_{1..k}} \;|\; \vv_{1..k} \in D_{\vtone} \}
+  \dynamicdomain(\env, \overname{\TArray(\ve, \vtone)}{\vt}) =
+  \overname{\{ \nvvector{\vv_{1..k}} \;|\; \vv_{1..k} \in D_{\vtone} \}}{\vd}
 }
 \end{mathpar}
 
@@ -1214,8 +1216,8 @@ in the \emph{local dynamic environment} of $\denv$.
   L \in \{\TRecord, \TException\}\\
   i=1..k: \dynamicdomain(\env, \vt_i) = D_i
 }{
-  \dynamicdomain(\env, L([i=1..k: (\id_i,\vt_i))]) = \\
-  \{ \nvrecord{\{i=1..k: \id_i\mapsto \vv_i\}} \;|\; \vv_i \in D_i \}
+  \dynamicdomain(\env, \overname{L([i=1..k: (\id_i,\vt_i))]}{\vt}) = \\
+  \overname{\{ \nvrecord{\{i=1..k: \id_i\mapsto \vv_i\}} \;|\; \vv_i \in D_i \}}{\vd}
 }
 \end{mathpar}
 
@@ -1223,7 +1225,7 @@ in the \emph{local dynamic environment} of $\denv$.
 \inferrule[t\_named]{
   G^\tenv.\declaredtypes(\id)=\tty
 }{
-  \dynamicdomain(\env, \TNamed(\id)) = \dynamicdomain(\env, \tty)
+  \dynamicdomain(\env, \overname{\TNamed(\id)}{\vt}) = \overname{\dynamicdomain(\env, \tty)}{\vd}
 }
 \end{mathpar}
 
@@ -1633,6 +1635,40 @@ type C of B;
 \isempty{\subsection{Comments}}
 \lrmcomment{This is related to \identr{GVZK}.}
 
+\section{TypingRule.StructuredType \label{sec:TypingRule.StructuredType}}
+\hypertarget{def-isstructured}{}
+\hypertarget{def-structuredtype}{}
+A \emph{\structuredtype} is any type that consists of a list of field identifiers
+that denote individual storage elements. In ASL there are two such types --- record types and exception types.
+
+The predicate
+\[
+  \isstructured(\overname{\ty}{\tty}) \;\aslto\; \overname{\Bool}{\vb}
+\]
+tests whether the type $\tty$ is a \structuredtype\ and yields the result in $\vb$.
+
+\subsection{Prose}
+The result $\vb$ is $\True$ if and only if $\tty$ is either a record type or an exception type,
+which is determined via the AST label of $\tty$.
+
+\subsection{Example}
+In the following example, the types \texttt{SyntaxException} and \texttt{PointRecord}
+are each an example of a \structuredtype:
+\begin{verbatim}
+type SyntaxException of exception {message: string };
+type PointRecord of Record {x : real, y: real, z: real};
+\end{verbatim}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule{}{
+  \isstructured(\tty) \typearrow \overname{\astlabel(\tty) \in \{\TRecord, \TException\}}{\vb}
+}
+\end{mathpar}
+
+\isempty{\subsection{Comments}}
+\lrmcomment{This is related to \identd{WGQS}, \identd{QXYC}.}
+
 \section{TypingRule.NonPrimitiveType \label{sec:TypingRule.NonPrimitiveType}}
 \hypertarget{def-isnonprimitive}{}
 The predicate
@@ -1666,7 +1702,7 @@ One of the following applies:
     \end{itemize}
   \item All of the following apply (\textsc{structured}):
     \begin{itemize}
-    \item $\tty$ is a record or exception with fields $\fields$;
+    \item $\tty$ is a \structuredtype\ with fields $\fields$;
     \item $\vb$ is $\True$ if and only if there exists a non-primitive type in $\fields$.
     \end{itemize}
 \end{itemize}
@@ -1804,7 +1840,7 @@ One of the following applies:
   \end{itemize}
 \item All of the following apply (\textsc{structured}):
   \begin{itemize}
-  \item $\tty$ is either a record or an exception with fields $\fields$;
+  \item $\tty$ is a \structuredtype\ with fields $\fields$;
   \item obtaining the structure for each type $\vt$ associated with field $\id$ yields a type $\vt_\id$\ProseOrTypeError;
   \item $\vt$ is a record or an exception, in correspondence to $\tty$, with the list of pairs $(\id, \vt\_\id)$;
   \end{itemize}
@@ -2213,8 +2249,8 @@ One of the following applies:
 
 \item All of the following apply (\textsc{structured}):
   \begin{itemize}
-  \item $\vs$ has the \underlyingtype\ $L(\vfieldss)$, which is either a record type or an exception type;
-  \item $\vt$ has the \underlyingtype\ $L(\vfieldst)$, which is either a record type or an exception type;
+  \item $\vs$ has the \underlyingtype\ $L(\vfieldss)$, which is a \structuredtype;
+  \item $\vt$ has the \underlyingtype\ $L(\vfieldst)$, which is a \structuredtype;
   \item since both underlying types have the same AST label they are either both record types or both exception types;
   \item $\vb$ is $\True$ if and only if for each field in $\vfieldss$ with type $\vtys$
   there exists a field in $\vfieldst$ with type $\vtyt$ such that both $\vtys$ and $\vtyt$
@@ -4477,7 +4513,7 @@ The following example declares a valid enumeration type:
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\tty$ is either a record type or an exception type, corresponding to its AST label $L$;
+  \item $\tty$ is a \structuredtype\ with AST label $L$;
   \item the list of fields of $\tty$ is $\fields$;
   \item $\decl$ is $\True$, indicating that $\tty$ should be considered in the context of a declaration;
   \item $\fields$ is a list of pairs where the first element is an identifier and the second is a type --- $(\vx_i, \vt_i)$, for $i=1..k$;
@@ -4499,6 +4535,7 @@ In the following example, all the uses of record or exception types are valid:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
+  L \in \{\TRecord, \TException\}\\
   \fields \eqname [i=1..k: (\vx_i, \vt_i)]\\
   \checknoduplicates(\vx_{1..k}) \typearrow \True \OrTypeError\\\\
   i=1..k: \annotatetype{\False, \tenv, \vt_i} \typearrow \vtp_i \OrTypeError\\\\
@@ -4515,7 +4552,7 @@ In the following example, all the uses of record or exception types are valid:
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\tty$ is either a record type, an exception type, or an enumeration type;
+  \item $\tty$ is a \structuredtype\ or an enumeration type;
   \item $\decl$ is $\False$, indicating that $\tty$ should be considered to be outside the context of a declaration
   of $\tty$;
   \item a type error is returned, indicating that the use of anonymous form of enumerations, record,
@@ -5401,7 +5438,7 @@ All of the following apply:
 \item $\ve$ denotes the record expression or an exception expression of type $\tty$ with fields $\fields$;
 \item determining whether $\tty$ is a named type yields $\True$\ProseOrTypeError;
 \item determining the \structure\ of $\tty$ yields $\vtp$\ProseOrTypeError;
-\item $\vtp$ is neither a record nor an exception type;
+\item $\vtp$ is not a \structuredtype;
 \item the result is an error indicating that $\tty$ is not appropriate for constructing a record.
 \end{itemize}
 
@@ -5430,7 +5467,7 @@ All of the following apply:
 A§ll of the following apply:
 \begin{itemize}
   \item $\ve$ denotes the record expression or an exception expression of type $\tty$ with fields $\fields$;
-  \item $\tty$ is the name of a record or exception type with fields $\fieldtypes$;
+  \item $\tty$ is a \structuredtype\ with fields $\fieldtypes$;
   \item there exists a field in $\fieldtypes$ that is not initialised by $\fields$;
   \item the result is an error indicating that a field is missing initialization.
 \end{itemize}
@@ -5464,7 +5501,7 @@ A§ll of the following apply:
 All of the following apply:
 \begin{itemize}
   \item $\ve$ denotes the record creation expression (which is also used for creating exceptions) of type $\tty$ with fields $\fields$;
-  \item $\tty$ is the name of a record or exception type with fields $\fieldtypes$;
+  \item $\tty$ is the name of a \structuredtype\ with fields $\fieldtypes$;
   \item \underline{every} field in $\fieldtypes$ is initialised by a corresponding expression in $\fields$;
   \item annotating the expressions that initialize each of the fields in $\fields$ via \\
         $\annotatefieldinit$ yields $\fieldsp$\ProseOrTypeError;
@@ -5508,7 +5545,7 @@ All of the following apply:
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$\ProseOrTypeError;
   \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$\ProseOrTypeError;
   % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$\ProseOrTypeError;
-  \item $\vtetwo$ is either a record type or an exception type with fields $\fields$;
+  \item $\vtetwo$ is a \structuredtype\ with fields $\fields$;
   \item the field $\fieldname$ is associated with the type $\vt$ in $\fields$
   \item $\newe$ is the access of field $\fieldname$ on the record or exception object $\vetwo$, that is, $\EGetField(\vetwo, \fieldname)$.
 \end{itemize}
@@ -5542,7 +5579,7 @@ All of the following apply:
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo)$\ProseOrTypeError;
   \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$\ProseOrTypeError;
   % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$\ProseOrTypeError;
-  \item $\vtetwo$ is either a record type or an exception type with fields $\fields$;
+  \item $\vtetwo$ is a \structuredtype\ with fields $\fields$;
   \item the field $\fieldname$ is not associated with any type in $\fields$
   \item the result is a type error indicating the missing field.
 \end{itemize}
@@ -6462,7 +6499,7 @@ All of the following apply:
   \item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
   \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\
         $\vletwo$\ProseOrTypeError;
-  \item the \structure\ of $\vtleone$ in $\tenv$ is either a record type or an exception type with list of fields $\fields$\ProseOrTypeError;
+  \item the \structure\ of $\vtleone$ in $\tenv$ is a \structuredtype\ with list of fields $\fields$\ProseOrTypeError;
   \item $\field$ is not associated with any type in $\fields$;
   \item the result is an error indicating that the field $\field$ is missing from the type of $\vleone$.
 \end{itemize}
@@ -6494,7 +6531,7 @@ All of the following apply:
   \item $\vle$ denotes the access to the field named \texttt{field} in $\vleone$;
   \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$\ProseOrTypeError;
   \item annotating the left-hand-side expression  $\vleone$ with type $\vtleone$ in $\tenv$ yields $\vletwo$\ProseOrTypeError;
-  \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields either a record type or an exception type with fields $\fields$\ProseOrTypeError;
+  \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a\structuredtype\ with fields $\fields$\ProseOrTypeError;
   \item the type associated with the field $\field$ in $\fields$ is $\vt$;
   \item determining whether $\vte$ \typesatisfies\ $\vt$ yields $\True$\ProseOrTypeError;
   \item $\newle$ is the access to the field $\field$ in $\vletwo$, that is, $\LESetField(\vletwo, \field)$.
@@ -6687,7 +6724,7 @@ All of the following apply:
   \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$\ProseOrTypeError;
   \item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$\ProseOrTypeError;
   \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a type $\vt$\ProseOrTypeError;
-  \item $\vt$ is neither a record type, an exception type, or a bitvector type;
+  \item $\vt$ is neither a \structuredtype\ nor a bitvector type;
   \item the result is an error indicating that the type of $\vle$ conflicts with the requirements of a field access expression.
 \end{itemize}
 
@@ -11718,8 +11755,8 @@ One of the following applies:
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is,\\ $\TNamed(\vsuper)$) yields
           $\True$\ProseOrTypeError;
     \item $\vsuper$ is bound to a type $\vt$ in $\tenv$;
-    \item checking that $\vt$ is either a record type or an exception type yields $\True$ or a type error
-          indicating that either a record type or an exception was expected, thereby short-circuiting the entire rule;
+    \item checking that $\vt$ is a \structuredtype\ yields $\True$ or a type error
+          indicating that a \structuredtype\ was expected, thereby short-circuiting the entire rule;
     \item $\vt$ has AST label $L$ and fields $\fields$;
     \item $\newty$ is the type with AST label $L$ and list fields that is the concatenation of $\fields$ and $\extrafields$;
     \item $\newtenv$ is $\tenv$ with its $\subtypes$ component updated by binding $\name$ to $\vsuper$.
@@ -12471,7 +12508,7 @@ One of the following applies:
 
   \item All of the following apply (\textsc{structured}):
   \begin{itemize}
-    \item $\vt$ is a structured type with fields $\fields$;
+    \item $\vt$ is a \structuredtype\ with fields $\fields$;
     \item define $\ids$ as the union of applying $\usety$ to each field type in $\fields$.
   \end{itemize}
 
@@ -17461,8 +17498,8 @@ One of the following applies:
   \item All of the following apply (\textsc{tstructured}):
   \begin{itemize}
     \item $L$ is either $\TRecord$ or $\TException$;
-    \item $\vtone$ is either a record type or an exception type with list of fields $\vfieldsone$, that is $L(\vfieldsone)$;
-    \item $\vttwo$ is either a record type or an exception type with list of fields $\vfieldstwo$, that is $L(\vfieldstwo)$;
+    \item $\vtone$ is a \structuredtype\ with list of fields $\vfieldsone$, that is $L(\vfieldsone)$;
+    \item $\vttwo$ is a \structuredtype\ with list of fields $\vfieldstwo$, that is $L(\vfieldstwo)$;
     \item checking whether the set of field names in $\vfieldsone$ is equal to the set of field names in $\vfieldstwo$
           yields $\True$ or $\False$, which short-circuits the entire rule;
     \item for each field $\vf$ in the set of fields of $\vfieldsone$, testing whether the type associated with

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -4344,7 +4344,10 @@ In the following example, all the uses of bitvector types are valid:
 }
 \end{mathpar}
 
-\isempty{\subsection{Comments}}
+\subsection{Comments}
+The width of a bitvector type $\TBits(\ewidth, \bitfields)$, given by the expression \\
+$\ewidth$,
+must be non-negative.
 
 \section{TypingRule.TTuple \label{sec:TypingRule.TTuple}}
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -46,7 +46,7 @@
 \newcommand\isprimitive[0]{\hyperlink{def-isprimitive}{\texttt{is\_primitive}}}
 
 \newcommand\isunconstrainedinteger[0]{\hyperlink{def-isunconstrainedinteger}{\textsf{is\_unconstrained\_integer}}}
-\newcommand\isunderconstrainedinteger[0]{\hyperlink{def-isunderconstrainedinteger}{\textsf{is\_under\_constrained\_integer}}}
+\newcommand\isparameterizedinteger[0]{\hyperlink{def-isparameterizedinteger}{\textsf{is\_parameterized\_integer}}}
 \newcommand\iswellconstrainedinteger[0]{\hyperlink{def-iswellconstrainedinteger}{\textsf{is\_well\_constrained\_integer}}}
 \newcommand\unconstrainedinteger[0]{\hyperlink{def-unconstrainedinteger}{\textsf{unconstrained\_integer}}}
 
@@ -202,6 +202,7 @@
 \newcommand\ELInt[1]{\hyperlink{def-elint}{\texttt{ELInt}}(#1)}
 
 % Glossary
+\newcommand\parameterizedintegertype[0]{\hyperlink{def-parameterizedintegertype}{parameterized integer type}}
 \newcommand\structuredtype[0]{\hyperlink{def-structuredtype}{structured type}}
 \newcommand\structure[0]{\hyperlink{def-structure}{structure}}
 \newcommand\underlyingtype[0]{\hyperlink{def-underlyingtype}{underlying type}}
@@ -689,18 +690,19 @@ with a new mapping $x \mapsto v$, we use the notation $\tenv.f[x \mapsto v]$ to 
   \item A \emph{constrained type} is a type whose definition relies on an expression, for example, certain integers and bitvectors.
   \item A type which is not constrained is \emph{unconstrained}.
   \item A constrained type with a non-empty constraint is \emph{well-constrained}.
-  \item An \emph{under-constrained integer type} is an implicit type of a subprogram parameter.
+  \hypertarget{def-parameterizedintegertype}
+  \item A \emph{\parameterizedintegertype} is an implicit type of a subprogram parameter.
   \end{itemize}
 The widths of bitvector storage elements are constrained integers.
 
 \hypertarget{def-isunconstrainedinteger}{}
-\hypertarget{def-isunderconstrainedinteger}{}
+\hypertarget{def-isparameterizedinteger}{}
 \hypertarget{def-iswellconstrainedinteger}{}
 We define the following helper predicates to classify integer types:
 \[
   \begin{array}{rcl}
   \isunconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool\\
-  \isunderconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool\\
+  \isparameterizedinteger(\overname{\ty}{\vt}) &\aslto& \Bool\\
   \iswellconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool
   \end{array}
 \]
@@ -708,8 +710,8 @@ We define the following helper predicates to classify integer types:
 We define the following shorthands for classifying integers:
 \[
   \begin{array}{rcl}
-  \isunconstrainedinteger(\vt) &\triangleq& \vt = \TInt(\unconstrained)\\
-  \isunderconstrainedinteger(\vt) &\triangleq& \vt = \TInt(\Ignore)\\
+  \isunconstrainedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\unconstrained\\
+  \isparameterizedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\parameterized\\
   \iswellconstrainedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\wellconstrained\\
 \end{array}
 \]
@@ -993,9 +995,9 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_int\_underconstrained}):
+  \item All of the following apply (\textsc{t\_int\_parameterized}):
   \begin{itemize}
-    \item $\vt$ is an under constrained integer for parameter $\id$, \\ $\TInt(\underconstrained(\id))$;
+    \item $\vt$ is a \parameterizedintegertype\ for parameter $\id$, \\ $\TInt(\parameterized(\id))$;
     \item the native value associated with $\id$ in the local dynamic environment is the native integer value for $n$;
     \item $\vd$ is the set containing the single integer value for $n$.
   \end{itemize}
@@ -1144,10 +1146,10 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
 The notation $L^\denv(\id)$ denotes the native value associated with the identifier $\id$
 in the \emph{local dynamic environment} of $\denv$.
 \begin{mathpar}
-  \inferrule[t\_int\_underconstrained]{
+  \inferrule[t\_int\_parameterized]{
   L^\denv(\id) = \nvint(n)
 }{
-  \dynamicdomain(\env, \overname{\TInt(\underconstrained(\id))}{\vt}) = \overname{\{ \nvint(n) \}}{\vd}
+  \dynamicdomain(\env, \overname{\TInt(\parameterized(\id))}{\vt}) = \overname{\{ \nvint(n) \}}{\vd}
 }
 \end{mathpar}
 
@@ -1994,9 +1996,9 @@ One of the following applies:
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{underconstrained}):
+  \item All of the following apply (\textsc{parameterized}):
   \begin{itemize}
-    \item $\vt$ is an underconstrained integer;
+    \item $\vt$ is a \parameterizedintegertype;
     \item the result is $\True$.
   \end{itemize}
 
@@ -2024,9 +2026,9 @@ One of the following applies:
   \checkconstrainedinteger(\tenv, \TInt(\wellconstrained(\Ignore))) \typearrow \True
 }
 \and
-\inferrule[underconstrained]{}
+\inferrule[parameterized]{}
 {
-  \checkconstrainedinteger(\tenv, \TInt(\underconstrained(\Ignore))) \typearrow \True
+  \checkconstrainedinteger(\tenv, \TInt(\parameterized(\Ignore))) \typearrow \True
 }
 \and
 \inferrule[unconstrained]{}
@@ -2892,9 +2894,10 @@ One of the following applies:
       \item $\tty$ is the unconstrained integer type.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_int\_underconstrained}):
+    \item All of the following apply (\textsc{t\_int\_parameterized}):
     \begin{itemize}
-      \item neither of $\vt$ and $\vs$ are the unconstrained integer type;
+      \item neither $\vt$ nor $\vs$ are the unconstrained integer type;
+      \item one of $\vt$ and $\vs$ is a \parameterizedintegertype;
       \item the \wellconstrainedversion\ of $\vt$ is $\vtone$;
       \item the \wellconstrainedversion\ of $\vs$ is $\vsone$;
       \item $\tty$ the lowest common ancestor of $\vtone$ and $\vsone$ in $\tenv$ is $\tty$\ProseOrTypeError.
@@ -3039,12 +3042,12 @@ We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is \typeequivalent\
   \lca(\tenv, \vt, \vs) \typearrow \unconstrainedinteger
 }
 \and
-\inferrule[t\_int\_underconstrained]{
+\inferrule[t\_int\_parameterized]{
   \typeequal(\tenv, \vt, \vs) \typearrow \False\\
   \astlabel(\vt) = \astlabel(\vs) = \TInt\\
   \neg\isunconstrainedinteger(\vt)\\
   \neg\isunconstrainedinteger(\vs)\\
-  \isunderconstrainedinteger(\vt) \lor \isunderconstrainedinteger(\vs)\\
+  \isparameterizedinteger(\vt) \lor \isparameterizedinteger(\vs)\\
   \towellconstrained(\tenv, \vt) \typearrow \vtone\\
   \towellconstrained(\tenv, \vs) \typearrow \vsone\\
   \lca(\tenv, \vtone, \vsone) \typearrow \tty \OrTypeError
@@ -3190,11 +3193,11 @@ One of the following applies:
   $\TInt(\wellconstrained(\vcsnew))$;
 \end{itemize}
 
-\item All of the following apply (\textsc{neg\_t\_int\_underconstrained}):
+\item All of the following apply (\textsc{neg\_t\_int\_parameterized}):
 \begin{itemize}
   \item $\op$ is $\NEG$;
   \item determining whether $\vt$ \typesatisfies\ $\unconstrainedinteger$ yields $\True$\ProseOrTypeError;
-  \item obtaining the \structure\ of $\vt$ yields the underconstrained integer type with parameter $\vv$, that is,
+  \item obtaining the \structure\ of $\vt$ yields the \parameterizedintegertype\ with parameter $\vv$, that is,
   $\TInt(\wellconstrained(\vv))$\ProseOrTypeError;
   \item converting $\TInt(\wellconstrained(\vv))$ to a well-constrained integer with an exact constraint expression for $\vv$
   (see $\getwellconstrainedstructure$) yields $\vtone$;
@@ -3281,9 +3284,9 @@ the values it represents:
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[neg\_t\_int\_underconstrained]{
+\inferrule[neg\_t\_int\_parameterized]{
   \typesat(\tenv, \vt, \unconstrainedinteger) \typearrow \True\\
-  \tstruct(\tenv, \vtone) \typearrow \TInt(\underconstrained(\vv))\\
+  \tstruct(\tenv, \vtone) \typearrow \TInt(\parameterized(\vv))\\
   \getwellconstrainedstructure(\tenv, \vt) \typearrow \vtone\\
   \CheckUnop(\tenv, \NEG, \vtone) \typearrow \vs
 }{
@@ -4294,8 +4297,8 @@ In the following examples, all the uses of integer types are valid:
   \annotatetype{\Ignore, \tenv, \tty} \typearrow \tty
 }
 \and
-\inferrule[underconstrained]{
-  \tty \eqname \TInt(\underconstrained(\Ignore))\\
+\inferrule[parameterized]{
+  \tty \eqname \TInt(\parameterized(\Ignore))\\
 }{
   \annotatetype{\Ignore, \tenv, \tty} \typearrow \tty
 }
@@ -8761,18 +8764,18 @@ One of the following applies:
         \item $\calleeparam$ does not have a type annotation, that is, $(\Ignore, \None)$.
       \end{itemize}
 
-      \item All of the following apply (\textsc{underconstrained}):
+      \item All of the following apply (\textsc{parameterized}):
       \begin{itemize}
-        \item $\calleeparam$ is a parameter $\vs$ with a type annotation of an
-              underconstrained integer for the same parameter, that is, \\
-              $(\vs, \langle\TInt(\underconstrained(\vs))\rangle)$.
+        \item $\calleeparam$ is a parameter $\vs$ with a type annotation of a
+              \parameterizedintegertype\ for the same parameter, that is, \\
+              $(\vs, \langle\TInt(\parameterized(\vs))\rangle)$.
       \end{itemize}
 
       \item All of the following apply (\textsc{other}):
       \begin{itemize}
         \item $\calleeparam$ is a parameter $\vs$ whose type annotation is \\
               $\calleeparamt$, that is, $(\vs, \langle\calleeparamt\rangle)$;
-        \item $\calleeparamt$ is not the underconstrained integer for the same parameter;
+        \item $\calleeparamt$ is not the \parameterizedintegertype\ for the same parameter;
         \item substituting the parameter expressions from $\eqsthree$ in $\calleeparamt$
               yields $\calleeparamtrenamed$\ProseOrTypeError;
         \item applying $\assocopt$ to $\eqsthree$ and $\vs$ the expression $\callerparame$
@@ -8803,8 +8806,8 @@ One of the following applies:
   \checkcalleeparams(\tenv, \calleeparams, \eqsthree) \typearrow \True
 }
 \and
-\inferrule[underconstrained]{
-  \calleeparams \eqname [(\vs, \langle\TInt(\underconstrained(\vs))\rangle)] \concat \calleeparamsone\\
+\inferrule[parameterized]{
+  \calleeparams \eqname [(\vs, \langle\TInt(\parameterized(\vs))\rangle)] \concat \calleeparamsone\\
   \checkcalleeparams(\tenv, \calleeparamsone, \eqsthree) \typearrow \True \OrTypeError
 }{
   \checkcalleeparams(\tenv, \calleeparams, \eqsthree) \typearrow \True
@@ -8812,7 +8815,7 @@ One of the following applies:
 \and
 \inferrule[other]{
   \calleeparams \eqname [(\vs, \langle\calleeparamt\rangle)] \concat \calleeparamsone\\
-  \calleeparamt \neq \TInt(\underconstrained(\vs))\\
+  \calleeparamt \neq \TInt(\parameterized(\vs))\\
   \renametyeqs(\tenv, \eqsthree, \calleeparamt) \typearrow \calleeparamtrenamed \OrTypeError\\\\
   \assocopt(\eqsthree, \vs) \typearrow \langle \ve \rangle\\
   \annotateexpr{\tenv, \callerparame} \typearrow \callerparamt \OrTypeError\\\\
@@ -8860,9 +8863,9 @@ One of the following applies:
           $\newconstraints$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_int\_underconstrained}):
+  \item All of the following apply (\textsc{t\_int\_parameterized}):
   \begin{itemize}
-    \item $\tty$ is an underconstrained integer type for the parameter $\name$;
+    \item $\tty$ is a \parameterizedintegertype\ for the parameter $\name$;
     \item applying $\substexprnormalize$ to $\eqs$ and the expression $\EVar(\name)$ yields $\ve$;
     \item define $\newty$ as the well-constrained integer type with the single constraint for $\ve$, that is,
           $\TInt(\wellconstrained(\ConstraintExact(\ve)))$.
@@ -8902,11 +8905,11 @@ One of the following applies:
   \newty
 }
 \and
-\inferrule[t\_int\_underconstrained]{
+\inferrule[t\_int\_parameterized]{
   \substexprnormalize(\eqs, \EVar(\name)) \typearrow \ve\\
   \newty \eqdef \TInt(\wellconstrained(\ConstraintExact(\ve)))
 }{
-  \renametyeqs(\tenv, \eqs, \overname{\TInt(\underconstrained(\name))}{\tty}) \typearrow \newty
+  \renametyeqs(\tenv, \eqs, \overname{\TInt(\parameterized(\name))}{\tty}) \typearrow \newty
 }
 \and
 \inferrule[t\_tuple]{
@@ -10506,10 +10509,10 @@ All of the following apply:
         indicating that each parameter must have a defining argument, thus short-circuiting the entire rule;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{type\_underconstrained}):
+    \item All of the following apply (\textsc{type\_parameterized}):
     \begin{itemize}
-      \item $\tyopt$ is either $\None$ or an unconstrained integer type;
-      \item $\vt$ is defined as the underconstrained integer type for the identifier $\vx$.
+      \item $\tyopt$ is either $\None$ or a \parameterizedintegertype;
+      \item $\vt$ is defined as the \parameterizedintegertype\ for the identifier $\vx$.
     \end{itemize}
 
     \item All of the following apply (\textsc{type\_annotated}):
@@ -10527,11 +10530,11 @@ All of the following apply:
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule[type\_underconstrained]{
+\inferrule[type\_parameterized]{
   \checkvarnotinenv{\tenvonep, \vx} \typearrow \True \OrTypeError\\\\
   \checktrans{\vx \in \potentialparams}{\ParameterWithoutDecl} \checktransarrow \True \OrTypeError\\\\
   (\tyopt = \None \lor \tyopt = \langle \TInt(\unconstrained)\rangle) \\
-  \vt \eqdef \TInt(\underconstrained(\vx))\\
+  \vt \eqdef \TInt(\parameterized(\vx))\\
   \checkconstrainedinteger(\tenvone, \vt) \typearrow \True \OrTypeError\\\\
   \addlocal(\tenvonep, \vx, \vt, \LDKLet) \typearrow \newtenv\\
   \declaredparams \eqdef \acc[\vx \mapsto \vt]
@@ -10743,7 +10746,7 @@ One of the following applies:
   \item All of the following apply (\textsc{tint\_unconstrained}):
   \begin{itemize}
     \item $\tty$ is the unconstrained integer type;
-    \item $\newty$ is the underconstrained integer type for the identifier $\vx$.
+    \item $\newty$ is the \parameterizedintegertype\ for the identifier $\vx$.
   \end{itemize}
 
   \item All of the following apply (\textsc{other}):
@@ -12493,7 +12496,7 @@ One of the following applies:
 
   \item All of the following apply (\textsc{int\_no\_constraints}):
   \begin{itemize}
-    \item $\vt$ is either the unconstrained integer type or an underconstrained integer type;
+    \item $\vt$ is either the unconstrained integer type or a \parameterizedintegertype;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
@@ -12559,7 +12562,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[int\_no\_constraints]{
-  \astlabel(\vc) \in \{\unconstrained, \underconstrained\}
+  \astlabel(\vc) \in \{\unconstrained, \parameterized\}
 }{
   \usety(\overname{\TInt(\vc)}{\vt}) \typearrow \overname{\emptyset}{\ids}
 }
@@ -14891,9 +14894,9 @@ One of the following applies:
     \item define $\vd$ as $\DInt(\Top)$, which intuitively represents the entire set of integers.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_underconstrained}):
+  \item All of the following apply (\textsc{int\_parameterized}):
   \begin{itemize}
-    \item $\vt$ is the underconstrained integer type for the identifier $\id$;
+    \item $\vt$ is the \parameterizedintegertype\ for the identifier $\id$;
     \item define $\vd$ as the symbolic constrained integer domain with a single constraint for the variable expression for $\id$,
           that is, \\ $\DInt(\FromSyntax([\ConstraintExact(\EVar(\id))]))$.
   \end{itemize}
@@ -14993,8 +14996,8 @@ One of the following applies:
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[int\_underconstrained]{}{
-  \symdomoftype(\tenv, \overname{\TInt(\underconstrained(\id))}{\vt}) \typearrow \\
+\inferrule[int\_parameterized]{}{
+  \symdomoftype(\tenv, \overname{\TInt(\parameterized(\id))}{\vt}) \typearrow \\
   \overname{\DInt(\FromSyntax([\ConstraintExact(\EVar(\id))]))}{\vd}
 }
 \end{mathpar}
@@ -16501,9 +16504,9 @@ The function
 \subsection{Prose}
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{unconstrained\_underconstrained}):
+  \item All of the following apply (\textsc{unconstrained\_parameterized}):
   \begin{itemize}
-    \item the AST label of $\vc$ is either $\unconstrained$ or $\underconstrained$;
+    \item the AST label of $\vc$ is either $\unconstrained$ or $\parameterized$;
     \item define $\newc$ as $\vc$.
   \end{itemize}
 
@@ -16518,15 +16521,15 @@ One of the following applies:
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule[unconstrained\_underconstrained]{
-  \astlabel(\vc) \in \{\unconstrained, \underconstrained\}
+\inferrule[unconstrained\_parameterized]{
+  \astlabel(\vc) \in \{\unconstrained, \parameterized\}
 }{
   \reduceconstraints(\tenv, \vc) \typearrow \overname{\vc}{\newc}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[unconstrained\_underconstrained]{
+\inferrule[unconstrained\_parameterized]{
   \newc \eqdef [\vi\in\listrange(\cs): \reduceconstraint(\tenv, \cs[\vi])]
 }{
   \reduceconstraints(\tenv, \overname{\wellconstrained(\cs)}{\vc}) \typearrow \newc
@@ -17452,10 +17455,10 @@ One of the following applies:
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tint\_underconstrained}):
+  \item All of the following apply (\textsc{tint\_parameterized}):
   \begin{itemize}
-    \item $\vtone$ is the underconstrained integer type with identifier $\vione$, that is, \\ $\TInt(\underconstrained(\vione))$;
-    \item $\vttwo$ is the underconstrained integer type with identifier $\vitwo$, that is, \\ $\TInt(\underconstrained(\vitwo))$;
+    \item $\vtone$ is the \parameterizedintegertype\  with identifier $\vione$, that is, \\ $\TInt(\parameterized(\vione))$;
+    \item $\vttwo$ is the \parameterizedintegertype\ with identifier $\vitwo$, that is, \\ $\TInt(\parameterized(\vitwo))$;
     \item $\vb$ is $\True$ if and only if $\vione$ is equal to $\vitwo$.
   \end{itemize}
 
@@ -17548,10 +17551,10 @@ One of the following applies:
   \typeequal(\tenv, \TInt(\unconstrained), \TInt(\unconstrained)) \typearrow \True
 }
 \and
-\inferrule[tint\_underconstrained]{
+\inferrule[tint\_parameterized]{
   \vb \eqdef \vione = \vitwo
 }{
-  \typeequal(\tenv, \TInt(\underconstrained(\vione)), \TInt(\underconstrained(\vitwo))) \typearrow \vb
+  \typeequal(\tenv, \TInt(\parameterized(\vione)), \TInt(\parameterized(\vitwo))) \typearrow \vb
 }
 \and
 \inferrule[tint\_wellconstrained]{
@@ -19431,29 +19434,29 @@ returns the \wellconstrainedversion\ of a type $\vt$ --- $\vtp$, which is define
 
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{t\_int\_underconstrained}):
+  \item All of the following apply (\textsc{t\_int\_parameterized}):
   \begin{itemize}
-    \item $\vt$ is an underconstrained integer for the variable $\vv$;
+    \item $\vt$ is a \parameterizedintegertype\ for the variable $\vv$;
     \item $\vtp$ is the well-constrained integer constrained by the variable expression for $\vv$,
     that is, $\TInt(\wellconstrained(\constraintexact(\EVar(\vv))))$.
   \end{itemize}
 
   \item All of the following apply (\textsc{t\_int\_other, other}):
   \begin{itemize}
-    \item $\vt$ is not an underconstrained integer for the variable $\vv$;
+    \item $\vt$ is not a \parameterizedintegertype\ for the variable $\vv$;
     \item $\vtp$ is $\vt$.
   \end{itemize}
 \end{itemize}
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule[t\_int\_underconstrained]{}
+\inferrule[t\_int\_parameterized]{}
 {
-  \towellconstrained(\TInt(\underconstrained(\vv))) \typearrow\\ \TInt(\wellconstrained(\constraintexact(\EVar(\vv))))
+  \towellconstrained(\TInt(\parameterized(\vv))) \typearrow\\ \TInt(\wellconstrained(\constraintexact(\EVar(\vv))))
 }
 \and
 \inferrule[t\_int\_other]{
-  \astlabel(\vi) \neq \underconstrained
+  \astlabel(\vi) \neq \parameterized
 }
 {
   \towellconstrained(\TInt(\vi)) \typearrow \vt

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -214,7 +214,7 @@
 \newcommand\intconstraint[0]{\textsf{int\_constraint}}
 \newcommand\unconstrained[0]{\textsf{Unconstrained}}
 \newcommand\wellconstrained[0]{\textsf{WellConstrained}}
-\newcommand\underconstrained[0]{\textsf{Underconstrained}}
+\newcommand\parameterized[0]{\textsf{Parameterized}}
 \newcommand\constraintexact[0]{\textsf{Constraint\_Exact}}
 \newcommand\constraintrange[0]{\textsf{Constraint\_Range}}
 \newcommand\bitfield[0]{\textsf{bitfield}}

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -155,7 +155,7 @@ Runtime checks:
 
   $ aslref under-constrained-used.asl
 
-UnderConstrained integers:
+Parameterized integers:
   $ aslref bad-underconstrained-call.asl
   File bad-underconstrained-call.asl, line 9, characters 9 to 23:
   ASL Typing error: a subtype of integer {0..(M - 1)} was expected,


### PR DESCRIPTION
- [x] Define and use 'structured type' throughout the ASL Typing Reference
- [x] Clarify that bitvector widths must be non-negative
- [x] Rename 'underconstrained integer type' to 'parameterized integer type'