### PR TITLE
[asl] Pending constrained integers

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -238,6 +238,8 @@ and constraint_kind =
   | WellConstrained of int_constraint list
       (** An integer type constrained from ASL syntax: it is the union of each
           constraint in the list. *)
+  | PendingConstrained
+      (** An integer type whose constraint will be inferred during type-checking. *)
   | Parameterized of uid * identifier
       (** A parameterized integer, the default type for parameters of
           function at compile time, with a unique identifier and the variable

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -235,7 +235,7 @@ and use_slices slices = use_list use_slice slices
 and use_ty t =
   match t.desc with
   | T_Named s -> ISet.add s
-  | T_Int (UnConstrained | Parameterized _)
+  | T_Int (UnConstrained | Parameterized _ | PendingConstrained)
   | T_Enum _ | T_Bool | T_Real | T_String ->
       Fun.id
   | T_Int (WellConstrained cs) -> use_constraints cs
@@ -744,7 +744,8 @@ let rename_locals map_name ast =
     | Slice_Star (e1, e2) -> Slice_Star (map_e e1, map_e e2)
   and map_t t =
     map_desc_st' t @@ function
-    | T_Real | T_String | T_Bool | T_Enum _ | T_Named _ | T_Int UnConstrained ->
+    | T_Real | T_String | T_Bool | T_Enum _ | T_Named _
+    | T_Int (UnConstrained | PendingConstrained) ->
         t.desc
     | T_Int (Parameterized _) ->
         failwith "Not yet implemented: obfuscate parametrized types"

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -482,7 +482,7 @@ module DeterministicBackend = struct
             NV_Literal (L_BitVector (Bitvector.zeros (Z.to_int n)))
         | _ -> (* Bad types *) assert false)
     | T_Enum _ | T_Tuple _ | T_Array _ | T_Record _ | T_Exception _ | T_Named _
-      ->
+    | T_Int PendingConstrained ->
         assert false
 
   let deterministic_unknown_of_type ~eval_expr_sef =

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -169,6 +169,7 @@ and pp_ty f t =
   | T_Int UnConstrained -> pp_print_string f "integer"
   | T_Int (WellConstrained cs) ->
       fprintf f "@[integer {%a}@]" pp_int_constraints cs
+  | T_Int PendingConstrained -> pp_print_string f "integer{-}"
   | T_Int (Parameterized (_uid, var)) -> fprintf f "@[integer {%s}@]" var
   | T_Real -> pp_print_string f "real"
   | T_String -> pp_print_string f "string"

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -297,7 +297,9 @@ let colon_for_type == COLON | COLON_COLON
 (* Constrained types helpers *)
 
 let constraint_kind_opt == constraint_kind | { UnConstrained }
-let constraint_kind == ~=braced(clist(int_constraint)); < WellConstrained >
+let constraint_kind ==
+  | ~=braced(nclist(int_constraint)); < WellConstrained >
+  | braced(MINUS); { PendingConstrained }
 
 let int_constraint ==
   | ~=expr;                     < Constraint_Exact >

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -222,6 +222,7 @@ and pp_int_constraints f = function
   | WellConstrained cs ->
       addb f "WellConstrained ";
       pp_list pp_int_constraint f cs
+  | PendingConstrained -> addb f "PendingConstrained"
   | Parameterized (i, x) -> bprintf f "Parameterized (%d, %S)" i x
 
 let rec pp_lexpr =

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -575,6 +575,7 @@
 \newcommand\intconstraint[0]{\hyperlink{ast-intconstraint}{\textsf{int\_constraint}}}
 \newcommand\unconstrained[0]{\hyperlink{ast-unconstrained}{\textsf{Unconstrained}}}
 \newcommand\wellconstrained[0]{\hyperlink{ast-wellconstrained}{\textsf{WellConstrained}}}
+\newcommand\pendingconstrained[0]{\hyperlink{ast-pendingconstrained}{\textsf{PendingConstrained}}}
 \newcommand\parameterized[0]{\hyperlink{ast-parameterized}{\textsf{Parameterized}}}
 \newcommand\constraintexact[0]{\hyperlink{ast-constraintexact}{\textsf{Constraint\_Exact}}}
 \newcommand\constraintrange[0]{\hyperlink{ast-constraintrange}{\textsf{Constraint\_Range}}}
