### PR TITLE
Get rid of asserts in AArch64 instruction parser

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -93,7 +93,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_ADD_SIMD _| I_ADD_SIMD_S _| I_ADR _| I_ALIGND _| I_ALIGNU _| I_BC _
     | I_BLR _| I_BR _| I_BUILD _| I_CAS _| I_CASBH _| I_CASP _| I_CHKEQ _| I_CHKSLD _
     | I_CHKTGD _| I_CLRTAG _| I_CPYTYPE _| I_CPYVALUE _| I_CSEAL _| I_CSEL _| I_DC _
-    | I_EOR_SIMD _| I_ERET| I_FENCE _| I_GC _| I_IC _| I_LD1 _| I_LD1M _| I_LD1R _ | I_LDAP1 _
+    | I_OP3_SIMD _| I_ERET| I_FENCE _| I_GC _| I_IC _| I_LD1 _| I_LD1M _| I_LD1R _ | I_LDAP1 _
     | I_LD2 _| I_LD2M _| I_LD2R _| I_LD3 _| I_LD3M _| I_LD3R _| I_LD4 _| I_LD4M _
     | I_LD4R _| I_LDAR _| I_LDARBH _| I_LDCT _| I_LDG _| I_LDOP _| I_LDOPBH _
     | I_LDP _| I_LDP_SIMD _| I_LDPSW _| I_LDR _
@@ -118,7 +118,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
     | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
     | I_DUP_SV _ | I_ADD_SV _ | I_PTRUE _
-    | I_NEG_SV _ | I_EOR_SV _ | I_MOVPRFX _
+    | I_NEG_SV _ | I_OP3_SV _ | I_MOVPRFX _
     | I_SMSTART _ | I_SMSTOP _ | I_LD1SPT _ | I_ST1SPT _
     | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
       -> true
@@ -313,12 +313,12 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_TLBI (_,_)
       | I_MOV_V _ | I_MOV_VE _ | I_MOV_S _ | I_MOV_TG _ | I_MOV_FG _
       | I_MOVI_S _ | I_MOVI_V _ | I_ADDV _ | I_DUP _ |  I_FMOV_TG _
-      | I_EOR_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
+      | I_OP3_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
       | I_UDF _ | I_ADDSUBEXT _ | I_MOPL _ | I_MOP _
       | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
       | I_UADDV _
       | I_MOV_SV _ | I_DUP_SV _ | I_ADD_SV _ | I_PTRUE _
-      | I_NEG_SV _ | I_MOVPRFX _ | I_EOR_SV _
+      | I_NEG_SV _ | I_MOVPRFX _ | I_OP3_SV _
       | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
       | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
       | I_SMSTART _ | I_SMSTOP _ | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
@@ -395,7 +395,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_UADDV (_,r,_,_)
       | I_MOV_SV (r,_,_)
       | I_DUP_SV (r,_,_) | I_ADD_SV (r,_,_) | I_PTRUE (r,_)
-      | I_NEG_SV (r,_,_) | I_MOVPRFX (r,_,_) | I_EOR_SV (r,_,_)
+      | I_NEG_SV (r,_,_) | I_MOVPRFX (r,_,_) | I_OP3_SV (_,r,_,_)
       | I_INDEX_SI (r,_,_,_) | I_INDEX_IS (r,_,_,_) | I_INDEX_SS (r,_,_,_) | I_INDEX_II (r,_,_)
       | I_RDVL (r,_) | I_ADDVL (r,_,_) | I_CNT_INC_SVE (_,r,_,_)
       | I_LD1SPT (_,r,_,_,_,_,_) | I_MOVA_TV (r,_,_,_,_) | I_MOVA_VT (r,_,_,_,_)
@@ -425,7 +425,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_MOV_VE _
       | I_MOV_V _|I_MOV_TG _|I_MOV_FG _
       | I_MOV_S _|I_MOVI_V _|I_MOVI_S _
-      | I_EOR_SIMD _|I_ADD_SIMD _|I_ADD_SIMD_S _
+      | I_OP3_SIMD _|I_ADD_SIMD _|I_ADD_SIMD_S _
       | I_ALIGND _|I_ALIGNU _
       | I_BUILD _|I_CHKEQ _|I_CHKSLD _|I_CHKTGD _|I_CLRTAG _
       | I_CPYTYPE _|I_CPYVALUE _|I_CSEAL _|I_GC _
@@ -456,7 +456,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_MOV_V _|I_MOV_TG _|I_MOV_FG _
       | I_MOV_S _|I_MOVI_V _|I_MOVI_S _
       | I_ADDV _| I_DUP _ | I_FMOV_TG _
-      | I_EOR_SIMD _|I_ADD_SIMD _|I_ADD_SIMD_S _
+      | I_OP3_SIMD _|I_ADD_SIMD _|I_ADD_SIMD_S _
       | I_LDP _|I_LDPSW _|I_STP _
       | I_STR _|I_STLR _|I_ALIGND _|I_ALIGNU _
       | I_BUILD _|I_CHKEQ _|I_CHKSLD _|I_CHKTGD _|I_CLRTAG _
