### PR TITLE
[asl][reference] Fixes to reference rules for bitfield slicing

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1335,7 +1335,7 @@
 \newcommand\getliteraldivopt[0]{\hyperlink{def-getliteraldivopt}{\textfunc{get\_literal\_div\_opt}}}
 \newcommand\checkslicesinwidth[0]{\hyperlink{def-checkslicesinwidth}{\textfunc{check\_slices\_in\_width}}}
 \newcommand\disjointslicestopositions[0]{\hyperlink{def-disjointslicestopositions}{\textfunc{disjoint\_slices\_to\_positions}}}
-\newcommand\bitfieldslicetopositions[0]{\hyperlink{bitfieldslicetopositions}{\textfunc{bitfield\_slice\_to\_positions}}}
+\newcommand\bitfieldslicetopositions[0]{\hyperlink{def-bitfieldslicetopositions}{\textfunc{bitfield\_slice\_to\_positions}}}
 \newcommand\checkpositionsinwidth[0]{\hyperlink{def-checkpositionsinwidth}{\textfunc{check\_positions\_in\_width}}}
 \newcommand\shouldslicesreducetocall[0]{\tododefine{should\_slices\_reduce\_to\_call}}
 \newcommand\shouldreducetocall[0]{\tododefine{should\_reduce\_to\_call}}
@@ -1383,6 +1383,8 @@
 \newcommand\sliceequal[0]{\hyperlink{def-sliceequal}{\textfunc{slice\_equal}}}
 \newcommand\constraintsequal[0]{\hyperlink{def-constraintsequal}{\textfunc{constraints\_equal}}}
 \newcommand\constraintequal[0]{\hyperlink{def-constraintequal}{\textfunc{constraint\_equal}}}
