### PR TITLE
Remove `::` to denote types

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -271,7 +271,7 @@ let expr :=
     | ~=expr; IN; ~=pattern_set;                              < E_Pattern            >
     | ~=expr; EQ_OP; ~=pattern_mask;                          < E_Pattern            >
     | e=expr; NEQ; p=pattern_mask;                            { E_Pattern (e, Pattern_Not (p) |> add_pos_from p) }
-    | ARBITRARY; colon_for_type; ~=ty;                        < E_Arbitrary        >
+    | ARBITRARY; COLON; ~=ty;                                 < E_Arbitrary        >
     | e=pared(expr);                                          { E_Tuple [ e ]        }
 
     | t=annotated(IDENTIFIER); fields=braced(clist(field_assign));
@@ -285,8 +285,6 @@ let expr :=
                                 Types
 
   ------------------------------------------------------------------------- *)
-
-let colon_for_type == COLON | COLON_COLON
 
 (* Constrained types helpers *)
 
@@ -322,7 +320,7 @@ let expr_pattern :=
     | ~=expr_pattern; EQ_OP; ~=pattern_mask;                          < E_Pattern            >
     | e=expr_pattern; NEQ; p=pattern_mask;                            { E_Pattern (e, Pattern_Not (p) |> add_pos_from p) }
 
-    | ARBITRARY; colon_for_type; ~=ty;                                < E_Arbitrary        >
+    | ARBITRARY; COLON; ~=ty;                                         < E_Arbitrary        >
     | e=pared(expr_pattern);                                          { E_Tuple [ e ]        }
 
     | t=annotated(IDENTIFIER); fields=braced(clist(field_assign));
@@ -393,7 +391,7 @@ let ty_decl := ty |
 
 (* Constructs on ty *)
 (* Begin AsTy *)
-let as_ty := colon_for_type; ty
+let as_ty := COLON; ty
 (* End *)
 
 (* Begin TypedIdentifier *)

