### PR TITLE
[asl][reference] Remove inlining of clist and storage_keyword

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -184,7 +184,7 @@ let nlist(x) :=
   | ~=x; { [ x ] }
   | ~=x; l=nlist(x); { x :: l }
 
-let end_semicolon :=
+let end_semicolon ==
   | END; SEMI_COLON; <>
   | END; {
       if not Config.allow_no_end_semicolon then

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -151,7 +151,7 @@ let nclist(x) :=
   | h=x; COMMA; t=nclist(x); { h :: t }
 
 (* A comma separated list. *)
-let clist(x) == { [] } | nclist(x)
+let clist(x) := { [] } | nclist(x)
 
 (* A comma separated list with at least 2 elements. *)
 let clist2(x) := ~=x; COMMA; li=nclist(x); { x :: li }
@@ -277,7 +277,10 @@ let expr :=
     | ARBITRARY; COLON; ~=ty;                                 < E_Arbitrary        >
     | e=pared(expr);                                          { E_Tuple [ e ]        }
 
-    | t=annotated(IDENTIFIER); fields=braced(clist(field_assign));
+    (* For E_Record we use an inlined clist to avoid a shift/reduce conflict with elided_param_call's empty case *)
+    | t=annotated(IDENTIFIER); LBRACE; RBRACE;
+        { E_Record (add_pos_from t (T_Named t.desc), []) }
+    | t=annotated(IDENTIFIER); fields=braced(nclist(field_assign));
         { E_Record (add_pos_from t (T_Named t.desc), fields) }
     (* Excluded from expr_pattern *)
     | ~=plist2(expr);                                             < E_Tuple              >
@@ -326,7 +329,10 @@ let expr_pattern :=
     | ARBITRARY; COLON; ~=ty;                                         < E_Arbitrary        >
     | e=pared(expr_pattern);                                          { E_Tuple [ e ]        }
 
-    | t=annotated(IDENTIFIER); fields=braced(clist(field_assign));
+    (* For E_Record we use an inlined clist to avoid a shift/reduce conflict with elided_param_call *)
+    | t=annotated(IDENTIFIER); LBRACE; RBRACE;
+        { E_Record (add_pos_from t (T_Named t.desc), []) }
+    | t=annotated(IDENTIFIER); fields=braced(nclist(field_assign));
         { E_Record (add_pos_from t (T_Named t.desc), fields) }
   )
 
@@ -467,11 +473,13 @@ let local_decl_keyword :=
   | VAR       ; { LDK_Var       }
   *)
 
-let storage_keyword ==
+let storage_keyword :=
   | LET       ; { GDK_Let      }
   | CONSTANT  ; { GDK_Constant }
-  | VAR       ; { GDK_Var      }
   | CONFIG    ; { GDK_Config   }
+  (* Var conflicts with global_uninit_var and as such is inlined in the decl production
+  | VAR       ; { GDK_Var      }
+  *)
 
 let pass == { S_Pass }
 let assign(x, y) == ~=x ; EQ ; ~=y ; < S_Assign >
@@ -664,6 +672,9 @@ let decl :=
       | keyword=storage_keyword; name=ignored_or_identifier;
         ty=option(as_ty); EQ; initial_value=some(expr);
         { D_GlobalStorage { keyword; name; ty; initial_value } }
+      | VAR; name=ignored_or_identifier;
+        ty=option(as_ty); EQ; initial_value=some(expr);
+        { D_GlobalStorage { keyword=GDK_Var; name; ty; initial_value } }
       (* End *)
       (* Begin global_uninit_var *)
       | VAR; name=ignored_or_identifier; ty=some(as_ty);

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -469,7 +469,7 @@
 \newcommand\Ntydecl[0]{\hyperlink{def-ntydecl}{\nonterminal{ty\_decl}}}
 \newcommand\Nsubtype[0]{\hyperlink{def-nsubtype}{\nonterminal{subtype}}}
 \newcommand\Nsubtypeopt[0]{\hyperlink{def-nsubtypeopt}{\nonterminal{subtype\_opt}}}
