### PR TITLE
[asl] Refine constant types at declarations

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -2113,8 +2113,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     | LDI_Typed (ldi', t) ->
         let t' = annotate_type ~loc env t in
         let+ () = check_can_be_initialized_with loc env t' ty in
+        let t'' = match ldk with LDK_Constant -> ty | _ -> t' in
         let new_env, new_ldi' =
-          annotate_local_decl_item loc env t' ldk ?e ldi'
+          annotate_local_decl_item loc env t'' ldk ?e ldi'
         in
         (new_env, LDI_Typed (new_ldi', t')) |: TypingRule.LDTyped
     (* End *)

--- a/asllib/tests/regressions.t/refine-constant-types.asl
+++ b/asllib/tests/regressions.t/refine-constant-types.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    constant a: integer = 3;
+    constant b: integer = 2;
+    constant c: integer = (a DIV b);
+    return 0;
+end

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -33,6 +33,14 @@ Type-checking errors:
 
   $ aslref constant-zeros.asl
 
+  $ aslref refine-constant-types.asl
+  File refine-constant-types.asl, line 5, characters 27 to 34: All values in
+  constraints {(3 DIV 2)} would fail with op DIV, operation will always fail.
+  File refine-constant-types.asl, line 5, characters 27 to 34:
+  ASL Typing error: Illegal application of operator DIV on types integer {3}
+    and integer {2}
+  [1]
+
 Bad types:
   $ aslref overlapping-slices.asl
   File overlapping-slices.asl, line 1, character 0 to line 4, character 2:


### PR DESCRIPTION
Ignore type annotations for constants if a more precise type can be infered. This makes constants really behave like their inlining.

For example, the following test should be rejected statically:
```
func main() => integer
begin
    constant a: integer = 3;
    constant b: integer = 2;
    constant c: integer = (a DIV b);
    return 0;
end
```