### PR TITLE
BPF: Add amo-sequences

### DIFF
--- a/catalogue/bpf/shelf.py
+++ b/catalogue/bpf/shelf.py
@@ -180,4 +180,6 @@ illustrative_tests = [
 	"tests/C-RW-r+RW-a+RW-B+RW-B+RW-B+RW-B+RW-B+RW-B-BPF.litmus",
     "tests/2+2W+release+fence.litmus",
     "tests/Z6.3+fence+fence+acquire.litmus",
+    "tests/amo-sequence-1.litmus",
+    "tests/amo-sequence-2.litmus",
 ]

--- a/catalogue/bpf/tests/amo-sequence-1.litmus
+++ b/catalogue/bpf/tests/amo-sequence-1.litmus
@@ -1,0 +1,15 @@
+BPF amo-sequence-1
+(*
+ * Result: Never
+ *)
+{
+ 0:r2=x; 0:r4=y;
+ 1:r2=y;
+ 2:r2=y; 2:r4=x;
+}
+ P0                                 | P1                          | P2                                 ;
+ r1 = 1                             | r1 = 1                      | r1 = load_acquire((u32 *)(r2 + 0)) ;
+ *(u32 *)(r2 + 0) = r1              | lock *(u32 *)(r2 + 0) += r1 | r3 = *(u32 *)(r4 + 0)              ;
+ r3 = 1                             |                             |                                    ;
+ store_release((u32 *)(r4 + 0), r3) |                             |                                    ;
+exists (2:r1=2 /\ 2:r3=0)

--- a/catalogue/bpf/tests/amo-sequence-2.litmus
+++ b/catalogue/bpf/tests/amo-sequence-2.litmus
@@ -1,0 +1,15 @@
+BPF amo-sequence-2
+(*
+ * Result: Never
+ *)
+{
+ 0:r2=x; 0:r4=y;
+ 1:r2=y;
+ 2:r2=y; 2:r4=x;
+}
+ P0                                 | P1                                         | P2                                 ;
+ r1 = 1                             | r1 = 1                                     | r1 = load_acquire((u32 *)(r2 + 0)) ;
+ *(u32 *)(r2 + 0) = r1              | r3 = atomic_fetch_add((u32 *)(r2 + 0), r1) | r3 = *(u32 *)(r4 + 0)              ;
+ r3 = 1                             |                                            |                                    ;
+ store_release((u32 *)(r4 + 0), r3) |                                            |                                    ;
+exists (2:r1=2 /\ 2:r3=0)

--- a/catalogue/bpf/tests/kinds.txt
+++ b/catalogue/bpf/tests/kinds.txt
@@ -169,3 +169,5 @@ C-LB-LRR+R-A+R-A+OB-O+OB-OB-BPF Forbidden
 C-LB-LWR+R-A+OB-OB-BPF Forbidden
 2+2W+release+fence Allowed
 Z6.3+fence+fence+acquire Forbidden
+amo-sequence-1 Forbidden
+amo-sequence-2 Forbidden

--- a/herd/libdir/bpf.cat
+++ b/herd/libdir/bpf.cat
@@ -66,7 +66,8 @@ let ppo =
 
 (* Propagation ordering from SC and release operations *)
 let A-cumul = rfe? ; (po_amo_fetch | store_release)
-let prop = (coe | fre)? ; A-cumul* ; rfe?
+let amo-sequence = (rf ; ([R & W] | amo))*
+let prop = (coe | fre)? ; (A-cumul ; amo-sequence)* ; rfe?
 
 (**********)
 (* Axioms *)


### PR DESCRIPTION
Language models such as LKMM and C11 allow so called "AMO sequences" to provide a certain form of cumulativity: for example,

$ cat lkmm-amo-sequence.litmus
C lkmm-amo-sequence

(*
 * Result: Never *)

{}

P0(int *x, atomic_t *y)
{
	WRITE_ONCE(*x, 1);
	atomic_set_release(y, 1);
}

P1(atomic_t *y)
{
	atomic_inc(y);
}

P2(int *x, atomic_t *y)
{
	int r0;
	int r1;

	r0 = atomic_read_acquire(y);
	r1 = READ_ONCE(*x);
}

exists (2:r0=2 /\ 2:r1=0)

$ herd7 -conf linux-kernel.cfg lkmm-amo-sequence.litmusTest lkmm-amo-sequence Allowed
States 5
2:r0=0; 2:r1=0;
2:r0=0; 2:r1=1;
2:r0=1; 2:r1=0;
2:r0=1; 2:r1=1;
2:r0=2; 2:r1=1;
No
Witnesses
Positive: 0 Negative: 9
Condition exists (2:r0=2 /\ 2:r1=0)
Observation lkmm-amo-sequence Never 0 9
Time lkmm-amo-sequence 0.01
Hash=ad9b6e1caa2fac8973b38ba285fa0d04

