### PR TITLE
[asl] Handle arrays with enumerated indices

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -108,16 +108,7 @@ type literal =
   | L_Real of Q.t
   | L_BitVector of Bitvector.t
   | L_String of string
-  | L_Label of (string * int)
-      (** An enumeration label, given by its name and its index in the
-          containing enumeration type declaration.
-          The index is only used for herd executions.
-          For example, the declaration
-              type MyEnum of enumeration {LABEL_A, LABEL_B};
-          will result in the following labels:
-              L_Label ("LABEL_A", 0)
-              L_Label ("LABEL_B", 1)
-      *)
+  | L_Label of string  (** An enumeration label, given by its name. *)
 
 (* -------------------------------------------------------------------------
 

--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -109,9 +109,9 @@ type literal =
   | L_BitVector of Bitvector.t
   | L_String of string
   | L_Label of (string * int)
-      (** An enumeration label, given by its name and its index in its type
-          definition.
-
+      (** An enumeration label, given by its name and its index in the
+          containing enumeration type declaration.
+          The index is only used for herd executions.
           For example, the declaration
               type MyEnum of enumeration {LABEL_A, LABEL_B};
           will result in the following labels:
@@ -158,6 +158,17 @@ type expr_desc =
   | E_Slice of expr * slice list
   | E_Cond of expr * expr * expr
   | E_GetArray of expr * expr
+      (** [E_GetArray base index] Represents an access to an array given
+        by the expression [base] at index [index].
+        When this node appears in the untyped AST, the index may either
+        be integer-typed or enumeration-typed.
+        When this node appears in the typed AST, the index can only be
+        integer-typed.
+    *)
+  | E_GetEnumArray of expr * expr
+      (** Access an array with an enumeration index.
+        This constructor is only part of the typed AST.
+    *)
   | E_GetField of expr * identifier
   | E_GetFields of expr * identifier list
   | E_GetItem of expr * int
@@ -167,6 +178,15 @@ type expr_desc =
   | E_Array of { length : expr; value : expr }
       (** Initial value for an array of size [length] and of content [value] at
           each array cell.
+
+          This expression constructor is only part of the typed AST, i.e. it is
+          only built by the type-checker, not any parser.
+      *)
+  | E_EnumArray of { enum : identifier; labels : identifier list; value : expr }
+      (** Initial value for an array where the index is the enumeration [enum],
+          which declares the list of labels [labels],
+          and the content of each cell is given by [value].
+          [enum] is only used for pretty-printing.
 
           This expression constructor is only part of the typed AST, i.e. it is
           only built by the type-checker, not any parser.
@@ -268,8 +288,8 @@ and bitfield =
 and array_index =
   | ArrayLength_Expr of expr
       (** An integer expression giving the length of the array. *)
-  | ArrayLength_Enum of identifier * int
-      (** An enumeration name and its length. *)
+  | ArrayLength_Enum of identifier * identifier list
+      (** An enumeration name and its list of labels. *)
 
 and field = identifier * ty
 (** A field of a record-like structure. *)
@@ -291,6 +311,17 @@ type lexpr_desc =
   | LE_Var of identifier
   | LE_Slice of lexpr * slice list
   | LE_SetArray of lexpr * expr
+      (** [LE_SetArray base index] represents a write to an array given
+        by the expression [base] at index [index].
+        When this node appears in the untyped AST, the index may either
+        be integer-typed or enumeration-typed.
+        When this node appears in the typed AST, the index can only be
+        integer-typed.
+    *)
+  | LE_SetEnumArray of lexpr * expr
+      (** Represents a write to an array with an enumeration index.
+        This constructor is only part of the typed AST.
+    *)
   | LE_SetField of lexpr * identifier
   | LE_SetFields of lexpr * identifier list * (int * int) list
       (** LE_SetFields (le, fields, _) unpacks the various fields. Third argument is a type annotation. *)

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -385,7 +385,7 @@ let literal_equal v1 v2 =
   | L_BitVector _, _ -> false
   | L_String s1, L_String s2 -> String.equal s1 s2
   | L_String _, _ -> false
-  | L_Label (l1, _), L_Label (l2, _) -> String.equal l1 l2
+  | L_Label l1, L_Label l2 -> String.equal l1 l2
   | L_Label _, _ -> false
 
 let rec expr_equal eq e1 e2 =

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -245,7 +245,8 @@ let rec use_e e =
   | E_Literal _ -> Fun.id
   | E_ATC (e, ty) -> use_ty ty $ use_e e
   | E_Var x -> ISet.add x
-  | E_GetArray (e1, e2) | E_Binop (_, e1, e2) -> use_e e1 $ use_e e2
+  | E_GetArray (e1, e2) | E_GetEnumArray (e1, e2) | E_Binop (_, e1, e2) ->
+      use_e e1 $ use_e e2
   | E_Unop (_op, e) -> use_e e
   | E_Call { name; args; params } -> ISet.add name $ use_es params $ use_es args
   | E_Slice (e, slices) -> use_e e $ use_slices slices
@@ -256,6 +257,9 @@ let rec use_e e =
   | E_Record (ty, li) -> use_ty ty $ use_fields li
   | E_Tuple es -> use_es es
   | E_Array { length; value } -> use_e length $ use_e value
+  | E_EnumArray { labels; value } ->
+      (fun init -> List.fold_left (fun acc lab -> ISet.add lab acc) init labels)
+      $ use_e value
   | E_Arbitrary t -> use_ty t
   | E_Pattern (e, p) -> use_e e $ use_pattern p
 
@@ -337,7 +341,7 @@ and use_le le =
   | LE_Var x -> ISet.add x
   | LE_Destructuring les -> List.fold_right use_le les
   | LE_Discard -> Fun.id
-  | LE_SetArray (le, e) -> use_le le $ use_e e
+  | LE_SetArray (le, e) | LE_SetEnumArray (le, e) -> use_le le $ use_e e
   | LE_SetField (le, _) | LE_SetFields (le, _, _) -> use_le le
   | LE_Slice (le, slices) -> use_slices slices $ use_le le
 
@@ -410,6 +414,9 @@ let rec expr_equal eq e1 e2 =
   | E_GetArray (e11, e21), E_GetArray (e12, e22) ->
       expr_equal eq e11 e12 && expr_equal eq e21 e22
   | E_GetArray _, _ | _, E_GetArray _ -> false
+  | E_GetEnumArray (e11, e21), E_GetEnumArray (e12, e22) ->
+      expr_equal eq e11 e12 && expr_equal eq e21 e22
+  | E_GetEnumArray _, _ | _, E_GetEnumArray _ -> false
   | E_GetField (e1', f1), E_GetField (e2', f2) ->
       String.equal f1 f2 && expr_equal eq e1' e2'
   | E_GetField _, _ | _, E_GetField _ -> false
@@ -427,6 +434,10 @@ let rec expr_equal eq e1 e2 =
   | E_Array { length = l1; value = v1 }, E_Array { length = l2; value = v2 } ->
       expr_equal eq l1 l2 && expr_equal eq v1 v2
   | E_Array _, _ | _, E_Array _ -> false
+  | ( E_EnumArray { labels = l1; value = v1 },
+      E_EnumArray { labels = l2; value = v2 } ) ->
+      list_equal String.equal l1 l2 && expr_equal eq v1 v2
+  | E_EnumArray _, _ | _, E_EnumArray _ -> false
   | E_ATC (e1, t1), E_ATC (e2, t2) -> expr_equal eq e1 e2 && type_equal eq t1 t2
   | E_ATC _, _ | _, E_ATC _ -> false
   | E_Unop (o1, e1), E_Unop (o2, e2) -> o1 = o2 && expr_equal eq e1 e2
@@ -463,7 +474,8 @@ and constraints_equal eq cs1 cs2 =
 and array_length_equal eq l1 l2 =
   match (l1, l2) with
   | ArrayLength_Expr e1, ArrayLength_Expr e2 -> expr_equal eq e1 e2
-  | ArrayLength_Enum (s1, _), ArrayLength_Enum (s2, _) -> String.equal s1 s2
+  | ArrayLength_Enum (enum1, labels1), ArrayLength_Enum (enum2, labels2) ->
+      String.equal enum1 enum2 && list_equal String.equal labels1 labels2
   | ArrayLength_Enum (_, _), ArrayLength_Expr _
   | ArrayLength_Expr _, ArrayLength_Enum (_, _) ->
       false
@@ -588,6 +600,7 @@ let expr_of_lexpr : lexpr -> expr =
     | LE_Var x -> E_Var x
     | LE_Slice (le, args) -> E_Slice (map_desc aux le, args)
     | LE_SetArray (le, e) -> E_GetArray (map_desc aux le, e)
+    | LE_SetEnumArray (le, e) -> E_GetEnumArray (map_desc aux le, e)
     | LE_SetField (le, x) -> E_GetField (map_desc aux le, x)
     | LE_SetFields (le, x, _) -> E_GetFields (map_desc aux le, x)
     | LE_Discard -> E_Var "-"
@@ -703,6 +716,7 @@ let rec subst_expr substs e =
           call_type;
         }
   | E_GetArray (e1, e2) -> E_GetArray (tr e1, tr e2)
+  | E_GetEnumArray (e1, e2) -> E_GetEnumArray (tr e1, tr e2)
   | E_GetField (e, x) -> E_GetField (tr e, x)
   | E_GetFields (e, fields) -> E_GetFields (tr e, fields)
   | E_GetItem (e, i) -> E_GetItem (tr e, i)
@@ -714,6 +728,8 @@ let rec subst_expr substs e =
   | E_Tuple es -> E_Tuple (List.map tr es)
   | E_Array { length; value } ->
       E_Array { length = tr length; value = tr value }
+  | E_EnumArray { enum; labels; value } ->
+      E_EnumArray { enum; labels; value = tr value }
   | E_ATC (e, t) -> E_ATC (tr e, t)
   | E_Arbitrary _ -> e.desc
   | E_Unop (op, e) -> E_Unop (op, tr e)
@@ -724,8 +740,11 @@ let rec is_simple_expr e =
   | E_Var _ | E_Literal _ | E_Arbitrary _ -> true
   | E_Array { length = e1; value = e2 }
   | E_GetArray (e1, e2)
+  | E_GetEnumArray (e1, e2)
   | E_Binop (_, e1, e2) ->
       is_simple_expr e1 && is_simple_expr e2
+  | E_EnumArray { value = e }
+  | E_ATC (e, _)
   | E_GetFields (e, _)
   | E_GetField (e, _)
   | E_GetItem (e, _)
@@ -739,7 +758,7 @@ let rec is_simple_expr e =
       is_simple_expr e && List.for_all is_simple_slice slices
   | E_Record (_, fields) ->
       List.for_all (fun (_name, e) -> is_simple_expr e) fields
-  | E_ATC (_, _) | E_Call _ -> false
+  | E_Call _ -> false
 
 and is_simple_slice = function
   | Slice_Length (e1, e2) | Slice_Range (e1, e2) | Slice_Star (e1, e2) ->
@@ -788,6 +807,7 @@ let rename_locals map_name ast =
     | E_Slice (e', slices) -> E_Slice (map_e e', map_slices slices)
     | E_Cond (e1, e2, e3) -> E_Cond (map_e e1, map_e e2, map_e e3)
     | E_GetArray (e1, e2) -> E_GetArray (map_e e1, map_e e2)
+    | E_GetEnumArray (e1, e2) -> E_GetEnumArray (map_e e1, map_e e2)
     | E_GetField (e', f) -> E_GetField (map_e e', f)
     | E_GetFields (e', li) -> E_GetFields (map_e e', li)
     | E_GetItem (e', i) -> E_GetItem (map_e e', i)
@@ -795,6 +815,8 @@ let rename_locals map_name ast =
     | E_Tuple li -> E_Tuple (map_es li)
     | E_Array { length; value } ->
         E_Array { length = map_e length; value = map_e value }
+    | E_EnumArray { enum; labels; value } ->
+        E_EnumArray { enum; labels; value = map_e value }
     | E_Pattern (_, _) -> failwith "Not yet implemented: obfuscate patterns"
   and map_es li = List.map map_e li
   and map_slices slices = List.map map_slice slices
@@ -858,6 +880,7 @@ let rename_locals map_name ast =
     | LE_Var x -> LE_Var (map_name x)
     | LE_Slice (le, slices) -> LE_Slice (map_le le, map_slices slices)
     | LE_SetArray (le, i) -> LE_SetArray (map_le le, map_e i)
+    | LE_SetEnumArray (le, i) -> LE_SetEnumArray (map_le le, map_e i)
     | LE_SetField (le, f) -> LE_SetField (map_le le, f)
     | LE_SetFields (le, f, annot) -> LE_SetFields (map_le le, f, annot)
     | LE_Destructuring les -> LE_Destructuring (List.map map_le les)

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -257,9 +257,7 @@ let rec use_e e =
   | E_Record (ty, li) -> use_ty ty $ use_fields li
   | E_Tuple es -> use_es es
   | E_Array { length; value } -> use_e length $ use_e value
-  | E_EnumArray { labels; value } ->
-      (fun init -> List.fold_left (fun acc lab -> ISet.add lab acc) init labels)
-      $ use_e value
+  | E_EnumArray { labels; value } -> use_list ISet.add labels $ use_e value
   | E_Arbitrary t -> use_ty t
   | E_Pattern (e, p) -> use_e e $ use_pattern p
 
@@ -474,8 +472,8 @@ and constraints_equal eq cs1 cs2 =
 and array_length_equal eq l1 l2 =
   match (l1, l2) with
   | ArrayLength_Expr e1, ArrayLength_Expr e2 -> expr_equal eq e1 e2
-  | ArrayLength_Enum (enum1, labels1), ArrayLength_Enum (enum2, labels2) ->
-      String.equal enum1 enum2 && list_equal String.equal labels1 labels2
+  | ArrayLength_Enum (enum1, _), ArrayLength_Enum (enum2, _) ->
+      String.equal enum1 enum2
   | ArrayLength_Enum (_, _), ArrayLength_Expr _
   | ArrayLength_Expr _, ArrayLength_Enum (_, _) ->
       false

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -141,10 +141,10 @@ val var_ : identifier -> expr
 (** [var_ x] is the expression [x]. *)
 
 val binop : binop -> expr -> expr -> expr
-(** Builds a binary operation from to sub-expressions. *)
+(** Builds a binary operation from to subexpressions. *)
 
 val unop : unop -> expr -> expr
-(** Builds a unary operation from its sub-expression. *)
+(** Builds a unary operation from its subexpression. *)
 
 val expr_of_z : Z.t -> expr
 (** [expr_of_z z] is the integer literal for [z]. *)

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -51,7 +51,7 @@ let pp_literal f =
   | L_Real r -> Q.pp_print f r
   | L_BitVector bv -> pp_print_string f (Bitvector.to_string_hexa bv)
   | L_String s -> pp_print_string f s
-  | L_Label (l, _) -> pp_print_string f l
+  | L_Label l -> pp_print_string f l
 
 let rec pp_native_value f =
   let open Format in
@@ -93,10 +93,7 @@ module NativeBackend (C : Config) = struct
     | NV_Literal (L_Int z) -> Some (Z.to_int z)
     | _ -> None
 
-  let v_to_label = function
-    | NV_Literal (L_Label (l, _)) -> l
-    | _ -> assert false
-
+  let v_to_label = function NV_Literal (L_Label l) -> l | _ -> assert false
   let bind (vm : 'a m) (f : 'a -> 'b m) : 'b m = f vm
   let prod_par (r1 : 'a m) (r2 : 'b m) : ('a * 'b) m = (r1, r2)
   let return v = v

--- a/asllib/Operations.ml
+++ b/asllib/Operations.ml
@@ -99,8 +99,8 @@ let binop_values pos t op v1 v2 =
   | EQ_OP, L_String s1, L_String s2 -> L_Bool (String.equal s1 s2)
   | NEQ, L_String s1, L_String s2 -> L_Bool (not (String.equal s1 s2))
   (* enum -> enum -> bool *)
-  | EQ_OP, L_Label (s1, _), L_Label (s2, _) -> L_Bool (String.equal s1 s2)
-  | NEQ, L_Label (s1, _), L_Label (s2, _) -> L_Bool (not (String.equal s1 s2))
+  | EQ_OP, L_Label s1, L_Label s2 -> L_Bool (String.equal s1 s2)
+  | NEQ, L_Label s1, L_Label s2 -> L_Bool (not (String.equal s1 s2))
   (* Failure *)
   | _ -> fatal_from pos (Error.UnsupportedBinop (t, op, v1, v2))
 

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -110,7 +110,7 @@ let pp_literal f = function
       fprintf f "(%a.0 / %a.0)" Z.pp_print (Q.num r) Z.pp_print (Q.den r)
   | L_BitVector bv -> Bitvector.pp_t f bv
   | L_String s -> fprintf f "%S" s
-  | L_Label (l, _) -> fprintf f "%s" l
+  | L_Label l -> fprintf f "%s" l
 
 let rec pp_expr f e =
   match e.desc with

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -123,6 +123,8 @@ let rec pp_expr =
         bprintf f "E_Cond (%a, %a, %a)" pp_expr e1 pp_expr e2 pp_expr e3
     | E_GetArray (e1, e2) ->
         bprintf f "E_GetArray (%a, %a)" pp_expr e1 pp_expr e2
+    | E_GetEnumArray (e1, e2) ->
+        bprintf f "E_GetEnumArray (%a, %a)" pp_expr e1 pp_expr e2
     | E_GetField (e, x) -> bprintf f "E_GetField (%a, %S)" pp_expr e x
     | E_GetFields (e, x) ->
         bprintf f "E_GetFields (%a, %a)" pp_expr e (pp_list pp_string) x
@@ -135,6 +137,9 @@ let rec pp_expr =
     | E_Array { length; value } ->
         bprintf f "E_Array { length=(%a); value=(%a) }" pp_expr length pp_expr
           value
+    | E_EnumArray { labels; value } ->
+        bprintf f "E_EnumArray { labels=(%a); value=(%a) }" (pp_list pp_string)
+          labels pp_expr value
     | E_Arbitrary ty -> bprintf f "E_Arbitrary (%a)" pp_ty ty
     | E_Pattern (e, p) -> bprintf f "E_Pattern (%a, %a)" pp_expr e pp_pattern p
   in
@@ -200,7 +205,8 @@ and pp_ty =
 
 and pp_array_length f = function
   | ArrayLength_Expr e -> bprintf f "ArrayLength_Expr (%a)" pp_expr e
-  | ArrayLength_Enum (s, i) -> bprintf f "ArrayLength_Enum (%S, %i)" s i
+  | ArrayLength_Enum (enum, labels) ->
+      bprintf f "ArrayLength_Enum (%s, %a)" enum (pp_list pp_string) labels
 
 and pp_bitfield f = function
   | BitField_Simple (name, slices) ->
@@ -233,6 +239,8 @@ let rec pp_lexpr =
         bprintf f "LE_Slice (%a, %a)" pp_lexpr le pp_slice_list args
     | LE_SetArray (le, e) ->
         bprintf f "LE_SetArray (%a, %a)" pp_lexpr le pp_expr e
+    | LE_SetEnumArray (le, e) ->
+        bprintf f "LE_SetEnumArray (%a, %a)" pp_lexpr le pp_expr e
     | LE_SetField (le, x) -> bprintf f "LE_SetField (%a, %S)" pp_lexpr le x
     | LE_SetFields (le, x, _) ->
         bprintf f "LE_SetFields (%a, %a)" pp_lexpr le (pp_list pp_string) x

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -94,7 +94,7 @@ let pp_literal f = function
   | L_BitVector bv ->
       bprintf f "L_BitVector (Bitvector.of_string %S)" (Bitvector.to_string bv)
   | L_String s -> bprintf f "L_String %S" s
-  | L_Label (s, d) -> bprintf f "L_Label (%S, %d)" s d
+  | L_Label s -> bprintf f "L_Label %S" s
 
 let subprogram_type_to_string = function
   | ST_Function -> "ST_Function"

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -137,9 +137,9 @@ let rec pp_expr =
     | E_Array { length; value } ->
         bprintf f "E_Array { length=(%a); value=(%a) }" pp_expr length pp_expr
           value
-    | E_EnumArray { labels; value } ->
-        bprintf f "E_EnumArray { labels=(%a); value=(%a) }" (pp_list pp_string)
-          labels pp_expr value
+    | E_EnumArray { enum; labels; value } ->
+        bprintf f "E_EnumArray { enum=%S; labels=(%a); value=(%a) }" enum
+          (pp_list pp_string) labels pp_expr value
     | E_Arbitrary ty -> bprintf f "E_Arbitrary (%a)" pp_ty ty
     | E_Pattern (e, p) -> bprintf f "E_Pattern (%a, %a)" pp_expr e pp_pattern p
   in

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -117,7 +117,7 @@ let annotate_literal env = function
   | L_Real _ -> T_Real
   | L_String _ -> T_String
   | L_BitVector bv -> Bitvector.length bv |> expr_of_int |> t_bits_bitwidth
-  | L_Label (label, _) -> (
+  | L_Label label -> (
       try IMap.find label env.global.declared_types |> fst |> desc
       with Not_found -> assert false)
 (* End *)
@@ -3593,10 +3593,10 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       match t2.desc with
       | T_Enum ids ->
           let t = T_Named name |> here in
-          let declare_one i env2 label =
-            declare_const ~loc label t (L_Label (label, i)) env2
+          let declare_one env2 label =
+            declare_const ~loc label t (L_Label label) env2
           in
-          let genv3 = list_fold_lefti declare_one env2.global ids in
+          let genv3 = List.fold_left declare_one env2.global ids in
           { env2 with global = genv3 }
       | _ -> env2
     in

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -117,8 +117,8 @@ let annotate_literal env = function
   | L_Real _ -> T_Real
   | L_String _ -> T_String
   | L_BitVector bv -> Bitvector.length bv |> expr_of_int |> t_bits_bitwidth
-  | L_Label (l, _) -> (
-      try IMap.find l env.global.storage_types |> fst |> desc
+  | L_Label (label, _) -> (
+      try IMap.find label env.global.declared_types |> fst |> desc
       with Not_found -> assert false)
 (* End *)
 
@@ -748,7 +748,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         match IMap.find_opt x env.global.declared_types with
         | Some (t, _) -> (
             match (Types.make_anonymous env t).desc with
-            | T_Enum li -> Some (x, List.length li)
+            | T_Enum labels -> Some (x, labels)
             | _ -> None)
         | None -> None)
     | _ -> None
@@ -1201,7 +1201,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           match index with
           | ArrayLength_Expr e -> (
               match get_variable_enum' env e with
-              | Some (s, i) -> (ArrayLength_Enum (s, i), SES.empty)
+              | Some (s, labels) -> (ArrayLength_Enum (s, labels), SES.empty)
               | None ->
                   let e', ses = annotate_static_integer ~loc env e in
                   (ArrayLength_Expr e', ses))
@@ -2154,7 +2154,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         | _ -> conflict ~loc [ default_array_ty ] t_base |: TypingRule.EGetArray
         )
     (* End *)
-    | E_GetItem _ -> assert false
+    | E_GetItem _ | E_EnumArray _ | E_GetEnumArray _ -> assert false
 
   (* Begin AnnotateGetArray *)
   and annotate_get_array ~loc env (size, t_elem) (e_base, ses_base, e_index) =
@@ -2162,8 +2162,12 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     let wanted_t_index = type_of_array_length ~loc size in
     let+ () = check_type_satisfies ~loc env t_index' wanted_t_index in
     let ses = ses_non_conflicting_union ~loc ses_index ses_base in
-    (t_elem, E_GetArray (e_base, e_index') |> add_pos_from ~loc, ses)
-    |: TypingRule.AnnotateGetArray
+    let new_e =
+      match size with
+      | ArrayLength_Enum _ -> E_GetEnumArray (e_base, e_index')
+      | ArrayLength_Expr _ -> E_GetArray (e_base, e_index')
+    in
+    (t_elem, new_e |> add_pos_from ~loc, ses) |: TypingRule.AnnotateGetArray
   (* End *)
 
   (** For an expression of the form [e1.[f1,...,fn]], if [e1] represents a call
@@ -2257,14 +2261,12 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     | T_Tuple li ->
         let exprs = List.map (base_value_v1 ~loc env) li in
         E_Tuple exprs |> here
-    | T_Array (length, ty) ->
+    | T_Array (index, ty) -> (
         let value = base_value_v1 ~loc env ty in
-        let length =
-          match length with
-          | ArrayLength_Enum (_, i) -> expr_of_int i
-          | ArrayLength_Expr e -> e
-        in
-        E_Array { length; value } |> here
+        match index with
+        | ArrayLength_Enum (enum, labels) ->
+            E_EnumArray { enum; labels; value } |> here
+        | ArrayLength_Expr length -> E_Array { length; value } |> here)
   (* End *)
 
   let rec base_value_v0 ~loc env t : expr =
@@ -2299,14 +2301,12 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             fields
         in
         E_Record (t, fields) |> here
-    | T_Array (length, ty) ->
+    | T_Array (length, ty) -> (
         let value = base_value_v0 ~loc env ty in
-        let length =
-          match length with
-          | ArrayLength_Enum (_, i) -> expr_of_int i
-          | ArrayLength_Expr e -> e
-        in
-        E_Array { length; value } |> here
+        match length with
+        | ArrayLength_Enum (enum, labels) ->
+            E_EnumArray { enum; labels; value } |> here
+        | ArrayLength_Expr length -> E_Array { length; value } |> here)
     | T_Named _id ->
         let t = Types.make_anonymous env t in
         base_value_v0 ~loc env t
@@ -2327,8 +2327,12 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     let wanted_t_index = type_of_array_length ~loc:e_base size in
     let+ () = check_type_satisfies ~loc env t_index' wanted_t_index in
     let ses = ses_non_conflicting_union ~loc ses_base ses_index in
-    (LE_SetArray (e_base, e_index') |> add_pos_from ~loc, ses)
-    |: TypingRule.AnnotateSetArray
+    let new_le =
+      match size with
+      | ArrayLength_Enum _ -> LE_SetEnumArray (e_base, e_index')
+      | ArrayLength_Expr _ -> LE_SetArray (e_base, e_index')
+    in
+    (new_le |> add_pos_from ~loc, ses) |: TypingRule.AnnotateSetArray
   (* End *)
 
   let rec annotate_lexpr env le t_e =
@@ -2496,7 +2500,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
               (e_base', ses_base, e_index)
         | _ -> conflict ~loc [ default_array_ty ] t_base)
     (* End *)
-    | LE_SetFields (_, _, _ :: _) -> assert false
+    | LE_SetFields (_, _, _ :: _) | LE_SetEnumArray _ -> assert false
 
   (* Begin CheckCanBeInitializedWith *)
   let can_be_initialized_with env s t =
@@ -3145,7 +3149,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           let ses = SES.union ses_call ses_e in
           Some (S_Call call |> here, ses)
         else None
-    | LE_SetArray _ -> assert false
+    | LE_SetArray _ | LE_SetEnumArray _ -> assert false
 
   (** [func_sig_types f] returns a list of the types in the signature [f].
       The return type is first, followed by the argument types in order. *)
@@ -3589,8 +3593,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       match t2.desc with
       | T_Enum ids ->
           let t = T_Named name |> here in
-          let declare_one i env2 x =
-            declare_const ~loc x t (L_Label (x, i)) env2
+          let declare_one i env2 label =
+            declare_const ~loc label t (L_Label (label, i)) env2
           in
           let genv3 = list_fold_lefti declare_one env2.global ids in
           { env2 with global = genv3 }

--- a/asllib/backend.mli
+++ b/asllib/backend.mli
@@ -61,6 +61,10 @@ module type S = sig
   (** [v_to_int v] returns, if possible, an integer corresponding to the value.
       Should be called only on values of type integer. *)
 
+  val v_to_label : value -> string
+  (** [v_to_label v] returns the identifier of the label nested in the literal inside [v].
+      Should be called only on values of type [NV_Literal] where the literal is of type [L_Label]. *)
+
   (* Monadic operators *)
   (*-------------------*)
 
@@ -89,8 +93,8 @@ module type S = sig
   (** Monadic product operation, two monads are combined "in parallel".*)
 
   val appl_data : 'a m -> ('a -> 'b) -> 'b m
-  (** Applicative map. 
-  
+  (** Applicative map.
+
       Creates a data dependency between the output events and
       the input events of the argument in the resulting monad. *)
 

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -386,26 +386,27 @@ We use the following rule notation, where $P_{1..k}$ are the rule premises and $
 For example, the rule TypingRule.ELit has one premise:
 \begin{mathpar}
 \inferrule{
-  \textsf{annotate\_literal}(\vv) \typearrow \vt
+  \annotateliteral{\vv} \typearrow \vt
 }{
-  \texttt{annotate\_expr}(\tenv, \ELiteral(\vv)) \typearrow (\vt, \ELiteral(\vv))
+  \annotateexpr{\tenv, \ELiteral(\vv)} \typearrow (\vt, \ELiteral(\vv))
 }
 \end{mathpar}
 
-and the rule TypingRule.Binop (somewhat simplified here) has three premises:
+and the rule \nameref{sec:TypingRule.Binop} (somewhat simplified here) has three premises:
 \begin{mathpar}
-  \inferrule{
-    \texttt{annotate\_expr}(\tenv, \veone) \typearrow (\vtone, \veone') \\\\
-    \texttt{annotate\_expr}(\tenv, \vetwo) \typearrow (\vttwo, \vetwo') \\\\
-    \texttt{check\_binop}(\tenv, \op, \vtone, \vttwo) \typearrow \vt
-    }
-  {\texttt{annotate\_expr}(\tenv, \EBinop(\op, \veone, \vetwo)) \typearrow (\vt, \EBinop(\op, \veone', \vetwo'))}
+\inferrule{
+  \annotateexpr{\tenv, \veone} \typearrow (\vtone, \veone') \\\\
+  \annotateexpr{\tenv, \vetwo} \typearrow (\vttwo, \vetwo') \\\\
+  \applybinoptypes(\tenv, \op, \vtone, \vttwo) \typearrow \vt
+}{
+  \annotateexpr{\tenv, \EBinop(\op, \veone, \vetwo)} \typearrow (\vt, \EBinop(\op, \veone', \vetwo'))
+}
 \end{mathpar}
 
 The free variables appearing in the premises and conclusion are interpreted \underline{universally}.
 That is, the rules apply to any values (of the appropriate types) assigned to their free variables.
 %
-For example, the rule TypingRule.Binop applies to any choice of values for the free variables
+For example, the rule \nameref{sec:TypingRule.Binop} applies to any choice of values for the free variables
 $\tenv$ (a static environment),
 $\veone$, $\vetwo$, $\veone'$, $\vetwo'$ (expressions),
 $\vt$, $\vtone$, and $\vttwo$ (types).
@@ -415,14 +416,15 @@ Assertions can be \emph{grounded} by substituting their free variables with valu
 A \emph{ground rule} is a rule with all its assertions (premises and conclusion) grounded.
 \end{definition}
 For example,
-the following is a grounding of TypingRule.Binop
+the following is a grounding of \nameref{sec:TypingRule.Binop}
 \begin{mathpar}
-  \inferrule{
-    \texttt{annotate\_expr}(\emptytenv, \ELiteral(\lint(2))) \typearrow (\TInt, \ELiteral(\lint(2))) \\\\
-    \texttt{annotate\_expr}(\emptytenv, \ELiteral(\lint(3))) \typearrow (\TInt, \ELiteral(\lint(3))) \\\\
-    \texttt{check\_binop}(\emptytenv, \MUL, \TInt, \TInt) \typearrow \TInt
-    }
-  {\texttt{annotate\_expr}(\emptytenv, \EBinop(\MUL, \ELiteral(\lint(2)), \ELiteral(\lint(3)))) \typearrow \\ (\TInt, \EBinop(\MUL, \ELiteral(\lint(2)), \ELiteral(\lint(3))))}
+\inferrule{
+  \annotateexpr{\emptytenv, \ELiteral(\lint(2))} \typearrow (\TInt, \ELiteral(\lint(2))) \\\\
+  \annotateexpr{\emptytenv, \ELiteral(\lint(3))} \typearrow (\TInt, \ELiteral(\lint(3))) \\\\
+  \applybinoptypes(\emptytenv, \MUL, \TInt, \TInt) \typearrow \TInt
+}{
+  \annotateexpr{\emptytenv, \EBinop(\MUL, \ELiteral(\lint(2)), \ELiteral(\lint(3)))} \typearrow \\ (\TInt, \EBinop(\MUL, \ELiteral(\lint(2)), \ELiteral(\lint(3))))
+}
 \end{mathpar}
 obtained by the following substitutions:
 \begin{tabular}{ll}
@@ -447,15 +449,15 @@ An \emph{axiom} is a rule with an empty set of premises.
 An axiom is denoted by simply stating its conclusion.
 \end{definition}
 
-An example of an axiom in the ASL type system is TypingRule.SPass:
+An example of an axiom in the ASL type system is \nameref{sec:TypingRule.SPass}:
 \begin{mathpar}
-  \inferrule{}{\texttt{annotate\_stmt}(\tenv, \SPass) \typearrow (\SPass,\tenv)}
+\inferrule{}{\annotatestmt(\tenv, \SPass) \typearrow (\SPass,\tenv)}
 \end{mathpar}
 \hypertarget{SemanticsRule.PAll-example}{}
 An example of an axiom in the ASL semantics is SemanticsRule.PAll:
 \begin{mathpar}
 \inferrule{}{
-  \texttt{eval\_pattern}(\texttt{env}, \Ignore, \PatternAll) \evalarrow \textsf{Normal}(\texttt{Bool}(\True), \emptyset_{\textsf{g}})
+  \evalpattern{\env, \Ignore, \PatternAll} \evalarrow \Normal(\nvbool(\True), \emptygraph)
 }
 \end{mathpar}
 
@@ -471,9 +473,6 @@ the set of semantic rules, we must apply rules to form a \emph{derivation tree}.
   corresponding to the ground premises of the same rule.
 \end{definition}
 
-% TODO: point to the example in the semantics reference
-% when all references are joined into a single document.
-
 \subsection{Transitions\label{sec:transitions}}
 
 We use rules as a structured way for defining relations (and therefore functions, as a special case).
@@ -487,9 +486,9 @@ A set of rules $M$ with transition assertions defines the relation
     R = \{ (x,y) \;|\; x \rulearrow y \text{ can be derived from rules in } M\} \enspace.
 \]
 
-For example, the rule \hyperlink{TypingRule.ELit}{TypingRule.ELit} defines a relation
+For example, the rule \nameref{sec:TypingRule.ELit} defines a relation
 between the infinite set of elements of the form
-$\texttt{annotate\_expr}(\tenv, \ELiteral(\vv))$ (for the
+$\annotateexpr{\tenv, \ELiteral(\vv)}$ (for the
 infinite choice of values for the free variables $\tenv$ and
 $\vv$) to the infinite set of pairs of the form $(\vt,
 \ELiteral(\vv))$, such that the premise holds.
@@ -514,11 +513,11 @@ The domain of a configuration $C=L(\ldots)$, denoted $\configdomain{C}$, is the 
 We refer to configurations at the origin of a transition as \emph{input configurations} and to the
 configurations at the destination of a transition as \emph{output transitions}.
 
-For example, the conclusion of the rule TypingRule.ELit has \\
-$\texttt{annotate\_expr}(\tenv, \ELiteral(\vv))$ as its input configuration
+For example, the conclusion of the rule \nameref{sec:TypingRule.ELit} has \\
+$\annotateexpr{\tenv, \ELiteral(\vv)}$ as its input configuration
 and $(\vt, \ELiteral(\vv))$ as its output configuration.
 Further, \\
-$\configdomain{\texttt{annotate\_expr}(\tenv, \ELiteral(\vv))} = \texttt{annotate\_expr}$,
+$\configdomain{\annotateexpr{\tenv, \ELiteral(\vv)}} = \textit{annotate\_expr}$,
 while the output configuration does not have a configuration domain, since it is an unlabelled pair.
 
 Our rules always make use of labelled input configurations. This makes it easier to ensure

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -2395,6 +2395,8 @@
 \newcommand\vezero[0]{\texttt{e0}}
 \newcommand\veone[0]{\texttt{e1}}
 \newcommand\venum[0]{\texttt{enum}}
+\newcommand\venumone[0]{\texttt{enum1}}
+\newcommand\venumtwo[0]{\texttt{enum2}}
 \newcommand\veoneopt[0]{\texttt{e1\_opt}}
 \newcommand\vetwoopt[0]{\texttt{e2\_opt}}
 \newcommand\vzoneopt[0]{\texttt{z1\_opt}}
@@ -2431,6 +2433,7 @@
 \newcommand\vfsthree[0]{\texttt{fs3}}
 \newcommand\vfactor[0]{\texttt{v\_factor}}
 \newcommand\vfield[0]{\texttt{field}}
+\newcommand\vfieldinits[0]{\texttt{field\_inits}}
 \newcommand\vfieldassignasts[0]{\texttt{field\_assign\_asts}}
 \newcommand\vfieldassigns[0]{\texttt{field\_assigns}}
 \newcommand\vfieldasts[0]{\texttt{field\_asts}}
@@ -2490,6 +2493,8 @@
 \newcommand\vl[0]{\texttt{l}}
 \newcommand\vlabel[0]{\texttt{label}}
 \newcommand\vlabels[0]{\texttt{labels}}
+\newcommand\vlabelsone[0]{\texttt{labels1}}
+\newcommand\vlabelstwo[0]{\texttt{labels2}}
 \newcommand\vlastindex[0]{\texttt{last\_index}}
 \newcommand\vle[0]{\texttt{le}}
 \newcommand\vlelist[0]{\texttt{le\_list}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -624,11 +624,13 @@
 \newcommand\ESlice[0]{\hyperlink{ast-eslice}{\textsf{E\_Slice}}}
 \newcommand\ECond[0]{\hyperlink{ast-econd}{\textsf{E\_Cond}}}
 \newcommand\EGetArray[0]{\hyperlink{ast-egetarray}{\textsf{E\_GetArray}}}
+\newcommand\EGetEnumArray[0]{\hyperlink{ast-egetenumarray}{\textsf{E\_GetEnumArray}}}
 \newcommand\EGetField[0]{\hyperlink{ast-egetfield}{\textsf{E\_GetField}}}
 \newcommand\EGetItem[0]{\hyperlink{ast-egetitem}{\textsf{E\_GetItem}}}
 \newcommand\EGetFields[0]{\hyperlink{ast-getfields}{\textsf{E\_GetFields}}}
 \newcommand\ERecord[0]{\hyperlink{ast-erecord}{\textsf{E\_Record}}}
 \newcommand\EArray[0]{\hyperlink{ast-earray}{\textsf{E\_Array}}}
+\newcommand\EEnumArray[0]{\hyperlink{ast-eenumarray}{\textsf{E\_EnumArray}}}
 \newcommand\ETuple[0]{\hyperlink{ast-etuple}{\textsf{E\_Tuple}}}
 \newcommand\EArbitrary[0]{\hyperlink{ast-earbitrary}{\textsf{E\_Arbitrary}}}
 \newcommand\EPattern[0]{\hyperlink{ast-epattern}{\textsf{E\_Pattern}}}
@@ -638,6 +640,7 @@
 \newcommand\LEVar[0]{\hyperlink{ast-levar}{\textsf{LE\_Var}}}
 \newcommand\LESlice{\hyperlink{ast-leslice}{\textsf{LE\_Slice}}}
 \newcommand\LESetArray[0]{\hyperlink{ast-lesetarray}{\textsf{LE\_SetArray}}}
+\newcommand\LESetEnumArray[0]{\hyperlink{ast-lesetenumarray}{\textsf{LE\_SetEnumArray}}}
 \newcommand\LESetField[0]{\hyperlink{ast-lesetfield}{\textsf{LE\_SetField}}}
 \newcommand\LESetFields[0]{\hyperlink{ast-lesetfields}{\textsf{LE\_SetFields}}}
 \newcommand\LEDestructuring[0]{\hyperlink{ast-ledestructuring}{\textsf{LE\_Destructuring}}}
@@ -927,6 +930,7 @@
 \newcommand\Forbody[0]{\text{body}}
 \newcommand\Forlimit[0]{\text{limit}}
 \newcommand\EArrayLength[0]{\text{length}}
+\newcommand\EArrayLabels[0]{\text{labels}}
 \newcommand\EArrayValue[0]{\text{value}}
 \newcommand\callname[0]{\text{name}}
 \newcommand\callparams[0]{\text{params}}
@@ -989,6 +993,7 @@
 \newcommand\nvbool[0]{\hyperlink{def-nvbool}{\texttt{Bool}}}
 \newcommand\nvreal[0]{\hyperlink{nv-real}{\texttt{Real}}}
 \newcommand\nvstring[0]{\hyperlink{def-nvstring}{\texttt{String}}}
+\newcommand\nvlabel[0]{\hyperlink{def-nvlabel}{\texttt{Label}}}
 \newcommand\nvbitvector[0]{\hyperlink{def-nvbitvector}{\texttt{Bitvector}}}
 \newcommand\tint[0]{\hyperlink{def-tint}{\mathcal{Z}}}
 \newcommand\tbool[0]{\hyperlink{def-tbool}{\mathcal{B}}}
@@ -997,6 +1002,7 @@
 \newcommand\tbitvector[0]{\hyperlink{def-tbitvector}{\mathcal{B}\mathcal{V}}}
 \newcommand\tvector[0]{\hyperlink{def-tvector}{\mathcal{V}\mathcal{E}\mathcal{C}}}
 \newcommand\trecord[0]{\hyperlink{def-trecord}{\mathcal{R}\mathcal{E}\mathcal{C}}}
+\newcommand\tlabel[0]{\hyperlink{def-tlabel}{\mathcal{L}\mathcal{A}\mathcal{B}\mathcal{E}\mathcal{L}}}
 
 \newcommand\evalrel[0]{\hyperlink{def-evalrel}{\textsf{eval}}}
 \newcommand\evalarrow[0]{\xrightarrow{\evalrel}}
@@ -1951,6 +1957,7 @@
 \newcommand\ety[0]{\texttt{e\_ty}}
 \newcommand\etuple[0]{\texttt{e\_tuple}}
 \newcommand\evalue[0]{\texttt{e\_value}}
+\newcommand\ekey[0]{\texttt{e\_key}}
 \newcommand\ewidth[0]{\texttt{e\_width}}
 \newcommand\ewidthone[0]{\texttt{e\_width1}}
 \newcommand\ewidthp[0]{\texttt{e\_width'}}
@@ -2100,6 +2107,8 @@
 \newcommand\newldis[0]{\texttt{new\_ldis'}}
 \newcommand\newle[0]{\texttt{new\_le}}
 \newcommand\newli[0]{\texttt{new\_li}}
+\newcommand\newleint[0]{\texttt{new\_le\_int}}
+\newcommand\newleenum[0]{\texttt{new\_le\_enum}}
 \newcommand\newlocalstoragetypes[0]{\texttt{new\_local\_storagetypes}}
 \newcommand\newmbv[0]{\texttt{new\_m\_bv}}
 \newcommand\newname[0]{\texttt{new\_name}}
@@ -2385,6 +2394,7 @@
 \newcommand\vendv[0]{\texttt{end\_v}}
 \newcommand\vezero[0]{\texttt{e0}}
 \newcommand\veone[0]{\texttt{e1}}
+\newcommand\venum[0]{\texttt{enum}}
 \newcommand\veoneopt[0]{\texttt{e1\_opt}}
 \newcommand\vetwoopt[0]{\texttt{e2\_opt}}
 \newcommand\vzoneopt[0]{\texttt{z1\_opt}}
@@ -2478,6 +2488,7 @@
 \newcommand\vk[0]{\texttt{k}}
 \newcommand\vkeyword[0]{\texttt{keyword}}
 \newcommand\vl[0]{\texttt{l}}
+\newcommand\vlabel[0]{\texttt{label}}
 \newcommand\vlabels[0]{\texttt{labels}}
 \newcommand\vlastindex[0]{\texttt{last\_index}}
 \newcommand\vle[0]{\texttt{le}}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -572,7 +572,7 @@ The rules for expressions have the following extra derivation rules:
              |\ & \LESetEnumArray(\overtext{\lexpr}{base}, \overtext{\expr}{index}) &\\
 \end{flalign*}
 
-Their use is as follows:
+The intention for each AST node type above is as follows:
 \begin{itemize}
 \item $\EArray\{\EArrayLength: \veone, \EArrayValue: \vetwo\}$ is used to construct an integer-indexed array value
 in order to initialize an array-typed variable;

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -127,9 +127,9 @@ integers, Booleans, real numbers, bitvectors, and strings.
  & \hypertarget{ast-lstring}{}
 \\
  |\ & \lstring(\overname{S}{S \in \{C \;|\; \texttt{"$C$"}\ \in\ \Strings\}}) &
-\\
- |\ & \llabel(\overname{l}{\identifier}, \overname{n}{\N})
- & \hypertarget{ast-llabel}{}
+ \hypertarget{ast-llabel}{} \\
+ |\ & \llabel(\overname{l}{\identifier})
+ & \\
 \end{flalign*}
 
 \subsection{Basic Operations\label{sec:BasicOperations}}
@@ -369,17 +369,6 @@ The type of array indices is given by the following AST type:
 \arrayindex \derives\ &  \ArrayLengthExpr(\overtext{\expr}{array length}) &
 \end{flalign*}
 
-% \[
-%   \begin{array}{rcl}
-%     & & \ASTComment{The type of indexes for an array.}  \\
-%     \hline
-%     \arrayindex & \derives
-%       & \ArrayLengthExpr(\overtext{\expr}{array length})
-%       \hypertarget{ast-arraylengthenum}{}\\
-%     &|& \ArrayLengthEnum(\overtext{\identifier}{name of enumeration}, \overtext{\Z}{length}) \\
-%   \end{array}
-% \]
-
 \subsection{Fields and Typed Identifiers \label{sec:FieldsAndTypedIdentifiers}}
 
 The following rule corresponds to a field of a record-like structure:
@@ -574,14 +563,26 @@ Declaration keyword for global storage elements:
 The derivation rules for the typed abstract syntax are the same as the rules for the untyped abstract syntax,
 except for the following differences.
 
-The rules for expressions have the following extra derivation rule:
+The rules for expressions have the following extra derivation rules:
 \hypertarget{ast-earray}{}
 \begin{flalign*}
-\expr \derives\ & \EArray \{\EArrayLength: \expr, \EArrayValue: \expr\} &
+\expr \derives\ & \EArray \{\EArrayLength: \expr, \EArrayValue: \expr\} & \hypertarget{ast-eenumarray}{}\\
+             |\ & \EEnumArray \{\EArrayLabels: \identifier^+, \EArrayValue: \expr\} & \hypertarget{ast-egetenumarray}{}\\
+             |\ & \EGetEnumArray(\overtext{\expr}{base}, \overtext{\expr}{key}) & \hypertarget{ast-esetenumarray}{}\\
+             |\ & \LESetEnumArray(\overtext{\lexpr}{base}, \overtext{\expr}{value}) &\\
 \end{flalign*}
 
-$\EArray\{\EArrayLength: \veone, \EArrayValue: \vetwo\}$ is used to construct an array value
-in order to initialize an array-typed variable.
+Their use is as follows:
+\begin{itemize}
+\item $\EArray\{\EArrayLength: \veone, \EArrayValue: \vetwo\}$ is used to construct an integer-indexed array value
+in order to initialize an array-typed variable;
+\item $\EEnumArray\{\EArrayLabels: \vl_{1..k}, \EArrayValue: \vetwo\}$ is used to construct an enumeration-indexed
+array value in order to initialize an array-typed variable;
+\item $\EGetEnumArray(\ebase, \ekey)$ is used for accessing an enumerated array given by $\ebase$ at the entry
+      given by $\ekey$;
+\item $\LESetEnumArray(\ebase, \evalue)$ is used for updating an enumerated array left-hand-side expression given
+      by $\ebase$ with the value given by $\evalue$;
+\end{itemize}
 
 The rules for statements exclude \texttt{case} statements, since those are transformed into
 conditional statements (see \nameref{sec:TypingRule.DesugarCaseStmt}).
@@ -605,14 +606,14 @@ for \SliceLength.
 The following extra rule enables expressing array indices based on enumeration:
 \hypertarget{ast-arraylengthenum}{}
 \begin{flalign*}
-\arrayindex \derives\ &  \ArrayLengthEnum(\overtext{\identifier}{name of enumeration}, \overtext{\Z}{length}) &
+\arrayindex \derives\ &  \ArrayLengthEnum(\overtext{\identifier}{name of enumeration}, \overtext{\identifier^+}{enumeration labels}) &
 \end{flalign*}
 
 In the \untypedast, the $\globaldecl$ child node in the abstract syntax nodes of the form $\DGlobalStorage(\globaldecl)$
 contains an optional expression field assigned to the $\GDinitialvalue$ field. In the \typedast, this field
 always contains an expression (that is, it is never $\None$).
 
-Global pragma declarations $\DPragma$ are removed from the \untypedast once their expressions have been type checked and do not appear in the \typedast.
+Global pragma declarations $\DPragma$ are removed from the \untypedast\ once their expressions have been type checked and do not appear in the \typedast.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Building Abstract Syntax Trees\label{sec:BuildingAbstractSyntaxTrees}}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -569,7 +569,7 @@ The rules for expressions have the following extra derivation rules:
 \expr \derives\ & \EArray \{\EArrayLength: \expr, \EArrayValue: \expr\} & \hypertarget{ast-eenumarray}{}\\
              |\ & \EEnumArray \{\EArrayLabels: \identifier^+, \EArrayValue: \expr\} & \hypertarget{ast-egetenumarray}{}\\
              |\ & \EGetEnumArray(\overtext{\expr}{base}, \overtext{\expr}{key}) & \hypertarget{ast-esetenumarray}{}\\
-             |\ & \LESetEnumArray(\overtext{\lexpr}{base}, \overtext{\expr}{value}) &\\
+             |\ & \LESetEnumArray(\overtext{\lexpr}{base}, \overtext{\expr}{index}) &\\
 \end{flalign*}
 
 Their use is as follows:
@@ -867,6 +867,7 @@ which is utilized both for the type system and semantics:
   \torexpr(\LEVar(\vx)) &=& \EVar(\vx)\\
   \torexpr(\LESlice(\vle, \vargs)) &=& \ESlice(\torexpr(\vle), \vargs)\\
   \torexpr(\LESetArray(\vle, \ve)) &=& \EGetArray(\torexpr(\vle), \ve)\\
+  \torexpr(\LESetEnumArray(\vle, \ve)) &=& \EGetEnumArray(\torexpr(\vle), \ve)\\
   \torexpr(\LESetField(\vle, \vx)) &=& \EGetField(\torexpr(\vle), \vx)\\
   \torexpr(\LESetFields(\vle, \vx)) &=& \EGetFields(\torexpr(\vle), \vx)\\
   \torexpr(\LEDiscard) &=& \EVar(\texttt{-})\\

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -820,7 +820,7 @@ All of the following apply:
         $\True$\ProseOrTypeError;
   \item \Prosenonconflictingunion{$\vsesbase$ and $\vsesindex$}{$\vses$};
   \item \Proseeqdef{$\newle$}{
-    an integer-based array update for $\ebasep$ at index $\eindexp$, that is, \\ $\LESetArray(\ebasep, \eindexp)$,
+    an integer-based array update for $\ebasep$ at index $\eindexp$, that is, $\LESetArray(\ebasep, \eindexp)$,
     if $\size$ is an integer-typed array index, and
     an enumeration-based array update for $\ebasep$ at index $\eindexp$, that is, \\ $\LESetEnumArray(\ebasep, \eindexp)$,
     if $\size$ is an enumeration-typed array index.
@@ -919,9 +919,9 @@ All of the following apply:
   \item evaluating the right-hand-side expression corresponding to $\rearray$ in $\env$
   is \Normal(\rmarray, \envone)\ProseOrAbnormal;
   \item evaluating $\eindex$ in $\envone$ is \Normal(\mindex, \envtwo)\ProseOrAbnormal;
-  \item $\mindex$ consists of the native label $\vindex$ and the execution graph $\vgone$;
+  \item $\mindex$ consists of the native value $\vindex$ and the execution graph $\vgone$;
   \item $\vindex$ is the native label for $\vl$;
-  \item $\rmarray$ consists of the native vector $\rvarray$ and the execution graph $\vgtwo$;
+  \item $\rmarray$ consists of the native value $\rvarray$ and the execution graph $\vgtwo$;
   \item setting the value $\vv$ of field $\vl$ of $\rvarray$ is the native record $\vvone$;
   \item $\vmone$ is the pair consisting of $\vvone$ and the parallel composition of $\vgone$ and $\vgtwo$;
   \item the steps so far computed the updated array, but have not assigned it to the variable

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -734,7 +734,7 @@ which is when the \textsc{empty} axiom case is used.
 
 \section{Array Assignment Expressions\label{sec:ArrayAssignmentExpressions}}
 This section details the syntax, abstract syntax, semantics, and typing of array write expressions.
-In the untyped AST, a write to either an integer-indexed array or an enumeration-indexed arrays is represented
+In the untyped AST, a write to either an integer-indexed array or an enumeration-indexed array is represented
 the same way. They type system infers the kind of array and outputs a typed AST node differentiating
 the two kinds of arrays, either a $\LESetArray$ or a $\LESetEnumArray$, via \nameref{sec:TypingRule.LESetArray}.
 The semantics utilizes a rule matching the corresponding type of array ---

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -733,9 +733,18 @@ until both lists become empty
 which is when the \textsc{empty} axiom case is used.
 
 \section{Array Assignment Expressions\label{sec:ArrayAssignmentExpressions}}
+This section details the syntax, abstract syntax, semantics, and typing of array write expressions.
+In the untyped AST, a write to either an integer-indexed array or an enumeration-indexed arrays is represented
+the same way. They type system infers the kind of array and outputs a typed AST node differentiating
+the two kinds of arrays, either a $\LESetArray$ or a $\LESetEnumArray$, via \nameref{sec:TypingRule.LESetArray}.
+The semantics utilizes a rule matching the corresponding type of array ---
+\nameref{sec:SemanticsRule.LESetArray} for integer-indexed arrays and
+\nameref{sec:SemanticsRule.LESetEnumArray} for enumeration-indexed arrays.
+
 \subsection{Abstract Syntax}
 \begin{flalign*}
-\lexpr \derives\ & \LESetArray(\lexpr, \expr) &
+\lexpr \derives\ & \LESetArray(\lexpr, \expr) &\\
+|\ & \LESetEnumArray(\overtext{\lexpr}{base}, \overtext{\expr}{index}) &\\
 \end{flalign*}
 
 \subsection{Typing}
@@ -901,6 +910,42 @@ getter invocation
 
 We note that the index is guaranteed by the type-checker to be within the array bounds
 via \secref{TypingRule.LESetArray}.
+
+\subsubsection{SemanticsRule.LESetEnumArray\label{sec:SemanticsRule.LESetEnumArray}}
+\subsubsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\vle$ denotes an array update expression, $\LESetEnumArray(\rearray, \eindex)$;
+  \item evaluating the right-hand-side expression corresponding to $\rearray$ in $\env$
+  is \Normal(\rmarray, \envone)\ProseOrAbnormal;
+  \item evaluating $\eindex$ in $\envone$ is \Normal(\mindex, \envtwo)\ProseOrAbnormal;
+  \item $\mindex$ consists of the native label $\vindex$ and the execution graph $\vgone$;
+  \item $\vindex$ is the native label for $\vl$;
+  \item $\rmarray$ consists of the native vector $\rvarray$ and the execution graph $\vgtwo$;
+  \item setting the value $\vv$ of field $\vl$ of $\rvarray$ is the native record $\vvone$;
+  \item $\vmone$ is the pair consisting of $\vvone$ and the parallel composition of $\vgone$ and $\vgtwo$;
+  \item the steps so far computed the updated array, but have not assigned it to the variable
+  bound to the array given by $\rearray$, which is achieved next.
+  Evaluating the left-hand-side expression $\rearray$ in an environment $\envtwo$ with $\vmone$
+  is the output configuration $C$.
+\end{itemize}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \evalexpr{\env, \torexpr(\rearray)} \evalarrow \Normal(\rmarray, \envone) \OrAbnormal\\
+  \evalexpr{\envone, \eindex} \evalarrow \Normal(\mindex, \envtwo) \OrAbnormal\\
+  \mindex \eqname (\vindex, \vgone)\\
+  \vindex \eqname \nvlabel(\vl)\\
+  \rmarray \eqname (\rvarray, \vgtwo)\\
+  \setfield(\vl, \vv, \rvarray) \evalarrow \vvone\\
+  \vmone \eqdef (\vvone, \vgone \parallelcomp \vgtwo)\\
+  \evallexpr{\envtwo, \rearray, \vmone} \evalarrow C
+}{
+  \evallexpr{\env, \LESetEnumArray(\rearray, \eindex), (\vv, \vg)} \evalarrow C
+}
+\end{mathpar}
+\CodeSubsection{\EvalLESetEnumArrayBegin}{\EvalLESetEnumArrayEnd}{../Interpreter.ml}
 
 \section{Bitvector Slice Assignment Expressions\label{sec:BitvectorSliceAssignmentExpressions}}
 \subsection{Abstract Syntax}

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -810,7 +810,12 @@ All of the following apply:
   \item determining whether $\tindexp$ \typesatisfies\ $\wantedtindex$ in $\tenv$ yields \\
         $\True$\ProseOrTypeError;
   \item \Prosenonconflictingunion{$\vsesbase$ and $\vsesindex$}{$\vses$};
-  \item \Proseeqdef{$\newle$}{array update for $\ebasep$ at index $\eindexp$, that is, \\ $\LESetArray(\ebasep, \eindexp)$}.
+  \item \Proseeqdef{$\newle$}{
+    an integer-based array update for $\ebasep$ at index $\eindexp$, that is, \\ $\LESetArray(\ebasep, \eindexp)$,
+    if $\size$ is an integer-typed array index, and
+    an enumeration-based array update for $\ebasep$ at index $\eindexp$, that is, \\ $\LESetEnumArray(\ebasep, \eindexp)$,
+    if $\size$ is an enumeration-typed array index.
+    }
 \end{itemize}
 
 \subsubsection{Formally}
@@ -821,7 +826,14 @@ All of the following apply:
   \typeofarraylength(\tenv, \size) \typearrow \wantedtindex\\
   \checktypesat(\tenv, \tindexp, \wantedtindex) \typearrow \True \OrTypeError\\\\
   \nonconflictingunion(\vsesbase, \vsesindex) \typearrow \vses \OrTypeError\\\\
-  \newle \eqdef \LESetArray(\ebasep, \eindexp)
+  \newleint \eqdef \LESetArray(\ebasep, \eindexp)\\
+  \newleenum \eqdef \LESetEnumArray(\ebasep, \eindexp)\\
+  {
+  \newle \eqdef \begin{cases}
+    \newleint & \text{if }\astlabel(\size) = \ArrayLengthExpr\\
+    \newleenum & \text{if }\astlabel(\size) = \ArrayLengthEnum\\
+  \end{cases}
+  }
 }{
   {
   \begin{array}{r}

--- a/asllib/doc/BaseValues.tex
+++ b/asllib/doc/BaseValues.tex
@@ -100,12 +100,11 @@ One of the following applies:
 
     \item All of the following apply (\textsc{t\_array\_enum}):
     \begin{itemize}
-        \item $\vt$ is the array type over an enumerated index of $\vi$ labels and element type $\tty$, that is,
-              $\TArray(\ArrayLengthEnum(\Ignore, \vi), \tty)$ ;
+        \item $\vt$ is the enumerated array type over for the enumeration $\venum$ and labels $\vlabels$ and element type $\tty$,
+              that is, $\TArray(\ArrayLengthEnum(\venum, \vlabels), \tty)$ ;
         \item applying $\basevalue$ to $\tty$ in $\tenv$ yields the expression $\vvalue$\ProseOrTypeError;
-        \item define $\vlength$ as the literal integer expression for $\vi$;
-        \item $\veinit$ is the array construction expression with length expression $\vlength$ and value expression $\vvalue$,
-              that is, $\EArray\{\EArrayLength: \length, \EArrayValue: \vvalue\}$.
+        \item $\veinit$ is the array construction expression for an enumerated array with labels $\vlabels$ and initial value $\vvalue$,
+              that is, $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \vvalue\}$.
     \end{itemize}
 
     \item All of the following apply (\textsc{t\_array\_expr}):
@@ -206,13 +205,12 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[t\_array\_enum]{
-    \basevalue(\tenv, \tty) \typearrow \vvalue \OrTypeError\\\\
-    \length \eqdef \elint{\vi}
+    \basevalue(\tenv, \tty) \typearrow \vvalue \OrTypeError
 }{
     {
         \begin{array}{r}
-            \basevalue(\tenv, \overname{\TArray(\ArrayLengthEnum(\Ignore, \vi), \tty)}{\vt}) \typearrow \\
-            \overname{\EArray\{\EArrayLength: \length, \EArrayValue: \vvalue\}}{\veinit}
+            \basevalue(\tenv, \overname{\TArray(\ArrayLengthEnum(\venum, \vlabels), \tty)}{\vt}) \typearrow \\
+            \overname{\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \vvalue\}}{\veinit}
         \end{array}
     }
 }

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -195,7 +195,7 @@ This is checked by \nameref{sec:TypingRule.BitfieldSliceToPositions}.
 
 \hypertarget{def-es}{}
 \item[$\EmptySlice$]
-This error indicates that an expression is either a slice with an empty list of slice sub-expressions
+This error indicates that an expression is either a slice with an empty list of slice subexpressions
 or an incorrect way of invoking a getter or a setter with the wrong list of arguments, a missing
 list of arguments, or a list of arguments where the getter or setter are declared with no arguments.
 This is checked by \nameref{sec:TypingRule.ESlice}.

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -1332,7 +1332,13 @@ resulting bitvector --- and the execution graph $\vgone$;
 \CodeSubsection{\EvalESliceBegin}{\EvalESliceEnd}{../Interpreter.ml}
 
 \section{Array Access Expressions\label{sec:ArrayAccessExpressions}}
-This section details the syntax, abstract syntax, semantics, and typing of array access expressions.
+This section details the syntax, abstract syntax, semantics, and typing of array read expressions.
+In the untyped AST, a read from either an integer-indexed array or an enumeration-indexed arrays is represented
+the same way. They type system infers the kind of array and outputs a typed AST node differentiating
+the two kinds of arrays, either a $\EGetArray$ or a $\EGetEnumArray$, via \nameref{sec:TypingRule.EGetArray}.
+The semantics utilizes a rule matching the corresponding type of array ---
+\nameref{sec:SemanticsRule.EGetArray} for integer-indexed arrays and
+\nameref{sec:SemanticsRule.EGetEnumArray} for enumeration-indexed arrays.
 
 \subsection{Syntax}
 \begin{flalign*}
@@ -1481,6 +1487,7 @@ All of the following apply:
   \item evaluating the value at index $\vi$ of $\varray$ is $\vv$;
   \item $\vg$ is the parallel composition of $\vgone$ and $\vgtwo$.
 \end{itemize}
+
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
@@ -1496,6 +1503,42 @@ All of the following apply:
 }
 \end{mathpar}
 \CodeSubsection{\EvalEGetArrayBegin}{\EvalEGetArrayEnd}{../Interpreter.ml}
+
+\subsubsection{SemanticsRule.EGetEnumArray\label{sec:SemanticsRule.EGetEnumArray}}
+\subsubsection{Example}
+In the specification:
+\ASLExample{\semanticstests/SemanticsRule.EGetEnumArray.asl}
+the enumeration-typed array \texttt{Arr} is accessed for reading and writing
+with indices taken from the enumeration type \texttt{Enum}.
+
+\subsubsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ denotes an array access expression, $\EGetArray(\earray, \eindex)$;
+  \item the evaluation of $\earray$ in $\env$ is $\Normal(\marray, \envone)$\ProseOrAbnormal;
+  \item the evaluation of $\eindex$ in $\env$ is  $\Normal(\mindex, \newenv)$\ProseOrAbnormal
+  \item $\marray$ consists of the native vector $\varray$ and execution graph $\vgone$;
+  \item $\mindex$ consists of the native integer $\vindex$ and execution graph $\vgtwo$;
+  \item $\vindex$ is the native literal for the label $\vl$;
+  \item accessing the field $\vl$ of $\varray$, which is a native record value, yields $\vv$;
+  \item $\vg$ is the parallel composition of $\vgone$ and $\vgtwo$.
+\end{itemize}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \evalexpr{\env, \earray} \evalarrow \Normal(\marray, \envone)  \OrAbnormal\\
+  \evalexpr{\envone, \eindex} \evalarrow \Normal(\mindex, \newenv)  \OrAbnormal\\
+  \marray \eqname (\varray, \vgone)\\
+  \mindex \eqname (\vindex, \vgtwo)\\
+  \vindex \eqname \nvlabel(\vl)\\
+  \getfield(\vl, \varray) \evalarrow \vv\\
+  \vg \eqdef \vgone \parallelcomp \vgtwo\\
+}{
+  \evalexpr{\env, \EGetEnumArray(\earray, \eindex)} \evalarrow \Normal((\vv, \vg), \newenv)
+}
+\end{mathpar}
+\CodeSubsection{\EvalEGetEnumArrayBegin}{\EvalEGetEnumArrayEnd}{../Interpreter.ml}
 
 \section{Field Reading Expressions\label{sec:FieldReadingExpressions}}
 \subsection{Syntax}
@@ -2712,6 +2755,12 @@ In the specification:
 \ASLExample{\semanticstests/SemanticsRule.EArbitraryIntegerRange3-42-3.asl}
 the expression \verb|ARBITRARY : integer {3, 42}| evaluates to either $\nvint(3)$ or $\nvint(42)$.
 
+\subsubsection{Example}
+The specification:
+\ASLExample{\semanticstests/SemanticsRule.EArbitraryArray.asl}
+demonstrates how to obtain an arbitrary integer-indexed array, \texttt{int\_array},
+and how to obtain an arbitrary enumeration-indexed array, \texttt{enum\_array}.
+
 \subsubsection{Prose}
 All of the following apply:
 \begin{itemize}
@@ -2738,7 +2787,7 @@ Notice that this rule introduces non-determinism.
 \subsection{Syntax}
 \begin{flalign*}
 \Nexpr \derives\  & \Tidentifier \parsesep \Tlbrace \parsesep \Trbrace &\\
-	       \| & \Tidentifier \parsesep \Tlbrace \parsesep \NClist{\Nfieldassign} \parsesep \Trbrace &\\
+	       |\ & \Tidentifier \parsesep \Tlbrace \parsesep \NClist{\Nfieldassign} \parsesep \Trbrace &\\
 \Nfieldassign \derives \ & \Tidentifier \parsesep \Teq \parsesep \Nexpr &
 \end{flalign*}
 
@@ -3043,7 +3092,8 @@ no rules for building the AST for such expressions nor rules for type-checking t
 
 \subsection{Abstract Syntax}
 \begin{flalign*}
-\expr \derives\ & \EArray\{\EArrayLength: \expr, \EArrayValue: \expr\} &
+\expr \derives\ & \EArray\{\EArrayLength: \expr, \EArrayValue: \expr\} &\\
+             |\ & \EEnumArray \{\EArrayLabels: \identifier^+, \EArrayValue: \expr\}
 \end{flalign*}
 
 \subsection{Semantics}
@@ -3051,7 +3101,7 @@ no rules for building the AST for such expressions nor rules for type-checking t
 The Semantic Rules use $\evalexprsef\empty$ because the type-checker in
 $\annotatetype$ guarantees that expressions in types are side-effect-free.
 
-\subsubsection{SemanticsRule.EvalEArray}
+\subsubsection{SemanticsRule.EArray}
 \subsubsection{Prose}
 All of the following apply:
 \begin{itemize}
@@ -3079,6 +3129,36 @@ All of the following apply:
 }
 \end{mathpar}
 \CodeSubsection{\EvalEArrayBegin}{\EvalEArrayEnd}{../Typing.ml}
+
+\subsubsection{SemanticsRule.EEnumArray}
+\subsubsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item $\ve$ is an array construction expression for an enumerated-index array with
+        list of labels $\vlabels$ and value expression $\evalue$,
+        that is, \\
+        $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \evalue\}$;
+  \item evaluating the expression $\evalue$ in $\env$ yields $\Normal((\vvalue, \vg), \newenv)$\ProseOrAbnormal;
+  \item \Proseeqdef{$\vv$}{the native record mapping each label $\vl\in\vlabels$ to $\vvalue$};
+  \item define $\vg$ as the parallel composition of $\vgone$ and $\vgtwo$.
+\end{itemize}
+
+\subsubsection{Formally}
+\begin{mathpar}
+\inferrule{
+  \evalexpr{\env, \evalue} \evalarrow \Normal((\vvalue, \vg), \newenv) \OrAbnormal\\\\
+  \vv \eqdef \nvrecord{\vl\in\vlabels: [\vl\mapsto \vvalue]}
+}{
+  {
+  \begin{array}{r}
+    \evalexpr{\env, \overname{\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \evalue\}}{\ve}} \evalarrow\\
+    \Normal((\vv, \vg), \newenv)
+  \end{array}
+  }
+}
+\end{mathpar}
+
+\CodeSubsection{\EvalEEnumArrayBegin}{\EvalEEnumArrayEnd}{../Typing.ml}
 
 \section{Side-effect-free Expressions\label{sec:SideEffectFreeExpressions}}
 \subsection{Typing}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -1517,8 +1517,8 @@ All of the following apply:
   \item $\ve$ denotes an array access expression, $\EGetArray(\earray, \eindex)$;
   \item the evaluation of $\earray$ in $\env$ is $\Normal(\marray, \envone)$\ProseOrAbnormal;
   \item the evaluation of $\eindex$ in $\env$ is  $\Normal(\mindex, \newenv)$\ProseOrAbnormal
-  \item $\marray$ consists of the native vector $\varray$ and execution graph $\vgone$;
-  \item $\mindex$ consists of the native integer $\vindex$ and execution graph $\vgtwo$;
+  \item $\marray$ consists of the native value $\varray$ and execution graph $\vgone$;
+  \item $\mindex$ consists of the native value $\vindex$ and execution graph $\vgtwo$;
   \item $\vindex$ is the native literal for the label $\vl$;
   \item accessing the field $\vl$ of $\varray$, which is a native record value, yields $\vv$;
   \item $\vg$ is the parallel composition of $\vgone$ and $\vgtwo$.
@@ -3139,8 +3139,7 @@ All of the following apply:
         that is, \\
         $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \evalue\}$;
   \item evaluating the expression $\evalue$ in $\env$ yields $\Normal((\vvalue, \vg), \newenv)$\ProseOrAbnormal;
-  \item \Proseeqdef{$\vv$}{the native record mapping each label $\vl\in\vlabels$ to $\vvalue$};
-  \item define $\vg$ as the parallel composition of $\vgone$ and $\vgtwo$.
+  \item \Proseeqdef{$\vv$}{the native record mapping each label $\vl\in\vlabels$ to $\vvalue$}.
 \end{itemize}
 
 \subsubsection{Formally}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -136,7 +136,7 @@ All of the following apply:
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \annotateliteral{\vv, \tenv} \typearrow \vt
+  \annotateliteral{\tenv, \vv} \typearrow \vt
 }{
   \annotateexpr{\tenv, \overname{\ELiteral(\vv)}{\ve}} \typearrow (\vt, \overname{\ELiteral(\vv)}{\newe}, \overname{\emptyset}{\vses})
 }
@@ -453,7 +453,7 @@ an error. Surrounding $\ve$ by parenthesis fixes the error.
 
 For example, \texttt{a + b + c} is considered legal, since the same binary operator (\texttt{+})
 is used, whereas \texttt{a + b - c} is considered illegal, since $\PLUS$ and $\MINUS$ have the
-same precedence ($3$). To fix this, we can surround one of the sub-expressions by parenthesis,
+same precedence ($3$). To fix this, we can surround one of the subexpressions by parenthesis,
 for example: \texttt{(a + b) - c}.
 
 \subsubsection{Prose}
@@ -1424,7 +1424,12 @@ All of the following apply:
   \item applying $\typeofarraylength$ to $\size$, to obtain the type of the array length, yields
         $\wantedtindex$;
   \item checking that $\tindexp$ \typesatisfies\ $\wantedtindex$ in $\tenv$ yields $\True$\ProseOrTypeError;
-  \item \Prosenonconflictingunion{$\vsesindex$ and $\vsesbase$}{$\vses$}.
+  \item \Prosenonconflictingunion{$\vsesindex$ and $\vsesbase$}{$\vses$};
+  \item \Proseeqdef{$\newe$}{
+    an access to an integer-indexed array for $\ebase$ and $\eindexp$, that is, $\EGetArray(\ebase, \eindexp)$ if $\size$ is an integer-typed array index,
+    and an access to an enumeration-indexed array for $\ebase$ and $\eindexp$, that is,\\
+    $\EGetEnumArray(\ebase, \eindexp)$ if $\size$ is an enumeration-typed array index.
+  }
 \end{itemize}
 
 \subsubsection{Formally}
@@ -1434,11 +1439,17 @@ All of the following apply:
   \typeofarraylength(\size) \typearrow \wantedtindex\\
   \checktypesat(\tenv, \tindexp, \wantedtindex) \typearrow \True \OrTypeError\\\\
   \nonconflictingunion([\vsesindex, \vsesbase]) \typearrow \vses \OrTypeError\\\\
+  {
+    \newe \eqdef \begin{cases}
+      \EGetArray(\ebase, \eindexp)     & \text{if }\astlabel(\size) = \ArrayLengthExpr\\
+      \EGetEnumArray(\ebase, \eindexp) & \text{if }\astlabel(\size) = \ArrayLengthEnum
+    \end{cases}
+  }
 }{
   {
   \begin{array}{r}
   \annotategetarray(\tenv, (\size, \telem), (\ebase, \vsesbase, \eindex)) \typearrow\\
-  (\overname{\telem}{\vt}, \overname{\EGetArray(\ebase, \eindexp)}{\newe}, \vses)
+  (\overname{\telem}{\vt}, \newe, \vses)
   \end{array}
   }
 }

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -453,7 +453,7 @@ an error. Surrounding $\ve$ by parenthesis fixes the error.
 
 For example, \texttt{a + b + c} is considered legal, since the same binary operator (\texttt{+})
 is used, whereas \texttt{a + b - c} is considered illegal, since $\PLUS$ and $\MINUS$ have the
-same precedence ($3$). To fix this, we can surround one of the subexpressions by parenthesis,
+same precedence ($3$). To fix this, we can surround one of the subexpressions with parenthesis,
 for example: \texttt{(a + b) - c}.
 
 \subsubsection{Prose}

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -75,55 +75,56 @@ transforms a parse node $\vparsednode$ for $\Nvalue$ into an AST node $\vastnode
 \hypertarget{def-annotateliteral}{}
 The function
 \[
-  \annotateliteral{\overname{\literal}{\vl}, \overname{\staticenvs}{\tenv}} \aslto \overname{\ty}{\vt}
+  \annotateliteral{\overname{\staticenvs}{\tenv}, \overname{\literal}{\vl}} \aslto \overname{\ty}{\vt}
 \]
-annotates a literal $\vl$ in a static environment $\tenv$, resulting in a type $\vt$.
+annotates a literal $\vl$ in the static environment $\tenv$, resulting in a type $\vt$.
 
 \subsubsection{Prose}
 The result of annotating a literal $\vl$ in a static environment $\tenv$ is $\vt$ and one of the following applies:
 \begin{itemize}
-\item (\texttt{int}): $\vl$ is an integer literal $\vn$ and $\vt$ is the well-constrained integer type, constraining
+\item (\textsc{int}): $\vl$ is an integer literal $\vn$ and $\vt$ is the well-constrained integer type, constraining
 its set to the single value $\vn$;
-\item (\texttt{bool}): $\vl$ is a Boolean literal and $\vt$ is the Boolean type;
-\item (\texttt{real}): $\vl$ is a real literal and $\vt$ is the real type;
-\item (\texttt{string}): $\vl$ is a string literal and $\vt$ is the string type;
-\item (\texttt{bitvector}): $\vl$ is a bitvector literal of length $\vn$ and $\vt$ is the bitvector type of fixed width $\vn$.
-\item (\texttt{label}): $\vl$ is an enumeration label literal of name $\vx$ and $\vx$ is globally bound to the type $\vt$ in $\tenv$.
+\item (\textsc{bool}): $\vl$ is a Boolean literal and $\vt$ is the Boolean type;
+\item (\textsc{real}): $\vl$ is a real literal and $\vt$ is the real type;
+\item (\textsc{string}): $\vl$ is a string literal and $\vt$ is the string type;
+\item (\textsc{bitvector}): $\vl$ is a bitvector literal of length $\vn$ and $\vt$ is the bitvector type of fixed width $\vn$.
+\item (\textsc{label}): $\vl$ is an enumeration label for $\vlabel$ and $\vlabel$ is bound to the type $\vt$ in the
+      $\declaredtypes$ map of the global environment $\tenv$.
 \end{itemize}
 
 \CodeSubsection{\LitBegin}{\LitEnd}{../Typing.ml}
 
 \subsubsection{Formally}
 \begin{mathpar}
-\inferrule[int]{}{\annotateliteral{\lint(n), \Ignore}\typearrow \TInt(\langle[\ConstraintExact(\ELInt{n})]\rangle)}
+\inferrule[int]{}{\annotateliteral{\Ignore, \lint(n)}\typearrow \TInt(\langle[\ConstraintExact(\ELInt{n})]\rangle)}
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[bool]{}{\annotateliteral{\lbool(\Ignore), \Ignore}\typearrow \TBool}
+\inferrule[bool]{}{\annotateliteral{\Ignore, \lbool(\Ignore)}\typearrow \TBool}
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[real]{}{\annotateliteral{\lreal(\Ignore), \Ignore}\typearrow \TReal}
+\inferrule[real]{}{\annotateliteral{\Ignore, \lreal(\Ignore)}\typearrow \TReal}
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[string]{}{\annotateliteral{\lstring(\Ignore), \Ignore}\typearrow \TString}
+\inferrule[string]{}{\annotateliteral{\Ignore, \lstring(\Ignore)}\typearrow \TString}
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[bitvector]{
   n \eqdef \listlen{\bits}
 }{
-  \annotateliteral{\lbitvector(\bits), \Ignore}\typearrow \TBits(\ELInt{n}, \emptylist)
+  \annotateliteral{\Ignore, \lbitvector(\bits)}\typearrow \TBits(\ELInt{n}, \emptylist)
 }
 \end{mathpar}
 
 \begin{mathpar}
-  \inferrule[label]{%
-    G^\tenv.\globalstoragetypes(\vx) = (\vt, \Ignore)\\
-  }{%
-    \annotateliteral{\llabel(\vx, \Ignore), \tenv}\typearrow \vt
-  }
+\inferrule[label]{
+  G^\tenv.\declaredtypes(\vlabel) = (\vt, \Ignore)
+}{
+  \annotateliteral{\tenv, \llabel(\vlabel)}\typearrow \vt
+}
 \end{mathpar}
 
 \subsection{Example}

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -156,5 +156,5 @@ in $S$, so they will not be printed.
                    & to make the number of hexadecimal digits printed equal the width \\
                    & of $b$ divided by 4, and rounded up to the following integer. \\
   $\lstring(S)$ & $S$. \\
-  $\llabel(s, \Ignore)$ & $s$. \\
+  $\llabel(s)$ & $s$. \\
 \end{tabular}

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -1290,13 +1290,13 @@ of \texttt{width} bits.
 \subsubsection{Operators Over Label Values \label{sec:LabelOperations}}
 \begin{mathpar}
 \inferrule[eq\_label]{}{
-  \binopliterals(\overname{\EQOP}{\op}, \overname{\llabel(a, \Ignore)}{\vvone}, \overname{\llabel(b, \Ignore)}{\vvtwo}) \typearrow \overname{\lbool(a = b)}{\vr}
+  \binopliterals(\overname{\EQOP}{\op}, \overname{\llabel(a)}{\vvone}, \overname{\llabel(b)}{\vvtwo}) \typearrow \overname{\lbool(a = b)}{\vr}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[ne\_label]{}{
-  \binopliterals(\overname{\NEQ}{\op}, \overname{\llabel(a, \Ignore)}{\vvone}, \overname{\llabel(b, \Ignore)}{\vvtwo}) \typearrow \overname{\lbool(a \neq b)}{\vr}
+  \binopliterals(\overname{\NEQ}{\op}, \overname{\llabel(a)}{\vvone}, \overname{\llabel(b)}{\vvtwo}) \typearrow \overname{\lbool(a \neq b)}{\vr}
 }
 \end{mathpar}
 
@@ -1598,8 +1598,8 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[label\_rel]{
-  \binopliterals(\op, \llabel(a, i_a), \llabel(b, i_b)) \typearrow \lbool(c)
+  \binopliterals(\op, \llabel(a), \llabel(b)) \typearrow \lbool(c)
 }{
-  \binoprel(\op, \overname{\llabel(a, i_a)}{\vvone}, \overname{\llabel(b, i_b)}{\vvtwo}) \evalarrow \overname{\nvbool(c)}{\vr}
+  \binoprel(\op, \overname{\llabel(a)}{\vvone}, \overname{\llabel(b)}{\vvtwo}) \evalarrow \overname{\nvbool(c)}{\vr}
 }
 \end{mathpar}

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -143,7 +143,8 @@ We define the following shorthands for \nativevalue\ literals:
 \begin{array}{rcl}
 \nvint(z)       &\triangleq& \nvliteral{\lint(z)}           \hypertarget{def-nvbool}{}\\
 \nvbool(b)      &\triangleq& \nvliteral{\lbool(b)}          \hypertarget{def-nvreal}{}\\
-\nvreal(r)      &\triangleq& \nvliteral{\lreal(r)}          \hypertarget{def-nvstring}{}\\
+\nvreal(r)      &\triangleq& \nvliteral{\lreal(r)}          \hypertarget{def-nvlabel}{}\\
+\nvlabel(l)     &\triangleq& \nvliteral{\llabel(l)}         \hypertarget{def-nvstring}{}\\
 \nvstring(s)    &\triangleq& \nvliteral{\lstring(s)}        \hypertarget{def-nvbitvector}{}\\
 \nvbitvector(v) &\triangleq& \nvliteral{\lbitvector(v)}\\
 \end{array}
@@ -156,6 +157,7 @@ We define the following types of \nativevalues:
   \tint       &\triangleq& \{ \nvint(z) \;|\; z \in \Z\}                                        \hypertarget{def-tbool}{}\\
   \tbool      &\triangleq& \{ \nvbool(\True), \nvbool(\False) \}                                \hypertarget{def-treal}{}\\
   \treal      &\triangleq& \{ \nvreal(r) \;|\; r \in \Q\}                                       \hypertarget{def-tstring}{}\\
+  \tlabel     &\triangleq& \{ \nvlabel(l) \;|\; l \in \identifier\}                             \hypertarget{def-tlabel}{}\\
   \tstring    &\triangleq& \{ \nvstring(s) \;|\; s \in \Strings\}  \hypertarget{def-tbitvector}{}\\
   \tbitvector &\triangleq& \{ \nvbitvector(\textit{bits}) \;|\; \textit{bits} \in \{0,1\}^*\}   \hypertarget{def-tvector}{}\\
   \tvector    &\triangleq& \{ \nvvector{\textit{vals}} \;|\; \textit{vals} \in \vals^*\}        \hypertarget{def-trecord}{}\\

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -944,6 +944,12 @@ One of the following applies:
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
+  \item All of the following apply (\textsc{e\_getenumarray}):
+  \begin{itemize}
+    \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and enumeration-typed index expression $\vetwo$;
+    \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
+  \end{itemize}
+
   \item All of the following apply (\textsc{e\_binop}):
   \begin{itemize}
     \item $\ve$ is the binary operation expression over expressions $\veone$ and $\vetwo$;
@@ -1012,6 +1018,15 @@ One of the following applies:
     \item define $\ids$ as the union of applying of $\useexpr$ to each of $\veone$ and $\vetwo$.
   \end{itemize}
 
+  \item All of the following apply (\textsc{e\_enumarray}):
+  \begin{itemize}
+    \item $\ve$ is the array construction expression for the array with enumeration-typed index for the list of labels
+          $\vlabels$ and value expression $\vvalue$,
+          that is, \\
+          $\EEnumArray\{\EArrayLabels:\vlabels, \EArrayValue:\vvalue\}$;
+    \item define $\ids$ as the union of labels listed in $\vlabels$ and the result of applying $\useexpr$ to $\vvalue$.
+  \end{itemize}
+
   \item All of the following apply (\textsc{e\_arbitrary}):
   \begin{itemize}
     \item $\ve$ is the arbitrary expression with type $\vt$;
@@ -1053,6 +1068,12 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[e\_getarray]{}{
   \useexpr(\overname{\EGetArray(\veone, \vetwo)}{\ve}) \typearrow \overname{\useexpr(\veone) \cup \useexpr(\vetwo)}{\ids}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[e\_getenumarray]{}{
+  \useexpr(\overname{\EGetEnumArray(\veone, \vetwo)}{\ve}) \typearrow \overname{\useexpr(\veone) \cup \useexpr(\vetwo)}{\ids}
 }
 \end{mathpar}
 
@@ -1123,6 +1144,12 @@ One of the following applies:
 \end{mathpar}
 
 \begin{mathpar}
+\inferrule[e\_enumarray]{}{
+  \useexpr(\overname{\EEnumArray\{\EArrayLabels:\vlabels, \EArrayValue:\vvalue\}}{\ve}) \typearrow \overname{\{\vlabels\} \cup \useexpr(\vvalue)}{\ids}
+}
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[e\_arbitrary]{}{
   \useexpr(\overname{\EArbitrary(\vt)}{\ve}) \typearrow \overname{\usety(\vt)}{\ids}
 }
@@ -1170,6 +1197,13 @@ One of the following applies:
     \item define $\ids$ as the union of applying $\uselexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
+  \item All of the following apply (\textsc{le\_setenumarray}):
+  \begin{itemize}
+    \item $\vle$ is a left-hand-side array update of the array given by the expression $\veone$ and
+          the enumeration-typed index expression $\vetwo$;
+    \item define $\ids$ as the union of applying $\uselexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
+  \end{itemize}
+
   \item All of the following apply (\textsc{le\_setfield}):
   \begin{itemize}
     \item $\vle$ is a left-hand-side field update of the record given by the expression $\veone$;
@@ -1207,6 +1241,12 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[le\_setarray]{}{
   \uselexpr(\overname{\LESetArray(\veone, \vetwo)}{\vle}) \typearrow \overname{\uselexpr(\veone) \cup \useexpr(\vetwo)}{\ids}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[le\_setenumarray]{}{
+  \uselexpr(\overname{\LESetEnumArray(\veone, \vetwo)}{\vle}) \typearrow \overname{\uselexpr(\veone) \cup \useexpr(\vetwo)}{\ids}
 }
 \end{mathpar}
 

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -584,9 +584,9 @@ One of the following applies:
 
   \item All of the following apply (\textsc{e\_slice}):
   \begin{itemize}
-    \item $\ve$ is the slicing expression for sub-expression $\veone$ and list of slices $\vslices$, that is, $\ESlice(\veone, \vslices)$;
+    \item $\ve$ is the slicing expression for subexpression $\veone$ and list of slices $\vslices$, that is, $\ESlice(\veone, \vslices)$;
     \item applying $\substexpr$ to $\veone$ in $\tenv$ yields $\veonep$;
-    \item define $\newe$ as slicing expression for sub-expression $\veonep$ and list of slices $\vslices$, that is, $\ESlice(\veonep, \vslices)$.
+    \item define $\newe$ as slicing expression for subexpression $\veonep$ and list of slices $\vslices$, that is, $\ESlice(\veonep, \vslices)$.
   \end{itemize}
 
   \item All of the following apply (\textsc{e\_tuple}):
@@ -604,8 +604,9 @@ One of the following applies:
           $\EArray\{\EArrayLength: \length, \EArrayValue: \vvalue\}$;
     \item applying $\substexpr$ to $\substs$ and $\length$ in $\tenv$ yields $\lengthp$;
     \item applying $\substexpr$ to $\substs$ and $\vvalue$ in $\tenv$ yields $\vvaluep$;
-    \item define $\newe$ as the array construction expression with length expression $\lengthp$ and value expression $\vvaluep$, that is,
-    $\EArray\{\EArrayLength: \lengthp, \EArrayValue: \vvaluep\}$.
+    \item define $\newe$ as the array construction expression with length expression \\
+          $\lengthp$ and value expression $\vvaluep$, that is, \\
+          $\EArray\{\EArrayLength: \lengthp, \EArrayValue: \vvaluep\}$.
   \end{itemize}
 
   \item All of the following apply (\textsc{e\_atc}):

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -540,6 +540,17 @@ One of the following applies:
     that is, $\EGetArray(\veonep, \vetwop)$.
   \end{itemize}
 
+  \item All of the following apply (\textsc{e\_getenumarray}):
+  \begin{itemize}
+    \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and an enumeration-typed index expression $\vetwo$,
+          that is, $\EGetEnumArray(\veone, \vetwo)$;
+    \item applying $\substexpr$ to $\substs$ and $\veone$ in $\tenv$ yields $\veonep$;
+    \item applying $\substexpr$ to $\substs$ and $\vetwo$ in $\tenv$ yields $\vetwop$;
+    \item define $\newe$ as the \arrayaccess\ expression for base expression $\veonep$ and \\
+          enumeration-typed index expression $\vetwop$,
+          that is, $\EGetEnumArray(\veonep, \vetwop)$.
+  \end{itemize}
+
   \item All of the following apply (\textsc{e\_getfield}):
   \begin{itemize}
     \item $\ve$ is the field access expression for base expression $\ve$ and field $\vx$,
@@ -605,8 +616,19 @@ One of the following applies:
     \item applying $\substexpr$ to $\substs$ and $\length$ in $\tenv$ yields $\lengthp$;
     \item applying $\substexpr$ to $\substs$ and $\vvalue$ in $\tenv$ yields $\vvaluep$;
     \item define $\newe$ as the array construction expression with length expression \\
-          $\lengthp$ and value expression $\vvaluep$, that is, \\
+          $\lengthp$ and initial element value expression $\vvaluep$, that is, \\
           $\EArray\{\EArrayLength: \lengthp, \EArrayValue: \vvaluep\}$.
+  \end{itemize}
+
+  \item All of the following apply (\textsc{e\_enumarray}):
+  \begin{itemize}
+    \item $\ve$ is an array construction expression for an enumeration-typed index
+          with list of labels $\vlabels$ and initial element value expression $\vvalue$, that is, \\
+          $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \vvalue\}$;
+    \item applying $\substexpr$ to $\substs$ and $\vvalue$ in $\tenv$ yields $\vvaluep$;
+    \item define $\newe$ as the array construction expression with list of labels $\vlabels$
+          and value expression $\vvaluep$, that is,
+          $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \vvaluep\}$.
   \end{itemize}
 
   \item All of the following apply (\textsc{e\_atc}):
@@ -690,6 +712,15 @@ One of the following applies:
 \end{mathpar}
 
 \begin{mathpar}
+\inferrule[e\_getenumarray]{
+  \substexpr(\tenv, \substs, \veone) \typearrow \veonep\\
+  \substexpr(\tenv, \substs, \vetwop) \typearrow \vetwop
+}{
+  \substexpr(\tenv, \substs, \overname{\EGetEnumArray(\veone, \vetwo)}{\ve}) \typearrow \overname{\EGetEnumArray(\veonep, \vetwop)}{\newe}
+}
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[e\_getfield]{
   \substexpr(\tenv, \substs, \veone) \typearrow \veonep
 }{
@@ -756,6 +787,19 @@ One of the following applies:
     \begin{array}{r}
   \substexpr(\tenv, \substs, \overname{\EArray\{\EArrayLength: \length, \EArrayValue: \vvalue\}}{\ve}) \typearrow\\
   \overname{\EArray\{\EArrayLength: \length, \EArrayValue: \vvaluep\}}{\newe}
+    \end{array}
+  }
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[e\_enumarray]{
+  \substexpr(\tenv, \substs, \vvalue) \typearrow \vvaluep
+}{
+  {
+    \begin{array}{r}
+  \substexpr(\tenv, \substs, \overname{\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \vvalue\}}{\ve}) \typearrow\\
+  \overname{\EEnumArray\{\EArrayLabels: \length, \EArrayValue: \vvaluep\}}{\newe}
     \end{array}
   }
 }

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -536,7 +536,7 @@ One of the following applies:
 
   \item All of the following apply (\textsc{ATC}):
   \begin{itemize}
-    \item $\ve$ is an asserting type conversion for the sub-expression $\vep$, that is, \\
+    \item $\ve$ is an asserting type conversion for the subexpression $\vep$, that is, \\
           $\EATC(\vep, \Ignore)$;
     \item applying $\toir$ to $\vep$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -1866,9 +1866,11 @@ One of the following applies:
 
   \item All of the following apply (\textsc{enum\_enum}):
   \begin{itemize}
-    \item $\vlone$ is an enumeration type length expression over the enumeration $\vsone$, that is, $\ArrayLengthEnum(\vsone, \Ignore)$;
-    \item $\vltwo$ is an enumeration type length expression over the enumeration $\vstwo$, that is, $\ArrayLengthEnum(\vstwo, \Ignore)$;
-    \item $\vb$ is $\True$ if and only if $\vsone$ is equal to $\vstwo$.
+    \item $\vlone$ is an enumeration type index for the identifier $\venumone$ and a list of labels, that is,
+          $\ArrayLengthEnum(\venumone, \Ignore)$;
+    \item $\vltwo$ is an enumeration type index for the identifier $\venumtwo$ and a list of labels, that is,
+           $\ArrayLengthEnum(\venumtwo, \Ignore)$;
+    \item $\vb$ is $\True$ if and only if $\venumone$ is equal to $\venumtwo$.
   \end{itemize}
 \end{itemize}
 
@@ -1879,17 +1881,21 @@ One of the following applies:
 }{
   \arraylengthequal(\vlone, \vltwo) \typearrow \False
 }
-\and
-  \inferrule[expr\_expr]{
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[expr\_expr]{
   \exprequal(\veoneone, \vetwoone) \typearrow \vb \OrTypeError
 }{
   \arraylengthequal(\ArrayLengthExpr(\veoneone), \ArrayLengthExpr(\vetwoone)) \typearrow \vb
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[enum\_enum]{
-  \vb \eqdef \vsone = \vstwo
+  \vb \eqdef (\venumone = \venumtwo)
 }{
-  \arraylengthequal(\ArrayLengthEnum(\vsone, \Ignore), \ArrayLengthEnum(\vstwo, \Ignore)) \typearrow \vb
+  \arraylengthequal(\ArrayLengthEnum(\venumone, \Ignore), \ArrayLengthEnum(\venumtwo, \Ignore)) \typearrow \vb
 }
 \end{mathpar}
 

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -568,7 +568,12 @@ All of the following apply:
 \inferrule{
   \ids \eqname \id_{1..k}\\
   \tenv_0 \eqdef \tenv\\
-  \vi=1..k: \declareconst(\tenv_{\vi-1}, \id_\vi, \TNamed(\name), \llabel(\id_\vi, \vi-1)) \typearrow \tenv_{\vi} \OrTypeError
+  {
+  \begin{array}{r}
+    \vi=1..k: \declareconst(\tenv_{\vi-1}, \id_\vi, \TNamed(\name), \llabel(\id_\vi, \vi-1)) \typearrow \\
+    \tenv_{\vi} \OrTypeError
+  \end{array}
+  }
 }{
   \declareenumlabels(\tenv, \name, \ids) \typearrow \overname{\tenv_k}{\newtenv}
 }

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -557,7 +557,7 @@ All of the following apply:
 \begin{itemize}
   \item $\ids$ is the (non-empty) list of labels $\id_{1..k}$;
   \item $\tenv_0$ is $\tenv$;
-  \item declaring the constant $\id_i$ with the type $\TNamed(\name)$ and literal $\llabel(\id_i, i-1)$ in $\tenv_{i-1}$
+  \item declaring the constant $\id_i$ with the type $\TNamed(\name)$ and literal $\llabel(\id_i)$ in $\tenv_{i-1}$
         via $\declareconst$
         yields $\tenv_i$, for $i=1 $ to $k$ (if $k>1$)\ProseOrTypeError;
   \item $\newtenv$ is $\tenv_k$.
@@ -570,7 +570,7 @@ All of the following apply:
   \tenv_0 \eqdef \tenv\\
   {
   \begin{array}{r}
-    \vi=1..k: \declareconst(\tenv_{\vi-1}, \id_\vi, \TNamed(\name), \llabel(\id_\vi, \vi-1)) \typearrow \\
+    \vi=1..k: \declareconst(\tenv_{\vi-1}, \id_\vi, \TNamed(\name), \llabel(\id_\vi)) \typearrow \\
     \tenv_{\vi} \OrTypeError
   \end{array}
   }

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -89,8 +89,8 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
 
   \item All of the following apply (\textsc{t\_enumeration}):
   \begin{itemize}
-    \item $\vt$ is the enumeration type with labels $\id_{1..k}$, that is $\TEnum(\id_{1..k})$;
-    \item $\vd$ is the set of all native enumeration labels $\llabel(\id_\vi, \vi)$, for $\vi = 1..k$.
+    \item $\vt$ is the enumeration type with labels $\vl_{1..k}$, that is $\TEnum(\vl_{1..k})$;
+    \item $\vd$ is the set of all native labels $\nvlabel(\vl_\vi)$, for $\vi = 1..k$.
   \end{itemize}
 
   \item All of the following apply (\textsc{t\_int\_unconstrained}):
@@ -188,36 +188,49 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     is from $D_i$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_array\_dynamic\_error}):
+  \item All of the following apply:
   \begin{itemize}
-    \item $\vt$ is an array type with length expression $\ve$ and element type $\vt_i$, for $i=1..k$, $\TArray(\ve, \vtone)$;
-    \item evaluating $\ve$ in $\env$, results in a dynamic error configuration;
-    \item $\vd$ is the empty set.
+    \item $\vt$ is an integer-indexed array type with length expression $\ve$ and element type $\telem$, $\TArray(\ArrayLengthExpr(\ve), \telem)$;
+    \item One of the following applies:
+    \item All of the following apply (\textsc{t\_array\_dynamic\_error}):
+    \begin{itemize}
+      \item evaluating $\ve$ in $\env$, results in a dynamic error configuration;
+      \item $\vd$ is the empty set.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_array\_negative\_length\_error}):
+    \begin{itemize}
+      \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $k$;
+      \item $k$ is negative;
+      \item $\vd$ is the empty set.
+    \end{itemize}
+
+    \item All of the following apply (\textsc{t\_array\_okay}):
+    \begin{itemize}
+      \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $k$;
+      \item $k$ is greater than or equal to $0$;
+      \item the domain of $\vtone$ is $D_\telem$;
+      \item $\vd$ is the set of all native vectors of $k$ values taken from $D_\telem$.
+    \end{itemize}
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_array\_negative\_length\_error}):
+  \item All of the following apply (\textsc{t\_enum\_array}):
   \begin{itemize}
-    \item $\vt$ is an array type with length expression $\ve$ and element type $\vt_i$, for $i=1..k$, $\TArray(\ve, \vtone)$;
-    \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $k$;
-    \item $k$ is negative;
-    \item $\vd$ is the empty set.
-  \end{itemize}
-
-  \item All of the following apply (\textsc{t\_array\_okay}):
-  \begin{itemize}
-    \item $\vt$ is an array type with length expression $\ve$ and element type $\vt_i$, for $i=1..k$, $\TArray(\ve, \vtone)$;
-    \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $k$;
-    \item $k$ is greater than or equal to $0$;
-    \item the domain of $\vtone$ is $D_\vtone$;
-    \item $\vd$ is the set containing all native vectors of $k$ values taken from $D_\vtone$.
+    \item $\vt$ is an enumeration-indexed array type with for the enumeration $\id$ with $k$ labels and element type $\telem$,
+          $\TArray(\ArrayLengthEnum(\id, k), \telem)$;
+    \item view $\env$ as the pair consisting of the static environment $\tenv$ and a dynamic environment;
+    \item the type bound to $\id$ in the $\declaredtypes$ map of the static environment of $\tenv$ is the enumeration type
+          for the labels $\vl_{1..k}$, that is, $\TEnum(\vl_{1..k})$;
+    \item the dynamic domain of $\telem$ in $\env$ is $D_\telem$;
+    \item $\vd$ is the set of all native records where each $\vl_i$ is mapped to a value taken from $D_\telem$, for $i=1..k$.
   \end{itemize}
 
   \item All of the following apply (\textsc{t\_structured}):
   \begin{itemize}
-    \item $\vt$ is a \structuredtype\ with typed fields $(\id_i, \vt_i$, for $i=1..k$, that is $L([i=1..k: (\id_i,\vt_i))]$
+    \item $\vt$ is a \structuredtype\ with typed fields $(\id_i, \vt_i)$, for $i=1..k$, that is $L([i=1..k: (\id_i,\vt_i))]$
     where $L\in\{\TRecord, \TException\}$;
     \item the domain of each type $\vt_i$ is $D_i$, for $i=1..k$;
-    \item $\vd$ is the set containing all native records where $\id_i$ is mapped to a value taken from $D_i$.
+    \item $\vd$ is the set containing all native records where $\id_i$ is mapped to a value taken from $D_i$, for $i=1..k$.
   \end{itemize}
 
   \item All of the following apply (\textsc{t\_named}):
@@ -238,7 +251,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
 \inferrule[t\_real]{}{ \dynamicdomain(\env, \overname{\TReal}{\vt}) = \overname{\treal}{\vd} }
 \and
 \inferrule[t\_enumeration]{}{
-  \dynamicdomain(\env, \overname{\TEnum(\id_{1..k})}{\vt}) = \overname{\{ \vi = 1..k: \nvliteral{\llabel(\id_\vi, \vi)} \}}{\vd}
+  \dynamicdomain(\env, \overname{\TEnum(\vl_{1..k})}{\vt}) = \overname{\{ \vi = 1..k: \nvlabel(\vl_\vi) \}}{\vd}
 }
 \end{mathpar}
 
@@ -341,23 +354,38 @@ in the \emph{local dynamic environment} of $\denv$.
 \inferrule[t\_array\_dynamic\_error]{
   \evalexprsef{\env, \ve} \evalarrow \DynErrorConfig
 }{
-  \dynamicdomain(\env, \overname{\TArray(\ve, \vtone)}{\vt}) = \overname{\emptyset}{\vd}
+  \dynamicdomain(\env, \overname{\TArray(\ArrayLengthExpr(\ve), \telem)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_array\_negative\_length\_error]{
   \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
   k < 0
 }{
-  \dynamicdomain(\env, \overname{\TArray(\ve, \vtone)}{\vt}) = \overname{\emptyset}{\vd}
+  \dynamicdomain(\env, \overname{\TArray(\ArrayLengthExpr(\ve), \telem)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_array\_okay]{
   \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
   k \geq 0\\
-  \dynamicdomain(\env, \vtone) = D_\vtone
+  \dynamicdomain(\env, \telem) = D_\telem
 }{
-  \dynamicdomain(\env, \overname{\TArray(\ve, \vtone)}{\vt}) =
-  \overname{\{ \nvvector{\vv_{1..k}} \;|\; \vv_{1..k} \in D_{\vtone} \}}{\vd}
+  \dynamicdomain(\env, \overname{\TArray(\ArrayLengthExpr(\ve), \telem)}{\vt}) =
+  \overname{\{ \nvvector{\vv_{1..k}} \;|\; \vv_{1..k} \in D_{\telem} \}}{\vd}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[t\_enum\_array]{
+  \env \eqname (\tenv, \Ignore)\\
+  G^\tenv.\declaredtypes(\id) = \TEnum(\vl_{1..k})\\
+  \dynamicdomain(\env, \telem) = D_\telem
+}{
+  {
+  \begin{array}{c}
+    \dynamicdomain(\env, \overname{\TArray(\ArrayLengthEnum(\id, k), \telem)}{\vt}) =\\
+    \overname{\{ \nvrecord{\{i=1..k: \vl_i\mapsto \vv_i\}} \;|\; \vv_i \in D_\telem \}}{\vd}
+  \end{array}
+  }
 }
 \end{mathpar}
 
@@ -393,7 +421,7 @@ The domain of \texttt{bits(2)} is the set $\{\nvbitvector(00)$, $\nvbitvector(01
 $\nvbitvector(10)$, $\nvbitvector(11)\}$.
 
 The domain of \verb|enumeration {GREEN, ORANGE, RED}| is the set \\
-$\{\nvint(1), \nvint(2), \nvint(3)\}$ and so is the domain
+$\{\nvlabel(\texttt{GREEN}), \nvlabel(\texttt{ORANGE}), \nvlabel(\texttt{RED})\}$ and so is the domain
 of \\
 \verb|type TrafficLights of enumeration {GREEN, ORANGE, RED}|.
 

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -108,37 +108,37 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
   \item All of the following apply (\textsc{constraint\_exact\_okay}):
   \begin{itemize}
     \item $\vc$ is a constraint consisting of a single side-effect-free expression $\ve$, that is, $\ConstraintExact(\ve)$;
-    \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $n$;
+    \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $n$;
     \item $\vd$ is the set containing the single native integer value for $n$.
   \end{itemize}
 
   \item All of the following apply (\textsc{constraint\_exact\_dynamic\_error}):
   \begin{itemize}
     \item $\vc$ is a constraint consisting of a single side-effect-free expression $\ve$, that is, $\ConstraintExact(\ve)$;
-    \item evaluating $\ve$ in $\env$, results in a dynamic error configuration;
+    \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
   \item All of the following apply (\textsc{constraint\_range\_okay}):
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
-    \item evaluating $\veone$ in $\env$, results in a configuration with the native integer for $a$;
-    \item evaluating $\vetwo$ in $\env$, results in a configuration with the native integer for $b$;
+    \item evaluating $\veone$ in $\env$ results in a configuration with the native integer for $a$;
+    \item evaluating $\vetwo$ in $\env$ results in a configuration with the native integer for $b$;
     \item $\vd$ is the set containing all native integer values for integers greater or equal to $a$ and less than or equal to $b$.
   \end{itemize}
 
   \item All of the following apply (\textsc{constraint\_range\_dynamic\_error1}):
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
-    \item evaluating $\veone$ in $\env$, results in a dynamic error configuration;
+    \item evaluating $\veone$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
   \item All of the following apply (\textsc{constraint\_range\_dynamic\_error2}):
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
-    \item evaluating $\veone$ in $\env$, results in a configuration with the native integer for $a$;
-    \item evaluating $\vetwo$ in $\env$, results in a dynamic error configuration;
+    \item evaluating $\veone$ in $\env$ results in a configuration with the native integer for $a$;
+    \item evaluating $\vetwo$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
@@ -152,14 +152,14 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
   \item All of the following apply (\textsc{t\_bits\_dynamic\_error}):
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
-    \item evaluating $\ve$ in $\env$, results in a dynamic error configuration;
+    \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
   \item All of the following apply (\textsc{t\_bits\_negative\_width\_error}):
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
-    \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $k$;
+    \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
     \item $k$ is negative;
     \item $\vd$ is the empty set.
   \end{itemize}
@@ -167,14 +167,14 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
   \item All of the following apply (\textsc{t\_bits\_empty}):
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
-    \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $0$;
+    \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $0$;
     \item $\vd$ is the set containing the single \nativevalue\ for an empty bitvector.
   \end{itemize}
 
   \item All of the following apply (\textsc{t\_bits\_non\_empty}):
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
-    \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $k$;
+    \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
     \item $k$ is greater than $0$;
     \item $\vd$ is the set containing all \nativevalues\ for bitvectors of size exactly $k$.
   \end{itemize}
@@ -183,7 +183,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
   \begin{itemize}
     \item $\vt$ is a tuple type over types $\vt_i$, for $i=1..k$, $\TTuple(\vt_{1..k})$;
     \item the domain of each element $\vt_i$ is $D_i$, for $i=1..k$;
-    \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $k$;
+    \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
     \item $\vd$ is the set containing all native vectors of $k$ values, where the value at position $i$
     is from $D_i$.
   \end{itemize}
@@ -192,25 +192,27 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
   \begin{itemize}
     \item $\vt$ is an integer-indexed array type with length expression $\ve$ and element type $\telem$, $\TArray(\ArrayLengthExpr(\ve), \telem)$;
     \item One of the following applies:
-    \item All of the following apply (\textsc{t\_array\_dynamic\_error}):
-    \begin{itemize}
-      \item evaluating $\ve$ in $\env$, results in a dynamic error configuration;
-      \item $\vd$ is the empty set.
-    \end{itemize}
+      \begin{itemize}
+      \item All of the following apply (\textsc{t\_array\_dynamic\_error}):
+      \begin{itemize}
+        \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
+        \item $\vd$ is the empty set.
+      \end{itemize}
 
-    \item All of the following apply (\textsc{t\_array\_negative\_length\_error}):
-    \begin{itemize}
-      \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $k$;
-      \item $k$ is negative;
-      \item $\vd$ is the empty set.
-    \end{itemize}
+      \item All of the following apply (\textsc{t\_array\_negative\_length\_error}):
+      \begin{itemize}
+        \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
+        \item $k$ is negative;
+        \item $\vd$ is the empty set.
+      \end{itemize}
 
-    \item All of the following apply (\textsc{t\_array\_okay}):
-    \begin{itemize}
-      \item evaluating $\ve$ in $\env$, results in a configuration with the native integer for $k$;
-      \item $k$ is greater than or equal to $0$;
-      \item the domain of $\vtone$ is $D_\telem$;
-      \item $\vd$ is the set of all native vectors of $k$ values taken from $D_\telem$.
+      \item All of the following apply (\textsc{t\_array\_okay}):
+      \begin{itemize}
+        \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
+        \item $k$ is greater than or equal to $0$;
+        \item the domain of $\vtone$ is $D_\telem$;
+        \item $\vd$ is the set of all native vectors of $k$ values taken from $D_\telem$.
+      \end{itemize}
     \end{itemize}
   \end{itemize}
 

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -616,6 +616,16 @@ In the following example, all the uses of tuple types are well-typed:
 \subsubsection{Example}
 
 \section{Array Types\label{sec:ArrayTypes}}
+ASL offers two kinds of arrays:
+\begin{description}
+  \item[Integer-indexed arrays] representing a consecutive list of elements at positions $0$ to the size
+      specified for the array. The array elements can be accessed via an \texttt{integer}
+      type that specifies the $0$-based position of the element to read/update.
+  \item[Enumeration-indexed arrays] representing a dictionary-like data type where the keys are defined
+      by a given enumeration type. The array elements can be accessed via values of the \texttt{enumeration}
+      type specified for the array type.
+\end{description}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nty \derives\ & \Tarray \parsesep \Tlbracket \parsesep \Nexpr \parsesep \Trbracket \parsesep \Tof \parsesep \Nty &

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -676,10 +676,10 @@ All of the following apply:
 \inferrule[expr\_is\_enum]{
   \annotatetype{\False, \tenv, \vt} \typearrow (\vtp, \vsest) \OrTypeError\\\\
   \commonprefixline\\\\
-  \getvariableenum(\tenv, \ve) \typearrow \langle \vs, \vi \rangle\OrTypeError
+  \getvariableenum(\tenv, \ve) \typearrow \langle \vs, \vlabels \rangle\OrTypeError
 }{
   \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\AbbrevTArrayLengthExpr{\ve}{\vt}}{\tty}} \typearrow
-  (\overname{\AbbrevTArrayLengthEnum{\ve}{\vi}{\vtp}}{\newty}, \overname{\emptyset}{\vsest})
+  (\overname{\AbbrevTArrayLengthEnum{\ve}{\vlabels}{\vtp}}{\newty}, \overname{\emptyset}{\vsest})
 }
 \end{mathpar}
 
@@ -702,10 +702,11 @@ All of the following apply:
 The function
 \[
 \getvariableenum(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
-\langle (\overname{\identifier}{\vx}, \overname{\N}{n})\rangle
+\langle (\overname{\identifier}{\vx}, \overname{\identifier^+}{\vlabels})\rangle
 \]
 tests whether the expression $\ve$ represents a variable of an enumeration type.
-If so, the result is $\vx$ --- the name of the variable and the number of labels defined for the enumeration type.
+If so, the result is $\vx$ --- the name of the variable and the list of labels $\vlabels$,
+declared for the enumeration type.
 Otherwise, the result is $\None$.
 
 \subsubsection{Prose}
@@ -728,8 +729,8 @@ One of the following applies:
   \begin{itemize}
     \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
     \item $\vx$ is associated with a type $\vt$ in the global environment of $\tenv$;
-    \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields an enumeration type with labels $\vli$\ProseOrTypeError;
-    \item the result is the pair consisting of $\vx$ and the length of $\vli$.
+    \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields an enumeration type with labels $\vlabels$\ProseOrTypeError;
+    \item the result is the pair consisting of $\vx$ and $\vlabels$.
   \end{itemize}
 
   \item All of the following apply (\textsc{declared\_not\_enum}):
@@ -761,9 +762,9 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[declared\_enum]{
   G^\tenv.\declaredtypes(\vx) = (\vt, \Ignore)\\
-  \makeanonymous(\tenv, \vt) \typearrow \TEnum(\vli) \OrTypeError
+  \makeanonymous(\tenv, \vt) \typearrow \TEnum(\vlabels) \OrTypeError
 }{
-  \getvariableenum(\tenv, \overname{\EVar(\vx)}{\ve}) \typearrow \langle(\vx, |\vli|)\rangle
+  \getvariableenum(\tenv, \overname{\EVar(\vx)}{\ve}) \typearrow \langle(\vx, \vlabels)\rangle
 }
 \end{mathpar}
 

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -245,7 +245,7 @@ module PPrint = struct
           (pp_comma_list pp_type_desc)
           li
     | BadField (s, ty) ->
-        fprintf f "ASL Error: There are no field '%s'@ on type %a." s pp_ty ty
+        fprintf f "ASL Error: There is no field '%s'@ on type %a." s pp_ty ty
     | MissingField (fields, ty) ->
         fprintf f
           "ASL Error: Fields mismatch for creating a value of type %a@ -- \

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -41,6 +41,7 @@ module SemanticsRule = struct
     | ESlice
     | ECall
     | EGetArray
+    | EGetEnumArray
     | ESliceError
     | ERecord
     | EGetBitField
@@ -49,6 +50,7 @@ module SemanticsRule = struct
     | EConcat
     | ETuple
     | EArray
+    | EEnumArray
     | EArbitrary
     | EPattern
     | LEDiscard
@@ -58,6 +60,7 @@ module SemanticsRule = struct
     | LEUndefIdentV1
     | LESlice
     | LESetArray
+    | LESetEnumArray
     | LESetField
     | LESetFields
     | LEDestructuring
@@ -132,8 +135,10 @@ module SemanticsRule = struct
     | EConcat -> "EConcat"
     | ETuple -> "ETuple"
     | EArray -> "EArray"
+    | EEnumArray -> "EEnumArray"
     | ECondSimple -> "ECondSimple"
     | EGetArray -> "EGetArray"
+    | EGetEnumArray -> "EGetEnumArray"
     | ESliceError -> "ESliceError"
     | EArbitrary -> "EArbitrary"
     | EPattern -> "EPattern"
@@ -142,6 +147,7 @@ module SemanticsRule = struct
     | LEMultiAssign -> "LEMultiAssign"
     | LESlice -> "LESlice"
     | LESetArray -> "LESetArray"
+    | LESetEnumArray -> "LESetEnumArray"
     | LESetField -> "LESetField"
     | LESetFields -> "LESetFields"
     | LEDestructuring -> "LEDestructuring"
@@ -216,6 +222,7 @@ module SemanticsRule = struct
       ESlice;
       ECall;
       EGetArray;
+      EGetEnumArray;
       ESliceError;
       ERecord;
       EGetBitField;
@@ -224,6 +231,7 @@ module SemanticsRule = struct
       EConcat;
       ETuple;
       EArray;
+      EEnumArray;
       EArbitrary;
       EPattern;
       LEDiscard;
@@ -233,6 +241,7 @@ module SemanticsRule = struct
       LEUndefIdentV1;
       LESlice;
       LESetArray;
+      LESetEnumArray;
       LESetField;
       LESetFields;
       LEDestructuring;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EArbitraryArray.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EArbitraryArray.asl
@@ -1,0 +1,15 @@
+type Enum of enumeration {A, B, C};
+type Arr of array[Enum] of integer;
+
+func main () => integer
+begin
+  var int_array = ARBITRARY : array[3] of integer;
+  int_array[[2]] = 1;
+  assert int_array[[2]] == 1;
+
+  var enum_array = ARBITRARY : Arr;
+  enum_array[[A]] = 7;
+  assert enum_array[[A]] == 7;
+
+  return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGetEnumArray.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGetEnumArray.asl
@@ -1,0 +1,12 @@
+type Enum of enumeration {A, B, C};
+type Arr of array[Enum] of integer;
+
+func main () => integer
+begin
+  var arr: Arr;
+  arr[[A]] = 32;
+  arr[[B]] = 64;
+  arr[[C]] = 128;
+  assert 2 * arr[[A]] + arr[[B]] == arr[[C]];
+  return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -174,3 +174,4 @@ ASL Semantics Reference:
   $ aslref SemanticsRule.SCond3.asl
   $ aslref SemanticsRule.SCond4.asl
   $ aslref SemanticsRule.STry.asl
+  $ aslref SemanticsRule.EGetEnumArray.asl

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -58,6 +58,7 @@ ASL Semantics Reference:
     characters 9 to 14:
   ASL Execution error: Assertion failed: (x == 42).
   [1]
+  $ aslref SemanticsRule.EArbitraryArray.asl
   $ aslref SemanticsRule.EPatternFALSE.asl
   $ aslref SemanticsRule.EPatternTRUE.asl
   $ aslref SemanticsRule.LELocalVar.asl

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -391,8 +391,8 @@ module Domain = struct
                 assert false (* Type error - should have been caught earlier. *)
           in
           expr_fold approx env f' e1 acc
-      | E_Array _ | E_GetArray _ | E_GetField _ | E_GetFields _ | E_GetItem _
-      | E_Record _ | E_Tuple _ ->
+      | E_Array _ | E_EnumArray _ | E_GetArray _ | E_GetEnumArray _
+      | E_GetField _ | E_GetFields _ | E_GetItem _ | E_Record _ | E_Tuple _ ->
           (* Not supported: aggregate types. *)
           assert_under approx acc
       | E_ATC (_, _) | E_Slice (_, _) | E_Pattern (_, _) | E_Call _ ->

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -188,7 +188,7 @@ module Make (C : Config) = struct
         | L_Real _f ->
             Printf.eprintf "real: %s\n%!" (Q.to_string _f);
             Warn.fatal "Cannot use reals yet."
-        | L_String _f -> Warn.fatal "Cannot strings in herd yet."
+        | L_String _f -> Warn.fatal "Cannot instantiate strings in herd yet."
         | L_Label (_, i) -> S_Int (Z.of_int i) |> concrete
       in
       fun v -> V.Val (tr v)
@@ -196,6 +196,8 @@ module Make (C : Config) = struct
     let v_to_int = function
       | V.Val (Constant.Concrete (ASLScalar.S_Int i)) -> Some (Z.to_int i)
       | _ -> None
+
+    let v_to_label v = V.as_symbol v
 
     let v_as_int = function
       | V.Val (Constant.Concrete i) -> V.Cst.Scalar.to_int i
@@ -905,6 +907,7 @@ module Make (C : Config) = struct
         let v_of_int = V.intToV
         let v_of_literal = v_of_literal
         let v_to_int = v_to_int
+        let v_to_label = v_to_label
         let bind_data = M.asl_data
         let bind_seq = M.asl_seq
         let bind_ctrl = M.asl_ctrl

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -189,7 +189,7 @@ module Make (C : Config) = struct
             Printf.eprintf "real: %s\n%!" (Q.to_string _f);
             Warn.fatal "Cannot use reals yet."
         | L_String _f -> Warn.fatal "Cannot instantiate strings in herd yet."
-        | L_Label (_, i) -> S_Int (Z.of_int i) |> concrete
+        | L_Label s -> S_Label s |> concrete
       in
       fun v -> V.Val (tr v)
 
@@ -197,7 +197,9 @@ module Make (C : Config) = struct
       | V.Val (Constant.Concrete (ASLScalar.S_Int i)) -> Some (Z.to_int i)
       | _ -> None
 
-    let v_to_label v = V.as_symbol v
+      let v_to_label = function
+      | V.Val (Constant.Concrete (ASLScalar.S_Label l)) -> l
+      | v -> Warn.fatal "Cannot make a label out of value %s" (V.pp_v v)
 
     let v_as_int = function
       | V.Val (Constant.Concrete i) -> V.Cst.Scalar.to_int i

--- a/herd/tests/instructions/ASL/enum-array.litmus
+++ b/herd/tests/instructions/ASL/enum-array.litmus
@@ -1,0 +1,15 @@
+ASL enum-arrays
+{}
+type Enum of enumeration {A, B, C};
+type Arr of array[Enum] of integer;
+func main () => integer
+begin
+  var arr: Arr;
+  println(arr);
+  arr[[A]] = 32;
+  arr[[B]] = 64;
+  arr[[C]] = 128;
+  assert 2 * arr[[A]] + arr[[B]] == arr[[C]];
+  println(arr);
+  return 0;
+end;

--- a/herd/tests/instructions/ASL/enum-array.litmus.expected
+++ b/herd/tests/instructions/ASL/enum-array.litmus.expected
@@ -1,0 +1,10 @@
+{A:0,B:0,C:0,}
+{A:32,B:64,C:128,}
+Test enum-arrays Required
+States 1
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (true)
+Observation enum-arrays Always 1 0
+Hash=be5ae986ade4b6f6e1a9fc497ec9008a

--- a/herd/tests/instructions/ASL/enum-array.litmus.expected
+++ b/herd/tests/instructions/ASL/enum-array.litmus.expected
@@ -2,9 +2,11 @@
 {A:32,B:64,C:128,}
 Test enum-arrays Required
 States 1
+
 Ok
 Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation enum-arrays Always 1 0
 Hash=be5ae986ade4b6f6e1a9fc497ec9008a
+

--- a/lib/AArch64ASLValue.ml
+++ b/lib/AArch64ASLValue.ml
@@ -27,6 +27,7 @@ end) : Value.AArch64ASL = struct
       | S_BitVector bv -> S_Int (Asllib.Bitvector.printable  bv)
       | S_Bool b -> S_Int (if b then Z.one else Z.zero)
       | S_Int i -> S_Int (printable_z i)
+      | S_Label _ as s -> s
   end
   module AArch64Cst = SymbConstant.Make (ASLScalar) (AArch64PteVal) (AArch64I)
   module AArch64Op = AArch64Op.Make(ASLScalar)(ASLOp)


### PR DESCRIPTION
This PR aims to represent enumeration labels without relying on an underlying integer.
More specifically, it represents arrays where the index type is an enumeration (an _enumerated array_) in the dynamic semantics via records where each field corresponds to a label of the corresponding enumerated type.
For example
```
type Color of enumeration {RED, GREEN, BLUE};
type ColorWeights of array[Color] of real;
func main() => integer
begin
  var weight : ColorWeights;
  weight[[RED]] = 5.0;
  let rw = weight[[RED]];
  print(rw);
  return 0;
end;
```
should print 5.0.

To achieve this, the typed AST is extended with the following:
* `E_EnumArray`, which is used to construct of an enumerated array. In our example, the dynamic semantics will construct a record for the fields `RED`, `GREEN`, and `BLUE`, each initialized with the base value for a real, 0.0.
* `E_GetEnumArray`, which is used to read from an enumerated array. In our example, this will be used for the right-hand side of `let rw = weight[[RED]`.
* `LE_SetEnumArray`, which is used to write to an enumerated array. In our example, this will be used for the left-hand side of `weight[[RED]] = 5.0`.

- [x] Implemented changes explained above.
- [x] Tests for `ARBITRARY` of enumeration types and enuemrated array types.
- [x] Document changes in the ASL Reference.