### PR TITLE
Streamlining the static model

### DIFF
--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -142,6 +142,34 @@ val binop : binop -> expr -> expr -> expr
 val unop : unop -> expr -> expr
 (** Builds a unary operation from its sub-expression. *)
 
+val expr_of_z : Z.t -> expr
+(** [expr_of_z z] is the integer literal for [z]. *)
+
+val zero_expr : expr
+(** The integer literal for [0]. *)
+
+val expr_of_rational : Q.t -> expr
+(** [expr_of_rational q] is the rational literal for [q]. *)
+
+val mul_expr : expr -> expr -> expr
+(** [mul_expr e1 e2] is an expression representing [e1 * e2]. *)
+
+val pow_expr : expr -> int -> expr
+(** [pow_expr e i] is an expression representing [e ^ i]. *)
+
+val div_expr : expr -> Z.t -> expr
+(** [div_expr e z] is an expression representing [e DIV z]. *)
+
+val add_expr : expr -> int * expr -> expr
+(** [add_expr e1 (s, e2)] is an expression representing [e1 + sign(s) * e2].
+    [e2] is expected to be non-negative. *)
+
+val conj_expr : expr -> expr -> expr
+(** [conj_expr e1 e2] is an expression representing [e1 && e2]. *)
+
+val cond_expr : expr -> expr -> expr -> expr
+(** [cond_expr e e1 e2] is an expression representing [if e then e1 else e2]. *)
+
 val fresh_var : string -> identifier
 (** [fresh_var "doc"] is a fresh variable whose name begins with "doc". *)
 

--- a/asllib/StaticModel.ml
+++ b/asllib/StaticModel.ml
@@ -424,19 +424,7 @@ let rec to_ir env (e : expr) : ir_expr =
       and ir2' = ASTUtils.list_cross restrict nctnts ir2 in
       Disjunction (ir1' @ ir2')
   | E_ATC (e', _) -> to_ir env e'
-  | _ -> (
-      let v =
-        let open StaticInterpreter in
-        try static_eval env e
-        with
-        | StaticEvaluationUnknown
-        | Error.ASLException { desc = UnsupportedExpr _; _ }
-        ->
-          raise NotYetImplemented
-      in
-      match v with
-      | L_Int i -> poly_of_z i |> always
-      | _ -> raise NotYetImplemented)
+  | _ -> raise NotYetImplemented
 
 and to_cond env (e : expr) : ctnts disjunction * ctnts disjunction =
   let ( ||| ) = disjunction_or in

--- a/asllib/StaticModel.ml
+++ b/asllib/StaticModel.ml
@@ -196,7 +196,7 @@ let divide_polys : polynomial -> polynomial -> polynomial =
            | _, None -> o1
            | None, Some 0 -> None
            | None, Some _ -> raise NotYetImplemented
-           | Some p1, Some p2 when p1 > p2 -> Some (p2 - p1)
+           | Some p1, Some p2 when p1 > p2 -> Some (p1 - p2)
            | Some p1, Some p2 when p1 = p2 -> None
            | Some _, Some _ -> raise NotYetImplemented)
          map1 map2)
@@ -487,7 +487,7 @@ let equal_mod_branches (Disjunction li1) (Disjunction li2) =
     in
     let ctnts = ctnts_and ctnts1 ctnts2 in
     match ctnts with
-    | Bottom -> Bottom
+    | Bottom -> ctnts_true
     | Conjunction _ ->
         let equality' = reduce_ctnts equality in
         let () =

--- a/asllib/StaticModel.ml
+++ b/asllib/StaticModel.ml
@@ -58,13 +58,7 @@ module PMap = Map.Make (PolynomialOrdered)
 (** Map from polynomials. *)
 
 (** A constraint on a numerical value. *)
-type sign =
-  | Null
-  | StrictPositive
-  | Positive
-  | Negative
-  | StrictNegative
-  | NotNull
+type sign = Null | NotNull
 
 (** A conjunctive logical formulae with polynomials.
 
@@ -119,15 +113,7 @@ let pp_poly f (Sum poly) =
     pp_close_box f ())
 
 let pp_sign f s =
-  let s =
-    match s with
-    | Null -> "= 0"
-    | NotNull -> "!= 0"
-    | StrictPositive -> "> 0"
-    | Positive -> "\u{2265} 0"
-    | Negative -> "\u{2264} 0"
-    | StrictNegative -> "< 0"
-  in
+  let s = match s with Null -> "= 0" | NotNull -> "!= 0" in
   Format.pp_print_string f s
 
 let pp_ctnt f (p, s) =
@@ -166,46 +152,9 @@ exception ConjunctionBottomInterrupt
 
 let sign_and _p s1 s2 =
   match (s1, s2) with
-  | Null, Null
-  | Null, Positive
-  | Positive, Null
-  | Negative, Null
-  | Null, Negative
-  | Negative, Positive
-  | Positive, Negative ->
-      Some Null
-  | StrictPositive, StrictPositive
-  | StrictPositive, Positive
-  | Positive, StrictPositive
-  | Positive, NotNull
-  | NotNull, Positive
-  | StrictPositive, NotNull
-  | NotNull, StrictPositive ->
-      Some StrictPositive
-  | Positive, Positive -> Some Positive
-  | Negative, Negative -> Some Negative
+  | Null, Null -> Some Null
   | NotNull, NotNull -> Some NotNull
-  | StrictNegative, StrictNegative
-  | StrictNegative, Negative
-  | Negative, StrictNegative
-  | Negative, NotNull
-  | NotNull, Negative
-  | NotNull, StrictNegative
-  | StrictNegative, NotNull ->
-      Some StrictNegative
-  | Null, NotNull
-  | NotNull, Null
-  | Negative, StrictPositive
-  | StrictPositive, Negative
-  | StrictNegative, Positive
-  | Positive, StrictNegative
-  | Null, StrictPositive
-  | StrictPositive, Null
-  | Null, StrictNegative
-  | StrictNegative, Null
-  | StrictNegative, StrictPositive
-  | StrictPositive, StrictNegative ->
-      raise_notrace ConjunctionBottomInterrupt
+  | Null, NotNull | NotNull, Null -> raise_notrace ConjunctionBottomInterrupt
 
 let add_mono_to_poly =
   let updater factor = function
