### PR TITLE
[asl] Fix inference of constraints with MOD

### DIFF
--- a/asllib/StaticOperations.ml
+++ b/asllib/StaticOperations.ml
@@ -9,7 +9,7 @@ let range a b = Constraint_Range (a, b)
 (* Begin ConstraintMod *)
 let constraint_mod = function
   | Constraint_Exact e | Constraint_Range (_, e) ->
-      range zero_expr e |: TypingRule.ConstraintMod
+      range zero_expr (binop MINUS e one_expr) |: TypingRule.ConstraintMod
 (* End *)
 
 (* Begin PossibleExtremitiesLeft *)

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -208,6 +208,12 @@
   \lstinputlisting{#1}
 }
 
+\newcommand\ASLListing[3]{
+\begin{center}
+\lstinputlisting[caption=#1\label{listing:#2}]{#3}
+\end{center}
+}
+
 \ifcode
 % First argument is \<rule>Begin, second is \<rule>End, third is the file name.
 % Example: for SemanticsRule.Lit, use the following:
@@ -222,6 +228,7 @@
 \newtheorem{definition}{Definition}
 \newtheorem{example}{Example}
 \newcommand\figref[1]{Figure.~\ref{fi:#1}}
+\newcommand\listingref[1]{Listing~\ref{listing:#1}}
 \newcommand\taref[1]{Table.~\ref{ta:#1}}
 \newcommand\defref[1]{Definition~\ref{def:#1}}
 \newcommand\secref[1]{Section~\ref{sec:#1}}
@@ -2361,6 +2368,8 @@
 \newcommand\vdone[0]{\texttt{d1}}
 \newcommand\vdtwo[0]{\texttt{d2}}
 \newcommand\ve[0]{\texttt{e}}
+\newcommand\veminusone[0]{\texttt{e\_minus\_1}}
+\newcommand\veupper[0]{\texttt{e\_upper}}
 \newcommand\veinit[0]{\texttt{e\_init}}
 \newcommand\veelse[0]{\texttt{e\_else}}
 \newcommand\vefive[0]{\texttt{e5}}

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -1175,36 +1175,36 @@ The function
 yields a range constraint $\newc$ from $0$ to the expression in $\vc$ that is maximal.
 This is needed to apply the modulus operation to a pair of constraints.
 
-\subsubsection{Prose}
-One of the following applies:
-\begin{itemize}
-  \item All of the following apply (\textsc{exact}):
-  \begin{itemize}
-    \item $\vc$ is a constraint for the expression $\ve$, that is, $\ConstraintExact(\ve)$;
-    \item $\newc$ is a constraint for the range from the literal expression for $0$ to $\ve$.
-  \end{itemize}
+\subsubsection{Example}
+In \listingref{typing-constraintmod}, the assignment to \texttt{z} is illegal, since the type
+inferred for \texttt{z} is\\
+\verb|integer{0..2}|.
 
-  \item All of the following apply (\textsc{range}):
-  \begin{itemize}
-    \item $\vc$ is a range constraint for some start expression and end expression $\ve$, that is, $\ConstraintRange(\Ignore, \ve)$;
-    \item $\newc$ is a constraint for the range from the literal expression for $0$ to $\ve$.
-  \end{itemize}
+\ASLListing{An illegal value for }{typing-constraintmod}{\typingtests/TypingRule.ConstraintMod.bad.asl}
+
+\subsubsection{Prose}
+All of the following apply:
+\begin{itemize}
+  \item \Proseeqdef{$\veupper$}{
+    $\ve$ if $\vc$ is a single constraint for $\ve$,
+    and $\vb$ if $\vc$ is a range constraint for a pair of expressions, the second of which is $\vb$.
+  };
+  \item \Proseeqdef{$\veminusone$}{the binary expression subtracting $1$ from $\veupper$};
+  \item \Proseeqdef{$\newc$}{a range constraint for the literal expression for $0$ for $\veminusone$}.
 \end{itemize}
 
 \subsubsection{Formally}
 \begin{mathpar}
-\inferrule[exact]{}{
-  \constraintmod(\overname{\ConstraintExact(\ve)}{\vc})
-  \typearrow
-  \overname{\ConstraintRange(\ELInt{0}, \ve)}{\newc}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[range]{}{
-  \constraintmod(\overname{\ConstraintRange(\Ignore, \ve)}{\vc})
-  \typearrow
-  \overname{\ConstraintRange(\ELInt{0}, \ve)}{\newc}
+\inferrule{
+  {
+    \veupper \eqdef \begin{cases}
+      \ve & \vc = \ConstraintExact(\ve)\\
+      \vb & \vc = \ConstraintRange(\Ignore, \vb)
+    \end{cases}
+  }\\
+  \veminusone \eqdef \EBinop(\MINUS, \veupper, \ELInt{1})
+}{
+  \constraintmod(\vc) \typearrow \overname{\ConstraintRange(\ELInt{0}, \veminusone)}{\newc}
 }
 \end{mathpar}
 \CodeSubsection{\ConstraintModBegin}{\ConstraintModEnd}{../Typing.ml}

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ConstraintMod.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ConstraintMod.bad.asl
@@ -1,0 +1,11 @@
+func main() => integer
+begin
+    var x : integer{0..10};
+    var y = 3;
+    var z = x MOD y;
+    z = 0;
+    z = 1;
+    z = 2;
+    z = 3; // Illegal: the type inferred for z is integer{0..2}
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -45,3 +45,8 @@ ASL Typing Reference / annotating types:
   $ aslref TypingRule.BuiltinSingularTypes.asl
   $ aslref TypingRule.EnumerationType.asl
   $ aslref TypingRule.TString.asl
+  $ aslref TypingRule.ConstraintMod.bad.asl
+  File TypingRule.ConstraintMod.bad.asl, line 9, characters 4 to 5:
+  ASL Typing error: a subtype of integer {0..2} was expected,
+    provided integer {3}.
+  [1]

--- a/asllib/tests/division.t/static-mod-intervals.asl
+++ b/asllib/tests/division.t/static-mod-intervals.asl
@@ -4,6 +4,6 @@ begin
   let b = ARBITRARY: integer {a};
   let c = ARBITRARY: integer {-1000..1000};
 
-  let d: integer {0..20} = c MOD a;
-  let e: integer {0..a} = c MOD b;
+  let d: integer {0..20-1} = c MOD a;
+  let e: integer {0..a-1} = c MOD b;
 end;


### PR DESCRIPTION
The inference of a constraint resulting from the `MOD` operation needed to subtract 1 from the upper bound.
Consider the following example (now added to the list of tests):
```
func main() => integer
begin
    var x : integer{0..10};
    var y = 3;
    var z = x MOD y;
    z = 0;
    z = 1;
    z = 2;
    z = 3; // Illegal: the type inferred for z is integer{0..2}
    return 0;
end;
```
the last assignment to `z` should be illegal.

- [x] Updated `StaticOperations.ml/constraint_mod`
- [x] Updated `TypingRule.ConstaintMod` 
- [x] Updated `tests/division.t/static-mod-intervals` by subtracting 1 from the left-hand-side types.
- [x] Added the test above to the regression suite and to the docuemntation. 