### PR TITLE
[ci][asl] Upload ASLReference as job artifact

### DIFF
--- a/.github/workflows/build-asl-reference.yml
+++ b/.github/workflows/build-asl-reference.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
+  pull_request:
+    paths:
+      - 'asllib/doc/**'
 
 permissions: read-all
 


### PR DESCRIPTION
- [x] Makes the built PDF of ASLReference downloadable from the action result
- [x] Makes the workflow run on every PR that changes something in the `asllib/doc` folder