### PR TITLE
[asl] Renamed terms for more clarity

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -167,7 +167,7 @@ and slice =
 (** Type descriptors.*)
 and type_desc =
   (* Begin Constrained *)
-  | T_Int of int_constraints
+  | T_Int of constraint_kind
   | T_Bits of expr * bitfield list
   (* End Constrained *)
   | T_Real
@@ -187,16 +187,16 @@ and int_constraint =
   | Constraint_Exact of expr
       (** Exactly this value, as given by a statically evaluable expression. *)
   | Constraint_Range of (expr * expr)
-      (** In the range of these two statically evaluable values.*)
+      (** In the inclusive range of these two statically evaluable values. *)
 
-(** The int_constraints constraints the integer type to a certain subset.*)
-and int_constraints =
+(** The constraint_kind constrains an integer type to a certain subset. *)
+and constraint_kind =
   | UnConstrained  (** The normal, unconstrained, integer type. *)
   | WellConstrained of int_constraint list
       (** An integer type constrained from ASL syntax: it is the union of each
           constraint in the list. *)
   | Parameterized of uid * identifier
-      (** An under-constrained integer, the default type for parameters of
+      (** A parameterized integer, the default type for parameters of
           function at compile time, with a unique identifier and the variable
           bearing its name. *)
 

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -180,7 +180,7 @@ val is_global_ignored : identifier -> bool
 (** [is_global_ignored s] is true iff [s] has been created with [global_ignored ()]. *)
 
 val constraint_binop :
-  binop -> int_constraint list -> int_constraint list -> int_constraints
+  binop -> int_constraint list -> int_constraint list -> constraint_kind
 (** [constraint_binop PLUS cs1 cs2] is the set of constraints given by the
     element wise application of [PLUS]. *)
 

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -337,8 +337,8 @@ let colon_for_type == COLON | COLON_COLON
 
 (* Constrained types helpers *)
 
-let int_constraints_opt == int_constraints | { UnConstrained }
-let int_constraints == ~=braced(nclist(int_constraint)); < WellConstrained >
+let int_constraints_opt == constraint_kind | { UnConstrained }
+let constraint_kind == ~=braced(nclist(int_constraint)); < WellConstrained >
 
 let int_constraint ==
   | ~=expr;                     < Constraint_Exact >
@@ -414,7 +414,7 @@ let typed_identifier == pair(IDENTIFIER, as_ty)
 (* End *)
 
 let ty_opt == ioption(as_ty)
-let implicit_t_int == annotated ( ~=int_constraints ; <T_Int> )
+let implicit_t_int == annotated ( ~=constraint_kind ; <T_Int> )
 
 
 (* ------------------------------------------------------------------------

--- a/asllib/StaticEnv.ml
+++ b/asllib/StaticEnv.ml
@@ -29,7 +29,7 @@ type global = {
   storage_types : (ty * global_decl_keyword) IMap.t;
   subtypes : identifier IMap.t;
   subprograms : AST.func IMap.t;
-  subprogram_renamings : ISet.t IMap.t;
+  overloaded_subprograms : ISet.t IMap.t;
   expr_equiv : expr IMap.t;
 }
 
@@ -82,18 +82,18 @@ module PPEnv = struct
         declared_types;
         subtypes;
         subprograms;
-        subprogram_renamings;
+        overloaded_subprograms;
         expr_equiv;
       } =
     fprintf f
       "@[<v 2>Global with:@ - @[constants:@ %a@]@ - @[storage:@ %a@]@ - \
        @[types:@ %a@]@ - @[subtypes:@ %a@]@ - @[subprograms:@ %a@]@ - \
-       @[subprogram_renamings:@ %a@]@ - @[expr equiv:@ %a@]@]"
+       @[overloaded_subprograms:@ %a@]@ - @[expr equiv:@ %a@]@]"
       (pp_map PP.pp_literal) constant_values
       (pp_map (fun f (t, _) -> PP.pp_ty f t))
       storage_types (pp_map PP.pp_ty) declared_types (pp_map pp_print_string)
       subtypes (pp_map pp_subprogram) subprograms (pp_map pp_iset)