@@ -431,13 +380,7 @@ let polynomial_to_expr (Sum map) =
     zero
     (MMap.bindings map |> List.rev)
 
-let sign_to_binop = function
-  | Null -> EQ_OP
-  | NotNull -> NEQ
-  | StrictPositive -> LT
-  | Positive -> LEQ
-  | Negative -> GEQ
-  | StrictNegative -> GT
+let sign_to_binop = function Null -> EQ_OP | NotNull -> NEQ
 
 let ctnts_to_expr : ctnts -> expr option =
   let e_band e1 e2 =
@@ -483,14 +426,8 @@ let poly_get_constant_opt (Sum p) =
   else None
 
 let constant_satisfies c s =
-  let open Q in
-  match s with
-  | Null -> equal c Q.zero
-  | NotNull -> not (equal c Q.zero)
-  | Positive -> geq c Q.zero
-  | StrictPositive -> gt c Q.zero
-  | Negative -> leq c Q.zero
-  | StrictNegative -> lt c Q.zero
+  let eq_zero = Q.equal c Q.zero in
+  match s with Null -> eq_zero | NotNull -> not eq_zero
 
 let ctnt_is_trivial p s =
   match poly_get_constant_opt p with

--- a/asllib/StaticModel.mli
+++ b/asllib/StaticModel.mli
@@ -1,0 +1,5 @@
+val equal_in_env : StaticEnv.env -> AST.expr -> AST.expr -> bool
+val try_normalize : StaticEnv.env -> AST.expr -> AST.expr
+
+(* used by tests/static.ml *)
+val normalize : StaticEnv.env -> AST.expr -> AST.expr

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -49,22 +49,9 @@ let rec list_mapi2 f i l1 l2 =
 (* Begin ReduceConstants *)
 let reduce_constants env e =
   let open StaticInterpreter in
-  let open StaticModel in
-  let eval_expr env e =
-    try static_eval env e with NotYetImplemented -> unsupported_expr e
-  in
-  try eval_expr env e
+  try static_eval env e
   with StaticEvaluationUnknown ->
-    (let () =
-       if false then
-         Format.eprintf
-           "@[<hov>Static evaluation failed. Trying to reduce.@ For %a@ at \
-            %a@]@."
-           PP.pp_expr e PP.pp_pos e
-     in
-     try StaticModel.try_normalize env e |> eval_expr env
-     with StaticEvaluationUnknown -> unsupported_expr e)
-    |: TypingRule.ReduceConstants
+    unsupported_expr e |: TypingRule.ReduceConstants
 (* End *)
 
 (* Begin ReduceToZOpt *)

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -16542,7 +16542,6 @@ and then we define the following rules:
   \item TypingRule.ReduceConstraint (see \secref{TypingRule.ReduceConstraint})
   \item TypingRule.ReduceConstraints (see \secref{TypingRule.ReduceConstraints})
   \item TypingRule.ToIR (see \secref{TypingRule.ToIR})
-  \item TypingRule.ToIRCase (see \secref{TypingRule.ToIRCase})
   \item TypingRule.ExprEqualNorm (see \secref{TypingRule.ExprEqualNorm})
   \item TypingRule.ExprEqual (see \secref{TypingRule.ExprEqual})
   \item TypingRule.ExprEqualCase (see \secref{TypingRule.ExprEqualCase})
@@ -16563,8 +16562,8 @@ Our symbolic reduction and equivalence testing rules use \emph{symbolic expressi
 \hypertarget{def-sum}{}
 \[
   \begin{array}{rcl}
-    \polynomial &\triangleq& \Sum(\unitarymonomial \partialto \Q)                  \hypertarget{def-monomial}{}\hypertarget{def-prod}{}\\
-    \unitarymonomial   &\triangleq& \Prod(\Identifiers \partialto \Npos)\\
+    \polynomial &\triangleq& \unitarymonomial \partialto \Q \setminus \{0\}\\
+    \unitarymonomial   &\triangleq& \Identifiers \partialto \Npos\\
   \end{array}
 \]
 
@@ -16577,19 +16576,19 @@ We also define operations over symbolic expressions.
 A \emph{Unitary Monomial} is a partial function from identifiers to positive integers\footnote{A unitary monomial has a unit factor,
 for example $x^3$, whereas a non-unitary monomial has a non-unit factor, for example, $2 x^3$.}.
 
-A non-empty unitary monomial, $\Prod(\vm)\in\unitarymonomial$ where $\vm \neq \emptyfunc$, can be interpreted as follows:
+A non-empty unitary monomial, $\vm\in\unitarymonomial$ where $\vm \neq \emptyfunc$, can be interpreted as follows:
 \[
-  \alpha(\Prod(\vm)) \triangleq \prod_{\vx \in \dom(\vm)} \vx^{\vm(\vx)} \enspace.
+  \alpha(\vm) \triangleq \prod_{\vx \in \dom(\vm)} \vx^{\vm(\vx)} \enspace.
 \]
 
 An empty unitary monomial is interpreted as the constant $1$:
 \[
-  \alpha(\Prod(\emptyfunc)) \triangleq 1 \enspace.
+  \alpha(\emptyfunc) \triangleq 1 \enspace.
 \]
 \end{definition}
 For example,
 \[
-  \alpha(\ \Prod(\{\vx\mapsto 3, \vy\mapsto 1, \vz\mapsto2\})\ ) = x^3 \cdot y \cdot z^2 \enspace.
+  \alpha(\ \{\vx\mapsto 3, \vy\mapsto 1, \vz\mapsto2\}\ ) = x^3 \cdot y \cdot z^2 \enspace.
 \]
 
 \hypertarget{def-mulmonomials}{}
@@ -16613,33 +16612,33 @@ multiplies two unitary monomials and returns a unitary monomial
     }
   }
   {
-    \mulmonomials(\overname{\Prod(\vfone)}{\vmone}, \overname{\Prod(\vftwo)}{\vmtwo}) \typearrow \overname{\Prod(\vf)}{\vm}
+    \mulmonomials(\overname{\vfone}{\vmone}, \overname{\vftwo}{\vmtwo}) \typearrow \overname{\vf}{\vm}
   }
 \end{mathpar}
 For example,
 \[
   \begin{array}{ll}
-  \mulmonomials( & \Prod(\{\vx\mapsto 3, \vy\mapsto 1, \vz\mapsto2\}), \Prod(\{\vx\mapsto 1, \vw\mapsto 2\})\ ) =\\
-                 & \Prod(\{\vx\mapsto 4, \vy\mapsto 1, \vz\mapsto2, \vw\mapsto2\})
+  \mulmonomials( & \{\vx\mapsto 3, \vy\mapsto 1, \vz\mapsto2\}, \{\vx\mapsto 1, \vw\mapsto 2\}\ ) =\\
+                 & \{\vx\mapsto 4, \vy\mapsto 1, \vz\mapsto2, \vw\mapsto2\}
   \end{array}
 \]
 
 \hypertarget{def-polynomial}{}
 \begin{definition}[Polynomial]
