### PR TITLE
[asl] Fix 0.0 ^ 0 == 1.0

### DIFF
--- a/asllib/StaticOperations.ml
+++ b/asllib/StaticOperations.ml
@@ -93,13 +93,13 @@ let constraint_pow c1 c2 =
       [ exact (pow a c) ] |: TypingRule.ConstraintPow
   | Constraint_Range (a, b), Constraint_Exact c ->
       (* We need:
-         - 1 for 0 POW 0 that can be included everywhere and is the only time that POW is very unpredictable
          - the case a positive is included in the case a negative.
          - 0..b POW c for the positive values
          - (- ((-a) POW c)) .. ((-a) POW c) for the negative values
+         - the case 0 POW 0 can only happen if c = 0, and then this is included in 0..b POW c
       *)
       let mac = pow (neg a) c in
-      [ range zero_expr (pow b c); range (neg mac) mac; exact one_expr ]
+      [ range zero_expr (pow b c); range (neg mac) mac ]
   | Constraint_Exact a, Constraint_Range (_c, d) ->
       (* We need here:
          - 1 for 0 POW 0 that can be included everywhere and is the only time that POW is very unpredictable

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -1239,7 +1239,6 @@ One of the following applies:
       \item the range constraint for the literal integer expression for $0$ and the expression
             $\EBinop(\POW, \vb, \vc)$;
       \item the range constraint for the expression $\EUnop(\NEG, \vmac)$ and $\vmac$;
-      \item the constraint for the literal integer expression for $1$.
     \end{itemize}
   \end{itemize}
 
@@ -1293,8 +1292,7 @@ One of the following applies:
   \constraintpow(\overname{\ConstraintRange(\va, \vb)}{\vcone}, \overname{\ConstraintExact(\vc)}{\vctwo}) \typearrow \\
   \overname{[
   \AbbrevConstraintRange{\ELInt{0}}{\AbbrevEBinop{\POW}{\vb}{\vc}},\
-  \AbbrevConstraintRange{\EUnop(\NEG, \vmac)}{\vmac},\
-  \AbbrevConstraintExact{\ELInt{1}}
+  \AbbrevConstraintRange{\EUnop(\NEG, \vmac)}{\vmac}
   ]}{\newcs}
     \end{array}
   }

--- a/asllib/tests/ConstraintBinops.ml
+++ b/asllib/tests/ConstraintBinops.ml
@@ -103,11 +103,11 @@ let print_test op (x, y, cs1, cs2) =
       x Z.pp_print y PP.pp_int_constraints cs1 PP.pp_int_constraints cs2
       (PP.binop_to_string op)
 
-let long_factor = 100
+let long_factor = 1000
 let base_count = 10000
 
 let test_abcd op =
-  let count = base_count * 10
+  let count = base_count
   and name =
     Printf.sprintf "constraint_binop [a..b] %s [c..d] is sound"
       (PP.binop_to_string op)

--- a/asllib/tests/division.t/run.t
+++ b/asllib/tests/division.t/run.t
@@ -156,3 +156,12 @@ Other polynomial equations:
   $ aslref rat-poly-01.asl
   ASL Dynamic error: Cannot extract from bitvector of length 0 slice 0+:-2.
   [1]
+
+Division as POW:
+  $ aslref zero-pow-neg.asl
+  ASL Dynamic error: Illegal application of operator ^ for values (0.0 / 1.0)
+    and -1.
+  [1]
+
+  $ aslref zero-pow-zero.asl
+

--- a/asllib/tests/division.t/zero-pow-neg.asl
+++ b/asllib/tests/division.t/zero-pow-neg.asl
@@ -1,0 +1,6 @@
+func main () => integer
+  begin
+    assert (0.0 ^ -1 == 1.0);
+
+    return 0;
+  end;

--- a/asllib/tests/division.t/zero-pow-zero.asl
+++ b/asllib/tests/division.t/zero-pow-zero.asl
@@ -1,0 +1,7 @@
+func main () => integer
+  begin
+    assert (0.0 ^ 0 == 1.0);
+
+    return 0;
+  end;
+


### PR DESCRIPTION
- [x] Fix bug and now `0.0 ^ 1 == 1.0`
- [x] include a very small gain for `{a..n} POW c` which now does not contain the extra value `1`.
- [x] the base count for `{a..b} OP {c..d}` got put in par with the other type of interval operations in the generated tests with QCheck
- [x] the long factor for QCheck tests of static operations on intervals has been multiplied by 10, which means they take a few minutes to complete on my computer. This is not really a problem as those tests can only be triggered manually.