### PR TITLE
[asl] Changes to left-hand sides

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -308,20 +308,14 @@ type local_decl_keyword = LDK_Var | LDK_Constant | LDK_Let
     v}
 *)
 type local_decl_item =
-  | LDI_Discard
-      (** [LDI_Discard] is the ignored [local_decl_item], for example used in:
-          {v let - = 42; v}. *)
   | LDI_Var of identifier
       (** [LDI_Var x] is the variable declaration of the variable [x], used for
           example in: {v let x = 42; v}. *)
-  | LDI_Tuple of local_decl_item list
-      (** [LDI_Tuple ldis] is the tuple declarations of the items in [ldis],
-          used for example in: {v let (x, y, -, z) = (1, 2, 3, 4); v}
-
-          Note that a the list here must be at least 2 items long.
+  | LDI_Tuple of identifier list
+      (** [LDI_Tuple names] is the tuple declarations of [names], for example:
+          {v let (x, y, z) = (1, 2, 3); v}
+          We expect the list to contain at least 2 items.
       *)
-  | LDI_Typed of local_decl_item * ty
-      (** [LDI_Typed (ldi, t)] declares the item [ldi] with type [t]. *)
 
 (** Statements. Parametric on the type of literals in expressions. *)
 type for_direction = Up | Down
@@ -329,7 +323,7 @@ type for_direction = Up | Down
 type stmt_desc =
   | S_Pass
   | S_Seq of stmt * stmt
-  | S_Decl of local_decl_keyword * local_decl_item * expr option
+  | S_Decl of local_decl_keyword * local_decl_item * ty option * expr option
   | S_Assign of lexpr * expr
   | S_Call of call
   | S_Return of expr option

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -156,6 +156,15 @@ let rec list_map_split f = function
       let xs, ys = list_map_split f l in
       (x1 :: x2 :: xs, y1 :: y2 :: ys)
 
+let get_first_duplicate li =
+  let rec scan_for_dup = function
+    | [] | [ _ ] -> None
+    | x :: y :: rest ->
+        if String.equal x y then Some x else scan_for_dup (y :: rest)
+  in
+  let sorted = List.sort String.compare li in
+  scan_for_dup sorted
+
 let list_is_empty = function [] -> true | _ -> false
 let pair x y = (x, y)
 let pair' y x = (x, y)

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -300,7 +300,7 @@ let rec use_s s =
       use_option use_e limit $ use_e start_e $ use_e end_e $ use_s body
   | S_While (e, limit, s) | S_Repeat (s, e, limit) ->
       use_option use_e limit $ use_s s $ use_e e
-  | S_Decl (_, ldi, e) -> use_option use_e e $ use_ldi ldi
+  | S_Decl (_, _, ty, e) -> use_option use_e e $ use_option use_ty ty
   | S_Throw (Some (e, _)) -> use_e e
   | S_Throw None -> Fun.id
   | S_Try (s, catchers, s') ->
@@ -308,11 +308,6 @@ let rec use_s s =
   | S_Print { args; debug = _ } -> use_es args
   | S_Pragma (name, args) -> ISet.add name $ use_es args
   | S_Unreachable -> Fun.id
-
-and use_ldi = function
-  | LDI_Discard | LDI_Var _ -> Fun.id
-  | LDI_Typed (ldi, t) -> use_ty t $ use_ldi ldi
-  | LDI_Tuple ldis -> List.fold_right use_ldi ldis
 
 and use_case { desc = { pattern; where; stmt }; _ } =
   use_option use_e where $ use_pattern pattern $ use_s stmt
@@ -552,12 +547,19 @@ module Infix = struct
   let ( !$ ) i = expr_of_int i
 end
 
-let lid_of_lexpr =
-  let rec tr le =
+let fresh_var =
+  let i = ref 0 in
+  fun s ->
+    let () = incr i in
+    s ^ "-" ^ string_of_int !i
+
+let ldi_of_lexpr =
+  let tr_tuple_var le = match le.desc with LE_Var x -> x | _ -> raise Exit in
+  let tr le =
     match le.desc with
-    | LE_Discard -> LDI_Discard
+    | LE_Discard -> LDI_Var (fresh_var "__ldi_discard")
     | LE_Var x -> LDI_Var x
-    | LE_Destructuring les -> LDI_Tuple (List.map tr les)
+    | LE_Destructuring les -> LDI_Tuple (List.map tr_tuple_var les)
     | _ -> raise Exit
   in
   fun le -> try Some (tr le) with Exit -> None
@@ -574,12 +576,6 @@ let expr_of_lexpr : lexpr -> expr =
     | LE_Destructuring les -> E_Tuple (List.map (map_desc aux) les)
   in
   map_desc aux
-
-let fresh_var =
-  let i = ref 0 in
-  fun s ->
-    let () = incr i in
-    s ^ "-" ^ string_of_int !i
 
 (* Straight out of stdlib 4.12 *)
 let string_starts_with ~prefix s =
@@ -619,7 +615,9 @@ let desugar_case_stmt : stmt -> stmt =
         cases_to_cond ~loc:s e0 cases
     | S_Case (e, cases) ->
         let x = fresh_var "__case__linearisation" in
-        let decl_x = S_Decl (LDK_Let, LDI_Var x, Some e) |> add_pos_from e in
+        let decl_x =
+          S_Decl (LDK_Let, LDI_Var x, None, Some e) |> add_pos_from e
+        in
         S_Seq (decl_x, cases_to_cond ~loc:s (var_ x) cases) |> add_pos_from s
     | _ -> raise (Invalid_argument "desugar_case_stmt")
 (* End *)
@@ -802,7 +800,8 @@ let rename_locals map_name ast =
     map_desc_st' s @@ function
     | S_Pass -> s.desc
     | S_Seq (s1, s2) -> S_Seq (map_s s1, map_s s2)
-    | S_Decl (ldk, ldi, e) -> S_Decl (ldk, map_ldi ldi, Option.map map_e e)
+    | S_Decl (ldk, ldi, ty, e) ->
+        S_Decl (ldk, map_ldi ldi, Option.map map_t ty, Option.map map_e e)
     | S_Assign (le, e) -> S_Assign (map_le le, map_e e)
     | S_Call { name; args; params; call_type } ->
         S_Call { name; args = map_es args; params = map_es params; call_type }
@@ -839,10 +838,8 @@ let rename_locals map_name ast =
     | LE_SetFields (le, f, annot) -> LE_SetFields (map_le le, f, annot)
     | LE_Destructuring les -> LE_Destructuring (List.map map_le les)
   and map_ldi = function
-    | LDI_Discard as ldi -> ldi
     | LDI_Var x -> LDI_Var (map_name x)
-    | LDI_Typed (ldi, t) -> LDI_Typed (map_ldi ldi, map_t t)
-    | LDI_Tuple ldis -> LDI_Tuple (List.map map_ldi ldis)
+    | LDI_Tuple names -> LDI_Tuple (List.map map_name names)
   and map_body = function
     | SB_Primitive _ as b -> b
     | SB_ASL s -> SB_ASL (map_s s)

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -350,6 +350,10 @@ val list_fold_left_map :
 val uniq : 'a list -> 'a list
 (** [uniq l] returns the unique elements of [l], in the order they appear *)
 
+val get_first_duplicate : identifier list -> identifier option
+(** [get_first_duplicate ids] returns [None] if all identifiers in [ids] are
+    unique, otherwise it returns [Some id] where [id] is the first duplicate. *)
+
 val list_is_empty : 'a list -> bool
 (** [list_is_empty li] is [true] iff [li] is empty, [false] otherwise. *)
 

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -262,7 +262,7 @@ val bitwidth_equal : (expr -> expr -> bool) -> expr -> expr -> bool
 
 (** {1 Transformers} *)
 
-val lid_of_lexpr : lexpr -> local_decl_item option
+val ldi_of_lexpr : lexpr -> local_decl_item option
 val expr_of_lexpr : lexpr -> expr
 val desugar_case_stmt : stmt -> stmt
 val slice_is_single : slice -> bool

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -252,12 +252,9 @@ let pp_local_decl_keyword f k =
   | LDK_Constant -> "constant"
   | LDK_Let -> "let"
 
-let rec pp_local_decl_item f = function
-  | LDI_Discard -> pp_print_string f "-"
+let pp_local_decl_item f = function
   | LDI_Var x -> pp_print_string f x
-  | LDI_Tuple ldis ->
-      fprintf f "@[(%a)@]" (pp_comma_list pp_local_decl_item) ldis
-  | LDI_Typed (ldi, t) -> fprintf f "@[%a: %a@]" pp_local_decl_item ldi pp_ty t
+  | LDI_Tuple ldis -> fprintf f "@[(%a)@]" (pp_comma_list pp_print_string) ldis
 
 let rec pp_stmt f s =
   match s.desc with
@@ -309,11 +306,17 @@ let rec pp_stmt f s =
       fprintf f "@[<hv>@[<h>for %a = %a %s %a%a@ do@]@;<1 2>@[<hv>%a@]@ end@]"
         pp_print_string index_name pp_expr start_e (pp_for_direction dir)
         pp_expr end_e pp_loop_limit limit pp_stmt body
-  | S_Decl (ldk, ldi, None) ->
+  | S_Decl (ldk, ldi, None, None) ->
       fprintf f "@[<2>%a %a;@]" pp_local_decl_keyword ldk pp_local_decl_item ldi
-  | S_Decl (ldk, ldi, Some e) ->
+  | S_Decl (ldk, ldi, None, Some e) ->
       fprintf f "@[<2>%a %a =@ %a;@]" pp_local_decl_keyword ldk
         pp_local_decl_item ldi pp_expr e
+  | S_Decl (ldk, ldi, Some ty, None) ->
+      fprintf f "@[<2>%a %a:@ %a;@]" pp_local_decl_keyword ldk
+        pp_local_decl_item ldi pp_ty ty
+  | S_Decl (ldk, ldi, Some ty, Some e) ->
+      fprintf f "@[<2>%a %a:@ %a =@ %a;@]" pp_local_decl_keyword ldk
+        pp_local_decl_item ldi pp_ty ty pp_expr e
   | S_Throw (Some (e, _ty_annotation)) ->
       fprintf f "@[<2>throw@ %a;@]" pp_expr e
   | S_Throw None -> fprintf f "throw;"

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -430,6 +430,10 @@ let discard_or_sliced_basic_lexpr :=
   | MINUS;                { None }
   | ~=sliced_basic_lexpr; < Some >
 
+let discard_or_field :=
+  | MINUS;                   { None }
+  | ~=annotated(IDENTIFIER); < Some >
+
 let lexpr :=
   | ~=sliced_basic_lexpr; < desugar_lhs_access >
   | ~=annotated(pared(clist2(discard_or_sliced_basic_lexpr))); < desugar_lhs_tuple >
@@ -437,6 +441,8 @@ let lexpr :=
     | MINUS; { LE_Discard }
     | x=annotated(IDENTIFIER); DOT; flds=bracketed(clist2(IDENTIFIER));
       { LE_SetFields (le_var x, flds, []) }
+    | x=annotated(IDENTIFIER); DOT; flds=pared(clist2(discard_or_field));
+      { desugar_lhs_fields_tuple x flds }
   )
 
 (* Decl items are another kind of left-hand-side expressions, which appear only

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -250,12 +250,9 @@ let pp_local_decl_keyboard f k =
     | LDK_Constant -> "LDK_Constant"
     | LDK_Let -> "LDK_Let")
 
-let rec pp_local_decl_item f = function
-  | LDI_Discard -> addb f "LDI_Discard"
+let pp_local_decl_item f = function
   | LDI_Var s -> bprintf f "LDI_Var %S" s
-  | LDI_Typed (ldi, t) ->
-      bprintf f "LDI_Typed (%a, %a)" pp_local_decl_item ldi pp_ty t
-  | LDI_Tuple ldis -> bprintf f "LDI_Tuple %a" (pp_list pp_local_decl_item) ldis
+  | LDI_Tuple ldis -> bprintf f "LDI_Tuple %a" (pp_list pp_string) ldis
 
 let rec pp_stmt =
   let pp_desc f = function
@@ -286,9 +283,10 @@ let rec pp_stmt =
           index_name pp_expr start_e
           (match dir with Up -> "Up" | Down -> "Down")
           pp_expr end_e pp_stmt body (pp_option pp_expr) limit
-    | S_Decl (ldk, ldi, e_opt) ->
-        bprintf f "S_Decl (%a, %a, %a)" pp_local_decl_keyboard ldk
-          pp_local_decl_item ldi (pp_option pp_expr) e_opt
+    | S_Decl (ldk, ldi, ty_opt, e_opt) ->
+        bprintf f "S_Decl (%a, %a, %a, %a)" pp_local_decl_keyboard ldk
+          pp_local_decl_item ldi (pp_option pp_ty) ty_opt (pp_option pp_expr)
+          e_opt
     | S_Throw opt ->
         bprintf f "S_Throw (%a)"
           (pp_option (pp_pair pp_expr (pp_option pp_ty)))

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -2577,26 +2577,11 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           T_Tuple lhs_tys' |> add_pos_from ~loc:lhs_ty
     | _ -> lhs_ty
 
-  let rec annotate_local_decl_item ~loc (env : env) ty ldk ?e ldi =
+  let annotate_local_decl_item ~loc (env : env) ty ldk ?e ldi =
     let () =
       if false then Format.eprintf "Annotating %a.@." PP.pp_local_decl_item ldi
     in
     match ldi with
-    (* Begin LDDiscard *)
-    | LDI_Discard -> (env, ldi, SES.empty) |: TypingRule.LDDiscard
-    (* End *)
-    (* Begin LDTyped *)
-    | LDI_Typed (ldi', t) ->
-        let ty' = Types.get_structure env ty in
-        let t = inherit_integer_constraints ~loc t ty' in
-        let t', ses_t = annotate_type ~loc env t in
-        let+ () = check_can_be_initialized_with ~loc env t' ty in
-        let new_env, new_ldi', ses_ldi =
-          annotate_local_decl_item ~loc env t' ldk ?e ldi'
-        in
-        let ses = SES.union ses_t ses_ldi in
-        (new_env, LDI_Typed (new_ldi', t'), ses) |: TypingRule.LDTyped
-    (* End *)
     (* Begin LDVar *)
     | LDI_Var x ->
         (* Rule LCFD: A ~local declaration shall not declare an identifier
@@ -2604,64 +2589,36 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         let+ () = check_var_not_in_env ~loc env x in
         let env2 = add_local x ty ldk env in
         let new_env = add_immutable_expression env2 ldk e x in
-        (new_env, LDI_Var x, SES.empty) |: TypingRule.LDVar
+        new_env |: TypingRule.LDVar
     (* End *)
     (* Begin LDTuple *)
-    | LDI_Tuple ldis ->
+    | LDI_Tuple names ->
         let tys =
           match (Types.make_anonymous env ty).desc with
-          | T_Tuple tys when List.compare_lengths tys ldis = 0 -> tys
+          | T_Tuple tys when List.compare_lengths tys names = 0 -> tys
           | T_Tuple tys ->
               fatal_from ~loc
                 (Error.BadArity
                    ( Static,
                      "tuple initialization",
                      List.length tys,
-                     List.length ldis ))
+                     List.length names ))
           | _ -> conflict ~loc [ T_Tuple [] ] ty
         in
-        let new_env, new_ldis, sess =
+        let new_env =
           List.fold_right2
-            (fun ty' ldi' (env', les, sess) ->
-              let env', le, ses =
-                annotate_local_decl_item ~loc env' ty' ldk ldi'
-              in
-              (env', le :: les, ses :: sess))
-            tys ldis (env, [], [])
+            (fun ty' name env' ->
+              let+ () = check_var_not_in_env ~loc env' name in
+              add_local name ty' ldk env')
+            tys names env
         in
-        let ses = SES.unions sess in
-        (new_env, LDI_Tuple new_ldis, ses) |: TypingRule.LDTuple
-  (* End *)
-
-  (* Begin AnnotateLocalDeclItemUninit *)
-  let annotate_local_decl_item_uninit ~loc (env : env) ldi =
-    (* Here implicitly ldk=LDK_Var *)
-    match ldi with
-    | LDI_Discard | LDI_Tuple _ | LDI_Var _ ->
-        (* Here LDI_Tuple is never parsed containing any LDI_Typed, so we don't
-           need to care about decalarations in it. *)
-        fatal_from ~loc (Error.BadLDI ldi) |: TypingRule.LDUninitialisedVar
-    | LDI_Typed (ldi', t) ->
-        let t', ses_t = annotate_type ~loc env t in
-        let e_init = base_value ~loc env t' in
-        let new_env, new_ldi', ses_ldi =
-          annotate_local_decl_item ~loc env t' LDK_Var ldi'
-        in
-        let ses = SES.union ses_t ses_ldi in
-        (new_env, LDI_Typed (new_ldi', t'), e_init, ses)
-        |: TypingRule.LDUninitialisedTyped
+        new_env |: TypingRule.LDTuple
   (* End *)
 
   (* Begin DeclareLocalConstant *)
-  let declare_local_constant =
-    let rec add_constants v env ldi =
-      match ldi with
-      | LDI_Discard -> env
-      | LDI_Var x -> add_local_constant x v env
-      | LDI_Tuple _ -> (* Not yet implemented *) env
-      | LDI_Typed (ldi, _ty) -> add_constants v env ldi
-    in
-    fun env v ldi -> add_constants v env ldi
+  let declare_local_constant env v = function
+    | LDI_Var x -> add_local_constant x v env
+    | LDI_Tuple _ -> (* Not yet implemented *) env
   (* End *)
 
   let rec annotate_stmt env s : stmt * env * SES.t =
@@ -2707,14 +2664,13 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                     * Fix this by typing first assignments of
                     * undeclared variables as declarations.
                     *)
-                   match ASTUtils.lid_of_lexpr le with
+                   match ASTUtils.ldi_of_lexpr le with
                    | None -> env
                    | Some ldi ->
-                       let rec undefined = function
-                         | LDI_Discard -> true
+                       let undefined = function
                          | LDI_Var x -> is_undefined x env
-                         | LDI_Tuple ldis -> List.for_all undefined ldis
-                         | LDI_Typed (ldi', _) -> undefined ldi'
+                         | LDI_Tuple names ->
+                             List.for_all (fun x -> is_undefined x env) names
                        in
                        if undefined ldi then
                          let () =
@@ -2724,7 +2680,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                                PP.pp_stmt s
                          in
                          let ldk = LDK_Var in
-                         let env2, _ldi, _ses_ldi =
+                         let env2 =
                            annotate_local_decl_item ~loc env t_re ldk ldi
                          in
                          env2
@@ -2859,7 +2815,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         |: TypingRule.SFor
     (* End *)
     (* Begin SDecl *)
-    | S_Decl (ldk, ldi, e_opt) -> (
+    | S_Decl (ldk, ldi, ty_opt, e_opt) -> (
         match (ldk, e_opt) with
         (* SDecl.Some( *)
         | _, Some e ->
@@ -2868,18 +2824,26 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
               if false then
                 Format.eprintf "Found rhs side-effects: %a@." SES.pp_print ses_e
             in
-            let env1, ldi1, ses_ldi =
-              annotate_local_decl_item ~loc env t_e ldk ~e:typed_e ldi
+            let env1, ty_opt', ses_ldi =
+              match ty_opt with
+              | None ->
+                  let env1 =
+                    annotate_local_decl_item ~loc env t_e ldk ~e:typed_e ldi
+                  in
+                  (* When [print_typed] is specified, wrap untyped items with their inferred type. *)
+                  let ty_opt = if C.print_typed then Some t_e else None in
+                  (env1, ty_opt, SES.empty)
+              | Some t ->
+                  let t_e' = Types.get_structure env t_e in
+                  let t = inherit_integer_constraints ~loc t t_e' in
+                  let t', ses_t = annotate_type ~loc env t in
+                  let+ () = check_can_be_initialized_with ~loc env t' t_e in
+                  let env1 =
+                    annotate_local_decl_item ~loc env t' ldk ~e:typed_e ldi
+                  in
+                  (env1, Some t', ses_t)
             in
             let ses = SES.union ses_e ses_ldi in
-            let ldi1 =
-              if C.print_typed then
-                (* When [print_typed] is specified, wrap untyped items with their inferred type. *)
-                match ldi1 with
-                | LDI_Typed _ | LDI_Discard -> ldi1
-                | LDI_Var _ | LDI_Tuple _ -> LDI_Typed (ldi1, t_e)
-              else ldi1
-            in
             let new_env =
               match ldk with
               | LDK_Let | LDK_Var -> env1
@@ -2887,18 +2851,28 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                   let+ () = check_leq_constant_time ~loc:s typed_e in
                   try
                     let v = StaticInterpreter.static_eval env1 e in
-                    declare_local_constant env1 v ldi1
+                    declare_local_constant env1 v ldi
                   with Error.(ASLException _) -> env1)
             in
-            (S_Decl (ldk, ldi1, Some e') |> here, new_env, ses)
+            (S_Decl (ldk, ldi, ty_opt', Some e') |> here, new_env, ses)
             |: TypingRule.SDecl
         (* SDecl.Some) *)
         (* SDecl.None( *)
         | LDK_Var, None ->
-            let new_env, ldi1, e_init, ses_ldi =
-              annotate_local_decl_item_uninit ~loc env ldi
-            in
-            (S_Decl (LDK_Var, ldi1, Some e_init) |> here, new_env, ses_ldi)
+            (match ty_opt with
+            | None ->
+                fatal_from ~loc (Error.BadLDI ldi)
+                |: TypingRule.LDUninitialisedVar
+            | Some t ->
+                let t', ses_t' = annotate_type ~loc env t in
+                let e_init = base_value ~loc env t' in
+                let new_env =
+                  annotate_local_decl_item ~loc env t' LDK_Var ldi
+                in
+                ( S_Decl (LDK_Var, ldi, Some t', Some e_init) |> here,
+                  new_env,
+                  ses_t' )
+                |: TypingRule.LDUninitialisedTyped)
             |: TypingRule.SDecl
         | (LDK_Constant | LDK_Let), None ->
             fatal_from ~loc UnrespectedParserInvariant)
@@ -3062,12 +3036,10 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     let t_sub_re, sub_re, ses_sub_re =
       expr_of_lexpr sub_le |> annotate_expr env
     in
-    let env1, ldi_x, ses_ldi =
-      annotate_local_decl_item ~loc env t_sub_re LDK_Var (LDI_Var x)
-    in
+    let ldi_x = LDI_Var x in
+    let env1 = annotate_local_decl_item ~loc env t_sub_re LDK_Var ldi_x in
     let s1, ses_s1 =
-      ( S_Decl (LDK_Var, ldi_x, Some sub_re) |> here,
-        SES.union ses_ldi ses_sub_re )
+      (S_Decl (LDK_Var, ldi_x, None, Some sub_re) |> here, ses_sub_re)
     in
     let s2, ses_s2 =
       let t_e, e, ses_e = typed_e in
@@ -3147,9 +3119,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         match (Types.make_anonymous env t_e).desc with
         | T_Tuple t_es when List.compare_lengths les t_es = 0 ->
             let x = fresh_var "__setter_destructuring" in
-            let env1, ldi_x, ses_ldi =
-              annotate_local_decl_item ~loc env t_e LDK_Let ~e:typed_e
-                (LDI_Var x)
+            let ldi_x = LDI_Var x in
+            let env1 =
+              annotate_local_decl_item ~loc env t_e LDK_Let ~e:typed_e ldi_x
             in
             let sub_e i = E_GetItem (E_Var x |> here, i) |> here in
             let recurse_one i sub_le t_sub_e =
@@ -3159,7 +3131,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             let subs = list_mapi2 recurse_one 0 les t_es in
             if List.for_all Option.is_none subs then None
             else
-              let s0 = S_Decl (LDK_Let, ldi_x, Some e) |> here in
+              let s0 = S_Decl (LDK_Let, ldi_x, None, Some e) |> here in
               let produce_one i sub_le t_sub_e_i = function
                 | None ->
                     let sub_le', sub_le_ses =
@@ -3172,7 +3144,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                 list_mapi3 produce_one 0 les t_es subs |> List.split
               in
               let s = stmt_from_list (s0 :: stmts)
-              and ses = SES.unions (ses_ldi :: ses_e :: sess) in
+              and ses = SES.unions (ses_e :: sess) in
               Some (s, ses)
         | _ -> None)
     | LE_Var x ->

--- a/asllib/carpenter/ASTEnums.ml
+++ b/asllib/carpenter/ASTEnums.ml
@@ -289,22 +289,15 @@ module Make (C : Config.S) = struct
   let ldks = scaled_finite [ LDK_Constant; LDK_Var; LDK_Let ]
 
   let ldis =
-    fix @@ fun ldis ->
-    let ldi_discard = just LDI_Discard
-    and ldi_var =
+    let ldi_var =
       let make_ldi_var s = LDI_Var s in
       vars |> map make_ldi_var
     and ldi_tuple =
       let make_ldi_tuple ldis = LDI_Tuple ldis in
-      list2 ldis |> map make_ldi_tuple
-    and ldi_typed =
-      let make_ldi_typed (ldi, ty) = LDI_Typed (ldi, ty) in
-      ldis ** tys |> map make_ldi_typed
+      list2 names |> map make_ldi_tuple
     in
     [
-      (if C.Syntax.ldi_discard then Some ldi_discard else None);
       (if C.Syntax.ldi_var then Some ldi_var else None);
-      (if C.Syntax.ldi_typed then Some ldi_typed else None);
       (if C.Syntax.ldi_tuple then Some ldi_tuple else None);
     ]
     |> filter_none |> oneof
@@ -359,8 +352,10 @@ module Make (C : Config.S) = struct
       let make_s_return expr = S_Return expr in
       option exprs |> map make_s_return
     and s_decl =
-      let make_s_decl (ldk, (ldi, expr_opt)) = S_Decl (ldk, ldi, expr_opt) in
-      ldks ** ldis ** option exprs |> map make_s_decl
+      let make_s_decl (ldk, (ldi, (ty_opt, expr_opt))) =
+        S_Decl (ldk, ldi, ty_opt, expr_opt)
+      in
+      ldks ** ldis ** option tys ** option exprs |> map make_s_decl
     and s_for =
       let make_s_for (index_name, (start_e, (dir, (end_e, body)))) =
         S_For { index_name; start_e; dir; end_e; body; limit = None }

--- a/asllib/carpenter/config.ml
+++ b/asllib/carpenter/config.ml
@@ -93,10 +93,8 @@ module type Syntax = sig
   val ldk_var : bool
   val ldk_let : bool
   val ldk_constant : bool
-  val ldi_discard : bool
   val ldi_var : bool
   val ldi_tuple : bool
-  val ldi_typed : bool
   val up : bool
   val down : bool
   val s_pass : bool
@@ -214,10 +212,8 @@ module All : Syntax = struct
   let ldk_var = true
   let ldk_let = true
   let ldk_constant = true
-  let ldi_discard = true
   let ldi_var = true
   let ldi_tuple = true
-  let ldi_typed = true
   let up = true
   let down = true
   let s_pass = true
@@ -350,10 +346,8 @@ module Parse = struct
         ("ldk_var", true);
         ("ldk_let", true);
         ("ldk_constant", true);
-        ("ldi_discard", true);
         ("ldi_var", true);
         ("ldi_tuple", true);
-        ("ldi_typed", true);
         ("up", true);
         ("down", true);
         ("s_pass", true);
@@ -471,10 +465,8 @@ module Parse = struct
       let ldk_var = Tbl.find tbl "ldk_var"
       let ldk_let = Tbl.find tbl "ldk_let"
       let ldk_constant = Tbl.find tbl "ldk_constant"
-      let ldi_discard = Tbl.find tbl "ldi_discard"
       let ldi_var = Tbl.find tbl "ldi_var"
       let ldi_tuple = Tbl.find tbl "ldi_tuple"
-      let ldi_typed = Tbl.find tbl "ldi_typed"
       let up = Tbl.find tbl "up"
       let down = Tbl.find tbl "down"
       let s_pass = Tbl.find tbl "s_pass"

--- a/asllib/desugar.ml
+++ b/asllib/desugar.ml
@@ -38,7 +38,7 @@ let desugar_setter call fields rhs =
         let getter_call =
           E_Call { name; args; params; call_type = ST_Getter } |> here
         in
-        S_Decl (LDK_Var, LDI_Var temp, Some getter_call) |> here
+        S_Decl (LDK_Var, LDI_Var temp, None, Some getter_call) |> here
       in
       (* temp.field = rhs OR temp.[field1, field2, ...] = rhs; *)
       let modify =
@@ -58,10 +58,10 @@ let desugar_setter call fields rhs =
       in
       S_Seq (s_then read modify, write)
 
-let desugar_elided_parameter ldk lhs (call : call annotated) =
+let desugar_elided_parameter ldk lhs ty (call : call annotated) =
   let bits_e =
-    match lhs with
-    | LDI_Typed (_, { desc = T_Bits (bits_e, []) }) -> bits_e
+    match ty.desc with
+    | T_Bits (bits_e, []) -> bits_e
     | _ ->
         (* For example, let x = foo{,M}(args); cannot be desugared as there is
            no bits(_) annotation on the left-hand side *)
@@ -69,4 +69,4 @@ let desugar_elided_parameter ldk lhs (call : call annotated) =
   in
   let params = bits_e :: call.desc.params in
   let rhs = E_Call { call.desc with params } |> add_pos_from call in
-  S_Decl (ldk, lhs, Some rhs)
+  S_Decl (ldk, lhs, Some ty, Some rhs)

--- a/asllib/desugar.mli
+++ b/asllib/desugar.mli
@@ -46,3 +46,32 @@ val desugar_elided_parameter :
   ]}
   Similarly for [var] and [constant].
 *)
+
+(* -------------------------------------------------------------------------
+    Left-hand sides
+   ------------------------------------------------------------------------- *)
+
+(* Types to represent valid left-hand sides produced by parsing. *)
+
+type lhs_field = identifier annotated
+
+type lhs_access = {
+  base : identifier annotated;
+  index : expr option;
+  fields : lhs_field list;  (** empty means no fields *)
+  slices : slice list annotated;  (** empty means no slices *)
+}
+(** An access has a [base] variable, optionally followed by an
+    array [index], nested field accesses [fields], and [slices]:
+    [base[[index]].field1.field2[slices]]
+*)
+
+val desugar_lhs_access : lhs_access -> lexpr
+(** Desugar an [lhs_access] to an [lexpr]. *)
+
+val desugar_lhs_tuple : lhs_access option list annotated -> lexpr
+(** Desugar a list of [lhs_access] options to an [LE_Destructuring].
+    The [None] entries turn in to [LE_Discard], and the [Some] entries are
+    desugared using [desugar_lhs_access].
+    Also check that none of the entries share a base variable, i.e. none of them
+    attempt to write the the same variable. *)

--- a/asllib/desugar.mli
+++ b/asllib/desugar.mli
@@ -37,7 +37,7 @@ val desugar_setter : call annotated -> identifier list -> expr -> stmt_desc
 *)
 
 val desugar_elided_parameter :
-  local_decl_keyword -> local_decl_item -> call annotated -> stmt_desc
+  local_decl_keyword -> local_decl_item -> ty -> call annotated -> stmt_desc
 (**
   Desugar an elided parameter, in particular:
   {[

--- a/asllib/desugar.mli
+++ b/asllib/desugar.mli
@@ -75,3 +75,9 @@ val desugar_lhs_tuple : lhs_access option list annotated -> lexpr
     desugared using [desugar_lhs_access].
     Also check that none of the entries share a base variable, i.e. none of them
     attempt to write the the same variable. *)
+
+val desugar_lhs_fields_tuple :
+  identifier annotated -> lhs_field option list -> lexpr_desc
+(** [desugar_lhs_fields_tuple x flds] desugards a left-hand side of the form
+    [x.(fld1, ..., fldk)] to [(x.fld1, ..., x.fldk)], ensuring that the [flds]
+    are unique. *)

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -492,7 +492,6 @@
 \newcommand\Nstmt[0]{\hyperlink{def-nstmt}{\nonterminal{stmt}}}
 \newcommand\Nselse[0]{\hyperlink{def-nselse}{\nonterminal{s\_else}}}
 \newcommand\Ndeclitem[0]{\hyperlink{def-ndeclitem}{\nonterminal{decl\_item}}}
-\newcommand\Nuntypeddeclitem[0]{\hyperlink{def-nuntypeddeclitem}{\nonterminal{untyped\_decl\_item}}}
 \newcommand\Nslice[0]{\hyperlink{def-nslice}{\nonterminal{slice}}}
 \newcommand\Nslices[0]{\hyperlink{def-nslices}{\nonterminal{slices}}}
 \newcommand\Nconstraintkind[0]{\hyperlink{def-nintconstraints}{\nonterminal{constraint\_kind}}}
@@ -707,9 +706,7 @@
 \newcommand\PatternTuple[0]{\hyperlink{ast-patterntuple}{\textsf{Pattern\_Tuple}}}
 
 % Local declarations
-\newcommand\LDIDiscard[0]{\hyperlink{ast-ldidiscard}{\textsf{LDI\_Discard}}}
 \newcommand\LDIVar[0]{\hyperlink{ast-ldivar}{\textsf{LDI\_Var}}}
-\newcommand\LDITyped[0]{\hyperlink{ast-ldityped}{\textsf{LDI\_Typed}}}
 \newcommand\LDITuple[0]{\hyperlink{ast-ldituple}{\textsf{LDI\_Tuple}}}
 
 \newcommand\LDKVar[0]{\hyperlink{ast-ldkvar}{\textsf{LDK\_Var}}}
@@ -758,7 +755,6 @@
 \newcommand\buildast[0]{\hyperlink{build-ast}{\textfunc{build\_ast}}}
 \newcommand\builddecl[0]{\hyperlink{build-decl}{\textfunc{build\_decl}}}
 \newcommand\builddeclitem[0]{\hyperlink{build-declitem}{\textfunc{build\_decl\_item}}}
-\newcommand\builduntypeddeclitem[0]{\hyperlink{build-untypeddeclitem}{\textfunc{build\_untyped\_decl\_item}}}
 \newcommand\makesetter[0]{\hyperlink{def-makesetter}{\textfunc{make\_setter}}}
 \newcommand\desugarsetter[0]{\hyperlink{def-desugarsetter}{\textfunc{desugar\_setter}}}
 \newcommand\buildlooplimit[0]{\hyperlink{build-looplimit}{\textfunc{build\_looplimit}}}
@@ -1287,7 +1283,6 @@
 \newcommand\usebitfield[0]{\hyperlink{def-usebitfield}{\textfunc{use\_bitfield}}}
 \newcommand\useconstraint[0]{\hyperlink{def-useconstraint}{\textfunc{use\_constraint}}}
 \newcommand\usestmt[0]{\hyperlink{def-usestmt}{\textfunc{use\_s}}}
-\newcommand\useldi[0]{\hyperlink{def-useldi}{\textfunc{use\_ldi}}}
 \newcommand\usecase[0]{\hyperlink{def-usecase}{\textfunc{use\_case}}}
 \newcommand\usecatcher[0]{\hyperlink{def-usecatcher}{\textfunc{use\_catcher}}}
 \newcommand\builddependencies[0]{\hyperlink{def-builddependencies}{\textfunc{build\_dependencies}}}
@@ -1610,7 +1605,7 @@
 \newcommand\reduceconstraint[0]{\hyperlink{def-reduceconstraint}{\textfunc{reduce\_constraint}}}
 \newcommand\reduceconstraints[0]{\hyperlink{def-reduceconstraints}{\textfunc{reduce\_constraints}}}
 \newcommand\declarelocalconstant[0]{\hyperlink{def-declarelocalconstant}{\textfunc{declare\_local\_constant}}}
-\newcommand\annotatelocaldeclitemuninit[0]{\hyperlink{def-annotatelocaldeclitemuninit}{\textfunc{annotate\_local\_decl\_item\_uninit}}}
+\newcommand\annotatelocaldecltypeannot[0]{\hyperlink{def-annotatelocaldecltypeannot}{\textfunc{annotate\_local\_decl\_type\_annot}}}
 \newcommand\checkvarnotinenv[1]{\hyperlink{def-checkvarnotinenv}{\textfunc{check\_var\_not\_in\_env}}(#1)}
 \newcommand\checkvarnotingenv[1]{\hyperlink{def-checkvarnotingenv}{\textfunc{check\_var\_not\_in\_genv}}(#1)}
 \newcommand\annotatesubprogram[0]{\hyperlink{def-annotatesubprogram}{\textfunc{annotate\_subprogram}}}
@@ -2025,7 +2020,6 @@
 \newcommand\mcond[0]{\texttt{m\_cond}}
 \newcommand\mfactor[0]{\texttt{m\_factor}}
 \newcommand\mindex[0]{\texttt{m\_index}}
-\newcommand\minitopt[0]{\texttt{m\_init\_opt}}
 \newcommand\minpos[0]{\texttt{min\_pos}}
 \newcommand\mlength[0]{\texttt{m\_length}}
 \newcommand\monome[0]{\texttt{monome}}
@@ -2443,6 +2437,7 @@
 \newcommand\vidasts[0]{\texttt{id\_asts}}
 \newcommand\vidopt[0]{\texttt{id\_opt}}
 \newcommand\vids[0]{\texttt{ids}}
+\newcommand\vignoredoridentifier[0]{\texttt{ignored\_or\_identifier}}
 \newcommand\vindex[0]{\texttt{index}}
 \newcommand\vindexname[0]{\texttt{index\_name}}
 \newcommand\vinitialvalue[0]{\texttt{initial\_value}}
@@ -2722,7 +2717,6 @@
 \newcommand\vu[0]{\texttt{u}}
 \newcommand\vunop[0]{\texttt{unop}}
 \newcommand\vuntypedast[0]{\texttt{untyped\_ast}}
-\newcommand\vuntypedlocaldeclitem[0]{\texttt{untyped\_local\_decl\_item}}
 \newcommand\vused[0]{\texttt{used}}
 \newcommand\vusedone[0]{\texttt{used1}}
 \newcommand\vv[0]{\texttt{v}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -570,7 +570,7 @@
 \newcommand\SHL[0]{\hyperlink{ast-shl}{\texttt{SHL}}} % Shift left for integers
 \newcommand\SHR[0]{\hyperlink{ast-shr}{\texttt{SHR}}} % Shift right for integers
 
-\newcommand\ARBITRARY[0]{\hyperlink{ast-arbitrary}{\texttt{ARBITRARY}}}
+\newcommand\ARBITRARY[0]{\hyperlink{ast-earbitrary}{\texttt{ARBITRARY}}}
 
 % For loop direction
 \newcommand\UP[0]{\hyperlink{ast-up}{\texttt{Up}}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -474,8 +474,12 @@
 \newcommand\Ninitialvalue[0]{\hyperlink{def-ninitialvalue}{\nonterminal{initial\_value}}}
 \newcommand\Nty[0]{\hyperlink{def-nty}{\nonterminal{ty}}}
 \newcommand\Nexpr[0]{\hyperlink{def-nexpr}{\nonterminal{expr}}}
+\newcommand\Nbasiclexpr[0]{\hyperlink{def-nbasiclexpr}{\nonterminal{basic\_lexpr}}}
+\newcommand\Nnestedfields[0]{\hyperlink{def-nnestedfields}{\nonterminal{nested\_fields}}}
+\newcommand\Nslicedbasiclexpr[0]{\hyperlink{def-nslicedbasiclexpr}{\nonterminal{sliced\_basic\_lexpr}}}
+\newcommand\Ndiscardorslicedbasiclexpr[0]{\hyperlink{def-ndiscardorslicedbasiclexpr}{\nonterminal{discard\_or\_sliced\_basic\_lexpr}}}
+\newcommand\Ndiscardoridentifier[0]{\hyperlink{def-ndiscardoridentifier}{\nonterminal{discard\_or\_identifier}}}
 \newcommand\Nlexpr[0]{\hyperlink{def-nlexpr}{\nonterminal{lexpr}}}
-\newcommand\Nlexpratom[0]{\hyperlink{def-nlexpratom}{\nonterminal{lexpr\_atom}}}
 \newcommand\Nfields[0]{\hyperlink{def-nfields}{\nonterminal{fields}}}
 \newcommand\Nfieldsopt[0]{\hyperlink{def-nfieldsopt}{\nonterminal{fields\_opt}}}
 \newcommand\Nopttypedidentifier[0]{\hyperlink{def-nopttypeidentifier}{\nonterminal{opt\_typed\_identifier}}}
@@ -594,6 +598,7 @@
 \newcommand\bitfield[0]{\hyperlink{ast-bitfield}{\textsf{bitfield}}}
 \newcommand\spec[0]{\hyperlink{ast-spec}{\textsf{spec}}}
 \newcommand\typedidentifier[0]{\hyperlink{ast-typedidentifier}{\textsf{typed\_identifier}}}
+\newcommand\lhsaccess[0]{\hyperlink{ast-lhsaccess}{\textsf{lhs\_access}}}
 \newcommand\localdeclkeyword[0]{\hyperlink{ast-localdeclkeyword}{\textsf{local\_decl\_keyword}}}
 \newcommand\globaldeclkeyword[0]{\hyperlink{ast-globaldeclkeyword}{\textsf{global\_decl\_keyword}}}
 \newcommand\localdeclitem[0]{\hyperlink{ast-localdeclitem}{\textsf{local\_decl\_item}}}
@@ -763,7 +768,16 @@
 \newcommand\buildstmt[0]{\hyperlink{build-stmt}{\textfunc{build\_stmt}}}
 \newcommand\buildexpr[0]{\hyperlink{build-expr}{\textfunc{build\_expr}}}
 \newcommand\buildlexpr[0]{\hyperlink{build-lexpr}{\textfunc{build\_lexpr}}}
-\newcommand\buildlexpratom[0]{\hyperlink{build-lexpratom}{\textfunc{build\_lexpr\_atom}}}
+\newcommand\buildbasiclexpr[0]{\hyperlink{build-basiclexpr}{\textfunc{build\_basic\_lexpr}}}
+\newcommand\buildnestedfields[0]{\hyperlink{build-nestedfields}{\textfunc{build\_nested\_fields}}}
+\newcommand\buildslicedbasiclexpr[0]{\hyperlink{build-slicedbasiclexpr}{\textfunc{build\_sliced\_basic\_lexpr}}}
+\newcommand\builddiscardorslicedbasiclexpr[0]{\hyperlink{build-discardorslicedbasiclexpr}{\textfunc{build\_discard\_or\_sliced\_basic\_lexpr}}}
+\newcommand\builddiscardoridentifier[0]{\hyperlink{build-discardoridentifier}{\textfunc{build\_discard\_or\_identifier}}}
+\newcommand\desugarlhsaccess[0]{\hyperlink{def-desugarlhsaccess}{\textfunc{desugar\_lhs\_access}}}
+\newcommand\desugarlhsaccessopt[0]{\hyperlink{def-desugarlhsaccessopt}{\textfunc{desugar\_lhs\_access\_opt}}}
+\newcommand\desugarlhstuple[0]{\hyperlink{def-desugarlhstuple}{\textfunc{desugar\_lhs\_tuple}}}
+\newcommand\desugarlhsfieldopt[0]{\hyperlink{def-desugarlhsfieldopt}{\textfunc{desugar\_lhs\_field\_opt}}}
+\newcommand\desugarlhsfieldstuple[0]{\hyperlink{def-desugarlhsfieldstuple}{\textfunc{desugar\_lhs\_fields\_tuple}}}
 \newcommand\buildparamsopt[0]{\hyperlink{build-paramsopt}{\textfunc{build\_params\_opt}}}
 \newcommand\buildfuncargs[0]{\hyperlink{build-funcargs}{\textfunc{build\_func\_args}}}
 \newcommand\buildcall[0]{\hyperlink{build-call}{\textfunc{build\_call}}}
@@ -918,6 +932,10 @@
 \newcommand\callparams[0]{\text{params}}
 \newcommand\callargs[0]{\text{args}}
 \newcommand\callcalltype[0]{\text{call\_type}}
+\newcommand\lhsaccessbase[0]{\text{base}}
+\newcommand\lhsaccessindex[0]{\text{index}}
+\newcommand\lhsaccessfields[0]{\text{fields}}
+\newcommand\lhsaccessslices[0]{\text{slices}}
 
 \newcommand\True[0]{\hyperlink{def-true}{\texttt{TRUE}}}
 \newcommand\False[0]{\hyperlink{def-false}{\texttt{FALSE}}}
@@ -1664,6 +1682,7 @@
 \newcommand\samescope[0]{\hyperlink{def-samescope}{\textfunc{same\_scope}}}
 
 \newcommand\checknoduplicates[0]{\hyperlink{def-checknoduplicates}{\textfunc{check\_no\_duplicates}}}
+\newcommand\filteroptionlist[0]{\hyperlink{def-filteroptionlist}{\textfunc{filter\_option\_list}}}
 \newcommand\typeofarraylength[0]{\hyperlink{def-typeofarraylength}{\textfunc{type\_of\_array\_length}}}
 \newcommand\addlocal[0]{\hyperlink{def-addlocal}{\textfunc{add\_local}}}
 \newcommand\declaretype[0]{\hyperlink{def-declaretype}{\textfunc{declare\_type}}}
@@ -1949,6 +1968,8 @@
 \newcommand\fieldname[0]{\texttt{field\_name}}
 \newcommand\fields[0]{\texttt{fields}}
 \newcommand\fieldsone[0]{\texttt{fields1}}
+\newcommand\fieldopt[0]{\texttt{field\_opt}}
+\newcommand\fieldopts[0]{\texttt{field\_opts}}
 \newcommand\fieldsp[0]{\texttt{fields'}}
 \newcommand\fieldstwo[0]{\texttt{fields2}}
 \newcommand\fieldtypes[0]{\texttt{field\_types}}
@@ -2284,6 +2305,7 @@
 \newcommand\vb[0]{\texttt{b}}
 \newcommand\vbp[0]{\texttt{b'}}
 \newcommand\vbase[0]{\texttt{base}}
+\newcommand\vbasiclexpr[0]{\texttt{basic\_lexpr}}
 \newcommand\vbequal[0]{\texttt{b\_equal}}
 \newcommand\vbequallength[0]{\texttt{b\_equal\_length}}
 \newcommand\vbexploding[0]{\texttt{b\_exploding}}
@@ -2423,6 +2445,10 @@
 \newcommand\vg[0]{\texttt{g}}
 \newcommand\vgfour[0]{\texttt{g4}}
 \newcommand\vgfive[0]{\texttt{g5}}
+\newcommand\vlhsaccess[0]{\texttt{lhs\_access}}
+\newcommand\vlhsaccesses[0]{\texttt{lhs\_accesses}}
+\newcommand\vlhsaccessopt[0]{\texttt{lhs\_access\_opt}}
+\newcommand\vlhsaccessopts[0]{\texttt{lhs\_access\_opts}}
 \newcommand\vlocal[0]{\texttt{local}}
 \newcommand\vlooplimit[0]{\texttt{looplimit}}
 \newcommand\vglobal[0]{\texttt{global}}
@@ -2468,7 +2494,6 @@
 \newcommand\vletwo[0]{\texttt{le2}}
 \newcommand\vlexpr[0]{\texttt{lexpr}}
 \newcommand\vlexprasts[0]{\texttt{lexpr\_asts}}
-\newcommand\vlexpratom[0]{\texttt{lexpr\_atom}}
 \newcommand\vlexprs[0]{\texttt{lexprs}}
 \newcommand\vli[0]{\texttt{li}}
 \newcommand\vlimit[0]{\texttt{limit}}
@@ -2516,6 +2541,7 @@
 \newcommand\vnamet[0]{\texttt{name\_t}}
 \newcommand\vneg[0]{\texttt{neg}}
 \newcommand\vnested[0]{\texttt{nested}}
+\newcommand\vnestedfields[0]{\texttt{nested\_fields}}
 \newcommand\vnextlimitopt[0]{\texttt{next\_limit\_opt}}
 \newcommand\vnew[0]{\texttt{new}}
 \newcommand\vds[0]{\texttt{ds}}
@@ -2619,7 +2645,9 @@
 \newcommand\vsesty[0]{\texttt{ses\_ty}}
 \newcommand\newses[0]{\texttt{new\_ses}}
 \newcommand\vslice[0]{\texttt{slice}}
+\newcommand\vsliced[0]{\texttt{sliced}}
 \newcommand\vsliceasts[0]{\texttt{slice\_asts}}
+\newcommand\vslicedbasiclexpr[0]{\texttt{sliced\_basic\_lexpr}}
 \newcommand\vsliceone[0]{\texttt{slice1}}
 \newcommand\vslicetwo[0]{\texttt{slice2}}
 \newcommand\vslices[0]{\texttt{slices}}
@@ -2727,11 +2755,14 @@
 \newcommand\vvfields[0]{\texttt{v\_fields}}
 \newcommand\vvl[0]{\texttt{vl}}
 \newcommand\vvopt[0]{\texttt{v\_opt}}
+\newcommand\vvopts[0]{\texttt{v\_opts}}
+\newcommand\vvoptsp[0]{\texttt{v\_opts'}}
 \newcommand\vvoptp[0]{\texttt{v\_opt'}}
 \newcommand\vvone[0]{\texttt{v1}}
 \newcommand\vvp[0]{\texttt{v'}}
 \newcommand\vvparams[0]{\texttt{vparams}}
 \newcommand\vvs[0]{\texttt{vs}}
+\newcommand\vvsp[0]{\texttt{vs'}}
 \newcommand\vvsg[0]{\texttt{vsg}}
 \newcommand\vvsm[0]{\texttt{vsm}}
 \newcommand\vvsmone[0]{\texttt{vsm1}}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -425,21 +425,16 @@ the local declaration item is
 
 \hypertarget{ast-localdeclitem}{} \hypertarget{ast-ldidiscard}{}
 \begin{flalign*}
-\localdeclitem \derives\ & \LDIDiscard
-  % & & \ASTComment{The ignored local declaration item, for example used in: \Verb!let - = 42;!.}
+\localdeclitem \derives\ &
   & \hypertarget{ast-ldivar}{}\\
   |\ & \LDIVar(\identifier)
   % & & \ASTComment{\texttt{LDI\_Var x} is the variable declaration of the variable \texttt{x}, used for example in:}\\
   % & & \ASTComment{\texttt{let x = 42;}.}
   & \hypertarget{ast-ldituple}{}\\
-  |\ & \LDITuple(\localdeclitem^*)
+  |\ & \LDITuple(\identifier^*) &
   % & & \ASTComment{\texttt{LDI\_Tuple ldis} is the tuple declarations of the items in \texttt{ldis},}\\
   % & & \ASTComment{used for example in: \texttt{let (x, y, -, z) = (1, 2, 3, 4);}}\\
   % & & \ASTComment{Note that a the list here must be at least 2 items long.}
-  & \hypertarget{ast-ldityped}{}\\
-  |\ & \LDITyped(\localdeclitem, \ty) &
-  % & & \ASTComment{\texttt{LDI\_Typed (ldi, t)} declares the item \texttt{ldi} with type \texttt{t}, used for example in:} \\
-  % & & \ASTComment{\texttt{let x: integer = 4;}}
 \end{flalign*}
 
 \subsection{Statements \label{sec:Statements}}
@@ -452,7 +447,7 @@ the local declaration item is
 \hypertarget{ast-sseq}{} &\\
   |\ & \SSeq(\stmt, \stmt)
   \hypertarget{ast-sdecl}{} &\\
-  |\ & \SDecl(\localdeclkeyword, \localdeclitem, \expr?)
+  |\ & \SDecl(\localdeclkeyword, \localdeclitem, \ty?, \expr?)
   \hypertarget{ast-sassign}{} &\\
   |\ & \SAssign(\lexpr, \expr)
   \hypertarget{ast-scall}{} &\\

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -8,6 +8,7 @@ by $\lexpr$.
 
 We show the syntax relevant to \assignableexpressions\ in \secref{AssignableExpressionsSyntax} and
 the rules need to build the AST for \assignableexpressions\ in \secref{AssignableExpressionsAbstractSyntaxBuilders}.
+These rules rely on three further desugaring relations, defined in \secref{AssignableExpressionsDesugaring}.
 We then define the abstract syntax, typing, and semantics of the different kinds of \assignableexpressions:
 \begin{itemize}
 \item Discarding assignment expressions (see \secref{DiscardingAssignmentExpressions})
@@ -61,17 +62,52 @@ using $\texttt{eval\_expr}$ to evaluate it.
 
 \section{Syntax\label{sec:AssignableExpressionsSyntax}}
 \begin{flalign*}
-\Nlexpr \derives\ & \Nlexpratom &\\
-|\ & \Tminus &\\
-|\ & \Tlpar \parsesep \Clisttwo{\Nlexpr} \parsesep \Trpar &\\
-\Nlexpratom \derives\ & \Tidentifier &\\
-|\ & \Nlexpratom \parsesep \Nslices &\\
-|\ & \Nlexpratom \parsesep \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket &\\
-|\ & \Nlexpratom \parsesep \Tdot \parsesep \Tidentifier{\field} &\\
-|\ & \Nlexpratom \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clist{{\Tidentifier}} \parsesep \Trbracket &
+\Nlexpr \derives\
+   & \Tminus &\\
+|\ & \Nslicedbasiclexpr &\\
+|\ & \Tlpar \parsesep \Clisttwo{\Ndiscardorslicedbasiclexpr} \parsesep \Trpar &\\
+|\ & \Tidentifier \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clisttwo{\Tidentifier} \parsesep \Trbracket &\\
+|\ & \Tidentifier \parsesep \Tdot \parsesep \Tlpar \parsesep \Clisttwo{\Nignoredoridentifier} \parsesep \Trpar &
+\end{flalign*}
+
+\begin{flalign*}
+\Nbasiclexpr \derives\
+   & \Tidentifier \parsesep \Nnestedfields &\\
+|\ & \Tidentifier \parsesep \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket \parsesep \Nnestedfields &
+\end{flalign*}
+
+\begin{flalign*}
+\Nnestedfields \derives\ & \emptysentence \;|\; \Tdot \parsesep \Tidentifier \parsesep \Nnestedfields &
+\end{flalign*}
+
+\begin{flalign*}
+\Nslicedbasiclexpr \derives\ & \Nbasiclexpr \;|\; \Nbasiclexpr \parsesep \Nslices &
+\end{flalign*}
+
+\begin{flalign*}
+\Ndiscardorslicedbasiclexpr \derives\ & \Tminus \;|\; \Nslicedbasiclexpr &
 \end{flalign*}
 
 \subsection{Abstract Syntax Builders\label{sec:AssignableExpressionsAbstractSyntaxBuilders}}
+
+We first define $\lhsaccess$, which we use in this section as an intermediate representation between some syntax forms of \assignableexpressions{} and their corresponding abstract syntax.
+In particular, rather than directly building the abstract syntax for these \assignableexpressions{}, we first build structures containing $\lhsaccess$, which we then desugar into abstract syntax in \secref{AssignableExpressionsDesugaring}.
+
+\hypertarget{ast-lhsaccess}{}
+\begin{flalign*}
+\lhsaccess \derives\ &
+{
+\left\{
+  \begin{array}{rcl}
+    \lhsaccessbase &:& \identifier, \\
+    \lhsaccessindex &:& \expr?,\\
+    \lhsaccessfields &:& \identifier^{*},\\
+    \lhsaccessslices &:& \slice^{*}
+\end{array}
+\right\}
+} &
+\end{flalign*}
+
 \subsubsection{ASTRule.LExpr \label{sec:ASTRule.LExpr}}
 \hypertarget{build-lexpr}{}
 The function
@@ -81,72 +117,325 @@ The function
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
-\inferrule[lexpr\_atom]{}{
-  \buildlexpr(\Nlexpr(\punnode{\Nlexpratom})) \astarrow \overname{\astof{\vlexpratom}}{\vastnode}
-}
-\end{mathpar}
-
-\begin{mathpar}
 \inferrule[discard]{}{
   \buildlexpr(\Nlexpr(\Tminus)) \astarrow \overname{\LEDiscard}{\vastnode}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[multi\_lexpr]{
-  \buildclist[\Nlexpr](\vlexprs) \astarrow \vlexprasts
+\inferrule[sliced\_basic\_lexpr]{
+  \desugarlhsaccess(\astof{\vslicedbasiclexpr}) \astarrow \vastnode
 }{
-  \buildlexpr(\Nlexpr(\Tlpar, \namednode{\vlexprs}{\Clisttwo{\Nlexpr}}, \Trpar)) \astarrow
-  \overname{\LEDestructuring(\vlexprasts)}{\vastnode}
-}
-\end{mathpar}
-
-\subsubsection{ASTRule.LExprAtom \label{sec:ASTRule.LExprAtom}}
-\hypertarget{build-lexpratom}{}
-The function
-\[
-  \buildlexpratom(\overname{\parsenode{\Nlexpratom}}{\vparsednode}) \;\aslto\; \overname{\lexpr}{\vastnode}
-\]
-transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
-
-\begin{mathpar}
-\inferrule[var]{}{
-  \buildlexpratom(\Nlexpr(\Tidentifier(\id))) \astarrow
-  \overname{\LEVar(\id)}{\vastnode}
+  \buildlexpr(\Nlexpr(\punnode{\Nslicedbasiclexpr})) \astarrow \vastnode
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[slice]{}{
-  \buildlexpratom(\Nlexpr(\punnode{\Nlexpratom}, \punnode{\Nslices})) \astarrow
-  \overname{\LESlice(\astof{\vlexpratom}, \astof{\vslices})}{\vastnode}
+\inferrule[multi\_lexpr]{
+  \buildclist[\builddiscardorslicedbasiclexpr](\vlexprs) \astarrow \vlexprasts \\
+  \desugarlhstuple(\vlexprasts) \astarrow \vastnode
+}{
+  {
+  \begin{array}{r}
+  \buildlexpr(\Nlexpr(\Tlpar, \namednode{\vlexprs}{\Clisttwo{\Ndiscardorslicedbasiclexpr}}, \Trpar)) \\
+  \astarrow \vastnode
+  \end{array}
+  }
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[array]{}{
-  \buildlexpratom(\Nlexpr(\punnode{\Nlexpratom}, \Tllbracket, \punnode{\Nexpr}, \Trrbracket)) \astarrow
-  \overname{\LESetArray(\astof{\vlexpratom}, \astof{\vexpr})}{\vastnode}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[set\_field]{}{
-  \buildlexpratom(\Nlexpr(\punnode{\Nlexpratom}, \Tdot, \Tidentifier(\id))) \astarrow
-  \overname{\LESetField(\astof{\vlexpratom}, \id)}{\vastnode}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[set\_fields]{
+\inferrule[concat\_fields]{
   \buildclist[\buildidentity](\vfields) \astarrow \vfieldasts
 }{
   {
   \begin{array}{r}
-  \buildlexpratom(\Nlexpr(\punnode{\Nlexpratom}, \Tdot, \Tlbracket, \namednode{\vfields}{\Clist{\Tidentifier}}, \Trbracket)) \astarrow\\
-  \overname{\LESetFields(\astof{\vlexpratom}, \vfieldasts)}{\vastnode}
+  \buildlexpr(\Nlexpr(\Tidentifier(\id), \Tdot, \Tlbracket, \namednode{\vfields}{\Clisttwo{\Tidentifier}}, \Trbracket)) \astarrow \\
+  \overname{\LESetFields (\LEVar(\id), \vfieldasts)}{\vastnode}
   \end{array}
   }
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[tuple\_fields]{
+  \buildclist[\builddiscardoridentifier](\vids) \astarrow \astversion{\vids} \\
+  \desugarlhsfieldstuple(\id, \astversion{\vids}) \astarrow \vastnode
+}{
+  {
+  \begin{array}{r}
+  \buildlexpr(\Nlexpr(\Tidentifier(\id), \Tdot, \Tlpar, \namednode{\vids}{\Clisttwo{\Ndiscardoridentifier}}, \Trpar))\\ \astarrow
+  \vastnode
+  \end{array}
+  }
+}
+\end{mathpar}
+
+\subsubsection{ASTRule.BasicLexpr \label{sec:ASTRule.BasicLexpr}}
+\hypertarget{build-basiclexpr}{}
+The function
+\[
+  \buildbasiclexpr(\overname{\parsenode{\Nbasiclexpr}}{\vparsednode}) \;\aslto\; \overname{\lhsaccess}{\vastnode}
+\]
+transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
+
+\begin{mathpar}
+\inferrule[no\_index]{
+  \vastnode \eqdef \left\{
+  {
+  \begin{array}{rcl}
+    \lhsaccessbase   &:& \id,\\
+    \lhsaccessindex  &:& \None,\\
+    \lhsaccessfields &:& \astof{\vnestedfields},\\
+    \lhsaccessslices &:& \emptylist
+  \end{array}
+  }
+  \right\}
+}{
+  \buildbasiclexpr(\Nbasiclexpr(\Tidentifier(\id), \punnode{\Nnestedfields})) \astarrow
+  \vastnode
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[index]{
+  \vastnode \eqdef \left\{
+  {
+  \begin{array}{rcl}
+    \lhsaccessbase   &:& \id,\\
+    \lhsaccessindex  &:& \langle \astof{\vexpr} \rangle,\\
+    \lhsaccessfields &:& \astof{\vnestedfields},\\
+    \lhsaccessslices &:& \emptylist
+  \end{array}
+  }
+  \right\}
+}{
+  \buildbasiclexpr(\Nbasiclexpr(\Tidentifier(\id), \Tllbracket, \punnode{\Nexpr}, \Trrbracket, \punnode{\Nnestedfields})) \astarrow
+  \vastnode
+}
+\end{mathpar}
+
+\subsubsection{ASTRule.NestedFields \label{sec:ASTRule.NestedFields}}
+\hypertarget{build-nestedfields}{}
+The function
+\[
+  \buildnestedfields(\overname{\parsenode{\Nnestedfields}}{\vparsednode}) \;\aslto\; \overname{\identifier^*}{\vastnode}
+\]
+transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
+
+\begin{mathpar}
+\inferrule[empty]{}{
+  \buildnestedfields(\Nnestedfields(\emptysentence)) \astarrow
+  \overname{\emptylist}{\vastnode}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_empty]{}{
+  {
+    \begin{array}{r}
+      \buildnestedfields(\Nnestedfields(\Tdot, \Tidentifier(\id), \punnode{\Nnestedfields})) \astarrow\\
+      \overname{[\id] \concat \vnestedfields}{\vastnode}
+    \end{array}
+  }
+}
+\end{mathpar}
+
+\subsubsection{ASTRule.SlicedBasicLexpr \label{sec:ASTRule.SlicedBasicLexpr}}
+\hypertarget{build-slicedbasiclexpr}{}
+The function
+\[
+  \buildslicedbasiclexpr(\overname{\parsenode{\Nslicedbasiclexpr}}{\vparsednode}) \;\aslto\; \overname{\lhsaccess}{\vastnode}
+\]
+transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
+
+\begin{mathpar}
+\inferrule[no\_slices]{}{
+  \buildslicedbasiclexpr(\Nslicedbasiclexpr(\punnode{\Nbasiclexpr})) \astarrow
+  \overname{\astof{\vbasiclexpr}}{\vastnode}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[slices]{}{
+  {
+    \begin{array}{r}
+      \buildslicedbasiclexpr(\Nslicedbasiclexpr(\punnode{\Nbasiclexpr}, \punnode{\Nslices})) \astarrow \\
+      \overname{\astof{\vbasiclexpr}[\lhsaccessslices \mapsto \astof{\vslices}]}{\vastnode}
+    \end{array}
+  }
+}
+\end{mathpar}
+
+\subsubsection{ASTRule.DiscardOrSlicedBasicLexpr \label{sec:ASTRule.DiscardOrSlicedBasicLexpr}}
+
+\hypertarget{build-discardorslicedbasiclexpr}{}
+The function
+\[
+\begin{array}{r}
+  \builddiscardorslicedbasiclexpr(\overname{\parsenode{\Ndiscardorslicedbasiclexpr}}{\vparsednode}) \;\aslto\\
+  \overname{\langle\lhsaccess\rangle}{\vastnode}
+\end{array}
+\]
+transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
+
+\begin{mathpar}
+\inferrule[discard]{}{
+  \builddiscardorslicedbasiclexpr(\Ndiscardorslicedbasiclexpr(\Tminus)) \astarrow \overname{\None}{\vastnode}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[sliced\_basic]{}{
+  {
+    \begin{array}{r}
+      \builddiscardorslicedbasiclexpr(\Ndiscardorslicedbasiclexpr(\punnode{\Nslicedbasiclexpr})) \astarrow \\
+      \overname{\langle \astof{\vslicedbasiclexpr} \rangle}{\vastnode}
+    \end{array}
+  }
+}
+\end{mathpar}
+
+\subsection{Desugaring Assignable Expressions\label{sec:AssignableExpressionsDesugaring}}
+
+This section defines three desugaring relations which produce assignable expression abstract syntax, that is, $\lexpr$.
+They are used in \secref{AssignableExpressionsAbstractSyntaxBuilders} to build $\lexpr$ abstract syntax.
+\begin{itemize}
+  \item $\desugarlhsaccess$, which desugars an $\lhsaccess$ into an $\lexpr$.
+  \item $\desugarlhstuple$, which desugars a tuple of optional $\lhsaccess$ elements into an $\lexpr$.
+    This represents a multi-assignment of a tuple value, where $\None$ means that element of the tuple is discarded.
+  \item $\desugarlhsfieldstuple$, which desugars a multi-assignment of a tuple value to multiple fields of an identifier.
+\end{itemize}
+
+\subsubsection{ASTRule.DesugarLHSAccess \label{sec:ASTRule.DesugarLHSAccess}}
+\hypertarget{def-desugarlhsaccess}{}
+The function
+\[
+  \desugarlhsaccess(\overname{\lhsaccess}{\vlhsaccess}) \;\aslto\; \overname{\lexpr}{\vlexpr}
+\]
+transforms an $\lhsaccess$ into an AST node $\vlexpr$.
+
+\begin{mathpar}
+\inferrule[index\_none]{
+  \vlexprs_0 \eqdef \EVar(\id) \\
+  i \in 1..|\vfields|: \vlexprs_i \eqdef \LESetField(\vlexprs_{i-1}, \vfields_i) \\
+  \vsliced \eqdef
+  \choice{\vslices = \emptylist}{\vlexprs_{|\vfields|}}{\ESlice(\vlexprs_{|\vfields|}, \vslices)} \\
+}{
+  \desugarlhsaccess\overname{
+    \left\{
+      {
+        \begin{array}{rcl}
+          \lhsaccessbase &:& \id, \\
+          \lhsaccessindex &:& \None,\\
+          \lhsaccessfields &:& \vfields,\\
+          \lhsaccessslices &:& \vslices
+        \end{array}
+      }
+    \right\}
+  }{\vlhsaccess} \astarrow \overname{\vsliced}{\vlexpr}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[index\_some]{
+  \vlexprs_0 \eqdef \LESetArray(\EVar(\id), \vindex) \\
+  i \in 1..|\vfields|: \vlexprs_i \eqdef \LESetField(\vlexprs_{i-1}, \vfields_i) \\
+  \vsliced \eqdef
+  \choice{\vslices = \emptylist}{\vlexprs_{|\vfields|}}{\ESlice(\vlexprs_{|\vfields|}, \vslices)} \\
+}{
+  \desugarlhsaccess\overname{
+    \left\{
+      {
+        \begin{array}{rcl}
+          \lhsaccessbase &:& \id, \\
+          \lhsaccessindex &:& \langle\vindex\rangle,\\
+          \lhsaccessfields &:& \vfields,\\
+          \lhsaccessslices &:& \vslices
+        \end{array}
+      }
+    \right\}
+  }{\vlhsaccess} \astarrow \overname{\vsliced}{\vlexpr}
+}
+\end{mathpar}
+\subsubsection{ASTRule.DesugarLHSTuple \label{sec:ASTRule.DesugarLHSTuple}}
+\hypertarget{def-desugarlhstuple}{}
+The function
+\[
+  \desugarlhstuple(\overname{\langle\lhsaccess\rangle^*}{\vlhsaccessopts}) \;\aslto\; \overname{\lexpr}{\vlexpr}
+\]
+transforms a list of \optional{} $\lhsaccess$ elements into an AST node $\vlexpr$. \\
+
+\hypertarget{def-desugarlhsaccessopt}{}
+\noindent We first define the helper AST function
+\[
+    \desugarlhsaccessopt(\overname{\langle\lhsaccess\rangle}{\vlhsaccessopt}) \;\aslto\; \overname{\lexpr}{\vlexpr}
+\]
+via the following rules:
+\begin{mathpar}
+\inferrule[none]{}
+{
+  \desugarlhsaccessopt(\overname{\None}{\vlhsaccessopt}) \astarrow \overname{\LEDiscard}{\vlexpr}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[some]{
+  \desugarlhsaccess(\vlhsaccess) \astarrow \vlexpr
+}{
+  \desugarlhsaccessopt(\overname{\langle\vlhsaccess\rangle}{\vlhsaccessopt}) \astarrow \vlexpr
+}
+\end{mathpar}
+
+\noindent We now use the helper rules to define $\desugarlhstuple$:
+\begin{mathpar}
+\inferrule{
+  \vlhsaccesses \eqdef \filteroptionlist(\vlhsaccessopts) \\
+  \vids \eqdef [i \in 1..|\vlhsaccesses|: \vlhsaccesses_i.\lhsaccessbase] \\
+  \checknoduplicates(\vids) \typearrow \True \OrTypeError \\
+  i \in 1..|\vlhsaccessopts|: \desugarlhsaccessopt(\vlhsaccessopt_i) \astarrow \vlexpr_i \\
+  \vlexprs \eqdef [i \in 1..|\vlhsaccessopts|: \vlexpr_i]
+}{
+  \desugarlhstuple(\vlhsaccessopts) \astarrow \overname{\LEDestructuring(\vlexprs)}{\vlexpr}
+}
+\end{mathpar}
+
+\subsubsection{ASTRule.DesugarLHSFieldsTuple \label{sec:ASTRule.DesugarLHSFieldsTuple}}
+\hypertarget{def-desugarlhsfieldstuple}{}
+The function
+\[
+  \desugarlhsfieldstuple(\overname{\identifier}{\id} \aslsep \overname{\langle\identifier\rangle^*}{\fieldopts}) \;\aslto\; \overname{\lexpr}{\vlexpr}
+\]
+transforms an assignment to a tuple of fields $\fields$ of variable $\id$ into an AST node $\vlexpr$. \\
+
+\hypertarget{def-desugarlhsfieldopt}{}
+\noindent We first define the helper AST function
+\[
+    \desugarlhsfieldopt(\overname{\identifier}{\id} \aslsep \overname{\langle\identifier\rangle}{\fieldopt}) \;\aslto\; \overname{\lexpr}{\vlexpr}
+\]
+via the following rules:
+\begin{mathpar}
+\inferrule[none]{}
+{
+  \desugarlhsfieldopt(\id, \overname{\None}{\fieldopt}) \astarrow \overname{\LEDiscard}{\vlexpr}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule{}{
+  \desugarlhsfieldopt(\id, \overname{\langle\vfield\rangle}{\fieldopt}) \astarrow \overname{\LESetField(\LEVar(\id), \vfield)}{\vlexpr}
+}
+\end{mathpar}
+
+\noindent We now use the helper rules to define $\desugarlhsfieldstuple$:
+\begin{mathpar}
+\inferrule{
+  \fields \eqdef \filteroptionlist(\fieldopts) \\
+  \checknoduplicates(\fields) \typearrow \True \OrTypeError \\
+  i \in 1..|\fieldopts|: \desugarlhsfieldopt(\fieldopts_i) \astarrow \vlexpr_i \\
+  \vlexprs \eqdef [i \in 1..|\fieldopts|: \vlexpr_i]
+}{
+  \desugarlhsfieldstuple(\id, \fieldopts) \astarrow \overname{\LEDestructuring(\vlexprs)}{\vlexpr}
 }
 \end{mathpar}
 

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -496,7 +496,7 @@ The following list represents keywords that are reserved for future use.
 \begin{tabular}{ll}
 \textbf{Lexical Regular Expressions} & \textbf{Lexeme Action}\\
 \hline
-\texttt{"SAMPLE"}, \texttt{"UNSTABLE"} & $\lexicalerror$ \\
+\texttt{"SAMPLE"}, \texttt{"UNKNOWN"}, \texttt{"UNSTABLE"} & $\lexicalerror$ \\
 \texttt{"\_"}, \texttt{"any"} & $\lexicalerror$ \\
 \texttt{"assume"}, \texttt{"assumes"} & $\lexicalerror$ \\
 \texttt{"call"}, \texttt{"cast"} & $\lexicalerror$ \\

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -13,9 +13,7 @@ We show the syntax relevant to local declarations in \secref{LocalStorageDeclara
 the AST rule and rules need to build the AST for \assignableexpressions\ in \secref{LocalStorageDeclarationsAbstractSyntax}.
 We then define the typing and semantics of the different kinds of local declarations:
 \begin{itemize}
-\item Discarding declarations (see \secref{DiscardingDeclarations})
-\item Un-annotated variable declarations (see \secref{UnAnnotatedVariableDeclarations})
-\item Type-annotated variable declarations (see \secref{TypeAnnotatedVariableDeclarations})
+\item Variable declarations (see \secref{VariableDeclarations})
 \item Tuple declarations (see \secref{TupleDeclarations})
 \end{itemize}
 
@@ -33,15 +31,14 @@ We then define the typing and semantics of the different kinds of local declarat
     \overname{\localdeclitem}{\ldi}
     \end{array}
    \right) \aslto\\
-  (\overname{\staticenvs}{\newtenv} \aslsep \overname{\localdeclitem}{\newldi} \aslsep \overname{\TSideEffectSet}{\vses})
+  (\overname{\staticenvs}{\newtenv})
   \cup \overname{\TTypeError}{\TypeErrorConfig}
   \end{array}
 \]
 annotates a \localdeclarationitem\ $\ldi$ with a \localdeclarationkeyword\ $\ldk$, given a type $\tty$,
 and optionally $\veopt$ --- an initializing expression and \sideeffectsetterm,
-in a static environment $\tenv$ results in $(\newenv, \newldi)$ where $\newenv$ is the modified
-static environment, the annotated local declaration item $\newldi$, and the
-\sideeffectsetterm\ $\vses$.
+in a static environment $\tenv$ results in $\newenv$, the modified
+static environment.
 \ProseOtherwiseTypeError
 
 \paragraph{Semantics:} The relation
@@ -50,14 +47,14 @@ static environment, the annotated local declaration item $\newldi$, and the
   \evallocaldecl{
     \overname{\envs}{\env} \aslsep
     \overname{\localdeclitem}{\ldi} \aslsep
-    \overname{\langle\overname{\vals}{\vv}\times\overname{\XGraphs}{\vgone}\rangle}{\minitopt}
+    \overname{\overname{\vals}{\vv}\times\overname{\XGraphs}{\vgone}}{\vm}
     } \;\aslrel\;
     \Normal(\overname{\XGraphs}{\newg}, \overname{\envs}{\newenv})
 \]
 evaluates a \localdeclarationitem\ $\ldi$ in an environment
-$\env$ with an optional initialization value $\minitopt$.
-That is, the right-hand side of the declaration, if it exists,
-has already been evaluated, yielding $\minitopt$ (see, for example, \nameref{sec:SemanticsRule.SDeclSome}).
+$\env$ with an initialization value $\vm$.
+That is, the right-hand side of the declaration
+has already been evaluated, yielding $\vm$ (see, for example, \nameref{sec:SemanticsRule.SDeclSome}).
 Evaluation of the local variables $\ldi$
 in an environment $\env$ is either $\Normal(\vg, \newenv)$
 or an abnormal configuration.
@@ -69,27 +66,24 @@ from the perspective of the semantics of local storage elements, they are all tr
 \section{Syntax\label{sec:LocalStorageDeclarationsSyntax}}
 Declaring a local storage element is done via the following grammar rules:
 \begin{flalign*}
-\Nstmt \derives \ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
+\Nstmt \derives \ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
 |\ & \Tvar \parsesep \Clisttwo{\Tidentifier} \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon &\\
 \end{flalign*}
 
 \begin{flalign*}
 \Nlocaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant&\\
-\Ndeclitem \derives\ & \Nuntypeddeclitem \parsesep \Nasty&\\
-|\ & \Nuntypeddeclitem  &\\
-\Nuntypeddeclitem \derives \ & \Tidentifier &\\
-|\ & \Tminus &\\
-|\ & \Plisttwo{\Ndeclitem} &
+\Ndeclitem \derives\
+   & \Nignoredoridentifier &\\
+|\ & \Plisttwo{\Nignoredoridentifier} &
 \end{flalign*}
 
 \section{Abstract Syntax\label{sec:LocalStorageDeclarationsAbstractSyntax}}
 \begin{flalign*}
 \localdeclkeyword \derives\ & \LDKVar \;|\; \LDKConstant \;|\; \LDKLet &\\
-\localdeclitem \derives\ & \LDIDiscard &\\
-    |\ & \LDIVar(\identifier) & \\
-    |\ & \LDITuple(\localdeclitem^*) &\\
-    |\ & \LDITyped(\localdeclitem, \ty) &
+\localdeclitem \derives\
+     & \LDIVar(\identifier) & \\
+  |\ & \LDITuple(\identifier^*) &
 \end{flalign*}
 
 \subsubsection{ASTRule.LocalDeclKeyword\label{sec:ASTRule.LocalDeclKeyword}}
@@ -122,107 +116,26 @@ The function
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
-\inferrule[typed]{}{
-  {
-    \begin{array}{r}
-  \builddeclitem(\Ndeclitem(\punnode{\Nuntypeddeclitem}, \punnode{\Nasty})) \astarrow \\
-  \overname{\LDITyped(\astof{\vuntypedlocaldeclitem}, \astof{\vasty})}{\vastnode}
-    \end{array}
-  }
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[untyped]{}{
-  \builddeclitem(\Ndeclitem(\punnode{\Nuntypeddeclitem})) \astarrow
-  \overname{\astof{\vuntypedlocaldeclitem}}{\vastnode}
-}
-\end{mathpar}
-
-\subsubsection{ASTRule.UntypedDeclItem\label{sec:ASTRule.UntypedDeclItem}}
-\hypertarget{build-untypeddeclitem}{}
-The function
-\[
-  \builduntypeddeclitem(\overname{\parsenode{\Nuntypeddeclitem}}{\vparsednode}) \;\aslto\; \overname{\localdeclitem}{\vastnode}
-\]
-transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
-
-\begin{mathpar}
 \inferrule[var]{}{
-  \builduntypeddeclitem(\Nuntypeddeclitem(\Tidentifier(\id))) \astarrow
-  \overname{\LDIVar(\id)}{\vastnode}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[discard]{}{
-  \builduntypeddeclitem(\Nuntypeddeclitem(\Tminus)) \astarrow
-  \overname{\LDIDiscard}{\vastnode}
+  \builddeclitem(\Ndeclitem(\punnode{\Nignoredoridentifier})) \astarrow
+  \overname{\astof{\vignoredoridentifier}}{\vastnode}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[tuple]{
-  \buildclist[\builddeclitem](\vdeclitems) \astarrow \vdeclitemasts
+  \buildclist[\buildignoredoridentifier](\vids) \astarrow \astversion{\vids}
 }{
   {
     \begin{array}{r}
-  \builduntypeddeclitem(\Nuntypeddeclitem(\namednode{\vdeclitems}{\Plisttwo{\Ndeclitem}})) \astarrow \\
-  \overname{\LDITuple(\vdeclitemasts)}{\vastnode}
+  \builddeclitem(\Ndeclitem(\namednode{\vids}{\Plisttwo{\Nignoredoridentifier}})) \astarrow \\
+  \overname{\LDITuple(\astversion{\vids})}{\vastnode}
     \end{array}
   }
 }
 \end{mathpar}
 
-\section{Discarding Declarations\label{sec:DiscardingDeclarations}}
-\subsection{Typing}
-\subsubsection{TypingRule.LDDiscard \label{sec:TypingRule.LDDiscard}}
-\subsubsection{Example}
-\VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDDiscard.asl}
-
-\subsubsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\ldi$ is a local declaration which can be discarded, that is, $\LDIDiscard(\None)$;
-  \item $\newenv$ is $\tenv$;
-  \item $\newldi$ is $\ldi$;
-  \item \Proseeqdef{$\vses$}{the empty set}.
-\end{itemize}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{}{
-  \annotatelocaldeclitem(\tenv, \tty, \ldk, \veopt, \overname{\LDIDiscard(\None)}{\ldi}) \typearrow (\tenv, \ldi, \overname{\emptyset}{\vses})
-}
-\end{mathpar}
-\CodeSubsection{\LDDiscardBegin}{\LDDiscardEnd}{../Typing.ml}
-
-\subsection{Semantics}
-\subsubsection{SemanticsRule.LDDiscard \label{sec:SemanticsRule.LDDiscard}}
-\subsubsection{Example}
-In the specification:
-\VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.LDDiscard.asl}
-\texttt{var - : integer;} does not modify the environment.
-
-\subsubsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\ldi$ indicates that the initialization value will be discarded,
-        $\LDIDiscard$;
-  \item $\newg$ is the empty graph;
-  \item $\newenv$ is $\env$.
-\end{itemize}
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{}
-{
-  \evallocaldecl{\env, \overname{\LDIDiscard}{\ldi}, \overname{\color{white}{\texttt{xx}\Ignore}\texttt{xx}}{\minitopt}}
-  \evalarrow \Normal(\overname{\emptygraph}{\newg}, \overname{\env}{\newenv})
-}
-\end{mathpar}
-\CodeSubsection{\EvalLDDiscardBegin}{\EvalLDDiscardEnd}{../Interpreter.ml}
-
-\section{Un-annotated Variable Declarations\label{sec:UnAnnotatedVariableDeclarations}}
+\section{Variable Declarations\label{sec:VariableDeclarations}}
 \subsection{Typing}
 \subsubsection{TypingRule.LDVar \label{sec:TypingRule.LDVar}}
 \subsubsection{Example}
@@ -235,9 +148,7 @@ All of the following apply:
   \item determining whether $\vx$ is not declared in $\tenv$ yields $\True$\ProseOrTypeError;
   \item $\tenvtwo$ is $\tenv$ modified so that $\vx$ is locally declared to have type $\tty$;
   \item applying $\addimmutableexpression$ to $\ldk$, $\veopt$, and $\vx$ in $\tenv$ (to conditionally
-        update $\tenvtwo$) yields $\newtenv$;
-  \item $\newldi$ is the declaration of variable $\vx$;
-  \item \Proseeqdef{$\vses$}{the empty set}.
+        update $\tenvtwo$) yields $\newtenv$.
 \end{itemize}
 \subsubsection{Formally}
 \begin{mathpar}
@@ -246,8 +157,7 @@ All of the following apply:
   \addlocal(\tenv, \vx, \tty, \ldk) \typearrow \tenvtwo\\
   \addimmutableexpression(\tenvtwo, \ldk, \veopt, \vx) \typearrow \newtenv
 }{
-  \annotatelocaldeclitem(\tenv, \tty, \ldk, \veopt, \overname{\LDIVar(\vx)}{\ldi}) \typearrow
-  (\newtenv, \LDIVar(\vx), \overname{\emptyset}{\vses})
+  \annotatelocaldeclitem(\tenv, \tty, \ldk, \veopt, \overname{\LDIVar(\vx)}{\ldi}) \typearrow \newtenv
 }
 \end{mathpar}
 \CodeSubsection{\LDVarBegin}{\LDVarEnd}{../Typing.ml}
@@ -259,7 +169,6 @@ All of the following apply:
     All of the following apply:
     \begin{itemize}
     \item $\ldi$ is a variable declaration, $\LDIVar(\vx)$;
-    \item $\minitopt$ is $\vm$;
     \item $\vm$ is a pair consisting of the value $\vv$ and execution graph $\vgone$;
     \item declaring $\vx$ in $\env$ is $(\newenv, \vgtwo)$;
     \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge.
@@ -283,217 +192,10 @@ In the specification:
   \declarelocalidentifier(\env, \vx, \vv)\evalarrow(\newenv, \vgtwo)\\
   \newg \eqdef \ordered{\vgone}{\asldata}{\vgtwo}
 }{
-  \evallocaldecl{\env, \LDIVar(\vx), \langle \vm\rangle} \evalarrow \Normal(\newg, \newenv)
+  \evallocaldecl{\env, \LDIVar(\vx), \vm} \evalarrow \Normal(\newg, \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalLDVarBegin}{\EvalLDVarEnd}{../Interpreter.ml}
-
-\section{Type-annotated Variable Declarations\label{sec:TypeAnnotatedVariableDeclarations}}
-\subsection{Typing}
-\subsubsection{TypingRule.LDTyped\label{sec:TypingRule.LDTyped}}
-\subsubsection{Example}
-\VerbatimInput{../tests/ASLTypingReference.t/TypingRule.LDTyped.asl}
-
-\subsubsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\ldi$ denotes a local declaration item $\ldip$ with local declaration keyword $\ldk$
-        and a type $\vt$, that is $\LDITyped(\ldip, \vt)$;
-  \item determining the \structure{} of right-hand side type $\tty$ in $\tenv$ yields $\ttyp$;
-  \item propagating integer constraints from $\ttyp$ to $\vt$ using $\inheritintegerconstraints$ yields $\vtone$;
-  \item annotating the type $\vtone$ in $\tenv$ yields $(\vttwo, \vsest)$\ProseOrTypeError;
-  \item determining whether $\vttwo$ can be initialized with $\tty$ in $\tenv$ yields $\True$\ProseOrTypeError;
-  \item annotating the local declaration item $\ldip$ with the local declaration keyword $\ldk$, given
-        the type $\vttwo$, in the environment $\tenv$, yields $(\newtenv,\newldip, \vsesldi)$;
-  \item $\newldi$ is the local declaration denoting $\newldip$ and the type $\vtp$, that is, \\
-        $\LDITyped(\newldip, \vttwo)$;
-  \item \Proseeqdef{$\vses$}{the union of $\vsest$ and $\vsesldi$}.
-\end{itemize}
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \tstruct(\tenv, \tty) \typearrow \ttyp \\
-  \inheritintegerconstraints(\vt, \ttyp) \typearrow \vtone \OrTypeError \\
-  \annotatetype{\tenv, \vtone} \typearrow (\vttwo, \vsest) \OrTypeError\\\\
-  \checkcanbeinitializedwith(\tenv, \vttwo, \tty) \typearrow \True \OrTypeError\\\\
-  {
-    \begin{array}{r}
-  \annotatelocaldeclitem(\tenv, \vttwo, \ldk, \veopt, \ldip) \typearrow \\
-  (\newtenv, \newldip, \vsesldi) \OrTypeError
-    \end{array}
-  }\\
-  \vses \eqdef \vsest \cup \vsesldi
-}{
-  \annotatelocaldeclitem(\tenv, \tty, \ldk, \veopt, \overname{\LDITyped(\ldip, \vt)}{\ldi}) \typearrow \\
-  (\newtenv, \LDITyped(\newldip, \vttwo), \vses)
-}
-\end{mathpar}
-\CodeSubsection{\LDTypedBegin}{\LDTypedEnd}{../Typing.ml}
-
-\subsubsection{TypingRule.InheritIntegerConstraints\label{sec:TypingRule.InheritIntegerConstraints}}
-\hypertarget{def-inheritintegerconstraints}{}
-The helper function
-\[
-\inheritintegerconstraints(\overname{\ty}{\lhs} \aslsep \overname{\ty}{\rhs})
-\typearrow \lhsp \cup\ \overname{\TTypeError}{\TypeErrorConfig}
-\]
-propagates integer constraints from the right-hand side type $\rhs$ to the left-hand side type annotation $\lhs$.
-In particular, each occurence of \pendingconstrainedintegertype{} on the left-hand side should inherit constraints from a corresponding \wellconstrainedintegertype{} on the right-hand side.
-If the corresponding right-hand side type is not a \wellconstrainedintegertype{} (including if it is an \unconstrainedintegertype{}), the result is a type error.
-
-\subsubsection{Prose}
-One of the following applies:
-\begin{itemize}
-  \item All of the following apply (\textsc{int}):
-  \begin{itemize}
-    \item $\lhs$ is a \pendingconstrainedintegertype{};
-    \item $\rhs$ is a \wellconstrainedintegertype{}\ProseOrTypeError;
-    \item $\lhsp$ is $\rhs$.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{tuple}):
-  \begin{itemize}
-    \item $\lhs$ is a tuple of types \texttt{lhs\_tys};
-    \item $\rhs$ is a tuple of types \texttt{rhs\_tys};
-    \item the lengths of \texttt{lhs\_tys} and \texttt{rhs\_tys} are equal\ProseOrTypeError;
-    \item define \texttt{lhs\_tys'} by applying $\inheritintegerconstraints$ to each element of \texttt{lhs\_tys} and \texttt{rhs\_tys}\ProseOrTypeError;
-    \item $\lhsp$ is $\TTuple(\texttt{lhs\_tys'})$.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{other}):
-  \begin{itemize}
-    \item $\lhs$ is not a \pendingconstrainedintegertype{}, or one of $\lhs$ and $\rhs$ is not a tuple type;
-    \item $\lhsp$ is $\lhs$.
-  \end{itemize}
-\end{itemize}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule[int]{
-  \rhs \eqname \TInt(\wellconstrained(\Ignore)) \OrTypeError
-}{
-  \inheritintegerconstraints(\overname{\TInt(\pendingconstrained)}{\lhs}, \rhs) \typearrow \overname{\rhs}{\lhsp}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[tuple]{
-  \lhs \eqname \TTuple(\texttt{lhs\_tys}) \\
-  \rhs \eqname \TTuple(\texttt{rhs\_tys}) \\\\
-  \equallength(\texttt{lhs\_tys}, \texttt{rhs\_tys}) \typearrow \True \OrTypeError \\
-  \vi \in \listrange(\lhs): \inheritintegerconstraints(\texttt{lhs\_tys}_i, \texttt{rhs\_tys}_i) \typearrow \texttt{lhs\_tys'}_i \OrTypeError \\
-}{
-  \inheritintegerconstraints(\lhs, \rhs) \typearrow \overname{\TTuple(\texttt{lhs\_tys'})}{\lhsp}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[other]{
-  \lhs \neq \TInt(\pendingconstrained) \;\lor\; \astlabel(\lhs) \neq \TTuple \;\lor\; \astlabel(\rhs) \neq \TTuple
-}{
-  \inheritintegerconstraints(\lhs, \rhs) \typearrow \overname{\lhs}{\lhsp}
-}
-\end{mathpar}
-
-\subsubsection{TypingRule.CheckCanBeInitializedWith\label{sec:TypingRule.CheckCanBeInitializedWith}}
-\hypertarget{def-checkcanbeinitializedwith}{}
-The helper function
-\[
-\checkcanbeinitializedwith(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vs} \aslsep \overname{\ty}{\vt})
-\typearrow \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
-\]
-checks whether an expression of type $\vs$ can be used to initialize a storage element of type $\vt$ in the static environment
-$\tenv$.
-If the answer if $\False$, the result is a type error.
-
-\subsubsection{Prose}
-One of the following applies:
-\begin{itemize}
-  \item All of the following apply (\textsc{okay}):
-  \begin{itemize}
-    \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\True$;
-    \item the result is $\True$.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{error}):
-  \begin{itemize}
-    \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\False$;
-    \item the result is a type error indicating that an expression of type $\vs$ cannot
-          be used to initialize a storage element of type $\vt$.
-  \end{itemize}
-\end{itemize}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule[okay]{
-  \typesat(\tenv, \vt, \vs) \typearrow \True
-}{
-  \checkcanbeinitializedwith(\tenv, \vs, \vt) \typearrow \True
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[error]{
-  \typesat(\tenv, \vt, \vs) \typearrow \False
-}{
-  \checkcanbeinitializedwith(\tenv, \vs, \vt) \typearrow \TypeErrorVal{CannotBeInitializedWith}
-}
-\end{mathpar}
-\lrmcomment{This is related to \identr{ZCVD} and \identr{LXQZ}.}
-
-\subsection{Semantics}
-\subsubsection{SemanticsRule.LDTyped\label{sec:SemanticsRule.LDTyped}}
-\subsubsection{Example (Initialized)}
-In the specification:
-\VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.LDTyped.asl}
-\texttt{var x : integer = 42;} binds \texttt{x} in $\env$ to $\nvint(42)$.
-
-\subsubsection{Example (Uninitialized)}
-In the specification:
-\VerbatimInput{../tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTyped.asl}
-\verb|var x : integer{3..43};| binds \texttt{x} in $\env$ to the base value of \verb|integer{3..43}|,
-which is $\nvint(3)$.
-
-\subsubsection{Prose}
-One of the following applies:
-\begin{itemize}
-    \item All of the following apply (\textsc{initialized}):
-    \begin{itemize}
-        \item $\ldi$ is a typed declaration, $\LDITyped(\ldione, \vt)$;
-        \item $\minitopt$ corresponds to the initializing value $\vm$;
-        \item the resulting configuration is obtained via the evaluation
-        of the local declaration $\ldione$ in $\env$ with $\minitopt$ as $\vm$,
-        that is, \\ $\evallocaldecl{\env, \ldi1, \langle \vm\rangle}$.
-    \end{itemize}
-
-    \item All of the following apply (\textsc{uninitialized}):
-    \begin{itemize}
-      \item $\ldi$ gives a local declaration with a type, but no initial value, \\
-            $\LDITyped(\ldione, \vt)$;
-      \item $\minitopt$ is $\None$;
-      \item the base value of $\vt$ is $\vm$\ProseOrError;
-      \item evaluating the local declaration $\ldione$ with $\vm$
-            as the $\minitopt$ component yields the output configuration.
-    \end{itemize}
-\end{itemize}
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule[initialized]{
-  \evallocaldecl{\env, \ldi1, \langle \vm\rangle} \evalarrow C
-}{
-  \evallocaldecl{\env, \LDITyped(\ldi1, \Ignore), \langle \vm\rangle} \evalarrow C
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[uninitialized]{
-    \basevalue(\env, \vt) \evalarrow \vm \OrDynError\\\\
-    \evallocaldecl{\env, \ldione, \langle \vm \rangle} \evalarrow C
-}{
-    \evallocaldecl{\env, \LDITyped(\ldione, \vt), \None} \evalarrow C
-}
-\end{mathpar}
-\CodeSubsection{\EvalLDTypedBegin}{\EvalLDTypedEnd}{../Interpreter.ml}
 
 \section{Tuple Declarations\label{sec:TupleDeclarations}}
 \subsection{Typing}
@@ -504,18 +206,14 @@ One of the following applies:
 \subsubsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\ldi$ denotes a tuple of local declaration items $\ldi_{1..k}$, that is, $\LDITuple(\ldi_{1..k})$;
+  \item $\ldi$ denotes a tuple of identifiers $\vids_{1..k}$, that is, $\LDITuple(\vids_{1..k})$;
   \item obtaining the \underlyingtype\ of $\tty$ in $\tenv$ yields $\vtp$\ProseOrTypeError;
   \item determining whether $\vtp$ is a tuple type yields $\True$\ProseOrTypeError;
-  \item determining whether $\vtp$ the number of elements of $\vtp$ is $k$ yields $\True$\ProseOrTypeError;
-  \item annotating the local declaration items in $\ldis$ from right to left with their corresponding
+  \item determining whether the number of elements of $\vtp$ is $k$ yields $\True$\ProseOrTypeError;
+  \item declaring the identifiers in $\vids$ in the static environment $\tenv$ from from right to left with their corresponding
         (that is, with the same index) types $t_{1..k}$ in $\tenv$,
-        propagating static environments from one annotation to the next,
-        yields the local declaration items $\ldip_{1..k}$ and \sideeffectsetterm\ $\vxs_{1..k}$\ProseOrTypeError;
-  \item $\newtenv$ is the static environment yielded by annotating $\ldi_1$;
-  \item $\newldi$ is a tuple of local declaration items with $\ldip_{1..k}$, that is, \\
-        $\LDITuple(\ldip_{1..k})$;
-  \item \Proseeqdef{$\vses$}{the union of all \sideeffectsetterm\ $\vxs_i$, for $i=1..k$}.
+        propagating static environments from one declaration to the next,
+        yields the resulting environment $\newtenv$\ProseOrTypeError.
 \end{itemize}
 \subsubsection{Formally}
 \begin{mathpar}
@@ -524,19 +222,18 @@ All of the following apply:
   \checktrans{\astlabel(\vtp) = \TTuple}{TupleTypeExpected} \checktransarrow \True \OrTypeError\\\\
   \vtp \eqname \TTuple([\vt_{1..n}])\\\\
   \checktrans{k = n}{InvalidArity} \checktransarrow \True \OrTypeError\\\\
-  \newtenv_k \eqdef \tenv\\
+  \newtenv_k \eqdef \tenv\\\\
   {
     \begin{array}{r}
-  i=k..1:
-  \annotatelocaldeclitem(\newtenv_{i}, \vt_{i}, \ldk, \None, \ldi_{i}, ) \typearrow \\
-  (\newtenv_{i-1}, \ldip_i, \vxs_i) \OrTypeError
+      i=k..1: \hfill \\
+      \quad \checkvarnotinenv{\newtenv_i, \vids_i} \typearrow \True \OrTypeError\\
+      \quad \addlocal(\tenv, \vids_i, \vt_i, \ldk) \typearrow \newtenv_{i-1}
     \end{array}
-  }\\
-  \newtenv \eqdef \newtenv_0\\
-  \vses \eqdef \bigcup_{i=1..k} \vxs_i
+  }\\\\
+  \newtenv \eqdef \newtenv_0
 }{
-  \annotatelocaldeclitem(\tenv, \tty, \ldk, \veopt, \overname{\LDITuple(\ldi_{1..k})}{\ldi}) \typearrow \\
-  (\newtenv, \LDITuple(\ldip_{1..k}), \vses)
+  \annotatelocaldeclitem(\tenv, \tty, \ldk, \veopt, \overname{\LDITuple(\vids_{1..k})}{\ldi}) \typearrow \\
+  \newtenv
 }
 \end{mathpar}
 \CodeSubsection{\LDTupleBegin}{\LDTupleEnd}{../Typing.ml}
@@ -553,20 +250,19 @@ evaluation of \texttt{3} in $\env$.
 \subsubsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item $\ldi$ declares a list of local variables, $\LDITuple(\ldis)$;
-  \item $\minitopt$ is $\vm$;
+  \item $\ldi$ declares a list of local variables, $\LDITuple(\vids)$;
   \item $\vm$ is a pair consisting of the native vector $\vv$ and execution graph $\vg$;
-  \item $\ldis$ is a list of local declaration items $\ldi_{1..k}$;
+  \item $\vids$ is a list of identifiers $\id_{1..k}$;
   \item the value at each index of $\vv$ is $\vv_i$, for $i=1..k$;
   \item $\liv$ is the list of pairs $(\vv_i, \vg)$, for $i=1..k$;
-  \item the output configuration is obtained by declare each local declaration item $\ldi_i$
-  with the corresponding value ($\minitopt$ component) $(\vv_i, \vg)$.
+  \item the output configuration is obtained by declaring each identifier $\id_i$
+  with the corresponding value ($\vm$ component) $(\vv_i, \vg)$.
 \end{itemize}
 \subsubsection{Formally}
 \hypertarget{def-ldituplefolder}{}
 We first define the helper semantic relation
 \[
-    \ldituplefolder(\overname{\envs}{\env} \aslsep \overname{\localdeclitem^*}{\ldis} \aslsep \overname{(\vals \times \XGraphs)^*}{\liv}) \;\aslrel\;
+    \ldituplefolder(\overname{\envs}{\env} \aslsep \overname{\identifier^*}{\vids} \aslsep \overname{(\vals \times \XGraphs)^*}{\liv}) \;\aslrel\;
      \Normal(\overname{\XGraphs}{\vg} \aslsep \overname{\envs}{\newenv})
 \]
 via the following rules:
@@ -577,14 +273,14 @@ via the following rules:
 }
 \and
 \inferrule{
-  \ldis \eqname [\ldi] \concat \ldis'\\
+  \vids \eqname [\id] \concat \vids'\\
   \liv \eqname [\vm] \concat \liv'\\
-  \vm \eqname (\vv, \vgone)\\
-  \evallocaldecl{\env, \ldi, \langle\vm\rangle} \evalarrow \Normal(\vgone, \envone)\\
-  \ldituplefolder(\envone, \ldis', \liv') \evalarrow \Normal(\vgtwo, \newenv)\\
-  \newg \eqdef \vgone \parallelcomp \vgtwo
+  \vm \eqname (\vv, \vgone)\\\\
+  \declarelocalidentifier(\env, \id, \vv) \evalarrow (\envone, \vgtwo)\\
+  \ldituplefolder(\envone, \vids', \liv') \evalarrow \Normal(\vgthree, \newenv)\\
+  \newg \eqdef (\ordered{\vgone}{\asldata}{\vgtwo}) \parallelcomp \vgthree\\
 }{
-  \ldituplefolder(\env, \ldis, \liv) \evalarrow \Normal(\newg, \newenv)
+  \ldituplefolder(\env, \vids, \liv) \evalarrow \Normal(\newg, \newenv)
 }
 \end{mathpar}
 
@@ -592,12 +288,12 @@ We now use the helper rules to define the rule for local declaration item tuples
 \begin{mathpar}
 \inferrule{
   \vm \eqname (\vv, \vg)\\
-  \ldis \eqname \ldi_{1..k}\\
+  \ldis \eqname \id_{1..k}\\
   i=1..k: \getindex(i, \vv) \evalarrow \vv_i\\
   \liv \eqname [i=1..k: (\vv_i, \vg)]\\
-  \ldituplefolder(\env, \ldis, \liv) \evalarrow C
+  \ldituplefolder(\env, \vids, \liv) \evalarrow C
 }{
-  \evallocaldecl{\env, \LDITuple(\ldis), \langle \vm\rangle} \evalarrow C
+  \evallocaldecl{\env, \LDITuple(\vids), \vm} \evalarrow C
 }
 \end{mathpar}
 \CodeSubsection{\EvalLDTupleBegin}{\EvalLDTupleEnd}{../Interpreter.ml}

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -1540,8 +1540,8 @@ One of the following applies:
 
   \item All of the following apply (\textsc{s\_decl}):
   \begin{itemize}
-    \item $\vs$ is a declaration statement with local declaration item $\ldi$ and \optional\ initialization expression $\ve$;
-    \item define $\ids$ as the union of applying $\useexpr$ to $\ve$ and $\useldi$ to $\ldi$.
+    \item $\vs$ is a declaration statement with \optional{} type annotation $\vt$ and \optional\ initialization expression $\ve$;
+    \item define $\ids$ as the union of applying $\usety$ to $\vt$ and $\useexpr$ to $\ve$.
   \end{itemize}
 
   \item All of the following apply (\textsc{s\_try}):
@@ -1637,7 +1637,7 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[s\_decl]{}{
-  \usestmt(\overname{\SDecl(\Ignore, \ldi, \ve)}\vs) \typearrow \overname{\useexpr(\ve) \cup \useldi(\ldi)}{\ids}
+  \usestmt(\overname{\SDecl(\Ignore, \ldi, \vt, \ve)}\vs) \typearrow \overname{\usety(\vt) \cup \useexpr(\ve)}{\ids}
 }
 \end{mathpar}
 
@@ -1664,55 +1664,6 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[s\_unreachable]{}{
   \usestmt(\overname{\SUnreachable}{\vs}) \typearrow \overname{\emptyset}{\ids}
-}
-\end{mathpar}
-
-\subsubsection{TypingRule.UseLDI \label{sec:TypingRule.UseLDI}}
-\hypertarget{def-useldi}{}
-The function
-\[
-\useldi(\overname{\localdeclitem}{\ldi}) \aslto \overname{\pow{\identifier}}{\ids}
-\]
-returns the set of identifiers $\ids$ which the local declaration item $\ldi$ depends on.
-
-\subsubsection{Prose}
-One of the following applies:
-\begin{itemize}
-  \item All of the following apply (\textsc{discard}):
-  \begin{itemize}
-    \item $\ldi$ is a discarding declaration;
-    \item define $\ids$ as the empty set.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{typed}):
-  \begin{itemize}
-    \item $\ldi$ is a typed declaration for the local declaration item $\ldione$ and type $\vt$;
-    \item define $\ids$ as the union of applying $\useldi$ to $\ldione$ and $\usety$ to $\vt$.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{tuple}):
-  \begin{itemize}
-    \item $\ldi$ is a multi-variable declaration for the list of local declarations $\ldis$;
-    \item define $\ids$ as the union of applying $\useldi$ to each local declaration item in $\ldis$.
-  \end{itemize}
-\end{itemize}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule[discard]{}{
-  \useldi(\overname{\LDIDiscard}{\ldi}) \typearrow \overname{\emptyset}{\ids}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[typed]{}{
-  \useldi(\overname{\LDITyped(\ldione, \vt)}{\ldi}) \typearrow \overname{\useldi(\ldione) \cup \usety(\vt)}{\ids}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[tuple]{}{
-  \useldi(\overname{\LDITuple(\ldis)}{\ldi}) \typearrow \overname{\bigcup_{\ldione\in\ldis}\useldi(\ldione)}{\ids}
 }
 \end{mathpar}
 

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -322,7 +322,7 @@ builds a statement $\news$ from an assignment of expression $\rhs$ to a setter i
   \fields \eqname [\field] \\
   \vx \in \Identifiers \text{ is fresh} \\\\
   \setcalltype(\vcall, \STGetter) \aslto \texttt{getter} \\\\
-  \texttt{read} \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \langle\texttt{getter}\rangle) \\\\
+  \texttt{read} \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \None, \langle\texttt{getter}\rangle) \\\\
   \texttt{modify} \eqdef \SAssign(\LESetField(\LEVar(\vx), \field), \rhs) \\\\
   \makesetter(\vcall, \EVar(\vx)) \aslto \texttt{setter}
 }{
@@ -337,7 +337,7 @@ builds a statement $\news$ from an assignment of expression $\rhs$ to a setter i
   \listlen{\fields} > 1 \\
   \vx \in \Identifiers \text{ is fresh} \\\\
   \setcalltype(\vcall, \STGetter) \aslto \texttt{getter} \\\\
-  \texttt{read} \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \langle\texttt{getter}\rangle) \\\\
+  \texttt{read} \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \None, \langle\texttt{getter}\rangle) \\\\
   \texttt{modify} \eqdef \SAssign(\LESetFields(\LEVar(\vx), \fields), \rhs) \\\\
   \makesetter(\vcall, \EVar(\vx)) \aslto \texttt{setter}
 }{
@@ -387,24 +387,26 @@ As given by applying the relevant rules to the desugared AST.
 \section{Declaration Statements\label{sec:DeclarationStatements}}
 \subsection{Syntax}
 \begin{flalign*}
-\Nstmt \derives \ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
+\Nstmt \derives \ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
 |\ & \Tvar \parsesep \Clisttwo{\Tidentifier} \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon &\\
 \end{flalign*}
 
 \subsection{Abstract Syntax}
 \begin{flalign*}
-\stmt \derives\ & \SDecl(\localdeclkeyword, \localdeclitem, \expr?) &
+\stmt \derives\ & \SDecl(\localdeclkeyword, \localdeclitem, \ty?, \expr?)
 \end{flalign*}
 
 \subsubsection{ASTRule.SDecl}
 \begin{mathpar}
-\inferrule[let\_constant]{}{
+\inferrule[let\_constant]{
+  \buildoption[\buildty](\vt) \astarrow \astversion{\vt}
+}{
   {
   \begin{array}{r}
-  \buildstmt(\overname{\Nstmt(\Nlocaldeclkeyword, \Ndeclitem, \Teq, \punnode{\Nexpr}, \Tsemicolon)}{\vparsednode})
+  \buildstmt(\overname{\Nstmt(\Nlocaldeclkeyword, \Ndeclitem, \namednode{\vt}{\option{\Nty}}, \Teq, \punnode{\Nexpr}, \Tsemicolon)}{\vparsednode})
   \astarrow\\
-  \overname{\SDecl(\astof{\vlocaldeclkeyword}, \astof{\vdeclitem}, \langle\astof{\vexpr}\rangle)}{\vastnode}
+  \overname{\SDecl(\astof{\vlocaldeclkeyword}, \astof{\vdeclitem}, \astversion{\vt}, \langle\astof{\vexpr}\rangle)}{\vastnode}
   \end{array}
   }
 }
@@ -412,13 +414,14 @@ As given by applying the relevant rules to the desugared AST.
 
 \begin{mathpar}
 \inferrule[var]{
+  \buildoption[\buildty](\vt) \astarrow \astversion{\vt} \\
   \buildoption[\buildexpr](\ve) \astarrow \astversion{\ve}
 }{
   {
     \begin{array}{r}
-  \buildstmt(\overname{\Nstmt(\Tvar, \Ndeclitem, \namednode{\ve}{\option{\Teq, \Nexpr}}, \Tsemicolon)}{\vparsednode})
+  \buildstmt(\overname{\Nstmt(\Tvar, \Ndeclitem, \namednode{\vt}{\option{\Nty}}, \namednode{\ve}{\option{\Teq, \Nexpr}}, \Tsemicolon)}{\vparsednode})
   \astarrow \\
-  \overname{\SDecl(\LDKVar, \astof{\vdeclitem}, \astversion{\ve})}{\vastnode}
+  \overname{\SDecl(\LDKVar, \astof{\vdeclitem}, \astversion{\vt}, \astversion{\ve})}{\vastnode}
 \end{array}
 }
 }
@@ -427,7 +430,7 @@ As given by applying the relevant rules to the desugared AST.
 \begin{mathpar}
 \inferrule[multi\_var]{
   \buildclist[\buildidentity](\vids) \astarrow \astversion{\vids}\\
-  \vstmts \eqdef [\vx\in\astversion{\vids}: \SDecl(\LDKVar, \vx, \astof{\tty})]\\
+  \vstmts \eqdef [\vx\in\astversion{\vids}: \SDecl(\LDKVar, \vx, \langle\astof{\tty}\rangle, \None)]\\
   \stmtfromlist(\vstmts) \astarrow \vastnode
 }{
   \buildstmt(\overname{\Nstmt(\Tvar, \namednode{\vids}{\Clisttwo{\Tidentifier}}, \Tcolon, \punnode{\Nty}, \Tsemicolon)}{\vparsednode})
@@ -443,13 +446,10 @@ One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{some}):
   \begin{itemize}
-    \item $\vs$ is a declaration with local declaration keyword $\ldk$, local identifiers $\ldi$, and an expression $\ve$,
-          that is, $\SDecl(\ldk, \ldi, \langle\ve\rangle)$;
+    \item $\vs$ is a declaration with an initializing expression $\ve$,
+          that is, $\SDecl(\ldk, \ldi, \tyopt, \langle\ve\rangle)$;
     \item annotating the right-hand-side expression $\ve$ in $\tenv$ yields $(\vte,\vep, \vsese)$\ProseOrTypeError;
-    \item annotating the local declaration item $\ldi$ with local declaration keyword $\ldk$, the type $\vte$,
-          the initializing expression $\vep$ and $\vsese$, in $\tenv$
-          yields \\
-          $(\tenvone, \ldione, \vsesldi)$\ProseOrTypeError;
+    \item applying $\annotatelocaldecltypeannot$ to the environment $\tenv$, type annotation $\tyopt$, type $\vte$, local declaration keyword $\ldk$, expression $\vep$, and local declaration item $\ldi$ yields $(\tenvone, \tyoptp, \vsesldi)$\ProseOrTypeError;
     \item \Proseeqdef{$\vses$}{the union of $\vsese$ and $\vsesldi$};
     \item One of the following applies:
     \begin{itemize}
@@ -458,14 +458,14 @@ One of the following applies:
         \item $\ldk$ indicates a local constant declaration, that is, $\LDKConstant$;
         \item checking that all \timeframesterm\ in $\vsese$ are before \timeframeconstant\ yields $\True$\ProseOrTypeError;
         \item symbolically simplifying $\ve$ in $\tenvone$ yields the literal $\vv$\ProseOrTypeError;
-        \item declaring a local constant of type $\vte$, literal $\vv$ and local declaration item $\ldione$ in $\tenvone$ yields $\newtenv$;
-        \item $\news$ is a declaration with $\ldk$, $\ldione$ and an expression $\vep$.
+        \item declaring a local constant with literal $\vv$ and local declaration item $\ldi$ in $\tenvone$ yields $\newtenv$;
+        \item $\news$ is a declaration with $\ldk$, $\ldi$, type annotation $\tyoptp$, and an expression $\vep$.
       \end{itemize}
 
       \item All of the following apply (\textsc{non\_constant}):
       \begin{itemize}
         \item $\ldk$ indicates that this is not a local constant declaration, that is, $\ldk\neq\LDKConstant$;
-        \item $\news$ is a declaration with $\ldk$, $\ldione$ and an expression $\vep$;
+        \item $\news$ is a declaration with $\ldk$, $\ldi$, type annotation $\tyoptp$, and an expression $\vep$;
         \item $\newtenv$ is $\tenvone$.
       \end{itemize}
     \end{itemize}
@@ -473,64 +473,58 @@ One of the following applies:
 
   \item All of the following apply (\textsc{none}):
   \begin{itemize}
-  \item $\vs$ is a local declaration statement with a variable keyword and local identifiers $\ldi$, and no initial expression,
-        that is, $\SDecl(\LDKVar, \ldi, \None)$ (local declarations of \texttt{let} variables and constants require
+  \item $\vs$ is a local declaration statement with a variable keyword and no initializing expression,
+        that is, $\SDecl(\LDKVar, \ldi, \tyopt, \None)$ (local declarations of \texttt{let} variables and constants require
         an initializing expression, otherwise they are rejected by an ASL parser);
-  \item annotating the uninitialised local declarations $\ldi$ in $\tenv$ yields \\
-        $(\newtenv, \ldione, \veinit, \vsesldi)$;
-  \item $\news$ is a local declaration statement with variable keyword, local identifiers $\ldione$, and the initializing expression $\veinit$,
-        that is, \\
-        $\SDecl(\LDKVar, \ldione, \langle\veinit\rangle)$;
-  \item \Proseeqdef{$\vses$}{$\vsesldi$}.
+  \item $\tyopt$ is $\langle\vt\rangle$\ProseOrTypeError;
+  \item annotating $\vt$ in $\tenv$ yields $(\vtp, \vses)$\ProseOrTypeError;
+  \item applying $\basevalue$ to $\vtp$ in $\tenv$ yields $\veinit$\ProseOrTypeError;
+  \item annotating the local declaration item $\ldi$ with the type $\vtp$ and local declaration keyword $\LDIVar$
+        yields $\newtenv$\ProseOrTypeError;
+  \item define $\news$ as local declaration statement with variable keyword, local declaration item $\ldi$, type annotation $\vtp$, and initializing expression $\veinit$, that is, $\SDecl(\LDKVar, \ldi, \langle\veinit\rangle)$.
   \end{itemize}
 \end{itemize}
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[constant]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vsese) \OrTypeError\\\\
-  {
-  \begin{array}{r}
-    \annotatelocaldeclitem(\tenv, \vte, \ldk, \langle(\vep, \vsese)\rangle, \ldi) \typearrow \\
-    (\tenvone, \ldione, \vsesldi) \OrTypeError
-  \end{array}
-  }\\
+  \annotatelocaldecltypeannot(\tenv, \tyopt, \vte, \ldk, \vep, \ldi) \typearrow (\tenvone, \tyoptp, \vsesldi) \OrTypeError\\\\
   \vses \eqdef \vsese \cup \vsesldi\\\\
   \commonprefixline\\\\
   \ldk = \LDKConstant\\
   \checktrans{\sesisbefore(\vsese, \timeframeconstant)}{TimeFrameConstant} \typearrow \True \OrTypeError\\\\
   \staticeval(\tenvone, \ve) \typearrow \vv \OrTypeError\\\\
-  \declarelocalconstant(\tenvone, \vv, \ldione) \typearrow \newtenv\\
-  \news \eqdef \SDecl(\LDKConstant, \ldione, \langle\vep\rangle)
+  \declarelocalconstant(\tenvone, \vv, \ldi) \typearrow \newtenv\\
+  \news \eqdef \SDecl(\LDKConstant, \ldi, \tyoptp, \langle\vep\rangle)
 }{
-  \annotatestmt(\tenv, \overname{\SDecl(\ldk, \ldi, \langle\ve\rangle)}{\vs}) \typearrow (\news, \newtenv, \vses)
+  \annotatestmt(\tenv, \overname{\SDecl(\ldk, \ldi, \tyopt, \langle\ve\rangle)}{\vs}) \typearrow (\news, \newtenv, \vses)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[non\_constant]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vsese) \OrTypeError\\\\
-  {
-  \begin{array}{r}
-    \annotatelocaldeclitem(\tenv, \vte, \ldk, \langle(\vep, \vsese)\rangle, \ldi) \typearrow \\
-    (\tenvone, \ldione, \vsesldi) \OrTypeError
-  \end{array}
-  }\\
+  \annotatelocaldecltypeannot(\tenv, \tyopt, \vte, \ldk, \vep, \ldi) \typearrow (\tenvone, \tyoptp, \vsesldi) \OrTypeError\\\\
   \vses \eqdef \vsese \cup \vsesldi\\\\
   \commonprefixline\\\\
   \ldk \neq \LDKConstant\\
-  \news \eqdef \SDecl(\ldk, \ldione, \langle\vep\rangle)
+  \news \eqdef \SDecl(\ldk, \ldi, \tyoptp, \langle\vep\rangle)
 }{
-  \annotatestmt(\tenv, \overname{\SDecl(\ldk, \ldi, \langle\ve\rangle)}{\vs}) \typearrow (\news, \overname{\tenvone}{\newtenv}, \vses)
+  \annotatestmt(\tenv, \overname{\SDecl(\ldk, \ldi, \tyopt, \langle\ve\rangle)}{\vs}) \typearrow (\news, \overname{\tenvone}{\newtenv}, \vses)
 }
 \end{mathpar}
 \lrmcomment{This is related to \identr{YSPM}.}
 
 \begin{mathpar}
 \inferrule[none]{
-  \annotatelocaldeclitemuninit(\tenv, \ldi) \typearrow (\newtenv, \ldione, \veinit, \vsesldi) \OrTypeError\\\\
-  \news \eqdef \SDecl(\LDKVar, \ldione, \langle\veinit\rangle)
+  \checktrans{\tyopt = \langle\Ignore\rangle}{\TypeErrorVal{ExpectedInitializingExpression}} \typearrow \True \OrTypeError \\
+  \tyopt \eqname \langle\vt\rangle \\
+  \annotatetype{\tenv, \vt} \typearrow (\vtp, \vses) \OrTypeError\\\\
+  \basevalue(\tenv, \vtp) \typearrow \veinit \OrTypeError\\\\
+  \annotatelocaldeclitem{\tenv, \vtp, \LDKVar, \None, \ldip} \typearrow \newtenv \OrTypeError \\
+  \news \eqdef \SDecl(\LDKVar, \ldi, \langle\vtp\rangle, \langle\veinit\rangle)
 }{
-  \annotatestmt(\tenv, \overname{\SDecl(\LDKVar, \ldi, \None)}{\vs}) \typearrow (\news, \newtenv, \overname{\vsesldi}{\vses})
+  \annotatestmt(\tenv, \overname{\SDecl(\LDKVar, \ldi, \tyopt, \None)}{\vs}) \typearrow (\news, \newtenv, \vses)
 }
 \end{mathpar}
 \CodeSubsection{\SDeclegin}{\SDeclEnd}{../Typing.ml}
@@ -548,12 +542,6 @@ yielding the modified static environment $\newtenv$.
 \subsubsection{Prose}
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{discard}):
-  \begin{itemize}
-    \item $\ldi$ corresponds to a discarding declaration, that is, $\LDIDiscard$;
-    \item $\newtenv$ is $\tenv$.
-  \end{itemize}
-
   \item All of the following apply (\textsc{var}):
   \begin{itemize}
     \item $\ldi$ corresponds to a variable declaration for $\vx$, that is, $\LDIVar(\vx)$;
@@ -565,20 +553,8 @@ One of the following applies:
     \item $\ldi$ corresponds to a tuple declaration, that is, $\LDIVar(\Ignore)$;
     \item this case is not yet implemented.
   \end{itemize}
-
-  \item All of the following apply (\textsc{typed}):
-  \begin{itemize}
-    \item $\ldi$ corresponds to a typed declaration of the local declaration item $\ldip$ and some type, that is, $\LDITyped(\ldip, \Ignore)$;
-    \item applying $\declarelocalconstant$ to $\vv$ and $\ldip$ in $\tenv$ yields $\newtenv$.
-  \end{itemize}
 \end{itemize}
 \subsubsection{Formally}
-\begin{mathpar}
-\inferrule[discard]{}{
-  \declarelocalconstant(\tenv, \vv, \overname{\LDIDiscard}{\ldi}) \typearrow \overname{\tenv}{\newtenv}
-}
-\end{mathpar}
-
 \begin{mathpar}
 \inferrule[var]{
   \addlocalconstant(\tenv, \vx, \vv) \typearrow \newtenv
@@ -592,84 +568,192 @@ One of the following applies:
   \declarelocalconstant(\tenv, \vv, \overname{\LDITuple(\Ignore)}{\ldi}) \typearrow \tododefine{not implemented yet}
 }
 \end{mathpar}
-
-\begin{mathpar}
-\inferrule[typed]{
-  \declarelocalconstant(\tenv, \vv, \ldip) \typearrow \newtenv
-}{
-  \declarelocalconstant(\tenv, \vv, \overname{\LDITyped(\ldip, \Ignore)}{\ldi}) \typearrow \newtenv
-}
-\end{mathpar}
 \CodeSubsection{\DeclareLocalConstantBegin}{\DeclareLocalConstantEnd}{../Typing.ml}
 
-\subsubsection{TypingRule.AnnotateLocalDeclItemUninit \label{sec:TypingRule.AnnotateLocalDeclItemUninit}}
-\hypertarget{def-annotatelocaldeclitemuninit}{}
+\subsubsection{TypingRule.AnnotateLocalDeclTypeAnnot \label{sec:TypingRule.AnnotateLocalDeclTypeAnnot}}
+\hypertarget{def-annotatelocaldecltypeannot}{}
 The helper function
 \[
-\begin{array}{r}
-\annotatelocaldeclitemuninit(\overname{\staticenvs}{\tenv} \aslsep \overname{\localdeclitem}{\ldi})
-\typearrow \\
-(\overname{\staticenvs}{\newtenv} \times \overname{\localdeclitem}{\newldi} \times \overname{\expr}{\veinit} \times \overname{\TSideEffectSet}{\vses})
-\cup \overname{\TTypeError}{\TypeErrorConfig}
-\end{array}
+  \annotatelocaldecltypeannot
+  \left(
+  \begin{array}{c}
+    \overname{\staticenvs}{\tenv} \aslsep \\
+    \overname{\langle\ty\rangle}{\tyopt} \aslsep \\
+    \overname{\ty}{\vte} \aslsep \\
+    \overname{\localdeclkeyword}{\ldk} \aslsep \\
+    \overname{\expr}{\vep} \aslsep\\
+    \overname{\localdeclitem}{\ldi}
+  \end{array}
+  \right)
+  \typearrow
+  \left(
+  \begin{array}{cl}
+    \left(\overname{\staticenvs}{\newtenv} \aslsep \overname{\langle\ty\rangle}{\tyoptp} \aslsep \overname{\TSideEffectSet}{\vses}\right)
+    & \cup \\
+    \overname{\TTypeError}{\TypeErrorConfig} &
+  \end{array}
+  \right)
 \]
-annotates the local declaration for a variable declaration without an initializing expression $\ldi$,
-in the static environment $\tenv$,
-yielding the annotated local declaration item $\newldi$,
-the modified static environment $\newtenv$,
-an initializing expression $\veinit$, and
-the inferred \sideeffectsetterm\ $\vses$.
+annotates the type annotation $\tyopt$ in the static environment $\tenv$ within the context of a local declaration with keyword $\ldk$, item $\ldi$, and initializing expression $\vep$ with type $\vte$.
+It yields the modified static environment $\newtenv$, the annotated type annotation $\tyoptp$, and the inferred \sideeffectsetterm{} $\vses$.
 \ProseOtherwiseTypeError
 
 \subsubsection{Prose}
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{typed}):
+  \item All of the following apply (\textsc{none}):
   \begin{itemize}
-    \item $\ldi$ corresponds to a variable declaration via the local declaration item $\ldip$ and type annotation $\vt$,
-          that is, $\LDITyped(\ldip, \vt)$;
-          \item annotating $\vt$ in $\tenv$ yields $(\vtp, \vsest)$\ProseOrTypeError;
-          \item applying $\basevalue$ to $\vtp$ in $\tenv$ yields $\veinit$\ProseOrTypeError;
-    \item annotating the local declaration item $\ldip$ with the type $\vtp$ and local declaration keyword $\LDIVar$
-          yields $(\newtenv, \newldip, \vsesldi)$\ProseOrTypeError;
-    \item define $\newldi$ as the typed local declaration item with local declaration item $\newldip$, type $\vtp$, and
-          $\veinit$;
-    \item \Proseeqdef{$\vses$}{the union of $\vsest$ and $\vsesldi$}.
+    \item $\tyopt$ is $\None$;
+    \item $\newtenv$ is the result of $\annotatelocaldeclitem{\tenv, \vte, \ldk, \langle\vep\rangle, \ldi}$\ProseOrTypeError;
+    \item $\tyoptp$ is $\tyopt$;
+    \item \Proseeqdef{$\vses$}{the empty set}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item All of the following apply (\textsc{some}):
   \begin{itemize}
-    \item $\ldi$ does not correspond to a typed declaration item;
-    \item the result is a type error indicating that an initializing expression was expected.
+    \item $\tyopt$ is $\langle\vt\rangle$;
+    \item determining the \structure{} of $\vte$ in $\tenv$ yields $\vtep$\ProseOrTypeError;
+    \item propagating integer constraints from $\vtep$ to $\vt$ using $\inheritintegerconstraints$ yields $\vtp$\ProseOrTypeError;
+    \item annotating the type $\vtp$ in $\tenv$ yields $(\vtpp, \vses)$\ProseOrTypeError;
+  \item determining whether $\vtpp$ can be initialized with $\vte$ in $\tenv$ yields $\True$\ProseOrTypeError;
+  \item annotating the local declaration item $\ldi$ with the local declaration keyword $\ldk$, given
+  the expression $\vep$, in the environment $\tenv$, yields $\newtenv$;
+  \item $\tyoptp$ is $\langle\vtpp\rangle$.
   \end{itemize}
 \end{itemize}
 
 \subsubsection{Formally}
 \begin{mathpar}
-\inferrule[typed]{
-  \annotatetype{\tenv, \vt} \typearrow (\vtp, \vsest) \OrTypeError\\\\
-  \basevalue(\tenv, \vtp) \typearrow \veinit \OrTypeError\\\\
-  {
-    \begin{array}{r}
-      \annotatelocaldeclitem(\tenv, \vtp, \LDKVar, \None, \ldip) \typearrow \\
-      (\newtenv, \newldip, \vsesldi) \OrTypeError
-    \end{array}
-  }\\
-  \newldi \eqdef \LDITyped(\newldip, \vtp, \veinit)\\
-  \vses \eqdef \vsest \cup \vsesldi
+\inferrule[none]{
+  \annotatelocaldeclitem{\tenv, \vte, \ldk, \langle\vep\rangle, \ldi} \typearrow \newtenv \OrTypeError
 }{
-  \annotatelocaldeclitemuninit(\tenv, \overname{\LDITyped(\ldip, \vt)}{\ldi}) \typearrow (\newtenv, \newldi, \vses)
+  \annotatelocaldecltypeannot(\tenv, \None, \vte, \ldk, \vep, \ldi) \typearrow (\newtenv, \overname{\None}{\tyoptp}, \overname{\emptyset}{\vses})
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[some]{
+  \tstruct(\tenv, \vte) \typearrow \vtep \OrTypeError \\
+  \inheritintegerconstraints(\vt, \vtep) \typearrow \vtp \OrTypeError \\
+  \annotatetype{\tenv, \vtp} \typearrow (\vtpp, \vses) \OrTypeError\\\\
+  \checkcanbeinitializedwith(\tenv, \vtpp, \vte) \typearrow \True \OrTypeError\\\\
+  \annotatelocaldeclitem{\tenv, \vtpp, \ldk, \langle \vep \rangle, \ldip} \typearrow \newtenv \OrTypeError
+}{
+  \annotatelocaldecltypeannot(\tenv, \langle\vt\rangle, \vte, \ldk, \vep, \ldi) \typearrow (\newtenv, \overname{\langle\vtpp\rangle}{\tyoptp}, \vses)
+}
+\end{mathpar}
+
+\subsubsection{TypingRule.InheritIntegerConstraints\label{sec:TypingRule.InheritIntegerConstraints}}
+\hypertarget{def-inheritintegerconstraints}{}
+The helper function
+\[
+\inheritintegerconstraints(\overname{\ty}{\lhs} \aslsep \overname{\ty}{\rhs})
+\typearrow \lhsp \cup\ \overname{\TTypeError}{\TypeErrorConfig}
+\]
+propagates integer constraints from the right-hand side type $\rhs$ to the left-hand side type annotation $\lhs$.
+In particular, each occurence of \pendingconstrainedintegertype{} on the left-hand side should inherit constraints from a corresponding \wellconstrainedintegertype{} on the right-hand side.
+If the corresponding right-hand side type is not a \wellconstrainedintegertype{} (including if it is an \unconstrainedintegertype{}), the result is a type error.
+
+\subsubsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{int}):
+  \begin{itemize}
+    \item $\lhs$ is a \pendingconstrainedintegertype{};
+    \item $\rhs$ is a \wellconstrainedintegertype{}\ProseOrTypeError;
+    \item $\lhsp$ is $\rhs$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{tuple}):
+  \begin{itemize}
+    \item $\lhs$ is a tuple of types \texttt{lhs\_tys};
+    \item $\rhs$ is a tuple of types \texttt{rhs\_tys};
+    \item the lengths of \texttt{lhs\_tys} and \texttt{rhs\_tys} are equal\ProseOrTypeError;
+    \item define \texttt{lhs\_tys'} by applying $\inheritintegerconstraints$ to each element of \texttt{lhs\_tys} and \texttt{rhs\_tys}\ProseOrTypeError;
+    \item $\lhsp$ is $\TTuple(\texttt{lhs\_tys'})$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{other}):
+  \begin{itemize}
+    \item $\lhs$ is not a \pendingconstrainedintegertype{}, or one of $\lhs$ and $\rhs$ is not a tuple type;
+    \item $\lhsp$ is $\lhs$.
+  \end{itemize}
+\end{itemize}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule[int]{
+  \rhs \eqname \TInt(\wellconstrained(\Ignore)) \OrTypeError
+}{
+  \inheritintegerconstraints(\overname{\TInt(\pendingconstrained)}{\lhs}, \rhs) \typearrow \overname{\rhs}{\lhsp}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[tuple]{
+  \lhs \eqname \TTuple(\texttt{lhs\_tys}) \\
+  \rhs \eqname \TTuple(\texttt{rhs\_tys}) \\\\
+  \equallength(\texttt{lhs\_tys}, \texttt{rhs\_tys}) \typearrow \True \OrTypeError \\
+  \vi \in \listrange(\lhs): \inheritintegerconstraints(\texttt{lhs\_tys}_i, \texttt{rhs\_tys}_i) \typearrow \texttt{lhs\_tys'}_i \OrTypeError \\
+}{
+  \inheritintegerconstraints(\lhs, \rhs) \typearrow \overname{\TTuple(\texttt{lhs\_tys'})}{\lhsp}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[other]{
+  \lhs \neq \TInt(\pendingconstrained) \;\lor\; \astlabel(\lhs) \neq \TTuple \;\lor\; \astlabel(\rhs) \neq \TTuple
+}{
+  \inheritintegerconstraints(\lhs, \rhs) \typearrow \overname{\lhs}{\lhsp}
+}
+\end{mathpar}
+
+\subsubsection{TypingRule.CheckCanBeInitializedWith\label{sec:TypingRule.CheckCanBeInitializedWith}}
+\hypertarget{def-checkcanbeinitializedwith}{}
+The helper function
+\[
+\checkcanbeinitializedwith(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vs} \aslsep \overname{\ty}{\vt})
+\typearrow \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+checks whether an expression of type $\vs$ can be used to initialize a storage element of type $\vt$ in the static environment
+$\tenv$.
+If the answer if $\False$, the result is a type error.
+
+\subsubsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{okay}):
+  \begin{itemize}
+    \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\True$;
+    \item the result is $\True$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{error}):
+  \begin{itemize}
+    \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\False$;
+    \item the result is a type error indicating that an expression of type $\vs$ cannot
+          be used to initialize a storage element of type $\vt$.
+  \end{itemize}
+\end{itemize}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule[okay]{
+  \typesat(\tenv, \vt, \vs) \typearrow \True
+}{
+  \checkcanbeinitializedwith(\tenv, \vs, \vt) \typearrow \True
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[error]{
-  \astlabel(\ldi) \in \{\LDIDiscard, \LDIVar, \LDITuple\}
+  \typesat(\tenv, \vt, \vs) \typearrow \False
 }{
-  \annotatelocaldeclitemuninit(\tenv, \ldi) \typearrow \TypeErrorVal{ExpectedInitializingExpression}
+  \checkcanbeinitializedwith(\tenv, \vs, \vt) \typearrow \TypeErrorVal{CannotBeInitializedWith}
 }
 \end{mathpar}
-\CodeSubsection{\AnnotateLocalDeclItemUninitBegin}{\AnnotateLocalDeclItemUninitEnd}{../Typing.ml}
+\lrmcomment{This is related to \identr{ZCVD} and \identr{LXQZ}.}
+
 
 \subsection{Semantics}
 \subsubsection{SemanticsRule.SDeclSome\label{sec:SemanticsRule.SDeclSome}}
@@ -689,36 +773,32 @@ One of the following applies:
   \item All of the following apply (\textsc{some}):
   \begin{itemize}
     \item $\vs$ is a declaration with an initial value,
-    $\SDecl(\text{ldk}, \ldi, \langle\ve\rangle)$;
+    $\SDecl(\Ignore, \ldi, \Ignore, \langle\ve\rangle)$;
     \item evaluating $\ve$ in $\env$ is $\Normal(\vm, \envone)$\ProseOrAbnormal;
-    \item evaluating the local declaration $\ldi$ with $\langle\vm\rangle$ as the initializing
+    \item evaluating the local declaration $\ldi$ with $\vm$ as the initializing
     value in $\envone$ as per \chapref{LocalStorageDeclarations} is $\Normal(\newg, \newenv)$;
     \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
   \end{itemize}
 
   \item All of the following apply (\textsc{none}):
   \begin{itemize}
-    \item $\vs$ is a declaration without an initial value, $\SDecl(\Ignore, \ldi, \None)$;
-    \item evaluating the local declaration $(\ldi, \None)$ as per \chapref{LocalStorageDeclarations}
-    is \\ $\Normal(\newg, \newenv)$;
-    \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
+    \item $\vs$ is a declaration without an initial value, $\SDecl(\Ignore, \ldi, \Ignore, \None)$;
+    \item the result is a dynamic error.
   \end{itemize}
 \end{itemize}
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[some]{
   \evalexpr{\env, \ve} \evalarrow \Normal(\vm, \envone) \OrAbnormal\\
-  \evallocaldecl{\envone, \ldi, \langle\vm\rangle} \evalarrow \Normal(\newg, \newenv)\\
+  \evallocaldecl{\envone, \ldi, \vm} \evalarrow \Normal(\newg, \newenv)\\
 }{
-  \evalstmt{\env, \SDecl(\Ignore, \ldi, \langle\ve\rangle)} \evalarrow \Continuing(\newg, \newenv)
+  \evalstmt{\env, \SDecl(\Ignore, \ldi, \Ignore, \langle\ve\rangle)} \evalarrow \Continuing(\newg, \newenv)
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[none]{
-  \evallocaldecl{\env, \vs, \ldi, \None} \evalarrow \Normal(\newg, \newenv)\\
-}{
-  \evalstmt{\env, \SDecl(\Ignore, \ldi, \None)} \evalarrow \Continuing(\newg, \newenv)
+\inferrule[none]{}{
+  \evalstmt{\env, \SDecl(\Ignore, \ldi, \Ignore, \None)} \evalarrow \DynamicErrorVal{UninitialisedDecl}
 }
 \end{mathpar}
 \CodeSubsection{\EvalSDeclBegin}{\EvalSDeclEnd}{../Interpreter.ml}
@@ -728,8 +808,8 @@ One of the following applies:
 \subsection{Syntax}
 \begin{flalign*}
 \Nstmt \derives \
-   & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Ndeclitem \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
+   & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Nasty \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Ndeclitem \parsesep \Nasty \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
 \end{flalign*}
 
 \begin{flalign*}
@@ -795,21 +875,23 @@ The helper function
 \desugarelidedparameter(
   \overname{\localdeclkeyword}{\ldk} \aslsep
   \overname{\localdeclitem}{\ldi} \aslsep
+  \overname{\ty}{\vt} \aslsep
   \overname{\call}{\vcall})
 \aslto \overname{\stmt}{\news}
 \cup\ \{\ParseError\}
 \]
-builds a declaration statement $\news$ from an assignment of the call $\vcall$ to the left-hand side $\ldi$ with keyword $\ldk$, where the call has an elided parameter.
+builds a declaration statement $\news$ from an assignment of the call $\vcall$ to the left-hand side $\ldi$ with keyword $\ldk$ and type annotation $\vt$, where the call has an elided parameter.
 Otherwise, the result is a parse error.
 
 \begin{mathpar}
 \inferrule{
-  \ldi \eqname \LDITyped(\Ignore, \TBits(\ve, \Ignore)) \;\terminateas \ParseError \\
+  \checktrans{\vt = \TBits(\Ignore, \Ignore)}{\ParseError} \typearrow \True \;\terminateas \ParseError \\
+  \vt \eqname \TBits(\ve, \Ignore) \\
   \vcallp \eqdef \vcall[\callparams\mapsto [\ve] \concat \vcall.\callparams ]
 }{
-  \desugarelidedparameter(\ldk, \ldi, \vcall)
+  \desugarelidedparameter(\ldk, \ldi, \vt, \vcall)
   \astarrow
-  \SDecl(\ldk, \ldi, \ECall(\vcallp))
+  \SDecl(\ldk, \ldi, \langle\vt\rangle, \ECall(\vcallp))
 }
 \end{mathpar}
 
@@ -817,12 +899,12 @@ Otherwise, the result is a parse error.
 \begin{mathpar}
 \inferrule{
   \buildelidedparamcall (\vcall) \astarrow \astversion{\vcall} \\
-  \desugarelidedparameter(\astof{\vlocaldeclkeyword}, \astof{\vdeclitem}, \astversion{\vcall}) \astarrow \vastnode
+  \desugarelidedparameter(\astof{\vlocaldeclkeyword}, \astof{\vdeclitem}, \astof{\vasty}, \astversion{\vcall}) \astarrow \vastnode
 }{
   {
     \begin{array}{l}
     \buildstmt(\Nstmt \\
-    \qquad (\punnode{\Nlocaldeclkeyword}, \punnode{\Ndeclitem}, \Teq, \namednode{\vcall}{\Nelidedparamcall}, \Tsemicolon)) \astarrow \vastnode
+    \qquad (\punnode{\Nlocaldeclkeyword}, \punnode{\Ndeclitem}, \punnode{\Nasty}, \Teq, \namednode{\vcall}{\Nelidedparamcall}, \Tsemicolon)) \astarrow \vastnode
     \end{array}
   }
 }
@@ -831,21 +913,16 @@ Otherwise, the result is a parse error.
 \begin{mathpar}
 \inferrule{
   \buildelidedparamcall (\vcall) \astarrow \astversion{\vcall} \\
-  \desugarelidedparameter(\LDKVar, \astof{\vdeclitem}, \astversion{\vcall}) \astarrow \vastnode
+  \desugarelidedparameter(\LDKVar, \astof{\vdeclitem}, \astof{\vasty}, \astversion{\vcall}) \astarrow \vastnode
 }{
   {
     \begin{array}{l}
     \buildstmt(\Nstmt \\
-    \qquad (\Tvar, \punnode{\Ndeclitem}, \Teq, \namednode{\vcall}{\Nelidedparamcall}, \Tsemicolon)) \astarrow \vastnode
+    \qquad (\Tvar, \punnode{\Ndeclitem}, \punnode{\Nasty}, \Teq, \namednode{\vcall}{\Nelidedparamcall}, \Tsemicolon)) \astarrow \vastnode
     \end{array}
   }
 }
 \end{mathpar}
-
-
-% \Nstmt \derives \
-%    & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
-% |\ & \Tvar \parsesep \Ndeclitem \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
 
 \subsection{Typing and semantics}
 As given by the applying the relevant rules to the desugared AST (see \secref{DeclarationStatements}).
@@ -1390,7 +1467,7 @@ All of the following apply:
 \inferrule[non\_var]{
   \astlabel(\ve) \neq \EVar\\
   \vx \in \Identifiers \text{ is fresh}\\
-  \vdeclx \eqname \SDecl(\LDKLet, \LDIVar(\vx), \langle\ve\rangle)\\
+  \vdeclx \eqname \SDecl(\LDKLet, \LDIVar(\vx), \None, \langle\ve\rangle)\\
   \casestocond(\EVar(\vx), \vcases) \typearrow \vscond
 }{
   \desugarcasestmt(\overname{\SCase(\ve, \vcases)}{\vs}) \typearrow \overname{\SSeq(\vdeclx, \vscond)}{\news}

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -401,15 +401,15 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 |\ & \Treturn \parsesep \option{\Nexpr} \parsesep \Tsemicolon &\\
 |\ & \Ncall &\\
 |\ & \Tassert \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Nlexpr \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Ncall \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Ncall \parsesep \Tdot \parsesep \Tidentifier \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Ncall \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clisttwo{{\Tidentifier}} \parsesep \Trbracket \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
+|\ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Nasty \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
 |\ & \Tvar \parsesep \Clisttwo{\Tidentifier} \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Ndeclitem \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Ndeclitem \parsesep \Nasty \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
 |\ & \Tprint \parsesep \Plist{\Nexpr} \parsesep \Tsemicolon &\\
 |\ & \Tunreachable \parsesep \Tlpar \parsesep \Trpar \parsesep \Tsemicolon &\\
 |\ & \Trepeat \parsesep \Nstmtlist \parsesep \Tuntil \parsesep \Nexpr \parsesep \Nlooplimit \parsesep \Tsemicolon &\\
@@ -451,15 +451,9 @@ which appears only in declarations. It cannot have setter calls or set record fi
 it must declare a new variable.
 \hypertarget{def-ndeclitem}{}
 \begin{flalign*}
-\Ndeclitem \derives\ & \Nuntypeddeclitem \parsesep \Nasty&\\
-|\ & \Nuntypeddeclitem  &
-\end{flalign*}
-
-\hypertarget{def-nuntypeddeclitem}{}
-\begin{flalign*}
-\Nuntypeddeclitem \derives \ & \Tidentifier &\\
-|\ & \Tminus &\\
-|\ & \Plisttwo{\Ndeclitem} &
+\Ndeclitem \derives\
+   & \Nignoredoridentifier &\\
+|\ & \Plisttwo{\Nignoredoridentifier}  &
 \end{flalign*}
 
 \hypertarget{def-nintconstraintsopt}{}

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -432,18 +432,39 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 
 \hypertarget{def-nlexpr}{}
 \begin{flalign*}
-\Nlexpr \derives\ & \Nlexpratom &\\
-|\ & \Tminus &\\
-|\ & \Tlpar \parsesep \Clisttwo{\Nlexpr} \parsesep \Trpar &
+\Nlexpr \derives\
+   & \Tminus &\\
+|\ & \Nslicedbasiclexpr &\\
+|\ & \Tlpar \parsesep \Clisttwo{\Ndiscardorslicedbasiclexpr} \parsesep \Trpar &\\
+|\ & \Tidentifier \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clisttwo{\Tidentifier} \parsesep \Trbracket &\\
+|\ & \Tidentifier \parsesep \Tdot \parsesep \Tlpar \parsesep \Clisttwo{\Ndiscardoridentifier} \parsesep \Trpar &
 \end{flalign*}
 
-\hypertarget{def-nlexpratom}{}
+\hypertarget{def-nbasiclexpr}{}
 \begin{flalign*}
-\Nlexpratom \derives\ & \Tidentifier &\\
-|\ & \Nlexpratom \parsesep \Nslices &\\
-|\ & \Nlexpratom \parsesep \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket &\\
-|\ & \Nlexpratom \parsesep \Tdot \parsesep \Tidentifier &\\
-|\ & \Nlexpratom \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clist{{\Tidentifier}} \parsesep \Trbracket &
+\Nbasiclexpr \derives\
+   & \Tidentifier \parsesep \Nnestedfields &\\
+|\ & \Tidentifier \parsesep \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket \parsesep \Nnestedfields &
+\end{flalign*}
+
+\hypertarget{def-nnested-fields}{}
+\begin{flalign*}
+\Nnestedfields \derives\ & \emptysentence \;|\; \Tdot \parsesep \Tidentifier \parsesep \Nnestedfields &
+\end{flalign*}
+
+\hypertarget{def-nslicedbasiclexpr}{}
+\begin{flalign*}
+\Nslicedbasiclexpr \derives\ & \Nbasiclexpr \;|\; \Nbasiclexpr \parsesep \Nslices &
+\end{flalign*}
+
+\hypertarget{def-ndiscardorslicedbasiclexpr}{}
+\begin{flalign*}
+\Ndiscardorslicedbasiclexpr \derives\ & \Tminus \;|\; \Nslicedbasiclexpr &
+\end{flalign*}
+
+\hypertarget{def-ndiscardoridentifier}{}
+\begin{flalign*}
+\Ndiscardoridentifier \derives \ & \Tminus \;|\; \Tidentifier &
 \end{flalign*}
 
 A $\Ndeclitem$ is another kind of left-hand-side expression,

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -111,6 +111,60 @@ One of the following applies:
 }
 \end{mathpar}
 
+\hypertarget{def-filteroptionlist}{}
+\subsubsection{TypingRule.FilterOptionList \label{sec:TypingRule.FilterOptionList}}
+The parametric function
+\[
+  \filteroptionlist(\overname{\langle T \rangle^*}{\vvopts}) \aslto \overname{T^*}{\vvs}
+\]
+filters a list of \optional{} elements, removing those which are $\None$ and unwrapping those which are $\langle v \rangle$ to $v$.
+
+\subsubsection{Prose}
+One of the following applies:
+\begin{itemize}
+  \item All of the following apply (\textsc{empty}):
+  \begin{itemize}
+    \item $\vvopts$ is the empty list;
+    \item $\vvs$ is the empty list.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{non\_empty\_none}):
+  \begin{itemize}
+    \item $\vvopts$ is the non-empty list with head $\None$ and tail $\vvoptsp$;
+    \item applying $\filteroptionlist$ to $\vvoptsp$ yields $\vvs$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{non\_empty\_some}):
+  \begin{itemize}
+    \item $\vvopts$ is the non-empty list with head $\langle\vv\rangle$ and tail $\vvoptsp$;
+    \item applying $\filteroptionlist$ to $\vvoptsp$ yields $\vvsp$;
+    \item $\vvs$ is the concatenation of $\vv$ and $\vvsp$.
+  \end{itemize}
+\end{itemize}
+
+\begin{mathpar}
+  \inferrule[none]{}
+  {
+    \filteroptionlist(\overname{\emptylist}{\vvopts}) \typearrow \overname{\emptylist}{\vvs}
+  }
+\end{mathpar}
+
+\begin{mathpar}
+  \inferrule[non\_empty\_none]{
+    \filteroptionlist(\vvoptsp) \typearrow \vvs
+  }{
+    \filteroptionlist(\overname{[\None] \concat \vvoptsp}{\vvopts}) \typearrow \vvs
+  }
+\end{mathpar}
+
+\begin{mathpar}
+  \inferrule[non\_empty\_some]{
+    \filteroptionlist(\vvoptsp) \typearrow \vvsp
+  }{
+    \filteroptionlist(\overname{[\langle\vv\rangle] \concat \vvoptsp}{\vvopts}) \typearrow \overname{[\vv] \concat \vvsp}{\vvs}
+  }
+\end{mathpar}
+
 \subsubsection{TypingRule.Sort\label{sec:sortinglists}}
 \hypertarget{def-sort}{}
 The parametric function

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -92,6 +92,7 @@ type error_desc =
   | BadPrintType of ty
   | ConfigTimeBroken of expr * SideEffect.SES.t
   | ConstantTimeBroken of expr * SideEffect.SES.t
+  | MultipleWrites of identifier
 
 type error = error_desc annotated
 
@@ -183,6 +184,7 @@ let error_label = function
   | ConflictingSideEffects _ -> "ConflictingSideEffects"
   | ConfigTimeBroken _ -> "ConfigTimeBroken"
   | ConstantTimeBroken _ -> "ConstantTimeBroken"
+  | MultipleWrites _ -> "MultipleWrites"
 
 let warning_label = function
   | NoLoopLimit -> "NoLoopLimit"
@@ -449,7 +451,9 @@ module PPrint = struct
           "ASL Typing error:@ bitfields `%s` and `%s` are in the same scope \
            but define different slices of the containing bitvector type: %s \
            and %s, respectively."
-          field1_absname field2_absname field1_absslices field2_absslices);
+          field1_absname field2_absname field1_absslices field2_absslices
+    | MultipleWrites id ->
+        fprintf f "ASL Typing error:@ multiple@ writes@ to@ %S." id);
     pp_close_box f ()
 
   let pp_warning_desc f w =

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -74,7 +74,6 @@ module SemanticsRule = struct
     | PTuple
     | LDDiscard
     | LDVar
-    | LDTyped
     | LDTuple
     | SPass
     | SAssignCall
@@ -161,7 +160,6 @@ module SemanticsRule = struct
     | PTuple -> "PTuple"
     | LDDiscard -> "LDDiscard"
     | LDVar -> "LDVar"
-    | LDTyped -> "LDTyped"
     | LDTuple -> "LDTuple"
     | SPass -> "SPass"
     | SAssignCall -> "SAssignCall"
@@ -251,7 +249,6 @@ module SemanticsRule = struct
       PTuple;
       LDDiscard;
       LDVar;
-      LDTyped;
       LDTuple;
       SPass;
       SAssignCall;
@@ -387,11 +384,9 @@ module TypingRule = struct
     | PTuple
     | LDDiscard
     | LDVar
-    | LDTyped
     | LDTuple
     | LDUninitialisedVar
     | LDUninitialisedTyped
-    | LDUninitialisedTuple
     | SPass
     | SAssignCall
     | SAssign
@@ -574,12 +569,10 @@ module TypingRule = struct
     | PMask -> "PMask"
     | PTuple -> "PTuple"
     | LDDiscard -> "LDDiscardNone"
-    | LDTyped -> "LDTyped"
     | LDVar -> "LDVar"
     | LDUninitialisedVar -> "LDUninitialisedVar"
     | LDUninitialisedTyped -> "LDUninitialisedTyped"
     | LDTuple -> "LDTuple"
-    | LDUninitialisedTuple -> "LDUninitialisedTuple"
     | SPass -> "SPass"
     | SAssignCall -> "SAssignCall"
     | SAssign -> "SAssign"

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTuple.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDUninitialisedTuple.asl
@@ -1,9 +1,0 @@
-func main () => integer
-begin
-  
-  var (x : integer, y : boolean);
-
-  assert x == 0 && y == TRUE;
-
-  return 0;
-end;

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -134,10 +134,6 @@ ASL Semantics Reference:
   $ aslref SemanticsRule.LDTuple.asl
   $ aslref SemanticsRule.LDTypedTuple.asl
   $ aslref SemanticsRule.LDTypedVar.asl
-  $ aslref SemanticsRule.LDUninitialisedTuple.asl
-  File SemanticsRule.LDUninitialisedTuple.asl, line 4, characters 2 to 33:
-  Unsupported declaration: (x: integer, y: boolean).
-  [1]
   $ aslref SemanticsRule.LDTyped.asl
   $ aslref SemanticsRule.LDUninitialisedTyped.asl
   $ aslref SemanticsRule.SAssign.asl

--- a/asllib/tests/intersecting_slices.t
+++ b/asllib/tests/intersecting_slices.t
@@ -25,7 +25,7 @@ Two intersecting slices...
   > EOF
 
   $ aslref intersecting_slices2.asl
-  File intersecting_slices2.asl, line 5, characters 2 to 9:
+  File intersecting_slices2.asl, line 5, characters 3 to 9:
   ASL Static error: overlapping slices i+:1, j+:1.
   [1]
 

--- a/asllib/tests/regressions.t/base_values_tuple.asl
+++ b/asllib/tests/regressions.t/base_values_tuple.asl
@@ -1,0 +1,9 @@
+func main () => integer
+begin
+
+  var (x, y) : (integer, boolean);
+
+  assert x == 0 && y == FALSE;
+
+  return 0;
+end;

--- a/asllib/tests/regressions.t/lhs-tuple-fields-same-field.asl
+++ b/asllib/tests/regressions.t/lhs-tuple-fields-same-field.asl
@@ -1,0 +1,12 @@
+type BV of bits (8) {
+  [1:0] fld,
+};
+
+func main() => integer
+begin
+  var bv : BV;
+  bv.(fld, -, fld) = ('11', TRUE, '11');
+
+  assert FALSE;
+  return 0;
+end;

--- a/asllib/tests/regressions.t/lhs-tuple-fields.asl
+++ b/asllib/tests/regressions.t/lhs-tuple-fields.asl
@@ -1,0 +1,14 @@
+type BV of bits (8) {
+  [1:0] fldA,
+  [7:5] fldB
+};
+
+func main() => integer
+begin
+  var bv : BV;
+  bv.(fldA, -, fldB) = ('11', TRUE, '111');
+  assert (bv.fldA == '11');
+  assert (bv.fldB == '111');
+
+  return 0;
+end;

--- a/asllib/tests/regressions.t/lhs-tuple-same-var.asl
+++ b/asllib/tests/regressions.t/lhs-tuple-same-var.asl
@@ -1,0 +1,12 @@
+type BV of bits (8) {
+  [1:0] fld
+};
+
+func main() => integer
+begin
+  var bv : BV;
+  (bv[7], -, bv.fld) = ('1', TRUE, '11');
+
+  assert FALSE;
+  return 0;
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -375,6 +375,8 @@ Base values
     determined since it consists of N.
   [1]
 
+  $ aslref base_values_tuple.asl
+
 Getters/setters
   $ aslref nonempty-getter-called-without-slices.asl
   File nonempty-getter-called-without-slices.asl, line 8, characters 10 to 12:

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -434,3 +434,14 @@ Inherit integer constraints on left-hand sides
     character 2:
   ASL Typing error: a pending constrained integer is illegal here.
   [1]
+
+Left-hand sides
+  $ aslref lhs-tuple-fields.asl
+  $ aslref lhs-tuple-fields-same-field.asl
+  File lhs-tuple-fields-same-field.asl, line 8, characters 2 to 4:
+  ASL Typing error: multiple writes to "bv.fld".
+  [1]
+  $ aslref lhs-tuple-same-var.asl
+  File lhs-tuple-same-var.asl, line 8, characters 2 to 20:
+  ASL Typing error: multiple writes to "bv".
+  [1]

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -153,7 +153,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
       let ii = unalias ii in
       let open Asllib.AST in
       let with_pos desc = Asllib.ASTUtils.add_dummy_annotation ~version:V0 desc in
-      let ( ^= ) x e = S_Decl (LDK_Let, LDI_Var x, Some e) |> with_pos in
+      let ( ^= ) x e = S_Decl (LDK_Let, LDI_Var x, None, Some e) |> with_pos in
       let ( ^^= ) x e =
         let le_x = LE_Var x |> with_pos in
         S_Assign (le_x, e) |> with_pos in

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=a6cfc4e5ef77d95821a69651cfe17c1e
+Hash=f8f935ebd24694eeff8bf4ac221b18c0
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=32c7c0ab18879927dabc9481c82ccc8b
+Hash=466e821ea60d973ab26752734da568af
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=fa85f0c82a7e7f57059557a0551b654e
+Hash=15df8cf323b245ce9ea8cda83f272459
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=148ba7f9d68dd187e6a82a263aef2aab
+Hash=ebac45eb11ff7337abe24cad6fd7804f
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=67ffa6c60f20578584e46071ec3b9096
+Hash=dcedec31e50a4dfb925736e0e762a814
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=b3955161d6a8a8c5e4f917139ed7abd4
+Hash=9afeed12c63f5f24e9289cc2d020e781
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=fcb0e955f995a2fab3a11dd590ad7249
+Hash=b8e27e922bc18f0973cc3106bb0dd632
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=639acf1eccbd478a41bde430c15cc274
+Hash=68d7efe1712d077db896e6ce5713ecc4
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=242e58e94606fc81e8af2cec1f11627b
+Hash=8b0c8bd2dab15e33ae58f45a9f4dea57
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=d846a56dabc063f52bb85e979171c7ba
+Hash=74a8227f37a93156a99e18e86daae33b
 

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T1.0.a=1 /\ 0:T1.0.b=0)
 Observation MP-pseudo-arch Sometimes 1 3
-Hash=efebd3ed556ab89e429f822a74bc4b7c
+Hash=e4d9f8a971e26430ea558fcb187d603a
 

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:a=1 /\ 0:b=0)
 Observation MP-pseudo-arch Sometimes 1 3
-Hash=feb3c0483c44439a193427664a696f3f
+Hash=41cf9739fb59dfbb93b77168c09f4f5f
 

--- a/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.res=1)
 Observation YL-01 Always 1 0
-Hash=10aabe0aced3d55788e64cc552a3e4bf
+Hash=7e45428ead65a5e0d10ba711c60b5e2c
 

--- a/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation catch-exec-twice Always 1 0
-Hash=eaa6a4f16b7d23f757820519f62c5cc2
+Hash=374c8f16fe6155cd33b1be482ac852d0
 

--- a/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation for-toofar Always 3 0
-Hash=099caa4eb0042089d4862b07b6e2583b
+Hash=2f2c3cc08f9ef4945df9607f2f204fdf
 

--- a/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c=16)
 Observation frozen-tuple-arg Always 1 0
-Hash=342fd47a625ab7363ce6b5aed719104f
+Hash=80490cd7ed5acbbbe052765de0a44800
 

--- a/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c=16)
 Observation frozen-tuple-arg Always 1 0
-Hash=80490cd7ed5acbbbe052765de0a44800
+Hash=588a4789c83564caa4527718a73d3d5d
 

--- a/herd/tests/instructions/ASL-pseudo-arch/non-deterministic.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/non-deterministic.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation non-deterministic Always 2 0
-Hash=434928dc8325fdf1374c3cf44203b723
+Hash=ee9f71b97b098f6294dfbc3fccf06961
 

--- a/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation repeat-toofar Always 3 0
-Hash=397c92068c5733b4f9e6bd21e7280894
+Hash=8b31a48972e9d53a1a48c9a48d93d7e8
 

--- a/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c=3)
 Observation return-tuple Always 1 0
-Hash=d7f6775e03d6bdf21c3809304bd5ef1c
+Hash=2f551486a767d0027e5031e92c91fbbd
 

--- a/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c=3)
 Observation return-tuple Always 1 0
-Hash=b8c8749cb8aa24ae4f55dcdefa5840cd
+Hash=d7f6775e03d6bdf21c3809304bd5ef1c
 

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 9 Negative: 0
 Condition forall (0:z=2 /\ 0:t=2 /\ (0:g.0.a=0 /\ 0:main.0.y=0 \/ 0:g.0.a=1 /\ 0:main.0.y=1))
 Observation throw-propagate Always 9 0
-Hash=fcf1cdbbc349b4b2c44e7e95f9574523
+Hash=2671fa55986e76494683e69590408c27
 

--- a/herd/tests/instructions/ASL-pseudo-arch/try-non-deterministic.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/try-non-deterministic.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation try-non-deterministic Always 2 0
-Hash=a43cf198bf289fa7afacceca5330f600
+Hash=2dcc3ec62a279348fa075048307fdda4
 

--- a/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation while-toofar Always 3 0
-Hash=ec05eed3b9c6ad0d56e3325cbe06be0b
+Hash=18af3c2d65d7c6d9c13ed93a21870763
 

--- a/herd/tests/instructions/ASL/assign1.litmus.expected
+++ b/herd/tests/instructions/ASL/assign1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3)
 Observation assign1 Always 1 0
-Hash=3768c61844ebba5c7172894782e402e0
+Hash=239918d15065818c420ead18b4123575
 

--- a/herd/tests/instructions/ASL/assign2.litmus.expected
+++ b/herd/tests/instructions/ASL/assign2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c1=3 /\ 0:main.0.c2=5 /\ 0:main.0.c3=15 /\ 0:main.0.c4=3)
 Observation assign2 Always 1 0
-Hash=e06b614b66a79d43f2e12dfc88294599
+Hash=98e2c8198685d716f084370c6d93dfe7
 

--- a/herd/tests/instructions/ASL/assign3.litmus.expected
+++ b/herd/tests/instructions/ASL/assign3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.eq=1 /\ 0:main.0.ne=1 /\ 0:main.0.lt=1 /\ 0:main.0.al=1)
 Observation assign3 Always 1 0
-Hash=641205b87f6dd8140a47f546cfa5bff8
+Hash=b403f3b0ce942458aa8e0a98b882c25e
 

--- a/herd/tests/instructions/ASL/bitfields1.litmus.expected
+++ b/herd/tests/instructions/ASL/bitfields1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.b=1 /\ 0:main.0.d=1 /\ 0:main.0.e=1)
 Observation bitfields1 Always 1 0
-Hash=07dc029fd6daa7640925654246d06198
+Hash=f6bb584e083b68646159fb3791b28248
 

--- a/herd/tests/instructions/ASL/case1.litmus.expected
+++ b/herd/tests/instructions/ASL/case1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=1 /\ 0:main.0.b=0)
 Observation case1 Always 1 0
-Hash=a7a79acf263482f63500dc0b184e1298
+Hash=7d2852e475c1cf52a2462f2f01112600
 

--- a/herd/tests/instructions/ASL/data-return-01.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-01.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation no Always 1 0
-Hash=e19e61389c276c4e37a837cc7cbecc0f
+Hash=baf58be4152af0fc668276b372af6b7b
 

--- a/herd/tests/instructions/ASL/data-return-02.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-02.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation no Always 1 0
-Hash=e6b10d45a05c9ad07cabe1f0dce8d4fa
+Hash=50d8bbf023547487542974b2cf857480
 

--- a/herd/tests/instructions/ASL/double-load.litmus.expected
+++ b/herd/tests/instructions/ASL/double-load.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.three=3)
 Observation double-load Always 1 0
-Hash=5dbf3288826e27ceb755cca330aba801
+Hash=e6d7dfff400d582cb5789f1bf40d2b0b
 

--- a/herd/tests/instructions/ASL/for1.litmus.expected
+++ b/herd/tests/instructions/ASL/for1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.s=110)
 Observation for1 Always 1 0
-Hash=3986e882326dc179b5c919e7911c1184
+Hash=bd45b66b820e45e40af86be6e26cee56
 

--- a/herd/tests/instructions/ASL/func1.litmus.expected
+++ b/herd/tests/instructions/ASL/func1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3 /\ 0:main.0.y=3)
 Observation func1 Always 1 0
-Hash=8f99d15892de36ef69b7c1612d04c069
+Hash=d9f68b63dd785d263d825c3b7f1144b0
 

--- a/herd/tests/instructions/ASL/func2.litmus.expected
+++ b/herd/tests/instructions/ASL/func2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=4 /\ 0:X-1.0.internal_i=2 /\ 0:X-1.0.internal_v=3)
 Observation func02 Always 1 0
-Hash=15cd1b923685053849e1225063e3cc18
+Hash=c79fcc3a1e8aa899c9c67f2ee5534a46
 

--- a/herd/tests/instructions/ASL/func3.litmus.expected
+++ b/herd/tests/instructions/ASL/func3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=3 /\ 0:main.0.b=3 /\ 0:main.0.c=7 /\ 0:f3_storage=12 /\ 0:f4_storage=15)
 Observation func3 Always 1 0
-Hash=020281c874c5a7f941655f5de0c2ba41
+Hash=30075d488e0fe6c178d31ab2f1a840f3
 

--- a/herd/tests/instructions/ASL/func4.litmus.expected
+++ b/herd/tests/instructions/ASL/func4.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=0 /\ 0:main.0.b=1 /\ 0:main.0.c=5)
 Observation func4 Always 1 0
-Hash=1372c690745401d1fd199694f8c8cd41
+Hash=1725135c8954c6cee5841a83594eb5bf
 

--- a/herd/tests/instructions/ASL/records.litmus.expected
+++ b/herd/tests/instructions/ASL/records.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3)
 Observation records Always 1 0
-Hash=900ad0b2371237326c04efb1ef861d48
+Hash=a525096870e854b910f1548037573a58
 

--- a/herd/tests/instructions/ASL/unknown.litmus.expected
+++ b/herd/tests/instructions/ASL/unknown.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation Unknown Always 2 0
-Hash=3e042a35d95e13427946c3c2617324e4
+Hash=4820ca8b37c442cde159de5fd3d5972e
 

--- a/herd/tests/instructions/ASL/while1.litmus.expected
+++ b/herd/tests/instructions/ASL/while1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.y=6 /\ 0:main.0.x=0)
 Observation while1 Always 1 0
-Hash=1a5aa21341891fb5de716b635046ef06
+Hash=af6eec1dc3e63f59fe6450e6ac6316bf
 

--- a/herd/tests/instructions/ASL/while2.litmus.expected
+++ b/herd/tests/instructions/ASL/while2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.z=0 /\ 0:main.0.x=2)
 Observation while2 Always 1 0
-Hash=e4b6df53e8f706bfe65550efa09b0964
+Hash=d8cc7b9e128d32e53e4739fa5bf4ff73
 

--- a/herd/tests/instructions/ASL/write_mem.litmus.expected
+++ b/herd/tests/instructions/ASL/write_mem.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 0 Negative: 1
 Condition forall ([x]=3)
 Observation write-mem Never 0 1
-Hash=88e6297bebd9e06e743a53b8119f5852
+Hash=e9513c0291b45e774106925af72a677e
 


### PR DESCRIPTION
Restrict left-hand sides as follows:
- _(local declarations)_ Forbid all nesting within tuples - allow type annotations only at the top-level, and allow only variables/discards within tuples.
- _(mutable assignments)_
  - Enforce a strict grammar of left-hand sides in parsing, which is then desugared to produced the underlying representation for type-checking and interpretation.
  - Check that for tuple assignments, the same underlying variable is not written to multiple times.

Also add a new mutable assignment left-hand side: `x.(a,b,-,c)`, which assigns to fields `a`, `b`, and `c` of `x` given an appropriate tupled right-hand side. This also checks that the field names are distinct.

A last stray commit ensures that `UNKNOWN` is documented as a reserved keyword.