### PR TITLE
[litmus] Emit label related code only when instruction type is defined

### DIFF
--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -85,7 +85,9 @@ module Make
     let has_instruction_ptr = Insert.exists "instruction.h"
 
 (* Precise fault handling, impact on label tables *)
-    let do_precise = Cfg.is_kvm && Fault.Handling.is_fatal Cfg.precision
+    let do_precise =
+      has_instruction_ptr &&
+      Cfg.is_kvm && Fault.Handling.is_fatal Cfg.precision
 
     module
       LocMake


### PR DESCRIPTION
All label related code should depend on the existence of the "instruction.h" file in the architecture specific sub-directory of `litmus/libdir`. The "instruction.h" file defines the C type of instructions `ins_t`.

In other words, the absence of this file means that we give up on implementing code addressing for a given architecture.

This PR fixes a bug discovered by testing PR #966 : although we gave up on implementing instruction offset computation in the complex case of the varying length instruction encoding of Intel processors, part of the instruction offset computation code was emitted, leading to systematic fatal compilation errors in `kvm` mode.