### PR TITLE
[herd,asl] Fix unsound XOR optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,8 @@ cata-test:: mte-test
 mte-test:
 	@ echo
 	$(HERD_CATALOGUE_REGRESSION_TEST) \
+		-herd-timeout $(TIMEOUT) \
+		-j $(J) \
 		-herd-path $(HERD) \
 		-libdir-path ./herd/libdir \
 		-kinds-path catalogue/aarch64-MTE/tests/kinds.txt \

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -1689,10 +1689,7 @@ Monad type:
     and op op v1 v2 =
       any_op
         (fun () -> V.op op v1 v2)
-        (fun () ->
-          match op with
-          | Op.Xor when V.compare v1 v2 = 0 -> VC.Atom V.zero
-          | _ -> VC.Binop (op,v1,v2))
+        (fun () -> VC.Binop (op,v1,v2))
 
     and op3 op v1 v2 v3 =
       any_op

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -2008,6 +2008,8 @@ let match_reg_events es =
             Constant.is_symbol cst ||
             Constant.is_label cst
             -> ()
+        | Some (A.Location_global (V.Var _))
+            -> ()
         | Some loc ->
             Warn.user_error "Non-symbolic memory access found on '%s'"
               (A.pp_location loc)

--- a/herd/tests/instructions/AArch64/L103.litmus
+++ b/herd/tests/instructions/AArch64/L103.litmus
@@ -1,0 +1,16 @@
+AArch64 L103
+(* Test xor'ing symbolic addresses *)
+{
+int z = 1;
+int *p = z;
+int *q = z;
+int x = 2;
+int y = 2;
+0:X0=p; 0:X1=q; 0:X2=x;
+1:X0=p; 1:X1=q; 1:X2=y;
+}
+  P0           |  P1         ;
+LDR X3,[X0]    | LDR X3,[X1] ;
+EOR X4,X3,X3   | STR X2,[X0] ;
+STR X2,[X1,X4] |             ;
+exists 0:X3=y /\ 1:X3=x

--- a/herd/tests/instructions/AArch64/L103.litmus.expected
+++ b/herd/tests/instructions/AArch64/L103.litmus.expected
@@ -1,0 +1,13 @@
+Test L103 Allowed
+States 4
+0:X3=y; 1:X3=x;
+0:X3=y; 1:X3=z;
+0:X3=z; 1:X3=x;
+0:X3=z; 1:X3=z;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:X3=y /\ 1:X3=x)
+Observation L103 Sometimes 1 3
+Hash=ec81d74db1ff1e32cf72d50b1e0b4a38
+

--- a/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus
@@ -1,0 +1,15 @@
+ASL YL-01
+
+(* testing multiple XOR on bitvector slices *)
+
+{ }
+
+func main() => integer
+begin
+  constant x : bits(1) = '0';
+  constant y : bit = x[0] XOR '0' XOR '1';
+  let res = UInt(y);
+  return 0;
+end
+
+forall (0: main.0.res = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus.expected
@@ -1,0 +1,10 @@
+Test YL-01 Required
+States 1
+0:main.0.res=1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:main.0.res=1)
+Observation YL-01 Always 1 0
+Hash=ec33afcd7ced9e8d29ae6ef7ec580a1a
+

--- a/lib/ASLScalar.ml
+++ b/lib/ASLScalar.ml
@@ -39,6 +39,9 @@ type t = S_Int of Z.t | S_Bool of bool | S_BitVector of BV.t
 (* Irrelevant here? *)
 let machsize = MachSize.Quad
 let zero = S_Int Z.zero
+
+let unique_zero = false
+
 let one = S_Int Z.one
 let zeros sz = S_BitVector (BV.zeros sz)
 (*

--- a/lib/capabilityScalar.ml
+++ b/lib/capabilityScalar.ml
@@ -18,6 +18,7 @@ open Uint
 type t = bool * Uint128.t
 
 let zero = false, Uint128.zero
+let unique_zero = true
 let one = false, Uint128.one
 (* "NUM COLON NUM" as "Value:Tag" *)
 let of_string x =

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -161,8 +161,13 @@ module type S =  sig
   val intToV  : int -> v
   val stringToV  : string -> v
   val nameToV  : string -> v
+
+  (** numeric zero *)
   val zero : v
+
+  (** numeric one *)
   val one : v
+
   val as_int : v -> int option
   val bit_at : int -> Scalar.t -> Scalar.t
   val pp : bool -> v -> string (* true -> hexa *)

--- a/lib/extendScalar.ml
+++ b/lib/extendScalar.ml
@@ -31,6 +31,7 @@ module
     let machsize = Narrow.machsize
 
     let zero = Narrow Narrow.zero
+    let unique_zero = false (* Wide also have a zero *)
     let one = Narrow Narrow.one
 
     (*****************)

--- a/lib/int128Scalar.ml
+++ b/lib/int128Scalar.ml
@@ -16,6 +16,8 @@
 
 include Int128
 
+let unique_zero = true
+
 let printable c = c
 
 let shift_right_arithmetic = Int128.shift_right

--- a/lib/int32Scalar.ml
+++ b/lib/int32Scalar.ml
@@ -16,6 +16,8 @@
 
 include Int32
 
+let unique_zero = true
+
 let printable c = c
 
 let shift_right_arithmetic = Int32.shift_right

--- a/lib/int64Scalar.ml
+++ b/lib/int64Scalar.ml
@@ -17,6 +17,8 @@
 
 include Int64
 
+let unique_zero = true
+
 let printable c = c
 
 let shift_right_arithmetic = Int64.shift_right

--- a/lib/scalar.mli
+++ b/lib/scalar.mli
@@ -22,6 +22,9 @@ module type S = sig
   val machsize : MachSize.sz
 
   val zero : t
+
+  (** zero is unique and here it is *)
+  val unique_zero : bool
   val one : t
 
   val of_string : string -> t

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -341,8 +341,12 @@ module
       | _ -> binop_cs_cs Op.Or Cst.Scalar.logor v1 v2
 
   and xor v1 v2 =
-    if compare v1 v2 = 0 then zero else
-    binop Op.Xor (Cst.Scalar.logxor) v1 v2
+    if equal v1 v2 && Cst.Scalar.unique_zero then zero else
+    match v1,v2 with
+    | (Val (Symbolic id1),Val (Symbolic id2))
+      when Constant.symbol_eq id1 id2
+        -> zero
+    | _ -> binop Op.Xor Cst.Scalar.logxor v1 v2
 
   and maskop op sz v = match v,sz with
   | Val (Tag _),_ -> v (* tags are small enough for any mask be idempotent *)

--- a/lib/uint128Scalar.ml
+++ b/lib/uint128Scalar.ml
@@ -17,6 +17,8 @@
 open Uint
 include Uint128
 
+let unique_zero = true
+
 let promote_int64 x = Uint64.of_int64 x |> Uint128.of_uint64
 
 (* Compare is unsigned *)


### PR DESCRIPTION
For XOR, the optimization when the two values are equal (`compare` returns 0) is to return `V.zero`. However, the actual result might be different for different scalar types. Thus `V.zero` should not be used in all the cases.

An example is the `ASLConstant` module, when XOR-ing two bitvectors, the result should be a zeroed bitvector of the same length, rather than `V.zero`, i.e. `S_Int Z.zero`.

This PR implements a fix by removing the optimization. An alternative fix would be to make `zero` generic over the scalar's type (and similarly `one` if it's used for generic optimization).