### PR TITLE
[asl][reference] Rename "statically evaluable" -> "symbolically evaluable"

### DIFF
--- a/asllib/SideEffect.ml
+++ b/asllib/SideEffect.ml
@@ -163,8 +163,8 @@ let is_pure = function
   | WritesLocal _ | WritesGlobal _ | CallsRecursive _ | ThrowsException _ ->
       false
 
-(* Begin IsStaticallyEvaluable *)
-let is_statically_evaluable = function
+(* Begin IsSymbolicallyEvaluable *)
+let is_symbolically_evaluable = function
   | ReadsLocal { immutable } | ReadsGlobal { immutable } -> immutable
   | WritesLocal _ | WritesGlobal _ | NonDeterministic | CallsRecursive _
   | ThrowsException _ | PerformsAssertions ->
@@ -228,8 +228,8 @@ module SES = struct
   let all_reads_are_immutable ses =
     ISet.is_empty ses.local_reads && ISet.is_empty ses.global_reads
 
-  (* Begin SESIsStaticallyEvaluable *)
-  let is_statically_evaluable ses =
+  (* Begin SESIsSymbolicallyEvaluable *)
+  let is_symbolically_evaluable ses =
     is_pure ses && (not ses.non_determinism)
     && (not ses.assertions_performed)
     && all_reads_are_immutable ses

--- a/asllib/SideEffect.mli
+++ b/asllib/SideEffect.mli
@@ -37,7 +37,7 @@ val compare : t -> t -> int
 val pp_print : Format.formatter -> t -> unit
 val time_frame : t -> TimeFrame.t
 val is_pure : t -> bool
-val is_statically_evaluable : t -> bool
+val is_symbolically_evaluable : t -> bool
 
 (** The module [SES] provides an abstraction over a set of side-effects. *)
 module SES : sig
@@ -58,7 +58,7 @@ module SES : sig
   (* Properties *)
   val max_time_frame : t -> TimeFrame.t
   val is_pure : t -> bool
-  val is_statically_evaluable : t -> bool
+  val is_symbolically_evaluable : t -> bool
   val equal : t -> t -> bool
   val is_deterministic : t -> bool
 

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1214,19 +1214,19 @@
 \newcommand\pairstomap[0]{\hyperlink{def-pairstomap}{\textfunc{pairs\_to\_map}}}
 \newcommand\assocopt[0]{\hyperlink{def-assocopt}{\textfunc{assoc\_opt}}}
 \newcommand\annotatefieldinit[0]{\hyperlink{def-annotatefieldinit}{\textfunc{annotate\_field\_init}}}
