### PR TITLE
[herd,aarch64] Force integer encoding of booleans in NZCV computation

### DIFF
--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -844,9 +844,12 @@ module
         unop op
           (fun s -> logand (lognot (mask_one k)) s)
     | ReadBit k ->
+        (* ReadBit returns 0 or 1, not false or true *)
         unop op
           (fun s ->
-            bool_to_scalar (Cst.Scalar.compare (logand (mask_one k) s) zero <> 0))
+             if equal (logand (mask_one k) s) zero
+             then zero
+             else one)
     | LogicalRightShift 0
     | LeftShift 0
     | AddK 0 -> fun s -> s


### PR DESCRIPTION
When computing the status flags NZCV, it is important not to introduce actual booleans.

As a matter of fact, the code assumes the encoding of false as 0 and true as 1. If booleans are encoded differently the old code fails. In practice this untimely situation occurs where AArch64Sem code is executed in AArch64+ASL mode, which indeed occurs. The fix consists in introducing some explicit boolean to integer operations `(fun b -> b ? 1 : 0)`, and to change the readBit operation output.