### PR TITLE
[catalogue,aarch64] 2 tests for release-to-acquire ordering

### DIFF
--- a/catalogue/aarch64/tests/@all
+++ b/catalogue/aarch64/tests/@all
@@ -43,3 +43,5 @@ SB+CAS-rfi-addr+DMBSY.litmus
 SB+SWP-rfi-addr+DMBSY.litmus
 #Litmus testing
 STABLE.litmus
+SB+dmb.sy+rel-acq.litmus
+SB+dmb.sy+rel-acqpc.litmus

--- a/catalogue/aarch64/tests/SB+dmb.sy+rel-acq.litmus
+++ b/catalogue/aarch64/tests/SB+dmb.sy+rel-acq.litmus
@@ -1,0 +1,14 @@
+AArch64 SB+dmb.sy+rel-acq
+Hash=2b3370ed5486fa3f8ccd5b3583989571
+
+{
+ 0:X1=x; 0:X3=y;
+ 1:X1=x; 1:X3=y;
+}
+ P0          | P1           ;
+ MOV W0,#1   | MOV W2,#1    ;
+ STR W0,[X1] | STLR W2,[X3] ;
+ DMB SY      |              ;
+ LDR W2,[X3] | LDAR W0,[X1] ;
+
+exists (0:X2=0 /\ 1:X0=0)

--- a/catalogue/aarch64/tests/SB+dmb.sy+rel-acqpc.litmus
+++ b/catalogue/aarch64/tests/SB+dmb.sy+rel-acqpc.litmus
@@ -1,0 +1,14 @@
+AArch64 SB+dmb.sy+rel-acqpc
+Hash=5b3a6dbce76eccd468d8ca9cc613b045
+
+{
+ 0:X1=x; 0:X3=y;
+ 1:X1=x; 1:X3=y;
+}
+ P0          | P1            ;
+ MOV W0,#1   | MOV W2,#1     ;
+ STR W0,[X1] | STLR W2,[X3]  ;
+ DMB SY      |               ;
+ LDR W2,[X3] | LDAPR W0,[X1] ;
+
+exists (0:X2=0 /\ 1:X0=0)

--- a/catalogue/aarch64/tests/kinds.txt
+++ b/catalogue/aarch64/tests/kinds.txt
@@ -56,3 +56,5 @@ CoRW2          Forbidden
 CoWR           Forbidden
 CoWW           Forbidden
 LB+SWP-RsRt-addr+rel Allowed
+SB+dmb.sy+rel-acq               Forbidden
+SB+dmb.sy+rel-acqpc             Allowed


### PR DESCRIPTION
This PR adds two tests to illustrate the clause in Barrier-ordered-before that is sensitive to the differences between the `LDAR` and `LDAPR` instructions.