-  \emph{Polynomials} are partial functions from monomials to rationals.
+  \emph{Polynomials} are partial functions from monomials to rationals other than zero.
   Intuitively, each unitary monomial is mapped to its factor in the polynomial.
-  A polynomial $\Sum(\vp)$ can be interpreted as follows:
+  A polynomial $\vp$ can be interpreted as follows:
   %
 \[
-  \alpha(\Sum(\vp)) \triangleq \sum_{\vm \in \dom(\vp)} \vp(\vm)\cdot\alpha(\vm)
+  \alpha(\vp) \triangleq \sum_{\vm \in \dom(\vp)} \vp(\vm)\cdot\alpha(\vm)
 \]
 \end{definition}
 For example,
 \[
-  \Sum\left(\left\{
+  \left(\left\{
     \begin{array}{lcl}
-      \Prod(\{\vx\mapsto 3, \vy\mapsto 1, \vz\mapsto2\}) &\mapsto& -1,\\
-      \Prod(\{\vx\mapsto 2, \vy\mapsto 1\}) &\mapsto& \frac{3}{4}
+      \{\vx\mapsto 3, \vy\mapsto 1, \vz\mapsto2\} &\mapsto& -1,\\
+      \{\vx\mapsto 2, \vy\mapsto 1\} &\mapsto& \frac{3}{4}
     \end{array} \right\}\right) =
     -1\cdot x^3 \cdot y \cdot z^2 + \frac{3}{4} \cdot \vx^2\cdot \vy \enspace.
 \]
@@ -16658,12 +16657,13 @@ adds two polynomials:
     \begin{array}{ll}
       \vfone(\vm) & \text{if } \vm \in \dom(\vfone) \setminus \dom(\vftwo)\\
       \vftwo(\vm) & \text{if } \vm \in \dom(\vftwo) \setminus \dom(\vfone)\\
-      \vfone(\vm)+\vftwo(\vm) & \text{else } \vm \in \dom(\vfone) \cap \dom(\vftwo)\\
+      \bot        & \text{if } \vm \in \dom(\vfone) \cap \dom(\vftwo) \text{ and } \vfone(\vm)+\vftwo(\vm) = 0\\
+      \vfone(\vm)+\vftwo(\vm) & \text{else } \vm \in \dom(\vfone) \cap \dom(\vftwo) \text{ and } \vfone(\vm)+\vftwo(\vm) \neq 0\\
     \end{array}
     \right.
   }
 }{
-  \addpolynomials(\overname{\Sum(\vfone)}{\vpone}, \overname{\Sum(\vftwo)}{\vptwo}) \typearrow \overname{\Sum(\vf)}{\vp}
+  \addpolynomials(\overname{\vfone}{\vpone}, \overname{\vftwo}{\vptwo}) \typearrow \overname{\vf}{\vp}
 }
 \end{mathpar}
 
@@ -16673,7 +16673,7 @@ The overloaded function
 \]
 adds a list of polynomials:
 \begin{mathpar}
-\inferrule[empty]{}{ \addpolynomials(\emptylist) \typearrow \Prod(\emptyfunc) }
+\inferrule[empty]{}{ \addpolynomials(\emptylist) \typearrow \emptyfunc }
 \and
 \inferrule[one]{}{ \addpolynomials([ \vp ]) \typearrow \vp }
 \and
@@ -16695,7 +16695,7 @@ multiplies two polynomials.
   {
     \vps \eqdef \left\{
       \begin{array}{l}
-        \Sum(\{\mulmonomials(\vmone, \vmtwo) \mapsto \vfone(\vmone)\times\vftwo(\vmtwo)\})  \;|\; \\
+        \{\mulmonomials(\vmone, \vmtwo) \mapsto \vfone(\vmone)\times\vftwo(\vmtwo)\}  \;|\; \\
        \vmone\in\dom(\vfone)\ \land\ \vmtwo\in\dom(\vgtwo)
     \end{array}
     \right\}
@@ -16703,7 +16703,7 @@ multiplies two polynomials.
   \orderedps \eqdef [i=1..k: \vp_i ] \text{ such that }\{\vp_i \;|\; i=1..k\} = \vps\\
   \addpolynomials(i=1..k: \orderedps) \typearrow \vp\\
 }{
-  \mulpolynomials(\overname{\Sum(\vfone)}{\vpone}, \overname{\Sum(\vftwo)}{\vptwo}) \typearrow \vp
+  \mulpolynomials(\overname{\vfone}{\vpone}, \overname{\vftwo}{\vptwo}) \typearrow \vp
 }
 \end{mathpar}
 
