### PR TITLE
[asl] Updates to `config`s

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -472,13 +472,9 @@ let local_decl_keyword_non_var :=
   | VAR       ; { LDK_Var       }
   *)
 
-let global_decl_keyword_non_var :=
+let global_let_or_constant :=
   | LET       ; { GDK_Let      }
   | CONSTANT  ; { GDK_Constant }
-  | CONFIG    ; { GDK_Config   }
-  (* Var conflicts with global_uninit_var and as such is inlined in the decl production
-  | VAR       ; { GDK_Var      }
-  *)
 
 let pass == { S_Pass }
 let assign(x, y) == ~=x ; EQ ; ~=y ; < S_Assign >
@@ -664,9 +660,12 @@ let decl :=
       | TYPE; x=IDENTIFIER; s=annotated(subtype);         < make_ty_decl_subtype >
       (* End *)
       (* Begin global_storage *)
-      | keyword=global_decl_keyword_non_var; name=ignored_or_identifier;
+      | keyword=global_let_or_constant; name=ignored_or_identifier;
         ty=option(as_ty); EQ; initial_value=some(expr);
         { D_GlobalStorage { keyword; name; ty; initial_value } }
+      | CONFIG; name=ignored_or_identifier;
+        ty=as_ty; EQ; initial_value=some(expr);
+        { D_GlobalStorage { keyword=GDK_Config; name; ty=Some ty; initial_value } }
       | VAR; name=ignored_or_identifier;
         ty=option(as_ty); EQ; initial_value=some(expr);
         { D_GlobalStorage { keyword=GDK_Var; name; ty; initial_value } }

--- a/asllib/SideEffect.ml
+++ b/asllib/SideEffect.ml
@@ -4,21 +4,18 @@ module ISet = ASTUtils.ISet
 module IMap = ASTUtils.IMap
 
 module TimeFrame = struct
-  type t = Constant | Config | Execution
+  type t = Constant | Execution
 
   let equal t1 t2 =
     match (t1, t2) with
-    | Constant, Constant | Config, Config | Execution, Execution -> true
-    | Constant, (Config | Execution)
-    | Config, (Constant | Execution)
-    | Execution, (Config | Constant) ->
-        false
+    | Constant, Constant | Execution, Execution -> true
+    | Constant, Execution | Execution, Constant -> false
 
   let is_before t1 t2 =
     match (t1, t2) with
-    | Constant, Constant | Config, Config | Execution, Execution -> true
-    | Config, Execution | Constant, (Config | Execution) -> true
-    | Execution, Config | (Config | Execution), Constant -> false
+    | Constant, Constant | Execution, Execution -> true
+    | Constant, Execution -> true
+    | Execution, Constant -> false
 
   let max t1 t2 = if is_before t1 t2 then t2 else t1
 
@@ -29,9 +26,7 @@ module TimeFrame = struct
   let of_gdk =
     let open AST in
     function
-    | GDK_Constant -> Constant
-    | GDK_Config -> Config
-    | GDK_Let | GDK_Var -> Execution
+    | GDK_Constant -> Constant | GDK_Config | GDK_Let | GDK_Var -> Execution
 end
 
 type read = { name : identifier; time_frame : TimeFrame.t; immutable : bool }

--- a/asllib/SideEffect.mli
+++ b/asllib/SideEffect.mli
@@ -1,7 +1,7 @@
 type identifier = string
 
 module TimeFrame : sig
-  type t = Constant | Config | Execution
+  type t = Constant | Execution
 
   val is_before : t -> t -> bool
   val max : t -> t -> t

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -492,7 +492,7 @@
 \newcommand\Ntydecl[0]{\hyperlink{def-ntydecl}{\nonterminal{ty\_decl}}}
 \newcommand\Nsubtype[0]{\hyperlink{def-nsubtype}{\nonterminal{subtype}}}
 \newcommand\Nsubtypeopt[0]{\hyperlink{def-nsubtypeopt}{\nonterminal{subtype\_opt}}}
-\newcommand\Nglobaldeclkeyword[0]{\hyperlink{def-nglobaldeclkeyword}{\nonterminal{global\_decl\_keyword\_non\_var}}}
+\newcommand\Nglobaldeclkeyword[0]{\hyperlink{def-nglobaldeclkeyword}{\nonterminal{global\_let\_or\_constant}}}
 \newcommand\Nignoredoridentifier[0]{\hyperlink{def-nignoredoridentifier}{\nonterminal{ignored\_or\_identifier}}}
 \newcommand\Nty[0]{\hyperlink{def-nty}{\nonterminal{ty}}}
 \newcommand\Nexpr[0]{\hyperlink{def-nexpr}{\nonterminal{expr}}}