--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -310,9 +310,9 @@ type SCTLRType of bits(64) {
 // the global Exclusives monitor for processorid.
 
 func MarkExclusiveGlobal
-  (paddress :: FullAddress,
-  processorid :: integer,
-  size :: integer)
+  (paddress : FullAddress,
+  processorid : integer,
+  size : integer)
 begin
   return;
 end;
@@ -325,9 +325,9 @@ end;
 // the local Exclusives monitor for processorid.
 
 func MarkExclusiveLocal
-  (paddress :: FullAddress,
-  processorid :: integer,
-  size :: integer)
+  (paddress : FullAddress,
+  processorid : integer,
+  size : integer)
 begin
   return;
 end;
@@ -342,7 +342,7 @@ end;
 var RESADDR : bits(64);
 
 func AArch64_MarkExclusiveVA
-(address :: bits(64), processorid :: integer, size :: integer)
+(address : bits(64), processorid : integer, size : integer)
 begin
   RESADDR = address;
 end;
@@ -363,7 +363,7 @@ end;
 var SuccessVA : boolean ;
 
 func AArch64_IsExclusiveVA
-(address :: bits(64), processorid :: integer, size :: integer) => boolean
+(address : bits(64), processorid : integer, size : integer) => boolean
 begin
   // Try both possibilties: write or not write
   SuccessVA = SomeBoolean();
@@ -396,7 +396,7 @@ end;
 // the physical address region of size bytes starting at paddress.
 
 func IsExclusiveLocal
-(paddress :: FullAddres, processorid :: integer, size :: integer) => boolean
+(paddress : FullAddres, processorid : integer, size : integer) => boolean
 begin
   return TRUE;
 end;
@@ -409,7 +409,7 @@ end;
 // the physical address region of size bytes starting at paddress.
 
 func IsExclusiveGlobal
-(paddress :: FullAddres, processorid :: integer, size :: integer) => boolean
+(paddress : FullAddres, processorid : integer, size : integer) => boolean
 begin
   return TRUE;
 end;
@@ -421,7 +421,7 @@ end;
 // =====================
 // Clear the local Exclusives monitor for the specified processorid.
 
-func ClearExclusiveLocal(processorid :: integer)
+func ClearExclusiveLocal(processorid : integer)
 begin
   return;
 end;
@@ -437,7 +437,7 @@ end;
 
 // =============================================================================
 
-func IsFeatureImplemented(f :: Feature) => boolean
+func IsFeatureImplemented(f : Feature) => boolean
 begin
     return FALSE;
 end;
@@ -445,9 +445,9 @@ end;
 // =============================================================================
 
 func PhysMemWrite{N}(
-  desc::AddressDescriptor,
-  accdesc::AccessDescriptor,
-  value::bits(8*N)
+  desc:AddressDescriptor,
+  accdesc:AccessDescriptor,
+  value:bits(8*N)
 ) => PhysMemRetStatus
 begin
   write_memory_gen {N*8}(desc.vaddress, value,accdesc);
@@ -462,8 +462,8 @@ end;
 // =============================================================================
 
 func PhysMemRead{N}(
-  desc::AddressDescriptor,
-  accdesc::AccessDescriptor
+  desc:AddressDescriptor,
+  accdesc:AccessDescriptor
 ) => (PhysMemRetStatus, bits(8*N))
 begin
   let value = read_memory_gen {N*8}(desc.vaddress,accdesc);
@@ -496,7 +496,7 @@ end;
 // ========
 // Return TRUE if Exception level 'el' is supported
 
-func HaveEL(el:: bits(2)) => boolean
+func HaveEL(el: bits(2)) => boolean
 begin
     if el IN {EL1,EL0} then
         return TRUE;                             // EL1 and EL0 must exist
@@ -514,19 +514,19 @@ end;
 // It is IMPLEMENTATION DEFINED whether the global Exclusives monitor for processorid
 // is also cleared if it records any part of the address region.
 
-func ClearExclusiveByAddress(paddress :: FullAddress, processorid :: integer, size :: integer)
+func ClearExclusiveByAddress(paddress : FullAddress, processorid : integer, size : integer)
 begin
   pass;
 end;
 
 // =============================================================================
 
-getter _R (n :: integer) => bits(64)
+getter _R (n : integer) => bits(64)
 begin
   return read_register(n);
 end;
 
-setter _R (n :: integer) = value :: bits(64)
+setter _R (n : integer) = value : bits(64)
 begin
   write_register(n, value);
 end;

--- a/herd/libdir/asl-pseudocode/patches.asl
+++ b/herd/libdir/asl-pseudocode/patches.asl
@@ -34,7 +34,7 @@ The ARM Reference Manual is available here:
 // The whole logic is too complex for our simple use, so we return the base value of the return type.
 
 // MPAMinfo GenMPAMatEL(AccessType acctype, bits(2) el)
-func GenMPAMatEL(acctype:: AccessType, el::bits(2)) => MPAMinfo
+func GenMPAMatEL(acctype: AccessType, el:bits(2)) => MPAMinfo
 begin
   var x : MPAMinfo;
   return x;
@@ -48,12 +48,12 @@ end;
 // From https://developer.arm.com/documentation/ddi0602/2023-09/Shared-Pseudocode/shared-functions-common?lang=en#impl-shared.IsAligned.2
 // We disable alignment checks.
 
-func IsAligned{N}(x :: bits(N), y::integer) => boolean
+func IsAligned{N}(x : bits(N), y:integer) => boolean
 begin
   return TRUE;
 end;
 
-func IsAligned(x::integer, y::integer) => boolean
+func IsAligned(x:integer, y:integer) => boolean
 begin
   return TRUE;
 end;
@@ -66,7 +66,7 @@ end;
 // From https://developer.arm.com/documentation/ddi0602/2023-09/Shared-Pseudocode/shared-functions-memory?lang=en#impl-shared.BigEndian.1
 // We only use small-endian
 
-func BigEndian(acctype:: AccessType) => boolean
+func BigEndian(acctype: AccessType) => boolean
 begin
   return FALSE;
 end;
@@ -80,7 +80,7 @@ end;
 // From https://developer.arm.com/documentation/ddi0602/2023-09/Shared-Pseudocode/shared-functions-aborts?lang=en#impl-shared.IsFault.1
 // No fault is ever constructed with the associated address descriptors.
 
-func IsFault(addrdesc:: AddressDescriptor) => boolean
+func IsFault(addrdesc: AddressDescriptor) => boolean
 begin
   return FALSE;
 end;
@@ -94,7 +94,7 @@ end;
 // From https://developer.arm.com/documentation/ddi0602/2023-09/Shared-Pseudocode/aarch64-translation-vmsa-translation?lang=en#AArch64.TranslateAddress.4
 // We disable address translation
 
-func AArch64_TranslateAddress(address::bits(64), accdesc::AccessDescriptor, aligned::boolean, size::integer) => AddressDescriptor
+func AArch64_TranslateAddress(address:bits(64), accdesc:AccessDescriptor, aligned:boolean, size:integer) => AddressDescriptor
 begin
   var full_addr : FullAddress;
   return CreateAddressDescriptor(address, full_addr, NormalNCMemAttr());
@@ -112,7 +112,7 @@ end;
 // From https://developer.arm.com/documentation/ddi0602/2023-09/Shared-Pseudocode/shared-functions-system?lang=en#impl-shared.ELStateUsingAArch32K.2
 // We are always on AArch64
 
-func ELStateUsingAArch32K(el::bits(2), secure::boolean) => (boolean, boolean)
+func ELStateUsingAArch32K(el:bits(2), secure:boolean) => (boolean, boolean)
 begin
     return (TRUE, FALSE);
 end;

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus
@@ -7,15 +7,15 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let x0 = UInt(read_memory{64}(x));
   write_memory{64}(y, one);
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let x1 = UInt(read_memory{64}(y));
   write_memory{64}(x, one);

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus
@@ -7,9 +7,9 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(x);
   let x0 = UInt(read);
@@ -17,7 +17,7 @@ begin
   write_memory{64}(y, data);
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(y);
   let x1 = UInt(read);

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus
@@ -7,9 +7,9 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(x);
   let x0 = UInt(read);
@@ -17,7 +17,7 @@ begin
   write_memory{64}(y, data);
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let x1 = UInt(read_memory{64}(y));
   write_memory{64}(x, one);

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus
@@ -7,9 +7,9 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(x);
   let x0 = UInt(read);
@@ -17,12 +17,12 @@ begin
   write_memory{64}(y, data);
 end;
 
-func f(read::bits(64)) => bits(64)
+func f(read:bits(64)) => bits(64)
 begin
   return one;
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(y);
   let x1 = UInt(read);

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus
@@ -7,9 +7,9 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(x);
   let x0 = UInt(read);
@@ -17,12 +17,12 @@ begin
   write_memory{64}(y, data);
 end;
 
-func f(read::bits(64)) => bits(64)
+func f(read:bits(64)) => bits(64)
 begin
   return read[63:0] OR one;
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(y);
   let x1 = UInt(read);

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus
@@ -7,9 +7,9 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(x);
   let x0 = UInt(read);
@@ -17,14 +17,14 @@ begin
   write_memory{64}(y, data);
 end;
 
-func f(read::bits(64)) => bits(64)
+func f(read:bits(64)) => bits(64)
 begin
   var t = read;
   t[0] = '1';
   return t;
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(y);
   let x1 = UInt(read);

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus
@@ -7,9 +7,9 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(x);
   let x0 = UInt(read);
@@ -17,7 +17,7 @@ begin
   write_memory{64}(y, data);
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(y);
   let x1 = UInt(read);

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus
@@ -7,9 +7,9 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(x);
   let x0 = UInt(read);
@@ -17,7 +17,7 @@ begin
   write_memory{64}(y, data);
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let x1 = UInt(read_memory{64}(y));
   if x1 == 1 then

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus
@@ -7,9 +7,9 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(x);
   let x0 = UInt(read);
@@ -17,12 +17,12 @@ begin
   write_memory{64}(y, data);
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(y);
   let x1 = UInt(read);
 
-  var data :: bits(64);
+  var data : bits(64);
   if x1 == one then
     data = one;
   else

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus
@@ -7,9 +7,9 @@ ASL LB-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(x);
   let x0 = UInt(read);
@@ -17,9 +17,9 @@ begin
   write_memory{64}(y, data);
 end;
 
-var data_T1:: bits(64);
+var data_T1: bits(64);
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let read = read_memory{64}(y);
   let x1 = UInt(read);

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus
@@ -7,15 +7,15 @@ ASL MP-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   write_memory{64}(x, one);
   write_memory{64}(y, one);
 end;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   let a = UInt(read_memory{64}(y));
   let b = UInt(read_memory{64}(x));

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus
@@ -7,9 +7,9 @@ ASL MP-pseudo-arch
   0: X2= y;
 }
 
