### PR TITLE
ASL Reference: Top-level chapter and various fixes

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -1344,7 +1344,7 @@ module Make (B : Backend.S) (C : Config) = struct
            (Dynamic, "tuple construction", List.length les, List.length monads)
     else multi_assign ver env les monads
 
-  (* Begin EvalTopLevel *)
+  (* Begin EvalSpec *)
   let run_typed_env env (static_env : StaticEnv.global) (ast : AST.t) :
       B.value m =
     let*| env = build_genv env eval_expr_sef static_env ast in
@@ -1362,8 +1362,8 @@ module Make (B : Backend.S) (C : Config) = struct
               Format.asprintf "%a %s" PP.pp_ty ty (B.debug_value v)
         in
         Error.fatal_unknown_pos (Error.UncaughtException msg))
-    |: SemanticsRule.TopLevel
+    |: SemanticsRule.Spec
 
   let run_typed env ast = run_typed_env [] env ast
-  (* End TopLevel *)
+  (* End *)
 end

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -103,8 +103,8 @@ let s_call call = S_Call { call with call_type = ST_Procedure }
 
 (* ------------------------------------------------------------------------- *)
 
-%type <AST.t> ast
-%start ast
+%type <AST.t> spec
+%start spec
 
 (* This start-point is for .opn files in arm-pseudocodes for instructions. *)
 %type <AST.t> opn
@@ -627,7 +627,7 @@ let decl ==
   )
 
 (* Begin AST *)
-let ast := terminated(list(decl), EOF)
+let spec := terminated(list(decl), EOF)
 (* End *)
 
 let opn := body=stmt; EOF;

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -210,9 +210,9 @@
 %type <AST.stmt> simple_stmts
 %type <AST.stmt> simple_stmt_list
 %type <AST.stmt> stmts
-%type <AST.t> ast
+%type <AST.t> spec
 %type <AST.t> opn
-%start ast
+%start spec
 %start opn
 
 %nonassoc ELSE
@@ -232,7 +232,7 @@
 let filter(x) == ~=x; { List.filter_map Fun.id x }
 let some(x) == ~=x; < Some >
 
-let ast := list(EOL); terminated (filter(list(decl)), EOF)
+let spec := list(EOL); terminated (filter(list(decl)), EOF)
 
 let opn := list(EOL); body=list(stmts); EOF;
     {

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -3089,28 +3089,24 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     in
     let new_d, new_genv =
       match d.desc with
-      (* Begin TypecheckFunc *)
+      (* Begin TypecheckDecl *)
       | D_Func ({ body = SB_ASL _; _ } as f) ->
           let env1, f1 = annotate_and_declare_func ~loc f genv in
           let f2 = try_annotate_subprogram env1 f1 in
           let new_env = add_subprogram f2.name f2 env1
           and new_d = D_Func f2 |> here in
-          (new_d, new_env.global) |: TypingRule.TypecheckFunc
-      (* End *)
+          (new_d, new_env.global) |: TypingRule.TypecheckDecl
       | D_Func ({ body = SB_Primitive; _ } as f) ->
           let new_env, f2 = annotate_and_declare_func ~loc f genv in
           let new_d = D_Func f2 |> here in
           (new_d, new_env.global)
-      (* Begin TypecheckGlobalStorage *)
       | D_GlobalStorage gsd ->
           let gsd', new_genv = declare_global_storage loc gsd genv in
           let new_d = D_GlobalStorage gsd' |> here in
-          (new_d, new_genv) |: TypingRule.TypecheckGlobalStorage
-      (* End *)
-      (* Begin TypecheckTypeDecl *)
+          (new_d, new_genv) |: TypingRule.TypecheckDecl
       | D_TypeDecl (x, ty, s) ->
           let new_genv = declare_type loc x ty s genv in
-          (d, new_genv) |: TypingRule.TypecheckTypeDecl
+          (d, new_genv) |: TypingRule.TypecheckDecl
       (* End *)
     in
     (new_d :: acc, new_genv)

--- a/asllib/builder.ml
+++ b/asllib/builder.ml
@@ -71,7 +71,7 @@ let from_lexbuf ast_type parser_config version (lexbuf : lexbuf) =
       let module Lexer = Lexer.Make (struct
         let allow_double_underscore = parser_config.allow_double_underscore
       end) in
-      let parse = select_type ~opn:Parser.opn ~ast:Parser.ast ast_type in
+      let parse = select_type ~opn:Parser.opn ~ast:Parser.spec ast_type in
       try parse Lexer.token lexbuf with
       | Parser.Error -> cannot_parse lexbuf
       | Lexer.LexerError -> unknown_symbol lexbuf)

--- a/asllib/bundler.ml
+++ b/asllib/bundler.ml
@@ -57,7 +57,7 @@ let build_ast_from_file ?(is_opn = false) f =
   let module Lexer = Lexer.Make (struct
     let allow_double_underscore = false
   end) in
-  let parse = if is_opn then Parser.opn else Parser.ast in
+  let parse = if is_opn then Parser.opn else Parser.spec in
   let chan = open_in f in
   let lexbuf = Lexing.from_channel chan in
   let () =

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -310,7 +310,7 @@ The parametric function
 \[
 \uniquelist : \overname{T^*}{l} \rightarrow T^*
 \]