@@ -1397,6 +1398,7 @@
 \newcommand\unconstrainedintegertype[0]{\hyperlink{def-unconstrainedintegertype}{unconstrained integer type}}
 \newcommand\parameterizedintegertype[0]{\hyperlink{def-parameterizedintegertype}{parameterized integer type}}
 \newcommand\wellconstrainedintegertype[0]{\hyperlink{def-wellconstrainedintegertype}{well-constrained integer type}}
+\newcommand\pendingconstrainedintegertype[0]{\hyperlink{def-pendingconstrainedintegertype}{pending constrained integer type}}
 \newcommand\structuredtype[0]{\hyperlink{def-structuredtype}{structured type}}
 \newcommand\structure[0]{\hyperlink{def-structure}{structure}}
 \newcommand\underlyingtype[0]{\hyperlink{def-underlyingtype}{underlying type}}
@@ -1611,6 +1613,7 @@
 \newcommand\BaseValueEmptyType[0]{\hyperlink{def-bvet}{\TypeErrorCode{BVET}}}
 \newcommand\NonReturningFunction[0]{\hyperlink{def-nrf}{\TypeErrorCode{NRF}}}
 \newcommand\BuiltinExpectedToBeFunction[0]{\hyperlink{def-bef}{\TypeErrorCode{BEF}}}
+\newcommand\UnexpectedPendingConstrained[0]{\hyperlink{def-upc}{\TypeErrorCode{UPC}}}
 
 %% Dynamic Error Codes
 \newcommand\DynamicErrorVal[1]{\Error(\texttt{#1})}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -323,6 +323,8 @@ as indicated by respective comments.
   & \hypertarget{ast-wellconstrained}{}\\
   |\ & \wellconstrained(\intconstraint^{+})
   % & & \ASTComment{An integer type with explicit constraints.}
+  & \hypertarget{ast-pendingconstrained}{}\\
+  |\ & \pendingconstrained{}
   & \hypertarget{ast-parameterized}{}\\
   |\ & \parameterized(\overtext{\identifier}{parameter}) &
   % & & \ASTComment{Implicitly constrained integer from function declaration.} \\

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -226,6 +226,11 @@ This error indicates an attempt to list a top-level declaration that is not a fu
 in the standard library
 (see \nameref{sec:TypingRule.SetBuiltin}).
 
+\hypertarget{def-upc}{}
+\item[$\UnexpectedPendingConstrained$]
+This error indicates that a \pendingconstrainedintegertype{} has been encountered where one is not permitted.
+(see \nameref{sec:TypingRule.TInt}).
+
 \end{description}
 
 \section{Dynamic Error Codes}

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -323,14 +323,15 @@ The helper function
 \typearrow \lhsp \cup\ \overname{\TTypeError}{\TypeErrorConfig}
 \]
 propagates integer constraints from the right-hand side type $\rhs$ to the left-hand side type annotation $\lhs$.
-It can fail with a type error.
+In particular, each occurence of \pendingconstrainedintegertype{} on the left-hand side should inherit constraints from a corresponding \wellconstrainedintegertype{} on the right-hand side.
+If the corresponding right-hand side type is not a \wellconstrainedintegertype{} (including if it is an \unconstrainedintegertype{}), the result is a type error.
 
 \subsubsection{Prose}
 One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{int}):
   \begin{itemize}
-    \item $\lhs$ is a \wellconstrainedintegertype{} with no constraints;
+    \item $\lhs$ is a \pendingconstrainedintegertype{};
     \item $\rhs$ is a \wellconstrainedintegertype{}\ProseOrTypeError;
     \item $\lhsp$ is $\rhs$.
   \end{itemize}
@@ -346,7 +347,7 @@ One of the following applies:
 
   \item All of the following apply (\textsc{other}):
   \begin{itemize}
-    \item $\lhs$ is not a \wellconstrainedintegertype{} with no constraints, or one of $\lhs$ and $\rhs$ is not a tuple type;
+    \item $\lhs$ is not a \pendingconstrainedintegertype{}, or one of $\lhs$ and $\rhs$ is not a tuple type;
     \item $\lhsp$ is $\lhs$.
   \end{itemize}
 \end{itemize}
@@ -356,7 +357,7 @@ One of the following applies:
 \inferrule[int]{
   \rhs \eqname \TInt(\wellconstrained(\Ignore)) \OrTypeError
 }{
-  \inheritintegerconstraints(\overname{\TInt(\wellconstrained(\emptylist))}{\lhs}, \rhs) \typearrow \overname{\rhs}{\lhsp}
+  \inheritintegerconstraints(\overname{\TInt(\pendingconstrained)}{\lhs}, \rhs) \typearrow \overname{\rhs}{\lhsp}
 }
 \end{mathpar}
 
@@ -373,7 +374,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[other]{
-  \lhs \neq \TInt(\wellconstrained(\Ignore)) \;\lor\; \astlabel(\lhs) \neq \TTuple \;\lor\; \astlabel(\rhs) \neq \TTuple
+  \lhs \neq \TInt(\pendingconstrained) \;\lor\; \astlabel(\lhs) \neq \TTuple \;\lor\; \astlabel(\rhs) \neq \TTuple
 }{
   \inheritintegerconstraints(\lhs, \rhs) \typearrow \overname{\lhs}{\lhsp}
 }

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -650,7 +650,7 @@ One of the following applies:
 
   \item All of the following apply (\textsc{int\_no\_constraints}):
   \begin{itemize}
-    \item $\vt$ is either the unconstrained integer type or a \parameterizedintegertype;
+    \item $\vt$ is either the unconstrained integer type or a \parameterizedintegertype{} or a \pendingconstrainedintegertype;
     \item define $\ids$ as the empty set.
   \end{itemize}
 

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -469,7 +469,9 @@ it must declare a new variable.
 
 \hypertarget{def-nintconstraints}{}
 \begin{flalign*}
-\Nconstraintkind \derivesinline\ & \Tlbrace \parsesep \Clist{\Nintconstraint} \parsesep \Trbrace &
+\Nconstraintkind \derivesinline\ &
+       \Tlbrace \parsesep \NClist{\Nintconstraint} \parsesep \Trbrace &\\
+  |\ & \Tlbrace \parsesep \Tminus \parsesep \Trbrace &
 \end{flalign*}
 
 \hypertarget{def-nintconstraint}{}

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -680,7 +680,7 @@ One of the following applies:
 
   \item All of the following apply (\textsc{unconstrained}):
   \begin{itemize}
-    \item $\vt$ is an unconstrained integer;
+    \item $\vt$ is an unconstrained integer or pending constrained integer;
     \item the result is a type error indicating that a constrained integer type is expected.
   \end{itemize}
 
@@ -707,9 +707,11 @@ One of the following applies:
   \checkconstrainedinteger(\tenv, \TInt(\parameterized(\Ignore))) \typearrow \True
 }
 \and