-constant one :: bits(64) = 1[63:0];
+constant one : bits(64) = 1[63:0];
 
-func T0(x::bits(64), y:: bits(64))
+func T0(x:bits(64), y: bits(64))
 begin
   write_memory{64}(x, one);
   write_memory{64}(y, one);
@@ -18,7 +18,7 @@ end;
 var a: integer;
 var b: integer;
 
-func T1(x::bits(64), y:: bits(64))
+func T1(x:bits(64), y: bits(64))
 begin
   a = UInt(read_memory{64}(y));
   b = UInt(read_memory{64}(x));

--- a/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus
@@ -5,7 +5,7 @@ x = 0;
 0:X1=x;
 }
 
-func T0(x::bits(64))
+func T0(x:bits(64))
 begin
   var s: integer = 0;
   let imax = UInt(read_memory{32}(x));
@@ -14,7 +14,7 @@ begin
   end;
 end;
 
-func T1(x::bits(64))
+func T1(x:bits(64))
 begin
   for k = 1 to 3 do
     write_memory{32}(x,k[31:0]);

--- a/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus
@@ -5,7 +5,7 @@ x = 0;
 0:X1=x;
 }
 
-func T0(x::bits(64))
+func T0(x:bits(64))
 begin
   var s: integer = 0;
   var i = UInt(read_memory{32}(x));