-      subprogram_renamings (pp_map PP.pp_expr) expr_equiv
+      overloaded_subprograms (pp_map PP.pp_expr) expr_equiv
 
   let pp_env f { global; local } =
     fprintf f "@[<v 2>Env with:@ - %a@ - %a@]" pp_local local pp_global global
@@ -111,7 +111,7 @@ let empty_global =
     storage_types = IMap.empty;
     subtypes = IMap.empty;
     subprograms = IMap.empty;
-    subprogram_renamings = IMap.empty;
+    overloaded_subprograms = IMap.empty;
     expr_equiv = IMap.empty;
   }
 
@@ -174,7 +174,8 @@ let set_renamings name set env =
     global =
       {
         env.global with
-        subprogram_renamings = IMap.add name set env.global.subprogram_renamings;
+        overloaded_subprograms =
+          IMap.add name set env.global.overloaded_subprograms;
       };
   }
 

--- a/asllib/StaticEnv.mli
+++ b/asllib/StaticEnv.mli
@@ -35,8 +35,8 @@ type global = {
       (** Maps an identifier s to its parent in the subtype relation. *)
   subprograms : AST.func IMap.t;
       (** Maps each subprogram runtime name to its signature. *)
-  subprogram_renamings : ISet.t IMap.t;
-      (** Maps each subprogram declared name to the equivalence class of all
+  overloaded_subprograms : ISet.t IMap.t;
+      (** Maps the name of each declared subprogram to the equivalence class of all
           the subprogram runtime names that were declared with this name. *)
   expr_equiv : expr IMap.t;
       (** Maps every expression to a reduced immutable form. *)

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -292,7 +292,7 @@ module FunctionRenaming (C : ANNOTATE_CONFIG) = struct
 
   (* Begin AddNewFunc *)
   let add_new_func loc env name formals subpgm_type =
-    match IMap.find_opt name env.global.subprogram_renamings with
+    match IMap.find_opt name env.global.overloaded_subprograms with
     | None ->
         let new_env = set_renamings name (ISet.singleton name) env in
         (new_env, name)
@@ -334,7 +334,7 @@ module FunctionRenaming (C : ANNOTATE_CONFIG) = struct
       if false then Format.eprintf "Trying to rename call to %S@." name
     in
     let renaming_set =
-      try IMap.find name env.global.subprogram_renamings
+      try IMap.find name env.global.overloaded_subprograms
       with Not_found -> undefined_identifier loc name
     in
     let get_func_sig name' =
@@ -383,7 +383,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
 
   (* Begin ShouldReduceToCall *)
   let should_reduce_to_call env name st =
-    match IMap.find_opt name env.global.subprogram_renamings with
+    match IMap.find_opt name env.global.overloaded_subprograms with
     | None -> false
     | Some set ->
         ISet.exists
@@ -2076,15 +2076,15 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
   let can_be_initialized_with env s t =
     (* Rules:
        - ZCVD: It is illegal for a storage element whose type has the
-         structure of the under-constrained integer to be initialized with a
-         value whose type has the structure of the under-constrained integer,
+         structure of the parameterized integer to be initialized with a
+         value whose type has the structure of the parameterized integer,
          unless the type is omitted from the declaration (and therefore the
          type can be unambiguously inferred) or the initialization expression
          is omitted (and therefore the type is not omitted from the
          declaration).
        - LXQZ: A storage element of type S, where S is
          any type that does not have the structure of
-         the under-constrained integer type, may only be
+         the parameterized integer type, may only be
          assigned or initialized with a value of type T
          if T type-satisfies S)
     *)

--- a/asllib/doc/ASLReference.tex
+++ b/asllib/doc/ASLReference.tex
@@ -35,11 +35,6 @@
 \include{notice.tex}
 \include{disclaimer.tex}
 
-% \input{ASLFormal.tex}
-% \input{ASLSyntaxReference.tex}
-% \input{ASLTypingReference.tex}
-% \input{ASLSemanticsReference.tex}
-
 \input{introduction.tex}
 \input{ASLFormal.tex}
 \input{LexicalStructure.tex}
@@ -61,13 +56,11 @@
 \input{BlockStatements.tex}
 \input{CatchingExceptions.tex}
 \input{SubprogramCalls.tex}
-
 \input{GlobalDeclarations.tex}
 \input{GlobalStorageDeclarations.tex}
 \input{TypeDeclarations.tex}
 \input{SubprogramDeclarations.tex}
 \input{Specifications.tex}
-
 \input{StaticEvaluation.tex}
 \input{SymbolicSubsumptionTesting.tex}
 \input{SymbolicEquivalenceTesting.tex}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -510,7 +510,7 @@
 
 \newcommand\ty[0]{\hyperlink{ast-ty}{\textsf{ty}}}
 \newcommand\pattern[0]{\hyperlink{ast-pattern}{\textsf{pattern}}}
-\newcommand\intconstraints[0]{\hyperlink{ast-intconstraints}{\textsf{int\_constraints}}}
+\newcommand\constraintkind[0]{\hyperlink{ast-constraintkind}{\textsf{constraint\_kind}}}
 \newcommand\intconstraint[0]{\hyperlink{ast-intconstraint}{\textsf{int\_constraint}}}
 \newcommand\unconstrained[0]{\hyperlink{ast-unconstrained}{\textsf{Unconstrained}}}
 \newcommand\wellconstrained[0]{\hyperlink{ast-wellconstrained}{\textsf{WellConstrained}}}
@@ -851,7 +851,7 @@
 \newcommand\declaredtypes[0]{\hyperlink{def-declaredtypes}{\textsf{declared\_types}}}
 \newcommand\subtypes[0]{\hyperlink{def-subtypes}{\textsf{subtypes}}}
 \newcommand\subprograms[0]{\hyperlink{def-subprograms}{\textsf{subprograms}}}
-\newcommand\subprogramrenamings[0]{\hyperlink{def-subprogramrenamings}{\textsf{subprogram\_renamings}}}
+\newcommand\overloadedsubprograms[0]{\hyperlink{def-overloadedsubprograms}{\textsf{overloaded\_subprograms}}}
 \newcommand\exprequiv[0]{\hyperlink{def-exprequiv}{\textsf{expr\_equiv}}}
 \newcommand\parameters[0]{\hyperlink{def-parameters}{\textsf{parameters}}}
 

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -273,7 +273,7 @@ as indicated by respective comments.
 
 \hypertarget{ast-ty}{} \hypertarget{ast-tint}{}
 \begin{flalign*}
-\ty \derives\ & \TInt(\intconstraints)
+\ty \derives\ & \TInt(\constraintkind)
 \hypertarget{ast-treal}{}\\
   |\ & \TReal
   & \hypertarget{ast-tstring}{}\\
@@ -299,10 +299,10 @@ as indicated by respective comments.
 
 \subsection{Constraints \label{sec:Constraints}}
 
-\hypertarget{ast-intconstraints}{} \hypertarget{ast-unconstrained}{}
+\hypertarget{ast-constraintkind}{} \hypertarget{ast-unconstrained}{}
 \begin{flalign*}
   % & & \ASTComment{Constraints that may be assigned to integer types.}  \\
-  \intconstraints \derives\ & \unconstrained
+  \constraintkind \derives\ & \unconstrained
   % & & \ASTComment{The unconstrained integer type.}
   & \hypertarget{ast-wellconstrained}{}\\
   |\ & \wellconstrained(\intconstraint^{+})

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -10,7 +10,8 @@ There are four kinds of global declarations:
 \end{itemize}
 
 The typing of global declarations is defined in \secref{GlobalDeclarationsTyping}.
-The semantics of global declarations in defined in \secref{GlobalStorageDeclarationsSemantics}.
+As the only kind of global declarations that are associated with semantics are global storage declarations,
+their semantics is given in \secref{GlobalStorageDeclarationsSemantics}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Syntax}

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -1672,7 +1672,7 @@ The function
   \overname{\intconstraint^*}{\csone} \aslsep
   \overname{\intconstraint^*}{\cstwo}
 ) \aslto \\
