### PR TITLE
[litmus,aarch64] Fix SVC execution from EL0

### DIFF
--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -63,6 +63,9 @@ static void install_fault_handler(int cpu) {
   struct thread_info *ti = thread_info_sp(user_stack[cpu]);
   ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
   ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
-  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = fault_handler;
+  /* SVC is executed normally to transit back from EL0 to EL1,
+     do not override default behaviour
+    ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = fault_handler;
+  */
 #endif
 }


### PR DESCRIPTION
 When EL0 mode is specified, SVC is executed normally to transit back from EL0 to EL1, do not override default behaviour.

Without the fix EL0 tests will not terminate. This applies for instance for this simple test:

```
AArch64 TST-EL0
Variant=precise
EL0=P0
{
int x=1;
pte_x=(el0:0);
0:X2=x;
1:X2=x;
}
  P0        |  P1         ;
LDR W0,[X2] | LDR W0,[X2] ;
forall Fault(P0,x) /\ 0:X0=0 /\ ~Fault(P1,x) /\ 1:X0=1
```

Problem introduced by PR #1079. As a result of this fix, one can no longer run tests that execute `svc` as a test instruction in EL0 mode. Is this fixable ? @HadrienRenaud, @diaolo01.