### PR TITLE
Small fixes for ASL Reference

### DIFF
--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -864,7 +864,7 @@ This is useful in that it allows us to use assertions in rule macros.
 \subsection{Rule Naming}
 To name a rule, we place it in a section with its name.
 However, some relations are defined by a group of rules.
-\hypertarget{def-caserules}
+\hypertarget{def-caserules}{}
 In such cases, we refer to the individual rules in a group as \emph{case rules},
 or simply \emph{cases}. We annotate case rules by names
 appearing above and to the left of the rule. The name of these case rules

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -395,7 +395,7 @@ All of the following apply:
 \end{mathpar}
 \CodeSubsection{\EvalLEDestructuringBegin}{\EvalLEDestructuringEnd}{../Interpreter.ml}
 
-\subsubsection{SemanticsRule.LEMultiAssign\label{sec:SemanticsRuleLEMultiAssign}}
+\subsubsection{SemanticsRule.LEMultiAssign\label{sec:SemanticsRule.LEMultiAssign}}
 \subsubsection{Prose}
 The helper relation
 \hypertarget{def-evalmultiassign}{}

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -596,7 +596,7 @@ is defined by the following table:
 \[
 \begin{array}{|c|c|c|c|}
   \hline
-  \textbf{\maskmatch} & 0 & 1 & \vx\\
+  \textbf{$\maskmatch$} & 0 & 1 & \vx\\
   \hline
   0 & \True & \False & \True\\
   \hline

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -93,7 +93,7 @@ type subInt of integer subtypes superInt;
 \lrmcomment{This is related to \identr{NXRX}, \identi{KGKS}, \identi{MTML}, \identi{JVRM}, \identi{CHMP}.}
 
 \subsection{TypingRule.SubtypeSatisfaction\label{sec:TypingRule.SubtypeSatisfaction}}
-\hypertarget{def-subtypesat}
+\hypertarget{def-subtypesat}{}
 The predicate
 \[
   \subtypesat(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -19,7 +19,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Typing}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\hypertarget{def-annotatecall}
+\hypertarget{def-annotatecall}{}
 The function
 \[
   \annotatecall(

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -20,7 +20,7 @@ In proof-theoretic terms, we can say that our equivalence tests are \emph{sound}
 
 Notice that for a conservative test, it is always correct to return $\False$.
 
-\hypertarget{def-unsupportedexpression}
+\hypertarget{def-unsupportedexpression}{}
 In this chapter, we use the special value $\CannotBeTransformed$
 to represent a failure in transforming an expression into a desired form (the specific
 desired form varies according to the functions utilizing this value).

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -171,7 +171,7 @@ We also define the following helper rules:
   \item TypingRule.DeclareConst (see \secref{TypingRule.DeclareConst})
 \end{itemize}
 
-\subsubsection{TypingRuleDeclareType \label{sec:TypingRule.DeclareType}}
+\subsubsection{TypingRule.DeclareType \label{sec:TypingRule.DeclareType}}
 \hypertarget{def-declaretype}{}
 The function
 \[
@@ -244,7 +244,7 @@ All of the following apply:
 }
 \end{mathpar}\lrmcomment{This is related to \identr{DHRC}, \identd{YZBQ}, \identr{DWSP}, \identi{MZXL}, \identr{MDZD}, \identr{CHKR}.}
 
-\subsubsection{TypingRuleAnnotateExtraFields \label{sec:TypingRule.AnnotateExtraFields}}
+\subsubsection{TypingRule.AnnotateExtraFields \label{sec:TypingRule.AnnotateExtraFields}}
 \hypertarget{def-annotateextrafields}{}
 The function
 \[
@@ -355,7 +355,7 @@ One of the following applies:
 }
 \end{mathpar}
 
-\subsubsection{TypingRuleAnnotateTypeOpt \label{sec:TypingRule.AnnotateTypeOpt}}
+\subsubsection{TypingRule.AnnotateTypeOpt \label{sec:TypingRule.AnnotateTypeOpt}}
 \hypertarget{def-annotatetypeopt}{}
 The function
 \[
@@ -396,7 +396,7 @@ One of the following applies:
 }
 \end{mathpar}
 
-\subsubsection{TypingRuleAnnotateExprOpt \label{sec:TypingRule.AnnotateExprOpt}}
+\subsubsection{TypingRule.AnnotateExprOpt \label{sec:TypingRule.AnnotateExprOpt}}
 \hypertarget{def-annotateexpropt}{}
 The function
 \[
@@ -438,7 +438,7 @@ One of the following applies:
 }
 \end{mathpar}
 
-\subsubsection{TypingRuleAnnotateInitType \label{sec:TypingRule.AnnotateInitType}}
+\subsubsection{TypingRule.AnnotateInitType \label{sec:TypingRule.AnnotateInitType}}
 \hypertarget{def-annotateinittype}{}
 The function
 \[
@@ -541,7 +541,7 @@ One of the following applies:
 }
 \end{mathpar}
 
-\subsubsection{TypingRuleAnnotateEnumLabels \label{sec:TypingRule.AnnotateEnumLabels}}
+\subsubsection{TypingRule.AnnotateEnumLabels \label{sec:TypingRule.AnnotateEnumLabels}}
 \hypertarget{def-annotateenumlabels}{}
 The function
 \[

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -38,7 +38,7 @@ a static domain that is equal to any of their dynamic domains.
 In those cases, we simply refer to their \emph{domain}.
 
 Associating a set of values to a type is done by evaluating any expression appearing
-in the type definitions. Evaluation is defined by the relation $\evalexprsef$.
+in the type definitions. Evaluation is defined by the relation $\evalexprsef\empty$.
 which evaluates side-effect-free expressions and either returns
 a configuration of the form $\Normal(\vv,\vg)$ or a dynamic error configuration $\DynErrorConfig$.
 In the first case, $\vv$ is a \nativevalue\ and $\vg$


### PR DESCRIPTION
These are flagged by `pandoc` and may also make sense for the upstream LaTeX tool.