### PR TITLE
[asl,test] Fix `Bitfields_nested` example

### DIFF
--- a/asllib/tests/ASLDefinition.t/Bitfields_nested.asl
+++ b/asllib/tests/ASLDefinition.t/Bitfields_nested.asl
@@ -1,9 +1,9 @@
 type Nested_Type of bits(32) {
-    [31:15] fmt0 {
+    [31:16] fmt0 {
         [15] common,
         [14] moving
     },
-    [31:15] fmt1 {
+    [31:16] fmt1 {
         [15] common,
         [0]  moving
     },

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -4,3 +4,4 @@ Examples used in ASL High-level Definition:
   $ aslref spec3.asl
 
   $ aslref --no-exec Bitfields.asl
+  $ aslref Bitfields_nested.asl


### PR DESCRIPTION
Issue: `dune exec aslref asllib/tests/ASLDefinition.t/Bitfields_nested.asl` generates the following error:

```
File asllib/tests/ASLDefinition.t/Bitfields_nested.asl, line 30,
  characters 11 to 32:
ASL Execution error: Assertion failed: (common == common_fmt0).
```

Actually, to refer to the upper 16 bits, the slicing range should be `[31:16]`. Also add it to the cram test.