### PR TITLE
[asl] Reserve variables starting with '__'

### DIFF
--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -182,6 +182,9 @@ val fresh_var : string -> identifier
 val global_ignored : unit -> identifier
 (** Creates a fresh dummy variable for a global ignored variable. *)
 
+val string_starts_with : prefix:string -> string -> bool
+(** A copy of String.starts_with out of stdlib 4.12 *)
+
 val is_global_ignored : identifier -> bool
 (** [is_global_ignored s] is true iff [s] has been created with [global_ignored ()]. *)
 

--- a/asllib/builder.mli
+++ b/asllib/builder.mli
@@ -22,34 +22,41 @@
 
 open Lexing
 
-(**
-   Builds an {!AST.t} from some files.
-
-   In this file the optional argument allow_no_end_semicolon - defaults to false
-   *)
+(** Builds an {!AST.t} from some files. *)
 
 type token = Tokens.token
 type ast_type = [ `Opn | `Ast ]
 type version = [ `ASLv0 | `ASLv1 ]
 type version_selector = [ `ASLv0 | `ASLv1 | `Any ]
 
+type parser_config = {
+  allow_no_end_semicolon : bool;
+  allow_double_underscore : bool;
+}
+
+val default_parser_config : parser_config
+(** The default parser configuration. It sets the following:
+        allow_no_end_semicolon = false
+        allow_double_underscore = false
+    *)
+
 val from_file_result :
   ?ast_type:ast_type ->
-  ?allow_no_end_semicolon:bool ->
+  ?parser_config:parser_config ->
   version ->
   string ->
   AST.t Error.result
 
 val from_file :
   ?ast_type:ast_type ->
-  ?allow_no_end_semicolon:bool ->
+  ?parser_config:parser_config ->
   version ->
   string ->
   AST.t
 
 val from_lexer_lexbuf :
   ?ast_type:ast_type ->
-  ?allow_no_end_semicolon:bool ->
+  ?parser_config:parser_config ->
   version ->
   'a ->
   lexbuf ->
@@ -57,7 +64,7 @@ val from_lexer_lexbuf :
 
 val from_file_multi_version :
   ?ast_type:ast_type ->
-  ?allow_no_end_semicolon:bool ->
+  ?parser_config:parser_config ->
   version_selector ->
   string ->
   AST.t Error.result

--- a/asllib/bundler.ml
+++ b/asllib/bundler.ml
@@ -54,6 +54,9 @@ let build_ast_from_file ?(is_opn = false) f =
   let module Parser = Parser.Make (struct
     let allow_no_end_semicolon = false
   end) in
+  let module Lexer = Lexer.Make (struct
+    let allow_double_underscore = false
+  end) in
   let parse = if is_opn then Parser.opn else Parser.ast in
   let chan = open_in f in
   let lexbuf = Lexing.from_channel chan in

--- a/asllib/doc/ASLRefProgress.tex
+++ b/asllib/doc/ASLRefProgress.tex
@@ -23,9 +23,6 @@ This chapter describes what is not yet present in the executable version of ASLR
 % ------------------------------------------------------------------------------
 \section{Syntax}
 
-\subsection{Reserved Keyword}
-\texttt{pattern} should be a reserved keyword.
-
 \subsection{Pragmas}
 ASLRef does not currently parse pragmas:
 \begin{verbatim}

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -500,35 +500,32 @@ The following list represents keywords that are reserved for future use.
 \textbf{Lexical Regular Expressions} & \textbf{Lexeme Action}\\
 \hline
 \texttt{"SAMPLE"}, \texttt{"UNSTABLE"} & $\lexicalerror$ \\
-\texttt{"\_"}, \texttt{"access"}, \texttt{"advice"}, \texttt{"after"} & $\lexicalerror$ \\
-\texttt{"any"}, \texttt{"aspect"} & $\lexicalerror$ \\
-\texttt{"assume"}, \texttt{"assumes"}, \texttt{"before"} & $\lexicalerror$ \\
+\texttt{"\_"}, \texttt{"any"} & $\lexicalerror$ \\
+\texttt{"assume"}, \texttt{"assumes"} & $\lexicalerror$ \\
 \texttt{"call"}, \texttt{"cast"} & $\lexicalerror$ \\
 \texttt{"class"}, \texttt{"dict"} & $\lexicalerror$ \\
 \texttt{"endcase"}, \texttt{"endcatch"}, \texttt{"endclass"} & $\lexicalerror$ \\
 \texttt{"endevent"}, \texttt{"endfor"}, \texttt{"endfunc"}, \texttt{"endgetter"} & $\lexicalerror$ \\
 \texttt{"endif"}, \texttt{"endmodule"}, \texttt{"endnamespace"}, \texttt{"endpackage"} & $\lexicalerror$ \\
 \texttt{"endproperty"}, \texttt{"endrule"}, \texttt{"endsetter"}, \texttt{"endtemplate"} & $\lexicalerror$ \\
-\texttt{"endtry"}, \texttt{"endwhile"}, \texttt{"entry"} & $\lexicalerror$ \\
-\texttt{"event"}, \texttt{"export"}, \texttt{"expression"} & $\lexicalerror$ \\
+\texttt{"endtry"}, \texttt{"endwhile"} & $\lexicalerror$ \\
+\texttt{"event"}, \texttt{"export"} & $\lexicalerror$ \\
 \texttt{"extends"}, \texttt{"extern"}, \texttt{"feature"} & $\lexicalerror$ \\
-\texttt{"get"}, \texttt{"gives"} & $\lexicalerror$ \\
+\texttt{"gives"} & $\lexicalerror$ \\
 \texttt{"iff"}, \texttt{"implies"}, \texttt{"import"} & $\lexicalerror$ \\
 \texttt{"intersect"}, \texttt{"intrinsic"} & $\lexicalerror$ \\
-\texttt{"invariant"}, \texttt{"is"}, \texttt{"list"} & $\lexicalerror$ \\
+\texttt{"invariant"}, \texttt{"list"} & $\lexicalerror$ \\
 \texttt{"map"}, \texttt{"module"}, \texttt{"namespace"}, \texttt{"newevent"} & $\lexicalerror$ \\
 \texttt{"newmap"}, \texttt{"original"} & $\lexicalerror$ \\
 \texttt{"package"}, \texttt{"parallel"} & $\lexicalerror$ \\
-\texttt{"pointcut"}, \texttt{"port"}, \texttt{"private"} & $\lexicalerror$ \\
+\texttt{"port"}, \texttt{"private"} & $\lexicalerror$ \\
 \texttt{"profile"}, \texttt{"property"}, \texttt{"protected"}, \texttt{"public"} & $\lexicalerror$ \\
-\texttt{"replace"} & $\lexicalerror$ \\
 \texttt{"requires"}, \texttt{"rethrow"}, \texttt{"rule"} & $\lexicalerror$ \\
-\texttt{"set"}, \texttt{"shared"}, \texttt{"signal"} & $\lexicalerror$ \\
-\texttt{"statements"}, \texttt{"template"} & $\lexicalerror$ \\
+\texttt{"shared"}, \texttt{"signal"} & $\lexicalerror$ \\
+\texttt{"template"} & $\lexicalerror$ \\
 \texttt{"typeof"}, \texttt{"union"} & $\lexicalerror$ \\
-\texttt{"using"}, \texttt{"watch"} & $\lexicalerror$ \\
+\texttt{"using"} & $\lexicalerror$ \\
 \texttt{"ztype"} & $\lexicalerror$ \\
-% "pattern"
 \hline
 \end{tabular}
 \end{center}

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -98,3 +98,25 @@ Some problems with bitvectors and bitmasks:
   ASL Typing error: cannot find a common ancestor to those two types bits(0)
     and bits(1).
   [1]
+
+Check that variables starting with `__` are reserved:
+  $ cat >reserved0.asl <<EOF
+  > var pattern: bits(4) = '0001';
+  > var _okay: integer = 1;
+  > var __reserved: integer = 2;
+  > func main() => integer
+  > begin
+  >   print(pattern);
+  >   print(_okay);
+  >   print(__reserved);
+  >   return 0;
+  > end;
+  > EOF
+
+  $ aslref reserved0.asl
+  ASL Lexical error: "__reserved" is a reserved keyword.
+  [1]
+  $ aslref --allow-double-underscore reserved0.asl
+  '0001'
+  1
+  2

--- a/herd/ASLParseTest.ml
+++ b/herd/ASLParseTest.ml
@@ -40,7 +40,11 @@ module Make (Conf : RunTest.Config) (ModelConfig : MemCat.Config) = struct
     type instruction = ASLA.parsedPseudo
     type token = Asllib.Tokens.token
 
-    let lexer = Asllib.Lexer.token
+    let lexer =
+        let module Lexer = Asllib.Lexer.Make(struct
+          let allow_double_underscore = false
+        end) in
+        Lexer.token
 
     let parser =
       let version =

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -224,6 +224,9 @@ let stmts_from_string s =
   let module Parser = Parser.Make(struct
     let allow_no_end_semicolon = false
   end) in
+  let module Lexer = Lexer.Make(struct
+    let allow_double_underscore = false
+  end) in
   try Parser.stmts Lexer.token lexbuf
   with e ->
     Warn.fatal "Internal parsing of \"%s\" failed with %s" s


### PR DESCRIPTION
This PR also removes the following keywords from the reserved list:
```
access
advice
after
aspect
before
entry
expression
get
is
pattern
pointcut
replace
set
statements
watch
```