@@ -477,7 +477,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD1SP _ | I_LD2SP _ | I_LD3SP _ | I_LD4SP _
       | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
       | I_ADD_SV _ | I_PTRUE _
-      | I_NEG_SV _ | I_MOVPRFX _ | I_EOR_SV _
+      | I_NEG_SV _ | I_MOVPRFX _ | I_OP3_SV _
       | I_MOV_SV _ | I_DUP_SV _
       | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
       | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -3433,7 +3433,7 @@ module Make
         | I_MOVI_S(var,r,k) ->
             check_neon inst;
             !(movi_s var r k ii)
-        | I_EOR_SIMD(r1,r2,r3) ->
+        | I_OP3_SIMD(EOR,r1,r2,r3) ->
             check_neon inst;
             let sz = neon_sz r1 in
             !(read_reg_neon false r3 ii >>|
@@ -3670,7 +3670,7 @@ module Make
         |  I_ADD_SV (r1,r2,r3) ->
           check_sve inst;
           !(add_sv r1 r2 r3 ii)
-        |  I_EOR_SV (r1,r2,r3) ->
+        |  I_OP3_SV (EOR,r1,r2,r3) ->
           check_sve inst;
           !(read_reg_scalable false r3 ii >>|
             read_reg_scalable false r2 ii >>= fun (v1,v2) ->
@@ -4252,6 +4252,7 @@ module Make
 (*  Cannot handle *)
         (* | I_BL _|I_BLR _|I_BR _|I_RET _ *)
         | (I_STG _|I_STZG _|I_STZ2G _
+        | I_OP3_SIMD _ | I_OP3_SV _
         | I_LDR_SIMD _| I_STR_SIMD _
         | I_LD1SP _| I_LD2SP _| I_LD3SP _| I_LD4SP _
         | I_ST1SP _|I_ST2SP _|I_ST3SP _|I_ST4SP _

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -669,12 +669,12 @@ include Arch.MakeArch(struct
     | I_MOV_V _ | I_MOV_VE _ | I_MOV_S _
     | I_MOV_FG _ | I_MOV_TG _
     | I_MOVI_V _ | I_MOVI_S _
-    | I_EOR_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
+    | I_OP3_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
         -> Warn.fatal "Neon instructions are not implemented yet"
     (* Scalable Vector Extension *)
     | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
     | I_UADDV _ | I_DUP_SV _ | I_ADD_SV _ | I_NEG_SV _ | I_MOVPRFX _
-    | I_EOR_SV _
+    | I_OP3_SV _
     | I_LD1SP _ | I_LD2SP _ | I_LD3SP _ | I_LD4SP _
     | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
     | I_MOV_SV _ | I_PTRUE _

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1365,7 +1365,7 @@ type 'k kinstruction =
   | I_MOV_S of simd_variant * reg * reg * int
   | I_MOVI_V of reg * 'k * 'k s
   | I_MOVI_S of simd_variant * reg * 'k
-  | I_EOR_SIMD of reg * reg * reg
+  | I_OP3_SIMD of op * reg * reg * reg
   | I_ADD_SIMD of reg * reg * reg
   | I_ADD_SIMD_S of reg * reg * reg
   (* More loads *)
@@ -1571,7 +1571,7 @@ type 'k kinstruction =
   (* MOVPRFX <Zd>.<T>, <Pg>/<ZM>, <Zn>.<T> *)
   | I_MOVPRFX of reg * reg * reg
   (* EOR <Zd>.D, <Zn>.D, <Zm>.D, vectors, unpredicated *)
-  | I_EOR_SV of reg * reg * reg
+  | I_OP3_SV of op * reg * reg * reg
   (* INDEX <Zd>.<T>, <R><n>, #<imm> *)
   | I_INDEX_SI of reg * variant * reg * 'k
   (* INDEX <Zd>.<T>, #<imm>, <R><m> *)
@@ -2137,8 +2137,8 @@ let do_pp_instruction m =
       pp_vmem_shift "MOVI" r k s
   | I_MOVI_S (v,r,k) ->
       pp_sri "MOVI" v r k
-  | I_EOR_SIMD (r1,r2,r3) ->
-      pp_simd_rrr "EOR" r1 r2 r3
+  | I_OP3_SIMD (op,r1,r2,r3) ->
+      pp_simd_rrr (pp_op op) r1 r2 r3
   | I_ADD_SIMD (r1,r2,r3) ->
       pp_simd_rrr "ADD" r1 r2 r3
   | I_ADD_SIMD_S (r1,r2,r3) ->
@@ -2182,8 +2182,8 @@ let do_pp_instruction m =
     sprintf "NEG %s,%s,%s" (pp_zreg r1) (pp_preg r2) (pp_zreg r3)
   | I_MOVPRFX (r1,r2,r3) ->
     sprintf "MOVPRFX %s,%s,%s" (pp_zreg r1) (pp_preg r2) (pp_zreg r3)
-  | I_EOR_SV (r1,r2,r3) ->
-    sprintf "EOR %s,%s,%s" (pp_zreg r1) (pp_zreg r2) (pp_zreg r3)
+  | I_OP3_SV (op,r1,r2,r3) ->
+    sprintf "%s %s,%s,%s" (pp_op op) (pp_zreg r1) (pp_zreg r2) (pp_zreg r3)
   | I_INDEX_SI (r1,v,r2,k) ->
       sprintf "INDEX %s,%s,%s" (pp_zreg r1) (pp_vreg v r2) (m.pp_k k)
   | I_INDEX_IS (r1,v,k,r2) ->
@@ -2554,11 +2554,11 @@ let fold_regs (f_regs,f_sregs) =
   | I_SC (_,r1,r2,r3)
   | I_LDP_SIMD (_,_,r1,r2,r3,_)
   | I_STP_SIMD (_,_,r1,r2,r3,_)
-  | I_EOR_SIMD (r1,r2,r3) | I_ADD_SIMD (r1,r2,r3) | I_ADD_SIMD_S (r1,r2,r3)
+  | I_OP3_SIMD (_,r1,r2,r3) | I_ADD_SIMD (r1,r2,r3) | I_ADD_SIMD_S (r1,r2,r3)
   | I_LDXP (_,_,r1,r2,r3)
   | I_WHILELT (r1,_,r2,r3) | I_WHILELE (r1,_,r2,r3) | I_WHILELO (r1,_,r2,r3) | I_WHILELS (r1,_,r2,r3)
   | I_INDEX_SS(r1,_,r2,r3)
-  | I_UADDV (_,r1,r2,r3) | I_ADD_SV (r1,r2,r3) | I_NEG_SV (r1,r2,r3) | I_MOVPRFX (r1,r2,r3) | I_EOR_SV (r1,r2,r3)
+  | I_UADDV (_,r1,r2,r3) | I_ADD_SV (r1,r2,r3) | I_NEG_SV (r1,r2,r3) | I_MOVPRFX (r1,r2,r3) | I_OP3_SV (_,r1,r2,r3)
     -> fold_reg r1 (fold_reg r2 (fold_reg r3 c))
   | I_LDP (_,_,r1,r2,r3,_)
   | I_LDPSW (r1,r2,r3,_)
@@ -2760,8 +2760,8 @@ let map_regs f_reg f_symb =
       I_MOVI_V (map_reg r,k,os)
   | I_MOVI_S (v,r,k) ->
       I_MOVI_S (v,map_reg r,k)
-  | I_EOR_SIMD (r1,r2,r3) ->
-      I_EOR_SIMD(map_reg r1,map_reg r2,map_reg r3)
+  | I_OP3_SIMD (op,r1,r2,r3) ->
+      I_OP3_SIMD(op,map_reg r1,map_reg r2,map_reg r3)
   | I_ADD_SIMD (r1,r2,r3) ->
       I_ADD_SIMD (map_reg r1,map_reg r2,map_reg r3)
   | I_ADD_SIMD_S (r1,r2,r3) ->
@@ -2805,8 +2805,8 @@ let map_regs f_reg f_symb =
       I_NEG_SV (map_reg r1,map_reg r2,map_reg r3)
   | I_MOVPRFX (r1,r2,r3) ->
       I_MOVPRFX (map_reg r1,map_reg r2,map_reg r3)
-  | I_EOR_SV (r1,r2,r3) ->
-      I_EOR_SV (map_reg r1,map_reg r2,map_reg r3)
+  | I_OP3_SV (op,r1,r2,r3) ->
+      I_OP3_SV (op,map_reg r1,map_reg r2,map_reg r3)
   | I_INDEX_SI (r1,v,r2,k) ->
       I_INDEX_SI (map_reg r1,v,map_reg r2,k)
   | I_INDEX_IS (r1,v,k,r2) ->
@@ -3050,7 +3050,7 @@ let get_next =
   | I_MOV_VE _ | I_MOV_V _ | I_MOV_TG _ | I_MOV_FG _
   | I_MOV_S _
   | I_MOVI_V _ | I_MOVI_S _
-  | I_EOR_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
+  | I_OP3_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
   | I_LDXP _|I_STXP _|I_UDF _
   | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
   | I_UADDV _ | I_DUP_SV _ | I_PTRUE _
@@ -3058,7 +3058,7 @@ let get_next =
   | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
   | I_LD1SP _ | I_LD2SP _ | I_LD3SP _ | I_LD4SP _
   | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
-  | I_MOV_SV _ | I_ADD_SV _ | I_NEG_SV _ | I_EOR_SV _ | I_MOVPRFX _
+  | I_MOV_SV _ | I_ADD_SV _ | I_NEG_SV _ | I_OP3_SV _ | I_MOVPRFX _
   | I_LD1SPT _  | I_ST1SPT _ | I_SMSTART _ | I_SMSTOP _
   | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
     -> [Label.Next;]
@@ -3235,9 +3235,16 @@ let is_valid i =
     -> is_granule_offset k
   | I_STG _ | I_STZG _ | I_STZ2G _
     -> false
+  | I_OP3_SIMD (EOR,Vreg(_,(8,8)),Vreg(_,(8,8)),Vreg(_,(8,8)))
+  | I_OP3_SIMD (EOR,Vreg(_,(16,8)),Vreg(_,(16,8)),Vreg(_,(16,8)))
+     -> true
+  | I_OP3_SIMD _
+     -> false
+  | I_OP3_SV(EOR,Zreg(_,64),Zreg(_,64),Zreg(_,64))
+     -> true
+  | I_OP3_SV _
+     -> false
   | _ -> true
-
-
 
 module PseudoI = struct
       type ins = instruction
@@ -3321,7 +3328,7 @@ module PseudoI = struct
         | I_WHILELT _ | I_WHILELE _ | I_WHILELO _| I_WHILELS _
         | I_UADDV _ | I_DUP_SV _ | I_PTRUE _
         | I_ADD_SV _ | I_INDEX_SS _
-        | I_NEG_SV _ | I_EOR_SV _ | I_MOVPRFX _
+        | I_NEG_SV _ | I_OP3_SV _ | I_MOVPRFX _
         | I_SMSTART _ | I_SMSTOP _ | I_ADDA _
             as keep -> keep
         | I_LDR (v,r1,r2,idx) -> I_LDR (v,r1,r2,ext_tr idx)
@@ -3387,7 +3394,7 @@ module PseudoI = struct
         | I_STLUR_SIMD (v,r1,r2,k) -> I_STLUR_SIMD (v,r1,r2,k_tr k)
         | I_MOVI_V (r,k,s) -> I_MOVI_V (r,k_tr k,ap_shift k_tr s)
         | I_MOVI_S (v,r,k) -> I_MOVI_S (v,r,k_tr k)
-        | I_EOR_SIMD (r1,r2,r3) -> I_EOR_SIMD (r1,r2,r3)
+        | I_OP3_SIMD (op,r1,r2,r3) -> I_OP3_SIMD (op,r1,r2,r3)
         | I_ADD_SIMD (r1,r2,r3) -> I_ADD_SIMD (r1,r2,r3)
         | I_ADD_SIMD_S (r1,r2,r3) -> I_ADD_SIMD_S (r1,r2,r3)
         | I_UDF k -> I_UDF (k_tr k)
@@ -3497,12 +3504,12 @@ module PseudoI = struct
         | I_MOV_VE _ | I_MOV_V _ | I_MOV_TG _ | I_MOV_FG _
         | I_MOV_S _
         | I_MOVI_V _ | I_MOVI_S _
-        | I_EOR_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
+        | I_OP3_SIMD _ | I_ADD_SIMD _ | I_ADD_SIMD_S _
         | I_UDF _
         | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
         | I_PTRUE _
         | I_ADD_SV _ | I_UADDV _ | I_DUP_SV _
-        | I_NEG_SV _ | I_MOVPRFX _ | I_EOR_SV _
+        | I_NEG_SV _ | I_MOVPRFX _ | I_OP3_SV _
         | I_INDEX_SI _ | I_INDEX_IS _  | I_INDEX_SS _ | I_INDEX_II _
         | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
         | I_MOV_SV _ | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -353,106 +353,48 @@ pattern:
 | COMMA pattern_not_empty { $2 }
 
 zabreg:
-| ARCH_ZABREG
-  { match $1 with
-    | ZAreg (tile,_,_) when tile <= 0
-      -> $1
-    | _ -> assert false }
+| ARCH_ZABREG { $1 }
 
 zahreg:
-| ARCH_ZAHREG
-  { match $1 with
-    | ZAreg (tile,_,_) when tile <= 1
-      -> $1
-    | _ -> assert false }
+| ARCH_ZAHREG { $1 }
 
 zasreg:
-| ARCH_ZASREG
-  { match $1 with
-    | ZAreg (tile,_,_) when tile <= 3
-      -> $1
-    | _ -> assert false }
+| ARCH_ZASREG { $1 }
 
 zadreg:
-| ARCH_ZADREG
-  { match $1 with
-    | ZAreg (tile,_,_) when tile <= 7
-      -> $1
-    | _ -> assert false }
+| ARCH_ZADREG { $1 }
 
 zaqreg:
-| ARCH_ZAQREG
-  { match $1 with
-    | ZAreg (tile,_,_) when tile <= 15
-      -> $1
-    | _ -> assert false }
+| ARCH_ZAQREG { $1 }
 
 slice :
 | LBRK wreg COMMA NUM RBRK
-  { if ( $4 >= 0) then
-      ($2,$4)
-    else
-      assert false}
+  { ($2,$4) }
 
 zab_slice:
 | zabreg slice
   { let (index,offset) = $2 in
-    if (offset <= 15) then
-      match $1 with
-      | ZAreg (_,Some _,_)
-        -> ($1,(index,MetaConst.Int offset))
-      | _ -> assert false
-    else
-      assert false
-  }
+    ($1,(index,MetaConst.Int offset)) }
 
 zah_slice:
 | zahreg slice
   { let (index,offset) = $2 in
-    if (offset <= 7) then
-      match $1 with
-      | ZAreg (_,Some _,_)
-        -> ($1,(index,MetaConst.Int offset))
-      | _ -> assert false
-    else
-      assert false
-  }
+    ($1,(index,MetaConst.Int offset)) }
 
 zas_slice:
 | zasreg slice
   { let (index,offset) = $2 in
-    if (offset <= 3) then
-      match $1 with
-      | ZAreg (_,Some _,_)
-        -> ($1,(index,MetaConst.Int offset))
-      | _ -> assert false
-    else
-      assert false
-  }
+    ($1,(index,MetaConst.Int offset)) }
 
 zad_slice:
 | zadreg slice
   { let (index,offset) = $2 in
-    if (offset <= 1) then
-      match $1 with
-      | ZAreg (_,Some _,_)
-        -> ($1,(index,MetaConst.Int offset))
-      | _ -> assert false
-    else
-      assert false
-  }
+    ($1,(index,MetaConst.Int offset)) }
 
 zaq_slice:
 | zaqreg slice
   { let (index,offset) = $2 in
-    if (offset <= 0) then
-      match $1 with
-      | ZAreg (_,Some _,_)
-        -> ($1,(index,MetaConst.Int offset))
-      | _ -> assert false
-    else
-      assert false
-  }
+    ($1,(index,MetaConst.Int offset)) }
 
 smopt:
 | { None }
@@ -833,10 +775,7 @@ instr:
 | LD1 vregs1 INDEX COMMA LBRK xreg RBRK kx0_no_shift
   { I_LD1 ($2, $3, $6, $8) }
 | LDAP1 vregs1 INDEX COMMA LBRK xreg RBRK
-  { match List.hd $2 with
-    | Vreg(_,(0,64)) -> I_LDAP1 ($2, $3, $6, K (MetaConst.zero))
-    | _ -> assert false
-  }
+  { I_LDAP1 ($2, $3, $6, K (MetaConst.zero)) }
 | LD1 vregs COMMA LBRK xreg RBRK kx0_no_shift
   { I_LD1M ($2, $5, $7) }
 | LD1R vregs1 COMMA LBRK xreg RBRK kx0_no_shift
@@ -862,10 +801,7 @@ instr:
 | ST1 vregs1 INDEX COMMA LBRK xreg RBRK kx0_no_shift
    { I_ST1 ($2, $3, $6, $8) }
 | STL1 vregs1 INDEX COMMA LBRK xreg RBRK
-  { match List.hd $2 with
-    | Vreg(_,(0,64)) -> I_STL1 ($2, $3, $6,  K (MetaConst.zero))
-    | _ -> assert false
-  }
+  { I_STL1 ($2, $3, $6,  K (MetaConst.zero)) }
 | ST1 vregs COMMA LBRK xreg RBRK kx0_no_shift
    { I_ST1M ($2, $5, $7) }
 | ST2 vregs2 INDEX COMMA LBRK xreg RBRK kx0_no_shift
@@ -973,332 +909,131 @@ instr:
 | LD1B zregs1 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-    | ZReg (_,LSL,MetaConst.Int 0)
-    | ZReg (_,UXTW,MetaConst.Int 0)
-    | ZReg (_,SXTW,MetaConst.Int 0)
-      -> I_LD1SP (VSIMD8,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD1SP (VSIMD8,$2,$4,ra,ext) }
 | LD1H zregs1 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-    | ZReg (_,LSL,MetaConst.Int 0)
-    | ZReg (_,UXTW,MetaConst.Int 0)
-    | ZReg (_,SXTW,MetaConst.Int 0)
-    | ZReg (_,LSL,MetaConst.Int 1)
-    | ZReg (_,UXTW,MetaConst.Int 1)
-    | ZReg (_,SXTW,MetaConst.Int 1)
-      -> I_LD1SP (VSIMD16,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD1SP (VSIMD16,$2,$4,ra,ext) }
 | LD1W zregs1 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2)
