### PR TITLE
[herd]  Check the liveness of some read-from relations

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -936,7 +936,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
         | ASLS.Act.NoAction ->
            (* As long as aarch64.cat ignores "NoAction" effects *)
            None
-        | ASLS.Act.TooFar msg -> Some (Act.TooFar msg)
+        | ASLS.Act.CutOff msg -> Some (Act.CutOff msg)
 
       let tr_expr acc = function
         | ASLVC.Atom a -> (M.VC.Atom (tr_v a), acc)

--- a/herd/ASLAction.ml
+++ b/herd/ASLAction.ml
@@ -48,7 +48,7 @@ module Make (A : S) = struct
     | Access of dirn * A.location * A.V.v * MachSize.sz * AArch64Annot.t
     | Barrier of A.barrier
     | Branching of string option
-    | TooFar of string
+    | CutOff of string
     | NoAction
 
   let mk_init_write loc sz v = Access (W, loc, v, sz, AArch64Annot.N)
@@ -65,12 +65,12 @@ module Make (A : S) = struct
     | Branching txt ->
        Printf.sprintf "Branching(%s)"
          (Misc.app_opt_def "" Misc.identity txt)
-    | TooFar msg -> Printf.sprintf "TooFar:%s" msg
+    | CutOff msg -> Printf.sprintf "CutOff:%s" msg
     | NoAction -> ""
 
   let is_local = function
     | Access (_, A.Location_reg (_, r), _, _, _) -> A.is_local r
-    | Access _|Barrier _|Branching _|TooFar _|NoAction
+    | Access _|Barrier _|Branching _|CutOff _|NoAction
       -> false
 
   (** Write to PC *)
@@ -92,25 +92,25 @@ module Make (A : S) = struct
   let value_of =
     function
     | Access (_, _, v, _, _) -> Some v
-    | Barrier _|Branching _|TooFar _|NoAction
+    | Barrier _|Branching _|CutOff _|NoAction
       -> None
 
   let read_of =
     function
     | Access (R, _, v, _, _) -> Some v
-    | Access _|Barrier _|Branching _|TooFar _|NoAction
+    | Access _|Barrier _|Branching _|CutOff _|NoAction
       -> None
 
   let written_of =
     function
     | Access (W, _, v, _, _) -> Some v
-    | Access _|Barrier _| Branching _|TooFar _|NoAction
+    | Access _|Barrier _| Branching _|CutOff _|NoAction
       -> None
 
   let location_of =
     function
     | Access (_, l, _, _, _) -> Some l
-    | Branching _|Barrier _|TooFar _|NoAction
+    | Branching _|Barrier _|CutOff _|NoAction
      -> None
 
   (************************)
@@ -120,112 +120,112 @@ module Make (A : S) = struct
   (* relative to memory *)
   let is_mem_store = function
     | Access (W, A.Location_global _, _, _, _) -> true
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
 
   let is_mem_load = function
     | Access (R, A.Location_global _, _, _, _) -> true
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
 
   let is_additional_mem_load = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
 
   let is_mem = function
     | Access (_, A.Location_global _, _, _, _) -> true
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
 
   let is_ifetch = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
   let is_tag = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
   let is_additional_mem  = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
   let is_atomic = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
   let is_fault = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
 
   let to_fault = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> None
 
   let get_mem_dir = function
     | Access (d, A.Location_global _, _, _, _) -> d
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> assert false
 
   let get_mem_size = function
     | Access (_, A.Location_global _, _, sz, _) -> sz
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> assert false
 
   let is_pte_access = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
 
   let is_explicit = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
 
   let is_not_explicit = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
 
   (* relative to the registers of the given proc *)
   let is_reg_store = function
     | Access (W, A.Location_reg (p, _), _, _, _) -> Proc.equal p
-    | Access _|Barrier _|Branching _|TooFar _|NoAction
+    | Access _|Barrier _|Branching _|CutOff _|NoAction
       ->
        fun _ -> false
 
   let is_reg_load = function
     | Access (R, A.Location_reg (p, _), _, _, _) -> Proc.equal p
-    | Access _|Barrier _|Branching _|TooFar _|NoAction
+    | Access _|Barrier _|Branching _|CutOff _|NoAction
       ->
        fun _ -> false
 
 
   let is_reg = function
     | Access (_, A.Location_reg (p, _), _, _, _) -> Proc.equal p
