### PR TITLE
[test] Add option `-nohash` to test tools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ test-local:: test-asl
 test-asl:
 	@ echo
 	$(HERD_REGRESSION_TEST) \
+		-nohash \
 		-herd-path $(HERD) \
 		-libdir-path ./herd/libdir \
 		-litmus-dir ./herd/tests/instructions/ASL \
@@ -254,6 +255,7 @@ test-local:: test-pseudo-asl
 test-pseudo-asl:
 	@ echo
 	$(HERD_REGRESSION_TEST) \
+		-nohash \
 		-herd-path $(HERD) \
 		-libdir-path ./herd/libdir \
 		-litmus-dir ./herd/tests/instructions/ASL-pseudo-arch \
@@ -320,7 +322,7 @@ aarch32-test::
 		-litmus-dir ./herd/tests/instructions/AArch32 \
 		-conf ./herd/tests/instructions/AArch32/aarch32.cfg \
 		$(REGRESSION_TEST_MODE)
-	@ echo "herd7 ARM instructions tests: OK"
+	@ echo "herd7 AArch32 instructions tests: OK"
 
 test::aarch32-test
 test-local::aarch32-test

--- a/internal/herd_diycross_regression_test.ml
+++ b/internal/herd_diycross_regression_test.ml
@@ -30,6 +30,7 @@ type flags = {
   diycross_args : string list ;
   expected_dir  : path ;
   variants      : string list ;
+  nohash        : bool ;
 }
 
 
@@ -117,7 +118,8 @@ let run_tests ?j flags =
     | None ->
        List.map
          (fun (l, e) ->
-           TestHerd.herd_output_matches_expected ~bell:None ~cat:None
+            TestHerd.herd_output_matches_expected ~nohash:flags.nohash
+              ~bell:None ~cat:None
              ~conf:flags.herd_conf
              ~variants:flags.variants
              ~libdir:flags.libdir
@@ -131,7 +133,7 @@ let run_tests ?j flags =
             ~libdir:flags.libdir
             flags.herd ~j:j litmus_paths) ;
        List.map
-         (fun (l,e) -> TestHerd.output_matches_expected l e)
+         (fun (l,e) -> TestHerd.output_matches_expected ~nohash:flags.nohash l e)
          les
   in
   let passed x = x in
@@ -216,6 +218,7 @@ let () =
   (* Optional arguments. *)
   let conf = ref None in
   let j = ref None in
+  let nohash = ref false in
 
   let anon_args = ref [] in
   let options = [
@@ -226,7 +229,7 @@ let () =
     "-diycross-arg", Args.append_string diycross_args,  "one argument for diycross (cumulative)" ;
     Args.is_file ("-conf", Args.set_string_option conf,   "path to config file to pass to herd7") ;
                   "-variant",     Args.append_string variants,   "variant to pass to herd7" ;
-    Args.npar j ;
+    Args.npar j ; Args.nohash nohash ;
   ] in
   Arg.parse options (fun a -> anon_args := a :: !anon_args) usage ;
 
@@ -253,7 +256,7 @@ let () =
     diycross_args = !diycross_args ;
     expected_dir = !expected_dir ;
     variants = !variants ;
-
+    nohash = !nohash ;
     } in
   let j = !j in
   match !anon_args with

--- a/internal/herd_regression_test.ml
+++ b/internal/herd_regression_test.ml
@@ -29,6 +29,7 @@ type flags = {
   litmus_dir : path ;
   variants   : string list ;
   conf       : path option ;
+  nohash     : bool ;
 }
 
 
@@ -130,7 +131,7 @@ let show_tests_par j flags =
 
   let run_tests_seq flags =
     let test_passes l =
-      TestHerd.herd_output_matches_expected ~bell:None ~cat:None
+      TestHerd.herd_output_matches_expected ~nohash:flags.nohash ~bell:None ~cat:None
         ~conf:flags.conf
         ~variants:flags.variants
         ~libdir:flags.libdir
@@ -231,11 +232,12 @@ let () =
   let conf = ref None in
   let variants = ref [] in
   let j = ref None in
+  let nohash = ref false in
 
   let anon_args = ref [] in
 
   let options = [
-    Args.npar j;
+    Args.npar j; Args.nohash nohash;
     Args.is_file ("-herd-path",   Arg.Set_string herd,           "path to herd binary") ;
     Args.is_dir  ("-libdir-path", Arg.Set_string libdir,         "path to herd libdir") ;
     Args.is_dir  ("-litmus-dir",  Arg.Set_string litmus_dir,     "path to directory of .litmus files to test against") ;
@@ -263,6 +265,7 @@ let () =
     litmus_dir = !litmus_dir ;
     conf = !conf ;
     variants = !variants ;
+    nohash = !nohash ;
     } in
   let j = !j in
   match !anon_args with

--- a/internal/lib/args.ml
+++ b/internal/lib/args.ml
@@ -32,6 +32,10 @@ let npar j =
   "-j",Arg.Int (fun i -> j := Some (max i 1)),
   "<n> concurrent run with at most <n> instances"
 
+let nohash b =
+  "-nohash",Arg.Unit (fun () -> b := true),
+  "do not check hashes"
+
 (** Validators. *)
 
 let validate check msg (key, spec, doc) =

--- a/internal/lib/args.mli
+++ b/internal/lib/args.mli
@@ -36,6 +36,12 @@ val set_string_option : string option ref -> Arg.spec
 
 val npar : int option ref -> spec
 
+(** [nohash b] Build an Arg.spec for setting b to true, with documentation
+    as not checking hashes *)
+
+val nohash : bool ref -> spec
+
+
 (** Validators. *)
 
 (** [is_file (k, s, d)] returns [k, s', d], where [s'] wraps [s] with an

--- a/internal/lib/testHerd.mli
+++ b/internal/lib/testHerd.mli
@@ -96,10 +96,10 @@ val run_herd_concurrent :
   libdir   : path ->
      path -> j:int-> path list -> int
 
-(** [herd_output_matches_expected litmus expected] returns true when
+(** [herd_output_matches_expected nohash litmus expected] returns true when
  * the output file produced by running [litmus] matches reference
- *  [expected]. *)
-val output_matches_expected : path -> path -> bool
+ *  [expected]. If argument [nohash] is true, hashes are not compared. *)
+val output_matches_expected : ?nohash:bool -> path -> path -> bool
 
 (** [herd_output_matches_expected ~bell ~cat ~conf ~variants ~libdir herd
  *  litmus expected expected_failure expected_warn] runs the binary
@@ -115,6 +115,7 @@ val output_matches_expected : path -> path -> bool
  *  Paths to [cat], [bell], and [conf] files, as well as [variants], can also
  *  be passed in. *)
 val herd_output_matches_expected :
+  ?nohash  : bool ->
   bell     : path option ->
   cat      : path option ->
   conf     : path option ->
@@ -127,6 +128,7 @@ val herd_output_matches_expected :
   *  as [herd_output_matches_expected] above but a different interface,
   *   as command line options are given as the list [args]. *)
 val herd_args_output_matches_expected :
+  ?nohash:bool ->
   path -> string list -> path -> path -> path -> path  -> bool
 
 (** [is_litmus filename] returns whether the [filename] is a .litmus file. *)


### PR DESCRIPTION
By popular demand, the `-nohash` option of the `mcompare` tool  now exists for regression tools.

When present, this option disables the check of hashes produced by herd during regression testing.

Option is set for ASL tests.