### PR TITLE
[asl][reference] Fix minor bugs in grammar spec

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -372,7 +372,7 @@
 \newcommand\Tdot[0]{\verbatimterminal{DOT}{.}}
 \newcommand\Tdownto[0]{\verbatimterminal{DOWNTO}{downto}}
 \newcommand\Telse[0]{\verbatimterminal{ELSE}{else}}
-\newcommand\Telseif[0]{\verbatimterminal{ELSIF}{elseif}}
+\newcommand\Telseif[0]{\verbatimterminal{ELSIF}{elsif}}
 \newcommand\Tend[0]{\verbatimterminal{END}{end}}
 \newcommand\Tenumeration[0]{\verbatimterminal{ENUMERATION}{enumeration}}
 \newcommand\Txor[0]{\verbatimterminal{XOR}{XOR}}
@@ -797,7 +797,7 @@
 \newcommand\buildcaseotherwise[0]{\hyperlink{build-caseotherwise}{\textfunc{build\_case\_otherwise}}}
 \newcommand\buildotherwiseopt[0]{\hyperlink{build-otherwiseopt}{\textfunc{build\_otherwise\_opt}}}
 \newcommand\buildcatcher[0]{\hyperlink{build-catcher}{\textfunc{build\_catcher}}}
-\newcommand\buildasty[0]{\textfunc{build\_as\_ty}}
+\newcommand\buildasty[0]{\hyperlink{build-as-ty}{\textfunc{build\_as\_ty}}}
 \newcommand\buildignoredoridentifier[0]{\hyperlink{build-ignoredoridentifier}{\textfunc{build\_ignored\_or\_identifier}}}
 \newcommand\buildlocaldeclkeyword[0]{\hyperlink{build-localdeclkeyword}{\textfunc{build\_local\_decl\_keyword\_non\_var}}}
 \newcommand\buildstmtlist[0]{\hyperlink{build-stmtlist}{\textfunc{build\_stmt\_list}}}

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -66,9 +66,9 @@ from the perspective of the semantics of local storage elements, they are all tr
 \section{Syntax\label{sec:LocalStorageDeclarationsSyntax}}
 Declaring a local storage element is done via the following grammar rules:
 \begin{flalign*}
-\Nstmt \derives \ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Clisttwo{\Tidentifier} \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon &\\
+\Nstmt \derives \ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nasty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nasty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Clisttwo{\Tidentifier} \parsesep \Nasty \parsesep \Tsemicolon &\\
 \end{flalign*}
 
 \begin{flalign*}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -387,9 +387,9 @@ As given by applying the relevant rules to the desugared AST.
 \section{Declaration Statements\label{sec:DeclarationStatements}}
 \subsection{Syntax}
 \begin{flalign*}
-\Nstmt \derives \ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Clisttwo{\Tidentifier} \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon &\\
+\Nstmt \derives \ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nasty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nasty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Clisttwo{\Tidentifier} \parsesep \Nasty \parsesep \Tsemicolon &\\
 \end{flalign*}
 
 \subsection{Abstract Syntax}