@@ -811,7 +811,7 @@
 \newcommand\buildtydecl[0]{\hyperlink{build-tydecl}{\textfunc{build\_ty\_decl}}}
 \newcommand\buildsubtype[0]{\hyperlink{build-subtype}{\textfunc{build\_subtype}}}
 \newcommand\buildsubtypeopt[0]{\hyperlink{build-subtypeopt}{\textfunc{build\_subtype\_opt}}}
-\newcommand\buildglobaldeclkeyword[0]{\hyperlink{build-globaldeclkeyword}{\textfunc{build\_global\_decl\_keyword\_non\_var}}}
+\newcommand\buildglobaldeclkeyword[0]{\hyperlink{build-globaldeclkeyword}{\textfunc{build\_global\_decl\_let\_or\_constant}}}
 \newcommand\builddirection[0]{\hyperlink{build-direction}{\textfunc{build\_direction}}}
 \newcommand\buildcasealt[0]{\hyperlink{build-casealt}{\textfunc{build\_case\_alt}}}
 \newcommand\buildcasealtlist[0]{\hyperlink{build-casealtlist}{\textfunc{build\_case\_alt\_list}}}
@@ -1332,7 +1332,6 @@
 
 \newcommand\TTimeFrame[0]{\hyperlink{def-timeframetype}{\textsf{TimeFrame}}}
 \newcommand\timeframeconstant[0]{\hyperlink{def-timeframeconstant}{\textsf{Constant}}}
-\newcommand\timeframeconfig[0]{\hyperlink{def-timeframeconfig}{\textsf{Config}}}
 \newcommand\timeframeexecution[0]{\hyperlink{def-timeframeexecution}{\textsf{Execution}}}
 \newcommand\timeframeless[0]{\hyperlink{def-timeframeless}{<_{\text{time}}}}
 \newcommand\timeframeleq[0]{\hyperlink{def-timeframeleq}{\leq_{\text{time}}}}

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -39,6 +39,7 @@ Global storage declarations:
 \begin{flalign*}
 \Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep &\\
     & \wrappedline\ \option{\Tcolon \parsesep \Nty} \parsesep \Teq \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Tconfig \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&\\
 \end{flalign*}
 

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -10,6 +10,25 @@ The semantics of a list of global storage declarations is defined in \SemanticsR
 where the list is ordered via \SemanticsRuleRef{BuildGlobalEnv}.
 The semantics of a single global storage declarations is defined in \SemanticsRuleRef{DeclareGlobal}.
 
+\section{Configurable Global Storage Declarations}
+Global storage declarations with keyword \texttt{config} aim to assist implementation-specific support for ``configuration'' of an ASL specification.
+In particular, implementations may provide mechanisms to override \texttt{config} values, such as:
+\begin{itemize}
+  \item Preprocessing source code before typechecking of a specification to rewrite initialisation expressions.
+  \item Internally modifying \texttt{config} values after typechecking but before evaluation of a specification.
+\end{itemize}
+Note that if modifying values after typechecking, care must be taken to ensure that the modified values remain compatible with the expected types of the original values.
+For example, a \texttt{config} value declared with type \texttt{integer{0..10}} can be modified to \texttt{5} but should not be modified to \texttt{11}.
+This is because as \texttt{5} is compatible with \texttt{integer{0..10}}, but \texttt{11} is not.
+
+The language supports such overriding mechanisms (and in particular, simplifies tracking of types for \texttt{config} storage elements) as follows:
+\begin{itemize}
+  \item The \texttt{config} keyword syntactically identifies configurable storage elements.
+  \item Types of \texttt{config} storage elements must be \emph{both} explicitly declared \emph{and} singular (\TypingRuleRef{SingularType}).
+  \item The \timeframeterm{} of \texttt{config} storage elements is $\timeframeexecution$, so their values are not relied upon by typechecking.
+  \item Values of \texttt{config} storage elements must have \timeframeterm{} less than of equal to $\timeframeconstant$, so they can depend only on constant values (and not other \texttt{config} storage elements for example).
+\end{itemize}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Syntax\label{sec:GlobalStorageDeclarationsSyntax}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -16,6 +16,7 @@ The semantics of a single global storage declarations is defined in \SemanticsRu
 \begin{flalign*}
 \Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep &\\
         & \wrappedline\ \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+  |\ & \Tconfig \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 	|\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
         & \wrappedline\ \Nexpr \parsesep \Tsemicolon &\\
         |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&\\
@@ -23,7 +24,7 @@ The semantics of a single global storage declarations is defined in \SemanticsRu
 \end{flalign*}
 
 \begin{flalign*}
-\Nglobaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant \;|\; \Tconfig&\\
+\Nglobaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant&\\
 \Nignoredoridentifier \derives \ & \Tminus \;|\; \Tidentifier &
 \end{flalign*}
 
@@ -47,7 +48,7 @@ The semantics of a single global storage declarations is defined in \SemanticsRu
 
 \ASTRuleDef{GlobalStorageDecl}
 \begin{mathpar}
