### PR TITLE
[diy] Code improvement: upgrade the `Code.v` type

### DIFF
--- a/gen/AArch64Arch_gen.ml
+++ b/gen/AArch64Arch_gen.ml
@@ -877,7 +877,10 @@ let get_ie e = match e with
 
 let fold_edge f r = Code.fold_ie (fun ie r -> f (IFF ie) (f (FIF ie) r)) r
 
-let compute_rmw r old co = match r with
+let compute_rmw r old co = 
+    let old = Code.value_to_int old in
+    let co = Code.value_to_int co in
+    let new_value = match r with 
     | LdOp op | StOp op ->
       begin match op with
         | A_ADD -> old + co
@@ -893,7 +896,8 @@ let compute_rmw r old co = match r with
         | A_SET -> old lor co
         | A_CLR -> old land (lnot co)
     end
-    | LrSc | Swp | Cas  -> co
+    | LrSc | Swp | Cas  -> co in
+    Code.value_of_int new_value
 
 include
     ArchExtra_gen.Make

--- a/gen/ARMCompile_gen.ml
+++ b/gen/ARMCompile_gen.ml
@@ -250,7 +250,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     let emit_joker st init = None,init,[],st
 
-    let emit_access  st p init e =  match e.dir with
+    let emit_access  st p init e =  
+    (* collapse the value `v` in event `e` to integer *)
+    let value = Code.value_to_int e.v in
+    match e.dir with
     | None ->  Warn.fatal "ARMCompile.emit_access"
     | Some d ->
         match d,e.atom,e.loc with
@@ -264,11 +267,11 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let r,init,cs,st = emit_lda st p init loc  in
             Some r,init,cs,st
         | W,None,Data loc ->
-            let init,cs,st = emit_store st p init loc e.v in
+            let init,cs,st = emit_store st p init loc value in
             None,init,cs,st
         | W,Some Reserve,Data _ -> Warn.fatal "No store with reservation"
         | W,Some Atomic,Data loc ->
-            let ro,init,cs,st = emit_sta st p init loc e.v in
+            let ro,init,cs,st = emit_sta st p init loc value in
             ro,init,cs,st
         | _,Some (Mixed _),Data _ -> assert false
         | Code.J,_,Data _ -> emit_joker st init
@@ -276,7 +279,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     let emit_exch st p init er ew =
       let rA,init,st = U.next_init st p init (as_data er.loc) in
-      let rW,init,csi,st = U.emit_mov st p init ew.v in
+      let rW,init,csi,st = U.emit_mov st p init (Code.value_to_int ew.v) in
       let rR,st = next_reg st in
       let cs,st = emit_pair p st rR rW rA in
       Some rR,init,csi@cs,st
@@ -290,6 +293,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         fun r2 r1 -> I_XOR (DontSetFlags,r2,r1,r1)
 
     let emit_access_dep_addr st p init e  r1 =
+      (* collapse the value `v` in event `e` to integer *)
+      let value = Code.value_to_int e.v in
       let r2,st = next_reg st in
       let c =  calc0 r2 r1 in
       match Misc.as_some e.dir,e.atom,e.loc with
@@ -303,11 +308,11 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           let r,init,cs,st = emit_lda_idx st p init loc r2 in
           Some r,init, Instruction c::cs,st
       | W,None,Data loc ->
-          let init,cs,st = emit_store_idx st p init loc r2 e.v in
+          let init,cs,st = emit_store_idx st p init loc r2 value in
           None,init,Instruction c::cs,st
       | W,Some Reserve,Data _ -> Warn.fatal "No store with reservation"
       | W,Some Atomic,Data loc ->
-          let ro,init,cs,st = emit_sta_idx st p init loc r2 e.v in
+          let ro,init,cs,st = emit_sta_idx st p init loc r2 value in
           ro,init,Instruction c::cs,st
       | _,Some (Mixed _),Data _ -> assert false
       | Code.J,_,Data _ -> emit_joker st init
@@ -319,7 +324,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         [Instruction (calc0 tempo1 rd);
          Instruction (I_ADD3 (DontSetFlags,tempo1,rA,tempo1));] in
       let r,init,csr,st = emit_ldrex_reg st p init tempo1 in
-      let init,csw,st = emit_one_strex_reg st p init tempo1 ew.v in
+      let init,csw,st = emit_one_strex_reg st p init tempo1 (Code.value_to_int ew.v) in
       r,init,c@csr@csw,st
 
 
