### PR TITLE
[herd]: Fix address generation for STG, LDG and friends (again)

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -3090,7 +3090,7 @@ module Make
         end
 
       let ldg rt rn k ii =
-        let ma = get_ea rn (AArch64.K k) (AArch64.S_LSL MachSize.granule_log2bytes) ii in
+        let ma = get_ea rn (AArch64.K k) AArch64.S_NOEXT ii in
         let do_ldg a_virt ac ma =
           let ( let* ) = (>>=) in
           let _do_ldg a =
@@ -3112,7 +3112,7 @@ module Make
       type double = Once|Twice
 
       let stg d rt rn k ii =
-        let ma = get_ea rn (AArch64.K k) (AArch64.S_LSL MachSize.granule_log2bytes) ii
+        let ma = get_ea rn (AArch64.K k) AArch64.S_NOEXT ii
         and mv = read_reg_data MachSize.Quad rt ii >>= tag_extract in
         let do_stg ac ma mv =
           let __do_stg a v =
@@ -3148,7 +3148,7 @@ module Make
                  M.op1 (Op.AddK MachSize.granule_nbytes) a
                  >>= fun a -> do_write_mem sz Annot.N aexp  ac a v ii in
                (mop1 >>| mop2) >>! () in
-        let ma = get_ea rn (AArch64.K k) (AArch64.S_LSL MachSize.granule_log2bytes) ii >>= loc_extract in
+        let ma = get_ea rn (AArch64.K k) AArch64.S_NOEXT ii >>= loc_extract in
         lift_memop rn Dir.W true false (* Unchecked *)
           (fun ac ma mv ->
             if Access.is_physical ac then begin

--- a/herd/tests/instructions/AArch64.MTE/B009.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B009.litmus
@@ -5,7 +5,7 @@ int x[8]={1,2,3,4,5,6,7,8};
 0:X0=x:green; 0:X1=x:red;
 }
 P0                ;
-STG X1,[X0,#1]    ;
+STG X1,[X0,#16]   ;
 DSB SY            ;
 MOV W2,#9         ;
 STR W2,[X0,#16]   ;

--- a/herd/tests/instructions/AArch64.MTE/B009.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B009.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (fault(P0,x))
 Observation B009 Always 1 0
-Hash=a0049bcae76b7e6c49f320a8c62b6b8b
+Hash=e709dfa5687229ee24c64baa4be1d1d9
 

--- a/herd/tests/instructions/AArch64.MTE/B010.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B010.litmus
@@ -5,7 +5,7 @@ int x[8]={1,2,3,4,5,6,7,8};
 0:X0=x:green; 0:X1=x:red;
 }
 P0                ;
-STG X1,[X0,#1]    ;
+STG X1,[X0,#16]   ;
 DSB SY            ;
 MOV W2,#9         ;
 STR W2,[X0,#12]   ;

--- a/herd/tests/instructions/AArch64.MTE/B010.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B010.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (not (fault(P0,x)))
 Observation B010 Always 1 0
-Hash=96b31e9a3d4696c3cc7ba14e1aa59685
+Hash=683370b37c1159c10a7517d849f3c051
 

--- a/herd/tests/instructions/AArch64.MTE/B011.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B011.litmus
@@ -5,7 +5,7 @@ int x[8]={1,2,3,4,5,6,7,8};
 0:X0=x:green; 0:X1=x:red;
 }
 P0                ;
-STG X1,[X0,#1]    ;
+STG X1,[X0,#16]   ;
 DSB SY            ;
 MOV W2,#9         ;
 STR W2,[X1]       ;

--- a/herd/tests/instructions/AArch64.MTE/B011.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B011.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (fault(P0,x))
 Observation B011 Always 1 0
-Hash=8cade37cdb9933f54d962504c55ec46f
+Hash=6d2736480bf9fc9b54cd2c78b0330fbe
 

--- a/herd/tests/instructions/AArch64.MTE/B012.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B012.litmus
@@ -5,7 +5,7 @@ int x[8]={1,2,3,4,5,6,7,8};
 0:X0=x:green; 0:X1=x:red;
 }
 P0                ;
-STG X1,[X0,#1]    ;
+STG X1,[X0,#16]   ;
 DSB SY            ;
 MOV W2,#9         ;
 STR W2,[X1,#16]    ;

--- a/herd/tests/instructions/AArch64.MTE/B012.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B012.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (not (fault(P0,x)))
 Observation B012 Always 1 0
-Hash=d24bc3e60702c74ece0d92df2985281b
+Hash=373fea60dc2524676ae0d6095296613a
 

--- a/herd/tests/instructions/AArch64.MTE/B013.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B013.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:X2=x:green /\ 0:X3=x:red)
 Observation B013 Always 1 0
-Hash=61e3ccc9a6795411106ff0b5f9ca313a
+Hash=ff1d49fd5f406a9bad36312fd738487f
 

--- a/herd/tests/instructions/AArch64.MTE/B014.litmus
+++ b/herd/tests/instructions/AArch64.MTE/B014.litmus
@@ -1,14 +1,14 @@
-AArch64 B013
+AArch64 B014
+(* Should not come through *)
 {
 int x[8]={1,2,3,4,5,6,7,8};
 
 0:X0=x:green; 0:X1=x:red;
 }
 P0                ;
-STG X1,[X0,#16]   ;
+STG X1,[X0,#1]   ;
 DSB SY            ;
 LDG X2,[X0]       ;
-LDG X3,[X0,#16]   ;
+LDG X3,[X0,#1]   ;
 SUB X3,X3,#16     ;
-
 forall 0:X2=x:green /\ 0:X3=x:red

--- a/herd/tests/instructions/AArch64.MTE/B014.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.MTE/B014.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.MTE/B014.litmus": Illegal instruction 'STG X1,[X0,#1]' (User error)

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -3080,6 +3080,8 @@ let is_nbits_signed n =
 
 let is_6bits_signed = is_nbits_signed 6
 
+let is_granule_offset k = is_nbits_signed 9 k && (k mod MachSize.granule_nbytes == 0)
+
 let variant_raw = function
   | V128 -> 128
   | V64 -> 64
@@ -3226,6 +3228,13 @@ let is_valid i =
     -> is_6bits_signed k
   | I_CNT_INC_SVE (_,_,_,k)
     -> is_4bits_unsigned (k-1)
+  | I_STG (_,_,(k,Idx))
+  | I_STZG (_,_,(k,Idx))
+  | I_STZ2G (_,_,(k,Idx))
+  | I_LDG (_,_,k)
+    -> is_granule_offset k
+  | I_STG _ | I_STZG _ | I_STZ2G _
+    -> false
   | _ -> true
 
 


### PR DESCRIPTION
Partially revert c00eaf38b63 ("[herd]: Fix address generation for STG, LDG and friends").

Altough it is correct that address generation using immediate signed offset scaled by the Tag granule, it only applies to encoding of the instruction but immediate for assembler has different requirement:

```
<simm> Is the optional signed immediate offset, a multiple of 16
in the range -4096 to 4080, defaulting to 0 and encoded in the "imm9"
field.
```
and it is what assembler implements

```
Error: immediate value must be a multiple of 16 at operand 2 -- `stg X1,[X0,#1]'
Error: immediate value must be a multiple of 16 at operand 2 -- `ldg X3,[X0,#1]'
```

So roll back herd part and update MTE tests, also add extra check for immediate and dedicated litmus test to exercise the check.