-    | ZReg (_,LSL,MetaConst.Int 0)
-    | ZReg (_,UXTW,MetaConst.Int 0)
-    | ZReg (_,SXTW,MetaConst.Int 0)
-    | ZReg (_,LSL,MetaConst.Int 2)
-    | ZReg (_,UXTW,MetaConst.Int 2)
-    | ZReg (_,SXTW,MetaConst.Int 2)
-      -> I_LD1SP (VSIMD32,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD1SP (VSIMD32,$2,$4,ra,ext) }
 | LD1D zregs1 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-    | ZReg (_,LSL,MetaConst.Int 0)
-    | ZReg (_,UXTW,MetaConst.Int 0)
-    | ZReg (_,SXTW,MetaConst.Int 0)
-    | ZReg (_,LSL,MetaConst.Int 3)
-    | ZReg (_,UXTW,MetaConst.Int 3)
-    | ZReg (_,SXTW,MetaConst.Int 3)
-      -> I_LD1SP (VSIMD64,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD1SP (VSIMD64,$2,$4,ra,ext) }
 | LD2B zregs2 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-      -> I_LD2SP (VSIMD8,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD2SP (VSIMD8,$2,$4,ra,ext) }
 | LD2H zregs2 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-      -> I_LD2SP (VSIMD16,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD2SP (VSIMD16,$2,$4,ra,ext) }
 | LD2W zregs2 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2) -> I_LD2SP (VSIMD32,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD2SP (VSIMD32,$2,$4,ra,ext) }
 | LD2D zregs2 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-      -> I_LD2SP (VSIMD64,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD2SP (VSIMD64,$2,$4,ra,ext) }
 | LD3B zregs3 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-      -> I_LD3SP (VSIMD8,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD3SP (VSIMD8,$2,$4,ra,ext) }
 | LD3H zregs3 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-      -> I_LD3SP (VSIMD16,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD3SP (VSIMD16,$2,$4,ra,ext) }
 | LD3W zregs3 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2)
