### PR TITLE
[doc] Fix spelling mistake

### DIFF
--- a/doc/tso-01.cat
+++ b/doc/tso-01.cat
@@ -7,7 +7,7 @@ let com-tso = rfe | co | fr
 (* Program order that orders events *)
 let po-tso = po & (W*W | R*M)
 
-(* TSP global-happens-before *)
+(* TSO global-happens-before *)
 let ghb = po-tso | com-tso
 acyclic ghb
 show ghb

--- a/doc/tso-02.cat
+++ b/doc/tso-02.cat
@@ -13,7 +13,7 @@ let com-tso = rfe | co | fr
 let mfence = po & (_ * MFENCE) ; po
 let po-tso = po & (W*W | R*M) | mfence
 
-(* TSP global-happens-before *)
+(* TSO global-happens-before *)
 let ghb = po-tso | com-tso
 show mfence,ghb
 acyclic ghb as tso


### PR DESCRIPTION
I assume these should say "TSO" and not "TSP"