### PR TITLE
[asl] Fix unary operator precedence for ASL0

### DIFF
--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -223,7 +223,7 @@
 %left PLUS MINUS EOR AND OR
 %left STAR SLASH MOD LT_LT GT_GT DIV
 %left CARET
-%nonassoc BANG NOT
+%nonassoc UNOPS
 %left LBRACK
 %left DOT
 
@@ -368,7 +368,7 @@ let binop_expr(e, b) ==
         { AST.E_Call { name; args; params; call_type = ST_Function } }
       | name=qualident; params=braced(clist(expr)); args=pared(clist(expr));
         { AST.E_Call { name; args; params; call_type = ST_Function } }
-      | ~=unop; ~=e;                                  < AST.E_Unop      >
+      | ~=unop; ~=e;                                  < AST.E_Unop      > %prec UNOPS
       | e1=e; op=b; e2=e;                             { AST.E_Binop (op, e1, e2) }
       | ~=pared(nnclist(expr));                       < AST.E_Tuple     >
       | IF; c=expr; THEN; e=expr; ~=e_else;           < AST.E_Cond      >


### PR DESCRIPTION
@acjf3 found some unexpected behaviour with unary operator precedence in ASL0. In particular, for the following example of concrete syntax:
```
- 1 MOD 2
- 1 * 2
```

Running `aslref --print` gives:
```
- (1 MOD 2)
- (1 * 2)
```

This is not consistent with ASL1's precedence, and seems unexpected given the concrete syntax.
This PR ensures the above becomes:
```
(- 1) MOD 2
(- 1) * 2
```