-      -> I_LD3SP (VSIMD32,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD3SP (VSIMD32,$2,$4,ra,ext) }
 | LD3D zregs3 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-      -> I_LD3SP (VSIMD64,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD3SP (VSIMD64,$2,$4,ra,ext) }
 | LD4B zregs4 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-      -> I_LD4SP (VSIMD8,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD4SP (VSIMD8,$2,$4,ra,ext) }
 | LD4H zregs4 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-      -> I_LD4SP (VSIMD16,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD4SP (VSIMD16,$2,$4,ra,ext) }
 | LD4W zregs4 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2)
-      -> I_LD4SP (VSIMD32,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD4SP (VSIMD32,$2,$4,ra,ext) }
 | LD4D zregs4 COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-      -> I_LD4SP (VSIMD64,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_LD4SP (VSIMD64,$2,$4,ra,ext) }
 | ST1B zregs1 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-    | ZReg (_,LSL,MetaConst.Int 0)
-    | ZReg (_,UXTW,MetaConst.Int 0)
-    | ZReg (_,SXTW,MetaConst.Int 0)
-      -> I_ST1SP (VSIMD8,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST1SP (VSIMD8,$2,$4,ra,ext) }
 | ST1H zregs1 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-    | ZReg (_,LSL,MetaConst.Int 0)