-    | Access _|Barrier _|Branching _|TooFar _|NoAction
+    | Access _|Barrier _|Branching _|CutOff _|NoAction
       -> fun _ -> false
 
   (* Reg events, proc not specified *)
   let is_reg_store_any = function
     | Access (W, A.Location_reg _, _, _, _) -> true
-    | Access _|Barrier _|Branching _|TooFar _|NoAction
+    | Access _|Barrier _|Branching _|CutOff _|NoAction
       -> false
 
   let is_reg_load_any = function
     | Access (R, A.Location_reg _, _, _, _) -> true
-      | Access _|Barrier _|Branching _|TooFar _|NoAction
+      | Access _|Barrier _|Branching _|CutOff _|NoAction
       -> false
 
 
   let is_reg_any = function
     | Access (_, A.Location_reg _, _, _, _) -> true
-    | Access _|Barrier _|Branching _|TooFar _|NoAction
+    | Access _|Barrier _|Branching _|CutOff _|NoAction
       -> false
 
   (* Store/Load to memory or register *)
   let is_store =
     function
     | Access (W, _, _, _, _) -> true
-    | Access _|Barrier _|Branching _|TooFar _|NoAction
+    | Access _|Barrier _|Branching _|CutOff _|NoAction
       -> false
 
   let is_load =
     function
     | Access (R, _, _, _, _) -> true
-    | Access _|Barrier _|Branching _|TooFar _|NoAction
+    | Access _|Barrier _|Branching _|CutOff _|NoAction
       -> false
 
   (* Compatible accesses *)
@@ -237,34 +237,34 @@ module Make (A : S) = struct
   (* Barriers *)
   let is_barrier = function
     | Barrier _  -> true
-    | Access _|Branching _|TooFar _|NoAction
+    | Access _|Branching _|CutOff _|NoAction
       -> false
 
   let barrier_of = function
     | Barrier b -> Some b
-    | Access _|Branching _|TooFar _|NoAction
+    | Access _|Branching _|CutOff _|NoAction
       -> None
 
   let same_barrier_id _a1 _a2 = assert false
 
   (* Commits *)
   let is_bcc  = function
-    | Access _| Branching _|Barrier _|TooFar _|NoAction
+    | Access _| Branching _|Barrier _|CutOff _|NoAction
       -> false
 
   let is_pred ?(cond=None) = function
     | Branching cond0 ->
        Option.is_none cond || Option.equal String.equal cond cond0
-    | Access _|Barrier _|TooFar _|NoAction -> false
+    | Access _|Barrier _|CutOff _|NoAction -> false
 
   let is_commit = function
     | Branching _ -> true
-    | Access _|Barrier _|TooFar _|NoAction -> false
+    | Access _|Barrier _|CutOff _|NoAction -> false
 
   (* Unrolling control *)
-  let toofar msg = TooFar msg
-  let is_toofar = function
-    | TooFar _ -> true
+  let cutoff msg = CutOff msg
+  let is_cutoff = function
+    | CutOff _ -> true
     | Access _|Barrier _|Branching _|NoAction
       -> false
 
@@ -275,7 +275,7 @@ module Make (A : S) = struct
   let undetermined_vars_in_action = function
     | Access (_, l, v, _, _) ->
         V.ValueSet.union (A.undetermined_vars_in_loc l) (V.undetermined_vars v)
-    | Barrier _ | Branching _| TooFar _ | NoAction -> V.ValueSet.empty
+    | Barrier _ | Branching _| CutOff _ | NoAction -> V.ValueSet.empty
 
   let simplify_vars_in_action soln a =
     match a with
@@ -283,7 +283,7 @@ module Make (A : S) = struct
         Access
           (d, A.simplify_vars_in_loc soln l,
            V.simplify_var soln v, sz, a)
-    | Barrier _ | Branching _ | TooFar _ | NoAction -> a
+    | Barrier _ | Branching _ | CutOff _ | NoAction -> a
 end
 
 module FakeModuleForCheckingSignatures (A : S) : Action.S

