### PR TITLE
[doc] Capturing convention about 'fault' predicate

### DIFF
--- a/catalogue/aarch64-faults/README.md
+++ b/catalogue/aarch64-faults/README.md
@@ -31,3 +31,31 @@ in the folder `${KUT_DIR}`:
     % sh ./litmus/run.sh
 
 > **_NOTE:_** litmus7 does not support MTE and, consequently, cannot run the test LDRredF.
+
+Support for fault atoms in herd7 and litmus7
+--------------------------------------------
+
+The syntax for the fault atom is `fault(<Pn>:<label>, <location>, <fault_type>)`.
+The components of the syntax are defined as follows:
+
+| Component      | Mandatory | Description                                                                             |
+|----------------|-----------|-----------------------------------------------------------------------------------------|
+| `<Pn>`         | Yes       | The processor or thread identifier. Represents the context in which the fault occurred. |
+| `<label>`      | No        | A label associated with the fault, indicating where the fault has occurred.             |
+| `<location>`   | No        | The memory address or resource where the fault occurred.                                |
+| `<fault_type>` | No        | The type of fault encountered as defined below.                                         |
+
+Currently, herdtools7 supports the following types of faults:
+
+    - `MMU:Translation` fault, illustrated by 3faults.litmus test.
+    - `MMU:AccessFlag` fault, illustrated by 3faults.litmus and LDRaf0F.litmus tests.
+    - `MMU:Permission` fault, illustrated by STRdb0F.litmus.
+    - `TagCheck` fault, illustrated by LDRredF.litmus test. Not applicable to litmus7.
+    - `UndefinedInstruction`, illustrated by UDF.litmus and noUDF.litmus tests.
+    - `SupervisorCall`, illustrated by SVC.litmus test.
+
+The litmus tests above follow the convention that the `fault()` predicate
+inquires about the instruction that caused the fault rather than the instruction
+to which the program returns after exiting the fault handler. This difference
+is only relevant for the SVC instruction, where the return address is the next
+instruction after SVC.

--- a/catalogue/aarch64-faults/tests/SVC.litmus
+++ b/catalogue/aarch64-faults/tests/SVC.litmus
@@ -1,0 +1,9 @@
+AArch64 SVC
+Variant=fatal
+{
+}
+ P0         ;
+L0:         ;
+    SVC #0  ;
+L1:         ;
+forall(Fault(P0:L0,SupervisorCall))


### PR DESCRIPTION
When introducing the SVC instruction, as part of the following commit: https://github.com/herd/herdtools7/commit/62b1036808b0e0ce4d6ad306ba55b1b635d1fa6c, it became apparent that there is a significant difference between checking the address or label of the instruction that caused the fault and the return address of the fault. This distinction emerged since SVC handler returns to the instruction after the SVC, unlike most instructions which return to the instruction that caused the fault.