@@ -16912,68 +16912,7 @@ by a symbolic expression (because, for example, it contains operations that are 
 the special value $\CannotBeTransformed$ is returned.
 
 \subsection{Prose}
-Intuitively, $\toir$ first conducts a case analysis to determine whether the ASL expression corresponds to a polynomial.
-If that fails, it proceeds to check whether the expression is a compile time constant.
-
-One of the following applies:
-\begin{itemize}
-  \item All of the following apply (\textsc{case\_success}):
-  \begin{itemize}
-    \item applying $\toircase$ to $\ve$ in $\tenv$ yields a symbolic expression $\vp$.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{static\_eval\_literal}):
-  \begin{itemize}
-    \item applying $\toircase$ to $\ve$ in $\tenv$ yields $\CannotBeTransformed$;
-    \item applying $\staticeval$ to $\ve$ yields an integer literal for $\vv$\ProseTerminateAs{\CannotBeTransformed};
-    \item define $\vp$ as the polynomial representing the value $\vv$.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{static\_eval\_non\_literal}):
-  \begin{itemize}
-    \item applying $\toircase$ to $\ve$ in $\tenv$ yields $\CannotBeTransformed$;
-    \item applying $\staticeval$ to $\ve$ in $\tenv$ yields a literal $\vl$\ProseTerminateAs{\CannotBeTransformed};
-    \item $\vl$ is not an integer value;
-    \item define $\vp$ as $\CannotBeTransformed$.
-  \end{itemize}
-\end{itemize}
-\subsection{Formally}
-\begin{mathpar}
-\inferrule[case\_success]{
-  \toircase(\tenv, \ve) \typearrow \vp\\
-  \vp \neq \CannotBeTransformed
-}{
-  \toir(\tenv, \ve) \typearrow \vp
-}
-\and
-\inferrule[static\_eval\_literal]{
-  \toircase(\tenv, \ve) \typearrow \CannotBeTransformed\\
-  \staticeval(\tenv, \ve) \typearrow \lint(\vv) \terminateas \CannotBeTransformed\\\\
-  \vp \eqdef \Sum( \{ \Prod(\emptyfunc)\mapsto \vv \} )
-}{
-  \toir(\tenv, \ve) \typearrow \vp
-}
-\and
-\inferrule[static\_eval\_non\_literal]{
-  \toircase(\tenv, \ve) \typearrow \CannotBeTransformed\\
-  \staticeval(\tenv, \ve) \typearrow \vl \terminateas \CannotBeTransformed\\\\
-  \astlabel(\vl) \neq \lint
-}{
-  \toir(\tenv, \ve) \typearrow \CannotBeTransformed
-}
-\end{mathpar}
-\section{TypingRule.ToIRCase \label{sec:TypingRule.ToIRCase}}
-\hypertarget{def-toircase}{}
-The function
-\[
-  \toircase(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto \overname{\polynomial}{\vp} \cup \{\CannotBeTransformed\}
-\]
-transforms a subset of ASL expressions into symbolic expressions. If an expression cannot be represented
-by a symbolic expression, the special value $\CannotBeTransformed$ is returned.
-
-\subsection{Prose}
-Intuitively, $\toir$ first conducts a case analysis to determine whether the ASL expression corresponds to a polynomial.
-If that fails, it proceeds to check whether the expression is a compile time constant.
+Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expression corresponds to a polynomial.
 
 \newcommand\ProseOrTypeErrorOrBot[0]{\ProseTerminateAs{\CannotBeTransformed,\TypeErrorConfig}}
 
@@ -16997,7 +16936,7 @@ One of the following applies:
     \item looking up the constant associated with $\vs$ in $\tenv$ yields the literal expression for $\vv$, that is, $\ELiteral(\vv)$;
     \item checking whether $\vv$ is an integer literal yields $\True$\ProseOrTypeError;
     \item $\vv$ is an integer literal for $\vi$;
-    \item $\vp$ is the symbolic expression for $\vi$, that is, $\Sum( \{ \Prod(\emptyfunc)\mapsto \vi \} )$.
+    \item $\vp$ is the symbolic expression for $\vi$, that is, $\{ \emptyfunc\mapsto \vi \}$.
   \end{itemize}
 
   \item All of the following apply (\textsc{int\_exact\_constant}):
@@ -17019,7 +16958,7 @@ One of the following applies:
     \item the \underlyingtype\ of $\vt$ is $\ttyone$\ProseOrTypeError;
     \item checking whether $\ttyone$ is an integer type yields $\True$\ProseOrTypeError;
     \item $\ttyone$ is not a well-constrained integer with a single exact constraint;
-    \item $\vp$ is the symbolic expression for the variable $\vs$, that is, $\Sum( \{ \Prod(\{\vs\mapsto 1\})\mapsto 1 \} )$.
+    \item $\vp$ is the symbolic expression for the variable $\vs$, that is, $\{ \{\vs\mapsto 1\}\mapsto 1 \}$.
   \end{itemize}
 
   \item All of the following apply (\textsc{ebinop\_plus}):
@@ -17111,7 +17050,7 @@ One of the following applies:
     \item $\veone$ is the literal expression for literal $\vlone$;
     \item $\vetwo$ is the literal expression for literal $\vltwo$;
     \item statically applying $\op$ to $\vlone$ and $\vltwo$ yields the integer literal for $k$;
-    \item $\vp$ is the symbolic expression for the integer $k$, that is, $\Sum( \{ \Prod(\emptyfunc)\mapsto k \} )$.
+    \item $\vp$ is the symbolic expression for the integer $k$, that is, $\{ \emptyfunc\mapsto k \}$.
   \end{itemize}
 
   \item All of the following apply (\textsc{eunop\_neg}):
@@ -17138,13 +17077,13 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[literal\_int]{}
 {
-  \toircase(\tenv, \overname{\ELiteral(\lint(\vi))}{\ve}) \typearrow \overname{\Sum( \{ \Prod(\emptyfunc)\mapsto \vi \} )}{\vp}
+  \toir(\tenv, \overname{\ELiteral(\lint(\vi))}{\ve}) \typearrow \overname{\{ \emptyfunc\mapsto \vi \}}{\vp}
 }
 \and
 \inferrule[literal\_other]{
   \astlabel(\vv) \neq \lint
 }{
-  \toircase(\tenv, \overname{\ELiteral(\vv)}{\ve}) \typearrow \CannotBeTransformed
+  \toir(\tenv, \overname{\ELiteral(\vv)}{\ve}) \typearrow \CannotBeTransformed
 }
 \and
 \inferrule[int\_constant]{
@@ -17152,7 +17091,7 @@ One of the following applies:
   \checktrans{\astlabel(\vv) = \lint}{ExpectedIntegerLiteral} \typearrow \True \OrTypeError\\\\
   \vv \eqname \lint(\vi)
 }{
-  \toircase(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \overname{\Sum( \{ \Prod(\emptyfunc)\mapsto \vi \} )}{\vp}
+  \toir(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \overname{\{ \emptyfunc\mapsto \vi \}}{\vp}
 }
 \and
 \inferrule[int\_exact\_constraint]{
@@ -17163,7 +17102,7 @@ One of the following applies:
   \ttyone = \TInt(\wellconstrained([\ConstraintExact(\ve)]))\\
   \toir(\ve) \typearrow \vp
 }{
-  \toircase(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \vp
+  \toir(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \vp
 }
 \and
 \inferrule[int\_var]{
@@ -17173,7 +17112,7 @@ One of the following applies:
   \checktrans{\astlabel(\ttyone) = \TInt}{ExpectedIntegerType} \typearrow \True\\
   \ttyone \neq \TInt(\wellconstrained([\ConstraintExact(\Ignore)]))
 }{
-  \toircase(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \overname{\Sum( \{ \Prod(\{\vs\mapsto 1\})\mapsto 1 \} )}{\vp}
+  \toir(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \overname{\{ \{\vs\mapsto 1\}\mapsto 1 \}}{\vp}
 }
 \end{mathpar}
 
@@ -17183,7 +17122,7 @@ One of the following applies:
   \toir(\tenv, \vetwo) \typearrow \irtwo \OrTypeError, \CannotBeTransformed\\\\
   \vp \eqdef \addpolynomials(\irone, \irtwo)
 }{
-  \toircase(\tenv, \overname{\EBinop(\PLUS, \veone, \vetwo)}{\ve}) \typearrow \vp
+  \toir(\tenv, \overname{\EBinop(\PLUS, \veone, \vetwo)}{\ve}) \typearrow \vp
 }
 \end{mathpar}
 
@@ -17192,7 +17131,7 @@ One of the following applies:
   \vep \eqdef \EBinop(\PLUS, \veone, \EUnop(\MINUS, \vetwo))\\
   \toir(\tenv, \vep) \typearrow \vp \OrTypeError, \CannotBeTransformed\\\\
 }{
-  \toircase(\tenv, \overname{\EBinop(\MINUS, \veone, \vetwo)}{\ve}) \typearrow \vp
+  \toir(\tenv, \overname{\EBinop(\MINUS, \veone, \vetwo)}{\ve}) \typearrow \vp
 }
 \end{mathpar}
 
@@ -17202,7 +17141,7 @@ One of the following applies:
   \toir(\tenv, \vetwo) \typearrow \irtwo \OrTypeError, \CannotBeTransformed\\\\
   \vp \eqdef \mulpolynomials(\irone, \irtwo)
 }{
-  \toircase(\tenv, \overname{\EBinop(\MUL, \veone, \vetwo)}{\ve}) \typearrow \vp
+  \toir(\tenv, \overname{\EBinop(\MUL, \veone, \vetwo)}{\ve}) \typearrow \vp
 }
 \end{mathpar}
 
@@ -17210,16 +17149,16 @@ One of the following applies:
 \inferrule[ebinop\_div\_non\_int\_denominator]{
   \vetwo \neq \ELiteral(\lint(\Ignore))
 }{
-  \toircase(\tenv, \overname{\EBinop(\DIV, \veone, \vetwo)}{\ve}) \typearrow \CannotBeTransformed
+  \toir(\tenv, \overname{\EBinop(\DIV, \veone, \vetwo)}{\ve}) \typearrow \CannotBeTransformed
 }
 \and
 \inferrule[ebinop\_div\_int\_denominator]{
   \toir(\tenv, \veone) \typearrow \irone \OrTypeError, \CannotBeTransformed\\\\
   \vftwo \eqdef \frac{1}{\vitwo}\\
-  \irone \eqname \Sum [i=1..k: \vm_\vi \mapsto \vc_\vi]\\
-  \vp \eqdef \Sum [i=1..k: \vm_\vi \mapsto \vc_\vi \times \vftwo]\\
+  \irone \eqname [i=1..k: \vm_\vi \mapsto \vc_\vi]\\
+  \vp \eqdef [i=1..k: \vm_\vi \mapsto \vc_\vi \times \vftwo]\\
 }{
-  \toircase(\tenv, \overname{\EBinop(\DIV, \veone, \overname{\ELiteral(\lint(\vitwo))}{\vetwo})}{\ve}) \typearrow \vp
+  \toir(\tenv, \overname{\EBinop(\DIV, \veone, \overname{\ELiteral(\lint(\vitwo))}{\vetwo})}{\ve}) \typearrow \vp
 }
 \end{mathpar}
 
@@ -17227,7 +17166,7 @@ One of the following applies:
 \inferrule[ebinop\_shl\_non\_lint\_exponent]{
     \vetwo \neq \ELiteral(\lint(\Ignore))
 }{
-  \toircase(\tenv, \overname{\EBinop(\SHL, \Ignore, \vetwo)}{\ve}) \typearrow \CannotBeTransformed
+  \toir(\tenv, \overname{\EBinop(\SHL, \Ignore, \vetwo)}{\ve}) \typearrow \CannotBeTransformed
 }
 \end{mathpar}
 
@@ -17235,17 +17174,17 @@ One of the following applies:
 \inferrule[ebinop\_shl\_neg\_shift]{
   \vitwo < 0
 }{
-  \toircase(\tenv, \overname{\EBinop(\SHL, \veone, \ELiteral(\lint(\vitwo)))}{\ve}) \typearrow \CannotBeTransformed
+  \toir(\tenv, \overname{\EBinop(\SHL, \veone, \ELiteral(\lint(\vitwo)))}{\ve}) \typearrow \CannotBeTransformed
 }
 \and
   \inferrule[ebinop\_shl\_okay]{
     \toir(\tenv, \veone) \typearrow \irone \OrTypeError, \CannotBeTransformed\\\\
     \vitwo \geq 0\\
     \vftwo \eqdef 2^{\vitwo}\\
-    \irone \eqname \Sum [i=1..k: \vm_\vi \mapsto \vc_\vi]\\
-    \vp \eqdef \Sum [i=1..k: \vm_\vi \mapsto \vc_\vi \times \vftwo]\\
+    \irone \eqname [i=1..k: \vm_\vi \mapsto \vc_\vi]\\
+    \vp \eqdef [i=1..k: \vm_\vi \mapsto \vc_\vi \times \vftwo]\\
 }{
-  \toircase(\tenv, \overname{\EBinop(\SHL, \veone, \ELiteral(\lint(\vitwo)))}{\ve}) \typearrow \vp
+  \toir(\tenv, \overname{\EBinop(\SHL, \veone, \ELiteral(\lint(\vitwo)))}{\ve}) \typearrow \vp
 }
 \end{mathpar}
 
@@ -17254,7 +17193,7 @@ One of the following applies:
   \op \not\in \{\PLUS, \MINUS, \MUL, \DIV, \SHL\}\\
   (\veone \neq \ELiteral(\Ignore) \lor \vetwo \neq \ELiteral(\Ignore))
 }{
-  \toircase(\tenv, \overname{\EBinop(\op, \veone, \vetwo)}{\ve}) \typearrow \CannotBeTransformed
+  \toir(\tenv, \overname{\EBinop(\op, \veone, \vetwo)}{\ve}) \typearrow \CannotBeTransformed
 }
 \and
 \inferrule[ebinop\_other\_literals\_non\_int\_result]{
@@ -17262,15 +17201,15 @@ One of the following applies:
   \binopliterals(\op, \vlone, \vltwo) \typearrow \vl\\
   \vl \neq \lint(\Ignore)
 }{
-  \toircase(\tenv, \overname{\EBinop(\op, \ELiteral(\vlone), \ELiteral(\vltwo))}{\ve}) \typearrow \CannotBeTransformed
+  \toir(\tenv, \overname{\EBinop(\op, \ELiteral(\vlone), \ELiteral(\vltwo))}{\ve}) \typearrow \CannotBeTransformed
 }
 \and
 \inferrule[ebinop\_other\_literals\_int\_result]{
   \op \not\in \{\PLUS, \MINUS, \MUL, \SHL\}\\
   \binopliterals(\op, \vlone, \vltwo) \typearrow \lint(k)\\
-  \vp \eqdef \Sum( \{ \Prod(\emptyfunc)\mapsto k \} )
+  \vp \eqdef \{ \emptyfunc\mapsto k \}
 }{
-  \toircase(\tenv, \overname{\EBinop(\op, \ELiteral(\vlone), \ELiteral(\vltwo))}{\ve}) \typearrow \vp
+  \toir(\tenv, \overname{\EBinop(\op, \ELiteral(\vlone), \ELiteral(\vltwo))}{\ve}) \typearrow \vp
 }
 \end{mathpar}
 
@@ -17278,13 +17217,13 @@ One of the following applies:
 \inferrule[eunop\_neg]{
   \toir(\tenv, \EBinop(\MUL, \ELiteral(\lint(-1)),\veone )) \typearrow \vp \OrTypeError, \CannotBeTransformed\\\\
 }{
-  \toircase(\tenv, \overname{\EUnop(\NEG, \veone)}{\ve}) \typearrow \vp
+  \toir(\tenv, \overname{\EUnop(\NEG, \veone)}{\ve}) \typearrow \vp
 }
 \and
 \inferrule[eunop\_other]{
   \op \neq \NEG
 }{
-  \toircase(\tenv, \overname{\EUnop(\op, \Ignore)}{\ve}) \typearrow \CannotBeTransformed
+  \toir(\tenv, \overname{\EUnop(\op, \Ignore)}{\ve}) \typearrow \CannotBeTransformed
 }
 \end{mathpar}
 
@@ -17292,7 +17231,7 @@ One of the following applies:
 \inferrule[other]{
   \astlabel(\ve) \not\in \{\ELiteral, \EVar, \EBinop, \EUnop\}
 }{
-  \toircase(\tenv, \ve) \typearrow \CannotBeTransformed
+  \toir(\tenv, \ve) \typearrow \CannotBeTransformed
 }
 \end{mathpar}
 
@@ -18446,22 +18385,7 @@ The function
 simplifies the polynomial $\vp$, yielding the simplified polynomial $\newp$.
 
 \subsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\vp$ is $\Sum(f)$ where $f$ binds monomials to their integer coefficients;
-  \item $g$ is the restriction of $f$ to the bindings where the coefficients are non-zero;
-  \item $\newp$ is $\Sum(g)$.
-\end{itemize}
-
 \subsection{Formally}
-\begin{mathpar}
-\inferrule{
-  { g \eqdef \restrictfunc{f}{\{\vm \in \dom(f)\;|\; f(\vm) \neq 0\}} }
-}{
-  \reduceir(\overname{\Sum(f)}{\vp}) \typearrow \overname{\Sum(g)}{\newp}
-}
-\end{mathpar}
-
 \section{TypingRule.PolynomialToExpr \label{sec:TypingRule.PolynomialToExpr}}
 \hypertarget{def-polynomialtoexpr}{}
 The function
@@ -18475,13 +18399,13 @@ One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{empty}):
   \begin{itemize}
-    \item $\vp$ is the polynomial with an empty list of monomials, that is, $\Sum(\emptyfunc)$;
+    \item $\vp$ is the polynomial with an empty list of monomials, that is, $\emptyfunc$;
     \item define $\ve$ as the literal expression for $0$.
   \end{itemize}
 
   \item All of the following apply (\textsc{non\_empty}):
   \begin{itemize}
-    \item $\vp$ is the polynomial $\Sum(f)$;
+    \item $\vp$ is the polynomial $f$;
     \item sorting (see $\sort$ for details) the graph of $f$ (see $\funcgraph$ for details)
           yields $\monoms$ --- a list consisting of pairs of unitary monomials and rationals.
           In principle, any total order of the graph of $f$ is acceptable for sorting.
@@ -18499,7 +18423,7 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[empty]{}
 {
-  \polynomialtoexpr(\overname{\Sum(\emptyfunc)}{\vp}) \typearrow \overname{\ELiteral(\lint(0))}{\ve}
+  \polynomialtoexpr(\overname{\emptyfunc}{\vp}) \typearrow \overname{\ELiteral(\lint(0))}{\ve}
 }
 \and
 \inferrule[non\_empty]{
@@ -18513,7 +18437,7 @@ One of the following applies:
   \end{cases}
   }
 }{
-  \polynomialtoexpr(\overname{\Sum(f)}{\vp}) \typearrow \ve
+  \polynomialtoexpr(\overname{f}{\vp}) \typearrow \ve
 }
 \end{mathpar}
 
@@ -18536,14 +18460,14 @@ One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{equal\_monomials}):
   \begin{itemize}
