### PR TITLE
[herd] Check the liveness of read-from relations

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -801,6 +801,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
           condition = ConstrGen.ExistsState (ConstrGen.And []);
           locations = [];
           extra_data = MiscParser.empty_extra;
+          too_far=false;
         }
       in
       let name =

--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -189,3 +189,6 @@ let CMODX-unordered-conflicts =
   CMODX-conflicts \ (CMODX-ordering | CMODX-ordering^-1)
 
 flag ~empty CMODX-unordered-conflicts as violates-CMODX-requirements
+
+let fr-toofar = ([domain(fr)];po;[TooFar])\((fr;rf)&po;po)
+empty fr-toofar as liveness

--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -190,5 +190,9 @@ let CMODX-unordered-conflicts =
 
 flag ~empty CMODX-unordered-conflicts as violates-CMODX-requirements
 
-let fr-toofar = ([domain(fr)];po;[TooFar])\((fr;rf)&po;po)
+(*** Liveness check, work in progres ***)
+
+let W-DSB = W & domain(po;[dsb.full])
+
+let fr-toofar = ([domain(fr;[W-DSB])];po;[TooFar])\((fr;[W-DSB];rf)&po;po)
 empty fr-toofar as liveness

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -492,6 +492,9 @@ end = struct
           | Barrier b -> p b
           | _ -> false
           in tag,p) A.barrier_sets
+
+    and toofar_set = ("TooFar",is_toofar)
+
     and cmo_sets =
       List.map
         (fun (tag,p) ->
@@ -570,7 +573,8 @@ end = struct
           (fun (key,p) k -> (key,on_pteval p)::k) A.pteval_sets k
     else
       fun k -> k)
-      (bsets @ cmo_sets @ asets @ esets @ lsets @ aasets @ ifetch_sets @ fault_sets @ tlbi_sets)
+      (toofar_set::bsets @ cmo_sets @ asets @ esets
+       @ lsets @ aasets @ ifetch_sets @ fault_sets @ tlbi_sets)
 
   let arch_rels =
     if kvm then

--- a/herd/test_herd.ml
+++ b/herd/test_herd.ml
@@ -40,7 +40,8 @@ type
      extra_data : MiscParser.extra_data ;
      access_size : MachSize.sz list ;
      proc_info : proc_info ;
-    }
+     too_far:bool;
+   }
 
 (* Name and nothing else *)
 let simple_name test = test.name.Name.name
@@ -150,6 +151,7 @@ module Make(A:Arch_herd.S) =
            condition = final ;
            locations = locs ;
            extra_data = extra_data ;
+           too_far;
          } = t in
 
       let prog,starts,rets = Load.load nice_prog in
@@ -213,6 +215,7 @@ module Make(A:Arch_herd.S) =
        type_env;
        access_size = mem_access_size init nice_prog ;
        proc_info;
+       too_far;
      }
 
     let empty_test =
@@ -247,8 +250,11 @@ module Make(A:Arch_herd.S) =
        extra_data = MiscParser.empty_extra;
        access_size = [];
        proc_info = [];
+       too_far = false;
      }
 
     let find_our_constraint test = test.cond
+
+    let gone_toofar test = test.too_far
 
 end

--- a/herd/test_herd.mli
+++ b/herd/test_herd.mli
@@ -40,6 +40,7 @@ type
      extra_data : MiscParser.extra_data ;
      access_size : MachSize.sz list ;
      proc_info : proc_info ;
+     too_far : bool ;
    }
 
 val simple_name :
@@ -82,6 +83,8 @@ module Make(A:Arch_herd.S) : sig
   val build : Name.t -> A.pseudo MiscParser.t -> result
 
   val find_our_constraint : result -> A.constr
+
+  val gone_toofar : result -> bool
 
   (* needed to interpret bell *)
   val empty_test : result

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -330,7 +330,7 @@ module Make(O:Config)(M:XXXMem.S) =
                 if O.outcomereads then
                   A.LocSet.union (PU.all_regs_that_read conc.S.str) c.reads
                 else c.reads;
-              toofar =  c.toofar || (showtoofar && S.gone_toofar conc);
+              toofar =  c.toofar || S.gone_toofar conc;
             } in
           if not O.badexecs && is_bad flags then raise (Over r) ;
           let r = match O.nshow with

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -235,6 +235,7 @@ module Make(O:Config)(M:XXXMem.S) =
     let model_kont ochan test do_restrict cstr =
 
       let check = check_prop test in
+      let showtoofar = showtoofar || T.gone_toofar test in
 
       fun conc (st,flts) (set_pp,vbpp) flags c ->
         if not showtoofar && S.gone_toofar conc then

--- a/jingle/mapping.ml
+++ b/jingle/mapping.ml
@@ -316,6 +316,7 @@ module Make(C:Config) = struct
       condition = condition;
       locations = locations;
       extra_data = src.extra_data;
+      too_far = src.too_far;
     }
 
 end

--- a/lib/CGenParser_lib.ml
+++ b/lib/CGenParser_lib.ml
@@ -182,7 +182,7 @@ module Do
           code)
       prog ;
 *)
-    let (locs,filter,final,_quantifiers) =
+    let (locs,filter,(too_far,final),_quantifiers) =
       I.call_parser_loc "final"
 		      chan constr_loc SL.token StateParser.constraints in
     check_regs procs init locs final ;
