### PR TITLE
[asl] Simplify V0 standard library

### DIFF
--- a/asllib/libdir/stdlib0.asl
+++ b/asllib/libdir/stdlib0.asl
@@ -2,30 +2,22 @@
 // Backwards compatibility for ASLv0
 
 bits(N) ReplicateBit(boolean isZero, integer N)
-  return if isZero then Zeros(N) else Ones(N);
+  return ReplicateBit{N}(isZero);
 
 bits(M*N) Replicate(bits(M) x, integer N)
-  if M == 1 then
-    return ReplicateBit(IsZero(x), M*N);
-  else
-    r = Zeros(M*N);
-    for i=0 to N-1
-        r<M*(i+1) - 1 : M*i> = x;
-    return r;
+  return Replicate{M*N,M}(x);
 
 bits(N) Zeros(integer N)
-  return 0<N-1:0>;
+  return Zeros{N}();
 
 bits(N) Ones(integer N)
-  return NOT Zeros(N);
+  return Ones{N}();
 
 bits(N) SignExtend(bits(M) x, integer N)
-  assert N >= M;
-  return Replicate(x<M-1>, N-M) : x;
+  return SignExtend{N,M}(x);
 
 bits(N) ZeroExtend(bits(M) x, integer N)
-  assert N >= M;
-  return Zeros(N-M) : x;
+  return ZeroExtend{N,M}(x);
 
 bits(N) Extend(bits(M) x, integer N, boolean unsigned)
-  return if unsigned then ZeroExtend(x, N) else SignExtend(x, N);
+  return Extend{N,M}(x, unsigned);


### PR DESCRIPTION
Using V0 grammar changes in https://github.com/herd/herdtools7/pull/1074, the V0 standard library functions used for backwards compatibility can simply call their V1 versions with appropriate parameter instantiations.