-    \item $\vmone$ is $\Prod(f)$ and $\vmtwo$ is $\Prod(g)$;
+    \item $\vmone$ is $f$ and $\vmtwo$ is $g$;
     \item $f$ is equal to $g$;
     \item $\vs$ is the sign of $\vqtwo - \vqone$.
   \end{itemize}
 
   \item All of the following apply (\textsc{different\_monomials}):
   \begin{itemize}
-    \item $\vmone$ is $\Prod(f)$ and $\vmtwo$ is $\Prod(g)$;
+    \item $\vmone$ is $f$ and $\vmtwo$ is $g$;
     \item $f$ is different from to $g$;
     \item $\ids$ is the list obtained by taking the set of identifiers in the domain of $f$ and in the domain of $g$,
           and sorting them according to the lexical order for identifiers (ASCII string order);
@@ -18565,7 +18489,7 @@ via the lexicographic ordering.
   f = g\\
   \vs \eqdef \sign(\vqtwo - \vqone)
 }{
-  \comparemonomialbindings((\overname{\Prod(f)}{\vmone}, \vqone), (\overname{\Prod(g)}{\vmtwo}, \vqtwo)) \typearrow \vs
+  \comparemonomialbindings((\overname{f}{\vmone}, \vqone), (\overname{g}{\vmtwo}, \vqtwo)) \typearrow \vs
 }
 \and
 \inferrule[different\_monomials]{
@@ -18582,7 +18506,7 @@ via the lexicographic ordering.
     \end{cases}
 }
 }{
-  \comparemonomialbindings((\overname{\Prod(f)}{\vmone}, \vqone), (\overname{\Prod(g)}{\vmtwo}, \vqtwo)) \typearrow \vs
+  \comparemonomialbindings((\overname{f}{\vmone}, \vqone), (\overname{g}{\vmtwo}, \vqtwo)) \typearrow \vs
 }
 \end{mathpar}
 

