### PR TITLE
[litmus] Change types of registers

### DIFF
--- a/lib/CType.ml
+++ b/lib/CType.ml
@@ -216,3 +216,16 @@ let rec sizeof = function
   | Base b ->
      do_base_size b >>= apply MachSize.nbytes
   | Pointer _ -> None
+
+let larger t1 t2 =
+  match sizeof t1,sizeof t2 with
+  | Some n1,Some n2 ->
+     if n1 > n2 then t1
+     else if n2 > n1 then t2
+     else begin
+       match signed t1,signed t2 with
+       | (true,false) -> t2
+       | (false,true) -> t1
+       | _,_ -> t2
+     end
+  | (None,_)|(_,None) -> t1

--- a/lib/CType.mli
+++ b/lib/CType.mli
@@ -76,3 +76,6 @@ val base_size : t -> MachSize.sz option
 
 (* Best effort to find size of types in bytes (C sizeof) *)
 val sizeof : t -> int option
+
+(* Select larger type of two, in case of impossibility, select second type *)
+val larger : t -> t -> t

--- a/litmus/AArch64Arch_litmus.ml
+++ b/litmus/AArch64Arch_litmus.ml
@@ -26,6 +26,29 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
 
   module V = V
 
+(* t1 is declared (or inferred) type, t2 is type from instruction *)
+  let error t1 t2 =
+    let open CType in
+(*          Printf.eprintf "Error %s and %s\n" (debug t1) (debug t2) ; *)
+    match t1,t2 with
+    | (Base
+         ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"),
+       Pointer _)
+      | (Pointer _,
+         Base ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"))  ->
+       true
+    | _ -> false
+
+  let warn t1 t2 =
+    let open CType in
+    match t1,t2 with
+    | Base ("ins_t"|"int"|"int32_t"|"uint32_t"
+            |"int16_t"|"uint16_t"
+            |"int8_t"|"uint8_t"),
+      Base ("ins_t"|"int"|"int32_t"|"uint32_t") -> false
+    | (Base "int",_)|(_,Base "int") -> true
+    | _ -> false
+
   module FaultType = FaultType.AArch64
 
   let tab = Hashtbl.create 17
@@ -89,29 +112,6 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
           | Preg _ | PMreg _ -> check_init init "Upl"
           | _ -> check_init init "r"
         let comment = comment
-
-(* t1 is declared (or inferred) type, t2 is type from instruction *)
-        let error t1 t2 =
-          let open CType in
-(*          Printf.eprintf "Error %s and %s\n" (debug t1) (debug t2) ; *)
-          match t1,t2 with
-          | (Base
-               ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"),
-             Pointer _)
-          | (Pointer _,
-             Base ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"))  ->
-              true
-
-          | _ -> false
-        let warn t1 t2 =
-          let open CType in
-          match t1,t2 with
-          | Base ("ins_t"|"int"|"int32_t"|"uint32_t"
-                  |"int16_t"|"uint16_t"
-                  |"int8_t"|"uint8_t"),
-            Base ("ins_t"|"int"|"int32_t"|"uint32_t") -> false
-          | (Base "int",_)|(_,Base "int") -> true
-          | _ -> false
 
       end)
 

--- a/litmus/ARMArch_litmus.ml
+++ b/litmus/ARMArch_litmus.ml
@@ -23,6 +23,27 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
   include ARMBase
   module V = V
 
+  let error t1 t2 =
+    let open CType in
+    match t1,t2 with
+    | (Base
+         ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"),
+       Pointer _)
+    | (Pointer _,
+       Base ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"))  ->
+         true
+    | _ -> false
+
+  let warn t1 t2 =
+    let open CType in
+    match t1,t2 with
+    | Base ("ins_t"|"int"|"int32_t"|"uint32_t"
+            |"int16_t"|"uint16_t"
+            |"int8_t"|"uint8_t"),
+      Base ("ins_t"|"int"|"int32_t"|"uint32_t") -> false
+    | (Base "int",_)|(_,Base "int") -> true
+    | _ -> false
+
   module FaultType = FaultType.No
 
   let tab = Hashtbl.create 17
@@ -55,27 +76,6 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
         let reg_class _ = "=&r"
         let reg_class_stable init _ = if init then "+r" else "=&r"
         let comment = comment
-        let error t1 t2 =
-          let open CType in
-(*          Printf.eprintf "Error %s and %s\n" (debug t1) (debug t2) ; *)
-          match t1,t2 with
-          | (Base
-               ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"),
-             Pointer _)
-          | (Pointer _,
-             Base ("int"|"ins_t"|"int16_t"|"uint16_t"|"int8_t"|"uint8_t"))  ->
-              true
-
-          | _ -> false
-        let warn t1 t2 =
-          let open CType in
-          match t1,t2 with
-          | Base ("ins_t"|"int"|"int32_t"|"uint32_t"
-                  |"int16_t"|"uint16_t"
-                  |"int8_t"|"uint8_t"),
-            Base ("ins_t"|"int"|"int32_t"|"uint32_t") -> false
-          | (Base "int",_)|(_,Base "int") -> true
-          | _ -> false
       end)
   let features = []
   let nop = I_NOP

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -113,6 +113,9 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
 
   let features = []
 
+  let error _ _ = false
+  and warn _ _ = false
+
   include HardwareExtra.No
 
   module GetInstr = GetInstr.No(struct type instr = instruction end)

--- a/litmus/CLang.ml
+++ b/litmus/CLang.ml
@@ -90,8 +90,9 @@ module Make(C:Config)(E:Extra) = struct
       (List.map
          (fun (x,ty) -> sprintf "%s -> %s" x (CType.debug ty))
          env)
-  let dump_fun ?user chan _args0 env globEnv _envVolatile proc t =
+  let dump_fun ?user chan _args0 globEnv _envVolatile proc t =
     assert (Misc.is_none user) ;
+    let env = t.CTarget.ty_env in
     if dbg then
       begin
         let pp = pp_env globEnv in
@@ -126,7 +127,7 @@ module Make(C:Config)(E:Extra) = struct
     out "}\n\n"
 
 
-  let dump_call f_id args0 tr_idx chan indent _env (globEnv,_) _envVolatile proc t =
+  let dump_call f_id args0 tr_idx chan indent (globEnv,_) _envVolatile proc t =
 
     if dbg then
       begin
@@ -175,7 +176,8 @@ module Make(C:Config)(E:Extra) = struct
     LangUtils.dump_code_call chan indent f_id args
 
 
-  let dump chan indent env (globEnv,_) _envVolatile proc t =
+  let dump chan indent (globEnv,_) _envVolatile proc t =
+    let env = t.CTarget.ty_env in
     let out x = fprintf chan x in
     out "%sdo {\n" indent;
     begin

--- a/litmus/CTarget.ml
+++ b/litmus/CTarget.ml
@@ -23,8 +23,8 @@ type code = string
 type t =
   { inputs : (string * CType.t) list ;
     finals : arch_reg list ;
-    code : code ; }
-
+    code : code ;
+    ty_env : CType.t RegMap.t ; }
 
 let fmt_reg x = x
 
