### PR TITLE
[asl] Ensure `<->` is parsed to `BEQ`

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -205,7 +205,7 @@ let binop ==
   | AND         ; { AND    }
   | BAND        ; { BAND   }
   | BOR         ; { BOR    }
-  | BEQ         ; { EQ_OP  }
+  | BEQ         ; { BEQ    }
   | DIV         ; { DIV    }
   | DIVRM       ; { DIVRM  }
   | EOR         ; { EOR    }

--- a/asllib/doc/.gitignore
+++ b/asllib/doc/.gitignore
@@ -5,3 +5,4 @@ comment.cut
 *.bbl
 *.blg
 *.dvi
+__pycache__

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -111,7 +111,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[]{}{
-  \buildbinop(\Nbinop(\Tbeq)) \astarrow \overname{\EQOP}{\vastnode}
+  \buildbinop(\Nbinop(\Tbeq)) \astarrow \overname{\BEQ}{\vastnode}
 }
 \end{mathpar}
 

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -251,6 +251,11 @@ Parameterized integers:
   ASL Error: Cannot parse.
   [1]
 
+  $ aslref same-precedence2.asl
+  File same-precedence2.asl, line 6, characters 10 to 17:
+  ASL Error: Cannot parse.
+  [1]
+
   $ aslref rdiv_checks.asl
   File rdiv_checks.asl, line 3, characters 12 to 25:
   ASL Typing error: Illegal application of operator / on types real and string.

--- a/asllib/tests/regressions.t/same-precedence2.asl
+++ b/asllib/tests/regressions.t/same-precedence2.asl
@@ -1,0 +1,9 @@
+func main () => integer
+begin
+  let a = TRUE;
+  let b = TRUE;
+  let c = TRUE;
+  let - = a --> b <-> c;
+
+  return 0;
+end;


### PR DESCRIPTION
Bug report by @acjf3. Previously, `<->` was parsed to `EQ_OP` (like `==`), so some programs were accepted when they should have been rejected due to bad precedence, e.g.:
```
a --> b <-> c
```

Also add `__pycache__` to `asllib/doc/.gitignore`.