--- a/herd/BellAction.ml
+++ b/herd/BellAction.ml
@@ -24,7 +24,7 @@ module Make (A : Arch_herd.S) : sig
           bool * string list * MachSize.sz
     | Barrier of string list * (Label.Set.t * Label.Set.t) option
     | Commit
-    | TooFar of string
+    | CutOff of string
 
   include Action.S with module A = A and type action := action
 
@@ -41,7 +41,7 @@ end = struct
 
     | Barrier of string list * (Label.Set.t * Label.Set.t) option
     | Commit
-    | TooFar of string
+    | CutOff of string
 
 (* I think this is right... *)
   let mk_init_write l sz v = Access(W,l,v,false,[],sz)
@@ -78,7 +78,7 @@ end = struct
             (BellBase.string_of_labels s2)
       )
   | Commit -> "Commit"
-  | TooFar msg -> "TooFar:" ^ msg
+  | CutOff msg -> "CutOff:" ^ msg
 
 (* Utility functions to pick out components *)
   let value_of a = match a with
@@ -201,9 +201,9 @@ end = struct
   let is_commit = is_bcc
 
 (* Unroll control *)
-  let toofar msg = TooFar msg
-  let is_toofar = function
-    | TooFar _ -> true
+  let cutoff msg = CutOff msg
+  let is_cutoff = function
+    | CutOff _ -> true
     | _ -> false
 
 (* Equations *)
@@ -214,7 +214,7 @@ end = struct
         V.ValueSet.union
           (A.undetermined_vars_in_loc l)
           (V.undetermined_vars v)
-    | Barrier _|Commit|TooFar _ -> V.ValueSet.empty
+    | Barrier _|Commit|CutOff _ -> V.ValueSet.empty
 
   let simplify_vars_in_action soln a =
     match a with
@@ -222,7 +222,7 @@ end = struct
         let l' = A.simplify_vars_in_loc soln l in
         let v' = V.simplify_var soln v in
         Access (d,l',v',ato,s,sz)
-    | Barrier _ | Commit| TooFar _ -> a
+    | Barrier _ | Commit| CutOff _ -> a
 
 (*************************************************************)
 (* Add together event structures from different instructions *)

--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -36,8 +36,8 @@ module Make (A : Arch_herd.S) : sig
     | ReadLock of A.location * bool
 (* SRCU : location, nature, and optional value (for lock/unlock) *)
     | SRCU of A.location * MemOrderOrAnnot.annot * A.V.v option
-(* TooFar: unroll too much *)
-    | TooFar of string
+(* CutOff: unroll too much *)
+    | CutOff of string
 
   include Action.S with type action := action and module A = A
 
@@ -61,7 +61,7 @@ end = struct
     | TryLock of A.location (* Failed trylock *)
     | ReadLock of A.location * bool
     | SRCU of A.location * annot * V.v option
-    | TooFar of string
+    | CutOff of string
 
   let mk_init_write l sz v = Access (W,l,v,AN [],false,sz)
 
@@ -115,7 +115,7 @@ end = struct
         (bra pp_annot an)
         (A.pp_location l)
         (V.pp_v v)
-  | TooFar msg -> "TooFar:" ^ msg
+  | CutOff msg -> "CutOff:" ^ msg
 
 (* Utility functions to pick out components *)
 
@@ -145,7 +145,7 @@ end = struct
   | RMW (loc,_,_,_,_)
   | SRCU (loc,_,_)
     -> Some loc
-  | Fence _|TooFar _ -> None
+  | Fence _|CutOff _ -> None
 
 (* relative to memory *)
   let is_mem_store a = match a with
@@ -263,9 +263,9 @@ end = struct
   let is_commit _ = false
 
 (* Unrolling control *)
-  let toofar msg = TooFar msg
-  let is_toofar = function
-    | TooFar _ -> true
+  let cutoff msg = CutOff msg
+  let is_cutoff = function
+    | CutOff _ -> true
     | _ -> false
 
 (* RMWs *)
@@ -361,7 +361,7 @@ end = struct
     | ReadLock (l,_)
     | SRCU(l,_,None) ->
         A.undetermined_vars_in_loc l
-    | Fence _|TooFar _ -> V.ValueSet.empty
+    | Fence _|CutOff _ -> V.ValueSet.empty
 
   let simplify_vars_in_action soln a =
     match a with
