### PR TITLE
[litmus] Fail on incomplete pte values

### DIFF
--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -669,7 +669,7 @@ module RegMap = A.RegMap)
           List.map
             (fun p ->
               match A.V.PteVal.as_physical p with
-              | None ->
+              | None|Some "" ->
                   Warn.user_error "litmus cannot handle pte initialisation with '%s'"
                     (A.V.PteVal.pp O.hexa p)
               | Some s ->


### PR DESCRIPTION
The following test was compiled by **litmus7** to a C files that could not compile:
```
AArch64 NoPa
{

int x;
0:X1=PTE(x);
0:X2=(valid:0);
1:X1=x;
}
  P0        | P1          ;
STR X2,[X1] | LDR W0,[X1] ;
exists fault(P1,x)
```

With this PR, **litmus7** now flags a fatal error:
```
% /opt/WIP/bin/litmus7 -mach kvm-aarch64 NoPa.litmus -o /tmp/A.tar
File "NoPa.litmus" litmus cannot handle pte initialisation with '(oa:PA(), valid:0)'
```