-retains only the first occurence of each element of the list $l$.
+retains only the first occurrence of each element of the list $l$.
 It relies on the helper function $\uniquep$:
 \[
 \begin{array}{rcl}

--- a/asllib/doc/ASLReference.tex
+++ b/asllib/doc/ASLReference.tex
@@ -61,6 +61,7 @@
 \input{TypeDeclarations.tex}
 \input{SubprogramDeclarations.tex}
 \input{Specifications.tex}
+\input{TopLevel.tex}
 \input{StaticEvaluation.tex}
 \input{SymbolicSubsumptionTesting.tex}
 \input{SymbolicEquivalenceTesting.tex}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -15,40 +15,96 @@
 \usepackage{listings}
 \lstdefinelanguage{ASL}
 {
-    morekeywords={AND, DIV, DIVRM, EOR,
-    IN, MOD, NOT, OR,
-    SAMPLE, UNKNOWN, UNSTABLE, XOR,
-    access, advice, after,
-    any, array, as, aspect,
-    assert, assume, assumes, before,
-    begin, bit, bits, boolean,
-    call, case, cast, catch,
-    class, config, constant, dict,
-    do, downto, else, elsif,
-    end, endcase, endcatch, endclass,
-    endevent, endfor, endfunc, endgetter,
-    endif, endmodule, endnamespace, endpackage,
-    endproperty, endrule, endsetter, endtemplate,
-    endtry, endwhile, entry, enumeration,
-    event, exception, export, expression,
-    extends, extern, feature, for,
-    func, get, getter, gives,
-    if, iff, implies, import,
-    in, integer, intersect, intrinsic,
-    invariant, is, let, list,
-    map, module, namespace, newevent,
-    newmap, of, original, otherwise,
-    package, parallel, pass, pattern,
-    pointcut, port, pragma, private,
-    profile, property, protected, public,
-    real, record, repeat, replace,
-    requires, rethrow, return, rule,
-    set, setter, shared, signal,
-    statements, string, subtypes, template,
-    then, throw, to, try,
-    type, typeof, union, until,
-    using, var, watch, when,
-    where, while, with, ztype, _},
+    morekeywords={
+      AND,
+      array,
+      as,
+      assert,
+      begin,
+      bit,
+      bits,
+      boolean,
+      case,
+      catch,
+      config,
+      constant,
+      DIV,
+      DIVRM,
+      do,
+      downto,
+      else,
+      elsif,
+      end,
+      enumeration,
+      XOR,
+      exception,
+      FALSE,
+      for,
+      func,
+      getter,
+      if,
+      IN,
+      integer,
+      let,
+      looplimit,
+      MOD,
+      NOT,
+      of,
+      OR,
+      otherwise,
+      pass,
+      pragma,
+      print,
+      real,
+      record,
+      recurselimit,
+      repeat,
+      return,
+      setter,
+      string,
+      subtypes,
+      then,
+      throw,
+      to,
+      try,
+      TRUE,
+      type,
+      UNKNOWN,
+      Unreachable,
+      until,
+      var,
+      when,
+      where,
+      while,
+      with,
+      SAMPLE, UNSTABLE,
+      _, any,
+      assume, assumes,
+      call, cast,
+      class, dict,
+      endcase, endcatch, endclass,
+      ,endevent, endfor, endfunc, endgetter,
+      endif, endmodule, endnamespace, endpackage,
+      endproperty, endrule, endsetter, endtemplate,
+      endtry, endwhile,
+      event, export,
+      extends, extern, feature,
+      gives,
+      iff, implies, import,
+      intersect, intrinsic,
+      invariant, list,
+      map, module, namespace, newevent,
+      newmap, original,
+      package, parallel,
+      port, private,
+      profile, property, protected, public,
+      requires, rethrow, rule,
+      shared, signal,
+      template,
+      typeof, union,
+      using,
+      ztype
+    },
     keywordstyle=\color{red},
     morecomment=[l][\color{blue}]{//},
     morecomment=[s][\color{blue}]{/*}{*/},
@@ -213,6 +269,7 @@
 \newcommand\uniquelist[0]{\hyperlink{def-uniquelist}{\textfunc{unique}}}
 \newcommand\concat[0]{\hyperlink{def-concat}{+}}
 \newcommand\prepend[0]{\hyperlink{def-prepend}{{+}{+}}}
+\newcommand\reverselist[0]{\hyperlink{def-reverselist}{\textfunc{reverse}}}
 \newcommand\listcomprehension[2]{[#1 : #2]} % #1 is a list element predicate, #2 is the output list element.
 \newcommand\setcomprehension[2]{\{#1 : #2\}} % #1 is a set element predicate, #2 is the output set element.
 
@@ -236,6 +293,7 @@
 \newcommand\funcgraph[0]{\hyperlink{def-funcgraph}{\texttt{func\_graph}}}
 \DeclareMathOperator{\dom}{\hyperlink{def-dom}{dom}}
 \newcommand\sign[0]{\hyperlink{def-sign}{\texttt{sign}}}
+\newcommand\graphtransitive[1]{#1^{\hyperlink{def-graphtransitive}{*}}}
 
 \newcommand\configdomain[1]{\hyperlink{def-configdomain}{\texttt{config\_domain}}({#1})}
 
@@ -244,6 +302,7 @@
 \newcommand\booltrans[1]{\hyperlink{def-booltrans}{\textfunc{bool\_transition}}(#1)}
 \newcommand\booltransarrow[0]{\longrightarrow}
 \newcommand\checktrans[2]{\hyperlink{def-checktrans}{\textfunc{check}}(#1, \texttt{#2})}
+\newcommand\Prosechecktrans[2]{\hyperlink{def-checktrans}{checking} #1 yields $\True$\ProseTerminateAs{#2}}
 \newcommand\checktransarrow[0]{\longrightarrow}
 
 \newcommand\termx[0]{\mathit{tx}}
@@ -384,7 +443,7 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Macros for non-terminals
-\newcommand\Nast[0]{\hyperlink{def-nast}{\nonterminal{ast}}}
+\newcommand\Nspec[0]{\hyperlink{def-nspec}{\nonterminal{spec}}}
 \newcommand\Ndecl[0]{\hyperlink{def-ndecl}{\nonterminal{decl}}}
 \newcommand\Nparamsopt[0]{\hyperlink{def-nparamsopt}{\nonterminal{params\_opt}}}
 \newcommand\Ncall[0]{\hyperlink{def-ncall}{\nonterminal{call}}}
@@ -658,7 +717,6 @@
 \newcommand\DGlobalStorage[0]{\hyperlink{ast-dglobalstorage}{\texttt{D\_GlobalStorage}}}
 \newcommand\DTypeDecl[0]{\hyperlink{ast-dtypedecl}{\texttt{D\_TypeDecl}}}
 
-\newcommand\specification[0]{\hyperlink{ast-specification}{\texttt{specification}}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Macros for AST builders
 \newcommand\BuildErrorConfig[0]{\hyperlink{def-builderrorconfig}{\texttt{\#BE}}}
@@ -669,7 +727,7 @@
 \newcommand\OrBuildError[0]{\;\terminateas \BuildErrorConfig}
 
 \newcommand\astarrow[0]{\xrightarrow{\textsf{ast}}}
-\newcommand\scanarrow[0]{\xrightarrow{\textsf{scan}}}
+\newcommand\scanarrow[0]{\xrightarrow{\hyperlink{def-aslscan}{\textsf{scan}}}}
 
 \newcommand\buildidentity[0]{\hyperlink{build-identity}{\textfunc{build\_identity}}}
 \newcommand\buildlist[0]{\hyperlink{build-list}{\textfunc{build\_list}}}
@@ -679,6 +737,7 @@
 \newcommand\buildtclist[0]{\hyperlink{build-tclist}{\textfunc{build\_tclist}}}
 \newcommand\buildoption[0]{\hyperlink{build-option}{\textfunc{build\_option}}}
 
+\newcommand\Prosebuildast[2]{\hyperlink{build-ast}{building} an untyped AST from the parse tree #1 yields #2}
 \newcommand\buildast[0]{\hyperlink{build-ast}{\textfunc{build\_ast}}}
 \newcommand\builddecl[0]{\hyperlink{build-decl}{\textfunc{build\_decl}}}
 \newcommand\builddeclitem[0]{\hyperlink{build-declitem}{\textfunc{build\_decl\_item}}}
@@ -764,14 +823,17 @@
 \newcommand\REidentifier[0]{\hyperlink{def-reidentifier}{\texttt{<}\textsf{identifier}\texttt{>}}}
 \newcommand\RElinecomment[0]{\hyperlink{def-relinecomment}{\texttt{<}\textsf{line\_comment}\texttt{>}}}
 
+\newcommand\parsearrow[0]{\xrightarrow{\hyperlink{def-aslparse}{\textsf{parse}}}}
 \newcommand\aslparse[0]{\hyperlink{def-aslparse}{\textfunc{asl\_parse}}}
+\newcommand\Proseaslparse[2]{\hyperlink{def-aslparse}{parsing} the list of tokens #1 yields the parse tree #2}
 \newcommand\aslscan[0]{\hyperlink{def-aslscan}{\textfunc{scan}}}
+\newcommand\Proseaslscan[3]{\hyperlink{def-aslscan}{applying lexical analysis} to #1 with the lexical specification #2 yields the list of tokens #3}
 \newcommand\maxmatches[0]{\hyperlink{def-maxmatch}{\textfunc{max\_matches}}}
 \newcommand\remaxmatch[0]{\hyperlink{def-rematch}{\textfunc{re\_max\_match}}}
 \newcommand\munch[0]{\hyperlink{def-munch}{\textfunc{munch}}}
 \newcommand\Token[0]{\hyperlink{def-token}{\mathbb{T}\mathbb{O}\mathbb{K}\mathbb{E}\mathbb{N}}}
-\newcommand\LexicalError[0]{\hyperlink{def-lexicalerrorresult}{\textsf{\#LE}}}
-\newcommand\ParseError[0]{\hyperlink{def-parseerror}{\textsf{\#PE}}}
+\newcommand\LexicalError[0]{\hyperlink{def-lexicalerrorresult}{\texttt{\#LE}}}
+\newcommand\ParseError[0]{\hyperlink{def-parseerror}{\texttt{\#PE}}}
 \newcommand\discard[0]{\hyperlink{def-discard}{\textfunc{discard}}}
 \newcommand\booltolit[0]{\hyperlink{def-booltolit}{\textfunc{bool\_to\_lit}}}
 \newcommand\decimaltolit[0]{\hyperlink{def-decimaltolit}{\textfunc{dec\_to\_lit}}}
@@ -945,6 +1007,7 @@
 \newcommand\DynErrorConfig[0]{\hyperlink{def-errorconfig}{\texttt{\#DE}}}
 \newcommand\OrAbnormal[0]{\;\terminateas \ThrowingConfig, \DynErrorConfig}
 \newcommand\OrDynError[0]{\;\terminateas \DynErrorConfig}
+\newcommand\ProseOtherwiseDynamicError[0]{Otherwise, the result is a dynamic error.}
 \newcommand\ProseOrAbnormal[0]{\ProseTerminateAs{\ThrowingConfig, \DynErrorConfig}}
 \newcommand\ProseOrError[0]{\ProseTerminateAs{\DynErrorConfig}}
 \newcommand\TNormal[0]{\hyperlink{def-tnormal}{\textsf{TNormal}}}
@@ -980,10 +1043,10 @@
 \newcommand\assignargs[0]{\hyperlink{def-assignargs}{\textfunc{assign\_args}}}
 \newcommand\assignnamedargs[0]{\hyperlink{def-assignnamedargs}{\textfunc{assign\_named\_args}}}
 \newcommand\matchfuncres[0]{\hyperlink{def-matchfuncres}{\textfunc{match\_func\_res}}}
+\newcommand\Prosebuildgenv[4]{\hyperlink{def-buildgenv}{building} an environment from the static environment #1 and specification #2 yields #3 and the execution graph #4}
 \newcommand\buildgenv[0]{\hyperlink{def-buildgenv}{\textfunc{build\_genv}}}
-\newcommand\setbuiltin[0]{\hyperlink{def-setbuiltin}{\textfunc{set\_builtin}}}
-\newcommand\topologicaldecls[0]{\hyperlink{def-topologicaldecls}{\textfunc{topological\_decls}}}
 \newcommand\evalglobals[0]{\hyperlink{def-evalglobals}{\textfunc{eval\_globals}}}
+\newcommand\Proseevalspec[3]{\hyperlink{def-evalspec}{evaluating} the typed AST #1 in the static environment #2 yields #3}
 \newcommand\evalspec[0]{\hyperlink{def-evalspec}{\textfunc{eval\_spec}}}
 \newcommand\lexprisvar[0]{\hyperlink{def-lexprisvar}{\textfunc{lexpr\_is\_var}}}
 \newcommand\desugarcasestmt[0]{\hyperlink{def-desugarcasestmt}{\textfunc{desugar\_case\_stmt}}}
@@ -1005,7 +1068,6 @@
 \newcommand\declarelocalidentifier[0]{\hyperlink{def-declarelocalidentifier}{\textfunc{declare\_local\_identifier}}}
 \newcommand\declarelocalidentifierm[0]{\hyperlink{def-declarelocalidentifierm}{\textfunc{declare\_local\_identifier\_m}}}
 \newcommand\declarelocalidentifiermm[0]{\hyperlink{def-declarelocalidentifermm}{\textfunc{declare\_local\_identifier\_mm}}}
-%\newcommand\envfind[0]{\hyperlink{def-envfind}{\textfunc{env\_find}}}
 \newcommand\removelocal[0]{\hyperlink{def-removelocal}{\textfunc{remove\_local}}}
 \newcommand\readidentifier[0]{\hyperlink{def-readidentifier}{\textfunc{read\_identifier}}}
 \newcommand\writeidentifier[0]{\hyperlink{def-writeidentifier}{\textfunc{write\_identifier}}}
@@ -1193,6 +1255,7 @@
 \newcommand\usecase[0]{\hyperlink{def-usecase}{\textfunc{use\_case}}}
 \newcommand\usecatcher[0]{\hyperlink{def-usecatcher}{\textfunc{use\_catcher}}}
 \newcommand\builddependencies[0]{\hyperlink{def-builddependencies}{\textfunc{build\_dependencies}}}
+\newcommand\Prosebuilddependencies[2]{\hyperlink{def-builddependencies}{building} the \dependencygraphterm\ of #1 yields #2}
 \newcommand\decldependencies[0]{\hyperlink{def-decldependencies}{\textfunc{decl\_dependencies}}}
 
 % Symbolic equivalence testing macros
@@ -1308,7 +1371,15 @@
 \newcommand\AbbrevTArrayLengthExpr[2]{\overbracket{\texttt{array }[#1]\texttt{ of }#2}^{\hyperlink{def-abbrevtarraylengthexpr}{\abbrevfont{T\_Array(ArrayLength\_Expr)}}}}
 \newcommand\AbbrevTArrayLengthEnum[3]{\overbracket{\texttt{array }[#1 \# #2]\texttt{ of }#3}^{\hyperlink{def-abbrevtarraylengthenum}{\abbrevfont{T\_Array(Array\_Length\_Enum)}}}}
 
-% Glossary
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Top level macros
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newcommand\checkandinterpret[0]{\hyperlink{def-checkandinterpret}{\textfunc{check\_and\_interpret}}}
+\newcommand\setbuiltin[0]{\hyperlink{def-setbuiltin}{\textfunc{set\_builtin}}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Glossary
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newcommand\partialfunctionterm[0]{\hyperlink{def-partialfunctionterm}{partial function}}
 \newcommand\head[0]{\hyperlink{def-head}{\texttt{head}}}
 \newcommand\tail[0]{\hyperlink{def-tail}{\texttt{tail}}}
@@ -1367,6 +1438,10 @@
 \newcommand\basevalueterm[0]{\hyperlink{def-basevalueterm}{base value}}
 \newcommand\controlflowsymbolterm[0]{\hyperlink{def-controlflowsymbolterm}{control flow state}}
 
+\newcommand\defusedependencyterm[0]{\hyperlink{def-builddependencies}{def-use dependency}}
+\newcommand\defusedependenciesterm[0]{\hyperlink{def-builddependencies}{def-use dependencies}}
+\newcommand\dependencygraphterm[0]{\hyperlink{def-builddependencies}{def-use dependency graph}}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Type functions
 \newcommand\applyunoptype[0]{\hyperlink{def-applyunoptype}{\textfunc{apply\_unop\_type}}}
@@ -1424,7 +1499,8 @@
 \newcommand\annotatelocaldeclitemuninit[0]{\hyperlink{def-annotatelocaldeclitemuninit}{\textfunc{annotate\_local\_decl\_item\_uninit}}}
 \newcommand\checkvarnotinenv[1]{\hyperlink{def-checkvarnotinenv}{\textfunc{check\_var\_not\_in\_env}}(#1)}
 \newcommand\checkvarnotingenv[1]{\hyperlink{def-checkvarnotingenv}{\textfunc{check\_var\_not\_in\_genv}}(#1)}
-\newcommand\annotatesubprogram[1]{\hyperlink{def-annotatesubprogram}{\textfunc{annotate\_subprogram}}(#1)}
+\newcommand\annotatesubprogram[0]{\hyperlink{def-annotatesubprogram}{\textfunc{annotate\_subprogram}}}
+\newcommand\Proseannotatesubprogram[3]{\hyperlink{def-annotatesubprogram}{annotating} the subprogram definition #1 in the static environment #2 yields the subprogram definition #3}
 \newcommand\checkstmtreturnsorthrows[0]{\hyperlink{def-checkstmtreturnsorthrows}{\textfunc{check\_stmt\_returns\_or\_throws}}}
 
 \newcommand\controlflowfromstmt[0]{\hyperlink{def-controlflowfromstmt}{\textfunc{control\_flow\_from\_stmt}}}
@@ -1437,12 +1513,16 @@
 
 \newcommand\annotatedecl[1]{\hyperlink{def-annotatedecl}{\textfunc{annotate\_decl}}(#1)}
 \newcommand\declaredecl[1]{\hyperlink{def-declaredecl}{\textfunc{declare\_decl}}(#1)}
+\newcommand\Prosetypecheckast[4]{\hyperlink{def-typecheckast}{type-checking} #1 in #2 yields the typed AST #3 and static environment #4}
 \newcommand\typecheckast[0]{\hyperlink{def-typecheckast}{\textfunc{type\_check\_ast}}}
+\newcommand\ProseSCC[3]{\hyperlink{def-scc}{partitioning} the set of declarations #1 with the set of edges #2 yields the list of strongly-connected components #3}
 \newcommand\SCC[0]{\hyperlink{def-scc}{\textfunc{SCC}}}
-\newcommand\topologicalordering[0]{\hyperlink{def-topologicalordering}{\textfunc{topological\_ordering}}}
+\newcommand\topologicalorderingcomps[0]{\hyperlink{def-topologicalorderingcomps}{\textfunc{topological\_ordering\_comps}}}
+\newcommand\Prosetopologicalorderingcomps[3]{\hyperlink{def-topologicalorderingcomps}{ordering} the set of strongly-connected components #1, with respect to #2, yields the list of strongly-connected components #3}
 \newcommand\declsofcomp[0]{\hyperlink{def-declsofcomp}{\textfunc{decls\_of\_comp}}}
 \newcommand\sortcomponents[0]{\hyperlink{def-sortcomponents}{\textfunc{sort\_components}}}
 \newcommand\annotatedeclcomps[0]{\hyperlink{def-annotatedeclcomps}{\textfunc{annotate\_decl\_comps}}}
+\newcommand\Proseannotatedeclcomps[4]{\hyperlink{def-annotatedeclcomps}{annotating} the list of declaration components #2 in the global static environment #1 yields the list of annotated declarations #3 and new global static environment #4}
 \newcommand\evalconstraint[1]{\textfunc{eval\_constraint}(#1)}
 \newcommand\annotateliteral[1]{\hyperlink{def-annotateliteral}{\textfunc{annotate\_literal}}(#1)}
 \newcommand\exprequalcase[0]{\hyperlink{def-exprequalcase}{\textfunc{expr\_equal\_case}}}
@@ -1489,7 +1569,7 @@
 \newcommand\intsetop[0]{\hyperlink{def-intsetop}{\textfunc{intset\_op}}}
 \newcommand\intsettointconstraints[0]{\hyperlink{def-intsettointconstraints}{\textfunc{int\_set\_to\_int\_constraints}}}
 
-%% BUild Error Codes
+%% Build Error Codes
 \newcommand\BuildErrorCode[1]{\texttt{BE\_#1}}
 \newcommand\BinopPrecedence[0]{\hyperlink{def-binopprecedence}{\BuildErrorCode{BOP}}}
 
@@ -1530,6 +1610,7 @@
 \newcommand\BaseValueNonStatic[0]{\hyperlink{def-bvns}{\TypeErrorCode{BVNS}}}
 \newcommand\BaseValueEmptyType[0]{\hyperlink{def-bvet}{\TypeErrorCode{BVET}}}
 \newcommand\NonReturningFunction[0]{\hyperlink{def-nrf}{\TypeErrorCode{NRF}}}
+\newcommand\BuiltinExpectedToBeFunction[0]{\hyperlink{def-bef}{\TypeErrorCode{BEF}}}
 
 %% Dynamic Error Codes
 \newcommand\DynamicErrorVal[1]{\Error(\texttt{#1})}
@@ -1630,6 +1711,7 @@
 \newcommand\compare[0]{\texttt{compare}}
 \newcommand\compdecls[0]{\texttt{comp\_decls}}
 \newcommand\compfordir[0]{\texttt{comp\_for\_dir}}
+\newcommand\orderedcomps[0]{\texttt{orderedcomps}}
 \newcommand\comps[0]{\texttt{comps}}
 \newcommand\compsone[0]{\texttt{comps1}}
 \newcommand\compstwo[0]{\texttt{comps2}}
@@ -1664,6 +1746,7 @@
 \newcommand\denvthrow[0]{\texttt{denv\_throw}}
 \newcommand\denvtwo[0]{\textsf{denv2}}
 \newcommand\dependencies[0]{\texttt{depends}}
+\newcommand\reverseddependencies[0]{\texttt{rev\_deps}}
 \newcommand\dir[0]{\texttt{dir}}
 \newcommand\ds[0]{\texttt{ds}}
 \newcommand\dst[0]{\texttt{dst}}
@@ -2327,6 +2410,17 @@
 \newcommand\vstwoltwo[0]{\texttt{s2l2}}
 \newcommand\vstwoltwosone[0]{\texttt{s2l2s1}}
 \newcommand\vsp[0]{\texttt{s'}}
+\newcommand\vspec[0]{\texttt{spec}}
+\newcommand\vspectext[0]{\texttt{spec\_text}}
+\newcommand\vstdtext[0]{\texttt{std\_text}}
+\newcommand\vspectokens[0]{\texttt{spec\_tokens}}
+\newcommand\vstdtokens[0]{\texttt{std\_tokens}}
+\newcommand\vspecparse[0]{\texttt{spec\_parse}}
+\newcommand\vstdparse[0]{\texttt{std\_parse}}
+\newcommand\vspecast[0]{\texttt{spec\_ast}}
+\newcommand\vstdast[0]{\texttt{std\_ast}}
+\newcommand\vstddeclast[0]{\texttt{std\_decl\_ast}}
+\newcommand\vstdasbuiltin[0]{\texttt{std\_as\_builtin}}
 \newcommand\vspp[0]{\texttt{s''}}
 \newcommand\vsstruct[0]{\texttt{s\_struct}}
 \newcommand\vstacksize[0]{\texttt{stack\_size}}
@@ -2392,6 +2486,7 @@
 \newcommand\vttwoanon[0]{\texttt{t2\_anon}}
 \newcommand\vttwostruct[0]{\texttt{t2\_struct}}
 \newcommand\vtwe[0]{\texttt{twe}}
+\newcommand\vtypedast[0]{\texttt{typed\_ast}}
 \newcommand\vtypeasts[0]{\texttt{type\_asts}}
 \newcommand\vtypes[0]{\texttt{types}}
 \newcommand\vtys[0]{\texttt{ty\_s}}
@@ -2399,6 +2494,7 @@
 \newcommand\vtyt[0]{\texttt{ty\_t}}
 \newcommand\vu[0]{\texttt{u}}
 \newcommand\vunop[0]{\texttt{unop}}
+\newcommand\vuntypedast[0]{\texttt{untyped\_ast}}
 \newcommand\vuntypedlocaldeclitem[0]{\texttt{untyped\_local\_decl\_item}}
 \newcommand\vused[0]{\texttt{used}}
 \newcommand\vusedone[0]{\texttt{used1}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -3,9 +3,6 @@
 \usepackage{mathtools}  % Additional math package
 \usepackage{amssymb}  % Classic math package
 \usepackage{mathtools}  % Additional math package
-\usepackage{graphicx}  % For figures
-\usepackage{caption}  % For figure captions
-\usepackage{subcaption}  % For subfigure captions
 \usepackage{url}  % Automatically escapes urls
 \usepackage{hyperref}  % Insert links inside pdfs
 \hypersetup{
@@ -93,7 +90,6 @@
   % To visualize:
   % showframe
 ]{geometry}
-%\usepackage{stmaryrd} % for \llbracket and \rrbracket
 \input{ifempty}
 \input{ifcode}
 \input{control}
@@ -196,8 +192,6 @@
 \newcommand\cartimes[0]{\hyperlink{def-cartimes}{\times}}
 
 \newcommand\view[0]{\hyperlink{def-deconstruction}{view}}
-%\newcommand\defpoint[1]{\underline{#1}}
-\newcommand\defpoint[1]{#1}
 \newcommand\eqname[0]{\hyperlink{def-deconstruction}{\stackrel{\mathsmaller{\mathsf{is}}}{=}}}
 \newcommand\eqdef[0]{\hyperlink{def-eqdef}{:=}}
 \newcommand\overname[2]{\overbrace{#1}^{#2}}
@@ -264,11 +258,9 @@
 % These are used by the AST reference, typing reference, and semantics reference.
 \newcommand\nonterminal[1]{\texttt{#1}}
 \newcommand\terminal[1]{\mathtt{\mathbf{#1}}}
-%\newcommand\verbatimterminal[2]{\mathtt{\mathbf{#1}}}
 \newcommand\verbatimterminal[2]{\texttt{"}\texttt{#2}\texttt{"}} % Grammar terminals
 \newcommand\emptysentence[0]{\hyperlink{def-emptysentence}{\epsilon}}
 \newcommand\astof[1]{\overline{{#1}}}
-%\newcommand\parsenode[1]{\hyperlink{def-parsenode}{\textsf{Parse}}[#1]}
 \newcommand\parsenode[1]{\hyperlink{def-parsenode}{\mathbb{P}\mathbb{A}\mathbb{R}\mathbb{S}\mathbb{E}}[#1]}
 \newcommand\namednode[2]{#1:#2} % #1 is a free variable, #2 is the grammar symbol
 \newcommand\punnode[1]{#1}
@@ -1019,7 +1011,7 @@
 \newcommand\writeidentifier[0]{\hyperlink{def-writeidentifier}{\textfunc{write\_identifier}}}
 \newcommand\createbitvector[0]{\hyperlink{def-createbitvector}{\textfunc{create\_bitvector}}}
 \newcommand\concatbitvectors[0]{\hyperlink{def-concatbitvector}{\textfunc{concat\_bitvectors}}}
-\newcommand\readfrombitvector[0]{\hyperlink{def-readfrinbitvector}{\textfunc{read\_from\_bitvector}}}
+\newcommand\readfrombitvector[0]{\hyperlink{def-readfrombitvector}{\textfunc{read\_from\_bitvector}}}
 \newcommand\writetobitvector[0]{\hyperlink{def-writetobitvector}{\textfunc{write\_to\_bitvector}}}
 \newcommand\asbitvector[0]{\hyperlink{def-asbitvector}{\textfunc{as\_bitvector}}}
 \newcommand\slicestopositions[0]{\hyperlink{def-slicestopositions}{\textfunc{slices\_to\_positions}}}
@@ -1379,6 +1371,7 @@
 %% Type functions
 \newcommand\applyunoptype[0]{\hyperlink{def-applyunoptype}{\textfunc{apply\_unop\_type}}}
 \newcommand\applybinoptypes[0]{\hyperlink{def-applybinoptypes}{\textfunc{apply\_binop\_types}}}
+\newcommand\Proseapplybinoptypes[5]{\hyperlink{def-applybinoptypes}{applying} #2 to the type #3 and type #4 in the static environment #1 yields the type #5}
 \newcommand\constraintbinop[0]{\hyperlink{def-constraintbinop}{\textfunc{constraint\_binop}}}
 \newcommand\applybinopextremities[0]{\hyperlink{def-applybinopextremities}{\textfunc{apply\_binop\_extremities}}}
 \newcommand\possibleextremitiesleft[0]{\hyperlink{def-possibleextremitiesleft}{\textfunc{possible\_extremities\_left}}}
@@ -1410,6 +1403,7 @@
 \newcommand\annotateconstraint[0]{\hyperlink{def-annotateconstraint}{\textfunc{annotate\_constraint}}}
 \newcommand\getvariableenum[0]{\hyperlink{def-getvariableenum}{\textfunc{get\_variable\_enum}}}
 \newcommand\annotateexpr[1]{\hyperlink{def-annotateexpr}{\textfunc{annotate\_expr}}(#1)}
+\newcommand\Proseannotateexpr[3]{\hyperlink{def-annotateexpr}{annotating} the expression #1 in the static environment #2 yields #3}
 \newcommand\annotateexprlist[0]{\hyperlink{def-annotateexprs}{\textfunc{annotate\_exprs}}}
 \newcommand\annotatelimitexpr[0]{\hyperlink{def-annotatelimitexpr}{\textfunc{annotate\_limit\_expr}}}
 \newcommand\annotatelexpr[1]{\hyperlink{def-annotatelexpr}{\textfunc{annotate\_lexpr}}(#1)}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -99,7 +99,7 @@ An abstract syntax consists of a set of derivation rules and a start non-termina
 
 \section{Untyped Abstract Grammar\label{sec:UntypedAbstractGrammar}}
 
-The abstract syntax of ASL is given in terms of the derivation rules below and the start non-terminal $\specification$.
+The abstract syntax of ASL is given in terms of the derivation rules below and the start non-terminal $\spec$.
 %
 Some extra details are given by using the notation $\overname{\textit{symbol}}{\text{detail}}$.
 
@@ -561,9 +561,9 @@ Declaration keyword for global storage elements:
 \end{flalign*}
 
 \subsection{Specifications \label{sec:Specifications}}
-\hypertarget{ast-specification}{}
+\hypertarget{ast-spec}{}
 \begin{flalign*}
-\specification \derives\ & \decl^* &
+\spec \derives\ & \decl^* &
 \end{flalign*}
 
 \section{Typed Abstract Syntax Grammar\label{sec:TypedAbstractSyntaxGrammar}}
@@ -622,6 +622,9 @@ AST. The builder function is defined in terms of one inference rule per alternat
 The input for the builder for an alternative $R = S_{1..m}$ is a parse node
 $N(S_{1..m})$. To allow the builder to refer to the children nodes of $N$,
 we use the notation $\namednode{n_i}{S_i}$, which names the child node $S_i$ as $n_i$.
+
+The set of builder relations is defined in the respective chapters for their constructs
+(for example, the builder for expressions is defined in \chapref{Expressions}).
 
 \subsection{Example}
 Consider the derivation for while loops:

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -827,7 +827,7 @@ All of the following apply:
       \item $\vw$ is the width of $\slices$;
       \item $\vtp$ is defined as the bitvector type of width $\vw$ and an empty list of bitfields, that is, $\TBits(\vw , \emptylist)$;
       \item checking whether $\vtp$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
-      \item checking whether$\vte$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
+      \item checking whether $\vte$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
       \item $\vletwo$ is defined as the slicing of $\vleone$ by $\slices$, that is, \\ $\LESlice(\vleone, \slices)$;
       \item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields $\newle$\ProseOrTypeError.
     \end{itemize}

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -217,8 +217,14 @@ This is produced by \nameref{sec:TypingRule.BaseValue}.
 \hypertarget{def-nrf}{}
 \item[$\NonReturningFunction$]
 This error indicates that a function contains a control-flow path that may not terminate by
-either returning a value, throwing an exception, or executing \texttt{Unreachable()}
-(see \nameref{sec:TypingRule.CheckStmtReturnsOrThrows}).
+either returning a value, throwing an exception, or executing \\
+\texttt{Unreachable()} (see \nameref{sec:TypingRule.CheckStmtReturnsOrThrows}).
+
+\hypertarget{def-bef}{}
+\item[$\BuiltinExpectedToBeFunction$]
+This error indicates an attempt to list a top-level declaration that is not a function
+in the standard library
+(see \nameref{sec:TypingRule.SetBuiltin}).
 
 \end{description}
 

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -479,11 +479,10 @@ One of the following applies:
 All of the following apply:
 \begin{itemize}
   \item $\ve$ denotes a binary operation $\op$ over two expressions $\veone$ and $\vetwo$, that is, \\ $\EBinop(\op, \veone, \vetwo)$;
-  \item the result of annotating $\veone$ in $\tenv$ is $(\vtone, \veonep)$\ProseOrTypeError;
-  \item the result of annotating $\vetwo$ in $\tenv$ is $(\vttwo, \vetwop)$\ProseOrTypeError;
-  \item the result of checking compatibility of $\op$ with $\vtone$ and $\vttwo$ as per \secref{TypingRule.ApplyBinopTypes}
-  is $\vt$\ProseOrTypeError;
-  \item $\newenv$ denotes $\op$ over $\veonep$ and $\vetwop$.
+  \item \Proseannotateexpr{$\veone$}{$\tenv$}{$(\vtone, \veonep)$\ProseOrTypeError};
+  \item \Proseannotateexpr{$\vetwo$}{$\tenv$}{$(\vttwo, \vetwop)$\ProseOrTypeError};
+  \item \Proseapplybinoptypes{$\tenv$}{\op}{\vtone}{\vttwo}{$\vt$\ProseOrTypeError};
+  \item define $\newe$ as the binary expression $\op$ over $\veonep$ and $\vetwop$.
 \end{itemize}
 \subsubsection{Formally}
 \begin{mathpar}
@@ -1269,7 +1268,7 @@ resulting bitvector --- and the execution graph $\vgone$;
 \inferrule{
   \evalexpr{\env, \ebv} \evalarrow \Normal(\mbv, \envone)  \OrAbnormal\\\\
   \mbv \eqname (\vbv,\vgone) \\
-  \evalslices{\envone, \slices} \evalarrow \Normal(\mpositions, \newenv)  \OrAbnormal \\
+  \evalslices(\envone, \slices) \evalarrow \Normal(\mpositions, \newenv)  \OrAbnormal \\
   \mpositions \eqname (\positions, \vgtwo) \\
   \readfrombitvector(\vbv, \positions) \evalarrow \vv \OrDynError\\\\
   \vg \eqdef \vgone \parallelcomp \vgtwo

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -69,7 +69,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \end{mathpar}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Typing\label{sec:GlobalDeclarationsTyping}}
+\section{Typing Global Declarations\label{sec:GlobalDeclarationsTyping}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \hypertarget{def-typecheckdecl}{}
 The function
@@ -85,26 +85,45 @@ annotates a global declaration $\vd$ in the global static environment $\genv$,
 yielding an annotated global declaration $\newd$ and modified global static environment $\newgenv$.
 \ProseOtherwiseTypeError
 
-\subsubsection{TypingRule.TypecheckFunc\label{sec:TypingRule.TypecheckFunc}}
+\subsubsection{TypingRule.TypecheckDecl\label{sec:TypingRule.TypecheckDecl}}
 \subsubsection{Prose}
-All of the following apply:
+One of the following applies:
 \begin{itemize}
-  \item $\vd$ is a subprogram AST node with a subprogram definition $\vf$, that is, $\DFunc(\vf)$;
-  \item annotating and declaring the subprogram for $\vf$ in $\genv$ as per \secref{TypingRule.AnnotateAndDeclareFunc}
-        yields the environment $\tenvone$ and a subprogram definition $\vfone$\ProseOrTypeError;
-  \item annotating the subprogram definition $\vfone$ in $\tenv$ as per \nameref{sec:TypingRule.Subprogram} yields
-        the annotated subprogram definition $\vftwo$\ProseOrTypeError;
-  \item applying $\addsubprogram$ to bind $\vftwo.\funcname$ to $\vftwo$ in $\tenvone$ yields $\newtenv$;
-  \item define $\newd$ as the subprogram AST node with $\vftwo$, that is, $\DFunc(\vftwo)$;
-  \item define $\newgenv$ as the global component of $\newtenv$.
-\end{itemize}\CodeSubsection{\TypecheckFuncBegin}{\TypecheckFuncEnd}{../Typing.ml}
+  \item All of the following apply (\textsc{func}):
+  \begin{itemize}
+    \item $\vd$ is a subprogram AST node with a subprogram definition $\vf$, that is, $\DFunc(\vf)$;
+    \item annotating and declaring the subprogram for $\vf$ in $\genv$ as per \secref{TypingRule.AnnotateAndDeclareFunc}
+          yields the environment $\tenvone$ and a subprogram definition $\vfone$\ProseOrTypeError;
+    \item \Proseannotatesubprogram{$\vfone$}{$\tenv$}{$\vftwo$\ProseOrTypeError};
+    \item applying $\addsubprogram$ to bind $\vftwo.\funcname$ to $\vftwo$ in $\tenvone$ yields $\newtenv$;
+    \item define $\newd$ as the subprogram AST node with $\vftwo$, that is, $\DFunc(\vftwo)$;
+    \item define $\newgenv$ as the global component of $\newtenv$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{global\_storage}):
+  \begin{itemize}
+    \item $\vd$ is a global storage declaration with description $\gsd$, that is, \\ $\DGlobalStorage(\gsd)$;
+    \item declaring the global storage with description $\gsd$ in $\genv$ yields the new environment
+          $\newgenv$ and new global storage description $\gsdp$\ProseOrTypeError;
+    \item define $\newd$ as the global storage declaration with description $\gsdp$, that is, \\ $\DGlobalStorage(\gsdp)$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{type}):
+  \begin{itemize}
+    \item $\vd$ is a type declaration with identifier $\vx$, type $\tty$,
+          and \optional\ field initializers $\vs$, that is, $\DTypeDecl(\vx, \tty, \vs)$;
+    \item declaring the type described by $(\vx, \tty, \vs)$ in $\genv$
+          as per \secref{TypingRule.DeclaredType} yields the modified global static environment $\newgenv$\ProseOrTypeError;
+    \item define $\newd$ as $\vd$.
+  \end{itemize}
+\end{itemize}
 
 \subsubsection{Formally}
 \begin{mathpar}
-\inferrule{
+\inferrule[func]{
   \vf \eqname \{\text{body}: \SBASL, \ldots\}\\
   \annotateanddeclarefunc(\genv, \vf) \typearrow (\tenvone, \vfone) \OrTypeError\\\\
-  \annotatesubprogram{\tenvone, \vfone} \typearrow \vftwo \OrTypeError\\\\
+  \annotatesubprogram(\tenvone, \vfone) \typearrow \vftwo \OrTypeError\\\\
   \addsubprogram(\tenvone, \vftwo.\funcname, \vftwo) \typearrow \newtenv
 }{
   \typecheckdecl(\genv, \overname{\DFunc(\vf)}{\vd})
@@ -112,11 +131,33 @@ All of the following apply:
 }
 \end{mathpar}
 
+\begin{mathpar}
+\inferrule[global\_storage]{
+  \declareglobalstorage(\genv, \gsd) \typearrow (\newgenv, \gsdp) \OrTypeError
+}{
+  {
+    \begin{array}{r}
+  \typecheckdecl(\genv, \overname{\DGlobalStorage(\gsd)}{\vd})
+  \typearrow \\ (\overname{\DGlobalStorage(\gsdp)}{\newd}, \newgenv)
+    \end{array}
+  }
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[type]{
+  \declaretype(\genv, \vx, \tty, \vs) \typearrow \newgenv \OrTypeError
+}{
+  \typecheckdecl(\genv, \overname{\DTypeDecl(\vx, \tty, \vs)}{\vd}) \typearrow (\overname{\vd}{\newd}, \newgenv)
+}
+\end{mathpar}
+\CodeSubsection{\TypecheckDeclBegin}{\TypecheckDeclEnd}{../Typing.ml}
+
 \subsubsection{TypingRule.Subprogram \label{sec:TypingRule.Subprogram}}
 \hypertarget{def-annotatesubprogram}{}
 The function
 \[
-  \annotatesubprogram{\overname{\staticenvs}{\tenv} \aslsep \overname{\func}{\vf}} \aslto \overname{\func}{\vfp}
+  \annotatesubprogram(\overname{\staticenvs}{\tenv} \aslsep \overname{\func}{\vf}) \aslto \overname{\func}{\vfp}
   \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 annotates a subprogram $\vf$ in an environment $\tenv$, resulting in an annotated subprogram $\vfp$.
@@ -151,7 +192,7 @@ One of the following applies:
   \vf.\funcreturntype = \None\\
   \vfp \eqdef \substrecordfield(\vf, \funcbody, \SBASL(\newbody))
 }{
-  \annotatesubprogram{\tenv, \vf} \typearrow \vfp
+  \annotatesubprogram(\tenv, \vf) \typearrow \vfp
 }
 \end{mathpar}
 
@@ -162,7 +203,7 @@ One of the following applies:
   \checkstmtreturnsorthrows(\newbody) \typearrow \True \OrTypeError\\\\
   \vfp \eqdef \substrecordfield(\vf, \funcbody, \SBASL(\newbody))
 }{
-  \annotatesubprogram{\tenv, \vf} \typearrow \vfp
+  \annotatesubprogram(\tenv, \vf) \typearrow \vfp
 }
 \end{mathpar}
 
@@ -383,48 +424,3 @@ returns in $\vctrlflow$ the maximal element of $\vtone$ and $\vttwo$ in the foll
 \[
   \assertednotinterrupt\ \sqsubset \interrupt \sqsubset \maynotinterrupt \enspace.
 \]
-
-\subsubsection{TypingRule.TypecheckGlobalStorage\label{sec:TypingRule.TypecheckGlobalStorage}}
-\subsubsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\vd$ is a global storage declaration with description $\gsd$, that is, \\ $\DGlobalStorage(\gsd)$;
-  \item declaring the global storage with description $\gsd$ in $\genv$ yields the new environment
-        $\newgenv$ and new global storage description $\gsdp$\ProseOrTypeError;
-  \item define $\newd$ as the global storage declaration with description $\gsdp$, that is, \\ $\DGlobalStorage(\gsdp)$.
-\end{itemize}\CodeSubsection{\TypecheckGlobalStorageBegin}{\TypecheckGlobalStorageEnd}{../Typing.ml}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \declareglobalstorage(\genv, \gsd) \typearrow (\newgenv, \gsdp) \OrTypeError
-}{
-  {
-    \begin{array}{r}
-  \typecheckdecl(\genv, \overname{\DGlobalStorage(\gsd)}{\vd})
-  \typearrow \\ (\overname{\DGlobalStorage(\gsdp)}{\newd}, \newgenv)
-    \end{array}
-  }
-}
-\end{mathpar}
-
-\subsubsection{TypingRule.TypecheckTypeDecl\label{sec:TypingRule.TypecheckTypeDecl}}
-\subsubsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\vd$ is a type declaration with identifier $\vx$, type $\tty$,
-        and \optional\ field initializers $\vs$, that is, $\DTypeDecl(\vx, \tty, \vs)$;
-  \item declaring the type described by $(\vx, \tty, \vs)$ in $\genv$
-        as per \secref{TypingRule.DeclaredType} yields the modified global static environment $\newgenv$\ProseOrTypeError;
-  \item define $\newd$ as $\vd$.
-  \end{itemize}
-\CodeSubsection{\TypecheckTypeDeclBegin}{\TypecheckTypeDeclEnd}{../Typing.ml}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \declaretype(\genv, \vx, \tty, \vs) \typearrow \newgenv \OrTypeError
-}{
-  \typecheckdecl(\genv, \overname{\DTypeDecl(\vx, \tty, \vs)}{\vd}) \typearrow (\overname{\vd}{\newd}, \newgenv)
-}
-\end{mathpar}

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -1140,7 +1140,7 @@ One of the following applies:
     \item at least one of $\vtone$ and $\vttwo$ is a \namedtype;
     \item determining the \underlyingtype\ if $\vtone$ yields $\vtoneanon$\ProseOrTypeError;
     \item determining the \underlyingtype\ if $\vttwo$ yields $\vttwoanon$\ProseOrTypeError;
-    \item applying $\applybinoptypes$ to $\vtoneanon$ and $\vttwoanon$ in $\tenv$ yields $\vt$\ProseOrTypeError.
+    \item \Proseapplybinoptypes{$\tenv$}{$\op$}{$\vtoneanon$}{$\vttwoanon$}{$\vt$\ProseOrTypeError}.
   \end{itemize}
 
   \item All of the following apply (\textsc{boolean}):
@@ -1237,8 +1237,7 @@ One of the following applies:
     \item both $\vtone$ and $\vttwo$ are integer types and at least one them is a \parameterizedintegertype;
     \item applying $\towellconstrained$ to $\vtone$ yields $\vtonewellconstrained$;
     \item applying $\towellconstrained$ to $\vttwo$ yields $\vttwowellconstrained$;
-    \item applying $\applybinoptypes$ to $\vtonewellconstrained$ and \\
-          $\vttwowellconstrained$ in $\tenv$ yields $\vt$.
+    \item \Proseapplybinoptypes{$\tenv$}{$\op$}{$\vtonewellconstrained$}{$\vttwowellconstrained$}{$\vt$}.
   \end{itemize}
 
   \item All of the following apply (\textsc{arith\_t\_int\_wellconstrained}):
@@ -1341,7 +1340,7 @@ One of the following applies:
   \astlabel(\vtone) = \TNamed \lor \astlabel(\vttwo) = \TNamed\\
   \makeanonymous(\tenv, \vtone) \typearrow \vtoneanon \OrTypeError\\\\
   \makeanonymous(\tenv, \vttwo) \typearrow \vttwoanon \OrTypeError\\\\
-  \applybinoptypes(\tenv, \vtoneanon, \vttwoanon) \typearrow \vt \OrTypeError
+  \applybinoptypes(\tenv, \op, \vtoneanon, \vttwoanon) \typearrow \vt \OrTypeError
 }{
   \applybinoptypes(\tenv, \op, \vtone, \vttwo) \typearrow \vt
 }

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -424,7 +424,7 @@ The relation
 \hypertarget{def-evalslice}{}
 \[
   \begin{array}{rl}
-  \evalslice{\overname{\envs}{\env} \aslsep \overname{\slice}{\vs}} \;\aslrel &
+  \evalslice(\overname{\envs}{\env} \aslsep \overname{\slice}{\vs}) \;\aslrel &
     \Normal(((\overname{\tint}{\vstart} \times \overname{\tint}{\vlength}) \times \overname{\XGraphs}{\newg}), \overname{\envs}{\newenv})\ \cup \\
     & \overname{\Throwing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
   \end{array}

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -1,34 +1,34 @@
 \chapter{Specifications\label{chap:Specifications}}
 
-Specifications are grammatically derived from $\Nast$ and represented as ASTs by \\
-$\specification$.
+Specifications are grammatically derived from $\Nspec$ and represented as ASTs by \\
+$\spec$.
 %
 Typing specifications is done by the relation $\typecheckast$, which is defined in
 \nameref{sec:TypingRule.TypeCheckAST}.
 %
-The semantics of specifications in given by the relation $\evalspec$, which is defined in \nameref{sec:SemanticsRule.TopLevel}.
+The semantics of specifications in given by the relation $\evalspec$, which is defined in \nameref{sec:SemanticsRule.EvalSpec}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Syntax}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{flalign*}
-\Nast   \derives\ & \maybeemptylist{\Ndecl} &
+\Nspec   \derives\ & \maybeemptylist{\Ndecl} &
 \end{flalign*}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Abstract Syntax}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{flalign*}
-\specification \derives\ & \decl^* &
+\spec \derives\ & \decl^* &
 \end{flalign*}
 
 \subsubsection{ASTRule.AST \label{sec:ASTRule.AST}}
 \hypertarget{build-ast}{}
 The relation
 \[
-  \buildast : \overname{\parsenode{\Nast}}{\vparsednode} \;\aslrel\; \overname{\specification}{\vastnode}
+  \buildast : \overname{\parsenode{\Nspec}}{\vparsednode} \;\aslrel\; \overname{\spec}{\vastnode}
 \]
-transforms an $\Nast$ node $\vparsednode$ into an AST specification node $\vastnode$.
+transforms an $\Nspec$ node $\vparsednode$ into an AST specification node $\vastnode$.
 
 We define this function for subprogram declarations, type declarations, and global storage declarations in the corresponding chapters.
 
@@ -36,43 +36,35 @@ We define this function for subprogram declarations, type declarations, and glob
 \inferrule[ast]{
     \buildlist[\builddecl](\vdecls) \astarrow \vadecls
 }{
-    \buildast(\overname{\Nast(\namednode{\vdecls}{\maybeemptylist{\Ndecl}})}{\vparsednode}) \astarrow \overname{\vadecls}{\vastnode}
+    \buildast(\overname{\Nspec(\namednode{\vdecls}{\maybeemptylist{\Ndecl}})}{\vparsednode}) \astarrow \overname{\vadecls}{\vastnode}
 }
 \end{mathpar}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Typing}
+\section{Typing Specifications\label{sec:TypingSpecifications}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-The untyped AST of an ASL specification consists of a list of declarations.
-Type-checking the untyped AST succeeds if all declarations can be successfully annotated.
-This is achieved via \nameref{sec:TypingRule.TypeCheckAST}.
+The untyped AST of an ASL specification consists of a list of global declarations.
+Type-checking the untyped AST succeeds if all declarations can be successfully annotated,
+which is achieved via \nameref{sec:TypingRule.TypeCheckAST}. Otherwise, the result is a
+type error.
 
-We define the following helper rules:
-\begin{itemize}
-  \item TypingRule.AnnotateDeclComps (see \secref{TypingRule.AnnotateDeclComps})
-  \item TypingRule.BuildDependencies (see \secref{TypingRule.BuildDependencies})
-  \item TypingRule.DeclDependencies (see \secref{TypingRule.DeclDependencies})
-  \item TypingRule.TypeCheckMutuallyRec (see \secref{TypingRule.TypeCheckMutuallyRec})
-  \item TypingRule.DeclareSubprograms (see \secref{TypingRule.DeclareSubprograms})
-  \item TypingRule.AddSubprogramDecls (see \secref{TypingRule.AddSubprogramDecls})
-  \item TypingRule.DefDecl (see \secref{TypingRule.DefDecl})
-  \item TypingRule.DefEnumLabels (see \secref{TypingRule.DefEnumLabels})
-  \item TypingRule.UseDecl (see \secref{TypingRule.UseDecl})
-  \item TypingRule.UseTy (see \secref{TypingRule.UseTy})
-  \item TypingRule.UseSubtypes (see \secref{TypingRule.UseSubtypes})
-  \item TypingRule.UseExpr (see \secref{TypingRule.UseExpr})
-  \item TypingRule.UseLexpr (see \secref{TypingRule.UseLexpr})
-  \item TypingRule.UsePattern (see \secref{TypingRule.UsePattern})
-  \item TypingRule.UseSlice (see \secref{TypingRule.UseSlice})
-  \item TypingRule.UseBitfield (see \secref{TypingRule.UseBitfield})
-  \item TypingRule.UseConstraint (see \secref{TypingRule.UseConstraint})
-  \item TypingRule.UseStmt (see \secref{TypingRule.UseStmt})
-  \item TypingRule.UseLDI (see \secref{TypingRule.UseLDI})
-  \item TypingRule.UseCase (see \secref{TypingRule.UseCase})
-  \item TypingRule.UseCatcher (see \secref{TypingRule.UseCatcher})
-  \item TypingRule.SetBuiltin (see \secref{TypingRule.SetBuiltin})
-\end{itemize}
+We note that whether type-checking a specification succeeds or fails with a type
+error, does not depend on the order in which the declarations appear in the specification.
+That is, if type-checking a specification with one ordering of its declarations leads to
+a type error, then type-checking that specification with any other ordering of its
+declarations also leads to a type error, but the type errors may not be the same
+(since there may be two erroneous declarations and the type error returned
+depends on which declaration is processed first).
+
+When type-checking declarations, it is important to process them in a certain order,
+to avoid false type errors resulting from type-checking a declaration that uses an identifier
+before a declaration that defines it.
+This order relies on the notion of \defusedependencyterm, which we formally define in
+\secref{Dependencies}.
+\secref{TopologicalOrdering} formally defines how to use the inferred \defusedependenciesterm\ to
+order the declarations such that false type errors are avoided.
+\lrmcomment{This relates to \identi{LWQQ}.}
 
 \subsubsection{TypingRule.TypeCheckAST\label{sec:TypingRule.TypeCheckAST}}
 \hypertarget{def-typecheckast}{}
@@ -89,50 +81,19 @@ annotates a list of declarations $\decls$ in an input global static environment 
 yielding an output static environment $\newtenv$ and annotated list of declarations $\newdecls$.
 \ProseOtherwiseTypeError
 
-\begin{definition}[Strongly Connected Components]
-\hypertarget{def-scc}{}
-Given a graph $G=(V, E)$, a \\ subset of its nodes $C \subseteq V$ is called
-a \emph{strongly connected component} of $G$ if
-every pair of nodes $u,v \in C$ reachable from one another.
-
-The \emph{strongly connected components} of a graph $(V, E)$ uniquely partitions its set of
-nodes $V$ into a set of strongly connected components:
-\[
-\SCC(V, E) \triangleq \{ C \subseteq V \;|\; \forall u,v\in C.\ (u,v), (v,u) \in E^* \} \enspace.
-\]
-
-We write $E^*$ to denote the reflexive-transitive closure of $E$.
-\end{definition}
-
-\begin{definition}[Topological Ordering]
-For a graph $G=(V, E)$ and its \\
-strongly connected components $\comps \triangleq \SCC(V, E)$,
-we say that $C_1\in\comps$ is ordered before $C_2\in\comps$, denoted $C_1 < C_2$,
-if the following condition holds:
-\[
-C_1 < C_2 \Leftrightarrow \exists c_1\in C_1.\ c_2\in C_2.\ (c_1,c_2) \in E^* \enspace.
-\]
-This ordering is not total. That is, there may exist strongly connected components
-$A,B\in\comps$ such that $A \not< B$ and $B \not< A$.
-
-\hypertarget{def-topologicalordering}{}
-We say that a list of subsets of $V$ --- $\compstwo$ --- respects the topological ordering of $\comps$
-if each element of $\compstwo$ is a member of $\comps$ and for every $C_1,C_2\in\comps$ such that
-$C_1 < C_2$ we have that $C_1$ appears before $C_2$ in $\compstwo$.
-We denote this as $\compstwo \in \topologicalordering(V, E, \comps)$.
-\end{definition}
-
 \subsubsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item applying $\builddependencies$ to $\decls$ yields the dependency graph \\ $(\defs, \dependencies)$;
-  \item partitioning the nodes of the dependency graph $(\defs, \dependencies)$ into strongly connected components
-        yields $\comps$;
-  \item $\compstwo$ is an ordering of $\comps$ that respects the topological ordering induced by $\dependencies$;
-  \item $\compdecls$ applies $\declsofcomp$ to each component $\vc$ in $\compstwo$ to transform it into a list,
+  \item \Prosebuilddependencies{\decls}{$(\defs, \dependencies)$};
+  \item define $\reverseddependencies$ as the relation $\dependencies$ with its elements in reversed order.
+        That is, if $(a,b)$ is in $\dependencies$ then $\reverseddependencies$ contains $(b, a)$.
+        The reversal is necessary, since we want to check a declaration $b$ before any declaration $a$
+        that depends on it;
+  \item \ProseSCC{$\defs$}{$\reverseddependencies$}{$\comps$};
+  \item \Prosetopologicalorderingcomps{$\comps$}{$\reverseddependencies$}{$\orderedcomps$};
+  \item $\compdecls$ applies $\declsofcomp$ to each component $\vc$ in $\orderedcomps$ to transform it into a list,
         yielding a list of lists where each sublist corresponds to one strongly connected component;
-  \item applying $\annotatedeclcomps$ to $\compdecls$ in $\genv$ yields \\
-        $(\newdecls, \newtenv)$\ProseOrTypeError.
+  \item \Proseannotatedeclcomps{$\genv$}{$\compdecls$}{$\newdecls$}{$\newtenv$\ProseOrTypeError}.
 \end{itemize}
 \CodeSubsection{\TypeCheckASTBegin}{\TypeCheckASTEnd}{../Typing.ml}
 
@@ -140,72 +101,13 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{
   \builddependencies(\decls) \typearrow (\defs, \dependencies)\\
-  \SCC(\defs, \dependencies) = \compsone\\
-  \compstwo \in \topologicalordering(\compsone, \dependencies)\\
-  \compdecls \eqdef [ \vc\in\compstwo: \declsofcomp(\vc, \decls) ]\\
+  \reverseddependencies \eqdef [(a,b) \in \dependencies: (b,a)]\\
+  \SCC(\defs, \reverseddependencies) = \comps\\
+  \orderedcomps \in \topologicalorderingcomps(\comps, \reverseddependencies)\\
+  \compdecls \eqdef [ \vc\in\orderedcomps: \declsofcomp(\vc, \decls) ]\\
   \annotatedeclcomps(\genv, \compdecls) \typearrow (\newdecls, \newtenv) \OrTypeError
 }{
   \typecheckast(\genv, \decls) \typearrow (\newdecls, \newtenv)
-}
-\end{mathpar}
-
-\subsubsection{Comments}
-It is crucial to process the strongly connected components obtained from the dependency graph
-according to the topological ordering of the components. Otherwise, the type-system could
-falsely result in a type error indicating that some identifier is not defined.
-However, a topological ordering is not unique, which is why $\typecheckast$ is a relation rather than
-a function.
-It is possible to obtain a deterministic ordering by ordering components so as to respect
-the order of declarations in $\decls$, that is,
-the order in which declarations appear in the specification.
-Similarly, any ordering of the declarations within a single strongly connected component is correct,
-but it is possible to order the declarations according to their order of appearance in $\decls$,
-as demonstrated in TypingRule.DeclsOfComp.
-
-\lrmcomment{This relates to \identi{LWQQ}.}
-
-\subsubsection{TypingRule.DeclsOfComp \label{sec:TypingRule.DeclsOfComp}}
-\hypertarget{def-declsofcomp}{}
-The helper function
-\[
-\declsofcomp(
-  \overname{\pow{\identifier}}{\comp} \aslsep
-  \overname{\decl^*}{\decls}
-) \aslto \overname{\decl^*}{\compdecls}
-\]
-lists the sublist of declarations in $\decls$ corresponding to the identifiers in $\comp$
-yielding $\compdecls$
-
-\subsubsection{Prose}
-One of the following applies:
-\begin{itemize}
-  \item All of the following apply (\textsc{empty}):
-  \begin{itemize}
-    \item $\decls$ is the empty list;
-    \item define $\compdecls$ as the empty list.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{non\_empty}):
-  \begin{itemize}
-    \item $\decls$ is the list with \head\ $\vd$ and \tail\ $declsone$;
-    \item define $\declstwo$ as the singleton list for $\vd$ if applying $\defdecl$ to $\vd$ yields an identifier
-          that is a member of $\comp$ and the empty list, otherwise;
-    \item applying $\declsofcomp$ to $\comp$ and $\declsone$ yields $\declsthree$;
-    \item define $\compdecls$ as the concatenation of $\declstwo$ and $\declsthree$.
-  \end{itemize}
-\end{itemize}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule[empty]{}{
-  \declsofcomp(\comp, \overname{\emptylist}{\decls}) \typearrow \overname{\emptylist}{\compdecls}
-}
-\and
-\inferrule[non\_empty]{
-  \declstwo \eqdef \choice{\defdecl(\vd) \in \comp}{[\vd]}{\emptylist}\\
-  \declsofcomp(\comp, \declsone) \typearrow \declsthree
-}{
-  \declsofcomp(\comp, \overname{[\vd]\concat\declsone}{\decls}) \typearrow \overname{\declstwo\concat\declsthree}{\compdecls}
 }
 \end{mathpar}
 
@@ -253,8 +155,7 @@ One of the following applies:
   \item All of the following apply (\textsc{mutually\_recursive}):
   \begin{itemize}
     \item $\comps$ is a list with \head\ $\comp$ and \tail\ $\compsone$;
-    \item $\comp$ is a list with more than one declaration (which together represent a mutually-recursive
-          list of declarations);
+    \item $\comp$ is a list with more than one declaration (that is, a list of mutually-recursive declarations);
     \item applying $\typecheckmutuallyrec$ to $\comp$ in $\genv$ yields \\ $(\declsone, \genvone)$\ProseOrTypeError;
     \item applying $\annotatedeclcomps$ to $\compsone$ in $\genvone$ yields \\ $(\newgenv, \declstwo)$\ProseOrTypeError;
     \item define $\newdecls$ as the concatenation of $\declsone$ and $\declstwo$.
@@ -266,7 +167,9 @@ One of the following applies:
 \inferrule[empty]{}{
   \annotatedeclcomps(\genv, \overname{\emptylist}{\comps}) \aslto (\overname{\genv}{\newgenv}, \overname{\emptylist}{\newdecls})
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[single]{
   \comp = [\vd]\\
   \typecheckdecl(\genv, \vd) \typearrow (\vdone, \genvone) \OrTypeError\\\\
@@ -275,7 +178,9 @@ One of the following applies:
   \annotatedeclcomps(\genv, \overname{[\comp] \concat \compsone}{\comps}) \aslto
   (\newgenv, \overname{[\vdone] \concat \declsone}{\newdecls})
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[mutually\_recursive]{
   |\comp| > 1\\
   \typecheckmutuallyrec(\genv, \comp) \typearrow (\declsone, \genvone) \OrTypeError\\\\
@@ -283,72 +188,6 @@ One of the following applies:
 }{
   \annotatedeclcomps(\genv, \overname{[\comp] \concat \compsone}{\comps}) \aslto
   (\newgenv, \overname{\declsone \concat \declstwo}{\newdecls})
-}
-\end{mathpar}
-
-\subsubsection{TypingRule.BuildDependencies \label{sec:TypingRule.BuildDependencies}}
-\hypertarget{def-builddependencies}{}
-The function
-\[
-\builddependencies(\overname{\decl^*}{\decls})
-\aslto
-(\overname{\identifier^*}{\defs}, \overname{(\identifier\times\identifier)^*}{\dependencies})
-\]
-takes a set of declarations $\decls$ and
-returns a graph whose set of nodes are the identifiers that are used to name declarations
-and whose set of edges $\dependencies$ consists of pairs $(a,b)$
-where the declaration of $a$ uses an identifier defined by $b$.
-We refer to this graph as the \emph{dependency graph} (of $\decls$).
-
-\subsubsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item define $\defs$ as the union of two sets:
-  \begin{enumerate}
-  \item the set of identifiers obtained by applying $\defdecl$ to each declaration in $\decls$;
-  \item the union of applying $\defenumlabels$ to each declaration in $\decls$.
-  \end{enumerate}
-  \item define $\dependencies$ as the union of applying $\decldependencies$ to each declaration in $\decls$.
-\end{itemize}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \defs \eqdef \{ \defdecl(\vd) \;|\; \vd \in \decls\} \cup \bigcup_{\vd\in\decls} \defenumlabels(\vd)\\
-  \dependencies \eqdef \bigcup_{\vd \in \decls} \decldependencies(\vd)
-}{
-  \builddependencies(\decls) \typearrow (\ids, \dependencies)
-}
-\end{mathpar}
-
-\subsubsection{TypingRule.DeclDependencies \label{sec:TypingRule.DeclDependencies}}
-\hypertarget{def-decldependencies}{}
-The function
-\[
-\decldependencies(\overname{\decl}{\vd}) \aslto \overname{(\identifier\times\identifier)^*}{\dependencies}
-\]
-returns the set of dependent pairs of identifiers $\dependencies$ induced by the declaration $\vd$.
-
-\subsubsection{Prose}
-Define $\dependencies$ as the union of the following two sets:
-\begin{enumerate}
-  \item a pair $(\idone, \idtwo)$ where $\idone$ is the result of applying $\defdecl$ to $\vd$
-        and $\idtwo$ included in the result of applying $\defenumlabels$ to $\vd$; and
-  \item a pair $(\idone, \idtwo)$ where $\idone$ is the result of applying $\defdecl$ to $\vd$
-        and $\idtwo$ included in the result of applying $\usedecl$ to $\vd$; and
-\end{enumerate}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{
-  {
-    \begin{array}{rcll}
-  \dependencies & \eqdef  & \{ (\idone, \idtwo) \;|\; \idone = \defdecl(\vd) \land \idtwo \in \defenumlabels(\vd) \} & \cup\\
-                &         & \{ (\idone, \idtwo) \;|\; \idone = \defdecl(\vd) \land \idtwo \in \usedecl(\vd) \}  &
-    \end{array}
-  }
-}{
-  \decldependencies(\vd) \typearrow \dependencies
 }
 \end{mathpar}
 
@@ -424,7 +263,7 @@ All of the following apply:
   \declaresubprograms(\genv, \envandfsone) \typearrow (\genvtwo, \envandfstwo) \OrTypeError\\\\
   {
     \begin{array}{r}
-  (\lenvtwo, \vf)\in\envandfstwo: \annotatesubprogram{(\genvtwo, \lenvtwo), \vf} \typearrow \\ \vfunc_\vf \OrTypeError
+  (\lenvtwo, \vf)\in\envandfstwo: \annotatesubprogram(\genvtwo, \lenvtwo), \vf) \typearrow \\ \vfunc_\vf \OrTypeError
     \end{array}
   }\\\\
   \vfsthree \eqdef [(\Ignore, \vf)\in\envandfstwo: \vfunc_\vf]\\
@@ -517,7 +356,8 @@ One of the following applies:
   \begin{itemize}
     \item $\vfuncs$ is the list with \head\ $\vf$ and \tail\ $\vfuncsone$;
     \item applying $\addsubprogram$ to $vf.\funcname$ and $\vf$ in $\tenv$ yields $\tenvone$;
-    \item applying $\addsubprogramdecls$ to $\tenvone$ and $\vfuncsone$ yields $(\newtenv, \vdeclsone)$;
+    \item applying $\addsubprogramdecls$ to $\tenvone$ and $\vfuncsone$ yields \\
+          $(\newtenv, \vdeclsone)$;
     \item define $\decls$ as the list with $\DFunc(\vf)$ as its \head\ and $\vdeclsone$ as its tail.
   \end{itemize}
 \end{itemize}
@@ -536,6 +376,82 @@ One of the following applies:
 }{
   \addsubprogramdecls(\tenv, \overname{\vf \concat \vfuncsone}{\vfuncs}) \typearrow
   (\newtenv, \overname{[\DFunc(\vf)] \concat \vdeclsone}{\decls})
+}
+\end{mathpar}
+
+\section{Establishing Def-Use Dependencies Between Global Declarations\label{sec:TopologicalOrdering}}
+We now define how to construct a graph of \defusedependenciesterm\ between the identifiers associated
+with global declarations.
+This is achieved by associating, for each declaration $d$, the set identifiers \emph{used} by $d$,
+which is formally defined by $\usedecl$, and the identifier \emph{defined} by $d$,
+which is formally defined by $\defdecl$.
+%
+The set of \defusedependenciesterm\ associated with a declaration $\vd$ is given by
+$\decldependencies(\vd)$ (see \nameref{sec:TypingRule.DeclDependencies}).
+
+\subsubsection{TypingRule.BuildDependencies \label{sec:TypingRule.BuildDependencies}}
+\hypertarget{def-builddependencies}{}
+The function
+\[
+\builddependencies(\overname{\decl^*}{\decls})
+\aslto
+(\overname{\identifier^*}{\defs}, \overname{(\identifier\times\identifier)^*}{\dependencies})
+\]
+takes a set of declarations $\decls$ and
+returns a graph whose set of nodes --- $\defs$ --- consists of the identifiers that are used to name declarations
+and whose set of edges $\dependencies$ consists of pairs $(a,b)$
+where the declaration of $a$ uses an identifier defined by the declaration of $b$.
+We refer to this graph as the \emph{\dependencygraphterm} (of $\decls$).
+
+\subsubsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item define $\defs$ as the union of two sets:
+  \begin{enumerate}
+  \item the set of identifiers obtained by applying $\defdecl$ to each declaration in $\decls$;
+  \item the union of applying $\defenumlabels$ to each declaration in $\decls$.
+  \end{enumerate}
+  \item define $\dependencies$ as the union of applying $\decldependencies$ to each declaration in $\decls$.
+\end{itemize}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \defs \eqdef \{ \defdecl(\vd) \;|\; \vd \in \decls\} \cup \bigcup_{\vd\in\decls} \defenumlabels(\vd)\\
+  \dependencies \eqdef \bigcup_{\vd \in \decls} \decldependencies(\vd)
+}{
+  \builddependencies(\decls) \typearrow (\defs, \dependencies)
+}
+\end{mathpar}
+
+\subsubsection{TypingRule.DeclDependencies \label{sec:TypingRule.DeclDependencies}}
+\hypertarget{def-decldependencies}{}
+The function
+\[
+\decldependencies(\overname{\decl}{\vd}) \aslto \overname{(\identifier\times\identifier)^*}{\dependencies}
+\]
+returns the set of dependent pairs of identifiers $\dependencies$ induced by the declaration $\vd$.
+
+\subsubsection{Prose}
+Define $\dependencies$ as the union of the following two sets of pairs:
+\begin{enumerate}
+  \item a pair $(\idone, \idtwo)$, where $\idone$ is the result of applying $\defdecl$ to $\vd$
+        and $\idtwo$ included in the result of applying $\defenumlabels$ to $\vd$; and
+  \item a pair $(\idone, \idtwo)$ ,where $\idone$ is the result of applying $\defdecl$ to $\vd$
+        and $\idtwo$ included in the result of applying $\usedecl$ to $\vd$.
+\end{enumerate}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule{
+  {
+    \begin{array}{rcll}
+  \dependencies & \eqdef  & \{ (\idone, \idtwo) \;|\; \idone = \defdecl(\vd) \land \idtwo \in \defenumlabels(\vd) \} & \cup\\
+                &         & \{ (\idone, \idtwo) \;|\; \idone = \defdecl(\vd) \land \idtwo \in \usedecl(\vd) \}  &
+    \end{array}
+  }
+}{
+  \decldependencies(\vd) \typearrow \dependencies
 }
 \end{mathpar}
 
@@ -1750,159 +1666,174 @@ All of the following apply:
 }
 \end{mathpar}
 
-\subsubsection{TypingRule.SetBuiltin\label{sec:TypingRule.SetBuiltin}}
-The helper function
-\hypertarget{def-setbuiltin}{}
+\section{Ordering Global Declarations via Def-Use Dependencies\label{sec:Dependencies}}
+
+\hypertarget{def-graphtransitive}{}
+We denote the reflexive-transitive closure of a relation $E$ as $\graphtransitive{E}$.
+
+\begin{definition}[Strongly Connected Components]
+\hypertarget{def-scc}{}
+Given a graph $G=(V, E)$, a \\ subset of its nodes $C \subseteq V$ is called
+a \emph{strongly connected component} of $G$ if
+every pair of nodes $u,v \in C$ reachable from one another.
+
+The \emph{strongly connected components} of a graph $(V, E)$ uniquely partitions its set of
+nodes $V$ into a set of strongly connected components:
 \[
-  \setbuiltin(\overname{\decl}{\vdecl}) \aslto
-  \overname{\decl}{\vdeclp}
-  \cup \overname{\TTypeError}{\TypeErrorConfig}
+\SCC(V, E) \triangleq \{ C \subseteq V \;|\; \forall u,v\in C.\ (u,v), (v,u) \in E^* \} \enspace.
 \]
-sets the $\funcbuiltin$ flag of a top-level function declaration, which is used to identify standard library functions in \secref{TypingRule.InsertStdlibParam}.
-It produces a type error when given a top-level declaration which is not a function.
+\end{definition}
+
+\hypertarget{def-topologicalorderingcomps}{}
+\begin{definition}[Topological Ordering of Components]
+For a non-empty graph \\
+$G=(V, E)$ and its strongly connected components $\comps \triangleq \SCC(V, E)$,
+a listing of $\comps$ ---
+$C_{1..k}$ --- is a \emph{topological ordering of components},
+denoted \\
+$C_{1..k} \in \topologicalorderingcomps(\comps, E)$, if the following condition holds:
+\[
+  \forall 1 \leq i \leq j \leq k.\ \exists c_i\in C_i.\ c_j\in C_j.\ (c_i,c_j) \in \graphtransitive{E} \;\;\Longrightarrow\;\;
+  i \leq j \enspace .
+\]
+\end{definition}
+
+\subsubsection{TypingRule.DeclsOfComp \label{sec:TypingRule.DeclsOfComp}}
+\hypertarget{def-declsofcomp}{}
+The helper function
+\[
+\declsofcomp(
+  \overname{\pow{\identifier}}{\comp} \aslsep
+  \overname{\decl^*}{\decls}
+) \aslto \overname{\decl^*}{\compdecls}
+\]
+filters $\decls$ in order to retain the declarations whose identifiers are members of $\comp$,
+yielding $\compdecls$
+
+\subsubsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{empty}):
+  \begin{itemize}
+    \item $\decls$ is the empty list;
+    \item define $\compdecls$ as the empty list.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{non\_empty}):
+  \begin{itemize}
+    \item $\decls$ is the list with \head\ $\vd$ and \tail\ $declsone$;
+    \item define $\declstwo$ as the singleton list for $\vd$ if applying $\defdecl$ to $\vd$ yields an identifier
+          that is a member of $\comp$ and the empty list, otherwise;
+    \item applying $\declsofcomp$ to $\comp$ and $\declsone$ yields $\declsthree$;
+    \item define $\compdecls$ as the concatenation of $\declstwo$ and $\declsthree$.
+  \end{itemize}
+\end{itemize}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule[empty]{}{
+  \declsofcomp(\comp, \overname{\emptylist}{\decls}) \typearrow \overname{\emptylist}{\compdecls}
+}
+\and
+\inferrule[non\_empty]{
+  \declstwo \eqdef \choice{\defdecl(\vd) \in \comp}{[\vd]}{\emptylist}\\
+  \declsofcomp(\comp, \declsone) \typearrow \declsthree
+}{
+  \declsofcomp(\comp, \overname{[\vd]\concat\declsone}{\decls}) \typearrow \overname{\declstwo\concat\declsthree}{\compdecls}
+}
+\end{mathpar}
+
+\section{Semantics of Specifications\label{sec:SemanticsOfSpecifications}}
+The semantics of specifications is defined via the relation $\evalspec$, which is defined next.
+
+\subsubsection{SemanticsRule.EvalSpec\label{sec:SemanticsRule.EvalSpec}}
+The relation
+\hypertarget{def-evalspec}{}
+\[
+  \evalspec(\overname{\staticenvs}{\tenv} \aslsep \overname{\spec}{\vspec}) \;\aslrel\;
+   ((\overname{\tint}{\vv}\times \overname{\XGraphs}{\vg}) \cup \overname{\TDynError}{\DynErrorConfig})
+\]
+evaluates the specification $\vspec$ with the static environment $\tenv$,
+yielding the native integer value $\vv$ and execution graph $\vg$.
+Otherwise, the result is a dynamic error.
 
 \subsubsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item view $\vdecl$ as a function, that is, $\DFunc(\funcsig)$\ProseOrTypeError;
-  \item define $\funcsigp$ as $\funcsig$ with its $\funcbuiltin$ flag set to $\True$;
-  \item $\vdeclp$ is $\DFunc(\funcsigp)$.
-\end{itemize}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \vdecl \eqname \DFunc(\funcsig) \OrTypeError \\
-  \funcsigp \eqdef \funcsig[\funcbuiltin \mapsto \True]
-}{
-  \setbuiltin(\vdecl) \typearrow \DFunc(\funcsigp)
-}
-\end{mathpar}
-
-\section{Semantics}
-The rule SemanticsRule.TopLevel (see \secref{SemanticsRule.TopLevel})
-evaluates entire specifications with the help of the following rules:
-\begin{itemize}
-  \item SemanticsRule.EvalGlobals (see \secref{SemanticsRule.EvalGlobals});
-  \item SemanticsRule.BuildGlobalEnv (see \secref{SemanticsRule.BuildGlobalEnv}).
-\end{itemize}
-
-\subsubsection{SemanticsRule.TopLevel \label{sec:SemanticsRule.TopLevel}}
-The relation
-\hypertarget{def-evalspec}{}
-\[
-  \evalspec(\overname{\spec}{\parsedast}, \overname{\spec}{\parsedstd}) \;\aslrel\;
-   ((\overname{\vals}{\vv}\times \overname{\XGraphs}{\vg}) \cup \overname{\TDynError}{\DynErrorConfig})
-\]
-evaluates the \texttt{main} function in a given specification and standard library.
-
-The function $\typecheckast$ (see \secref{TypingRule.TypeCheckAST})
-takes an initial typing environment and a untyped AST and returns a corresponding typed AST and typing
-environment.
-
-\subsubsection{Prose}
-  All of the following apply:
+  \item \Prosebuildgenv{$\tenv$}{$\spec$}{$\env$}{$\vg$}\ProseOrError;
+  \item One of the following applies:
   \begin{itemize}
-    \item define $\parsedstdp$ by applying $\setbuiltin$ to each top-level declaration in the AST for the parsed standard library $\parsedstdp$\ProseOrTypeError;
-    \item the AST for the parsed specification, $\parsedspec$, and AST for the parsed standard library,
-    $\parsedstdp$, are concatenated to give $\parsedast$;
-    \item applying the type-checker to $\parsedast$ with an empty static environment yields
-    $(\typedspec, \tenv)$;
-    \item populating the environment with the declarations of the global storage elements
-          by applying $\buildgenv$ to $\typedspec$ and the environment where the static environment is $\tenv$
-          and the dynamic environment is the empty environment ($\emptydenv$) yields $(\env, \vgone)$\ProseOrError;
-    \item One of the following applies:
+    \item All of the following apply (\textsc{normal}):
     \begin{itemize}
-      \item All of the following apply (\textsc{normal}):
-      \begin{itemize}
-        \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
-        in $\env$ is $\Normal([(\vv, \vgtwo)], \Ignore)$\ProseOrError;
-        \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\aslpo$ edge;
-        \item the result of the entire evaluation is $(\vv, \newg)$.
-      \end{itemize}
+      \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
+      in $\env$ yields $\Normal([(\vv, \vgtwo)], \Ignore)$\ProseOrError;
+      \item $\vg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\aslpo$ edge;
+      \item the result of the entire evaluation is $(\vv, \vg)$.
+    \end{itemize}
 
-      \item All of the following apply (\textsc{throwing}):
-      \begin{itemize}
-        \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
-        in $\env$ is $\Throwing(\texttt{v\_opt}, \Ignore)$, which is an uncaught exception;
-        \item the result of the entire evaluation is an error indicating that an exception was not caught.
-      \end{itemize}
+    \item All of the following apply (\textsc{throwing}):
+    \begin{itemize}
+      \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
+      in $\env$ yields $\Throwing(\vvopt, \Ignore)$, which is an uncaught exception;
+      \item the result of the entire evaluation is an error indicating that an exception was not caught.
     \end{itemize}
   \end{itemize}
-
-  \subsubsection{Example}
-
-  \CodeSubsection{\EvalTopLevelBegin}{\EvalTopLevelEnd}{../Interpreter.ml}
+\end{itemize}
 
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[normal]{
-  \vi \in \listrange(\parsedstd): \setbuiltin(\parsedstd_i) \typearrow \parsedstdp_i \OrTypeError\\
-  \parsedast \eqdef \parsedspec \concat \parsedstdp\\
-  \typecheckast(\emptytenv, \parsedast) \typearrow (\typedspec,\tenv)\\
-  \buildgenv(\typedspec, (\tenv, \emptydenv)) \evalarrow (\env, \vgone) \OrDynError\\\\
+  \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynError\\\\
   \evalsubprogram{\env, \texttt{"main"}, \emptylist, \emptylist} \evalarrow \Normal([(\vv, \vgtwo)], \Ignore) \OrDynError\\\\
-  \newg \eqdef \ordered{\vgone}{\aslpo}{\vgtwo}
-}
-{
-  \evalspec(\parsedast, \parsedstd) \evalarrow (\vv, \newg)
+  \vg \eqdef \ordered{\vgone}{\aslpo}{\vgtwo}
+}{
+  \evalspec(\tenv, \vspec) \evalarrow (\vv, \vg)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[throwing]{
-  \vi \in \listrange(\parsedstd): \setbuiltin(\parsedstd_i) \typearrow \parsedstdp_i \OrTypeError\\
-  \parsedast \eqdef \parsedspec \concat \parsedstdp\\
-  \typecheckast(\emptytenv, \parsedast) \typearrow (\typedspec,\tenv)\\
-  \buildgenv(\typedspec, (\tenv, \emptydenv)) \evalarrow (\env, \vgone)\\
-  \evalsubprogram{\env, \texttt{"main"}, \emptylist, \emptylist} \evalarrow \Throwing(\texttt{v\_opt}, \Ignore)
-}
-{
-  \evalspec(\parsedspec, \parsedstd) \evalarrow \ErrorVal{UncaughtException}
+  \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynError\\\\
+  \evalsubprogram{\env, \texttt{"main"}, \emptylist, \emptylist} \evalarrow \Throwing(\vvopt, \Ignore)
+}{
+  \evalspec(\tenv, \vspec) \evalarrow \ErrorVal{UncaughtException}
 }
 \end{mathpar}
-Notice that when the type-checker fails due to a type error in the given specification,
-the corresponding premise in the rule above does not hold, and the semantics
-is undefined. Indeed, the ASL semantics is only defined for well-typed specifications.
-
+\CodeSubsection{\EvalSpecBegin}{\EvalSpecEnd}{../Interpreter.ml}
 
 \subsubsection{SemanticsRule.BuildGlobalEnv\label{sec:SemanticsRule.BuildGlobalEnv}}
 The helper relation
 \hypertarget{def-buildgenv}{}
 \[
-  \buildgenv(\overname{\envs}{\env}, \overname{\spec}{\typedspec}) \;\aslrel\;
+  \buildgenv(\overname{\staticenvs}{\tenv}, \overname{\spec}{\typedspec}) \;\aslrel\;
   (\overname{\envs}{\newenv}\times\overname{\XGraphs}{\newg}) \cup \overname{\TDynError}{\DynErrorConfig}
 \]
-populates the environment and output execution graph with the global
-storage declarations.
-This works by traversing the global storage declarations in \emph{dependency order}
-and updating the environment accordingly. By dependency order, we mean that if
-a declaration $b$ refers to an identifier declared in $a$ then $a$ is evaluated
-before $b$.
+populates the environment $\env$ and output execution graph $\newg$ with the global
+storage declarations in $\typedspec$, starting from the static environment $\tenv$.
+This works by traversing the global storage declarations
+and updating the environment accordingly.
+\ProseOtherwiseDynamicError
+
+It is assumed that $\typedspec$ lists the declarations in reverse order with respect
+to the \defusedependencyterm\ order
+(see \nameref{sec:TypingRule.TypeCheckAST}).
 
 \subsubsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item sorting the declarations of the global storage elements in topological order with respect to the dependency order
-  gives $\vdecls$;
-  \item evaluating the global storage declarations in $\vdecls$ in $\env$ with the empty execution graph
-  is $(\newenv, \newg)$\ProseOrError.
+  \item define the environment $\env$ as consisting of the static environment $\tenv$ and the empty dynamic environment $\emptydenv$;
+  \item evaluating the global storage declarations in $\typedspec$ in $\env$ with the empty execution graph
+        is $(\newenv, \newg)$\ProseOrError.
   \item the result of the entire evaluation is $(\newenv, \newg)$.
 \end{itemize}
-\subsubsection{Example}
 
 \subsubsection{Formally}
-\hypertarget{def-topologicaldecls}{}
-The helper relation $\topologicaldecls(\overname{\decl^*}{\parsedspec}, \overname{\decl^*}{\parsedstd})$
-accepts a specification and returns the subset of global storage declarations ordered by
-dependency order.
-
 \begin{mathpar}
 \inferrule{
-  \topologicaldecls(\typedspec) \evalarrow \vdecls\\
-  \evalglobals(\vdecls, (\env, \emptygraph)) \evalarrow (\newenv, \newg) \OrDynError
+  \env \eqdef (\tenv, \emptydenv)\\
+  \evalglobals(\typedspec, (\env, \emptygraph)) \evalarrow (\newenv, \newg) \OrDynError
 }{
-  \buildgenv(\env, \typedspec) \evalarrow (\newenv, \newg)
+  \buildgenv(\tenv, \typedspec) \evalarrow (\newenv, \newg)
 }
 \end{mathpar}
 \CodeSubsection{\EvalBuildGlobalEnvBegin}{\EvalBuildGlobalEnvEnd}{../Interpreter.ml}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -1009,11 +1009,6 @@ All of the following apply:
 }
 \end{mathpar}
 \CodeSubsection{\SCallBegin}{\SCallEnd}{../Typing.ml}
-
-\subsubsection{Comments}
-Notice that the input statement, which belongs to the untyped AST, has two children nodes ---
-$\name$ and $\vargs$, whereas the output statement, which belongs to the typed AST has the additional
-node $\neweqs$, which associates expressions with parameters.
 \lrmcomment{This is related to \identd{VXKM}.}
 
 \subsection{Semantics}

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -102,7 +102,7 @@ We note that a parametric production can be either a normal derivation or an inl
 
 For example, the derivation for a list of ASL global declarations is as follows:
 \begin{flalign*}
-\Nast \derives\ & \maybeemptylist{\Ndecl} &
+\Nspec \derives\ & \maybeemptylist{\Ndecl} &
 \end{flalign*}
 It is defined via the parametric production for possibly-empty lists:
 \begin{flalign*}
@@ -118,9 +118,9 @@ The result of the expansion is then:
 \Ndecllist   \derives\ & \emptysentence \;|\; \Ndecl \parsesep \Ndecllist &\\
 \end{flalign*}
 The new symbol is substituted anywhere $\maybeemptylist{\Ndecl}$ appears in the original grammar,
-which results in the following derivation replacing the original derivation for $\Nast$:
+which results in the following derivation replacing the original derivation for $\Nspec$:
 \begin{flalign*}
-\Nast \derives\ & \Ndecllist &
+\Nspec \derives\ & \Ndecllist &
 \end{flalign*}
 
 % For example,
@@ -210,7 +210,7 @@ We define the following parametric productions for various types of lists and op
 \end{flalign*}
 
 \section{ASL Grammar\label{sec:ASLGrammar}}
-We now present the list of derivations for the ASL Grammar where the start non-terminal is $\Nast$.
+We now present the list of derivations for the ASL Grammar where the start non-terminal is $\Nspec$.
 %
 The derivations allow certain parse trees where lists may have invalid sizes.
 Those parse trees must be rejected in a later phase.
@@ -223,21 +223,16 @@ and can be ignored upon first reading.
 For brevity, tokens are presented via their label only, dropping their associated value.
 For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 
-\hypertarget{def-nast}{}
+\hypertarget{def-nspec}{}
 \begin{flalign*}
-\Nast   \derives\ & \maybeemptylist{\Ndecl} &
-\end{flalign*}
-
-\hypertarget{def-nrecurselimit}{}
-\begin{flalign*}
-\Nrecurselimit   \derivesinline\ & \Trecurselimit \parsesep \Nexpr &\\
-|\              & \emptysentence &\\
+\Nspec   \derives\ & \maybeemptylist{\Ndecl} &
 \end{flalign*}
 
 \hypertarget{def-ndecl}{}
 \hypertarget{def-funcdecl}{}
 \begin{flalign*}
-\Ndecl  \derivesinline\ & \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nreturntype \parsesep \Nrecurselimit \parsesep \Nfuncbody &
+\Ndecl  \derivesinline\ & \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nreturntype \parsesep \Nrecurselimit \parsesep &\\
+                        & \wrappedline\ \Nfuncbody
 \hypertarget{def-proceduredecl}{}\\
 |\ & \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nfuncbody &
 \hypertarget{def-getter}{}\\
@@ -256,6 +251,12 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&
 \hypertarget{def-globalpragma}{}\\
 |\ & \Tpragma \parsesep \Tidentifier \parsesep \Clist{\Nexpr} \parsesep \Tsemicolon&
+\end{flalign*}
+
+\hypertarget{def-nrecurselimit}{}
+\begin{flalign*}
+\Nrecurselimit   \derivesinline\ & \Trecurselimit \parsesep \Nexpr &\\
+|\              & \emptysentence &\\
 \end{flalign*}
 
 \hypertarget{def-nsubtype}{}
@@ -656,7 +657,7 @@ A \emph{parse tree} has one of the following forms:
 (In the literature, parse trees are also referred to as \emph{derivation trees}.)
 
 \begin{definition}[Well-formed Parse Trees]
-A parse tree is \emph{well-formed} if its root is labelled by the start non-terminal ($\Nast$ for ASL)
+A parse tree is \emph{well-formed} if its root is labelled by the start non-terminal ($\Nspec$ for ASL)
 and each non-terminal node $N(n_{1..k})$ corresponds to a grammar derivation
 $N \derives l_{1..k}$ where $l_i$ is the label of node $n_i$ if it is a non-terminal node and $n_i$
 itself when it is a token.
@@ -683,7 +684,7 @@ We denote the set of well-formed parse trees for a non-terminal symbol $S$ by $\
 \hypertarget{def-aslparse}{}
 A parser is a function
 \[
-\aslparse : (\Token^* \setminus \{\Terror\}) \aslto \parsenode{\Nast} \cup \{\ParseError\}
+\aslparse : (\Token^* \setminus \{\Terror\}) \aslto \parsenode{\Nspec} \cup \{\ParseError\}
 \]
 \hypertarget{def-parseerror}{}
 where $\ParseError$ stands for a \emph{parse error}.

--- a/asllib/doc/TopLevel.tex
+++ b/asllib/doc/TopLevel.tex
@@ -1,0 +1,106 @@
+\chapter{Top Level\label{chap:TopLevel}}
+In previous chapters, we defined the following components:
+\begin{itemize}
+    \item Lexical analysis (\chapref{LexicalStructure}),
+    \item Parsing (\chapref{Syntax}),
+    \item AST building (\secref{BuildingAbstractSyntaxTrees}),
+    \item Type checking (\secref{TypingSpecifications}), and
+    \item Semantic evaluation (\secref{SemanticsOfSpecifications}).
+\end{itemize}
+
+In this chapter, we show how these components can be combined to form an interpreter
+for an ASL standard library and a given ASL specification.
+%
+We emphasize that this is only an example usage of the components listed above.
+One can think of other combinations where, for example, semantic evaluation is
+replaced with a translation to a hardware description language.
+
+\hypertarget{def-checkandinterpret}{}
+The relation
+\[
+\checkandinterpret(\overname{\Strings}{\vspectext}, \overname{\Strings}{\vstdtext}) \aslrel
+\left(
+    \begin{array}{cc}
+        (\overname{\tint}{\vret} \times \overname{\XGraphs}{\vg})   & \cup\\
+        \{\ \LexicalError, \ParseError, \BuildErrorConfig\ \}    & \cup\\
+        \overname{\TTypeError}{\TypeErrorConfig}    & \cup\\
+        \overname{\TDynError}{\DynErrorConfig}      &
+    \end{array}
+\right)
+\]
+accepts a textual description of a specification in $\vspectext$ and a textual description of the standard library in $\vstdtext$.
+The descriptions are statically checked for validity.
+If found invalid, an error configuration corresponding to the phase where the error
+exists is returned --- scanning, parsing, or AST building.
+If found valid, an AST is built and semantically evaluated, yielding an integer return code $\vret$ and an execution graph $\vg$,
+or a dynamic error.
+
+\subsubsection{TopLevelRule.CheckAndInterpret}
+\subsubsection{Prose}
+All of the following apply:
+\begin{itemize}
+    \item \Proseaslscan{$\vstdtext$}{$\spectoken$}{$\vstdtokens$\ProseTerminateAs{\LexicalError}};
+    \item \Proseaslparse{$\vstdtokens$}{$\vstdparse$\ProseTerminateAs{\ParseError}};
+    \item \Prosebuildast{$\vstdparse$}{$\vstdast$\ProseTerminateAs{\BuildErrorConfig}};
+    \item define $\vstdasbuiltin$ by applying $\setbuiltin$ to each top-level declaration in\\
+          $\vstdast$\ProseOrTypeError;
+    %%%%%
+    \item \Proseaslscan{$\vspectext$}{$\spectoken$}{$\vspectokens$\ProseTerminateAs{\LexicalError}};
+    \item \Proseaslparse{$\vspectokens$}{$\vspecparse$\ProseTerminateAs{\ParseError}};
+    \item \Prosebuildast{$\vspecparse$}{$\vspecast$\ProseTerminateAs{\BuildErrorConfig}};
+    %%%%%
+    \item define $\vuntypedast$ as the concatenation of the AST $\vstdasbuiltin$ and
+          the AST $\vspecast$ (both are lists of $\decl$);
+    \item \Prosetypecheckast{$\vuntypedast$}{empty static global environment}{$\vtypedast$}{$\tenv$\ProseOrTypeError};
+    \item \Proseevalspec{$\vtypedast$}{$\tenv$}{the integer $\vret$ and the execution graph $\vg$\ProseOrError}.
+\end{itemize}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule{
+    \aslscan(\spectoken, \vstdtext) \scanarrow \vstdtokens \terminateas \LexicalError\\\\
+    \aslparse(\vstdtokens) \parsearrow \vstdparse \terminateas \ParseError\\\\
+    \buildast(\vstdparse) \astarrow \vstdast \terminateas \BuildErrorConfig\\\\
+    \vi \in \listrange(\vstdast): \setbuiltin(\vstdast_i) \typearrow \vstddeclast_i \OrTypeError\\\\
+    \vstdasbuiltin \eqdef [\vi \in \listrange(\vstdast): \vstddeclast_i]\\
+    \aslscan(\spectoken, \vspectext) \scanarrow \vspectokens \terminateas \LexicalError\\\\
+    \aslparse(\vspectokens) \parsearrow \vspecparse \terminateas \ParseError\\\\
+    \buildast(\vspecparse) \astarrow \vspecast \terminateas \BuildErrorConfig\\\\
+    \vuntypedast \eqdef \vstdasbuiltin \concat \vspecast\\
+    \typecheckast(G^{\emptytenv}, \vuntypedast) \typearrow (\vtypedast, \tenv) \OrTypeError\\\\
+    \evalspec(\tenv, \vtypedast) \evalarrow (\nvint(\vret), \vg) \OrDynError
+}{
+    \checkandinterpret(\vspectext, \vstdtext) \longrightarrow (\nvint(\vret), \vg)
+}
+\end{mathpar}
+
+\subsubsection{TypingRule.SetBuiltin\label{sec:TypingRule.SetBuiltin}}
+The helper function
+\hypertarget{def-setbuiltin}{}
+\[
+  \setbuiltin(\overname{\decl}{\vdecl}) \aslto
+  \overname{\decl}{\vdeclp}
+  \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+sets the $\funcbuiltin$ flag of a top-level function declaration, which is used to identify standard library functions in \secref{TypingRule.InsertStdlibParam}.
+It produces a type error when given a top-level declaration which is not a function.
+
+\subsubsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item \Prosechecktrans{that $\vdecl$ is a function}{\BuiltinExpectedToBeFunction};
+  \item view $\vdecl$ as $\DFunc(\funcsig)$;
+  \item define $\funcsigp$ as $\funcsig$ with its $\funcbuiltin$ flag set to $\True$;
+  \item define $\vdeclp$ as $\DFunc(\funcsigp)$.
+\end{itemize}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \checktrans{\astlabel(\vdecl) = \DFunc}{\BuiltinExpectedToBeFunction} \typearrow \True \OrTypeError\\\\
+  \vdecl \eqname \DFunc(\funcsig)\\
+  \funcsigp \eqdef \funcsig[\funcbuiltin \mapsto \True]
+}{
+  \setbuiltin(\vdecl) \typearrow \DFunc(\funcsigp)
+}
+\end{mathpar}

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -1,7 +1,7 @@
 \chapter{Type System Utility Rules\label{chap:TypeSystemUtilityRules}}
 
-\subsection{Checked Transitions}
 \hypertarget{def-checktrans}{}
+\subsection{Checked Transitions}
 We define the following rules to allow us asserting that a condition holds,
 returning a type error otherwise:
 \begin{mathpar}

--- a/asllib/doc/introduction.tex
+++ b/asllib/doc/introduction.tex
@@ -1,12 +1,10 @@
 \chapter{Introduction\label{chap:Introduction}}
 
-The increasing importance of the Arm architecture coupled with the increasing use of formal verification of both
-hardware and software make it important to have a readable, precise way of describing the majority of the Arm
-architecture. This reference defines Arm’s Architecture Specification Language (ASL), which is the language
+This reference defines Arm’s Architecture Specification Language (ASL), which is the language
 used in Arm’s architecture reference manuals to describe the Arm architecture.
 
-ASL is designed and used to specify architectures. As a formal
-specification language it is designed to be accessible, understandable, and unambiguous to programmers, hardware
+ASL is designed and used to specify architectures. As a specification language, it is designed to be accessible,
+understandable, and unambiguous to programmers, hardware
 engineers, and hardware verification engineers, who collectively have quite a small intersection of languages they
 all understand. It can intentionally under specify behaviors in the architecture being described.
 
@@ -84,7 +82,7 @@ More specifically, a specification is the set of declarations written in ASL cod
 \begin{itemize}
     \item A function \texttt{Dot8} which operates on 2 bitvectors a byte at a time.
     \item A global variable \texttt{COUNT} to indicate the number of calls to the \texttt{Fib} function.
-    \item A function \texttt{Fib} demonstrating recursion.
+    \item A function \texttt{Fib} demonstrating recursion with a bound of 1000 on its depth.
     \item Assignment of a global bitvector \texttt{X} with a call to the \texttt{Dot8} function.
     \item Assignment of a variable from the result of a call to the recursive function \texttt{Fib}.
     \item A function \texttt{main}.

--- a/asllib/gparser0.ml
+++ b/asllib/gparser0.ml
@@ -164,12 +164,12 @@ let parse_repeatable parse lexer_state lexbuf : AST.t =
 let ast_chunk lexbuf =
   let lexer = Lexer0.token () in
   let lexer_state = RL.of_lexer_lexbuf is_eof lexer lexbuf in
-  let r = parse_repeatable Parser0.Incremental.ast lexer_state lexbuf in
+  let r = parse_repeatable Parser0.Incremental.spec lexer_state lexbuf in
   if false then Printf.eprintf "Chunk of size %d\n" (List.length r);
   r
 
 (** The main entry-point for this module. Should be usable as a drop-in
-    replacement for [Parser0.ast]. *)
+    replacement for [Parser0.spec]. *)
 
 (* Set [as_chunks] to false parsing ASL files as a whole *)
 
@@ -197,7 +197,7 @@ let ast (lexer : lexbuf -> token) (lexbuf : lexbuf) : AST.t =
     List.concat (List.rev asts)
   else
     let lexer_state = RL.of_lexer_lexbuf is_eof lexer lexbuf in
-    parse_repeatable Parser0.Incremental.ast lexer_state lexbuf
+    parse_repeatable Parser0.Incremental.spec lexer_state lexbuf
 
 let opn (lexer : lexbuf -> token) (lexbuf : lexbuf) : AST.t =
   let () =

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -104,7 +104,7 @@ module SemanticsRule = struct
     | CatchOtherwise
     | CatchNone
     | CatchNoThrow
-    | TopLevel
+    | Spec
     | FindCatcher
     | RethrowImplicit
     | ReadValueFrom
@@ -191,7 +191,7 @@ module SemanticsRule = struct
     | CatchOtherwise -> "CatchOtherwise"
     | CatchNone -> "CatchNone"
     | CatchNoThrow -> "CatchNoThrow"
-    | TopLevel -> "TopLevel"
+    | Spec -> "Spec"
     | FindCatcher -> "FindCatcher"
     | RethrowImplicit -> "RethrowImplicit"
     | ReadValueFrom -> "ReadValueFrom"
@@ -281,7 +281,7 @@ module SemanticsRule = struct
       CatchOtherwise;
       CatchNone;
       CatchNoThrow;
-      TopLevel;
+      Spec;
       FindCatcher;
       RethrowImplicit;
       ReadValueFrom;
@@ -438,9 +438,7 @@ module TypingRule = struct
     | TBitFields
     | ReduceSlicesToCall
     | TypeOfArrayLength
-    | TypecheckFunc
-    | TypecheckGlobalStorage
-    | TypecheckTypeDecl
+    | TypecheckDecl
     | AnnotateAndDeclareFunc
     | AnnotateFuncSig
     | CheckSetterHasGetter
@@ -621,9 +619,7 @@ module TypingRule = struct
     | TBitFields -> "TBitFields"
     | ReduceSlicesToCall -> "ReduceSlicesToCall"
     | TypeOfArrayLength -> "TypeOfArrayLength"
-    | TypecheckFunc -> "TypecheckFunc"
-    | TypecheckGlobalStorage -> "TypecheckFunc"
-    | TypecheckTypeDecl -> "TypecheckTypeDecl"
+    | TypecheckDecl -> "TypecheckDecl"
     | AnnotateAndDeclareFunc -> "AnnotateAndDeclareFunc"
     | AnnotateFuncSig -> "AnnotateFuncSig"
     | CheckSetterHasGetter -> "CheckSetterHasGetter"
@@ -786,9 +782,7 @@ module TypingRule = struct
       TBitFields;
       ReduceSlicesToCall;
       TypeOfArrayLength;
-      TypecheckFunc;
-      TypecheckGlobalStorage;
-      TypecheckTypeDecl;
+      TypecheckDecl;
       AnnotateAndDeclareFunc;
       AnnotateFuncSig;
       CheckSetterHasGetter;

--- a/asllib/tests/ASLDefinition.t/spec3.asl
+++ b/asllib/tests/ASLDefinition.t/spec3.asl
@@ -11,7 +11,7 @@ var X: bits(16) = '1010 1111 0101 0000';
 
 var COUNT: integer = 0;
 
-func Fib(n: integer) => integer
+func Fib(n: integer) => integer recurselimit 1000
 begin
     COUNT = COUNT + 1;
     if n < 2 then

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchNoThrow.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CatchNoThrow.asl
@@ -11,6 +11,7 @@ begin
       otherwise =>
         assert FALSE;
     end;
+    print("No exception raised");
 
   return 0;
 end;

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -171,6 +171,7 @@ ASL Semantics Reference:
     provided integer {2}.
   [1]
   $ aslref SemanticsRule.CatchNoThrow.asl
+  No exception raised
   $ aslref SemanticsRule.EConcat2.asl
   $ aslref SemanticsRule.LEGlobalVar.asl
   $ aslref SemanticsRule.SCond2.asl

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -256,7 +256,7 @@ module Make (C : Config) = struct
     let to_int_signed = wrap_op1_symb_as_var (Op.ArchOp1 ASLOp.ToIntS)
 
     (**************************************************************************)
-    (* Special monad interations                                              *)
+    (* Special monad interactions                                              *)
     (**************************************************************************)
 
     let create_barrier b ii = M.mk_singleton_es (Act.Barrier b) ii >>! []


### PR DESCRIPTION
* Renamed the grammar non-terminal `ast` to `spec`.
* Added a new chapter that shows how scanning, parsing, type-checking, and semantic evaluation can be combined together to implement an ASL interpreter.
* Unified all typing rules for global declarations into a single rule with case rules.
* Started employing a `\ProseF` macro for a function/relation `\F` to standardize the prose for each occurrence of `\F` and to lower the chance of typos/errors.
* Reworked dependencies and topological ordering and added explanations.
* Fixed wording in disclaimer per request from Jade.
* Fixed Fibonaci example in introduction to include a recursion limit, per request from Chris January.