-\newcommand\annotatestaticinteger[0]{\hyperlink{def-annotatestaticinteger}{\textfunc{annotate\_static\_integer}}}
-\newcommand\annotatestaticallyevaluableexpr[0]{\hyperlink{def-annotatestaticallyevaluableexpr}{\textfunc{annotate\_statically\_evaluable\_expr}}}
-\newcommand\Proseannotatestaticallyevaluableexpr[3]{\hyperlink{def-annotatestaticallyevaluableexpr}{annotating} the
-    \staticallyevaluable\ expression #2 in the static environment #1 yields #3}
-\newcommand\annotatestaticconstrainedinteger[0]{\hyperlink{def-annotatestaticconstrainedinteger}{\textfunc{annotate\_static\_constrained\_integer}}}
+\newcommand\annotatesymbolicinteger[0]{\hyperlink{def-annotatesymbolicinteger}{\textfunc{annotate\_symbolic\_integer}}}
+\newcommand\annotatesymbolicallyevaluableexpr[0]{\hyperlink{def-annotatesymbolicallyevaluableexpr}{\textfunc{annotate\_symbolically\_evaluable\_expr}}}
+\newcommand\Proseannotatesymbolicallyevaluableexpr[3]{\hyperlink{def-annotatesymbolicallyevaluableexpr}{annotating} the
+    \symbolicallyevaluable\ expression #2 in the static environment #1 yields #3}
+\newcommand\annotatesymbolicconstrainedinteger[0]{\hyperlink{def-annotatesymbolicconstrainedinteger}{\textfunc{annotate\_symbolic\_constrained\_integer}}}
 \newcommand\checkatc[0]{\hyperlink{def-checkatc}{\textfunc{check\_atc}}}
 \newcommand\sliceswidth[0]{\hyperlink{def-sliceswidth}{\textfunc{slices\_width}}}
 \newcommand\slicewidth[0]{\hyperlink{def-slicewidth}{\textfunc{slice\_width}}}
 \newcommand\checkstructurelabel[0]{\hyperlink{def-checkstructurelabel}{\textfunc{check\_structure}}}
 \newcommand\checkstructureinteger[0]{\hyperlink{def-checkstructureinteger}{\textfunc{check\_structure\_integer}}}
-\newcommand\isstaticallyevaluable[0]{\hyperlink{def-isstaticallyevaluable}{\textfunc{is\_statically\_evaluable}}}
-\newcommand\checkstaticallyevaluable[0]{\hyperlink{def-checkstaticallyevaluable}{\textfunc{check\_statically\_evaluable}}}
-\newcommand\Prosecheckstaticallyevaluable[1]{\hyperlink{def-checkstaticallyevaluable}{checking} that #1 is \staticallyevaluable\ yields $\True$\ProseOrTypeError}
+\newcommand\issymbolicallyevaluable[0]{\hyperlink{def-issymbolicallyevaluable}{\textfunc{is\_symbolically\_evaluable}}}
+\newcommand\checksymbolicallyevaluable[0]{\hyperlink{def-checksymbolicallyevaluable}{\textfunc{check\_symbolically\_evaluable}}}
+\newcommand\Prosechecksymbolicallyevaluable[1]{\hyperlink{def-checksymbolicallyevaluable}{checking} that #1 is \symbolicallyevaluable\ yields $\True$\ProseOrTypeError}
 \newcommand\negateconstraint[0]{\hyperlink{def-negateconstraint}{\textfunc{negate\_constraint}}}
 \newcommand\getwellconstrainedstructure[0]{\hyperlink{def-getwellconstrainedstructure}{\textfunc{get\_well\_constrained\_structure}}}
 \newcommand\towellconstrained[0]{\hyperlink{def-towellconstrained}{\textfunc{to\_well\_constrained}}}
@@ -1341,7 +1341,7 @@
 % sets of side effect descriptors
 \newcommand\timeframe[0]{\hyperlink{def-sideeffecttimeframe}{\textfunc{time\_frame}}}
 \newcommand\sideeffectispure[0]{\hyperlink{def-sideeffectispure}{\textfunc{side\_effect\_is\_pure}}}
-\newcommand\sideeffectisstaticallyevaluable[0]{\hyperlink{def-sideeffectisstaticallyevaluable}{\textfunc{side\_effect\_statically\_evaluable}}}
+\newcommand\sideeffectissymbolicallyevaluable[0]{\hyperlink{def-sideeffectissymbolicallyevaluable}{\textfunc{side\_effect\_symbolically\_evaluable}}}
 \newcommand\sideeffectconflict[0]{\hyperlink{def-sideeffectconflict}{\textfunc{side\_effect\_conflict}}}
 \newcommand\arenonconflicting[0]{\hyperlink{def-arenonconflicting}{\textfunc{are\_non\_conflicting}}}
 \newcommand\nonconflictingunion[0]{\hyperlink{def-nonconflictingunion}{\textfunc{non\_conflicting\_union}}}
@@ -1731,7 +1731,7 @@
 \newcommand\PerformsAssertionsTerm[0]{\hyperlink{def-performsassertionsterm}{assertion side effect descriptor}}
 \newcommand\NonDeterministicTerm[0]{\hyperlink{def-nondeterministicterm}{non-determinism side effect descriptor}}
 
-\newcommand\staticallyevaluable[0]{\hyperlink{def-staticallyevaluable}{statically evaluable}}
+\newcommand\symbolicallyevaluable[0]{\hyperlink{def-symbolicallyevaluable}{symbolically evaluable}}
 \newcommand\timeframeterm[0]{\hyperlink{def-timeframe}{time frame}}
 \newcommand\timeframesterm[0]{\hyperlink{def-timeframe}{time frames}}
 \newcommand\sideeffectdescriptorterm[0]{\hyperlink{def-sideeffectdescriptorterm}{side effect descriptor}}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -333,10 +333,10 @@ as indicated by respective comments.
 \begin{flalign*}
 % & & \ASTComment{A constraint on an integer part.}\\
 \intconstraint \derives\ & \ConstraintExact(\expr)
-  % & & \ASTComment{A single value, given by a statically evaluable expression.}
+  % & & \ASTComment{A single value, given by a symbolically evaluable expression.}
   & \hypertarget{ast-constraintrange}{}\\
   |\ & \ConstraintRange(\overtext{\expr}{start}, \overtext{\expr}{end})&
-  % & & \ASTComment{An interval between two statically evaluable expression.}\\
+  % & & \ASTComment{An interval between two symbolically evaluable expression.}\\
 \end{flalign*}
 
 \subsection{Bit Fields \label{sec:BitFields}}

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -172,7 +172,7 @@ See \TypingRuleRef{LESetStructuredField} for an example.
 
 \hypertarget{def-dii}{}
 \item[$\DivIntIndivisible$]
-This error indicates that a \staticallyevaluable\ expression contain an integer division expression where
+This error indicates that static evaluation encountered an integer division expression where
 the denominator does not divide the numerator.
 See \textsc{TypingRule.BinopLiterals.DIV\_INT} (\TypingRuleRef{BinopLiterals}) for an example.
 

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -54,7 +54,7 @@ The AST for these expressions is $\expr$ --- same as the AST for $\Nexpr$.
 The builders for $\Nexprpattern$ are identical to those of $\Nexpr$. For completeness,
 we list those in \secref{ASTRulesForPatternExpressions}.
 Those expressions are side-effect-free, as guaranteed by the checks to
-$\checkstaticallyevaluable$, and thus in the semantics we can use
+$\checksymbolicallyevaluable$, and thus in the semantics we can use
 $\evalexprsef\empty$.
 
 \section{Matching All Values\label{sec:MatchingAllValues}}
@@ -144,7 +144,7 @@ All of the following apply:
 \begin{itemize}
   \item $\vp$ is the pattern that matches the expression $\ve$, that is, $\PatternSingle(\ve)$;
   \item annotating the expression $\ve$ in $\tenv$ yields $(\vte, \vep, \vses)$\ProseOrTypeError;
-  \item \Prosecheckstaticallyevaluable{$\vses$};
+  \item \Prosechecksymbolicallyevaluable{$\vses$};
   \item obtaining the \underlyingtype\ of $\vt$ yields $\vtstruct$\ProseOrTypeError;
   \item obtaining the \underlyingtype\ of $\vte$ yields $\testruct$\ProseOrTypeError;
   \item One of the following holds:
@@ -182,7 +182,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule[t\_bool, t\_real, t\_int, t\_string]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vses) \OrTypeError\\\\
-  \checkstaticallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
+  \checksymbolicallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
   \makeanonymous(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \makeanonymous(\tenv, \vte) \typearrow \testruct \OrTypeError\\\\
   \commonprefixline\\\\
@@ -196,7 +196,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule[t\_bits]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vses) \OrTypeError\\\\
-  \checkstaticallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
+  \checksymbolicallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
   \makeanonymous(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \makeanonymous(\tenv, \vte) \typearrow \vtestruct \OrTypeError\\\\
   \commonprefixline\\\\
@@ -212,7 +212,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule[t\_enum]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vses) \OrTypeError\\\\
-  \checkstaticallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
+  \checksymbolicallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
   \makeanonymous(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \makeanonymous(\tenv, \vte) \typearrow \vtestruct \OrTypeError\\\\
   \commonprefixline\\\\
@@ -229,7 +229,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule[error]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vses) \OrTypeError\\\\
-  \checkstaticallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
+  \checksymbolicallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
   \makeanonymous(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \makeanonymous(\tenv, \vte) \typearrow \testruct \OrTypeError\\\\
   \commonprefixline\\\\
@@ -301,9 +301,9 @@ All of the following apply:
 \begin{itemize}
   \item $\vp$ is the pattern which matches anything within the range given by
   expressions $\veone$ and $\vetwo$, that is, $\PatternRange(\veone, \vetwo)$;
-  \item \Proseannotatestaticallyevaluableexpr{$\tenv$}{$\veone$}{$(\vteone, \veonep, \vsesone)$}\ProseOrTypeError;
-  \item \Proseannotatestaticallyevaluableexpr{$\tenv$}{$\vetwo$}{$(\vtetwo, \vetwop, \vsestwo)$}\ProseOrTypeError;
-  \item define $\vses$ as the union of $\vsesone$ and $\vsestwo$ (which do not conflict since that are both \staticallyevaluable);
+  \item \Proseannotatesymbolicallyevaluableexpr{$\tenv$}{$\veone$}{$(\vteone, \veonep, \vsesone)$}\ProseOrTypeError;
+  \item \Proseannotatesymbolicallyevaluableexpr{$\tenv$}{$\vetwo$}{$(\vtetwo, \vetwop, \vsestwo)$}\ProseOrTypeError;
+  \item define $\vses$ as the union of $\vsesone$ and $\vsestwo$ (which do not conflict since that are both \symbolicallyevaluable);
   \item determining whether both $\veonep$ and $\vetwop$ are compile-time constant expressions yields $\True$\ProseOrTypeError;
   \item obtaining the \underlyingtype\ for $\vt$, $\vteone$, and $\vtetwo$ yields
         $\vtstruct$, $\vteonestruct$, and $\vtetwostruct$, respectively\ProseOrTypeError;
@@ -316,8 +316,8 @@ All of the following apply:
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \annotatestaticallyevaluableexpr(\tenv, \veone) \typearrow (\vteone, \veonep, \vsesone) \OrTypeError\\\\
-  \annotatestaticallyevaluableexpr(\tenv, \vetwo) \typearrow (\vtetwo, \vetwop, \vsestwo) \OrTypeError\\\\
+  \annotatesymbolicallyevaluableexpr(\tenv, \veone) \typearrow (\vteone, \veonep, \vsesone) \OrTypeError\\\\
+  \annotatesymbolicallyevaluableexpr(\tenv, \vetwo) \typearrow (\vtetwo, \vetwop, \vsestwo) \OrTypeError\\\\
   \vses \eqdef \vsesone \cup \vsestwo\\
   \makeanonymous(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vteonestruct \OrTypeError\\\\
@@ -403,7 +403,7 @@ All of the following apply:
 \item $\vp$ is the pattern which matches anything less than or equal to an expression $\ve$,
 that is, $\PatternLeq(\ve)$;
 \item annotating the expression $\ve$ in $\tenv$ yields $(\vte, \vep, \vses)$\ProseOrTypeError;
-\item \Prosecheckstaticallyevaluable{$\vses$};
+\item \Prosechecksymbolicallyevaluable{$\vses$};
 \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields $\vtstruct$\ProseOrTypeError;
 \item obtaining the \underlyingtype\ of $\vte$ in $\tenv$ yields $\testruct$\ProseOrTypeError;
 \item $\vb$ is true if and only if $\vtstruct$ and $\testruct$ are both integer types or both real types;
@@ -416,7 +416,7 @@ which short-circuits the entire rule;
 \begin{mathpar}
 \inferrule{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vses) \OrTypeError\\\\
-  \checkstaticallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
+  \checksymbolicallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
   \makeanonymous(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \makeanonymous(\tenv, \vte) \typearrow \testruct \OrTypeError\\\\
   {
@@ -488,7 +488,7 @@ All of the following apply:
 \item $\vp$ is the pattern which matches anything greater than or equal to an expression $\ve$,
       that is, $\PatternGeq(\ve)$;
 \item annotating the expression $\ve$ in $\tenv$ yields $(\vte, \vep, \vses)$\ProseOrTypeError;
-\item \Prosecheckstaticallyevaluable{$\vses$};
+\item \Prosechecksymbolicallyevaluable{$\vses$};
 \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields $\vtstruct$\ProseOrTypeError;
 \item obtaining the \underlyingtype\ of $\vte$ in $\tenv$ yields $\testruct$\ProseOrTypeError;
 \item $\vb$ is true if and only if $\vtstruct$ and $\testruct$ are both integer types or both real types;
@@ -501,7 +501,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vses) \OrTypeError\\\\
-  \checkstaticallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
+  \checksymbolicallyevaluable(\vses) \typearrow \True \OrTypeError\\\\
   \makeanonymous(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \makeanonymous(\tenv, \vte) \typearrow \testruct \OrTypeError\\\\
   {
@@ -800,7 +800,7 @@ All of the following apply:
 \item $\newp$ is the pattern which matches anything in $\newli$, that is, \\ $\PatternAny(\newli)$;
 \item define $\vses$ as the union of all $\vxs_\vl$, for each $\vl$ in $\vli$.
       (Checking for absence of conflicts is not required as all patterns are ensured to be
-      \staticallyevaluable. See, for example, \TypingRuleRef{PSingle}.)
+      \symbolicallyevaluable. See, for example, \TypingRuleRef{PSingle}.)
 \end{itemize}
 
 \subsubsection{Formally}

--- a/asllib/doc/SideEffects.tex
+++ b/asllib/doc/SideEffects.tex
@@ -63,7 +63,7 @@ That is, evaluating the expressions results in the same set of configurations,
 up to the order of values, and ignoring dynamic errors that are not due to assertions.
 \end{definition}
 
-Along the way, we also define the concept of \emph{pure expressions} and \staticallyevaluable\ expressions.
+Along the way, we also define the concept of \emph{pure expressions} and \symbolicallyevaluable\ expressions.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Time Frames\label{sec:TimeFrames}}
@@ -269,14 +269,14 @@ a \NonDeterministicTerm, or a \PerformsAssertionsTerm.
 }
 \end{mathpar}
 
-\TypingRuleDef{SideEffectIsStaticallyEvaluable}
-\hypertarget{def-sideeffectisstaticallyevaluable}{}
+\TypingRuleDef{SideEffectIsSymbolicallyEvaluable}
+\hypertarget{def-sideeffectissymbolicallyevaluable}{}
 \[
-    \sideeffectisstaticallyevaluable(\overname{\TSideEffect}{\vs}) \aslto \overname{\Bool}{\vb}
+    \sideeffectissymbolicallyevaluable(\overname{\TSideEffect}{\vs}) \aslto \overname{\Bool}{\vb}
 \]
-defines whether a \sideeffectdescriptorsterm\ $\vs$ is considered \emph{\staticallyevaluable},
+defines whether a \sideeffectdescriptorsterm\ $\vs$ is considered \emph{\symbolicallyevaluable},
 yielding the result in $\vb$.
-Intuitively, a \emph{statically evaluable} \sideeffectdescriptorterm\ helps establish that
+Intuitively, a \emph{symbolically evaluable} \sideeffectdescriptorterm\ helps establish that
 an expression evaluates without failing assertions, without modifying any storage element,
 and always yielding the same result, that is, deterministically.
 
@@ -290,7 +290,7 @@ a \ReadGlobalTerm\ associated with an immutable storage element.
 \inferrule{
     \vb \eqdef \vs = \ReadLocal(\Ignore, \Ignore, \True) \lor \vs = \ReadGlobal(\Ignore, \Ignore, \True)
 }{
-    \sideeffectisstaticallyevaluable(\vs) \typearrow \vb
+    \sideeffectissymbolicallyevaluable(\vs) \typearrow \vb
 }
 \end{mathpar}
 
@@ -606,57 +606,57 @@ One of the following applies:
 }
 \end{mathpar}
 
-\TypingRuleDef{SESIsStaticallyEvaluable}
-\hypertarget{def-isstaticallyevaluable}{}
-\hypertarget{def-staticallyevaluable}{}
+\TypingRuleDef{SESIsSymbolicallyEvaluable}
+\hypertarget{def-issymbolicallyevaluable}{}
+\hypertarget{def-symbolicallyevaluable}{}
 The function
 \[
-  \isstaticallyevaluable(\overname{\TSideEffectSet}{\vses}) \aslto \overname{\Bool}{\bv}
+  \issymbolicallyevaluable(\overname{\TSideEffectSet}{\vses}) \aslto \overname{\Bool}{\bv}
 \]
-tests whether a set of \sideeffectdescriptorsterm\ $\vses$ are all \staticallyevaluable,
+tests whether a set of \sideeffectdescriptorsterm\ $\vses$ are all \symbolicallyevaluable,
 yielding the result in $\vb$.
 
 \subsubsection{Prose}
 Define $\vb$ as $\True$ if and only if every \sideeffectdescriptorterm\ $\vs$ in $\vses$
-is \staticallyevaluable.
+is \symbolicallyevaluable.
 
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \vb \eqdef \bigwedge_{\vs\in\vses} \sideeffectisstaticallyevaluable(\vs)
+  \vb \eqdef \bigwedge_{\vs\in\vses} \sideeffectissymbolicallyevaluable(\vs)
 }{
-  \isstaticallyevaluable(\vses) \typearrow \vb
+  \issymbolicallyevaluable(\vses) \typearrow \vb
 }
 \end{mathpar}
 
-\hypertarget{def-checkstaticallyevaluable}{}
-\TypingRuleDef{CheckStaticallyEvaluable}
+\hypertarget{def-checksymbolicallyevaluable}{}
+\TypingRuleDef{CheckSymbolicallyEvaluable}
 The function
 \[
-  \checkstaticallyevaluable(\overname{\TSideEffectSet}{\vses}) \aslto
+  \checksymbolicallyevaluable(\overname{\TSideEffectSet}{\vses}) \aslto
   \{\True\} \cup \TTypeError
 \]
-returns $\True$ if the set of \sideeffectdescriptorsterm\ $\vses$ is \staticallyevaluable.
+returns $\True$ if the set of \sideeffectdescriptorsterm\ $\vses$ is \symbolicallyevaluable.
 \ProseOtherwiseTypeError
 
 \subsubsection{Prose}
 All of the following applies:
 \begin{itemize}
-  \item applying $\isstaticallyevaluable$ to $\ve$ in $\tenv$ yields $\vb$;
+  \item applying $\issymbolicallyevaluable$ to $\ve$ in $\tenv$ yields $\vb$;
   \item the result is $\True$ if $\vb$ is $\True$, otherwise it is a type error indicating that the expression
-  is not statically evaluable.
+  is not \symbolicallyevaluable.
 \end{itemize}
 
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \isstaticallyevaluable(\vses) \typearrow \vb\\
-  \checktrans{\vb}{NotStaticallyEvaluable} \checktransarrow \True \OrTypeError
+  \issymbolicallyevaluable(\vses) \typearrow \vb\\
+  \checktrans{\vb}{NotSymbolicallyEvaluable} \checktransarrow \True \OrTypeError
 }{
-  \checkstaticallyevaluable(\vses) \typearrow \True
+  \checksymbolicallyevaluable(\vses) \typearrow \True
 }
 \end{mathpar}
-\CodeSubsection{\CheckStaticallyEvaluableBegin}{\CheckStaticallyEvaluableEnd}{../Typing.ml}
+\CodeSubsection{\CheckSymbolicallyEvaluableBegin}{\CheckSymbolicallyEvaluableEnd}{../Typing.ml}
 
 \TypingRuleDef{SESIsPure}
 \hypertarget{def-sesispure}{}

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -236,7 +236,7 @@ One of the following applies:
           $\SliceLength(\eoffset, \elength)$;
     \item annotating the expression $\eoffset$ in $\tenv$ yields \\
           $(\toffset, \eoffsetp, \vsesoffset)$\ProseOrTypeError;
-    \item annotating the \staticallyevaluable\ \constrainedinteger\ expression $\elength$ in $\tenv$ yields
+    \item annotating the \symbolicallyevaluable\ \constrainedinteger\ expression $\elength$ in $\tenv$ yields
     $(\elengthp, \vseslength)$\ProseOrTypeError;
     \item determining whether $\toffset$ has the \structureofinteger\ yields $\True$\ProseOrTypeError;
     \item $\vsp$ is the slice at offset $\eoffsetp$ and length $\elength'$, that is,\\
@@ -275,7 +275,7 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[length]{
   \annotateexpr{\tenv, \eoffset} \typearrow (\toffset, \eoffsetp, \vsesoffset) \OrTypeError\\\\
-  \annotatestaticconstrainedinteger(\tenv, \elength) \typearrow (\elengthp, \vseslength) \OrTypeError\\\\
+  \annotatesymbolicconstrainedinteger(\tenv, \elength) \typearrow (\elengthp, \vseslength) \OrTypeError\\\\
   \checkstructureinteger(\tenv, \toffset) \typearrow \True \OrTypeError\\\\
   \vses \eqdef \vsesoffset \cup \vseslength
 }{
@@ -394,37 +394,37 @@ One of the following applies:
 }
 \end{mathpar}
 
-\TypingRuleDef{StaticConstrainedInteger}
-\hypertarget{def-annotatestaticconstrainedinteger}{}
+\TypingRuleDef{SymbolicConstrainedInteger}
+\hypertarget{def-annotatesymbolicconstrainedinteger}{}
 The function
 \[
-  \annotatestaticconstrainedinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
+  \annotatesymbolicconstrainedinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
   (\overname{\expr}{\vepp} \times \overname{\TSideEffectSet}{\vses}) \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-annotates a \staticallyevaluable\ integer expression $\ve$ of a constrained integer type in the static environment $\tenv$
+annotates a \symbolicallyevaluable\ integer expression $\ve$ of a constrained integer type in the static environment $\tenv$
 and returns the annotated expression $\vepp$ and \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \subsubsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item \Proseannotatestaticallyevaluableexpr{$\tenv$}{$\ve$}{$(\vt, \vep, \vses)$\ProseOrTypeError};
-  \item determining whether $\vt$ is a statically \constrainedinteger\ in $\tenv$ yields $\True$\ProseOrTypeError;
-  \item determining whether $\vep$ is \staticallyevaluable\  in $\tenv$ yields $\True$\ProseOrTypeError;
+  \item \Proseannotatesymbolicallyevaluableexpr{$\tenv$}{$\ve$}{$(\vt, \vep, \vses)$\ProseOrTypeError};
+  \item determining whether $\vt$ is a symbolically \constrainedinteger\ in $\tenv$ yields $\True$\ProseOrTypeError;
+  \item determining whether $\vep$ is \symbolicallyevaluable\  in $\tenv$ yields $\True$\ProseOrTypeError;
   \item applying $\normalize$ to $\vep$ in $\tenv$ yields $\vepp$.
 \end{itemize}
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \annotatestaticallyevaluableexpr(\tenv, \ve) \typearrow (\vt, \vep, \vses) \OrTypeError\\\\
+  \annotatesymbolicallyevaluableexpr(\tenv, \ve) \typearrow (\vt, \vep, \vses) \OrTypeError\\\\
   \checkconstrainedinteger(\tenv, \vt) \typearrow \True \OrTypeError\\\\
-  \checkstaticallyevaluable(\tenv, \vep) \typearrow \True \OrTypeError\\\\
+  \checksymbolicallyevaluable(\tenv, \vep) \typearrow \True \OrTypeError\\\\
   \normalize(\tenv, \vep) \typearrow \vepp
 }{
-  \annotatestaticconstrainedinteger(\tenv, \ve) \typearrow (\vepp, \vses)
+  \annotatesymbolicconstrainedinteger(\tenv, \ve) \typearrow (\vepp, \vses)
 }
 \end{mathpar}
-\CodeSubsection{\StaticConstrainedIntegerBegin}{\StaticConstrainedIntegerEnd}{../Typing.ml}
+\CodeSubsection{\SymbolicConstrainedIntegerBegin}{\SymbolicConstrainedIntegerEnd}{../Typing.ml}
 
 \subsection{Semantics}
 \SemanticsRuleDef{Slice}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -1792,7 +1792,7 @@ One of the following applies:
   \item All of the following apply (\textsc{some}):
   \begin{itemize}
     \item $\ve$ is $\langle\vlimit\rangle$;
-    \item applying $\annotatestaticconstrainedinteger$ to $\vlimit$ in $\tenv$ yields \\
+    \item applying $\annotatesymbolicconstrainedinteger$ to $\vlimit$ in $\tenv$ yields \\
           $(\vlimitp, \vses)$\ProseOrTypeError;
     \item $\vep$ is $\langle\vlimitp\rangle$.
   \end{itemize}
@@ -1806,7 +1806,7 @@ One of the following applies:
 \end{mathpar}
 \begin{mathpar}
 \inferrule[some]{
-  \annotatestaticconstrainedinteger(\tenv, \vlimit) \typearrow (\vlimitp, \vses) \OrTypeError
+  \annotatesymbolicconstrainedinteger(\tenv, \vlimit) \typearrow (\vlimitp, \vses) \OrTypeError
 }{
   \annotatelimitexpr(\tenv, \overname{\langle\vlimit\rangle}{\ve}) \typearrow (\overname{\langle\vlimitp\rangle}{\vep}, \vses)
 }

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -270,7 +270,7 @@ One of the following applies:
           \tail\ $\funcsigparamsone$, and
           $\params$ is a non-empty list with \head\ \\
           $(\tyactual, \eactual, \vsesactual)$ and \tail\ $\paramsone$;
-    \item \Prosecheckstaticallyevaluable{$\vsesactual$};
+    \item \Prosechecksymbolicallyevaluable{$\vsesactual$};
     \item checking that $\tyactual$ represents a \constrainedinteger{} yields $\True$\ProseOrTypeError;
     \item One of the following applies:
     \begin{itemize}
@@ -303,7 +303,7 @@ One of the following applies:
 \inferrule[parameterized]{
   \funcsigparams \eqname [(\vx, \tydeclopt)] \concat \funcsigparamsone\\
   \params \eqname [(\tyactual, \eactual, \vsesactual)] \concat \paramsone\\
-  \checkstaticallyevaluable(\vsesactual) \typearrow \True\OrTypeError\\\\
+  \checksymbolicallyevaluable(\vsesactual) \typearrow \True\OrTypeError\\\\
   \checkconstrainedinteger(\tenv, \tyactual) \typearrow \True\OrTypeError\\\\
   \commonprefixline\\\\
   \tydeclopt = \langle\TInt(\parameterized(\vx))\rangle\\\\
@@ -315,7 +315,7 @@ One of the following applies:
 \inferrule[other]{
   \funcsigparams \eqname [(\vx, \tydeclopt)] \concat \funcsigparamsone\\
   \params \eqname [(\tyactual, \eactual, \vsesactual)] \concat \paramsone\\
-  \checkstaticallyevaluable(\vsesactual) \typearrow \True\OrTypeError\\\\
+  \checksymbolicallyevaluable(\vsesactual) \typearrow \True\OrTypeError\\\\
   \checkconstrainedinteger(\tenv, \tyactual) \typearrow \True\OrTypeError\\\\
   \commonprefixline\\\\
   \tydeclopt \eqname \langle\tydecl\rangle\\

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -473,7 +473,7 @@ $\{\nvint(1), \nvint(2), \nvint(3)\}$, which subsumes
 the domain of \verb|integer{1,2}|, which is \\ $\{\nvint(1), \nvint(2)\}$.
 
 Since dynamic domains are potentially infinite, this requires \emph{symbolic reasoning}.
-Furthermore, since any (statically evaluable) expressions may appear inside integer and bitvector
+Furthermore, since any (\symbolicallyevaluable{}) expressions may appear inside integer and bitvector
 types, testing subsumption is undecidable.
 We therefore approximate subsumption testing \emph{conservatively} via the predicate $\symsubsumes(\tenv, \vt, \vs)$.
 

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -724,7 +724,7 @@ The function
   \aslsep \overname{\expr}{\ve}) \aslto \overname{\staticenvs}{\newtenv}
 \]
 binds the identifier $\vx$, which is assumed to name a global storage element,
-to the expression $\ve$, which is assumed to be \staticallyevaluable,
+to the expression $\ve$, which is assumed to be \symbolicallyevaluable,
 in the static environment $\tenv$,
 resulting in the updated environment $\newtenv$.
 
@@ -752,7 +752,7 @@ The function
   \aslsep \overname{\expr}{\ve}) \aslto \overname{\staticenvs}{\newtenv}
 \]
 binds the identifier $\vx$, which is assumed to name a local storage element,
