### PR TITLE
[asl][fix] Raise error on arbitrary of an empty type

### DIFF
--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -72,6 +72,7 @@ type error_desc =
   | BadParameterDecl of identifier * identifier list * identifier list
       (** name, expected, actual *)
   | BaseValueEmptyType of ty
+  | ArbitraryEmptyType of ty
   | BaseValueNonStatic of ty * expr
   | SettingIntersectingSlices of bitfield list
   | SetterWithoutCorrespondingGetter of func
@@ -173,6 +174,7 @@ let error_label = function
   | ParameterWithoutDecl _ -> "ParameterWithoutDecl"
   | BadParameterDecl _ -> "BadParameterDecl"
   | BaseValueEmptyType _ -> "BaseValueEmptyType"
+  | ArbitraryEmptyType _ -> "ArbitraryEmptyType"
   | BaseValueNonStatic _ -> "BaseValueNonStatic"
   | SettingIntersectingSlices _ -> "SettingIntersectingSlices"
   | SetterWithoutCorrespondingGetter _ -> "SetterWithoutCorrespondingGetter"
@@ -381,6 +383,8 @@ module PPrint = struct
           expected
           (pp_comma_list pp_print_string)
           actual
+    | ArbitraryEmptyType t ->
+        fprintf f "ASL Execution error: ARBITRARY of empty type %a." pp_ty t
     | BaseValueEmptyType t ->
         fprintf f "ASL Typing error: base value of empty type %a." pp_ty t
     | BaseValueNonStatic (t, e) ->

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -76,3 +76,36 @@ Bad slices
   File bad-types6.asl, line 1, character 0 to line 7, character 2:
   ASL Static error: Cannot extract from bitvector of length 3 slice 8+:3.
   [1]
+
+Empty types
+===========
+
+Arbitrary of empty type
+
+  $ cat >bad-types7.asl <<EOF
+  > func main () => integer
+  > begin
+  >    let b: integer {1..0} = ARBITRARY: integer {1..0};
+  >    return 0;
+  > end;
+  > EOF
+
+  $ aslref bad-types7.asl
+  File bad-types7.asl, line 3, characters 38 to 52:
+  ASL Execution error: ARBITRARY of empty type integer {1..0}.
+  [1]
+
+Base value of empty type
+
+  $ cat >bad-types8.asl <<EOF
+  > func main () => integer
+  > begin
+  >   var b: integer {1..0};
+  >   return 0;
+  > end;
+  > EOF
+
+  $ aslref bad-types8.asl
+  File bad-types8.asl, line 3, characters 2 to 24:
+  ASL Typing error: base value of empty type integer {1..0}.
+  [1]


### PR DESCRIPTION
The following test was passing, and printing 1. This is not the expected behavior. This PR makes this forbidden.

```
func main () => integer
begin
   let b: integer {1..0} = ARBITRARY: integer {1..0};
   println(b);
   return 0;
end;
```