### PR TITLE
[asl] Add semicolon after 'end'

### DIFF
--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -24,7 +24,7 @@
 
 exception LexerError
 
-open Parser
+open Tokens
 
 open Error
 

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -527,7 +527,7 @@ let loop_limit == { None }
 
 let stmt ==
   annotated (
-    | terminated_by(END,
+    | terminated_by(END; SEMI_COLON,
       | IF; e=expr; THEN; s1=stmt_list; s2=s_else;    <S_Cond>
       | CASE; ~=expr; OF; alt=case_alt_list;          <S_Case>
       | WHILE; ~=expr; ~=loop_limit; DO; ~=stmt_list; <S_While>
@@ -584,7 +584,7 @@ let params_opt == { [] } | braced(clist(opt_typed_identifier))
 let access_args == bracketed(clist(typed_identifier))
 let func_args == plist(typed_identifier)
 let maybe_empty_stmt_list == stmt_list | annotated({ S_Pass })
-let func_body == delimited(BEGIN, maybe_empty_stmt_list, END)
+let func_body == delimited(BEGIN, maybe_empty_stmt_list, END; SEMI_COLON)
 let ignored_or_identifier ==
   | MINUS; { global_ignored () }
   | IDENTIFIER

--- a/asllib/ParserConfig.mli
+++ b/asllib/ParserConfig.mli
@@ -20,51 +20,8 @@
 (* herdtools7 github repository.                                              *)
 (******************************************************************************)
 
-open Lexing
-
-(**
-   Builds an {!AST.t} from some files.
-
-   In this file the optional argument allow_no_end_semicolon - defaults to false
-   *)
-
-type token = Tokens.token
-type ast_type = [ `Opn | `Ast ]
-type version = [ `ASLv0 | `ASLv1 ]
-type version_selector = [ `ASLv0 | `ASLv1 | `Any ]
-
-val from_file_result :
-  ?ast_type:ast_type ->
-  ?allow_no_end_semicolon:bool ->
-  version ->
-  string ->
-  AST.t Error.result
-
-val from_file :
-  ?ast_type:ast_type ->
-  ?allow_no_end_semicolon:bool ->
-  version ->
-  string ->
-  AST.t
-
-val from_lexer_lexbuf :
-  ?ast_type:ast_type ->
-  ?allow_no_end_semicolon:bool ->
-  version ->
-  'a ->
-  lexbuf ->
-  AST.t Error.result
-
-val from_file_multi_version :
-  ?ast_type:ast_type ->
-  ?allow_no_end_semicolon:bool ->
-  version_selector ->
-  string ->
-  AST.t Error.result
-
-val stdlib : AST.t Lazy.t
-val with_stdlib : AST.t -> AST.t
-val is_stdlib_name : AST.identifier -> bool
-
-val with_primitives :
-  ?loc:unit AST.annotated -> (AST.func * 'a) list -> AST.t -> AST.t
+(** The CONFIG module signature for the ASL1 Parser *)
+module type CONFIG = sig
+  val allow_no_end_semicolon : bool
+  (** Allow no semicolon after [end]. *)
+end

--- a/asllib/Tokens.mly
+++ b/asllib/Tokens.mly
@@ -1,0 +1,116 @@
+(******************************************************************************)
+(*                                ASLRef                                      *)
+(******************************************************************************)
+(*
+ * SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ *)
+(******************************************************************************)
+(* Disclaimer:                                                                *)
+(* This material covers both ASLv0 (viz, the existing ASL pseudocode language *)
+(* which appears in the Arm Architecture Reference Manual) and ASLv1, a new,  *)
+(* experimental, and as yet unreleased version of ASL.                        *)
+(* This material is work in progress, more precisely at pre-Alpha quality as  *)
+(* per Arm’s quality standards.                                               *)
+(* In particular, this means that it would be premature to base any           *)
+(* production tool development on this material.                              *)
+(* However, any feedback, question, query and feature request would be most   *)
+(* welcome; those can be sent to Arm’s Architecture Formal Team Lead          *)
+(* Jade Alglave <jade.alglave@arm.com>, or by raising issues or PRs to the    *)
+(* herdtools7 github repository.                                              *)
+(******************************************************************************)
+
+(* ------------------------------------------------------------------------
+
+                                   Tokens
+
+  ------------------------------------------------------------------------- *)
+
+%token AND ARRAY ARROW AS ASSERT BAND BEGIN BEQ BIT BITS BNOT BOOLEAN BOR CASE
+%token CATCH COLON COLON_COLON COMMA CONCAT CONFIG CONSTANT DEBUG DIV DIVRM DO
+%token DOT DOWNTO ELSE ELSIF END ENUMERATION EOF EOR EQ EQ_OP EXCEPTION FOR
+%token FUNC GEQ GETTER GT IF IMPL IN INTEGER LBRACE LBRACKET LEQ LET (* LIMIT *) LPAR
+%token LT MINUS MOD MUL NEQ NOT OF OR OTHERWISE PASS PLUS PLUS_COLON POW PRAGMA
+%token PRINT RBRACE RBRACKET RDIV REAL RECORD REPEAT RETURN RPAR STAR_COLON
+%token SEMI_COLON SETTER SHL SHR SLICING STRING SUBTYPES THEN THROW TO TRY TYPE
+%token UNKNOWN UNREACHABLE UNTIL VAR WHEN WHERE WHILE WITH
+
+%token ARROBASE_LOOPLIMIT
+%token <string> IDENTIFIER STRING_LIT
+%token <Bitvector.mask> MASK_LIT
+%token <Bitvector.t> BITVECTOR_LIT
+%token <Z.t> INT_LIT
+%token <Q.t> REAL_LIT
+%token <bool> BOOL_LIT
+
+
+(* ------------------------------------------------------------------------
+
+                           Associativity and priority
+
+  ------------------------------------------------------------------------- *)
+
+(*
+   This section on associativity uses menhir associativity and priority
+   features. Internally, it is used by menhir to resolve some conflicts that
+   could arrise from different conflicting expressions, e.g. [3 + 4 + 5].
+
+   For a quick intro, menhir assigns a priority level to tokens that have a
+   [left], [right], or [nonassoc] declaration in the order in which they are
+   declared. For example, here [PLUS]'s associativity is declared before [MUL]
+   so [3 + 4 * 5] will be parsed as [3 + (4 * 5)].
+
+   Associativity is straigh-forward.
+
+   Priority declarations that follow are created because of the fusion of
+   multiple recursive bnf rules into one, e.g. [expr] is the fusion of [expr]
+   and many others such as [cexpr].
+   The rule tree that I am translating here into priority rules is the
+   following:
+
+     expr <-----------------------|IF|----------------------< cexpr
+     cexpr <----|binop_boolean, checked_type_constraint|---<  cexpr_cmp
+     cexpr_cmp <-----------|binop_comparison|---------------< cexpr_add_sub
+     cexpr_add_sub <------|binop_add_sub_logic|-------------< cexpr_mul_div
+     cexpr_mul_div <------|binop_mul_div_shift|-------------< cexpr_pow
+     cepxr_pow <---------------|binop_pow|------------------< bexpr
+     bexpr <---------------------|unop|---------------------< expr_term
+     expr_term <------------------|IN|----------------------< expr_atom
+     expr_atom <-----------|DOT, brackets, ...|-------------< expr
+
+
+  Note that the token MINUS has two different precedence: one for when it is a
+  binary operator, in that case it has the same precedence as PLUS, and one for
+  when it is a unary operator, in which case it has the same precendence as
+  NOT.
+*)
+
+(* IF *)
+%nonassoc ELSE
+
+(* binop_boolean, checked_type_constraint *)
+%left BOR BAND IMPL BEQ AS
+
+(* binop_comparison *)
+%left EQ_OP NEQ
+%nonassoc GT GEQ LT LEQ
+
+(* binop_add_sub_logic *)
+%left PLUS MINUS OR EOR AND
+
+(* binop_mul_div_shift *)
+%left MUL DIV DIVRM RDIV MOD SHL SHR
+
+(* binop_pow *)
+%left POW CONCAT
+
+(* unop: NOT, BNOT, MINUS *)
+%nonassoc UNOPS
+
+(* IN *)
+%nonassoc IN
+
+(* DOT, brackets, etc. *)
+%left DOT LBRACKET
+
+%%

--- a/asllib/bundler.ml
+++ b/asllib/bundler.ml
@@ -50,6 +50,10 @@ let build_ast_from_file ?(is_opn = false) f =
       pos.pos_lnum
       (pos.pos_cnum - pos.pos_bol)
   in
+  (* For now expect the ASL input to adhere to the spec. *)
+  let module Parser = Parser.Make (struct
+    let allow_no_end_semicolon = false
+  end) in
   let parse = if is_opn then Parser.opn else Parser.ast in
   let chan = open_in f in
   let lexbuf = Lexing.from_channel chan in

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -642,12 +642,12 @@ we use the notation $\namednode{n_i}{S_i}$, which names the child node $S_i$ as 
 \subsection{Example}
 Consider the derivation for while loops:
 \[
-\Nstmt \derives \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend
+\Nstmt \derives \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon
 \]
 
 The parse node for a while statement has the form
 \[
-\Nstmt(\Twhile, \namednode{\ve}{\Nexpr}, \Tdo, \namednode{\vstmtlist}{\Nstmtlist}, \Tend)
+\Nstmt(\Twhile, \namednode{\ve}{\Nexpr}, \Tdo, \namednode{\vstmtlist}{\Nstmtlist}, \Tend, \Tsemicolon)
 \]
 where $\ve$ names the node representing the condition of the loop and $\vstmtlist$ names
 the list of statements that form the body of the loop.
@@ -663,7 +663,7 @@ We also employ the following rule:
 }{
 {
 \begin{array}{r}
-  \buildstmt(\Nstmt(\Twhile, \namednode{\ve}{\Nexpr}, \Tdo, \namednode{\vstmtlist}{\Nstmtlist}, \Tend))
+  \buildstmt(\Nstmt(\Twhile, \namednode{\ve}{\Nexpr}, \Tdo, \namednode{\vstmtlist}{\Nstmtlist}, \Tend, \Tsemicolon))
   \astarrow\\
   \SWhile(\astversion{\ve}, \None, \astversion{\vstmtlist})
 \end{array}
@@ -701,7 +701,7 @@ In our example, this results in the abbreviated rule notation
 \inferrule{}{
 {
 \begin{array}{r}
-  \buildstmt(\Nstmt(\Twhile, \punnode{\Nexpr}, \Tdo, \punnode{\Nstmtlist}, \Tend))
+  \buildstmt(\Nstmt(\Twhile, \punnode{\Nexpr}, \Tdo, \punnode{\Nstmtlist}, \Tend, \Tsemicolon))
   \astarrow\\
   \SWhile(\astof{\vexpr}, \None, \astof{\vstmtlist})
   \end{array}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -819,7 +819,7 @@ All of the following apply:
 \section{Conditional Statements\label{sec:ConditionalStatements}}
 \subsection{Syntax}
 \begin{flalign*}
-\Nstmt \derivesinline\ & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nstmtlist \parsesep \Nselse \parsesep \Tend &\\
+\Nstmt \derivesinline\ & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nstmtlist \parsesep \Nselse \parsesep \Tend \parsesep \Tsemicolon &\\
 \Nselse \derives\ & \Telseif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nstmtlist \parsesep \Nselse &\\
         |\ & \Tpass &\\
         |\ & \Telse \parsesep \Nstmtlist &
@@ -835,7 +835,7 @@ All of the following apply:
 \inferrule{}{
   {
     \begin{array}{r}
-  \buildstmt(\overname{\Nstmt(\Tif, \punnode{\Nexpr}, \Tthen, \punnode{\Nstmtlist}, \punnode{\Nselse}, \Tend)}{\vparsednode})
+  \buildstmt(\overname{\Nstmt(\Tif, \punnode{\Nexpr}, \Tthen, \punnode{\Nstmtlist}, \punnode{\Nselse}, \Tend, \Tsemicolon)}{\vparsednode})
   \astarrow \\
   \overname{\SCond(\astof{\vexpr}, \astof{\vstmtlist}, \astof{\velse})}{\vastnode}
     \end{array}
@@ -954,7 +954,7 @@ as defined by \nameref{sec:TypingRule.DesugarCaseStmt}.
 
 \subsection{Syntax}
 \begin{flalign*}
-\Nstmt \derivesinline\ & \Tcase \parsesep \Nexpr \parsesep \Tof \parsesep \Ncasealtlist \parsesep \Tend &\\
+\Nstmt \derivesinline\ & \Tcase \parsesep \Nexpr \parsesep \Tof \parsesep \Ncasealtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 \Ncasealtlist \derivesinline\ & \NClist{\Ncasealt} \parsesep &\\
                            |\ & \NClist{\Ncasealt} \parsesep \Ncaseotherwise &\\
 \Ncasealt \derivesinline\ & \Twhen \parsesep \Npatternlist \parsesep \option{\Twhere \parsesep \Nexpr} \parsesep \Tarrow \parsesep \Nstmtlist &\\
@@ -973,7 +973,7 @@ as defined by \nameref{sec:TypingRule.DesugarCaseStmt}.
 }{
   {
     \begin{array}{r}
-  \buildstmt(\overname{\Nstmt(\Tcase, \punnode{\Nexpr}, \Tof, \namednode{\vcasealtlist}{\Ncasealtlist}, \Tend)}{\vparsednode})
+  \buildstmt(\overname{\Nstmt(\Tcase, \punnode{\Nexpr}, \Tof, \namednode{\vcasealtlist}{\Ncasealtlist}, \Tend, \Tsemicolon)}{\vparsednode})
   \astarrow \\
   \overname{\SCase(\astof{\vexpr}, \vcasealtlistast)}{\vastnode}
     \end{array}
@@ -1347,8 +1347,8 @@ All of the following apply:
 \section{While Statements\label{sec:WhileStatements}}
 \subsection{Syntax}
 \begin{flalign*}
-\Nstmt \derivesinline\ & \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend &\\
-|\ & \Tlooplimit \parsesep \Tlpar \parsesep \Nexpr \parsesep \Trpar \parsesep \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend &\\
+\Nstmt \derivesinline\ & \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
+|\ & \Tlooplimit \parsesep \Tlpar \parsesep \Nexpr \parsesep \Trpar \parsesep \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 \end{flalign*}
 
 \subsection{Abstract Syntax}
@@ -1361,7 +1361,7 @@ All of the following apply:
 \inferrule[no\_limit]{}{
   {
     \begin{array}{r}
-  \buildstmt(\overname{\Nstmt(\Twhile, \punnode{\Nexpr}, \Tdo, \punnode{\Nstmtlist}, \Tend)}{\vparsednode})
+  \buildstmt(\overname{\Nstmt(\Twhile, \punnode{\Nexpr}, \Tdo, \punnode{\Nstmtlist}, \Tend, \Tsemicolon)}{\vparsednode})
   \astarrow\\
   \overname{\SWhile(\astof{\vexpr}, \None, \astof{\vstmtlist})}{\vastnode}
 \end{array}
@@ -1378,7 +1378,7 @@ All of the following apply:
   \buildstmt\left(\overname{\Nstmt\left(
     \begin{array}{r}
     \Tlooplimit, \Tlpar, \namednode{\vlimitexpr}{\Nexpr}, \Trpar, \Twhile,  \\
-    \wrappedline\ \punnode{\Nexpr}, \Tdo, \punnode{\Nstmtlist}, \Tend
+    \wrappedline\ \punnode{\Nexpr}, \Tdo, \punnode{\Nstmtlist}, \Tend, \Tsemicolon
     \end{array}
     \right)}{\vparsednode}\right)
   \astarrow\\
@@ -1695,7 +1695,7 @@ either \\ $\Returning((\vvs, \newg), \newenv)$ or an output configuration $D$ an
 \subsection{Syntax}
 \begin{flalign*}
 \Nstmt \derivesinline\ & \Tfor \parsesep \Tidentifier \parsesep \Teq \parsesep \Nexpr \parsesep \Ndirection \parsesep
-                    \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend &\\
+                    \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 \Ndirection \derivesinline\ & \Tto \;|\; \Tdownto &
 \end{flalign*}
 
@@ -1725,7 +1725,7 @@ either \\ $\Returning((\vvs, \newg), \newenv)$ or an output configuration $D$ an
       \buildstmt\left(\overname{\Nstmt\left(
         \begin{array}{l}
         \Tfor, \Tidentifier(\vindexname), \Teq, \namednode{\vstarte}{\Nexpr}, \Ndirection, \\
-        \wrappedline\ \namednode{\vende}{\Nexpr}, \Tdo, \punnode{\Nstmtlist}, \Tend
+        \wrappedline\ \namednode{\vende}{\Nexpr}, \Tdo, \punnode{\Nstmtlist}, \Tend, \Tsemicolon
         \end{array}
         \right)}{\vparsednode}\right)
       \astarrow \\
@@ -2316,7 +2316,7 @@ One of the following applies:
 \section{Try Statements\label{sec:TryStatements}}
 \subsection{Syntax}
 \begin{flalign*}
-\Nstmt \derivesinline\ & \Ttry \parsesep \Nstmtlist \parsesep \Tcatch \parsesep \nonemptylist{\Ncatcher} \parsesep \Notherwiseopt \parsesep \Tend &
+\Nstmt \derivesinline\ & \Ttry \parsesep \Nstmtlist \parsesep \Tcatch \parsesep \nonemptylist{\Ncatcher} \parsesep \Notherwiseopt \parsesep \Tend \parsesep \Tsemicolon &
 \end{flalign*}
 
 \subsection{Abstract Syntax}
@@ -2335,7 +2335,7 @@ One of the following applies:
     \begin{array}{r}
     \Ttry, \Nstmtlist, \Tcatch,  \\
     \wrappedline\ \namednode{\vcatcherlist}{\nonemptylist{\Ncatcher}}, \\
-    \wrappedline\ \Notherwiseopt, \Tend
+    \wrappedline\ \Notherwiseopt, \Tend, \Tsemicolon
     \end{array}
     \right)}{\vparsednode}\right)
   \astarrow \\

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -27,7 +27,7 @@ Subprogram declarations have no associated semantics.
 \Nopttypedidentifier \derivesinline\ & \Tidentifier \parsesep \option{\Nasty} &\\
 \Nfuncargs          \derivesinline\ & \Tlpar \parsesep \Clist{\Ntypedidentifier} \parsesep \Trpar &\\
 \Nreturntype        \derivesinline\ & \Tarrow \parsesep \Nty &\\
-\Nfuncbody          \derivesinline\ & \Tbegin \parsesep \Nmaybeemptystmtlist \parsesep \Tend &\\
+\Nfuncbody          \derivesinline\ & \Tbegin \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 \Naccessargs        \derivesinline\ & \Tlbracket \parsesep \Clist{\Ntypedidentifier} \parsesep \Trbracket &\\
 \Nmaybeemptystmtlist \derivesinline\ & \emptysentence \;|\; \Nstmtlist &
 \end{flalign*}
@@ -364,7 +364,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \inferrule{}{
   {
   \begin{array}{r}
-  \buildfuncbody(\overname{\Nfuncbody(\Tbegin, \namednode{\vstmts}{\Nmaybeemptystmtlist}, \Tend)}{\vparsednode}) \astarrow \\
+  \buildfuncbody(\overname{\Nfuncbody(\Tbegin, \namednode{\vstmts}{\Nmaybeemptystmtlist}, \Tend, \Tsemicolon)}{\vparsednode}) \astarrow \\
   \overname{\astof{\vmaybeemptystmtlist}}{\vastnode}
   \end{array}
   }

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -310,7 +310,7 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 
 \hypertarget{def-nfuncbody}{}
 \begin{flalign*}
-\Nfuncbody          \derivesinline\ & \Tbegin \parsesep \Nmaybeemptystmtlist \parsesep \Tend &
+\Nfuncbody          \derivesinline\ & \Tbegin \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon &
 \end{flalign*}
 
 \hypertarget{def-nignoredoridentifier}{}
@@ -364,13 +364,13 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 
 \hypertarget{def-nstmt}{}
 \begin{flalign*}
-\Nstmt \derivesinline\ & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nstmtlist \parsesep \Nselse \parsesep \Tend &\\
-|\ & \Tcase \parsesep \Nexpr \parsesep \Tof \parsesep \Ncasealtlist \parsesep \Tend &\\
-|\ & \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend &\\
-|\ & \Tlooplimit \parsesep \Tlpar \parsesep \Nexpr \parsesep \Trpar \parsesep \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend &\\
+\Nstmt \derivesinline\ & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nstmtlist \parsesep \Nselse \parsesep \Tend \parsesep \Tsemicolon &\\
+|\ & \Tcase \parsesep \Nexpr \parsesep \Tof \parsesep \Ncasealtlist \parsesep \Tend \parsesep \Tsemicolon &\\
+|\ & \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
+|\ & \Tlooplimit \parsesep \Tlpar \parsesep \Nexpr \parsesep \Trpar \parsesep \Twhile \parsesep \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 |\ & \Tfor \parsesep \Tidentifier \parsesep \Teq \parsesep \Nexpr \parsesep \Ndirection \parsesep
-                    \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend &\\
-|\ & \Ttry \parsesep \Nstmtlist \parsesep \Tcatch \parsesep \nonemptylist{\Ncatcher} \parsesep \Notherwiseopt \parsesep \Tend &\\
+                    \Nexpr \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
+|\ & \Ttry \parsesep \Nstmtlist \parsesep \Tcatch \parsesep \nonemptylist{\Ncatcher} \parsesep \Notherwiseopt \parsesep \Tend \parsesep \Tsemicolon &\\
 |\ & \Tpass \parsesep \Tsemicolon &\\
 |\ & \Treturn \parsesep \option{\Nexpr} \parsesep \Tsemicolon &\\
 |\ & \Tidentifier \parsesep \Plist{\Nexpr} \parsesep \Tsemicolon &\\

--- a/asllib/dune
+++ b/asllib/dune
@@ -8,7 +8,13 @@
 (ocamllex splitasl)
 
 (menhir
- (modules Parser))
+ (modules Tokens)
+ (flags --only-tokens))
+
+(menhir
+ (modules Tokens Parser)
+ (merge_into Parser)
+ (flags --external-tokens Tokens))
 
 (menhir
  (modules Parser0)
@@ -31,7 +37,7 @@
   (:standard \ aslref bundler))
  (public_name herdtools7.asllib)
  (private_modules Parser0 Gparser0 Lexer0 SimpleLexer0 RepeatableLexer)
- (modules_without_implementation Backend AST)
+ (modules_without_implementation Backend AST ParserConfig)
  (flags
   (:standard -w -40-42-48))
  (libraries menhirLib zarith))

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -43,6 +43,7 @@ type error_desc =
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
   | NotYetImplemented of string
+  | ObsoleteSyntax of string
   | ConflictingTypes of type_desc list * ty
   | AssertionFailed of expr
   | CannotParse
@@ -121,6 +122,7 @@ let error_label = function
   | InvalidExpr _ -> "InvalidExpr"
   | MismatchType _ -> "MismatchType"
   | NotYetImplemented _ -> "NotYetImplemented"
+  | ObsoleteSyntax _ -> "ObsoleteSyntax"
   | ConflictingTypes _ -> "ConflictingTypes"
   | AssertionFailed _ -> "AssertionFailed"
   | CannotParse -> "CannotParse"
@@ -232,6 +234,8 @@ module PPrint = struct
           name expected provided
     | NotYetImplemented s ->
         pp_print_text f @@ "ASL Internal error: Not yet implemented: " ^ s
+    | ObsoleteSyntax s ->
+        fprintf f "%a@ %s" pp_print_text "ASL Grammar error: Obsolete syntax:" s
     | ConflictingTypes ([ expected ], provided) ->
         fprintf f
           "ASL Typing error:@ a subtype of@ %a@ was expected,@ provided %a."

--- a/asllib/libdir/stdlib.asl
+++ b/asllib/libdir/stdlib.asl
@@ -20,17 +20,17 @@
 func Min(a: integer, b: integer) => integer
 begin
   return if a < b then a else b;
-end
+end;
 
 func Max(a: integer, b: integer) => integer
 begin
   return if a > b then a else b;
-end
+end;
 
 func Abs(x: integer) => integer
 begin
   return if x < 0 then -x else x;
-end
+end;
 
 // Log2
 
@@ -38,13 +38,13 @@ end
 func IsEven(a: integer) => boolean
 begin
     return (a MOD 2) == 0;
-end
+end;
 
 // Return true if integer is odd (1 modulo 2).
 func IsOdd(a: integer) => boolean
 begin
     return (a MOD 2) == 1;
-end
+end;
 
 //------------------------------------------------------------------------------
 // Functions on reals
@@ -65,19 +65,19 @@ end
 func Abs(x: real) => real
 begin
   return if x >= 0.0 then x else -x;
-end
+end;
 
 // Maximum of reals.
 func Max(a: real, b: real) => real
 begin
   return if a>b then a else b;
-end
+end;
 
 // Minimum of reals.
 func Min(a: real, b: real) => real
 begin
   return if a<b then a else b;
-end
+end;
 
 // Calculate the square root of x to sf binary digits.
 // The second tuple element of the return value is TRUE if the result is
@@ -96,13 +96,13 @@ begin
   var xn: real = x0;
   while Abs(x - xn * xn) > precision do
     xn = (xn + x / xn) / 2.0 ;
-  end
+  end;
   let root = xn;
 
   let inexact = x != root * root;
 
   return (root, inexact);
-end
+end;
 
 //------------------------------------------------------------------------------
 // Standard bitvector functions and procedures
@@ -115,7 +115,7 @@ end
 func ReplicateBit(isZero: boolean, N: integer) => bits(N)
 begin
   return if isZero then Zeros(N) else Ones(N);
-end
+end;
 
 func Replicate{M}(x: bits(M), N: integer) => bits(M*N)
 begin
@@ -125,15 +125,15 @@ begin
     var r: bits(M*N) = Zeros(M*N);
     for i=0 to N-1 do
       r[i*:M] = x;
-    end
+    end;
     return r;
-  end
-end
+  end;
+end;
 
 func Len{N}(x: bits(N)) => integer {N}
 begin
   return N;
-end
+end;
 
 func BitCount{N}(x: bits(N)) => integer{0..N}
 begin
@@ -141,85 +141,85 @@ begin
   for i = 0 to N-1 do
     if x[i] == '1' then
       result = result + 1;
-    end
-  end
+    end;
+  end;
   return result as integer {0..N};
-end
+end;
 
 func LowestSetBit{N}(x: bits(N)) => integer{0..N}
 begin
   for i = 0 to N-1 do
     if x[i] == '1' then
       return i as integer{0..N};
-    end
-  end
+    end;
+  end;
   return N as integer {0..N};
-end
+end;
 
 func HighestSetBit{N}(x: bits(N)) => integer{-1..N-1}
 begin
   for i = N-1 downto 0 do
     if x[i] == '1' then
       return i as integer {-1..N-1};
-    end
-  end
+    end;
+  end;
   return -1 as {-1..N-1};
-end
+end;
 
 func Zeros(N: integer) => bits(N)
 begin
   return 0[N-1:0];
-end
+end;
 
 func Ones(N: integer) => bits(N)
 begin
   return NOT Zeros(N);
-end
+end;
 
 func IsZero{N}(x: bits(N)) => boolean
 begin
   return x == Zeros(N);
-end
+end;
 
 func IsOnes{N}(x: bits(N)) => boolean
 begin
   return x == Ones(N);
-end
+end;
 
 func SignExtend {M} (x: bits(M), N: integer) => bits(N)
 begin
   assert N >= M;
   return [Replicate(x[M-1], N - M), x];
-end
+end;
 
 func ZeroExtend {M} (x: bits(M), N: integer) => bits(N)
 begin
   assert N >= M;
   return [Zeros(N - M), x];
-end
+end;
 
 func Extend {M} (x: bits(M), N: integer, unsigned: boolean) => bits(N)
 begin
   return if unsigned then ZeroExtend(x, N) else SignExtend(x, N);
-end
+end;
 
 func CountLeadingZeroBits{N}(x: bits(N)) => integer {0..N}
 begin
   return N - 1 - HighestSetBit(x);
-end
+end;
 
 // Leading sign bits in a bitvector. Count the number of consecutive
 // bits following the leading bit, that are equal to it.
 func CountLeadingSignBits{N}(x: bits(N)) => integer{0..N-1}
 begin
   return CountLeadingZeroBits(x[N-1:1] XOR x[N-2:0]);
-end
+end;
 
 // Treating input as an integer, align down to nearest multiple of 2^y.
 func AlignDown{N}(x: bits(N), y: integer{1..N}) => bits(N)
 begin
     return [x[N-1:y], Zeros(y)];
-end
+end;
 
 // Treating input as an integer, align up to nearest multiple of 2^y.
 // Returns zero if the result is not representable in N bits.
@@ -229,8 +229,8 @@ begin
     return x;
   else
     return [x[N-1:y]+1, Zeros(y)];
-  end
-end
+  end;
+end;
 
 // The shift functions LSL, LSR, ASR and ROR accept a non-negative shift amount.
 // The shift functions LSL_C, LSR_C, ASR_C and ROR_C accept a non-zero positive shift amount.
@@ -244,8 +244,8 @@ begin
     return [x[(N-bshift)-1:0], Zeros(bshift)];
   else
     return Zeros(N);
-  end
-end
+  end;
+end;
 
 // Logical left shift with carry out.
 func LSL_C{N}(x: bits(N), shift: integer) => (bits(N), bit)
@@ -255,8 +255,8 @@ begin
     return (LSL(x, shift), x[N-shift]);
   else
     return (Zeros(N), '0');
-  end
-end
+  end;
+end;
 
 // Logical right shift, shifting zeroes into higher bits.
 func LSR{N}(x: bits(N), shift: integer) => bits(N)
@@ -267,8 +267,8 @@ begin
     return ZeroExtend(x[N-1:bshift], N);
   else
     return Zeros(N);
-  end
-end
+  end;
+end;
 
 // Logical right shift with carry out.
 func LSR_C{N}(x: bits(N), shift: integer) => (bits(N), bit)
@@ -278,8 +278,8 @@ begin
     return (LSR(x, shift), x[shift-1]);
   else
     return (Zeros(N), '0');
-  end
-end
+  end;
+end;
 
 // Arithmetic right shift, shifting sign bits into higher bits.
 func ASR{N}(x: bits(N), shift: integer) => bits(N)
@@ -287,14 +287,14 @@ begin
   assert shift >= 0;
   let bshift = Min(shift, N-1) as integer{0..N-1};
   return SignExtend(x[N-1:bshift], N);
-end
+end;
 
 // Arithmetic right shift with carry out.
 func ASR_C{N}(x: bits(N), shift: integer) => (bits(N), bit)
 begin
   assert shift > 0;
   return (ASR(x, shift), x[Min(shift-1, N-1)]);
-end
+end;
 
 // Rotate right.
 // This function shifts by [shift] bits to the right, the bits deleted are
@@ -304,7 +304,7 @@ begin
   assert shift >= 0;
   let cshift = (shift MOD N) as integer{0..N-1};
   return [x[0+:cshift], x[N-1:cshift]];
-end
+end;
 
 // Rotate right with carry out.
 // As ROR, the function effectively operates modulo N.
@@ -313,5 +313,4 @@ begin
   assert shift > 0;
   let cpos = (shift-1) MOD N;
   return (ROR(x, shift), x[cpos]);
-end
-
+end;

--- a/asllib/tests/ASLDefinition.t/Bitfields_nested.asl
+++ b/asllib/tests/ASLDefinition.t/Bitfields_nested.asl
@@ -30,4 +30,4 @@ begin
     assert common == common_fmt0;
     assert common == common_fmt1;
     return 0;
-end
+end;

--- a/asllib/tests/ASLDefinition.t/spec1.asl
+++ b/asllib/tests/ASLDefinition.t/spec1.asl
@@ -5,9 +5,9 @@ var R2: bits(4);
 func MyOR{M}(x: bits(M), y: bits(M)) => bits(M)
 begin
     return x OR y;
-end
+end;
 
 func reset()
 begin
     R2 = MyOR(R0, R1);
-end
+end;

--- a/asllib/tests/ASLDefinition.t/spec2.asl
+++ b/asllib/tests/ASLDefinition.t/spec2.asl
@@ -3,11 +3,11 @@ var COUNT: integer;
 func ColdReset()
 begin
     COUNT = 0;
-end
+end;
 
 func Step()
 begin
     assert COUNT >= 0;
     COUNT = COUNT + 1;
     assert COUNT > 0;
-end
+end;

--- a/asllib/tests/ASLDefinition.t/spec3.asl
+++ b/asllib/tests/ASLDefinition.t/spec3.asl
@@ -3,9 +3,9 @@ begin
     var n: integer = 0;
     for i = 0 to (N DIV 8) - 1 do
         n = n + UInt(a[i*:8]) * UInt(b[i*:8]);
-    end
+    end;
     return n[0 +: N];
-end
+end;
 
 var X: bits(16) = '1010 1111 0101 0000';
 
@@ -18,12 +18,12 @@ begin
         return 1;
     else
         return Fib(n - 1) + Fib(n - 2);
-    end
-end
+    end;
+end;
 
 func main() => integer
 begin
     X = Dot8(X, X);
     var fib10 = Fib(10);
     return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/EvalCatchers.asl
+++ b/asllib/tests/ASLSemanticsReference.t/EvalCatchers.asl
@@ -6,7 +6,7 @@ begin
     var x = 5;
     g = 1;
     throw MyExceptionType{};
-end
+end;
 
 func main() => integer
 begin
@@ -16,6 +16,6 @@ begin
      catch
        when MyExceptionType =>
          print(x, g);
-     end
+     end;
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCError.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCError.asl
@@ -4,5 +4,5 @@ begin
   let my_ctc = (3 as integer {3..5});
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCNotDynamicErrorIfFalse.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCNotDynamicErrorIfFalse.asl
@@ -1,9 +1,9 @@
 func f1()
 begin 
   return FALSE;
-end
+end;
 
 func checkY (y: integer)
 begin
-  if (f1() && f2(y as {2,4,8})) then pass; end
-end
+  if (f1() && f2(y as {2,4,8})) then pass; end;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCValue.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCValue.asl
@@ -5,5 +5,5 @@ begin
   assert my_ctc == 3;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCVariousErrors.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCVariousErrors.asl
@@ -7,5 +7,5 @@ begin
       var d: integer{4, 5, 6} = 2; // static error.
       // The following is not a dynamic error as will never be evaluated,
       var e: integer{4, 5, 6} = 2 as integer{4, 5, 6};
-  end
-end
+  end;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Block.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Block.asl
@@ -2,9 +2,9 @@ func main() => integer
 begin
   var x : integer = 1;
 
-  if TRUE then x = 2; let y = 2;  else pass; end
+  if TRUE then x = 2; let y = 2;  else pass; end;
   let y = 1;
   assert (x == 2 && y == 1);
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Catch.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Catch.asl
@@ -11,7 +11,7 @@ begin
         assert TRUE;
       otherwise =>
         assert FALSE;
-    end
+    end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchNamed.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchNamed.asl
@@ -10,7 +10,7 @@ begin
         assert exn.msg == 42;
     otherwise =>
       assert FALSE;
-    end
+    end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchNoThrow.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchNoThrow.asl
@@ -10,7 +10,7 @@ begin
         assert FALSE;
       otherwise =>
         assert FALSE;
-    end
+    end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchNone.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchNone.asl
@@ -11,10 +11,10 @@ begin
      catch
        when MyExceptionType2 =>
          assert FALSE;
-     end
+     end;
   catch MyExceptionType1;
     assert TRUE; 
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchOtherwise.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchOtherwise.asl
@@ -12,7 +12,7 @@ begin
          assert FALSE;
        otherwise =>
          print("Otherwise");
-     end
+     end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopAndFalse.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopAndFalse.asl
@@ -2,11 +2,11 @@ func fail() => boolean
 begin
   assert FALSE;
   return TRUE;
-end
+end;
 
 func main () => integer
 begin
   let b = FALSE && fail();
   assert b == FALSE;
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopDIVBackendDefinedError.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopDIVBackendDefinedError.asl
@@ -4,4 +4,4 @@ begin
   let x = 3 DIV 0;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopImplExFalso.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopImplExFalso.asl
@@ -3,4 +3,4 @@ begin
   let b = (0 == 1) --> (1 == 0);
   assert b;
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopOrTrue.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopOrTrue.asl
@@ -3,4 +3,4 @@ begin
   let b = (0 == 1) || (1 == 1);
   assert b;
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopPlusAssert.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopPlusAssert.asl
@@ -5,4 +5,4 @@ begin
   assert x==5;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopPlusPrint.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EBinopPlusPrint.asl
@@ -5,4 +5,4 @@ begin
   print(x);
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ECall.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ECall.asl
@@ -1,7 +1,7 @@
 func Return42() => integer 
 begin
   return 42;
-end
+end;
 
 func main () => integer
 begin
@@ -10,4 +10,4 @@ begin
   assert x == 42;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EConcat.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EConcat.asl
@@ -5,4 +5,4 @@ begin
   assert x=='1011';
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EConcat2.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EConcat2.asl
@@ -3,5 +3,5 @@ var T: boolean = [ '1111', '0000' ] == '11110000';
 func main () => integer
 begin
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ECondFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ECondFALSE.asl
@@ -1,7 +1,7 @@
 func Return42() => integer 
 begin
   return 42;
-end
+end;
 
 func main () => integer
 begin
@@ -10,4 +10,4 @@ begin
   assert x==3;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ECondUNKNOWN3or42.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ECondUNKNOWN3or42.asl
@@ -1,7 +1,7 @@
 func Return42() => integer 
 begin
   return 42;
-end
+end;
 
 func main () => integer
 begin
@@ -10,4 +10,4 @@ begin
   assert x==3;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGetArray.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGetArray.asl
@@ -9,4 +9,4 @@ begin
   assert my_array[2]==42;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGetArrayTooSmall.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGetArrayTooSmall.asl
@@ -6,4 +6,4 @@ func main () => integer
 begin
   print(my_array[3]);
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGlobalVar.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGlobalVar.asl
@@ -6,4 +6,4 @@ func main () => integer
     assert global_x == 3;
     return 0;
 
-  end
+  end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGlobalVarError.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGlobalVarError.asl
@@ -6,4 +6,4 @@ begin
   assert x == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ELocalVar.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ELocalVar.asl
@@ -5,4 +5,4 @@ begin
   assert x == 3;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EPatternFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EPatternFALSE.asl
@@ -5,4 +5,4 @@ begin
   assert x == FALSE;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EPatternTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EPatternTRUE.asl
@@ -5,4 +5,4 @@ begin
   assert x == TRUE;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ERecord.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ERecord.asl
@@ -7,4 +7,4 @@ begin
   assert my_record.a == 3;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ESlice.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ESlice.asl
@@ -5,4 +5,4 @@ begin
   assert x == '1110';
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ETuple.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ETuple.asl
@@ -1,7 +1,7 @@
 func Return42() => integer 
 begin
   return 42;
-end
+end;
 
 func main () => integer
 begin
@@ -11,4 +11,4 @@ begin
   assert y == 42;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUndefIdent.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUndefIdent.asl
@@ -5,5 +5,5 @@ begin
   assert y;
 
   return 0;
-end  
+end;  
 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnknownInteger0.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnknownInteger0.asl
@@ -5,4 +5,4 @@ begin
   assert x == 0;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnknownInteger3.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnknownInteger3.asl
@@ -5,4 +5,4 @@ begin
   assert x==3;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnknownIntegerRange3-42-3.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnknownIntegerRange3-42-3.asl
@@ -5,4 +5,4 @@ begin
   assert x==3;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnknownIntegerRange3-42-42.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnknownIntegerRange3-42-42.asl
@@ -5,4 +5,4 @@ begin
   assert x==42;
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnopAssert.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EUnopAssert.asl
@@ -5,4 +5,4 @@ begin
   assert x=='0101';
 
   return 0;
-end 
+end; 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.FCall.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.FCall.asl
@@ -3,14 +3,14 @@ begin
 
   return x + 1;
 
-end
+end;
 
 func bar (x : integer) 
 begin
 
   assert x == 3; 
 
-end
+end;
 
 func main () => integer
 begin
@@ -19,4 +19,4 @@ begin
   bar(3);
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.FPrimitive.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.FPrimitive.asl
@@ -4,5 +4,5 @@ begin
   print("Hello, world!");
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.FUndefIdent.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.FUndefIdent.asl
@@ -4,4 +4,4 @@ begin
      foo ();
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.For.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.For.asl
@@ -3,7 +3,7 @@ begin
 
   for i = 0 to 3 do
     assert i <= 3;
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDDiscard.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDDiscard.asl
@@ -5,4 +5,4 @@ begin
   assert TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTuple.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTuple.asl
@@ -6,4 +6,4 @@ begin
   assert x == 1 && y == 2 && z == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTyped.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTyped.asl
@@ -6,4 +6,4 @@ begin
   assert x == 42;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTypedTuple.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTypedTuple.asl
@@ -6,4 +6,4 @@ begin
   assert x == 0 && y == 0 && z == 0;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTypedVar.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDTypedVar.asl
@@ -6,4 +6,4 @@ begin
   assert x == 0;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTuple.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTuple.asl
@@ -6,4 +6,4 @@ begin
   assert x == 0 && y == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTyped.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTyped.asl
@@ -5,4 +5,4 @@ begin
   assert x == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDVar0.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDVar0.asl
@@ -6,4 +6,4 @@ begin
   assert x == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDVar1.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDVar1.asl
@@ -6,4 +6,4 @@ begin
   assert x == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LEDestructuring.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LEDestructuring.asl
@@ -9,4 +9,4 @@ begin
   assert x == 3 && y == 42;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LEDiscard.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LEDiscard.asl
@@ -5,4 +5,4 @@ begin
   assert TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LEGlobalVar.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LEGlobalVar.asl
@@ -7,4 +7,4 @@ begin
   assert x==42;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LELocalVar.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LELocalVar.asl
@@ -6,4 +6,4 @@ begin
   assert x == 42;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LESetArray.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LESetArray.asl
@@ -6,4 +6,4 @@ begin
   assert my_array[3] == 53;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LESetField.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LESetField.asl
@@ -8,4 +8,4 @@ begin
   assert my_record.a == 42 && my_record.b == 100;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LESlice.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LESlice.asl
@@ -6,4 +6,4 @@ begin
   assert x == '11110000';
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LEUndefIdentV1.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LEUndefIdentV1.asl
@@ -5,4 +5,4 @@ begin
   y = 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Lit.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Lit.asl
@@ -4,4 +4,4 @@ begin
   assert 3 == 3;
   return 0;
 
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Loop.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Loop.asl
@@ -6,7 +6,7 @@ begin
   while i <= 3 do
     assert i <= 3;
     i = i + 1;
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PAll.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PAll.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PAnyFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PAnyFALSE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == FALSE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PAnyTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PAnyTRUE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PGeqFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PGeqFALSE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == FALSE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PGeqTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PGeqTRUE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PLeqFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PLeqFALSE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == FALSE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PLeqTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PLeqTRUE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMaskFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMaskFALSE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == FALSE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMaskTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMaskTRUE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PNotFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PNotFALSE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == FALSE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PNotTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PNotTRUE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PRangeFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PRangeFALSE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == FALSE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PRangeTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PRangeTRUE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PSingleFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PSingleFALSE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == FALSE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PSingleTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PSingleTRUE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PTupleFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PTupleFALSE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == FALSE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PTupleTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PTupleTRUE.asl
@@ -5,4 +5,4 @@ begin
   assert match_me == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssertNo.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssertNo.asl
@@ -4,4 +4,4 @@ begin
   assert (42 == 3);
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssertOk.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssertOk.asl
@@ -4,4 +4,4 @@ begin
   assert (42 != 3);
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssign.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssign.asl
@@ -7,4 +7,4 @@ begin
   assert x == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssignCall.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssignCall.asl
@@ -1,7 +1,7 @@
 func f(x:integer) => (integer, integer)
 begin
   return (x,x+1);
-end
+end;
 
 func main() => integer
 begin
@@ -11,4 +11,4 @@ begin
 
   assert (a+b == 3);
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssignTuple.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SAssignTuple.asl
@@ -7,4 +7,4 @@ begin
 
   assert (b && x == 42);
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCall.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCall.asl
@@ -4,4 +4,4 @@ begin
   assert Zeros(3) == '000';
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCase.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCase.asl
@@ -5,7 +5,7 @@ begin
     when 42 => assert FALSE;
     when <= 42 => assert TRUE;
     otherwise => assert FALSE;
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCond.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCond.asl
@@ -4,7 +4,7 @@ begin
   if TRUE 
     then assert TRUE; 
     else assert FALSE; 
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCond2.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCond2.asl
@@ -10,6 +10,6 @@ var y:integer;
       return -1;
   else
       return 0;
-  end
+  end;
 
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCond3.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCond3.asl
@@ -5,5 +5,5 @@ begin
 
   if d IN {13,15} || n IN {13,15} then
       UNPREDICTABLE();
-  end
-end
+  end;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCond4.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCond4.asl
@@ -6,7 +6,7 @@ begin
 
   if size == '01' then
     esize = 16; elements = 4;
-  end
+  end;
 
 return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SDeclNone.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SDeclNone.asl
@@ -6,4 +6,4 @@ begin
   assert x == 0;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SDeclSome.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SDeclSome.asl
@@ -6,4 +6,4 @@ begin
   assert x == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SFor.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SFor.asl
@@ -4,7 +4,7 @@ begin
   for i = 0 to 3 do
     assert i <= 3;
     print(i);
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SPass.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SPass.asl
@@ -4,4 +4,4 @@ begin
   pass;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SRepeat.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SRepeat.asl
@@ -9,4 +9,4 @@ begin
   until i > 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SReturnNone.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SReturnNone.asl
@@ -4,11 +4,11 @@ begin
   for i = 0 to 42 do
     if i >= 3 then
       return;
-    end
-  end
+    end;
+  end;
   assert FALSE;
 
-end
+end;
 
 func main () => integer 
 begin 
@@ -16,4 +16,4 @@ begin
     print_me (); 
 
     return 0; 
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SReturnOne.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SReturnOne.asl
@@ -5,8 +5,8 @@ begin
     x = x + 1;
     assert x == 1; // Only the first loop is executed
     return 3;
-  end
-end
+  end;
+end;
 
 func main () => integer
 begin
@@ -14,5 +14,5 @@ begin
   assert f () == 3;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SReturnSome.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SReturnSome.asl
@@ -5,8 +5,8 @@ begin
     x = x + 1;
     assert x == 1; // Only the first loop is executed
     return (3, 42);
-  end
-end
+  end;
+end;
 
 func main () => integer
 begin
@@ -15,5 +15,5 @@ begin
   assert x == 3 && y == 42;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SSeq.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SSeq.asl
@@ -7,4 +7,4 @@ begin
   assert x == 3 && y == 4;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SThrowNone.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SThrowNone.asl
@@ -9,14 +9,14 @@ begin
     catch
       when MyExceptionType => throw;
       otherwise => assert FALSE;
-    end
+    end;
     assert FALSE;
 
   catch
     when exn: MyExceptionType =>
       assert exn.a == 42; 
     otherwise => assert FALSE;
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SThrowSomeTyped.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SThrowSomeTyped.asl
@@ -9,7 +9,7 @@ begin
     when exn: MyExceptionType =>
       assert exn.a == 42;
     otherwise => assert FALSE;
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.STry.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.STry.asl
@@ -9,7 +9,7 @@ begin
   catch 
     when MyExceptionType => assert TRUE;
     otherwise => assert FALSE;
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SWhile.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SWhile.asl
@@ -5,7 +5,7 @@ var i: integer = 0;
   while i <= 3 do
     assert i <= 3;
     i = i + 1;
-   end
+   end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SliceLength.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SliceLength.asl
@@ -5,5 +5,5 @@ begin
   assert x[2+:3] == '111';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SliceRange.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SliceRange.asl
@@ -6,4 +6,4 @@ begin
   assert x[4:2] == '111';
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SliceSingle.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SliceSingle.asl
@@ -5,4 +5,4 @@ begin
   assert x[2] == '1';
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SliceStar.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SliceStar.asl
@@ -5,5 +5,5 @@ begin
   assert x[3*:2] == '11';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLSemanticsReference.t/hello_world.asl
+++ b/asllib/tests/ASLSemanticsReference.t/hello_world.asl
@@ -2,4 +2,4 @@ func main() => integer
 begin
   print("Hello, world!");
   return 0;
-end
+end;

--- a/asllib/tests/ASLSyntaxReference.t/expr1.asl
+++ b/asllib/tests/ASLSyntaxReference.t/expr1.asl
@@ -1,11 +1,11 @@
-getter g_no_args => integer begin return 0; end
+getter g_no_args => integer begin return 0; end;
 
-getter g0_bits[] => bits(4) begin return '1000'; end
+getter g0_bits[] => bits(4) begin return '1000'; end;
 
 getter g1_bits[p: integer] => bits(4)
 begin
   return '1000'[p, 2:0];
-end
+end;
 
 type point of record{x: bits(4), y: bits(4)};
 type except of exception;
@@ -39,4 +39,4 @@ begin
   var b8 = [b0, b1];
   b8 = (NOT b8) AND UNKNOWN: bits(8);
   return 0;
-end
+end;

--- a/asllib/tests/ASLSyntaxReference.t/expr2.asl
+++ b/asllib/tests/ASLSyntaxReference.t/expr2.asl
@@ -1,17 +1,17 @@
 getter g_no_args => integer
 begin
   return 0;
-end
+end;
 
 getter g0_bits[] => bits(4)
 begin
   return '1000';
-end
+end;
 
 getter g1_bits[p: integer] => bits(4)
 begin
   return '1000'[p, 2:0];
-end
+end;
 
 type point of record{x: bits(4), y: bits(4)};
 type except of exception;
@@ -33,7 +33,7 @@ begin
   if (t2.item0 IN {'1110'}) then
     // E_Record 2: an exception construction.
     throw except{};
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateFuncSig.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateFuncSig.asl
@@ -8,4 +8,4 @@ func signature_example{A}(
     C: integer) => bits(A+B)
 begin
     return [bv, Ones(B)];
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.Block0.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.Block0.asl
@@ -3,8 +3,8 @@
       if TRUE then
          let i = 3;
          print (DecStr (i));
-      end
+      end;
       let i = "Some text";
       print (i);
-      return 0; 
-    end
+      return 0;
+    end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinAggregateTypes.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinAggregateTypes.asl
@@ -18,4 +18,4 @@ begin
   t2[CZ] = o.z;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinExceptionType.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinExceptionType.asl
@@ -7,7 +7,7 @@ begin
     throw Not_found {};
   else
     throw SyntaxException { message="syntax" };
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinSingularTypes.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinSingularTypes.asl
@@ -7,4 +7,4 @@ begin
   let z4 : bits(4) = '0000';
   let o2 : bits(2) = '11';
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckBinOp.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckBinOp.asl
@@ -4,4 +4,4 @@ begin
   var b: bits(10);
   var c: bits(10) = a XOR b; // Check that XOR operator is recognized by the lexer.
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EConcatUnresolvableToInteger.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EConcatUnresolvableToInteger.asl
@@ -1,7 +1,7 @@
 func foo{N}(x: bits(N)) => bit
 begin
     return x[0];
-end
+end;
 
 config LIMIT1: integer = 2;
 config LIMIT2: integer{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} = 7;
@@ -11,9 +11,9 @@ begin
     var ret: integer = 0;
     while ret < LIMIT1 do
         ret = ret + ret * 2;
-    end
+    end;
     return ret as integer{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-end
+end;
 
 func main() => integer
 begin
@@ -23,4 +23,4 @@ begin
     let y = Zeros(M);
     let z = foo([x, y]);
     return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EnumerationType.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EnumerationType.asl
@@ -4,4 +4,4 @@ func main () => integer
 begin
   assert (RED != BLACK);
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LDDiscard.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LDDiscard.asl
@@ -6,4 +6,4 @@ begin
   let - = '101010';
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LDTuple.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LDTuple.asl
@@ -6,5 +6,5 @@ begin
 
   assert x == 5 && y;
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LDTyped.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LDTyped.asl
@@ -3,7 +3,7 @@ type MyT of integer;
 func foo (t: MyT) => integer
 begin
   return t as integer;
-end
+end;
 
 func main () => integer
 begin
@@ -14,4 +14,4 @@ begin
   assert foo (z) == 0;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LDVar.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LDVar.asl
@@ -4,4 +4,4 @@ begin
   assert x == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.Lit.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.Lit.asl
@@ -12,4 +12,4 @@ begin
   var bv1 = '11 01'; // type: bits(4)
   var bv2 = ''; // type: bits(0)
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TArray.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TArray.asl
@@ -10,7 +10,7 @@ begin
   var y = x;
   y[3] = 2;
   return y;
-end
+end;
 
 func main () => integer
 begin
@@ -20,4 +20,4 @@ begin
   x = foo (x as array [4] of integer);
   let y: array [4] of integer = x;
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TBitField.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TBitField.asl
@@ -4,7 +4,7 @@ func foo (x: bits(4) { [3:2] A, [1] B }) =>
   bits(4) { [3:2] A, [1] B }
 begin
   return x;
-end
+end;
 
 func main () => integer
 begin
@@ -18,4 +18,4 @@ begin
   assert x as bits(4) { [3:2] A, [1] B } == x;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TBits.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TBits.asl
@@ -3,7 +3,7 @@ type MyType of bits(4);
 func foo (x: bits(4)) => bits(4)
 begin
   return NOT x;
-end
+end;
 
 func main () => integer
 begin
@@ -17,5 +17,5 @@ begin
   assert x as bits(4) == x;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TBool.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TBool.asl
@@ -3,7 +3,7 @@ type MyType of boolean;
 func foo (x: boolean) => boolean
 begin
   return FALSE --> x;
-end
+end;
 
 func main () => integer
 begin
@@ -17,4 +17,4 @@ begin
   assert x as boolean == x;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TIntUnConstrained.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TIntUnConstrained.asl
@@ -2,7 +2,7 @@ type MyType of integer;
 func foo (x: integer) => integer
 begin
   return x;
-end
+end;
 
 func main () => integer
 begin
@@ -16,5 +16,5 @@ begin
   assert x as integer == x;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TIntUnderConstrained.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TIntUnderConstrained.asl
@@ -1,12 +1,12 @@
 func foo {N} (x: bits(N)) => integer
 begin
   return N;
-end
+end;
 
 func bar (N: integer) => bits(N)
 begin
   return Zeros(N);
-end
+end;
 
 func main() => integer
 begin
@@ -14,5 +14,5 @@ begin
   assert bar(3) == '000';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TIntWellConstrained.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TIntWellConstrained.asl
@@ -3,7 +3,7 @@ type MyType of integer {1..12};
 func foo (x: integer {1..12}) => integer {1..12}
 begin
   return x;
-end
+end;
 
 func main () => integer
 begin
@@ -17,5 +17,5 @@ begin
   assert x as integer {1..11} == x;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TNamed.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TNamed.asl
@@ -3,7 +3,7 @@ type MyType of integer;
 func foo (x: MyType) => MyType
 begin
   return x;
-end
+end;
 
 func main () => integer
 begin
@@ -17,5 +17,5 @@ begin
   assert x as MyType == x;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TNonDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TNonDecl.asl
@@ -1,2 +1,2 @@
 func (x: record { a: integer, b: boolean }) => integer
-begin return 0; end
+begin return 0; end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TReal.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TReal.asl
@@ -3,7 +3,7 @@ type MyType of real;
 func foo (x: real) => real
 begin
   return x + 1.0;
-end
+end;
 
 func main () => integer
 begin
@@ -17,5 +17,5 @@ begin
   assert x as real == x;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TRecordExceptionDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TRecordExceptionDecl.asl
@@ -2,5 +2,5 @@ type MyRecord of record { a: integer, b: boolean };
 type MyException of exception { a: integer, b: boolean };
 
 func main () => integer
-begin return 0; end
+begin return 0; end;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TString.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TString.asl
@@ -3,7 +3,7 @@ type MyType of string;
 func foo (x: string) => string
 begin
   return x;
-end
+end;
 
 func main () => integer
 begin
@@ -17,4 +17,4 @@ begin
   assert x as string == x;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TTuple.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TTuple.asl
@@ -4,7 +4,7 @@ func foo (x: (integer, boolean)) => (integer, boolean)
 begin
   let (z, y): (integer, boolean) = x;
   return (z + 1, FALSE --> y);
-end
+end;
 
 func main () => integer
 begin
@@ -19,4 +19,4 @@ begin
   assert x0 == 4 && x1 == TRUE;
 
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypeSatisfaction1.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypeSatisfaction1.asl
@@ -11,4 +11,4 @@ begin
   var pair: pairT = (1, dataT1);
   // legal since the right hand side has anonymous, non-primitive type (integer, T1)
 return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypeSatisfaction2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypeSatisfaction2.asl
@@ -15,4 +15,4 @@ begin
   // legal since the right-hand-side has anonymous, 
   // primitive type (integer, integer)
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypeSatisfaction3.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypeSatisfaction3.asl
@@ -16,4 +16,4 @@ begin
   // non-primitive type (integer, T2)
   // which does not subtype-satisfy named type pairT
   return 0;
-end
+end;

--- a/asllib/tests/ASLTypingReference.t/hello_world.asl
+++ b/asllib/tests/ASLTypingReference.t/hello_world.asl
@@ -2,4 +2,4 @@ func main() => integer
 begin
   print("Hello, world!");
   return 0;
-end
+end;

--- a/asllib/tests/allow_no_end_semicolon.t
+++ b/asllib/tests/allow_no_end_semicolon.t
@@ -1,0 +1,16 @@
+We should be able to make semicolons after 'end' optional
+  $ cat >no_semicolon.asl <<EOF
+  > func main () => integer
+  > begin
+  >   if TRUE then
+  >      print("test");
+  >   end
+  >   return 0;
+  > end
+  > EOF
+  $ aslref no_semicolon.asl
+  File no_semicolon.asl, line 5, characters 2 to 5:
+  ASL Grammar error: Obsolete syntax: Missing ';' after 'end' keyword.
+  [1]
+  $ aslref --allow-no-end-semicolon no_semicolon.asl
+  test

--- a/asllib/tests/atcs.t
+++ b/asllib/tests/atcs.t
@@ -3,7 +3,7 @@ Deferred to execution ATCs
   > func main () => integer begin
   >   let x = (3 as integer {42});
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref atcs1.asl
@@ -17,7 +17,7 @@ Bad structure ATCs
   > func main () => integer begin
   >   let x = (3 as boolean);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref atcs2.asl
@@ -31,7 +31,7 @@ ATCs on other types
   > func main () => integer begin
   >   let x = ("a string" as string);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref atcs3.asl
@@ -41,7 +41,7 @@ ATCs on other types
   > func main () => integer begin
   >   let x = (myty { a = 4, b = Zeros(4) }) as myty;
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref atcs4.asl
@@ -53,7 +53,7 @@ ATCs on other types
   >   let x = (myty { a = 4, b = Zeros(4) }) as myty;
   >   let y = x as myty2;
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref atcs5.asl
@@ -66,7 +66,7 @@ ATCs on other types
   > func main () => integer begin
   >   let x = ((42, Zeros(4)) as myty);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref atcs6.asl
@@ -80,7 +80,7 @@ ATCs on other types
   > func main () => integer begin
   >   let x = ((42, Zeros(4)) as myty);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref atcs7.asl
@@ -94,7 +94,7 @@ ATCs on other types
   >     var a: array[10] of B;
   >     let b = a as array[10] of A;
   >     return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref atcs8.asl

--- a/asllib/tests/control-flow.t/always-throw.asl
+++ b/asllib/tests/control-flow.t/always-throw.asl
@@ -3,7 +3,7 @@ type E of exception {};
 func always_throws () => integer
 begin
   throw E {};
-end
+end;
 
 func main () => integer
 begin
@@ -12,10 +12,9 @@ begin
     let x = always_throws ();
   catch
     when E => y = 42;
-  end
+  end;
 
   assert y == 42;
 
   return 0;
-end
-
+end;

--- a/asllib/tests/control-flow.t/if-return-if.asl
+++ b/asllib/tests/control-flow.t/if-return-if.asl
@@ -1,9 +1,9 @@
 func sign (n: integer) => integer
 begin
   if n <= 0 then return -1;
-  else if n >= 0 then return 1; end
-  end
-end
+  else if n >= 0 then return 1; end;
+  end;
+end;
 
 func main () => integer
 begin
@@ -12,5 +12,4 @@ begin
   assert (sign (2) == 1);
 
   return 0;
-end
-
+end;

--- a/asllib/tests/control-flow.t/if-return-return.asl
+++ b/asllib/tests/control-flow.t/if-return-return.asl
@@ -2,8 +2,8 @@ func sign (n: integer) => integer
 begin
   if n <= 0 then return -1;
   else return 1;
-  end
-end
+  end;
+end;
 
 func main () => integer
 begin
@@ -12,5 +12,4 @@ begin
   assert (sign (2) == 1);
 
   return 0;
-end
-
+end;

--- a/asllib/tests/control-flow.t/if-return-throw.asl
+++ b/asllib/tests/control-flow.t/if-return-throw.asl
@@ -4,8 +4,8 @@ func foo (x: integer) => integer
 begin
   if x >= 0 then return x;
   else throw E {};
-  end
-end
+  end;
+end;
 
 func main () => integer
 begin
@@ -13,5 +13,4 @@ begin
   assert foo (3) == 3;
 
   return 0;
-end
-
+end;

--- a/asllib/tests/control-flow.t/if-return.asl
+++ b/asllib/tests/control-flow.t/if-return.asl
@@ -1,4 +1,4 @@
 func sign (n: integer) => integer
 begin
-  if n >= 0 then return 1; end
-end
+  if n >= 0 then return 1; end;
+end;

--- a/asllib/tests/control-flow.t/inherited-always-throw.asl
+++ b/asllib/tests/control-flow.t/inherited-always-throw.asl
@@ -3,12 +3,12 @@ type E of exception {};
 func always_throws () => integer
 begin
   throw E {};
-end
+end;
 
 func inherited_always_throws () => integer
 begin
   let - = always_throws ();
-end
+end;
 
 func main () => integer
 begin
@@ -17,11 +17,9 @@ begin
     let x = inherited_always_throws ();
   catch
     when E => y = 42;
-  end
+  end;
 
   assert y == 42;
 
   return 0;
-end
-
-
+end;

--- a/asllib/tests/control-flow.t/no-return.asl
+++ b/asllib/tests/control-flow.t/no-return.asl
@@ -1,3 +1,3 @@
 func main () => integer
 begin
-end
+end;

--- a/asllib/tests/control-flow.t/run.t
+++ b/asllib/tests/control-flow.t/run.t
@@ -14,7 +14,7 @@
   [1]
 
   $ aslref if-return.asl
-  File if-return.asl, line 3, characters 2 to 30:
+  File if-return.asl, line 3, characters 2 to 31:
   ASL Typing error: function "sign" does not return anything.
   [1]
 
@@ -23,7 +23,6 @@
   $ aslref if-return-throw.asl
 
   $ aslref if-return-if.asl
-  File if-return-if.asl, line 3, character 2 to line 5, character 5:
+  File if-return-if.asl, line 3, character 2 to line 5, character 6:
   ASL Typing error: function "sign" does not return anything.
   [1]
-

--- a/asllib/tests/control-flow.t/with-return.asl
+++ b/asllib/tests/control-flow.t/with-return.asl
@@ -1,4 +1,4 @@
 func main () => integer
 begin
   return 0;
-end
+end;

--- a/asllib/tests/division.t/TNegative9-1.asl
+++ b/asllib/tests/division.t/TNegative9-1.asl
@@ -3,4 +3,4 @@ begin
     let testB : bits(N) = [Zeros(N DIV 4), Zeros(N DIV 2)]; // bits(3N/4) != bits(N)
     // Type of Zeros(N) its bits(N), not bits(M), so this is illegal regardless of the fact that N and M have the same domain,
     // they could have different runtime values so we must evaluate the type safety symbolically
-end
+end;

--- a/asllib/tests/division.t/TPositive9.asl
+++ b/asllib/tests/division.t/TPositive9.asl
@@ -1,4 +1,4 @@
 func positive9(N : integer {8,16}, M : integer {8,16})
 begin
     let testF : bits(N)   = [Zeros(N DIV 2), Zeros(N DIV 2)]; // type system must work out that [bits(N/2), bits(N/2)] is the same as bits(N)
-end
+end;

--- a/asllib/tests/division.t/div-by-param.asl
+++ b/asllib/tests/division.t/div-by-param.asl
@@ -1,12 +1,12 @@
 func foo {N} (x: bits(N))
 begin
   let y = 5 DIV (N + 1);
-end
+end;
 
 func main () => integer
 begin
   foo ('1');
   foo ('');
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/div-constants.asl
+++ b/asllib/tests/division.t/div-constants.asl
@@ -3,4 +3,4 @@ constant y: integer = 2;
 constant z: integer = x DIV y;
 
 func main () => integer
-begin return 0; end
+begin return 0; end;

--- a/asllib/tests/division.t/div-multi-slices-zero.asl
+++ b/asllib/tests/division.t/div-multi-slices-zero.asl
@@ -6,6 +6,6 @@ begin
   let z = x DIV y;
 
   return 0;
-end
+end;
 
 

--- a/asllib/tests/division.t/div-multi-slices.asl
+++ b/asllib/tests/division.t/div-multi-slices.asl
@@ -6,5 +6,5 @@ begin
   let z = x DIV y;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/dynamic-div-neg.asl
+++ b/asllib/tests/division.t/dynamic-div-neg.asl
@@ -4,5 +4,5 @@ begin
   let y: integer = -3;
   let z = x DIV y;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/dynamic-div-undiv.asl
+++ b/asllib/tests/division.t/dynamic-div-undiv.asl
@@ -4,5 +4,5 @@ begin
   let y: integer = 3;
   let z = x DIV y;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/dynamic-div-zero.asl
+++ b/asllib/tests/division.t/dynamic-div-zero.asl
@@ -4,5 +4,5 @@ begin
   let y: integer = 0;
   let z = x DIV y;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/dynamic-divrm-neg.asl
+++ b/asllib/tests/division.t/dynamic-divrm-neg.asl
@@ -4,5 +4,5 @@ begin
   let y: integer = -3;
   let z = x DIVRM y;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/dynamic-divrm-zero.asl
+++ b/asllib/tests/division.t/dynamic-divrm-zero.asl
@@ -4,5 +4,5 @@ begin
   let y: integer = 0;
   let z = x DIVRM y;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/dynamic-mod-neg.asl
+++ b/asllib/tests/division.t/dynamic-mod-neg.asl
@@ -4,5 +4,5 @@ begin
   let y: integer = -3;
   let z = x MOD y;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/dynamic-mod-zero.asl
+++ b/asllib/tests/division.t/dynamic-mod-zero.asl
@@ -4,5 +4,5 @@ begin
   let y: integer = 0;
   let z = x MOD y;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/examples.asl
+++ b/asllib/tests/division.t/examples.asl
@@ -15,4 +15,4 @@ begin
   assert -5 MOD 3 == 1;
 
   return 0;
-end
+end;

--- a/asllib/tests/division.t/param-div-2.asl
+++ b/asllib/tests/division.t/param-div-2.asl
@@ -2,7 +2,7 @@ func foo {N} (bv: bits(N)) => bits(N)
 begin
   let y = Ones (N DIV 2);
   return [Zeros(N DIV 2), y];
-end
+end;
 
 func main () => integer
 begin
@@ -13,4 +13,4 @@ begin
   let - = foo ('101');
 
   return 0;
-end
+end;

--- a/asllib/tests/division.t/rat-poly-00.asl
+++ b/asllib/tests/division.t/rat-poly-00.asl
@@ -1,7 +1,7 @@
 func FirstHalf {N} (bv: bits(N)) => bits (N DIV 2)
 begin
   return bv[0+:N DIV 2];
-end
+end;
 
 func main () => integer
 begin
@@ -15,4 +15,4 @@ begin
   assert c == '000';
   
   return 0;
-end
+end;

--- a/asllib/tests/division.t/rat-poly-01.asl
+++ b/asllib/tests/division.t/rat-poly-01.asl
@@ -3,7 +3,7 @@ begin
   let y = Zeros(2 * ((N DIV 2) - 5));
   let z = Zeros(10);
   return [y, z];
-end
+end;
 
 func main () => integer
 begin
@@ -13,4 +13,4 @@ begin
   let d = foo(Zeros(9));
 
   return 0;
-end
+end;

--- a/asllib/tests/division.t/static-div-intervals.asl
+++ b/asllib/tests/division.t/static-div-intervals.asl
@@ -8,4 +8,4 @@ begin
   let e : integer {10..20} = 10;
   let f: integer {1..2} = e DIV d;
   let g: integer {1} = d DIV e;
-end
+end;

--- a/asllib/tests/division.t/static-div-neg.asl
+++ b/asllib/tests/division.t/static-div-neg.asl
@@ -2,5 +2,5 @@ func main () => integer
 begin
   let x: integer = 6 DIV -3;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/static-div-undiv-bis.asl
+++ b/asllib/tests/division.t/static-div-undiv-bis.asl
@@ -3,4 +3,4 @@ begin
   let x = (1 DIV 2) as integer {3, 4};
 
   return 0;
-end
+end;

--- a/asllib/tests/division.t/static-div-undiv-ter.asl
+++ b/asllib/tests/division.t/static-div-undiv-ter.asl
@@ -4,5 +4,5 @@ begin
   let b = a DIV 2 as integer {1};
 
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/static-div-undiv.asl
+++ b/asllib/tests/division.t/static-div-undiv.asl
@@ -2,5 +2,5 @@ func main () => integer
 begin
   let x: integer = 5 DIV 3;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/static-div-zero.asl
+++ b/asllib/tests/division.t/static-div-zero.asl
@@ -2,5 +2,5 @@ func main () => integer
 begin
   let x: integer = 6 DIV 0;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/static-divrm-neg.asl
+++ b/asllib/tests/division.t/static-divrm-neg.asl
@@ -2,5 +2,5 @@ func main () => integer
 begin
   let x: integer = 6 DIVRM -3;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/static-divrm-zero.asl
+++ b/asllib/tests/division.t/static-divrm-zero.asl
@@ -2,5 +2,5 @@ func main () => integer
 begin
   let x: integer = 6 DIVRM 0;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/static-mod-intervals.asl
+++ b/asllib/tests/division.t/static-mod-intervals.asl
@@ -6,5 +6,4 @@ begin
 
   let d: integer {0..20} = c MOD a;
   let e: integer {0..a} = c MOD b;
-end
-
+end;

--- a/asllib/tests/division.t/static-mod-neg.asl
+++ b/asllib/tests/division.t/static-mod-neg.asl
@@ -2,5 +2,5 @@ func main () => integer
 begin
   let x: integer = 6 MOD -3;
   return 0;
-end
+end;
 

--- a/asllib/tests/division.t/static-mod-zero.asl
+++ b/asllib/tests/division.t/static-mod-zero.asl
@@ -2,5 +2,5 @@ func main () => integer
 begin
   let x: integer = 6 MOD 0;
   return 0;
-end
+end;
 

--- a/asllib/tests/intersecting_slices.t
+++ b/asllib/tests/intersecting_slices.t
@@ -7,7 +7,7 @@ One slice cannot intersect itself:
   >   x[i] = '1';
   >   print (x);
   >   return 0;
-  > end
+  > end;
   > EOF
   $ aslref intersecting_slices1.asl
   '0001'
@@ -21,7 +21,7 @@ Two intersecting slices...
   >   x[i, j] = '10';
   >   print (x);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref intersecting_slices2.asl
@@ -39,7 +39,7 @@ Two maybe intersecting slices...
   >   x[i, j] = '10';
   >   print (x);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref intersecting_slices3.asl
@@ -52,13 +52,13 @@ Two maybe intersecting slices...
   >   var bv2 = bv;
   >   bv2[x,y] = '10'; // Should fail dynamically for x == y
   >   return bv2;
-  > end
+  > end;
   > func main () => integer
   > begin
   >   print (set_unset('1111', 2, 3));
   >   print (set_unset('1111', 2, 2));
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref intersecting_slices3b.asl
@@ -75,7 +75,7 @@ Two intersecting bitfields
   >   x.[f1, f2] = '10';
   >   print (x);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref intersecting_slices4.asl

--- a/asllib/tests/lca.t
+++ b/asllib/tests/lca.t
@@ -5,7 +5,7 @@
   >   let -: integer = x;
   >   let -: integer {2, 3} = x;
   >   let -: real = x;
-  > end
+  > end;
   > EOF
 
   $ aslref lca1.asl
@@ -19,7 +19,7 @@
   >   let x = if UNKNOWN: boolean then 2 as integer else 3;
   >   let -: integer = x;
   >   let -: integer {2, 3} = x;
-  > end
+  > end;
   > EOF
 
   $ aslref lca2.asl
@@ -33,7 +33,7 @@
   >   let x = if UNKNOWN: boolean then N else 3;
   >   let -: integer = x;
   >   let -: integer {N} = x;
-  > end
+  > end;
   > EOF
 
   $ aslref lca3.asl
@@ -47,7 +47,7 @@
   > begin
   >   let x = if UNKNOWN: boolean then 3 as integer {0..N} else 3;
   >   let -: real = x;
-  > end
+  > end;
   > EOF
 
   $ aslref lca4.asl
@@ -59,7 +59,7 @@
   > func main () => integer
   > begin
   >   let x = if UNKNOWN: boolean then TRUE else 3;
-  > end
+  > end;
   > EOF
 
   $ aslref lca5.asl
@@ -76,7 +76,7 @@
   > begin
   >   let x = if UNKNOWN: boolean then 3 as T3 else 2 as T2;
   >   let -: real = x;
-  > end
+  > end;
   > EOF
 
   $ aslref lca6.asl
@@ -90,7 +90,7 @@
   > func main () => integer
   > begin
   >   let - = if UNKNOWN: boolean then 3 as T1 else 2 as T2;
-  > end
+  > end;
   > EOF
 
   $ aslref lca7.asl
@@ -105,7 +105,7 @@
   > begin
   >   let x = if UNKNOWN: boolean then '101' as T1 else '101' as bits(3);
   >   let -: real = x;
-  > end
+  > end;
   > EOF
 
   $ aslref lca8.asl
@@ -120,7 +120,7 @@
   >   let x = if UNKNOWN: boolean then '101' as T1 else '101' as bits (3) { [2] b1 };
   >   let -: bits(3) { [2] b1 } = x;
   >   let -: real = x;
-  > end
+  > end;
   > EOF
 
   $ aslref lca9.asl
@@ -136,7 +136,7 @@
   >   let x = if UNKNOWN: boolean then 3 as T1 else 2 as T2;
   >   let -: integer = x;
   >   let -: real = x;
-  > end
+  > end;
   > EOF
 
   $ aslref lca10.asl
@@ -151,7 +151,7 @@
   >   let x = if UNKNOWN: boolean then 3 as T1 else 2 as integer;
   >   let -: T1 = x;
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref lca11.asl
@@ -163,7 +163,7 @@
   >   let x = if UNKNOWN: boolean then (3 as integer, 2 as T1) else (3 as T1, 2 as integer);
   >   let -: (T1, T1) = x;
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref lca12.asl
@@ -173,7 +173,7 @@
   > begin
   >   let v : (integer{3,1}, integer{2,4}) = if UNKNOWN: boolean then (3, 2) else (1, 4);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref lca13.asl
@@ -186,7 +186,7 @@
   >   var b: array[4] of T1;
   >   let x = if UNKNOWN: boolean then a else b;
   >   let -: real = x;
-  > end
+  > end;
   > EOF
 
   $ aslref lca14.asl

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -1,6 +1,6 @@
   $ cat >print1.asl <<EOF
   > constant msg = "old pond\\nfrog leaps in\\nwater's sound";
-  > func main () => integer begin print(msg); return 0; end
+  > func main () => integer begin print(msg); return 0; end;
   > EOF
   $ aslref print1.asl
   old pond
@@ -8,7 +8,7 @@
   water's sound
   $ cat >print2.asl <<EOF
   > constant msg = "old pond\\n\\tfrog\\tleaps in\\nwater's\\tsound";
-  > func main () => integer begin print(msg); return 0; end
+  > func main () => integer begin print(msg); return 0; end;
   > EOF
   $ aslref print2.asl
   old pond
@@ -16,7 +16,7 @@
   water's	sound
   $ cat >print3.asl <<EOF
   > constant msg = "Check out this haiku:\\n\\t\\"old pond\\n\\tfrog leaps in\\n\\twater's sound\\"";
-  > func main () => integer begin print(msg); return 0; end
+  > func main () => integer begin print(msg); return 0; end;
   > EOF
   $ aslref print3.asl
   Check out this haiku:
@@ -25,13 +25,13 @@
   	water's sound"
   $ cat >print4.asl <<EOF
   > constant msg = "Something with \\\\ backslashes.";
-  > func main () => integer begin print(msg); return 0; end
+  > func main () => integer begin print(msg); return 0; end;
   > EOF
   $ aslref print4.asl
   Something with \ backslashes.
   $ cat >print5.asl <<EOF
   > constant msg = "Something with \\p bad characters.";
-  > func main () => integer begin print(msg); return 0; end
+  > func main () => integer begin print(msg); return 0; end;
   > EOF
   $ aslref print5.asl
   File print5.asl, line 1, characters 32 to 33:
@@ -39,7 +39,7 @@
   [1]
   $ cat >print6.asl <<EOF
   > constant msg = "Some unterminated string;
-  > func main () => integer begin print(msg); return 0; end
+  > func main () => integer begin print(msg); return 0; end;
   > EOF
   $ aslref print6.asl
   File print6.asl, line 3, character 0:
@@ -55,7 +55,7 @@ C-Style comments
   > that finishes somewhere **/ print (msg); // but not here! */
   > return 0; /* oh a new one */
   > // /* when in a commented line, it doesn't count!
-  > end
+  > end;
   > EOF
 
   $ aslref comments1.asl
@@ -90,7 +90,7 @@ Some problems with bitvectors and bitmasks:
   >     let expr_c = '' IN {'0'};
   >     let expr_d = '0' IN {''};
   >     return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref masks0.asl

--- a/asllib/tests/print.t
+++ b/asllib/tests/print.t
@@ -4,7 +4,7 @@
   >   print ("no type-checking");
   >   print (32);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref printer1.asl
@@ -18,7 +18,7 @@
   >   print ("no type-checking");
   >   print (32);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref printer2.asl

--- a/asllib/tests/recursive.t/double-recursive-constant.asl
+++ b/asllib/tests/recursive.t/double-recursive-constant.asl
@@ -4,5 +4,5 @@ constant y = x + 2;
 func main () => integer
 begin
   return 0;
-end
+end;
 

--- a/asllib/tests/recursive.t/double-recursive-types.asl
+++ b/asllib/tests/recursive.t/double-recursive-types.asl
@@ -4,4 +4,4 @@ type node of (integer, tree);
 func main () => integer
 begin
   return 0;
-end
+end;

--- a/asllib/tests/recursive.t/double-recursive.asl
+++ b/asllib/tests/recursive.t/double-recursive.asl
@@ -4,22 +4,22 @@ begin
     return 1 + g (x - 1);
   else
     return 0;
-  end
-end
+  end;
+end;
 
 func g (x: integer) => integer
 begin
   return f (x);
-end
+end;
 
 func main () => integer
 begin
   assert f(0) == 1;
   for i = -1 to 20 do
     assert f(i) == i + 1;
-  end
+  end;
 
   return 0;
-end
+end;
   
 

--- a/asllib/tests/recursive.t/enum-fn-recursive.asl
+++ b/asllib/tests/recursive.t/enum-fn-recursive.asl
@@ -6,11 +6,11 @@ begin
   var f = D;
 
   return x;
-end
+end;
 
 type MyEnum2 of enumeration { D, E, F };
 
 func main () => integer
 begin
   return foo(0);
-end
+end;

--- a/asllib/tests/recursive.t/fn-val-recursive.asl
+++ b/asllib/tests/recursive.t/fn-val-recursive.asl
@@ -3,9 +3,9 @@ var x = f (4, 5);
 func f (y: integer, z: integer) => integer
 begin
   return x + y + z;
-end
+end;
 
 func main () => integer
 begin
   return 0;
-end
+end;

--- a/asllib/tests/recursive.t/recursive-constant.asl
+++ b/asllib/tests/recursive.t/recursive-constant.asl
@@ -3,4 +3,4 @@ constant x = x + 3;
 func main () => integer
 begin
   return 0;
-end
+end;

--- a/asllib/tests/recursive.t/recursive-type.asl
+++ b/asllib/tests/recursive.t/recursive-type.asl
@@ -3,4 +3,4 @@ type tree of (tree, integer, tree);
 func main () => integer
 begin
   return 0;
-end
+end;

--- a/asllib/tests/recursive.t/simple-recursive.asl
+++ b/asllib/tests/recursive.t/simple-recursive.asl
@@ -4,17 +4,17 @@ begin
     return 1 + f (x - 1);
   else
     return 0;
-  end
-end
+  end;
+end;
 
 func main () => integer
 begin
   assert f(0) == 1;
   for i = -1 to 20 do
     assert f(i) == i + 1;
-  end
+  end;
 
   return 0;
-end
+end;
   
 

--- a/asllib/tests/recursive.t/type-val-recursive.asl
+++ b/asllib/tests/recursive.t/type-val-recursive.asl
@@ -5,5 +5,5 @@ type MyT of integer {x};
 func main () => integer
 begin
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/anonymous-types-example-success.asl
+++ b/asllib/tests/regressions.t/anonymous-types-example-success.asl
@@ -21,7 +21,7 @@ begin
   // pair = (1, dataT2);
   // illegal since right hand side has anonymous, non-primitive type (integer, T2)
   // which does not subtype-satisfy named type pairT
-end
+end;
 
 func main () => integer
 begin
@@ -29,7 +29,7 @@ begin
   tsub01();
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/anonymous-types-example.asl
+++ b/asllib/tests/regressions.t/anonymous-types-example.asl
@@ -21,7 +21,7 @@ begin
   pair = (1, dataT2);
   // illegal since right hand side has anonymous, non-primitive type (integer, T2)
   // which does not subtype-satisfy named type pairT
-end
+end;
 
 func main () => integer
 begin
@@ -29,5 +29,5 @@ begin
   tsub01();
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/arg-as-param-call.asl
+++ b/asllib/tests/regressions.t/arg-as-param-call.asl
@@ -1,10 +1,10 @@
 func test(N: integer, a: bits(N))
 begin
     pass;
-end
+end;
 
 func main() => integer
 begin
     test(10, '1111');
     return 0;
-end
+end;

--- a/asllib/tests/regressions.t/array-index-error.asl
+++ b/asllib/tests/regressions.t/array-index-error.asl
@@ -9,5 +9,5 @@ begin
   let x = arr[14];
 
   return 1;
-end
+end;
   

--- a/asllib/tests/regressions.t/array-lca.asl
+++ b/asllib/tests/regressions.t/array-lca.asl
@@ -6,5 +6,5 @@ begin
     var c : array[5] of A;
     var x = if (b) then a else c;
     return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/array-with-enums.asl
+++ b/asllib/tests/regressions.t/array-with-enums.asl
@@ -19,4 +19,4 @@ begin
   assert myArray[MyEnumB] == 4;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/array.asl
+++ b/asllib/tests/regressions.t/array.asl
@@ -5,7 +5,7 @@ var global_a: a;
 func get_2(local_a: a) => integer
 begin
   return local_a[2];
-end
+end;
 
 func main () => integer
 begin
@@ -17,5 +17,5 @@ begin
   assert get_2(local_a) == 5;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/assign-to-global-immutable.asl
+++ b/asllib/tests/regressions.t/assign-to-global-immutable.asl
@@ -5,4 +5,4 @@ begin
   my_immutable_global = 4;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/assign1.asl
+++ b/asllib/tests/regressions.t/assign1.asl
@@ -4,7 +4,7 @@ begin
     assert x == 3;
 
     return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/bad-equality.asl
+++ b/asllib/tests/regressions.t/bad-equality.asl
@@ -2,4 +2,4 @@ func main () => integer
 begin
   print((1, 2) == (1,2));
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bad-pattern.asl
+++ b/asllib/tests/regressions.t/bad-pattern.asl
@@ -2,5 +2,5 @@ func main () => integer
 begin
   case 3 of
   when '101' => print ("Cannot happen");
-  end
-end
+  end;
+end;

--- a/asllib/tests/regressions.t/bad-shift.asl
+++ b/asllib/tests/regressions.t/bad-shift.asl
@@ -4,4 +4,4 @@ begin
   let b = LSL(a,10);
   print(b);
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bad-slices.asl
+++ b/asllib/tests/regressions.t/bad-slices.asl
@@ -4,4 +4,4 @@ begin
   let y = x[-20:4];
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bad-underconstrained-call-02.asl
+++ b/asllib/tests/regressions.t/bad-underconstrained-call-02.asl
@@ -1,15 +1,15 @@
 func foo {N} (x: bits(N), i: integer {N})
 begin
   assert Len(x) == i;
-end
+end;
 
 func bar {M} (x: bits(M))
 begin
   foo (x, 3);
-end
+end;
 
 func main () => integer
 begin
   bar ('101010');
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bad-underconstrained-call-03.asl
+++ b/asllib/tests/regressions.t/bad-underconstrained-call-03.asl
@@ -1,16 +1,16 @@
 func foo {N} (x: bits(N), i: integer {N})
 begin
   assert Len(x) == i;
-end
+end;
 
 func bar {M} (x: bits(M))
 begin
   foo (x, M + 1);
-end
+end;
 
 func main () => integer
 begin
   bar ('101010');
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/bad-underconstrained-call.asl
+++ b/asllib/tests/regressions.t/bad-underconstrained-call.asl
@@ -1,16 +1,16 @@
 func GetBitAt{N}(x: bits(N), i: integer {0..N-1}) => bits(1)
 begin
   return x[i];
-end
+end;
 
 func GetMiddleBit{M}(x: bits(M)) => bits(1)
 begin
   // return GetBitAt(x, M DIVRM 2);
   return GetBitAt(x, M); 
-end
+end;
 
 func main() => integer
 begin
   let - = GetMiddleBit('11110000');
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bad-underconstrained-ctc.asl
+++ b/asllib/tests/regressions.t/bad-underconstrained-ctc.asl
@@ -1,10 +1,10 @@
 func GetLastBit {N} (x: bits(N)) => bits(1)
 begin
   return x[(N as integer {N - 1})];
-end
+end;
 
 func main () => integer
 begin
   let - = GetLastBit ('1111');
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bad-underconstrained-return-02.asl
+++ b/asllib/tests/regressions.t/bad-underconstrained-return-02.asl
@@ -1,11 +1,11 @@
 func BadBitCount {N} (x: bits(N)) => integer {0..N}
 begin
   return 5;
-end
+end;
 
 func main() => integer
 begin
   assert BadBitCount ('101') == 2;
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/bad-underconstrained-return.asl
+++ b/asllib/tests/regressions.t/bad-underconstrained-return.asl
@@ -1,10 +1,10 @@
 func BadBitCount {N} (x: bits(N)) => integer {0..N}
 begin
   return N + 1;
-end
+end;
 
 func main() => integer
 begin
   assert BadBitCount ('101') == 2;
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/base_values.asl
+++ b/asllib/tests/regressions.t/base_values.asl
@@ -4,7 +4,7 @@ func foo {N, M} (bv: bits(N), bv2: bits(M)) => integer {N..M, 42}
 begin
   var x: integer {N..M, 42};
   return x;
-end
+end;
 
 func main () => integer
 begin
@@ -63,4 +63,4 @@ begin
   assert c == MyEnum1;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/base_values_empty.asl
+++ b/asllib/tests/regressions.t/base_values_empty.asl
@@ -2,7 +2,7 @@ func foo {N, M} (bv: bits(N), bv2: bits(M)) => integer {N..M}
 begin
   var x: integer {N..M};
   return x;
-end
+end;
 
 func main () => integer
 begin
@@ -14,4 +14,4 @@ begin
 
   let x2 = foo ('00', '0');
   assert FALSE; // Should have failed earlier!
-end
+end;

--- a/asllib/tests/regressions.t/big-ints.asl
+++ b/asllib/tests/regressions.t/big-ints.asl
@@ -4,4 +4,4 @@ begin
   // assert (UInt(0x2a2345678123456789[127:64]) == 42);
   
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bitfields.asl
+++ b/asllib/tests/regressions.t/bitfields.asl
@@ -10,24 +10,24 @@ type MyBitVector of bits (5) {
 func build_one() => MyBitVector
 begin
   return '10111';
-end
+end;
 
 func set_first(bv:MyBitVector, b:bits(1)) => MyBitVector
 begin
   var bv_bis = bv;
   bv_bis.first = b;
   return bv_bis;
-end
+end;
 
 func get_first_three(bv:MyBitVector) => bits(3)
 begin
   return bv.first_three;
-end
+end;
 
 func as_MyBitVector(x:bits(5)) => MyBitVector
 begin
   return x;
-end
+end;
 
 func main () => integer
 begin
@@ -44,7 +44,7 @@ begin
   assert as_MyBitVector('11010').swapped == '10011';
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/bitvectors.asl
+++ b/asllib/tests/regressions.t/bitvectors.asl
@@ -8,7 +8,7 @@ begin
   assert b == '01';
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/bug1.asl
+++ b/asllib/tests/regressions.t/bug1.asl
@@ -5,4 +5,4 @@ begin
   let foo: bits(x) = Zeros(y);
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bug2.asl
+++ b/asllib/tests/regressions.t/bug2.asl
@@ -5,4 +5,4 @@ begin
   let t = y[x: 0];
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bug3.asl
+++ b/asllib/tests/regressions.t/bug3.asl
@@ -4,4 +4,4 @@ begin
   let t = Zeros(x);
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/bug4.asl
+++ b/asllib/tests/regressions.t/bug4.asl
@@ -5,4 +5,4 @@ begin
   let pb = Zeros(a) OR Zeros(b);
   
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/case.asl
+++ b/asllib/tests/regressions.t/case.asl
@@ -3,8 +3,8 @@ begin
   case i of
     when 0 => return 1;
     when 1 => return 0;
-  end
-end
+  end;
+end;
 
 func main() => integer
 begin
@@ -12,7 +12,7 @@ begin
   assert 0 == inv(1);
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set -syntax:case_implies' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/cases_where.asl
+++ b/asllib/tests/regressions.t/cases_where.asl
@@ -7,7 +7,7 @@ begin
     when 1 => assert FALSE;
     when 0 where 1 + 1 == 2 => assert TRUE;
     otherwise => assert FALSE;
-  end
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/concat-empty.asl
+++ b/asllib/tests/regressions.t/concat-empty.asl
@@ -2,4 +2,4 @@ func main() => integer
 begin
   let empty_concatenation_should_not_parse = [];
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/concat01.asl
+++ b/asllib/tests/regressions.t/concat01.asl
@@ -18,4 +18,4 @@ begin
   let p14 = [o6,o8];
   assert o14 == p14;
 return 0;
-end
+end;

--- a/asllib/tests/regressions.t/concat02.asl
+++ b/asllib/tests/regressions.t/concat02.asl
@@ -11,4 +11,4 @@ begin
   let y20 = [b5,a15];
   assert x20 == y20;
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/concat03.asl
+++ b/asllib/tests/regressions.t/concat03.asl
@@ -5,4 +5,4 @@ begin
   let c = [a,b];
   assert c == '11110000101';
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/constant-zeros.asl
+++ b/asllib/tests/regressions.t/constant-zeros.asl
@@ -5,4 +5,4 @@ begin
   assert z == '000000000000000';
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/constrained-integer-types-example.asl
+++ b/asllib/tests/regressions.t/constrained-integer-types-example.asl
@@ -14,7 +14,7 @@ begin
   I = B; // legal: FMXK clause 2
   // B = I; // illegal: subtype-satisfaction fails due to domains
   A = I; // legal: FMXK clause 2
-end
+end;
 
 var gInt: integer; // unconstrained global integer
 
@@ -31,17 +31,17 @@ begin
   // a value from myInt_A since
   // `integer {0..20}` does not type satisfy
   // `integer {1..10}` due to domains
-end
+end;
 
 func wid1() => integer {8,16}
 begin
   return 8; // someWid1;
-end
+end;
 
 func wid2() => integer {4,8}
 begin
   return 8; // someWid2;
-end
+end;
 
 func f2()
 begin
@@ -64,7 +64,7 @@ begin
   // so we require a Checked Type Conversion:
   b1 = b2 as bits(w1); // Type check PASS
   // but requires an execution-time width check that (w2==w1)
-end
+end;
 
 func main () => integer
 begin
@@ -75,7 +75,7 @@ begin
   f2 ();
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/constrained-types-example.asl
+++ b/asllib/tests/regressions.t/constrained-types-example.asl
@@ -1,7 +1,7 @@
 func invokeMe {N: integer {8,16,32}} (x: bits(N))
 begin
   return;
-end
+end;
 
 func test(M: integer {8,16,32}, L: integer {8,16})
 begin
@@ -10,7 +10,7 @@ begin
 
   if (M != L) then
     return;
-  end
+  end;
   // Note the type-checker does not do full program analysis
   // So it does not know that M==L after this statement
 
@@ -30,7 +30,7 @@ begin
   // which complies with the declaration of parameter 'N'
   // The rules for subtype-satisfaction are satisfied since
   // the formal 'x' and the actual 'myL' are of the same determined width.
-end
+end;
 
 func main() => integer
 begin
@@ -39,7 +39,7 @@ begin
   test (32, 8);
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/declaration-primitive-local.asl
+++ b/asllib/tests/regressions.t/declaration-primitive-local.asl
@@ -1,4 +1,4 @@
 config N : integer = 0;
 func main () => integer begin
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/defining_param.asl
+++ b/asllib/tests/regressions.t/defining_param.asl
@@ -11,4 +11,4 @@ begin
     // declaration would be illegal.
     // None of the other formals are parameter-defining.
     return;
-end
+end;

--- a/asllib/tests/regressions.t/division.asl
+++ b/asllib/tests/regressions.t/division.asl
@@ -12,7 +12,7 @@ begin
   // Rounding
   assert(5 DIVRM 2 == 2);
   assert(11 DIVRM 3 == 3);
-end
+end;
 
 func check_mod()
 begin
@@ -20,7 +20,7 @@ begin
   assert(4 MOD 2 == 0);
   assert(3 MOD 2 == 1);
   assert(3 MOD 3 == 0);
-end
+end;
 
 func main () => integer
 begin
@@ -42,4 +42,4 @@ begin
   assert (-5) MOD 3 == 1;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/duplicate_expr_record.asl
+++ b/asllib/tests/regressions.t/duplicate_expr_record.asl
@@ -4,4 +4,4 @@ func main() => integer
 begin
     var x = A{h = 5, h = 9};
     return 0;
-end
+end;

--- a/asllib/tests/regressions.t/duplicate_function_args.asl
+++ b/asllib/tests/regressions.t/duplicate_function_args.asl
@@ -1,4 +1,4 @@
 func foo(i: integer, i: integer)
 begin
   pass;
-end
+end;

--- a/asllib/tests/regressions.t/duplicated-otherwise.asl
+++ b/asllib/tests/regressions.t/duplicated-otherwise.asl
@@ -6,6 +6,6 @@ begin
         otherwise => print("otherwise");
         when 0.0 => print("2.0");
         otherwise => print("otherwise");
-    end
+    end;
     return 0;
-end
+end;

--- a/asllib/tests/regressions.t/empty-getter-called-with-slices-2.asl
+++ b/asllib/tests/regressions.t/empty-getter-called-with-slices-2.asl
@@ -1,11 +1,11 @@
 getter f1 => boolean
 begin
   return TRUE;
-end
+end;
 
 func main () => integer
 begin
   let x = f1[];
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/empty-getter-called-with-slices.asl
+++ b/asllib/tests/regressions.t/empty-getter-called-with-slices.asl
@@ -1,11 +1,11 @@
 getter f1 => integer
 begin
   return 0;
-end
+end;
 
 func main () => integer
 begin
   let x = f1[];
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/empty-setter-called-with-slices.asl
+++ b/asllib/tests/regressions.t/empty-setter-called-with-slices.asl
@@ -1,16 +1,16 @@
 getter f1 => bits(4)
 begin
   return '0000';
-end
+end;
 
 setter f1 = v: bits(4)
 begin
   pass;
-end
+end;
 
 func main () => integer
 begin
   f1[] = '';
   
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/empty-setter-nonempty-getter.asl
+++ b/asllib/tests/regressions.t/empty-setter-nonempty-getter.asl
@@ -1,14 +1,14 @@
 getter f1[] => integer
 begin
   return 3;
-end
+end;
 
 setter f1 = v: integer
 begin
   pass;
-end
+end;
 
 func main () => integer
 begin
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/empty-slice.asl
+++ b/asllib/tests/regressions.t/empty-slice.asl
@@ -2,11 +2,11 @@ func foo(x: integer {0..10}, y: integer {0..10})
 begin
   let z = Zeros(64);
   print(z[x:y]);
-end
+end;
 
 func main() => integer
 begin
     foo(4, 2);
     foo(2, 4);
     return 0;
-end
+end;

--- a/asllib/tests/regressions.t/enum-array.asl
+++ b/asllib/tests/regressions.t/enum-array.asl
@@ -16,5 +16,5 @@ begin
   assert (my_array[C] == 3);
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/equality.asl
+++ b/asllib/tests/regressions.t/equality.asl
@@ -20,5 +20,5 @@ begin
   assert (1 as myty) != (2 as integer);
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/exceptions.asl
+++ b/asllib/tests/regressions.t/exceptions.asl
@@ -10,7 +10,7 @@ begin
     reason="Undefined",
     opcode = opcode
   };
-end
+end;
 
 func try_opcode() => integer
 begin
@@ -23,8 +23,8 @@ begin
       assert e.opcode == opcode;
       return 0;
     otherwise => return 3;
-  end
-end
+  end;
+end;
 
 var opcode_counter: integer = 0;
 
@@ -34,9 +34,9 @@ begin
   catch
     when BAD_OPCODE => assert FALSE;
     when UNDEFINED_OPCODE => opcode_counter = opcode_counter + 1; throw;
-  end
+  end;
   assert FALSE;
-end
+end;
 
 func try_rethrow ()
 begin
@@ -45,8 +45,8 @@ begin
   catch
     when e: UNDEFINED_OPCODE => assert e.opcode == opcode; assert opcode_counter == 1;
     otherwise => assert FALSE;
-  end
-end
+  end;
+end;
 
 type COUNTING of exception { counter: integer };
 
@@ -57,7 +57,7 @@ begin
   let x = counter;
   counter = x + 1;
   throw COUNTING { counter = x };
-end
+end;
 
 func throw_imbricated()
 begin
@@ -72,11 +72,11 @@ begin
       catch
         when COUNTING => assert FALSE;
         otherwise => assert FALSE;
-      end
+      end;
       assert FALSE;
-  end
+  end;
   assert FALSE;
-end
+end;
 
 func try_imbricated()
 begin
@@ -87,9 +87,9 @@ begin
       assert e.counter == 0;
       counter = counter + 1;
     otherwise => assert FALSE;
-  end
+  end;
   assert counter == 2;
-end
+end;
 
 func try_with_local_variable ()
 begin
@@ -100,15 +100,15 @@ begin
       when UNDEFINED_OPCODE =>
         local_counter = local_counter + 1;
         throw;
-    end
+    end;
     assert FALSE;
   catch
     when UNDEFINED_OPCODE =>
       local_counter = local_counter + 1;
     otherwise => assert FALSE;
-  end
+  end;
   assert local_counter == 2;
-end
+end;
 
 func main () => integer
 begin
@@ -118,7 +118,7 @@ begin
   try_with_local_variable ();
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/func1.asl
+++ b/asllib/tests/regressions.t/func1.asl
@@ -1,7 +1,7 @@
 func f(i:integer) => integer
 begin
     return i;
-end
+end;
 
 func main() => integer
 begin
@@ -11,7 +11,7 @@ begin
     assert y == 3;
 
     return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/func2.asl
+++ b/asllib/tests/regressions.t/func2.asl
@@ -1,13 +1,13 @@
 getter X[i:integer] => integer
 begin
     return i;
-end
+end;
 
 setter X[i:integer] = v:integer
 begin
     let internal_i = i;
     let internal_v = v;
-end
+end;
 
 func main() => integer
 begin
@@ -17,7 +17,7 @@ begin
     assert x == 4;
 
     return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/func3.asl
+++ b/asllib/tests/regressions.t/func3.asl
@@ -1,43 +1,43 @@
 getter f1[] => integer
 begin
   return 3;
-end
+end;
 
 setter f1[] = v : integer
 begin
   assert v == 3;
-end
+end;
 
 getter f1b => integer
 begin
   return 4;
-end
+end;
 
 setter f1b = v : integer
 begin
   assert v == 4;
-end
+end;
 
 getter f2[x:integer] => integer
 begin
   return f1b + x;
-end
+end;
 
 setter f2[x:integer] = v : integer
 begin
   f1b = 4 * (v - x);
-end
+end;
 
 getter f3[x:integer] => integer
 begin
   return 0;
-end
+end;
 
 setter f3[x:integer] = v : integer
 begin
   assert x == 12;
   assert v == 13;
-end
+end;
 
 func main() => integer
 begin
@@ -57,7 +57,7 @@ begin
   f3[12] = 13;
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/func4.asl
+++ b/asllib/tests/regressions.t/func4.asl
@@ -1,17 +1,17 @@
 func f() => integer
 begin
   return 0;
-end
+end;
 
 func f(x:integer) => integer
 begin
   return x;
-end
+end;
 
 func f(x:integer, y:integer) => integer
 begin
   return x + y;
-end
+end;
 
 func main() => integer
 begin
@@ -20,7 +20,7 @@ begin
   assert 5 == f(2, 3);
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/func5.asl
+++ b/asllib/tests/regressions.t/func5.asl
@@ -2,17 +2,17 @@
 func f(i : integer) => integer
 begin
   return i + 2;
-end
+end;
 
 func f(b : boolean) => boolean
 begin
   return if b then FALSE else TRUE;
-end
+end;
 
 func f(x : bits(3)) => boolean
 begin
   return x[0] == '0';
-end
+end;
 
 func main() => integer
 begin
@@ -22,7 +22,7 @@ begin
   assert f('110');
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/func6.asl
+++ b/asllib/tests/regressions.t/func6.asl
@@ -6,7 +6,7 @@ begin
   assert Len('') == 0;
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/func7.asl
+++ b/asllib/tests/regressions.t/func7.asl
@@ -1,17 +1,17 @@
 func f0 {N} (x: bits(N)) => bits(N)
 begin
   return x;
-end
+end;
 
 func f1 {M} (x: bits(M)) => integer {0..M}
 begin
   return Len(x) as integer {0..M};
-end
+end;
 
 func f2 (L: integer) => bits(L)
 begin
   return Zeros(L);
-end
+end;
 
 func main() => integer
 begin
@@ -20,7 +20,7 @@ begin
   let z: bits(6) = f2 (6);
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/getter_sub_tuple.asl
+++ b/asllib/tests/regressions.t/getter_sub_tuple.asl
@@ -3,17 +3,17 @@ type MyBV of bits(8) { [5] bitfield };
 getter F => MyBV
 begin
   return Zeros(8) as MyBV;
-end
+end;
 
 setter F = v: MyBV
 begin
   assert v[0] == '0';
-end
+end;
 
 func main () => integer
 begin
   assert (F, 3).item0 == Zeros(8);
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/getter_subfield.asl
+++ b/asllib/tests/regressions.t/getter_subfield.asl
@@ -3,17 +3,17 @@ type MyBV of bits(8) { [5] bitfield };
 getter F => MyBV
 begin
   return Zeros(8) as MyBV;
-end
+end;
 
 setter F = v: MyBV
 begin
   assert v[0] == '0';
-end
+end;
 
 func main () => integer
 begin
   assert F.bitfield == '0';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/getter_subfields.asl
+++ b/asllib/tests/regressions.t/getter_subfields.asl
@@ -3,17 +3,17 @@ type MyBV of bits(8) { [5] b1, [4] b2 };
 getter F => MyBV
 begin
   return Zeros(8) as MyBV;
-end
+end;
 
 setter F = v: MyBV
 begin
   assert v[0] == '0';
-end
+end;
 
 func main () => integer
 begin
   assert F.[b1, b2] == '00';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/getter_subslice.asl
+++ b/asllib/tests/regressions.t/getter_subslice.asl
@@ -3,17 +3,17 @@ type MyBV of bits(8) { [5] bitfield };
 getter F => MyBV
 begin
   return Zeros(8) as MyBV;
-end
+end;
 
 setter F = v: MyBV
 begin
   assert v[0] == '0';
-end
+end;
 
 func main () => integer
 begin
   assert F.bitfield == '0';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/global_vars-02.asl
+++ b/asllib/tests/regressions.t/global_vars-02.asl
@@ -7,4 +7,4 @@ begin
     assert y == 5;
 
     return 0;
-end
+end;

--- a/asllib/tests/regressions.t/global_vars.asl
+++ b/asllib/tests/regressions.t/global_vars.asl
@@ -4,19 +4,19 @@ var global_x : integer = 0;
 func incr ()
 begin
   global_x = global_x + 1;
-end
+end;
 
 func incr2 () => integer
 begin
   let y = global_x;
   global_x = y + 1;
   return y;
-end
+end;
 
 func add (x : integer, y: integer) => integer
 begin
   return x + y;
-end
+end;
 
 func main () => integer
 begin
@@ -31,7 +31,7 @@ begin
   assert global_x == 5;
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/hello_world.asl
+++ b/asllib/tests/regressions.t/hello_world.asl
@@ -2,4 +2,4 @@ func main() => integer
 begin
   print("Hello, world!");
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/integer-accessed-bitvector.asl
+++ b/asllib/tests/regressions.t/integer-accessed-bitvector.asl
@@ -4,4 +4,4 @@ begin
   x[0] = '1';
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/lexpr-concat-2.asl
+++ b/asllib/tests/regressions.t/lexpr-concat-2.asl
@@ -4,5 +4,5 @@ begin
   let half = N DIV 2;
   var (a, b) = (Zeros(half*8), Zeros (half*8));
   [a, b] = value;
-end
+end;
 

--- a/asllib/tests/regressions.t/lexpr-concat.asl
+++ b/asllib/tests/regressions.t/lexpr-concat.asl
@@ -8,8 +8,8 @@ begin
     assert [a, b, c, d] == to_test;
     [a, [c, b], d] = to_test;
     assert [a, c, b, d] == to_test;
-  end
+  end;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/masks.asl
+++ b/asllib/tests/regressions.t/masks.asl
@@ -22,7 +22,7 @@ begin
   ((1 IN {2}) && ('10' IN {'1x'}));
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/more-assignments-examples.asl
+++ b/asllib/tests/regressions.t/more-assignments-examples.asl
@@ -26,14 +26,14 @@ begin
   // eightBits = underconstrainedBits; // illegal since widths do not match
   // someBits  = underconstrainedBits; // illegal since widths do not match
                                        // (someWid==N may be false)
-end
+end;
 
 func main () => integer
 begin
   assignBits (32, '111', '0000');
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/more-invocation-examples.asl
+++ b/asllib/tests/regressions.t/more-invocation-examples.asl
@@ -6,7 +6,7 @@ begin
 // Since wid is not a formal, it takes its value in an invocation from
 // the width of one of the the corresponding actuals
 return arg0;
-end
+end;
 
 // ------------------------------------------------------------
 // Cases for invocation of function `bus`
@@ -21,7 +21,7 @@ begin
   // The invocation width of bus's arg1 is therefore `8*2`
   // y type satisfies arg0: bits(16)
   return bus(x, y);
-end
+end;
 
 func legal_fun_underconstrained_actual (N: integer) => bits(N)
 begin
@@ -34,7 +34,7 @@ begin
   // the under-constrained width bitvector of determined width `N`
   // which is type satisfied by x
   return bus(x, y);
-end
+end;
 
 // func legal_fun_constrained_actual (arg: bits({32,64})) => bits(32)
 // begin
@@ -44,7 +44,7 @@ end
   // undetermined width bitvector
   // return bus(arg, [arg,arg])[31:0];
   // return Zeros(32);
-// end
+// end;
 
 // func illegal_fun_parameter_mismatch (N: integer{32,64}, M: integer{64,128})
 // begin
@@ -60,7 +60,7 @@ end
 
   // A checked type conversion might be useful...
   // let legal = bus(argN, argM as bits(N*2));
-// end
+// end;
 
 func main () => integer
 begin
@@ -71,7 +71,7 @@ begin
   // illegal_fun_parameter_mismatch (32, 64);
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/named-types-example.asl
+++ b/asllib/tests/regressions.t/named-types-example.asl
@@ -11,12 +11,12 @@ begin
   // x may be used as the expression in the return statement
   // since the return type is type satisfied by the type of x
   return x;
-end
+end;
 
 func raw_physical_addr(x: PHYSICAL_ADDR) => bits(32)
 begin
     return x;
-end
+end;
 
 func addresses()
 begin
@@ -32,7 +32,7 @@ begin
   addr     = raw_physical_addr(physical);
   physical = addr[31:0]; // a bitslice is of type bits(N)
   addr     = physical[31:0];
-end
+end;
 
 type Char of integer{0..255};
 type Byte of integer{0..255};
@@ -48,14 +48,14 @@ begin
   // global_c = 210;  // legal: c has the structure of integer and can be assigned an integer
   // global_c = K;    // legal: K has type Char and can be assigned to a Char
   // global_b = K;    // illegal: a Char cannot be directly assigned to a Byte
-end
+end;
 
 func main() => integer
 begin
   pass;
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/named-types-in-slices.asl
+++ b/asllib/tests/regressions.t/named-types-in-slices.asl
@@ -5,11 +5,11 @@ var ones = Ones(64);
 func f(sz:pagros) => bits(sz)
 begin
   return ones[sz-1:0];
-end
+end;
 
 func main() => integer
 begin
   let x = f(8);
   print(x);
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/nested-bitfields.asl
+++ b/asllib/tests/regressions.t/nested-bitfields.asl
@@ -51,4 +51,4 @@ begin
   let TTA_bis: bit = if E2H_bis == '0' then CPTR_bis.E2H0.TTA else CPTR_bis.E2H1.TTA;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/nonempty-getter-called-without-slices.asl
+++ b/asllib/tests/regressions.t/nonempty-getter-called-without-slices.asl
@@ -1,11 +1,11 @@
 getter f1[] => integer
 begin
   return 4;
-end
+end;
 
 func main () => integer
 begin
   let x = f1;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/nonempty-setter-called-without-slices.asl
+++ b/asllib/tests/regressions.t/nonempty-setter-called-without-slices.asl
@@ -1,16 +1,16 @@
 getter f1[] => integer
 begin
   return 4;
-end
+end;
 
 setter f1[] = v: integer
 begin
   pass;
-end
+end;
 
 func main () => integer
 begin
   f1 = 4;
   
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/nonempty-setter-empty-getter.asl
+++ b/asllib/tests/regressions.t/nonempty-setter-empty-getter.asl
@@ -1,14 +1,14 @@
 getter f1 => integer
 begin
   return 3;
-end
+end;
 
 setter f1[] = v: integer
 begin
   pass;
-end
+end;
 
 func main () => integer
 begin
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/operator_precedence.asl
+++ b/asllib/tests/regressions.t/operator_precedence.asl
@@ -52,7 +52,7 @@ begin
   // Must be written as:
   let p_eq_eq_A1 = (a == b) == g;
   // Note: 'a == (b == g)' is not valid as it does not type satisfy.
-end
+end;
 
 func main() => integer
 begin
@@ -64,12 +64,12 @@ begin
             for n = 0 to 3 do
               operator_precedence (i, j, k, l[7:0], m[7:0], n[7:0], TRUE);
               operator_precedence (i, j, k, l[7:0], m[7:0], n[7:0], FALSE);
-            end
-          end
-        end
-      end
-    end
-  end
+            end;
+          end;
+        end;
+      end;
+    end;
+  end;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/overlapping-slices.asl
+++ b/asllib/tests/regressions.t/overlapping-slices.asl
@@ -6,4 +6,4 @@ type t of bits(64) {
 func main () => integer
 begin
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/pass.asl
+++ b/asllib/tests/regressions.t/pass.asl
@@ -3,7 +3,7 @@ begin
   pass;
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/pattern-string.asl
+++ b/asllib/tests/regressions.t/pattern-string.asl
@@ -5,8 +5,8 @@ begin
            print("helloworld\n");
         otherwise =>
            return;
-    end
-end
+    end;
+end;
 
 func main () => integer
 begin
@@ -14,4 +14,4 @@ begin
   myfunction ("helloworld\n");
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/patterns.asl
+++ b/asllib/tests/regressions.t/patterns.asl
@@ -15,14 +15,14 @@ begin
   let expr_G = 3 IN !{1,2,4};                       //  TRUE
   assert expr_G;
 
-end
+end;
 
 func main () => integer
 begin
   example_5_3 ();
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/pstate-exp.asl
+++ b/asllib/tests/regressions.t/pstate-exp.asl
@@ -14,17 +14,17 @@ var _NZCV : ProcState;
 func isNZCV(n:integer) => boolean
 begin
   return 0 <= n && n < 4 ;
-end
+end;
 
 getter PSTATE[] => ProcState
 begin
  return _PSTATE;
-end
+end;
 
 setter PSTATE[] = v : ProcState
 begin
   _PSTATE = v;
-end
+end;
 
 getter PSTATE[n:integer] => bits(1)
 begin
@@ -32,8 +32,8 @@ begin
     return _NZCV[n];
   else
     return _PSTATE[n];
-  end
-end
+  end;
+end;
 
 setter PSTATE[n:integer] = v : bits(1)
 begin
@@ -41,8 +41,8 @@ begin
     _NZCV[n] = v;
   else
     _PSTATE[n] = v;
-  end
-end
+  end;
+end;
 
 
 getter PSTATE[n:integer,m:integer] => bits(2)
@@ -51,8 +51,8 @@ begin
     return _NZCV[n,m];
   else
     return _PSTATE[n,m];
-  end
-end
+  end;
+end;
 
 setter PSTATE[n:integer,m:integer] = v : bits(2)
 begin
@@ -60,8 +60,8 @@ begin
     _NZCV[n,m] = v;
   else
     _PSTATE[n,m] = v;
-  end
-end
+  end;
+end;
 
 getter PSTATE[n:integer,m:integer,o:integer] => bits(3)
 begin
@@ -69,8 +69,8 @@ begin
     return _NZCV[n,m,o];
   else
     return _PSTATE[n,m,o];
-  end
-end
+  end;
+end;
 
 setter PSTATE[n:integer,m:integer,o:integer] = v : bits(3)
 begin
@@ -78,8 +78,8 @@ begin
     _NZCV[n,m,o] = v;
   else
     _PSTATE[n,m,o] = v;
-  end
-end
+  end;
+end;
 
 getter PSTATE[n:integer,m:integer,o:integer,p:integer] => bits(4)
 begin
@@ -87,8 +87,8 @@ begin
     return _NZCV[n,m,o,p];
   else
     return _PSTATE[n,m,o,p];
-  end
-end
+  end;
+end;
 
 setter PSTATE[n:integer,m:integer,o:integer,p:integer] = v : bits(4)
 begin
@@ -96,8 +96,8 @@ begin
     _NZCV[n,m,o,p] = v;
   else
     _PSTATE[n,m,o,p] = v;
-  end
-end
+  end;
+end;
 
 func main () => integer
 begin
@@ -109,4 +109,4 @@ begin
   PSTATE.[N, Z] = '00';
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/rdiv_checks.asl
+++ b/asllib/tests/regressions.t/rdiv_checks.asl
@@ -2,4 +2,4 @@ func main() => integer
 begin
     var x = 5.3 / "hello";
     return 0;
-end
+end;

--- a/asllib/tests/regressions.t/record-getfields.asl
+++ b/asllib/tests/regressions.t/record-getfields.asl
@@ -21,5 +21,5 @@ begin
   assert z == '1111100';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/records-2.asl
+++ b/asllib/tests/regressions.t/records-2.asl
@@ -18,7 +18,7 @@ begin
     x.flag == y.flag &&
     x.count == y.count &&
     x.data == y.data;
-end
+end;
 
 func main() => integer
 begin
@@ -36,7 +36,7 @@ begin
   assert equal_a_record_ty (a, aa);
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/records.asl
+++ b/asllib/tests/regressions.t/records.asl
@@ -22,26 +22,26 @@ begin
     },
     fieldC = 5
   };
-end
+end;
 
 func access_subfieldA(obj:MyRecord) => boolean
 begin
   return obj.fieldB.subfieldA;
-end
+end;
 
 func incr_subfieldB(obj:MyRecord) => MyRecord
 begin
   var obj2 = obj;
   obj2.fieldB.subfieldB = obj2.fieldB.subfieldB + 1;
   return obj2;
-end
+end;
 
 func set_fieldC(obj:MyRecord, val:integer) => MyRecord
 begin
   var obj2 = obj;
   obj2.fieldC = val;
   return obj2;
-end
+end;
 
 func build_and_access()
 begin
@@ -54,7 +54,7 @@ begin
     fieldC = 5
   };
   assert obj.fieldB.subfieldA;
-end
+end;
 
 func build_access()
 begin
@@ -66,7 +66,7 @@ begin
     },
     fieldC = 5
   }.fieldB.subfieldA;
-end
+end;
 
 func main() => integer
 begin
@@ -84,7 +84,7 @@ begin
   build_access ();
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/rename-returned-tuples.asl
+++ b/asllib/tests/regressions.t/rename-returned-tuples.asl
@@ -1,13 +1,13 @@
 func foo (M: integer) => (bits (M), boolean)
 begin
   return (Zeros(M), TRUE);
-end
+end;
 
 func bar {A} (bv: bits(A), B: integer) => bits (B)
 begin
   let (result, b) = foo (B);
   return result;
-end
+end;
 
 func main () => integer
 begin
@@ -15,4 +15,4 @@ begin
   let y = bar ('0101', 4);
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -17,7 +17,7 @@ Type-checking errors:
   [1]
 
   $ aslref duplicate_function_args.asl
-  File duplicate_function_args.asl, line 1, character 0 to line 4, character 3:
+  File duplicate_function_args.asl, line 1, character 0 to line 4, character 4:
   ASL Typing error: cannot declare already declared element "i".
   [1]
 
@@ -43,7 +43,7 @@ Global ignored:
   $ cat >global_ignored.asl <<EOF
   > var - = 3 / 0;
   > func main () => integer
-  > begin return 0; end
+  > begin return 0; end;
   > EOF
 
   $ aslref global_ignored.asl
@@ -59,7 +59,7 @@ Constrained-type satisfaction:
   >   var x: integer { 8, 16 };
   >   var y: integer { 8, 16, 32};
   >   x = y; // illegal as domain of x is not a subset of domain of y
-  > end
+  > end;
   > EOF
 
   $ aslref type-sat1.asl
@@ -74,7 +74,7 @@ Constrained-type satisfaction:
   >   var x: integer { 8 , 16 };
   >   var y: integer;
   >   x = y; // illegal
-  > end
+  > end;
   > EOF
 
   $ aslref type-sat2.asl
@@ -101,7 +101,7 @@ Constrained-type satisfaction:
   >   // N is under-constrained integer
   >   var x: integer { 2, 4} = N;
   >    return;
-  > end
+  > end;
   > EOF
 
   $ aslref type-sat3.asl
@@ -116,7 +116,7 @@ Constrained-type satisfaction:
   >   // N is under-constrained integer
   >   var x: integer { 2, 4} = N;
   >   return;
-  > end
+  > end;
   > EOF
 
   $ aslref type-sat4.asl
@@ -131,7 +131,7 @@ Runtime checks:
   > begin
   >   let x: integer {1} = 2 as integer {1};
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref runtime-type-sat1.asl
@@ -143,12 +143,12 @@ Runtime checks:
   $ cat >runtime-type-sat2.asl <<EOF
   > func test(size: integer {3, 4}) begin
   >   let - = Zeros(4) as bits(size);
-  > end
+  > end;
   > func main () => integer begin
   >   test(4);
   >   test(3);
   >   return 0;
-  > end
+  > end;
   > EOF
 
   $ aslref runtime-type-sat2.asl
@@ -224,7 +224,7 @@ Parameterized integers:
   [1]
 
   $ aslref setter_without_getter.asl
-  File setter_without_getter.asl, line 1, character 0 to line 4, character 3:
+  File setter_without_getter.asl, line 1, character 0 to line 4, character 4:
   ASL Typing error: setter "f" does not have a corresponding getter of
     signature integer -> integer.
   [1]
@@ -390,13 +390,13 @@ Empty getters/setters
   [1]
   $ aslref empty-setter-nonempty-getter.asl
   File empty-setter-nonempty-getter.asl, line 6, character 0 to line 9,
-    character 3:
+    character 4:
   ASL Typing error: setter "f1" does not have a corresponding getter of
     signature  -> integer.
   [1]
   $ aslref nonempty-setter-empty-getter.asl
   File nonempty-setter-empty-getter.asl, line 6, character 0 to line 9,
-    character 3:
+    character 4:
   ASL Typing error: setter "f1" does not have a corresponding getter of
     signature  -> integer.
   [1]

--- a/asllib/tests/regressions.t/setter_bitfields.asl
+++ b/asllib/tests/regressions.t/setter_bitfields.asl
@@ -3,19 +3,19 @@ type MyBV of bits(8) { [5] bitfield };
 getter F[] => MyBV
 begin
   return Zeros(8) as MyBV;
-end
+end;
 
 getter F[field: integer] => bit
 begin
   assert field == 5;
   return Ones(1);
-end
+end;
 
 setter F[field: integer] = v: bit
 begin
   assert field == 5;
   assert v == '0';
-end
+end;
 
 func main () => integer
 begin
@@ -23,5 +23,5 @@ begin
   F.bitfield = '0';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/setter_sub_tuple.asl
+++ b/asllib/tests/regressions.t/setter_sub_tuple.asl
@@ -3,17 +3,17 @@ type MyBV of bits(8) { [5] bitfield };
 getter F => MyBV
 begin
   return Zeros(8) as MyBV;
-end
+end;
 
 setter F = v: MyBV
 begin
   assert v[0] == '0';
-end
+end;
 
 func foo () => (bit, integer)
 begin
   return ('0', 1);
-end
+end;
 
 func main () => integer
 begin
@@ -22,5 +22,5 @@ begin
   assert x == 1;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/setter_sub_tuple_02.asl
+++ b/asllib/tests/regressions.t/setter_sub_tuple_02.asl
@@ -3,17 +3,17 @@ type MyBV of bits(8) { [5] bitfield };
 getter F => MyBV
 begin
   return Zeros(8) as MyBV;
-end
+end;
 
 setter F = v: MyBV
 begin
   assert v[0] == '0';
-end
+end;
 
 func foo () => (bit, integer)
 begin
   return ('0', 1);
-end
+end;
 
 func main () => integer
 begin
@@ -22,5 +22,5 @@ begin
   assert x == 1;
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/setter_subfield.asl
+++ b/asllib/tests/regressions.t/setter_subfield.asl
@@ -3,17 +3,17 @@ type MyBV of bits(8) { [5] bitfield };
 getter F => MyBV
 begin
   return Zeros(8) as MyBV;
-end
+end;
 
 setter F = v: MyBV
 begin
   assert v[0] == '0';
-end
+end;
 
 func main () => integer
 begin
   F.bitfield = '0';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/setter_subslice.asl
+++ b/asllib/tests/regressions.t/setter_subslice.asl
@@ -3,17 +3,17 @@ type MyBV of bits(8) { [5] bitfield };
 getter F => MyBV
 begin
   return Zeros(8) as MyBV;
-end
+end;
 
 setter F = v: MyBV
 begin
   assert v[0] == '0';
-end
+end;
 
 func main () => integer
 begin
   assert F[5] == '0';
 
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/setter_without_getter.asl
+++ b/asllib/tests/regressions.t/setter_without_getter.asl
@@ -1,25 +1,25 @@
 setter f[x: integer] = v: integer
 begin
   pass;
-end
+end;
 
 getter f[] => integer
 begin
   return 0;
-end
+end;
 
 getter f[x: integer, y: integer] => integer
 begin
   return 0;
-end
+end;
 
 getter f[x: boolean] => integer
 begin
   return 0;
-end
+end;
 
 func main () => integer
 begin
   return 0;
-end
+end;
 

--- a/asllib/tests/regressions.t/single-slice.asl
+++ b/asllib/tests/regressions.t/single-slice.asl
@@ -4,4 +4,4 @@ begin
   let b = A[UInt('1')*2+:2];
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/static.asl
+++ b/asllib/tests/regressions.t/static.asl
@@ -28,7 +28,7 @@ begin
   assert C10 == -5;
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/stdlib.asl
+++ b/asllib/tests/regressions.t/stdlib.asl
@@ -2,16 +2,16 @@ func test_uint {N} (bv: bits(N))
 begin
   for i = 0 to 1 << N do
     assert UInt (i[N:0]) == i;
-  end
-end
+  end;
+end;
 
 func test_sint {N} (bv: bits(N))
 begin
   for i = 0 to 1 << N  - 1 do
     assert SInt (i[N:0]) == i;
     assert SInt (['1', i[N-1:0]]) == i - 1 << N;
-  end
-end
+  end;
+end;
 
 // Extra main
 func main() => integer
@@ -81,7 +81,7 @@ begin
 
   for n = 0 to 25 do
     assert Log2(2 ^ n) == n;
-  end
+  end;
 
   assert ((1 << 1)  == 2);
   assert ((1 << 0)  == 1);
@@ -93,20 +93,20 @@ begin
     assert RoundUp (q) == m;
     assert RoundDown (q) == m;
     assert RoundTowardsZero (q) == m;
-  end
+  end;
 
   for m = -100 to 100 do
     let q = Real (m) / 3.0;
     assert RoundDown (q) == m DIVRM 3;
-  end
+  end;
 
   for a = -100 to 100 do
     for b = 1 to 5 do
       assert a MOD b + (a DIVRM b) * b == a;
       assert (b * a) DIV b == a;
-      if a MOD b == 0 then assert b * (a DIV b) == a; end
-    end
-  end
+      if a MOD b == 0 then assert b * (a DIV b) == a; end;
+    end;
+  end;
 
   for i = 1 to 10 do
     for p = 1 to 10 do
@@ -114,8 +114,8 @@ begin
       let (res, inexact) = SqrtRoundDown(x, p);
       assert Abs(res * res - x) <= 1.0 / 2.0 ^ p;
       assert inexact || res * res == x;
-    end
-  end
+    end;
+  end;
 
   assert BitCount ('000') == 0;
   assert BitCount ('101') == 2;
@@ -133,7 +133,7 @@ begin
   assert HighestSetBit ('') == -1;
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/subtype-satisfaction-arrray-illegal.asl
+++ b/asllib/tests/regressions.t/subtype-satisfaction-arrray-illegal.asl
@@ -6,4 +6,4 @@ type o of array[10] of n subtypes m;
 func main () => integer
 begin
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/subtypes-example.asl
+++ b/asllib/tests/regressions.t/subtypes-example.asl
@@ -36,7 +36,7 @@ begin
     // so it cannot be assigned to any named type
     // Illegal: mySuperInt = myUniqueInt;
     // Illegal: mySubInt = myUniqueInt;
-end
+end;
 
 type aNumberOfThings of integer;
 type ShapeSides      of aNumberOfThings;
@@ -51,7 +51,7 @@ begin
     var  centipedeLegs: InsectLegs = 100;           // legal
     var  animalLegs   : AnimalLegs = centipedeLegs; // legal
     // var  insectLegs   : InsectLegs = animalLegs;    // illegal: subtype is wrong way
-end
+end;
 
 func main () => integer
 begin
@@ -59,7 +59,7 @@ begin
   subtyping ();
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/subtypes-with.asl
+++ b/asllib/tests/regressions.t/subtypes-with.asl
@@ -30,4 +30,4 @@ begin
   assert b.c == 5;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/tuple_items.asl
+++ b/asllib/tests/regressions.t/tuple_items.asl
@@ -5,4 +5,4 @@ begin
   assert x.item1 == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/tuples.asl
+++ b/asllib/tests/regressions.t/tuples.asl
@@ -3,7 +3,7 @@
 func f() => (integer, integer, integer)
 begin
   return (3, 4, 5);
-end
+end;
 
 func multiple_return_values ()
 begin
@@ -11,7 +11,7 @@ begin
   assert a == 3;
   assert b == 4;
   assert c == 5;
-end
+end;
 
 func other_tuple_usages ()
 begin
@@ -20,7 +20,7 @@ begin
   assert a == 3;
   assert b == 4;
   assert c == 5;
-end
+end;
 
 func with_var ()
 begin
@@ -29,7 +29,7 @@ begin
   assert a == 3;
   assert b == 4;
   assert c == 5;
-end
+end;
 
 func main() => integer
 begin
@@ -38,7 +38,7 @@ begin
   with_var ();
 
   return 0;
-end
+end;
 
 // RUN: archex.sh --eval=':set asl=1.0' --eval=':set +syntax:aslv1_colon_colon' --eval=':load %s' --eval='assert main() == 0;' | FileCheck %s
 

--- a/asllib/tests/regressions.t/type_satisfaction_illegal_f3.asl
+++ b/asllib/tests/regressions.t/type_satisfaction_illegal_f3.asl
@@ -1,10 +1,10 @@
 func invoke_me(N: integer { 8, 16})
 begin
     return;
-end
+end;
 
 func illegal_f3()
 begin
     var x: integer;
     invoke_me(x); // illegal as domains doesn't match
-end
+end;

--- a/asllib/tests/regressions.t/type_satisfaction_illegal_f4.asl
+++ b/asllib/tests/regressions.t/type_satisfaction_illegal_f4.asl
@@ -1,10 +1,10 @@
 func invoke_me(N: integer { 8, 16})
 begin
     return;
-end
+end;
 
 func illegal_f4()
 begin
     var x: integer { 8 .. 64 };
     invoke_me(x);
-end
+end;

--- a/asllib/tests/regressions.t/typed-arg-as-param-call.asl
+++ b/asllib/tests/regressions.t/typed-arg-as-param-call.asl
@@ -1,10 +1,10 @@
 func test(N: integer{5..10}, a: bits(N))
 begin
     pass;
-end
+end;
 
 func main() => integer
 begin
     test(2, '11');
     return 0;
-end
+end;

--- a/asllib/tests/regressions.t/typed-param-call.asl
+++ b/asllib/tests/regressions.t/typed-param-call.asl
@@ -1,10 +1,10 @@
 func test{N: integer{5..10}}(a: bits(N))
 begin
     pass;
-end
+end;
 
 func main() => integer
 begin
     test('11');
     return 0;
-end
+end;

--- a/asllib/tests/regressions.t/undeclared-variable.asl
+++ b/asllib/tests/regressions.t/undeclared-variable.asl
@@ -2,4 +2,4 @@ func main () => integer
 begin
   bar = (32 - 46) * 0;
   return bar;
-end
+end;

--- a/asllib/tests/regressions.t/under-constrained-used.asl
+++ b/asllib/tests/regressions.t/under-constrained-used.asl
@@ -1,11 +1,11 @@
 func foo {N} (x: bits(N)) => integer {0..2*N}
 begin
   return N as integer {0..2*N};
-end
+end;
 
 func main () => integer
 begin
   assert foo ('100') == 3;
 
   return 0;
-end
+end;

--- a/asllib/tests/regressions.t/unreachable.asl
+++ b/asllib/tests/regressions.t/unreachable.asl
@@ -2,4 +2,4 @@ func main () => integer
 begin
   Unreachable ();
   return 0;
-end
+end;

--- a/asllib/tests/typing.t/CNegative1.asl
+++ b/asllib/tests/typing.t/CNegative1.asl
@@ -3,4 +3,4 @@ func negative1{N}(bv : bits(N))
 begin
     var b : integer {-1} = -1;
     var a : integer {0..N} = b; // illegal
-end
+end;

--- a/asllib/tests/typing.t/CNegative10.asl
+++ b/asllib/tests/typing.t/CNegative10.asl
@@ -5,5 +5,5 @@ begin
     var b = 0 as integer{0..M};
     if N == M then
         a = b; // illegal; only the static type is considered for type-checking
-    end
-end
+    end;
+end;

--- a/asllib/tests/typing.t/CNegative11.asl
+++ b/asllib/tests/typing.t/CNegative11.asl
@@ -3,4 +3,4 @@ func negative11{N, M}(x: bits(N), y: bits(M))
 begin
     var z = 0 as integer{0..N};
     z = M; // illegal
-end
+end;

--- a/asllib/tests/typing.t/CNegative12.asl
+++ b/asllib/tests/typing.t/CNegative12.asl
@@ -2,4 +2,4 @@
 func negative12{N}(bv : bits(N), N: integer, bv2 : bits({0..N}))
 begin
     pass;
-end
+end;

--- a/asllib/tests/typing.t/CNegative2.asl
+++ b/asllib/tests/typing.t/CNegative2.asl
@@ -2,4 +2,4 @@
 func negative2{N}(x: bits(N)) => integer {N}
 begin
   return 3; // illegal
-end
+end;

--- a/asllib/tests/typing.t/CNegative3.asl
+++ b/asllib/tests/typing.t/CNegative3.asl
@@ -10,8 +10,8 @@ begin
         y = 2.0*x*y + y0;
         x = xtemp;
         z = z + 1; // should be illegal without ATC
-    end
+    end;
     let W = z;
     var bv: bits(W) = Ones(W);
     return BitCount(bv);
-end
+end;

--- a/asllib/tests/typing.t/CNegative4.asl
+++ b/asllib/tests/typing.t/CNegative4.asl
@@ -6,4 +6,4 @@ begin
         Ones(5),
         x
     ];
-end
+end;

--- a/asllib/tests/typing.t/CNegative5.asl
+++ b/asllib/tests/typing.t/CNegative5.asl
@@ -7,8 +7,8 @@ begin
   print(" == ");
   print(DecStr(Len(bv)));
   print("\n");
-end
+end;
 func negative5() => integer
 begin
   printLengths (3, Zeros(12)); // illegal
-end
+end;

--- a/asllib/tests/typing.t/CNegative6.asl
+++ b/asllib/tests/typing.t/CNegative6.asl
@@ -2,4 +2,4 @@
 func negative6{N}(x: bits(N)) => integer {0..N}
 begin
   return N + 1; // illegal
-end
+end;

--- a/asllib/tests/typing.t/CNegative7.asl
+++ b/asllib/tests/typing.t/CNegative7.asl
@@ -2,8 +2,8 @@
 func GetBitAt{N}(x: bits(N), i: integer {0..N-1}) => bits(1)
 begin
     return x[i];
-end
+end;
 func negative7{M}(x: bits(M)) => bits(1)
 begin
   return GetBitAt(x, M); // illegal
-end
+end;

--- a/asllib/tests/typing.t/CNegative8.asl
+++ b/asllib/tests/typing.t/CNegative8.asl
@@ -5,4 +5,4 @@ begin
     var b = 0 as integer{0..M};
 
     a = b; // illegal, would require ATC
-end
+end;

--- a/asllib/tests/typing.t/CPositive1-1.asl
+++ b/asllib/tests/typing.t/CPositive1-1.asl
@@ -3,4 +3,4 @@ func positive1{N}(x: bits(N), offset: integer)
 begin
     let y = offset MOD N;
     let z: integer {0..N} = y;
-end
+end;

--- a/asllib/tests/typing.t/CPositive1.asl
+++ b/asllib/tests/typing.t/CPositive1.asl
@@ -3,4 +3,4 @@ func positive1{N}(x: bits(N), offset: integer) => bit
 begin
     var y = offset MOD N;
     return x[y];
-end
+end;

--- a/asllib/tests/typing.t/CPositive10.asl
+++ b/asllib/tests/typing.t/CPositive10.asl
@@ -2,4 +2,4 @@
 func positive10(N : integer, x: bits(N+1), y: bits(N+2)) => bits(N*3+3)
 begin
     return [Zeros(N), x, y];
-end
+end;

--- a/asllib/tests/typing.t/CPositive11a.asl
+++ b/asllib/tests/typing.t/CPositive11a.asl
@@ -5,4 +5,4 @@ begin
         Ones(5) as bits(64 - N),
         x
     ]; // has static width of bits(64)
-end
+end;

--- a/asllib/tests/typing.t/CPositive11b.asl
+++ b/asllib/tests/typing.t/CPositive11b.asl
@@ -5,4 +5,4 @@ begin
         Ones(5),
         x
     ] as bits(64); // has static width of bits(64)
-end
+end;

--- a/asllib/tests/typing.t/CPositive12.asl
+++ b/asllib/tests/typing.t/CPositive12.asl
@@ -9,7 +9,7 @@ getter X[n : Rnum_X, width : ElementSize] => bits(width)
 begin
     assert width IN {8,16,32,64};
     return n[width-1:0];
-end
+end;
 
 func ExtendReg(reg : Rnum_X, exttype : ExtendType, shift : integer{0..4}, N : ElementSize) => bits(N)
 begin
@@ -27,13 +27,13 @@ begin
         when ExtendType_UXTH => unsigned = TRUE;  len = 16;
         when ExtendType_UXTW => unsigned = TRUE;  len = 32;
         when ExtendType_UXTX => unsigned = TRUE;  len = 64;
-    end
+    end;
 
     let nbits = Min(len, N - shift) as integer{0..N};
     return Extend([val[0+:nbits] , Zeros(shift)], N, unsigned);
-end
+end;
 
 func CPositive12() => bits(8)
 begin
     return ExtendReg(0, ExtendType_SXTH, 2, 8);
-end
+end;

--- a/asllib/tests/typing.t/CPositive2.asl
+++ b/asllib/tests/typing.t/CPositive2.asl
@@ -3,4 +3,4 @@ func positive2{N}(x: bits(N)) => integer{N+1}
 begin
     var N1 = N + 1;
     return N1;
-end
+end;

--- a/asllib/tests/typing.t/CPositive3.asl
+++ b/asllib/tests/typing.t/CPositive3.asl
@@ -3,4 +3,4 @@ func positive3{N}(bv : bits(N))
 begin
     var b = 0; // b has type integer{0}
     var a : integer {0..N} = b;
-end
+end;

--- a/asllib/tests/typing.t/CPositive4.asl
+++ b/asllib/tests/typing.t/CPositive4.asl
@@ -2,9 +2,9 @@
 func sub{N}(arg : bits(N))
 begin
     pass;
-end
+end;
 func positive4(w: integer{1, 2, 3})
 begin
     sub(Zeros(12));
     sub(Zeros(w));
-end
+end;

--- a/asllib/tests/typing.t/CPositive5.asl
+++ b/asllib/tests/typing.t/CPositive5.asl
@@ -5,4 +5,4 @@ begin
     var b = 0 as integer {0..N};
 
     a = b;
-end
+end;

--- a/asllib/tests/typing.t/CPositive6.asl
+++ b/asllib/tests/typing.t/CPositive6.asl
@@ -2,4 +2,4 @@
 func positive6{N}(x: bits(N))
 begin
     var R : integer = N;
-end
+end;

--- a/asllib/tests/typing.t/CPositive7.asl
+++ b/asllib/tests/typing.t/CPositive7.asl
@@ -3,4 +3,4 @@ func positive7{N}(bv: bits(N), x: integer{0..N})
 begin
     var a: integer{0..2*N} = x;
     var b: integer{0..N+1} = x;
-end
+end;

--- a/asllib/tests/typing.t/CPositive9.asl
+++ b/asllib/tests/typing.t/CPositive9.asl
@@ -4,4 +4,4 @@ begin
     let y: bits(N) = Zeros(N);
     let z: bits(N DIV 2) = Zeros(N DIV 2);
     return [y, z];
-end
+end;

--- a/asllib/tests/typing.t/HExample1.asl
+++ b/asllib/tests/typing.t/HExample1.asl
@@ -3,16 +3,16 @@ begin
     var value : bits(size*8) = Zeros(size*8);
     value = Read(address, size, unknown);
     return value;
-end
+end;
 
 func Read(address : integer, size : integer, unknown : boolean) => bits(8*size)
 begin
     var value : bits(size*8) = UNKNOWN : bits(size*8);
     if !unknown then
         value = MemRead(address, size);
-    end
+    end;
     return value;
-end
+end;
 
 func MemRead(address : integer, size : integer) => bits(8*size)
 begin
@@ -26,10 +26,10 @@ begin
             for i = 1 to regs do
                 let lsb = i - 1 * 32;
                 result[lsb+31:lsb] = read_mem_bits(4);
-            end
+            end;
         else
             return read_mem_bits(4)[(8*size)-1:0];
-        end
+        end;
         return result;
     elsif address == 0x400000000 then
         result[31:0] = Ones(32);
@@ -37,10 +37,10 @@ begin
     else
         let val = read_mem_bits(size);
         return val[(8*size)-1:0];
-    end
-end
+    end;
+end;
 
 func read_mem_bits(size : integer) => bits(8*size)
 begin
     return Ones(8*size);
-end
+end;

--- a/asllib/tests/typing.t/HExample10.asl
+++ b/asllib/tests/typing.t/HExample10.asl
@@ -3,14 +3,14 @@ func division_example(width : integer, data_in : bits(width)) => bits(width)
 begin
     var iterations = width DIV 8;
     return Zeros(width);
-end
+end;
 
 func for_loop_example1{N}(data : bits(N))
 begin
     for i = 0 to (N DIV 8) - 1 do
         var byte = data[i*8+7:i*8];
-    end
-end
+    end;
+end;
 
 func for_loop_example2(width : integer, data_in : bits(width)) => bits(width)
 begin
@@ -19,6 +19,6 @@ begin
     var iterations = width DIV 8;
     for i=0 to iterations-1 do
         data[63+i*64:64*i] = Ones(64);
-    end
+    end;
     return data;
-end
+end;

--- a/asllib/tests/typing.t/HExample11.asl
+++ b/asllib/tests/typing.t/HExample11.asl
@@ -5,4 +5,4 @@ begin
 
     let size = minimum;
     var x = Zeros (N);
-end
+end;

--- a/asllib/tests/typing.t/HExample12.asl
+++ b/asllib/tests/typing.t/HExample12.asl
@@ -4,13 +4,13 @@ begin
     let E = 5;
     let F = N - (E + 1);
     return [sign, Zeros(E), Zeros(F)];
-end
+end;
 
 // Mixture here is fine - constrained + underconstrained - requires type equivalence
 func Extract(offset : integer{0..32}, size: integer, reg_value : bits(128)) => bits(size * 8)
 begin
     return reg_value[(offset+size) * 8 - 1:(offset) * 8];
-end
+end;
 
 // Underconstrained to Named type constraint
 type myconstraint of integer{1,2,3,4};
@@ -20,4 +20,4 @@ begin
     l = (N+5) as myconstraint;
     let x = l;
     var y = Zeros (x);
-end
+end;

--- a/asllib/tests/typing.t/HExample13.asl
+++ b/asllib/tests/typing.t/HExample13.asl
@@ -8,4 +8,4 @@ begin
   let bv2: bits(x) = Replicate(bv, x DIV y);
 
   return 0;
-end
+end;

--- a/asllib/tests/typing.t/HExample14.asl
+++ b/asllib/tests/typing.t/HExample14.asl
@@ -1,7 +1,7 @@
 func Reverse{N}(word : bits(N), M : integer{1..N}) => bits(N)
 begin
     return Zeros(N);
-end
+end;
 
 func main () => integer
 begin
@@ -10,6 +10,6 @@ begin
   let res = Reverse(bv, 8);
 
   return 0;
-end
+end;
 
 

--- a/asllib/tests/typing.t/HExample15.asl
+++ b/asllib/tests/typing.t/HExample15.asl
@@ -2,5 +2,5 @@ func HExample15(x: integer {4, 8}, y: integer {4, 8}, a: integer)
 begin
   let d = x DIV y;
   let - = a < d;
-end
+end;
 

--- a/asllib/tests/typing.t/HExample16.asl
+++ b/asllib/tests/typing.t/HExample16.asl
@@ -1,11 +1,11 @@
 func Reverse{N}(word : bits(N), M : integer{1..N}) => bits(N)
 begin
     return Zeros(N);
-end
+end;
 
 func HExemple16 (a: integer {8, 16, 32, 64}, b: integer {8, 16, 32, 64})
 begin
-  if a < b then Unreachable(); end
+  if a < b then Unreachable(); end;
   let bv = Zeros(a);
   let -: bits(a) = Reverse(bv, b);
-end
+end;

--- a/asllib/tests/typing.t/HExample17.asl
+++ b/asllib/tests/typing.t/HExample17.asl
@@ -1,12 +1,12 @@
 func Reverse{N}(word : bits(N), M : integer{1..N}) => bits(N)
 begin
     return Zeros(N);
-end
+end;
 
 func HExemple17 (a: integer {8, 16, 32, 64})
 begin
-  if a != 64 then Unreachable(); end
+  if a != 64 then Unreachable(); end;
   let b = 32;
   let bv = Zeros(a);
   let -: bits(a) = Reverse(bv, b);
-end
+end;

--- a/asllib/tests/typing.t/HExample18.asl
+++ b/asllib/tests/typing.t/HExample18.asl
@@ -1,14 +1,14 @@
 func Reverse{N}(word : bits(N), M : integer{1..N}) => bits(N)
 begin
     return Zeros(N);
-end
+end;
 
 func HExemple18 (a: bits(2))
 begin
-  if a IN {'0x'} then Unreachable(); end
+  if a IN {'0x'} then Unreachable(); end;
   let a2 = 8 << UInt(a);
   let bv = Zeros(a2);
   let b = 16;
   let -: bits(a2) = Reverse(bv, a2);
-end
+end;
 

--- a/asllib/tests/typing.t/HExample2.asl
+++ b/asllib/tests/typing.t/HExample2.asl
@@ -24,12 +24,12 @@ begin
                 register[31:0] = Ones(32);
             else
                 register = ZeroExtend('0', 8*size);
-            end
+            end;
             return register;
-    end
-end
+    end;
+end;
 
 func register_read(size : integer) => bits(8*size)
 begin
     return Ones(8*size);
-end
+end;

--- a/asllib/tests/typing.t/HExample3.asl
+++ b/asllib/tests/typing.t/HExample3.asl
@@ -23,11 +23,11 @@ begin
             // but causes a runtime error
             function(ZeroExtend(temp, 8*size), size);
 
-    end
+    end;
     return result;
-end
+end;
 
 func function(x : bits(8*size), size : integer)
 begin
     pass;
-end
+end;

--- a/asllib/tests/typing.t/HExample4.asl
+++ b/asllib/tests/typing.t/HExample4.asl
@@ -6,4 +6,4 @@ begin
     var value = Zeros (8*bytes);
     value = Ones(8*bytes);
     return value;
-end
+end;

--- a/asllib/tests/typing.t/HExample5.asl
+++ b/asllib/tests/typing.t/HExample5.asl
@@ -2,20 +2,20 @@ func halfsize0(op1 : bits(N DIV 2), op2 : bits(N DIV 2), N : integer) => bits(N)
 begin
     var value1 : bits(N) = [op1, Zeros(N DIV 2)];
     return value1;
-end
+end;
 
 func halfsize1{N}(op : bits(N)) => bits(N DIV 2)
 begin
     var result = Zeros (N);
     let halfsize = N DIV 2;
     return result[(2*halfsize)-1:halfsize];
-end
+end;
 
 func halfsize2{N}(op1 : bits(N) , op2 : bits(N)) => bits(N)
 begin
     var result = Zeros (2*N);
     return result[2*N-1:N];
-end
+end;
 
 func halfsize3(size : integer) => bits(size*8)
 begin
@@ -28,9 +28,9 @@ begin
     value = [highhalf, lowhalf];
 
     return value;
-end
+end;
 
 func returnOnes(size : integer) => bits(8*size)
 begin
     return Ones(8*size);
-end
+end;

--- a/asllib/tests/typing.t/HExample6.asl
+++ b/asllib/tests/typing.t/HExample6.asl
@@ -3,10 +3,10 @@ begin
     assert(N == M * 8);
     let p2bits = ClosestPow2(N) as integer{0..N*2};
     var op = Zeros (p2bits);
-end
+end;
 
 func ClosestPow2(N : integer) => integer
 begin
     var x = HighestSetBit(N[63:0] + 1);
     return x;
-end
+end;

--- a/asllib/tests/typing.t/HExample7.asl
+++ b/asllib/tests/typing.t/HExample7.asl
@@ -7,8 +7,8 @@ begin
     for i = 0 to 1 do
         for j = 0 to 1 do
             e = Ones(esize);
-        end
+        end;
         result[(2*i) *: esize] = e;
-    end
+    end;
     return result;
-end
+end;

--- a/asllib/tests/typing.t/HExample8.asl
+++ b/asllib/tests/typing.t/HExample8.asl
@@ -4,10 +4,10 @@ func ArrayExample{M,N}(vector1 : bits(M), vector0 : bits(N)) => bits(M)
 begin
     let E = N DIVRM 8;
     return FunctWithConstraint(vector1, E as integer{1, 2, 3, 4});
-end
+end;
 
 func FunctWithConstraint{M}(result : bits(M), x : integer{1,2,3,4}) => bits(M)
 begin
     var y : array[x] of integer;
     return result;
-end
+end;

--- a/asllib/tests/typing.t/HExample9.asl
+++ b/asllib/tests/typing.t/HExample9.asl
@@ -1,52 +1,52 @@
 func LimitBits{N}(x : bits(N), value : integer) => bits(N)
 begin
     return value[N-1:0];
-end
+end;
 
 func Return32_bits{N}(data_in : bits(N)) => bits(32)
 begin
     var data : bits(N) = data_in;
     return data[31:0];
-end
+end;
 
 // Create bit-vector of return type
 func ReturnReturnType{M}(op : bits(M), N : integer) => bits(N)
 begin
     var result : bits(N) = Ones(N);
     return result;
-end
+end;
 
 // Unused N
 func UnusedUnderconstrained{N}(op1 : bits(N)) => bits(4)
 begin
     return '1111';
-end
+end;
 
 // Going from unconstrained to constrained
 func rolling0{N}(x : bits(N), shift : integer) => bits(N)
 begin
     return rolling1(x, N-shift);
-end
+end;
 
 func rolling1{N}(x : bits(N), shift : integer) => bits(N)
 begin
     let length = shift as integer{0..N};
     return Ones(length)[N-1:0];
-end
+end;
 
 // Condition on one underconstraint and generate a bit-vector based on return type
 func ConditionalInput{N}(input : bits(N), esize : integer) => bits(esize)
 begin
     if N == esize then
         return input[esize-1:0];
-    end
+    end;
     return Ones(esize);
-end
+end;
 
 func AmmendZero{N}(op : bits(N)) => bits(N)
 begin
     return ['0', op[N-2:0]];
-end
+end;
 
 func NPlusM{N,M}(op1 : bits(M), op2 : bits(N)) => bits(M+N)
 begin
@@ -54,10 +54,10 @@ begin
     var result0 : bits(M+N) = ZeroExtend(op2, M+N);
     for i =0 to M-1 do
         result[i] = '1';
-    end
+    end;
 
     return result;
-end
+end;
 
 func save_bits{N}(x : bits(N)) => bits(N)
 begin
@@ -69,6 +69,6 @@ begin
     elsif N == 32 then
         result[31:0] = x[31:0];
         return result;
-    end
+    end;
     return result;
-end
+end;

--- a/asllib/tests/typing.t/NegParam.asl
+++ b/asllib/tests/typing.t/NegParam.asl
@@ -1,7 +1,7 @@
 func test(N: integer, bv: bits(N+1))
 begin
   let x: integer {0..N} = 0;
-end
+end;
 
 func main () => integer
 begin
@@ -9,4 +9,4 @@ begin
   test(-1, '');
 
   return 0;
-end
+end;

--- a/asllib/tests/typing.t/TDegraded13-sets1.asl
+++ b/asllib/tests/typing.t/TDegraded13-sets1.asl
@@ -7,4 +7,4 @@ begin
   // K*(K-1) is the second highest number that z can take.
   // The distance between K*K and K*(K-1) is K, so (K*K)-1 is not a value reachable by z.
   z = (K*K)-1; // Is this legal?
-end
+end;

--- a/asllib/tests/typing.t/TDegraded13-sets2.asl
+++ b/asllib/tests/typing.t/TDegraded13-sets2.asl
@@ -3,5 +3,5 @@ begin
   var z = UInt(a) * UInt(b);
   z = (2 ^ 107) - 1;
   // This is a prime number according to https://www.mersenne.org/primes/
-end
+end;
 

--- a/asllib/tests/typing.t/TDegraded13.asl
+++ b/asllib/tests/typing.t/TDegraded13.asl
@@ -6,7 +6,7 @@ begin
     // apply is implementation defined.
     let temp               = UInt(a) * UInt(b);
     let testA : bits(temp) = Zeros(temp);
-end
+end;
 
 func main() => integer
 begin
@@ -14,4 +14,4 @@ begin
   // WARNING: aslref freezes
   // degraded13(Zeros(64) + 12345, Zeros(64) + 54321);
   return 0;
-end
+end;

--- a/asllib/tests/typing.t/TNegative10-0.asl
+++ b/asllib/tests/typing.t/TNegative10-0.asl
@@ -15,4 +15,4 @@ begin
     let letWidthN2               = widthN;
     let testB : bits(letWidthN1) = Zeros(letWidthN2); // illegal as type bits(letWidthN1) is different from bits(letWidthN2).
 
-end
+end;

--- a/asllib/tests/typing.t/TNegative10-1.asl
+++ b/asllib/tests/typing.t/TNegative10-1.asl
@@ -1,4 +1,4 @@
-func foo() => integer {0..7} begin return UNKNOWN: integer {0..7}; end
+func foo() => integer {0..7} begin return UNKNOWN: integer {0..7}; end;
 
 func negative10(N : integer {8,16}, M : integer {8,16})
 begin
@@ -26,4 +26,4 @@ begin
     let tempC3A                 = tempC2A;
     let tempC3B                 = tempC2B;
     let testC : bits(tempC3A)   = Zeros(tempC3B); // illegal, type bits(tempC1) != bits(tempC3B)
-end
+end;

--- a/asllib/tests/typing.t/TNegative10.asl
+++ b/asllib/tests/typing.t/TNegative10.asl
@@ -7,4 +7,4 @@ begin
     // <some code>
     let testA : bits(N) = Zeros(widthN);
 
-end
+end;

--- a/asllib/tests/typing.t/TNegative12.asl
+++ b/asllib/tests/typing.t/TNegative12.asl
@@ -2,5 +2,5 @@ func negative12(N : integer {8,16})
 begin
     let testA = N     as bits(8); // ATC's can't change structure.
     let testB = testA as integer;
-end
+end;
 

--- a/asllib/tests/typing.t/TNegative14-0.asl
+++ b/asllib/tests/typing.t/TNegative14-0.asl
@@ -6,4 +6,4 @@ begin
     let tempA : NamedTypeB = w1;        // illegal, not the same type
     // let testB : bits(w1)   = Zeros(w2); // illegal, just because w1 and w2 are the same type doesn't mean they are the same value, so
                                         // type bits(w1) != bits(w2)
-end
+end;

--- a/asllib/tests/typing.t/TNegative14-1.asl
+++ b/asllib/tests/typing.t/TNegative14-1.asl
@@ -6,4 +6,4 @@ begin
     // let tempA : NamedTypeB = w1;        // illegal, not the same type
     let testB : bits(w1)   = Zeros(w2); // illegal, just because w1 and w2 are the same type doesn't mean they are the same value, so
                                         // type bits(w1) != bits(w2)
-end
+end;

--- a/asllib/tests/typing.t/TNegative15-0.asl
+++ b/asllib/tests/typing.t/TNegative15-0.asl
@@ -5,5 +5,5 @@ func negative15(x: integer, w1: NamedTypeA, w2: NamedTypeA)
 begin
     let testA     = 0xA55A1234[x+7:x];  // The RHS width express does not result in a constrained integer, so even though the width is
                                         // guaranteed to be 8, this is illegal.
-end
+end;
 

--- a/asllib/tests/typing.t/TNegative15-1.asl
+++ b/asllib/tests/typing.t/TNegative15-1.asl
@@ -4,5 +4,5 @@ type NamedTypeB of integer {8,16};
 func negative15(x: integer, w1: NamedTypeA, w2: NamedTypeA)
 begin
     let testB     = 0xA55A1234[0 +: x]; // illegal, bit width isn't a constrained integer
-end
+end;
 

--- a/asllib/tests/typing.t/TNegative15-2.asl
+++ b/asllib/tests/typing.t/TNegative15-2.asl
@@ -5,5 +5,5 @@ func negative15(x: integer, w1: NamedTypeA, w2: NamedTypeA)
 begin
     let testC     = 0xA55A1234[0 *: x]; // illegal, bit width isn't a constrained integer
 
-end
+end;
 

--- a/asllib/tests/typing.t/TNegative15-3.asl
+++ b/asllib/tests/typing.t/TNegative15-3.asl
@@ -5,5 +5,5 @@ func negative15(x: integer, w1: NamedTypeA, w2: NamedTypeA)
 begin
     var testD     = Zeros(32);
     testD[0 *: x] = Zeros(x); // Same rules apply to bit slices on LHS
-end
+end;
 

--- a/asllib/tests/typing.t/TNegative2-0.asl
+++ b/asllib/tests/typing.t/TNegative2-0.asl
@@ -2,4 +2,4 @@ func negative2(size : integer {0..3}, size2 : integer {8,16,32,64}, myInt : inte
 begin
     // assignment to a variable with a domain thats a subset is illegal without ATC's
     let testA : integer {0..2}    = size;
-end
+end;

--- a/asllib/tests/typing.t/TNegative2-1.asl
+++ b/asllib/tests/typing.t/TNegative2-1.asl
@@ -2,4 +2,4 @@ func negative2(size : integer {0..3}, size2 : integer {8,16,32,64}, myInt : inte
 begin
     // assignment to a variable with a domain thats a subset is illegal without ATC's
     let testB : integer {8,16,32} = size2;
-end
+end;

--- a/asllib/tests/typing.t/TNegative2-2.asl
+++ b/asllib/tests/typing.t/TNegative2-2.asl
@@ -2,4 +2,4 @@ func negative2(size : integer {0..3}, size2 : integer {8,16,32,64}, myInt : inte
 begin
     // assignment to a variable with a domain thats a subset is illegal without ATC's
     let testC : integer {8,16,32} = myInt; // assignment of unconstrained integers to constrained integers is also illegal without a ATC
-end
+end;

--- a/asllib/tests/typing.t/TNegative3.asl
+++ b/asllib/tests/typing.t/TNegative3.asl
@@ -3,5 +3,5 @@ func negative3(size2 : integer {8,16,32,64})
 begin
     // inexact operators (eg those with rounding) don't propagate constraints
     let testA : integer {1,2,4,8} = size2 DIVRM 8; // illegal as DIVRM output is of type "integer" not "integer {1,2,4,8}"
-end
+end;
 

--- a/asllib/tests/typing.t/TNegative4-bis.asl
+++ b/asllib/tests/typing.t/TNegative4-bis.asl
@@ -3,4 +3,4 @@ var      VAR_ALLOWED_NUMS    : integer {8, 16} = 8;
 func negative4()
 begin
     let testA : integer {VAR_ALLOWED_NUMS} = 8; // illegal var's aren't allowed in constraints
-end
+end;

--- a/asllib/tests/typing.t/TNegative4.asl
+++ b/asllib/tests/typing.t/TNegative4.asl
@@ -3,4 +3,4 @@ var      VAR_ALLOWED_NUMS    : integer {8}    = 8;
 func negative4()
 begin
     let testA : integer {VAR_ALLOWED_NUMS} = 8; // illegal var's aren't allowed in constraints
-end
+end;

--- a/asllib/tests/typing.t/TNegative5-0.asl
+++ b/asllib/tests/typing.t/TNegative5-0.asl
@@ -5,5 +5,5 @@ begin
     let testA : integer {0..3} = temp; // illegal as value of type integer {8,16} can't be assigned to var of type integer {0..3}.
                                        // Even though temp is guaranteed to be within the range 0..3 because it comes from size
 
-end
+end;
 

--- a/asllib/tests/typing.t/TNegative5-1.asl
+++ b/asllib/tests/typing.t/TNegative5-1.asl
@@ -2,5 +2,5 @@ func negative5(size : integer {0..3})
 begin
     // ATC's can't coerce the structure
     let testB : integer = TRUE as integer;
-end
+end;
 

--- a/asllib/tests/typing.t/TNegative6.asl
+++ b/asllib/tests/typing.t/TNegative6.asl
@@ -5,7 +5,7 @@
 func foo() => integer {8, 16}
 begin
   return UNKNOWN : integer {8, 16};
-end
+end;
 
 func negative6()
 begin
@@ -18,5 +18,5 @@ begin
             when 64 =>
                 pass;
                 // <some code>
-    end
-end
+    end;
+end;

--- a/asllib/tests/typing.t/TNegative7.asl
+++ b/asllib/tests/typing.t/TNegative7.asl
@@ -5,5 +5,5 @@ type MyByteSizes  of integer {1,2,4};
 func negative7(size : MyBitsSizes)
 begin
     let testA : MyOtherSizes = size; // illegal as testA and size are different named types, even though they are the same structure and domain
-end
+end;
 

--- a/asllib/tests/typing.t/TNegative8-0.asl
+++ b/asllib/tests/typing.t/TNegative8-0.asl
@@ -3,5 +3,5 @@ begin
     let N : integer = 7;
     for i = 0 to N do
         let testA : integer {0..7}  = i; // N is an unconstrained integer, so i is also unconstrained
-    end
-end
+    end;
+end;

--- a/asllib/tests/typing.t/TNegative8-1.asl
+++ b/asllib/tests/typing.t/TNegative8-1.asl
@@ -3,5 +3,5 @@ begin
     let N : integer = 7;
     for i = N downto 0 do
         let testB : integer {0..7}  = i; // N is an unconstrained integer, so i is also unconstrained
-    end
-end
+    end;
+end;

--- a/asllib/tests/typing.t/TNegative8-2.asl
+++ b/asllib/tests/typing.t/TNegative8-2.asl
@@ -3,5 +3,5 @@ begin
     let N : integer = 7;
     for i = N to 31 do
         let testC : integer {7..31} = i; // N is an unconstrained integer, so i is also unconstrained
-    end
-end
+    end;
+end;

--- a/asllib/tests/typing.t/TNegative8-3.asl
+++ b/asllib/tests/typing.t/TNegative8-3.asl
@@ -3,5 +3,5 @@ begin
     let N : integer = 7;
     for i = 31 downto N do
         let testD : integer {7..31} = i; // N is an unconstrained integer, so i is also unconstrained
-    end
-end
+    end;
+end;

--- a/asllib/tests/typing.t/TNegative9-0.asl
+++ b/asllib/tests/typing.t/TNegative9-0.asl
@@ -1,4 +1,4 @@
 func negative9(N : integer {8,16}, M : integer {8,16}, X : integer)
 begin
     let testA : bits(8) = Zeros(16);
-end
+end;

--- a/asllib/tests/typing.t/TNegative9-1.asl
+++ b/asllib/tests/typing.t/TNegative9-1.asl
@@ -3,4 +3,4 @@ begin
     let testB : bits(N) = [Zeros(N DIV 4), Zeros(N DIV 2)]; // bits(3N/4) != bits(N)
     // Type of Zeros(N) its bits(N), not bits(M), so this is illegal regardless of the fact that N and M have the same domain,
     // they could have different runtime values so we must evaluate the type safety symbolically
-end
+end;

--- a/asllib/tests/typing.t/TNegative9-2.asl
+++ b/asllib/tests/typing.t/TNegative9-2.asl
@@ -1,4 +1,4 @@
 func negative9(N : integer {8,16}, M : integer {8,16}, X : integer)
 begin
     let testC : bits(M) = Zeros(N);
-end
+end;

--- a/asllib/tests/typing.t/TNegative9-3.asl
+++ b/asllib/tests/typing.t/TNegative9-3.asl
@@ -1,4 +1,4 @@
 func negative9(N : integer {8,16}, M : integer {8,16}, X : integer)
 begin
     let testD : bits(X) = Zeros(X); // X isn't a constrained integer, so can't be used as bit width
-end
+end;

--- a/asllib/tests/typing.t/TNegative9-4.asl
+++ b/asllib/tests/typing.t/TNegative9-4.asl
@@ -1,4 +1,4 @@
 func negative9(N : integer {8,16}, M : integer {8,16}, X : integer)
 begin
     let testE : bits(N) = Zeros(8); // N != 8, even though 8 is in the constraint set for N. N could be 16 after all.
-end
+end;

--- a/asllib/tests/typing.t/TPositive1.asl
+++ b/asllib/tests/typing.t/TPositive1.asl
@@ -14,4 +14,4 @@ begin
     // and the assignment to testD is legal
     let temp                    = testC;
     let testD : integer {-8..7} = temp;
-end
+end;

--- a/asllib/tests/typing.t/TPositive10-0.asl
+++ b/asllib/tests/typing.t/TPositive10-0.asl
@@ -1,4 +1,4 @@
-func foo() => integer {0..7} begin return UNKNOWN: integer {0..7}; end
+func foo() => integer {0..7} begin return UNKNOWN: integer {0..7}; end;
 
 func positive10(N : integer {8,16}, M : integer {8,16}, O : integer {8})
 begin
@@ -40,4 +40,4 @@ begin
                                                                    // common point.
 
     let testH : bits(8) = Zeros(O); // as "O" only has a single allowed value, Zeros(O) evaluates to type bits(8). See R_QZJS
-end
+end;

--- a/asllib/tests/typing.t/TPositive10-1.asl
+++ b/asllib/tests/typing.t/TPositive10-1.asl
@@ -12,4 +12,4 @@ begin
   let width8b = global_width8b;
   let testB: bits(global_width8) = Zeros(width8b);
 
-end
+end;

--- a/asllib/tests/typing.t/TPositive10.asl
+++ b/asllib/tests/typing.t/TPositive10.asl
@@ -1,4 +1,4 @@
-func foo() => integer {0..7} begin return UNKNOWN: integer {0..7}; end
+func foo() => integer {0..7} begin return UNKNOWN: integer {0..7}; end;
 
 func positive10(N : integer {8,16}, M : integer {8,16}, O : integer {8})
 begin
@@ -40,4 +40,4 @@ begin
                                                                    // common point.
 
     let testH : bits(8) = Zeros(O); // as "O" only has a single allowed value, Zeros(O) evaluates to type bits(8). See R_QZJS
-end
+end;

--- a/asllib/tests/typing.t/TPositive11-0.asl
+++ b/asllib/tests/typing.t/TPositive11-0.asl
@@ -1,7 +1,7 @@
 func ZerosBytes(N : integer {1,2,4,8}) => bits(N*8)
 begin
     return Zeros(N*8);
-end
+end;
 
 func positive11(size : bits(2), width : integer {1..3})
 begin
@@ -18,4 +18,4 @@ begin
 
     let tempE                            = width + sizeInt;
     let testE : bits(tempE)              = [Zeros(sizeInt), Zeros(width)];
-end
+end;

--- a/asllib/tests/typing.t/TPositive11-1.asl
+++ b/asllib/tests/typing.t/TPositive11-1.asl
@@ -1,7 +1,7 @@
 func ZerosBytes(N : integer {1,2,4,8}) => bits(N*8)
 begin
     return Zeros(N*8);
-end
+end;
 
 func positive11(size : bits(2), width : integer {1..3})
 begin
@@ -18,4 +18,4 @@ begin
 
     let tempE                            = width + sizeInt;
     let testE : bits(tempE)              = [Zeros(sizeInt), Zeros(width)];
-end
+end;

--- a/asllib/tests/typing.t/TPositive11.asl
+++ b/asllib/tests/typing.t/TPositive11.asl
@@ -1,7 +1,7 @@
 func ZerosBytes(N : integer {1,2,4,8}) => bits(N*8)
 begin
     return Zeros(N*8);
-end
+end;
 
 func positive11(size : bits(2), width : integer {1..3})
 begin
@@ -18,4 +18,4 @@ begin
 
     let tempE                            = width + sizeInt;
     let testE : bits(tempE)              = [Zeros(sizeInt), Zeros(width)];
-end
+end;

--- a/asllib/tests/typing.t/TPositive12.asl
+++ b/asllib/tests/typing.t/TPositive12.asl
@@ -7,5 +7,5 @@ begin
     let testC : bits(32) = Zeros(N)  as bits(32);
     let testD : bits(N)  = Zeros(32) as bits(N);
     let testE : bits(8)  = Zeros(32) as bits(8);
-end
+end;
 

--- a/asllib/tests/typing.t/TPositive13.asl
+++ b/asllib/tests/typing.t/TPositive13.asl
@@ -12,10 +12,10 @@ begin
     let testD = testA[63:0];
     let testE = testB[63:0];
     let testF = testC[63:0];
-end
+end;
 
 func main() => integer
 begin
   positive13(Zeros(64) + 123456789, Zeros(64) + 987654321, Zeros(64) + 987654321);
   return 0;
-end
+end;

--- a/asllib/tests/typing.t/TPositive14.asl
+++ b/asllib/tests/typing.t/TPositive14.asl
@@ -10,4 +10,4 @@ begin
     let testC : integer {8,16} = w1;
     let testD : NamedTypeB     = testC;
     let tempE : NamedTypeB     = w1 as integer {8,16}; // Combined version of testC/D. Using ATC to erase named type.
-end
+end;

--- a/asllib/tests/typing.t/TPositive15.asl
+++ b/asllib/tests/typing.t/TPositive15.asl
@@ -15,4 +15,4 @@ begin
 
     // bit slices of bit vectors
     let testI           = Zeros(2)[n];        // statically allowed, but may fail at runtime if n > 1
-end
+end;

--- a/asllib/tests/typing.t/TPositive2.asl
+++ b/asllib/tests/typing.t/TPositive2.asl
@@ -12,5 +12,5 @@ begin
     // Combinations of both of the above are also legal
     let testE : integer {0,1,2,3,4}      = size;
     let testF : integer {0..128}         = size2;
-end
+end;
 

--- a/asllib/tests/typing.t/TPositive3-0.asl
+++ b/asllib/tests/typing.t/TPositive3-0.asl
@@ -6,5 +6,5 @@ begin
     let testC : integer {0,2,4,6}    = size * 2;
     let testD : integer {1,2,4,8}    = size2 DIV 8;
     let testE : integer {7,15,31,63} = size2 - 1;
-end
+end;
 

--- a/asllib/tests/typing.t/TPositive3-1.asl
+++ b/asllib/tests/typing.t/TPositive3-1.asl
@@ -6,6 +6,6 @@ begin
     // let testC : integer {0,2,4,6}    = size * 2;
     let testD : integer {1,2,4,8}    = size2 DIV 8;
     let testE : integer {7,15,31,63} = size2 - 1;
-end
+end;
 
 

--- a/asllib/tests/typing.t/TPositive3.asl
+++ b/asllib/tests/typing.t/TPositive3.asl
@@ -6,4 +6,4 @@ begin
     let testC : integer {0,2,4,6}    = size * 2;
     let testD : integer {1,2,4,8}    = size2 DIV 8;
     let testE : integer {7,15,31,63} = size2 - 1;
-end
+end;

--- a/asllib/tests/typing.t/TPositive4-1.asl
+++ b/asllib/tests/typing.t/TPositive4-1.asl
@@ -3,5 +3,5 @@ let      LET_ALLOWED_NUMS_B  : integer {8,16} = 8;
 func positive4()
 begin
     let testB : integer {LET_ALLOWED_NUMS_B}     = 16;
-end
+end;
 

--- a/asllib/tests/typing.t/TPositive4-2.asl
+++ b/asllib/tests/typing.t/TPositive4-2.asl
@@ -1,10 +1,10 @@
 func foo () => integer {8, 16}
-begin return 8; end
+begin return 8; end;
 
 let      LET_ALLOWED_NUMS_C  : integer {8,16} = foo();
 
 func positive4()
 begin
     let testC : integer {LET_ALLOWED_NUMS_C}     = 16; 
-end
+end;
 

--- a/asllib/tests/typing.t/TPositive4-3.asl
+++ b/asllib/tests/typing.t/TPositive4-3.asl
@@ -1,5 +1,5 @@
 func foo () => integer {8, 16}
-begin return 8; end
+begin return 8; end;
 
 let      LET_ALLOWED_NUMS_C  : integer {8,16} = foo();
 
@@ -7,5 +7,5 @@ func positive4()
 begin
     let testD : integer {0..LET_ALLOWED_NUMS_C}  = 3;
     let testE : integer {0..16}                  = testD;
-end
+end;
 

--- a/asllib/tests/typing.t/TPositive4-4.asl
+++ b/asllib/tests/typing.t/TPositive4-4.asl
@@ -1,5 +1,5 @@
 func foo () => integer {8, 16}
-begin return 8; end
+begin return 8; end;
 
 config   CONFIG_ALLOWED_NUMS : integer {8,16} = foo();
 
@@ -7,5 +7,5 @@ func positive4()
 begin
     // configs can also be used and follow the same rules as lets
     let testF : integer {CONFIG_ALLOWED_NUMS}    = 16;
-end
+end;
 

--- a/asllib/tests/typing.t/TPositive4-5.asl
+++ b/asllib/tests/typing.t/TPositive4-5.asl
@@ -1,10 +1,10 @@
 func foo () => integer {8, 16}
-begin return 8; end
+begin return 8; end;
 
 config   CONFIG_ALLOWED_NUMS : integer {8,16} = foo();
 
 func positive4()
 begin
     let testG : integer {0..CONFIG_ALLOWED_NUMS} = 3;
-end
+end;
 

--- a/asllib/tests/typing.t/TPositive4.asl
+++ b/asllib/tests/typing.t/TPositive4.asl
@@ -3,5 +3,5 @@ let      LET_ALLOWED_NUMS_A                   = 8;
 func positive4()
 begin
     let testA : integer {LET_ALLOWED_NUMS_A}     = 8;
-end
+end;
 

--- a/asllib/tests/typing.t/TPositive5.asl
+++ b/asllib/tests/typing.t/TPositive5.asl
@@ -13,4 +13,4 @@ begin
     // The domain of the output of the ATC is the domain of the ATC, and this domain is used for type inference
     let temp                   = size as integer {0..1}; // temp has type integer {0..1}
     let testF : integer {0..1} = temp;
-end
+end;

--- a/asllib/tests/typing.t/TPositive6.asl
+++ b/asllib/tests/typing.t/TPositive6.asl
@@ -4,7 +4,7 @@
 func foo() => integer {8, 16}
 begin
   return UNKNOWN : integer {8, 16};
-end
+end;
 
 func positive6(size : integer {0..3})
 begin
@@ -27,5 +27,5 @@ begin
         when 32 => // Unreachable but legal code
             pass;
             // <some code>
-    end
-end
+    end;
+end;

--- a/asllib/tests/typing.t/TPositive7.asl
+++ b/asllib/tests/typing.t/TPositive7.asl
@@ -13,4 +13,4 @@ begin
     let testF : MyOtherSizes      = size as MyOtherSizes; // ATC's can be used between named types of the same structure
     let testG : MyByteSizes       = size as MyByteSizes;  // As per positive5 and ASL-313, ATC's can be used even if the domains are disjoint. This
                                                           // must be valid statically but will fail at runtime if the line is reached.
-end
+end;

--- a/asllib/tests/typing.t/TPositive8-1.asl
+++ b/asllib/tests/typing.t/TPositive8-1.asl
@@ -3,6 +3,6 @@ begin
     // NOTE: this test is not supported by ASLRef.
     for i = 100 as integer {8,16} to 110 as integer {0,31} do
         let testK : integer {8..31} = i;
-    end
-end
+    end;
+end;
 

--- a/asllib/tests/typing.t/TPositive8.asl
+++ b/asllib/tests/typing.t/TPositive8.asl
@@ -6,36 +6,36 @@ begin
     for i = 0 to 7 do
         // i has type integer {0..7}
         let testA : integer {0..7} = i;
-    end
+    end;
     for i = 7 downto 0 do
         // i has type integer {0..7}
         let testB : integer {0..7} = i;
-    end
+    end;
     for i = 0 to N do
         // i has type integer {0..N}
         let testC : integer {0..15} = i;
-    end
+    end;
     for i = 0 to M do
         // i has type integer {0..M}
         let testD : integer {0..15} = i;
-    end
+    end;
     for i = N downto 0 do
         let testE : integer {0..15} = i;
-    end
+    end;
     for i = M downto 0 do
         let testF : integer {0..15} = i;
-    end
+    end;
     for i = N to 31 do
         let testG : integer {0..31} = i; // i has type integer {N..31}
-    end
+    end;
     for i = M to 31 do
         let testH : integer {7..31} = i; // i has type integer {M..31}
-    end
+    end;
     for i = 31 downto N do
         let testI : integer {0..31} = i;
-    end
+    end;
     for i = 31 downto M do
         let testJ : integer {7..31} = i;
-    end
-end
+    end;
+end;
 

--- a/asllib/tests/typing.t/TPositive9-1.asl
+++ b/asllib/tests/typing.t/TPositive9-1.asl
@@ -9,5 +9,5 @@ begin
     let testG : bits(M)   = Zeros(N) as bits(M);
     for i = 0 to 7 do
         let testH : bits(i) = Zeros(i); // i is both immutable and a constrained integer, so can be used as a bit width
-    end
-end
+    end;
+end;

--- a/asllib/tests/typing.t/TPositive9.asl
+++ b/asllib/tests/typing.t/TPositive9.asl
@@ -9,5 +9,5 @@ begin
     let testG : bits(M)   = Zeros(N) as bits(M);
     for i = 0 to 7 do
         let testH : bits(i) = Zeros(i); // i is both immutable and a constrained integer, so can be used as a bit width
-    end
-end
+    end;
+end;

--- a/asllib/tests/typing.t/TReconsider15.asl
+++ b/asllib/tests/typing.t/TReconsider15.asl
@@ -6,5 +6,5 @@ begin
     let testA = Zeros(2)[8];
     // Similar issue with negative width bit vectors
     let testB = Zeros(8)[0 +: -1];
-end
+end;
 

--- a/asllib/tests/typing.t/TReconsider4-0.asl
+++ b/asllib/tests/typing.t/TReconsider4-0.asl
@@ -12,4 +12,4 @@ begin
     // to make the following legal.
     let testA : integer {CONST_ALLOWED_NUMS}     = 16;
     let testB : integer {0..CONST_ALLOWED_NUMS}  = 10;
-end
+end;

--- a/asllib/tests/typing.t/TReconsider4-1.asl
+++ b/asllib/tests/typing.t/TReconsider4-1.asl
@@ -12,4 +12,4 @@ begin
     // to make the following legal.
     // let testA : integer {CONST_ALLOWED_NUMS}     = 16;
     let testB : integer {0..CONST_ALLOWED_NUMS}  = 10;
-end
+end;

--- a/herd/ASLParseTest.ml
+++ b/herd/ASLParseTest.ml
@@ -38,7 +38,7 @@ module Make (Conf : RunTest.Config) (ModelConfig : MemCat.Config) = struct
 
   module ASLLexParse = struct
     type instruction = ASLA.parsedPseudo
-    type token = Asllib.Parser.token
+    type token = Asllib.Tokens.token
 
     let lexer = Asllib.Lexer.token
 

--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -315,7 +315,7 @@ func MarkExclusiveGlobal
   size :: integer)
 begin
   return;
-end
+end;
 
 // =============================================================================
 
@@ -330,7 +330,7 @@ func MarkExclusiveLocal
   size :: integer)
 begin
   return;
-end
+end;
 
 // =============================================================================
 
@@ -345,7 +345,7 @@ func AArch64_MarkExclusiveVA
 (address :: bits(64), processorid :: integer, size :: integer)
 begin
   RESADDR = address;
-end
+end;
 
 // =============================================================================
 
@@ -370,9 +370,9 @@ begin
   // Read RESADDR localy because we want a read event in all cases.
   let reserved = RESADDR;
   // If write succeeds then effective address and reservation coincide.
-  if SuccessVA then CheckProp(address == reserved); end
+  if SuccessVA then CheckProp(address == reserved); end;
   return SuccessVA;
-end
+end;
 
 // =============================================================================
 
@@ -386,7 +386,7 @@ end
 func ExclusiveMonitorsStatus() => bit
 begin
   return if SuccessVA then '0' else '1';
-end
+end;
 
 // =============================================================================
 
@@ -399,7 +399,7 @@ func IsExclusiveLocal
 (paddress :: FullAddres, processorid :: integer, size :: integer) => boolean
 begin
   return TRUE;
-end
+end;
 
 // =============================================================================
 
@@ -412,7 +412,7 @@ func IsExclusiveGlobal
 (paddress :: FullAddres, processorid :: integer, size :: integer) => boolean
 begin
   return TRUE;
-end
+end;
 
 // =============================================================================
 
@@ -424,14 +424,14 @@ end
 func ClearExclusiveLocal(processorid :: integer)
 begin
   return;
-end
+end;
 
 // =============================================================================
 
 func ConstrainUnpredictableBool(which:Unpredictable) => boolean
 begin
   return FALSE;
-end
+end;
 
 // =============================================================================
 
@@ -440,7 +440,7 @@ end
 func IsFeatureImplemented(f :: Feature) => boolean
 begin
     return FALSE;
-end
+end;
 
 // =============================================================================
 
@@ -458,7 +458,7 @@ begin
     merrorstate = ErrorState_CE,  // ??
     store64bstatus = Zeros(64)
   };
-end
+end;
 
 // =============================================================================
 
@@ -477,21 +477,21 @@ begin
     store64bstatus = Zeros(64)
   };
   return (ret_status, value);
-end
+end;
 
 // =============================================================================
 
 func HaveAArch32() => boolean
 begin
   return FALSE;
-end
+end;
 
 // =============================================================================
 
 func HaveAArch64() => boolean
 begin
   return TRUE;
-end
+end;
 
 // =============================================================================
 
@@ -505,8 +505,8 @@ begin
         return TRUE;                             // EL1 and EL0 must exist
     else
         return FALSE; // boolean IMPLEMENTATION_DEFINED;
-    end
-end
+    end;
+end;
 
 // =============================================================================
 
@@ -520,36 +520,36 @@ end
 func ClearExclusiveByAddress(paddress :: FullAddress, processorid :: integer, size :: integer)
 begin
   pass;
-end
+end;
 
 // =============================================================================
 
 getter _PC => bits(64)
 begin
   return read_pc();
-end
+end;
 
 setter _PC = value :: bits(64)
 begin
   write_pc(value);
-end
+end;
 
 getter _R [n :: integer] => bits(64)
 begin
   return read_register(n);
-end
+end;
 
 setter _R [n :: integer] = value :: bits(64)
 begin
   write_register(n, value);
-end
+end;
 
 // =============================================================================
 
 getter SCTLR_EL1[] => SCTLRType
 begin
   return Zeros(64);
-end
+end;
 
 // =============================================================================
 
@@ -558,7 +558,7 @@ end
 func InstructionSynchronizationBarrier()
 begin
   primitive_isb();
-end
+end;
 
 // =============================================================================
 
@@ -575,8 +575,8 @@ begin
     when MBReqDomain_InnerShareable => return 1;
     when MBReqDomain_OuterShareable => return 2;
     when MBReqDomain_FullSystem => return 3;
-  end
-end
+  end;
+end;
 
 func MBReqTypesToInteger(types : MBReqTypes) => integer
 begin
@@ -584,13 +584,13 @@ begin
     when MBReqTypes_Reads => return 0;
     when MBReqTypes_Writes => return 1;
     when MBReqTypes_All => return 2;
-  end
-end
+  end;
+end;
 
 func DataMemoryBarrier(domain : MBReqDomain, types : MBReqTypes)
 begin
   primitive_dmb(MBReqDomainToInteger(domain),MBReqTypesToInteger(types));
-end
+end;
 
 // DataSynchronizationBarrier()
 // ============================
@@ -601,7 +601,7 @@ func DataSynchronizationBarrier
    nXS : boolean)
 begin
   primitive_dsb(MBReqDomainToInteger(domain),MBReqTypesToInteger(types));
-end
+end;
 
 // =============================================================================
 
@@ -613,4 +613,4 @@ end
 func Hint_Branch(hint : BranchType)
 begin
   return;
-end
+end;

--- a/herd/libdir/asl-pseudocode/patches.asl
+++ b/herd/libdir/asl-pseudocode/patches.asl
@@ -38,7 +38,7 @@ func GenMPAMatEL(acctype:: AccessType, el::bits(2)) => MPAMinfo
 begin
   var x : MPAMinfo;
   return x;
-end
+end;
 
 // =============================================================================
 
@@ -51,12 +51,12 @@ end
 func IsAligned(x :: bits(N), y::integer) => boolean
 begin
   return TRUE;
-end
+end;
 
 func IsAligned(x::integer, y::integer) => boolean
 begin
   return TRUE;
-end
+end;
 
 // =============================================================================
 
@@ -69,7 +69,7 @@ end
 func BigEndian(acctype:: AccessType) => boolean
 begin
   return FALSE;
-end
+end;
 
 // =============================================================================
 
@@ -83,7 +83,7 @@ end
 func IsFault(addrdesc:: AddressDescriptor) => boolean
 begin
   return FALSE;
-end
+end;
 
 // =============================================================================
 
@@ -98,7 +98,7 @@ func AArch64_TranslateAddress(address::bits(64), accdesc::AccessDescriptor, alig
 begin
   var full_addr : FullAddress;
   return CreateAddressDescriptor(address, full_addr, NormalNCMemAttr());
-end
+end;
 
 // =============================================================================
 
@@ -115,7 +115,7 @@ end
 func ELStateUsingAArch32K(el::bits(2), secure::boolean) => (boolean, boolean)
 begin
     return (TRUE, FALSE);
-end
+end;
 
 // =============================================================================
 
@@ -183,7 +183,7 @@ var PSTATE : ProcState;
 func GenerateAddress(base:bits(64), offset:bits(64), accdesc:AccessDescriptor) => bits(64)
 begin
   return base + offset;
-end
+end;
 
 // =============================================================================
 
@@ -199,7 +199,7 @@ func AArch64_BranchAddr
   (vaddress:bits(64), el:bits(2)) => bits(64)
 begin
   return vaddress;
-end
+end;
 
 // =============================================================================
 
@@ -218,9 +218,9 @@ begin
    if IsFeatureImplemented(FEAT_SPE) then
      SPEBranch
        (UNKNOWN:bits(64), branchtype, branch_conditional, branchtaken);
-    end
+    end;
     return;
-end
+end;
 
 // =============================================================================
 
@@ -232,7 +232,7 @@ end
 func UsingAArch32() => boolean
 begin
   return FALSE;
-end
+end;
 
 // AltDecodeBitMasks()
 // ===================
@@ -247,4 +247,4 @@ func AltDecodeBitMasks(immN:bit,imms:bits(6), immr:bits(6),
 => (bits(M), bits(M))
 begin
   throw NotImplemented {};
-end
+end;

--- a/herd/libdir/asl-pseudocode/pstate-exp.asl
+++ b/herd/libdir/asl-pseudocode/pstate-exp.asl
@@ -6,17 +6,17 @@ var _NZCV : ProcState;
 func isNZCV(n:integer) => boolean
 begin
   return 0 <= n && n < 4 ;
-end
+end;
 
 getter PSTATE[] => ProcState
 begin
  return _PSTATE;
-end
+end;
 
 setter PSTATE[] = v : ProcState
 begin
   _PSTATE = v;
-end
+end;
 
 getter PSTATE[n:integer] => bits(1)
 begin
@@ -24,8 +24,8 @@ begin
     return _NZCV[n];
   else
     return _PSTATE[n];
-  end
-end
+  end;
+end;
 
 setter PSTATE[n:integer] = v : bits(1)
 begin
@@ -33,8 +33,8 @@ begin
     _NZCV[n] = v;
   else
     _PSTATE[n] = v;
-  end
-end
+  end;
+end;
 
 
 getter PSTATE[n:integer,m:integer] => bits(2)
@@ -43,8 +43,8 @@ begin
     return _NZCV[n,m];
   else
     return _PSTATE[n,m];
-  end
-end
+  end;
+end;
 
 setter PSTATE[n:integer,m:integer] = v : bits(2)
 begin
@@ -52,8 +52,8 @@ begin
     _NZCV[n,m] = v;
   else
     _PSTATE[n,m] = v;
-  end
-end
+  end;
+end;
 
 getter PSTATE[n:integer,m:integer,o:integer] => bits(3)
 begin
@@ -61,8 +61,8 @@ begin
     return _NZCV[n,m,o];
   else
     return _PSTATE[n,m,o];
-  end
-end
+  end;
+end;
 
 setter PSTATE[n:integer,m:integer,o:integer] = v : bits(3)
 begin
@@ -70,8 +70,8 @@ begin
     _NZCV[n,m,o] = v;
   else
     _PSTATE[n,m,o] = v;
-  end
-end
+  end;
+end;
 
 getter PSTATE[n:integer,m:integer,o:integer,p:integer] => bits(4)
 begin
@@ -79,8 +79,8 @@ begin
     return _NZCV[n,m,o,p];
   else
     return _PSTATE[n,m,o,p];
-  end
-end
+  end;
+end;
 
 setter PSTATE[n:integer,m:integer,o:integer,p:integer] = v : bits(4)
 begin
@@ -88,6 +88,6 @@ begin
     _NZCV[n,m,o,p] = v;
   else
     _PSTATE[n,m,o,p] = v;
-  end
-end
+  end;
+end;
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus
@@ -13,13 +13,13 @@ func T0(x::bits(64), y:: bits(64))
 begin
   let x0 = UInt(read_memory(x, 64));
   write_memory(y, 64, one);
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
   let x1 = UInt(read_memory(y, 64));
   write_memory(x, 64, one);
-end
+end;
 
 func main() => integer
 begin
@@ -30,6 +30,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus
@@ -15,7 +15,7 @@ begin
   let x0 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(y, 64, data);
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
@@ -23,7 +23,7 @@ begin
   let x1 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(x, 64, data);
-end
+end;
 
 func main() => integer
 begin
@@ -34,6 +34,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus
@@ -15,13 +15,13 @@ begin
   let x0 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(y, 64, data);
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
   let x1 = UInt(read_memory(y, 64));
   write_memory(x, 64, one);
-end
+end;
 
 func main() => integer
 begin
@@ -32,6 +32,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus
@@ -15,12 +15,12 @@ begin
   let x0 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(y, 64, data);
-end
+end;
 
 func f(read::bits(64)) => bits(64)
 begin
   return one;
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
@@ -28,7 +28,7 @@ begin
   let x1 = UInt(read);
   let data = f(read);
   write_memory(x, 64, data);
-end
+end;
 
 func main() => integer
 begin
@@ -39,6 +39,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus
@@ -15,12 +15,12 @@ begin
   let x0 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(y, 64, data);
-end
+end;
 
 func f(read::bits(64)) => bits(64)
 begin
   return read[63:0] OR one;
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
@@ -28,7 +28,7 @@ begin
   let x1 = UInt(read);
   let data = f(read);
   write_memory(x, 64, data);
-end
+end;
 
 func main() => integer
 begin
@@ -39,6 +39,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus
@@ -15,14 +15,14 @@ begin
   let x0 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(y, 64, data);
-end
+end;
 
 func f(read::bits(64)) => bits(64)
 begin
   var t = read;
   t[0] = '1';
   return t;
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
@@ -30,7 +30,7 @@ begin
   let x1 = UInt(read);
   let data = f(read);
   write_memory(x, 64, data);
-end
+end;
 
 func main() => integer
 begin
@@ -41,6 +41,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus
@@ -15,7 +15,7 @@ begin
   let x0 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(y, 64, data);
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
@@ -23,7 +23,7 @@ begin
   let x1 = UInt(read);
   let data = if read == one then one else one;
   write_memory(x, 64, data);
-end
+end;
 
 func main() => integer
 begin
@@ -34,6 +34,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus
@@ -15,7 +15,7 @@ begin
   let x0 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(y, 64, data);
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
@@ -24,8 +24,8 @@ begin
     write_memory(x, 64, one);
   else
     write_memory(x, 64, one);
-  end
-end
+  end;
+end;
 
 func main() => integer
 begin
@@ -36,6 +36,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus
@@ -15,7 +15,7 @@ begin
   let x0 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(y, 64, data);
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
@@ -27,10 +27,10 @@ begin
     data = one;
   else
     data = one;
-  end
+  end;
 
   write_memory(x, 64, data);
-end
+end;
 
 func main() => integer
 begin
@@ -41,6 +41,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus
@@ -15,7 +15,7 @@ begin
   let x0 = UInt(read);
   let data = one OR (read XOR read);
   write_memory(y, 64, data);
-end
+end;
 
 var data_T1:: bits(64);
 
@@ -25,7 +25,7 @@ begin
   let x1 = UInt(read);
   data_T1 = one OR (read XOR read);
   write_memory(x, 64, data_T1);
-end
+end;
 
 func main() => integer
 begin
@@ -36,6 +36,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T0.0.x0 = 1 /\ 0: T1.0.x1 = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus
@@ -13,13 +13,13 @@ func T0(x::bits(64), y:: bits(64))
 begin
   write_memory(x, 64, one);
   write_memory(y, 64, one);
-end
+end;
 
 func T1(x::bits(64), y:: bits(64))
 begin
   let a = UInt(read_memory(y, 64));
   let b = UInt(read_memory(x, 64));
-end
+end;
 
 func main() => integer
 begin
@@ -30,6 +30,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: T1.0.a = 1 /\ 0: T1.0.b = 0)

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus
@@ -13,7 +13,7 @@ func T0(x::bits(64), y:: bits(64))
 begin
   write_memory(x, 64, one);
   write_memory(y, 64, one);
-end
+end;
 
 var a: integer;
 var b: integer;
@@ -22,7 +22,7 @@ func T1(x::bits(64), y:: bits(64))
 begin
   a = UInt(read_memory(y, 64));
   b = UInt(read_memory(x, 64));
-end
+end;
 
 func main() => integer
 begin
@@ -33,6 +33,6 @@ begin
   T1(x, y);
 
   return 0;
-end
+end;
 
 exists (0: a = 1 /\ 0: b = 0)

--- a/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus
@@ -10,6 +10,6 @@ begin
   constant y : bit = x[0] XOR '0' XOR '1';
   let res = UInt(y);
   return 0;
-end
+end;
 
 forall (0: main.0.res = 1)

--- a/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus
@@ -17,11 +17,11 @@ begin
     when Bonga =>
       let coucou = 11 ;
       print(coucou);
-  end
+  end;
   return 0;
-end
+end;
 
 func main() => integer
 begin  
   return g();
-end
+end;

--- a/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus
@@ -11,15 +11,15 @@ begin
   let imax = UInt(read_memory(x, 32));
   for i = 1 to imax do
     s = s + i;
-  end
-end
+  end;
+end;
 
 func T1(x::bits(32))
 begin
   for k = 1 to 3 do
     write_memory(x,32,k[2:0]);
-  end
-end
+  end;
+end;
 
 func main() => integer
 begin
@@ -29,6 +29,6 @@ begin
   T1(x);
 
   return 0;
-end
+end;
 
 locations [0:T0.0.s;]

--- a/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus
@@ -19,6 +19,6 @@ begin
   let (a,b) = (1,UInt(read_memory(x,32)));
   let c = a+b;
   return 0;
-end
+end;
 
 forall 0:main.0.c=16

--- a/herd/tests/instructions/ASL-pseudo-arch/non-deterministic.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/non-deterministic.litmus
@@ -8,14 +8,14 @@ begin
   let b = SomeBoolean();
   if b then
     return 1;
-  end
+  end;
   return 2;
-end
+end;
 
 func main() => integer
 begin
   let z = g();
   return 0;
-end
+end;
 
 locations [0:main.0.z;]

--- a/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus
@@ -14,14 +14,14 @@ begin
     s = s + i;
     i = i-1;
   until i <= 0;
-end
+end;
 
 func T1(x::bits(32))
 begin
   for k = 1 to 3 do
     write_memory(x,32,k[2:0]);
-  end
-end
+  end;
+end;
 
 func main() => integer
 begin
@@ -31,6 +31,6 @@ begin
   T1(x);
 
   return 0;
-end
+end;
 
 locations [0:T0.0.s;]

--- a/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus
@@ -7,13 +7,13 @@ ASL return-tuple
 func f() => (integer, integer)
 begin
   return (1,2);
-end
+end;
 
 func main() => integer
 begin
   let (a,b) = f();
   let c = a+b;
   return 0;
-end
+end;
 
 forall 0:main.0.c=3

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus
@@ -16,7 +16,7 @@ func f() => integer
 begin
   z = 2;
   throw Coucou {};
-end
+end;
 
 func main() => integer
 begin
@@ -24,7 +24,7 @@ begin
     z = f();
   catch
     when Coucou => return 0;
-  end
-end
+  end;
+end;
 
 forall 0:z=2

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus
@@ -20,8 +20,8 @@ begin
     throw Coucou {};
   else
     return 1;
-  end
-end
+  end;
+end;
 
 func g() => integer
 begin
@@ -29,16 +29,16 @@ begin
   let b = SomeBoolean();
   try
     a = f();
-    if b then throw Coucou {}; end
+    if b then throw Coucou {}; end;
     t = 2;
-    if SomeBoolean() then throw Bonga {}; end
+    if SomeBoolean() then throw Bonga {}; end;
     return a;
   catch
-    when Coucou => if SomeBoolean() then a = 0; throw Coucou {}; end
-    when Bonga => if SomeBoolean() then a=0; throw Coucou {}; end
-  end
+    when Coucou => if SomeBoolean() then a = 0; throw Coucou {}; end;
+    when Bonga => if SomeBoolean() then a=0; throw Coucou {}; end;
+  end;
   return a;
-end
+end;
 
 func main() => integer
 begin
@@ -48,8 +48,8 @@ begin
     return 0;
   catch
     when Coucou => return 0;
-  end
-end
+  end;
+end;
 
 locations [0:main.0.y;]
 forall 0:z=2 /\ 0:t=2 /\

--- a/herd/tests/instructions/ASL-pseudo-arch/try-non-deterministic.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/try-non-deterministic.litmus
@@ -10,18 +10,18 @@ begin
     let b = SomeBoolean();
     if b then
       throw Coucou {};
-    end
+    end;
     return a+1;
   catch
     when Coucou =>
       return a+3;
-  end
+  end;
 
-end
+end;
 func main() => integer
 begin
   let  x = g(0);
   return 0;
-end
+end;
 
 locations [0:main.0.x;]

--- a/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus
@@ -13,15 +13,15 @@ begin
   while i > 0 do
     s = s + i;
     i = i-1;
-  end
-end
+  end;
+end;
 
 func T1(x::bits(32))
 begin
   for k = 1 to 3 do
     write_memory(x,32,k[2:0]);
-  end
-end
+  end;
+end;
 
 func main() => integer
 begin
@@ -31,6 +31,6 @@ begin
   T1(x);
 
   return 0;
-end
+end;
 
 locations [0:T0.0.s;]

--- a/herd/tests/instructions/ASL/assign1.litmus
+++ b/herd/tests/instructions/ASL/assign1.litmus
@@ -7,7 +7,7 @@ begin
     let x = 3;
 
     return 0;
-end
+end;
 
 forall (
     0: main.0.x = 3

--- a/herd/tests/instructions/ASL/assign2.litmus
+++ b/herd/tests/instructions/ASL/assign2.litmus
@@ -18,7 +18,7 @@ begin
   let c5 = C5;
 
   return 0;
-end
+end;
 
 forall (
      0: main.0.c1 = 3

--- a/herd/tests/instructions/ASL/assign3.litmus
+++ b/herd/tests/instructions/ASL/assign3.litmus
@@ -28,7 +28,7 @@ begin
   let al = if CondAL == '1110' then 1 else 0;
 
   return 0;
-end
+end;
 
 forall (
      0: main.0.eq = 1

--- a/herd/tests/instructions/ASL/bitfields1.litmus
+++ b/herd/tests/instructions/ASL/bitfields1.litmus
@@ -12,18 +12,18 @@ type MyBits of bits(5) {
 func constructor(b:: bits(5)) => MyBits
 begin
   return b;
-end
+end;
 
 func get_b(b::MyBits) => bits(3)
 begin
   return b.b;
-end
+end;
 
 func set_e(b::MyBits, e::bits(1)) => MyBits
 begin
   b.e = e;
   return b;
-end
+end;
 
 func main() => integer
 begin
@@ -35,7 +35,7 @@ begin
   let e = if c.c == '00101' then 1 else 0;
 
   return 0;
-end
+end;
 
 forall (
      0: main.0.b = 1

--- a/herd/tests/instructions/ASL/case1.litmus
+++ b/herd/tests/instructions/ASL/case1.litmus
@@ -7,8 +7,8 @@ begin
   case i of 
     when 0 => return 1;
     when 1 => return 0;
-  end
-end
+  end;
+end;
 
 func main() => integer
 begin
@@ -16,6 +16,6 @@ begin
   let b = inv(1);
 
   return 0;
-end
+end;
 
 forall (0: main.0.a = 1 /\ 0: main.0.b = 0)

--- a/herd/tests/instructions/ASL/data-return-01.litmus
+++ b/herd/tests/instructions/ASL/data-return-01.litmus
@@ -5,12 +5,12 @@ ASL no data return
 func f(x::integer) => integer
 begin
   return 3;
-end
+end;
 
 func main() => integer
 begin
   let a = f (3);
 
   return 0;
-end
+end;
 

--- a/herd/tests/instructions/ASL/data-return-02.litmus
+++ b/herd/tests/instructions/ASL/data-return-02.litmus
@@ -6,12 +6,12 @@ func f(x::integer) => integer
 begin
   let y = x;
   return 3;
-end
+end;
 
 func main() => integer
 begin
   let a = f (3);
 
   return 0;
-end
+end;
 

--- a/herd/tests/instructions/ASL/double-load.litmus
+++ b/herd/tests/instructions/ASL/double-load.litmus
@@ -14,6 +14,6 @@ begin
   let three = UInt (data_x);
 
   return 0;
-end
+end;
 
 forall (0: main.0.three = 3)

--- a/herd/tests/instructions/ASL/for1.litmus
+++ b/herd/tests/instructions/ASL/for1.litmus
@@ -7,12 +7,12 @@ begin
   var s = 0;
   for i = 1 to 10 do
     s = s + i ;
-  end
+  end;
   for i = 10 downto 1 do
     s = s + i ;
-  end
+  end;
 
   return 0;
-end
+end;
 
 forall (0: main.0.s = 110)

--- a/herd/tests/instructions/ASL/func1.litmus
+++ b/herd/tests/instructions/ASL/func1.litmus
@@ -5,7 +5,7 @@ ASL func1
 func f(i::integer) => integer
 begin
     return i;
-end
+end;
 
 func main() => integer
 begin
@@ -13,7 +13,7 @@ begin
     let y = f(x);
 
     return 0;
-end
+end;
 
 forall (
     0: main.0.x = 3 /\

--- a/herd/tests/instructions/ASL/func2.litmus
+++ b/herd/tests/instructions/ASL/func2.litmus
@@ -6,13 +6,13 @@ ASL func02
 getter X[i::integer] => integer
 begin
     return i;
-end
+end;
 
 setter X[i::integer] = v::integer
 begin
     let internal_i = i;
     let internal_v = v;
-end
+end;
 
 func main() => integer
 begin
@@ -20,7 +20,7 @@ begin
     let x = X[4];
 
     return 0;
-end
+end;
 
 forall (
      0: main.0.x = 4

--- a/herd/tests/instructions/ASL/func3.litmus
+++ b/herd/tests/instructions/ASL/func3.litmus
@@ -6,23 +6,23 @@ ASL func3
 getter f1[] => integer
 begin
   return 3;
-end
+end;
 
 setter f1[] = v :: integer
 begin
   pass;
   // Hahaha, as if I was to do anything with the value
-end
+end;
 
 getter f2[x::integer] => integer
 begin
   return f1[] + x;
-end
+end;
 
 setter f2[x::integer] = v :: integer
 begin
   f1[] = v + x;
-end
+end;
 
 var f3_storage: integer = -1;
 var f4_storage: integer = -1;
@@ -30,22 +30,22 @@ var f4_storage: integer = -1;
 getter f3[x::integer] => integer
 begin
   return f3_storage;
-end
+end;
 
 setter f3[x::integer] = v :: integer
 begin
   f3_storage = x;
-end
+end;
 
 getter f4[x::integer] => integer
 begin
   return f4_storage;
-end
+end;
 
 setter f4[x::integer] = v :: integer
 begin
   f4_storage = v;
-end
+end;
 
 func main() => integer
 begin
@@ -59,7 +59,7 @@ begin
   f4[14] = 15;
 
   return 0;
-end
+end;
 
 forall(
      0: main.0.a = 3

--- a/herd/tests/instructions/ASL/func4.litmus
+++ b/herd/tests/instructions/ASL/func4.litmus
@@ -6,17 +6,17 @@ ASL func4
 func f() => integer
 begin
   return 0;
-end
+end;
 
 func f(x::integer) => integer
 begin
   return x;
-end
+end;
 
 func f(x::integer, y::integer) => integer
 begin
   return x + y;
-end
+end;
 
 func main() => integer
 begin
@@ -25,7 +25,7 @@ begin
   let c = f(2, 3);
 
   return 0;
-end
+end;
 
 forall (
      0: main.0.a = 0

--- a/herd/tests/instructions/ASL/globals.litmus
+++ b/herd/tests/instructions/ASL/globals.litmus
@@ -12,4 +12,4 @@ begin
   x = x+UInt(b);
   assert (x == 6);  
   return 0 ;
-end
+end;

--- a/herd/tests/instructions/ASL/no-main.litmus
+++ b/herd/tests/instructions/ASL/no-main.litmus
@@ -5,4 +5,4 @@ ASL no-main
 func blablabla() => integer
 begin
   return 3;
-end
+end;

--- a/herd/tests/instructions/ASL/records.litmus
+++ b/herd/tests/instructions/ASL/records.litmus
@@ -13,23 +13,23 @@ begin
     f1 = a1,
     f2 = a2
   };
-end
+end;
 
 func inv2 (r::R) => R
 begin
   r.f2 = !r.f2;
   return r;
-end
+end;
 
 func read_f1 (r::R) => integer
 begin
   return r.f1;
-end
+end;
 
 func read_f2 (r::R) => integer
 begin
   return r.f2;
-end
+end;
 
 func main() => integer
 begin
@@ -40,6 +40,6 @@ begin
   assert read_f2(r);
 
   return 0;
-end
+end;
 
 forall (0: main.0.x = 3)

--- a/herd/tests/instructions/ASL/unknown.litmus
+++ b/herd/tests/instructions/ASL/unknown.litmus
@@ -7,7 +7,7 @@ variant = ASL
 func random_bool () => boolean
 begin
   return (UNKNOWN:: boolean);
-end
+end;
 
 func main () => integer
 begin
@@ -17,9 +17,9 @@ begin
     x = 1;
   else
     x = 0;
-  end
+  end;
 
   return 0;
-end
+end;
 
 locations [0: main.0.x]

--- a/herd/tests/instructions/ASL/while1.litmus
+++ b/herd/tests/instructions/ASL/while1.litmus
@@ -9,9 +9,9 @@ begin
   while x > 0 do
     y = y + 2 ;
     x = x - 1 ;
-  end
+  end;
 
   return 0;
-end
+end;
 
 forall (0: main.0.y = 6 /\ 0: main.0.x=0)

--- a/herd/tests/instructions/ASL/while2.litmus
+++ b/herd/tests/instructions/ASL/while2.litmus
@@ -8,11 +8,11 @@ begin
   repeat
     while FALSE do
       let z = 2 ;
-    end
+    end;
     x = 2;
   until x >= 2 ;
 
   return 0;
-end
+end;
 
 forall (0:main.0.z=0 /\ 0:main.0.x=2)

--- a/herd/tests/instructions/ASL/write_mem.litmus
+++ b/herd/tests/instructions/ASL/write_mem.litmus
@@ -9,6 +9,6 @@ begin
   write_memory(address, 64, data);
 
   return 0;
-end
+end;
 
 forall (x = 3)

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -195,6 +195,9 @@ let asl_generic_parser version lexer lexbuf =
 let stmts_from_string s =
   let open Asllib in
   let lexbuf = Lexing.from_string s in
+  let module Parser = Parser.Make(struct
+    let allow_no_end_semicolon = false
+  end) in
   try Parser.stmts Lexer.token lexbuf
   with e ->
     Warn.fatal "Internal parsing of \"%s\" failed with %s" s


### PR DESCRIPTION
As per request. This PR makes semicolons required after every statement including function bodies (`begin .. end;`)

For reference the command used for the majority of the `end` -> `end;` migration was:
```
find <target> -name '*.asl' -type f | xargs gsed -i 's/\([^A-Za-z0-9_]\|^\)end\([^A-Za-z0-9_;]\|$\)/\1end;\2/g'
```