@@ -16,7 +16,7 @@ begin
   until i <= 0;
 end;
 
-func T1(x::bits(64))
+func T1(x:bits(64))
 begin
   for k = 1 to 3 do
     write_memory{32}(x,k[31:0]);

--- a/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus
@@ -5,7 +5,7 @@ x = 0;
 0:X1=x;
 }
 
-func T0(x::bits(64))
+func T0(x:bits(64))
 begin
   var s: integer = 0;
   var i = UInt(read_memory{32}(x));
@@ -16,7 +16,7 @@ begin
   end;
 end;
 
-func T1(x::bits(64))
+func T1(x:bits(64))
 begin
   for k = 1 to 3 do
     write_memory{32}(x,k[31:0]);

--- a/herd/tests/instructions/ASL/assign2.litmus
+++ b/herd/tests/instructions/ASL/assign2.litmus
@@ -3,11 +3,11 @@ ASL assign2
 
 {}
 
-constant C1 :: integer = 3;
-constant C2 :: integer = C1 + 2;
-constant C3 :: integer = C4 * C2;
-constant C4 :: integer = C1;
-constant C5 :: integer = - C2;
+constant C1 : integer = 3;
+constant C2 : integer = C1 + 2;
+constant C3 : integer = C4 * C2;
+constant C4 : integer = C1;
+constant C5 : integer = - C2;
 
 func main() => integer
 begin

