### PR TITLE
Pointer authentication code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,19 @@ test-bnfc:
 	dune build @bnfc_test
 	@ echo "BNFC tests: OK"
 
+test:: test.pac
+test-local:: test.pac
+test.pac::
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/AArch64.PAC \
+		-conf ./herd/tests/instructions/AArch64.PAC/pac.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64 PAC instructions tests: OK"
+
+
 ### CATALOGUE testing, catalogue must be here
 CATATEST := $(shell if test -d catalogue; then echo cata-test; fi)
 

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -121,6 +121,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_NEG_SV _ | I_OP3_SV _ | I_MOVPRFX _
     | I_SMSTART _ | I_SMSTOP _ | I_LD1SPT _ | I_ST1SPT _
     | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
+    | I_PAC _ | I_AUT _ | I_XPACI _ | I_XPACD _
       -> true
 
     let is_cmodx_restricted_value =
@@ -322,6 +323,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
       | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
       | I_SMSTART _ | I_SMSTOP _ | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
+      | I_PAC _ | I_AUT _ | I_XPACI _ | I_XPACD _
           -> None
 
     let all_regs =
@@ -434,7 +436,10 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_CASP _
         ->
          all_regs (* safe approximation *)
- 
+      | I_PAC (_, r, _) | I_AUT (_, r, _) | I_XPACI r | I_XPACD r
+        ->
+          [r]
+
     let get_lx_sz = function
       | I_LDAR (var,(XX|AX),_,_)|I_LDXP (var,_,_,_,_) -> MachSize.Ld (tr_variant var)
       | I_LDARBH (bh,(XX|AX),_,_) -> MachSize.Ld (bh_to_sz bh)
@@ -484,6 +489,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_SMSTART _ | I_SMSTOP _
       | I_LD1SPT _ | I_ST1SPT _
       | I_MOVA_TV _| I_MOVA_VT _ | I_ADDA _
+      | I_PAC _ | I_AUT _ | I_XPACI _ | I_XPACD _
         -> MachSize.No
 
     let reg_defaults =

--- a/herd/CParseTest.ml
+++ b/herd/CParseTest.ml
@@ -20,7 +20,12 @@
   end
   module ArchConfig = SemExtra.ConfigToArchConfig(Conf)
 
-  module MakeRun (CValue:Value.S with module Cst.Instr=CBase.Instr and type arch_op = CBase.arch_op) = struct
+  module
+    MakeRun
+      (CValue:Value.S with
+        module Cst.Instr=CBase.Instr
+        and type arch_extra_op = CBase.arch_extra_op
+        and type 'a arch_constr_op = 'a CBase.arch_constr_op) = struct
       module CS = CSem.Make(Conf)(CValue)
       module CM = CMem.Make(ModelConfig)(CS)
       module C = CArch_herd.Make(ArchConfig)(CValue)
@@ -41,7 +46,7 @@
       end
       module P = CGenParser_lib.Make (Conf) (C) (CLexParse)
       module X = RunTest.Make (CS) (P) (CM) (Conf)
-  end     
+  end
 
    let run =
      if Conf.variant Variant.S128 then

--- a/herd/CSem.ml
+++ b/herd/CSem.ml
@@ -20,9 +20,10 @@ end
 module
   Make
     (Conf:Config)
-    (V:Value.S with type Cst.Instr.t = CBase.instruction and type arch_op = CBase.arch_op)
-    =
-  struct
+    (V:Value.S with
+      type Cst.Instr.t = CBase.instruction
+      and type arch_extra_op = CBase.arch_extra_op
+      and type 'a arch_constr_op = 'a CBase.arch_constr_op) = struct
     let unroll =
       match Conf.unroll with
       | None -> Opts.unroll_default `C

--- a/herd/JavaSem.ml
+++ b/herd/JavaSem.ml
@@ -19,7 +19,10 @@
 module
   Make
     (Conf:Sem.Config)
-    (V:Value.S with type Cst.Instr.t = JavaBase.instruction and type arch_op = JavaBase.arch_op) = struct
+    (V:Value.S with
+      type Cst.Instr.t = JavaBase.instruction
+      and type arch_extra_op = JavaBase.arch_extra_op
+      and type 'a arch_constr_op = 'a JavaBase.arch_constr_op) = struct
 
 	module Java = JavaArch_herd.Make(SemExtra.ConfigToArchConfig(Conf))(V)
 	module Act = JavaAction.Make(Java)
@@ -109,7 +112,7 @@ module
                 ((build_semantics_expr true dest ii) >>= fun v_dest ->
                     (M.mk_singleton_es
                     (Act.RMW (A.Location_global loc_vh,
-                      v_expect, v_dest, 
+                      v_expect, v_dest,
                             (match read_am , write_am with
                               | AccessModes.Acquire, AccessModes.Plain -> read_am
                               | AccessModes.Plain, AccessModes.Release -> write_am
@@ -172,7 +175,7 @@ module
             let ii = {ii with A.inst = hd; } in
             (build_semantics test ii) >>> fun (prog_order, _branch) ->
                 build_semantics_list test tl {ii with A.program_order_index = prog_order;}
-    
+
     let spurious_setaf _ = assert false
 
     end

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -648,7 +648,8 @@ module Make(C:Config) (I:I) : S with module I = I
                     { Constant.name=s ;
                       tag=tag ;
                       cap=cap ;
-                      offset=i*nbytes} in
+                      offset=i*nbytes;
+                      pac=PAC.canonical} in
                   of_symbolic_data sym_data,(TestType.Ty array_prim,I.V.cstToV v))
                 vs in
               List.fold_left

--- a/herd/debug_herd.ml
+++ b/herd/debug_herd.ml
@@ -29,6 +29,7 @@ type t = {
     mixed : bool ;
     files : bool ;
     timeout : bool ;
+    pac : bool ;
     profile_cat: bool ;
     profile_asl: bool ;
     exc : bool ;
@@ -48,6 +49,7 @@ let tags =
   "mixed";
   "files";
   "timeout";
+  "pac";
   "profile_cat";
   "profile_asl";
   "exception";
@@ -67,6 +69,7 @@ let none =
    mixed = false ;
    files = false ;
    timeout = false ;
+   pac = false;
    profile_cat = false;
    profile_asl = false;
    exc = false ;
@@ -85,6 +88,7 @@ let parse t tag = match tag with
   | "mixed" -> Some { t with mixed = true ;}
   | "files"|"file" -> Some { t with files = true ;}
   | "timeout" -> Some { t with timeout = true ;}
+  | "pac" -> Some { t with pac = true }
   | "exception"|"exc" -> Some { t with exc = true ;}
   | "profile_cat" -> Some { t with profile_cat = true }
   | "profile_asl" -> Some { t with profile_asl = true }

--- a/herd/debug_herd.mli
+++ b/herd/debug_herd.mli
@@ -29,6 +29,7 @@ type t = {
   mixed : bool ;
   files : bool ;
   timeout : bool ;
+  pac : bool ;
   profile_cat: bool ;
   profile_asl: bool ;
   exc : bool ;  }

--- a/herd/event.ml
+++ b/herd/event.ml
@@ -523,6 +523,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
     let memtag = C.variant Variant.MemTag
     let kvm = C.variant Variant.VMSA
     let is_branching = kvm && not (C.variant Variant.NoPteBranch)
+    let pac = C.variant Variant.Pac
     let is_po_partial = A.arch = `ASL
     type eiid = int
     type subid = int
@@ -1834,7 +1835,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
              [rloc.intra_causality_control;
               rmem.intra_causality_control;rreg.intra_causality_control;
               wmem.intra_causality_control;wreg.intra_causality_control;];
-           if memtag || (physical && is_branching) then
+           if memtag || pac || (physical && is_branching) then
  (* Notice similarity with data composition.  *)
              EventRel.cartesian
                (get_ctrl_output_commits rloc)
@@ -2393,7 +2394,7 @@ module Make  (C:Config) (AI:Arch_herd.S) (Act:Action.S with module A = AI) :
               wm.intra_causality_control])
           (let output_br = get_ctrl_output br in
            EventRel.union4
-             (if is_branching && is_phy then
+             (if pac || (is_branching && is_phy) then
                 EventRel.cartesian (get_ctrl_output_commits rn)
                   (EventSet.union input_rm input_wm)
               else EventRel.empty)

--- a/herd/tests/instructions/AArch64.PAC/A01.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A01.litmus
@@ -1,0 +1,10 @@
+AArch64 A01
+Variant=pac,fpac,const-pac-field
+
+{ 0:x0=x; int64_t 0:x1=0 }
+
+P0            ;
+  pacdza x0   ;
+  ldr x1,[x0] ;
+forall
+  ( Fault(P0, MMU:Translation) )

--- a/herd/tests/instructions/AArch64.PAC/A01.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A01.litmus.expected
@@ -1,0 +1,10 @@
+Test A01 Required
+States 1
+ Fault(P0,x,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0,MMU:Translation))
+Observation A01 Always 1 0
+Hash=6f3c6346b0ce9b0aca45d8f32f70d21c
+

--- a/herd/tests/instructions/AArch64.PAC/A02.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A02.litmus
@@ -1,0 +1,10 @@
+AArch64 A02
+Variant=pac,fpac,const-pac-field
+
+{ 0:x0=x; int64_t 0:x1=0 }
+
+P0            ;
+  pacdza x0   ;
+  str x1,[x0] ;
+forall
+  ( Fault(P0, MMU:Translation) )

--- a/herd/tests/instructions/AArch64.PAC/A02.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A02.litmus.expected
@@ -1,0 +1,10 @@
+Test A02 Required
+States 1
+ Fault(P0,x,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0,MMU:Translation))
+Observation A02 Always 1 0
+Hash=8f48e77efae479af335941f65a8a3a2e
+

--- a/herd/tests/instructions/AArch64.PAC/A03.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A03.litmus
@@ -1,0 +1,10 @@
+AArch64 A03
+Variant=pac,fpac,const-pac-field
+
+{ 0:x0=x; int64_t 0:x1=0 }
+
+P0            ;
+  pacdza x0   ;
+  swp x1, x1,[x0] ;
+forall
+  ( Fault(P0, MMU:Translation) )

--- a/herd/tests/instructions/AArch64.PAC/A03.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A03.litmus.expected
@@ -1,0 +1,10 @@
+Test A03 Required
+States 1
+ Fault(P0,x,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0,MMU:Translation))
+Observation A03 Always 1 0
+Hash=a40b38ec0e041533626da99c9b006ae0
+