-to the expression $\ve$, which is assumed to be \staticallyevaluable,
+to the expression $\ve$, which is assumed to be \symbolicallyevaluable,
 in the static environment $\tenv$,
 resulting in the updated environment $\newtenv$.
 
@@ -784,13 +784,13 @@ reason about type satisfaction, yielding the result in $\vb$.
 
 \subsubsection{Prose}
 Define $\vb$ as $\True$ if and only if
-applying $\isstaticallyevaluable$ to $\vses$ with \PerformsAssertionsTerm\ removed from it,
+applying $\issymbolicallyevaluable$ to $\vses$ with \PerformsAssertionsTerm\ removed from it,
 yields $\True$.
 
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \isstaticallyevaluable(\vses \setminus \{\PerformsAssertions\}) \typearrow \vb
+  \issymbolicallyevaluable(\vses \setminus \{\PerformsAssertions\}) \typearrow \vb
 }{
   \shouldrememberimmutableexpression(\vses) \typearrow \vb
 }
@@ -809,11 +809,11 @@ The function
   \overname{\staticenvs}{\newtenv} \cup \TTypeError
 \end{array}
 \]
-conditionally adds the information that the expression in $\veopt$ is statically evaluable
+conditionally adds the information that the expression in $\veopt$ is \symbolicallyevaluable{}
 and bound to $\vx$.
 More precisely, $\addimmutableexpression(\tenv, \ldk, \veopt, \vx)$
 associates an expression with the identifier $\vx$