-\inferrule[unconstrained]{}
+\inferrule[unconstrained]{
+  \astlabel(\vc) = \unconstrained \;\lor\; \astlabel{\vc} = \pendingconstrained
+}
 {
-  \checkconstrainedinteger(\tenv, \TInt(\unconstrained(\Ignore))) \typearrow \\
+  \checkconstrainedinteger(\tenv, \TInt(\vc)) \typearrow \\
   \TypeErrorVal{ConstrainedIntegerExpected}
 }
 \and
@@ -730,6 +732,7 @@ One of the following applies:
         Specifically, the \hypertarget{def-unconstrainedintegertype}{\unconstrainedintegertype}.
   \item A constrained type with a non-empty constraint is \emph{well-constrained}.
   \hypertarget{def-parameterizedintegertype}
+  \item A \hypertarget{def-pendingconstrainedintegertype}{\emph{\pendingconstrainedintegertype}} is an integer type whose constraints will be inferred during type checking.
   \item A \emph{\parameterizedintegertype} is an implicit type of a subprogram parameter.
   \end{itemize}
 The widths of bitvector storage elements are constrained integers.

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -78,6 +78,7 @@ expressions and statements.
 \Nty \derives\ & \Tinteger \parsesep \Nconstraintkindopt &\\
 \Nconstraintkindopt \derivesinline\ & \Nconstraintkind \;|\; \emptysentence &\\
 \Nconstraintkind \derivesinline\ & \Tlbrace \parsesep \NClist{\Nintconstraint} \parsesep \Trbrace &\\
+|\ & \Tlbrace \parsesep \Tminus \parsesep \Trbrace &\\
 \Nintconstraint \derivesinline\ & \Nexpr &\\
 |\ & \Nexpr \parsesep \Tslicing \parsesep \Nexpr &
 \end{flalign*}
