### PR TITLE
[asl][reference] Fix LaTeX error on having \notbool defined twice

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1177,7 +1177,7 @@
 \newcommand\unopsignatures[0]{\hyperlink{def-unopsignatures}{\textfunc{unop\_signatures}}}
 \newcommand\binopsignatures[0]{\hyperlink{def-binopsignatures}{\textfunc{binop\_signatures}}}
 
-\newcommand\notbool[0]{\hyperlink{def-notbool}{\text{not\_bool}}}
+\renewcommand\notbool[0]{\hyperlink{def-notbool}{\text{not\_bool}}}
 \newcommand\andbool[0]{\hyperlink{def-andbool}{\text{and\_bool}}}
 \newcommand\orbool[0]{\hyperlink{def-orbool}{\text{or\_bool}}}
 \newcommand\eqbool[0]{\hyperlink{def-eqbool}{\text{eq\_bool}}}


### PR DESCRIPTION
I'm not sure which package define this macro and 
```
% latexdef --find \notbool

\notbool:
undefined
```
I'm therefore `\renewcommand`ing this to force LaTeX to accept it.