-in the static environment $\tenv$, if one exists in $\veopt$ and it is \staticallyevaluable\ with
+in the static environment $\tenv$, if one exists in $\veopt$ and it is \symbolicallyevaluable\ with
 respect to the \sideeffectsetterm\ $\vsese$,
 along with the local declaration keyword $\ldk$. The result is the updated static environment $\newtenv$.
 \ProseOtherwiseTypeError

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -326,15 +326,15 @@ One of the following applies:
   \item All of the following apply (\textsc{exact}):
   \begin{itemize}
     \item $\vc$ is the exact integer constraint for the expression $\ve$, that is, \\ $\ConstraintExact(\ve)$;
-    \item applying $\annotatestaticconstrainedinteger$ to $\ve$ in $\tenv$ yields $(\vep, \vses)$\ProseOrTypeError;
+    \item applying $\annotatesymbolicconstrainedinteger$ to $\ve$ in $\tenv$ yields $(\vep, \vses)$\ProseOrTypeError;
     \item define $\newc$ as the exact integer constraint for $\vep$, that is, $\ConstraintExact(\vep)$.
   \end{itemize}
 
   \item All of the following apply (\textsc{range}):
   \begin{itemize}
     \item $\vc$ is the range integer constraint for expressions $\veone$ and $\vetwo$, that is, \\ $\ConstraintRange(\veone, \vetwo)$;
