### PR TITLE
[litmus] New `-variant noinit` option.

### DIFF
--- a/asllib/tests/ASLDefinition.t/Bitfields_nested.asl
+++ b/asllib/tests/ASLDefinition.t/Bitfields_nested.asl
@@ -1,9 +1,9 @@
 type Nested_Type of bits(32) {
-    [31:15] fmt0 {
+    [31:16] fmt0 {
         [15] common,
         [14] moving
     },
-    [31:15] fmt1 {
+    [31:16] fmt1 {
         [15] common,
         [0]  moving
     },

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -4,3 +4,4 @@ Examples used in ASL High-level Definition:
   $ aslref spec3.asl
 
   $ aslref --no-exec Bitfields.asl
+  $ aslref Bitfields_nested.asl

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -149,26 +149,37 @@ let check_env_for_dups env =
           (LocSet.pp_str "," dump_location bad)
   end
 
-let dump_state_atom is_global dump_loc dump_val (loc,(t,v)) =
+let dump_loc_typed is_global  dump_loc loc t =
   let open TestType in
   match t with
   | TyDef ->
-     if is_global loc then
-       sprintf "[%s]=%s" (dump_loc loc) (dump_val v)
-     else
-      sprintf "%s=%s" (dump_loc loc) (dump_val v)
+      if is_global loc then
+        sprintf "[%s]" (dump_loc loc)
+      else
+        sprintf "%s" (dump_loc loc)
   | TyDefPointer ->
-      sprintf "*%s=%s" (dump_loc loc) (dump_val v)
+      sprintf "*%s" (dump_loc loc)
   | Ty "pteval_t" when is_global loc ->
-      sprintf "[%s]=%s" (dump_loc loc) (dump_val v)
+      sprintf "[%s]" (dump_loc loc)
   | Ty t ->
-      sprintf "%s %s=%s" t (dump_loc loc) (dump_val v)
+      sprintf "%s %s" t (dump_loc loc)
   | Atomic t ->
-      sprintf "_Atomic %s %s=%s" t (dump_loc loc) (dump_val v)
+      sprintf "_Atomic %s %s" t (dump_loc loc)
   | Pointer t ->
-      sprintf "%s *%s=%s" t (dump_loc loc) (dump_val v)
+      sprintf "%s *%s" t (dump_loc loc)
   | TyArray (t,sz) ->
-      sprintf "%s %s[%i]=%s" t (dump_loc loc) sz (dump_val v)
+      sprintf "%s %s[%i]" t (dump_loc loc) sz
+
+let dump_state_atom is_global dump_loc dump_val (loc,(t,v)) =
+  sprintf "%s=%s"
+    (dump_loc_typed is_global  dump_loc loc t)
+    (dump_val v)
+
+let dump_state_atom_no_init  is_global dump_loc dump_val (loc,(t,_) as bd) =
+  if is_global loc then
+    dump_loc_typed is_global  dump_loc loc t
+  else
+    dump_state_atom is_global dump_loc dump_val bd
 
 (* Packed result *)
 type info = (string * string) list

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -70,6 +70,10 @@ val dump_state_atom :
   ('loc -> bool) ->
   ('loc -> string) -> ('v -> string) -> ('loc * (TestType.t * 'v)) -> string
 
+val dump_state_atom_no_init :
+  ('loc -> bool) ->
+  ('loc -> string) -> ('v -> string) -> ('loc * (TestType.t * 'v)) -> string
+
 (* Packed result *)
 type info = (string * string) list
 

--- a/litmus/klitmus.ml
+++ b/litmus/klitmus.ml
@@ -203,6 +203,7 @@ let () =
       let sharelocks = !sharelocks
       let delay = !delay
       let carch = !carch
+      let variant _ = false (* No variant for kernel tests *)
 (* tar stuff *)
       let tarname = KOption.get_tar ()
     end in

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -68,11 +68,17 @@ module Make
       val dump : Name.t -> T.t -> unit
     end = struct
 
-    module Insert =
+(* Non valid mode for presi *)  
+  let () =
+    if Cfg.variant Variant_litmus.NoInit then
+      Warn.user_error "Switches `-variant NoInit` and `-mode (presi|kvm)` are not compatible"
+        
+  module Insert =
       ObjUtil.Insert
         (struct
           let sysarch = Cfg.sysarch
         end)
+
 (* MacOS has no affinity control *)
     let do_affinity =
       match Cfg.affinity with

--- a/litmus/test_litmus.ml
+++ b/litmus/test_litmus.ml
@@ -16,6 +16,7 @@
 
 module type Cfg = sig
   val hexa : bool
+  val variant : Variant_litmus.t -> bool
 end
 
 module type S = sig
@@ -149,7 +150,12 @@ struct
             let dump_v = A.V.pp Cfg.hexa
 
             let dump_state_atom =
-              MiscParser.dump_state_atom A.is_global A.pp_location dump_v
+              let do_dump =
+                if Cfg.variant Variant_litmus.NoInit then
+                  MiscParser.dump_state_atom_no_init
+                else
+                  MiscParser.dump_state_atom in
+              do_dump A.is_global A.pp_location dump_v
 
             type state = A.fullstate
 

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -41,6 +41,7 @@ module type Config = sig
   val sharelocks : int option
   val delay : int
   val carch : Archs.System.t
+  val variant : Variant_litmus.t -> bool
 end
 
 module Top(O:Config)(Tar:Tar.S) = struct

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -23,12 +23,16 @@ type t =
   | Telechat (* Telechat idiosyncrasies *)
   | SVE (* Do nothing *)
   | SME (* Do nothing *)
+  | NoInit (* Do not initialise variables *)
 
 let compare = compare
 
-let tags = "s128"::"self"::"mixed"::"vmsa"::"telechat"::Fault.Handling.tags
+let tags =
+  "noinit"::"s128"::"self"::"mixed"::"vmsa"::"telechat"
+  ::Fault.Handling.tags
 
 let parse s = match Misc.lowercase s with
+| "noinit" -> Some NoInit
 | "s128" -> Some S128
 | "self" -> Some Self
 | "mixed" -> Some Mixed
@@ -56,6 +60,7 @@ let parse s = match Misc.lowercase s with
     else None
 
 let pp = function
+  | NoInit -> "noinit"
   | Self -> "self"
   | Mixed -> "mixed"
   | S128 -> "s128"
@@ -78,4 +83,3 @@ let set_mte_precision _ _ = false
 let set_sve_length _ _ = None
 let set_sme_length _ _ = None
 let check_tag tag = [tag]
-

--- a/litmus/variant_litmus.mli
+++ b/litmus/variant_litmus.mli
@@ -23,6 +23,7 @@ type t =
   | Telechat (* Telechat idiosyncrasies *)
   | SVE (* Do nothing *)
   | SME (* Do nothing *)
+  | NoInit (* Do not initialise variables *)
 
 val tags : string list
 val parse : string -> t option


### PR DESCRIPTION
The option disables memory location initialisation. It is useful for time measures, especially when arrays are involved.