### PR TITLE
[asl] Add types to local/global storage elements when given --print-typed

### DIFF
--- a/asllib/Typing.mli
+++ b/asllib/Typing.mli
@@ -31,6 +31,7 @@ type strictness = [ `Silence | `Warn | `TypeCheck ]
 module type ANNOTATE_CONFIG = sig
   val check : strictness
   val output_format : Error.output_format
+  val print_typed : bool
 end
 
 module type S = sig

--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -208,6 +208,7 @@ let () =
     let module C = struct
       let output_format = args.output_format
       let check = args.strictness
+      let print_typed = args.print_typed
     end in
     let module T = Typing.Annotate (C) in
     or_exit @@ fun () -> T.type_check_ast ast

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -343,23 +343,21 @@ One of the following applies:
     \item annotating the right-hand-side expression $\ve$ in $\tenv$ yields $(\vte,\vep)$\ProseOrTypeError;
     \item annotating the local declaration item $\ldi$ with local declaration keyword $\ldk$, the type $\vte$,
           and the initializing expression $\vep$, in $\tenv$
-          yields $(\tenvone, \ldip)$;
+          yields $(\tenvone, \ldione)$;
     \item One of the following applies:
     \begin{itemize}
       \item All of the following apply (\textsc{constant}):
       \begin{itemize}
         \item $\ldk$ indicates a local constant declaration, that is, $\LDKConstant$;
         \item symbolically simplifying $\ve$ in $\tenvone$ yields the literal $\vv$\ProseOrTypeError;
-        \item declaring a local constant of type $\vte$, literal $\vv$ and identifier $\ldi$ in $\tenvone$ yields $(\newtenv, \ldip)$;
-        \item $\news$ is a declaration with $\ldk$, $\ldip$ and an expression $\vep$.
+        \item declaring a local constant of type $\vte$, literal $\vv$ and local declaration item $\ldione$ in $\tenvone$ yields $\newtenv$;
+        \item $\news$ is a declaration with $\ldk$, $\ldione$ and an expression $\vep$.
       \end{itemize}
 
       \item All of the following apply (\textsc{non\_constant}):
       \begin{itemize}
         \item $\ldk$ indicates that this is not a local constant declaration, that is, $\ldk\neq\LDKConstant$;
-        \item declaring the local identifiers $\ldi$ of type $\vte$ with local declaration keyword $\ldk$ in $\tenv$
-              yields $(\newtenv, \ldip)$;
-        \item $\news$ is a declaration with $\ldk$, $\ldip$ and an expression $\vep$;
+        \item $\news$ is a declaration with $\ldk$, $\ldione$ and an expression $\vep$;
         \item $\newtenv$ is $\tenvone$.
       \end{itemize}
     \end{itemize}
@@ -371,21 +369,21 @@ One of the following applies:
         that is, $\SDecl(\LDKVar, \ldi, \None)$ (local declarations of \texttt{let} variables and constants require
         an initializing expression, otherwise they are rejected by an ASL parser);
   \item annotating the uninitialised local declarations $\ldi$ in $\tenv$ yields \\
-        $(\newtenv, \ldip)$;
-  \item $\news$ is a local declaration statement with variable keyword, local identifiers $\ldip$, and no initial expression,
-        that is, $\SDecl(\LDKVar, \ldip, \None)$.
+        $(\newtenv, \ldione)$;
+  \item $\news$ is a local declaration statement with variable keyword, local identifiers $\ldione$, and no initial expression,
+        that is, $\SDecl(\LDKVar, \ldione, \None)$.
   \end{itemize}
 \end{itemize}
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[constant]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
-  \annotatelocaldeclitem{\tenv, \vte, \ldk, \vep, \ldi} \typearrow (\tenvone, \ldip)\\\\
+  \annotatelocaldeclitem{\tenv, \vte, \ldk, \langle\vep\rangle, \ldi} \typearrow (\tenvone, \ldione)\\\\
   \commonprefixline\\\\
   \ldk = \LDKConstant\\
   \reduceconstants(\tenvone, \ve) \typearrow \vv \OrTypeError\\\\
-  \declarelocalconstant(\tenvone, \vv, \ldi) \typearrow \newtenv\\
-  \news \eqdef \SDecl(\LDKConstant, \ldip, \langle\vep\rangle)
+  \declarelocalconstant(\tenvone, \vv, \ldione) \typearrow \newtenv\\
+  \news \eqdef \SDecl(\LDKConstant, \ldione, \langle\vep\rangle)
 }{
   \annotatestmt(\tenv, \overname{\SDecl(\ldk, \ldi, \langle\ve\rangle)}{\vs}) \typearrow (\news, \newtenv)
 }
@@ -394,10 +392,10 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[non\_constant]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep) \OrTypeError\\\\
-  \annotatelocaldeclitem{\tenv, \vte, \ldk, \vep, \ldi} \typearrow (\tenvone, \ldip)\\\\
+  \annotatelocaldeclitem{\tenv, \vte, \ldk, \langle\vep\rangle, \ldi} \typearrow (\tenvone, \ldione)\\\\
   \commonprefixline\\\\
   \ldk \neq \LDKConstant\\
-  \news \eqdef \SDecl(\ldk, \ldip, \langle\vep\rangle)
+  \news \eqdef \SDecl(\ldk, \ldione, \langle\vep\rangle)
 }{
   \annotatestmt(\tenv, \overname{\SDecl(\ldk, \ldi, \langle\ve\rangle)}{\vs}) \typearrow (\news, \overname{\tenvone}{\newtenv})
 }
@@ -406,8 +404,8 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[none]{
-  \annotatelocaldeclitemuninit(\tenv, \ldi) \typearrow (\newtenv, \ldip) \OrTypeError\\\\
-  \news \eqdef \SDecl(\LDKVar, \ldip, \None)
+  \annotatelocaldeclitemuninit(\tenv, \ldi) \typearrow (\newtenv, \ldione) \OrTypeError\\\\
+  \news \eqdef \SDecl(\LDKVar, \ldione, \None)
 }{
   \annotatestmt(\tenv, \overname{\SDecl(\LDKVar, \ldi, \None)}{\vs}) \typearrow (\news, \newtenv)
 }

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -110,6 +110,7 @@ module Make (C : Config) = struct
       else `Silence
 
     let output_format = Asllib.Error.Silence
+    let print_typed = false
   end)
 
   module ASLInterpreterConfig = struct


### PR DESCRIPTION
This PR adds type annotations to local and global declarations when `--print-typed` is specified on the command line.
This doesn't have any observable effect on the type system and semantics, but it allows reading the types inferred by ASLRef.

For example `% aslref --print-typed asllib/tests/ASLTypingReference.t/TypingRule.LDTuple.asl` makes the types inferred for `g`, `x`, and `y` visible:
```
var g = 3;
func main () => integer
begin
    let (x, -, y): (integer {5}, integer {3}, boolean) = (5, 3, TRUE);
    assert ((x == 5) && y);
    return 0;
end
```

Also, a small fix to the documentation of `annotate_stmt` for declaration statements.