### PR TITLE
[herd] Fix aarch64 <-> ASL interface

### DIFF
--- a/herd/tests/instructions/AArch64.ASL/CSET01.litmus
+++ b/herd/tests/instructions/AArch64.ASL/CSET01.litmus
@@ -1,4 +1,4 @@
-AArch64 CSET
+AArch64 CSET01
 {
 0:X0=1;
 0:X1=1;

--- a/herd/tests/instructions/AArch64.ASL/CSET01.litmus.expected
+++ b/herd/tests/instructions/AArch64.ASL/CSET01.litmus.expected
@@ -1,10 +1,10 @@
-Test CSET Required
+Test CSET01 Required
 States 1
 0:X2=1; 0:X3=0; 0:X4=-1; 0:X5=0;
 Ok
 Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:X2=1 /\ 0:X3=0 /\ 0:X4=-1 /\ 0:X5=0)
-Observation CSET Always 1 0
+Observation CSET01 Always 1 0
 Hash=87d63dd83933539eb697c53b9633361f
 

--- a/herd/tests/instructions/AArch64.ASL/CSET02.litmus
+++ b/herd/tests/instructions/AArch64.ASL/CSET02.litmus
@@ -1,0 +1,16 @@
+AArch64 CSET02
+{
+  int x=0;
+  0:X2=x;
+  1:X2=x;
+}
+  P0          |  P1         ;
+ LDR W0,[X2]  | MOV W1,#1   ;
+ CMP W0,#0    | STR W1,[X2] ;
+ CSET W3,EQ   |             ;
+ CMP W0,#0    |             ;
+ CSET W4,NE   |             ;
+ ADD W5,W3,W4 |             ;
+locations [0:X3; 0:X4;]
+forall 0:X5=1
+ 

--- a/herd/tests/instructions/AArch64.ASL/CSET02.litmus.expected
+++ b/herd/tests/instructions/AArch64.ASL/CSET02.litmus.expected
@@ -1,0 +1,11 @@
+Test CSET02 Required
+States 2
+0:X3=0; 0:X4=1; 0:X5=1;
+0:X3=1; 0:X4=0; 0:X5=1;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall (0:X5=1)
+Observation CSET02 Always 2 0
+Hash=88cd8ae0c0bba2fe4756a882959e75ad
+


### PR DESCRIPTION
Architecture flags NZCV have different incarnations:
  + For ASL, global variable `_NZCV`, holding a bitvector.
  + For AArch64, register holding an integer.

This commit implements the cast from integer to bitvector that was absent from the AArch64 to ASL interface.

Notice that the translation from ASL to AArch64 is performed differently: writes to `_NZVC` are intercepted during ASL interpretation, so as to generate the appropriate write effect, with integer value.

This PR is an alternative to PR #1181, which I believe to be more general.