--- a/herd/tests/instructions/ASL/assign3.litmus
+++ b/herd/tests/instructions/ASL/assign3.litmus
@@ -3,22 +3,22 @@ ASL assign3
 
 {}
 
-constant CondEQ :: bits(4) = 0x0[3:0];
-constant CondNE :: bits(4) = 0x1[3:0];
-constant CondCS :: bits(4) = 0x2[3:0];
-constant CondCC :: bits(4) = 0x3[3:0];
-constant CondMI :: bits(4) = 0x4[3:0];
-constant CondPL :: bits(4) = 0x5[3:0];
-constant CondVS :: bits(4) = 0x6[3:0];
-constant CondVC :: bits(4) = 0x7[3:0];
-constant CondHI :: bits(4) = 0x8[3:0];
-constant CondLS :: bits(4) = 0x9[3:0];
-constant CondGE :: bits(4) = 0xA[3:0];
-constant CondLT :: bits(4) = 0xB[3:0];
-constant CondGT :: bits(4) = 0xC[3:0];
-constant CondLE :: bits(4) = 0xD[3:0];
-constant CondAL :: bits(4) = 0xE[3:0];
-constant CondNV :: bits(4) = 0xF[3:0];
+constant CondEQ : bits(4) = 0x0[3:0];
+constant CondNE : bits(4) = 0x1[3:0];
+constant CondCS : bits(4) = 0x2[3:0];
+constant CondCC : bits(4) = 0x3[3:0];
+constant CondMI : bits(4) = 0x4[3:0];
+constant CondPL : bits(4) = 0x5[3:0];
+constant CondVS : bits(4) = 0x6[3:0];
+constant CondVC : bits(4) = 0x7[3:0];
+constant CondHI : bits(4) = 0x8[3:0];
+constant CondLS : bits(4) = 0x9[3:0];
+constant CondGE : bits(4) = 0xA[3:0];
+constant CondLT : bits(4) = 0xB[3:0];
+constant CondGT : bits(4) = 0xC[3:0];
+constant CondLE : bits(4) = 0xD[3:0];
+constant CondAL : bits(4) = 0xE[3:0];
+constant CondNV : bits(4) = 0xF[3:0];
 
 func main() => integer
 begin

--- a/herd/tests/instructions/ASL/bitfields1.litmus
+++ b/herd/tests/instructions/ASL/bitfields1.litmus
@@ -9,17 +9,17 @@ type MyBits of bits(5) {
   [4  ] e,
 };
 
-func constructor(b:: bits(5)) => MyBits
+func constructor(b: bits(5)) => MyBits
 begin
   return b;
 end;
 
-func get_b(b::MyBits) => bits(3)
+func get_b(b:MyBits) => bits(3)
 begin
   return b.b;
 end;
 
-func set_e(b::MyBits, e::bits(1)) => MyBits
+func set_e(b:MyBits, e:bits(1)) => MyBits
 begin
   var b2 = b;
   b2.e = e;

--- a/herd/tests/instructions/ASL/case1.litmus
+++ b/herd/tests/instructions/ASL/case1.litmus
@@ -2,7 +2,7 @@ ASL case1
 
 {}
 
-func inv(i::integer) => integer
+func inv(i:integer) => integer
 begin
   case i of 
     when 0 => return 1;

--- a/herd/tests/instructions/ASL/data-return-01.litmus
+++ b/herd/tests/instructions/ASL/data-return-01.litmus
@@ -2,7 +2,7 @@ ASL no data return
 
 {}
 
-func f(x::integer) => integer
+func f(x:integer) => integer
 begin
   return 3;
 end;

--- a/herd/tests/instructions/ASL/data-return-02.litmus
+++ b/herd/tests/instructions/ASL/data-return-02.litmus
@@ -2,7 +2,7 @@ ASL no data return
 
 {}
 
-func f(x::integer) => integer
+func f(x:integer) => integer
 begin
   let y = x;
   return 3;

