### PR TITLE
[herd.litmus] Fix svc return

### DIFF
--- a/herd/branch.ml
+++ b/herd/branch.ml
@@ -39,8 +39,8 @@ module type S = sig
     | IndirectJump of v * Label.Full.Set.t * bds
     (* Stop now *)
     | Exit
-    (* Raise Fault *)
-    | Fault of bds
+    (* Raise Fault, boolean specifies system call *)
+    | Fault of bool * bds
     (* Return from Fault Handler *)
     | FaultRet of tgt
 
@@ -58,6 +58,9 @@ module type S = sig
 (* Conditional branch *)
   val bccT : v -> lbl -> t monad
   val faultRetT : lbl -> t monad
+  (* Faults and syscalls *)
+  val fault : bds -> t
+  val syscall : bds -> t
 end
 
 
@@ -82,7 +85,7 @@ module Make(M:Monad.S) = struct
     (* Stop now *)
     | Exit
     (* Raise Fault *)
-    | Fault of bds
+    | Fault of bool * bds
     (* Return from Fault Handler *)
     | FaultRet of tgt
 
@@ -99,4 +102,6 @@ module Make(M:Monad.S) = struct
   let indirectBranchT v lbls bds = M.unitT (IndirectJump (v,lbls,bds))
   let bccT v lbl = M.unitT (CondJump (v,Lbl lbl))
   let faultRetT lbl = M.unitT (FaultRet (Lbl lbl))
+  let fault bds = Fault (false,bds)
+  let syscall bds = Fault (true,bds)
 end

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -523,7 +523,7 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
           let env =
             match branch with
             | S.B.Next bds|S.B.Jump (_,bds)|S.B.IndirectJump (_,_,bds)
-            | B.Fault bds ->
+            | B.Fault (_,bds) ->
                 List.fold_right
                   (fun (r,v) -> A.set_reg r v)
                   bds env
@@ -557,7 +557,7 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
             addr in
           EM.failcodeT (Misc.UserError msg) true
 
-      and add_fault re_exec inst fetch_proc proc env seen addr nexts =
+      and add_fault re_exec inst fetch_proc proc env seen addr syscall nexts =
         match env.A.fh_code,re_exec with
         | Some _, true ->
            let e = "Fault inside a fault handler" in
@@ -569,10 +569,19 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
         | None, false ->
            let open Fault.Handling in
            match C.fault_handling with
-           | Fatal -> EM.unitcodeT true
-           | Skip -> add_code false fetch_proc proc env seen nexts
+           | Fatal ->
+               (* Abort thread execution *)
+               EM.unitcodeT true
+           | Skip ->
+               (* Execute next instruction *)
+               add_code false fetch_proc proc env seen nexts
            | Handled ->
-              add_next_instr true fetch_proc proc env seen addr inst nexts
+               (* "Natural" behaviour, differs between syscalls and faults *)
+               if syscall then
+                 (* Execute instruction *)
+                 add_code false fetch_proc proc env seen nexts
+               else (* execute  again the same instruction *)
+                 add_next_instr true fetch_proc proc env seen addr inst nexts
 
       and next_instr re_exec inst fetch_proc proc env seen addr nexts b =
         match b with
@@ -581,8 +590,8 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
           add_code re_exec fetch_proc proc env seen nexts
       | S.B.Jump (tgt,_) ->
           add_tgt re_exec true proc env seen addr tgt
-      | S.B.Fault _ ->
-          add_fault re_exec inst fetch_proc proc env seen addr nexts
+      | S.B.Fault (syscall,_) ->
+          add_fault re_exec inst fetch_proc proc env seen addr syscall nexts
       | S.B.FaultRet tgt ->
           add_tgt false true proc env seen addr tgt
       | S.B.CondJump (v,tgt) ->

--- a/herd/tests/instructions/AArch64.kvm/A020.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A020.litmus
@@ -1,0 +1,10 @@
+AArch64 A020
+variant=vmsa,handled
+{
+0:X0=0;
+}
+  P0          ;
+L0:           ;
+ SVC #0       ;
+ ADD W0,W0,#1 ;
+forall fault(P0:L0) /\ 0:X0=1

