### PR TITLE
[herd] Some optimisation aiming at faster Cat file interpretation

### DIFF
--- a/herd/event.ml
+++ b/herd/event.ml
@@ -283,6 +283,7 @@ val same_instance : event -> event -> bool
   val location_of   : event -> A.location option
   val location_reg_of : event -> A.reg option
   val global_loc_of    : event -> A.global_loc option
+  val global_index_of : event -> int option
   val virtual_loc_of : event -> string option
 
 (****************************)

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -751,7 +751,9 @@ let map_loc_find loc m =
 
 let match_reg_events es =
   let loc_loads = U.collect_reg_loads es
-  and loc_stores = U.collect_reg_stores es in
+  and loc_stores = U.collect_reg_stores es
+  (* Share computation of the iico relation *)
+  and is_before_strict =  U.is_before_strict es in
 
 (* For all loads find the right store, the one "just before" the load *)
   let rfm =
@@ -763,7 +765,7 @@ let match_reg_events es =
             let rf =
               List.fold_left
                 (fun rf ew ->
-                  if U.is_before_strict es ew er then
+                  if is_before_strict ew er then
                     match rf with
                     | S.Init -> S.Store ew
                     | S.Store ew0 ->
@@ -771,7 +773,7 @@ let match_reg_events es =
                           S.Store ew
                         else begin
                           (* store order is total *)
-                            if not (U.is_before_strict es ew ew0) then begin
+                            if not (is_before_strict ew ew0) then begin
                               Printf.eprintf "Not ordered stores %a and %a\n"
                                 E.debug_event ew0
                                 E.debug_event ew ;

--- a/herd/memUtils.ml
+++ b/herd/memUtils.ml
@@ -51,7 +51,7 @@ module Make(S : SemExtra.S) = struct
   (* Slight extension of prog order *)
 
   let is_before_strict es =
-    let iico = E.iico  es in
+    let iico = E.iico es in
     fun e1 e2  ->
       (do_po_strict es e1 e2) ||           (* e1 is po-before e2 *)
       (if do_po_strict es e2 e1 then false (* e2 is po-before e1 *)

--- a/herd/memUtils.ml
+++ b/herd/memUtils.ml
@@ -354,17 +354,12 @@ let lift_proc_info i evts =
 
 (* Collect various events by their location *)
 
-  let map_loc_find loc m =
-    try LocEnv.find loc m
-    with Not_found -> []
-
   let collect_by_loc es pred =
     E.EventSet.fold
       (fun e k ->
         if pred e then
           let loc = get_loc e in
-          let evts = map_loc_find loc k in
-          LocEnv.add loc (e::evts) k
+          LocEnv.accumulate loc e k
         else k)
       es.E.events LocEnv.empty
 
@@ -387,8 +382,7 @@ let lift_proc_info i evts =
       E.EventSet.fold
         (fun e k -> match E.location_of e with
         | Some loc ->
-            let evts = map_loc_find loc k in
-            LocEnv.add loc (e::evts) k
+            LocEnv.accumulate loc e k
         | None -> k) es LocEnv.empty in
 
     LocEnv.fold (fun _ evts k -> E.EventSet.of_list evts::k) env []

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -212,6 +212,12 @@ type ('scalar, 'pte, 'instr) t =
   | Instruction of 'instr
   | Frozen of int
 
+let as_scalar = function
+  | Concrete c -> Some c
+  | ConcreteVector _|ConcreteRecord _|Symbolic _|Label _
+  | Tag _|PteVal _|Instruction _|Frozen _
+      -> None
+
 let rec compare scalar_compare pteval_compare instr_compare c1 c2 =
   match c1,c2 with
   | Concrete i1, Concrete i2 -> scalar_compare i1 i2
@@ -440,6 +446,11 @@ let as_virtual v = match v with
 
 let as_symbol = function
   | Symbolic sym -> Some sym
+  | _ -> None
+
+let as_fault_base = function
+  | Symbolic (Virtual {name;_}) -> Some name
+  | Symbolic (System (PTE,name)) -> Some (Misc.add_pte name)
   | _ -> None
 
 let as_symbolic_data =function

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -91,6 +91,8 @@ type ('scalar, 'pte, 'instr) t =
   | Instruction of 'instr  (** An instruction. *)
   | Frozen of int (** Frozen symbolic value. *)
 
+val as_scalar : ('scalar, 'pte, 'instr) t -> 'scalar option
+
 val compare :
   ('scalar -> 'scalar -> int) ->
     ('pte -> 'pte -> int) ->
@@ -143,6 +145,7 @@ val check_sym : ('a,'pte,'instr) t -> ('b,'pte,'instr) t
 val is_virtual : ('scalar,'pte,'instr) t -> bool
 val as_virtual : ('scalar,'pte,'instr) t -> string option
 val as_symbol : ('scalar,'pte,'instr) t -> symbol option
+val as_fault_base :  ('scalar,'pte,'instr) t -> string option
 val as_symbolic_data : ('scalar,'pte,'instr) t -> symbolic_data option
 val of_symbolic_data : symbolic_data -> ('scalar,'pte,'instr) t
 

--- a/lib/myMap.ml
+++ b/lib/myMap.ml
@@ -44,6 +44,9 @@ module type S = sig
   val from_bindings :  (key * 'a) list -> 'a t
 
   val fold_values : ('a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
+
+(* Bind keys to list of values *)
+  val accumulate : key -> 'a -> 'a list t -> 'a list t
 end
 
 module Make(O:Set.OrderedType) : S with type key = O.t =
@@ -93,4 +96,9 @@ module Make(O:Set.OrderedType) : S with type key = O.t =
     let fold_values fold_value =
       let fold_binding _key v acc = fold_value v acc in
       fun t acc -> fold fold_binding t acc
+
+    let accumulate k v m =
+      let vs = safe_find [] k m in
+      add k (v::vs) m
+
   end

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -72,8 +72,17 @@ module
 
   let pp_unsigned hexa = do_pp (Cst.pp_unsigned hexa)
 
+
   let pp_v =  do_pp Cst.pp_v
   let pp_v_old =  do_pp Cst.pp_v_old
+
+(* Basic utilities *)
+
+  let as_constant = function
+    | Var _ -> None
+    | Val c -> Some c
+
+  let as_scalar v = Option.bind (as_constant v) Constant.as_scalar
 
   let printable = function
     | Val (c) ->

--- a/lib/value.mli
+++ b/lib/value.mli
@@ -48,6 +48,10 @@ module type S =
       val pp : bool (* hexa *) -> v -> string
       val pp_unsigned : bool (* hexa *) -> v -> string
 
+(* Extracting constants and scalars *)
+      val as_constant : v -> Cst.v option
+      val as_scalar : v -> Cst.Scalar.t option
+
 (* Some architecture may somehow normalize values before
    printing them. *)
       val printable : v -> v


### PR DESCRIPTION
With ASL the cat interpreter now faces inputs of thousands events. This PR regroups attempts to avoid some quadratic behaviours in the computation of pre-defined relations such as the `loc` relation.

More precisely, we compute the `loc` relation by first computing a mapping from locations to event sets. Then we union all the subrelation made by applying the cartesian product to each  event set. Relations `same-low-order-bits`, `int` and `ext` are computed by a similar technique.