@@ -331,7 +336,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           let r2,st = next_reg st in
           let cs2 =
             [Instruction (calc0 r2 r1) ;
-             Instruction (I_ADD (DontSetFlags,r2,r2,e.v)) ; ] in
+             Instruction (I_ADD (DontSetFlags,r2,r2,(Code.value_to_int e.v))) ; ] in
           begin match e.atom,e.loc with
           | None,Data loc ->
               let init,cs,st = emit_store_reg st p init loc r2 in
@@ -401,7 +406,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let do_check_load p st r e =
       let ok,st = A.ok_reg st in
       (fun k ->
-        Instruction (I_CMPI (r,e.v))::
+        Instruction (I_CMPI (r, (Code.value_to_int e.v)))::
         Instruction (I_BNE (Label.last p))::
         Instruction (I_ADD (DontSetFlags,ok,ok,1))::
         k),

--- a/gen/CArch_gen.ml
+++ b/gen/CArch_gen.ml
@@ -270,8 +270,11 @@ let applies_atom_rmw _ ar aw = match ar,aw with
 let show_rmw_reg _ = true
 
 let compute_rmw rmw old co =
-  match rmw with
+  let old = Code.value_to_int old in
+  let co = Code.value_to_int co in
+  let new_value = match rmw with
   | Exch -> co
-  | Add -> old+co
+  | Add -> old+co in
+  Code.value_of_int new_value
 
 include NoEdge

--- a/gen/CCompile_gen.ml
+++ b/gen/CCompile_gen.ml
@@ -137,7 +137,7 @@ module Make(O:Config) : Builder.S
         let eloc =  mk_eloc pdp loc in
         let v = e.C.v in
         let ev = match  pdp with
-        | Yes (A.DATA,pr) ->  A.AddZero (A.Const v,pr)
+        | Yes (A.DATA,pr) -> A.AddZero (A.Const v,pr)
         | _ -> A.Const v in
         match e.C.atom with
         | None ->
@@ -227,7 +227,7 @@ module Make(O:Config) : Builder.S
         let decls = A.Decl (A.Plain A.deftype,r,None)
         and body =
           A.Seq
-            (A.SetReg (r,load_from No mo x),breakcond A.Ne p r 0) in
+            (A.SetReg (r,load_from No mo x),breakcond A.Ne p r (Code.value_of_int 0)) in
         r,A.Seq (decls,A.Loop body),st
 
       let compile_load_one st p mo x =
@@ -236,7 +236,7 @@ module Make(O:Config) : Builder.S
         and body =
           A.Seq
             (A.SetReg (r,load_from No mo x),
-             breakcond A.Eq p r 1) in
+             breakcond A.Eq p r (Code.value_of_int 1)) in
         r,A.Seq (decls,A.Loop body),st
 
 
@@ -245,14 +245,14 @@ module Make(O:Config) : Builder.S
         let idx,st = alloc_loop_idx p st in
         let decls =
           A.Seq
-            (A.Decl (A.Plain TypBase.Int,idx,Some (A.Const 200)),
+            (A.Decl (A.Plain TypBase.Int,idx,Some (A.Const (Code.value_of_int 200))),
              A.Decl (A.Plain A.deftype,r,None))
         and body =
           A.seqs
             [A.SetReg (r,load_from No mo x) ;
              do_breakcond A.Ne p r e ;
              A.Decr idx ;
-             breakcond A.Eq p idx 0;] in
+             breakcond A.Eq p idx (Code.value_of_int 0);] in
         r,A.Seq (decls,A.Loop body),st
 
       let compile_load_not_value st p mo x v =
@@ -309,7 +309,7 @@ module Make(O:Config) : Builder.S
       let insert_now d i =
         List.fold_right
           (fun (t,r) k ->
-            A.seqs [A.Decl (t,r,Some (A.Const (-1)));k])
+            A.seqs [A.Decl (t,r,Some (A.Const (Code.value_of_int (-1))));k])
           d i
 
       let rec lift_rec top xs i =
@@ -379,7 +379,7 @@ module Make(O:Config) : Builder.S
         | v::vs ->
             let r,c,st =
               compile_load_assertvalue  No
-                (IntSet.choose v) st p mo x  in
+                (Code.value_of_int @@ IntSet.choose v) st p mo x  in
             let cs,fs = straight_observer_std fenced st p  mo x vs in
             A.seq c (add_fence fenced cs),F.add_final_v p r v fs
 
@@ -387,7 +387,7 @@ module Make(O:Config) : Builder.S
         | [] -> assert false (* A.Nop,[] *)
         | [_] as vs -> straight_observer_std fenced st p mo x vs
         | v::vs ->