-    | ZReg (_,UXTW,MetaConst.Int 0)
-    | ZReg (_,SXTW,MetaConst.Int 0)
-    | ZReg (_,LSL,MetaConst.Int 1)
-    | ZReg (_,UXTW,MetaConst.Int 1)
-    | ZReg (_,SXTW,MetaConst.Int 1)
-      -> I_ST1SP (VSIMD16,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST1SP (VSIMD16,$2,$4,ra,ext) }
 | ST1W zregs1 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2)
-    | ZReg (_,LSL,MetaConst.Int 0)
-    | ZReg (_,UXTW,MetaConst.Int 0)
-    | ZReg (_,SXTW,MetaConst.Int 0)
-    | ZReg (_,LSL,MetaConst.Int 2)
-    | ZReg (_,UXTW,MetaConst.Int 2)
-    | ZReg (_,SXTW,MetaConst.Int 2)
-      -> I_ST1SP (VSIMD32,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST1SP (VSIMD32,$2,$4,ra,ext) }
 | ST1D zregs1 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-    | ZReg (_,LSL,MetaConst.Int 0)
-    | ZReg (_,UXTW,MetaConst.Int 0)
-    | ZReg (_,SXTW,MetaConst.Int 0)
-    | ZReg (_,LSL,MetaConst.Int 3)
-    | ZReg (_,UXTW,MetaConst.Int 3)
-    | ZReg (_,SXTW,MetaConst.Int 3)
-      -> I_ST1SP (VSIMD64,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST1SP (VSIMD64,$2,$4,ra,ext) }
 | ST2B zregs2 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-      -> I_ST2SP (VSIMD8,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST2SP (VSIMD8,$2,$4,ra,ext) }
 | ST2H zregs2 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-      -> I_ST2SP (VSIMD16,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST2SP (VSIMD16,$2,$4,ra,ext) }
 | ST2W zregs2 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2)
