### PR TITLE
[herd7,aarch64] A failed CAS may write back

### DIFF
--- a/herd/monad.mli
+++ b/herd/monad.mli
@@ -211,6 +211,13 @@ module type S =
            ('loc -> unit t) ->
             ('v -> 'v -> unit t) -> unit t
 
+    val aarch64_cas_no_with_writeback :
+          bool -> (* physical access *)
+            'loc t -> 'v t ->
+              ('v -> unit t) -> ('loc -> 'v t) -> ('loc -> 'v -> unit t) ->
+              ('loc -> unit t) ->
+                ('v -> 'v -> unit t) -> unit t
+
     val aarch64_cas_ok :
       bool -> (* physical access *)
         'loc t -> 'v t -> 'v t ->

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h0+amo.casa.w0w0-pow0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h0+amo.casa.w0w0-pow0w0.litmus.expected
@@ -5,8 +5,8 @@ States 3
 1:X1=0x101; 1:X3=0x1010000; [y]=0x2020202;
 No
 Witnesses
-Positive: 0 Negative: 6
+Positive: 0 Negative: 8
 Condition exists ([y]=0x2020202 /\ 1:X1=0x101 /\ 1:X3=0x0)
-Observation MP+dmb.syh2h0+amo.casa.w0w0-pow0w0 Never 0 6
+Observation MP+dmb.syh2h0+amo.casa.w0w0-pow0w0 Never 0 8
 Hash=de0b51dd0baeae300ccb7bb64c89c67f
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h2+amo.casa.w0w0-pow0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2h2+amo.casa.w0w0-pow0w0.litmus.expected
@@ -5,8 +5,8 @@ States 3
 1:X2=0x1010000; 1:X4=0x1010000; [y]=0x2020202;
 No
 Witnesses
-Positive: 0 Negative: 6
+Positive: 0 Negative: 8
 Condition exists ([y]=0x2020202 /\ 1:X2=0x1010000 /\ 1:X4=0x0)
-Observation MP+dmb.syh2h2+amo.casa.w0w0-pow0w0 Never 0 6
+Observation MP+dmb.syh2h2+amo.casa.w0w0-pow0w0 Never 0 8
 Hash=ccd1563306b43f28d7565b33bc2812c4
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+amo.casa.h0h0-poh0w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+amo.casa.h0h0-poh0w0.litmus.expected
@@ -5,8 +5,8 @@ States 3
 1:X1=0x101; 1:X3=0x1010000; [y]=0x1010202;
 No
 Witnesses
-Positive: 0 Negative: 6
+Positive: 0 Negative: 8
 Condition exists ([y]=0x1010202 /\ 1:X1=0x101 /\ 1:X3=0x0)
-Observation MP+dmb.syh2w0+amo.casa.h0h0-poh0w0 Never 0 6
+Observation MP+dmb.syh2w0+amo.casa.h0h0-poh0w0 Never 0 8
 Hash=91643c1d02ebd53a9c3fb07ad22b176e
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+amo.casa.h2h2-poh2w0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syh2w0+amo.casa.h2h2-poh2w0.litmus.expected
@@ -5,8 +5,8 @@ States 3
 1:X1=0x101; 1:X4=0x1010000; [y]=0x2020101;
 No
 Witnesses
-Positive: 0 Negative: 6
+Positive: 0 Negative: 8
 Condition exists ([y]=0x2020101 /\ 1:X1=0x101 /\ 1:X4=0x0)
-Observation MP+dmb.syh2w0+amo.casa.h2h2-poh2w0 Never 0 6
+Observation MP+dmb.syh2w0+amo.casa.h2h2-poh2w0 Never 0 8
 Hash=a505ef52a19e87a874d77d613b2644a1
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h0+amo.casa.w0w0-pow0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h0+amo.casa.w0w0-pow0h0.litmus.expected
@@ -5,8 +5,8 @@ States 3
 1:X1=0x101; 1:X3=0x101; [y]=0x2020202;
 No
 Witnesses
-Positive: 0 Negative: 6
+Positive: 0 Negative: 8
 Condition exists ([y]=0x2020202 /\ 1:X1=0x101 /\ 1:X3=0x0)
-Observation MP+dmb.syw0h0+amo.casa.w0w0-pow0h0 Never 0 6
+Observation MP+dmb.syw0h0+amo.casa.w0w0-pow0h0 Never 0 8
 Hash=012860ecc04db3a0c0cca4401aa0a718
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h2+amo.casa.w0w0-pow0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0h2+amo.casa.w0w0-pow0h0.litmus.expected
@@ -5,8 +5,8 @@ States 3
 1:X2=0x1010000; 1:X4=0x101; [y]=0x2020202;
 No
 Witnesses
-Positive: 0 Negative: 6
+Positive: 0 Negative: 8
 Condition exists ([y]=0x2020202 /\ 1:X2=0x1010000 /\ 1:X4=0x0)
-Observation MP+dmb.syw0h2+amo.casa.w0w0-pow0h0 Never 0 6
+Observation MP+dmb.syw0h2+amo.casa.w0w0-pow0h0 Never 0 8
 Hash=ce2a7c8ea6503ba5f9bc7011832e680e
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+amo.casa.h0h0-poh0h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+amo.casa.h0h0-poh0h0.litmus.expected
@@ -5,8 +5,8 @@ States 3
 1:X1=0x101; 1:X3=0x101; [y]=0x1010202;
 No
 Witnesses
-Positive: 0 Negative: 6
+Positive: 0 Negative: 8
 Condition exists ([y]=0x1010202 /\ 1:X1=0x101 /\ 1:X3=0x0)
-Observation MP+dmb.syw0w0+amo.casa.h0h0-poh0h0 Never 0 6
+Observation MP+dmb.syw0w0+amo.casa.h0h0-poh0h0 Never 0 8
 Hash=9f7ea35957b7fcaa3c120cad7b8ed304
 

--- a/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+amo.casa.h2h2-poh2h0.litmus.expected
+++ b/herd/tests/diycross/AArch64.mixed.strict/MP+dmb.syw0w0+amo.casa.h2h2-poh2h0.litmus.expected
@@ -5,8 +5,8 @@ States 3
 1:X1=0x101; 1:X4=0x101; [y]=0x2020101;
 No
 Witnesses
-Positive: 0 Negative: 6
+Positive: 0 Negative: 8
 Condition exists ([y]=0x2020101 /\ 1:X1=0x101 /\ 1:X4=0x0)
-Observation MP+dmb.syw0w0+amo.casa.h2h2-poh2h0 Never 0 6
+Observation MP+dmb.syw0w0+amo.casa.h2h2-poh2h0 Never 0 8
 Hash=27e2a650c1b171931160eba3ded2ec7c
 

--- a/herd/tests/instructions/AArch64.kvm/A019.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A019.litmus
@@ -1,0 +1,10 @@
+AArch64 A019
+TTHM=P0:HD
+Variant=vmsa
+{
+ 0:X1=x; 0:X2=7; 0:X0=42;
+ TTD(x)=(oa:PA(x),db:0,dbm:1);
+}
+P0             ;
+CAS W0,W2,[X1] ;
+exists TTD(x)=(oa:PA(x),db:0,dbm:1)

--- a/herd/tests/instructions/AArch64.kvm/A019.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A019.litmus.expected
@@ -1,0 +1,11 @@
+Test A019 Allowed
+States 2
+[PTE(x)]=(oa:PA(x), db:0, dbm:1);
+[PTE(x)]=(oa:PA(x), dbm:1);
+Ok
+Witnesses
+Positive: 2 Negative: 3
+Condition exists ([PTE(x)]=(oa:PA(x), db:0, dbm:1))
+Observation A019 Sometimes 2 3
+Hash=f45eee29aa2a126c7370f37a156463ea
+

--- a/herd/tests/instructions/AArch64.mixed/M008.litmus.expected
+++ b/herd/tests/instructions/AArch64.mixed/M008.litmus.expected
@@ -6,8 +6,8 @@ States 4
 1:X1=0x101; [x]=0x2; [y]=0x202;
 Ok
 Witnesses
-Positive: 2 Negative: 6
+Positive: 2 Negative: 8
 Condition exists ([x]=0x2 /\ [y]=0x202 /\ 1:X1=0x101)
-Observation M008 Sometimes 2 6
+Observation M008 Sometimes 2 8
 Hash=dce7776cf1382a6e5b1afce5eab68a83
 

--- a/herd/tests/instructions/AArch64/A242.litmus.expected
+++ b/herd/tests/instructions/AArch64/A242.litmus.expected
@@ -3,8 +3,8 @@ States 1
 a[0]=2; a[1]=2; x[0]=0; x[1]=0; y[0]=2; y[1]=2; z[0]=0; z[1]=0;
 Ok
 Witnesses
-Positive: 16 Negative: 0
+Positive: 36 Negative: 0
 Condition forall (x[0]=0 /\ x[1]=0 /\ y[0]=2 /\ y[1]=2 /\ z[0]=0 /\ z[1]=0 /\ a[0]=2 /\ a[1]=2)
-Observation A242 Always 16 0
+Observation A242 Always 36 0
 Hash=a53545f0a258acc581288f0aa9b5c936
 

--- a/herd/tests/instructions/AArch64/A243.litmus.expected
+++ b/herd/tests/instructions/AArch64/A243.litmus.expected
@@ -3,8 +3,8 @@ States 1
 a[0]=2; a[1]=2; x[0]=0; x[1]=0; y[0]=2; y[1]=2; z[0]=0; z[1]=0;
 Ok
 Witnesses
-Positive: 16 Negative: 0
+Positive: 36 Negative: 0
 Condition forall (x[0]=0 /\ x[1]=0 /\ y[0]=2 /\ y[1]=2 /\ z[0]=0 /\ z[1]=0 /\ a[0]=2 /\ a[1]=2)
-Observation A243 Always 16 0
+Observation A243 Always 36 0
 Hash=450d6bea2cb06cb6a4eec6037dcb6802
 

--- a/herd/tests/instructions/AArch64/A244.litmus.expected
+++ b/herd/tests/instructions/AArch64/A244.litmus.expected
@@ -3,8 +3,8 @@ States 1
 a[0]=2; a[1]=2; x[0]=0; x[1]=0; y[0]=2; y[1]=2; z[0]=0; z[1]=0;
 Ok
 Witnesses
-Positive: 16 Negative: 0
+Positive: 36 Negative: 0
 Condition forall (x[0]=0 /\ x[1]=0 /\ y[0]=2 /\ y[1]=2 /\ z[0]=0 /\ z[1]=0 /\ a[0]=2 /\ a[1]=2)
-Observation A244 Always 16 0
+Observation A244 Always 36 0
 Hash=f5f65af42b0b1c4ef91a867eb4c84a3c
 

--- a/herd/tests/instructions/AArch64/A245.litmus.expected
+++ b/herd/tests/instructions/AArch64/A245.litmus.expected
@@ -3,8 +3,8 @@ States 1
 a[0]=2; a[1]=2; x[0]=0; x[1]=0; y[0]=2; y[1]=2; z[0]=0; z[1]=0;
 Ok
 Witnesses
-Positive: 16 Negative: 0
+Positive: 36 Negative: 0
 Condition forall (x[0]=0 /\ x[1]=0 /\ y[0]=2 /\ y[1]=2 /\ z[0]=0 /\ z[1]=0 /\ a[0]=2 /\ a[1]=2)
-Observation A245 Always 16 0
+Observation A245 Always 36 0
 Hash=51b29db6588f853cf4e04fe2a1242893
 

--- a/herd/tests/instructions/AArch64/A246.litmus.expected
+++ b/herd/tests/instructions/AArch64/A246.litmus.expected
@@ -3,8 +3,8 @@ States 1
 a[0]=2; a[1]=2; x[0]=0; x[1]=0; y[0]=2; y[1]=2; z[0]=0; z[1]=0;
 Ok
 Witnesses
-Positive: 16 Negative: 0
+Positive: 36 Negative: 0
 Condition forall (x[0]=0 /\ x[1]=0 /\ y[0]=2 /\ y[1]=2 /\ z[0]=0 /\ z[1]=0 /\ a[0]=2 /\ a[1]=2)
-Observation A246 Always 16 0
+Observation A246 Always 36 0
 Hash=dfcdd105748ed1fb63dad2657811b691
 

--- a/herd/tests/instructions/AArch64/L007.litmus.expected
+++ b/herd/tests/instructions/AArch64/L007.litmus.expected
@@ -3,8 +3,8 @@ States 1
 0:X3=0; 1:X3=0; [x]=0; [y]=2;
 Ok
 Witnesses
-Positive: 4 Negative: 0
+Positive: 6 Negative: 0
 Condition forall ([x]=0 /\ [y]=2)
-Observation L007 Always 4 0
+Observation L007 Always 6 0
 Hash=dcd669f7a9ed4f2e408f12673d09b57f
 

--- a/herd/tests/instructions/AArch64/L056.litmus.expected
+++ b/herd/tests/instructions/AArch64/L056.litmus.expected
@@ -4,8 +4,8 @@ States 2
 1:X0=1; 1:X1=0; x={1,0};
 Ok
 Witnesses
-Positive: 4 Negative: 0
+Positive: 6 Negative: 0
 Condition forall (x={1,0} \/ x={1,2})
-Observation L056 Always 4 0
+Observation L056 Always 6 0
 Hash=56239ea29c96ee505c91efa59ac63a18
 

--- a/herd/tests/instructions/AArch64/L057.litmus.expected
+++ b/herd/tests/instructions/AArch64/L057.litmus.expected
@@ -4,8 +4,8 @@ States 2
 1:X0=0; 1:X1=1; x={0,1};
 Ok
 Witnesses
-Positive: 4 Negative: 0
+Positive: 6 Negative: 0
 Condition forall (x={0,1} \/ x={2,1})
-Observation L057 Always 4 0
+Observation L057 Always 6 0
 Hash=57ac32621316eec60874e7e2c863b043
 


### PR DESCRIPTION
The objective of this PR is to amend the instruction semantics for CAS in case when its comparison fails. Broadly speaking, whenever a CAS fails its comparison, it is now allowed to read the original value in memory and then write the same value back. This has consequences: an Explicit Write Effect may be created, a Hardware Update might be created, (with FEAT_MTE_STOREONLY not supported by `herd7` presently) a TagCheck may be created.

The following kinds of executions are expected of a failed CAS:
- CAS generates an Explicit Write Effect of a value that is already in memory and, if `-variant vmsa` is enabled, that leads to generating a Hardware Update to the dirty bit.
- CAS does not generate an Explicit Write Effect and, if `-variant vmsa` is enabled, a candidate execution with a Hardware Update to the dirty bit is generated.
- CAS does not generate an Explicit Write Effect and, if `-variant vmsa` is enabled, a candidate execution without a Hardware Update to the dirty bit is generated.

Note that the aforementioned three executions are archetypes: other "alternatives" affect the overall number of executions. Thus, for instance, the test `./herd/tests/instructions/AArch64.kvm/A019.litmus` has 5 rather than 3 executions.