--- a/herd/tests/instructions/AArch64.PAC/A04.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A04.litmus
@@ -1,0 +1,10 @@
+AArch64 A04
+Variant=pac,fpac,const-pac-field
+
+{ 0:x0=x; int64_t 0:x1=0; int64_t x=0; int64_t 0:x2=42 }
+
+P0                 ;
+  pacdza x0        ;
+  cas x1, x2, [x0] ;
+forall
+  ( Fault(P0, MMU:Translation) )

--- a/herd/tests/instructions/AArch64.PAC/A04.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A04.litmus.expected
@@ -1,0 +1,10 @@
+Test A04 Required
+States 1
+ Fault(P0,x,MMU:Translation);
+Ok
+Witnesses
+Positive: 3 Negative: 0
+Condition forall (fault(P0,MMU:Translation))
+Observation A04 Always 3 0
+Hash=5b3f0aae55a8e35f7f951827036312fc
+

--- a/herd/tests/instructions/AArch64.PAC/A05.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A05.litmus
@@ -1,0 +1,10 @@
+AArch64 A05
+Variant=pac,fpac
+
+{ 0:x0=x }
+
+P0                 ;
+  pacdza x0        ;
+  autdzb x0        ;
+forall
+  ( Fault(P0, PacCheck:DB) )

--- a/herd/tests/instructions/AArch64.PAC/A05.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A05.litmus.expected
@@ -1,0 +1,10 @@
+Test A05 Required
+States 1
+ Fault(P0,PacCheck:DB);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0,PacCheck:DB))
+Observation A05 Always 1 0
+Hash=efa569ed78eba108ea8f24f8428c8a0c
+

--- a/herd/tests/instructions/AArch64.PAC/A06.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A06.litmus
@@ -1,0 +1,9 @@
+AArch64 A06
+Variant=pac
+
+{ 0:x0=x }
+
+P0                 ;
+  autdza x0        ;
+forall
+  ( ~Fault(P0) /\ 0:x0=x )

--- a/herd/tests/instructions/AArch64.PAC/A06.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A06.litmus.expected
@@ -1,0 +1,10 @@
+Test A06 Required
+States 1
+0:X0=x;  ~Fault(P0);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (not (fault(P0)) /\ 0:X0=x)
+Observation A06 Always 1 0
+Hash=44a5d20520bdadd90a158d8352318da5
+

--- a/herd/tests/instructions/AArch64.PAC/A07.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A07.litmus
@@ -1,0 +1,10 @@
+AArch64 A07
+Variant=pac
+
+{ 0:x0=x; int64_t 0:x1=42 }
+
+P0            ;
+  pacda x0,x1 ;
+  autda x0,x1 ;
+forall
+  ( ~Fault(P0) /\ 0:x0=x )

--- a/herd/tests/instructions/AArch64.PAC/A07.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A07.litmus.expected
@@ -1,0 +1,10 @@
+Test A07 Required
+States 1
+0:X0=x;  ~Fault(P0);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (not (fault(P0)) /\ 0:X0=x)
+Observation A07 Always 1 0
+Hash=dc84365f505f54790af74111bd1fa0a7
+

--- a/herd/tests/instructions/AArch64.PAC/A08.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A08.litmus
@@ -1,0 +1,8 @@
+AArch64 A08
+Variant=pac
+
+{ 0:x0=x; int64_t 0:x1=42 }
+
+P0            ;
+  pacda x0,x1 ;
+  pacda x0,x1 ;

--- a/herd/tests/instructions/AArch64.PAC/A08.litmus.expected-failure
+++ b/herd/tests/instructions/AArch64.PAC/A08.litmus.expected-failure
@@ -1,0 +1,1 @@
+Warning: File "./herd/tests/instructions/AArch64.PAC/A08.litmus": Illegal operation AddOnePac:DA on pacda(x, 0x2a, 0) and 42 (User error)

--- a/herd/tests/instructions/AArch64.PAC/A09.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A09.litmus
@@ -1,0 +1,10 @@
+AArch64 A09
+Variant=pac,const-pac-field
+
+{ 0:x0=x; int64_t 0:x1=42 }
+
+P0            ;
+  pacda x0,x1 ;
+  pacda x0,x1 ;
+forall
+  ( 0:x0=x )

--- a/herd/tests/instructions/AArch64.PAC/A09.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A09.litmus.expected
@@ -1,0 +1,10 @@
+Test A09 Required
+States 1
+0:X0=x;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=x)
+Observation A09 Always 1 0
+Hash=8e3687af3f4acc6df2f8218486e61ad2
+

--- a/herd/tests/instructions/AArch64.PAC/A10.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A10.litmus
@@ -1,0 +1,13 @@
+AArch64 A10
+Variant=pac,const-pac-field
+
+{ 0:x0=x; int64_t 0:x1=42; int64_t x = 53 }
+
+P0            ;
+  pacda x0,x1 ;
+  pacdzb x0   ;
+  autda x0,x1 ;
+  autdzb x0   ;
+  ldr x1,[x0] ;
+forall
+  ( 0:x1=53 )

--- a/herd/tests/instructions/AArch64.PAC/A10.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A10.litmus.expected
@@ -1,0 +1,10 @@
+Test A10 Required
+States 1
+0:X1=53;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=53)
+Observation A10 Always 1 0
+Hash=180175b47aae92c49d0142601e283543
+

--- a/herd/tests/instructions/AArch64.PAC/A11.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A11.litmus
@@ -1,0 +1,11 @@
+AArch64 A11
+Variant=pac
+
+{ 0:x0=x; int64_t 0:x1=42; int64_t x = 53; }
+
+P0            ;
+  pacda x0,x1 ;
+  xpacd x0    ;
+  ldr x1,[x0] ;
+forall
+  ( 0:x1=53 )

--- a/herd/tests/instructions/AArch64.PAC/A11.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A11.litmus.expected
@@ -1,0 +1,10 @@
+Test A11 Required
+States 1
+0:X1=53;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=53)
+Observation A11 Always 1 0
+Hash=402d1491077203c22dcbfa120090300a
+

--- a/herd/tests/instructions/AArch64.PAC/A12.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A12.litmus
@@ -1,0 +1,11 @@
+AArch64 A12
+Variant=pac
+
+{ 0:x0=x; int64_t 0:x1=42; int64_t x = 53; }
+
+P0            ;
+  pacia x0,x1 ;
+  xpacd x0    ;
+  ldr x1,[x0] ;
+forall
+  ( 0:x1=53 )

--- a/herd/tests/instructions/AArch64.PAC/A12.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A12.litmus.expected
@@ -1,0 +1,10 @@
+Test A12 Required
+States 1
+0:X1=53;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=53)
+Observation A12 Always 1 0
+Hash=cc4de507083bc36b4d82f02925b527b6
+

--- a/herd/tests/instructions/AArch64.PAC/A13.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A13.litmus
@@ -1,0 +1,12 @@
+AArch64 A13
+Variant=pac
+
+{ 0:x0=x }
+
+P0             ;
+  pacdza x0    ;
+  add x0,x0,#4 ;
+  autdza x0    ;
+  sub x0,x0,#4 ;
+  ldr x1,[x0]  ;
+forall (Fault(P0))

--- a/herd/tests/instructions/AArch64.PAC/A13.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A13.litmus.expected
@@ -1,0 +1,10 @@
+Test A13 Required
+States 1
+ Fault(P0,x,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0))
+Observation A13 Always 1 0
+Hash=62ce8eee649224132e8db35d8a135926
+

--- a/herd/tests/instructions/AArch64.PAC/A14.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A14.litmus
@@ -1,0 +1,9 @@
+AArch64 A14
+Variant=pac
+
+{ 0:x0=x }
+
+P0            ;
+  autdza x0   ;
+  ldr x1,[x0] ;
+forall (Fault(P0))

--- a/herd/tests/instructions/AArch64.PAC/A14.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A14.litmus.expected
@@ -1,0 +1,10 @@
+Test A14 Required
+States 1
+ Fault(P0,x,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0))
+Observation A14 Always 1 0
+Hash=8c780e41c667f762524255b6e643b85e
+

--- a/herd/tests/instructions/AArch64.PAC/A15.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A15.litmus
@@ -1,0 +1,9 @@
+AArch64 A15
+Variant=pac,fpac,const-pac-field
+
+{ 0:x0=x; int64_t x=42; int64_t 0:x1=0 }
+
+P0            ;
+  ldr x1,[x0] ;
+forall
+  ( ~Fault(P0, MMU:Translation) /\ 0:x1=42 )

