### PR TITLE
[litmus,aarch64] EL0 mode by vector table.

### DIFF
--- a/herd/tests/instructions/AArch64.kvm/NORUN
+++ b/herd/tests/instructions/AArch64.kvm/NORUN
@@ -1,0 +1,7 @@
+#Not for generic litmus
+#CAS inside
+A007
+A019
+A011
+#Label in output
+A006

--- a/litmus/AArch64Arch_litmus.ml
+++ b/litmus/AArch64Arch_litmus.ml
@@ -117,13 +117,19 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
 
       let nop = I_NOP
 
+
       let user_handler_clobber = "x29"
       let user_handler_clobbers = [ user_handler_clobber; ]
 
+      let default_sync_handler user =
+        if user then "el0_sync_64"
+        else "el1h_sync"
+
+
       let vector_table is_user name =
         let el1h_sync,el0_sync_64 =
-          if is_user then "el1h_sync",name
-          else name,"el0_sync_64" in
+          if is_user then default_sync_handler false,name
+          else name, default_sync_handler true in
         let ventry label k = ".align 7"::Printf.sprintf "b %s" label::k
         and wentry _label k =
           ".align 7"

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -340,10 +340,14 @@ module RegMap = A.RegMap)
 
       let before_dump args0 compile_out_reg compile_val compile_cpy
           chan indent proc t trashed =
+        List.iter
+          (fun (t,n) ->
+             fprintf chan "  extern %s %s;\n" (CType.dump t) n)
+          args0.Template.externs ;
         begin match args0.Template.trashed with
         | [] -> ()
         | trs ->
-            fprintf chan "uint64_t %s;" (String.concat "," trs)
+            fprintf chan "  uint64_t %s;\n" (String.concat "," trs)
         end ;
         RegSet.iter
           (fun reg ->
@@ -547,9 +551,12 @@ module RegMap = A.RegMap)
             addrs_proc in
         let params0 =
           List.map
-            (fun ((t,n),_) ->
-              sprintf "%s %s" (CType.dump t) n)
-          args0.Template.inputs in
+            (fun (tns,_) ->
+               List.map
+                 (fun (t,n)  ->
+                    sprintf "%s %s" (CType.dump t) n)
+                 tns)
+          args0.Template.inputs |> List.flatten in
         let ptes =
           List.map
             (fun x -> sprintf "pteval_t *%s" (Misc.add_pte x))

--- a/litmus/arch_litmus.mli
+++ b/litmus/arch_litmus.mli
@@ -66,6 +66,9 @@ module type Base = sig
 
   val features : ((instruction -> bool) * string) list
   val user_handler_clobbers : string list
+
+  (* In the following two functions first argument specifies user mode *)
+  val default_sync_handler : bool -> string
   val vector_table : bool -> string -> string list
 
 (* Reaction to different types, fail or warn *)

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -530,7 +530,7 @@ module A.FaultType = A.FaultType)
         else code in
       let code =
         if user then
-          C.user_mode has_handler proc
+          C.user_mode has_handler  proc
           @code
           @C.kernel_mode has_handler
         else code

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -530,7 +530,7 @@ module A.FaultType = A.FaultType)
         else code in
       let code =
         if user then
-          C.user_mode has_handler  proc
+          C.user_mode has_handler proc
           @code
           @C.kernel_mode has_handler
         else code

--- a/litmus/handler.ml
+++ b/litmus/handler.ml
@@ -18,13 +18,15 @@
 
 module type S = sig
   type ins
-
+  (* Strictly greater than any label in handler *)
   val max_handler_label : int
 
+  (* Emit code to and from user mode *)
   val user_mode : bool -> Proc.t -> ins list
   val kernel_mode : bool -> ins list
 
-  val fault_handler_prologue : bool -> int -> ins list
+  (* Explicit handlers prologue and epilogue *)
+  val fault_handler_prologue : bool -> Proc.t -> ins list
   val fault_handler_epilogue : bool -> ins list -> ins list
 end
 