-\overname{\intconstraints}{\vics}
+\overname{\constraintkind}{\vics}
 \cup \overname{\TTypeError}{\TypeErrorConfig}
 \end{array}
 \]

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -1809,7 +1809,7 @@ The function
     \overname{\expr}{\vetwop} \aslsep
     \overname{\dir}{\dir}
   ) \aslto
-  \overname{\intconstraints}{\vis} \cup\ \overname{\TTypeError}{\TypeErrorConfig}
+  \overname{\constraintkind}{\vis} \cup\ \overname{\TTypeError}{\TypeErrorConfig}
 \]
 infers the integer constraints for a \texttt{for} loop index variable from the following:
 \begin{itemize}

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1125,14 +1125,14 @@ One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{undefined}):
   \begin{itemize}
-    \item $\tenv$ does not contain a binding for $\name$ in the $\subprogramrenamings$ map
-          ($G^\tenv.\subprogramrenamings$);
+    \item $\tenv$ does not contain a binding for $\name$ in the $\overloadedsubprograms$ map
+          ($G^\tenv.\overloadedsubprograms$);
     \item the result is a type error indicating that the identifier has not been declared (as a subprogram).
   \end{itemize}
 
   \item All of the following apply (\textsc{no\_candidates}):
   \begin{itemize}