--- a/herd/tests/instructions/AArch64.kvm/A020.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A020.litmus.expected
@@ -1,0 +1,10 @@
+Test A020 Required
+States 1
+0:X0=1; Fault(P0:L0,SupervisorCall);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0:L0) /\ 0:X0=1)
+Observation A020 Always 1 0
+Hash=8fee4366aa4d7780c51e044180985ce6
+

--- a/herd/tests/instructions/AArch64.kvm/A021.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A021.litmus
@@ -1,0 +1,11 @@
+AArch64 A021
+variant=vmsa,skip
+{
+0:X0=0;
+}
+  P0          ;
+L0:           ;
+ SVC #0       ;
+ ADD W0,W0,#1 ;
+forall fault(P0:L0) /\ 0:X0=1
+

--- a/herd/tests/instructions/AArch64.kvm/A021.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A021.litmus.expected
@@ -1,0 +1,10 @@
+Test A021 Required
+States 1
+0:X0=1; Fault(P0:L0,SupervisorCall);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0:L0) /\ 0:X0=1)
+Observation A021 Always 1 0
+Hash=8fee4366aa4d7780c51e044180985ce6
+

--- a/herd/tests/instructions/AArch64.kvm/A022.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A022.litmus
@@ -1,0 +1,11 @@
+AArch64 A022
+variant=vmsa,fatal
+{
+0:X0=0;
+}
+  P0          ;
+L0:           ;
+ SVC #0       ;
+ ADD W0,W0,#1 ;
+ ADD W0,W0,#1 ;
+forall fault(P0:L0) /\ 0:X0=0

--- a/herd/tests/instructions/AArch64.kvm/A022.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A022.litmus.expected
@@ -1,0 +1,10 @@
+Test A022 Required
+States 1
+0:X0=0; Fault(P0:L0,SupervisorCall);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (fault(P0:L0) /\ 0:X0=0)
+Observation A022 Always 1 0
+Hash=6ca8359946048292b27f673122774a3e
+

--- a/herd/tests/instructions/AArch64.kvm/F004.litmus
+++ b/herd/tests/instructions/AArch64.kvm/F004.litmus
@@ -1,0 +1,11 @@
+AArch64 F004
+{
+0:X2=0;
+}
+  P0          | P0.F           ;
+L0:           | MOV W2,#1      ;
+  SVC #0      | ERET           ;
+L1:           |                ;
+  ADD W2,W2,#2|                ;
+
+forall 0:X2=3;

--- a/herd/tests/instructions/AArch64.kvm/F004.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/F004.litmus.expected
@@ -1,0 +1,10 @@
+Test F004 Required
+States 1
+0:X2=3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X2=3)
+Observation F004 Always 1 0
+Hash=e06f7ca51d2491ed933049436a3069fd
+

--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -50,7 +50,15 @@ static void fault_handler(struct pt_regs *regs,unsigned int esr) {
   regs->pc = (u64)lbls->ret[w->proc];
 #else
 #ifdef FAULT_SKIP
-  regs->pc += 4;
+  /*
+   * In skip mode, ERET should branch to the instruction
+   * that follows the faulting instruction.
+   * As SVC already behaves that way, do not
+   * increment pc when handler execution results
+   * from executing SVC.
+   */
+  if (esr >> ESR_EL1_EC_SHIFT != ESR_EL1_EC_SVC64)
+    regs->pc += 4;
 #endif
 #endif
 }


### PR DESCRIPTION
In AArch64, the SVC instruction generates a specific fault for both **herd** and **litmus**.
    
When tools imitate "natural" behaviour (_i.e._ `-variant handled` or `-variant imprecise`), control returns to the instruction that follows the SVC instruction. Previous behaviour was to re-execute SVC, following the standard behaviour for synchronous faults.

As an example the following test passes on hardware, while it yielded no **herd** output previously, due the repetitive execution of `SVC`.
```
AArch64 A020
variant=vmsa,handled
{
0:X0=0;
}
  P0          ;
L0:           ;
 SVC #0       ;
 ADD W0,W0,#1 ;
forall fault(P0:L0) /\ 0:X0=1
```
By contrast the test was already correct for **litmus**.

On a related note, we also changed the **litmus**  behaviour of  `-variant skip` to transfer control to the instruction that immediately follows the `SVC` instruction instead of skipping it, as it was the case previously.