@@ -50,3 +50,5 @@ let out_code chan code = Printf.fprintf chan "%s\n" code
 let has_fault_handler _ = false
 
 let find_offset _ _ = assert false
+
+let get_reg_env _ _ t = t.ty_env

--- a/litmus/CTarget.mli
+++ b/litmus/CTarget.mli
@@ -17,14 +17,15 @@
 (* C target, a simplified template *)
 
 type arch_reg = string
-module RegMap : MyMap.S with type key = String.t
+module RegMap = StringMap
 type ins = unit
 type code = string
 
 type t =
   { inputs : (arch_reg * CType.t) list ;
     finals : arch_reg list ;
-    code : code ; }
+    code : code ;
+    ty_env : CType.t RegMap.t ; }
 
 
 val fmt_reg : arch_reg -> string
@@ -40,3 +41,7 @@ val get_addrs : t -> string list * string list
 val out_code : out_channel -> code -> unit
 val has_fault_handler : t -> bool
 val find_offset : Label.t -> t -> int
+val get_reg_env :
+  (CType.t -> CType.t -> bool) ->
+  (CType.t -> CType.t -> bool) ->
+  t -> CType.t RegMap.t

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -47,10 +47,8 @@ module Make
      type instruction = A.instruction and
      type P.code = P.code and module A = A and module FaultType = A.FaultType)
     (O:Indent.S)
