### PR TITLE
Litmus x86_64 test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ DUNE_PROFILE = release
 
 DIYCROSS                      = _build/install/default/bin/diycross7
 HERD                          = _build/install/default/bin/herd7
+LITMUS                        = _build/install/default/bin/litmus7
+LITMUS_LIB_DIR                = $(PWD)/litmus/libdir
 HERD_REGRESSION_TEST          = _build/default/internal/herd_regression_test.exe
 HERD_DIYCROSS_REGRESSION_TEST = _build/default/internal/herd_diycross_regression_test.exe
 HERD_CATALOGUE_REGRESSION_TEST = _build/default/internal/herd_catalogue_regression_test.exe
@@ -685,3 +687,9 @@ clean-asl-pseudocode:
 
 asldoc: $(BENTO)
 	@ $(MAKE) $(MFLAGS) -C $(@D)/asllib/doc all
+
+
+KUT_DIR := $(shell mktemp -d)
+RUN_TESTS := false
+
+include Makefile.x86_64

--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -1,0 +1,39 @@
+GCC_X86_64 ?= gcc
+
+litmus-x86_64-test:: litmus-cata-x86_64-test-std
+litmus-cata-x86_64-test-std: TEMP_DIR:=$(shell mktemp -d)
+litmus-cata-x86_64-test-std:
+	$(LITMUS) -set-libdir $(PWD)/litmus/libdir -mach x86_64 -gcc=$(GCC_X86_64) -mode std -a 4 catalogue/x86_64/tests/@all -o $(TEMP_DIR)
+	make -C $(TEMP_DIR) -j $(J)
+	if $(RUN_TESTS); then ( cd $(TEMP_DIR) && sh ./run.sh ); fi
+	$(RM) -rf $(TEMP_DIR)
+	@ echo "litmus7 in -mode std catalogue x86_64 tests: OK"
+
+litmus-x86_64-test:: litmus-cata-x86_64-test-presi
+litmus-cata-x86_64-test-presi: TEMP_DIR:=$(shell mktemp -d)
+litmus-cata-x86_64-test-presi:
+	$(LITMUS) -set-libdir $(PWD)/litmus/libdir -mach x86_64 -gcc=$(GCC_X86_64) -mode presi -driver C -a 4 -s 1k -r 50 catalogue/x86_64/tests/@all -o $(TEMP_DIR)
+	make -C $(TEMP_DIR) -j $(J)
+	if $(RUN_TESTS); then ( cd $(TEMP_DIR) && ./run.exe ); fi
+	$(RM) -rf $(TEMP_DIR)
+	@ echo "litmus7 in -mode presi catalogue x86_64 tests: OK"
+
+KUT_X86_64_CONFIG_PARAMS=
+
+litmus-x86_64-dep:
+	cd $(KUT_DIR); \
+	git clone -q https://gitlab.com/kvm-unit-tests/kvm-unit-tests.git; \
+	cd kvm-unit-tests; \
+	./configure $(KUT_X86_64_CONFIG_PARAMS); \
+	make
+
+litmus-x86_64-test:: litmus-cata-x86_64-test-kvm
+litmus-cata-x86_64-test-kvm: litmus-x86_64-dep
+	mkdir $(KUT_DIR)/kvm-unit-tests/t
+	$(LITMUS) -set-libdir $(PWD)/litmus/libdir -mach kvm-x86_64 -s 1k -r 50 -driver C -a 4 catalogue/x86_64/tests/@all -o $(KUT_DIR)/kvm-unit-tests/t
+	cd $(KUT_DIR)/kvm-unit-tests/t; make -j $(J)
+	if $(RUN_TESTS); then ( cd $(KUT_DIR)/kvm-unit-tests && sh t/run.sh ); fi
+	$(RM) -rf $(KUT_DIR)
+	@ echo "litmus7 in -mode kvm catalogue x86_64 tests: OK"
+
+

