### PR TITLE
[asl][reference] A minor fix to SemanticsRule.MatchFuncRes

### DIFF
--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1927,7 +1927,7 @@ The helper relation
     \matchfuncres(\TContinuing \cup \TReturning) \;\aslrel\;
                   \Normal(((\Identifiers\times\vals)^*\times\XGraphs)\aslsep\envs)
 \]
-converts normal and throwing configurations
+converts continuing configurations and returning configurations
 into corresponding normal configurations that can be returned by a subprogram evaluation.
 
 \subsubsection{Prose}


### PR DESCRIPTION
The description was wrong.