### PR TITLE
[asl] Fix ATCs on types with same structure

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1520,7 +1520,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           check_atc env t_struct ty_struct ~fail:(fun () ->
               fatal_from loc (BadATC (t, ty)))
         in
-        (if Types.subtype_satisfies env t ty' then (ty', e'')
+        (if Types.subtype_satisfies env t_struct ty_struct then (ty', e'')
          else if forbid_atcs then fatal_from loc Error.UnexpectedATC
          else (ty', E_ATC (e'', ty_struct) |> here))
         |: TypingRule.ATC

--- a/asllib/tests/atcs.t
+++ b/asllib/tests/atcs.t
@@ -85,12 +85,26 @@ ATCs on other types
 
   $ aslref atcs7.asl
 
-ATCs in types:
   $ cat > atcs8.asl <<EOF
-  > let bv : bits(1 as integer{2}) = Ones(1);
+  > type A of record{ a: integer};
+  > type B subtypes A;
+  > func main () => integer
+  > begin
+  >     let x: A = B { a = 0 };
+  >     var a: array[10] of B;
+  >     let b = a as array[10] of A;
+  >     return 0;
+  > end
   > EOF
 
   $ aslref atcs8.asl
-  File atcs8.asl, line 1, characters 14 to 29:
+
+ATCs in types:
+  $ cat > atcs9.asl <<EOF
+  > let bv : bits(1 as integer{2}) = Ones(1);
+  > EOF
+
+  $ aslref atcs9.asl
+  File atcs9.asl, line 1, characters 14 to 29:
   ASL Typing error: unexpected ATC.
   [1]


### PR DESCRIPTION
ATCs on types with same structures are allowed by the type checker, but not supported by the interpreter. We change that by removing at type-checking time atcs on types whose structures type-satisfies one-another.