--- a/catalogue/x86_64/tests/2+2W.litmus
+++ b/catalogue/x86_64/tests/2+2W.litmus
@@ -1,0 +1,15 @@
+X86_64 2+2W
+"PodWW Coe PodWW Coe"
+Cycle=Coe PodWW Coe PodWW
+Relax=
+Safe=Coe PodWW
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=W
+Com=Co Co
+Orig=PodWW Coe PodWW Coe
+{
+}
+ P0          | P1          ;
+ movl $2,(x) | movl $2,(y) ;
+ movl $1,(y) | movl $1,(x) ;
+exists ([x]=2 /\ [y]=2)

--- a/catalogue/x86_64/tests/@all
+++ b/catalogue/x86_64/tests/@all
@@ -1,0 +1,30 @@
+# diy7 -arch X86_64 -safe Pod**,Rfe,Fre,Coe,[Rfi,PodRR],FencedWR -num false -size 5
+# Version 7.57+1, Revision: 9db4e9370b5b41855c6e914dcad7e0438edfca10
+SB+rfi-pos.litmus
+SB+rfi-po+po-rfi-po.litmus
+SB+po+rfi-po.litmus
+RWC+po+rfi-po.litmus
+SB+mfence+rfi-po.litmus
+R+po+rfi-po.litmus
+WRW+WR+po+rfi-po.litmus
+SB+po+po-rfi-po.litmus
+SB+mfence+po-rfi-po.litmus
+R+po+po-rfi-po.litmus
+MP+po+po-rfi-po.litmus
+RWC.litmus
+WRW+WR.litmus
+WRC.litmus
+RWC+po+mfence.litmus
+WRW+WR+po+mfence.litmus
+WRR+2W.litmus
+WRW+2W.litmus
+WWC.litmus
+MP.litmus
+S.litmus
+LB.litmus
+SB.litmus
+SB+mfence+po.litmus
+R.litmus
+SB+mfences.litmus
+R+po+mfence.litmus
+2+2W.litmus

--- a/catalogue/x86_64/tests/LB.litmus
+++ b/catalogue/x86_64/tests/LB.litmus
@@ -1,0 +1,15 @@
+X86_64 LB
+"PodRW Rfe PodRW Rfe"
+Cycle=Rfe PodRW Rfe PodRW
+Relax=
+Safe=Rfe PodRW
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=W
+Com=Rf Rf
+Orig=PodRW Rfe PodRW Rfe
+{
+}
+ P0            | P1            ;
+ movl (x),%eax | movl (y),%eax ;
+ movl $1,(y)   | movl $1,(x)   ;
+exists (0:rax=1 /\ 1:rax=1)

--- a/catalogue/x86_64/tests/MP+po+po-rfi-po.litmus
+++ b/catalogue/x86_64/tests/MP+po+po-rfi-po.litmus
@@ -1,0 +1,17 @@
+X86_64 MP+po+po-rfi-po
+"PodWW Rfe PodRW Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre PodWW Rfe PodRW
+Relax=
+Safe=[Rfi,PodRR] Rfe Fre PodWW PodRW
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
+Com=Rf Fr
+Orig=PodWW Rfe PodRW Rfi PodRR Fre
+{
+}
+ P0          | P1            ;
+ movl $1,(x) | movl (y),%eax ;
+ movl $1,(y) | movl $1,(z)   ;
+             | movl (z),%ebx ;
+             | movl (x),%ecx ;
+exists (1:rax=1 /\ 1:rbx=1 /\ 1:rcx=0)