--- a/asllib/doc/ASLTypingReference.tex
+++ b/asllib/doc/ASLTypingReference.tex
@@ -15917,22 +15917,17 @@ The function
 \symbolicallysimplifies\ the \underline{integer-typed} expression $\ve$ and returns the resulting integer or $\Top$ if
 the result of the simplification is not an integer.
 
-We assume that $\ve$ has been annotated as it is part of the constraint for an integer type,
-and therefore applying $\normalize$ to it does not yield a type error.
-
 \subsection{Prose}
 One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{integer}):
   \begin{itemize}
-    \item applying $\normalize$ to $\ve$ in $\tenv$ yields the expression $\veone$;
     \item applying $\staticeval$ to $\veone$ in $\tenv$ yields the integer literal for $n$.
   \end{itemize}
 
   \item All of the following apply (\textsc{top}):
   \begin{itemize}
-    \item applying $\normalize$ to $\ve$ in $\tenv$ yields the expression $\veone$;
-    \item applying $\staticeval$ to $\veone$ in $\tenv$ yields $\top$.
+    \item applying $\staticeval$ to $\veone$ in $\tenv$ yields $\top$;
     \item the result is $\Top$.
   \end{itemize}
 \end{itemize}
@@ -15940,15 +15935,13 @@ One of the following applies:
 \subsection{Formally}
 \begin{mathpar}
 \inferrule[integer]{
-  \normalize(\tenv, \ve) \typearrow \veone\\
-  \staticeval(\tenv, \veone) \typearrow \lint(n)
+  \staticeval(\tenv, \ve) \typearrow \lint(n)
 }{
   \normalizetoint(\tenv, \ve) \typearrow n
 }
 \and
 \inferrule[top]{
-  \normalize(\tenv, \ve) \typearrow \veone\\
-  \staticeval(\tenv, \veone) \typearrow \top
+  \staticeval(\tenv, \ve) \typearrow \top
 }{
   \normalizetoint(\tenv, \ve) \typearrow \Top
 }
