### PR TITLE
[gen] I annotation on reads, reject P becoming I

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1729,15 +1729,18 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     | None,_ -> Warn.fatal "AArchCompile.emit_access"
     | Some d,Code lab ->
         begin match d,e.C.atom with
-        | R,None ->
+        | R,Some (Instr, None) ->
             let r,init,cs,st = LDR.emit_fetch st p init lab in
             Some r,init,cs,st
-        | W,(None | Some (Instr, None)) ->
-            let init,cs,st = STR.emit_store_nop st p init lab in
-            None,init,cs,st
-        | R, Some (Instr, None) ->
+        (* Plain read from an instruction label is currently not supported, 
+           but will be implemented in a future patch
+        | R, None ->
             let r,init,cs,st = LDR.emit_load st p init lab in
             Some r,init,cs,st
+        | W, Some(Instr, None)  *)
+        | W, None ->
+            let init,cs,st = STR.emit_store_nop st p init lab in
+            None,init,cs,st
         | _,_ -> Warn.fatal "Not Yet (%s,%s)!!!"
               (pp_dir d) (C.debug_evt e)
         end

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -173,6 +173,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
             | Code.CapaSeal
             | Code.Ord
             | Code.Pair
+            | Code.Instr
               ->
                 Some (I evt.C.C.v)
             | Code.VecReg _->
@@ -186,9 +187,6 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
                 Some (S (Code.add_tag (Code.as_data evt.C.C.loc) evt.C.C.v))
             | Code.Pte ->
                 Some (P evt.C.C.pte)
-            | Code.Instr ->
-              let s = C.A.pp_i evt.C.C.ins in
-              Some (S s)
             end
         | Some Code.W ->
            assert (evt.C.C.bank = Code.Ord || evt.C.C.bank = Code.CapaSeal) ;

--- a/gen/libdir/forbidden_ifetch.conf
+++ b/gen/libdir/forbidden_ifetch.conf
@@ -1,0 +1,13 @@
+-arch AArch64
+
+-relax [FreIP PodW* DC.CVAUp DSB.ISH IC.IVAUp DSB.ISH] [FreIP PosW* DC.CVAUp DSB.ISH IC.IVAUp DSB.ISH] [FreIP PodW*PI DC.CVAUp DSB.ISH IC.IVAUp DSB.ISH ISB] [FreIP PosW*PI DC.CVAUp DSB.ISH IC.IVAUp DSB.ISH ISB] [DpCtrldRPI IC.IVAUn DSB.ISH ISB FreIP PodW* DC.CVAUp DMB.ISH] [DpCtrldRPI IC.IVAUn DSB.ISH ISB FreIP PodW* DC.CVAUp DSB.ISH] [DpAddrdRPI IC.IVAUn DSB.ISH ISB FreIP PodW* DC.CVAUp DMB.ISH] [ Pod*RPI DSB.ISH IC.IVAUn DSB.ISH ISB FreIP PodW* DC.CVAUp DSB.ISH] [Pod*RPI DSB.ISH IC.IVAUn DSB.ISH ISB FreIP PodW* DC.CVAUp DMB.ISH] [ Pod*RPI DSB.ISH DC.CVAUn DSB.ISH IC.IVAUn DSB.ISH ISB FreIP] [ DpCtrldRPI DC.CVAUn DSB.ISH IC.IVAUn DSB.ISH ISB FreIP] [ DpAddrdRPI DC.CVAUn DSB.ISH IC.IVAUn DSB.ISH ISB FreIP] [Pod*RPI DMB.ISH DC.CVAUn DSB.ISH IC.IVAUn DSB.ISH ISB FreIP]  [PodRRII FreIP PodW* DC.CVAUp DSB.ISH IC.IVAUp DSB.ISH] RfePI PodR*IP [DSB.ISHd*RPI ISB]  [DpAddrdR, ISBd*RPI] [DpAddrdW, ISBd*RPI] [DpAddrsR, ISBs*RPI] [DpAddrsW, ISBs*RPI] [DpAddrsR, ISBd*RPI] [DpAddrsW, ISBd*RPI] [DpAddrdR, ISBs*RPI] [DpAddrdW, ISBs*RPI]
+
+-safe Rfe Fre Coe DMB.ISHd** DMB.STdWW DpAddrdR DpAddrdW DpAddrsR DpAddrsW DpDatadW DpDatasW DpCtrldW DpCtrlsW DpCtrlIsbdR [DpAddrdR, ISBd*R] [DpAddrdW, ISBd*R] DpCtrlIsbsR [DpAddrsR, ISBs*R] [DpAddrsW, ISBs*R] [DpAddrsR, ISBd*R] [DpAddrsW, ISBd*R] [DpAddrdR, ISBs*R] [DpAddrdW, ISBs*R] [DpAddrdR, Pod*W] [DpAddrdW, Pod*W] [DpAddrsR, Pos*W] [DpAddrsW, Pos*W] [DpAddrsR, Pod*W] [DpAddrsW, Pod*W] [DpAddrdR, Pos*W] [DpAddrdW, Pos*W] [DpAddrdW, Rfi] [DpDatadW, Rfi] [DpAddrsW, Rfi] [DpDatasW, Rfi]
+
+-moreedges true
+-ins 10
+-nprocs 2
+-size 4
+-mix true
+-maxrelax 3
+-variant self

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -257,16 +257,9 @@ let get_fence n =
               begin match o with
               | None   -> finals (* Code write *)
               | Some r -> (* fetch! *)
-                  match n.C.prev.C.edge.E.edge, n.C.edge.E.edge with
-                  | E.Rf _, _ when E.is_ifetch n.C.prev.C.edge.E.a2 ->
-                      F.add_final (A.get_friends st) p o n finals
-                  | _, E.Po _ | _, E.Fr _ when E.is_ifetch n.C.edge.E.a1 ->
-                      F.add_final (A.get_friends st) p o n finals
-                  | _, _-> begin
                   let m,fenv =  finals in
                   m,F.add_final_v p r (IntSet.singleton (U.fetch_val n))
                     fenv
-                    end
               end),
           st
       end


### PR DESCRIPTION
This commit:
- changes the function of the I annotation to work on Reads instead of Writes.
- prevents Plain annotations from eating Instr annotations, allowing the user to specify whether a relaxation in diy7 can be followed/preceded by I or not. This is useful when trying to build relaxations from a cat file for lines specifying `[~(Imp & M)]`
- Remove explicit reads of Labels