### PR TITLE
Accessibility enhancements to the ASL Reference - Phase 2

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -539,8 +539,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     | _ -> conflict ~loc [ default_t_bits ] t
   (* End *)
 
-  (* Begin CheckStructureInteger *)
-  let check_structure_integer ~loc env t () =
+  (* Begin CheckUnderlyingInteger *)
+  let check_underlying_integer ~loc env t () =
     let () =
       if false then
         Format.eprintf "Checking that %a is an integer.@." PP.pp_ty t
@@ -1374,7 +1374,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
   (* Begin AnnotateSymbolicInteger *)
   and annotate_symbolic_integer ~(loc : 'a annotated) env e =
     let t, e', ses = annotate_symbolically_evaluable_expr env e in
-    let+ () = check_structure_integer ~loc env t in
+    let+ () = check_underlying_integer ~loc env t in
     (StaticModel.try_normalize env e', ses)
   (* End *)
 
@@ -1419,7 +1419,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           and length', ses_length =
             annotate_symbolic_constrained_integer ~loc env length
           in
-          let+ () = check_structure_integer ~loc:offset env t_offset in
+          let+ () = check_underlying_integer ~loc:offset env t_offset in
           let ses = SES.union ses_length ses_offset in
           (Slice_Length (offset', length'), ses |: TypingRule.Slice)
       | Slice_Range (j, i) ->
@@ -2902,7 +2902,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
               WellConstrained [ Constraint_Range (e_bot, e_top) ]
           | T_Int _, _ -> conflict ~loc [ integer' ] end_t
           | _, _ -> conflict ~loc [ integer' ] start_t
-          (* only happens in relaxed type-checking mode because of check_structure_integer earlier. *)
+          (* only happens in relaxed type-checking mode because of check_underlying_integer earlier. *)
           (* TypingRule.ForConstraint) *)
         in
         let ty = T_Int cs |> here in

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -572,7 +572,7 @@ Since the rule does not need to refer to the value, we do not name it and use an
 instead.
 
 \subsection{Flavors of Equality In Rules \label{sec:FlavoursOfEqualityInRules}}
-We now explain equality notations in rules, two of which are used in \SemanticsRuleRef{ECond},
+We now explain the equality notations in rules, two of which are used in \SemanticsRuleRef{ECond},
 shown here:
 \begin{mathpar}
 \inferrule{

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -648,9 +648,10 @@ we sometimes only care about a subset of the fields $\{f_{i_1},\ldots,f_{i_m}\} 
 In such cases, we write $\{f_{i_1}:t_{i_1},\ldots,f_{i_m}:t_{i_m},\ldots\}$,
 where $\ldots$ stands for fields that are irrelevant for the rule.
 
-For example\footnote{This example is from \SemanticsRuleRef{FCall}.}, the \func\ non-terminal is
+For example, the \func\ non-terminal is
 of a record type and has the following fields:
-$\funcname$, $\funcparameters$, $\funcargs$, $\funcbody$, $\funcreturntype$, and $\funcsubprogramtype$.
+$\funcname$, $\funcparameters$, $\funcargs$, $\funcbody$, $\funcreturntype$, $\funcsubprogramtype$,
+$\funcrecurselimit$, and $\funcbuiltin$.
 The notation $\{ \funcbody:\vbody,\ \funcargs:\vargdecls, \ldots \}$
 allows us to deconstruct a given \func\ node by matching only the $\funcbody$ and $\funcargs$ fields.
 

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -648,15 +648,16 @@ we sometimes only care about a subset of the fields $\{f_{i_1},\ldots,f_{i_m}\} 
 In such cases, we write $\{f_{i_1}:t_{i_1},\ldots,f_{i_m}:t_{i_m},\ldots\}$,
 where $\ldots$ stands for fields that are irrelevant for the rule.
 
-For example\footnote{This example is from \SemanticsRuleRef{FCall}.}, the \func\ non-terminal is of a record type and has the following fields:
-$\textsf{name}$, $\textsf{parameters}$, $\textsf{args}$, $\textsf{body}$, $\textsf{return\_type}$, and $\textsf{subprogram\_type}$.
-The notation $\{ \textsf{body}:\SBASL(\texttt{body}),\ \textsf{args}:\texttt{arg\_decls}, \ldots \}$
-allows us to deconstruct a given \func\ node by matching only the \textsf{body} and \textsf{args} fields.
+For example\footnote{This example is from \SemanticsRuleRef{FCall}.}, the \func\ non-terminal is
+of a record type and has the following fields:
+$\funcname$, $\funcparameters$, $\funcargs$, $\funcbody$, $\funcreturntype$, and $\funcsubprogramtype$.
+The notation $\{ \funcbody:\vbody,\ \funcargs:\vargdecls, \ldots \}$
+allows us to deconstruct a given \func\ node by matching only the $\funcbody$ and $\funcargs$ fields.
 
 Recall that a subset of AST nodes are either labels or labelled tuples.
 \hypertarget{def-astlabel}{}
 The partial function $\astlabel$ returns the label $\vl\in\astlabels$ of an AST node, when it exists.
-For example, $\astlabel(\TBool) = \TBool$ and $\astlabel(\TNamed(\texttt{x})) = \TNamed$.
+For example, $\astlabel(\TBool) = \TBool$ and $\astlabel(\TNamed(\vx)) = \TNamed$.
 
 \subsection{How to Parse Rules Efficiently}
 Consider the following examples, which is a simplified version of \SemanticsRuleRef{Binop}

--- a/asllib/doc/ASLRefProgress.tex
+++ b/asllib/doc/ASLRefProgress.tex
@@ -15,7 +15,7 @@ The following simultaneous declaration of three global variables does not curren
 
 The same line does parse and correctly handled inside a subprogram.
 
-\lrmcomment{This is related to \identr{QDQD}.}
+\identr{QDQD}
 
 \subsection{Guards}
 
@@ -23,8 +23,7 @@ Guards are used on \texttt{case} and \texttt{catch} statements, to restrict
 matching on the evaluation of a boolean expression.
 %
 They are not yet implemented in ASLRef.
-
-\lrmcomment{This relates to \identr{WGSY}.}
+\identr{WGSY}
 
 % ------------------------------------------------------------------------------
 \section{Semantics}
@@ -61,7 +60,7 @@ The analysis currently ignores dynamic errors that are not due to assertions.
 Restrictions on the use of parameterized integer types as storage element types are not
 implemented.
 
-\lrmcomment{This is related to \identr{ZCVD}.}
+\identr{ZCVD}
 
 \subsubsection{\texttt{as} Expression With a Constrained Type}
 
@@ -71,7 +70,7 @@ Asserted Typed Conversion is not implemented in ASLRef.
 For example, the following will not raise a type-error:
 \VerbatimInput[firstline=1,lastline=4]{../tests/regressions.t/under-constrained-used.asl}
 
-\lrmcomment{This is related to \identi{TBHH}, \identr{ZDKC}.}
+\identi{TBHH} \identr{ZDKC}
 
 % ------------------------------------------------------------------------------
 \chapter{Issues Not Yet Addressed by the Reference\label{appendix:MissingTransliteration}}
@@ -82,7 +81,7 @@ For example, the following will not raise a type-error:
 
 The standard library is not yet defined in this reference.
 
-\lrmcomment{This is related to \identr{RXYN}.}
+\identr{RXYN}
 
 % ------------------------------------------------------------------------------
 \section{Typing}
@@ -94,4 +93,4 @@ Type annotations that contain expressions that may fail dynamically are not chec
 % Finding the type of a literal value, or a compile-time constant expression, is
 % not yet transliterated.
 
-% \lrmcomment{This is related to \identr{ZJKY} and \identi{RYRP}.}
+% \identr{ZJKY}  \identi{RYRP}

--- a/asllib/doc/ASLReference.tex
+++ b/asllib/doc/ASLReference.tex
@@ -22,7 +22,7 @@
 \makeatletter
 \renewcommand{\l@section}{\@dottedtocline{1}{1.5em}{2.6em}}
 \makeatother
-\setcounter{tocdepth}{1}
+\setcounter{tocdepth}{0}
 
 \author{Arm Architecture Technology Group}
 \title{ASL Reference \\
@@ -52,8 +52,8 @@
 \input{Types.tex}
 \input{Bitfields.tex}
 \input{Expressions.tex}
-\input{PatternMatching.tex}
 \input{Slicing.tex}
+\input{PatternMatching.tex}
 \input{AssignableExpressions.tex}
 \input{LocalStorageDeclarations.tex}
 \input{Statements.tex}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -151,21 +151,6 @@
 
 \fvset{fontsize=\small}
 
-\newcommand\tododefine[1]{\hyperlink{tododefine}{\color{red}{\texttt{#1}}}}
-\newcommand\lrmcomment[1]{}
-\newcommand\textfunc[1]{\textit{#1}}
-\newcommand\ProseParagraph[0]{\subsubsection{Prose}}
-\newcommand\FormallyParagraph[0]{\subsubsection{Formally}}
-\newcommand\CaseDef[1]{\textsc{#1}}
-\newcommand\CaseName[1]{case \textsc{#1}}
-\newcommand\AllApply[0]{All of the following apply:}
-\newcommand\AllApplyCase[1]{All of the following apply (\CaseDef{#1}):}
-\newcommand\OneApplies[0]{One of the following applies:}
-\newcommand\Proseeqdef[2]{define #1 as #2}
-\newcommand\ProseEqdef[2]{Define #1 as #2}
-\newcommand\ExampleDef[1]{\subsubsection{Example: #1\label{Example:#1}}}
-\newcommand\ExampleRef[1]{Example~\ref{Example:#1}}
-
 \usepackage{enumitem}
 \renewlist{itemize}{itemize}{20}
 \setlist[itemize,1]{label=\textbullet}
@@ -188,6 +173,21 @@
 \setlist[itemize,18]{label=\textasteriskcentered}
 \setlist[itemize,19]{label=\textendash}
 \setlist[itemize,20]{label=\textendash}
+
+\newcommand\tododefine[1]{\hyperlink{tododefine}{\color{red}{\texttt{#1}}}}
+\newcommand\lrmcomment[1]{}
+\newcommand\textfunc[1]{\textit{#1}}
+\newcommand\ProseParagraph[0]{\subsubsection{Prose}}
+\newcommand\FormallyParagraph[0]{\subsubsection{Formally}}
+\newcommand\CaseDef[1]{\textsc{#1}}
+\newcommand\CaseName[1]{case \textsc{#1}}
+\newcommand\AllApply[0]{All of the following apply:}
+\newcommand\AllApplyCase[1]{All of the following apply (\CaseDef{#1}):}
+\newcommand\OneApplies[0]{One of the following applies:}
+\newcommand\Proseeqdef[2]{define #1 as #2}
+\newcommand\ProseEqdef[2]{Define #1 as #2}
+\newcommand\ExampleDef[1]{\subsubsection{Example: #1\label{Example:#1}}}
+\newcommand\ExampleRef[1]{Example~\ref{Example:#1}}
 
 \ifcode
 % First argument is \<rule>Begin, second is \<rule>End, third is the file name.
@@ -258,6 +258,8 @@
 \newcommand\wrappedline[0]{{\hyperlink{def-wrapline}{\color{red}\hookrightarrow}}}
 \newcommand\commonprefixline[0]{{\hyperlink{def-commonprefixline}{\color{cyan}{\text{\tiny******** common prefix ********}} }}}
 \newcommand\commonsuffixline[0]{{\hyperlink{def-commonsuffixline}{\color{cyan}{\text{\tiny******** common suffix ********}} }}}
+\newcommand\stdlibfunc[1]{standard library function \texttt{#1}}
+\newcommand\stdlibfuncname[1]{\texttt{#1}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%$%%%%%
 %% Mathematical notations and Inference Rule macros

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -156,11 +156,15 @@
 \newcommand\textfunc[1]{\textit{#1}}
 \newcommand\ProseParagraph[0]{\subsubsection{Prose}}
 \newcommand\FormallyParagraph[0]{\subsubsection{Formally}}
+\newcommand\CaseDef[1]{\textsc{#1}}
+\newcommand\CaseName[1]{case \textsc{#1}}
 \newcommand\AllApply[0]{All of the following apply:}
-\newcommand\AllApplyCase[1]{All of the following apply (\textsc{#1}):}
+\newcommand\AllApplyCase[1]{All of the following apply (\CaseDef{#1}):}
 \newcommand\OneApplies[0]{One of the following applies:}
 \newcommand\Proseeqdef[2]{define #1 as #2}
 \newcommand\ProseEqdef[2]{Define #1 as #2}
+\newcommand\ExampleDef[1]{\subsubsection{Example: #1\label{Example:#1}}}
+\newcommand\ExampleRef[1]{Example~\ref{Example:#1}}
 
 \usepackage{enumitem}
 \renewlist{itemize}{itemize}{20}
@@ -225,8 +229,8 @@
 \newtheorem{definition}{Definition}
 \newtheorem{example}{Example}
 \newcommand\ConventionDef[1]{\paragraph{Convention.#1:\label{sec:Convention.#1}}}
-\newcommand\RequirementDef[1]{\paragraph{Requirement.#1\label{Requirement.#1}}}
-\newcommand\RequirementDefExample[1]{\emph{Requirement.#1}}
+\newcommand\RequirementDef[1]{\paragraph{Guide.#1\label{Guide.#1}}}
+\newcommand\RequirementDefExample[1]{\emph{Guide.#1}}
 \newcommand\LexicalRuleDef[1]{\subsubsection{LexicalRule.#1\label{sec:LexicalRule.#1}}}
 \newcommand\ASTRuleDef[1]{\subsubsection{ASTRule.#1\label{sec:ASTRule.#1}}}
 \newcommand\ASTRuleDefExample[1]{\emph{ASTRule.#1}}
@@ -243,7 +247,7 @@
 \newcommand\appendixref[1]{Appendix~\ref{appendix:#1}}
 \newcommand\ASTRuleRef[1]{\nameref{sec:ASTRule.#1}}
 \newcommand\ConventionRef[1]{\nameref{sec:Convention.#1}}
-\newcommand\RequirementRef[1]{\nameref{Requirement.#1}}
+\newcommand\RequirementRef[1]{\nameref{Guide.#1}}
 \newcommand\LexicalRuleRef[1]{\nameref{sec:LexicalRule.#1}}
 \newcommand\TypingRuleRef[1]{\nameref{sec:TypingRule.#1}}
 \newcommand\SemanticsRuleRef[1]{\nameref{sec:SemanticsRule.#1}}
@@ -1054,7 +1058,7 @@
 \newcommand\ProseOrAbnormal[0]{\ProseTerminateAs{\ThrowingConfig, \DynErrorConfig}}
 \newcommand\ProseOrError[0]{\ProseTerminateAs{\DynErrorConfig}}
 \newcommand\TNormal[0]{\hyperlink{def-tnormal}{\textsf{TNormal}}}
-\newcommand\TDynError[0]{\hyperlink{def-terror}{\textsf{TDynError}}}
+\newcommand\TDynError[0]{\hyperlink{def-tdynerror}{\textsf{TDynError}}}
 \newcommand\TThrowing[0]{\hyperlink{def-tthrowing}{\textsf{TThrowing}}}
 \newcommand\TContinuing[0]{\hyperlink{def-tcontinuing}{\textsf{TContinuing}}}
 \newcommand\TReturning[0]{\hyperlink{def-treturning}{\textsf{TReturning}}}
@@ -1633,10 +1637,10 @@
 \newcommand\otherwisecaseterm[0]{\hyperlink{def-otherwisecaseterm}{otherwise case}}
 
 %% Constraint macros
-\newcommand\constraintexactterm[0]{an exact constraint}
-\newcommand\Proseconstraintexact[1]{an exact constraint for the expression #1}
-\newcommand\constraintrangeterm[0]{a range constraint}
-\newcommand\Proseconstraintrange[2]{a range constraint for the lower end expression #1 and upper end expression #2}
+\newcommand\exactconstraintterm[0]{\hyperlink{def-exactconstraintterm}{exact constraint}}
+\newcommand\Proseexactconstraint[1]{\hyperlink{def-exactconstraintterm}{exact constraint} for the expression #1}
+\newcommand\rangeconstraintterm[0]{\hyperlink{def-rangeconstraintterm}{range constraint}}
+\newcommand\Proserangeconstraint[2]{\hyperlink{def-rangeconstraintterm}{range constraint} for the lower end expression #1 and upper end expression #2}
 
 %% Expression macros
 \newcommand\literalexpressionterm[0]{\hyperlink{def-literalexpressionterm}{literal expression}}
@@ -2600,6 +2604,7 @@
 \newcommand\vcondexpr[0]{\texttt{cond\_expr}}
 \newcommand\vcone[0]{\texttt{c1}}
 \newcommand\vconstraintasts[0]{\texttt{constraint\_asts}}
+\newcommand\vcsasts[0]{\texttt{cs\_asts}}
 \newcommand\vconstraints[0]{\texttt{constraints}}
 \newcommand\vconstraintkind[0]{\texttt{constraint\_kind}}
 \newcommand\vconstraintkindopt[0]{\texttt{constraint\_kind\_opt}}
@@ -3129,3 +3134,7 @@
 \newcommand\vfieldnames[0]{\texttt{field\_names}}
 \newcommand\vexpectedconstraintlength[0]{\texttt{expected\_constraint\_length}}
 \newcommand\vconsolestream[0]{\texttt{consolestream}}
+\newcommand\vlhstys[0]{\texttt{lhs\_tys}}
+\newcommand\vlhstysp[0]{\texttt{lhs\_tys'}}
+\newcommand\vrhstys[0]{\texttt{rhs\_tys}}
+\newcommand\vrhstysp[0]{\texttt{rhs\_tys'}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1745,6 +1745,7 @@
 \newcommand\returnstatementterm[0]{\hyperlink{def-returnstatementterm}{return statement}}
 \newcommand\returnstatement[1]{\hyperlink{def-returnstatementterm}{return statement} for the optional expression #1}
 \newcommand\printstatementterm[0]{\hyperlink{def-printstatementterm}{print statement}}
+\newcommand\printstatementsterm[0]{\hyperlink{def-printstatementterm}{print statements}}
 \newcommand\printstatement[2]{\hyperlink{def-printstatementterm}{print statement} with list of expressions #1 and newline flag #2}
 \newcommand\unreachablestatementterm[0]{\hyperlink{def-unreachablestatementterm}{unreachable statement}}
 \newcommand\pragmastatementterm[0]{\hyperlink{def-pragmastatementterm}{pragma statement}}
@@ -3139,3 +3140,4 @@
 \newcommand\vlhstysp[0]{\texttt{lhs\_tys'}}
 \newcommand\vrhstys[0]{\texttt{rhs\_tys}}
 \newcommand\vrhstysp[0]{\texttt{rhs\_tys'}}
+\newcommand\vargdecls[0]{\texttt{arg\_decls}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1054,7 +1054,7 @@
 \newcommand\DynErrorConfig[0]{\hyperlink{def-errorconfig}{\texttt{\#DE}}}
 \newcommand\OrAbnormal[0]{\;\terminateas \ThrowingConfig, \DynErrorConfig}
 \newcommand\OrDynError[0]{\;\terminateas \DynErrorConfig}
-\newcommand\ProseOtherwiseDynamicError[0]{Otherwise, the result is a dynamic error.}
+\newcommand\ProseOtherwiseDynamicError[0]{Otherwise, the result is a \dynamicerrorterm.}
 \newcommand\ProseOrAbnormal[0]{\ProseTerminateAs{\ThrowingConfig, \DynErrorConfig}}
 \newcommand\ProseOrError[0]{\ProseTerminateAs{\DynErrorConfig}}
 \newcommand\TNormal[0]{\hyperlink{def-tnormal}{\textsf{TNormal}}}
@@ -1160,9 +1160,8 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newcommand\typingrulecasename[2]{TypingRule.{#1}.\textsc{#2}}
 
-\newcommand\ProseOtherwiseTypeError[0]{Otherwise, the result is a type error.}
+\newcommand\ProseOtherwiseTypeError[0]{Otherwise, the result is a \typingerrorterm.}
 \newcommand\OrTypeError[0]{\;\terminateas \TypeErrorConfig}
-%\newcommand\ProseOrTypeError[0]{or a type error that short-circuits the entire rule}
 \newcommand\ProseOrTypeError[0]{\ProseTerminateAs{\TypeErrorConfig}}
 
 \newcommand\annotaterel[0]{\hyperlink{def-annotaterel}{\textsf{type}}}
@@ -1961,7 +1960,7 @@
 \newcommand\BinopPrecedence[0]{\hyperlink{def-binopprecedence}{\BuildErrorCode{BOP}}}
 \newcommand\BuildBadDeclaration[0]{\hyperlink{def-buildbaddeclaration}{\BuildErrorCode{BD}}}
 
-%% Type Error Codes
+%% Typing Error Codes
 \newcommand\TypeErrorPrefix[0]{\texttt{TE}}
 \newcommand\TypeErrorCode[1]{\texttt{\TypeErrorPrefix\_#1}}
 \newcommand\UndefinedIdentifier[0]{\hyperlink{def-undefinedidentifier}{\TypeErrorCode{UI}}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1237,7 +1237,7 @@
 \newcommand\sliceswidth[0]{\hyperlink{def-sliceswidth}{\textfunc{slices\_width}}}
 \newcommand\slicewidth[0]{\hyperlink{def-slicewidth}{\textfunc{slice\_width}}}
 \newcommand\checkstructurelabel[0]{\hyperlink{def-checkstructurelabel}{\textfunc{check\_structure}}}
-\newcommand\checkstructureinteger[0]{\hyperlink{def-checkstructureinteger}{\textfunc{check\_structure\_integer}}}
+\newcommand\checkunderlyinginteger[0]{\hyperlink{def-checkunderlyinginteger}{\textfunc{check\_underlying\_integer}}}
 \newcommand\issymbolicallyevaluable[0]{\hyperlink{def-issymbolicallyevaluable}{\textfunc{is\_symbolically\_evaluable}}}
 \newcommand\checksymbolicallyevaluable[0]{\hyperlink{def-checksymbolicallyevaluable}{\textfunc{check\_symbolically\_evaluable}}}
 \newcommand\Prosechecksymbolicallyevaluable[1]{\hyperlink{def-checksymbolicallyevaluable}{checking} that #1 is \symbolicallyevaluable\ yields $\True$\ProseOrTypeError}
@@ -1476,8 +1476,8 @@
 \newcommand\AbbrevConstraintRange[2]{\overbracket{#1..#2}^{\hyperlink{def-abbrevconstraintrange}{\abbrevfont{Constraint\_Range}}}}
 \newcommand\AbbrevEBinop[3]{\overbracket{#2\ #1\ #3}^{\hyperlink{def-abbrevebinop}{\abbrevfont{E\_Binop}}}}
 \newcommand\AbbrevTArray[2]{\overbracket{\texttt{array }[#1]\texttt{ of }#2}^{\hyperlink{def-abbrevtarray}{\abbrevfont{T\_Array}}}}
-\newcommand\AbbrevTArrayLengthExpr[2]{\overbracket{\texttt{array }[#1]\texttt{ of }#2}^{\hyperlink{def-abbrevtarraylengthexpr}{\abbrevfont{T\_Array(ArrayLength\_Expr)}}}}
-\newcommand\AbbrevTArrayLengthEnum[3]{\overbracket{\texttt{array }[#1 \# #2]\texttt{ of }#3}^{\hyperlink{def-abbrevtarraylengthenum}{\abbrevfont{T\_Array(Array\_Length\_Enum)}}}}
+\newcommand\AbbrevTArrayLengthExpr[2]{\overbracket{\texttt{array [[}#1\texttt{]] of }#2}^{\hyperlink{def-abbrevtarraylengthexpr}{\abbrevfont{T\_Array(ArrayLength\_Expr)}}}}
+\newcommand\AbbrevTArrayLengthEnum[3]{\overbracket{\texttt{array [[}#1 \# #2\texttt{]] of }#3}^{\hyperlink{def-abbrevtarraylengthenum}{\abbrevfont{T\_Array(Array\_Length\_Enum)}}}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Top level macros
@@ -1569,17 +1569,34 @@
 \newcommand\subtypesterm[0]{\hyperlink{def-subtypes}{subtypes}}
 \newcommand\subtypeterm[0]{\hyperlink{def-subtypes}{subtype}}
 \newcommand\supertypeterm[0]{\hyperlink{def-supertypeterm}{supertype}}
+\newcommand\normalizedterm[0]{\hyperlink{def-normalizedterm}{normalized}}
+\newcommand\normalizedexpressionterm[0]{\hyperlink{def-normalizedterm}{normalized expression}}
 
 %% Type macros
 \newcommand\integertypeterm[0]{\hyperlink{integertypeterm}{integer type}}
+\newcommand\integertypesterm[0]{\hyperlink{integertypeterm}{integer types}}
 \newcommand\bitvectortypeterm[0]{\hyperlink{bitvectortypeterm}{bitvector type}}
 \newcommand\bitvectortypesterm[0]{\hyperlink{bitvectortypeterm}{bitvector types}}
+\newcommand\bitfieldterm[0]{\hyperlink{bitfieldterm}{bitfield}}
+\newcommand\bitfieldsterm[0]{\hyperlink{bitfieldterm}{bitfields}}
+\newcommand\bitsliceterm[0]{\hyperlink{bitsliceterm}{bitslice}}
+\newcommand\bitslicesterm[0]{\hyperlink{bitsliceterm}{bitslices}}
 \newcommand\realtypeterm[0]{\hyperlink{realtypeterm}{real type}}
 \newcommand\stringtypeterm[0]{\hyperlink{stringtypeterm}{string type}}
 \newcommand\booleantypeterm[0]{\hyperlink{booleantypeterm}{boolean type}}
 \newcommand\enumerationtypeterm[0]{\hyperlink{enumerationtypeterm}{enumeration type}}
+\newcommand\enumerationtypesterm[0]{\hyperlink{enumerationtypeterm}{enumeration types}}
+\newcommand\Enumerationtypesterm[0]{\hyperlink{enumerationtypeterm}{Enumeration types}}
 \newcommand\tupletypeterm[0]{\hyperlink{tupletypeterm}{tuple type}}
+\newcommand\tupletypesterm[0]{\hyperlink{tupletypeterm}{tuple types}}
+\newcommand\Tupletypesterm[0]{\hyperlink{tupletypeterm}{Tuple types}}
+\newcommand\Prosetupletype[1]{\tupletypeterm{} with member types #1}
 \newcommand\arraytypeterm[0]{\hyperlink{arraytypeterm}{array type}}
+\newcommand\arraytypesterm[0]{\hyperlink{arraytypeterm}{array types}}
+\newcommand\intarraytypeterm[0]{\hyperlink{intarraytypeterm}{integer-indexed array type}}
+\newcommand\Intarraytypeterm[0]{\hyperlink{intarraytypeterm}{Integer-indexed array type}}
+\newcommand\enumarraytypeterm[0]{\hyperlink{enumarraytypeterm}{enumeration-indexed array type}}
+\newcommand\Enumarraytypeterm[0]{\hyperlink{enumarraytypeterm}{Enumeration-indexed array type}}
 \newcommand\namedtypeterm[0]{\hyperlink{namedtypeterm}{named type}}
 \newcommand\recordtypeterm[0]{\hyperlink{recordtypeterm}{record type}}
 \newcommand\exceptiontypeterm[0]{\hyperlink{exceptiontypeterm}{exception type}}
@@ -1604,7 +1621,7 @@
 \newcommand\bitwidthequivalent[0]{\hyperlink{def-bitwidthequal}{bitwidth-equivalent}}
 \newcommand\typeclash[0]{\hyperlink{def-typeclashes}{type-clash}}
 \newcommand\constrainedinteger[0]{\hyperlink{def-checkconstrainedinteger}{constrained integer}}
-\newcommand\structureofinteger[0]{\hyperlink{def-checkstructureinteger}{structure of an integer}}
+\newcommand\structureofinteger[0]{\hyperlink{def-checkunderlyinginteger}{structure of an integer}}
 \newcommand\wellconstrainedstructure[0]{\hyperlink{def-getwellconstrainedstructure}{well-constrained structure}}
 \newcommand\wellconstrainedversion[0]{\hyperlink{def-towellconstrained}{well-constrained version}}
 \newcommand\namedlowestcommonancestor[0]{\hyperlink{def-namedlowestcommonancestor}{named lowest common ancestor}}
@@ -1775,6 +1792,7 @@
 \newcommand\PerformsAssertionsTerm[0]{\hyperlink{def-performsassertionsterm}{assertion side effect descriptor}}
 \newcommand\NonDeterministicTerm[0]{\hyperlink{def-nondeterministicterm}{non-determinism side effect descriptor}}
 
+\newcommand\staticallyevaluable[0]{\hyperlink{def-staticallyevaluable}{statically evaluable}}
 \newcommand\symbolicallyevaluable[0]{\hyperlink{def-symbolicallyevaluable}{symbolically evaluable}}
 \newcommand\timeframeterm[0]{\hyperlink{def-timeframe}{time frame}}
 \newcommand\timeframesterm[0]{\hyperlink{def-timeframe}{time frames}}
@@ -2017,7 +2035,8 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % LRM Ident info
-\newcommand\ident[2]{\texttt{#1}\textsubscript{\texttt{\MakeUppercase{#2}}}}
+\newcommand\ident[2]{}
+%\newcommand\ident[2]{\texttt{#1}\textsubscript{\texttt{\MakeUppercase{#2}}}}
 \newcommand\identi[1]{\ident{I}{#1}}
 \newcommand\identr[1]{\ident{R}{#1}}
 \newcommand\identd[1]{\ident{D}{#1}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -284,6 +284,7 @@
 \newcommand\restrictfunc[2]{{#1}\hyperlink{def-restrictfunc}{|}_{#2}}
 
 \newcommand\emptylist[0]{\hyperlink{def-emptylist}{[\ ]}}
+\newcommand\Proseemptylist[1]{#1 is the empty list}
 \newcommand\choice[3]{\hyperlink{def-choice}{\textsf{choice}}(#1,#2,#3)}
 \newcommand\equallength[0]{\hyperlink{def-equallength}{\textfunc{equal\_length}}}
 \newcommand\listrange[0]{\hyperlink{def-listrange}{\textfunc{indices}}}
@@ -895,7 +896,7 @@
 \newcommand\LexSpec[0]{\hyperlink{def-lexspec}{\textsf{LexSpec}}}
 \newcommand\Lang[0]{\hyperlink{def-lang}{\textsf{Lang}}}
 \newcommand\RegExp[0]{\hyperlink{def-regex}{\textsf{RegExp}}}
-\newcommand\ascii[1]{\textsf{ASCII}\texttt{\{#1\}}}
+\newcommand\ascii[1]{\hyperlink{def-ascii}{\textsf{ASCII}}\texttt{\{#1\}}}
 \newcommand\scantoken[0]{\textfunc{scan\_token}}
 \newcommand\scancomment[0]{\textfunc{scan\_comment}}
 
@@ -976,6 +977,8 @@
 \newcommand\emptytenv[0]{\hyperlink{def-emptytenv}{\emptyset_{\mathbb{SE}}}}
 \newcommand\tstruct[0]{\hyperlink{def-tstruct}{\textfunc{get\_structure}}}
 \newcommand\astlabel[0]{\hyperlink{def-astlabel}{\textfunc{ast\_label}}}
+\newcommand\ProsetypesatTrue[3]{#2 \typesatisfies{} #3 in the static environment #1}
+\newcommand\ProsetypesatFalse[3]{#2 does not \typesatisfy{} #3 in the static environment #1}
 \newcommand\typesat[0]{\hyperlink{def-typesatisfies}{\textfunc{type\_satisfies}}}
 
 \newcommand\constantvalues[0]{\hyperlink{def-constantvalues}{\textsf{constant\_values}}}
@@ -1027,6 +1030,7 @@
 \newcommand\stacksize[0]{\hyperlink{def-stacksize}{\textsf{stack\_size}}}
 \newcommand\xgraph[0]{\textsf{g}}
 \newcommand\emptygraph[0]{{\hyperlink{def-emptygraph}{\emptyset_\xgraph}}}
+\newcommand\Proseemptygraph[1]{#1 is the empty \executiongraph{}}
 \newcommand\asldata[0]{\hyperlink{def-asldata}{\mathtt{asl\_data}}}
 \newcommand\aslctrl[0]{\hyperlink{def-aslctrl}{\mathtt{asl\_ctrl}}}
 \newcommand\aslpo[0]{\hyperlink{def-aslpo}{\mathtt{asl\_po}}}
@@ -1067,7 +1071,8 @@
 \newcommand\TOutConfig[0]{\hyperlink{def-toutconfig}{\textsf{TOutConfig}}}
 
 \newcommand\evalexpr[1]{\hyperlink{def-evalexpr}{\textfunc{eval\_expr}}(#1)}
-\newcommand\Proseevalexpr[3]{\hyperlink{def-evalexpr}{evaluating} the expression #2 in the environment #1 yields #3}
+\newcommand\Proseevalexpr[3]{
+    \hyperlink{def-evalexpr}{evaluating} the expression #2 in the environment #1 yields #3}
 \newcommand\evalexprsef[1]{\hyperlink{def-evalexprsef}{\textfunc{eval\_expr\_sef}}(#1)}
 \newcommand\evallexpr[1]{\hyperlink{def-evallexpr}{\textfunc{eval\_lexpr}}(#1)}
 \newcommand\Proseevallexpr[4]{\hyperlink{def-evalexpr}{evaluating} the left-hand-side expression #2 in the environment #1 and #3, yields #4}
@@ -1521,6 +1526,7 @@
 \newcommand\renamelocalsconstraint[0]{\hyperlink{def-renamelocalsconstraint}{\textfunc{rename\_locals\_constraint}}}
 \newcommand\Proserenamelocalsconstraint[2]{\hyperlink{def-renamelocalsconstraint}{renaming}
   the local storage elements in the constraint #1 yields the constraint #2}
+\newcommand\stdliblocalprefix[0]{\texttt{\_\_stdlib\_local\_}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Glossary
@@ -1543,6 +1549,7 @@
 
 \newcommand\head[0]{\hyperlink{def-head}{\texttt{head}}}
 \newcommand\tail[0]{\hyperlink{def-tail}{\texttt{tail}}}
+\newcommand\Proselist[2]{list with \head{} #1 and \tail{} #2}
 \newcommand\optional[0]{\hyperlink{def-optional}{optional}}
 
 \newcommand\inferencerule[0]{\hyperlink{def-inferencerule}{inference rule}}
@@ -2439,6 +2446,7 @@
 \newcommand\slicestwo[0]{\texttt{slices2}}
 \newcommand\slicetwo[0]{\texttt{slice2}}
 \newcommand\sm[0]{\texttt{s\_m}}
+\newcommand\smnew[0]{\texttt{s\_m\_new}}
 \newcommand\src[0]{\texttt{src}}
 \newcommand\start[0]{\texttt{start}}
 \newcommand\stm[0]{\texttt{stm}}
@@ -3141,3 +3149,9 @@
 \newcommand\vrhstys[0]{\texttt{rhs\_tys}}
 \newcommand\vrhstysp[0]{\texttt{rhs\_tys'}}
 \newcommand\vargdecls[0]{\texttt{arg\_decls}}
+\newcommand\vmain[0]{\texttt{main}}
+\newcommand\vread[0]{\texttt{read}}
+\newcommand\vmodify[0]{\texttt{modify}}
+\newcommand\vsetter[0]{\texttt{setter}}
+\newcommand\vgetter[0]{\texttt{sgtter}}
+\newcommand\vcode[0]{\texttt{code}}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -170,7 +170,7 @@ and pattern matching expressions.
 \hypertarget{ast-expr}{} \hypertarget{ast-eliteral}{}
 \begin{flalign*}
 \expr \derives\ & \ELiteral(\literal)
-& \hypertarget{ast-evar}{} \hypertarget{ast-identifier}{}\\
+& \hypertarget{ast-evar}{}\\
 	|\ & \EVar(\overtext{\identifier}{variable name})
   &\hypertarget{ast-eatc}{}\\
 	|\ & \overtext{\EATC}{Type assertion}(\expr, \overtext{\ty}{asserted type})
@@ -367,7 +367,7 @@ The type of array indices is given by the following AST type:
 The following rule corresponds to a field of a record-like structure:
 \hypertarget{ast-field}{}
 \begin{flalign*}
-\Field \derives\ & (\identifier, \ty) & \hypertarget{ast-typedidentifier}{}
+\Field \derives\ & (\identifier, \ty) &
 \end{flalign*}
 
 The following rule corresponds to an identifier with its associated type:

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -385,8 +385,8 @@ The following rules define the types of left-hand side of assignments:
   |\ & \LEVar(\identifier) & \hypertarget{ast-leslice}{}\\
   |\ & \LESlice(\lexpr, \slice^*) & \hypertarget{ast-lesetarray}{}\\
   |\ & \LESetArray(\lexpr, \expr) & \hypertarget{ast-lesetfield}{}\\
-  |\ & \LESetField(\lexpr, \identifier) & \hypertarget{ast-lesetfields}{}\\
-  |\ & \LESetFields(\lexpr, \identifier^*) & \hypertarget{ast-ledestructuring}{}\\
+  |\ & \LESetField(\lexpr \identifier) & \hypertarget{ast-lesetfields}{}\\
+  |\ & \LESetFields(\lexpr \identifier^*) & \hypertarget{ast-ledestructuring}{}\\
   |\ & \LEDestructuring(\lexpr^*) & \\
 \end{flalign*}
 

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -385,8 +385,8 @@ The following rules define the types of left-hand side of assignments:
   |\ & \LEVar(\identifier) & \hypertarget{ast-leslice}{}\\
   |\ & \LESlice(\lexpr, \slice^*) & \hypertarget{ast-lesetarray}{}\\
   |\ & \LESetArray(\lexpr, \expr) & \hypertarget{ast-lesetfield}{}\\
-  |\ & \LESetField(\lexpr \identifier) & \hypertarget{ast-lesetfields}{}\\
-  |\ & \LESetFields(\lexpr \identifier^*) & \hypertarget{ast-ledestructuring}{}\\
+  |\ & \LESetField(\lexpr, \identifier) & \hypertarget{ast-lesetfields}{}\\
+  |\ & \LESetFields(\lexpr, \identifier^*) & \hypertarget{ast-ledestructuring}{}\\
   |\ & \LEDestructuring(\lexpr^*) & \\
 \end{flalign*}
 

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -589,10 +589,8 @@ In \listingref{semantics-lediscard}, the assignment \texttt{- = 42;} does not af
   \annotatelexpr{\tenv, \overname{\LEVar(\vx)}{\vle}, \vte} \typearrow \TypeErrorVal{\UndefinedIdentifier}
 }
 \end{mathpar}
-\lrmcomment{
-  This is related to \identr{WDGQ}, \identr{GNTS}, \identi{MMKF},
-  \identi{DGWJ}, \identi{KKCC} and \identr{LXQZ}.
-}
+\identr{WDGQ} \identr{GNTS} \identi{MMKF}
+\identi{DGWJ} \identi{KKCC}  \identr{LXQZ}
 \CodeSubsection{\LEVarBegin}{\LEVarEnd}{../Typing.ml}
 
 \subsection{Semantics}
@@ -959,7 +957,7 @@ of \\
 \CodeSubsection{\EvalLESetArrayBegin}{\EvalLESetArrayEnd}{../Interpreter.ml}
 
 \subsubsection{Comments}
-\lrmcomment{This is related to \identr{WHRS}:}
+\identr{WHRS}
 If the declared type of the \rhsexpression\ of a setter has the structure of a
 bitvector or a type with fields, then if a bitslice or field selection is
 applied to a setter invocation, then the assignment to that bitslice is
@@ -1135,7 +1133,7 @@ in the environment where \texttt{x} is bound to $\nvbitvector(11111111)$.
 \end{mathpar}
 \CodeSubsection{\EvalLESliceBegin}{\EvalLESliceEnd}{../Interpreter.ml}
 \subsubsection{Comments}
-\lrmcomment{This is related to \identr{WHRS}:}
+\identr{WHRS}
 
 If the declared type of the \rhsexpression\ of a setter has the structure of a
 bitvector or a type with fields, then if a bitslice or field selection is
@@ -1232,7 +1230,7 @@ ranges $(\vsone, \vlone)$ and $(\vstwo, \vltwo)$ do not intersect, yielding $\Tr
 \section{Structured Type Field Assignment Expressions\label{sec:StructuredTypeFieldAssignmentExpressions}}
 \subsection{Abstract Syntax}
 \begin{flalign*}
-\lexpr \derives\ & \LESetField(\lexpr, \identifier) &
+\lexpr \derives\ & \LESetField(\lexpr \identifier) &
 \end{flalign*}
 
 \subsection{Typing}
@@ -1296,7 +1294,7 @@ ranges $(\vsone, \vlone)$ and $(\vstwo, \vltwo)$ do not intersect, yielding $\Tr
 \section{Structured Type Multi-field Assignment Expressions\label{sec:StructuredTypeMultiFieldAssignmentExpressions}}
 \subsection{Abstract Syntax}
 \begin{flalign*}
-\lexpr \derives\ & \LESetFields(\lexpr, \identifier^*) &
+\lexpr \derives\ & \LESetFields(\lexpr \identifier^*) &
 \end{flalign*}
 
 \subsection{Typing}
@@ -1719,7 +1717,7 @@ in the environment where \texttt{my\_record} is bound to \texttt{\{a: 3, b: 100\
 We note that the typechecker guarantees that $\fieldname$ exists in the record given by $\record$
 via \TypingRuleRef{LESetStructuredField}.
 
-\lrmcomment{This is related to \identr{WHRS}:}
+\identr{WHRS}
 If the declared type of the \rhsexpression\ of a setter has the structure of a
 bitvector or a type with fields, then if a bitslice or field selection is
 applied to a setter invocation, then the assignment to that bitslice is

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -895,7 +895,8 @@ All of the following apply:
 \SemanticsRuleDef{LESetArray}
 \subsubsection{Example}
 In \listingref{semantics-lesetarray}, the assignment \verb|my_array[[3]] = 53;| binds the third element
-of \texttt{my\_array} to the value \texttt{53}.
+of \\
+\texttt{my\_array} to the value \texttt{53}.
 \ASLListing{Assignment to an array cell}{semantics-lesetarray}{\semanticstests/SemanticsRule.LESetArray.asl}
 
 \ProseParagraph

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -482,7 +482,7 @@ via the following rules:
 \subsection{Typing}
 \TypingRuleDef{LEDiscard}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes an expression that can be discarded, that is, $\LEDiscard$;
   \item \Proseeqdef{$\newle$}{$\vle$};
@@ -503,7 +503,7 @@ In \listingref{semantics-lediscard}, the assignment \texttt{- = 42;} does not af
 \ASLListing{Assignment to \texttt{-}}{semantics-lediscard}{\semanticstests/SemanticsRule.LEDiscard.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ is a discarding expression, $\LEDiscard$;
   \item $\newg$ is $\vg$;
@@ -530,7 +530,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{LEVar}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes a left-hand-side variable expression for $\vx$, that is, $\LEVar(\vx)$;
   \item One of the following applies (\textsc{local}):
@@ -610,19 +610,19 @@ In \listingref{semantics-leglobalvar},
 \ASLListing{Assignment to a global variable}{semantics-leglobalvar}{\semanticstests/SemanticsRule.LEGlobalVar.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
     \item $\vle$ denotes a variable, $\LEVar(\vx)$;
     \item view $\env$ as an environment where $\tenv$ is the static environment and $\denv$ is the dynamic environment;
     \item One of the following applies:
     \begin{itemize}
-        \item All of the following apply (\textsc{local}):
+        \item \AllApplyCase{local}:
         \begin{itemize}
             \item $\vx$ is in the local dynamic environment ($L^\denv$);
             \item $\newenv$ is $\env$ where $\vx$ is bound to $\vv$ in the local dynamic environment ($L^\denv$).
         \end{itemize}
 
-        \item All of the following apply (\textsc{global}):
+        \item \AllApplyCase{global}:
         \begin{itemize}
             \item $\vx$ is bound in the global dynamic environment ($G^\denv.\storage$);
             \item $\newenv$ is $\env$ where $\vx$ is bound to $\vv$ in the $\storage$ map of the global dynamic environment $G^\denv$.
@@ -665,7 +665,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{LEDestructuring}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes a tuple of left-hand-side expressions $\les$, that is, $\LEDestructuring(\les)$;
   \item $\les$ is a list $\ve_{1..k}$;
@@ -707,7 +707,7 @@ $\nvint(42)$ in the environment where \texttt{x} is bound to $\nvint(42)$ and
 \ASLListing{Assignment to multiple left-hand-side expressions}{semantics-ledestructuring}{\semanticstests/SemanticsRule.LEDestructuring.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes a list of left-hand-side expressions, $\LEDestructuring(\vlelist)$;
   \item $\vlelist$ is the list of expressions $\vle_{1..n}$;
@@ -788,7 +788,7 @@ The semantics utilizes a rule matching the corresponding type of array ---
 \subsection{Typing}
 \TypingRuleDef{LESetArray}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes the array access of a left-hand-side expression $\ebase$ by the index $\eindex$, that is, $\LESetArray(\ebase, \eindex)$;
   \item annotating the right-hand-side expression corresponding to $\ebase$ in $\tenv$ yields \\ $(\tbase, \Ignore, \Ignore)$\ProseOrTypeError;
@@ -847,7 +847,7 @@ The result is the annotated assignable expression $\newle$ and
 \ProseOrTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item determining that $\telem$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
   \item annotating the index expression $\eindex$ in $\tenv$ yields \\
@@ -900,7 +900,7 @@ of \\
 \ASLListing{Assignment to an array cell}{semantics-lesetarray}{\semanticstests/SemanticsRule.LESetArray.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes an array update expression, $\LESetArray(\rearray, \eindex)$;
   \item evaluating the right-hand-side expression corresponding to $\rearray$ in $\env$
@@ -952,7 +952,7 @@ via \TypingRuleRef{LESetArray}.
 
 \SemanticsRuleDef{LESetEnumArray}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes an array update expression, $\LESetEnumArray(\rearray, \eindex)$;
   \item evaluating the right-hand-side expression corresponding to $\rearray$ in $\env$
@@ -996,7 +996,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{LESlice}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes the slicing of a left-hand-side expression $\vleone$ by the slices $\slices$, that is, $\LESlice(\vleone, \slices)$;
   \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\
@@ -1046,7 +1046,7 @@ tests whether the list of slices $\slices$ do not overlap in $\tenv$, yielding $
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\disjointslicestopositions$ to $\slices$ in $\tenv$ yields a set of positions\ProseOrTypeError.
   \item the result is $\True$.
@@ -1072,7 +1072,7 @@ in the environment where \texttt{x} is bound to $\nvbitvector(11111111)$.
 \ASLListing{Assignment to a slice}{semantics-leslice}{\semanticstests/SemanticsRule.LESlice.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes a left-hand-side slicing expression, $\LESlice(\ebv, \slices)$;
   \item evaluating the right-hand-side expression that corresponds to $\ebv$
@@ -1137,7 +1137,7 @@ overlap, yielding $\True$.
 \ProseOrError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item view $\valueranges$ as the list $\vrange_{1..k}$;
   \item for every pair of indices $\vi$ and $\vj$ such that $1 \leq \vi < \vj \leq k$,
@@ -1178,7 +1178,7 @@ ranges $(\vsone, \vlone)$ and $(\vstwo, \vltwo)$ do not intersect, yielding $\Tr
 \ProseOrError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item evaluating $\PLUS$ for $\vsone$ and $\vlone$ via $\binoprel$ yields $\vsonelone$;
   \item evaluating $\LEQ$ for $\vsonelone$ and $\vstwo$ yields $\vsonelonestwo$;
@@ -1213,7 +1213,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{LESetBadField}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
   \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore, \Ignore)$\ProseOrTypeError;
@@ -1237,7 +1237,7 @@ All of the following apply:
 
 \TypingRuleDef{LESetStructuredField}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes the access to the field named \texttt{field} in $\vleone$;
   \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore, \Ignore)$\ProseOrTypeError;
@@ -1277,7 +1277,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{LESetFields}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ is an assignable expression for assigning the list of fields $\vlefields$ of the base
         expression $\lebase$;
@@ -1286,7 +1286,7 @@ All of the following apply:
   \item \Prosemakeanonymous{$\tenv$}{$\tbase$}{\\ $\tbaseanon$}\ProseOrTypeError;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{bits}):
+    \item \AllApplyCase{bits}:
     \begin{itemize}
       \item $\tanonbase$ is a bitvector type with list of bitfields $\vbitfields$;
       \item applying $\findbitfieldsslices$ to $\name$ and $\vbitfields$, for every $\name$ in $\vlefields$, yields $\vslices_\name$\ProseOrTypeError;
@@ -1295,7 +1295,7 @@ All of the following apply:
       \item \Proseannotatelexpr{$\tenv$}{$\vleslice$}{$\vte$}{$(\newle, \vses)$}\ProseOrTypeError.
     \end{itemize}
 
-    \item All of the following apply (\textsc{record}):
+    \item \AllApplyCase{record}:
     \begin{itemize}
       \item $\tanonbase$ is a record type with list of fields $\vbasefields$;
       \item applying $\foldbitvectorfields$ to $\vlefields$ and $\vbasefields$ in $\tenv$ yields $(\vlength, \vslices)$ \ProseOrTypeError;
@@ -1306,7 +1306,7 @@ All of the following apply:
       \item \Proseeqdef{$\vses$}{$\vsesbase$}.
     \end{itemize}
 
-    \item All of the following apply (\textsc{error}):
+    \item \AllApplyCase{error}:
     \begin{itemize}
       \item $\tanonbase$ is neither a bitvector type nor a record type;
       \item the result is a type error indicating that the type of the left-hand-side expression is expected to be
@@ -1375,14 +1375,14 @@ The helper function
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\vlefields$ is empty;
     \item \Proseeqdef{$\vlength$}{$0$};
     \item \Proseeqdef{$\vslices$}{the empty list}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\vlefields$ is the list with prefix $\vlefieldsone$ (the elements excluding the last one) and last element $\vfield$;
     \item applying $\foldbitvectorfields$ to $\vbasefields$ and $\vlefieldsone$ in $\tenv$ yields $(\vstart, \vslicesone)$\ProseOrTypeError;
@@ -1422,7 +1422,7 @@ One of the following applies:
 \subsection{Semantics}
 \SemanticsRuleDef{LESetFields}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ is an expression for assigning each of the fields in $\fields$ of the record expression $\vlerecord$
         with the corresponding slices given in $\vslices$ from the bitvector value $\vv$
@@ -1466,13 +1466,13 @@ slices given by $\vslices$ of the \concurrentnativevalue\ $\vm$, yielding the
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\fields$ and $\vslices$ are both empty lists;
     \item \Proseeqdef{$\vmtwo$}{$\vmone$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\fields$ is a list with \head\ $\fieldname$ and \tail\ $\fieldsone$;
     \item $\vslices$ is a list with \head\ $(\vione, \vitwo)$ and \tail\ $\vslicesone$;
@@ -1527,7 +1527,7 @@ One of the following applies:
 \subsection{Typing}
 \TypingRuleDef{LESetBitField}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes the access to the field named $\field$ in $\vleone$, that is, \\ $\LESetField(\vleone, \field)$;
   \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore, \Ignore)$\ProseOrTypeError;
@@ -1535,14 +1535,14 @@ All of the following apply:
   \item obtaining the \underlyingtype\ of $\vtleone$ in $\tenv$ yields a bitvector type with bitfields $\bitfields$\ProseOrTypeError;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following applies (\textsc{error\_missing\_field}):
+    \item \AllApplyCase{error\_missing\_field}:
     \begin{itemize}
       \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields $\None$, meaning the field is not declared
             in $\vtleone$;
       \item the result is a type error $\BadField$.
     \end{itemize}
 
-    \item All of the following applies (\textsc{field\_simple}):
+    \item \AllApplyCase{field\_simple}:
     \begin{itemize}
       \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields a bitfield with corresponding slices $\slices$,
             that is, $\BitFieldSimple(\Ignore, \slices)$;
@@ -1553,7 +1553,7 @@ All of the following apply:
       \item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields \\ $(\newle, \vses)$\ProseOrTypeError.
     \end{itemize}
 
-    \item All of the following applies (\textsc{field\_nested}):
+    \item \AllApplyCase{field\_nested}:
     \begin{itemize}
       \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields a nested bitfield with corresponding
             slices $\slices$ and list of bitfields $\bitfieldsp$, that is, \\ $\BitFieldNested(\Ignore, \slices, \bitfieldsp)$;
@@ -1564,7 +1564,7 @@ All of the following apply:
       \item annotating the left-hand-side expression $\vlethree$ in $\tenv$ yields \\ $(\newle, \vses)$\ProseOrTypeError.
     \end{itemize}
 
-    \item All of the following applies (\textsc{field\_typed}):
+    \item \AllApplyCase{field\_typed}:
     \begin{itemize}
       \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields a typed bitfield with corresponding
             slices $\slices$ and a type $\vt$, that is, \\ $\BitFieldType(\Ignore, \vslices, \vt)$;
@@ -1659,7 +1659,7 @@ in the environment where \texttt{my\_record} is bound to \texttt{\{a: 3, b: 100\
 \ASLListing{Assignment to a field}{semantics-lesetfield}{\semanticstests/SemanticsRule.LESetField.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vle$ denotes a field update expression, $\LESetField(\rerecord, \fieldname)$;
   \item evaluating the right-hand-side expression corresponding to $\rerecord$

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -733,7 +733,6 @@ $\nvint(42)$ in the environment where \texttt{x} is bound to $\nvint(42)$ and
 \CodeSubsection{\EvalLEDestructuringBegin}{\EvalLEDestructuringEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{LEMultiAssign}
-\ProseParagraph
 The helper relation
 \hypertarget{def-evalmultiassign}{}
 \[
@@ -746,18 +745,43 @@ That is, the simultaneous assignment of the list of value-execution graph pairs 
 to the corresponding list of left-hand side expressions $\vlelist$, in the environment $\env$.
 The result is either the execution graph $\vg$ and new environment $\newenv$ or an abnormal configuration.
 
+\ProseParagraph
+\begin{itemize}
+  \item \AllApplyCase{empty}
+  \begin{itemize}
+    \item both $\vlelist$ and $\vmlist$ are empty lists;
+    \item \Proseeqdef{$\newg$}{the empth \executiongraph};
+    \item \Proseeqdef{$\newenv$}{$\env$}.
+  \end{itemize}
+
+  \item \AllApplyCase{non\_empty}
+  \begin{itemize}
+    \item $\vle$ is a \Proselist{$\vle$}{$\vlelistone$};
+    \item $\vmlist$ is a \Proselist{$\vm$}{$\vmlistone$};
+    \item \Proseevallexpr{$\env$}{$\vle$}{$\vm$}{$\Normal(\envone, \vgone)$}\ProseOrAbnormal;
+    \item applying $\evalmultiassignment$ to $\envone$, $\vlelistone$, and $\vmlistone$
+          yields \\
+          $\Normal(\newenv, \vgtwo)$\ProseOrAbnormal;
+    \item \Proseeqdef{$\newg$}{the ordered composition of $\vgone$ and $\vgtwo$
+          with the edge $\aslpo$}.
+  \end{itemize}
+\end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[empty]{}
 {
-  \evalmultiassignment(\env, \emptylist, \emptylist) \evalarrow \Normal(\emptygraph, \env)
+  \evalmultiassignment(\env, \overname{\emptylist}{\vlelist}, \overname{\emptylist}{\vmlist}) \evalarrow
+  \Normal(\overname{\emptygraph}{\newg}, \overname{\env}{\newenv})
 }
-\and
-\inferrule[nonempty]{
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_empty]{
   \vlelist \eqname [\vle] \concat \vlelistone\\
   \vmlist \eqname [\vm] \concat \vmlistone\\
-  \evallexpr{\env, \vle, \vm} \evalarrow \Normal(\envone, \vgone) \OrAbnormal\\
-  \evalmultiassignment(\envone, \vlelistone, \vmlistone) \evalarrow \Normal(\newenv, \vgtwo) \OrAbnormal\\
+  \evallexpr{\env, \vle, \vm} \evalarrow \Normal(\envone, \vgone) \OrAbnormal\\\\
+  \evalmultiassignment(\envone, \vlelistone, \vmlistone) \evalarrow \Normal(\newenv, \vgtwo) \OrAbnormal\\\\
   \newg \eqdef \ordered{\vgone}{\aslpo}{\vgtwo}
 }{
   \evalmultiassignment(\env, \vlelist, \vmlist) \evalarrow \Normal(\newg, \newenv)

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -670,8 +670,8 @@ In \listingref{semantics-leglobalvar},
 \begin{itemize}
   \item $\vle$ denotes a tuple of left-hand-side expressions $\les$, that is, $\LEDestructuring(\les)$;
   \item $\les$ is a list $\ve_{1..k}$;
-  \item checking whether $\vte$ is a tuple type yields $\True$\ProseTerminateAs{\UnexpectedType};
-  \item $\vte$ is a tuple type over the list of types $\tys$, that is, $\TTuple(\tys)$;
+  \item checking whether $\vte$ is a \tupletypeterm{} yields $\True$\ProseTerminateAs{\UnexpectedType};
+  \item $\vte$ is a \tupletypeterm{} over the list of types $\tys$, that is, $\TTuple(\tys)$;
   \item determining whether $\les$ and $\subtys$ have the same length yields $\True$\ProseTerminateAs{\UnexpectedType};
   \item $\subtys$ is the list of types $\vt_{1..k}$;
   \item annotating the left-hand-side expression $\ve_i$ with the type $\vt_i$, for $i=1..k$, yields $(\vep_i, \vxs_i)$\ProseOrTypeError;

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -530,10 +530,10 @@ In \listingref{semantics-lediscard}, the assignment \texttt{- = 42;} does not af
 \subsection{Typing}
 \TypingRuleDef{LEVar}
 \ProseParagraph
-\AllApply
+\OneApplies
 \begin{itemize}
   \item $\vle$ denotes a left-hand-side variable expression for $\vx$, that is, $\LEVar(\vx)$;
-  \item One of the following applies (\textsc{local}):
+  \item \AllApplyCase{local}
   \begin{itemize}
     \item $\vx$ is declared in $\tenv$ as a local storage element with type $\tty$ and local declaration keyword $k$;
     \item checking that $k$ corresponds to a mutable variable, that is, $\LDKVar$, yields $\True$\ProseTerminateAs{\AssignmentToImmutable};
@@ -542,7 +542,7 @@ In \listingref{semantics-lediscard}, the assignment \texttt{- = 42;} does not af
     \item \Proseeqdef{$\vses$}{the \WriteLocalTerm\ for $\vx$}.
   \end{itemize}
 
-  \item One of the following applies (\textsc{global}):
+  \item \AllApplyCase{global}
   \begin{itemize}
     \item $\vx$ is declared in $\tenv$ as a global storage element with type $\tty$ and global declaration keyword $k$;
     \item checking that $k$ corresponds to a mutable variable, that is, $\GDKVar$, yields $\True$\ProseTerminateAs{\AssignmentToImmutable};
@@ -551,12 +551,13 @@ In \listingref{semantics-lediscard}, the assignment \texttt{- = 42;} does not af
     \item \Proseeqdef{$\vses$}{the \WriteGlobalTerm\ for $\vx$}.
   \end{itemize}
 
-  \item One of the following applies (\textsc{error\_undefined}):
+  \item \AllApplyCase{error\_undefined}
   \begin{itemize}
     \item $\vx$ is not declared in $\tenv$ as a local storage element nor as a global storage element;
     \item the result is a type error $\UndefinedIdentifier$.
   \end{itemize}
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[local]{
@@ -614,15 +615,15 @@ In \listingref{semantics-leglobalvar},
 \begin{itemize}
     \item $\vle$ denotes a variable, $\LEVar(\vx)$;
     \item view $\env$ as an environment where $\tenv$ is the static environment and $\denv$ is the dynamic environment;
-    \item One of the following applies:
+    \item \OneApplies
     \begin{itemize}
-        \item \AllApplyCase{local}:
+        \item \AllApplyCase{local}
         \begin{itemize}
             \item $\vx$ is in the local dynamic environment ($L^\denv$);
             \item $\newenv$ is $\env$ where $\vx$ is bound to $\vv$ in the local dynamic environment ($L^\denv$).
         \end{itemize}
 
-        \item \AllApplyCase{global}:
+        \item \AllApplyCase{global}
         \begin{itemize}
             \item $\vx$ is bound in the global dynamic environment ($G^\denv.\storage$);
             \item $\newenv$ is $\env$ where $\vx$ is bound to $\vv$ in the $\storage$ map of the global dynamic environment $G^\denv$.
@@ -1284,9 +1285,9 @@ ranges $(\vsone, \vlone)$ and $(\vstwo, \vltwo)$ do not intersect, yielding $\Tr
   \item \Proseannotateexpr{$\tenv$}{the right-hand side expression corresponding to \\ $\lebaseannot$}{$(\tbase, \Ignore, \Ignore)$}\ProseOrTypeError;
   \item \Proseannotatelexpr{$\tenv$}{$\lebase$}{$\tbase$}{$(\lebaseannot, \vsesbase)$}\ProseOrTypeError;
   \item \Prosemakeanonymous{$\tenv$}{$\tbase$}{\\ $\tbaseanon$}\ProseOrTypeError;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{bits}:
+    \item \AllApplyCase{bits}
     \begin{itemize}
       \item $\tanonbase$ is a bitvector type with list of bitfields $\vbitfields$;
       \item applying $\findbitfieldsslices$ to $\name$ and $\vbitfields$, for every $\name$ in $\vlefields$, yields $\vslices_\name$\ProseOrTypeError;
@@ -1295,7 +1296,7 @@ ranges $(\vsone, \vlone)$ and $(\vstwo, \vltwo)$ do not intersect, yielding $\Tr
       \item \Proseannotatelexpr{$\tenv$}{$\vleslice$}{$\vte$}{$(\newle, \vses)$}\ProseOrTypeError.
     \end{itemize}
 
-    \item \AllApplyCase{record}:
+    \item \AllApplyCase{record}
     \begin{itemize}
       \item $\tanonbase$ is a record type with list of fields $\vbasefields$;
       \item applying $\foldbitvectorfields$ to $\vlefields$ and $\vbasefields$ in $\tenv$ yields $(\vlength, \vslices)$ \ProseOrTypeError;
@@ -1306,7 +1307,7 @@ ranges $(\vsone, \vlone)$ and $(\vstwo, \vltwo)$ do not intersect, yielding $\Tr
       \item \Proseeqdef{$\vses$}{$\vsesbase$}.
     \end{itemize}
 
-    \item \AllApplyCase{error}:
+    \item \AllApplyCase{error}
     \begin{itemize}
       \item $\tanonbase$ is neither a bitvector type nor a record type;
       \item the result is a type error indicating that the type of the left-hand-side expression is expected to be
@@ -1373,16 +1374,16 @@ The helper function
 \]
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vlefields$ is empty;
     \item \Proseeqdef{$\vlength$}{$0$};
     \item \Proseeqdef{$\vslices$}{the empty list}.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vlefields$ is the list with prefix $\vlefieldsone$ (the elements excluding the last one) and last element $\vfield$;
     \item applying $\foldbitvectorfields$ to $\vbasefields$ and $\vlefieldsone$ in $\tenv$ yields $(\vstart, \vslicesone)$\ProseOrTypeError;
@@ -1464,15 +1465,15 @@ slices given by $\vslices$ of the \concurrentnativevalue\ $\vm$, yielding the
 \concurrentnativevalue\ $\vmtwo$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\fields$ and $\vslices$ are both empty lists;
     \item \Proseeqdef{$\vmtwo$}{$\vmone$}.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\fields$ is a list with \head\ $\fieldname$ and \tail\ $\fieldsone$;
     \item $\vslices$ is a list with \head\ $(\vione, \vitwo)$ and \tail\ $\vslicesone$;
@@ -1533,16 +1534,16 @@ One of the following applies:
   \item annotating the right-hand-side expression corresponding to $\vleone$ in $\tenv$ yields \\ $(\vtleone, \Ignore, \Ignore)$\ProseOrTypeError;
   \item annotating the left-hand-side expression $\vleone$ in $\tenv$ yields $(\vletwo, \vses)$\ProseOrTypeError;
   \item obtaining the \underlyingtype\ of $\vtleone$ in $\tenv$ yields a bitvector type with bitfields $\bitfields$\ProseOrTypeError;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{error\_missing\_field}:
+    \item \AllApplyCase{error\_missing\_field}
     \begin{itemize}
       \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields $\None$, meaning the field is not declared
             in $\vtleone$;
       \item the result is a type error $\BadField$.
     \end{itemize}
 
-    \item \AllApplyCase{field\_simple}:
+    \item \AllApplyCase{field\_simple}
     \begin{itemize}
       \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields a bitfield with corresponding slices $\slices$,
             that is, $\BitFieldSimple(\Ignore, \slices)$;
@@ -1553,7 +1554,7 @@ One of the following applies:
       \item annotating the left-hand-side expression $\vletwo$ in $\tenv$ yields \\ $(\newle, \vses)$\ProseOrTypeError.
     \end{itemize}
 
-    \item \AllApplyCase{field\_nested}:
+    \item \AllApplyCase{field\_nested}
     \begin{itemize}
       \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields a nested bitfield with corresponding
             slices $\slices$ and list of bitfields $\bitfieldsp$, that is, \\ $\BitFieldNested(\Ignore, \slices, \bitfieldsp)$;
@@ -1564,7 +1565,7 @@ One of the following applies:
       \item annotating the left-hand-side expression $\vlethree$ in $\tenv$ yields \\ $(\newle, \vses)$\ProseOrTypeError.
     \end{itemize}
 
-    \item \AllApplyCase{field\_typed}:
+    \item \AllApplyCase{field\_typed}
     \begin{itemize}
       \item applying $\findbitfieldopt$ to $\bitfields$ and $\vfield$ yields a typed bitfield with corresponding
             slices $\slices$ and a type $\vt$, that is, \\ $\BitFieldType(\Ignore, \vslices, \vt)$;

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -1230,7 +1230,7 @@ ranges $(\vsone, \vlone)$ and $(\vstwo, \vltwo)$ do not intersect, yielding $\Tr
 \section{Structured Type Field Assignment Expressions\label{sec:StructuredTypeFieldAssignmentExpressions}}
 \subsection{Abstract Syntax}
 \begin{flalign*}
-\lexpr \derives\ & \LESetField(\lexpr \identifier) &
+\lexpr \derives\ & \LESetField(\lexpr, \identifier) &
 \end{flalign*}
 
 \subsection{Typing}
@@ -1294,7 +1294,7 @@ ranges $(\vsone, \vlone)$ and $(\vstwo, \vltwo)$ do not intersect, yielding $\Tr
 \section{Structured Type Multi-field Assignment Expressions\label{sec:StructuredTypeMultiFieldAssignmentExpressions}}
 \subsection{Abstract Syntax}
 \begin{flalign*}
-\lexpr \derives\ & \LESetFields(\lexpr \identifier^*) &
+\lexpr \derives\ & \LESetFields(\lexpr, \identifier^*) &
 \end{flalign*}
 
 \subsection{Typing}

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -498,7 +498,7 @@ via the following rules:
 
 \subsection{Semantics}
 \SemanticsRuleDef{LEDiscard}
-\subsubsection{Example}
+\ExampleDef{Discarding Assignments}
 In \listingref{semantics-lediscard}, the assignment \texttt{- = 42;} does not affect the environment.
 \ASLListing{Assignment to \texttt{-}}{semantics-lediscard}{\semanticstests/SemanticsRule.LEDiscard.asl}
 
@@ -595,14 +595,14 @@ In \listingref{semantics-lediscard}, the assignment \texttt{- = 42;} does not af
 
 \subsection{Semantics}
 \SemanticsRuleDef{LEVar}
-\subsubsection{Example (Local Variable)}
+\ExampleDef{Local Variable}
 In \listingref{semantics-levar}, \SemanticsRuleRef{LEVar} is (only) used
 to assign the value $42$ to the left-hand-side expression
 \texttt{x} within \texttt{x = 42;}.
 
 \ASLListing{Semantics of a left-hand-side variable expression}{semantics-levar}{\semanticstests/SemanticsRule.LELocalVar.asl}
 
-\subsubsection{Example (Global Variable)}
+\ExampleDef{Global Variable}
 In \listingref{semantics-leglobalvar},
 \SemanticsRuleRef{LEVar} is (only) used to assign the value $42$ to the left-hand-side expression
 \texttt{x} within \texttt{x = 42;}.
@@ -698,7 +698,7 @@ In \listingref{semantics-leglobalvar},
 
 \subsection{Semantics}
 \SemanticsRuleDef{LEDestructuring}
-\subsubsection{Example}
+\ExampleDef{Multi-variable Assignments}
 In \listingref{semantics-ledestructuring}, the assignment \texttt{(x, y) = (3, 42)} binds
 \texttt{x} to $\nvint(3)$ and \texttt{y} to
 $\nvint(42)$ in the environment where \texttt{x} is bound to $\nvint(42)$ and
@@ -916,7 +916,7 @@ The result is the annotated assignable expression $\newle$ and
 
 \subsection{Semantics}
 \SemanticsRuleDef{LESetArray}
-\subsubsection{Example}
+\ExampleDef{Array Update Assignments}
 In \listingref{semantics-lesetarray}, the assignment \verb|my_array[[3]] = 53;| binds the third element
 of \\
 \texttt{my\_array} to the value \texttt{53}.
@@ -1086,7 +1086,7 @@ tests whether the list of slices $\slices$ do not overlap in $\tenv$, yielding $
 
 \subsection{Semantics}
 \SemanticsRuleDef{LESlice}
-\subsubsection{Example}
+\ExampleDef{Slice Assignments}
 In \listingref{semantics-leslice}, the assignment \texttt{x[3:0] = '0000'} binds
 \texttt{x} to $\nvbitvector(11110000)$
 via the rule \SemanticsRuleRef{LESlice}
@@ -1674,7 +1674,7 @@ as the type system transforms the \untypedast\ for assigning to an individual bi
 
 \SemanticsRuleDef{LESetField}
 
-\subsubsection{Example}
+\ExampleDef{Field Assignment}
 In \listingref{semantics-lesetfield}, the assignment
 \verb|my\_record.a = 42;| binds \texttt{my\_record} to \texttt{\{a: 42, b: 100\}}
 in the environment where \texttt{my\_record} is bound to \texttt{\{a: 3, b: 100\}}.

--- a/asllib/doc/BaseValues.tex
+++ b/asllib/doc/BaseValues.tex
@@ -18,7 +18,7 @@ The following types do not have a \basevalueterm{}:
 Subprogram parameters can be parameterized integers, and since they will be initialized by their
 invocation, there is no need to have a \basevalueterm{} for them.
 
-\subsubsection{Example: Base Values}
+\ExampleDef{Base Values}
 \listingref{base-values} shows a specification with examples of well-typed \basevalueterm{}
 for various types, followed by the output to the console.
 \ASLListing{Well-typed Base Values}{base-values}{\typingtests/TypingRule.BaseValue.asl}
@@ -36,7 +36,7 @@ enumeration_array_base = [[RED=0, GREEN=0, BLUE=0]]
 \end{Verbatim}
 % CONSOLE_END
 
-\subsubsection{Example: Types Without Base Value}
+\ExampleDef{Types Without Base Value}
 \listingref{base-values-bad} shows an ill-typed specification
 due to the fact that \parameterizedintegertypes{} have no defined \basevalueterm{},
 which is also true for a \bitvectortypeterm{} whose width is parameterized.
@@ -63,6 +63,8 @@ of type $\vt$ in the static environment $\tenv$.
 \ProseOtherwiseTypeError
 
 \TypingRuleDef{BaseValue}
+See \ExampleRef{Base Values} and \ExampleRef{Types Without Base Value}.
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -292,6 +294,13 @@ returns a single element list containing the integer closest to $0$ that satisfi
 and an empty list if the constraint represents an empty set.
 Otherwise, the result is $\TypeErrorVal{\NoBaseValue}$.
 
+\ExampleDef{Minimal Absolute Value in a Constraint List}
+The minimal absolute value of \verb|{7, -2}| is \verb|-2|.\\
+%
+The minimal absolute value of \verb|{2, -2}| is \verb|2|.\\
+%
+The minimal absolute value of \verb|{-2..2, 5}| is \verb|0|.
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -367,7 +376,7 @@ of integers in the list $\vl$. The result is biased towards positive integers. T
 if two integers $x$ and $y$ have the same absolute value and $x$ is positive and $y$ is negative
 then $x$ is considered closer to $0$.
 
-\subsubsection{Example: Minimal Absolute Value}
+\ExampleDef{Minimal Absolute Value}
 The minimal absolute value of $[9, -3]$ is $-3$,
 and the minimal absolute value of $[2, -2]$ is $2$.
 

--- a/asllib/doc/BaseValues.tex
+++ b/asllib/doc/BaseValues.tex
@@ -136,7 +136,7 @@ One of the following applies:
 
     \item All of the following apply (\textsc{t\_string}): \lrmcomment{\identr{WKCY}}
     \begin{itemize}
-        \item $\vt$ is the string type;
+        \item $\vt$ is the \stringtypeterm{};
         \item $\veinit$ is the string literal expression for the empty list of characters.
     \end{itemize}
 

--- a/asllib/doc/BaseValues.tex
+++ b/asllib/doc/BaseValues.tex
@@ -120,7 +120,7 @@ One of the following applies:
 
     \item All of the following apply (\textsc{t\_real}): \lrmcomment{\identr{GYCG}}
     \begin{itemize}
-        \item $\vt$ is the real type;
+        \item $\vt$ is the \realtypeterm{};
         \item $\veinit$ is the real literal expression for $0$.
     \end{itemize}
 
@@ -281,7 +281,6 @@ One of the following applies:
 \end{mathpar}
 
 \TypingRuleDef{ConstraintAbsMin}
-\ProseParagraph
 \hypertarget{def-constraintabsmin}{}
 The function
 \[

--- a/asllib/doc/BaseValues.tex
+++ b/asllib/doc/BaseValues.tex
@@ -66,13 +66,13 @@ of type $\vt$ in the static environment $\tenv$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-    \item All of the following apply (\textsc{t\_bool}): \lrmcomment{\identr{CPCK}}
+    \item \AllApplyCase{t\_bool} \lrmcomment{\identr{CPCK}}
     \begin{itemize}
         \item $\vt$ is the Boolean type;
         \item $\veinit$ is the literal expression for $\False$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_bits}): \lrmcomment{\identr{ZVPT}}
+    \item \AllApplyCase{t\_bits} \lrmcomment{\identr{ZVPT}}
     \begin{itemize}
         \item $\vt$ is the bitvector type with width expression $\ve$;
         \item applying $\reducetozopt$ to $\ve$ in $\tenv$ yields $\vzopt$;
@@ -82,26 +82,26 @@ One of the following applies:
         \item $\veinit$ is the literal expression for a bitvector made of a sequence of $\length$ values of $0$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_enum}): \lrmcomment{\identr{LCCN}}
+    \item \AllApplyCase{t\_enum} \lrmcomment{\identr{LCCN}}
     \begin{itemize}
         \item $\vt$ is the enumeration type with a list of labels where $\name$ as its \head;
         \item $\name$ is bound to the literal $\vl$ by the $\constantvalues$ in the global static environment of $\tenv$;
         \item $\veinit$ is the literal expression for $\vl$, that is, $\eliteral{\vl}$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_int\_unconstrained}): \lrmcomment{\identr{NJDZ}}
+    \item \AllApplyCase{t\_int\_unconstrained} \lrmcomment{\identr{NJDZ}}
     \begin{itemize}
         \item $\vt$ is the \unconstrainedintegertype;
         \item $\veinit$ is the literal expression for $0$, that is, $\ELiteral(\lint(0))$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_int\_parameterized}): \lrmcomment{\identr{QGGH}}
+    \item \AllApplyCase{t\_int\_parameterized} \lrmcomment{\identr{QGGH}}
     \begin{itemize}
         \item $\vt$ is the \parameterizedintegertype;
         \item the result is a type error indicating the lack of a statically known base value.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_int\_wellconstrained}): \lrmcomment{\identr{CFTD}}
+    \item \AllApplyCase{t\_int\_wellconstrained} \lrmcomment{\identr{CFTD}}
     \begin{itemize}
         \item $\vt$ is the \wellconstrainedintegertype\ with a list of constraints $\cs$;
         \item define $\vzminlist$ as the concatenation of lists obtained for each
@@ -111,20 +111,20 @@ One of the following applies:
         \item $\veinit$ is the integer literal expression for $\vzmin$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_named}):
+    \item \AllApplyCase{t\_named}:
     \begin{itemize}
         \item $\vt$ is the \namedtype\ for $\id$;
         \item obtaining the \underlyingtype\ for $\id$ in $\tenv$ yields $\vtp$\ProseOrTypeError;
         \item applying $\basevalue$ to $\vtp$ in $\tenv$ yields $\veinit$\ProseOrTypeError.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_real}): \lrmcomment{\identr{GYCG}}
+    \item \AllApplyCase{t\_real} \lrmcomment{\identr{GYCG}}
     \begin{itemize}
         \item $\vt$ is the \realtypeterm{};
         \item $\veinit$ is the real literal expression for $0$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{structured}): \lrmcomment{\identr{MBRM}, \ident{SVJB}}
+    \item \AllApplyCase{structured} \lrmcomment{\identr{MBRM}, \ident{SVJB}}
     \begin{itemize}
         \item $\vt$ is a \structuredtype\ with list of fields $\fields$;
         \item applying $\basevalue$ to $\vtefield$ in $\tenv$ for each $(\name, \vtefield)$ in $\fields$
@@ -134,20 +134,20 @@ One of the following applies:
               $\ERecord((\name, \vtefield) \in \fields: (\name, \ve_\name))$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_string}): \lrmcomment{\identr{WKCY}}
+    \item \AllApplyCase{t\_string} \lrmcomment{\identr{WKCY}}
     \begin{itemize}
         \item $\vt$ is the \stringtypeterm{};
         \item $\veinit$ is the string literal expression for the empty list of characters.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_tuple}): \lrmcomment{\identr{QWSQ}}
+    \item \AllApplyCase{t\_tuple} \lrmcomment{\identr{QWSQ}}
     \begin{itemize}
         \item $\vt$ is the tuple type over the list of types $\vt_{1..k}$, that is, $\TTuple(\vt_{1..k})$;
         \item applying $\basevalue$ to each type $\vt_\vi$ in $\tenv$ for $\vi=1..k$; yields the list of expressions $\ve_{1..k}$;
         \item $\veinit$ is the tuple expression $\ETuple(\ve_{1..k})$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_array\_enum}):
+    \item \AllApplyCase{t\_array\_enum}
     \begin{itemize}
         \item $\vt$ is the enumerated array type over for the enumeration $\venum$ and labels $\vlabels$ and element type $\tty$,
               that is, $\TArray(\ArrayLengthEnum(\venum, \vlabels), \tty)$ ;
@@ -156,7 +156,7 @@ One of the following applies:
               that is, $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \vvalue\}$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_array\_expr}): \lrmcomment{\identr{WGVR}}
+    \item \AllApplyCase{t\_array\_expr} \lrmcomment{\identr{WGVR}}
     \begin{itemize}
         \item $\vt$ is the array type over an integer index expression $\vlength$ and element type $\tty$, that is,
               $\TArray(\ArrayLengthExpr(\vlength), \tty)$ ;
@@ -295,7 +295,7 @@ Otherwise, the result is $\TypeErrorVal{\NoBaseValue}$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-    \item All of the following apply (\textsc{exact}):
+    \item \AllApplyCase{exact}:
     \begin{itemize}
         \item $\vc$ is the constraint given by the expression $\ve$, that is, $\ConstraintExact(\ve)$;
         \item applying $\reducetozopt$ to $\ve$ in $\tenv$ yields the optional integer $\vzopt$;
@@ -304,7 +304,7 @@ One of the following applies:
         \item define $\vzs$ as the single element list containing $\vz$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{range}):
+    \item \AllApplyCase{range}:
     \begin{itemize}
         \item $\vc$ is the constraint given by the expression $\veone$ and $\vetwo$, that is, \\
                 $\ConstraintRange(\veone, \vetwo)$;
@@ -374,12 +374,12 @@ and the minimal absolute value of $[2, -2]$ is $2$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-    \item All of the following apply (\textsc{one}):
+    \item \AllApplyCase{one}:
     \begin{itemize}
         \item $\vl$ is the single element list for $\vz$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{more\_than\_one}):
+    \item \AllApplyCase{more\_than\_one}:
     \begin{itemize}
         \item $\vl$ is the list where $\vzone$ is its \head\ and $\vltwo$ is its \tail;
         \item $\vltwo$ is not the empty list;

--- a/asllib/doc/BaseValues.tex
+++ b/asllib/doc/BaseValues.tex
@@ -64,7 +64,7 @@ of type $\vt$ in the static environment $\tenv$.
 
 \TypingRuleDef{BaseValue}
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
     \item \AllApplyCase{t\_bool} \lrmcomment{\identr{CPCK}}
     \begin{itemize}
@@ -111,7 +111,7 @@ One of the following applies:
         \item $\veinit$ is the integer literal expression for $\vzmin$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_named}:
+    \item \AllApplyCase{t\_named}
     \begin{itemize}
         \item $\vt$ is the \namedtype\ for $\id$;
         \item obtaining the \underlyingtype\ for $\id$ in $\tenv$ yields $\vtp$\ProseOrTypeError;
@@ -293,9 +293,9 @@ and an empty list if the constraint represents an empty set.
 Otherwise, the result is $\TypeErrorVal{\NoBaseValue}$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-    \item \AllApplyCase{exact}:
+    \item \AllApplyCase{exact}
     \begin{itemize}
         \item $\vc$ is the constraint given by the expression $\ve$, that is, $\ConstraintExact(\ve)$;
         \item applying $\reducetozopt$ to $\ve$ in $\tenv$ yields the optional integer $\vzopt$;
@@ -304,7 +304,7 @@ One of the following applies:
         \item define $\vzs$ as the single element list containing $\vz$.
     \end{itemize}
 
-    \item \AllApplyCase{range}:
+    \item \AllApplyCase{range}
     \begin{itemize}
         \item $\vc$ is the constraint given by the expression $\veone$ and $\vetwo$, that is, \\
                 $\ConstraintRange(\veone, \vetwo)$;
@@ -372,14 +372,14 @@ The minimal absolute value of $[9, -3]$ is $-3$,
 and the minimal absolute value of $[2, -2]$ is $2$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-    \item \AllApplyCase{one}:
+    \item \AllApplyCase{one}
     \begin{itemize}
         \item $\vl$ is the single element list for $\vz$.
     \end{itemize}
 
-    \item \AllApplyCase{more\_than\_one}:
+    \item \AllApplyCase{more\_than\_one}
     \begin{itemize}
         \item $\vl$ is the list where $\vzone$ is its \head\ and $\vltwo$ is its \tail;
         \item $\vltwo$ is not the empty list;

--- a/asllib/doc/BaseValues.tex
+++ b/asllib/doc/BaseValues.tex
@@ -14,7 +14,7 @@ The following types do not have a \basevalueterm{}:
     \item a \bitvectortypeterm{} whose length is negative.
 \end{itemize}
 
-\lrmcomment{\identi{WVQZ}}
+\identi{WVQZ}
 Subprogram parameters can be parameterized integers, and since they will be initialized by their
 invocation, there is no need to have a \basevalueterm{} for them.
 
@@ -66,13 +66,13 @@ of type $\vt$ in the static environment $\tenv$.
 \ProseParagraph
 \OneApplies
 \begin{itemize}
-    \item \AllApplyCase{t\_bool} \lrmcomment{\identr{CPCK}}
+    \item \AllApplyCase{t\_bool} \identr{CPCK}
     \begin{itemize}
         \item $\vt$ is the Boolean type;
         \item $\veinit$ is the literal expression for $\False$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_bits} \lrmcomment{\identr{ZVPT}}
+    \item \AllApplyCase{t\_bits} \identr{ZVPT}
     \begin{itemize}
         \item $\vt$ is the bitvector type with width expression $\ve$;
         \item applying $\reducetozopt$ to $\ve$ in $\tenv$ yields $\vzopt$;
@@ -82,26 +82,26 @@ of type $\vt$ in the static environment $\tenv$.
         \item $\veinit$ is the literal expression for a bitvector made of a sequence of $\length$ values of $0$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_enum} \lrmcomment{\identr{LCCN}}
+    \item \AllApplyCase{t\_enum} \identr{LCCN}
     \begin{itemize}
-        \item $\vt$ is the enumeration type with a list of labels where $\name$ as its \head;
+        \item $\vt$ is the \enumerationtypeterm{} with a list of labels where $\name$ as its \head;
         \item $\name$ is bound to the literal $\vl$ by the $\constantvalues$ in the global static environment of $\tenv$;
         \item $\veinit$ is the literal expression for $\vl$, that is, $\eliteral{\vl}$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_int\_unconstrained} \lrmcomment{\identr{NJDZ}}
+    \item \AllApplyCase{t\_int\_unconstrained} \identr{NJDZ}
     \begin{itemize}
         \item $\vt$ is the \unconstrainedintegertype;
         \item $\veinit$ is the literal expression for $0$, that is, $\ELiteral(\lint(0))$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_int\_parameterized} \lrmcomment{\identr{QGGH}}
+    \item \AllApplyCase{t\_int\_parameterized} \identr{QGGH}
     \begin{itemize}
         \item $\vt$ is the \parameterizedintegertype;
         \item the result is a type error indicating the lack of a statically known base value.
     \end{itemize}
 
-    \item \AllApplyCase{t\_int\_wellconstrained} \lrmcomment{\identr{CFTD}}
+    \item \AllApplyCase{t\_int\_wellconstrained} \identr{CFTD}
     \begin{itemize}
         \item $\vt$ is the \wellconstrainedintegertype\ with a list of constraints $\cs$;
         \item define $\vzminlist$ as the concatenation of lists obtained for each
@@ -118,13 +118,13 @@ of type $\vt$ in the static environment $\tenv$.
         \item applying $\basevalue$ to $\vtp$ in $\tenv$ yields $\veinit$\ProseOrTypeError.
     \end{itemize}
 
-    \item \AllApplyCase{t\_real} \lrmcomment{\identr{GYCG}}
+    \item \AllApplyCase{t\_real} \identr{GYCG}
     \begin{itemize}
         \item $\vt$ is the \realtypeterm{};
         \item $\veinit$ is the real literal expression for $0$.
     \end{itemize}
 
-    \item \AllApplyCase{structured} \lrmcomment{\identr{MBRM}, \ident{SVJB}}
+    \item \AllApplyCase{structured} \identr{MBRM} \identr{SVJB}
     \begin{itemize}
         \item $\vt$ is a \structuredtype\ with list of fields $\fields$;
         \item applying $\basevalue$ to $\vtefield$ in $\tenv$ for each $(\name, \vtefield)$ in $\fields$
@@ -134,15 +134,15 @@ of type $\vt$ in the static environment $\tenv$.
               $\ERecord((\name, \vtefield) \in \fields: (\name, \ve_\name))$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_string} \lrmcomment{\identr{WKCY}}
+    \item \AllApplyCase{t\_string} \identr{WKCY}
     \begin{itemize}
         \item $\vt$ is the \stringtypeterm{};
         \item $\veinit$ is the string literal expression for the empty list of characters.
     \end{itemize}
 
-    \item \AllApplyCase{t\_tuple} \lrmcomment{\identr{QWSQ}}
+    \item \AllApplyCase{t\_tuple} \identr{QWSQ}
     \begin{itemize}
-        \item $\vt$ is the tuple type over the list of types $\vt_{1..k}$, that is, $\TTuple(\vt_{1..k})$;
+        \item $\vt$ is the \tupletypeterm{} over the list of types $\vt_{1..k}$, that is, $\TTuple(\vt_{1..k})$;
         \item applying $\basevalue$ to each type $\vt_\vi$ in $\tenv$ for $\vi=1..k$; yields the list of expressions $\ve_{1..k}$;
         \item $\veinit$ is the tuple expression $\ETuple(\ve_{1..k})$.
     \end{itemize}
@@ -156,7 +156,7 @@ of type $\vt$ in the static environment $\tenv$.
               that is, $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \vvalue\}$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_array\_expr} \lrmcomment{\identr{WGVR}}
+    \item \AllApplyCase{t\_array\_expr} \identr{WGVR}
     \begin{itemize}
         \item $\vt$ is the array type over an integer index expression $\vlength$ and element type $\tty$, that is,
               $\TArray(\ArrayLengthExpr(\vlength), \tty)$ ;

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -160,7 +160,7 @@ resulting in $\newfields$ --- the \typedast\ for $\fields$ and $\ewidth$
 as well as a set of \sideeffectdescriptorsterm\ $\vses$. \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item checking that the list of bitfield names in $\bitfields$ does not contain duplicates yields $\True$\ProseOrTypeError;
   \item symbolically simplifying $\ewidth$ in $\tenv$ via $\staticeval$ yields the literal integer for $\width$\ProseOrTypeError;
@@ -259,13 +259,13 @@ and an empty list if there are none.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{simple\_type}):
+  \item \AllApplyCase{simple\_type}:
   \begin{itemize}
     \item $\vbf$ does not have nested bitfields;
     \item $\vnested$ is the empty list.
   \end{itemize}
 
-  \item All of the following apply (\textsc{nested}):
+  \item \AllApplyCase{nested}:
   \begin{itemize}
     \item $\vbf$ is bitfields with nested bitfields $\vnested$.
   \end{itemize}
@@ -302,13 +302,13 @@ annotated bitfield --- $\newfield$ --- or a type error, if one is detected.
   \item annotating the slices $\vslices$ yields $(\slicesone, \vsesslices)$\ProseOrTypeError;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{simple}):
+    \item \AllApplyCase{simple}:
     \begin{itemize}
       \item checking whether the range of positions in $\slicesone$ fits inside $0..\width-1$ yields $\True$\ProseOrTypeError;
       \item define $\newfield$ as the bitfield named $\name$ with list of slices $\slicesone$, that is, $\BitFieldSimple(\name, \slicesone)$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{nested}):
+    \item \AllApplyCase{nested}:
     \begin{itemize}
       \item converting the $\slicesone$ into a list of positions with $\width$ and static environment $\tenv$
             yields $\positions$\ProseOrTypeError;
@@ -321,7 +321,7 @@ annotated bitfield --- $\newfield$ --- or a type error, if one is detected.
       \item define $\vses$ as the union of $\vsesslices$ and $\vsesbitfields$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{type}):
+    \item \AllApplyCase{type}:
     \begin{itemize}
       \item Annotating the type $\vt$ yields $(\vtp, \vsesty)$\ProseOrTypeError;
       \item checking whether the range of positions in $\slicesone$ fit inside $0..\width$ yields $\True$\ProseOrTypeError;
@@ -401,7 +401,7 @@ checks whether the slices in $\vslices$ fit within the bitvector width given by 
 yielding $\True$. \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
     \item applying $\disjointslicestopositions$ to $\vslices$ in $\tenv$ checks whether the
     slices in $\vslices$ are disjoint and yields the set of their positions\ProseOrTypeError;
@@ -431,7 +431,7 @@ checks whether the set of positions in $\positions$ fit within the bitvector wid
 yielding $\True$. \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
     \item define $\minpos$ as the minimal position in $\positions$;
     \item define $\maxpos$ as the maximal position in $\positions$;
@@ -466,13 +466,13 @@ In particular, this rule checks that the bitfield slices do not overlap and that
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\vslices$ is the empty list;
     \item $\positions$ is the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\vslices$ is the list with $\vs$ as its \head\ and $\vslicesone$ as its \tail;
     \item applying $\bitfieldslicetopositions$ to $\vs$ in $\tenv$ yields the optional set of positions \\
@@ -518,14 +518,14 @@ if they can be statically evaluated, or $\None$ if they cannot be statically eva
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{single}):
+  \item \AllApplyCase{single}:
   \begin{itemize}
     \item $\vslice$ is a \singleslice\ defined by the expression $\ve$, that is, $\SliceSingle(\ve)$;
     \item applying $\reducetozopt$ to $\ve$ in $\tenv$ yields the integer literal for $\vx$\ProseTerminateAs{\None};
     \item $\positions$ is the singleton set for $\vx$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vslice$ is \rangeslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
           $\SliceRange(\veone, \vetwo)$;
@@ -535,7 +535,7 @@ One of the following applies:
     \item $\positions$ is the set of integers between $\vx$ and $\vy$, inclusive.
   \end{itemize}
 
-  \item All of the following apply (\textsc{length}):
+  \item \AllApplyCase{length}:
   \begin{itemize}
     \item $\vslice$ is \lengthslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
           $\SliceLength(\veone, \vetwo)$;
@@ -545,7 +545,7 @@ One of the following applies:
     \item $\positions$ is the set of integers between $\vx$ and $\vx+\vy-1$, inclusive.
   \end{itemize}
 
-  \item All of the following apply (\textsc{scaled}):
+  \item \AllApplyCase{scaled}:
   \begin{itemize}
     \item $\vslice$ is \scaledslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
           $\SliceStar(\veone, \vetwo)$;
@@ -640,13 +640,13 @@ but have different absolute slices}
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\vbitfields$ is the empty list;
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\vbitfields$ is not the empty list;
     \item define $\vlastindex$ as $\vwidth - 1$;
@@ -698,7 +698,7 @@ of bitfields $\vbitfields$, whose \bitfieldscope\ and \absoluteslice\ is given b
 $\vabsoluteparent$, in the static environment $\tenv$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\bitfieldtoabsolute$ to each field $\vf$ in $\vbitfields$ with $\vabsoluteparent$ in $\tenv$,
         yields $\va_\vf$;
@@ -730,7 +730,7 @@ bitfields nested in $\vbf$, including itself, where the \bitfieldscope\ and \abs
 of the bitfield containing $\vbf$ are $\vabsoluteparent$, in the static environment $\tenv$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item obtaining the name of the bitfield $\vbf$ via $\bitfieldgetname$ yields $\name$;
   \item define the \absolutename\ of $\vbfname$ for $\vbf$ by appending $\name$ to $\vabsname$, the \absolutename{} of $\vabsoluteparent$;
@@ -783,7 +783,7 @@ and returns the sub-list of $\indices$ indicated by the indices in $\sliceindice
 % which represents sequence of indices via intervals.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item view $\sliceindices$ as the list $S_{m..0}$;
   \item view $\indices$ as the list $I_{n..0}$;
@@ -810,7 +810,7 @@ and exist in the same scope. If they do, $\vb$ indicates whether their \absolute
 are equal. Otherwise, the result if $\True$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vf$ is an \absolutebitfield\ with \absolutename\ $\vf_{1..k}$ and \absoluteslice\ $\vsliceone$;
   \item $\vg$ is an \absolutebitfield\ with \absolutename\ $\vg_{1..n}$ and \absoluteslice\ $\vslicetwo$;
@@ -847,7 +847,7 @@ The function
 returns the list of indices $\indices$ represented by the bitvector slice $\vs$ in the static environment $\tenv$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a \lengthslice\ for the expressions $\vi$ and $\vw$;
   \item \Prosestaticeval{$\tenv$}{$\vi$}{the literal for the integer $\vz_\vi$};

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -194,7 +194,7 @@ The function
 returns the name of a bitfield --- $\name$, given a bitfield $\vbf$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
   \item $\vbf$ is a simple bitfield with name $\name$, that is, $\BitFieldSimple(\name, \Ignore)$;
   \item $\vbf$ is a nested bitfield with name $\name$, that is, $\BitFieldNested(\name, \Ignore, \Ignore)$;
@@ -225,7 +225,7 @@ The function
 returns the list of slices $\vslices$ associated with the bitfield $\vbf$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
   \item $\vbf$ is a simple bitfield with list of slices $\vslices$, that is, $\BitFieldSimple(\Ignore, \vslices)$;
   \item $\vbf$ is a nested bitfield with list of slices $\vslices$, that is, $\BitFieldNested(\Ignore, \vslices, \Ignore)$;
@@ -257,15 +257,15 @@ returns the list of bitfields $\vnested$ nested within the bitfield $\vbf$, if t
 and an empty list if there are none.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{simple\_type}:
+  \item \AllApplyCase{simple\_type}
   \begin{itemize}
     \item $\vbf$ does not have nested bitfields;
     \item $\vnested$ is the empty list.
   \end{itemize}
 
-  \item \AllApplyCase{nested}:
+  \item \AllApplyCase{nested}
   \begin{itemize}
     \item $\vbf$ is bitfields with nested bitfields $\vnested$.
   \end{itemize}
@@ -300,15 +300,15 @@ annotated bitfield --- $\newfield$ --- or a type error, if one is detected.
 \begin{itemize}
   \item $\vfield$ is a bitfield with list of slices $\vslices$;
   \item annotating the slices $\vslices$ yields $(\slicesone, \vsesslices)$\ProseOrTypeError;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{simple}:
+    \item \AllApplyCase{simple}
     \begin{itemize}
       \item checking whether the range of positions in $\slicesone$ fits inside $0..\width-1$ yields $\True$\ProseOrTypeError;
       \item define $\newfield$ as the bitfield named $\name$ with list of slices $\slicesone$, that is, $\BitFieldSimple(\name, \slicesone)$.
     \end{itemize}
 
-    \item \AllApplyCase{nested}:
+    \item \AllApplyCase{nested}
     \begin{itemize}
       \item converting the $\slicesone$ into a list of positions with $\width$ and static environment $\tenv$
             yields $\positions$\ProseOrTypeError;
@@ -321,7 +321,7 @@ annotated bitfield --- $\newfield$ --- or a type error, if one is detected.
       \item define $\vses$ as the union of $\vsesslices$ and $\vsesbitfields$.
     \end{itemize}
 
-    \item \AllApplyCase{type}:
+    \item \AllApplyCase{type}
     \begin{itemize}
       \item Annotating the type $\vt$ yields $(\vtp, \vsesty)$\ProseOrTypeError;
       \item checking whether the range of positions in $\slicesone$ fit inside $0..\width$ yields $\True$\ProseOrTypeError;
@@ -464,15 +464,15 @@ In particular, this rule checks that the bitfield slices do not overlap and that
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vslices$ is the empty list;
     \item $\positions$ is the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vslices$ is the list with $\vs$ as its \head\ and $\vslicesone$ as its \tail;
     \item applying $\bitfieldslicetopositions$ to $\vs$ in $\tenv$ yields the optional set of positions \\
@@ -516,16 +516,16 @@ if they can be statically evaluated, or $\None$ if they cannot be statically eva
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{single}:
+  \item \AllApplyCase{single}
   \begin{itemize}
     \item $\vslice$ is a \singleslice\ defined by the expression $\ve$, that is, $\SliceSingle(\ve)$;
     \item applying $\reducetozopt$ to $\ve$ in $\tenv$ yields the integer literal for $\vx$\ProseTerminateAs{\None};
     \item $\positions$ is the singleton set for $\vx$.
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vslice$ is \rangeslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
           $\SliceRange(\veone, \vetwo)$;
@@ -535,7 +535,7 @@ One of the following applies:
     \item $\positions$ is the set of integers between $\vx$ and $\vy$, inclusive.
   \end{itemize}
 
-  \item \AllApplyCase{length}:
+  \item \AllApplyCase{length}
   \begin{itemize}
     \item $\vslice$ is \lengthslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
           $\SliceLength(\veone, \vetwo)$;
@@ -545,7 +545,7 @@ One of the following applies:
     \item $\positions$ is the set of integers between $\vx$ and $\vx+\vy-1$, inclusive.
   \end{itemize}
 
-  \item \AllApplyCase{scaled}:
+  \item \AllApplyCase{scaled}
   \begin{itemize}
     \item $\vslice$ is \scaledslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
           $\SliceStar(\veone, \vetwo)$;
@@ -638,15 +638,15 @@ but have different absolute slices}
 {CommonBitfieldsAlignError}{\typingtests/TypingRule.CheckCommonBitfieldsAlign.Error.asl}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vbitfields$ is the empty list;
     \item the result is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vbitfields$ is not the empty list;
     \item define $\vlastindex$ as $\vwidth - 1$;

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -384,7 +384,7 @@ annotated bitfield --- $\newfield$ --- or a type error, if one is detected.
 }
 \end{mathpar}
 
-\subsubsection{Example}
+\ExampleDef{Well-typed Bitfields}
 In \listingref{welltypedbitvectortypes}, all the uses of bitvector types with bitfields are well-typed.
 \ASLListing{Well-typed bitfields}{welltypedbitvectortypes}{\typingtests/TypingRule.TBitField.asl}
 
@@ -626,12 +626,12 @@ via a list of intervals, each represented by its limits.}
 
 Premises in \TypingRuleRef{TBits} guarantee that $\vwidth > 0$ holds.
 
-\subsubsection{Example}
+\ExampleDef{Ill-typed Bitfields}
 \listingref{CommonBitfieldsAlignError} shows an example where the two bitfields named \texttt{common}
 exist in the same \bitfieldscope, but their \absoluteslices\ are not the same.
 Specifically, the \absoluteslice\ for the bitfield \texttt{common} is \texttt{[1:0]}
 whereas the \absoluteslice\ for the bitfield \texttt{sub.common} is \texttt{[0, 1]}.
-Typechecking this example results in the type error \BadSlices.
+Typechecking this example results in the \typingerrorterm{} \BadSlices.
 
 \ASLListing{An example where two bitfields of the same name (\texttt{common}) exist in the same scope
 but have different absolute slices}

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -84,9 +84,9 @@ defined for each bitfield.
 \subsection{Abstract Syntax}
 \begin{flalign*}
 \bitfield \derives\ & \BitFieldSimple(\identifier, \slice^{*})
-  & \hypertarget{ast-bitfieldnested}{}\\
+  & \\
   |\ & \BitFieldNested(\identifier, \slice^{*}, \bitfield^{*})
-  & \hypertarget{ast-bitfieldtype}{}\\
+  & \\
   |\ & \BitFieldType(\identifier, \slice^{*}, \ty) &
 \end{flalign*}
 

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -1,12 +1,12 @@
 \chapter{Bitfields\label{chap:Bitfields}}
 
 Bitvector types allow defining bitslices of bitvectors, to be treated as named
-fields, which can be read or written. \lrmcomment{\identi{KGMC}}
+fields, which can be read or written. \identi{KGMC}
 
 Individual bitfields are grammatically derived from $\Nbitfield$ and represented as ASTs by $\bitfield$.
 Bitfields are not associated with a semantic relation.
 
-\subsection{Example}
+\ExampleDef{A bitvector type with bitfields}
 \listingref{bitfields1} declares a global variable whose type is a bitvector with bitfields.
 \ASLListing{A bitvector type with bitfields}{bitfields1}{\definitiontests/Bitfields.asl}
 \begin{itemize}
@@ -68,7 +68,7 @@ if they share the same name and exist in the same \bitfieldscope\ then their \ab
 equal.
 This is formalized in \TypingRuleRef{CheckCommonBitfieldsAlign} and exemplified in \listingref{nestedbitfields}.
 
-\subsection{Example}
+\ExampleDef{A bitvector type with nested bitfields}
 \listingref{nestedbitfields} shows a bitvector type with nested bitfields, along with the absolute bitfield
 defined for each bitfield.
 \ASLListing{A bitvector type with nested bitfields}{nestedbitfields}{\definitiontests/Bitfields_nested.asl}

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -355,7 +355,11 @@ annotated bitfield --- $\newfield$ --- or a type error, if one is detected.
   \disjointslicestopositions(\tenv, \slicesone) \typearrow \positions \OrTypeError\\\\
   \checkpositionsinwidth(\tenv, \width, \positions) \typearrow \True \OrTypeError\\\\
   \widthp \eqdef \listlen{\positions}\\
-  \annotatebitfields(\tenv, \widthp, \bitfieldsp) \typearrow (\bitfieldspp, \vsesbitfields) \OrTypeError\\
+  {
+  \begin{array}{r}
+  \annotatebitfields(\tenv, \widthp, \bitfieldsp) \typearrow \\ (\bitfieldspp, \vsesbitfields) \OrTypeError
+  \end{array}
+  }\\
   \vses \eqdef \vsesslices \cup \vsesbitfields
 }{
   \annotatebitfield(\tenv, \width, \BitFieldNested(\name, \vslices, \bitfieldsp)) \typearrow \\
@@ -586,10 +590,14 @@ One of the following applies:
 \inferrule[scaled]{
   \reducetozopt(\tenv, \veone) \typearrow \langle\vx\rangle \terminateas\None\\\\
   \reducetozopt(\tenv, \vetwo) \typearrow \langle\vy\rangle \terminateas\None\\\\
-  \checktrans{\vx > 0}{\BadSlices} \checktransarrow \True \OrTypeError\\\\
+  \checktrans{\vx > 0}{\BadSlices} \checktransarrow \True \OrTypeError
 }{
-  \bitfieldslicetopositions(\tenv, \overname{\SliceStar(\veone, \vetwo)}{\vslice}) \typearrow
+  {
+  \begin{array}{r}
+  \bitfieldslicetopositions(\tenv, \overname{\SliceStar(\veone, \vetwo)}{\vslice}) \typearrow \\
   \overname{\langle\{n \;|\; \vx \times \vy \leq n \leq \vx \times (\vy + 1) - 1\}\rangle}{\positions}
+  \end{array}
+  }
 }
 \end{mathpar}
 

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -273,7 +273,7 @@ and an empty list if there are none.
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[simple\_typed]{
+\inferrule[simple\_type]{
   \astlabel(\vbf) \neq \BitFieldNested
 }{
   \bitfieldgetname(\vbf) \typearrow \emptylist
@@ -557,7 +557,7 @@ if they can be statically evaluated, or $\None$ if they cannot be statically eva
 \end{itemize}
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[single\_static]{
+\inferrule[single]{
   \reducetozopt(\tenv, \ve) \typearrow \langle\vx\rangle \terminateas\None
 }{
   \bitfieldslicetopositions(\tenv, \overname{\SliceSingle(\ve)}{\vslice}) \typearrow \overname{\langle\{\vx\}\rangle}{\positions}

--- a/asllib/doc/BlockStatements.tex
+++ b/asllib/doc/BlockStatements.tex
@@ -46,7 +46,7 @@ is in scope from the point immediately after its declaration until the end of th
 immediately enclosing block. This means, we can discard the environment at the end of
 an enclosing block, which has the effect of dropping bindings of the identifiers declared inside the block.
 
-\lrmcomment{This is related to \identr{JBXQ}.}
+\identr{JBXQ}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Semantics\label{sec:BlockStatementsSemantics}}

--- a/asllib/doc/BlockStatements.tex
+++ b/asllib/doc/BlockStatements.tex
@@ -25,7 +25,7 @@ statement $\newstmt$ and inferred \sideeffectsetterm\ $\vses$.
 
 \TypingRuleDef{Block}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item annotating the statement $\vs$ in $\tenv$ yields $(\newstmt, \newtenv, \vses)$\ProseOrTypeError;
   \item the modified environment $\newtenv$ is dropped.
@@ -65,7 +65,7 @@ which drops back to the original local environment of $\env$ when the evaluation
 
 \SemanticsRuleDef{Block}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
     \item evaluating $\stm$ in $\env$, as per \chapref{Statements},
     is $\Continuing(\newg, \envone)$\ProseTerminateAs{\ReturningConfig};

--- a/asllib/doc/BlockStatements.tex
+++ b/asllib/doc/BlockStatements.tex
@@ -1,7 +1,7 @@
 \chapter{Block Statements\label{chap:BlockStatements}}
 Block statements are statements executing in their own scope within the scope of their enclosing subprogram.
 
-\subsubsection{Example}
+\ExampleDef{Block Statements}
 In \listingref{block},
 the conditional statement \verb|if TRUE then ... end;| defines a
 block structure. Thus, the scope of the declaration \texttt{let y = 2;} is
@@ -24,6 +24,7 @@ statement $\newstmt$ and inferred \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \TypingRuleDef{Block}
+See \ExampleRef{Block Statements}.
 \ProseParagraph
 \AllApply
 \begin{itemize}

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -363,7 +363,6 @@ The specification in \listingref{semantics-nothrow} prints \texttt{No exception 
 \ASLListing{A \texttt{try} statement that does not raise an exception}{semantics-nothrow}{\semanticstests/SemanticsRule.CatchNoThrow.asl}
 
 \ProseParagraph
-\OneApplies
 \AllApply
 \begin{itemize}
 \item $\sm$ is either $\Throwing((\None, \sg), \envthrow)$ (that is, an implicit throw) or

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -119,9 +119,9 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \section{Typing}
 \TypingRuleDef{Catcher}
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item the catcher has no named identifier, that is, $\vc$ is $(\overname{\None}{\nameopt}, \tty, \vstmt)$;
     \item annotating the type $\tty$ in $\tenv$ yields $(\ttyp, \vsesty)$\ProseOrTypeError;
@@ -130,7 +130,7 @@ One of the following applies:
     \item \Proseeqdef{$\newcatcher$}{$(\overname{\None}{\nameopt}, \ttyp, \newstmt)$};
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item the catcher has a named identifier, that is, $\vc$ is $(\langle\name\rangle, \tty, \vstmt)$;
     \item annotating the type $\tty$ in $\tenv$ yields $(\ttyp, \vsesty)$\ProseOrTypeError;
@@ -365,7 +365,7 @@ The specification in \listingref{semantics-nothrow} prints \texttt{No exception 
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item One of the following holds:
+  \item \OneApplies
   \begin{itemize}
     \item (\textsc{implicit\_throw}) $\sm$ is $\Throwing((\None, \sg), \envthrow)$ (that is, an implicit throw);
     \item (\textsc{non\_throwing}) $\sm$ is a normal configuration (that is, the domain of $\sm$ is $\Normal$);
@@ -402,15 +402,15 @@ returns the first catcher clause in $\catchers$ that matches the type $\vvty$ (a
 by invoking $\typesat$ with the static environment $\tenv$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\catchers$ is an empty list;
     \item the result is $\None$.
   \end{itemize}
 
-  \item \AllApplyCase{match}:
+  \item \AllApplyCase{match}
   \begin{itemize}
     \item $\catchers$ has $\vc$ as its head and $\catchersone$ as its tail;
     \item $\vc$ consists of $(\nameopt, \ety, \vs)$;
@@ -418,7 +418,7 @@ One of the following applies:
     \item the result is the singleton set for $\vc$.
   \end{itemize}
 
-  \item \AllApplyCase{no\_match}:
+  \item \AllApplyCase{no\_match}
   \begin{itemize}
     \item $\catchers$ has $\vc$ as its head and $\catchersone$ as its tail;
     \item $\vc$ consists of $(\nameopt, \ety, \vs)$;
@@ -479,15 +479,15 @@ Implicit throwing configurations are changed by substituting the optional $\valu
 pair with $\vv$ and $\vvty$, respectively.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{implicit\_throwing}:
+  \item \AllApplyCase{implicit\_throwing}
   \begin{itemize}
     \item $\vres$ is $\Throwing((\None, \vg), \envthrowone)$, which is an implicit throwing configuration;
     \item the result is $\Throwing((\langle(\vv, \vvty)\rangle, \vg), \envthrowone)$.
   \end{itemize}
 
-  \item \AllApplyCase{explicit\_throwing}:
+  \item \AllApplyCase{explicit\_throwing}
   \begin{itemize}
     \item $\vres$ is $\Throwing(\langle(\vv', \vvty')\rangle, \vg)$, which is an explicit throwing configuration
     (due to $(\vv', \vvty')$);
@@ -495,7 +495,7 @@ One of the following applies:
     That is, the same throwing configuration is returned.
   \end{itemize}
 
-  \item \AllApplyCase{non\_throwing}:
+  \item \AllApplyCase{non\_throwing}
   \begin{itemize}
     \item the configuration, $C$, domain is non-throwing;
     \item the result is $C$.

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -121,7 +121,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item the catcher has no named identifier, that is, $\vc$ is $(\overname{\None}{\nameopt}, \tty, \vstmt)$;
     \item annotating the type $\tty$ in $\tenv$ yields $(\ttyp, \vsesty)$\ProseOrTypeError;
@@ -130,7 +130,7 @@ One of the following applies:
     \item \Proseeqdef{$\newcatcher$}{$(\overname{\None}{\nameopt}, \ttyp, \newstmt)$};
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item the catcher has a named identifier, that is, $\vc$ is $(\langle\name\rangle, \tty, \vstmt)$;
     \item annotating the type $\tty$ in $\tenv$ yields $(\ttyp, \vsesty)$\ProseOrTypeError;
@@ -209,7 +209,7 @@ That is, no dynamic error occurs.
 \ASLListing{Catching an exception}{semantics-catch}{\semanticstests/SemanticsRule.Catch.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\sm$ is $\Throwing((\langle \valuereadfrom(\vv, \eid), \vvty \rangle, \sg), \envthrow)$;
   \item $\env$ consists of the static environment $\tenv$ and dynamic environment $\denv$;
@@ -246,7 +246,7 @@ The specification in \listingref{semantics-catchnamed}, prints \texttt{My except
 \ASLListing{Catching a named exception}{semantics-catchnamed}{\semanticstests/SemanticsRule.CatchNamed.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\sm$ is $\Throwing((\langle \valuereadfrom(\vv, \eid), \vvty \rangle, \sg), \envthrow)$;
   \item $\env$ consists of the static environment $\tenv$ and dynamic environment $\denv$;
@@ -294,7 +294,7 @@ The specification in \listingref{semantics-catchotherwise} prints \texttt{Otherw
 \ASLListing{Catching an exception with \texttt{otherwise}}{semantics-catchotherwise}{\semanticstests/SemanticsRule.CatchOtherwise.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\sm$ is $\Throwing((\langle \valuereadfrom(\vv, \eid), \vvty \rangle, \sg), \envthrow)$;
   \item $\env$ consists of the static environment $\tenv$ and dynamic environment $\denv$;
@@ -335,7 +335,7 @@ that matches the exception type (\texttt{MyExceptionType1}).
 \ASLListing{A catch clause that does not match a thrown exception type}{semantics-catchnone}{\semanticstests/SemanticsRule.CatchNone.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\sm$ is $\Throwing((\langle \valuereadfrom(\vv, \eid), \vvty \rangle, \sg), \envthrow)$;
   \item $\env$ consists of the static environment $\tenv$ and dynamic environment $\denv$;
@@ -363,7 +363,7 @@ The specification in \listingref{semantics-nothrow} prints \texttt{No exception 
 \ASLListing{A \texttt{try} statement that does not raise an exception}{semantics-nothrow}{\semanticstests/SemanticsRule.CatchNoThrow.asl}
 
 \ProseParagraph
-all of the following apply:
+\AllApply
 \begin{itemize}
   \item One of the following holds:
   \begin{itemize}
@@ -404,13 +404,13 @@ by invoking $\typesat$ with the static environment $\tenv$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\catchers$ is an empty list;
     \item the result is $\None$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{match}):
+  \item \AllApplyCase{match}:
   \begin{itemize}
     \item $\catchers$ has $\vc$ as its head and $\catchersone$ as its tail;
     \item $\vc$ consists of $(\nameopt, \ety, \vs)$;
@@ -418,7 +418,7 @@ One of the following applies:
     \item the result is the singleton set for $\vc$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{no\_match}):
+  \item \AllApplyCase{no\_match}:
   \begin{itemize}
     \item $\catchers$ has $\vc$ as its head and $\catchersone$ as its tail;
     \item $\vc$ consists of $(\nameopt, \ety, \vs)$;
@@ -481,13 +481,13 @@ pair with $\vv$ and $\vvty$, respectively.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{implicit\_throwing}):
+  \item \AllApplyCase{implicit\_throwing}:
   \begin{itemize}
     \item $\vres$ is $\Throwing((\None, \vg), \envthrowone)$, which is an implicit throwing configuration;
     \item the result is $\Throwing((\langle(\vv, \vvty)\rangle, \vg), \envthrowone)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{explicit\_throwing}):
+  \item \AllApplyCase{explicit\_throwing}:
   \begin{itemize}
     \item $\vres$ is $\Throwing(\langle(\vv', \vvty')\rangle, \vg)$, which is an explicit throwing configuration
     (due to $(\vv', \vvty')$);
@@ -495,7 +495,7 @@ One of the following applies:
     That is, the same throwing configuration is returned.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_throwing}):
+  \item \AllApplyCase{non\_throwing}:
   \begin{itemize}
     \item the configuration, $C$, domain is non-throwing;
     \item the result is $C$.

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -23,7 +23,7 @@ The result is the \sideeffectsetterm\ $\vsesfiltered$, the annotated catcher $\n
 
 The semantic relation for evaluating catchers employs an argument
 that is an output configuration. This argument corresponds to the result
-of evaluating a \texttt{try} statement and its type is defined as follows:
+of evaluating a \trystatementterm{} and its type is defined as follows:
 \hypertarget{def-toutconfig}{}
 \[
   \TOutConfig \triangleq \TNormal \cup  \TThrowing \cup \TContinuing \cup \TReturning \enspace.
@@ -43,9 +43,9 @@ The relation
     \end{array}
   \right)
 \]
-evaluates a list of \texttt{catch} clauses $\catchers$, an \texttt{otherwise} clause,
+evaluates a list of \texttt{catch} clauses $\catchers$, an optional \texttt{otherwise} clause,
 and a configuration $\sm$ resulting from the evaluation of the throwing expression,
-in the environment $\env$. The result is either a continuation configuration,
+in the environment $\env$. The result --- $\smnew$ --- is either a continuation configuration,
 an early return configuration, or an abnormal configuration.
 
 When the statement in a \texttt{try} block, which we will refer to as the try-block statement,
@@ -363,28 +363,18 @@ The specification in \listingref{semantics-nothrow} prints \texttt{No exception 
 \ASLListing{A \texttt{try} statement that does not raise an exception}{semantics-nothrow}{\semanticstests/SemanticsRule.CatchNoThrow.asl}
 
 \ProseParagraph
+\OneApplies
 \AllApply
 \begin{itemize}
-  \item \OneApplies
-  \begin{itemize}
-    \item (\textsc{implicit\_throw}) $\sm$ is $\Throwing((\None, \sg), \envthrow)$ (that is, an implicit throw);
-    \item (\textsc{non\_throwing}) $\sm$ is a normal configuration (that is, the domain of $\sm$ is $\Normal$);
-  \end{itemize}
-  \item the result is $\sm$.
+\item $\sm$ is either $\Throwing((\None, \sg), \envthrow)$ (that is, an implicit throw) or
+    $\sm$ is a normal configuration (that is, the domain of $\sm$ is $\Normal$);
+\item \Proseeqdef{$\smnew$}{$\sm$}.
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[implicit\_throw]{
-  \sm \eqname \Throwing((\None, \sg), \envthrow)
-}{
-  \evalcatchers{\env, \catchers, \Ignore, \sm} \evalarrow \sm
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[non\_throwing]{
-  \configdomain{\sm} = \Normal
+\inferrule{
+  \sm = \Throwing((\None, \sg), \envthrow) \lor \configdomain{\sm} = \Normal
 }{
   \evalcatchers{\env, \catchers, \Ignore, \sm} \evalarrow \sm
 }

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -167,7 +167,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 \CodeSubsection{\CatcherNoneBegin}{\CatcherNoneEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{SDJK}.}
+\identr{SDJK}
 
 \begin{mathpar}
 \inferrule[some]{
@@ -199,7 +199,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 % let ses = SES.union ses_block ses_ty in
 
 \CodeSubsection{\CatcherBegin}{\CatcherEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{SDJK}, \identr{WVXS}, \identi{FCGK}.}
+\identr{SDJK} \identr{WVXS} \identi{FCGK}
 
 \section{Semantics}
 \SemanticsRuleDef{Catch}
@@ -447,7 +447,7 @@ by invoking $\typesat$ with the static environment $\tenv$.
 \CodeSubsection{\EvalFindCatcherBegin}{\EvalFindCatcherEnd}{../Interpreter.ml}
 
 \subsubsection{Comments}
-\lrmcomment{This is related to \identr{SPNM}:}
+\identr{SPNM}
 When the \texttt{catch} of a \texttt{try} statement is executed, then the
 thrown exception is caught by the first catcher in that \texttt{catch} which it
 type-satisfies or the \texttt{otherwise\_opt} in that catch if it exists.
@@ -518,6 +518,6 @@ pair with $\vv$ and $\vvty$, respectively.
 \CodeSubsection{\EvalRethrowImplicitBegin}{\EvalRethrowImplicitEnd}{../Interpreter.ml}
 
 \subsubsection{Comments}
-\lrmcomment{This is related to \identr{GVKS}:}
+\identr{GVKS}
 An expressionless \texttt{throw} statement causes the exception which the
 currently executing catcher caught to be thrown.

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -203,7 +203,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \section{Semantics}
 \SemanticsRuleDef{Catch}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Catch}
 The specification in \listingref{semantics-catch} terminates successfully.
 That is, no dynamic error occurs.
 \ASLListing{Catching an exception}{semantics-catch}{\semanticstests/SemanticsRule.Catch.asl}
@@ -241,7 +241,7 @@ That is, no dynamic error occurs.
 \CodeSubsection{\EvalCatchBegin}{\EvalCatchEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{CatchNamed}
-\subsubsection{Example}
+\ExampleDef{Catching a Named Exception}
 The specification in \listingref{semantics-catchnamed}, prints \texttt{My exception with my message}.
 \ASLListing{Catching a named exception}{semantics-catchnamed}{\semanticstests/SemanticsRule.CatchNamed.asl}
 
@@ -289,7 +289,7 @@ The specification in \listingref{semantics-catchnamed}, prints \texttt{My except
 \CodeSubsection{\EvalCatchNamedBegin}{\EvalCatchNamedEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{CatchOtherwise}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Catch with an Otherwise}
 The specification in \listingref{semantics-catchotherwise} prints \texttt{Otherwise}.
 \ASLListing{Catching an exception with \texttt{otherwise}}{semantics-catchotherwise}{\semanticstests/SemanticsRule.CatchOtherwise.asl}
 
@@ -328,7 +328,7 @@ The specification in \listingref{semantics-catchotherwise} prints \texttt{Otherw
 \CodeSubsection{\EvalCatchOtherwiseBegin}{\EvalCatchOtherwiseEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{CatchNone}
-\subsubsection{Example}
+\ExampleDef{Evaluation of an Uncaught Exception}
 The specification in \listingref{semantics-catchnone} does not print anything.
 It shows how a \texttt{try} statement (the inner one) may not have a \texttt{catch} clause
 that matches the exception type (\texttt{MyExceptionType1}).
@@ -358,7 +358,7 @@ that matches the exception type (\texttt{MyExceptionType1}).
 \CodeSubsection{\EvalCatchNoneBegin}{\EvalCatchNoneEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{CatchNoThrow}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Try Statement that Does Not Raise an Exception}
 The specification in \listingref{semantics-nothrow} prints \texttt{No exception raised}.
 \ASLListing{A \texttt{try} statement that does not raise an exception}{semantics-nothrow}{\semanticstests/SemanticsRule.CatchNoThrow.asl}
 

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -11,7 +11,24 @@ including when these errors must be detected and reported to users.
 
 \RequirementDef{StaticErrorCheck} Implementations should detect and report \staticerrorsterm.
 Specifically, \staticerrorsterm{} must never cause a \dynamicerrorterm{} or
+Specifically, \staticerrorsterm{} must never cause a \dynamicerrorterm{} or
 cause an exception to be raised.
+%
+\secref{ExampleInterpreter} shows how an interpreter detects \builderrorsterm{}
+and \typingerrorsterm{}.
+%
+\listingref{typing-error-reporting} shows a specification containing a typing error,
+followed by an example of a report from \aslref{} in a \linuxbashshell.
+
+\ASLListing{A specification resulting in a typing error}{typing-error-reporting}{\definitiontests/TypingErrorReporting.asl}
+% CONSOLE_BEGIN CONSOLE_STDERR aslref \definitiontests/TypingErrorReporting.asl
+\begin{Verbatim}[fontsize=\footnotesize, frame=single]
+File ../tests/ASLDefinition.t/TypingErrorReporting.asl, line 3,
+  characters 11 to 22:
+ASL Typing error: Illegal application of operator + on types integer {5}
+  and string.
+\end{Verbatim}
+% CONSOLE_END
 %
 \secref{ExampleInterpreter} shows how an interpreter detects \builderrorsterm{}
 and \typingerrorsterm{}.

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -279,7 +279,7 @@ The following table summarises all error codes.
     \item Expected integer types in \texttt{for}-loop bounds (\TypingRuleRef{SForConstraints}).
     \item Expected a bitvector (\TypingRuleRef{ApplyBinopTypes}).
     \item Expected a structured type (\TypingRuleRef{ERecord}).
-    \item Expected a tuple type of a specific length (\TypingRuleRef{LEDestructuring}).
+    \item Expected a \tupletypeterm{} of a specific length (\TypingRuleRef{LEDestructuring}).
     \item Expected a printable type (\TypingRuleRef{SPrint}).
     \item Encountered a forbidden \pendingconstrainedintegertype{} (\TypingRuleRef{TInt}).
     \item An anonymous enumeration or \structuredtype{} was used as a type annotation outside of a type declaration (\TypingRuleRef{TNonDecl}).

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -11,7 +11,6 @@ including when these errors must be detected and reported to users.
 
 \RequirementDef{StaticErrorCheck} Implementations should detect and report \staticerrorsterm.
 Specifically, \staticerrorsterm{} must never cause a \dynamicerrorterm{} or
-Specifically, \staticerrorsterm{} must never cause a \dynamicerrorterm{} or
 cause an exception to be raised.
 %
 \secref{ExampleInterpreter} shows how an interpreter detects \builderrorsterm{}

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -29,22 +29,6 @@ ASL Typing error: Illegal application of operator + on types integer {5}
   and string.
 \end{Verbatim}
 % CONSOLE_END
-%
-\secref{ExampleInterpreter} shows how an interpreter detects \builderrorsterm{}
-and \typingerrorsterm{}.
-%
-\listingref{typing-error-reporting} shows a specification containing a typing error,
-followed by an example of a report from \aslref{} in a \linuxbashshell.
-
-\ASLListing{A specification resulting in a typing error}{typing-error-reporting}{\definitiontests/TypingErrorReporting.asl}
-% CONSOLE_BEGIN CONSOLE_STDERR aslref \definitiontests/TypingErrorReporting.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-File ../tests/ASLDefinition.t/TypingErrorReporting.asl, line 3,
-  characters 11 to 22:
-ASL Typing error: Illegal application of operator + on types integer {5}
-  and string.
-\end{Verbatim}
-% CONSOLE_END
 
 \RequirementDef{DynamicErrorBehavior} The behaviour of an implementation when a \dynamicerrorterm{}
 occurs is implementation defined, including, but not limited to,

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -44,12 +44,9 @@ The relation
             \Normal((\overname{\vals}{\vv} \times \overname{\XGraphs}{\vg}) \aslsep \overname{\envs}{\newenv}) \cup
             \overname{\TThrowing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
 \]
-evaluates the expression $\ve$ in an environment $\env$ and one of the following applies:
-\begin{itemize}
-  \item the evaluation terminates normally, returning a \nativevalue\  $\vv$, a concurrent execution graph $\vg$,
-  and a modified environment $\newenv$;
-  \item the evaluation terminates abnormally.
-\end{itemize}
+evaluates the expression $\ve$ in an environment $\env$ and terminates normally with
+a \nativevalue{} $\vv$, an \executiongraph{} $\vg$, and a modified environment $\newenv$.
+Otherwise, the evaluation terminates abnormally.
 
 \section{Evaluation Order}
 It is an error for an expression’s meaning to rely on evaluation order except that conditional expressions, and uses
@@ -195,9 +192,9 @@ A variable expression consists of an identifier for a storage element.
 \AllApply
 \begin{itemize}
   \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{local\_constant}:
+    \item \AllApplyCase{local\_constant}
     \begin{itemize}
     \item $\vx$ is bound to the type $\vt$ and local declaration keyword $\LDKConstant$
           via the $\localstoragetypes$ map of the local environment component of $\tenv$;
@@ -206,7 +203,7 @@ A variable expression consists of an identifier for a storage element.
     \item define $\vses$ as the empty set.
     \end{itemize}
 
-    \item \AllApplyCase{local\_non\_constant}:
+    \item \AllApplyCase{local\_non\_constant}
     \begin{itemize}
     \item $\vx$ is bound to the type $\vt$ and local declaration keyword $k$
           via the \\
@@ -219,7 +216,7 @@ A variable expression consists of an identifier for a storage element.
           $k$ ($\timeframeofldk$) and the immutability status of $k$ ($\ldkisimmutable$).
     \end{itemize}
 
-    \item \AllApplyCase{global\_constant}:
+    \item \AllApplyCase{global\_constant}
     \begin{itemize}
     \item $\vx$ is not bound via the $\localstoragetypes$ map of the local component of $\tenv$;
     \item $\vx$ is bound to $(\tty, \GDKConstant)$ via the $\globalstoragetypes$ map of the global component of $\tenv$;
@@ -228,7 +225,7 @@ A variable expression consists of an identifier for a storage element.
     \item define $\vses$ as the empty set.
     \end{itemize}
 
-    \item \AllApplyCase{global\_non\_constant}:
+    \item \AllApplyCase{global\_non\_constant}
     \begin{itemize}
       \item $\vx$ is not bound via the $\localstoragetypes$ map of the local component of $\tenv$;
       \item $\vx$ is bound to $(\tty, k)$ via the $\globalstoragetypes$ map of the global component of $\tenv$;
@@ -238,7 +235,7 @@ A variable expression consists of an identifier for a storage element.
             $k$ ($\timeframeofgdk$) and the immutability status of $k$ ($\gdkisimmutable$).
     \end{itemize}
 
-    \item \AllApplyCase{error\_undefined}:
+    \item \AllApplyCase{error\_undefined}
     \begin{itemize}
       \item $\vx$ is not bound via the $\localstoragetypes$ map of the local component of $\tenv$;
       \item $\vx$ is not bound via the $\globalstoragetypes$ map of the local component of $\tenv$;
@@ -309,15 +306,15 @@ function calls) to global constant variables.
 \begin{itemize}
   \item $\ve$ denotes a variable expression, that is, $\EVar(\vx)$;
   \item view $\env$ as an environment where $\denv$ is the dynamic environment;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{local}:
+    \item \AllApplyCase{local}
     \begin{itemize}
       \item $\vx$ is bound locally in $\env$;
       \item $\vv$ is the value of $\vx$ in the local component of $\env$;
     \end{itemize}
 
-    \item \AllApplyCase{global}:
+    \item \AllApplyCase{global}
     \begin{itemize}
       \item $\vx$ is bound in the storage map of $\denv$;
       \item $\vv$ is the value of $\vx$ in the global component of $\env$;
@@ -456,15 +453,15 @@ same precedence ($3$). To fix this, we can surround one of the subexpressions wi
 for example: \texttt{(a + b) - c}.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{not\_binop}:
+  \item \AllApplyCase{not\_binop}
   \begin{itemize}
     \item $\ve$ is not a binary operation expression;
     \item the result is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{binop}:
+  \item \AllApplyCase{binop}
   \begin{itemize}
     \item $\ve$ is a binary operation expression for the operator $\opp$;
     \item checking whether $\op$ is different from $\opp$ implies that $\op$ and $\opp$ have different precedence levels
@@ -505,15 +502,15 @@ the expression \texttt{3 DIV 0} results in a type error.
   \item \Proseannotateexpr{$\tenv$}{$\vetwo$}{\\ $(\vttwo, \vetwop, \vsestwo)$\ProseOrTypeError};
   \item \Proseapplybinoptypes{$\tenv$}{\op}{\vtone}{\vttwo}{$\vt$\ProseOrTypeError};
   \item define $\newe$ as the binary expression $\op$ over $\veonep$ and $\vetwop$;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{ordered}:
+    \item \AllApplyCase{ordered}
     \begin{itemize}
       \item $\op$ is one of $\BAND$, $\BOR$, or $\IMPL$;
       \item define $\vses$ as the union of $\vsesone$ and $\vsestwo$.
     \end{itemize}
 
-    \item \AllApplyCase{unordered}:
+    \item \AllApplyCase{unordered}
     \begin{itemize}
       \item $\op$ is not one of $\BAND$, $\BOR$, or $\IMPL$;
       \item \Prosenonconflictingunion{consisting of $\vsesone$ and $\vsestwo$}{$\vses$}.
@@ -1176,15 +1173,15 @@ subprogram \texttt{Return42()} is implemented to return the value \texttt{42}.
   \item $\ve$ denotes a subprogram call, $\ECall(\vcall)$;
   \item the evaluation of that subprogram call in $\env$ is either
   $\Normal(\vms, \newenv)$\ProseOrAbnormal;
-  \item one of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{single\_returned\_value}:
+    \item \AllApplyCase{single\_returned\_value}
     \begin{itemize}
       \item $\vms$ consists of a single returned value $(\vv,\vg)$,
       which goes into the output configuration $\Normal((\vv, \vg), \newenv)$.
     \end{itemize}
 
-    \item \AllApplyCase{multiple\_returned\_values}:
+    \item \AllApplyCase{multiple\_returned\_values}
     \begin{itemize}
       \item $\vms$ consists of a list of returned value $(\vv_i,\vg_i)$, for $i=1..k$;
       \item $\vg$ is the parallel composition of $\vg_i$, for $i=1..k$;
@@ -1892,9 +1889,9 @@ the expression \verb|my_record.a| evaluates to the value \texttt{3}.
   \item \Proseannotateexpr{$\tenv$}{$\ebase$}{\\ $(\tbaseannot, \vetwo, \vsesbase)$}\ProseOrTypeError;
   \item obtaining the \underlyingtype\ of $\tbaseannot$ in $\tenv$ yields \\
         $\tbaseannotanon$\ProseOrTypeError;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{bits}:
+    \item \AllApplyCase{bits}
     \begin{itemize}
       \item $\tbaseannotanon$ is a bitvector type with list of bitfields $\vbitfields$\ProseOrTypeError;
       \item applying $\findbitfieldsslices$ to each field name $\name$ and list of bitfields $\vbitfields$ in $\vfields$ yields \\
@@ -1903,7 +1900,7 @@ the expression \verb|my_record.a| evaluates to the value \texttt{3}.
       \item \Proseannotateexpr{$\tenv$}{$\veslice$}{\\ $(\vt, \newe, \vses)$}\ProseOrTypeError.
     \end{itemize}
 
-    \item \AllApplyCase{record}:
+    \item \AllApplyCase{record}
     \begin{itemize}
       \item $\tbaseannotanon$ is a record type with list of fields $\vbasefields$\ProseOrTypeError;
       \item applying $\getbitfieldwidth$ to $\vf$ in $\vbasefields$ and $\vbasefields$, for each $\vf$ in $\vbasefields$, in $\tenv$ yields $\ewidth_\vf$\ProseOrTypeError;
@@ -1915,7 +1912,7 @@ the expression \verb|my_record.a| evaluates to the value \texttt{3}.
       \item define $\vses$ as $\vsesbase$.
     \end{itemize}
 
-    \item \AllApplyCase{error}:
+    \item \AllApplyCase{error}
     \begin{itemize}
       \item $\tbaseannotanon$ is neither a bitvector type nor a record type;
       \item the result is a type error indicating an unexpected type.
@@ -1976,23 +1973,23 @@ in $\vslices$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{found}:
+  \item \AllApplyCase{found}
   \begin{itemize}
     \item $\vbitfields$ is a list with \head\ $\vfield$ and \tail\ $\vbitfieldsone$;
     \item applying $\bitfieldgetname$ to $\vfield$ yields $\name$;
     \item applying $\bitfieldgetslices$ to $\vfield$ yields $\vslices$.
   \end{itemize}
 
-  \item \AllApplyCase{tail}:
+  \item \AllApplyCase{tail}
   \begin{itemize}
     \item $\vbitfields$ is a list with \head\ $\vfield$ and \tail\ $\vbitfieldsone$;
     \item applying $\bitfieldgetname$ to $\vfield$ yields $\namep$, which is different to $\name$;
     \item applying $\findbitfieldsslices$ to $\name$ and $vbitfieldsone$ yields $\vslices$\ProseOrTypeError.
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item $\vbitfields$ is an empty list;
     \item the result is a type error indicating that a bitfield named $\name$ does not exist in $\vbitfields$.
@@ -2040,15 +2037,15 @@ in the list of fields $\tfields$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{okay}:
+  \item \AllApplyCase{okay}
   \begin{itemize}
     \item applying $\assocopt$ to find the type associated with $\name$ in $\tfields$ yields the type $\vt$;
     \item applying $\getbitvectorwidth$ to $\vt$ in $\tenv$ yields $\ewidth$.
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item applying $\assocopt$ to find the type associated with $\name$ in $\tfields$ yields $\None$;
     \item the result is a type error indicating that $\name$ is not associated with any field in $\tfields$.
@@ -2086,15 +2083,15 @@ normalized in the static environment $\tenv$.
 \ProseOrTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\exprs$ is an empty list;
     \item $\ewidth$ is the literal expression for $0$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\exprs$ is the list with \head\ $\ve$ and \tail\ $\exprsone$;
     \item applying $\widthplus$ to $\exprsone$ yields $\ewidthone$;
@@ -2254,22 +2251,22 @@ are compatible for a typing assertion in the static environment $\tenv$, yieldin
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{equal}:
+  \item \AllApplyCase{equal}
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\True$\ProseOrTypeError;
     \item the result is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{different\_labels\_error}:
+  \item \AllApplyCase{different\_labels\_error}
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\False$;
     \item the AST labels of $\vtone$ and $\vttwo$ are different;
     \item the result is a type error indicating that the type assertion will always fail.
   \end{itemize}
 
-  \item \AllApplyCase{int\_bits}:
+  \item \AllApplyCase{int\_bits}
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\False$;
     \item the AST labels of $\vtone$ and $\vttwo$ are the same;
@@ -2277,7 +2274,7 @@ One of the following applies:
     \item the result is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{tuple}:
+  \item \AllApplyCase{tuple}
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\False$;
     \item $\vtone$ is a tuple type with list of tuples $\vlone$, that is, $\TTuple(\vlone)$;
@@ -2287,7 +2284,7 @@ One of the following applies:
     \item the result is $\True$;
   \end{itemize}
 
-  \item \AllApplyCase{other\_error}:
+  \item \AllApplyCase{other\_error}
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\False$;
     \item the AST labels of $\vtone$ and $\vttwo$ are the same;
@@ -2371,14 +2368,14 @@ evaluated:
 \item $\ve$ denotes an asserted type conversion expression, $\EATC(\veone, \vt)$;
 \item evaluating $\veone$ in $\env$ results in $\Normal((\vv, \vgone), \newenv)$\ProseOrAbnormal;
 \item evaluating whether $\vv$ has type $\vt$ in $\env$ results in $(\vb, \vgtwo)$\ProseTerminateAs{\DynErrorConfig};
-\item one of the following applies:
+\item \OneApplies
       \begin{itemize}
-      \item \AllApplyCase{okay}:
+      \item \AllApplyCase{okay}
             \begin{itemize}
             \item $\vb$ is the native Boolean for \True;
             \item $\vg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge.
             \end{itemize}
-      \item \AllApplyCase{error}:
+      \item \AllApplyCase{error}
             \begin{itemize}
             \item $\vb$ is the native Boolean for \False;
             \item the result is a dynamic error indicating that the type assertion failed
@@ -2427,9 +2424,9 @@ only returns \False\ in cases where dynamic information is required.
 Recall that the $\vt$ is the result of $\annotatetype$, which ensures that
 all sub-expressions appearing in $\vt$ are side-effect-free.
 
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{type\_equal}:
+  \item \AllApplyCase{type\_equal}
   \begin{itemize}
     \item the AST label of $\vt$ is not $\TInt$, $\TBits$, or $\TTuple$;
     \item $\vb$ is $\True$ (since \TypingRuleRef{ATC}
@@ -2437,14 +2434,14 @@ One of the following applies:
     \item $\vg$ is the empty graph.
   \end{itemize}
 
-  \item \AllApplyCase{int\_unconstrained}:
+  \item \AllApplyCase{int\_unconstrained}
   \begin{itemize}
     \item $\vt$ has the structure of the unconstrained integer;
     \item $\vb$ is \True;
     \item $\vg$ is the empty graph.
   \end{itemize}
 
-  \item \AllApplyCase{int\_wellconstrained}:
+  \item \AllApplyCase{int\_wellconstrained}
   \begin{itemize}
     \item $\vt$ has the structure of a well-constrained integer with constraints $\vc_{1..k}$;
     \item $\vv$ is the \nativevalue\  integer for $n$;
@@ -2454,7 +2451,7 @@ One of the following applies:
     \item $\vg$ is the parallel composition of all execution graphs $\vg_i$, for $i=1..k$;
   \end{itemize}
 
-  \item \AllApplyCase{bits}:
+  \item \AllApplyCase{bits}
   \begin{itemize}
     \item $\vt$ is a bitvector type with expression $\ve$, that is, $\TBits(\ve, \Ignore)$;
     \item $\vv$ is a native bitvector value for the sequence of bits $\vbits$, that is, \\ $\nvbitvector(\vbits)$;
@@ -2462,7 +2459,7 @@ One of the following applies:
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vvp$ is equal to the number of bits in $\vbits$}.
   \end{itemize}
 
-  \item \AllApplyCase{tuple}:
+  \item \AllApplyCase{tuple}
   \begin{itemize}
     \item $\vt$ is a tuple with types $\vt_i$, for $i=1..k$;
     \item the value at every index $i=1..k$ of $\vv$ is $\vu_i$, for $i=1..k$,
@@ -2546,9 +2543,9 @@ and returns a Boolean answer $\vb$ and the execution graph $\vg$ resulting from 
 the expressions appearing in $\vc$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{Constraint\_Exact\_Sat}:
+  \item \AllApplyCase{Constraint\_Exact\_Sat}
   \begin{itemize}
     \item $\vc$ is a constraint for the expression $\ve$;
     \item evaluating the side-effect-free expression $\ve$ in $\env$ yields the \concurrentnativevalue\ given
@@ -2556,7 +2553,7 @@ One of the following applies:
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $m$ is equal to $n$}.
   \end{itemize}
 
-  \item \AllApplyCase{Constraint\_Range\_Sat}:
+  \item \AllApplyCase{Constraint\_Range\_Sat}
   \begin{itemize}
     \item $\vc$ is a constraint for the expressions $\veone$ and $\vetwo$;
     \item evaluating the side-effect-free expression $\veone$ in $\env$ yields the \concurrentnativevalue\ given
@@ -2786,9 +2783,9 @@ and how to obtain an arbitrary enumeration-indexed array, \texttt{enum\_array}.
 \AllApply
 \begin{itemize}
   \item $\ve$ denotes the \texttt{ARBITRARY} expression annotated with type $\vt$;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{okay}:
+    \item \AllApplyCase{okay}
     \begin{itemize}
       \item the domain of $\vt$ in $\env$ (see \secref{DynDomain}) is not empty;
       \item $\vv$ is an arbitrary value in the domain of $\vt$ in $\env$;
@@ -2796,7 +2793,7 @@ and how to obtain an arbitrary enumeration-indexed array, \texttt{enum\_array}.
       \item $\vg$ is the empty execution graph.
     \end{itemize}
 
-    \item \AllApplyCase{error}:
+    \item \AllApplyCase{error}
     \begin{itemize}
       \item the domain of $\vt$ in $\env$ is empty;
       \item the result is a dynamic error (\ArbitraryEmptyType) indicating that the type $\vt$ has an empty
@@ -3042,16 +3039,16 @@ $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
 \subsection{Typing}
 \TypingRuleDef{ETuple}
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{parenthesized}:
+  \item \AllApplyCase{parenthesized}
   \begin{itemize}
     \item $\ve$ denotes a tuple expression with list of expressions consisting solely of $\vep$, that is, $\ETuple([\vep])$,
           meaning it represents a parenthesized expression (see \ASTRuleRef{ParenExpr});
     \item annotating $\vep$ in $\tenv$ yields $(\vt, \newe, \vses)$\ProseOrTypeError.
   \end{itemize}
 
-  \item \AllApplyCase{list}:
+  \item \AllApplyCase{list}
   \begin{itemize}
     \item $\ve$ denotes a tuple expression with list of expressions $\vli$, that is, $ \ETuple(\vli)$;
     \item $\vli$ consists of at least two expressions;

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -845,10 +845,10 @@ order does not affect the result of an expression, including any side-effects.
 
 \subsection{Semantics}
 \SemanticsRuleDef{Unop}
-\ExampleDef{Evaluation of }
+\ExampleDef{Evaluation of a Unary Operation Expression}
 In \listingref{semantics-unopassert},
 the expression \texttt{NOT '1010'} evaluates to the value \texttt{'0101'}.
-\ASLListing{Evaluating a unary expression}{semantics-unopassert}{\semanticstests/SemanticsRule.EUnopAssert.asl}
+\ASLListing{Evaluating a unary operation expression}{semantics-unopassert}{\semanticstests/SemanticsRule.EUnopAssert.asl}
 
 \ProseParagraph
 \AllApply
@@ -2759,7 +2759,7 @@ Note that there are two important consequences of producing an arbitrary value w
 
 \subsection{Semantics}
 \SemanticsRuleDef{EArbitrary}
-\ExampleDef{Evaluation of ARBITRARY for an Uncostrained Integer Type}
+\ExampleDef{Evaluation of ARBITRARY for an Unconstrained Integer Type}
 In \listingref{semantics-earbitraryunconstrained},
 the expression \verb|ARBITRARY : integer| evaluates to an arbitrary integer value.
 \ASLListing{Evaluating an \texttt{ARBITRARY} expression for an unconstrained integer}{semantics-earbitraryunconstrained}
@@ -3256,7 +3256,7 @@ If the evaluation of any expression terminates abnormally then the abnormal conf
   \begin{itemize}
     \item \Proseemptylist{$\vle$};
     \item \Proseemptylist{$\vv$};
-    \item \Proseemptygraph{$\vg$}
+    \item \Proseemptygraph{$\vg$};
     \item \Proseeqdef{$\newenv$}{$\env$}.
   \end{itemize}
 

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -18,7 +18,7 @@ The function
 transforms an expression parse node $\vparsednode$ into an expression AST node $\vastnode$.
 \ProseOtherwiseBuildError
 
-All expressions have a unique type (which can be a tuple type).
+All expressions have a unique type (which can be a \tupletypeterm{}).
 \hypertarget{def-annotateexpr}{}
 The function
 \[
@@ -1518,7 +1518,7 @@ which has indexes \texttt{0}, \texttt{1} and \texttt{2} only.
 \subsubsection{Example}
 In \listingref{semantics-egetenumarray},
 the enumeration-typed array \texttt{Arr} is accessed for reading and writing
-with indices taken from the enumeration type \texttt{Enum}.
+with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \ASLListing{Evaluating an access to an enumeration-indexed array}{semantics-egetenumarray}
 {\semanticstests/SemanticsRule.EGetEnumArray.asl}
 
@@ -1762,7 +1762,7 @@ for its verbatim string.
   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
   \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$\ProseOrTypeError;
-  \item $\vtetwo$ is tuple type with list of types $\tys$, that is, $\TTuple(\tys)$;
+  \item $\vtetwo$ is \tupletypeterm{} with list of types $\tys$, that is, $\TTuple(\tys)$;
   \item $\fieldname$ is an identifier consisting of the prefix \itemprefix{} and the suffix $\num$;
   \item $\num$ is lexically an integer token with the integer value $\vindex$;
   \item determining whether $\vindex$ is between $0$ and the number of types in $\tys$, inclusive, yields $\True$\ProseOrTypeError;
@@ -2281,8 +2281,8 @@ are compatible for a typing assertion in the static environment $\tenv$, yieldin
   \item \AllApplyCase{tuple}
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\False$;
-    \item $\vtone$ is a tuple type with list of tuples $\vlone$, that is, $\TTuple(\vlone)$;
-    \item $\vtone$ is a tuple type with list of tuples $\vltwo$, that is, $\TTuple(\vltwo)$;
+    \item $\vtone$ is a \tupletypeterm{} with list of tuples $\vlone$, that is, $\TTuple(\vlone)$;
+    \item $\vtone$ is a \tupletypeterm{} with list of tuples $\vltwo$, that is, $\TTuple(\vltwo)$;
     \item checking whether $\vlone$ and $\vltwo$ have the same length yields $\True$\ProseTerminateAs{\TypeAssertionFailure};
     \item applying $\checkatc$ to $\vlone[\vi]$ and $\vltwo[\vi]$ in $\tenv$ for every $\vi\in\listrange(\vlone)$ yields $\True$\ProseOrTypeError;
     \item the result is $\True$;
@@ -3057,7 +3057,7 @@ $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
     \item $\ve$ denotes a tuple expression with list of expressions $\vli$, that is, $ \ETuple(\vli)$;
     \item $\vli$ consists of at least two expressions;
     \item annotating each expression $\vle[i]$ in $\tenv$, for $i=1..k$, yields $(\vt_i, \ve_i, \vxs_i$)\ProseOrTypeError;
-    \item $\vt$ is the tuple type with list of types $\vt_i$, for $i=1..k$;
+    \item $\vt$ is the \tupletypeterm{} with list of types $\vt_i$, for $i=1..k$;
     \item $\newe$ is tuple expression over list of expressions $\ve_i$, for $i=1..k$;
     \item \Prosenonconflictingunion{consisting of $\vxs_i$, for $i=1..k$,}{$\vses$}\ProseOrTypeError.
   \end{itemize}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -127,7 +127,7 @@ A literal expression represents a literal as an expression.
 \subsection{Typing}
 \TypingRuleDef{ELit}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\ve$ is the literal expression $\vv$;
 \item $\vt$ is the type of the literal $\vv$;
@@ -152,7 +152,7 @@ In \listingref{literalssemantics}, each of the expressions \texttt{3} evaluates 
 
 \SemanticsRuleDef{ELit}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\ve$ is the literal expression for $\vl$, that is, $\ELiteral(\vl)$
 \item $\vv$ is the \nativevalue\ corresponding to $\vl$;
@@ -192,12 +192,12 @@ A variable expression consists of an identifier for a storage element.
 \subsection{Typing}
 \TypingRuleDef{EVar}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{local\_constant}):
+    \item \AllApplyCase{local\_constant}:
     \begin{itemize}
     \item $\vx$ is bound to the type $\vt$ and local declaration keyword $\LDKConstant$
           via the $\localstoragetypes$ map of the local environment component of $\tenv$;
@@ -206,7 +206,7 @@ All of the following apply:
     \item define $\vses$ as the empty set.
     \end{itemize}
 
-    \item All of the following apply (\textsc{local\_non\_constant}):
+    \item \AllApplyCase{local\_non\_constant}:
     \begin{itemize}
     \item $\vx$ is bound to the type $\vt$ and local declaration keyword $k$
           via the \\
@@ -219,7 +219,7 @@ All of the following apply:
           $k$ ($\timeframeofldk$) and the immutability status of $k$ ($\ldkisimmutable$).
     \end{itemize}
 
-    \item All of the following apply (\textsc{global\_constant}):
+    \item \AllApplyCase{global\_constant}:
     \begin{itemize}
     \item $\vx$ is not bound via the $\localstoragetypes$ map of the local component of $\tenv$;
     \item $\vx$ is bound to $(\tty, \GDKConstant)$ via the $\globalstoragetypes$ map of the global component of $\tenv$;
@@ -228,7 +228,7 @@ All of the following apply:
     \item define $\vses$ as the empty set.
     \end{itemize}
 
-    \item All of the following apply (\textsc{global\_non\_constant}):
+    \item \AllApplyCase{global\_non\_constant}:
     \begin{itemize}
       \item $\vx$ is not bound via the $\localstoragetypes$ map of the local component of $\tenv$;
       \item $\vx$ is bound to $(\tty, k)$ via the $\globalstoragetypes$ map of the global component of $\tenv$;
@@ -238,7 +238,7 @@ All of the following apply:
             $k$ ($\timeframeofgdk$) and the immutability status of $k$ ($\gdkisimmutable$).
     \end{itemize}
 
-    \item All of the following apply (\textsc{error\_undefined}):
+    \item \AllApplyCase{error\_undefined}:
     \begin{itemize}
       \item $\vx$ is not bound via the $\localstoragetypes$ map of the local component of $\tenv$;
       \item $\vx$ is not bound via the $\globalstoragetypes$ map of the local component of $\tenv$;
@@ -305,19 +305,19 @@ function calls) to global constant variables.
 \subsection{Semantics}
 \SemanticsRuleDef{EVar}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a variable expression, that is, $\EVar(\vx)$;
   \item view $\env$ as an environment where $\denv$ is the dynamic environment;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{local}):
+    \item \AllApplyCase{local}:
     \begin{itemize}
       \item $\vx$ is bound locally in $\env$;
       \item $\vv$ is the value of $\vx$ in the local component of $\env$;
     \end{itemize}
 
-    \item All of the following apply (\textsc{global}):
+    \item \AllApplyCase{global}:
     \begin{itemize}
       \item $\vx$ is bound in the storage map of $\denv$;
       \item $\vv$ is the value of $\vx$ in the global component of $\env$;
@@ -458,13 +458,13 @@ for example: \texttt{(a + b) - c}.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{not\_binop}):
+  \item \AllApplyCase{not\_binop}:
   \begin{itemize}
     \item $\ve$ is not a binary operation expression;
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{binop}):
+  \item \AllApplyCase{binop}:
   \begin{itemize}
     \item $\ve$ is a binary operation expression for the operator $\opp$;
     \item checking whether $\op$ is different from $\opp$ implies that $\op$ and $\opp$ have different precedence levels
@@ -498,7 +498,7 @@ the expression \texttt{3 DIV 0} results in a type error.
 {\semanticstests/SemanticsRule.EBinopDIVBackendDefinedError.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a binary operation $\op$ over two expressions $\veone$ and $\vetwo$, that is, \\ $\EBinop(\op, \veone, \vetwo)$;
   \item \Proseannotateexpr{$\tenv$}{$\veone$}{\\ $(\vtone, \veonep, \vsesone)$\ProseOrTypeError};
@@ -507,13 +507,13 @@ All of the following apply:
   \item define $\newe$ as the binary expression $\op$ over $\veonep$ and $\vetwop$;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following applies (\textsc{ordered}):
+    \item \AllApplyCase{ordered}:
     \begin{itemize}
       \item $\op$ is one of $\BAND$, $\BOR$, or $\IMPL$;
       \item define $\vses$ as the union of $\vsesone$ and $\vsestwo$.
     \end{itemize}
 
-    \item All of the following applies (\textsc{unordered}):
+    \item \AllApplyCase{unordered}:
     \begin{itemize}
       \item $\op$ is not one of $\BAND$, $\BOR$, or $\IMPL$;
       \item \Prosenonconflictingunion{consisting of $\vsesone$ and $\vsestwo$}{$\vses$}.
@@ -556,7 +556,7 @@ the expression \texttt{FALSE \&\& fail()} evaluates to the value \texttt{FALSE}.
 \ASLListing{Semantics of conjunction}{andsemantics}{\semanticstests/SemanticsRule.EBinopAndFalse.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\ve$ denotes a conjunction over two expressions,
       $\EBinop(\BAND, \veone, \vetwo)$;
@@ -617,7 +617,7 @@ In \listingref{semantics-binopor}, the expression \texttt{(0 == 1) || (1 == 1)} 
 \ASLListing{Evaluating a disjunction expression}{semantics-binopor}{\semanticstests/SemanticsRule.EBinopOrTrue.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\ve$ denotes a disjunction of two expressions, $\EBinop(\BOR, \veone, \vetwo)$;
 \item $C$ is the result of the evaluation of
@@ -679,7 +679,7 @@ the expression \texttt{(0 == 1) --> (1 == 0)} evaluates to the value \True, acco
 \ASLListing{Evaluating an implication expression}{semantics-binopimpl}{\semanticstests/SemanticsRule.EBinopImplExFalso.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes an implication over two expressions, $\EBinop(\IMPL, \veone, \vetwo)$;
   \item $\ve$ is evaluated as \texttt{if e1 then e2 else true}.
@@ -721,7 +721,7 @@ an if-statement is used to achieve the same effect.
 \hypertarget{def-binopexpressionterm}{}
 \SemanticsRuleDef{Binop}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a Binary Operator $\op$ over two expressions, $\EBinop(\op, \veone, \vetwo)$;
   \item the operator $\op$ is not one of $\BAND$, $\BOR$, or $\IMPL$.
@@ -830,7 +830,7 @@ order does not affect the result of an expression, including any side-effects.
 \subsection{Typing}
 \TypingRuleDef{Unop}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a unary operation $\op$ over an expression $\vep$, that is $\EUnop(\op, \vep)$;
   \item annotating $\vep$ in $\tenv$ yields $(\vtpp, \vepp, \vses)$\ProseOrTypeError;
@@ -857,7 +857,7 @@ the expression \texttt{NOT '1010'} evaluates to the value \texttt{'0101'}.
 \SemanticsRuleDef{Unop}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\ve$ denotes a unary operator $\op$ over an expression, $\EUnop(\op, \veone)$;
 \item the evaluation of the expression $\veone$ in $\env$ yields \\ $\Normal((\vvone, \vg), \newenv)$\ProseOrAbnormal;
@@ -948,7 +948,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \subsection{Typing}
 \TypingRuleDef{ECond}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a conditional expression with condition $\econd$ with two options $\etrue$ and $\efalse$;
   \item annotating $\econd$ in $\tenv$ results in $(\tcond, \econdp, \vsescond)$\ProseOrTypeError;
@@ -999,7 +999,7 @@ evaluate either \texttt{3} or \texttt{Return42()}, depending on the
 % true and false sub-expressions do not contain function calls. Since this is an
 % optimization, we do not document it.
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a conditional expression $\econd$ with two options $\veone$ and $\vetwo$,
         that is, $\ECond(\econd, \veone, \vetwo)$;
@@ -1143,7 +1143,7 @@ changes the call type of $\vcall$ to $\texttt{call\_type}$.
 \subsection{Typing}
 \TypingRuleDef{ECall}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a call to a subprogram, that is, $\ECall(\vcall)$;
   \item applying $\annotatecall$ to $\vcall$ and in $\tenv$
@@ -1171,20 +1171,20 @@ subprogram \texttt{Return42()} is implemented to return the value \texttt{42}.
 
 \SemanticsRuleDef{ECall}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a subprogram call, $\ECall(\vcall)$;
   \item the evaluation of that subprogram call in $\env$ is either
   $\Normal(\vms, \newenv)$\ProseOrAbnormal;
   \item one of the following applies:
   \begin{itemize}
-    \item all of the following apply (\textsc{single\_returned\_value}):
+    \item \AllApplyCase{single\_returned\_value}:
     \begin{itemize}
       \item $\vms$ consists of a single returned value $(\vv,\vg)$,
       which goes into the output configuration $\Normal((\vv, \vg), \newenv)$.
     \end{itemize}
 
-    \item all of the following apply (\textsc{multiple\_returned\_values}):
+    \item \AllApplyCase{multiple\_returned\_values}:
     \begin{itemize}
       \item $\vms$ consists of a list of returned value $(\vv_i,\vg_i)$, for $i=1..k$;
       \item $\vg$ is the parallel composition of $\vg_i$, for $i=1..k$;
@@ -1246,7 +1246,7 @@ The details of the various types of bitvector slices is deferred to \chapref{Bit
 \subsection{Typing}
 \TypingRuleDef{ESlice}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the slicing of expression $\vep$ by the slices $\slices$, that is, \\
         $\ESlice(\vep, \slices)$;
@@ -1286,7 +1286,7 @@ initializer expression.
 
 \TypingRuleDef{ESliceError}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the slicing of expression $\vep$ by the slices $\slices$;
   \item $(\tep,\vepp)$ is the result of annotating the expression $\vep$ in $\tenv$;
@@ -1314,7 +1314,7 @@ the expression \texttt{'11110000'[6:3]} evaluates to the value \texttt{'1110'}.
 \ASLListing{Evaluating a slice expression}{semantics-eslice}{\semanticstests/SemanticsRule.ESlice.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\ve$ denotes a slicing expression, $\ESlice(\ebv, \slices)$;
 \item the evaluation of $\ebv$ in $\env$ yields $\Normal(\mbv, \envone)$\ProseOrAbnormal;
@@ -1383,7 +1383,7 @@ and the $\emph{index}$ subexpressions, respectively.
 \end{definition}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the \arrayaccess{} expression with base $\ebase$ and index $\eindex$;
   \item \Proseannotateexpr{$\tenv$}{$\ebase$}{\\ $(\tbase,\ebasep, \vsesbase)$}\ProseOrTypeError;
@@ -1436,7 +1436,7 @@ The function returns the type of the annotated expression in $\vt$,
 the annotated expression $\newe$, and the inferred \sideeffectdescriptorterm\ $\vses$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item \Proseannotateexpr{$\tenv$}{$\eindex$}{(\tindexp, \eindexp, \vsesindex)}\ProseOrTypeError;
   \item applying $\typeofarraylength$ to $\size$, to obtain the type of the array length, yields
@@ -1489,7 +1489,7 @@ which has indexes \texttt{0}, \texttt{1} and \texttt{2} only.
 \ASLListing{Evaluating an illegal array access}{semantics-egetarrayerror}{\semanticstests/SemanticsRule.EGetArrayTooSmall.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes an array access expression, $\EGetArray(\earray, \eindex)$;
   \item the evaluation of $\earray$ in $\env$ is $\Normal(\marray, \envone)$\ProseOrAbnormal;
@@ -1526,7 +1526,7 @@ with indices taken from the enumeration type \texttt{Enum}.
 {\semanticstests/SemanticsRule.EGetEnumArray.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes an array access expression, $\EGetArray(\earray, \eindex)$;
   \item the evaluation of $\earray$ in $\env$ is $\Normal(\marray, \envone)$\ProseOrAbnormal;
@@ -1579,7 +1579,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{EGetRecordField}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
@@ -1610,7 +1610,7 @@ All of the following apply:
 
 \TypingRuleDef{EGetBadRecordField}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
@@ -1635,7 +1635,7 @@ All of the following apply:
 
 \TypingRuleDef{EGetBadBitField}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
@@ -1660,7 +1660,7 @@ All of the following apply:
 
 \TypingRuleDef{EGetBitField}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
@@ -1688,7 +1688,7 @@ All of the following apply:
 
 \TypingRuleDef{EGetBitFieldNested}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
@@ -1725,7 +1725,7 @@ All of the following apply:
 
 \TypingRuleDef{EGetBitFieldTyped}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
@@ -1756,7 +1756,7 @@ All of the following apply:
 
 \TypingRuleDef{EGetTupleItem}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
@@ -1789,7 +1789,7 @@ All of the following apply:
 
 \TypingRuleDef{EGetBadField}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the access of field $\fieldname$ in the value represented by the expression $\veone$, that is, $\EGetField(\veone, \fieldname)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
@@ -1817,7 +1817,7 @@ the expression \verb|my_record.a| evaluates to the value \texttt{3}.
 \ASLListing{Evaluating a field access expression}{semantics-egetfield}{\semanticstests/SemanticsRule.ERecord.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\ve$ denotes a field access expression, $\EGetField(\erecord, \fieldname)$;
 \item the evaluation of $\erecord$ in $\env$ is $\Normal((\vrecord, \vg), \newenv)$\ProseOrAbnormal;
@@ -1836,7 +1836,7 @@ All of the following apply:
 
 \SemanticsRuleDef{EGetItem}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ is an expression for accessing the component given by the index $\vindex$ of the tuple
         given by the expression $\etuple$, that is, $\EGetItem(\etuple, \vindex)$;
@@ -1885,7 +1885,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{EGetFields}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ is a multi-field access expression for the base expression $\ebase$ and list of fields $\vfields$,
         that is, $\EGetFields(\ebase, \vfields)$;
@@ -1894,7 +1894,7 @@ All of the following apply:
         $\tbaseannotanon$\ProseOrTypeError;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{bits}):
+    \item \AllApplyCase{bits}:
     \begin{itemize}
       \item $\tbaseannotanon$ is a bitvector type with list of bitfields $\vbitfields$\ProseOrTypeError;
       \item applying $\findbitfieldsslices$ to each field name $\name$ and list of bitfields $\vbitfields$ in $\vfields$ yields \\
@@ -1903,7 +1903,7 @@ All of the following apply:
       \item \Proseannotateexpr{$\tenv$}{$\veslice$}{\\ $(\vt, \newe, \vses)$}\ProseOrTypeError.
     \end{itemize}
 
-    \item All of the following apply (\textsc{record}):
+    \item \AllApplyCase{record}:
     \begin{itemize}
       \item $\tbaseannotanon$ is a record type with list of fields $\vbasefields$\ProseOrTypeError;
       \item applying $\getbitfieldwidth$ to $\vf$ in $\vbasefields$ and $\vbasefields$, for each $\vf$ in $\vbasefields$, in $\tenv$ yields $\ewidth_\vf$\ProseOrTypeError;
@@ -1915,7 +1915,7 @@ All of the following apply:
       \item define $\vses$ as $\vsesbase$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{error}):
+    \item \AllApplyCase{error}:
     \begin{itemize}
       \item $\tbaseannotanon$ is neither a bitvector type nor a record type;
       \item the result is a type error indicating an unexpected type.
@@ -1978,21 +1978,21 @@ in $\vslices$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{found}):
+  \item \AllApplyCase{found}:
   \begin{itemize}
     \item $\vbitfields$ is a list with \head\ $\vfield$ and \tail\ $\vbitfieldsone$;
     \item applying $\bitfieldgetname$ to $\vfield$ yields $\name$;
     \item applying $\bitfieldgetslices$ to $\vfield$ yields $\vslices$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tail}):
+  \item \AllApplyCase{tail}:
   \begin{itemize}
     \item $\vbitfields$ is a list with \head\ $\vfield$ and \tail\ $\vbitfieldsone$;
     \item applying $\bitfieldgetname$ to $\vfield$ yields $\namep$, which is different to $\name$;
     \item applying $\findbitfieldsslices$ to $\name$ and $vbitfieldsone$ yields $\vslices$\ProseOrTypeError.
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item $\vbitfields$ is an empty list;
     \item the result is a type error indicating that a bitfield named $\name$ does not exist in $\vbitfields$.
@@ -2042,13 +2042,13 @@ in the list of fields $\tfields$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{okay}):
+  \item \AllApplyCase{okay}:
   \begin{itemize}
     \item applying $\assocopt$ to find the type associated with $\name$ in $\tfields$ yields the type $\vt$;
     \item applying $\getbitvectorwidth$ to $\vt$ in $\tenv$ yields $\ewidth$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item applying $\assocopt$ to find the type associated with $\name$ in $\tfields$ yields $\None$;
     \item the result is a type error indicating that $\name$ is not associated with any field in $\tfields$.
@@ -2088,13 +2088,13 @@ normalized in the static environment $\tenv$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\exprs$ is an empty list;
     \item $\ewidth$ is the literal expression for $0$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\exprs$ is the list with \head\ $\ve$ and \tail\ $\exprsone$;
     \item applying $\widthplus$ to $\exprsone$ yields $\ewidthone$;
@@ -2121,7 +2121,7 @@ One of the following applies:
 \subsection{Semantics}
 \SemanticsRuleDef{EGetfields}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ is the multi-field access expression for the expression $\erecord$ and list of field names
         $\vfieldnames$;
@@ -2203,7 +2203,7 @@ is a dynamic error.
 \subsection{Typing}
 \TypingRuleDef{ATC}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes an asserting type conversion with expression $\vep$ and type $\tty$, that is $\EATC(\vep, \tty)$;
   \item annotating the expression $\vep$ in $\tenv$ yields $(\vt, \vepp, \\vsese)$\ProseOrTypeError;
@@ -2256,20 +2256,20 @@ are compatible for a typing assertion in the static environment $\tenv$, yieldin
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{equal}):
+  \item \AllApplyCase{equal}:
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\True$\ProseOrTypeError;
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{different\_labels\_error}):
+  \item \AllApplyCase{different\_labels\_error}:
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\False$;
     \item the AST labels of $\vtone$ and $\vttwo$ are different;
     \item the result is a type error indicating that the type assertion will always fail.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_bits}):
+  \item \AllApplyCase{int\_bits}:
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\False$;
     \item the AST labels of $\vtone$ and $\vttwo$ are the same;
@@ -2277,7 +2277,7 @@ One of the following applies:
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tuple}):
+  \item \AllApplyCase{tuple}:
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\False$;
     \item $\vtone$ is a tuple type with list of tuples $\vlone$, that is, $\TTuple(\vlone)$;
@@ -2287,7 +2287,7 @@ One of the following applies:
     \item the result is $\True$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{other\_error}):
+  \item \AllApplyCase{other\_error}:
   \begin{itemize}
     \item determining whether $\vtone$ is \typeequivalent\ to $\vttwo$ in $\tenv$ yields $\False$;
     \item the AST labels of $\vtone$ and $\vttwo$ are the same;
@@ -2366,19 +2366,19 @@ evaluated:
 \ASLListing{Various type errors and dynamic errors}{semantics-variousatcs}{\semanticstests/SemanticsRule.ATCVariousErrors.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\ve$ denotes an asserted type conversion expression, $\EATC(\veone, \vt)$;
 \item evaluating $\veone$ in $\env$ results in $\Normal((\vv, \vgone), \newenv)$\ProseOrAbnormal;
 \item evaluating whether $\vv$ has type $\vt$ in $\env$ results in $(\vb, \vgtwo)$\ProseTerminateAs{\DynErrorConfig};
 \item one of the following applies:
       \begin{itemize}
-      \item all of the following apply (\textsc{okay}):
+      \item \AllApplyCase{okay}:
             \begin{itemize}
             \item $\vb$ is the native Boolean for \True;
             \item $\vg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge.
             \end{itemize}
-      \item all of the following apply (\textsc{error}):
+      \item \AllApplyCase{error}:
             \begin{itemize}
             \item $\vb$ is the native Boolean for \False;
             \item the result is a dynamic error indicating that the type assertion failed
@@ -2429,7 +2429,7 @@ all sub-expressions appearing in $\vt$ are side-effect-free.
 
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{type\_equal}):
+  \item \AllApplyCase{type\_equal}:
   \begin{itemize}
     \item the AST label of $\vt$ is not $\TInt$, $\TBits$, or $\TTuple$;
     \item $\vb$ is $\True$ (since \TypingRuleRef{ATC}
@@ -2437,14 +2437,14 @@ One of the following applies:
     \item $\vg$ is the empty graph.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_unconstrained}):
+  \item \AllApplyCase{int\_unconstrained}:
   \begin{itemize}
     \item $\vt$ has the structure of the unconstrained integer;
     \item $\vb$ is \True;
     \item $\vg$ is the empty graph.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_wellconstrained}):
+  \item \AllApplyCase{int\_wellconstrained}:
   \begin{itemize}
     \item $\vt$ has the structure of a well-constrained integer with constraints $\vc_{1..k}$;
     \item $\vv$ is the \nativevalue\  integer for $n$;
@@ -2454,7 +2454,7 @@ One of the following applies:
     \item $\vg$ is the parallel composition of all execution graphs $\vg_i$, for $i=1..k$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{bits}):
+  \item \AllApplyCase{bits}:
   \begin{itemize}
     \item $\vt$ is a bitvector type with expression $\ve$, that is, $\TBits(\ve, \Ignore)$;
     \item $\vv$ is a native bitvector value for the sequence of bits $\vbits$, that is, \\ $\nvbitvector(\vbits)$;
@@ -2462,7 +2462,7 @@ One of the following applies:
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vvp$ is equal to the number of bits in $\vbits$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tuple}):
+  \item \AllApplyCase{tuple}:
   \begin{itemize}
     \item $\vt$ is a tuple with types $\vt_i$, for $i=1..k$;
     \item the value at every index $i=1..k$ of $\vv$ is $\vu_i$, for $i=1..k$,
@@ -2548,7 +2548,7 @@ the expressions appearing in $\vc$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{Constraint\_Exact\_Sat}):
+  \item \AllApplyCase{Constraint\_Exact\_Sat}:
   \begin{itemize}
     \item $\vc$ is a constraint for the expression $\ve$;
     \item evaluating the side-effect-free expression $\ve$ in $\env$ yields the \concurrentnativevalue\ given
@@ -2556,7 +2556,7 @@ One of the following applies:
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $m$ is equal to $n$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{Constraint\_Range\_Sat}):
+  \item \AllApplyCase{Constraint\_Range\_Sat}:
   \begin{itemize}
     \item $\vc$ is a constraint for the expressions $\veone$ and $\vetwo$;
     \item evaluating the side-effect-free expression $\veone$ in $\env$ yields the \concurrentnativevalue\ given
@@ -2647,7 +2647,7 @@ Lists of patterns are also used in case statements.
 \subsection{Typing}
 \TypingRuleDef{EPattern}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a pattern expression to test whether $\veone$ matches the pattern $\vpat$, that is, \\ $\EPattern(\veone, \vpat)$;
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vtetwo, \vetwo, \vsese)$\ProseOrTypeError;
@@ -2679,7 +2679,7 @@ whereas the expression \texttt{42 IN \{0..3, -4\}} evaluates to $\nvbool(\False)
 \ASLListing{Evaluating a pattern expression}{semantics-epattern}{\semanticstests/SemanticsRule.EPattern.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a pattern expression, $\EPattern(\ve, \vp)$;
   \item evaluating the expression $\ve$ in an environment $\env$ results in \\
@@ -2739,7 +2739,7 @@ Note that there are two important consequences of producing an arbitrary value w
 \subsection{Typing}
 \TypingRuleDef{EArbitrary}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes an expression \ARBITRARY\ of type $\tty$, that is, $\EArbitrary(\tty)$;
   \item annotating the type $\tty$ in $\tenv$ yields $(\ttyone, \vsesty)$\ProseOrTypeError;
@@ -2783,12 +2783,12 @@ and how to obtain an arbitrary enumeration-indexed array, \texttt{enum\_array}.
 {\semanticstests/SemanticsRule.EArbitraryArray.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the \texttt{ARBITRARY} expression annotated with type $\vt$;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{okay}):
+    \item \AllApplyCase{okay}:
     \begin{itemize}
       \item the domain of $\vt$ in $\env$ (see \secref{DynDomain}) is not empty;
       \item $\vv$ is an arbitrary value in the domain of $\vt$ in $\env$;
@@ -2796,7 +2796,7 @@ All of the following apply:
       \item $\vg$ is the empty execution graph.
     \end{itemize}
 
-    \item All of the following apply (\textsc{error}):
+    \item \AllApplyCase{error}:
     \begin{itemize}
       \item the domain of $\vt$ in $\env$ is empty;
       \item the result is a dynamic error (\ArbitraryEmptyType) indicating that the type $\vt$ has an empty
@@ -2895,7 +2895,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \subsection{Typing}
 \TypingRuleDef{ERecord}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes the record construction expression (which is also used for creating exceptions) of type $\tty$ with fields $\fields$,
         that is, $\ERecord(\tty, \vfields)$;
@@ -2963,7 +2963,7 @@ with list of fields \\ $\fieldtypes$ and returns the annotated initializing expr
 and its \sideeffectdescriptorterm\ $\vses$. \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item annotating the expression $\vep$ in $\tenv$ yields $(\vtp, \vepp, \vses)$\ProseOrTypeError;
   \item checking whether there exists a type associated with $\name$ in $\fieldtypes$ yields $\True$\ProseOrTypeError;
@@ -2992,7 +2992,7 @@ $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
 \ASLListing{Evaluating a record construction expression}{semantics-erecord}{\semanticstests/SemanticsRule.ERecord.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\ve$ denotes a record creation expression, $\ERecord(\names, \efields)$;
 \item the names of the fields are $\id_{1..k}$;
@@ -3044,14 +3044,14 @@ All of the following apply:
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{parenthesized}):
+  \item \AllApplyCase{parenthesized}:
   \begin{itemize}
     \item $\ve$ denotes a tuple expression with list of expressions consisting solely of $\vep$, that is, $\ETuple([\vep])$,
           meaning it represents a parenthesized expression (see \ASTRuleRef{ParenExpr});
     \item annotating $\vep$ in $\tenv$ yields $(\vt, \newe, \vses)$\ProseOrTypeError.
   \end{itemize}
 
-  \item All of the following apply (\textsc{list}):
+  \item \AllApplyCase{list}:
   \begin{itemize}
     \item $\ve$ denotes a tuple expression with list of expressions $\vli$, that is, $ \ETuple(\vli)$;
     \item $\vli$ consists of at least two expressions;
@@ -3090,7 +3090,7 @@ the expression \texttt{(3, Return42())} evaluates to the value \texttt{(3, 42)}.
 \ASLListing{Evaluating a tuple expression}{semantics-etuple}{\semanticstests/SemanticsRule.ETuple.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ denotes a tuple expression, $\ETuple(\elist)$;
   \item the evaluation of $\elist$ in $\env$ is $\Normal((\vlist, \vg), \newenv)$\ProseOrAbnormal;
@@ -3150,7 +3150,7 @@ $\annotatetype$ guarantees that expressions in types are side-effect-free.
 
 \SemanticsRuleDef{EArray}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ is an array construction expression with length expression $\elength$ and value expression $\evalue$,
         that is, $\EArray\{\EArrayLength: \elength, \EArrayValue: \evalue\}$;
@@ -3181,7 +3181,7 @@ All of the following apply:
 
 \SemanticsRuleDef{EEnumArray}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ve$ is an array construction expression for an enumerated-index array with
         list of labels $\vlabels$ and value expression $\evalue$,

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -2427,7 +2427,7 @@ One of the following applies:
   \item All of the following apply (\textsc{type\_equal}):
   \begin{itemize}
     \item the AST label of $\vt$ is not $\TInt$, $\TBits$, or $\TTuple$;
-    \item $\vb$ is \True (since \TypingRuleRef{ATC}
+    \item $\vb$ is $\True$ (since \TypingRuleRef{ATC}
     succeeds in these cases only if the \structure\ of the type of the expression and the \structure\ of the type asserted against are \typeequivalent);
     \item $\vg$ is the empty graph.
   \end{itemize}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -1118,14 +1118,14 @@ conditional expression evaluates to the \texttt{else} expression.
 Above, $\STFunction$ is inserted as a default call type for any parsed $\call$.
 The helper function
 \[
-  \setcalltype(\overname{\call}{\vcall} \aslsep \overname{\subprogramtype}{\texttt{call\_type}}) \aslto \overname{\call}{\vcallp}
+  \setcalltype(\overname{\call}{\vcall} \aslsep \overname{\subprogramtype}{\calltype}) \aslto \overname{\call}{\vcallp}
 \]
-changes the call type of $\vcall$ to $\texttt{call\_type}$.
+changes the call type of $\vcall$ to $\calltype$.
 
 \begin{mathpar}
 \inferrule{}{
-  \setcalltype(\vcall, \texttt{call\_type}) \aslto
-  \overname{\vcall[\callcalltype\mapsto\texttt{call\_type}]}{\vcallp}
+  \setcalltype(\vcall, \calltype) \aslto
+  \overname{\vcall[\callcalltype\mapsto\calltype]}{\vcallp}
 }
 \end{mathpar}
 
@@ -1752,6 +1752,10 @@ with indices taken from the enumeration type \texttt{Enum}.
 \CodeSubsection{\EGetBitFieldTypedBegin}{\EGetBitFieldTypedEnd}{../Typing.ml}
 
 \TypingRuleDef{EGetTupleItem}
+\newcommand\itemprefix[0]{\texttt{item}}
+In the following rule definition, we use $\itemprefix$ to stand
+for its verbatim string.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1759,7 +1763,7 @@ with indices taken from the enumeration type \texttt{Enum}.
   \item annotating the expression $\veone$ in $\tenv$ yields $(\vteone, \vetwo, \vsesone)$\ProseOrTypeError;
   \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$\ProseOrTypeError;
   \item $\vtetwo$ is tuple type with list of types $\tys$, that is, $\TTuple(\tys)$;
-  \item $\fieldname$ is an identifier with the prefix \texttt{item} and the suffix $\num$;
+  \item $\fieldname$ is an identifier consisting of the prefix \itemprefix{} and the suffix $\num$;
   \item $\num$ is lexically an integer token with the integer value $\vindex$;
   \item determining whether $\vindex$ is between $0$ and the number of types in $\tys$, inclusive, yields $\True$\ProseOrTypeError;
   \item $\vt$ is the type at position $\vindex$ of $\tys$;
@@ -1772,7 +1776,7 @@ with indices taken from the enumeration type \texttt{Enum}.
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo, \vsesone) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
   \vtetwo \eqname \TTuple(\tys)\\
-  \fieldname \eqname \texttt{"item"}\num\\
+  \fieldname = \itemprefix \stringconcat \num\\
   \num \in \Lang(\REintlit)\\
   \decimaltolit(\num) = \Tintlit(\vindex)\\
   \checktrans{0 \leq \vindex \leq \listlen{\tys}}{\BadTupleIndex} \checktransarrow \True \OrTypeError\\\\
@@ -1989,7 +1993,7 @@ in $\vslices$.
     \item applying $\findbitfieldsslices$ to $\name$ and $vbitfieldsone$ yields $\vslices$\ProseOrTypeError.
   \end{itemize}
 
-  \item \AllApplyCase{error}
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vbitfields$ is an empty list;
     \item the result is a type error indicating that a bitfield named $\name$ does not exist in $\vbitfields$.
@@ -2219,7 +2223,7 @@ is a dynamic error.
 \end{itemize}
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[type\_equal]{
+\inferrule{
   \annotateexpr{\tenv, \vep} \typearrow (\vt, \vepp, \vsese) \OrTypeError\\\\
   \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError\\\\
   \annotatetype{\tenv, \tty} \typearrow (\ttyp, \vsesty) \OrTypeError\\\\
@@ -3237,7 +3241,6 @@ since side-effect-free expressions do not modify the environment.
 
 \section{Evaluating a List of Expressions\label{sec:ExprList}}
 \SemanticsRuleDef{EExprList}
-\ProseParagraph
 The relation
 \hypertarget{def-evalexprlist}{}
 \[
@@ -3250,19 +3253,40 @@ and returns the resulting value $\vv$, the parallel composition of the execution
 generated from evaluating each expression, and the new environment $\newenv$.
 If the evaluation of any expression terminates abnormally then the abnormal configuration is returned.
 
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{empty}
+  \begin{itemize}
+    \item \Proseemptylist{$\vle$};
+    \item \Proseemptylist{$\vv$};
+    \item \Proseemptygraph{$\vg$}
+    \item \Proseeqdef{$\newenv$}{$\env$}.
+  \end{itemize}
+
+  \item \AllApplyCase{non\_empty}
+  \begin{itemize}
+    \item $\vle$ is a \Proselist{$\ve$}{$\vle1$};
+    \item \Proseevalexpr{$\env$}{$\ve$}{\\ $\Normal((\vvone, \vgone), \envone)$}\ProseOrAbnormal;
+    \item \Proseeqdef{$\vg$}{the parallel composition of $\vgone$ and $\vgtwo$};
+    \item \Proseeqdef{$\vv$}{the list with \head{} $\vvone$ and \tail{} $\vvs$}.
+  \end{itemize}
+\end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[empty]{}
 {
-  \evalexprlist{\env, \emptylist} \evalarrow \Normal((\emptylist, \emptygraph), \env)
+  \evalexprlist{\env, \overname{\emptylist}{\vle}} \evalarrow
+  \Normal((\overname{\emptylist}{\vv}, \overname{\emptygraph}{\vg}), \overname{\env}{\newenv})
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[nonempty]{
-  \texttt{le} \eqname [\ve] \concat \vle1\\
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vvone, \vgone), \envone) \OrAbnormal\\
-  \evalexprlist{\envone, \vle1} \evalarrow \Normal((\vvs, \vgtwo), \newenv) \OrAbnormal\\
+  \vle = [\ve] \concat \vle1\\
+  \evalexpr{\env, \ve} \evalarrow \Normal((\vvone, \vgone), \envone) \OrAbnormal\\\\
+  \evalexprlist{\envone, \vle1} \evalarrow \Normal((\vvs, \vgtwo), \newenv) \OrAbnormal\\\\
   \vg \eqdef \vgone \parallelcomp \vgtwo \\
   \vv \eqdef [\vvone] \concat \vvs
 }{

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -612,6 +612,10 @@ for readers of ASL specifications and as a consequence it is recommended that
 an if-statement is used to achieve the same effect.
 
 \SemanticsRuleDef{BinopOr}
+\subsubsection{Example}
+In \listingref{semantics-binopor}, the expression \texttt{(0 == 1) || (1 == 1)} evaluates to the value \True.
+\ASLListing{Evaluating a disjunction expression}{semantics-binopor}{\semanticstests/SemanticsRule.EBinopOrTrue.asl}
+
 \ProseParagraph
 All of the following apply:
 \begin{itemize}
@@ -620,10 +624,7 @@ All of the following apply:
       \texttt{if e1 then true else e2} (see \SemanticsRuleRef{ECond}).
 \end{itemize}
 
-\subsubsection{Example}
-In \listingref{semantics-binopor}, the expression \texttt{(0 == 1) || (1 == 1)} evaluates to the value \True.
-\ASLListing{Evaluating a disjunction expression}{semantics-binopor}{\semanticstests/SemanticsRule.EBinopOrTrue.asl}
-
+\FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \truep \eqdef \ELiteral(\lbool(\True))\\
@@ -672,6 +673,11 @@ for readers of ASL specifications and as a consequence it is recommended that
 an if-statement is used to achieve the same effect.
 
 \SemanticsRuleDef{BinopImpl}
+\subsubsection{Example}
+In \listingref{semantics-binopimpl},
+the expression \texttt{(0 == 1) --> (1 == 0)} evaluates to the value \True, according to the definition of implication.
+\ASLListing{Evaluating an implication expression}{semantics-binopimpl}{\semanticstests/SemanticsRule.EBinopImplExFalso.asl}
+
 \ProseParagraph
 All of the following apply:
 \begin{itemize}
@@ -679,17 +685,12 @@ All of the following apply:
   \item $\ve$ is evaluated as \texttt{if e1 then e2 else true}.
 \end{itemize}
 
-\subsubsection{Example}
-In \listingref{semantics-binopimpl},
-the expression \texttt{(0 == 1) --> (1 == 0)} evaluates to the value \True, according to the definition of implication.
-\ASLListing{Evaluating an implication expression}{semantics-binopimpl}{\semanticstests/SemanticsRule.EBinopImplExFalso.asl}
-
+\FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \truep \eqdef \ELiteral(\lbool(\True))\\
   \evalexpr{\env, \ECond(\veone, \vetwo, \truep)} \evalarrow C
-}
-{
+}{
 \evalexpr{\env, \EBinop(\IMPL, \veone, \vetwo)} \evalarrow C
 }
 \end{mathpar}
@@ -1169,6 +1170,7 @@ subprogram \texttt{Return42()} is implemented to return the value \texttt{42}.
 \ASLListing{Evaluating a call expression}{semantics-ecall}{\semanticstests/SemanticsRule.ECall.asl}
 
 \SemanticsRuleDef{ECall}
+\ProseParagraph
 All of the following apply:
 \begin{itemize}
   \item $\ve$ denotes a subprogram call, $\ECall(\vcall)$;
@@ -1642,6 +1644,8 @@ All of the following apply:
   \item the field $\fieldname$ is not found in $\bitfields$
   \item the result is a type error indicating the missing field.
 \end{itemize}
+
+\FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo, \vsesone) \OrTypeError\\\\
@@ -1666,6 +1670,7 @@ All of the following apply:
   \item $\vethree$ denotes the slicing of the expression \vetwo\ by the slices $\slices$, that is, \\ $\ESlice(\vetwo, \slices)$;
   \item annotating $\vethree$ in $\tenv$ yields $(\vt, \newe, \vses)$\ProseOrTypeError.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -143,7 +143,7 @@ A literal expression represents a literal as an expression.
 \CodeSubsection{\ELitBegin}{\ELitEnd}{../Typing.ml}
 
 \subsection{Semantics}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Literal Expressions}
 In \listingref{literalssemantics}, each of the expressions \texttt{3} evaluates to the \nativevalue\ $\nvint(3)$.
 \ASLListing{Semantics of literals}{literalssemantics}{\semanticstests/SemanticsRule.Lit.asl}
 
@@ -301,6 +301,17 @@ function calls) to global constant variables.
 
 \subsection{Semantics}
 \SemanticsRuleDef{EVar}
+
+\ExampleDef{Evaluation of a Local Variable Expression}
+In \listingref{localvarsemantics}, the evaluation of \texttt{x} within \texttt{assert x == 3;}
+uses \\ \SemanticsRuleRef{EVar}.LOCAL.
+\ASLListing{Semantics of local variables}{localvarsemantics}{\semanticstests/SemanticsRule.ELocalVar.asl}
+
+\ExampleDef{Evaluation of a Global Variable Expression}
+In \listingref{globalvarsemantics}, the evaluation of~\texttt{global\_x} within~\texttt{assert global\_x == 3;}
+uses the rule \SemanticsRuleRef{EVar}.GLOBAL.
+\ASLListing{Semantics of global variables}{globalvarsemantics}{\semanticstests/SemanticsRule.EGlobalVar.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -351,16 +362,6 @@ This is enforced by \TypingRuleRef{LDVar} in the Chapter ``Typing of Local Decla
 and
 \TypingRuleRef{DeclareGlobalStorage} and \TypingRuleRef{DeclareOneFunc},
 both in the Chapter ``Typing of Global Declarations''.
-
-\subsubsection{Example}
-In \listingref{localvarsemantics}, the evaluation of \texttt{x} within \texttt{assert x == 3;}
-uses \\ \SemanticsRuleRef{EVar}.LOCAL.
-\ASLListing{Semantics of local variables}{localvarsemantics}{\semanticstests/SemanticsRule.ELocalVar.asl}
-
-\subsubsection{Example}
-In \listingref{globalvarsemantics}, the evaluation of~\texttt{global\_x} within~\texttt{assert global\_x == 3;}
-uses the rule \SemanticsRuleRef{EVar}.GLOBAL.
-\ASLListing{Semantics of global variables}{globalvarsemantics}{\semanticstests/SemanticsRule.EGlobalVar.asl}
 
 \section{Binary Expressions\label{sec:BinaryExpressions}}
 \subsection{Syntax}
@@ -488,7 +489,7 @@ for example: \texttt{(a + b) - c}.
 
 \subsection{Typing}
 \TypingRuleDef{EBinop}
-\subsubsection{Example}
+\ExampleDef{Typing of Binary Expressions}
 In \listingref{typing-binoperror},
 the expression \texttt{3 DIV 0} results in a type error.
 \ASLListing{Evaluating a binary expression resulting in a type error}{typing-binoperror}
@@ -547,7 +548,7 @@ the expression \texttt{3 DIV 0} results in a type error.
 
 \subsection{Semantics}
 \SemanticsRuleDef{BinopAnd}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Binary And Expressions}
 In \listingref{andsemantics},
 the expression \texttt{FALSE \&\& fail()} evaluates to the value \texttt{FALSE}. Notice that the function \texttt{fail} is never called.
 \ASLListing{Semantics of conjunction}{andsemantics}{\semanticstests/SemanticsRule.EBinopAndFalse.asl}
@@ -608,7 +609,7 @@ for readers of ASL specifications and as a consequence it is recommended that
 an if-statement is used to achieve the same effect.
 
 \SemanticsRuleDef{BinopOr}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Binary Or Expressions}
 In \listingref{semantics-binopor}, the expression \texttt{(0 == 1) || (1 == 1)} evaluates to the value \True.
 \ASLListing{Evaluating a disjunction expression}{semantics-binopor}{\semanticstests/SemanticsRule.EBinopOrTrue.asl}
 
@@ -667,7 +668,7 @@ for readers of ASL specifications and as a consequence it is recommended that
 an if-statement is used to achieve the same effect.
 
 \SemanticsRuleDef{BinopImpl}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Implication Expressions}
 In \listingref{semantics-binopimpl},
 the expression \texttt{(0 == 1) --> (1 == 0)} evaluates to the value \True, according to the definition of implication.
 \ASLListing{Evaluating an implication expression}{semantics-binopimpl}{\semanticstests/SemanticsRule.EBinopImplExFalso.asl}
@@ -714,6 +715,11 @@ an if-statement is used to achieve the same effect.
 
 \hypertarget{def-binopexpressionterm}{}
 \SemanticsRuleDef{Binop}
+\ExampleDef{Evaluation of Binary Expressions}
+In \listingref{semantics-binopassert},
+the expression \texttt{3 + 2} evaluates to the value \texttt{5}.
+\ASLListing{Evaluating a binary expression}{semantics-binopassert}{\semanticstests/SemanticsRule.EBinopPlusAssert.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -732,11 +738,6 @@ an if-statement is used to achieve the same effect.
   \item applying the Binary Operator $\op$ to $\vvone$ and $\vvtwo$ results in $\vv$\ProseOrError;
   \item $\vg$ is the parallel composition of $\vgone$ and $\vgtwo$.
 \end{itemize}
-
-\subsubsection{Example}
-In \listingref{semantics-binopassert},
-the expression \texttt{3 + 2} evaluates to the value \texttt{5}.
-\ASLListing{Evaluating a binary expression}{semantics-binopassert}{\semanticstests/SemanticsRule.EBinopPlusAssert.asl}
 
 \FormallyParagraph
 \begin{mathpar}
@@ -843,12 +844,11 @@ order does not affect the result of an expression, including any side-effects.
 \CodeSubsection{\UnopBegin}{\UnopEnd}{../Typing.ml}
 
 \subsection{Semantics}
-\subsubsection{Example}
+\SemanticsRuleDef{Unop}
+\ExampleDef{Evaluation of }
 In \listingref{semantics-unopassert},
 the expression \texttt{NOT '1010'} evaluates to the value \texttt{'0101'}.
 \ASLListing{Evaluating a unary expression}{semantics-unopassert}{\semanticstests/SemanticsRule.EUnopAssert.asl}
-
-\SemanticsRuleDef{Unop}
 
 \ProseParagraph
 \AllApply
@@ -973,22 +973,22 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \identr{XZVT}
 
 \subsection{Semantics}
-\subsubsection{Example}
+\SemanticsRuleDef{ECond}
+\ExampleDef{Evaluation of Conditional Expressions}
 In \listingref{semantics-econdfalse},
 the expression \texttt{if FALSE then Return42() else 3} evaluates to the value \texttt{3}.
 \ASLListing{Evaluating a conditional expression yielding the result of the \texttt{else} subexpression}
 {semantics-econdfalse}{\semanticstests/SemanticsRule.ECondFalse.asl}
 
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Non-deterministic Conditional Expression}
 In \listingref{semantics-econdarbitrary},
 the expression \texttt{if ARBITRARY: boolean then 3 else Return42()} will
-evaluate either \texttt{3} or \texttt{Return42()}, depending on the
+evaluate to either \texttt{3} or \texttt{Return42()}, depending on the
 (non-deterministic) result of \\
 \texttt{ARBITRARY: boolean}.
 \ASLListing{Evaluating a conditional expression with non-determinic choice}{semantics-econdarbitrary}
 {\semanticstests/SemanticsRule.ECondARBITRARY3or42.asl}
 
-\SemanticsRuleDef{ECond}
 % Transliteration note: the code uses an optimized semantics for the case where
 % true and false sub-expressions do not contain function calls. Since this is an
 % optimization, we do not document it.
@@ -1157,13 +1157,13 @@ changes the call type of $\vcall$ to $\calltype$.
 \identd{CFYP} \identr{BQJG}
 
 \subsection{Semantics}
-\subsubsection{Example}
+\SemanticsRuleDef{ECall}
+\ExampleDef{Evaluation of Call Expressions}
 In \listingref{semantics-ecall},
 the expression \texttt{Return42()} evaluates to the value \texttt{42} because the
 subprogram \texttt{Return42()} is implemented to return the value \texttt{42}.
 \ASLListing{Evaluating a call expression}{semantics-ecall}{\semanticstests/SemanticsRule.ECall.asl}
 
-\SemanticsRuleDef{ECall}
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1302,7 +1302,7 @@ initializer expression.
 
 \subsection{Semantics}
 \SemanticsRuleDef{ESlice}
-\subsubsection{Example}
+\subsubsection{Evaluation of Slicing Expressions}
 In \listingref{semantics-eslice},
 the expression \texttt{'11110000'[6:3]} evaluates to the value \texttt{'1110'}.
 \ASLListing{Evaluating a slice expression}{semantics-eslice}{\semanticstests/SemanticsRule.ESlice.asl}
@@ -1469,13 +1469,13 @@ the annotated expression $\newe$, and the inferred \sideeffectdescriptorterm\ $\
 \CodeSubsection{\AnnotateGetArrayBegin}{\AnnotateGetArrayEnd}{../Typing.ml}
 
 \SemanticsRuleDef{EGetArray}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Array Reading Expressions}
 In \listingref{semantics-egetarray},
 the expression \verb|my_array[[2]]| appearing in the assertion evaluates to the value \texttt{42} since the element
 indexed by \texttt{2} in \texttt{my\_array} is \texttt{42}.
 \ASLListing{Evaluating an array access expression}{semantics-egetarray}{\semanticstests/SemanticsRule.EGetArray.asl}
 
-\subsubsection{Example}
+\ExampleDef{Evaluation of an Illegal Array Read}
 In \listingref{semantics-egetarrayerror}.
 evaluating the array access expression \verb|my_array[[3]]| results in a dynamic error,
 since we are trying to access index \texttt{3} of an array
@@ -1512,7 +1512,7 @@ which has indexes \texttt{0}, \texttt{1} and \texttt{2} only.
 \CodeSubsection{\EvalEGetArrayBegin}{\EvalEGetArrayEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{EGetEnumArray}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Reading from an Enumeration-indexed Array}
 In \listingref{semantics-egetenumarray},
 the enumeration-typed array \texttt{Arr} is accessed for reading and writing
 with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
@@ -1809,7 +1809,7 @@ for its verbatim string.
 
 \subsection{Semantics}
 \SemanticsRuleDef{EGetField}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Field Read Expression}
 In \listingref{semantics-egetfield},
 the expression \verb|my_record.a| evaluates to the value \texttt{3}.
 \ASLListing{Evaluating a field access expression}{semantics-egetfield}{\semanticstests/SemanticsRule.ERecord.asl}
@@ -2345,21 +2345,20 @@ are compatible for a typing assertion in the static environment $\tenv$, yieldin
 
 \subsection{Semantics}
 \SemanticsRuleDef{ATC}
-\subsubsection{Example}
+\ExampleDef{Evaluation of an Asserting Type Conversion Expressions}
 In \listingref{semantics-atcvalue}, both type assertions ---
 \verb|3 as integer| and \verb|3 as integer{3..5}| --- succeed.
 \ASLListing{Evaluating a successful type assertion expression}{semantics-atcvalue}{\semanticstests/SemanticsRule.ATCValue.asl}
 
-\subsubsection{Example}
+\ExampleDef{An Unevaluated Asserting Type Conversion}
 \identr{YCPX}
-
 In \listingref{semantics-atcnotevaluated}, the asserting type conversion on \texttt{y}
 does not yield a dynamic error, since the invocation of \texttt{f1} returns $\False$ when
 evaluated:
 \ASLListing{A asserting type conversion that is never evaluated}{semantics-atcnotevaluated}
 {\semanticstests/SemanticsRule.ATCNotDynamicErrorIfFalse.asl}
 
-\subsubsection{Example}
+\ExampleDef{Asserting Type Conversions with Typing Errors and Dynamic Errors}
 \listingref{semantics-variousatcs} shows various type errors and dynamic errors:
 \ASLListing{Various type errors and dynamic errors}{semantics-variousatcs}{\semanticstests/SemanticsRule.ATCVariousErrors.asl}
 
@@ -2670,7 +2669,7 @@ Lists of patterns are also used in case statements.
 
 \subsection{Semantics}
 \SemanticsRuleDef{EPattern}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Pattern Expressions}
 In \listingref{semantics-epattern},
 the expression \texttt{42 IN \{0..3, 42\}} evaluates to $\nvbool(\True)$
 whereas the expression \texttt{42 IN \{0..3, -4\}} evaluates to $\nvbool(\False)$.
@@ -2760,20 +2759,20 @@ Note that there are two important consequences of producing an arbitrary value w
 
 \subsection{Semantics}
 \SemanticsRuleDef{EArbitrary}
-\subsubsection{Example}
+\ExampleDef{Evaluation of ARBITRARY for an Uncostrained Integer Type}
 In \listingref{semantics-earbitraryunconstrained},
 the expression \verb|ARBITRARY : integer| evaluates to an arbitrary integer value.
 \ASLListing{Evaluating an \texttt{ARBITRARY} expression for an unconstrained integer}{semantics-earbitraryunconstrained}
 {\semanticstests/SemanticsRule.EArbitraryInteger3.asl}
 
-\subsubsection{Example}
+\subsubsection{Evaluation of ARBITRARY for a Costrained Integer Type}
 In \listingref{semantics-earbitraryconstrained},
 the expression \verb|ARBITRARY : integer {3, 42}| evaluates to either \\
 $\nvint(3)$ or $\nvint(42)$.
 \ASLListing{Evaluating an \texttt{ARBITRARY} expression for a constrained integer}{semantics-earbitraryconstrained}
 {\semanticstests/SemanticsRule.EArbitraryIntegerRange3-42-3.asl}
 
-\subsubsection{Example}
+\subsubsection{Evaluation of ARBITRARY for an Integer-indexed Array}
 \listingref{semantics-earbitraryarray}
 demonstrates how to obtain an arbitrary integer-indexed array, \texttt{int\_array},
 and how to obtain an arbitrary enumeration-indexed array, \texttt{enum\_array}.
@@ -2983,7 +2982,7 @@ and its \sideeffectdescriptorterm\ $\vses$. \ProseOtherwiseTypeError
 
 \subsection{Semantics}
 \SemanticsRuleDef{ERecord}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Record Construction Expressions}
 In \listingref{semantics-erecord},
 the expression \verb|MyRecordType{a=3, b=42}| evaluates to the native record value \\
 $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
@@ -3082,7 +3081,7 @@ $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
 
 \subsection{Semantics}
 \SemanticsRuleDef{ETuple}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Tuple Expressions}
 In \listingref{semantics-etuple},
 the expression \texttt{(3, Return42())} evaluates to the value \texttt{(3, 42)}.
 \ASLListing{Evaluating a tuple expression}{semantics-etuple}{\semanticstests/SemanticsRule.ETuple.asl}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -51,11 +51,11 @@ Otherwise, the evaluation terminates abnormally.
 \section{Evaluation Order}
 It is an error for an expression’s meaning to rely on evaluation order except that conditional expressions, and uses
 of the boolean operators $\Tband$, $\Tbor$, $\Timpl$, are guaranteed to evaluate from left to right.
-\lrmcomment{\identr{XKGC}}
+\identr{XKGC}
 
 An implementation could enforce this rule by performing a global analysis of all functions to determine whether a
 function can throw an exception and the set of global variables read and written by a function.
-\lrmcomment{\identi{YMRT}}
+\identi{YMRT}
 
 For any function call $F(e_1,\ldots,e_m)$, tuple $(e_1,\ldots, e_m)$, or operation $e_1 \op e_2$
 (with the exception of $\Tband$, $\Tbor$, and$\Timpl$),
@@ -66,14 +66,14 @@ it is an error if the subexpressions conflict with each other by:
   \item one writing to a variable and the other throwing an exception.
   \item both throwing exceptions.
 \end{itemize}
-\lrmcomment{\identi{QJTN}}
+\identi{QJTN}
 
 These conditions are sufficient but not necessary to ensure that evaluation order does not affect the result of an
 expression, including any side-effects.
-\lrmcomment{\identi{GFZT}}
+\identi{GFZT}
 
 Conditional expressions and the operations $\Tband$, $\Tbor$, and$\Timpl$ have short-circuit evaluation.
-\lrmcomment{\identi{QRXP}}
+\identi{QRXP}
 
 We now define the syntax, abstract syntax, typing, and semantics of the following kinds of expressions:
 \begin{itemize}
@@ -576,25 +576,24 @@ the expression \texttt{FALSE \&\& fail()} evaluates to the value \texttt{FALSE}.
 The evaluation via the rule above ensures that $\veone$ is evaluated first and
 only if it evaluates to $\True$ is $\vetwo$ evaluated.
 
-\lrmcomment{This is related to \identr{BKNT}: add table}
-
-\lrmcomment{This is related to \identr{XKGC}:}
+\identr{BKNT} % TODO: add table
+\identr{XKGC}
 
 It is an error for an expression’s meaning to rely on evaluation order except
 that conditional expressions, and uses of the boolean operators \texttt{\&\&},
 \texttt{||},\texttt{-->}, are guaranteed to evaluate from left to right.
 
-\lrmcomment{This is related to \identi{YMRT}:}
+\identi{YMRT}
 
 An implementation could enforce this rule by performing a global analysis of
 all functions to determine whether a function can throw an exception and the
 set of global variables read and written by a function.
 
-\lrmcomment{This is related to \identi{QRXP}:}
+\identi{QRXP}
 Conditional expressions and the operations \texttt{\&\&}, \texttt{||},
 \texttt{-->} provide a short-circuit evaluation mechanism:
 
-\lrmcomment{This is related to the note under \identr{LRHD}:}
+% This is related to the note under \identr{LRHD}
 \begin{itemize}
 \item the first operand of \texttt{if} is always evaluated but only one of the
 remaining operands is evaluated;
@@ -636,26 +635,24 @@ The evaluation via the rule above ensures that $\veone$ is evaluated first and o
 it evaluates to $\False$, is $\vetwo$ evaluated.
 
 \subsubsection{Comments}
-\lrmcomment{This is related to \identr{BKNT}: add table}
-
-\lrmcomment{This is related to \identr{XKGC}:}
-
+\identr{BKNT} % TODO: add table
+\identr{XKGC}
 It is an error for an expression’s meaning to rely on
 evaluation order except that conditional expressions, and uses of the boolean
 operators \texttt{\&\&}, \texttt{||}, \texttt{-->}, are guaranteed to evaluate
 from left to right.
 
-\lrmcomment{This is related to \identi{YMRT}:}
+\identi{YMRT}
 
 An implementation could enforce this rule by performing a global analysis of
 all functions to determine whether a function can throw an exception and the
 set of global variables read and written by a function.
 
-\lrmcomment{This is related to \identi{QRXP}:}
+\identi{QRXP}
 Conditional expressions and the operations \texttt{\&\&}, \texttt{||},
 \texttt{-->} provide a short-circuit evaluation mechanism:
 
-\lrmcomment{This is related to the note under \identr{LRHD}:}
+% This is related to the note under \identr{LRHD}
 \begin{itemize}
 \item the first operand of \texttt{if} is always evaluated but only one of the
 remaining operands is evaluated;
@@ -697,7 +694,7 @@ it evaluates to \True, is $\vetwo$ evaluated.
 
 \lrmcomment{This is related to \identr{BKNT}: add table}
 
-\lrmcomment{This is related to \identi{QRXP}:}
+\identi{QRXP}
 Conditional expressions and the operations \texttt{\&\&}, \texttt{||},
 \texttt{-->} provide a short-circuit evaluation mechanism:
 
@@ -763,7 +760,7 @@ as well as \texttt{==}).
 \subsubsection{Comments}
 \lrmcomment{This is related to \identr{BKNT}: add table}
 
-\lrmcomment{This is related to \identr{XKGC}:}
+\identr{XKGC}
 
 The semantics takes a semantic transition over the left subexpression before
 the right subexpression.
@@ -776,13 +773,13 @@ evaluation order except that conditional expressions, and uses of the boolean
 operators \texttt{\&\&}, \texttt{||}, \texttt{-->}, are guaranteed to evaluate
 from left to right.
 
-\lrmcomment{This is related to \identi{YMRT}:}
+\identi{YMRT}
 
 An implementation could enforce this rule by performing a global analysis of
 all functions to determine whether a function can throw an exception and the
 set of global variables read and written by a function.
 
-\lrmcomment{This is related to \identi{QJTN}:}
+\identi{QJTN}
 
 Notice that when one of the subexpressions terminates exceptionally,
 the other expression must be side effect-free and non-throwing.
@@ -798,7 +795,7 @@ subexpressions conflict with each other by:
 \item both throwing exceptions
 \end{itemize}
 
-\lrmcomment{This is related to \identi{GFZT}:}
+\identi{GFZT}
 These conditions are sufficient but not necessary to ensure that evaluation
 order does not affect the result of an expression, including any side-effects.
 
@@ -973,7 +970,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 \CodeSubsection{\ECondBegin}{\ECondEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{XZVT}.}
+\identr{XZVT}
 
 \subsection{Semantics}
 \subsubsection{Example}
@@ -1023,7 +1020,7 @@ evaluate either \texttt{3} or \texttt{Return42()}, depending on the
 \CodeSubsection{\EvalECondBegin}{\EvalECondEnd}{../Interpreter.ml}
 
 \subsubsection{Comments}
-\lrmcomment{This is related to \identr{YCDB}:}
+\identr{YCDB}
 
 A conditional expression evaluates to its \texttt{then} expression if the
 condition expression evaluates to $\True$. If the condition expression
@@ -1157,7 +1154,7 @@ changes the call type of $\vcall$ to $\calltype$.
 }
 \end{mathpar}
 \CodeSubsection{\ECallBegin}{\ECallEnd}{../Typing.ml}
-\lrmcomment{This is related to \identd{CFYP}, \identr{BQJG}.}
+\identd{CFYP} \identr{BQJG}
 
 \subsection{Semantics}
 \subsubsection{Example}
@@ -1279,7 +1276,7 @@ The details of the various types of bitvector slices is deferred to \chapref{Bit
 The width of \slices\ might be a symbolic expression if one of the
 widths references a \texttt{let} identifier with a non-compile-time-constant
 initializer expression.
-\lrmcomment{This is related to \identi{MJWM}.}
+\identi{MJWM}
 
 \TypingRuleDef{ESliceError}
 \ProseParagraph
@@ -2147,19 +2144,19 @@ normalized in the static environment $\tenv$.
 
 \hypertarget{def-atceexpressionterm}{}
 \section{Asserting Type Conversion Expressions\label{sec:AssertingTypeConversionExpressions}}
-\lrmcomment{This is related to \identi{TCST}:}
+\identi{TCST}
 The rule about domains in the definitions of subtype-satisfaction and
 type-satisfaction means that it is illegal to use the unconstrained integer
 where a constrained integer is expected. An asserting type conversion (ATC) can
 be used to overcome this.
 
-\lrmcomment{This is related to \identi{CGRH}:}
+\identi{CGRH}
 An ATC allows code to explicitly mark places where uses of constrained types
 would otherwise be a static typechecking error. The intent is to reduce the
 incidence of unintended errors by making such uses fail typechecking unless
 the asserting type conversion is provided.
 
-\lrmcomment{This is related to \identr{WZVX}:}
+\identr{WZVX}
 Note that ATCs are execution-time checks. An execution-time check is a
 condition that is evaluated during the evaluation of an execution-time
 initializer expression or subprogram. If the condition evaluates to $\False$ it
@@ -2238,9 +2235,9 @@ is a dynamic error.
 \end{mathpar}
 \CodeSubsection{\ATCBegin}{\ATCEnd}{../Typing.ml}
 \lrmcomment{
-  This is related to \identr{VBLL}, \identi{KRLL}, \identg{PFRQ}, \identi{XVBG},
-  \identr{GYJZ}, \identi{SZVF}, \identr{PZZJ}, \identr{YCPX}, \identi{ZLBW},
-  \identi{TCST}, \identi{CGRH}, \identi{YJBB}.
+  This is related to \identr{VBLL} \identi{KRLL} \identg{PFRQ} \identi{XVBG},
+  \identr{GYJZ} \identi{SZVF} \identr{PZZJ} \identr{YCPX} \identi{ZLBW},
+  \identi{TCST} \identi{CGRH} \identi{YJBB}.
 }
 
 \TypingRuleDef{CheckATC}
@@ -2354,7 +2351,7 @@ In \listingref{semantics-atcvalue}, both type assertions ---
 \ASLListing{Evaluating a successful type assertion expression}{semantics-atcvalue}{\semanticstests/SemanticsRule.ATCValue.asl}
 
 \subsubsection{Example}
-\lrmcomment{This is related to \identr{YCPX}:}
+\identr{YCPX}
 
 In \listingref{semantics-atcnotevaluated}, the asserting type conversion on \texttt{y}
 does not yield a dynamic error, since the invocation of \texttt{f1} returns $\False$ when
@@ -2827,7 +2824,7 @@ and how to obtain an arbitrary enumeration-indexed array, \texttt{enum\_array}.
 
 \subsubsection{Comments}
 Notice that this rule introduces non-determinism.
-\lrmcomment{This is related to \identr{WLCH}:}
+\identr{WLCH}
 
 \hypertarget{def-recordexpressionterm}{}
 \section{Structured Type Construction Expressions\label{sec:StructuredTypeConstructionExpressions}}
@@ -2944,7 +2941,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 \CodeSubsection{\ERecordBegin}{\ERecordEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{WBCQ}.}
+\identr{WBCQ}
 
 \hypertarget{def-annotatefieldinit}{}
 \TypingRuleDef{AnnotateFieldInit}

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -107,7 +107,7 @@ yielding an annotated global declaration $\newd$ and modified global static envi
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{func}):
+  \item \AllApplyCase{func}:
   \begin{itemize}
     \item $\vd$ is a subprogram AST node with a subprogram definition $\vf$, that is, $\DFunc(\vf)$;
     \item annotating and declaring the subprogram for $\vf$ in $\genv$ as per \\
@@ -119,7 +119,7 @@ One of the following applies:
     \item define $\newgenv$ as the global component of $\newtenv$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{global\_storage}):
+  \item \AllApplyCase{global\_storage}:
   \begin{itemize}
     \item $\vd$ is a global storage declaration with description $\gsd$, that is, \\ $\DGlobalStorage(\gsd)$;
     \item declaring the global storage with description $\gsd$ in $\genv$ yields the new environment
@@ -127,7 +127,7 @@ One of the following applies:
     \item define $\newd$ as the global storage declaration with description $\gsdp$, that is, \\ $\DGlobalStorage(\gsdp)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{type}):
+  \item \AllApplyCase{type}:
   \begin{itemize}
     \item $\vd$ is a type declaration with identifier $\vx$, type $\tty$,
           and \optional\ field initializers $\vs$, that is, $\DTypeDecl(\vx, \tty, \vs)$;
@@ -191,17 +191,17 @@ and inferred \sideeffectsetterm\ $\vses$.
 Note that the return type in $\vf$ has already been annotated by $\annotatefuncsig$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item annotating $\vf.\funcbody$ in $\tenv$ as per \TypingRuleRef{Block} yields $(\newbody, \vsesbody)$\ProseOrTypeError;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{procedure}):
+    \item \AllApplyCase{procedure}:
     \begin{itemize}
       \item $\vf.\funcreturntype$ is $\None$;
     \end{itemize}
 
-    \item All of the following apply (\textsc{function}):
+    \item \AllApplyCase{function}:
     \begin{itemize}
       \item $\vf.\funcreturntype$ is not $\None$;
       \item applying $\checkstmtreturnsorthrows$ to $\newbody$ yields $\True$\ProseOrTypeError;
@@ -257,7 +257,7 @@ checks whether all control-flow paths defined by the statement $\vs$ terminate b
 a statement returning a value, a \texttt{throw} statement, or the \texttt{Unreachable()} statement.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\controlflowfromstmt$ to $\vs$ yields a \controlflowsymbolterm\ $\vctrlflow$;
   \item checking that $\vctrlflow$ is different from $\maynotinterrupt$ yields $\True$\ProseTerminateAs{\BadSubprogramDeclaration};
@@ -310,25 +310,25 @@ and determines the \controlflowsymbolterm\ $\vctrlflow$ to be one of the followi
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{falls\_through}):
+  \item \AllApplyCase{falls\_through}:
   \begin{itemize}
     \item the AST label of $\vs$ is $\SPass$, $\SDecl$, $\SAssign$, $\SAssert$, $\SCall$, $\SPrint$ or $\SPragma$;
     \item $\vctrlflow$ is $\maynotinterrupt$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{unreachable}):
+  \item \AllApplyCase{unreachable}:
   \begin{itemize}
     \item $\vs$ is $\SUnreachable$;
     \item $\vctrlflow$ is $\assertednotinterrupt$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{return\_throw}):
+  \item \AllApplyCase{return\_throw}:
   \begin{itemize}
     \item the AST label of $\vs$ is either $\SReturn$ or $\SThrow$;
     \item $\vctrlflow$ is $\interrupt$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_seq}):
+  \item \AllApplyCase{s\_seq}:
   \begin{itemize}
     \item $\vs$ is the \sequencingstatementterm\ for $\vsone$ and $\vstwo$;
     \item applying $\controlflowfromstmt$ to $\vsone$ yields $\vctrlflowone$;
@@ -336,7 +336,7 @@ One of the following applies:
     \item applying $\controlflowseq$ to $\vctrlflowone$ and $\vctrlflowtwo$ yields $\vctrlflow$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_cond}):
+  \item \AllApplyCase{s\_cond}:
   \begin{itemize}
     \item $\vs$ is the \conditionalstatementterm\ for an expression and statements $\vsone$ and $\vstwo$;
     \item applying $\controlflowfromstmt$ to $\vsone$ yields $\vctrlflowone$;
@@ -344,19 +344,19 @@ One of the following applies:
     \item applying $\controlflowjoin$ to $\vctrlflowone$ and $\vctrlflowtwo$ yields $\vctrlflow$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_while\_for}):
+  \item \AllApplyCase{s\_while\_for}:
   \begin{itemize}
     \item $\vs$ is either a \whilestatementterm\ or a \forstatementterm;
     \item define $\vctrlflow$ as $\maynotinterrupt$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_repeat}):
+  \item \AllApplyCase{s\_repeat}:
   \begin{itemize}
     \item $\vs$ is the \repeatstatementterm\ with the body statement $\vbody$;
     \item applying $\controlflowfromstmt$ to $\vbody$ yields $\vctrlflow$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_try}):
+  \item \AllApplyCase{s\_try}:
   \begin{itemize}
     \item $\vs$ is the \trystatement{$\vbody$}{\\ $\catchers$}{$\votherwiseopt$};
     \item applying $\controlflowfromstmt$ to $\vbody$ yields $\vreszero$;

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -105,9 +105,9 @@ yielding an annotated global declaration $\newd$ and modified global static envi
 
 \TypingRuleDef{TypecheckDecl}
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{func}:
+  \item \AllApplyCase{func}
   \begin{itemize}
     \item $\vd$ is a subprogram AST node with a subprogram definition $\vf$, that is, $\DFunc(\vf)$;
     \item annotating and declaring the subprogram for $\vf$ in $\genv$ as per \\
@@ -119,7 +119,7 @@ One of the following applies:
     \item define $\newgenv$ as the global component of $\newtenv$.
   \end{itemize}
 
-  \item \AllApplyCase{global\_storage}:
+  \item \AllApplyCase{global\_storage}
   \begin{itemize}
     \item $\vd$ is a global storage declaration with description $\gsd$, that is, \\ $\DGlobalStorage(\gsd)$;
     \item declaring the global storage with description $\gsd$ in $\genv$ yields the new environment
@@ -127,7 +127,7 @@ One of the following applies:
     \item define $\newd$ as the global storage declaration with description $\gsdp$, that is, \\ $\DGlobalStorage(\gsdp)$.
   \end{itemize}
 
-  \item \AllApplyCase{type}:
+  \item \AllApplyCase{type}
   \begin{itemize}
     \item $\vd$ is a type declaration with identifier $\vx$, type $\tty$,
           and \optional\ field initializers $\vs$, that is, $\DTypeDecl(\vx, \tty, \vs)$;
@@ -194,14 +194,14 @@ Note that the return type in $\vf$ has already been annotated by $\annotatefuncs
 \AllApply
 \begin{itemize}
   \item annotating $\vf.\funcbody$ in $\tenv$ as per \TypingRuleRef{Block} yields $(\newbody, \vsesbody)$\ProseOrTypeError;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{procedure}:
+    \item \AllApplyCase{procedure}
     \begin{itemize}
       \item $\vf.\funcreturntype$ is $\None$;
     \end{itemize}
 
-    \item \AllApplyCase{function}:
+    \item \AllApplyCase{function}
     \begin{itemize}
       \item $\vf.\funcreturntype$ is not $\None$;
       \item applying $\checkstmtreturnsorthrows$ to $\newbody$ yields $\True$\ProseOrTypeError;
@@ -308,27 +308,27 @@ and determines the \controlflowsymbolterm\ $\vctrlflow$ to be one of the followi
 \end{description}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{falls\_through}:
+  \item \AllApplyCase{falls\_through}
   \begin{itemize}
     \item the AST label of $\vs$ is $\SPass$, $\SDecl$, $\SAssign$, $\SAssert$, $\SCall$, $\SPrint$ or $\SPragma$;
     \item $\vctrlflow$ is $\maynotinterrupt$;
   \end{itemize}
 
-  \item \AllApplyCase{unreachable}:
+  \item \AllApplyCase{unreachable}
   \begin{itemize}
     \item $\vs$ is $\SUnreachable$;
     \item $\vctrlflow$ is $\assertednotinterrupt$;
   \end{itemize}
 
-  \item \AllApplyCase{return\_throw}:
+  \item \AllApplyCase{return\_throw}
   \begin{itemize}
     \item the AST label of $\vs$ is either $\SReturn$ or $\SThrow$;
     \item $\vctrlflow$ is $\interrupt$;
   \end{itemize}
 
-  \item \AllApplyCase{s\_seq}:
+  \item \AllApplyCase{s\_seq}
   \begin{itemize}
     \item $\vs$ is the \sequencingstatementterm\ for $\vsone$ and $\vstwo$;
     \item applying $\controlflowfromstmt$ to $\vsone$ yields $\vctrlflowone$;
@@ -336,7 +336,7 @@ One of the following applies:
     \item applying $\controlflowseq$ to $\vctrlflowone$ and $\vctrlflowtwo$ yields $\vctrlflow$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_cond}:
+  \item \AllApplyCase{s\_cond}
   \begin{itemize}
     \item $\vs$ is the \conditionalstatementterm\ for an expression and statements $\vsone$ and $\vstwo$;
     \item applying $\controlflowfromstmt$ to $\vsone$ yields $\vctrlflowone$;
@@ -344,19 +344,19 @@ One of the following applies:
     \item applying $\controlflowjoin$ to $\vctrlflowone$ and $\vctrlflowtwo$ yields $\vctrlflow$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_while\_for}:
+  \item \AllApplyCase{s\_while\_for}
   \begin{itemize}
     \item $\vs$ is either a \whilestatementterm\ or a \forstatementterm;
     \item define $\vctrlflow$ as $\maynotinterrupt$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_repeat}:
+  \item \AllApplyCase{s\_repeat}
   \begin{itemize}
     \item $\vs$ is the \repeatstatementterm\ with the body statement $\vbody$;
     \item applying $\controlflowfromstmt$ to $\vbody$ yields $\vctrlflow$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_try}:
+  \item \AllApplyCase{s\_try}
   \begin{itemize}
     \item $\vs$ is the \trystatement{$\vbody$}{\\ $\catchers$}{$\votherwiseopt$};
     \item applying $\controlflowfromstmt$ to $\vbody$ yields $\vreszero$;

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -239,11 +239,8 @@ Note that the return type in $\vf$ has already been annotated by $\annotatefuncs
   \annotatesubprogram(\tenv, \vf, \vsesfuncsig) \typearrow \vfp
 }
 \end{mathpar}
-
-\lrmcomment{
-This is related to \identi{GHGK}, \identr{HWTV}, \identr{SCHV}, \identr{VDPC},
-\identr{TJKQ}, \identi{LFJZ}, \identi{BZVB}, \identi{RQQB}.
-}
+\identi{GHGK} \identr{HWTV} \identr{SCHV} \identr{VDPC}
+\identr{TJKQ} \identi{LFJZ} \identi{BZVB} \identi{RQQB}
 \CodeSubsection{\SubprogramBegin}{\SubprogramEnd}{../Typing.ml}
 
 \TypingRuleDef{CheckStmtReturnsOrThrows}

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -76,9 +76,13 @@ The case rules for building global declarations are the following:
 \inferrule[global\_pragma]{
   \buildclist[\Nexpr](\vargs) \astarrow \astversion{\vargs}
 }{
-    \builddecl(\overname{\Ndecl(\Tpragma, \Tidentifier(\id), \namednode{\vargs}{\ClistZero{\Nexpr}}, \Tsemicolon)}{\vparsednode})
-  \astarrow
+  {
+  \begin{array}{r}
+  \builddecl(\overname{\Ndecl(\Tpragma, \Tidentifier(\id), \namednode{\vargs}{\ClistZero{\Nexpr}}, \Tsemicolon)}{\vparsednode})
+  \astarrow \\
     \overname{\DPragma(\id, \astversion{\vargs})}{\vastnode}
+  \end{array}
+  }
 }
 \end{mathpar}
 
@@ -106,7 +110,8 @@ One of the following applies:
   \item All of the following apply (\textsc{func}):
   \begin{itemize}
     \item $\vd$ is a subprogram AST node with a subprogram definition $\vf$, that is, $\DFunc(\vf)$;
-    \item annotating and declaring the subprogram for $\vf$ in $\genv$ as per \TypingRuleRef{AnnotateAndDeclareFunc}
+    \item annotating and declaring the subprogram for $\vf$ in $\genv$ as per \\
+          \TypingRuleRef{AnnotateAndDeclareFunc}
           yields the environment $\tenvone$ and a subprogram definition $\vfone$\ProseOrTypeError;
     \item \Proseannotatesubprogram{$\vfone$}{$\tenv$}{$\vftwo$\ProseOrTypeError};
     \item applying $\addsubprogram$ to bind $\vftwo.\funcname$ to $\vftwo$ in $\tenvone$ yields $\newtenv$;
@@ -127,7 +132,9 @@ One of the following applies:
     \item $\vd$ is a type declaration with identifier $\vx$, type $\tty$,
           and \optional\ field initializers $\vs$, that is, $\DTypeDecl(\vx, \tty, \vs)$;
     \item declaring the type described by $(\vx, \tty, \vs)$ in $\genv$
-          as per \TypingRuleRef{DeclaredType} yields the modified global static environment $\newgenv$\ProseOrTypeError;
+          as per \\
+          \TypingRuleRef{DeclaredType} yields the modified global static environment \\
+          $\newgenv$\ProseOrTypeError;
     \item define $\newd$ as $\vd$.
   \end{itemize}
 \end{itemize}
@@ -171,9 +178,11 @@ One of the following applies:
 \hypertarget{def-annotatesubprogram}{}
 The function
 \[
+\begin{array}{r}
   \annotatesubprogram(\overname{\staticenvs}{\tenv} \aslsep \overname{\func}{\vf} \aslsep \overname{\TSideEffectSet}{\vsesfuncsig})
-  \aslto (\overname{\func}{\vfp} \times \overname{\TSideEffectSet}{\vses})
-  \cup \overname{\TTypeError}{\TypeErrorConfig}
+  \aslto \\
+  (\overname{\func}{\vfp} \times \overname{\TSideEffectSet}{\vses})\ \cup \overname{\TTypeError}{\TypeErrorConfig}
+\end{array}
 \]
 annotates a subprogram $\vf$ in an environment $\tenv$ and \sideeffectsetterm\ $\vsesfuncsig$, resulting in an annotated subprogram $\vfp$
 and inferred \sideeffectsetterm\ $\vses$.

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -301,9 +301,9 @@ the annotation of the type in $\tyoptp$ (in case there is a type), and the type
 that should be associated with the storage element $\declaredt$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{some\_some}:
+  \item \AllApplyCase{some\_some}
   \begin{itemize}
     \item $\tyoptp$ is the singleton set for the type $\vt$;
     \item $\initialvalue$ is the singleton set for the expression $\ve$;
@@ -318,7 +318,7 @@ One of the following applies:
     \item define $\declaredt$ as $\vtp$;
   \end{itemize}
 
-  \item \AllApplyCase{some\_none}:
+  \item \AllApplyCase{some\_none}
   \begin{itemize}
     \item $\tyoptp$ is the singleton set for the type $\vt$;
     \item $\initialvalue$ is $\None$;
@@ -331,7 +331,7 @@ One of the following applies:
     \item define $\declaredt$ as $\vtp$;
   \end{itemize}
 
-  \item \AllApplyCase{none\_some}:
+  \item \AllApplyCase{none\_some}
   \begin{itemize}
     \item $\tyoptp$ is $\None$;
     \item $\initialvalue$ is the singleton set for the expression $\ve$;
@@ -421,9 +421,9 @@ This helper function is applied following $\addglobalstorage(\tenv, \name, \gdk,
 is the type associated with $\name$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{constant}:
+  \item \AllApplyCase{constant}
   \begin{itemize}
     \item $\gdk$ is $\GDKConstant$;
     \item view $\typedinitialvalue$ as $(\Ignore, \initialvaluep, \vsesinitialvalue)$;
@@ -432,21 +432,21 @@ One of the following applies:
     \item applying $\tryaddglobalconstant$ to $\name$ and $\initialvaluep$ in $\tenv$ yields $\newtenv$.
   \end{itemize}
 
-  \item \AllApplyCase{let\_normalizable}:
+  \item \AllApplyCase{let\_normalizable}
   \begin{itemize}
     \item $\gdk$ is $\GDKLet$;
     \item applying $\normalizeopt$ to $\ve$ in $\tenv$ yields $\langle\vep\rangle$\ProseOrTypeError;
     \item applying $\addglobalimmutableexpr$ to $\name$ and $\vep$ in $\tenv$ yields $\newtenv$.
   \end{itemize}
 
-  \item \AllApplyCase{let\_non\_normalizable}:
+  \item \AllApplyCase{let\_non\_normalizable}
   \begin{itemize}
     \item $\gdk$ is $\GDKLet$;
     \item applying $\normalizeopt$ to $\ve$ in $\tenv$ yields $\None$\ProseOrTypeError;
     \item \Proseeqdef{$\newtenv$}{$\tenv$}.
   \end{itemize}
 
-  \item \AllApplyCase{config}:
+  \item \AllApplyCase{config}
   \begin{itemize}
     \item $\gdk$ is $\GDKConfig$;
     \item view $\typedinitialvalue$ as $(\Ignore, \initialvaluep, \vsesinitialvalue)$;
@@ -455,7 +455,7 @@ One of the following applies:
     \item \Proseeqdef{$\newtenv$}{$\tenv$}.
   \end{itemize}
 
-  \item \AllApplyCase{var}:
+  \item \AllApplyCase{var}
   \begin{itemize}
     \item $\gdk$ is $\GDKVar$;
     \item \Proseeqdef{$\newtenv$}{$\tenv$}.
@@ -565,15 +565,15 @@ attempts to update $\tenv$ by binding $\name$ to a literal value when $\ve$ can 
 evaluated to one. The resulting static environment is $\newtenv$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{okay}:
+  \item \AllApplyCase{okay}
   \begin{itemize}
     \item \Prosestaticeval{$\tenv$}{$\ve$}{the literal $\vv$};
     \item applying $\addglobalconstant$ to $\ve$ and $\vv$ in $\tenv$ yields $\newtenv$;
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item \Prosestaticeval{$\tenv$}{$\ve$}{a type error};
     \item \Proseeqdef{$\newtenv$}{$\tenv$};
@@ -654,15 +654,15 @@ The relation
 updates the input environment and execution graph by initializing the global storage declarations.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item there are no declarations of global variables;
     \item the result is $\envm$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vdecls$ has $\vd$ as its head and $\vdecls'$ as its tail;
     \item $d$ is the AST node for declaring a global storage element with initial value $\ve$,

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -207,7 +207,7 @@ yielding a modified global static environment $\newgenv$ and annotated global st
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\gsd$ is a global storage declaration with keyword $\keyword$, initial value \\ $\initialvalue$,
         \optional\ type $\tyopt$, and name $\name$;
@@ -303,7 +303,7 @@ that should be associated with the storage element $\declaredt$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{some\_some}):
+  \item \AllApplyCase{some\_some}:
   \begin{itemize}
     \item $\tyoptp$ is the singleton set for the type $\vt$;
     \item $\initialvalue$ is the singleton set for the expression $\ve$;
@@ -318,7 +318,7 @@ One of the following applies:
     \item define $\declaredt$ as $\vtp$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{some\_none}):
+  \item \AllApplyCase{some\_none}:
   \begin{itemize}
     \item $\tyoptp$ is the singleton set for the type $\vt$;
     \item $\initialvalue$ is $\None$;
@@ -331,7 +331,7 @@ One of the following applies:
     \item define $\declaredt$ as $\vtp$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{none\_some}):
+  \item \AllApplyCase{none\_some}:
   \begin{itemize}
     \item $\tyoptp$ is $\None$;
     \item $\initialvalue$ is the singleton set for the expression $\ve$;
@@ -423,7 +423,7 @@ is the type associated with $\name$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{constant}):
+  \item \AllApplyCase{constant}:
   \begin{itemize}
     \item $\gdk$ is $\GDKConstant$;
     \item view $\typedinitialvalue$ as $(\Ignore, \initialvaluep, \vsesinitialvalue)$;
@@ -432,21 +432,21 @@ One of the following applies:
     \item applying $\tryaddglobalconstant$ to $\name$ and $\initialvaluep$ in $\tenv$ yields $\newtenv$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{let\_normalizable}):
+  \item \AllApplyCase{let\_normalizable}:
   \begin{itemize}
     \item $\gdk$ is $\GDKLet$;
     \item applying $\normalizeopt$ to $\ve$ in $\tenv$ yields $\langle\vep\rangle$\ProseOrTypeError;
     \item applying $\addglobalimmutableexpr$ to $\name$ and $\vep$ in $\tenv$ yields $\newtenv$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{let\_non\_normalizable}):
+  \item \AllApplyCase{let\_non\_normalizable}:
   \begin{itemize}
     \item $\gdk$ is $\GDKLet$;
     \item applying $\normalizeopt$ to $\ve$ in $\tenv$ yields $\None$\ProseOrTypeError;
     \item \Proseeqdef{$\newtenv$}{$\tenv$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{config}):
+  \item \AllApplyCase{config}:
   \begin{itemize}
     \item $\gdk$ is $\GDKConfig$;
     \item view $\typedinitialvalue$ as $(\Ignore, \initialvaluep, \vsesinitialvalue)$;
@@ -455,7 +455,7 @@ One of the following applies:
     \item \Proseeqdef{$\newtenv$}{$\tenv$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{var}):
+  \item \AllApplyCase{var}:
   \begin{itemize}
     \item $\gdk$ is $\GDKVar$;
     \item \Proseeqdef{$\newtenv$}{$\tenv$}.
@@ -567,13 +567,13 @@ evaluated to one. The resulting static environment is $\newtenv$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{okay}):
+  \item \AllApplyCase{okay}:
   \begin{itemize}
     \item \Prosestaticeval{$\tenv$}{$\ve$}{the literal $\vv$};
     \item applying $\addglobalconstant$ to $\ve$ and $\vv$ in $\tenv$ yields $\newtenv$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item \Prosestaticeval{$\tenv$}{$\ve$}{a type error};
     \item \Proseeqdef{$\newtenv$}{$\tenv$};
@@ -617,7 +617,7 @@ is bound to the global storage keyword $\keyword$ and type $\declaredt$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item checking that $\name$ is not declared in the global environment of $\tenv$ yields $\True$\ProseOrTypeError;
   \item $\newgenv$ is the global static environment of $\tenv$ with its $\globalstoragetypes$ component updated by binding $\name$ to
@@ -656,13 +656,13 @@ updates the input environment and execution graph by initializing the global sto
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item there are no declarations of global variables;
     \item the result is $\envm$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\vdecls$ has $\vd$ as its head and $\vdecls'$ as its tail;
     \item $d$ is the AST node for declaring a global storage element with initial value $\ve$,

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -675,7 +675,6 @@ updates the input environment and execution graph by initializing the global sto
     \item the result of the entire evaluation is $C$.
   \end{itemize}
 \end{itemize}
-\subsubsection{Example}
 
 \FormallyParagraph
 \begin{mathpar}

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -275,7 +275,7 @@ yielding a modified global static environment $\newgenv$ and annotated global st
 }
 \end{mathpar}
 \CodeSubsection{\DeclareGlobalStorageBegin}{\DeclareGlobalStorageEnd}{../Typing.ml}
-\lrmcomment{This relates to \identr{YSPM} and \identr{FWQM}.}
+\identr{YSPM} \identr{FWQM}
 
 \TypingRuleDef{AnnotateTyOptInitialValue}
 \hypertarget{def-annotatetyoptinitialvalue}{}

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -14,8 +14,8 @@ The semantics of a single global storage declarations is defined in \SemanticsRu
 \section{Syntax\label{sec:GlobalStorageDeclarationsSyntax}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{flalign*}
-\Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
-        & \wrappedline\ \Nexpr \parsesep \Tsemicolon &\\
+\Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep &\\
+        & \wrappedline\ \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 	|\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
         & \wrappedline\ \Nexpr \parsesep \Tsemicolon &\\
         |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&\\
@@ -121,8 +121,10 @@ The semantics of a single global storage declarations is defined in \SemanticsRu
 \hypertarget{build-globaldeclkeyword}{}
 The function
 \[
-\buildglobaldeclkeyword(\overname{\parsenode{\Nglobaldeclkeyword}}{\vparsednode}) \;\aslto\;
+\begin{array}{r}
+\buildglobaldeclkeyword(\overname{\parsenode{\Nglobaldeclkeyword}}{\vparsednode}) \aslto \\
   \overname{\globaldeclkeyword}{\vastnode}
+\end{array}
 \]
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
@@ -134,13 +136,23 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[constant]{}{
-  \buildglobaldeclkeyword(\overname{\Nglobaldeclkeyword(\Tconstant)}{\vparsednode}) \astarrow \overname{\GDKConstant}{\vastnode}
+  {
+\begin{array}{r}
+  \buildglobaldeclkeyword(\overname{\Nglobaldeclkeyword(\Tconstant)}{\vparsednode}) \astarrow \\
+  \overname{\GDKConstant}{\vastnode}
+\end{array}
+  }
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[config]{}{
-  \buildglobaldeclkeyword(\overname{\Nglobaldeclkeyword(\Tconfig)}{\vparsednode}) \astarrow \overname{\GDKConfig}{\vastnode}
+  {
+  \begin{array}{r}
+    \buildglobaldeclkeyword(\overname{\Nglobaldeclkeyword(\Tconfig)}{\vparsednode}) \astarrow \\
+    \overname{\GDKConfig}{\vastnode}
+  \end{array}
+  }
 }
 \end{mathpar}
 
@@ -202,14 +214,15 @@ All of the following apply:
   \item checking that $\name$ is not already declared in $\genv$ yields $\True$\ProseOrTypeError;
   \item applying $\withemptylocal$ to $\genv$ yields $\tenv$;
   \item applying $\timeframeofgdk$ to $\keyword$ yields $\vtargettimeframe$;
-  \item applying $\annotatetyoptinitialvalue$ to $\vtargettimeframe$, $\tyoptp$, and $\initialvalue$ in $\tenv$ yields
+  \item applying $\annotatetyoptinitialvalue$ to $\vtargettimeframe$, $\tyoptp$, and \\
+        $\initialvalue$ in $\tenv$ yields
         $(\typedinitialvalue, \tyoptp, \declaredt)$\ProseOrTypeError;
   \item adding a global storage element with name $\name$, global declaration keyword \\ $\keyword$ and type $\declaredt$
         to $\tenv$ via $\addglobalstorage$ yields $\tenvone$\ProseOrTypeError;
   \item applying $\withemptylocal$ to $\genvone$ yields $\tenvone$;
   \item view $\typedinitialvalue$ as $(\Ignore, \initialvaluep, \vsesinitialvalue)$;
-  \item applying $\updateglobalstorage$ to$\name$, $\keyword$, $\initialvaluep$, and $\vsesinitialvalue$ in $\tenvone$ \\
-        yields $\tenvtwo$\ProseOrTypeError;
+  \item applying $\updateglobalstorage$ to$\name$, $\keyword$, $\initialvaluep$, and \\
+        $\vsesinitialvalue$ in $\tenvone$ yields $\tenvtwo$\ProseOrTypeError;
   \item define $\newgsd$ as $\gsd$ with its type component ($\GDty$) set to $\tyoptp$ and its initial value component
         ($\GDinitialvalue$) set to $\initialvaluep$;
   \item define $\newgenv$ as the global component of $\tenvtwo$.
@@ -398,7 +411,8 @@ The helper function
 \]
 updates the static environment $\tenv$ for the global storage element
 named $\name$ with global declaration keyword $\gdk$,
-and a tuple (obtained via \TypingRuleRef{AnnotateTyOptInitialValue})
+and a tuple (obtained via \\
+\TypingRuleRef{AnnotateTyOptInitialValue})
 $\typedinitialvalue$, which consists a type for the initializing value,
 the annotated initializing expression, and the inferred \sideeffectsetterm\ for the initializing value.
 The result is the updated static environment $\newtenv$.
@@ -595,8 +609,7 @@ The function
     \overname{\ty}{\declaredt}
   )
   \aslto
-    \overname{\globalstaticenvs}{\newgenv} \aslsep
-  \cup \overname{\TTypeError}{\TypeErrorConfig}
+    \overname{\globalstaticenvs}{\newgenv} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 returns a global static environment $\newgenv$ which is identical to the global static environment $\genv$,
 except that the identifier $\name$, which is assumed to name a global storage element,

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -143,7 +143,7 @@ $\REreallit$ &$\triangleq$& \texttt{\REdigit\ (\Underscore\ | \REdigit)* '.' \RE
 Boolean literals are written using \texttt{TRUE} or \texttt{FALSE}.
 
 \section{Bitvector Literals}
-Constant bit-vectors are written using 1, 0 and spaces surrounded by single-quotes.
+Constant bitvectors are written using 1, 0 and spaces surrounded by single-quotes.
 \hypertarget{def-rebitvectorlit}{}
 \begin{center}
 \begin{tabular}{rcl}

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -321,7 +321,6 @@ The set of tokens used for the lexical analysis of ASL strings is defined below.
   \item Tokens of the form $\Tbitvectorlit(b)$ represent bitvector literals; \hypertarget{def-tmasklit}
   \item Tokens of the form $\Tmasklit(m)$ represent constant bitmasks; \hypertarget{def-tboollit}{}
   \item Tokens of the form $\Tboollit(b)$ represent Boolean literals; \hypertarget{def-tidentifier}{}
-  \hypertarget{def-tidentifier}{}
   \item Tokens of the form $\Tidentifier(i)$ represent identifiers; \hypertarget{def-tlexeme}{}
   \item Tokens with the label $\Tlexeme$ are ones where the value $s$ is simply the \emph{lexeme} for that token.
   That is, the substring representing that token. Later we will refer to such token by simply quoting

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -34,7 +34,7 @@ Table~\ref{ta:LexicalRegularExpressions} defines the regular expressions $\RegEx
 \textbf{RegExp} & \textbf{Matches}\\
 \hline
 $\underbracket{\texttt{a\_string}}$   & Any character in \texttt{a\_string}\\
-$\square$                             & The space character (decimal 32)\\
+$\square$                             & The space character (decimal 32) \hypertarget{def-ascii}{}\\
 \ascii{a}                             & The ASCII with decimal 'a'\\
 \ascii{a-b}                           & The ASCII range between decimals 'a' and 'b'\\
 (\texttt{$A$})                        & $A$\\

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -225,7 +225,7 @@ Tuple element selectors are classed as identifiers.
 %
 For example, \texttt{item0} is classed as an identifier
 in the expression \verb|(1, 2).item0|.
-\lrmcomment{This is related to \identiTSXL}
+\identi{TSXL}
 
 \RequirementDef{ReservedIdentifiers}
 Identifiers that begin with double-underscore are reserved for use in the implementation and should

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -90,16 +90,45 @@ The function
 annotates a literal $\vl$ in the static environment $\tenv$, resulting in a type $\vt$.
 
 \ProseParagraph
-The result of annotating a literal $\vl$ in a static environment $\tenv$ is $\vt$ and one of the following applies:
+\OneApplies
 \begin{itemize}
-\item (\textsc{int}): $\vl$ is an integer literal $\vn$ and $\vt$ is the well-constrained integer type, constraining
-its set to the single value $\vn$;
-\item (\textsc{bool}): $\vl$ is a Boolean literal and $\vt$ is the Boolean type;
-\item (\textsc{real}): $\vl$ is a real literal and $\vt$ is the \realtypeterm{};
-\item (\textsc{string}): $\vl$ is a string literal and $\vt$ is the \stringtypeterm{};
-\item (\textsc{bitvector}): $\vl$ is a bitvector literal of length $\vn$ and $\vt$ is the bitvector type of fixed width $\vn$.
-\item (\textsc{label}): $\vl$ is an enumeration label for $\vlabel$ and $\vlabel$ is bound to the type $\vt$ in the
-      $\declaredtypes$ map of the global environment $\tenv$.
+  \item \AllApplyCase{int}
+  \begin{itemize}
+    \item $\vl$ is an integer literal $\vn$;
+    \item \Proseeqdef{$\vt$}{the well-constrained integer type, constraining
+          its set to the single value $\vn$}.
+  \end{itemize}
+
+  \item \AllApplyCase{bool}
+  \begin{itemize}
+    \item $\vl$ is a Boolean literal;
+    \item \Proseeqdef{$\vt$}{the \booleantypeterm}.
+  \end{itemize}
+
+  \item \AllApplyCase{real}
+  \begin{itemize}
+    \item $\vl$ is real literal;
+    \item \Proseeqdef{$\vt$}{the \realtypeterm}.
+  \end{itemize}
+
+  \item \AllApplyCase{string}
+  \begin{itemize}
+    \item $\vl$ is a string literal;
+    \item \Proseeqdef{$\vt$}{the \stringtypeterm}.
+  \end{itemize}
+
+  \item \AllApplyCase{string}
+  \begin{itemize}
+    \item $\vl$ is a bitvector literal of length $\vn$ and $\vt$;
+    \item \Proseeqdef{$\vt$}{the bitvector type of fixed width $\vn$}.
+  \end{itemize}
+
+  \item \AllApplyCase{label}
+  \begin{itemize}
+    \item $\vl$ is an enumeration label for $\vlabel$;
+    \item \Proseeqdef{$\vt$}{the type to which $\vlabel$ is bound in the
+        $\declaredtypes$ map of the global environment $\tenv$}.
+  \end{itemize}
 \end{itemize}
 
 \FormallyParagraph

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -95,7 +95,7 @@ The result of annotating a literal $\vl$ in a static environment $\tenv$ is $\vt
 \item (\textsc{int}): $\vl$ is an integer literal $\vn$ and $\vt$ is the well-constrained integer type, constraining
 its set to the single value $\vn$;
 \item (\textsc{bool}): $\vl$ is a Boolean literal and $\vt$ is the Boolean type;
-\item (\textsc{real}): $\vl$ is a real literal and $\vt$ is the real type;
+\item (\textsc{real}): $\vl$ is a real literal and $\vt$ is the \realtypeterm{};
 \item (\textsc{string}): $\vl$ is a string literal and $\vt$ is the string type;
 \item (\textsc{bitvector}): $\vl$ is a bitvector literal of length $\vn$ and $\vt$ is the bitvector type of fixed width $\vn$.
 \item (\textsc{label}): $\vl$ is an enumeration label for $\vlabel$ and $\vlabel$ is bound to the type $\vt$ in the

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -77,6 +77,10 @@ transforms a parse node $\vparsednode$ for $\Nvalue$ into an AST node $\vastnode
 \end{mathpar}
 
 \section{Typing}
+\ExampleDef{Well-typed literals}
+\listingref{literals1} shows literals and their corresponding types in comments:
+\ASLListing{Literals and their corresponding types}{literals1}{\typingtests/TypingRule.Lit.asl}
+
 \TypingRuleDef{Lit}
 \hypertarget{def-annotateliteral}{}
 The function
@@ -85,10 +89,6 @@ The function
 \]
 annotates a literal $\vl$ in the static environment $\tenv$, resulting in a type $\vt$.
 
-\subsection{Example}
-\listingref{literals1} shows literals and their corresponding types in comments:
-\ASLListing{Literals and their corresponding types}{literals1}{\typingtests/TypingRule.Lit.asl}
-
 \ProseParagraph
 The result of annotating a literal $\vl$ in a static environment $\tenv$ is $\vt$ and one of the following applies:
 \begin{itemize}
@@ -96,7 +96,7 @@ The result of annotating a literal $\vl$ in a static environment $\tenv$ is $\vt
 its set to the single value $\vn$;
 \item (\textsc{bool}): $\vl$ is a Boolean literal and $\vt$ is the Boolean type;
 \item (\textsc{real}): $\vl$ is a real literal and $\vt$ is the \realtypeterm{};
-\item (\textsc{string}): $\vl$ is a string literal and $\vt$ is the string type;
+\item (\textsc{string}): $\vl$ is a string literal and $\vt$ is the \stringtypeterm{};
 \item (\textsc{bitvector}): $\vl$ is a bitvector literal of length $\vn$ and $\vt$ is the bitvector type of fixed width $\vn$.
 \item (\textsc{label}): $\vl$ is an enumeration label for $\vlabel$ and $\vlabel$ is bound to the type $\vt$ in the
       $\declaredtypes$ map of the global environment $\tenv$.

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -89,6 +89,8 @@ The function
 \]
 annotates a literal $\vl$ in the static environment $\tenv$, resulting in a type $\vt$.
 
+See \ExampleRef{Well-typed literals}.
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -121,7 +121,7 @@ See \ExampleRef{Well-typed literals}.
 
   \item \AllApplyCase{bits}
   \begin{itemize}
-    \item $\vl$ is a bitvector literal of length $\vn$ and $\vt$;
+    \item $\vl$ is a bitvector literal of length $\vn$;
     \item \Proseeqdef{$\vt$}{the bitvector type of fixed width $\vn$}.
   \end{itemize}
 

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -117,7 +117,7 @@ annotates a literal $\vl$ in the static environment $\tenv$, resulting in a type
     \item \Proseeqdef{$\vt$}{the \stringtypeterm}.
   \end{itemize}
 
-  \item \AllApplyCase{string}
+  \item \AllApplyCase{bits}
   \begin{itemize}
     \item $\vl$ is a bitvector literal of length $\vn$ and $\vt$;
     \item \Proseeqdef{$\vt$}{the bitvector type of fixed width $\vn$}.
@@ -149,7 +149,7 @@ annotates a literal $\vl$ in the static environment $\tenv$, resulting in a type
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[bitvector]{
+\inferrule[bits]{
   n \eqdef \listlen{\bits}
 }{
   \annotateliteral{\Ignore, \lbitvector(\bits)}\typearrow \TBits(\ELInt{n}, \emptylist)

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -168,6 +168,6 @@ annotates a literal $\vl$ in the static environment $\tenv$, resulting in a type
 \section{Semantics}
 A literal $\vl$ can be converted to the \nativevalue\ $\nvliteral{\vl}$.
 
-\subsubsection{Example}
+\ExampleDef{Converting a Literal to a Value}
 The literal $\lint(5)$ can be used as a \nativevalue\ $\nvliteral{\lint(5)}$,
 which we will usually abbreviate as $\nvint(5)$.

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -212,7 +212,7 @@ the statement
 \begin{itemize}
   \item $\ldi$ denotes a tuple of identifiers $\vids_{1..k}$, that is, $\LDITuple(\vids_{1..k})$;
   \item obtaining the \underlyingtype\ of $\tty$ in $\tenv$ yields $\vtp$\ProseOrTypeError;
-  \item determining whether $\vtp$ is a tuple type yields $\True$\ProseOrTypeError;
+  \item determining whether $\vtp$ is a \tupletypeterm{} yields $\True$\ProseOrTypeError;
   \item determining whether the number of elements of $\vtp$ is $k$ yields $\True$\ProseOrTypeError;
   \item declaring the identifiers in $\vids$ in the static environment $\tenv$ from right to left with their corresponding
         (that is, with the same index) types $t_{1..k}$ in $\tenv$,

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -139,7 +139,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \section{Variable Declarations\label{sec:VariableDeclarations}}
 \subsection{Typing}
 \TypingRuleDef{LDVar}
-\subsubsection{Example}
+\ExampleDef{Well-typed Local Variable Declarations}
 In \listingref{ldvar}, the statement \texttt{let x = 3;} is legal, since
 \texttt{x} is not defined elsewhere. It is added to the type environment
 with the type inferred type \texttt{integer{3}}.
@@ -169,6 +169,10 @@ with the type inferred type \texttt{integer{3}}.
 
 \subsection{Semantics}
 \SemanticsRuleDef{LDVar}
+\ExampleDef{Evaluation of a Local Variable Declaration}
+The statement \texttt{var x = 3;} in \listingref{ldvar} binds \texttt{x}
+to the evaluation of \texttt{3} in $\env$.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -177,17 +181,6 @@ with the type inferred type \texttt{integer{3}}.
   \item declaring $\vx$ in $\env$ is $(\newenv, \vgtwo)$;
   \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge.
 \end{itemize}
-
-\subsubsection{Example}
-The statement \texttt{var x = 3;} in \listingref{ldvar} binds \texttt{x}
-to the evaluation of \texttt{3} in $\env$.
-
-\subsubsection{Example}
-In \listingref{semantics-ldvar1},
-the statement
-\texttt{var x : integer = 3;} binds \texttt{x} to the evaluation of
-\texttt{3} in $\env$.
-\ASLListing{Binding a local variable to a literal integer}{semantics-ldvar1}{\semanticstests/SemanticsRule.LDVar1.asl}
 
 \FormallyParagraph
 \begin{mathpar}
@@ -204,7 +197,7 @@ the statement
 \section{Tuple Declarations\label{sec:TupleDeclarations}}
 \subsection{Typing}
 \TypingRuleDef{LDTuple}
-\subsubsection{Example}
+\ExampleDef{Well-typed Tuple Declarations}
 \ASLListing{Declaring a tuple in the local storage}{typing-ldtuple}{\typingtests/TypingRule.LDTuple.asl}
 
 \ProseParagraph
@@ -244,7 +237,7 @@ the statement
 
 \subsection{Semantics}
 \SemanticsRuleDef{LDTuple}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Tuple Declarations}
 In \listingref{semantics-ldtuple},
 \texttt{var (x,y,z) = (1,2,3);} binds \texttt{x} to the evaluation of
 \texttt{1}, \texttt{y} to the evaluation of \texttt{2}, and \texttt{z} to the

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -165,7 +165,7 @@ with the type inferred type \texttt{integer{3}}.
 }
 \end{mathpar}
 \CodeSubsection{\LDVarBegin}{\LDVarEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{YSPM}, \identd{FXST}.}
+\identr{YSPM} \identd{FXST}
 
 \subsection{Semantics}
 \SemanticsRuleDef{LDVar}

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -146,7 +146,7 @@ with the type inferred type \texttt{integer{3}}.
 \ASLListing{A local storage declaration}{ldvar}{\typingtests/TypingRule.LDVar.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ldi$ denotes a variable $\vx$, that is, $\LDIVar(\vx)$;
   \item determining whether $\vx$ is not declared in $\tenv$ yields $\True$\ProseOrTypeError;
@@ -170,7 +170,7 @@ All of the following apply:
 \subsection{Semantics}
 \SemanticsRuleDef{LDVar}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ldi$ is a variable declaration, $\LDIVar(\vx)$;
   \item $\vm$ is a pair consisting of the value $\vv$ and execution graph $\vgone$;
@@ -208,7 +208,7 @@ the statement
 \ASLListing{Declaring a tuple in the local storage}{typing-ldtuple}{\typingtests/TypingRule.LDTuple.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ldi$ denotes a tuple of identifiers $\vids_{1..k}$, that is, $\LDITuple(\vids_{1..k})$;
   \item obtaining the \underlyingtype\ of $\tty$ in $\tenv$ yields $\vtp$\ProseOrTypeError;
@@ -252,7 +252,7 @@ evaluation of \texttt{3} in $\env$.
 \ASLListing{Evaluating a tuple declaration in the local storage}{semantics-ldtuple}{\semanticstests/SemanticsRule.LDTuple.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ldi$ declares a list of local variables, $\LDITuple(\vids)$;
   \item $\vm$ is a pair consisting of the native vector $\vv$ and execution graph $\vg$;

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -589,7 +589,7 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{3} is not great
 }
 \end{mathpar}
 \CodeSubsection{\PMaskBegin}{\PMaskEnd}{../Typing.ml}
-\lrmcomment{This is related to \identi{VMKF}.}
+\identi{VMKF}
 
 \subsection{Semantics}
 \SemanticsRuleDef{PMask}

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -147,29 +147,29 @@ since \texttt{-} matches any value and \texttt{42} in particular.
   \item \Prosechecksymbolicallyevaluable{$\vses$};
   \item obtaining the \underlyingtype\ of $\vt$ yields $\vtstruct$\ProseOrTypeError;
   \item obtaining the \underlyingtype\ of $\vte$ yields $\testruct$\ProseOrTypeError;
-  \item One of the following holds:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{t\_bool, t\_real, t\_int, t\_string}:
+    \item \AllApplyCase{t\_bool, t\_real, t\_int, t\_string}
     \begin{itemize}
       \item the AST label of $\vtstruct$ is one of $\TBool$, $\TReal$, $\TInt$, or $\TString$;
       \item checking that the labels of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
     \end{itemize}
 
-    \item \AllApplyCase{t\_bits}:
+    \item \AllApplyCase{t\_bits}
     \begin{itemize}
       \item the AST label of $\vtstruct$ is $\TBits$;
       \item checking that the labels of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
       \item determining whether the bitwidths of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
     \end{itemize}
 
-    \item \AllApplyCase{t\_enum}:
+    \item \AllApplyCase{t\_enum}
     \begin{itemize}
       \item the AST label of $\vtstruct$ is $\TEnum$;
       \item checking that the labels of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
       \item determining whether the lists of enumeration literals of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
     \end{itemize}
 
-    \item \AllApplyCase{error}:
+    \item \AllApplyCase{error}
     \begin{itemize}
       \item determining whether the labels of $\vtstruct$ and $\testruct$ are the same yields $\True$\ProseOrTypeError;
       \item the label of $\vtstruct$ is not one of $\TBool$, $\TReal$, $\TInt$, $\TBits$, or $\TEnum$;

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -666,8 +666,8 @@ is defined by the following table:
   \begin{itemize}
   \item $\vp$ is the pattern which matches a tuple $\vli$, that is, $\PatternTuple(\vli)$;
   \item obtaining the \structure\ of $\vt$ yields $\vtstruct$\ProseOrTypeError;
-  \item determining whether $\vtstruct$ is a tuple type yields $\True$\ProseOrTypeError;
-  \item $\vtstruct$ is a tuple type with list of tuple $\vts$;
+  \item determining whether $\vtstruct$ is a \tupletypeterm{} yields $\True$\ProseOrTypeError;
+  \item $\vtstruct$ is a \tupletypeterm{} with list of tuple $\vts$;
   \item determining whether $\vts$ is a list of the same size as $\vli$ yields $\True$\ProseOrTypeError;
   \item annotating each pattern in $\vli$ with the corresponding type in $\vts$ for each \Proselistrange{$i$}{$\vli$},
         yields $(\vlip[i], \vxs_i)$\ProseOrTypeError;

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -79,7 +79,7 @@ $\evalexprsef\empty$.
 \subsection{Typing}
 \TypingRuleDef{PAll}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is the pattern matching everything, that is, $\PatternAll$;
   \item $\newp$ is $\vp$;
@@ -102,7 +102,7 @@ since \texttt{-} matches any value and \texttt{42} in particular.
 \ASLListing{Matching any value}{semantics-pall}{\semanticstests/SemanticsRule.PAll.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is the pattern which matches everything, $\PatternAll$, and therefore
     matches $\vv$;
@@ -140,7 +140,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{PSingle}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is the pattern that matches the expression $\ve$, that is, $\PatternSingle(\ve)$;
   \item annotating the expression $\ve$ in $\tenv$ yields $(\vte, \vep, \vses)$\ProseOrTypeError;
@@ -149,27 +149,27 @@ All of the following apply:
   \item obtaining the \underlyingtype\ of $\vte$ yields $\testruct$\ProseOrTypeError;
   \item One of the following holds:
   \begin{itemize}
-    \item All of the following apply (\textsc{t\_bool, t\_real, t\_int, t\_string}):
+    \item \AllApplyCase{t\_bool, t\_real, t\_int, t\_string}:
     \begin{itemize}
       \item the AST label of $\vtstruct$ is one of $\TBool$, $\TReal$, $\TInt$, or $\TString$;
       \item checking that the labels of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_bits}):
+    \item \AllApplyCase{t\_bits}:
     \begin{itemize}
       \item the AST label of $\vtstruct$ is $\TBits$;
       \item checking that the labels of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
       \item determining whether the bitwidths of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_enum}):
+    \item \AllApplyCase{t\_enum}:
     \begin{itemize}
       \item the AST label of $\vtstruct$ is $\TEnum$;
       \item checking that the labels of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
       \item determining whether the lists of enumeration literals of $\vtstruct$ and $\testruct$ are equal yields $\True$\ProseOrTypeError;
     \end{itemize}
 
-    \item All of the following apply (\textsc{error}):
+    \item \AllApplyCase{error}:
     \begin{itemize}
       \item determining whether the labels of $\vtstruct$ and $\testruct$ are the same yields $\True$\ProseOrTypeError;
       \item the label of $\vtstruct$ is not one of $\TBool$, $\TReal$, $\TInt$, $\TBits$, or $\TEnum$;
@@ -251,7 +251,7 @@ whereas \\
 \ASLListing{Matching against a single value}{semantics-psingle}{\semanticstests/SemanticsRule.PSingle.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is the condition corresponding to being equal to the
     side-effect-free expression $\ve$, $\PatternSingle(\ve)$;
@@ -297,7 +297,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{PRange}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is the pattern which matches anything within the range given by
   expressions $\veone$ and $\vetwo$, that is, $\PatternRange(\veone, \vetwo)$;
@@ -346,7 +346,7 @@ range given by \texttt{3..42}.
 \ASLListing{Matching against a range of values}{semantics-prange}{\semanticstests/SemanticsRule.PRange.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is the condition corresponding to being greater than or equal
     to $\veone$, and lesser or equal to $\vetwo$, that is, $\PatternRange(\veone, \vetwo)$;
@@ -398,7 +398,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{PLeq}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\vp$ is the pattern which matches anything less than or equal to an expression $\ve$,
 that is, $\PatternLeq(\ve)$;
@@ -441,7 +441,7 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{42} is not less
 \ASLListing{Matching against an upper bound value}{semantics-pleq}{\semanticstests/SemanticsRule.PLeq.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is the condition corresponding to being less than or equal
     to the side-effect-free expression $\ve$, $\PatternLeq(\ve)$;
@@ -483,7 +483,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{PGeq}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\vp$ is the pattern which matches anything greater than or equal to an expression $\ve$,
       that is, $\PatternGeq(\ve)$;
@@ -526,7 +526,7 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{3} is not great
 \ASLListing{Matching against a lower bound}{semantics-pgeq}{\semanticstests/SemanticsRule.PGeq.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is the condition corresponding to being greater than or equal
     than the side-effect-free expression $\ve$, $\PatternGeq(\ve)$;
@@ -568,7 +568,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{PMask}
 \ProseParagraph
-All of the following apply:
+\AllApply
   \begin{itemize}
   \item $\vp$ is the pattern which matches a mask $\vm$, that is, $\PatternMask(\vm)$;
   \item determining whether $\vt$ has the structure of a bitvector type yields $\True$\ProseOrTypeError;
@@ -601,7 +601,7 @@ whereas \texttt{match\_false} evaluates to \False, since
 \ASLListing{Matching against a bitmask}{semantics-pmask}{\semanticstests/SemanticsRule.PMask.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is a mask pattern, $\PatternMask(\vm)$,
   of length $n$ (with spaces removed);
@@ -662,7 +662,7 @@ is defined by the following table:
 \subsection{Typing}
 \TypingRuleDef{PTuple}
 \ProseParagraph
-All of the following apply:
+\AllApply
   \begin{itemize}
   \item $\vp$ is the pattern which matches a tuple $\vli$, that is, $\PatternTuple(\vli)$;
   \item obtaining the \structure\ of $\vt$ yields $\vtstruct$\ProseOrTypeError;
@@ -704,7 +704,7 @@ the tuple of expression \texttt{(3, '1101010')} does not match the tuple of patt
 \ASLListing{Matching against a tuple of patterns}{semantics-ptuple}{\semanticstests/SemanticsRule.PTuple.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ gives a list of patterns $\vps$ of length $k$, $\PatternTuple(\vps)$;
   \item $\vv$ gives a tuple of values $\vvs$ of length $k$;
@@ -792,7 +792,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \subsection{Typing}
 \TypingRuleDef{PAny}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\vp$ is the pattern which matches anything in a list $\vli$, that is, $\PatternAny(\vli)$;
 \item annotating each pattern $\vl$ in $\vli$ yields $(\newl_\vl, \vxs_\vl)$\ProseOrTypeError;
@@ -825,7 +825,7 @@ any pattern in \verb|{3, 4}|.
 \ASLListing{Matching against any pattern in a list of patterns}{semantics-pany}{\semanticstests/SemanticsRule.PAny.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is a list of patterns, $\PatternAny(\vps)$;
   \item $\vps$ is $\vp_{1..k}$;
@@ -863,7 +863,7 @@ The AST building rule is \ASTRuleRef{PatternSet} (the \textsc{NOT} case).
 \subsection{Typing}
 \TypingRuleDef{PNot}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is the pattern which matches the negation of a pattern $\vq$, that is, $\PatternNot(\vq)$;
   \item annotating $\vq$ in $\tenv$ yields $(\newq, \vses)$\ProseOrTypeError;
@@ -888,7 +888,7 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{42} does match 
 \ASLListing{Matching against a negated pattern}{semantics-pnot}{\semanticstests/SemanticsRule.PNot.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vp$ is a negation pattern, $\PatternNot(\vpone)$;
   \item evaluating that pattern $\vpone$ in an environment $\env$ is \\

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -310,7 +310,7 @@ All of the following apply:
   \item a check the AST labels of $\vtstruct$, $\vteonestruct$, and $\vtetwostruct$ are all the same and are either
         $\TInt$ or $\TReal$ yields $\True$. Otherwise, the result is a type error, which short-circuits the entire rule.
         The type error indicates that the types of
-        $\veone$, $\vetwo$ and the type $\vt$ must be either of integer type or of real type.
+        $\veone$, $\vetwo$ and the type $\vt$ must be either of integer type or of \realtypeterm{}.
   \item $\newp$ is a range pattern with bounds $\veonep$ and $\vetwop$, that is, $\PatternRange(\veonep, \vetwop)$.
 \end{itemize}
 \FormallyParagraph
@@ -406,7 +406,7 @@ that is, $\PatternLeq(\ve)$;
 \item \Prosechecksymbolicallyevaluable{$\vses$};
 \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields $\vtstruct$\ProseOrTypeError;
 \item obtaining the \underlyingtype\ of $\vte$ in $\tenv$ yields $\testruct$\ProseOrTypeError;
-\item $\vb$ is true if and only if $\vtstruct$ and $\testruct$ are both integer types or both real types;
+\item $\vb$ is true if and only if $\vtstruct$ and $\testruct$ are both integer types or both the \realtypeterm{};
 \item if $\vb$ is $\False$ a type error is returned (indicating that the types of $\vt$ and $\vte$
       are inappropriate for the $\LEQ$ operator),
 which short-circuits the entire rule;
@@ -491,7 +491,7 @@ All of the following apply:
 \item \Prosechecksymbolicallyevaluable{$\vses$};
 \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields $\vtstruct$\ProseOrTypeError;
 \item obtaining the \underlyingtype\ of $\vte$ in $\tenv$ yields $\testruct$\ProseOrTypeError;
-\item $\vb$ is true if and only if $\vtstruct$ and $\testruct$ are both integer types or both real types;
+\item $\vb$ is true if and only if $\vtstruct$ and $\testruct$ are both integer types or both the \realtypeterm{};
 \item if $\vb$ is $\False$ a type error is returned (indicating that the types of $\vt$ and $\vte$
       are inappropriate for the $\GEQ$ operator),
       which short-circuits the entire rule;

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -96,7 +96,7 @@ $\evalexprsef\empty$.
 
 \subsection{Semantics}
 \SemanticsRuleDef{PAll}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Match-all Pattern}
 In \listingref{semantics-pall}, \texttt{match\_me} evaluates to \True,
 since \texttt{-} matches any value and \texttt{42} in particular.
 \ASLListing{Matching any value}{semantics-pall}{\semanticstests/SemanticsRule.PAll.asl}
@@ -243,7 +243,7 @@ since \texttt{-} matches any value and \texttt{42} in particular.
 
 \subsection{Semantics}
 \SemanticsRuleDef{PSingle}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Single-expression Pattern}
 In \listingref{semantics-psingle},
 \texttt{match\_true} evaluates to \True, since \texttt{42} matches \verb|{42}|,
 whereas \\
@@ -337,7 +337,7 @@ whereas \\
 
 \subsection{Semantics}
 \SemanticsRuleDef{PRange}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Range Pattern}
 In \listingref{semantics-prange},
 \texttt{match\_true} evaluates to \True, since \texttt{42} is in the range given by
 \texttt{3..42},
@@ -434,7 +434,7 @@ which short-circuits the entire rule;
 
 \subsection{Semantics}
 \SemanticsRuleDef{PLeq}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Less-or-equal Pattern}
 In \listingref{semantics-pleq},
 \texttt{match\_true} evaluates to \True, since \texttt{3} is less than or equal to \texttt{42},
 whereas \texttt{match\_false} evaluates to \False, since \texttt{42} is not less than or equal to \texttt{3}.
@@ -519,7 +519,7 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{42} is not less
 
 \subsection{Semantics}
 \SemanticsRuleDef{PGeq}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Greater-or-equal Pattern}
 In \listingref{semantics-pgeq},
 \texttt{match\_true} evaluates to \True, since \texttt{42} is greater or equal to \texttt{3},
 whereas \texttt{match\_false} evaluates to \False, since \texttt{3} is not greater or equal to \texttt{42}.
@@ -593,7 +593,7 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{3} is not great
 
 \subsection{Semantics}
 \SemanticsRuleDef{PMask}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Mask Pattern}
 In \listingref{semantics-pmask}, \texttt{match\_true} evaluates to \True, since
 \texttt{101010} matches the bitmask \texttt{xx1010},
 whereas \texttt{match\_false} evaluates to \False, since
@@ -693,7 +693,7 @@ is defined by the following table:
 
 \subsection{Semantics}
 \SemanticsRuleDef{PTuple}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Tuple Pattern}
 In \listingref{semantics-ptuple},
 \texttt{match\_true} evaluates to \True, since
 the tuple of expression \\
@@ -817,7 +817,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \subsection{Semantics}
 \SemanticsRuleDef{PAny}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Match-any Pattern}
 In \listingref{semantics-pany},
 \texttt{match\_true} evaluates to \True, since \texttt{42} matches the second pattern in \verb|{3, 42}|,
 whereas \texttt{match\_false} evaluates to \False, since \texttt{42} does not match
@@ -881,7 +881,7 @@ The AST building rule is \ASTRuleRef{PatternSet} (the \textsc{NOT} case).
 
 \subsection{Semantics}
 \SemanticsRuleDef{PNot}
-\subsubsection{Example}
+\ExampleDef{Evaluation of a Negated Pattern}
 In \listingref{semantics-pnot},
 \texttt{match\_true} evaluates to \True, since \texttt{42} does not match the pattern \verb|{3}|,
 whereas \texttt{match\_false} evaluates to \False, since \texttt{42} does match the pattern \verb|{42}|.

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -281,13 +281,13 @@ operation.
 \hline
 \textbf{Operator} & \textbf{Operand 1} & \textbf{Operand 2} & \textbf{Result} & \textbf{Name}\\
 \hline
-\Tbnot & \lbool & -        & \lbool & \aslnotbool\\
-\Tband & \lbool & \lbool  & \lbool & \andbool\\
-\Tbor & \lbool & \lbool  & \lbool & \orbool\\
-\Teqop & \lbool & \lbool  & \lbool & \eqbool\\
-\Tneq & \lbool & \lbool  & \lbool & \nebool\\
-\Timpl & \lbool & \lbool  & \lbool & \impliesbool\\
-\Tbeq & \lbool & \lbool  & \lbool & \equivbool\\
+$\Tbnot$  & $\lbool$ & -        & $\lbool$ & $\aslnotbool$\\
+$\Tband$  & $\lbool$ & $\lbool$ & $\lbool$ & $\andbool$\\
+$\Tbor$   & $\lbool$ & $\lbool$ & $\lbool$ & $\orbool$\\
+$\Teqop$  & $\lbool$ & $\lbool$ & $\lbool$ & $\eqbool$\\
+$\Tneq$   & $\lbool$ & $\lbool$ & $\lbool$ & $\nebool$\\
+$\Timpl$  & $\lbool$ & $\lbool$ & $\lbool$ & $\impliesbool$\\
+$\Tbeq$   & $\lbool$ & $\lbool$ & $\lbool$ & $\equivbool$\\
 \hline
 \end{tabular}
 \end{table}
@@ -315,22 +315,22 @@ operation.
 \hline
 \textbf{Operator} & \textbf{Operand 1} & \textbf{Operand 2} & \textbf{Result} & \textbf{Name}\\
 \hline
-\Tminus & \lint & - & \lint & \negateint\\
-\Tplus & \lint & \lint & \lint & \addint\\
-\Tminus & \lint & \lint & \lint & \subint\\
-\Tmul & \lint & \lint & \lint & \mulint\\
-\Tpow & \lint & \lint & \lint & \expint\\
-\Tshl & \lint & \lint & \lint & \shiftleftint\\
-\Tshr & \lint & \lint & \lint & \shiftrightint\\
-\Tdiv & \lint & \lint & \lint & \divint\\
-\Tdivrm & \lint & \lint & \lint & \fdivint\\
-\Tmod & \lint & \lint & \lint & \fremint\\
-\Teqop & \lint & \lint & \lbool & \eqint\\
-\Tneq & \lint & \lint & \lbool & \neint\\
-\Tleq & \lint & \lint & \lbool & \leint\\
-\Tlt & \lint & \lint & \lbool & \ltint\\
-\Tgt & \lint & \lint & \lbool & \gtint\\
-\Tgeq & \lint & \lint & \lbool & \geint\\
+$\Tminus$ & $\lint$ & - & $\lint$ & $\negateint$\\
+$\Tplus$  & $\lint$ & $\lint$ & $\lint$   & $\addint$\\
+$\Tminus$ & $\lint$ & $\lint$ & $\lint$   & $\subint$\\
+$\Tmul$   & $\lint$ & $\lint$ & $\lint$   & $\mulint$\\
+$\Tpow$   & $\lint$ & $\lint$ & $\lint$   & $\expint$\\
+$\Tshl$   & $\lint$ & $\lint$ & $\lint$   & $\shiftleftint$\\
+$\Tshr$   & $\lint$ & $\lint$ & $\lint$   & $\shiftrightint$\\
+$\Tdiv$   & $\lint$ & $\lint$ & $\lint$   & $\divint$\\
+$\Tdivrm$ & $\lint$ & $\lint$ & $\lint$   & $\fdivint$\\
+$\Tmod$   & $\lint$ & $\lint$ & $\lint$   & $\fremint$\\
+$\Teqop$  & $\lint$ & $\lint$ & $\lbool$  & $\eqint$\\
+$\Tneq$   & $\lint$ & $\lint$ & $\lbool$  & $\neint$\\
+$\Tleq$   & $\lint$ & $\lint$ & $\lbool$  & $\leint$\\
+$\Tlt$    & $\lint$ & $\lint$ & $\lbool$  & $\ltint$\\
+$\Tgt$    & $\lint$ & $\lint$ & $\lbool$  & $\gtint$\\
+$\Tgeq$   & $\lint$ & $\lint$ & $\lbool$  & $\geint$\\
 \hline
 \end{tabular}
 \end{table}
@@ -354,18 +354,18 @@ operation.
 \hline
 \textbf{Operator} & \textbf{Operand 1} & \textbf{Operand 2} & \textbf{Result} & \textbf{Name}\\
 \hline
-\Tminus & \lreal & - & \lreal & \negatereal\\
-\Tplus & \lreal & \lreal & \lreal & \addreal\\
-\Tminus & \lreal & \lreal & \lreal & \subreal\\
-\Tmul & \lreal & \lreal & \lreal & \mulreal\\
-\Tpow & \lreal & \lint & \lreal & \expreal\\
-\Trdiv & \lreal & \lreal & \lreal & \divreal\\
-\Teqop & \lreal & \lreal & \lbool & \eqreal\\
-\Tneq  & \lreal & \lreal & \lbool & \nereal\\
-\Tleq  & \lreal & \lreal & \lbool & \lereal\\
-\Tlt & \lreal & \lreal & \lbool & \ltreal\\
-\Tgt & \lreal & \lreal & \lbool & \gtreal\\
-\Tgeq  & \lreal & \lreal & \lbool & \gereal\\
+$\Tminus$ & $\lreal$ & - & $\lreal$ & $\negatereal$\\
+$\Tplus$  & $\lreal$ & $\lreal$ & $\lreal$ & $\addreal$\\
+$\Tminus$ & $\lreal$ & $\lreal$ & $\lreal$ & $\subreal$\\
+$\Tmul$   & $\lreal$ & $\lreal$ & $\lreal$ & $\mulreal$\\
+$\Tpow$   & $\lreal$ & $\lint$  & $\lreal$ & $\expreal$\\
+$\Trdiv$  & $\lreal$ & $\lreal$ & $\lreal$ & $\divreal$\\
+$\Teqop$  & $\lreal$ & $\lreal$ & $\lbool$ & $\eqreal$\\
+$\Tneq$   & $\lreal$ & $\lreal$ & $\lbool$ & $\nereal$\\
+$\Tleq$   & $\lreal$ & $\lreal$ & $\lbool$ & $\lereal$\\
+$\Tlt$    & $\lreal$ & $\lreal$ & $\lbool$ & $\ltreal$\\
+$\Tgt$    & $\lreal$ & $\lreal$ & $\lbool$ & $\gtreal$\\
+$\Tgeq$   & $\lreal$ & $\lreal$ & $\lbool$ & $\gereal$\\
 \hline
 \end{tabular}
 \end{table}
@@ -388,17 +388,17 @@ operation.
 \hline
 \textbf{Operator} & \textbf{Operand 1} & \textbf{Operand 2} & \textbf{Result} & \textbf{Name}\\
 \hline
-\Tplus  & \lbitvector & \lbitvector & \lbitvector & \addbits\\
-\Tplus  & \lbitvector & \lint  & \lbitvector & \addbitsint\\
-\Tminus & \lbitvector & \lbitvector & \lbitvector & \subbits\\
-\Tminus & \lbitvector & \lint  & \lbitvector & \subbitsint\\
-\Tnot   & \lbitvector & -      & \lbitvector & \notbits\\
-\Tand   & \lbitvector & \lbitvector & \lbitvector & \andbits\\
-\Tor    & \lbitvector & \lbitvector & \lbitvector & \orbits\\
-\Txor   & \lbitvector & \lbitvector & \lbitvector & \xorbits\\
-\Teqop  & \lbitvector & \lbitvector & \lbool & \eqbits\\
-\Tneq   & \lbitvector & \lbitvector & \lbool & \nebits\\
-\Tcoloncolon & \lbitvector & \lbitvector & \lbitvector & \concatbits\\
+$\Tplus$        & $\lbitvector$ & $\$lbitvector$ & $\lbitvector$ & $\addbits$\\
+$\Tplus$        & $\lbitvector$ & $\$lint$       & $\lbitvector$ & $\addbitsint$\\
+$\Tminus$       & $\lbitvector$ & $\$lbitvector$ & $\lbitvector$ & $\subbits$\\
+$\Tminus$       & $\lbitvector$ & $\$lint$       & $\lbitvector$ & $\subbitsint$\\
+$\Tnot$         & $\lbitvector$ & -              & $\lbitvector$ & $\notbits$\\
+$\Tand$         & $\lbitvector$ & $\$lbitvector$ & $\lbitvector$ & $\andbits$\\
+$\Tor$          & $\lbitvector$ & $\$lbitvector$ & $\lbitvector$ & $\orbits$\\
+$\Txor$         & $\lbitvector$ & $\$lbitvector$ & $\lbitvector$ & $\xorbits$\\
+$\Teqop$        & $\lbitvector$ & $\$lbitvector$ & $\lbool$      & $\eqbits$\\
+$\Tneq$         & $\lbitvector$ & $\$lbitvector$ & $\lbool$      & $\nebits$\\
+$\Tcoloncolon$  & $\lbitvector$ & $\$lbitvector$ & $\lbitvector$ & $\concatbits$\\
 \hline
 \end{tabular}
 \end{table}
@@ -412,8 +412,8 @@ operation.
 \hline
 \textbf{Operator} & \textbf{Operand 1} & \textbf{Operand 2} & \textbf{Result} & \textbf{Name}\\
 \hline
-\Teqop  & \lstring & \lstring & \lbool & \eqstring\\
-\Tneq   & \lstring & \lstring & \lbool & \nestring\\
+$\Teqop$  & $\lstring$ & $\lstring$ & $\lbool$ & $\eqstring$\\
+$\Tneq$   & $\lstring$ & $\lstring$ & $\lbool$ & $\nestring$\\
 \hline
 \end{tabular}
 \end{table}
@@ -427,8 +427,8 @@ operation.
 \hline
 \textbf{Operator} & \textbf{Operand 1} & \textbf{Operand 2} & \textbf{Result} & \textbf{Name}\\
 \hline
-\Teqop  & \llabel & \llabel & \lbool & \eqenum\\
-\Tneq   & \llabel & \llabel & \lbool & \neenum\\
+$\Teqop$  & $\llabel$ & $\llabel$ & $\lbool$ & $\eqenum$\\
+$\Tneq$   & $\llabel$ & $\llabel$ & $\lbool$ & $\neenum$\\
 \hline
 \end{tabular}
 \end{table}

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -1,7 +1,7 @@
 \chapter{Primitive Operations\label{chap:PrimitiveOperations}}
 
-\lrmcomment{\identd{KXWT}}
-\lrmcomment{\identi{HSQL}}
+\identd{KXWT}
+\identi{HSQL}
 The term \emph{Primitive Operations} denotes the set of operations available
 in the expression syntax that use an \emph{Operator} derived from either
 $\unop$ or $\binop$.
@@ -238,7 +238,7 @@ to refer to one of several different operations.
 for each primitive operation, the kinds of input literals and the kind of output literals,
 as well as assigning each primitive operation a unique name.
 
-\lrmcomment{BKNT}
+\identr{BKNT}
 \RequirementDef{PrimitiveOperatorImplements}
 An operation implements an operator if it appears in the same row as the operator in one
 of the tables in this section.
@@ -246,7 +246,7 @@ of the tables in this section.
 For example, the operation $\aslnotbool$ implements the operator $\Tbnot$
 as it appears on the first two of \taref{BooleanOperators}.
 
-\lrmcomment{JGWF}
+\identr{JGWF}
 \RequirementDef{PrimitiveOperatorMatches}
 An expression which invokes a primitive operator \emph{matches} an operation
 if the operation implements the operator and the operands of the expression
@@ -257,7 +257,7 @@ For example, the expression \verb|!TRUE|, which invokes the primitive operator
 $\Tbnot$, matches the primitive operation $\aslnotbool$, since the operand $\True$
 \typesatisfies{} the \booleantypeterm{}.
 
-\lrmcomment{TTGQ}
+\identr{TTGQ}
 \RequirementDef{PrimitiveOperationError}
 It is a type error if an expression which invokes a
 primitive operator does not match exactly one primitive operation

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -255,7 +255,7 @@ tables in this section.
 %
 For example, the expression \verb|!TRUE|, which invokes the primitive operator
 $\Tbnot$, matches the primitive operation $\aslnotbool$, since the operand $\True$
-\typesatisfies{} the \texttt{boolean} type.
+\typesatisfies{} the \booleantypeterm{}.
 
 \lrmcomment{TTGQ}
 \RequirementDef{PrimitiveOperationError}

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -480,34 +480,34 @@ not_bits: NOT '11 01' = 0x2
 % CONSOLE_END
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item $(\op, \astlabel(\vl))$ is not in $\unopsignatures$;
     \item the result is a type error indicating that the combination of $\op$ and $\astlabel(\vl)$
           is not legal.
   \end{itemize}
 
-  \item \AllApplyCase{negate\_int}:
+  \item \AllApplyCase{negate\_int}
   \begin{itemize}
     \item $\op$ is $\NEG$ and $\vl$ is an integer literal for $\vn$;
     \item define $\vr$ as the integer literal for $- \vn$.
   \end{itemize}
 
-  \item \AllApplyCase{negate\_real}:
+  \item \AllApplyCase{negate\_real}
   \begin{itemize}
     \item $\op$ is $\NEG$ and $\vl$ is a real literal for $\vq$;
     \item define $\vr$ as the real literal for $- \vq$.
   \end{itemize}
 
-  \item \AllApplyCase{not\_bool}:
+  \item \AllApplyCase{not\_bool}
   \begin{itemize}
     \item $\op$ is $\BNOT$ and $\vl$ is a Boolean literal for $\vb$;
     \item define $\vr$ as the Boolean literal for $\neg\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{not\_bits\_empty}, \textsc{not\_bits\_empty}:
+  \item \AllApplyCase{not\_bits\_empty}, \textsc{not\_bits\_empty}
   \begin{itemize}
     \item $\op$ is $\NOT$ and $\vl$ is a bitvector literal for the sequence of bits $\bits$;
     \item $\vc$ is the sequence of bits of the same length as $\bits$ where in each position
@@ -780,34 +780,34 @@ and argument types of its operand literals:
 \]
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item $(\op, \astlabel(\vlone), \astlabel(\vltwo))$ is not included in $\binopsignatures$;
     \item the result is a type error indicating the $\op$ cannot be applied to the arguments
           with the types given by $\astlabel(\vlone)$ and $\astlabel(\vltwo)$.
   \end{itemize}
 
-  \item \AllApplyCase{add\_int}:
+  \item \AllApplyCase{add\_int}
   \begin{itemize}
     \item $\op$ is $\PLUS$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the literal integer for $a+b$.
   \end{itemize}
 
-  \item \AllApplyCase{sub\_int}:
+  \item \AllApplyCase{sub\_int}
   \begin{itemize}
     \item $\op$ is $\MINUS$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the literal integer for $a-b$.
   \end{itemize}
 
-  \item \AllApplyCase{mul\_int}:
+  \item \AllApplyCase{mul\_int}
   \begin{itemize}
     \item $\op$ is $\MUL$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the literal integer for $a\times b$.
   \end{itemize}
 
-  \item \AllApplyCase{div\_int}:
+  \item \AllApplyCase{div\_int}
   \begin{itemize}
     \item $\op$ is $\DIV$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is positive yields $\True$\ProseOrTypeError;
@@ -816,7 +816,7 @@ One of the following applies:
     \item define $\vr$ as the literal integer for $a\div b$.
   \end{itemize}
 
-  \item \AllApplyCase{fdiv\_int}:
+  \item \AllApplyCase{fdiv\_int}
   \begin{itemize}
     \item $\op$ is $\DIVRM$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is positive yields $\True$\ProseOrTypeError;
@@ -824,7 +824,7 @@ One of the following applies:
     \item define $\vr$ as the literal integer for $n$.
   \end{itemize}
 
-  \item \AllApplyCase{frem\_int}:
+  \item \AllApplyCase{frem\_int}
   \begin{itemize}
     \item $\op$ is $\MOD$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item applying $\binopliterals$ to $\DIVRM$ with $\vlone$ and $\vltwo$ yields $c$\ProseOrTypeError;
@@ -832,7 +832,7 @@ One of the following applies:
     \item define $\vr$ as the literal integer for $n$.
   \end{itemize}
 
-  \item \AllApplyCase{exp\_int}:
+  \item \AllApplyCase{exp\_int}
   \begin{itemize}
     \item $\op$ is $\POW$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is non-negative yields $\True$\ProseOrTypeError;
@@ -840,7 +840,7 @@ One of the following applies:
     \item define $\vr$ as the literal integer for $n$.
   \end{itemize}
 
-  \item \AllApplyCase{shl}:
+  \item \AllApplyCase{shl}
   \begin{itemize}
     \item $\op$ is $\SHL$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is non-negative yields $\True$\ProseOrTypeError;
@@ -848,7 +848,7 @@ One of the following applies:
     \item applying $\binopliterals$ to $\MUL$ with $2$ and the literal integer for $e$ yields $\vr$.
   \end{itemize}
 
-  \item \AllApplyCase{shr}:
+  \item \AllApplyCase{shr}
   \begin{itemize}
     \item $\op$ is $\SHR$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is non-negative yields $\True$\ProseOrTypeError;
@@ -856,98 +856,98 @@ One of the following applies:
     \item applying $\binopliterals$ to $\DIVRM$ with $2$ and the literal integer for $e$ yields $\vr$.
   \end{itemize}
 
-  \item \AllApplyCase{eq\_int}:
+  \item \AllApplyCase{eq\_int}
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item \AllApplyCase{ne\_int}:
+  \item \AllApplyCase{ne\_int}
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$ holds.
   \end{itemize}
 
-  \item \AllApplyCase{le\_int}:
+  \item \AllApplyCase{le\_int}
   \begin{itemize}
     \item $\op$ is $\LEQ$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is less than or equal to $b$s.
   \end{itemize}
 
-  \item \AllApplyCase{lt\_int}:
+  \item \AllApplyCase{lt\_int}
   \begin{itemize}
     \item $\op$ is $\LT$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is less than $b$s.
   \end{itemize}
 
-  \item \AllApplyCase{ge\_int}:
+  \item \AllApplyCase{ge\_int}
   \begin{itemize}
     \item $\op$ is $\GEQ$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is greater or equal than $b$s.
   \end{itemize}
 
-  \item \AllApplyCase{gt\_int}:
+  \item \AllApplyCase{gt\_int}
   \begin{itemize}
     \item $\op$ is $\GT$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is greater than $b$s.
   \end{itemize}
 
-  \item \AllApplyCase{and\_bool}:
+  \item \AllApplyCase{and\_bool}
   \begin{itemize}
     \item $\op$ is $\BAND$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if both $a$ and $b$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{or\_bool}:
+  \item \AllApplyCase{or\_bool}
   \begin{itemize}
     \item $\op$ is $\BOR$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if at least one of $a$ and $b$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{implies\_bool}:
+  \item \AllApplyCase{implies\_bool}
   \begin{itemize}
     \item $\op$ is $\IMPL$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is $\False$ or $b$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{eq\_bool}:
+  \item \AllApplyCase{eq\_bool}
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item \AllApplyCase{ne\_bool}:
+  \item \AllApplyCase{ne\_bool}
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
   \end{itemize}
 
-  \item \AllApplyCase{add\_real}:
+  \item \AllApplyCase{add\_real}
   \begin{itemize}
     \item $\op$ is $\PLUS$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the real literal for $a + b$.
   \end{itemize}
 
-  \item \AllApplyCase{sub\_real}:
+  \item \AllApplyCase{sub\_real}
   \begin{itemize}
     \item $\op$ is $\MINUS$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the real literal for $a - b$.
   \end{itemize}
 
-  \item \AllApplyCase{mul\_real}:
+  \item \AllApplyCase{mul\_real}
   \begin{itemize}
     \item $\op$ is $\MUL$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the real literal for $a \times b$.
   \end{itemize}
 
-  \item \AllApplyCase{div\_real}:
+  \item \AllApplyCase{div\_real}
   \begin{itemize}
     \item $\op$ is $\RDIV$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item checking whether $b$ is different from $0$ yields $\True$\ProseOrTypeError;
     \item define $\vr$ as the real literal for $a \div b$.
   \end{itemize}
 
-  \item \AllApplyCase{exp\_real}:
+  \item \AllApplyCase{exp\_real}
   \begin{itemize}
     \item $\op$ is $\POW$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal integer for $b$;
     \item since exponentiation is undefined when $a$ is 0 and $b$ is negative,
@@ -955,43 +955,43 @@ One of the following applies:
     \item define $\vr$ as the real literal for $a^b$.
   \end{itemize}
 
-  \item \AllApplyCase{eq\_real}:
+  \item \AllApplyCase{eq\_real}
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item \AllApplyCase{ne\_real}:
+  \item \AllApplyCase{ne\_real}
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
   \end{itemize}
 
-  \item \AllApplyCase{le\_real}:
+  \item \AllApplyCase{le\_real}
   \begin{itemize}
     \item $\op$ is $\LEQ$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is less than or equal to $b$.
   \end{itemize}
 
-  \item \AllApplyCase{lt\_real}:
+  \item \AllApplyCase{lt\_real}
   \begin{itemize}
     \item $\op$ is $\LT$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is less than $b$.
   \end{itemize}
 
-  \item \AllApplyCase{ge\_real}:
+  \item \AllApplyCase{ge\_real}
   \begin{itemize}
     \item $\op$ is $\GEQ$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is greater than or equal to $b$.
   \end{itemize}
 
-  \item \AllApplyCase{gt\_real}:
+  \item \AllApplyCase{gt\_real}
   \begin{itemize}
     \item $\op$ is $\GT$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is greater than $b$.
   \end{itemize}
 
-  \item \AllApplyCase{bitwise\_different\_bitwidths}:
+  \item \AllApplyCase{bitwise\_different\_bitwidths}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a$;
     \item $\vvtwo$ is a bitvector literal for $b$;
@@ -999,7 +999,7 @@ One of the following applies:
     \item the result is a type error indicating that the bitvectors must be of the same width.
   \end{itemize}
 
-  \item \AllApplyCase{bitwise\_empty}:
+  \item \AllApplyCase{bitwise\_empty}
   \begin{itemize}
     \item $\vvone$ is the empty bitvector literal;
     \item $\vvtwo$ is the empty bitvector literal;
@@ -1007,7 +1007,7 @@ One of the following applies:
     \item define $\vr$ as the empty bitvector literal.
   \end{itemize}
 
-  \item \AllApplyCase{eq\_bits\_empty}:
+  \item \AllApplyCase{eq\_bits\_empty}
   \begin{itemize}
     \item $\vvone$ is the empty bitvector literal;
     \item $\vvtwo$ is the empty bitvector literal;
@@ -1015,7 +1015,7 @@ One of the following applies:
     \item define $\vr$ as the Boolean literal for $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{eq\_bits\_not\_empty}:
+  \item \AllApplyCase{eq\_bits\_not\_empty}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1024,7 +1024,7 @@ One of the following applies:
     \item define $\vr$ as the Boolean literal for $\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{ne\_bits}:
+  \item \AllApplyCase{ne\_bits}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a$;
     \item $\vvtwo$ is a bitvector literal for $b$;
@@ -1033,7 +1033,7 @@ One of the following applies:
     \item define $\vr$ as the Boolean literal for $\neg\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{or\_bits}:
+  \item \AllApplyCase{or\_bits}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1042,7 +1042,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c_{1..k}$.
   \end{itemize}
 
-  \item \AllApplyCase{and\_bits}:
+  \item \AllApplyCase{and\_bits}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1051,7 +1051,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c_{1..k}$.
   \end{itemize}
 
-  \item \AllApplyCase{xor\_bits}:
+  \item \AllApplyCase{xor\_bits}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1060,7 +1060,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c_{1..k}$.
   \end{itemize}
 
-  \item \AllApplyCase{add\_bits}:
+  \item \AllApplyCase{add\_bits}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1071,7 +1071,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c$.
   \end{itemize}
 
-  \item \AllApplyCase{sub\_bits}:
+  \item \AllApplyCase{sub\_bits}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1082,7 +1082,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c$.
   \end{itemize}
 
-  \item \AllApplyCase{concat\_bits}:
+  \item \AllApplyCase{concat\_bits}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..l}$;
@@ -1090,7 +1090,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $a_{1..k}b_{1..l}$.
   \end{itemize}
 
-  \item \AllApplyCase{add\_bits\_int}:
+  \item \AllApplyCase{add\_bits\_int}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a$;
     \item $\vvtwo$ is an integer literal for $b$;
@@ -1100,7 +1100,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c$.
   \end{itemize}
 
-  \item \AllApplyCase{sub\_bits\_int}:
+  \item \AllApplyCase{sub\_bits\_int}
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a$;
     \item $\vvtwo$ is an integer literal for $b$;
@@ -1110,25 +1110,25 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c$.
   \end{itemize}
 
-  \item \AllApplyCase{eq\_string}:
+  \item \AllApplyCase{eq\_string}
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal string for $a$, and $\vltwo$ is the literal string for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item \AllApplyCase{ne\_string}:
+  \item \AllApplyCase{ne\_string}
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal string for $a$, and $\vltwo$ is the literal string for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
   \end{itemize}
 
-  \item \AllApplyCase{eq\_label}:
+  \item \AllApplyCase{eq\_label}
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal label for $a$, and $\vltwo$ is the literal label for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item \AllApplyCase{ne\_label}:
+  \item \AllApplyCase{ne\_label}
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal label for $a$, and $\vltwo$ is the literal label for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
@@ -1555,23 +1555,23 @@ translates the resulting type error into the corresponding dynamic error.
 \end{mathpar}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{ok}:
+  \item \AllApplyCase{ok}
   \begin{itemize}
     \item $\vv$ is a literal native value, that is, $\nvliteral{l}$;
     \item statically evaluating $\op$ on the literal $l$ yields a literal $l'$;
     \item $\vw$ is the native literal value for $l'$.
   \end{itemize}
 
-  \item \AllApplyCase{static\_error}:
+  \item \AllApplyCase{static\_error}
   \begin{itemize}
     \item $\vv$ is a literal native value, that is, $\nvliteral{l}$;
     \item statically evaluating $\op$ on $l$ yields a type error;
     \item the result is a dynamic error.
   \end{itemize}
 
-  \item \AllApplyCase{non\_literal}:
+  \item \AllApplyCase{non\_literal}
   \begin{itemize}
     \item $\vv$ is not a literal native value;
     \item the result is a dynamic error indicating the mismatch.
@@ -1640,9 +1640,9 @@ translates the resulting type error into the corresponding dynamic error.
 \end{mathpar}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{ok}:
+  \item \AllApplyCase{ok}
   \begin{itemize}
     \item $\vvone$ is a literal native value, that is, $\nvliteral{l_1}$;
     \item $\vvtwo$ is a literal native value, that is, $\nvliteral{l_2}$;
@@ -1650,7 +1650,7 @@ One of the following applies:
     \item $\vw$ is the native literal value for $l'$.
   \end{itemize}
 
-  \item \AllApplyCase{static\_error}:
+  \item \AllApplyCase{static\_error}
   \begin{itemize}
     \item $\vvone$ is a literal native value, that is, $\nvliteral{l_1}$;
     \item $\vvtwo$ is a literal native value, that is, $\nvliteral{l_2}$;
@@ -1658,7 +1658,7 @@ One of the following applies:
     \item the result is a dynamic error ($\DynamicBadOperands$).
   \end{itemize}
 
-  \item \AllApplyCase{non\_literal}:
+  \item \AllApplyCase{non\_literal}
   \begin{itemize}
     \item either $\vvone$ or $\vvtwo$ is not a literal native value;
     \item the result is a dynamic error indicating the mismatch ($\DynamicBadOperands$).

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -507,7 +507,7 @@ not_bits: NOT '11 01' = 0x2
     \item define $\vr$ as the Boolean literal for $\neg\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{not\_bits\_empty}, \textsc{not\_bits\_empty}
+  \item \AllApplyCase{not\_bits\_empty, not\_bits\_not\_empty}
   \begin{itemize}
     \item $\op$ is $\NOT$ and $\vl$ is a bitvector literal for the sequence of bits $\bits$;
     \item $\vc$ is the sequence of bits of the same length as $\bits$ where in each position

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -34,25 +34,19 @@ on \nativevalues\ via $\unoprel$ and $\binoprel$.
 
 \section{Abstract Syntax\label{sec:PrimitiveOperationsAbstractSyntax}}
 \begin{flalign*}
-\unop \derives\ & \overname{\BNOT}{\texttt{"!"}} \;|\; \overname{\NEG}{\texttt{"-"}} \;|\; \overname{\NOT}{\texttt{"NOT"}}
-& \hypertarget{ast-binop}{} \hypertarget{ast-bor}{} \hypertarget{ast-impl}{} \hypertarget{ast-beq}{} \hypertarget{ast-band}{}
-\\
+\unop \derives\ & \overname{\BNOT}{\texttt{"!"}} \;|\; \overname{\NEG}{\texttt{"-"}} \;|\; \overname{\NOT}{\texttt{"NOT"}} & \\
 \binop  \derives\ & \overname{\BAND}{\texttt{"\&\&"}} \;|\; \overname{\BOR}{\texttt{"||"}} \;|\; \overname{\IMPL}{\texttt{"-->"}}
               \;|\; \overname{\BEQ}{\texttt{"<->"}}
-              & \hypertarget{ast-eqop}{} \hypertarget{ast-neq}{} \hypertarget{ast-gt}{} \hypertarget{ast-geq}{} \hypertarget{ast-lt}{} \hypertarget{ast-leq}{}
-\\
+        & \\
         |\ & \overname{\EQOP}{\texttt{"=="}} \;|\; \overname{\NEQ}{\texttt{"!="}} \;|\; \overname{\GT}{\texttt{"<"}}
         \;|\; \overname{\GEQ}{\texttt{">="}} \;|\; \overname{\LT}{\texttt{"<"}} \;|\; \overname{\LEQ}{\texttt{"<="}}
-        & \hypertarget{ast-plus}{} \hypertarget{ast-minus}{} \hypertarget{ast-or}{} \hypertarget{ast-xor}{} \hypertarget{ast-and}{}
-\\
+        & \\
         |\ & \overname{\PLUS}{\texttt{"+"}} \;|\; \overname{\MINUS}{\texttt{"-"}} \;|\; \overname{\OR}{\texttt{"OR"}}
         \;|\; \overname{\XOR}{\texttt{"XOR"}} \;|\; \overname{\AND}{\texttt{"AND"}}
-        & \hypertarget{ast-mul}{} \hypertarget{ast-div}{} \hypertarget{ast-divrm}{} \hypertarget{ast-mod}{} \hypertarget{ast-shl}{} \hypertarget{ast-shr}{}
-\\
+        & \\
         |\ & \overname{\MUL}{\texttt{"*"}} \;|\; \overname{\DIV}{\texttt{"DIV"}} \;|\; \overname{\DIVRM}{\texttt{"DIVRM"}}
         \;|\; \overname{\MOD}{\texttt{"MOD"}} \;|\; \overname{\SHL}{\texttt{"<<"}}  \;|\; \overname{\SHR}{\texttt{">>"}}
-        & \hypertarget{ast-rdiv}{} \hypertarget{ast-pow}{}
-\\
+        & \\
         |\ & \overname{\RDIV}{\texttt{"/"}} \;|\; \overname{\POW}{\texttt{"\^{}"}} \;|\; \overname{\BVCONCAT}{\texttt{"::"}}
         &
 \end{flalign*}

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -482,32 +482,32 @@ not_bits: NOT '11 01' = 0x2
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item $(\op, \astlabel(\vl))$ is not in $\unopsignatures$;
     \item the result is a type error indicating that the combination of $\op$ and $\astlabel(\vl)$
           is not legal.
   \end{itemize}
 
-  \item All of the following apply (\textsc{negate\_int}):
+  \item \AllApplyCase{negate\_int}:
   \begin{itemize}
     \item $\op$ is $\NEG$ and $\vl$ is an integer literal for $\vn$;
     \item define $\vr$ as the integer literal for $- \vn$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{negate\_real}):
+  \item \AllApplyCase{negate\_real}:
   \begin{itemize}
     \item $\op$ is $\NEG$ and $\vl$ is a real literal for $\vq$;
     \item define $\vr$ as the real literal for $- \vq$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{not\_bool}):
+  \item \AllApplyCase{not\_bool}:
   \begin{itemize}
     \item $\op$ is $\BNOT$ and $\vl$ is a Boolean literal for $\vb$;
     \item define $\vr$ as the Boolean literal for $\neg\vb$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{not\_bits\_empty}, \textsc{not\_bits\_empty}):
+  \item \AllApplyCase{not\_bits\_empty}, \textsc{not\_bits\_empty}:
   \begin{itemize}
     \item $\op$ is $\NOT$ and $\vl$ is a bitvector literal for the sequence of bits $\bits$;
     \item $\vc$ is the sequence of bits of the same length as $\bits$ where in each position
@@ -782,32 +782,32 @@ and argument types of its operand literals:
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item $(\op, \astlabel(\vlone), \astlabel(\vltwo))$ is not included in $\binopsignatures$;
     \item the result is a type error indicating the $\op$ cannot be applied to the arguments
           with the types given by $\astlabel(\vlone)$ and $\astlabel(\vltwo)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{add\_int}):
+  \item \AllApplyCase{add\_int}:
   \begin{itemize}
     \item $\op$ is $\PLUS$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the literal integer for $a+b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{sub\_int}):
+  \item \AllApplyCase{sub\_int}:
   \begin{itemize}
     \item $\op$ is $\MINUS$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the literal integer for $a-b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{mul\_int}):
+  \item \AllApplyCase{mul\_int}:
   \begin{itemize}
     \item $\op$ is $\MUL$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the literal integer for $a\times b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{div\_int}):
+  \item \AllApplyCase{div\_int}:
   \begin{itemize}
     \item $\op$ is $\DIV$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is positive yields $\True$\ProseOrTypeError;
@@ -816,7 +816,7 @@ One of the following applies:
     \item define $\vr$ as the literal integer for $a\div b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{fdiv\_int}):
+  \item \AllApplyCase{fdiv\_int}:
   \begin{itemize}
     \item $\op$ is $\DIVRM$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is positive yields $\True$\ProseOrTypeError;
@@ -824,7 +824,7 @@ One of the following applies:
     \item define $\vr$ as the literal integer for $n$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{frem\_int}):
+  \item \AllApplyCase{frem\_int}:
   \begin{itemize}
     \item $\op$ is $\MOD$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item applying $\binopliterals$ to $\DIVRM$ with $\vlone$ and $\vltwo$ yields $c$\ProseOrTypeError;
@@ -832,7 +832,7 @@ One of the following applies:
     \item define $\vr$ as the literal integer for $n$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{exp\_int}):
+  \item \AllApplyCase{exp\_int}:
   \begin{itemize}
     \item $\op$ is $\POW$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is non-negative yields $\True$\ProseOrTypeError;
@@ -840,7 +840,7 @@ One of the following applies:
     \item define $\vr$ as the literal integer for $n$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{shl}):
+  \item \AllApplyCase{shl}:
   \begin{itemize}
     \item $\op$ is $\SHL$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is non-negative yields $\True$\ProseOrTypeError;
@@ -848,7 +848,7 @@ One of the following applies:
     \item applying $\binopliterals$ to $\MUL$ with $2$ and the literal integer for $e$ yields $\vr$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{shr}):
+  \item \AllApplyCase{shr}:
   \begin{itemize}
     \item $\op$ is $\SHR$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item checking that $b$ is non-negative yields $\True$\ProseOrTypeError;
@@ -856,98 +856,98 @@ One of the following applies:
     \item applying $\binopliterals$ to $\DIVRM$ with $2$ and the literal integer for $e$ yields $\vr$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eq\_int}):
+  \item \AllApplyCase{eq\_int}:
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ne\_int}):
+  \item \AllApplyCase{ne\_int}:
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$ holds.
   \end{itemize}
 
-  \item All of the following apply (\textsc{le\_int}):
+  \item \AllApplyCase{le\_int}:
   \begin{itemize}
     \item $\op$ is $\LEQ$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is less than or equal to $b$s.
   \end{itemize}
 
-  \item All of the following apply (\textsc{lt\_int}):
+  \item \AllApplyCase{lt\_int}:
   \begin{itemize}
     \item $\op$ is $\LT$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is less than $b$s.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ge\_int}):
+  \item \AllApplyCase{ge\_int}:
   \begin{itemize}
     \item $\op$ is $\GEQ$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is greater or equal than $b$s.
   \end{itemize}
 
-  \item All of the following apply (\textsc{gt\_int}):
+  \item \AllApplyCase{gt\_int}:
   \begin{itemize}
     \item $\op$ is $\GT$, $\vlone$ is the literal integer for $a$, and $\vltwo$ is the literal integer for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is greater than $b$s.
   \end{itemize}
 
-  \item All of the following apply (\textsc{and\_bool}):
+  \item \AllApplyCase{and\_bool}:
   \begin{itemize}
     \item $\op$ is $\BAND$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if both $a$ and $b$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{or\_bool}):
+  \item \AllApplyCase{or\_bool}:
   \begin{itemize}
     \item $\op$ is $\BOR$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if at least one of $a$ and $b$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{implies\_bool}):
+  \item \AllApplyCase{implies\_bool}:
   \begin{itemize}
     \item $\op$ is $\IMPL$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is $\False$ or $b$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eq\_bool}):
+  \item \AllApplyCase{eq\_bool}:
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ne\_bool}):
+  \item \AllApplyCase{ne\_bool}:
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal Boolean for $a$, and $\vltwo$ is the literal Boolean for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{add\_real}):
+  \item \AllApplyCase{add\_real}:
   \begin{itemize}
     \item $\op$ is $\PLUS$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the real literal for $a + b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{sub\_real}):
+  \item \AllApplyCase{sub\_real}:
   \begin{itemize}
     \item $\op$ is $\MINUS$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the real literal for $a - b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{mul\_real}):
+  \item \AllApplyCase{mul\_real}:
   \begin{itemize}
     \item $\op$ is $\MUL$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the real literal for $a \times b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{div\_real}):
+  \item \AllApplyCase{div\_real}:
   \begin{itemize}
     \item $\op$ is $\RDIV$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item checking whether $b$ is different from $0$ yields $\True$\ProseOrTypeError;
     \item define $\vr$ as the real literal for $a \div b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{exp\_real}):
+  \item \AllApplyCase{exp\_real}:
   \begin{itemize}
     \item $\op$ is $\POW$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal integer for $b$;
     \item since exponentiation is undefined when $a$ is 0 and $b$ is negative,
@@ -955,43 +955,43 @@ One of the following applies:
     \item define $\vr$ as the real literal for $a^b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eq\_real}):
+  \item \AllApplyCase{eq\_real}:
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ne\_real}):
+  \item \AllApplyCase{ne\_real}:
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{le\_real}):
+  \item \AllApplyCase{le\_real}:
   \begin{itemize}
     \item $\op$ is $\LEQ$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is less than or equal to $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{lt\_real}):
+  \item \AllApplyCase{lt\_real}:
   \begin{itemize}
     \item $\op$ is $\LT$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is less than $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ge\_real}):
+  \item \AllApplyCase{ge\_real}:
   \begin{itemize}
     \item $\op$ is $\GEQ$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is greater than or equal to $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{gt\_real}):
+  \item \AllApplyCase{gt\_real}:
   \begin{itemize}
     \item $\op$ is $\GT$, $\vlone$ is the literal real for $a$, and $\vltwo$ is the literal real for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is greater than $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{bitwise\_different\_bitwidths}):
+  \item \AllApplyCase{bitwise\_different\_bitwidths}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a$;
     \item $\vvtwo$ is a bitvector literal for $b$;
@@ -999,7 +999,7 @@ One of the following applies:
     \item the result is a type error indicating that the bitvectors must be of the same width.
   \end{itemize}
 
-  \item All of the following apply (\textsc{bitwise\_empty}):
+  \item \AllApplyCase{bitwise\_empty}:
   \begin{itemize}
     \item $\vvone$ is the empty bitvector literal;
     \item $\vvtwo$ is the empty bitvector literal;
@@ -1007,7 +1007,7 @@ One of the following applies:
     \item define $\vr$ as the empty bitvector literal.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eq\_bits\_empty}):
+  \item \AllApplyCase{eq\_bits\_empty}:
   \begin{itemize}
     \item $\vvone$ is the empty bitvector literal;
     \item $\vvtwo$ is the empty bitvector literal;
@@ -1015,7 +1015,7 @@ One of the following applies:
     \item define $\vr$ as the Boolean literal for $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eq\_bits\_not\_empty}):
+  \item \AllApplyCase{eq\_bits\_not\_empty}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1024,7 +1024,7 @@ One of the following applies:
     \item define $\vr$ as the Boolean literal for $\vb$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ne\_bits}):
+  \item \AllApplyCase{ne\_bits}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a$;
     \item $\vvtwo$ is a bitvector literal for $b$;
@@ -1033,7 +1033,7 @@ One of the following applies:
     \item define $\vr$ as the Boolean literal for $\neg\vb$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{or\_bits}):
+  \item \AllApplyCase{or\_bits}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1042,7 +1042,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c_{1..k}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{and\_bits}):
+  \item \AllApplyCase{and\_bits}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1051,7 +1051,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c_{1..k}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{xor\_bits}):
+  \item \AllApplyCase{xor\_bits}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1060,7 +1060,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c_{1..k}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{add\_bits}):
+  \item \AllApplyCase{add\_bits}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1071,7 +1071,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{sub\_bits}):
+  \item \AllApplyCase{sub\_bits}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..k}$;
@@ -1082,7 +1082,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{concat\_bits}):
+  \item \AllApplyCase{concat\_bits}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..l}$;
@@ -1090,7 +1090,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $a_{1..k}b_{1..l}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{add\_bits\_int}):
+  \item \AllApplyCase{add\_bits\_int}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a$;
     \item $\vvtwo$ is an integer literal for $b$;
@@ -1100,7 +1100,7 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{sub\_bits\_int}):
+  \item \AllApplyCase{sub\_bits\_int}:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a$;
     \item $\vvtwo$ is an integer literal for $b$;
@@ -1110,25 +1110,25 @@ One of the following applies:
     \item define $\vr$ as the bitvector literal for $c$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eq\_string}):
+  \item \AllApplyCase{eq\_string}:
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal string for $a$, and $\vltwo$ is the literal string for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ne\_string}):
+  \item \AllApplyCase{ne\_string}:
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal string for $a$, and $\vltwo$ is the literal string for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eq\_label}):
+  \item \AllApplyCase{eq\_label}:
   \begin{itemize}
     \item $\op$ is $\EQOP$, $\vlone$ is the literal label for $a$, and $\vltwo$ is the literal label for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is equal to $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ne\_label}):
+  \item \AllApplyCase{ne\_label}:
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal label for $a$, and $\vltwo$ is the literal label for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
@@ -1557,21 +1557,21 @@ translates the resulting type error into the corresponding dynamic error.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{ok}):
+  \item \AllApplyCase{ok}:
   \begin{itemize}
     \item $\vv$ is a literal native value, that is, $\nvliteral{l}$;
     \item statically evaluating $\op$ on the literal $l$ yields a literal $l'$;
     \item $\vw$ is the native literal value for $l'$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{static\_error}):
+  \item \AllApplyCase{static\_error}:
   \begin{itemize}
     \item $\vv$ is a literal native value, that is, $\nvliteral{l}$;
     \item statically evaluating $\op$ on $l$ yields a type error;
     \item the result is a dynamic error.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_literal}):
+  \item \AllApplyCase{non\_literal}:
   \begin{itemize}
     \item $\vv$ is not a literal native value;
     \item the result is a dynamic error indicating the mismatch.
@@ -1642,7 +1642,7 @@ translates the resulting type error into the corresponding dynamic error.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{ok}):
+  \item \AllApplyCase{ok}:
   \begin{itemize}
     \item $\vvone$ is a literal native value, that is, $\nvliteral{l_1}$;
     \item $\vvtwo$ is a literal native value, that is, $\nvliteral{l_2}$;
@@ -1650,7 +1650,7 @@ One of the following applies:
     \item $\vw$ is the native literal value for $l'$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{static\_error}):
+  \item \AllApplyCase{static\_error}:
   \begin{itemize}
     \item $\vvone$ is a literal native value, that is, $\nvliteral{l_1}$;
     \item $\vvtwo$ is a literal native value, that is, $\nvliteral{l_2}$;
@@ -1658,7 +1658,7 @@ One of the following applies:
     \item the result is a dynamic error ($\DynamicBadOperands$).
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_literal}):
+  \item \AllApplyCase{non\_literal}:
   \begin{itemize}
     \item either $\vvone$ or $\vvtwo$ is not a literal native value;
     \item the result is a dynamic error indicating the mismatch ($\DynamicBadOperands$).

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -461,7 +461,7 @@ for a given unary operator:
 \right\}
 \]
 
-\subsubsection{Example (Unary Operations)}
+\ExampleDef{Unary Operations}
 \listingref{unary-operations} shows applications of unary operations
 (invalid applications appear in comments),
 followed by the resulting console output.
@@ -564,7 +564,7 @@ and returns the resulting literal $\vr$.
 The result is a type error, if it is illegal to apply the operator
 to the given values, or a different kind of type error is detected.
 
-\subsubsection{Example (Boolean Operations)\label{sec:BooleanOperations}}
+\ExampleDef{Boolean Operations}
 \listingref{binary-operations-boolean} shows applications
 of operations to Boolean-typed literals (invalid applications in comments),
 followed by the resulting console output.
@@ -594,7 +594,7 @@ equiv_bool: FALSE <-> TRUE = FALSE
 \end{Verbatim}
 % CONSOLE_END
 
-\subsubsection{Example (Integer Arithmetic)\label{sec:IntegerArithmetic}}
+\ExampleDef{Integer Arithmetic}
 \listingref{binary-operations-integer-arithmetic} shows applications
 of integer arithmetic operations to literals (invalid applications in comments),
 followed by the resulting console output.
@@ -628,7 +628,7 @@ shiftright_int: -1 >> 10 = -1
 \end{Verbatim}
 % CONSOLE_END
 
-\subsubsection{Example (Integer Comparison)\label{sec:IntegerComparison}}
+\ExampleDef{Integer Comparison}
 \listingref{binary-operations-integer-relational} shows applications
 of integer comparison operations to literals (invalid applications in comments),
 followed by the resulting console output.
@@ -650,7 +650,7 @@ ge_int: 6 >= 10 = FALSE
 \end{Verbatim}
 % CONSOLE_END
 
-\subsubsection{Example (Real Operations)\label{sec:RealOperations}}
+\ExampleDef{Real Operations}
 \listingref{binary-operations-real} shows applications
 of operations on real-typed literals (invalid applications in comments),
 followed by the resulting console output.
@@ -674,7 +674,7 @@ ge_real: 10.0 >= 0.5 = TRUE
 \end{Verbatim}
 % CONSOLE_END
 
-\subsubsection{Example (Bitvector Operations)\label{sec:ExampleBitvectorOperations}}
+\ExampleDef{Bitvector Operations}
 \listingref{binary-operations-bitvector} shows applications
 of operations on bitvector-typed literals (invalid applications in comments),
 followed by the resulting console output.
@@ -702,7 +702,7 @@ concat_bits: '100' :: '' = 0x4
 \end{Verbatim}
 % CONSOLE_END
 
-\subsubsection{Example (String and Enumeration Label Operations)\label{sec:StringLabelOperations}}
+\ExampleDef{String and Enumeration Label Operations}
 \listingref{binary-operations-stringslabels} shows applications
 of operations on string-typed literals and enumeration-typed literals (invalid applications in comments),
 followed by the resulting console output.
@@ -1530,7 +1530,7 @@ The function
 \]
 evaluates a unary operator $\op$ over a \nativevalue{} $\vv$ and returns the \nativevalue{} $\vw$ or an error.
 
-\subsubsection{Example (Valid Unary Operation)}
+\ExampleDef{Valid Unary Operation}
 The following grounded rule shows how the application of negation
 to the literal integer for $1$
 translates into the application of negation to the \nativevalue\ for $1$.
@@ -1542,7 +1542,7 @@ translates into the application of negation to the \nativevalue\ for $1$.
 }
 \end{mathpar}
 
-\subsubsection{Example (Invalid Unary Operation)}
+\ExampleDef{Invalid Unary Operation}
 The following grounded rule shows how the application of negation
 to the literal Boolean for $\True$
 translates the resulting type error into the corresponding dynamic error.
@@ -1614,7 +1614,7 @@ The function
 evaluates a binary operator $\op$ over a pair of \nativevalues\  --- $\vvone$ and $\vvtwo$ --- and returns the
 \nativevalue\  $\vw$ or an error.
 
-\subsubsection{Example (Valid Binary Operation)}
+\ExampleDef{Valid Binary Operation}
 The following grounded rule shows how the application of addition
 to the literal integer for $2$ and the literal integer for $3$
 translates into the application of addition to the \nativevalue\ for $2$
@@ -1627,7 +1627,7 @@ and the \nativevalue\ for $3$.
 }
 \end{mathpar}
 
-\subsubsection{Example (Invalid Binary Operation)}
+\ExampleDef{Invalid Binary Operation}
 The following grounded rule shows how the invalid application of addition
 to the literal integer for $2$ and the literal real for $1/2$
 translates the resulting type error into the corresponding dynamic error.

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -93,7 +93,7 @@ type subInt of integer subtypes superInt;
   }
 \end{mathpar}
 
-\lrmcomment{This is related to \identr{NXRX}, \identi{KGKS}, \identi{MTML}, \identi{JVRM}, \identi{CHMP}.}
+\identr{NXRX} \identi{KGKS} \identi{MTML} \identi{JVRM} \identi{CHMP}
 
 \TypingRuleDef{SubtypeSatisfaction}
 \hypertarget{def-subtypesat}{}
@@ -346,7 +346,7 @@ if there is a unique one, as follows:
 \end{mathpar}
 
 \isempty{\subsection{Comments}}
-\lrmcomment{This is related to \identd{TRVR}, \identi{SJDC}, \identi{MHYB}, \identi{TWTZ}, \identi{GYSK}, \identi{KXSD}, \identi{KNXJ}.}
+\identd{TRVR} \identi{SJDC} \identi{MHYB} \identi{TWTZ} \identi{GYSK} \identi{KXSD} \identi{KNXJ}
 
 \isempty{\subsection{Example}}
 
@@ -511,7 +511,7 @@ type \texttt{pairT}.
 Since the subtype relation is a partial order, it is reflexive. Therefore
 every type $\vt$ is a subtype of itself, and as a consequence, every type $\vt$
 \typesatisfies\  itself.
-\lrmcomment{This is related to \identr{FMXK} and \identi{NLFD}.}
+\identr{FMXK}  \identi{NLFD}
 
 \TypingRuleDef{CheckTypeSatisfaction}
 \hypertarget{def-checktypesat}{}
@@ -725,7 +725,7 @@ way around.
 Note that type-clashing is an equivalence relation. Therefore if $\vt$
 type-clashes with \texttt{A} and \texttt{B} then it is also the case that \texttt{A} and \texttt{B} type-clash.
 
-\lrmcomment{This is related to \identd{VPZZ}, \identi{PQCT} and \identi{WZKM}.}
+\identd{VPZZ} \identi{PQCT}  \identi{WZKM}
 
 \TypingRuleDef{LowestCommonAncestor}
 \hypertarget{def-lowestcommonancestor}{}
@@ -1006,7 +1006,7 @@ We define $\lca(\tenv, \vt, \vs)$ to be any type $\vtp$ that is \typeequivalent\
 }
 \end{mathpar}
 
-\lrmcomment{This is related to \identr{YZHM}.}
+\identr{YZHM}
 
 \TypingRuleDef{ApplyUnopType}
 \hypertarget{def-applyunoptype}{}
@@ -1574,12 +1574,10 @@ to operands of type $\vtone$ and $\vttwo$ in the static environment $\tenv$.
 \end{mathpar}
 \CodeSubsection{\applybinoptypesBegin}{\applybinoptypesEnd}{../Typing.ml}
 
-\lrmcomment{
-  This is related to \identr{BKNT}, \identr{ZYWY}, \identr{BZKW},
-  \identr{KFYS}, \identr{KXMR}, \identr{SQXN}, \identr{MRHT}, \identr{JGWF},
-  \identr{TTGQ}, \identi{YHML}, \identi{YHRP}, \identi{VMZF}, \identi{YXSY},
-  \identi{LGHJ}, \identi{RXLG}.
-}
+\identr{BKNT} \identr{ZYWY} \identr{BZKW}
+\identr{KFYS} \identr{KXMR} \identr{SQXN} \identr{MRHT} \identr{JGWF}
+\identr{TTGQ} \identi{YHML} \identi{YHRP} \identi{VMZF} \identi{YXSY}
+\identi{LGHJ} \identi{RXLG}
 
 \TypingRuleDef{FindNamedLCA}
 \hypertarget{def-namedlowestcommonancestor}{}

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -25,15 +25,15 @@ defines whether the type $\vtone$ subtypes the type $\vttwo$ in the static envir
 yielding the result in $\vb$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{reflexive}:
+  \item \AllApplyCase{reflexive}
   \begin{itemize}
     \item $\vtone$ and $\vttwo$ are both the same named type;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{transitive}:
+  \item \AllApplyCase{transitive}
   \begin{itemize}
     \item $\vtone$ is a named type with name $\idone$, that is $\TNamed(\idone)$;
     \item $\vttwo$ is a named type with name $\idtwo$, that is $\TNamed(\idtwo)$, such that $\idone$ is different from $\idtwo$;
@@ -42,7 +42,7 @@ One of the following applies:
     gives $\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{no\_supertype}:
+  \item \AllApplyCase{no\_supertype}
   \begin{itemize}
     \item $\vtone$ is a named type with name $\idone$, that is $\TNamed(\idone)$;
     \item $\vttwo$ is a named type with name $\idtwo$, that is $\TNamed(\idtwo)$, such that $\idone$ is different from $\idtwo$;
@@ -50,7 +50,7 @@ One of the following applies:
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{not\_named}:
+  \item \AllApplyCase{not\_named}
   \begin{itemize}
     \item at least one of $\vtone$ and $\vttwo$ is not a named type;
     \item $\vb$ is $\False$.
@@ -107,50 +107,50 @@ returning the result $\vb$ or a type error, if one is detected.
 The function assumes that both $\vt$ and $\vs$ are well-typed according to \chapref{Types}.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-\item \AllApplyCase{error1}:
+\item \AllApplyCase{error1}
   \begin{itemize}
   \item obtaining the \underlyingtype\ of $\vt$ gives a type error;
   \item the rule results in a type error.
   \end{itemize}
 
-\item \AllApplyCase{error2}:
+\item \AllApplyCase{error2}
   \begin{itemize}
     \item obtaining the \underlyingtype\ of $\vt$ gives a type $\vttwo$;
     \item obtaining the \underlyingtype\ of $\vs$ gives a type error;
     \item the rule results in a type error.
     \end{itemize}
 
-\item \AllApplyCase{different\_labels}:
+\item \AllApplyCase{different\_labels}
   \begin{itemize}
   \item the underlying types of $\vt$ and $\vs$ have different AST labels
   (for example, \texttt{integer} and \texttt{real});
   \item $\vb$ is $\False$.
   \end{itemize}
 
-\item \AllApplyCase{simple}:
+\item \AllApplyCase{simple}
   \begin{itemize}
   \item the \underlyingtype\ of $\vt$, $\vttwo$, is either \texttt{real}, \texttt{string}, or \texttt{bool};
   \item the \underlyingtype\ of $\vs$, $\vstwo$, is either \texttt{real}, \texttt{string}, or \texttt{bool};
   \item $\vb$ is $\True$ if and only if both $\vttwo$ and $\vstwo$ have the same ASL label.
   \end{itemize}
 
-\item \AllApplyCase{t\_int}:
+\item \AllApplyCase{t\_int}
   \begin{itemize}
   \item the \underlyingtype\ of $\vt$, $\vttwo$, is an \texttt{integer} (any kind);
   \item the \underlyingtype\ of $\vs$, $\vstwo$, is an \texttt{integer} (any kind);
   \item determining whether $\vs$ subsumes $\vt$ in $\tenv$ via symbolic reasoning results in $\vb$.
   \end{itemize}
 
-\item \AllApplyCase{t\_enum}:
+\item \AllApplyCase{t\_enum}
   \begin{itemize}
   \item the \underlyingtype\ of $\vt$ is an enumeration type with list of labels $\vlit$, that is, $\TEnum(\vlit)$;
   \item the \underlyingtype\ of $\vs$ is an enumeration type with list of labels $\vlis$, that is, $\TEnum(\vlis)$;
   \item $\vb$ is $\True$ if and only if $\vlit$ is equal to $\vlis$.
   \end{itemize}
 
-\item \AllApplyCase{t\_bits}:
+\item \AllApplyCase{t\_bits}
   \begin{itemize}
   \item the \underlyingtype\ of $\vs$ is a bitvector type with width $\ws$ and bit fields $\bfss$, that is $\TBits(\ws, \bfss)$;
   \item the \underlyingtype\ of $\vt$ is a bitvector type with width $\wt$ and bit fields $\bfst$, that is $\TBits(\wt, \bfst)$;
@@ -158,7 +158,7 @@ One of the following applies:
   \item determining whether the \symbolicdomain{} of bitwidth $\ws$ subsumes the \symbolicdomain{} of bitwidth $\wt$ in $\tenv$ yields $\vb$.
   \end{itemize}
 
-\item \AllApplyCase{t\_array\_expr}:
+\item \AllApplyCase{t\_array\_expr}
   \begin{itemize}
   \item $\vs$ has the \underlyingtype\ of an array with index $\vlengths$ and element type $\vtys$, that is $\TArray(\vlengths, \vtys)$;
   \item $\vt$ has the \underlyingtype\ of an array with index $\vlengtht$ and element type $\vtyt$, that is $\TArray(\vlengtht, \vtyt)$;
@@ -170,7 +170,7 @@ One of the following applies:
   \item determining whether expressions $\vlengthexprs$ and $\vlengthexprt$ are equivalent gives $\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_array\_enum}:
+  \item \AllApplyCase{t\_array\_enum}
   \begin{itemize}
   \item $\vs$ has the \underlyingtype\ of an array with index $\vlengths$ and element type $\vtys$, that is $\TArray(\vlengths, \vtys)$;
   \item $\vt$ has the \underlyingtype\ of an array with index $\vlengtht$ and element type $\vtyt$, that is $\TArray(\vlengtht, \vtyt)$;
@@ -182,7 +182,7 @@ One of the following applies:
   \item $\vb$ is $\True$ if and only if $\vnames$ and $\vnamet$ are the same.
   \end{itemize}
 
-\item \AllApplyCase{t\_tuple}:
+\item \AllApplyCase{t\_tuple}
   \begin{itemize}
   \item $\vs$ has the \underlyingtype\ of a tuple with type list $\vlis$, that is $\TTuple(\vlis)$;
   \item $\vt$ has the \underlyingtype\ of a tuple with type list $\vlit$, that is $\TTuple(\vlit)$;
@@ -193,7 +193,7 @@ One of the following applies:
   \item $\vb$ is $\True$ if and only if all $\vb_\vi$ are $\True$;
   \end{itemize}
 
-\item \AllApplyCase{structured}:
+\item \AllApplyCase{structured}
   \begin{itemize}
   \item $\vs$ has the \underlyingtype\ $L(\vfieldss)$, which is a \structuredtype;
   \item $\vt$ has the \underlyingtype\ $L(\vfieldst)$, which is a \structuredtype;
@@ -373,15 +373,15 @@ which is the same as $\typesat$, but yields a type error when \\ $\typesat(\tenv
 These functions assume that both $\vt$ and $\vs$ are well-typed according to \secref{Types}.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
  \begin{itemize}
-  \item \AllApplyCase{subtypes}:
+  \item \AllApplyCase{subtypes}
     \begin{itemize}
     \item $\vt$ subtypes $\vs$ in $\tenv$ ;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{anonymous}:
+  \item \AllApplyCase{anonymous}
   \begin{itemize}
     \item $\vt$ does not subtype $\vs$ in $\tenv$;
     \item at least one of $\vt$ and $\vs$ is an anonymous type in $\tenv$;
@@ -389,7 +389,7 @@ One of the following applies:
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_bits}:
+  \item \AllApplyCase{t\_bits}
   \begin{itemize}
     \item $\vt$ does not subtype $\vs$ in $\tenv$;
     \item determining whether $\vt$ is anonymous yields $\vbone$;
@@ -402,7 +402,7 @@ One of the following applies:
     \item determining whether $\widtht$ and $\widths$ are \bitwidthequivalent\ yields $\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{otherwise1}:
+  \item \AllApplyCase{otherwise1}
   \begin{itemize}
     \item $\vt$ does not subtype $\vs$ in $\tenv$;
     \item determining whether $\vt$ is anonymous yields $\vbone$;
@@ -413,7 +413,7 @@ One of the following applies:
     \item at least one of $\vt$ and $\vsstruct$ is not a bitvector type;
   \end{itemize}
 
-  \item \AllApplyCase{otherwise2}:
+  \item \AllApplyCase{otherwise2}
   \begin{itemize}
     \item $\vt$ does not subtype $\vs$ in $\tenv$;
     \item determining whether $\vt$ is anonymous yields $\vbone$;
@@ -549,15 +549,15 @@ tests whether a type $\vt$ \emph{type-clashes} with a type $\vs$ in environment 
 returning the result $\vb$ or a type error, if one is detected.
 
 \ProseParagraph
- One of the following applies:
+ \OneApplies
 \begin{itemize}
-  \item \AllApplyCase{subtype}:
+  \item \AllApplyCase{subtype}
   \begin{itemize}
     \item either $\vs$ subtypes $\vt$ or $\vt$ subtypes $\vs$;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{simple}:
+  \item \AllApplyCase{simple}
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$\ProseOrTypeError;
@@ -566,7 +566,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_enum}:
+  \item \AllApplyCase{t\_enum}
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields an enumeration type with labels $\vlit$;
@@ -574,7 +574,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\True$ if and only if $\vlis$ and $\vlit$ are equal.
   \end{itemize}
 
-  \item \AllApplyCase{t\_array}:
+  \item \AllApplyCase{t\_array}
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields an array type with element type $\vtyt$;
@@ -582,7 +582,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\True$ if and only if $\vtyt$ and $\vtys$ type-clash.
   \end{itemize}
 
-  \item \AllApplyCase{t\_tuple}:
+  \item \AllApplyCase{t\_tuple}
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields a tuple type with element types $\vt_{1..k}$;
@@ -591,7 +591,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\True$ if and only if $\vt_i$ type-clashes with $\vs_i$, for all $i=1..k$.
   \end{itemize}
 
-  \item \AllApplyCase{otherwise\_different\_labels}:
+  \item \AllApplyCase{otherwise\_different\_labels}
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$;
@@ -600,7 +600,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\False$;
   \end{itemize}
 
-  \item \AllApplyCase{otherwise\_structured}:
+  \item \AllApplyCase{otherwise\_structured}
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$;
@@ -721,9 +721,9 @@ returns the \emph{lowest common ancestor} of types $\vt$ and $\vs$ in $\tenv$ --
 The result is a type error if a lowest common ancestor does not exist or a type error is detected.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{type\_equal}:
+  \item \AllApplyCase{type\_equal}
   \begin{itemize}
     \item $\vt$ is \typeequal\ to $\vs$ in $\tenv$;
     \item $\tty$ is $\vs$ (can as well be $\vt$).
@@ -731,9 +731,9 @@ One of the following applies:
 
   \item \AllApply
   \begin{itemize}
-    \item $\vt$ is not \typeequal\ to $\vs$ in $\tenv$ and one of the following applies:
+    \item $\vt$ is not \typeequal\ to $\vs$ in $\tenv$ and \OneApplies
 
-    \item \AllApplyCase{named\_subtype1}:
+    \item \AllApplyCase{named\_subtype1}
     \begin{itemize}
       \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
       \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
@@ -743,7 +743,7 @@ One of the following applies:
       \item obtaining the lowest common ancestor of $\vanons$ and $\vanont$ in $\tenv$ yields $\tty$\ProseOrTypeError.
     \end{itemize}
 
-    \item \AllApplyCase{named\_subtype2}:
+    \item \AllApplyCase{named\_subtype2}
     \begin{itemize}
       \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
       \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
@@ -752,7 +752,7 @@ One of the following applies:
       \item $\tty$ is the named type with identifier $\name$, that is, $\TNamed(\name)$.
     \end{itemize}
 
-    \item \AllApplyCase{one\_named1}:
+    \item \AllApplyCase{one\_named1}
     \begin{itemize}
       \item only one of $\vt$ or $\vs$ is a named type;
       \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
@@ -761,7 +761,7 @@ One of the following applies:
       \item $\tty$ is $\vt$ if it is a named type (that is, $\astlabel(\vt)=\TNamed$), and $\vs$ otherwise.
     \end{itemize}
 
-    \item \AllApplyCase{one\_named2}:
+    \item \AllApplyCase{one\_named2}
     \begin{itemize}
       \item only one of $\vt$ or $\vs$ is a named type;
       \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
@@ -770,14 +770,14 @@ One of the following applies:
       \item the lowest common ancestor of $\vanont$ and $\vanons$ in $\tenv$ is $\tty$\ProseOrTypeError.
     \end{itemize}
 
-    \item \AllApplyCase{t\_int\_unconstrained}:
+    \item \AllApplyCase{t\_int\_unconstrained}
     \begin{itemize}
       \item both $\vt$ and $\vs$ are integer types;
       \item at least one of $\vt$ or $\vs$ is an unconstrained integer type;
       \item $\tty$ is the unconstrained integer type.
     \end{itemize}
 
-    \item \AllApplyCase{t\_int\_parameterized}:
+    \item \AllApplyCase{t\_int\_parameterized}
     \begin{itemize}
       \item neither $\vt$ nor $\vs$ are the unconstrained integer type;
       \item one of $\vt$ and $\vs$ is a \parameterizedintegertype;
@@ -786,14 +786,14 @@ One of the following applies:
       \item $\tty$ the lowest common ancestor of $\vtone$ and $\vsone$ in $\tenv$ is $\tty$\ProseOrTypeError.
     \end{itemize}
 
-    \item \AllApplyCase{t\_int\_wellconstrained}:
+    \item \AllApplyCase{t\_int\_wellconstrained}
     \begin{itemize}
       \item $\vt$ is a well-constrained integer type with constraints $\cst$;
       \item $\vs$ is a well-constrained integer type with constraints $\css$;
       \item $\tty$ is the well-constrained integer type with constraints $\cst \concat \css$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_bits}:
+    \item \AllApplyCase{t\_bits}
     \begin{itemize}
       \item $\vt$ is a bitvector type with length expression $\vet$, that is, $\TBits(\vet, \Ignore)$;
       \item $\vs$ is a bitvector type with length expression $\ves$, that is, $\TBits(\ves, \Ignore)$;
@@ -803,7 +803,7 @@ One of the following applies:
       \item $\tty$ is a bitvector type with length expression $\vet$ and an empty bitfield list, that is, $\TBits(\vet, \emptylist)$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_array}:
+    \item \AllApplyCase{t\_array}
     \begin{itemize}
       \item $\vt$ is an array type with width expression $\widtht$ and element type $\vtyt$;
       \item $\vs$ is an array type with width expression $\widths$ and element type $\vtys$;
@@ -814,7 +814,7 @@ One of the following applies:
       \item $\tty$ is an array type with width expression $\widths$ and element type $\vtone$.
     \end{itemize}
 
-    \item \AllApplyCase{t\_tuple}:
+    \item \AllApplyCase{t\_tuple}
     \begin{itemize}
       \item $\vt$ is a tuple type with type list $\vlit$;
       \item $\vs$ is a tuple type with type list $\vlis$;
@@ -827,7 +827,7 @@ One of the following applies:
       \item define $\tty$ as the tuple type with list of types $\vli$, that is, $\TTuple(\vli)$.
     \end{itemize}
 
-    \item \AllApplyCase{error}:
+    \item \AllApplyCase{error}
     \begin{itemize}
       \item either the AST labels of $\vt$ and $\vs$ are different, or one of them is $\TEnum$, $\TRecord$, or $\TException$;
       \item the result is a type error indicating the lack of a lowest common ancestor.
@@ -1001,16 +1001,16 @@ Similarly, we determine the negation of integer constraints.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-\item \AllApplyCase{bnot\_t\_bool}:
+\item \AllApplyCase{bnot\_t\_bool}
   \begin{itemize}
     \item $\op$ is $\BNOT$;
     \item determining whether $\vt$ \typesatisfies\ $\TBool$ yields $\True$\ProseOrTypeError;
     \item $\vs$ is $\TBool$;
   \end{itemize}
 
-\item \AllApplyCase{neg\_error}:
+\item \AllApplyCase{neg\_error}
 \begin{itemize}
   \item $\op$ is $\NEG$;
   \item determining whether $\vt$ \typesatisfies\ $\TReal$ yields $\False$\ProseOrTypeError;
@@ -1018,21 +1018,21 @@ One of the following applies:
   \item the result is a type error indicating the $\NEG$ is appropriate only for \texttt{real} and \texttt{integer} types;
 \end{itemize}
 
-\item \AllApplyCase{neg\_t\_real}:
+\item \AllApplyCase{neg\_t\_real}
 \begin{itemize}
   \item $\op$ is $\NEG$;
   \item determining whether $\vt$ \typesatisfies\ $\TReal$ yields $\True$;
   \item $\vs$ is $\TReal$;
 \end{itemize}
 
-\item \AllApplyCase{neg\_t\_int\_unconstrained}:
+\item \AllApplyCase{neg\_t\_int\_unconstrained}
 \begin{itemize}
   \item $\op$ is $\NEG$;
   \item obtaining the \wellconstrainedstructure\ of $\vt$ yields $\unconstrainedinteger$\ProseOrTypeError;
   \item $\vs$ is $\unconstrainedinteger$;
 \end{itemize}
 
-\item \AllApplyCase{neg\_t\_int\_well\_constrained}:
+\item \AllApplyCase{neg\_t\_int\_well\_constrained}
 \begin{itemize}
   \item $\op$ is $\NEG$;
   \item obtaining the \wellconstrainedstructure\ of $\vt$ yields the well-constrained integer type with constraints $\vcs$\ProseOrTypeError;
@@ -1041,7 +1041,7 @@ One of the following applies:
   $\TInt(\wellconstrained(\vcsnew))$;
 \end{itemize}
 
-\item \AllApplyCase{not\_t\_bits}:
+\item \AllApplyCase{not\_t\_bits}
   \begin{itemize}
   \item $\op$ is $\NOT$;
   \item $\vt$ has the structure of a bitvector;
@@ -1136,9 +1136,9 @@ to operands of type $\vtone$ and $\vttwo$ in the static environment $\tenv$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{named}:
+  \item \AllApplyCase{named}
   \begin{itemize}
     \item at least one of $\vtone$ and $\vttwo$ is a \namedtype;
     \item determining the \underlyingtype\ if $\vtone$ yields $\vtoneanon$\ProseOrTypeError;
@@ -1146,14 +1146,14 @@ One of the following applies:
     \item \Proseapplybinoptypes{$\tenv$}{$\op$}{$\vtoneanon$}{$\vttwoanon$}{$\vt$\ProseOrTypeError}.
   \end{itemize}
 
-  \item \AllApplyCase{boolean}:
+  \item \AllApplyCase{boolean}
   \begin{itemize}
     \item $\op$ is $\AND$, $\OR$, $\EQOP$ or $\IMPL$;
     \item both $\vtone$ and $\vttwo$ are $\TBool$;
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item \AllApplyCase{bits\_arith}:
+  \item \AllApplyCase{bits\_arith}
   \begin{itemize}
     \item $\op$ is one of $\AND$, $\OR$, $\XOR$, $\PLUS$, and $\MINUS$;
     \item $\vtone$ is a bitvector type with width expression $\vwone$;
@@ -1163,7 +1163,7 @@ One of the following applies:
     \item $\vt$ is the bitvector type of width $\vwone$ and empty list of bitfields, that is, \\ $\TBits(\vwone, \emptylist)$.
   \end{itemize}
 
-  \item \AllApplyCase{bits\_int}:
+  \item \AllApplyCase{bits\_int}
   \begin{itemize}
     \item $\op$ is either $\PLUS$ or $\MINUS$;
     \item $\vtone$ is a bitvector type with width expression $\vw$;
@@ -1171,7 +1171,7 @@ One of the following applies:
     \item $\vt$ is the bitvector type of width $\vw$ and empty list of bitfields, that is, \\ $\TBits(\vw, \emptylist)$.
   \end{itemize}
 
-  \item \AllApplyCase{bits\_concat}:
+  \item \AllApplyCase{bits\_concat}
   \begin{itemize}
     \item $\op$ is $\BVCONCAT$;
     \item $\vtone$ is a bitvector type with width expression $\vwone$;
@@ -1181,7 +1181,7 @@ One of the following applies:
     \item $\vt$ is the bitvector type of width $\vwp$ and empty list of bitfields, that is, \\ $\TBits(\vw, \emptylist)$.
   \end{itemize}
 
-  \item \AllApplyCase{rel}:
+  \item \AllApplyCase{rel}
   \begin{itemize}
     \item the operator $\op$ and types of $\vtone$ and $\vttwo$ match one of the rows in the following table:
     \[
@@ -1209,7 +1209,7 @@ One of the following applies:
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item \AllApplyCase{eq\_neq\_bits}:
+  \item \AllApplyCase{eq\_neq\_bits}
   \begin{itemize}
     \item $\op$ is either $\EQOP$ or $\NEQ$;
     \item $\vtone$ is a bitvector type with width expression $\vwone$;
@@ -1218,7 +1218,7 @@ One of the following applies:
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item \AllApplyCase{eq\_neq\_enum}:
+  \item \AllApplyCase{eq\_neq\_enum}
   \begin{itemize}
     \item $\op$ is either $\EQOP$ or $\NEQ$;
     \item $\vtone$ is $\TEnum(\vlione)$;
@@ -1227,14 +1227,14 @@ One of the following applies:
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item \AllApplyCase{arith\_t\_int\_unconstrained}:
+  \item \AllApplyCase{arith\_t\_int\_unconstrained}
   \begin{itemize}
     \item $\op$ is one of $\{\MUL, \DIV, \DIVRM, \MOD, \SHL,  \SHR, \POW, \PLUS, \MINUS\}$;
     \item both $\vtone$ and $\vttwo$ are integer types and at least one them is the unconstrained integer type;
     \item $\vt$ is the unconstrained integer type;
   \end{itemize}
 
-  \item \AllApplyCase{arith\_t\_int\_parameterized}:
+  \item \AllApplyCase{arith\_t\_int\_parameterized}
   \begin{itemize}
     \item $\op$ is one of $\{\MUL, \DIV, \DIVRM, \MOD, \SHL,  \SHR, \POW, \PLUS, \MINUS\}$;
     \item both $\vtone$ and $\vttwo$ are integer types, neither is an unconstrained integer type, and at least one them is a \parameterizedintegertype;
@@ -1243,7 +1243,7 @@ One of the following applies:
     \item \Proseapplybinoptypes{$\tenv$}{$\op$}{$\vtonewellconstrained$}{$\vttwowellconstrained$}{$\vt$}.
   \end{itemize}
 
-  \item \AllApplyCase{arith\_t\_int\_wellconstrained}:
+  \item \AllApplyCase{arith\_t\_int\_wellconstrained}
   \begin{itemize}
     \item $\op$ is one of $\{\MUL, \POW, \PLUS, \MINUS, \DIVRM, \DIV, \MOD, \SHL, \SHR\}$;
     \item $\vtone$ is the well-constrained integer type with constraints $\csone$;
@@ -1252,7 +1252,7 @@ One of the following applies:
     \item $\vt$ is the integer type with constraint kind $\vc$;
   \end{itemize}
 
-  \item \AllApplyCase{arith\_real}:
+  \item \AllApplyCase{arith\_real}
   \begin{itemize}
     \item the operator $\op$ and types of $\vtone$ and $\vttwo$ match one of the rows in the following table:
     \[
@@ -1269,7 +1269,7 @@ One of the following applies:
     \item $\vt$ is $\TReal$.
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item obtaining the \underlyingtype\ of $\vtone$ in $\tenv$ yields $\vtoneanon$\ProseOrTypeError;
     \item obtaining the \underlyingtype\ of $\vttwo$ in $\tenv$ yields $\vttwoanon$\ProseOrTypeError;
@@ -1587,23 +1587,23 @@ returns the set of \emph{named supertypes} given via the $\subtypes$ function of
 \]
 
 \ProseParagraph
-One of the following holds:
+\OneApplies
 \begin{itemize}
   \item $\vtsupers$ is in the set of named supertypes of $\vt$;
-  \item \AllApplyCase{found}:
+  \item \AllApplyCase{found}
   \begin{itemize}
     \item $\vs$ is in $\vtsupers$;
     \item $\tty$ is $\vs$;
   \end{itemize}
 
-  \item \AllApplyCase{super}:
+  \item \AllApplyCase{super}
   \begin{itemize}
     \item $\vs$ is not in $\vtsupers$;
     \item $\vs$ has a named super type in $\tenv$ --- $\vsp$;
     \item $\tty$ is the lowest common named \supertypeterm{} of $\vt$ and $\vsp$ in $\tenv$.
   \end{itemize}
 
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\vs$ is not in $\vtsupers$;
     \item $\vs$ has no named super type in $\tenv$;
@@ -1756,9 +1756,9 @@ in any environment consisting of the static environment $\tenv$.
 The result is the filtered list of constraints $\newcs$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{greater\_or\_equal}:
+  \item \AllApplyCase{greater\_or\_equal}
   \begin{itemize}
     \item $\op$ is one of $\SHL$, $\SHR$, and $\POW$;
     \item define $\vf$ as the specialization of $\refineconstraintbysign$ for the predicate
@@ -1767,7 +1767,7 @@ One of the following applies:
     \item checking whether $\newcs$ is empty yields $\True$\ProseTerminateAs{\BadOperands}.
   \end{itemize}
 
-  \item \AllApplyCase{greater\_than}:
+  \item \AllApplyCase{greater\_than}
   \begin{itemize}
     \item $\op$ is one of $\MOD$, $\DIV$, and $\DIVRM$;
     \item define $\vf$ as the specialization of $\refineconstraintbysign$ for the predicate
@@ -1776,7 +1776,7 @@ One of the following applies:
     \item checking whether $\newcs$ is empty yields $\True$\ProseTerminateAs{\BadOperands}.
   \end{itemize}
 
-  \item \AllApplyCase{no\_filtering}:
+  \item \AllApplyCase{no\_filtering}
   \begin{itemize}
     \item $\op$ is one of $\MINUS$, $\MUL$, and $\PLUS$;
     \item $\newcs$ is $\cs$.
@@ -1830,9 +1830,9 @@ reasoning may yield.
 If the set of those values is empty the result is $\None$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact\_reduces\_to\_z}:
+  \item \AllApplyCase{exact\_reduces\_to\_z}
   \begin{itemize}
     \item $\vc$ is an exact constraint for the expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\reducetozopt$ to $\ve$ in $\tenv$, in order to symbolically simplify $\ve$ to an integer,
@@ -1840,7 +1840,7 @@ One of the following applies:
     \item $\vcopt$ is $\langle\vc\rangle$ if $\vp$ holds for $\vz$ and $\None$ otherwise.
   \end{itemize}
 
-  \item \AllApplyCase{exact\_does\_not\_reduce\_to\_z}:
+  \item \AllApplyCase{exact\_does\_not\_reduce\_to\_z}
   \begin{itemize}
     \item $\vc$ is an exact constraint for the expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\reducetozopt$ to $\ve$ in $\tenv$, in order to symbolically simplify $\ve$ to an integer,
@@ -1848,7 +1848,7 @@ One of the following applies:
     \item $\vcopt$ is $\langle\vc\rangle$.
   \end{itemize}
 
-  \item \AllApplyCase{range\_both\_reduce\_to\_z}:
+  \item \AllApplyCase{range\_both\_reduce\_to\_z}
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\veone$ and $\vetwo$, that is, \\
           $\ConstraintRange(\veone, \vetwo)$;
@@ -1856,7 +1856,7 @@ One of the following applies:
           yields $\langle\vzone\rangle$;
     \item applying $\reducetozopt$ to $\vetwo$ in $\tenv$, in order to symbolically simplify $\vetwo$ to an integer,
           yields $\langle\vztwo\rangle$;
-    \item One of the following applies (defining $\vcopt$):
+    \item \OneApplies{} (defining $\vcopt$)
     \begin{itemize}
       \item if $\vp$ is $\True$ for both $\vzone$ and $\vztwo$, define $\vcopt$ as $\langle\vc\rangle$;
       \item if $\vp$ is $\False$ for $\vzone$ and $\True$ for $\vztwo$, define $\vcopt$ as the optional range constraint
@@ -1869,7 +1869,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item \AllApplyCase{only\_e1\_reduces\_to\_z}:
+  \item \AllApplyCase{only\_e1\_reduces\_to\_z}
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\veone$ and $\vetwo$, that is, \\
           $\ConstraintRange(\veone, \vetwo)$;
@@ -1877,7 +1877,7 @@ One of the following applies:
           yields $\langle\vzone\rangle$;
     \item applying $\reducetozopt$ to $\vetwo$ in $\tenv$, in order to symbolically simplify $\vetwo$ to an integer,
           yields $\None$;
-    \item One of the following applies (defining $\vcopt$):
+    \item \OneApplies{} (defining $\vcopt$):
     \begin{itemize}
       \item if $\vp$ is $\True$ for $\vzone$, define $\vcopt$ as $\langle\vc\rangle$;
       \item if $\vp$ is $\False$ for $\vzone$, define $\vcopt$ as the optional range constraint with the bottom expression
@@ -1886,7 +1886,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item \AllApplyCase{only\_e2\_reduces\_to\_z}:
+  \item \AllApplyCase{only\_e2\_reduces\_to\_z}
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\veone$ and $\vetwo$, that is, \\
           $\ConstraintRange(\veone, \vetwo)$;
@@ -1996,15 +1996,15 @@ The expression $\ve$ is assumed to appear in a constraint for a type that has be
 which means that applying $\normalize$ to it should not yield a type error.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{normalizes\_to\_z}:
+  \item \AllApplyCase{normalizes\_to\_z}
   \begin{itemize}
     \item symbolically simplifying $\ve$ in $\tenv$ via $\normalize$ yields a literal expression for the integer $\vz$;
     \item define $\vzopt$ as $\langle\vz\rangle$.
   \end{itemize}
 
-  \item \AllApplyCase{does\_not\_normalize\_to\_z}:
+  \item \AllApplyCase{does\_not\_normalize\_to\_z}
   \begin{itemize}
     \item symbolically simplifying $\ve$ in $\tenv$ via $\normalize$ yields an expression that is not an integer literal;
     \item define $\vzopt$ as $\None$.
@@ -2043,15 +2043,15 @@ refines a list of constraints $\cs$ by applying the refinement function $\vf$ to
 that do not refine to $\None$. The resulting list of constraints is given in $\newcs$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\cs$ is the empty list;
     \item $\newcs$ is the empty list.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty\_none}:
+  \item \AllApplyCase{non\_empty\_none}
   \begin{itemize}
     \item $\cs$ is the list with $\vc$ as its \head\ and $\csone$ as its \tail;
     \item applying $\vf$ to $\vc$ yields $\None$;
@@ -2059,7 +2059,7 @@ One of the following applies:
     \item $\newcs$ is $\csonep$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty\_somee}:
+  \item \AllApplyCase{non\_empty\_somee}
   \begin{itemize}
     \item $\cs$ is the list with $\vc$ as its \head\ and $\csone$ as its \tail;
     \item applying $\vf$ to $\vc$ yields $\langle\vcp\rangle$;
@@ -2106,9 +2106,9 @@ when $\op$ is the division operation.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{div}:
+  \item \AllApplyCase{div}
   \begin{itemize}
     \item $\op$ is $\DIV$;
     \item applying $\filterreduceconstraintdiv$ to each constraint $\cs[\vi]$, for each $\vi$ in $\listrange(\cs)$,
@@ -2118,7 +2118,7 @@ One of the following applies:
     \item checking that $\vres$ is not the empty list yields $\True$\ProseTerminateAs{\BadOperands}.
   \end{itemize}
 
-  \item \AllApplyCase{non\_div}:
+  \item \AllApplyCase{non\_div}
   \begin{itemize}
     \item $\op$ is not $\DIV$;
     \item define $\vres$ as $\cs$.
@@ -2158,9 +2158,9 @@ The result is returned in $\vcopt$.
 This is used to conservatively test whether $\vc$ would always fail dynamically.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact}:
+  \item \AllApplyCase{exact}
   \begin{itemize}
     \item $\vc$ is an exact constraint for the expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\getliteraldivopt$ to $\ve$ yields $\langle(\vzone, \vztwo)\rangle$\ProseTerminateAs{\None};
@@ -2171,7 +2171,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vc$ is a range constraint for $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item applying $\getliteraldivopt$ to $\veone$ yields $\veoneopt$;
@@ -2282,15 +2282,15 @@ applies $\explodedinterval$ to each constraint of $\cs$ in $\tenv$ and concatena
 list, yielding the result in $\newcs$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\cs$ is the empty list;
     \item $\newcs$ is the empty list.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\cs$ is the list with $\vc$ as its \head\ and $\csone$ as its \tail;
     \item applying $\explodeconstraint$ to $\vc$ in $\tenv$ yields $\vcp$ (a list of constraints);
@@ -2327,15 +2327,15 @@ $\vc$ matches a n ascending range constraint that is not too large in $\tenv$
 and the singleton list for $\vc$ otherwise.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact}:
+  \item \AllApplyCase{exact}
   \begin{itemize}
     \item $\vc$ is an exact constraint;
     \item $\vcs$ is the singleton list for $\vc$.
   \end{itemize}
 
-  \item \AllApplyCase{range\_reduced}:
+  \item \AllApplyCase{range\_reduced}
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\va$ and $\vb$;
     \item applying $\reducetozopt$ to $\va$ in $\tenv$ yields $\langle\vza\rangle$;
@@ -2347,7 +2347,7 @@ One of the following applies:
           $\explodedinterval$ otherwise.
   \end{itemize}
 
-  \item \AllApplyCase{range\_not\_reduced}:
+  \item \AllApplyCase{range\_not\_reduced}
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\va$ and $\vb$;
     \item applying $\reducetozopt$ to $\va$ in $\tenv$ yields $\vzaopt$;
@@ -2467,16 +2467,16 @@ The function
 checks whether the bitfield $\vbf$ exists in $\bfstwo$ in the context of $\tenv$, returning the result in $\vb$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\None$;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{simple\_any}:
+  \item \AllApplyCase{simple\_any}
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2484,7 +2484,7 @@ One of the following applies:
     \item symbolically checking whether $\vbfone$ is equivalent to $\vbftwo$ in $\tenv$ yields $\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{nested\_simple}:
+  \item \AllApplyCase{nested\_simple}
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2493,7 +2493,7 @@ One of the following applies:
     \item symbolically checking whether $\vbfone$ is equivalent to $\vbftwo$ in $\tenv$ yields $\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{nested\_nested}:
+  \item \AllApplyCase{nested\_nested}
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2505,7 +2505,7 @@ One of the following applies:
     \item $\vb$ is defined as the conjunction of $\vbone$, $\vbtwo$, and $\vbthree$.
   \end{itemize}
 
-  \item \AllApplyCase{nested\_typed}:
+  \item \AllApplyCase{nested\_typed}
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2514,7 +2514,7 @@ One of the following applies:
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{typed\_simple}:
+  \item \AllApplyCase{typed\_simple}
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2523,7 +2523,7 @@ One of the following applies:
     \item symbolically checking whether $\vbfone$ is equivalent to $\vbftwo$ in $\tenv$ yields $\vb$.
   \end{itemize}
 
-  \item \AllApplyCase{typed\_nested}:
+  \item \AllApplyCase{typed\_nested}
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2532,7 +2532,7 @@ One of the following applies:
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{typed\_typed}:
+  \item \AllApplyCase{typed\_typed}
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2642,16 +2642,16 @@ The function
 returns $\True$ is $\vt$ is has the \structure\ a of type corresponding to the AST label $\vl$ and a type error otherwise.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{okay}:
+  \item \AllApplyCase{okay}
   \begin{itemize}
     \item determining the \structure\ of $\vt$ yields $\vtp$\ProseOrTypeError;
     \item $\vtp$ has the label $\vl$;
     \item the result is $\True$;
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item determining the \structure\ of $\vt$ yields $\vtp$\ProseOrTypeError;
     \item $\vtp$ does not have the label $\vl$;
@@ -2687,16 +2687,16 @@ The function
 returns the \wellconstrainedversion\ of a type $\vt$ --- $\vtp$, which is defined as follows.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{t\_int\_parameterized}:
+  \item \AllApplyCase{t\_int\_parameterized}
   \begin{itemize}
     \item $\vt$ is a \parameterizedintegertype\ for the variable $\vv$;
     \item $\vtp$ is the well-constrained integer constrained by the variable expression for $\vv$,
     that is, $\TInt(\wellconstrained(\constraintexact(\EVar(\vv))))$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_int\_other, other}:
+  \item \AllApplyCase{t\_int\_other, other}
   \begin{itemize}
     \item $\vt$ is not a \parameterizedintegertype\ for the variable $\vv$;
     \item $\vtp$ is $\vt$.
@@ -2762,16 +2762,16 @@ in the static environment $\tenv$.
 \ProseOrTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{okay}:
+  \item \AllApplyCase{okay}
   \begin{itemize}
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields a bitvector type with width expression $\ve$,
           that is, $\TBits(\ve, \Ignore)$\ProseOrTypeError;
     \item the result is $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields a type that is not a bitvector type;
     \item the result is a type error indicating that a bitvector type was expected.
@@ -2842,15 +2842,15 @@ If the answer is positive, the result is $\True$. \ProseOtherwiseTypeError
 \begin{itemize}
   \item obtaining the width of $\vtone$ in $\tenv$ (via $\getbitvectorwidth$) yields the expression $\vn$\ProseOrTypeError;
   \item obtaining the width of $\vttwo$ in $\tenv$ (via $\getbitvectorwidth$) yields the expression $\vm$\ProseOrTypeError;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{true}:
+    \item \AllApplyCase{true}
     \begin{itemize}
       \item symbolically checking whether the bitwidth expressions $\vn$ and $\vm$ are equal (via $\bitwidthequal$) yields $\True$;
       \item the result is $\True$.
     \end{itemize}
 
-    \item \AllApplyCase{error}:
+    \item \AllApplyCase{error}
     \begin{itemize}
       \item symbolically checking whether the bitwidth expressions $\vn$ and $\vm$ are equal (via $\bitwidthequal$) yields $\False$;
       \item the result is a type error indicating that the bitwidths are different.

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -15,6 +15,13 @@ This section defines the following relations over types and operators:
 The \emph{subtype} relation is a partial order over \underline{named types}.
 The \emph{\supertypeterm} is the inverse relation. That is, \tty\ is a supertype of \tsy\ if and only if \tsy\ is a subtype of \tty.
 
+\ExampleDef{Subtypes and Supertypes}
+In the following example \texttt{subInt} is a subtype of itself and of \texttt{superInt}:
+\begin{lstlisting}
+type superInt of integer;
+type subInt of integer subtypes superInt;
+\end{lstlisting}
+
 \hypertarget{def-subtypesrel}{}
 The predicate
 \[
@@ -56,42 +63,35 @@ yielding the result in $\vb$.
     \item $\vb$ is $\False$.
   \end{itemize}
 \end{itemize}
-\subsubsection{Example}
-In the following example \texttt{subInt} is a subtype of itself and of \texttt{superInt}:
-\begin{lstlisting}
-type superInt of integer;
-type subInt of integer subtypes superInt;
-\end{lstlisting}
-
-\CodeSubsection{\SubtypeBegin}{\SubtypeEnd}{../types.ml}
 
 \FormallyParagraph
 \begin{mathpar}
-  \inferrule[reflexive]{}{
-    \subtypesrel(\tenv, \TNamed(\id), \TNamed(\id)) \typearrow \True
-  }
-  \and
-  \inferrule[transitive]{
-    \idone \neq \idtwo\\
-    G^\tenv.\subtypes(\idone) = \idthree\\
-    \subtypesrel(\tenv, \TNamed(\idthree), \vttwo) \typearrow \vb
-  }{
-    \subtypesrel(\tenv, \TNamed(\idone), \TNamed(\idtwo)) \typearrow \vb
-  }
-  \and
-  \inferrule[no\_supertype]{
-    \idone \neq \idtwo\\
-    G^\tenv.\subtypes(\idone) = \bot
-  }{
-    \subtypesrel(\tenv, \TNamed(\idone), \TNamed(\idtwo)) \typearrow \False
-  }
-  \and
-  \inferrule[not\_named]{
-    (\astlabel(\vtone) \neq \TNamed \lor \astlabel(\vttwo) \neq \TNamed)
-  }{
-    \subtypesrel(\tenv, \vtone, \vttwo) \typearrow \False
-  }
+\inferrule[reflexive]{}{
+  \subtypesrel(\tenv, \TNamed(\id), \TNamed(\id)) \typearrow \True
+}
+\and
+\inferrule[transitive]{
+  \idone \neq \idtwo\\
+  G^\tenv.\subtypes(\idone) = \idthree\\
+  \subtypesrel(\tenv, \TNamed(\idthree), \vttwo) \typearrow \vb
+}{
+  \subtypesrel(\tenv, \TNamed(\idone), \TNamed(\idtwo)) \typearrow \vb
+}
+\and
+\inferrule[no\_supertype]{
+  \idone \neq \idtwo\\
+  G^\tenv.\subtypes(\idone) = \bot
+}{
+  \subtypesrel(\tenv, \TNamed(\idone), \TNamed(\idtwo)) \typearrow \False
+}
+\and
+\inferrule[not\_named]{
+  (\astlabel(\vtone) \neq \TNamed \lor \astlabel(\vttwo) \neq \TNamed)
+}{
+  \subtypesrel(\tenv, \vtone, \vttwo) \typearrow \False
+}
 \end{mathpar}
+\CodeSubsection{\SubtypeBegin}{\SubtypeEnd}{../types.ml}
 
 \identr{NXRX} \identi{KGKS} \identi{MTML} \identi{JVRM} \identi{CHMP}
 
@@ -365,19 +365,19 @@ returning the result $\vb$.
 
 The function assumes that both $\vt$ and $\vs$ are well-typed according to \secref{Types}.
 
-\subsubsection{Example}
+\ExampleDef{Type-satisfaction Examples}
 In \listingref{typing-typesat1},
 \texttt{var pair: pairT = (1, dataT1)} is legal since the right-hand-side has
 anonymous, non-primitive type \texttt{(integer, T1)}.
 \ASLListing{Type satisfaction example}{typing-typesat1}{\typingtests/TypingRule.TypeSatisfaction1.asl}
 
-\subsubsection{Example}
+\ExampleDef{More Type-satisfaction Examples}
 In \listingref{typing-typesat2},
 \texttt{pair = (1, dataAsInt);} is legal since the right-hand-side has anonymous,
 primitive type \texttt{(integer, integer)}.
 \ASLListing{Type satisfaction example}{typing-typesat2}{\typingtests/TypingRule.TypeSatisfaction2.asl}
 
-\subsubsection{Example}
+\ExampleDef{Failing Type-satisfaction}
 In \listingref{typing-typesat3},
 \texttt{pair = (1, dataT2);} is illegal since the right-hand-side has anonymous,
 non-primitive type \texttt{(integer, T2)} which does not subtype-satisfy named

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -27,13 +27,13 @@ yielding the result in $\vb$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item all of the following apply (\textsc{reflexive}):
+  \item \AllApplyCase{reflexive}:
   \begin{itemize}
     \item $\vtone$ and $\vttwo$ are both the same named type;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item all of the following apply (\textsc{transitive}):
+  \item \AllApplyCase{transitive}:
   \begin{itemize}
     \item $\vtone$ is a named type with name $\idone$, that is $\TNamed(\idone)$;
     \item $\vttwo$ is a named type with name $\idtwo$, that is $\TNamed(\idtwo)$, such that $\idone$ is different from $\idtwo$;
@@ -42,7 +42,7 @@ One of the following applies:
     gives $\vb$.
   \end{itemize}
 
-  \item all of the following apply (\textsc{no\_supertype}):
+  \item \AllApplyCase{no\_supertype}:
   \begin{itemize}
     \item $\vtone$ is a named type with name $\idone$, that is $\TNamed(\idone)$;
     \item $\vttwo$ is a named type with name $\idtwo$, that is $\TNamed(\idtwo)$, such that $\idone$ is different from $\idtwo$;
@@ -50,7 +50,7 @@ One of the following applies:
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item all of the following apply (\textsc{not\_named}):
+  \item \AllApplyCase{not\_named}:
   \begin{itemize}
     \item at least one of $\vtone$ and $\vttwo$ is not a named type;
     \item $\vb$ is $\False$.
@@ -109,48 +109,48 @@ The function assumes that both $\vt$ and $\vs$ are well-typed according to \chap
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-\item All of the following apply (\textsc{error1}):
+\item \AllApplyCase{error1}:
   \begin{itemize}
   \item obtaining the \underlyingtype\ of $\vt$ gives a type error;
   \item the rule results in a type error.
   \end{itemize}
 
-\item All of the following apply (\textsc{error2}):
+\item \AllApplyCase{error2}:
   \begin{itemize}
     \item obtaining the \underlyingtype\ of $\vt$ gives a type $\vttwo$;
     \item obtaining the \underlyingtype\ of $\vs$ gives a type error;
     \item the rule results in a type error.
     \end{itemize}
 
-\item All of the following apply (\textsc{different\_labels}):
+\item \AllApplyCase{different\_labels}:
   \begin{itemize}
   \item the underlying types of $\vt$ and $\vs$ have different AST labels
   (for example, \texttt{integer} and \texttt{real});
   \item $\vb$ is $\False$.
   \end{itemize}
 
-\item All of the following apply (\textsc{simple}):
+\item \AllApplyCase{simple}:
   \begin{itemize}
   \item the \underlyingtype\ of $\vt$, $\vttwo$, is either \texttt{real}, \texttt{string}, or \texttt{bool};
   \item the \underlyingtype\ of $\vs$, $\vstwo$, is either \texttt{real}, \texttt{string}, or \texttt{bool};
   \item $\vb$ is $\True$ if and only if both $\vttwo$ and $\vstwo$ have the same ASL label.
   \end{itemize}
 
-\item All of the following apply (\textsc{t\_int}):
+\item \AllApplyCase{t\_int}:
   \begin{itemize}
   \item the \underlyingtype\ of $\vt$, $\vttwo$, is an \texttt{integer} (any kind);
   \item the \underlyingtype\ of $\vs$, $\vstwo$, is an \texttt{integer} (any kind);
   \item determining whether $\vs$ subsumes $\vt$ in $\tenv$ via symbolic reasoning results in $\vb$.
   \end{itemize}
 
-\item All of the following apply (\textsc{t\_enum}):
+\item \AllApplyCase{t\_enum}:
   \begin{itemize}
   \item the \underlyingtype\ of $\vt$ is an enumeration type with list of labels $\vlit$, that is, $\TEnum(\vlit)$;
   \item the \underlyingtype\ of $\vs$ is an enumeration type with list of labels $\vlis$, that is, $\TEnum(\vlis)$;
   \item $\vb$ is $\True$ if and only if $\vlit$ is equal to $\vlis$.
   \end{itemize}
 
-\item All of the following apply (\textsc{t\_bits}):
+\item \AllApplyCase{t\_bits}:
   \begin{itemize}
   \item the \underlyingtype\ of $\vs$ is a bitvector type with width $\ws$ and bit fields $\bfss$, that is $\TBits(\ws, \bfss)$;
   \item the \underlyingtype\ of $\vt$ is a bitvector type with width $\wt$ and bit fields $\bfst$, that is $\TBits(\wt, \bfst)$;
@@ -158,7 +158,7 @@ One of the following applies:
   \item determining whether the \symbolicdomain{} of bitwidth $\ws$ subsumes the \symbolicdomain{} of bitwidth $\wt$ in $\tenv$ yields $\vb$.
   \end{itemize}
 
-\item All of the following apply (\textsc{t\_array\_expr}):
+\item \AllApplyCase{t\_array\_expr}:
   \begin{itemize}
   \item $\vs$ has the \underlyingtype\ of an array with index $\vlengths$ and element type $\vtys$, that is $\TArray(\vlengths, \vtys)$;
   \item $\vt$ has the \underlyingtype\ of an array with index $\vlengtht$ and element type $\vtyt$, that is $\TArray(\vlengtht, \vtyt)$;
@@ -170,7 +170,7 @@ One of the following applies:
   \item determining whether expressions $\vlengthexprs$ and $\vlengthexprt$ are equivalent gives $\vb$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_array\_enum}):
+  \item \AllApplyCase{t\_array\_enum}:
   \begin{itemize}
   \item $\vs$ has the \underlyingtype\ of an array with index $\vlengths$ and element type $\vtys$, that is $\TArray(\vlengths, \vtys)$;
   \item $\vt$ has the \underlyingtype\ of an array with index $\vlengtht$ and element type $\vtyt$, that is $\TArray(\vlengtht, \vtyt)$;
@@ -182,7 +182,7 @@ One of the following applies:
   \item $\vb$ is $\True$ if and only if $\vnames$ and $\vnamet$ are the same.
   \end{itemize}
 
-\item All of the following apply (\textsc{t\_tuple}):
+\item \AllApplyCase{t\_tuple}:
   \begin{itemize}
   \item $\vs$ has the \underlyingtype\ of a tuple with type list $\vlis$, that is $\TTuple(\vlis)$;
   \item $\vt$ has the \underlyingtype\ of a tuple with type list $\vlit$, that is $\TTuple(\vlit)$;
@@ -193,7 +193,7 @@ One of the following applies:
   \item $\vb$ is $\True$ if and only if all $\vb_\vi$ are $\True$;
   \end{itemize}
 
-\item All of the following apply (\textsc{structured}):
+\item \AllApplyCase{structured}:
   \begin{itemize}
   \item $\vs$ has the \underlyingtype\ $L(\vfieldss)$, which is a \structuredtype;
   \item $\vt$ has the \underlyingtype\ $L(\vfieldst)$, which is a \structuredtype;
@@ -375,13 +375,13 @@ These functions assume that both $\vt$ and $\vs$ are well-typed according to \se
 \ProseParagraph
 One of the following applies:
  \begin{itemize}
-  \item All of the following apply (\textsc{subtypes}):
+  \item \AllApplyCase{subtypes}:
     \begin{itemize}
     \item $\vt$ subtypes $\vs$ in $\tenv$ ;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{anonymous}):
+  \item \AllApplyCase{anonymous}:
   \begin{itemize}
     \item $\vt$ does not subtype $\vs$ in $\tenv$;
     \item at least one of $\vt$ and $\vs$ is an anonymous type in $\tenv$;
@@ -389,7 +389,7 @@ One of the following applies:
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_bits}):
+  \item \AllApplyCase{t\_bits}:
   \begin{itemize}
     \item $\vt$ does not subtype $\vs$ in $\tenv$;
     \item determining whether $\vt$ is anonymous yields $\vbone$;
@@ -402,7 +402,7 @@ One of the following applies:
     \item determining whether $\widtht$ and $\widths$ are \bitwidthequivalent\ yields $\vb$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{otherwise1}):
+  \item \AllApplyCase{otherwise1}:
   \begin{itemize}
     \item $\vt$ does not subtype $\vs$ in $\tenv$;
     \item determining whether $\vt$ is anonymous yields $\vbone$;
@@ -413,7 +413,7 @@ One of the following applies:
     \item at least one of $\vt$ and $\vsstruct$ is not a bitvector type;
   \end{itemize}
 
-  \item All of the following apply (\textsc{otherwise2}):
+  \item \AllApplyCase{otherwise2}:
   \begin{itemize}
     \item $\vt$ does not subtype $\vs$ in $\tenv$;
     \item determining whether $\vt$ is anonymous yields $\vbone$;
@@ -551,13 +551,13 @@ returning the result $\vb$ or a type error, if one is detected.
 \ProseParagraph
  One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{subtype}):
+  \item \AllApplyCase{subtype}:
   \begin{itemize}
     \item either $\vs$ subtypes $\vt$ or $\vt$ subtypes $\vs$;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{simple}):
+  \item \AllApplyCase{simple}:
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$\ProseOrTypeError;
@@ -566,7 +566,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_enum}):
+  \item \AllApplyCase{t\_enum}:
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields an enumeration type with labels $\vlit$;
@@ -574,7 +574,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\True$ if and only if $\vlis$ and $\vlit$ are equal.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_array}):
+  \item \AllApplyCase{t\_array}:
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields an array type with element type $\vtyt$;
@@ -582,7 +582,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\True$ if and only if $\vtyt$ and $\vtys$ type-clash.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_tuple}):
+  \item \AllApplyCase{t\_tuple}:
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields a tuple type with element types $\vt_{1..k}$;
@@ -591,7 +591,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\True$ if and only if $\vt_i$ type-clashes with $\vs_i$, for all $i=1..k$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{otherwise\_different\_labels}):
+  \item \AllApplyCase{otherwise\_different\_labels}:
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$;
@@ -600,7 +600,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item $\vb$ is $\False$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{otherwise\_structured}):
+  \item \AllApplyCase{otherwise\_structured}:
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$;
@@ -723,17 +723,17 @@ The result is a type error if a lowest common ancestor does not exist or a type 
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{type\_equal}):
+  \item \AllApplyCase{type\_equal}:
   \begin{itemize}
     \item $\vt$ is \typeequal\ to $\vs$ in $\tenv$;
     \item $\tty$ is $\vs$ (can as well be $\vt$).
   \end{itemize}
 
-  \item All of the following apply:
+  \item \AllApply
   \begin{itemize}
     \item $\vt$ is not \typeequal\ to $\vs$ in $\tenv$ and one of the following applies:
 
-    \item All of the following apply (\textsc{named\_subtype1}):
+    \item \AllApplyCase{named\_subtype1}:
     \begin{itemize}
       \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
       \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
@@ -743,7 +743,7 @@ One of the following applies:
       \item obtaining the lowest common ancestor of $\vanons$ and $\vanont$ in $\tenv$ yields $\tty$\ProseOrTypeError.
     \end{itemize}
 
-    \item All of the following apply (\textsc{named\_subtype2}):
+    \item \AllApplyCase{named\_subtype2}:
     \begin{itemize}
       \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
       \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
@@ -752,7 +752,7 @@ One of the following applies:
       \item $\tty$ is the named type with identifier $\name$, that is, $\TNamed(\name)$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{one\_named1}):
+    \item \AllApplyCase{one\_named1}:
     \begin{itemize}
       \item only one of $\vt$ or $\vs$ is a named type;
       \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
@@ -761,7 +761,7 @@ One of the following applies:
       \item $\tty$ is $\vt$ if it is a named type (that is, $\astlabel(\vt)=\TNamed$), and $\vs$ otherwise.
     \end{itemize}
 
-    \item All of the following apply (\textsc{one\_named2}):
+    \item \AllApplyCase{one\_named2}:
     \begin{itemize}
       \item only one of $\vt$ or $\vs$ is a named type;
       \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
@@ -770,14 +770,14 @@ One of the following applies:
       \item the lowest common ancestor of $\vanont$ and $\vanons$ in $\tenv$ is $\tty$\ProseOrTypeError.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_int\_unconstrained}):
+    \item \AllApplyCase{t\_int\_unconstrained}:
     \begin{itemize}
       \item both $\vt$ and $\vs$ are integer types;
       \item at least one of $\vt$ or $\vs$ is an unconstrained integer type;
       \item $\tty$ is the unconstrained integer type.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_int\_parameterized}):
+    \item \AllApplyCase{t\_int\_parameterized}:
     \begin{itemize}
       \item neither $\vt$ nor $\vs$ are the unconstrained integer type;
       \item one of $\vt$ and $\vs$ is a \parameterizedintegertype;
@@ -786,14 +786,14 @@ One of the following applies:
       \item $\tty$ the lowest common ancestor of $\vtone$ and $\vsone$ in $\tenv$ is $\tty$\ProseOrTypeError.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_int\_wellconstrained}):
+    \item \AllApplyCase{t\_int\_wellconstrained}:
     \begin{itemize}
       \item $\vt$ is a well-constrained integer type with constraints $\cst$;
       \item $\vs$ is a well-constrained integer type with constraints $\css$;
       \item $\tty$ is the well-constrained integer type with constraints $\cst \concat \css$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_bits}):
+    \item \AllApplyCase{t\_bits}:
     \begin{itemize}
       \item $\vt$ is a bitvector type with length expression $\vet$, that is, $\TBits(\vet, \Ignore)$;
       \item $\vs$ is a bitvector type with length expression $\ves$, that is, $\TBits(\ves, \Ignore)$;
@@ -803,7 +803,7 @@ One of the following applies:
       \item $\tty$ is a bitvector type with length expression $\vet$ and an empty bitfield list, that is, $\TBits(\vet, \emptylist)$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_array}):
+    \item \AllApplyCase{t\_array}:
     \begin{itemize}
       \item $\vt$ is an array type with width expression $\widtht$ and element type $\vtyt$;
       \item $\vs$ is an array type with width expression $\widths$ and element type $\vtys$;
@@ -814,7 +814,7 @@ One of the following applies:
       \item $\tty$ is an array type with width expression $\widths$ and element type $\vtone$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{t\_tuple}):
+    \item \AllApplyCase{t\_tuple}:
     \begin{itemize}
       \item $\vt$ is a tuple type with type list $\vlit$;
       \item $\vs$ is a tuple type with type list $\vlis$;
@@ -827,7 +827,7 @@ One of the following applies:
       \item define $\tty$ as the tuple type with list of types $\vli$, that is, $\TTuple(\vli)$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{error}):
+    \item \AllApplyCase{error}:
     \begin{itemize}
       \item either the AST labels of $\vt$ and $\vs$ are different, or one of them is $\TEnum$, $\TRecord$, or $\TException$;
       \item the result is a type error indicating the lack of a lowest common ancestor.
@@ -1003,14 +1003,14 @@ Similarly, we determine the negation of integer constraints.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-\item All of the following apply (\textsc{bnot\_t\_bool}):
+\item \AllApplyCase{bnot\_t\_bool}:
   \begin{itemize}
     \item $\op$ is $\BNOT$;
     \item determining whether $\vt$ \typesatisfies\ $\TBool$ yields $\True$\ProseOrTypeError;
     \item $\vs$ is $\TBool$;
   \end{itemize}
 
-\item All of the following apply (\textsc{neg\_error}):
+\item \AllApplyCase{neg\_error}:
 \begin{itemize}
   \item $\op$ is $\NEG$;
   \item determining whether $\vt$ \typesatisfies\ $\TReal$ yields $\False$\ProseOrTypeError;
@@ -1018,21 +1018,21 @@ One of the following applies:
   \item the result is a type error indicating the $\NEG$ is appropriate only for \texttt{real} and \texttt{integer} types;
 \end{itemize}
 
-\item All of the following apply (\textsc{neg\_t\_real}):
+\item \AllApplyCase{neg\_t\_real}:
 \begin{itemize}
   \item $\op$ is $\NEG$;
   \item determining whether $\vt$ \typesatisfies\ $\TReal$ yields $\True$;
   \item $\vs$ is $\TReal$;
 \end{itemize}
 
-\item All of the following apply (\textsc{neg\_t\_int\_unconstrained}):
+\item \AllApplyCase{neg\_t\_int\_unconstrained}:
 \begin{itemize}
   \item $\op$ is $\NEG$;
   \item obtaining the \wellconstrainedstructure\ of $\vt$ yields $\unconstrainedinteger$\ProseOrTypeError;
   \item $\vs$ is $\unconstrainedinteger$;
 \end{itemize}
 
-\item All of the following apply (\textsc{neg\_t\_int\_well\_constrained}):
+\item \AllApplyCase{neg\_t\_int\_well\_constrained}:
 \begin{itemize}
   \item $\op$ is $\NEG$;
   \item obtaining the \wellconstrainedstructure\ of $\vt$ yields the well-constrained integer type with constraints $\vcs$\ProseOrTypeError;
@@ -1041,7 +1041,7 @@ One of the following applies:
   $\TInt(\wellconstrained(\vcsnew))$;
 \end{itemize}
 
-\item All of the following apply (\textsc{not\_t\_bits}):
+\item \AllApplyCase{not\_t\_bits}:
   \begin{itemize}
   \item $\op$ is $\NOT$;
   \item $\vt$ has the structure of a bitvector;
@@ -1138,7 +1138,7 @@ to operands of type $\vtone$ and $\vttwo$ in the static environment $\tenv$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{named}):
+  \item \AllApplyCase{named}:
   \begin{itemize}
     \item at least one of $\vtone$ and $\vttwo$ is a \namedtype;
     \item determining the \underlyingtype\ if $\vtone$ yields $\vtoneanon$\ProseOrTypeError;
@@ -1146,14 +1146,14 @@ One of the following applies:
     \item \Proseapplybinoptypes{$\tenv$}{$\op$}{$\vtoneanon$}{$\vttwoanon$}{$\vt$\ProseOrTypeError}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{boolean}):
+  \item \AllApplyCase{boolean}:
   \begin{itemize}
     \item $\op$ is $\AND$, $\OR$, $\EQOP$ or $\IMPL$;
     \item both $\vtone$ and $\vttwo$ are $\TBool$;
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{bits\_arith}):
+  \item \AllApplyCase{bits\_arith}:
   \begin{itemize}
     \item $\op$ is one of $\AND$, $\OR$, $\XOR$, $\PLUS$, and $\MINUS$;
     \item $\vtone$ is a bitvector type with width expression $\vwone$;
@@ -1163,7 +1163,7 @@ One of the following applies:
     \item $\vt$ is the bitvector type of width $\vwone$ and empty list of bitfields, that is, \\ $\TBits(\vwone, \emptylist)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{bits\_int}):
+  \item \AllApplyCase{bits\_int}:
   \begin{itemize}
     \item $\op$ is either $\PLUS$ or $\MINUS$;
     \item $\vtone$ is a bitvector type with width expression $\vw$;
@@ -1171,7 +1171,7 @@ One of the following applies:
     \item $\vt$ is the bitvector type of width $\vw$ and empty list of bitfields, that is, \\ $\TBits(\vw, \emptylist)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{bits\_concat}):
+  \item \AllApplyCase{bits\_concat}:
   \begin{itemize}
     \item $\op$ is $\BVCONCAT$;
     \item $\vtone$ is a bitvector type with width expression $\vwone$;
@@ -1181,7 +1181,7 @@ One of the following applies:
     \item $\vt$ is the bitvector type of width $\vwp$ and empty list of bitfields, that is, \\ $\TBits(\vw, \emptylist)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{rel}):
+  \item \AllApplyCase{rel}:
   \begin{itemize}
     \item the operator $\op$ and types of $\vtone$ and $\vttwo$ match one of the rows in the following table:
     \[
@@ -1209,7 +1209,7 @@ One of the following applies:
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eq\_neq\_bits}):
+  \item \AllApplyCase{eq\_neq\_bits}:
   \begin{itemize}
     \item $\op$ is either $\EQOP$ or $\NEQ$;
     \item $\vtone$ is a bitvector type with width expression $\vwone$;
@@ -1218,7 +1218,7 @@ One of the following applies:
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eq\_neq\_enum}):
+  \item \AllApplyCase{eq\_neq\_enum}:
   \begin{itemize}
     \item $\op$ is either $\EQOP$ or $\NEQ$;
     \item $\vtone$ is $\TEnum(\vlione)$;
@@ -1227,14 +1227,14 @@ One of the following applies:
     \item $\vt$ is $\TBool$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{arith\_t\_int\_unconstrained}):
+  \item \AllApplyCase{arith\_t\_int\_unconstrained}:
   \begin{itemize}
     \item $\op$ is one of $\{\MUL, \DIV, \DIVRM, \MOD, \SHL,  \SHR, \POW, \PLUS, \MINUS\}$;
     \item both $\vtone$ and $\vttwo$ are integer types and at least one them is the unconstrained integer type;
     \item $\vt$ is the unconstrained integer type;
   \end{itemize}
 
-  \item All of the following apply (\textsc{arith\_t\_int\_parameterized}):
+  \item \AllApplyCase{arith\_t\_int\_parameterized}:
   \begin{itemize}
     \item $\op$ is one of $\{\MUL, \DIV, \DIVRM, \MOD, \SHL,  \SHR, \POW, \PLUS, \MINUS\}$;
     \item both $\vtone$ and $\vttwo$ are integer types, neither is an unconstrained integer type, and at least one them is a \parameterizedintegertype;
@@ -1243,7 +1243,7 @@ One of the following applies:
     \item \Proseapplybinoptypes{$\tenv$}{$\op$}{$\vtonewellconstrained$}{$\vttwowellconstrained$}{$\vt$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{arith\_t\_int\_wellconstrained}):
+  \item \AllApplyCase{arith\_t\_int\_wellconstrained}:
   \begin{itemize}
     \item $\op$ is one of $\{\MUL, \POW, \PLUS, \MINUS, \DIVRM, \DIV, \MOD, \SHL, \SHR\}$;
     \item $\vtone$ is the well-constrained integer type with constraints $\csone$;
@@ -1252,7 +1252,7 @@ One of the following applies:
     \item $\vt$ is the integer type with constraint kind $\vc$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{arith\_real}):
+  \item \AllApplyCase{arith\_real}:
   \begin{itemize}
     \item the operator $\op$ and types of $\vtone$ and $\vttwo$ match one of the rows in the following table:
     \[
@@ -1269,7 +1269,7 @@ One of the following applies:
     \item $\vt$ is $\TReal$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item obtaining the \underlyingtype\ of $\vtone$ in $\tenv$ yields $\vtoneanon$\ProseOrTypeError;
     \item obtaining the \underlyingtype\ of $\vttwo$ in $\tenv$ yields $\vttwoanon$\ProseOrTypeError;
@@ -1590,20 +1590,20 @@ returns the set of \emph{named supertypes} given via the $\subtypes$ function of
 One of the following holds:
 \begin{itemize}
   \item $\vtsupers$ is in the set of named supertypes of $\vt$;
-  \item All of the following hold (\textsc{found}):
+  \item \AllApplyCase{found}:
   \begin{itemize}
     \item $\vs$ is in $\vtsupers$;
     \item $\tty$ is $\vs$;
   \end{itemize}
 
-  \item All of the following hold (\textsc{super}):
+  \item \AllApplyCase{super}:
   \begin{itemize}
     \item $\vs$ is not in $\vtsupers$;
     \item $\vs$ has a named super type in $\tenv$ --- $\vsp$;
     \item $\tty$ is the lowest common named \supertypeterm{} of $\vt$ and $\vsp$ in $\tenv$.
   \end{itemize}
 
-  \item All of the following hold (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\vs$ is not in $\vtsupers$;
     \item $\vs$ has no named super type in $\tenv$;
@@ -1758,7 +1758,7 @@ The result is the filtered list of constraints $\newcs$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{greater\_or\_equal}):
+  \item \AllApplyCase{greater\_or\_equal}:
   \begin{itemize}
     \item $\op$ is one of $\SHL$, $\SHR$, and $\POW$;
     \item define $\vf$ as the specialization of $\refineconstraintbysign$ for the predicate
@@ -1767,7 +1767,7 @@ One of the following applies:
     \item checking whether $\newcs$ is empty yields $\True$\ProseTerminateAs{\BadOperands}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{greater\_than}):
+  \item \AllApplyCase{greater\_than}:
   \begin{itemize}
     \item $\op$ is one of $\MOD$, $\DIV$, and $\DIVRM$;
     \item define $\vf$ as the specialization of $\refineconstraintbysign$ for the predicate
@@ -1776,7 +1776,7 @@ One of the following applies:
     \item checking whether $\newcs$ is empty yields $\True$\ProseTerminateAs{\BadOperands}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{no\_filtering}):
+  \item \AllApplyCase{no\_filtering}:
   \begin{itemize}
     \item $\op$ is one of $\MINUS$, $\MUL$, and $\PLUS$;
     \item $\newcs$ is $\cs$.
@@ -1832,7 +1832,7 @@ If the set of those values is empty the result is $\None$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact\_reduces\_to\_z}):
+  \item \AllApplyCase{exact\_reduces\_to\_z}:
   \begin{itemize}
     \item $\vc$ is an exact constraint for the expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\reducetozopt$ to $\ve$ in $\tenv$, in order to symbolically simplify $\ve$ to an integer,
@@ -1840,7 +1840,7 @@ One of the following applies:
     \item $\vcopt$ is $\langle\vc\rangle$ if $\vp$ holds for $\vz$ and $\None$ otherwise.
   \end{itemize}
 
-  \item All of the following apply (\textsc{exact\_does\_not\_reduce\_to\_z}):
+  \item \AllApplyCase{exact\_does\_not\_reduce\_to\_z}:
   \begin{itemize}
     \item $\vc$ is an exact constraint for the expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\reducetozopt$ to $\ve$ in $\tenv$, in order to symbolically simplify $\ve$ to an integer,
@@ -1848,7 +1848,7 @@ One of the following applies:
     \item $\vcopt$ is $\langle\vc\rangle$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range\_both\_reduce\_to\_z}):
+  \item \AllApplyCase{range\_both\_reduce\_to\_z}:
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\veone$ and $\vetwo$, that is, \\
           $\ConstraintRange(\veone, \vetwo)$;
@@ -1869,7 +1869,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item All of the following apply (\textsc{only\_e1\_reduces\_to\_z}):
+  \item \AllApplyCase{only\_e1\_reduces\_to\_z}:
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\veone$ and $\vetwo$, that is, \\
           $\ConstraintRange(\veone, \vetwo)$;
@@ -1886,7 +1886,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item All of the following apply (\textsc{only\_e2\_reduces\_to\_z}):
+  \item \AllApplyCase{only\_e2\_reduces\_to\_z}:
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\veone$ and $\vetwo$, that is, \\
           $\ConstraintRange(\veone, \vetwo)$;
@@ -1998,13 +1998,13 @@ which means that applying $\normalize$ to it should not yield a type error.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{normalizes\_to\_z}):
+  \item \AllApplyCase{normalizes\_to\_z}:
   \begin{itemize}
     \item symbolically simplifying $\ve$ in $\tenv$ via $\normalize$ yields a literal expression for the integer $\vz$;
     \item define $\vzopt$ as $\langle\vz\rangle$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{does\_not\_normalize\_to\_z}):
+  \item \AllApplyCase{does\_not\_normalize\_to\_z}:
   \begin{itemize}
     \item symbolically simplifying $\ve$ in $\tenv$ via $\normalize$ yields an expression that is not an integer literal;
     \item define $\vzopt$ as $\None$.
@@ -2045,13 +2045,13 @@ that do not refine to $\None$. The resulting list of constraints is given in $\n
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\cs$ is the empty list;
     \item $\newcs$ is the empty list.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty\_none}):
+  \item \AllApplyCase{non\_empty\_none}:
   \begin{itemize}
     \item $\cs$ is the list with $\vc$ as its \head\ and $\csone$ as its \tail;
     \item applying $\vf$ to $\vc$ yields $\None$;
@@ -2059,7 +2059,7 @@ One of the following applies:
     \item $\newcs$ is $\csonep$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty\_somee}):
+  \item \AllApplyCase{non\_empty\_somee}:
   \begin{itemize}
     \item $\cs$ is the list with $\vc$ as its \head\ and $\csone$ as its \tail;
     \item applying $\vf$ to $\vc$ yields $\langle\vcp\rangle$;
@@ -2108,7 +2108,7 @@ when $\op$ is the division operation.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{div}):
+  \item \AllApplyCase{div}:
   \begin{itemize}
     \item $\op$ is $\DIV$;
     \item applying $\filterreduceconstraintdiv$ to each constraint $\cs[\vi]$, for each $\vi$ in $\listrange(\cs)$,
@@ -2118,7 +2118,7 @@ One of the following applies:
     \item checking that $\vres$ is not the empty list yields $\True$\ProseTerminateAs{\BadOperands}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_div}):
+  \item \AllApplyCase{non\_div}:
   \begin{itemize}
     \item $\op$ is not $\DIV$;
     \item define $\vres$ as $\cs$.
@@ -2160,7 +2160,7 @@ This is used to conservatively test whether $\vc$ would always fail dynamically.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact}):
+  \item \AllApplyCase{exact}:
   \begin{itemize}
     \item $\vc$ is an exact constraint for the expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\getliteraldivopt$ to $\ve$ yields $\langle(\vzone, \vztwo)\rangle$\ProseTerminateAs{\None};
@@ -2171,7 +2171,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vc$ is a range constraint for $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item applying $\getliteraldivopt$ to $\veone$ yields $\veoneopt$;
@@ -2284,13 +2284,13 @@ list, yielding the result in $\newcs$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\cs$ is the empty list;
     \item $\newcs$ is the empty list.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\cs$ is the list with $\vc$ as its \head\ and $\csone$ as its \tail;
     \item applying $\explodeconstraint$ to $\vc$ in $\tenv$ yields $\vcp$ (a list of constraints);
@@ -2329,13 +2329,13 @@ and the singleton list for $\vc$ otherwise.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact}):
+  \item \AllApplyCase{exact}:
   \begin{itemize}
     \item $\vc$ is an exact constraint;
     \item $\vcs$ is the singleton list for $\vc$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range\_reduced}):
+  \item \AllApplyCase{range\_reduced}:
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\va$ and $\vb$;
     \item applying $\reducetozopt$ to $\va$ in $\tenv$ yields $\langle\vza\rangle$;
@@ -2347,7 +2347,7 @@ One of the following applies:
           $\explodedinterval$ otherwise.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range\_not\_reduced}):
+  \item \AllApplyCase{range\_not\_reduced}:
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\va$ and $\vb$;
     \item applying $\reducetozopt$ to $\va$ in $\tenv$ yields $\vzaopt$;
@@ -2441,7 +2441,7 @@ tests whether the set of bit fields $\bfsone$ is included in the set of bit fiel
 returning a type error, if one is detected.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item checking whether each field $\vbf$ in $\bfsone$ exists in $\bfstwo$ via $\membfs$ yields $\vb_\vbf$\ProseOrTypeError;
   \item the result --- $\vb$ --- is the conjunction of $\vb_\vbf$ for all bitfields $\vbf$ in $\bfsone$.
@@ -2469,14 +2469,14 @@ checks whether the bitfield $\vbf$ exists in $\bfstwo$ in the context of $\tenv$
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\None$;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{simple\_any}):
+  \item \AllApplyCase{simple\_any}:
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2484,7 +2484,7 @@ One of the following applies:
     \item symbolically checking whether $\vbfone$ is equivalent to $\vbftwo$ in $\tenv$ yields $\vb$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{nested\_simple}):
+  \item \AllApplyCase{nested\_simple}:
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2493,7 +2493,7 @@ One of the following applies:
     \item symbolically checking whether $\vbfone$ is equivalent to $\vbftwo$ in $\tenv$ yields $\vb$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{nested\_nested}):
+  \item \AllApplyCase{nested\_nested}:
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2505,7 +2505,7 @@ One of the following applies:
     \item $\vb$ is defined as the conjunction of $\vbone$, $\vbtwo$, and $\vbthree$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{nested\_typed}):
+  \item \AllApplyCase{nested\_typed}:
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2514,7 +2514,7 @@ One of the following applies:
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{typed\_simple}):
+  \item \AllApplyCase{typed\_simple}:
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2523,7 +2523,7 @@ One of the following applies:
     \item symbolically checking whether $\vbfone$ is equivalent to $\vbftwo$ in $\tenv$ yields $\vb$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{typed\_nested}):
+  \item \AllApplyCase{typed\_nested}:
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2532,7 +2532,7 @@ One of the following applies:
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{typed\_typed}):
+  \item \AllApplyCase{typed\_typed}:
   \begin{itemize}
     \item the name associated with the bitfield $\vbfone$ is $\name$;
     \item finding the bitfield associated with $\name$ in $\bfstwo$ yields $\vbftwo$;
@@ -2644,14 +2644,14 @@ returns $\True$ is $\vt$ is has the \structure\ a of type corresponding to the A
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{okay}):
+  \item \AllApplyCase{okay}:
   \begin{itemize}
     \item determining the \structure\ of $\vt$ yields $\vtp$\ProseOrTypeError;
     \item $\vtp$ has the label $\vl$;
     \item the result is $\True$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item determining the \structure\ of $\vt$ yields $\vtp$\ProseOrTypeError;
     \item $\vtp$ does not have the label $\vl$;
@@ -2689,14 +2689,14 @@ returns the \wellconstrainedversion\ of a type $\vt$ --- $\vtp$, which is define
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{t\_int\_parameterized}):
+  \item \AllApplyCase{t\_int\_parameterized}:
   \begin{itemize}
     \item $\vt$ is a \parameterizedintegertype\ for the variable $\vv$;
     \item $\vtp$ is the well-constrained integer constrained by the variable expression for $\vv$,
     that is, $\TInt(\wellconstrained(\constraintexact(\EVar(\vv))))$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_int\_other, other}):
+  \item \AllApplyCase{t\_int\_other, other}:
   \begin{itemize}
     \item $\vt$ is not a \parameterizedintegertype\ for the variable $\vv$;
     \item $\vtp$ is $\vt$.
@@ -2734,7 +2734,7 @@ returns the \wellconstrainedstructure\ of a type $\vt$ in the static environment
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item the \structure\ of $\vt$ in $\tenv$ is $\vtone$\ProseOrTypeError;
   \item the well-constrained version of $\vtone$ is $\vtp$.
@@ -2764,14 +2764,14 @@ in the static environment $\tenv$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{okay}):
+  \item \AllApplyCase{okay}:
   \begin{itemize}
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields a bitvector type with width expression $\ve$,
           that is, $\TBits(\ve, \Ignore)$\ProseOrTypeError;
     \item the result is $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields a type that is not a bitvector type;
     \item the result is a type error indicating that a bitvector type was expected.
@@ -2807,7 +2807,7 @@ in the static environment $\tenv$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\getbitvectorwidth$ to $\vt$ in $\tenv$ yields $\ewidth$\ProseOrTypeError;
   \item \Prosestaticeval{$\tenv$}{$\ewidth$}{integer for $\vw$}\ProseOrTypeError.
@@ -2838,19 +2838,19 @@ tests whether the types $\vtone$ and $\vttwo$ are bitvector types of the same wi
 If the answer is positive, the result is $\True$. \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item obtaining the width of $\vtone$ in $\tenv$ (via $\getbitvectorwidth$) yields the expression $\vn$\ProseOrTypeError;
   \item obtaining the width of $\vttwo$ in $\tenv$ (via $\getbitvectorwidth$) yields the expression $\vm$\ProseOrTypeError;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{true}):
+    \item \AllApplyCase{true}:
     \begin{itemize}
       \item symbolically checking whether the bitwidth expressions $\vn$ and $\vm$ are equal (via $\bitwidthequal$) yields $\True$;
       \item the result is $\True$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{error}):
+    \item \AllApplyCase{error}:
     \begin{itemize}
       \item symbolically checking whether the bitwidth expressions $\vn$ and $\vm$ are equal (via $\bitwidthequal$) yields $\False$;
       \item the result is a type error indicating that the bitwidths are different.

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -360,17 +360,29 @@ The predicate
   \aslto \overname{\Bool}{\vb} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 tests whether a type $\vt$ \emph{\typesatisfies} a type $\vs$ in environment $\tenv$,
-returning the result $\vb$ or a type error, if one is detected.
+returning the result $\vb$.
+\ProseOtherwiseTypeError
 
-\hypertarget{def-checktypesat}{}
-We also define
-\[
-  \checktypesat(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
-  \aslto \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
-\]
-which is the same as $\typesat$, but yields a type error when \\ $\typesat(\tenv, \vt, \vs)$ is $\False$.
+The function assumes that both $\vt$ and $\vs$ are well-typed according to \secref{Types}.
 
-These functions assume that both $\vt$ and $\vs$ are well-typed according to \secref{Types}.
+\subsubsection{Example}
+In \listingref{typing-typesat1},
+\texttt{var pair: pairT = (1, dataT1)} is legal since the right-hand-side has
+anonymous, non-primitive type \texttt{(integer, T1)}.
+\ASLListing{Type satisfaction example}{typing-typesat1}{\typingtests/TypingRule.TypeSatisfaction1.asl}
+
+\subsubsection{Example}
+In \listingref{typing-typesat2},
+\texttt{pair = (1, dataAsInt);} is legal since the right-hand-side has anonymous,
+primitive type \texttt{(integer, integer)}.
+\ASLListing{Type satisfaction example}{typing-typesat2}{\typingtests/TypingRule.TypeSatisfaction2.asl}
+
+\subsubsection{Example}
+In \listingref{typing-typesat3},
+\texttt{pair = (1, dataT2);} is illegal since the right-hand-side has anonymous,
+non-primitive type \texttt{(integer, T2)} which does not subtype-satisfy named
+type \texttt{pairT}.
+\ASLListing{Type satisfaction example}{typing-typesat3}{\typingtests/TypingRule.TypeSatisfaction3.asl}
 
 \ProseParagraph
 \OneApplies
@@ -426,27 +438,6 @@ These functions assume that both $\vt$ and $\vs$ are well-typed according to \se
     \item $\vb$ is $\False$;
   \end{itemize}
 \end{itemize}
-
-\subsubsection{Example}
-In \listingref{typing-typesat1},
-\texttt{var pair: pairT = (1, dataT1)} is legal since the right-hand-side has
-anonymous, non-primitive type \texttt{(integer, T1)}.
-\ASLListing{Type satisfaction example}{typing-typesat1}{\typingtests/TypingRule.TypeSatisfaction1.asl}
-
-\subsubsection{Example}
-In \listingref{typing-typesat2},
-\texttt{pair = (1, dataAsInt);} is legal since the right-hand-side has anonymous,
-primitive type \texttt{(integer, integer)}.
-\ASLListing{Type satisfaction example}{typing-typesat2}{\typingtests/TypingRule.TypeSatisfaction2.asl}
-
-\subsubsection{Example}
-In \listingref{typing-typesat3},
-\texttt{pair = (1, dataT2);} is illegal since the right-hand-side has anonymous,
-non-primitive type \texttt{(integer, T2)} which does not subtype-satisfy named
-type \texttt{pairT}.
-\ASLListing{Type satisfaction example}{typing-typesat3}{\typingtests/TypingRule.TypeSatisfaction3.asl}
-
-\CodeSubsection{\TypeSatisfactionBegin}{\TypeSatisfactionEnd}{../types.ml}
 
 \FormallyParagraph
 \begin{mathpar}
@@ -514,10 +505,44 @@ type \texttt{pairT}.
 }
 \end{mathpar}
 
-The rules for the checked type-satisfy predicate are:
+\CodeSubsection{\TypeSatisfactionBegin}{\TypeSatisfactionEnd}{../types.ml}
+
+\subsubsection{Comments}
+Since the subtype relation is a partial order, it is reflexive. Therefore
+every type $\vt$ is a subtype of itself, and as a consequence, every type $\vt$
+\typesatisfies\  itself.
+\lrmcomment{This is related to \identr{FMXK} and \identi{NLFD}.}
+
+\TypingRuleDef{CheckTypeSatisfaction}
+\hypertarget{def-checktypesat}{}
+We also define
+\[
+  \checktypesat(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
+  \aslto \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
+\]
+which is the same as $\typesat$, but yields a type error when \\ $\typesat(\tenv, \vt, \vs)$ is $\False$.
+
+The function assumes that both $\vt$ and $\vs$ are well-typed according to \secref{Types}.
+
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{okay}
+  \begin{itemize}
+    \item \ProsetypesatTrue{$\tenv$}{$\vt$}{$\vs$}.
+  \end{itemize}
+
+  \item \AllApplyCase{error}
+  \begin{itemize}
+    \item \ProsetypesatFalse{$\tenv$}{$\vt$}{$\vs$}..
+    \item the result is a \typingerrorterm{} (\TypeSatisfactionFailure).
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
 \begin{mathpar}
-\inferrule[true]{
-  \typesat(\tenv, \vt, \vs) \typearrow \True \OrTypeError\\
+\inferrule[okay]{
+  \typesat(\tenv, \vt, \vs) \typearrow \True
 }{
   \checktypesat(\tenv, \vt, \vs) \typearrow \True
 }
@@ -530,13 +555,6 @@ The rules for the checked type-satisfy predicate are:
   \checktypesat(\tenv, \vt, \vs) \typearrow \TypeErrorVal{\TypeSatisfactionFailure}
 }
 \end{mathpar}
-
-\subsubsection{Comments}
-Since the subtype relation is a partial order, it is reflexive. Therefore
-every type $\vt$ is a subtype of itself, and as a consequence, every type $\vt$
-\typesatisfies\  itself.
-
-\lrmcomment{This is related to \identr{FMXK} and \identi{NLFD}.}
 
 \TypingRuleDef{TypeClash}
 \hypertarget{def-typeclashes}{}
@@ -1807,7 +1825,7 @@ The result is the filtered list of constraints $\newcs$.
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[no\_filter]{
+\inferrule[no\_filtering]{
   \op \in \{\MINUS, \MUL, \PLUS\}
 }{
   \binopfilterrhs(\op, \cs) \typearrow \overname{\cs}{\newcs}
@@ -1901,6 +1919,17 @@ If the set of those values is empty the result is $\None$.
             $\veone$ and the top expression the literal expression for $0$ if $\vp$ holds for $0$ and the literal expression for $-1$ otherwise.
     \end{itemize}
   \end{itemize}
+
+  \item \AllApplyCase{none\_reduce\_to\_z}
+  \begin{itemize}
+    \item $\vc$ is a range constraint for the expressions $\veone$ and $\vetwo$, that is, \\
+          $\ConstraintRange(\veone, \vetwo)$;
+    \item applying $\reducetozopt$ to $\veone$ in $\tenv$, in order to symbolically simplify $\veone$ to an integer,
+          yields $\None$;
+    \item applying $\reducetozopt$ to $\vetwo$ in $\tenv$, in order to symbolically simplify $\vetwo$ to an integer,
+          yields $\None$;
+    \item \Proseeqdef{$\vcopt$}{$\vc$}.
+  \end{itemize}
 \end{itemize}
 
 \FormallyParagraph
@@ -1942,6 +1971,7 @@ If the set of those values is empty the result is $\None$.
 
 \begin{mathpar}
 \inferrule[only\_e1\_reduces\_to\_z]{
+  \vc = \ConstraintRange(\veone, \vetwo)\\
   \reducetozopt(\tenv, \veone) \typearrow \langle\vzone\rangle\\
   \reducetozopt(\tenv, \vetwo) \typearrow \None\\
   {
@@ -1953,12 +1983,13 @@ If the set of those values is empty the result is $\None$.
 \end{array}
   }
 }{
-  \refineconstraintbysign(\tenv, \vp, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \vcopt
+  \refineconstraintbysign(\tenv, \vp, \vc) \typearrow \vcopt
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[only\_e2\_reduces\_to\_z]{
+  \vc = \ConstraintRange(\veone, \vetwo)\\
   \reducetozopt(\tenv, \veone) \typearrow \None\\
   \reducetozopt(\tenv, \vetwo) \typearrow \langle\vztwo\rangle\\
   {
@@ -1970,16 +2001,17 @@ If the set of those values is empty the result is $\None$.
 \end{array}
   }
 }{
-  \refineconstraintbysign(\tenv, \vp, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \vcopt
+  \refineconstraintbysign(\tenv, \vp, \vc) \typearrow \vcopt
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[none\_reduce\_to\_z]{
+  \vc = \ConstraintRange(\veone, \vetwo)\\
   \reducetozopt(\tenv, \veone) \typearrow \None\\
   \reducetozopt(\tenv, \vetwo) \typearrow \None
 }{
-  \refineconstraintbysign(\tenv, \vp, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \overname{\vc}{\vcopt}
+  \refineconstraintbysign(\tenv, \vp, \vc) \typearrow \overname{\vc}{\vcopt}
 }
 \end{mathpar}
 
@@ -2059,7 +2091,7 @@ that do not refine to $\None$. The resulting list of constraints is given in $\n
     \item $\newcs$ is $\csonep$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty\_somee}
+  \item \AllApplyCase{non\_empty\_some}
   \begin{itemize}
     \item $\cs$ is the list with $\vc$ as its \head\ and $\csone$ as its \tail;
     \item applying $\vf$ to $\vc$ yields $\langle\vcp\rangle$;

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -1755,7 +1755,7 @@ error if found on the right-hand-side of a binary operation expression with the 
 in any environment consisting of the static environment $\tenv$.
 The result is the filtered list of constraints $\newcs$.
 
-\subsubsection{Prose}
+\ProseParagraph
 One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{greater\_or\_equal}):
@@ -2447,6 +2447,7 @@ All of the following apply:
   \item the result --- $\vb$ --- is the conjunction of $\vb_\vbf$ for all bitfields $\vbf$ in $\bfsone$.
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \vbf \in \bfsone: \membfs(\bfstwo, \vbf) \typearrow \vb_\vbf \OrTypeError\\\\
@@ -2544,6 +2545,7 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
 \inferrule[none]{
   \bitfieldgetname(\vbfone) \typearrow \name\\
@@ -2684,6 +2686,7 @@ The function
 \]
 returns the \wellconstrainedversion\ of a type $\vt$ --- $\vtp$, which is defined as follows.
 
+\ProseParagraph
 One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{t\_int\_parameterized}):

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -529,7 +529,8 @@ The function assumes that both $\vt$ and $\vs$ are well-typed according to \secr
 \begin{itemize}
   \item \AllApplyCase{okay}
   \begin{itemize}
-    \item \ProsetypesatTrue{$\tenv$}{$\vt$}{$\vs$}.
+    \item \ProsetypesatTrue{$\tenv$}{$\vt$}{$\vs$};
+    \item the result is $\True$.
   \end{itemize}
 
   \item \AllApplyCase{error}
@@ -750,106 +751,108 @@ The result is a type error if a lowest common ancestor does not exist or a type 
 
   \item \AllApply
   \begin{itemize}
-    \item $\vt$ is not \typeequal\ to $\vs$ in $\tenv$ and \OneApplies
-
-    \item \AllApplyCase{named\_subtype1}
+    \item $\vt$ is not \typeequal\ to $\vs$ in $\tenv$;
+    \item \OneApplies
     \begin{itemize}
-      \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
-      \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
-      \item there is no \namedlowestcommonancestor\ of $\namesubs$ and $\namesubt$ in $\tenv$;
-      \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
-      \item obtaining the \underlyingtype\ of $\vt$ yields $\vanont$\ProseOrTypeError;
-      \item obtaining the lowest common ancestor of $\vanons$ and $\vanont$ in $\tenv$ yields $\tty$\ProseOrTypeError.
-    \end{itemize}
+      \item \AllApplyCase{named\_subtype1}
+      \begin{itemize}
+        \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
+        \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
+        \item there is no \namedlowestcommonancestor\ of $\namesubs$ and $\namesubt$ in $\tenv$;
+        \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
+        \item obtaining the \underlyingtype\ of $\vt$ yields $\vanont$\ProseOrTypeError;
+        \item obtaining the lowest common ancestor of $\vanons$ and $\vanont$ in $\tenv$ yields $\tty$\ProseOrTypeError.
+      \end{itemize}
 
-    \item \AllApplyCase{named\_subtype2}
-    \begin{itemize}
-      \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
-      \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
-      \item the \namedlowestcommonancestor\ of $\namesubs$ and $\namesubt$ in $\tenv$ is \\
-            $\name$\ProseOrTypeError;
-      \item $\tty$ is the named type with identifier $\name$, that is, $\TNamed(\name)$.
-    \end{itemize}
+      \item \AllApplyCase{named\_subtype2}
+      \begin{itemize}
+        \item $\vt$ is a named type with identifier $\namesubt$, that is, $\TNamed(\namesubt)$;
+        \item $\vs$ is a named type with identifier $\namesubs$, that is, $\TNamed(\namesubs)$;
+        \item the \namedlowestcommonancestor\ of $\namesubs$ and $\namesubt$ in $\tenv$ is \\
+              $\name$\ProseOrTypeError;
+        \item $\tty$ is the named type with identifier $\name$, that is, $\TNamed(\name)$.
+      \end{itemize}
 
-    \item \AllApplyCase{one\_named1}
-    \begin{itemize}
-      \item only one of $\vt$ or $\vs$ is a named type;
-      \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
-      \item obtaining the \underlyingtype\ of $\vt$ yields $\vanont$\ProseOrTypeError;
-      \item $\vanont$ is \typeequal\ to $\vanons$;
-      \item $\tty$ is $\vt$ if it is a named type (that is, $\astlabel(\vt)=\TNamed$), and $\vs$ otherwise.
-    \end{itemize}
+      \item \AllApplyCase{one\_named1}
+      \begin{itemize}
+        \item only one of $\vt$ or $\vs$ is a named type;
+        \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
+        \item obtaining the \underlyingtype\ of $\vt$ yields $\vanont$\ProseOrTypeError;
+        \item $\vanont$ is \typeequal\ to $\vanons$;
+        \item $\tty$ is $\vt$ if it is a named type (that is, $\astlabel(\vt)=\TNamed$), and $\vs$ otherwise.
+      \end{itemize}
 
-    \item \AllApplyCase{one\_named2}
-    \begin{itemize}
-      \item only one of $\vt$ or $\vs$ is a named type;
-      \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
-      \item obtaining the \underlyingtype\ of $\vt$ yields $\vanont$\ProseOrTypeError;
-      \item $\vanont$ is not \typeequal\ to $\vanons$;
-      \item the lowest common ancestor of $\vanont$ and $\vanons$ in $\tenv$ is $\tty$\ProseOrTypeError.
-    \end{itemize}
+      \item \AllApplyCase{one\_named2}
+      \begin{itemize}
+        \item only one of $\vt$ or $\vs$ is a named type;
+        \item obtaining the \underlyingtype\ of $\vs$ yields $\vanons$\ProseOrTypeError;
+        \item obtaining the \underlyingtype\ of $\vt$ yields $\vanont$\ProseOrTypeError;
+        \item $\vanont$ is not \typeequal\ to $\vanons$;
+        \item the lowest common ancestor of $\vanont$ and $\vanons$ in $\tenv$ is $\tty$\ProseOrTypeError.
+      \end{itemize}
 
-    \item \AllApplyCase{t\_int\_unconstrained}
-    \begin{itemize}
-      \item both $\vt$ and $\vs$ are integer types;
-      \item at least one of $\vt$ or $\vs$ is an unconstrained integer type;
-      \item $\tty$ is the unconstrained integer type.
-    \end{itemize}
+      \item \AllApplyCase{t\_int\_unconstrained}
+      \begin{itemize}
+        \item both $\vt$ and $\vs$ are integer types;
+        \item at least one of $\vt$ or $\vs$ is an unconstrained integer type;
+        \item $\tty$ is the unconstrained integer type.
+      \end{itemize}
 
-    \item \AllApplyCase{t\_int\_parameterized}
-    \begin{itemize}
-      \item neither $\vt$ nor $\vs$ are the unconstrained integer type;
-      \item one of $\vt$ and $\vs$ is a \parameterizedintegertype;
-      \item the \wellconstrainedversion\ of $\vt$ is $\vtone$;
-      \item the \wellconstrainedversion\ of $\vs$ is $\vsone$;
-      \item $\tty$ the lowest common ancestor of $\vtone$ and $\vsone$ in $\tenv$ is $\tty$\ProseOrTypeError.
-    \end{itemize}
+      \item \AllApplyCase{t\_int\_parameterized}
+      \begin{itemize}
+        \item neither $\vt$ nor $\vs$ are the unconstrained integer type;
+        \item one of $\vt$ and $\vs$ is a \parameterizedintegertype;
+        \item the \wellconstrainedversion\ of $\vt$ is $\vtone$;
+        \item the \wellconstrainedversion\ of $\vs$ is $\vsone$;
+        \item $\tty$ the lowest common ancestor of $\vtone$ and $\vsone$ in $\tenv$ is $\tty$\ProseOrTypeError.
+      \end{itemize}
 
-    \item \AllApplyCase{t\_int\_wellconstrained}
-    \begin{itemize}
-      \item $\vt$ is a well-constrained integer type with constraints $\cst$;
-      \item $\vs$ is a well-constrained integer type with constraints $\css$;
-      \item $\tty$ is the well-constrained integer type with constraints $\cst \concat \css$.
-    \end{itemize}
+      \item \AllApplyCase{t\_int\_wellconstrained}
+      \begin{itemize}
+        \item $\vt$ is a well-constrained integer type with constraints $\cst$;
+        \item $\vs$ is a well-constrained integer type with constraints $\css$;
+        \item $\tty$ is the well-constrained integer type with constraints $\cst \concat \css$.
+      \end{itemize}
 
-    \item \AllApplyCase{t\_bits}
-    \begin{itemize}
-      \item $\vt$ is a bitvector type with length expression $\vet$, that is, $\TBits(\vet, \Ignore)$;
-      \item $\vs$ is a bitvector type with length expression $\ves$, that is, $\TBits(\ves, \Ignore)$;
-      \item applying $\typeequal$ to $\vt$ and $\vs$ in $\tenv$ yields $\False$;
-      \item applying $\exprequal$ to $\vet$ and $\ves$ in $\tenv$ yields $\vbequal$;
-      \item checking whether $\vbequal$ is $\True$ yields $\True$\ProseTerminateAs{\NoLCA};
-      \item $\tty$ is a bitvector type with length expression $\vet$ and an empty bitfield list, that is, $\TBits(\vet, \emptylist)$.
-    \end{itemize}
+      \item \AllApplyCase{t\_bits}
+      \begin{itemize}
+        \item $\vt$ is a bitvector type with length expression $\vet$, that is, $\TBits(\vet, \Ignore)$;
+        \item $\vs$ is a bitvector type with length expression $\ves$, that is, $\TBits(\ves, \Ignore)$;
+        \item applying $\typeequal$ to $\vt$ and $\vs$ in $\tenv$ yields $\False$;
+        \item applying $\exprequal$ to $\vet$ and $\ves$ in $\tenv$ yields $\vbequal$;
+        \item checking whether $\vbequal$ is $\True$ yields $\True$\ProseTerminateAs{\NoLCA};
+        \item $\tty$ is a bitvector type with length expression $\vet$ and an empty bitfield list, that is, $\TBits(\vet, \emptylist)$.
+      \end{itemize}
 
-    \item \AllApplyCase{t\_array}
-    \begin{itemize}
-      \item $\vt$ is an array type with width expression $\widtht$ and element type $\vtyt$;
-      \item $\vs$ is an array type with width expression $\widths$ and element type $\vtys$;
-      \item applying $\arraylengthequal$ to $\widtht$ and $\widths$ in $\tenv$ to equate the array lengths,
-            yields $\vbequallength$\ProseOrTypeError;
-      \item checking that $\vbequallength$ is $\True$ yields $\True$\ProseTerminateAs{\NoLCA};
-      \item the lowest common ancestor of $\vtyt$ and $\vtys$ is $\vtone$\ProseOrTypeError;
-      \item $\tty$ is an array type with width expression $\widths$ and element type $\vtone$.
-    \end{itemize}
+      \item \AllApplyCase{t\_array}
+      \begin{itemize}
+        \item $\vt$ is an array type with width expression $\widtht$ and element type $\vtyt$;
+        \item $\vs$ is an array type with width expression $\widths$ and element type $\vtys$;
+        \item applying $\arraylengthequal$ to $\widtht$ and $\widths$ in $\tenv$ to equate the array lengths,
+              yields $\vbequallength$\ProseOrTypeError;
+        \item checking that $\vbequallength$ is $\True$ yields $\True$\ProseTerminateAs{\NoLCA};
+        \item the lowest common ancestor of $\vtyt$ and $\vtys$ is $\vtone$\ProseOrTypeError;
+        \item $\tty$ is an array type with width expression $\widths$ and element type $\vtone$.
+      \end{itemize}
 
-    \item \AllApplyCase{t\_tuple}
-    \begin{itemize}
-      \item $\vt$ is a \tupletypeterm{} with type list $\vlit$;
-      \item $\vs$ is a \tupletypeterm{} with type list $\vlis$;
-      \item checking whether $\vlit$ and $\vlis$ have the same number of elements yields $\True$
-            or a type error, which short-circuits the entire rule (indicating that the number of elements in both tuples is expected
-            to be the same and thus there is no lowest common ancestor);
-      \item applying $\lca$ to $\vlit[\vi]$ and $\vlis[\vi]$ in $\tenv$, for every position of $\vlit$,
-            yields $\vt_\vi$\ProseOrTypeError;
-      \item define $\vli$ to be the list of types $\vt_\vi$, for every position of $\vlit$;
-      \item define $\tty$ as the \tupletypeterm{} with list of types $\vli$, that is, $\TTuple(\vli)$.
-    \end{itemize}
+      \item \AllApplyCase{t\_tuple}
+      \begin{itemize}
+        \item $\vt$ is a \tupletypeterm{} with type list $\vlit$;
+        \item $\vs$ is a \tupletypeterm{} with type list $\vlis$;
+        \item checking whether $\vlit$ and $\vlis$ have the same number of elements yields $\True$
+              or a type error, which short-circuits the entire rule (indicating that the number of elements in both tuples is expected
+              to be the same and thus there is no lowest common ancestor);
+        \item applying $\lca$ to $\vlit[\vi]$ and $\vlis[\vi]$ in $\tenv$, for every position of $\vlit$,
+              yields $\vt_\vi$\ProseOrTypeError;
+        \item define $\vli$ to be the list of types $\vt_\vi$, for every position of $\vlit$;
+        \item define $\tty$ as the \tupletypeterm{} with list of types $\vli$, that is, $\TTuple(\vli)$.
+      \end{itemize}
 
-    \item \AllApplyCase{error}
-    \begin{itemize}
-      \item either the AST labels of $\vt$ and $\vs$ are different, or one of them is $\TEnum$, $\TRecord$, or $\TException$;
-      \item the result is a type error indicating the lack of a lowest common ancestor.
+      \item \AllApplyCase{error}
+      \begin{itemize}
+        \item either the AST labels of $\vt$ and $\vs$ are different, or one of them is $\TEnum$, $\TRecord$, or $\TException$;
+        \item the result is a type error indicating the lack of a lowest common ancestor.
+      \end{itemize}
     \end{itemize}
   \end{itemize}
 \end{itemize}

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -125,28 +125,28 @@ The function assumes that both $\vt$ and $\vs$ are well-typed according to \chap
 \item \AllApplyCase{different\_labels}
   \begin{itemize}
   \item the underlying types of $\vt$ and $\vs$ have different AST labels
-  (for example, \texttt{integer} and \texttt{real});
+  (for example, $\TInt$ and $\TReal$);
   \item $\vb$ is $\False$.
   \end{itemize}
 
 \item \AllApplyCase{simple}
   \begin{itemize}
-  \item the \underlyingtype\ of $\vt$, $\vttwo$, is either \texttt{real}, \texttt{string}, or \texttt{bool};
-  \item the \underlyingtype\ of $\vs$, $\vstwo$, is either \texttt{real}, \texttt{string}, or \texttt{bool};
+  \item the \underlyingtype\ of $\vt$, $\vttwo$, is either \realtypeterm{}, \stringtypeterm{}, or \booleantypeterm{};
+  \item the \underlyingtype\ of $\vs$, $\vstwo$, is either \realtypeterm{}, \stringtypeterm{}, or \booleantypeterm{};
   \item $\vb$ is $\True$ if and only if both $\vttwo$ and $\vstwo$ have the same ASL label.
   \end{itemize}
 
 \item \AllApplyCase{t\_int}
   \begin{itemize}
-  \item the \underlyingtype\ of $\vt$, $\vttwo$, is an \texttt{integer} (any kind);
-  \item the \underlyingtype\ of $\vs$, $\vstwo$, is an \texttt{integer} (any kind);
+  \item the \underlyingtype\ of $\vt$, $\vttwo$, is an \integertypeterm{} (any kind);
+  \item the \underlyingtype\ of $\vs$, $\vstwo$, is an \integertypeterm{} (any kind);
   \item determining whether $\vs$ subsumes $\vt$ in $\tenv$ via symbolic reasoning results in $\vb$.
   \end{itemize}
 
 \item \AllApplyCase{t\_enum}
   \begin{itemize}
-  \item the \underlyingtype\ of $\vt$ is an enumeration type with list of labels $\vlit$, that is, $\TEnum(\vlit)$;
-  \item the \underlyingtype\ of $\vs$ is an enumeration type with list of labels $\vlis$, that is, $\TEnum(\vlis)$;
+  \item the \underlyingtype\ of $\vt$ is an \enumerationtypeterm{} with list of labels $\vlit$, that is, $\TEnum(\vlit)$;
+  \item the \underlyingtype\ of $\vs$ is an \enumerationtypeterm{} with list of labels $\vlis$, that is, $\TEnum(\vlis)$;
   \item $\vb$ is $\True$ if and only if $\vlit$ is equal to $\vlis$.
   \end{itemize}
 
@@ -580,15 +580,16 @@ returning the result $\vb$ or a type error, if one is detected.
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$\ProseOrTypeError;
     \item obtaining the \structure\ of $\vs$ in $\tenv$ yields $\vsstruct$\ProseOrTypeError;
-    \item both $\vtstruct$ and $\vsstruct$ are one of the following types: \\ \texttt{integer}, \texttt{real}, \texttt{string};
+    \item both $\vtstruct$ and $\vsstruct$ are one of the following types: \\
+          \integertypeterm{}, \realtypeterm{}, or \stringtypeterm{};
     \item $\vb$ is $\True$.
   \end{itemize}
 
   \item \AllApplyCase{t\_enum}
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
-    \item obtaining the \structure\ of $\vt$ in $\tenv$ yields an enumeration type with labels $\vlit$;
-    \item obtaining the \structure\ of $\vs$ in $\tenv$ yields an enumeration type with labels $\vlis$;
+    \item obtaining the \structure\ of $\vt$ in $\tenv$ yields an \enumerationtypeterm{} with labels $\vlit$;
+    \item obtaining the \structure\ of $\vs$ in $\tenv$ yields an \enumerationtypeterm{} with labels $\vlis$;
     \item $\vb$ is $\True$ if and only if $\vlis$ and $\vlit$ are equal.
   \end{itemize}
 
@@ -603,8 +604,8 @@ returning the result $\vb$ or a type error, if one is detected.
   \item \AllApplyCase{t\_tuple}
   \begin{itemize}
     \item neither $\vs$ subtypes $\vt$ nor $\vt$ subtypes $\vs$;
-    \item obtaining the \structure\ of $\vt$ in $\tenv$ yields a tuple type with element types $\vt_{1..k}$;
-    \item obtaining the \structure\ of $\vs$ in $\tenv$ yields a tuple type with element types $\vs_{1..n}$;
+    \item obtaining the \structure\ of $\vt$ in $\tenv$ yields a \tupletypeterm{} with element types $\vt_{1..k}$;
+    \item obtaining the \structure\ of $\vs$ in $\tenv$ yields a \tupletypeterm{} with element types $\vs_{1..n}$;
     \item if $n \neq k$ the rule short-circuits with $\vb=\False$;
     \item $\vb$ is $\True$ if and only if $\vt_i$ type-clashes with $\vs_i$, for all $i=1..k$.
   \end{itemize}
@@ -834,15 +835,15 @@ The result is a type error if a lowest common ancestor does not exist or a type 
 
     \item \AllApplyCase{t\_tuple}
     \begin{itemize}
-      \item $\vt$ is a tuple type with type list $\vlit$;
-      \item $\vs$ is a tuple type with type list $\vlis$;
+      \item $\vt$ is a \tupletypeterm{} with type list $\vlit$;
+      \item $\vs$ is a \tupletypeterm{} with type list $\vlis$;
       \item checking whether $\vlit$ and $\vlis$ have the same number of elements yields $\True$
             or a type error, which short-circuits the entire rule (indicating that the number of elements in both tuples is expected
             to be the same and thus there is no lowest common ancestor);
       \item applying $\lca$ to $\vlit[\vi]$ and $\vlis[\vi]$ in $\tenv$, for every position of $\vlit$,
             yields $\vt_\vi$\ProseOrTypeError;
       \item define $\vli$ to be the list of types $\vt_\vi$, for every position of $\vlit$;
-      \item define $\tty$ as the tuple type with list of types $\vli$, that is, $\TTuple(\vli)$.
+      \item define $\tty$ as the \tupletypeterm{} with list of types $\vli$, that is, $\TTuple(\vli)$.
     \end{itemize}
 
     \item \AllApplyCase{error}
@@ -1033,7 +1034,7 @@ Similarly, we determine the negation of integer constraints.
   \item $\op$ is $\NEG$;
   \item determining whether $\vt$ \typesatisfies\ $\TReal$ yields $\False$\ProseOrTypeError;
   \item determining whether $\vt$ \typesatisfies\ $\unconstrainedinteger$ yields $\False$\ProseOrTypeError;
-  \item the result is a type error indicating the $\NEG$ is appropriate only for \texttt{real} and \texttt{integer} types;
+  \item the result is a type error indicating the $\NEG$ is appropriate only for the \realtypeterm{} and the \integertypeterm{};
 \end{itemize}
 
 \item \AllApplyCase{neg\_t\_real}

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -443,7 +443,7 @@ $\graphof{C}$, and the environment of the semantic configuration, $\environof{C}
   \hline
   \Normal(\vv,\vg) & \vg & \text{undefined}\\
   \Normal((\vv,\vg), \env) & \vg & \env\\
-  \Normal(([i=1..k: (\texttt{va}_i,\texttt{vb})],\vg), \env) & \vg & \env\\
+  \Normal(([i=1..k: (\va_i,\vb)],\vg), \env) & \vg & \env\\
   \Normal(\vg, \env) & \vg & \env\\
   \Normal([\vv_{1..k}], \vg) & \vg & \env\\
   \Normal([i=1..k: (\vv_i,\vg_i)], \env) & \text{undefined} & \env\\
@@ -462,7 +462,7 @@ like $C$ where the graph component is substituted with $\vgp$:
   \hline
   \Normal(\vv,\vg) & \Normal(\vv,\vgp)\\
   \Normal((\vv,\vg), \env) & \Normal((\vv,\vgp), \env)\\
-  \Normal((i=1..k: (\texttt{va}_i,\texttt{vb}),\vg), \env) & \Normal((i=1..k: (\texttt{va}_i,\texttt{vb}),\vgp), \env)\\
+  \Normal((i=1..k: (\va_i,\vb),\vg), \env) & \Normal((i=1..k: (\va_i,\vb),\vgp), \env)\\
   \Normal(\vg, \env) & \Normal(\vgp, \env)\\
   \Normal(i=1..k: \vv_i, \vg) & \Normal(i=1..k: \vv_i, \vgp)\\
   \Normal([i=1..k: (\vv_i,\vg_i)], \env) & \text{undefined}\\
@@ -480,7 +480,7 @@ like $C$ where the environment component, if one exists, is substituted with $\e
   \hline
   \Normal(\vv,\vg) & \text{undefined}\\
   \Normal((\vv,\vg), \env) & \Normal((\vv,\vg), \envp)\\
-  \Normal((i=1..k: (\texttt{va}_i,\texttt{vb}),\vg), \env) & \Normal((i=1..k: (\texttt{va}_i,\texttt{vb}),\vg), \envp)\\
+  \Normal((i=1..k: (\va_i,\vb),\vg), \env) & \Normal((i=1..k: (\va_i,\vb),\vg), \envp)\\
   \Normal(\vg, \env) & \Normal(\vg, \envp)\\
   \Normal(i=1..k: \vv_i, \vg) & \Normal(i=1..k: \vv_i, \vg)\\
   \Normal([i=1..k: (\vv_i,\vg_i)], \env) & \Normal([i=1..k: (\vv_i,\vg_i)], \envp)\\

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -392,7 +392,7 @@ We define the following shorthands for types of output semantic configurations:
 \hypertarget{def-tcontinuing}{}
 \hypertarget{def-tthrowing}{}
 \hypertarget{def-treturning}{}
-\hypertarget{def-terror}{}
+\hypertarget{def-tdynerror}{}
 \[
   \begin{array}{rcl}
     \TNormal          & \triangleq & \Normal(\vals, \XGraphs) \cup \Normal((\vals \times \XGraphs), \envs)\ \cup \\

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -77,7 +77,7 @@ The function
 increments the value associated with $\name$ in $\genv.\stacksize$, yielding the updated global dynamic environment $\newgenv$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\getstacksize$ to $\name$ in $(\genv, \emptyfunc)$ yields $\vprev$;
   \item applying $\setstacksize$ to $\name$ and $\vprev + 1$ in $\genv$ yields $\newgenv$.
@@ -104,7 +104,7 @@ decrements the value associated with $\name$ in $\genv.\stacksize$, yielding the
 It is assumed that $\getstacksize((\genv, \emptyfunc), \name)$ yields a positive value.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\getstacksize$ to $\name$ in $(\genv, \emptyfunc)$ yields $\vprev$;
   \item applying $\setstacksize$ to $\name$ and $\vprev - 1$ in $\genv$ yields $\newgenv$.
@@ -127,10 +127,10 @@ The relation
 \[
   \removelocal(\overname{\envs}{\env} \aslsep \overname{\Identifiers}{\name}) \;\aslrel\; \overname{\envs}{\newenv}
 \]
-removes the binding of the identifier $\name$ from the local storage of the environment $\env$.
+removes the binding of the identifier $\name$ from the local storage of the environment $\env$,
+yielding the environment $\newenv$.
 
-Removal of the identifier $\name$ from the local storage of the environment $\env$
-is the environment $\newenv$ and all of the following apply:
+\AllApply
 \begin{itemize}
   \item $\env$ consists of the static environment $\tenv$ and dynamic environment $\denv$;
   \item $\newenv$ consists of the static environment $\tenv$ and the dynamic environment
@@ -496,12 +496,15 @@ The relation
   (\overname{\envs}{\newenv} \times \overname{\XGraphs}{\newg})
 \]
 declares the local identifier $\vx$ in the environment $\env$, in the context
-of the value-graph pair $(\vv, \vg)$, and all of the following apply:
+of the value-graph pair $(\vv, \vg)$, yielding a pair consisting
+of the environment $\newenv$ and \executiongraph{} $\newg$.
+
+\AllApply
 \begin{itemize}
   \item \newenv\ is the environment $\env$ modified to declare the variable $\vx$ as a local storage element;
   \item $\vgone$ is the execution graph resulting from the declaration of $\vx$;
-  \item $\vgtwo$ is the execution graph resulting from the ordered composition of $\vg$ and $\vgone$
-  with the $\asldata$ edge.
+  \item \Proseeqdef{$\newg$}{\executiongraph{} resulting from the ordered composition
+        of $\vg$ and $\vgone$ with the $\asldata$ edge}.
 \end{itemize}
 
 \FormallyParagraph
@@ -524,25 +527,27 @@ The relation
   \declarelocalidentifiermm(\overname{\envs}{\env} \aslsep
    \overname{\Identifiers}{\vx} \aslsep
    \overname{(\overname{\vals}{\vv}\times\overname{\XGraphs}{\vg})}{\vm}) \;\aslrel\;
-  (\overname{\envs}{\newenv} \times \overname{\XGraphs}{\vgtwo})
+  (\overname{\envs}{\newenv} \times \overname{\XGraphs}{\newg})
 \]
 declares the local identifier $\vx$ in the environment $\env$,
 in the context of the value-graph pair $(\vv, \vg)$,
-and all of the following apply:
+yielding a pair consisting of an environment $\newenv$
+and an \executiongraph{} $\vgtwo$.
+
+\AllApply
 \begin{itemize}
   \item \newenv\ is the environment $\env$ modified to declare the variable $\vx$ as a local storage element;
   \item $\vgone$ is the execution graph resulting from the declaration of $\vx$;
-  \item $\vgtwo$ is the execution graph resulting from the ordered composition of $\vg$ and $\vgone$
-  with the $\aslpo$ edge.
+  \item \Proseeqdef{$\newg$}{the execution graph resulting from the ordered composition
+        of $\vg$ and $\vgone$ with the $\aslpo$ edge.}
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
-  \inferrule{
-    \declarelocalidentifierm(\env, \vm) \evalarrow (\newenv, \vgone)\\
-    \vgtwo \eqdef \ordered{\vg}{\aslpo}{\vgone}
-  }
-  {
-    \declarelocalidentifiermm(\env, \vx, \vm) \evalarrow (\newenv, \vgtwo)
-  }
+\inferrule{
+  \declarelocalidentifierm(\env, \vm) \evalarrow (\newenv, \vgone)\\
+  \newg \eqdef \ordered{\vg}{\aslpo}{\vgone}
+}{
+  \declarelocalidentifiermm(\env, \vx, \vm) \evalarrow (\newenv, \newg)
+}
 \end{mathpar}

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -215,24 +215,44 @@ transforms a (possibly empty) list of bitvector \nativevalues\ $\vvs$ into a sin
 $\newvs$.
 
 \ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{empty}
+  \begin{itemize}
+    \item \Proseemptylist{$\vvs$};
+    \item \Proseeqdef{$\newvs$}{the \nativevalue{} bitvector for the empty sequence of bits}.
+  \end{itemize}
+
+  \item \AllApplyCase{non\_empty}
+  \begin{itemize}
+    \item $\vvs$ is a \Proselist{$\vv$}{$\vvs'$};
+    \item view $\vv$ as the \nativevalue{} bitvector for the sequence of bits $\bv$;
+    \item applying $\concatbitvectors$ to $\vvs'$ yields the
+          \nativevalue{} bitvector for the sequence of bits $\bv$;
+    \item \Proseeqdef{$\vres$}{the concatenation of $\bv$ and $\bv'$};
+    \item \Proseeqdef{$\newvs$}{the \nativevalue{} bitvector for sequence of bits $\vres$}.
+  \end{itemize}
+\end{itemize}
+
 Define $\newvs$ as the concatenation of bitvectors listed in $\vvs$.
 
 \FormallyParagraph
 \begin{mathpar}
-  \inferrule[ConcatBitvector.Empty]{}
-  {
-    \concatbitvectors(\emptylist) \evalarrow \nvbitvector(\emptylist)
-  }
-  \and
-  \inferrule[ConcatBitvector.NonEmpty]{
-    \vvs \eqname [\vv] \concat \vvs'\\
-    \vv\eqname\nvbitvector(\bv)\\
-    \concatbitvectors(\vvs') \evalarrow \nvbitvector(\bv')\\
-    \vres \eqdef \bv \concat \bv'
-  }
-  {
-    \concatbitvectors(\vvs) \evalarrow \nvbitvector(\vres)
-  }
+\inferrule[empty]{}
+{
+  \concatbitvectors(\overname{\emptylist}{\vvs}) \evalarrow \overname{\nvbitvector(\emptylist)}{\newvs}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_empty]{
+  \vvs = [\vv] \concat \vvs'\\
+  \vv\eqname\nvbitvector(\bv)\\
+  \concatbitvectors(\vvs') \evalarrow \nvbitvector(\bv')\\
+  \vres \eqdef \bv \concat \bv'
+}{
+  \concatbitvectors(\vvs) \evalarrow \nvbitvector(\vres)
+}
 \end{mathpar}
 
 \SemanticsRuleDef{ReadFromBitvector}
@@ -350,12 +370,12 @@ overwrites the bits of $\dst$ at the positions given by $\slices$ with the bits 
 
 \FormallyParagraph
 \begin{mathpar}
-  \inferrule[WriteToBitvector.Empty]{}
+  \inferrule[empty]{}
   {
     \writetobitvector(\emptylist, \nvbitvector(\emptylist), \nvbitvector(\emptylist)) \evalarrow \nvbitvector(\emptylist)
   }
   \and
-  \inferrule[WriteToBitvector.NonEmpty]{
+  \inferrule[non\_empty]{
     \vs_n \ldots \vs_1 \eqdef \asbitvector(\src)\\
     \vd_n \ldots \vd_1 \eqdef \asbitvector(\dst)\\
     \slicestopositions(n, \slices) \evalarrow \positions \OrDynError\\\\

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -246,7 +246,7 @@ reads from a bitvector $\bv$, or an integer seen as a bitvector, the indices spe
 thereby concatenating their values.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
   \item all indices are in range for $\bv$ and the returned bitvector consists of the concatenated bits specified
   by the slices.
@@ -339,8 +339,9 @@ The relation
   \writetobitvector(\overname{(\tint\times\tint)^*}{\slices} \aslsep \overname{\tbitvector}{\src} \aslsep \overname{\tbitvector}{\dst})
   \;\aslrel\; \overname{\tbitvector}{\vv} \cup \overname{\TDynError}{\DynErrorConfig}
 \]
-overwrites the bits of $\dst$ at the positions given by $\slices$ with the bits of $\src$
-and one of the following applies:
+overwrites the bits of $\dst$ at the positions given by $\slices$ with the bits of $\src$.
+
+\OneApplies
 \begin{itemize}
   \item all positions specified by $\slices$ are within range for $\dst$ and the modified version
   of $\dst$ with the bits of $\src$ at the specified positions is returned;

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -391,10 +391,10 @@ reads the value $\vv_i$ from the vector of values $\vvec$ at the index $\vi$.
 Notice that there is no rule to handle the case where the index is out of range ---
 this is guaranteed by the typechecker not to happen. Specifically,
 \begin{itemize}
-  \item \texttt{TypingRule.EGetArray} ensures that an index is within the bounds of the array
+  \item \TypingRuleRef{EGetArray} ensures that an index is within the bounds of the array
   being accessed via a check that the type of the index satisfies the type of the array size.
-  \item Typing rules \texttt{TypingRule.LEDestructuring}, \texttt{TypingRule.PTuple},
-  and \\ \texttt{TypingRule.LDTuple} use the same index sequences for the tuples
+  \item Typing rules \TypingRuleRef{LEDestructuring}, \TypingRuleRef{PTuple},
+  and \\ \TypingRuleRef{LDTuple} use the same index sequences for the tuples
   involved and the corresponding lists of expressions.
 \end{itemize}
 If the rules listed above do not hold the typechecker fails.

--- a/asllib/doc/SideEffects.tex
+++ b/asllib/doc/SideEffects.tex
@@ -108,6 +108,10 @@ The function
 \]
 constructs a \timeframeterm\ $\vt$ from a local declaration keyword $\ldk$.
 
+\ProseParagraph
+\ProseEqdef{$\vt$}{$\timeframeconstant$ if $\ldk$ is $\LDKConstant$, and
+    $\timeframeexecution$ otherwise}.
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{}{
@@ -126,9 +130,16 @@ constructs a \timeframeterm\ $\vt$ from a local declaration keyword $\ldk$.
 \hypertarget{def-timeframeofgdk}{}
 The function
 \[
-    \timeframeofgdk(\overname{\globaldeclkeyword}{\gdk}) \aslto \TTimeFrame
+    \timeframeofgdk(\overname{\globaldeclkeyword}{\gdk}) \aslto \overname{\TTimeFrame}{\vt}
 \]
 constructs a \timeframeterm\ $\vt$ from a global declaration keyword $\gdk$.
+
+\ProseParagraph
+\ProseEqdef{$\vt$}{$\timeframeconstant$ if $\gdk$ is $\GDKConstant$,
+    $\timeframeconfig$ if $\gdk$ is $\GDKConfig$,
+    $\timeframeexecution$ if $\gdk$ is $\GDKLet$, and
+    $\timeframeexecution$ if $\gdk$ is $\GDKVar$.
+}
 
 \FormallyParagraph
 \begin{mathpar}
@@ -211,19 +222,28 @@ The function
 \]
 retrieves the \timeframeterm\ $\vt$ from a \sideeffectdescriptorterm\ $\vs$.
 
+% \ProseParagraph
+% \OneApplies
+% \begin{itemize}
+%     \item \AllApplyCase{local}
+%     \begin{itemize}
+%         \item
+%     \end{itemize}
+% \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
-\inferrule{}{
+\inferrule[local]{}{
     \timeframe(\overname{\ReadLocal(\Ignore, \vt, \Ignore)}{\vs}) \typearrow \vt
 }
 \and
-\inferrule{}{
+\inferrule[global]{}{
     \timeframe(\overname{\ReadGlobal(\Ignore, \vt, \Ignore)}{\vs}) \typearrow \vt
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule{
+\inferrule[other]{
     {
     \configdomain{\vs} \in \left\{
         \begin{array}{c}

--- a/asllib/doc/SideEffects.tex
+++ b/asllib/doc/SideEffects.tex
@@ -345,16 +345,16 @@ defines whether there exists a \emph{\sideeffectconflictterm} between the \sidee
 and the \sideeffectdescriptorterm\ $\vstwo$, yielding the result in $\vb$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-    \item \AllApplyCase{globalread}:
+    \item \AllApplyCase{globalread}
     \begin{itemize}
         \item $\vsone$ is a \ReadGlobalTerm\ for a storage element named $\id$;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
               a \WriteGlobalTerm\ for a storage element named $\id$ or a \RecursiveCallTerm.
     \end{itemize}
 
-    \item \AllApplyCase{globalwrite}:
+    \item \AllApplyCase{globalwrite}
     \begin{itemize}
         \item $\vsone$ is a \WriteGlobalTerm\ for a storage element named $\id$;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -364,7 +364,7 @@ One of the following applies:
               a \RecursiveCallTerm.
     \end{itemize}
 
-    \item \AllApplyCase{exception}:
+    \item \AllApplyCase{exception}
     \begin{itemize}
         \item $\vsone$ is an \ThrowExceptionTerm;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -374,7 +374,7 @@ One of the following applies:
                 \RecursiveCallTerm.
     \end{itemize}
 
-    \item \AllApplyCase{localread}:
+    \item \AllApplyCase{localread}
     \begin{itemize}
         \item $\vsone$ is a \ReadLocalTerm\ for a storage element named $\id$;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -382,7 +382,7 @@ One of the following applies:
                 \RecursiveCallTerm.
     \end{itemize}
 
-    \item \AllApplyCase{localwrite}:
+    \item \AllApplyCase{localwrite}
     \begin{itemize}
         \item $\vsone$ is a \WriteLocalTerm\ for a storage element named $\id$;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -391,7 +391,7 @@ One of the following applies:
                 \RecursiveCallTerm.
     \end{itemize}
 
-    \item \AllApplyCase{assertion}:
+    \item \AllApplyCase{assertion}
     \begin{itemize}
         \item $\vsone$ is a \PerformsAssertionsTerm;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -399,13 +399,13 @@ One of the following applies:
             \RecursiveCallTerm.
     \end{itemize}
 
-    \item \AllApplyCase{nondeterminism}:
+    \item \AllApplyCase{nondeterminism}
     \begin{itemize}
         \item $\vsone$ is a \NonDeterministicTerm;
         \item define $\vb$ as $\False$.
     \end{itemize}
 
-    \item \AllApplyCase{recursion}:
+    \item \AllApplyCase{recursion}
     \begin{itemize}
         \item $\vsone$ is a \RecursiveCallTerm;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is not a \NonDeterministicTerm.
@@ -593,9 +593,9 @@ in $\vf$.
 (If $\vses$ is empty, the result is \timeframeconstant.)
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-    \item \AllApplyCase{execution}:
+    \item \AllApplyCase{execution}
     \begin{itemize}
         \item there exists a \sideeffectdescriptorterm\ in $\vses$ that is either
             a \WriteLocalTerm, a \WriteGlobalTerm, an \ThrowExceptionTerm, a \RecursiveCallTerm, or
@@ -603,7 +603,7 @@ One of the following applies:
         \item define $\vf$ as \timeframeexecution.
     \end{itemize}
 
-    \item \AllApplyCase{reads}:
+    \item \AllApplyCase{reads}
     \begin{itemize}
         \item define $\vreads$ as the subset of $\vses$ that contains only
             \sideeffectdescriptorsterm\ that are either \ReadLocalTerm\ or \ReadGlobalTerm;

--- a/asllib/doc/SideEffects.tex
+++ b/asllib/doc/SideEffects.tex
@@ -222,23 +222,48 @@ The function
 \]
 retrieves the \timeframeterm\ $\vt$ from a \sideeffectdescriptorterm\ $\vs$.
 
-% \ProseParagraph
-% \OneApplies
-% \begin{itemize}
-%     \item \AllApplyCase{local}
-%     \begin{itemize}
-%         \item
-%     \end{itemize}
-% \end{itemize}
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+    \item \AllApplyCase{read\_local}
+    \begin{itemize}
+        \item $\vs$ is a \ReadLocalTerm{} for the \timeframeterm{} $\vt$.
+    \end{itemize}
+
+    \item \AllApplyCase{read\_global}
+    \begin{itemize}
+        \item $\vs$ is a \ReadGlobalTerm{} for the \timeframeterm{} $\vt$.
+    \end{itemize}
+
+    \item \AllApplyCase{performs\_assertions}
+    \begin{itemize}
+        \item $\vs$ is a \PerformsAssertionsTerm{};
+        \item \Proseeqdef{$\vt$}{$\timeframeconstant$}.
+    \end{itemize}
+
+    \item \AllApplyCase{other}
+    \begin{itemize}
+        \item $\vs$ is either a \WriteLocalTerm{}, a \WriteGlobalTerm{},
+                a \NonDeterministicTerm{}, a \RecursiveCallTerm{}, or a
+                \ThrowExceptionTerm{};
+        \item \Proseeqdef{$\vt$}{$\timeframeexecution$}.
+    \end{itemize}
+\end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[local]{}{
+\inferrule[read\_local]{}{
     \timeframe(\overname{\ReadLocal(\Ignore, \vt, \Ignore)}{\vs}) \typearrow \vt
 }
 \and
-\inferrule[global]{}{
+\inferrule[read\_global]{}{
     \timeframe(\overname{\ReadGlobal(\Ignore, \vt, \Ignore)}{\vs}) \typearrow \vt
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[performs\_assertions]{}{
+    \timeframe(\overname{\PerformsAssertions}{\vs}) \typearrow \overname{\timeframeconstant}{\vt}
 }
 \end{mathpar}
 
@@ -257,12 +282,6 @@ retrieves the \timeframeterm\ $\vt$ from a \sideeffectdescriptorterm\ $\vs$.
     }
 }{
     \timeframe(\vs) \typearrow \overname{\timeframeexecution}{\vt}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule{}{
-    \timeframe(\overname{\PerformsAssertions}{\vs}) \typearrow \overname{\timeframeconstant}{\vt}
 }
 \end{mathpar}
 

--- a/asllib/doc/SideEffects.tex
+++ b/asllib/doc/SideEffects.tex
@@ -347,14 +347,14 @@ and the \sideeffectdescriptorterm\ $\vstwo$, yielding the result in $\vb$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-    \item All of the following apply (\textsc{globalread}):
+    \item \AllApplyCase{globalread}:
     \begin{itemize}
         \item $\vsone$ is a \ReadGlobalTerm\ for a storage element named $\id$;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
               a \WriteGlobalTerm\ for a storage element named $\id$ or a \RecursiveCallTerm.
     \end{itemize}
 
-    \item All of the following apply (\textsc{globalwrite}):
+    \item \AllApplyCase{globalwrite}:
     \begin{itemize}
         \item $\vsone$ is a \WriteGlobalTerm\ for a storage element named $\id$;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -364,7 +364,7 @@ One of the following applies:
               a \RecursiveCallTerm.
     \end{itemize}
 
-    \item All of the following apply (\textsc{exception}):
+    \item \AllApplyCase{exception}:
     \begin{itemize}
         \item $\vsone$ is an \ThrowExceptionTerm;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -374,7 +374,7 @@ One of the following applies:
                 \RecursiveCallTerm.
     \end{itemize}
 
-    \item All of the following apply (\textsc{localread}):
+    \item \AllApplyCase{localread}:
     \begin{itemize}
         \item $\vsone$ is a \ReadLocalTerm\ for a storage element named $\id$;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -382,7 +382,7 @@ One of the following applies:
                 \RecursiveCallTerm.
     \end{itemize}
 
-    \item All of the following apply (\textsc{localwrite}):
+    \item \AllApplyCase{localwrite}:
     \begin{itemize}
         \item $\vsone$ is a \WriteLocalTerm\ for a storage element named $\id$;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -391,7 +391,7 @@ One of the following applies:
                 \RecursiveCallTerm.
     \end{itemize}
 
-    \item All of the following apply (\textsc{assertion}):
+    \item \AllApplyCase{assertion}:
     \begin{itemize}
         \item $\vsone$ is a \PerformsAssertionsTerm;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is either
@@ -399,13 +399,13 @@ One of the following applies:
             \RecursiveCallTerm.
     \end{itemize}
 
-    \item All of the following apply (\textsc{nondeterminism}):
+    \item \AllApplyCase{nondeterminism}:
     \begin{itemize}
         \item $\vsone$ is a \NonDeterministicTerm;
         \item define $\vb$ as $\False$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{recursion}):
+    \item \AllApplyCase{recursion}:
     \begin{itemize}
         \item $\vsone$ is a \RecursiveCallTerm;
         \item define $\vb$ as $\True$ if and only if $\vstwo$ is not a \NonDeterministicTerm.
@@ -566,7 +566,7 @@ yields the union of the two sets of \sideeffectdescriptorsterm\ $\vsesone$ and $
 if they are \hyperlink{def-sideeffectconflictterm}{non-conflicting}. \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
     \item checking whether $\arenonconflicting$ yields $\True$ for $\vsesone$ and $\vsestwo$ yields\\
          $\True$\ProseTerminateAs{\SideEffectViolation};
@@ -595,7 +595,7 @@ in $\vf$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-    \item All of the following apply (\textsc{execution}):
+    \item \AllApplyCase{execution}:
     \begin{itemize}
         \item there exists a \sideeffectdescriptorterm\ in $\vses$ that is either
             a \WriteLocalTerm, a \WriteGlobalTerm, an \ThrowExceptionTerm, a \RecursiveCallTerm, or
@@ -603,7 +603,7 @@ One of the following applies:
         \item define $\vf$ as \timeframeexecution.
     \end{itemize}
 
-    \item All of the following apply (\textsc{reads}):
+    \item \AllApplyCase{reads}:
     \begin{itemize}
         \item define $\vreads$ as the subset of $\vses$ that contains only
             \sideeffectdescriptorsterm\ that are either \ReadLocalTerm\ or \ReadGlobalTerm;
@@ -679,7 +679,7 @@ returns $\True$ if the set of \sideeffectdescriptorsterm\ $\vses$ is \symbolical
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following applies:
+\AllApply
 \begin{itemize}
   \item applying $\issymbolicallyevaluable$ to $\ve$ in $\tenv$ yields $\vb$;
   \item the result is $\True$ if $\vb$ is $\True$, otherwise it is a type error indicating that the expression

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -82,9 +82,9 @@ The relation
 evaluates a list of slices $\slices$ in an environment $\env$, resulting in either \\
 $\Normal((\ranges, \newg), \newenv)$ or an abnormal configuration.
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item the list of slices is empty;
     \item $\ranges$ is the empty list;
@@ -92,7 +92,7 @@ One of the following applies:
     \item $\newenv$ is $\env$;
   \end{itemize}
 
-  \item \AllApplyCase{nonempty}:
+  \item \AllApplyCase{nonempty}
   \begin{itemize}
     \item the list of slices has $\slice$ as the head and $\slicesone$ as the tail;
     \item evaluating the slice $\vslice$ in $\env$ results in \\
@@ -220,22 +220,22 @@ annotates a single slice $\vs$ in the static environment $\tenv$,
 resulting in an annotated slice $\vsp$.
 \ProseOtherwiseTypeError
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{single}:
+  \item \AllApplyCase{single}
   \begin{itemize}
     \item $\vs$ is a \singleslice\ at index \vi, that is $\SliceSingle(\vi)$;
     \item annotating the slice at offset $\vi$ of length $1$ yields $\vsp$\ProseOrTypeError.
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vs$ is a slice for the range \texttt{(j, i)}, that is $\SliceRange(\vj, \vi)$;
     \item $\prelength$ is \texttt{i+:(j-i+1)};
     \item annotating the slice at offset $\vi$ of length $\prelength$ yields $\vsp$\ProseOrTypeError.
   \end{itemize}
 
-  \item \AllApplyCase{length}:
+  \item \AllApplyCase{length}
   \begin{itemize}
     \item $\vs$ is a \lengthslice\ of length $\elength$ and offset $\eoffset$, that is, \\
           $\SliceLength(\eoffset, \elength)$;
@@ -249,7 +249,7 @@ One of the following applies:
      \item define $\vses$ as the union of $\vsesoffset$ and $\vseslength$.
   \end{itemize}
 
-  \item \AllApplyCase{scaled}:
+  \item \AllApplyCase{scaled}
   \begin{itemize}
     \item $\vs$ is a \scaledslice\ \texttt{[factor *: pre\_length]}, that is, \\
           $\SliceStar(\factor, \prelength)$;
@@ -316,15 +316,15 @@ returns an expression $\vslices$ that represents the width of all slices given b
 in the static environment $\tenv$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vslices$ is the empty list;
     \item $\vwidth$ is the literal integer expression for $0$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vslices$ is the list with \head\ $\vs$ and \tail\ $\slicesone$;
     \item applying $\slicewidth$ to $\vs$ yields $\veone$;
@@ -359,21 +359,21 @@ The helper function
 returns an expression $\vwidth$ that represents the width of the slices given by $\vslice$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{single}:
+  \item \AllApplyCase{single}
   \begin{itemize}
     \item $\vslice$ is a single slice, that is, $\SliceSingle(\Ignore)$;
     \item $\vwidth$ is the literal integer expression for $1$;
   \end{itemize}
 
-  \item \AllApplyCase{star, length}:
+  \item \AllApplyCase{star, length}
   \begin{itemize}
     \item $\vslice$ is either a slice of the form \texttt{\_*:$\ve$} or \texttt{\_+:$\ve$};
     \item $\vwidth$ is $\ve$;
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vslice$ is a slice of the form \texttt{$\veone$:$\vetwo$};
     \item $\vwidth$ is the expression for $1 + (\veone - \vetwo)$.
@@ -466,16 +466,16 @@ In \listingref{semantics-scaledslice},
 \ASLListing{A scaled slice}{semantics-scaledslice}{\semanticstests/SemanticsRule.SliceStar.asl}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{single}:
+  \item \AllApplyCase{single}
   \begin{itemize}
     \item $\vs$ is a \singleslice\ with the expression $\ve$, $\SliceSingle(\ve)$;
     \item evaluating $\ve$ in $\env$ results in $\Normal((\vstart, \newg)$\newenv)\ProseOrAbnormal;
     \item $\vlength$ is the integer value 1.
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vs$ is the \rangeslice\ between the
       expressions $\estart$ and $\etop$, that is, \\ $\SliceRange(\etop, \estart)$;
@@ -487,7 +487,7 @@ One of the following applies:
     \item $\newg$ is the parallel composition of $\vgone$ and $\vgtwo$.
   \end{itemize}
 
-  \item \AllApplyCase{length}:
+  \item \AllApplyCase{length}
   \begin{itemize}
     \item $\vs$ is the \lengthslice, which starts at expression~$\estart$ with length~$\elength$,
     that is, $\SliceLength(\estart, \elength)$;
@@ -498,7 +498,7 @@ One of the following applies:
     \item $\newg$ is the parallel composition of $\vgone$ and $\vgtwo$.
   \end{itemize}
 
-  \item \AllApplyCase{scaled}:
+  \item \AllApplyCase{scaled}
   \begin{itemize}
     \item $\vs$ is the \scaledslice\ with factor given by the
       expression $\efactor$ and length given by the

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -1,6 +1,6 @@
 \chapter{Bitvector Slicing\label{chap:BitvectorSlicing}}
 \hypertarget{bitsliceterm}{}
-\subsubsection{Example}
+\ExampleDef{Well-typed Bitvector Slices}
 \listingref{BitvectorSlices} shows different ways of expressing bitvector slices
 and how they relate to one another in terms of the order of bits they represent.
 \ASLListing{Examples of bitvector slices and operations on slices}{BitvectorSlices}{\definitiontests/Bitvector_slices.asl}
@@ -49,6 +49,9 @@ The function
 annotates a list of slices $\vslices$ in the static environment $\tenv$, yielding a list of annotated slices (that is,
 slices in the \typedast) and \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
+
+See \ExampleRef{Well-typed Bitvector Slices}.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -446,21 +449,21 @@ evaluates an individual slice $\vs$ in an environment $\env$ is,
 resulting either in \\
 $\Normal(((\vstart, \vlength), \vg), \newenv)$, a throwing configuration, or a dynamic error configuration.
 
-\subsubsection{Example (Single Slice)}
+\ExampleDef{Single Slice}
 In \listingref{semantics-slicesingle},
 the slice \texttt{[2]} evaluates to \texttt{(2, 1)}, that is, the slice of
 length 1 starting at index 2.
 \ASLListing{A single expression slice}{semantics-slicesingle}{\semanticstests/SemanticsRule.SliceSingle.asl}
 
-\subsubsection{Example (Range Slice)}
+\ExampleDef{Range Slice}
 In \listingref{semantics-slicerange}, \texttt{4:2} evaluates to \texttt{(2, 3)}.
 \ASLListing{A range slice}{semantics-slicerange}{\semanticstests/SemanticsRule.SliceRange.asl}
 
-\subsubsection{Example (Length Slice)}
+\ExampleDef{Length Slice}
 In \listingref{semantics-slicelength}, \texttt{2+:3} evaluates to \texttt{(2, 3)}.
 \ASLListing{A slice by length}{semantics-slicelength}{\semanticstests/SemanticsRule.SliceLength.asl}
 
-\subsubsection{Example (Scaled Slice)}
+\ExampleDef{Scaled Slice}
 In \listingref{semantics-scaledslice},
 \texttt{x[3*:2]} evaluates to \texttt{'11'}.
 \ASLListing{A scaled slice}{semantics-scaledslice}{\semanticstests/SemanticsRule.SliceStar.asl}

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -50,7 +50,7 @@ annotates a list of slices $\vslices$ in the static environment $\tenv$, yieldin
 slices in the \typedast) and \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item annotating the slice $\vslices[\vi]$ in $\tenv$, for each $\vi\in\listrange(\vslices)$, yields \\
         $(\vs_\vi, \vxs_i)$\ProseOrTypeError;
@@ -84,7 +84,7 @@ $\Normal((\ranges, \newg), \newenv)$ or an abnormal configuration.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item the list of slices is empty;
     \item $\ranges$ is the empty list;
@@ -92,7 +92,7 @@ One of the following applies:
     \item $\newenv$ is $\env$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{nonempty}):
+  \item \AllApplyCase{nonempty}:
   \begin{itemize}
     \item the list of slices has $\slice$ as the head and $\slicesone$ as the tail;
     \item evaluating the slice $\vslice$ in $\env$ results in \\
@@ -222,20 +222,20 @@ resulting in an annotated slice $\vsp$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{single}):
+  \item \AllApplyCase{single}:
   \begin{itemize}
     \item $\vs$ is a \singleslice\ at index \vi, that is $\SliceSingle(\vi)$;
     \item annotating the slice at offset $\vi$ of length $1$ yields $\vsp$\ProseOrTypeError.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vs$ is a slice for the range \texttt{(j, i)}, that is $\SliceRange(\vj, \vi)$;
     \item $\prelength$ is \texttt{i+:(j-i+1)};
     \item annotating the slice at offset $\vi$ of length $\prelength$ yields $\vsp$\ProseOrTypeError.
   \end{itemize}
 
-  \item All of the following apply (\textsc{length}):
+  \item \AllApplyCase{length}:
   \begin{itemize}
     \item $\vs$ is a \lengthslice\ of length $\elength$ and offset $\eoffset$, that is, \\
           $\SliceLength(\eoffset, \elength)$;
@@ -249,7 +249,7 @@ One of the following applies:
      \item define $\vses$ as the union of $\vsesoffset$ and $\vseslength$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{scaled}):
+  \item \AllApplyCase{scaled}:
   \begin{itemize}
     \item $\vs$ is a \scaledslice\ \texttt{[factor *: pre\_length]}, that is, \\
           $\SliceStar(\factor, \prelength)$;
@@ -318,13 +318,13 @@ in the static environment $\tenv$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\vslices$ is the empty list;
     \item $\vwidth$ is the literal integer expression for $0$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\vslices$ is the list with \head\ $\vs$ and \tail\ $\slicesone$;
     \item applying $\slicewidth$ to $\vs$ yields $\veone$;
@@ -361,19 +361,19 @@ returns an expression $\vwidth$ that represents the width of the slices given by
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{single}):
+  \item \AllApplyCase{single}:
   \begin{itemize}
     \item $\vslice$ is a single slice, that is, $\SliceSingle(\Ignore)$;
     \item $\vwidth$ is the literal integer expression for $1$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{star, length}):
+  \item \AllApplyCase{star, length}:
   \begin{itemize}
     \item $\vslice$ is either a slice of the form \texttt{\_*:$\ve$} or \texttt{\_+:$\ve$};
     \item $\vwidth$ is $\ve$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vslice$ is a slice of the form \texttt{$\veone$:$\vetwo$};
     \item $\vwidth$ is the expression for $1 + (\veone - \vetwo)$.
@@ -411,7 +411,7 @@ and returns the annotated expression $\vepp$ and \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item \Proseannotatesymbolicallyevaluableexpr{$\tenv$}{$\ve$}{$(\vt, \vep, \vses)$\ProseOrTypeError};
   \item determining whether $\vt$ is a symbolically \constrainedinteger\ in $\tenv$ yields $\True$\ProseOrTypeError;
@@ -468,14 +468,14 @@ In \listingref{semantics-scaledslice},
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{single}):
+  \item \AllApplyCase{single}:
   \begin{itemize}
     \item $\vs$ is a \singleslice\ with the expression $\ve$, $\SliceSingle(\ve)$;
     \item evaluating $\ve$ in $\env$ results in $\Normal((\vstart, \newg)$\newenv)\ProseOrAbnormal;
     \item $\vlength$ is the integer value 1.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vs$ is the \rangeslice\ between the
       expressions $\estart$ and $\etop$, that is, \\ $\SliceRange(\etop, \estart)$;
@@ -487,7 +487,7 @@ One of the following applies:
     \item $\newg$ is the parallel composition of $\vgone$ and $\vgtwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{length}):
+  \item \AllApplyCase{length}:
   \begin{itemize}
     \item $\vs$ is the \lengthslice, which starts at expression~$\estart$ with length~$\elength$,
     that is, $\SliceLength(\estart, \elength)$;
@@ -498,7 +498,7 @@ One of the following applies:
     \item $\newg$ is the parallel composition of $\vgone$ and $\vgtwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{scaled}):
+  \item \AllApplyCase{scaled}:
   \begin{itemize}
     \item $\vs$ is the \scaledslice\ with factor given by the
       expression $\efactor$ and length given by the

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -367,7 +367,7 @@ returns an expression $\vwidth$ that represents the width of the slices given by
     \item $\vwidth$ is the literal integer expression for $1$;
   \end{itemize}
 
-  \item \AllApplyCase{star, length}
+  \item \AllApplyCase{scaled, length}
   \begin{itemize}
     \item $\vslice$ is either a slice of the form \texttt{\_*:$\ve$} or \texttt{\_+:$\ve$};
     \item $\vwidth$ is $\ve$;

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -1,5 +1,5 @@
 \chapter{Bitvector Slicing\label{chap:BitvectorSlicing}}
-
+\hypertarget{bitsliceterm}{}
 \subsubsection{Example}
 \listingref{BitvectorSlices} shows different ways of expressing bitvector slices
 and how they relate to one another in terms of the order of bits they represent.
@@ -281,7 +281,7 @@ resulting in an annotated slice $\vsp$.
 \inferrule[length]{
   \annotateexpr{\tenv, \eoffset} \typearrow (\toffset, \eoffsetp, \vsesoffset) \OrTypeError\\\\
   \annotatesymbolicconstrainedinteger(\tenv, \elength) \typearrow (\elengthp, \vseslength) \OrTypeError\\\\
-  \checkstructureinteger(\tenv, \toffset) \typearrow \True \OrTypeError\\\\
+  \checkunderlyinginteger(\tenv, \toffset) \typearrow \True \OrTypeError\\\\
   \vses \eqdef \vsesoffset \cup \vseslength
 }{
   {
@@ -471,7 +471,7 @@ In \listingref{semantics-scaledslice},
   \item \AllApplyCase{single}
   \begin{itemize}
     \item $\vs$ is a \singleslice\ with the expression $\ve$, $\SliceSingle(\ve)$;
-    \item evaluating $\ve$ in $\env$ results in $\Normal((\vstart, \newg)$\newenv)\ProseOrAbnormal;
+    \item evaluating $\ve$ in $\env$ results in $\Normal((\vstart, \newg), \newenv)$\ProseOrAbnormal;
     \item $\vlength$ is the integer value 1.
   \end{itemize}
 

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -578,6 +578,7 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
 \inferrule[d\_func]{}{
   \defdecl(\overname{\DFunc(\funcname: \name, \ldots)}{\vd}) \typearrow \name
@@ -617,6 +618,7 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
 \inferrule[decl\_enum]{
   \vd = \DTypeDecl(\name, \TEnum(\vlabels, \Ignore))

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -82,7 +82,7 @@ yielding an output static environment $\newtenv$ and annotated list of declarati
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item splitting $\decls$ into two sublists by testing each declaration to check whether
         it is that of a pragma yields $\pragmas$ and $\others$, respectively;
@@ -147,14 +147,14 @@ for single declarations and \textsc{mutually\_recursive} for more than one decla
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\comps$ is the empty list;
     \item define $\newgenv$ as $\tenv$;
     \item define $\newdecls$ as the empty list.
   \end{itemize}
 
-  \item All of the following apply (\textsc{single}):
+  \item \AllApplyCase{single}:
   \begin{itemize}
     \item $\comps$ is a list with \head\ $\comp$ and \tail\ $\compsone$;
     \item $\comp$ is a single declaration $\vd$;
@@ -163,7 +163,7 @@ One of the following applies:
     \item define $\newdecls$ as the list with \head\ $\vdone$ and \tail\ $\declsone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{mutually\_recursive}):
+  \item \AllApplyCase{mutually\_recursive}:
   \begin{itemize}
     \item $\comps$ is a list with \head\ $\comp$ and \tail\ $\compsone$;
     \item $\comp$ is a list with more than one declaration (that is, a list of mutually-recursive declarations);
@@ -229,7 +229,7 @@ the corresponding getter should have already been annotated and added to the env
 easy to check this requirement.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item checking that each declaration in $\vd$ is a subprogram declaration yields $\True$\ProseTerminateAs{\BadDeclaration};
   \item applying $\annotatefuncsig$ to each node $\vf$ in $\genv$, where $\DFunc(\vf)$ is a declaration in $\decls$,
@@ -308,7 +308,7 @@ yielding $\True$.
 
 \ProseParagraph
 
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vd$ is a global pragma declaration with any identifier and expression list $\vargs$. that is, $\DPragma(\Ignore, \vargs)$;
   \item applying $\withemptylocal$ to $\genv$ yields $\tenv$;
@@ -351,14 +351,14 @@ consisting of local static environment, annotated $\func$ AST node, and \sideeff
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\envandfs$ is the empty list;
     \item define $\newgenv$ as $\genv$;
     \item define $\newenvandfs$ as the empty list.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\envandfs$ is the list with \head\ $(\lenv, \vf, \vsesf)$ and \tail\ $\envandfsone$;
     \item define $\tenv$ as the environment where the global environment component is $\genv$ and the local environment component is $\lenv$;
@@ -401,13 +401,13 @@ adds each $\func$ element in $\vfuncs$ to the $\subprograms$ map of $G^\tenv$, y
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\vfuncs$ is the empty list;
     \item $\newtenv$ is $\tenv$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\vfuncs$ is the list with \head\ $(\vf, \vsesf)$ and \tail\ $\vfuncsone$;
     \item applying $\addsubprogram$ to $\vf.\funcname$, $\vf$, and $\vsesf$ in $\tenv$ yields $\tenvone$;
@@ -446,7 +446,7 @@ consists of the \sideeffectdescriptorsterm\ of all the $\func$ AST nodes of the
 recursive functions it may transitively call.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item define the set $V$ as the set that includes an AST node $\vf$ if and only if $(\vf, \Ignore)$ exists in $\vsess$.
         Intuitively, this is the set of all function definitions in associated with \sideeffectconflictsterm\ in $\vsess$;
@@ -500,7 +500,7 @@ where the declaration of $a$ uses an identifier defined by the declaration of $b
 We refer to this graph as the \emph{\dependencygraphterm} (of $\decls$).
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item define $\defs$ as the union of two sets:
   \begin{enumerate}
@@ -562,17 +562,17 @@ returns the identifier $\name$ being defined by the declaration $\vd$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{d\_func}):
+  \item \AllApplyCase{d\_func}:
   \begin{itemize}
     \item $\vd$ declares a subprogram for the identifier $\name$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{d\_globalstorage}):
+  \item \AllApplyCase{d\_globalstorage}:
   \begin{itemize}
     \item $\vd$ declares a global storage element for the identifier $\name$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{d\_typedecl}):
+  \item \AllApplyCase{d\_typedecl}:
   \begin{itemize}
     \item $\vd$ declares a type for the identifier $\name$.
   \end{itemize}
@@ -605,13 +605,13 @@ if it defines any.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{decl\_enum}):
+  \item \AllApplyCase{decl\_enum}:
   \begin{itemize}
     \item $\vd$ is a declaration of an enumeration type with labels $\vlabels$;
     \item the result is $\vlabels$ as a set (rather than a list).
   \end{itemize}
 
-  \item All of the following apply (\textsc{other}):
+  \item \AllApplyCase{other}:
   \begin{itemize}
     \item $\vd$ is not a declaration of an enumeration type;
     \item define $\vlabels$ as the empty set.
@@ -644,20 +644,20 @@ returns the set of identifiers $\ids$ which the declaration $\vd$ depends on.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{D\_TypeDecl}):
+  \item \AllApplyCase{D\_TypeDecl}:
   \begin{itemize}
     \item $\vd$ declares a type $\tty$ and fields $\fields$, that is,
           $\DTypeDecl(\Ignore, \tty, \fields)$ (the first component is the name, which is being defined);
     \item define $\ids$ as the union of applying $\usety$ to $\tty$ and applying $\usesubtypes$ to $\fields$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{D\_GlobalStorage}):
+  \item \AllApplyCase{D\_GlobalStorage}:
   \begin{itemize}
     \item $\vd$ declares a global storage element with initial value $\initialvalue$ and type $\tty$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\initialvalue$ and applying $\usety$ to $\tty$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{D\_Func}):
+  \item \AllApplyCase{D\_Func}:
   \begin{itemize}
     \item $\vd$ declares a subprogram with arguments $\vargs$, \optional\ return type \\
           $\rettyopt$, parameters $\vparams$, and body statement $\body$;
@@ -722,67 +722,67 @@ returns the set of identifiers $\ids$ which the type or \optional\ type $\vt$ de
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\vt$ is $\None$;
     \item define $\ids$ as $\emptyset$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\vt$ is $\langle\tty\rangle$;
     \item applying $\usety$ to $\tty$ yields $\ids$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{simple}):
+  \item \AllApplyCase{simple}:
   \begin{itemize}
     \item $\vt$ is one of the following types: enumeration, Boolean, real, or string;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_named}):
+  \item \AllApplyCase{t\_named}:
   \begin{itemize}
     \item $\vt$ is the named type for $\vs$;
     \item define $\ids$ as the singleton set for $\vs$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_no\_constraints}):
+  \item \AllApplyCase{int\_no\_constraints}:
   \begin{itemize}
     \item $\vt$ is either the unconstrained integer type or a \parameterizedintegertype{} or a \pendingconstrainedintegertype;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_well\_constrained}):
+  \item \AllApplyCase{int\_well\_constrained}:
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type with constraints $\vcs$;
     \item define $\ids$ as the union of applying $\useconstraint$ to each constraint in $\vcs$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_tuple}):
+  \item \AllApplyCase{t\_tuple}:
   \begin{itemize}
     \item $\vt$ is the tuple type with list of types $\vli$;
     \item define $\ids$ as the union of applying $\useconstraint$ to each constraint in $\vcs$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{structured}):
+  \item \AllApplyCase{structured}:
   \begin{itemize}
     \item $\vt$ is a \structuredtype\ with fields $\fields$;
     \item define $\ids$ as the union of applying $\usety$ to each field type in $\fields$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{array\_expr}):
+  \item \AllApplyCase{array\_expr}:
   \begin{itemize}
     \item $\vt$ is an array expression with length expression $\ve$ and element type $\vtp$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\ve$ and applying $\usety$ to $\vtp$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{array\_enum}):
+  \item \AllApplyCase{array\_enum}:
   \begin{itemize}
     \item $\vt$ is an array expression with enumeration type $\vs$ and element type $\vtp$;
     \item define $\ids$ as the union of the singleton set for $\vs$ and applying $\usety$ to $\vtp$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_bits}):
+  \item \AllApplyCase{t\_bits}:
   \begin{itemize}
     \item $\vt$ is a bitvector type with width expression $\ve$ and bitfields $\bitfields$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\ve$ and applying $\usebitfield$ to each field in $\bitfields$.
@@ -869,13 +869,13 @@ identifier $\vx$ (the type being subtyped) and fields $\subfields$ depends on.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\fields$ is $\None$;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\fields$ is $\langle(\vx, \subfields)\rangle$;
     \item define $\ids$ as the union of the singleton set for $\vx$ and the union of applying $\usety$
@@ -907,117 +907,117 @@ returns the set of identifiers $\ids$ which the expression or \optional\ express
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\ve$ is $\None$;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\ve$ is $\langle\veone\rangle$;
     \item applying $\useexpr$ to $\veone$ yields $\ids$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_literal}):
+  \item \AllApplyCase{e\_literal}:
   \begin{itemize}
     \item $\ve$ is a literal expression;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_atc}):
+  \item \AllApplyCase{e\_atc}:
   \begin{itemize}
     \item $\ve$ is the typing assertion for expression $\ve$ and type $\tty$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\usety$ to $\tty$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_var}):
+  \item \AllApplyCase{e\_var}:
   \begin{itemize}
     \item $\ve$ is the variable expression for identifier $\vx$;
     \item define $\ids$ as the singleton set for $\vx$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getarray}):
+  \item \AllApplyCase{e\_getarray}:
   \begin{itemize}
     \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and index expression $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getenumarray}):
+  \item \AllApplyCase{e\_getenumarray}:
   \begin{itemize}
     \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and enumeration-typed index expression $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_binop}):
+  \item \AllApplyCase{e\_binop}:
   \begin{itemize}
     \item $\ve$ is the binary operation expression over expressions $\veone$ and $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_unop}):
+  \item \AllApplyCase{e\_unop}:
   \begin{itemize}
     \item $\ve$ is the unary operation expression over any unary operation and an expression $\veone$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_call}):
+  \item \AllApplyCase{e\_call}:
   \begin{itemize}
     \item $\ve$ is the call expression of the subprogram named $\vx$ with argument expressions $\vargs$ and parameter expressions $\namedargs$;
     \item define $\ids$ as the union of the singleton set for $\vx$, and the set obtained by applying $\useexpr$ to each expression in
           $\vargs$ and each expression in $\namedargs$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_slice}):
+  \item \AllApplyCase{e\_slice}:
   \begin{itemize}
     \item $\ve$ is the slicing expression over expression $\veone$ and slices $\slices$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useslice$ to each slice in $\slices$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_cond}):
+  \item \AllApplyCase{e\_cond}:
   \begin{itemize}
     \item $\ve$ is the conditional expression over expressions $\veone$, $\vetwo$, and $\vethree$;
     \item define $\ids$ as the union of applying $\useexpr$ to each of $\veone$, $\vetwo$, and $\vethree$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getitem}):
+  \item \AllApplyCase{e\_getitem}:
   \begin{itemize}
     \item $\ve$ is the tuple access expression over expression $\veone$;
     \item define $\ids$ as the application of $\useexpr$ to $\veone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getfield}):
+  \item \AllApplyCase{e\_getfield}:
   \begin{itemize}
     \item $\ve$ is the field access expression over expression $\veone$;
     \item define $\ids$ as the application of $\useexpr$ to $\veone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getfields}):
+  \item \AllApplyCase{e\_getfields}:
   \begin{itemize}
     \item $\ve$ is the multiple field access expression over expression $\veone$;
     \item define $\ids$ as the application of $\useexpr$ to $\veone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_record}):
+  \item \AllApplyCase{e\_record}:
   \begin{itemize}
     \item $\ve$ is the record construction expression of type $\tty$ and field initializations $\vli$;
     \item define $\ids$ as the union of applying of $\usety$ to $\tty$ and applying $\usety$ to each field type in $\vli$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_tuple}):
+  \item \AllApplyCase{e\_tuple}:
   \begin{itemize}
     \item $\ve$ is the tuple construction expression for the expressions $\ves$;
     \item define $\ids$ as the union of applying of $\useexpr$ to each expression in $\ves$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_array}):
+  \item \AllApplyCase{e\_array}:
   \begin{itemize}
     \item $\ve$ is the array construction expression for the length expression $\veone$ and value expression $\vetwo$,
           that is, $\EArray\{\EArrayLength:\veone, \EArrayValue:\vetwo\}$;
     \item define $\ids$ as the union of applying of $\useexpr$ to each of $\veone$ and $\vetwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_enumarray}):
+  \item \AllApplyCase{e\_enumarray}:
   \begin{itemize}
     \item $\ve$ is the array construction expression for the array with enumeration-typed index for the list of labels
           $\vlabels$ and value expression $\vvalue$,
@@ -1026,13 +1026,13 @@ One of the following applies:
     \item define $\ids$ as the union of labels listed in $\vlabels$ and the result of applying $\useexpr$ to $\vvalue$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_arbitrary}):
+  \item \AllApplyCase{e\_arbitrary}:
   \begin{itemize}
     \item $\ve$ is the arbitrary expression with type $\vt$;
     \item define $\ids$ as the application of $\usety$ to $\vt$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_pattern}):
+  \item \AllApplyCase{e\_pattern}:
   \begin{itemize}
     \item $\ve$ is the pattern testing expression for subexpression $\veone$ and pattern $\vp$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\usepattern$ to $\vp$.
@@ -1171,51 +1171,51 @@ returns the set of identifiers $\ids$ which the left-hand-side expression $\vle$
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{le\_var}):
+  \item \AllApplyCase{le\_var}:
   \begin{itemize}
     \item $\vle$ is a left-hand-side variable expression for $\vx$;
     \item define $\ids$ as the singleton set for $\vx$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{le\_destructuring}):
+  \item \AllApplyCase{le\_destructuring}:
   \begin{itemize}
     \item $\vle$ is a left-hand-side expression for assigning to a list of expressions $\vles$,
           that is $\LEDestructuring(\vles)$;
     \item define $\ids$ as the union of applying $\uselexpr$ to each expression in $\vles$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{le\_discard}):
+  \item \AllApplyCase{le\_discard}:
   \begin{itemize}
     \item $\vle$ is a left-hand-side discard expression;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{le\_setarray}):
+  \item \AllApplyCase{le\_setarray}:
   \begin{itemize}
     \item $\vle$ is a left-hand-side array update of the array given by the expression $\veone$ and index expression $\vetwo$;
     \item define $\ids$ as the union of applying $\uselexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{le\_setenumarray}):
+  \item \AllApplyCase{le\_setenumarray}:
   \begin{itemize}
     \item $\vle$ is a left-hand-side array update of the array given by the expression $\veone$ and
           the enumeration-typed index expression $\vetwo$;
     \item define $\ids$ as the union of applying $\uselexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{le\_setfield}):
+  \item \AllApplyCase{le\_setfield}:
   \begin{itemize}
     \item $\vle$ is a left-hand-side field update of the record given by the expression $\veone$;
     \item define $\ids$ as the application of $\uselexpr$ to $\veone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{le\_setfields}):
+  \item \AllApplyCase{le\_setfields}:
   \begin{itemize}
     \item $\vle$ is a left-hand-side multiple field updates of the record given by the expression $\veone$;
     \item define $\ids$ as the application of $\uselexpr$ to $\veone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{le\_slice}):
+  \item \AllApplyCase{le\_slice}:
   \begin{itemize}
     \item $\vle$ is a left-hand-side slicing of the expression $\veone$ by slices $\slices$;
     \item define $\ids$ as the union of applying $\uselexpr$ to $\veone$ and applying $\useslice$ to each slice in $\slices$.
@@ -1278,49 +1278,49 @@ returns the set of identifiers $\ids$ which the declaration $\vd$ depends on.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{mask\_all}):
+  \item \AllApplyCase{mask\_all}:
   \begin{itemize}
     \item $\vp$ is either a mask pattern ($\PatternMask$) or a match-all pattern ($\PatternAll$);
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tuple}):
+  \item \AllApplyCase{tuple}:
   \begin{itemize}
     \item $\vp$ is a tuple pattern list of patterns $\vli$;
     \item define $\ids$ as the union of the application of $\usepattern$ for each pattern in $\vli$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{any}):
+  \item \AllApplyCase{any}:
   \begin{itemize}
     \item $\vp$ is a pattern for matching any of the patterns in the list of patterns $\vli$;
     \item define $\ids$ as the union of the application of $\usepattern$ for each pattern in $\vli$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{single}):
+  \item \AllApplyCase{single}:
   \begin{itemize}
     \item $\vp$ is a pattern for matching the expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{geq}):
+  \item \AllApplyCase{geq}:
   \begin{itemize}
     \item $\vp$ is a pattern for testing greater-or-equal with respect to the expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{leq}):
+  \item \AllApplyCase{leq}:
   \begin{itemize}
     \item $\vp$ is a pattern for testing less-than-or-equal with respect to the expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{not}):
+  \item \AllApplyCase{not}:
   \begin{itemize}
     \item $\vp$ is a pattern negating the pattern $\vpone$;
     \item define $\ids$ as the application of $\usepattern$ to $\vpone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vp$ is a pattern for testing the range of expressions from $\veone$ to $\vetwo$;
     \item define $\ids$ as the union of the application of $\useexpr$ to both $\veone$ and $\vetwo$.
@@ -1389,13 +1389,13 @@ returns the set of identifiers $\ids$ which the slice $\vs$ depends on.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{single}):
+  \item \AllApplyCase{single}:
   \begin{itemize}
     \item $\vs$ is the slice at the position given by the expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{start\_length\_rang}):
+  \item \AllApplyCase{start\_length\_rang}:
   \begin{itemize}
     \item $\vs$ is a slice given by the pair of expressions $\veone$ and $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to both $\veone$ and $\vetwo$.
@@ -1426,20 +1426,20 @@ returns the set of identifiers $\ids$ which the bitfield $\vbf$ depends on.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{simple}):
+  \item \AllApplyCase{simple}:
   \begin{itemize}
     \item $\vbf$ is the single field with slices $\slices$;
     \item define $\ids$ as the union of applying $\useslice$ to each slice in $\slices$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{nested}):
+  \item \AllApplyCase{nested}:
   \begin{itemize}
     \item $\vbf$ is the nested bitfield with slices $\slices$ and bitfields $\bitfields$;
     \item define $\ids$ as the union of applying $\useslice$ to each slice in $\slices$ and applying
           $\usebitfield$ to each bitfield in $\bitfields$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{type}):
+  \item \AllApplyCase{type}:
   \begin{itemize}
     \item $\vbf$ is the typed bitfield with slices $\slices$ and type $\tty$;
     \item define $\ids$ as the union of applying $\useslice$ to each slice in $\slices$ and applying
@@ -1477,13 +1477,13 @@ returns the set of identifiers $\ids$ which the integer constraint $\vc$ depends
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact}):
+  \item \AllApplyCase{exact}:
   \begin{itemize}
     \item $\vc$ is the single-value expression constraint with expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vc$ is the range constraint with expressions $\veone$ and $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to both $\veone$ and $\vetwo$.
@@ -1512,32 +1512,32 @@ returns the set of identifiers $\ids$ which the statement $\vs$ depends on.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{pass\_return\_none\_throw\_none}):
+  \item \AllApplyCase{pass\_return\_none\_throw\_none}:
   \begin{itemize}
     \item $\vs$ is either a pass statement $\SPass$, a return-nothing statement $\SReturn(\None)$,
           or a throw-nothing statement ($\SThrow(\None)$);
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_seq}):
+  \item \AllApplyCase{s\_seq}:
   \begin{itemize}
     \item $\vs$ is a sequencing statement for $\vsone$ and $\vstwo$;
     \item define $\ids$ as the union of applying $\usestmt$ to both $\vsone$ and $\vstwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{assert\_return\_some}):
+  \item \AllApplyCase{assert\_return\_some}:
   \begin{itemize}
     \item $\vs$ is either an assertion with expression $\ve$ or a return statement with expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_assign}):
+  \item \AllApplyCase{s\_assign}:
   \begin{itemize}
     \item $\vs$ is an assignment statement with left-hand-side $\vle$ and right-hand-side $\ve$;
     \item define $\ids$ as the union of applying $\uselexpr$ to $\vle$ and $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_call}):
+  \item \AllApplyCase{s\_call}:
   \begin{itemize}
     \item $\vs$ is a call statement for the subprogram with name $\vx$, arguments $\vargs$, and list of
           pairs consisting of a parameter identifier and associated expression $\namedargs$;
@@ -1546,13 +1546,13 @@ One of the following applies:
           a parameter in $\namedargs$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_cond}):
+  \item \AllApplyCase{s\_cond}:
   \begin{itemize}
     \item $\vs$ is the conditional statement with expression $\ve$ and statements $\vsone$ and $\vstwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\ve$ and $\usestmt$ to both of $\vsone$ and $\vstwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_for}):
+  \item \AllApplyCase{s\_for}:
   \begin{itemize}
     \item $\vs$ is the for statement $\SFor\left\{\begin{array}{rcl}
       \Forindexname &:& \Ignore\\
@@ -1565,33 +1565,33 @@ One of the following applies:
     \item define $\ids$ as the union of applying $\useexpr$ to $\vlimit$, $\vstarte$, and $\vende$ and applying $\usestmt$ to $\vsone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{while\_repeat}):
+  \item \AllApplyCase{while\_repeat}:
   \begin{itemize}
     \item $\vs$ is either a while statement or repeat statement, each with expression $\ve$, body statement $\vsone$,
           and optional limit expression $\vlimit$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\vlimit$ and to $\ve$, and applying $\usestmt$ to $\vsone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_decl}):
+  \item \AllApplyCase{s\_decl}:
   \begin{itemize}
     \item $\vs$ is a declaration statement with \optional{} type annotation $\vt$ and \optional\ initialization expression $\ve$;
     \item define $\ids$ as the union of applying $\usety$ to $\vt$ and $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_try}):
+  \item \AllApplyCase{s\_try}:
   \begin{itemize}
     \item $\vs$ is a try statement with statement $\vsone$, catcher list $\catchers$, and otherwise statement $\vstwo$;
     \item define $\ids$ as the union of applying $\usestmt$ to both $\vsone$ and $\vstwo$ and $\usecatcher$ to
           every catcher in $\catchers$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_print}):
+  \item \AllApplyCase{s\_print}:
   \begin{itemize}
     \item $\vs$ is a print statement with list of expressions $\vargs$;
     \item define $\ids$ as the union of applying $\useexpr$ to each expression in $\vargs$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{s\_unreachable}):
+  \item \AllApplyCase{s\_unreachable}:
   \begin{itemize}
     \item $\vs$ is an \texttt{Unreachable()};
     \item define $\ids$ as the empty set.
@@ -1704,7 +1704,7 @@ The function
 returns the set of identifiers $\ids$ which the try statement catcher $\vc$ depends on.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vc$ is a case alternative with type $\tty$ and statement $\vs$;
   \item define $\ids$ as the union of applying $\usety$ to $\ty$ and applying $\usestmt$ to $\vs$.
@@ -1764,13 +1764,13 @@ yielding $\compdecls$
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\decls$ is the empty list;
     \item define $\compdecls$ as the empty list.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\decls$ is the list with \head\ $\vd$ and \tail\ $declsone$;
     \item define $\declstwo$ as the singleton list for $\vd$ if applying $\defdecl$ to $\vd$ yields an identifier
@@ -1809,12 +1809,12 @@ yielding the native integer value $\vv$ and execution graph $\vg$.
 Otherwise, the result is a dynamic error.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item \Prosebuildgenv{$\tenv$}{$\spec$}{$\env$}{$\vg$}\ProseOrError;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{normal}):
+    \item \AllApplyCase{normal}:
     \begin{itemize}
       \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
       in $\env$ yields $\Normal([(\vv, \vgtwo)], \Ignore)$\ProseOrError;
@@ -1822,7 +1822,7 @@ All of the following apply:
       \item the result of the entire evaluation is $(\vv, \vg)$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{throwing}):
+    \item \AllApplyCase{throwing}:
     \begin{itemize}
       \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
       in $\env$ yields $\Throwing(\vvopt, \Ignore)$, which is an uncaught exception;
@@ -1870,7 +1870,7 @@ to the \defusedependencyterm\ order
 (see \TypingRuleRef{TypeCheckAST}).
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item define the environment $\env$ as consisting of the static environment $\tenv$ and the empty dynamic environment $\emptydenv$;
   \item evaluating the global storage declarations in $\typedspec$ in $\env$ with the empty execution graph

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -145,16 +145,16 @@ allows in ASL are between subprograms. The rules below handle these cases separa
 for single declarations and \textsc{mutually\_recursive} for more than one declaration).
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\comps$ is the empty list;
     \item define $\newgenv$ as $\tenv$;
     \item define $\newdecls$ as the empty list.
   \end{itemize}
 
-  \item \AllApplyCase{single}:
+  \item \AllApplyCase{single}
   \begin{itemize}
     \item $\comps$ is a list with \head\ $\comp$ and \tail\ $\compsone$;
     \item $\comp$ is a single declaration $\vd$;
@@ -163,7 +163,7 @@ One of the following applies:
     \item define $\newdecls$ as the list with \head\ $\vdone$ and \tail\ $\declsone$.
   \end{itemize}
 
-  \item \AllApplyCase{mutually\_recursive}:
+  \item \AllApplyCase{mutually\_recursive}
   \begin{itemize}
     \item $\comps$ is a list with \head\ $\comp$ and \tail\ $\compsone$;
     \item $\comp$ is a list with more than one declaration (that is, a list of mutually-recursive declarations);
@@ -349,16 +349,16 @@ The result is a modified global static environment $\newgenv$ and list of tuples
 consisting of local static environment, annotated $\func$ AST node, and \sideeffectdescriptorsetsterm.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\envandfs$ is the empty list;
     \item define $\newgenv$ as $\genv$;
     \item define $\newenvandfs$ as the empty list.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\envandfs$ is the list with \head\ $(\lenv, \vf, \vsesf)$ and \tail\ $\envandfsone$;
     \item define $\tenv$ as the environment where the global environment component is $\genv$ and the local environment component is $\lenv$;
@@ -399,15 +399,15 @@ The function
 adds each $\func$ element in $\vfuncs$ to the $\subprograms$ map of $G^\tenv$, yielding $\newtenv$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vfuncs$ is the empty list;
     \item $\newtenv$ is $\tenv$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vfuncs$ is the list with \head\ $(\vf, \vsesf)$ and \tail\ $\vfuncsone$;
     \item applying $\addsubprogram$ to $\vf.\funcname$, $\vf$, and $\vsesf$ in $\tenv$ yields $\tenvone$;
@@ -560,19 +560,19 @@ The function
 returns the identifier $\name$ being defined by the declaration $\vd$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{d\_func}:
+  \item \AllApplyCase{d\_func}
   \begin{itemize}
     \item $\vd$ declares a subprogram for the identifier $\name$.
   \end{itemize}
 
-  \item \AllApplyCase{d\_globalstorage}:
+  \item \AllApplyCase{d\_globalstorage}
   \begin{itemize}
     \item $\vd$ declares a global storage element for the identifier $\name$.
   \end{itemize}
 
-  \item \AllApplyCase{d\_typedecl}:
+  \item \AllApplyCase{d\_typedecl}
   \begin{itemize}
     \item $\vd$ declares a type for the identifier $\name$.
   \end{itemize}
@@ -603,15 +603,15 @@ takes a declaration $\vd$ and returns the set of enumeration labels it defines -
 if it defines any.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{decl\_enum}:
+  \item \AllApplyCase{decl\_enum}
   \begin{itemize}
     \item $\vd$ is a declaration of an enumeration type with labels $\vlabels$;
     \item the result is $\vlabels$ as a set (rather than a list).
   \end{itemize}
 
-  \item \AllApplyCase{other}:
+  \item \AllApplyCase{other}
   \begin{itemize}
     \item $\vd$ is not a declaration of an enumeration type;
     \item define $\vlabels$ as the empty set.
@@ -642,22 +642,22 @@ The function
 returns the set of identifiers $\ids$ which the declaration $\vd$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{D\_TypeDecl}:
+  \item \AllApplyCase{D\_TypeDecl}
   \begin{itemize}
     \item $\vd$ declares a type $\tty$ and fields $\fields$, that is,
           $\DTypeDecl(\Ignore, \tty, \fields)$ (the first component is the name, which is being defined);
     \item define $\ids$ as the union of applying $\usety$ to $\tty$ and applying $\usesubtypes$ to $\fields$.
   \end{itemize}
 
-  \item \AllApplyCase{D\_GlobalStorage}:
+  \item \AllApplyCase{D\_GlobalStorage}
   \begin{itemize}
     \item $\vd$ declares a global storage element with initial value $\initialvalue$ and type $\tty$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\initialvalue$ and applying $\usety$ to $\tty$.
   \end{itemize}
 
-  \item \AllApplyCase{D\_Func}:
+  \item \AllApplyCase{D\_Func}
   \begin{itemize}
     \item $\vd$ declares a subprogram with arguments $\vargs$, \optional\ return type \\
           $\rettyopt$, parameters $\vparams$, and body statement $\body$;
@@ -720,69 +720,69 @@ The function
 returns the set of identifiers $\ids$ which the type or \optional\ type $\vt$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\vt$ is $\None$;
     \item define $\ids$ as $\emptyset$.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\vt$ is $\langle\tty\rangle$;
     \item applying $\usety$ to $\tty$ yields $\ids$.
   \end{itemize}
 
-  \item \AllApplyCase{simple}:
+  \item \AllApplyCase{simple}
   \begin{itemize}
     \item $\vt$ is one of the following types: enumeration, Boolean, real, or string;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{t\_named}:
+  \item \AllApplyCase{t\_named}
   \begin{itemize}
     \item $\vt$ is the named type for $\vs$;
     \item define $\ids$ as the singleton set for $\vs$.
   \end{itemize}
 
-  \item \AllApplyCase{int\_no\_constraints}:
+  \item \AllApplyCase{int\_no\_constraints}
   \begin{itemize}
     \item $\vt$ is either the unconstrained integer type or a \parameterizedintegertype{} or a \pendingconstrainedintegertype;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{int\_well\_constrained}:
+  \item \AllApplyCase{int\_well\_constrained}
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type with constraints $\vcs$;
     \item define $\ids$ as the union of applying $\useconstraint$ to each constraint in $\vcs$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_tuple}:
+  \item \AllApplyCase{t\_tuple}
   \begin{itemize}
     \item $\vt$ is the tuple type with list of types $\vli$;
     \item define $\ids$ as the union of applying $\useconstraint$ to each constraint in $\vcs$.
   \end{itemize}
 
-  \item \AllApplyCase{structured}:
+  \item \AllApplyCase{structured}
   \begin{itemize}
     \item $\vt$ is a \structuredtype\ with fields $\fields$;
     \item define $\ids$ as the union of applying $\usety$ to each field type in $\fields$.
   \end{itemize}
 
-  \item \AllApplyCase{array\_expr}:
+  \item \AllApplyCase{array\_expr}
   \begin{itemize}
     \item $\vt$ is an array expression with length expression $\ve$ and element type $\vtp$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\ve$ and applying $\usety$ to $\vtp$.
   \end{itemize}
 
-  \item \AllApplyCase{array\_enum}:
+  \item \AllApplyCase{array\_enum}
   \begin{itemize}
     \item $\vt$ is an array expression with enumeration type $\vs$ and element type $\vtp$;
     \item define $\ids$ as the union of the singleton set for $\vs$ and applying $\usety$ to $\vtp$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_bits}:
+  \item \AllApplyCase{t\_bits}
   \begin{itemize}
     \item $\vt$ is a bitvector type with width expression $\ve$ and bitfields $\bitfields$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\ve$ and applying $\usebitfield$ to each field in $\bitfields$.
@@ -867,15 +867,15 @@ returns the set of identifiers $\ids$ which the \optional\ pair consisting of
 identifier $\vx$ (the type being subtyped) and fields $\subfields$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\fields$ is $\None$;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\fields$ is $\langle(\vx, \subfields)\rangle$;
     \item define $\ids$ as the union of the singleton set for $\vx$ and the union of applying $\usety$
@@ -905,119 +905,119 @@ The function
 returns the set of identifiers $\ids$ which the expression or \optional\ expression $\ve$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\ve$ is $\None$;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\ve$ is $\langle\veone\rangle$;
     \item applying $\useexpr$ to $\veone$ yields $\ids$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_literal}:
+  \item \AllApplyCase{e\_literal}
   \begin{itemize}
     \item $\ve$ is a literal expression;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{e\_atc}:
+  \item \AllApplyCase{e\_atc}
   \begin{itemize}
     \item $\ve$ is the typing assertion for expression $\ve$ and type $\tty$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\usety$ to $\tty$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_var}:
+  \item \AllApplyCase{e\_var}
   \begin{itemize}
     \item $\ve$ is the variable expression for identifier $\vx$;
     \item define $\ids$ as the singleton set for $\vx$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getarray}:
+  \item \AllApplyCase{e\_getarray}
   \begin{itemize}
     \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and index expression $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getenumarray}:
+  \item \AllApplyCase{e\_getenumarray}
   \begin{itemize}
     \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and enumeration-typed index expression $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_binop}:
+  \item \AllApplyCase{e\_binop}
   \begin{itemize}
     \item $\ve$ is the binary operation expression over expressions $\veone$ and $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_unop}:
+  \item \AllApplyCase{e\_unop}
   \begin{itemize}
     \item $\ve$ is the unary operation expression over any unary operation and an expression $\veone$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_call}:
+  \item \AllApplyCase{e\_call}
   \begin{itemize}
     \item $\ve$ is the call expression of the subprogram named $\vx$ with argument expressions $\vargs$ and parameter expressions $\namedargs$;
     \item define $\ids$ as the union of the singleton set for $\vx$, and the set obtained by applying $\useexpr$ to each expression in
           $\vargs$ and each expression in $\namedargs$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_slice}:
+  \item \AllApplyCase{e\_slice}
   \begin{itemize}
     \item $\ve$ is the slicing expression over expression $\veone$ and slices $\slices$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\useslice$ to each slice in $\slices$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_cond}:
+  \item \AllApplyCase{e\_cond}
   \begin{itemize}
     \item $\ve$ is the conditional expression over expressions $\veone$, $\vetwo$, and $\vethree$;
     \item define $\ids$ as the union of applying $\useexpr$ to each of $\veone$, $\vetwo$, and $\vethree$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getitem}:
+  \item \AllApplyCase{e\_getitem}
   \begin{itemize}
     \item $\ve$ is the tuple access expression over expression $\veone$;
     \item define $\ids$ as the application of $\useexpr$ to $\veone$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getfield}:
+  \item \AllApplyCase{e\_getfield}
   \begin{itemize}
     \item $\ve$ is the field access expression over expression $\veone$;
     \item define $\ids$ as the application of $\useexpr$ to $\veone$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getfields}:
+  \item \AllApplyCase{e\_getfields}
   \begin{itemize}
     \item $\ve$ is the multiple field access expression over expression $\veone$;
     \item define $\ids$ as the application of $\useexpr$ to $\veone$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_record}:
+  \item \AllApplyCase{e\_record}
   \begin{itemize}
     \item $\ve$ is the record construction expression of type $\tty$ and field initializations $\vli$;
     \item define $\ids$ as the union of applying of $\usety$ to $\tty$ and applying $\usety$ to each field type in $\vli$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_tuple}:
+  \item \AllApplyCase{e\_tuple}
   \begin{itemize}
     \item $\ve$ is the tuple construction expression for the expressions $\ves$;
     \item define $\ids$ as the union of applying of $\useexpr$ to each expression in $\ves$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_array}:
+  \item \AllApplyCase{e\_array}
   \begin{itemize}
     \item $\ve$ is the array construction expression for the length expression $\veone$ and value expression $\vetwo$,
           that is, $\EArray\{\EArrayLength:\veone, \EArrayValue:\vetwo\}$;
     \item define $\ids$ as the union of applying of $\useexpr$ to each of $\veone$ and $\vetwo$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_enumarray}:
+  \item \AllApplyCase{e\_enumarray}
   \begin{itemize}
     \item $\ve$ is the array construction expression for the array with enumeration-typed index for the list of labels
           $\vlabels$ and value expression $\vvalue$,
@@ -1026,13 +1026,13 @@ One of the following applies:
     \item define $\ids$ as the union of labels listed in $\vlabels$ and the result of applying $\useexpr$ to $\vvalue$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_arbitrary}:
+  \item \AllApplyCase{e\_arbitrary}
   \begin{itemize}
     \item $\ve$ is the arbitrary expression with type $\vt$;
     \item define $\ids$ as the application of $\usety$ to $\vt$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_pattern}:
+  \item \AllApplyCase{e\_pattern}
   \begin{itemize}
     \item $\ve$ is the pattern testing expression for subexpression $\veone$ and pattern $\vp$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\veone$ and applying $\usepattern$ to $\vp$.
@@ -1169,53 +1169,53 @@ The function
 returns the set of identifiers $\ids$ which the left-hand-side expression $\vle$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{le\_var}:
+  \item \AllApplyCase{le\_var}
   \begin{itemize}
     \item $\vle$ is a left-hand-side variable expression for $\vx$;
     \item define $\ids$ as the singleton set for $\vx$.
   \end{itemize}
 
-  \item \AllApplyCase{le\_destructuring}:
+  \item \AllApplyCase{le\_destructuring}
   \begin{itemize}
     \item $\vle$ is a left-hand-side expression for assigning to a list of expressions $\vles$,
           that is $\LEDestructuring(\vles)$;
     \item define $\ids$ as the union of applying $\uselexpr$ to each expression in $\vles$.
   \end{itemize}
 
-  \item \AllApplyCase{le\_discard}:
+  \item \AllApplyCase{le\_discard}
   \begin{itemize}
     \item $\vle$ is a left-hand-side discard expression;
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{le\_setarray}:
+  \item \AllApplyCase{le\_setarray}
   \begin{itemize}
     \item $\vle$ is a left-hand-side array update of the array given by the expression $\veone$ and index expression $\vetwo$;
     \item define $\ids$ as the union of applying $\uselexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item \AllApplyCase{le\_setenumarray}:
+  \item \AllApplyCase{le\_setenumarray}
   \begin{itemize}
     \item $\vle$ is a left-hand-side array update of the array given by the expression $\veone$ and
           the enumeration-typed index expression $\vetwo$;
     \item define $\ids$ as the union of applying $\uselexpr$ to $\veone$ and applying $\useexpr$ to $\vetwo$.
   \end{itemize}
 
-  \item \AllApplyCase{le\_setfield}:
+  \item \AllApplyCase{le\_setfield}
   \begin{itemize}
     \item $\vle$ is a left-hand-side field update of the record given by the expression $\veone$;
     \item define $\ids$ as the application of $\uselexpr$ to $\veone$.
   \end{itemize}
 
-  \item \AllApplyCase{le\_setfields}:
+  \item \AllApplyCase{le\_setfields}
   \begin{itemize}
     \item $\vle$ is a left-hand-side multiple field updates of the record given by the expression $\veone$;
     \item define $\ids$ as the application of $\uselexpr$ to $\veone$.
   \end{itemize}
 
-  \item \AllApplyCase{le\_slice}:
+  \item \AllApplyCase{le\_slice}
   \begin{itemize}
     \item $\vle$ is a left-hand-side slicing of the expression $\veone$ by slices $\slices$;
     \item define $\ids$ as the union of applying $\uselexpr$ to $\veone$ and applying $\useslice$ to each slice in $\slices$.
@@ -1276,51 +1276,51 @@ The function
 returns the set of identifiers $\ids$ which the declaration $\vd$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{mask\_all}:
+  \item \AllApplyCase{mask\_all}
   \begin{itemize}
     \item $\vp$ is either a mask pattern ($\PatternMask$) or a match-all pattern ($\PatternAll$);
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{tuple}:
+  \item \AllApplyCase{tuple}
   \begin{itemize}
     \item $\vp$ is a tuple pattern list of patterns $\vli$;
     \item define $\ids$ as the union of the application of $\usepattern$ for each pattern in $\vli$.
   \end{itemize}
 
-  \item \AllApplyCase{any}:
+  \item \AllApplyCase{any}
   \begin{itemize}
     \item $\vp$ is a pattern for matching any of the patterns in the list of patterns $\vli$;
     \item define $\ids$ as the union of the application of $\usepattern$ for each pattern in $\vli$.
   \end{itemize}
 
-  \item \AllApplyCase{single}:
+  \item \AllApplyCase{single}
   \begin{itemize}
     \item $\vp$ is a pattern for matching the expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{geq}:
+  \item \AllApplyCase{geq}
   \begin{itemize}
     \item $\vp$ is a pattern for testing greater-or-equal with respect to the expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{leq}:
+  \item \AllApplyCase{leq}
   \begin{itemize}
     \item $\vp$ is a pattern for testing less-than-or-equal with respect to the expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{not}:
+  \item \AllApplyCase{not}
   \begin{itemize}
     \item $\vp$ is a pattern negating the pattern $\vpone$;
     \item define $\ids$ as the application of $\usepattern$ to $\vpone$.
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vp$ is a pattern for testing the range of expressions from $\veone$ to $\vetwo$;
     \item define $\ids$ as the union of the application of $\useexpr$ to both $\veone$ and $\vetwo$.
@@ -1387,15 +1387,15 @@ The function
 returns the set of identifiers $\ids$ which the slice $\vs$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{single}:
+  \item \AllApplyCase{single}
   \begin{itemize}
     \item $\vs$ is the slice at the position given by the expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{start\_length\_rang}:
+  \item \AllApplyCase{start\_length\_rang}
   \begin{itemize}
     \item $\vs$ is a slice given by the pair of expressions $\veone$ and $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to both $\veone$ and $\vetwo$.
@@ -1424,22 +1424,22 @@ The function
 returns the set of identifiers $\ids$ which the bitfield $\vbf$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{simple}:
+  \item \AllApplyCase{simple}
   \begin{itemize}
     \item $\vbf$ is the single field with slices $\slices$;
     \item define $\ids$ as the union of applying $\useslice$ to each slice in $\slices$.
   \end{itemize}
 
-  \item \AllApplyCase{nested}:
+  \item \AllApplyCase{nested}
   \begin{itemize}
     \item $\vbf$ is the nested bitfield with slices $\slices$ and bitfields $\bitfields$;
     \item define $\ids$ as the union of applying $\useslice$ to each slice in $\slices$ and applying
           $\usebitfield$ to each bitfield in $\bitfields$.
   \end{itemize}
 
-  \item \AllApplyCase{type}:
+  \item \AllApplyCase{type}
   \begin{itemize}
     \item $\vbf$ is the typed bitfield with slices $\slices$ and type $\tty$;
     \item define $\ids$ as the union of applying $\useslice$ to each slice in $\slices$ and applying
@@ -1475,15 +1475,15 @@ The function
 returns the set of identifiers $\ids$ which the integer constraint $\vc$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact}:
+  \item \AllApplyCase{exact}
   \begin{itemize}
     \item $\vc$ is the single-value expression constraint with expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vc$ is the range constraint with expressions $\veone$ and $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to both $\veone$ and $\vetwo$.
@@ -1510,34 +1510,34 @@ The function
 returns the set of identifiers $\ids$ which the statement $\vs$ depends on.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{pass\_return\_none\_throw\_none}:
+  \item \AllApplyCase{pass\_return\_none\_throw\_none}
   \begin{itemize}
     \item $\vs$ is either a pass statement $\SPass$, a return-nothing statement $\SReturn(\None)$,
           or a throw-nothing statement ($\SThrow(\None)$);
     \item define $\ids$ as the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{s\_seq}:
+  \item \AllApplyCase{s\_seq}
   \begin{itemize}
     \item $\vs$ is a sequencing statement for $\vsone$ and $\vstwo$;
     \item define $\ids$ as the union of applying $\usestmt$ to both $\vsone$ and $\vstwo$.
   \end{itemize}
 
-  \item \AllApplyCase{assert\_return\_some}:
+  \item \AllApplyCase{assert\_return\_some}
   \begin{itemize}
     \item $\vs$ is either an assertion with expression $\ve$ or a return statement with expression $\ve$;
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_assign}:
+  \item \AllApplyCase{s\_assign}
   \begin{itemize}
     \item $\vs$ is an assignment statement with left-hand-side $\vle$ and right-hand-side $\ve$;
     \item define $\ids$ as the union of applying $\uselexpr$ to $\vle$ and $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_call}:
+  \item \AllApplyCase{s\_call}
   \begin{itemize}
     \item $\vs$ is a call statement for the subprogram with name $\vx$, arguments $\vargs$, and list of
           pairs consisting of a parameter identifier and associated expression $\namedargs$;
@@ -1546,13 +1546,13 @@ One of the following applies:
           a parameter in $\namedargs$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_cond}:
+  \item \AllApplyCase{s\_cond}
   \begin{itemize}
     \item $\vs$ is the conditional statement with expression $\ve$ and statements $\vsone$ and $\vstwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\ve$ and $\usestmt$ to both of $\vsone$ and $\vstwo$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_for}:
+  \item \AllApplyCase{s\_for}
   \begin{itemize}
     \item $\vs$ is the for statement $\SFor\left\{\begin{array}{rcl}
       \Forindexname &:& \Ignore\\
@@ -1565,33 +1565,33 @@ One of the following applies:
     \item define $\ids$ as the union of applying $\useexpr$ to $\vlimit$, $\vstarte$, and $\vende$ and applying $\usestmt$ to $\vsone$.
   \end{itemize}
 
-  \item \AllApplyCase{while\_repeat}:
+  \item \AllApplyCase{while\_repeat}
   \begin{itemize}
     \item $\vs$ is either a while statement or repeat statement, each with expression $\ve$, body statement $\vsone$,
           and optional limit expression $\vlimit$;
     \item define $\ids$ as the union of applying $\useexpr$ to $\vlimit$ and to $\ve$, and applying $\usestmt$ to $\vsone$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_decl}:
+  \item \AllApplyCase{s\_decl}
   \begin{itemize}
     \item $\vs$ is a declaration statement with \optional{} type annotation $\vt$ and \optional\ initialization expression $\ve$;
     \item define $\ids$ as the union of applying $\usety$ to $\vt$ and $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_try}:
+  \item \AllApplyCase{s\_try}
   \begin{itemize}
     \item $\vs$ is a try statement with statement $\vsone$, catcher list $\catchers$, and otherwise statement $\vstwo$;
     \item define $\ids$ as the union of applying $\usestmt$ to both $\vsone$ and $\vstwo$ and $\usecatcher$ to
           every catcher in $\catchers$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_print}:
+  \item \AllApplyCase{s\_print}
   \begin{itemize}
     \item $\vs$ is a print statement with list of expressions $\vargs$;
     \item define $\ids$ as the union of applying $\useexpr$ to each expression in $\vargs$.
   \end{itemize}
 
-  \item \AllApplyCase{s\_unreachable}:
+  \item \AllApplyCase{s\_unreachable}
   \begin{itemize}
     \item $\vs$ is an \texttt{Unreachable()};
     \item define $\ids$ as the empty set.
@@ -1762,15 +1762,15 @@ filters $\decls$ in order to retain the declarations whose identifiers are membe
 yielding $\compdecls$
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\decls$ is the empty list;
     \item define $\compdecls$ as the empty list.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\decls$ is the list with \head\ $\vd$ and \tail\ $declsone$;
     \item define $\declstwo$ as the singleton list for $\vd$ if applying $\defdecl$ to $\vd$ yields an identifier
@@ -1812,9 +1812,9 @@ Otherwise, the result is a dynamic error.
 \AllApply
 \begin{itemize}
   \item \Prosebuildgenv{$\tenv$}{$\spec$}{$\env$}{$\vg$}\ProseOrError;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{normal}:
+    \item \AllApplyCase{normal}
     \begin{itemize}
       \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
       in $\env$ yields $\Normal([(\vv, \vgtwo)], \Ignore)$\ProseOrError;
@@ -1822,7 +1822,7 @@ Otherwise, the result is a dynamic error.
       \item the result of the entire evaluation is $(\vv, \vg)$.
     \end{itemize}
 
-    \item \AllApplyCase{throwing}:
+    \item \AllApplyCase{throwing}
     \begin{itemize}
       \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
       in $\env$ yields $\Throwing(\vvopt, \Ignore)$, which is an uncaught exception;

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -1395,7 +1395,7 @@ returns the set of identifiers $\ids$ which the slice $\vs$ depends on.
     \item define $\ids$ as the application of $\useexpr$ to $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{start\_length\_rang}
+  \item \AllApplyCase{start\_length\_range}
   \begin{itemize}
     \item $\vs$ is a slice given by the pair of expressions $\veone$ and $\vetwo$;
     \item define $\ids$ as the union of applying $\useexpr$ to both $\veone$ and $\vetwo$.
@@ -1408,7 +1408,7 @@ returns the set of identifiers $\ids$ which the slice $\vs$ depends on.
   \useslice(\overname{\SliceSingle(\ve)}{\vs}) \typearrow \overname{\useexpr(\ve)}{\ids}
 }
 \and
-\inferrule[star\_length\_range]{
+\inferrule[start\_length\_range]{
   L \in \{\SliceStar, \SliceLength, \SliceRange\}
 }{
   \useslice(\overname{L(\veone, \vetwo)}{\vs}) \typearrow \overname{\useexpr(\veone) \cup \useexpr(\vetwo)}{\ids}
@@ -1835,7 +1835,7 @@ Otherwise, the result is a dynamic error.
 \begin{mathpar}
 \inferrule[normal]{
   \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynError\\\\
-  \evalsubprogram{\env, \texttt{"main"}, \emptylist, \emptylist} \evalarrow \Normal([(\vv, \vgtwo)], \Ignore) \OrDynError\\\\
+  \evalsubprogram{\env, \vmain, \emptylist, \emptylist} \evalarrow \Normal([(\vv, \vgtwo)], \Ignore) \OrDynError\\\\
   \vg \eqdef \ordered{\vgone}{\aslpo}{\vgtwo}
 }{
   \evalspec(\tenv, \vspec) \evalarrow (\vv, \vg)
@@ -1845,7 +1845,7 @@ Otherwise, the result is a dynamic error.
 \begin{mathpar}
 \inferrule[throwing]{
   \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynError\\\\
-  \evalsubprogram{\env, \texttt{"main"}, \emptylist, \emptylist} \evalarrow \Throwing(\vvopt, \Ignore)
+  \evalsubprogram{\env, \vmain, \emptylist, \emptylist} \evalarrow \Throwing(\vvopt, \Ignore)
 }{
   \evalspec(\tenv, \vspec) \evalarrow \DynamicErrorVal{\UncaughtException}
 }

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -64,7 +64,7 @@ This order relies on the notion of \defusedependencyterm, which we formally defi
 \secref{Dependencies}.
 \secref{TopologicalOrdering} formally defines how to use the inferred \defusedependenciesterm\ to
 order the declarations such that false type errors are avoided.
-\lrmcomment{This relates to \identi{LWQQ}.}
+\identi{LWQQ}
 
 \TypingRuleDef{TypeCheckAST}
 \hypertarget{def-typecheckast}{}

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -607,13 +607,13 @@ if it defines any.
 \begin{itemize}
   \item \AllApplyCase{decl\_enum}
   \begin{itemize}
-    \item $\vd$ is a declaration of an enumeration type with labels $\vlabels$;
+    \item $\vd$ is a declaration of an \enumerationtypeterm{} with labels $\vlabels$;
     \item the result is $\vlabels$ as a set (rather than a list).
   \end{itemize}
 
   \item \AllApplyCase{other}
   \begin{itemize}
-    \item $\vd$ is not a declaration of an enumeration type;
+    \item $\vd$ is not a declaration of an \enumerationtypeterm{};
     \item define $\vlabels$ as the empty set.
   \end{itemize}
 \end{itemize}
@@ -760,7 +760,7 @@ returns the set of identifiers $\ids$ which the type or \optional\ type $\vt$ de
 
   \item \AllApplyCase{t\_tuple}
   \begin{itemize}
-    \item $\vt$ is the tuple type with list of types $\vli$;
+    \item $\vt$ is the \tupletypeterm{} with list of types $\vli$;
     \item define $\ids$ as the union of applying $\useconstraint$ to each constraint in $\vcs$.
   \end{itemize}
 
@@ -778,7 +778,7 @@ returns the set of identifiers $\ids$ which the type or \optional\ type $\vt$ de
 
   \item \AllApplyCase{array\_enum}
   \begin{itemize}
-    \item $\vt$ is an array expression with enumeration type $\vs$ and element type $\vtp$;
+    \item $\vt$ is an array expression with \enumerationtypeterm{} $\vs$ and element type $\vtp$;
     \item define $\ids$ as the union of the singleton set for $\vs$ and applying $\usety$ to $\vtp$.
   \end{itemize}
 

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -446,18 +446,18 @@ As given by applying the relevant rules to the desugared AST.
 \subsection{Typing}
 \TypingRuleDef{SDecl}
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\vs$ is a declaration with an initializing expression $\ve$,
           that is, $\SDecl(\ldk, \ldi, \tyopt, \langle\ve\rangle)$;
     \item annotating the right-hand-side expression $\ve$ in $\tenv$ yields $(\vte,\vep, \vsese)$\ProseOrTypeError;
     \item applying $\annotatelocaldecltypeannot$ to the environment $\tenv$, type annotation $\tyopt$, type $\vte$, local declaration keyword $\ldk$, expression $\vep$, and local declaration item $\ldi$ yields $(\tenvone, \tyoptp, \vsesldi)$\ProseOrTypeError;
     \item \Proseeqdef{$\vses$}{the union of $\vsese$ and $\vsesldi$};
-    \item One of the following applies:
+    \item \OneApplies
     \begin{itemize}
-      \item \AllApplyCase{constant}:
+      \item \AllApplyCase{constant}
       \begin{itemize}
         \item $\ldk$ indicates a local constant declaration, that is, $\LDKConstant$;
         \item checking that all \timeframesterm\ in $\vsese$ are before \timeframeconstant\ yields $\True$\ProseOrTypeError;
@@ -466,7 +466,7 @@ One of the following applies:
         \item $\news$ is a declaration with $\ldk$, $\ldi$, type annotation $\tyoptp$, and an expression $\vep$.
       \end{itemize}
 
-      \item \AllApplyCase{non\_constant}:
+      \item \AllApplyCase{non\_constant}
       \begin{itemize}
         \item $\ldk$ indicates that this is not a local constant declaration, that is, $\ldk\neq\LDKConstant$;
         \item $\news$ is a declaration with $\ldk$, $\ldi$, type annotation $\tyoptp$, and an expression $\vep$;
@@ -475,7 +475,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
   \item $\vs$ is a local declaration statement with a variable keyword and no initializing expression,
         that is, $\SDecl(\LDKVar, \ldi, \tyopt, \None)$ (local declarations of \texttt{let} variables and constants require
@@ -544,15 +544,15 @@ adds the literal $\vv$ with the local declaration item $\ldi$ as a constant to t
 yielding the modified static environment $\newtenv$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{var}:
+  \item \AllApplyCase{var}
   \begin{itemize}
     \item $\ldi$ corresponds to a variable declaration for $\vx$, that is, $\LDIVar(\vx)$;
     \item applying $\addlocalconstant$ to $\vx$ and $\vv$ in $\tenv$ yields $\newtenv$.
   \end{itemize}
 
-  \item \AllApplyCase{tuple}:
+  \item \AllApplyCase{tuple}
   \begin{itemize}
     \item $\ldi$ corresponds to a tuple declaration, that is, $\LDIVar(\Ignore)$;
     \item this case is not yet implemented.
@@ -605,9 +605,9 @@ It yields the modified static environment $\newtenv$, the annotated type annotat
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\tyopt$ is $\None$;
     \item $\newtenv$ is the result of $\annotatelocaldeclitem{\tenv, \vte, \ldk, \langle\vep\rangle, \ldi}$\ProseOrTypeError;
@@ -615,7 +615,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{the empty set}.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\tyopt$ is $\langle\vt\rangle$;
     \item determining the \structure{} of $\vte$ in $\tenv$ yields $\vtep$\ProseOrTypeError;
@@ -670,7 +670,7 @@ in the \CaseName{int} below.
 {\typingtests/TypingRule.InheritIntegerConstraints.unconstrained.bad.asl}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
   \item \AllApplyCase{int}
   \begin{itemize}
@@ -679,7 +679,7 @@ One of the following applies:
     \item \Proseeqdef{$\lhsp$}{$\rhs$}.
   \end{itemize}
 
-  \item \AllApplyCase{tuple}:
+  \item \AllApplyCase{tuple}
   \begin{itemize}
     \item $\lhs$ is a tuple of types $\vlhstys$;
     \item $\rhs$ is a tuple of types $\vrhstys$;
@@ -689,7 +689,7 @@ One of the following applies:
     \item \Proseeqdef{$\lhsp$}{$\TTuple(\vlhstysp)$}.
   \end{itemize}
 
-  \item \AllApplyCase{other}:
+  \item \AllApplyCase{other}
   \begin{itemize}
     \item $\lhs$ is not a \pendingconstrainedintegertype{}, or one of $\lhs$ and $\rhs$ is not a tuple type;
     \item \Proseeqdef{$\lhsp$}{$\lhs$}.
@@ -741,15 +741,15 @@ $\tenv$.
 If the answer if $\False$, the result is a type error.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{okay}:
+  \item \AllApplyCase{okay}
   \begin{itemize}
     \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\True$;
     \item the result is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\False$;
     \item the result is a type error indicating that an expression of type $\vs$ cannot
@@ -789,9 +789,9 @@ In \listingref{semantics-sdeclnone},
 \ASLListing{Evaluating a declaration without a given initial value}{semantics-sdeclnone}{\semanticstests/SemanticsRule.SDeclNone.asl}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\vs$ is a declaration with an initial value,
     $\SDecl(\Ignore, \ldi, \Ignore, \langle\ve\rangle)$;
@@ -801,7 +801,7 @@ One of the following applies:
     \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
   \end{itemize}
 
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\vs$ is a declaration without an initial value, $\SDecl(\Ignore, \ldi, \Ignore, \None)$;
     \item the result is a dynamic error.
@@ -1706,16 +1706,16 @@ evaluating \texttt{assert (42 == 3);} results in an \texttt{AssertionFailed} err
 \AllApply
 \begin{itemize}
   \item $\vs$ is an assertion statement, $\SAssert(\ve)$;
-  \item one of the following holds:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{okay}:
+    \item \AllApplyCase{okay}
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ is $\Normal((\vv, \newg), \newenv)$\ProseOrAbnormal;
       \item $\vv$ is a native Boolean value for $\True$;
       \item the resulting configuration is $\Continuing(\newg, \newenv)$.
     \end{itemize}
 
-    \item \AllApplyCase{error}:
+    \item \AllApplyCase{error}
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ is $\Normal((\vv, \newg), \newenv)$;
       \item $\vv$ is a native Boolean value for $\False$;
@@ -1723,6 +1723,7 @@ evaluating \texttt{assert (42 == 3);} results in an \texttt{AssertionFailed} err
     \end{itemize}
   \end{itemize}
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[okay]{
@@ -1849,16 +1850,16 @@ yielding a pair consisting of an expression $\vep$ and a \sideeffectsetterm\ $\v
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\ve$ is $\None$;
     \item $\vep$ is $\None$;
     \item \Proseeqdef{$\vses$}{the empty set}.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\ve$ is $\langle\vlimit\rangle$;
     \item applying $\annotatesymbolicconstrainedinteger$ to $\vlimit$ in $\tenv$ yields \\
@@ -1953,9 +1954,9 @@ and the specification terminates with exit code $0$.
 
 \CodeSubsection{\EvalLoopBegin}{\EvalLoopEnd}{../Interpreter.ml}
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-\item \AllApplyCase{exit}:
+\item \AllApplyCase{exit}
   \begin{itemize}
     \item evaluating $\econd$ in $\env$ is $\Normal(\condm, \newenv)$\ProseOrAbnormal;
     \item $\condm$ consists of a native Boolean for $\vb$ and an execution graph $\newg$;
@@ -1963,7 +1964,7 @@ One of the following applies:
     \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$
     and the loop is exited.
   \end{itemize}
-\item \AllApplyCase{continue}:
+\item \AllApplyCase{continue}
   \begin{itemize}
     \item evaluating $\econd$ in $\env$ is $\Normal(\condm, \envone)$;
     \item $\mcond$ consists of a native Boolean for $\vb$ and an execution graph $\vgone$;
@@ -2031,16 +2032,16 @@ guaranteed side-effect-free by the typechecker,
 see \TypingRuleRef{AnnotateLimitExpr}.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\velimitopt$ is $\None$;
     \item $\vvopt$ is $\None$;
     \item $\vg$ is the empty execution graph.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\velimitopt$ is the expression $\velimit$;
     \item evaluating the side-effect-free expression $\velimitopt$ in $denv$ yields the native integer for $\vv$ and
@@ -2076,21 +2077,21 @@ the optional integer value $\vvopt$.
 If the value is $0$, the result is a dynamic error.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\vvopt$ is $\None$;
     \item $\vvoptp$ is $\None$.
   \end{itemize}
 
-  \item \AllApplyCase{some\_ok}:
+  \item \AllApplyCase{some\_ok}
   \begin{itemize}
     \item $\vvopt$ is the positive integer $\vv$;
     \item $\vvoptp$ is $\langle\vv-1\rangle$.
   \end{itemize}
 
-  \item \AllApplyCase{some\_error}:
+  \item \AllApplyCase{some\_error}
   \begin{itemize}
     \item $\vvopt$ is the integer $0$;
     \item the result is a dynamic error indicating that a limit has been reached
@@ -2435,23 +2436,23 @@ The result is $\vis$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{not\_integers}:
+  \item \AllApplyCase{not\_integers}
   \begin{itemize}
     \item at least one of $\structone$ and $\structtwo$ is not an integer type;
     \item the result is a type error indicating that the start expression and end expression of \texttt{for} loops
           must have the \structure\ of integer types.
   \end{itemize}
 
-  \item \AllApplyCase{unconstrained}:
+  \item \AllApplyCase{unconstrained}
   \begin{itemize}
     \item both of $\structone$ and $\structtwo$ are integer types;
     \item at least one of $\structone$ and $\structtwo$ is the unconstrained integer type;
     \item define $\vis$ as $\unconstrained$.
   \end{itemize}
 
-  \item \AllApplyCase{well\_constrained}:
+  \item \AllApplyCase{well\_constrained}
   \begin{itemize}
     \item both of $\structone$ and $\structtwo$ are integer types;
     \item neither $\structone$ nor $\structtwo$ is the unconstrained integer type;
@@ -2690,16 +2691,16 @@ or an abnormal configuration.
   \item \Proseticklooplimit{$\vlimitopt$}{$\vnextlimitopt$}\ProseOrError;
   \item $\compfordir$ is either $\LT$ when $\dir$ is $\UP$ or $\GT$ when $\dir$ is $\DOWN$;
   \item reading $\vstart$ into the identifier $\vindexname$ gives $\vgone$;
-  \item One of the following applies:
+  \item \OneApplies
     \begin{itemize}
-    \item \AllApplyCase{return}:
+    \item \AllApplyCase{return}
     \begin{itemize}
       \item using $\compfordir$ to compare $\vend$ to $\vstart$ gives the native Boolean for $\True$;
       \item $\newg$ is $\vgone$;
       \item $\newenv$ is $\env$;
       \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
     \end{itemize}
-    \item \AllApplyCase{continue}:
+    \item \AllApplyCase{continue}
     \begin{itemize}
       \item using $\compfordir$ to compare $\vend$ to $\vstart$ gives the native Boolean for $\False$;
       \item evaluating the loop body via $\evalforloop$ with \\ $(\vindexname, \vlimitopt, \vstart, \dir, \vend, \vbody)$
@@ -2827,9 +2828,9 @@ $\evalforloop$ (the latter in a mutually recursive manner):
 \TypingRuleDef{SThrow}
 \newcommand\NoNameException[0]{\texttt{\_}}
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\vs$ is a throw statement with no expression, that is, $\SThrow(\None)$;
     \item $\news$ is $\vs$;
@@ -2837,7 +2838,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{the singleton set for $\ThrowException(\NoNameException)$}
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\vs$ is a throw statement with expression $\ve$, that is, $\SThrow(\langle\ve\rangle)$;
     \item annotating the right-hand-side expression $\ve$ in $\tenv$ yields $(\vte, \vep, \vsesone)$\ProseOrTypeError;
@@ -2889,9 +2890,9 @@ terminates successfully. That is, no dynamic error occurs.
 \ASLListing{Throwing an exception}{semantics-sthrowsometyped}{\semanticstests/SemanticsRule.SThrowSomeTyped.asl}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
   \item $\vs$ is a \texttt{throw} statement that does not provide an expression, $\SThrow(\None)$;
   \item $\newenv$ is $\env$;
@@ -2900,7 +2901,7 @@ One of the following applies:
   \item an exception is thrown with $\newenv$.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\vs$ is a \texttt{throw} statement that provides an expression and a type, \\
           $\SThrow(\langle(\ve, \vt)\rangle)$;
@@ -3009,9 +3010,9 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
         and $\vxs_i$\ProseOrTypeError;
   \item $\catchersp$ is the list of annotated catchers $\vc\_\vi$ for each $\vi\in\listrange(\catchers)$;
   \item \Proseeqdef{$\vsescatchers$}{the union of all $\vxs_\vi$, for \Proselistrange{$\vi$}{$\catchers$}};
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{no\_otherwise}:
+    \item \AllApplyCase{no\_otherwise}
     \begin{itemize}
       \item there is no \texttt{otherwise} statement;
       \item $\news$ is a try statement with statement $\vspp$, list catchers $\catchersp$ and no \texttt{otherwise} statement,
@@ -3021,7 +3022,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
       \item \Proseeqdef{$\vsesthree$}{$\vsestwo$}.
     \end{itemize}
 
-    \item \AllApplyCase{otherwise}:
+    \item \AllApplyCase{otherwise}
     \begin{itemize}
       \item there is an \texttt{otherwise} statement $\otherwise$;
       \item annotating the statement $\otherwise$ as a block statement in $\tenv$ yields $\otherwisep$\ProseOrTypeError;
@@ -3126,9 +3127,9 @@ does not result in any Assertion error, and the specification terminates with th
 \subsection{Typing}
 \TypingRuleDef{SReturn}
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement with an optional expression $\veopt$, that is, \\
           $\SReturn(\veopt)$;
@@ -3138,7 +3139,7 @@ One of the following applies:
           and the (existence of the) return expression.
   \end{itemize}
 
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement with no expression, that is, $\SReturn(\None)$;
     \item the enclosing subprogram does not have a \texttt{return} type (it is either a setter
@@ -3148,7 +3149,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{the empty set}.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement with an expression $\ve$, that is, $\SReturn(\langle \vep \rangle)$;
     \item the enclosing subprogram has a return type $\vt$;
@@ -3208,9 +3209,9 @@ In \listingref{semantics-sreturntuple},
 \ASLListing{Evaluating a \texttt{return} statement with a tuple of values}{semantics-sreturntuple}{\semanticstests/SemanticsRule.SReturnSome.asl}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement, $\SReturn(\None)$;
     \item $\vvs$ is the empty list, $\emptylist$;
@@ -3218,7 +3219,7 @@ One of the following applies:
     \item $\newenv$ is $\env$.
   \end{itemize}
 
-  \item \AllApplyCase{one}:
+  \item \AllApplyCase{one}
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement;
     \item $\vs$ is a \texttt{return} statement for a single expression, $\SReturn(\langle\ve\rangle)$;
@@ -3228,7 +3229,7 @@ One of the following applies:
     \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge.
   \end{itemize}
 
-  \item \AllApplyCase{tuple}:
+  \item \AllApplyCase{tuple}
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement for a list of expressions, $\SReturn(\langle\ETuple(\es)\rangle)$;
     \item evaluating each expression in $\es$ separately as per \secref{SemanticsRule.EExprListM}
@@ -3279,15 +3280,15 @@ and returns the list of values associated with graphs $\vms$ and the new environ
 If the evaluation of any expression terminates abnormally then the abnormal configuration is returned.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vEs$ is an empty list;
     \item $\vms$ is then empty list.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vEs$ is a list with \head\ $\ve$ and \tail\ $\vesone$;
     \item evaluating $\ve$ in $\env$ yields $\Normal(\vmone, \envone)$\ProseOrAbnormal;

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -518,7 +518,7 @@ As given by applying the relevant rules to the desugared AST.
   \annotatestmt(\tenv, \overname{\SDecl(\ldk, \ldi, \tyopt, \langle\ve\rangle)}{\vs}) \typearrow (\news, \overname{\tenvone}{\newtenv}, \vses)
 }
 \end{mathpar}
-\lrmcomment{This is related to \identr{YSPM}.}
+\identr{YSPM}
 
 \begin{mathpar}
 \inferrule[none]{
@@ -774,7 +774,7 @@ If the answer if $\False$, the result is a type error.
   \checkcanbeinitializedwith(\tenv, \vs, \vt) \typearrow \TypeErrorVal{\TypeSatisfactionFailure}
 }
 \end{mathpar}
-\lrmcomment{This is related to \identr{ZCVD} and \identr{LXQZ}.}
+\identr{ZCVD}  \identr{LXQZ}
 
 
 \subsection{Semantics}
@@ -1152,7 +1152,7 @@ evaluates \texttt{let y = x + 1}.
 }
 \end{mathpar}
 \CodeSubsection{\SCallBegin}{\SCallEnd}{../Typing.ml}
-\lrmcomment{This is related to \identd{VXKM}.}
+\identd{VXKM}
 
 \subsection{Semantics}
 \SemanticsRuleDef{SCall}
@@ -1179,7 +1179,7 @@ In \listingref{semantics-scall},
 }
 \end{mathpar}
 \CodeSubsection{\EvalSCallBegin}{\EvalSCallEnd}{../Interpreter.ml}
-% \lrmcomment{This is related to \identd{KCYT}:}
+\identd{KCYT}
 
 \hypertarget{def-conditionalstatementterm}{}
 \section{Conditional Statements\label{sec:ConditionalStatements}}
@@ -1268,7 +1268,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 \CodeSubsection{\SCondBegin}{\SCondEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{NBDJ}.}
+\identr{NBDJ}
 
 \subsection{Semantics}
 \SemanticsRuleDef{SCond}
@@ -1622,7 +1622,7 @@ a list of \texttt{case} alternatives already converted to conditionals, into a c
 \subsection{Typing}
 Since case statements are transformed into other statements,
 they do not require type system rules.
-\lrmcomment{This is related to \identr{WGSY}.}
+\identr{WGSY}
 
 \subsection{Semantics}
 Since case statements are transformed into other statements,
@@ -1689,7 +1689,7 @@ The first call to \verb|checked_8bit_add| succeeds, whereas the second call fail
 }
 \end{mathpar}
 \CodeSubsection{\SAssertBegin}{\SAssertEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{JQYF}.}
+\identr{JQYF}
 
 \subsection{Semantics}
 \SemanticsRuleDef{SAssert}
@@ -1744,7 +1744,7 @@ evaluating \texttt{assert (42 == 3);} results in an \texttt{AssertionFailed} err
 }
 \end{mathpar}
 \CodeSubsection{\EvalSAssertBegin}{\EvalSAssertEnd}{../Interpreter.ml}
-\lrmcomment{This is related to \identd{QJYV}, \identr{WZSL}, \identr{WQRN}.}
+\identd{QJYV} \identr{WZSL} \identr{WQRN}
 
 \hypertarget{def-whilestatementterm}{}
 \section{While Statements\label{sec:WhileStatements}}
@@ -1834,7 +1834,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 \CodeSubsection{\SWhileBegin}{\SWhileEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{FTVN}.}
+\identr{FTVN}
 
 \TypingRuleDef{AnnotateLimitExpr}
 \hypertarget{def-annotatelimitexpr}{}
@@ -2182,7 +2182,7 @@ If the value is $0$, the result is a dynamic error.
 }
 \end{mathpar}
 \CodeSubsection{\SRepeatBegin}{\SRepeatEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{FTVN}.}
+\identr{FTVN}
 
 \subsection{Semantics}
 \SemanticsRuleDef{SRepeat}
@@ -2409,7 +2409,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 \CodeSubsection{\SForBegin}{\SForEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{SSBD}, \identr{ZSND}, \identr{VTJW}.}
+\identr{SSBD} \identr{ZSND} \identr{VTJW}
 
 \TypingRuleDef{SForConstraints}
 \hypertarget{def-getforconstraints}{}
@@ -2872,7 +2872,7 @@ $\evalforloop$ (the latter in a mutually recursive manner):
   (\overname{\SThrow(\langle (\vep, \vte) \rangle)}{\news}, \overname{\tenv}{\newtenv}, \vses)
 }
 \end{mathpar}
-\lrmcomment{This is related to \identr{NXRC}.}
+\identr{NXRC}
 \CodeSubsection{\SThrowBegin}{\SThrowEnd}{../Typing.ml}
 
 \subsection{Semantics}
@@ -3073,7 +3073,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }
 \end{mathpar}
 \CodeSubsection{\STryBegin}{\STryEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{WVXS}.}
+\identr{WVXS}
 
 \subsection{Semantics}
 \SemanticsRuleDef{STry}
@@ -3190,7 +3190,7 @@ does not result in any Assertion error, and the specification terminates with th
 }
 \end{mathpar}
 \CodeSubsection{\SReturn}{\SReturnEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{FTPK}.}
+\identr{FTPK}
 
 \subsection{Semantics}
 \SemanticsRuleDef{SReturn}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -90,7 +90,7 @@ We now define the syntax, abstract syntax, typing, and semantics for the followi
 \subsection{Typing}
 \TypingRuleDef{SPass}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a pass statement, that is, $\SPass$;
   \item $\news$ is $\vs$;
@@ -110,7 +110,7 @@ In \listingref{semantics-spass}, \texttt{pass;} does nothing.:
 \ASLListing{Evaluating a \texttt{pass} statement}{semantics-spass}{\semanticstests/SemanticsRule.SPass.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\vs$ is a \passstatementterm, $\SPass$;
 \item $\newg$ is the empty graph;
@@ -149,7 +149,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{SAssign}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is an assignment \texttt{le = re}, that is, $\SAssign(\vle, \vre)$;
   \item annotating the right-hand-side expression $\vre$ in $\tenv$ yields $(\vtre, \vreone, \vsesre)$\ProseOrTypeError;
@@ -180,7 +180,7 @@ $\nvint(42)$, and $\newenv$ is such that \texttt{x} is bound to $\nvint(3)$.
 \ASLListing{Evaluating an assignment}{semantics-sassign}{\semanticstests/SemanticsRule.SAssign.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is an assignment statement, $\SAssign(\vle, \vre)$;
   \item $\vre$ is not a call expression;
@@ -225,7 +225,7 @@ and the value $\nvint(2)$ to the mutable variable~\texttt{b}, and discards $\nvi
 \ASLListing{Assignment from a call expression.}{assigncallsemantics}{\semanticstests/SemanticsRule.SAssignCall.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ assigns an \assignableexpression\ list from a subprogram call, \\
         $\SAssign(\LEDestructuring(\les),\ECall(\vcall))$;
@@ -448,7 +448,7 @@ As given by applying the relevant rules to the desugared AST.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\vs$ is a declaration with an initializing expression $\ve$,
           that is, $\SDecl(\ldk, \ldi, \tyopt, \langle\ve\rangle)$;
@@ -457,7 +457,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{the union of $\vsese$ and $\vsesldi$};
     \item One of the following applies:
     \begin{itemize}
-      \item All of the following apply (\textsc{constant}):
+      \item \AllApplyCase{constant}:
       \begin{itemize}
         \item $\ldk$ indicates a local constant declaration, that is, $\LDKConstant$;
         \item checking that all \timeframesterm\ in $\vsese$ are before \timeframeconstant\ yields $\True$\ProseOrTypeError;
@@ -466,7 +466,7 @@ One of the following applies:
         \item $\news$ is a declaration with $\ldk$, $\ldi$, type annotation $\tyoptp$, and an expression $\vep$.
       \end{itemize}
 
-      \item All of the following apply (\textsc{non\_constant}):
+      \item \AllApplyCase{non\_constant}:
       \begin{itemize}
         \item $\ldk$ indicates that this is not a local constant declaration, that is, $\ldk\neq\LDKConstant$;
         \item $\news$ is a declaration with $\ldk$, $\ldi$, type annotation $\tyoptp$, and an expression $\vep$;
@@ -475,7 +475,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
   \item $\vs$ is a local declaration statement with a variable keyword and no initializing expression,
         that is, $\SDecl(\LDKVar, \ldi, \tyopt, \None)$ (local declarations of \texttt{let} variables and constants require
@@ -546,13 +546,13 @@ yielding the modified static environment $\newtenv$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{var}):
+  \item \AllApplyCase{var}:
   \begin{itemize}
     \item $\ldi$ corresponds to a variable declaration for $\vx$, that is, $\LDIVar(\vx)$;
     \item applying $\addlocalconstant$ to $\vx$ and $\vv$ in $\tenv$ yields $\newtenv$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tuple}):
+  \item \AllApplyCase{tuple}:
   \begin{itemize}
     \item $\ldi$ corresponds to a tuple declaration, that is, $\LDIVar(\Ignore)$;
     \item this case is not yet implemented.
@@ -607,7 +607,7 @@ It yields the modified static environment $\newtenv$, the annotated type annotat
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\tyopt$ is $\None$;
     \item $\newtenv$ is the result of $\annotatelocaldeclitem{\tenv, \vte, \ldk, \langle\vep\rangle, \ldi}$\ProseOrTypeError;
@@ -615,7 +615,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{the empty set}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\tyopt$ is $\langle\vt\rangle$;
     \item determining the \structure{} of $\vte$ in $\tenv$ yields $\vtep$\ProseOrTypeError;
@@ -679,7 +679,7 @@ One of the following applies:
     \item \Proseeqdef{$\lhsp$}{$\rhs$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tuple}):
+  \item \AllApplyCase{tuple}:
   \begin{itemize}
     \item $\lhs$ is a tuple of types $\vlhstys$;
     \item $\rhs$ is a tuple of types $\vrhstys$;
@@ -689,7 +689,7 @@ One of the following applies:
     \item \Proseeqdef{$\lhsp$}{$\TTuple(\vlhstysp)$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{other}):
+  \item \AllApplyCase{other}:
   \begin{itemize}
     \item $\lhs$ is not a \pendingconstrainedintegertype{}, or one of $\lhs$ and $\rhs$ is not a tuple type;
     \item \Proseeqdef{$\lhsp$}{$\lhs$}.
@@ -743,13 +743,13 @@ If the answer if $\False$, the result is a type error.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{okay}):
+  \item \AllApplyCase{okay}:
   \begin{itemize}
     \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\True$;
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item testing whether $\vt$ \typesatisfies\ $\vs$ in $\tenv$ yields $\False$;
     \item the result is a type error indicating that an expression of type $\vs$ cannot
@@ -791,7 +791,7 @@ In \listingref{semantics-sdeclnone},
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\vs$ is a declaration with an initial value,
     $\SDecl(\Ignore, \ldi, \Ignore, \langle\ve\rangle)$;
@@ -801,7 +801,7 @@ One of the following applies:
     \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\vs$ is a declaration without an initial value, $\SDecl(\Ignore, \ldi, \Ignore, \None)$;
     \item the result is a dynamic error.
@@ -1041,7 +1041,7 @@ instances of $\SPass$.
 \subsection{Typing}
 \TypingRuleDef{SSeq}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is the AST node for the sequence of statements $\vsone$ and $\vstwo$, that is, $\SSeq(\vsone, \vstwo)$;
   \item annotating $\vsone$ in $\tenv$ yields $(\newsone, \tenvone, \vsesone)$\ProseOrTypeError;
@@ -1070,7 +1070,7 @@ evaluates \texttt{let y = x + 1}.
 \ASLListing{Evaluating a sequence of statements}{semantics-sseq}{\semanticstests/SemanticsRule.SSeq.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a \emph{sequencing statement} \texttt{s1; s2}, that is, $\SSeq(\vsone, \vstwo)$;
   \item evaluating $\vsone$ in $\env$ is either $\Continuing(\vgone, \envone)$ in which case
@@ -1124,7 +1124,7 @@ All of the following apply:
 \subsection{Typing}
 \TypingRuleDef{SCall}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a call to a subprogram, that is, $\SCall(\vcall)$;
   \item annotating the subprogram call $\vcall$ as per \chapref{SubprogramCalls}
@@ -1161,7 +1161,7 @@ In \listingref{semantics-scall},
 \ASLListing{Evaluating a call statement}{semantics-scall}{\semanticstests/SemanticsRule.SCall.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a call statement, $\SCall(\vcall)$;
   \item evaluating the subprogram call as per \chapref{SubprogramCalls} is
@@ -1242,7 +1242,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \subsection{Typing}
 \TypingRuleDef{SCond}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a condition $\ve$ with the statements $\vsone$ and $\vstwo$, that is, $\SCond(\ve, \vsone, \vstwo)$;
   \item annotating the right-hand-side expression $\ve$ in $\tenv$ yields $(\tcond, \econd, \vsescond)$\ProseOrTypeError;
@@ -1287,7 +1287,7 @@ The specification in \listingref{semantics-scond4} does not result in any error.
 \ASLListing{Evaluating a condition statement with only a \texttt{then} branch}{semantics-scond4}{\semanticstests/SemanticsRule.SCond4.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\vs$ is a condition statement, $\SCond(\ve, \vsone, \vstwo)$;
 \item evaluating $\ve$ in $\env$ is $\Normal(\vv, \vgone)$\ProseOrAbnormal;
@@ -1666,7 +1666,7 @@ The first call to \verb|checked_8bit_add| succeeds, whereas the second call fail
 \subsection{Typing}
 \TypingRuleDef{SAssert}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is an assert statement with expression $\ve$, that is, $\SAssert(\ve)$;
   \item annotating the right-hand-side expression $\ve$ in $\tenv$ yields $(\tep,\vep, \vsese)$\ProseOrTypeError;
@@ -1703,19 +1703,19 @@ evaluating \texttt{assert (42 == 3);} results in an \texttt{AssertionFailed} err
 \ASLListing{Evaluating an assertion that fails}{semantics-sassertno}{\semanticstests/SemanticsRule.SAssertNo.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is an assertion statement, $\SAssert(\ve)$;
   \item one of the following holds:
   \begin{itemize}
-    \item all of the following hold (\textsc{okay}):
+    \item \AllApplyCase{okay}:
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ is $\Normal((\vv, \newg), \newenv)$\ProseOrAbnormal;
       \item $\vv$ is a native Boolean value for $\True$;
       \item the resulting configuration is $\Continuing(\newg, \newenv)$.
     \end{itemize}
 
-    \item all of the following hold (\textsc{error}):
+    \item \AllApplyCase{error}:
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ is $\Normal((\vv, \newg), \newenv)$;
       \item $\vv$ is a native Boolean value for $\False$;
@@ -1804,7 +1804,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \subsection{Typing}
 \TypingRuleDef{SWhile}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
 \item $\vs$ is a \texttt{while} statement with expression $\veone$, optional limit expression $\vlimitone$,
       and statement block $\vsone$, that is, $\SWhile(\veone, \vsone)$;
@@ -1851,14 +1851,14 @@ yielding a pair consisting of an expression $\vep$ and a \sideeffectsetterm\ $\v
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\ve$ is $\None$;
     \item $\vep$ is $\None$;
     \item \Proseeqdef{$\vses$}{the empty set}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\ve$ is $\langle\vlimit\rangle$;
     \item applying $\annotatesymbolicconstrainedinteger$ to $\vlimit$ in $\tenv$ yields \\
@@ -1889,8 +1889,9 @@ The specification in \listingref{semantics-swhile} prints \texttt{0123}.
 \ASLListing{Evaluating a \texttt{while} loop}{semantics-swhile}{\semanticstests/SemanticsRule.SWhile.asl}
 
 \ProseParagraph
-Evaluation of the statement $\vs$ in an environment $\env$ is
-the output configuration $C$ and all of the following apply:
+Evaluation of the statement $\vs$ in an environment $\env$ yields
+the output configuration $C$.
+\AllApply
 \begin{itemize}
   \item $\vs$ is a \texttt{while} statement, $\SWhile(\ve, \velimitopt, \vbody)$;
   \item evaluating the optional limit expression $\velimitopt$ via $\evallimit$ in $\env$
@@ -1954,7 +1955,7 @@ and the specification terminates with exit code $0$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-\item all of the following apply (\textsc{exit}):
+\item \AllApplyCase{exit}:
   \begin{itemize}
     \item evaluating $\econd$ in $\env$ is $\Normal(\condm, \newenv)$\ProseOrAbnormal;
     \item $\condm$ consists of a native Boolean for $\vb$ and an execution graph $\newg$;
@@ -1962,7 +1963,7 @@ One of the following applies:
     \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$
     and the loop is exited.
   \end{itemize}
-\item all of the following apply (\textsc{continue}):
+\item \AllApplyCase{continue}:
   \begin{itemize}
     \item evaluating $\econd$ in $\env$ is $\Normal(\condm, \envone)$;
     \item $\mcond$ consists of a native Boolean for $\vb$ and an execution graph $\vgone$;
@@ -2032,14 +2033,14 @@ see \TypingRuleRef{AnnotateLimitExpr}.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\velimitopt$ is $\None$;
     \item $\vvopt$ is $\None$;
     \item $\vg$ is the empty execution graph.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\velimitopt$ is the expression $\velimit$;
     \item evaluating the side-effect-free expression $\velimitopt$ in $denv$ yields the native integer for $\vv$ and
@@ -2077,19 +2078,19 @@ If the value is $0$, the result is a dynamic error.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\vvopt$ is $\None$;
     \item $\vvoptp$ is $\None$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some\_ok}):
+  \item \AllApplyCase{some\_ok}:
   \begin{itemize}
     \item $\vvopt$ is the positive integer $\vv$;
     \item $\vvoptp$ is $\langle\vv-1\rangle$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some\_error}):
+  \item \AllApplyCase{some\_error}:
   \begin{itemize}
     \item $\vvopt$ is the integer $0$;
     \item the result is a dynamic error indicating that a limit has been reached
@@ -2152,7 +2153,7 @@ One of the following applies:
 \subsection{Typing}
 \TypingRuleDef{SRepeat}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a \texttt{repeat} statement with statement block $\vsone$,
         optional limit expression $\vlimitone$, and expression $\veone$, that is, $\SRepeat(\vsone, \veone, \vlimitone)$;
@@ -2196,8 +2197,10 @@ The specification in \listingref{semantics-srepeat} is followed by its output to
 % CONSOLE_END
 
 \ProseParagraph
-Evaluation of the statement $\vs$ in an environment $\env$ is
-either \\ $\Returning((\vvs, \newg), \newenv)$ or an output configuration $D$ and all of the following apply:
+Evaluation of the statement $\vs$ in an environment $\env$ yields
+either \\ $\Returning((\vvs, \newg), \newenv)$ or an output configuration $D$.
+
+\AllApply
 \begin{itemize}
   \item $\vs$ is a \texttt{repeat} statement, $\SRepeat(\ve, \vbody, \velimitopt)$;
   \item evaluating the optional limit expression $\velimitopt$ via $\evallimit$ in $\env$
@@ -2311,7 +2314,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \subsection{Typing}
 \TypingRuleDef{SFor}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a \texttt{for} statement with index $\vindexname$,
         start expression $\vstarte$,
@@ -2434,21 +2437,21 @@ The result is $\vis$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{not\_integers}):
+  \item \AllApplyCase{not\_integers}:
   \begin{itemize}
     \item at least one of $\structone$ and $\structtwo$ is not an integer type;
     \item the result is a type error indicating that the start expression and end expression of \texttt{for} loops
           must have the \structure\ of integer types.
   \end{itemize}
 
-  \item All of the following apply (\textsc{unconstrained}):
+  \item \AllApplyCase{unconstrained}:
   \begin{itemize}
     \item both of $\structone$ and $\structtwo$ are integer types;
     \item at least one of $\structone$ and $\structtwo$ is the unconstrained integer type;
     \item define $\vis$ as $\unconstrained$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{well\_constrained}):
+  \item \AllApplyCase{well\_constrained}:
   \begin{itemize}
     \item both of $\structone$ and $\structtwo$ are integer types;
     \item neither $\structone$ nor $\structtwo$ is the unconstrained integer type;
@@ -2512,7 +2515,7 @@ The specification in \listingref{semantics-sfor} is followed by its output to th
 % CONSOLE_END
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a \texttt{for} statement, $\SFor\left\{\begin{array}{rcl}
     \Forindexname &:& \vindexname\\
@@ -2647,7 +2650,7 @@ iterations.
 
 \ProseParagraph
 \subsubsection{Stepping the Index Variable}
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\opfordir$ is either $\PLUS$ when $\dir$ is $\UP$ or $\MINUS$ when $\dir$ is $\DOWN$;
   \item reading $\vstart$ into the identifier $\vindexname$ gives $\vgone$;
@@ -2659,7 +2662,7 @@ All of the following apply:
 \end{itemize}
 
 \subsubsection{Running the Loop Body}
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item evaluating $\vbody$ as a block statement (see \SemanticsRuleRef{Block}) in $\env$
         yields \\ $\Continuing(\vgone, \envone)$\ProseTerminateAs{\ReturningConfig, \ThrowingConfig, \DynErrorConfig};
@@ -2677,25 +2680,26 @@ All of the following apply:
 The specification in \listingref{semantics-sfor}
 does not result in any assertion error, and terminates with exit-code $0$.
 
-Evaluating $(\vindexname, \vstart, \dir, \vend, \vbody)$ in $\env$ is either
-a continuing configuration $\Continuing(\newg, \newenv)$ or a returning configuration
-(in case the body of the loop results in an early return)
-or an abnormal configuration,
-and All of the following apply:
+Evaluating $(\vindexname, \vstart, \dir, \vend, \vbody)$ in $\env$ yields either
+a continuing configuration $\Continuing(\newg, \newenv)$, or a returning configuration
+(in case the body of the loop results in an early return),
+or an abnormal configuration.
+
+\AllApply
 \begin{itemize}
   \item \Proseticklooplimit{$\vlimitopt$}{$\vnextlimitopt$}\ProseOrError;
   \item $\compfordir$ is either $\LT$ when $\dir$ is $\UP$ or $\GT$ when $\dir$ is $\DOWN$;
   \item reading $\vstart$ into the identifier $\vindexname$ gives $\vgone$;
   \item One of the following applies:
     \begin{itemize}
-    \item All of the following apply (\textsc{return}):
+    \item \AllApplyCase{return}:
     \begin{itemize}
       \item using $\compfordir$ to compare $\vend$ to $\vstart$ gives the native Boolean for $\True$;
       \item $\newg$ is $\vgone$;
       \item $\newenv$ is $\env$;
       \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
     \end{itemize}
-    \item All of the following apply (\textsc{continue}):
+    \item \AllApplyCase{continue}:
     \begin{itemize}
       \item using $\compfordir$ to compare $\vend$ to $\vstart$ gives the native Boolean for $\False$;
       \item evaluating the loop body via $\evalforloop$ with \\ $(\vindexname, \vlimitopt, \vstart, \dir, \vend, \vbody)$
@@ -2825,7 +2829,7 @@ $\evalforloop$ (the latter in a mutually recursive manner):
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\vs$ is a throw statement with no expression, that is, $\SThrow(\None)$;
     \item $\news$ is $\vs$;
@@ -2833,7 +2837,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{the singleton set for $\ThrowException(\NoNameException)$}
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\vs$ is a throw statement with expression $\ve$, that is, $\SThrow(\langle\ve\rangle)$;
     \item annotating the right-hand-side expression $\ve$ in $\tenv$ yields $(\vte, \vep, \vsesone)$\ProseOrTypeError;
@@ -2887,7 +2891,7 @@ terminates successfully. That is, no dynamic error occurs.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
   \item $\vs$ is a \texttt{throw} statement that does not provide an expression, $\SThrow(\None)$;
   \item $\newenv$ is $\env$;
@@ -2896,7 +2900,7 @@ One of the following applies:
   \item an exception is thrown with $\newenv$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\vs$ is a \texttt{throw} statement that provides an expression and a type, \\
           $\SThrow(\langle(\ve, \vt)\rangle)$;
@@ -2997,7 +3001,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \subsection{Typing}
 \TypingRuleDef{STry}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a try statement with statement $\vsp$, list of catchers $\catchers$ and an \optional\ \texttt{otherwise} block;
   \item annotating the statement $\vsp$ as a block statement yields $(\vspp, \vsesone)$\ProseOrTypeError;
@@ -3007,7 +3011,7 @@ All of the following apply:
   \item \Proseeqdef{$\vsescatchers$}{the union of all $\vxs_\vi$, for \Proselistrange{$\vi$}{$\catchers$}};
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{no\_otherwise}):
+    \item \AllApplyCase{no\_otherwise}:
     \begin{itemize}
       \item there is no \texttt{otherwise} statement;
       \item $\news$ is a try statement with statement $\vspp$, list catchers $\catchersp$ and no \texttt{otherwise} statement,
@@ -3017,7 +3021,7 @@ All of the following apply:
       \item \Proseeqdef{$\vsesthree$}{$\vsestwo$}.
     \end{itemize}
 
-    \item All of the following apply (\textsc{otherwise}):
+    \item \AllApplyCase{otherwise}:
     \begin{itemize}
       \item there is an \texttt{otherwise} statement $\otherwise$;
       \item annotating the statement $\otherwise$ as a block statement in $\tenv$ yields $\otherwisep$\ProseOrTypeError;
@@ -3077,7 +3081,7 @@ does not result in any Assertion error, and the specification terminates with th
 \ASLListing{Evaluating a \texttt{try} statement}{semantics-stry}{\semanticstests/SemanticsRule.STry.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a \texttt{try} statement, $\STry(\vs, \catchers, \otherwiseopt)$;
   \item evaluating $\vsone$ in $\env$ as per \chapref{BlockStatements}
@@ -3124,7 +3128,7 @@ All of the following apply:
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement with an optional expression $\veopt$, that is, \\
           $\SReturn(\veopt)$;
@@ -3134,7 +3138,7 @@ One of the following applies:
           and the (existence of the) return expression.
   \end{itemize}
 
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement with no expression, that is, $\SReturn(\None)$;
     \item the enclosing subprogram does not have a \texttt{return} type (it is either a setter
@@ -3144,7 +3148,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{the empty set}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement with an expression $\ve$, that is, $\SReturn(\langle \vep \rangle)$;
     \item the enclosing subprogram has a return type $\vt$;
@@ -3206,7 +3210,7 @@ In \listingref{semantics-sreturntuple},
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement, $\SReturn(\None)$;
     \item $\vvs$ is the empty list, $\emptylist$;
@@ -3214,7 +3218,7 @@ One of the following applies:
     \item $\newenv$ is $\env$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{one}):
+  \item \AllApplyCase{one}:
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement;
     \item $\vs$ is a \texttt{return} statement for a single expression, $\SReturn(\langle\ve\rangle)$;
@@ -3224,7 +3228,7 @@ One of the following applies:
     \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tuple}):
+  \item \AllApplyCase{tuple}:
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement for a list of expressions, $\SReturn(\langle\ETuple(\es)\rangle)$;
     \item evaluating each expression in $\es$ separately as per \secref{SemanticsRule.EExprListM}
@@ -3277,13 +3281,13 @@ If the evaluation of any expression terminates abnormally then the abnormal conf
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\vEs$ is an empty list;
     \item $\vms$ is then empty list.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\vEs$ is a list with \head\ $\ve$ and \tail\ $\vesone$;
     \item evaluating $\ve$ in $\env$ yields $\Normal(\vmone, \envone)$\ProseOrAbnormal;
@@ -3408,7 +3412,7 @@ by composing the graphs in $\vms$ with Write Effects for the respective values.
 \listingref{literals1} shows literals and their corresponding types in comments.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ denotes the print statement with arguments $\vargs$ and newline indicator $\vnewline$;
   \item annotating for each \Proselistrange{$i$}{$\vargs$}, the expression $\vargs_i$ in $\tenv$ yields $(\vt_i, \vargsp_i, \vxs_i)$\ProseOrTypeError;
@@ -3656,7 +3660,7 @@ Evaluating $\SUnreachable$ in an environment $\env$ results in a dynamic error i
 
 \TypingRuleDef{SPragma}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vs$ is a pragma statement with identifier $\id$ and expression list $\vargs$. that is, $\SPragma(\id, \vargs)$;
   \item for each \Proselistrange{$i$}{$\vargs$}, \Proseannotateexpr{$\tenv$}{$\vargs[i]$}{$(\Ignore, \Ignore, \vxs_i)$}\ProseOrTypeError;

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -323,14 +323,14 @@ builds a statement $\news$ from an assignment of expression $\rhs$ to a setter i
 \inferrule[singleton]{
   \fields \eqname [\field] \\
   \vx \in \Identifiers \text{ is fresh} \\\\
-  \setcalltype(\vcall, \STGetter) \aslto \texttt{getter} \\\\
-  \texttt{read} \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \None, \langle\texttt{getter}\rangle) \\\\
-  \texttt{modify} \eqdef \SAssign(\LESetField(\LEVar(\vx), \field), \rhs) \\\\
-  \makesetter(\vcall, \EVar(\vx)) \aslto \texttt{setter}
+  \setcalltype(\vcall, \STGetter) \aslto \vgetter \\\\
+  \vread \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \None, \langle\vgetter\rangle) \\\\
+  \vmodify \eqdef \SAssign(\LESetField(\LEVar(\vx), \field), \rhs) \\\\
+  \makesetter(\vcall, \EVar(\vx)) \aslto \vsetter
 }{
   \desugarsetter(\vcall, \fields, \rhs)
   \astarrow
-  \SSeq (\SSeq(\texttt{read}, \texttt{modify}), \SCall(\texttt{setter}))
+  \SSeq (\SSeq(\vread, \vmodify), \SCall(\vsetter))
 }
 \end{mathpar}
 
@@ -338,14 +338,14 @@ builds a statement $\news$ from an assignment of expression $\rhs$ to a setter i
 \inferrule[multiple]{
   \listlen{\fields} > 1 \\
   \vx \in \Identifiers \text{ is fresh} \\\\
-  \setcalltype(\vcall, \STGetter) \aslto \texttt{getter} \\\\
-  \texttt{read} \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \None, \langle\texttt{getter}\rangle) \\\\
-  \texttt{modify} \eqdef \SAssign(\LESetFields(\LEVar(\vx), \fields), \rhs) \\\\
-  \makesetter(\vcall, \EVar(\vx)) \aslto \texttt{setter}
+  \setcalltype(\vcall, \STGetter) \aslto \vgetter \\\\
+  \vread \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \None, \langle\vgetter\rangle) \\\\
+  \vmodify \eqdef \SAssign(\LESetFields(\LEVar(\vx), \fields), \rhs) \\\\
+  \makesetter(\vcall, \EVar(\vx)) \aslto \vsetter
 }{
   \desugarsetter(\vcall, \fields, \rhs)
   \astarrow
-  \SSeq (\SSeq(\texttt{read}, \texttt{modify}), \SCall(\texttt{setter}))
+  \SSeq (\SSeq(\vread, \vmodify), \SCall(\vsetter))
 }
 \end{mathpar}
 
@@ -488,6 +488,7 @@ As given by applying the relevant rules to the desugared AST.
   \item define $\news$ as local declaration statement with variable keyword, local declaration item $\ldi$, type annotation $\vtp$, and initializing expression $\veinit$, that is, $\SDecl(\LDKVar, \ldi, \langle\veinit\rangle)$.
   \end{itemize}
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[constant]{
@@ -3485,7 +3486,7 @@ Notice that empty bitvectors are displayed as \verb|0x|.
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[Print]{
+\inferrule[print]{
   \evalexprlist{\env, \elist} \evalarrow \Normal((\vlist, \vg), \env_1) \OrAbnormal\\
   \vi\in\listrange(\vlist): \outputtoconsole(\env_\vi, \vlist[i]) \evalarrow \env_{\vi + 1} \\
   n \eqdef \listlen{\vlist}\\
@@ -3495,10 +3496,12 @@ Notice that empty bitvectors are displayed as \verb|0x|.
 }
 \end{mathpar}
 
+We define the newline character $\vnewline \triangleq \ascii{10}$.
+
 \begin{mathpar}
-\inferrule[Println]{
+\inferrule[println]{
   \evalstmt{\env, \SPrint(\elist, \False)} \evalarrow \Continuing(\vg, \envone) \OrAbnormal\\\\
-  \outputtoconsole(\envone, \nvstring(\texttt{"\char`\\n"})) \evalarrow \newenv
+  \outputtoconsole(\envone, \nvstring(\vnewline)) \evalarrow \newenv
 }{
   \evalstmt{\env, \SPrint(\elist, \True)} \evalarrow \Continuing(\vg, \newenv)
 }
@@ -3569,7 +3572,7 @@ $\llabel(s)$      & $s$. \\
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[console\_exists]{
+\inferrule{
   \env \eqname (\tenv, \denv, \vconsolestream)\\
   \newenv \eqdef (\tenv, \denv, \vconsolestream \concat \literaltostring(\vl))
 }{
@@ -3585,7 +3588,7 @@ The function ignores the string value and returns the environment unchanged.
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[no\_console]{}{
+\inferrule{}{
   \outputtoconsole(\env, \Ignore) \evalarrow \overname{\env}{\newenv}
 }
 \end{mathpar}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -681,11 +681,11 @@ One of the following applies:
 
   \item All of the following apply (\textsc{tuple}):
   \begin{itemize}
-    \item $\lhs$ is a tuple of types \vlhstys;
-    \item $\rhs$ is a tuple of types \vrhstys;
-    \item checking that the lengths of \vlhstys and \vrhstys are equal yields $\True$\ProseOrTypeError;
-    \item define \vlhstysp by applying $\inheritintegerconstraints$ to each element of \\
-          \vlhstys\ and \vrhstys\ProseOrTypeError;
+    \item $\lhs$ is a tuple of types $\vlhstys$;
+    \item $\rhs$ is a tuple of types $\vrhstys$;
+    \item checking that the lengths of $\vlhstys$ and $\vrhstys$ are equal yields $\True$\ProseOrTypeError;
+    \item define $\vlhstysp$ by applying $\inheritintegerconstraints$ to each element of \\
+         $ \vlhstys$ and $\vrhstys$\ProseOrTypeError;
     \item \Proseeqdef{$\lhsp$}{$\TTuple(\vlhstysp)$}.
   \end{itemize}
 
@@ -1333,14 +1333,6 @@ selected case 2
 % CONSOLE_END
 \listingref{case-discriminant} shows an example of a \casestatementterm{}
 and the output to a console when it is evaluated.
-
-\ASLListing{A side-effecting case discriminant}{case-discriminant}{\definitiontests/CaseStatement.discriminant.asl}
-% CONSOLE_BEGIN aslref \definitiontests/CaseStatement.discriminant.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-num_tests: 0
-selected case 2
-\end{Verbatim}
-% CONSOLE_END
 
 \hypertarget{def-casediscriminantterm}{}
 \hypertarget{def-casealternativeterm}{}
@@ -3660,7 +3652,7 @@ All of the following apply:
 \subsection{Semantics\label{sec:PragmaSemantics}}
 
 \ProseParagraph
-Pragmas are structures present in the \untypedast \ which are designed to be used
+Pragmas are structures present in the \untypedast{} that are designed to be used
 by third-party tools.
 
 To avoid conflicts between different ASL parsers, it is recommended that the pragma's identifier $\Tidentifier(\id)$ be prefixed by the name of the ASL tool that supports that pragma

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -3232,6 +3232,7 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
 \inferrule[none]{}
 {

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -654,42 +654,52 @@ One of the following applies:
 The helper function
 \[
 \inheritintegerconstraints(\overname{\ty}{\lhs} \aslsep \overname{\ty}{\rhs})
-\typearrow \lhsp \cup\ \overname{\TTypeError}{\TypeErrorConfig}
+\aslto \overname{\ty}{\lhsp} \cup\ \overname{\TTypeError}{\TypeErrorConfig}
 \]
 propagates integer constraints from the right-hand side type $\rhs$ to the left-hand side type annotation $\lhs$.
-In particular, each occurence of \pendingconstrainedintegertype{} on the left-hand side should inherit constraints from a corresponding \wellconstrainedintegertype{} on the right-hand side.
+In particular, each occurrence of \pendingconstrainedintegertype{} on the left-hand side should inherit constraints from a corresponding \wellconstrainedintegertype{} on the right-hand side.
 If the corresponding right-hand side type is not a \wellconstrainedintegertype{} (including if it is an \unconstrainedintegertype{}), the result is a type error.
+
+\listingref{typing-pendingconstrained} shows examples of pending-constrained
+integer types.
+
+\ExampleDef{Pending-constrained integer type vs. unconstrained integer type}
+\listingref{pending-constrained-unconstrained} corresponds to the type error
+in the \CaseName{int} below.
+\ASLListing{An ill-typed pending-constrained integer type}{pending-constrained-unconstrained}
+{\typingtests/TypingRule.InheritIntegerConstraints.unconstrained.bad.asl}
 
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{int}):
+  \item \AllApplyCase{int}
   \begin{itemize}
     \item $\lhs$ is a \pendingconstrainedintegertype{};
-    \item $\rhs$ is a \wellconstrainedintegertype{}\ProseOrTypeError;
-    \item $\lhsp$ is $\rhs$.
+    \item checking that $\rhs$ is a \wellconstrainedintegertype{} yields $\True$\ProseOrTypeError;
+    \item \Proseeqdef{$\lhsp$}{$\rhs$}.
   \end{itemize}
 
   \item All of the following apply (\textsc{tuple}):
   \begin{itemize}
-    \item $\lhs$ is a tuple of types \texttt{lhs\_tys};
-    \item $\rhs$ is a tuple of types \texttt{rhs\_tys};
-    \item the lengths of \texttt{lhs\_tys} and \texttt{rhs\_tys} are equal\ProseOrTypeError;
-    \item define \texttt{lhs\_tys'} by applying $\inheritintegerconstraints$ to each element of \texttt{lhs\_tys} and \texttt{rhs\_tys}\ProseOrTypeError;
-    \item $\lhsp$ is $\TTuple(\texttt{lhs\_tys'})$.
+    \item $\lhs$ is a tuple of types \vlhstys;
+    \item $\rhs$ is a tuple of types \vrhstys;
+    \item checking that the lengths of \vlhstys and \vrhstys are equal yields $\True$\ProseOrTypeError;
+    \item define \vlhstysp by applying $\inheritintegerconstraints$ to each element of \\
+          \vlhstys\ and \vrhstys\ProseOrTypeError;
+    \item \Proseeqdef{$\lhsp$}{$\TTuple(\vlhstysp)$}.
   \end{itemize}
 
   \item All of the following apply (\textsc{other}):
   \begin{itemize}
     \item $\lhs$ is not a \pendingconstrainedintegertype{}, or one of $\lhs$ and $\rhs$ is not a tuple type;
-    \item $\lhsp$ is $\lhs$.
+    \item \Proseeqdef{$\lhsp$}{$\lhs$}.
   \end{itemize}
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[int]{
-  \rhs \eqname \TInt(\wellconstrained(\Ignore)) \OrTypeError
+  \checktrans{\iswellconstrainedinteger(\rhs)}{\UnexpectedType} \checktransarrow \True\OrTypeError
 }{
   \inheritintegerconstraints(\overname{\TInt(\pendingconstrained)}{\lhs}, \rhs) \typearrow \overname{\rhs}{\lhsp}
 }
@@ -697,18 +707,23 @@ One of the following applies:
 
 \begin{mathpar}
 \inferrule[tuple]{
-  \lhs \eqname \TTuple(\texttt{lhs\_tys}) \\
-  \rhs \eqname \TTuple(\texttt{rhs\_tys}) \\\\
-  \equallength(\texttt{lhs\_tys}, \texttt{rhs\_tys}) \typearrow \True \OrTypeError \\
-  \vi \in \listrange(\lhs): \inheritintegerconstraints(\texttt{lhs\_tys}_i, \texttt{rhs\_tys}_i) \typearrow \texttt{lhs\_tys'}_i \OrTypeError \\
+  \lhs = \TTuple(\vlhstys) \\
+  \rhs = \TTuple(\vrhstys) \\\\
+  \checktrans{\equallength(\vlhstys, \vrhstys)}{\UnexpectedType} \typearrow \True \OrTypeError \\\\
+  {
+  \begin{array}{r}
+  \vi \in \listrange(\lhs): \inheritintegerconstraints(\vlhstys_\vi, \vrhstys_\vi) \typearrow \\
+  \vlhstysp_\vi \OrTypeError
+  \end{array}
+  }
 }{
-  \inheritintegerconstraints(\lhs, \rhs) \typearrow \overname{\TTuple(\texttt{lhs\_tys'})}{\lhsp}
+  \inheritintegerconstraints(\lhs, \rhs) \typearrow \overname{\TTuple(\vlhstysp)}{\lhsp}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[other]{
-  \lhs \neq \TInt(\pendingconstrained) \;\lor\; \astlabel(\lhs) \neq \TTuple \;\lor\; \astlabel(\rhs) \neq \TTuple
+  \lhs \neq \TInt(\pendingconstrained) \lor \astlabel(\lhs) \neq \TTuple \lor \astlabel(\rhs) \neq \TTuple
 }{
   \inheritintegerconstraints(\lhs, \rhs) \typearrow \overname{\lhs}{\lhsp}
 }
@@ -1113,7 +1128,8 @@ All of the following apply:
 \begin{itemize}
   \item $\vs$ is a call to a subprogram, that is, $\SCall(\vcall)$;
   \item annotating the subprogram call $\vcall$ as per \chapref{SubprogramCalls}
-        yields $(\vcallp, \None, \vses)$\ProseOrTypeError;
+        yields \\
+        $(\vcallp, \None, \vses)$\ProseOrTypeError;
   \item $\news$ is the call using $\vcallp$, that is, $\SCall(\vcallp)$;
   \item $\newtenv$ is $\tenv$.
 \end{itemize}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -105,7 +105,7 @@ We now define the syntax, abstract syntax, typing, and semantics for the followi
 
 \subsection{Semantics}
 \SemanticsRuleDef{SPass}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Pass Statements}
 In \listingref{semantics-spass}, \texttt{pass;} does nothing.:
 \ASLListing{Evaluating a \texttt{pass} statement}{semantics-spass}{\semanticstests/SemanticsRule.SPass.asl}
 
@@ -173,7 +173,7 @@ In \listingref{semantics-spass}, \texttt{pass;} does nothing.:
 
 \subsection{Semantics}
 \SemanticsRuleDef{SAssign}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Assignment Statements}
 In \listingref{semantics-sassign},
 \texttt{x = 3;} binds \texttt{x} to $\nvint(3)$ in the environment where \texttt{x} is bound to
 $\nvint(42)$, and $\newenv$ is such that \texttt{x} is bound to $\nvint(3)$.
@@ -215,7 +215,7 @@ and then completes the update via an appropriate rule for evaluating the
 etc.
 
 \SemanticsRuleDef{SAssignCall}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Assignment from Subprogram Calls}
 In \listingref{assigncallsemantics}, given that the function call \texttt{f(1)} returns a triple of values ---
 $\nvint(1)$, $\nvint(2)$, and $\nvint(3)$
 (each with its own associated execution graph),
@@ -779,12 +779,12 @@ If the answer if $\False$, the result is a type error.
 
 \subsection{Semantics}
 \SemanticsRuleDef{SDeclSome}
-\subsubsection{Example (Declaration With an Initializing Value)}
+\ExampleDef{Declaration With an Initializing Value}
 In \listingref{semantics-sdeclsome},
 \texttt{let x = 3;} binds \texttt{x} to $\nvint(3)$ in the empty environment.
 \ASLListing{Evaluating a declaration with a given initial value}{semantics-sdeclsome}{\semanticstests/SemanticsRule.SDeclSome.asl}
 
-\subsubsection{Example (Declaration Without an Initializing Value)}
+\ExampleDef{Declaration Without an Initializing Value}
 In \listingref{semantics-sdeclnone},
 \texttt{var x : integer;} binds \texttt{x} in $\env$ to the base value of \texttt{integer}.
 \ASLListing{Evaluating a declaration without a given initial value}{semantics-sdeclnone}{\semanticstests/SemanticsRule.SDeclNone.asl}
@@ -1064,7 +1064,7 @@ instances of $\SPass$.
 
 \subsection{Semantics}
 \SemanticsRuleDef{SSeq}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Sequencing Statements}
 In \listingref{semantics-sseq},
 the evaluation of \texttt{let x = 3; let y = x + 1} first evaluates \texttt{let x = 3} and only then
 evaluates \texttt{let y = x + 1}.
@@ -1156,7 +1156,7 @@ evaluates \texttt{let y = x + 1}.
 
 \subsection{Semantics}
 \SemanticsRuleDef{SCall}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Call Statements}
 In \listingref{semantics-scall},
 \verb|Zeros{3}| evaluates to \texttt{'000'}.
 \ASLListing{Evaluating a call statement}{semantics-scall}{\semanticstests/SemanticsRule.SCall.asl}
@@ -1272,7 +1272,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \subsection{Semantics}
 \SemanticsRuleDef{SCond}
-\subsubsection{Examples}
+\ExampleDef{Conditional Statements}
 The specification in \listingref{semantics-scond} does not result in any Assertion Error.
 \ASLListing{Evaluating a conditional statement}{semantics-scond}{\semanticstests/SemanticsRule.SCond.asl}
 
@@ -1404,7 +1404,7 @@ That is, they are transformed into an untyped AST node that does not have
 an explicit representation for \texttt{case} statements.
 This is achieved via \ASTRuleRef{DesugarCaseStmt}.
 
-\subsubsection{Example}
+\ExampleDef{Case Statement Desugaring}
 \listingref{ast-case1} shows an example of how a \texttt{case} statement can be transformed into a corresponding
 compound condition statement.
 \ASLListing{Transforming a case statement with a variable as the case discriminant}{ast-case1}{\syntaxtests/ASTRule.Desugar_SCase1.asl}
@@ -1693,14 +1693,14 @@ The first call to \verb|checked_8bit_add| succeeds, whereas the second call fail
 
 \subsection{Semantics}
 \SemanticsRuleDef{SAssert}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Assertions: Success}
 In \listingref{semantics-sasertok},
 \texttt{assert (42 != 3);} ensures that \texttt{3} is not equal to \texttt{42}.
 \ASLListing{Evaluating an assertion that succeeds}{semantics-sasertok}{\semanticstests/SemanticsRule.SAssertOk.asl}
 
-\subsubsection{Example}
+\ExampleDef{Evaluation of Assertions: Failure}
 In \listingref{semantics-sassertno},
-evaluating \texttt{assert (42 == 3);} results in an \texttt{AssertionFailed} error.
+evaluating \texttt{assert (42 == 3);} results in an \DynamicAssertionFailure{} error.
 \ASLListing{Evaluating an assertion that fails}{semantics-sassertno}{\semanticstests/SemanticsRule.SAssertNo.asl}
 
 \ProseParagraph
@@ -1886,7 +1886,7 @@ yielding a pair consisting of an expression $\vep$ and a \sideeffectsetterm\ $\v
 
 \subsection{Semantics}
 \SemanticsRuleDef{SWhile}
-\subsubsection{Example}
+\ExampleDef{Evaluation of While Statements}
 The specification in \listingref{semantics-swhile} prints \texttt{0123}.
 \ASLListing{Evaluating a \texttt{while} loop}{semantics-swhile}{\semanticstests/SemanticsRule.SWhile.asl}
 
@@ -1948,12 +1948,11 @@ the result is a dynamic error.
 The result is either the continuing configuration \\ $\Continuing(\newg,\newenv)$,
 an early return configuration, or an abnormal configuration.
 
-\subsubsection{Example}
+\ExampleDef{Evaluation of Loops}
 The specification in \listingref{semantics-loop} does not result in any Assertion Error
 and the specification terminates with exit code $0$.
 \ASLListing{Evaluating a loop}{semantics-loop}{\semanticstests/SemanticsRule.Loop.asl}
 
-\CodeSubsection{\EvalLoopBegin}{\EvalLoopEnd}{../Interpreter.ml}
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -2015,6 +2014,7 @@ The negation of the condition is used to decide whether to continue the loop ite
   \evalloop{\env, \iswhile, \vlimitopt, \econd, \vbody} \evalarrow \Continuing(\newg, \newenv)
 }
 \end{mathpar}
+\CodeSubsection{\EvalLoopBegin}{\EvalLoopEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{EvalLimit}
 The relation
@@ -2186,7 +2186,7 @@ If the value is $0$, the result is a dynamic error.
 
 \subsection{Semantics}
 \SemanticsRuleDef{SRepeat}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Repeat Statements}
 The specification in \listingref{semantics-srepeat} is followed by its output to the console.
 \ASLListing{Evaluating a \texttt{repeat} loop}{semantics-srepeat}{\semanticstests/SemanticsRule.SRepeat.asl}
 % CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.SRepeat.asl
@@ -2504,7 +2504,7 @@ environment. The type system ensures, via \TypingRuleRef{SFor}, that the index v
 is not already declared in the scope of the subprogram containing the \texttt{for}
 statement.
 
-\subsubsection{Example}
+\ExampleDef{Evaluation of For Statements}
 The specification in \listingref{semantics-sfor} is followed by its output to the console.
 \ASLListing{Evaluating a \texttt{for} loop}{semantics-sfor}{\semanticstests/SemanticsRule.SFor.asl}
 % CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.SFor.asl
@@ -2678,7 +2678,7 @@ iterations.
 \end{itemize}
 
 \subsubsection{Overall Evaluation}
-\subsubsection{Example}
+\ExampleDef{Overall Evaluation of For Statements}
 The specification in \listingref{semantics-sfor}
 does not result in any assertion error, and terminates with exit-code $0$.
 
@@ -2877,7 +2877,7 @@ $\evalforloop$ (the latter in a mutually recursive manner):
 
 \subsection{Semantics}
 subsubsection{SemanticsRule.SThrow\label{sec:SemanticsRule.SThrow}}
-\subsubsection{Example (Rethrowing an Exception)}
+\ExampleDef{Rethrowing an Exception}
 The specification in \listingref{semantics-sthrownone}
 first catches the exception raised by \\
 \verb|throw MyExceptionType{a=42}|
@@ -2885,7 +2885,7 @@ and then raises it in the catch clause via \verb|throw;|,
 catching it again in the outer \texttt{try-catch} statement.
 \ASLListing{Rethrowing an exception}{semantics-sthrownone}{\semanticstests/SemanticsRule.SThrowNone.asl}
 
-\subsubsection{Example (Throwing a Typed Exception)}
+\ExampleDef{Throwing a Typed Exception}
 The specification in \listingref{semantics-sthrowsometyped}
 terminates successfully. That is, no dynamic error occurs.
 \ASLListing{Throwing an exception}{semantics-sthrowsometyped}{\semanticstests/SemanticsRule.SThrowSomeTyped.asl}
@@ -3077,7 +3077,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \subsection{Semantics}
 \SemanticsRuleDef{STry}
-\subsubsection{Example}
+\ExampleDef{Evaluation of Try Statements}
 Evaluating the specification in \listingref{semantics-stry}
 does not result in any Assertion error, and the specification terminates with the exit code $0$.
 \ASLListing{Evaluating a \texttt{try} statement}{semantics-stry}{\semanticstests/SemanticsRule.STry.asl}
@@ -3194,17 +3194,17 @@ does not result in any Assertion error, and the specification terminates with th
 
 \subsection{Semantics}
 \SemanticsRuleDef{SReturn}
-\subsubsection{Example (No Return Value)}
+\ExampleDef{No Return Value}
 The specification in \listingref{semantics-sreturn} exits the procedure \texttt{println\_me}
 by evaluating the \texttt{return;} statement.
 \ASLListing{Evaluating a \texttt{return} statement with no value}{semantics-sreturn}{\semanticstests/SemanticsRule.SReturnNone.asl}
 
-\subsubsection{Example (Returning a Single Value)}
+\ExampleDef{Returning a Single Value}
 In \listingref{semantic-ssreturnone},
 \texttt{return 3;} exits the function \texttt{f} with value \texttt{3}.
 \ASLListing{Evaluating a \texttt{return} statement with a single value}{semantic-ssreturnone}{\semanticstests/SemanticsRule.SReturnOne.asl}
 
-\subsubsection{Example (Returning a Tuple of Values)}
+\ExampleDef{Returning a Tuple of Values}
 In \listingref{semantics-sreturntuple},
 \texttt{return (3, 42);} exits the function \texttt{f} with the value \texttt{(3, 42)}.
 \ASLListing{Evaluating a \texttt{return} statement with a tuple of values}{semantics-sreturntuple}{\semanticstests/SemanticsRule.SReturnSome.asl}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -1315,6 +1315,16 @@ num_tests: 0
 selected case 2
 \end{Verbatim}
 % CONSOLE_END
+\listingref{case-discriminant} shows an example of a \casestatementterm{}
+and the output to a console when it is evaluated.
+
+\ASLListing{A side-effecting case discriminant}{case-discriminant}{\definitiontests/CaseStatement.discriminant.asl}
+% CONSOLE_BEGIN aslref \definitiontests/CaseStatement.discriminant.asl
+\begin{Verbatim}[fontsize=\footnotesize, frame=single]
+num_tests: 0
+selected case 2
+\end{Verbatim}
+% CONSOLE_END
 
 \hypertarget{def-casediscriminantterm}{}
 \hypertarget{def-casealternativeterm}{}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -692,7 +692,7 @@ in the \CaseName{int} below.
 
   \item \AllApplyCase{other}
   \begin{itemize}
-    \item $\lhs$ is not a \pendingconstrainedintegertype{}, or one of $\lhs$ and $\rhs$ is not a tuple type;
+    \item $\lhs$ is not a \pendingconstrainedintegertype{}, or one of $\lhs$ and $\rhs$ is not a \tupletypeterm{};
     \item \Proseeqdef{$\lhsp$}{$\lhs$}.
   \end{itemize}
 \end{itemize}
@@ -1631,7 +1631,7 @@ they do not appear in the typed AST and thus are not associated with a semantics
 \hypertarget{def-assertionstatementterm}{}
 \section{Assertion Statements\label{sec:AssertionStatements}}
 Assertion statements are used to check that certain conditions are satisfied.
-They take a single \texttt{boolean}-typed operand, which we refer to as the
+They take a single \booleantypeterm{} operand, which we refer to as the
 \emph{condition}. If the condition is \False, the statement fails with a
 \dynamicerrorterm{} (\errorcodeterm{} $\DynamicAssertionFailure$).
 

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -2821,6 +2821,7 @@ $\evalforloop$ (the latter in a mutually recursive manner):
 
 \subsection{Typing}
 \TypingRuleDef{SThrow}
+\newcommand\NoNameException[0]{\texttt{\_}}
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
@@ -2829,7 +2830,7 @@ One of the following applies:
     \item $\vs$ is a throw statement with no expression, that is, $\SThrow(\None)$;
     \item $\news$ is $\vs$;
     \item $\newtenv$ is $\tenv$;
-    \item \Proseeqdef{$\vses$}{the singleton set for $\ThrowException(\texttt{\_})$}
+    \item \Proseeqdef{$\vses$}{the singleton set for $\ThrowException(\NoNameException)$}
   \end{itemize}
 
   \item All of the following apply (\textsc{some}):
@@ -2849,7 +2850,7 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[none]{}{
   \annotatestmt(\tenv, \overname{\SThrow(\None)}{\vs}) \typearrow
-  (\overname{\SThrow(\None)}{\news}, \overname{\tenv}{\newtenv}, \overname{\{\ThrowException(\texttt{\_})\}}{\vses})
+  (\overname{\SThrow(\None)}{\news}, \overname{\tenv}{\newtenv}, \overname{\{\ThrowException(\NoNameException)\}}{\vses})
 }
 \end{mathpar}
 \lrmcomment{Note that \identr{BRCJ} is done in~\cite[SemanticsRule.TopLevel]{ASLSemanticsReference}.}
@@ -3321,21 +3322,47 @@ The helper relation
 concatenates the input values in $\vms$ and generates an execution graph
 by composing the graphs in $\vms$ with Write Effects for the respective values.
 
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{empty}
+  \begin{itemize}
+    \item $\vms$ is the empty list;
+    \item \Proseeqdef{$\vvs$}{the empty list};
+    \item \Proseeqdef{$\newg$}{the empty graph}.
+  \end{itemize}
+
+  \item \AllApplyCase{non\_empty}
+  \begin{itemize}
+    \item $\vms$ is a list with \head{} $\vm$ and \tail{} $\vmsone$;
+    \item view $\vm$ as the \nativevalue{} $\vv$ and the \executiongraph{} $\vg$;
+    \item \Proseeqdef{$\wid$}{a fresh identifier};
+    \item applying $\writeidentifier$ to $\wid$ and $\vv$ yields $\vgone$;
+    \item applying $\writefolder$ to $\vms$ and $\vgone$ yields the pair $(\vvsone, \vgtwo)$;
+    \item \Proseeqdef{$\vvs$}{the list with \head{} $\vv$ and \tail{} $\vvsone$};
+    \item \Proseeqdef{$\newg$}{the ordered composition of $\vg$ and $\vgone$ with the $\aslpo$ edge
+          and $\vgtwo$ with the $\asldata$ edge}.
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
 \begin{mathpar}
 \inferrule[empty]{}{
-  \writefolder(\emptylist) \evalarrow (\emptylist, \emptygraph)
+  \writefolder(\overname{\emptylist}{\vms}) \evalarrow (\overname{\emptylist}{\vvs}, \overname{\emptygraph}{\newg})
 }
-\and
-\inferrule[nonempty]{
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_empty]{
   \vms \eqname [\vm] \concat \vmsone\\
   \vm \eqdef (\vv, \vg)\\
   \wid \in \Identifiers\text{ is fresh}\\
   \writeidentifier(\wid, \vv) \evalarrow \vgone\\
   \writefolder(\vmsone, \vgone) \evalarrow (\vvsone, \vgtwo)\\
   \vvs \eqdef [\vv] \concat \vvsone\\
-  \newg \eqdef \ordered{\vgone}{\asldata}{\vgtwo}
+  \newg \eqdef \ordered{\vg}{\aslpo}{\ordered{\vgone}{\asldata}{\vgtwo}}
 }{
-  \writefolder(\vms) \evalarrow (\vvs, \ordered{\vg}{\aslpo}{\newg})
+  \writefolder(\vms) \evalarrow (\vvs, \newg)
 }
 \end{mathpar}
 
@@ -3406,7 +3433,7 @@ All of the following apply:
 \subsection{Semantics}
 \SemanticsRuleDef{SPrint}
 
-\subsection{Example (Printing Literals)}
+\ExampleDef{Printing Literals}
 \listingref{semantics-literals} shows examples of printing various types of literals,
 followed by the output to the console resulting from running the specification.
 \ASLListing{Literals and how they are displayed}{semantics-literals}{\semanticstests/SemanticsRule.SPrint.asl}
@@ -3473,7 +3500,6 @@ Notice that empty bitvectors are displayed as \verb|0x|.
 \end{mathpar}
 \CodeSubsection{\EvalSPrintBegin}{\EvalSPrintEnd}{../Interpreter.ml}
 
-\SemanticsRuleDef{OutputToConsole}
 Not all ASL runtimes support printing to a console (see \RequirementRef{Printing}).
 %
 Therefore, the semantics is parameterized by the function
@@ -3485,22 +3511,11 @@ Therefore, the semantics is parameterized by the function
 which takes a string and communicates it to a console, where one exists.
 
 We now explain how printing is modelled when the runtime supports a console
-and how it is modelled when the runtime does not support a console.
+(\SemanticsRuleRef{SupportedOutputToConsole})
+and how it is modelled when the runtime does not support a console
+(\SemanticsRuleRef{UnsupportedOutputToConsole}).
 
-\subsubsection{Runtime Does Not Support a Console}
-The function ignores the string value and returns the environment unchanged.
-
-\ProseParagraph
-\ProseEqdef{$\newenv$}{$\env$}.
-
-\FormallyParagraph
-\begin{mathpar}
-\inferrule[no\_console]{}{
-  \outputtoconsole(\env, \Ignore) \evalarrow \overname{\env}{\newenv}
-}
-\end{mathpar}
-
-\subsubsection{Runtime Supports a Console}
+\SemanticsRuleDef{SupportedOutputToConsole}
 To support a console, the definition of environments needs
 to include an extra component to capture the string of characters sent to the console:
 \[
@@ -3557,8 +3572,21 @@ $\llabel(s)$      & $s$. \\
 }
 \end{mathpar}
 
-\hypertarget{def-unreachablestatementterm}{}
+\SemanticsRuleDef{UnsupportedOutputToConsole}
+The function ignores the string value and returns the environment unchanged.
+
+\ProseParagraph
+\ProseEqdef{$\newenv$}{$\env$}.
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[no\_console]{}{
+  \outputtoconsole(\env, \Ignore) \evalarrow \overname{\env}{\newenv}
+}
+\end{mathpar}
+
 \section{The Unreachable Statement\label{sec:UnreachableStatement}}
+\hypertarget{def-unreachablestatementterm}{}
 \listingref{UnreachableStatement} shows an example of using an \unreachablestatementterm{}
 to implement a custom form of assertion checking.
 \ASLListing{An example use of an \texttt{Unreachable} statement}{UnreachableStatement}{\definitiontests/UnreachableStatement.asl}

--- a/asllib/doc/StaticEvaluation.tex
+++ b/asllib/doc/StaticEvaluation.tex
@@ -16,6 +16,10 @@ in the static environment $\tenv$, returning a literal $\vv$.
 If the evaluation terminates by a thrown exception of a value that is not a literal
 (for example, a record value), the result is a type error.
 
+\hypertarget{def-staticallyevaluable}{}
+We say that an expression $\ve$ is \staticallyevaluable{} in a given static environment $\tenv$ if
+applying $\staticeval(\tenv, \ve) \typearrow \vv$ and $\vv$ is a literal value.
+
 Static evaluation employs the dynamic semantics to evaluate $\ve$ and inspects the result to extract
 a literal. The evaluation should be able to access global constants as well as local constants that
 are bound in $\tenv$. Therefore, a dynamic environment is constructed from the constants defined in $\tenv$

--- a/asllib/doc/StaticEvaluation.tex
+++ b/asllib/doc/StaticEvaluation.tex
@@ -25,21 +25,21 @@ are bound in $\tenv$. Therefore, a dynamic environment is constructed from the c
 \AllApply
 \begin{itemize}
   \item applying $\staticenvtoenv$ to $\tenv$ yields $\env$;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{normal\_literal}:
+    \item \AllApplyCase{normal\_literal}
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ yields $\Normal(\nvliteral{\vv}, \Ignore)$.
     \end{itemize}
 
-    \item \AllApplyCase{normal\_non\_literal}:
+    \item \AllApplyCase{normal\_non\_literal}
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ yields $\Normal(\vx, \Ignore)$
             where $\vx$ is not a native value for a literal;
       \item the result is a type error indicating that $\ve$ cannot be statically evaluated to a literal.
     \end{itemize}
 
-    \item \AllApplyCase{abnormal}:
+    \item \AllApplyCase{abnormal}
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ yields an abnormal configuration;
       \item the result is a type error indicating that $\ve$ cannot be statically evaluated to a literal.

--- a/asllib/doc/StaticEvaluation.tex
+++ b/asllib/doc/StaticEvaluation.tex
@@ -22,24 +22,24 @@ are bound in $\tenv$. Therefore, a dynamic environment is constructed from the c
 (see \TypingRuleRef{StaticEnvToEnv}).
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\staticenvtoenv$ to $\tenv$ yields $\env$;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{normal\_literal}):
+    \item \AllApplyCase{normal\_literal}:
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ yields $\Normal(\nvliteral{\vv}, \Ignore)$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{normal\_non\_literal}):
+    \item \AllApplyCase{normal\_non\_literal}:
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ yields $\Normal(\vx, \Ignore)$
             where $\vx$ is not a native value for a literal;
       \item the result is a type error indicating that $\ve$ cannot be statically evaluated to a literal.
     \end{itemize}
 
-    \item All of the following apply (\textsc{abnormal}):
+    \item \AllApplyCase{abnormal}:
     \begin{itemize}
       \item evaluating $\ve$ in $\env$ yields an abnormal configuration;
       \item the result is a type error indicating that $\ve$ cannot be statically evaluated to a literal.
@@ -87,7 +87,7 @@ The function
 transforms the constants defined in the static environment $\tenv$ into an environment $\env$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item define the global dynamic environment $\vglobal$ as the map that bind
         each $\id$ in the domain of $G^\tenv.\constantvalues$ to $\nvliteral{\vl}$

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -61,7 +61,7 @@ We also define helper functions via respective rules:
 
 \TypingRuleDef{AnnotateCall}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\annotateexprlist$ to annotate the expression list $\vcall.\callargs$ in $\tenv$ yields \\
         $\args$\ProseOrTypeError;
@@ -117,7 +117,7 @@ is similar to $\annotatecall$, except that it accepts annotated version of param
 
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\unziplistthree$ to $\typedargs$ yields the corresponding list of types $\argtypes$,
         list of expressions $\args$, and a list of \sideeffectdescriptorsetsterm\ $\vsessargs$;
@@ -210,7 +210,7 @@ Note that this function relies on all standard library functions with input para
 
 
 \ProseParagraph
-All of the following applies:
+\AllApply
 \begin{itemize}
   \item $\funcsig.\funcparameters$ is either
     a list with one parameter with a name $\vx$,
@@ -258,13 +258,13 @@ It assumes that $\funcsigparams$ and $\params$ have the same length.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\funcsigparams$ is an empty list;
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply:
+  \item \AllApply
   \begin{itemize}
     \item $\funcsigparams$ is a non-empty list with \head\ $(\vx, \tydeclopt)$ and \\
           \tail\ $\funcsigparamsone$, and
@@ -274,13 +274,13 @@ One of the following applies:
     \item checking that $\tyactual$ represents a \constrainedinteger{} yields $\True$\ProseOrTypeError;
     \item One of the following applies:
     \begin{itemize}
-      \item All of the following apply (\textsc{parameterized}):
+      \item \AllApplyCase{parameterized}:
       \begin{itemize}
         \item $\tyactual$ is a \parameterizedintegertype{} for the parameter $\vx$, that is, \\
               $\langle\TInt(\parameterized(\vx))\rangle$.
       \end{itemize}
 
-      \item All of the following apply (\textsc{other}):
+      \item \AllApplyCase{other}:
       \begin{itemize}
         \item $\tydeclopt$ is not $\None$, that is, $\langle\tydecl\rangle$;
         \item $\tydecl$ is not the \parameterizedintegertype{} for the parameter $\vx$;
@@ -346,14 +346,14 @@ $\eqs$, yielding the type $\newty$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{t\_bits}):
+  \item \AllApplyCase{t\_bits}:
   \begin{itemize}
     \item $\tty$ is a bitvector type with width expression $\ve$ and fields $\fields$, that is, $\TBits(\ve, \fields)$;
     \item applying $\substexprnormalize$ to $\eqs$ and $\ve$ in $\tenv$ yields the expression $\newe$;
     \item define $\newty$ as a bitvector type with expression $\newe$ and fields $\fields$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_int\_wellconstrained}):
+  \item \AllApplyCase{t\_int\_wellconstrained}:
   \begin{itemize}
     \item $\tty$ is a well-constrained integer type with constraints $\constraints$;
     \item applying $\substconstraint$ to each constraint $\constraints[\vi]$, for $\vi$ in \\
@@ -364,7 +364,7 @@ One of the following applies:
           $\newconstraints$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_int\_parameterized}):
+  \item \AllApplyCase{t\_int\_parameterized}:
   \begin{itemize}
     \item $\tty$ is a \parameterizedintegertype\ for the parameter $\name$;
     \item applying $\substexprnormalize$ to $\eqs$ and the expression $\EVar(\name)$ yields $\ve$;
@@ -372,7 +372,7 @@ One of the following applies:
           $\TInt(\wellconstrained(\ConstraintExact(\ve)))$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_tuple}):
+  \item \AllApplyCase{t\_tuple}:
   \begin{itemize}
     \item $\tty$ is the tuple type over the list of tuples $\tys$, that is, $\TTuple(\tys)$;
     \item applying $\renametyeqs$ to $\eqs$ and the type $\tys[\vi]$, for each $\vi$ in \\
@@ -381,7 +381,7 @@ One of the following applies:
     \item define $\newty$ as the tuple type over $\newtys$, that is, $\TTuple(\newtys)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{other}):
+  \item \AllApplyCase{other}:
   \begin{itemize}
     \item $\tty$ is not one of the types in the previous cases,
           that is, $\tty$ is not a bitvector type, nor an integer type, nor a tuple type;
@@ -444,7 +444,7 @@ $\eqs$, and then attempting to symbolically simplify the result, yielding the ex
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item transforming $\ve$ in the static environment $\tenv$, by substituting the parameter expressions
         $\eqs$, yields $\veone$;
@@ -479,14 +479,14 @@ $\substs$, yielding the expression $\newe$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{e\_var\_in\_substs}):
+  \item \AllApplyCase{e\_var\_in\_substs}:
   \begin{itemize}
     \item $\ve$ is a variable expression for the identifier $\vs$, that is, $\EVar(\vs)$;
     \item applying $\assocopt$ to $\vs$ and $\substs$ yields the expression $\newe$.
           That is, $\vs$ is a parameter with an associated expression;
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_var\_not\_in\_substs}):
+  \item \AllApplyCase{e\_var\_not\_in\_substs}:
   \begin{itemize}
     \item $\ve$ is the variable expression for the identifier $\vs$, that is, $\EVar(\vs)$;
     \item applying $\assocopt$ to $\vs$ and $\substs$ yields $\None$.
@@ -494,14 +494,14 @@ One of the following applies:
     \item define $\newe$ is $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_unop}):
+  \item \AllApplyCase{e\_unop}:
   \begin{itemize}
     \item $\ve$ is the unary operator expression for the operator $\op$ and expression $\ve$, that is, $\EUnop(\op, \veone)$;
     \item applying $\substexpr$ to $\substs$ and $\veone$ in $\tenv$ yields $\veonep$;
     \item define $\newe$ as the unary operator expression for the operator $\op$ and expression $\veonep$, that is, $\EUnop(\op, \veonep)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_binop}):
+  \item \AllApplyCase{e\_binop}:
   \begin{itemize}
     \item $\ve$ is the binary operator expression for the operator $\op$ and expressions $\veone$ and $\vetwo$, that is, $\EBinop(\op, \veone, \vetwo)$;
     \item applying $\substexpr$ to $\substs$ and $\veone$ in $\tenv$ yields $\veonep$;
@@ -509,7 +509,7 @@ One of the following applies:
     \item define $\newe$ as the unary operator expression for the operator $\op$ and expression $\veonep$, that is, $\EUnop(\op, \veonep)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_cond}):
+  \item \AllApplyCase{e\_cond}:
   \begin{itemize}
     \item $\ve$ is the conditional expression for expressions $\veone$, $\vetwo$, and $\vethree$, that is, \\
           $\ECond(\veone, \vetwo, \vethree)$;
@@ -519,7 +519,7 @@ One of the following applies:
     \item define $\newe$ as the conditional expression for expressions $\veonep$, $\vetwop$, and $\vethreep$, that is, $\ECond(\veonep, \vetwop, \vethreep)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_call}):
+  \item \AllApplyCase{e\_call}:
   \begin{itemize}
     \item $\ve$ is the call expression for subprogram $\vx$ with arguments $\vargs$ and parameter expressions $\paramargs$,
           that is, $\ECall(\vx, \vargs, \paramargs)$;
@@ -530,7 +530,7 @@ One of the following applies:
     that is, $\ECall(\vx, \vargsp, \paramargs)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getarray}):
+  \item \AllApplyCase{e\_getarray}:
   \begin{itemize}
     \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and index expression $\vetwo$,
           that is, $\EGetArray(\veone, \vetwo)$;
@@ -540,7 +540,7 @@ One of the following applies:
     that is, $\EGetArray(\veonep, \vetwop)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getenumarray}):
+  \item \AllApplyCase{e\_getenumarray}:
   \begin{itemize}
     \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and an enumeration-typed index expression $\vetwo$,
           that is, $\EGetEnumArray(\veone, \vetwo)$;
@@ -551,7 +551,7 @@ One of the following applies:
           that is, $\EGetEnumArray(\veonep, \vetwop)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getfield}):
+  \item \AllApplyCase{e\_getfield}:
   \begin{itemize}
     \item $\ve$ is the field access expression for base expression $\ve$ and field $\vx$,
           that is, $\EGetField(\veone, \vx)$;
@@ -560,7 +560,7 @@ One of the following applies:
           that is, $\EGetField(\veonep, \vx)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getfields}):
+  \item \AllApplyCase{e\_getfields}:
   \begin{itemize}
     \item $\ve$ is the access to fields $\fields$ with base expression $\veone$, that is, \\
           $\EGetFields(\veone, \fields)$;
@@ -568,7 +568,7 @@ One of the following applies:
     \item define $\newe$ as the access to fields $\fields$ with base expression $\veonep$, that is, $\EGetFields(\veonep, \fields)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getitem}):
+  \item \AllApplyCase{e\_getitem}:
   \begin{itemize}
     \item $\ve$ is the access to tuple item $\vi$ of the tuple expression $\veone$, that is, \\
           $\EGetItem(\veone, \vi)$;
@@ -577,7 +577,7 @@ One of the following applies:
           $\EGetItem(\veonep, \vi)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_pattern}):
+  \item \AllApplyCase{e\_pattern}:
   \begin{itemize}
     \item $\ve$ is the pattern expression of expression $\veone$ and patterns $\vps$, that is, \\
           $\EPattern(\veone, \vps)$;
@@ -585,7 +585,7 @@ One of the following applies:
     \item define $\newe$ as the pattern expression of expression $\veonep$ and patterns $\vps$, that is, $\EPattern(\veonep, \vps)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_record}):
+  \item \AllApplyCase{e\_record}:
   \begin{itemize}
     \item $\ve$ is the record expression of record type $\vt$ and list of fields $\fields$;
     \item for every pair $(\vx,\veone)$ in $\fields$, applying $\substexpr$ to $\substs$ $\veone$ in $\tenv$ yields $\veonep_\vx$;
@@ -593,14 +593,14 @@ One of the following applies:
     \item define $\newe$ as the record expression of record type $\vt$ and list of fields $\fieldsp$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_slice}):
+  \item \AllApplyCase{e\_slice}:
   \begin{itemize}
     \item $\ve$ is the slicing expression for subexpression $\veone$ and list of slices $\vslices$, that is, $\ESlice(\veone, \vslices)$;
     \item applying $\substexpr$ to $\veone$ in $\tenv$ yields $\veonep$;
     \item define $\newe$ as slicing expression for subexpression $\veonep$ and list of slices $\vslices$, that is, $\ESlice(\veonep, \vslices)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_tuple}):
+  \item \AllApplyCase{e\_tuple}:
   \begin{itemize}
     \item $\ve$ is the tuple expression of expressions $\ves$, that is, $\ETuple(\ves)$;
     \item applying $\substexpr$ to $\substs$ and every expression $\ves[\vi]$ in $\tenv$, for every $\vi$ in $\listrange(\ves)$
@@ -609,7 +609,7 @@ One of the following applies:
     \item define $\newe$ as the tuple expression of expressions $\vesp$, that is, $\ETuple(\vesp)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_array}):
+  \item \AllApplyCase{e\_array}:
   \begin{itemize}
     \item $\ve$ is an array construction expression with length expression $\length$ and value expression $\vvalue$, that is,
           $\EArray\{\EArrayLength: \length, \EArrayValue: \vvalue\}$;
@@ -620,7 +620,7 @@ One of the following applies:
           $\EArray\{\EArrayLength: \lengthp, \EArrayValue: \vvaluep\}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_enumarray}):
+  \item \AllApplyCase{e\_enumarray}:
   \begin{itemize}
     \item $\ve$ is an array construction expression for an enumeration-typed index
           with list of labels $\vlabels$ and initial element value expression $\vvalue$, that is, \\
@@ -631,14 +631,14 @@ One of the following applies:
           $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \vvaluep\}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_atc}):
+  \item \AllApplyCase{e\_atc}:
   \begin{itemize}
     \item $\ve$ is the type assertion of expression $\veone$ and type $\vt$, that is, $\EATC(\veone, \vt)$;
     \item applying $\substexpr$ to $\substs$ and $\veone$ in $\tenv$ yields $\veonep$;
     \item define $\newe$ as the type assertion of expression $\veonep$ and type $\vt$, that is, $\EATC(\veonep, \vt)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{other}):
+  \item \AllApplyCase{other}:
   \begin{itemize}
     \item $\ve$ is either a literal expression or an arbitrary value expression;
     \item define $\newe$ as $\ve$.
@@ -842,7 +842,7 @@ yielding the integer constraint $\newc$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact}):
+  \item \AllApplyCase{exact}:
   \begin{itemize}
     \item $\vc$ is an exact constraint for the expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\substexprnormalize$ in $\tenv$ to $\eqs$ and $\ve$ yields $\newe$;
@@ -850,7 +850,7 @@ One of the following applies:
           $\ConstraintExact(\newe)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\veone$ and $\vetwo$, that is, \\
           $\ConstraintRange(\veone, \vetwo)$;
@@ -897,13 +897,13 @@ arguments as per $\eqs$ and results in a type error otherwise.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item both $\funcsigargs$ and $\argtypes$ are empty;
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item view $\funcsigargs$ as a list with \head\ $(\Ignore, \tydecl)$ and \tail\ $\funcsigargsone$;
     \item view $\argtypes$ as a list with \head\ $\tyactual$ and \tail\ \\
@@ -962,7 +962,7 @@ yielding the \optional\ annotated type $\rettyopt$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{function\_or\_getter}):
+  \item \AllApplyCase{function\_or\_getter}:
   \begin{itemize}
     \item $\calltype$ is one of $\STFunction$ or $\STGetter$;
     \item $\funcsig$ is $\langle\tty\rangle$;
@@ -970,14 +970,14 @@ One of the following applies:
     \item $\rettyopt$ is $\langle\ttyone\rangle$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{procedure\_or\_setter}):
+  \item \AllApplyCase{procedure\_or\_setter}:
   \begin{itemize}
     \item $\calltype$ is one of $\STProcedure$ or $\STSetter$;
     \item $\funcsigrettyopt$ is $\None$;
     \item define $\rettyopt$ as $\None$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ret\_type\_mismatch}):
+  \item \AllApplyCase{ret\_type\_mismatch}:
   \begin{itemize}
     \item the condition that $\calltype$ is one of $\STProcedure$ or $\STSetter$
           if and only if $\funcsigrettyopt$ is $\None$ does not hold;
@@ -1062,14 +1062,14 @@ If the second case holds, the function returns a tuple which comprises:
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{undefined}):
+  \item \AllApplyCase{undefined}:
   \begin{itemize}
     \item $\tenv$ does not contain a binding for $\name$ in the $\overloadedsubprograms$ map
           ($G^\tenv.\overloadedsubprograms$);
     \item the result is a type error indicating that the identifier has not been declared (as a subprogram).
   \end{itemize}
 
-  \item All of the following apply (\textsc{no\_candidates}):
+  \item \AllApplyCase{no\_candidates}:
   \begin{itemize}
     \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$ and $\vses$;
     \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
@@ -1078,7 +1078,7 @@ One of the following applies:
           does not match any defined subprogram.
   \end{itemize}
 
-  \item All of the following apply (\textsc{too\_many\_candidates}):
+  \item \AllApplyCase{too\_many\_candidates}:
   \begin{itemize}
     \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$ and $\vses$;
     \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
@@ -1088,7 +1088,7 @@ One of the following applies:
           $\callerargtypes$ matches more than one defined subprogram.
   \end{itemize}
 
-  \item All of the following apply (\textsc{one\_candidate}):
+  \item \AllApplyCase{one\_candidate}:
   \begin{itemize}
     \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$ and $\vses$;
     \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
@@ -1174,13 +1174,13 @@ The names $\candidates$ are assumed to exist in $G^\tenv.\subprograms$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{no\_candidates}):
+  \item \AllApplyCase{no\_candidates}:
   \begin{itemize}
     \item $\candidates$ is empty;
     \item $\matches$ is empty.
   \end{itemize}
 
-  \item All of the following apply (\textsc{candidates\_exist}):
+  \item \AllApplyCase{candidates\_exist}:
   \begin{itemize}
     \item $\candidates$ is a list with \head\ $\name$ and \tail\ $\candidatesone$;
     \item the function definition associated with $\name$ in $\tenv$ is $\funcdef$;
@@ -1226,7 +1226,7 @@ in the list of arguments $\vargs$ in $\tenv$, yielding the result in $\vb$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item equating the list lengths of $\formaltys$ and $\vargs$ either yields $\True$
         or $\False$, which short-circuits the entire rule;
@@ -1264,13 +1264,13 @@ each consisting of a type, an annotated expression, and a \sideeffectsetterm.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\exprs$ is empty;
     \item $\typedexprs$ is empty.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\exprs$ has $\ve$ as its \head\ expression and $\exprsone$ as its \tail;
     \item annotating $\ve$ in $\tenv$ yields the pair $\typedexpr$ consisting of a type and an expression
@@ -1366,7 +1366,7 @@ We also define the following helper rules:
 
 \SemanticsRuleDef{Call}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item evaluating each expression in $\args$ separately in $\env$ as per \\
         \SemanticsRuleRef{EExprListM} is $\Normal(\vvargs, \envone)$\ProseOrAbnormal;
@@ -1380,7 +1380,7 @@ All of the following apply:
   to the local environment of the caller);
   \item one of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{normal}):
+    \item \AllApplyCase{normal}:
     \begin{itemize}
       \item evaluating the subprogram named $\name$ with parameters $\vvparams$ and arguments $\vvargs$ in
       $\denvtwo'$ is $\Normal(\vms, (\vglobal, \Ignore))$ (that is, we ignore the local environment
@@ -1393,7 +1393,7 @@ All of the following apply:
       \item the entire evaluation results in $\Normal(\vmstwo, \newenv)$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{throwing}):
+    \item \AllApplyCase{throwing}:
     \begin{itemize}
       \item evaluating the subprogram named $\name$ with arguments $\vvargs$ and parameters $\vvparams$ in
             $\denvtwo'$ is $\Throwing(\vv, \envthrow)$\ProseOrError;
@@ -1445,7 +1445,7 @@ All of the following apply:
 
 \SemanticsRuleDef{FPrimitive}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\env$ consists of the static environment $\tenv$ and the dynamic environment with $\genv$ as its
         global component and an empty local component;
@@ -1494,7 +1494,7 @@ the function \texttt{main} calls the function \texttt{foo} and the procedure \te
 \ASLListing{Evaluating function calls}{semantics-fcall}{\semanticstests/SemanticsRule.FCall.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\env$ consists of the static environment $\tenv$ and the dynamic environment with the global
         component $\genv$ and an empty local component;
@@ -1571,13 +1571,13 @@ Otherwise, the result is a dynamic error indicating that the recursion limit has
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\None, \vg)$\ProseOrError;
     \item define $\vg$ as the empty graph.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some\_ok}):
+  \item \AllApplyCase{some\_ok}:
   \begin{itemize}
     \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrError;
     \item view $\env$ as $(\tenv, \denv)$;
@@ -1585,7 +1585,7 @@ One of the following applies:
     \item $\vlimit$ is less than $\vstacksize$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some\_error}):
+  \item \AllApplyCase{some\_error}:
   \begin{itemize}
     \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrError;
     \item view $\env$ as $(\tenv, \denv)$;
@@ -1636,7 +1636,7 @@ generates an execution graph for reading the given value to a variable given
 by the identifier, and pairs it with the given value.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item reading the value $\vv$ into the variable named $\id$ gives $\newg$;
   \item the result is $(\vv, \newg)$.
@@ -1666,13 +1666,13 @@ returned by the evaluation of a primitive subprogram:
 \ProseParagraph
   one of the following applies:
   \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item the list of value-execution graphs $\vvsm$ is empty;
     \item the result is a pair consisting of an empty list and an empty graph.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item the list of value-execution graphs $\vvsm$ has $\vm$ as its head and $\vvsmone$ as its tail;
     \item $\vx$ is a fresh identifier;
@@ -1729,14 +1729,14 @@ yielding the updated pair $(\newenv, \newg)$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item both $\vids$ and $\actuals$ are empty lists;
     \item \Proseeqdef{$\newenv$}{$\env$};
     \item \Proseeqdef{$\newg$}{$\vgone$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\vids$ has $\vx$ as its head and $\vidsone$ as its tail,
           and $\actuals$ has $\vm$ as its head and $\actualsone$ as its tail;
@@ -1779,14 +1779,14 @@ into corresponding normal configurations that can be returned by a subprogram ev
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{continuing}):
+  \item \AllApplyCase{continuing}:
   \begin{itemize}
     \item the given configuration is $\Continuing(\vg, \env)$. This happens when,
     for example, the subprogram called is either a setter or a procedure;
     \item the result is $\Normal((\emptylist, \vg), \env)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{returning}):
+  \item \AllApplyCase{returning}:
   \begin{itemize}
     \item the given configuration is $\Returning(\xs, \retenv)$, which is the case of a function;
     \item $\xs$ is the list $\vv_i$, for $i=1..k$;

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -88,12 +88,10 @@ We also define helper functions via respective rules:
 }
 \end{mathpar}
 \CodeSubsection{\AnnotateCallBegin}{\AnnotateCallEnd}{../Typing.ml}
-\lrmcomment{
-  This is related to \identi{VFDP}, \identd{TRFW}, \identr{KMDB},
-  \identi{YMHX}, \identr{CCVD}, \identr{QYBH}, \identr{PFWQ}, \identr{ZLWD},
-  \identi{FLKF}, \identd{PMBL}, \identr{MWBN}, \identr{TZSP}, \identr{SBWR},
-  \identi{CMLP}, \identr{BQJG}, \identr{RTCF}.
-}
+\identi{VFDP} \identd{TRFW} \identr{KMDB}
+\identi{YMHX} \identr{CCVD} \identr{QYBH} \identr{PFWQ} \identr{ZLWD}
+\identi{FLKF} \identd{PMBL} \identr{MWBN} \identr{TZSP} \identr{SBWR}
+\identi{CMLP} \identr{BQJG} \identr{RTCF}
 
 \TypingRuleDef{AnnotateCallActualsTyped}
 \hypertarget{def-annotatecallactualstyped}{}
@@ -1553,7 +1551,7 @@ the function \texttt{main} calls the function \texttt{foo} and the procedure \te
 \CodeSubsection{\EvalFCallBegin}{\EvalFCallEnd}{../Interpreter.ml}
 
 \subsubsection{Comments}
-\lrmcomment{This is related to \identr{DFWZ}:}
+\identr{DFWZ}
 It is not an error for execution of a procedure or setter to end without a
 return statement.
 

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1055,7 +1055,7 @@ If the second case holds, the function returns a tuple which comprises:
 \begin{itemize}
 \item $\namep$ --- the string that uniquely identifies this subprogram;
 \item $\callee$ --- the AST node defining the called subprogram; and
-\item $\vses$ --- the set of \sideeffectdescriptorsterm associated with $\name$.
+\item $\vses$ --- the set of \sideeffectdescriptorsterm{} associated with $\name$.
 \end{itemize}
 \ProseOtherwiseTypeError
 

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -256,9 +256,9 @@ checks that annotated parameters $\params$ are correct with respect to the decla
 It assumes that $\funcsigparams$ and $\params$ have the same length.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\funcsigparams$ is an empty list;
     \item the result is $\True$.
@@ -272,15 +272,15 @@ One of the following applies:
           $(\tyactual, \eactual, \vsesactual)$ and \tail\ $\paramsone$;
     \item \Prosechecksymbolicallyevaluable{$\vsesactual$};
     \item checking that $\tyactual$ represents a \constrainedinteger{} yields $\True$\ProseOrTypeError;
-    \item One of the following applies:
+    \item \OneApplies
     \begin{itemize}
-      \item \AllApplyCase{parameterized}:
+      \item \AllApplyCase{parameterized}
       \begin{itemize}
         \item $\tyactual$ is a \parameterizedintegertype{} for the parameter $\vx$, that is, \\
               $\langle\TInt(\parameterized(\vx))\rangle$.
       \end{itemize}
 
-      \item \AllApplyCase{other}:
+      \item \AllApplyCase{other}
       \begin{itemize}
         \item $\tydeclopt$ is not $\None$, that is, $\langle\tydecl\rangle$;
         \item $\tydecl$ is not the \parameterizedintegertype{} for the parameter $\vx$;
@@ -344,16 +344,16 @@ $\eqs$, yielding the type $\newty$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{t\_bits}:
+  \item \AllApplyCase{t\_bits}
   \begin{itemize}
     \item $\tty$ is a bitvector type with width expression $\ve$ and fields $\fields$, that is, $\TBits(\ve, \fields)$;
     \item applying $\substexprnormalize$ to $\eqs$ and $\ve$ in $\tenv$ yields the expression $\newe$;
     \item define $\newty$ as a bitvector type with expression $\newe$ and fields $\fields$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_int\_wellconstrained}:
+  \item \AllApplyCase{t\_int\_wellconstrained}
   \begin{itemize}
     \item $\tty$ is a well-constrained integer type with constraints $\constraints$;
     \item applying $\substconstraint$ to each constraint $\constraints[\vi]$, for $\vi$ in \\
@@ -364,7 +364,7 @@ One of the following applies:
           $\newconstraints$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_int\_parameterized}:
+  \item \AllApplyCase{t\_int\_parameterized}
   \begin{itemize}
     \item $\tty$ is a \parameterizedintegertype\ for the parameter $\name$;
     \item applying $\substexprnormalize$ to $\eqs$ and the expression $\EVar(\name)$ yields $\ve$;
@@ -372,7 +372,7 @@ One of the following applies:
           $\TInt(\wellconstrained(\ConstraintExact(\ve)))$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_tuple}:
+  \item \AllApplyCase{t\_tuple}
   \begin{itemize}
     \item $\tty$ is the tuple type over the list of tuples $\tys$, that is, $\TTuple(\tys)$;
     \item applying $\renametyeqs$ to $\eqs$ and the type $\tys[\vi]$, for each $\vi$ in \\
@@ -381,7 +381,7 @@ One of the following applies:
     \item define $\newty$ as the tuple type over $\newtys$, that is, $\TTuple(\newtys)$.
   \end{itemize}
 
-  \item \AllApplyCase{other}:
+  \item \AllApplyCase{other}
   \begin{itemize}
     \item $\tty$ is not one of the types in the previous cases,
           that is, $\tty$ is not a bitvector type, nor an integer type, nor a tuple type;
@@ -477,16 +477,16 @@ $\substs$, yielding the expression $\newe$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{e\_var\_in\_substs}:
+  \item \AllApplyCase{e\_var\_in\_substs}
   \begin{itemize}
     \item $\ve$ is a variable expression for the identifier $\vs$, that is, $\EVar(\vs)$;
     \item applying $\assocopt$ to $\vs$ and $\substs$ yields the expression $\newe$.
           That is, $\vs$ is a parameter with an associated expression;
   \end{itemize}
 
-  \item \AllApplyCase{e\_var\_not\_in\_substs}:
+  \item \AllApplyCase{e\_var\_not\_in\_substs}
   \begin{itemize}
     \item $\ve$ is the variable expression for the identifier $\vs$, that is, $\EVar(\vs)$;
     \item applying $\assocopt$ to $\vs$ and $\substs$ yields $\None$.
@@ -494,14 +494,14 @@ One of the following applies:
     \item define $\newe$ is $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_unop}:
+  \item \AllApplyCase{e\_unop}
   \begin{itemize}
     \item $\ve$ is the unary operator expression for the operator $\op$ and expression $\ve$, that is, $\EUnop(\op, \veone)$;
     \item applying $\substexpr$ to $\substs$ and $\veone$ in $\tenv$ yields $\veonep$;
     \item define $\newe$ as the unary operator expression for the operator $\op$ and expression $\veonep$, that is, $\EUnop(\op, \veonep)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_binop}:
+  \item \AllApplyCase{e\_binop}
   \begin{itemize}
     \item $\ve$ is the binary operator expression for the operator $\op$ and expressions $\veone$ and $\vetwo$, that is, $\EBinop(\op, \veone, \vetwo)$;
     \item applying $\substexpr$ to $\substs$ and $\veone$ in $\tenv$ yields $\veonep$;
@@ -509,7 +509,7 @@ One of the following applies:
     \item define $\newe$ as the unary operator expression for the operator $\op$ and expression $\veonep$, that is, $\EUnop(\op, \veonep)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_cond}:
+  \item \AllApplyCase{e\_cond}
   \begin{itemize}
     \item $\ve$ is the conditional expression for expressions $\veone$, $\vetwo$, and $\vethree$, that is, \\
           $\ECond(\veone, \vetwo, \vethree)$;
@@ -519,7 +519,7 @@ One of the following applies:
     \item define $\newe$ as the conditional expression for expressions $\veonep$, $\vetwop$, and $\vethreep$, that is, $\ECond(\veonep, \vetwop, \vethreep)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_call}:
+  \item \AllApplyCase{e\_call}
   \begin{itemize}
     \item $\ve$ is the call expression for subprogram $\vx$ with arguments $\vargs$ and parameter expressions $\paramargs$,
           that is, $\ECall(\vx, \vargs, \paramargs)$;
@@ -530,7 +530,7 @@ One of the following applies:
     that is, $\ECall(\vx, \vargsp, \paramargs)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getarray}:
+  \item \AllApplyCase{e\_getarray}
   \begin{itemize}
     \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and index expression $\vetwo$,
           that is, $\EGetArray(\veone, \vetwo)$;
@@ -540,7 +540,7 @@ One of the following applies:
     that is, $\EGetArray(\veonep, \vetwop)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getenumarray}:
+  \item \AllApplyCase{e\_getenumarray}
   \begin{itemize}
     \item $\ve$ is the \arrayaccess\ expression for base expression $\veone$ and an enumeration-typed index expression $\vetwo$,
           that is, $\EGetEnumArray(\veone, \vetwo)$;
@@ -551,7 +551,7 @@ One of the following applies:
           that is, $\EGetEnumArray(\veonep, \vetwop)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getfield}:
+  \item \AllApplyCase{e\_getfield}
   \begin{itemize}
     \item $\ve$ is the field access expression for base expression $\ve$ and field $\vx$,
           that is, $\EGetField(\veone, \vx)$;
@@ -560,7 +560,7 @@ One of the following applies:
           that is, $\EGetField(\veonep, \vx)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getfields}:
+  \item \AllApplyCase{e\_getfields}
   \begin{itemize}
     \item $\ve$ is the access to fields $\fields$ with base expression $\veone$, that is, \\
           $\EGetFields(\veone, \fields)$;
@@ -568,7 +568,7 @@ One of the following applies:
     \item define $\newe$ as the access to fields $\fields$ with base expression $\veonep$, that is, $\EGetFields(\veonep, \fields)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getitem}:
+  \item \AllApplyCase{e\_getitem}
   \begin{itemize}
     \item $\ve$ is the access to tuple item $\vi$ of the tuple expression $\veone$, that is, \\
           $\EGetItem(\veone, \vi)$;
@@ -577,7 +577,7 @@ One of the following applies:
           $\EGetItem(\veonep, \vi)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_pattern}:
+  \item \AllApplyCase{e\_pattern}
   \begin{itemize}
     \item $\ve$ is the pattern expression of expression $\veone$ and patterns $\vps$, that is, \\
           $\EPattern(\veone, \vps)$;
@@ -585,7 +585,7 @@ One of the following applies:
     \item define $\newe$ as the pattern expression of expression $\veonep$ and patterns $\vps$, that is, $\EPattern(\veonep, \vps)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_record}:
+  \item \AllApplyCase{e\_record}
   \begin{itemize}
     \item $\ve$ is the record expression of record type $\vt$ and list of fields $\fields$;
     \item for every pair $(\vx,\veone)$ in $\fields$, applying $\substexpr$ to $\substs$ $\veone$ in $\tenv$ yields $\veonep_\vx$;
@@ -593,14 +593,14 @@ One of the following applies:
     \item define $\newe$ as the record expression of record type $\vt$ and list of fields $\fieldsp$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_slice}:
+  \item \AllApplyCase{e\_slice}
   \begin{itemize}
     \item $\ve$ is the slicing expression for subexpression $\veone$ and list of slices $\vslices$, that is, $\ESlice(\veone, \vslices)$;
     \item applying $\substexpr$ to $\veone$ in $\tenv$ yields $\veonep$;
     \item define $\newe$ as slicing expression for subexpression $\veonep$ and list of slices $\vslices$, that is, $\ESlice(\veonep, \vslices)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_tuple}:
+  \item \AllApplyCase{e\_tuple}
   \begin{itemize}
     \item $\ve$ is the tuple expression of expressions $\ves$, that is, $\ETuple(\ves)$;
     \item applying $\substexpr$ to $\substs$ and every expression $\ves[\vi]$ in $\tenv$, for every $\vi$ in $\listrange(\ves)$
@@ -609,7 +609,7 @@ One of the following applies:
     \item define $\newe$ as the tuple expression of expressions $\vesp$, that is, $\ETuple(\vesp)$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_array}:
+  \item \AllApplyCase{e\_array}
   \begin{itemize}
     \item $\ve$ is an array construction expression with length expression $\length$ and value expression $\vvalue$, that is,
           $\EArray\{\EArrayLength: \length, \EArrayValue: \vvalue\}$;
@@ -620,7 +620,7 @@ One of the following applies:
           $\EArray\{\EArrayLength: \lengthp, \EArrayValue: \vvaluep\}$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_enumarray}:
+  \item \AllApplyCase{e\_enumarray}
   \begin{itemize}
     \item $\ve$ is an array construction expression for an enumeration-typed index
           with list of labels $\vlabels$ and initial element value expression $\vvalue$, that is, \\
@@ -631,14 +631,14 @@ One of the following applies:
           $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \vvaluep\}$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_atc}:
+  \item \AllApplyCase{e\_atc}
   \begin{itemize}
     \item $\ve$ is the type assertion of expression $\veone$ and type $\vt$, that is, $\EATC(\veone, \vt)$;
     \item applying $\substexpr$ to $\substs$ and $\veone$ in $\tenv$ yields $\veonep$;
     \item define $\newe$ as the type assertion of expression $\veonep$ and type $\vt$, that is, $\EATC(\veonep, \vt)$.
   \end{itemize}
 
-  \item \AllApplyCase{other}:
+  \item \AllApplyCase{other}
   \begin{itemize}
     \item $\ve$ is either a literal expression or an arbitrary value expression;
     \item define $\newe$ as $\ve$.
@@ -840,9 +840,9 @@ yielding the integer constraint $\newc$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact}:
+  \item \AllApplyCase{exact}
   \begin{itemize}
     \item $\vc$ is an exact constraint for the expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\substexprnormalize$ in $\tenv$ to $\eqs$ and $\ve$ yields $\newe$;
@@ -850,7 +850,7 @@ One of the following applies:
           $\ConstraintExact(\newe)$.
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vc$ is a range constraint for the expressions $\veone$ and $\vetwo$, that is, \\
           $\ConstraintRange(\veone, \vetwo)$;
@@ -895,15 +895,15 @@ formal arguments $\funcsigargs$ with the parameters substituted with their corre
 arguments as per $\eqs$ and results in a type error otherwise.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item both $\funcsigargs$ and $\argtypes$ are empty;
     \item the result is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item view $\funcsigargs$ as a list with \head\ $(\Ignore, \tydecl)$ and \tail\ $\funcsigargsone$;
     \item view $\argtypes$ as a list with \head\ $\tyactual$ and \tail\ \\
@@ -960,9 +960,9 @@ yielding the \optional\ annotated type $\rettyopt$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{function\_or\_getter}:
+  \item \AllApplyCase{function\_or\_getter}
   \begin{itemize}
     \item $\calltype$ is one of $\STFunction$ or $\STGetter$;
     \item $\funcsig$ is $\langle\tty\rangle$;
@@ -970,14 +970,14 @@ One of the following applies:
     \item $\rettyopt$ is $\langle\ttyone\rangle$.
   \end{itemize}
 
-  \item \AllApplyCase{procedure\_or\_setter}:
+  \item \AllApplyCase{procedure\_or\_setter}
   \begin{itemize}
     \item $\calltype$ is one of $\STProcedure$ or $\STSetter$;
     \item $\funcsigrettyopt$ is $\None$;
     \item define $\rettyopt$ as $\None$.
   \end{itemize}
 
-  \item \AllApplyCase{ret\_type\_mismatch}:
+  \item \AllApplyCase{ret\_type\_mismatch}
   \begin{itemize}
     \item the condition that $\calltype$ is one of $\STProcedure$ or $\STSetter$
           if and only if $\funcsigrettyopt$ is $\None$ does not hold;
@@ -1060,16 +1060,16 @@ If the second case holds, the function returns a tuple which comprises:
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{undefined}:
+  \item \AllApplyCase{undefined}
   \begin{itemize}
     \item $\tenv$ does not contain a binding for $\name$ in the $\overloadedsubprograms$ map
           ($G^\tenv.\overloadedsubprograms$);
     \item the result is a type error indicating that the identifier has not been declared (as a subprogram).
   \end{itemize}
 
-  \item \AllApplyCase{no\_candidates}:
+  \item \AllApplyCase{no\_candidates}
   \begin{itemize}
     \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$ and $\vses$;
     \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
@@ -1078,7 +1078,7 @@ One of the following applies:
           does not match any defined subprogram.
   \end{itemize}
 
-  \item \AllApplyCase{too\_many\_candidates}:
+  \item \AllApplyCase{too\_many\_candidates}
   \begin{itemize}
     \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$ and $\vses$;
     \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
@@ -1088,7 +1088,7 @@ One of the following applies:
           $\callerargtypes$ matches more than one defined subprogram.
   \end{itemize}
 
-  \item \AllApplyCase{one\_candidate}:
+  \item \AllApplyCase{one\_candidate}
   \begin{itemize}
     \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$ and $\vses$;
     \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
@@ -1172,15 +1172,15 @@ subprograms whose arguments clash in $\candidates$.
 The names $\candidates$ are assumed to exist in $G^\tenv.\subprograms$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{no\_candidates}:
+  \item \AllApplyCase{no\_candidates}
   \begin{itemize}
     \item $\candidates$ is empty;
     \item $\matches$ is empty.
   \end{itemize}
 
-  \item \AllApplyCase{candidates\_exist}:
+  \item \AllApplyCase{candidates\_exist}
   \begin{itemize}
     \item $\candidates$ is a list with \head\ $\name$ and \tail\ $\candidatesone$;
     \item the function definition associated with $\name$ in $\tenv$ is $\funcdef$;
@@ -1262,15 +1262,15 @@ each consisting of a type, an annotated expression, and a \sideeffectsetterm.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\exprs$ is empty;
     \item $\typedexprs$ is empty.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\exprs$ has $\ve$ as its \head\ expression and $\exprsone$ as its \tail;
     \item annotating $\ve$ in $\tenv$ yields the pair $\typedexpr$ consisting of a type and an expression
@@ -1378,9 +1378,9 @@ We also define the following helper rules:
   consisting of the static environment $\tenv$ and the dynamic environment with the global component
   $\genv$ and an empty local component (intuitively, this is because the called subprogram does not have access
   to the local environment of the caller);
-  \item one of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{normal}:
+    \item \AllApplyCase{normal}
     \begin{itemize}
       \item evaluating the subprogram named $\name$ with parameters $\vvparams$ and arguments $\vvargs$ in
       $\denvtwo'$ is $\Normal(\vms, (\vglobal, \Ignore))$ (that is, we ignore the local environment
@@ -1393,7 +1393,7 @@ We also define the following helper rules:
       \item the entire evaluation results in $\Normal(\vmstwo, \newenv)$.
     \end{itemize}
 
-    \item \AllApplyCase{throwing}:
+    \item \AllApplyCase{throwing}
     \begin{itemize}
       \item evaluating the subprogram named $\name$ with arguments $\vvargs$ and parameters $\vvparams$ in
             $\denvtwo'$ is $\Throwing(\vv, \envthrow)$\ProseOrError;
@@ -1569,15 +1569,15 @@ in $\env$, yielding the execution graph resulting from evaluating the optional e
 Otherwise, the result is a dynamic error indicating that the recursion limit has been reached.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\None, \vg)$\ProseOrError;
     \item define $\vg$ as the empty graph.
   \end{itemize}
 
-  \item \AllApplyCase{some\_ok}:
+  \item \AllApplyCase{some\_ok}
   \begin{itemize}
     \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrError;
     \item view $\env$ as $(\tenv, \denv)$;
@@ -1585,7 +1585,7 @@ One of the following applies:
     \item $\vlimit$ is less than $\vstacksize$.
   \end{itemize}
 
-  \item \AllApplyCase{some\_error}:
+  \item \AllApplyCase{some\_error}
   \begin{itemize}
     \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrError;
     \item view $\env$ as $(\tenv, \denv)$;
@@ -1664,15 +1664,15 @@ generates Write Effects for the values
 returned by the evaluation of a primitive subprogram:
 
 \ProseParagraph
-  one of the following applies:
+  \OneApplies
   \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item the list of value-execution graphs $\vvsm$ is empty;
     \item the result is a pair consisting of an empty list and an empty graph.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item the list of value-execution graphs $\vvsm$ has $\vm$ as its head and $\vvsmone$ as its tail;
     \item $\vx$ is a fresh identifier;
@@ -1727,16 +1727,16 @@ by assigning the values given by $\actuals$ to the identifiers given by $\vids$,
 yielding the updated pair $(\newenv, \newg)$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item both $\vids$ and $\actuals$ are empty lists;
     \item \Proseeqdef{$\newenv$}{$\env$};
     \item \Proseeqdef{$\newg$}{$\vgone$}.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vids$ has $\vx$ as its head and $\vidsone$ as its tail,
           and $\actuals$ has $\vm$ as its head and $\actualsone$ as its tail;
@@ -1777,16 +1777,16 @@ converts continuing configurations and returning configurations
 into corresponding normal configurations that can be returned by a subprogram evaluation.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{continuing}:
+  \item \AllApplyCase{continuing}
   \begin{itemize}
     \item the given configuration is $\Continuing(\vg, \env)$. This happens when,
     for example, the subprogram called is either a setter or a procedure;
     \item the result is $\Normal((\emptylist, \vg), \env)$.
   \end{itemize}
 
-  \item \AllApplyCase{returning}:
+  \item \AllApplyCase{returning}
   \begin{itemize}
     \item the given configuration is $\Returning(\xs, \retenv)$, which is the case of a function;
     \item $\xs$ is the list $\vv_i$, for $i=1..k$;

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1616,7 +1616,7 @@ Otherwise, the result is a dynamic error indicating that the recursion limit has
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[some\_ok]{
+\inferrule[some\_error]{
   \evallimit(\env, \velimitopt) \evalarrow (\langle\vlimit\rangle, \vg) \OrDynError\\\\
   \env \eqname (\tenv, \denv)\\
   \getstacksize(\denv, \name) \evalarrow \vstacksize\\

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1486,10 +1486,10 @@ That is, it is not a part of $\evalarrow$ but rather a separate transition relat
 \CodeSubsection{\EvalFPrimitiveBegin}{\EvalFPrimitiveEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{FCall}
-\subsubsection{Example}
+\ExampleDef{Subprogram Calls}
 In \listingref{semantics-fcall},
 the function \texttt{main} calls the function \texttt{foo} and the procedure \texttt{bar}.
-\ASLListing{Evaluating function calls}{semantics-fcall}{\semanticstests/SemanticsRule.FCall.asl}
+\ASLListing{Evaluating subprogram calls}{semantics-fcall}{\semanticstests/SemanticsRule.FCall.asl}
 
 \ProseParagraph
 \AllApply

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -374,17 +374,17 @@ $\eqs$, yielding the type $\newty$.
 
   \item \AllApplyCase{t\_tuple}
   \begin{itemize}
-    \item $\tty$ is the tuple type over the list of tuples $\tys$, that is, $\TTuple(\tys)$;
+    \item $\tty$ is the \tupletypeterm{} over the list of tuples $\tys$, that is, $\TTuple(\tys)$;
     \item applying $\renametyeqs$ to $\eqs$ and the type $\tys[\vi]$, for each $\vi$ in \\
           $\listrange(\tys)$, yields the type $\newty_\vi$;
     \item define $\newtys$ as the list of types $\newty_\vi$, for each $\vi$ in $\listrange(\tys)$;
-    \item define $\newty$ as the tuple type over $\newtys$, that is, $\TTuple(\newtys)$.
+    \item define $\newty$ as the \tupletypeterm{} over $\newtys$, that is, $\TTuple(\newtys)$.
   \end{itemize}
 
   \item \AllApplyCase{other}
   \begin{itemize}
     \item $\tty$ is not one of the types in the previous cases,
-          that is, $\tty$ is not a bitvector type, nor an integer type, nor a tuple type;
+          that is, $\tty$ is not a bitvector type, nor an integer type, nor a \tupletypeterm{};
     \item $\newty$ is $\tty$.
   \end{itemize}
 \end{itemize}

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -706,7 +706,7 @@ It assumes that $\tty$ appears in a function signature.
 
   \item \AllApplyCase{other}
     \begin{itemize}
-      \item $\tty$ is not a tuple type, bitvector type, or \wellconstrainedintegertype;
+      \item $\tty$ is not a \tupletypeterm{}, bitvector type, or \wellconstrainedintegertype;
       \item $\ids$ is the empty list.
     \end{itemize}
 \end{itemize}

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -1152,7 +1152,7 @@ resulting in an annotated function definition $\newfuncdef$ and new static envir
 }
 \end{mathpar}
 \CodeSubsection{\DeclareOneFuncBegin}{\DeclareOneFuncEnd}{../Typing.ml}
-\lrmcomment{This relates to \identi{HJRD}, \identd{BTBR}, \identi{FSFQ}, \identi{PFGQ}, and \identr{PGFC}.}
+\identi{HJRD} \identd{BTBR} \identi{FSFQ} \identi{PFGQ} \identr{PGFC}
 
 \TypingRuleDef{SubprogramClash}
 \hypertarget{def-subprogramclash}{}
@@ -1224,7 +1224,7 @@ which defines whether two subprogram types are considered to be clashing:
   \subprogramclash(\tenv, \name, \subpgmtype, \formaltypes) \typearrow \vb
 }
 \end{mathpar}
-\lrmcomment{This is related to \identd{BTBR}, \identi{FSFQ}, \identi{PFGQ}.}
+\identd{BTBR} \identi{FSFQ} \identi{PFGQ}
 
 \TypingRuleDef{AddNewFunc}
 \hypertarget{def-addnewfunc}{}
@@ -1305,7 +1305,7 @@ and the environment $\newtenv$, which is updated with $\newname$.
   (\newtenv, \newname)
 }
 \end{mathpar}
-\lrmcomment{This is related to \identr{PGFC}.}
+\identr{PGFC}
 \CodeSubsection{\AddNewFuncBegin}{\AddNewFuncEnd}{../Typing.ml}
 
 \TypingRuleDef{CheckSetterHasGetter}

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -510,16 +510,16 @@ Therefore, $\tenvwithparams$ effectively reflects the added declarations \\
 \ASLListing{A function with parameters}{typing-parameterofconstraint}{\typingtests/TypingRule.AnnotateFuncSig.asl}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\params$ is the empty list;
     \item $\tenvwithparams$ is $\newtenv$;
     \item $\paramsone$ is $\acc$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\params$ is a list with $(\vx, \tyopt)$ as its \head\ and $\paramsp$ as its \tail;
     \item applying $\annotateoneparam$ to the parameter $(\vx, \tyopt)$ with $\tenv$ and $\newtenv$ yields the pair $\newtenvp$ and $\tty$\ProseOrTypeError;
@@ -567,15 +567,15 @@ The updated environment $\newtenvp$ and annotated parameter type $\tty$ are retu
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{type\_parameterized}:
+    \item \AllApplyCase{type\_parameterized}
     \begin{itemize}
       \item $\tyopt$ is either $\None$ or an \unconstrainedintegertype{};
       \item $\tty$ is defined as the \parameterizedintegertype\ for the identifier $\vx$.
     \end{itemize}
 
-    \item \AllApplyCase{type\_annotated}:
+    \item \AllApplyCase{type\_annotated}
     \begin{itemize}
       \item $\tyopt$ is the type $\langle\ttyp\rangle$, which is not the unconstrained integer type;
       \item annotating $\ttyp$ in $\tenv$ yields $\tty$\ProseOrTypeError.
@@ -681,30 +681,30 @@ finds the list of parameters in the type $\tty$.
 It assumes that $\tty$ appears in a function signature.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 
 \begin{itemize}
-  \item \AllApplyCase{tbits}:
+  \item \AllApplyCase{tbits}
     \begin{itemize}
       \item $\tty$ is a bitvector type, that is, $\TBits(\ve, \Ignore)$;
       \item applying $\paramsofexpr$ to $\ve$ in $\tenv$ yields $\ids$.
     \end{itemize}
 
-  \item \AllApplyCase{ttuple}:
+  \item \AllApplyCase{ttuple}
     \begin{itemize}
       \item $\tty$ is a tuple over a list of types $\tys$, that is, $\TTuple(\tys)$;
       \item applying $\paramsofty$ to each type $\tty_i$ in $\tys$ yields $\ids_i$;
       \item $\ids$ is the concatenation of all the $\ids_i$.
     \end{itemize}
 
-  \item \AllApplyCase{tint\_constrained}:
+  \item \AllApplyCase{tint\_constrained}
     \begin{itemize}
       \item $\tty$ is a \wellconstrainedintegertype, that is, $\TInt(\wellconstrained(\cs))$;
       \item applying $\paramsofconstraint$ to each constraint $\vc_i$ in $\cs$ yields $\ids_i$;
       \item $\ids$ is the concatenation of all the $\ids_i$.
     \end{itemize}
 
-  \item \AllApplyCase{other}:
+  \item \AllApplyCase{other}
     \begin{itemize}
       \item $\tty$ is not a tuple type, bitvector type, or \wellconstrainedintegertype;
       \item $\ids$ is the empty list.
@@ -758,22 +758,22 @@ finds the list of parameters in the expression $\ve$.
 It assumes that $\ve$ appears as $\TBits(\ve, \Ignore)$ or as part of a \wellconstrainedintegertype{} in a function signature.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 
 \begin{itemize}
-  \item \AllApplyCase{eval}:
+  \item \AllApplyCase{eval}
     \begin{itemize}
       \item $\ve$ is a variable, that is, $\EVar(\vx)$;
       \item if $\vx$ is undefined in $\tenv$ then $\ids$ is $[\vx]$, otherwise $\ids$ is $\emptylist$.
     \end{itemize}
 
-  \item \AllApplyCase{eunop}:
+  \item \AllApplyCase{eunop}
     \begin{itemize}
       \item $\ve$ is a unary operation, that is, $\EUnop(\Ignore, \ve)$;
       \item applying $\paramsofexpr$ to $\veone$ in $\tenv$ yields $\ids$.
     \end{itemize}
 
-  \item \AllApplyCase{ebinop}:
+  \item \AllApplyCase{ebinop}
     \begin{itemize}
       \item $\ve$ is a binary operation, that is, $\EBinop(\Ignore, \veone, \vetwo)$;
       \item applying $\paramsofexpr$ to $\veone$ in $\tenv$ yields $\idsone$;
@@ -781,7 +781,7 @@ One of the following applies:
       \item define $\ids$ as the concatenation of $\idsone$ and $\idstwo$.
     \end{itemize}
 
-  \item \AllApplyCase{other}:
+  \item \AllApplyCase{other}
     \begin{itemize}
       \item $\ve$ is not a variable, unary operation, or binary operation;
       \item $\ids$ is the empty list.
@@ -833,16 +833,16 @@ finds the list of parameters in the constraint $\vc$.
 It assumes that $\vc$ appears within a \wellconstrainedintegertype{} in a function signature.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 
 \begin{itemize}
-  \item \AllApplyCase{exact}:
+  \item \AllApplyCase{exact}
     \begin{itemize}
       \item $\vc$ is an exact constraint, that is, $\ConstraintExact(\ve)$;
       \item applying $\paramsofexpr$ to $\ve$ in $\tenv$ yields $ids$.
     \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
     \begin{itemize}
       \item $\vc$ is an range constraint, that is, $\ConstraintRange(\veone, \vetwo)$;
       \item applying $\paramsofexpr$ to $\veone$ in $\tenv$ yields $\idsone$;
@@ -916,9 +916,9 @@ In \listingref{typing-parameterofconstraint}, the annotated arguments are
 \texttt{bv}, \texttt{bv2}, \texttt{bv3}, and \texttt{C}.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\args$ is the empty list;
     \item $\tenvwithargs$ is $\newtenv$;
@@ -926,7 +926,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{$\vsesin$}
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\args$ is a list with $(\vx, \tty)$ as its \head\ and $\vargsp$ as its \tail;
     \item applying $\annotateonearg$ to the argument $(\vx, \tty)$ with $\tenv$ and $\newtenv$ yields
@@ -1018,9 +1018,9 @@ and the inferred \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{no\_return\_type}:
+  \item \AllApplyCase{no\_return\_type}
   \begin{itemize}
     \item $\vreturntype$ is $\None$;
     \item $\newtenv$ is $\tenvwithargs$;
@@ -1028,7 +1028,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{$\vsesin$}.
   \end{itemize}
 
-  \item \AllApplyCase{has\_return\_type}:
+  \item \AllApplyCase{has\_return\_type}
   \begin{itemize}
     \item $\returntype$ is $\langle\tty\rangle$;
     \item annotating $\tty$ in $\tenvwithparams$ yields $(\ttyp, \vsesty)$\ProseOrTypeError;
@@ -1250,16 +1250,16 @@ and the environment $\newtenv$, which is updated with $\newname$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{first\_name}:
+  \item \AllApplyCase{first\_name}
   \begin{itemize}
     \item the $\overloadedsubprograms$ map in the global environment of $\tenv$ does not have a binding for $\name$;
     \item $\newtenv$ is $\tenv$ with the $\overloadedsubprograms$ updated by binding $\name$ to the singleton set containing
           $\name$.
   \end{itemize}
 
-  \item \AllApplyCase{name\_exists}:
+  \item \AllApplyCase{name\_exists}
   \begin{itemize}
     \item the $\overloadedsubprograms$ map in the global environment of $\tenv$ binds $\name$ to the set of strings $\othernames$;
     \item $\newname$ is the unique name that will be associated with the subprogram given by the identifier $\name$, list of formals $\formals$,

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -500,10 +500,12 @@ and declares it in environment $\newtenv$.
 It returns the updated environment $\tenvwithparams$ and the annotated parameters $\paramsone$, together with any annotated parameters already in the accumulator $\acc$.
 \ProseOtherwiseTypeError
 
-\subsection{Example}
+\ExampleDef{Annotating Parameters}
 In \listingref{typing-parameterofconstraint}, the list of explicitly defined parameters
-of the function \texttt{signature\_example} is $\{\texttt{A},\texttt{B}\}$.
-Therefore, $\tenvwithparams$ effectively reflects the added declarations \verb|let A: integer{A}| and \verb|let B: integer{B}|.
+of the function \\
+\verb|signature_example| is $\{\texttt{A},\texttt{B}\}$.
+Therefore, $\tenvwithparams$ effectively reflects the added declarations \\
+\verb|let A: integer{A}| and \verb|let B: integer{B}|.
 
 \ASLListing{A function with parameters}{typing-parameterofconstraint}{\typingtests/TypingRule.AnnotateFuncSig.asl}
 
@@ -909,7 +911,7 @@ together with any annotated arguments already in the accumulator $\acc$,
 and a \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
-\subsection{Example}
+\ExampleDef{Annotating Subprogram Arguments}
 In \listingref{typing-parameterofconstraint}, the annotated arguments are
 \texttt{bv}, \texttt{bv2}, \texttt{bv3}, and \texttt{C}.
 

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -739,7 +739,7 @@ One of the following applies:
 \begin{mathpar}
 \inferrule[other]{
   \astlabel(\tty) \notin \{ \TBits, \TTuple \} \\
-  \tty \neq \TInt(\wellconstrained(\Ignore))
+  \neg \iswellconstrainedinteger(\tty)
 }{
   \paramsofty(\tenv, \tty) \typearrow \overname{\emptylist}{\ids}
 }

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -380,7 +380,7 @@ $\newtenv$, and an inferred \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item annotating the signature of $\funcsig$ in $\genv$ as per
         \TypingRuleRef{AnnotateFuncSig} yields
@@ -417,7 +417,7 @@ an inferred \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tenv$ is the static environment which comprises of the global static environment $\genv$ and an empty local environment;
   \item applying $\annotatelimitexpr$ to $\funcsig.\funcrecurselimit$ in $\tenvone$ yields \\
@@ -512,14 +512,14 @@ Therefore, $\tenvwithparams$ effectively reflects the added declarations \\
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\params$ is the empty list;
     \item $\tenvwithparams$ is $\newtenv$;
     \item $\paramsone$ is $\acc$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\params$ is a list with $(\vx, \tyopt)$ as its \head\ and $\paramsp$ as its \tail;
     \item applying $\annotateoneparam$ to the parameter $(\vx, \tyopt)$ with $\tenv$ and $\newtenv$ yields the pair $\newtenvp$ and $\tty$\ProseOrTypeError;
@@ -565,17 +565,17 @@ The updated environment $\newtenvp$ and annotated parameter type $\tty$ are retu
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{type\_parameterized}):
+    \item \AllApplyCase{type\_parameterized}:
     \begin{itemize}
       \item $\tyopt$ is either $\None$ or an \unconstrainedintegertype{};
       \item $\tty$ is defined as the \parameterizedintegertype\ for the identifier $\vx$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{type\_annotated}):
+    \item \AllApplyCase{type\_annotated}:
     \begin{itemize}
       \item $\tyopt$ is the type $\langle\ttyp\rangle$, which is not the unconstrained integer type;
       \item annotating $\ttyp$ in $\tenv$ yields $\tty$\ProseOrTypeError.
@@ -620,7 +620,7 @@ The function
 checks the parameters declared in $\funcsig$ for validity.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item Finding the list of types in $\funcsig$ using $\typesinfuncsig$ yields $\tys$;
   \item Applying $\paramsofty$ to each type in $\tys$ and concatenating the results yields the list of parameter identifiers $\params$;
@@ -684,27 +684,27 @@ It assumes that $\tty$ appears in a function signature.
 One of the following applies:
 
 \begin{itemize}
-  \item All of the following apply (\textsc{tbits}):
+  \item \AllApplyCase{tbits}:
     \begin{itemize}
       \item $\tty$ is a bitvector type, that is, $\TBits(\ve, \Ignore)$;
       \item applying $\paramsofexpr$ to $\ve$ in $\tenv$ yields $\ids$.
     \end{itemize}
 
-  \item All of the following apply (\textsc{ttuple}):
+  \item \AllApplyCase{ttuple}:
     \begin{itemize}
       \item $\tty$ is a tuple over a list of types $\tys$, that is, $\TTuple(\tys)$;
       \item applying $\paramsofty$ to each type $\tty_i$ in $\tys$ yields $\ids_i$;
       \item $\ids$ is the concatenation of all the $\ids_i$.
     \end{itemize}
 
-  \item All of the following apply (\textsc{tint\_constrained}):
+  \item \AllApplyCase{tint\_constrained}:
     \begin{itemize}
       \item $\tty$ is a \wellconstrainedintegertype, that is, $\TInt(\wellconstrained(\cs))$;
       \item applying $\paramsofconstraint$ to each constraint $\vc_i$ in $\cs$ yields $\ids_i$;
       \item $\ids$ is the concatenation of all the $\ids_i$.
     \end{itemize}
 
-  \item All of the following apply (\textsc{other}):
+  \item \AllApplyCase{other}:
     \begin{itemize}
       \item $\tty$ is not a tuple type, bitvector type, or \wellconstrainedintegertype;
       \item $\ids$ is the empty list.
@@ -761,19 +761,19 @@ It assumes that $\ve$ appears as $\TBits(\ve, \Ignore)$ or as part of a \wellcon
 One of the following applies:
 
 \begin{itemize}
-  \item All of the following apply (\textsc{eval}):
+  \item \AllApplyCase{eval}:
     \begin{itemize}
       \item $\ve$ is a variable, that is, $\EVar(\vx)$;
       \item if $\vx$ is undefined in $\tenv$ then $\ids$ is $[\vx]$, otherwise $\ids$ is $\emptylist$.
     \end{itemize}
 
-  \item All of the following apply (\textsc{eunop}):
+  \item \AllApplyCase{eunop}:
     \begin{itemize}
       \item $\ve$ is a unary operation, that is, $\EUnop(\Ignore, \ve)$;
       \item applying $\paramsofexpr$ to $\veone$ in $\tenv$ yields $\ids$.
     \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop}):
+  \item \AllApplyCase{ebinop}:
     \begin{itemize}
       \item $\ve$ is a binary operation, that is, $\EBinop(\Ignore, \veone, \vetwo)$;
       \item applying $\paramsofexpr$ to $\veone$ in $\tenv$ yields $\idsone$;
@@ -781,7 +781,7 @@ One of the following applies:
       \item define $\ids$ as the concatenation of $\idsone$ and $\idstwo$.
     \end{itemize}
 
-  \item All of the following apply (\textsc{other}):
+  \item \AllApplyCase{other}:
     \begin{itemize}
       \item $\ve$ is not a variable, unary operation, or binary operation;
       \item $\ids$ is the empty list.
@@ -836,13 +836,13 @@ It assumes that $\vc$ appears within a \wellconstrainedintegertype{} in a functi
 One of the following applies:
 
 \begin{itemize}
-  \item All of the following apply (\textsc{exact}):
+  \item \AllApplyCase{exact}:
     \begin{itemize}
       \item $\vc$ is an exact constraint, that is, $\ConstraintExact(\ve)$;
       \item applying $\paramsofexpr$ to $\ve$ in $\tenv$ yields $ids$.
     \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
     \begin{itemize}
       \item $\vc$ is an range constraint, that is, $\ConstraintRange(\veone, \vetwo)$;
       \item applying $\paramsofexpr$ to $\veone$ in $\tenv$ yields $\idsone$;
@@ -918,7 +918,7 @@ In \listingref{typing-parameterofconstraint}, the annotated arguments are
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\args$ is the empty list;
     \item $\tenvwithargs$ is $\newtenv$;
@@ -926,7 +926,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{$\vsesin$}
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\args$ is a list with $(\vx, \tty)$ as its \head\ and $\vargsp$ as its \tail;
     \item applying $\annotateonearg$ to the argument $(\vx, \tty)$ with $\tenv$ and $\newtenv$ yields
@@ -974,7 +974,7 @@ and inferred \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item annotating the type $\tty$ in $\tenv$ yields $(\ttyp, \vses)$\ProseOrTypeError;
   \item checking that $\vx$ is not defined in $\newtenv$ yields $\True$\ProseOrTypeError;
@@ -1020,7 +1020,7 @@ and the inferred \sideeffectsetterm\ $\vses$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{no\_return\_type}):
+  \item \AllApplyCase{no\_return\_type}:
   \begin{itemize}
     \item $\vreturntype$ is $\None$;
     \item $\newtenv$ is $\tenvwithargs$;
@@ -1028,7 +1028,7 @@ One of the following applies:
     \item \Proseeqdef{$\vses$}{$\vsesin$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{has\_return\_type}):
+  \item \AllApplyCase{has\_return\_type}:
   \begin{itemize}
     \item $\returntype$ is $\langle\tty\rangle$;
     \item annotating $\tty$ in $\tenvwithparams$ yields $(\ttyp, \vsesty)$\ProseOrTypeError;
@@ -1084,7 +1084,7 @@ resulting in an annotated function definition $\newfuncdef$ and new static envir
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\funcsig$ has name $\name$, arguments $\vargs$, and type $\subprogramtype$, that is,
   \[
@@ -1177,7 +1177,7 @@ The function is only defined when there exists a binding for $\name$ in the
 $\subprograms$ map of $\tenv$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item the identifier $\name$ is bound to the $\func$ AST node $\otherfuncsig$ in the \\
         $\subprograms$ map
@@ -1252,14 +1252,14 @@ and the environment $\newtenv$, which is updated with $\newname$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{first\_name}):
+  \item \AllApplyCase{first\_name}:
   \begin{itemize}
     \item the $\overloadedsubprograms$ map in the global environment of $\tenv$ does not have a binding for $\name$;
     \item $\newtenv$ is $\tenv$ with the $\overloadedsubprograms$ updated by binding $\name$ to the singleton set containing
           $\name$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{name\_exists}):
+  \item \AllApplyCase{name\_exists}:
   \begin{itemize}
     \item the $\overloadedsubprograms$ map in the global environment of $\tenv$ binds $\name$ to the set of strings $\othernames$;
     \item $\newname$ is the unique name that will be associated with the subprogram given by the identifier $\name$, list of formals $\formals$,
@@ -1319,7 +1319,7 @@ checks whether the setter procedure given by $\funcsig$ has a corresponding gett
 returning $\True$ if this condition holds and a type error otherwise.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item checking that the subprogram type of $\funcsig$ is $\STSetter$ has one of two outcomes:
         $\False$, which satisfies the premise;

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -214,13 +214,13 @@ yielding an expression $\newe$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{normalizable})
+  \item \AllApplyCase{normalizable}
   \begin{itemize}
     \item applying $\toir$ to $\ve$ in $\tenv$ to obtain a symbolic expression yields a symbolic expression $\vpone$\ProseOrTypeError;
     \item applying $\polynomialtoexpr$ to $\vpone$ to transform it into an expression yields $\newe$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{not\_normalizable})
+  \item \AllApplyCase{not\_normalizable}
   \begin{itemize}
     \item applying $\toir$ to $\ve$ in $\tenv$ to obtain a symbolic expression yields $\CannotBeTransformed$,
           indicating it cannot be transformed to a corresponding symbolic expression;
@@ -260,14 +260,14 @@ The function
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact}):
+  \item \AllApplyCase{exact}:
   \begin{itemize}
     \item $\vc$ is an exact integer constraint for $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\normalize$ to $\ve$ in $\tenv$ yields $\vep$;
     \item define $\newc$ as the exact integer constraint for $\vep$, that is, $\ConstraintExact(\ve)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vc$ is an range integer constraint for $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item applying $\normalize$ to $\veone$ in $\tenv$ yields $\veonep$;
@@ -309,7 +309,7 @@ The function
 \symbolicallysimplifies\ a list of integer constraints $\cs$, yielding a list of integer constraints $\newcs$
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\reduceconstraint$ to every constraint $\cs[\vi]$ in $\tenv$ for every $\vi$ in \\
         $\listrange(\cs)$ yields $\vc_\vi$;
@@ -344,19 +344,19 @@ Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expre
 
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{literal\_int}):
+  \item \AllApplyCase{literal\_int}:
   \begin{itemize}
     \item $\ve$ is an integer literal expression for $\vi$, that is, $\ELiteral(\lint(\vi))$;
     \item $\vp$ is the symbolic expression for $\vi$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{literal\_other}):
+  \item \AllApplyCase{literal\_other}:
   \begin{itemize}
     \item $\ve$ is a variable expression other than an integer literal;
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{evar\_int\_constant}):
+  \item \AllApplyCase{evar\_int\_constant}:
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ via $\lookupconstant$ yields the literal expression for $\vv$, that is, $\ELiteral(\vv)$;
@@ -365,7 +365,7 @@ One of the following applies:
     \item $\vp$ is the symbolic expression for $\vi$, that is, $\{ \emptyfunc\mapsto \vi \}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{evar\_immutable\_expr}):
+  \item \AllApplyCase{evar\_immutable\_expr}:
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ via $\lookupconstant$ yields $\bot$;
@@ -374,7 +374,7 @@ One of the following applies:
     \item applying $\toir$ to $\vep$ in $\tenv$ yields $\vp$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{evar\_exact\_constraint}):
+  \item \AllApplyCase{evar\_exact\_constraint}:
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ via $\lookupconstant$ yields $\bot$;
@@ -387,7 +387,7 @@ One of the following applies:
     \item converting $\ve$ to a symbolic expression yields $\vp$\ProseTerminateAs{\CannotBeTransformed}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_var}):
+  \item \AllApplyCase{int\_var}:
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ yields $\bot$;
@@ -398,7 +398,7 @@ One of the following applies:
     \item $\vp$ is the symbolic expression for the variable $\vs$, that is, $\{ \{\vs\mapsto 1\}\mapsto 1 \}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_plus}):
+  \item \AllApplyCase{ebinop\_plus}:
   \begin{itemize}
     \item $\ve$ is a binary addition expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\PLUS, \veone, \vetwo)$;
     \item converting $\veone$ to a symbolic expression in $\tenv$ yields $\irone$\ProseOrTypeErrorOrCannotBeTransformed;
@@ -406,14 +406,14 @@ One of the following applies:
     \item $\vp$ is the symbolic expression adding up $\irone$ and $\irtwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_minus}):
+  \item \AllApplyCase{ebinop\_minus}:
   \begin{itemize}
     \item $\ve$ is a binary subtraction expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\MINUS, \veone, \vetwo)$;
     \item $\vep$ is the addition expression with operands $\veone$ and the negation of $\vetwo$, that is, \\ $\EBinop(\PLUS, \veone, \EUnop(\MINUS, \vetwo))$;
     \item converting $\vep$ into a symbolic expression in $\tenv$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_mul\_div\_left}):
+  \item \AllApplyCase{ebinop\_mul\_div\_left}:
   \begin{itemize}
     \item $\ve$ is a binary multiplication expression where the left operand is a binary division expression over $\veone$ and $\vetwo$
           and the right operand is $\vethree$, that is, \\ $\EBinop(\MUL, \EBinop(\DIV, \veone, \vetwo), \vethree)$;
@@ -421,7 +421,7 @@ One of the following applies:
           and $\vethree$ and the right operand is $\vetwo$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_mul\_div\_right}):
+  \item \AllApplyCase{ebinop\_mul\_div\_right}:
   \begin{itemize}
     \item $\ve$ is a binary multiplication expression where the left operand is $\veone$ and the right operand
           is the division expression over $\vetwo$ and $\vethree$, that is, \\
@@ -431,7 +431,7 @@ One of the following applies:
           and $\vetwo$ and the right operand is $\vethree$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_mul}):
+  \item \AllApplyCase{ebinop\_mul}:
   \begin{itemize}
     \item $\ve$ is a binary multiplication expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\MUL, \veone, \vetwo)$;
     \item neither $\veone$ nor $\vetwo$ are binary vision expressions;
@@ -440,7 +440,7 @@ One of the following applies:
     \item $\vp$ is the symbolic expression multiplying $\irone$ and $\irtwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_div\_int\_denominator}):
+  \item \AllApplyCase{ebinop\_div\_int\_denominator}:
   \begin{itemize}
     \item $\ve$ is a binary division expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\DIV, \veone, \vetwo)$;
     \item $\vetwo$ is an integer literal expression for $\vitwo$;
@@ -449,7 +449,7 @@ One of the following applies:
     \item $\vp$ is the polynomial $\irone$ with each monomial multiplied by $\vftwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_div\_monomial\_denominator}):
+  \item \AllApplyCase{ebinop\_div\_monomial\_denominator}:
   \begin{itemize}
     \item $\ve$ is a binary division expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\DIV, \veone, \vetwo)$;
     \item converting $\veone$ to a symbolic expression in $\tenv$ yields $\irone$\ProseOrTypeErrorOrCannotBeTransformed;
@@ -458,7 +458,7 @@ One of the following applies:
     \item applying $\polynomialdividebyterm$ to $\irone$, $\vfactor$, and $\vmono$ yields $\vp$\ProseTerminateAs{\CannotBeTransformed}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_div\_non\_monomial\_denominator}):
+  \item \AllApplyCase{ebinop\_div\_non\_monomial\_denominator}:
   \begin{itemize}
     \item $\ve$ is a binary division expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\DIV, \veone, \vetwo)$;
     \item converting $\veone$ to a symbolic expression in $\tenv$ yields $\irone$\ProseOrTypeErrorOrCannotBeTransformed;
@@ -467,14 +467,14 @@ One of the following applies:
     \item the result is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_shl\_non\_lint\_exponent}):
+  \item \AllApplyCase{ebinop\_shl\_non\_lint\_exponent}:
   \begin{itemize}
     \item $\ve$ is a binary shift-left expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\SHL, \veone, \vetwo)$;
     \item $\vetwo$ is not an integer literal expression;
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_shl\_non\_neg\_shift}):
+  \item \AllApplyCase{ebinop\_shl\_non\_neg\_shift}:
   \begin{itemize}
     \item $\ve$ is a binary shift-left expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\SHL, \veone, \vetwo)$;
     \item $\vetwo$ is an integer literal expression for $\vitwo$;
@@ -482,7 +482,7 @@ One of the following applies:
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_shl\_okay}):
+  \item \AllApplyCase{ebinop\_shl\_okay}:
   \begin{itemize}
     \item $\ve$ is a binary shift-left expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\SHL, \veone, \vetwo)$;
     \item $\vetwo$ is an integer literal expression for $\vitwo$;
@@ -492,7 +492,7 @@ One of the following applies:
     \item $\vp$ is the polynomial $\irone$ with each monomial multiplied by $\vftwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_other\_non\_literals}):
+  \item \AllApplyCase{ebinop\_other\_non\_literals}:
   \begin{itemize}
     \item $\ve$ is a binary expression with an operator $\op$ that is other than $\PLUS$, $\MINUS$, $\MUL$, or $\SHL$,
           applied to the operand expressions $\veone$ and $\vetwo$;
@@ -500,7 +500,7 @@ One of the following applies:
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_other\_literals\_non\_int\_result}):
+  \item \AllApplyCase{ebinop\_other\_literals\_non\_int\_result}:
   \begin{itemize}
     \item $\ve$ is a binary expression with an operator $\op$ that is other than $\PLUS$, $\MINUS$, $\MUL$, $\DIV$, or $\SHL$,
           applied to the operand expressions $\veone$ and $\vetwo$;
@@ -510,7 +510,7 @@ One of the following applies:
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ebinop\_other\_literals\_int\_result}):
+  \item \AllApplyCase{ebinop\_other\_literals\_int\_result}:
   \begin{itemize}
     \item $\ve$ is a binary expression with an operator $\op$ that is other than $\PLUS$, $\MINUS$, $\MUL$, or $\SHL$,
           applied to the operand expressions $\veone$ and $\vetwo$;
@@ -520,27 +520,27 @@ One of the following applies:
     \item $\vp$ is the symbolic expression for the integer $k$, that is, $\{ \emptyfunc\mapsto k \}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eunop\_neg}):
+  \item \AllApplyCase{eunop\_neg}:
   \begin{itemize}
     \item $\ve$ is a unary expression with the negation operator $\NEG$ and operand $\veone$;
     \item converting the binary expression with operator $\MUL$ and left-hand-side operand for the integer literal $-1$ and
     right-hand-side operand $\veone$ in $\tenv$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item All of the following apply (\textsc{eunop\_other}):
+  \item \AllApplyCase{eunop\_other}:
   \begin{itemize}
     \item $\ve$ is a unary expression with an operator other than $\NEG$;
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ATC}):
+  \item \AllApplyCase{ATC}:
   \begin{itemize}
     \item $\ve$ is an asserting type conversion for the subexpression $\vep$, that is, \\
           $\EATC(\vep, \Ignore)$;
     \item applying $\toir$ to $\vep$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item All of the following apply (\textsc{other}):
+  \item \AllApplyCase{other}:
   \begin{itemize}
     \item $\ve$ is an expression with a label other than $\ELiteral$, $\EVar$, $\EBinop$, $\EUnop$, and $\EATC$;
     \item $\vp$ is $\CannotBeTransformed$.
@@ -786,13 +786,13 @@ The result is given in $\vb$ or a type error, if one is detected.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{norm\_true}):
+  \item \AllApplyCase{norm\_true}:
   \begin{itemize}
     \item comparing $\veone$ to $\vetwo$ in $\tenv$ via $\exprequalnorm$ yields $\True$\ProseOrTypeError;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{norm\_false}):
+  \item \AllApplyCase{norm\_false}:
   \begin{itemize}
     \item comparing $\veone$ to $\vetwo$ in $\tenv$ via $\exprequalnorm$ yields $\False$;
     \item comparing $\veone$ to $\vetwo$ by case analysis via $\exprequalcase$ yields $\vb$\ProseOrTypeError.
@@ -830,20 +830,20 @@ The result is given in $\vb$ or a type error, if one is detected.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{all\_supported}):
+  \item \AllApplyCase{all\_supported}:
   \begin{itemize}
     \item transforming $\veone$ into a symbolic expression in $\tenv$ yields $\irone$\ProseOrTypeError;
     \item transforming $\vetwo$ into a symbolic expression in $\tenv$ yields $\irtwo$\ProseOrTypeError;
     \item $\vb$ is the result of equating $\irone$ and $\irtwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{unsupported1}):
+  \item \AllApplyCase{unsupported1}:
   \begin{itemize}
     \item transforming $\veone$ into a symbolic expression in $\tenv$ yields $\CannotBeTransformed$;
     \item $\vb$ is $\False$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{unsupported2}):
+  \item \AllApplyCase{unsupported2}:
   \begin{itemize}
     \item transforming $\veone$ into a symbolic expression in $\tenv$ yields $\irone$;
     \item transforming $\vetwo$ into a symbolic expression in $\tenv$ yields $\CannotBeTransformed$;
@@ -888,13 +888,13 @@ The result is given in $\vb$ or a type error, if one is detected.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{different\_labels}):
+  \item \AllApplyCase{different\_labels}:
   \begin{itemize}
     \item the AST labels of $\veone$ and $\vetwo$ are different;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_binop}):
+  \item \AllApplyCase{e\_binop}:
   \begin{itemize}
     \item $\veone$ is a binary expression with operator $\opone$ and operands $\veoneone$ and $\veonetwo$,
           that is, $\EBinop(\opone, \veoneone, \veonetwo)$;
@@ -905,7 +905,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\opone$ is equal to $\optwo$ and both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_call}):
+  \item \AllApplyCase{e\_call}:
   \begin{itemize}
     \item $\veone$ is a call expression with subprogram name $\nameone$ and list of arguments $\vargsone$,
           that is, $\ECall(\nameone, \vargsone, \Ignore)$;
@@ -919,7 +919,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\vb_i$ is $\True$ for each index $i$ in the list of indices for $\vargsone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_cond}):
+  \item \AllApplyCase{e\_cond}:
   \begin{itemize}
     \item $\veone$ is a conditional expression with expressions $\veoneone$, $\veonetwo$, and $\veonethree$,
           that is, $\ECond(\veoneone, \veonetwo, \veonethree)$;
@@ -931,7 +931,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if all of $\vbone$, $\vbtwo$, and $\vbthree$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_slice}):
+  \item \AllApplyCase{e\_slice}:
   \begin{itemize}
     \item $\veone$ is a slicing expression with expression $\veoneone$ and list of slices $\slicesone$,
           that is, $\ESlice(\veoneone, \slicesone)$;
@@ -942,7 +942,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getarray}):
+  \item \AllApplyCase{e\_getarray}:
   \begin{itemize}
     \item $\veone$ is an \arrayaccess\ expression with array expression $\veoneone$ and position expression $\veonetwo$,
           that is, $\EGetArray(\veoneone, \veonetwo)$;
@@ -953,7 +953,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getfield}):
+  \item \AllApplyCase{e\_getfield}:
   \begin{itemize}
     \item $\veone$ is a field access expression with subexpression $\veoneone$ and field name $\vfieldone$,
           that is, $\EGetField(\veoneone, \vfieldone)$;
@@ -964,7 +964,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getfields}):
+  \item \AllApplyCase{e\_getfields}:
   \begin{itemize}
     \item $\veone$ is a fields access expression with subexpression $\veoneone$ and list of field names $\vfieldsone$,
           that is, $\EGetFields(\veoneone, \vfieldsone)$;
@@ -975,7 +975,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_getitem}):
+  \item \AllApplyCase{e\_getitem}:
   \begin{itemize}
     \item $\veone$ is a tuple access expression with subexpression $\veoneone$ and position $\vione$,
           that is, $\EGetItem(\veoneone, \vione)$;
@@ -986,26 +986,26 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_literal}):
+  \item \AllApplyCase{e\_literal}:
   \begin{itemize}
     \item $\veone$ is the literal expression with literal $\vvone$;
     \item $\vetwo$ is the literal expression with literal $\vvtwo$;
     \item $\vb$ is $\True$ if and only if $\vvone$ is equivalent to $\vvtwo$ in $\tenv$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_pattern}):
+  \item \AllApplyCase{e\_pattern}:
   \begin{itemize}
     \item both $\veone$ and $\vetwo$ are pattern expressions;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_record}):
+  \item \AllApplyCase{e\_record}:
   \begin{itemize}
     \item both $\veone$ and $\vetwo$ are record expressions;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_tuple}):
+  \item \AllApplyCase{e\_tuple}:
   \begin{itemize}
     \item $\veone$ is a tuple expression with subexpression list $\vlone$,
           that is, $\ETuple(\vlone)$;
@@ -1018,7 +1018,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\vb_i$ is $\True$ for each index $i$ in the list of indices for $\vlone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_array}):
+  \item \AllApplyCase{e\_array}:
   \begin{itemize}
     \item $\veone$ is an array construction expression with length expression $\vlone$ and value expression $\vvone$,
           that is, $\EArray\{\EArrayLength: \vlone, \EArrayValue: \vvone\}$;
@@ -1029,7 +1029,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_unop}):
+  \item \AllApplyCase{e\_unop}:
   \begin{itemize}
     \item $\veone$ is a unary operator expression with operator $\opone$ and operand expressions $\veoneone$,
           that is, $\EUnop(\opone, \veoneone)$;
@@ -1039,13 +1039,13 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\opone$ is equal to $\optwo$ and $\vbone$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_arbitrary}):
+  \item \AllApplyCase{e\_arbitrary}:
   \begin{itemize}
     \item both $\veone$ and $\vetwo$ are $\ARBITRARY$ expressions;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_atc}):
+  \item \AllApplyCase{e\_atc}:
   \begin{itemize}
     \item $\veone$ is a type assertion with subexpression with operator $\veoneone$ and type $\vtone$,
           that is, $\EATC(\veoneone, \vtone)$;
@@ -1056,7 +1056,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_var}):
+  \item \AllApplyCase{e\_var}:
   \begin{itemize}
     \item $\veone$ is a variable expression with identifier $\nameone$, that is, $\EVar(\nameone)$;
     \item $\vetwo$ is a variable expression with identifier $\nametwo$, that is, $\EVar(\nametwo)$;
@@ -1276,39 +1276,39 @@ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{different\_labels}):
+  \item \AllApplyCase{different\_labels}:
   \begin{itemize}
     \item the AST labels of $\vtone$ and $\vttwo$ are different;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tbool\_treal\_tstring}):
+  \item \AllApplyCase{tbool\_treal\_tstring}:
   \begin{itemize}
     \item both $\vtone$ and $\vttwo$ are both either $\TBool$, $\TReal$, or $\TString$;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tint\_unconstrained}):
+  \item \AllApplyCase{tint\_unconstrained}:
   \begin{itemize}
     \item both $\vtone$ and $\vttwo$ are the unconstrained integer type $\unconstrainedinteger$;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tint\_parameterized}):
+  \item \AllApplyCase{tint\_parameterized}:
   \begin{itemize}
     \item $\vtone$ is the \parameterizedintegertype\  with identifier $\vione$, that is, \\ $\TInt(\parameterized(\vione))$;
     \item $\vttwo$ is the \parameterizedintegertype\ with identifier $\vitwo$, that is, \\ $\TInt(\parameterized(\vitwo))$;
     \item $\vb$ is $\True$ if and only if $\vione$ is equal to $\vitwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tint\_wellconstrained}):
+  \item \AllApplyCase{tint\_wellconstrained}:
   \begin{itemize}
     \item $\vtone$ is the well-constrained integer type with list of constraints $\vcone$, that is, \\ $\TInt(\wellconstrained(\vcone))$;
     \item $\vttwo$ is the well-constrained integer type with list of constraints $\vctwo$, that is, \\ $\TInt(\wellconstrained(\vctwo))$;
     \item testing whether $\vcone$ and $\vctwo$ are equivalent in $\tenv$ yields $\vb$\ProseOrTypeError.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tbits}):
+  \item \AllApplyCase{tbits}:
   \begin{itemize}
     \item $\vtone$ is the bitvector type with width expression $\vwone$ and list of bitfields $\bfone$, that is, $\TBits(\vwone, \bfone)$;
     \item $\vttwo$ is the bitvector type with width expression $\vwtwo$ and list of bitfields $\bftwo$, that is, $\TBits(\vwtwo, \bftwo)$;
@@ -1317,7 +1317,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tarray}):
+  \item \AllApplyCase{tarray}:
   \begin{itemize}
     \item $\vtone$ is an array type with index $\vlone$ and element type $\vtone$, that is, $\TArray(\vlone, \vtone)$;
     \item $\vttwo$ is an array type with index $\vltwo$ and element type $\vttwo$, that is, $\TArray(\vltwo, \vttwo)$;
@@ -1326,21 +1326,21 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tnamed}):
+  \item \AllApplyCase{tnamed}:
   \begin{itemize}
     \item $\vtone$ is a named type with identifier $\vsone$, that is $\TNamed(\vsone)$;
     \item $\vttwo$ is a named type with identifier $\vstwo$, that is $\TNamed(\vstwo)$;
     \item $\vb$ is $\True$ if and only if $\vsone$ is equal to $\vstwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tenum}):
+  \item \AllApplyCase{tenum}:
   \begin{itemize}
     \item $\vtone$ is an enumeration type with identifier $\vlone$, that is $\TEnum(\vlone)$;
     \item $\vttwo$ is an enumeration type with identifier $\vltwo$, that is $\TEnum(\vltwo)$;
     \item $\vb$ is $\True$ if and only if $\vlone$ is equal to $\vltwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tstructured}):
+  \item \AllApplyCase{tstructured}:
   \begin{itemize}
     \item $L$ is either $\TRecord$ or $\TException$;
     \item $\vtone$ is a \structuredtype\ with list of fields $\vfieldsone$, that is $L(\vfieldsone)$;
@@ -1353,7 +1353,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\vb_\vf$ is $\True$ for each field $\vf$ in the set of fields of $\vfieldsone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{ttuple}):
+  \item \AllApplyCase{ttuple}:
   \begin{itemize}
     \item $\vtone$ is a tuple type with list of types $\vtsone$, that is $\TTuple(\vtsone)$;
     \item $\vttwo$ is a tuple type with list of types $\vtstwo$, that is $\TTuple(\vtstwo)$;
@@ -1499,13 +1499,13 @@ in environment $\tenv$ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{different\_lengths}):
+  \item \AllApplyCase{different\_lengths}:
   \begin{itemize}
     \item the number of bitfields in $\bfone$ is different from the number of bitfields in $\bftwo$;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{same\_lengths}):
+  \item \AllApplyCase{same\_lengths}:
   \begin{itemize}
     \item the number of bitfields in $\bfone$ is the same as the number of bitfields in $\bftwo$;
     \item testing whether the bitfield $\bfone[i]$ is equivalent to $\bftwo[i]$ in $\tenv$ for every index
@@ -1544,13 +1544,13 @@ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{different\_labels}):
+  \item \AllApplyCase{different\_labels}:
   \begin{itemize}
     \item the AST labels of $\bfone$ and $\bftwo$ are different;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{bitfield\_simple}):
+  \item \AllApplyCase{bitfield\_simple}:
   \begin{itemize}
     \item $\bfone$ is a simple bitfield with name $\nameone$ and list of slices $\slicesone$, that is, \\ $\BitFieldSimple(\nameone, \slicesone)$;
     \item $\bftwo$ is a simple bitfield with name $\nametwo$ and list of slices $\slicestwo$, that is, \\ $\BitFieldSimple(\nametwo, \slicestwo)$;
@@ -1559,7 +1559,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{bitfield\_nested}):
+  \item \AllApplyCase{bitfield\_nested}:
   \begin{itemize}
     \item $\bfone$ is a nested bitfield with name $\nameone$, list of slices $\slicesone$, and nested bitfields $\bfoneone$, that is,
           $\BitFieldNested(\nameone, \slicesone, \bfoneone)$;
@@ -1571,7 +1571,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{bitfield\_typed}):
+  \item \AllApplyCase{bitfield\_typed}:
   \begin{itemize}
     \item $\bfone$ is a typed bitfield with name $\nameone$, list of slices $\slicesone$, and type $\vtone$, that is,
           $\BitFieldType(\nameone, \slicesone, \vtone)$;
@@ -1635,7 +1635,7 @@ conservatively tests whether the constraint list $\csone$ is equivalent to the c
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item checking whether the number of constraints in $\csone$ is the same as the number of constraints in $\cstwo$
         yields $\True$\ProseTerminateAs{\False};
@@ -1668,20 +1668,20 @@ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{different\_labels}):
+  \item \AllApplyCase{different\_labels}:
   \begin{itemize}
     \item the AST labels of $\vcone$ and $\vctwo$ are different;
     \item define $\vb$ as $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{constraint\_exact}):
+  \item \AllApplyCase{constraint\_exact}:
   \begin{itemize}
     \item $\vcone$ is an exact constraint with subexpression $\veone$, that is, $\ConstraintExact(\veone)$;
     \item $\vctwo$ is an exact constraint with subexpression $\vetwo$, that is, $\ConstraintExact(\vetwo)$;
     \item applying $\exprequal$ to $\veone$ and $\vetwo$ yields $\vb$\ProseOrTypeError.
   \end{itemize}
 
-  \item All of the following apply (\textsc{constraint\_range}):
+  \item \AllApplyCase{constraint\_range}:
   \begin{itemize}
     \item $\vcone$ is a range constraint with subexpressions $\veoneone$ and $\veonetwo$, that is, \\ $\ConstraintRange(\veoneone, \veonetwo)$;
     \item $\vctwo$ is a range constraint with subexpressions $\vetwoone$ and $\vetwotwo$, that is, \\ $\ConstraintRange(\vetwoone, \vetwotwo)$;
@@ -1731,13 +1731,13 @@ in environment $\tenv$ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{different\_lengths}):
+  \item \AllApplyCase{different\_lengths}:
   \begin{itemize}
     \item checking whether the number of slices in $\slicesone$ is equal to the number of slice in $\slicestwo$ yields $\False$;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{same\_lengths}):
+  \item \AllApplyCase{same\_lengths}:
   \begin{itemize}
     \item checking whether the number of slices in $\slicesone$ is equal to the number of slice in $\slicestwo$ yields $\True$;
     \item determining whether the expression $\slicesone[i]$ is equivalent to $\slicestwo[i]$ in $\tenv$
@@ -1776,20 +1776,20 @@ in environment $\tenv$ and yields the result in $\vb$. \ProseOtherwiseTypeError
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{different\_labels}):
+  \item \AllApplyCase{different\_labels}:
   \begin{itemize}
     \item $\sliceone$ and $\slicetwo$ have different AST labels;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{slice\_single}):
+  \item \AllApplyCase{slice\_single}:
   \begin{itemize}
     \item $\sliceone$ is a slice for a single position, given by the expression $\veone$, that is, $\SliceSingle(\veone)$;
     \item $\slicetwo$ is a slice for a single position, given by the expression $\vetwo$, that is, $\SliceSingle(\vetwo)$;
     \item testing $\veone$ and $\vetwo$ for equivalence yields $\vb$\ProseOrTypeError.
   \end{itemize}
 
-  \item All of the following apply (\textsc{slice\_range}):
+  \item \AllApplyCase{slice\_range}:
   \begin{itemize}
     \item $\sliceone$ is a slice for a range of positions, given by the expressions $\veoneone$ and $\veonetwo$, that is, $\SliceRange(\veoneone, \veonetwo)$;
     \item $\slicetwo$ is a slice for a range of positions, given by the expressions $\vetwoone$ and $\vetwotwo$, that is, $\SliceRange(\vetwoone, \vetwotwo)$;
@@ -1798,7 +1798,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{slice\_length}):
+  \item \AllApplyCase{slice\_length}:
   \begin{itemize}
     \item $\sliceone$ is a slice for a range of positions, given by the start expression $\veoneone$ and length expression $\veonetwo$, that is, $\SliceLength(\veoneone, \veonetwo)$;
     \item $\slicetwo$ is a slice for a range of positions, given by the start expression $\vetwoone$ and length expression $\vetwotwo$, that is, $\SliceLength(\vetwoone, \vetwotwo)$;
@@ -1852,20 +1852,20 @@ in $\vb$. \ProseOtherwiseTypeError
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{different\_labels}):
+  \item \AllApplyCase{different\_labels}:
   \begin{itemize}
     \item $\vlone$ and $\vltwo$ have different AST labels;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{expr\_expr}):
+  \item \AllApplyCase{expr\_expr}:
   \begin{itemize}
     \item $\vlone$ is an integer type length expression with subexpression $\veoneone$, that is, \\ $\ArrayLengthExpr(\veoneone)$;
     \item $\vltwo$ is an integer type length expression with subexpression $\vetwoone$, that is, \\ $\ArrayLengthExpr(\vetwoone)$;
     \item testing whether $\veoneone$ and $\vetwoone$ are equivalent in $\tenv$ yields $\vb$\ProseOrTypeError.
   \end{itemize}
 
-  \item All of the following apply (\textsc{enum\_enum}):
+  \item \AllApplyCase{enum\_enum}:
   \begin{itemize}
     \item $\vlone$ is an enumeration type index for the identifier $\venumone$ and a list of labels, that is,
           $\ArrayLengthEnum(\venumone, \Ignore)$;
@@ -1931,13 +1931,13 @@ transforms a polynomial $\vp$ into the corresponding expression $\ve$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\vp$ is the polynomial with an empty list of monomials, that is, $\emptyfunc$;
     \item define $\ve$ as the literal expression for $0$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\vp$ is the polynomial $f$;
     \item sorting (see $\sort$ for details) the graph of $f$ (see $\funcgraph$ for details)
@@ -1992,14 +1992,14 @@ and $1$ to mean that the second monomial binding should be ordered before the fi
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{equal\_monomials}):
+  \item \AllApplyCase{equal\_monomials}:
   \begin{itemize}
     \item $\vmone$ is $f$ and $\vmtwo$ is $g$;
     \item $f$ is equal to $g$;
     \item $\vs$ is the sign of $\vqtwo - \vqone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{different\_monomials}):
+  \item \AllApplyCase{different\_monomials}:
   \begin{itemize}
     \item $\vmone$ is $f$ and $\vmtwo$ is $g$;
     \item $f$ is different from to $g$;
@@ -2058,13 +2058,13 @@ and a sign value $\vs$, which indicates the sign of the resulting sum.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\monoms$ is an empty list;
     \item $\ve$ is the literal expression for the integer $0$ and $\vs$ is $0$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty}):
+  \item \AllApplyCase{non\_empty}:
   \begin{itemize}
     \item $\monoms$ is a list with $(\vm,q)$ as its \head\ and $\monomsone$ as its \tail;
     \item transforming the unitary monomial $\vm$ to an expression via \\ $\unitarymonomialstoexpr$ yields $\veonep$;
@@ -2104,21 +2104,21 @@ which represents the absolute value of $\ve$ multiplied by $q$, and the sign of 
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{q\_zero}):
+  \item \AllApplyCase{q\_zero}:
   \begin{itemize}
     \item $q$ is $0$;
     \item $\newe$ is the literal expression for $0$;
     \item $\vs$ is $0$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{q\_natural}):
+  \item \AllApplyCase{q\_natural}:
   \begin{itemize}
     \item $q$ a strictly positive;
     \item symbolically multiplying the literal expression for $q$ and $\ve$ via $\symmulexpr$ yields $\newe$;
     \item $\vs$ is $1$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{q\_positive\_fraction}):
+  \item \AllApplyCase{q\_positive\_fraction}:
   \begin{itemize}
     \item $q$ a strictly positive fraction, that is, not an integer;
     \item the reduced representation of the fraction $q$ is $\frac{d}{n}$;
@@ -2127,7 +2127,7 @@ One of the following applies:
     \item $\vs$ is $1$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{q\_negative}):
+  \item \AllApplyCase{q\_negative}:
   \begin{itemize}
     \item $q$ a strictly negative;
     \item transforming $\ve$ with $-q$ to an expression and a sign via $\monomialtoexpr$ yields $(\newe, 1)$;
@@ -2205,13 +2205,13 @@ $\vstwo$                      & -1                         & 0               & 1
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{zero}):
+  \item \AllApplyCase{zero}:
   \begin{itemize}
     \item either $\vsone$ is $0$ or $\vstwo$ is $0$;
     \item the result is $(\vetwo, \vstwo)$ if $\vsone$ is $0$ and $(\veone, \vsone)$, otherwise.
   \end{itemize}
 
-  \item All of the following apply (\textsc{same\_sign}):
+  \item \AllApplyCase{same\_sign}:
   \begin{itemize}
     \item both $\vsone$ and $\vstwo$ are not $0$;
     \item $\vsone$ is equal to $\vstwo$;
@@ -2220,7 +2220,7 @@ One of the following applies:
     \item $\vs$ is $\vsone$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{same\_sign}):
+  \item \AllApplyCase{same\_sign}:
   \begin{itemize}
     \item both $\vsone$ and $\vstwo$ are not $0$;
     \item $\vsone$ is different from $\vstwo$;
@@ -2266,19 +2266,19 @@ Intuitively, $\monoms$ represented a multiplication of the single-variable unita
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\monoms$ is the empty list;
     \item $\ve$ is the literal expression for $1$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{exp\_zero}):
+  \item \AllApplyCase{exp\_zero}:
   \begin{itemize}
     \item $\monoms$ is a list where the first element is $(\vv, 0)$ and its tail is $\monoms$;
     \item transforming $\monomsone$ to an expression yields $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{exp\_one}):
+  \item \AllApplyCase{exp\_one}:
   \begin{itemize}
     \item $\monoms$ is a list where the first element is $(\vv, 1)$ and its tail is $\monoms$;
     \item $\veone$ is the variable expression for $\vv$;
@@ -2286,7 +2286,7 @@ One of the following applies:
     \item symbolically multiplying $\veone$ and $\vetwo$ via $\symmulexpr$ yields $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{exp\_two}):
+  \item \AllApplyCase{exp\_two}:
   \begin{itemize}
     \item $\monoms$ is a list where the first element is $(\vv, 2)$ and its tail is $\monoms$;
     \item $\veone$ is the binary expression with operator $\MUL$ and operands $\EVar(\vv)$ and $\EVar(\vv)$
@@ -2295,7 +2295,7 @@ One of the following applies:
     \item symbolically multiplying $\veone$ and $\vetwo$ via $\symmulexpr$ yields $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{exp\_gt\_two}):
+  \item \AllApplyCase{exp\_gt\_two}:
   \begin{itemize}
     \item $\monoms$ is a list where the first element is $(\vv, n)$ and its tail is $\monoms$;
     \item $n$ is greater than $1$;
@@ -2365,7 +2365,7 @@ simplifying away the case where one of the operands is the literal one.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{one\_operand}):
+  \item \AllApplyCase{one\_operand}:
   \begin{itemize}
     \item either $\veone$ or $\vetwo$ is the literal expression for $1$;
     \item $\ve$ is $\vetwo$ if $\veone$ is the literal expression for $1$ and $\veone$, otherwise.
@@ -2402,18 +2402,18 @@ $\vs$. The result is type error if $\vs$ is not associated with any type.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{local}):
+  \item \AllApplyCase{local}:
   \begin{itemize}
     \item $\vs$ is associated with a type $\tty$ in the local environment of $\tenv$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{global}):
+  \item \AllApplyCase{global}:
   \begin{itemize}
     \item $\vs$ is not associated with a type in the local environment of $\tenv$;
     \item $\vs$ is associated with a type $\tty$ in the global environment of $\tenv$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item $\vs$ is not associated with a type in the local environment of $\tenv$;
     \item $\vs$ is not associated with a type in the global environment of $\tenv$;
@@ -2460,7 +2460,7 @@ expression that can be symbolically simplified.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{normalizable})
+  \item \AllApplyCase{normalizable}
   \begin{itemize}
     \item applying $\toir$ to $\ve$ in $\tenv$ to obtain a symbolic expression yields a symbolic expression $\vpone$
     (that is, not $\CannotBeTransformed$)\ProseOrTypeError;
@@ -2468,7 +2468,7 @@ One of the following applies:
     \item \Proseeqdef{$\neweopt$}{$\langle\newe\rangle$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{not\_normalizable})
+  \item \AllApplyCase{not\_normalizable}
   \begin{itemize}
     \item applying $\toir$ to $\ve$ in $\tenv$ to obtain a symbolic expression yields $\CannotBeTransformed$;
     \item \Proseeqdef{$\neweopt$}{$\None$}.

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -211,6 +211,9 @@ The function
 yielding an expression $\newe$.
 \ProseOtherwiseTypeError
 
+\hypertarget{def-normalizedterm}{}
+We refer to an expression in the image of $\normalize$ as a \emph{\normalizedexpressionterm}.
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -1335,8 +1338,8 @@ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
   \item \AllApplyCase{tenum}
   \begin{itemize}
-    \item $\vtone$ is an enumeration type with identifier $\vlone$, that is $\TEnum(\vlone)$;
-    \item $\vttwo$ is an enumeration type with identifier $\vltwo$, that is $\TEnum(\vltwo)$;
+    \item $\vtone$ is an \enumerationtypeterm{} with identifier $\vlone$, that is $\TEnum(\vlone)$;
+    \item $\vttwo$ is an \enumerationtypeterm{} with identifier $\vltwo$, that is $\TEnum(\vltwo)$;
     \item $\vb$ is $\True$ if and only if $\vlone$ is equal to $\vltwo$.
   \end{itemize}
 
@@ -1355,8 +1358,8 @@ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
   \item \AllApplyCase{ttuple}
   \begin{itemize}
-    \item $\vtone$ is a tuple type with list of types $\vtsone$, that is $\TTuple(\vtsone)$;
-    \item $\vttwo$ is a tuple type with list of types $\vtstwo$, that is $\TTuple(\vtstwo)$;
+    \item $\vtone$ is a \tupletypeterm{} with list of types $\vtsone$, that is $\TTuple(\vtsone)$;
+    \item $\vttwo$ is a \tupletypeterm{} with list of types $\vtstwo$, that is $\TTuple(\vtstwo)$;
     \item checking whether the list of types $\vtsone$ has the same length as the list of types $\vtstwo$ yields $\True$
           or $\False$, which short-circuits the entire rule;
     \item for each index $i$ in the list $\vtsone$, testing whether $\vtsone[i]$ is equivalent to $\vtstwo[i]$ in $\tenv$
@@ -1867,9 +1870,9 @@ in $\vb$. \ProseOtherwiseTypeError
 
   \item \AllApplyCase{enum\_enum}
   \begin{itemize}
-    \item $\vlone$ is an enumeration type index for the identifier $\venumone$ and a list of labels, that is,
+    \item $\vlone$ is an \enumerationtypeterm{} index for the identifier $\venumone$ and a list of labels, that is,
           $\ArrayLengthEnum(\venumone, \Ignore)$;
-    \item $\vltwo$ is an enumeration type index for the identifier $\venumtwo$ and a list of labels, that is,
+    \item $\vltwo$ is an \enumerationtypeterm{} index for the identifier $\venumtwo$ and a list of labels, that is,
            $\ArrayLengthEnum(\venumtwo, \Ignore)$;
     \item $\vb$ is $\True$ if and only if $\venumone$ is equal to $\venumtwo$.
   \end{itemize}

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -2389,7 +2389,7 @@ One of the following applies:
 }
 \end{mathpar}
 
-\subsubsection{TypingRule.TypeOf}
+\TypingRuleDef{TypeOf}
 \hypertarget{def-typeof}{}
 The function
 \[

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -474,7 +474,7 @@ Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expre
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_shl\_non\_neg\_shift}
+  \item \AllApplyCase{ebinop\_shl\_neg\_shift}
   \begin{itemize}
     \item $\ve$ is a binary shift-left expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\SHL, \veone, \vetwo)$;
     \item $\vetwo$ is an integer literal expression for $\vitwo$;
@@ -533,7 +533,7 @@ Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expre
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{ATC}
+  \item \AllApplyCase{atc}
   \begin{itemize}
     \item $\ve$ is an asserting type conversion for the subexpression $\vep$, that is, \\
           $\EATC(\vep, \Ignore)$;
@@ -1375,7 +1375,7 @@ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[TBool\_TReal\_TString]{
+\inferrule[tbool\_treal\_tstring]{
   \astlabel(\vtone) = \astlabel(\vttwo)\\
   \astlabel(\vtone) \in \{\TBool, \TReal, \TString\}
 }{
@@ -1810,7 +1810,7 @@ in environment $\tenv$ and yields the result in $\vb$. \ProseOtherwiseTypeError
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[different\_label]{
+\inferrule[different\_labels]{
   \astlabel(\sliceone) \neq \astlabel(\slicetwo)
 }{
   \slicesequal(\tenv, \sliceone, \slicetwo) \typearrow \False
@@ -2220,7 +2220,7 @@ $\vstwo$                      & -1                         & 0               & 1
     \item $\vs$ is $\vsone$;
   \end{itemize}
 
-  \item \AllApplyCase{same\_sign}
+  \item \AllApplyCase{different\_signs}
   \begin{itemize}
     \item both $\vsone$ and $\vstwo$ are not $0$;
     \item $\vsone$ is different from $\vstwo$;
@@ -2437,7 +2437,7 @@ $\vs$. The result is type error if $\vs$ is not associated with any type.
   \typeof(\tenv, \vs) \typearrow \tty
 }
 \and
-\inferrule[none]{
+\inferrule[error]{
   L^\tenv.\localstoragetypes(\vs) = \bot\\
   G^\tenv.\globalstoragetypes(\vs) = \bot
 }{

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -1541,6 +1541,7 @@ The function
 conservatively tests whether the bitfield $\bfone$ is equivalent to the bitfield $\bftwo$ in environment $\tenv$
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
+\ProseParagraph
 One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{different\_labels}):
@@ -1727,7 +1728,7 @@ The function
 conservatively tests whether the list of slices $\slicesone$ is equivalent to the list of slices $\slicestwo$
 in environment $\tenv$ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
-\FormallyParagraph
+\ProseParagraph
 One of the following applies:
 \begin{itemize}
   \item All of the following apply (\textsc{different\_lengths}):

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -212,7 +212,7 @@ yielding an expression $\newe$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
   \item \AllApplyCase{normalizable}
   \begin{itemize}
@@ -258,16 +258,16 @@ The function
 \symbolicallysimplifies\ an integer constraint $\vc$, yielding the integer constraint $\newc$
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact}:
+  \item \AllApplyCase{exact}
   \begin{itemize}
     \item $\vc$ is an exact integer constraint for $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\normalize$ to $\ve$ in $\tenv$ yields $\vep$;
     \item define $\newc$ as the exact integer constraint for $\vep$, that is, $\ConstraintExact(\ve)$.
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vc$ is an range integer constraint for $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item applying $\normalize$ to $\veone$ in $\tenv$ yields $\veonep$;
@@ -342,21 +342,21 @@ the special value $\CannotBeTransformed$ is returned.
 \ProseParagraph
 Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expression corresponds to a polynomial.
 
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{literal\_int}:
+  \item \AllApplyCase{literal\_int}
   \begin{itemize}
     \item $\ve$ is an integer literal expression for $\vi$, that is, $\ELiteral(\lint(\vi))$;
     \item $\vp$ is the symbolic expression for $\vi$.
   \end{itemize}
 
-  \item \AllApplyCase{literal\_other}:
+  \item \AllApplyCase{literal\_other}
   \begin{itemize}
     \item $\ve$ is a variable expression other than an integer literal;
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{evar\_int\_constant}:
+  \item \AllApplyCase{evar\_int\_constant}
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ via $\lookupconstant$ yields the literal expression for $\vv$, that is, $\ELiteral(\vv)$;
@@ -365,7 +365,7 @@ One of the following applies:
     \item $\vp$ is the symbolic expression for $\vi$, that is, $\{ \emptyfunc\mapsto \vi \}$.
   \end{itemize}
 
-  \item \AllApplyCase{evar\_immutable\_expr}:
+  \item \AllApplyCase{evar\_immutable\_expr}
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ via $\lookupconstant$ yields $\bot$;
@@ -374,7 +374,7 @@ One of the following applies:
     \item applying $\toir$ to $\vep$ in $\tenv$ yields $\vp$.
   \end{itemize}
 
-  \item \AllApplyCase{evar\_exact\_constraint}:
+  \item \AllApplyCase{evar\_exact\_constraint}
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ via $\lookupconstant$ yields $\bot$;
@@ -387,7 +387,7 @@ One of the following applies:
     \item converting $\ve$ to a symbolic expression yields $\vp$\ProseTerminateAs{\CannotBeTransformed}.
   \end{itemize}
 
-  \item \AllApplyCase{int\_var}:
+  \item \AllApplyCase{int\_var}
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ yields $\bot$;
@@ -398,7 +398,7 @@ One of the following applies:
     \item $\vp$ is the symbolic expression for the variable $\vs$, that is, $\{ \{\vs\mapsto 1\}\mapsto 1 \}$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_plus}:
+  \item \AllApplyCase{ebinop\_plus}
   \begin{itemize}
     \item $\ve$ is a binary addition expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\PLUS, \veone, \vetwo)$;
     \item converting $\veone$ to a symbolic expression in $\tenv$ yields $\irone$\ProseOrTypeErrorOrCannotBeTransformed;
@@ -406,14 +406,14 @@ One of the following applies:
     \item $\vp$ is the symbolic expression adding up $\irone$ and $\irtwo$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_minus}:
+  \item \AllApplyCase{ebinop\_minus}
   \begin{itemize}
     \item $\ve$ is a binary subtraction expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\MINUS, \veone, \vetwo)$;
     \item $\vep$ is the addition expression with operands $\veone$ and the negation of $\vetwo$, that is, \\ $\EBinop(\PLUS, \veone, \EUnop(\MINUS, \vetwo))$;
     \item converting $\vep$ into a symbolic expression in $\tenv$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_mul\_div\_left}:
+  \item \AllApplyCase{ebinop\_mul\_div\_left}
   \begin{itemize}
     \item $\ve$ is a binary multiplication expression where the left operand is a binary division expression over $\veone$ and $\vetwo$
           and the right operand is $\vethree$, that is, \\ $\EBinop(\MUL, \EBinop(\DIV, \veone, \vetwo), \vethree)$;
@@ -421,7 +421,7 @@ One of the following applies:
           and $\vethree$ and the right operand is $\vetwo$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_mul\_div\_right}:
+  \item \AllApplyCase{ebinop\_mul\_div\_right}
   \begin{itemize}
     \item $\ve$ is a binary multiplication expression where the left operand is $\veone$ and the right operand
           is the division expression over $\vetwo$ and $\vethree$, that is, \\
@@ -431,7 +431,7 @@ One of the following applies:
           and $\vetwo$ and the right operand is $\vethree$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_mul}:
+  \item \AllApplyCase{ebinop\_mul}
   \begin{itemize}
     \item $\ve$ is a binary multiplication expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\MUL, \veone, \vetwo)$;
     \item neither $\veone$ nor $\vetwo$ are binary vision expressions;
@@ -440,7 +440,7 @@ One of the following applies:
     \item $\vp$ is the symbolic expression multiplying $\irone$ and $\irtwo$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_div\_int\_denominator}:
+  \item \AllApplyCase{ebinop\_div\_int\_denominator}
   \begin{itemize}
     \item $\ve$ is a binary division expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\DIV, \veone, \vetwo)$;
     \item $\vetwo$ is an integer literal expression for $\vitwo$;
@@ -449,7 +449,7 @@ One of the following applies:
     \item $\vp$ is the polynomial $\irone$ with each monomial multiplied by $\vftwo$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_div\_monomial\_denominator}:
+  \item \AllApplyCase{ebinop\_div\_monomial\_denominator}
   \begin{itemize}
     \item $\ve$ is a binary division expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\DIV, \veone, \vetwo)$;
     \item converting $\veone$ to a symbolic expression in $\tenv$ yields $\irone$\ProseOrTypeErrorOrCannotBeTransformed;
@@ -458,7 +458,7 @@ One of the following applies:
     \item applying $\polynomialdividebyterm$ to $\irone$, $\vfactor$, and $\vmono$ yields $\vp$\ProseTerminateAs{\CannotBeTransformed}.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_div\_non\_monomial\_denominator}:
+  \item \AllApplyCase{ebinop\_div\_non\_monomial\_denominator}
   \begin{itemize}
     \item $\ve$ is a binary division expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\DIV, \veone, \vetwo)$;
     \item converting $\veone$ to a symbolic expression in $\tenv$ yields $\irone$\ProseOrTypeErrorOrCannotBeTransformed;
@@ -467,14 +467,14 @@ One of the following applies:
     \item the result is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_shl\_non\_lint\_exponent}:
+  \item \AllApplyCase{ebinop\_shl\_non\_lint\_exponent}
   \begin{itemize}
     \item $\ve$ is a binary shift-left expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\SHL, \veone, \vetwo)$;
     \item $\vetwo$ is not an integer literal expression;
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_shl\_non\_neg\_shift}:
+  \item \AllApplyCase{ebinop\_shl\_non\_neg\_shift}
   \begin{itemize}
     \item $\ve$ is a binary shift-left expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\SHL, \veone, \vetwo)$;
     \item $\vetwo$ is an integer literal expression for $\vitwo$;
@@ -482,7 +482,7 @@ One of the following applies:
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_shl\_okay}:
+  \item \AllApplyCase{ebinop\_shl\_okay}
   \begin{itemize}
     \item $\ve$ is a binary shift-left expression with operands $\veone$ and $\vetwo$, that is, \\ $\EBinop(\SHL, \veone, \vetwo)$;
     \item $\vetwo$ is an integer literal expression for $\vitwo$;
@@ -492,7 +492,7 @@ One of the following applies:
     \item $\vp$ is the polynomial $\irone$ with each monomial multiplied by $\vftwo$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_other\_non\_literals}:
+  \item \AllApplyCase{ebinop\_other\_non\_literals}
   \begin{itemize}
     \item $\ve$ is a binary expression with an operator $\op$ that is other than $\PLUS$, $\MINUS$, $\MUL$, or $\SHL$,
           applied to the operand expressions $\veone$ and $\vetwo$;
@@ -500,7 +500,7 @@ One of the following applies:
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_other\_literals\_non\_int\_result}:
+  \item \AllApplyCase{ebinop\_other\_literals\_non\_int\_result}
   \begin{itemize}
     \item $\ve$ is a binary expression with an operator $\op$ that is other than $\PLUS$, $\MINUS$, $\MUL$, $\DIV$, or $\SHL$,
           applied to the operand expressions $\veone$ and $\vetwo$;
@@ -510,7 +510,7 @@ One of the following applies:
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{ebinop\_other\_literals\_int\_result}:
+  \item \AllApplyCase{ebinop\_other\_literals\_int\_result}
   \begin{itemize}
     \item $\ve$ is a binary expression with an operator $\op$ that is other than $\PLUS$, $\MINUS$, $\MUL$, or $\SHL$,
           applied to the operand expressions $\veone$ and $\vetwo$;
@@ -520,27 +520,27 @@ One of the following applies:
     \item $\vp$ is the symbolic expression for the integer $k$, that is, $\{ \emptyfunc\mapsto k \}$.
   \end{itemize}
 
-  \item \AllApplyCase{eunop\_neg}:
+  \item \AllApplyCase{eunop\_neg}
   \begin{itemize}
     \item $\ve$ is a unary expression with the negation operator $\NEG$ and operand $\veone$;
     \item converting the binary expression with operator $\MUL$ and left-hand-side operand for the integer literal $-1$ and
     right-hand-side operand $\veone$ in $\tenv$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item \AllApplyCase{eunop\_other}:
+  \item \AllApplyCase{eunop\_other}
   \begin{itemize}
     \item $\ve$ is a unary expression with an operator other than $\NEG$;
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{ATC}:
+  \item \AllApplyCase{ATC}
   \begin{itemize}
     \item $\ve$ is an asserting type conversion for the subexpression $\vep$, that is, \\
           $\EATC(\vep, \Ignore)$;
     \item applying $\toir$ to $\vep$ yields $\vp$\ProseOrTypeErrorOrCannotBeTransformed.
   \end{itemize}
 
-  \item \AllApplyCase{other}:
+  \item \AllApplyCase{other}
   \begin{itemize}
     \item $\ve$ is an expression with a label other than $\ELiteral$, $\EVar$, $\EBinop$, $\EUnop$, and $\EATC$;
     \item $\vp$ is $\CannotBeTransformed$.
@@ -784,15 +784,15 @@ conservatively checks whether the expression $\veone$ is equivalent to the expre
 The result is given in $\vb$ or a type error, if one is detected.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{norm\_true}:
+  \item \AllApplyCase{norm\_true}
   \begin{itemize}
     \item comparing $\veone$ to $\vetwo$ in $\tenv$ via $\exprequalnorm$ yields $\True$\ProseOrTypeError;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{norm\_false}:
+  \item \AllApplyCase{norm\_false}
   \begin{itemize}
     \item comparing $\veone$ to $\vetwo$ in $\tenv$ via $\exprequalnorm$ yields $\False$;
     \item comparing $\veone$ to $\vetwo$ by case analysis via $\exprequalcase$ yields $\vb$\ProseOrTypeError.
@@ -828,22 +828,22 @@ and, if successful, comparing the resulting normal forms for equality.
 The result is given in $\vb$ or a type error, if one is detected.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{all\_supported}:
+  \item \AllApplyCase{all\_supported}
   \begin{itemize}
     \item transforming $\veone$ into a symbolic expression in $\tenv$ yields $\irone$\ProseOrTypeError;
     \item transforming $\vetwo$ into a symbolic expression in $\tenv$ yields $\irtwo$\ProseOrTypeError;
     \item $\vb$ is the result of equating $\irone$ and $\irtwo$.
   \end{itemize}
 
-  \item \AllApplyCase{unsupported1}:
+  \item \AllApplyCase{unsupported1}
   \begin{itemize}
     \item transforming $\veone$ into a symbolic expression in $\tenv$ yields $\CannotBeTransformed$;
     \item $\vb$ is $\False$;
   \end{itemize}
 
-  \item \AllApplyCase{unsupported2}:
+  \item \AllApplyCase{unsupported2}
   \begin{itemize}
     \item transforming $\veone$ into a symbolic expression in $\tenv$ yields $\irone$;
     \item transforming $\vetwo$ into a symbolic expression in $\tenv$ yields $\CannotBeTransformed$;
@@ -886,15 +886,15 @@ for the different types of expressions.
 The result is given in $\vb$ or a type error, if one is detected.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{different\_labels}:
+  \item \AllApplyCase{different\_labels}
   \begin{itemize}
     \item the AST labels of $\veone$ and $\vetwo$ are different;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_binop}:
+  \item \AllApplyCase{e\_binop}
   \begin{itemize}
     \item $\veone$ is a binary expression with operator $\opone$ and operands $\veoneone$ and $\veonetwo$,
           that is, $\EBinop(\opone, \veoneone, \veonetwo)$;
@@ -905,7 +905,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\opone$ is equal to $\optwo$ and both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_call}:
+  \item \AllApplyCase{e\_call}
   \begin{itemize}
     \item $\veone$ is a call expression with subprogram name $\nameone$ and list of arguments $\vargsone$,
           that is, $\ECall(\nameone, \vargsone, \Ignore)$;
@@ -919,7 +919,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\vb_i$ is $\True$ for each index $i$ in the list of indices for $\vargsone$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_cond}:
+  \item \AllApplyCase{e\_cond}
   \begin{itemize}
     \item $\veone$ is a conditional expression with expressions $\veoneone$, $\veonetwo$, and $\veonethree$,
           that is, $\ECond(\veoneone, \veonetwo, \veonethree)$;
@@ -931,7 +931,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if all of $\vbone$, $\vbtwo$, and $\vbthree$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_slice}:
+  \item \AllApplyCase{e\_slice}
   \begin{itemize}
     \item $\veone$ is a slicing expression with expression $\veoneone$ and list of slices $\slicesone$,
           that is, $\ESlice(\veoneone, \slicesone)$;
@@ -942,7 +942,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getarray}:
+  \item \AllApplyCase{e\_getarray}
   \begin{itemize}
     \item $\veone$ is an \arrayaccess\ expression with array expression $\veoneone$ and position expression $\veonetwo$,
           that is, $\EGetArray(\veoneone, \veonetwo)$;
@@ -953,7 +953,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getfield}:
+  \item \AllApplyCase{e\_getfield}
   \begin{itemize}
     \item $\veone$ is a field access expression with subexpression $\veoneone$ and field name $\vfieldone$,
           that is, $\EGetField(\veoneone, \vfieldone)$;
@@ -964,7 +964,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getfields}:
+  \item \AllApplyCase{e\_getfields}
   \begin{itemize}
     \item $\veone$ is a fields access expression with subexpression $\veoneone$ and list of field names $\vfieldsone$,
           that is, $\EGetFields(\veoneone, \vfieldsone)$;
@@ -975,7 +975,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_getitem}:
+  \item \AllApplyCase{e\_getitem}
   \begin{itemize}
     \item $\veone$ is a tuple access expression with subexpression $\veoneone$ and position $\vione$,
           that is, $\EGetItem(\veoneone, \vione)$;
@@ -986,26 +986,26 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_literal}:
+  \item \AllApplyCase{e\_literal}
   \begin{itemize}
     \item $\veone$ is the literal expression with literal $\vvone$;
     \item $\vetwo$ is the literal expression with literal $\vvtwo$;
     \item $\vb$ is $\True$ if and only if $\vvone$ is equivalent to $\vvtwo$ in $\tenv$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_pattern}:
+  \item \AllApplyCase{e\_pattern}
   \begin{itemize}
     \item both $\veone$ and $\vetwo$ are pattern expressions;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_record}:
+  \item \AllApplyCase{e\_record}
   \begin{itemize}
     \item both $\veone$ and $\vetwo$ are record expressions;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_tuple}:
+  \item \AllApplyCase{e\_tuple}
   \begin{itemize}
     \item $\veone$ is a tuple expression with subexpression list $\vlone$,
           that is, $\ETuple(\vlone)$;
@@ -1018,7 +1018,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\vb_i$ is $\True$ for each index $i$ in the list of indices for $\vlone$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_array}:
+  \item \AllApplyCase{e\_array}
   \begin{itemize}
     \item $\veone$ is an array construction expression with length expression $\vlone$ and value expression $\vvone$,
           that is, $\EArray\{\EArrayLength: \vlone, \EArrayValue: \vvone\}$;
@@ -1029,7 +1029,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_unop}:
+  \item \AllApplyCase{e\_unop}
   \begin{itemize}
     \item $\veone$ is a unary operator expression with operator $\opone$ and operand expressions $\veoneone$,
           that is, $\EUnop(\opone, \veoneone)$;
@@ -1039,13 +1039,13 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\opone$ is equal to $\optwo$ and $\vbone$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_arbitrary}:
+  \item \AllApplyCase{e\_arbitrary}
   \begin{itemize}
     \item both $\veone$ and $\vetwo$ are $\ARBITRARY$ expressions;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_atc}:
+  \item \AllApplyCase{e\_atc}
   \begin{itemize}
     \item $\veone$ is a type assertion with subexpression with operator $\veoneone$ and type $\vtone$,
           that is, $\EATC(\veoneone, \vtone)$;
@@ -1056,7 +1056,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_var}:
+  \item \AllApplyCase{e\_var}
   \begin{itemize}
     \item $\veone$ is a variable expression with identifier $\nameone$, that is, $\EVar(\nameone)$;
     \item $\vetwo$ is a variable expression with identifier $\nametwo$, that is, $\EVar(\nametwo)$;
@@ -1274,41 +1274,41 @@ conservatively tests whether the type $\vtone$ is equivalent to the type $\vttwo
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{different\_labels}:
+  \item \AllApplyCase{different\_labels}
   \begin{itemize}
     \item the AST labels of $\vtone$ and $\vttwo$ are different;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{tbool\_treal\_tstring}:
+  \item \AllApplyCase{tbool\_treal\_tstring}
   \begin{itemize}
     \item both $\vtone$ and $\vttwo$ are both either $\TBool$, $\TReal$, or $\TString$;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{tint\_unconstrained}:
+  \item \AllApplyCase{tint\_unconstrained}
   \begin{itemize}
     \item both $\vtone$ and $\vttwo$ are the unconstrained integer type $\unconstrainedinteger$;
     \item $\vb$ is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{tint\_parameterized}:
+  \item \AllApplyCase{tint\_parameterized}
   \begin{itemize}
     \item $\vtone$ is the \parameterizedintegertype\  with identifier $\vione$, that is, \\ $\TInt(\parameterized(\vione))$;
     \item $\vttwo$ is the \parameterizedintegertype\ with identifier $\vitwo$, that is, \\ $\TInt(\parameterized(\vitwo))$;
     \item $\vb$ is $\True$ if and only if $\vione$ is equal to $\vitwo$.
   \end{itemize}
 
-  \item \AllApplyCase{tint\_wellconstrained}:
+  \item \AllApplyCase{tint\_wellconstrained}
   \begin{itemize}
     \item $\vtone$ is the well-constrained integer type with list of constraints $\vcone$, that is, \\ $\TInt(\wellconstrained(\vcone))$;
     \item $\vttwo$ is the well-constrained integer type with list of constraints $\vctwo$, that is, \\ $\TInt(\wellconstrained(\vctwo))$;
     \item testing whether $\vcone$ and $\vctwo$ are equivalent in $\tenv$ yields $\vb$\ProseOrTypeError.
   \end{itemize}
 
-  \item \AllApplyCase{tbits}:
+  \item \AllApplyCase{tbits}
   \begin{itemize}
     \item $\vtone$ is the bitvector type with width expression $\vwone$ and list of bitfields $\bfone$, that is, $\TBits(\vwone, \bfone)$;
     \item $\vttwo$ is the bitvector type with width expression $\vwtwo$ and list of bitfields $\bftwo$, that is, $\TBits(\vwtwo, \bftwo)$;
@@ -1317,7 +1317,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{tarray}:
+  \item \AllApplyCase{tarray}
   \begin{itemize}
     \item $\vtone$ is an array type with index $\vlone$ and element type $\vtone$, that is, $\TArray(\vlone, \vtone)$;
     \item $\vttwo$ is an array type with index $\vltwo$ and element type $\vttwo$, that is, $\TArray(\vltwo, \vttwo)$;
@@ -1326,21 +1326,21 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{tnamed}:
+  \item \AllApplyCase{tnamed}
   \begin{itemize}
     \item $\vtone$ is a named type with identifier $\vsone$, that is $\TNamed(\vsone)$;
     \item $\vttwo$ is a named type with identifier $\vstwo$, that is $\TNamed(\vstwo)$;
     \item $\vb$ is $\True$ if and only if $\vsone$ is equal to $\vstwo$.
   \end{itemize}
 
-  \item \AllApplyCase{tenum}:
+  \item \AllApplyCase{tenum}
   \begin{itemize}
     \item $\vtone$ is an enumeration type with identifier $\vlone$, that is $\TEnum(\vlone)$;
     \item $\vttwo$ is an enumeration type with identifier $\vltwo$, that is $\TEnum(\vltwo)$;
     \item $\vb$ is $\True$ if and only if $\vlone$ is equal to $\vltwo$.
   \end{itemize}
 
-  \item \AllApplyCase{tstructured}:
+  \item \AllApplyCase{tstructured}
   \begin{itemize}
     \item $L$ is either $\TRecord$ or $\TException$;
     \item $\vtone$ is a \structuredtype\ with list of fields $\vfieldsone$, that is $L(\vfieldsone)$;
@@ -1353,7 +1353,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if $\vb_\vf$ is $\True$ for each field $\vf$ in the set of fields of $\vfieldsone$.
   \end{itemize}
 
-  \item \AllApplyCase{ttuple}:
+  \item \AllApplyCase{ttuple}
   \begin{itemize}
     \item $\vtone$ is a tuple type with list of types $\vtsone$, that is $\TTuple(\vtsone)$;
     \item $\vttwo$ is a tuple type with list of types $\vtstwo$, that is $\TTuple(\vtstwo)$;
@@ -1497,15 +1497,15 @@ conservatively tests whether the list of bitfields $\bfone$ is equivalent to the
 in environment $\tenv$ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{different\_lengths}:
+  \item \AllApplyCase{different\_lengths}
   \begin{itemize}
     \item the number of bitfields in $\bfone$ is different from the number of bitfields in $\bftwo$;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{same\_lengths}:
+  \item \AllApplyCase{same\_lengths}
   \begin{itemize}
     \item the number of bitfields in $\bfone$ is the same as the number of bitfields in $\bftwo$;
     \item testing whether the bitfield $\bfone[i]$ is equivalent to $\bftwo[i]$ in $\tenv$ for every index
@@ -1542,15 +1542,15 @@ conservatively tests whether the bitfield $\bfone$ is equivalent to the bitfield
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{different\_labels}:
+  \item \AllApplyCase{different\_labels}
   \begin{itemize}
     \item the AST labels of $\bfone$ and $\bftwo$ are different;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{bitfield\_simple}:
+  \item \AllApplyCase{bitfield\_simple}
   \begin{itemize}
     \item $\bfone$ is a simple bitfield with name $\nameone$ and list of slices $\slicesone$, that is, \\ $\BitFieldSimple(\nameone, \slicesone)$;
     \item $\bftwo$ is a simple bitfield with name $\nametwo$ and list of slices $\slicestwo$, that is, \\ $\BitFieldSimple(\nametwo, \slicestwo)$;
@@ -1559,7 +1559,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{bitfield\_nested}:
+  \item \AllApplyCase{bitfield\_nested}
   \begin{itemize}
     \item $\bfone$ is a nested bitfield with name $\nameone$, list of slices $\slicesone$, and nested bitfields $\bfoneone$, that is,
           $\BitFieldNested(\nameone, \slicesone, \bfoneone)$;
@@ -1571,7 +1571,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{bitfield\_typed}:
+  \item \AllApplyCase{bitfield\_typed}
   \begin{itemize}
     \item $\bfone$ is a typed bitfield with name $\nameone$, list of slices $\slicesone$, and type $\vtone$, that is,
           $\BitFieldType(\nameone, \slicesone, \vtone)$;
@@ -1666,22 +1666,22 @@ conservatively tests whether the constraint $\vcone$ is equivalent to the constr
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{different\_labels}:
+  \item \AllApplyCase{different\_labels}
   \begin{itemize}
     \item the AST labels of $\vcone$ and $\vctwo$ are different;
     \item define $\vb$ as $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_exact}:
+  \item \AllApplyCase{constraint\_exact}
   \begin{itemize}
     \item $\vcone$ is an exact constraint with subexpression $\veone$, that is, $\ConstraintExact(\veone)$;
     \item $\vctwo$ is an exact constraint with subexpression $\vetwo$, that is, $\ConstraintExact(\vetwo)$;
     \item applying $\exprequal$ to $\veone$ and $\vetwo$ yields $\vb$\ProseOrTypeError.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_range}:
+  \item \AllApplyCase{constraint\_range}
   \begin{itemize}
     \item $\vcone$ is a range constraint with subexpressions $\veoneone$ and $\veonetwo$, that is, \\ $\ConstraintRange(\veoneone, \veonetwo)$;
     \item $\vctwo$ is a range constraint with subexpressions $\vetwoone$ and $\vetwotwo$, that is, \\ $\ConstraintRange(\vetwoone, \vetwotwo)$;
@@ -1729,15 +1729,15 @@ conservatively tests whether the list of slices $\slicesone$ is equivalent to th
 in environment $\tenv$ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{different\_lengths}:
+  \item \AllApplyCase{different\_lengths}
   \begin{itemize}
     \item checking whether the number of slices in $\slicesone$ is equal to the number of slice in $\slicestwo$ yields $\False$;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{same\_lengths}:
+  \item \AllApplyCase{same\_lengths}
   \begin{itemize}
     \item checking whether the number of slices in $\slicesone$ is equal to the number of slice in $\slicestwo$ yields $\True$;
     \item determining whether the expression $\slicesone[i]$ is equivalent to $\slicestwo[i]$ in $\tenv$
@@ -1774,22 +1774,22 @@ conservatively tests whether the slice $\sliceone$ is equivalent to the slice $\
 in environment $\tenv$ and yields the result in $\vb$. \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{different\_labels}:
+  \item \AllApplyCase{different\_labels}
   \begin{itemize}
     \item $\sliceone$ and $\slicetwo$ have different AST labels;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{slice\_single}:
+  \item \AllApplyCase{slice\_single}
   \begin{itemize}
     \item $\sliceone$ is a slice for a single position, given by the expression $\veone$, that is, $\SliceSingle(\veone)$;
     \item $\slicetwo$ is a slice for a single position, given by the expression $\vetwo$, that is, $\SliceSingle(\vetwo)$;
     \item testing $\veone$ and $\vetwo$ for equivalence yields $\vb$\ProseOrTypeError.
   \end{itemize}
 
-  \item \AllApplyCase{slice\_range}:
+  \item \AllApplyCase{slice\_range}
   \begin{itemize}
     \item $\sliceone$ is a slice for a range of positions, given by the expressions $\veoneone$ and $\veonetwo$, that is, $\SliceRange(\veoneone, \veonetwo)$;
     \item $\slicetwo$ is a slice for a range of positions, given by the expressions $\vetwoone$ and $\vetwotwo$, that is, $\SliceRange(\vetwoone, \vetwotwo)$;
@@ -1798,7 +1798,7 @@ One of the following applies:
     \item $\vb$ is $\True$ if and only if both $\vbone$ and $\vbtwo$ are $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{slice\_length}:
+  \item \AllApplyCase{slice\_length}
   \begin{itemize}
     \item $\sliceone$ is a slice for a range of positions, given by the start expression $\veoneone$ and length expression $\veonetwo$, that is, $\SliceLength(\veoneone, \veonetwo)$;
     \item $\slicetwo$ is a slice for a range of positions, given by the start expression $\vetwoone$ and length expression $\vetwotwo$, that is, $\SliceLength(\vetwoone, \vetwotwo)$;
@@ -1850,22 +1850,22 @@ tests whether the array lengths $\vlone$ and $\vltwo$ are equivalent and yields 
 in $\vb$. \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{different\_labels}:
+  \item \AllApplyCase{different\_labels}
   \begin{itemize}
     \item $\vlone$ and $\vltwo$ have different AST labels;
     \item $\vb$ is $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{expr\_expr}:
+  \item \AllApplyCase{expr\_expr}
   \begin{itemize}
     \item $\vlone$ is an integer type length expression with subexpression $\veoneone$, that is, \\ $\ArrayLengthExpr(\veoneone)$;
     \item $\vltwo$ is an integer type length expression with subexpression $\vetwoone$, that is, \\ $\ArrayLengthExpr(\vetwoone)$;
     \item testing whether $\veoneone$ and $\vetwoone$ are equivalent in $\tenv$ yields $\vb$\ProseOrTypeError.
   \end{itemize}
 
-  \item \AllApplyCase{enum\_enum}:
+  \item \AllApplyCase{enum\_enum}
   \begin{itemize}
     \item $\vlone$ is an enumeration type index for the identifier $\venumone$ and a list of labels, that is,
           $\ArrayLengthEnum(\venumone, \Ignore)$;
@@ -1929,15 +1929,15 @@ The function
 transforms a polynomial $\vp$ into the corresponding expression $\ve$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vp$ is the polynomial with an empty list of monomials, that is, $\emptyfunc$;
     \item define $\ve$ as the literal expression for $0$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vp$ is the polynomial $f$;
     \item sorting (see $\sort$ for details) the graph of $f$ (see $\funcgraph$ for details)
@@ -1990,16 +1990,16 @@ $0$ to mean that any ordering of the monomial bindings is acceptable,
 and $1$ to mean that the second monomial binding should be ordered before the first.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{equal\_monomials}:
+  \item \AllApplyCase{equal\_monomials}
   \begin{itemize}
     \item $\vmone$ is $f$ and $\vmtwo$ is $g$;
     \item $f$ is equal to $g$;
     \item $\vs$ is the sign of $\vqtwo - \vqone$.
   \end{itemize}
 
-  \item \AllApplyCase{different\_monomials}:
+  \item \AllApplyCase{different\_monomials}
   \begin{itemize}
     \item $\vmone$ is $f$ and $\vmtwo$ is $g$;
     \item $f$ is different from to $g$;
@@ -2056,15 +2056,15 @@ into an expression $\ve$, which represents the absolute value of the sum of all 
 and a sign value $\vs$, which indicates the sign of the resulting sum.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\monoms$ is an empty list;
     \item $\ve$ is the literal expression for the integer $0$ and $\vs$ is $0$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty}:
+  \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\monoms$ is a list with $(\vm,q)$ as its \head\ and $\monomsone$ as its \tail;
     \item transforming the unitary monomial $\vm$ to an expression via \\ $\unitarymonomialstoexpr$ yields $\veonep$;
@@ -2102,23 +2102,23 @@ transforms an expression $\ve$ and rational $q$ into the expression $\newe$,
 which represents the absolute value of $\ve$ multiplied by $q$, and the sign of $q$ as $\vs$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{q\_zero}:
+  \item \AllApplyCase{q\_zero}
   \begin{itemize}
     \item $q$ is $0$;
     \item $\newe$ is the literal expression for $0$;
     \item $\vs$ is $0$.
   \end{itemize}
 
-  \item \AllApplyCase{q\_natural}:
+  \item \AllApplyCase{q\_natural}
   \begin{itemize}
     \item $q$ a strictly positive;
     \item symbolically multiplying the literal expression for $q$ and $\ve$ via $\symmulexpr$ yields $\newe$;
     \item $\vs$ is $1$.
   \end{itemize}
 
-  \item \AllApplyCase{q\_positive\_fraction}:
+  \item \AllApplyCase{q\_positive\_fraction}
   \begin{itemize}
     \item $q$ a strictly positive fraction, that is, not an integer;
     \item the reduced representation of the fraction $q$ is $\frac{d}{n}$;
@@ -2127,7 +2127,7 @@ One of the following applies:
     \item $\vs$ is $1$.
   \end{itemize}
 
-  \item \AllApplyCase{q\_negative}:
+  \item \AllApplyCase{q\_negative}
   \begin{itemize}
     \item $q$ a strictly negative;
     \item transforming $\ve$ with $-q$ to an expression and a sign via $\monomialtoexpr$ yields $(\newe, 1)$;
@@ -2203,15 +2203,15 @@ $\vstwo$                      & -1                         & 0               & 1
 \end{center}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{zero}:
+  \item \AllApplyCase{zero}
   \begin{itemize}
     \item either $\vsone$ is $0$ or $\vstwo$ is $0$;
     \item the result is $(\vetwo, \vstwo)$ if $\vsone$ is $0$ and $(\veone, \vsone)$, otherwise.
   \end{itemize}
 
-  \item \AllApplyCase{same\_sign}:
+  \item \AllApplyCase{same\_sign}
   \begin{itemize}
     \item both $\vsone$ and $\vstwo$ are not $0$;
     \item $\vsone$ is equal to $\vstwo$;
@@ -2220,7 +2220,7 @@ One of the following applies:
     \item $\vs$ is $\vsone$;
   \end{itemize}
 
-  \item \AllApplyCase{same\_sign}:
+  \item \AllApplyCase{same\_sign}
   \begin{itemize}
     \item both $\vsone$ and $\vstwo$ are not $0$;
     \item $\vsone$ is different from $\vstwo$;
@@ -2264,21 +2264,21 @@ transforms a list of single-variable unitary monomials $\monoms$ into an express
 Intuitively, $\monoms$ represented a multiplication of the single-variable unitary monomials.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\monoms$ is the empty list;
     \item $\ve$ is the literal expression for $1$.
   \end{itemize}
 
-  \item \AllApplyCase{exp\_zero}:
+  \item \AllApplyCase{exp\_zero}
   \begin{itemize}
     \item $\monoms$ is a list where the first element is $(\vv, 0)$ and its tail is $\monoms$;
     \item transforming $\monomsone$ to an expression yields $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{exp\_one}:
+  \item \AllApplyCase{exp\_one}
   \begin{itemize}
     \item $\monoms$ is a list where the first element is $(\vv, 1)$ and its tail is $\monoms$;
     \item $\veone$ is the variable expression for $\vv$;
@@ -2286,7 +2286,7 @@ One of the following applies:
     \item symbolically multiplying $\veone$ and $\vetwo$ via $\symmulexpr$ yields $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{exp\_two}:
+  \item \AllApplyCase{exp\_two}
   \begin{itemize}
     \item $\monoms$ is a list where the first element is $(\vv, 2)$ and its tail is $\monoms$;
     \item $\veone$ is the binary expression with operator $\MUL$ and operands $\EVar(\vv)$ and $\EVar(\vv)$
@@ -2295,7 +2295,7 @@ One of the following applies:
     \item symbolically multiplying $\veone$ and $\vetwo$ via $\symmulexpr$ yields $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{exp\_gt\_two}:
+  \item \AllApplyCase{exp\_gt\_two}
   \begin{itemize}
     \item $\monoms$ is a list where the first element is $(\vv, n)$ and its tail is $\monoms$;
     \item $n$ is greater than $1$;
@@ -2363,9 +2363,9 @@ produces an expression representing the multiplication of expressions $\veone$ a
 simplifying away the case where one of the operands is the literal one.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{one\_operand}:
+  \item \AllApplyCase{one\_operand}
   \begin{itemize}
     \item either $\veone$ or $\vetwo$ is the literal expression for $1$;
     \item $\ve$ is $\vetwo$ if $\veone$ is the literal expression for $1$ and $\veone$, otherwise.
@@ -2400,20 +2400,20 @@ looks up the environment $\tenv$ for a type $\tty$ associated with an identifier
 $\vs$. The result is type error if $\vs$ is not associated with any type.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{local}:
+  \item \AllApplyCase{local}
   \begin{itemize}
     \item $\vs$ is associated with a type $\tty$ in the local environment of $\tenv$;
   \end{itemize}
 
-  \item \AllApplyCase{global}:
+  \item \AllApplyCase{global}
   \begin{itemize}
     \item $\vs$ is not associated with a type in the local environment of $\tenv$;
     \item $\vs$ is associated with a type $\tty$ in the global environment of $\tenv$;
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item $\vs$ is not associated with a type in the local environment of $\tenv$;
     \item $\vs$ is not associated with a type in the global environment of $\tenv$;
@@ -2458,7 +2458,7 @@ expression that can be symbolically simplified.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
   \item \AllApplyCase{normalizable}
   \begin{itemize}

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -980,7 +980,7 @@ $\forall z\in\Z.\ -\infty < z$ and $\forall z\in\Z.\ z < +\infty$.
 
   \item \AllApplyCase{range\_under}
   \begin{itemize}
-    \item $\vc$ is an \Proserangeconstraint{\veone}{\vetwo};
+    \item $\vc$ is a \Proserangeconstraint{\veone}{\vetwo};
     \item \Proseapproxexprmax{$\tenv$}{$\veone$}{$\vzone$};
     \item \Proseapproxexprmin{$\tenv$}{$\vetwo$}{$\vztwo$};
     \item \Proseeqdef{$\vsinterval$}{the set of integers greater or equal to $\vzone$ and

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -963,13 +963,13 @@ $\forall z\in\Z.\ -\infty < z$ and $\forall z\in\Z.\ z < +\infty$.
 \begin{itemize}
   \item \AllApplyCase{exact}
   \begin{itemize}
-    \item $\vc$ is an \Proseconstraintexact{\ve};
+    \item $\vc$ is an \Proseexactconstraint{\ve};
     \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\ve$}{$\vs$}.
   \end{itemize}
 
   \item \AllApplyCase{range\_over}
   \begin{itemize}
-    \item $\vc$ is an \Proseconstraintrange{\veone}{\vetwo};
+    \item $\vc$ is a \Proserangeconstraint{\veone}{\vetwo};
     \item \Proseapproxexprmin{$\tenv$}{$\veone$}{$\vzone$};
     \item \Proseapproxexprmax{$\tenv$}{$\vetwo$}{$\vztwo$};
     \item \Proseeqdef{$\vsinterval$}{the set of integers greater or equal to $\vzone$ and
@@ -980,7 +980,7 @@ $\forall z\in\Z.\ -\infty < z$ and $\forall z\in\Z.\ z < +\infty$.
 
   \item \AllApplyCase{range\_over}
   \begin{itemize}
-    \item $\vc$ is an \Proseconstraintrange{\veone}{\vetwo};
+    \item $\vc$ is an \Proserangeconstraint{\veone}{\vetwo};
     \item \Proseapproxexprmax{$\tenv$}{$\veone$}{$\vzone$};
     \item \Proseapproxexprmin{$\tenv$}{$\vetwo$}{$\vztwo$};
     \item \Proseeqdef{$\vsinterval$}{the set of integers greater or equal to $\vzone$ and
@@ -1316,7 +1316,7 @@ based on the \approximationdirectionterm\ $\vapprox$.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[named]{
-  \vt = \TNamed(\Ignore)\\
+  \isnamed(\vt)\\
   \makeanonymous(\tenv, \vt) \typearrow \vtp\\
   \approxtype(\tenv, \vapprox, \vtp) \typearrow \vs
 }{
@@ -1335,7 +1335,7 @@ based on the \approximationdirectionterm\ $\vapprox$.
 
 \begin{mathpar}
 \inferrule[other]{
-  \vt \neq \TNamed(\Ignore) \land \vt \neq \TInt(\wellconstrained(\Ignore))\\
+  \neg\isnamed(\vt) \land \neg\iswellconstrainedinteger(\vt)\\
   \approxbottomtop(\vapprox) \typearrow \vs
 }{
   \approxtype(\tenv, \vapprox, \vt) \typearrow \vs

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -86,22 +86,22 @@ The function
 transforms a type $\vt$ in a static environment $\tenv$ into a symbolic domain $\vd$.
 It assumes its input type has an \underlyingtype{} which is an integer.
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{int\_unconstrained}:
+  \item \AllApplyCase{int\_unconstrained}
   \begin{itemize}
     \item $\vt$ is the unconstrained integer type;
     \item define $\vd$ as $\Top$, which intuitively represents the entire set of integers.
   \end{itemize}
 
-  \item \AllApplyCase{int\_parameterized}:
+  \item \AllApplyCase{int\_parameterized}
   \begin{itemize}
     \item $\vt$ is the \parameterizedintegertype\ for the identifier $\id$;
     \item define $\vd$ as the symbolic constrained integer domain with a single constraint for the variable expression for $\id$,
           that is, \\ $\FromSyntax([\ConstraintExact(\EVar(\id))])$.
   \end{itemize}
 
-  \item \AllApplyCase{int\_well\_constrained\_finite}:
+  \item \AllApplyCase{int\_well\_constrained\_finite}
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type for the list of constraints $\vcs$;
     \item applying $\intsetofintconstraints$ to $\vcs$ in $\tenv$ yields $\vis$;
@@ -109,7 +109,7 @@ One of the following applies:
     \item define $\vd$ as the symbolic finite set integer domain for $\vis$.
   \end{itemize}
 
-  \item \AllApplyCase{int\_well\_constrained\_symbolic}:
+  \item \AllApplyCase{int\_well\_constrained\_symbolic}
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type for the list of constraints $\vcs$;
     \item applying $\intsetofintconstraints$ to $\vcs$ in $\tenv$ yields $\vis$;
@@ -117,7 +117,7 @@ One of the following applies:
     \item define $\vd$ as the symbolic constrained integer domain for the list of constraints $\vcs$, that is, $\FromSyntax(\vcs)$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_named}:
+  \item \AllApplyCase{t\_named}
   \begin{itemize}
     \item $\vt$ is the named type for identifier $\id$;
     \item applying $\makeanonymous$ to $\vt$ in $\tenv$ yields $\vtone$;
@@ -178,22 +178,22 @@ The function
 assigns a symbolic domain $\vd$ to an \underline{integer typed} expression $\ve$ in the static environment $\tenv$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{e\_literal}:
+  \item \AllApplyCase{e\_literal}
   \begin{itemize}
     \item $\ve$ is a literal expression for the literal $\vv$;
     \item applying $\symdomofliteral$ to $\vv$ yields $\vd$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_var\_constant}:
+  \item \AllApplyCase{e\_var\_constant}
   \begin{itemize}
     \item $\ve$ is a variable expression for the identifier $\vx$;
     \item applying $\lookupconstant$ to $\vx$ in $\tenv$ yields the literal $\vv$;
     \item applying $\symdomofliteral$ to $\vv$ yields $\vd$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_var\_type}:
+  \item \AllApplyCase{e\_var\_type}
   \begin{itemize}
     \item $\ve$ is a variable expression for the identifier $\vx$;
     \item applying $\lookupconstant$ to $\vx$ in $\tenv$ yields $\bot$;
@@ -201,20 +201,20 @@ One of the following applies:
     \item applying $\symdomoftype$ to $\vtone$ yields $\vd$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_unop\_minus}:
+  \item \AllApplyCase{e\_unop\_minus}
   \begin{itemize}
     \item $\ve$ is a unary operation expression for the operation $\MINUS$ and subexpression $\veone$;
     \item applying $\symdomofexpr$ to the binary operation expression with the operation $\MINUS$
           and the literal expression for $0$ and $\veone$ in $\tenv$ yields $\vd$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_unop\_unknown}:
+  \item \AllApplyCase{e\_unop\_unknown}
   \begin{itemize}
     \item $\ve$ is a unary operation expression for an operation that is not $\MINUS$;
     \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$
   \end{itemize}
 
-  \item \AllApplyCase{e\_binop\_supported}:
+  \item \AllApplyCase{e\_binop\_supported}
   \begin{itemize}
     \item $\ve$ is a binary operation expression for an operation that is one of $\PLUS$, $\MINUS$, or $\MUL$
           and subexpressions $\veone$ and $\vetwo$;
@@ -224,13 +224,13 @@ One of the following applies:
     \item define $\vd$ as $\vis$.
   \end{itemize}
 
-  \item \AllApplyCase{e\_binop\_unsupported}:
+  \item \AllApplyCase{e\_binop\_unsupported}
   \begin{itemize}
     \item $\ve$ is a binary operation expression for an operation that is not one of $\PLUS$, $\MINUS$, or $\MUL$;
     \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$
   \end{itemize}
 
-  \item \AllApplyCase{unsupported}:
+  \item \AllApplyCase{unsupported}
   \begin{itemize}
     \item $\ve$ is not one of the following expression types a literal expression, a variable expression, a unary operation
           expression, or a binary operation expression;
@@ -323,9 +323,9 @@ assigns a symbolic domain $\vd$ to an \underline{integer typed} expression $\ve$
 In contrast to $\symdomofexpr$, $\symdomofwidth$ should be applied to expressions that represent a bitvector width.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{finite\_one\_width}:
+  \item \AllApplyCase{finite\_one\_width}
   \begin{itemize}
     \item applying $\symdomofexpr$ to $\ve$ in $\tenv$ yields $\vdone$;
     \item $\vdone$ is a set of integers, that is, $\Finite(s)$;
@@ -333,7 +333,7 @@ One of the following applies:
     \item $\vd$ is $\vdone$.
   \end{itemize}
 
-  \item \AllApplyCase{finite\_multiple\_widths}:
+  \item \AllApplyCase{finite\_multiple\_widths}
   \begin{itemize}
     \item applying $\symdomofexpr$ to $\ve$ in $\tenv$ yields $\vdone$;
     \item $\vdone$ is a set of integers, that is, $\Finite(s)$;
@@ -341,7 +341,7 @@ One of the following applies:
     \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_finite}:
+  \item \AllApplyCase{non\_finite}
   \begin{itemize}
     \item applying $\symdomofexpr$ to $\ve$ in $\tenv$ yields $\vdone$;
     \item $\vdone$ is not a set of integers, that is, $\astlabel(\vdone)$ is not $\Finite$;
@@ -390,15 +390,15 @@ applies the binary operation $\op$ to the symbolic domains $\visone$ and $\vistw
 yielding the symbolic domain $\vis$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{top}:
+  \item \AllApplyCase{top}
   \begin{itemize}
     \item at least one of $\visone$ and $\vistwo$ is $\Top$;
     \item define $\vis$ as $\Top$.
   \end{itemize}
 
-  \item \AllApplyCase{finite\_finite}:
+  \item \AllApplyCase{finite\_finite}
   \begin{itemize}
     \item $\visone$ is the symbolic finite set integer domain for $\vsone$;
     \item $\vistwo$ is the symbolic finite set integer domain for $\vstwo$;
@@ -406,7 +406,7 @@ One of the following applies:
           by applying $\op$ to each element of $\vsone$ and each element of $\vstwo$.
   \end{itemize}
 
-  \item \AllApplyCase{finite\_syntax}:
+  \item \AllApplyCase{finite\_syntax}
   \begin{itemize}
     \item $\visone$ is the symbolic finite set integer domain for $\vsone$;
     \item $\vistwo$ is the symbolic constrained integer domain for $\vstwo$;
@@ -415,7 +415,7 @@ One of the following applies:
           and $\vistwo$ yields $\vis$.
   \end{itemize}
 
-  \item \AllApplyCase{syntax\_finite}:
+  \item \AllApplyCase{syntax\_finite}
   \begin{itemize}
     \item $\visone$ is the symbolic constrained integer domain for $\csone$;
     \item $\vistwo$ is the symbolic finite set integer domain for $\vstwo$;
@@ -424,7 +424,7 @@ One of the following applies:
           for $\cstwo$, yields $\vis$.
   \end{itemize}
 
-  \item \AllApplyCase{syntax\_syntax\_well\_constrained}:
+  \item \AllApplyCase{syntax\_syntax\_well\_constrained}
   \begin{itemize}
     \item $\visone$ is the symbolic constrained integer domain for $\csone$;
     \item $\vistwo$ is the symbolic constrained integer domain for $\cstwo$;
@@ -485,22 +485,22 @@ The function
 transforms a finite set of integers into the equivalent list of integer constraints.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vs$ is the empty set;
     \item define $\cs$ as the empty list.
   \end{itemize}
 
-  \item \AllApplyCase{singleton}:
+  \item \AllApplyCase{singleton}
   \begin{itemize}
     \item $\vs$ is the singleton set for $a$;
     \item define $\cs$ as the list containing the single range constraint for the interval starting from $a$
           and ending at $a$, that is, $\ConstraintRange(\ELInt{a}, \ELInt{a})$.
   \end{itemize}
 
-  \item \AllApplyCase{new\_interval}:
+  \item \AllApplyCase{new\_interval}
   \begin{itemize}
     \item define $a$ as the minimal element of $\vs$;
     \item define $\vsone$ as the set $\vs$ with $a$ removed from it;
@@ -512,7 +512,7 @@ One of the following applies:
           second element a range constraint for the interval from $b$ to $c$, and remaining elements given by $\cstwo$.
   \end{itemize}
 
-  \item \AllApplyCase{merge\_interval}:
+  \item \AllApplyCase{merge\_interval}
   \begin{itemize}
     \item define $a$ as the minimal element of $\vs$;
     \item define $\vsone$ as the set $\vs$ with $a$ removed from it;
@@ -606,16 +606,16 @@ returns the symbolic domain $\vis$ for the list of constraints $\vcs$
 in the static environment $\tenv$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{finite}:
+  \item \AllApplyCase{finite}
   \begin{itemize}
     \item applying $\constrainttointset$ to every constraint $\vcs[\vi]$ in $\tenv$, for $\vi$ in \\ $\listrange(\vcs)$,
           yields a finite set of integers $C_\vi$, that is, $\Finite(C_\vi)$;
     \item define $\vis$ as the union of $C_\vi$ for all $\vi$ in $\listrange(\vcs)$.
   \end{itemize}
 
-  \item \AllApplyCase{symbolic}:
+  \item \AllApplyCase{symbolic}
   \begin{itemize}
     \item there exists a constraint $\vc$ in $\vcs$ such that applying $\constrainttointset$ to $\vc$
           in $\tenv$ does not yield a finite set of integers;
@@ -662,16 +662,16 @@ It produces $\Top$ when the expressions involved in the integer constraints cann
 to integers.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact}:
+  \item \AllApplyCase{exact}
   \begin{itemize}
     \item $\vc$ is a single expression constraint for $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\normalizetoint$ to $\ve$ in $\tenv$ yields the integer $n$\ProseTerminateAs{\Top};
     \item define $\vis$ as the singleton set for $n$, that is, $\Finite(\{n\})$.
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vc$ is a range constraint for $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item applying $\normalizetoint$ to $\veone$ in $\tenv$ yields the integer $b$\ProseTerminateAs{\Top};
@@ -713,15 +713,15 @@ We assume that $\ve$ has been annotated as it is part of the constraint for an i
 and therefore applying $\normalize$ to it does not yield a type error.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{integer}:
+  \item \AllApplyCase{integer}
   \begin{itemize}
     \item applying $\normalize$ to $\ve$ in $\tenv$ yields the expression $\veone$;
     \item applying $\staticeval$ to $\veone$ in $\tenv$ yields the integer literal for $n$.
   \end{itemize}
 
-  \item \AllApplyCase{top}:
+  \item \AllApplyCase{top}
   \begin{itemize}
     \item applying $\normalize$ to $\ve$ in $\tenv$ yields the expression $\veone$;
     \item applying $\staticeval$ to $\veone$ in $\tenv$ yields $\top$.
@@ -784,29 +784,29 @@ and the symbol $\Under$ to stand for \emph{underapproximation}.
 We refer such a symbol as an \approximationdirectionterm.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{right\_top}:
+  \item \AllApplyCase{right\_top}
   \begin{itemize}
     \item $\vistwo$ is $\Top$;
     \item define $\vb$ as $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{left\_top\_right\_not\_top}:
+  \item \AllApplyCase{left\_top\_right\_not\_top}
   \begin{itemize}
     \item $\visone$ is $\Top$;
     \item $\vistwo$ is not $\Top$;
     \item define $\vb$ as $\False$.
   \end{itemize}
 
-  \item \AllApplyCase{finite\_finite}:
+  \item \AllApplyCase{finite\_finite}
   \begin{itemize}
     \item $\visone$ is a finite set of integers for $\vsone$, that is, $\Finite(\vsone)$;
     \item $\vistwo$ is a finite set of integers for $\vstwo$, that is, $\Finite(\vstwo)$;
     \item define $\vb$ as $\True$ if and only if $\vsone$ is a subset of $\vstwo$ or both sets are equal.
   \end{itemize}
 
-  \item \AllApplyCase{syntax\_syntax}:
+  \item \AllApplyCase{syntax\_syntax}
   \begin{itemize}
     \item $\visone$ is a list of constraints $\csone$, that is, $\FromSyntax(\vsone)$;
     \item $\vistwo$ is a list of constraints $\cstwo$, that is, $\FromSyntax(\vstwo)$;
@@ -815,7 +815,7 @@ One of the following applies:
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vsone$ is a subset of $\vstwo$}.
   \end{itemize}
 
-  \item \AllApplyCase{finite\_syntax}:
+  \item \AllApplyCase{finite\_syntax}
   \begin{itemize}
     \item $\visone$ is a finite set of integers for $\vsone$, that is, $\Finite(\vsone)$;
     \item $\vistwo$ is a list of constraints $\cstwo$, that is, $\FromSyntax(\vstwo)$;
@@ -823,7 +823,7 @@ One of the following applies:
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vsone$ is a subset of $\vstwo$}.
   \end{itemize}
 
-  \item \AllApplyCase{syntax\_finite}:
+  \item \AllApplyCase{syntax\_finite}
   \begin{itemize}
     \item $\visone$ is a list of constraints $\csone$, that is, $\FromSyntax(\vsone)$;
     \item $\vistwo$ is a finite set of integers for $\vstwo$, that is, $\Finite(\vstwo)$;
@@ -1357,9 +1357,9 @@ symbolically applies the binary operation $\op$ to the lists of integer constrai
 yielding the integer constraints $\vics$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{extremities}:
+  \item \AllApplyCase{extremities}
   \begin{itemize}
     \item $\op$ is either $\DIV$, $\DIVRM$, $\MUL$, $\PLUS$, $\MINUS$, $\SHR$, or $\SHL$;
     \item applying $\applybinopextremities$ to every pair of constraints $\csone[\vi]$ and $\cstwo[\vj]$
@@ -1368,14 +1368,14 @@ One of the following applies:
           $\vi\in\listrange(\csone)$ and $\vj\in\listrange(\cstwo)$.
   \end{itemize}
 
-  \item \AllApplyCase{mod}:
+  \item \AllApplyCase{mod}
   \begin{itemize}
     \item $\op$ is $\MOD$;
     \item applying $\constraintmod$ to $\cstwo[\vj]$, for every $\vj\in\listrange(\cstwo)$, yields $\vc_\vj$;
     \item define $\newcs$ as $\vc_\vj$, for every $\vj\in\listrange(\cstwo)$.
   \end{itemize}
 
-  \item \AllApplyCase{pow}:
+  \item \AllApplyCase{pow}
   \begin{itemize}
     \item $\op$ is $\POW$;
     \item applying $\constraintpow$ to every pair of constraints $\csone[\vi]$ and $\cstwo[\vj]$
@@ -1440,16 +1440,16 @@ yields a list of constraints $\newcs$ for the constraints $\vcone$ and $\vctwo$,
 range constraints for cases where the binary operation $\op$ yields a dynamic error.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact\_exact}:
+  \item \AllApplyCase{exact\_exact}
   \begin{itemize}
     \item $\vcone$ is a constraint for the expression $\va$;
     \item $\vctwo$ is a constraint for the expression $\vc$;
     \item define $\newcs$ as the list containing the constraint for the binary expression $\AbbrevEBinop{\op}{\va}{\vc}$.
   \end{itemize}
 
-  \item \AllApplyCase{range\_exact}:
+  \item \AllApplyCase{range\_exact}
   \begin{itemize}
     \item $\vcone$ is a range constraint for the expressions $\va$ and $\vb$;
     \item $\vctwo$ is a constraint for the expression $\vc$;
@@ -1458,7 +1458,7 @@ One of the following applies:
           for each pair of expressions $(\vap, \vbp)$ in $\extpairs$.
   \end{itemize}
 
-  \item \AllApplyCase{exact\_range}:
+  \item \AllApplyCase{exact\_range}
   \begin{itemize}
     \item $\vcone$ is a constraint for the expression $\va$;
     \item $\vctwo$ is a range constraint for the expressions $\vc$ and $\vd$;
@@ -1467,7 +1467,7 @@ One of the following applies:
           for each pair of expressions $(\vcp, \vdp)$ in $\extpairs$.
   \end{itemize}
 
-  \item \AllApplyCase{range\_range}:
+  \item \AllApplyCase{range\_range}
   \begin{itemize}
     \item $\vcone$ is a range constraint for the expressions $\va$ and $\vb$;
     \item $\vctwo$ is a range constraint for the expressions $\vc$ and $\vd$;
@@ -1540,13 +1540,13 @@ for cases where applying $\op$ to $\va$ and $\vb$ would lead to a dynamic error.
 
 \ProseParagraph
 \begin{itemize}
-  \item \AllApplyCase{mul}:
+  \item \AllApplyCase{mul}
   \begin{itemize}
     \item $\op$ is $\MUL$;
     \item define $\extpairs$ as the list consisting of $(\va, \va)$, $(\va, \vb)$, $(\vb, \va)$, and $(\vb, \vb)$.
   \end{itemize}
 
-  \item \AllApplyCase{other}:
+  \item \AllApplyCase{other}
   \begin{itemize}
     \item $\op$ is either $\DIV$, $\DIVRM$, $\SHR$, $\SHL$, $\PLUS$, or $\MINUS$;
     \item define $\extpairs$ as the list consisting of $(\va, \vb)$.
@@ -1583,31 +1583,31 @@ for cases where applying $\op$ to $\vc$ and $\vd$ would lead to a dynamic error.
 
 \ProseParagraph
 \begin{itemize}
-  \item \AllApplyCase{plus}:
+  \item \AllApplyCase{plus}
   \begin{itemize}
     \item $\op$ is $\PLUS$;
     \item define $\extpairs$ as the list consisting of $(\vc, \vd)$.
   \end{itemize}
 
-  \item \AllApplyCase{minus}:
+  \item \AllApplyCase{minus}
   \begin{itemize}
     \item $\op$ is $\MINUS$;
     \item define $\extpairs$ as the list consisting of $(\vd, \vc)$.
   \end{itemize}
 
-  \item \AllApplyCase{mul}:
+  \item \AllApplyCase{mul}
   \begin{itemize}
     \item $\op$ is $\MUL$;
     \item define $\extpairs$ as the list consisting of $(\vc, \vc)$, $(\vc, \vd)$, $(\vd, \vc)$, and $(\vd, \vd)$.
   \end{itemize}
 
-  \item \AllApplyCase{shl\_shr}:
+  \item \AllApplyCase{shl\_shr}
   \begin{itemize}
     \item $\op$ is either $\SHL$ or $\SHR$;
     \item define $\extpairs$ as the list consisting of $(\vd, \ELInt{0})$ and $(\ELInt{0}, \vd)$.
   \end{itemize}
 
-  \item \AllApplyCase{div\_divrm}:
+  \item \AllApplyCase{div\_divrm}
   \begin{itemize}
     \item $\op$ is either $\DIV$ or $\DIVRM$;
     \item define $\extpairs$ as the list consisting of $(\vd, \ELInt{1})$ and $(\ELInt{1}, \vd)$.
@@ -1702,9 +1702,9 @@ yields a list of range constraints $\newcs$ that are needed to calculate the res
 applying a $\POW$ operation to the constraints $\vcone$ and $\vctwo$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact\_exact}:
+  \item \AllApplyCase{exact\_exact}
   \begin{itemize}
     \item $\vcone$ is the constraint for the expression $\va$;
     \item $\vcone$ is the constraint for the expression $\vc$;
@@ -1712,7 +1712,7 @@ One of the following applies:
     for the expression \\ $\EBinop(\POW, \va, \vc)$.
   \end{itemize}
 
-  \item \AllApplyCase{range\_exact}:
+  \item \AllApplyCase{range\_exact}
   \begin{itemize}
     \item $\vcone$ is the range constraint for the expressions $\va$ and $\vb$;
     \item $\vctwo$ is the constraint for the expression $\vc$;
@@ -1725,7 +1725,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item \AllApplyCase{exact\_range}:
+  \item \AllApplyCase{exact\_range}
   \begin{itemize}
     \item $\vcone$ is the constraint for the expression $\va$;
     \item $\vctwo$ is the range constraint for the expressions $\Ignore$ and $\vd$;
@@ -1739,7 +1739,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item \AllApplyCase{range\_range}:
+  \item \AllApplyCase{range\_range}
   \begin{itemize}
     \item $\vcone$ is the range constraint for the expressions $\va$ and $\vb$;
     \item $\vctwo$ is the range constraint for the expressions $\Ignore$ and $\vd$;

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -978,7 +978,7 @@ $\forall z\in\Z.\ -\infty < z$ and $\forall z\in\Z.\ z < +\infty$.
     \item \Proseeqdef{$\vs$}{$\vsinterval$ if $\vzone$ is less than or equal to $\vztwo$ and $\vsbottomtop$, otherwise}.
   \end{itemize}
 
-  \item \AllApplyCase{range\_over}
+  \item \AllApplyCase{range\_under}
   \begin{itemize}
     \item $\vc$ is an \Proserangeconstraint{\veone}{\vetwo};
     \item \Proseapproxexprmax{$\tenv$}{$\veone$}{$\vzone$};

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -59,7 +59,7 @@ We assume that both $\vt$ and $\vs$ have been successfully annotated to integer 
 (otherwise a typing error prevents us from applying this function).
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\symdomoftype$ to $\vt$ in $\tenv$ yields $\dt$;
   \item applying $\symdomoftype$ to $\vs$ in $\tenv$ yields $\ds$;
@@ -88,20 +88,20 @@ It assumes its input type has an \underlyingtype{} which is an integer.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{int\_unconstrained}):
+  \item \AllApplyCase{int\_unconstrained}:
   \begin{itemize}
     \item $\vt$ is the unconstrained integer type;
     \item define $\vd$ as $\Top$, which intuitively represents the entire set of integers.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_parameterized}):
+  \item \AllApplyCase{int\_parameterized}:
   \begin{itemize}
     \item $\vt$ is the \parameterizedintegertype\ for the identifier $\id$;
     \item define $\vd$ as the symbolic constrained integer domain with a single constraint for the variable expression for $\id$,
           that is, \\ $\FromSyntax([\ConstraintExact(\EVar(\id))])$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_well\_constrained\_finite}):
+  \item \AllApplyCase{int\_well\_constrained\_finite}:
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type for the list of constraints $\vcs$;
     \item applying $\intsetofintconstraints$ to $\vcs$ in $\tenv$ yields $\vis$;
@@ -109,7 +109,7 @@ One of the following applies:
     \item define $\vd$ as the symbolic finite set integer domain for $\vis$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{int\_well\_constrained\_symbolic}):
+  \item \AllApplyCase{int\_well\_constrained\_symbolic}:
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type for the list of constraints $\vcs$;
     \item applying $\intsetofintconstraints$ to $\vcs$ in $\tenv$ yields $\vis$;
@@ -117,7 +117,7 @@ One of the following applies:
     \item define $\vd$ as the symbolic constrained integer domain for the list of constraints $\vcs$, that is, $\FromSyntax(\vcs)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_named}):
+  \item \AllApplyCase{t\_named}:
   \begin{itemize}
     \item $\vt$ is the named type for identifier $\id$;
     \item applying $\makeanonymous$ to $\vt$ in $\tenv$ yields $\vtone$;
@@ -180,20 +180,20 @@ assigns a symbolic domain $\vd$ to an \underline{integer typed} expression $\ve$
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{e\_literal}):
+  \item \AllApplyCase{e\_literal}:
   \begin{itemize}
     \item $\ve$ is a literal expression for the literal $\vv$;
     \item applying $\symdomofliteral$ to $\vv$ yields $\vd$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_var\_constant}):
+  \item \AllApplyCase{e\_var\_constant}:
   \begin{itemize}
     \item $\ve$ is a variable expression for the identifier $\vx$;
     \item applying $\lookupconstant$ to $\vx$ in $\tenv$ yields the literal $\vv$;
     \item applying $\symdomofliteral$ to $\vv$ yields $\vd$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_var\_type}):
+  \item \AllApplyCase{e\_var\_type}:
   \begin{itemize}
     \item $\ve$ is a variable expression for the identifier $\vx$;
     \item applying $\lookupconstant$ to $\vx$ in $\tenv$ yields $\bot$;
@@ -201,20 +201,20 @@ One of the following applies:
     \item applying $\symdomoftype$ to $\vtone$ yields $\vd$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_unop\_minus}):
+  \item \AllApplyCase{e\_unop\_minus}:
   \begin{itemize}
     \item $\ve$ is a unary operation expression for the operation $\MINUS$ and subexpression $\veone$;
     \item applying $\symdomofexpr$ to the binary operation expression with the operation $\MINUS$
           and the literal expression for $0$ and $\veone$ in $\tenv$ yields $\vd$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_unop\_unknown}):
+  \item \AllApplyCase{e\_unop\_unknown}:
   \begin{itemize}
     \item $\ve$ is a unary operation expression for an operation that is not $\MINUS$;
     \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_binop\_supported}):
+  \item \AllApplyCase{e\_binop\_supported}:
   \begin{itemize}
     \item $\ve$ is a binary operation expression for an operation that is one of $\PLUS$, $\MINUS$, or $\MUL$
           and subexpressions $\veone$ and $\vetwo$;
@@ -224,13 +224,13 @@ One of the following applies:
     \item define $\vd$ as $\vis$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{e\_binop\_unsupported}):
+  \item \AllApplyCase{e\_binop\_unsupported}:
   \begin{itemize}
     \item $\ve$ is a binary operation expression for an operation that is not one of $\PLUS$, $\MINUS$, or $\MUL$;
     \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$
   \end{itemize}
 
-  \item All of the following apply (\textsc{unsupported}):
+  \item \AllApplyCase{unsupported}:
   \begin{itemize}
     \item $\ve$ is not one of the following expression types a literal expression, a variable expression, a unary operation
           expression, or a binary operation expression;
@@ -325,7 +325,7 @@ In contrast to $\symdomofexpr$, $\symdomofwidth$ should be applied to expression
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{finite\_one\_width}):
+  \item \AllApplyCase{finite\_one\_width}:
   \begin{itemize}
     \item applying $\symdomofexpr$ to $\ve$ in $\tenv$ yields $\vdone$;
     \item $\vdone$ is a set of integers, that is, $\Finite(s)$;
@@ -333,7 +333,7 @@ One of the following applies:
     \item $\vd$ is $\vdone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{finite\_multiple\_widths}):
+  \item \AllApplyCase{finite\_multiple\_widths}:
   \begin{itemize}
     \item applying $\symdomofexpr$ to $\ve$ in $\tenv$ yields $\vdone$;
     \item $\vdone$ is a set of integers, that is, $\Finite(s)$;
@@ -341,7 +341,7 @@ One of the following applies:
     \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_finite}):
+  \item \AllApplyCase{non\_finite}:
   \begin{itemize}
     \item applying $\symdomofexpr$ to $\ve$ in $\tenv$ yields $\vdone$;
     \item $\vdone$ is not a set of integers, that is, $\astlabel(\vdone)$ is not $\Finite$;
@@ -392,13 +392,13 @@ yielding the symbolic domain $\vis$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{top}):
+  \item \AllApplyCase{top}:
   \begin{itemize}
     \item at least one of $\visone$ and $\vistwo$ is $\Top$;
     \item define $\vis$ as $\Top$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{finite\_finite}):
+  \item \AllApplyCase{finite\_finite}:
   \begin{itemize}
     \item $\visone$ is the symbolic finite set integer domain for $\vsone$;
     \item $\vistwo$ is the symbolic finite set integer domain for $\vstwo$;
@@ -406,7 +406,7 @@ One of the following applies:
           by applying $\op$ to each element of $\vsone$ and each element of $\vstwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{finite\_syntax}):
+  \item \AllApplyCase{finite\_syntax}:
   \begin{itemize}
     \item $\visone$ is the symbolic finite set integer domain for $\vsone$;
     \item $\vistwo$ is the symbolic constrained integer domain for $\vstwo$;
@@ -415,7 +415,7 @@ One of the following applies:
           and $\vistwo$ yields $\vis$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{syntax\_finite}):
+  \item \AllApplyCase{syntax\_finite}:
   \begin{itemize}
     \item $\visone$ is the symbolic constrained integer domain for $\csone$;
     \item $\vistwo$ is the symbolic finite set integer domain for $\vstwo$;
@@ -424,7 +424,7 @@ One of the following applies:
           for $\cstwo$, yields $\vis$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{syntax\_syntax\_well\_constrained}):
+  \item \AllApplyCase{syntax\_syntax\_well\_constrained}:
   \begin{itemize}
     \item $\visone$ is the symbolic constrained integer domain for $\csone$;
     \item $\vistwo$ is the symbolic constrained integer domain for $\cstwo$;
@@ -487,20 +487,20 @@ transforms a finite set of integers into the equivalent list of integer constrai
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\vs$ is the empty set;
     \item define $\cs$ as the empty list.
   \end{itemize}
 
-  \item All of the following apply (\textsc{singleton}):
+  \item \AllApplyCase{singleton}:
   \begin{itemize}
     \item $\vs$ is the singleton set for $a$;
     \item define $\cs$ as the list containing the single range constraint for the interval starting from $a$
           and ending at $a$, that is, $\ConstraintRange(\ELInt{a}, \ELInt{a})$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{new\_interval}):
+  \item \AllApplyCase{new\_interval}:
   \begin{itemize}
     \item define $a$ as the minimal element of $\vs$;
     \item define $\vsone$ as the set $\vs$ with $a$ removed from it;
@@ -512,7 +512,7 @@ One of the following applies:
           second element a range constraint for the interval from $b$ to $c$, and remaining elements given by $\cstwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{merge\_interval}):
+  \item \AllApplyCase{merge\_interval}:
   \begin{itemize}
     \item define $a$ as the minimal element of $\vs$;
     \item define $\vsone$ as the set $\vs$ with $a$ removed from it;
@@ -579,7 +579,7 @@ The function
 returns the symbolic domain $\vd$ that corresponds to the literal $\vv$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\vv$ is an integer literal for $n$;
   \item define $\vd$ as the symbolic finite set integer domain for the singleton set for $n$, that is, $\Finite(\{n\})$.
@@ -608,14 +608,14 @@ in the static environment $\tenv$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{finite}):
+  \item \AllApplyCase{finite}:
   \begin{itemize}
     \item applying $\constrainttointset$ to every constraint $\vcs[\vi]$ in $\tenv$, for $\vi$ in \\ $\listrange(\vcs)$,
           yields a finite set of integers $C_\vi$, that is, $\Finite(C_\vi)$;
     \item define $\vis$ as the union of $C_\vi$ for all $\vi$ in $\listrange(\vcs)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{symbolic}):
+  \item \AllApplyCase{symbolic}:
   \begin{itemize}
     \item there exists a constraint $\vc$ in $\vcs$ such that applying $\constrainttointset$ to $\vc$
           in $\tenv$ does not yield a finite set of integers;
@@ -664,14 +664,14 @@ to integers.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact}):
+  \item \AllApplyCase{exact}:
   \begin{itemize}
     \item $\vc$ is a single expression constraint for $\ve$, that is, $\ConstraintExact(\ve)$;
     \item applying $\normalizetoint$ to $\ve$ in $\tenv$ yields the integer $n$\ProseTerminateAs{\Top};
     \item define $\vis$ as the singleton set for $n$, that is, $\Finite(\{n\})$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vc$ is a range constraint for $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item applying $\normalizetoint$ to $\veone$ in $\tenv$ yields the integer $b$\ProseTerminateAs{\Top};
@@ -715,13 +715,13 @@ and therefore applying $\normalize$ to it does not yield a type error.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{integer}):
+  \item \AllApplyCase{integer}:
   \begin{itemize}
     \item applying $\normalize$ to $\ve$ in $\tenv$ yields the expression $\veone$;
     \item applying $\staticeval$ to $\veone$ in $\tenv$ yields the integer literal for $n$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{top}):
+  \item \AllApplyCase{top}:
   \begin{itemize}
     \item applying $\normalize$ to $\ve$ in $\tenv$ yields the expression $\veone$;
     \item applying $\staticeval$ to $\veone$ in $\tenv$ yields $\top$.
@@ -786,27 +786,27 @@ We refer such a symbol as an \approximationdirectionterm.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{right\_top}):
+  \item \AllApplyCase{right\_top}:
   \begin{itemize}
     \item $\vistwo$ is $\Top$;
     \item define $\vb$ as $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{left\_top\_right\_not\_top}):
+  \item \AllApplyCase{left\_top\_right\_not\_top}:
   \begin{itemize}
     \item $\visone$ is $\Top$;
     \item $\vistwo$ is not $\Top$;
     \item define $\vb$ as $\False$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{finite\_finite}):
+  \item \AllApplyCase{finite\_finite}:
   \begin{itemize}
     \item $\visone$ is a finite set of integers for $\vsone$, that is, $\Finite(\vsone)$;
     \item $\vistwo$ is a finite set of integers for $\vstwo$, that is, $\Finite(\vstwo)$;
     \item define $\vb$ as $\True$ if and only if $\vsone$ is a subset of $\vstwo$ or both sets are equal.
   \end{itemize}
 
-  \item All of the following apply (\textsc{syntax\_syntax}):
+  \item \AllApplyCase{syntax\_syntax}:
   \begin{itemize}
     \item $\visone$ is a list of constraints $\csone$, that is, $\FromSyntax(\vsone)$;
     \item $\vistwo$ is a list of constraints $\cstwo$, that is, $\FromSyntax(\vstwo)$;
@@ -815,7 +815,7 @@ One of the following applies:
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vsone$ is a subset of $\vstwo$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{finite\_syntax}):
+  \item \AllApplyCase{finite\_syntax}:
   \begin{itemize}
     \item $\visone$ is a finite set of integers for $\vsone$, that is, $\Finite(\vsone)$;
     \item $\vistwo$ is a list of constraints $\cstwo$, that is, $\FromSyntax(\vstwo)$;
@@ -823,7 +823,7 @@ One of the following applies:
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vsone$ is a subset of $\vstwo$}.
   \end{itemize}
 
-  \item All of the following apply (\textsc{syntax\_finite}):
+  \item \AllApplyCase{syntax\_finite}:
   \begin{itemize}
     \item $\visone$ is a list of constraints $\csone$, that is, $\FromSyntax(\vsone)$;
     \item $\vistwo$ is a finite set of integers for $\vstwo$, that is, $\Finite(\vstwo)$;
@@ -1359,7 +1359,7 @@ yielding the integer constraints $\vics$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{extremities}):
+  \item \AllApplyCase{extremities}:
   \begin{itemize}
     \item $\op$ is either $\DIV$, $\DIVRM$, $\MUL$, $\PLUS$, $\MINUS$, $\SHR$, or $\SHL$;
     \item applying $\applybinopextremities$ to every pair of constraints $\csone[\vi]$ and $\cstwo[\vj]$
@@ -1368,14 +1368,14 @@ One of the following applies:
           $\vi\in\listrange(\csone)$ and $\vj\in\listrange(\cstwo)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{mod}):
+  \item \AllApplyCase{mod}:
   \begin{itemize}
     \item $\op$ is $\MOD$;
     \item applying $\constraintmod$ to $\cstwo[\vj]$, for every $\vj\in\listrange(\cstwo)$, yields $\vc_\vj$;
     \item define $\newcs$ as $\vc_\vj$, for every $\vj\in\listrange(\cstwo)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{pow}):
+  \item \AllApplyCase{pow}:
   \begin{itemize}
     \item $\op$ is $\POW$;
     \item applying $\constraintpow$ to every pair of constraints $\csone[\vi]$ and $\cstwo[\vj]$
@@ -1442,14 +1442,14 @@ range constraints for cases where the binary operation $\op$ yields a dynamic er
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact\_exact}):
+  \item \AllApplyCase{exact\_exact}:
   \begin{itemize}
     \item $\vcone$ is a constraint for the expression $\va$;
     \item $\vctwo$ is a constraint for the expression $\vc$;
     \item define $\newcs$ as the list containing the constraint for the binary expression $\AbbrevEBinop{\op}{\va}{\vc}$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range\_exact}):
+  \item \AllApplyCase{range\_exact}:
   \begin{itemize}
     \item $\vcone$ is a range constraint for the expressions $\va$ and $\vb$;
     \item $\vctwo$ is a constraint for the expression $\vc$;
@@ -1458,7 +1458,7 @@ One of the following applies:
           for each pair of expressions $(\vap, \vbp)$ in $\extpairs$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{exact\_range}):
+  \item \AllApplyCase{exact\_range}:
   \begin{itemize}
     \item $\vcone$ is a constraint for the expression $\va$;
     \item $\vctwo$ is a range constraint for the expressions $\vc$ and $\vd$;
@@ -1467,7 +1467,7 @@ One of the following applies:
           for each pair of expressions $(\vcp, \vdp)$ in $\extpairs$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range\_range}):
+  \item \AllApplyCase{range\_range}:
   \begin{itemize}
     \item $\vcone$ is a range constraint for the expressions $\va$ and $\vb$;
     \item $\vctwo$ is a range constraint for the expressions $\vc$ and $\vd$;
@@ -1540,13 +1540,13 @@ for cases where applying $\op$ to $\va$ and $\vb$ would lead to a dynamic error.
 
 \ProseParagraph
 \begin{itemize}
-  \item All of the following apply (\textsc{mul}):
+  \item \AllApplyCase{mul}:
   \begin{itemize}
     \item $\op$ is $\MUL$;
     \item define $\extpairs$ as the list consisting of $(\va, \va)$, $(\va, \vb)$, $(\vb, \va)$, and $(\vb, \vb)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{other}):
+  \item \AllApplyCase{other}:
   \begin{itemize}
     \item $\op$ is either $\DIV$, $\DIVRM$, $\SHR$, $\SHL$, $\PLUS$, or $\MINUS$;
     \item define $\extpairs$ as the list consisting of $(\va, \vb)$.
@@ -1583,31 +1583,31 @@ for cases where applying $\op$ to $\vc$ and $\vd$ would lead to a dynamic error.
 
 \ProseParagraph
 \begin{itemize}
-  \item All of the following apply (\textsc{plus}):
+  \item \AllApplyCase{plus}:
   \begin{itemize}
     \item $\op$ is $\PLUS$;
     \item define $\extpairs$ as the list consisting of $(\vc, \vd)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{minus}):
+  \item \AllApplyCase{minus}:
   \begin{itemize}
     \item $\op$ is $\MINUS$;
     \item define $\extpairs$ as the list consisting of $(\vd, \vc)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{mul}):
+  \item \AllApplyCase{mul}:
   \begin{itemize}
     \item $\op$ is $\MUL$;
     \item define $\extpairs$ as the list consisting of $(\vc, \vc)$, $(\vc, \vd)$, $(\vd, \vc)$, and $(\vd, \vd)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{shl\_shr}):
+  \item \AllApplyCase{shl\_shr}:
   \begin{itemize}
     \item $\op$ is either $\SHL$ or $\SHR$;
     \item define $\extpairs$ as the list consisting of $(\vd, \ELInt{0})$ and $(\ELInt{0}, \vd)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{div\_divrm}):
+  \item \AllApplyCase{div\_divrm}:
   \begin{itemize}
     \item $\op$ is either $\DIV$ or $\DIVRM$;
     \item define $\extpairs$ as the list consisting of $(\vd, \ELInt{1})$ and $(\ELInt{1}, \vd)$.
@@ -1666,7 +1666,7 @@ inferred for \texttt{z} is\\
 \ASLListing{An illegal value for }{typing-constraintmod}{\typingtests/TypingRule.ConstraintMod.bad.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item \Proseeqdef{$\veupper$}{
     $\ve$ if $\vc$ is a single constraint for $\ve$,
@@ -1704,7 +1704,7 @@ applying a $\POW$ operation to the constraints $\vcone$ and $\vctwo$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact\_exact}):
+  \item \AllApplyCase{exact\_exact}:
   \begin{itemize}
     \item $\vcone$ is the constraint for the expression $\va$;
     \item $\vcone$ is the constraint for the expression $\vc$;
@@ -1712,7 +1712,7 @@ One of the following applies:
     for the expression \\ $\EBinop(\POW, \va, \vc)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range\_exact}):
+  \item \AllApplyCase{range\_exact}:
   \begin{itemize}
     \item $\vcone$ is the range constraint for the expressions $\va$ and $\vb$;
     \item $\vctwo$ is the constraint for the expression $\vc$;
@@ -1725,7 +1725,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item All of the following apply (\textsc{exact\_range}):
+  \item \AllApplyCase{exact\_range}:
   \begin{itemize}
     \item $\vcone$ is the constraint for the expression $\va$;
     \item $\vctwo$ is the range constraint for the expressions $\Ignore$ and $\vd$;
@@ -1739,7 +1739,7 @@ One of the following applies:
     \end{itemize}
   \end{itemize}
 
-  \item All of the following apply (\textsc{range\_range}):
+  \item \AllApplyCase{range\_range}:
   \begin{itemize}
     \item $\vcone$ is the range constraint for the expressions $\va$ and $\vb$;
     \item $\vctwo$ is the range constraint for the expressions $\Ignore$ and $\vd$;

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -1658,12 +1658,12 @@ The function
 yields a range constraint $\newc$ from $0$ to the expression in $\vc$ that is maximal.
 This is needed to apply the modulus operation to a pair of constraints.
 
-\subsubsection{Example}
+\ExampleDef{Ill-typed Modulus Constraint Assignment}
 In \listingref{typing-constraintmod}, the assignment to \texttt{z} is illegal, since the type
 inferred for \texttt{z} is\\
 \verb|integer{0..2}|.
 
-\ASLListing{An illegal value for }{typing-constraintmod}{\typingtests/TypingRule.ConstraintMod.bad.asl}
+\ASLListing{An ill-typed modulus constraint assignment}{typing-constraintmod}{\typingtests/TypingRule.ConstraintMod.bad.asl}
 
 \ProseParagraph
 \AllApply

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -716,15 +716,15 @@ which is never returned by the scanner.
 \begin{tabular}{ll}
 \textbf{Terminals} & \textbf{Associativity}\\
 \hline
-\Telse & \nonassoc\\
-\Tbor, \Tband, \Timpl, \Tbeq, \Tas & \leftassoc\\
-\Teqop, \Tneq & \leftassoc\\
-\Tgt, \Tgeq, \Tlt, \Tleq & \nonassoc\\
-\Tplus, \Tminus, \Tor, \Txor, \Tand, \Tcoloncolon & \leftassoc\\
-\Tmul, \Tdiv, \Tdivrm, \Trdiv, \Tmod, \Tshl, \Tshr & \leftassoc\\
-\Tpow & \leftassoc\\
-$\Tunops$ & \nonassoc\\
-\Tin & \nonassoc\\
-\Tdot, \Tlbracket, \Tllbracket & \leftassoc
+$\Telse$ & $\nonassoc$\\
+$\Tbor$, $\Tband$, $\Timpl$, $\Tas$ & $\leftassoc$\\
+$\Teqop$, $\Tneq$ & $\leftassoc$\\
+$\Tgt$, $\Tgeq$, $\Tlt$, $\Tleq$ & $\nonassoc$\\
+$\Tplus$, $\Tminus$, $\Tor$, $\Txor$, $\Tand$, $\Tcoloncolon$ & $\leftassoc$\\
+$\Tmul$, $\Tdiv$, $\Tdivrm$, $\Trdiv$, $\Tmod$, $\Tshl$, $\Tshr$ & $\leftassoc$\\
+$\Tpow$ & $\leftassoc$\\
+$\Tunops$ & $\nonassoc$\\
+$\Tin$ & $\nonassoc$\\
+$\Tdot$, $\Tlbracket$, $\Tllbracket$ & $\leftassoc$
 \end{tabular}
 \end{center}

--- a/asllib/doc/TopLevel.tex
+++ b/asllib/doc/TopLevel.tex
@@ -1287,17 +1287,17 @@ yielding the constraint $\newc$.
 \begin{itemize}
   \item \AllApplyCase{exact}
   \begin{itemize}
-    \item $\vx$ is a \Proseconstraintexact{$\ve$};
+    \item $\vx$ is an \Proseexactconstraint{$\ve$};
     \item \Proserenamelocals{$\ve$}{$\vep$};
-    \item \Proseeqdef{$\newc$}{\Proseconstraintexact{$\vep$}}.
+    \item \Proseeqdef{$\newc$}{\Proseexactconstraint{$\vep$}}.
   \end{itemize}
 
   \item \AllApplyCase{range}
   \begin{itemize}
-    \item $\vx$ is a \Proseconstraintrange{$\veone$}{$\vetwo$};
+    \item $\vx$ is a \Proserangeconstraint{$\veone$}{$\vetwo$};
     \item \Proserenamelocals{$\veone$}{$\veonep$};
     \item \Proserenamelocals{$\vetwo$}{$\vetwop$};
-    \item \Proseeqdef{$\newc$}{\Proseconstraintrange{$\veonep$}{$\vetwop$}}.
+    \item \Proseeqdef{$\newc$}{the \Proserangeconstraint{$\veonep$}{$\vetwop$}}.
   \end{itemize}
 \end{itemize}
 

--- a/asllib/doc/TopLevel.tex
+++ b/asllib/doc/TopLevel.tex
@@ -39,7 +39,7 @@ or a dynamic error.
 
 \subsubsection{TopLevelRule.CheckAndInterpret\label{sec:TopLevelRule.CheckAndInterpret}}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
     \item \Proseaslscan{$\vstdtext$}{$\spectoken$}{$\vstdtokens$\ProseTerminateAs{\LexicalErrorConfig}};
     \item \Proseaslparse{$\vstdtokens$}{$\vstdparse$\ProseTerminateAs{\ParseErrorConfig}};
@@ -112,7 +112,7 @@ renames the local storage elements appearing in $\vdecls$,
 yielding the list of declarations $\vnewdecls$.
 
 \ProseParagraph
-\AllApply:
+\AllApply
 \begin{itemize}
   \item \Proserenamelocalsdecl{$\vdecls[\vi]$}{$\vnewdecl_\vi$},
         for each \Proselistrange{$\vi$}{$\vdecls$};

--- a/asllib/doc/TopLevel.tex
+++ b/asllib/doc/TopLevel.tex
@@ -1377,12 +1377,12 @@ renames the local identifier $\name$,
 yielding the identifier $\newname$.
 
 \ProseParagraph
-\Proseeqdef{$\newname$}{the string concatenation of \texttt{\_\_stdlib\_local\_} and $\name$}.
+\Proseeqdef{$\newname$}{the string concatenation of $\stdliblocalprefix$ and $\name$}.
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{}{
-  \renamelocalsname(\name) \astarrow \overname{\texttt{\_\_stdlib\_local\_}\ \stringconcat\ \name}{\newname}
+  \renamelocalsname(\name) \astarrow \overname{\stdliblocalprefix\ \stringconcat\ \name}{\newname}
 }
 \end{mathpar}
 

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -137,7 +137,7 @@ The predicate
 tests whether the type $\tty$ is a \emph{builtin type}.
 
 \ProseParagraph
-$\tty$ is a builtin type and one of the following applies:
+$\tty$ is a builtin type and \OneApplies
 \begin{itemize}
 \item $\tty$ is singular;
 \item $\tty$ is builtin aggregate.
@@ -348,29 +348,29 @@ The predicate
 tests whether the type $\tty$ is a \emph{non-primitive type}.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{singular}:
+  \item \AllApplyCase{singular}
   \begin{itemize}
   \item $\tty$ is a builtin singular type;
   \item $\vb$ is $\False$.
   \end{itemize}
-  \item \AllApplyCase{named}:
+  \item \AllApplyCase{named}
   \begin{itemize}
     \item $\tty$ is a named type;
     \item $\vb$ is $\True$.
   \end{itemize}
-  \item \AllApplyCase{tuple}:
+  \item \AllApplyCase{tuple}
   \begin{itemize}
     \item $\tty$ is a tuple type $\vli$;
     \item $\vb$ is $\True$ if and only if there exists a non-primitive type in $\vli$.
   \end{itemize}
-  \item \AllApplyCase{array}:
+  \item \AllApplyCase{array}
     \begin{itemize}
     \item $\tty$ is an array of type $\tty'$
     \item $\vb$ is $\True$ if and only if $\tty'$ is non-primitive.
     \end{itemize}
-  \item \AllApplyCase{structured}:
+  \item \AllApplyCase{structured}
     \begin{itemize}
     \item $\tty$ is a \structuredtype\ with fields $\fields$;
     \item $\vb$ is $\True$ if and only if there exists a non-primitive type in $\fields$.
@@ -488,20 +488,20 @@ which ensures that \TypingRuleRef{Structure} terminates\footnote{In mathematical
 this ensures that \TypingRuleRef{Structure} is a proper \emph{structural induction.}}.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-\item \AllApplyCase{named}:
+\item \AllApplyCase{named}
   \begin{itemize}
   \item $\tty$ is a named type $\vx$;
   \item obtaining the declared type associated with $\vx$ in the static environment $\tenv$ yields $\vtone$\ProseOrTypeError;
   \item obtaining the structure of $\vtone$ static environment $\tenv$ yields $\vt$\ProseOrTypeError;
   \end{itemize}
-\item \AllApplyCase{builtin\_singular}:
+\item \AllApplyCase{builtin\_singular}
   \begin{itemize}
   \item $\tty$ is a builtin singular type;
   \item $\vt$ is $\tty$.
   \end{itemize}
-\item \AllApplyCase{tuple}:
+\item \AllApplyCase{tuple}
   \begin{itemize}
   \item $\tty$ is a tuple type with list of types $\tys$;
   \item the types in $\tys$ are indexed as $\vt_i$, for $i=1..k$;
@@ -509,13 +509,13 @@ One of the following applies:
   yields $\vtp_i$\ProseOrTypeError;
   \item $\vt$ is a tuple type with the list of types $\vtp_i$, for $i=1..k$.
   \end{itemize}
-\item \AllApplyCase{array}:
+\item \AllApplyCase{array}
   \begin{itemize}
     \item $\tty$ is an array type of length $\ve$ with element type $\vt$;
     \item obtaining the structure of $\vt$ yields $\vtone$\ProseOrTypeError;
     \item $\vt$ is an array type with of length $\ve$ with element type $\vtone$.
   \end{itemize}
-\item \AllApplyCase{structured}:
+\item \AllApplyCase{structured}
   \begin{itemize}
   \item $\tty$ is a \structuredtype\ with fields $\fields$;
   \item obtaining the structure for each type $\vt$ associated with field $\id$ yields a type $\vt_\id$\ProseOrTypeError;
@@ -617,16 +617,16 @@ The \underlyingtype{} of \texttt{(integer, T2)} and \texttt{T3} is
 \texttt{T2}, which is \texttt{(integer, integer)}.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{named}:
+  \item \AllApplyCase{named}
   \begin{itemize}
     \item $\tty$ is a named type $\vx$;
     \item obtaining the type declared for $\vx$ yields $\vtone$\ProseOrTypeError;
     \item the \underlyingtype\ of $\vtone$ is $\vt$.
   \end{itemize}
 
-  \item \AllApplyCase{non-named}:
+  \item \AllApplyCase{non-named}
   \begin{itemize}
     \item $\tty$ is not a named type $\vx$;
     \item $\vt$ is $\tty$.
@@ -660,27 +660,27 @@ The function
 checks whether the type $\vt$ is a \constrainedinteger. If so, the result is $\True$, otherwise a type error is returned.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{well-constrained}:
+  \item \AllApplyCase{well-constrained}
   \begin{itemize}
     \item $\vt$ is a well-constrained integer;
     \item the result is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{parameterized}:
+  \item \AllApplyCase{parameterized}
   \begin{itemize}
     \item $\vt$ is a \parameterizedintegertype;
     \item the result is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{unconstrained}:
+  \item \AllApplyCase{unconstrained}
   \begin{itemize}
     \item $\vt$ is an unconstrained integer or pending constrained integer;
     \item the result is a type error indicating that a constrained integer type is expected.
   \end{itemize}
 
-  \item \AllApplyCase{conflicting\_type}:
+  \item \AllApplyCase{conflicting\_type}
   \begin{itemize}
     \item $\vt$ is not an integer type;
     \item the result is a type error indicating the type conflict.

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -207,7 +207,7 @@ tests whether the type $\tty$ is an \anonymoustype.
 
 \ProseParagraph
 \Anonymoustypes\ are types that are not declared using the type syntax:
-integer types, the \realtypeterm{}, the string type, the Boolean type,
+integer types, the \realtypeterm{}, the \stringtypeterm{}, the Boolean type,
 bitvector types, tuple types, and array types.
 
 \subsubsection{Example}

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -234,14 +234,9 @@ The predicate
   \issingular(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\tty}) \;\aslto\;
   \overname{\Bool}{\vb} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-tests whether the type $\tty$ is a \emph{singular type} in the static environment $\tenv$.
-
-\ProseParagraph
-A type $\tty$ is singular if and only if all of the following apply:
-\begin{itemize}
-  \item obtaining the \underlyingtype\ of $\tty$ in the environment $\tenv$ yields $\vtone$\ProseOrTypeError;
-  \item $\vtone$ is a builtin singular type.
-\end{itemize}
+tests whether the type $\tty$ is a \emph{singular type} in the static environment $\tenv$,
+yielding the result in $\vb$.
+\ProseOtherwiseTypeError
 
 \subsubsection{Example}
 In the following example, the types \texttt{A}, \texttt{B}, and \texttt{C} are all singular types:
@@ -250,6 +245,13 @@ type A of integer;
 type B of A;
 type C of B;
 \end{lstlisting}
+
+\ProseParagraph
+\AllApply
+\begin{itemize}
+  \item obtaining the \underlyingtype\ of $\tty$ in the environment $\tenv$ yields $\vtone$\ProseOrTypeError;
+  \item applying $\isbuiltinsingular$ to $\vtone$ yields $\vb$.
+\end{itemize}
 
 \CodeSubsection{\SingularBegin}{\SingularEnd}{../types.ml}
 
@@ -273,16 +275,10 @@ The predicate
   \isaggregate(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\tty}) \;\aslto\;
   \overname{\Bool}{\vb} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-tests whether the type $\tty$ is an \emph{aggregate type} in the static environment $\tenv$.
+tests whether the type $\tty$ is an \emph{aggregate type} in the static environment $\tenv$,
+yielding the result in $\vb$.
 
-\ProseParagraph
-A type $\tty$ is aggregate in an environment $\tenv$ if and only if all of the following apply:
-\begin{itemize}
-  \item obtaining the \underlyingtype\ of $\tty$ in the environment $\tenv$ yields $\vtone$\ProseOrTypeError;
-  \item $\vtone$ is a builtin aggregate.
-\end{itemize}
-
-\subsubsection{Example}
+\ExampleDef{Aggregate Types}
 In the following example, the types \texttt{A}, \texttt{B}, and \texttt{C} are all aggregate types:
 \begin{lstlisting}
 type A of (integer, integer);
@@ -290,7 +286,12 @@ type B of A;
 type C of B;
 \end{lstlisting}
 
-\CodeSubsection{\AggregateBegin}{\AggregateEnd}{../types.ml}
+\ProseParagraph
+\AllApply
+\begin{itemize}
+  \item obtaining the \underlyingtype\ of $\tty$ in the environment $\tenv$ yields $\vtone$\ProseOrTypeError;
+  \item $\vtone$ is a builtin aggregate.
+\end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
@@ -301,9 +302,8 @@ type C of B;
   \isaggregate(\tenv, \tty) \typearrow \vb
 }
 \end{mathpar}
-
-\isempty{\subsubsection{Comments}}
 \lrmcomment{This is related to \identr{GVZK}.}
+\CodeSubsection{\AggregateBegin}{\AggregateEnd}{../types.ml}
 
 \TypingRuleDef{StructuredType}
 \hypertarget{def-isstructured}{}
@@ -350,27 +350,27 @@ tests whether the type $\tty$ is a \emph{non-primitive type}.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{singular}):
+  \item \AllApplyCase{singular}:
   \begin{itemize}
   \item $\tty$ is a builtin singular type;
   \item $\vb$ is $\False$.
   \end{itemize}
-  \item All of the following apply (\textsc{named}):
+  \item \AllApplyCase{named}:
   \begin{itemize}
     \item $\tty$ is a named type;
     \item $\vb$ is $\True$.
   \end{itemize}
-  \item All of the following apply (\textsc{tuple}):
+  \item \AllApplyCase{tuple}:
   \begin{itemize}
     \item $\tty$ is a tuple type $\vli$;
     \item $\vb$ is $\True$ if and only if there exists a non-primitive type in $\vli$.
   \end{itemize}
-  \item All of the following apply (\textsc{array}):
+  \item \AllApplyCase{array}:
     \begin{itemize}
     \item $\tty$ is an array of type $\tty'$
     \item $\vb$ is $\True$ if and only if $\tty'$ is non-primitive.
     \end{itemize}
-  \item All of the following apply (\textsc{structured}):
+  \item \AllApplyCase{structured}:
     \begin{itemize}
     \item $\tty$ is a \structuredtype\ with fields $\fields$;
     \item $\vb$ is $\True$ if and only if there exists a non-primitive type in $\fields$.
@@ -490,18 +490,18 @@ this ensures that \TypingRuleRef{Structure} is a proper \emph{structural inducti
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-\item All of the following apply (\textsc{named}):
+\item \AllApplyCase{named}:
   \begin{itemize}
   \item $\tty$ is a named type $\vx$;
   \item obtaining the declared type associated with $\vx$ in the static environment $\tenv$ yields $\vtone$\ProseOrTypeError;
   \item obtaining the structure of $\vtone$ static environment $\tenv$ yields $\vt$\ProseOrTypeError;
   \end{itemize}
-\item All of the following apply (\textsc{builtin\_singular}):
+\item \AllApplyCase{builtin\_singular}:
   \begin{itemize}
   \item $\tty$ is a builtin singular type;
   \item $\vt$ is $\tty$.
   \end{itemize}
-\item All of the following apply (\textsc{tuple}):
+\item \AllApplyCase{tuple}:
   \begin{itemize}
   \item $\tty$ is a tuple type with list of types $\tys$;
   \item the types in $\tys$ are indexed as $\vt_i$, for $i=1..k$;
@@ -509,13 +509,13 @@ One of the following applies:
   yields $\vtp_i$\ProseOrTypeError;
   \item $\vt$ is a tuple type with the list of types $\vtp_i$, for $i=1..k$.
   \end{itemize}
-\item All of the following apply (\textsc{array}):
+\item \AllApplyCase{array}:
   \begin{itemize}
     \item $\tty$ is an array type of length $\ve$ with element type $\vt$;
     \item obtaining the structure of $\vt$ yields $\vtone$\ProseOrTypeError;
     \item $\vt$ is an array type with of length $\ve$ with element type $\vtone$.
   \end{itemize}
-\item All of the following apply (\textsc{structured}):
+\item \AllApplyCase{structured}:
   \begin{itemize}
   \item $\tty$ is a \structuredtype\ with fields $\fields$;
   \item obtaining the structure for each type $\vt$ associated with field $\id$ yields a type $\vt_\id$\ProseOrTypeError;
@@ -619,14 +619,14 @@ The \underlyingtype{} of \texttt{(integer, T2)} and \texttt{T3} is
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{named}):
+  \item \AllApplyCase{named}:
   \begin{itemize}
     \item $\tty$ is a named type $\vx$;
     \item obtaining the type declared for $\vx$ yields $\vtone$\ProseOrTypeError;
     \item the \underlyingtype\ of $\vtone$ is $\vt$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non-named}):
+  \item \AllApplyCase{non-named}:
   \begin{itemize}
     \item $\tty$ is not a named type $\vx$;
     \item $\vt$ is $\tty$.
@@ -662,25 +662,25 @@ checks whether the type $\vt$ is a \constrainedinteger. If so, the result is $\T
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{well-constrained}):
+  \item \AllApplyCase{well-constrained}:
   \begin{itemize}
     \item $\vt$ is a well-constrained integer;
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{parameterized}):
+  \item \AllApplyCase{parameterized}:
   \begin{itemize}
     \item $\vt$ is a \parameterizedintegertype;
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{unconstrained}):
+  \item \AllApplyCase{unconstrained}:
   \begin{itemize}
     \item $\vt$ is an unconstrained integer or pending constrained integer;
     \item the result is a type error indicating that a constrained integer type is expected.
   \end{itemize}
 
-  \item All of the following apply (\textsc{conflicting\_type}):
+  \item \AllApplyCase{conflicting\_type}:
   \begin{itemize}
     \item $\vt$ is not an integer type;
     \item the result is a type error indicating the type conflict.

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -83,7 +83,7 @@ The builtin aggregate types are:
 \item \texttt{exception}.
 \end{itemize}
 
-\subsubsection{Example}
+\ExampleDef{Builtin Aggreate Types}
 \listingref{typing-builtinaggregatetypes} provides examples of some builtin aggregate types.
 \ASLListing{Builtin aggregate types}{typing-builtinaggregatetypes}{\typingtests/TypingRule.BuiltinAggregateTypes.asl}
 
@@ -107,7 +107,7 @@ enumeration. In the example above, \texttt{PointArray} can only be accessed with
 The (builtin aggregate) type \verb|{ x : real, y : real, z : real }| is a record type with three fields
 \texttt{x}, \texttt{y} and \texttt{z}.
 
-\subsubsection{Example}
+\subsubsection{Builtin Aggregate Exception Types}
 \listingref{typing-builtinexceptiontype} defines two (builtin aggregate) exception types:
 \begin{itemize}
 \item \verb|exception{}| (for \texttt{Not\_found}), which carries no value; and
@@ -135,21 +135,19 @@ The predicate
 \]
 tests whether the type $\tty$ is a \emph{builtin type}.
 
-\ProseParagraph
-$\tty$ is a builtin type and \OneApplies
-\begin{itemize}
-\item $\tty$ is singular;
-\item $\tty$ is builtin aggregate.
-\end{itemize}
-
-\subsubsection{Example}
+\ExampleDef{BUiltin Types}
 In the specification
 \begin{lstlisting}
 type ticks of integer;
 \end{lstlisting}
 the type \texttt{integer} is a builtin type but the type of \texttt{ticks} is not.
 
-\CodeSubsection{\BuiltinSingularOrAggregateBegin}{\BuiltinSingularOrAggregateEnd}{../types.ml}
+\ProseParagraph
+$\tty$ is a builtin type and \OneApplies
+\begin{itemize}
+\item $\tty$ is singular;
+\item $\tty$ is builtin aggregate.
+\end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
@@ -160,6 +158,7 @@ the type \texttt{integer} is a builtin type but the type of \texttt{ticks} is no
     \isbuiltin(\tty) \typearrow \vbone \lor \vbtwo
   }
 \end{mathpar}
+\CodeSubsection{\BuiltinSingularOrAggregateBegin}{\BuiltinSingularOrAggregateEnd}{../types.ml}
 
 \TypingRuleDef{NamedType}
 \hypertarget{def-isnamed}{}
@@ -172,17 +171,15 @@ tests whether the type $\tty$ is a \emph{named type}.
 \Enumerationtypesterm{}, record types, and exception types must be declared
 and associated with a named type.
 
-\ProseParagraph
-A named type is a type that is declared by using the \texttt{type of} syntax.
-
-\subsubsection{Example}
+\ExampleDef{Named Types}
 In the specification
 \begin{lstlisting}
 type ticks of integer;
 \end{lstlisting}
 \texttt{ticks} is a named type.
 
-\CodeSubsection{\NamedBegin}{\NamedEnd}{../types.ml}
+\ProseParagraph
+A named type is a type that is declared by using the \texttt{type of} syntax.
 
 \FormallyParagraph
 \begin{mathpar}
@@ -192,8 +189,7 @@ type ticks of integer;
   \isnamed(\tty) \typearrow \vb
 }
 \end{mathpar}
-
-
+\CodeSubsection{\NamedBegin}{\NamedEnd}{../types.ml}
 \identd{vmzx}
 
 \TypingRuleDef{AnonymousType}
@@ -205,7 +201,7 @@ The predicate
 \]
 tests whether the type $\tty$ is an \anonymoustype.
 
-\subsubsection{Example}
+\ExampleDef{Anonymous Types}
 The \tupletypeterm{} \texttt{(integer, integer)} is an \anonymoustype.
 
 \ProseParagraph
@@ -310,17 +306,17 @@ The predicate
 \]
 tests whether the type $\tty$ is a \structuredtype\ and yields the result in $\vb$.
 
-\ProseParagraph
-The result $\vb$ is $\True$ if and only if $\tty$ is either a record type or an exception type,
-which is determined via the AST label of $\tty$.
-
-\subsubsection{Example}
+\ExampleDef{Structured Types}
 In the following example, the types \texttt{SyntaxException} and \texttt{PointRecord}
 are each an example of a \structuredtype:
 \begin{lstlisting}
 type SyntaxException of exception {message: string };
 type PointRecord of Record {x : real, y: real, z: real};
 \end{lstlisting}
+
+\ProseParagraph
+The result $\vb$ is $\True$ if and only if $\tty$ is either a record type or an exception type,
+which is determined via the AST label of $\tty$.
 
 \FormallyParagraph
 \begin{mathpar}
@@ -338,6 +334,18 @@ The predicate
   \isnonprimitive(\overname{\ty}{\tty}) \;\aslto\; \overname{\Bool}{\vb}
 \]
 tests whether the type $\tty$ is a \emph{non-primitive type}.
+
+\ExampleDef{Non-primitive Types}
+The following types are non-primitive:
+
+\begin{tabular}{ll}
+\textbf{Type definition} & \textbf{Reason for being non-primitive}\\
+\hline
+\texttt{type A of integer}  & Named types are non-primitive\\
+\texttt{(integer, A)}       & The second component, \texttt{A}, has non-primitive type\\
+\texttt{array[6] of A}      & Element type \texttt{A} has a non-primitive type\\
+\verb|record { a : A }|     & The field \texttt{a} has a non-primitive type
+\end{tabular}
 
 \ProseParagraph
 \OneApplies
@@ -368,20 +376,6 @@ tests whether the type $\tty$ is a \emph{non-primitive type}.
     \item $\vb$ is $\True$ if and only if there exists a non-primitive type in $\fields$.
     \end{itemize}
 \end{itemize}
-
-\subsubsection{Example}
-The following types are non-primitive:
-
-\begin{tabular}{ll}
-\textbf{Type definition} & \textbf{Reason for being non-primitive}\\
-\hline
-\texttt{type A of integer}  & Named types are non-primitive\\
-\texttt{(integer, A)}       & The second component, \texttt{A}, has non-primitive type\\
-\texttt{array[6] of A}      & Element type \texttt{A} has a non-primitive type\\
-\verb|record { a : A }|     & The field \texttt{a} has a non-primitive type
-\end{tabular}
-
-\CodeSubsection{\NonPrimitiveBegin}{\NonPrimitiveEnd}{../types.ml}
 
 \FormallyParagraph
 The cases \textsc{tuple} and \textsc{structured} below, use the notation $\vb_\vt$ to name
@@ -424,8 +418,7 @@ Boolean variables by using the types denoted by $\vt$ as a subscript.
   \isnonprimitive(\overname{L(\fields)}{\tty}) \typearrow \vb
 }
 \end{mathpar}
-
-
+\CodeSubsection{\NonPrimitiveBegin}{\NonPrimitiveEnd}{../types.ml}
 \identd{GWXK}
 
 \TypingRuleDef{PrimitiveType}
@@ -436,10 +429,7 @@ The predicate
 \]
 tests whether the type $\tty$ is a \emph{primitive type}.
 
-\ProseParagraph
-A type $\tty$ is primitive if it is not non-primitive.
-
-\subsubsection{Example}
+\ExampleDef{Primitive Types}
 The following types are primitive:
 
 \begin{tabular}{ll}
@@ -451,7 +441,8 @@ The following types are primitive:
 \verb|record {ticks : integer}| & The single field \texttt{ticks} has a primitive type
 \end{tabular}
 
-\CodeSubsection{\PrimitiveBegin}{\PrimitiveEnd}{../types.ml}
+\ProseParagraph
+A type $\tty$ is primitive if it is not non-primitive.
 
 \FormallyParagraph
 \begin{mathpar}
@@ -461,8 +452,7 @@ The following types are primitive:
   \isprimitive(\tty) \typearrow \neg\vb
 }
 \end{mathpar}
-
-
+\CodeSubsection{\PrimitiveBegin}{\PrimitiveEnd}{../types.ml}
 \identd{GWXK}
 
 \TypingRuleDef{Structure}
@@ -478,6 +468,30 @@ If a named type is not associated with a declared type in $\tenv$, a type error 
 \TypingRuleRef{TypeCheckAST} ensures the absence of circular type definitions,
 which ensures that \TypingRuleRef{Structure} terminates\footnote{In mathematical terms,
 this ensures that \TypingRuleRef{Structure} is a proper \emph{structural induction.}}.
+
+\ExampleDef{The Structure of a Type}
+In this example:
+\texttt{type T1 of integer;} is the named type \texttt{T1}
+whose structure is \texttt{integer}.
+
+In this example:
+\texttt{type T2 of (integer, T1);}
+is the named type \texttt{T2} whose structure is (integer, integer). In this
+example, \texttt{(integer, T1)} is non-primitive since it uses \texttt{T1}, which is builtin aggregate.
+
+In this example:
+\texttt{var x: T1;}
+the type of $\vx$ is the named (hence non-primitive) type \texttt{T1}, whose structure
+is \texttt{integer}.
+
+In this example:
+\texttt{var y: integer;}
+the type of \texttt{y} is the anonymous primitive type \texttt{integer}.
+
+In this example:
+\texttt{var z: (integer, T1);}
+the type of \texttt{z} is the anonymous non-primitive type
+\texttt{(integer, T1)} whose structure is \texttt{(integer, integer)}.
 
 \ProseParagraph
 \OneApplies
@@ -515,32 +529,6 @@ this ensures that \TypingRuleRef{Structure} is a proper \emph{structural inducti
   \end{itemize}
 \end{itemize}
 
-\subsubsection{Example}
-In this example:
-\texttt{type T1 of integer;} is the named type \texttt{T1}
-whose structure is \texttt{integer}.
-
-In this example:
-\texttt{type T2 of (integer, T1);}
-is the named type \texttt{T2} whose structure is (integer, integer). In this
-example, \texttt{(integer, T1)} is non-primitive since it uses \texttt{T1}, which is builtin aggregate.
-
-In this example:
-\texttt{var x: T1;}
-the type of $\vx$ is the named (hence non-primitive) type \texttt{T1}, whose structure
-is \texttt{integer}.
-
-In this example:
-\texttt{var y: integer;}
-the type of \texttt{y} is the anonymous primitive type \texttt{integer}.
-
-In this example:
-\texttt{var z: (integer, T1);}
-the type of \texttt{z} is the anonymous non-primitive type
-\texttt{(integer, T1)} whose structure is \texttt{(integer, integer)}.
-
-\CodeSubsection{\StructureBegin}{\StructureEnd}{../types.ml}
-
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[named]{
@@ -577,8 +565,7 @@ the type of \texttt{z} is the anonymous non-primitive type
  L([ (\id,\vt) \in \fields : (\id,\vt_\id) ])
 }
 \end{mathpar}
-
-
+\CodeSubsection{\StructureBegin}{\StructureEnd}{../types.ml}
 \identd{FXQV}
 
 \TypingRuleDef{MakeAnonymous}
@@ -593,7 +580,7 @@ Intuitively, $\tty$ is the first non-named type that is used to define $\tty$. U
 $\makeanonymous$ replaces named types by their definition until the first non-named type is found but
 does not recurse further.
 
-\subsubsection{Example}
+\ExampleDef{The Underlying Type of a Type}
 Consider the following example:
 \begin{lstlisting}
 type T1 of integer;

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -207,7 +207,7 @@ tests whether the type $\tty$ is an \anonymoustype.
 
 \ProseParagraph
 \Anonymoustypes\ are types that are not declared using the type syntax:
-integer types, the real type, the string type, the Boolean type,
+integer types, the \realtypeterm{}, the string type, the Boolean type,
 bitvector types, tuple types, and array types.
 
 \subsubsection{Example}

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -729,28 +729,3 @@ One of the following applies:
   \item A \emph{\parameterizedintegertype} is an implicit type of a subprogram parameter.
   \end{itemize}
 The widths of bitvector storage elements are constrained integers.
-
-\hypertarget{def-isunconstrainedinteger}{}
-\hypertarget{def-isparameterizedinteger}{}
-\hypertarget{def-iswellconstrainedinteger}{}
-We use the following helper predicates to classify integer types:
-\[
-  \begin{array}{rcl}
-  \isunconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool\\
-  \isparameterizedinteger(\overname{\ty}{\vt}) &\aslto& \Bool\\
-  \iswellconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool
-  \end{array}
-\]
-Those are defined as follows:
-\[
-  \begin{array}{rcl}
-  \isunconstrainedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\unconstrained\\
-  \isparameterizedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\parameterized\\
-  \iswellconstrainedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\wellconstrained\\
-\end{array}
-\]\lrmcomment{This is related to \identd{ZTPP}, \identr{WJYH}, \identr{HJPN}, \identr{CZTX}, \identr{TPHR}.}
-
-\paragraph{Shorthand Notations:}
-
-\hypertarget{def-unconstrainedinteger}{}
-We use the shorthand notation $\unconstrainedinteger$ to denote the unconstrained integer type: $\TInt(\unconstrained)$.

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -131,11 +131,11 @@ omitted in type declarations, as is the case for \texttt{Not\_found}.
 \hypertarget{def-isbuiltin}{}
 The predicate
 \[
-  \isbuiltin(\overname{\ty}{\tty}) \;\aslto\; \Bool
+  \isbuiltin(\overname{\ty}{\tty}) \;\aslto\; \overname{\Bool}{\vb}
 \]
-tests whether the type $\tty$ is a \emph{builtin type}.
+tests whether the type $\tty$ is a \emph{builtin type}, yielding the result in $\vb$.
 
-\ExampleDef{BUiltin Types}
+\ExampleDef{Builtin Types}
 In the specification
 \begin{lstlisting}
 type ticks of integer;
@@ -143,20 +143,15 @@ type ticks of integer;
 the type \texttt{integer} is a builtin type but the type of \texttt{ticks} is not.
 
 \ProseParagraph
-$\tty$ is a builtin type and \OneApplies
-\begin{itemize}
-\item $\tty$ is singular;
-\item $\tty$ is builtin aggregate.
-\end{itemize}
+\Proseeqdef{$\vb$}{$\True$ if and only if either $\tty$ is singular or $\tty$ is builtin aggregate}.
 
 \FormallyParagraph
 \begin{mathpar}
-  \inferrule{
-    \isbuiltinsingular(\tty) \typearrow \vbone\\
-    \isbuiltinaggregate(\tty) \typearrow \vbtwo
-  }{
-    \isbuiltin(\tty) \typearrow \vbone \lor \vbtwo
-  }
+\inferrule{
+  \isbuiltinsingular(\tty) \lor \isbuiltinaggregate(\tty)
+}{
+  \isbuiltin(\tty) \typearrow \vbone \lor \vbtwo
+}
 \end{mathpar}
 \CodeSubsection{\BuiltinSingularOrAggregateBegin}{\BuiltinSingularOrAggregateEnd}{../types.ml}
 
@@ -179,7 +174,7 @@ type ticks of integer;
 \texttt{ticks} is a named type.
 
 \ProseParagraph
-A named type is a type that is declared by using the \texttt{type of} syntax.
+A named type is a type that is declared by using the \texttt{type ... of ...} syntax.
 
 \FormallyParagraph
 \begin{mathpar}
@@ -242,7 +237,7 @@ type C of B;
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item obtaining the \underlyingtype\ of $\tty$ in the environment $\tenv$ yields $\vtone$\ProseOrTypeError;
+  \item obtaining the \underlyingtype\ of $\tty$ in the static environment $\tenv$ yields $\vtone$\ProseOrTypeError;
   \item applying $\isbuiltinsingular$ to $\vtone$ yields $\vb$.
 \end{itemize}
 
@@ -471,11 +466,11 @@ this ensures that \TypingRuleRef{Structure} is a proper \emph{structural inducti
 
 \ExampleDef{The Structure of a Type}
 In this example:
-\texttt{type T1 of integer;} is the named type \texttt{T1}
+\texttt{type T1 of integer;}, \texttt{T1}, is the named type \texttt{T1}
 whose structure is \texttt{integer}.
 
 In this example:
-\texttt{type T2 of (integer, T1);}
+\texttt{type T2 of (integer, T1);}, \texttt{T2},
 is the named type \texttt{T2} whose structure is (integer, integer). In this
 example, \texttt{(integer, T1)} is non-primitive since it uses \texttt{T1}, which is builtin aggregate.
 

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -33,21 +33,21 @@ tests whether the type $\tty$ is a \emph{builtin singular type}.
 \ProseParagraph
 The \emph{builtin singular types} are:
 \begin{itemize}
-\item \texttt{integer};
-\item \texttt{real};
-\item \texttt{string};
-\item \texttt{boolean};
-\item \texttt{bits} (which also represents \texttt{bit}, as a special case);
-\item \texttt{enumeration}.
+\item the \integertypesterm{};
+\item the \realtypeterm{};
+\item the \stringtypeterm{};
+\item the \booleantypeterm{};
+\item the \bitvectortypeterm{} (which includes \texttt{bit}, as a special case);
+\item the \enumerationtypeterm{}.
 \end{itemize}
 
-\subsubsection{Example}
+\ExampleDef{Builtin singular types}
 \listingref{typing-builtinsingulartype} defines variables of builtin singular types
 \texttt{integer}, \texttt{real},
 \texttt{boolean}, \texttt{bits(4)}, and~\texttt{bits(2)}
 \ASLListing{Examples of builtin singular types}{typing-builtinsingulartype}{\typingtests/TypingRule.BuiltinSingularTypes.asl}
 
-\subsubsection{Example}
+\ExampleDef{Builtin enumeration types}
 In \listingref{typing-builtinenumerationtype},
 the builtin singular type \texttt{Color} consists in two constants:
 \texttt{RED} and~\texttt{BLACK}.
@@ -63,7 +63,7 @@ the builtin singular type \texttt{Color} consists in two constants:
 \end{mathpar}
 \CodeSubsection{\BuiltinSingularBegin}{\BuiltinSingularEnd}{../types.ml}
 
-\isempty{\subsubsection{Comments}}
+
 \lrmcomment{This is related to \identd{PQCK} and \identd{NZWT}.}
 
 \TypingRuleDef{BuiltinAggregateType}
@@ -94,7 +94,7 @@ or enumeration-typed.  In the example above, \texttt{T} is
 declared as an array with an integer-typed index (as indicated
 by the used of the integer-typed constant \texttt{3}) whereas
 \texttt{PointArray} is declared with the index of
-\texttt{Coord}, which is an enumeration type.
+\texttt{Coord}, which is an \enumerationtypeterm{}.
 
 Arrays declared with integer-typed indices can be accessed only by integers ranging from $0$ to
 the size of the array minus $1$. In the example above, $\texttt{T}$ can be accessed with
@@ -125,7 +125,7 @@ omitted in type declarations, as is the case for \texttt{Not\_found}.
 \end{mathpar}
 \CodeSubsection{\BuiltinAggregateBegin}{\BuiltinAggregateEnd}{../types.ml}
 
-\isempty{\subsubsection{Comments}}
+
 \lrmcomment{This is related to \identd{PQCK} and \identd{KNBD}.}
 
 \TypingRuleDef{BuiltinSingularOrAggregate}
@@ -170,7 +170,7 @@ The predicate
 \]
 tests whether the type $\tty$ is a \emph{named type}.
 
-Enumeration types, record types, and exception types must be declared
+\Enumerationtypesterm{}, record types, and exception types must be declared
 and associated with a named type.
 
 \ProseParagraph
@@ -194,41 +194,39 @@ type ticks of integer;
 }
 \end{mathpar}
 
-\isempty{\subsubsection{Comments}}
+
 \lrmcomment{This is related to \identd{vmzx}.}
 
 \TypingRuleDef{AnonymousType}
 \hypertarget{def-isanonymous}{}
+\identd{VMZX}%
 The predicate
 \[
   \isanonymous(\overname{\ty}{\tty}) \;\aslto\; \Bool
 \]
 tests whether the type $\tty$ is an \anonymoustype.
 
-\ProseParagraph
-\Anonymoustypes\ are types that are not declared using the type syntax:
-integer types, the \realtypeterm{}, the \stringtypeterm{}, the Boolean type,
-bitvector types, tuple types, and array types.
-
 \subsubsection{Example}
-The tuple type \texttt{(integer, integer)} is an \anonymoustype.
+The \tupletypeterm{} \texttt{(integer, integer)} is an \anonymoustype.
 
-\CodeSubsection{\AnonymousBegin}{\AnonymousEnd}{../types.ml}
+\ProseParagraph
+\Anonymoustypes\ are types that are not declared using the \texttt{type ... of ...} syntax:
+\integertypesterm{}, the \realtypeterm{}, the \stringtypeterm{}, the \booleantypeterm{},
+\bitvectortypesterm{}, \tupletypesterm{}, and \arraytypesterm{}.
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule{ \vb \eqdef \astlabel(\tty) \neq \TNamed
-}
-{
+\inferrule{
+  \vb \eqdef \astlabel(\tty) \neq \TNamed
+}{
   \isanonymous(\tty) \typearrow \vb
 }
 \end{mathpar}
-
-\isempty{\subsubsection{Comments}}
-\lrmcomment{This is related to \identd{VMZX}.}
+\CodeSubsection{\AnonymousBegin}{\AnonymousEnd}{../types.ml}
 
 \TypingRuleDef{SingularType}
 \hypertarget{def-issingular}{}
+\identr{GVZK}%
 The predicate
 \[
   \issingular(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\tty}) \;\aslto\;
@@ -238,7 +236,7 @@ tests whether the type $\tty$ is a \emph{singular type} in the static environmen
 yielding the result in $\vb$.
 \ProseOtherwiseTypeError
 
-\subsubsection{Example}
+\ExampleDef{Singular types}
 In the following example, the types \texttt{A}, \texttt{B}, and \texttt{C} are all singular types:
 \begin{lstlisting}
 type A of integer;
@@ -253,20 +251,16 @@ type C of B;
   \item applying $\isbuiltinsingular$ to $\vtone$ yields $\vb$.
 \end{itemize}
 
-\CodeSubsection{\SingularBegin}{\SingularEnd}{../types.ml}
-
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \makeanonymous(\tenv, \tty) \typearrow \vtone \OrTypeError\\\\
   \isbuiltinsingular(\vtone) \typearrow \vb
 }{
-\issingular(\tenv, \tty) \typearrow \vb
+  \issingular(\tenv, \tty) \typearrow \vb
 }
 \end{mathpar}
-
-\isempty{\subsubsection{Comments}}
-\lrmcomment{This is related to \identr{GVZK}.}
+\CodeSubsection{\SingularBegin}{\SingularEnd}{../types.ml}
 
 \TypingRuleDef{AggregateType}
 \hypertarget{def-isaggregate}{}
@@ -336,7 +330,7 @@ type PointRecord of Record {x : real, y: real, z: real};
 }
 \end{mathpar}
 
-\isempty{\subsubsection{Comments}}
+
 \lrmcomment{This is related to \identd{WGQS}, \identd{QXYC}.}
 
 \TypingRuleDef{NonPrimitiveType}
@@ -362,7 +356,7 @@ tests whether the type $\tty$ is a \emph{non-primitive type}.
   \end{itemize}
   \item \AllApplyCase{tuple}
   \begin{itemize}
-    \item $\tty$ is a tuple type $\vli$;
+    \item $\tty$ is a \tupletypeterm{} $\vli$;
     \item $\vb$ is $\True$ if and only if there exists a non-primitive type in $\vli$.
   \end{itemize}
   \item \AllApplyCase{array}
@@ -433,7 +427,7 @@ Boolean variables by using the types denoted by $\vt$ as a subscript.
 }
 \end{mathpar}
 
-\isempty{\subsubsection{Comments}}
+
 \lrmcomment{This is related to \identd{GWXK}.}
 
 \TypingRuleDef{PrimitiveType}
@@ -470,7 +464,7 @@ The following types are primitive:
 }
 \end{mathpar}
 
-\isempty{\subsubsection{Comments}}
+
 \lrmcomment{This is related to \identd{GWXK}.}
 
 \TypingRuleDef{Structure}
@@ -503,11 +497,11 @@ this ensures that \TypingRuleRef{Structure} is a proper \emph{structural inducti
   \end{itemize}
 \item \AllApplyCase{tuple}
   \begin{itemize}
-  \item $\tty$ is a tuple type with list of types $\tys$;
+  \item $\tty$ is a \tupletypeterm{} with list of types $\tys$;
   \item the types in $\tys$ are indexed as $\vt_i$, for $i=1..k$;
   \item obtaining the structure of each type $\vt_i$, for $i=1..k$, in $\tys$ in the static environment $\tenv$,
   yields $\vtp_i$\ProseOrTypeError;
-  \item $\vt$ is a tuple type with the list of types $\vtp_i$, for $i=1..k$.
+  \item $\vt$ is a \tupletypeterm{} with the list of types $\vtp_i$, for $i=1..k$.
   \end{itemize}
 \item \AllApplyCase{array}
   \begin{itemize}
@@ -586,7 +580,7 @@ the type of \texttt{z} is the anonymous non-primitive type
 }
 \end{mathpar}
 
-\isempty{\subsubsection{Comments}}
+
 \lrmcomment{This is related to \identd{FXQV}.}
 
 \TypingRuleDef{MakeAnonymous}

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -64,7 +64,7 @@ the builtin singular type \texttt{Color} consists in two constants:
 \CodeSubsection{\BuiltinSingularBegin}{\BuiltinSingularEnd}{../types.ml}
 
 
-\lrmcomment{This is related to \identd{PQCK} and \identd{NZWT}.}
+\identd{PQCK} \identd{NZWT}
 
 \TypingRuleDef{BuiltinAggregateType}
 \hypertarget{def-isbuiltinaggregate}{}
@@ -125,8 +125,7 @@ omitted in type declarations, as is the case for \texttt{Not\_found}.
 \end{mathpar}
 \CodeSubsection{\BuiltinAggregateBegin}{\BuiltinAggregateEnd}{../types.ml}
 
-
-\lrmcomment{This is related to \identd{PQCK} and \identd{KNBD}.}
+\identd{PQCK} \identd{KNBD}
 
 \TypingRuleDef{BuiltinSingularOrAggregate}
 \hypertarget{def-isbuiltin}{}
@@ -195,7 +194,7 @@ type ticks of integer;
 \end{mathpar}
 
 
-\lrmcomment{This is related to \identd{vmzx}.}
+\identd{vmzx}
 
 \TypingRuleDef{AnonymousType}
 \hypertarget{def-isanonymous}{}
@@ -296,7 +295,7 @@ type C of B;
   \isaggregate(\tenv, \tty) \typearrow \vb
 }
 \end{mathpar}
-\lrmcomment{This is related to \identr{GVZK}.}
+\identr{GVZK}
 \CodeSubsection{\AggregateBegin}{\AggregateEnd}{../types.ml}
 
 \TypingRuleDef{StructuredType}
@@ -330,8 +329,7 @@ type PointRecord of Record {x : real, y: real, z: real};
 }
 \end{mathpar}
 
-
-\lrmcomment{This is related to \identd{WGQS}, \identd{QXYC}.}
+\identd{WGQS} \identd{QXYC}
 
 \TypingRuleDef{NonPrimitiveType}
 \hypertarget{def-isnonprimitive}{}
@@ -428,7 +426,7 @@ Boolean variables by using the types denoted by $\vt$ as a subscript.
 \end{mathpar}
 
 
-\lrmcomment{This is related to \identd{GWXK}.}
+\identd{GWXK}
 
 \TypingRuleDef{PrimitiveType}
 \hypertarget{def-isprimitive}{}
@@ -465,7 +463,7 @@ The following types are primitive:
 \end{mathpar}
 
 
-\lrmcomment{This is related to \identd{GWXK}.}
+\identd{GWXK}
 
 \TypingRuleDef{Structure}
 \hypertarget{def-structure}{}
@@ -581,7 +579,7 @@ the type of \texttt{z} is the anonymous non-primitive type
 \end{mathpar}
 
 
-\lrmcomment{This is related to \identd{FXQV}.}
+\identd{FXQV}
 
 \TypingRuleDef{MakeAnonymous}
 \hypertarget{def-makeanonymous}{}

--- a/asllib/doc/TypeChecking.tex
+++ b/asllib/doc/TypeChecking.tex
@@ -141,7 +141,7 @@ We use the notation $G^\tenv.m$ and $L^\tenv.m$ to access the $m$ component of a
 To update a function component $f$ (e.g., $\declaredtypes$) of a global or local environment $E$
 with a new mapping $x \mapsto v$, we use the notation $\tenv.f[x \mapsto v]$ to stand for $E[f \mapsto E.f[x \mapsto v]]$.
 
-\lrmcomment{This is related to \identd{JRXM} and \identi{ZTMQ}.}
+\identd{JRXM} \identi{ZTMQ}
 
 \section{Typing Rule Configurations}
 The output configurations of type system assertions have two flavors:

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -190,15 +190,15 @@ in the global static environment $\genv$, resulting in the modified global stati
   \item applying $\maxtimeframe$ to $\vsest$ yields $\vtimeframe$;
   \item applying $\addtype$ to $\name$, $\vttwo$, and $\vtimeframe$ in $\tenv$ yields $\tenvtwo$;
   \item $\tenvtwo$ is $\tenvone$ with its $\declaredtypes$ component updated by binding $\name$ to $\vttwo$;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{enum}:
+    \item \AllApplyCase{enum}
     \begin{itemize}
       \item $\vttwo$ is an enumeration type with labels $\ids$, that is, $\TEnum(\ids)$;
       \item applying $\declareenumlabels$ to $\vttwo$ in $\tenvtwo$ $\newtenv$\ProseOrTypeError.
     \end{itemize}
 
-    \item \AllApplyCase{not\_enum}:
+    \item \AllApplyCase{not\_enum}
     \begin{itemize}
       \item $\vttwo$ is not an enumeration type;
       \item $\newtenv$ is $\tenvtwo$.
@@ -260,16 +260,16 @@ the modified environment $\newtenv$ and type $\newty$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\vs$ is $\None$;
     \item $\newtenv$ is $\tenv$;
     \item $\newty$ is $\tty$.
   \end{itemize}
 
-  \item \AllApplyCase{empty\_fields}:
+  \item \AllApplyCase{empty\_fields}
   \begin{itemize}
     \item $\vs$ is $\langle(\vsuper, \extrafields)\rangle$;
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is, \\ $\TNamed(\vsuper)$) yields
@@ -279,7 +279,7 @@ One of the following applies:
     \item $\newty$ is $\tty$.
   \end{itemize}
 
-  \item \AllApplyCase{no\_super}:
+  \item \AllApplyCase{no\_super}
   \begin{itemize}
     \item $\vs$ is $\langle(\vsuper, \extrafields)\rangle$;
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is, \\ $\TNamed(\vsuper)$) yields
@@ -289,7 +289,7 @@ One of the following applies:
     \item the result is a type error indicating that $\vsuper$ is not a declared type.
   \end{itemize}
 
-  \item \AllApplyCase{structured}:
+  \item \AllApplyCase{structured}
   \begin{itemize}
     \item $\vs$ is $\langle(\vsuper, \extrafields)\rangle$;
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is,\\ $\TNamed(\vsuper)$) yields
@@ -365,15 +365,15 @@ annotates the type $\vt$ inside an \optional\ $\tyopt$, if there is one, and lea
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\tyopt$ is $\None$;
     \item $\tyoptp$ is $\tyopt$.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\tyopt$ contains the type $\vt$;
     \item annotating $\vt$ in $\tenv$ yields $\vtone$\ProseOrTypeError;
@@ -407,15 +407,15 @@ for the type and annotated expression in $\vres$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item $\expropt$ is $\None$;
     \item $\vres$ is $(\None, \None)$.
   \end{itemize}
 
-  \item \AllApplyCase{some}:
+  \item \AllApplyCase{some}
   \begin{itemize}
     \item $\expropt$ contains the expression $\ve$;
     \item annotating $\ve$ in $\tenv$ yields $(\vt, \vep)$\ProseOrTypeError;
@@ -456,22 +456,22 @@ The ASL parser ensures that at least one of $\initialvaluetype$ and \\
 $\typeannotation$ should not be $\None$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{both}:
+  \item \AllApplyCase{both}
   \begin{itemize}
     \item $\initialvaluetype$ is $\langle\vtone\rangle$ and $\typeannotation$ is $\langle\vttwo\rangle$;
     \item checking that $\vtone$ \typesatisfies\ $\vttwo$ in $\tenv$ yields $\True$\ProseOrTypeError;
     \item $\declaredtype$ is $\vtone$.
   \end{itemize}
 
-  \item \AllApplyCase{annotated}:
+  \item \AllApplyCase{annotated}
   \begin{itemize}
     \item $\initialvaluetype$ is $\None$ and $\typeannotation$ is $\langle\vttwo\rangle$;
     \item $\declaredtype$ is $\vttwo$.
   \end{itemize}
 
-  \item \AllApplyCase{initial}:
+  \item \AllApplyCase{initial}
   \begin{itemize}
     \item $\initialvaluetype$ is $\langle\vtone\rangle$ and $\typeannotation$ is $\None$;
     \item $\declaredtype$ is $\vtone$.
@@ -508,14 +508,14 @@ retrieves the type associated with the identifier $\id$ in the static environmen
 If the identifier is not associated with a declared type, a type error is returned.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exists}:
+  \item \AllApplyCase{exists}
   \begin{itemize}
     \item $\id$ is bound in the global environment to the type $\vt$.
   \end{itemize}
 
-  \item \AllApplyCase{type\_not\_declared}:
+  \item \AllApplyCase{type\_not\_declared}
   \begin{itemize}
     \item $\id$ is not bound in the global environment to any type;
     \item the result is a type error indicating the lack of a type declaration for $\id$ (\UndefinedIdentifier).

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -478,6 +478,7 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
 \inferrule[both]{
   \checktypesat(\tenv, \vtone, \vttwo) \typearrow \True \OrTypeError

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -194,13 +194,13 @@ in the global static environment $\genv$, resulting in the modified global stati
   \begin{itemize}
     \item \AllApplyCase{enum}
     \begin{itemize}
-      \item $\vttwo$ is an enumeration type with labels $\ids$, that is, $\TEnum(\ids)$;
+      \item $\vttwo$ is an \enumerationtypeterm{} with labels $\ids$, that is, $\TEnum(\ids)$;
       \item applying $\declareenumlabels$ to $\vttwo$ in $\tenvtwo$ $\newtenv$\ProseOrTypeError.
     \end{itemize}
 
     \item \AllApplyCase{not\_enum}
     \begin{itemize}
-      \item $\vttwo$ is not an enumeration type;
+      \item $\vttwo$ is not an \enumerationtypeterm{};
       \item $\newtenv$ is $\tenvtwo$.
     \end{itemize}
   \end{itemize}
@@ -542,7 +542,7 @@ The function
   \cup \overname{\TTypeError}{\TypeErrorConfig}
 )
 \]
-updates the static environment $\tenv$ with the identifiers $\ids$ listed by an enumeration type,
+updates the static environment $\tenv$ with the identifiers $\ids$ listed by an \enumerationtypeterm{},
 yielding the modified environment $\newtenv$.
 \ProseOtherwiseTypeError
 

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -67,7 +67,6 @@ The function
 \]
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
-\hypertarget{build-subtype}{}
 \begin{mathpar}
 \inferrule[with\_fields]{}{
   {

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -238,7 +238,7 @@ in the global static environment $\genv$, resulting in the modified global stati
 }
 \end{mathpar}
 \CodeSubsection{\DeclareTypeBegin}{\DeclareTypeEnd}{../Typing.ml}
-\lrmcomment{This is related to \identr{DHRC}, \identd{YZBQ}, \identr{DWSP}, \identi{MZXL}, \identr{MDZD}, \identr{CHKR}.}
+\identr{DHRC} \identd{YZBQ} \identr{DWSP} \identi{MZXL} \identr{MDZD} \identr{CHKR}
 
 \TypingRuleDef{AnnotateExtraFields}
 \hypertarget{def-annotateextrafields}{}

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -179,7 +179,7 @@ in the global static environment $\genv$, resulting in the modified global stati
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item checking that $\name$ is not already declared in the global environment of $\genv$ yields $\True$\ProseOrTypeError;
   \item define $\tenv$ as the static environment whose global component is $\genv$ and its local component is the empty local
@@ -192,13 +192,13 @@ All of the following apply:
   \item $\tenvtwo$ is $\tenvone$ with its $\declaredtypes$ component updated by binding $\name$ to $\vttwo$;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{enum}):
+    \item \AllApplyCase{enum}:
     \begin{itemize}
       \item $\vttwo$ is an enumeration type with labels $\ids$, that is, $\TEnum(\ids)$;
       \item applying $\declareenumlabels$ to $\vttwo$ in $\tenvtwo$ $\newtenv$\ProseOrTypeError.
     \end{itemize}
 
-    \item All of the following apply (\textsc{not\_enum}):
+    \item \AllApplyCase{not\_enum}:
     \begin{itemize}
       \item $\vttwo$ is not an enumeration type;
       \item $\newtenv$ is $\tenvtwo$.
@@ -262,14 +262,14 @@ the modified environment $\newtenv$ and type $\newty$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\vs$ is $\None$;
     \item $\newtenv$ is $\tenv$;
     \item $\newty$ is $\tty$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{empty\_fields}):
+  \item \AllApplyCase{empty\_fields}:
   \begin{itemize}
     \item $\vs$ is $\langle(\vsuper, \extrafields)\rangle$;
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is, \\ $\TNamed(\vsuper)$) yields
@@ -279,7 +279,7 @@ One of the following applies:
     \item $\newty$ is $\tty$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{no\_super}):
+  \item \AllApplyCase{no\_super}:
   \begin{itemize}
     \item $\vs$ is $\langle(\vsuper, \extrafields)\rangle$;
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is, \\ $\TNamed(\vsuper)$) yields
@@ -289,7 +289,7 @@ One of the following applies:
     \item the result is a type error indicating that $\vsuper$ is not a declared type.
   \end{itemize}
 
-  \item All of the following apply (\textsc{structured}):
+  \item \AllApplyCase{structured}:
   \begin{itemize}
     \item $\vs$ is $\langle(\vsuper, \extrafields)\rangle$;
     \item checking that $\tty$ \subtypesatisfies\ the named type $\vsuper$ (that is,\\ $\TNamed(\vsuper)$) yields
@@ -367,13 +367,13 @@ annotates the type $\vt$ inside an \optional\ $\tyopt$, if there is one, and lea
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\tyopt$ is $\None$;
     \item $\tyoptp$ is $\tyopt$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\tyopt$ contains the type $\vt$;
     \item annotating $\vt$ in $\tenv$ yields $\vtone$\ProseOrTypeError;
@@ -409,13 +409,13 @@ for the type and annotated expression in $\vres$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item $\expropt$ is $\None$;
     \item $\vres$ is $(\None, \None)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{some}):
+  \item \AllApplyCase{some}:
   \begin{itemize}
     \item $\expropt$ contains the expression $\ve$;
     \item annotating $\ve$ in $\tenv$ yields $(\vt, \vep)$\ProseOrTypeError;
@@ -458,20 +458,20 @@ $\typeannotation$ should not be $\None$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{both}):
+  \item \AllApplyCase{both}:
   \begin{itemize}
     \item $\initialvaluetype$ is $\langle\vtone\rangle$ and $\typeannotation$ is $\langle\vttwo\rangle$;
     \item checking that $\vtone$ \typesatisfies\ $\vttwo$ in $\tenv$ yields $\True$\ProseOrTypeError;
     \item $\declaredtype$ is $\vtone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{annotated}):
+  \item \AllApplyCase{annotated}:
   \begin{itemize}
     \item $\initialvaluetype$ is $\None$ and $\typeannotation$ is $\langle\vttwo\rangle$;
     \item $\declaredtype$ is $\vttwo$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{initial}):
+  \item \AllApplyCase{initial}:
   \begin{itemize}
     \item $\initialvaluetype$ is $\langle\vtone\rangle$ and $\typeannotation$ is $\None$;
     \item $\declaredtype$ is $\vtone$.
@@ -510,12 +510,12 @@ If the identifier is not associated with a declared type, a type error is return
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exists}):
+  \item \AllApplyCase{exists}:
   \begin{itemize}
     \item $\id$ is bound in the global environment to the type $\vt$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{type\_not\_declared}):
+  \item \AllApplyCase{type\_not\_declared}:
   \begin{itemize}
     \item $\id$ is not bound in the global environment to any type;
     \item the result is a type error indicating the lack of a type declaration for $\id$ (\UndefinedIdentifier).
@@ -547,7 +547,7 @@ yielding the modified environment $\newtenv$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\ids$ is the (non-empty) list of labels $\id_{1..k}$;
   \item $\tenv_0$ is $\tenv$;
@@ -589,7 +589,7 @@ global static environment $\genv$, yielding the modified environment $\newgenv$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item adding the global storage given by the identifier $\name$, global declaration keyword $\GDKConstant$,
         and type $\tty$ to $\genv$ yields $\genvone$;

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -77,7 +77,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
 
   \item All of the following apply (\textsc{t\_string}):
   \begin{itemize}
-    \item $\vt$ is the string type, $\TString$;
+    \item $\vt$ is the \stringtypeterm{}, $\TString$;
     \item $\vd$ is the set of all native string values, $\tstring$.
   \end{itemize}
 

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -67,7 +67,7 @@ by overloading $\dynamicdomain$:
 \]
 
 \ProseParagraph
-For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and \OneApplies
+\OneApplies
 \begin{itemize}
   \item \AllApplyCase{t\_bool}
   \begin{itemize}

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -439,12 +439,10 @@ the native integer value $c$,
 which is assigned to \texttt{N} by a given dynamic environment. The static domain of that parameter
 is the infinite set of all native integer values.
 
-\lrmcomment{
-This is related to \identd{BMGM}, \identr{PHRL}, \identr{PZNR},
-\identr{RLQP}, \identr{LYDS}, \identr{SVDJ}, \identi{WLPJ}, \identr{FWMM},
-\identi{WPWL}, \identi{CDVY}, \identi{KFCR}, \identi{BBQR}, \identr{ZWGH},
-\identr{DKGQ}, \identr{DHZT}, \identi{HSWR}, \identd{YZBQ}.
-}
+\identd{BMGM} \identr{PHRL} \identr{PZNR}
+\identr{RLQP} \identr{LYDS} \identr{SVDJ} \identi{WLPJ} \identr{FWMM}
+\identi{WPWL} \identi{CDVY} \identi{KFCR} \identi{BBQR} \identr{ZWGH}
+\identr{DKGQ} \identr{DHZT} \identi{HSWR} \identd{YZBQ}
 
 \subsection{Subsumption Testing\label{sec:subsumptiontesting}}
 Whether an assignment statement is well-typed depends on whether the dynamic domain of the

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -67,59 +67,59 @@ by overloading $\dynamicdomain$:
 \]
 
 \ProseParagraph
-For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and one of the following applies:
+For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and \OneApplies
 \begin{itemize}
-  \item \AllApplyCase{t\_bool}:
+  \item \AllApplyCase{t\_bool}
   \begin{itemize}
     \item $\vt$ is the Boolean type, $\TBool$;
     \item $\vd$ is the set of native Boolean values, $\tbool$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_string}:
+  \item \AllApplyCase{t\_string}
   \begin{itemize}
     \item $\vt$ is the \stringtypeterm{}, $\TString$;
     \item $\vd$ is the set of all native string values, $\tstring$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_real}:
+  \item \AllApplyCase{t\_real}
   \begin{itemize}
     \item $\vt$ is the \realtypeterm{}, $\TReal$;
     \item $\vd$ is the set of all native real values, $\treal$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_enumeration}:
+  \item \AllApplyCase{t\_enumeration}
   \begin{itemize}
     \item $\vt$ is the enumeration type with labels $\vl_{1..k}$, that is $\TEnum(\vl_{1..k})$;
     \item $\vd$ is the set of all native labels $\nvlabel(\vl_\vi)$, for $\vi = 1..k$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_int\_unconstrained}:
+  \item \AllApplyCase{t\_int\_unconstrained}
   \begin{itemize}
     \item $\vt$ is the unconstrained integer type, $\unconstrainedinteger$;
     \item $\vd$ is the set of all native integer values, $\tint$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_int\_well\_constrained}:
+  \item \AllApplyCase{t\_int\_well\_constrained}
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type $\TInt(\wellconstrained(\vc_{1..k}))$;
     \item $\vd$ is the union of the dynamic domains of each of the constraints $\vc_{1..k}$ in $\env$.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_exact\_okay}:
+  \item \AllApplyCase{constraint\_exact\_okay}
   \begin{itemize}
     \item $\vc$ is a constraint consisting of a single side-effect-free expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $n$;
     \item $\vd$ is the set containing the single native integer value for $n$.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_exact\_dynamic\_error}:
+  \item \AllApplyCase{constraint\_exact\_dynamic\_error}
   \begin{itemize}
     \item $\vc$ is a constraint consisting of a single side-effect-free expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_range\_okay}:
+  \item \AllApplyCase{constraint\_range\_okay}
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item evaluating $\veone$ in $\env$ results in a configuration with the native integer for $a$;
@@ -127,14 +127,14 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the set containing all native integer values for integers greater or equal to $a$ and less than or equal to $b$.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_range\_dynamic\_error1}:
+  \item \AllApplyCase{constraint\_range\_dynamic\_error1}
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item evaluating $\veone$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_range\_dynamic\_error2}:
+  \item \AllApplyCase{constraint\_range\_dynamic\_error2}
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item evaluating $\veone$ in $\env$ results in a configuration with the native integer for $a$;
@@ -142,21 +142,21 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{t\_int\_parameterized}:
+  \item \AllApplyCase{t\_int\_parameterized}
   \begin{itemize}
     \item $\vt$ is a \parameterizedintegertype\ for parameter $\id$, \\ $\TInt(\parameterized(\id))$;
     \item the \nativevalue\ associated with $\id$ in the local dynamic environment is the native integer value for $n$;
     \item $\vd$ is the set containing the single integer value for $n$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_bits\_dynamic\_error}:
+  \item \AllApplyCase{t\_bits\_dynamic\_error}
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
     \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{t\_bits\_negative\_width\_error}:
+  \item \AllApplyCase{t\_bits\_negative\_width\_error}
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
     \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
@@ -164,14 +164,14 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{t\_bits\_empty}:
+  \item \AllApplyCase{t\_bits\_empty}
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
     \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $0$;
     \item $\vd$ is the set containing the single \nativevalue\ for an empty bitvector.
   \end{itemize}
 
-  \item \AllApplyCase{t\_bits\_non\_empty}:
+  \item \AllApplyCase{t\_bits\_non\_empty}
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
     \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
@@ -179,7 +179,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the set containing all \nativevalues\ for bitvectors of size exactly $k$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_tuple}:
+  \item \AllApplyCase{t\_tuple}
   \begin{itemize}
     \item $\vt$ is a tuple type over types $\vt_i$, for $i=1..k$, $\TTuple(\vt_{1..k})$;
     \item the domain of each element $\vt_i$ is $D_i$, for $i=1..k$;
@@ -191,22 +191,22 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
   \item \AllApply
   \begin{itemize}
     \item $\vt$ is an integer-indexed array type with length expression $\ve$ and element type $\telem$, $\TArray(\ArrayLengthExpr(\ve), \telem)$;
-    \item One of the following applies:
+    \item \OneApplies
       \begin{itemize}
-      \item \AllApplyCase{t\_array\_dynamic\_error}:
+      \item \AllApplyCase{t\_array\_dynamic\_error}
       \begin{itemize}
         \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
         \item $\vd$ is the empty set.
       \end{itemize}
 
-      \item \AllApplyCase{t\_array\_negative\_length\_error}:
+      \item \AllApplyCase{t\_array\_negative\_length\_error}
       \begin{itemize}
         \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
         \item $k$ is negative;
         \item $\vd$ is the empty set.
       \end{itemize}
 
-      \item \AllApplyCase{t\_array\_okay}:
+      \item \AllApplyCase{t\_array\_okay}
       \begin{itemize}
         \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
         \item $k$ is greater than or equal to $0$;
@@ -216,7 +216,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \end{itemize}
   \end{itemize}
 
-  \item \AllApplyCase{t\_enum\_array}:
+  \item \AllApplyCase{t\_enum\_array}
   \begin{itemize}
     \item $\vt$ is an enumeration-indexed array type with for the enumeration $\id$ with $k$ labels and element type $\telem$,
           $\TArray(\ArrayLengthEnum(\id, k), \telem)$;
@@ -227,7 +227,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the set of all native records where each $\vl_i$ is mapped to a value taken from $D_\telem$, for $i=1..k$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_structured}:
+  \item \AllApplyCase{t\_structured}
   \begin{itemize}
     \item $\vt$ is a \structuredtype\ with typed fields $(\id_i, \vt_i)$, for $i=1..k$, that is $L([i=1..k: (\id_i,\vt_i))]$
     where $L\in\{\TRecord, \TException\}$;
@@ -235,7 +235,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the set containing all native records where $\id_i$ is mapped to a value taken from $D_i$, for $i=1..k$.
   \end{itemize}
 
-  \item \AllApplyCase{t\_named}:
+  \item \AllApplyCase{t\_named}
   \begin{itemize}
     \item $\vt$ is a named type with name $\id$, $\TNamed(\id)$;
     \item the type associated with $\id$ in $\tenv$ is $\tty$;

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -69,57 +69,57 @@ by overloading $\dynamicdomain$:
 \ProseParagraph
 For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and one of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{t\_bool}):
+  \item \AllApplyCase{t\_bool}:
   \begin{itemize}
     \item $\vt$ is the Boolean type, $\TBool$;
     \item $\vd$ is the set of native Boolean values, $\tbool$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_string}):
+  \item \AllApplyCase{t\_string}:
   \begin{itemize}
     \item $\vt$ is the \stringtypeterm{}, $\TString$;
     \item $\vd$ is the set of all native string values, $\tstring$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_real}):
+  \item \AllApplyCase{t\_real}:
   \begin{itemize}
     \item $\vt$ is the \realtypeterm{}, $\TReal$;
     \item $\vd$ is the set of all native real values, $\treal$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_enumeration}):
+  \item \AllApplyCase{t\_enumeration}:
   \begin{itemize}
     \item $\vt$ is the enumeration type with labels $\vl_{1..k}$, that is $\TEnum(\vl_{1..k})$;
     \item $\vd$ is the set of all native labels $\nvlabel(\vl_\vi)$, for $\vi = 1..k$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_int\_unconstrained}):
+  \item \AllApplyCase{t\_int\_unconstrained}:
   \begin{itemize}
     \item $\vt$ is the unconstrained integer type, $\unconstrainedinteger$;
     \item $\vd$ is the set of all native integer values, $\tint$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_int\_well\_constrained}):
+  \item \AllApplyCase{t\_int\_well\_constrained}:
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type $\TInt(\wellconstrained(\vc_{1..k}))$;
     \item $\vd$ is the union of the dynamic domains of each of the constraints $\vc_{1..k}$ in $\env$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{constraint\_exact\_okay}):
+  \item \AllApplyCase{constraint\_exact\_okay}:
   \begin{itemize}
     \item $\vc$ is a constraint consisting of a single side-effect-free expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $n$;
     \item $\vd$ is the set containing the single native integer value for $n$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{constraint\_exact\_dynamic\_error}):
+  \item \AllApplyCase{constraint\_exact\_dynamic\_error}:
   \begin{itemize}
     \item $\vc$ is a constraint consisting of a single side-effect-free expression $\ve$, that is, $\ConstraintExact(\ve)$;
     \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{constraint\_range\_okay}):
+  \item \AllApplyCase{constraint\_range\_okay}:
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item evaluating $\veone$ in $\env$ results in a configuration with the native integer for $a$;
@@ -127,14 +127,14 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the set containing all native integer values for integers greater or equal to $a$ and less than or equal to $b$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{constraint\_range\_dynamic\_error1}):
+  \item \AllApplyCase{constraint\_range\_dynamic\_error1}:
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item evaluating $\veone$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{constraint\_range\_dynamic\_error2}):
+  \item \AllApplyCase{constraint\_range\_dynamic\_error2}:
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item evaluating $\veone$ in $\env$ results in a configuration with the native integer for $a$;
@@ -142,21 +142,21 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_int\_parameterized}):
+  \item \AllApplyCase{t\_int\_parameterized}:
   \begin{itemize}
     \item $\vt$ is a \parameterizedintegertype\ for parameter $\id$, \\ $\TInt(\parameterized(\id))$;
     \item the \nativevalue\ associated with $\id$ in the local dynamic environment is the native integer value for $n$;
     \item $\vd$ is the set containing the single integer value for $n$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_bits\_dynamic\_error}):
+  \item \AllApplyCase{t\_bits\_dynamic\_error}:
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
     \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_bits\_negative\_width\_error}):
+  \item \AllApplyCase{t\_bits\_negative\_width\_error}:
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
     \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
@@ -164,14 +164,14 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_bits\_empty}):
+  \item \AllApplyCase{t\_bits\_empty}:
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
     \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $0$;
     \item $\vd$ is the set containing the single \nativevalue\ for an empty bitvector.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_bits\_non\_empty}):
+  \item \AllApplyCase{t\_bits\_non\_empty}:
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
     \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
@@ -179,7 +179,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the set containing all \nativevalues\ for bitvectors of size exactly $k$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_tuple}):
+  \item \AllApplyCase{t\_tuple}:
   \begin{itemize}
     \item $\vt$ is a tuple type over types $\vt_i$, for $i=1..k$, $\TTuple(\vt_{1..k})$;
     \item the domain of each element $\vt_i$ is $D_i$, for $i=1..k$;
@@ -188,25 +188,25 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     is from $D_i$.
   \end{itemize}
 
-  \item All of the following apply:
+  \item \AllApply
   \begin{itemize}
     \item $\vt$ is an integer-indexed array type with length expression $\ve$ and element type $\telem$, $\TArray(\ArrayLengthExpr(\ve), \telem)$;
     \item One of the following applies:
       \begin{itemize}
-      \item All of the following apply (\textsc{t\_array\_dynamic\_error}):
+      \item \AllApplyCase{t\_array\_dynamic\_error}:
       \begin{itemize}
         \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
         \item $\vd$ is the empty set.
       \end{itemize}
 
-      \item All of the following apply (\textsc{t\_array\_negative\_length\_error}):
+      \item \AllApplyCase{t\_array\_negative\_length\_error}:
       \begin{itemize}
         \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
         \item $k$ is negative;
         \item $\vd$ is the empty set.
       \end{itemize}
 
-      \item All of the following apply (\textsc{t\_array\_okay}):
+      \item \AllApplyCase{t\_array\_okay}:
       \begin{itemize}
         \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
         \item $k$ is greater than or equal to $0$;
@@ -216,7 +216,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \end{itemize}
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_enum\_array}):
+  \item \AllApplyCase{t\_enum\_array}:
   \begin{itemize}
     \item $\vt$ is an enumeration-indexed array type with for the enumeration $\id$ with $k$ labels and element type $\telem$,
           $\TArray(\ArrayLengthEnum(\id, k), \telem)$;
@@ -227,7 +227,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the set of all native records where each $\vl_i$ is mapped to a value taken from $D_\telem$, for $i=1..k$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_structured}):
+  \item \AllApplyCase{t\_structured}:
   \begin{itemize}
     \item $\vt$ is a \structuredtype\ with typed fields $(\id_i, \vt_i)$, for $i=1..k$, that is $L([i=1..k: (\id_i,\vt_i))]$
     where $L\in\{\TRecord, \TException\}$;
@@ -235,7 +235,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
     \item $\vd$ is the set containing all native records where $\id_i$ is mapped to a value taken from $D_i$, for $i=1..k$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{t\_named}):
+  \item \AllApplyCase{t\_named}:
   \begin{itemize}
     \item $\vt$ is a named type with name $\id$, $\TNamed(\id)$;
     \item the type associated with $\id$ in $\tenv$ is $\tty$;

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -83,7 +83,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and on
 
   \item All of the following apply (\textsc{t\_real}):
   \begin{itemize}
-    \item $\vt$ is the real type, $\TReal$;
+    \item $\vt$ is the \realtypeterm{}, $\TReal$;
     \item $\vd$ is the set of all native real values, $\treal$.
   \end{itemize}
 

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -409,7 +409,7 @@ in the \emph{local dynamic environment} of $\denv$.
 }
 \end{mathpar}
 
-\subsubsection{Examples}
+\ExampleDef{Type Domains}
 The domain of \texttt{integer} is the infinite set of all integers.
 
 The domain of \verb|integer {2,16}| is the set $\{\nvint(2), \nvint(16)\}$.

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -89,7 +89,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and \O
 
   \item \AllApplyCase{t\_enumeration}
   \begin{itemize}
-    \item $\vt$ is the enumeration type with labels $\vl_{1..k}$, that is $\TEnum(\vl_{1..k})$;
+    \item $\vt$ is the \enumerationtypeterm{} with labels $\vl_{1..k}$, that is $\TEnum(\vl_{1..k})$;
     \item $\vd$ is the set of all native labels $\nvlabel(\vl_\vi)$, for $\vi = 1..k$.
   \end{itemize}
 
@@ -181,7 +181,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and \O
 
   \item \AllApplyCase{t\_tuple}
   \begin{itemize}
-    \item $\vt$ is a tuple type over types $\vt_i$, for $i=1..k$, $\TTuple(\vt_{1..k})$;
+    \item $\vt$ is a \tupletypeterm{} over types $\vt_i$, for $i=1..k$, $\TTuple(\vt_{1..k})$;
     \item the domain of each element $\vt_i$ is $D_i$, for $i=1..k$;
     \item evaluating $\ve$ in $\env$ results in a configuration with the native integer for $k$;
     \item $\vd$ is the set containing all native vectors of $k$ values, where the value at position $i$
@@ -221,7 +221,7 @@ For an environment $\env \in \envs$ and a type $\vt$, the domain is $\vd$ and \O
     \item $\vt$ is an enumeration-indexed array type with for the enumeration $\id$ with $k$ labels and element type $\telem$,
           $\TArray(\ArrayLengthEnum(\id, k), \telem)$;
     \item view $\env$ as the pair consisting of the static environment $\tenv$ and a dynamic environment;
-    \item the type bound to $\id$ in the $\declaredtypes$ map of the static environment of $\tenv$ is the enumeration type
+    \item the type bound to $\id$ in the $\declaredtypes$ map of the static environment of $\tenv$ is the \enumerationtypeterm{}
           for the labels $\vl_{1..k}$, that is, $\TEnum(\vl_{1..k})$;
     \item the dynamic domain of $\telem$ in $\env$ is $D_\telem$;
     \item $\vd$ is the set of all native records where each $\vl_i$ is mapped to a value taken from $D_\telem$, for $i=1..k$.

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -217,7 +217,7 @@ One of the following applies:
 }
 \end{mathpar}
 
-\subsubsection{TypingRule.FindBitfieldOpt}
+\TypingRuleDef{FindBitfieldOpt}
 \hypertarget{def-findbitfieldopt}{}
 The function
 \[
@@ -351,8 +351,8 @@ One of the following applies:
 
 \section{Static Environment Utilities}
 
+\TypingRuleDef{WithEmptyLocal}
 \hypertarget{def-withemptylocal}{}
-\subsubsection{TypingRule.WithEmptyLocal}
 The function
 \[
   \withemptylocal(\overname{\globalstaticenvs}{\genv})

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -42,6 +42,7 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
 \inferrule[empty]{}{ \pairstomap(\emptylist) \typearrow \emptyfunc }
 \and
@@ -49,11 +50,12 @@ One of the following applies:
   i,j \in 1..k\\
   i \neq j\\
   \id_i = \id_j
-}
-{
+}{
   \pairstomap([i=1..k: (\id_i,t_i)]) \typearrow \TypeErrorVal{\IdentifierAlreadyDeclared}
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[okay]{
   \forall i,j \in 1..k. \id_i \neq \id_j\\
   {
@@ -62,8 +64,7 @@ One of the following applies:
     \bot & \text{ otherwise}
   \end{cases}
   }
-}
-{
+}{
   \pairstomap([i=1..k: (\id_i,t_i)]) \typearrow f
 }
 \end{mathpar}
@@ -93,20 +94,21 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
-  \inferrule[okay]{
-    \cardinality{\{\id_{1..k}\}} = k
-  }
-  {
-    \checknoduplicates(\id_{1..k}) \typearrow \True
-  }
-\and
+\inferrule[okay]{
+  \cardinality{\{\id_{1..k}\}} = k
+}{
+  \checknoduplicates(\id_{1..k}) \typearrow \True
+}
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[error]{
   i,j \in 1..k\\
   i \neq j\\
   \id_i = \id_j
-}
-{
+}{
   \checknoduplicates(\id_{1..k}) \typearrow \TypeErrorVal{\IdentifierAlreadyDeclared}
 }
 \end{mathpar}
@@ -142,6 +144,7 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
   \inferrule[none]{}
   {
@@ -248,6 +251,7 @@ One of the following applies:
   \end{itemize}
 \end{itemize}
 
+\FormallyParagraph
 \begin{mathpar}
 \inferrule[match]{
   \bitfieldgetname(\vbf) \typearrow \name

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -5,9 +5,11 @@
 We define the following rules to allow us asserting that a condition holds,
 returning a type error otherwise:
 \begin{mathpar}
-  \inferrule[check\_trans\_true]{}{ \checktrans{\True}{<message>} \checktransarrow \True }
-  \and
-  \inferrule[check\_trans\_false]{}{ \checktrans{\False}{<message>} \checktransarrow \TypeErrorVal{\texttt{<message>}} }
+\inferrule[check\_trans\_true]{}{ \checktrans{\True}{\vcode} \checktransarrow \True }
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[check\_trans\_false]{}{ \checktrans{\False}{\vcode} \checktransarrow \TypeErrorVal{\vcode} }
 \end{mathpar}
 
 \hypertarget{def-pairstomap}{}
@@ -146,7 +148,7 @@ filters a list of \optional{} elements, removing those which are $\None$ and unw
 
 \FormallyParagraph
 \begin{mathpar}
-  \inferrule[none]{}
+  \inferrule[empty]{}
   {
     \filteroptionlist(\overname{\emptylist}{\vvopts}) \typearrow \overname{\emptylist}{\vvs}
   }

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -21,21 +21,21 @@ of type $T$ into a function mapping each identifier to its respective value in t
 If a duplicate identifier exists in $\pairs$ then a type error is returned.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\pairs$ is empty;
     \item $f$ is the empty function.
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item there exist two different positions in the list where the identifier is the same;
     \item the result is a type error indicating the existence of a duplicate identifier.
   \end{itemize}
 
-  \item \AllApplyCase{okay}:
+  \item \AllApplyCase{okay}
   \begin{itemize}
     \item all identifiers occurring in the list are unique;
     \item $f$ is a function that associates to each identifier the value appearing with it in $\pairs$.
@@ -79,15 +79,15 @@ checks whether a non-empty list of identifiers contains a duplicate identifier. 
 is $\True$ and otherwise the result is a type error.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{okay}:
+  \item \AllApplyCase{okay}
   \begin{itemize}
     \item the set containing all identifiers in the list has the same cardinality as the length of the list;
     \item the result is $\True$.
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item there exist two different positions in the list where the identifier is the same;
     \item the result is a type error indicating the existence of a duplicate identifier.
@@ -122,21 +122,21 @@ The parametric function
 filters a list of \optional{} elements, removing those which are $\None$ and unwrapping those which are $\langle v \rangle$ to $v$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\vvopts$ is the empty list;
     \item $\vvs$ is the empty list.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty\_none}:
+  \item \AllApplyCase{non\_empty\_none}
   \begin{itemize}
     \item $\vvopts$ is the non-empty list with head $\None$ and tail $\vvoptsp$;
     \item applying $\filteroptionlist$ to $\vvoptsp$ yields $\vvs$.
   \end{itemize}
 
-  \item \AllApplyCase{non\_empty\_some}:
+  \item \AllApplyCase{non\_empty\_some}
   \begin{itemize}
     \item $\vvopts$ is the non-empty list with head $\langle\vv\rangle$ and tail $\vvoptsp$;
     \item applying $\filteroptionlist$ to $\vvoptsp$ yields $\vvsp$;
@@ -181,15 +181,15 @@ $0$ to mean that $a$ and $b$ can be ordered in any way,
 and $-1$ to mean that $b$ should be ordered before $a$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{empty\_or\_single}:
+  \item \AllApplyCase{empty\_or\_single}
   \begin{itemize}
     \item $\vlone$ is either empty or contains a single element;
     \item $\vltwo$ is $\vlone$.
   \end{itemize}
 
-  \item \AllApplyCase{two\_or\_more}:
+  \item \AllApplyCase{two\_or\_more}
   \begin{itemize}
     \item $\vlone$ contains at least two elements;
     \item $f$ is a permutation of $1..n$;
@@ -228,23 +228,23 @@ returns the bitfield associated with the name $\name$ in the list of bitfields $
 if there is one. Otherwise, the result is $\None$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{match}:
+  \item \AllApplyCase{match}
   \begin{itemize}
     \item $\bitfields$ starts with a bitfield $\vbf$;
     \item obtaining the name associated with $\vbf$ yields $\name$;
     \item the result if $\vbf$.
   \end{itemize}
 
-  \item \AllApplyCase{tail}:
+  \item \AllApplyCase{tail}
   \begin{itemize}
     \item $\bitfields$ starts with a bitfield $\vbf$ and continues with the tail list $\bitfieldsp$;
     \item obtaining the name associated with $\vbf$ yields $\namep$, which is different than $\name$;
     \item finding the bitfield associated with $\name$ in $\bitfieldsp$ yields the result $\vr$.
   \end{itemize}
 
-  \item \AllApplyCase{empty}:
+  \item \AllApplyCase{empty}
   \begin{itemize}
     \item $\bitfields$ is an empty list;
     \item the result is $\None$.
@@ -282,15 +282,15 @@ The function
 returns the type for the array length $\size$ in $\vt$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{enum}:
+  \item \AllApplyCase{enum}
   \begin{itemize}
     \item $\size$ is an enumeration index over the enumeration $\vs$, that is, \\ $\ArrayLengthEnum(\vs, \Ignore)$;
     \item $\vt$ is the named type for $\vs$, that is, $\TNamed(\vs)$.
   \end{itemize}
 
-  \item \AllApplyCase{expr}:
+  \item \AllApplyCase{expr}
   \begin{itemize}
     \item $\size$ is an expression for integer-sized arrays, that is, $\ArrayLengthExpr(\Ignore)$;
     \item $\vt$ is the \unconstrainedintegertype.
@@ -319,15 +319,15 @@ The function
 returns the value $\vv$ associated with the identifier $\id$ in the list of pairs $\vli$ or $\None$, if no such association exists.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{member}:
+  \item \AllApplyCase{member}
   \begin{itemize}
     \item a pair $(\id,\vv)$ exists in the list $\vli$;
     \item the result is $\langle\vv\rangle$.
   \end{itemize}
 
-  \item \AllApplyCase{not\_member}:
+  \item \AllApplyCase{not\_member}
   \begin{itemize}
     \item every pair $(\vx,\Ignore)$ in the list $\vli$ has $\vx\neq\id$;
     \item the result is $\None$.
@@ -564,20 +564,20 @@ looks up the environment $\tenv$ for a constant $\vv$ associated with an identif
 $\vs$. The result is $\bot$ if $\vs$ is not associated with any constant.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{local}:
+  \item \AllApplyCase{local}
   \begin{itemize}
     \item $\vs$ is associated with a constant $\vv$ in the local environment of $\tenv$;
   \end{itemize}
 
-  \item \AllApplyCase{global}:
+  \item \AllApplyCase{global}
   \begin{itemize}
     \item $\vs$ is not associated with a constant in the local environment of $\tenv$;
     \item $\vs$ is associated with a constant $\vv$ in the global environment of $\tenv$;
   \end{itemize}
 
-  \item \AllApplyCase{not\_found}:
+  \item \AllApplyCase{not\_found}
   \begin{itemize}
     \item $\vs$ is not associated with a constant in the local environment of $\tenv$;
     \item $\vs$ is not associated with a constant in the global environment of $\tenv$;
@@ -669,20 +669,20 @@ looks up the static environment $\tenv$ for an immutable expression associated w
 returning $\bot$ if there is none.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{local}:
+  \item \AllApplyCase{local}
   \begin{itemize}
     \item applying $\exprequiv$ to $\vx$ in the local component of $\tenv$, yields $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{global}:
+  \item \AllApplyCase{global}
   \begin{itemize}
     \item applying $\exprequiv$ to $\vx$ in the local component of $\tenv$, yields $\bot$;
     \item applying $\exprequiv$ to $\vx$ in the global component of $\tenv$, yields $\ve$.
   \end{itemize}
 
-  \item \AllApplyCase{none}:
+  \item \AllApplyCase{none}
   \begin{itemize}
     \item applying $\exprequiv$ to $\vx$ in the local component of $\tenv$, yields $\bot$;
     \item applying $\exprequiv$ to $\vx$ in the global component of $\tenv$, yields $\bot$;
@@ -822,9 +822,9 @@ along with the local declaration keyword $\ldk$. The result is the updated stati
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{ok}:
+  \item \AllApplyCase{ok}
   \begin{itemize}
     \item $\vep$ contains the expression $\ve$ and \sideeffectsetterm\ $\vsese$;
     \item $\ldk$ is either $\LDKConstant$ or $\LDKLet$;
@@ -833,9 +833,9 @@ One of the following applies:
     \item applying $\addlocalimmutableexpr$ to $\vx$ and $\ve$ yields $\newtenv$.
   \end{itemize}
 
-  \item \AllApplyCase{fail}:
+  \item \AllApplyCase{fail}
   \begin{itemize}
-    \item One of the following applies:
+    \item \OneApplies
     \begin{itemize}
       \item $\vep$ is $\None$;
       \item $\ldk$ is neither $\LDKConstant$ nor $\LDKLet$;

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -23,19 +23,19 @@ If a duplicate identifier exists in $\pairs$ then a type error is returned.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\pairs$ is empty;
     \item $f$ is the empty function.
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item there exist two different positions in the list where the identifier is the same;
     \item the result is a type error indicating the existence of a duplicate identifier.
   \end{itemize}
 
-  \item All of the following apply (\textsc{okay}):
+  \item \AllApplyCase{okay}:
   \begin{itemize}
     \item all identifiers occurring in the list are unique;
     \item $f$ is a function that associates to each identifier the value appearing with it in $\pairs$.
@@ -81,13 +81,13 @@ is $\True$ and otherwise the result is a type error.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{okay}):
+  \item \AllApplyCase{okay}:
   \begin{itemize}
     \item the set containing all identifiers in the list has the same cardinality as the length of the list;
     \item the result is $\True$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item there exist two different positions in the list where the identifier is the same;
     \item the result is a type error indicating the existence of a duplicate identifier.
@@ -124,19 +124,19 @@ filters a list of \optional{} elements, removing those which are $\None$ and unw
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\vvopts$ is the empty list;
     \item $\vvs$ is the empty list.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty\_none}):
+  \item \AllApplyCase{non\_empty\_none}:
   \begin{itemize}
     \item $\vvopts$ is the non-empty list with head $\None$ and tail $\vvoptsp$;
     \item applying $\filteroptionlist$ to $\vvoptsp$ yields $\vvs$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{non\_empty\_some}):
+  \item \AllApplyCase{non\_empty\_some}:
   \begin{itemize}
     \item $\vvopts$ is the non-empty list with head $\langle\vv\rangle$ and tail $\vvoptsp$;
     \item applying $\filteroptionlist$ to $\vvoptsp$ yields $\vvsp$;
@@ -183,13 +183,13 @@ and $-1$ to mean that $b$ should be ordered before $a$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{empty\_or\_single}):
+  \item \AllApplyCase{empty\_or\_single}:
   \begin{itemize}
     \item $\vlone$ is either empty or contains a single element;
     \item $\vltwo$ is $\vlone$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{two\_or\_more}):
+  \item \AllApplyCase{two\_or\_more}:
   \begin{itemize}
     \item $\vlone$ contains at least two elements;
     \item $f$ is a permutation of $1..n$;
@@ -230,21 +230,21 @@ if there is one. Otherwise, the result is $\None$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{match}):
+  \item \AllApplyCase{match}:
   \begin{itemize}
     \item $\bitfields$ starts with a bitfield $\vbf$;
     \item obtaining the name associated with $\vbf$ yields $\name$;
     \item the result if $\vbf$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{tail}):
+  \item \AllApplyCase{tail}:
   \begin{itemize}
     \item $\bitfields$ starts with a bitfield $\vbf$ and continues with the tail list $\bitfieldsp$;
     \item obtaining the name associated with $\vbf$ yields $\namep$, which is different than $\name$;
     \item finding the bitfield associated with $\name$ in $\bitfieldsp$ yields the result $\vr$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{empty}):
+  \item \AllApplyCase{empty}:
   \begin{itemize}
     \item $\bitfields$ is an empty list;
     \item the result is $\None$.
@@ -284,13 +284,13 @@ returns the type for the array length $\size$ in $\vt$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{enum}):
+  \item \AllApplyCase{enum}:
   \begin{itemize}
     \item $\size$ is an enumeration index over the enumeration $\vs$, that is, \\ $\ArrayLengthEnum(\vs, \Ignore)$;
     \item $\vt$ is the named type for $\vs$, that is, $\TNamed(\vs)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{expr}):
+  \item \AllApplyCase{expr}:
   \begin{itemize}
     \item $\size$ is an expression for integer-sized arrays, that is, $\ArrayLengthExpr(\Ignore)$;
     \item $\vt$ is the \unconstrainedintegertype.
@@ -321,13 +321,13 @@ returns the value $\vv$ associated with the identifier $\id$ in the list of pair
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{member}):
+  \item \AllApplyCase{member}:
   \begin{itemize}
     \item a pair $(\id,\vv)$ exists in the list $\vli$;
     \item the result is $\langle\vv\rangle$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{not\_member}):
+  \item \AllApplyCase{not\_member}:
   \begin{itemize}
     \item every pair $(\vx,\Ignore)$ in the list $\vli$ has $\vx\neq\id$;
     \item the result is $\None$.
@@ -383,7 +383,7 @@ checks whether $\id$ is already declared in $\tenv$. If it is, the result is a t
 and otherwise the result is $\True$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\isundefined$ to $\vx$ in $\genv$ yields $\vb$;
   \item checking whether $\vb$ is $\True$ yields $\True$\ProseTerminateAs{\IdentifierAlreadyDeclared}.
@@ -410,7 +410,7 @@ checks whether $\id$ is already declared in the global static environment $\genv
 If it is, the result is a type error, and otherwise the result is $\True$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item applying $\isglobalundefined$ to $\vx$ in $\genv$ yields $\vb$;
   \item checking whether $\vb$ is $\True$ yields $\True$\ProseTerminateAs{\IdentifierAlreadyDeclared}.
@@ -443,7 +443,7 @@ adds the identifier $\id$ as a local storage element with type $\tty$ and local 
 to the local environment of $\tenv$, resulting in the static environment $\newtenv$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item the map $\newlocalstoragetypes$ is defined by updating the map \\
         $\localstoragetypes$ of $\tenv$
@@ -566,18 +566,18 @@ $\vs$. The result is $\bot$ if $\vs$ is not associated with any constant.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{local}):
+  \item \AllApplyCase{local}:
   \begin{itemize}
     \item $\vs$ is associated with a constant $\vv$ in the local environment of $\tenv$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{global}):
+  \item \AllApplyCase{global}:
   \begin{itemize}
     \item $\vs$ is not associated with a constant in the local environment of $\tenv$;
     \item $\vs$ is associated with a constant $\vv$ in the global environment of $\tenv$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{not\_found}):
+  \item \AllApplyCase{not\_found}:
   \begin{itemize}
     \item $\vs$ is not associated with a constant in the local environment of $\tenv$;
     \item $\vs$ is not associated with a constant in the global environment of $\tenv$;
@@ -671,18 +671,18 @@ returning $\bot$ if there is none.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{local}):
+  \item \AllApplyCase{local}:
   \begin{itemize}
     \item applying $\exprequiv$ to $\vx$ in the local component of $\tenv$, yields $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{global}):
+  \item \AllApplyCase{global}:
   \begin{itemize}
     \item applying $\exprequiv$ to $\vx$ in the local component of $\tenv$, yields $\bot$;
     \item applying $\exprequiv$ to $\vx$ in the global component of $\tenv$, yields $\ve$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{none}):
+  \item \AllApplyCase{none}:
   \begin{itemize}
     \item applying $\exprequiv$ to $\vx$ in the local component of $\tenv$, yields $\bot$;
     \item applying $\exprequiv$ to $\vx$ in the global component of $\tenv$, yields $\bot$;
@@ -732,7 +732,7 @@ in the static environment $\tenv$,
 resulting in the updated environment $\newtenv$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item define $\newtenv$ as the static environment with the same local environment as $\tenv$ and a global environment
         where $\exprequiv$ binds $\vx$ to $\ve$.
@@ -760,7 +760,7 @@ in the static environment $\tenv$,
 resulting in the updated environment $\newtenv$.
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item define $\newtenv$ as the static environment with the same global environment as $\tenv$ and a local environment
         where $\exprequiv$ binds $\vx$ to $\ve$.
@@ -824,7 +824,7 @@ along with the local declaration keyword $\ldk$. The result is the updated stati
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{ok}):
+  \item \AllApplyCase{ok}:
   \begin{itemize}
     \item $\vep$ contains the expression $\ve$ and \sideeffectsetterm\ $\vsese$;
     \item $\ldk$ is either $\LDKConstant$ or $\LDKLet$;
@@ -833,7 +833,7 @@ One of the following applies:
     \item applying $\addlocalimmutableexpr$ to $\vx$ and $\ve$ yields $\newtenv$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{fail}):
+  \item \AllApplyCase{fail}:
   \begin{itemize}
     \item One of the following applies:
     \begin{itemize}

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -564,11 +564,11 @@ In \listingref{typing-tstring}, all the uses of the \stringtypeterm{} are well-t
 \end{mathpar}
 \CodeSubsection{\TStringBegin}{\TStringEnd}{../Typing.ml}
 
-\hypertarget{booleantypeterm}{}
 \section{The Boolean Type\label{sec:BooleanType}}
+\hypertarget{booleantypeterm}{}
 The \emph{\booleantypeterm{}} represents the algebraic Boolean type.
 
-\subsubsection{Example}
+\ExampleDef{Boolean Type}
 In \listingref{typing-tbool}, all the uses of \booleantypeterm{} are well-typed.
 \ASLListing{Well-typed Boolean types}{typing-tbool}{\typingtests/TypingRule.TBool.asl}
 
@@ -591,6 +591,7 @@ In \listingref{typing-tbool}, all the uses of \booleantypeterm{} are well-typed.
 \end{mathpar}
 
 \subsection{Typing the Boolean Type\label{sec:TypingBooleanType}}
+See \ExampleRef{Boolean Type}.
 \TypingRuleDef{TBool}
 \ProseParagraph
 \AllApply
@@ -1367,7 +1368,12 @@ The rule for typing exception types is \TypingRuleRef{TStructuredDecl}.
 \end{mathpar}
 
 \subsection{Typing Named Types\label{sec:TypingNamedTypes}}
+\ExampleDef{Well-typed Named Types}
+In \listingref{typing-tnamed}, all the uses of \texttt{MyType} are well-typed.
+\ASLListing{Well-typed named types}{typing-tnamed}{\typingtests/TypingRule.TNamed.asl}
+
 \TypingRuleDef{TNamed}
+See \ExampleRef{Well-typed Named Types}.
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1388,10 +1394,6 @@ The rule for typing exception types is \TypingRuleRef{TStructuredDecl}.
 }
 \end{mathpar}
 \CodeSubsection{\TNamedBegin}{\TNamedEnd}{../Typing.ml}
-
-\subsubsection{Example}
-In \listingref{typing-tnamed}, all the uses of \texttt{MyType} are well-typed.
-\ASLListing{Well-typed named types}{typing-tnamed}{\typingtests/TypingRule.TNamed.asl}
 
 \section{Declared Types\label{sec:DeclaredTypes}}
 A declared type can be an \enumerationtypeterm{}, a record type, an exception type, or an \anonymoustype.
@@ -1418,7 +1420,7 @@ are only permitted in named type declarations. This is enforced by \TypingRuleRe
 See \ExampleRef{Ill-typed pending-constrained integer type}.
 
 \TypingRuleDef{TNonDecl}
-\subsubsection{Example}
+\ExampleDef{Ill-typed Type Declarations}
 In \listingref{typing-trecorderror}, the use of a record type outside of a declaration is erroneous.
 \ASLListing{An erroneous use of a record type}{typing-trecorderror}{\typingtests/TypingRule.TNonDecl.asl}
 

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -8,7 +8,7 @@ Next, we introduce each type available in ASL and define
 how it is represented in the syntax and AST, and how it is typechecked:
 \begin{itemize}
   \item Integer types (see \secref{IntegerTypes})
-  \item The real type (see \secref{RealType})
+  \item The \realtypeterm{} (see \secref{RealType})
   \item The string type (see \secref{StringType})
   \item The Boolean type (see \secref{BooleanType})
   \item Bitvector types (see \secref{BitvectorTypes})
@@ -465,6 +465,16 @@ and there is no bound on their precision.
 %
 There is no mechanism in the language to generate an irrational value of \realtypeterm.
 
+Conversions from an \integertypeterm{} value to a \realtypeterm{} value are performed
+using the \stdlibfunc{Real}.
+%
+Conversions from a \realtypeterm{} value an \integertypeterm{} value to are performed
+using the \stdlibfunc{RoundDown} or \stdlibfunc{RoundUp}.
+
+\subsubsection{Example}
+In \listingref{typing-treal}, all the uses of the \realtypeterm{} are well-typed.
+\ASLListing{Well-typed real types}{typing-treal}{\typingtests/TypingRule.TReal.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nty \derives\ & \Treal &
@@ -485,15 +495,11 @@ There is no mechanism in the language to generate an irrational value of \realty
 
 \subsection{Typing the Real Type\label{sec:TypingRealType}}
 \TypingRuleDef{TReal}
-\subsubsection{Example}
-In \listingref{typing-treal}, all the uses of \texttt{real} are well-typed.
-\ASLListing{Well-typed real types}{typing-treal}{\typingtests/TypingRule.TReal.asl}
-
 \ProseParagraph
 All of the following apply:
 \begin{itemize}
-  \item $\tty$ is the real type \TReal.
-  \item $\newty$ is the real type \TReal;
+  \item $\tty$ is the \realtypeterm{}.
+  \item $\newty$ is the \realtypeterm{};
   \item define $\vses$ as the empty set.
 \end{itemize}
 

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -1,20 +1,20 @@
 \chapter{Types\label{chap:Types}}
 
 Types describe the allowed values of variables, constants, function arguments, etc.
-\lrmcomment{\identi{BYVL}}
+\identi{BYVL}
 
 This chapter first describes how types are represented formally (see \secref{FormalRepresentationofTypes}).
 Next, we introduce each type available in ASL and define
 how it is represented in the syntax and AST, and how it is typechecked:
 \begin{itemize}
-  \item Integer types (see \secref{IntegerTypes})
+  \item The \integertypeterm{} (see \secref{IntegerTypes})
   \item The \realtypeterm{} (see \secref{RealType})
   \item The \stringtypeterm{} (see \secref{StringType})
-  \item The Boolean type (see \secref{BooleanType})
-  \item Bitvector types (see \secref{BitvectorTypes})
-  \item Tuple types (see \secref{TupleTypes})
+  \item The \booleantypeterm{} (see \secref{BooleanType})
+  \item The \bitvectortypeterm{} (see \secref{BitvectorTypes})
+  \item \Tupletypesterm{} (see \secref{TupleTypes})
+  \item \Enumerationtypesterm{} (see \secref{EnumerationTypes})
   \item Array types (see \secref{ArrayTypes})
-  \item Enumeration types (see \secref{EnumerationTypes})
   \item Record types (see \secref{RecordTypes})
   \item Exception types (see \secref{ExceptionTypes})
   \item Named types (see \secref{NamedTypes})
@@ -88,7 +88,7 @@ The function
 typechecks a type $\tty$ in a static environment $\tenv$,
 resulting in a \typedast\ $\newty$ and a \sideeffectsetterm\ $\vses$.
 The flag $\decl$ indicates whether $\tty$ is a type currently being declared or not,
-and makes a difference only when $\tty$ is an enumeration type or a \structuredtype.
+and makes a difference only when $\tty$ is an \enumerationtypeterm{} or a \structuredtype.
 \ProseOtherwiseTypeError
 
 \subsection{Semantics}
@@ -98,15 +98,16 @@ which is defined in \secref{DomainOfValuesForTypes}.
 
 \hypertarget{integertypeterm}{}
 \section{Integer Types\label{sec:IntegerTypes}}
-The \emph{\integertypeterm{}} represents mathematical integer value.
+The \emph{\integertypesterm{}} represent mathematical integer value.
 
-There are four kinds of integer types, which we explain next:
+There are four kinds of integer types, and we
+use the term \integertypeterm{} to refer to them collectively:
 \emph{unconstrained}, \emph{well-constrained},
 \emph{pending constrained}, and \emph{parameterized}.
 
 \subsection{Unconstrained Integer Types}
 The type \verb|integer| represents all integer values.
-\lrmcomment{\identi{HJBH}}
+\identi{HJBH}%
 There is no bound on the minimum and maximum integer value that can be represented.
 
 \ExampleDef{Unconstrained Integer Types}
@@ -114,7 +115,7 @@ There is no bound on the minimum and maximum integer value that can be represent
 \ASLListing{Well-typed unconstrained integer types}{typing-unconstrained}{\typingtests/TypingRule.TIntUnConstrained.asl}
 
 \subsection{Well-constrained Integer Types}
-\lrmcomment{\identr{GWCP}}
+\identr{GWCP}%
 The type \texttt{integer\{$c_1,\ldots,c_n$\}} represents the
 union of sets of integers represented by the \emph{integer constraints} $c_1,\ldots,c_n$.
 \hypertarget{def-exactconstraintterm}{}
@@ -290,7 +291,8 @@ Those are defined as follows:
   \isparameterizedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\parameterized\\
   \iswellconstrainedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\wellconstrained\\
 \end{array}
-\]\lrmcomment{This is related to \identd{ZTPP}, \identr{WJYH}, \identr{HJPN}, \identr{CZTX}, \identr{TPHR}.}
+\]
+\identd{ZTPP} \identr{WJYH} \identr{HJPN} \identr{CZTX} \identr{TPHR}
 
 \hypertarget{def-unconstrainedinteger}{}
 We use the shorthand notation $\unconstrainedinteger \triangleq \TInt(\unconstrained)$
@@ -567,7 +569,7 @@ In \listingref{typing-tstring}, all the uses of the \stringtypeterm{} are well-t
 The \emph{\booleantypeterm{}} represents the algebraic Boolean type.
 
 \subsubsection{Example}
-In \listingref{typing-tbool}, all the uses of \texttt{boolean} are well-typed.
+In \listingref{typing-tbool}, all the uses of \booleantypeterm{} are well-typed.
 \ASLListing{Well-typed Boolean types}{typing-tbool}{\typingtests/TypingRule.TBool.asl}
 
 \subsection{Syntax}
@@ -607,8 +609,52 @@ In \listingref{typing-tbool}, all the uses of \texttt{boolean} are well-typed.
 \end{mathpar}
 \CodeSubsection{\TBoolBegin}{\TBoolEnd}{../Typing.ml}
 
-\hypertarget{bitvectortypeterm}{}
 \section{Bitvector Types\label{sec:BitvectorTypes}}
+\hypertarget{bitvectortypeterm}{}
+\emph{Bitvectors} represent sequences of $0$ and $1$.
+%
+The \texttt{bits(N)} type represents a bitvector of length \texttt{N},
+where \texttt{N} may specify a fixed width or a constrained width.
+%
+The \texttt{bit} type is syntactic sugar for \texttt{bits(1)} (see \ASTRuleRef{Ty.TBits}.\texttt{BIT}).
+
+\identi{KGMC}%
+The syntax for \bitvectortypesterm{} has an optional $\Nbitfields$,
+which allows specifying \emph{\bitfieldsterm} ---
+\bitslicesterm{} of bitvectors --- to be treated as named
+fields that can be read or written.
+\chapref{Bitfields} defines \bitfieldsterm{}
+and \chapref{BitvectorSlicing} defines \bitslicesterm{}.
+
+\RequirementDef{BitvectorWidthImmutable}
+The width of a bitvector cannot be modified.
+
+\RequirementDef{BitvectorWidthBounds}
+There is no bound on the maximum bitvector width allowed, although an implementation may specify an upper
+limit.
+%The minimum bound is zero.
+It is recognized that zero-length bitvectors might not be supported in systems
+to which ASL might be translated (such as SMT solvers),
+and an implementation might need to lower bitvector
+expressions to a form where they do not exist.
+
+\RequirementDef{BitvectorWidthKind}
+The width of a \bitvectortypeterm{} can be either \staticallyevaluable{}
+or a \symbolicallyevaluable{} \constrainedinteger{}.
+
+\ExampleDef{Rotating a Bitvector}
+\listingref{bits-rotate} shows a specification with a fixed-width bitvector type
+(\verb|bits(5)| for \texttt{bv}), a constrained-width bitvector types
+(\verb|bits(N)|, \verb|bits(i)|, and \verb|bits(N-i)|),
+and related operations,
+followed by the output to the console.
+\ASLListing{Rotating a bitevector}{bits-rotate}{\definitiontests/Bitvector_rotate.asl}
+% CONSOLE_BEGIN aslref \definitiontests/Bitvector_rotate.asl
+\begin{Verbatim}[fontsize=\footnotesize, frame=single]
+bv=0x14, rotated twice=0x05
+\end{Verbatim}
+% CONSOLE_END
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nty \derives\ & \Tbit &\\
@@ -646,40 +692,62 @@ In \listingref{typing-tbool}, all the uses of \texttt{boolean} are well-typed.
 \end{mathpar}
 
 \subsection{Typing}
-\TypingRuleDef{TBits}
-\subsubsection{Example}
+\ExampleDef{Bitvector examples}
 In \listingref{typing-tbits}, all the uses of bitvector types are well-typed.
 \ASLListing{Well-typed Bitevector types}{typing-tbits}{\typingtests/TypingRule.TBits.asl}
 
+\ExampleRef{A bitvector type with bitfields} shows a \bitvectortypeterm{} with bitfields.
+
+\TypingRuleDef{TBits}
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item $\tty$ is the bit-vector type with width given by the expression
+  \item $\tty$ is the \bitvectortypeterm{} with width given by the expression
     $\ewidth$ and the bitfields given by $\bitfields$, that is, $\TBits(\ewidth, \bitfields)$;
   \item annotating the expression $\ewidth$ yields $(\twidth, \ewidthp, \seswidth)$\ProseOrTypeError;
   \item \Prosechecksymbolicallyevaluable{\seswidth};
   \item \Prosecheckconstrainedinteger{$\tenv$}{$\twidth$};
-  \item annotating the bitfields $\bitfields$ yields $(\bitfieldsp, \vsesbitfields)$\ProseOrTypeError;
-  \item \Prosestaticeval{$\tenv$}{$\ewidthp$}{$\lint(\vwidth)$};
-  \item \Prosecheckcommonbitfieldsalign{$\tenv$}{$\bitfieldsp$}{$\vwidth$}\ProseOrTypeError;
-  \item $\newty$ is the bit-vector type with width given by the expression
-    $\ewidthp$ and the bitfields given by $\bitfieldsp$, that is, $\TBits(\ewidthp, \bitfieldsp)$;
-  \item define $\vses$ as the union of $\seswidth$ and $\vsesbitfields$.
+  \OneApplies
+  \begin{itemize}
+    \item \AllApplyCase{with\_bitfields}
+    \begin{itemize}
+      \item $\bitfields$ is not empty;
+      \item annotating the bitfields $\bitfields$ yields \\
+            $(\bitfieldsp, \vsesbitfields)$\ProseOrTypeError;
+      \item \Prosestaticeval{$\tenv$}{$\ewidthp$}{$\lint(\vwidth)$};
+      \item \Prosecheckcommonbitfieldsalign{$\tenv$}{$\bitfieldsp$}{$\vwidth$}\ProseOrTypeError;
+      \item \Proseeqdef{$\newty$}{the \bitvectortypeterm{} with width given by the expression
+            $\ewidthp$ and the bitfields given by $\bitfieldsp$, that is, \\
+            $\TBits(\ewidthp, \bitfieldsp)$};
+      \item \Proseeqdef{$\vses$}{the union of $\seswidth$ and $\vsesbitfields$}.
+    \end{itemize}
+
+    \item \AllApplyCase{no\_bitfields}
+    \begin{itemize}
+      \item $\bitfields$ is not empty;
+      \item \Proseeqdef{$\newty$}{the \bitvectortypeterm{} with width given by the expression
+            $\ewidthp$ and an empty list of bitfields, that is,
+            $\TBits(\ewidthp, \emptylist)$};
+      \item \Proseeqdef{$\vses$}{$\seswidth$}.
+    \end{itemize}
+  \end{itemize}
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule{
+\inferrule[with\_bitfields]{
   \annotateexpr{\tenv, \ewidth} \typearrow (\twidth, \ewidthp, \seswidth) \OrTypeError\\\\
   \checksymbolicallyevaluable(\seswidth) \typearrow \True \OrTypeError\\\\
   \checkconstrainedinteger(\tenv, \twidth) \typearrow \True \OrTypeError\\\\
+  \commonprefixline\\\\
+  \bitfields \neq \emptylist\\\\
   {
   \begin{array}{r}
     \annotatebitfields(\tenv, \ewidthp, \bitfields) \typearrow \\
     (\bitfieldsp, \vsesbitfields) \OrTypeError
   \end{array}
   }\\
-  \staticeval(\tenv, \ewidthp) \typearrow \lint(\vwidth)\\
+  \staticeval(\tenv, \ewidthp) \typearrow \lint(\vwidth) \OrTypeError\\\\
   \checkcommonbitfieldsalign(\tenv, \bitfieldsp, \vwidth) \typearrow \True \OrTypeError\\\\
   \vses \eqdef \seswidth \cup \vsesbitfields
 }{
@@ -691,15 +759,46 @@ In \listingref{typing-tbits}, all the uses of bitvector types are well-typed.
   }
 }
 \end{mathpar}
+
+\begin{mathpar}
+\inferrule[no\_bitfields]{
+  \annotateexpr{\tenv, \ewidth} \typearrow (\twidth, \ewidthp, \seswidth) \OrTypeError\\\\
+  \checksymbolicallyevaluable(\seswidth) \typearrow \True \OrTypeError\\\\
+  \checkconstrainedinteger(\tenv, \twidth) \typearrow \True \OrTypeError\\\\
+  \commonprefixline\\\\
+  \bitfields = \emptylist
+}{
+  {
+    \begin{array}{r}
+  \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \TBits(\ewidth, \bitfields)} \typearrow \\
+  (\overname{\TBits(\ewidthp, \bitfieldsp)}{\newty}, \overname{}{\seswidth})
+    \end{array}
+  }
+}
+\end{mathpar}
 \CodeSubsection{\TBitsBegin}{\TBitsEnd}{../Typing.ml}
 
-\subsubsection{Comments}
-The width of a bitvector type $\TBits(\ewidth, \bitfields)$, given by the expression \\
-$\ewidth$,
-must be non-negative.
-
-\hypertarget{tupletypeterm}{}
 \section{Tuple Types\label{sec:TupleTypes}}
+\hypertarget{tupletypeterm}{}
+
+Types can be combined into \tupletypesterm{} whose values consist of tuples of values of those types.
+For example, the expression \verb|(TRUE, Zeros{32})| has type \verb|(boolean, bits(32))|.
+
+\ExampleDef{Well-typed Tuples}
+In \listingref{typing-ttuple}, all the uses of \tupletypesterm{} are well-typed.
+\ASLListing{Well-typed tuple types}{typing-ttuple}{\typingtests/TypingRule.TTuple.asl}
+
+\RequirementDef{TupleLength}
+A \tupletypeterm{} must contain at least two elements.
+
+\RequirementDef{TupleImmutability}
+The value and type of tuple elements cannot be modified.
+
+\RequirementDef{TupleElementAccess}
+The $k+1$ element of a tuple \verb|t| with $n>1$ elements
+can be accessed via the \texttt{t.item$k$} notation,
+as long as $0 \leq k < n$.
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nty \derives\ & \PlistZero{\Nty} &
@@ -721,19 +820,15 @@ must be non-negative.
 \end{mathpar}
 
 \subsection{Typing Tuple Types\label{sec:TypingTupleTypes}}
-\subsubsection{Example}
-In \listingref{typing-ttuple}, all the uses of tuple types are well-typed.
-\ASLListing{Well-typed tuple types}{typing-ttuple}{\typingtests/TypingRule.TTuple.asl}
-
 \TypingRuleDef{TTuple}
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item $\tty$ is the tuple type with member types $\tys$, that is, $\TTuple(\tys)$;
-  \item $\tys$ is the list $\tty_i$, for $i=1..k$;
+  \item $\tty$ is the \Prosetupletype{$\tys$}, that is, $\TTuple(\tys)$;
+  \item $\tys$ is the list $\tty_i$, for $i=1..k$ and $k>1$;
   \item annotating each type $\tty_i$ in $\tenv$, for $i=1..k$,
-  yields $(\ttyp_i, \vxs_i)$\ProseOrTypeError;
-  \item $\newty$ is the tuple type with member types $\ttyp$, for $i=1..k$;
+        yields $(\ttyp_i, \vxs_i)$\ProseOrTypeError;
+  \item $\newty$ is the \Prosetupletype{$\ttyp_i$}, for $i=1..k$;
   \item define $\vses$ as the union of all $\vxs_i$, for $i=1..k$.
 \end{itemize}
 
@@ -742,7 +837,7 @@ In \listingref{typing-ttuple}, all the uses of tuple types are well-typed.
 \inferrule{
   k \geq 2\\
   \tys \eqname \tty_{1..k}\\
-  i=1..k: \annotatetype{\False, \tenv, \tty_i} \typearrow (\ttyp_i, \vxs_i) \OrTypeError\\
+  i=1..k: \annotatetype{\False, \tenv, \tty_i} \typearrow (\ttyp_i, \vxs_i) \OrTypeError\\\\
   \vses \eqdef \bigcup_{i=1..k} \vxs_i
 }{
   \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \TTuple(\tys)} \typearrow (\overname{\TTuple(\tysp)}{\newty}, \vses)
@@ -750,17 +845,120 @@ In \listingref{typing-ttuple}, all the uses of tuple types are well-typed.
 \end{mathpar}
 \CodeSubsection{\TTupleBegin}{\TTupleEnd}{../Typing.ml}
 
-\hypertarget{arraytypeterm}{}
+\section{Enumeration Types\label{sec:EnumerationTypes}}
+\hypertarget{enumerationtypeterm}{}
+The \emph{\enumerationtypeterm} defines a list of enumeration literals,
+also referred to as \emph{labels}, that act
+as global constants that can be compared for equality and inequality and used
+as indices in enumeration-indexed arrays.
+%
+The type of an enumeration literal is the anonymous \enumerationtypeterm{}
+that defined the literal.
+\identd{YZBQ} \identr{HJYJ}
+
+\identi{PRPY}%
+Unlike many languages, there is no ordering defined for enumeration literals
+and therefore enumeration types do not support ordering comparisons such as \verb|<=|.
+
+\ExampleDef{Well-typed Enumeration Types}
+\listingref{typing-tenum} shows an example of a well-typed enumeration type declaration.
+\ASLListing{Well-typed enumeration type}{typing-tenum}{\typingtests/TypingRule.TEnumDecl.asl}
+
+\identr{DWSP} \identr{QMWT} \identi{MZXL}%
+\RequirementDef{LabelNamespace}
+Enumeration literals exist in the same namespace as all other declared objects,
+including storage elements and subprograms, so no other declared object
+may have the same name in the same scope.
+In particular, this means that an enumeration literal can be declared in
+at most one \enumerationtypeterm{} declaration.
+
+\RequirementDef{AnonymousEnumerations}
+Enumeration types are only allowed in declarations.
+
+\subsection{Syntax}
+\begin{flalign*}
+\Ntydecl \derives\ & \Tenumeration \parsesep \Tlbrace \parsesep \TClistOne{\Tidentifier} \parsesep \Trbrace &
+\end{flalign*}
+
+\subsection{Abstract Syntax}
+\begin{flalign*}
+\ty \derives\ & \TEnum(\overtext{\identifier^{*}}{labels}) &
+\end{flalign*}
+
+\ASTRuleDef{TyDecl.TEnum}
+\begin{mathpar}
+\inferrule{
+  \buildtclist[\buildidentity](\vids) \astarrow \vidasts
+}{
+  {
+    \begin{array}{r}
+  \buildtydecl(\Ntydecl(\Tenumeration, \Tlbrace, \namednode{\vids}{\TClistOne{\Tidentifier}}, \Trbrace)) \astarrow\\
+  \overname{\TEnum(\vidasts)}{\vastnode}
+\end{array}
+  }
+}
+\end{mathpar}
+
+\subsection{Typing Enumeration Types\label{sec:TypingEnumerationTypes}}
+\ExampleDef{Ill-typed enumeration type declarations}
+\listingref{typing-tenum-bad} shows examples of ill-typed enumeration type declarations.
+\ASLListing{Ill-typed enumeration types}{typing-tenum-bad}{\typingtests/TypingRule.TEnumDecl.bad.asl}
+
+\TypingRuleDef{TEnumDecl}
+\ProseParagraph
+\AllApply
+\begin{itemize}
+  \item $\tty$ is the \enumerationtypeterm{} with enumeration literals
+        $\vli$, that is, $\TEnum(\vli)$;
+  \item $\decl$ is $\True$, indicating that $\tty$ should be considered in the context of a declaration;
+  \item determining that $\vli$ does not contain duplicates yields $\True$\ProseOrTypeError;
+  \item determining that none of the labels in $\vli$ is declared in the global environment
+  yields $\True$\ProseOrTypeError;
+  \item $\newty$ is the \enumerationtypeterm{} $\tty$;
+  \item define $\vses$ as the empty set.
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule{
+  \checknoduplicates(\vli) \typearrow \True \OrTypeError\\\\
+  \vl \in \vli: \checkvarnotingenv{G^\tenv, \vl} \typearrow \True \OrTypeError
+}{
+  \annotatetype{\True, \tenv, \TEnum(\vli)} \typearrow (\overname{\TEnum(\vli)}{\newty}, \overname{\emptyset}{\vses})
+}
+\end{mathpar}
+\CodeSubsection{\TEnumDeclBegin}{\TEnumDeclEnd}{../Typing.ml}
+
 \section{Array Types\label{sec:ArrayTypes}}
+\hypertarget{arraytypeterm}{}
+\identr{DFXJ}%
+Arrays are sequences of values of a single given type.
+The syntax \verb|array [[expr]] of ty| declares a single-dimensional array of type \texttt{ty}
+with an index type derived from the expression \texttt{expr}.
+%
+\identr{YHNV}%
 ASL offers two kinds of arrays:
+\hypertarget{intarraytypeterm}{}
+\hypertarget{enumarraytypeterm}{}
 \begin{description}
-  \item[Integer-indexed arrays] representing a consecutive list of elements at positions $0$ to the size
-      specified for the array. The array elements can be accessed via an \texttt{integer}
-      type that specifies the $0$-based position of the element to read/update.
-  \item[Enumeration-indexed arrays] representing a dictionary-like data type where the keys are defined
-      by a given enumeration type. The array elements can be accessed via values of the \texttt{enumeration}
-      type specified for the array type.
+  \item[\Intarraytypeterm] represents a consecutive list of elements at positions $0$ to the size
+      specified for the array. The array elements can be accessed via an \integertypeterm{}
+      that specifies the $0$-based position of the element to read/update.
+  \item[\Enumarraytypeterm] represents a dictionary-like data type where the keys are defined
+      by a given \enumerationtypeterm{}. The array elements can be accessed via values of the
+      \enumerationtypeterm{} specified for the array type.
 \end{description}
+
+\RequirementDef{ArrayLengthImmutable}
+The length of an \intarraytypeterm{} cannot be modified.
+
+\RequirementDef{ArrayLengthExpression}
+The length expression of an \intarraytypeterm{} must be a \symbolicallyevaluable{}
+expression whose \underlyingtype{} is an \integertypeterm{} .
+
+\ExampleDef{Well-typed Array Types}
+In \listingref{typing-tarray}, all the uses of array types are well-typed.
+\ASLListing{Well-typed array types}{typing-tarray}{\typingtests/TypingRule.TArray.asl}
 
 \subsection{Syntax}
 \begin{flalign*}
@@ -785,9 +983,11 @@ ASL offers two kinds of arrays:
 }
 \end{mathpar}
 \subsection{Typing Array Types\label{sec:TypingArrayTypes}}
-\subsubsection{Example}
-In \listingref{typing-tarray}, all the uses of array types are well-typed.
-\ASLListing{Well-typed array types}{typing-tarray}{\typingtests/TypingRule.TArray.asl}
+\ExampleDef{Ill-typed Array Types}
+In \listingref{typing-tarray-bad}, the array type for \verb|illegal_array|
+is ill-typed, since the expression \verb|non_symbolically_evaluable|
+is not \symbolicallyevaluable{}.
+\ASLListing{Ill-typed array types}{typing-tarray-bad}{\typingtests/TypingRule.TArray.bad.asl}
 
 \TypingRuleDef{TArray}
 \ProseParagraph
@@ -802,7 +1002,7 @@ In \listingref{typing-tarray}, all the uses of array types are well-typed.
       \item the array index is $\ve$ and determining whether $\ve$ corresponds to an enumeration in $\tenv$
       via $\getvariableenum$ yields the enumeration variable
       name $\vs$ of size $\vi$, that is, $\langle \vs, \vi \rangle$\ProseOrTypeError;
-      \item $\newty$ is the array type indexed by an enumeration type
+      \item $\newty$ is the array type indexed by an \enumerationtypeterm{}
       named $\vs$ of length $\vi$ and of elements of type $\vtp$, that is, $\TArray(\ArrayLengthEnum(\vs, \vi), \vtp)$;
       \item define $\vses$ as $\vsest$.
     \end{itemize}
@@ -821,12 +1021,13 @@ In \listingref{typing-tarray}, all the uses of array types are well-typed.
     \end{itemize}
   \end{itemize}
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[expr\_is\_enum]{
   \annotatetype{\False, \tenv, \vt} \typearrow (\vtp, \vsest) \OrTypeError\\\\
   \commonprefixline\\\\
-  \getvariableenum(\tenv, \ve) \typearrow \langle \vs, \vlabels \rangle\OrTypeError
+  \getvariableenum(\tenv, \ve) \typearrow \langle \vs, \vlabels \rangle
 }{
   \annotatetype{\overname{\Ignore}{\vdecl}, \tenv, \overname{\AbbrevTArrayLengthExpr{\ve}{\vt}}{\tty}} \typearrow
   (\overname{\AbbrevTArrayLengthEnum{\ve}{\vlabels}{\vtp}}{\newty}, \overname{\emptyset}{\vsest})
@@ -837,7 +1038,7 @@ In \listingref{typing-tarray}, all the uses of array types are well-typed.
 \inferrule[expr\_not\_enum]{
   \annotatetype{\False, \tenv, \vt} \typearrow (\vtp, \vsest) \OrTypeError\\\\
   \commonprefixline\\\\
-  \getvariableenum(\tenv, \ve) \typearrow \None \OrTypeError\\\\
+  \getvariableenum(\tenv, \ve) \typearrow \None\\
   \annotatesymbolicinteger(\tenv, \ve) \typearrow (\vep, \vsesindex) \OrTypeError\\\\
   \vses \eqdef \vsest \cup \vsesindex
 }{
@@ -854,10 +1055,15 @@ The function
 \getvariableenum(\overname{\staticenvs}{\tenv} \aslsep \overname{\expr}{\ve}) \aslto
 \langle (\overname{\identifier}{\vx}, \overname{\identifier^+}{\vlabels})\rangle
 \]
-tests whether the expression $\ve$ represents a variable of an enumeration type.
+tests whether the expression $\ve$ represents a variable of an \enumerationtypeterm{}.
 If so, the result is $\vx$ --- the name of the variable and the list of labels $\vlabels$,
-declared for the enumeration type.
+declared for the \enumerationtypeterm{}.
 Otherwise, the result is $\None$.
+
+\ExampleDef{Retriving Enumeration Labels from Variable Expressions}
+\listingref{typing-getvariableenum} shows examples of retrieving
+enumeration labels from variable expressions.
+\ASLListing{Retriving enumeration labels from expressions}{typing-getvariableenum}{\typingtests/TypingRule.GetVariableEnum.asl}
 
 \ProseParagraph
 \OneApplies
@@ -879,7 +1085,7 @@ Otherwise, the result is $\None$.
   \begin{itemize}
     \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
     \item $\vx$ is associated with a type $\vt$ in the global environment of $\tenv$;
-    \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields an enumeration type with labels $\vlabels$\ProseOrTypeError;
+    \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields an \enumerationtypeterm{} with labels $\vlabels$;
     \item the result is the pair consisting of $\vx$ and $\vlabels$.
   \end{itemize}
 
@@ -887,7 +1093,7 @@ Otherwise, the result is $\None$.
   \begin{itemize}
     \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
     \item $\vx$ is associated with a type $\vt$ in the global environment of $\tenv$;
-    \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields a type that is not an enumeration type;
+    \item obtaining the \underlyingtype\ of $\vt$ in $\tenv$ yields a type that is not an \enumerationtypeterm{};
     \item the result is $\None$.
   \end{itemize}
 \end{itemize}
@@ -912,7 +1118,7 @@ Otherwise, the result is $\None$.
 \begin{mathpar}
 \inferrule[declared\_enum]{
   G^\tenv.\declaredtypes(\vx) = (\vt, \Ignore)\\
-  \makeanonymous(\tenv, \vt) \typearrow \TEnum(\vlabels) \OrTypeError
+  \makeanonymous(\tenv, \vt) \typearrow \TEnum(\vlabels)
 }{
   \getvariableenum(\tenv, \overname{\EVar(\vx)}{\ve}) \typearrow \langle(\vx, \vlabels)\rangle
 }
@@ -938,8 +1144,19 @@ The function
 \end{array}
 \]
 annotates the expression $\ve$ in the static environment $\tenv$ and checks that it is \symbolicallyevaluable,
-yielding the resulting type in $\vt$, the annotated expression in $\vep$ and the \sideeffectsetterm\ in $\vses$.
+yielding the type in $\vt$, the annotated expression $\vep$ and the \sideeffectsetterm{} $\vses$.
 \ProseOtherwiseTypeError
+
+\identi{PKXK} \identd{YYDW}%
+\RequirementDef{SymbolicallyEvaluable}
+An expression is \symbolicallyevaluable{} if its evaluation only involves
+the use of immutable values.
+
+\ExampleDef{Annotating Symbolically Evaluable Expressions}
+\listingref{typing-annotatesymbolicallyevaluableexpr} shows examples of
+expressions and classifies them as either \symbolicallyevaluable{} or not.
+\ASLListing{Annotating symbolically evaluable Expressions}{typing-annotatesymbolicallyevaluableexpr}
+{\typingtests/TypingRule.AnnotateSymbolicallyEvaluableExpr.asl}
 
 \ProseParagraph
 \AllApply
@@ -967,23 +1184,21 @@ The function
   (\overname{\expr}{\vepp} \times \overname{\TSideEffectSet}{\vses}) \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 annotates a \symbolicallyevaluable\ integer expression $\ve$ in the static environment $\tenv$
-and returns the annotated expression $\vepp$ and \sideeffectsetterm\ $\vses$.
+and returns the annotated expression $\vepp$ as a \normalizedexpressionterm{} and \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
 \AllApply
 \begin{itemize}
   \item \Proseannotatesymbolicallyevaluableexpr{$\tenv$}{$\ve$}{$(\vt, \vep, \vses)$\ProseOrTypeError};
-  \item determining whether $\vt$ has the structure of an integer yields $\True$\ProseOrTypeError;
-  \item determining whether $\vep$ is \symbolicallyevaluable\ in $\tenv$ yields $\True$\ProseOrTypeError;
+  \item determining whether the \underlyingtype{} of $\vt$ is an \integertypeterm{} yields $\True$\ProseOrTypeError;
   \item applying $\normalize$ to $\vep$ in $\tenv$ yields $\vepp$.
 \end{itemize}
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \annotatesymbolicallyevaluableexpr(\tenv, \ve) \typearrow (\vt, \vep, \vses) \OrTypeError\\\\
-  \checkstructureinteger(\tenv, \vt) \typearrow \True \OrTypeError\\\\
-  \checksymbolicallyevaluable(\tenv, \vep) \typearrow \True \OrTypeError\\\\
+  \checkunderlyinginteger(\tenv, \vt) \typearrow \True \OrTypeError\\\\
   \normalize(\tenv, \vep) \typearrow \vepp
 }{
   \annotatesymbolicinteger(\tenv, \ve) \typearrow (\vepp, \vses)
@@ -991,11 +1206,11 @@ and returns the annotated expression $\vepp$ and \sideeffectsetterm\ $\vses$.
 \end{mathpar}
 \CodeSubsection{\AnnotateSymbolicIntegerBegin}{\AnnotateSymbolicIntegerEnd}{../Typing.ml}
 
-\hypertarget{def-checkstructureinteger}{}
-\TypingRuleDef{CheckStructureInteger}
+\hypertarget{def-checkunderlyinginteger}{}
+\TypingRuleDef{CheckUnderlyingInteger}
 The function
 \[
-  \checkstructureinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt}) \aslto
+  \checkunderlyinginteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt}) \aslto
   \{\True\} \cup \TTypeError
 \]
 returns $\True$ is $\vt$ is has the \structure\ an integer type and a type error otherwise.
@@ -1018,86 +1233,40 @@ returns $\True$ is $\vt$ is has the \structure\ an integer type and a type error
   \end{itemize}
 \end{itemize}
 
-\CodeSubsection{\CheckStructureIntegerBegin}{\CheckStructureIntegerEnd}{../Typing.ml}
-
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[okay]{
   \tstruct(\vt) \typearrow \vtp \OrTypeError\\\\
   \astlabel(\vtp) = \TInt
+}{
+  \checkunderlyinginteger(\tenv, \vt) \typearrow \True
 }
-{
-  \checkstructureinteger(\tenv, \vt) \typearrow \True
-}
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[error]{
   \tstruct(\vt) \typearrow \vtp\\
   \astlabel(\vtp) \neq \TInt
-}
-{
-  \checkstructureinteger(\tenv, \vt) \typearrow \TypeErrorVal{\UnexpectedType}
-}
-\end{mathpar}
-
-\hypertarget{enumerationtypeterm}{}
-\section{Enumeration Types\label{sec:EnumerationTypes}}
-\subsection{Syntax}
-\begin{flalign*}
-\Ntydecl \derives\ & \Tenumeration \parsesep \Tlbrace \parsesep \TClistOne{\Tidentifier} \parsesep \Trbrace &
-\end{flalign*}
-
-\subsection{Abstract Syntax}
-\begin{flalign*}
-\ty \derives\ & \TEnum(\overtext{\identifier^{*}}{labels}) &
-\end{flalign*}
-
-\ASTRuleDef{TyDecl.TEnum}
-\begin{mathpar}
-\inferrule{
-  \buildtclist[\buildidentity](\vids) \astarrow \vidasts
 }{
-  {
-    \begin{array}{r}
-  \buildtydecl(\Ntydecl(\Tenumeration, \Tlbrace, \namednode{\vids}{\TClistOne{\Tidentifier}}, \Trbrace)) \astarrow\\
-  \overname{\TEnum(\vidasts)}{\vastnode}
-\end{array}
-  }
+  \checkunderlyinginteger(\tenv, \vt) \typearrow \TypeErrorVal{\UnexpectedType}
 }
 \end{mathpar}
+\CodeSubsection{\CheckUnderlyingIntegerBegin}{\CheckUnderlyingIntegerEnd}{../Typing.ml}
 
-\subsection{Typing Enumeration Types\label{sec:TypingEnumerationTypes}}
-\TypingRuleDef{TEnumDecl}
-
-\ProseParagraph
-\AllApply
-\begin{itemize}
-  \item $\tty$ is the enumeration type with enumeration literals
-    $\vli$, that is, $\TEnum(\vli)$;
-  \item $\decl$ is $\True$, indicating that $\tty$ should be considered in the context of a declaration;
-  \item determining that $\vli$ does not contain duplicates yields $\True$\ProseOrTypeError;
-  \item determining that none of the labels in $\vli$ is declared in the global environment
-  yields $\True$\ProseOrTypeError;
-  \item $\newty$ is the enumeration type $\tty$;
-  \item define $\vses$ as the empty set.
-\end{itemize}
-\FormallyParagraph
-\begin{mathpar}
-\inferrule{
-  \checknoduplicates(\vli) \typearrow \True \OrTypeError\\\\
-  \vl \in \vli: \checkvarnotingenv{G^\tenv, \vl} \typearrow \True \OrTypeError
-}{
-  \annotatetype{\True, \tenv, \TEnum(\vli)} \typearrow (\overname{\TEnum(\vli)}{\newty}, \overname{\emptyset}{\vses})
-}
-\CodeSubsection{\TEnumDeclBegin}{\TEnumDeclEnd}{../Typing.ml}
-
-\end{mathpar}
-\lrmcomment{This is related to \identd{YZBQ}, \identr{DWSP}, \identi{MZXL}.}
-\subsubsection{Example}
-\listingref{typing-tenum} shows an example of a well-typed enumeration type declaration.
-\ASLListing{Well-typed enumeration type}{typing-tenum}{\typingtests/TypingRule.TEnumDecl.asl}
-
-\hypertarget{recordtypeterm}{}
 \section{Record Types\label{sec:RecordTypes}}
+\hypertarget{recordtypeterm}{}
+\identd{WGQS}
+A record is a \structuredtype{} consisting of a list of field identifiers which denote individual storage elements.
+\identr{DXWN}
+A record type is described by specifying for each field identifier its type.
+
+\identr{WFMF}
+The syntax \verb|record| (with no field list) is syntactic sugar for \verb|record {}|.
+
+\ExampleDef{Well-typed Record Types}
+In \listingref{typing-trecord}, all the uses of record or exception types are well-typed.
+\ASLListing{Well-typed structured types}{typing-trecord}{\typingtests/TypingRule.TRecordDecl.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Ntydecl \derives\ & \Trecord \parsesep \Nfieldsopt &
@@ -1150,12 +1319,12 @@ returns $\True$ is $\vt$ is has the \structure\ an integer type and a type error
 \end{mathpar}
 \CodeSubsection{\TStructuredDeclBegin}{\TStructuredDeclEnd}{../Typing.ml}
 
-\subsubsection{Example}
-In \listingref{typing-trecord}, all the uses of record or exception types are well-typed.
-\ASLListing{Well-typed structured types}{typing-trecord}{\typingtests/TypingRule.TRecordExceptionDecl.asl}
-
-\hypertarget{exceptiontypeterm}{}
 \section{Exception Types\label{sec:ExceptionTypes}}
+\hypertarget{exceptiontypeterm}{}
+\ExampleDef{Well-typed Exception Types}
+In \listingref{typing-texception}, all the uses of record or exception types are well-typed.
+\ASLListing{Well-typed structured types}{typing-texception}{\typingtests/TypingRule.TExceptionDecl.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Ntydecl \derives\ & \Texception \parsesep \Nfieldsopt &
@@ -1225,7 +1394,7 @@ In \listingref{typing-tnamed}, all the uses of \texttt{MyType} are well-typed.
 \ASLListing{Well-typed named types}{typing-tnamed}{\typingtests/TypingRule.TNamed.asl}
 
 \section{Declared Types\label{sec:DeclaredTypes}}
-A declared type can be an enumeration type, a record type, an exception type, or an \anonymoustype.
+A declared type can be an \enumerationtypeterm{}, a record type, an exception type, or an \anonymoustype.
 \subsection{Syntax}
 \begin{flalign*}
 \Ntydecl \derives\ & \Nty &
@@ -1241,7 +1410,7 @@ A declared type can be an enumeration type, a record type, an exception type, or
 \end{mathpar}
 
 \subsection{Typing Declared Types}
-\lrmcomment{\identr{RGRVJ}}
+\identr{RGRVJ}%
 \RequirementDef{RestrictionsOnAnonymousTypes}
 A declared type for an enumeration, a record type, or an exception type
 are only permitted in named type declarations. This is enforced by \TypingRuleRef{TNonDecl}.
@@ -1256,7 +1425,7 @@ In \listingref{typing-trecorderror}, the use of a record type outside of a decla
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item $\tty$ is a \structuredtype\ or an enumeration type;
+  \item $\tty$ is a \structuredtype\ or an \enumerationtypeterm{};
   \item $\decl$ is $\False$, indicating that $\tty$ should be considered to be outside the context of a declaration
   of $\tty$;
   \item a type error is returned, indicating that the use of anonymous form of enumerations, record,

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -405,6 +405,12 @@ annotates an integer constraint $\vc$ in the static environment $\tenv$ yielding
 integer constraint $\newc$ and \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
+\listingref{annotate-constraint} shows examples of \wellconstrainedintegertypes{}
+and the resulting annotated constraints in comments.
+The annotated constraints inline the constant \texttt{N} and the right-hand-side
+expressions of \texttt{let} storage elements.
+\ASLListing{Annotated constraints}{annotate-constraint}{\typingtests/TypingRule.AnnotateConstraint.asl}
+
 \ProseParagraph
 One of the following applies:
 \begin{itemize}

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -98,7 +98,7 @@ which is defined in \secref{DomainOfValuesForTypes}.
 
 \hypertarget{integertypeterm}{}
 \section{Integer Types\label{sec:IntegerTypes}}
-The \texttt{integer} type represents mathematical integer values.
+The \texttt{integer} type represents mathematical integer value.
 
 There are four kinds of integer types, which we explain next:
 \emph{unconstrained}, \emph{well-constrained},
@@ -411,6 +411,14 @@ The annotated constraints inline the constant \texttt{N} and the right-hand-side
 expressions of \texttt{let} storage elements.
 \ASLListing{Annotated constraints}{annotate-constraint}{\typingtests/TypingRule.AnnotateConstraint.asl}
 
+\RequirementDef{ConstraintSymbolicallyConstrained}
+The expressions appearing in integer constraints must be both
+\symbolicallyevaluable{} and \constrainedinteger{} types.
+%
+In \listingref{annotate-constraint-unconstrained}, the constraint
+\verb|x..x+1| is ill-typed, since the type of \texttt{x} is not constrained.
+\ASLListing{Ill-typed constraint}{annotate-constraint-unconstrained}{\typingtests/TypingRule.AnnotateConstraint.bad.asl}
+
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
@@ -451,6 +459,12 @@ One of the following applies:
 
 \hypertarget{realtypeterm}{}
 \section{The Real Type\label{sec:RealType}}
+The \realtypeterm{} represents mathematical rational number values.
+There is no bound on the minimum and maximum rational value that can be represented,
+and there is no bound on their precision.
+%
+There is no mechanism in the language to generate an irrational value of \realtypeterm.
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nty \derives\ & \Treal &

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -9,7 +9,7 @@ how it is represented in the syntax and AST, and how it is typechecked:
 \begin{itemize}
   \item Integer types (see \secref{IntegerTypes})
   \item The \realtypeterm{} (see \secref{RealType})
-  \item The string type (see \secref{StringType})
+  \item The \stringtypeterm{} (see \secref{StringType})
   \item The Boolean type (see \secref{BooleanType})
   \item Bitvector types (see \secref{BitvectorTypes})
   \item Tuple types (see \secref{TupleTypes})
@@ -98,7 +98,7 @@ which is defined in \secref{DomainOfValuesForTypes}.
 
 \hypertarget{integertypeterm}{}
 \section{Integer Types\label{sec:IntegerTypes}}
-The \texttt{integer} type represents mathematical integer value.
+The \emph{\integertypeterm{}} represents mathematical integer value.
 
 There are four kinds of integer types, which we explain next:
 \emph{unconstrained}, \emph{well-constrained},
@@ -459,7 +459,7 @@ One of the following applies:
 
 \hypertarget{realtypeterm}{}
 \section{The Real Type\label{sec:RealType}}
-The \realtypeterm{} represents mathematical rational number values.
+The \emph{\realtypeterm{}} represents mathematical rational number values.
 There is no bound on the minimum and maximum rational value that can be represented,
 and there is no bound on their precision.
 %
@@ -471,7 +471,7 @@ using the \stdlibfunc{Real}.
 Conversions from a \realtypeterm{} value an \integertypeterm{} value to are performed
 using the \stdlibfunc{RoundDown} or \stdlibfunc{RoundUp}.
 
-\subsubsection{Example}
+\ExampleDef{Well-typed Real Types}
 In \listingref{typing-treal}, all the uses of the \realtypeterm{} are well-typed.
 \ASLListing{Well-typed real types}{typing-treal}{\typingtests/TypingRule.TReal.asl}
 
@@ -498,8 +498,8 @@ In \listingref{typing-treal}, all the uses of the \realtypeterm{} are well-typed
 \ProseParagraph
 All of the following apply:
 \begin{itemize}
-  \item $\tty$ is the \realtypeterm{}.
-  \item $\newty$ is the \realtypeterm{};
+  \item $\tty$ is the \realtypeterm{}, $\TReal$.
+  \item $\newty$ is the \realtypeterm{}, $\TReal$;
   \item define $\vses$ as the empty set.
 \end{itemize}
 
@@ -514,6 +514,17 @@ All of the following apply:
 
 \hypertarget{stringtypeterm}{}
 \section{The String Type\label{sec:StringType}}
+The \emph{\stringtypeterm{}} represents strings of characters.
+
+Strings play relatively little role in specifications and the only operations
+on strings are equality and inequality tests.
+String are useful in \printstatementsterm{} for debugging and diagnostic purposes
+on runtimes that support printing.
+
+\ExampleDef{Well-typed String Types}
+In \listingref{typing-tstring}, all the uses of the \stringtypeterm{} are well-typed.
+\ASLListing{Well-typed string types}{typing-tstring}{\typingtests/TypingRule.TString.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nty \derives\ & \Tstring &
@@ -534,16 +545,12 @@ All of the following apply:
 
 \subsection{Typing the String Type\label{sec:TypingStringType}}
 \TypingRuleDef{TString}
-\subsubsection{Example}
-In \listingref{typing-tstring}, all the uses of \texttt{string} are well-typed.
-\ASLListing{Well-typed string types}{typing-tstring}{\typingtests/TypingRule.TString.asl}
-
 \ProseParagraph
 All of the following apply:
 \begin{itemize}
-  \item $\tty$ is the string type \TString.
-  \item $\newty$ is the string type \TString.
-  \item $\vses$ is the empty set.
+  \item $\tty$ is the \stringtypeterm{}, $\TString$.
+  \item $\newty$ is the \stringtypeterm{}, $\TString$.
+  \item \Proseeqdef{$\vses$}{the empty set}.
 \end{itemize}
 
 \FormallyParagraph
@@ -557,6 +564,12 @@ All of the following apply:
 
 \hypertarget{booleantypeterm}{}
 \section{The Boolean Type\label{sec:BooleanType}}
+The \emph{\booleantypeterm{}} represents the algebraic Boolean type.
+
+\subsubsection{Example}
+In \listingref{typing-tbool}, all the uses of \texttt{boolean} are well-typed.
+\ASLListing{Well-typed Boolean types}{typing-tbool}{\typingtests/TypingRule.TBool.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nty \derives\ & \Tboolean &
@@ -577,10 +590,6 @@ All of the following apply:
 
 \subsection{Typing the Boolean Type\label{sec:TypingBooleanType}}
 \TypingRuleDef{TBool}
-\subsubsection{Example}
-In \listingref{typing-tbool}, all the uses of \texttt{boolean} are well-typed.
-\ASLListing{Well-typed Boolean types}{typing-tbool}{\typingtests/TypingRule.TBool.asl}
-
 \ProseParagraph
 All of the following apply:
 \begin{itemize}

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -471,7 +471,7 @@ Conversions from an \integertypeterm{} value to a \realtypeterm{} value are perf
 using the \stdlibfunc{Real}.
 %
 Conversions from a \realtypeterm{} value an \integertypeterm{} value to are performed
-using the \stdlibfunc{RoundDown} or \stdlibfunc{RoundUp}.
+using the \stdlibfunc{RoundDown}, \stdlibfunc{RoundUp}. and \stdlibfunc{RoundTowardsZero}.
 
 \ExampleDef{Well-typed Real Types}
 In \listingref{typing-treal}, all the uses of the \realtypeterm{} are well-typed.
@@ -520,7 +520,7 @@ The \emph{\stringtypeterm{}} represents strings of characters.
 
 Strings play relatively little role in specifications and the only operations
 on strings are equality and inequality tests.
-String are useful in \printstatementsterm{} for debugging and diagnostic purposes
+Strings are useful in \printstatementsterm{} for debugging and diagnostic purposes
 on runtimes that support printing.
 
 \ExampleDef{Well-typed String Types}
@@ -566,7 +566,7 @@ In \listingref{typing-tstring}, all the uses of the \stringtypeterm{} are well-t
 
 \section{The Boolean Type\label{sec:BooleanType}}
 \hypertarget{booleantypeterm}{}
-The \emph{\booleantypeterm{}} represents the algebraic Boolean type.
+The \emph{\booleantypeterm{}} represents Booleans.
 
 \ExampleDef{Boolean Type}
 In \listingref{typing-tbool}, all the uses of \booleantypeterm{} are well-typed.
@@ -612,7 +612,7 @@ See \ExampleRef{Boolean Type}.
 
 \section{Bitvector Types\label{sec:BitvectorTypes}}
 \hypertarget{bitvectortypeterm}{}
-\emph{Bitvectors} represent sequences of $0$ and $1$.
+\emph{Bitvectors} represent sequences of $0$ and $1$ bits.
 %
 The \texttt{bits(N)} type represents a bitvector of length \texttt{N},
 where \texttt{N} may specify a fixed width or a constrained width.
@@ -637,16 +637,16 @@ limit.
 It is recognized that zero-length bitvectors might not be supported in systems
 to which ASL might be translated (such as SMT solvers),
 and an implementation might need to lower bitvector
-expressions to a form where they do not exist.
+expressions to a form where zero-length bitvectors do not exist.
 
 \RequirementDef{BitvectorWidthKind}
 The width of a \bitvectortypeterm{} can be either \staticallyevaluable{}
-or a \symbolicallyevaluable{} \constrainedinteger{}.
+or \emph{constrained}. That is, a \symbolicallyevaluable{} \constrainedinteger{}.
 
 \ExampleDef{Rotating a Bitvector}
-\listingref{bits-rotate} shows a specification with a fixed-width bitvector type
-(\verb|bits(5)| for \texttt{bv}), a constrained-width bitvector types
-(\verb|bits(N)|, \verb|bits(i)|, and \verb|bits(N-i)|),
+\listingref{bits-rotate} shows a specification where the width of the bitvector type
+\texttt{bv} is a literal (\verb|bits(5)|), and bitvector types where the width is
+constrained (\verb|bits(N)|, \verb|bits(i)|, and \verb|bits(N-i)|),
 and related operations,
 followed by the output to the console.
 \ASLListing{Rotating a bitevector}{bits-rotate}{\definitiontests/Bitvector_rotate.asl}
@@ -708,7 +708,7 @@ In \listingref{typing-tbits}, all the uses of bitvector types are well-typed.
   \item annotating the expression $\ewidth$ yields $(\twidth, \ewidthp, \seswidth)$\ProseOrTypeError;
   \item \Prosechecksymbolicallyevaluable{\seswidth};
   \item \Prosecheckconstrainedinteger{$\tenv$}{$\twidth$};
-  \OneApplies
+  \item \OneApplies
   \begin{itemize}
     \item \AllApplyCase{with\_bitfields}
     \begin{itemize}
@@ -725,7 +725,7 @@ In \listingref{typing-tbits}, all the uses of bitvector types are well-typed.
 
     \item \AllApplyCase{no\_bitfields}
     \begin{itemize}
-      \item $\bitfields$ is not empty;
+      \item $\bitfields$ is empty;
       \item \Proseeqdef{$\newty$}{the \bitvectortypeterm{} with width given by the expression
             $\ewidthp$ and an empty list of bitfields, that is,
             $\TBits(\ewidthp, \emptylist)$};
@@ -1061,10 +1061,10 @@ If so, the result is $\vx$ --- the name of the variable and the list of labels $
 declared for the \enumerationtypeterm{}.
 Otherwise, the result is $\None$.
 
-\ExampleDef{Retriving Enumeration Labels from Variable Expressions}
+\ExampleDef{Retrieving Enumeration Labels from Variable Expressions}
 \listingref{typing-getvariableenum} shows examples of retrieving
 enumeration labels from variable expressions.
-\ASLListing{Retriving enumeration labels from expressions}{typing-getvariableenum}{\typingtests/TypingRule.GetVariableEnum.asl}
+\ASLListing{Retrieving enumeration labels from expressions}{typing-getvariableenum}{\typingtests/TypingRule.GetVariableEnum.asl}
 
 \ProseParagraph
 \OneApplies
@@ -1256,12 +1256,12 @@ returns $\True$ is $\vt$ is has the \structure\ an integer type and a type error
 
 \section{Record Types\label{sec:RecordTypes}}
 \hypertarget{recordtypeterm}{}
-\identd{WGQS}
+\identd{WGQS}%
 A record is a \structuredtype{} consisting of a list of field identifiers which denote individual storage elements.
-\identr{DXWN}
+\identr{DXWN}%
 A record type is described by specifying for each field identifier its type.
 
-\identr{WFMF}
+\identr{WFMF}%
 The syntax \verb|record| (with no field list) is syntactic sugar for \verb|record {}|.
 
 \ExampleDef{Well-typed Record Types}

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -2,8 +2,10 @@
 
 Types describe the allowed values of variables, constants, function arguments, etc.
 \lrmcomment{\identi{BYVL}}
-This chapter first defines for each type how it is represented by the ASL syntax,
-by the abstract syntax, and how it is typechecked:
+
+This chapter first describes how types are represented formally (see \secref{FormalRepresentationofTypes}).
+Next, we introduce each type available in ASL and define
+how it is represented in the syntax and AST, and how it is typechecked:
 \begin{itemize}
   \item Integer types (see \secref{IntegerTypes})
   \item The real type (see \secref{RealType})
@@ -18,18 +20,45 @@ by the abstract syntax, and how it is typechecked:
   \item Named types (see \secref{NamedTypes})
 \end{itemize}
 
+The chapter then defines the following aspects of types:
+\begin{itemize}
+\item \secref{DeclaredTypes} defines \emph{declared types} and restrictions over them;
+\item \secref{DomainOfValuesForTypes} defines how values are associated with each type;
+\item \secref{BasicTypeAttributes} assigns basic properties to types, which are useful
+in classifying them;
+\item \secref{RelationsOnTypes} defines relations on types that are needed to typecheck
+expressions and statements; and
+\item \secref{BaseValues} defines how to produce an expression to initialize storage
+      elements of a given type (for which no initializing expression is supplied).
+\end{itemize}
+
+\section{Formal Representation of Types\label{sec:FormalRepresentationofTypes}}
 \Anonymoustypes\ are grammatically derived from the non-terminal $\Nty$
 and types that must be declared and named are grammatically derived from the non-terminal $\Ntydecl$.
-All types are represented as ASTs derived from the AST non-terminal $\ty$.
+The type system represents types by their AST, which is derived from the non-terminal $\ty$.
 
+\subsection{Abstract Syntax}
 \hypertarget{build-ty}{}
 The function
 \[
   \buildty(\overname{\parsenode{\Nty}}{\vparsednode}) \;\aslto\; \overname{\ty}{\vastnode}
   \cup \overname{\TBuildError}{\BuildErrorConfig}
 \]
-transforms an anonymous type parse node $\vparsednode$ into a type AST node $\vastnode$.
+transforms an anonymous type parse node $\vparsednode$ into the corresponding AST node $\vastnode$.
 \ProseOtherwiseBuildError
+
+We define $\buildty$ per type in the following sections.
+
+\hypertarget{build-tydecl}{}
+The function
+\[
+  \buildtydecl(\overname{\parsenode{\Ntydecl}}{\vparsednode}) \;\aslto\; \overname{\ty}{\vastnode}
+  \cup \overname{\TBuildError}{\BuildErrorConfig}
+\]
+transforms a \namedtype\ parse node $\vparsednode$ into an AST node $\vastnode$.
+\ProseOtherwiseBuildError
+
+We define $\buildtydecl$ per the corresponding type in the following sections.
 
 \hypertarget{build-as-ty}{}
 The function
@@ -41,7 +70,6 @@ transforms a type annotation parse node $\vparsednode$ into a type AST node $\va
 \ProseOtherwiseBuildError
 
 Formally:
-
 \begin{mathpar}
 \inferrule{
   \buildty(\vt) \astarrow \astversion{\vt}
@@ -50,53 +78,82 @@ Formally:
 }
 \end{mathpar}
 
-\hypertarget{build-tydecl}{}
-The function
-\[
-  \buildtydecl(\overname{\parsenode{\Ntydecl}}{\vparsednode}) \;\aslto\; \overname{\ty}{\vastnode}
-  \cup \overname{\TBuildError}{\BuildErrorConfig}
-\]
-transforms a \namedtype\ parse node $\vparsednode$ into an AST node $\vastnode$.
-\ProseOtherwiseBuildError
-
+\subsection{Typing}
 \hypertarget{def-annotatetype}{}
 The function
 \[
   \annotatetype{\overname{\Bool}{\vdecl} \aslsep \overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\tty}}
   \aslto (\overname{\ty}{\newty} \times \overname{\TSideEffectSet}{\vses}) \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-typechecks a type $\tty$ in an environment $\tenv$, resulting in a \typedast\ $\newty$
-and a \sideeffectsetterm\ $\vses$.
-The flag $\decl$ indicates whether $\tty$ is a type currently being declared,
+typechecks a type $\tty$ in a static environment $\tenv$,
+resulting in a \typedast\ $\newty$ and a \sideeffectsetterm\ $\vses$.
+The flag $\decl$ indicates whether $\tty$ is a type currently being declared or not,
 and makes a difference only when $\tty$ is an enumeration type or a \structuredtype.
 \ProseOtherwiseTypeError
 
-Types are not associated with a semantic relation.
-
-The rest of this chapter defines the following aspects of types:
-\begin{itemize}
-\item \secref{DomainOfValuesForTypes} defines how values are associated with each type.
-\item \secref{BasicTypeAttributes} assigns basic properties to types, which are useful
-in classifying them.
-\item \secref{RelationsOnTypes} defines relations on types that are needed to typecheck
-expressions and statements.
-\item \secref{BaseValues} defines how to produce an expression to initialize storage
-      elements of a given type (for which no initializing expression is supplied).
-\end{itemize}
+\subsection{Semantics}
+Types are not evaluated dynamically.
+However, the dynamic semantics of types is given by their \emph{domain of values},
+which is defined in \secref{DomainOfValuesForTypes}.
 
 \hypertarget{integertypeterm}{}
 \section{Integer Types\label{sec:IntegerTypes}}
-\begin{center}
-\begin{tabular}{lll}
-\hline
-\secreflink{IntegerTypesSyntax} & \secreflink{IntegerTypesAST} & \secreflink{TypingIntegerTypes}\\
-& \secreflink{ASTRule.Ty.TInt} & \secreflink{TypingRule.TInt}\\
-& \secreflink{ASTRule.IntConstraintsOpt} & \secreflink{TypingRule.AnnotateConstraint}\\
-& \secreflink{ASTRule.IntConstraints} & \\
-& \secreflink{ASTRule.IntConstraint} &\\
-\hline
-\end{tabular}
-\end{center}
+The \texttt{integer} type represents mathematical integer values.
+
+There are four kinds of integer types, which we explain next:
+\emph{unconstrained}, \emph{well-constrained},
+\emph{pending constrained}, and \emph{parameterized}.
+
+\subsection{Unconstrained Integer Types}
+The type \verb|integer| represents all integer values.
+\lrmcomment{\identi{HJBH}}
+There is no bound on the minimum and maximum integer value that can be represented.
+
+\ExampleDef{Unconstrained Integer Types}
+\listingref{typing-unconstrained} shows examples of unconstrained integer types.
+\ASLListing{Well-typed unconstrained integer types}{typing-unconstrained}{\typingtests/TypingRule.TIntUnConstrained.asl}
+
+\subsection{Well-constrained Integer Types}
+\lrmcomment{\identr{GWCP}}
+The type \texttt{integer\{$c_1,\ldots,c_n$\}} represents the
+union of sets of integers represented by the \emph{integer constraints} $c_1,\ldots,c_n$.
+\hypertarget{def-exactconstraintterm}{}
+\hypertarget{def-rangeconstraintterm}{}
+A constraint can either be an \emph{\exactconstraintterm}, consisting of a single expression like \texttt{4},
+or a \emph{\rangeconstraintterm}, consisting of a pair of expressions like \texttt{1..10}.
+
+\ExampleDef{Well-constrained Integer Types}
+\listingref{typing-wellconstrained} shows examples of well-constrained integer types.
+\ASLListing{Well-typed well-constrained integer types}{typing-wellconstrained}{\typingtests/TypingRule.TIntWellConstrained.asl}
+
+\subsection{Pending-constrained Integer Types}
+The type \verb|integer{-}| represents a well-constrained integer type whose
+constraints have yet to be determined.
+These constraints are inferred by the type system based on the expression used to initialize
+the storage element (see \TypingRuleRef{InheritIntegerConstraints}).
+
+\RequirementDef{PendingConstrainedLocal}
+Pending-constrained integer types may only appear on the left-hand-side
+of local storage element declarations.
+%
+\listingref{global-pending-constrained} shows an ill-typed specification.
+
+\ExampleDef{Well-typed pending-constrained types}
+\listingref{typing-pendingconstrained} shows examples of well-typed pending-constrained
+integer types.
+\ASLListing{Well-typed pending-constrained integer types}{typing-pendingconstrained}{\typingtests/TypingRule.InheritIntegerConstraints.asl}
+
+\subsection{Parameterized Integer Types}
+Subprogram parameters are implicitly \emph{parameterized integer types},
+which represent a singleton set for the integer passed to the parameter
+at the call site.
+
+\ExampleDef{Parameterized Integer Types}
+\listingref{typing-parameterized} shows examples of well-typed parameterized
+integer types.
+Notice that the type of the parameter \texttt{M} of the function \texttt{bar}
+is a parameterized integer type, \underline{not} an unconstrained integer type.
+\ASLListing{Well-typed parameterized integer types}{typing-parameterized}{\typingtests/TypingRule.TIntParameterized.asl}
 
 \subsection{Syntax\label{sec:IntegerTypesSyntax}}
 \begin{flalign*}
@@ -167,12 +224,12 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[well\_constrained]{
-  \buildclist[\buildintconstraint](\vconstraints) \astarrow \vconstraintasts
+  \buildclist[\buildintconstraint](\cs) \astarrow \vcsasts
 }{
   {
     \begin{array}{r}
-  \buildconstraintkind(\Nconstraintkind(\Tlbrace, \namednode{\vconstraints}{\ClistOne{\Nintconstraint}}, \Trbrace)) \astarrow\\
-  \overname{\wellconstrained(\vconstraintasts)}{\vastnode}
+  \buildconstraintkind(\Nconstraintkind(\Tlbrace, \namednode{\cs}{\ClistOne{\Nintconstraint}}, \Trbrace)) \astarrow\\
+  \overname{\wellconstrained(\vcsasts)}{\vastnode}
     \end{array}
   }
 }
@@ -215,15 +272,40 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \end{mathpar}
 
 \subsection{Typing Integer Types\label{sec:TypingIntegerTypes}}
+\hypertarget{def-isunconstrainedinteger}{}
+\hypertarget{def-isparameterizedinteger}{}
+\hypertarget{def-iswellconstrainedinteger}{}
+We use the following helper predicates to classify integer types:
+\[
+  \begin{array}{rcl}
+  \isunconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool\\
+  \isparameterizedinteger(\overname{\ty}{\vt}) &\aslto& \Bool\\
+  \iswellconstrainedinteger(\overname{\ty}{\vt}) &\aslto& \Bool
+  \end{array}
+\]
+Those are defined as follows:
+\[
+  \begin{array}{rcl}
+  \isunconstrainedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\unconstrained\\
+  \isparameterizedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\parameterized\\
+  \iswellconstrainedinteger(\vt) &\triangleq& \vt = \TInt(c) \land \astlabel(c)=\wellconstrained\\
+\end{array}
+\]\lrmcomment{This is related to \identd{ZTPP}, \identr{WJYH}, \identr{HJPN}, \identr{CZTX}, \identr{TPHR}.}
+
+\hypertarget{def-unconstrainedinteger}{}
+We use the shorthand notation $\unconstrainedinteger \triangleq \TInt(\unconstrained)$
+for unconstrained integers.
+
 \TypingRuleDef{TInt}
-\subsubsection{Example}
-In \listingref{typing-unconstrained}, \listingref{typing-wellconstrained},
-and \listingref{typing-parameterized} all examples of
-\unconstrainedintegertypes, \wellconstrainedintegertypes,
-and \parameterizedintegertypes, respectively, are well-typed.
-\ASLListing{Well-typed unconstrained integer types}{typing-unconstrained}{\typingtests/TypingRule.TIntUnConstrained.asl}
-\ASLListing{Well-typed well-constrained integer types}{typing-wellconstrained}{\typingtests/TypingRule.TIntWellConstrained.asl}
-\ASLListing{Well-typed parameterized integer types}{typing-parameterized}{\typingtests/TypingRule.TIntParameterized.asl}
+\ExampleDef{Ill-typed pending-constrained integer type}
+\listingref{global-pending-constrained}
+and \listingref{rhs-pending-constrained}
+correspond to \CaseName{pending\_constrained}.
+\ASLListing{Ill-typed pending-constrained integer type}{global-pending-constrained}
+{\typingtests/TypingRule.TInt.global_pending_constrained.bad.asl}
+
+\ASLListing{Ill-typed pending-constrained integer type}{rhs-pending-constrained}
+{\typingtests/TypingRule.TInt.rhs_pending_constrained.bad.asl}
 
 \ProseParagraph
 One of the following applies:
@@ -313,8 +395,11 @@ One of the following applies:
 \hypertarget{def-annotateconstraint}{}
 The function
 \[
+\begin{array}{r}
 \annotateconstraint(\overname{\staticenvs}{\tenv} \aslsep \overname{\intconstraint}{\vc})
-\aslto (\overname{\intconstraint}{\newc} \times \overname{\TSideEffectSet}{\vses}) \cup \overname{\TTypeError}{\TypeErrorConfig}
+\aslto (\overname{\intconstraint}{\newc} \times \overname{\TSideEffectSet}{\vses})\ \cup \\
+\overname{\TTypeError}{\TypeErrorConfig}
+\end{array}
 \]
 annotates an integer constraint $\vc$ in the static environment $\tenv$ yielding the annotated
 integer constraint $\newc$ and \sideeffectsetterm\ $\vses$.
@@ -326,7 +411,8 @@ One of the following applies:
   \item All of the following apply (\textsc{exact}):
   \begin{itemize}
     \item $\vc$ is the exact integer constraint for the expression $\ve$, that is, \\ $\ConstraintExact(\ve)$;
-    \item applying $\annotatesymbolicconstrainedinteger$ to $\ve$ in $\tenv$ yields $(\vep, \vses)$\ProseOrTypeError;
+    \item applying $\annotatesymbolicconstrainedinteger$ to $\ve$ in $\tenv$ yields \\
+          $(\vep, \vses)$\ProseOrTypeError;
     \item define $\newc$ as the exact integer constraint for $\vep$, that is, $\ConstraintExact(\vep)$.
   \end{itemize}
 
@@ -552,7 +638,12 @@ All of the following apply:
   \annotateexpr{\tenv, \ewidth} \typearrow (\twidth, \ewidthp, \seswidth) \OrTypeError\\\\
   \checksymbolicallyevaluable(\seswidth) \typearrow \True \OrTypeError\\\\
   \checkconstrainedinteger(\tenv, \twidth) \typearrow \True \OrTypeError\\\\
-  \annotatebitfields(\tenv, \ewidthp, \bitfields) \typearrow (\bitfieldsp, \vsesbitfields) \OrTypeError\\\\
+  {
+  \begin{array}{r}
+    \annotatebitfields(\tenv, \ewidthp, \bitfields) \typearrow \\
+    (\bitfieldsp, \vsesbitfields) \OrTypeError
+  \end{array}
+  }\\
   \staticeval(\tenv, \ewidthp) \typearrow \lint(\vwidth)\\
   \checkcommonbitfieldsalign(\tenv, \bitfieldsp, \vwidth) \typearrow \True \OrTypeError\\\\
   \vses \eqdef \seswidth \cup \vsesbitfields
@@ -650,8 +741,12 @@ ASL offers two kinds of arrays:
 \ASTRuleDef{Ty.TArray}
 \begin{mathpar}
 \inferrule{}{
-  \buildty(\Nty(\Tarray, \Tllbracket, \punnode{\Nexpr}, \Trrbracket, \Tof, \punnode{\Nty})) \astarrow
-  \overname{\TArray(\ArrayLengthExpr(\astof{\vexpr}), \astof{\tty})}{\vastnode}
+  {
+  \begin{array}{r}
+    \buildty(\Nty(\Tarray, \Tllbracket, \punnode{\Nexpr}, \Trrbracket, \Tof, \punnode{\Nty})) \astarrow\\
+    \overname{\TArray(\ArrayLengthExpr(\astof{\vexpr}), \astof{\tty})}{\vastnode}
+  \end{array}
+  }
 }
 \end{mathpar}
 \subsection{Typing Array Types\label{sec:TypingArrayTypes}}
@@ -1044,6 +1139,9 @@ In \listingref{typing-trecord}, all the uses of record or exception types are we
 }
 \end{mathpar}
 
+\subsection{Typing Exception Types}
+The rule for typing exception types is \TypingRuleRef{TStructuredDecl}.
+
 \hypertarget{namedtypeterm}{}
 \section{Named Types\label{sec:NamedTypes}}
 \subsection{Syntax}
@@ -1055,9 +1153,6 @@ In \listingref{typing-trecord}, all the uses of record or exception types are we
 \begin{flalign*}
 \ty \derives\ & \TNamed(\overtext{\identifier}{type name}) &
 \end{flalign*}
-
-\subsection{Typing Exception Types}
-The rule for typing exception type is \TypingRuleRef{TStructuredDecl}.
 
 \ASTRuleDef{Ty.TNamed}
 \begin{mathpar}
@@ -1094,7 +1189,7 @@ All of the following apply:
 In \listingref{typing-tnamed}, all the uses of \texttt{MyType} are well-typed.
 \ASLListing{Well-typed named types}{typing-tnamed}{\typingtests/TypingRule.TNamed.asl}
 
-\section{Declared Types}
+\section{Declared Types\label{sec:DeclaredTypes}}
 A declared type can be an enumeration type, a record type, an exception type, or an \anonymoustype.
 \subsection{Syntax}
 \begin{flalign*}
@@ -1111,6 +1206,13 @@ A declared type can be an enumeration type, a record type, an exception type, or
 \end{mathpar}
 
 \subsection{Typing Declared Types}
+\lrmcomment{\identr{RGRVJ}}
+\RequirementDef{RestrictionsOnAnonymousTypes}
+A declared type for an enumeration, a record type, or an exception type
+are only permitted in named type declarations. This is enforced by \TypingRuleRef{TNonDecl}.
+%
+See \ExampleRef{Ill-typed pending-constrained integer type}.
+
 \TypingRuleDef{TNonDecl}
 \subsubsection{Example}
 In \listingref{typing-trecorderror}, the use of a record type outside of a declaration is erroneous.

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -308,14 +308,14 @@ correspond to \CaseName{pending\_constrained}.
 {\typingtests/TypingRule.TInt.rhs_pending_constrained.bad.asl}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{pending\_constrained}:
+  \item \AllApplyCase{pending\_constrained}
     \begin{itemize}
       \item $\tty$ is a \pendingconstrainedintegertype;
       \item the result is a type error (\UnexpectedType).
     \end{itemize}
-  \item \AllApplyCase{well\_constrained}:
+  \item \AllApplyCase{well\_constrained}
     \begin{itemize}
       \item $\tty$ is the well-constrained integer type constrained by
         constraints $\vc_i$, for $u=1..k$;
@@ -328,7 +328,7 @@ One of the following applies:
       \item define $\vses$ as the union of all $\vxs_i$, for $i=1..k$.
     \end{itemize}
 
-    \item \AllApplyCase{parameterized}:
+    \item \AllApplyCase{parameterized}
     \begin{itemize}
       \item $\tty$ is a \parameterizedintegertype\ for $\name$;
       \item define $\vses$ as the singleton set for the singleton \sideeffectdescriptorterm,
@@ -336,7 +336,7 @@ One of the following applies:
       \item $\newty$ is the unconstrained integer type.
     \end{itemize}
 
-    \item \AllApplyCase{unconstrained}:
+    \item \AllApplyCase{unconstrained}
     \begin{itemize}
       \item $\tty$ is an \unconstrainedintegertype;
       \item $\newty$ is the unconstrained integer type;
@@ -420,9 +420,9 @@ In \listingref{annotate-constraint-unconstrained}, the constraint
 \ASLListing{Ill-typed constraint}{annotate-constraint-unconstrained}{\typingtests/TypingRule.AnnotateConstraint.bad.asl}
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{exact}:
+  \item \AllApplyCase{exact}
   \begin{itemize}
     \item $\vc$ is the exact integer constraint for the expression $\ve$, that is, \\ $\ConstraintExact(\ve)$;
     \item applying $\annotatesymbolicconstrainedinteger$ to $\ve$ in $\tenv$ yields \\
@@ -430,7 +430,7 @@ One of the following applies:
     \item define $\newc$ as the exact integer constraint for $\vep$, that is, $\ConstraintExact(\vep)$.
   \end{itemize}
 
-  \item \AllApplyCase{range}:
+  \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vc$ is the range integer constraint for expressions $\veone$ and $\vetwo$, that is, \\ $\ConstraintRange(\veone, \vetwo)$;
     \item applying $\annotatesymbolicconstrainedinteger$ to $\veone$ in $\tenv$ yields\\ $(\veonep, \vsesone)$\ProseOrTypeError;
@@ -795,9 +795,9 @@ In \listingref{typing-tarray}, all the uses of array types are well-typed.
 \begin{itemize}
   \item $\tty$ is the array type with element type $\vt$;
   \item Annotating the type $\vt$ in $\tenv$ yields $(\vtp, \vsest)$\ProseOrTypeError;
-  \item One of the following applies:
+  \item \OneApplies
   \begin{itemize}
-    \item \AllApplyCase{expr\_is\_enum}:
+    \item \AllApplyCase{expr\_is\_enum}
     \begin{itemize}
       \item the array index is $\ve$ and determining whether $\ve$ corresponds to an enumeration in $\tenv$
       via $\getvariableenum$ yields the enumeration variable
@@ -807,7 +807,7 @@ In \listingref{typing-tarray}, all the uses of array types are well-typed.
       \item define $\vses$ as $\vsest$.
     \end{itemize}
 
-    \item \AllApplyCase{expr\_not\_enum}:
+    \item \AllApplyCase{expr\_not\_enum}
     \begin{itemize}
       \item the array index is $\ve$ and determining whether $\ve$ corresponds to an enumeration in $\tenv$
       via $\getvariableenum$ yields $\None$ (meaning it does not
@@ -860,22 +860,22 @@ declared for the enumeration type.
 Otherwise, the result is $\None$.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{not\_evar}:
+  \item \AllApplyCase{not\_evar}
   \begin{itemize}
     \item $\ve$ is not a variable expression;
     \item the result is $\None$.
   \end{itemize}
 
-  \item \AllApplyCase{no\_declared\_type}:
+  \item \AllApplyCase{no\_declared\_type}
   \begin{itemize}
     \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
     \item $\vx$ is not associated with a type in the global environment of $\tenv$;
     \item the result is $\None$.
   \end{itemize}
 
-  \item \AllApplyCase{declared\_enum}:
+  \item \AllApplyCase{declared\_enum}
   \begin{itemize}
     \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
     \item $\vx$ is associated with a type $\vt$ in the global environment of $\tenv$;
@@ -883,7 +883,7 @@ One of the following applies:
     \item the result is the pair consisting of $\vx$ and $\vlabels$.
   \end{itemize}
 
-  \item \AllApplyCase{declared\_not\_enum}:
+  \item \AllApplyCase{declared\_not\_enum}
   \begin{itemize}
     \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
     \item $\vx$ is associated with a type $\vt$ in the global environment of $\tenv$;
@@ -1001,16 +1001,16 @@ The function
 returns $\True$ is $\vt$ is has the \structure\ an integer type and a type error otherwise.
 
 \ProseParagraph
-One of the following applies:
+\OneApplies
 \begin{itemize}
-  \item \AllApplyCase{okay}:
+  \item \AllApplyCase{okay}
   \begin{itemize}
     \item determining the \structure\ of $\vt$ yields $\vtp$\ProseOrTypeError;
     \item $\vtp$ is an integer type;
     \item the result is $\True$;
   \end{itemize}
 
-  \item \AllApplyCase{error}:
+  \item \AllApplyCase{error}
   \begin{itemize}
     \item determining the \structure\ of $\vt$ yields $\vtp$\ProseOrTypeError;
     \item $\vtp$ is not an integer type;

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -310,12 +310,12 @@ correspond to \CaseName{pending\_constrained}.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{pending\_constrained}):
+  \item \AllApplyCase{pending\_constrained}:
     \begin{itemize}
       \item $\tty$ is a \pendingconstrainedintegertype;
       \item the result is a type error (\UnexpectedType).
     \end{itemize}
-  \item All of the following apply (\textsc{well\_constrained}):
+  \item \AllApplyCase{well\_constrained}:
     \begin{itemize}
       \item $\tty$ is the well-constrained integer type constrained by
         constraints $\vc_i$, for $u=1..k$;
@@ -328,7 +328,7 @@ One of the following applies:
       \item define $\vses$ as the union of all $\vxs_i$, for $i=1..k$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{parameterized}):
+    \item \AllApplyCase{parameterized}:
     \begin{itemize}
       \item $\tty$ is a \parameterizedintegertype\ for $\name$;
       \item define $\vses$ as the singleton set for the singleton \sideeffectdescriptorterm,
@@ -336,7 +336,7 @@ One of the following applies:
       \item $\newty$ is the unconstrained integer type.
     \end{itemize}
 
-    \item All of the following apply (\textsc{unconstrained}):
+    \item \AllApplyCase{unconstrained}:
     \begin{itemize}
       \item $\tty$ is an \unconstrainedintegertype;
       \item $\newty$ is the unconstrained integer type;
@@ -422,7 +422,7 @@ In \listingref{annotate-constraint-unconstrained}, the constraint
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{exact}):
+  \item \AllApplyCase{exact}:
   \begin{itemize}
     \item $\vc$ is the exact integer constraint for the expression $\ve$, that is, \\ $\ConstraintExact(\ve)$;
     \item applying $\annotatesymbolicconstrainedinteger$ to $\ve$ in $\tenv$ yields \\
@@ -430,7 +430,7 @@ One of the following applies:
     \item define $\newc$ as the exact integer constraint for $\vep$, that is, $\ConstraintExact(\vep)$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{range}):
+  \item \AllApplyCase{range}:
   \begin{itemize}
     \item $\vc$ is the range integer constraint for expressions $\veone$ and $\vetwo$, that is, \\ $\ConstraintRange(\veone, \vetwo)$;
     \item applying $\annotatesymbolicconstrainedinteger$ to $\veone$ in $\tenv$ yields\\ $(\veonep, \vsesone)$\ProseOrTypeError;
@@ -496,7 +496,7 @@ In \listingref{typing-treal}, all the uses of the \realtypeterm{} are well-typed
 \subsection{Typing the Real Type\label{sec:TypingRealType}}
 \TypingRuleDef{TReal}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is the \realtypeterm{}, $\TReal$.
   \item $\newty$ is the \realtypeterm{}, $\TReal$;
@@ -546,7 +546,7 @@ In \listingref{typing-tstring}, all the uses of the \stringtypeterm{} are well-t
 \subsection{Typing the String Type\label{sec:TypingStringType}}
 \TypingRuleDef{TString}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is the \stringtypeterm{}, $\TString$.
   \item $\newty$ is the \stringtypeterm{}, $\TString$.
@@ -591,7 +591,7 @@ In \listingref{typing-tbool}, all the uses of \texttt{boolean} are well-typed.
 \subsection{Typing the Boolean Type\label{sec:TypingBooleanType}}
 \TypingRuleDef{TBool}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is the boolean type, \TBool;
   \item $\newty$ is the boolean type, \TBool;
@@ -652,7 +652,7 @@ In \listingref{typing-tbits}, all the uses of bitvector types are well-typed.
 \ASLListing{Well-typed Bitevector types}{typing-tbits}{\typingtests/TypingRule.TBits.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is the bit-vector type with width given by the expression
     $\ewidth$ and the bitfields given by $\bitfields$, that is, $\TBits(\ewidth, \bitfields)$;
@@ -727,7 +727,7 @@ In \listingref{typing-ttuple}, all the uses of tuple types are well-typed.
 
 \TypingRuleDef{TTuple}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is the tuple type with member types $\tys$, that is, $\TTuple(\tys)$;
   \item $\tys$ is the list $\tty_i$, for $i=1..k$;
@@ -791,13 +791,13 @@ In \listingref{typing-tarray}, all the uses of array types are well-typed.
 
 \TypingRuleDef{TArray}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is the array type with element type $\vt$;
   \item Annotating the type $\vt$ in $\tenv$ yields $(\vtp, \vsest)$\ProseOrTypeError;
   \item One of the following applies:
   \begin{itemize}
-    \item All of the following apply (\textsc{expr\_is\_enum}):
+    \item \AllApplyCase{expr\_is\_enum}:
     \begin{itemize}
       \item the array index is $\ve$ and determining whether $\ve$ corresponds to an enumeration in $\tenv$
       via $\getvariableenum$ yields the enumeration variable
@@ -807,7 +807,7 @@ All of the following apply:
       \item define $\vses$ as $\vsest$.
     \end{itemize}
 
-    \item All of the following apply (\textsc{expr\_not\_enum}):
+    \item \AllApplyCase{expr\_not\_enum}:
     \begin{itemize}
       \item the array index is $\ve$ and determining whether $\ve$ corresponds to an enumeration in $\tenv$
       via $\getvariableenum$ yields $\None$ (meaning it does not
@@ -862,20 +862,20 @@ Otherwise, the result is $\None$.
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{not\_evar}):
+  \item \AllApplyCase{not\_evar}:
   \begin{itemize}
     \item $\ve$ is not a variable expression;
     \item the result is $\None$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{no\_declared\_type}):
+  \item \AllApplyCase{no\_declared\_type}:
   \begin{itemize}
     \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
     \item $\vx$ is not associated with a type in the global environment of $\tenv$;
     \item the result is $\None$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{declared\_enum}):
+  \item \AllApplyCase{declared\_enum}:
   \begin{itemize}
     \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
     \item $\vx$ is associated with a type $\vt$ in the global environment of $\tenv$;
@@ -883,7 +883,7 @@ One of the following applies:
     \item the result is the pair consisting of $\vx$ and $\vlabels$.
   \end{itemize}
 
-  \item All of the following apply (\textsc{declared\_not\_enum}):
+  \item \AllApplyCase{declared\_not\_enum}:
   \begin{itemize}
     \item $\ve$ is a variable expression for $\vx$, that is, $\EVar(\vx)$;
     \item $\vx$ is associated with a type $\vt$ in the global environment of $\tenv$;
@@ -942,7 +942,7 @@ yielding the resulting type in $\vt$, the annotated expression in $\vep$ and the
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item \Proseannotateexpr{$\tenv$}{$\ve$}{$(\vt, \vep, \vses)$};
   \item \Prosechecksymbolicallyevaluable{$\vses$}.
@@ -971,7 +971,7 @@ and returns the annotated expression $\vepp$ and \sideeffectsetterm\ $\vses$.
 \ProseOtherwiseTypeError
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item \Proseannotatesymbolicallyevaluableexpr{$\tenv$}{$\ve$}{$(\vt, \vep, \vses)$\ProseOrTypeError};
   \item determining whether $\vt$ has the structure of an integer yields $\True$\ProseOrTypeError;
@@ -1003,14 +1003,14 @@ returns $\True$ is $\vt$ is has the \structure\ an integer type and a type error
 \ProseParagraph
 One of the following applies:
 \begin{itemize}
-  \item All of the following apply (\textsc{okay}):
+  \item \AllApplyCase{okay}:
   \begin{itemize}
     \item determining the \structure\ of $\vt$ yields $\vtp$\ProseOrTypeError;
     \item $\vtp$ is an integer type;
     \item the result is $\True$;
   \end{itemize}
 
-  \item All of the following apply (\textsc{error}):
+  \item \AllApplyCase{error}:
   \begin{itemize}
     \item determining the \structure\ of $\vt$ yields $\vtp$\ProseOrTypeError;
     \item $\vtp$ is not an integer type;
@@ -1069,7 +1069,7 @@ One of the following applies:
 \TypingRuleDef{TEnumDecl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is the enumeration type with enumeration literals
     $\vli$, that is, $\TEnum(\vli)$;
@@ -1119,7 +1119,7 @@ All of the following apply:
 \subsection{Typing Record Types\label{sec:TypingRecordTypes}}
 \TypingRuleDef{TStructuredDecl}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is a \structuredtype\ with AST label $L$;
   \item the list of fields of $\tty$ is $\fields$;
@@ -1200,7 +1200,7 @@ The rule for typing exception types is \TypingRuleRef{TStructuredDecl}.
 \subsection{Typing Named Types\label{sec:TypingNamedTypes}}
 \TypingRuleDef{TNamed}
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is the named type $\vx$, that is $\TNamed(\vx)$;
   \item checking whether $\vx$ is bound to any declared type in $\tenv$ yields $\True$\ProseOrTypeError;
@@ -1254,7 +1254,7 @@ In \listingref{typing-trecorderror}, the use of a record type outside of a decla
 \ASLListing{An erroneous use of a record type}{typing-trecorderror}{\typingtests/TypingRule.TNonDecl.asl}
 
 \ProseParagraph
-All of the following apply:
+\AllApply
 \begin{itemize}
   \item $\tty$ is a \structuredtype\ or an enumeration type;
   \item $\decl$ is $\False$, indicating that $\tty$ should be considered to be outside the context of a declaration

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -390,10 +390,14 @@ def check_rule_case_consistency(rule_block: RuleBlock) -> List[str]:
 
 
 def check_rule_has_example(rule_block: RuleBlock) -> List[str]:
+    r"""
+    Every typing rule and semantics rule should provide or reference at least
+    one example.
+    """
     example_found = False
     for line_number in range(rule_block.begin, rule_block.end + 1):
         line = rule_block.file_lines[line_number].strip()
-        if line.startswith("\\ExampleDef") or "\\ExampleRef" in line:
+        if line.startswith("\\ExampleDef") or "\\ExampleRef" in line or "\\subsubsection{Example}" in line:
             example_found = True
             break
     error_messages = []
@@ -409,7 +413,7 @@ def check_rules(filename: str) -> int:
     checks = [
         check_rule_prose_formally_structure,
         # check_rule_case_consistency,
-        check_rule_has_example,
+        # check_rule_has_example,
     ]
     num_errors = 0
     rule_blocks: List[RuleBlock] = match_rules(filename)
@@ -464,7 +468,7 @@ def main():
         ],
     )
 
-    print(f"There are #{num_rules} rules")
+    #print(f"There are #{num_rules} rules")
     if num_errors > 0:
         print(f"There were {num_errors} errors!", file=sys.stderr)
         sys.exit(1)

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -303,7 +303,7 @@ def check_rule_prose_formally_structure(rule_block: RuleBlock) -> List[str]:
     block_errors: List[str] = []
     for line_number in range(rule_block.begin, rule_block.end + 1):
         line = rule_block.file_lines[line_number].strip()
-        if line.startswith('%'):
+        if line.startswith("%"):
             continue
         if re.search(r"\\ProseParagraph", line):
             num_prose_paragraphs += 1
@@ -335,14 +335,12 @@ def check_rule_case_consistency(rule_block: RuleBlock) -> List[str]:
     """
     prose_cases: Set[str] = set()
     formally_cases: Set[str] = set()
-    prose_cases_pattern = re.compile(
-        r"\\AllApplyCase[(.*?)]|.*\(\\textsc{(.*?)}\)"
-    )
-    formally_case_pattern = re.compile(r"\\inferrule\[(.*?)\]")
+    prose_cases_pattern = re.compile(r".*\\AllApplyCase{(.*?)}")
+    formally_case_pattern = re.compile(r".*\\inferrule\[(.*?)\]")
     error_messages: List[str] = []
     for line_number in range(rule_block.begin, rule_block.end + 1):
         line = rule_block.file_lines[line_number].strip()
-        if line.startswith('%'):
+        if line.startswith("%"):
             continue
         formally_matches = re.match(formally_case_pattern, line)
         if formally_matches:
@@ -393,7 +391,6 @@ def check_rules(filename: str) -> int:
             continue
         error_messages: List[str] = []
         error_messages.extend(check_rule_prose_formally_structure(rule_block))
-        # The following check finds 41 errors - too many to fix at this point.
         # error_messages.extend(check_rule_case_consistency(rule_block))
         if error_messages:
             error_messages = ", ".join(error_messages)

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -147,21 +147,23 @@ def check_repeated_words(filename: str) -> int:
     """
     num_errors = 0
     line_number = 0
-    last_word = ""
+    last_token = ""
     for line in read_file_lines(filename):
         line_number += 1
         line = line.strip()
-        parts = line.split()
-        if len(parts) < 2:
+        tokens = re.split(' |{|}', line)
+        if not tokens:
             continue
-        for current_word in parts:
-            if current_word.isalpha() and last_word.lower() == current_word.lower():
+        for current_token in tokens:
+            current_token_lower = current_token.lower()
+            last_token_lower = last_token.lower()
+            if current_token_lower.isalpha() and last_token_lower == current_token_lower:
                 num_errors += 1
                 print(
                     f"./{filename} line {line_number}: \
-                        word repetition ({last_word} {current_word}) in '{line}'"
+                        word repetition ({last_token} {current_token}) in '{line}'"
                 )
-            last_word = current_word
+            last_token = current_token
     return num_errors
 
 
@@ -391,7 +393,7 @@ def check_rules(filename: str) -> int:
             continue
         error_messages: List[str] = []
         error_messages.extend(check_rule_prose_formally_structure(rule_block))
-        # error_messages.extend(check_rule_case_consistency(rule_block))
+        #error_messages.extend(check_rule_case_consistency(rule_block))
         if error_messages:
             error_messages = ", ".join(error_messages)
             print(f"{rule_block.filename} {rule_block.str()}: {error_messages}")

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -4,8 +4,15 @@ import os, sys, fnmatch
 from extended_macros import apply_all_macros
 
 import argparse
-cli_parser = argparse.ArgumentParser(prog='ASL Reference Linter')
-cli_parser.add_argument('-t', '--transform', help='Rewrites *.tex files with extended macros', action='store_true')
+
+cli_parser = argparse.ArgumentParser(prog="ASL Reference Linter")
+cli_parser.add_argument(
+    "-t",
+    "--transform",
+    help="Rewrites *.tex files with extended macros",
+    action="store_true",
+)
+
 
 def extract_labels_from_line(line: str, left_delim: str, labels: set[str]):
     r"""
@@ -25,14 +32,16 @@ def extract_labels_from_line(line: str, left_delim: str, labels: set[str]):
         labels.add(label)
         label_pos = right_brace_pos + 1
 
+
 def check_hyperlinks_and_hypertargets():
     r"""
     Checks whether all labels defined in `\hyperlink` definitions match
-    labels defined in `\hypertarget` definitions, print the mismatches to the console.
+    labels defined in `\hypertarget` definitions, print the mismatches
+    to the console.
     """
-    latex_files = fnmatch.filter(os.listdir('.'), '*.tex')
-    hyperlink_labels : set[str] = set()
-    hypertarget_labels : set[str] = set()
+    latex_files = fnmatch.filter(os.listdir("."), "*.tex")
+    hyperlink_labels: set[str] = set()
+    hypertarget_labels: set[str] = set()
     for latex_source in latex_files:
         with open(latex_source) as file:
             for line in file.readlines():
@@ -43,7 +52,11 @@ def check_hyperlinks_and_hypertargets():
     if missing_hypertargets:
         num_missing_hypertargets = len(missing_hypertargets)
         num_errors += num_missing_hypertargets
-        print(f"ERROR: found {num_missing_hypertargets} hyperlinks without matching hypertargets: ", file=sys.stderr)
+        print(
+            f"ERROR: found {num_missing_hypertargets} hyperlinks without \
+              matching hypertargets: ",
+            file=sys.stderr,
+        )
         for label in missing_hypertargets:
             print(label, file=sys.stderr)
 
@@ -51,11 +64,16 @@ def check_hyperlinks_and_hypertargets():
     if not missing_hyperlinks == set():
         num_missing_hyperlinks = len(missing_hyperlinks)
         num_errors += num_missing_hyperlinks
-        print(f"ERROR: found {num_missing_hyperlinks} hypertargets without matching hyperlinks: ", file=sys.stderr)
+        print(
+            f"ERROR: found {num_missing_hyperlinks} hypertargets without\
+               matching hyperlinks: ",
+            file=sys.stderr,
+        )
         for label in missing_hyperlinks:
             print(label, file=sys.stderr)
 
     return num_errors
+
 
 def check_undefined_references_and_multiply_defined_labels():
     r"""
@@ -66,12 +84,27 @@ def check_undefined_references_and_multiply_defined_labels():
     with open("./ASLReference.log") as file:
         log_str = file.read()
         if "LaTeX Warning: There were undefined references." in log_str:
-            print(f"ERROR: There are undefined references (see ./ASLReference.log)", file=sys.stderr)
+            print(
+                f"ERROR: There are undefined references (see ./ASLReference.log)",
+                file=sys.stderr,
+            )
             num_errors += 1
         if "LaTeX Warning: There were multiply-defined labels." in log_str:
-            print(f"ERROR: There are multiply-defined labels (see ./ASLReference.log)", file=sys.stderr)
+            print(
+                f"ERROR: There are multiply-defined labels (see ./ASLReference.log)",
+                file=sys.stderr,
+            )
+            num_errors += 1
+        if "destination with the same identifier" in log_str:
+            print(
+                f"ERROR: There are multiply-defined \\hypertarget labels \
+                  (see 'destination with the same identifier' in \
+                  ./ASLReference.log)",
+                file=sys.stderr,
+            )
             num_errors += 1
     return num_errors
+
 
 def check_tododefines():
     r"""
@@ -80,24 +113,28 @@ def check_tododefines():
     """
     MAX_TODODEFINE_INSTANCES = 7
     num_todo_define = 0
-    latex_files = fnmatch.filter(os.listdir('.'), '*.tex')
+    latex_files = fnmatch.filter(os.listdir("."), "*.tex")
     for latex_source in latex_files:
         with open(latex_source) as file:
             file_str = file.read()
-            num_todo_define += file_str.count('\\tododefine')
-    num_todo_define -= 1 # Ignore the definition of the \tododefine macro itself.
+            num_todo_define += file_str.count("\\tododefine")
+    num_todo_define -= 1  # Ignore the definition of the \tododefine macro itself.
     if num_todo_define > MAX_TODODEFINE_INSTANCES:
         # Disallow adding new \tododefines
-        print(f"ERROR: There are {num_todo_define} occurrences of \\tododefine, expected at most {MAX_TODODEFINE_INSTANCES}")
+        print(
+            f"ERROR: There are {num_todo_define} occurrences of \\tododefine,\
+               expected at most {MAX_TODODEFINE_INSTANCES}"
+        )
         return num_todo_define
     else:
         print(f"WARNING: There are {num_todo_define} occurrences of \\tododefine")
         return 0
 
+
 def check_repeated_words():
     last_word = ""
     num_errors = 0
-    latex_files = fnmatch.filter(os.listdir('.'), '*.tex')
+    latex_files = fnmatch.filter(os.listdir("."), "*.tex")
     for latex_source in latex_files:
         with open(latex_source) as file:
             line_number = 0
@@ -108,17 +145,24 @@ def check_repeated_words():
                 if len(parts) < 2:
                     continue
                 for current_word in parts:
-                    if current_word.isalpha() and last_word.lower() == current_word.lower():
+                    if (
+                        current_word.isalpha()
+                        and last_word.lower() == current_word.lower()
+                    ):
                         num_errors += 1
-                        print(f"./{latex_source} line {line_number}: word repetition ({last_word} {current_word}) in '{line}'")
+                        print(
+                            f"./{latex_source} line {line_number}: \
+                              word repetition ({last_word} {current_word}) in '{line}'"
+                        )
                     last_word = current_word
     return num_errors
+
 
 def main():
     args = cli_parser.parse_args()
     if args.transform:
         apply_all_macros()
-    print('Linting files...')
+    print("Linting files...")
     num_errors = 0
     num_errors += check_hyperlinks_and_hypertargets()
     num_errors += check_undefined_references_and_multiply_defined_labels()
@@ -128,6 +172,7 @@ def main():
     if num_errors > 0:
         print(f"There were {num_errors} errors!", file=sys.stderr)
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-import os, fnmatch
+import os, sys, fnmatch
 from extended_macros import apply_all_macros
 
 import argparse

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -156,8 +156,8 @@ def check_repeated_words(latex_files: list[str]):
 
 def detect_incorrect_latex_macros_spacing(latex_files) -> int:
     r"""
-    Detects erroneous occurrences of LaTeX macros succeeded by a space
-    character.
+    Detects erroneous occurrences of LaTeX macros rendered without
+    separation from the next word.
     """
     num_errors = 0
     for latex_source in latex_files:
@@ -178,10 +178,17 @@ def detect_incorrect_latex_macros_spacing(latex_files) -> int:
             for pattern in patterns_to_remove:
                 file_str = re.sub(pattern, '', file_str, flags=re.DOTALL)
 
+            # Look for things like \macro word
             macro_followed_by_space = r'\\[a-zA-Z]+(?= )'
             matches = re.findall(macro_followed_by_space, file_str)
             for match in matches:
                 print(f'{latex_source}: LaTeX macro followed by space "{match }"')
+                num_errors += 1
+            # Look for things like \macro{}word
+            macro_followed_by_space = r'\\[a-zA-Z]+{}[a-zA-Z]'
+            matches = re.findall(macro_followed_by_space, file_str)
+            for match in matches:
+                print(f'{latex_source}: LaTeX macro running into next word "{match}"')
                 num_errors += 1
     return num_errors
 

--- a/asllib/doc/extended_macros.py
+++ b/asllib/doc/extended_macros.py
@@ -3,15 +3,18 @@
 import os, fnmatch, subprocess, shlex
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+import re
 
-ASLREF_EXE = 'aslref'
+ASLREF_EXE = "aslref"
 
 debug = False
 
+
 def yellow_error_message(msg: str) -> str:
-    YELLOW = '\033[43m'
-    COLOR_RESET = '\033[m'
+    YELLOW = "\033[43m"
+    COLOR_RESET = "\033[m"
     return YELLOW + msg + COLOR_RESET
+
 
 def get_latex_sources(exclude) -> list[str]:
     r"""
@@ -19,30 +22,39 @@ def get_latex_sources(exclude) -> list[str]:
     If 'exclude' is True, common files that are not required
     for transformation and linting are excluded.
     """
-    latex_files = fnmatch.filter(os.listdir('.'), '*.tex')
+    latex_files = fnmatch.filter(os.listdir("."), "*.tex")
     if exclude:
-        excluded_files = ['ASLReference.tex', 'ASLmacros.tex', 'ASLRefALP2.1ChangeLog.tex', 'ASLRefALP2ChangeLog.tex']
+        excluded_files = [
+            "ASLReference.tex",
+            "ASLmacros.tex",
+            "ASLRefALP2.1ChangeLog.tex",
+            "ASLRefALP2ChangeLog.tex",
+        ]
         for excluded_file in excluded_files:
             latex_files.remove(excluded_file)
     return latex_files
+
 
 def execute_and_capture_output(command: str, error_expected: bool) -> str:
     r"""
     Executes `command` and returns the output in a string.
     """
     args = shlex.split(command)
-    if 'aslref' not in args[0]:
-        raise ValueError(f'Command {command} does not refer to aslref!')
+    if "aslref" not in args[0]:
+        raise ValueError(f"Command {command} does not refer to aslref!")
     try:
         if error_expected:
-            subprocess_result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            subprocess_result = subprocess.run(
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
             output = subprocess_result.stdout + subprocess_result.stderr
         else:
             output = subprocess.check_output(args, text=True)
         return output
     except Exception as e:
-        print(yellow_error_message(f'Error: failed executing {command}! Aborting run'))
+        print(yellow_error_message(f"Error: failed executing {command}! Aborting run"))
         raise e
+
 
 @dataclass
 class Block:
@@ -50,8 +62,10 @@ class Block:
     Represents the range of lines in a source file
     given by the (0-indexed) slice `[begin : end + 1]`.
     """
+
     begin: int
     end: int
+
 
 class BlockMacro(ABC):
     r"""
@@ -73,7 +87,9 @@ class BlockMacro(ABC):
         pass
 
     @classmethod
-    def extend_to_all_blocks(cls, blocks_to_transform: list[Block], num_lines) -> list[tuple[Block, bool]]:
+    def extend_to_all_blocks(
+        cls, blocks_to_transform: list[Block], num_lines
+    ) -> list[tuple[Block, bool]]:
         r"""
         Adds the blocks that should not be transformed between
         `blocks_to_transform`. The output is a list of pairs, each consisting
@@ -83,16 +99,16 @@ class BlockMacro(ABC):
         given file.
         """
         assert blocks_to_transform
-        all_blocks : list[Block] = []
+        all_blocks: list[Block] = []
         last_end_line = 0
         for block in blocks_to_transform:
             if block.begin > last_end_line:
-                all_blocks.append( (Block(last_end_line, block.begin - 1), False) )
-            all_blocks.append( (block, True) )
+                all_blocks.append((Block(last_end_line, block.begin - 1), False))
+            all_blocks.append((block, True))
             last_end_line = block.end + 1
         # Append any lines after the last block to transform.
         if last_end_line < num_lines - 1:
-            all_blocks.append( (Block(last_end_line, num_lines), False) )
+            all_blocks.append((Block(last_end_line, num_lines), False))
         return all_blocks
 
     @classmethod
@@ -102,7 +118,7 @@ class BlockMacro(ABC):
         that partition the range (0, num_lines).
         """
         last_line_number = -1
-        for (block, _) in blocks:
+        for block, _ in blocks:
             assert block.end >= block.begin
             assert block.begin == last_line_number + 1
             last_line_number = block.end
@@ -110,35 +126,44 @@ class BlockMacro(ABC):
 
     @classmethod
     def apply_to_file(cls, source: str):
-        lines : list[str] = []
+        lines: list[str] = []
         with open(source) as file:
             lines = file.readlines()
         blocks_to_transform = cls.find_blocks(lines)
         if not blocks_to_transform:
             return
         if debug:
-            print(f'{source}: found {len(blocks_to_transform)} macro instance(s)')
-        all_blocks : list[Block] = cls.extend_to_all_blocks(blocks_to_transform, len(lines))
+            print(f"{source}: found {len(blocks_to_transform)} macro instance(s)")
+        all_blocks: list[Block] = cls.extend_to_all_blocks(
+            blocks_to_transform, len(lines)
+        )
         cls.validate_blocks(all_blocks, len(lines))
-        output_lines : list[str] = []
+        output_lines: list[str] = []
         number_of_changes = 0
-        for (block, should_transform) in all_blocks:
+        for block, should_transform in all_blocks:
             original_lines = lines[block.begin : block.end + 1]
-            block_output_lines : list[str] = []
+            block_output_lines: list[str] = []
             if should_transform:
                 block_output_lines = cls.transform(original_lines)
                 # Ensure lines end with a newline character.
-                block_output_lines = [line + '\n' if not line.endswith('\n') else line for line in block_output_lines]
+                block_output_lines = [
+                    line + "\n" if not line.endswith("\n") else line
+                    for line in block_output_lines
+                ]
                 if block_output_lines != original_lines:
                     first_changed_line_number = len(output_lines) + 1
-                    last_changed_line_number = first_changed_line_number + len(block_output_lines)
-                    print(f'{source} lines {first_changed_line_number}-{last_changed_line_number} are new.')
+                    last_changed_line_number = first_changed_line_number + len(
+                        block_output_lines
+                    )
+                    print(
+                        f"{source} lines {first_changed_line_number}-{last_changed_line_number} are new."
+                    )
                     number_of_changes += 1
             else:
                 block_output_lines = original_lines
             output_lines.extend(block_output_lines)
-        if number_of_changes > 0: # Avoid changing file timestamps
-            with open(source, 'w') as file:
+        if number_of_changes > 0:  # Avoid changing file timestamps
+            with open(source, "w") as file:
                 file.writelines(output_lines)
 
     @classmethod
@@ -147,7 +172,8 @@ class BlockMacro(ABC):
             try:
                 cls.apply_to_file(source)
             except ValueError as e:
-                print(f'Error in ./{source}: ', e)
+                print(f"Error in ./{source}: ", e)
+
 
 class ConsoleMacro(BlockMacro):
     r"""
@@ -155,10 +181,11 @@ class ConsoleMacro(BlockMacro):
     and ends with `CONSOLE_END`.
     The macro executes `<cmd>` and typesets its output.
     """
-    CONSOLE_BEGIN = 'CONSOLE_BEGIN'
-    CONSOLE_END = 'CONSOLE_END'
-    CONSOLE_STDERR = 'CONSOLE_STDERR'
-    CONSOLE_CMD = 'CONSOLE_CMD'
+
+    CONSOLE_BEGIN = "CONSOLE_BEGIN"
+    CONSOLE_END = "CONSOLE_END"
+    CONSOLE_STDERR = "CONSOLE_STDERR"
+    CONSOLE_CMD = "CONSOLE_CMD"
 
     @classmethod
     def find_blocks(cls, lines):
@@ -170,53 +197,107 @@ class ConsoleMacro(BlockMacro):
             if cls.CONSOLE_END in line:
                 end_lines.append(line_number)
         if len(begin_lines) != len(end_lines):
-            error_message = f'there are {len(begin_lines)} occurrences of {cls.CONSOLE_BEGIN}'\
-                f' and {len(end_lines)} occurrences of {cls.CONSOLE_END}! Aborting.'
+            error_message = (
+                f"there are {len(begin_lines)} occurrences of {cls.CONSOLE_BEGIN}"
+                f" and {len(end_lines)} occurrences of {cls.CONSOLE_END}! Aborting."
+            )
             raise ValueError(error_message)
-        blocks : list[Block] = []
-        for (begin_line_number, end_line_number) in zip(begin_lines, end_lines):
+        blocks: list[Block] = []
+        for begin_line_number, end_line_number in zip(begin_lines, end_lines):
             blocks.append(Block(begin_line_number, end_line_number))
         return blocks
 
     @classmethod
     def transform(cls, block_lines: list[str]) -> list[str]:
         assert block_lines
-        begin_line : str = block_lines[0]
+        begin_line: str = block_lines[0]
         error_expected = cls.CONSOLE_STDERR in begin_line
         include_cmd = cls.CONSOLE_CMD in begin_line
         command = (
-            begin_line.replace('%', '')
-            .replace(cls.CONSOLE_BEGIN, '')
-            .replace(cls.CONSOLE_STDERR, '')
-            .replace(cls.CONSOLE_CMD, '')
-            .replace('aslref', ASLREF_EXE)
-            .replace('\\definitiontests', '../tests/ASLDefinition.t')
-            .replace('\\syntaxtests', '../tests/ASLSyntaxReference.t')
-            .replace('\\typingtests', '../tests/ASLTypingReference.t')
-            .replace('\\semanticstests', '../tests/ASLSemanticsReference.t')
-            .replace('\n', '')
+            begin_line.replace("%", "")
+            .replace(cls.CONSOLE_BEGIN, "")
+            .replace(cls.CONSOLE_STDERR, "")
+            .replace(cls.CONSOLE_CMD, "")
+            .replace("aslref", ASLREF_EXE)
+            .replace("\\definitiontests", "../tests/ASLDefinition.t")
+            .replace("\\syntaxtests", "../tests/ASLSyntaxReference.t")
+            .replace("\\typingtests", "../tests/ASLTypingReference.t")
+            .replace("\\semanticstests", "../tests/ASLSemanticsReference.t")
+            .replace("\n", "")
             .strip()
         )
         if debug:
-            print(f'Executing {command}')
-        transformed_lines = execute_and_capture_output(command, error_expected).splitlines()
+            print(f"Executing {command}")
+        transformed_lines = execute_and_capture_output(
+            command, error_expected
+        ).splitlines()
         end_line = block_lines[-1]
-        transformed_lines = [
-            begin_line,
-            '\\begin{Verbatim}[fontsize=\\footnotesize, frame=single]'
-        ] + (['> ' + command] if include_cmd else []) + transformed_lines + [
-            '\\end{Verbatim}',
-            end_line
-        ]
+        transformed_lines = (
+            [begin_line, "\\begin{Verbatim}[fontsize=\\footnotesize, frame=single]"]
+            + (["> " + command] if include_cmd else [])
+            + transformed_lines
+            + ["\\end{Verbatim}", end_line]
+        )
         return transformed_lines
 
+
+def transform_by_line(filenames: list[str], from_pattern: str, to_pattern: str):
+    r"""
+    Performs a line-by-line transformation for all files in 'filenames'.
+    Lines matching 'from_pattern' are transformed using the 'to_pattern'.
+
+    For example, the following substitutes a LaTeX macro:
+    transform_by_line(
+        files,
+        r"All of the following apply \(\\textsc{(.*?)}\)",
+        r"\\AllApplyCase{\1}"
+    )
+    """
+    num_changes = 0
+    for filename in filenames:
+        new_lines: list[str] = []
+        lines: list[str] = []
+        with open(filename, "r", encoding="utf-8") as file:
+            lines = file.readlines()
+        for line_number, line in enumerate(lines, start=1):
+            new_line = re.sub(from_pattern, to_pattern, line)
+            new_lines.append(new_line)
+            if new_line != line:
+                print(
+                    f"{filename} {line_number}: transformed from '{line.strip()}' to '{new_line.strip()}'"
+                )
+                num_changes += 1
+        with open(filename, "w", encoding="utf-8") as file:
+            file.writelines(new_lines)
+    if num_changes > 0:
+        print(f"Performed {num_changes} line transformations")
+
+
 def apply_all_macros():
-    print('Extended macros: applying all macros... ')
-    ConsoleMacro.apply_to_files(get_latex_sources(True))
-    print('Extended macros: done')
+    print("Extended macros: applying all macros... ")
+    pruned_latex_sources = get_latex_sources(True)
+    ConsoleMacro.apply_to_files(pruned_latex_sources)
+    transform_by_line(
+        pruned_latex_sources,
+        r"\\AllApplyCase{(.*?)}:",
+        r"\\AllApplyCase{\1}",
+    )
+    transform_by_line(
+        pruned_latex_sources,
+        r"\\AllApply:",
+        r"\\AllApply",
+    )
+    transform_by_line(
+        pruned_latex_sources,
+        r"\\OneApplies:",
+        r"\\OneApplies",
+    )
+    print("Extended macros: done")
+
 
 def main():
     apply_all_macros()
+
 
 if __name__ == "__main__":
     main()

--- a/asllib/doc/extended_macros.py
+++ b/asllib/doc/extended_macros.py
@@ -13,14 +13,17 @@ def yellow_error_message(msg: str) -> str:
     COLOR_RESET = '\033[m'
     return YELLOW + msg + COLOR_RESET
 
-def get_latex_sources() -> list[str]:
+def get_latex_sources(exclude) -> list[str]:
     r"""
-    Returns the list of .tex files in the current directory,
-    excluding macros.tex.
+    Returns the list of .tex files in the current directory.
+    If 'exclude' is True, common files that are not required
+    for transformation and linting are excluded.
     """
     latex_files = fnmatch.filter(os.listdir('.'), '*.tex')
-    if 'macros.tex' in latex_files:
-        latex_files.remove('macros.tex')
+    if exclude:
+        excluded_files = ['ASLReference.tex', 'ASLmacros.tex', 'ASLRefALP2.1ChangeLog.tex', 'ASLRefALP2ChangeLog.tex']
+        for excluded_file in excluded_files:
+            latex_files.remove(excluded_file)
     return latex_files
 
 def execute_and_capture_output(command: str, error_expected: bool) -> str:
@@ -209,7 +212,7 @@ class ConsoleMacro(BlockMacro):
 
 def apply_all_macros():
     print('Extended macros: applying all macros... ')
-    ConsoleMacro.apply_to_files(get_latex_sources())
+    ConsoleMacro.apply_to_files(get_latex_sources(True))
     print('Extended macros: done')
 
 def main():

--- a/asllib/doc/introduction.tex
+++ b/asllib/doc/introduction.tex
@@ -45,7 +45,7 @@ ASL does not have support for:
 \end{itemize}
 
 A \emph{\specificationterm} consists of a self-contained collection of ASL code.
-\lrmcomment{\identd{GVBK}}
+\identd{GVBK}
 More specifically, a \specificationterm\ is the set of \globaldeclarationsterm\
 written in ASL code which describe an architecture.
 

--- a/asllib/tests/ASLDefinition.t/Bitvector_rotate.asl
+++ b/asllib/tests/ASLDefinition.t/Bitvector_rotate.asl
@@ -1,0 +1,15 @@
+func rotate_right{N}(src: bits(N), amount: integer) => bits(N)
+begin
+    let i = (amount MOD N) as integer {0..N-1};
+    // upper may be a zero width bitvector
+    let upper: bits(i) = src[0+:i];
+    let lower: bits(N-i) = src[i+:N-i];
+    return upper :: lower;
+end;
+
+func main() => integer
+begin
+    var bv = '10100';
+    println("bv=", bv, ", rotated twice=", rotate_right{5}(bv, 2));
+    return 0;
+end;

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -10,6 +10,8 @@ Examples used in ASL High-level Definition:
   $ aslref --no-exec Bitfields.asl
   $ aslref Bitfields_nested.asl
   $ aslref Bitvector_slices.asl
+  $ aslref Bitvector_rotate.asl
+  bv=0x14, rotated twice=0x05
 
   $ aslref CaseStatement.discriminant.asl
   num_tests: 0

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDVar1.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LDVar1.asl
@@ -1,9 +1,0 @@
-func main () => integer
-begin
-
-  var x : integer = 3;
-
-  assert x == 3;
-
-  return 0;
-end;

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -128,7 +128,6 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.LESlice.asl
   $ aslref SemanticsRule.LESetField.asl
   $ aslref SemanticsRule.LEDestructuring.asl
-  $ aslref SemanticsRule.LDVar1.asl
   $ aslref SemanticsRule.SliceSingle.asl
   $ aslref SemanticsRule.SliceLength.asl
   $ aslref SemanticsRule.SliceRange.asl

--- a/asllib/tests/ASLSyntaxReference.t/Lexical.Comments.asl
+++ b/asllib/tests/ASLSyntaxReference.t/Lexical.Comments.asl
@@ -1,7 +1,7 @@
 // Comment example 1.
 
-// In next line, the two strings "/*" and "*/" are regular characters within the comment
-// start of comment, /* still in comment */ and still in comment which ends with newline
+// In the next line, "/*" and "*/" are regular strings within the comment
+// start of comment, /* still in comment */ and still in comment, ending with newline
 
 /* line 1 of example 2, a single comment 4 lines long.
 line 2 of the comment

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateConstraint.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateConstraint.asl
@@ -1,0 +1,16 @@
+func foo{M}(bv: bits(M)) => integer
+begin
+    var z: integer{3*M} = 3*M; // type of z: integer {(3 * M)}
+    return z;
+end;
+
+constant N = 15;
+
+func main() => integer
+begin
+  let x: integer{1..2*N} = 1;   // type of x: integer {1..30}
+  let t: integer{x..x+1} = 2;   // type of t: integer {1..2}
+  var y: integer{x, t};         // type of y: integer {1, 2}
+
+  return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateConstraint.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateConstraint.bad.asl
@@ -1,0 +1,6 @@
+func main() => integer
+begin
+  var x : integer = 1;
+  let t: integer{x..x+1} = 2; // illegal as 'x' is not constrained.
+  return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateSymbolicallyEvaluableExpr.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateSymbolicallyEvaluableExpr.asl
@@ -1,0 +1,31 @@
+func pure_func(x: integer, y: integer) => integer
+begin
+    return x * y + y;
+end;
+
+type my_exception of exception {};
+
+func impure_func(x: integer, y: integer) => integer
+begin
+    if x == 0 then
+        throw my_exception{};
+    end;
+    return x * y + y;
+end;
+
+let I = pure_func(7, 3);
+var M = pure_func(7, 3);
+
+func main() => integer
+begin
+    // Right-hand-side expression is symbolically evaluable?
+    var - = 9;                      // Yes: literals are immutable
+    var x = pure_func(5, 6) + 9;    // Yes: 'pure_func' is side-effect-free
+    var - = I;                      // Yes: 'I' is immutable.
+    var - = impure_func(5, 6);      // No: 'impure_func' may throw an exception.
+    var - = x;                      // No: 'x' is mutable.
+    var - = M;                      // Yes: 'M' is immutable.
+    // Only symbolically evaluable expressions can be array length expressions:
+    var - : array[[pure_func(5, 6) + 9 + I]] of integer;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinSingularTypes.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinSingularTypes.asl
@@ -6,5 +6,6 @@ begin
   let b : boolean = TRUE;
   let z4 : bits(4) = '0000';
   let o2 : bits(2) = '11';
+  let o: bit = '1';
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.GetVariableEnum.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.GetVariableEnum.asl
@@ -1,0 +1,10 @@
+type Key of enumeration {One, Two, Three};
+type SubKey subtypes Key;
+
+func main() => integer
+begin            // The right-hand-side expression is | Reason:
+    var x = 5;   // Not an enumeration variable       | not a variable expression
+    var - = x;   // Not an enumeration variable       | x is integer-typed
+    var - = One; // An enumeration variable           | the underlying type is Key
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.InheritIntegerConstraints.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.InheritIntegerConstraints.asl
@@ -1,0 +1,10 @@
+constant max_bits = 64;
+var b : integer{1..5, 7, 20..max_bits};
+var c : integer{6..9};
+
+func main() => integer
+begin
+    var e : integer{-} = b + c;
+    var f : integer{-} = 5;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.InheritIntegerConstraints.unconstrained.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.InheritIntegerConstraints.unconstrained.bad.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    var a : integer;
+    // The following is illegal as 'a' is not a constrained integer.
+    var g : integer{-} = a;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TArray.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TArray.bad.asl
@@ -1,0 +1,10 @@
+func foo(symbolically_evaluable_var: integer)
+begin
+    var legal_array: array [[symbolically_evaluable_var]] of integer;
+    let symbolically_evaluable_var2 = symbolically_evaluable_var * 2;
+    var legal_array2: array [[symbolically_evaluable_var2]] of integer;
+
+    // Illegal as non_symbolically_evaluable is mutable.
+    var non_symbolically_evaluable = 5;
+    var illegal_array: array [[non_symbolically_evaluable]] of integer;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TBits.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TBits.asl
@@ -1,21 +1,16 @@
-type MyType of bits(4);
+type MyType of bits(4); // Bitvector types can be aliased
 
-func foo (x: bits(4)) => bits(4)
+func foo(x: bits(4)) => bits(4)
 begin
   return NOT x;
 end;
 
-func main () => integer
+func main() => integer
 begin
   var x: bits(4);
-
   x = '1010';
-  x = foo (x as bits(4));
-  
+  x = foo(x as bits(4));
   let y: bits(4) = x;
-
   assert x as bits(4) == x;
-
   return 0;
 end;
-

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TEnumDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TEnumDecl.asl
@@ -2,12 +2,9 @@ type Color of enumeration { GREEN, ORANGE, RED };
 
 func rotate_color(c : Color) => Color
 begin
-    if c == GREEN then
-        return ORANGE;
-    end;
-    if c == ORANGE then
-        return RED;
-    else // c == RED
-        return GREEN;
+    case c of
+        when GREEN => return ORANGE;
+        when ORANGE => return RED;
+        when RED => return GREEN;
     end;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TEnumDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TEnumDecl.asl
@@ -1,1 +1,13 @@
-type MyEnum of enumeration { A, B, C };
+type Color of enumeration { GREEN, ORANGE, RED };
+
+func rotate_color(c : Color) => Color
+begin
+    if c == GREEN then
+        return ORANGE;
+    end;
+    if c == ORANGE then
+        return RED;
+    else // c == RED
+        return GREEN;
+    end;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TEnumDecl.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TEnumDecl.bad.asl
@@ -1,0 +1,3 @@
+constant GREEN = 1;
+type Color of enumeration { GREEN, ORANGE, RED }; // Illegal: GREEN already declared.
+type Status of enumeration { OK, RED }; // Illegal: RED already declared.

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TExceptionDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TExceptionDecl.asl
@@ -1,0 +1,11 @@
+type MyException of exception { a: integer, b: boolean };
+type ExceptionWithEmptyFieldList of exception;
+type ExceptionWithoutFields of exception;
+
+func main() => integer
+begin
+    var - = MyException {a = 3, b = TRUE};
+    var - = ExceptionWithEmptyFieldList {};
+    var - = ExceptionWithoutFields {};
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TInt.global_pending_constrained.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TInt.global_pending_constrained.bad.asl
@@ -1,0 +1,2 @@
+// Pending-constrained types are illegal in global declarations.
+var d : integer{-} = 5;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TInt.rhs_pending_constrained.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TInt.rhs_pending_constrained.bad.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    // Pending-constrained integer types are illegal
+    // on in right-hand-side expressions.
+    var x : integer{1..2} = 3 as integer{-};
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TInt.rhs_pending_constrained.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TInt.rhs_pending_constrained.bad.asl
@@ -1,7 +1,7 @@
 func main() => integer
 begin
     // Pending-constrained integer types are illegal
-    // on in right-hand-side expressions.
+    // in right-hand-side expressions.
     var x : integer{1..2} = 3 as integer{-};
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TIntParameterized.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TIntParameterized.asl
@@ -3,9 +3,9 @@ begin
   return N;
 end;
 
-func bar{N}() => bits(N)
+func bar{M: integer}() => bits(M)
 begin
-  return Zeros{N};
+  return Zeros{M};
 end;
 
 func main() => integer

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TIntUnconstrained.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TIntUnconstrained.asl
@@ -11,7 +11,7 @@ begin
   x = 4;
   x = (x + foo (x as integer)) - 1000;
 
-  let z: integer{5} = 5;
+  let z: integer = 5;
   let w = foo(z);
   let y: integer = x * z;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TIntUnconstrained.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TIntUnconstrained.asl
@@ -1,4 +1,4 @@
-type MyType of integer; 
+type MyType of integer;
 func foo (x: integer) => integer
 begin
   return x;
@@ -9,12 +9,13 @@ begin
   var x: integer;
 
   x = 4;
-  x = foo (x as integer);
-  
-  let y: integer = x;
+  x = (x + foo (x as integer)) - 1000;
+
+  let z: integer{5} = 5;
+  let w = foo(z);
+  let y: integer = x * z;
 
   assert x as integer == x;
 
   return 0;
 end;
-

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TIntWellConstrained.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TIntWellConstrained.asl
@@ -1,22 +1,26 @@
-type MyType of integer {1..12};
+type MyType of integer{1..12}; // Name a well-constrained integer type.
 
-func foo (x: integer {1..12}) => integer {1..12}
+func foo(x: integer{1..7}) => integer{1..12}
 begin
   return x;
 end;
 
 func main () => integer
 begin
-  var x: integer {1..12};
-
+  var x: integer{1..12};
   x = 4;
-  x = foo (x as integer {1..12});
-  
-  let y: integer {1..12} = x;
+  x = foo(x as integer{1..7});
 
-  let x2 = x as integer {1..11};
+  let y: integer{1..12} = x;
+  let x2 = x as integer{1..11};
   assert x2 == x;
+
+  let z : integer{2..24} = x + y;
+  // The type of 'w' is inferred to be integer{2..24}.
+  var w = x + y;
+  w = z;
+
+  var c = 3; // The type of 'c' is inferred to be integer{3}.
 
   return 0;
 end;
-

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TReal.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TReal.asl
@@ -1,6 +1,6 @@
 type MyType of real; // An alias of real
 
-func circle_circumferece(radius: real) => real
+func circle_circumference(radius: real) => real
 begin
   let pi = 3.141592;
   return 2.0 * pi * radius;
@@ -9,7 +9,7 @@ end;
 func main() => integer
 begin
   var x: real = Real(5);
-  x = circle_circumferece(x as real);
+  x = circle_circumference(x as real);
   assert x as real == x;
   let y: integer = RoundDown(x);
   return 0;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TReal.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TReal.asl
@@ -1,21 +1,16 @@
-type MyType of real;
+type MyType of real; // An alias of real
 
-func foo (x: real) => real
+func circle_circumferece(radius: real) => real
 begin
-  return x + 1.0;
+  let pi = 3.141592;
+  return 2.0 * pi * radius;
 end;
 
-func main () => integer
+func main() => integer
 begin
-  var x: real;
-
-  x = 3.141592;
-  x = foo (x as real);
-  
-  let y: real = x + x;
-
+  var x: real = Real(5);
+  x = circle_circumferece(x as real);
   assert x as real == x;
-
+  let y: integer = RoundDown(x);
   return 0;
 end;
-

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TRecordDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TRecordDecl.asl
@@ -1,0 +1,11 @@
+type MyRecord of record { a: integer, b: boolean };
+type RecordWithEmptyFieldList of record {};
+type RecordWithoutFields of record;
+
+func main() => integer
+begin
+    var - = MyRecord {a = 3, b = TRUE};
+    var - = RecordWithEmptyFieldList {};
+    var - = RecordWithoutFields {};
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TRecordExceptionDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TRecordExceptionDecl.asl
@@ -1,6 +1,0 @@
-type MyRecord of record { a: integer, b: boolean };
-type MyException of exception { a: integer, b: boolean };
-
-func main () => integer
-begin return 0; end;
-

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TString.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TString.asl
@@ -1,20 +1,15 @@
-type MyType of string;
+type MyType of string; // An alias of string
 
-func foo (x: string) => string
+func foo(x: string) => string
 begin
   return x;
 end;
 
-func main () => integer
+func main() => integer
 begin
-  var x: string;
-
-  x = "foo";
-  x = foo (x as string);
-  
-  let y: string = x;
-
+  var x: string = "foo";
   assert x as string == x;
-
+  x = foo(x as string);
+  let y: string = x;
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TTuple.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TTuple.asl
@@ -1,22 +1,21 @@
-type MyType of (integer, boolean);
+type MyType of (integer, boolean); // Tuple types can be aliased.
 
-func foo (x: (integer, boolean)) => (integer, boolean)
+func foo(x: (integer, boolean)) => (integer, boolean)
 begin
   let (z, y): (integer, boolean) = x;
   return (z + 1, FALSE --> y);
 end;
 
-func main () => integer
+func main() => integer
 begin
   var x: (integer, boolean);
-
   x = (3, TRUE);
-  x = foo (x as (integer, boolean));
-  
+  x = foo(x as(integer, boolean));
   let y: (integer, boolean) = x;
 
-  let (x0, x1) = x as (integer, boolean);
+  let (x0, x1) = x as (integer, boolean); // Tuples can be deconstructed.
   assert x0 == 4 && x1 == TRUE;
-
+  // Tuple elements can be accessed via field-like notation.
+  assert x0 == x.item0 && x1 == x.item1;
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -52,6 +52,7 @@ ASL Typing Tests / annotating types:
   [1]
 
   $ aslref TypingRule.AnnotateConstraint.asl
+  $ aslref TypingRule.AnnotateConstraint.bad.asl
 
   $ aslref TypingRule.TBits.asl
   $ aslref TypingRule.TTuple.asl

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -29,9 +29,28 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.TReal.asl
   $ aslref TypingRule.TBool.asl
   $ aslref TypingRule.TNamed.asl
-  $ aslref TypingRule.TIntUnConstrained.asl
+  $ aslref TypingRule.TIntUnconstrained.asl
   $ aslref TypingRule.TIntWellConstrained.asl
   $ aslref TypingRule.TIntParameterized.asl
+  $ aslref TypingRule.InheritIntegerConstraints.asl
+  $ aslref TypingRule.InheritIntegerConstraints.unconstrained.bad.asl
+  File TypingRule.InheritIntegerConstraints.unconstrained.bad.asl, line 5,
+    characters 4 to 27:
+  ASL Typing error: constrained integer expected, provided integer.
+  [1]
+
+  $ aslref TypingRule.TInt.global_pending_constrained.bad.asl
+  File TypingRule.TInt.global_pending_constrained.bad.asl, line 2,
+    characters 0 to 23:
+  ASL Typing error: a pending constrained integer is illegal here.
+  [1]
+
+  $ aslref TypingRule.TInt.rhs_pending_constrained.bad.asl
+  File TypingRule.TInt.rhs_pending_constrained.bad.asl, line 5,
+    characters 28 to 43:
+  ASL Typing error: a pending constrained integer is illegal here.
+  [1]
+
   $ aslref TypingRule.TBits.asl
   $ aslref TypingRule.TTuple.asl
   $ aslref TypingRule.TArray.asl

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -51,6 +51,8 @@ ASL Typing Tests / annotating types:
   ASL Typing error: a pending constrained integer is illegal here.
   [1]
 
+  $ aslref TypingRule.AnnotateConstraint.asl
+
   $ aslref TypingRule.TBits.asl
   $ aslref TypingRule.TTuple.asl
   $ aslref TypingRule.TArray.asl

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -74,7 +74,8 @@ ASL Typing Tests / annotating types:
   ASL Typing error: cannot declare already declared element "RED".
   [1]
   $ aslref --no-exec TypingRule.GetVariableEnum.asl
-  $ aslref TypingRule.TRecordExceptionDecl.asl
+  $ aslref TypingRule.TRecordDecl.asl
+  $ aslref TypingRule.TExceptionDecl.asl
   $ aslref TypingRule.TNonDecl.asl
   File TypingRule.TNonDecl.asl, line 1, characters 5 to 6:
   ASL Error: Cannot parse.

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -53,6 +53,10 @@ ASL Typing Tests / annotating types:
 
   $ aslref TypingRule.AnnotateConstraint.asl
   $ aslref TypingRule.AnnotateConstraint.bad.asl
+  File TypingRule.AnnotateConstraint.bad.asl, line 4, characters 17 to 18:
+  ASL Typing error: a pure expression was expected, found x, which produces the
+    following side-effects: [ReadsLocal "x"].
+  [1]
 
   $ aslref TypingRule.TBits.asl
   $ aslref TypingRule.TTuple.asl

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -61,7 +61,19 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.TBits.asl
   $ aslref TypingRule.TTuple.asl
   $ aslref TypingRule.TArray.asl
+  $ aslref TypingRule.TArray.bad.asl
+  File TypingRule.TArray.bad.asl, line 9, characters 31 to 57:
+  ASL Typing error: a pure expression was expected,
+    found non_symbolically_evaluable, which produces the following
+    side-effects: [ReadsLocal "non_symbolically_evaluable"].
+  [1]
+  $ aslref TypingRule.AnnotateSymbolicallyEvaluableExpr.asl
   $ aslref --no-exec TypingRule.TEnumDecl.asl
+  $ aslref --no-exec TypingRule.TEnumDecl.bad.asl
+  File TypingRule.TEnumDecl.bad.asl, line 2, characters 0 to 49:
+  ASL Typing error: cannot declare already declared element "RED".
+  [1]
+  $ aslref --no-exec TypingRule.GetVariableEnum.asl
   $ aslref TypingRule.TRecordExceptionDecl.asl
   $ aslref TypingRule.TNonDecl.asl
   File TypingRule.TNonDecl.asl, line 1, characters 5 to 6:


### PR DESCRIPTION
* Added prose and examples to the Types chapter.
* Standardized examples - they all use the `\ExampleDef` macro, which means they are all captioned.
* Moved many examples to the beginning of rule definitions. This helps automate finding which rules miss examples.
* Typing.ml: renamed c`heck_structure_integer` -> `check_underlying_integer`, since it `uses make_anonymous` rather than `get_structure`.
* Replaced many teletype variables (things like, `\texttt{v_a}`) with proper macros.
* Removed many `\lrmcomment` macro instances.
* Made `\idenX` macros silent.
* Removed redundant `\hypertarget` instances.
* Standardized usage of `\AllApply`, `\AllApplyCase`, and `\OneApplies`.
* Added missing paragraph statements, e.g., in `SemanticsRule.LEMultiAssign` and `SemanticsRule.EExprList`
* Defined statically evaluable to mean evaluates to a literal.