### PR TITLE
[asl] Report when operators with same precedence are used without parentheses

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1343,6 +1343,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         in
         (t, E_Cond (e_cond', e_true', e_false') |> here) |: TypingRule.ECond
     (* End *)
+    | E_Tuple [ e ] -> annotate_expr_ ~forbid_atcs env e
     (* Begin ETuple *)
     | E_Tuple li ->
         let ts, es =
@@ -1445,13 +1446,13 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                   check_true (not (list_is_empty slices)) @@ fun () ->
                   fatal_from loc Error.EmptySlice
                 in
-                let w = slices_width env slices in
                 (* TODO: check that:
                    - Rule SNQJ: An expression or subexpression which
                      may result in a zero-length bitvector must not be
                      side-effecting.
                 *)
                 let slices' = best_effort slices (annotate_slices env) in
+                let w = slices_width env slices' in
                 (T_Bits (w, []) |> here, E_Slice (e'', slices') |> here)
                 |: TypingRule.ESlice
             (* End *)

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -240,6 +240,11 @@ Parameterized integers:
   ASL Typing error: cannot declare already declared element "h".
   [1]
 
+  $ aslref same-precedence.asl
+  File same-precedence.asl, line 6, characters 10 to 15:
+  ASL Error: Cannot parse.
+  [1]
+
   $ aslref rdiv_checks.asl
   File rdiv_checks.asl, line 3, characters 12 to 25:
   ASL Typing error: Illegal application of operator / on types real and string.

--- a/asllib/tests/regressions.t/same-precedence.asl
+++ b/asllib/tests/regressions.t/same-precedence.asl
@@ -1,0 +1,8 @@
+func main () => integer
+begin
+  let a = 1;
+  let b = 2;
+  let c = 4;
+  let - = a + b - c;
+
+  return 0;

--- a/asllib/tests/typing.t/CNegative3.asl
+++ b/asllib/tests/typing.t/CNegative3.asl
@@ -6,7 +6,7 @@ begin
     var z = N;
     // some algorithm with an undeterminable loop count
     while x*x + y*y <= 2.0*2.0 do
-        let xtemp = x*x - y*y + x0;
+        let xtemp = (x*x - y*y) + x0;
         y = 2.0*x*y + y0;
         x = xtemp;
         z = z + 1; // should be illegal without ATC

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=bad63763883ba8f1c18be47e445058b7
+Hash=292d8a1f647a7bcb9a18c1fc651aee33
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=08ac824ad1d5a3d5dbf9fa693f5c9a3e
+Hash=d683defca33d97a24f08882335ff8591
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=b2e28d6e49641ae233d2956d903710ce
+Hash=c26e79e8a665f8ca1ec9c8eed82b2e07
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=feba98e1370ea893b2c77debe00448ce
+Hash=ec05690c096dfd933a8777cd6e6c9eaa
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=3fc04f3517e8479bed44f409d0dedc19
+Hash=cbb61b804079364d0e781b19f229cae5
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=18387829b9a7e144f3edce911e403abb
+Hash=640fb2c6e94078525edebd01347e5a6d
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=7c82a9af991e52546d1756c9041ddd51
+Hash=b707baead2b638b4c5d773c5b7e55731
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=05bf9dc92c907b66ee01266504de89da
+Hash=2cdc2249d1970cce6cfeb8612874f590
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=6f93a3f6ee52feeaa91bc05848ff2839
+Hash=a5e2354c65f5aedc64898d42410af259
 

--- a/herd/tests/instructions/ASL/globals.litmus.expected
+++ b/herd/tests/instructions/ASL/globals.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation globals Always 1 0
-Hash=67542ca438284cccade13b6981c3413b
+Hash=eed9af62ee54d92d93162e35efd0e924
 

--- a/herd/tests/instructions/ASL/unknown.litmus.expected
+++ b/herd/tests/instructions/ASL/unknown.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation Unknown Always 2 0
-Hash=e9207fd12ef12177972a17e0c8a08546
+Hash=99c2911874c0c25a0759538490ccb5a8
 


### PR DESCRIPTION
For example, the following code is now forbidden:
```
let - = a + b - c;
```