### PR TITLE
[asl] Reintroduce equality with masks as sugar for patterns in v1.

### DIFF
--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMaskFALSE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMaskFALSE.asl
@@ -1,7 +1,7 @@
 func main () => integer
 begin
 
-  let match_me = '101010' IN '0x1010';
+  let match_me = '101010' IN {'0x1010' };
   assert match_me == FALSE;
 
   return 0;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMaskTRUE.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMaskTRUE.asl
@@ -1,7 +1,7 @@
 func main () => integer
 begin
 
-  let match_me = '101010' IN 'xx1010';
+  let match_me = '101010' IN {'xx1010'};
   assert match_me == TRUE;
 
   return 0;

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -85,15 +85,16 @@ Some problems with bitvectors and bitmasks:
   > func main() => integer
   > begin
   >     var b = '';
-  >     let expr_a = '' IN '1';
-  >     let expr_b = '1' IN '';
-  >     let expr_c = '' IN '0';
-  >     let expr_d = '0' IN '0';
+  >     let expr_a = '' IN {'1'};
+  >     let expr_b = '1' IN {''};
+  >     let expr_c = '' IN {'0'};
+  >     let expr_d = '0' IN {''};
   >     return 0;
   > end
   > EOF
 
   $ aslref masks0.asl
-  File masks0.asl, line 4, characters 17 to 26:
-  ASL Typing error: a subtype of bits(1) was expected, provided bits(0).
+  File masks0.asl, line 4, characters 17 to 28:
+  ASL Typing error: cannot find a common ancestor to those two types bits(0)
+    and bits(1).
   [1]

--- a/asllib/tests/regressions.t/masks.asl
+++ b/asllib/tests/regressions.t/masks.asl
@@ -1,8 +1,9 @@
 func main () => integer
 begin
   assert ('111' IN {'1xx'}) == TRUE;
-  assert ('111' IN '1xx') == TRUE;
+  assert ('111' == '1xx') == TRUE;
   assert ('111' IN {'0xx'}) == FALSE;
+  assert ('111' == '0xx') == FALSE;
   assert (3 IN {2,3,4}) == TRUE;
   assert (1 IN {2,3,4}) == FALSE;
   assert (3 IN {1..10}) == TRUE;

--- a/asllib/tests/regressions.t/pattern-masks-no-braces.asl
+++ b/asllib/tests/regressions.t/pattern-masks-no-braces.asl
@@ -1,0 +1,8 @@
+
+func main () => integer
+begin
+  assert ('111' IN '1xx') == TRUE;
+  assert ('111' IN '0xx') == FALSE;
+
+  return 0;
+end

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -425,6 +425,10 @@ Empty getters/setters
   File bad-pattern.asl, line 4, characters 7 to 12:
   ASL Typing error: Erroneous pattern '101' for expression of type integer {3}.
   [1]
+  $ aslref pattern-masks-no-braces.asl
+  File pattern-masks-no-braces.asl, line 4, characters 19 to 24:
+  ASL Error: Cannot parse.
+  [1]
 
 ASLRef Field getter extension
   $ aslref --use-field-getter-extension setter_bitfields.asl


### PR DESCRIPTION
- [x] Remove possibility to write `'1010' IN '10x0'`: braces are mandatory and this should be written `'1010' IN {'10x0'}`
- [x] Add possibility to write `'1010' == '10x0'`: this is a sugar for `'1010' IN {'10x0'}`