@@ -88,6 +89,8 @@ expressions and statements.
 \constraintkind \derives\ & \unconstrained
 & \\
 |\ & \wellconstrained(\intconstraint^{+})
+& \\
+|\ & \pendingconstrained{}
 & \\
 |\ & \parameterized(\overtext{\identifier}{parameter}) &\\
 \intconstraint \derives\ & \ConstraintExact(\expr)
@@ -138,7 +141,7 @@ The function
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
-\inferrule{
+\inferrule[well\_constrained]{
   \buildclist[\buildintconstraint](\vconstraintasts) \astarrow \vconstraintasts
 }{
   {
@@ -147,6 +150,13 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
   \overname{\wellconstrained(\vconstraintasts)}{\vastnode}
     \end{array}
   }
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[pending\_constrained]{}{
+  \buildconstraintkind(\Nconstraintkind(\Tlbrace, \Tminus, \Trbrace)) \astarrow
+  \overname{\pendingconstrained}{\vastnode}
 }
 \end{mathpar}
 
@@ -190,15 +200,15 @@ One of the following applies:
       \item $\tty$ is an integer type that is not well-constrained;
       \item $\newty$ is the unconstrained integer type.
     \end{itemize}
-  \item All of the following apply (\textsc{well\_constrained\_empty}):
+  \item All of the following apply (\textsc{pending\_constrained}):
     \begin{itemize}
-      \item $\tty$ is the well-constrained integer type with no constraints;
-      \item the result is a type error.
+      \item $\tty$ is a \pendingconstrainedintegertype;
+      \item the result is a type error (\UnexpectedPendingConstrained).
     \end{itemize}
   \item All of the following apply (\textsc{well\_constrained}):
     \begin{itemize}
       \item $\tty$ is the well-constrained integer type constrained by
-        non-empty constraints $\vc_i$, for $u=1..k$;
+        constraints $\vc_i$, for $u=1..k$;
       \item annotating each constraint $\vc_i$, for $i=1..k$,
       yields $\newc_i$\ProseOrTypeError;
       \item $\newconstraints$ is the list of annotated constraints $\newc_i$,
@@ -220,20 +230,18 @@ In the following examples, all the uses of integer types are well-typed:
 \begin{mathpar}
 \inferrule[not\_well\_constrained]{
   \tty \eqname \TInt(\vc)\\
-  \astlabel(\vc) \neq \wellconstrained
+  \astlabel(\vc) \notin \{\wellconstrained,\pendingconstrained\}
 }{
   \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \tty} \typearrow \overname{\tty}{\newty}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[well\_constrained\_empty]{
-  \constraints \eqname \emptylist
-}{
+\inferrule[pending\_constrained]{}{
   {
     \begin{array}{r}
-  \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\TInt(\wellconstrained(\emptylist))}{\tty}} \typearrow
-  \TypeErrorConfig
+  \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\TInt(\pendingconstrained)}{\tty}} \typearrow
+  \TypeErrorVal{\UnexpectedPendingConstrained}
     \end{array}
   }
 }
@@ -241,7 +249,6 @@ In the following examples, all the uses of integer types are well-typed:
 
 \begin{mathpar}
 \inferrule[well\_constrained]{
-  \listlen{\constraints} > 0\\
   \constraints \eqname \vc_{1..k}\\
   i=1..k: \annotateconstraint(\vc_i) \typearrow\newc_i \OrTypeError\\\\
   \newconstraints \eqdef \newc_{1..k}

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -81,6 +81,7 @@ type error_desc =
   | LoopLimitReached
   | RecursionLimitReached
   | EmptyConstraints
+  | UnexpectedPendingConstrained
 
 type error = error_desc annotated
 
@@ -166,6 +167,7 @@ let error_label = function
   | LoopLimitReached -> "LoopLimitReached"
   | RecursionLimitReached -> "RecursionLimitReached"
   | EmptyConstraints -> "EmptyConstraints"
+  | UnexpectedPendingConstrained -> "UnexpectedPendingConstrained"
 
 let warning_label = function
   | NoLoopLimit -> "NoLoopLimit"
@@ -402,7 +404,10 @@ module PPrint = struct
     | EmptyConstraints ->
         fprintf f
           "ASL Typing error:@ a@ well-constrained@ integer@ cannot@ have@ \
-           empty@ constraints.");
+           empty@ constraints."
+    | UnexpectedPendingConstrained ->
+        pp_print_text f
+          "ASL Typing error: a pending constrained integer is illegal here.");
     pp_close_box f ()
 
   let pp_warning_desc f w =