@@ -400,11 +400,11 @@ As given by applying the relevant rules to the desugared AST.
 \subsubsection{ASTRule.SDecl}
 \begin{mathpar}
 \inferrule[let\_constant]{
-  \buildoption[\buildty](\vt) \astarrow \astversion{\vt}
+  \buildoption[\buildasty](\vt) \astarrow \astversion{\vt}
 }{
   {
   \begin{array}{r}
-  \buildstmt(\overname{\Nstmt(\Nlocaldeclkeyword, \Ndeclitem, \namednode{\vt}{\option{\Nty}}, \Teq, \punnode{\Nexpr}, \Tsemicolon)}{\vparsednode})
+  \buildstmt(\overname{\Nstmt(\Nlocaldeclkeyword, \Ndeclitem, \namednode{\vt}{\option{\Nasty}}, \Teq, \punnode{\Nexpr}, \Tsemicolon)}{\vparsednode})
   \astarrow\\
   \overname{\SDecl(\astof{\vlocaldeclkeyword}, \astof{\vdeclitem}, \astversion{\vt}, \langle\astof{\vexpr}\rangle)}{\vastnode}
   \end{array}
@@ -414,12 +414,12 @@ As given by applying the relevant rules to the desugared AST.
 
 \begin{mathpar}
 \inferrule[var]{
-  \buildoption[\buildty](\vt) \astarrow \astversion{\vt} \\
+  \buildoption[\buildasty](\vt) \astarrow \astversion{\vt} \\
   \buildoption[\buildexpr](\ve) \astarrow \astversion{\ve}
 }{
   {
     \begin{array}{r}
-  \buildstmt(\overname{\Nstmt(\Tvar, \Ndeclitem, \namednode{\vt}{\option{\Nty}}, \namednode{\ve}{\option{\Teq, \Nexpr}}, \Tsemicolon)}{\vparsednode})
+  \buildstmt(\overname{\Nstmt(\Tvar, \Ndeclitem, \namednode{\vt}{\option{\Nasty}}, \namednode{\ve}{\option{\Teq, \Nexpr}}, \Tsemicolon)}{\vparsednode})
   \astarrow \\
   \overname{\SDecl(\LDKVar, \astof{\vdeclitem}, \astversion{\vt}, \astversion{\ve})}{\vastnode}
 \end{array}
@@ -430,10 +430,11 @@ As given by applying the relevant rules to the desugared AST.
 \begin{mathpar}
 \inferrule[multi\_var]{
   \buildclist[\buildidentity](\vids) \astarrow \astversion{\vids}\\
-  \vstmts \eqdef [\vx\in\astversion{\vids}: \SDecl(\LDKVar, \vx, \langle\astof{\tty}\rangle, \None)]\\
+  \buildasty(\vt) \astarrow \astversion{\vt} \\
+  \vstmts \eqdef [\vx\in\astversion{\vids}: \SDecl(\LDKVar, \vx, \astversion{\vt}, \None)]\\
   \stmtfromlist(\vstmts) \astarrow \vastnode
 }{
-  \buildstmt(\overname{\Nstmt(\Tvar, \namednode{\vids}{\Clisttwo{\Tidentifier}}, \Tcolon, \punnode{\Nty}, \Tsemicolon)}{\vparsednode})
+  \buildstmt(\overname{\Nstmt(\Tvar, \namednode{\vids}{\Clisttwo{\Tidentifier}}, \namednode{\vt}{\Nasty}, \Tsemicolon)}{\vparsednode})
   \astarrow
   \vastnode
 }
@@ -1149,8 +1150,8 @@ All of the following apply:
 \begin{flalign*}
 \Nstmt \derives \ & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nstmtlist \parsesep \Nselse \parsesep \Tend \parsesep \Tsemicolon &\\
 \Nselse \derives\ & \Telseif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nstmtlist \parsesep \Nselse &\\
-        |\ & \Tpass &\\
-        |\ & \Telse \parsesep \Nstmtlist &
+        |\ & \Telse \parsesep \Nstmtlist &\\
+        |\ & \emptysentence &
 \end{flalign*}
 
 \subsection{Abstract Syntax}
@@ -1192,7 +1193,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[pass]{}{
-  \buildselse(\Nselse(\Tpass)) \astarrow \overname{\SPass}{\vastnode}
+  \buildselse(\Nselse(\emptysentence)) \astarrow \overname{\SPass}{\vastnode}
 }
 \end{mathpar}
 

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -400,18 +400,19 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 |\ & \Ttry \parsesep \Nstmtlist \parsesep \Tcatch \parsesep \nonemptylist{\Ncatcher} \parsesep \Notherwiseopt \parsesep \Tend \parsesep \Tsemicolon &\\
 |\ & \Tpass \parsesep \Tsemicolon &\\
 |\ & \Treturn \parsesep \option{\Nexpr} \parsesep \Tsemicolon &\\
-|\ & \Ncall &\\
+|\ & \Ncall \parsesep \Tsemicolon &\\
 |\ & \Tassert \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nasty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Nlexpr \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Ncall \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Ncall \parsesep \Tdot \parsesep \Tidentifier \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Ncall \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clisttwo{{\Tidentifier}} \parsesep \Trbracket \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Nasty \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Clisttwo{\Tidentifier} \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nasty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Clisttwo{\Tidentifier} \parsesep \Nasty \parsesep \Tsemicolon &\\
 |\ & \Tvar \parsesep \Ndeclitem \parsesep \Nasty \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
 |\ & \Tprint \parsesep \Plist{\Nexpr} \parsesep \Tsemicolon &\\
+|\ & \Tprintln \parsesep \Plist{\Nexpr} \parsesep \Tsemicolon &\\
 |\ & \Tunreachable \parsesep \Tlpar \parsesep \Trpar \parsesep \Tsemicolon &\\
 |\ & \Trepeat \parsesep \Nstmtlist \parsesep \Tuntil \parsesep \Nexpr \parsesep \Nlooplimit \parsesep \Tsemicolon &\\
 |\ & \Tthrow \parsesep \Nexpr \parsesep \Tsemicolon &\\
@@ -427,8 +428,8 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \hypertarget{def-nselse}{}
 \begin{flalign*}
 \Nselse \derives\ & \Telseif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nstmtlist \parsesep \Nselse &\\
-|\ & \Tpass &\\
-|\ & \Telse \parsesep \Nstmtlist &
+|\ & \Telse \parsesep \Nstmtlist &\\
+|\ & \emptysentence &
 \end{flalign*}
 
 \hypertarget{def-nlexpr}{}

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -26,13 +26,16 @@ All types are represented as ASTs derived from the AST non-terminal $\ty$.
 The function
 \[
   \buildty(\overname{\parsenode{\Nty}}{\vparsednode}) \;\aslto\; \overname{\ty}{\vastnode}
+  \cup \overname{\TBuildError}{\BuildErrorConfig}
 \]
 transforms an anonymous type parse node $\vparsednode$ into a type AST node $\vastnode$.
+\ProseOtherwiseBuildError
 
 \hypertarget{build-as-ty}{}
 The function
 \[
   \buildasty(\overname{\parsenode{\Nasty}}{\vparsednode}) \;\aslto\; \overname{\ty}{\vastnode}
+  \cup \overname{\TBuildError}{\BuildErrorConfig}
 \]
 transforms a type annotation parse node $\vparsednode$ into a type AST node $\vastnode$.
 \ProseOtherwiseBuildError
@@ -51,8 +54,10 @@ Formally:
 The function
 \[
   \buildtydecl(\overname{\parsenode{\Ntydecl}}{\vparsednode}) \;\aslto\; \overname{\ty}{\vastnode}
+  \cup \overname{\TBuildError}{\BuildErrorConfig}
 \]
 transforms a \namedtype\ parse node $\vparsednode$ into an AST node $\vastnode$.
+\ProseOtherwiseBuildError
 
 \hypertarget{def-annotatetype}{}
 The function

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -29,6 +29,24 @@ The function
 \]
 transforms an anonymous type parse node $\vparsednode$ into a type AST node $\vastnode$.
 
+\hypertarget{build-as-ty}{}
+The function
+\[
+  \buildasty(\overname{\parsenode{\Nasty}}{\vparsednode}) \;\aslto\; \overname{\ty}{\vastnode}
+\]
+transforms a type annotation parse node $\vparsednode$ into a type AST node $\vastnode$.
+\ProseOtherwiseBuildError
+
+Formally:
+
+\begin{mathpar}
+\inferrule{
+  \buildty(\vt) \astarrow \astversion{\vt}
+} {
+  \buildasty(\Tcolon, \namednode{\vt}{\Nty}) \astarrow \astversion{\vt}
+}
+\end{mathpar}
+
 \hypertarget{build-tydecl}{}
 The function
 \[


### PR DESCRIPTION
This PR fixes the following:
 * Rename the `elseif` terminal to `elsif`
 * Add a semicolon after a statement function call (`call` -> `call ;`)
 * Correct a few instances where `\Nty` was used instead of `\Nasty` (missing `:`)
 * Defined `build_as_ty` which was used in `opt_typed_identifier` but never described. Also modified the formal descriptions of the above rules to use it instead of `build_ty`
 * Correct the statement no-else case - it should be empty, not `pass`