In contrast,

$ cat catalogue/bpf/tests/amo-sequence-1.litmus
BPF amo-sequence-1
(*
 * Result: Never *) {
 0:r2=x; 0:r4=y;
 1:r2=y;
 2:r2=y; 2:r4=x;
}
 P0                                 | P1                          | P2                                 ;
 r1 = 1                             | r1 = 1                      | r1 = load_acquire((u32 *)(r2 + 0)) ;
 *(u32 *)(r2 + 0) = r1              | lock *(u32 *)(r2 + 0) += r1 | r3 = *(u32 *)(r4 + 0)              ;
 r3 = 1                             |                             |                                    ;
 store_release((u32 *)(r4 + 0), r3) |                             |                                    ;
exists (2:r1=2 /\ 2:r3=0)

$ herd7 catalogue/bpf/tests/amo-sequence-1.litmus
Test amo-sequence-1 Allowed
States 6
2:r1=0; 2:r3=0;
2:r1=0; 2:r3=1;
2:r1=1; 2:r3=0;
2:r1=1; 2:r3=1;
2:r1=2; 2:r3=0;
2:r1=2; 2:r3=1;
Ok
Witnesses
Positive: 1 Negative: 9
Condition exists (2:r1=2 /\ 2:r3=0)
Observation amo-sequence-1 Sometimes 1 9
Time amo-sequence-1 0.00
Hash=9e6f4c4ddf9dbb1391cec35bfa7668b3

In a similar way,

$ cat c11-amo-sequence.litmus
C c11-amo-sequence

(*
 * Result: Never *)

{}

P0(atomic_int *x, atomic_int *y)
{
	atomic_store_explicit(x, 1, memory_order_relaxed);
	atomic_store_explicit(y, 1, memory_order_release);
}

P1(atomic_int *y)
{
	int r0;

	r0 = atomic_fetch_add_explicit(y, 1, memory_order_relaxed);
}

P2(atomic_int *x, atomic_int *y)
{
	int r0;
	int r1;

	r0 = atomic_load_explicit(y, memory_order_acquire);
	r1 = atomic_load_explicit(x, memory_order_relaxed);
}

exists (2:r0=2 /\ 2:r1=0)

$ herd7 c11-amo-sequence.litmus
Test c11-amo-sequence Allowed
States 5
2:r0=0; 2:r1=0;
2:r0=0; 2:r1=1;
2:r0=1; 2:r1=0;
2:r0=1; 2:r1=1;
2:r0=2; 2:r1=1;
No
Witnesses
Positive: 0 Negative: 9
Condition exists (2:r0=2 /\ 2:r1=0)
Observation c11-amo-sequence Never 0 9
Time c11-amo-sequence 0.02
Hash=a896a0e2c669f03d65dade49e25fa3e7

However, even in its SC realization,

$ cat catalogue/bpf/tests/amo-sequence-2.litmus
BPF amo-sequence-2
(*
 * Result: Never *) {
 0:r2=x; 0:r4=y;
 1:r2=y;
 2:r2=y; 2:r4=x;
}
 P0                                 | P1                                         | P2                                 ;
 r1 = 1                             | r1 = 1                                     | r1 = load_acquire((u32 *)(r2 + 0)) ;
 *(u32 *)(r2 + 0) = r1              | r3 = atomic_fetch_add((u32 *)(r2 + 0), r1) | r3 = *(u32 *)(r4 + 0)              ;
 r3 = 1                             |                                            |                                    ;
 store_release((u32 *)(r4 + 0), r3) |                                            |                                    ;
exists (2:r1=2 /\ 2:r3=0)

$ herd7 catalogue/bpf/tests/amo-sequence-2.litmus
Test amo-sequence-2 Allowed
States 6
2:r1=0; 2:r3=0;
2:r1=0; 2:r3=1;
2:r1=1; 2:r3=0;
2:r1=1; 2:r3=1;
2:r1=2; 2:r3=0;
2:r1=2; 2:r3=1;
Ok
Witnesses
Positive: 1 Negative: 9
Condition exists (2:r1=2 /\ 2:r3=0)
Observation amo-sequence-2 Sometimes 1 9
Time amo-sequence-2 0.01
Hash=0234f9d66686fc4378b756cdf7e8e519

To address such gaps, introduce the amo-sequence relation, representing an arbitrarily long sequence of atomic memory operations, in which each operation reads from the previous one, and allow it to extend A-cumul. This solution is following/based on ebd50e2947de9 ("tools: memory-model: Add rmw-sequences to the LKMM") in the Linux kernel.


Cc: Puranjay Mohan <puranjay@kernel.org>