### PR TITLE
ASL: desugar case statement

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -350,7 +350,6 @@ type stmt_desc =
   | S_Call of call
   | S_Return of expr option
   | S_Cond of expr * stmt * stmt
-  | S_Case of expr * case_alt list
   | S_Assert of expr
   | S_For of {
       index_name : identifier;

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -264,7 +264,6 @@ val bitwidth_equal : (expr -> expr -> bool) -> expr -> expr -> bool
 
 val ldi_of_lexpr : lexpr -> local_decl_item option
 val expr_of_lexpr : lexpr -> expr
-val desugar_case_stmt : stmt -> stmt
 val slice_is_single : slice -> bool
 val slice_as_single : slice -> expr
 

--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -1037,7 +1037,6 @@ module Make (B : Backend.S) (C : Config) = struct
         let*^ v, env' = eval_expr env e in
         choice_with_branch_effect v e s1 s2 (eval_block env')
         |: SemanticsRule.SCond
-    | S_Case _ -> fatal_from s Error.TypeInferenceNeeded |: SemanticsRule.SCase
     (* Begin EvalSAssert *)
     | S_Assert e ->
         let*^ v, env1 = eval_expr env e in

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -159,7 +159,7 @@ and pp_slice f = function
 
 and pp_pattern f p =
   match p.desc with
-  | Pattern_All -> pp_print_string f "-"
+  | Pattern_All -> pp_print_string f "{-}"
   | Pattern_Any li -> fprintf f "@[{%a}@]" (pp_comma_list pp_pattern) li
   | Pattern_Geq e -> fprintf f "@[>= %a@]" pp_expr e
   | Pattern_Leq e -> fprintf f "@[<= %a@]" pp_expr e
@@ -278,16 +278,16 @@ let rec pp_stmt f s =
   | S_Return (Some e) -> fprintf f "return %a;" pp_expr e
   | S_Return None -> fprintf f "return;"
   | S_Cond (e, s1, { desc = S_Pass; _ }) ->
-      fprintf f "@[<hv>@[<h>if %a@ then@]@;<1 2>@[<hv>%a@]@ end@]" pp_expr e
+      fprintf f "@[<hv>@[<h>if %a@ then@]@;<1 2>@[<hv>%a@]@ end;@]" pp_expr e
         pp_stmt s1
   | S_Cond (e, s1, s2) ->
       fprintf f
         "@[<hv>@[<h>if %a@ then@]@;\
          <1 2>@[<hv>%a@]@ else@;\
-         <1 2>@[<hv>%a@]@ end@]" pp_expr e pp_stmt s1 pp_stmt s2
+         <1 2>@[<hv>%a@]@ end;@]" pp_expr e pp_stmt s1 pp_stmt s2
   | S_Assert e -> fprintf f "@[<2>assert@ %a;@]" pp_expr e
   | S_While (e, limit, s) ->
-      fprintf f "@[<hv>@[<h>while %a%a@ do@]@;<1 2>@[<hv>%a@]@ end@]" pp_expr e
+      fprintf f "@[<hv>@[<h>while %a%a@ do@]@;<1 2>@[<hv>%a@]@ end;@]" pp_expr e
         pp_loop_limit limit pp_stmt s
   | S_Repeat (s, e, limit) ->
       fprintf f "@[<hv 2>repeat@;<1 2>@[<hv>%a@]@;<1 0>@[<h>until@ %a%a;@]@]"

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -285,25 +285,6 @@ let rec pp_stmt f s =
         "@[<hv>@[<h>if %a@ then@]@;\
          <1 2>@[<hv>%a@]@ else@;\
          <1 2>@[<hv>%a@]@ end@]" pp_expr e pp_stmt s1 pp_stmt s2
-  | S_Case (e, case_li) ->
-      let pp_where f = function
-        | None -> ()
-        | Some e -> fprintf f "where %a@ " pp_expr e
-      in
-      let pp_case_alt f { desc = { pattern; where; stmt }; _ } =
-        match (pattern.desc, where) with
-        | Pattern_All, None ->
-            fprintf f "@[<hv 2>otherwise@ => @[<hv>%a@]@]" pp_stmt stmt
-        | Pattern_Any li, _ ->
-            fprintf f "@[<hv 2>when @[<h>%a@]@ %a=> @[<hv>%a@]@]"
-              (pp_comma_list pp_pattern) li pp_where where pp_stmt stmt
-        | _ ->
-            fprintf f "@[<hv 2>when %a@ %a=> @[<hv>%a@]@]" pp_pattern pattern
-              pp_where where pp_stmt stmt
-      in
-      fprintf f "@[<v 2>case %a of@ %a@;<1 -2>end@]" pp_expr e
-        (pp_print_list ~pp_sep:pp_print_space pp_case_alt)
-        case_li
   | S_Assert e -> fprintf f "@[<2>assert@ %a;@]" pp_expr e
   | S_While (e, limit, s) ->
       fprintf f "@[<hv>@[<h>while %a%a@ do@]@;<1 2>@[<hv>%a@]@ end@]" pp_expr e

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -511,7 +511,8 @@ let stmt :=
   annotated (
     | terminated_by(end_semicolon,
       | IF; e=expr; THEN; s1=stmt_list; s2=s_else;    <S_Cond>
-      | CASE; ~=expr; OF; alt=case_alt_list;          <S_Case>
+      | CASE; ~=expr; OF; alt=case_alt_list;
+          { desugar_case_stmt expr alt }
       | WHILE; ~=expr; ~=loop_limit; DO; ~=stmt_list; <S_While>
       | FOR; index_name=IDENTIFIER; EQ; start_e=expr; dir=direction;
           end_e=expr; limit=loop_limit; DO; body=stmt_list;

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -492,13 +492,10 @@ let case_alt :=
   )
 
 let case_otherwise :=
-  annotated(
-    loc=annotated(OTHERWISE); ARROW; stmt=stmt_list;
-      { { pattern = add_pos_from loc Pattern_All; where = None; stmt } }
-  )
+    OTHERWISE; ARROW; otherwise_stmt=stmt_list;
+      { otherwise_stmt }
 
-let case_alt_list :=
-    nlist_opt_terminated(case_alt, case_otherwise)
+let case_alt_list := nlist(case_alt)
 
 let otherwise == OTHERWISE; ARROW; stmt_list
 let otherwise_opt := ioption(otherwise)
@@ -512,7 +509,9 @@ let stmt :=
     | terminated_by(end_semicolon,
       | IF; e=expr; THEN; s1=stmt_list; s2=s_else;    <S_Cond>
       | CASE; ~=expr; OF; alt=case_alt_list;
-          { desugar_case_stmt expr alt }
+          { desugar_case_stmt expr alt (S_Unreachable |> ASTUtils.add_pos_from expr)}
+      | CASE; ~=expr; OF; alt=case_alt_list; ~=case_otherwise;
+          { desugar_case_stmt expr alt case_otherwise }
       | WHILE; ~=expr; ~=loop_limit; DO; ~=stmt_list; <S_While>
       | FOR; index_name=IDENTIFIER; EQ; start_e=expr; dir=direction;
           end_e=expr; limit=loop_limit; DO; body=stmt_list;

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -76,7 +76,7 @@
   end
 
   open Prelude
-
+  open Desugar
 %}
 
 %token <string> IDENTIFIER STRING_LIT
@@ -710,7 +710,8 @@ let conditional_stmt ==
   (* The first two cases of asl.ott are united in this simpler rule. *)
   | IF; ~=expr; THEN; ~=possibly_empty_block; ~=s_else;       < AST.S_Cond >
   | IF; ~=expr; THEN; ~=simple_stmt_list; ~=simple_else; EOL; < AST.S_Cond >
-  | CASE; ~=expr; OF; EOL; INDENT; ~=list(alt); DEDENT;   < AST.S_Case >
+  | CASE; ~=expr; OF; EOL; INDENT; alts=list(alt); DEDENT;
+    { desugar_case_stmt expr alts }
 
 let s_elsif == annotated ( ELSIF; ~=expr; THEN; ~=possibly_empty_block; <> )
 let s_else == ~=list(s_elsif); ~=ioption(ELSE; possibly_empty_block); < build_stmt_conds >

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -711,7 +711,7 @@ let conditional_stmt ==
   | IF; ~=expr; THEN; ~=possibly_empty_block; ~=s_else;       < AST.S_Cond >
   | IF; ~=expr; THEN; ~=simple_stmt_list; ~=simple_else; EOL; < AST.S_Cond >
   | CASE; ~=expr; OF; EOL; INDENT; alts=list(alt); DEDENT;
-    { desugar_case_stmt expr alts }
+    { desugar_case_stmt expr alts (AST.S_Unreachable |> ASTUtils.add_pos_from expr) }
 
 let s_elsif == annotated ( ELSIF; ~=expr; THEN; ~=possibly_empty_block; <> )
 let s_else == ~=list(s_elsif); ~=ioption(ELSE; possibly_empty_block); < build_stmt_conds >

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -273,10 +273,6 @@ let rec pp_stmt =
     | S_Cond (e, s1, s2) ->
         bprintf f "S_Cond (%a, %a, %a)" pp_expr e pp_stmt s1 pp_stmt s2
     | S_Return e -> bprintf f "S_Return (%a)" (pp_option pp_expr) e
-    | S_Case (e, cases) ->
-        bprintf f "S_Case (%a, %a)" pp_expr e
-          (pp_list (pp_annotated pp_case_alt))
-          cases
     | S_Assert e -> bprintf f "S_Assert (%a)" pp_expr e
     | S_While (e, limit, s) ->
         bprintf f "S_While(%a, %a, %a)" pp_expr e (pp_option pp_expr) limit
@@ -313,10 +309,6 @@ let rec pp_stmt =
 
 and pp_catcher f (name, ty, s) =
   bprintf f "(%a, %a, %a)" (pp_option pp_string) name pp_ty ty pp_stmt s
-
-and pp_case_alt f { pattern; where; stmt } =
-  bprintf f "{ pattern: %a; where: %a; stmt: %a }" pp_pattern pattern
-    (pp_option pp_expr) where pp_stmt stmt
 
 let pp_gdk f gdk =
   addb f

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -2742,9 +2742,6 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         let ses = SES.union3 ses_cond ses1 ses2 in
         (S_Cond (e_cond, s1', s2') |> here, env, ses) |: TypingRule.SCond
     (* End *)
-    (* Begin SCase *)
-    | S_Case _ -> desugar_case_stmt s |> annotate_stmt env |: TypingRule.SCase
-    (* End *)
     (* Begin SAssert *)
     | S_Assert e ->
         let t_e', e', ses_e = annotate_expr env e in
@@ -3423,8 +3420,6 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       | S_Repeat (body, _, _) -> from_stmt body
       | S_While _ | S_For _ -> MayNotInterrupt
       | S_Try (body, _, _) -> from_stmt body
-      | S_Case (_, _) ->
-          (* Should be unsugared, so only for v0 *) AssertedNotInterrupt
     (* End *)
 
     (** [check_stmt_interrupts name env body] checks that the function named

--- a/asllib/desugar.ml
+++ b/asllib/desugar.ml
@@ -148,14 +148,10 @@ let desugar_case_stmt e0 cases =
     (* End *)
   in
   (* Begin DesugarCaseStmt *)
-  let res_annotated =
-    match e0 with
-    | { desc = E_Var _ } -> cases_to_cond ~loc:e0 e0 cases
-    | _ ->
-        let x = fresh_var "__case__linearisation" in
-        let decl_x = S_Decl (LDK_Let, LDI_Var x, None, Some e0) in
-        S_Seq (decl_x |> add_pos_from e0, cases_to_cond ~loc:e0 (var_ x) cases)
-        |> add_pos_from e0
-    (* End *)
-  in
-  res_annotated.desc
+  match e0.desc with
+  | E_Var _ -> (cases_to_cond ~loc:e0 e0 cases).desc
+  | _ ->
+      let x = fresh_var "__case__linearisation" in
+      let decl_x = S_Decl (LDK_Let, LDI_Var x, None, Some e0) in
+      S_Seq (decl_x |> add_pos_from e0, cases_to_cond ~loc:e0 (var_ x) cases)
+(* End *)

--- a/asllib/desugar.ml
+++ b/asllib/desugar.ml
@@ -132,6 +132,7 @@ let desugar_lhs_fields_tuple base field_opts =
       LE_Destructuring (List.map desugar_one field_opts)
 
 let desugar_case_stmt e0 cases otherwise =
+  (* Begin CaseToCond *)
   let case_to_cond e0 case tail =
     let { pattern; where; stmt } = case.desc in
     let e_pattern = E_Pattern (e0, pattern) |> add_pos_from pattern in
@@ -141,6 +142,7 @@ let desugar_case_stmt e0 cases otherwise =
       | Some e_where -> binop BAND e_pattern e_where
     in
     S_Cond (cond, stmt, tail) |> add_pos_from case
+    (* End *)
   in
   (* Begin CasesToCond *)
   let cases_to_cond e0 cases =

--- a/asllib/desugar.mli
+++ b/asllib/desugar.mli
@@ -78,6 +78,13 @@ val desugar_lhs_tuple : lhs_access option list annotated -> lexpr
 
 val desugar_lhs_fields_tuple :
   identifier annotated -> lhs_field option list -> lexpr_desc
-(** [desugar_lhs_fields_tuple x flds] desugards a left-hand side of the form
+(** [desugar_lhs_fields_tuple x flds] desugars a left-hand side of the form
     [x.(fld1, ..., fldk)] to [(x.fld1, ..., x.fldk)], ensuring that the [flds]
     are unique. *)
+
+val desugar_case_stmt :
+  expr_desc annotated -> case_alt_desc annotated list -> stmt_desc
+(** [desugar_case_stmt e0 cases] desugars a case statement for the expression
+    [e0] and case alternatives [cases] into a conditional statement
+    (possibly preceded an assignment of the condition [e0] to a fresh temporary
+    variable). *)

--- a/asllib/desugar.mli
+++ b/asllib/desugar.mli
@@ -86,5 +86,5 @@ val desugar_case_stmt :
   expr_desc annotated -> case_alt_desc annotated list -> stmt_desc
 (** [desugar_case_stmt e0 cases] desugars a case statement for the expression
     [e0] and case alternatives [cases] into a conditional statement
-    (possibly preceded an assignment of the condition [e0] to a fresh temporary
-    variable). *)
+    (possibly preceded by an assignment of the condition [e0] to a fresh
+     variable). *)

--- a/asllib/desugar.mli
+++ b/asllib/desugar.mli
@@ -83,8 +83,9 @@ val desugar_lhs_fields_tuple :
     are unique. *)
 
 val desugar_case_stmt :
-  expr_desc annotated -> case_alt_desc annotated list -> stmt_desc
-(** [desugar_case_stmt e0 cases] desugars a case statement for the expression
-    [e0] and case alternatives [cases] into a conditional statement
-    (possibly preceded by an assignment of the condition [e0] to a fresh
-     variable). *)
+  expr_desc annotated -> case_alt_desc annotated list -> stmt -> stmt_desc
+(** [desugar_case_stmt e0 cases otherwise] desugars a case statement for the
+    discriminant expression [e0], case alternatives [cases], and otherwise
+    statement [otherwise].
+    The result is a conditional statement, possibly preceded by an assignment
+    of the condition [e0] to a fresh variable). *)

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -485,7 +485,6 @@
 \newcommand\Nlocaldeclkeyword[0]{\hyperlink{def-nlocaldeclkeyword}{\nonterminal{local\_decl\_keyword\_non\_var}}}
 \newcommand\Ndirection[0]{\hyperlink{def-ndirection}{\nonterminal{direction}}}
 \newcommand\Ncasealt[0]{\hyperlink{def-ncasealt}{\nonterminal{case\_alt}}}
-\newcommand\Ncaseotherwise[0]{\hyperlink{def-ncaseotherwise}{\nonterminal{case\_otherwise}}}
 \newcommand\Ncasealtlist[0]{\hyperlink{def-ncasealtlist}{\nonterminal{case\_alt\_list}}}
 \newcommand\Npatternlist[0]{\hyperlink{def-npatternlist}{\nonterminal{pattern\_list}}}
 \newcommand\Notherwiseopt[0]{\hyperlink{def-notherwiseopt}{\nonterminal{otherwise\_opt}}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -152,14 +152,14 @@
 \newcommand\tododefine[1]{\hyperlink{tododefine}{\color{red}{\texttt{#1}}}}
 \newcommand\lrmcomment[1]{}
 \newcommand\textfunc[1]{\textit{#1}}
-\newcommand\TypingRule[1]{\subsubsection{TypingRule.#1{\label{sec:TypingRule.#1}}}}
-\newcommand\SemanticsRule[1]{\subsubsection{SemanticsRule.#1{\label{sec:SemanticsRule.#1}}}}
 \newcommand\ProseParagraph[0]{\subsubsection{Prose}}
 \newcommand\FormallyParagraph[0]{\subsubsection{Formally}}
 \newcommand\AllApply[0]{All of the following apply:}
 \newcommand\AllApplyCase[1]{All of the following apply (\textsc{#1}):}
 \newcommand\OneApplies[0]{One of the following applies:}
 \newcommand\Proseeqdef[2]{define #1 as #2}
+\newcommand\RequirementDef[1]{\paragraph{R\_#1\label{Requirement.#1}}}
+\newcommand\RequirementRef[1]{\nameref{Requirement.#1}}
 
 \usepackage{enumitem}
 \renewlist{itemize}{itemize}{20}
@@ -1296,7 +1296,6 @@
 \newcommand\usebitfield[0]{\hyperlink{def-usebitfield}{\textfunc{use\_bitfield}}}
 \newcommand\useconstraint[0]{\hyperlink{def-useconstraint}{\textfunc{use\_constraint}}}
 \newcommand\usestmt[0]{\hyperlink{def-usestmt}{\textfunc{use\_s}}}
-\newcommand\usecase[0]{\hyperlink{def-usecase}{\textfunc{use\_case}}}
 \newcommand\usecatcher[0]{\hyperlink{def-usecatcher}{\textfunc{use\_catcher}}}
 \newcommand\builddependencies[0]{\hyperlink{def-builddependencies}{\textfunc{build\_dependencies}}}
 \newcommand\Prosebuilddependencies[2]{\hyperlink{def-builddependencies}{building} the \dependencygraphterm\ of #1 yields #2}
@@ -1532,6 +1531,11 @@
 \newcommand\defusedependencyterm[0]{\hyperlink{def-builddependencies}{def-use dependency}}
 \newcommand\defusedependenciesterm[0]{\hyperlink{def-builddependencies}{def-use dependencies}}
 \newcommand\dependencygraphterm[0]{\hyperlink{def-builddependencies}{def-use dependency graph}}
+
+\newcommand\casediscriminantterm[0]{\hyperlink{def-casediscriminantterm}{case discriminant}}
+\newcommand\casealternativeterm[0]{\hyperlink{def-casealternativeterm}{case alternative}}
+\newcommand\casealternativesterm[0]{\hyperlink{def-casealternativeterm}{case alternatives}}
+\newcommand\otherwisecaseterm[0]{\hyperlink{def-otherwisecaseterm}{otherwise case}}
 
 % Side effect macros
 
@@ -2368,6 +2372,7 @@
 \newcommand\vdone[0]{\texttt{d1}}
 \newcommand\vdtwo[0]{\texttt{d2}}
 \newcommand\ve[0]{\texttt{e}}
+\newcommand\vediscriminant[0]{\texttt{e\_discriminant}}
 \newcommand\veminusone[0]{\texttt{e\_minus\_1}}
 \newcommand\veupper[0]{\texttt{e\_upper}}
 \newcommand\veinit[0]{\texttt{e\_init}}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -445,8 +445,6 @@ the local declaration item is
   |\ & \SReturn(\expr?)
   \hypertarget{ast-scond}{} &\\
   |\ & \SCond(\expr, \stmt, \stmt)
-  \hypertarget{ast-scase}{} &\\
-  |\ & \SCase(\expr, \casealt^*)
   \hypertarget{ast-sassert}{} &\\
   |\ & \SAssert(\expr)
   \hypertarget{ast-sfor}{} &\\

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -33,7 +33,7 @@ Bitfields may have nested bitfields. This can have several uses, one of which be
 different views of a register.
 
 We now define several properties of bitfields, illustrated by the example below.
-These are used to define \nameref{sec:Requirement.BitifledAlignment}.
+These are used to define \RequirementRef{BitifledAlignment}.
 
 The \hypertarget{def-absolutename}{\absolutename} of a (possibly-nested) bitfield is the list of identifiers starting from the
 name of the top-level bitfield containing it and following with the names of the nested bitfields,
@@ -61,7 +61,7 @@ They exist in the same scope, since \texttt{fmt0.later1} is a prefix of
 In contrast, a pair of bitfields with \absolutenames\ \texttt{fmt0.common}
 and \texttt{fmt1.common}, since neither of \texttt{fmt0} and \texttt{fmt1} is a prefix of the other.
 
-\subsubsection{Requirement.BitifledAlignment\label{sec:Requirement.BitifledAlignment}}
+\RequirementDef{BitifledAlignment}
 For every two bitfields of a given bitvector type,
 if they share the same name and exist in the same \bitfieldscope\ then their \absoluteslices\ must be
 equal.

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -33,7 +33,7 @@ Bitfields may have nested bitfields. This can have several uses, one of which be
 different views of a register.
 
 We now define several properties of bitfields, illustrated by the example below.
-These are used to define \RequirementRef{BitifledAlignment}.
+These are used to define \RequirementRef{BitfieldAlignment}.
 
 The \hypertarget{def-absolutename}{\absolutename} of a (possibly-nested) bitfield is the list of identifiers starting from the
 name of the top-level bitfield containing it and following with the names of the nested bitfields,
@@ -61,7 +61,7 @@ They exist in the same scope, since \texttt{fmt0.later1} is a prefix of
 In contrast, a pair of bitfields with \absolutenames\ \texttt{fmt0.common}
 and \texttt{fmt1.common}, since neither of \texttt{fmt0} and \texttt{fmt1} is a prefix of the other.
 
-\RequirementDef{BitifledAlignment}
+\RequirementDef{BitfieldAlignment}
 For every two bitfields of a given bitvector type,
 if they share the same name and exist in the same \bitfieldscope\ then their \absoluteslices\ must be
 equal.
@@ -602,7 +602,7 @@ The function
   \overname{\N}{\vwidth}
 ) \aslto \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-checks \nameref{sec:Requirement.BitifledAlignment}
+checks \RequirementRef{BitfieldAlignment}
 for every pair of bitfields in $\vbitfields$, contained in a
 bitvector type of width $\vwidth$ in the static environment $\tenv$.
 \ProseOtherwiseTypeError

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -23,7 +23,8 @@ control: control.tex $(CONTROLS)
 ASLReference.pdf: control\
 				ASLASTLines.tex ASLTypeSatisfactionLines.tex ASLStaticModelLines.tex ASLStaticInterpreterLines.tex\
 				ASLStaticEnvLines.tex ASLEnvLines.tex ASLASTUtilsLines.tex\
-				ASLTypingLines.tex ASLSemanticsLines.tex ASLStaticOperationsLines.tex
+				ASLTypingLines.tex ASLSemanticsLines.tex ASLStaticOperationsLines.tex\
+				desugarLines.tex
 	$(LATEX) ASLReference.tex
 	$(BIBTEX) ASLReference
 	$(LATEX) ASLReference.tex
@@ -41,6 +42,9 @@ ASLEnvLines.tex: ../env.ml
 	$(BENTO) $< > $@
 
 ASLSemanticsLines.tex: ../Interpreter.ml
+	$(BENTO) $< > $@
+
+desugarLines.tex: ../desugar.ml
 	$(BENTO) $< > $@
 
 ASL%Lines.tex: ../%.ml

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -1550,12 +1550,6 @@ One of the following applies:
     \item define $\ids$ as the union of applying $\useexpr$ to $\ve$ and $\usestmt$ to both of $\vsone$ and $\vstwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_case}):
-  \begin{itemize}
-    \item $\vs$ is the case statement with expression $\ve$ and case list $\vcases$;
-    \item define $\ids$ as the union of applying $\useexpr$ to $\ve$ and $\usecase$ to every case in $\vcases$.
-  \end{itemize}
-
   \item All of the following apply (\textsc{s\_for}):
   \begin{itemize}
     \item $\vs$ is the for statement $\SFor\left\{\begin{array}{rcl}
@@ -1645,12 +1639,6 @@ One of the following applies:
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[s\_case]{}{
-  \usestmt(\overname{\SCase(\ve, \vcases)}{\vs}) \typearrow \overname{\useexpr(\ve) \cup \bigcup_{\vc\in\vcases}\usecase(\vc)}{\ids}
-}
-\end{mathpar}
-
-\begin{mathpar}
 \inferrule[s\_for]{
   \ids \eqdef \useexpr(\vlimit) \cup \useexpr(\vstarte) \cup \useexpr(\vende) \cup \usestmt(\vbody)
 }{
@@ -1702,32 +1690,6 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[s\_unreachable]{}{
   \usestmt(\overname{\SUnreachable}{\vs}) \typearrow \overname{\emptyset}{\ids}
-}
-\end{mathpar}
-
-\subsubsection{TypingRule.UseCase \label{sec:TypingRule.UseCase}}
-\hypertarget{def-usecase}{}
-The function
-\[
-\usecase(\overname{\casealt}{\vc}) \aslto \overname{\pow{\identifier}}{\ids}
-\]
-returns the set of identifiers $\ids$ which the case alternative $\vc$ depends on.
-
-\subsubsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\vc$ is the case alternative for the pattern $\pattern$, \optional\ \texttt{where} expression
-        $\veopt$ and \texttt{otherwise} statement $\vs$;
-  \item define $\ids$ as the union of applying $\usepattern$ to $\pattern$, applying $\useexpr$ to $\veopt$,
-        and applying $\usestmt$ to $\vs$.
-\end{itemize}
-
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \ids \eqdef \usepattern(\pattern) \cup \useexpr(\veopt) \cup \usestmt(\vs)
-}{
-  \usecase(\overname{\{ \CasePattern : \pattern, \CaseWhere : \veopt, \CaseStmt : \vs \}}{\vc}) \typearrow \ids
 }
 \end{mathpar}
 

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -1500,6 +1500,7 @@ compound conditional statement (see \listingref{ast-case2} for an example):
   \desugarcasestmt(\vezero, \vcases, \votherwise) \astarrow \overname{\SSeq(\vdeclx, \vscond)}{\news}
 }
 \end{mathpar}
+\CodeSubsection{\DesugarCaseStmtBegin}{\DesugarCaseStmtEnd}{../desugar.ml}
 
 \subsubsection{ASTRule.CasesToCond\label{sec:ASTRule.CasesToCond}}
 \hypertarget{def-casestocond}{}
@@ -1532,6 +1533,7 @@ into a statement $\news$.
   \casestocond(\ve, \overname{[\vcase] \concat \vcasesone}{\vcases}, \votherwise) \astarrow \news
 }
 \end{mathpar}
+\CodeSubsection{\CasesToCondBegin}{\CasesToCondEnd}{../desugar.ml}
 
 \subsubsection{ASTRule.CaseToCond\label{sec:ASTRule.CaseToCond}}
 \hypertarget{def-casetocond}{}
@@ -1553,6 +1555,7 @@ a list of \texttt{case} alternatives already converted to conditionals, into a c
   \casetocond(\vezero, \vcase, \vtail) \astarrow \overname{\SCond(\vcond, \vstmt, \vtail)}{\news}
 }
 \end{mathpar}
+\CodeSubsection{\CaseToCondBegin}{\CaseToCondEnd}{../desugar.ml}
 
 \subsection{Typing}
 Since case statements are transformed into other statements,

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -50,7 +50,7 @@ We now define the syntax, abstract syntax, typing, and semantics for the followi
 \item Setter assignment statements (see \secref{SetterAssignmentStatements})
 \item Declaration statements (see \secref{DeclarationStatements})
 \item Declaration statements with an elided parameter (see \secref{DeclarationStatementsElidedParameter})
-\item Sequencing statements (see \secref{SeuqncingStatements})
+\item Sequencing statements (see \secref{SequencingStatement})
 \item Call statements (see \secref{CallStatements})
 \item Conditional statements (see \secref{ConditionalStatements})
 \item Case statements (see \secref{CaseStatements})
@@ -902,13 +902,23 @@ Otherwise, the result is a parse error.
 \begin{mathpar}
 \inferrule{
   \buildelidedparamcall (\vcall) \astarrow \astversion{\vcall} \\
-  \desugarelidedparameter(\astof{\vlocaldeclkeyword}, \astof{\vdeclitem}, \astof{\vasty}, \astversion{\vcall}) \astarrow \vastnode
+  {
+    \begin{array}{r}
+      \desugarelidedparameter(\astof{\vlocaldeclkeyword}, \astof{\vdeclitem}, \astof{\vasty}, \astversion{\vcall}) \astarrow \\
+      \vastnode
+    \end{array}
+  }
 }{
   {
-    \begin{array}{l}
-    \buildstmt(\Nstmt \\
-    \qquad (\punnode{\Nlocaldeclkeyword}, \punnode{\Ndeclitem}, \punnode{\Nasty}, \Teq, \namednode{\vcall}{\Nelidedparamcall}, \Tsemicolon)) \astarrow \vastnode
-    \end{array}
+    \buildstmt\left(
+      \Nstmt\left(
+        \begin{array}{l}
+          \punnode{\Nlocaldeclkeyword}, \\
+          \wrappedline\ \punnode{\Ndeclitem}, \punnode{\Nasty}, \Teq, \\
+          \wrappedline\ \namednode{\vcall}{\Nelidedparamcall}, \Tsemicolon
+        \end{array}
+      \right)
+    \right) \astarrow \vastnode
   }
 }
 \end{mathpar}
@@ -919,9 +929,9 @@ Otherwise, the result is a parse error.
   \desugarelidedparameter(\LDKVar, \astof{\vdeclitem}, \astof{\vasty}, \astversion{\vcall}) \astarrow \vastnode
 }{
   {
-    \begin{array}{l}
-    \buildstmt(\Nstmt \\
-    \qquad (\Tvar, \punnode{\Ndeclitem}, \punnode{\Nasty}, \Teq, \namednode{\vcall}{\Nelidedparamcall}, \Tsemicolon)) \astarrow \vastnode
+    \begin{array}{r}
+    \buildstmt(\Nstmt(\Tvar, \punnode{\Ndeclitem}, \punnode{\Nasty}, \Teq, \namednode{\vcall}{\Nelidedparamcall}, \Tsemicolon)) \astarrow\\
+     \vastnode
     \end{array}
   }
 }
@@ -930,7 +940,7 @@ Otherwise, the result is a parse error.
 \subsection{Typing and semantics}
 As given by the applying the relevant rules to the desugared AST (see \secref{DeclarationStatements}).
 
-\section{Sequencing Statements\label{sec:SeuqncingStatements}}
+\section{Sequencing Statements\label{sec:SequencingStatement}}
 \subsection{Syntax}
 \begin{flalign*}
 \Nstmtlist \derives \ & \nonemptylist{\Nstmt} &
@@ -1285,7 +1295,8 @@ $\vstwo$ will be evaluated);
 \CodeSubsection{\EvalSCondBegin}{\EvalSCondEnd}{../Interpreter.ml}
 
 \section{Case Statements\label{sec:CaseStatements}}
-Case statements have the syntax shown below.
+Case statements allow executing different statements, based on which
+condition an expression satisfies.
 
 \subsection{Syntax}
 \begin{flalign*}
@@ -1304,15 +1315,18 @@ The list following the \Tof\ keyword consists of \emph{\casealternativesterm},
 optionally ending with an \emph{\otherwisecaseterm}, which follows the \Totherwise\ keyword.
 
 \subsection{Abstract Syntax}
-Case statements are considered syntactic sugar and are desugared-away via \\
-\nameref{sec:ASTRule.DesugarCaseStmt}
-by considering the following requirements:
+Case statements are considered syntactic sugar and are \emph{desugared}.
+That is, they are transformed into an untyped AST node that does not have
+an explicit representation for \texttt{case} statements.
+This is achieved via \nameref{sec:ASTRule.DesugarCaseStmt},
+which obeys the following requirements:
 \RequirementDef{CaseDiscriminant} The \casediscriminantterm\ of a \texttt{case}
 statement should be evaluated only once each time the case statement is evaluated.
 
-\RequirementDef{CaseAlternatives} The \casealternativesterm\ are examined in sequential order.
+\RequirementDef{CaseAlternatives} The \casealternativesterm\ are examined
+one after another, in the order they are listed.
 If any of the patterns match the \casediscriminantterm (and the guard
-expression is true, if present --- see below) then this \casealternativeterm\ is considered selected,
+expression is true, if present) then this \casealternativeterm\ is considered selected,
 its statement list is executed, and the \texttt{case} statement ends without examining any further
 \casealternativesterm.
 
@@ -1329,18 +1343,21 @@ It is not a static error if it can be statically determined that none of the pat
 and there is no \otherwisecaseterm, it is a dynamic error.
 
 \subsubsection{Example}
-\listingref{ast-case1} shows an example of how a \texttt{case} statement can be desugared into a corresponding
+\listingref{ast-case1} shows an example of how a \texttt{case} statement can be transformed into a corresponding
 compound condition statement.
-\ASLListing{Desugaring a case statement with a variable as the case discriminant}{ast-case1}{\syntaxtests/ASTRule.Desugar_SCase1.asl}
+\ASLListing{Transforming a case statement with a variable as the case discriminant}{ast-case1}{\syntaxtests/ASTRule.Desugar_SCase1.asl}
 
-\listingref{ast-case2} shows an example of how a \texttt{case} statement can be desugared into
-by storing the \casediscriminantterm\ in a variable and by adding
-a call to \Tunreachable, to ensure that a dynamic error occurs when no \casealternativeterm\ is selected.
-\ASLListing{Desugaring a case statement with a non-variable as the case discriminant
+\listingref{ast-case2} shows an example of how a \texttt{case} statement can be transformed into
+a statement that does not contain any \text{case} statement.
+By storing the \casediscriminantterm\ in a variable and by adding
+a call to \Tunreachable, the transformation ensures that a dynamic error occurs when no
+\casealternativeterm\ is selected.
+\ASLListing{Transforming a case statement with a non-variable as the case discriminant
 and no otherwise case}{ast-case2}{\syntaxtests/ASTRule.Desugar_SCase2.asl}
 
 The untyped AST contains non-terminals for \casealternativesterm, which exist
-only as a data type used by the desugaring function:
+only as a data type used by $\desugarcasestmt$ and do not later appear in the untyped
+AST:
 
 \begin{flalign*}
 \casealt \derives\ & \{ \CasePattern : \pattern, \CaseWhere : \expr?, \CaseStmt : \stmt \} &
@@ -1483,27 +1500,27 @@ The relation
 transforms a \casediscriminantterm\ $\vezero$ and a list of \casealternativesterm\ $\vcases$
 into a statement $\news$.
 
-\subsubsection{Prose}
-One of the following applies:
-\begin{itemize}
-  \item All of the following apply (\textsc{var}):
-  \begin{itemize}
-    \item $\vezero$ is a variable expression;
-    \item applying $\casestocond$ to $\vezero$ and $\vcases$ yields $\news$.
-  \end{itemize}
+% \subsubsection{Prose}
+% One of the following applies:
+% \begin{itemize}
+%   \item All of the following apply (\textsc{var}):
+%   \begin{itemize}
+%     \item $\vezero$ is a variable expression;
+%     \item applying $\casestocond$ to $\vezero$ and $\vcases$ yields $\news$.
+%   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_var}):
-  \begin{itemize}
-    \item $\vezero$ is not a variable expression;
-    \item let $\vx$ be a fresh identifier;
-    \item define $\vdeclx$ the statement declaring $\vx$ as an immutable variable initialized by $\vezero$;
-    \item applying $\casestocond$ to the variable expression for $\vx$ ($\EVar(\vx)$) and $\vcases$ yields
-          the condition statement $\vscond$;
-    \item define $\news$ as the sequence statement for $\vdeclx$ and $\vscond$.
-  \end{itemize}
-\end{itemize}
+%   \item All of the following apply (\textsc{non\_var}):
+%   \begin{itemize}
+%     \item $\vezero$ is not a variable expression;
+%     \item let $\vx$ be a fresh identifier;
+%     \item define $\vdeclx$ the statement declaring $\vx$ as an immutable variable initialized by $\vezero$;
+%     \item applying $\casestocond$ to the variable expression for $\vx$ ($\EVar(\vx)$) and $\vcases$ yields
+%           the condition statement $\vscond$;
+%     \item define $\news$ as the sequence statement for $\vdeclx$ and $\vscond$.
+%   \end{itemize}
+% \end{itemize}
 
-\subsubsection{Formally}
+% \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[var]{
   \astlabel(\vezero) = \EVar\\
@@ -1537,24 +1554,24 @@ The function
 transforms an expression $\ve$ and a list of \texttt{case} alternatives $\vcases$
 into a statement $\news$.
 
-\subsubsection{Prose}
-One of the following applies:
-\begin{itemize}
-  \item All of the following apply (\textsc{last}):
-  \begin{itemize}
-    \item $\vcases$ is the list consisting of just $\vcase$;
-    \item applying $\casetocond$ to $\ve$, $\vcase$, and $\SUnreachable$ yields $\news$.
-  \end{itemize}
+% \subsubsection{Prose}
+% One of the following applies:
+% \begin{itemize}
+%   \item All of the following apply (\textsc{last}):
+%   \begin{itemize}
+%     \item $\vcases$ is the list consisting of just $\vcase$;
+%     \item applying $\casetocond$ to $\ve$, $\vcase$, and $\SUnreachable$ yields $\news$.
+%   \end{itemize}
 
-  \item All of the following apply (\textsc{not\_last}):
-  \begin{itemize}
-    \item $\vcases$ is the list with $\vcase$ as its \head\ and a non-empty list $\vcasesone$ as its \tail;
-    \item applying $\casestocond$ to $\ve$ and $\vcasesone$ yields $\vsone$;
-    \item applying $\casetocond$ to $\ve$, $\vcase$, and $\vsone$ yields $\news$.
-  \end{itemize}
-\end{itemize}
+%   \item All of the following apply (\textsc{not\_last}):
+%   \begin{itemize}
+%     \item $\vcases$ is the list with $\vcase$ as its \head\ and a non-empty list $\vcasesone$ as its \tail;
+%     \item applying $\casestocond$ to $\ve$ and $\vcasesone$ yields $\vsone$;
+%     \item applying $\casetocond$ to $\ve$, $\vcase$, and $\vsone$ yields $\news$.
+%   \end{itemize}
+% \end{itemize}
 
-\subsubsection{Formally}
+% \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[last]{
   \casetocond(\ve, \vcase, \SUnreachable) \astarrow \news
@@ -1584,20 +1601,20 @@ transforms an expression $\vezero$ (the condition used for a \texttt{case} state
 a single \texttt{case} alternative $\vcase$, and a statement $\vtail$, which represents
 a list of \texttt{case} alternatives already converted to conditionals, into a condition statement $\news$.
 
-\subsubsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item view $\vcase$ as the \texttt{case} alternative with pattern $\vpattern$, optional \texttt{where} clause $\vwhere$,
-        and statement $\vstmt$;
-  \item define $\vepattern$ as the pattern expression for expression $\vezero$ and the pattern \\
-        $\vpattern$;
-  \item define $\vcond$ as the binary expression with operator $\BAND$ and expressions \\
-        $\vepattern$ and $\vewhere$
-        if $\vwhere$ is the expression $\vewhere$ and $\vepattern$, otherwise;
-  \item define $\news$ as the condition statement with the condition expression $\vcond$ and statements $\vstmt$ and $\vtail$.
-\end{itemize}
+% \subsubsection{Prose}
+% All of the following apply:
+% \begin{itemize}
+%   \item view $\vcase$ as the \texttt{case} alternative with pattern $\vpattern$, optional \texttt{where} clause $\vwhere$,
+%         and statement $\vstmt$;
+%   \item define $\vepattern$ as the pattern expression for expression $\vezero$ and the pattern \\
+%         $\vpattern$;
+%   \item define $\vcond$ as the binary expression with operator $\BAND$ and expressions \\
+%         $\vepattern$ and $\vewhere$
+%         if $\vwhere$ is the expression $\vewhere$ and $\vepattern$, otherwise;
+%   \item define $\news$ as the condition statement with the condition expression $\vcond$ and statements $\vstmt$ and $\vtail$.
+% \end{itemize}
 
-\subsubsection{Formally}
+% \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
   \vcase \eqname \{ \CasePattern : \vpattern, \CaseWhere : \vwhere, \CaseStmt : \vstmt \}\\

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -1285,8 +1285,7 @@ $\vstwo$ will be evaluated);
 \CodeSubsection{\EvalSCondBegin}{\EvalSCondEnd}{../Interpreter.ml}
 
 \section{Case Statements\label{sec:CaseStatements}}
-Case statements are considered syntactic sugar for compound condition statements,
-as defined by \nameref{sec:TypingRule.DesugarCaseStmt}.
+Case statements have the syntax shown below.
 
 \subsection{Syntax}
 \begin{flalign*}
@@ -1297,22 +1296,75 @@ as defined by \nameref{sec:TypingRule.DesugarCaseStmt}.
 \Ncaseotherwise \derives \ & \Totherwise \parsesep \Tarrow \parsesep \Nstmtlist &
 \end{flalign*}
 
+\hypertarget{def-casediscriminantterm}{}
+\hypertarget{def-casealternativeterm}{}
+\hypertarget{def-otherwisecaseterm}{}
+The expression following the \Tcase\ keyword is called the \emph{\casediscriminantterm}.
+The list following the \Tof\ keyword consists of \emph{\casealternativesterm},
+optionally ending with an \emph{\otherwisecaseterm}, which follows the \Totherwise\ keyword.
+
 \subsection{Abstract Syntax}
+Case statements are considered syntactic sugar and are desugared-away via \\
+\nameref{sec:ASTRule.DesugarCaseStmt}
+by considering the following requirements:
+\RequirementDef{CaseDiscriminant} The \casediscriminantterm\ of a \texttt{case}
+statement should be evaluated only once each time the case statement is evaluated.
+
+\RequirementDef{CaseAlternatives} The \casealternativesterm\ are examined in sequential order.
+If any of the patterns match the \casediscriminantterm (and the guard
+expression is true, if present --- see below) then this \casealternativeterm\ is considered selected,
+its statement list is executed, and the \texttt{case} statement ends without examining any further
+\casealternativesterm.
+
+\RequirementDef{CaseOtherwise} If no \casealternativeterm\ is selected, and there is an
+\otherwisecaseterm\, the \otherwisecaseterm\ is executed.
+
+\RequirementDef{CaseDiscriminantTesting} Testing the \casediscriminantterm\ against a \\
+pattern list
+follows the semantics of pattern matching defined in \chapref{PatternMatching}.
+It is not a static error if it can be statically determined that none of the patterns in a
+\casealternativeterm\ can match the discriminant.
+
+\RequirementDef{CaseNoCaseError} If no \casealternativeterm\ is selected,
+and there is no \otherwisecaseterm, it is a dynamic error.
+
+\subsubsection{Example}
+\listingref{ast-case1} shows an example of how a \texttt{case} statement can be desugared into a corresponding
+compound condition statement.
+\ASLListing{Desugaring a case statement with a variable as the case discriminant}{ast-case1}{\syntaxtests/ASTRule.Desugar_SCase1.asl}
+
+\listingref{ast-case2} shows an example of how a \texttt{case} statement can be desugared into
+by storing the \casediscriminantterm\ in a variable and by adding
+a call to \Tunreachable, to ensure that a dynamic error occurs when no \casealternativeterm\ is selected.
+\ASLListing{Desugaring a case statement with a non-variable as the case discriminant
+and no otherwise case}{ast-case2}{\syntaxtests/ASTRule.Desugar_SCase2.asl}
+
+The untyped AST contains non-terminals for \casealternativesterm, which exist
+only as a data type used by the desugaring function:
+
 \begin{flalign*}
-\stmt \derives\ & \SCase(\expr, \casealt^*) &
+\casealt \derives\ & \{ \CasePattern : \pattern, \CaseWhere : \expr?, \CaseStmt : \stmt \} &
 \end{flalign*}
 
 \subsubsection{ASTRule.SCase}
 \begin{mathpar}
 \inferrule{
-  \buildlist[\Ncasealt](\vcasealtlist) \astarrow \vcasealtlistast
+  \buildlist[\buildcasealt](\vcasealtlist) \astarrow \vcasealtlistast\\
+  \buildexpr(\vediscriminant) \astarrow \astversion{\vediscriminant}\\
+  \desugarcasestmt(\astversion{\vediscriminant}, \vcasealtlistast) \astarrow \vastnode
 }{
   {
-    \begin{array}{r}
-  \buildstmt(\overname{\Nstmt(\Tcase, \punnode{\Nexpr}, \Tof, \namednode{\vcasealtlist}{\Ncasealtlist}, \Tend, \Tsemicolon)}{\vparsednode})
-  \astarrow \\
-  \overname{\SCase(\astof{\vexpr}, \vcasealtlistast)}{\vastnode}
-    \end{array}
+  \buildstmt\left(\overname{
+    \Nstmt\left(
+      \begin{array}{l}
+        \Tcase, \namednode{\vediscriminant}{\Nexpr}, \Tof, \\
+        \wrappedline\ \namednode{\vcasealtlist}{\Ncasealtlist}, \\
+        \wrappedline\ \Tend, \Tsemicolon
+      \end{array}
+    \right)
+    }{\vparsednode}\right)
+  \astarrow
+  \vastnode
   }
 }
 \end{mathpar}
@@ -1422,62 +1474,60 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 
-\subsection{Typing}
-\subsubsection{TypingRule.DesugarCaseStmt\label{sec:TypingRule.DesugarCaseStmt}}
+\subsubsection{ASTRule.DesugarCaseStmt\label{sec:ASTRule.DesugarCaseStmt}}
 \hypertarget{def-desugarcasestmt}{}
 The relation
 \[
-\desugarcasestmt(\overname{\stmt}{\vs}) \;\aslrel\; \overname{\stmt}{\news}
+\desugarcasestmt(\overname{\expr}{\vezero}, \overname{\casealt^*}{\vcases}) \;\aslrel\; \overname{\stmt}{\news}
 \]
-transforms a case statement $\vs$ into a conditional statement $\news$.
+transforms a \casediscriminantterm\ $\vezero$ and a list of \casealternativesterm\ $\vcases$
+into a statement $\news$.
 
 \subsubsection{Prose}
-All of the following apply:
+One of the following applies:
 \begin{itemize}
-  \item $\vs$ is a \texttt{case} statement with expression $\ve$ and list of cases $\vcases$, that is, \\
-        $\SCase(\ve, \vcases)$;
-  \item One of the following applies:
+  \item All of the following apply (\textsc{var}):
   \begin{itemize}
-    \item All of the following apply (\textsc{var}):
-    \begin{itemize}
-      \item $\ve$ is a variable expression;
-      \item applying $\casestocond$ to $\ve$ and $\vcases$ yields $\news$.
-    \end{itemize}
+    \item $\vezero$ is a variable expression;
+    \item applying $\casestocond$ to $\vezero$ and $\vcases$ yields $\news$.
+  \end{itemize}
 
-    \item All of the following apply (\textsc{non\_var}):
-    \begin{itemize}
-      \item $\ve$ is not a variable expression;
-      \item let $\vx$ be a fresh identifier;
-      \item define $\vdeclx$ the statement declaring $\vx$ as an immutable variable initialized by $\ve$;
-      \item applying $\casestocond$ to the variable expression for $\vx$ ($\EVar(\vx)$) and $\vcases$ yields
-            the condition statement $\vscond$;
-      \item define $\news$ as the sequence statement for $\vdeclx$ and $\vscond$.
-    \end{itemize}
+  \item All of the following apply (\textsc{non\_var}):
+  \begin{itemize}
+    \item $\vezero$ is not a variable expression;
+    \item let $\vx$ be a fresh identifier;
+    \item define $\vdeclx$ the statement declaring $\vx$ as an immutable variable initialized by $\vezero$;
+    \item applying $\casestocond$ to the variable expression for $\vx$ ($\EVar(\vx)$) and $\vcases$ yields
+          the condition statement $\vscond$;
+    \item define $\news$ as the sequence statement for $\vdeclx$ and $\vscond$.
   \end{itemize}
 \end{itemize}
 
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[var]{
-  \astlabel(\ve) = \EVar\\
-  \casestocond(\ve, \vcases) \typearrow \news
+  \astlabel(\vezero) = \EVar\\
+  \casestocond(\vezero, \vcases) \typearrow \news
 }{
-  \desugarcasestmt(\overname{\SCase(\ve, \vcases)}{\vs}) \typearrow \news
+  \desugarcasestmt(\vezero, \vcases) \astarrow \news
 }
 \end{mathpar}
 
+To satisfy \RequirementRef{CaseDiscriminant}, the transformation assigns the
+\casediscriminantterm\ to a temporary variable, which is then used in a
+compound conditional statement (see \listingref{ast-case2} for an example):
 \begin{mathpar}
 \inferrule[non\_var]{
-  \astlabel(\ve) \neq \EVar\\
+  \astlabel(\vezero) \neq \EVar\\
   \vx \in \Identifiers \text{ is fresh}\\
-  \vdeclx \eqname \SDecl(\LDKLet, \LDIVar(\vx), \None, \langle\ve\rangle)\\
+  \vdeclx \eqname \SDecl(\LDKLet, \LDIVar(\vx), \None, \langle\vezero\rangle)\\
   \casestocond(\EVar(\vx), \vcases) \typearrow \vscond
 }{
-  \desugarcasestmt(\overname{\SCase(\ve, \vcases)}{\vs}) \typearrow \overname{\SSeq(\vdeclx, \vscond)}{\news}
+  \desugarcasestmt(\vezero, \vcases) \astarrow \overname{\SSeq(\vdeclx, \vscond)}{\news}
 }
 \end{mathpar}
 
-\subsubsection{TypingRule.CasesToCond\label{sec:TypingRule.CasesToCond}}
+\subsubsection{ASTRule.CasesToCond\label{sec:ASTRule.CasesToCond}}
 \hypertarget{def-casestocond}{}
 The function
 \[
@@ -1507,9 +1557,9 @@ One of the following applies:
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[last]{
-  \casetocond(\ve, \vcase, \SUnreachable) \typearrow \news
+  \casetocond(\ve, \vcase, \SUnreachable) \astarrow \news
 }{
-  \casestocond(\ve, \overname{[\vcase]}{\vcases}) \typearrow \news
+  \casestocond(\ve, \overname{[\vcase]}{\vcases}) \astarrow \news
 }
 \end{mathpar}
 
@@ -1519,11 +1569,11 @@ One of the following applies:
   \casestocond(\ve, \vcasesone) \typearrow \vsone\\
   \casetocond(\ve, \vcase, \vsone) \typearrow \news
 }{
-  \casestocond(\ve, \overname{[\vcase] \concat \vcasesone}{\vcases}) \typearrow \news
+  \casestocond(\ve, \overname{[\vcase] \concat \vcasesone}{\vcases}) \astarrow \news
 }
 \end{mathpar}
 
-\subsubsection{TypingRule.CaseToCond\label{sec:TypingRule.CaseToCond}}
+\subsubsection{ASTRule.CaseToCond\label{sec:ASTRule.CaseToCond}}
 \hypertarget{def-casetocond}{}
 The function
 \[
@@ -1554,33 +1604,17 @@ All of the following apply:
   \vepattern \eqdef \EPattern(\vezero, \vpattern)\\
   \vcond \eqdef \choice{\vwhere = \langle\vewhere\rangle}{\EBinop(\BAND, \vepattern, \vewhere)}{\vepattern}
 }{
-  \casetocond(\vezero, \vcase, \vtail) \typearrow \overname{\SCond(\vcond, \vstmt, \vtail)}{\news}
+  \casetocond(\vezero, \vcase, \vtail) \astarrow \overname{\SCond(\vcond, \vstmt, \vtail)}{\news}
 }
 \end{mathpar}
 
-\subsubsection{TypingRule.SCase\label{sec:TypingRule.SCase}}
-\subsubsection{Prose}
-All of the following apply:
-\begin{itemize}
-  \item $\vs$ is a case statement;
-  \item applying $\desugarcasestmt$ to $\vs$ transforms $\vs$ to a conditional statement $\vsp$;
-  \item annotating $\vsp$ in $\tenv$ yields $(\news, \newtenv, \vses)$\ProseOrTypeError.
-\end{itemize}
-\subsubsection{Formally}
-\begin{mathpar}
-\inferrule{
-  \astlabel(\vs) = \SCase\\
-  \desugarcasestmt(\vs) \typearrow \vsp\\
-  \annotatestmt(\tenv, \vsp) \typearrow (\news, \newtenv, \vses) \OrTypeError
-}{
-  \annotatestmt(\tenv,\vs) \typearrow (\news, \newtenv, \vses)
-}
-\end{mathpar}
-\CodeSubsection{\SCaseBegin}{\SCaseEnd}{../Typing.ml}
+\subsection{Typing}
+Since case statements are transformed into other statements,
+they do not require type system rules.
 \lrmcomment{This is related to \identr{WGSY}.}
 
 \subsection{Semantics}
-Since case statements are transformed into conditional statements,
+Since case statements are transformed into other statements,
 they do not appear in the typed AST and thus are not associated with a semantics.
 
 \section{Assertion Statements\label{sec:AssertionStatements}}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -1301,10 +1301,10 @@ condition an expression satisfies.
 \subsection{Syntax}
 \begin{flalign*}
 \Nstmt \derives \ & \Tcase \parsesep \Nexpr \parsesep \Tof \parsesep \Ncasealtlist \parsesep \Tend \parsesep \Tsemicolon &\\
+|\ & \Tcase \parsesep \Nexpr \parsesep \Tof \parsesep \Ncasealtlist \parsesep \Totherwise \parsesep \Tarrow &\\
+   & \wrappedline\ \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 \Ncasealtlist \derives \ & \NClist{\Ncasealt} \parsesep &\\
-                           |\ & \NClist{\Ncasealt} \parsesep \Ncaseotherwise &\\
 \Ncasealt \derives \ & \Twhen \parsesep \Npatternlist \parsesep \option{\Twhere \parsesep \Nexpr} \parsesep \Tarrow \parsesep \Nstmtlist &\\
-\Ncaseotherwise \derives \ & \Totherwise \parsesep \Tarrow \parsesep \Nstmtlist &
 \end{flalign*}
 
 \hypertarget{def-casediscriminantterm}{}
@@ -1339,7 +1339,7 @@ follows the semantics of pattern matching defined in \chapref{PatternMatching}.
 It is not a static error if it can be statically determined that none of the patterns in a
 \casealternativeterm\ can match the discriminant.
 
-\RequirementDef{CaseNoCaseError} If no \casealternativeterm\ is selected,
+\RequirementDef{CaseNoOtherwiseError} If no \casealternativeterm\ is selected,
 and there is no \otherwisecaseterm, it is a dynamic error.
 
 \subsubsection{Example}
@@ -1350,7 +1350,7 @@ compound condition statement.
 \listingref{ast-case2} shows an example of how a \texttt{case} statement can be transformed into
 a statement that does not contain any \text{case} statement.
 By storing the \casediscriminantterm\ in a variable and by adding
-a call to \Tunreachable, the transformation ensures that a dynamic error occurs when no
+a call to \texttt{Unreachable()}, the transformation ensures that a dynamic error occurs when no
 \casealternativeterm\ is selected.
 \ASLListing{Transforming a case statement with a non-variable as the case discriminant
 and no otherwise case}{ast-case2}{\syntaxtests/ASTRule.Desugar_SCase2.asl}
@@ -1364,11 +1364,18 @@ AST:
 \end{flalign*}
 
 \subsubsection{ASTRule.SCase}
+To satisfy \RequirementRef{CaseNoOtherwiseError}, when no \otherwisecaseterm\ exists,
+$\SUnreachable$ is used instead:
 \begin{mathpar}
-\inferrule{
+\inferrule[no\_otherwise]{
   \buildlist[\buildcasealt](\vcasealtlist) \astarrow \vcasealtlistast\\
   \buildexpr(\vediscriminant) \astarrow \astversion{\vediscriminant}\\
-  \desugarcasestmt(\astversion{\vediscriminant}, \vcasealtlistast) \astarrow \vastnode
+  {
+  \begin{array}{r}
+  \desugarcasestmt(\astversion{\vediscriminant}, \vcasealtlistast, \SUnreachable) \astarrow \\
+  \vastnode
+  \end{array}
+  }
 }{
   {
   \buildstmt\left(\overname{
@@ -1376,6 +1383,35 @@ AST:
       \begin{array}{l}
         \Tcase, \namednode{\vediscriminant}{\Nexpr}, \Tof, \\
         \wrappedline\ \namednode{\vcasealtlist}{\Ncasealtlist}, \\
+        \wrappedline\ \Tend, \Tsemicolon
+      \end{array}
+    \right)
+    }{\vparsednode}\right)
+  \astarrow
+  \vastnode
+  }
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[otherwise]{
+  \buildlist[\buildcasealt](\vcasealtlist) \astarrow \vcasealtlistast\\
+  \buildexpr(\vediscriminant) \astarrow \astversion{\vediscriminant}\\
+  \buildstmtlist(\votherwise) \astarrow \astversion{\votherwise}\\
+  {
+  \begin{array}{r}
+  \desugarcasestmt(\astversion{\vediscriminant}, \vcasealtlistast, \astversion{\votherwise}) \astarrow \\
+  \vastnode
+  \end{array}
+  }
+}{
+  {
+  \buildstmt\left(\overname{
+    \Nstmt\left(
+      \begin{array}{l}
+        \Tcase, \namednode{\vediscriminant}{\Nexpr}, \Tof, \\
+        \wrappedline\ \namednode{\vcasealtlist}{\Ncasealtlist}, \\
+        \wrappedline\ \Totherwise, \Tarrow, \namednode{\votherwise}{\Nstmtlist}, \\
         \wrappedline\ \Tend, \Tsemicolon
       \end{array}
     \right)
@@ -1395,29 +1431,10 @@ The function
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
-\inferrule[no\_otherwise]{
+\inferrule{
   \buildclist[\buildcasealt](\vcases) \typearrow \vastnode
 }{
   \buildcasealtlist(\overname{\Ncasealtlist(\vcases : \NClist{\Ncasealt})}{\vparsednode}) \astarrow \vastnode
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[otherwise]{
-  \buildclist[\buildcasealt](\vcases) \astarrow h\\
-  \buildcasealt(\votherwise) \astarrow t
-}{
-  {
-  \buildcasealtlist\left(\overname{
-      \Ncasealtlist\left(
-        \begin{array}{l}
-          \vcases : \NClist{\Ncasealt}, \\
-          \votherwise:\Ncaseotherwise
-        \end{array}
-    \right)
-    }{\vparsednode}\right) \astarrow
-  \overname{[h] \concat t}{\vastnode}
-  }
 }
 \end{mathpar}
 
@@ -1449,84 +1466,24 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 
-\subsubsection{ASTRule.CaseOtherwise\label{sec:ASTRule.CaseOtherwise}}
-\hypertarget{build-caseotherwise}{}
-The function
-\[
-\buildcaseotherwise(\overname{\parsenode{\Ncaseotherwise}}{\vparsednode}) \;\aslto\; \overname{\casealt}{\vastnode}
-\]
-transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
-
-\begin{mathpar}
-\inferrule{}{
-  {
-    \begin{array}{r}
-  \buildcaseotherwise(\overname{\Ncasealt(\Totherwise, \Tarrow, \namednode{\vstmts}{\Nstmtlist})}{\vparsednode})
-  \astarrow \\
-  \overname{\casealt(\CasePattern: \PatternAll, \CaseWhere: \None, \CaseStmt: \astof{\vstmtlist})}{\vastnode}
-    \end{array}
-  }
-}
-\end{mathpar}
-
-\subsubsection{ASTRule.OtherwiseOpt\label{sec:ASTRule.OtherwiseOpt}}
-\hypertarget{build-otherwiseopt}{}
-The function
-\[
-\buildotherwiseopt(\overname{\parsenode{\Notherwiseopt}}{\vparsednode}) \;\aslto\; \overname{\stmt?}{\vastnode}
-\]
-transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
-
-\begin{mathpar}
-\inferrule{
-  \buildoption[\buildstmtlist] (\vv)\astarrow \vastnode
-}{
-  {
-  \begin{array}{r}
-  \buildotherwiseopt(\overname{\Notherwiseopt(\namednode{\vv}{\option{\Totherwise, \Tarrow, \Nstmtlist}})}{\vparsednode})
-  \astarrow \\
-  \vastnode
-  \end{array}
-  }
-}
-\end{mathpar}
-
 \subsubsection{ASTRule.DesugarCaseStmt\label{sec:ASTRule.DesugarCaseStmt}}
 \hypertarget{def-desugarcasestmt}{}
 The relation
 \[
-\desugarcasestmt(\overname{\expr}{\vezero}, \overname{\casealt^*}{\vcases}) \;\aslrel\; \overname{\stmt}{\news}
+\desugarcasestmt(
+  \overname{\expr}{\vezero},
+  \overname{\casealt^*}{\vcases},
+  \overname{\stmt}{\votherwise}) \;\aslrel\; \overname{\stmt}{\news}
 \]
-transforms a \casediscriminantterm\ $\vezero$ and a list of \casealternativesterm\ $\vcases$
-into a statement $\news$.
+transforms a \casediscriminantterm\ $\vezero$, a list of \casealternativesterm\ $\vcases$,
+and a statement $\votherwise$ into a statement $\news$.
 
-% \subsubsection{Prose}
-% One of the following applies:
-% \begin{itemize}
-%   \item All of the following apply (\textsc{var}):
-%   \begin{itemize}
-%     \item $\vezero$ is a variable expression;
-%     \item applying $\casestocond$ to $\vezero$ and $\vcases$ yields $\news$.
-%   \end{itemize}
-
-%   \item All of the following apply (\textsc{non\_var}):
-%   \begin{itemize}
-%     \item $\vezero$ is not a variable expression;
-%     \item let $\vx$ be a fresh identifier;
-%     \item define $\vdeclx$ the statement declaring $\vx$ as an immutable variable initialized by $\vezero$;
-%     \item applying $\casestocond$ to the variable expression for $\vx$ ($\EVar(\vx)$) and $\vcases$ yields
-%           the condition statement $\vscond$;
-%     \item define $\news$ as the sequence statement for $\vdeclx$ and $\vscond$.
-%   \end{itemize}
-% \end{itemize}
-
-% \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[var]{
   \astlabel(\vezero) = \EVar\\
-  \casestocond(\vezero, \vcases) \typearrow \news
+  \casestocond(\vezero, \vcases, \votherwise) \typearrow \news
 }{
-  \desugarcasestmt(\vezero, \vcases) \astarrow \news
+  \desugarcasestmt(\vezero, \vcases, \votherwise) \astarrow \news
 }
 \end{mathpar}
 
@@ -1538,9 +1495,9 @@ compound conditional statement (see \listingref{ast-case2} for an example):
   \astlabel(\vezero) \neq \EVar\\
   \vx \in \Identifiers \text{ is fresh}\\
   \vdeclx \eqname \SDecl(\LDKLet, \LDIVar(\vx), \None, \langle\vezero\rangle)\\
-  \casestocond(\EVar(\vx), \vcases) \typearrow \vscond
+  \casestocond(\EVar(\vx), \vcases, \votherwise) \typearrow \vscond
 }{
-  \desugarcasestmt(\vezero, \vcases) \astarrow \overname{\SSeq(\vdeclx, \vscond)}{\news}
+  \desugarcasestmt(\vezero, \vcases, \votherwise) \astarrow \overname{\SSeq(\vdeclx, \vscond)}{\news}
 }
 \end{mathpar}
 
@@ -1548,35 +1505,21 @@ compound conditional statement (see \listingref{ast-case2} for an example):
 \hypertarget{def-casestocond}{}
 The function
 \[
-\casestocond(\overname{\expr}{\ve} \aslsep \overname{\casealt^*}{\vcases})
+\casestocond(
+  \overname{\expr}{\ve} \aslsep
+  \overname{\casealt^*}{\vcases} \aslsep
+  \overname{\stmt}{\votherwise})
 \;\aslrel\; \overname{\stmt}{\news}
 \]
-transforms an expression $\ve$ and a list of \texttt{case} alternatives $\vcases$
+transforms an expression $\ve$, a list of \texttt{case} alternatives $\vcases$,
+and a statement $\votherwise$
 into a statement $\news$.
 
-% \subsubsection{Prose}
-% One of the following applies:
-% \begin{itemize}
-%   \item All of the following apply (\textsc{last}):
-%   \begin{itemize}
-%     \item $\vcases$ is the list consisting of just $\vcase$;
-%     \item applying $\casetocond$ to $\ve$, $\vcase$, and $\SUnreachable$ yields $\news$.
-%   \end{itemize}
-
-%   \item All of the following apply (\textsc{not\_last}):
-%   \begin{itemize}
-%     \item $\vcases$ is the list with $\vcase$ as its \head\ and a non-empty list $\vcasesone$ as its \tail;
-%     \item applying $\casestocond$ to $\ve$ and $\vcasesone$ yields $\vsone$;
-%     \item applying $\casetocond$ to $\ve$, $\vcase$, and $\vsone$ yields $\news$.
-%   \end{itemize}
-% \end{itemize}
-
-% \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[last]{
-  \casetocond(\ve, \vcase, \SUnreachable) \astarrow \news
+  \casetocond(\ve, \vcase, \votherwise) \astarrow \news
 }{
-  \casestocond(\ve, \overname{[\vcase]}{\vcases}) \astarrow \news
+  \casestocond(\ve, \overname{[\vcase]}{\vcases}, \votherwise) \astarrow \news
 }
 \end{mathpar}
 
@@ -1586,7 +1529,7 @@ into a statement $\news$.
   \casestocond(\ve, \vcasesone) \typearrow \vsone\\
   \casetocond(\ve, \vcase, \vsone) \typearrow \news
 }{
-  \casestocond(\ve, \overname{[\vcase] \concat \vcasesone}{\vcases}) \astarrow \news
+  \casestocond(\ve, \overname{[\vcase] \concat \vcasesone}{\vcases}, \votherwise) \astarrow \news
 }
 \end{mathpar}
 
@@ -1601,20 +1544,6 @@ transforms an expression $\vezero$ (the condition used for a \texttt{case} state
 a single \texttt{case} alternative $\vcase$, and a statement $\vtail$, which represents
 a list of \texttt{case} alternatives already converted to conditionals, into a condition statement $\news$.
 
-% \subsubsection{Prose}
-% All of the following apply:
-% \begin{itemize}
-%   \item view $\vcase$ as the \texttt{case} alternative with pattern $\vpattern$, optional \texttt{where} clause $\vwhere$,
-%         and statement $\vstmt$;
-%   \item define $\vepattern$ as the pattern expression for expression $\vezero$ and the pattern \\
-%         $\vpattern$;
-%   \item define $\vcond$ as the binary expression with operator $\BAND$ and expressions \\
-%         $\vepattern$ and $\vewhere$
-%         if $\vwhere$ is the expression $\vewhere$ and $\vepattern$, otherwise;
-%   \item define $\news$ as the condition statement with the condition expression $\vcond$ and statements $\vstmt$ and $\vtail$.
-% \end{itemize}
-
-% \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
   \vcase \eqname \{ \CasePattern : \vpattern, \CaseWhere : \vwhere, \CaseStmt : \vstmt \}\\

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -355,17 +355,11 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \hypertarget{def-ncasealtlist}{}
 \begin{flalign*}
 \Ncasealtlist \derives \ & \NClist{\Ncasealt} &\\
-                      |\ & \NClist{\Ncasealt} \parsesep \Ncaseotherwise &\\
 \end{flalign*}
 
 \hypertarget{def-ncasealt}{}
 \begin{flalign*}
 \Ncasealt \derives \ & \Twhen \parsesep \Npatternlist \parsesep \option{\Twhere \parsesep \Nexpr} \parsesep \Tarrow \parsesep \Nstmtlist &
-\end{flalign*}
-
-\hypertarget{def-ncaseotherwise}{}
-\begin{flalign*}
-\Ncaseotherwise \derives \ & \Totherwise \parsesep \Tarrow \parsesep \Nstmtlist &
 \end{flalign*}
 
 \hypertarget{def-notherwiseopt}{}
@@ -389,6 +383,8 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \begin{flalign*}
 \Nstmt \derives \ & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nstmtlist \parsesep \Nselse \parsesep \Tend \parsesep \Tsemicolon &\\
 |\ & \Tcase \parsesep \Nexpr \parsesep \Tof \parsesep \Ncasealtlist \parsesep \Tend \parsesep \Tsemicolon &\\
+|\ & \Tcase \parsesep \Nexpr \parsesep \Tof \parsesep \Ncasealtlist \parsesep \Totherwise \parsesep \Tarrow &\\
+   & \wrappedline\ \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 |\ & \Twhile \parsesep \Nexpr \parsesep \Nlooplimit \parsesep \Tdo \parsesep \Nstmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 |\ & \Tfor \parsesep \Tidentifier \parsesep \Teq \parsesep \Nexpr \parsesep \Ndirection \parsesep
                     \Nexpr \parsesep \Nlooplimit \parsesep \Tdo &\\

--- a/asllib/tests/ASLSyntaxReference.t/ASTRule.Desugar_SCase1.asl
+++ b/asllib/tests/ASLSyntaxReference.t/ASTRule.Desugar_SCase1.asl
@@ -1,0 +1,22 @@
+func main () => integer
+begin
+  var x : integer = ARBITRARY: integer;
+  // The following case statement:
+  case x of
+    when 42 => x = 42;
+    when <= 42 => x = 0;
+    otherwise => x = 43;
+  end;
+  // can be desugared into the following condition statement:
+  if x IN {42} then
+    x = 42;
+  else
+    if x IN {<= 42} then
+      x = 0;
+    else
+      if x IN {-} then x = 43; else Unreachable(); end;
+    end;
+  end;
+
+  return x;
+end;

--- a/asllib/tests/ASLSyntaxReference.t/ASTRule.Desugar_SCase1.asl
+++ b/asllib/tests/ASLSyntaxReference.t/ASTRule.Desugar_SCase1.asl
@@ -11,11 +11,7 @@ begin
   if x IN {42} then
     x = 42;
   else
-    if x IN {<= 42} then
-      x = 0;
-    else
-      if x IN {-} then x = 43; else Unreachable(); end;
-    end;
+    if x IN {<= 42} then x = 0; else x = 43; end;
   end;
 
   return x;

--- a/asllib/tests/ASLSyntaxReference.t/ASTRule.Desugar_SCase2.asl
+++ b/asllib/tests/ASLSyntaxReference.t/ASTRule.Desugar_SCase2.asl
@@ -1,0 +1,22 @@
+func main () => integer
+begin
+  var x : integer;
+  // The following case statement:
+  case 3 of
+    when 42 => x = 42;
+    when <= 42 => x = 0;
+  end;
+  // can be desugared into the following statement:
+  let discriminant_var: integer {3} = 3;
+  if discriminant_var IN {42} then
+    x = 42;
+  else
+    if discriminant_var IN {<= 42} then
+      x = 0;
+    else
+      Unreachable();
+    end;
+  end;
+
+  return x;
+end;

--- a/asllib/tests/ASLSyntaxReference.t/run.t
+++ b/asllib/tests/ASLSyntaxReference.t/run.t
@@ -1,3 +1,5 @@
 Examples used in the ASL Syntax Reference:
   $ aslref expr1.asl
   $ aslref expr2.asl
+  $ aslref ASTRule.Desugar_SCase1.asl
+  $ aslref ASTRule.Desugar_SCase2.asl


### PR DESCRIPTION
* Moved desugaring of `case` statements to the AST building.
* Documented the desugaring in the ASL Reference.
* Added requirements for desugaring `case` statements to the ASL Reference.
* Added examples for desugaring `case` statements.
* Fixed pretty-printing of conditional and while statements by ending them with a ;
* Fixed pretty-printing of `-` patterns by surrounding them with braces.
* Optimized desugaring of case statements with an otherwise alternative by not adding an unnecessary condition with a call to `Unreachable()`.