### PR TITLE
[asl] Fix bug in constant iterations on empty sets.

### DIFF
--- a/asllib/tests/regressions.t/bad-inclusion-in-symbolic-type.asl
+++ b/asllib/tests/regressions.t/bad-inclusion-in-symbolic-type.asl
@@ -1,0 +1,3 @@
+config A : integer{1..2} = 1;
+var ah: integer{2..A} = 1;
+

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -39,6 +39,12 @@ Bad types:
   ASL Static error: overlapping slices 0+:11, 3+:2.
   [1]
 
+  $ aslref bad-inclusion-in-symbolic-type.asl
+  File bad-inclusion-in-symbolic-type.asl, line 2, characters 0 to 26:
+  ASL Typing error: a subtype of integer {2..A} was expected,
+    provided integer {1}.
+  [1]
+
 Global ignored:
   $ cat >global_ignored.asl <<EOF
   > var - = 3 / 0;

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -359,8 +359,11 @@ module Domain = struct
         if Z.lt z2 z1 then acc else f z1 acc |> aux f (Z.succ z1) z2
       in
       fun f z1 z2 acc ->
-        if Z.equal z1 z2 then f z1 acc
-        else acc |> f z1 |> f z2 |> aux f (Z.succ z1) (Z.pred z2)
+        match Z.compare z1 z2 with
+        | 1 -> acc
+        | 0 -> f z1 acc
+        | -1 -> acc |> f z1 |> f z2 |> aux f (Z.succ z1) (Z.pred z2)
+        | _ -> assert false
 
     let rec expr_fold :
           'acc. _ -> _ -> (literal -> 'acc -> 'acc) -> _ -> 'acc -> 'acc =


### PR DESCRIPTION
Before this PR, the type-checker did not raise any problems with the following test:

```
config A : integer {1..2} = 1;
var x: integer {2..A} = 1; // should fail
```

This is due to the logic on constants missing the case where the interval is empty. This case now added, the previous test does not pass, as expected.