### PR TITLE
[asl] Allow ASL arch to display bitvectors as hexa

### DIFF
--- a/herd/ASLAction.ml
+++ b/herd/ASLAction.ml
@@ -33,6 +33,10 @@
 
 open Dir
 
+module type Config = sig
+  val hexa: bool
+end
+
 module type S = sig
   include Arch_herd.S
 
@@ -40,7 +44,7 @@ module type S = sig
   val is_pc : reg -> bool
 end
 
-module Make (A : S) = struct
+module Make (C: Config) (A : S) = struct
   module A = A
   module V = A.V
 
@@ -56,7 +60,7 @@ module Make (A : S) = struct
   let pp_action = function
     | Access (d, l, v, _sz,a) ->
         Printf.sprintf "%s%s=%s%s"
-          (pp_dirn d) (A.pp_location l) (V.pp false v)
+          (pp_dirn d) (A.pp_location l) (V.pp C.hexa v)
           (let open AArch64Annot in
            match a with
            | N -> ""
@@ -286,5 +290,5 @@ module Make (A : S) = struct
     | Barrier _ | Branching _ | CutOff _ | NoAction -> a
 end
 
-module FakeModuleForCheckingSignatures (A : S) : Action.S
-       with module A = A =  Make (A)
+module FakeModuleForCheckingSignatures (C: Config) (A : S) : Action.S
+       with module A = A =  Make (C) (A)

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -101,7 +101,7 @@ module Make (C : Config) = struct
     let opt_env = true
   end
 
-  module Act = ASLAction.Make (ASL64AH)
+  module Act = ASLAction.Make (C.PC) (ASL64AH)
   include SemExtra.Make (C) (ASL64AH) (Act)
 
   let is_experimental = C.variant Variant.ASLExperimental

--- a/lib/ASLScalar.ml
+++ b/lib/ASLScalar.ml
@@ -54,27 +54,28 @@ let z63 = Z.shift_left Z.one (MachSize.nbits machsize-1)
 let z64 = Z.shift_left Z.one (MachSize.nbits machsize)
 
 let norm_unsigned z = if Z.sign z < 0 then Z.add z z64 else z
+
 let norm_signed z =
   let z = Z.erem z z64 in
-  if Z.geq z z63 then Z.sub z z64
-  else z
+  if Z.geq z z63 then Z.sub z z64 else z
+
+let z_format_hexa z = "0x" ^ Z.format "%x" z
 
 let pp hexa = function
-  | S_Int i ->
-     if hexa then norm_unsigned i |> Z.format "%x"
-     else Z.format "%d" i
+  | S_Int i -> if hexa then z_format_hexa (norm_unsigned i) else Z.format "%d" i
   | S_Bool true -> "TRUE"
   | S_Bool false -> "FALSE"
-  | S_BitVector bv -> BV.to_string bv
+  | S_BitVector bv ->
+      if hexa then z_format_hexa (BV.to_z_unsigned bv) else BV.to_string bv
 
 let pp_unsigned hexa = function
   | S_Int i ->
-     let i = norm_unsigned i in
-     if hexa then "0x" ^ Z.format "%x" i else Z.format "%d" i
+      let i = norm_unsigned i in
+      if hexa then z_format_hexa i else Z.format "%d" i
   | S_Bool true -> "TRUE"
   | S_Bool false -> "FALSE"
-  | S_BitVector bv -> BV.to_string bv
-
+  | S_BitVector bv ->
+      if hexa then z_format_hexa (BV.to_z_unsigned bv) else BV.to_string bv
 
 let of_string s =
   try S_Int (Z.of_string s)


### PR DESCRIPTION
This allows graphs done with the ASL architecture to display on pdf bitvectors written as hexadecimal (unsigned) integers.