-    (Lang:Language.S
-    with type arch_reg = T.A.reg and type t = A.Out.t
-    and module RegMap = T.A.RegMap) :
-    sig
+    (Lang:Language.S with type t = A.Out.t)
+    : sig
       val dump : Name.t -> T.t -> unit
     end =
   struct
@@ -650,9 +648,8 @@ let dump_threads _tname env test =
       test.T.globals in
   List.iter
     (fun (proc,(out,(_outregs,envVolatile))) ->
-      let myenv = U.select_proc proc env in
       Lang.dump_fun O.out Template.no_extra_args
-        myenv global_env envVolatile proc out ;
+        global_env envVolatile proc out ;
       O.f "static int thread%i(void *_p) {" proc ;
       O.oi "ctx_t *_a = (ctx_t *)_p;" ;
       O.o "" ;
@@ -675,7 +672,7 @@ let dump_threads _tname env test =
       | Some _|None -> idx in
       Lang.dump_call (LangUtils.code_fun proc)
         [] tr_idx O.out (Indent.as_string indent3)
-        myenv (global_env,aligned_env) envVolatile proc out ;
+        (global_env,aligned_env) envVolatile proc out ;
       O.oii "}" ;
       O.oi "}" ;
       O.oi "smp_mb();" ;

--- a/litmus/LISAArch_litmus.ml
+++ b/litmus/LISAArch_litmus.ml
@@ -25,6 +25,16 @@ module Make(V:Constant.S) = struct
   | GPRreg _ -> pp_reg r
   | Symbolic_reg _ -> assert false
 
+  let error t1 t2 =
+    let open CType in
+    match t1,t2 with
+    | (Base "int",Pointer _)
+      | (Pointer _,Base "int")  ->
+       true
+    | _ -> false
+
+  let warn _t1 _t2 = false
+
   include
       ArchExtra_litmus.Make
       (struct
@@ -44,14 +54,6 @@ module Make(V:Constant.S) = struct
         let reg_class _ = ""
         let reg_class_stable _ _ = ""
         let comment = comment
-        let error t1 t2 =
-          let open CType in
-          match t1,t2 with
-          | (Base "int",Pointer _)
-          | (Pointer _,Base "int")  ->
-              true
-          | _ -> false
-        let warn _t1 _t2 = false
       end)
   let features = []
   let nop = Pnop

--- a/litmus/LISALang.ml
+++ b/litmus/LISALang.ml
@@ -44,7 +44,7 @@ module Make(V:Constant.S) = struct
  *)
         dump_ins (k+1) ts in
 (* Prefix *)
-    let reg_env = Tmpl.get_reg_env A.I.error A.I.warn t in
+    let reg_env = t.Tmpl.ty_env in
     let all_regs = Tmpl.all_regs_in_tmpl t in
     let init =
       List.fold_left (fun m (r,v) -> RegMap.add r v m)
@@ -101,8 +101,9 @@ module Make(V:Constant.S) = struct
 
   and compile_out_reg_fun p r = sprintf "*%s" (Tmpl.dump_out_reg p r)
 
-  let dump_fun ?user chan _args0 env globEnv _volatileEnv proc t =
+  let dump_fun ?user chan _args0 globEnv _volatileEnv proc t =
     assert (Misc.is_none user) ;
+    let env = t.Tmpl.ty_env in
     let addrs_proc = A.Out.get_addrs_only t in
     let addrs =
       List.map
@@ -142,7 +143,7 @@ module Make(V:Constant.S) = struct
     sprintf "&_a->%s" (Tmpl.compile_out_reg proc reg)
 
   let dump_call f_id args0