--- a/litmus/handler.mli
+++ b/litmus/handler.mli
@@ -18,16 +18,16 @@
 
 module type S = sig
   type ins
-
   (* Strictly greater than any label in handler *)
   val max_handler_label : int
 
-  (* Emit code to and from user mode,
-     boolean argument signals explicit handler *)
+  (* Emit code to and from user mode.
+     First boolean argument reflects explicit handler *)
   val user_mode : bool -> Proc.t -> ins list
   val kernel_mode : bool -> ins list
 
-  (* First boolean argument reflects user mode *)
+  (* Explicit handlers prologue and epilogue.
+     First boolean argument reflects user mode *)
   val fault_handler_prologue : bool -> Proc.t -> ins list
   val fault_handler_epilogue : bool -> ins list -> ins list
 end

--- a/litmus/hardwareExtra.ml
+++ b/litmus/hardwareExtra.ml
@@ -19,11 +19,13 @@
 
 module type S  = sig
   val user_handler_clobbers : string list
+  val default_sync_handler : bool -> string
   val vector_table : bool -> string -> string list
 end
 
 module No = struct
   let user_handler_clobbers = []
+  let default_sync_handler _ = ""
   let vector_table _ _ = []
 end
               

--- a/litmus/hardwareExtra.mli
+++ b/litmus/hardwareExtra.mli
@@ -18,6 +18,7 @@
 
 module type S  = sig
   val user_handler_clobbers : string list
+  val default_sync_handler : bool -> string
   val vector_table : bool -> string -> string list
 end
 

--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -71,9 +71,6 @@ static void install_fault_handler(int cpu) {
   struct thread_info *ti = thread_info_sp(user_stack[cpu]);
   ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_DABT_EL0] = fault_handler;
   ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_UNKNOWN] = fault_handler;
-  /* SVC is executed normally to transit back from EL0 to EL1,
-     do not override default behaviour
-    ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = fault_handler;
-  */
+  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = fault_handler;
 #endif
 }

--- a/litmus/libdir/_aarch64/kvm_user_stacks.c
+++ b/litmus/libdir/_aarch64/kvm_user_stacks.c
@@ -4,10 +4,6 @@
 
 #define USER_MODE 1
 
-static void back_to_el1(struct pt_regs *regs,unsigned int esr) {
-  regs->pstate |= 0b0101;
-}
-
 static uint64_t user_stack[AVAIL];
 
 static void set_user_stack(int cpu) {
@@ -18,7 +14,5 @@ static void set_user_stack(int cpu) {
   struct thread_info *ti = thread_info_sp(sp_usr);
   thread_info_init(ti, TIF_USER_MODE);
   ti->pgtable = ti0->pgtable;
-  ti->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = back_to_el1;
-  ti0->exception_handlers[EL0_SYNC_64][ESR_EL1_EC_SVC64] = back_to_el1;
   user_stack[cpu] = sp_usr;
 }

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -49,11 +49,13 @@ end
 
 type extra_args =
   { trashed: string list;
-    inputs: ((CType.t * string) * (string * string)) list;
+    inputs: ((CType.t * string) list * (string * string)) list;
     constants: (string * string) list;
-    clobbers: string list; }
+    clobbers: string list;
+    externs : (CType.t * string) list; }
 
-let no_extra_args = { trashed=[]; inputs=[]; constants=[]; clobbers=[]; }
+let no_extra_args =
+  { trashed=[]; inputs=[]; constants=[]; clobbers=[]; externs=[]; }
 
 module type S = sig
   module V : Constant.S


### PR DESCRIPTION
We now systematically change the vector table of EL0 threads, by introducing an indirect jump in the slot for EL0 synchronous interruptions.

During test the indirection point to the appropriate fault handler. Just before leaving test code, the indirection is changed to point to the end of test code. This technique permits returning to EL1 at test end by using a `SVC` instruction.

Moreover, `SVC` instructions that may be present in test code are treated by the appropriate fault handler.

This PR is a followup to PR #1157.