### PR TITLE
[litmus] Add some typing of registers in x86_64 code

### DIFF
--- a/herd/tests/instructions/X86_64/A009.litmus
+++ b/herd/tests/instructions/X86_64/A009.litmus
@@ -7,5 +7,5 @@ int64_t 0:rcx;
 }
 
 P0                        ;
-movq 0(%rax,%ebx,8),%rcx  ;
+movq 0(%rax,%rbx,8),%rcx  ;
 forall 0:rcx = -1

--- a/herd/tests/instructions/X86_64/A009.litmus.expected
+++ b/herd/tests/instructions/X86_64/A009.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:rcx=-1)
 Observation A009 Always 1 0
-Hash=a97bc3fd7318c7656902927df4f2aa4a
+Hash=7ca3c35015d75a877ccf509d75062e79
 

--- a/herd/tests/instructions/X86_64/A010.litmus
+++ b/herd/tests/instructions/X86_64/A010.litmus
@@ -1,0 +1,9 @@
+X86_64 A010
+{
+  uint64_t x;
+  0:RBX=0x202020202020202;
+}
+  P0            ;
+  MOVQ %RBX,(x) ;
+locations [x;]
+forall [x] = 0x202020202020202

--- a/herd/tests/instructions/X86_64/A010.litmus.expected
+++ b/herd/tests/instructions/X86_64/A010.litmus.expected
@@ -1,0 +1,10 @@
+Test A010 Required
+States 1
+[x]=144680345676153346;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall ([x]=144680345676153346)
+Observation A010 Always 1 0
+Hash=a4f2c7b46c9fe04acb695c7d4ca4630b
+


### PR DESCRIPTION
The registers of this machine have several incarnations (64bits, 32bits,...). Litmus needs a precise knowledge of those to treat initial constants correctly.

Consider for instance this test:
```
X86_64 A010
{
  uint64_t x;
  0:RBX=0x202020202020202;
}
  P0            ;
  MOVQ %RBX,(x) ;
locations [x;]
forall [x] = 0x202020202020202
```
Before this PR, **litmus** fails on this test  as the constant `0x202020202020202` is casted into the default type `int`. With code typing  a correct, 64 bits, type is inferred.

Typing remains minimal and is probably insufficient. 