### PR TITLE
[asl] Change 'SInt' behaviour on zero-length bitvector.

### DIFF
--- a/asllib/bitvector.ml
+++ b/asllib/bitvector.ml
@@ -123,10 +123,13 @@ let remask (length, data) =
    --------------------------------------------------------------------------*)
 
 let sign_bit (length, data) =
-  let n = length / 8 and m = length mod 8 in
-  let data_pos = if m = 0 then n - 1 else n in
-  let bit_index = (m + 7) mod 8 in
-  String.get data data_pos |> read_bit_raw bit_index
+  match length with
+  | 0 -> 0
+  | _ ->
+      let n = length / 8 and m = length mod 8 in
+      let data_pos = if m = 0 then n - 1 else n in
+      let bit_index = (m + 7) mod 8 in
+      String.get data data_pos |> read_bit_raw bit_index
 
 let extend signed nbytes (length, data) =
   let to_length = 8 * nbytes in

--- a/asllib/tests/regressions.t/stdlib.asl
+++ b/asllib/tests/regressions.t/stdlib.asl
@@ -67,6 +67,7 @@ begin
   assert SInt('000') == 0;
   assert SInt('0') == 0;
   assert SInt('1') == -1;
+  assert SInt('') == 0;
 
   test_uint{0}(Zeros{0});
   test_uint{1}(Zeros{1});


### PR DESCRIPTION
At the moment the expression `SInt('')` fails. Consider the following test:
```
func main() => integer
begin
  let x = SInt('');
  println(x);
  return 0;
end;
```
Execution yields:
```
% aslref sint0.asl 
Fatal error: exception Invalid_argument("index out of bounds")
```
As a fix, the expression now has value zero.

However the type of `SInt('')` is problematic. With `aslref` option `--print-typed`, we see:
```
...
let x: integer {(- (2 ^ (0 - 1)))..((2 ^ (0 - 1)) - 1)} = SInt{0}('');
...
```
This is problematic as `2^(0-1)` is illegal. Nevertheless, until this question is settled, avoiding a cryptic failure looks like a decent solution.

A specific exception is another option,  @relokin, @HadrienRenaud., @jalglave?
