### PR TITLE
[asl] Add `[:wid]` shorthand for `[0+:wid]` slice

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -58,6 +58,8 @@ let version = V1
 let t_bit =
   T_Bits (E_Literal (L_Int Z.one) |> add_dummy_annotation ~version, [])
 
+let zero = E_Literal (L_Int Z.zero) |> add_dummy_annotation ~version
+
 let make_ldi_vars (xs, ty) =
   let make_one x =
     S_Decl (LDK_Var, LDI_Typed (LDI_Var x, ty), None)
@@ -332,6 +334,7 @@ let slice ==
   | ~=expr;                       < Slice_Single  >
   | e1=expr; COLON; e2=expr;      < Slice_Range   >
   | e1=expr; PLUS_COLON; e2=expr; < Slice_Length  >
+  | COLON; e=expr;                { Slice_Length(zero, e) }
   | e1=expr; STAR_COLON; e2=expr; < Slice_Star    >
 
 (* Bitfields *)

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -131,7 +131,8 @@ the function $\annotateslice$ (see \nameref{sec:TypingRule.Slice}) annotates a s
 \Nslice \derivesinline\ & \Nexpr &\\
             |\  & \Nexpr \parsesep \Tcolon \parsesep \Nexpr &\\
             |\  & \Nexpr \parsesep \Tpluscolon \parsesep \Nexpr &\\
-            |\  & \Nexpr \parsesep \Tstarcolon \parsesep \Nexpr &
+            |\  & \Nexpr \parsesep \Tstarcolon \parsesep \Nexpr &\\
+            |\  & \Tcolon \parsesep \Nexpr &
 \end{flalign*}
 
 \subsection{Abstract Syntax}
@@ -141,6 +142,8 @@ the function $\annotateslice$ (see \nameref{sec:TypingRule.Slice}) annotates a s
   |\ & \SliceLength(\overname{\expr}{\vi}, \overname{\expr}{\vn}) &\\
   |\ & \SliceStar(\overname{\expr}{\vi}, \overname{\expr}{\vn}) &
 \end{flalign*}
+
+Note that the syntax \texttt{[:width]} is a shorthand for \texttt{x[0:width]}.
 
 \subsubsection{ASTRule.Slice\label{sec:ASTRule.Slice}}
 \hypertarget{build-slice}{}
@@ -184,6 +187,13 @@ transforms a parse node for a slice $\vparsednode$ into an AST node for a slice 
 }{
   \buildslices(\Nslice(\namednode{\veone}{\Nexpr}, \Tstarcolon, \namednode{\vetwo}{\Nexpr})) \astarrow
   \overname{\SliceStar(\astversion{\veone}, \astversion{\vetwo})}{\vastnode}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[width]{}{
+  \buildslices(\Nslice(\Tcolon, \punnode{\Nexpr})) \astarrow
+  \overname{\SliceLength(\ELiteral(\lint(0)), \astof{\vexpr})}{\vastnode}
 }
 \end{mathpar}
 

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -526,7 +526,8 @@ except they do not derive tuples, which are the last derivation for $\Nexpr$.
 \Nslice \derivesinline\ & \Nexpr &\\
               |\  & \Nexpr \parsesep \Tcolon \parsesep \Nexpr &\\
               |\  & \Nexpr \parsesep \Tpluscolon \parsesep \Nexpr &\\
-              |\  & \Nexpr \parsesep \Tstarcolon \parsesep \Nexpr &
+              |\  & \Nexpr \parsesep \Tstarcolon \parsesep \Nexpr &\\
+              |\  & \Tcolon \parsesep \Nexpr &
 \end{flalign*}
 
 \hypertarget{def-nbitfields}{}

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -257,6 +257,8 @@ Parameterized integers:
   ASL Typing error: a subtype of bits(-) was expected, provided integer.
   [1]
 
+  $ aslref slice-width-shorthand.asl
+
 Arrays indexed by enumerations
   $ aslref enum-array.asl
   [0, 0, 0]

--- a/asllib/tests/regressions.t/slice-width-shorthand.asl
+++ b/asllib/tests/regressions.t/slice-width-shorthand.asl
@@ -1,0 +1,6 @@
+func main() => integer
+begin
+  assert (0x12345[:20] == 0x123456789_12345[0+:20]);
+
+  return 0;
+end;


### PR DESCRIPTION
Desugar to `Slice_Length(0, wid)` during parsing, add a test, and update reference documentation.