-      -> I_ST2SP (VSIMD32,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST2SP (VSIMD32,$2,$4,ra,ext) }
 | ST2D zregs2 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-      -> I_ST2SP (VSIMD64,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST2SP (VSIMD64,$2,$4,ra,ext) }
 | ST3B zregs3 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-      -> I_ST3SP (VSIMD8,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST3SP (VSIMD8,$2,$4,ra,ext) }
 | ST3H zregs3 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-      -> I_ST3SP (VSIMD16,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST3SP (VSIMD16,$2,$4,ra,ext) }
 | ST3W zregs3 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2)
-      -> I_ST3SP (VSIMD32,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST3SP (VSIMD32,$2,$4,ra,ext) }
 | ST3D zregs3 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-      -> I_ST3SP (VSIMD64,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST3SP (VSIMD64,$2,$4,ra,ext) }
 | ST4B zregs4 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-      -> I_ST4SP (VSIMD8,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST4SP (VSIMD8,$2,$4,ra,ext) }
 | ST4H zregs4 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-      -> I_ST4SP (VSIMD16,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST4SP (VSIMD16,$2,$4,ra,ext) }
 | ST4W zregs4 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2)
-      -> I_ST4SP (VSIMD32,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST4SP (VSIMD32,$2,$4,ra,ext) }
 | ST4D zregs4 COMMA preg COMMA mem_ea
   { let open MemExt in
     let (ra,ext) = $6 in
-    match ext with
-    | Imm (_,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-      -> I_ST4SP (VSIMD64,$2,$4,ra,ext)
-    | _ -> assert false
-  }
+    I_ST4SP (VSIMD64,$2,$4,ra,ext) }
 | MOV zreg COMMA k
   { I_MOV_SV ($2, $4, S_NOEXT) }
 | MOV zreg COMMA k COMMA shift
