### PR TITLE
[herd] Unroll metadata

### DIFF
--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -50,6 +50,16 @@ module Top (TopConf:RunTest.Config) = struct
           end)
       (* Override *)
       include TopConf
+      let unroll =
+        Option.map
+          (fun s ->
+             try int_of_string s
+             with Failure _ ->
+               Warn.user_error "unroll exects an integer argument")
+          (MiscParser.get_info_on_info MiscParser.unroll_key
+             splitted.Splitter.info)
+        |>
+        (function | None -> unroll | Some _ as o -> o)
       let fault_handling = TestConf.fault_handling
       let mte_precision = TestConf.mte_precision
       let sve_vector_length = TestConf.sve_vector_length

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -227,6 +227,7 @@ and user_key = "user"
 and el0_key = "el0"
 and memory_type_key = "MemoryType"
 and mt_key = "MT"
+and unroll_key = "Unroll"
 
 let key_match k1 k2 =
   let len1 = String.length k1 in

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -125,7 +125,7 @@ val user_key : string
 val el0_key : string
 val memory_type_key : string
 val mt_key : string
-
+val unroll_key : string
 val key_match : string -> string -> bool
 
 (* Meta-data included in digest ? *)


### PR DESCRIPTION
Implement `Unroll=<int>` metadata in test source. As usual, this in-test specification has the highest precedence.