### PR TITLE
Rework the intrinsic dependencies for SVE instructions

### DIFF
--- a/herd/event.ml
+++ b/herd/event.ml
@@ -352,7 +352,7 @@ val same_instance : event -> event -> bool
   val data_input_union : (* input to both structures *)
     event_structure -> event_structure -> event_structure option
 
-  val data_to_output : (* inut to second es output *)
+  val data_to_output : (* input to second es output *)
     event_structure -> event_structure -> event_structure option
 
   val data_to_minimals : (* second es entries are minimal evts all iico *)

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -365,6 +365,9 @@ val same_instance : event -> event -> bool
   val (=$$=) :
       event_structure -> event_structure -> event_structure option
 
+  val data_output_union :
+    event_structure -> event_structure -> event_structure option
+
 (* sequential composition, add control dependency *)
   val (=**=) :
      event_structure -> event_structure -> event_structure option
@@ -1494,6 +1497,12 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
         Some out in
       check_disjoint (data_comp minimals_data out)
 
+    let data_output_union es1 es2 =
+      let r = data_comp minimals sequence_data_output es1 es2 in
+      Some
+        { r with
+          output = union_output es1 es2 ;
+        }
 
 (* Composition with intra_causality_control from first to second *)
 

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -352,6 +352,9 @@ val same_instance : event -> event -> bool
   val data_input_union : (* input to both structures *)
     event_structure -> event_structure -> event_structure option
 
+  val data_to_output : (* inut to second es output *)
+    event_structure -> event_structure -> event_structure option
+
   val data_to_minimals : (* second es entries are minimal evts all iico *)
       event_structure -> event_structure -> event_structure option
 
@@ -1469,6 +1472,18 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
 
     let data_to_minimals =
       check_disjoint (data_comp minimals sequence_data_output)
+
+    let data_to_output es1 es2 =
+      let r =
+        data_comp
+          get_output
+          sequence_data_output es1 es2 in
+      let r =
+        { r with
+          input = union_input_seq es1 es2 ;
+          data_input = union_data_input_seq es1 es2 ;
+        } in
+      Some r
 
     let (=$$=) =
       let out es1 es2 =

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -793,6 +793,9 @@ Monad type:
     let seq_mem : 'a t -> 'b t -> ('a * 'b) t
       = fun  s1 s2 -> combi Misc.pair E.seq_mem s1 s2
 
+    let seq_mem_list : 'a t -> 'a list t -> 'a list t
+      = fun  s1 s2 -> combi Misc.cons E.seq_mem s1 s2
+
 (* Force monad value *)
     let forceT (v : 'a) : 'b t -> 'a t =
       let f (_, vcl, es) = (v, vcl, es) in

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -272,6 +272,7 @@ Monad type:
       = fun s f -> data_comp (=**=) s f
 
     let control_input_union s f = data_comp E.control_input_union s f
+    let control_input_next s f = data_comp E.control_input_next s f
 
     let (>>*==) : 'a t -> ('a -> 'b t) -> ('b) t
         = fun s f -> data_comp (=*$$=) s f
@@ -290,6 +291,8 @@ Monad type:
     let asl_ctrl s f = data_comp E.bind_ctrl_sequence_data_po s f
 
     let bind_data_to_minimals s f =  data_comp E.data_to_minimals s f
+
+    let bind_data_to_output s f = data_comp E.data_to_output s f
 
 (* Triple composition *)
     let comp_comp comp_str m1 m2 m3 eiid =

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -266,6 +266,9 @@ Monad type:
     let (>>==) : 'a t -> ('a -> 'b t) -> ('b) t
         = fun s f -> data_comp (=$$=) s f
 
+    let data_output_union : 'a t -> ('a -> 'b t) -> ('b) t
+        = fun s f -> data_comp (E.data_output_union) s f
+
     let asl_data s f = data_comp E.data_po_seq s f
 
     let (>>*=) : 'a t -> ('a -> 'b t) -> ('b) t

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -74,19 +74,21 @@ module type S =
     (* Input to both args *)
 
     val data_output_union : 'a t -> ('a -> 'b t) -> 'b t