@@ -389,7 +389,7 @@ end = struct
     | SRCU(l,a,vo) ->
         let l' =  A.simplify_vars_in_loc soln l in
         SRCU(l',a,Misc.app_opt (V.simplify_var soln) vo)
-    | Fence _|TooFar _ -> a
+    | Fence _|CutOff _ -> a
 
 (*************************************************************)
 (* Add together event structures from different instructions *)
@@ -401,5 +401,5 @@ end = struct
   | SRCU(_,a,_)
     -> List.exists (fun a -> Misc.string_eq str a) a
   | Access (_, _, _, MO _,_,_)|Fence (MO _)|RMW (_, _, _, _,_)
-  | Lock _|Unlock _|TryLock _|ReadLock _|TooFar _ -> false
+  | Lock _|Unlock _|TryLock _|ReadLock _|CutOff _ -> false
 end

--- a/herd/CSem.ml
+++ b/herd/CSem.ml
@@ -73,7 +73,7 @@ module
       let no_mo = MOorAN.AN []
       let mo_as_anmo mo = MOorAN.MO mo
 
-      let mk_toofar msg ii = M.mk_singleton_es (Act.TooFar msg) ii
+      let mk_cutoff msg ii = M.mk_singleton_es (Act.CutOff msg) ii
 
       let read_loc is_data mo =
         M.read_loc is_data (fun loc v -> Act.Access (Dir.R, loc, v, mo, false, nat_sz))
@@ -412,7 +412,7 @@ module
                 M.unitT (ii.A.program_order_index, next0)
               and then_branch =
                 if n >= unroll then
-                  mk_toofar "While" ii >>= fun () -> M.unitT (ii.A.program_order_index, B.Exit)
+                  mk_cutoff "While" ii >>= fun () -> M.unitT (ii.A.program_order_index, B.Exit)
                 else
                   build_semantics test
                     {ii with A.inst = t} >>> fun (prog_order, _branch) ->

--- a/herd/action.mli
+++ b/herd/action.mli
@@ -98,8 +98,8 @@ module type S = sig
   val is_commit : action -> bool
 
 (* Unrolling control *)
-  val toofar : string -> action
-  val is_toofar : action -> bool
+  val cutoff : string -> action
+  val is_cutoff : action -> bool
 
 (********************)
 (* Equation solving *)

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -137,7 +137,7 @@ val same_instance : event -> event -> bool
   val is_commit : event -> bool
 
 (* Too much unrolling *)
-  val is_toofar : event -> bool
+  val is_cutoff : event -> bool
 
 (**************)
 (* Event sets *)
@@ -721,7 +721,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
     let is_commit e = Act.is_commit e.action
 
 (*  Unrolling control *)
-    let is_toofar e = Act.is_toofar e.action
+    let is_cutoff e = Act.is_cutoff e.action
 
 (******************************)
 (* Build structures of events *)

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -1711,8 +1711,8 @@ Monad type:
 
     let eqT : V.v -> V.v -> unit t = assign
 
-    let tooFar msg ii v =
-      forceT v (mk_singleton_es (E.Act.toofar msg) ii)
+    let cutoffT msg ii v =
+      forceT v (mk_singleton_es (E.Act.cutoff msg) ii)
 
     type evt_struct = E.event_structure
     type output = VC.cnstrnts * evt_struct

--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -189,3 +189,10 @@ let CMODX-unordered-conflicts =
   CMODX-conflicts \ (CMODX-ordering | CMODX-ordering^-1)
 
 flag ~empty CMODX-unordered-conflicts as violates-CMODX-requirements
+
+(*** Liveness check, work in progres ***)
+
+let W-DSB = W & domain(po;[dsb.full])
+
+let fr-cutoff  = ([domain(fre;[W-DSB])];po;[CutOff])\((fre;[W-DSB];rfe)&po;po)
+empty fr-cutoff as liveness

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -546,7 +546,7 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
             let m ii =
               EM.addT
                 (A.next_po_index ii.A.program_order_index)
-                (EM.tooFar (tgt2lbl tgt) ii (S.B.Next [])) in
+                (EM.cutoffT (tgt2lbl tgt) ii (S.B.Next [])) in
             wrap
               re_exec tgt_proc proc inst addr env m >>> fun _ -> EM.unitcodeT true
         | No (_,[]) -> assert false (* Backward jump cannot be to end of code *)

--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -256,7 +256,7 @@ module type S =
 
     val altT : 'a t -> 'a t -> 'a t
 
-    val tooFar : string -> E.A.inst_instance_id -> 'v -> 'v t
+    val cutoffT : string -> E.A.inst_instance_id -> 'v -> 'v t
 
     val debugT : string -> 'a t -> 'a t
     (** [debugT str s] prints [str] followed by a string

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -192,7 +192,7 @@ type concrete =
   val tgt2tgt : A.inst_instance_id -> BranchTarget.t -> B.tgt
   val tgt2offset : A.inst_instance_id -> BranchTarget.t -> int
 
-  val gone_toofar : concrete -> bool
+  val exists_cutoff : concrete -> bool
 
 (************)
 (* Barriers *)
@@ -492,8 +492,8 @@ type concrete =
            with Not_found -> assert false in
          b-ii.A.addr
 
-    let gone_toofar { str; _ } =
-      try E.EventSet.exists E.is_toofar str.E.events
+    let exists_cutoff { str; _ } =
+      try E.EventSet.exists E.is_cutoff str.E.events
       with Exit -> false
 
 (************)

--- a/herd/tests/instructions/AArch64.kvm/A018.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A018.litmus.expected
@@ -1,7 +1,7 @@
 Test A018 Required
 States 1
 0:X0=1;
-Ok
+Loop Ok
 Witnesses
 Positive: 1 Negative: 0
 Flag Assuming-common-inner-shareable-domain

--- a/herd/tests/instructions/AArch64.kvm/A018.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.kvm/A018.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.kvm/A018.litmus", unrolling limit exceeded, legal outcomes may be missing.

--- a/herd/tests/instructions/AArch64.kvm/A019.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A019.litmus
@@ -1,0 +1,17 @@
+AArch64 A019
+variant=cutoff
+
+{
+  int x;
+  0:X1=(valid:0,oa:PA(x)); 0:X0=PTE(x);
+  0:X2=x; 1:X0=x;
+}
+
+  P0              | P1          ;
+                  |L0:          ;
+  STR X1,[X0]     | LDR W1,[X0] ;
+  DSB ISHST       | CBZ W1,L0   ;
+  LSR X9,X2,#12   |             ;
+  TLBI VAAE1IS,X9 |             ;
+
+exists ~fault(P1:L0,x,MMU:Translation)

--- a/herd/tests/instructions/AArch64.kvm/A019.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A019.litmus.expected
@@ -1,0 +1,12 @@
+Test A019 Allowed
+States 2
+  ~Fault(P1:L0,x,MMU:Translation);
+ Fault(P1:L0,x,MMU:Translation);
+Loop Ok
+Witnesses
+Positive: 1 Negative: 3
+Flag Assuming-common-inner-shareable-domain
+Condition exists (not (fault(P1:L0,x,MMU:Translation)))
+Observation A019 Sometimes 1 3
+Hash=a9ef472ee3000422afc790d72541b72c
+

--- a/herd/tests/instructions/AArch64.kvm/A019.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.kvm/A019.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.kvm/A019.litmus", unrolling limit exceeded, legal outcomes may be missing.

--- a/herd/tests/instructions/AArch64.kvm/A020.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A020.litmus
@@ -1,0 +1,17 @@
+AArch64 A020
+variant=cutoff
+
+{
+  int x;
+  0:X1=(valid:0,oa:PA(x)); 0:X0=PTE(x);
+  0:X2=x; 1:X0=x;
+}
+
+  P0              | P1          ;
+                  |L0:          ;
+  STR X1,[X0]     | LDR W1,[X0] ;
+  DSB ISHST       | CBZ W1,L0   ;
+  LSR X9,X2,#12   |             ;
+  TLBI VAAE1IS,X9 |             ;
+  DSB ISH         |             ;
+forall (fault(P1:L0,x,MMU:Translation))

--- a/herd/tests/instructions/AArch64.kvm/A020.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A020.litmus.expected
@@ -1,0 +1,11 @@
+Test A020 Required
+States 1
+ Fault(P1:L0,x,MMU:Translation);
+Loop Ok
+Witnesses
+Positive: 6 Negative: 0
+Flag Assuming-common-inner-shareable-domain
+Condition forall (fault(P1:L0,x,MMU:Translation))
+Observation A020 Always 6 0
+Hash=f914ca7a6bb4273336da2761313b6352
+

--- a/herd/tests/instructions/AArch64.kvm/A020.litmus.expected-warn
+++ b/herd/tests/instructions/AArch64.kvm/A020.litmus.expected-warn
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.kvm/A020.litmus", unrolling limit exceeded, legal outcomes may be missing.

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -47,7 +47,7 @@ type t =
   | MemTag
   | MTEPrecision of Precision.t (* MTE tag mismatch handling *)
   | FaultHandling of Fault.Handling.t (* Fault handling *)
-  | TooFar
+  | CutOff
   | Morello
   | Neon
   | SVE (* Specify SVE *)
@@ -115,7 +115,7 @@ let tags =
    "fullscdepend";"splittedrmw";"switchdepscwrite";"switchdepscresult";"lrscdiffok";
    "mixed";"dontcheckmixed";"weakpredicated"; "lkmmv1"; "lkmmv2"; "memtag";"vmsa";"kvm";]@
     Precision.tags @ Fault.Handling.tags @
-   ["toofar"; "deps"; "morello"; "instances"; "noptebranch"; "pte2";
+   ["CutOff"; "deps"; "morello"; "instances"; "noptebranch"; "pte2";
    "pte-squared"; "PhantomOnLoad"; "OptRfRMW"; "ConstrainedUnpredictable";
     "exp"; "self"; "cos-opt"; "test"; "T[0-9][0-9]"; "asl"; "strict";
     "warn"; "S128"; "ASLType+Warn";    "ASLType+Silence"; "ASLType+Check";
@@ -140,7 +140,7 @@ let parse s = match Misc.lowercase s with
 | "lkmmv1" -> Some (LKMMVersion `lkmmv1)
 | "lkmmv2" -> Some (LKMMVersion `lkmmv2)
 | "tagmem"|"memtag"|"mte" -> Some MemTag
-| "toofar" -> Some TooFar
+| "cutoff" -> Some CutOff
 | "morello" -> Some Morello
 | "neon" -> Some Neon
 | "sve" -> Some SVE
@@ -238,7 +238,7 @@ let pp = function
   | MemTag -> "memtag"
   | MTEPrecision p -> Precision.pp p
   | FaultHandling p -> Fault.Handling.pp p
-  | TooFar -> "TooFar"
+  | CutOff -> "CutOff"
   | Morello -> "Morello"
   | Neon -> "Neon"
   | SVE -> "sve"

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -45,7 +45,7 @@ type t =
   | MemTag           (* Memory Tagging, synonym of MTE *)
   | MTEPrecision of Precision.t (* MTE tag mismatch handling *)
   | FaultHandling of Fault.Handling.t (* Fault handling *)
-  | TooFar         (* Do not discard candidates with TooFar events *)
+  | CutOff
   | Morello
   | Neon
   | SVE (* Specify SVE *)


### PR DESCRIPTION
Intuitively, this "liveness" property is that a read cannot indefinitely read from a non-final write. Our formulation involves 'pruned' executions and requires that, for all locations x the last read of x in a pruned po is from the final write to x.

Our implementation builds on the "CutOff" (ex "TooFar") feature. Namely, for the sake of avoiding infinite or excessive running times, some executions are pruned, resulting in execution prefixes. Those are normally discarded, unless `-variant CutOff` is specified. In those executions, pruned `po` relation end with a specific `CutOff` effect.

The liveness condition applies to those execution prefixes. The condition will reject executions for which there exists
some `fr` source in a pruned po that is not followed by a `rf` target:

That is, given
```
      +-fr->W
      |
      |
      R ----po---> CutOff
```
there does not exists a rf s.t.
 ```
      +-fr->W-rf-+
      |          |
      |         \ /
      R ----po---R-----> CutOff
```
Notice that this "liveness" condition applies to writes that are followed by a DSB effect (_i.e._ stores followed by a DSB fence instruction).
