### PR TITLE
[asl] Add missing EOF in cram tests

### DIFF
--- a/asllib/tests/atcs.t
+++ b/asllib/tests/atcs.t
@@ -4,6 +4,7 @@ Deferred to execution ATCs
   >   let x = (3 as integer {42});
   >   return 0;
   > end
+  > EOF
 
   $ aslref atcs1.asl
   File atcs1.asl, line 2, characters 11 to 12:
@@ -17,6 +18,7 @@ Bad structure ATCs
   >   let x = (3 as boolean);
   >   return 0;
   > end
+  > EOF
 
   $ aslref atcs2.asl
   File atcs2.asl, line 2, characters 11 to 23:
@@ -30,6 +32,7 @@ ATCs on other types
   >   let x = ("a string" as string);
   >   return 0;
   > end
+  > EOF
 
   $ aslref atcs3.asl
 
@@ -39,6 +42,7 @@ ATCs on other types
   >   let x = (myty { a = 4, b = Zeros(4) }) as myty;
   >   return 0;
   > end
+  > EOF
 
   $ aslref atcs4.asl
 
@@ -50,6 +54,7 @@ ATCs on other types
   >   let y = x as myty2;
   >   return 0;
   > end
+  > EOF
 
   $ aslref atcs5.asl
   File atcs5.asl, line 5, characters 10 to 20:
@@ -62,6 +67,7 @@ ATCs on other types
   >   let x = ((42, Zeros(4)) as myty);
   >   return 0;
   > end
+  > EOF
 
   $ aslref atcs6.asl
   File atcs6.asl, line 3, characters 11 to 25:
@@ -75,12 +81,14 @@ ATCs on other types
   >   let x = ((42, Zeros(4)) as myty);
   >   return 0;
   > end
+  > EOF
 
   $ aslref atcs7.asl
 
 ATCs in types:
   $ cat > atcs8.asl <<EOF
   > let bv : bits(1 as integer{2}) = Ones(1);
+  > EOF
 
   $ aslref atcs8.asl
   File atcs8.asl, line 1, characters 14 to 29:

--- a/asllib/tests/intersecting_slices.t
+++ b/asllib/tests/intersecting_slices.t
@@ -8,6 +8,7 @@ One slice cannot intersect itself:
   >   print (x);
   >   return 0;
   > end
+  > EOF
   $ aslref intersecting_slices1.asl
   '0001'
 
@@ -21,6 +22,7 @@ Two intersecting slices...
   >   print (x);
   >   return 0;
   > end
+  > EOF
 
   $ aslref intersecting_slices2.asl
   File intersecting_slices2.asl, line 5, characters 2 to 9:
@@ -38,6 +40,7 @@ Two maybe intersecting slices...
   >   print (x);
   >   return 0;
   > end
+  > EOF
 
   $ aslref intersecting_slices3.asl
   File intersecting_slices3.asl, line 6, characters 7 to 8:
@@ -54,6 +57,7 @@ Two intersecting bitfields
   >   print (x);
   >   return 0;
   > end
+  > EOF
 
   $ aslref intersecting_slices4.asl
   File intersecting_slices4.asl, line 5, characters 2 to 12:

--- a/asllib/tests/lca.t
+++ b/asllib/tests/lca.t
@@ -6,6 +6,7 @@
   >   let -: integer {2, 3} = x;
   >   let -: real = x;
   > end
+  > EOF
 
   $ aslref lca1.asl
   File lca1.asl, line 6, characters 2 to 18:
@@ -19,6 +20,7 @@
   >   let -: integer = x;
   >   let -: integer {2, 3} = x;
   > end
+  > EOF
 
   $ aslref lca2.asl
   File lca2.asl, line 5, characters 2 to 28:
@@ -32,6 +34,7 @@
   >   let -: integer = x;
   >   let -: integer {N} = x;
   > end
+  > EOF
 
   $ aslref lca3.asl
   File lca3.asl, line 5, characters 2 to 25:
@@ -45,6 +48,7 @@
   >   let x = if UNKNOWN: boolean then 3 as integer {0..N} else 3;
   >   let -: real = x;
   > end
+  > EOF
 
   $ aslref lca4.asl
   File lca4.asl, line 4, characters 2 to 18:
@@ -56,6 +60,7 @@
   > begin
   >   let x = if UNKNOWN: boolean then TRUE else 3;
   > end
+  > EOF
 
   $ aslref lca5.asl
   File lca5.asl, line 3, characters 10 to 46:
@@ -72,6 +77,7 @@
   >   let x = if UNKNOWN: boolean then 3 as T3 else 2 as T2;
   >   let -: real = x;
   > end
+  > EOF
 
   $ aslref lca6.asl
   File lca6.asl, line 7, characters 2 to 18:
@@ -85,6 +91,7 @@
   > begin
   >   let - = if UNKNOWN: boolean then 3 as T1 else 2 as T2;
   > end
+  > EOF
 
   $ aslref lca7.asl
   File lca7.asl, line 5, characters 48 to 55:
@@ -99,6 +106,7 @@
   >   let x = if UNKNOWN: boolean then '101' as T1 else '101' as bits(3);
   >   let -: real = x;
   > end