-\newcommand\Nstoragekeyword[0]{\hyperlink{def-nstoragekeyword}{\nonterminal{storage\_keyword}}}
+\newcommand\Nglobaldeclkeyword[0]{\hyperlink{def-nglobaldeclkeyword}{\nonterminal{global\_decl\_keyword\_non\_var}}}
 \newcommand\Nignoredoridentifier[0]{\hyperlink{def-nignoredoridentifier}{\nonterminal{ignored\_or\_identifier}}}
 \newcommand\Ninitialvalue[0]{\hyperlink{def-ninitialvalue}{\nonterminal{initial\_value}}}
 \newcommand\Nty[0]{\hyperlink{def-nty}{\nonterminal{ty}}}
@@ -485,7 +485,7 @@
 \newcommand\Nopttypedidentifier[0]{\hyperlink{def-nopttypeidentifier}{\nonterminal{opt\_typed\_identifier}}}
 \newcommand\Nstmtlist[0]{\hyperlink{def-nstmtlist}{\nonterminal{stmt\_list}}}
 \newcommand\Nmaybeemptystmtlist[0]{\hyperlink{def-nmaybeemptystmtlist}{\nonterminal{maybe\_empty\_stmt\_list}}}
-\newcommand\Nlocaldeclkeyword[0]{\hyperlink{def-nlocaldeclkeyword}{\nonterminal{local\_decl\_keyword}}}
+\newcommand\Nlocaldeclkeyword[0]{\hyperlink{def-nlocaldeclkeyword}{\nonterminal{local\_decl\_keyword\_non\_var}}}
 \newcommand\Ndirection[0]{\hyperlink{def-ndirection}{\nonterminal{direction}}}
 \newcommand\Ncasealt[0]{\hyperlink{def-ncasealt}{\nonterminal{case\_alt}}}
 \newcommand\Ncaseotherwise[0]{\hyperlink{def-ncaseotherwise}{\nonterminal{case\_otherwise}}}
@@ -790,7 +790,7 @@
 \newcommand\buildtydecl[0]{\hyperlink{build-tydecl}{\textfunc{build\_ty\_decl}}}
 \newcommand\buildsubtype[0]{\hyperlink{build-subtype}{\textfunc{build\_subtype}}}
 \newcommand\buildsubtypeopt[0]{\hyperlink{build-subtypeopt}{\textfunc{build\_subtype\_opt}}}
-\newcommand\buildstoragekeyword[0]{\hyperlink{build-storagekeyword}{\textfunc{build\_storage\_keyword}}}
+\newcommand\buildglobaldeclkeyword[0]{\hyperlink{build-globaldeclkeyword}{\textfunc{build\_global\_decl\_keyword\_non\_var}}}
 \newcommand\builddirection[0]{\hyperlink{build-direction}{\textfunc{build\_direction}}}
 \newcommand\buildcasealt[0]{\hyperlink{build-casealt}{\textfunc{build\_case\_alt}}}
 \newcommand\buildcasealtlist[0]{\hyperlink{build-casealtlist}{\textfunc{build\_case\_alt\_list}}}
@@ -799,7 +799,7 @@
 \newcommand\buildcatcher[0]{\hyperlink{build-catcher}{\textfunc{build\_catcher}}}
 \newcommand\buildasty[0]{\textfunc{build\_as\_ty}}
 \newcommand\buildignoredoridentifier[0]{\hyperlink{build-ignoredoridentifier}{\textfunc{build\_ignored\_or\_identifier}}}
