### PR TITLE
[asl][reference] Fix double declaration of add_global_storage

### DIFF
--- a/asllib/StaticEnv.ml
+++ b/asllib/StaticEnv.ml
@@ -193,11 +193,8 @@ let set_renamings name set env =
       };
   }
 
-(* Begin AddGlobalStorage *)
 let add_global_storage x ty gdk (genv : global) =
   { genv with storage_types = IMap.add x (ty, gdk) genv.storage_types }
-  |: TypingRule.AddGlobalStorage
-(* End *)
 
 let add_type x ty env =
   let () =


### PR DESCRIPTION
There are two functions named `add_global_storage` - one in Typing.ml and another in StaticEnv.ml. I've dropeed the begin/end markers and TypingRule.AddGlobalStorage from the version in StaticEnv.ml, since it is only used by the version in Typing.ml.