--- a/herd/tests/instructions/AArch64.PAC/A15.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A15.litmus.expected
@@ -1,0 +1,10 @@
+Test A15 Required
+States 1
+0:X1=42;  ~Fault(P0,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (not (fault(P0,MMU:Translation)) /\ 0:X1=42)
+Observation A15 Always 1 0
+Hash=1cfeebc48d4f6b42e548bb0c8b6d859d
+

--- a/herd/tests/instructions/AArch64.PAC/A16.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A16.litmus
@@ -1,0 +1,9 @@
+AArch64 A16
+Variant=pac,fpac,const-pac-field
+
+{ 0:x0=x; int64_t x=42; int64_t 0:x1=43 }
+
+P0            ;
+  str x1,[x0] ;
+forall
+  ( ~Fault(P0, MMU:Translation) /\ [x]=43 )

--- a/herd/tests/instructions/AArch64.PAC/A16.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A16.litmus.expected
@@ -1,0 +1,10 @@
+Test A16 Required
+States 1
+[x]=43;  ~Fault(P0,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (not (fault(P0,MMU:Translation)) /\ [x]=43)
+Observation A16 Always 1 0
+Hash=17016a7da33e9b766baa2bed6b5ec3f0
+

--- a/herd/tests/instructions/AArch64.PAC/A17.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A17.litmus
@@ -1,0 +1,9 @@
+AArch64 A17
+Variant=pac,fpac,const-pac-field
+
+{ 0:x0=x; int64_t x=42; int64_t 0:x1=43; int64_t 0:x2=0 }
+
+P0            ;
+  swp x1,x2,[x0] ;
+forall
+  ( ~Fault(P0, MMU:Translation) /\ [x]=43 /\ 0:x1=43 /\ 0:x2=42 )

--- a/herd/tests/instructions/AArch64.PAC/A17.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A17.litmus.expected
@@ -1,0 +1,10 @@
+Test A17 Required
+States 1
+0:X1=43; 0:X2=42; [x]=43;  ~Fault(P0,MMU:Translation);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (not (fault(P0,MMU:Translation)) /\ [x]=43 /\ 0:X1=43 /\ 0:X2=42)
+Observation A17 Always 1 0
+Hash=555a7d903fa89c424c59b9e83e9bb322
+

--- a/herd/tests/instructions/AArch64.PAC/A18.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A18.litmus
@@ -1,0 +1,9 @@
+AArch64 A18
+Variant=pac,fpac,const-pac-field
+
+{ 0:x0=x; int64_t x=42; int64_t 0:x1=42; int64_t 0:x2=0 }
+
+P0               ;
+  cas x1,x2,[x0] ;
+forall
+  ( ~Fault(P0, MMU:Translation) /\ [x]=0 /\ 0:x1=42 /\ 0:x2=0 )

--- a/herd/tests/instructions/AArch64.PAC/A18.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A18.litmus.expected
@@ -1,0 +1,10 @@
+Test A18 Required
+States 1
+0:X1=42; 0:X2=0; [x]=0;  ~Fault(P0,MMU:Translation);
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (not (fault(P0,MMU:Translation)) /\ [x]=0 /\ 0:X1=42 /\ 0:X2=0)
+Observation A18 Always 2 0
+Hash=dbf06243b88a0f72983f9d347b6ab39c
+

--- a/herd/tests/instructions/AArch64.PAC/A19.litmus
+++ b/herd/tests/instructions/AArch64.PAC/A19.litmus
@@ -1,0 +1,9 @@
+AArch64 A19
+Variant=pac,fpac,const-pac-field
+
+{ 0:x0=x; int64_t x=42; int64_t 0:x1=43; int64_t 0:x2=0 }
+
+P0               ;
+  cas x1,x2,[x0] ;
+forall
+  ( ~Fault(P0, MMU:Translation) /\ [x]=42 /\ 0:x1=42 /\ 0:x2=0 )

--- a/herd/tests/instructions/AArch64.PAC/A19.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A19.litmus.expected
@@ -1,0 +1,10 @@
+Test A19 Required
+States 1
+0:X1=42; 0:X2=0; [x]=42;  ~Fault(P0,MMU:Translation);
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (not (fault(P0,MMU:Translation)) /\ [x]=42 /\ 0:X1=42 /\ 0:X2=0)
+Observation A19 Always 2 0
+Hash=8864b6cac41de226f37db2b6700f1e2c
+

--- a/herd/tests/instructions/AArch64.PAC/pac.cfg
+++ b/herd/tests/instructions/AArch64.PAC/pac.cfg
@@ -1,0 +1,1 @@
+variant pac

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -244,6 +244,13 @@ module Make(O:Config)(M:XXXMem.S) =
           | Some flag -> not (Flag.Set.mem (Flag.Flag flag) flags)
         then c
         else
+          let flts =
+            if O.debug.Debug_herd.pac then flts
+            else A.FaultSet.map
+              (A.map_fault (A.V.map_const Constant.make_canonical)) flts in
+          let st =
+            if O.debug.Debug_herd.pac then st
+            else A.map_state (A.V.map_const Constant.make_canonical) st in
           let st = A.map_state A.V.printable st in
           let fsc = st,flts in
           let ok = check fsc in

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -112,6 +112,12 @@ type t =
   | OldSolver
   (* Accept cyclic equation sets as being solvable *)
   | OOTA
+(* Pointer Authentication Code *)
+  | Pac
+(* Fault generation with Pointer authentication code *)
+  | FPac
+(* Allow to use pac(pac(...)) using the XOR of two pac fields *)
+  | ConstPacField
 
 let tags =
   ["success";"instr";"specialx0";"normw";"acqrelasfence";"backcompat";
@@ -122,7 +128,8 @@ let tags =
    "pte-squared"; "PhantomOnLoad"; "OptRfRMW"; "ConstrainedUnpredictable";
     "exp"; "self"; "cos-opt"; "test"; "T[0-9][0-9]"; "asl"; "strict";
     "warn"; "S128"; "ASLType+Warn";    "ASLType+Silence"; "ASLType+Check";
-    "ASL+Experimental"; "ASL+AArch64+UDF"; "telechat"; "OldSolver"; "oota";]
+    "ASL+Experimental"; "ASL+AArch64+UDF"; "telechat"; "OldSolver"; "oota";
+    "pac"; "fpac"; "const-pac-field";]
 
 let parse s = match Misc.lowercase s with
 | "success" -> Some Success
@@ -185,6 +192,9 @@ let parse s = match Misc.lowercase s with
 | "nv2" | "NV2" -> Some NV2
 | "oldsolver" -> Some OldSolver
 | "oota" -> Some OOTA
+| "pac" -> Some Pac
+| "const-pac-field" -> Some ConstPacField
+| "fpac" -> Some FPac
 | s ->
   let (>>=) o f = match o with
     | Some _ -> o
@@ -287,6 +297,9 @@ let pp = function
   | NV2 -> "NV2"
   | OldSolver -> "OldSolver"
   | OOTA -> "oota"
+  | Pac -> "pac"
+  | ConstPacField -> "const-pac-field"
+  | FPac -> "fpac"
 
 let compare = compare
 let equal v1 v2 = compare v1 v2 = 0

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -113,6 +113,13 @@ type t =
   | OldSolver
 (* Accept cyclic equation sets as being solvable *)
   | OOTA
+(* Pointer authentication code, represent the activation of the keys that we can
+   find in the system register `SCTLR_EL1.En*` *)
+  | Pac
+(* Fault generation with Pointer authentication code *)
+  | FPac
+(* Allow to use pac(pac(...)) using the XOR of two pac fields *)
+  | ConstPacField
 
 
 val compare : t -> t -> int

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -651,6 +651,21 @@ include Arch.MakeArch(struct
         conv_reg r1 >> fun r1 ->
         conv_reg r2 >! fun r2 ->
         I_STCT(r1,r2)
+    (* Pointer Authentication Core extension *)
+    | I_PAC (k, r1, r2) ->
+        conv_reg r1 >> fun r1 ->
+        conv_reg r2 >! fun r2 ->
+        I_PAC (k, r1, r2)
+    | I_AUT (k, r1, r2) ->
+        conv_reg r1 >> fun r1 ->
+        conv_reg r2 >! fun r2 ->
+        I_AUT (k, r1, r2)
+    | I_XPACI r ->
+        conv_reg r >! fun r ->
+        I_XPACI(r)
+    | I_XPACD r ->
+        conv_reg r >! fun r ->
+        I_XPACD(r)
     (* Neon Extension *)
     | I_LD1 _ | I_LD1M _ | I_LD1R _ | I_LDAP1 _
     | I_LD2 _ | I_LD2M _ | I_LD2R _

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1709,6 +1709,64 @@ type 'k kinstruction =
   | I_STZ2G of reg * reg * 'k idx
   | I_LDG of reg * reg * 'k
   | I_UDF of 'k
+(* Pointer Authentication Code: Basic instruction only
+   See ARM Arm Issue K.a, C3.1.10 for the complete list of instructions
+    - First part: Add PAC to a register or SP, and and return the value in a
+    general purpose register
+*)
+  (* see ARM Arm Issue K.a, C6.2.266
+   * PACIA <Xd>, <Xn|Sp>
+   * PACIZA <Xd>, <X31>
+   * PACIASP <X30>, <Sp>
+   * PACIAZ <X30>, <X31>
+   * PACIA1716 <X17>, <X16>
+   *
+   * see ARM Arm Issue K.a, C6.2.267
+   * PACIB <Xd>, <Xn|Sp>
+   * PACIZA <Xd>, <X31>
+   * PACIBSP <X30>, <Sp>
+   * PACIBZ <X30>, <X31>
+   * PACIB1716 <X17>, <X16>
+   *
+   * see ARM Arm Issue K.a, C6.2.263
+   * PACDA <Xd>, <Xn|Sp>
+   * PACDZA <Xd>, <X31>
+   *
+   * see ARM Arm Issue K.a, C6.2.264
+   * PACDB <Xd>, <Xn|Sp>
+   * PACDZB <Xd>, <X31>
+   *)
+  | I_PAC of PAC.key * reg * reg     (* destination <- AddPACIA(source) *)
+
+(*  - Second part: check the PAC of a register *)
+  (* see ARM Arm Issue K.a, C6.2.23
+   * AUTIA <Xd>, <Xn|Sp>
+   * AUTIZA <Xd>, <X31>
+   * AUTIASP <X30>, <Sp>
+   * AUTIAZ <X30>, <X31>
+   * AUTIA1716 <X17>, <X16>
+   *
+   * see ARM Arm Issue K.a, C6.2.24
+   * AUTIB <Xd>, <Xn|Sp>
+   * AUTIZB <Xd>, <X31>
+   * AUTIBSP <X30>, <Sp>
+   * AUTIBZ <X30>, <X31>
+   * AUTIB1716 <X17>, <X16>
+   *
+   * see ARM Arm Issue K.a, C6.2.21
+   * AUTDA <Xd>, <Xn|Sp>
+   * AUTDZA <Xd>, <X31>
+   *
+   * see ARM Arm Issue K.a, C6.2.22
+   * AUTDB <Xd>, <Xn|Sp>
+   * AUTDZB <Xd>, <X31>
+   *)
+  | I_AUT of PAC.key * reg * reg (* destination <- AuthIA(source) *)
+
+(*  - Third part: strip the PAC of a register *)
+  (* | I_XPACLRI (* strip a PAC from LR *) *)
+  | I_XPACI of reg (* strip an instruction address PAC *)
+  | I_XPACD of reg (* strip a data address PAC *)
 
 type instruction = int kinstruction
 type parsedInstruction = MetaConst.k kinstruction
@@ -2412,6 +2470,15 @@ let do_pp_instruction m =
       pp_mem "LDG" V64 rt rn (K k)
   | I_UDF k ->
       sprintf "UDF %s" (m.pp_k k)
+  (* Pointer Authentication Code *)
+  | I_PAC (key, r1, r2) ->
+      sprintf "PAC%s %s, %s" (PAC.pp_upper_key key) (pp_reg r1) (pp_reg r2)
+  | I_AUT (key, r1, r2) ->
+      sprintf "AUT%s %s, %s" (PAC.pp_upper_key key) (pp_reg r1) (pp_reg r2)
+  | I_XPACI r ->
+      sprintf "XPACI %s" (pp_reg r)
+  | I_XPACD r ->
+      sprintf "XPACD %s" (pp_reg r)
 
 let m_int = { compat = false ; pp_k = string_of_int ;
               zerop = (function 0 -> true | _ -> false);
@@ -2588,6 +2655,11 @@ let fold_regs (f_regs,f_sregs) =
   | I_LD1SPT (_,r1,r2,_,r3,r4,idx)
   | I_ST1SPT (_,r1,r2,_,r3,r4,idx)
     -> fold_reg r1 (fold_reg r2 ( fold_reg r3 (fold_reg r4 (fold_idx idx c))))
+  | I_PAC (_, src, dst)
+  | I_AUT (_, src, dst)
+    -> fold_reg src (fold_reg dst c)
+  | I_XPACI r -> fold_reg r c
+  | I_XPACD r -> fold_reg r c
 
 let map_regs f_reg f_symb =
 
@@ -2835,7 +2907,7 @@ let map_regs f_reg f_symb =
       I_MOVA_TV (map_reg r1,map_reg r2,map_reg r3,map_reg r4,k)
   | I_ADDA (s,r1,r2,r3,r4) ->
       I_ADDA (s,map_reg r1,map_reg r2,map_reg r3,map_reg r4)
-  | I_SMSTART (Some(r)) -> 
+  | I_SMSTART (Some(r)) ->
       I_SMSTART (Some(map_reg r))
   | I_SMSTOP (Some(r)) ->
       I_SMSTOP (Some(map_reg r))
@@ -2960,6 +3032,15 @@ let map_regs f_reg f_symb =
       I_STZ2G (map_reg r1,map_reg r2,k)
   | I_LDG (r1,r2,k) ->
       I_LDG (map_reg r1,map_reg r2, k)
+  (* Pointer Authentication code *)
+  | I_PAC (key, r1, r2) ->
+      I_PAC (key, map_reg r1, map_reg r2)
+  | I_AUT (key, r1, r2) ->
+      I_AUT (key, map_reg r1, map_reg r2)
+  | I_XPACI r ->
+      I_XPACI (map_reg r)
+  | I_XPACD r ->
+      I_XPACD (map_reg r)
 
 (* No addresses burried in ARM code *)
 let fold_addrs _f c _ins = c
@@ -3065,6 +3146,8 @@ let get_next =
   | I_MOV_SV _ | I_ADD_SV _ | I_NEG_SV _ | I_OP3_SV _ | I_MOVPRFX _
   | I_LD1SPT _  | I_ST1SPT _ | I_SMSTART _ | I_SMSTOP _
   | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
+  | I_PAC _ | I_AUT _
+  | I_XPACI _ | I_XPACD _
     -> [Label.Next;]
 
 (* Check instruction validity, beyond parsing *)
@@ -3268,7 +3351,7 @@ let is_valid i =
      -> true
   | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _
      -> false
-  | I_ST1SP (v,_,_,_,ext) 
+  | I_ST1SP (v,_,_,_,ext)
   | I_LD1SP (v,_,_,_,ext) ->
      let open MemExt in
      begin match (v,ext) with
@@ -3447,6 +3530,8 @@ module PseudoI = struct
         | I_ADD_SV _ | I_INDEX_SS _
         | I_NEG_SV _ | I_OP3_SV _ | I_MOVPRFX _
         | I_SMSTART _ | I_SMSTOP _ | I_ADDA _
+        | I_PAC _ | I_AUT _
+        | I_XPACI _ | I_XPACD _
             as keep -> keep
         | I_LDR (v,r1,r2,idx) -> I_LDR (v,r1,r2,ext_tr idx)
         | I_LDRSW (r1,r2,idx) -> I_LDRSW (r1,r2,ext_tr idx)
@@ -3566,6 +3651,8 @@ module PseudoI = struct
         | I_LDUR_SIMD _ | I_LDAPUR_SIMD _
         | I_STUR_SIMD _ | I_STLUR_SIMD _
         | I_TLBI (_,_)
+        | I_XPACI _
+        | I_XPACD _
           -> 1
         | I_LDP _|I_LDPSW _|I_STP _|I_LDXP _|I_STXP _
         | I_CAS _ | I_CASBH _
@@ -3576,6 +3663,8 @@ module PseudoI = struct
         | I_LDP_SIMD _ | I_STP_SIMD _
         | I_LD2 _ | I_LD2R _
         | I_ST2 _
+        | I_PAC _
+        | I_AUT _
           -> 2
         | I_LD3 _ | I_LD3R _
         | I_ST3 _

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -145,6 +145,37 @@ match name with
 | "movi" | "MOVI" -> MOVI
 | "mvn" | "MVN" -> MVN
 | "fmov" | "FMOV" -> FMOV
+(* Pointer Authentication Code *)
+| "PACIA" | "pacia" -> PACIA
+| "PACIA1716" | "pacia1716" -> PACIA1716
+| "PACIAZ" | "paciaz" -> PACIAZ
+| "PACIZA" | "paciza" -> PACIZA
+| "PACIASP" | "paciasp" -> PACIASP
+| "PACIB" | "pacib" -> PACIB
+| "PACIB1716" | "pacib1716" -> PACIB1716
+| "PACIBZ" | "pacibz" -> PACIBZ
+| "PACIZB" | "pacizb" -> PACIZB
+| "PACIBSP" | "pacibsp" -> PACIBSP
+| "PACDA" | "pacda" -> PACDA
+| "PACDZA" | "pacdza" -> PACDZA
+| "PACDB" | "pacdb" -> PACDB
+| "PACDZB" | "pacdzb" -> PACDZB
+| "AUTIA" | "autia" -> AUTIA
+| "AUTIA1716" | "autia1716" -> AUTIA1716
+| "AUTIAZ" | "autiaz" -> AUTIAZ
+| "AUTIZA" | "autiza" -> AUTIZA
+| "AUTIASP" | "autiasp" -> AUTIASP
+| "AUTIB" | "autib" -> AUTIB
+| "AUTIB1716" | "autib1716" -> AUTIB1716
+| "AUTIBZ" | "autibz" -> AUTIBZ
+| "AUTIZB" | "autizb" -> AUTIZB
+| "AUTIBSP" | "autibsp" -> AUTIBSP
+| "AUTDA" | "autda" -> AUTDA
+| "AUTDZA" | "autdza" -> AUTDZA
+| "AUTDB" | "autdb" -> AUTDB
+| "AUTDZB" | "autdzb" -> AUTDZB
+| "XPACI" | "xpaci" -> XPACI
+| "XPACD" | "xpacd" -> XPACD
 (* Scalabel Vector Extension *)
 | "whilelt" | "WHILELT" -> WHILELT
 | "whilele" | "WHILELE" -> WHILELE

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -80,6 +80,13 @@ let check_op3 op e =
 /* Variable shift's */
 %token TOK_LSLV TOK_LSRV TOK_ASRV TOK_RORV
 
+/* Pointer Authentication Code Extension */
+%token PACIA PACIASP PACIA1716 PACIAZ PACIZA PACDA PACDZA
+%token PACIB PACIBSP PACIB1716 PACIBZ PACIZB PACDB PACDZB
+%token AUTIA AUTIASP AUTIA1716 AUTIAZ AUTIZA AUTDA AUTDZA
+%token AUTIB AUTIBSP AUTIB1716 AUTIBZ AUTIZB AUTDB AUTDZB
+%token XPACI XPACD
+
 /* Instructions */
 %token NOP HINT HLT
 %token TOK_B BR CBZ CBNZ TBZ TBNZ
@@ -1544,6 +1551,38 @@ instr:
   { I_TLBI ($2, ZR) }
 | TLBI TLBI_OP COMMA xreg
   { I_TLBI ($2, $4) }
+
+/* Pointer Authentication Code Extension */
+| PACIA1716 { I_PAC (PAC.IA, Ireg R17, Ireg R16) }
+| PACIASP { I_PAC (PAC.IA, Ireg R30, SP) }
+| PACIAZ { I_PAC (PAC.IA, Ireg R30, ZR) }
+| PACIA xreg COMMA xreg { I_PAC (PAC.IA, $2, $4) }
+| PACIZA xreg { I_PAC (PAC.IA, $2, ZR) }
+| PACDA xreg COMMA xreg { I_PAC (PAC.DA, $2, $4) }
+| PACDZA xreg { I_PAC (PAC.DA, $2, ZR) }
+| PACIB1716 { I_PAC (PAC.IB, Ireg R17, Ireg R16) }
+| PACIBSP { I_PAC (PAC.IB, Ireg R30, SP) }
+| PACIBZ { I_PAC (PAC.IB, Ireg R30, ZR) }
+| PACIB xreg COMMA xreg { I_PAC (PAC.IB, $2, $4) }
+| PACIZB xreg { I_PAC (PAC.IB, $2, ZR) }
+| PACDB xreg COMMA xreg { I_PAC (PAC.DB, $2, $4) }
+| PACDZB xreg { I_PAC (PAC.DB, $2, ZR) }
+| AUTIA1716 { I_AUT (PAC.IA, Ireg R17, Ireg R16) }
+| AUTIASP { I_AUT (PAC.IA, Ireg R30, SP) }
+| AUTIAZ { I_AUT (PAC.IA, Ireg R30, ZR) }
+| AUTIA xreg COMMA xreg { I_AUT (PAC.IA, $2, $4) }
+| AUTIZA xreg { I_AUT (PAC.IA, $2, ZR) }
+| AUTDA xreg COMMA xreg { I_AUT (PAC.DA, $2, $4) }
+| AUTDZA xreg { I_AUT (PAC.DA, $2, ZR) }
+| AUTIB1716 { I_AUT (PAC.IB, Ireg R17, Ireg R16) }
+| AUTIBSP { I_AUT (PAC.IB, Ireg R30, SP) }
+| AUTIBZ { I_AUT (PAC.IB, Ireg R30, ZR) }
+| AUTIB xreg COMMA xreg { I_AUT (PAC.IB, $2, $4) }
+| AUTIZB xreg { I_AUT (PAC.IB, $2, ZR) }
+| AUTDB xreg COMMA xreg { I_AUT (PAC.DB, $2, $4) }
+| AUTDZB xreg { I_AUT (PAC.DB, $2, ZR) }
+| XPACI xreg { I_XPACI $2 }
+| XPACD xreg { I_XPACD $2 }
 
 /* System register */
 | MRS xreg COMMA SYSREG

--- a/lib/ASLOp.ml
+++ b/lib/ASLOp.ml
@@ -31,12 +31,17 @@
 (* herdtools7 github repository.                                              *)
 (******************************************************************************)
 
-type op =
+(* No extra binary operation *)
+type extra_op
+
+type 'a constr_op =
   | Divrm
   | SetIndex of int
   | SetField of string
   | Concat
   | BVSliceSet of int list
+
+type op = extra_op constr_op
 
 (* No extra operation *)
 type extra_op1

--- a/lib/CBase.ml
+++ b/lib/CBase.ml
@@ -53,7 +53,9 @@ type mutex_kind = MutexLinux | MutexC11
 
 type return = OpReturn | FetchOp
 
-type arch_op = ArchOp.no_arch_op
+type arch_extra_op = ArchOp.no_extra_op
+type 'a arch_constr_op = 'a ArchOp.no_constr_op
+type arch_op = arch_extra_op arch_constr_op
 type op = arch_op Op.op
 
 let pp_phantom_archop _ = assert false

--- a/lib/JavaBase.ml
+++ b/lib/JavaBase.ml
@@ -46,7 +46,9 @@ let symb_reg_name r =
 
 let symb_reg r = sprintf "%%%s" r
 
-type arch_op = ArchOp.no_arch_op
+type arch_extra_op = ArchOp.no_extra_op
+type 'a arch_constr_op = 'a ArchOp.no_constr_op
+type arch_op = arch_extra_op arch_constr_op
 type op = arch_op Op.op
 
 let pp_phantom_archop _ = assert false

--- a/lib/PAC.ml
+++ b/lib/PAC.ml
@@ -1,0 +1,88 @@
+type key = DA | DB | IA | IB
+
+(* A vritual address must have a PAC field represented in the most significant
+   bits of the pointer, this PAC field may contani multiple PAC signatures using
+   the XOR off all the signatures *)
+type signature =
+  {
+    (* "ia", "da", "ib" or "db" *)
+    key : key ;
+    (* modifier: a string used as a "salt" added to the hash *)
+    modifier : string ;
+    (* the offset of the pointer at the time we compute the PAC field *)
+    offset : int ;
+  }
+
+(* lower case pretty printing of keys *)
+let pp_lower_key = function
+  | DA -> "da"
+  | DB -> "db"
+  | IA -> "ia"
+  | IB -> "ib"
+
+let pp_upper_key = function
+  | DA -> "DA"
+  | DB -> "DB"
+  | IA -> "IA"
+  | IB -> "IB"
+
+let parse_key : string -> key = function
+  | "da" | "DA" -> DA
+  | "ia" | "IA" -> IA
+  | "db" | "DB" -> DB
+  | "ib" | "IB" -> IB
+  | s -> Warn.user_error "PAC fields must use keys in {da,db,ia,ib}, found %s" s
+
+let compare_key x y =
+  match x, y with
+  | DA, DA | DB, DB | IA, IA | IB, IB -> 0
+  | DA, _ | DB, IA | _, IB -> -1
+  | _, _ -> 1
+
+let pp_signature p s =
+  Printf.sprintf "pac%s(%s, %s, %d)" (pp_lower_key p.key) s p.modifier p.offset
+
+let compare_signature p1 p2 =
+  match compare_key p1.key p2.key with
+  | 0 ->
+      begin match String.compare p1.modifier p2.modifier with
+      | 0 -> Int.compare p1.offset p2.offset
+      | r -> r
+      end
+  | r -> r
+
+module PacSet = Set.Make (struct
+  type t = signature
+  let compare = compare_signature
+end)
+
+module PacMap = Map.Make (struct
+  type t = signature
+  let compare = compare_signature
+end)
+
+type t = PacSet.t
+
+let canonical = PacSet.empty
+
+let is_canonical pac =
+  PacSet.is_empty pac
+
+(* add a PAC signature in a PAC field using an exclusive OR *)
+let add key modifier offset pac =
+  if PacSet.mem {modifier; key; offset} pac then
+    PacSet.remove {modifier; key; offset} pac
+  else
+    PacSet.add {modifier; key; offset} pac
+
+let compare = PacSet.compare
+
+let equal = PacSet.equal
+
+let pp pac s =
+  let rec aux = function
+    | x :: xs -> pp_signature x (aux xs)
+    | [] -> s
+  in
+  aux (PacSet.elements pac)
+

--- a/lib/PAC.mli
+++ b/lib/PAC.mli
@@ -1,0 +1,39 @@
+
+(* Symbolic implementation of `FEAT_Pauth2` and `FEAT_CONSTPACFIELD`
+ * Also add a type of solver state to reason about hash collisions
+ *)
+
+(* Symbolic type for Pointer Authentication Codes *)
+type t
+
+type key = DA | DB | IA | IB
+
+val compare_key : key -> key -> int
+
+(* Pretty print a key in upper case (IA, IB, DA, DB) *)
+val pp_upper_key : key -> string
+
+(* Pretty print a key in lower case (ia, ib, da, db) *)
+val pp_lower_key : key -> string
+
+val parse_key : string -> key
+
+(* Generate a canonical PAC field *)
+val canonical : t
+
+(* Check if a virtual address is canonical *)
+val is_canonical : t -> bool
+
+(* Symbolically add a new pac field to a pointer with an exclusive OR using
+ * the key, the modifier and the current offset of the pointer.
+ * If `x` is a canonical virtual address and `p` is a PAC field:
+ *     `add modifier key offset p = pac(x+offset, key, modifier) eor p`
+ *)
+val add : key -> string -> int -> t -> t
+
+val pp : t -> string -> string
+
+val compare : t -> t -> int
+
+
+val equal : t -> t -> bool

--- a/lib/archOp.ml
+++ b/lib/archOp.ml
@@ -17,7 +17,9 @@
 (** Operations that are arch specific *)
 
 module type S = sig
-  type op
+  type extra_op
+  type 'a constr_op
+  type op = extra_op constr_op
   type extra_op1
   type 'a constr_op1
   type op1 = extra_op1 constr_op1
@@ -52,18 +54,22 @@ end
 
 type no_extra_op1
 type 'a no_constr_op1
-type no_arch_op
+type no_extra_op
+type 'a no_constr_op
 
 module No (Cst : Constant.S) :
   S
     with type scalar = Cst.Scalar.t
      and type pteval = Cst.PteVal.t
      and type instr = Cst.Instr.t
-     and type op = no_arch_op
+     and type extra_op = no_extra_op
+     and type 'a constr_op = 'a no_constr_op
      and type extra_op1 = no_extra_op1
      and type 'a constr_op1 = 'a no_constr_op1
 = struct
-  type op = no_arch_op
+  type extra_op = no_extra_op
+  type 'a constr_op = 'a no_constr_op
+  type op = extra_op constr_op
   type extra_op1 = no_extra_op1
   type 'a constr_op1 = 'a no_constr_op1
   type op1 = extra_op1 constr_op1
@@ -112,11 +118,14 @@ module OnlyArchOp1 (A : S1) :
      and type scalar = A.scalar
      and type pteval = A.pteval
      and type instr = A.instr
-     and type op = no_arch_op
+     and type extra_op = no_extra_op
+     and type 'a constr_op = 'a no_constr_op
 = struct
   include A
 
-  type op = no_arch_op
+  type extra_op = no_extra_op
+  type 'a constr_op = 'a no_constr_op
+  type op = extra_op constr_op
 
   let pp_op _ = assert false
   let do_op _ _ _ = None

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -20,6 +20,7 @@ type tag = string option
 type cap = Int64.t
 type offset = int
 
+
 (* Symbolic location metadata*)
 (* Memory cell, with optional tag, capability<128:95>,optional vector metadata, and offset *)
 type symbolic_data =
@@ -28,6 +29,7 @@ type symbolic_data =
    tag : tag ;
    cap : cap ;
    offset : offset ;
+   pac : PAC.t ;
   }
 
 val default_symbolic_data : symbolic_data
@@ -43,7 +45,7 @@ type syskind =
   | PTE2 (* Page table entry of page table entry (non-writable) *)
   | TLB  (* TLB key *)
 
-(* 
+(*
  * Tag location are based upon physical or virtual addresses.
  * In effect the two kinds of tag locations cannot co-exists,
  * as teh formet is for VMSA mode and the latter for
@@ -104,6 +106,13 @@ val eq :
         ('instr -> 'instr -> bool) ->
           ('scalar,'pte,'instr) t -> ('scalar,'pte,'instr) t -> bool
 
+(* Return if the collision of two PAC fields can imply equality of the two
+   syntactically different constants *)
+val collision :
+  ('scalar, 'pte, 'instr) t ->
+    ('scalar, 'pte, 'instr) t ->
+      (PAC.t * PAC.t) option
+
 (* New style: PTE(s), PHY(s), etc. *)
 val pp :
   ('scalar -> string) -> ('pte -> string) -> ('instr -> string) ->
@@ -151,6 +160,9 @@ val of_symbolic_data : symbolic_data -> ('scalar,'pte,'instr) t
 
 val as_pte : ('scalar,'pte,'instr) t -> ('scalar,'pte,'instr) t option
 val is_pt : ('scalar,'pte,'instr)  t -> bool
+
+(* Remove the Pac field of a virtual address *)
+val make_canonical : ('scalar,'pte,'instr) t -> ('scalar,'pte,'instr) t
 
 module type S =  sig
 

--- a/lib/fault.ml
+++ b/lib/fault.ml
@@ -67,6 +67,7 @@ module type S = sig
     fault_type option * string option
 
   val pp_fault : fault -> string
+  val map_fault : (loc_global -> loc_global) -> fault -> fault
   module FaultSet : MySet.S with type elt = fault
 
   type fatom = (loc_global,fault_type) atom
@@ -85,6 +86,11 @@ module Make(A:I) =
     type fault =
       (Proc.t * Label.Set.t) * loc_global option
       * fault_type option * string option
+
+    (* Map over the loc_global in a fault *)
+    let map_fault f = function
+      | (lbl,Some x,ftype,msg) -> (lbl,Some (f x),ftype,msg)
+      | fault -> fault
 
     let pp_lbl (p,lbl) = match Label.Set.as_small 1 lbl with
     | Some [] ->  Proc.pp p

--- a/lib/fault.mli
+++ b/lib/fault.mli
@@ -49,6 +49,7 @@ module type S = sig
     * fault_type option * string option
 
   val pp_fault : fault -> string
+  val map_fault : (loc_global -> loc_global) -> fault -> fault
 
   module FaultSet : MySet.S with type elt = fault
 

--- a/lib/faultType.ml
+++ b/lib/faultType.ml
@@ -35,6 +35,7 @@ module type AArch64Sig = sig
     | TagCheck
     | UndefinedInstruction
     | SupervisorCall
+    | PacCheck of PAC.key
 
   include S with type t := t
 end
@@ -55,6 +56,7 @@ module AArch64 = struct
     | TagCheck
     | UndefinedInstruction
     | SupervisorCall
+    | PacCheck of PAC.key
 
   let sets = [
       "MMU", [MMU Translation;
@@ -64,6 +66,10 @@ module AArch64 = struct
       "AccessFlag", [MMU AccessFlag];
       "Permission", [MMU Permission];
       "TagCheck", [TagCheck];
+      "PacCheck", [PacCheck PAC.DA;
+                   PacCheck PAC.DB;
+                   PacCheck PAC.IA;
+                   PacCheck PAC.IB];
       "UndefinedInstruction",[UndefinedInstruction];
       "SVC", [SupervisorCall];
     ]
@@ -73,12 +79,17 @@ module AArch64 = struct
     | TagCheck -> "TagCheck"
     | UndefinedInstruction -> "UndefinedInstruction"
     | SupervisorCall -> "SupervisorCall"
+    | PacCheck k -> Printf.sprintf "PacCheck:%s" (PAC.pp_upper_key k)
 
   let parse = function
     | "MMU:Translation" -> MMU Translation
     | "MMU:AccessFlag" -> MMU AccessFlag
     | "MMU:Permission" -> MMU Permission
     | "TagCheck" -> TagCheck
+    | "PacCheck:DA" -> PacCheck PAC.DA
+    | "PacCheck:DB" -> PacCheck PAC.DB
+    | "PacCheck:IA" -> PacCheck PAC.IA
+    | "PacCheck:IB" -> PacCheck PAC.IB
     | "UndefinedInstruction" -> UndefinedInstruction
     | "SupervisorCall" -> SupervisorCall
     | _ as s -> Warn.user_error "%s not a valid fault type" s

--- a/lib/faultType.mli
+++ b/lib/faultType.mli
@@ -35,6 +35,7 @@ module type AArch64Sig = sig
     | TagCheck
     | UndefinedInstruction
     | SupervisorCall
+    | PacCheck of PAC.key
 
   include S with type t := t
 end

--- a/lib/op.ml
+++ b/lib/op.ml
@@ -137,8 +137,6 @@ type 'aop op1 =
   | Demote  (* Demote to lower precision *)
   | ArchOp1 of 'aop
 
-
-
 let pp_op1 hexa pp_aop o = match o with
 | Not -> "!"
 | SetBit i -> sprintf "setbit%i" i

--- a/lib/op.mli
+++ b/lib/op.mli
@@ -19,7 +19,6 @@
 (**********)
 (* Binary *)
 (**********)
-
 type 'aop op =
   | Add | Sub | Mul | Div | Rem
   | And | Or | Xor | Nor

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -121,7 +121,7 @@ reg:
 | DOLLARNAME {  $1 }
 
 location_global:
-| NAME { Constant.mk_sym $1  }
+| NAME { Constant.mk_sym $1 }
 | TOK_PTE LPAR NAME RPAR { Constant.mk_sym_pte  $3 }
 | TOK_PTE LPAR TOK_PTE LPAR NAME RPAR RPAR { Constant.mk_sym_pte2 $5 }
 | TOK_PA LPAR NAME RPAR { Constant.mk_sym_pa $3 }

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -34,7 +34,9 @@ module
 
   module Cst = Cst
 
-  type arch_op = ArchOp.op
+  type arch_extra_op = ArchOp.extra_op
+  type 'a arch_constr_op = 'a ArchOp.constr_op
+  type arch_op = arch_extra_op arch_constr_op
   type arch_extra_op1 = ArchOp.extra_op1
   type 'a arch_constr_op1 = 'a ArchOp.constr_op1
   type arch_op1 = arch_extra_op1 arch_constr_op1
@@ -302,8 +304,7 @@ module
     | (Val (Symbolic _),Val (Symbolic _))
     | (Val (Label _),Val (Label _))
     | (Val (PteVal _),Val (PteVal _))
-    | (Val (Instruction _),Val (Instruction _))
-      ->
+    | (Val (Instruction _),Val (Instruction _)) ->
         Val (Concrete (Cst.Scalar.of_int (compare  v1 v2)))
     (* 0 is sometime used as invalid PTE, no orpat because warning 57
        cannot be disabled in some versions ?  *)

--- a/lib/symbValue.mli
+++ b/lib/symbValue.mli
@@ -31,4 +31,5 @@ module Make : functor
      and module Cst.Scalar = Cst.Scalar
      and type arch_extra_op1 = ArchOp.extra_op1
      and type 'a arch_constr_op1 = 'a ArchOp.constr_op1
-     and type arch_op = ArchOp.op
+     and type arch_extra_op = ArchOp.extra_op
+     and type 'a arch_constr_op = 'a ArchOp.constr_op

--- a/lib/value.mli
+++ b/lib/value.mli
@@ -20,7 +20,9 @@ module type S =
     sig
 (* Constants, notice that they include symbolic "rigid" constants *)
       module Cst : Constant.S
-      type arch_op
+      type arch_extra_op
+      type 'a arch_constr_op
+      type arch_op = arch_extra_op arch_constr_op
       type arch_extra_op1
       type 'a arch_constr_op1 (* Arch specific operations *)
       type arch_op1 = arch_extra_op1 arch_constr_op1
@@ -133,10 +135,12 @@ module type AArch64 =
   S
   with type Cst.PteVal.t = AArch64PteVal.t
   and type Cst.Instr.t = AArch64Base.instruction
-  and type 'a arch_constr_op1 = 'a AArch64Op.t
+  and type 'a arch_constr_op1 = 'a AArch64Op.unop
+  and type 'a arch_constr_op = 'a AArch64Op.binop
 
 module type AArch64ASL =
   AArch64
   with type Cst.Scalar.t = ASLScalar.t
-  and type arch_op = ASLOp.op
+  (*and type arch_op = ASLOp.op AArch64Op.binop*)
+  and type arch_extra_op = ASLOp.op
   and type arch_extra_op1 = ASLOp.op1

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1383,7 +1383,7 @@ module Make(V:Constant.S)(C:Config) =
         }
       | _ -> assert false
 
-    let pp_sm_op = function 
+    let pp_sm_op = function
     | None -> ""
     | Some r -> " " ^ (pp_sm r |> Misc.lowercase)
 
@@ -1976,6 +1976,55 @@ module Make(V:Constant.S)(C:Config) =
         { empty_ins with memo; }::k
     | I_UDF _ ->
         { empty_ins with memo = ".word 0"; }::k
+    | I_XPACD rD ->
+        let rD,fD = do_arg1o V64 rD 0 in
+        { empty_ins with
+          memo = sprintf "xpacd %s" fD;
+          inputs = rD;
+          outputs = rD;
+          reg_env = add_v V64 rD
+        }::k
+    | I_XPACI rD ->
+        let rD,fD = do_arg1o V64 rD 0 in
+        { empty_ins with
+          memo = sprintf "xpaci %s" fD;
+          inputs = rD;
+          outputs = rD;
+          reg_env = add_v V64 rD
+        }::k
+    | I_PAC (key, rD, ZR) | I_AUT (key, rD, ZR) ->
+        let op = match ins with
+          | I_PAC _ -> "pac"
+          | I_AUT _ -> "aut"
+          | _ -> assert false
+        and key = match key with
+          | PAC.IA -> "iza"
+          | PAC.DA -> "dza"
+          | PAC.IB -> "izb"
+          | PAC.DB -> "dzb"
+        in
+
+        let rD,fD = do_arg1i V64 rD 0 in
+        { empty_ins with
+          memo = sprintf "%s%s %s" op key fD;
+          inputs = rD;
+          outputs = rD;
+          reg_env = add_v V64 rD
+        }::k
+    | I_PAC (key, rD, rN) | I_AUT (key, rD, rN) ->
+        let op = match ins with
+          | I_PAC _ -> "pac"
+          | I_AUT _ -> "aut"
+          | _ -> assert false
+        and key = PAC.pp_lower_key key in
+
+        let rD,fD,rN,fN = args2i V64 rD rN in
+        { empty_ins with
+          memo = sprintf "%s%s %s,%s" op key fD fN;
+          inputs = rD@rN;
+          outputs = rD;
+          reg_env = add_v V64 (rD@rN)
+        }::k
 
     let no_tr lbl = lbl
     let branch_neq r i lab k = cmpk V32 r i::bcc no_tr NE lab::k

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -489,6 +489,9 @@ module RegMap = A.RegMap)
       let compile_val_fun =
         let open Constant in
         fun ptevalEnv v -> match v with
+        | Symbolic (Virtual {pac})
+          when not (PAC.is_canonical pac) ->
+            Warn.user_error "Litmus cannot initialize a virtual address with a non-canonical PAC field"
         | Symbolic sym ->
             let s = Constant.pp_symbol_old sym in
             sprintf "%s%s"

--- a/litmus/answer.mli
+++ b/litmus/answer.mli
@@ -27,5 +27,6 @@ type answer =
         * StringSet.t    (* cycles *)
         * hash_env       (* name -> hash *)
         * int            (* number of threads *)
+        * bool           (* require Pointer Authentication Code *)
   | Interrupted of Archs.t * exn
   | Absent of Archs.t

--- a/litmus/libdir/_aarch64/_auth.c
+++ b/litmus/libdir/_aarch64/_auth.c
@@ -1,0 +1,163 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris, France.                                       */
+/* Rémy Citérin, ARM Ltd, Cambridge, UK                                     */
+/*                                                                          */
+/* Copyright 2025-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+
+#include "auth.h"
+#ifndef KVM
+#include <stdio.h>
+#endif
+
+// read the SCTLR_EL1 status register
+static uint64_t read_sctlr_el1(void) {
+  uint64_t ret;
+  asm __volatile__("mrs %[ret], SCTLR_EL1": [ret] "=r" (ret));
+  return ret;
+}
+
+static void init_pauth_key_ia(void) {
+  uint64_t x = 0xaaaaaaaaaaaaaaaa;
+  uint64_t y = 0xaaaaaaaaaaaaaaaa;
+  asm __volatile__("msr APIAKeyHi_EL1, %[x]":: [x] "r" (x));
+  asm __volatile__("msr APIAKeyLo_EL1, %[y]":: [y] "r" (y));
+}
+
+static void init_pauth_key_ib(void) {
+  uint64_t x = 0x5555555555555555;
+  uint64_t y = 0x5555555555555555;
+  asm __volatile__("msr APIBKeyHi_EL1, %[x]":: [x] "r" (x));
+  asm __volatile__("msr APIBKeyLo_EL1, %[y]":: [y] "r" (y));
+}
+
+static void init_pauth_key_da(void) {
+  uint64_t x = 0x5555555555555555;
+  uint64_t y = 0xaaaaaaaaaaaaaaaa;
+  asm __volatile__("msr APDAKeyHi_EL1, %[x]":: [x] "r" (x));
+  asm __volatile__("msr APDAKeyLo_EL1, %[y]":: [y] "r" (y));
+}
+
+static void init_pauth_key_db(void) {
+  uint64_t x = 0xaaaaaaaaaaaaaaaa;
+  uint64_t y = 0x5555555555555555;
+  asm __volatile__("msr APDBKeyHi_EL1, %[x]":: [x] "r" (x));
+  asm __volatile__("msr APDBKeyLo_EL1, %[y]":: [y] "r" (y));
+}
+
+// update the SCTLR_EL1 status register
+static void write_sctlr_el1(uint64_t x) {
+  asm __volatile__("msr SCTLR_EL1, %[x]":: [x] "r" (x));
+}
+
+// Initialize pointer authentication
+void init_pauth(void) {
+  uint64_t enIA = 1ULL << 31;
+  uint64_t enIB = 1ULL << 30;
+  uint64_t enDA = 1ULL << 27;
+  uint64_t enDB = 1ULL << 13;
+  write_sctlr_el1(enIA | enIB | enDA | enDB | read_sctlr_el1());
+  init_pauth_key_ia();
+  init_pauth_key_ib();
+  init_pauth_key_da();
+  init_pauth_key_db();
+}
+
+/*
+ * My reading of ARM ARM suggests combining the APA and API
+ * fields with the or operation.
+ * Namely, both fields have the same values for a certain
+ * levels of the PAC feature, while specifying different
+ * algorithms for implementing it.
+ * Thus, encoding will tell us that any algorithm is
+ * implementated at the specified level:
+ * 0b0000 -> no authentification
+ * 0b0001 -> FEAT_PAuth
+ * 0b0010 -> FEAT_EPAC
+ * 0b0011 -> FEAT_PAuth2
+ * 0b0100 -> FEAT_FPAC
+ * 0b0101 -> FEAT_FPACCOMBINE
+ */
+static uint64_t get_isar1_apia(void) {
+  uint64_t isar1 ;
+  asm volatile("mrs %[isar1], ID_AA64ISAR1_EL1": [isar1] "=r" (isar1));
+  uint64_t isar1_api = (isar1 >> 8) & 0b1111;
+  uint64_t isar1_apa = (isar1 >> 4) & 0b1111;
+  return  isar1_api|isar1_apa ;
+}
+
+// Check if `FEAT_Pauth2` is implemented
+int check_pac_variant(char* tname) {
+  uint64_t isar1_apia = get_isar1_apia();
+
+  switch (isar1_apia) {
+    case 0b0001:
+    case 0b0010:
+      printf(
+        "Warning %s: PAC is only available without FEAT_PAuth2 on this system\n",
+        tname);
+      return 1;
+    case 0b0100:
+    case 0b0011:
+    case 0b0101:
+      return 1;
+    default:
+      printf("Test %s, PAC not available on this system\n", tname);
+      return 0;
+  }
+}
+
+// Check if `FEAT_FPAC` is implemented iff `present`:
+// FPAC change the way `aut*` is executed in case of failure
+int check_fpac_variant(char* tname, int present) {
+  uint64_t isar1_apia = get_isar1_apia();
+
+  switch (isar1_apia) {
+    case 0b0100:
+    case 0b0101:
+      if (!present)
+        printf("Test %s, FPAC is implemented on this system\n", tname);
+      return present;
+    default:
+      if (present)
+        printf("Test %s, FPAC not implemented on this system\n", tname);
+      return !present;
+  }
+}
+
+// Check if `FEAT_CONSTPACFIELD` is implemented
+int check_const_pac_field_variant(char* tname) {
+  uint64_t isar2;
+  asm volatile("mrs %[isar2], ID_AA64ISAR2_EL1": [isar2] "=r" (isar2));
+  uint64_t isar2_pac = (isar2 >> 24) & 0b1111;
+
+  switch (isar2_pac) {
+    case 0b0001:
+      return 1;
+    default:
+      printf("Test %s, CONSTPACFIELD not available on this system\n", tname);
+      return 0;
+  }
+}
+
+// Remove the PAC field in an instruction pointer
+void* strip_pauth_instruction(void* ptr) {
+  asm volatile("xpaci %[ptr]": [ptr] "+r" (ptr));
+  return ptr;
+}
+
+// Remove the PAC field in a data pointer
+void* strip_pauth_data(void* ptr) {
+  asm volatile("xpacd %[ptr]": [ptr] "+r" (ptr));
+  return ptr;
+}

--- a/litmus/libdir/_aarch64/_auth.h
+++ b/litmus/libdir/_aarch64/_auth.h
@@ -1,0 +1,41 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* Copyright 2025-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+#ifndef _AUTH_H
+#define _AUTH_H 1
+
+#include "utils.h"
+
+
+// Initialize pointer authentication
+void init_pauth(void);
+
+// Check if `FEAT_Pauth2` is implemented
+int check_pac_variant(char* tname);
+
+// Check if `FEAT_FPAC` is implemented iff `present`:
+// FPAC change the way `aut*` instructions are executed in case of failure
+int check_fpac_variant(char* tname, int present);
+
+// Check if `FEAT_CONSTPACFIELD` is implemented
+int check_const_pac_field_variant(char* tname);
+
+// Remove the PAC field in an instruction pointer
+void* strip_pauth_instruction(void* ptr);
+
+// Remove the PAC field in a data pointer
+void* strip_pauth_data(void* ptr);
+
+#endif

--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -63,14 +63,19 @@ static void fault_handler(struct pt_regs *regs,unsigned int esr) {
 #endif
 }
 
+#define ESR_EL1_EC_PAC 0b011100
+
 static void install_fault_handler(int cpu) {
   install_exception_handler(EL1H_SYNC, ESR_EL1_EC_DABT_EL1, fault_handler);
   install_exception_handler(EL1H_SYNC, ESR_EL1_EC_UNKNOWN, fault_handler);
   install_exception_handler(EL1H_SYNC, ESR_EL1_EC_SVC64, fault_handler);
+  // Pointer Authentication Code error code is not present in KVM-unit-tests
+  install_exception_handler(EL1H_SYNC, ESR_EL1_EC_PAC, fault_handler);
 #ifdef USER_MODE
   struct thread_info *ti = thread_info_sp(user_stack[cpu]);
   ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
   ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
   ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = fault_handler;
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_PAC] = fault_handler;
 #endif
 }

--- a/litmus/libdir/_aarch64/kvm_fault_type.c
+++ b/litmus/libdir/_aarch64/kvm_fault_type.c
@@ -3,6 +3,10 @@
 enum fault_type_t {
   FaultUndefinedInstruction,
   FaultSupervisorCall,
+  FaultPacCheckIA,
+  FaultPacCheckIB,
+  FaultPacCheckDA,
+  FaultPacCheckDB,
   FaultMMUAddressSize,
   FaultMMUTranslation,
   FaultMMUAccessFlag,
@@ -16,6 +20,10 @@ enum fault_type_t {
 static const char *fault_type_names[] = {
   "UndefinedInstruction",
   "SupervisorCall",
+  "PacCheck:IA",
+  "PacCheck:IB",
+  "PacCheck:DA",
+  "PacCheck:DB",
   "MMU:AddressSize",
   "MMU:Translation",
   "MMU:AccessFlag",
@@ -23,6 +31,8 @@ static const char *fault_type_names[] = {
   "TagCheck",
   "Unsupported",
 };
+
+#define ESR_EL1_EC_PAC 0b011100
 
 static enum fault_type_t get_fault_type(unsigned long esr)
 {
@@ -35,6 +45,8 @@ static enum fault_type_t get_fault_type(unsigned long esr)
     return FaultUndefinedInstruction;
   } else if (ec == ESR_EL1_EC_SVC64) {
     return FaultSupervisorCall;
+  } else if (ec == ESR_EL1_EC_PAC) {
+    return FaultPacCheckIA + (esr & 0x3U);
   } else {
     dfsc = esr & 0x3fU;
     fault_type = (dfsc >> 2) + FaultMMUAddressSize;

--- a/litmus/libdir/kvm-m1.cfg
+++ b/litmus/libdir/kvm-m1.cfg
@@ -21,4 +21,4 @@ makevar = LIBFDT_archive = $(SRCDIR)/lib/libfdt/libfdt.a
 makevar = cstart.o = $(SRCDIR)/arm/cstart64.o
 makevar = FLATLIBS = $(libcflat) $(LIBFDT_archive) $(libeabi)
 makevar = optional-ccopt = $(shell if $(CC) -Werror $(1) -S -o /dev/null -xc /dev/null > /dev/null 2>&1; then echo "$(1)"; fi)
-ccopts = -std=gnu99 -ffreestanding -I $(SRCDIR)/lib -I $(SRCDIR)/libfdt -Wall -Werror  -fomit-frame-pointer -Wno-frame-address   -fno-pic  -no-pie -Wmissing-parameter-type -Wold-style-declaration -Woverride-init -O2 $(call optional-ccopt, -mno-outline-atomics) -march=armv8.1-a
+ccopts = -std=gnu99 -ffreestanding -I $(SRCDIR)/lib -I $(SRCDIR)/libfdt -Wall -Werror  -fomit-frame-pointer -Wno-frame-address   -fno-pic  -no-pie -Wmissing-parameter-type -Wold-style-declaration -Woverride-init -O2 $(call optional-ccopt, -mno-outline-atomics) -march=armv8.6-a

--- a/litmus/myName.ml
+++ b/litmus/myName.ml
@@ -41,7 +41,10 @@ let envlib =
   try Some (Sys.getenv "LITMUSDIR") with Not_found ->
   try Some (Sys.getenv "LITMUSLIB") with Not_found -> None
 
-let open_lib name =
+let open_lib ?sub name =
+  let name = match sub with
+    | Some sub -> Filename.concat sub name
+    | None -> name in
   try try_open "." name
   with Exit -> try match envlib with
   | Some lib -> try_open lib name

--- a/litmus/myName.mli
+++ b/litmus/myName.mli
@@ -25,7 +25,7 @@ val chop_litmus : string -> string
 val outname : string -> string -> string
 
 (* Open litmus own files *)
-val open_lib : string -> string * in_channel
+val open_lib : ?sub:string -> string -> string * in_channel
 
 (* Get litmus own file complete name *)
 val name_lib : string -> string

--- a/litmus/objUtil.ml
+++ b/litmus/objUtil.ml
@@ -60,6 +60,17 @@ module type InsertConfig = sig
   val sysarch : Archs.System.t
 end
 
+let dir_of_sysarch = function
+  | `X86 -> "_x86"
+  | `X86_64 -> "_x86_64"
+  | `PPC -> "_ppc"
+  | `ARM -> "_arm"
+  | `BPF -> "_bpf"
+  | `MIPS -> "_mips"
+  | `AArch64 -> "_aarch64"
+  | `RISCV -> "_riscv"
+  | `Unknown -> "_none"
+
 module Insert (O:InsertConfig) :
     sig
       val insert : (string -> unit) -> string -> unit
@@ -69,16 +80,7 @@ module Insert (O:InsertConfig) :
     end =
   struct
 
-    let dir = match O.sysarch with
-      | `X86 -> "_x86"
-      | `X86_64 -> "_x86_64"
-      | `PPC -> "_ppc"
-      | `ARM -> "_arm"
-      | `BPF -> "_bpf"
-      | `MIPS -> "_mips"
-      | `AArch64 -> "_aarch64"
-      | `RISCV -> "_riscv"
-      | `Unknown -> "_none"
+    let dir = dir_of_sysarch O.sysarch
 
     let find_lib src =
       let n1 = Filename.concat dir src in
@@ -144,8 +146,8 @@ module Make(O:Config)(Tar:Tar.S) =
 
     let actual_name name ext = Tar.outname (name ^ ext)
 
-    let do_cpy ?prf fnames src tgt ext =
-      let _,in_chan = MyName.open_lib (src ^ ext) in
+    let do_cpy ?sub ?prf fnames src tgt ext =
+      let _,in_chan = MyName.open_lib ?sub (src ^ ext) in
       let fnames =
         begin try
           let fname = actual_name tgt ext in
@@ -156,10 +158,12 @@ module Make(O:Config)(Tar:Tar.S) =
       fnames
 
 (* Copy lib file *)
-    let cpy ?prf fnames name ext = do_cpy ?prf fnames ("_" ^ name) name ext
+    let cpy ?sub ?prf fnames name ext =
+      do_cpy ?sub ?prf fnames ("_" ^ name) name ext
 
 (* Copy lib file, changing its name *)
-    let cpy' ?prf fnames src dst ext = do_cpy ?prf fnames ("_" ^ src) dst ext
+    let cpy' ?sub ?prf fnames src dst ext =
+      do_cpy ?sub ?prf fnames ("_" ^ src) dst ext
 
 (* Copy from platform subdirectory *)
     let cpy_platform fnames name ext =
@@ -177,7 +181,7 @@ module Make(O:Config)(Tar:Tar.S) =
     | Mac as os ->
         Warn.fatal "Affinity not implemented for %s" (TargetOS.pp os)
 
-    let dump () =
+    let dump some_pac =
       let fnames = [] in
       let fnames = match O.driver with
       | Driver.Shell -> fnames
@@ -256,6 +260,13 @@ module Make(O:Config)(Tar:Tar.S) =
             let fnames = do_cpy fnames affi "affinity" ".c" in
             let fnames = cpy fnames "affinity" ".h" in
             fnames in
+      let fnames =
+        if some_pac then
+          let sub = dir_of_sysarch O.sysarch in
+          let fnames = cpy ~sub:sub fnames "auth" ".c" in
+          let fnames = cpy ~sub:sub fnames "auth" ".h" in
+          fnames
+        else fnames in
       fnames
 
   end

--- a/litmus/runUtils.ml
+++ b/litmus/runUtils.ml
@@ -34,6 +34,7 @@ module type CommonConfig = sig
   val speedcheck : Speedcheck.t
   val isync : bool
   val c11 : bool
+  val variant : Variant_litmus.t -> bool
   include DumpParams.Config
 end
 

--- a/litmus/run_litmus.ml
+++ b/litmus/run_litmus.ml
@@ -50,10 +50,13 @@ module Make(O:Config)(Tar:Tar.S)(D:CoreDumper.S) =
           | Mode.PreSi | Mode.Kvm ->
              Warn.fatal "No direct execution in %s mode"
                (Mode.pp O.mode) in
-          let utils =
+          let k =
             match O.affinity with
             | Affinity.No -> "utils.c"::k
             | _ ->  "utils.c"::"affinity.c"::k in
+          let utils =
+            if O.variant Variant_litmus.Pac
+            then "auth.c"::k else k in
           String.concat " " (List.map Tar.outname utils) in
         let com = sprintf "%s -o %s %s %s" gcc sX utils source in
         exec_stdout com

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -270,6 +270,7 @@ end = struct
                 let allocated = allocate parsed in
                 let compiled = compile doc allocated in
                 let source = MyName.outname name ".c" in
+                let pac = O.variant Variant_litmus.Pac in
                 dump source doc compiled;
                 if not OT.is_out then begin
                     let _utils =
@@ -283,11 +284,11 @@ end = struct
                           | _ -> false
                       end in
                       let module Obj = ObjUtil.Make(OO)(Tar) in
-                      Obj.dump () in
+                      Obj.dump pac in
                     ()
                   end ;
                 R.run name out_chan doc allocated source ;
-                Completed (A'.arch,doc,source,cycles,hash_env,nprocs)
+                Completed (A'.arch,doc,source,cycles,hash_env,nprocs,pac)
               end else begin
                 let cause = if limit_ok then "" else " (too many threads)" in
                 W.warn "%s test not compiled%s"

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -24,12 +24,15 @@ type t =
   | SVE (* Do nothing *)
   | SME (* Do nothing *)
   | NoInit (* Do not initialise variables *)
+  | Pac (* Pointer authentication instructions *)
+  | FPac (* Fault on pointer authentication *)
+  | ConstPacField (* Bit 55 is used to compute the VA-range in ComputePAC *)
 
 let compare = compare
 
 let tags =
-  "noinit"::"s128"::"self"::"mixed"::"vmsa"::"telechat"
-  ::Fault.Handling.tags
+  "noinit"::"s128"::"self"::"mixed"::"vmsa"::"telechat"::"pac"
+  ::"const-pac-field"::"fpac"::Fault.Handling.tags
 
 let parse s = match Misc.lowercase s with
 | "noinit" -> Some NoInit
@@ -40,6 +43,9 @@ let parse s = match Misc.lowercase s with
 | "telechat" -> Some Telechat
 | "sve" -> Some SVE
 | "sme" -> Some SME
+| "pac" -> Some Pac
+| "fpac" -> Some FPac
+| "const-pac-field" -> Some ConstPacField
 | tag ->
   match
    Misc.app_opt (fun p -> FaultHandling p) (Fault.Handling.parse tag)
@@ -69,6 +75,9 @@ let pp = function
   | FaultHandling p -> Fault.Handling.pp p
   | SVE -> "sve"
   | SME -> "sme"
+  | Pac -> "pac"
+  | FPac -> "fpac"
+  | ConstPacField -> "const-pac-field"
 
 let ok v a = match v,a with
 | Self,`AArch64 -> true

--- a/litmus/variant_litmus.mli
+++ b/litmus/variant_litmus.mli
@@ -24,6 +24,9 @@ type t =
   | SVE (* Do nothing *)
   | SME (* Do nothing *)
   | NoInit (* Do not initialise variables *)
+  | Pac (* Pointer authentication instructions *)
+  | FPac (* Fault on pointer authentication *)
+  | ConstPacField (* Bit 55 is used to compute the VA-range in ComputePAC *)
 
 val tags : string list
 val parse : string -> t option


### PR DESCRIPTION
Here is some support for the Pointer Authentication Code extension of AArch64, it support basic instructions for `FEAT_Pauth2` in herd (`xpad*`, `pac*` and `aut*`).  It support optionally `FEAT_FPAC` to generate faults in case of a `aut*` failure and `FEAT_CONSTPACFIELD` to enable `pac*` on virtual addresses with a non canonical pac field (using the xor semantic)

## Syntax

Pac fields can be added to virtual addresses using the `pac*` instructions or into the initial state using some notations:
- `0:x0=pacda(x, 42)` or `0:x0=pac(x,da,42)` will return the virtual address `x` in `x0` with a pac field `ComputePAC(x,da,42)`: with the key `da`, and the modifier `42` (modifier must be an integer in initial and final state)
- `0:x0=pacda(x,42,10)` or `0:x0=pac(x,da,42,10)` will return the virtual address `x` with the pac field `ComputePAC(x+10,da,42)`, like the other features in herd, we assume their is no aliasing here

One can write this litmus test to use herd with pac:

```
AArch64 pac example
Variant=pac,fpac,const-pac-field
{ 0:x0=pacdb(x,0); int x = pacda(y,42) }
P0;
  autdzb x0;
  ldr x1,[x0];
  xpacd x1;
  pacdza x0;
forall
  ( 0:x1=y /\ 0:x0=pac(x,da,0) /\ ~Fault(P0) )
```

some examples of usage of PAC are also provided with `make test.pac`. Some instructions are still not supported like the combined instructions or the `pacga` instruction. Also this PR completely ignores hash collisions between pac fields (two virtual addresses with syntactically different pac fields are different). Also executing pac related instructions without the `pac` variant is not supported, maybe some checks must be added for it: I don't really know the semantic of `pac` instruction in term of dependencies if it is not activated with `SCTLR_EL1`, so it will be a future work.


Here is some ressources I made to explain the basics of PAC (you can also found some very low level informations in the Arm ARM):
[notes3.md](https://github.com/user-attachments/files/18361549/notes3.md)
![autda_success](https://github.com/user-attachments/assets/f1b9016c-dfbe-4fe3-9e6d-97ca13c1326c)
![autdb_failure](https://github.com/user-attachments/assets/9699af0f-8eda-4efd-bdfb-45ad1167f5d8)
![ldr_failure](https://github.com/user-attachments/assets/110fe37a-a4c3-470b-b41e-3386d6bb1632)
![ldr_success](https://github.com/user-attachments/assets/5816bb41-5ddd-48a0-9887-c31847027330)
![pacda](https://github.com/user-attachments/assets/f0668dd8-39d4-4aad-ad39-1d495dce1b1c)
![str_failure](https://github.com/user-attachments/assets/d92c5bad-cb34-498d-a001-336f9187b608)
![str_success](https://github.com/user-attachments/assets/a6558c9e-28b5-46c1-81f7-c1ead20f2be7)
![xpacd](https://github.com/user-attachments/assets/9e13f285-7b51-43af-ba3e-fa6986d54b43)
