### PR TITLE
[herd] Add support for SVC instruction

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -88,7 +88,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     *   Arm ARM B2.2.5 "Concurrent modification and execution of instructions"
     *)
     let is_cmodx_restricted_instruction = function
-    | I_B _| I_BL _| I_CBNZ _| I_CBZ _| I_FENCE ISB | I_NOP | I_TBNZ _| I_TBZ _
+    | I_B _| I_BL _| I_CBNZ _| I_CBZ _| I_FENCE ISB | I_NOP | I_TBNZ _| I_TBZ _ | I_SVC _
       -> false
     | I_ADD_SIMD _| I_ADD_SIMD_S _| I_ADR _| I_ALIGND _| I_ALIGNU _| I_BC _
     | I_BLR _| I_BR _| I_BUILD _| I_CAS _| I_CASBH _| I_CASP _| I_CHKEQ _| I_CHKSLD _
@@ -298,7 +298,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDOPBH (_,v,_,_,_,_) | I_STOPBH (_,v,_,_,_) ->
           Some (bh_to_sz v)
       | I_NOP|I_B _|I_BR _|I_BC (_, _)|I_CBZ (_, _, _)
-      | I_CBNZ (_, _, _)|I_BL _|I_BLR _|I_RET _|I_ERET|I_LDAR (_, _, _, _)
+      | I_CBNZ (_, _, _)|I_BL _|I_BLR _|I_RET _|I_ERET| I_SVC _ | I_LDAR (_, _, _, _)
       | I_TBNZ(_,_,_,_) | I_TBZ (_,_,_,_) | I_MOVZ (_,_,_,_) | I_MOVK(_,_,_,_)
       | I_MOVN _
       | I_MOV (_, _, _)|I_SXTW (_, _)|I_OP3 (_, _, _, _, _)
@@ -355,7 +355,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_FENCE _
       | I_IC _|I_DC _|I_TLBI _
       | I_NOP|I_TBZ _|I_TBNZ _
-      | I_BL _ | I_BLR _ | I_RET _ | I_ERET | I_UDF _
+      | I_BL _ | I_BLR _ | I_RET _ | I_ERET | I_SVC _ | I_UDF _
       | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
       | I_ST1SPT _
         -> [] (* For -variant self only ? *)
@@ -441,7 +441,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_STXR _|I_STXRBH _ | I_STXP _ -> MachSize.St
       | I_LDAR (_, (AA|AQ), _, _)|I_LDARBH (_, (AA|AQ), _, _)
       | I_NOP|I_B _|I_BR _|I_BC _|I_CBZ _|I_CBNZ _
-      | I_TBNZ _|I_TBZ _|I_BL _|I_BLR _|I_RET _|I_ERET
+      | I_TBNZ _|I_TBZ _|I_BL _|I_BLR _|I_RET _|I_ERET | I_SVC _
       | I_UBFM _ | I_SBFM _
       | I_LDR _|I_LDRSW _|I_LDRS _|I_LDUR _|I_LD1 _|I_LDAP1 _
       | I_LD1M _|I_LD1R _|I_LD2 _|I_LD2M _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -3324,6 +3324,14 @@ module Make
              fun () -> read_reg_ord AArch64.elr_el1 ii >>=
              eret_to_addr
 
+        | I_SVC _ ->
+          let (>>!) = M.(>>!) in
+          let ft = Some FaultType.AArch64.SupervisorCall in
+          let m_fault = mk_fault None Dir.R Annot.N ii ft None in
+          let lbl_v = get_instr_label ii in
+          let lbl_ret = get_link_addr test ii in
+          m_fault >>| set_elr_el1 lbl_ret ii >>! B.Fault [AArch64Base.elr_el1, lbl_v]
+
         | I_CBZ(_,r,l) ->
             (read_reg_ord r ii)
               >>= is_zero

--- a/herd/tests/instructions/AArch64/A259.litmus
+++ b/herd/tests/instructions/AArch64/A259.litmus
@@ -1,0 +1,9 @@
+AArch64 A259
+Variant=fatal
+{
+}
+ P0         ;
+L0:         ;
+    SVC #0  ;
+L1:         ;
+forall(Fault(P0:L0,SupervisorCall))

