### PR TITLE
[herd, aarch64]: Do not Tag Check cache maintenance operation(s)

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -3165,7 +3165,8 @@ module Make
             let dir = match op.AArch64Base.DC.funct with
               | AArch64Base.DC.I -> Dir.W
               | _ -> Dir.R in
-            lift_memop rd dir false memtag
+            (* CMO by VA other than DC ZVA are Tag Unchecked *)
+            lift_memop rd dir false false
               (fun ac ma _mv -> (* value fake here *)
                 if Access.is_physical ac then
                   M.bind_ctrldata ma (mop ac)


### PR DESCRIPTION
Arm ARM's rule state

  RDRGYL A single-copy atomic explicit memory access is Tag Unchecked
         due to any of the following, otherwise it is Tag Checked:
	 • The access is:
	 ...
	 — Due to a cache maintenance operation by VA other than DC ZVA
	 ...

However, currently DC is Tag check. Let's align DC with the rule and make it Tag Unchecked