-        _tr_idx chan indent _env _globEnv _volatileEnv proc t =
+        _tr_idx chan indent _globEnv _volatileEnv proc t =
     let addrs_proc = Tmpl.get_addrs_only t in
     let addrs = List.map compile_addr_call addrs_proc
     and outs = List.map (compile_out_reg_call proc) t.Tmpl.final in
@@ -150,6 +151,6 @@ module Make(V:Constant.S) = struct
     LangUtils.dump_code_call chan indent f_id args
 
 
-  let dump _chan _indent _env _globEnv _volatileEnv _proc _t = ()
+  let dump _chan _indent _globEnv _volatileEnv _proc _t = ()
 
 end

--- a/litmus/MIPSArch_litmus.ml
+++ b/litmus/MIPSArch_litmus.ml
@@ -26,6 +26,9 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
   | _ -> pp_reg r
 
 
+  let error _ _ = false
+  let warn _ _ = false
+
   include
       ArchExtra_litmus.Make(O)
       (struct
@@ -47,8 +50,6 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
         let reg_class _ = "=&r"
         let reg_class_stable init _ = if init then "+r" else "=&r"
         let comment = comment
-        let error _ _ = false
-        let warn _ _ = false
       end)
   let features = []
   let nop = NOP

--- a/litmus/PPCArch_litmus.ml
+++ b/litmus/PPCArch_litmus.ml
@@ -64,6 +64,9 @@ module Make (O:Arch_litmus.Config)(V:Constant.S) = struct
   | Symbolic_reg _ -> assert false
   | _ -> assert false
 
+  let error _ _ = false
+  let warn _ _ = false
+
   include
       ArchExtra_litmus.Make(O)
       (struct
@@ -88,8 +91,6 @@ module Make (O:Arch_litmus.Config)(V:Constant.S) = struct
         let reg_class _ = "=&r"
         let reg_class_stable init _ = if init then "+r" else "=&r"
         let comment = comment
-        let error _ _ = false
-        let warn _ _ = false
       end)
 
   let features = []

--- a/litmus/RISCVArch_litmus.ml
+++ b/litmus/RISCVArch_litmus.ml
@@ -26,6 +26,8 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
   | Symbolic_reg _|RESADDR -> assert false
   | Ireg _ -> pp_reg r
 
+  let error _t1 _t2 = false
+  and warn _t1 _t2 = false
 
   include
       ArchExtra_litmus.Make(O)
@@ -42,8 +44,6 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
         let reg_class _ = "=&r"
         let reg_class_stable init _r = if init then "+w" else "=&r"
         let comment = comment
-        let error _t1 _t2 = false
-        and warn _t1 _t2 = false
       end)
   let features = []
   let nop = INop

--- a/litmus/X86Arch_litmus.ml
+++ b/litmus/X86Arch_litmus.ml
@@ -34,6 +34,9 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
   | Internal i -> sprintf "i%i" i
   | _ -> assert false
 
+  let error _ _ = false
+  let warn _ _ = false
+
   include
       ArchExtra_litmus.Make(O)
       (struct
@@ -65,9 +68,8 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
           ^ do_reg_class r
 
         let comment = comment
-        let error _ _ = false
-        let warn _ _ = false
       end)
+
   let features = []
   let nop =  I_NOP
 

--- a/litmus/X86_64Arch_litmus.ml
+++ b/litmus/X86_64Arch_litmus.ml
@@ -32,6 +32,9 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
     | Internal i -> sprintf "i%i" i
     | _ -> assert false
 
+  let error _ _ = false
+  let warn _ _ = false
+
   include
     ArchExtra_litmus.Make(O)
       (struct
@@ -64,9 +67,8 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
           (if init then "+" else "=&")
           ^ do_reg_class r
         let comment = comment
-        let error _ _ = false
-        let warn _ _ = false
       end)
+
   let features = []
   let nop =  I_NOP
 

--- a/litmus/archExtra_litmus.ml
+++ b/litmus/archExtra_litmus.ml
@@ -27,8 +27,6 @@ module type I = sig
   val reg_class : arch_reg -> string
   val reg_class_stable : bool -> arch_reg -> string
   val comment : string
-  val error : CType.t -> CType.t -> bool
-  val warn : CType.t -> CType.t -> bool
 end
 
 module type S = sig

