### PR TITLE
[fix][dune] specify ignored modules in asllib/tests

### DIFF
--- a/asllib/tests/dune
+++ b/asllib/tests/dune
@@ -12,7 +12,7 @@
   (:standard ../libdir/stdlib.asl))
  (libraries asllib zarith)
  (modules
-  (:standard \ toposort))
+  (:standard \ toposort ConstraintBinops))
  (flags
   (:standard -w -40-42))
  (action


### PR DESCRIPTION
Error report:

```
# make && make test
make  207.24s user 44.45s system 398% cpu 1:03.18 total
                                         
File "asllib/tests/dune", line 1, characters 0-0:
Error: Module "ConstraintBinops" is used in several stanzas:
- asllib/tests/dune:1
- asllib/tests/dune:8
To fix this error, you must specify an explicit "modules" field in every
library, executable, and executables stanzas in this dune file. Note that
each module cannot appear in more than one "modules" field - it must belong
to a single library or executable.
make: *** [Makefile:80: dune-test] Error 1         
make test  3.83s user 1.91s system 122% cpu 4.683 total
```