@@ -1310,36 +1045,16 @@ instr:
   { I_ADD_SV ($2,$4,$6) }
 | OP ARCH_ZDREG COMMA ARCH_ZDREG COMMA ARCH_ZDREG
   { I_OP3_SV ($1,$2,$4,$6) }
-| TOK_INDEX zreg COMMA xreg COMMA k
-  { match $2 with
-    | Zreg(_,64) -> I_INDEX_SI ($2,V64,$4,$6)
-    | _ -> assert false }
-| TOK_INDEX zreg COMMA wreg COMMA k
-  { match $2 with
-    | Zreg(_,8)
-    | Zreg(_,16)
-    | Zreg(_,32) -> I_INDEX_SI ($2,V32,$4,$6)
-    | _ -> assert false }
-| TOK_INDEX zreg COMMA k COMMA xreg
-  { match $6 with
-    | Zreg(_,64) -> I_INDEX_IS ($2,V64,$4,$6)
-    | _ -> assert false }
-| TOK_INDEX zreg COMMA k COMMA wreg
-  { match $6 with
-    | Zreg(_,8)
-    | Zreg(_,16)
-    | Zreg(_,32) -> I_INDEX_IS ($2,V32,$4,$6)
-    | _ -> assert false }
+| TOK_INDEX zreg COMMA wxreg COMMA k
+  { let v,r = $4 in 
+    I_INDEX_SI ($2,v,r,$6) }
+| TOK_INDEX zreg COMMA k COMMA wxreg
+  { let v,r = $6 in
+    I_INDEX_IS ($2,v,$4,r)}
 | TOK_INDEX zreg COMMA xreg COMMA xreg
-  { match $2 with
-    | Zreg(_,64) -> I_INDEX_SS ($2,V64,$4,$6)
-    | _ -> assert false }
+  { I_INDEX_SS ($2,V64,$4,$6) }
 | TOK_INDEX zreg COMMA wreg COMMA wreg
-  { match $2 with
-    | Zreg(_,8)
-    | Zreg(_,16)
-    | Zreg(_,32) -> I_INDEX_SS ($2,V32,$4,$6)
-    | _ -> assert false }
+  { I_INDEX_SS ($2,V32,$4,$6) }
 | RDVL xreg COMMA k
    { I_RDVL ($2,$4) }
 | ADDVL xreg COMMA xreg COMMA k
@@ -1365,102 +1080,52 @@ instr:
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-      -> I_LD1SPT (VSIMD8,zareg,index,offset,$6,ra,ext)
-    | _ ->  assert false
-  }
+    I_LD1SPT (VSIMD8,zareg,index,offset,$6,ra,ext) }
 | LD1H LCRL zah_slice RCRL COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-      -> I_LD1SPT (VSIMD16,zareg,index,offset,$6,ra,ext)
-    | _ -> assert false
-  }
+    I_LD1SPT (VSIMD16,zareg,index,offset,$6,ra,ext) }
 | LD1W LCRL zas_slice RCRL COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2)
-      -> I_LD1SPT (VSIMD32,zareg,index,offset,$6,ra,ext)
-    | _ -> assert false
-  }
+    I_LD1SPT (VSIMD32,zareg,index,offset,$6,ra,ext) }
 | LD1D LCRL zad_slice RCRL COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-      -> I_LD1SPT (VSIMD64,zareg,index,offset,$6,ra,ext)
-    | _ -> assert false
-  }
+    I_LD1SPT (VSIMD64,zareg,index,offset,$6,ra,ext) }
 | LD1Q LCRL zaq_slice RCRL COMMA pmreg_z COMMA mem_ea
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 4)
-      -> I_LD1SPT (VSIMD128,zareg,index,offset,$6,ra,ext)
-    | _ -> assert false
-  }
+    I_LD1SPT (VSIMD128,zareg,index,offset,$6,ra,ext) }
 | ST1B LCRL zab_slice RCRL COMMA preg COMMA mem_ea
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 0)
-      -> I_ST1SPT (VSIMD8,zareg,index,offset,$6,ra,ext)
-    | _ ->  assert false
-  }
+    I_ST1SPT (VSIMD8,zareg,index,offset,$6,ra,ext) }
 | ST1H LCRL zah_slice RCRL COMMA preg COMMA mem_ea
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 1)
-      -> I_ST1SPT (VSIMD16,zareg,index,offset,$6,ra,ext)
-    | _ -> assert false
-  }
+    I_ST1SPT (VSIMD16,zareg,index,offset,$6,ra,ext) }
 | ST1W LCRL zas_slice RCRL COMMA preg COMMA mem_ea
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 2)
-      -> I_ST1SPT (VSIMD32,zareg,index,offset,$6,ra,ext)
-    | _ -> assert false
-  }
+    I_ST1SPT (VSIMD32,zareg,index,offset,$6,ra,ext) }
 | ST1D LCRL zad_slice RCRL COMMA preg COMMA mem_ea
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 3)
-      -> I_ST1SPT (VSIMD64,zareg,index,offset,$6,ra,ext)
-    | _ -> assert false
-  }
+    I_ST1SPT (VSIMD64,zareg,index,offset,$6,ra,ext) }
 | ST1Q LCRL zaq_slice RCRL COMMA preg COMMA mem_ea
   { let open MemExt in
     let (zareg,(index, offset)) = $3 in
     let (ra,ext) = $8 in
-    match ext with
-    | Imm (MetaConst.Int 0,Idx)
-    | Reg (V64,_,LSL,MetaConst.Int 4)
-      -> I_ST1SPT (VSIMD128,zareg,index,offset,$6,ra,ext)
-    | _ -> assert false
-  }
+    I_ST1SPT (VSIMD128,zareg,index,offset,$6,ra,ext) }
 | MOVA zab_slice COMMA pmreg COMMA zbreg
   {
     let (zareg,(index, offset)) = $2 in
@@ -1512,10 +1177,7 @@ instr:
     I_MOVA_TV ($2,$4,zareg,index,offset)
   }
 | ADDA zasreg COMMA pmreg COMMA pmreg COMMA zsreg