--- a/litmus/arch_litmus.mli
+++ b/litmus/arch_litmus.mli
@@ -68,6 +68,10 @@ module type Base = sig
   val user_handler_clobbers : string list
   val vector_table : bool -> string -> string list
 
+(* Reaction to different types, fail or warn *)
+  val error : (CType.t -> CType.t -> bool)
+  val warn : (CType.t -> CType.t -> bool)
+
   module FaultType : FaultType.S
 
   module GetInstr : GetInstr.S with type t = instruction
@@ -102,6 +106,10 @@ module type S =
     include ArchBase.S
 
     module V : Constant.S with type Instr.t = instruction
+
+(* Reaction to different types, fail or warn *)
+    val error : (CType.t -> CType.t -> bool)
+    val warn : (CType.t -> CType.t -> bool)
 
     val reg_to_string : reg -> string
 

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -714,9 +714,9 @@ module A.FaultType = A.FaultType)
             A.LocMap.fold
               (fun loc t k -> match loc with
               | A.Location_reg (p,r) when Misc.int_eq p proc ->
-                  (r,t)::k
+                  RegMap.add r t k
               | _ -> k)
-              ty_env [] in
+              ty_env RegMap.empty in
           let init = compile_init proc init observed_proc code in
           let final = compile_final proc observed_proc in
           let addrs = StringSet.elements addrs in
@@ -725,7 +725,7 @@ module A.FaultType = A.FaultType)
                  (A.RegSet.union stable stable_info)
                  (A.Out.all_regs code fhandler final) in
           let stable = A.RegSet.elements stable in
-          proc,
+          let t =
           { init ;
             addrs ;
             ptes = StringSet.elements ptes ;
@@ -734,7 +734,11 @@ module A.FaultType = A.FaultType)
             all_clobbers;
             code; fhandler; name; nrets; nnops;
             ty_env;
-          }) outs
+            code_ty_env = RegMap.empty;
+          } in
+          let code_ty_env = A.Out.get_reg_env A.error A.warn t in
+          let t = { t with code_ty_env;} in
+        proc,t) outs
 
     let _pp_env env =
       StringMap.pp_str

--- a/litmus/language.ml
+++ b/litmus/language.ml
@@ -15,15 +15,12 @@
 (****************************************************************************)
 
 module type S = sig
-  type arch_reg
-  module RegMap : MyMap.S with type key = arch_reg
   type t
 
   val dump_fun :
     ?user:bool ->
     out_channel ->
     Template.extra_args ->
-    CType.t RegMap.t ->
     (string * CType.t) list ->
     string list ->
     Proc.t ->
@@ -36,7 +33,6 @@ module type S = sig
     (CType.t -> string -> string) ->
     out_channel ->
     string ->
-    CType.t RegMap.t ->
     ((string * CType.t) list * (string * CType.t) list) ->
     string list ->
     Proc.t ->
@@ -47,7 +43,6 @@ module type S = sig
   val dump :
     out_channel ->
     string ->
-    CType.t RegMap.t ->
     ((string * CType.t) list * (string * CType.t) list) ->
     string list ->
     Proc.t ->

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -86,9 +86,7 @@ module Make
      type instruction = A.instruction and
      type P.code = P.code and module A = A and module FaultType = A.FaultType)
     (O:Indent.S)
-    (Lang:Language.S
-    with type arch_reg = T.A.reg and type t = A.Out.t
-    and module RegMap = T.A.RegMap) : sig
+    (Lang:Language.S with type t = A.Out.t) : sig
       val dump : Name.t -> T.t -> unit
     end = struct
   module MakeLoc
