### PR TITLE
[asl] Fix dynamic domain after enum labels

### DIFF
--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -85,12 +85,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
   \item All of the following apply (\textsc{t\_enumeration}):
   \begin{itemize}
     \item $\vt$ is the enumeration type with labels $\id_{1..k}$, that is $\TEnum(\id_{1..k})$;
-    \item $\vd$ is the set of all native integer values for $1..k$.\\
-    \textbf{Why represent enumeration domains via integers:}
-    Conceptually, enumeration labels carry two pieces of information --- the identifiers themselves
-    and their position in the list of identifiers, which are used for accessing arrays.
-    For the purpose of type-checking, we use the identifiers, but for the purpose of the semantics
-    and the domain of values, only the positions are relevant.
+    \item $\vd$ is the set of all native enumeration labels $\llabel(\id_\vi, \vi)$, for $\vi = 1..k$.
   \end{itemize}
 
   \item All of the following apply (\textsc{t\_int\_unconstrained}):
@@ -238,7 +233,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
 \inferrule[t\_real]{}{ \dynamicdomain(\env, \overname{\TReal}{\vt}) = \overname{\treal}{\vd} }
 \and
 \inferrule[t\_enumeration]{}{
-  \dynamicdomain(\env, \overname{\TEnum(\id_{1..k})}{\vt}) = \overname{\{\nvint(1),\ldots,\nvint(k)\}}{\vd}
+  \dynamicdomain(\env, \overname{\TEnum(\id_{1..k})}{\vt}) = \overname{\{ \vi = 1..k: \nvliteral{\llabel(\id_\vi, \vi)} \}}{\vd}
 }
 \end{mathpar}
 


### PR DESCRIPTION
Dynamic domain was still using the old definition of enumeration labels: enumeration labels were compiled to integers. After PR #1091, enumeration labels are first class citizens, and so we can update the definition of dynamic domains to use those. This results in a simpler and more straight forward definition of dynamic domains.

### Before

- Prose:
<img width="743" alt="Screenshot 2024-12-14 at 13 31 06" src="https://github.com/user-attachments/assets/4a09165f-eb6d-4f13-bec2-134fe0d2b5ce" />

- Formally:
<img width="449" alt="Screenshot 2024-12-14 at 13 31 39" src="https://github.com/user-attachments/assets/786f4d14-aa8e-4667-a512-af27b607a264" />

### After

- Prose:
<img width="676" alt="Screenshot 2024-12-14 at 13 29 05" src="https://github.com/user-attachments/assets/59a6b48c-2a89-436b-b638-b26945dce716" />

- Formally:
<img width="691" alt="Screenshot 2024-12-14 at 13 28 41" src="https://github.com/user-attachments/assets/071de9f0-613b-47c9-84d3-59334520351c" />