-            let v0 = IntSet.choose v in
+            let v0 = value_of_int @@ IntSet.choose v in
             if O.cpp then
               let ce = A.Const v0,A.Eq,assertval No mo x v0 in
               let cs,fs = straight_observer_check fenced st p  mo x vs in
@@ -608,7 +608,7 @@ module Make(O:Config) : Builder.S
                      (fun (v,obs) ->
                        if Array.length v > 1 then
                          Warn.fatal "No wide access in C" ;
-                       v.(0),obs))
+                       (Code.value_to_int v.(0)),obs))
                   vss in
               loc,vss)
             cos in
@@ -618,11 +618,11 @@ module Make(O:Config) : Builder.S
 
       let do_add_load st p f mo x v =
         let r,c,st = compile_load_assertvalue No v st p mo x in
-        c,F.add_final_v p r (IntSet.singleton v) f,st
+        c,F.add_final_v p r (IntSet.singleton @@ Code.value_to_int v) f,st
 
       let do_add_loop st p f mo x v w =
         let r,c,st = compile_load_not_value st p mo x v in
-        c,F.add_final_v p r (IntSet.singleton w) f,st
+        c,F.add_final_v p r (IntSet.singleton @@ Code.value_to_int w) f,st
 
       let add_fence n is = match n.C.edge.E.edge with
       | E.Fenced (fe,_,_,_) -> A.Seq (A.Fence fe,is)
@@ -872,18 +872,18 @@ module Make(O:Config) : Builder.S
             sprintf "atomic_load_explicit(%s,%s)"
               (dump_exp loc) (dump_mem_order mo)
         | AtomicExch (MemOrder.SC,loc,v) ->
-            sprintf "atomic_exchange(%s,%i)" (dump_exp loc) v
+            sprintf "atomic_exchange(%s,%s)" (dump_exp loc) (Code.pp_v v)
         | AtomicExch (mo,loc,v) ->
-            sprintf "atomic_exchange_explicit(%s,%i,%s)"
-              (dump_exp loc) v (dump_mem_order mo)
+            sprintf "atomic_exchange_explicit(%s,%s,%s)"
+              (dump_exp loc) (Code.pp_v v) (dump_mem_order mo)
         | AtomicFetchOp (MemOrder.SC,loc,v) ->
-            sprintf "atomic_fetch_add(%s,%i)" (dump_exp loc) v
+            sprintf "atomic_fetch_add(%s,%s)" (dump_exp loc) (Code.pp_v v)
         | AtomicFetchOp (mo,loc,v) ->
-            sprintf "atomic_fetch_add_explicit(%s,%i,%s)"
-              (dump_exp loc) v (dump_mem_order mo)
+            sprintf "atomic_fetch_add_explicit(%s,%s,%s)"
+              (dump_exp loc) (Code.pp_v v) (dump_mem_order mo)
         | Deref (Load _ as e) -> sprintf "*%s" (dump_exp e)
         | Deref e -> sprintf "*(%s)" (dump_exp e)
-        | Const v -> sprintf "%i" v
+        | Const v -> sprintf "%s" (Code.pp_v v)
         | AssertVal (e,_) -> dump_exp e
 
       let dump_left_val = function
@@ -1041,16 +1041,16 @@ module Make(O:Config) : Builder.S
             sprintf "%s.load(%s)"
               (dump_exp loc) (dump_mem_order mo)
         | AtomicExch (mo,loc,v) ->
-            sprintf "%s.exchange(%i,%s)"
-              (dump_exp loc) v (dump_mem_order mo)
+            sprintf "%s.exchange(%s,%s)"
+              (dump_exp loc) (Code.pp_v v) (dump_mem_order mo)
        | AtomicFetchOp (mo,loc,v) ->
-            sprintf "%s.fetch_add(%i,%s)"
-              (dump_exp loc) v (dump_mem_order mo)
+            sprintf "%s.fetch_add(%s,%s)"
+              (dump_exp loc) (Code.pp_v v) (dump_mem_order mo)
         | Deref (Load _ as e) -> sprintf "*%s" (dump_exp e)
         | Deref e -> sprintf "*(%s)" (dump_exp e)
-        | Const v -> sprintf "%i" v
+        | Const v -> sprintf "%s" (Code.pp_v v)
         | AssertVal (AtomicLoad _|Load _ as e,v) ->