--- a/asllib/tests/regressions.t/inherit-integer-constraints-bad-basic.asl
+++ b/asllib/tests/regressions.t/inherit-integer-constraints-bad-basic.asl
@@ -1,6 +1,6 @@
 func bad_basic() => integer{43}
 begin
-  let x : integer{} = 42;
+  let x : integer{-} = 42;
   return x;
 end;
 

--- a/asllib/tests/regressions.t/inherit-integer-constraints-bad-tuple.asl
+++ b/asllib/tests/regressions.t/inherit-integer-constraints-bad-tuple.asl
@@ -1,6 +1,6 @@
 func bad_tuple() => (integer{42}, integer{0})
 begin
-  let y : (integer{}, boolean, integer{}) = (42, TRUE, 43);
+  let y : (integer{-}, boolean, integer{-}) = (42, TRUE, 43);
   return (y.item0, y.item2);
 end;
 

--- a/asllib/tests/regressions.t/inherit-integer-constraints-bad-type.asl
+++ b/asllib/tests/regressions.t/inherit-integer-constraints-bad-type.asl
@@ -1,5 +1,5 @@
 type badtype of record {
-    a : integer{},
+    a : integer{-},
     c : integer
 };
 

--- a/asllib/tests/regressions.t/inherit-integer-constraints.asl
+++ b/asllib/tests/regressions.t/inherit-integer-constraints.asl
@@ -2,20 +2,20 @@ type foo of (integer{1}, boolean);
 
 func good_basic() => integer{42}
 begin
-  let x : integer{} = 42;
+  let x : integer{-} = 42;
   return x;
 end;
 
 func good_tuple() => (integer{42}, integer{43})
 begin
-  let y : (integer{}, boolean, integer{}) = (42, TRUE, 43);
+  let y : (integer{-}, boolean, integer{-}) = (42, TRUE, 43);
   return (y.item0, y.item2);
 end;
 
 func good_named_tuple() => (integer{1}, boolean)
 begin
   var f : foo;
-  let z : (integer{}, boolean) = f;
+  let z : (integer{-}, boolean) = f;
   return z;
 end;
 

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -425,5 +425,5 @@ Inherit integer constraints on left-hand sides
   $ aslref inherit-integer-constraints-bad-type.asl
   File inherit-integer-constraints-bad-type.asl, line 1, character 0 to line 4,
     character 2:
-  ASL Typing error: a well-constrained integer cannot have empty constraints.
+  ASL Typing error: a pending constrained integer is illegal here.
   [1]

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -316,6 +316,7 @@ module Domain = struct
         FromSyntax [ Constraint_Exact (var_ var) ]
     | T_Int (WellConstrained constraints) ->
         int_set_of_int_constraints env constraints
+    | T_Int PendingConstrained -> assert false
     | T_Bool | T_String | T_Real ->
         failwith "Unimplemented: domain of primitive type"
     | T_Bits _ | T_Enum _ | T_Array _ | T_Exception _ | T_Record _ | T_Tuple _
@@ -395,6 +396,7 @@ module Domain = struct
       match t.desc with
       | T_Real | T_String | T_Int (UnConstrained | Parameterized _) ->
           assert_under approx acc (* We can't iterate on all of those. *)
+      | T_Int PendingConstrained -> assert false
       | T_Int (WellConstrained cs) -> constraints_fold approx env f cs acc
       | T_Bool -> acc |> f (L_Bool true) |> f (L_Bool false)
       | T_Bits (e_len, _) ->


### PR DESCRIPTION
This PR iterates on https://github.com/herd/herdtools7/pull/1056. In particular, that PR used the `integer{}` syntax (AST: `WellConstrained []`) to inherit integer constraints from right-hand sides to left-hand sides. However, `integer{}` could be confused with a hypothetical "empty" set of constraints, and the changes to the reference documents and AST did not help this.

This PR replaces this with the `integer{-}` syntax, which parses to a new AST node `PendingConstrained : constraint_kind`. Similarly, reference documentation refers to these integers as "pending constrained". This should avoid the confusion above. This therefore partially reverts the PR above, but not fully.