@@ -16780,18 +16773,9 @@ One of the following applies:
     \item applying $\staticeval$ to $\ve$ in $\tenv$ yields the literal $\vl$\ProseOrTypeError.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eval\_normalized}):
-  \begin{itemize}
-    \item applying $\staticeval$ to $\ve$ in $\tenv$ yields $\CannotBeTransformed$;
-    \item applying $\normalize$ to $\ve$ in $\tenv$ yields $\veone$\ProseOrTypeError;
-    \item applying $\staticeval$ to $\veone$ in $\tenv$ yields the literal $\vl$\ProseOrTypeError.
-  \end{itemize}
-
   \item All of the following apply (\textsc{eval\_failure}):
   \begin{itemize}
     \item applying $\staticeval$ to $\ve$ in $\tenv$ yields $\CannotBeTransformed$;
-    \item applying $\normalize$ to $\ve$ in $\tenv$ yields $\veone$\ProseOrTypeError;
-    \item applying $\staticeval$ to $\veone$ in $\tenv$ yields $\CannotBeTransformed$'
     \item the result is a type error indicating that $\ve$ cannot be reduced to a constant in $\tenv$.
   \end{itemize}
 \end{itemize}
@@ -16807,18 +16791,8 @@ One of the following applies:
   \reduceconstants(\tenv, \ve) \typearrow \vl
 }
 \and