--- a/herd/tests/instructions/ASL/func1.litmus
+++ b/herd/tests/instructions/ASL/func1.litmus
@@ -2,7 +2,7 @@ ASL func1
 
 {}
 
-func f(i::integer) => integer
+func f(i:integer) => integer
 begin
     return i;
 end;

--- a/herd/tests/instructions/ASL/func2.litmus
+++ b/herd/tests/instructions/ASL/func2.litmus
@@ -3,12 +3,12 @@ ASL func02
 
 {}
 
-getter X(i::integer) => integer
+getter X(i:integer) => integer
 begin
     return i;
 end;
 
-setter X(i::integer) = v::integer
+setter X(i:integer) = v:integer
 begin
     let internal_i = i;
     let internal_v = v;

--- a/herd/tests/instructions/ASL/func3.litmus
+++ b/herd/tests/instructions/ASL/func3.litmus
@@ -8,18 +8,18 @@ begin
   return 3;
 end;
 
-setter f1() = v :: integer
+setter f1() = v : integer
 begin
   pass;
   // Hahaha, as if I was to do anything with the value
 end;
 
-getter f2(x::integer) => integer
+getter f2(x:integer) => integer
 begin
   return f1() + x;
 end;
 
-setter f2(x::integer) = v :: integer
+setter f2(x:integer) = v : integer
 begin
   f1() = v + x;
 end;
@@ -27,22 +27,22 @@ end;
 var f3_storage: integer = -1;
 var f4_storage: integer = -1;
 
-getter f3(x::integer) => integer
+getter f3(x:integer) => integer
 begin
   return f3_storage;
 end;
 
-setter f3(x::integer) = v :: integer
+setter f3(x:integer) = v : integer
 begin
   f3_storage = x;
 end;
 
-getter f4(x::integer) => integer
+getter f4(x:integer) => integer
 begin
   return f4_storage;
 end;
 
-setter f4(x::integer) = v :: integer
+setter f4(x:integer) = v : integer
 begin
   f4_storage = v;
 end;

--- a/herd/tests/instructions/ASL/func4.litmus
+++ b/herd/tests/instructions/ASL/func4.litmus
@@ -8,12 +8,12 @@ begin
   return 0;
 end;
 
-func f(x::integer) => integer
+func f(x:integer) => integer
 begin
   return x;
 end;
 
-func f(x::integer, y::integer) => integer
+func f(x:integer, y:integer) => integer
 begin
   return x + y;
 end;

--- a/herd/tests/instructions/ASL/records.litmus
+++ b/herd/tests/instructions/ASL/records.litmus
@@ -3,11 +3,11 @@ ASL records
 {}
 
 type R of record {
-  f1::integer,
-  f2::boolean
+  f1:integer,
+  f2:boolean
 };
 
-func constructor (a1::integer, a2::boolean) => R
+func constructor (a1:integer, a2:boolean) => R
 begin
   return R {
     f1 = a1,
@@ -15,18 +15,18 @@ begin
   };
 end;
 
-func inv2 (r::R) => R
+func inv2 (r:R) => R
 begin
   r.f2 = !r.f2;
   return r;
 end;
 
-func read_f1 (r::R) => integer
+func read_f1 (r:R) => integer
 begin
   return r.f1;
 end;
 
-func read_f2 (r::R) => integer
+func read_f2 (r:R) => integer
 begin
   return r.f2;
 end;

--- a/herd/tests/instructions/ASL/unknown.litmus
+++ b/herd/tests/instructions/ASL/unknown.litmus
@@ -6,7 +6,7 @@ variant = ASL
 
 func random_bool () => boolean
 begin
-  return (ARBITRARY:: boolean);
+  return (ARBITRARY: boolean);
 end;
 
 func main () => integer


### PR DESCRIPTION
I believe this is legacy support for prior ASL1 syntax, which is no longer in the language definition. As requested by @nigelito