-    \item applying $\annotatestaticconstrainedinteger$ to $\veone$ in $\tenv$ yields\\ $(\veonep, \vsesone)$\ProseOrTypeError;
-    \item applying $\annotatestaticconstrainedinteger$ to $\vetwo$ in $\tenv$ yields\\ $(\vetwop, \vsestwo)$\ProseOrTypeError;
+    \item applying $\annotatesymbolicconstrainedinteger$ to $\veone$ in $\tenv$ yields\\ $(\veonep, \vsesone)$\ProseOrTypeError;
+    \item applying $\annotatesymbolicconstrainedinteger$ to $\vetwo$ in $\tenv$ yields\\ $(\vetwop, \vsestwo)$\ProseOrTypeError;
     \item define $\newc$ as the range integer constraint for expressions $\veonep$ and $\vetwop$, that is, $\ConstraintRange(\veonep, \vetwop)$;
     \item define $\vses$ as the union of $\vsesone$ and $\vsestwo$.
   \end{itemize}
@@ -343,14 +343,14 @@ One of the following applies:
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule[exact]{
-  \annotatestaticconstrainedinteger(\tenv, \ve) \typearrow (\vep, \vses) \OrTypeError
+  \annotatesymbolicconstrainedinteger(\tenv, \ve) \typearrow (\vep, \vses) \OrTypeError
 }{
   \annotateconstraint(\tenv, \overname{\ConstraintExact(\ve)}{\vc}) \typearrow (\overname{\ConstraintExact(\vep)}{\newc}, \vses)
 }
 \and
 \inferrule[range]{
-  \annotatestaticconstrainedinteger(\tenv, \veone) \typearrow (\veonep, \vsesone) \OrTypeError\\\\
-  \annotatestaticconstrainedinteger(\tenv, \vetwo) \typearrow (\vetwop, \vsestwo) \OrTypeError\\\\
+  \annotatesymbolicconstrainedinteger(\tenv, \veone) \typearrow (\veonep, \vsesone) \OrTypeError\\\\
+  \annotatesymbolicconstrainedinteger(\tenv, \vetwo) \typearrow (\vetwop, \vsestwo) \OrTypeError\\\\
   \vses \eqdef \vsesone \cup \vsestwo
 }{
   \annotateconstraint(\tenv, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \overname{\ConstraintRange(\veonep, \vetwop)}{\newc}
@@ -536,7 +536,7 @@ All of the following apply:
   \item $\tty$ is the bit-vector type with width given by the expression
     $\ewidth$ and the bitfields given by $\bitfields$, that is, $\TBits(\ewidth, \bitfields)$;
   \item annotating the expression $\ewidth$ yields $(\twidth, \ewidthp, \seswidth)$\ProseOrTypeError;
-  \item \Prosecheckstaticallyevaluable{\seswidth};
+  \item \Prosechecksymbolicallyevaluable{\seswidth};
   \item \Prosecheckconstrainedinteger{$\tenv$}{$\twidth$};
   \item annotating the bitfields $\bitfields$ yields $(\bitfieldsp, \vsesbitfields)$\ProseOrTypeError;
   \item \Prosestaticeval{$\tenv$}{$\ewidthp$}{$\lint(\vwidth)$};
@@ -550,7 +550,7 @@ All of the following apply:
 \begin{mathpar}
 \inferrule{
   \annotateexpr{\tenv, \ewidth} \typearrow (\twidth, \ewidthp, \seswidth) \OrTypeError\\\\
-  \checkstaticallyevaluable(\seswidth) \typearrow \True \OrTypeError\\\\
+  \checksymbolicallyevaluable(\seswidth) \typearrow \True \OrTypeError\\\\
   \checkconstrainedinteger(\tenv, \twidth) \typearrow \True \OrTypeError\\\\
   \annotatebitfields(\tenv, \ewidthp, \bitfields) \typearrow (\bitfieldsp, \vsesbitfields) \OrTypeError\\\\
   \staticeval(\tenv, \ewidthp) \typearrow \lint(\vwidth)\\
@@ -682,7 +682,7 @@ All of the following apply:
       \item the array index is $\ve$ and determining whether $\ve$ corresponds to an enumeration in $\tenv$
       via $\getvariableenum$ yields $\None$ (meaning it does not
       correspond to an enumeration)\ProseOrTypeError;
-      \item annotating the statically evaluable integer expression $\ve$ yields\\
+      \item annotating the \symbolicallyevaluable{} integer expression $\ve$ yields\\
       $(\vep, \vsesindex)$\ProseOrTypeError;
       \item $\newty$ the array type indexed by integer bounded by
       the expression $\vep$ and of elements of type $\vtp$, that is,
@@ -708,7 +708,7 @@ All of the following apply:
   \annotatetype{\False, \tenv, \vt} \typearrow (\vtp, \vsest) \OrTypeError\\\\
   \commonprefixline\\\\
   \getvariableenum(\tenv, \ve) \typearrow \None \OrTypeError\\\\
-  \annotatestaticinteger(\tenv, \ve) \typearrow (\vep, \vsesindex) \OrTypeError\\\\
+  \annotatesymbolicinteger(\tenv, \ve) \typearrow (\vep, \vsesindex) \OrTypeError\\\\
   \vses \eqdef \vsest \cup \vsesindex
 }{
   \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\AbbrevTArrayLengthExpr{\ve}{\vt}}{\tty}} \typearrow
@@ -798,16 +798,16 @@ One of the following applies:
 }
 \end{mathpar}
 