--- a/catalogue/x86_64/tests/MP.litmus
+++ b/catalogue/x86_64/tests/MP.litmus
@@ -1,0 +1,15 @@
+X86_64 MP
+"PodWW Rfe PodRR Fre"
+Cycle=Rfe PodRR Fre PodWW
+Relax=
+Safe=Rfe Fre PodWW PodRR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
+Com=Rf Fr
+Orig=PodWW Rfe PodRR Fre
+{
+}
+ P0          | P1            ;
+ movl $1,(x) | movl (y),%eax ;
+ movl $1,(y) | movl (x),%ebx ;
+exists (1:rax=1 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/R+po+mfence.litmus
+++ b/catalogue/x86_64/tests/R+po+mfence.litmus
@@ -1,0 +1,16 @@
+X86_64 R+po+mfence
+"PodWW Coe MFencedWR Fre"
+Cycle=Fre PodWW Coe MFencedWR
+Relax=
+Safe=Fre Coe PodWW MFencedWR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
+Com=Co Fr
+Orig=PodWW Coe MFencedWR Fre
+{
+}
+ P0          | P1            ;
+ movl $1,(x) | movl $2,(y)   ;
+ movl $1,(y) | mfence        ;
+             | movl (x),%eax ;
+exists ([y]=2 /\ 1:rax=0)

--- a/catalogue/x86_64/tests/R+po+po-rfi-po.litmus
+++ b/catalogue/x86_64/tests/R+po+po-rfi-po.litmus
@@ -1,0 +1,17 @@
+X86_64 R+po+po-rfi-po
+"PodWW Coe PodWW Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre PodWW Coe PodWW
+Relax=
+Safe=[Rfi,PodRR] Fre Coe PodWW
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
+Com=Co Fr
+Orig=PodWW Coe PodWW Rfi PodRR Fre
+{
+}
+ P0          | P1            ;
+ movl $1,(x) | movl $2,(y)   ;
+ movl $1,(y) | movl $1,(z)   ;
+             | movl (z),%eax ;
+             | movl (x),%ebx ;
+exists ([y]=2 /\ 1:rax=1 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/R+po+rfi-po.litmus
+++ b/catalogue/x86_64/tests/R+po+rfi-po.litmus
@@ -1,0 +1,16 @@
+X86_64 R+po+rfi-po
+"PodWW Coe Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre PodWW Coe
+Relax=
+Safe=[Rfi,PodRR] Fre Coe PodWW
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
+Com=Co Fr
+Orig=PodWW Coe Rfi PodRR Fre
+{
+}
+ P0          | P1            ;
+ movl $1,(x) | movl $2,(y)   ;
+ movl $1,(y) | movl (y),%eax ;
+             | movl (x),%ebx ;
+exists ([y]=2 /\ 1:rax=2 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/R.litmus
+++ b/catalogue/x86_64/tests/R.litmus
@@ -1,0 +1,15 @@
+X86_64 R
+"PodWW Coe PodWR Fre"
+Cycle=Fre PodWW Coe PodWR
+Relax=
+Safe=Fre Coe PodWW PodWR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
+Com=Co Fr
+Orig=PodWW Coe PodWR Fre
+{
+}
+ P0          | P1            ;
+ movl $1,(x) | movl $2,(y)   ;
+ movl $1,(y) | movl (x),%eax ;
+exists ([y]=2 /\ 1:rax=0)

--- a/catalogue/x86_64/tests/RWC+po+mfence.litmus
+++ b/catalogue/x86_64/tests/RWC+po+mfence.litmus
@@ -1,0 +1,16 @@
+X86_64 RWC+po+mfence
+"Rfe PodRR Fre MFencedWR Fre"
+Cycle=Rfe PodRR Fre MFencedWR Fre
+Relax=
+Safe=Rfe Fre PodRR MFencedWR
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=T,2:y=F,2:x=T
+Com=Rf Fr Fr
+Orig=Rfe PodRR Fre MFencedWR Fre
+{
+}
+ P0          | P1            | P2            ;
+ movl $1,(x) | movl (x),%eax | movl $1,(y)   ;
+             | movl (y),%ebx | mfence        ;
+             |               | movl (x),%eax ;
+exists (1:rax=1 /\ 1:rbx=0 /\ 2:rax=0)

--- a/catalogue/x86_64/tests/RWC+po+rfi-po.litmus
+++ b/catalogue/x86_64/tests/RWC+po+rfi-po.litmus
@@ -1,0 +1,16 @@
+X86_64 RWC+po+rfi-po
+"Rfe PodRR Fre Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre Rfe PodRR Fre
+Relax=
+Safe=[Rfi,PodRR] Rfe Fre PodRR
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=T,2:y=F,2:x=T
+Com=Rf Fr Fr
+Orig=Rfe PodRR Fre Rfi PodRR Fre
+{
+}
+ P0          | P1            | P2            ;
+ movl $1,(x) | movl (x),%eax | movl $1,(y)   ;
+             | movl (y),%ebx | movl (y),%eax ;
+             |               | movl (x),%ebx ;
+exists (1:rax=1 /\ 1:rbx=0 /\ 2:rax=1 /\ 2:rbx=0)

--- a/catalogue/x86_64/tests/RWC.litmus
+++ b/catalogue/x86_64/tests/RWC.litmus
@@ -1,0 +1,15 @@
+X86_64 RWC
+"Rfe PodRR Fre PodWR Fre"
+Cycle=Rfe PodRR Fre PodWR Fre
+Relax=
+Safe=Rfe Fre PodWR PodRR
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=T,2:y=F,2:x=T
+Com=Rf Fr Fr
+Orig=Rfe PodRR Fre PodWR Fre
+{
+}
+ P0          | P1            | P2            ;
+ movl $1,(x) | movl (x),%eax | movl $1,(y)   ;
+             | movl (y),%ebx | movl (x),%eax ;
+exists (1:rax=1 /\ 1:rbx=0 /\ 2:rax=0)

--- a/catalogue/x86_64/tests/S.litmus
+++ b/catalogue/x86_64/tests/S.litmus
@@ -1,0 +1,15 @@
+X86_64 S
+"PodWW Rfe PodRW Coe"
+Cycle=Rfe PodRW Coe PodWW
+Relax=
+Safe=Rfe Coe PodWW PodRW
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=W,1:y=F,1:x=W
+Com=Rf Co
+Orig=PodWW Rfe PodRW Coe
+{
+}
+ P0          | P1            ;
+ movl $2,(x) | movl (y),%eax ;
+ movl $1,(y) | movl $1,(x)   ;
+exists ([x]=2 /\ 1:rax=1)

--- a/catalogue/x86_64/tests/SB+mfence+po-rfi-po.litmus
+++ b/catalogue/x86_64/tests/SB+mfence+po-rfi-po.litmus
@@ -1,0 +1,17 @@
+X86_64 SB+mfence+po-rfi-po
+"MFencedWR Fre PodWW Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre MFencedWR Fre PodWW
+Relax=
+Safe=[Rfi,PodRR] Fre PodWW MFencedWR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=T,1:y=F,1:x=T
+Com=Fr Fr
+Orig=MFencedWR Fre PodWW Rfi PodRR Fre
+{
+}
+ P0            | P1            ;
+ movl $1,(x)   | movl $1,(y)   ;
+ mfence        | movl $1,(z)   ;
+ movl (y),%eax | movl (z),%eax ;
+               | movl (x),%ebx ;
+exists (0:rax=0 /\ 1:rax=1 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/SB+mfence+po.litmus
+++ b/catalogue/x86_64/tests/SB+mfence+po.litmus
@@ -1,0 +1,16 @@
+X86_64 SB+mfence+po
+"MFencedWR Fre PodWR Fre"
+Cycle=Fre PodWR Fre MFencedWR
+Relax=
+Safe=Fre PodWR MFencedWR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=T,1:y=F,1:x=T
+Com=Fr Fr
+Orig=MFencedWR Fre PodWR Fre
+{
+}
+ P0            | P1            ;
+ movl $1,(x)   | movl $1,(y)   ;
+ mfence        | movl (x),%eax ;
+ movl (y),%eax |               ;
+exists (0:rax=0 /\ 1:rax=0)

--- a/catalogue/x86_64/tests/SB+mfence+rfi-po.litmus
+++ b/catalogue/x86_64/tests/SB+mfence+rfi-po.litmus
@@ -1,0 +1,16 @@
+X86_64 SB+mfence+rfi-po
+"MFencedWR Fre Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre MFencedWR Fre
+Relax=
+Safe=[Rfi,PodRR] Fre MFencedWR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=T,1:y=F,1:x=T
+Com=Fr Fr
+Orig=MFencedWR Fre Rfi PodRR Fre
+{
+}
+ P0            | P1            ;
+ movl $1,(x)   | movl $1,(y)   ;
+ mfence        | movl (y),%eax ;
+ movl (y),%eax | movl (x),%ebx ;
+exists (0:rax=0 /\ 1:rax=1 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/SB+mfences.litmus
+++ b/catalogue/x86_64/tests/SB+mfences.litmus
@@ -1,0 +1,16 @@
+X86_64 SB+mfences
+"MFencedWR Fre MFencedWR Fre"
+Cycle=Fre MFencedWR Fre MFencedWR
+Relax=
+Safe=Fre MFencedWR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=T,1:y=F,1:x=T
+Com=Fr Fr
+Orig=MFencedWR Fre MFencedWR Fre
+{
+}
+ P0            | P1            ;
+ movl $1,(x)   | movl $1,(y)   ;
+ mfence        | mfence        ;
+ movl (y),%eax | movl (x),%eax ;
+exists (0:rax=0 /\ 1:rax=0)

--- a/catalogue/x86_64/tests/SB+po+po-rfi-po.litmus
+++ b/catalogue/x86_64/tests/SB+po+po-rfi-po.litmus
@@ -1,0 +1,17 @@
+X86_64 SB+po+po-rfi-po
+"PodWR Fre PodWW Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre PodWR Fre PodWW
+Relax=
+Safe=[Rfi,PodRR] Fre PodWW PodWR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=T,1:y=F,1:x=T
+Com=Fr Fr
+Orig=PodWR Fre PodWW Rfi PodRR Fre
+{
+}
+ P0            | P1            ;
+ movl $1,(x)   | movl $1,(y)   ;
+ movl (y),%eax | movl $1,(z)   ;
+               | movl (z),%eax ;
+               | movl (x),%ebx ;
+exists (0:rax=0 /\ 1:rax=1 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/SB+po+rfi-po.litmus
+++ b/catalogue/x86_64/tests/SB+po+rfi-po.litmus
@@ -1,0 +1,16 @@
+X86_64 SB+po+rfi-po
+"PodWR Fre Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre PodWR Fre
+Relax=
+Safe=[Rfi,PodRR] Fre PodWR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=T,1:y=F,1:x=T
+Com=Fr Fr
+Orig=PodWR Fre Rfi PodRR Fre
+{
+}
+ P0            | P1            ;
+ movl $1,(x)   | movl $1,(y)   ;
+ movl (y),%eax | movl (y),%eax ;
+               | movl (x),%ebx ;
+exists (0:rax=0 /\ 1:rax=1 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/SB+rfi-po+po-rfi-po.litmus
+++ b/catalogue/x86_64/tests/SB+rfi-po+po-rfi-po.litmus
@@ -1,0 +1,17 @@
+X86_64 SB+rfi-po+po-rfi-po
+"Rfi PodRR Fre PodWW Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre Rfi PodRR Fre PodWW
+Relax=
+Safe=[Rfi,PodRR] Fre PodWW
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=T,1:y=F,1:x=T
+Com=Fr Fr
+Orig=Rfi PodRR Fre PodWW Rfi PodRR Fre
+{
+}
+ P0            | P1            ;
+ movl $1,(x)   | movl $1,(y)   ;
+ movl (x),%eax | movl $1,(z)   ;
+ movl (y),%ebx | movl (z),%eax ;
+               | movl (x),%ebx ;
+exists (0:rax=1 /\ 0:rbx=0 /\ 1:rax=1 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/SB+rfi-pos.litmus
+++ b/catalogue/x86_64/tests/SB+rfi-pos.litmus
@@ -1,0 +1,16 @@
+X86_64 SB+rfi-pos
+"Rfi PodRR Fre Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre Rfi PodRR Fre
+Relax=
+Safe=[Rfi,PodRR] Fre
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=T,1:y=F,1:x=T
+Com=Fr Fr
+Orig=Rfi PodRR Fre Rfi PodRR Fre
+{
+}
+ P0            | P1            ;
+ movl $1,(x)   | movl $1,(y)   ;
+ movl (x),%eax | movl (y),%eax ;
+ movl (y),%ebx | movl (x),%ebx ;
+exists (0:rax=1 /\ 0:rbx=0 /\ 1:rax=1 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/SB.litmus
+++ b/catalogue/x86_64/tests/SB.litmus
@@ -1,0 +1,15 @@
+X86_64 SB
+"PodWR Fre PodWR Fre"
+Cycle=Fre PodWR Fre PodWR
+Relax=
+Safe=Fre PodWR
+Generator=diy7 (version 7.57+1)
+Prefetch=0:x=F,0:y=T,1:y=F,1:x=T
+Com=Fr Fr
+Orig=PodWR Fre PodWR Fre
+{
+}
+ P0            | P1            ;
+ movl $1,(x)   | movl $1,(y)   ;
+ movl (y),%eax | movl (x),%eax ;
+exists (0:rax=0 /\ 1:rax=0)

--- a/catalogue/x86_64/tests/WRC.litmus
+++ b/catalogue/x86_64/tests/WRC.litmus
@@ -1,0 +1,15 @@
+X86_64 WRC
+"Rfe PodRW Rfe PodRR Fre"
+Cycle=Rfe PodRW Rfe PodRR Fre
+Relax=
+Safe=Rfe Fre PodRW PodRR
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=W,2:y=F,2:x=T
+Com=Rf Rf Fr
+Orig=Rfe PodRW Rfe PodRR Fre
+{
+}
+ P0          | P1            | P2            ;
+ movl $1,(x) | movl (x),%eax | movl (y),%eax ;
+             | movl $1,(y)   | movl (x),%ebx ;
+exists (1:rax=1 /\ 2:rax=1 /\ 2:rbx=0)

--- a/catalogue/x86_64/tests/WRR+2W.litmus
+++ b/catalogue/x86_64/tests/WRR+2W.litmus
@@ -1,0 +1,15 @@
+X86_64 WRR+2W
+"Rfe PodRR Fre PodWW Coe"
+Cycle=Rfe PodRR Fre PodWW Coe
+Relax=
+Safe=Rfe Fre Coe PodWW PodRR
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=T,2:y=F,2:x=W
+Com=Rf Fr Co
+Orig=Rfe PodRR Fre PodWW Coe
+{
+}
+ P0          | P1            | P2          ;
+ movl $2,(x) | movl (x),%eax | movl $1,(y) ;
+             | movl (y),%ebx | movl $1,(x) ;
+exists ([x]=2 /\ 1:rax=2 /\ 1:rbx=0)

--- a/catalogue/x86_64/tests/WRW+2W.litmus
+++ b/catalogue/x86_64/tests/WRW+2W.litmus
@@ -1,0 +1,15 @@
+X86_64 WRW+2W
+"Rfe PodRW Coe PodWW Coe"
+Cycle=Rfe PodRW Coe PodWW Coe
+Relax=
+Safe=Rfe Coe PodWW PodRW
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=W,2:y=F,2:x=W
+Com=Rf Co Co
+Orig=Rfe PodRW Coe PodWW Coe
+{
+}
+ P0          | P1            | P2          ;
+ movl $2,(x) | movl (x),%eax | movl $2,(y) ;
+             | movl $1,(y)   | movl $1,(x) ;
+exists ([x]=2 /\ [y]=2 /\ 1:rax=2)

--- a/catalogue/x86_64/tests/WRW+WR+po+mfence.litmus
+++ b/catalogue/x86_64/tests/WRW+WR+po+mfence.litmus
@@ -1,0 +1,16 @@
+X86_64 WRW+WR+po+mfence
+"Rfe PodRW Coe MFencedWR Fre"
+Cycle=Rfe PodRW Coe MFencedWR Fre
+Relax=
+Safe=Rfe Fre Coe PodRW MFencedWR
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=W,2:y=F,2:x=T
+Com=Rf Co Fr
+Orig=Rfe PodRW Coe MFencedWR Fre
+{
+}
+ P0          | P1            | P2            ;
+ movl $1,(x) | movl (x),%eax | movl $2,(y)   ;
+             | movl $1,(y)   | mfence        ;
+             |               | movl (x),%eax ;
+exists ([y]=2 /\ 1:rax=1 /\ 2:rax=0)

--- a/catalogue/x86_64/tests/WRW+WR+po+rfi-po.litmus
+++ b/catalogue/x86_64/tests/WRW+WR+po+rfi-po.litmus
@@ -1,0 +1,16 @@
+X86_64 WRW+WR+po+rfi-po
+"Rfe PodRW Coe Rfi PodRR Fre"
+Cycle=Rfi PodRR Fre Rfe PodRW Coe
+Relax=
+Safe=[Rfi,PodRR] Rfe Fre Coe PodRW
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=W,2:y=F,2:x=T
+Com=Rf Co Fr
+Orig=Rfe PodRW Coe Rfi PodRR Fre
+{
+}
+ P0          | P1            | P2            ;
+ movl $1,(x) | movl (x),%eax | movl $2,(y)   ;
+             | movl $1,(y)   | movl (y),%eax ;
+             |               | movl (x),%ebx ;
+exists ([y]=2 /\ 1:rax=1 /\ 2:rax=2 /\ 2:rbx=0)

--- a/catalogue/x86_64/tests/WRW+WR.litmus
+++ b/catalogue/x86_64/tests/WRW+WR.litmus
@@ -1,0 +1,15 @@
+X86_64 WRW+WR
+"Rfe PodRW Coe PodWR Fre"
+Cycle=Rfe PodRW Coe PodWR Fre
+Relax=
+Safe=Rfe Fre Coe PodWR PodRW
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=W,2:y=F,2:x=T
+Com=Rf Co Fr
+Orig=Rfe PodRW Coe PodWR Fre
+{
+}
+ P0          | P1            | P2            ;
+ movl $1,(x) | movl (x),%eax | movl $2,(y)   ;
+             | movl $1,(y)   | movl (x),%eax ;
+exists ([y]=2 /\ 1:rax=1 /\ 2:rax=0)

--- a/catalogue/x86_64/tests/WWC.litmus
+++ b/catalogue/x86_64/tests/WWC.litmus
@@ -1,0 +1,15 @@
+X86_64 WWC
+"Rfe PodRW Rfe PodRW Coe"
+Cycle=Rfe PodRW Rfe PodRW Coe
+Relax=
+Safe=Rfe Coe PodRW
+Generator=diy7 (version 7.57+1)
+Prefetch=1:x=F,1:y=W,2:y=F,2:x=W
+Com=Rf Rf Co
+Orig=Rfe PodRW Rfe PodRW Coe
+{
+}
+ P0          | P1            | P2            ;
+ movl $2,(x) | movl (x),%eax | movl (y),%eax ;
+             | movl $1,(y)   | movl $1,(x)   ;
+exists ([x]=2 /\ 1:rax=2 /\ 2:rax=1)

--- a/catalogue/x86_64/tests/X.conf
+++ b/catalogue/x86_64/tests/X.conf
@@ -1,0 +1,4 @@
+-arch X86_64
+-safe Pod**,Rfe,Fre,Coe,[Rfi,PodRR],FencedWR
+-num false
+-size 5


### PR DESCRIPTION
Inspired by PR #845. The general idea would be to have optional litmus testing by issuing the command `make litmus-<arch>-test`.