--- a/herd/tests/instructions/AArch64/A259.litmus.expected
+++ b/herd/tests/instructions/AArch64/A259.litmus.expected
@@ -1,0 +1,10 @@
+Test A259 Required
+States 1
+ Fault(P0:L0,SupervisorCall);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0:L0,SupervisorCall))
+Observation A259 Always 1 0
+Hash=4091dac82d97298f370a841c62bd669c
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -299,7 +299,7 @@ include Arch.MakeArch(struct
     end in
 
     function
-    | (I_FENCE _|I_NOP|I_RET None|I_ERET|I_UDF _) as i -> unitT i
+    | (I_FENCE _|I_NOP|I_RET None|I_ERET|I_SVC _|I_UDF _) as i -> unitT i
     | I_B l ->
         find_lab l >! fun l -> I_B l
     | I_BR r ->

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -407,6 +407,8 @@ match name with
 | "stuminlh"|"STUMINLH" -> STOPBH (A.H,A.A_UMIN,A.W_L)
 | "stuminb"|"STUMINB" -> STOPBH (A.B,A.A_UMIN,A.W_P)
 | "stuminlb"|"STUMINLB" -> STOPBH (A.B,A.A_UMIN,A.W_L)
+(* SupervisorCall *)
+| "svc"|"SVC" -> SVC
 (* Undefined *)
 | "udf"|"UDF" -> UDF
 (* Memory Tagging *)

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -87,6 +87,7 @@ let check_op3 op e =
 %token TOK_CS TOK_CC TOK_MI TOK_PL TOK_VS TOK_VC TOK_HI TOK_LS TOK_AL
 %token BEQ BNE BGE BGT BLE BLT BCS BCC BMI BPL BVS BVC BHI BLS BAL
 %token BL BLR RET ERET
+%token SVC
 %token LDR LDRSW LDP LDNP LDPSW LDIAPP STP STNP STILP
 %token LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
 %token LDRSB LDRSH
@@ -1549,6 +1550,8 @@ instr:
   { I_MRS ($2,$4) }
 | MSR SYSREG COMMA xreg
   { I_MSR ($2,$4) }
+| SVC NUM
+  { I_SVC (MetaConst.Int $2) }
 | UDF NUM
   { I_UDF (MetaConst.Int $2) }
 

--- a/lib/faultType.ml
+++ b/lib/faultType.ml
@@ -34,6 +34,7 @@ module type AArch64Sig = sig
     | MMU of mmu_t
     | TagCheck
     | UndefinedInstruction
+    | SupervisorCall
 
   include S with type t := t
 end
@@ -53,6 +54,7 @@ module AArch64 = struct
     | MMU of mmu_t
     | TagCheck
     | UndefinedInstruction
+    | SupervisorCall
 
   let sets = [
       "MMU", [MMU Translation;
@@ -63,12 +65,14 @@ module AArch64 = struct
       "Permission", [MMU Permission];
       "TagCheck", [TagCheck];
       "UndefinedInstruction",[UndefinedInstruction];
+      "SupervisorCall", [SupervisorCall];
     ]
 
   let pp = function
     | MMU m -> Printf.sprintf "MMU:%s" (pp_mmu_t m)
     | TagCheck -> "TagCheck"
     | UndefinedInstruction -> "UndefinedInstruction"
+    | SupervisorCall -> "SupervisorCall"
 
   let parse = function
     | "MMU:Translation" -> MMU Translation
@@ -76,6 +80,7 @@ module AArch64 = struct
     | "MMU:Permission" -> MMU Permission
     | "TagCheck" -> TagCheck
     | "UndefinedInstruction" -> UndefinedInstruction
+    | "SupervisorCall" -> SupervisorCall
     | _ as s -> Warn.user_error "%s not a valid fault type" s
 
   let is s = try ignore (parse s); true  with  _ -> false

--- a/lib/faultType.mli
+++ b/lib/faultType.mli
@@ -34,6 +34,7 @@ module type AArch64Sig = sig
     | MMU of mmu_t
     | TagCheck
     | UndefinedInstruction
+    | SupervisorCall
 
   include S with type t := t
 end

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1960,6 +1960,9 @@ module Make(V:Constant.S)(C:Config) =
       I_SEAL _|I_STCT _|I_UNSEAL _ ->
         Warn.fatal "No litmus output for instruction %s"
             (dump_instruction ins)
+    | I_SVC kk ->
+      let memo = sprintf "svc #%i" kk  in
+        { empty_ins with memo; }::k
     | I_UDF _ ->
         { empty_ins with memo = ".word 0"; }::k
 

--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -9,13 +9,22 @@ static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
   fault_info_t flt;
   unsigned long far;
 
+  flt.type = get_fault_type(esr);
+
+  if (flt.type == FaultSupervisorCall) {
+    // SVC, SMC and HVC return address points to the next instruction
+    // after the exception generating instruction. For the purposes
+    // of fault recording, we are interested in the instruction that
+    // generated the fault.
+    pc -= 4;
+  }
+
   flt.instr_symb = get_instr_symb_id(lbls, (ins_t *)pc);
   if (get_far(esr, &far)) {
     flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
   } else {
     flt.data_symb = DATA_SYMB_ID_UNKNOWN;
   }
-  flt.type = get_fault_type(esr);
 
   if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {
     return;
@@ -49,9 +58,11 @@ static void fault_handler(struct pt_regs *regs,unsigned int esr) {
 static void install_fault_handler(int cpu) {
   install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
   install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_SVC64, fault_handler);
 #ifdef USER_MODE
   struct thread_info *ti = thread_info_sp(user_stack[cpu]);
   ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
   ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = fault_handler;
 #endif
 }

--- a/litmus/libdir/_aarch64/kvm_fault_type.c
+++ b/litmus/libdir/_aarch64/kvm_fault_type.c
@@ -2,6 +2,7 @@
 
 enum fault_type_t {
   FaultUndefinedInstruction,
+  FaultSupervisorCall,
   FaultMMUAddressSize,
   FaultMMUTranslation,
   FaultMMUAccessFlag,
@@ -14,6 +15,7 @@ enum fault_type_t {
 
 static const char *fault_type_names[] = {
   "UndefinedInstruction",
+  "SupervisorCall",
   "MMU:AddressSize",
   "MMU:Translation",
   "MMU:AccessFlag",
@@ -31,6 +33,8 @@ static enum fault_type_t get_fault_type(unsigned long esr)
   ec = esr >> ESR_EL1_EC_SHIFT;
   if (ec == ESR_EL1_EC_UNKNOWN) {
     return FaultUndefinedInstruction;
+  } else if (ec == ESR_EL1_EC_SVC64) {
+    return FaultSupervisorCall;
   } else {
     dfsc = esr & 0x3fU;
     fault_type = (dfsc >> 2) + FaultMMUAddressSize;


### PR DESCRIPTION
This commit extends the herd7 model to support litmus tests with SVC instructions.