-\inferrule[eval\_noramalized]{
-  \staticeval(\tenv, \ve) \typearrow \CannotBeTransformed\\
-  \normalize(\tenv, \ve) \typearrow \veone \OrTypeError\\\\
-  \staticeval(\tenv, \veone) \typearrow \vl \OrTypeError
-}{
-  \reduceconstants(\tenv, \ve) \typearrow \vl
-}
-\and
 \inferrule[eval\_failure]{
-  \staticeval(\tenv, \ve) \typearrow \CannotBeTransformed\\
-  \normalize(\tenv, \ve) \typearrow \veone\\
-  \staticeval(\tenv, \veone) \typearrow \CannotBeTransformed \OrTypeError
+  \staticeval(\tenv, \ve) \typearrow \CannotBeTransformed
 }{
   \reduceconstants(\tenv, \ve) \typearrow \TypeErrorVal{CannotBeReducedToAConstant}
 }

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1147,9 +1147,6 @@
 \newcommand\symsubsumes[0]{\hyperlink{def-symsubsumes}{\textfunc{sym\_subsumes}}}
 
 \newcommand\toir[0]{\hyperlink{def-toir}{\textfunc{to\_ir}}}
-\newcommand\toircase[0]{\hyperlink{def-toircase}{\textfunc{to\_ir\_case}}}
-\newcommand\Prod[0]{\hyperlink{def-prod}{\textsf{Prod}}}
-\newcommand\Sum[0]{\hyperlink{def-sum}{\textsf{Sum}}}
 \newcommand\unitarymonomial[0]{\hyperlink{def-unitarymonomial}{\textsf{unitary\_monomial}}}
 \newcommand\monomial[0]{\hyperlink{def-monomial}{\textsf{monomial}}}
 \newcommand\polynomial[0]{\hyperlink{def-polynomial}{\textsf{polynomial}}}

--- a/asllib/tests/static.ml
+++ b/asllib/tests/static.ml
@@ -88,46 +88,10 @@ let fpzero_example () =
 
   assert (StaticModel.equal_in_env env !%"N" res)
 
-let[@warning "-44"] normalize_affectations () =
-  let open StaticModel in
-  let affectations = [ ("x", Z.of_int 3, None); ("y", Z.of_int 7, None) ] in
-  let m_1 = Prod AMap.empty in
-  let m_1', f_1' = subst_mono affectations m_1 (Q.of_int 1) in
-  assert (mono_compare m_1' m_1 = 0 && f_1' = Q.of_int 1);
-
-  let m_x = Prod (AMap.singleton "x" 1) in
-  let m_x', f_x' = subst_mono affectations m_x (Q.of_int 1) in
-  assert (mono_compare m_x' m_1 = 0 && f_x' = Q.of_int 3);
-
-  let m_xy = Prod (AMap.singleton "x" 1 |> AMap.add "y" 1) in
-  let m_xy', f_xy' = subst_mono affectations m_xy (Q.of_int 1) in
-  assert (mono_compare m_xy' m_1 = 0 && f_xy' = Q.of_int 21);
-
-  let p_1 = Sum (MMap.singleton m_1 (Q.of_int 1)) in
-  let p_x = Sum (MMap.singleton m_x (Q.of_int 1)) in
-  let p_x_1 = add_polys p_1 p_x in
-  let p_xy_1 =
-    Sum (MMap.singleton m_xy (Q.of_int 1) |> MMap.add m_1 (Q.of_int 1))
-  in
-
-  let p_1' = subst_poly affectations p_1 in
-  let p_x' = subst_poly affectations p_x in
-  let p_x_1' = subst_poly affectations p_x_1 in
-  let p_xy_1' = subst_poly affectations p_xy_1 in
-
-  assert (poly_compare p_1 p_1 = 0);
-  assert (poly_compare p_1' p_1 = 0);
-  assert (poly_compare p_x' (poly_of_int 3) = 0);
-  assert (poly_compare p_x_1' (poly_of_int 4) = 0);
-  assert (poly_compare p_xy_1' (poly_of_int 22) = 0);
-
-  ()
-
 let () =
   exec_tests
     [
       ("build_consts", build_consts);
       ("static.normalize", normalize);
       ("static.fpzero_example", fpzero_example);
-      ("static.normalize_affectations", normalize_affectations);
     ]

--- a/asllib/tests/typing.t/run.t
+++ b/asllib/tests/typing.t/run.t
@@ -216,17 +216,8 @@ Large constraint sets
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
   File TPositive13.asl, line 8, characters 17 to 34:
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
-  File TPositive13.asl, line 9, characters 17 to 34:
-  Interval too large: [ -9223372036854775808 .. 9223372036854775807 ].
-  Keeping it as an interval.
-  File TPositive13.asl, line 9, characters 17 to 34:
-  Interval too large: [ -9223372036854775808 .. 9223372036854775807 ].
-  Keeping it as an interval.
   File TPositive13.asl, line 10, characters 17 to 34:
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
-  File TPositive13.asl, line 10, characters 17 to 34:
-  Interval too large: [ -9223372036854775808 .. 9223372036854775807 ].
-  Keeping it as an interval.
   $ aslref --no-exec TDegraded13.asl
   File TDegraded13.asl, line 7, characters 29 to 46:
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -215,7 +215,6 @@ module Domain = struct
     let v =
       let open StaticInterpreter in
       let open StaticModel in
-      let e = try normalize env e with NotYetImplemented -> e in
       try static_eval env e
       with StaticEvaluationUnknown -> raise_notrace StaticEvaluationTop
     in


### PR DESCRIPTION
This PR attempts to streamline static normalisation in a few ways:
- Avoid using both static evaluation and normalisation if one should suffice
- Weaken normalisation based on its usage
  - Remove "affectations"
  - Reduce the kinds of constraints it can track to just equality/inequality with zero
- Fix a couple of potential bugs
- Avoid reducing polynomials by maintaining a stronger invariant about the absence of 0-coefficients
- Limit catching of `ConjunctionBottomInterrupt` exception to within a single function, to simplify control flow
- Along the way, do various refactors - including a final significant refactor attempting to modularise the various moving parts in normalisation (monomials/polynomials/internal representation)