-    (** [data_output_union s f] returns a composition of the event
-        structures of [s] and the result of [f] where the
-        iico_causality_data includes pairs (e1, e2) where e1 is an
-        output event of e1 and e2 an input event of the result of
-        [f]. The output of the resulting event structure is the union
-        of the output events of [s] and the result of [f] *)
+    (** [data_output_union s f] returns a composition of the event structures of
+        [s] and the result of [f] where the [iico_causality_data] includes pairs
+        (e1, e2) where e1 is an output event of e1 and e2 an input event of the
+        result of [f]. The output of the resulting event structure is the union
+        of the output events of [s] and the output events of the result of [f].
+        *)
 
 (* Control composition *)
     val (>>*=) : 'a t -> ('a -> 'b t) -> 'b t
 
-(* Input is union of both arg inputs *)
     val control_input_union :  'a t -> ('a -> 'b t) -> 'b t
+    (** Input is union of both arg inputs *)
+
     val control_input_next :  'a t -> ('a -> 'b t) -> 'b t
+    (** Input is second arg's input *)
 
     val (>>*==) : 'a t -> ('a -> 'b t) -> 'b t (* Output events stay in first argument *)
     val bind_control_set_data_input_first :
@@ -99,10 +101,12 @@ module type S =
     val bind_data_to_minimals : 'a t -> ('a -> 'b t) -> ('b) t
 
     val bind_data_to_output : 'a t -> ('a -> 'b t) -> 'b t
-    (** [bind_data_to_output p1 p2] returns a composition of the event
-        structures of [s1] and [s2] where there is iico_causality_data
-        relation from the output events of [s1] to the output events
-        of [s2] *)
+    (** [bind_data_to_output s f] returns a composition of the event structures
+        of [s] and the result of [f] where the [iico_causality_data] includes
+        pairs (e1, e2) where e1 is an output event of e1 and e2 an onput event
+        of the result of [f]. The output of the resulting event structure is the
+        union of the output events of [s] and the output events of the result of
+        [f]. *)
 
     (* Control compoisition, but output events might be in first event if
        second is empty. *)
@@ -256,6 +260,8 @@ module type S =
         event in [s2] *)
 
     val seq_mem_list : 'a t -> 'a list t -> 'a list t
+    (** [seq_mem_list] is similar to [seq_mem], but cons the results instead of
+        pairing them *)
 
     val (|*|)   : bool code -> unit code -> unit code   (* Cross product *)
 (*    val lockT : 'a t -> 'a t *)

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -77,6 +77,7 @@ module type S =
 
 (* Input is union of both arg inputs *)
     val control_input_union :  'a t -> ('a -> 'b t) -> 'b t
+    val control_input_next :  'a t -> ('a -> 'b t) -> 'b t
 
     val (>>*==) : 'a t -> ('a -> 'b t) -> 'b t (* Output events stay in first argument *)
     val bind_control_set_data_input_first :
@@ -87,6 +88,12 @@ module type S =
 
     (* Data composition, entry for snd monad: minimals for complete iico *)
     val bind_data_to_minimals : 'a t -> ('a -> 'b t) -> ('b) t
+
+    val bind_data_to_output : 'a t -> ('a -> 'b t) -> 'b t
+    (** [bind_data_to_output p1 p2] returns a composition of the event
+        structures of [s1] and [s2] where there is iico_causality_data
+        relation from the output events of [s1] to the output events
+        of [s2] *)
 
     (* Control compoisition, but output events might be in first event if
        second is empty. *)

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -71,6 +71,15 @@ module type S =
     val asl_data : 'a t -> ('a -> 'b t) -> 'b t
 
     val (>>==) : 'a t -> ('a -> 'b t) -> 'b t (* Output events stay in first arg *)
