### PR TITLE
[ci] Add the "dispatch" property to the run-litmus action

### DIFF
--- a/.github/workflows/run-litmus-x86_64.yml
+++ b/.github/workflows/run-litmus-x86_64.yml
@@ -3,6 +3,7 @@ name: Run Litmus X86_64
 on:
   schedule:
     - cron: '0 10 * * 0'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Small change, useful, useful when something went wrong for the scheduled action.