+\newcommand\constraintsforall[0]{\tododefine{\textfunc{constraints\_for\_all}}}
+\newcommand\constraintsexists[0]{\tododefine{\textfunc{constraints\_exists}}}
 \newcommand\arraylengthequal[0]{\hyperlink{def-arraylengthequal}{\textfunc{array\_length\_equal}}}
 \newcommand\literalequal[0]{\hyperlink{def-literalequal}{\textfunc{literal\_equal}}}
 \newcommand\finddeducecheck[0]{\hyperlink{def-finddeducecheck}{\textfunc{find\_deduce\_check}}}

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -402,7 +402,7 @@ One of the following applies:
 \hypertarget{def-bitfieldslicetopositions}{}
 The function
 \[
-  \bitfieldslicetopositions(\overname{\staticenvs}{\tenv}, \overname{\vslice}{\vslices})
+  \bitfieldslicetopositions(\overname{\staticenvs}{\tenv}, \overname{\slice}{\vslice})
   \aslto \overname{\powfin{\Z}}{\positions} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 returns the set of integers defined by the bitfield slice $\vslice$ in $\positions$. \ProseOtherwiseTypeError
@@ -425,10 +425,10 @@ One of the following applies:
           $\SliceRange(\veone, \vetwo)$;
     \item applying $\reduceconstants$ to $\veone$ in $\tenv$ yields the literal $\vlone$\ProseOrTypeError;
     \item checking that $\vlone$ is an integer literal yields $\True$\ProseTerminateAs{\IntConstantExpected};
-    \item $\vlone$ is the integer literal for $\vx$;
+    \item $\vlone$ is the integer literal for $\vy$;
     \item applying $\reduceconstants$ to $\vetwo$ in $\tenv$ yields the literal $\vltwo$\ProseOrTypeError;
     \item checking that $\vltwo$ is an integer literal yields $\True$\ProseTerminateAs{\IntConstantExpected};
-    \item $\vltwo$ is the integer literal for $\vy$;
+    \item $\vltwo$ is the integer literal for $\vx$;
     \item checking that $\vx$ is less than or equal to $\vy$ yields $\True$\ProseTerminateAs{\BitfieldSliceReversed};
     \item $\positions$ is the set of integers between $\vx$ and $\vy$, inclusive.
   \end{itemize}
@@ -443,7 +443,7 @@ One of the following applies:
     \item applying $\reduceconstants$ to $\vetwo$ in $\tenv$ yields the literal $\vltwo$\ProseOrTypeError;
     \item checking that $\vltwo$ is an integer literal yields $\True$\ProseTerminateAs{\IntConstantExpected};
     \item $\vltwo$ is the integer literal for $\vy$;
-    \item checking that $\vx$ is less than or equal to $\vy$ yields $\True$\ProseTerminateAs{\BitfieldSliceReversed};
+    \item checking that $\vx \leq \vx+\vy-1$ holds yields $\True$\ProseTerminateAs{\BitfieldSliceReversed};
     \item $\positions$ is the set of integers between $\vx$ and $\vx+\vy-1$, inclusive.
   \end{itemize}
 
@@ -457,7 +457,7 @@ One of the following applies:
     \item applying $\reduceconstants$ to $\vetwo$ in $\tenv$ yields the literal $\vltwo$\ProseOrTypeError;
     \item checking that $\vltwo$ is an integer literal yields $\True$\ProseTerminateAs{\IntConstantExpected};
     \item $\vltwo$ is the integer literal for $\vy$;
-    \item checking that $\vx$ is less than or equal to $\vy$ yields $\True$\ProseTerminateAs{\BitfieldSliceReversed};
+    \item checking that $\vx \times \vy \leq \vx \times (\vy + 1) - 1$ holds yields $\True$\ProseTerminateAs{\BitfieldSliceReversed};
     \item $\positions$ is the set of integers between $\vx \times \vy$ and $\vx \times (\vy + 1) - 1$, inclusive.
   \end{itemize}
 \end{itemize}
@@ -476,10 +476,10 @@ One of the following applies:
 \inferrule[range]{
   \reduceconstants(\tenv, \veone) \typearrow \vlone \OrTypeError\\\\
   \checktrans{\astlabel(\vlone) = \lint}{\IntConstantExpected} \checktransarrow \True \OrTypeError\\\\
-  \vlone \eqname \lint(\vx)\\
+  \vlone \eqname \lint(\vy)\\
   \reduceconstants(\tenv, \vetwo) \typearrow \vltwo \OrTypeError\\\\
   \checktrans{\astlabel(\vltwo) = \lint}{\IntConstantExpected} \checktransarrow \True \OrTypeError\\\\
-  \vltwo \eqname \lint(\vy)\\
+  \vltwo \eqname \lint(\vx)\\
   \checktrans{\vx \leq \vy}{\BitfieldSliceReversed} \checktransarrow \True \OrTypeError\\\\
 }{
   \bitfieldslicetopositions(\tenv, \overname{\SliceRange(\veone, \vetwo)}{\vslice}) \typearrow \overname{\{n \;|\; \vx \leq n \leq \vy\}}{\positions}
@@ -494,7 +494,7 @@ One of the following applies:
   \reduceconstants(\tenv, \vetwo) \typearrow \vltwo \OrTypeError\\\\
   \checktrans{\astlabel(\vltwo) = \lint}{\IntConstantExpected} \checktransarrow \True \OrTypeError\\\\
   \vltwo \eqname \lint(\vy)\\
-  \checktrans{\vx \leq \vy}{\BitfieldSliceReversed} \checktransarrow \True \OrTypeError\\\\
+  \checktrans{\vx \leq \vx+\vy-1}{\BitfieldSliceReversed} \checktransarrow \True \OrTypeError\\\\
 }{
   \bitfieldslicetopositions(\tenv, \overname{\SliceRange(\veone, \vetwo)}{\vslice}) \typearrow \overname{\{n \;|\; \vx \leq n \leq \vx+\vy-1\}}{\positions}
 }
@@ -508,7 +508,7 @@ One of the following applies:
   \reduceconstants(\tenv, \vetwo) \typearrow \vltwo \OrTypeError\\\\
   \checktrans{\astlabel(\vltwo) = \lint}{\IntConstantExpected} \checktransarrow \True \OrTypeError\\\\
   \vltwo \eqname \lint(\vy)\\
-  \checktrans{\vx \leq \vy}{\BitfieldSliceReversed} \checktransarrow \True \OrTypeError\\\\
+  \checktrans{\vx \times \vy \leq \vx \times (\vy + 1) - 1}{\BitfieldSliceReversed} \checktransarrow \True \OrTypeError\\\\
 }{
   \bitfieldslicetopositions(\tenv, \overname{\SliceStar(\veone, \vetwo)}{\vslice}) \typearrow
   \overname{\{n \;|\; \vx \times \vy \leq n \leq \vx \times (\vy + 1) - 1\}}{\positions}

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -246,7 +246,7 @@ One of the following applies:
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule{
+\inferrule[range]{
   \binopliterals(\MINUS, \vi, \vi) \typearrow \prelengthp\\
   \binopliterals(\PLUS, \prelengthp, \eliteral{1}) \typearrow \prelength\\
   \annotateslice(\SliceLength(\vi, \prelength)) \typearrow \vsp \OrTypeError

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -480,6 +480,7 @@ module TypingRule = struct
     | CheckVarNotInEnv
     | CheckVarNotInGEnv
     | CheckDisjointSlices
+    | BitfieldSliceToPositions
 
   let to_string : t -> string = function
     | BuiltinSingularType -> "BuiltinSingularType"
@@ -653,6 +654,7 @@ module TypingRule = struct
     | CheckVarNotInEnv -> "CheckVarNotInEnv"
     | CheckVarNotInGEnv -> "CheckVarNotInGEnv"
     | CheckDisjointSlices -> "CheckDisjointSlices"
+    | BitfieldSliceToPositions -> "BitfieldSliceToPositions"
 
   let pp f r = to_string r |> Format.pp_print_string f
 
@@ -808,6 +810,7 @@ module TypingRule = struct
       CheckVarNotInEnv;
       CheckVarNotInGEnv;
       CheckDisjointSlices;
+      BitfieldSliceToPositions;
     ]
 
   let all_nb = List.length all


### PR DESCRIPTION
Fixes to rules for bitfield slices.
A bit of refactoring to `bitfield_slice_to_positions`.