-  { match $2 with
-    | ZAreg (_,None,_)
-      -> I_ADDA ($1,$2,$4,$6,$8)
-    | _ -> assert false; }
+  { I_ADDA ($1,$2,$4,$6,$8) }
     /* Compare and swap */
 | CAS wreg COMMA wreg COMMA  LBRK cxreg zeroopt RBRK
   { I_CAS (V32,RMW_P,$2,$4,$7) }

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -946,9 +946,7 @@ instr:
 | MOVI dreg COMMA k
   { I_MOVI_S ( VSIMD64, $2, $4) }
 | OP vreg COMMA vreg COMMA vreg
-  { match $1 with
-    | EOR -> I_EOR_SIMD ($2,$4,$6)
-    | _ -> assert false}
+  { I_OP3_SIMD ($1,$2,$4,$6) }
 | TOK_ADD vreg COMMA vreg COMMA vreg
   { I_ADD_SIMD ($2,$4,$6) }
 | TOK_ADD dreg COMMA dreg COMMA dreg
@@ -1311,9 +1309,7 @@ instr:
 | TOK_ADD zreg COMMA zreg COMMA zreg
   { I_ADD_SV ($2,$4,$6) }
 | OP ARCH_ZDREG COMMA ARCH_ZDREG COMMA ARCH_ZDREG
-  { match $1 with
-    | EOR -> I_EOR_SV ($2,$4,$6)
-    | _ -> assert false}
+  { I_OP3_SV ($1,$2,$4,$6) }
 | TOK_INDEX zreg COMMA xreg COMMA k
   { match $2 with
     | Zreg(_,64) -> I_INDEX_SI ($2,V64,$4,$6)

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -76,7 +76,7 @@ module Make(V:Constant.S)(C:Config) =
     (* Accept P/M register so assume partial update of register *)
     | I_NEG_SV (r,_,_)
     | I_MOVPRFX (r,_,_)
-    | I_EOR_SV (r,_,_)
+    | I_OP3_SV (_,r,_,_)
       -> A.RegSet.of_list [r]
     (* Reserve slice index *)
     | I_LD1SPT (_,_,r,_,_,_,_)
@@ -1820,7 +1820,8 @@ module Make(V:Constant.S)(C:Config) =
     | I_MOVI_S (v,r,k1) -> movi_s v r k1::k
     | I_MOVI_V (r,kr,s) -> movi_v r kr s::k
     | I_MOV_S (v,r1,r2,i) -> mov_simd_s v r1 r2 i::k
-    | I_EOR_SIMD (r1,r2,r3) -> eor_simd r1 r2 r3::k
+    | I_OP3_SIMD (EOR,r1,r2,r3) -> eor_simd r1 r2 r3::k
+    | I_OP3_SIMD _ -> assert false
     | I_ADD_SIMD (r1,r2,r3) -> add_simd r1 r2 r3::k
     | I_ADD_SIMD_S (r1,r2,r3) -> add_simd_s r1 r2 r3::k
 (* Scalable Vector Extension *)
@@ -1847,7 +1848,8 @@ module Make(V:Constant.S)(C:Config) =
     | I_PTRUE (pred,pat) -> ptrue pred pat::k
     | I_NEG_SV (r1,r2,r3) -> neg_sv r1 r2 r3::k
     | I_MOVPRFX (r1,r2,r3) -> movprfx r1 r2 r3::k
-    | I_EOR_SV (r1,r2,r3) -> eor_sv r1 r2 r3::k
+    | I_OP3_SV (EOR,r1,r2,r3) -> eor_sv r1 r2 r3::k
+    | I_OP3_SV _ -> assert false
     | I_RDVL (r1,k1) -> rdvl r1 k1::k
     | I_ADDVL (r1,r2,k1) -> addvl r1 r2 k1::k
     | I_CNT_INC_SVE  (op,rd,pat,k1) -> cnt_inc_sve op rd pat k1::k


### PR DESCRIPTION
Currently sanity checks for vector instructions done during parsing and asserts if instruction is malformed - that definitely is not user-friendly and we could do better. Let's convert all asserts for vector instructions to checks in dedicated validation (`is_valid`) pass.
