### PR TITLE
[Asl0] Small subtlety with patterns in ASL0

### DIFF
--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -349,6 +349,8 @@ let binop_expr(e, b) ==
       | ~=e; ~=bracketed(clist(slice));               < AST.E_Slice     >
       | ~=bracketed(clist(expr));                     < AST.E_Concat    >
       | ~=e; IN; ~=bpattern;                           < AST.E_Pattern   >
+      | e=e; EQ_EQ; m=MASK_LIT;                       { AST.(E_Pattern (e, Pattern_Mask (m))) }
+      | e=e; BANG_EQ; m=MASK_LIT;                     { AST.(E_Pattern (e, Pattern_Not (Pattern_Mask (m)))) }
       | ~=annotated(ty_non_tuple); UNKNOWN;           < AST.E_Unknown   >
       (*
       | ~=e; LT; ~=clist(slice); GT;          < AST.E_Slice     >

--- a/asllib/tests/regressions.t/asl0-patterns.asl
+++ b/asllib/tests/regressions.t/asl0-patterns.asl
@@ -1,6 +1,9 @@
 integer main()
     bits(64) x = Zeros(64);
     y = x[1+:10]; // this would be invalid ASL0, but we use it in the XML
-    if x[0+:4] IN '10x1' then
+    if x IN {'10x1101010'} then  z = 1; // valid
+    if x == '10x1101010' then z = 1; // valid
+    if x != '10x1101010' then z = 1; // valid
+    if x[0+:4] IN '10x1' then // invalid
         z = 1;
     return 1;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -302,7 +302,7 @@ Required tests:
   $ aslref array.asl
   $ aslref -0 assign-v0.asl
   $ aslref -0 asl0-patterns.asl
-  File asl0-patterns.asl, line 4, characters 25 to 29:
+  File asl0-patterns.asl, line 7, characters 25 to 29:
   ASL Error: Cannot parse.
   [1]
   $ aslref assign1.asl


### PR DESCRIPTION
In ASL0, we want to forbid:
```
if x IN '10x1' then
```
but accept:
```
if x IN {'10x1'} then // valid
if x == '10x1'   then // valid 
```