-            sprintf "%s.readsvalue(%i)" (dump_exp e) v
+            sprintf "%s.readsvalue(%s)" (dump_exp e) (Code.pp_v v)
         | AssertVal _ ->
             Warn.fatal "Cannot compile to C++ (expr)"
 

--- a/gen/X86Compile_gen.ml
+++ b/gen/X86Compile_gen.ml
@@ -112,7 +112,10 @@ struct
 
   let emit_joker st init = None,init,[],st
 
-  let emit_access st _p init e = match e.C.dir,e.C.loc with
+  let emit_access st _p init e = 
+  (* collapse the value `v` in event `e` to integer *)
+  let value = Code.value_to_int e.C.v in
+  match e.C.dir,e.C.loc with
   | None,_ -> Warn.fatal "TODO"
   | Some R,Data loc ->
       let rA,st = next_reg st in
@@ -127,17 +130,17 @@ struct
         (match e.C.atom with Some Atomic -> true | None -> false)
       then
         let rX,st = next_reg st in
-        None,init,pseudo (emit_sta loc rX e.C.v),
+        None,init,pseudo (emit_sta loc rX value),
         st
       else
-        None,init,pseudo [emit_store loc e.C.v],st
+        None,init,pseudo [emit_store loc value],st
   | Some J,_ -> emit_joker st init
   | _,Code _ -> Warn.fatal "No code location for X86"
 
   let emit_exch st _p init er ew =
     let rA,st = next_reg st in
     rA,init,
-    pseudo  (emit_sta (Code.as_data er.C.loc) rA ew.C.v),
+    pseudo  (emit_sta (Code.as_data er.C.loc) rA (Code.value_to_int ew.C.v)),
     st
 
   let emit_rmw () st p init er ew  =
@@ -166,7 +169,7 @@ struct
   let do_check_load p st r e =
     let ok,st = A.ok_reg st in
     (fun k ->
-      Instruction (emit_cmp_int_ins r e.C.v)::
+      Instruction (emit_cmp_int_ins r (Code.value_to_int e.C.v))::
       Instruction (emit_jne_ins (Label.last p))::
       Instruction (emit_inc ok)::
       k),

--- a/gen/code.ml
+++ b/gen/code.ml
@@ -15,6 +15,7 @@
 (****************************************************************************)
 
 (* Event components *)
+(* TODO introduce a monad operation? *)
 type loc = Data of string | Code of Label.t
 
 let as_data = function
@@ -57,11 +58,22 @@ let ok = Data ok_str
 let myok p n = Data (Printf.sprintf "ok%i%i" p n)
 let myok_proc p = Data (Printf.sprintf "ok%i" p)
 
-type v = int
+type v = NoValue | Plain of int
+let value_to_int = function
+    | NoValue -> -1
+    | Plain v -> v
+let no_value = NoValue
+let value_of_int v = Plain v
+let value_compare lhs rhs =
+    match lhs, rhs with
+    | NoValue, NoValue -> 0
+    | NoValue, Plain _ -> -1
+    | Plain _, NoValue -> 1
+    | Plain lhs, Plain rhs -> Misc.int_compare lhs rhs
 
-let pp_v ?(hexa=false) =
-  Printf.sprintf
-    (if hexa then "0x%x" else "%d")
+let pp_v ?(hexa=false) = function
+  | NoValue -> "**"
+  | Plain v -> Printf.sprintf (if hexa then "0x%x" else "%d") v
 
 type proc = Proc.t
 let pp_proc p = Proc.pp p