@@ -1772,11 +1770,10 @@ module Make
             test.T.globals in
         List.iter
           (fun (proc,(out,(_outregs,envVolatile))) ->
-            let myenv = U.select_proc proc env
-            and global_env = U.select_global env in
+            let global_env = U.select_global env in
             if do_ascall then begin
                 Lang.dump_fun O.out
-                  Template.no_extra_args myenv global_env envVolatile proc out
+                  Template.no_extra_args global_env envVolatile proc out
             end ;
             let  do_collect =  do_collect_local && (do_safer || proc=0) in
             O.f "static void *P%i(void *_vb) {" proc ;
@@ -1981,8 +1978,9 @@ module Make
               let f_id =
                 if do_self then LangUtils.code_fun_cpy proc else
                 LangUtils.code_fun proc in
-              Lang.dump_call f_id [] (fun _ s -> s) else Lang.dump)
-              O.out (Indent.as_string iloop) myenv (global_env,aligned_env) envVolatile proc out ;
+              Lang.dump_call f_id [] (fun _ s -> s)
+             else Lang.dump)
+              O.out (Indent.as_string iloop) (global_env,aligned_env) envVolatile proc out ;
             if do_verbose_barrier && have_timebase  then begin
               if do_timebase then begin
                 O.fx iloop "_a->tb_delta[%i][_i] = _delta;" proc ;

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -355,7 +355,7 @@ end
       let select_proc (p:int) (env,_) =
         select_types_reg
           (function
-            | A.Location_reg (q,reg) when p = q -> Some reg
+            | A.Location_reg (q,reg) when Proc.equal p q -> Some reg
             | A.Location_global _ | A.Location_reg _  -> None)
           env
 

--- a/litmus/target.mli
+++ b/litmus/target.mli
@@ -18,8 +18,8 @@
 module type S = sig
   module V : Constant.S
   type arch_reg
+  module RegMap : MyMap.S with type key = arch_reg
   type t
-
   val get_nrets : t -> int
   val get_nnops : t -> int
   val has_asmhandler : t -> bool
@@ -31,4 +31,9 @@ module type S = sig
   val dump_init_val : V.v -> string
   val has_fault_handler : t -> bool
   val find_offset : Label.t -> t -> int
+
+  val get_reg_env :
+    (CType.t ->CType.t ->bool)
+    -> (CType.t ->CType.t ->bool)
+    -> t -> CType.t RegMap.t
 end

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -73,10 +73,7 @@ module Top(O:Config)(Tar:Tar.S) = struct
 
 
   module Utils(A:Arch_litmus.Base)(MemType:MemoryType.S)
-      (Lang:Language.S
-      with type arch_reg = A.Out.arch_reg
-      and type t = A.Out.t
-      and module RegMap = A.RegMap)
+      (Lang:Language.S with type t = A.Out.t)
       (Pseudo:PseudoAbstract.S with type ins = A.instruction) =
     struct
       module T = Test_litmus.Make(O)(A)(Pseudo)

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -155,10 +155,7 @@ end = struct
 
 
   module Utils (O:Config) (A':Arch_litmus.Base)
-           (Lang:Language.S
-            with type arch_reg = A'.Out.arch_reg
-             and type t = A'.Out.t
-             and module RegMap = A'.RegMap)
+           (Lang:Language.S with type t = A'.Out.t)
            (Pseudo:PseudoAbstract.S with type ins = A'.instruction) =
     struct
 


### PR DESCRIPTION
Since PR #483 the initial values of registers given as input parameters to the assembly template are casted to the type of the register as declared or to the default `int` type. In some cases the register type is wrong and the cast truncates the value. Consider:
```
AArch64 IntInit
{
0:X0=0x0101010101010101;
uint64_t x;
0:X1=x;
}
  P0        ;
STR X0,[X1] ;
locations [x;]
```
The type of the `0:X0` register is the default `int`. Although **litmus7** flags a warning, one tends to neglect the problem, since the register is not printed. However, the cast to `int` destroys the higher order part of the value and the final output is wrong, although `x` type is correct:
```
...
Histogram (1 states)
40000 :>[x]=0x1010101;
...
```
Out test base contains many such tests and we cannot reject them. Thus, our solution is to use a different type for casting the initial value: analysing the code we infer a type `uint64_t` leading to the following correct output:
```
...
Histogram (1 states)
40000 :>[x]=0x101010101010101;
...
```
In practice, the code template record `Template.t` is enriched  by two two fields `ty_env` for "declared types" and `code_ty_env` for types inferred from the code.