-\TypingRuleDef{AnnotateStaticallyEvaluableExpr}
-\hypertarget{def-annotatestaticallyevaluableexpr}{}
+\TypingRuleDef{AnnotateSymbolicallyEvaluableExpr}
+\hypertarget{def-annotatesymbolicallyevaluableexpr}{}
 The function
 \[
 \begin{array}{r}
-  \annotatestaticallyevaluableexpr(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto \\
+  \annotatesymbolicallyevaluableexpr(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto \\
   (\overname{\ty}{\vt}\times\overname{\expr}{\vep}\times\overname{\TSideEffectSet}{\vses}) \cup \overname{\TTypeError}{\TypeErrorConfig}
 \end{array}
 \]
-annotates the expression $\ve$ in the static environment $\tenv$ and checks that it is \staticallyevaluable,
+annotates the expression $\ve$ in the static environment $\tenv$ and checks that it is \symbolicallyevaluable,
 yielding the resulting type in $\vt$, the annotated expression in $\vep$ and the \sideeffectsetterm\ in $\vses$.
 \ProseOtherwiseTypeError
 
@@ -815,51 +815,51 @@ yielding the resulting type in $\vt$, the annotated expression in $\vep$ and the
 All of the following apply:
 \begin{itemize}
   \item \Proseannotateexpr{$\tenv$}{$\ve$}{$(\vt, \vep, \vses)$};
-  \item \Prosecheckstaticallyevaluable{$\vses$}.
+  \item \Prosechecksymbolicallyevaluable{$\vses$}.
 \end{itemize}
 
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
   \annotateexpr{\tenv, \ve} \typearrow (\vt, \vep, \vses) \OrTypeError\\\\
-  \checkstaticallyevaluable(\vses) \typearrow \True \OrTypeError
+  \checksymbolicallyevaluable(\vses) \typearrow \True \OrTypeError
 }{
-  \annotatestaticallyevaluableexpr(\tenv, \ve) \typearrow (\vt, \vep, \vses)
+  \annotatesymbolicallyevaluableexpr(\tenv, \ve) \typearrow (\vt, \vep, \vses)
 }
 \end{mathpar}
-\CodeSubsection{\AnnotateStaticallyEvaluableExprBegin}{\AnnotateStaticallyEvaluableExprEnd}{../Typing.ml}
+\CodeSubsection{\AnnotateSymbolicallyEvaluableExprBegin}{\AnnotateSymbolicallyEvaluableExprEnd}{../Typing.ml}
 
-\TypingRuleDef{AnnotateStaticInteger}
-\hypertarget{def-annotatestaticinteger}{}
+\TypingRuleDef{AnnotateSymbolicInteger}
+\hypertarget{def-annotatesymbolicinteger}{}
 The function
 \[
-  \annotatestaticinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
+  \annotatesymbolicinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
   (\overname{\expr}{\vepp} \times \overname{\TSideEffectSet}{\vses}) \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-annotates a \staticallyevaluable\ integer expression $\ve$ in the static environment $\tenv$
+annotates a \symbolicallyevaluable\ integer expression $\ve$ in the static environment $\tenv$
 and returns the annotated expression $\vepp$ and \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \subsubsection{Prose}
 All of the following apply:
 \begin{itemize}
-  \item \Proseannotatestaticallyevaluableexpr{$\tenv$}{$\ve$}{$(\vt, \vep, \vses)$\ProseOrTypeError};
+  \item \Proseannotatesymbolicallyevaluableexpr{$\tenv$}{$\ve$}{$(\vt, \vep, \vses)$\ProseOrTypeError};
   \item determining whether $\vt$ has the structure of an integer yields $\True$\ProseOrTypeError;
-  \item determining whether $\vep$ is \staticallyevaluable\ in $\tenv$ yields $\True$\ProseOrTypeError;
+  \item determining whether $\vep$ is \symbolicallyevaluable\ in $\tenv$ yields $\True$\ProseOrTypeError;
   \item applying $\normalize$ to $\vep$ in $\tenv$ yields $\vepp$.
 \end{itemize}
 \subsubsection{Formally}
 \begin{mathpar}
 \inferrule{
-  \annotatestaticallyevaluableexpr(\tenv, \ve) \typearrow (\vt, \vep, \vses) \OrTypeError\\\\
+  \annotatesymbolicallyevaluableexpr(\tenv, \ve) \typearrow (\vt, \vep, \vses) \OrTypeError\\\\
   \checkstructureinteger(\tenv, \vt) \typearrow \True \OrTypeError\\\\
-  \checkstaticallyevaluable(\tenv, \vep) \typearrow \True \OrTypeError\\\\
+  \checksymbolicallyevaluable(\tenv, \vep) \typearrow \True \OrTypeError\\\\
   \normalize(\tenv, \vep) \typearrow \vepp
 }{
-  \annotatestaticinteger(\tenv, \ve) \typearrow (\vepp, \vses)
+  \annotatesymbolicinteger(\tenv, \ve) \typearrow (\vepp, \vses)
 }
 \end{mathpar}
-\CodeSubsection{\AnnotateStaticIntegerBegin}{\AnnotateStaticIntegerEnd}{../Typing.ml}
+\CodeSubsection{\AnnotateSymbolicIntegerBegin}{\AnnotateSymbolicIntegerEnd}{../Typing.ml}
 
 \hypertarget{def-checkstructureinteger}{}
 \TypingRuleDef{CheckStructureInteger}

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -475,8 +475,8 @@ module TypingRule = struct
     | BitfieldSliceToPositions
     | CheckPositionsInWidth
     | ShouldReduceToCall
-    | IsStaticallyEvaluable
-    | CheckStaticallyEvaluable
+    | IsSymbolicallyEvaluable
+    | CheckSymbolicallyEvaluable
     | ShouldRememberImmutableExpression
     | AddImmutableExpression
     | SymIntSetSubset
@@ -663,8 +663,8 @@ module TypingRule = struct
     | BitfieldSliceToPositions -> "BitfieldSliceToPositions"
     | CheckPositionsInWidth -> "CheckPositionsInWidth"
     | ShouldReduceToCall -> "ShouldReduceToCall"
-    | IsStaticallyEvaluable -> "IsStaticallyEvaluable"
-    | CheckStaticallyEvaluable -> "CheckStaticallyEvaluable"
+    | IsSymbolicallyEvaluable -> "IsSymbolicallyEvaluable"
+    | CheckSymbolicallyEvaluable -> "CheckSymbolicallyEvaluable"
     | ShouldRememberImmutableExpression -> "ShouldRememberImmutableExpression"
     | AddImmutableExpression -> "AddImmutableExpression"
     | SymIntSetSubset -> "SymIntSetSubset"
@@ -835,8 +835,8 @@ module TypingRule = struct
       BitfieldSliceToPositions;
       CheckPositionsInWidth;
       ShouldReduceToCall;
-      IsStaticallyEvaluable;
-      CheckStaticallyEvaluable;
+      IsSymbolicallyEvaluable;
+      CheckSymbolicallyEvaluable;
       ShouldRememberImmutableExpression;
       AddImmutableExpression;
       SymIntSetSubset;


### PR DESCRIPTION
Note that we deliberately do not rename "static interpretation" (implementation in `StaticInterpreter.ml`) as this is actually doing static interpretation during type-checking.

We only rename the concept of "statically evaluable" to "symbolically evaluable" - i.e. anything which uses side-effect analysis to decide whether an expression can be evaluated deterministically without side-effects.