-    \item $\tenv$ binds $\name$ via $\subprogramrenamings$ map to $\renamingset$;
+    \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$;
     \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
           in $\tenv$ (see \secref{TypingRule.FilterCallCandidates}) yields an empty set\ProseOrTypeError;
     \item the result is a type error indicating that the call given by $\name$ and \\ $\callerargtypes$
@@ -1141,7 +1141,7 @@ One of the following applies:
 
   \item All of the following apply (\textsc{too\_many\_candidates}):
   \begin{itemize}
-    \item $\tenv$ binds $\name$ via $\subprogramrenamings$ map to $\renamingset$;
+    \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$;
     \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
           in $\tenv$ (see \secref{TypingRule.FilterCallCandidates}) yields $\matchingrenamings$\ProseOrTypeError;
     \item $\matchingrenamings$ contains at least two elements;
@@ -1151,7 +1151,7 @@ One of the following applies:
 
   \item All of the following apply (\textsc{one\_candidate}):
   \begin{itemize}
-    \item $\tenv$ binds $\name$ via $\subprogramrenamings$ map to $\renamingset$;
+    \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$;
     \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
           in $\tenv$ (see \secref{TypingRule.FilterCallCandidates}) yields $\matchingrenamings$\ProseOrTypeError;
     \item $\matchingrenamings$ contains a single element --- $(\matchedname, \funcsig)$;
@@ -1165,7 +1165,7 @@ One of the following applies:
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[undefined]{
-  G^\tenv.\subprogramrenamings(\name) = \bot
+  G^\tenv.\overloadedsubprograms(\name) = \bot
 }{
   \subprogramforname(\tenv, \name, \callerargtypes) \typearrow \TypeErrorVal{\UndefinedIdentifier}
 }
