### PR TITLE
[asl][references] Addressing feedback for the typing review

### DIFF
--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -589,7 +589,7 @@ let constraint_binop op =
   let righ_inc = is_right_increasing op
   and righ_dec = is_right_decreasing op
   and left_inc = is_left_increasing op in
-  let do_op c1 c2 =
+  let constraint_binop_pair c1 c2 =
     match (c1, c2) with
     | Constraint_Exact e1, Constraint_Exact e2 ->
         Constraint_Exact (binop op e1 e2)
@@ -608,10 +608,11 @@ let constraint_binop op =
     | _ -> raise_notrace FailedConstraintOp
   in
   fun cs1 cs2 ->
-    try WellConstrained (list_cross do_op cs1 cs2)
+    try WellConstrained (list_cross constraint_binop_pair cs1 cs2)
     with FailedConstraintOp -> UnConstrained
 (* End *)
 
+(* Begin SubstExpr *)
 let rec subst_expr substs e =
   (* WARNING: only subst runtime vars. *)
   let tr e = subst_expr substs e in
@@ -637,6 +638,7 @@ let rec subst_expr substs e =
   | E_ATC (e, t) -> E_ATC (tr e, t)
   | E_Unknown _ -> e.desc
   | E_Unop (op, e) -> E_Unop (op, tr e)
+(* End *)
 
 let scope_equal s1 s2 =
   match (s1, s2) with

--- a/asllib/StaticModel.ml
+++ b/asllib/StaticModel.ml
@@ -709,8 +709,10 @@ let reduce (Disjunction ir) =
           | None -> (ctnts, p) :: acc)
         li [] )
 
+(* Begin Normalize *)
 let normalize (env : StaticEnv.env) (e : expr) : expr =
   e |> to_ir env |> reduce |> of_ir |> with_pos_from e
+(* End *)
 
 let free_variables (Disjunction li) =
   let mono_free (Prod map) = AMap.fold (fun s _ -> ISet.add s) map in

--- a/asllib/doc/.gitignore
+++ b/asllib/doc/.gitignore
@@ -1,7 +1,7 @@
 ifempty.tex
 ifcode.tex
 comment.cut
-ASLASTLines.tex
+*Lines.tex
 *.bbl
 *.blg
 *.dvi

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -67,7 +67,7 @@ Finally, $\neg\True\triangleq\False$ and $\neg\False\triangleq\True$.
 
 \item
 \hypertarget{def-astlabels}{}
-    $\astlabels$ is the set of all AST labels.
+    $\astlabels$ is the set of all labels of Abstract Syntax Tree (AST) nodes.
 
 \item
 \hypertarget{def-strings}{}
@@ -102,7 +102,7 @@ which is defined next is named $q$.
 
 \hypertarget{def-pow}{}
 \begin{definition}[Powerset]
-  The \emph{powerset} of a set $A$, denoted as $\pow{A}$, is the set of all subsets (including the empty set) of $A$:
+  The \emph{powerset} of a set $A$, denoted as $\pow{A}$, is the set of all subsets of $A$, including the empty set and $A$ itself:
   \[
      \pow{A} \triangleq \{ B \;|\; B \subseteq A\} \enspace.
   \]
@@ -214,7 +214,7 @@ The commas carry no special meaning.
 For a non-empty list $v_1 \ldots\ v_k$, the \emph{\head} of the list is the first element --- $v_1$ ---
 and the \emph{\tail} of the list is the suffix obtained by removing $v_1$ from the list.
 
-We refer to individual elements of a non-empty list $V$ by the index notation $V[i]$ where $i\in\N$.
+We refer to individual elements of a non-empty list $V$ by the index notation $V[i]$ where $i\in\Npos$.
 
 \hypertarget{def-listlen}{}
 \begin{definition}[List Length]
@@ -222,7 +222,7 @@ The \emph{length} of a list is the number of elements in that list:
 $\listlen{\emptylist} \triangleq 0$ and $\listlen{v_1,\ldots,v_k}=k$.
 \end{definition}
 
-We use the notation $a..b$, where $a,b\in\Z$ and $a\leq b$, as a shorthand for the interval $a\ldots b$.
+We use the notation $a..b$, where $a,b\in\Z$ and $a\leq b$, as a shorthand for the interval $[a\ldots b]$.
 We write $x_{a..b}$ as a shorthand for the sequence $x_a \ldots x_b$.
 %
 We write $i=1..k: V(i)$, where $V(i)$ is a mathematical expression parameterized by $i$,
@@ -715,7 +715,7 @@ Stands for the set of rule macros
 }
 \end{mathpar}
 
-Notice that after all rule macros are expanded into normal rules,
+Notice that after all rule macros are expanded, in a top-to-bottom and left-to-right order, into normal rules,
 they behave like normal rules where the order of premises does
 not matter.
 
@@ -882,8 +882,11 @@ or that of TypingRule.CheckUnop).
 \item
 The notation $\wrappedline$ denotes that a line that is longer than the page width continues on the next line.
 
-\hypertarget{def-casesplitline}{}
-\item The notation $\casesplitline$ serves as a visual aid to delimit a common prefix of premises shared by two rule cases.
+\hypertarget{def-commonprefixline}{}
+\item The notation $\commonprefixline$ serves as a visual aid to delimit a common prefix of premises shared by rule cases.
+
+\hypertarget{def-commonsufffixline}{}
+\item The notation $\commonsuffixline$ serves as a visual aid to delimit a common suffix of premises shared by rule cases.
 
 \hypertarget{tododefine}{}
 \item \textbf{Missing definition:} Red hyperlinks indicate items that are yet to be defined.

--- a/asllib/doc/ASLSemanticsReference.tex
+++ b/asllib/doc/ASLSemanticsReference.tex
@@ -20,10 +20,10 @@
 \newcommand\ordered[3]{{#1}\hyperlink{def-ordered}{\xrightarrow{#2}}{#3}}
 \newcommand\parallelcomp[0]{\hyperlink{def-parallel}{\parallel}}
 
-\newcommand\graphof[1]{\hyperlink{def-graphof}{\texttt{graph}}({#1})}
-\newcommand\withgraph[2]{{#1}(\hyperlink{def-withgraph}{\texttt{graph}}\mapsto{#2})}
-\newcommand\environof[1]{\hyperlink{def-environof}{\texttt{environ}}({#1})}
-\newcommand\withenviron[2]{{#1}(\hyperlink{def-withenviron}{\texttt{environ}}\mapsto{#2})}
+\newcommand\graphof[1]{\hyperlink{def-graphof}{\textfunc{graph}}({#1})}
+\newcommand\withgraph[2]{{#1}(\hyperlink{def-withgraph}{\textfunc{graph}}\mapsto{#2})}
+\newcommand\environof[1]{\hyperlink{def-environof}{\textfunc{environ}}({#1})}
+\newcommand\withenviron[2]{{#1}(\hyperlink{def-withenviron}{\textfunc{environ}}\mapsto{#2})}
 
 \newcommand\primitiverel[0]{\hyperlink{def-primitiverel}{\textsf{primitive}}}
 \newcommand\evalprimitivearrow[0]{\hyperlink{def-evalprimitivearrow}{\stackrel{\primitiverel}{\rightsquigarrow}}}
@@ -42,65 +42,64 @@
 \newcommand\TReturning[0]{\hyperlink{def-treturning}{\textsf{TReturning}}}
 \newcommand\TOutConfig[0]{\hyperlink{def-toutconfig}{\textsf{TOutConfig}}}
 
-\newcommand\evalexpr[1]{\hyperlink{def-evalexpr}{\texttt{eval\_expr}}(#1)}
-\newcommand\evalexprsef[1]{\hyperlink{def-evalexprsef}{\texttt{eval\_expr\_sef}}(#1)}
-\newcommand\evallexpr[1]{\hyperlink{def-evallexpr}{\texttt{eval\_lexpr}}(#1)}
-\newcommand\evalexprlist[1]{\hyperlink{def-evalexprlist}{\texttt{eval\_expr\_list}}(#1)}
-\newcommand\evalexprlistm[1]{\hyperlink{def-evalexprlistm}{\texttt{eval\_expr\_list\_m}}(#1)}
-\newcommand\evalpattern[1]{\hyperlink{def-evalpattern}{\texttt{eval\_pattern}}(#1)}
-\newcommand\evallocaldecl[1]{\hyperlink{def-evallocaldecl}{\texttt{eval\_local\_decl}}(#1)}
-\newcommand\evalslices[1]{\hyperlink{def-evalslices}{\texttt{eval\_slices}}(#1)}
-\newcommand\evalslice[1]{\hyperlink{def-evalslice}{\texttt{eval\_slice}}(#1)}
-\newcommand\evalstmt[1]{\hyperlink{def-evalstmt}{\texttt{eval\_stmt}}(#1)}
-\newcommand\evalblock[1]{\hyperlink{def-evalblock}{\texttt{eval\_block}}(#1)}
-\newcommand\evalloop[1]{\hyperlink{def-evalloop}{\texttt{eval\_loop}}(#1)}
-\newcommand\evalfor[1]{\hyperlink{def-evalfor}{\texttt{eval\_for}}(#1)}
-\newcommand\evalcatchers[1]{\hyperlink{def-evalcatchers}{\texttt{eval\_catchers}}(#1)}
-\newcommand\evalsubprogram[1]{\hyperlink{def-evalsubprogram}{\texttt{eval\_subprogram}}(#1)}
-\newcommand\evalcall[1]{\hyperlink{def-evalcall}{\texttt{eval\_call}}(#1)}
-\newcommand\evalprimitive[1]{\hyperlink{def-evalprimitive}{\texttt{eval\_primitive}}(#1)}
-\newcommand\evalmultiassignment[1]{\hyperlink{def-evalmultiassign}{\texttt{multi\_assign}}(#1)}
-\newcommand\rethrowimplicit[0]{\hyperlink{def-rethrowimplicit}{\texttt{rethrow\_implicit}}}
-\newcommand\assignargs[0]{\hyperlink{def-assignargs}{\texttt{assign\_args}}}
-\newcommand\assignnamedargs[0]{\hyperlink{def-assignnamedargs}{\texttt{assign\_named\_args}}}
-\newcommand\matchfuncres[0]{\hyperlink{def-matchfuncres}{\texttt{match\_func\_res}}}
-\newcommand\buildgenv[0]{\hyperlink{def-buildgenv}{\texttt{build\_genv}}}
-\newcommand\topologicaldecls[0]{\hyperlink{def-topologicaldecls}{\texttt{topological\_decls}}}
-\newcommand\evalglobals[0]{\hyperlink{def-evalglobals}{\texttt{eval\_globals}}}
-\newcommand\evalspec[1]{\hyperlink{def-evalspec}{\texttt{eval\_spec}}(#1)}
-\newcommand\lexprisvar[0]{\hyperlink{def-lexprisvar}{\texttt{lexpr\_is\_var}}}
-\newcommand\casetoconds[0]{\hyperlink{def-casetoconds}{\texttt{case\_to\_conds}}}
-\newcommand\findcatcher[0]{\hyperlink{def-findcatcher}{\texttt{find\_catcher}}}
+\newcommand\evalexpr[1]{\hyperlink{def-evalexpr}{\textfunc{eval\_expr}}(#1)}
+\newcommand\evalexprsef[1]{\hyperlink{def-evalexprsef}{\textfunc{eval\_expr\_sef}}(#1)}
+\newcommand\evallexpr[1]{\hyperlink{def-evallexpr}{\textfunc{eval\_lexpr}}(#1)}
+\newcommand\evalexprlist[1]{\hyperlink{def-evalexprlist}{\textfunc{eval\_expr\_list}}(#1)}
+\newcommand\evalexprlistm[1]{\hyperlink{def-evalexprlistm}{\textfunc{eval\_expr\_list\_m}}(#1)}
+\newcommand\evalpattern[1]{\hyperlink{def-evalpattern}{\textfunc{eval\_pattern}}(#1)}
+\newcommand\evallocaldecl[1]{\hyperlink{def-evallocaldecl}{\textfunc{eval\_local\_decl}}(#1)}
+\newcommand\evalslices[1]{\hyperlink{def-evalslices}{\textfunc{eval\_slices}}(#1)}
+\newcommand\evalslice[1]{\hyperlink{def-evalslice}{\textfunc{eval\_slice}}(#1)}
+\newcommand\evalstmt[1]{\hyperlink{def-evalstmt}{\textfunc{eval\_stmt}}(#1)}
+\newcommand\evalblock[1]{\hyperlink{def-evalblock}{\textfunc{eval\_block}}(#1)}
+\newcommand\evalloop[1]{\hyperlink{def-evalloop}{\textfunc{eval\_loop}}(#1)}
+\newcommand\evalfor[1]{\hyperlink{def-evalfor}{\textfunc{eval\_for}}(#1)}
+\newcommand\evalcatchers[1]{\hyperlink{def-evalcatchers}{\textfunc{eval\_catchers}}(#1)}
+\newcommand\evalsubprogram[1]{\hyperlink{def-evalsubprogram}{\textfunc{eval\_subprogram}}(#1)}
+\newcommand\evalcall[1]{\hyperlink{def-evalcall}{\textfunc{eval\_call}}(#1)}
+\newcommand\evalprimitive[1]{\hyperlink{def-evalprimitive}{\textfunc{eval\_primitive}}(#1)}
+\newcommand\evalmultiassignment[1]{\hyperlink{def-evalmultiassign}{\textfunc{multi\_assign}}(#1)}
+\newcommand\rethrowimplicit[0]{\hyperlink{def-rethrowimplicit}{\textfunc{rethrow\_implicit}}}
+\newcommand\assignargs[0]{\hyperlink{def-assignargs}{\textfunc{assign\_args}}}
+\newcommand\assignnamedargs[0]{\hyperlink{def-assignnamedargs}{\textfunc{assign\_named\_args}}}
+\newcommand\matchfuncres[0]{\hyperlink{def-matchfuncres}{\textfunc{match\_func\_res}}}
+\newcommand\buildgenv[0]{\hyperlink{def-buildgenv}{\textfunc{build\_genv}}}
+\newcommand\topologicaldecls[0]{\hyperlink{def-topologicaldecls}{\textfunc{topological\_decls}}}
+\newcommand\evalglobals[0]{\hyperlink{def-evalglobals}{\textfunc{eval\_globals}}}
+\newcommand\evalspec[1]{\hyperlink{def-evalspec}{\textfunc{eval\_spec}}(#1)}
+\newcommand\lexprisvar[0]{\hyperlink{def-lexprisvar}{\textfunc{lexpr\_is\_var}}}
+\newcommand\casetoconds[0]{\hyperlink{def-casetoconds}{\textfunc{case\_to\_conds}}}
+\newcommand\findcatcher[0]{\hyperlink{def-findcatcher}{\textfunc{find\_catcher}}}
 
-\newcommand\declarelocalidentifier[0]{\hyperlink{def-declarelocalidentifier}{\texttt{declare\_local\_identifier}}}
-\newcommand\declarelocalidentifierm[0]{\hyperlink{def-declarelocalidentifierm}{\texttt{declare\_local\_identifier\_m}}}
-\newcommand\declarelocalidentifiermm[0]{\hyperlink{def-declarelocalidentifermm}{\texttt{declare\_local\_identifier\_mm}}}
-\newcommand\removelocal[0]{\hyperlink{def-removelocal}{\texttt{remove\_local}}}
-\newcommand\readidentifier[0]{\hyperlink{def-readidentifier}{\texttt{read\_identifier}}}
-\newcommand\writeidentifier[0]{\hyperlink{def-writeidentifier}{\texttt{write\_identifier}}}
-\newcommand\createbitvector[0]{\hyperlink{def-createbitvector}{\texttt{create\_bitvector}}}
-\newcommand\concatbitvectors[0]{\hyperlink{def-concatbitvector}{\texttt{concat\_bitvectors}}}
-\newcommand\readfrombitvector[0]{\hyperlink{def-readfrinbitvector}{\texttt{read\_from\_bitvector}}}
-\newcommand\writetobitvector[0]{\hyperlink{def-writetobitvector}{\texttt{write\_to\_bitvector}}}
-\newcommand\asbitvector[0]{\hyperlink{def-asbitvector}{\texttt{as\_bitvector}}}
-\newcommand\slicestopositions[0]{\hyperlink{def-slicestopositions}{\texttt{slices\_to\_positions}}}
-\newcommand\getindex[0]{\hyperlink{def-getindex}{\texttt{get\_index}}}
-\newcommand\setindex[0]{\hyperlink{def-setindex}{\texttt{set\_index}}}
-\newcommand\getfield[0]{\hyperlink{def-getfield}{\texttt{get\_field}}}
-\newcommand\setfield[0]{\hyperlink{def-setfield}{\texttt{set\_field}}}
-\newcommand\declareglobal[0]{\hyperlink{def-declareglobal}{\texttt{declare\_global}}}
-\newcommand\basevalue[0]{\hyperlink{def-basevalue}{\texttt{base\_value}}}
-\newcommand\isvaloftype[0]{\hyperlink{def-isvaloftype}{\texttt{is\_val\_of\_type}}}
-\newcommand\positioninrange[0]{\hyperlink{def-positioninrange}{\texttt{position\_in\_range}}}
-\newcommand\integerconstraintsatisfied[0]{\hyperlink{def-integerconstraintsatisfied}{\texttt{int\_constraint\_sat}}}
-\newcommand\readvaluefrom[0]{\hyperlink{def-readvaluefrom}{\texttt{read\_value\_from}}}
-\newcommand\writeretvals[0]{\hyperlink{def-writeretvals}{\texttt{write\_ret\_vals}}}
+\newcommand\declarelocalidentifier[0]{\hyperlink{def-declarelocalidentifier}{\textfunc{declare\_local\_identifier}}}
+\newcommand\declarelocalidentifierm[0]{\hyperlink{def-declarelocalidentifierm}{\textfunc{declare\_local\_identifier\_m}}}
+\newcommand\declarelocalidentifiermm[0]{\hyperlink{def-declarelocalidentifermm}{\textfunc{declare\_local\_identifier\_mm}}}
+\newcommand\removelocal[0]{\hyperlink{def-removelocal}{\textfunc{remove\_local}}}
+\newcommand\readidentifier[0]{\hyperlink{def-readidentifier}{\textfunc{read\_identifier}}}
+\newcommand\writeidentifier[0]{\hyperlink{def-writeidentifier}{\textfunc{write\_identifier}}}
+\newcommand\createbitvector[0]{\hyperlink{def-createbitvector}{\textfunc{create\_bitvector}}}
+\newcommand\concatbitvectors[0]{\hyperlink{def-concatbitvector}{\textfunc{concat\_bitvectors}}}
+\newcommand\readfrombitvector[0]{\hyperlink{def-readfrinbitvector}{\textfunc{read\_from\_bitvector}}}
+\newcommand\writetobitvector[0]{\hyperlink{def-writetobitvector}{\textfunc{write\_to\_bitvector}}}
+\newcommand\asbitvector[0]{\hyperlink{def-asbitvector}{\textfunc{as\_bitvector}}}
+\newcommand\slicestopositions[0]{\hyperlink{def-slicestopositions}{\textfunc{slices\_to\_positions}}}
+\newcommand\getindex[0]{\hyperlink{def-getindex}{\textfunc{get\_index}}}
+\newcommand\setindex[0]{\hyperlink{def-setindex}{\textfunc{set\_index}}}
+\newcommand\getfield[0]{\hyperlink{def-getfield}{\textfunc{get\_field}}}
+\newcommand\setfield[0]{\hyperlink{def-setfield}{\textfunc{set\_field}}}
+\newcommand\declareglobal[0]{\hyperlink{def-declareglobal}{\textfunc{declare\_global}}}
+\newcommand\basevalue[0]{\hyperlink{def-basevalue}{\textfunc{base\_value}}}
+\newcommand\isvaloftype[0]{\hyperlink{def-isvaloftype}{\textfunc{is\_val\_of\_type}}}
+\newcommand\positioninrange[0]{\hyperlink{def-positioninrange}{\textfunc{position\_in\_range}}}
+\newcommand\integerconstraintsatisfied[0]{\hyperlink{def-integerconstraintsatisfied}{\textfunc{int\_constraint\_sat}}}
+\newcommand\readvaluefrom[0]{\hyperlink{def-readvaluefrom}{\textfunc{read\_value\_from}}}
+\newcommand\writeretvals[0]{\hyperlink{def-writeretvals}{\textfunc{write\_ret\_vals}}}
 
-\newcommand\unoprel[0]{\hyperlink{def-unoprel}{\texttt{unop}}}
-\newcommand\binoprel[0]{\hyperlink{def-binoprel}{\texttt{binop}}}
+\newcommand\unoprel[0]{\hyperlink{def-unoprel}{\textfunc{unop}}}
+\newcommand\binoprel[0]{\hyperlink{def-binoprel}{\textfunc{binop}}}
 
-\newcommand\findfunc[0]{\hyperlink{def-findfunc}{\texttt{find\_func}}}
-\newcommand\unknownval[0]{\texttt{unknown\_val}}
+\newcommand\findfunc[0]{\hyperlink{def-findfunc}{\textfunc{find\_func}}}
 
 \newcommand\valuereadfrom[0]{\hyperlink{def-valuereadfrom}{\textsf{value\_read\_from}}}
 \newcommand\Normal[0]{\hyperlink{def-normal}{\textsf{Normal}}}
@@ -3906,7 +3905,7 @@ prints
       \fordirection &:& \vdirection\\
       \Forende &:& \vende\\
       \Forbody &:& \vbody\\
-      Forlimit &:& \Ignore
+      \Forlimit &:& \Ignore
     \end{array}\right\}$;
     \item evaluating the side-effect-free expression $\veone$ in $\env$ is either
     $\Normal(\vvone, \vgone)$\ProseOrError;

--- a/asllib/doc/ASLSyntaxReference.tex
+++ b/asllib/doc/ASLSyntaxReference.tex
@@ -405,66 +405,66 @@
 %\newcommand\productionname[2]{[\hyperlink{build-#1}{\textsc{#2}}]}
 \newcommand\productionname[2]{}
 
-\newcommand\buildidentity[0]{\hyperlink{build-identity}{\textsf{build\_identity}}}
-\newcommand\buildlist[0]{\hyperlink{build-list}{\textsf{build\_list}}}
+\newcommand\buildidentity[0]{\hyperlink{build-identity}{\textfunc{build\_identity}}}
+\newcommand\buildlist[0]{\hyperlink{build-list}{\textfunc{build\_list}}}
 \newcommand\buildplist[0]{\hyperlink{build-plist}{\textsf{build\_plist}}}
-\newcommand\buildclist[0]{\hyperlink{build-clist}{\textsf{build\_clist}}}
-\newcommand\buildntclist[0]{\hyperlink{build-ntclist}{\textsf{build\_ntclist}}}
-\newcommand\buildtclist[0]{\hyperlink{build-tclist}{\textsf{build\_tclist}}}
-\newcommand\buildoption[0]{\hyperlink{build-option}{\textsf{build\_option}}}
+\newcommand\buildclist[0]{\hyperlink{build-clist}{\textfunc{build\_clist}}}
+\newcommand\buildntclist[0]{\hyperlink{build-ntclist}{\textfunc{build\_ntclist}}}
+\newcommand\buildtclist[0]{\hyperlink{build-tclist}{\textfunc{build\_tclist}}}
+\newcommand\buildoption[0]{\hyperlink{build-option}{\textfunc{build\_option}}}
 
-\newcommand\buildast[0]{\hyperlink{build-ast}{\textsf{build\_ast}}}
-\newcommand\builddecl[0]{\hyperlink{build-decl}{\textsf{build\_decl}}}
-\newcommand\builddeclitem[0]{\hyperlink{build-declitem}{\textsf{build\_decl\_item}}}
-\newcommand\builduntypeddeclitem[0]{\hyperlink{build-untypeddeclitem}{\textsf{build\_untyped\_decl\_item}}}
-\newcommand\buildstmt[0]{\hyperlink{build-stmt}{\textsf{build\_stmt}}}
-\newcommand\buildexpr[0]{\hyperlink{build-expr}{\textsf{build\_expr}}}
-\newcommand\buildlexpr[0]{\hyperlink{build-lexpr}{\textsf{build\_lexpr}}}
-\newcommand\buildlexpratom[0]{\hyperlink{build-lexpratom}{\textsf{build\_lexpr\_atom}}}
-\newcommand\buildparamsopt[0]{\hyperlink{build-paramsopt}{\textsf{build\_params\_opt}}}
-\newcommand\buildaccessargs[0]{\hyperlink{build-accessargs}{\textsf{build\_access\_args}}}
-\newcommand\buildfuncargs[0]{\hyperlink{build-funcargs}{\textsf{build\_func\_args}}}
-\newcommand\buildreturntype[0]{\hyperlink{build-returntype}{\textsf{build\_return\_type}}}
-\newcommand\buildfuncbody[0]{\hyperlink{build-funcbody}{\textsf{build\_func\_body}}}
-\newcommand\buildtypedidentifier[0]{\hyperlink{build-typedidentifier}{\textsf{build\_typed\_identifier}}}
-\newcommand\buildopttypedidentifier[0]{\hyperlink{build-opttypedidentifier}{\textsf{build\_opt\_typed\_identifier}}}
-\newcommand\buildtydecl[0]{\hyperlink{build-tydecl}{\textsf{build\_ty\_decl}}}
-\newcommand\buildsubtype[0]{\hyperlink{build-subtype}{\textsf{build\_subtype}}}
-\newcommand\buildsubtypeopt[0]{\hyperlink{build-subtypeopt}{\textsf{build\_subtype\_opt}}}
-\newcommand\buildstoragekeyword[0]{\hyperlink{build-storagekeyword}{\textsf{build\_storage\_keyword}}}
-\newcommand\builddirection[0]{\hyperlink{build-direction}{\textsf{build\_direction}}}
-\newcommand\buildalt[0]{\hyperlink{build-alt}{\textsf{build\_alt}}}
-\newcommand\buildotherwiseopt[0]{\hyperlink{build-otherwiseopt}{\textsf{build\_otherwise\_opt}}}
-\newcommand\buildcatcher[0]{\hyperlink{build-catcher}{\textsf{build\_catcher}}}
-\newcommand\buildasty[0]{\textsf{build\_as\_ty}}
-\newcommand\buildignoredoridentifier[0]{\hyperlink{build-ignoredoridentifier}{\textsf{build\_ignored\_or\_identifier}}}
-\newcommand\buildlocaldeclkeyword[0]{\hyperlink{build-localdeclkeyword}{\textsf{build\_local\_decl\_keyword}}}
-\newcommand\buildstmtlist[0]{\hyperlink{build-stmtlist}{\textsf{build\_stmt\_list}}}
-\newcommand\buildmaybeemptystmtlist[0]{\hyperlink{build-maybeemptystmtlist}{\textsf{build\_maybe\_empty\_stmt\_list}}}
-\newcommand\buildselse[0]{\hyperlink{build-selse}{\textsf{build\_s\_else}}}
-\newcommand\buildintconstraints[0]{\hyperlink{build-intconstraints}{\textsf{build\_int\_constraints}}}
-\newcommand\buildintconstraintsopt[0]{\hyperlink{build-intconstraintsopt}{\textsf{build\_int\_constraints\_opt}}}
-\newcommand\buildintconstraint[0]{\hyperlink{build-intconstraint}{\textsf{build\_int\_constraint}}}
-\newcommand\buildexprpattern[0]{\hyperlink{build-exprpattern}{\textsf{build\_expr\_pattern}}}
-\newcommand\buildfieldassign[0]{\hyperlink{build-fieldassign}{\textsf{build\_field\_assign}}}
-\newcommand\buildpatternset[0]{\hyperlink{build-patternset}{\textsf{build\_pattern\_set}}}
-\newcommand\buildpatternlist[0]{\hyperlink{build-patternlist}{\textsf{build\_pattern\_list}}}
-\newcommand\buildpattern[0]{\hyperlink{build-pattern}{\textsf{build\_pattern}}}
-\newcommand\buildfields[0]{\hyperlink{build-fields}{\textsf{build\_fields}}}
-\newcommand\buildfieldsopt[0]{\hyperlink{build-fieldsopt}{\textsf{build\_fields\_opt}}}
-\newcommand\buildnslices[0]{\hyperlink{build-nslices}{\textsf{build\_nslices}}}
-\newcommand\buildslices[0]{\hyperlink{build-slices}{\textsf{build\_slices}}}
-\newcommand\buildslice[0]{\hyperlink{build-slice}{\textsf{build\_slice}}}
-\newcommand\buildbitfields[0]{\hyperlink{build-bitfields}{\textsf{build\_bitfields}}}
-\newcommand\buildbitfield[0]{\hyperlink{build-bitfield}{\textsf{build\_bitfield}}}
-\newcommand\buildty[0]{\hyperlink{build-ty}{\textsf{build\_ty}}}
-\newcommand\buildeelse[0]{\hyperlink{build-eelse}{\textsf{build\_e\_else}}}
-\newcommand\buildvalue[0]{\hyperlink{build-value}{\textsf{build\_value}}}
-\newcommand\buildunop[0]{\hyperlink{build-unop}{\textsf{build\_unop}}}
-\newcommand\buildbinop[0]{\hyperlink{build-binop}{\textsf{build\_binop}}}
+\newcommand\buildast[0]{\hyperlink{build-ast}{\textfunc{build\_ast}}}
+\newcommand\builddecl[0]{\hyperlink{build-decl}{\textfunc{build\_decl}}}
+\newcommand\builddeclitem[0]{\hyperlink{build-declitem}{\textfunc{build\_decl\_item}}}
+\newcommand\builduntypeddeclitem[0]{\hyperlink{build-untypeddeclitem}{\textfunc{build\_untyped\_decl\_item}}}
+\newcommand\buildstmt[0]{\hyperlink{build-stmt}{\textfunc{build\_stmt}}}
+\newcommand\buildexpr[0]{\hyperlink{build-expr}{\textfunc{build\_expr}}}
+\newcommand\buildlexpr[0]{\hyperlink{build-lexpr}{\textfunc{build\_lexpr}}}
+\newcommand\buildlexpratom[0]{\hyperlink{build-lexpratom}{\textfunc{build\_lexpr\_atom}}}
+\newcommand\buildparamsopt[0]{\hyperlink{build-paramsopt}{\textfunc{build\_params\_opt}}}
+\newcommand\buildaccessargs[0]{\hyperlink{build-accessargs}{\textfunc{build\_access\_args}}}
+\newcommand\buildfuncargs[0]{\hyperlink{build-funcargs}{\textfunc{build\_func\_args}}}
+\newcommand\buildreturntype[0]{\hyperlink{build-returntype}{\textfunc{build\_return\_type}}}
+\newcommand\buildfuncbody[0]{\hyperlink{build-funcbody}{\textfunc{build\_func\_body}}}
+\newcommand\buildtypedidentifier[0]{\hyperlink{build-typedidentifier}{\textfunc{build\_typed\_identifier}}}
+\newcommand\buildopttypedidentifier[0]{\hyperlink{build-opttypedidentifier}{\textfunc{build\_opt\_typed\_identifier}}}
+\newcommand\buildtydecl[0]{\hyperlink{build-tydecl}{\textfunc{build\_ty\_decl}}}
+\newcommand\buildsubtype[0]{\hyperlink{build-subtype}{\textfunc{build\_subtype}}}
+\newcommand\buildsubtypeopt[0]{\hyperlink{build-subtypeopt}{\textfunc{build\_subtype\_opt}}}
+\newcommand\buildstoragekeyword[0]{\hyperlink{build-storagekeyword}{\textfunc{build\_storage\_keyword}}}
+\newcommand\builddirection[0]{\hyperlink{build-direction}{\textfunc{build\_direction}}}
+\newcommand\buildalt[0]{\hyperlink{build-alt}{\textfunc{build\_alt}}}
+\newcommand\buildotherwiseopt[0]{\hyperlink{build-otherwiseopt}{\textfunc{build\_otherwise\_opt}}}
+\newcommand\buildcatcher[0]{\hyperlink{build-catcher}{\textfunc{build\_catcher}}}
+\newcommand\buildasty[0]{\textfunc{build\_as\_ty}}
+\newcommand\buildignoredoridentifier[0]{\hyperlink{build-ignoredoridentifier}{\textfunc{build\_ignored\_or\_identifier}}}
+\newcommand\buildlocaldeclkeyword[0]{\hyperlink{build-localdeclkeyword}{\textfunc{build\_local\_decl\_keyword}}}
+\newcommand\buildstmtlist[0]{\hyperlink{build-stmtlist}{\textfunc{build\_stmt\_list}}}
+\newcommand\buildmaybeemptystmtlist[0]{\hyperlink{build-maybeemptystmtlist}{\textfunc{build\_maybe\_empty\_stmt\_list}}}
+\newcommand\buildselse[0]{\hyperlink{build-selse}{\textfunc{build\_s\_else}}}
+\newcommand\buildintconstraints[0]{\hyperlink{build-intconstraints}{\textfunc{build\_int\_constraints}}}
+\newcommand\buildintconstraintsopt[0]{\hyperlink{build-intconstraintsopt}{\textfunc{build\_int\_constraints\_opt}}}
+\newcommand\buildintconstraint[0]{\hyperlink{build-intconstraint}{\textfunc{build\_int\_constraint}}}
+\newcommand\buildexprpattern[0]{\hyperlink{build-exprpattern}{\textfunc{build\_expr\_pattern}}}
+\newcommand\buildfieldassign[0]{\hyperlink{build-fieldassign}{\textfunc{build\_field\_assign}}}
+\newcommand\buildpatternset[0]{\hyperlink{build-patternset}{\textfunc{build\_pattern\_set}}}
+\newcommand\buildpatternlist[0]{\hyperlink{build-patternlist}{\textfunc{build\_pattern\_list}}}
+\newcommand\buildpattern[0]{\hyperlink{build-pattern}{\textfunc{build\_pattern}}}
+\newcommand\buildfields[0]{\hyperlink{build-fields}{\textfunc{build\_fields}}}
+\newcommand\buildfieldsopt[0]{\hyperlink{build-fieldsopt}{\textfunc{build\_fields\_opt}}}
+\newcommand\buildnslices[0]{\hyperlink{build-nslices}{\textfunc{build\_nslices}}}
+\newcommand\buildslices[0]{\hyperlink{build-slices}{\textfunc{build\_slices}}}
+\newcommand\buildslice[0]{\hyperlink{build-slice}{\textfunc{build\_slice}}}
+\newcommand\buildbitfields[0]{\hyperlink{build-bitfields}{\textfunc{build\_bitfields}}}
+\newcommand\buildbitfield[0]{\hyperlink{build-bitfield}{\textfunc{build\_bitfield}}}
+\newcommand\buildty[0]{\hyperlink{build-ty}{\textfunc{build\_ty}}}
+\newcommand\buildeelse[0]{\hyperlink{build-eelse}{\textfunc{build\_e\_else}}}
+\newcommand\buildvalue[0]{\hyperlink{build-value}{\textfunc{build\_value}}}
+\newcommand\buildunop[0]{\hyperlink{build-unop}{\textfunc{build\_unop}}}
+\newcommand\buildbinop[0]{\hyperlink{build-binop}{\textfunc{build\_binop}}}
 
-\newcommand\stmtfromlist[0]{\hyperlink{def-stmtfromlist}{\textsf{stmt\_from\_list}}}
-\newcommand\sequencestmts[0]{\hyperlink{def-sequencestmts}{\textsf{sequence\_stmts}}}
+\newcommand\stmtfromlist[0]{\hyperlink{def-stmtfromlist}{\textfunc{stmt\_from\_list}}}
+\newcommand\sequencestmts[0]{\hyperlink{def-sequencestmts}{\textfunc{sequence\_stmts}}}
 
 \newcommand\eof[0]{\hyperlink{def-eof}{\textsf{eof}}}
 
@@ -486,27 +486,27 @@
 \newcommand\REidentifier[0]{\hyperlink{def-reidentifier}{\texttt{<}\textsf{identifier}\texttt{>}}}
 \newcommand\REcomment[0]{\hyperlink{def-recomment}{\texttt{<}\textsf{comment}\texttt{>}}}
 
-\newcommand\aslparse[0]{\textsf{asl\_parse}}
-\newcommand\aslscan[0]{\hyperlink{def-aslscan}{\textsf{scan}}}
-\newcommand\maxmatches[0]{\hyperlink{def-maxmatch}{\textsf{max\_matches}}}
-\newcommand\remaxmatch[0]{\hyperlink{def-rematch}{\textsf{re\_max\_match}}}
+\newcommand\aslparse[0]{\hyperlink{def-aslparse}{\textfunc{asl\_parse}}}
+\newcommand\aslscan[0]{\hyperlink{def-aslscan}{\textfunc{scan}}}
+\newcommand\maxmatches[0]{\hyperlink{def-maxmatch}{\textfunc{max\_matches}}}
+\newcommand\remaxmatch[0]{\hyperlink{def-rematch}{\textfunc{re\_max\_match}}}
 \newcommand\Token[0]{\hyperlink{def-token}{\textsf{Token}}}
 \newcommand\LexicalError[0]{\hyperlink{def-lexicalerrorresult}{\textsf{\#LE}}}
-\newcommand\ParseError[0]{\textsf{\#PE}}
-\newcommand\discard[0]{\hyperlink{def-discard}{\textsf{discard}}}
-\newcommand\booltolit[0]{\hyperlink{def-booltolit}{\textsf{bool\_to\_lit}}}
-\newcommand\decimaltolit[0]{\hyperlink{def-decimaltolit}{\textsf{dec\_to\_lit}}}
-\newcommand\hextolit[0]{\hyperlink{def-hextolit}{\textsf{hex\_to\_lit}}}
-\newcommand\realtolit[0]{\hyperlink{def-realtolit}{\textsf{real\_to\_lit}}}
-\newcommand\strtolit[0]{\hyperlink{def-strtolit}{\textsf{str\_to\_lit}}}
-\newcommand\bitstolit[0]{\hyperlink{def-bitstolit}{\textsf{bits\_to\_lit}}}
-\newcommand\masktolit[0]{\hyperlink{def-masktolit}{\textsf{mask\_to\_lit}}}
-\newcommand\truetolit[0]{\hyperlink{def-truetolit}{\textsf{true\_to\_lit}}}
-\newcommand\falsetolit[0]{\hyperlink{def-falsetolit}{\textsf{false\_to\_lit}}}
-\newcommand\tokenid[0]{\hyperlink{def-tokenid}{\textsf{token\_id}}}
-\newcommand\lexicalerror[0]{\hyperlink{def-lexicalerror}{\textsf{lexical\_error}}}
-\newcommand\toidentifier[0]{\hyperlink{def-toidentifier}{\textsf{to\_identifier}}}
-\newcommand\eoftoken[0]{\hyperlink{def-eoftoken}{\textsf{eof\_token}}}
+\newcommand\ParseError[0]{\hyperlink{def-parseerror}{\textsf{\#PE}}}
+\newcommand\discard[0]{\hyperlink{def-discard}{\textfunc{discard}}}
+\newcommand\booltolit[0]{\hyperlink{def-booltolit}{\textfunc{bool\_to\_lit}}}
+\newcommand\decimaltolit[0]{\hyperlink{def-decimaltolit}{\textfunc{dec\_to\_lit}}}
+\newcommand\hextolit[0]{\hyperlink{def-hextolit}{\textfunc{hex\_to\_lit}}}
+\newcommand\realtolit[0]{\hyperlink{def-realtolit}{\textfunc{real\_to\_lit}}}
+\newcommand\strtolit[0]{\hyperlink{def-strtolit}{\textfunc{str\_to\_lit}}}
+\newcommand\bitstolit[0]{\hyperlink{def-bitstolit}{\textfunc{bits\_to\_lit}}}
+\newcommand\masktolit[0]{\hyperlink{def-masktolit}{\textfunc{mask\_to\_lit}}}
+\newcommand\truetolit[0]{\hyperlink{def-truetolit}{\textfunc{true\_to\_lit}}}
+\newcommand\falsetolit[0]{\hyperlink{def-falsetolit}{\textfunc{false\_to\_lit}}}
+\newcommand\tokenid[0]{\hyperlink{def-tokenid}{\textfunc{token\_id}}}
+\newcommand\lexicalerror[0]{\hyperlink{def-lexicalerror}{\textfunc{lexical\_error}}}
+\newcommand\toidentifier[0]{\hyperlink{def-toidentifier}{\textfunc{to\_identifier}}}
+\newcommand\eoftoken[0]{\hyperlink{def-eoftoken}{\textfunc{eof\_token}}}
 \newcommand\Teof[0]{\hyperlink{def-teof}{\textsf{EOF}}}
 \newcommand\Terror[0]{\hyperlink{def-terror}{\textsf{ERROR}}}
 \newcommand\Twhitespace[0]{\hyperlink{def-twhitespace}{\textsf{WHITE\_SPACE}}}
@@ -1127,7 +1127,7 @@ and creating a version of the first derivation for each binary operator:
 
 By defining the derivations of $\Nbinop$ as inlined, we achieve the same effect more compactly:
 \begin{flalign*}
-\Nbinop \derives\ & \Tand \;|\; \Tband \;|\; \Tbor \;|\; \Tbeq \;|\; \Tdiv \;|\; \Tdivrm \;|\; \Txor \;|\; \Teqop \;|\; \Tneq &\\
+\Nbinop \derivesinline\ & \Tand \;|\; \Tband \;|\; \Tbor \;|\; \Tbeq \;|\; \Tdiv \;|\; \Tdivrm \;|\; \Txor \;|\; \Teqop \;|\; \Tneq &\\
                       |\ & \Tgt \;|\; \Tgeq \;|\; \Timpl \;|\; \Tlt \;|\; \Tleq \;|\; \Tplus \;|\; \Tminus \;|\; \Tmod \;|\; \Tmul &\\
                       |\ & \Tor \;|\; \Trdiv \;|\; \Tshl \;|\; \Tshr \;|\; \Tpow \;|\; \Tconcat
 \end{flalign*}
@@ -1676,7 +1676,7 @@ $N \derives \emptysentence$.
 
 \hypertarget{def-yield}{}
 \begin{definition}[Parse Tree Yield]
-The \emph{\yield} of a parse tree is the list of its tokens
+The \emph{\yield} of a parse tree is the list of tokens
 given by an in-order walk of the tree:
 \[
 \yield(n) \triangleq \begin{cases}
@@ -1695,16 +1695,19 @@ given by an in-order walk of the tree:
 \hypertarget{def-parsenode}{}
 We denote the set of well-formed parse trees for a non-terminal symbol $S$ by $\parsenode{S}$.
 
+\hypertarget{def-aslparse}{}
 A parser is a function
 \[
 \aslparse : \Token^* \setminus \{\Terror\} \aslto \parsenode{\Nast} \cup \{\ParseError\}
 \]
-such that if $\aslparse(\ts) = n$ then $\yield(n)=\ts$ $\yield(n)=\ts$
+\hypertarget{def-parseerror}{}
+where $\ParseError$ stands for a \emph{parse error}.
+If $\aslparse(\ts) = n$ then $\yield(n)=\ts$ $\yield(n)=\ts$
 and if $\aslparse(\ts) = \ParseError$ then there is no well-formed tree
 $n$ such that $\yield(n)=\ts$.
 (Notice that we do not define a parser if $\ts$ is lexically illegal.)
 
-The language of a grammar $G$ is defined as follows:
+The \emph{language of a grammar} $G$ is defined as follows:
 \[
 \Lang(G) = \{\yield(n) \;|\; n \text{ is a well-formed parse tree for }G\} \enspace.
 \]
@@ -1856,7 +1859,7 @@ We sometimes provide extra details to individual derivations by adding comments 
  &|& \lbitvector(\overname{B}{B \in \{0, 1\}^*})
 \hypertarget{ast-lstring}{}
 \\
- &|& \lstring(\overname{S}{S \in \{C \;|\; \texttt{"$C$"} \in \texttt{<string\_lit>}\}})\\
+ &|& \lstring(\overname{S}{S \in \{C \;|\; \texttt{"$C$"}\ \in\ \Strings\}})\\
 \end{array}
 \]
 
@@ -2044,8 +2047,7 @@ We sometimes provide extra details to individual derivations by adding comments 
 \begin{array}{rcl}
 & & \ASTComment{Type of left-hand side of assignments.}\\
 \hline
-\lexpr &\derives& \LEDiscard\\
-  & & \ASTComment{\texttt{"-"}}\\
+\lexpr &\derives& \overtext{\LEDiscard}{\texttt{"-"}}\\
   &|& \LEVar(\identifier)
   \hypertarget{ast-leslice}{}\\
   &|& \LESlice(\lexpr, \slice^*)
@@ -2059,9 +2061,10 @@ We sometimes provide extra details to individual derivations by adding comments 
   &|& \LEDestructuring(\lexpr^*)
   \hypertarget{ast-leconcat}{}\\
   &|& \LEConcat(\lexpr^+)\\
-  & & \ASTComment{$\LEConcat(\texttt{les}, \_)$ unpacks a list of \lexpr.}
 \end{array}
 \]
+
+$\LEConcat(\texttt{les})$ represents the left-hand-side list of expressions for simultaneous assignments.
 
 \hypertarget{ast-localdeclkeyword}{} \hypertarget{ast-ldkvar}{} \hypertarget{ast-ldkconstant}{} \hypertarget{ast-ldklet}{}
 \[
@@ -2140,8 +2143,8 @@ We sometimes provide extra details to individual derivations by adding comments 
   \hypertarget{ast-srepeat}{} &\\
   |\ & \SRepeat(\overtext{\stmt}{loop body}, \overtext{\expr}{condition}, \overtext{\expr?}{loop limit})
   \hypertarget{ast-sthrow}{} &\\
+  & \ASTComment{The option represents an implicit throw: \texttt{throw;}.}\\
   |\ & \SThrow((\expr, \None)?) &\\
-     & \ASTComment{The option represents an implicit throw: \texttt{throw;}.}
   \hypertarget{ast-stry}{} &\\
   |\ & \STry(\stmt, \catcher^*, \overtext{\stmt?}{otherwise})
   \hypertarget{ast-sprint}{} &\\
@@ -2293,11 +2296,10 @@ $N(S_{1..m})$. To allow the builder to refer to the children nodes of $N$,
 we use the notation $\namednode{n_i}{S_i}$, which names the child node $S_i$ as $n_i$.
 
 \section{Example}
-Consider the derivation
+Consider the derivation for while loops:
 \[
 \Nstmt \derives \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend
 \]
-for while loops.
 
 The parse node for a while statement has the form
 \[
@@ -2306,10 +2308,10 @@ The parse node for a while statement has the form
 where $\ve$ names the node representing the condition of the loop and $\vstmtlist$ names
 the list of statements that form the body of the loop.
 
-To build the corresponding AST, we would employ the builder function $\buildstmt$, since
+To build the corresponding AST, we employ the builder function $\buildstmt$, since
 the non-terminal labelling the parse node is $\Nstmt$.
 
-We would also employ the following rule:
+We also employ the following rule:
 \begin{mathpar}
 \inferrule{
   \buildexpr(\ve) \astarrow \astversion{\ve}\\
@@ -2324,9 +2326,9 @@ We would also employ the following rule:
 }
 }
 \end{mathpar}
-That is, we apply the $\buildexpr$ to transform the condition parse node into the corresponding AST node,
-we apply $\buildstmtlist$ to transform the body of the list into the corresponding AST node,
-and finally return the AST node with AST label $\SWhile$ with the two nodes as its children.
+That is, we apply the $\buildexpr$ to transform the condition parse node $\ve$ into the corresponding AST node,
+we apply $\buildstmtlist$ to transform the parse node $\vstmtlist$ for the body of the list into the corresponding AST node,
+and finally return the AST node for \texttt{while} loops --- $\SWhile$ --- with the two nodes as its children.
 
 \subsection{Abbreviated Rule Notation}
 Notice that there is only one instance of $\Nexpr$ and one instance of $\Nstmtlist$ in this production.
@@ -2350,14 +2352,6 @@ In our example, this results in the abbreviated rule notation
   \astarrow\\
   \SWhile(\astof{\vexpr}, \None, \astof{\vstmtlist})
   \end{array}
-}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule{}{
-{
-  \Nexpr(\Nexpr, \Nbinop, \Nexpr)
 }
 }
 \end{mathpar}

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -2,6 +2,10 @@
 \input{ASLmacros}
 \input{ASLTypingLines}
 \input{ASLTypeSatisfactionLines}
+\input{ASLStaticModelLines}
+\input{ASLStaticInterpreterLines}
+\input{ASLStaticEnvLines}
+\input{ASLASTUtilsLines}
 \input{ASLASTLines}
 \newcommand{\tests}{../tests/ASLTypingReference.t/}
 
@@ -26,8 +30,6 @@
 \newcommand\TError[0]{\textsf{TDynError}}
 \newcommand\ErrorConfig[0]{\hyperlink{def-errorconfig}{\texttt{\#DE}}}
 
-\newcommand\dynamicdomain[0]{\hyperlink{def-dyndomain}{\textsf{dyn\_dom}}}
-
 \newcommand\ProseOtherwiseTypeError[0]{Otherwise, the result is a type error.}
 \newcommand\OrTypeError[0]{\;\terminateas \TypeErrorConfig}
 %\newcommand\ProseOrTypeError[0]{or a type error that short-circuits the entire rule}
@@ -35,173 +37,188 @@
 
 \newcommand\annotaterel[0]{\hyperlink{def-annotaterel}{\textsf{type}}}
 \newcommand\typearrow[0]{\xrightarrow{\annotaterel}}
-\newcommand\isbuiltinsingular[0]{\hyperlink{def-isbuiltinsingular}{\texttt{is\_builtin\_singular}}}
-\newcommand\isbuiltinaggregate[0]{\hyperlink{def-isbuiltinaggregate}{\texttt{is\_builtin\_aggregate}}}
-\newcommand\isbuiltin[0]{\hyperlink{def-isbuiltin}{\texttt{is\_builtin}}}
-\newcommand\isnamed[0]{\hyperlink{def-isnamed}{\texttt{is\_named}}}
-\newcommand\isanonymous[0]{\hyperlink{def-isanonymous}{\texttt{is\_anonymous}}}
-\newcommand\issingular[0]{\hyperlink{def-issingular}{\texttt{is\_singular}}}
-\newcommand\isaggregate[0]{\hyperlink{def-isaggregate}{\texttt{is\_aggregate}}}
-\newcommand\isstructured[0]{\hyperlink{def-isstructured}{\texttt{is\_structured}}}
-\newcommand\isnonprimitive[0]{\hyperlink{def-isnonprimitive}{\texttt{is\_non\_primitive}}}
-\newcommand\isprimitive[0]{\hyperlink{def-isprimitive}{\texttt{is\_primitive}}}
+
+\newcommand\dynamicdomain[0]{\hyperlink{def-dyndomain}{\textsf{dyn\_dom}}}
+
+\newcommand\isbuiltinsingular[0]{\hyperlink{def-isbuiltinsingular}{\\textfunc{is\_builtin\_singular}}}
+\newcommand\isbuiltinaggregate[0]{\hyperlink{def-isbuiltinaggregate}{\\textfunc{is\_builtin\_aggregate}}}
+\newcommand\isbuiltin[0]{\hyperlink{def-isbuiltin}{\textfunc{is\_builtin}}}
+\newcommand\isnamed[0]{\hyperlink{def-isnamed}{\textfunc{is\_named}}}
+\newcommand\isanonymous[0]{\hyperlink{def-isanonymous}{\textfunc{is\_anonymous}}}
+\newcommand\issingular[0]{\hyperlink{def-issingular}{\textfunc{is\_singular}}}
+\newcommand\isaggregate[0]{\hyperlink{def-isaggregate}{\textfunc{is\_aggregate}}}
+\newcommand\isstructured[0]{\hyperlink{def-isstructured}{\textfunc{is\_structured}}}
+\newcommand\isnonprimitive[0]{\hyperlink{def-isnonprimitive}{\textfunc{is\_non\_primitive}}}
+\newcommand\isprimitive[0]{\hyperlink{def-isprimitive}{\textfunc{is\_primitive}}}
 
 \newcommand\isunconstrainedinteger[0]{\hyperlink{def-isunconstrainedinteger}{\textsf{is\_unconstrained\_integer}}}
 \newcommand\isparameterizedinteger[0]{\hyperlink{def-isparameterizedinteger}{\textsf{is\_parameterized\_integer}}}
 \newcommand\iswellconstrainedinteger[0]{\hyperlink{def-iswellconstrainedinteger}{\textsf{is\_well\_constrained\_integer}}}
 \newcommand\unconstrainedinteger[0]{\hyperlink{def-unconstrainedinteger}{\textsf{unconstrained\_integer}}}
 
-\newcommand\checkconstrainedinteger[0]{\hyperlink{def-checkconstrainedinteger}{\texttt{check\_constrained\_integer}}}
+\newcommand\checkconstrainedinteger[0]{\hyperlink{def-checkconstrainedinteger}{\textfunc{check\_constrained\_integer}}}
 
-\newcommand\staticeval[0]{\hyperlink{def-staticeval}{\texttt{static\_eval}}}
-\newcommand\isstaticallyevaluable[0]{\texttt{check\_statically\_evaluable}}
+\newcommand\staticeval[0]{\hyperlink{def-staticeval}{\textfunc{static\_eval}}}
+\newcommand\isstaticallyevaluable[0]{\textfunc{check\_statically\_evaluable}}
 
-\newcommand\makeanonymous[0]{\hyperlink{def-makeanonymous}{\texttt{make\_anonymous}}}
-\newcommand\subtypesrel[0]{\hyperlink{def-subtypesrel}{\texttt{is\_subtype}}}
-\newcommand\structsubtypesat[0]{\hyperlink{def-structsubtypesat}{\texttt{structural\_subtype\_satisfies}}}
-\newcommand\domsubtypesat[0]{\hyperlink{def-domsubtypesat}{\texttt{domain\_subtype\_satisfies}}}
-\newcommand\subtypesat[0]{\hyperlink{def-subtypesat}{\texttt{subtype\_satisfies}}}
-\newcommand\checktypesat[0]{\hyperlink{def-checktypesat}{\texttt{checked\_typesat}}}
-\newcommand\typeclashes[0]{\hyperlink{def-typeclashes}{\texttt{type\_clashes}}}
-\newcommand\lca[0]{\hyperlink{def-lowestcommonancestor}{\texttt{lowest\_common\_ancestor}}}
-\newcommand\namedlca[0]{\hyperlink{def-namedlowestcommonancestor}{\texttt{named\_lowest\_common\_ancestor}}}
+\newcommand\makeanonymous[0]{\hyperlink{def-makeanonymous}{\textfunc{make\_anonymous}}}
+\newcommand\subtypesrel[0]{\hyperlink{def-subtypesrel}{\textfunc{is\_subtype}}}
+\newcommand\structsubtypesat[0]{\hyperlink{def-structsubtypesat}{\textfunc{structural\_subtype\_satisfies}}}
+\newcommand\domsubtypesat[0]{\hyperlink{def-domsubtypesat}{\textfunc{domain\_subtype\_satisfies}}}
+\newcommand\subtypesat[0]{\hyperlink{def-subtypesat}{\textfunc{subtype\_satisfies}}}
+\newcommand\checktypesat[0]{\hyperlink{def-checktypesat}{\textfunc{checked\_typesat}}}
+\newcommand\typeclashes[0]{\hyperlink{def-typeclashes}{\textfunc{type\_clashes}}}
+\newcommand\lca[0]{\hyperlink{def-lowestcommonancestor}{\textfunc{lowest\_common\_ancestor}}}
+\newcommand\namedlca[0]{\hyperlink{def-namedlowestcommonancestor}{\textfunc{named\_lowest\_common\_ancestor}}}
 \newcommand\Supers{\textsf{Supers}}
-\newcommand\bitfieldsincluded[0]{\hyperlink{def-bitfieldsincluded}{\texttt{bitfields\_included}}}
-\newcommand\membfs[0]{\hyperlink{def-membfs}{\texttt{mem\_bfs}}}
-\newcommand\instantiate[0]{\texttt{instantiate}}
-\newcommand\canbeinitializedwith[0]{\texttt{can\_be\_initialized\_with}}
-\newcommand\getbitvectorwidth[0]{\hyperlink{def-getbitvectorwidth}{\texttt{get\_bitvector\_width}}}
-\newcommand\checkbitsequalwidth[0]{\hyperlink{def-checkbitsequalwidth}{\texttt{check\_bits\_equal\_width}}}
-\newcommand\findsubprogram[0]{\hyperlink{def-findsubprogram}{\texttt{find\_subprogram}}}
-\newcommand\subprogramtypeclash[0]{\texttt{subprogram\_type\_clash}}
-\newcommand\hassubprogramtypeclash[0]{\texttt{subprogram\_type\_clash}}
-\newcommand\subprogramclash[0]{\hyperlink{def-subprogramclash}{\texttt{subprogram\_clash}}}
-\newcommand\argsclash[0]{\texttt{args\_clash}}
-\newcommand\bitfieldgetname[0]{\hyperlink{def-bitfieldgetname}{\texttt{bitfield\_get\_name}}}
-\newcommand\pairstomap[0]{\hyperlink{def-pairstomap}{\texttt{pairs\_to\_map}}}
-\newcommand\assocopt[0]{\hyperlink{def-assocopt}{\texttt{assoc\_opt}}}
-\newcommand\annotatefieldinit[0]{\hyperlink{def-annotatefieldinit}{\texttt{annotate\_field\_init}}}
-\newcommand\annotatestaticinteger[0]{\hyperlink{def-annotatestaticinteger}{\texttt{annotate\_static\_integer}}}
-\newcommand\annotatestaticconstrainedinteger[0]{\hyperlink{def-annotatestaticconstrainedinteger}{\texttt{annotate\_static\_constrained\_integer}}}
-\newcommand\checkatc[0]{\hyperlink{def-checkatc}{\texttt{check\_atc}}}
-\newcommand\checkstructurelabel[0]{\hyperlink{def-checkstructurelabel}{\texttt{check\_structure}}}
-\newcommand\checkstructureinteger[0]{\hyperlink{def-checkstructureinteger}{\texttt{check\_structure\_integer}}}
-\newcommand\checkstaticallyevaluable[0]{\hyperlink{def-checkstaticallyevaluable}{\texttt{check\_statically\_evaluable}}}
-\newcommand\storageispure[0]{\hyperlink{def-storageispure}{\texttt{storage\_is\_pure}}}
-\newcommand\negateconstraint[0]{\hyperlink{def-negateconstraint}{\texttt{negate\_constraint}}}
-\newcommand\getwellconstrainedstructure[0]{\hyperlink{def-getwellconstrainedstructure}{\texttt{get\_well\_constrained\_structure}}}
-\newcommand\towellconstrained[0]{\hyperlink{def-towellconstrained}{\texttt{to\_well\_constrained}}}
-\newcommand\annotatelebits[0]{\hyperlink{def-annotatelebits}{\texttt{annotate\_lebits}}}
-\newcommand\annotatecase[1]{\hyperlink{def-annotatecase}{\texttt{annotate\_case}}(#1)}
-\newcommand\getforconstraints[0]{\hyperlink{def-getforconstraints}{\texttt{for\_constraints}}}
-\newcommand\findbitfieldopt[0]{\hyperlink{def-findbitfieldopt}{\texttt{find\_bitfield\_opt}}}
-\newcommand\lookupconstant[0]{\hyperlink{def-lookupconstant}{\texttt{lookup\_constant}}}
-\newcommand\typeof[0]{\hyperlink{def-typeof}{\texttt{type\_of}}}
-\newcommand\typecheckdecl[0]{\hyperlink{def-typecheckdecl}{\texttt{typecheck\_decl}}}
-\newcommand\annotateanddeclarefunc[0]{\hyperlink{def-annotateanddeclarefunc}{\texttt{annotate\_and\_declare\_func}}}
-\newcommand\declareglobalstorage[0]{\hyperlink{def-declareglobalstorage}{\texttt{declare\_global\_storage}}}
-\newcommand\annotatefuncsig[0]{\hyperlink{def-annotatefuncsig}{\texttt{annotate\_func\_sig}}}
-\newcommand\declareonefunc[0]{\hyperlink{def-declareonefunc}{\texttt{declare\_one\_func}}}
-\newcommand\checksetterhasgetter[0]{\hyperlink{def-checksetterhashgetter}{\texttt{check\_setter\_has\_getter}}}
-\newcommand\addnewfunc[0]{\hyperlink{def-addnewfunc}{\texttt{add\_new\_func}}}
-\newcommand\addsubprogram[0]{\hyperlink{def-addsubprogram}{\texttt{add\_subprogram}}}
-\newcommand\isundefined[0]{\hyperlink{def-isundefined}{\texttt{is\_undedined}}}
-\newcommand\scanforparams[0]{\hyperlink{def-scanforparams}{\texttt{scan\_for\_params}}}
-\newcommand\annotateparams[0]{\hyperlink{def-annotateparams}{\texttt{annotate\_params}}}
-\newcommand\annotateoneparam[0]{\hyperlink{def-annotateoneparam}{\texttt{annotate\_one\_param}}}
-\newcommand\argsasparams[0]{\hyperlink{def-argsasparams}{\texttt{args\_as\_params}}}
-\newcommand\argasparam[0]{\hyperlink{def-argasparam}{\texttt{arg\_as\_param}}}
-\newcommand\annotatetypeopt[0]{\hyperlink{def-annotatetypeopt}{\texttt{annotate\_type\_opt}}}
-\newcommand\annotateexpropt[0]{\hyperlink{def-annotateexpropt}{\texttt{annotate\_expr\_opt}}}
-\newcommand\annotateinittype[0]{\hyperlink{def-annotateinittype}{\texttt{annotate\_init\_type}}}
-\newcommand\addglobalstorage[0]{\hyperlink{def-addglobalstorage}{\texttt{add\_global\_storage}}}
-\newcommand\annotateextrafields[0]{\hyperlink{def-annotateextrafields}{\texttt{annotate\_extra\_fields}}}
-\newcommand\declareenumlabels[0]{\hyperlink{def-annotateenumlabels}{\texttt{declare\_enum\_labels}}}
-\newcommand\declareconst[0]{\hyperlink{def-declareconst}{\texttt{declare\_const}}}
-\newcommand\annotateparamtype[0]{\hyperlink{def-annotateparamtype}{\texttt{annotate\_param\_type}}}
-\newcommand\annotateargs[0]{\hyperlink{def-annotateargs}{\texttt{annotate\_args}}}
-\newcommand\annotateonearg[0]{\hyperlink{def-annotateonearg}{\texttt{annotate\_one\_arg}}}
-\newcommand\annotatereturntype[0]{\hyperlink{def-annotatereturntype}{\texttt{annotate\_return\_type}}}
-\newcommand\slicestopositions[0]{\hyperlink{def-slicestopositions}{\texttt{slices\_to\_positions}}}
-\newcommand\extractslice[0]{\hyperlink{def-extractslice}{\texttt{extract\_slice}}}
-\newcommand\slicetopositions[0]{\hyperlink{def-slicetopositions}{\texttt{slice\_to\_positions}}}
-\newcommand\evaltoint[0]{\hyperlink{def-evaltoint}{\texttt{eval\_to\_int}}}
-\newcommand\sort[0]{\hyperlink{def-sort}{\texttt{sort}}}
-\newcommand\comparemonomialbindings[0]{\hyperlink{def-comparemonomialbindings}{\texttt{compare\_monomial\_bindings}}}
-\newcommand\annotatecalleeparameters[0]{\hyperlink{def-annotatecalleeparameters}{\texttt{annotate\_callee\_params}}}
-\newcommand\checkargstypesat[0]{\hyperlink{def-checkargstypesat}{\texttt{check\_args\_typesat}}}
-\newcommand\checkcalleeparams[0]{\hyperlink{def-checkcalleeparams}{\texttt{check\_callee\_params}}}
-\newcommand\annotateretty[0]{\hyperlink{def-annotateretty}{\texttt{annotate\_ret\_ty}}}
-\newcommand\renametyeqs[0]{\hyperlink{def-renametyeqs}{\texttt{rename\_ty\_eqs}}}
-\newcommand\substexpr[0]{\hyperlink{def-substexpr}{\texttt{subst\_expr}}}
-\newcommand\substexprnormalize[0]{\hyperlink{def-substexprnormalize}{\texttt{subst\_expr\_normalize}}}
-\newcommand\substconstraint[0]{\hyperlink{def-substconstraint}{\texttt{subst\_constraint}}}
-\newcommand\typecheckmutuallyrec[0]{\hyperlink{def-typecheckmutuallyrec}{\texttt{type\_check\_mutually\_rec}}}
-\newcommand\foldenvandfs[0]{\hyperlink{def-foldenvandfs}{\texttt{fold\_env\_and\_fs}}}
-\newcommand\defdecl[0]{\hyperlink{def-defdecl}{\texttt{def\_decl}}}
-\newcommand\defenumlabels[0]{\hyperlink{def-defenumlabels}{\texttt{def\_enum\_labels}}}
-\newcommand\usedecl[0]{\hyperlink{def-usedecl}{\texttt{use\_decl}}}
-\newcommand\usety[0]{\hyperlink{def-usety}{\texttt{use\_ty}}}
-\newcommand\usesubtypes[0]{\hyperlink{def-usesubtypes}{\texttt{use\_subtypes}}}
-\newcommand\useexpr[0]{\hyperlink{def-useexpr}{\texttt{use\_e}}}
-\newcommand\uselexpr[0]{\hyperlink{def-uselexpr}{\texttt{use\_le}}}
-\newcommand\usefields[0]{\hyperlink{def-usefields}{\texttt{use\_fields}}}
-\newcommand\usepattern[0]{\hyperlink{def-usepattern}{\texttt{use\_pattern}}}
-\newcommand\useslice[0]{\hyperlink{def-useslice}{\texttt{use\_slice}}}
-\newcommand\usebitfield[0]{\hyperlink{def-usebitfield}{\texttt{use\_bitfield}}}
-\newcommand\useconstraint[0]{\hyperlink{def-useconstraint}{\texttt{use\_constraint}}}
-\newcommand\usestmt[0]{\hyperlink{def-usestmt}{\texttt{use\_s}}}
-\newcommand\useldi[0]{\hyperlink{def-useldi}{\texttt{use\_ldi}}}
-\newcommand\usecase[0]{\hyperlink{def-usecase}{\texttt{use\_case}}}
-\newcommand\usecatcher[0]{\hyperlink{def-usecatcher}{\texttt{use\_catcher}}}
-\newcommand\usefuncsig[0]{\hyperlink{def-usefuncsig}{\texttt{use\_func\_sig}}}
-\newcommand\builddependencies[0]{\hyperlink{def-builddependencies}{\texttt{build\_dependencies}}}
-\newcommand\decldependencies[0]{\hyperlink{def-decldependencies}{\texttt{decl\_dependencies}}}
+\newcommand\bitfieldsincluded[0]{\hyperlink{def-bitfieldsincluded}{\textfunc{bitfields\_included}}}
+\newcommand\membfs[0]{\hyperlink{def-membfs}{\textfunc{mem\_bfs}}}
+\newcommand\instantiate[0]{\textfunc{instantiate}}
+\newcommand\checkcanbeinitializedwith[0]{\hyperlink{def-checkcanbeinitializedwith}{\textfunc{check\_can\_be\_initialized\_with}}}
+\newcommand\getbitvectorwidth[0]{\hyperlink{def-getbitvectorwidth}{\textfunc{get\_bitvector\_width}}}
+\newcommand\checkbitsequalwidth[0]{\hyperlink{def-checkbitsequalwidth}{\textfunc{check\_bits\_equal\_width}}}
+\newcommand\findsubprogram[0]{\hyperlink{def-findsubprogram}{\textfunc{find\_subprogram}}}
+\newcommand\subprogramtypeclash[0]{\textfunc{subprogram\_type\_clash}}
+\newcommand\hassubprogramtypeclash[0]{\textfunc{subprogram\_type\_clash}}
+\newcommand\subprogramclash[0]{\hyperlink{def-subprogramclash}{\textfunc{subprogram\_clash}}}
+\newcommand\argsclash[0]{\textfunc{args\_clash}}
+\newcommand\bitfieldgetname[0]{\hyperlink{def-bitfieldgetname}{\textfunc{bitfield\_get\_name}}}
+\newcommand\pairstomap[0]{\hyperlink{def-pairstomap}{\textfunc{pairs\_to\_map}}}
+\newcommand\assocopt[0]{\hyperlink{def-assocopt}{\textfunc{assoc\_opt}}}
+\newcommand\annotatefieldinit[0]{\hyperlink{def-annotatefieldinit}{\textfunc{annotate\_field\_init}}}
+\newcommand\annotatestaticinteger[0]{\hyperlink{def-annotatestaticinteger}{\textfunc{annotate\_static\_integer}}}
+\newcommand\annotatestaticconstrainedinteger[0]{\hyperlink{def-annotatestaticconstrainedinteger}{\textfunc{annotate\_static\_constrained\_integer}}}
+\newcommand\checkatc[0]{\hyperlink{def-checkatc}{\textfunc{check\_atc}}}
+\newcommand\sliceswidth[0]{\hyperlink{def-sliceswidth}{\textfunc{slices\_width}}}
+\newcommand\slicewidth[0]{\hyperlink{def-slicewidth}{\textfunc{slice\_width}}}
+\newcommand\checkstructurelabel[0]{\hyperlink{def-checkstructurelabel}{\textfunc{check\_structure}}}
+\newcommand\checkstructureinteger[0]{\hyperlink{def-checkstructureinteger}{\textfunc{check\_structure\_integer}}}
+\newcommand\checkstaticallyevaluable[0]{\hyperlink{def-checkstaticallyevaluable}{\textfunc{check\_statically\_evaluable}}}
+\newcommand\storageispure[0]{\hyperlink{def-storageispure}{\textfunc{storage\_is\_pure}}}
+\newcommand\negateconstraint[0]{\hyperlink{def-negateconstraint}{\textfunc{negate\_constraint}}}
+\newcommand\getwellconstrainedstructure[0]{\hyperlink{def-getwellconstrainedstructure}{\textfunc{get\_well\_constrained\_structure}}}
+\newcommand\towellconstrained[0]{\hyperlink{def-towellconstrained}{\textfunc{to\_well\_constrained}}}
+\newcommand\annotatelebits[0]{\hyperlink{def-annotatelebits}{\textfunc{annotate\_lebits}}}
+\newcommand\annotatecase[1]{\hyperlink{def-annotatecase}{\textfunc{annotate\_case}}(#1)}
+\newcommand\getforconstraints[0]{\hyperlink{def-getforconstraints}{\textfunc{for\_constraints}}}
+\newcommand\findbitfieldopt[0]{\hyperlink{def-findbitfieldopt}{\textfunc{find\_bitfield\_opt}}}
+\newcommand\lookupconstant[0]{\hyperlink{def-lookupconstant}{\textfunc{lookup\_constant}}}
+\newcommand\typeof[0]{\hyperlink{def-typeof}{\textfunc{type\_of}}}
+\newcommand\typecheckdecl[0]{\hyperlink{def-typecheckdecl}{\textfunc{typecheck\_decl}}}
+\newcommand\annotateanddeclarefunc[0]{\hyperlink{def-annotateanddeclarefunc}{\textfunc{annotate\_and\_declare\_func}}}
+\newcommand\declareglobalstorage[0]{\hyperlink{def-declareglobalstorage}{\textfunc{declare\_global\_storage}}}
+\newcommand\annotatefuncsig[0]{\hyperlink{def-annotatefuncsig}{\textfunc{annotate\_func\_sig}}}
+\newcommand\declareonefunc[0]{\hyperlink{def-declareonefunc}{\textfunc{declare\_one\_func}}}
+\newcommand\checksetterhasgetter[0]{\hyperlink{def-checksetterhashgetter}{\textfunc{check\_setter\_has\_getter}}}
+\newcommand\addnewfunc[0]{\hyperlink{def-addnewfunc}{\textfunc{add\_new\_func}}}
+\newcommand\addsubprogram[0]{\hyperlink{def-addsubprogram}{\textfunc{add\_subprogram}}}
+\newcommand\isundefined[0]{\hyperlink{def-isundefined}{\textfunc{is\_undefined}}}
+\newcommand\scanforparams[0]{\hyperlink{def-scanforparams}{\textfunc{scan\_for\_params}}}
+\newcommand\annotateparams[0]{\hyperlink{def-annotateparams}{\textfunc{annotate\_params}}}
+\newcommand\annotateoneparam[0]{\hyperlink{def-annotateoneparam}{\textfunc{annotate\_one\_param}}}
+\newcommand\argsasparams[0]{\hyperlink{def-argsasparams}{\textfunc{args\_as\_params}}}
+\newcommand\argasparam[0]{\hyperlink{def-argasparam}{\textfunc{arg\_as\_param}}}
+\newcommand\annotatetypeopt[0]{\hyperlink{def-annotatetypeopt}{\textfunc{annotate\_type\_opt}}}
+\newcommand\annotateexpropt[0]{\hyperlink{def-annotateexpropt}{\textfunc{annotate\_expr\_opt}}}
+\newcommand\annotateinittype[0]{\hyperlink{def-annotateinittype}{\textfunc{annotate\_init\_type}}}
+\newcommand\addglobalstorage[0]{\hyperlink{def-addglobalstorage}{\textfunc{add\_global\_storage}}}
+\newcommand\annotateextrafields[0]{\hyperlink{def-annotateextrafields}{\textfunc{annotate\_extra\_fields}}}
+\newcommand\declareenumlabels[0]{\hyperlink{def-annotateenumlabels}{\textfunc{declare\_enum\_labels}}}
+\newcommand\declareconst[0]{\hyperlink{def-declareconst}{\textfunc{declare\_const}}}
+\newcommand\annotateparamtype[0]{\hyperlink{def-annotateparamtype}{\textfunc{annotate\_param\_type}}}
+\newcommand\annotateargs[0]{\hyperlink{def-annotateargs}{\textfunc{annotate\_args}}}
+\newcommand\annotateonearg[0]{\hyperlink{def-annotateonearg}{\textfunc{annotate\_one\_arg}}}
+\newcommand\annotatereturntype[0]{\hyperlink{def-annotatereturntype}{\textfunc{annotate\_return\_type}}}
+\newcommand\slicestopositions[0]{\hyperlink{def-slicestopositions}{\textfunc{slices\_to\_positions}}}
+\newcommand\extractslice[0]{\hyperlink{def-extractslice}{\textfunc{extract\_slice}}}
+\newcommand\slicetopositions[0]{\hyperlink{def-slicetopositions}{\textfunc{slice\_to\_positions}}}
+\newcommand\evaltoint[0]{\hyperlink{def-evaltoint}{\textfunc{eval\_to\_int}}}
+\newcommand\sort[0]{\hyperlink{def-sort}{\textfunc{sort}}}
+\newcommand\comparemonomialbindings[0]{\hyperlink{def-comparemonomialbindings}{\textfunc{compare\_monomial\_bindings}}}
+\newcommand\annotatecalleeparameters[0]{\hyperlink{def-annotatecalleeparameters}{\textfunc{annotate\_callee\_params}}}
+\newcommand\checkargstypesat[0]{\hyperlink{def-checkargstypesat}{\textfunc{check\_args\_typesat}}}
+\newcommand\checkcalleeparams[0]{\hyperlink{def-checkcalleeparams}{\textfunc{check\_callee\_params}}}
+\newcommand\annotateretty[0]{\hyperlink{def-annotateretty}{\textfunc{annotate\_ret\_ty}}}
+\newcommand\renametyeqs[0]{\hyperlink{def-renametyeqs}{\textfunc{rename\_ty\_eqs}}}
+\newcommand\substexpr[0]{\hyperlink{def-substexpr}{\textfunc{subst\_expr}}}
+\newcommand\substexprnormalize[0]{\hyperlink{def-substexprnormalize}{\textfunc{subst\_expr\_normalize}}}
+\newcommand\substconstraint[0]{\hyperlink{def-substconstraint}{\textfunc{subst\_constraint}}}
+\newcommand\typecheckmutuallyrec[0]{\hyperlink{def-typecheckmutuallyrec}{\textfunc{type\_check\_mutually\_rec}}}
+\newcommand\foldenvandfs[0]{\hyperlink{def-foldenvandfs}{\textfunc{fold\_env\_and\_fs}}}
+\newcommand\defdecl[0]{\hyperlink{def-defdecl}{\textfunc{def\_decl}}}
+\newcommand\defenumlabels[0]{\hyperlink{def-defenumlabels}{\textfunc{def\_enum\_labels}}}
+\newcommand\usedecl[0]{\hyperlink{def-usedecl}{\textfunc{use\_decl}}}
+\newcommand\usety[0]{\hyperlink{def-usety}{\textfunc{use\_ty}}}
+\newcommand\usesubtypes[0]{\hyperlink{def-usesubtypes}{\textfunc{use\_subtypes}}}
+\newcommand\useexpr[0]{\hyperlink{def-useexpr}{\textfunc{use\_e}}}
+\newcommand\uselexpr[0]{\hyperlink{def-uselexpr}{\textfunc{use\_le}}}
+\newcommand\usefields[0]{\hyperlink{def-usefields}{\textfunc{use\_fields}}}
+\newcommand\usepattern[0]{\hyperlink{def-usepattern}{\textfunc{use\_pattern}}}
+\newcommand\useslice[0]{\hyperlink{def-useslice}{\textfunc{use\_slice}}}
+\newcommand\usebitfield[0]{\hyperlink{def-usebitfield}{\textfunc{use\_bitfield}}}
+\newcommand\useconstraint[0]{\hyperlink{def-useconstraint}{\textfunc{use\_constraint}}}
+\newcommand\usestmt[0]{\hyperlink{def-usestmt}{\textfunc{use\_s}}}
+\newcommand\useldi[0]{\hyperlink{def-useldi}{\textfunc{use\_ldi}}}
+\newcommand\usecase[0]{\hyperlink{def-usecase}{\textfunc{use\_case}}}
+\newcommand\usecatcher[0]{\hyperlink{def-usecatcher}{\textfunc{use\_catcher}}}
+\newcommand\usefuncsig[0]{\hyperlink{def-usefuncsig}{\textfunc{use\_func\_sig}}}
+\newcommand\builddependencies[0]{\hyperlink{def-builddependencies}{\textfunc{build\_dependencies}}}
+\newcommand\decldependencies[0]{\hyperlink{def-decldependencies}{\textfunc{decl\_dependencies}}}
 
 % Symbolic equivalence testing macros
-\newcommand\normalize[0]{\hyperlink{def-normalize}{\texttt{normalize}}}
-\newcommand\typeequal[0]{\hyperlink{def-typeequal}{\texttt{type\_equal}}}
-\newcommand\exprequal[0]{\hyperlink{def-exprequal}{\texttt{expr\_equal}}}
-\newcommand\bitwidthequal[0]{\hyperlink{def-bitwidthequal}{\texttt{bitwidth\_equal}}}
-\newcommand\bitfieldequal[0]{\hyperlink{def-bitfieldequal}{\texttt{bitfield\_equal}}}
-\newcommand\bitfieldsequal[0]{\hyperlink{def-bitfieldsequal}{\texttt{bitfields\_equal}}}
-\newcommand\reduceir[0]{\hyperlink{def-reduceir}{\texttt{reduce\_ir}}}
-\newcommand\polynomialtoexpr[0]{\hyperlink{def-polynomialtoexpr}{\texttt{polynomial\_to\_expr}}}
-\newcommand\monomialtoexpr[0]{\hyperlink{def-monomialtoexpr}{\texttt{monomial\_to\_expr}}}
-\newcommand\symmulexpr[0]{\hyperlink{def-symmulexpr}{\texttt{sym\_mul\_expr}}}
-\newcommand\symaddexpr[0]{\hyperlink{def-symaddexpr}{\texttt{sym\_add\_expr}}}
-\newcommand\monomialstoexpr[0]{\hyperlink{def-monomialstoexpr}{\texttt{monomials\_to\_expr}}}
-\newcommand\unitarymonomialstoexpr[0]{\hyperlink{def-unitarymonomialstoexpr}{\texttt{unitary\_monomials\_to\_expr}}}
-\newcommand\compareidentifier[0]{\hyperlink{def-compareidentifier}{\texttt{compare\_identifier}}}
+\newcommand\normalize[0]{\hyperlink{def-normalize}{\textfunc{normalize}}}
+\newcommand\typeequal[0]{\hyperlink{def-typeequal}{\textfunc{type\_equal}}}
+\newcommand\exprequal[0]{\hyperlink{def-exprequal}{\textfunc{expr\_equal}}}
+\newcommand\bitwidthequal[0]{\hyperlink{def-bitwidthequal}{\textfunc{bitwidth\_equal}}}
+\newcommand\bitfieldequal[0]{\hyperlink{def-bitfieldequal}{\textfunc{bitfield\_equal}}}
+\newcommand\bitfieldsequal[0]{\hyperlink{def-bitfieldsequal}{\textfunc{bitfields\_equal}}}
+\newcommand\reduceir[0]{\hyperlink{def-reduceir}{\textfunc{reduce\_ir}}}
+\newcommand\polynomialtoexpr[0]{\hyperlink{def-polynomialtoexpr}{\textfunc{polynomial\_to\_expr}}}
+\newcommand\monomialtoexpr[0]{\hyperlink{def-monomialtoexpr}{\textfunc{monomial\_to\_expr}}}
+\newcommand\symmulexpr[0]{\hyperlink{def-symmulexpr}{\textfunc{sym\_mul\_expr}}}
+\newcommand\symaddexpr[0]{\hyperlink{def-symaddexpr}{\textfunc{sym\_add\_expr}}}
+\newcommand\monomialstoexpr[0]{\hyperlink{def-monomialstoexpr}{\textfunc{monomials\_to\_expr}}}
+\newcommand\unitarymonomialstoexpr[0]{\hyperlink{def-unitarymonomialstoexpr}{\textfunc{unitary\_monomials\_to\_expr}}}
+\newcommand\compareidentifier[0]{\hyperlink{def-compareidentifier}{\textfunc{compare\_identifier}}}
 
-\newcommand\subsumes[0]{\hyperlink{def-subsumes}{\texttt{subsumes}}}
-\newcommand\symsubsumes[0]{\hyperlink{def-symsubsumes}{\texttt{sym\_subsumes}}}
+\newcommand\subsumes[0]{\hyperlink{def-subsumes}{\textfunc{subsumes}}}
+\newcommand\symsubsumes[0]{\hyperlink{def-symsubsumes}{\textfunc{sym\_subsumes}}}
 
-\newcommand\toir[0]{\hyperlink{def-toir}{\texttt{to\_ir}}}
-\newcommand\toircase[0]{\hyperlink{def-toircase}{\texttt{to\_ir\_case}}}
+\newcommand\toir[0]{\hyperlink{def-toir}{\textfunc{to\_ir}}}
+\newcommand\toircase[0]{\hyperlink{def-toircase}{\textfunc{to\_ir\_case}}}
 \newcommand\Prod[0]{\hyperlink{def-prod}{\textsf{Prod}}}
 \newcommand\Sum[0]{\hyperlink{def-sum}{\textsf{Sum}}}
 \newcommand\unitarymonomial[0]{\hyperlink{def-unitarymonomial}{\textsf{unitary\_monomial}}}
 \newcommand\monomial[0]{\hyperlink{def-monomial}{\textsf{monomial}}}
 \newcommand\polynomial[0]{\hyperlink{def-polynomial}{\textsf{polynomial}}}
-\newcommand\addpolynomials[0]{\hyperlink{def-addpolynomials}{\texttt{add\_polynomials}}}
-\newcommand\mulpolynomials[0]{\hyperlink{def-mulpolynomials}{\texttt{mul\_polynomials}}}
-\newcommand\mulmonomials[0]{\hyperlink{def-mulmonomials}{\texttt{mul\_mononimials}}}
+\newcommand\addpolynomials[0]{\hyperlink{def-addpolynomials}{\textfunc{add\_polynomials}}}
+\newcommand\mulpolynomials[0]{\hyperlink{def-mulpolynomials}{\textfunc{mul\_polynomials}}}
+\newcommand\mulmonomials[0]{\hyperlink{def-mulmonomials}{\textfunc{mul\_monomials}}}
 
-\newcommand\declaredtype[0]{\hyperlink{def-declaredtype}{\texttt{declared\_type}}}
+\newcommand\declaredtype[0]{\hyperlink{def-declaredtype}{\textfunc{declared\_type}}}
 
-\newcommand\fieldnames[0]{\hyperlink{def-fieldnames}{\texttt{field\_names}}}
-\newcommand\fieldtype[0]{\hyperlink{def-fieldtype}{\texttt{field\_type}}}
+\newcommand\fieldnames[0]{\hyperlink{def-fieldnames}{\textfunc{field\_names}}}
+\newcommand\fieldtype[0]{\hyperlink{def-fieldtype}{\textfunc{field\_type}}}
 
 \newcommand\eliteral[1]{\textsf{E\_Literal}(#1)}
 
 % An expression that we do not statically evaluate.
 \newcommand\CannotBeTransformed[0]{\hyperlink{def-unsupportedexpression}{\top}}
 
-\newcommand\unopsignatures[0]{\hyperlink{def-unopsignatures}{\texttt{unop\_signatures}}}
-\newcommand\binopsignatures[0]{\hyperlink{def-binopsignatures}{\texttt{binop\_signatures}}}
+\newcommand\unopsignatures[0]{\hyperlink{def-unopsignatures}{\textfunc{unop\_signatures}}}
+\newcommand\binopsignatures[0]{\hyperlink{def-binopsignatures}{\textfunc{binop\_signatures}}}
 
-\newcommand\ELInt[1]{\hyperlink{def-elint}{\texttt{ELInt}}(#1)}
+% AST abbreviations
+%\newcommand\ELInt[1]{\hyperlink{def-elint}{\texttt{ELInt}}(#1)}
+\newcommand\ELInt[1]{\overbracket{#1}^{\hyperlink{def-elint}{\ELiteral(\lint)}}}
+\newcommand\AbbrevConstraintExact[1]{\overbracket{#1}^{\hyperlink{def-abbrevconstraintexact}{\scriptscriptstyle{\ConstraintExact}}}}
+\newcommand\AbbrevConstraintRange[2]{\overbracket{#1..#2}^{\hyperlink{def-abbrevconstraintrange}{\scriptscriptstyle{\ConstraintRange}}}}
+\newcommand\AbbrevEBinop[3]{\overbracket{#2\ #1\ #3}^{\hyperlink{def-abbrevebinop}{\scriptscriptstyle{\EBinop}}}}
+\newcommand\AbbrevTArray[2]{\overbracket{\texttt{array }[#1]\texttt{ of }#2}^{\hyperlink{def-tarrayshort}{\scriptscriptstyle{\TArray}}}}
+% \newcommand\AbbrevArrayLengthExpr[1]{\overbracket{#1}^{\hyperlink{def-arraylengthexpr}{\scriptscriptstyle{\ArrayLengthExpr}}}}
+% \newcommand\AbbrevArrayLengthEnum[2]{\overbracket{\texttt{enum }#1 |#2|}^{\hyperlink{def-arraylengthenum}{\scriptscriptstyle{\ArrayLengthEnum}}}}
+\newcommand\AbbrevTArrayLengthExpr[2]{\overbracket{\texttt{array }[#1]\texttt{ of }#2}^{\hyperlink{def-abbrevtarraylengthexpr}{\scriptscriptstyle{\TArray(\ArrayLengthExpr)}}}}
+\newcommand\AbbrevTArrayLengthEnum[3]{\overbracket{\texttt{array }[#1 \# #2]\texttt{ of }#3}^{\hyperlink{def-abbrevtarraylengthenum}{\scriptscriptstyle{\TArray(\ArrayLengthEnum)}}}}
 
 % Glossary
 \newcommand\parameterizedintegertype[0]{\hyperlink{def-parameterizedintegertype}{parameterized integer type}}
@@ -230,93 +247,92 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Type functions
-\newcommand\CheckUnop[0]{\hyperlink{def-checkunop}{\texttt{check\_unop}}}
-\newcommand\CheckBinop[0]{\hyperlink{def-checkbinop}{\texttt{check\_binop}}}
-\newcommand\constraintsbinop[0]{\hyperlink{def-constraintbinops}{\texttt{constraints\_binop}}}
-\newcommand\constraintbinop[0]{\hyperlink{def-constraintbinop}{\texttt{constraint\_binop}}}
-\newcommand\isrightincreasing[0]{\hyperlink{def-isrightincreasing}{\texttt{is\_right\_increasing}}}
-\newcommand\isrightdecreasing[0]{\hyperlink{def-isrightdecreasing}{\texttt{is\_right\_decreasing}}}
-\newcommand\isleftincreasing[0]{\hyperlink{def-isleftincreasing}{\texttt{is\_left\_increasing}}}
-\newcommand\annotateconstraintbinop[0]{\hyperlink{def-annotateconstraintbinop}{\texttt{annotate\_constraint\_binop}}}
-\newcommand\explodeintervals[0]{\hyperlink{def-explodeintervals}{\texttt{explode\_intervals}}}
-\newcommand\explodeconstraint[0]{\hyperlink{def-explodeconstraint}{\texttt{explode\_constraint}}}
-\newcommand\intervaltoolarge[0]{\hyperlink{def-intervaltoolarge}{\texttt{interval\_too\_large}}}
-\newcommand\binopisexploding[0]{\hyperlink{def-binopisexploding}{\texttt{binop\_is\_exploding}}}
-\newcommand\binopfilterrhs[0]{\hyperlink{def-binopfilter}{\texttt{binop\_filter\_rhs}}}
-\newcommand\refineconstraintbysign[0]{\hyperlink{def-refineconstraintbysign}{\texttt{refine\_constraint\_by\_sign}}}
-\newcommand\reducetozopt[0]{\hyperlink{def-reducetozopt}{\texttt{reduce\_to\_z\_opt}}}
-\newcommand\refineconstraints[0]{\hyperlink{def-refineconstraints}{\texttt{refine\_constraints}}}
-\newcommand\filterreduceconstraintdiv[0]{\hyperlink{def-filterreduceconstraintdiv}{\texttt{filter\_reduce\_constraint\_div}}}
-\newcommand\getliteraldivopt[0]{\hyperlink{def-getliteraldivopt}{\texttt{get\_literal\_div\_opt}}}
+\newcommand\CheckUnop[0]{\hyperlink{def-checkunop}{\textfunc{check\_unop}}}
+\newcommand\CheckBinop[0]{\hyperlink{def-checkbinop}{\textfunc{check\_binop}}}
+\newcommand\constraintbinop[0]{\hyperlink{def-constraintbinop}{\textfunc{constraint\_binop}}}
+\newcommand\constraintbinoppair[0]{\hyperlink{def-constraintbinoppair}{\textfunc{constraint\_binop\_pair}}}
+\newcommand\isrightincreasing[0]{\hyperlink{def-isrightincreasing}{\textfunc{is\_right\_increasing}}}
+\newcommand\isrightdecreasing[0]{\hyperlink{def-isrightdecreasing}{\textfunc{is\_right\_decreasing}}}
+\newcommand\isleftincreasing[0]{\hyperlink{def-isleftincreasing}{\textfunc{is\_left\_increasing}}}
+\newcommand\annotateconstraintbinop[0]{\hyperlink{def-annotateconstraintbinop}{\textfunc{annotate\_constraint\_binop}}}
+\newcommand\explodeintervals[0]{\hyperlink{def-explodeintervals}{\textfunc{explode\_intervals}}}
+\newcommand\explodeconstraint[0]{\hyperlink{def-explodeconstraint}{\textfunc{explode\_constraint}}}
+\newcommand\intervaltoolarge[0]{\hyperlink{def-intervaltoolarge}{\textfunc{interval\_too\_large}}}
+\newcommand\binopisexploding[0]{\hyperlink{def-binopisexploding}{\textfunc{binop\_is\_exploding}}}
+\newcommand\binopfilterrhs[0]{\hyperlink{def-binopfilterrhs}{\textfunc{binop\_filter\_rhs}}}
+\newcommand\refineconstraintbysign[0]{\hyperlink{def-refineconstraintbysign}{\textfunc{refine\_constraint\_by\_sign}}}
+\newcommand\reducetozopt[0]{\hyperlink{def-reducetozopt}{\textfunc{reduce\_to\_z\_opt}}}
+\newcommand\refineconstraints[0]{\hyperlink{def-refineconstraints}{\textfunc{refine\_constraints}}}
+\newcommand\filterreduceconstraintdiv[0]{\hyperlink{def-filterreduceconstraintdiv}{\textfunc{filter\_reduce\_constraint\_div}}}
+\newcommand\getliteraldivopt[0]{\hyperlink{def-getliteraldivopt}{\textfunc{get\_literal\_div\_opt}}}
 \newcommand\checkslicesinwidth[0]{\tododefine{check\_slices\_in\_width}}
 \newcommand\disjointslicestopositions[0]{\tododefine{disjoint\_slices\_to\_positions}}
 \newcommand\checkpositionsinwidth[0]{\tododefine{check\_positions\_in\_width}}
 \newcommand\shouldslicesreducetocall[0]{\tododefine{should\_slices\_reduce\_to\_call}}
 \newcommand\checkdisjointslices[0]{\tododefine{check\_disjoint\_slices}}
-\newcommand\sliceswidth[0]{\texttt{slices\_width}}
-\newcommand\annotatetype[1]{\hyperlink{def-annotatetype}{\texttt{annotate\_type}}(#1)}
-\newcommand\annotateconstraint[0]{\hyperlink{def-annotateconstraint}{\texttt{annotate\_constraint}}}
-\newcommand\getvariableenum[0]{\hyperlink{def-getvariableenum}{\texttt{get\_variable\_enum}}}
-\newcommand\annotateexpr[1]{\hyperlink{def-annotateexpr}{\texttt{annotate\_expr}}(#1)}
-\newcommand\annotateexprlist[0]{\hyperlink{def-annotateexprs}{\texttt{annotate\_exprs}}}
-\newcommand\annotatelooplimit[0]{\hyperlink{def-annotatelooplimit}{\texttt{annotate\_loop\_limit}}}
-\newcommand\annotatelexpr[1]{\hyperlink{def-annotatelexpr}{\texttt{annotate\_lexpr}}(#1)}
-\newcommand\annotatearrayindex[0]{\texttt{annotate\_array\_index}}
-\newcommand\annotateslice[0]{\hyperlink{def-annotateslice}{\texttt{annotate\_slice}}}
-\newcommand\annotateslices[0]{\hyperlink{def-annotateslices}{\texttt{annotate\_slices}}}
-\newcommand\annotatepattern[0]{\hyperlink{def-annotatepattern}{\texttt{annotate\_pattern}}}
-\newcommand\annotatelocaldeclitem[1]{\hyperlink{def-annotatelocaldeclitem}{\texttt{annotate\_local\_decl\_item}}(#1)}
-\newcommand\annotatestmt[0]{\hyperlink{def-annotatestmt}{\texttt{annotate\_stmt}}}
-\newcommand\annotateblock[1]{\hyperlink{def-annotateblock}{\texttt{annotate\_block}}(#1)}
-\newcommand\inlinesetter[1]{\texttt{setter\_should\_reduce\_to\_call\_s}(#1)}
-\newcommand\annotatecall[0]{\hyperlink{def-annotatecall}{\texttt{annotate\_call}}}
-\newcommand\annotatecallargtyped[0]{\hyperlink{def-annotatecallargtyped}{\texttt{annotate\_call\_arg\_typed}}}
-\newcommand\annotateparameterdefining[0]{\hyperlink{def-annotateparameterdefining}{\texttt{annotate\_parameter\_defining}}}
-\newcommand\annotatecatcher[1]{\hyperlink{def-annotatecatcher}{\texttt{annotate\_catcher}}(#1)}
-\newcommand\reduceconstants[0]{\hyperlink{def-reduceconstants}{\texttt{reduce\_constants}}}
-\newcommand\reduceconstraint[0]{\hyperlink{def-reduceconstraint}{\texttt{reduce\_constraint}}}
-\newcommand\reduceconstraints[0]{\hyperlink{def-reduceconstraints}{\texttt{reduce\_constraints}}}
-\newcommand\declarelocalconstant[1]{\texttt{declare\_local\_constant}(#1)}
-\newcommand\annotatelocaldeclitemuninit[1]{\texttt{annotate\_local\_decl\_item\_uninit}(#1)}
-\newcommand\checkvarnotinenv[1]{\hyperlink{def-checkvarnotinenv}{\texttt{check\_var\_not\_in\_env}}(#1)}
-\newcommand\checkvarnotingenv[1]{\hyperlink{def-checkvarnotingenv}{\texttt{check\_var\_not\_in\_genv}}(#1)}
-\newcommand\varinenv[1]{\hyperlink{def-varinenv}{\texttt{var\_in\_env}}(#1)}
-\newcommand\annotatesubprogram[1]{\hyperlink{def-annotatesubprogram}{\texttt{annotate\_subprogram}}(#1)}
-\newcommand\annotatedecl[1]{\hyperlink{def-annotatedecl}{\texttt{annotate\_decl}}(#1)}
-\newcommand\declaredecl[1]{\hyperlink{def-declaredecl}{\texttt{declare\_decl}}(#1)}
-\newcommand\typecheckast[0]{\hyperlink{def-typecheckast}{\texttt{type\_check\_ast}}}
-\newcommand\SCC[0]{\hyperlink{def-scc}{\texttt{SCC}}}
-\newcommand\topologicalordering[0]{\hyperlink{def-topologicalordering}{\texttt{topological\_ordering}}}
-\newcommand\declsofcomp[0]{\hyperlink{def-declsofcomp}{\texttt{decls\_of\_comp}}}
-\newcommand\sortcomponents[0]{\hyperlink{def-sortcomponents}{\texttt{sort\_components}}}
-\newcommand\annotatedeclcomps[0]{\hyperlink{def-annotatedeclcomps}{\texttt{annotate\_decl\_comps}}}
-\newcommand\evalexpr[1]{\texttt{eval\_expr}(#1)}
-\newcommand\evalconstraint[1]{\texttt{eval\_constraint}(#1)}
-\newcommand\annotateliteral[1]{\hyperlink{def-annotateliteral}{\texttt{annotate\_literal}}(#1)}
-\newcommand\exprequalcase[0]{\hyperlink{def-exprequalcase}{\texttt{expr\_equal\_case}}}
-\newcommand\exprequalnorm[0]{\hyperlink{def-exprequalnorm}{\texttt{expr\_equal\_norm}}}
-\newcommand\slicesequal[0]{\hyperlink{def-slicesequal}{\texttt{slices\_equal}}}
-\newcommand\sliceequal[0]{\hyperlink{def-sliceequal}{\texttt{slice\_equal}}}
-\newcommand\constraintsequal[0]{\hyperlink{def-constraintsequal}{\texttt{constraints\_equal}}}
-\newcommand\constraintequal[0]{\hyperlink{def-constraintequal}{\texttt{constraint\_equal}}}
-\newcommand\arraylengthequal[0]{\hyperlink{def-arraylengthequal}{\texttt{array\_length\_equal}}}
-\newcommand\literalequal[0]{\hyperlink{def-literalequal}{\texttt{literal\_equal}}}
-\newcommand\finddeducecheck[0]{\hyperlink{def-finddeducecheck}{\texttt{find\_deduce\_check}}}
-\newcommand\annotatebitfield[0]{\hyperlink{def-annotatebitfield}{\texttt{annotate\_bitfield}}}
-\newcommand\annotatebitfields[0]{\hyperlink{def-annotatebitfields}{\texttt{annotate\_bitfields}}}
-\newcommand\checknoduplicates[0]{\hyperlink{def-checknoduplicates}{\texttt{check\_no\_duplicates}}}
-\newcommand\reduceslicestocall[0]{\hyperlink{def-reduceslicestocall}{\texttt{reduce\_slices\_to\_call}}}
-\newcommand\typeofarraylength[0]{\hyperlink{def-typeofarraylength}{\texttt{type\_of\_array\_length}}}
-\newcommand\addlocal[0]{\hyperlink{def-addlocal}{\texttt{add\_local}}}
-\newcommand\declaretype[0]{\hyperlink{def-declaretype}{\texttt{declare\_type}}}
-\newcommand\subprogramtypesclash[0]{\hyperlink{def-subprogramtypeclash}{\texttt{subprogram\_types\_clash}}}
-\newcommand\subprogramforname[0]{\hyperlink{def-subprogramforname}{\texttt{subprogram\_for\_name}}}
-\newcommand\hasargclash[0]{\hyperlink{def-hasargclash}{\texttt{has\_arg\_clash}}}
-\newcommand\filtercallcandidates[0]{\hyperlink{def-filtercandidates}{\texttt{filter\_call\_candidates}}}
-\newcommand\deduceeqs[0]{\hyperlink{def-deduceeqs}{\texttt{deduce\_eqs}}}
-\newcommand\getundeclareddefining[0]{\hyperlink{def-getundeclareddefining}{\texttt{get\_undeclared\_defining}}}
+\newcommand\annotatetype[1]{\hyperlink{def-annotatetype}{\textfunc{annotate\_type}}(#1)}
+\newcommand\annotateconstraint[0]{\hyperlink{def-annotateconstraint}{\textfunc{annotate\_constraint}}}
+\newcommand\getvariableenum[0]{\hyperlink{def-getvariableenum}{\textfunc{get\_variable\_enum}}}
+\newcommand\annotateexpr[1]{\hyperlink{def-annotateexpr}{\textfunc{annotate\_expr}}(#1)}
+\newcommand\annotateexprlist[0]{\hyperlink{def-annotateexprs}{\textfunc{annotate\_exprs}}}
+\newcommand\annotatelooplimit[0]{\hyperlink{def-annotatelooplimit}{\textfunc{annotate\_loop\_limit}}}
+\newcommand\annotatelexpr[1]{\hyperlink{def-annotatelexpr}{\textfunc{annotate\_lexpr}}(#1)}
+\newcommand\annotatearrayindex[0]{\textfunc{annotate\_array\_index}}
+\newcommand\annotateslice[0]{\hyperlink{def-annotateslice}{\textfunc{annotate\_slice}}}
+\newcommand\annotateslices[0]{\hyperlink{def-annotateslices}{\textfunc{annotate\_slices}}}
+\newcommand\annotatepattern[0]{\hyperlink{def-annotatepattern}{\textfunc{annotate\_pattern}}}
+\newcommand\annotatelocaldeclitem[1]{\hyperlink{def-annotatelocaldeclitem}{\textfunc{annotate\_local\_decl\_item}}(#1)}
+\newcommand\annotatestmt[0]{\hyperlink{def-annotatestmt}{\textfunc{annotate\_stmt}}}
+\newcommand\annotateblock[1]{\hyperlink{def-annotateblock}{\textfunc{annotate\_block}}(#1)}
+\newcommand\inlinesetter[0]{\tododefine{setter\_should\_reduce\_to\_call\_s}}
+\newcommand\annotatecall[0]{\hyperlink{def-annotatecall}{\textfunc{annotate\_call}}}
+\newcommand\annotatecallargtyped[0]{\hyperlink{def-annotatecallargtyped}{\textfunc{annotate\_call\_arg\_typed}}}
+\newcommand\annotateparameterdefining[0]{\hyperlink{def-annotateparameterdefining}{\textfunc{annotate\_parameter\_defining}}}
+\newcommand\annotatecatcher[1]{\hyperlink{def-annotatecatcher}{\textfunc{annotate\_catcher}}(#1)}
+\newcommand\reduceconstants[0]{\hyperlink{def-reduceconstants}{\textfunc{reduce\_constants}}}
+\newcommand\reduceconstraint[0]{\hyperlink{def-reduceconstraint}{\textfunc{reduce\_constraint}}}
+\newcommand\reduceconstraints[0]{\hyperlink{def-reduceconstraints}{\textfunc{reduce\_constraints}}}
+\newcommand\declarelocalconstant[0]{\hyperlink{def-declarelocalconstant}{\textfunc{declare\_local\_constant}}}
+\newcommand\annotatelocaldeclitemuninit[0]{\hyperlink{def-annotatelocaldeclitemuninit}{\textfunc{annotate\_local\_decl\_item\_uninit}}}
+\newcommand\checkvarnotinenv[1]{\hyperlink{def-checkvarnotinenv}{\textfunc{check\_var\_not\_in\_env}}(#1)}
+\newcommand\checkvarnotingenv[1]{\hyperlink{def-checkvarnotingenv}{\textfunc{check\_var\_not\_in\_genv}}(#1)}
+\newcommand\varinenv[1]{\hyperlink{def-varinenv}{\textfunc{var\_in\_env}}(#1)}
+\newcommand\annotatesubprogram[1]{\hyperlink{def-annotatesubprogram}{\textfunc{annotate\_subprogram}}(#1)}
+\newcommand\annotatedecl[1]{\hyperlink{def-annotatedecl}{\textfunc{annotate\_decl}}(#1)}
+\newcommand\declaredecl[1]{\hyperlink{def-declaredecl}{\textfunc{declare\_decl}}(#1)}
+\newcommand\typecheckast[0]{\hyperlink{def-typecheckast}{\textfunc{type\_check\_ast}}}
+\newcommand\SCC[0]{\hyperlink{def-scc}{\textfunc{SCC}}}
+\newcommand\topologicalordering[0]{\hyperlink{def-topologicalordering}{\textfunc{topological\_ordering}}}
+\newcommand\declsofcomp[0]{\hyperlink{def-declsofcomp}{\textfunc{decls\_of\_comp}}}
+\newcommand\sortcomponents[0]{\hyperlink{def-sortcomponents}{\textfunc{sort\_components}}}
+\newcommand\annotatedeclcomps[0]{\hyperlink{def-annotatedeclcomps}{\textfunc{annotate\_decl\_comps}}}
+\newcommand\evalexpr[1]{\textfunc{eval\_expr}(#1)}
+\newcommand\evalconstraint[1]{\textfunc{eval\_constraint}(#1)}
+\newcommand\annotateliteral[1]{\hyperlink{def-annotateliteral}{\textfunc{annotate\_literal}}(#1)}
+\newcommand\exprequalcase[0]{\hyperlink{def-exprequalcase}{\textfunc{expr\_equal\_case}}}
+\newcommand\exprequalnorm[0]{\hyperlink{def-exprequalnorm}{\textfunc{expr\_equal\_norm}}}
+\newcommand\slicesequal[0]{\hyperlink{def-slicesequal}{\textfunc{slices\_equal}}}
+\newcommand\sliceequal[0]{\hyperlink{def-sliceequal}{\textfunc{slice\_equal}}}
+\newcommand\constraintsequal[0]{\hyperlink{def-constraintsequal}{\textfunc{constraints\_equal}}}
+\newcommand\constraintequal[0]{\hyperlink{def-constraintequal}{\textfunc{constraint\_equal}}}
+\newcommand\arraylengthequal[0]{\hyperlink{def-arraylengthequal}{\textfunc{array\_length\_equal}}}
+\newcommand\literalequal[0]{\hyperlink{def-literalequal}{\textfunc{literal\_equal}}}
+\newcommand\finddeducecheck[0]{\hyperlink{def-finddeducecheck}{\textfunc{find\_deduce\_check}}}
+\newcommand\annotatebitfield[0]{\hyperlink{def-annotatebitfield}{\textfunc{annotate\_bitfield}}}
+\newcommand\annotatebitfields[0]{\hyperlink{def-annotatebitfields}{\textfunc{annotate\_bitfields}}}
+\newcommand\checknoduplicates[0]{\hyperlink{def-checknoduplicates}{\textfunc{check\_no\_duplicates}}}
+\newcommand\reduceslicestocall[0]{\hyperlink{def-reduceslicestocall}{\textfunc{reduce\_slices\_to\_call}}}
+\newcommand\typeofarraylength[0]{\hyperlink{def-typeofarraylength}{\textfunc{type\_of\_array\_length}}}
+\newcommand\addlocal[0]{\hyperlink{def-addlocal}{\textfunc{add\_local}}}
+\newcommand\declaretype[0]{\hyperlink{def-declaretype}{\textfunc{declare\_type}}}
+\newcommand\subprogramtypesclash[0]{\hyperlink{def-subprogramtypeclash}{\textfunc{subprogram\_types\_clash}}}
+\newcommand\subprogramforname[0]{\hyperlink{def-subprogramforname}{\textfunc{subprogram\_for\_name}}}
+\newcommand\hasargclash[0]{\hyperlink{def-hasargclash}{\textfunc{has\_arg\_clash}}}
+\newcommand\filtercallcandidates[0]{\hyperlink{def-filtercandidates}{\textfunc{filter\_call\_candidates}}}
+\newcommand\deduceeqs[0]{\hyperlink{def-deduceeqs}{\textfunc{deduce\_eqs}}}
+\newcommand\getundeclareddefining[0]{\hyperlink{def-getundeclareddefining}{\textfunc{get\_undeclared\_defining}}}
 \newcommand\bintounsigned[0]{\hyperlink{def-bintounsigned}{\textsf{binary\_to\_unsigned}}}
-\newcommand\inttobits[0]{\hyperlink{def-inttobits}{\texttt{int\_to\_bits}}}
+\newcommand\inttobits[0]{\hyperlink{def-inttobits}{\textfunc{int\_to\_bits}}}
 
 % Symbolic domain subsumption
 \newcommand\symdom[0]{\hyperlink{def-symdom}{\textsf{sym\_dom}}}
@@ -335,20 +351,21 @@
 \newcommand\Top[0]{\hyperlink{def-top}{\textsf{Top}}}
 \newcommand\FromSyntax[0]{\hyperlink{def-fromsymtax}{\textsf{FromSyntax}}}
 
-\newcommand\symdomoftype[0]{\hyperlink{def-symdomoftype}{\texttt{symdom\_of\_type}}}
-\newcommand\symdomofexpr[0]{\hyperlink{def-symdomofexpr}{\texttt{symdom\_of\_expr}}}
-\newcommand\symdomofliteral[0]{\hyperlink{def-symdomofliteral}{\texttt{symdom\_of\_literal}}}
-\newcommand\intsetofintconstraints[0]{\hyperlink{def-intsetofintconstraintse}{\texttt{intset\_of\_intconstraints}}}
-\newcommand\symdomissubset[0]{\hyperlink{def-symdomissubset}{\texttt{symdom\_is\_subset}}}
-\newcommand\constrainttointset[0]{\hyperlink{def-constrainttointset}{\texttt{constraint\_to\_intset}}}
-\newcommand\normalizetoint[0]{\hyperlink{def-normalizetoint}{\texttt{normalize\_to\_int}}}
-\newcommand\symintsetsubset[0]{\hyperlink{def-symintsetsubset}{\texttt{sym\_intset\_subset}}}
-\newcommand\intsetop[0]{\hyperlink{def-intsetop}{\texttt{intset\_op}}}
-\newcommand\intsettointconstraints[0]{\hyperlink{def-intsettointconstraints}{\texttt{int\_set\_to\_int\_constraints}}}
+\newcommand\symdomoftype[0]{\hyperlink{def-symdomoftype}{\textfunc{symdom\_of\_type}}}
+\newcommand\symdomofexpr[0]{\hyperlink{def-symdomofexpr}{\textfunc{symdom\_of\_expr}}}
+\newcommand\symdomofliteral[0]{\hyperlink{def-symdomofliteral}{\textfunc{symdom\_of\_literal}}}
+\newcommand\intsetofintconstraints[0]{\hyperlink{def-intsetofintconstraintse}{\textfunc{intset\_of\_intconstraints}}}
+\newcommand\symdomissubset[0]{\hyperlink{def-symdomissubset}{\textfunc{symdom\_is\_subset}}}
+\newcommand\constrainttointset[0]{\hyperlink{def-constrainttointset}{\textfunc{constraint\_to\_intset}}}
+\newcommand\normalizetoint[0]{\hyperlink{def-normalizetoint}{\textfunc{normalize\_to\_int}}}
+\newcommand\symintsetsubset[0]{\hyperlink{def-symintsetsubset}{\textfunc{sym\_intset\_subset}}}
+\newcommand\intsetop[0]{\hyperlink{def-intsetop}{\textfunc{intset\_op}}}
+\newcommand\intsettointconstraints[0]{\hyperlink{def-intsettointconstraints}{\textfunc{int\_set\_to\_int\_constraints}}}
 
 %% Type Error Codes
 \newcommand\TypeErrorCode[1]{\texttt{TE\_#1}}
 \newcommand\UndefinedIdentifier[0]{\hyperlink{def-undefinedidentifier}{\TypeErrorCode{UI}}}
+\newcommand\LengthsMismatch[0]{\hyperlink{def-lengthsmismatch}{\TypeErrorCode{LMM}}}
 \newcommand\SetterWithoutGetter[0]{\hyperlink{def-setterwithoutgetter}{\TypeErrorCode{SWG}}}
 \newcommand\ExpectedBitvectorType[0]{\hyperlink{def-expectedbitvectortype}{\TypeErrorCode{EBT}}}
 \newcommand\SubrogramDeclaredMultipleTimes[0]{\hyperlink{def-subprogramdeclaredmultipletimes}{\TypeErrorCode{SDM}}}
@@ -360,11 +377,18 @@
 \newcommand\CallBadArity[0]{\hyperlink{def-cba}{\TypeErrorCode{CBA}}}
 \newcommand\BadRecursiveDecls[0]{\hyperlink{def-brd}{\TypeErrorCode{BRA}}}
 \newcommand\RequireIntegerForLoopBounds[0]{\hyperlink{def-lbi}{\TypeErrorCode{LBI}}}
-\newcommand\RequireStructuredType[0]{\hyperlink{def-rst}{\TypeErrorCode{RST}}}
+\newcommand\ExpectedStructuredType[0]{\hyperlink{def-expectedstructuredtype}{\TypeErrorCode{EST}}}
+\newcommand\ExpectedTupleType[0]{\hyperlink{def-expectedtupletype}{\TypeErrorCode{ETT}}}
 \newcommand\MissingFieldInitializer[0]{\hyperlink{def-mfi}{\TypeErrorCode{MFI}}}
 \newcommand\RequireSameBitwidths[0]{\hyperlink{def-rsb}{\TypeErrorCode{RSB}}}
 \newcommand\TypeAsssertionFails[0]{\hyperlink{def-taf}{\TypeErrorCode{TAF}}}
 \newcommand\BinaryOperationFailsAllConstraints[0]{\hyperlink{def-ofc}{\TypeErrorCode{OFC}}}
+\newcommand\InvalidOperandTypesForBinop[0]{\hyperlink{def-otb}{\TypeErrorCode{OTB}}}
+\newcommand\ExpectedEnumerationType[0]{\hyperlink{def-expectedenumerationtype}{\TypeErrorCode{EET}}}
+\newcommand\AnnonymousFormNotAllowedHere[0]{\hyperlink{def-iaf}{\TypeErrorCode{IAF}}}
+\newcommand\AssignmentToImmutable[0]{\hyperlink{def-aim}{\TypeErrorCode{AIM}}}
+\newcommand\MissingField[0]{\hyperlink{def-mf}{\TypeErrorCode{MF}}}
+\newcommand\DivIntIndivisible[0]{\hyperlink{def-dii}{\TypeErrorCode{DII}}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Typeset variable names
@@ -692,8 +716,8 @@ The intuitive meaning of each component is as follows:
 The global environment and local environment consist of various components.
 We use the notation $G^\tenv.m$ and $L^\tenv.m$ to access the $m$ component of a given environment.
 
-To update a function component $f$ (e.g., $\declaredtypes$) of an environment $\tenv$ (either local or global)
-with a new mapping $x \mapsto v$, we use the notation $\tenv.f[x \mapsto v]$ to stand for $\tenv[f \mapsto E.f[x \mapsto v]]$.
+To update a function component $f$ (e.g., $\declaredtypes$) of a global or local environment $E$
+with a new mapping $x \mapsto v$, we use the notation $\tenv.f[x \mapsto v]$ to stand for $E[f \mapsto E.f[x \mapsto v]]$.
 
 \lrmcomment{This is related to \identd{JRXM} and \identi{ZTMQ}.}
 
@@ -790,11 +814,29 @@ Typing a specification consists of annotating the root of its AST with the rules
 in the remainder of this document.
 
 \paragraph{Shorthand Notations:}
-\hypertarget{def-elint}{}
-We use the shorthand $\ELInt{n}$ for the expression denoting the literal integer value $n$. That is, $\ELiteral(\overname{\lint(n)}{\vr})$.
 
 \hypertarget{def-unconstrainedinteger}{}
 We use the shorthand notation $\unconstrainedinteger$ to denote the unconstrained integer type: $\TInt(\unconstrained)$.
+
+We employ the following abbreviations for various AST nodes:
+\begin{center}
+\begin{tabular}{ll}
+\hline
+\textbf{Abbreviation} & \textbf{Meaning}
+\hypertarget{def-elint}{}\\
+\hline
+$\ELInt{n}$ & literal integer expression: $\ELiteral(\lint(n))$
+\hypertarget{def-abbrevconstraintexact}{}\\
+$\AbbrevConstraintExact{\ve}$ & $\ConstraintExact(\ve)$
+\hypertarget{def-abbrevconstraintrange}{}\\
+$\AbbrevConstraintRange{\veone}{\vetwo}$ & $\ConstraintRange(\veone, \vetwo)$ \hypertarget{def-abbrevebinop}{}\\
+$\AbbrevEBinop{\op}{\veone}{\vetwo}$ & $\EBinop(\op, \veone, \vetwo)$ \hypertarget{def-abbrevtarraylengthexpr}{}\\
+$\AbbrevTArray{\vi}{\vt}$ & $\TArray(\ArrayLengthExpr(\vi), \vt)$ \hypertarget{def-abbrevtarray}{}\\
+$\AbbrevTArrayLengthExpr{\ve}{\vt}$ & $\TArray(\ArrayLengthExpr(\ve), \vt)$ \hypertarget{def-abbrevtarraylengthenum}{}\\
+$\AbbrevTArrayLengthEnum{\ve}{\vs}{\vt}$ & $\TArray(\ArrayLengthEnum(\ve, \vs), \vt)$\\
+\hline
+\end{tabular}
+\end{center}
 
 Note that throughout this document we use $\tty$ to denote a type variable, which should not be confused with the abstract syntax variable $\ty$.
 
@@ -861,7 +903,7 @@ We define the following types of native values:
   \tstring    &\triangleq& \{ \nvstring(s) \;|\; s \in \Strings\}  \hypertarget{def-tbitvector}{}\\
   \tbitvector &\triangleq& \{ \nvbitvector(\textit{bits}) \;|\; \textit{bits} \in \{0,1\}^*\}   \hypertarget{def-tvector}{}\\
   \tvector    &\triangleq& \{ \nvvector{\textit{vals}} \;|\; \textit{vals} \in \vals^*\}        \hypertarget{def-trecord}{}\\
-  \trecord  &\triangleq& \{ \nvrecord{\fieldmap} \;|\; \fieldmap \in \Identifiers\rightarrow\vals\}\\
+  \trecord  &\triangleq& \{ \nvrecord{\fieldmap} \;|\; \fieldmap \in \Identifiers\rightarrowfin\vals\}\\
 \end{array}
 \]
 
@@ -976,7 +1018,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
   \item All of the following apply (\textsc{t\_int\_well\_constrained}):
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type $\TInt(\wellconstrained(\vc_{1..k}))$;
-    \item $\vd$ is the union of the dynamic domains of each of the constraints $vc_{1..k}$ in $\env$.
+    \item $\vd$ is the union of the dynamic domains of each of the constraints $\vc_{1..k}$ in $\env$.
   \end{itemize}
 
   \item All of the following apply (\textsc{constraint\_exact\_okay}):
@@ -998,8 +1040,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item evaluating $\veone$ in $\env$, results in a configuration with the native integer for $a$;
     \item evaluating $\vetwo$ in $\env$, results in a configuration with the native integer for $b$;
-    \item $a$ is less than or equal to $b$;
-    \item $\vd$ is the set containing all native integer values for integers from $a$ to $b$, inclusive.
+    \item $\vd$ is the set containing all native integer values for integers greater or equal to $a$ and less than or equal to $b$.
   \end{itemize}
 
   \item All of the following apply (\textsc{constraint\_range\_dynamic\_error1}):
@@ -2019,7 +2060,7 @@ The underlying type of \texttt{(integer, T2)} and \texttt{T3} is
 \hypertarget{def-checkconstrainedinteger}{}
 The function
 \[
-  \checkconstrainedinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\tty}) \aslto \True \cup \overname{\TTypeError}{\TypeErrorConfig}
+  \checkconstrainedinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\tty}) \aslto \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 checks whether the type $\vt$ is a \constrainedinteger. If so, the result is $\True$, otherwise a type error is returned.
 
@@ -2118,7 +2159,7 @@ We also define the helper rule TypingRule.FindNamedLCA (\secref{TypingRule.FindN
 
 \section{TypingRule.Subtype\label{sec:TypingRule.Subtype}}
 The \emph{subtype} relation is a partial order over \underline{named types}.
-The \emph{supertype} is the symmetric relation. That is, \tty\ is a supertype of \tsy\ if and only if \tsy\ is a subtype of \tty.
+The \emph{supertype} is the inverse relation. That is, \tty\ is a supertype of \tsy\ if and only if \tsy\ is a subtype of \tty.
 
 \hypertarget{def-subtypesrel}{}
 The predicate
@@ -2487,30 +2528,43 @@ One of the following applies:
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule[error1]{
-  \tstruct(\tenv, \vs) \typearrow \TypeErrorConfig\\
+\inferrule[error]{
+  (\tstruct(\tenv, \vs) \typearrow \TypeErrorConfig) \lor (\tstruct(\tenv, \vt) \typearrow \TypeErrorConfig)\\
 }{
   \domsubtypesat(\tenv, \vt, \vs) \typearrow \TypeErrorConfig
 }
-\and
-\inferrule[error2]{
-  \tstruct(\tenv, \vs) \typearrow \vsstruct\\
-  \tstruct(\tenv, \vt) \typearrow \TypeErrorConfig\\
-}{
-  \domsubtypesat(\tenv, \vt, \vs) \typearrow \TypeErrorConfig
-}
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[simple]{
   \tstruct(\tenv, \vs) \typearrow \vsstruct\\
-  \astlabel(\vsstruct) \in \{\TTuple, \TArray, \TRecord, \TException\}
+  {
+    \left(\begin{array}{ll}
+  \astlabel(\vsstruct) \in \{\TTuple, \TArray, \TRecord, \TException\} & \lor\\
+  \vsstruct \in \{\TReal, \TString, \TBool, \TEnum, \unconstrainedinteger\} &
+    \end{array}\right)
+  }
 }{
   \domsubtypesat(\tenv, \vt, \vs) \typearrow \True
 }
-\and
-\inferrule[symbolic]{
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[constrained\_int\_enum]{
   \tstruct(\tenv, \vs) \typearrow \vsstruct\\
   \tstruct(\tenv, \vt) \typearrow \vtstruct\\
-  \astlabel(\vsstruct) \in \{\TReal, \TString, \TBool, \TEnum, \TInt\}\\
+  (\vsstruct = \TInt(\vc) \land \vc \neq \unconstrained) \lor \astlabel(\vsstruct) = \TEnum\\
+  \symsubsumes(\tenv, \vsstruct, \vtstruct) \typearrow \vb
+}{
+  \domsubtypesat(\tenv, \vt, \vs) \typearrow \vb
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[bits]{
+  \tstruct(\tenv, \vs) \typearrow \vsstruct\\
+  \astlabel(\vsstruct) = \TBits\\
+  \tstruct(\tenv, \vt) \typearrow \vtstruct\\
   \symsubsumes(\tenv, \vsstruct, \vtstruct) \typearrow \vb
 }{
   \domsubtypesat(\tenv, \vt, \vs) \typearrow \vb
@@ -2570,7 +2624,7 @@ returning the result $\vb$ or a type error, if one is detected.
 We also define
 \[
   \checktypesat(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
-  \aslto \True \cup \overname{\TTypeError}{\TypeErrorConfig}
+  \aslto \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 which is the same as $\typesat$, but yields a type error when \\ $\typesat(\tenv, \vt, \vs)$ is $\False$.
 
@@ -2755,7 +2809,7 @@ returning the result $\vb$ or a type error, if one is detected.
 \subsection{Prose}
  One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{subtype1}, \textsc{subtype2}):
+  \item All of the following apply (\textsc{subtype}):
   \begin{itemize}
     \item either $\vs$ subtypes $\vt$ or $\vt$ subtypes $\vs$;
     \item $\vb$ is $\True$.
@@ -2821,15 +2875,8 @@ returning the result $\vb$ or a type error, if one is detected.
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule[subtype1]{
-  \subtypesrel(\tenv, \vs, \vt) \typearrow \True
-}{
-  \typeclashes(\tenv, \vt, \vs) \typearrow \overname{\True}{\vb}
-}
-\and
-\inferrule[subtype2]{
-  \subtypesrel(\tenv, \vs, \vt) \typearrow \False\\
-  \subtypesrel(\tenv, \vt, \vs) \typearrow \True
+\inferrule[subtype]{
+  (\subtypesrel(\tenv, \vs, \vt) \typearrow \True) \lor (\subtypesrel(\tenv, \vt, \vs) \typearrow \True)
 }{
   \typeclashes(\tenv, \vt, \vs) \typearrow \overname{\True}{\vb}
 }
@@ -2983,6 +3030,7 @@ One of the following applies:
 
     \item All of the following apply (\textsc{t\_int\_unconstrained}):
     \begin{itemize}
+      \item both $\vt$ and $\vs$ are integer types;
       \item at least one of $\vt$ or $\vs$ is an unconstrained integer type;
       \item $\tty$ is the unconstrained integer type.
     \end{itemize}
@@ -3003,37 +3051,25 @@ One of the following applies:
       \item $\tty$ is the well-constrained integer type with constraints $\cst \concat \css$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_bits\_equal}):
+    \item All of the following apply (\textsc{t\_bits}):
     \begin{itemize}
       \item $\vt$ is a bitvector type with with length expression $\vet$, that is, $\TBits(\vet, \Ignore)$;
       \item $\vs$ is a bitvector type with with length expression $\ves$, that is, $\TBits(\ves, \Ignore)$;
-      \item $\vet$ is equivalent to $\ves$ in $\tenv$;
+      \item applying $\typeequal$ to $\vt$ and $\vs$ in $\tenv$ yields $\False$;
+      \item applying $\exprequal$ to $\vet$ and $\ves$ in $\tenv$ yields $\vbequal$;
+      \item checking whether $\vbequal$ is $\True$ yields $\True$\ProseTerminateAs{\NoLCA};
       \item $\tty$ is a bitvector type with length expression $\vet$ and an empty bitfield list, that is, $\TBits(\vet, \emptylist)$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_bits\_not\_equal}):
-    \begin{itemize}
-      \item $\vt$ is a bitvector type with length expression $\vet$;
-      \item $\vs$ is a bitvector type with length expression $\ves$;
-      \item $\vet$ is not equivalent to $\ves$ in $\tenv$;
-      \item the result is a type error indicating the lack of a lowest common ancestor.
-    \end{itemize}
-
-    \item All of the following apply (\textsc{t\_array\_equal}):
+    \item All of the following apply (\textsc{t\_array}):
     \begin{itemize}
       \item $\vt$ is an array type with width expression $\widtht$ and element type $\vtyt$;
       \item $\vs$ is an array type with width expression $\widths$ and element type $\vtys$;
-      \item $\widtht$ is equivalent to $\widths$ in $\tenv$;
+      \item applying $\arraylengthequal$ to $\widtht$ and $\widths$ in $\tenv$ to equate the array lengths,
+            yields $\vbequallength$\ProseOrTypeError;
+      \item checking that $\vbequallength$ is $\True$ yields $\True$\ProseTerminateAs{\NoLCA};
       \item the lowest common ancestor of $\vtyt$ and $\vtys$ is $\vtone$\ProseOrTypeError;
       \item $\tty$ is an array type with width expression $\widths$ and element type $\vtone$.
-    \end{itemize}
-
-    \item All of the following apply (\textsc{t\_array\_not\_equal}):
-    \begin{itemize}
-      \item $\vt$ is an array type with width expression $\widtht$ and element type $\vtyt$;
-      \item $\vs$ is an array type with width expression $\widths$ and element type $\vtys$;
-      \item $\widtht$ is not equivalent to $\widths$ in $\tenv$;
-      \item the result is a type error indicating the lack of a lowest common ancestor.
     \end{itemize}
 
     \item All of the following apply (\textsc{t\_tuple}):
@@ -3043,11 +3079,13 @@ One of the following applies:
       \item checking whether $\vlit$ and $\vlis$ have the same number of elements yields $\True$
             or a type error, which short-circuits the entire rule (indicating that the number of elements in both tuples is expected
             to be the same and thus there is no lowest common ancestor);
-      \item $\vli[\vi]$ is the of types lowest common ancestor of $\vlit[\vi]$ and $\vlis[\vi]$, for every position of $\vlit$;
-      \item $\tty$ is the tuple type with list of types $\vli$, that is, $\TTuple(\vli)$.
+      \item applying $\lca$ to $\vlit[\vi]$ and $\vlis[\vi]$ in $\tenv$, for every position of $\vlit$,
+            yields $\vt_\vi$\ProseOrTypeError;
+      \item define $\vli$ to be the list of types $\vt_\vi$, for every position of $\vlit$;
+      \item define $\tty$ as the tuple type with list of types $\vli$, that is, $\TTuple(\vli)$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{labels}):
+    \item All of the following apply (\textsc{error}):
     \begin{itemize}
       \item either the AST labels of $\vt$ and $\vs$ are different, or one of them is $\TEnum$, $\TRecord$, or $\TException$;
       \item the result is a type error indicating the lack of a lowest common ancestor.
@@ -3068,7 +3106,7 @@ We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is \typeequivalent\
 \inferrule[type\_equal]{
   \typeequal(\tenv, \vt, \vs) \typearrow \True
 }{
-  \lca(\tenv, \vt, \vs) \typearrow \vs
+  \lca(\tenv, \vt, \vs) \typearrow \overname{\vs}{\tty}
 }
 \end{mathpar}
 
@@ -3093,7 +3131,7 @@ We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is \typeequivalent\
   \typeequal(\tenv, \vt, \vs) \typearrow \False\\
   \namedlca(\tenv, \namesubs, \namesubt) \typearrow \langle\name\rangle \OrTypeError\\
 }{
-  \lca(\tenv, \vt, \vs) \typearrow \TNamed(\name)
+  \lca(\tenv, \vt, \vs) \typearrow \overname{\TNamed(\name)}{\tty}
 }
 \end{mathpar}
 
@@ -3131,7 +3169,7 @@ We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is \typeequivalent\
   \astlabel(\vt) = \astlabel(\vs) = \TInt\\
   \isunconstrainedinteger(\vt) \lor \isunconstrainedinteger(\vs)
 }{
-  \lca(\tenv, \vt, \vs) \typearrow \unconstrainedinteger
+  \lca(\tenv, \vt, \vs) \typearrow \overname{\unconstrainedinteger}{\tty}
 }
 \and
 \inferrule[t\_int\_parameterized]{
@@ -3150,76 +3188,58 @@ We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is \typeequivalent\
 \inferrule[t\_int\_wellconstrained]
 {
   \typeequal(\tenv, \vt, \vs) \typearrow \False\\
-  \astlabel(\vt) = \astlabel(\vs) = \TInt\\
   \vt \eqname \TInt(\wellconstrained(\cst))\\
   \vs \eqname \TInt(\wellconstrained(\css))
 }{
-  \lca(\tenv, \vt, \vs) \typearrow \TInt(\wellconstrained(\cst \concat \css))
+  \lca(\tenv, \vt, \vs) \typearrow \overname{\TInt(\wellconstrained(\cst \concat \css))}{\tty}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[t\_bits\_equal]{
+\inferrule[t\_bits]{
   \typeequal(\tenv, \vt, \vs) \typearrow \False\\
-  \vt \eqname \TBits(\vet, \Ignore)\\
-  \vs \eqname \TBits(\ves, \Ignore)\\
-  \exprequal(\tenv, \vet, \ves) \typearrow \True
+  \exprequal(\tenv, \vet, \ves) \typearrow \vbequal\\
+  \checktrans{\vbequal}{\NoLCA} \checktransarrow \True \OrTypeError
 }{
-  \lca(\tenv, \vt, \vs) \typearrow \TBits(\vet, \emptylist)
-}
-\and
-\inferrule[t\_bits\_not\_equal]{
-  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
-  \vt \eqname \TBits(\vet, \Ignore)\\
-  \vs \eqname \TBits(\ves, \Ignore)\\
-  \exprequal(\tenv, \vet, \ves) \typearrow \False
-}{
-  \lca(\tenv, \vt, \vs) \typearrow \TypeErrorVal{\NoLCA}
+  \lca(\tenv, \overname{\TBits(\vet, \Ignore)}{\vt}, \overname{\TBits(\ves, \Ignore)}{\vs}) \typearrow \overname{\TBits(\vet, \emptylist)}{\tty}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[t\_array\_equal]{
+\inferrule[t\_array]{
   \typeequal(\tenv, \vt, \vs) \typearrow \False\\
-  \vt \eqname \TArray(\widtht, \vtyt)\\
-  \vs \eqname \TArray(\widths, \vtys)\\
-  \arraylengthequal(\tenv, \widtht, \widths) \typearrow \True\\
+  \arraylengthequal(\tenv, \widtht, \widths) \typearrow \vbequallength \OrTypeError\\\\
+  \checktrans{\vbequallength}{\NoLCA} \checktransarrow \True \OrTypeError\\\\
   \lca(\tenv, \vtyt, \vtys) \typearrow \vtone \OrTypeError
 }{
-  \lca(\tenv, \vt, \vs) \typearrow \TArray(\widtht, \vtone)
-}
-\and
-\inferrule[t\_array\_not\_equal]{
-  \typeequal(\tenv, \vt, \vs) \typearrow \False\\
-  \vt \eqname \TArray(\widtht, \vtyt)\\
-  \vs \eqname \TArray(\widths, \vtys)\\
-  \arraylengthequal(\tenv, \widtht, \widths) \typearrow \False
-}{
-  \lca(\tenv, \vt, \vs) \typearrow \TypeErrorVal{\NoLCA}
+  {
+  \begin{array}{r}
+  \lca(\tenv, \overname{\TArray(\widtht, \vtyt)}{\vt}, \overname{\TArray(\widths, \vtys)}{\vs}) \typearrow \\
+  \overname{\TArray(\widtht, \vtone)}{\tty}
+  \end{array}
+  }
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[t\_tuple]{
   \typeequal(\tenv, \vt, \vs) \typearrow \False\\
-  \vt \eqname \TTuple(\vlit)\\
-  \vs \eqname \TTuple(\vlis)\\
   \equallength(\vlit, \vlis) \typearrow \vb\\
-  \checktrans{\vb}{NoLCA/TuplesHaveDifferentLengths} \typearrow \True \OrTypeError\\\\
+  \checktrans{\vb}{\NoLCA} \typearrow \True \OrTypeError\\\\
   {
     \begin{array}{r}
   \vi\in\listrange(\vlit): \lca(\tenv, \vlit[\vi], \vlis[\vi]) \typearrow \\
-   \vli[\vi] \OrTypeError
+   \vt_\vi \OrTypeError
     \end{array}
   }\\
-  \vli \eqdef [\vi\in\listrange(\vlit): \vli[\vi]]
+  \vli \eqdef [\vi\in\listrange(\vlit): \vt_\vi]
 }{
-  \lca(\tenv, \vt, \vs) \typearrow \TTuple(\vli)
+  \lca(\tenv, \overname{\TTuple(\vlit)}{\vt}, \overname{\TTuple(\vlis)}{\vs}) \typearrow \overname{\TTuple(\vli)}{\tty}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[labels]{
+\inferrule[error]{
   \typeequal(\tenv, \vt, \vs) \typearrow \False\\
   (\astlabel(\vt) \neq \astlabel(\vs)) \lor
   \astlabel(\vt) \in \{\TEnum, \TRecord, \TException\}
@@ -3270,7 +3290,6 @@ One of the following applies:
 \item All of the following apply (\textsc{neg\_t\_int\_unconstrained}):
 \begin{itemize}
   \item $\op$ is $\NEG$;
-  \item determining whether $\vt$ \typesatisfies\ $\unconstrainedinteger$ yields $\True$;
   \item obtaining the \wellconstrainedstructure\ of $\vt$ yields $\unconstrainedinteger$\ProseOrTypeError;
   \item $\vs$ is $\unconstrainedinteger$;
 \end{itemize}
@@ -3278,7 +3297,6 @@ One of the following applies:
 \item All of the following apply (\textsc{neg\_t\_int\_well\_constrained}):
 \begin{itemize}
   \item $\op$ is $\NEG$;
-  \item determining whether $\vt$ \typesatisfies\ $\unconstrainedinteger$ yields $\True$\ProseOrTypeError;
   \item obtaining the \wellconstrainedstructure\ of $\vt$ yields the well-constrained integer type with constraints $\vcs$\ProseOrTypeError;
   \item negating the constraints in $\vcs$ (see $\negateconstraint$) yields $\vcsnew$;
   \item $\vs$ is the well-constrained integer type with constraints $\vcsnew$, that is, \\
@@ -3346,7 +3364,6 @@ the values it represents:
 
 \begin{mathpar}
 \inferrule[neg\_t\_int\_unconstrained]{
-  \typesat(\tenv, \vt, \unconstrainedinteger) \typearrow \True\\\\
   \getwellconstrainedstructure(\tenv, \vt) \typearrow \unconstrainedinteger \OrTypeError
 }{
   \CheckUnop(\tenv, \overname{\NEG}{\op}, \vt) \typearrow \overname{\unconstrainedinteger}{\vs}
@@ -3355,7 +3372,6 @@ the values it represents:
 
 \begin{mathpar}
 \inferrule[neg\_t\_int\_well\_constrained]{
-  \typesat(\tenv, \vt, \unconstrainedinteger) \typearrow \True\\
   \getwellconstrainedstructure(\tenv, \vt) \typearrow \TInt(\wellconstrained(\vcs))\\
   \vc \in \vcs: \negateconstraint(\vc) \typearrow \vneg_\vc\\
   \vcsnew \eqdef [\vc \in \vcs: \vneg_\vc]
@@ -3538,16 +3554,16 @@ One of the following applies:
                                     \textsc{arith\_t\_int\_unconstrained2}):
   \begin{itemize}
     \item $\op$ is one of $\{\MUL, \DIV, \DIVRM, \MOD, \SHL,  \SHR, \POW, \PLUS, \MINUS\}$;
-    \item the \wellconstrainedstructure\ of either $\vtone$ or $\vttwo$ in $\tenv$ is that of the unconstrained integer type;
+    \item the \wellconstrainedstructure\ of $\vtone$ or $\vttwo$ in $\tenv$ is that of the unconstrained integer type;
     \item $\vt$ is the unconstrained integer type;
   \end{itemize}
 
   \item All of the following apply (\textsc{arith\_t\_int\_wellconstrained}):
   \begin{itemize}
     \item $\op$ is one of $\{\MUL, \POW, \PLUS, \MINUS, \DIVRM, \DIV, \MOD, \SHL, \SHR\}$;
-    \item the \wellconstrainedstructure\ of either $\vtone$ in $\tenv$ is that of a well-constrained integer type with
+    \item the \wellconstrainedstructure\ of $\vtone$ in $\tenv$ is that of a well-constrained integer type with
           constraints $\vcsone$;
-    \item the \wellconstrainedstructure\ of either $\vttwo$ in $\tenv$ is that of a well-constrained integer type with
+    \item the \wellconstrainedstructure\ of $\vttwo$ in $\tenv$ is that of a well-constrained integer type with
           constraints $\vcstwo$;
     \item applying $\annotateconstraintbinop$ to $\op$, $\vcsone$, and $\vcstwo$ in $\tenv$ yields $\vcs$;
     \item $\vt$ is the integer type with constraints $\vcs$;
@@ -3589,7 +3605,8 @@ One of the following applies:
   \checktypesat(\tenv, \vt1, \TBool) \typearrow \True \OrTypeError\\\\
   \checktypesat(\tenv, \vttwo, \TBool) \typearrow \True \OrTypeError
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool}
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBool}{\vt}
+}
 \end{mathpar}
 
 \begin{mathpar}
@@ -3598,7 +3615,7 @@ One of the following applies:
   \checkbitsequalwidth(\tenv, \vtone, \vttwo) \typearrow \True \OrTypeError\\\\
   \getbitvectorwidth(\tenv, \vtone) \typearrow \vw
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(\vw, \emptylist)
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBits(\vw, \emptylist)}{\vt}
 }
 \end{mathpar}
 
@@ -3608,7 +3625,7 @@ One of the following applies:
   \tstruct(\tenv, \vtone) \typearrow \vtonestruct \OrTypeError\\\\
   \astlabel(\vtonestruct) \not\in \{\TBits,\TInt\}\\
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TypeErrorVal{InappropriateTypeForPlusMinus}
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TypeErrorVal{\InvalidOperandTypesForBinop}
 }
 \and
 \inferrule[plus\_minus\_bits\_int]{
@@ -3618,7 +3635,7 @@ One of the following applies:
   \typesat(\tenv, \vttwo, \unconstrainedinteger) \typearrow \True\\
   \getbitvectorwidth(\tenv, \vtone) \typearrow \vw\\
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(\vw, \emptylist)
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBits(\vw, \emptylist)}{\vt}
 }
 \and
 \inferrule[plus\_minus\_bits\_bits]{
@@ -3631,7 +3648,7 @@ One of the following applies:
   \bitwidthequal(\tenv, \vwone, \vwtwo) \typearrow \vb\\
   \checktrans{\vb}{DifferentBitwidths} \checktransarrow \True \OrTypeError
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBits(\vwone, \emptylist)
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBits(\vwone, \emptylist)}{\vt}
 }
 \end{mathpar}
 
@@ -3644,52 +3661,52 @@ One of the following applies:
   {
     \left(\begin{array}{ll}
   \astlabel(\vtoneanon) \neq \astlabel(\vttwoanon) & \lor \\
-  \astlabel(\vtone) \not\in \{\TInt, \TReal, \TBool, \TBits, \TEnum\} &
+  \astlabel(\vtoneanon) \not\in \{\TInt, \TReal, \TBool, \TBits, \TEnum\} &
     \end{array}\right)
   }
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TypeErrorVal{InappropriateTypeForEQ}
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TypeErrorVal{\InvalidOperandTypesForBinop}
 }
 \and
 \inferrule[eq\_neq\_bits]{
   \op \in  \{\EQOP, \NEQ\}\\
   \makeanonymous(\tenv, \vtone) \typearrow \vtoneanon \OrTypeError\\\\
-  \astlabel(\vtoneanon) = \TBits\\
   \makeanonymous(\tenv, \vttwo) \typearrow \vttwoanon \OrTypeError\\\\
+  \astlabel(\vtoneanon) = \TBits\\
   \astlabel(\vttwoanon) = \TBits\\
   \checkbitsequalwidth(\tenv, \vtoneanon, \vttwoanon) \typearrow \True \OrTypeError
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBool}{\vt}
 }
 \and
 \inferrule[eq\_neq\_bool]{
   \op \in  \{\EQOP, \NEQ\}\\
-  \makeanonymous(\tenv, \vtone) \typearrow \TBool\\
-  \makeanonymous(\tenv, \vttwo) \typearrow \TBool\\
+  \makeanonymous(\tenv, \vtone) \typearrow \vtoneanon \OrTypeError\\\\
+  \makeanonymous(\tenv, \vttwo) \typearrow \vttwoanon \OrTypeError\\\\
   \checktypesat(\tenv, \vtoneanon, \TBool) \typearrow \True \OrTypeError\\\\
   \checktypesat(\tenv, \vttwoanon, \TBool) \typearrow \True \OrTypeError
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBool}{\vt}
 }
 \and
 \inferrule[eq\_neq\_real]{
   \op \in  \{\EQOP, \NEQ\}\\
-  \makeanonymous(\tenv, \vtone) \typearrow \TReal\\
-  \makeanonymous(\tenv, \vttwo) \typearrow \TReal\\
+  \makeanonymous(\tenv, \vtone) \typearrow \vtoneanon \OrTypeError\\\\
+  \makeanonymous(\tenv, \vttwo) \typearrow \vttwoanon \OrTypeError\\\\
   \checktypesat(\tenv, \vtoneanon, \TReal) \typearrow \True \OrTypeError\\\\
   \checktypesat(\tenv, \vttwoanon, \TReal) \typearrow \True \OrTypeError
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBool}{\vt}
 }
 \and
 \inferrule[eq\_neq\_string]{
   \op \in  \{\EQOP, \NEQ\}\\
-  \makeanonymous(\tenv, \vtone) \typearrow \TString\\
-  \makeanonymous(\tenv, \vttwo) \typearrow \TString\\
+  \makeanonymous(\tenv, \vtone) \typearrow \vtoneanon \OrTypeError\\\\
+  \makeanonymous(\tenv, \vttwo) \typearrow \vttwoanon \OrTypeError\\\\
   \checktypesat(\tenv, \vtoneanon, \TString) \typearrow \True \OrTypeError\\\\
   \checktypesat(\tenv, \vttwoanon, \TString) \typearrow \True \OrTypeError
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBool}{\vt}
 }
 \and
 \inferrule[eq\_neq\_enum]{
@@ -3698,7 +3715,7 @@ One of the following applies:
   \makeanonymous(\tenv, \vttwo) \typearrow \TEnum(\vlitwo)\\
   \checktrans{\vlione = \vlitwo}{DifferentEnumLabels} \checktransarrow \True \OrTypeError
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBool}{\vt}
 }
 \end{mathpar}
 
@@ -3709,9 +3726,9 @@ One of the following applies:
   \typesat(\tenv, \vttwo, \unconstrainedinteger) \typearrow \vbtwo \OrTypeError\\\\
   \typesat(\tenv, \vtone, \TReal) \typearrow \vbthree \OrTypeError\\\\
   \typesat(\tenv, \vttwo, \TReal) \typearrow \vbfour \OrTypeError\\\\
-  \checktrans{\vbone \land \vbtwo \lor \vbthree \land \vbfour}{InappropriateTypeForRel} \checktransarrow \True \OrTypeError
+  \checktrans{\vbone \land \vbtwo \lor \vbthree \land \vbfour}{\InvalidOperandTypesForBinop} \checktransarrow \True \OrTypeError
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TBool
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \overname{\TBool}{\vt}
 }
 \end{mathpar}
 
@@ -3741,7 +3758,7 @@ One of the following applies:
     \right\}
   }
 }{
-  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TypeErrorVal{InappropriateTypeForBinop}
+  \CheckBinop(\tenv, \op, \vtone, \vttwo) \typearrow \TypeErrorVal{\InvalidOperandTypesForBinop}
 }
 \end{mathpar}
 
@@ -3830,8 +3847,8 @@ returns the set of \emph{named supertypes} given via the $\subtypes$ function of
 \[
   \supers(\tenv, \vt) \triangleq
   \begin{cases}
-    \{\vt\} \cup (\vs) & \text{ if }G^\tenv.\subtypes(\vt) = \vs\\
-    \{\vt\}  & \text{ otherwise } (G^\tenv.\subtypes(\vt) = \bot)\\
+    \{\vt\} \cup \supers(\vs) & \text{ if }G^\tenv.\subtypes(\vt) = \vs\\
+    \{\vt\}  & \text{ otherwise } (\text{that is, }G^\tenv.\subtypes(\vt) = \bot)\\
   \end{cases}
 \]
 
@@ -3953,7 +3970,7 @@ All of the following apply:
   (\csonearg, \cstwoarg) \eqdef \choice{\vbexploding}{(\csonee, \cstwoe)}{(\csone, \cstwof)}\\
   \constraintbinop(\op, \csonearg, \cstwoarg) \typearrow \csvanilla\\
   \reduceconstraints(\tenv, \csvanilla) \typearrow \cs\\\\
-  \casesplitline\\\\
+  \commonprefixline\\\\
   \op = \DIV \land \astlabel(\cs) = \wellconstrained\\
   \cs \eqname \wellconstrained(\cslist)\\
   {
@@ -3977,7 +3994,7 @@ All of the following apply:
   (\csonearg, \cstwoarg) \eqdef \choice{\vbexploding}{(\csonee, \cstwoe)}{(\csone, \cstwof)}\\
   \constraintbinop(\op, \csonearg, \cstwoarg) \typearrow \csvanilla\\
   \reduceconstraints(\tenv, \csvanilla) \typearrow \cs\\\\
-  \casesplitline\\\\
+  \commonprefixline\\\\
   \neg(\op = \DIV \land \astlabel(\cs) = \wellconstrained)
 }{
   \annotateconstraintbinop(\tenv, \op, \csone, \cstwo) \typearrow \overname{\cs}{\vics}
@@ -4804,9 +4821,9 @@ All of the following apply:
   \item $\newty$ is the tuple type with member types $\ttyp$, for $i=1..k$.
 \end{itemize}
 
-\subsection{Example}
 In the following example, all the uses of tuple types are valid:
 \VerbatimInput{../tests/ASLTypingReference.t/TypingRule.TTuple.asl}
+\subsection{Example}
 
 \CodeSubsection{\TTupleBegin}{\TTupleEnd}{../Typing.ml}
 
@@ -4828,15 +4845,14 @@ In the following example, all the uses of tuple types are valid:
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\tty$ is the array type indexed by integer bounded by the
-    expression $\ve$ and of elements of type $\vt$;
+  \item $\tty$ is the array type with element type $\vt$;
   \item Annotating the type $\vt$ in $\tenv$ yields $\vtp$\ProseOrTypeError;
   \item One of the following applies:
   \begin{itemize}
     \item All of the following apply (\textsc{expr\_is\_enum}):
     \begin{itemize}
-      \item determining whether $\ve$ corresponds to an enumeration in $\tenv$
-      via \\ $\getvariableenum$ yields the enumeration variable
+      \item the array index is $\ve$ and determining whether $\ve$ corresponds to an enumeration in $\tenv$
+      via $\getvariableenum$ yields the enumeration variable
       name $\vs$ of size $\vi$, that is, $\langle \vs, \vi \rangle$\ProseOrTypeError;
       \item $\newty$ is the array type indexed by an enumeration type
       named $\vs$ of length $\vi$ and of elements of type $\vtp$, that is, $\TArray(\ArrayLengthEnum(\vs, \vi), \vtp)$.
@@ -4844,8 +4860,8 @@ All of the following apply:
 
     \item All of the following apply (\textsc{expr\_not\_enum}):
     \begin{itemize}
-      \item determining whether $\ve$ corresponds to an enumeration in $\tenv$
-      via \\ $\getvariableenum$ yields $\None$ (meaning it does not
+      \item the array index is $\ve$ and determining whether $\ve$ corresponds to an enumeration in $\tenv$
+      via $\getvariableenum$ yields $\None$ (meaning it does not
       correspond to an enumeration)\ProseOrTypeError;
       \item annotating the statically evaluable integer expression $\ve$ yields
       $\vep$\ProseOrTypeError;
@@ -4856,8 +4872,8 @@ All of the following apply:
 
     \item All of the following apply (\textsc{index\_enum}):
     \begin{itemize}
-      \item $\ve$ is an enumeration type index with variable $\vs$ and size $\vi$,
-      that is, \\ $\ArrayLengthEnum(\vs, \vi)$;
+      \item the array index is an enumeration type named $\vs$ and a list of $\vi$ labels,
+      that is, $\ArrayLengthEnum(\vs, \vi)$;
       \item let $\tty$ be the named type defined for $\vs$, that is, $\TNamed(\vs)$;
       \item determining the \underlyingtype\ of $\tty$ yields $\tsanon$\ProseOrTypeError;
       \item checking whether $\tsanon$ is an enumeration type yields $\True$\ProseOrTypeError;
@@ -4879,43 +4895,38 @@ In the following example, all the uses of array types are valid:
 \begin{mathpar}
 \inferrule[expr\_is\_enum]{
   \annotatetype{\False, \tenv, \vt} \typearrow \vtp \OrTypeError\\\\
+  \commonprefixline\\\\
   \getvariableenum(\tenv, \ve) \typearrow \langle \vs, \vi \rangle\OrTypeError
 }{
-  {
-    \begin{array}{r}
-  \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\TArray(\ArrayLengthExpr(\ve), \vt)}{\tty}} \typearrow \\
-  \overname{\TArray(\ArrayLengthEnum(\vs, \vi), \vtp)}{\newty}
-    \end{array}
-  }
+  \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\AbbrevTArrayLengthExpr{\ve}{\vt}}{\tty}} \typearrow
+  \overname{\AbbrevTArrayLengthEnum{\ve}{\vi}{\vtp}}{\newty}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[expr\_not\_enum]{
   \annotatetype{\False, \tenv, \vt} \typearrow \vtp \OrTypeError\\\\
+  \commonprefixline\\\\
   \getvariableenum(\tenv, \ve) \typearrow \None \OrTypeError\\\\
   \annotatestaticinteger(\tenv, \ve) \typearrow \vep \OrTypeError
 }{
-  {
-    \begin{array}{r}
-  \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\TArray(\ArrayLengthExpr(\ve), \vt)}{\tty}} \typearrow \\
-  \overname{\TArray(\ArrayLengthExpr(\vep), \vtp)}{\newty}
-    \end{array}
-  }
+  \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\AbbrevTArrayLengthExpr{\ve}{\vt}}{\tty}} \typearrow
+  \overname{\AbbrevTArrayLengthExpr{\vep}{\vtp}}{\newty}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[index\_enum]{
   \annotatetype{\False, \tenv, \vt} \typearrow \vtp \OrTypeError\\\\
+  \commonprefixline\\\\
   \tsubs \eqdef \TNamed(\vs)\\
   \makeanonymous(\tenv, \tsubs) \typearrow \tsanon \OrTypeError\\\\
-  \checktrans{\astlabel(\tsanon) = \TEnum}{ExpectedEnumeration} \checktransarrow \True \OrTypeError\\\\
-  \vt \eqname \TEnum(\vli)\\
+  \checktrans{\astlabel(\tsanon) = \TEnum}{\ExpectedEnumerationType} \checktransarrow \True \OrTypeError\\\\
+  \tsanon \eqname \TEnum(\vli)\\
   \checktrans{\equallength(\vli, \vi)}{TypeConflict} \checktransarrow \True \OrTypeError
 }{
-  \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\TArray(\ArrayLengthEnum(\vs, \vi), \vt)}{\tty}} \typearrow \\
-  \overname{\TArray(\ArrayLengthEnum(\vs, \vi), \vtp)}{\newty}
+  \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\AbbrevTArrayLengthEnum{\vs}{\vi}{\vt}}{\tty}} \typearrow
+  \overname{\AbbrevTArrayLengthEnum{\vs}{\vi}{\vtp}}{\newty}
 }
 \end{mathpar}
 
@@ -4994,7 +5005,6 @@ In the following example, all the uses of record or exception types are valid:
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.TNonDecl \label{sec:TypingRule.TNonDecl}}
-
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
@@ -5016,7 +5026,7 @@ In the following example, the use of a record type outside of a declaration is e
 \inferrule{
   \astlabel(\tty) \in \{\TEnum, \TRecord, \TException\}
 }{
-  \annotatetype{\False, \tenv, \tty} \typearrow \TypeErrorVal{AnnonymousFormNotAllowedHere}
+  \annotatetype{\False, \tenv, \tty} \typearrow \TypeErrorVal{\AnnonymousFormNotAllowedHere}
 }
 \end{mathpar}
 
@@ -5168,7 +5178,7 @@ All of the following apply:
   \item applying $\normalize$ to $\vep$ in $\tenv$ yields $\vepp$.
 \end{itemize}
 
-\CodeSubsection{\StaticIntegerBegin}{\StaticIntegerEnd}{../Typing.ml}
+\CodeSubsection{\AnnotateStaticIntegerBegin}{\AnnotateStaticIntegerEnd}{../Typing.ml}
 
 \subsection{Formally}
 \begin{mathpar}
@@ -5196,23 +5206,24 @@ We define rules for annotating a single bitfield and a list of bitfields:
 \hypertarget{def-annotatebitfield}{}
 The function
 \[
-  \annotatebitfield(\overname{\staticenvs}{\tenv} \aslsep \overname{\Z}{\width} \aslsep \overname{\bitfield}{\field})
+  \annotatebitfield(\overname{\staticenvs}{\tenv} \aslsep \overname{\Z}{\width} \aslsep \overname{\bitfield}{\vfield})
   \aslto \overname{\bitfield}{\newfield} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-annotates a bitfield --- $\field$ --- with an integer --- $\width$ --- indicating the number of bits in
+annotates a bitfield --- $\vfield$ --- with an integer --- $\width$ --- indicating the number of bits in
 the bitvector type that contains $\field$,
 in an environment $\tenv$, resulting in an
 annotated bitfield --- $\newfield$ --- or a type error, if one is detected.
 
 \subsection{Prose}
 \begin{itemize}
-  \item Annotating the slices $\slices$ yields $\slicesone$\ProseOrTypeError;
-  One of the following applies:
+  \item $\vfield$ is a bitfield with list of slices $\vslices$;
+  \item annotating the slices $\vslices$ yields $\slicesone$\ProseOrTypeError;
+  \item One of the following applies:
   \begin{itemize}
     \item All of the following apply (\textsc{simple}):
     \begin{itemize}
       \item checking whether the range of positions in $\slicesone$ fits inside $0..\width-1$ yields $\True$\ProseOrTypeError;
-      \item $\newfield$ is a bitfield named $\name$ with list of slices $\slicesone$, that is, $\BitFieldSimple(\name, \sliceone)$.
+      \item $\newfield$ is a bitfield named $\name$ with list of slices $\slicesone$, that is, $\BitFieldSimple(\name, \slicesone)$.
     \end{itemize}
 
     \item All of the following apply (\textsc{nested}):
@@ -5248,30 +5259,33 @@ In the following example, all the uses of bitvector types with bitfields are val
 \subsection{Formally}
 \begin{mathpar}
 \inferrule[simple]{
-  \annotateslices(\tenv, \slices) \typearrow \slicesone \OrTypeError\\\\
+  \annotateslices(\tenv, \vslices) \typearrow \slicesone \OrTypeError\\\\
+  \commonprefixline\\\\
   \checkslicesinwidth(\tenv, \width, \slicesone) \typearrow \True \OrTypeError
 }{
-  \annotatebitfield(\tenv, \width, \BitFieldSimple(\name, \slices)) \typearrow \\
-  \BitFieldSimple(\name, \sliceone)
+  \annotatebitfield(\tenv, \width, \BitFieldSimple(\name, \vslices)) \typearrow \\
+  \BitFieldSimple(\name, \slicesone)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[nested]{
-  \annotateslices(\tenv, \slices) \typearrow \slicesone \OrTypeError\\\\
+  \annotateslices(\tenv, \vslices) \typearrow \slicesone \OrTypeError\\\\
+  \commonprefixline\\\\
   \disjointslicestopositions(\tenv, \width, \slicesone) \typearrow \positions \OrTypeError\\\\
   \checkpositionsinwidth(\tenv, \width, \positions) \typearrow \True \OrTypeError\\\\
   \widthp \eqdef \listlen{\positions}\\
   \annotatebitfields(\tenv, \widthp, \bitfieldsp) \typearrow \bitfieldspp \OrTypeError\\
 }{
-  \annotatebitfield(\tenv, \width, \BitFieldNested(\name, \slices, \bitfieldsp)) \typearrow \\
+  \annotatebitfield(\tenv, \width, \BitFieldNested(\name, \vslices, \bitfieldsp)) \typearrow \\
   \BitFieldNested(\slicesone, \bitfieldspp)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[type]{
-  \annotateslices(\tenv, \slices) \typearrow \slicesone \OrTypeError\\\\
+  \annotateslices(\tenv, \vslices) \typearrow \slicesone \OrTypeError\\\\
+  \commonprefixline\\\\
   \annotatetype{\tenv, \vt} \typearrow \vtp \OrTypeError\\\\
   \checkslicesinwidth(\tenv, \width, \slicesone) \typearrow \True \OrTypeError\\\\
   \disjointslicestopositions(\tenv, \slicesone) \typearrow \positions \OrTypeError\\\\
@@ -5279,7 +5293,7 @@ In the following example, all the uses of bitvector types with bitfields are val
   \widthp \eqdef \listlen{\positions}\\
   \checkbitsequalwidth(\TBits(\widthp, \emptylist), \vt) \typearrow \True \OrTypeError
 }{
-  \annotatebitfield(\tenv, \width, \BitFieldType(\name, \slices, \vt)) \typearrow \\
+  \annotatebitfield(\tenv, \width, \BitFieldType(\name, \vslices, \vt)) \typearrow \\
   \BitFieldType(\name, \slicesone, \vtp)
 }
 \end{mathpar}
@@ -5328,7 +5342,7 @@ All of the following apply:
 \isempty{\subsection{Comments}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\chapter{Typing of Expressions}
+\chapter{Typing of Expressions \label{chap:typingexpr}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \hypertarget{def-annotateexpr}{}
 The function
@@ -5661,7 +5675,7 @@ All of the following apply:
   \item determining whether $\vep$ together with $\slices$ corresponds to a subprogram call
   in $\tenv$ via $\reduceslicestocall$ yields a negative answer --- $\None$\ProseOrTypeError;
   \item annotating the expression $\vep$ in $\tenv$ yields $(\tep,\vepp)$\ProseOrTypeError;
-  \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\structtep$\ProseOrTypeError;
+  \item obtaining the \structure\ of $\tep$ in $\tenv$ yields $\structtep$\ProseOrTypeError;
   \item $\structtep$ is either a bitvector or an integer;
   \item obtaining the width of $\slices$ in $\tenv$ via $\sliceswidth$ yields $\vw$\ProseOrTypeError;
   \item $\slicesp$ is the result of annotating $\slices$ in $\tenv$;
@@ -5684,7 +5698,7 @@ All of the following apply:
   \sliceswidth(\tenv, \slices) \typearrow \vw \OrTypeError\\\\
   \annotateslices(\tenv, \slices) \typearrow \slicesp \OrTypeError
 }{
-  \annotateexpr{\tenv, \ESlice(\vep, \slices)} \typearrow (\TBits(\vw, \emptylist), \ESlice(\vepp, \slicesp))
+  \annotateexpr{\tenv, \overname{\ESlice(\vep, \slices)}{\ve}} \typearrow (\overname{\TBits(\vw, \emptylist)}{\vt}, \overname{\ESlice(\vepp, \slicesp)}{\newe})
 }
 \end{mathpar}
 
@@ -5704,15 +5718,15 @@ All of the following apply:
   $\ESlice(\vep, \slices)$;
   \item determining whether $\vep$ together with $\slices$ corresponds to a subprogram call
   in $\tenv$ via $\reduceslicestocall$ yields a positive answer --- $\langle (\name, \vargs)\rangle$\ProseOrTypeError;
-  \item annotating a call with $(\tenv, \name, \vargs, \emptylist, \STSetter)$
-  (that is, an empty list of parameters) yields $(\nameone, \vargsone, \eqs, \langle\tty\rangle)$\ProseOrTypeError;
-  \item $vt$ is $\tty$;
+  \item applying $\annotatecall$ to annotate the call with $(\tenv, \name, \vargs, \STSetter)$
+        yields $(\nameone, \vargsone, \eqs, \langle\tty\rangle)$\ProseOrTypeError;
+  \item $\vt$ is $\tty$;
   \item $\newe$ is the call expression $\ECall(\nameone, \vargsone, \eqs)$.
 \end{itemize}
 
 \isempty{\subsection{Example}}
 
-\CodeSubsection{\ESetterBegin}{\ESetterEnd}{../Typing.ml}
+\CodeSubsection{\ReduceSlicesToCallBegin}{\ReduceSlicesToCallEnd}{../Typing.ml}
 
 \subsection{Formally}
 \begin{mathpar}
@@ -5720,7 +5734,7 @@ All of the following apply:
   \reduceslicestocall(\tenv, \vep, \slices) \typearrow \langle(\name, \vargs)\rangle \OrTypeError\\\\
   \annotatecall(\tenv, \name, \vargs, \STSetter) \typearrow (\nameone, \vargsone, \eqs, \langle\tty\rangle) \OrTypeError\\
 }{
-  \annotateexpr{\tenv, \ESlice(\vep, \slices)} \typearrow (\tty, \ECall(\nameone, \vargsone, \eqs))
+  \annotateexpr{\tenv, \overname{\ESlice(\vep, \slices)}{\ve}} \typearrow (\overname{\tty}{\vt}, \overname{\ECall(\nameone, \vargsone, \eqs)}{\newe})
 }
 \end{mathpar}
 
@@ -5737,7 +5751,7 @@ All of the following apply:
         and yields $(\namep, \vargsp, \eqsp, \langle \vt \rangle)$\ProseOrTypeError.
         Notice that passing $\STFunction$ to $\annotatecall$ checks that $\name$ is not a procedure and that a value is indeed returned;
   \item $\newe$ is the call to the subprogram named $\namep$ with arguments $\vargsp$
-    and parameters $\eqsp$, that is, $\ECall(\name, \vargsp, \eqsp)$.
+    and parameters $\eqsp$, that is, $\ECall(\namep, \vargsp, \eqsp)$.
 \end{itemize}
 
 \isempty{\subsection{Example}}
@@ -5749,7 +5763,7 @@ All of the following apply:
 \inferrule{
   \annotatecall(\tenv, \name, \vargs, \STFunction) \typearrow (\namep, \vargsp, \eqsp, \langle \vt \rangle) \OrTypeError
 }{
-  \annotateexpr{\tenv, \ECall(\name, \vargs)} \typearrow (\vt, \ECall(\name, \vargsp, \eqsp))
+  \annotateexpr{\tenv, \overname{\ECall(\name, \vargs)}{\ve}} \typearrow (\vt, \overname{\ECall(\namep, \vargsp, \eqsp)}{\newe})
 }
 \end{mathpar}
 
@@ -5781,7 +5795,7 @@ All of the following apply:
   \begin{itemize}
     \item All of the following apply (\textsc{okay}):
     \begin{itemize}
-      \item $\slices$ consists of a single slice $\SliceSingle(\eindex)$;
+      \item $\slices$ is a list containing a single slice for an expression $\eindex$, that is, $[\SliceSingle(\eindex)]$;
       \item annotating the expression $\eindex$ in $\tenv$ yields $(\tindexp, \eindexp)$\ProseOrTypeError;
       \item determining the type of the array index for $\size$ in $\tenv$ via \\ $\typeofarraylength$
             yields $\wantedtindex$;
@@ -5793,7 +5807,7 @@ All of the following apply:
 
     \item All of the following apply (\textsc{error}):
     \begin{itemize}
-      \item $\slices$ consists of a single slice $\SliceSingle(\eindex)$;
+      \item $\slices$ is not a list containing a single slice for an expression $\eindex$;
       \item the result is a type error indicating that an array must be accessed with a slice corresponding
             to a single index expression.
     \end{itemize}
@@ -5810,21 +5824,23 @@ All of the following apply:
   \reduceslicestocall(\tenv, \vep, \slices) \typearrow \None \OrTypeError\\\\
   \annotateexpr{\tenv, \ve} \typearrow (\tep, \vepp) \OrTypeError\\\\
   \tstruct(\tenv, \tep) \typearrow \TArray(\size, \ttyp) \OrTypeError\\\\
+  \commonprefixline\\\\
   \slices = [ \SliceSingle(\eindex) ]\\
   \annotateexpr{\tenv, \eindex} \typearrow (\tindexp, \eindexp) \OrTypeError\\\\
   \typeofarraylength(\tenv, \size) \typearrow \wantedtindex\\
   \checktypesat(\tenv, \tindexp, \wantedtindex) \typearrow \True \OrTypeError\\
 }{
-  \annotateexpr{\tenv, \ESlice(\vep, \slices)} \typearrow (\ttyp, \EGetArray(\vepp, \eindexp))
+  \annotateexpr{\tenv, \overname{\ESlice(\vep, \slices)}{\ve}} \typearrow (\overname{\ttyp}{\vt}, \overname{\EGetArray(\vepp, \eindexp)}{\newe})
 }
 \and
 \inferrule[error]{
   \reduceslicestocall(\tenv, \vep, \slices) \typearrow \None \OrTypeError\\\\
   \annotateexpr{\tenv, \ve} \typearrow (\tep, \vepp) \OrTypeError\\\\
   \tstruct(\tenv, \tep) \typearrow \TArray(\size, \ttyp) \OrTypeError\\\\
+  \commonprefixline\\\\
   \slices \neq [ \SliceSingle(\Ignore) ]\\
 }{
-  \annotateexpr{\tenv, \ESlice(\vep, \slices)} \typearrow \TypeErrorVal{IllegalArraySlice}
+  \annotateexpr{\tenv, \overname{\ESlice(\vep, \slices)}{\ve}} \typearrow \TypeErrorVal{IllegalArraySlice}
 }
 \end{mathpar}
 
@@ -5852,11 +5868,11 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{
   \reduceslicestocall(\tenv, \vep, \slices) \typearrow \None \OrTypeError\\\\
-  \annotateexpr{\tenv, \ve} \typearrow (\tep, \vepp) \OrTypeError\\\\
+  \annotateexpr{\tenv, \vep} \typearrow (\tep, \vepp) \OrTypeError\\\\
   \tstruct(\tenv, \tep) \typearrow \vtp\\
   \astlabel(\vtp) \not\in \{\TInt, \TBits, \TArray\}
 }{
-  \annotateexpr{\tenv, \ESlice(\vep, \slices)} \typearrow \TypeErrorVal{IllegalSliceType}
+  \annotateexpr{\tenv, \overname{\ESlice(\vep, \slices)}{\ve}} \typearrow \TypeErrorVal{IllegalSliceType}
 }
 \end{mathpar}
 
@@ -5870,7 +5886,7 @@ All of the following apply:
   \item $\ve$ denotes the record construction expression (which is also used for creating exceptions) of type $\tty$ with fields $\fields$,
         that is, $\ERecord(\tty, \vfields)$;
   \item obtaining the \underlyingtype\ of $\tty$ in $\tenv$ yields $\ttyanon$\ProseOrTypeError;
-  \item checking that $\ttyanon$ is a \structuredtype\ yields $\True$\ProseOrTypeError;% \ProseTerminateAs{\TypeErrorVal{\RequireStructuredType}};
+  \item checking that $\ttyanon$ is a \structuredtype\ yields $\True$\ProseOrTypeError;% \ProseTerminateAs{\TypeErrorVal{\ExpectedStructuredType}};
   \item $\ttyanon$ is a \structuredtype\ with a list of $\field$ elements (consisting of a field name and a field type);
   \item obtaining the list of field names from $\vfields$ yields the list of identifiers \\
         $\initializedfields$;
@@ -5880,8 +5896,8 @@ All of the following apply:
   \item checking that the list $\initializedfields$ does not contain duplicates yields \\
         $\True$\ProseOrTypeError;
   \item applying $\annotatefieldinit$ to annotate each $\field$ element $(\name,\vep)$ of \\
-        $\vfields$ in $\tenv$ yields $(\name,\vepp)$\ProseOrTypeError;
-  \item define $\fieldsp$ as the list containing $(\name,\vep)$ for each $\field$ element $(\name,\vep)$ of $\vfields$;
+        $\vfields$ in $\tenv$ yields $(\name,\ve_\name)$\ProseOrTypeError;
+  \item define $\fieldsp$ as the list containing $(\name,\ve_\name)$ for each $\field$ element $(\name,\vep)$ of $\vfields$;
   \item $\vt$ is $\tty$;
   \item $\newe$ is the record expression with type $\tty$ and field initializers $\fieldsp$, that is, $\ERecord(\tty, \fieldsp)$;
 \end{itemize}
@@ -5895,7 +5911,7 @@ All of the following apply:
 \inferrule{
   \checktrans{\astlabel(\tty) = \TNamed}{NamedTypeExpected} \checktransarrow \True \OrTypeError\\\\
   \makeanonymous(\tenv, \tty) \typearrow \ttyanon \OrTypeError\\\\
-  \checktrans{\astlabel(\ttyanon) \in \{\TRecord, \TException\}}{\RequireStructuredType} \typearrow \True\OrTypeError\\\\
+  \checktrans{\astlabel(\ttyanon) \in \{\TRecord, \TException\}}{\ExpectedStructuredType} \typearrow \True\OrTypeError\\\\
   \ttyanon \eqname L(\fieldtypes)\\
   \initializedfields \eqdef \{\name \;|\; (\name, \Ignore)\in\vfields\}\\
   \names \eqdef \fieldnames(\fieldtypes)\\
@@ -5904,10 +5920,10 @@ All of the following apply:
   {
     \begin{array}{r}
   (\name, \vep) \in \vfields: \annotatefieldinit(\tenv, (\name, \vep), \fieldtypes) \typearrow \\
-  (\name, \vepp) \OrTypeError
+  (\name, \ve_\name) \OrTypeError
     \end{array}
   }\\
-  \fieldsp \eqdef [(\name, \vep) \in \fields : (\name, \vepp)]
+  \fieldsp \eqdef [(\name, \vep) \in \fields : (\name, \ve_\name)]
 }{
   \annotateexpr{\tenv, \overname{\ERecord(\tty, \vfields)}{\ve}} \typearrow (\overname{\tty}{\vt}, \overname{\ERecord(\tty, \fieldsp)}{\newe})
 }
@@ -6003,14 +6019,13 @@ All of the following apply:
 
 \begin{mathpar}
 \inferrule{
-  \ve \eqname \EGetField(\veone, \fieldname)\\
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
   % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
   \vtetwo \eqname \TBits(\Ignore, \bitfields)\\
   \findbitfieldopt(\bitfields, \fieldname) \typearrow \None
 }{
-  \annotateexpr{\tenv, \ve} \typearrow \TypeErrorVal{FieldDoesNotExist}
+  \annotateexpr{\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}} \typearrow \TypeErrorVal{FieldDoesNotExist}
 }
 \end{mathpar}
 
@@ -6038,7 +6053,6 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \ve \eqname \EGetField(\veone, \fieldname)\\
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
   % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
@@ -6047,7 +6061,7 @@ All of the following apply:
   \vethree \eqdef \ESlice(\vetwo, \slices)\\
   \annotateexpr{\tenv, \vethree} \typearrow (\vt, \newe) \OrTypeError
 }{
-  \annotateexpr{\tenv, \ve} \typearrow (\vt, \newe)
+  \annotateexpr{\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}} \typearrow (\vt, \newe)
 }
 \end{mathpar}
 
@@ -6078,7 +6092,6 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \ve \eqname \EGetField(\veone, \fieldname)\\
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
   % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
@@ -6093,7 +6106,7 @@ All of the following apply:
   \vtefour \eqname \TBits(\width, \Ignore)\\
   \vt \eqdef \TBits(\width, \bitfieldsp)
 }{
-  \annotateexpr{\tenv, \ve} \typearrow (\vt, \newe)
+  \annotateexpr{\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}} \typearrow (\vt, \newe)
 }
 \end{mathpar}
 
@@ -6109,7 +6122,7 @@ All of the following apply:
   \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$\ProseOrTypeError;
   % \item checking whether the field access with expression $\vtetwo$ and $\fieldname$ represents a call yields $\None$\ProseOrTypeError;
   \item $\vtetwo$ is a bitvector type with bit fields $\bitfields$;
-  \item $\fieldname$ is declared in $\bitfields$ with a slice list $\slices$ and typed-bitfield with type $vt$ that is,
+  \item $\fieldname$ is declared in $\bitfields$ with a slice list $\slices$ and typed-bitfield with type $\vt$ that is,
         $\BitFieldType(\Ignore, \slices, \vt)$;
   \item $\vethree$ denotes the slicing of the expression \vetwo\ by the slices $\slices$, that is, \\ $\ESlice(\vetwo, \slices)$;
   \item annotating $\vethree$ in $\tenv$ yields $(\vtefour, \newe)$\ProseOrTypeError;
@@ -6123,7 +6136,6 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \ve \eqname \EGetField(\veone, \fieldname)\\
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
   % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
@@ -6133,7 +6145,7 @@ All of the following apply:
   \annotateexpr{\tenv, \vethree} \typearrow (\vtefour, \newe) \OrTypeError\\\\
   \checktypesat(\tenv, \vtefour, \vt) \typearrow \True \OrTypeError
 }{
-  \annotateexpr{\tenv, \ve} \typearrow (\vt, \newe)
+  \annotateexpr{\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}} \typearrow (\vt, \newe)
 }
 \end{mathpar}
 
@@ -6162,7 +6174,6 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \ve \eqname \EGetField(\veone, \fieldname)\\
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
   % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
@@ -6172,7 +6183,7 @@ All of the following apply:
   \vt \eqdef \tys[\vindex]\\
   \newe \eqdef \EGetItem(\vetwo, \vindex)
 }{
-  \annotateexpr{\tenv, \ve} \typearrow (\vt, \newe)
+  \annotateexpr{\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}} \typearrow (\vt, \newe)
 }
 \end{mathpar}
 
@@ -6198,13 +6209,12 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \ve \eqname \EGetField(\veone, \fieldname)\\
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
   % \tododefine{reduce\_field\_to\_call}(\tenv, \vtetwo, \fieldname) \typearrow \None \OrTypeError\\\\
   \astlabel(\vtetwo) \not\in \{\TRecord, \TException, \TBits, \TTuple\}
 }{
-  \annotateexpr{\tenv, \ve} \typearrow \TypeErrorVal{ConflictingTypes}
+  \annotateexpr{\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}} \typearrow \TypeErrorVal{ConflictingTypes}
 }
 \end{mathpar}
 
@@ -6310,9 +6320,9 @@ All of the following apply:
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\ve$ denotes whether the expression $\veone$ matches the pattern $\vpat$, that is, \\ $\EPattern(\veone, \vpat)$;
+  \item $\ve$ denotes a pattern expression to test whether $\veone$ matches the pattern $\vpat$, that is, \\ $\EPattern(\veone, \vpat)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vtetwo, \vetwo)$\ProseOrTypeError;
-  \item annotating the pattern $\vttwo$ in $\tenv$ yields $\vpatp$\ProseOrTypeError;
+  \item applying $\annotatepattern$ to $\vtetwo$ and $\vpat$ in $\tenv$ yields $\vpatp$\ProseOrTypeError;
   \item $\vt$ is $\TBool$;
   \item $\newe$ denotes whether the expression $\vetwo$ matches $\vpatp$, that is, $\EPattern(\vetwo, \vpatp)$.
 \end{itemize}
@@ -6325,9 +6335,9 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\vtetwo, \vetwo) \OrTypeError\\\\
-  \annotatepattern(\tenv, \vtetwo) \typearrow \vpatp \OrTypeError
+  \annotatepattern(\tenv, \vtetwo, \vpat) \typearrow \vpatp \OrTypeError
 }{
-  \annotateexpr{\tenv, \EPattern(\veone, \vpat)} \typearrow (\TBool, \EPattern(\vetwo, \vpatp))
+  \annotateexpr{\tenv, \overname{\EPattern(\veone, \vpat)}{\ve}} \typearrow (\overname{\TBool}{\vr}, \overname{\EPattern(\vetwo, \vpatp)}{\newe})
 }
 \end{mathpar}
 
@@ -6498,8 +6508,7 @@ One of the following applies:
     \item determining whether $\vx$ is a subprogram name with $\slices$ as its actual arguments
     via $\shouldslicesreducetocall$
     yields a list of actual argument expressions $\vargs$\ProseOrTypeError;
-    \item $\name$ is $\vx$;
-    \item the result is $\langle (\name, \vle)\rangle$.
+    \item the result is $\langle (\vx, \vargs)\rangle$.
   \end{itemize}
 
   \item All of the following apply (\textsc{no}):
@@ -6513,7 +6522,7 @@ One of the following applies:
 
   \item All of the following apply (\textsc{non\_var}):
   \begin{itemize}
-    \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
+    \item $\ve$ is not a variable expression;
     \item the result is $\None$.
   \end{itemize}
 \end{itemize}
@@ -6524,23 +6533,23 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[yes]{
   \shouldslicesreducetocall(\tenv, \vx, \slices) \typearrow \langle \vargs \rangle\\
-  \name \eqdef \vx
+}{
+  \reduceslicestocall(\tenv, \EVar(\vx), \slices) \typearrow \langle (\vx, \vargs)\rangle
 }
-{
-  \reduceslicestocall(\tenv, \EVar(\vx), \slices) \typearrow \langle (\name, \vargs)\rangle
-}
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[no]{
   \shouldslicesreducetocall(\tenv, \vx, \slices) \typearrow \None
-}
-{
+}{
   \reduceslicestocall(\tenv, \EVar(\vx), \slices) \typearrow \None
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[non\_var]{
   \astlabel(\ve) \neq \EVar
-}
-{
+}{
   \reduceslicestocall(\tenv, \ve, \slices) \typearrow \None
 }
 \end{mathpar}
@@ -6683,8 +6692,103 @@ One of the following applies:
 }
 \end{mathpar}
 
+\section{TypingRule.SlicesWidth \label{sec:TypingRule.SlicesWidth}}
+\hypertarget{def-sliceswidth}{}
+The function
+\[
+  \sliceswidth(\overname{\staticenvs}{\tenv} \aslsep \overname{\slice^*}{\vslices}) \aslto
+  \overname{\expr}{\vwidth} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+returns an expression $\vslices$ that represents the width of all slices given by $\vslices$
+in the static environment $\tenv$.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{empty}):
+  \begin{itemize}
+    \item $\vslices$ is the empty list;
+    \item $\vwidth$ is the literal integer expression for $0$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{non\_empty}):
+  \begin{itemize}
+    \item $\vslices$ is the list with \head\ $\vs$ and \tail\ $\slicesone$;
+    \item applying $\slicewidth$ to $\vs$ yields $\veone$;
+    \item applying $\sliceswidth$ to $\slicesone$ yields $\vetwo$;
+    \item symbolically simplifying the binary expression summing $\veone$ with $\vetwo$ yields $\vwidth$\ProseOrTypeError.
+  \end{itemize}
+\end{itemize}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[empty]{}{
+  \sliceswidth(\tenv, \overname{\emptylist}{\vslices}) \typearrow \overname{\ELInt{0}}{\vwidth}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_empty]{
+  \slicewidth(\vs) \typearrow \veone\\
+  \sliceswidth(\slicesone) \typearrow \vetwo\\
+  \normalize(\AbbrevEBinop{\PLUS}{\veone}{\vetwo}) \typearrow \vwidth \OrTypeError
+}{
+  \sliceswidth(\tenv, \overname{[\vs]\concat\slicesone}{\vslices}) \typearrow \vwidth
+}
+\end{mathpar}
+
+\section{TypingRule.SliceWidth \label{sec:TypingRule.SliceWidth}}
+\hypertarget{def-slicewidth}{}
+The function
+\[
+  \slicewidth(\overname{\slice}{\vslice}) \aslto
+  \overname{\expr}{\vwidth}
+\]
+returns an expression $\vslices$ that represents the width of the slices given by $\vslice$.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{single}):
+  \begin{itemize}
+    \item $\vslice$ is a single slice, that is, $\SliceSingle(\Ignore)$;
+    \item $\vwidth$ is the literal integer expression for $1$;
+  \end{itemize}
+
+  \item All of the following apply (\textsc{star}, \text{length}):
+  \begin{itemize}
+    \item $\vslice$ is either a slice of the form \texttt{\_:*$\ve$} or \texttt{\_:+$\ve$};
+    \item $\vwidth$ is $\ve$;
+  \end{itemize}
+
+  \item All of the following apply (\textsc{range}):
+  \begin{itemize}
+    \item $\vslice$ is a slice of the form \texttt{$\veone$..$\vetwo$};
+    \item $\vwidth$ is the expression for $1 + (\veone - \vetwo)$.
+  \end{itemize}
+\end{itemize}
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[single]{}{
+  \slicewidth(\overname{\SliceSingle(\Ignore)}{\vslice}) \typearrow \overname{\ELInt{1}}{\vwidth}
+}
+\and
+\inferrule[star]{}{
+  \slicewidth(\overname{\SliceStar(\Ignore, \ve)}{\vslice}) \typearrow \overname{\ve}{\vwidth}
+}
+\and
+\inferrule[length]{}{
+  \slicewidth(\overname{\SliceLength(\Ignore, \ve)}{\vslices}) \typearrow \overname{\ve}{\vwidth}
+}
+\and
+\inferrule[range]{}{
+  \slicewidth(\overname{\SliceRange(\veone, \vetwo)}{\vslices}) \typearrow
+  \overname{\AbbrevEBinop{\PLUS}{\ELInt{1}}{(\AbbrevEBinop{\MINUS}{\veone}{\vetwo})}}{\vwidth}
+}
+\end{mathpar}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\chapter{Typing of Left-Hand-Side Expressions}
+\chapter{Typing of Left-Hand-Side Expressions \label{chap:typinglexpr}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \hypertarget{def-annotatelexpr}{}
 The function
@@ -6695,19 +6799,17 @@ The function
     \overname{\ty}{\vte}} \aslto
     \overname{\lexpr}{\newle} \cup \TTypeError
 \]
-annotates a left-hand side expression $\vle$ in an environment $\tenv$, assuming $\vle$
+annotates a left-hand side expression $\vle$ in an environment $\tenv$, assuming $\vte$
 to be the type of the corresponding right-hand-side expression,
 resulting in an annotated expression $\newle$.
 \ProseOtherwiseTypeError
 One of the following applies:
 \begin{itemize}
 \item TypingRule.LEDiscard (see \secref{TypingRule.LEDiscard}),
-\item TypingRule.LELocalVar (see \secref{TypingRule.LELocalVar}),
-\item TypingRule.LEGlobalVar (see \secref{TypingRule.LEGlobalVar}),
+\item TypingRule.LEVar (see \secref{TypingRule.LEVar}),
 \item TypingRule.LEDestructuring (see \secref{TypingRule.LEDestructuring}),
 \item TypingRule.LESlice (see \secref{TypingRule.LESlice}),
 \item TypingRule.LESetArray (see \secref{TypingRule.LESetArray}),
-\item TypingRule.LESetBadStructuredField (see \secref{TypingRule.LESetBadStructuredField}),
 \item TypingRule.LESetStructuredField (see \secref{TypingRule.LESetStructuredField}),
 \item TypingRule.LESetBadBitField (see \secref{TypingRule.LESetBadBitField}),
 \item TypingRule.LESetBitField (see \secref{TypingRule.LESetBitField}),
@@ -6726,7 +6828,6 @@ The correspondence is defined in the ASL Syntax Reference~\cite[Chapter 5]{ASLAb
 and given by the function $\torexpr : \lexpr \rightarrow \expr$.
 
 \section{TypingRule.LEDiscard \label{sec:TypingRule.LEDiscard}}
-
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
@@ -6735,79 +6836,83 @@ All of the following apply:
 \end{itemize}
 
 \isempty{\subsection{Example}}
-
 \CodeSubsection{\LEDiscardBegin}{\LEDiscardEnd}{../Typing.ml}
 
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{}{
-  \annotatelexpr{\tenv, \overname{\LEDiscard}{\vlt}, \vte} \typearrow \overname{\LEDiscard}{\newle}
+  \annotatelexpr{\tenv, \overname{\LEDiscard}{\vle}, \vte} \typearrow \overname{\LEDiscard}{\newle}
 }
 \end{mathpar}
 
 \isempty{\subsection{Comments}}
 
-\section{TypingRule.LELocalVar \label{sec:TypingRule.LELocalVar}}
-
+\section{TypingRule.LEVar \label{sec:TypingRule.LEVar}}
+\CodeSubsection{\LEVarBegin}{\LEVarEnd}{../Typing.ml}
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\vle$ denotes a local variable $\vx$, that is, $\LEVar(\vx)$;
-  \item $\vx$ is locally declared as a mutable variable of type $\tty$ in $\tenv$;
-  \item determining whether $\tty$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$\ProseOrTypeError;
-  \item $\newle$ is $\vle$.
+  \item $\vle$ denotes a left-hand-side variable expression for $\vx$, that is, $\LEVar(\vx)$;
+  \item One of the following applies (\textsc{local}):
+  \begin{itemize}
+    \item $\vx$ is declared in $\tenv$ as a local storage element with type $\tty$ and local declaration keyword $k$;
+    \item checking that $k$ corresponds to a mutable variable, that is, $\LDKVar$, yields $\True$\ProseTerminateAs{\AssignmentToImmutable};
+    \item determining whether $\tty$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$\ProseOrTypeError;
+    \item $\newle$ is $\vle$.
+  \end{itemize}
+
+  \item One of the following applies (\textsc{global}):
+  \begin{itemize}
+    \item $\vx$ is declared in $\tenv$ as a global storage element with type $\tty$ and global declaration keyword $k$;
+    \item checking that $k$ corresponds to a mutable variable, that is, $\GDKVar$, yields $\True$\ProseTerminateAs{\AssignmentToImmutable};
+    \item determining whether $\tty$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$\ProseOrTypeError;
+    \item $\newle$ is $\vle$.
+  \end{itemize}
+
+  \item One of the following applies (\textsc{error\_undefined}):
+  \begin{itemize}
+    \item $\vx$ is not declared in $\tenv$ as a local storage element nor as a global storage element;
+    \item the result is a type error $\UndefinedIdentifier$.
+  \end{itemize}
 \end{itemize}
 
-\isempty{\subsection{Example}}
-
-\CodeSubsection{\LELocalVarBegin}{\LELocalVarEnd}{../Typing.ml}
+\CodeSubsection{\LEVarBegin}{\LEVarEnd}{../Typing.ml}
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule{
-  \vle \eqname \LEVar(\vx)\\
-  L^\tenv.\localstoragetypes(\id) = (\tty, \LDKVar)\\
+\inferrule[local]{
+  L^\tenv.\localstoragetypes(\id) = (\tty, k)\\
+  \checktrans{k = \LDKVar}{\AssignmentToImmutable} \checktransarrow \True \OrTypeError\\\\
   \checktypesat(\tenv, \vte, \tty) \typearrow \True \OrTypeError
 }{
-  \annotatelexpr{\tenv, \vle, \vte} \typearrow \vle
+  \annotatelexpr{\tenv, \overname{\LEVar(\vx)}{\vle}, \vte} \typearrow \overname{\vle}{\newle}
 }
 \end{mathpar}
 
+\begin{mathpar}
+\inferrule[global]{
+  L^\tenv.\globalstoragetypes(\id) = (\tty, k)\\
+  \checktrans{k = \GDKVar}{AssignToImmutable} \checktransarrow \True \OrTypeError\\\\
+  \checktypesat(\tenv, \vte, \tty) \typearrow \True \OrTypeError
+}{
+  \annotatelexpr{\tenv, \overname{\LEVar(\vx)}{\vle}, \vte} \typearrow \overname{\vle}{\newle}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[error\_undefined]{
+  L^\tenv.\localstoragetypes(\id) = \bot\\
+  L^\tenv.\globalstoragetypes(\id) = \bot
+}{
+  \annotatelexpr{\tenv, \overname{\LEVar(\vx)}{\vle}, \vte} \typearrow \TypeErrorVal{\UndefinedIdentifier}
+}
+\end{mathpar}
 
 \isempty{\subsection{Comments}}
 \lrmcomment{
   This is related to \identr{WDGQ}, \identr{GNTS}, \identi{MMKF},
   \identi{DGWJ}, \identi{KKCC} and \identr{LXQZ}.
 }
-
-\section{TypingRule.LEGlobalVar \label{sec:TypingRule.LEGlobalVar}}
-
-\subsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\vle$ denotes a local variable $\vx$, that is, $\LEVar(\vx)$;
-  \item $\vx$ is globally declared as a mutable variable of type $\tty$ in $\tenv$;
-  \item determining whether $\tty$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$\ProseOrTypeError;
-  \item $\newle$ is $\vle$.
-\end{itemize}
-
-\isempty{\subsection{Example}}
-
-\CodeSubsection{\LEGlobalVarBegin}{\LEGlobalVarEnd}{../Typing.ml}
-
-\subsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \vle \eqname \LEVar(\vx)\\
-  G^\tenv.\globalstoragetypes(\vx) = (\tty, \GDKVar)\\
-  \checktypesat(\tenv, \vte, \tty) \typearrow \True \OrTypeError
- }{
-  \annotatelexpr{\tenv, \vle, \vte} \typearrow \overname{\vle}{\newle}
-}
-\end{mathpar}
-
-\isempty{\subsection{Comments}}
-\lrmcomment{This is related to \identr{WDGQ}.}
 
 \section{TypingRule.LEDestructuring \label{sec:TypingRule.LEDestructuring}}
 
@@ -6816,12 +6921,13 @@ All of the following apply:
 \begin{itemize}
   \item $\vle$ denotes a tuple of left-hand-side expressions $\les$, that is, $\LEDestructuring(\les)$;
   \item $\les$ is a list $\ve_{1..k}$;
-  \item $\vte$ is a tuple type $\subtys$;
-  \item determining whether $\les$ and $\subtys$ have the same length yields $\True$\ProseOrTypeError;
+  \item checking whether $\vte$ is a tuple type yields $\True$\ProseTerminateAs{\ExpectedTupleType};
+  \item $\vte$ is a tuple type over the list of types $\tys$, that is, $\TTuple(\tys)$;
+  \item determining whether $\les$ and $\subtys$ have the same length yields $\True$\ProseTerminateAs{\LengthsMismatch};
   \item $\subtys$ is the list of types $\vt_{1..k}$;
   \item annotating the left-hand-side expression $\ve_i$ with the type $\vt_i$, for $i=1..k$, yields $\vep_i$\ProseOrTypeError;
   \item the list of expressions $\lesp$ is $\vep_i$, for $i=1..k$;
-  \item $\newle$  is the list of left-hand-side expressions $\lesp$, that is, $\LEDestructuring(\lesp)$.
+  \item $\newle$ is the list of left-hand-side expressions $\lesp$, that is, $\LEDestructuring(\lesp)$.
 \end{itemize}
 
 \isempty{\subsection{Example}}
@@ -6831,17 +6937,16 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \vle \eqname \LEDestructuring(\les)\\
   \les \eqname [\ve_{1..k}]\\
-  \checktrans{\astlabel(\vle) = \TTuple}{TupleTypeExpected} \checktransarrow \True \OrTypeError\\\\
-  \vte \eqname \TTuple(\subtys)\\
-  \equallength(\les, \subtys) \typearrow \vb\\
-  \checktrans{\vb}{DifferentLengths} \checktransarrow \True \OrTypeError\\\\
-  \subtys \eqname [\vt_{1..k}]\\
+  \checktrans{\astlabel(\vte) = \TTuple}{\ExpectedTupleType} \checktransarrow \True \OrTypeError\\\\
+  \vte \eqname \TTuple(\tys)\\
+  \equallength(\les, \tys) \typearrow \vb\\
+  \checktrans{\vb}{\LengthsMismatch} \checktransarrow \True \OrTypeError\\\\
+  \tys \eqname [\vt_{1..k}]\\
   i=1..k: \annotatelexpr{\tenv, \ve_i,\vt_i} \typearrow \vep_i \OrTypeError\\\\
   \lesp \eqname [i=1..k: \vep_i]
 }{
-  \annotatelexpr{\tenv, \vle, \vte} \typearrow \LEDestructuring(\lesp)
+  \annotatelexpr{\tenv, \overname{\LEDestructuring(\les)}{\vle}, \vte} \typearrow \overname{\LEDestructuring(\lesp)}{\newle}
 }
 \end{mathpar}
 
@@ -6934,40 +7039,7 @@ All of the following apply:
 
 \isempty{\subsection{Comments}}
 
-\section{TypingRule.LESetBadStructuredField \label{sec:TypingRule.LESetBadStructuredField}}
-
-\subsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
-  \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\
-        $\vletwo$\ProseOrTypeError;
-  \item the \structure\ of $\vtleone$ in $\tenv$ is a \structuredtype\ with list of fields $\fields$\ProseOrTypeError;
-  \item $\field$ is not associated with any type in $\fields$;
-  \item the result is an error indicating that the field $\field$ is missing from the type of $\vleone$.
-\end{itemize}
-
-\isempty{\subsection{Example}}
-
-\CodeSubsection{\LESetBadStructuredFieldBegin}{\LESetBadStructuredFieldEnd}{../Typing.ml}
-
-\subsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\\\
-  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\\\
-  \tstruct(\tenv, \vtleone) \typearrow L(\fields) \OrTypeError\\\\
-  L \in \{\TException, \TRecord\}\\
-  \assocopt(\fields, \field) \typearrow \None
-}{
-  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \TypeErrorVal{MissingField}
-}
-\end{mathpar}
-
-\isempty{\subsection{Comments}}
-
 \section{TypingRule.LESetStructuredField \label{sec:TypingRule.LESetStructuredField}}
-
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
@@ -6976,6 +7048,7 @@ All of the following apply:
   \item annotating the left-hand-side expression  $\vleone$ with type $\vtleone$ in $\tenv$ yields $\vletwo$\ProseOrTypeError;
   \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a\structuredtype\ with fields \\
         $\fields$\ProseOrTypeError;
+  \item checking that there exists a type associated with the field $\field$ in $\fields$ $\True$ \ProseTerminateAs{\MissingField};
   \item the type associated with the field $\field$ in $\fields$ is $\vt$;
   \item determining whether $\vte$ \typesatisfies\ $\vt$ yields $\True$\ProseOrTypeError;
   \item $\newle$ is the access to the field $\field$ in $\vletwo$, that is, $\LESetField(\vletwo, \field)$.
@@ -6992,7 +7065,9 @@ All of the following apply:
   \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\\\
   \tstruct(\tenv, \vtleone) \typearrow L(\fields) \OrTypeError\\\\
   L \in \{\TException, \TRecord\}\\
-  \assocopt(\fields, \field) \typearrow \langle\vt\rangle\\
+  \assocopt(\fields, \field) \typearrow \tyopt\\
+  \checktrans{\tyopt \neq \None}{\MissingField} \checktransarrow \True \OrTypeError\\\\
+  \tyopt \eqname \langle\vt\rangle\\
   \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\\\
   \newle \eqdef \LESetField(\vletwo, \field)
 }{
@@ -7002,122 +7077,9 @@ All of the following apply:
 
 \isempty{\subsection{Comments}}
 
-\section{TypingRule.LESetBadBitField \label{sec:TypingRule.LESetBadBitField}}
-
-\subsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
-  \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\
-        $\vtleone$\ProseOrTypeError;
-  \item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$\ProseOrTypeError;
-  \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a bitvector type with bitfields \\ $\bitfields$, that is,
-        $\TBits(\Ignore, \bitfields)$\ProseOrTypeError;
-  \item find whether a bitfield $\field$ exists in $\bitfields$ yields $\None$;
-  \item the result is a type error indicating that the field $\field$ is missing from the type of $\vleone$.
-\end{itemize}
-
-\isempty{\subsection{Example}}
-
-\CodeSubsection{\LESetBadBitFieldBegin}{\LESetBadBitFieldEnd}{../Typing.ml}
-
-\subsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\\\
-  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\\\
-  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\\\
-  \findbitfieldopt(\bitfields, \field) \typearrow \None
-}{
-  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \TypeErrorVal{MissingField}
-}
-\end{mathpar}
-
-\isempty{\subsection{Comments}}
-
 \section{TypingRule.LESetBitField \label{sec:TypingRule.LESetBitField}}
-
+%%%%%% NEW %%%%%%
 \subsection{Prose}
-All of the following apply:
-\begin{itemize}
-\item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
-\item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$\ProseOrTypeError;
-\item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$\ProseOrTypeError;
-\item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a bitvector type with with bitfields $\bitfields$\ProseOrTypeError;
-\item looking for $\field$ in $\bitfields$ yields a bitfield with corresponding slices $\slices$, that is, $\BitFieldSimple(\Ignore, \slices)$;
-\item $\vw$ is the width of $\slices$;
-\item $\vt$ is defined as the bitvector type of width $\vw$ and empty list of bitfields, that is, $\TBits(\vw, \emptylist)$;
-\item checking whether $\vt$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$\ProseOrTypeError;
-\item $\vletwo$ is defined as the slicing of $\vleone$ by $\slices$, that is, $\LESlice(\vleone, \slices)$;
-\item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields $\newle$\ProseOrTypeError.
-\end{itemize}
-
-\isempty{\subsection{Example}}
-
-\CodeSubsection{\LESetBitFieldBegin}{\LESetBitFieldEnd}{../Typing.ml}
-
-\subsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\\\
-  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\\\
-  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\\\
-  \findbitfieldopt(\bitfields, \field) \typearrow \langle \BitFieldSimple(\Ignore, \slices) \rangle\\
-  \sliceswidth(\tenv, \vslices) \typearrow \vw\\
-  \vt \eqdef \TBits(\vw, \emptylist)\\
-  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\\\
-  \vletwo \eqdef \LESlice(\vleone, \slices)\\
-  \annotatelexpr{\tenv, \vletwo, \vte} \typearrow \newle \OrTypeError
-}{
-  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \newle
-}
-\end{mathpar}
-
-\isempty{\subsection{Comments}}
-
-\section{TypingRule.LESetBitFieldNested \label{sec:TypingRule.LESetBitFieldNested}}
-
-\subsection{Prose}
-All of the following apply:
-\begin{itemize}
-\item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
-\item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$\ProseOrTypeError;
-\item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$\ProseOrTypeError;
-\item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a bitvector type with with bitfields $\bitfields$\ProseOrTypeError;
-\item looking for $\field$ in $\bitfields$ yields a nested bitfield with corresponding slices $\slices$ and list of bitfields
-      $\bitfieldsp$, that is, \\ $\BitFieldNested(\Ignore, \slices, \bitfieldsp)$;
-\item $\vw$ is the width of $\slices$;
-\item $\vt$ is defined as the bitvector type of width $\vw$ and list of bitfields $\bitfieldsp$, that is, $\TBits(\vw, \bitfieldsp)$;
-\item checking whether $\vt$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$\ProseOrTypeError;
-\item $\vlethree$ is defined as the slicing of $\vleone$ by $\slices$, that is, $\LESlice(\vleone, \slices)$;
-\item annotating the left-hand-side expression $\vlethree$ in $\tenv$ yields $\newle$\ProseOrTypeError.
-\end{itemize}
-
-\isempty{\subsection{Example}}
-
-\CodeSubsection{\LESetBitFieldNestedBegin}{\LESetBitFieldNestedEnd}{../Typing.ml}
-
-\subsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\\\
-  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\\\
-  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\\\
-  \findbitfieldopt(\bitfields, \field) \typearrow \langle \BitFieldNested(\Ignore, \slices, \bitfieldsp) \rangle\\
-  \sliceswidth(\tenv, \vslices) \typearrow \vw\\
-  \vt \eqdef \TBits(\vw, \bitfieldsp)\\
-  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\\\
-  \vlethree \eqdef \LESlice(\vleone, \slices)\\
-  \annotatelexpr{\tenv, \vlethree, \vte} \typearrow \newle \OrTypeError
-}{
-  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \newle
-}
-\end{mathpar}
-
-\isempty{\subsection{Comments}}
-
-\section{TypingRule.LESetBitFieldTyped \label{sec:TypingRule.LESetBitFieldTyped}}
-
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
@@ -7125,30 +7087,74 @@ All of the following apply:
   \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore)$\ProseOrTypeError;
   \item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $\vletwo$\ProseOrTypeError;
   \item obtaining the \structure\ of $\vtleone$ in $\tenv$ yields a bitvector type with with bitfields $\bitfields$\ProseOrTypeError;
-  \item looking for $\field$ in $\bitfields$ yields a typed bitfield with corresponding slices $\slices$ and a type $\vt$,
-        that is, \\ $\BitFieldType(\Ignore, \vslices, \vt))$;
-  \item $\vw$ is the width of $\slices$;
-  \item $\vtp$ is defined as the bitvector type of width $\vw$ and an empty list of bitfields, that is, $\TBits(\vw , \emptylist)$;
-  \item checking whether $\vtp$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
-  \item checking whether $\vt$ \typesatisfies\ $\vte$ in $\tenv$ yields $\True$\ProseOrTypeError;
-  \item $\vletwo$ is defined as the slicing of $\vleone$ by $\slices$, that is, $\LESlice(\vleone, \slices)$;
-  \item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields $\newle$\ProseOrTypeError.
+  \item One of the following applies:
+  \begin{itemize}
+    \item All of the following applies (\textsc{error\_missing\_field}):
+    \begin{itemize}
+      \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields $\None$, meaning the field is not declared
+            in $\vtleone$;
+      \item the result is a type error $\MissingField$.
+    \end{itemize}
+
+    \item All of the following applies (\textsc{field\_simple}):
+    \begin{itemize}
+      \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields a bitfield with corresponding slices $\slices$,
+            that is, $\BitFieldSimple(\Ignore, \slices)$;
+      \item $\vw$ is the width of $\slices$;
+      \item $\vt$ is defined as the bitvector type of width $\vw$ and empty list of bitfields, that is, $\TBits(\vw, \emptylist)$;
+      \item checking whether$\vte$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
+      \item $\vletwo$ is defined as the slicing of $\vleone$ by $\slices$, that is, \\ $\LESlice(\vleone, \slices)$;
+      \item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields $\newle$\ProseOrTypeError.
+    \end{itemize}
+
+    \item All of the following applies (\textsc{field\_nested}):
+    \begin{itemize}
+      \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields a nested bitfield with corresponding
+            slices $\slices$ and list of bitfields $\bitfieldsp$, that is, \\ $\BitFieldNested(\Ignore, \slices, \bitfieldsp)$;
+      \item $\vw$ is the width of $\slices$;
+      \item $\vt$ is defined as the bitvector type of width $\vw$ and list of bitfields $\bitfieldsp$, that is, $\TBits(\vw, \bitfieldsp)$;
+      \item checking whether$\vte$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
+      \item $\vlethree$ is defined as the slicing of $\vleone$ by $\slices$, that is, \\ $\LESlice(\vleone, \slices)$;
+      \item annotating the left-hand-side expression $\vlethree$ in $\tenv$ yields $\newle$\ProseOrTypeError.
+    \end{itemize}
+
+    \item All of the following applies (\textsc{field\_typed}):
+    \begin{itemize}
+      \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields a typed bitfield with corresponding
+            slices $\slices$ and a type $\vt$, that is, \\ $\BitFieldType(\Ignore, \vslices, \vt))$;
+      \item $\vw$ is the width of $\slices$;
+      \item $\vtp$ is defined as the bitvector type of width $\vw$ and an empty list of bitfields, that is, $\TBits(\vw , \emptylist)$;
+      \item checking whether $\vtp$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
+      \item checking whether$\vte$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
+      \item $\vletwo$ is defined as the slicing of $\vleone$ by $\slices$, that is, \\ $\LESlice(\vleone, \slices)$;
+      \item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields $\newle$\ProseOrTypeError.
+    \end{itemize}
+  \end{itemize}
 \end{itemize}
-
-\isempty{\subsection{Example}}
-
-\CodeSubsection{\LESetBitFieldTypedBegin}{\LESetBitFieldTypedEnd}{../Typing.ml}
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule{
+\inferrule[error\_missing\_field]{
   \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\\\
   \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\\\
   \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\\\
-  \findbitfieldopt(\bitfields, \field) \typearrow \langle \BitFieldType(\Ignore, \vslices, \vt) \rangle\\
+  \commonprefixline\\\\
+  \findbitfieldopt(\bitfields, \field) \typearrow \None\
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \TypeErrorVal{\MissingField}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[field\_simple]{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\\\
+  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\\\
+  \commonprefixline\\\\
+  \findbitfieldopt(\bitfields, \field) \typearrow \langle \BitFieldSimple(\Ignore, \slices) \rangle\\
   \sliceswidth(\tenv, \vslices) \typearrow \vw\\
-  \vtp \eqdef \TBits(\vw , \emptylist)
-  \checktypesat(\tenv, \vtp, \vt) \typearrow \True \OrTypeError\\\\
+  \vt \eqdef \TBits(\vw, \emptylist)\\\\
+  \commonsuffixline\\\\
   \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\\\
   \vletwo \eqdef \LESlice(\vleone, \slices)\\
   \annotatelexpr{\tenv, \vletwo, \vte} \typearrow \newle \OrTypeError
@@ -7157,7 +7163,42 @@ All of the following apply:
 }
 \end{mathpar}
 
-\isempty{\subsection{Comments}}
+\begin{mathpar}
+\inferrule[field\_nested]{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\\\
+  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\\\
+  \commonprefixline\\\\
+  \findbitfieldopt(\bitfields, \field) \typearrow \langle \BitFieldNested(\Ignore, \slices, \bitfieldsp) \rangle\\
+  \sliceswidth(\tenv, \vslices) \typearrow \vw\\
+  \vt \eqdef \TBits(\vw, \bitfieldsp)\\\\
+  \commonsuffixline\\\\
+  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\\\
+  \vletwo \eqdef \LESlice(\vleone, \slices)\\
+  \annotatelexpr{\tenv, \vletwo, \vte} \typearrow \newle \OrTypeError
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \TypeErrorVal{MissingField}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[field\_typed]{
+  \annotateexpr{\tenv, \torexpr(\vleone)} \typearrow (\vtleone, \Ignore) \OrTypeError\\\\
+  \annotatelexpr{\tenv, \vleone, \vtleone} \typearrow \vletwo \OrTypeError\\\\
+  \tstruct(\tenv, \vtleone) \typearrow \TBits(\Ignore, \bitfields) \OrTypeError\\\\
+  \commonprefixline\\\\
+  \findbitfieldopt(\bitfields, \field) \typearrow \langle \BitFieldType(\Ignore, \vslices, \vt) \rangle\\
+  \sliceswidth(\tenv, \vslices) \typearrow \vw\\
+  \vtp \eqdef \TBits(\vw , \emptylist)\\
+  \checktypesat(\tenv, \vtp, \vt) \typearrow \True \OrTypeError\\\\
+  \commonsuffixline\\\\
+  \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\\\
+  \vletwo \eqdef \LESlice(\vleone, \slices)\\
+  \annotatelexpr{\tenv, \vletwo, \vte} \typearrow \newle \OrTypeError
+}{
+  \annotatelexpr{\tenv, \overname{\LESetField(\vleone, \field)}{\vle}, \vte} \typearrow \TypeErrorVal{MissingField}
+}
+\end{mathpar}
 
 \section{TypingRule.LESetBadField \label{sec:TypingRule.LESetBadField}}
 
@@ -7279,7 +7320,7 @@ The function
   \aslto
   \overname{\slice}{\vsp} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-annotates a slices $\vs$ in the static environment $\tenv$,
+annotates a single slice $\vs$ in the static environment $\tenv$,
 resulting in an annotated slice $\vsp$.
 \ProseOtherwiseTypeError
 
@@ -7328,7 +7369,7 @@ All of the following apply:
 \inferrule{
   \annotateslice(\SliceLength(\vi, \eliteral{1})) \typearrow \vsp \OrTypeError
 }{
-  \annotateslice(\tenv, \SliceSingle(\vi)) \typearrow \vsp
+  \annotateslice(\tenv, \overname{\SliceSingle(\vi)}{\vs}) \typearrow \vsp
 }
 \end{mathpar}
 
@@ -7357,12 +7398,12 @@ All of the following apply:
 \inferrule{
   \annotateexpr{\tenv, \eoffset} \typearrow (\toffset, \eoffsetp) \OrTypeError\\\\
   \annotatestaticconstrainedinteger(\tenv, \elength) \typearrow \elengthp \OrTypeError\\\\
-  \checkstructureinteger(\tenv, \eoffsetp, \toffset) \typearrow \True \OrTypeError
+  \checkstructureinteger(\tenv, \toffset) \typearrow \True \OrTypeError
 }{
   {
     \begin{array}{r}
-  \annotateslice(\tenv, \SliceLength(\eoffset, \elength)) \typearrow \\
-    \SliceLength(\eoffsetp, \elength')
+  \annotateslice(\tenv, \overname{\SliceLength(\eoffset, \elength)}{\vs}) \typearrow \\
+    \overname{\SliceLength(\eoffsetp, \elength')}{\vsp}
     \end{array}
   }
 }
@@ -7391,7 +7432,7 @@ All of the following apply:
   \binopliterals(\PLUS, \prelengthp, \eliteral{1}) \typearrow \prelength\\
   \annotateslice(\SliceLength(\vi, \prelength)) \typearrow \vsp \OrTypeError
 }{
-  \annotateslice(\tenv, \SliceRange(\vj, \vi)) \typearrow \vsp
+  \annotateslice(\tenv, \overname{\SliceRange(\vj, \vi)}{\vs}) \typearrow \vsp
 }
 \end{mathpar}
 
@@ -7418,7 +7459,7 @@ All of the following apply:
   \binopliterals(\MUL, \factor, \prelength) \typearrow \preoffset\\
   \annotateslice(\SliceLength(\preoffset, \prelength)) \typearrow \vsp \OrTypeError
 }{
-  \annotateslice(\tenv, \SliceStar(\factor, \prelength)) \typearrow \vsp
+  \annotateslice(\tenv, \overname{\SliceStar(\factor, \prelength)}{\vs}) \typearrow \vsp
 }
 \end{mathpar}
 
@@ -7429,7 +7470,8 @@ All of the following apply:
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item annotating the slices in $\slices$ from left to right yields the list of annotated slices $\slicesp$\ProseOrTypeError.
+  \item annotating the slice $\vslices[\vi]$ in $\tenv$, for each $\vi\in\listrange(\vslices)$, yields the slice $\vs_\vi$\ProseOrTypeError;
+  \item define $\slicesp$ as the list of slices $\vs_\vi$, for each $\vi\in\listrange(\vslices)$.
 \end{itemize}
 
 \isempty{\subsection{Example}}
@@ -7437,17 +7479,17 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \vs\in\slices: \annotateslice(\tenv, \vs) \typearrow \vsp \OrTypeError\\\\
-  \slicesp = [\vs\in\slices: \vsp]
+  \vi\in\listrange(\vslices): \annotateslice(\tenv, \vslices[\vi]) \typearrow \vs_\vi \OrTypeError\\\\
+  \slicesp \eqdef [\vi\in\listrange(\vslices): \vs_\vi]
 }{
-  \annotateslices(\tenv, \slices) \typearrow \slicesp
+  \annotateslices(\tenv, \vslices) \typearrow \slicesp
 }
 \end{mathpar}
 
 \isempty{\subsection{Comments}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\chapter{Typing of Patterns}
+\chapter{Typing of Patterns \label{chap:typingpatterns}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \hypertarget{def-annotatepattern}{}
 The function
@@ -7488,7 +7530,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{}
 {
-  \annotatepattern(\tenv, \vt, \PatternAll) \typearrow \PatternAll
+  \annotatepattern(\tenv, \vt, \overname{\PatternAll}{\vp}) \typearrow \overname{\PatternAll}{\newp}
 }
 \end{mathpar}
 
@@ -7515,7 +7557,7 @@ All of the following apply:
   \newli \eqdef [\vl\in\vli: \vlp]
 }
 {
-  \annotatepattern(\tenv, \vt, \PatternAny(\vli)) \typearrow \PatternAny(\newli)
+  \annotatepattern(\tenv, \vt, \overname{\PatternAny(\vli)}{\vp}) \typearrow \overname{\PatternAny(\newli)}{\newp}
 }
 \end{mathpar}
 
@@ -7559,7 +7601,7 @@ which short-circuits the entire rule;
   \checktrans{\vb}{InvalidTypesForBinop} \checktransarrow \True \OrTypeError
 }
 {
-  \annotatepattern(\tenv, \vt, \PatternGeq(\ve)) \typearrow \PatternGeq(\vep)
+  \annotatepattern(\tenv, \vt, \overname{\PatternGeq(\ve)}{\vp}) \typearrow \overname{\PatternGeq(\vep)}{\newp}
 }
 \end{mathpar}
 
@@ -7601,9 +7643,8 @@ which short-circuits the entire rule;
     \end{array}
   }\\
   \checktrans{\vb}{InvalidTypesForBinop} \checktransarrow \True \OrTypeError
-}
-{
-  \annotatepattern(\tenv, \vt, \PatternLeq(\ve)) \typearrow \PatternLeq(\vep)
+}{
+  \annotatepattern(\tenv, \vt, \overname{\PatternLeq(\ve)}{\vp}) \typearrow \overname{\PatternLeq(\vep)}{\newp}
 }
 \end{mathpar}
 
@@ -7612,11 +7653,11 @@ which short-circuits the entire rule;
 \section{TypingRule.PNot \label{sec:TypingRule.PNot}}
 
 \subsection{Prose}
-Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt{annotate\_pattern}) results in a pattern $\newp$ and all of the following apply:
+All of the following apply:
 \begin{itemize}
   \item $\vp$ is the pattern which matches the negation of a pattern $\vq$, that is, $\PatternNot(\vq)$;
   \item annotating $\vq$ in $\tenv$ yields $\newq$\ProseOrTypeError;
-  \item $\newp$ is pattern which matches the negation of $\newq$, that is, $\PatternLeq(\newq)$.
+  \item $\newp$ is pattern which matches the negation of $\newq$, that is, $\PatternNot(\newq)$.
 \end{itemize}
 
 \isempty{\subsection{Example}}
@@ -7628,7 +7669,7 @@ Annotating a pattern $\vt$ in an environment $\tenv$ given a type $\vt$ (\texttt
 \inferrule{
   \annotatepattern(\tenv, \vq) \typearrow \newq \OrTypeError
 }{
-  \annotatepattern(\tenv, \vt, \PatternNot(\vq)) \PatternNot \PatternLeq(\newq)
+  \annotatepattern(\tenv, \vt, \overname{\PatternNot(\vq)}{\vp}) \typearrow \overname{\PatternNot(\newq)}{\newp}
 }
 \end{mathpar}
 
@@ -7673,7 +7714,7 @@ All of the following apply:
   }\\
   \checktrans{\vb}{InvalidTypesForBinop} \checktransarrow \True \OrTypeError
 }{
-  \annotatepattern(\tenv, \vt, \PatternRange(\veone, \vetwo)) \typearrow \PatternRange(\veonep, \vetwop)
+  \annotatepattern(\tenv, \vt, \overname{\PatternRange(\veone, \vetwo)}{\vp}) \typearrow \overname{\PatternRange(\veonep, \vetwop)}{\newp}
 }
 \end{mathpar}
 
@@ -7692,18 +7733,21 @@ All of the following apply:
   \begin{itemize}
     \item All of the following apply (\textsc{t\_bool, t\_real, t\_int}):
     \begin{itemize}
-      \item the labels of $\vtstruct$ and $\testruct$ are both either $\TBool$, $\TReal$, or $\TInt$\ProseOrTypeError;
+      \item the AST label of $\vtstruct$ is one of $\TBool$, $\TReal$, or $\TInt$;
+      \item checking that the labels of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
     \end{itemize}
 
     \item All of the following apply (\textsc{t\_bits}):
     \begin{itemize}
-      \item the labels of $\vtstruct$ and $\testruct$ are both $\TBits$\ProseOrTypeError;
+      \item the AST label of $\vtstruct$ is $\TBits$;
+      \item checking that the labels of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
       \item determining whether the bitwidths of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
     \end{itemize}
 
     \item All of the following apply (\textsc{t\_enum}):
     \begin{itemize}
-      \item the labels of $\vtstruct$ and $\testruct$ are both $\TEnum$\ProseOrTypeError;
+      \item the AST label of $\vtstruct$ is $\TEnum$;
+      \item checking that the labels of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
       \item determining whether the lists of enumeration literals of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
     \end{itemize}
 
@@ -7727,14 +7771,11 @@ All of the following apply:
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
   \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \tstruct(\tenv, \vte) \typearrow \testruct \OrTypeError\\\\
-  {
-    \begin{array}{r}
-  \checktrans{\astlabel(\vtstruct) = \astlabel(\testruct)}{InvalidTypesForBinop} \checktransarrow \\ \True \OrTypeError
-    \end{array}
-  }\\
-  \astlabel(\vtstruct) \in \{\TBool, \TReal, \TInt\}
+  \commonprefixline\\\\
+  \astlabel(\vtstruct) \in \{\TBool, \TReal, \TInt\}\\
+  \checktrans{\astlabel(\vtstruct) = \astlabel(\testruct)}{\InvalidOperandTypesForBinop} \checktransarrow \True \OrTypeError
 }{
-  \annotatepattern(\tenv, \vt, \PatternSingle(\ve)) \typearrow \PatternSingle(\vep)
+  \annotatepattern(\tenv, \vt, \overname{\PatternSingle(\ve)}{\vp}) \typearrow \overname{\PatternSingle(\vep)}{\newp}
 }
 \end{mathpar}
 
@@ -7743,11 +7784,13 @@ All of the following apply:
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
   \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \tstruct(\tenv, \vte) \typearrow \vtestruct \OrTypeError\\\\
-  \astlabel(\vtstruct) = \astlabel(\testruct) = \TBits\\
+  \commonprefixline\\\\
+  \astlabel(\vtstruct) = \TBits\\
+  \checktrans{\astlabel(\vtstruct) = \astlabel(\testruct)}{\InvalidOperandTypesForBinop} \checktransarrow \True \OrTypeError\\
   \bitwidthequal(\tenv, \vtstruct, \testruct) \typearrow \vb\\
-  \checktrans{\vb}{BitvectorsDifferentWidths} \checktransarrow \True \OrTypeError\\
+  \checktrans{\vb}{BitvectorsDifferentWidths} \checktransarrow \True \OrTypeError
 }{
-  \annotatepattern(\tenv, \vt, \PatternSingle(\ve)) \typearrow \PatternSingle(\vep)
+  \annotatepattern(\tenv, \vt, \overname{\PatternSingle(\ve)}{\vp}) \typearrow \overname{\PatternSingle(\vep)}{\newp}
 }
 \end{mathpar}
 
@@ -7756,11 +7799,14 @@ All of the following apply:
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
   \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \tstruct(\tenv, \vte) \typearrow \vtestruct \OrTypeError\\\\
+  \commonprefixline\\\\
+  \astlabel(\vtstruct) = \TEnum\\
+  \checktrans{\astlabel(\vtstruct) = \astlabel(\testruct)}{\InvalidOperandTypesForBinop} \checktransarrow \True \OrTypeError\\
   \vtstruct \eqname \TEnum(\vlione)\\
   \vtestruct \eqname \TEnum(\vlitwo)\\
   \checktrans{\vlione = \vlitwo}{EnumDifferentLabels} \checktransarrow \True \OrTypeError\\
 }{
-  \annotatepattern(\tenv, \vt, \PatternSingle(\ve)) \typearrow \PatternSingle(\vep)
+  \annotatepattern(\tenv, \vt, \overname{\PatternSingle(\ve)}{\vp}) \typearrow \overname{\PatternSingle(\vep)}{\newp}
 }
 \end{mathpar}
 
@@ -7769,14 +7815,11 @@ All of the following apply:
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
   \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \tstruct(\tenv, \vte) \typearrow \testruct \OrTypeError\\\\
-  {
-    \begin{array}{r}
-  \checktrans{\astlabel(\vtstruct) = \astlabel(\testruct)}{InvalidTypesForBinop} \checktransarrow \\ \True \OrTypeError
-    \end{array}
-  }\\
-  \astlabel(\vtstruct) \in \{\TBool, \TReal, \TInt, \TBits, \TEnum\}
+  \commonprefixline\\\\
+  \checktrans{\astlabel(\vtstruct) = \astlabel(\testruct)}{\InvalidOperandTypesForBinop} \checktransarrow \True \OrTypeError\\
+  \astlabel(\vtstruct) \not\in \{\TBool, \TReal, \TInt, \TBits, \TEnum\}
 }{
-  \annotatepattern(\tenv, \vt, \PatternSingle(\ve)) \typearrow \TypeErrorVal{TypeConflict}
+  \annotatepattern(\tenv, \vt, \overname{\PatternSingle(\ve)}{\vp}) \typearrow \TypeErrorVal{TypeConflict}
 }
 \end{mathpar}
 
@@ -7806,7 +7849,7 @@ All of the following apply:
   \vn \eqdef \listlen{\vm}\\
   \checktypesat(\tenv, \vt, \TBits(\vn, \emptylist)) \typearrow \True \OrTypeError
 }{
-  \annotatepattern(\tenv, \vt, \PatternMask(\vm)) \typearrow \PatternMask(\vm)
+  \annotatepattern(\tenv, \vt, \overname{\PatternMask(\vm)}{\vp}) \typearrow \overname{\PatternMask(\vm)}{\newp}
 }
 \end{mathpar}
 
@@ -7843,7 +7886,7 @@ All of the following apply:
   \vi\in\listrange(\vli): \annotatepattern(\tenv, \vts[\vi], \vli[\vi]) \typearrow \vlip[i] \OrTypeError\\\\
   \newli \eqdef \vi\in\listrange(\vli): \vlip[\vi]
 }{
-  \annotatepattern(\tenv, \vt, \PatternTuple(\vli)) \typearrow \PatternTuple(\newli)
+  \annotatepattern(\tenv, \vt, \overname{\PatternTuple(\vli)}{\vp}) \typearrow \overname{\PatternTuple(\newli)}{\newp}
 }
 \end{mathpar}
 
@@ -7880,6 +7923,9 @@ One of the following applies:
 \end{itemize}
 
 \lrmcomment{This is related to \identr{YSPM}.}
+
+We also define the following helper rule:
+TypingRule.CheckCanBeInitializedWith \secref{TypingRule.CheckCanBeInitializedWith}.
 
 \section{TypingRule.LDDiscard \label{sec:TypingRule.LDDiscard}}
 
@@ -7958,7 +8004,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{
   \annotatetype{\tenv, \vt} \typearrow \vtp \OrTypeError\\\\
-  \canbeinitializedwith(\tenv, \vtp, \tty) \typearrow \True \OrTypeError\\\\
+  \checkcanbeinitializedwith(\tenv, \vtp, \tty) \typearrow \True \OrTypeError\\\\
   \annotatelocaldeclitem{\tenv, \vtp, \ldip, \ldk} \typearrow (\newtenv, \newldip) \OrTypeError
 }
 {
@@ -7970,14 +8016,13 @@ All of the following apply:
 \isempty{\subsection{Comments}}
 
 \section{TypingRule.LDTuple\label{sec:TypingRule.LDTuple}}
-
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
   \item $\ldi$ denotes a tuple of local declaration items $\ldi_{1..k}$, that is, $\LDITuple(\ldi_{1..k})$;
   \item determining the \structure\ of $\tty$ in $\tenv$ yields $\vtp$\ProseOrTypeError;
   \item determining whether $\vtp$ is a tuple type yields $\True$\ProseOrTypeError;
-  \item determining whether $\vtp$ the number of elements of $vtp$ is $k$ yields $\True$\ProseOrTypeError;
+  \item determining whether $\vtp$ the number of elements of $\vtp$ is $k$ yields $\True$\ProseOrTypeError;
   \item annotating the local declaration items in $\ldis$ from right to left with their corresponding
         (that is, with the same index) types $t_{1..k}$ in $\tenv$,
         propagating static environments from one annotation to the next,
@@ -8015,6 +8060,54 @@ All of the following apply:
 \end{mathpar}
 
 \isempty{\subsection{Comments}}
+
+\section{TypingRule.CheckCanBeInitializedWith \label{sec:TypingRule.CheckCanBeInitializedWith}}
+\hypertarget{def-checkcanbeinitializedwith}{}
+The function
+\[
+\checkcanbeinitializedwith(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vs} \aslsep \overname{\ty}{\vt})
+\typearrow \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+checks whether an expression of type $\vs$ can be used to initialize a storage element of type $\vt$ in the static environment
+$\tenv$.
+If the answer if $\False$, the result is a type error.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{okay}):
+  \begin{itemize}
+    \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\True$;
+    \item the result is $\True$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{error}):
+  \begin{itemize}
+    \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\False$;
+    \item the result is a type error indicating that an expression of type $\vs$ cannot
+          be used to initialize a storage element of type $\vt$.
+  \end{itemize}
+\end{itemize}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[okay]{
+  \typesatisfies(\tenv, \vt, \vs) \typearrow \True
+}{
+  \checkcanbeinitializedwith(\tenv, \vs, \vt) \typearrow \True
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[error]{
+  \typesatisfies(\tenv, \vt, \vs) \typearrow \False
+}{
+  \checkcanbeinitializedwith(\tenv, \vs, \vt) \typearrow \TypeErrorVal{CannotBeInitializedWith}
+}
+\end{mathpar}
+
+\isempty{\subsection{Comments}}
+\lrmcomment{This is related to \identr{ZCVD} and \identr{LXQZ}.}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Statements}
@@ -8056,6 +8149,8 @@ We also define the following helper functions:
   \item TypingRule.CaseAlt (see \secref{TypingRule.CaseAlt}),
   \item TypingRule.SForConstraints (see \secref{TypingRule.SForConstraints})
   \item TypingRule.AnnotateLoopLimit (see \secref{TypingRule.AnnotateLoopLimit})
+  \item TypingRule.DeclareLocalConstant (see \secref{TypingRule.DeclareLocalConstant})
+  \item TypingRule.AnnotateLocalDelItemUninit (\secref{TypingRule.AnnotateLocalDelItemUninit})
 \end{itemize}
 
 \section{TypingRule.SPass \label{sec:TypingRule.SPass}}
@@ -8089,14 +8184,14 @@ All of the following apply:
   \begin{itemize}
     \item All of the following apply (\textsc{setter}):
     \begin{itemize}
-      \item reducing $(\tenv, \vle, \vre)$ to a setter call via \\ $\inlinesetter{}$ yields the statement $\news$
+      \item reducing $(\tenv, \vle, \vre)$ to a setter call via \\ $\inlinesetter$ yields the statement $\news$
       (indicating that the assignment corresponds to setter)\ProseOrTypeError;
       \item $\newenv$ is $\tenv$.
     \end{itemize}
 
     \item All of the following apply (\textsc{non\_setter}):
     \begin{itemize}
-      \item reducing $(\tenv, \vle, \vre)$ to a setter call via \\ $\inlinesetter{}$ yields $\None$
+      \item reducing $(\tenv, \vle, \vre)$ to a setter call via \\ $\inlinesetter$ yields $\None$
             (indicating the assignment does not correspond to a setter);
       \item annotating the right-hand-side expression $\vre$ in $\tenv$ yields $(\vtre, \vreone)$\ProseOrTypeError;
       \item annotating the left-hand-side expression $\vle$ with the type $\vtre$ in $\tenv$ yields $\vleone$\ProseOrTypeError;
@@ -8114,13 +8209,13 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule[setter]{
-  \inlinesetter{\tenv, \vle, \vre} \typearrow \langle \news \rangle \OrTypeError\\
+  \inlinesetter(\tenv, \vle, \vre) \typearrow \langle \news \rangle \OrTypeError\\
 }{
   \annotatestmt(\tenv, \overname{\SAssign(\vle, \vre)}{\vs}) \typearrow (\news,\overname{\tenv}{\newtenv})
 }
 \and
 \inferrule[non\_setter]{
-  \inlinesetter{\tenv, \vle, \vre} \typearrow \langle \rangle \OrTypeError\\\\
+  \inlinesetter(\tenv, \vle, \vre) \typearrow \None \OrTypeError\\\\
   \annotateexpr{\tenv, \vre} \typearrow (\vtre, \vreone) \OrTypeError\\\\
   \annotatelexpr{\tenv, \vle, \vtre} \typearrow \vleone \OrTypeError
 }{
@@ -8282,7 +8377,11 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \annotatecall(\tenv, \name, \vargs, \STProcedure) \typearrow (\newname, \newargs, \eqs, \None)
+  {
+    \begin{array}{r}
+      \annotatecall(\tenv, \name, \vargs, \STProcedure) \typearrow \\ (\newname, \newargs, \eqs, \None) \OrTypeError
+    \end{array}
+  }
 }{
   {
     \begin{array}{r}
@@ -8456,8 +8555,8 @@ All of the following apply:
   \annotateexpr{\tenv, \veone} \typearrow (\vt, \vetwo) \OrTypeError\\\\
   \checktypesat(\tenv, \vt, \TBool) \typearrow \True \OrTypeError
 }{
-  \annotatestmt(\tenv, \overname{\SRepeat(\veone, \vsone, \vlimitone)}{\vs}) \typearrow
-  (\overname{\SRepeat(\vetwo, \vstwo, \vlimittwo)}{\news}, \overname{\tenv}{\newtenv})
+  \annotatestmt(\tenv, \overname{\SRepeat(\vsone, \veone, \vlimitone)}{\vs}) \typearrow
+  (\overname{\SRepeat(\vstwo, \vetwo, \vlimittwo)}{\news}, \overname{\tenv}{\newtenv})
 }
 \end{mathpar}
 
@@ -8617,8 +8716,8 @@ All of the following apply:
 \begin{itemize}
   \item $\vs$ is a try statement with statement $\vsp$, list of catchers $\catchers$ and an \optional\ \texttt{otherwise} block;
   \item annotating the statement $\vsp$ as a block statement yields $\vspp$\ProseOrTypeError;
-  \item annotating each catcher $\vc$ in $\catchers$ in $\tenv$ yields $\vcp$\ProseOrTypeError;
-  \item $\catchersp$ is the list of annotated catchers $\vcp$ for each $\vc\in\catchers$;
+  \item annotating each catcher $\catchers[\vi]$, for each $\vi$ in $\listrange(\catchers)$ in $\tenv$ yields $\vc\_\vi$\ProseOrTypeError;
+  \item $\catchersp$ is the list of annotated catchers $\vc\_\vi$ for each $\vi\in\listrange(\catchers)$;
   \item One of the following applies:
   \begin{itemize}
     \item All of the following apply (\textsc{no\_otherwise}):
@@ -8649,8 +8748,9 @@ All of the following apply:
 \begin{mathpar}
 \inferrule[no\_otherwise]{
   \annotateblock{\tenv, \vsp} \typearrow \vspp \OrTypeError\\\\
-  \vc \in \catchers: \annotatecatcher{\tenv, \vc} \typearrow \vcp \OrTypeError\\\\
-  \catchersp \eqdef [\vc \in \catchers : \vcp]\\
+  \vi\in\listrange(\catchers): \annotatecatcher{\tenv, \catchers[\vi]} \typearrow \vc_\vi \OrTypeError\\\\
+  \catchersp \eqdef [\vi\in\listrange(\catchers) : \vc_\vi]\\\\
+  \commonprefixline\\\\
   \news \eqdef \STry(\vspp, \catchersp, \None)
 }{
   \annotatestmt(\tenv, \overname{\STry(\vsp, \catchers, \None)}{\vs}) \typearrow (\news, \overname{\tenv}{\newtenv})
@@ -8658,9 +8758,10 @@ All of the following apply:
 \and
 \inferrule[otherwise]{
   \annotateblock{\tenv, \vsp} \typearrow \vspp \OrTypeError\\\\
+  \vi\in\listrange(\catchers): \annotatecatcher{\tenv, \catchers[\vi]} \typearrow \vc_\vi \OrTypeError\\\\
+  \catchersp \eqdef [\vi\in\listrange(\catchers) : \vc_\vi]\\\\
+  \commonprefixline\\\\
   \annotateblock{\tenv, \otherwise} \typearrow \otherwisep \OrTypeError\\\\
-  \vc \in \catchers: \annotatecatcher{\tenv, \vc} \typearrow \vcp \OrTypeError\\\\
-  \catchersp \eqdef [\vc \in \catchers : \vcp]\\
   \news \eqdef \STry(\vspp, \catchersp, \otherwise')
 }{
   \annotatestmt(\tenv, \overname{\STry(\vsp, \catchers, \langle\otherwise\rangle)}{\vs}) \typearrow (\news, \overname{\tenv}{\newtenv})
@@ -8706,14 +8807,16 @@ All of the following apply:
 \begin{mathpar}
 \inferrule[constant]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
-  \ldk =\LDKConstant\\
+  \ldk = \LDKConstant\\
   \reduceconstants(\tenv, \ve) \typearrow \vv \OrTypeError\\\\
-  \declarelocalconstant{\tenv, \vte, \vv, \ldi} \typearrow (\newtenv, \ldip)\\
+  \declarelocalconstant(\tenv, \vv, \ldi) \typearrow \newtenv\\
   \news \eqdef \SDecl(\LDKConstant, \ldip, \langle\vep\rangle)
 }{
   \annotatestmt(\tenv, \overname{\SDecl(\ldk, \ldi, \langle\ve\rangle)}{\vs}) \typearrow (\news, \newtenv)
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[non\_constant]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
   \ldk \neq \LDKConstant\\
@@ -8747,7 +8850,7 @@ All of the following apply:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \annotatelocaldeclitemuninit{\tenv, \ldi} \typearrow (\newtenv, \ldip) \OrTypeError\\\\
+  \annotatelocaldeclitemuninit(\tenv, \ldi) \typearrow (\newtenv, \ldip) \OrTypeError\\\\
   \news \eqdef \SDecl(\LDKVar, \ldip, \None)
 }{
   \annotatestmt(\tenv, \overname{\SDecl(\LDKVar, \ldi, \None)}{\vs}) \typearrow (\news, \newtenv)
@@ -8763,58 +8866,59 @@ The helper function
 \[
   \annotatecase{
     \overname{\staticenvs}{\tenv} \aslsep
-    \overname{\ty}{\vte} \aslsep
-    \overname{\casealt}{\vcase}
+    \overname{\casealt}{\vcase} \aslsep
+    \overname{\ty}{\vte}
   } \aslto
   \overname{\casealt}{\vcaseone} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-annotates the case clause $\vcase$ for matching an expression of type $\vte$ in $\tenv$,
-resulting in the annotated case clause $\vcaseone$, or a type error, if one is detected.
+annotates the case clause $\vcase$ for an expression of type $\vte$ in $\tenv$,
+resulting in the annotated case clause $\vcaseone$.
+\ProseOtherwiseTypeError
 
 \subsection{Prose}
 All of the following apply:
 \begin{itemize}
   \item $\vcase$ is a case clause with pattern $\vpzero$, \optional\ \texttt{where} expression $\vwzero$,
         and \texttt{otherwise} statement $\vszero$, that is,
-        $\{ \text{pattern} : \vpzero, \text{where} : \vwzero, \text{stmt} : \vszero \}$;
+        $\{ \CasePattern: \vpzero, \CaseWhere: \vwzero, \CaseStmt: \vszero \}$;
   \item annotating the pattern $\vpzero$ with type $\vte$ in $\tenv$ yields $\vpone$\ProseOrTypeError;
   \item annotating the statement $\vszero$ as a block statement in $\tenv$ yields $\vsone$\ProseOrTypeError;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{no\_where}):
+    \item All of the following apply (\textsc{no\_where\_stmt}):
     \begin{itemize}
       \item $\vwzero$ is $\None$ (that is, no \texttt{where} expression);
-      \item $\vcaseone$ is $\{ \text{pattern} : \vpone, \text{where} : \None, \text{stmt} : \vsone \}$.
+      \item $\vcaseone$ is $\{ \CasePattern: \vpone, \CaseWhere: \None, \CaseStmt: \vsone \}$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{where}):
+    \item All of the following apply (\textsc{where\_stmt}):
     \begin{itemize}
-      \item $\vwzero$ is the expression $\vewzero$;
+      \item $\vwzero$ is the singleton expression for $\vewzero$, that is, $\langle\vewzero\rangle$;
       \item annotating the expression $\vewzero$ in $\tenv$ yields $(\vtwe, \vewone)$\ProseOrTypeError;
       \item checking whether the structure of $\vtwe$ in $\tenv$ is that of the \texttt{boolean} type yields $\True$\ProseOrTypeError;
-      \item $\vcaseone$ is $\{ \text{pattern} : \vpone, \text{where} : \langle\vewone\rangle, \text{stmt} : \vsone \}$.
+      \item $\vcaseone$ is $\{ \CasePattern: \vpone, \CaseWhere: \langle\vewone\rangle, \CaseStmt: \vsone \}$.
     \end{itemize}
   \end{itemize}
 \end{itemize}
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule[no\_where]{
-  \vcase \eqname \{ \text{pattern} : \vpzero, \text{where} : \None, \text{stmt} : \vszero \}\\
+\inferrule[no\_where\_stmt]{
+  \vcase = \{ \CasePattern: \vpzero, \CaseWhere: \None, \CaseStmt : \vszero \}\\
   \annotatepattern(\tenv, \vte, \vpzero) \typearrow \vpone \OrTypeError\\\\
   \annotateblock{\tenv, \vszero} \typearrow \vsone \OrTypeError\\
 }{
-  \annotatecase{\tenv, \vcase} \typearrow \{ \text{pattern} : \vpone, \text{where} : \None, \text{stmt} : \vsone \}
+  \annotatecase{\tenv, \vcase, \vte} \typearrow \overname{\{ \CasePattern: \vpone, \CaseWhere: \None, \CaseStmt : \vsone \}}{\vcaseone}
 }
 \and
-\inferrule[where]{
-  \vcase \eqname \{ \text{pattern} : \vpzero, \text{where} : \langle\vewzero\rangle, \text{stmt} : \vszero \}\\
+\inferrule[where\_stmt]{
+  \vcase = \{ \CasePattern: \vpzero, \CaseWhere: \langle\vewzero\rangle, \CaseStmt : \vszero \}\\
   \annotatepattern(\tenv, \vte, \vpzero) \typearrow \vpone \OrTypeError\\\\
   \annotateblock{\tenv, \vszero} \typearrow \vsone \OrTypeError\\\\
   \annotateexpr{\tenv, \vewzero} \typearrow (\vtwe, \vewone) \OrTypeError\\\\
   \checkstructurelabel(\tenv, \vtwe, \TBool) \typearrow \True \OrTypeError
 }{
-  \annotatecase{\tenv, \vcase} \typearrow \{ \text{pattern} : \vpone, \text{where} : \langle\vewone\rangle, \text{stmt} : \vsone \}
+  \annotatecase{\tenv, \vcase, \vte} \typearrow \overname{\{ \CasePattern: \vpone, \CaseWhere: \langle\vewone\rangle, \CaseStmt : \vsone \}}{\vcaseone}
 }
 \end{mathpar}
 
@@ -8832,7 +8936,7 @@ The function
   ) \aslto
   \overname{\intconstraints}{\vis} \cup\ \overname{\TTypeError}{\TypeErrorConfig}
 \]
-infers the integer constraints --- $\vis$ --- for a \texttt{for} loop index variable from the following:
+infers the integer constraints for a \texttt{for} loop index variable from the following:
 \begin{itemize}
   \item the \wellconstrainedversion\ of the type of the start expression --- $\structone$
   \item the \wellconstrainedversion\ of the type of the end expression --- $\structtwo$
@@ -8840,6 +8944,7 @@ infers the integer constraints --- $\vis$ --- for a \texttt{for} loop index vari
   \item the annotated end expression --- $\vetwop$
   \item the loop direction --- $\dir$
 \end{itemize}
+The result is $\vis$.
 \ProseOtherwiseTypeError
 
 \subsection{Prose}
@@ -8953,6 +9058,138 @@ One of the following applies:
   \annotatelooplimit(\tenv, \overname{\langle\vlimit\rangle}{\vlimit}) \typearrow \overname{\langle\vlimitp\rangle}{\vlimitp}
 }
 \end{mathpar}
+
+\section{TypingRule.DeclareLocalConstant \label{sec:TypingRule.DeclareLocalConstant}}
+\hypertarget{def-declarelocalconstant}{}
+The function
+\[
+\declarelocalconstant(\overname{\staticenvs}{\tenv} \aslsep \overname{\literal}{\vv} \aslsep \overname{\localdeclitem}{\ldi})
+\typearrow \overname{\staticenvs}{\newtenv}
+\]
+adds the literal $\vv$ with the local declaration item $\ldi$ as a constant to the local component of the static environment $\tenv$,
+yielding the modified static environment $\newtenv$.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{discard}):
+  \begin{itemize}
+    \item $\ldi$ corresponds to a discarding declaration, that is, $\LDIDiscard$;
+    \item $\newtenv$ is $\tenv$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{var}):
+  \begin{itemize}
+    \item $\ldi$ corresponds to a variable declaration for $\vx$, that is, $\LDIVar(\vx)$;
+    \item define $\newtenv$ and the environment $\tenv$ with its global component updated by binding
+          $\vx$ to $\vv$ in its $\constantvalues$ map.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{tuple}):
+  \begin{itemize}
+    \item $\ldi$ corresponds to a tuple declaration, that is, $\LDIVar(\Ignore)$;
+    \item this case is not yet implemented.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{typed}):
+  \begin{itemize}
+    \item $\ldi$ corresponds to a typed declaration of the local declaration item $\ldip$ and some type, that is, $\LDITyped(\ldip, \Ignore)$;
+    \item applying $\declarelocalconstant$ to $\vv$ and $\ldip$ in $\tenv$ yields $\newtenv$.
+  \end{itemize}
+\end{itemize}
+
+\CodeSubsection{\DeclareLocalConstantBegin}{\DeclareLocalConstantEnd}{../Typing.ml}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[discard]{}{
+  \declarelocalconstant(\tenv, \vv, \overname{\LDIDiscard}{\ldi}) \typearrow \overname{\tenv}{\newtenv}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[var]{
+  \newtenv \eqdef (G^\tenv, L^\tenv.\constantvalues[\vx \mapsto \vv])
+}{
+  \declarelocalconstant(\tenv, \vv, \overname{\LDIVar(\vx)}{\ldi}) \typearrow \newtenv
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[tuple]{}{
+  \declarelocalconstant(\tenv, \vv, \overname{\LDITuple(\Ignore)}{\ldi}) \typearrow \tododefine{not implemented yet}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[typed]{
+  \declarelocalconstant(\tenv, \vv, \ldip) \typearrow \newtenv
+}{
+  \declarelocalconstant(\tenv, \vv, \overname{\LDITyped(\ldip, \Ignore)}{\ldi}) \typearrow \newtenv
+}
+\end{mathpar}
+
+\section{TypingRule.AnnotateLocalDelItemUninit \label{sec:TypingRule.AnnotateLocalDelItemUninit}}
+\hypertarget{def-annotatelocaldeclitemuninit}{}
+The function
+\[
+\begin{array}{r}
+\annotatelocaldeclitemuninit(\overname{\staticenvs}{\tenv} \aslsep \overname{\localdeclitem}{\ldi})
+\typearrow \\
+(\overname{\staticenvs}{\newtenv} \times \overname{\localdeclitem}{\newldi})
+\cup \overname{\TTypeError}{\TypeErrorConfig}
+\end{array}
+\]
+annotates the local declaration for a variable declaration without an initializing expressions in the static environment $\tenv$,
+yielding a pair consisting of the annotated local declaration item $\newldi$ and the modified static environment $\newtenv$.
+\ProseOtherwiseTypeError
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{discard}):
+  \begin{itemize}
+    \item $\ldi$ corresponds to a discarding declaration, that is, $\LDIDiscard$;
+    \item $\newtenv$ is $\tenv$ and $\newldi$ is $\ldi$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{typed}):
+  \begin{itemize}
+    \item $\ldi$ corresponds to a variable declaration via the local declaration item $\ldip$ and type annotation $\vt$,
+          that is, $\LDITyped(\ldip, \vt)$;
+    \item annotating $\vt$ in $\tenv$ yields $\vtp$\ProseOrTypeError;
+    \item annotating the local declaration item $\ldip$ with the type $\vtp$ and local declaration keyword $\LDIVar$
+          yields $(\newtenv, \newldip)$\ProseOrTypeError;
+    \item define $\newldi$ as the typed local declaration item with local declaration item $\newldip$ and type $\vtp$.
+  \end{itemize}
+\end{itemize}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[discard]{}{
+  \annotatelocaldeclitemuninit(\tenv, \overname{\LDIDiscard}{\ldi}) \typearrow (\overname{\tenv}{\newtenv}, \overname{\ldi}{\newldi})
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[typed]{
+  \annotatetype{\tenv, \vt} \typearrow \vtp \OrTypeError\\\\
+  \annotatelocaldeclitem{\tenv, \vtp, \LDKVar, \ldip} \typearrow (\newtenv, \newldip) \OrTypeError\\\\
+  \newldi \eqdef \LDITyped(\newldip, \vtp)
+}{
+  \annotatelocaldeclitemuninit(\tenv, \overname{\LDITyped(\ldip, \vt)}{\ldi}) \typearrow (\newtenv, \newldi)
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[error]{
+  \astlabel(\ldi) \in \{\LDIVar, \LDITuple\}
+}{
+  \annotatelocaldeclitemuninit(\tenv, \ldi) \typearrow \TypeErrorVal{ExpectedTypedDeclaration}
+}
+\end{mathpar}
+
+\CodeSubsection{\AnnotateLocalDeclItemUninitBegin}{\AnnotateLocalDeclItemUninitEnd}{../Typing.ml}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Blocks}
@@ -9307,7 +9544,7 @@ One of the following applies:
         \item $\calleeparamt$ is not the \parameterizedintegertype\ for the same parameter;
         \item substituting the parameter expressions from $\eqsthree$ in $\calleeparamt$
               yields $\calleeparamtrenamed$\ProseOrTypeError;
-        \item applying $\assocopt$ to $\eqsthree$ and $\vs$ the expression $\callerparame$
+        \item applying $\assocopt$ to $\eqsthree$ and $\vs$ yields the expression $\callerparame$
               (that is, the parameter $\vs$ is associated with the expression \\
               $\callerparame$);
         \item annotating the expression $\callerparame$ in $\tenv$ yields \\
@@ -9317,7 +9554,7 @@ One of the following applies:
       \end{itemize}
     \end{itemize}
     \item applying $\checkcalleeparams$ to $\calleeparamsone$ and $\eqsthree$ in $\tenv$
-          yields $\True$\ProseOrTypeError.
+          yields \\ $\True$\ProseOrTypeError.
   \end{itemize}
 \end{itemize}
 
@@ -9329,24 +9566,24 @@ One of the following applies:
 }
 \and
 \inferrule[no\_type]{
-  \calleeparams \eqname [(\Ignore, \None)] \concat \calleeparamsone\\
+  \calleeparams = [(\Ignore, \None)] \concat \calleeparamsone\\
   \checkcalleeparams(\tenv, \calleeparamsone, \eqsthree) \typearrow \True \OrTypeError
 }{
   \checkcalleeparams(\tenv, \calleeparams, \eqsthree) \typearrow \True
 }
 \and
 \inferrule[parameterized]{
-  \calleeparams \eqname [(\vs, \langle\TInt(\parameterized(\vs))\rangle)] \concat \calleeparamsone\\
+  \calleeparams = [(\vs, \langle\TInt(\parameterized(\vs))\rangle)] \concat \calleeparamsone\\
   \checkcalleeparams(\tenv, \calleeparamsone, \eqsthree) \typearrow \True \OrTypeError
 }{
   \checkcalleeparams(\tenv, \calleeparams, \eqsthree) \typearrow \True
 }
 \and
 \inferrule[other]{
-  \calleeparams \eqname [(\vs, \langle\calleeparamt\rangle)] \concat \calleeparamsone\\
+  \calleeparams = [(\vs, \langle\calleeparamt\rangle)] \concat \calleeparamsone\\
   \calleeparamt \neq \TInt(\parameterized(\vs))\\
   \renametyeqs(\tenv, \eqsthree, \calleeparamt) \typearrow \calleeparamtrenamed \OrTypeError\\\\
-  \assocopt(\eqsthree, \vs) \typearrow \langle \ve \rangle\\
+  \assocopt(\eqsthree, \vs) \typearrow \langle \callerparame \rangle\\
   \annotateexpr{\tenv, \callerparame} \typearrow \callerparamt \OrTypeError\\\\
   \checktypesat(\tenv, \callerparamt, \calleeparamtrenamed) \typearrow \True \OrTypeError\\\\
   \checkcalleeparams(\tenv, \calleeparamsone, \eqsthree) \typearrow \True \OrTypeError
@@ -9497,11 +9734,11 @@ The function
   \overname{\staticenvs}{\tenv} \aslsep
   \overname{(\identifier\times\expr)^*}{\substs} \aslsep
   \overname{\expr}{\ve}
-) \aslto \overname{\newe}{\expr}
+) \aslto \overname{\expr}{\newe}
 \]
 transforms the expression $\ve$ in the static environment $\tenv$,
 by substituting parameter names with their corresponding expressions in
-$\eqs$, yielding the expression $\newe$.
+$\substs$, yielding the expression $\newe$.
 \ProseOtherwiseTypeError
 
 \subsection{Prose}
@@ -9551,8 +9788,8 @@ One of the following applies:
   \begin{itemize}
     \item $\ve$ is the concatenation of expressions $\ves$, that is, $\EConcat(\ves)$;
     \item applying $\substexpr$ to $\substs$ and every expression $\ves[\vi]$, for $\vi$ in \\
-          $\listrange(\ves)$ yields $\vep[\vi]$;
-    \item define $\vesp$ as the list of expressions $\vep[\vi]$, for $\vi$ in $\listrange(\ves)$;
+          $\listrange(\ves)$ yields $\newes_\vi$;
+    \item define $\vesp$ as the list of expressions $\newes_\vi$, for $\vi$ in $\listrange(\ves)$;
     \item define $\newe$ as the concatenation of expressions $\vesp$, that is, $\EConcat(\vesp)$.
   \end{itemize}
 
@@ -9560,9 +9797,9 @@ One of the following applies:
   \begin{itemize}
     \item $\ve$ is the call expression for subprogram $\vx$ with arguments $\vargs$ and parameter expressions $\paramargs$,
           that is, $\ECall(\vx, \vargs, \paramargs)$;
-    \item applying $\substexpr$ to $\substs$ and every argument expression $\vargs[\vi]$, for $\vi$ in \\
+    \item applying $\substexpr$ to $\substs$ and every argument expression $\vargs[\vi]$, for $\vi$ in
           $\listrange(\vargs)$ yields $\ve_\vi$;
-    \item define $\vargsp$ as $\ve_\vi$ or $\vi$ in $\listrange(\vargs)$;
+    \item define $\vargsp$ as $\ve_\vi$ for each $\vi$ in $\listrange(\vargs)$;
     \item define $\newe$ as the call expression for subprogram $\vx$ with arguments $\vargsp$ and parameter expressions $\paramargs$,
     that is, $\ECall(\vx, \vargsp, \paramargs)$.
   \end{itemize}
@@ -9617,6 +9854,13 @@ One of the following applies:
     \item for every pair $(\vx,\veone)$ in $\fields$, applying $\substexpr$ to $\substs$ $\veone$ in $\tenv$ yields $\veonep_\vx$;
     \item define $\fieldsp$ as the list of pairs $(\vx,\veonep_\vx)$ for every pair $(\vx,\veone)$ in $\fields$;
     \item define $\newe$ as the record expression of record type $\vt$ and list of fields $\fieldsp$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{e\_slice}):
+  \begin{itemize}
+    \item $\ve$ is the slicing expression for sub-expression $\veone$ and list of slices $\vslices$, that is, $\ESlice(\veone, \vslices)$;
+    \item applying $\substexpr$ to $\veone$ in $\tenv$ yields $\veonep$;
+    \item define $\newe$ as slicing expression for sub-expression $\veonep$ and list of slices $\vslices$, that is, $\ESlice(\veonep, \vslices)$.
   \end{itemize}
 
   \item All of the following apply (\textsc{e\_tuple}):
@@ -9688,8 +9932,8 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[e\_concat]{
-  \vi\in\listrange(\ves): \substexpr(\tenv, \substs, \ves[\vi]) \typearrow \vep[\vi]\\
-  \vesp \eqdef [\vi\in\listrange(\ves): \vep[\vi]]
+  \vi\in\listrange(\ves): \substexpr(\tenv, \substs, \ves[\vi]) \typearrow \newes_\vi\\
+  \vesp \eqdef [\vi\in\listrange(\ves): \newes_\vi]
 }{
   \substexpr(\tenv, \substs, \overname{\EConcat(\ves)}{\ve}) \typearrow \overname{\EConcat(\vesp)}{\newe}
 }
@@ -9790,6 +10034,8 @@ One of the following applies:
   \substexpr(\tenv, \substs, \ve) \typearrow \overname{\ve}{\newe}
 }
 \end{mathpar}
+
+\CodeSubsection{\SubstExprBegin}{\SubstExprEnd}{../ASTUtils.ml}
 
 \section{TypingRule.SubstConstraint \label{sec:TypingRule.SubstConstraint}}
 \hypertarget{def-substconstraint}{}
@@ -9990,11 +10236,12 @@ that $\vargs$ and $\callerargstyped$ have the same length.
   \vargs \eqname [(\calleex, \Ignore)] \concat \vargsone\\
   \callerargstyped \eqname [(\callerty, \callere)] \concat \callerargstypedone\\
   {
-    \begin{array}{rl}
-  \calleeargisparam \eqdef  & \exists \vi\in\listrange(\calleeparams). \\
-                            & \calleeparams[\vi]=(\calleex, \Ignore)
-    \end{array}
-  }\\
+    \left(\begin{array}{l}
+  \calleeargisparam \eqdef \\
+  \exists \vi\in\listrange(\calleeparams).\ \calleeparams[\vi]=(\calleex, \Ignore)
+    \end{array}\right)
+  }\\\\
+  \commonprefixline\\\\
   \calleeargisparam\ = \True\\
   \checkstaticallyevaluable(\tenv, \callere) \typearrow \True\OrTypeError\\\\
   \checkconstrainedinteger(\tenv, \callerty) \typearrow \True\OrTypeError\\\\
@@ -10026,11 +10273,12 @@ that $\vargs$ and $\callerargstyped$ have the same length.
   \vargs \eqname [(\calleex, \Ignore)] \concat \vargsone\\
   \callerargstyped \eqname [(\callerty, \callere)] \concat \callerargstypedone\\
   {
-    \begin{array}{rl}
-  \calleeargisparam \eqdef & \exists \vi\in\listrange(\calleeparams).\\
-                           & \calleeparams[\vi]=(\calleex, \Ignore)
-    \end{array}
-  }\\
+    \left(\begin{array}{l}
+  \calleeargisparam \eqdef \\
+  \exists \vi\in\listrange(\calleeparams).\ \calleeparams[\vi]=(\calleex, \Ignore)
+    \end{array}\right)
+  }\\\\
+  \commonprefixline\\\\
   \calleeargisparam = \False\\
   \annotateparameterdefining(\tenv, \vargsone, \callerargstypedone, \eqsone) \typearrow \eqs\\
 }{
@@ -10077,7 +10325,8 @@ One of the following applies:
   \begin{itemize}
     \item $\calltype$ is one of $\STFunction$, $\STGetter$, or $\STEmptyGetter$;
     \item $\calleerettyopt$ is $\langle\tty\rangle$;
-    \item define $\rettyopt$ as $\langle\ttyone\rangle$.
+    \item applying $\renametyeqs$ to $\eqsthree$ and $\tty$ yields $\ttyone$\ProseOrTypeError;
+    \item $\rettyopt$ is $\langle\ttyone\rangle$.
   \end{itemize}
 
   \item All of the following apply (\textsc{procedure\_or\_setter}):
@@ -10331,7 +10580,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[not\_bits\_parameter]{
-  \caller \neq \TBits(\EVar(\vx))\\
+  \caller \neq \TBits(\EVar(\Ignore))\\
   \deduceeqs(\tenv, \callerargtypesone, \vargsone) \typearrow \eqs
 }{
   \deduceeqs(
@@ -10445,7 +10694,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{
   \equallength(\formaltypes, \vargs) \typearrow \True \terminateas \False\\
-  \argtys \eqdef [(\Ignore, \vt) \in\listrange(\vargs): \vt]\\
+  \argtys \eqdef [(\Ignore, \vt) \in \vargs: \vt]\\
   \vi\in\listrange(\formaltys): \typeclashes(\tenv, \formaltys[\vi], \argtys[\vi]) \typearrow \True \terminateas \False,\TypeErrorConfig
 }{
   \hasargclash(\tenv, \formaltys, \vargs) \typearrow \overname{\True}{\vb}
@@ -10459,9 +10708,12 @@ All of the following apply:
 The function
 \[
   \annotatesubprogram{\overname{\staticenvs}{\tenv} \aslsep \overname{\func}{\vf}} \aslto \overname{\func}{\vfp}
+  \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-annotates a subprogram $\vf$ in an environment $\tenv$, resulting in an annotated subprogram $\vfp$,
-or a type error, if one is detected.
+annotates a subprogram $\vf$ in an environment $\tenv$, resulting in an annotated subprogram $\vfp$.
+\ProseOtherwiseTypeError
+
+Note that the return type in $\vf$ has already been annotated by $\annotatefuncsig$.
 
 \section{TypingRule.Subprogram \label{sec:TypingRule.Subprogram}}
 
@@ -10474,8 +10726,6 @@ All of the following apply:
 \end{itemize}
 
 \isempty{\subsection{Example}}
-
-\CodeSubsection{\SubprogramBegin}{\SubprogramEnd}{../Typing.ml}
 
 \subsection{Formally}
 \begin{mathpar}
@@ -10513,6 +10763,7 @@ All of the following apply:
 This is related to \identi{GHGK}, \identr{HWTV}, \identr{SCHV}, \identr{VDPC},
 \identr{TJKQ}, \identi{LFJZ}, \identi{BZVB}, \identi{RQQB}.
 }
+\CodeSubsection{\SubprogramBegin}{\SubprogramEnd}{../Typing.ml}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \chapter{Typing of Global Declarations}
@@ -10787,7 +11038,7 @@ and applying $\usety$ to the \optional\ return type of $\vf$.
 \subsection{Formally}
 \begin{mathpar}
 \inferrule{}{
-  \usefuncsig(\vf) \typearrow \overname{\bigcup_{(\Ignore, \vt) \in \vf.\funcargs}\usety(vt) \cup \usety(\vf.\funcreturntype)}{\ids}
+  \usefuncsig(\vf) \typearrow \overname{\bigcup_{(\Ignore, \vt) \in \vf.\funcargs}\usety(\vt) \cup \usety(\vf.\funcreturntype)}{\ids}
 }
 \end{mathpar}
 
@@ -11173,18 +11424,10 @@ Therefore, $\newtenv$ will effectively contain the declaration \verb|let B: inte
   \vused \eqdef \setcomprehension{\vs\in\vusedone \land \vb_\vs \land \declaredparams(\vs) = \bot}{\vs}\\
   \argparams_1 \eqdef \declaredparams\\
   \tenvtwo_0 \eqdef \tenvtwo\\
-  {
-    \begin{array}{r}
-  \vi=1..k: \argasparam(\tenvtwo, \vused, \varg_\vi,\tenvtwo_{\vi-1}) \typearrow \\ (\tenvtwo_\vi, \argparams_\vi) \OrTypeError
-    \end{array}
-  }
+  \vi=1..k: \argasparam(\tenvtwo, \vused, \varg_\vi,\tenvtwo_{\vi-1}) \typearrow  (\tenvtwo_\vi, \argparams_\vi) \OrTypeError
 }{
-  {
-    \begin{array}{r}
-  \argsasparams(\tenvone, \tenvtwo, \funcsig, \declaredparams) \typearrow \\
+  \argsasparams(\tenvone, \tenvtwo, \funcsig, \declaredparams) \typearrow
   (\overname{\tenvtwo_k}{\newtenv}, \overname{\argparams_k}{\argparams})
-    \end{array}
-  }
 }
 \end{mathpar}
 
@@ -11288,14 +11531,16 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[tint\_unconstrained]{}
 {
-  \annotateparamtype(\tenv, \overname{\unconstrainedinteger}{\tty}) \typearrow \overname{\TInt(\parameterized(\vx))}{\newty}
+  \annotateparamtype(\tenv, \overname{\unconstrainedinteger}{\tty}, \vx) \typearrow \overname{\TInt(\parameterized(\vx))}{\newty}
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[other]{
   \tty \neq \unconstrainedinteger\\
   \annotatetype{\tenv, \tty} \typearrow \newty \OrTypeError
 }{
-  \annotateparamtype(\tenv, \tty) \typearrow \newty
+  \annotateparamtype(\tenv, \tty, \vx) \typearrow \newty
 }
 \end{mathpar}
 
@@ -11707,7 +11952,7 @@ One of the following applies:
           does not occur in any specification;
     \item $\formaltypes$ is the list of types that appear in $\formals$ in the same order;
     \item checking for each $\namep$ in $\othernames$ whether the subprogram associated with $\namep$ clashes
-          with the subprogram type $\subpgmtype$ and list of types $\formaltypes$ yields $\True$
+          with the subprogram type $\subpgmtype$ and list of types $\formaltypes$ yields $\False$
           or a type error that indicates there are multiply defined subprograms, which short-circuits the entire rule;
     \item $\newtenv$ is $\tenv$ with the $\subprogramrenamings$ updated by binding $\name$ to the union of $\othernames$ and
           $\{\newname\}$.
@@ -11715,8 +11960,6 @@ One of the following applies:
 \end{itemize}
 
 \isempty{\subsection{Example}}
-
-\CodeSubsection{\AddNewFuncBegin}{\AddNewFuncEnd}{../Typing.ml}
 
 \subsection{Formally}
 \newcommand\stringconcat[0]{\hyperlink{def-stringconcat}{\texttt{+}}}
@@ -11741,23 +11984,21 @@ to the corresponding string.
   \addnewfunc(\tenv, \name, \formals, \subpgmtype) \typearrow
   (\newtenv, \overname{\name}{\newname})
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[name\_exists]{
-  G^\tenv.\subprogramrenamings(\name) \neq \othernames\\
+  G^\tenv.\subprogramrenamings(\name) = \othernames\\
   k \eqdef \cardinality{\othernames}\\
   \newname \eqdef \name\ \stringconcat\ \texttt{"-"}\ \stringconcat\ \stringofint(k)\\
   \formaltypes \eqdef [(\id,\vt) \in \formals : \vt]\\
   {
-    \begin{array}{l}
+    \left(\begin{array}{l}
   \namep \in \othernames: \\ \subprogramclash(\tenv, \namep, \subpgmtype, \formaltypes) \typearrow
   \vb_{\namep} \OrTypeError
-    \end{array}
+    \end{array}\right)
   }\\\\
-  {
-    \begin{array}{l}
-      \namep \in \othernames: \\ \checktrans{\neg\vb_{\namep}}{\SubrogramDeclaredMultipleTimes} \typearrow \True \OrTypeError
-    \end{array}
-    }\\\\
+  \namep \in \othernames: \checktrans{\neg\vb_{\namep}}{\SubrogramDeclaredMultipleTimes} \typearrow \True \OrTypeError\\\\
   \newtenv \eqdef (G^\tenv.\subprogramrenamings[\name\mapsto \othernames \cup \{\newname\}],  L^\tenv)
 }{
   \addnewfunc(\tenv, \name, \formals, \subpgmtype) \typearrow
@@ -11767,6 +12008,8 @@ to the corresponding string.
 
 \isempty{\subsection{Comments}}
 \lrmcomment{This is related to \identr{PGFC}.}
+
+\CodeSubsection{\AddNewFuncBegin}{\AddNewFuncEnd}{../Typing.ml}
 
 \section{TypingRule.CheckSetterHasGetter \label{sec:TypingRule.CheckSetterHasGetter}}
 \hypertarget{def-checksetterhashgetter}{}
@@ -11879,7 +12122,7 @@ All of the following apply:
   \item $\gsd$ is a global storage declaration with keyword $\keyword$, initial value \\ $\initialvalue$,
         \optional\ type $\tyopt$, and name $\name$;
   \item checking that $\name$ is not already declared in the global environment of $\tenv$ yields $\True$\ProseOrTypeError;
-  \item annotating the \optional\ type $\tyoptp$ in $\tenv$ via $\annotatetypeopt$ yields \\
+  \item annotating the \optional\ type $\tyopt$ in $\tenv$ via $\annotatetypeopt$ yields \\
         $\tyoptp$\ProseOrTypeError;
   \item annotating the \optional\ expression $\initialvalue$ in $\tenv$ via $\annotateexpropt$ yields
         $(\initialvaluetype, \initialvaluep)$\ProseOrTypeError;
@@ -11899,7 +12142,7 @@ All of the following apply:
       \item $\newtenv$ is $\tenvtwo$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{non\_contant}):
+    \item All of the following apply (\textsc{non\_constant}):
     \begin{itemize}
       \item $\keyword$ is not $\GDKConstant$;
       \item $\newtenv$ is $\tenvone$.
@@ -11909,8 +12152,6 @@ All of the following apply:
 \end{itemize}
 
 \isempty{\subsection{Example}}
-
-\CodeSubsection{\DeclareGlobalStorageBegin}{\DeclareGlobalStorageEnd}{../Typing.ml}
 
 \subsection{Formally}
 \begin{mathpar}
@@ -11930,6 +12171,7 @@ All of the following apply:
 }\\
 \annotateinittype(\tenv, \initialvaluetype, \tyoptp) \typearrow \declaredt\\
 \addglobalstorage(\tenv, \name, \keyword, \declaredt) \typearrow \tenvone \OrTypeError\\\\
+\commonprefixline\\\\
 \keyword = \GDKConstant\\
 \initialvaluep \eqname \langle \ve \rangle\\
 \reduceconstants(\tenvone, \ve) \typearrow \vv \OrTypeError\\\\
@@ -11966,6 +12208,7 @@ All of the following apply:
 }\\
 \annotateinittype(\tenv, \initialvaluetype, \tyoptp) \typearrow \declaredt\\
 \addglobalstorage(\tenv, \name, \keyword, \declaredt) \typearrow \tenvone \OrTypeError\\\\
+\commonprefixline\\\\
 \keyword \neq \GDKConstant\\
 {
 \newgsd \eqdef \left\{
@@ -11984,6 +12227,7 @@ All of the following apply:
 
 \isempty{\subsection{Comments}}
 \lrmcomment{This relates to \identr{YSPM} and \identr{FWQM}.}
+\CodeSubsection{\DeclareGlobalStorageBegin}{\DeclareGlobalStorageEnd}{../Typing.ml}
 
 \section{TypingRule.AnnotateTypeOpt \label{sec:TypingRule.AnnotateTypeOpt}}
 \hypertarget{def-annotatetypeopt}{}
@@ -12001,13 +12245,13 @@ One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{none}):
   \begin{itemize}
-    \item $\tyoptp$ is $\None$;
+    \item $\tyopt$ is $\None$;
     \item $\tyoptp$ is $\tyopt$.
   \end{itemize}
 
   \item All of the following apply (\textsc{some}):
   \begin{itemize}
-    \item $\tyoptp$ contains the type $\vt$;
+    \item $\tyopt$ contains the type $\vt$;
     \item annotating $\vt$ in $\tenv$ yields $\vtone$\ProseOrTypeError;
     \item $\tyoptp$ is $\langle\vtone\rangle$.
   \end{itemize}
@@ -12043,13 +12287,13 @@ One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{none}):
   \begin{itemize}
-    \item $\exproptp$ is $\None$;
+    \item $\expropt$ is $\None$;
     \item $\vres$ is $(\None, \None)$.
   \end{itemize}
 
   \item All of the following apply (\textsc{some}):
   \begin{itemize}
-    \item $\exproptp$ contains the expression $\ve$;
+    \item $\expropt$ contains the expression $\ve$;
     \item annotating $\ve$ in $\tenv$ yields $(\vt, \vep)$\ProseOrTypeError;
     \item $\vres$ is $(\langle\vt\rangle, \langle\vep\rangle)$.
   \end{itemize}
@@ -12268,27 +12512,30 @@ One of the following applies:
 
   \item All of the following apply (\textsc{empty\_fields}):
   \begin{itemize}
-    \item $\vs$ is $(\vsuper, \emptylist)$;
+    \item $\vs$ is $\langle(\vsuper, \extrafields)\rangle$;
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is, \\ $\TNamed(\vsuper)$) yields
           $\True$\ProseOrTypeError;
+    \item $\extrafields$ is the empty list;
     \item $\newtenv$ is $\tenv$;
     \item $\newty$ is $\tty$.
   \end{itemize}
 
   \item All of the following apply (\textsc{no\_super}):
   \begin{itemize}
-    \item $\vs$ is $(\vsuper, \emptylist)$;
+    \item $\vs$ is $\langle(\vsuper, \extrafields)\rangle$;
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is, \\ $\TNamed(\vsuper)$) yields
           $\True$\ProseOrTypeError;
+    \item $\extrafields$ is not an empty list;
     \item $\vsuper$ is not bound to a type in $\tenv$;
     \item the result is a type error indicating that $\vsuper$ is not a declared type.
   \end{itemize}
 
   \item All of the following apply (\textsc{structured}):
   \begin{itemize}
-    \item $\vs$ is $(\vsuper, \emptylist)$;
+    \item $\vs$ is $\langle(\vsuper, \extrafields)\rangle$;
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is,\\ $\TNamed(\vsuper)$) yields
           $\True$\ProseOrTypeError;
+    \item $\extrafields$ is not an empty list;
     \item $\vsuper$ is bound to a type $\vt$ in $\tenv$;
     \item checking that $\vt$ is a \structuredtype\ yields $\True$ or a type error
           indicating that a \structuredtype\ was expected, thereby short-circuiting the entire rule;
@@ -12307,11 +12554,11 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[empty\_fields]{
-  \vs = \langle(\vsuper, \emptylist)\rangle\\
   \subtypesat(\tty, \TNamed(\vsuper)) \typearrow \vb\\
-  \checktrans{\vb}{TypeConflict} \typearrow \True \OrTypeError
+  \checktrans{\vb}{TypeConflict} \typearrow \True \OrTypeError\\\\
+  \extrafields = \emptylist
 }{
-  \annotateextrafields(\tenv, \tty, \vs) \typearrow (\overname{\tenv}{\newtenv}, \overname{\tty}{\newty})
+  \annotateextrafields(\tenv, \tty, \overname{\langle(\vsuper, \extrafields)\rangle}{\vs}) \typearrow (\overname{\tenv}{\newtenv}, \overname{\tty}{\newty})
 }
 \end{mathpar}
 
@@ -12319,6 +12566,7 @@ One of the following applies:
 \inferrule[no\_super]{
   \subtypesat(\tty, \TNamed(\vsuper)) \typearrow \vb\\
   \checktrans{\vb}{TypeConflict} \typearrow \True \OrTypeError\\\\
+  \extrafields \neq \emptylist\\\\
   G^\tenv.\declaredtypes(\vsuper) = \bot
 }{
   \annotateextrafields(\tenv, \tty, \overname{\langle(\vsuper, \extrafields)\rangle}{\vs}) \typearrow
@@ -12330,6 +12578,7 @@ One of the following applies:
 \inferrule[structured]{
   \subtypesat(\tty, \TNamed(\vsuper)) \typearrow \vb\\
   \checktrans{\vb}{TypeConflict} \typearrow \True \OrTypeError\\\\
+  \extrafields \neq \emptylist\\\\
   G^\tenv.\declaredtypes(\vsuper) = \vt\\
   {
     \begin{array}{r}
@@ -12484,7 +12733,7 @@ if the following condition holds:
 \[
 C_1 < C_2 \Leftrightarrow \exists c_1\in C_1.\ c_2\in C_2.\ (c_1,c_2) \in E^* \enspace.
 \]
-This ordering is not total. That is, there may exist to strongly connected components
+This ordering is not total. That is, there may exist strongly connected components
 $A,B\in\comps$ such that $A \not< B$ and $B \not< A$.
 
 \hypertarget{def-topologicalordering}{}
@@ -12509,7 +12758,7 @@ All of the following apply:
 
 \isempty{\subsection{Example}}
 
-\CodeSubsection{\SpecificationBegin}{\SpecificationEnd}{../Typing.ml}
+\CodeSubsection{\TypeCheckASTBegin}{\TypeCheckASTEnd}{../Typing.ml}
 
 \subsection{Formally}
 \begin{mathpar}
@@ -12746,6 +12995,12 @@ annotates a list of mutually recursive declarations
 $\decls$ in the static environment $\tenv$,
 yielding the annotated list of subprogram declarations $\newdecls$
 and modified environment $\newtenv$.
+
+One of the requirements from an ASL specification is that each setter has a corresponding getter.
+To facilitate checking this requirement, the type-system annotates the declarations of all subprograms
+that are not setters before annotating the declarations of setters. This way, when annotating a setter,
+the corresponding getter should have already been annotated and added to the environment, making it
+easy to check this requirement.
 
 \subsection{Prose}
 All of the following apply:
@@ -13010,7 +13265,7 @@ One of the following applies:
   \item All of the following apply (\textsc{none}):
   \begin{itemize}
     \item $\vt$ is $\None$;
-    \item define $\ids$ as $\None$.
+    \item define $\ids$ as $\emptyset$.
   \end{itemize}
 
   \item All of the following apply (\textsc{some}):
@@ -13077,7 +13332,7 @@ One of the following applies:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule[none]{}{
-  \usety(\overname{\None}{\vt}) \typearrow \overname{\None}{\ids}
+  \usety(\overname{\None}{\vt}) \typearrow \overname{\emptyset}{\ids}
 }
 \and
 \inferrule[some]{
@@ -13243,8 +13498,8 @@ One of the following applies:
   \item All of the following apply (\textsc{e\_call}):
   \begin{itemize}
     \item $\ve$ is the call expression of the subprogram named $\vx$ with argument expressions $\vargs$ and parameter expressions $\namedargs$;
-    \item define $\ids$ as the union of the singleton set for $\vx$, applying $\useexpr$ to each expression in $\vargs$ and each expression
-          in $\namedargs$.
+    \item define $\ids$ as the union of the singleton set for $\vx$, and the set obtained by applying $\useexpr$ to each expression in
+          $\vargs$ and each expression in $\namedargs$.
   \end{itemize}
 
   \item All of the following apply (\textsc{e\_slice}):
@@ -13353,7 +13608,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[e\_call]{
-  \ids \eqdef \{\vx\} \cup  \bigcup_{\veone}\useexpr(\veone\in\vargs) \cup \bigcup_{(\Ignore, \vt)\in\namedargs}\usety(\vt)
+  \ids \eqdef \{\vx\} \cup  \bigcup_{\veone\in\vargs}\useexpr(\veone) \cup \bigcup_{(\Ignore, \vt)\in\namedargs}\usety(\vt)
 }{
   \useexpr(\overname{\ECall(\vx, \vargs, \namedargs)}{\ve}) \typearrow \ids
 }
@@ -13389,7 +13644,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[e\_record]{}{
-  \useexpr(\overname{\ERecord(\tty, \vli)}{\ve}) \typearrow \overname{\usety(\tty) \cup \bigcup_{(\Ignore, \vt)\in\usety(\vt)}}{\ids}
+  \useexpr(\overname{\ERecord(\tty, \vli)}{\ve}) \typearrow \overname{\usety(\tty) \cup \bigcup_{(\Ignore, \vt)\in\vli}\usety(\vt)}{\ids}
 }
 \end{mathpar}
 
@@ -14317,7 +14572,7 @@ One of the following applies:
   \item All of the following apply (\textsc{not\_bool}):
   \begin{itemize}
     \item $\op$ is $\BNOT$ and $\vl$ is a Boolean literal for $\vb$;
-    \item define $\vr$ as the Boolean literal for $\neg\vq$.
+    \item define $\vr$ as the Boolean literal for $\neg\vb$.
   \end{itemize}
 
   \item All of the following apply (\textsc{not\_bits\_empty}, \textsc{not\_bits\_empty}):
@@ -14550,25 +14805,25 @@ One of the following applies:
   \item All of the following apply (\textsc{or\_bool}):
   \begin{itemize}
     \item $\op$ is $\BOR$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
-    \item define $\vr$ as the Boolean literal that is $\True$ if and only if one of $a$ and $b$ is $\True$.
+    \item define $\vr$ as the Boolean literal that is $\True$ if and only if at least one of $a$ and $b$ is $\True$.
   \end{itemize}
 
   \item All of the following apply (\textsc{implies\_bool}):
   \begin{itemize}
     \item $\op$ is $\IMPL$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
-    \item define $\vr$ as the Boolean literal that is $\True$ if and only if one of $a$ is $\False$ or $b$ is $\True$.
+    \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is $\False$ or $b$ is $\True$.
   \end{itemize}
 
   \item All of the following apply (\textsc{eq\_bool}):
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
-    \item define $\vr$ as the Boolean literal that is $\True$ if and only if one of $a$ is equal to $b$.
+    \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
   \item All of the following apply (\textsc{ne\_bool}):
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
-    \item define $\vr$ as the Boolean literal that is $\True$ if and only if one of $a$ is different from $b$.
+    \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
   \end{itemize}
 
   \item All of the following apply (\textsc{add\_real}):
@@ -14675,7 +14930,7 @@ One of the following applies:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a$;
     \item $\vvtwo$ is a bitvector literal for $b$;
-    \item $\op$ is $\EQOP$;
+    \item $\op$ is $\NEQ$;
     \item applying $\binopliterals$ to $\NEQ$ for $\vvone$ and $\vvtwo$ yields the Boolean literal for $\vb$\ProseOrTypeError;
     \item define $\vr$ as the Boolean literal for $\neg\vb$.
   \end{itemize}
@@ -14693,7 +14948,7 @@ One of the following applies:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
-    \item $\op$ is $\OR$;
+    \item $\op$ is $\AND$;
     \item define $c_i$ as the minimum of $a_i$ and $b_i$ for $i=1..k$;
     \item define $\vr$ as the bitvector literal for $c_{1..k}$.
   \end{itemize}
@@ -14702,7 +14957,7 @@ One of the following applies:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
-    \item $\op$ is $\OR$;
+    \item $\op$ is $\EOR$;
     \item define $c_i$ as $1$ if $a_i$ is different from $b_i$ and $0$ otherwise, for $i=1..k$;
     \item define $\vr$ as the bitvector literal for $c_{1..k}$.
   \end{itemize}
@@ -14722,7 +14977,7 @@ One of the following applies:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
-    \item $\op$ is $\PLUS$;
+    \item $\op$ is $\MINUS$;
     \item define $a$ as the natural number represented by $a_{1..k}$;
     \item define $b$ as the natural number represented by $b_{1..k}$;
     \item define $c$ as the two's complement little endian representation of $a-b$ in $k$ bits;
@@ -14783,7 +15038,7 @@ One of the following applies:
 \inferrule[div\_int]{
   \checktrans{b > 0}{DIV\_DenominatorNegative} \checktransarrow \True \OrTypeError\\\\
   n \eqdef a \div b \\\\
-  \checktrans{n \in \Z}{DIVInt\_Indivisibile} \checktransarrow \True \OrTypeError
+  \checktrans{n \in \Z}{\DivIntIndivisible} \checktransarrow \True \OrTypeError
 }{
   \binopliterals(\overname{\DIV}{\op}, \overname{\lint(a)}{\vvone}, \overname{\lint(b)}{\vvtwo}) \typearrow \overname{\lint(n)}{\vr}
 }
@@ -15221,7 +15476,7 @@ One of the following applies:
 \inferrule[length]{
   \evaltoint(\tenv, \ebot) \typearrow b \terminateas \CannotBeTransformed,\TypeErrorConfig\\\\
   \evaltoint(\tenv, \elength) \typearrow l \terminateas \CannotBeTransformed,\TypeErrorConfig\\\\
-  t \eqdef b + l - 1
+  t \eqdef b + l - 1\\
   \checktrans{t \geq b \geq 0}{BadSlice} \checktransarrow \True \OrTypeError
 }{
   \slicetopositions(\tenv, \overname{\SliceLength(\ebot, \elength)}{\vs}) \typearrow [ t..b ]
@@ -15368,7 +15623,6 @@ Other helper rules are as follows:
   \item TypingRule.NormalizeToInt (see \secref{TypingRule.NormalizeToInt})
   \item TypingRule.SymDomIsSubset (see \secref{TypingRule.SymDomIsSubset})
   \item TypingRule.SymIntSetSubset (see \secref{TypingRule.SymIntSetSubset})
-  \item TypingRule.ConstraintsBinop (see \secref{TypingRule.ConstraintsBinop})
   \item TypingRule.ConstraintBinop (see \secref{TypingRule.ConstraintBinop})
   \item TypingRule.IsRightIncreasing (see \secref{TypingRule.IsRightIncreasing})
   \item TypingRule.IsRightDecreasing (see \secref{TypingRule.IsRightDecreasing})
@@ -15439,7 +15693,7 @@ One of the following applies:
   \item All of the following apply (\textsc{t\_enum}):
   \begin{itemize}
     \item $\vt$ is the enumeration type with list of labels $\vli$;
-    \item define $\vd$ as the symbolic list of symbolic for $\vli$, that is, $\DSymbols(\vli)$.
+    \item define $\vd$ as the symbolic list of symbols $\vli$, that is, $\DSymbols(\vli)$.
   \end{itemize}
 
   \item All of the following apply (\textsc{int\_unconstrained}):
@@ -15459,7 +15713,7 @@ One of the following applies:
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type for the list of constraints $\vcs$;
     \item applying $\intsetofintconstraints$ to $\vcs$ in $\tenv$ yields $\vis$;
-    \item $\vis$ is a set of integers, that is, $\astlabel(\vis)$ if $\Finite$;
+    \item $\vis$ is a set of integers, that is, $\astlabel(\vis)$ is $\Finite$;
     \item define $\vd$ as the symbolic finite set integer domain for $\vis$.
   \end{itemize}
 
@@ -15678,7 +15932,7 @@ One of the following applies:
   \item All of the following apply (\textsc{e\_unop\_minus}):
   \begin{itemize}
     \item $\ve$ is a unary operation expression for the operation $\MINUS$ and subexpression $\veone$;
-    \item applying $symdomofexpr$ to the binary operation expression with the operation $\MINUS$
+    \item applying $\symdomofexpr$ to the binary operation expression with the operation $\MINUS$
           and the literal expression for $0$ and $\veone$ in $\tenv$ yields $\vd$.
   \end{itemize}
 
@@ -15746,7 +16000,7 @@ One of the following applies:
 \inferrule[e\_unop\_minus]{
   \symdomofexpr(\EBinop(\MINUS, \ELiteral(\lint(0)), \veone)) \typearrow \vd
 }{
-  \symdomofexpr(\tenv, \overname{\EUnop(\NEG, \veone)}{\ve}) \typearrow \vd
+  \symdomofexpr(\tenv, \overname{\EUnop(\MINUS, \veone)}{\ve}) \typearrow \vd
 }
 \end{mathpar}
 
@@ -16410,154 +16664,236 @@ One of the following applies:
 }
 \end{mathpar}
 
-\section{TypingRule.ConstraintsBinop \label{sec:TypingRule.ConstraintsBinop}}
-\hypertarget{def-constraintsbinop}{}
-The function
-\[
-\constraintsbinop(
-  \overname{\binop}{\op} \aslsep
-  \overname{\intconstraint^*}{\csone} \aslsep
-  \overname{\intconstraint^*}{\cstwo}
-)
-\aslto \overname{\intconstraint^*}{\cs} \cup \{\top\}
-\]
-symbolically applies the binary operation $\op$ to the lists of integer constraints $\csone$ and $\cstwo$,
-yielding the list of integer constraints $\cs$.
-Otherwise, the result is $\top$, which indicates a failure in representing the result by a list of integer constraints.
-
-\subsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item for every $\vi$ in $\listrange(\csone)$ and every $\vj$ in $\listrange(\cstwo)$,
-        applying \\
-        $\constraintbinop$ to $\op$, $\csone[\vi]$, and $\cstwo[\vj]$,
-        yields the constraint $\vc_{(\vi,\vj)}$\ProseTerminateAs{\top};
-  \item define $\cs$ as the list consisting of constraints $\vc_{(\vi,\vj)}$,
-        for every $\vi$ in $\listrange(\csone)$ and every $\vj$ in $\listrange(\cstwo)$.
-\end{itemize}
-
-\subsection{Formally}
-\begin{mathpar}
-\inferrule{
-  {
-    \begin{array}{r}
-  \vi\in\listrange(\csone), \vj\in\listrange(\cstwo):
-  \constraintbinop(\op, \csone[\vi], \cstwo[\vj]) \typearrow \\ \vc_{(\vi,\vj)} \terminateas \top
-    \end{array}
-  }\\
-  \cs \eqdef [\vi\in\listrange(\csone), \vj\in\listrange(\cstwo): \vc_{(\vi,\vj)}]
-}{
-  \constraintsbinop(\op, \csone, \cstwo) \typearrow \cs
-}
-\end{mathpar}
-
 \section{TypingRule.ConstraintBinop \label{sec:TypingRule.ConstraintBinop}}
 \hypertarget{def-constraintbinop}{}
 The function
 \[
 \constraintbinop(
   \overname{\binop}{\op} \aslsep
-  \overname{\intconstraint}{\vcone} \aslsep
-  \overname{\intconstraint}{\vctwo}
+  \overname{\intconstraint^*}{\csone} \aslsep
+  \overname{\intconstraint^*}{\cstwo}
 )
-\aslto \overname{\intconstraint}{\vc} \cup \{\top\}
+\aslto \overname{\intconstraints}{\vics}
 \]
-symbolically applies the binary operation $\op$ to the integer constraints $\vcone$ and $\vctwo$,
-yielding the integer constraint $\vc$.
-Otherwise, the result is $\top$, which indicates a failure in representing the result of
-by an integer constraint.
+symbolically applies the binary operation $\op$ to the lists of integer constraints $\csone$ and $\cstwo$,
+yielding the integer constraints $\vics$.
 
 \subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{well\_constrained}):
+  \begin{itemize}
+    \item for every $\vi$ in $\listrange(\csone)$ and every $\vj$ in $\listrange(\cstwo)$,
+          applying \\
+          $\constraintbinoppair$ to $\op$, $\csone[\vi]$, and $\cstwo[\vj]$,
+          yields the constraint $\vc_{(\vi,\vj)}$;
+    \item define $\cs$ as the list consisting of constraints $\vc_{(\vi,\vj)}$,
+          for every $\vi$ in $\listrange(\csone)$ and every $\vj$ in $\listrange(\cstwo)$;
+    \item $\vics$ is the well-constrained list of constrains $\cs$.
+  \end{itemize}
 
+  \item All of the following apply (\textsc{unconstrained}):
+  \begin{itemize}
+    \item there exist $\vi$ in $\listrange(\csone)$ and $\vj$ in $\listrange(\cstwo)$,
+          such that applying
+          $\constraintbinoppair$ to $\op$, $\csone[\vi]$, and $\cstwo[\vj]$,
+          yields $\top$;
+    \item $\vics$ is $\unconstrained$.
+  \end{itemize}
+\end{itemize}
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule[exact\_exact]{
-  \vcone = \ConstraintExact(\veone)\\
-  \vctwo = \ConstraintExact(\vetwo)\\\\
-  \vc \eqdef \ConstraintExact(\EBinop(\op, \veone, \vetwo))
+\inferrule[well\_constrained]{
+  {
+    \begin{array}{l}
+  \vi\in\listrange(\csone), \vj\in\listrange(\cstwo): \\
+  \constraintbinoppair(\op, \csone[\vi], \cstwo[\vj]) \typearrow \vc_{(\vi,\vj)}
+    \end{array}
+  }\\
+  \cs \eqdef [\vi\in\listrange(\csone), \vj\in\listrange(\cstwo): \vc_{(\vi,\vj)}]
 }{
-  \constraintbinop(\op, \vcone, \vctwo) \typearrow \vc
+  \constraintbinop(\op, \csone, \cstwo) \typearrow \overname{\wellconstrained(\cs)}{\vics}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[exact\_range\_right\_increasing]{
-  \vcone = \ConstraintExact(\veone)\\
-  \vctwo = \ConstraintRange(\vetwoone, \vetwotwo)\\\\
-  \isrightincreasing(\op) \typearrow \True \terminateas \top\\\\
-  \vc \eqdef \ConstraintRange(\EBinop(\op, \veone, \vetwoone), \EBinop(\op, \veone, \vetwotwo))
+\inferrule[unconstrained]{
+  {
+    \begin{array}{l}
+  \exists \vi\in\listrange(\csone).\ \exists \vj\in\listrange(\cstwo).\ \\
+  \constraintbinoppair(\op, \csone[\vi], \cstwo[\vj]) \typearrow \top
+    \end{array}
+  }
 }{
-  \constraintbinop(\op, \vcone, \vctwo) \typearrow \vc
+  \constraintbinop(\op, \csone, \cstwo) \typearrow \overname{\unconstrained}{\vics}
+}
+\end{mathpar}
+
+\section{TypingRule.ConstraintBinopPair \label{sec:TypingRule.ConstraintBinopPair}}
+\hypertarget{def-constraintbinoppair}{}
+The function
+\[
+\constraintbinoppair(
+  \overname{\binop}{\op} \aslsep
+  \overname{\intconstraint}{\vcone} \aslsep
+  \overname{\intconstraint}{\vctwo}
+)
+\aslto \overname{\overname{\intconstraint}{\vc} \cup \{\top\}}{\vres}
+\]
+symbolically applies the binary operation $\op$ to the pair of integer constraints $\vcone$ and $\vctwo$,
+yielding $\vres$ which is an integer constraint $\vc$ or
+$\top$, which indicates a failure in representing the result as an integer constraint.
+
+\subsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{exact\_exact}):
+  \begin{itemize}
+    \item $\vcone$ is an exact constraint for the expression $\veone$, that is, \ConstraintExact(\veone);
+    \item $\vctwo$ is an exact constraint for the expression $\vetwo$, that is, \ConstraintExact(\vetwo);
+    \item define $\vc$ as the exact constraint for the binary operation expression with $\op$, $\veone$, and $\vetwo$,
+          that is, $\ConstraintExact(\EBinop(\op, \veone, \vetwo))$;
+  \end{itemize}
+
+  \item All of the following apply (\textsc{exact\_range}):
+  \begin{itemize}
+    \item $\vcone$ is an exact constraint for the expression $\veone$, that is, $\ConstraintExact(\veone)$;
+    \item $\vctwo$ is an range constraint for the expressions $\vetwoone$ and $\vetwotwo$, that is, \\ $\ConstraintRange(\vetwoone, \vetwotwo)$;
+    \item One of the following applies:
+    \begin{itemize}
+      \item All of the following apply:
+      \begin{itemize}
+          \item applying $\isrightincreasing$ to $\op$ yields $\True$;
+          \item define $\vc$ as the range constraint for the following two expressions:
+          the binary operation expression for $\op$ $\veone$ and $\vetwoone$, and
+          the binary operation expression for $\op$ $\veone$ and $\vetwotwo$;
+      \end{itemize}
+
+      \item All of the following apply:
+      \begin{itemize}
+          \item applying $\isrightdecreasing$ to $\op$ yields $\True$;
+          \item define $\vc$ as the range constraint for the following two expressions:
+          the binary operation expression for $\op$ $\veone$ and $\vetwotwo$, and
+          the binary operation expression for $\op$ $\veone$ and $\vetwoone$;
+      \end{itemize}
+
+      \item Otherwise, the result is $\Top$;
+    \end{itemize}
+  \end{itemize}
+
+  \item All of the following apply (\textsc{range\_exact}):
+  \begin{itemize}
+    \item $\vcone$ is an range constraint for the expressions $\veoneone$ and $\veonetwo$, that is, \\ $\ConstraintRange(\veoneone, \veonetwo)$;
+    \item $\vctwo$ is an exact constraint for the expression $\vetwo$, that is, $\ConstraintExact(\vetwo)$;
+    \item One of the following applies:
+    \begin{itemize}
+      \item All of the following apply:
+      \begin{itemize}
+        \item applying $\isleftincreasing$ to $\op$ yields $\True$;
+        \item define $\vc$ as the range constraint for the following two expressions:
+              the binary operation expression for $\op$ $\veoneone$ and $\vetwo$, and
+              the binary operation expression for $\op$ $\veonetwo$ and $\vetwo$;
+      \end{itemize}
+      \item Otherwise, the result is $\Top$.
+    \end{itemize}
+  \end{itemize}
+
+  \item All of the following apply (\textsc{range\_range}):
+  \begin{itemize}
+    \item $\vcone$ is an range constraint for the expressions $\veoneone$ and $\veonetwo$, that is, \\ $\ConstraintRange(\veoneone, \veonetwo)$;
+    \item $\vctwo$ is an range constraint for the expressions $\vetwoone$ and $\vetwotwo$, that is, \\ $\ConstraintRange(\vetwoone, \vetwotwo)$;
+    \item One of the following applies:
+    \begin{itemize}
+      \item All of the following apply:
+      \begin{itemize}
+        \item applying $\isleftincreasing$ to $\op$ yields $\True$;
+        \item applying $\isrightincreasing$ to $\op$ yields $\True$;
+        \item define $\vc$ as the range constraint for the following two expressions:
+              the binary operation expression for $\op$ $\veoneone$ and $\vetwoone$, and
+              the binary operation expression for $\op$ $\veonetwo$ and $\vetwotwo$;
+      \end{itemize}
+      \item All of the following apply:
+      \begin{itemize}
+        \item applying $\isleftincreasing$ to $\op$ yields $\True$;
+        \item applying $\isrightdecreasing$ to $\op$ yields $\True$;
+        \item define $\vc$ as the range constraint for the following two expressions:
+              the binary operation expression for $\op$ $\veoneone$ and $\vetwotwo$, and
+              the binary operation expression for $\op$ $\veonetwo$ and $\vetwoone$;
+      \end{itemize}
+      \item Otherwise, the result is $\Top$.
+    \end{itemize}
+  \end{itemize}
+\end{itemize}
+
+\subsection{Formally}
+\begin{mathpar}
+\inferrule[exact\_exact]{}{
+  \constraintbinoppair(\op, \overname{\AbbrevConstraintExact{\veone}}{\vcone}, \overname{\AbbrevConstraintExact{\vetwo}}{\vctwo}) \typearrow
+  \overname{\AbbrevConstraintExact{\AbbrevEBinop{\op}{\veone}{\vetwo}}}{\vc}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[exact\_range\_right\_decreasing]{
-  \vcone = \ConstraintExact(\veone)\\
-  \vctwo = \ConstraintRange(\vetwoone, \vetwotwo)\\\\
-  \isrightdecreasing(\op) \typearrow \True \terminateas \top\\\\
-  \vc \eqdef \ConstraintRange(\EBinop(\op, \veone, \vetwotwo), \EBinop(\op, \veone, \vetwoone))
+\inferrule[exact\_range]{
+  \vres \eqdef
+  {
+    \begin{cases}
+      % 2
+      \AbbrevConstraintRange{\AbbrevEBinop{\op}{\veone}{\vetwoone}}{\AbbrevEBinop{\op}{\veone}{\vetwotwo}} & \textbf{if }
+      (\isrightincreasing(\op) \typearrow \True) \\
+      % 3
+      \AbbrevConstraintRange{\AbbrevEBinop{\op}{\veone}{\vetwotwo}}{\AbbrevEBinop{\op}{\veone}{\vetwoone}} & \textbf{if }
+      (\isrightdecreasing(\op) \typearrow \True) \\
+      %
+      \Top & \textbf{else}
+    \end{cases}
+  }
 }{
-  \constraintbinop(\op, \vcone, \vctwo) \typearrow \vc
+  \constraintbinoppair(\op, \overname{\AbbrevConstraintExact{\veone}}{\vcone}, \overname{\AbbrevConstraintRange{\vetwoone}{\vetwotwo}}{\vctwo}) \typearrow \vres
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[exact\_range\_top]{
-  \vcone = \ConstraintExact(\veone)\\
-  \vctwo = \ConstraintRange(\vetwoone, \vetwotwo)\\\\
-  \isrightincreasing(\op) \typearrow \False\\
-  \isrightdecreasing(\op) \typearrow \False\\
+\inferrule[range\_exact]{
+  \vres \eqdef
+  {
+    \begin{cases}
+      % 4
+      \AbbrevConstraintRange{\AbbrevEBinop{\op}{\veoneone}{\vetwo}}{\AbbrevEBinop{\op}{\veonetwo}{\vetwo}} & \textbf{if }
+      (\isleftincreasing(\op) \typearrow \True)\\
+      %
+      \Top & \textbf{else}
+    \end{cases}
+  }
 }{
-  \constraintbinop(\op, \vcone, \vctwo) \typearrow \vc
+  \constraintbinoppair(\op, \overname{\AbbrevConstraintRange{\veoneone}{\veonetwo}}{\vcone}, \overname{\AbbrevConstraintExact{\vetwo}}{\vctwo}) \typearrow \vres
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[range\_exact\_left\_increasing]{
-  \vcone = \ConstraintRange(\veoneone, \veonetwo)\\
-  \vctwo = \ConstraintExact(\vetwo)\\\\
-  \isleftincreasing(\op) \typearrow \True \terminateas \top\\\\
-  \vc \eqdef \ConstraintRange(\EBinop(\op, \veoneone, \vetwo), \EBinop(\op, \veonetwo, \vetwo))
+\inferrule[range\_range]{
+  \vres \eqdef
+  {
+    \begin{cases}
+      % 5
+      \AbbrevConstraintRange{\AbbrevEBinop{\op}{\veoneone}{\vetwoone}}{\AbbrevEBinop{\op}{\veonetwo}{\vetwotwo}} & \textbf{if }
+      \left(\begin{array}{ll}
+      \isleftincreasing(\op) \typearrow \True\\
+      \isrightincreasing(\op) \typearrow \True\\
+      \end{array}\right)\\
+      % 6
+      \AbbrevConstraintRange{\AbbrevEBinop{\op}{\veoneone}{\vetwotwo}}{\AbbrevEBinop{\op}{\veonetwo}{\vetwoone}} & \textbf{if }
+      \left(\begin{array}{ll}
+      \isleftincreasing(\op) \typearrow \True\\
+      \isrightdecreasing(\op) \typearrow \True
+      \end{array}\right)\\
+      %
+      \Top & \textbf{else}
+    \end{cases}
+  }
 }{
-  \constraintbinop(\op, \vcone, \vctwo) \typearrow \vc
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[range\_range\_left\_increasing\_right\_increasing]{
-  \vcone = \ConstraintRange(\veoneone, \veonetwo)\\
-  \vctwo = \ConstraintRange(\vetwoone, \vetwotwo)\\\\
-  \isleftincreasing(\op) \typearrow \True \terminateas \top\\\\
-  \isrightincreasing(\op) \typearrow \True \terminateas \top\\\\
-  \vc \eqdef \ConstraintRange(\EBinop(\op, \veoneone, \vetwoone), \EBinop(\op, \veonetwo, \vetwotwo))
-}{
-  \constraintbinop(\op, \vcone, \vctwo) \typearrow \vc
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[range\_range\_left\_increasing\_right\_decreasing]{
-  \vcone = \ConstraintRange(\veoneone, \veonetwo)\\
-  \vctwo = \ConstraintRange(\vetwoone, \vetwotwo)\\\\
-  \isleftincreasing(\op) \typearrow \True \terminateas \top\\\\
-  \isrightdecreasing(\op) \typearrow \True \terminateas \top\\\\
-  \vc \eqdef \ConstraintRange(\EBinop(\op, \veoneone, \vetwotwo), \EBinop(\op, \veonetwo, \vetwoone))
-}{
-  \constraintbinop(\op, \vcone, \vctwo) \typearrow \vc
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[range\_range\_left\_increasing\_top]{
-  \vcone = \ConstraintRange(\veoneone, \veonetwo)\\
-  \vctwo = \ConstraintRange(\vetwoone, \vetwotwo)\\\\
-  \isleftincreasing(\op) \typearrow \True \terminateas \top\\\\
-  \isrightincreasing(\op) \typearrow \False\\
-  \isrightdecreasing(\op) \typearrow \False
-}{
-  \constraintbinop(\op, \vcone, \vctwo) \typearrow \top
+  \constraintbinoppair(\op, \overname{\AbbrevConstraintRange{\veoneone}{\veonetwo}}{\vcone}, \overname{\AbbrevConstraintRange{\vetwoone}{\vetwotwo}}{\vctwo}) \typearrow \vres
 }
 \end{mathpar}
 
@@ -16711,7 +17047,7 @@ In this chapter, we define two forms of symbolic reasoning ---
 \emph{symbolic reduction} and \emph{symbolic equivalence testing}.
 Symbolic reduction simplifies expressions into \emph{equivalent} expressions
 that are simpler to reason about.
-In out context, equivalence means that we can substitute one expression for another without
+In our context, equivalence means that we can substitute one expression for another without
 affecting the semantics of the overall specification.
 %
 Symbolic equivalence is a \emph{conservative} test.
@@ -16756,7 +17092,7 @@ Our symbolic reduction and equivalence testing rules use \emph{symbolic expressi
 \[
   \begin{array}{rcl}
     \polynomial &\triangleq& \Sum(\unitarymonomial \partialto \Q)                  \hypertarget{def-monomial}{}\hypertarget{def-prod}{}\\
-    \unitarymonomial   &\triangleq& \Prod(\Identifiers \partialto \N)\\
+    \unitarymonomial   &\triangleq& \Prod(\Identifiers \partialto \Npos)\\
   \end{array}
 \]
 
@@ -16766,7 +17102,7 @@ We also define operations over symbolic expressions.
 
 \hypertarget{def-unitarymonomial}{}
 \begin{definition}[Unitary Monomial]
-A \emph{Unitary Monomial} is a partial function from identifiers to non-negative integers\footnote{A unitary monomial has a unit factor,
+A \emph{Unitary Monomial} is a partial function from identifiers to positive integers\footnote{A unitary monomial has a unit factor,
 for example $x^3$, whereas a non-unitary monomial has a non-unit factor, for example, $2 x^3$.}.
 
 A non-empty unitary monomial, $\Prod(\vm)\in\unitarymonomial$ where $\vm \neq \emptyfunc$, can be interpreted as follows:
@@ -16798,7 +17134,7 @@ multiplies two unitary monomials and returns a unitary monomial
       \left\{
       \begin{array}{ll}
         \vfone(\vx) & \text{if } \vx \in \dom(\vfone) \setminus \dom(\vftwo)\\
-        \vfone(\vx) & \text{if } \vx \in \dom(\vftwo) \setminus \dom(\vfone)\\
+        \vftwo(\vx) & \text{if } \vx \in \dom(\vftwo) \setminus \dom(\vfone)\\
         \vfone(\vx)+\vftwo(\vx) & \text{else } \vx \in \dom(\vfone) \cap \dom(\vftwo)\\
       \end{array}
       \right.
@@ -16836,6 +17172,7 @@ For example,
     -1\cdot x^3 \cdot y \cdot z^2 + \frac{3}{4} \cdot \vx^2\cdot \vy \enspace.
 \]
 
+\hypertarget{def-addpolynomials}{}
 The function
 \[
   \addpolynomials : \polynomial \times \polynomial \rightarrow \polynomial
@@ -16884,11 +17221,15 @@ multiplies two polynomials.
 \begin{mathpar}
 \inferrule{
   {
-    \vps \eqdef \{ \Sum(\{\mulmonomials(\vmone, \vmtwo) \mapsto \vcone\times\vctwo\})
-      \;|\; \vfone(\vmone)=\vcone, \vftwo(\vmtwo)=\vctwo\}
+    \vps \eqdef \left\{
+      \begin{array}{l}
+        \Sum(\{\mulmonomials(\vmone, \vmtwo) \mapsto \vfone(\vmone)\times\vftwo(\vmtwo)\})  \;|\; \\
+       \vmone\in\dom(\vfone), \vmtwo\in\dom(\vgtwo)
+    \end{array}
+    \right\}
   }\\
-  \vps \eqname \{ i=1..k: \vp[i] \}\\
-  \addpolynomials(i=1..k: \vp[i]) \typearrow \vp\\
+  \orderedps \eqdef [i=1..k: \vp_i ] \text{ such that }\{\vp_i \;|\; i=1..k\} = \vps\\
+  \addpolynomials(i=1..k: \orderedps) \typearrow \vp\\
 }{
   \mulpolynomials(\overname{\Sum(\vfone)}{\vpone}, \overname{\Sum(\vftwo)}{\vptwo}) \typearrow \vp
 }
@@ -16938,6 +17279,9 @@ One of the following applies:
   \normalize(\tenv, \ve) \typearrow \overname{\ve}{\newe}
 }
 \end{mathpar}
+
+\CodeSubsection{\NormalizeBegin}{\NormalizeEnd}{../StaticModel.ml}
+
 \section{TypingRule.ReduceConstants \label{sec:TypingRule.ReduceConstants}}
 \hypertarget{def-reduceconstants}{}
 The function
@@ -17235,8 +17579,8 @@ One of the following applies:
   \item All of the following apply (\textsc{ebinop\_minus}):
   \begin{itemize}
     \item $\ve$ is a binary subtraction expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\MINUS, \veone, \vetwo)$;
-    \item $\vep$ is the subtraction expression with operands $\veone$ and the negation of $\vetwo$, that is, \\ $\EBinop(\MINUS, \veone, \EUnop(\MINUS, \vetwo))$;
-    \item converting $\vpp$ into a symbolic expression in $\tenv$ yields $\vp$\ProseOrTypeErrorOrBot.
+    \item $\vep$ is the addition expression with operands $\veone$ and the negation of $\vetwo$, that is, \\ $\EBinop(\PLUS, \veone, \EUnop(\MINUS, \vetwo))$;
+    \item converting $\vep$ into a symbolic expression in $\tenv$ yields $\vp$\ProseOrTypeErrorOrBot.
   \end{itemize}
 
   \item All of the following apply (\textsc{ebinop\_mul}):
@@ -17259,7 +17603,7 @@ One of the following applies:
     \item $\ve$ is a binary division expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\DIV, \veone, \vetwo)$;
     \item $\vetwo$ is an integer literal expression for $\vitwo$;
     \item converting $\veone$ to a symbolic expression in $\tenv$ yields $\irone$\ProseOrTypeErrorOrBot;
-    \item $\vftwo$ is $\frac{1}{\vitwo}$;
+    \item $\vftwo$ is $\frac{1}{\vitwo}$ (testing against $\vitwo = 0$ is done dynamically);
     \item $\vp$ is the polynomial $\irone$ with each monomial multiplied by $\vftwo$.
   \end{itemize}
 
@@ -17326,13 +17670,13 @@ One of the following applies:
   \item All of the following apply (\textsc{eunop\_other}):
   \begin{itemize}
     \item $\ve$ is a unary expression with an operator other than $\NEG$;
-    \item $\vp$ is bottom
+    \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
   \item All of the following apply (\textsc{other}):
   \begin{itemize}
     \item $\ve$ is an expression with a label other than $\ELiteral$, $\EVar$, $\EBinop$, and $\EUnop$;
-    \item $\vp$ is bottom
+    \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 \end{itemize}
 
@@ -17392,7 +17736,7 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[ebinop\_minus]{
   \vep \eqdef \EBinop(\PLUS, \veone, \EUnop(\MINUS, \vetwo))\\
-  \toir(\tenv, \vpp) \typearrow \vp \OrTypeError, \CannotBeTransformed\\\\
+  \toir(\tenv, \vep) \typearrow \vp \OrTypeError, \CannotBeTransformed\\\\
 }{
   \toircase(\tenv, \overname{\EBinop(\MINUS, \veone, \vetwo)}{\ve}) \typearrow \vp
 }
@@ -17632,9 +17976,9 @@ One of the following applies:
 
   \item All of the following apply (\textsc{e\_call}):
   \begin{itemize}
-    \item $\veone$ is a call expression with subprogram name $\nameone$ and list of arguments $vargsone$,
+    \item $\veone$ is a call expression with subprogram name $\nameone$ and list of arguments $\vargsone$,
           that is, $\ECall(\nameone, \vargsone, \Ignore)$;
-    \item $\vetwo$ is a call expression with subprogram name $\nametwo$ and list of arguments $vargstwo$,
+    \item $\vetwo$ is a call expression with subprogram name $\nametwo$ and list of arguments $\vargstwo$,
           that is, $\ECall(\nametwo, \vargstwo, \Ignore)$;
     \item checking whether $\nameone$ is equal to $\nametwo$ either yields $\True$ or $\False$, which short-circuits the entire rule;
     \item checking whether the lists of arguments $\vargsone$ and $\vargstwo$ have the same length yields
@@ -18302,8 +18646,8 @@ One of the following applies:
           $\BitFieldType(\nameone, \slicesone, \vtone)$;
     \item $\bftwo$ is a typed bitfield with name $\nametwo$, list of slices $\slicestwo$, and type $\vttwo$, that is,
           $\BitFieldType(\nametwo, \slicestwo, \vttwo)$;
-    \item checking whether $\nameone$ is equal to $\nametwo$ yields $\vbone$;
-    \item testing whether $\slicesone$ and $\slicestwo$ are equivalent in $\tenv$ yields $\vbtwo$\ProseOrTypeError;
+    \item checking whether $\nameone$ is equal to $\nametwo$ yields $\True$\ProseTerminateAs{\False};
+    \item testing whether $\slicesone$ and $\slicestwo$ are equivalent in $\tenv$ yields $\vbone$\ProseOrTypeError;
     \item testing whether the types $\vtone$ and $\vttwo$ are equivalent in $\tenv$ yields $\vbtwo$\ProseOrTypeError;
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
@@ -18360,33 +18704,19 @@ conservatively tests whether the constraint list $\csone$ is equivalent to the c
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
 \subsection{Prose}
-One of the following applies:
+All of the following apply:
 \begin{itemize}
-  \item All of the following apply (\textsc{different\_lengths}):
-  \begin{itemize}
-    \item the number of constraints in $\csone$ is different from the number of constraints in $\cstwo$;
-    \item $\vb$ is $\False$.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{same\_lengths}):
-  \begin{itemize}
-    \item the number of constraints in $\csone$ is the same as the number of constraints in $\cstwo$;
-    \item testing whether the constraint $\csone[i]$ is equivalent to the constraint $\cstwo[i]$ in $\tenv$
-          yields $\vb_i$ for each index in the index in the indices for $\csone$ ($i\in\listrange(\csone)$)\ProseOrTypeError;
-    \item $\vb$ is $\True$ if and only if all $\vb_i$ are $\True$ for each index in the indices for $\csone$.
-  \end{itemize}
+  \item checking whether the number of constraints in $\csone$ is the same as the number of constraints in $\cstwo$
+        yields $\True$\ProseTerminateAs{\False};
+  \item testing whether the constraint $\csone[i]$ is equivalent to the constraint $\cstwo[i]$ in $\tenv$
+        yields $\vb_i$ for each index in the index in the indices for $\csone$ ($i\in\listrange(\csone)$)\ProseOrTypeError;
+  \item $\vb$ is $\True$ if and only if all $\vb_i$ are $\True$ for each index in the indices for $\csone$.
 \end{itemize}
 
 \subsection{Formally}
 \begin{mathpar}
-\inferrule[different\_lengths]{
-  \equallength(\csone, \cstwo) \typearrow \False
-}{
-  \constraintsequal(\tenv, \csone, \cstwo) \typearrow \False
-}
-\and
-\inferrule[same\_lengths]{
-  \equallength(\csone, \cstwo) \typearrow \True\\
+\inferrule{
+  \equallength(\csone, \cstwo) \typearrow \True \terminateas \False\\
   i\in\listrange(\csone): \constraintequal(\tenv, \csone[i], \cstwo[i]) \typearrow \vb_i \OrTypeError\\\\
   \vb \eqdef \bigwedge_{i\in\listrange(\csone)} \vb_i
 }{
@@ -18705,7 +19035,7 @@ One of the following applies:
           the graph of $f$;
     \item transforming $\monoms$ to an expression and sign via $\monomialstoexpr$ yields the expression $\veone$
           and sign $\vsone$;
-    \item define $\ve$ as $\veone$ if $\vs$ is either $0$ or $1$ and the unary expression negating $\veone$, that is,
+    \item define $\ve$ as $\veone$ if $\vsone$ is either $0$ or $1$ and the unary expression negating $\veone$, that is,
           $\EUnop(\NEG, \veone)$.
   \end{itemize}
 \end{itemize}
@@ -18763,7 +19093,7 @@ One of the following applies:
     \item $\ids$ is the list obtained by taking the set of identifiers in the domain of $f$ and in the domain of $g$,
           and sorting them according to the lexical order for identifiers (ASCII string order);
     \item $\vv$ is the first identifier in $\ids$ for which $f$ and $g$ behave differently (either one of them is defined
-          for $vv$ and the other is not, or they both bind $\vv$ to a different value);
+          for $\vv$ and the other is not, or they both bind $\vv$ to a different value);
     \item $s$ is determined as follows: $1$ if $\vv$ is not in the domain of $f$ and is in the domain of $g$;
           $-1$ if $\vv$ is not in the domain of $f$ and is in the domain of $g$;
           otherwise it is the sign of $g(\vv)-f(\vv)$.
@@ -18827,8 +19157,7 @@ One of the following applies:
     \item transforming the unitary monomial $\vm$ to an expression via \\ $\unitarymonomialstoexpr$ yields $\veonep$;
     \item transforming $\veonep$ and $q$ via $\monomialtoexpr$ yields the expression $\veone$ and sign $\vsone$;
     \item transforming $\monoms$ to an expression and sign via $\monomialstoexpr$ yields $(\vetwo, \vstwo)$;
-    \item symbolically adding $\veone, \vsone, \vetwo, \vstwo$ via $\symaddexpr$ yields $\ve$;
-    \item $\vs$ is $\vsone$.
+    \item symbolically adding $\veone, \vsone, \vetwo, \vstwo$ via $\symaddexpr$ yields $(\ve, \vs)$.
   \end{itemize}
 \end{itemize}
 
@@ -18836,16 +19165,16 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[empty]{}
 {
-  \monomialstoexpr(\overname{\emptylist}{\monoms}) \typearrow (\overname{\ELiteral(\lint(0))}{\ve}, \overname{0}{s})
+  \monomialstoexpr(\overname{\emptylist}{\monoms}) \typearrow (\overname{\ELiteral(\lint(0))}{\ve}, \overname{0}{\vs})
 }
 \and
 \inferrule[non\_empty]{
   \unitarymonomialstoexpr(\vm) \typearrow \veonep\\
   \monomialtoexpr(\veonep, q) \typearrow (\veone,\vsone)\\
   \monomialstoexpr(\monoms) \typearrow (\vetwo, \vstwo)\\
-  \symaddexpr(\veone, \vsone, \vetwo, \vstwo) \typearrow \ve
+  \symaddexpr(\veone, \vsone, \vetwo, \vstwo) \typearrow (\ve, \vs)
 }{
-  \monomialstoexpr(\overname{[(\vm,q)] \concat \monomsone}{\monoms}) \typearrow (\ve, \overname{\vsone}{\vs})
+  \monomialstoexpr(\overname{[(\vm,q)] \concat \monomsone}{\monoms}) \typearrow (\ve, \vs)
 }
 \end{mathpar}
 
@@ -18893,6 +19222,7 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\subsection{Formally}
 \begin{mathpar}
 \inferrule[q\_zero]{
   q = 0\\
@@ -18936,19 +19266,34 @@ The function
   \overname{\expr}{\vetwo} \aslsep
   \overname{\{-1,0,1\}}{\vstwo}
   )
-  \typearrow \overname{\expr}{\ve}
+  \typearrow (\overname{\expr}{\ve}, \overname{\{-1,0,1\}}{\vs})
 \]
 symbolically sums the expressions $\veone$ and $\vetwo$
 with respective signs $\vsone$ and $\vstwo$
-yielding the expression $\ve$.
+yielding the expression $\ve$ and sign $\vs$.
+
+The effect of the function can be summarized by the following table:
+\begin{center}
+\begin{tabular}{|c|c|c|c|}
+\hline
+ \diagbox{$\vstwo$}{$\vsone$} & -1                         & 0               & 1\\
+\hline
+-1                            &  $(\veone+\vetwo, \vsone)$ & (\vetwo,\vstwo) & $(\veone-\vetwo, \vsone)$ \\
+\hline
+ 0                            &  $(\veone, \vsone)$        & (\veone,\vsone) & $(\veone, \vsone)$ \\
+ \hline
+ 1                            &  $(\veone-\vetwo, \vsone)$ & (\vetwo,\vstwo) & $(\veone+\vetwo, \vsone)$ \\
+\hline
+\end{tabular}
+\end{center}
 
 \subsection{Prose}
 One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{zero}):
   \begin{itemize}
-    \item either $\vsone$ or $\vstwo$ are $0$;
-    \item $\ve$ is $\veone$ if $\vstwo$ is $0$ and $\veone$, otherwise.
+    \item either $\vsone$ is $0$ or $\vstwo$ is $0$;
+    \item the result is $(\vetwo, \vstwo)$ if $\vsone$ is $0$ and $(\veone, \vsone)$, otherwise.
   \end{itemize}
 
   \item All of the following apply (\textsc{same\_sign}):
@@ -18956,7 +19301,8 @@ One of the following applies:
     \item both $\vsone$ and $\vstwo$ are not $0$;
     \item $\vsone$ is equal to $\vstwo$;
     \item $\ve$ is the binary expression with operator $\PLUS$ and operands $\veone$ and $\vetwo$,
-          that is, $\EBinop(\PLUS, \veone, \vetwo)$.
+          that is, $\EBinop(\PLUS, \veone, \vetwo)$;
+    \item $\vs$ is $\vsone$;
   \end{itemize}
 
   \item All of the following apply (\textsc{same\_sign}):
@@ -18964,7 +19310,8 @@ One of the following applies:
     \item both $\vsone$ and $\vstwo$ are not $0$;
     \item $\vsone$ is different from $\vstwo$;
     \item $\ve$ is the binary expression with operator $\MINUS$ and operands $\veone$ and $\vetwo$,
-          that is, $\EBinop(\MINUS, \veone, \vetwo)$.
+          that is, $\EBinop(\MINUS, \veone, \vetwo)$;
+    \item $\vs$ is $\vsone$;
   \end{itemize}
 \end{itemize}
 
@@ -18972,23 +19319,23 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[zero]{
   (\vsone = 0 \lor \vstwo = 0)\\
-  \ve \eqdef \choice{\vsone = 0}{(\vetwo, \vstwo)}{\veone}
+  (\ve, \vs) \eqdef \choice{\vsone = 0}{(\vetwo, \vstwo)}{(\veone, \vsone)}
 }{
-  \symaddexpr(\veone, \vsone, \vetwo, \vstwo) \typearrow \ve
+  \symaddexpr(\veone, \vsone, \vetwo, \vstwo) \typearrow (\ve, \vs)
 }
 \and
 \inferrule[same\_sign]{
   \vsone \neq 0 \land \vstwo \neq 0\\
   \vsone = \vstwo
 }{
-  \symaddexpr(\veone, \vetwo) \typearrow \overname{\EBinop(\PLUS, \veone, \vetwo)}{\ve}
+  \symaddexpr(\veone, \vetwo) \typearrow (\overname{\EBinop(\PLUS, \veone, \vetwo)}{\ve}, \overname{\vsone}{\vs})
 }
 \and
-\inferrule[differnt\_sign]{
+\inferrule[different\_signs]{
   \vsone \neq 0 \land \vstwo \neq 0\\
   \vsone \neq \vstwo
 }{
-  \symaddexpr(\veone, \vetwo) \typearrow \overname{\EBinop(\MINUS, \veone, \vetwo)}{\ve}
+  \symaddexpr(\veone, \vetwo) \typearrow (\overname{\EBinop(\MINUS, \veone, \vetwo)}{\ve}, \overname{\vsone}{\vs})
 }
 \end{mathpar}
 
@@ -19027,7 +19374,8 @@ One of the following applies:
   \item All of the following apply (\textsc{exp\_two}):
   \begin{itemize}
     \item $\monoms$ is a list where the first element is $(\vv, 2)$ and its tail is $\monoms$;
-    \item $\veone$ is the binary expression with operator $\MUL$ and operands $\EVar(x)$ and $\EVar(x)$;
+    \item $\veone$ is the binary expression with operator $\MUL$ and operands $\EVar(\vv)$ and $\EVar(\vv)$
+          (that is, $\vv$ squared);
     \item transforming $\monomsone$ to an expression yields $\vetwo$;
     \item symbolically multiplying $\veone$ and $\vetwo$ via $\symmulexpr$ yields $\ve$.
   \end{itemize}
@@ -19071,7 +19419,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[exp\_two]{
-  \veone \eqdef \EBinop(\MUL, \EVar(\vv), \EVar(n))\\
+  \veone \eqdef \AbbrevEBinop{\MUL}{\EVar(\vv)}{\EVar(\vv)}\\
   \unitarymonomialstoexpr(\monomsone) \typearrow \vetwo\\
   \symmulexpr(\veone, \vetwo) \typearrow \ve
 }{
@@ -19082,7 +19430,7 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[exp\_gt\_two]{
   n \geq 2\\
-  \veone \eqdef \EBinop(\POW, \EVar(\vv), \ELiteral(n))\\
+  \veone \eqdef \AbbrevEBinop{\POW}{\EVar(\vv)}{\ELiteral(n)}\\
   \unitarymonomialstoexpr(\monomsone) \typearrow \vetwo\\
   \symmulexpr(\veone, \vetwo) \typearrow \ve
 }{
@@ -19202,7 +19550,7 @@ One of the following applies:
 \section{TypingRule.CheckNoDuplicates \label{sec:TypingRule.CheckNoDuplicates}}
 The function
 \[
-  \checknoduplicates(\overname{\identifier^*}{\id_{1..k}}) \aslto \True \cup \TTypeError
+  \checknoduplicates(\overname{\identifier^*}{\id_{1..k}}) \aslto \{\True\} \cup \TTypeError
 \]
 checks whether a non-empty list of identifiers contains a duplicate identifier. If it does not, the result
 is $\True$ and otherwise the result is a type error.
@@ -19331,7 +19679,7 @@ One of the following applies:
 The function
 \[
   \checkvarnotingenv{\overname{\staticenvs}{\tenv} \aslsep \overname{\Strings}{\id}}
-  \aslto \True \cup \overname{\TTypeError}{\TypeErrorConfig}
+  \aslto \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 checks whether $\id$ is already declared in the global environment of $\tenv$.
 If it is, the result is a type error, and otherwise the result is $\True$.
@@ -19379,7 +19727,7 @@ determines whether an identifier $\id$ is declared in the static environment $\t
 The function
 \[
   \checkvarnotinenv{\overname{\staticenvs}{\tenv} \aslsep \overname{\Strings}{\id}}
-  \aslto \True \cup \TTypeError
+  \aslto \{\True\} \cup \TTypeError
 \]
 checks whether $\id$ is already declared in $\tenv$. If it is, the result is a type error,
 and otherwise the result is $\True$.
@@ -19804,7 +20152,7 @@ One of the following applies:
 The function
 \[
   \checkstructureinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt}) \aslto
-  \True \cup \TTypeError
+  \{\True\} \cup \TTypeError
 \]
 returns $\True$ is $\vt$ is has the \structure\ an integer type and a type error otherwise.
 
@@ -19852,7 +20200,7 @@ One of the following applies:
 The function
 \[
   \checkstructurelabel(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\astlabels}{\vl}) \aslto
-  \True \cup \TTypeError
+  \{\True\} \cup \TTypeError
 \]
 returns $\True$ is $\vt$ is has the \structure\ a of type corresponding to the AST label $\vl$ and a type error otherwise.
 
@@ -19961,7 +20309,7 @@ One of the following applies:
 The function
 \[
   \checkstaticallyevaluable(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
-  \True \cup \TTypeError
+  \{\True\} \cup \TTypeError
 \]
 returns $\True$ if $\ve$ is a \staticallyevaluable\ expression in the static environment $\tenv$ and a type error otherwise.
 
@@ -20113,7 +20461,7 @@ The function
     \overname{\staticenvs}{\tenv} \aslsep
     \overname{\ty}{\vtone}) \aslsep
     \overname{\ty}{\vttwo})\aslto
-  \True \cup \TTypeError
+  \{\True\} \cup \TTypeError
 \]
 tests whether the types $\vtone$ and $\vttwo$ are bitvector types of the same width.
 If the answer is positive, the result is $\True$. \ProseOtherwiseTypeError
@@ -20383,6 +20731,27 @@ One of the following applies:
 \chapter{Type Error Codes}
 
 \begin{description}
+\hypertarget{def-expectedbitvectortype}{}
+\item[$\ExpectedBitvectorType$]
+This error indicates that a bitvector type was expected where a non-bitvector type was given.
+See \typingrulecasename{CheckBinop}{plus\_minus\_bits\_bits} (\secref{TypingRule.CheckBinop}) for an example.
+
+\hypertarget{def-expectedenumerationtype}{}
+\item[$\ExpectedEnumerationType$]
+This error indicates that an enumeration type was expected where a \\
+non-enumeration type was given.
+See \secref{TypingRule.TArray} for an example.
+
+\hypertarget{def-expectedstructuredtype}{}
+\item[$\ExpectedStructuredType$]
+This error indicates that a \structuredtype\ was expected where a non-\structuredtype\ was given.
+See \secref{TypingRule.ERecord} for an example.
+
+\hypertarget{def-expectedtupletype}{}
+\item[$\ExpectedTupleType$]
+This error indicates that a tuple type was expected where a non-tuple type was given.
+See \secref{TypingRule.LEDestructuring} for an example.
+
 \hypertarget{def-setterwithoutgetter}{}
 \item[$\SetterWithoutGetter$:]
 ASL requires each setter for a given identifier to have a corresponding getter for the same
@@ -20391,40 +20760,41 @@ The specification either does not contain a getter for the same identifier
 or a getter for the same identifier exists, but it does not have the expected
 signature (see \secref{TypingRule.CheckSetterHasGetter}).
 
-\hypertarget{def-expectedbitvectortype}{}
-\item[$\ExpectedBitvectorType$]
-A type that is not that of a bitvector was given where a bitvector type was expected.
-See \typingrulecasename{CheckBinop}{plus\_minus\_bits\_bits} (\secref{TypingRule.CheckBinop}) for an example.
-
 \hypertarget{def-undefinedidentifier}{}
 \item[$\UndefinedIdentifier$]
 An identifier that is missing a definition of the appropriate kind.
 See TypingRule.SubprogramForName (\secref{TypingRule.SubprogramForName}) for an example.
 
+\hypertarget{def-lengthsmismatch}{}
+\item[$\LengthsMismatch$]
+This error indicates that two lists that are expected to have the same length have different lengths.
+See \secref{TypingRule.LEDestructuring} for an example.
+
 \hypertarget{def-subprogramdeclaredmultipletimes}{}
 \item[$\SubrogramDeclaredMultipleTimes$]
-At least two subprograms in the specification clash (see \secref{TypingRule.AddNewFunc}).
+At least two subprograms in the specification clash.
+See \secref{TypingRule.AddNewFunc} for an example.
 
 \hypertarget{def-nocallcandidates}{}
 \item[$\NoCallCandidates$]
-A function call, given by its name and list of formal argument types, does not match any defined subprogram
-(see \secref{TypingRule.SubprogramForName}).
+A function call, given by its name and list of formal argument types, does not match any defined subprogram.
+See \secref{TypingRule.SubprogramForName} for an example.
 
 \hypertarget{def-toomanycandidates}{}
 \item[$\TooManyCandidates$]
 A function call, given by its name and list of formal argument types, matches more than one subprogram,
-which does not allow the type-checker to decide which subprogram the call refers to
-(see \secref{TypingRule.SubprogramForName}).
+which does not allow the type-checker to decide which subprogram the call refers to.
+See \secref{TypingRule.SubprogramForName} for an example.
 
 \hypertarget{def-parameterwithoutdecl}{}
 \item[$\ParameterWithoutDecl$]
-A subprogram includes a parameter that is not associated with any variable appearing in one of the arguments
-(see \secref{TypingRule.AnnotateParams}).
+A subprogram includes a parameter that is not associated with any variable appearing in one of the arguments.
+See \secref{TypingRule.AnnotateParams} for an example.
 
 \hypertarget{def-nolca}{}
 \item[$\NoLCA$]
-A conditional expressions results in two types that have no common ancestor type that can represent both
-(see \secref{TypingRule.LowestCommonAncestor}).
+A conditional expressions results in two types that have no common ancestor type that can represent both.
+See \secref{TypingRule.LowestCommonAncestor} for an example.
 
 \hypertarget{def-mrv}{}
 \item[$\MismatchedReturnValue$]
@@ -20432,21 +20802,21 @@ A call to a function must result in a returned value,
 whereas a call to a procedure must not.
 This error occurs when a call to a function or a getter is inferred to refer to a procedure or a setter,
 or a call to a procedure or a setter is inferred to refer to a function or a getter.
-(see \secref{TypingRule.AnnotateCallArgTyped}).
+See \secref{TypingRule.AnnotateCallArgTyped} for an example.
 
 \hypertarget{def-cba}{}
 \item[$\CallBadArity$]
 A call to a subprogram must have the same number of arguments as the list of formal arguments
 declared for the subprogram.
-This error indicates that the number of arguments is different to the number of declared formal arguments
-(see \secref{TypingRule.AnnotateCallArgTyped}).
+This error indicates that the number of arguments is different to the number of declared formal arguments.
+See \secref{TypingRule.AnnotateCallArgTyped} for an example.
 
 \hypertarget{def-brd}{}
 \item[$\BadRecursiveDecls$]
 Only subprogram declarations may be mutually recursive.
 This error indicates that at least one declaration in a given list of mutually recursive declarations
-is not a subprogram
-(see \secref{TypingRule.TypeCheckMutuallyRec}).
+is not a subprogram.
+See \secref{TypingRule.TypeCheckMutuallyRec} for an example.
 
 \hypertarget{def-lbi}{}
 \item[$\RequireIntegerForLoopBounds$]
@@ -20454,35 +20824,61 @@ The expressions defining the bounds of a \texttt{for} loop are required to have 
 an integer type.
 This error indicates that at least one of the start expression and end expression violate this
 requirement.
-(see \secref{TypingRule.TypeCheckMutuallyRec}).
-
-\hypertarget{def-rst}{}
-\item[$\RequireStructuredType$]
-This error indicates that a \structuredtype\ is required where a non-\structuredtype\ was supplied.
-(see \secref{TypingRule.ERecord}).
+See \secref{TypingRule.TypeCheckMutuallyRec} for an example.
 
 \hypertarget{def-mfi}{}
 \item[$\MissingFieldInitializer$]
 This error indicates that an initialization of a \structuredtype\ is missing an expression to initialize
 one of its fields.
-(see \secref{TypingRule.ERecord}).
+See \secref{TypingRule.ERecord} for an example.
 
 \hypertarget{def-rsb}{}
 \item[$\RequireSameBitwidths$]
 This error indicates that two bitvector types are required to have the same bitwidths but the type-checker
-was not able to prove it
-(see \secref{BitvectorOperations}).
+was not able to prove it.
+See \secref{BitvectorOperations} for an example.
 
 \hypertarget{def-taf}{}
 \item[$\TypeAsssertionFails$]
-This error indicates that a given at type assertion expression will always fail
-(see \secref{TypingRule.CheckATC}).
+This error indicates that a given at type assertion expression will always fail.
+See \secref{TypingRule.CheckATC} for an example.
 
 \hypertarget{def-ofc}{}
 \item[$\BinaryOperationFailsAllConstraints$]
-This error indicates that a binary expression appearing in a constraint will always fail dynamically
-(see \secref{sec:TypingRule.BinopFilterRhs}). This means that the set of values that the type containing
+This error indicates that a binary expression appearing in a constraint will always fail dynamically.
+This means that the set of values that the type containing
 the constraint can take is empty.
+See \secref{TypingRule.BinopFilterRhs} for an example.
+
+\hypertarget{def-otb}{}
+\item[$\InvalidOperandTypesForBinop$]
+This error indicates that the operator of a binary expression cannot be applied to its operand expressions
+due to their types.
+See \secref{TypingRule.CheckBinop} for an example.
+
+\hypertarget{def-iaf}{}
+\item[$\AnnonymousFormNotAllowedHere$]
+This error indicates that an anonymous type is being used as a type annotation in a context
+where anonymous types are not allowed.
+See \secref{TypingRule.TNonDecl} for an example.
+
+\hypertarget{def-aim}{}
+\item[$\AssignmentToImmutable$]
+This error indicates that an assignment has a left-hand-side storage element that is immutable.
+See \secref{TypingRule.LEVar} for an example.
+
+\hypertarget{def-mf}{}
+\item[$\MissingField$]
+This error indicates that an access is made (for either reading or writing) to a field that is
+not declared by the respective \structuredtype\ or a bitfield that is not declared by the respective
+bitvector type.
+See \secref{TypingRule.LESetStructuredField} for an example.
+
+\hypertarget{def-dii}{}
+\item[$\DivIntIndivisible$]
+This error indicates that a \staticallyevaluable\ expression contain an integer division expression where
+the denominator does not divide the numerator.
+See \textsc{TypingRule.BinopLiterals.DIV\_INT} (\secref{TypingRule.BinopLiterals}) for an example.
 
 \end{description}
 

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -14,7 +14,13 @@
     filecolor=magenta,
     urlcolor=cyan,
 }
-\makeatletter
+\usepackage{diagbox}
+
+% "Dark theme"
+% \usepackage{xcolor}
+% \pagecolor[rgb]{0.2,0.2,0.2}
+% \color[rgb]{0.5,0.5,0.5}
+
 \makeatletter
   \newcommand{\linkdest}[1]{\Hy@raisedlink{\hypertarget{#1}{}}}
 % \newcommand{\linkdest}[1]{\Hy@raisedlink{\hypertarget{#1}{}}}
@@ -48,6 +54,7 @@
 
 \newcommand\tododefine[1]{\hyperlink{tododefine}{\color{red}{\texttt{#1}}}}
 \newcommand\lrmcomment[1]{}
+\newcommand\textfunc[1]{\textit{#1}}
 
 \usepackage{enumitem}
 \renewlist{itemize}{itemize}{20}
@@ -99,7 +106,8 @@
 \newcommand\ie{i.\,e.}
 \newcommand\eg{e.\,g.}
 \newcommand\wrappedline[0]{{\hyperlink{def-wrapline}{\color{red}\hookrightarrow}}}
-\newcommand\casesplitline[0]{{\hyperlink{def-casesplitline}{\color{cyan}\tiny{\text{******** common prefix ********}} }}}
+\newcommand\commonprefixline[0]{{\hyperlink{def-commonprefixline}{\color{cyan}\tiny{\text{******** common prefix ********}} }}}
+\newcommand\commonsuffixline[0]{{\hyperlink{def-commonsuffixline}{\color{cyan}\tiny{\text{******** common suffix ********}} }}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%$%%%%%
 %% Mathematical notations and Inference Rule macros
@@ -120,7 +128,7 @@
 \newcommand\defpoint[1]{#1}
 \newcommand\eqname[0]{\hyperlink{def-deconstruction}{\stackrel{\mathsmaller{\mathsf{is}}}{=}}}
 \newcommand\eqdef[0]{\hyperlink{def-eqdef}{:=}}
-\newcommand\overname[2]{\overbracket{#1}^{#2}}
+\newcommand\overname[2]{\overbrace{#1}^{#2}}
 \newcommand\overtext[2]{\overbracket{#1}^{\text{#2}}}
 \newcommand\emptyfunc[0]{\hyperlink{def-emptyfunc}{{\emptyset}_\lambda}}
 \newcommand\restrictfunc[2]{{#1}\hyperlink{def-restrictfunc}{|}_{#2}}
@@ -165,9 +173,9 @@
 
 \newcommand\sslash[0]{\mathbin{/\mkern-6mu/}}
 \newcommand\terminateas[0]{\hyperlink{def-terminateas}{\sslash}\;}
-\newcommand\booltrans[1]{\hyperlink{def-booltrans}{\texttt{bool\_transition}}(#1)}
+\newcommand\booltrans[1]{\hyperlink{def-booltrans}{\textfunc{bool\_transition}}(#1)}
 \newcommand\booltransarrow[0]{\longrightarrow}
-\newcommand\checktrans[2]{\hyperlink{def-checktrans}{\texttt{check}}(#1, \texttt{#2})}
+\newcommand\checktrans[2]{\hyperlink{def-checktrans}{\textfunc{check}}(#1, \texttt{#2})}
 \newcommand\checktransarrow[0]{\longrightarrow}
 
 \newcommand\termx[0]{\mathit{tx}}
@@ -420,9 +428,9 @@
 \newcommand\localstaticenvs[0]{\hyperlink{def-localstaticenvs}{\mathbb{L}}}
 \newcommand\globalstaticenvs[0]{\hyperlink{def-globalstaticenvs}{\mathbb{G}}}
 \newcommand\emptytenv[0]{\hyperlink{def-emptytenv}{\emptyset_{\tenv}}}
-\newcommand\tstruct[0]{\hyperlink{def-tstruct}{\texttt{get\_structure}}}
-\newcommand\astlabel[0]{\hyperlink{def-astlabel}{\textsf{ast\_label}}}
-\newcommand\typesat[0]{\hyperlink{def-typesatisfies}{\texttt{type\_satisfies}}}
+\newcommand\tstruct[0]{\hyperlink{def-tstruct}{\textfunc{get\_structure}}}
+\newcommand\astlabel[0]{\hyperlink{def-astlabel}{\textfunc{ast\_label}}}
+\newcommand\typesat[0]{\hyperlink{def-typesatisfies}{\textfunc{type\_satisfies}}}
 
 \newcommand\constantvalues[0]{\hyperlink{def-constantvalues}{\textsf{constant\_values}}}
 \newcommand\globalstoragetypes[0]{\hyperlink{def-globalstoragetypes}{\textsf{global\_storage\_types}}}
@@ -434,8 +442,8 @@
 \newcommand\subprogramrenamings[0]{\hyperlink{def-subprogramrenamings}{\textsf{subprogram\_renamings}}}
 \newcommand\parameters[0]{\hyperlink{def-parameters}{\textsf{parameters}}}
 
-\newcommand\unopliterals[0]{\hyperlink{def-unopliterals}{\texttt{unop\_literals}}}
-\newcommand\binopliterals[0]{\hyperlink{def-binopliterals}{\texttt{binop\_literals}}}
+\newcommand\unopliterals[0]{\hyperlink{def-unopliterals}{\textfunc{unop\_literals}}}
+\newcommand\binopliterals[0]{\hyperlink{def-binopliterals}{\textfunc{binop\_literals}}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Semantics macros
@@ -623,7 +631,7 @@
 \newcommand\bits[0]{\texttt{bits}}
 \newcommand\veonep[0]{\texttt{e1'}}
 \newcommand\vetwop[0]{\texttt{e2'}}
-\newcommand\vethreep[0]{\texttt{e2'}}
+\newcommand\vethreep[0]{\texttt{e3'}}
 \newcommand\vepp[0]{\texttt{e''}}
 \newcommand\vtpp[0]{\texttt{t''}}
 \newcommand\vsp[0]{\texttt{s'}}
@@ -1012,3 +1020,7 @@
 \newcommand\vzbopt[0]{\texttt{zb\_opt}}
 \newcommand\explodedinterval[0]{\texttt{exploded\_interval}}
 \newcommand\vbtoolarge[0]{\texttt{b\_too\_large}}
+\newcommand\vbequallength[0]{\texttt{b\_equal\_length}}
+\newcommand\vbequal[0]{\texttt{b\_equal}}
+\newcommand\newes[0]{\texttt{new\_e\_s}}
+\newcommand\orderedps[0]{\texttt{ordered\_ps}}

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -15,9 +15,6 @@ code:
 no-empty:
 	$(MAKE) $(MFLAGS) NOEMPTY=1 all
 
-todo:
-	$(MAKE) $(MFLAGS) TODO=1 all
-
 CONTROLS=ifempty.tex ifcode.tex
 
 .PHONY: control
@@ -35,7 +32,7 @@ ASLSemanticsReference.pdf: control ASLSyntaxReference.pdf ASLSemanticsReference.
 	$(BIBTEX) ASLSemanticsReference
 	$(LATEX) ASLSemanticsReference.tex
 
-ASLTypingReference.pdf: control ASLSyntaxReference.pdf ASLTypingReference.tex ASLASTLines.tex ASLTypingLines.tex ASLTypeSatisfactionLines.tex
+ASLTypingReference.pdf: control ASLSyntaxReference.pdf ASLTypingReference.tex ASLASTLines.tex ASLTypingLines.tex ASLTypeSatisfactionLines.tex ASLStaticModelLines.tex ASLStaticInterpreterLines.tex ASLStaticEnvLines.tex ASLASTUtilsLines.tex
 	$(LATEX) ASLTypingReference.tex
 	$(BIBTEX) ASLTypingReference
 	$(LATEX) ASLTypingReference.tex
@@ -59,6 +56,18 @@ ASLTypeSatisfactionLines.tex: ../types.ml
 ASLASTLines.tex: ../AST.mli
 	$(BENTO) $< > $@
 
+ASLStaticModelLines.tex: ../StaticModel.ml
+	$(BENTO) $< > $@
+
+ASLStaticInterpreterLines.tex: ../StaticInterpreter.ml
+	$(BENTO) $< > $@
+
+ASLStaticEnvLines.tex: ../StaticEnv.ml
+	$(BENTO) $< > $@
+
+ASLASTUtilsLines.tex: ../ASTUtils.ml
+	$(BENTO) $< > $@
+
 .PHONY: force
 
 ifdef CODE
@@ -79,7 +88,7 @@ endif
 
 clean:
 	/bin/rm -f $(PDFS)
-	/bin/rm -f ASLSemanticsLines.tex ASLTypingLines.tex ASLTypeSatisfactionLines.tex ASLASTLines.tex
+	/bin/rm -f ASLSemanticsLines.tex ASLTypingLines.tex ASLTypeSatisfactionLines.tex ASLASTLines.tex ASLStaticModelLines.tex ASLStaticInterpreterLines.tex ASLStaticEnvLines.tex ASLASTUtilsLines.tex
 	/bin/rm -f *.aux *.log *.fls *.log *.toc *.fdb_latexmk *~
 	/bin/rm -f $(CONTROLS)
 	/bin/rm -f comment.cut

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -397,19 +397,15 @@ module TypingRule = struct
     | EUnknown
     | EPattern
     | LEDiscard
-    | LELocalVar
-    | LEGlobalVar
+    | LEVar
     | LEUndefIdentV0
     | LEUndefIdentV1
     | LEDestructuring
     | LESlice
     | LESetArray
-    | LESetBadStructuredField
     | LESetStructuredField
     | LESetBadBitField
     | LESetBitField
-    | LESetBitFieldNested
-    | LESetBitFieldTyped
     | LESetBadField
     | LESetFields
     | LEConcat
@@ -561,16 +557,12 @@ module TypingRule = struct
     | EUnknown -> "EUnknown"
     | EPattern -> "EPattern"
     | LEDiscard -> "LEDiscard"
-    | LELocalVar -> "LELocalVar"
-    | LEGlobalVar -> "LEGlobalVar"
+    | LEVar -> "LEVar"
     | LESlice -> "LESlice"
     | LESetArray -> "LESetArray"
-    | LESetBadStructuredField -> "LESetBadStructuredField"
     | LESetStructuredField -> "LESetStructuredField"
     | LESetBadBitField -> "LESetBadBitField"
     | LESetBitField -> "LESetBitField"
-    | LESetBitFieldNested -> "LESetBitFieldNested"
-    | LESetBitFieldTyped -> "LESetBitFieldTyped"
     | LESetBadField -> "LESetBadField"
     | LESetFields -> "LESetFields"
     | LEConcat -> "LEConcat"
@@ -728,16 +720,12 @@ module TypingRule = struct
       EConcat;
       ETuple;
       LEDiscard;
-      LELocalVar;
-      LEGlobalVar;
+      LEVar;
       LESlice;
       LESetArray;
-      LESetBadStructuredField;
       LESetStructuredField;
       LESetBadBitField;
       LESetBitField;
-      LESetBitFieldNested;
-      LESetBitFieldTyped;
       LESetBadField;
       LESetFields;
       LESetFields;

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -143,15 +143,15 @@ let rec is_non_primitive ty =
 let is_primitive ty = (not (is_non_primitive ty)) |: TypingRule.PrimitiveType
 (* End *)
 
-let under_constrained_constraints =
+let parameterized_constraints =
   let next_uid = ref 0 in
   fun var ->
     let uid = !next_uid in
     incr next_uid;
     Parameterized (uid, var)
 
-let under_constrained_ty var =
-  T_Int (under_constrained_constraints var) |> add_dummy_pos
+let parameterized_ty var =
+  T_Int (parameterized_constraints var) |> add_dummy_pos
 
 let to_well_constrained ty =
   match ty.desc with
@@ -559,7 +559,7 @@ module Domain = struct
         | L_Int z1 -> IntSet.mem z1 is2
         | _ -> false)
 
-  (* Begin SyDomIsSubrset *)
+  (* Begin SyDomIsSubset *)
   let is_subset env d1 d2 =
     let () =
       if false then Format.eprintf "Is %a a subset of %a?@." pp d1 pp d2

--- a/asllib/types.mli
+++ b/asllib/types.mli
@@ -75,11 +75,11 @@ val get_structure : env -> ty -> ty
 (** The structure of a type is the primitive type that can hold the same
     values. *)
 
-val under_constrained_ty : identifier -> ty
-(** From a declared variable, builds an under-constrained integer. *)
+val parameterized_ty : identifier -> ty
+(** Builds an parameterized integer type from a declared variable. *)
 
 val to_well_constrained : ty -> ty
-(** Transform an under-constrained type into a well-constrained integer equal
+(** Transform a parameterized integer type into a well-constrained integer equal
     to the parameter that have this type, and leave the other types (such as
     well-constrained integers) as they are. *)
 


### PR DESCRIPTION
* Addressed comments on ASL Typing Reference.
* Merged some rules, for example, LELocalVar/LEGLobalVar are now just LEVar.
* Added notations to enable locating rules that correspond to helper functions defined in other functions. I'm using `(* RuleName( *)` as a start delimiter for the code for a rule named `RuleName` and `(* RuleName) *)` as an ending delimiter.
* Added StaticModel.ml, StaticModel.ml, ASTUtils.ml, and StaticEnv.ml to Make file for line number extraction to enable referring to code used by the corresponding typing rules.
* Change font used for functions and relations throughout all reference from teletype to mathematical+italics.