### PR TITLE
[test] Regression test from  the catalogue in ASL mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ else
 	J=$(shell nproc)
 endif
 
-
 REGRESSION_TEST_MODE = test
 # REGRESSION_TEST_MODE = promote
 # REGRESSION_TEST_MODE = show
@@ -381,6 +380,23 @@ cata-aarch64-test:
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 catalogue aarch64 tests: OK"
 
+test-all:: cata-aarch64-test-asl
+cata-test-asl:: cata-aarch64-test-asl
+cata-aarch64-test-asl: asl-pseudocode
+	@ echo
+	$(HERD_CATALOGUE_REGRESSION_TEST) \
+		-j $(J) \
+		-variant asl+exp \
+		-variant strict \
+		-herd-timeout $(TIMEOUT) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-kinds-path catalogue/aarch64/tests/kinds.txt \
+		-shelf-path catalogue/aarch64/shelf.py \
+		-conf-path catalogue/aarch64/cfgs/asl.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 catalogue aarch64 tests (ASL): OK"
+
 cata-test:: aarch64-test-mixed
 aarch64-test-mixed:
 	@ echo
@@ -418,6 +434,22 @@ pick-test:
 		-shelf-path catalogue/aarch64-pick/shelf.py \
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 catalogue aarch64-pick tests: OK"
+
+test-all:: pick-test-asl
+cata-test-asl:: pick-test-asl
+pick-test-asl:  asl-pseudocode
+	@ echo
+	$(HERD_CATALOGUE_REGRESSION_TEST) \
+		-j $(J) \
+		-variant asl+exp \
+		-variant strict \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-kinds-path catalogue/aarch64-pick/tests/desired-kinds.txt \
+		-shelf-path catalogue/aarch64-pick/shelf.py \
+		-conf-path catalogue/aarch64-pick/cfgs/asl.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 catalogue aarch64-pick tests (ASL): OK"
 
 cata-test:: faults-test
 faults-test:

--- a/catalogue/aarch64-pick/cfgs/asl.cfg
+++ b/catalogue/aarch64-pick/cfgs/asl.cfg
@@ -1,0 +1,2 @@
+#Fixed by PR #1179
+nonames LB+rel+CAS

--- a/catalogue/aarch64/cfgs/asl.cfg
+++ b/catalogue/aarch64/cfgs/asl.cfg
@@ -1,0 +1,10 @@
+#ASL takes more time, overrides Makefile setting
+timeout 60
+#Fixed by PR #1179
+nonames LB+rel+CAS
+#Fixed by PR #1206
+nonames MP+rel+CASacq-noret-ok
+#All similar
+nonames MP+rel+CASnoret-ok-dmb.ld,MP+rel+SWPnoret-dmb.ld,MP+rel+LDADDnoret-dmb.ld
+#Different
+nonames LB+rel+CAS-ok-RsRs-addr


### PR DESCRIPTION
Two new entries are added in the Makefile:
  + `make cata-aarch64-test-asl` for testing
     the AArch64 catalogue in ASL mode
  + `make pick-test-asl` for pick test in ASL mode

With make `cata-test-asl` one runs both entries. The new entries are also run by `make test-all`.

Interestingly, the new tests reveal discrepancies with expected kinds:
```
% make cata-aarch64-test-asl 
...
Kinds differs: kinds file = catalogue/aarch64/tests/kinds.txt ; cat = "cats/aarch64.cat"
LB+rel+CAS-ok-RsRs-addr: expected=Allowed, actual=Forbidden
LB+rel+CAS: expected=Forbidden, actual=Allowed
MP+rel+CASacq-noret-ok: expected=Allowed, actual=Forbidden
MP+rel+CASnoret-ok-dmb.ld: expected=Allowed, actual=Forbidden
MP+rel+LDADDnoret-dmb.ld: expected=Allowed, actual=Forbidden
MP+rel+SWPnoret-dmb.ld: expected=Allowed, actual=Forbidden
make: *** [cata-aarch64-test-asl] Error 1
```
And
```
% make pick-test-asl
...
Kinds differs: kinds file = catalogue/aarch64-pick/tests/desired-kinds.txt ; cat = "cats/aarch64.cat"
LB+rel+CAS: expected=Forbidden, actual=Allowed
make: *** [pick-test-asl] Error 1
```

Pleas notice that for now the tests that fail are excluded, so that  `make cata-aarch64-test-asl`  and ``make pick-test-asl` now succeed.