@@ -194,15 +194,16 @@ module Do
         condition = final;
         locations = locs;
         extra_data = (MiscParser.CExtra params)::data_litmus;
+        too_far;
       } in
     let name  = name.Name.name in
     let parsed =
       match O.check_cond name  with
       | None -> parsed
       | Some k ->
-         let cond = parse_cond (Lexing.from_string k) in
+         let too_far,cond = parse_cond (Lexing.from_string k) in
          { parsed with
-           MiscParser.condition = cond ;} in
+           MiscParser.condition = cond; too_far;} in
     let parsed =
       match O.check_kind name  with
       | None -> parsed

--- a/lib/genParser.ml
+++ b/lib/genParser.ml
@@ -177,7 +177,7 @@ module Make
       let prog = parsed_tr prog in
       let prog = transpose procs prog in
       let prog = expn_prog prog in
-      let (locs,filter,final,_quantifiers) =
+      let (locs,filter,(too_far,final),_quantifiers) =
         I.call_parser_loc "final"
           chan constr_loc SL.token StateParser.constraints in
       check_regs procs init locs final ;
@@ -188,15 +188,16 @@ module Make
          filter = filter;
          condition = final;
          locations = locs;
-         extra_data = extra_data ;
+         extra_data = extra_data;
+         too_far;
        } in
       let name  = name.Name.name in
       let parsed =
         match O.check_cond name  with
         | None -> parsed
         | Some k ->
-            let cond =
-              let cond = parse_cond (Lexing.from_string k) in
+            let too_far,cond =
+              let too_far,cond = parse_cond (Lexing.from_string k) in
               try (* Apply mapping as condition may be expressed with external
                      registers *)
                 let map = List.assoc OutMapping.key info in
@@ -226,10 +227,10 @@ module Make
                       end
                 in
                 if O.verbose > 0 then prerr_endline "Bingo" ;
-                ConstrGen.map_constr map_atom cond
-              with Not_found -> cond in
+                too_far,ConstrGen.map_constr map_atom cond
+              with Not_found -> too_far,cond in
             { parsed with
-              MiscParser.condition = cond ;} in
+              MiscParser.condition = cond; too_far; } in
       let parsed =
         match O.check_kind name  with
         | None -> parsed

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -191,6 +191,7 @@ type ('i, 'p, 'prop, 'loc, 'v, 'ftype) result =
       condition : 'prop ConstrGen.constr ;
       locations : ('loc,'v,'ftype) LocationsItem.t list ;
       extra_data : extra_data ;
+      too_far : bool ;
 }
 
 (* Easier to handle *)

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -91,6 +91,7 @@ type ('i, 'p, 'prop, 'loc, 'v, 'ftype) result =
       condition : 'prop ConstrGen.constr ;
       locations : ('loc,'v,'ftype) LocationsItem.t list ;
       extra_data : extra_data ;
+      too_far : bool ;
     }
 
 (* Easier to handle *)

--- a/lib/splitter.mll
+++ b/lib/splitter.mll
@@ -155,8 +155,11 @@ and inside_prog do_skip_comments = parse
 (* | "+" *) (* Had to erase this to handle C-code, why here ?? *)
 | "final"
 | "forall"
+| "forallN"
 | ('~' blank* "exists" )
+| ('~' blank* "existsN" )
 | "exists"
+| "existsN"
 | "cases" (* not sure if this line should still be here *)
 | "observed"|"Observed"
 | "locations"

--- a/lib/stateLexer.mll
+++ b/lib/stateLexer.mll
@@ -63,8 +63,10 @@ rule token = parse
 | "false"     { FALSE }
 | "observed"|"Observed"   { OBSERVED }
 | "and" { TOKAND }
-| "exists"   { EXISTS }
-| "forall"   { FORALL }
+| "exists"   { EXISTS false }
+| "existsN"   { EXISTS true }
+| "forall"   { FORALL false }
+| "forallN"   { FORALL true }
 | "final"    { FINAL }
 | "with"     { WITH }
 | "locations" { LOCATIONS }

--- a/litmus/CGenParser_litmus.ml
+++ b/litmus/CGenParser_litmus.ml
@@ -146,7 +146,7 @@ let check_regs = GenParserUtils.check_regs
         call_parser_loc "prog" chan prog_loc L.lexer L.parser in
       let prog = List.map CAstUtils.strip_pointers prog in
       let procs = check_procs prog in
-      let (locs,filter,final,_quantifiers) =
+      let (locs,filter,(too_far,final),_quantifiers) =
         call_parser_loc "final"
           chan constr_loc SL.token StateParser.constraints in
       check_regs procs init locs final ;
@@ -158,15 +158,16 @@ let check_regs = GenParserUtils.check_regs
          condition = final;
          locations = locs;
          extra_data = MiscParser.empty_extra;
+         too_far;
        } in
       let name  = name.Name.name in
       let parsed =
         match O.check_cond name  with
         | None -> parsed
         | Some k ->
-            let cond = parse_cond (Lexing.from_string k) in
+            let too_far,cond = parse_cond (Lexing.from_string k) in
             { parsed with
-              MiscParser.condition = cond ;} in
+              MiscParser.condition = cond; too_far; } in
       let parsed =
         match O.check_kind name  with
         | None -> parsed


### PR DESCRIPTION
Intuitively, this "liveness" property is that a read cannot indefinitely read from a non-final write. Our formulation involves 'pruned' executions and requires that, for all locations x the last read of x in a pruned po is from the final write to x.