-\newcommand\buildlocaldeclkeyword[0]{\hyperlink{build-localdeclkeyword}{\textfunc{build\_local\_decl\_keyword}}}
+\newcommand\buildlocaldeclkeyword[0]{\hyperlink{build-localdeclkeyword}{\textfunc{build\_local\_decl\_keyword\_non\_var}}}
 \newcommand\buildstmtlist[0]{\hyperlink{build-stmtlist}{\textfunc{build\_stmt\_list}}}
 \newcommand\buildmaybeemptystmtlist[0]{\hyperlink{build-maybeemptystmtlist}{\textfunc{build\_maybe\_empty\_stmt\_list}}}
 \newcommand\buildselse[0]{\hyperlink{build-selse}{\textfunc{build\_s\_else}}}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -912,7 +912,7 @@ $\AbbrevTArrayLengthEnum{\ve}{\vs}{\vt}$ & $\TArray(\ArrayLengthEnum(\ve, \vs), 
 %   \item ASTRule.FuncBody (see \secref{ASTRule.FuncBody})
 %   \item ASTRule.IgnoredOrIdentifier (see \secref{ASTRule.IgnoredOrIdentifier})
 %   \item ASTRule.LocalDeclKeyword (see \secref{ASTRule.LocalDeclKeyword})
-%   \item ASTRule.StorageKeyword (see \secref{ASTRule.StorageKeyword})
+%   \item ASTRule.GlobalDeclKeyword (see \secref{ASTRule.GlobalDeclKeyword})
 %   \item ASTRule.Direction (see \secref{ASTRule.Direction})
 %   \item ASTRule.Alt (see \secref{ASTRule.Alt})
 %   \item ASTRule.OtherwiseOpt (see \secref{ASTRule.OtherwiseOpt})

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -2723,7 +2723,8 @@ Notice that this rule introduces non-determinism.
 \section{Structured Type Construction Expressions\label{sec:StructuredTypeConstructionExpressions}}
 \subsection{Syntax}
 \begin{flalign*}
-\Nexpr \derives\  & \Tidentifier \parsesep \Tlbrace \parsesep \Clist{\Nfieldassign} \parsesep \Trbrace &\\
+\Nexpr \derives\  & \Tidentifier \parsesep \Tlbrace \parsesep \Trbrace &\\
+	       \| & \Tidentifier \parsesep \Tlbrace \parsesep \NClist{\Nfieldassign} \parsesep \Trbrace &\\
 \Nfieldassign \derives \ & \Tidentifier \parsesep \Teq \parsesep \Nexpr &
 \end{flalign*}
 
@@ -2734,7 +2735,22 @@ Notice that this rule introduces non-determinism.
 
 \subsubsection{ASTRule.ERecord}
 \begin{mathpar}
-  \inferrule{
+  \inferrule[empty]{}{
+    {
+      \begin{array}{r}
+    \buildexpr(\overname{\Nexpr(
+    \begin{array}{l}
+    \Tidentifier(\vt), \Tlbrace, \Trbrace
+    \end{array}
+    )}{\vparsednode}) \\
+    \astarrow\ \overname{\ERecord(\TNamed(\vt), \emptylist)}{\vastnode}
+\end{array}
+}
+}
+\end{mathpar}
+
+\begin{mathpar}
+  \inferrule[non\_empty]{
     \buildclist[\buildfieldassign](\vfieldassigns) \astarrow \vfieldassignasts
   }{
     {
@@ -2742,7 +2758,7 @@ Notice that this rule introduces non-determinism.
   \buildexpr\left(\overname{\Nexpr\left(
     \begin{array}{l}
     \Tidentifier(\vt), \Tlbrace, \\
-    \wrappedline\ \namednode{\vfieldassigns}{\Clist{\Nfieldassign}}, \\
+    \wrappedline\ \namednode{\vfieldassigns}{\NClist{\Nfieldassign}}, \\
     \wrappedline\ \Trbrace
     \end{array}
     \right)}{\vparsednode}\right) \\

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -33,7 +33,7 @@ Type declarations:
 
 Global storage declarations:
 \begin{flalign*}
-\Ndecl  \derives \ & \Nstoragekeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
+\Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
     & \wrappedline\ \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&\\
 \end{flalign*}

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -14,7 +14,7 @@ The semantics of a single global storage declarations is defined in \nameref{sec
 \section{Syntax\label{sec:GlobalStorageDeclarationsSyntax}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{flalign*}
-\Ndecl  \derives \ & \Nstoragekeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
+\Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
         & \wrappedline\ \Nexpr \parsesep \Tsemicolon &\\
 	|\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
         & \wrappedline\ \Nexpr \parsesep \Tsemicolon &\\
@@ -23,7 +23,7 @@ The semantics of a single global storage declarations is defined in \nameref{sec
 \end{flalign*}
 
 \begin{flalign*}
-\Nstoragekeyword \derives \ & \Tlet \;|\; \Tconstant \;|\; \Tconfig&\\
+\Nglobaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant \;|\; \Tconfig&\\
 \Nignoredoridentifier \derives \ & \Tminus \;|\; \Tidentifier &
 \end{flalign*}
 
@@ -55,7 +55,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \hypertarget{build-globalstorage}{}
 \begin{mathpar}
 \inferrule[global\_storage]{
-  \buildstoragekeyword(\keyword) \astarrow \astof{\keyword}\\
+  \buildglobaldeclkeyword(\keyword) \astarrow \astof{\keyword}\\
   \buildoption[\buildasty](\tty) \astarrow \ttyp\\
   \buildexpr(\vinitialvalue) \typearrow \astof{\vinitialvalue}
 }
@@ -63,7 +63,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
   {
       \builddecl\left(\overname{\Ndecl\left(
       \begin{array}{r}
-      \namednode{\vkeyword}{\Nstoragekeyword}, \namednode{\name}{\Nignoredoridentifier},  \\
+      \namednode{\vkeyword}{\Nglobaldeclkeyword}, \namednode{\name}{\Nignoredoridentifier},  \\
   \wrappedline\ \namednode{\tty}{\option{\Nasty}}, \Teq, \namednode{\vinitialvalue}{\Nexpr}, \Tsemicolon
       \end{array}
   \right)}{\vparsednode}\right)
@@ -128,30 +128,30 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 
-\subsubsection{ASTRule.StorageKeyword \label{sec:ASTRule.StorageKeyword}}
-\hypertarget{build-storagekeyword}{}
+\subsubsection{ASTRule.GlobalDeclKeyword \label{sec:ASTRule.GlobalDeclKeyword}}
+\hypertarget{build-globaldeclkeyword}{}
 The function
 \[
-\buildstoragekeyword(\overname{\parsenode{\Nstoragekeyword}}{\vparsednode}) \;\aslto\;
+\buildglobaldeclkeyword(\overname{\parsenode{\Nglobaldeclkeyword}}{\vparsednode}) \;\aslto\;
   \overname{\globaldeclkeyword}{\vastnode}
 \]
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[let]{}{
-  \buildstoragekeyword(\overname{\Nstoragekeyword(\Tlet)}{\vparsednode}) \astarrow \overname{\GDKLet}{\vastnode}
+  \buildglobaldeclkeyword(\overname{\Nglobaldeclkeyword(\Tlet)}{\vparsednode}) \astarrow \overname{\GDKLet}{\vastnode}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[constant]{}{
-  \buildstoragekeyword(\overname{\Nstoragekeyword(\Tconstant)}{\vparsednode}) \astarrow \overname{\GDKConstant}{\vastnode}
+  \buildglobaldeclkeyword(\overname{\Nglobaldeclkeyword(\Tconstant)}{\vparsednode}) \astarrow \overname{\GDKConstant}{\vastnode}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[config]{}{
-  \buildstoragekeyword(\overname{\Nstoragekeyword(\Tconfig)}{\vparsednode}) \astarrow \overname{\GDKConfig}{\vastnode}
+  \buildglobaldeclkeyword(\overname{\Nglobaldeclkeyword(\Tconfig)}{\vparsednode}) \astarrow \overname{\GDKConfig}{\vastnode}
 }
 \end{mathpar}
 

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -16,12 +16,14 @@ The semantics of a single global storage declarations is defined in \nameref{sec
 \begin{flalign*}
 \Ndecl  \derives \ & \Nstoragekeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
         & \wrappedline\ \Nexpr \parsesep \Tsemicolon &\\
+	|\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
+        & \wrappedline\ \Nexpr \parsesep \Tsemicolon &\\
         |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&\\
         |\ & \Tpragma \parsesep \Tidentifier \parsesep \Clist{\Nexpr} \parsesep \Tsemicolon&
 \end{flalign*}
 
 \begin{flalign*}
-\Nstoragekeyword \derivesinline\ & \Tlet \;|\; \Tconstant \;|\; \Tvar \;|\; \Tconfig&\\
+\Nstoragekeyword \derives \ & \Tlet \;|\; \Tconstant \;|\; \Tconfig&\\
 \Nignoredoridentifier \derives \ & \Tminus \;|\; \Tidentifier &
 \end{flalign*}
 
@@ -81,6 +83,36 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 
+\hypertarget{build-globalstorage-var}{}
+\begin{mathpar}
+\inferrule[global\_storage\_var]{
+  \buildoption[\buildasty](\tty) \astarrow \ttyp\\
+  \buildexpr(\vinitialvalue) \typearrow \astof{\vinitialvalue}
+}
+{
+  {
+      \builddecl\left(\overname{\Ndecl\left(
+      \begin{array}{r}
+      \Tvar, \namednode{\name}{\Nignoredoridentifier},  \\
+  \wrappedline\ \namednode{\tty}{\option{\Nasty}}, \Teq, \namednode{\vinitialvalue}{\Nexpr}, \Tsemicolon
+      \end{array}
+  \right)}{\vparsednode}\right)
+  } \astarrow \\
+  {
+    \overname{
+  \DGlobalStorage\left(\left\{
+    \begin{array}{rcl}
+    \GDkeyword &:& \GDKVar,\\
+    \GDname &:& \astof{\name},\\
+    \GDty &:& \ttyp,\\
+    \GDinitialvalue &:& \astof{\vinitialvalue}
+  \end{array}
+  \right\}\right)
+  }{\vastnode}
+  }
+}
+\end{mathpar}
+
 \hypertarget{build-globaluninitvar}{}
 \begin{mathpar}
 \inferrule[global\_uninit\_var]{
@@ -114,12 +146,6 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \begin{mathpar}
 \inferrule[constant]{}{
   \buildstoragekeyword(\overname{\Nstoragekeyword(\Tconstant)}{\vparsednode}) \astarrow \overname{\GDKConstant}{\vastnode}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[var]{}{
-  \buildstoragekeyword(\overname{\Nstoragekeyword(\Tvar)}{\vparsednode}) \astarrow \overname{\GDKVar}{\vastnode}
 }
 \end{mathpar}
 

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -1020,7 +1020,22 @@ transforms a pattern expression parse node $\vparsednode$ into a pattern AST nod
 \end{mathpar}
 
 \begin{mathpar}
-  \inferrule[record]{
+  \inferrule[record\_empty]{}{
+    {
+      \begin{array}{r}
+  \buildexprpattern\left(\Nexprpattern\left(
+    \begin{array}{l}
+    \Tidentifier(\vt), \Tlbrace, \Trbrace \\
+    \end{array}
+    \right)\right) \\
+    \astarrow\ \overname{\ERecord(\TNamed(\vt), \emptylist)}{\vastnode}
+\end{array}
+}
+}
+\end{mathpar}
+
+\begin{mathpar}
+  \inferrule[record\_non\_empty]]{
     \buildclist[\buildfieldassign](\vfieldassigns) \astarrow \vfieldassignasts
   }{
     {

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -245,7 +245,7 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \hypertarget{def-subtypedecl}{}\\
 |\ & \Ttype \parsesep \Tidentifier \parsesep \Nsubtype \parsesep \Tsemicolon&
 \hypertarget{def-globalstorage}{}\\
-|\ & \Nstoragekeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
+|\ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
    & \wrappedline\ \Nexpr \parsesep \Tsemicolon &
 |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
    & \wrappedline\ \Nexpr \parsesep \Tsemicolon &
@@ -341,9 +341,9 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \Nlocaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant&
 \end{flalign*}
 
-\hypertarget{def-nstoragekeyword}{}
+\hypertarget{def-nglobaldeclkeyword}{}
 \begin{flalign*}
-\Nstoragekeyword \derives \ & \Tlet \;|\; \Tconstant \;|\; \Tconfig&
+\Nglobaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant \;|\; \Tconfig&
 \end{flalign*}
 
 \hypertarget{def-ndirection}{}

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -175,7 +175,7 @@ We define the following parametric productions for various types of lists and op
 \paragraph{Possibly-empty Comma-separated List}
 \hypertarget{def-clist}{}
 \begin{flalign*}
-\Clist{x}   \derivesinline\ & \emptysentence \;|\; \NClist{x} &\\
+\Clist{x}   \derives \ & \emptysentence \;|\; \NClist{x} &\\
 \end{flalign*}
 
 \paragraph{Comma-separated List With At Least Two Elements}
@@ -246,6 +246,8 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 |\ & \Ttype \parsesep \Tidentifier \parsesep \Nsubtype \parsesep \Tsemicolon&
 \hypertarget{def-globalstorage}{}\\
 |\ & \Nstoragekeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
+   & \wrappedline\ \Nexpr \parsesep \Tsemicolon &
+|\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
    & \wrappedline\ \Nexpr \parsesep \Tsemicolon &
 \hypertarget{def-globaluninitvar}{}\\
 |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&
@@ -341,7 +343,7 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 
 \hypertarget{def-nstoragekeyword}{}
 \begin{flalign*}
-\Nstoragekeyword \derivesinline\ & \Tlet \;|\; \Tconstant \;|\; \Tvar \;|\; \Tconfig&
+\Nstoragekeyword \derives \ & \Tlet \;|\; \Tconstant \;|\; \Tconfig&
 \end{flalign*}
 
 \hypertarget{def-ndirection}{}
@@ -516,7 +518,8 @@ except they do not derive tuples, which are the last derivation for $\Nexpr$.
                     |\  & \Nexpr \parsesep \Teqop \parsesep \Tmasklit &\\
                     |\  & \Nexpr \parsesep \Tneq \parsesep \Tmasklit &\\
                     |\  & \Tarbitrary \parsesep \Tcolon \parsesep \Nty &\\
-                    |\  & \Tidentifier \parsesep \Tlbrace \parsesep \Clist{\Nfieldassign} \parsesep \Trbrace &\\
+                    |\  & \Tidentifier \parsesep \Tlbrace \parsesep \Trbrace &\\
+                    |\  & \Tidentifier \parsesep \Tlbrace \parsesep \NClist{\Nfieldassign} \parsesep \Trbrace &\\
                     |\  & \Tlpar \parsesep \Nexprpattern \parsesep \Trpar &
 \end{flalign*}
 
@@ -629,7 +632,8 @@ except they do not derive tuples, which are the last derivation for $\Nexpr$.
                     |\  & \Nexpr \parsesep \Teqop \parsesep \Tmasklit &\\
                     |\  & \Nexpr \parsesep \Tneq \parsesep \Tmasklit &\\
                     |\  & \Tarbitrary \parsesep \Tcolon \parsesep \Nty &\\
-                    |\  & \Tidentifier \parsesep \Tlbrace \parsesep \Clist{\Nfieldassign} \parsesep \Trbrace &\\
+                    |\  & \Tidentifier \parsesep \Tlbrace \parsesep \Trbrace &\\
+                    |\  & \Tidentifier \parsesep \Tlbrace \parsesep \NClist{\Nfieldassign} \parsesep \Trbrace &\\
                     |\  & \Tlpar \parsesep \Nexpr \parsesep \Trpar &\\
                     |\  & \Plisttwo{\Nexpr} &
 \end{flalign*}


### PR DESCRIPTION
This patch removes all inline derivations except for `binop` and `unop`, which need to be inlined for the lr(1) precedence derivations.

Some new production rules were added to resole shift/reduce conflicts explicitly. 