+    (* Input to both args *)
+
+    val data_output_union : 'a t -> ('a -> 'b t) -> 'b t
+    (** [data_output_union s f] returns a composition of the event
+        structures of [s] and the result of [f] where the
+        iico_causality_data includes pairs (e1, e2) where e1 is an
+        output event of e1 and e2 an input event of the result of
+        [f]. The output of the resulting event structure is the union
+        of the output events of [s] and the result of [f] *)
 
 (* Control composition *)
     val (>>*=) : 'a t -> ('a -> 'b t) -> 'b t

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -246,6 +246,8 @@ module type S =
         every memory event in [s1] is iico_order before every memory
         event in [s2] *)
 
+    val seq_mem_list : 'a t -> 'a list t -> 'a list t
+
     val (|*|)   : bool code -> unit code -> unit code   (* Cross product *)
 (*    val lockT : 'a t -> 'a t *)
     val forceT : 'a -> 'b t -> 'a t


### PR DESCRIPTION
Supersedes #963.

- Add `iico_ctrl` to `AnyActiveElement` checks (for scatter load and gather store)
- Add `iico_ctrl` to `ActivePredicateElement` checks
- Add `iico_order` to SVE store[^1]
- Fix the semantics for the SVE `NEG` instruction

[^1]: Arm ARM B2.5 SVE memory ordering relaxations, R_CJHWV: "When a single SVE vector store instruction generates multiple writes to the same location, the instruction ensures that these writes appear in the coherence order for that location, in order of increasing vector element number. No other ordering restrictions apply to memory effects generated by the same SVE store instruction."

Example graph change for [`herd/tests/instructions/AArch64.sve/Y01.litmus`](https://github.com/herd/herdtools7/blob/39878681a0b8662d0fb740ad5b571d1a1ee0e8f1/herd/tests/instructions/AArch64.sve/Y01.litmus):

`LD1D {Z0.D},P0/Z,[X0]` (load, predicated) before:

<img width="358" alt="Screenshot 2024-09-18 at 14 56 28" src="https://github.com/user-attachments/assets/23e649fe-c501-4b4c-9578-beb07981ef0c">

after:

<img width="995" alt="Screenshot 2024-09-19 at 09 53 29" src="https://github.com/user-attachments/assets/30425e33-c849-40ab-b233-1f377056f80f">

`ST1D {Z0.D},P0,[X0]` (store, predicated) before:

<img width="366" alt="Screenshot 2024-09-18 at 14 58 21" src="https://github.com/user-attachments/assets/410e2ea2-e1d9-4076-9f1d-04279116d58f">

after:

<img width="995" alt="Screenshot 2024-09-19 at 09 54 20" src="https://github.com/user-attachments/assets/cb78c1f6-0ec7-46f2-96d8-60862008f9f1">

For `herd/tests/instructions/AArch64.sve/V16.litmus`'s `LD1W {Z2.S},P0/Z,[X1,Z1.S,UXTW #2]` (gather load), before:

![Screenshot 2024-09-18 at 15 43 50](https://github.com/user-attachments/assets/c6854f03-13ee-4be6-8e12-047cb5baf9a8)

after:

<img width="1095" alt="Screenshot 2024-09-18 at 16 42 02" src="https://github.com/user-attachments/assets/ede246b1-cd08-469a-aa0e-fbb1d26bb723">

For `herd/tests/instructions/AArch64.sve/V17.litmus`'s `ST1W {Z1.S},P0,[X1,Z1.S,UXTW #2]` (scatter store), before:

![Screenshot 2024-09-18 at 15 52 31](https://github.com/user-attachments/assets/423afeef-92d5-46cf-b8b0-60c9604f56d6)

after:

![Screenshot 2024-09-18 at 15 49 24](https://github.com/user-attachments/assets/c77bf39e-cb07-43fc-a193-1d82ba4dfd2b)
