### PR TITLE
[litmus] Add configuration file

### DIFF
--- a/litmus/libdir/kvm-aarch64-qemu.cfg
+++ b/litmus/libdir/kvm-aarch64-qemu.cfg
@@ -1,0 +1,26 @@
+#Compilation to local qemu, with cross-compilation
+crossrun = kvm
+gcc = aarch64-linux-gnu-gcc
+size_of_test = 5k
+number_of_run = 200
+avail = 4
+limit = true
+memory = direct
+stride = 1
+carch = AArch64
+barrier = userfence
+smt = 1
+smt_mode = seq
+ascall = true
+mode = kvm
+delay = 32
+makevar = AUXFLAGS=0x0
+makevar = SRCDIR=$(PWD)/..
+makevar = -include $(SRCDIR)/config.mak
+makevar = libcflat = $(SRCDIR)/lib/libcflat.a
+makevar = libeabi = $(SRCDIR)/lib/arm/libeabi.a
+makevar = LIBFDT_archive = $(SRCDIR)/lib/libfdt/libfdt.a
+makevar = cstart.o = $(SRCDIR)/arm/cstart64.o
+makevar = FLATLIBS = $(libcflat) $(LIBFDT_archive) $(libeabi)
+makevar = optional-ccopt = $(shell if $(CC) -Werror $(1) -S -o /dev/null -xc /dev/null > /dev/null 2>&1; then echo "$(1)"; fi)
+ccopts = -DNOSWP -std=gnu99 -ffreestanding -I $(SRCDIR)/lib -I $(SRCDIR)/libfdt -Wall -Werror  -fomit-frame-pointer -Wno-frame-address   -fno-pic  -no-pie -Wmissing-parameter-type -Wold-style-declaration -Woverride-init -O2 $(call optional-ccopt, -mno-outline-atomics)


### PR DESCRIPTION
The new file configures litmus for vmsa tests running on top of  qemu-system-aarch64 on a non-aarch64 system.

Notice that this is the final step after having
  + Installed the cross-compilation toolchain
  + Installed qemu-system-aarch64
  + Compiled kvm-unit-tests. on top of qemu