### PR TITLE
[aarch64,sve] Add support for SVE EOR vectors, unpredicated

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -118,7 +118,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
     | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
     | I_DUP_SV _ | I_ADD_SV _ | I_PTRUE _
-    | I_NEG_SV _ | I_MOVPRFX _
+    | I_NEG_SV _ | I_EOR_SV _ | I_MOVPRFX _
     | I_SMSTART _ | I_SMSTOP _ | I_LD1SPT _ | I_ST1SPT _
     | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
       -> true
@@ -318,7 +318,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
       | I_UADDV _
       | I_MOV_SV _ | I_DUP_SV _ | I_ADD_SV _ | I_PTRUE _
-      | I_NEG_SV _ | I_MOVPRFX _
+      | I_NEG_SV _ | I_MOVPRFX _ | I_EOR_SV _
       | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
       | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
       | I_SMSTART _ | I_SMSTOP _ | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
@@ -395,7 +395,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_UADDV (_,r,_,_)
       | I_MOV_SV (r,_,_)
       | I_DUP_SV (r,_,_) | I_ADD_SV (r,_,_) | I_PTRUE (r,_)
-      | I_NEG_SV (r,_,_) | I_MOVPRFX (r,_,_)
+      | I_NEG_SV (r,_,_) | I_MOVPRFX (r,_,_) | I_EOR_SV (r,_,_)
       | I_INDEX_SI (r,_,_,_) | I_INDEX_IS (r,_,_,_) | I_INDEX_SS (r,_,_,_) | I_INDEX_II (r,_,_)
       | I_RDVL (r,_) | I_ADDVL (r,_,_) | I_CNT_INC_SVE (_,r,_,_)
       | I_LD1SPT (_,r,_,_,_,_,_) | I_MOVA_TV (r,_,_,_,_) | I_MOVA_VT (r,_,_,_,_)
@@ -477,7 +477,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD1SP _ | I_LD2SP _ | I_LD3SP _ | I_LD4SP _
       | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
       | I_ADD_SV _ | I_PTRUE _
-      | I_NEG_SV _ | I_MOVPRFX _
+      | I_NEG_SV _ | I_MOVPRFX _ | I_EOR_SV _
       | I_MOV_SV _ | I_DUP_SV _
       | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
       | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -3634,6 +3634,12 @@ module Make
         |  I_ADD_SV (r1,r2,r3) ->
           check_sve inst;
           !(add_sv r1 r2 r3 ii)
+        |  I_EOR_SV (r1,r2,r3) ->
+          check_sve inst;
+          !(read_reg_scalable false r3 ii >>|
+            read_reg_scalable false r2 ii >>= fun (v1,v2) ->
+              M.op Op.Xor v1 v2 >>= fun v ->
+                write_reg_scalable r1 v ii)
         | I_UADDV(var,v,p,z) ->
           check_sve inst;
           !(uaddv var v p z ii)

--- a/herd/tests/instructions/AArch64.sve/Y01.litmus
+++ b/herd/tests/instructions/AArch64.sve/Y01.litmus
@@ -1,0 +1,18 @@
+AArch64 Y01
+(* EOR *)
+{
+  uint64_t t[2] = {1,2};
+  uint64_t s[2] = {3,4};
+  0:X0=t;
+  0:X1=s;
+}
+P0                    ;
+PTRUE P0.D,VL2        ;
+LD1D {Z0.D},P0/Z,[X0] ;
+LD1D {Z1.D},P0/Z,[X1] ;
+EOR Z0.D,Z0.D,Z1.D    ;
+ST1D {Z0.D},P0,[X0]   ;
+forall (
+  t={2,6} /\
+  s={3,4}
+)

--- a/herd/tests/instructions/AArch64.sve/Y01.litmus.expected
+++ b/herd/tests/instructions/AArch64.sve/Y01.litmus.expected
@@ -1,0 +1,11 @@
+Test Y01 Required
+States 1
+s={3,4}; t={2,6};
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Scalable-Vector-Extensions-is-work-in-progress
+Condition forall (t={2,6} /\ s={3,4})
+Observation Y01 Always 1 0
+Hash=c4df84c412ce399286611bf8e695a12a
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -674,6 +674,7 @@ include Arch.MakeArch(struct
     (* Scalable Vector Extension *)
     | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
     | I_UADDV _ | I_DUP_SV _ | I_ADD_SV _ | I_NEG_SV _ | I_MOVPRFX _
+    | I_EOR_SV _
     | I_LD1SP _ | I_LD2SP _ | I_LD3SP _ | I_LD4SP _
     | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
     | I_MOV_SV _ | I_PTRUE _

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -1310,6 +1310,10 @@ instr:
     I_DUP_SV ($2 , v, r) }
 | TOK_ADD zreg COMMA zreg COMMA zreg
   { I_ADD_SV ($2,$4,$6) }
+| OP ARCH_ZDREG COMMA ARCH_ZDREG COMMA ARCH_ZDREG
+  { match $1 with
+    | EOR -> I_EOR_SV ($2,$4,$6)
+    | _ -> assert false}
 | TOK_INDEX zreg COMMA xreg COMMA k
   { match $2 with
     | Zreg(_,64) -> I_INDEX_SI ($2,V64,$4,$6)

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -244,7 +244,7 @@ atom_init:
        (t, arr)
      else
        Warn.user_error
-         "Declared size of array %s does not match initial vakue size"
+         "Declared size of array %s does not match initial value size"
 	 (dump_location t) }
 /* prohibit "v[i] = scalar" form in init allow only "v[i]={scalar_list}" */
 | locindex EQUAL maybev { raise Parsing.Parse_error }

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -76,6 +76,7 @@ module Make(V:Constant.S)(C:Config) =
     (* Accept P/M register so assume partial update of register *)
     | I_NEG_SV (r,_,_)
     | I_MOVPRFX (r,_,_)
+    | I_EOR_SV (r,_,_)
       -> A.RegSet.of_list [r]
     (* Reserve slice index *)
     | I_LD1SPT (_,_,r,_,_,_,_)
@@ -1261,6 +1262,13 @@ module Make(V:Constant.S)(C:Config) =
         outputs = [r1];
         reg_env = (add_svint32_t [r1;r3;])@(add_svbool_t [pg;])}
 
+    let eor_sv r1 r2 r3 =
+      { empty_ins with
+        memo = sprintf "eor %s,%s,%s" (print_zreg "o" 0 0 r1) (print_zreg "i" 0 0 r2) (print_zreg "i" 0 1 r3);
+        inputs = [r2;r3];
+        outputs = [r1];
+        reg_env = (add_svint32_t [r1;r2;r3;])}
+
     let rdvl rd k =
       { empty_ins with
         memo = sprintf "rdvl ^o0,#%i" k;
@@ -1852,6 +1860,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_PTRUE (pred,pat) -> ptrue pred pat::k
     | I_NEG_SV (r1,r2,r3) -> neg_sv r1 r2 r3::k
     | I_MOVPRFX (r1,r2,r3) -> movprfx r1 r2 r3::k
+    | I_EOR_SV (r1,r2,r3) -> eor_sv r1 r2 r3::k
     | I_RDVL (r1,k1) -> rdvl r1 k1::k
     | I_ADDVL (r1,r2,k1) -> addvl r1 r2 k1::k
     | I_CNT_INC_SVE  (op,rd,pat,k1) -> cnt_inc_sve op rd pat k1::k


### PR DESCRIPTION
Similar to `I_ADD_SV`, the SVE EOR instruction is added as `I_EOR_SV`. Tested with `diy7` on `qemu-aarch64`.