-\inferrule[global\_storage]{
+\inferrule[global\_storage\_let\_or\_constant]{
   \buildglobaldeclkeyword(\keyword) \astarrow \astof{\keyword}\\
   \buildoption[\buildasty](\tty) \astarrow \ttyp\\
   \buildexpr(\vinitialvalue) \typearrow \astof{\vinitialvalue}
@@ -117,6 +118,19 @@ The semantics of a single global storage declarations is defined in \SemanticsRu
 }
 \end{mathpar}
 
+\begin{mathpar}
+\inferrule[global\_storage\_config]{
+  \buildignoredoridentifier(\cname) \astarrow \name
+}{
+  {
+    \begin{array}{r}
+      \builddecl(\overname{\Ndecl(\Tconfig, \namednode{\cname}{\Nignoredoridentifier}, \Tcolon, \punnode{\Nty}, \Teq, \punnode{\Nexpr}, \Tsemicolon)}{\vparsednode}) \astarrow
+    \end{array}
+  } \\
+  \overname{\DGlobalStorage(\{ \GDkeyword: \GDKConfig, \GDname: \name, \GDty: \Some{\astof{\vt}}, \GDinitialvalue: \Some{\astof{\vexpr}}\})}{\vastnode}
+}
+\end{mathpar}
+
 \ASTRuleDef{GlobalDeclKeyword}
 \hypertarget{build-globaldeclkeyword}{}
 The function
@@ -141,17 +155,6 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
   \buildglobaldeclkeyword(\overname{\Nglobaldeclkeyword(\Tconstant)}{\vparsednode}) \astarrow \\
   \overname{\GDKConstant}{\vastnode}
 \end{array}
-  }
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[config]{}{
-  {
-  \begin{array}{r}
-    \buildglobaldeclkeyword(\overname{\Nglobaldeclkeyword(\Tconfig)}{\vparsednode}) \astarrow \\
-    \overname{\GDKConfig}{\vastnode}
-  \end{array}
   }
 }
 \end{mathpar}
@@ -213,7 +216,7 @@ yielding a modified global static environment $\newgenv$ and annotated global st
         \optional\ type $\tyopt$, and name $\name$;
   \item checking that $\name$ is not already declared in $\genv$ yields $\True$\ProseOrTypeError;
   \item applying $\withemptylocal$ to $\genv$ yields $\tenv$;
-  \item applying $\timeframeofgdk$ to $\keyword$ yields $\vtargettimeframe$;
+  \item define $\vtargettimeframe$ as $\timeframeconstant$ if $\keyword$ is $\GDKConstant$ or $\GDKConfig$, and $\timeframeexecution$ otherwise;
   \item applying $\annotatetyoptinitialvalue$ to $\vtargettimeframe$, $\tyoptp$, and \\
         $\initialvalue$ in $\tenv$ yields
         $(\typedinitialvalue, \tyoptp, \declaredt)$\ProseOrTypeError;
@@ -238,7 +241,12 @@ yielding a modified global static environment $\newgenv$ and annotated global st
   \}\\
 \checkvarnotingenv{\genv, \name} \typearrow \True \OrTypeError\\\\
 \withemptylocal(\genv) \typearrow \tenv\\