@@ -1173,7 +1173,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[no\_candidates]{
-  G^\tenv.\subprogramrenamings(\name) = \renamingset\\
+  G^\tenv.\overloadedsubprograms(\name) = \renamingset\\
   {
     \begin{array}{r}
       \filtercallcandidates(\tenv, \callerargtypes, \renamingset) \typearrow \emptyset \OrTypeError
@@ -1186,7 +1186,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[too\_many\_candidates]{
-  G^\tenv.\subprogramrenamings(\name) = \renamingset\\
+  G^\tenv.\overloadedsubprograms(\name) = \renamingset\\
   {
     \begin{array}{r}
       \filtercallcandidates(\tenv, \callerargtypes, \renamingset) \typearrow \\ \matchingrenamings \OrTypeError
@@ -1200,7 +1200,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[one\_candidate]{
-  G^\tenv.\subprogramrenamings(\name) = \renamingset\\
+  G^\tenv.\overloadedsubprograms(\name) = \renamingset\\
   {
     \begin{array}{r}
       \filtercallcandidates(\tenv, \callerargtypes, \renamingset) \typearrow \\ \matchingrenamings \OrTypeError

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -1420,14 +1420,14 @@ One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{first\_name}):
   \begin{itemize}
-    \item the $\subprogramrenamings$ map in the global environment of $\tenv$ does not have a binding for $\name$;
-    \item $\newtenv$ is $\tenv$ with the $\subprogramrenamings$ updated by binding $\name$ to the singleton set containing
+    \item the $\overloadedsubprograms$ map in the global environment of $\tenv$ does not have a binding for $\name$;
+    \item $\newtenv$ is $\tenv$ with the $\overloadedsubprograms$ updated by binding $\name$ to the singleton set containing
           $\name$.
   \end{itemize}
 
   \item All of the following apply (\textsc{name\_exists}):
   \begin{itemize}
-    \item the $\subprogramrenamings$ map in the global environment of $\tenv$ binds $\name$ to the set of strings $\othernames$;
+    \item the $\overloadedsubprograms$ map in the global environment of $\tenv$ binds $\name$ to the set of strings $\othernames$;
     \item $\newname$ is the unique name that will be associated with the subprogram given by the identifier $\name$, list of formals $\formals$,
           and subprogram type $\subpgmtype$. It is constructed by concatenating a hyphen (\texttt{-}) to $\name$, followed
           by a string corresponding to the number of strings in $\othernames$.
@@ -1437,7 +1437,7 @@ One of the following applies:
     \item checking for each $\namep$ in $\othernames$ whether the subprogram associated with $\namep$ clashes
           with the subprogram type $\subpgmtype$ and list of types $\formaltypes$ yields $\False$
           or a type error that indicates there are multiply defined subprograms, which short-circuits the entire rule;
-    \item $\newtenv$ is $\tenv$ with the $\subprogramrenamings$ updated by binding $\name$ to the union of $\othernames$ and
+    \item $\newtenv$ is $\tenv$ with the $\overloadedsubprograms$ updated by binding $\name$ to the union of $\othernames$ and
           $\{\newname\}$.
   \end{itemize}
 \end{itemize}
@@ -1458,8 +1458,8 @@ to the corresponding string.
 
 \begin{mathpar}
 \inferrule[first\_name]{
-  G^\tenv.\subprogramrenamings(\name) = \bot\\
-  \newtenv \eqdef (G^\tenv.\subprogramrenamings[\name\mapsto\{\name\}],  L^\tenv)
+  G^\tenv.\overloadedsubprograms(\name) = \bot\\
+  \newtenv \eqdef (G^\tenv.\overloadedsubprograms[\name\mapsto\{\name\}],  L^\tenv)
 }{
   \addnewfunc(\tenv, \name, \formals, \subpgmtype) \typearrow
   (\newtenv, \overname{\name}{\newname})
@@ -1468,7 +1468,7 @@ to the corresponding string.
 
 \begin{mathpar}
 \inferrule[name\_exists]{
-  G^\tenv.\subprogramrenamings(\name) = \othernames\\
+  G^\tenv.\overloadedsubprograms(\name) = \othernames\\
   k \eqdef \cardinality{\othernames}\\
   \newname \eqdef \name\ \stringconcat\ \texttt{"-"}\ \stringconcat\ \stringofint(k)\\
   \formaltypes \eqdef [(\id,\vt) \in \formals : \vt]\\
@@ -1479,7 +1479,7 @@ to the corresponding string.
     \end{array}\right)
   }\\\\
   \namep \in \othernames: \checktrans{\neg\vb_{\namep}}{\SubrogramDeclaredMultipleTimes} \typearrow \True \OrTypeError\\\\
-  \newtenv \eqdef (G^\tenv.\subprogramrenamings[\name\mapsto \othernames \cup \{\newname\}],  L^\tenv)
+  \newtenv \eqdef (G^\tenv.\overloadedsubprograms[\name\mapsto \othernames \cup \{\newname\}],  L^\tenv)
 }{
   \addnewfunc(\tenv, \name, \formals, \subpgmtype) \typearrow
   (\newtenv, \newname)

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -344,9 +344,9 @@ The function
 \[
 \reduceconstraints(
   \overname{\staticenvs}{\tenv} \aslsep
-  \overname{\intconstraints}{\vc}
+  \overname{\constraintkind}{\vc}
 ) \aslto
-\overname{\intconstraints}{\newc}
+\overname{\constraintkind}{\newc}
 \]
 \symbolicallysimplifies\ an integer constraints AST node $\vc$, yielding the integer constraints AST node $\newc$
 

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -887,7 +887,7 @@ The function
   \overname{\intconstraint^*}{\csone} \aslsep
   \overname{\intconstraint^*}{\cstwo}
 )
-\aslto \overname{\intconstraints}{\vics}
+\aslto \overname{\constraintkind}{\vics}
 \]
 symbolically applies the binary operation $\op$ to the lists of integer constraints $\csone$ and $\cstwo$,
 yielding the integer constraints $\vics$.

--- a/asllib/doc/TypeChecking.tex
+++ b/asllib/doc/TypeChecking.tex
@@ -50,7 +50,7 @@ Static environments, denoted as $\staticenvs$, are defined as follows (referring
   \exprequiv            &\mapsto& \identifier \partialto \expr,\\
   \subtypes             &\mapsto& \identifier \partialto \identifier,\\
   \subprograms          &\mapsto& \identifier \partialto \func,\\
-  \subprogramrenamings  &\mapsto& \identifier \rightarrow \pow{\Strings}
+  \overloadedsubprograms  &\mapsto& \identifier \rightarrow \pow{\Strings}
 \end{array}
 \right]\\
 \hypertarget{def-localstaticenvs}{}\\
@@ -95,8 +95,8 @@ The intuitive meaning of each component is as follows:
   \hypertarget{def-subprograms}{}
   \item $\subprograms$ associates names of subprograms to the $\func$ AST node they were
   declared with;
-  \hypertarget{def-subprogramrenamings}{}
-  \item $\subprogramrenamings$ associates names of subprograms to the set of overloading
+  \hypertarget{def-overloadedsubprograms}{}
+  \item $\overloadedsubprograms$ associates names of subprograms to the set of overloading
   subprograms ---  $\func$ AST nodes that share the same name;
   \hypertarget{def-returntype}{}
   \item $\returntype$ contains the name of the type that a subprogram declares, if it is
@@ -117,7 +117,7 @@ The \emph{empty static environment}, \\ denoted as $\emptytenv$, is defined as f
   \exprequiv            &\mapsto& \emptyfunc,\\
   \subtypes             &\mapsto& \emptyfunc,\\
   \subprograms          &\mapsto& \emptyfunc,\\
-  \subprogramrenamings  &\mapsto& \emptyfunc
+  \overloadedsubprograms  &\mapsto& \emptyfunc
 \end{array}
 \right]}{\globalstaticenvs},
 \overname{

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -82,8 +82,8 @@ expressions and statements.
 
 \subsection{Abstract Syntax\label{sec:IntegerTypesAST}}
 \begin{flalign*}
-\ty \derives\ & \TInt(\intconstraints)\\
-\intconstraints \derives\ & \unconstrained
+\ty \derives\ & \TInt(\constraintkind)\\
+\constraintkind \derives\ & \unconstrained
 & \\
 |\ & \wellconstrained(\intconstraint^{+})
 & \\
@@ -105,7 +105,7 @@ expressions and statements.
 \hypertarget{build-intconstraintsopt}{}
 The function
 \[
-  \buildintconstraintsopt(\overname{\parsenode{\Nintconstraintsopt}}{\vparsednode}) \;\aslto\; \overname{\intconstraints}{\vastnode}
+  \buildintconstraintsopt(\overname{\parsenode{\Nintconstraintsopt}}{\vparsednode}) \;\aslto\; \overname{\constraintkind}{\vastnode}
 \]
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
@@ -131,7 +131,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \hypertarget{build-intconstraints}{}
 The function
 \[
-  \buildintconstraints(\overname{\parsenode{\Nintconstraints}}{\vparsednode}) \;\aslto\; \overname{\intconstraints}{\vastnode}
+  \buildintconstraints(\overname{\parsenode{\Nintconstraints}}{\vparsednode}) \;\aslto\; \overname{\constraintkind}{\vastnode}
 \]
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 

--- a/asllib/tests/regressions.t/more-assignments-examples.asl
+++ b/asllib/tests/regressions.t/more-assignments-examples.asl
@@ -1,6 +1,6 @@
 func assignBits {N:integer, M: integer} (someWid: integer {32,64}, argN: bits(N), argM: bits(M))
 begin
-  // argN and argM are immutable under-constrained width bitvectors
+  // argN and argM are immutable parameterized width bitvectors
   // assignments to them are illegal
   // legal since widths and domains match
   var eightBits: bits(8) = Zeros(8);
@@ -10,7 +10,7 @@ begin
   // declaration of someWid
   // var someBits: bits({32,64}) = Zeros(someWid);
 
-  // underconstrainedBits is a mutable under-constrained width bitvector
+  // underconstrainedBits is a mutable parameterized width bitvector
   // it can be assigned to
   var underconstrainedBits: bits(N);
 

--- a/asllib/tests/regressions.t/more-invocation-examples.asl
+++ b/asllib/tests/regressions.t/more-invocation-examples.asl
@@ -1,7 +1,7 @@
 func bus {wid: integer} (arg0: bits(wid), arg1: bits(wid*2)) => bits(wid)
 begin
     // When type-checking the declaration of func bus
-// arg0 and arg1 are under-constrained width bitvectors
+// arg0 and arg1 are parameterized width bitvectors
 // of determined width `wid`
 // Since wid is not a formal, it takes its value in an invocation from
 // the width of one of the the corresponding actuals
@@ -10,7 +10,7 @@ end
 
 // ------------------------------------------------------------
 // Cases for invocation of function `bus`
-// which has an under-constrained width bitvector formal
+// which has a parameterized width bitvector formal
 func legal_fun_fixed_width_actual () => bits(8)
 begin
   let x: bits(8)  = Zeros(8);
@@ -25,11 +25,11 @@ end
 
 func legal_fun_underconstrained_actual (N: integer) => bits(N)
 begin
-  // N is a parameter, therefore it is an under-constrained integer
+  // N is a parameter, therefore it is a parameterized integer
   var x: bits(N);
   var y: bits(N*2);
   // bus's wid parameter takes its value from the width of x
-  // which is `N` which is an under-constrained integer
+  // which is `N` which is a parameterized integer
   // Therefore the type of arg0 with the invocation width `N` is
   // the under-constrained width bitvector of determined width `N`
   // which is type satisfied by x

--- a/asllib/tests/typing.t/CPositive9.asl
+++ b/asllib/tests/typing.t/CPositive9.asl
@@ -1,4 +1,4 @@
-// Can use an under-constrained integer as a bitvector width in a subprogram body
+// Can use a parameterized integer as a bitvector width in a subprogram body
 func positive9{N}(x: bits(N)) => bits(N + N DIV 2)
 begin
     let y: bits(N) = Zeros(N);


### PR DESCRIPTION
After receiving feedback on names and confusing terms, I'm going with the following renaming:
- (StaticEnv.global) Renamed `subprogram_renamings` to `overloaded_subprograms`.
- (AST) Renamed `int_constraints` to `constraint_kind`, which is more accurate and avoids confusion with `int_constraint`.