### PR TITLE
Fix offsets in postcondition checks with litmus

### DIFF
--- a/litmus/compCond.ml
+++ b/litmus/compCond.ml
@@ -52,6 +52,10 @@ module Make (O:Indent.S) (I:CompCondUtils.I) =
             begin match v with
             | Constant.ConcreteVector vs ->
                 O.fprintf "(%s)" (dump_vec loc vs)
+            | Constant.Symbolic _ ->
+                O.fprintf "symbolic_equal(%s, %s)"
+                  (I.Loc.dump loc)
+                  (dump_v (Some (ConstrGen.loc_of_rloc loc)) v)
             | _ ->
                 O.fprintf "%s == %s"
                   (I.Loc.dump loc)

--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -23,7 +23,7 @@ static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
   if (get_far(esr, &far)) {
     flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
   } else {
-    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+    flt.data_symb = unknown_symbolic();
   }
 
   if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {

--- a/litmus/libdir/_aarch64/kvm_fault_type.c
+++ b/litmus/libdir/_aarch64/kvm_fault_type.c
@@ -61,7 +61,7 @@ static void th_faults_info_init(th_faults_info_t *th_flts)
   for (int i = 0; i < MAX_FAULTS_PER_THREAD; i++) {
     fault_info_t *f = &th_flts->faults[i];
     f->instr_symb = INSTR_SYMB_ID_UNKNOWN;
-    f->data_symb = unknown_symbolic();
+    f->data_symb = symbolic_of_id(DATA_SYMB_ID_UNKNOWN);
     f->type = FaultUnknown;
   }
   th_flts->n = 0;
@@ -96,9 +96,8 @@ static void pp_fault(int proc, int instr_symb, symb_t data_symb, int ftype)
     printf("fault(P%s", instr_symb_name[instr_symb]);
   else
     printf("fault(P%d", proc);
-  if (!symbolic_equal(data_symb, unknown_symbolic())) {
-    printf(","); pp_symbolic(data_symb);
-    printf(",%s", data_symb_name[data_symb]);
+  if (!symbolic_equal(data_symb, symbolic_of_id(DATA_SYMB_ID_UNKNOWN))) {
+    puts(","); puts(pp_symbolic(data_symb));
   } if (ftype != FaultUnknown)
     printf(",%s", fault_type_names[ftype]);
   printf(");");
@@ -125,7 +124,7 @@ static void pp_log_faults(FILE *chan, th_faults_info_t *th_flts, int proc, int i
     if (instr_symb != INSTR_SYMB_ID_UNKNOWN) {
       cond &= flt->instr_symb == instr_symb;
     }
-    if (!symbolic_equal(data_symb, unknown_symbolic())) {
+    if (!symbolic_equal(data_symb, symbolic_of_id(DATA_SYMB_ID_UNKNOWN))) {
       cond &= symbolic_equal(flt->data_symb, data_symb);
     }
     if (ftype != FaultUnknown) {
@@ -164,7 +163,7 @@ static int exists_fault(th_faults_info_t *th_flts, int instr_symb, symb_t data_s
     if (instr_symb != INSTR_SYMB_ID_UNKNOWN) {
       cond &= flt->instr_symb == instr_symb;
     }
-    if (!symbolic_equal(data_symb, unknown_symbolic())) {
+    if (!symbolic_equal(data_symb, symbolic_of_id(DATA_SYMB_ID_UNKNOWN))) {
       cond &= symbolic_equal(flt->data_symb, data_symb);
     }
     if (ftype != FaultUnknown) {

--- a/litmus/libdir/_aarch64/kvm_symb.c
+++ b/litmus/libdir/_aarch64/kvm_symb.c
@@ -1,0 +1,34 @@
+
+/* Generic type of symbolic value generated from the final state of a litmus
+ * test or the FAR_EL1 register in case of a fault.
+ *
+ * This type register all the data used for the pretty printing and checks of
+ * the final values like the `id` of the variable, it's `offset` and the raw
+ * pointer for a future usage in presence of a non-canonical MTE or PAC field
+ */
+typedef struct {
+  intmax_t* raw; // raw pointer value
+  uintptr_t offset; // offset between the raw value and the symbolic value
+  int id; // id of the symbolic value
+} symb_t;
+
+static symb_t symbolic_of_id(int id) {
+  symb_t ret = { .id = id, .offset = 0 };
+  return ret;
+}
+
+static symb_t unknown_symbolic() {
+  return symbolic_of_id(DATA_SYMB_ID_UNKNOWN);
+}
+
+static int symbolic_equal(symb_t s1, symb_t s2) {
+  return s1.id == s2.id && s1.offset == s2.offset;
+}
+
+static void pp_symbolic(symb_t s) {
+  printf("%s", data_symb_name[s.id]);
+
+  if (s.offset != 0)
+    printf("+%ld", s.offset);
+}
+

--- a/litmus/libdir/_aarch64/kvm_symb.c
+++ b/litmus/libdir/_aarch64/kvm_symb.c
@@ -1,13 +1,8 @@
 
 /* Generic type of symbolic value generated from the final state of a litmus
  * test or the FAR_EL1 register in case of a fault.
- *
- * This type register all the data used for the pretty printing and checks of
- * the final values like the `id` of the variable, it's `offset` and the raw
- * pointer for a future usage in presence of a non-canonical MTE or PAC field
  */
 typedef struct {
-  intmax_t* raw; // raw pointer value
   uintptr_t offset; // offset between the raw value and the symbolic value
   int id; // id of the symbolic value
 } symb_t;
@@ -17,18 +12,15 @@ static symb_t symbolic_of_id(int id) {
   return ret;
 }
 
-static symb_t unknown_symbolic() {
-  return symbolic_of_id(DATA_SYMB_ID_UNKNOWN);
-}
-
 static int symbolic_equal(symb_t s1, symb_t s2) {
   return s1.id == s2.id && s1.offset == s2.offset;
 }
 
-static void pp_symbolic(symb_t s) {
-  printf("%s", data_symb_name[s.id]);
-
-  if (s.offset != 0)
-    printf("+%ld", s.offset);
+// Pretty print a symbolic data, only print the
+static const char* pp_symbolic(symb_t s) {
+  char* buffer = (char*)malloc(sizeof(char) * 1024);
+  if (s.offset == 0) snprintf(buffer, 1024, "%s", data_symb_name[s.id]);
+  else snprintf(buffer, 1024, "%s+%ld", data_symb_name[s.id], s.offset);
+  return buffer;
 }
 

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -844,7 +844,7 @@ module Make
               end in
             begin
               O.o "static symb_t idx_addr(intmax_t *v_addr,vars_t *p) {" ;
-              O.oi "symb_t ret = { .raw = v_addr, .id = -1, .offset = 0 };" ;
+              O.oi "symb_t ret = { .id = -1, .offset = 0 };" ;
               begin match test.T.globals with
               | _::_ when Cfg.is_kvm ->
                  O.oi  "intmax_t *p_addr =" ;
@@ -899,7 +899,7 @@ module Make
                 [sprintf "instr_symb_name[p->%s]" (dump_rloc_tag_coded rloc)]
             | Pointer _ ->
                 None,
-                [sprintf "data_symb_name[p->%s.id]" (dump_rloc_tag_coded rloc)]
+                [sprintf "pp_symbolic(p->%s)" (dump_rloc_tag_coded rloc)]
             | Array (_,sz) ->
                 let tag = A.dump_rloc_tag rloc in
                 let rec pp_rec k =
@@ -993,6 +993,9 @@ module Make
                 pp_rec (k+1)
               end in
             pp_rec 0
+        | Pointer _ when not (U.is_rloc_label rloc env) ->
+            let loc = choose_dump_rloc_tag rloc env in
+            O.fii "symbolic_equal(p->%s, q->%s)%s" loc loc suf
         | _ -> do_eq rloc suf in
         let do_eq_faults = function
           | [] -> O.oii "1;"

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -838,8 +838,10 @@ module Make
               O.fi "if (%s == p->%s) ret.id = %s;"
                 addr s (SkelUtil.data_symb_id s) ;
               if Cfg.is_kvm then begin
-                O.fi "if ((pteval_t *)v_addr == p->%s) ret.id = %s;"
-                  (OutUtils.fmt_pte_tag s)
+                O.fi "if ((pteval_t *)v_addr == p->%s) {"
+                  (OutUtils.fmt_pte_tag s) ;
+                O.fii "ret.offset = 0;" ;
+                O.fii "ret.id = %s; }"
                   (SkelUtil.data_symb_id (Misc.add_pte s))
               end in
             begin

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -75,6 +75,7 @@ let dump_fatom_tag d ((p,lbl),v,_) =
      | None -> ""
      | Some v -> "_" ^ d v)
 
+let data_symb s = sprintf "DATA_SYMB_%s" (String.uppercase_ascii s)
 let data_symb_id s = sprintf "DATA_SYMB_ID_%s" (String.uppercase_ascii s)
 let instr_symb_id s = sprintf "INSTR_SYMB_ID_%s" (String.uppercase_ascii s)
 let fault_id s = sprintf "Fault%s" (Misc.to_c_name s)


### PR DESCRIPTION
Fix the issue #1160 about errors in litmus7 in case of an offset between the expected value and the observed value in a litmus test, for example with the test:
```
AArch64 offset_cex
{ 0:x0=x; uint64_t 0:x1=4; }
P0;
  add x0,x0,x1;

forall
  ( 0:x0=x )
```

herd return 
```
States 1
0:X0=x+4;
No
Witnesses
Positive: 0 Negative: 1
```

but the current version of litmus-kvm return
```
4000000:>0:X0=x;
Ok

Witnesses
Positive: 4000000, Negative: 0
```

but with this PR it return:
```
4000000*>0:X0=x+4;
No

Witnesses
Positive: 0, Negative: 4000000
```

because `idx_addr` now return a structure of type `symb_t` with the information of the ID and the offset of the variable it match.

Now the generated `idx_addr` look like this:
```C
static symb_t idx_addr(intmax_t *v_addr,vars_t *p) {
  symb_t ret = { .id = -1, .offset = 0 };
  intmax_t *p_addr =
    (intmax_t *)((uintptr_t)v_addr & PAGE_MASK);
  ret.offset = (uintptr_t)v_addr - (uintptr_t)p_addr;
  if (p_addr == p->x) ret.id = DATA_SYMB_ID_X;
  if ((pteval_t *)v_addr == p->pte_x) {
    ret.offset = 0;
    ret.id = DATA_SYMB_ID_PTE_X; }
  if (ret.id == -1)
    fatal("Cannot find symbol for address");
  return ret;
}
```