+  > EOF
 
   $ aslref lca8.asl
   File lca8.asl, line 5, characters 2 to 18:
@@ -113,6 +121,7 @@
   >   let -: bits(3) { [2] b1 } = x;
   >   let -: real = x;
   > end
+  > EOF
 
   $ aslref lca9.asl
   File lca9.asl, line 6, characters 2 to 18:
@@ -128,6 +137,7 @@
   >   let -: integer = x;
   >   let -: real = x;
   > end
+  > EOF
 
   $ aslref lca10.asl
   File lca10.asl, line 7, characters 2 to 18:
@@ -142,6 +152,7 @@
   >   let -: T1 = x;
   >   return 0;
   > end
+  > EOF
 
   $ aslref lca11.asl
 
@@ -153,6 +164,7 @@
   >   let -: (T1, T1) = x;
   >   return 0;
   > end
+  > EOF
 
   $ aslref lca12.asl
 
@@ -162,6 +174,7 @@
   >   let v : (integer{3,1}, integer{2,4}) = if UNKNOWN: boolean then (3, 2) else (1, 4);
   >   return 0;
   > end
+  > EOF
 
   $ aslref lca13.asl
 
@@ -174,6 +187,7 @@
   >   let x = if UNKNOWN: boolean then a else b;
   >   let -: real = x;
   > end
+  > EOF
 
   $ aslref lca14.asl
   File lca14.asl, line 7, characters 2 to 18:

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -1,6 +1,7 @@
   $ cat >print1.asl <<EOF
   > constant msg = "old pond\\nfrog leaps in\\nwater's sound";
   > func main () => integer begin print(msg); return 0; end
+  > EOF
   $ aslref print1.asl
   old pond
   frog leaps in
@@ -8,6 +9,7 @@
   $ cat >print2.asl <<EOF
   > constant msg = "old pond\\n\\tfrog\\tleaps in\\nwater's\\tsound";
   > func main () => integer begin print(msg); return 0; end
+  > EOF
   $ aslref print2.asl
   old pond
   	frog	leaps in
@@ -15,6 +17,7 @@
   $ cat >print3.asl <<EOF
   > constant msg = "Check out this haiku:\\n\\t\\"old pond\\n\\tfrog leaps in\\n\\twater's sound\\"";
   > func main () => integer begin print(msg); return 0; end
+  > EOF
   $ aslref print3.asl
   Check out this haiku:
   	"old pond
@@ -23,11 +26,13 @@
   $ cat >print4.asl <<EOF
   > constant msg = "Something with \\\\ backslashes.";
   > func main () => integer begin print(msg); return 0; end
+  > EOF
   $ aslref print4.asl
   Something with \ backslashes.
   $ cat >print5.asl <<EOF
   > constant msg = "Something with \\p bad characters.";
   > func main () => integer begin print(msg); return 0; end
+  > EOF
   $ aslref print5.asl
   File print5.asl, line 1, characters 32 to 33:
   ASL Error: Unknown symbol.
@@ -35,6 +40,7 @@
   $ cat >print6.asl <<EOF
   > constant msg = "Some unterminated string;
   > func main () => integer begin print(msg); return 0; end
+  > EOF
   $ aslref print6.asl
   File print6.asl, line 3, character 0:
   ASL Error: Unknown symbol.
@@ -50,6 +56,7 @@ C-Style comments
   > return 0; /* oh a new one */
   > // /* when in a commented line, it doesn't count!
   > end
+  > EOF
 
   $ aslref comments1.asl
   /* a comment inside a string? */

--- a/asllib/tests/print.t
+++ b/asllib/tests/print.t
@@ -5,6 +5,7 @@
   >   print (32);
   >   return 0;
   > end
+  > EOF
 
   $ aslref printer1.asl
   Wow 2 3.14 some other string
@@ -18,6 +19,7 @@
   >   print (32);
   >   return 0;
   > end
+  > EOF
 
   $ aslref printer2.asl
   File printer2.asl, line 2, characters 16 to 24:

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -102,6 +102,7 @@ Constrained-type satisfaction:
   >   var x: integer { 2, 4} = N;
   >    return;
   > end
+  > EOF
 
   $ aslref type-sat3.asl
   File type-sat3.asl, line 4, characters 2 to 29:
@@ -116,6 +117,7 @@ Constrained-type satisfaction:
   >   var x: integer { 2, 4} = N;
   >   return;
   > end
+  > EOF
 
   $ aslref type-sat4.asl
   File type-sat4.asl, line 4, characters 2 to 29:
@@ -130,6 +132,7 @@ Runtime checks:
   >   let x: integer {1} = 2 as integer {1};
   >   return 0;
   > end
+  > EOF
 
   $ aslref runtime-type-sat1.asl
   File runtime-type-sat1.asl, line 3, characters 23 to 24:
@@ -146,6 +149,7 @@ Runtime checks:
   >   test(3);
   >   return 0;
   > end
+  > EOF
 
   $ aslref runtime-type-sat2.asl
   File runtime-type-sat2.asl, line 2, characters 10 to 18:


### PR DESCRIPTION
Otherwise, `make test` may generate a diff ``+  warning: here-document at line N delimited by end-of-file (wanted `EOF')`` for some shells.