### PR TITLE
[asl] Fix initial guess for SQRT

### DIFF
--- a/asllib/libdir/stdlib.asl
+++ b/asllib/libdir/stdlib.asl
@@ -89,8 +89,7 @@ begin
   // Following https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Heron's_method
 
   // Initial guess
-  let x0 = 1.0 + (x / 4.0);
-  // assert x0 <= x && x <= x0 * x0
+  let x0 = x;
 
   let precision = 1.0 / (2.0 ^ sf);
 

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -207,7 +207,7 @@ Parameterized integers:
   '00000'
 
   $ aslref unreachable.asl
-  File ASL Standard Library, line 322, characters 9 to 14:
+  File ASL Standard Library, line 321, characters 9 to 14:
   ASL Execution error: Assertion failed: FALSE
   [1]
 


### PR DESCRIPTION
This is a very small change, that is probably not very observable, but makes more sense.

**Context**:
The Heron's method (a specialisation of Newton-Raphson zero finding method for derivable functions), is an iterative method to compute the square root number of a strictly positive number $x$ with quadratic convergence (under some assumptions that are satisfied here), with the formulae:
```math
x_{n+1} = \frac{1}{2} \left( x_n + \frac{x}{x_n} \right)
```
An iteresting question is the choice of $x_0$.

This method has been implemented in PR #934.

**Previous behaviour**:
The initial guess for $x_0$ was $1 + \frac{x}{4}$, which is only a better approximation of $\sqrt{x}$ than $x$ for $x > \frac{4}{3}$.

**New behaviour**:
Simply revert to an initial guess of $x_0 = x$.