@@ -194,6 +206,6 @@ let add_capability s t = Printf.sprintf "0xffffc0000:%s:%i" s (if t = 0 then 1 e
 
 let add_vector hexa v =
   let open Printf in
-  let pp = pp_v ~hexa:hexa in
+  let pp value = pp_v ~hexa:hexa (value_of_int value) in
   sprintf "{%s}"
-    (String.concat "," (List.map pp  v))
+    (String.concat "," (List.map pp v))

--- a/gen/code.mli
+++ b/gen/code.mli
@@ -33,8 +33,12 @@ val myok_proc : int -> loc
 
 
 
-type v = int
+type v = NoValue | Plain of int
 val pp_v : ?hexa:bool -> v -> string
+val no_value : v
+val value_to_int : v -> int
+val value_of_int : int -> v
+val value_compare : v -> v -> int
 
 type proc = Proc.t
 val pp_proc : proc -> string
@@ -94,8 +98,11 @@ type 'a bank = Ord | Tag | CapaTag | CapaSeal | Pte | VecReg of 'a | Pair | Inst
 
 val pp_bank : 'a bank -> string
 
-val add_tag : string -> v -> string
+(* TODO consider change the type `v` *)
+val add_tag : string -> int -> string
 
-val add_capability : string -> v -> string
+(* TODO consider change the type `v` *)
+val add_capability : string -> int -> string
 
+(* TODO consider change the type `v` *)
 val add_vector : bool -> int list -> string

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -68,7 +68,7 @@ module type S = sig
   val is_node : tedge -> bool
   val is_insert_store : tedge -> bool
   val is_non_pseudo : tedge -> bool
-  val compute_rmw : rmw -> int -> int -> int
+  val compute_rmw : rmw -> Code.v -> Code.v -> Code.v
 
   type edge = { edge: tedge;  a1:atom option; a2: atom option; }
 

--- a/gen/machMixed.mli
+++ b/gen/machMixed.mli
@@ -34,7 +34,7 @@ module Make :
 
     val fold_mixed : (t -> 'a -> 'a) -> 'a -> 'a
 
-    val tr_value : MachSize.sz -> int -> int
+    val tr_value : MachSize.sz -> Code.v -> Code.v
   end
 
 module type ValsConfig = sig
@@ -46,9 +46,9 @@ module Vals :
   functor(C:ValsConfig) ->
   sig
     val overwrite_value :
-      int (* old *) -> MachSize.sz -> offset -> int (* write *) -> int
+      Code.v (* old *) -> MachSize.sz -> offset -> Code.v (* write *) -> Code.v
 
-    val extract_value : int -> MachSize.sz -> offset -> int
+    val extract_value : Code.v -> MachSize.sz -> offset -> Code.v
 
   end
 

--- a/gen/rmw.mli
+++ b/gen/rmw.mli
@@ -27,5 +27,5 @@ module type S = sig
   val fold_rmw_compat : (rmw -> 'a -> 'a) -> 'a -> 'a
   val applies_atom_rmw : rmw -> rmw_atom option -> rmw_atom option -> bool
   val show_rmw_reg : rmw -> bool
-  val compute_rmw : rmw  -> int -> int -> int
+  val compute_rmw : rmw  -> Code.v -> Code.v -> Code.v
 end

--- a/gen/run_gen.ml
+++ b/gen/run_gen.ml
@@ -106,7 +106,7 @@ module Make (O:Config) (C:ArchRun.S) :
       MySet.Make
         (struct
           type t = Code.v State.t
-          let compare = State.compare Misc.int_compare
+          let compare = State.compare Code.value_compare
         end)
 
     let by_loc pred evts =
@@ -252,7 +252,7 @@ module Make (O:Config) (C:ArchRun.S) :
 
     module OV = struct
       type t = Code.v
-      let compare = Misc.int_compare
+      let compare = Code.value_compare
     end
 
     module VSet = MySet.Make(OV)
@@ -341,7 +341,7 @@ module Make (O:Config) (C:ArchRun.S) :
       | And [] -> "true"
       | Or fs -> do_dumps " \\/ " fs
       | And fs -> do_dumps " /\\ " fs
-      | Atom (loc,v) -> sprintf "%s=%i" (A.pp_location loc) v
+      | Atom (loc,v) -> sprintf "%s=%s" (A.pp_location loc) (Code.pp_v v)
 
     let dump_cond fs = do_dump (cond_of_finals fs)
 


### PR DESCRIPTION
Change the type of `Code.v` from plain `int` to a customer type `NoValue | Plain of int`.  We did not use the standard `option` type as we will introduce fold more value type in the future.

In cycle building process, there are too many different value related field in the `node` data structure. The use of those fields are based on the `node` type and mode/variant of the `diy7`, e.g. `kvm` and `mte`. Those cause confusion and unnecessary complications when maintaining the code.

It is now a relatively trivial change, where `NoValue` collapses to previously default value `-1` via a new function `Code.value_to_int`. However, this leads to a future change that folds other value-related types, such as pte value, instruction value (for iFetch) and memory tag value (for MTE), which means simpler and better-typed code for data type `node` in `cycle.ml`.

In general we assume that 
- in `xxxcompile`, `Code.v` will collapse to `int` and the compilation will work around `int` type
- all previous step work around `node` data structure will work around the more expressive `Code.v`. 


** Note that `Code.value_of_int` is NOT precisely the duality of `Code.value_to_int`, because `Code.value_of_int -1 = Plain -1`, which means `NoValue <> (Code.value_of_int @@ Code.value_to_int @@ NoValue)`.