### PR TITLE
[herd,aarch64,asl] Simplify physical memory functions

### DIFF
--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -444,7 +444,7 @@ end;
 
 // =============================================================================
 
-func PhysMemWriteV1{N}(
+func PhysMemWrite{N}(
   desc::AddressDescriptor,
   accdesc::AccessDescriptor,
   value::bits(8*N)
@@ -461,7 +461,7 @@ end;
 
 // =============================================================================
 
-func PhysMemReadV1{N}(
+func PhysMemRead{N}(
   desc::AddressDescriptor,
   accdesc::AccessDescriptor
 ) => (PhysMemRetStatus, bits(8*N))

--- a/herd/libdir/asl-pseudocode/implementations0.asl
+++ b/herd/libdir/asl-pseudocode/implementations0.asl
@@ -28,14 +28,15 @@ _PC = bits(64) value
   return;
 
 // =============================================================================
-
+// Wrapper to the V1 function
 PhysMemRetStatus PhysMemWrite(AddressDescriptor desc, integer size, AccessDescriptor accdesc,
                               bits(8*size) value)
-  return PhysMemWriteV1{size}(desc,accdesc,value);
+  return PhysMemWrite{size}(desc,accdesc,value);
 
 // =============================================================================
+// Wrapper to the V1 function
 
 (PhysMemRetStatus, bits(8*size)) PhysMemRead(AddressDescriptor desc, integer size,
                                              AccessDescriptor accdesc)
-    (ret_status,value) = PhysMemReadV1{size}(desc,accdesc);
+    (ret_status,value) = PhysMemRead{size}(desc,accdesc);
     return (ret_status,value);


### PR DESCRIPTION
As they have different type signatures, those functions can have the same names. Inspired by PR #1084.