### PR TITLE
[asl][reference] fix bug to enable making the ASL Reference

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1177,7 +1177,7 @@
 \newcommand\unopsignatures[0]{\hyperlink{def-unopsignatures}{\textfunc{unop\_signatures}}}
 \newcommand\binopsignatures[0]{\hyperlink{def-binopsignatures}{\textfunc{binop\_signatures}}}
 
-\renewcommand\notbool[0]{\hyperlink{def-notbool}{\text{not\_bool}}}
+\newcommand\aslnotbool[0]{\hyperlink{def-notbool}{\text{not\_bool}}}
 \newcommand\andbool[0]{\hyperlink{def-andbool}{\text{and\_bool}}}
 \newcommand\orbool[0]{\hyperlink{def-orbool}{\text{or\_bool}}}
 \newcommand\eqbool[0]{\hyperlink{def-eqbool}{\text{eq\_bool}}}

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -28,7 +28,7 @@ as well as a unique name.
 \hline
 \textbf{Operator} & \textbf{Operand 1} & \textbf{Operand 2} & \textbf{Result} & \textbf{Name}\\
 \hline
-\Tbnot & \lbool & -        & \lbool & \notbool\\
+\Tbnot & \lbool & -        & \lbool & \aslnotbool\\
 \Tband & \lbool & \lbool  & \lbool & \andbool\\
 \Tbor & \lbool & \lbool  & \lbool & \orbool\\
 \Teqop & \lbool & \lbool  & \lbool & \eqbool\\


### PR DESCRIPTION
The fix in #1009 didn't work for all configurations.
 \notbool is defined in some configurations and not others so I'm renaming to \aslnotbool.