-\timeframeofgdk(\keyword) \typearrow \vtargettimeframe\\
+{
+  \begin{array}{l}
+    \vtargettimeframe \eqdef \hfill \\
+    \choice{\keyword \in \{\GDKConstant, \GDKConfig\}}{\timeframeconstant}{\timeframeexecution}
+  \end{array}
+}\\
 {
   \begin{array}{r}
     \annotatetyoptinitialvalue(\tenv, \vtargettimeframe, \tyopt, \initialvalue) \typearrow \\
@@ -449,9 +457,10 @@ is the type associated with $\name$.
   \item \AllApplyCase{config}
   \begin{itemize}
     \item $\gdk$ is $\GDKConfig$;
-    \item view $\typedinitialvalue$ as $(\Ignore, \initialvaluep, \vsesinitialvalue)$;
+    \item view $\typedinitialvalue$ as \\ $(\initialvaluetype, \initialvaluep, \vsesinitialvalue)$;
     \item checking that all \timeframesterm\ in $\vsesinitialvalue$ are equal to or less than
-          $\timeframeconfig$ via $\sesisbefore$ yields $\True$\ProseOrTypeError;
+          $\timeframeconstant$ via $\sesisbefore$ yields $\True$\ProseOrTypeError;
+    \item checking that $\initialvaluetype$ is a singular type yields $\True$\ProseOrTypeError;
     \item \Proseeqdef{$\newtenv$}{$\tenv$}.
   \end{itemize}
 
@@ -466,7 +475,7 @@ is the type associated with $\name$.
 \begin{mathpar}
 \inferrule[constant]{
   \typedinitialvalue \eqname (\Ignore, \initialvaluep, \vsesinitialvalue)\\
-  \checktrans{\sesisbefore(\vsesinitialvalue, \timeframeconstant)}{BadTimeFrame} \typearrow \True \OrTypeError\\\\
+  \checktrans{\sesisbefore(\vsesinitialvalue, \timeframeconstant)}{\SideEffectViolation} \typearrow \True \OrTypeError\\\\
   \tryaddglobalconstant(\tenv, \name, \initialvaluep) \typearrow \newtenv
 }{
   {
@@ -519,8 +528,9 @@ is the type associated with $\name$.
 
 \begin{mathpar}
 \inferrule[config]{
-  \typedinitialvalue \eqname (\Ignore, \initialvaluep, \vsesinitialvalue)\\
-  \checktrans{\sesisbefore(\vsesinitialvalue, \timeframeconfig)}{BadTimeFrame} \typearrow \True \OrTypeError\\\\
+  \typedinitialvalue \eqname (\initialvaluetype, \initialvaluep, \vsesinitialvalue)\\
+  \checktrans{\sesisbefore(\vsesinitialvalue, \timeframeconstant)}{\SideEffectViolation} \typearrow \True \OrTypeError\\\\
+  \issingular(\tenv, \initialvaluetype) \typearrow \True \OrTypeError
 }{
   {
     \begin{array}{r}

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -338,7 +338,7 @@ that should be associated with the storage element $\declaredt$.
     \item annotating the expression $\ve$ in $\tenv$ yields $(\vte, \vep, \vsese)$\ProseOrTypeError;
     \item define $\typede$ as $(\vte, \vep, \vsese)$;
     \item checking that $\vte$ \typesatisfies\ $\vt$ in $\tenv$ yields $\True$\ProseOrTypeError;
-    \item checking that all \timeframesterm\ in $\vsest$ are less than or equal to \\
+    \item checking that all \timeframesterm\ in $\vsest$ and $\vsese$ are less than or equal to \\
           $\vtargettimeframe$ via $\sesisbefore$ yields $\True$\ProseOrTypeError;
     \item define $\typedinitialvalue$ as $\typede$;
     \item define $\tyoptp$ as the singleton set for $\vtp$;
@@ -363,6 +363,8 @@ that should be associated with the storage element $\declaredt$.
     \item $\tyoptp$ is $\None$;
     \item $\initialvalue$ is the singleton set for the expression $\ve$;
     \item annotating the expression $\ve$ in $\tenv$ yields $(\vte, \vep, \vsese)$\ProseOrTypeError;
+    \item checking that all \timeframesterm\ in $\vsese$ are less than or equal to \\
+          $\vtargettimeframe$ via $\sesisbefore$ yields $\True$\ProseOrTypeError;
     \item define $\typede$ as $(\vte, \vep, \vsese)$;
     \item define $\typedinitialvalue$ as $\typede$;
     \item define $\tyoptp$ as $\None$;
@@ -378,7 +380,7 @@ The case where both $\tyopt$ and $\initialvalue$ are $\None$ is considered a syn
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vsese) \OrTypeError\\\\
   \typede \eqdef (\vte, \vep, \vsese)\\
   \checktypesat(\tenv, \vte, \vt) \typearrow \True \OrTypeError\\\\
-  \checktrans{\sesisbefore(\vsest, \vtargettimeframe)}{WrongTimeFrame} \typearrow \True \OrTypeError
+  \checktrans{\sesisbefore(\vsest \cup \vsese, \vtargettimeframe)}{\SideEffectViolation} \typearrow \True \OrTypeError
 }{
   {
     \begin{array}{r}
@@ -393,7 +395,7 @@ The case where both $\tyopt$ and $\initialvalue$ are $\None$ is considered a syn
 \begin{mathpar}
 \inferrule[some\_none]{
   \annotatetype{\tenv, \vt} \typearrow (\vtp, \vsest) \OrTypeError\\\\
-  \checktrans{\sesisbefore(\vsest, \vtargettimeframe)}{WrongTimeFrame} \typearrow \True \OrTypeError\\\\
+  \checktrans{\sesisbefore(\vsest, \vtargettimeframe)}{\SideEffectViolation} \typearrow \True \OrTypeError\\\\
   \basevalue(\tenv, \vtp) \typearrow \vep \OrTypeError\\\\
   \typedinitialvalue \eqdef (\vtp, \vep, \emptyset)
 }{
@@ -410,7 +412,8 @@ The case where both $\tyopt$ and $\initialvalue$ are $\None$ is considered a syn
 \begin{mathpar}
 \inferrule[none\_some]{
   \annotateexpr{\tenv, \ve} \typearrow (\vte, \vep, \vsese) \OrTypeError\\\\
-  \typede \eqdef (\vte, \vep, \vsese)
+  \typede \eqdef (\vte, \vep, \vsese) \\
+  \checktrans{\sesisbefore(\vsese, \vtargettimeframe)}{\SideEffectViolation} \typearrow \True \OrTypeError
 }{
   {
     \begin{array}{r}
@@ -454,8 +457,6 @@ is the type associated with $\name$.
   \begin{itemize}
     \item $\gdk$ is $\GDKConstant$;
     \item view $\typedinitialvalue$ as $(\Ignore, \initialvaluep, \vsesinitialvalue)$;
-    \item checking that all \timeframesterm\ in $\vsesinitialvalue$ are equal to or less than
-          $\timeframeconstant$ via $\sesisbefore$ yields $\True$\ProseOrTypeError;
     \item applying $\tryaddglobalconstant$ to $\name$ and $\initialvaluep$ in $\tenv$ yields $\newtenv$.
   \end{itemize}
 
@@ -477,8 +478,6 @@ is the type associated with $\name$.
   \begin{itemize}
     \item $\gdk$ is $\GDKConfig$;
     \item view $\typedinitialvalue$ as \\ $(\initialvaluetype, \initialvaluep, \vsesinitialvalue)$;
-    \item checking that all \timeframesterm\ in $\vsesinitialvalue$ are equal to or less than
-          $\timeframeconstant$ via $\sesisbefore$ yields $\True$\ProseOrTypeError;
     \item checking that $\initialvaluetype$ is a singular type yields $\True$\ProseOrTypeError;
     \item \Proseeqdef{$\newtenv$}{$\tenv$}.
   \end{itemize}
@@ -494,7 +493,6 @@ is the type associated with $\name$.
 \begin{mathpar}
 \inferrule[constant]{
   \typedinitialvalue \eqname (\Ignore, \initialvaluep, \vsesinitialvalue)\\
-  \checktrans{\sesisbefore(\vsesinitialvalue, \timeframeconstant)}{\SideEffectViolation} \typearrow \True \OrTypeError\\\\
   \tryaddglobalconstant(\tenv, \name, \initialvaluep) \typearrow \newtenv
 }{
   {
@@ -548,7 +546,6 @@ is the type associated with $\name$.
 \begin{mathpar}
 \inferrule[config]{
   \typedinitialvalue \eqname (\initialvaluetype, \initialvaluep, \vsesinitialvalue)\\
-  \checktrans{\sesisbefore(\vsesinitialvalue, \timeframeconstant)}{\SideEffectViolation} \typearrow \True \OrTypeError\\\\
   \issingular(\tenv, \initialvaluetype) \typearrow \True \OrTypeError
 }{
   {

--- a/asllib/doc/SideEffects.tex
+++ b/asllib/doc/SideEffects.tex
@@ -72,7 +72,6 @@ Along the way, we also define the concept of \emph{pure expressions} and \symbol
 We divide side effects by \emph{\timeframesterm}, which indicate the phase where a side effect occurs:
 \begin{description}
     \item[Constant] Contains effects that take place during static evaluation (see \chapref{StaticEvaluation}). That is, during typechecking.
-    \item[Configuration] Contains effects that take place while rewriting the initializing value of a \texttt{config} storage element.
     \item[Execution] Contains effects that take place during semantic evaluation.
 \end{description}
 
@@ -81,9 +80,8 @@ Formally, \timeframesterm\ are totally ordered via $\timeframeless$ as follows:
 \hypertarget{def-timeframeless}{}
 \hypertarget{def-timeframeconstant}{}
 \hypertarget{def-timeframeexecution}{}
-\hypertarget{def-timeframeconfig}{}
 \[
-\TTimeFrame \triangleq \{ \timeframeconstant \timeframeless \timeframeconfig \timeframeless \timeframeexecution \}
+\TTimeFrame \triangleq \{ \timeframeconstant \timeframeless \timeframeexecution \}
 \]
 Additionally, we define the less-than-or-equal ordering as follows:
 \hypertarget{def-timeframeleq}{}
@@ -136,7 +134,7 @@ constructs a \timeframeterm\ $\vt$ from a global declaration keyword $\gdk$.
 
 \ProseParagraph
 \ProseEqdef{$\vt$}{$\timeframeconstant$ if $\gdk$ is $\GDKConstant$,
-    $\timeframeconfig$ if $\gdk$ is $\GDKConfig$,
+    $\timeframeexecution$ if $\gdk$ is $\GDKConfig$,
     $\timeframeexecution$ if $\gdk$ is $\GDKLet$, and
     $\timeframeexecution$ if $\gdk$ is $\GDKVar$.
 }
@@ -148,7 +146,7 @@ constructs a \timeframeterm\ $\vt$ from a global declaration keyword $\gdk$.
         \timeframeofgdk(\gdk) \typearrow
     \begin{cases}
         \timeframeconstant  & \text{if }\gdk = \GDKConstant\\
-        \timeframeconfig & \text{if }\gdk = \GDKConfig\\
+        \timeframeexecution & \text{if }\gdk = \GDKConfig\\
         \timeframeexecution & \text{if }\gdk = \GDKLet\\
         \timeframeexecution & \text{if }\gdk = \GDKVar\\
     \end{cases}
@@ -745,7 +743,7 @@ The function
 \]
 tests whether the \timeframesterm\ of \sideeffectdescriptorsterm\ in $\vses$ are all less than or equal to the \timeframeterm\
 $\vt$, yielding the result in $\vb$.
-% Transliteration note: this abstracts both leq_config_time and leq_constant_time
+% Transliteration note: this abstracts leq_constant_time
 
 \ProseParagraph
 Define $\vb$ as $\True$ if and only if the maximal \timeframeterm\ of all \sideeffectdescriptorsterm\ in $\vses$

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -221,6 +221,7 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 |\ & \Ttype \parsesep \Tidentifier \parsesep \Nsubtype \parsesep \Tsemicolon &\\
 |\ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} &\\
    & \wrappedline\ \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Tconfig \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon &\\
 |\ & \Tpragma \parsesep \Tidentifier \parsesep \ClistZero{\Nexpr} \parsesep \Tsemicolon&
@@ -314,7 +315,7 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 
 \hypertarget{def-nglobaldeclkeyword}{}
 \begin{flalign*}
-\Nglobaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant \;|\; \Tconfig&
+\Nglobaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant&
 \end{flalign*}
 
 \hypertarget{def-ndirection}{}

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -90,7 +90,7 @@ type error_desc =
       field1_absslices : string;
       field2_absslices : string;
     }
-  | BadPrintType of ty
+  | ExpectedSingularType of ty
   | ConfigTimeBroken of expr * SideEffect.SES.t
   | ConstantTimeBroken of expr * SideEffect.SES.t
   | MultipleWrites of identifier
@@ -193,7 +193,7 @@ let error_label = function
   | EmptyConstraints -> "EmptyConstraints"
   | UnexpectedPendingConstrained -> "UnexpectedPendingConstrained"
   | BitfieldsDontAlign _ -> "BitfieldsDontAlign"
-  | BadPrintType _ -> "BadPrintType"
+  | ExpectedSingularType _ -> "ExpectedSingularType"
   | ConflictingSideEffects _ -> "ConflictingSideEffects"
   | ConfigTimeBroken _ -> "ConfigTimeBroken"
   | ConstantTimeBroken _ -> "ConstantTimeBroken"
@@ -456,9 +456,9 @@ module PPrint = struct
         pp_print_text f
           "ASL Typing error: a well-constrained integer cannot have empty \
            constraints."
-    | BadPrintType t ->
+    | ExpectedSingularType t ->
         fprintf f "ASL Typing error:@ %a@ %a." pp_print_text
-          "print and println only accept singular types, found" pp_ty t
+          "expected singular type, found" pp_ty t
     | UnexpectedPendingConstrained ->
         pp_print_text f
           "ASL Typing error: a pending constrained integer is illegal here."

--- a/asllib/tests/print.t
+++ b/asllib/tests/print.t
@@ -65,7 +65,6 @@
 
   $ aslref print4.asl
   File print4.asl, line 2, characters 11 to 17:
-  ASL Typing error: print and println only accept singular types, found
-    (integer {1}, integer {2}).
+  ASL Typing error: expected singular type, found (integer {1}, integer {2}).
   [1]
 

--- a/asllib/tests/side-effects.t/config-type-uses-let.asl
+++ b/asllib/tests/side-effects.t/config-type-uses-let.asl
@@ -1,0 +1,7 @@
+let X = 1; // X is execution-time
+config Y : integer {0 .. 2 * X} = 0;
+
+func main () => integer
+begin
+  return 0;
+end;

--- a/asllib/tests/side-effects.t/config-uses-atc.asl
+++ b/asllib/tests/side-effects.t/config-uses-atc.asl
@@ -3,7 +3,7 @@ begin
   return 0 as integer {10};
 end;
 
-config Y = foo ();
+config Y: integer = foo ();
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-config-through-func.asl
+++ b/asllib/tests/side-effects.t/config-uses-config-through-func.asl
@@ -5,7 +5,7 @@ begin
   return X;
 end;
 
-config Y = foo ();
+config Y: integer = foo ();
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-config.asl
+++ b/asllib/tests/side-effects.t/config-uses-config.asl
@@ -1,5 +1,5 @@
 config X: integer = 0;
-config Y = X;
+config Y: integer = X;
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-constant-through-func.asl
+++ b/asllib/tests/side-effects.t/config-uses-constant-through-func.asl
@@ -5,7 +5,7 @@ begin
   return X;
 end;
 
-config Y = foo ();
+config Y: integer = foo ();
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-constant.asl
+++ b/asllib/tests/side-effects.t/config-uses-constant.asl
@@ -1,5 +1,5 @@
 constant X: integer = 0;
-config Y = X;
+config Y: integer = X;
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-let-through-func.asl
+++ b/asllib/tests/side-effects.t/config-uses-let-through-func.asl
@@ -5,7 +5,7 @@ begin
   return X;
 end;
 
-config Y = foo ();
+config Y: integer = foo ();
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-let.asl
+++ b/asllib/tests/side-effects.t/config-uses-let.asl
@@ -1,5 +1,5 @@
 let X: integer = 0;
-config Y = X;
+config Y: integer = X;
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-local-constant.asl
+++ b/asllib/tests/side-effects.t/config-uses-local-constant.asl
@@ -5,7 +5,7 @@ begin
   return x;
 end;
 
-config Y = foo ();
+config Y: integer = foo ();
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-local-let.asl
+++ b/asllib/tests/side-effects.t/config-uses-local-let.asl
@@ -5,7 +5,7 @@ begin
   return x;
 end;
 
-config Y = foo ();
+config Y: integer = foo ();
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-local-var.asl
+++ b/asllib/tests/side-effects.t/config-uses-local-var.asl
@@ -5,7 +5,7 @@ begin
   return x;
 end;
 
-config Y = foo ();
+config Y: integer = foo ();
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-unknown.asl
+++ b/asllib/tests/side-effects.t/config-uses-unknown.asl
@@ -3,7 +3,7 @@ begin
   return ARBITRARY: integer {0..10};
 end;
 
-config Y = foo ();
+config Y: integer = foo ();
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-var-through-func.asl
+++ b/asllib/tests/side-effects.t/config-uses-var-through-func.asl
@@ -5,7 +5,7 @@ begin
   return X;
 end;
 
-config Y = foo ();
+config Y: integer = foo ();
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/config-uses-var.asl
+++ b/asllib/tests/side-effects.t/config-uses-var.asl
@@ -1,5 +1,5 @@
 var X: integer = 0;
-config Y = X + 3;
+config Y: integer = X + 3;
 
 func main () => integer
 begin

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -125,13 +125,13 @@
   [1]
 
   $ aslref config-uses-var.asl
-  File config-uses-var.asl, line 2, characters 0 to 17:
+  File config-uses-var.asl, line 2, characters 0 to 26:
   ASL Typing error: expected config-time expression, got (X + 3), which
     produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-config.asl
   $ aslref config-uses-let.asl
-  File config-uses-let.asl, line 2, characters 0 to 13:
+  File config-uses-let.asl, line 2, characters 0 to 22:
   ASL Typing error: expected config-time expression, got X, which produces the
     following side-effects: [ReadsGlobal "X"].
   [1]
@@ -140,13 +140,13 @@
   $ aslref config-uses-local-let.asl
   $ aslref config-uses-local-constant.asl
   $ aslref config-uses-var-through-func.asl
-  File config-uses-var-through-func.asl, line 8, characters 0 to 18:
+  File config-uses-var-through-func.asl, line 8, characters 0 to 27:
   ASL Typing error: expected config-time expression, got foo(), which produces
     the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-config-through-func.asl
   $ aslref config-uses-let-through-func.asl
-  File config-uses-let-through-func.asl, line 8, characters 0 to 18:
+  File config-uses-let-through-func.asl, line 8, characters 0 to 27:
   ASL Typing error: expected config-time expression, got foo(), which produces
     the following side-effects: [ReadsGlobal "X"].
   [1]
@@ -157,7 +157,7 @@
     value 0 does not belong to type integer {10}.
   [1]
   $ aslref config-uses-unknown.asl
-  File config-uses-unknown.asl, line 6, characters 0 to 18:
+  File config-uses-unknown.asl, line 6, characters 0 to 27:
   ASL Typing error: expected config-time expression, got foo(), which produces
     the following side-effects: [NonDeterministic].
   [1]

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -126,14 +126,18 @@
 
   $ aslref config-uses-var.asl
   File config-uses-var.asl, line 2, characters 0 to 26:
-  ASL Typing error: expected config-time expression, got (X + 3), which
+  ASL Typing error: expected constant-time expression, got (X + 3), which
     produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-config.asl
+  File config-uses-config.asl, line 2, characters 0 to 22:
+  ASL Typing error: expected constant-time expression, got X, which produces
+    the following side-effects: [ReadsGlobal "X"].
+  [1]
   $ aslref config-uses-let.asl
   File config-uses-let.asl, line 2, characters 0 to 22:
-  ASL Typing error: expected config-time expression, got X, which produces the
-    following side-effects: [ReadsGlobal "X"].
+  ASL Typing error: expected constant-time expression, got X, which produces
+    the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-constant.asl
   $ aslref config-uses-local-var.asl
@@ -141,14 +145,18 @@
   $ aslref config-uses-local-constant.asl
   $ aslref config-uses-var-through-func.asl
   File config-uses-var-through-func.asl, line 8, characters 0 to 27:
-  ASL Typing error: expected config-time expression, got foo(), which produces
-    the following side-effects: [ReadsGlobal "X"].
+  ASL Typing error: expected constant-time expression, got foo(), which
+    produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-config-through-func.asl
+  File config-uses-config-through-func.asl, line 8, characters 0 to 27:
+  ASL Typing error: expected constant-time expression, got foo(), which
+    produces the following side-effects: [ReadsGlobal "X"].
+  [1]
   $ aslref config-uses-let-through-func.asl
   File config-uses-let-through-func.asl, line 8, characters 0 to 27:
-  ASL Typing error: expected config-time expression, got foo(), which produces
-    the following side-effects: [ReadsGlobal "X"].
+  ASL Typing error: expected constant-time expression, got foo(), which
+    produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-constant-through-func.asl
   $ aslref config-uses-atc.asl
@@ -158,8 +166,8 @@
   [1]
   $ aslref config-uses-unknown.asl
   File config-uses-unknown.asl, line 6, characters 0 to 27:
-  ASL Typing error: expected config-time expression, got foo(), which produces
-    the following side-effects: [NonDeterministic].
+  ASL Typing error: expected constant-time expression, got foo(), which
+    produces the following side-effects: [NonDeterministic].
   [1]
 
   $ aslref assert-read.asl

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -126,18 +126,18 @@
 
   $ aslref config-uses-var.asl
   File config-uses-var.asl, line 2, characters 0 to 26:
-  ASL Typing error: expected constant-time expression, got (X + 3), which
-    produces the following side-effects: [ReadsGlobal "X"].
+  ASL Typing error: expected constant-time expression, got (X + 3) as integer,
+    which produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-config.asl
   File config-uses-config.asl, line 2, characters 0 to 22:
-  ASL Typing error: expected constant-time expression, got X, which produces
-    the following side-effects: [ReadsGlobal "X"].
+  ASL Typing error: expected constant-time expression, got X as integer, which
+    produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-let.asl
   File config-uses-let.asl, line 2, characters 0 to 22:
-  ASL Typing error: expected constant-time expression, got X, which produces
-    the following side-effects: [ReadsGlobal "X"].
+  ASL Typing error: expected constant-time expression, got X as integer, which
+    produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-constant.asl
   $ aslref config-uses-local-var.asl
@@ -145,18 +145,18 @@
   $ aslref config-uses-local-constant.asl
   $ aslref config-uses-var-through-func.asl
   File config-uses-var-through-func.asl, line 8, characters 0 to 27:
-  ASL Typing error: expected constant-time expression, got foo(), which
-    produces the following side-effects: [ReadsGlobal "X"].
+  ASL Typing error: expected constant-time expression, got foo() as integer,
+    which produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-config-through-func.asl
   File config-uses-config-through-func.asl, line 8, characters 0 to 27:
-  ASL Typing error: expected constant-time expression, got foo(), which
-    produces the following side-effects: [ReadsGlobal "X"].
+  ASL Typing error: expected constant-time expression, got foo() as integer,
+    which produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-let-through-func.asl
   File config-uses-let-through-func.asl, line 8, characters 0 to 27:
-  ASL Typing error: expected constant-time expression, got foo(), which
-    produces the following side-effects: [ReadsGlobal "X"].
+  ASL Typing error: expected constant-time expression, got foo() as integer,
+    which produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-constant-through-func.asl
   $ aslref config-uses-atc.asl
@@ -166,8 +166,8 @@
   [1]
   $ aslref config-uses-unknown.asl
   File config-uses-unknown.asl, line 6, characters 0 to 27:
-  ASL Typing error: expected constant-time expression, got foo(), which
-    produces the following side-effects: [NonDeterministic].
+  ASL Typing error: expected constant-time expression, got foo() as integer,
+    which produces the following side-effects: [NonDeterministic].
   [1]
 
   $ aslref assert-read.asl

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -321,3 +321,9 @@
   ASL Execution error: unexpected exception E thrown during the evaluation of
     the initialisation of the global storage element "X".
   [1]
+
+  $ aslref config-type-uses-let.asl
+  File config-type-uses-let.asl, line 2, characters 0 to 36:
+  ASL Typing error: expected constant-time expression, got 0 as integer {0..2},
+    which produces the following side-effects: [ReadsGlobal "X"].
+  [1]


### PR DESCRIPTION
Make the following changes concerning global `config` declarations:
- All `config` declarations must:
  - have an explicit type annotation
  - be of a singular type
  - refer to only constant-time expressions
- Remove configuration-time from side-effect analysis, and treat `config` declarations as execution-time
- Document the level of language support for `config`