### PR TITLE
ASL Reference: examples phase 4

### DIFF
--- a/asllib/doc/.gitignore
+++ b/asllib/doc/.gitignore
@@ -6,3 +6,4 @@ comment.cut
 *.blg
 *.dvi
 __pycache__
+ASLReference.synctex(busy)

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -980,6 +980,8 @@
 \newcommand\accessorpairsetter[0]{\text{setter}}
 \newcommand\accessorpairsetterarg[0]{\text{setter\_arg}}
 
+\newcommand\itemprefix[0]{\texttt{item}}
+
 \newcommand\True[0]{\hyperlink{def-true}{\texttt{TRUE}}}
 \newcommand\False[0]{\hyperlink{def-false}{\texttt{FALSE}}}
 
@@ -1233,7 +1235,11 @@
 \newcommand\subtypesat[0]{\hyperlink{def-subtypesat}{\textfunc{subtype\_satisfies}}}
 \newcommand\checktypesat[0]{\hyperlink{def-checktypesat}{\textfunc{checked\_typesat}}}
 \newcommand\typeclashes[0]{\hyperlink{def-typeclashes}{\textfunc{type\_clashes}}}
+\newcommand\Prosetypeclashes[0]{\hyperlink{def-typeclashes}{type-clashes}}
+\newcommand\Prosetypeclash[0]{\hyperlink{def-typeclashes}{type-clash}}
+\newcommand\Prosetypeclashing[0]{\hyperlink{def-typeclashes}{type-clashing}}
 \newcommand\lca[0]{\hyperlink{def-lowestcommonancestor}{\textfunc{lowest\_common\_ancestor}}}
+\newcommand\Proselca[0]{\hyperlink{def-lowestcommonancestor}{lowest common ancestor}}
 \newcommand\namedlca[0]{\hyperlink{def-namedlowestcommonancestor}{\textfunc{named\_lowest\_common\_ancestor}}}
 \newcommand\Supers{\textsf{Supers}}
 \newcommand\bitfieldsincluded[0]{\hyperlink{def-bitfieldsincluded}{\textfunc{bitfields\_included}}}
@@ -1646,6 +1652,7 @@
 \newcommand\checkedtypesatisfies[0]{\hyperlink{def-checktypesat}{checked-type-satisfies}}
 \newcommand\typesatisft[0]{\hyperlink{def-typesatisfies}{type-satisft}}
 \newcommand\subtypesatisfies[0]{\hyperlink{def-subtypesat}{subtype-satisfies}}
+\newcommand\subtypesatisfy[0]{\hyperlink{def-subtypesat}{subtype-satisfy}}
 \newcommand\typeequivalent[0]{\hyperlink{def-typeequal}{type-equivalent}}
 \newcommand\bitwidthequivalent[0]{\hyperlink{def-bitwidthequal}{bitwidth-equivalent}}
 \newcommand\typeclash[0]{\hyperlink{def-typeclashes}{type-clash}}
@@ -3226,3 +3233,5 @@
 \newcommand\vsetter[0]{\texttt{setter}}
 \newcommand\vgetter[0]{\texttt{sgtter}}
 \newcommand\vcode[0]{\texttt{code}}
+\newcommand\vAbf[0]{\textbf{A}}
+\newcommand\vBbf[0]{\textbf{B}}

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -296,6 +296,10 @@ the bitvector type that contains $\field$,
 in an environment $\tenv$, resulting in an
 annotated bitfield --- $\newfield$ --- or a type error, if one is detected.
 
+\ExampleDef{Well-typed Bitfields}
+In \listingref{welltypedbitvectortypes}, all the uses of bitvector types with bitfields are well-typed.
+\ASLListing{Well-typed bitfields}{welltypedbitvectortypes}{\typingtests/TypingRule.TBitField.asl}
+
 \ProseParagraph
 \begin{itemize}
   \item $\vfield$ is a bitfield with list of slices $\vslices$;
@@ -383,11 +387,6 @@ annotated bitfield --- $\newfield$ --- or a type error, if one is detected.
   (\overname{\BitFieldType(\name, \slicesone, \vtp)}{\newfield}, \vses)
 }
 \end{mathpar}
-
-\ExampleDef{Well-typed Bitfields}
-In \listingref{welltypedbitvectortypes}, all the uses of bitvector types with bitfields are well-typed.
-\ASLListing{Well-typed bitfields}{welltypedbitvectortypes}{\typingtests/TypingRule.TBitField.asl}
-
 \CodeSubsection{\TBitFieldBegin}{\TBitFieldEnd}{../Typing.ml}
 
 \TypingRuleDef{CheckSlicesInWidth}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -103,6 +103,8 @@ and define how to evaluate a list of expressions (see \secref{ExprList}).
 \section{Literal Expressions\label{sec:LiteralExpressions}}
 A literal expression represents a literal as an expression.
 
+\ASLListing{Literal Expressions}{literalssemantics}{\semanticstests/SemanticsRule.Lit.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nexpr \derives\  & \Nvalue &\
@@ -123,6 +125,10 @@ A literal expression represents a literal as an expression.
 
 \subsection{Typing}
 \TypingRuleDef{ELit}
+\ExampleDef{Typing of Literal Expressions}
+In \listingref{literalssemantics}, each of the expressions \texttt{3}
+is annotated with the type \verb|integer{3}|.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -143,11 +149,10 @@ A literal expression represents a literal as an expression.
 \CodeSubsection{\ELitBegin}{\ELitEnd}{../Typing.ml}
 
 \subsection{Semantics}
+\SemanticsRuleDef{ELit}
 \ExampleDef{Evaluation of Literal Expressions}
 In \listingref{literalssemantics}, each of the expressions \texttt{3} evaluates to the \nativevalue\ $\nvint(3)$.
-\ASLListing{Semantics of literals}{literalssemantics}{\semanticstests/SemanticsRule.Lit.asl}
 
-\SemanticsRuleDef{ELit}
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -188,6 +193,19 @@ A variable expression consists of an identifier for a storage element.
 
 \subsection{Typing}
 \TypingRuleDef{EVar}
+\ExampleDef{Typing Variable Expressions}
+All of the variable expressions in \listingref{expressions-evar}
+are well-typed.
+\ASLListing{Variable expressions}{expressions-evar}{\typingtests/TypingRule.EVar.asl}
+
+The type system annotates the expression \verb|LOCAL_CONSTANT| as the literal for \verb|7|,
+since it is declared as a \verb|constant|, whereas the expression \verb|var_x|
+on the right-hand-side of the assignment \verb|var y = var_x;| is annotated as \verb|var_x|,
+since \verb|var_x| is not declared as a \verb|constant|.
+
+The variable \texttt{t} in \listingref{expressions-evar-undefined} is undefined.
+\ASLListing{An undefined variable}{expressions-evar-undefined}{\typingtests/TypingRule.EVar.undefined.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -293,11 +311,6 @@ A variable expression consists of an identifier for a storage element.
   \annotateexpr{\tenv,\overname{\EVar(\vx)}{\ve}} \typearrow \TypeErrorVal{\UndefinedIdentifier}
 }
 \end{mathpar}
-
-\subsubsection{Comments}
-Our type system does not currently address assignments of non-constant expressions (for example,
-function calls) to global constant variables.
-\CodeSubsection{\EUndefIdentBegin}{\EUndefIdentEnd}{../Typing.ml}
 
 \subsection{Semantics}
 \SemanticsRuleDef{EVar}
@@ -824,6 +837,9 @@ order does not affect the result of an expression, including any side-effects.
 
 \subsection{Typing}
 \TypingRuleDef{Unop}
+\ExampleRef{Applying Unary Operations to Types} shows examples
+of well-typed unary operation expressions.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -941,6 +957,8 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \subsection{Typing}
 \TypingRuleDef{ECond}
+\ExampleRef{Lowest Common Ancestor} shows examples of typing conditional expressions.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1032,6 +1050,8 @@ conditional expression evaluates to the \texttt{else} expression.
 
 \hypertarget{def-callexpressionterm}{}
 \section{Call Expressions\label{sec:CallExpressions}}
+\ASLListing{Call expressions}{semantics-ecall}{\semanticstests/SemanticsRule.ECall.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nexpr \derives\  & \Ncall &
@@ -1136,6 +1156,10 @@ changes the call type of $\vcall$ to $\calltype$.
 
 \subsection{Typing}
 \TypingRuleDef{ECall}
+\ExampleDef{Typing Call Expressions}
+\listingref{semantics-ecall} shows call expressions (on the right-hand-side of assignments)
+and the inferred types of the expressions, as type annotations on the left-hand-side variables.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1159,10 +1183,8 @@ changes the call type of $\vcall$ to $\calltype$.
 \subsection{Semantics}
 \SemanticsRuleDef{ECall}
 \ExampleDef{Evaluation of Call Expressions}
-In \listingref{semantics-ecall},
-the expression \texttt{Return42()} evaluates to the value \texttt{42} because the
-subprogram \texttt{Return42()} is implemented to return the value \texttt{42}.
-\ASLListing{Evaluating a call expression}{semantics-ecall}{\semanticstests/SemanticsRule.ECall.asl}
+\listingref{semantics-ecall} shows call expressions (on the right-hand-side of assignments)
+and the values they evaluate to, as assertions on the values assigned.
 
 \ProseParagraph
 \AllApply
@@ -1210,11 +1232,13 @@ subprogram \texttt{Return42()} is implemented to return the value \texttt{42}.
 \end{mathpar}
 \CodeSubsection{\EvalECallBegin}{\EvalECallEnd}{../Interpreter.ml}
 
-\hypertarget{def-sliceexpressionterm}{}
 \section{Slicing Expressions\label{sec:SlicingExpressions}}
+\hypertarget{def-sliceexpressionterm}{}
 This section details the high-level form of the syntax and abstract syntax of slicing expressions,
 and defines the semantics of bitvector slices.
-The details of the various types of bitvector slices is deferred to \chapref{BitvectorSlicing}.
+The details of the various types of bitvector slices are deferred to \chapref{BitvectorSlicing}.
+
+\ASLListing{Slicing Expressions}{semantics-eslice}{\semanticstests/SemanticsRule.ESlice.asl}
 
 \subsection{Syntax}
 \begin{flalign*}
@@ -1230,15 +1254,26 @@ The details of the various types of bitvector slices is deferred to \chapref{Bit
 \begin{mathpar}
 \inferrule{
   \buildexpr(\vexpr) \astarrow \astversion{\vexpr} \OrBuildError\\\\
-  \buildslice(\vslice) \astarrow \astversion{\vslice} \OrBuildError
+  \buildslices(\vslices) \astarrow \astversion{\vslices} \OrBuildError
 }{
-  \buildexpr(\overname{\Nexpr(\vexpr: \Nexpr, \vslice: \Nslice)}{\vparsednode}) \astarrow
-  \overname{\ESlice(\astversion{\vexpr}, \astversion{\vslice})}{\vastnode}
+  \buildexpr(\overname{\Nexpr(\vexpr: \Nexpr, \vslices: \Nslices)}{\vparsednode}) \astarrow
+  \overname{\ESlice(\astversion{\vexpr}, \astversion{\vslices})}{\vastnode}
 }
 \end{mathpar}
 
 \subsection{Typing}
 \TypingRuleDef{ESlice}
+\ExampleDef{Typing of Slicing Expressions}
+\listingref{semantics-eslice} the type inferred for the
+slicing expression \verb|'1 1110 000'[6:3, 7]| is \\
+\verb|bits(5){}|.
+That is, a bitvector of width \verb|5| without any bitfields.
+%
+The same type is inferred for the slicing expressions
+\verb|240[6:3, 7]| and \verb|496[6:3, 7]|
+(\verb|240| is equivalent to \verb|'1 111 0 000'|
+and \verb|496| is equivalent to \verb|'11 111 0 000'|).
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1279,6 +1314,10 @@ initializer expression.
 \identi{MJWM}
 
 \TypingRuleDef{ESliceError}
+\ExampleDef{Ill-typed Slicing Expressions}
+The expression \verb|5.0[2:0]| is ill-typed, since the type of \verb|5.0|
+is an \integertypeterm{} nor a \bitvectortypeterm.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1302,10 +1341,14 @@ initializer expression.
 
 \subsection{Semantics}
 \SemanticsRuleDef{ESlice}
-\subsubsection{Evaluation of Slicing Expressions}
-In \listingref{semantics-eslice},
-the expression \texttt{'11110000'[6:3]} evaluates to the value \texttt{'1110'}.
-\ASLListing{Evaluating a slice expression}{semantics-eslice}{\semanticstests/SemanticsRule.ESlice.asl}
+\ExampleDef{Evaluation of Slicing Expressions}
+\listingref{semantics-eslice} the slicing expression \verb|'1 1110 000'[6:3, 7]|
+evaluates to the bitvector value \texttt{'1110 1'},
+same as the slicing expressions
+\verb|240[6:3, 7]| and \verb|496[6:3, 7]|.
+
+Note that in the following definition,
+the function $\readfrombitvector$ takes care of converting integers to bitvectors.
 
 \ProseParagraph
 \AllApply
@@ -1320,6 +1363,7 @@ resulting bitvector --- and the execution graph $\vgone$;
       which concatenates all of the values from the indicates indices\ProseOrError;
 \item $\vg$ is the parallel composition of $\vgone$ and $\vgtwo$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
@@ -1335,9 +1379,9 @@ resulting bitvector --- and the execution graph $\vgone$;
 \end{mathpar}
 \CodeSubsection{\EvalESliceBegin}{\EvalESliceEnd}{../Interpreter.ml}
 
+\section{Array Access Expressions\label{sec:ArrayAccessExpressions}}
 \hypertarget{def-getarrayexpressionterm}{}
 \hypertarget{def-getenumarrayexpression}{}
-\section{Array Access Expressions\label{sec:ArrayAccessExpressions}}
 This section details the syntax, abstract syntax, semantics, and typing of array read expressions.
 In the untyped AST, a read from either an integer-indexed array or an enumeration-indexed arrays is represented
 the same way. They type system infers the kind of array and outputs a typed AST node differentiating
@@ -1370,11 +1414,17 @@ The semantics utilizes a rule matching the corresponding type of array ---
 \TypingRuleDef{EGetArray}
 \hypertarget{def-arrayaccess}{}
 \begin{definition}[Array Access]
-We refer to a right-hand-side expression of the form \texttt{b[[i]]},
+We refer to a right-hand-side expression of the form \verb|b[[i]]|,
 where $b, i$ are subexpressions, as an \arrayaccess\ expression.
 We refer to $b$ and $i$ as the \emph{base}
 and the $\emph{index}$ subexpressions, respectively.
 \end{definition}
+
+\ExampleDef{Array Access Expressions}
+\listingref{typing-tarray} shows examples of well-typed
+array access expressions on the right-hand-side of the
+assignments to \verb|int_arr| and \verb|big_little_arr|
+and the types inferred for them via the added \verb|as <inferred-type>|.
 
 \ProseParagraph
 \AllApply
@@ -1429,6 +1479,8 @@ $\eindex$ is the index expression.
 The function returns the type of the annotated expression in $\vt$,
 the annotated expression $\newe$, and the inferred \sideeffectdescriptorterm\ $\vses$.
 
+See \ExampleRef{Array Access Expressions}.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1476,7 +1528,7 @@ indexed by \texttt{2} in \texttt{my\_array} is \texttt{42}.
 \ASLListing{Evaluating an array access expression}{semantics-egetarray}{\semanticstests/SemanticsRule.EGetArray.asl}
 
 \ExampleDef{Evaluation of an Illegal Array Read}
-In \listingref{semantics-egetarrayerror}.
+In \listingref{semantics-egetarrayerror},
 evaluating the array access expression \verb|my_array[[3]]| results in a dynamic error,
 since we are trying to access index \texttt{3} of an array
 which has indexes \texttt{0}, \texttt{1} and \texttt{2} only.
@@ -1572,6 +1624,12 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 
 \subsection{Typing}
 \TypingRuleDef{EGetRecordField}
+\ExampleDef{Typing Record Field Expressions}
+\listingref{eget-record-field} shows field reading expressions
+as the right-hand-side expressions of assignments
+and the types inferred for them via the added \verb|as <inferred-type>|.
+\ASLListing{Typing record field expressions}{eget-record-field}{\typingtests/TypingRule.EGetRecordField.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1588,7 +1646,7 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo, \vsesone) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
-  \vtetwo \eqname L(\fields)\\
+  \vtetwo = L(\fields)\\
   L \in \{\TRecord, \TException\}\\
   \assocopt(\fields, \fieldname) \typearrow \langle \vt\rangle
 }{
@@ -1603,6 +1661,10 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \CodeSubsection{\EGetRecordFieldBegin}{\EGetRecordFieldEnd}{../Typing.ml}
 
 \TypingRuleDef{EGetBadRecordField}
+\ExampleDef{Ill-typed Record Field Expressions}
+\listingref{eget-bad-record-field} shows an ill-typed field expression.
+\ASLListing{An ill-typed record field expression}{eget-bad-record-field}{\typingtests/TypingRule.EGetBadRecordField.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1618,7 +1680,7 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
-  \vtetwo \eqname L(\fields)\\
+  \vtetwo = L(\fields)\\
   L \in \{\TRecord, \TException\}\\
   \assocopt(\fields, \fieldname) \typearrow \None
 }{
@@ -1628,6 +1690,10 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \CodeSubsection{\EGetBadRecordFieldBegin}{\EGetBadRecordFieldEnd}{../Typing.ml}
 
 \TypingRuleDef{EGetBadBitField}
+\ExampleDef{Ill-typed Bitfield Expressions}
+\listingref{eget-bad-bitfield} shows an ill-typed bitfield expression.
+\ASLListing{An ill-typed bitfield expression}{eget-bad-bitfield}{\typingtests/TypingRule.EGetBadBitfield.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1644,7 +1710,7 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo, \vsesone) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
-  \vtetwo \eqname \TBits(\Ignore, \bitfields)\\
+  \vtetwo = \TBits(\Ignore, \bitfields)\\
   \findbitfieldopt(\bitfields, \fieldname) \typearrow \None
 }{
   \annotateexpr{\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}} \typearrow \TypeErrorVal{\BadField}
@@ -1653,6 +1719,12 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \CodeSubsection{\EGetBadBitFieldBegin}{\EGetBadBitFieldEnd}{../Typing.ml}
 
 \TypingRuleDef{EGetBitField}
+\ExampleDef{Well-typed Bitfield Expressions}
+\listingref{eget-bitfield} shows well-typed bitfield expressions
+as the right-hand-side expressions of assignment statements,
+and the types inferred for them via the added \verb|as <inferred-type>|.
+\ASLListing{Well-typed bitfield expressions}{eget-bitfield}{\typingtests/TypingRule.EGetBitfield.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1670,7 +1742,7 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo, \vsesone) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
-  \vtetwo \eqname \TBits(\Ignore, \bitfields)\\
+  \vtetwo = \TBits(\Ignore, \bitfields)\\
   \findbitfieldopt(\bitfields, \fieldname) \typearrow \langle \BitFieldSimple(\Ignore, \slices)\rangle\\
   \vethree \eqdef \ESlice(\vetwo, \slices)\\
   \annotateexpr{\tenv, \vethree} \typearrow (\vt, \newe, \vses) \OrTypeError
@@ -1681,6 +1753,11 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \CodeSubsection{\EGetBitFieldBegin}{\EGetBitFieldEnd}{../Typing.ml}
 
 \TypingRuleDef{EGetBitFieldNested}
+\ExampleDef{Nested Bitfield Expressions}
+\listingref{eget-bitfield} shows the expression \verb|p.detailed_data.info|,
+which refers to the bitfield \verb|info|, which is nested in the bitfield
+\verb|detailed_data|.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1701,7 +1778,7 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo, \vsesone) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
-  \vtetwo \eqname \TBits(\Ignore, \bitfields)\\\\
+  \vtetwo = \TBits(\Ignore, \bitfields)\\\\
   {
     \begin{array}{r}
   \findbitfieldopt(\bitfields, \fieldname) \typearrow \\ \langle \BitFieldNested(\Ignore, \slices, \bitfieldsp)\rangle
@@ -1718,6 +1795,10 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \CodeSubsection{\EGetBitFieldNestedBegin}{\EGetBitFieldNestedEnd}{../Typing.ml}
 
 \TypingRuleDef{EGetBitFieldTyped}
+\ExampleDef{Typed Bitfield Expressions}
+\listingref{eget-bitfield} shows the expression \verb|p.detailed_data.info|,
+which includes the type annotation \verb|bits(4)|.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1737,7 +1818,7 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo, \vsesone) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
-  \vtetwo \eqname \TBits(\Ignore, \bitfields)\\
+  \vtetwo = \TBits(\Ignore, \bitfields)\\
   \findbitfieldopt(\bitfields, \fieldname) \typearrow \langle \BitFieldType(\Ignore, \slices, \vt)\rangle\\
   \vethree \eqdef \ESlice(\vetwo, \slices)\\
   \annotateexpr{\tenv, \vethree} \typearrow (\vtefour, \newe, \vsesnew) \OrTypeError\\\\
@@ -1749,7 +1830,10 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \CodeSubsection{\EGetBitFieldTypedBegin}{\EGetBitFieldTypedEnd}{../Typing.ml}
 
 \TypingRuleDef{EGetTupleItem}
-\newcommand\itemprefix[0]{\texttt{item}}
+\ExampleDef{Typing of a Tuple Item Expression}
+In \listingref{semantics-egetitem}, the type of the expression \verb|t.item0|
+is the \integertypeterm.
+
 In the following rule definition, we use $\itemprefix$ to stand
 for its verbatim string.
 
@@ -1761,7 +1845,7 @@ for its verbatim string.
   \item obtaining the \underlyingtype\ of $\vteone$ yields $\vtetwo$\ProseOrTypeError;
   \item $\vtetwo$ is \tupletypeterm{} with list of types $\tys$, that is, $\TTuple(\tys)$;
   \item $\fieldname$ is an identifier consisting of the prefix \itemprefix{} and the suffix $\num$;
-  \item $\num$ is lexically an integer token with the integer value $\vindex$;
+  \item $\num$ is lexically an integer numeral with the integer value $\vindex$;
   \item determining whether $\vindex$ is between $0$ and the number of types in $\tys$, inclusive, yields $\True$\ProseOrTypeError;
   \item $\vt$ is the type at position $\vindex$ of $\tys$;
   \item $\newe$ is the expression for obtaining the item at index $\vindex$ from the expression $\vetwo$, that is, $\EGetItem(\vetwo, \vindex)$;
@@ -1772,7 +1856,7 @@ for its verbatim string.
 \inferrule{
   \annotateexpr{\tenv, \veone} \typearrow (\vteone, \vetwo, \vsesone) \OrTypeError\\\\
   \makeanonymous(\tenv, \vteone) \typearrow \vtetwo \OrTypeError\\\\
-  \vtetwo \eqname \TTuple(\tys)\\
+  \vtetwo = \TTuple(\tys)\\
   \fieldname = \itemprefix \stringconcat \num\\
   \num \in \Lang(\REintlit)\\
   \decimaltolit(\num) = \Tintlit(\vindex)\\
@@ -1786,6 +1870,11 @@ for its verbatim string.
 \CodeSubsection{\EGetTupleItemBegin}{\EGetTupleItemEnd}{../Typing.ml}
 
 \TypingRuleDef{EGetBadField}
+\ExampleDef{An Ill-typed Field Expression}
+\listingref{eget-bad-field} shows an example of an ill-typed field expression
+\verb|a.f|.
+\ASLListing{An ill-typed field expression}{eget-bad-field}{\typingtests/TypingRule.EGetBadBitField.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1833,6 +1922,13 @@ the expression \verb|my_record.a| evaluates to the value \texttt{3}.
 \CodeSubsection{\EvalEGetFieldBegin}{\EvalEGetFieldEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{EGetItem}
+\ExampleDef{Evaluation of a Tuple Item Expression}
+In \listingref{semantics-egetitem},
+the expression \verb|t.item0| evaluates to the value \texttt{1}
+and
+the expression \verb|t.item1| evaluates to the value \texttt{2}.
+\ASLListing{Evaluating a tuple item access expression}{semantics-egetitem}{\semanticstests/SemanticsRule.EGetItem.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1882,6 +1978,11 @@ the expression \verb|my_record.a| evaluates to the value \texttt{3}.
 
 \subsection{Typing}
 \TypingRuleDef{EGetFields}
+\ExampleDef{Typing Multi-field Expressions}
+\pagebreak
+\listingref{egetfields} shows examples of well-typed multi-field expressions.
+\ASLListing{Typing multi-field expressions}{egetfields}{\typingtests/TypingRule.EGetFields.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1973,6 +2074,15 @@ returns the slices associated with the bitfield named $\name$ in the list of bit
 in $\vslices$.
 \ProseOtherwiseTypeError
 
+\ExampleDef{Finding the Slices of a Bitfield}
+In \listingref{eget-bitfield},
+given the list of bitfields of the \verb|Packet| type,
+the list of slices associated with
+\verb|data| is \verb|7:1|.
+Attempting to obtain the list of slices associated with
+\verb|crc|, given the list of bitfields of the \verb|Packet| type,
+yields a \typingerrorterm, since it is a nested bitfield.
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -2030,12 +2140,18 @@ The helper function
   \getbitfieldwidth(
     \overname{\staticenvs}{\tenv} \aslsep
     \overname{\identifier}{\name} \aslsep
-    \overname{\field^*}{\tfields})
+    \overname{\Field^*}{\tfields})
   \aslto \overname{\expr}{\ewidth} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 returns the expression $\ewidth$ that describes the width of the bitfield named $\name$
 in the list of fields $\tfields$.
 \ProseOtherwiseTypeError
+
+\ExampleDef{Obtaining the Width of a Bitfield}
+In \listingref{egetfields},
+obtaining the width of the field \verb|bits3_2|,
+given the list of fields of the type \verb|RecordWithBits|
+yields the literal expression for \verb|2|.
 
 \ProseParagraph
 \OneApplies
@@ -2043,7 +2159,7 @@ in the list of fields $\tfields$.
   \item \AllApplyCase{okay}
   \begin{itemize}
     \item applying $\assocopt$ to find the type associated with $\name$ in $\tfields$ yields the type $\vt$;
-    \item applying $\getbitvectorwidth$ to $\vt$ in $\tenv$ yields $\ewidth$.
+    \item applying $\getbitvectorwidth$ to $\vt$ in $\tenv$ yields $\ewidth$\ProseOrTypeError.
   \end{itemize}
 
   \item \AllApplyCase{error}
@@ -2057,7 +2173,7 @@ in the list of fields $\tfields$.
 \begin{mathpar}
 \inferrule[okay]{
   \assocopt(\name, \tfields) \typearrow \langle\vt\rangle\\
-  \getbitvectorwidth(\tenv, \vt) \typearrow \ewidth
+  \getbitvectorwidth(\tenv, \vt) \typearrow \ewidth \OrTypeError
 }{
   \getbitfieldwidth(\tenv, \name, \tfields) \typearrow \ewidth
 }
@@ -2082,6 +2198,12 @@ The helper function
 generates the expression $\ewidth$, which represents the summation of all expressions in the list $\exprs$,
 normalized in the static environment $\tenv$.
 \ProseOrTypeError
+
+\ExampleDef{Summing Widths}
+Summing the list of expression \verb|2, 3|,
+yields the expression \verb|2+3|,
+(in AST terms, \\
+$\AbbrevEBinop{\PLUS}{\ELInt{2}}{\ELInt{2}}$).
 
 \ProseParagraph
 \OneApplies
@@ -2118,6 +2240,16 @@ normalized in the static environment $\tenv$.
 
 \subsection{Semantics}
 \SemanticsRuleDef{EGetfields}
+\ExampleDef{Evaluating Multi-field Expressions}
+In \listingref{egetfields},
+evaluating the multi-field expression \\
+\verb|bits_var.[bits3_2, bit1, bit0, info_and_bits]|
+yields the bitvector value \\
+\verb|'00101010'|,
+and evaluating the multi-field expression \\
+\verb|record_var.[bits3_2, bit1, bit0, info]|
+yields the bitvector value \verb|'001010'|.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -2147,8 +2279,8 @@ normalized in the static environment $\tenv$.
 \identi{TCST}
 The rule about domains in the definitions of subtype-satisfaction and
 type-satisfaction means that it is illegal to use the unconstrained integer
-where a constrained integer is expected. An asserting type conversion (ATC) can
-be used to overcome this.
+where a constrained integer is expected.
+An asserting type conversion, ATC for short, can be used to overcome this.
 
 \identi{CGRH}
 An ATC allows code to explicitly mark places where uses of constrained types
@@ -2161,6 +2293,8 @@ Note that ATCs are execution-time checks. An execution-time check is a
 condition that is evaluated during the evaluation of an execution-time
 initializer expression or subprogram. If the condition evaluates to $\False$ it
 is a dynamic error.
+
+\ASLListing{ATC expressions}{typing-atc}{\typingtests/TypingRule.ATC.asl}
 
 \subsection{Syntax}
 \begin{flalign*}
@@ -2200,11 +2334,15 @@ is a dynamic error.
 
 \subsection{Typing}
 \TypingRuleDef{ATC}
+\ExampleDef{Well-typed Asserting Type Conversion Expressions}
+\listingref{typing-atc} shows examples of ATC expressions
+and the corresponding annotated expressions in comments.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
   \item $\ve$ denotes an asserting type conversion with expression $\vep$ and type $\tty$, that is $\EATC(\vep, \tty)$;
-  \item annotating the expression $\vep$ in $\tenv$ yields $(\vt, \vepp, \\vsese)$\ProseOrTypeError;
+  \item annotating the expression $\vep$ in $\tenv$ yields $(\vt, \vepp, \vsese)$\ProseOrTypeError;
   \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$\ProseOrTypeError;
   \item annotating the type $\tty$ in $\tenv$ yields $(\ttyp, \vsesty)$\ProseOrTypeError;
   \item obtaining the \structure\ of $\tty'$ in $\tenv$ yields $\vtystruct$\ProseOrTypeError;
@@ -2250,6 +2388,10 @@ The helper function
 checks whether the types $\vtone$ and $\vttwo$, which are assumed to not be named types,
 are compatible for a typing assertion in the static environment $\tenv$, yielding $\True$.
 \ProseOtherwiseTypeError
+
+\ExampleDef{Ill-typed ATC Expressions}
+\listingref{checkatc} shows examples of ill-typed ATC expressions.
+\ASLListing{Ill-typed ATC expressions}{checkatc}{\typingtests/TypingRule.CheckATC.asl}
 
 \ProseParagraph
 \OneApplies
@@ -2424,6 +2566,12 @@ only returns \False\ in cases where dynamic information is required.
 Recall that the $\vt$ is the result of $\annotatetype$, which ensures that
 all sub-expressions appearing in $\vt$ are side-effect-free.
 
+\ExampleDef{Checking Whether a Value Belongs to a Type}
+In \listingref{semantics-variousatcs},
+checking whether the value \verb|2| is a member of the type \verb|integer{1,2,3}|
+succeeds whereas checking whether the value \verb|2| is a member
+of the type \verb|integer{4, 5, 6}| fails.
+
 \OneApplies
 \begin{itemize}
   \item \AllApplyCase{type\_equal}
@@ -2471,6 +2619,7 @@ all sub-expressions appearing in $\vt$ are side-effect-free.
     of the constraints.
   \end{itemize}
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[type\_equal]{
@@ -2518,6 +2667,7 @@ all sub-expressions appearing in $\vt$ are side-effect-free.
 \end{mathpar}
 \CodeSubsection{\EvalValOfTypeBegin}{\EvalValOfTypeEnd}{../Interpreter.ml}
 
+\subsubsection{Comments}
 Notice that these rules cover all types, including named types ($\TNamed$),
 since the \typedast\ returned from \TypingRuleRef{ATC} is the \structure\ of the type
 given in the specification.
@@ -2541,6 +2691,8 @@ tests whether the integer value $n$ \emph{satisfies the constraint} $\vc$
 (that is, whether $n$ is within the range of values defined by $\vc$) in the environment $\env$
 and returns a Boolean answer $\vb$ and the execution graph $\vg$ resulting from evaluating
 the expressions appearing in $\vc$.
+
+See \ExampleRef{Checking Whether a Value Belongs to a Type}.
 
 \ProseParagraph
 \OneApplies
@@ -2596,6 +2748,8 @@ Lists of patterns are also used in case statements.
 %
 \chapref{PatternMatching} goes into the details of the various types of patterns that can be matched against.
 
+\ASLListing{Pattern expressions}{semantics-epattern}{\semanticstests/SemanticsRule.EPattern.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nexpr \derives\  & \Nexpr \parsesep \Tin \parsesep \Npatternset &\\
@@ -2643,6 +2797,8 @@ Lists of patterns are also used in case statements.
 
 \subsection{Typing}
 \TypingRuleDef{EPattern}
+\listingref{semantics-epattern} shows examples of pattern expressions.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -2673,7 +2829,9 @@ Lists of patterns are also used in case statements.
 In \listingref{semantics-epattern},
 the expression \texttt{42 IN \{0..3, 42\}} evaluates to $\nvbool(\True)$
 whereas the expression \texttt{42 IN \{0..3, -4\}} evaluates to $\nvbool(\False)$.
-\ASLListing{Evaluating a pattern expression}{semantics-epattern}{\semanticstests/SemanticsRule.EPattern.asl}
+%
+In addition, all assertions, which demonstrate pattern expression involving bitmasks,
+succeed.
 
 \ProseParagraph
 \AllApply
@@ -2712,7 +2870,6 @@ Note that there are two important consequences of producing an arbitrary value w
     In particular, the language does not define which valid member it is, and ASL specifications must not rely on the value (for example, there is no way to test whether a value was produced by evaluating \ARBITRARY{}).
 \end{enumerate}
 
-
 \subsection{Syntax}
 \begin{flalign*}
 \Nexpr \derives\  & \Tarbitrary \parsesep \Tcolon \parsesep \Nty &
@@ -2735,6 +2892,11 @@ Note that there are two important consequences of producing an arbitrary value w
 
 \subsection{Typing}
 \TypingRuleDef{EArbitrary}
+\listingref{semantics-earbitraryunconstrained},
+\listingref{semantics-earbitraryconstrained}, and
+\listingref{semantics-earbitraryarray}
+show examples of well-typed arbitrary value expressions.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -2825,8 +2987,10 @@ and how to obtain an arbitrary enumeration-indexed array, \texttt{enum\_array}.
 Notice that this rule introduces non-determinism.
 \identr{WLCH}
 
-\hypertarget{def-recordexpressionterm}{}
 \section{Structured Type Construction Expressions\label{sec:StructuredTypeConstructionExpressions}}
+\hypertarget{def-recordexpressionterm}{}
+\ASLListing{Record construction expression}{semantics-erecord}{\semanticstests/SemanticsRule.ERecord.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nexpr \derives\  & \Tidentifier \parsesep \Tlbrace \parsesep \Trbrace &\\
@@ -2891,13 +3055,16 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \subsection{Typing}
 \TypingRuleDef{ERecord}
+\listingref{semantics-erecord} shows an example of a well-typed record construction expression
+and an example (in comment) where the same field is initialized twice, which is incalid..
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
   \item $\ve$ denotes the record construction expression (which is also used for creating exceptions) of type $\tty$ with fields $\fields$,
         that is, $\ERecord(\tty, \vfields)$;
   \item obtaining the \underlyingtype\ of $\tty$ in $\tenv$ yields $\ttyanon$\ProseOrTypeError;
-  \item checking that $\ttyanon$ is a \structuredtype\ yields $\True$\ProseOrTypeError;% \ProseTerminateAs{\TypeErrorVal{\ExpectedStructuredType}};
+  \item checking that $\ttyanon$ is a \structuredtype\ yields $\True$\ProseTerminateAs{\UnexpectedType};
   \item $\ttyanon$ is a \structuredtype\ with a list of $\field$ elements (consisting of a field name and a field type);
   \item obtaining the list of field names from $\vfields$ yields the list of identifiers \\
         $\initializedfields$;
@@ -2957,7 +3124,10 @@ The function
 \]
 annotates a field initializers $(\name, \vep)$ in a record expression
 with list of fields \\ $\fieldtypes$ and returns the annotated initializing expression $\vepp$
-and its \sideeffectdescriptorterm\ $\vses$. \ProseOtherwiseTypeError
+and its \sideeffectdescriptorterm\ $\vses$.
+\ProseOtherwiseTypeError
+
+See \listingref{semantics-erecord} for an example.
 
 \ProseParagraph
 \AllApply
@@ -2986,7 +3156,6 @@ and its \sideeffectdescriptorterm\ $\vses$. \ProseOtherwiseTypeError
 In \listingref{semantics-erecord},
 the expression \verb|MyRecordType{a=3, b=42}| evaluates to the native record value \\
 $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
-\ASLListing{Evaluating a record construction expression}{semantics-erecord}{\semanticstests/SemanticsRule.ERecord.asl}
 
 \ProseParagraph
 \AllApply
@@ -3014,8 +3183,11 @@ $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
 \end{mathpar}
 \CodeSubsection{\EvalERecordBegin}{\EvalERecordEnd}{../Interpreter.ml}
 
-\hypertarget{def-tupleexpressionterm}{}
 \section{Tuple Expressions\label{sec:TupleExpressions}}
+\hypertarget{def-tupleexpressionterm}{}
+
+\ASLListing{Tuple expression}{semantics-etuple}{\semanticstests/SemanticsRule.ETuple.asl}
+
 \subsection{Syntax}
 \begin{flalign*}
 \Nexpr \derives\  & \Plisttwo{\Nexpr} &
@@ -3038,6 +3210,8 @@ $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
 
 \subsection{Typing}
 \TypingRuleDef{ETuple}
+\listingref{semantics-etuple} shows an example of a well-typed tuple expressions.
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -3084,7 +3258,6 @@ $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
 \ExampleDef{Evaluation of Tuple Expressions}
 In \listingref{semantics-etuple},
 the expression \texttt{(3, Return42())} evaluates to the value \texttt{(3, 42)}.
-\ASLListing{Evaluating a tuple expression}{semantics-etuple}{\semanticstests/SemanticsRule.ETuple.asl}
 
 \ProseParagraph
 \AllApply
@@ -3146,6 +3319,15 @@ The Semantic Rules use $\evalexprsef\empty$ because the typechecker in
 $\annotatetype$ guarantees that expressions in types are side-effect-free.
 
 \SemanticsRuleDef{EArray}
+In \listingref{typing-tarray},
+the variable \verb|int_arr| is initialized with an array construction expression
+(which is not expressible in ASL text, only in \typedast, but conceptually could be
+represented as \verb|array[[4]] of 0|),
+which evaluates to
+\[
+\nvvector{[\nvint(0), \nvint(0), \nvint(0), \nvint(0)]} \enspace.
+\]
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -3177,6 +3359,15 @@ $\annotatetype$ guarantees that expressions in types are side-effect-free.
 \CodeSubsection{\EvalEArrayBegin}{\EvalEArrayEnd}{../Typing.ml}
 
 \SemanticsRuleDef{EEnumArray}
+In \listingref{typing-tarray},
+the variable \verb|big_little_arr| is initialized with an array construction expression
+(which is not expressible in ASL text, only in \typedast, but conceptually could be
+represented as \verb|array[[Labels]] of '0000'|),
+which evaluates to
+\[
+\nvrecord{\{\texttt{BIG}\mapsto\nvbitvector(0000), \texttt{LITTLE}\mapsto\nvbitvector(0000)\}} \enspace.
+\]
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -3224,6 +3415,11 @@ The helper relation
 specializes the expression evaluation relation for side-effect-free expressions
 by omitting throwing configurations as possible output configurations.
 
+\ExampleDef{Evaluating a Side-effect-free Expression}
+Evaluating the literal expression $\lint(1)$ in any environment $\env$,
+yields \\
+$\Normal(\nvint(1), \emptygraph)$.
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
@@ -3237,8 +3433,8 @@ since side-effect-free expressions do not modify the environment.
 
 \section{Evaluating a List of Expressions\label{sec:ExprList}}
 \SemanticsRuleDef{EExprList}
-The relation
 \hypertarget{def-evalexprlist}{}
+The relation
 \[
   \evalexprlist{\overname{\envs}{\env} \aslsep \overname{\expr^*}{\vle}} \;\aslrel\;
   \Normal((\overname{\vals^*}{\vv} \times \overname{\XGraphs}{\vg})\aslsep \overname{\envs}{\newenv}) \cup
@@ -3248,6 +3444,12 @@ evaluates the list of expressions $\vle$ in left-to-right order in the initial e
 and returns the resulting value $\vv$, the parallel composition of the execution graphs
 generated from evaluating each expression, and the new environment $\newenv$.
 If the evaluation of any expression terminates abnormally then the abnormal configuration is returned.
+
+\ExampleDef{Evaluating a List of Expressions}
+In \listingref{semantics-erecord},
+evaluating the expression \verb|MyRecordType{a=3, b=42}| entails evaluating
+the expression list \verb|3, 42|, which yields
+the list of values $[\nvint(3), \nvint(42)]$.
 
 \ProseParagraph
 \OneApplies

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -17,8 +17,21 @@ The \emph{\supertypeterm} is the inverse relation.
 That is, \tty\ is a \supertypeterm{} of \tsy\ if and only if \tsy\ is a \subtypeterm{} of \tty.
 
 \ExampleDef{Subtypes and Supertypes}
-In \listingref{subtype},
-\texttt{subInt} is a subtype of itself and of \texttt{superInt}
+The following table determines whether the type \vAbf{}
+subtypes the type \vBbf{} with respect to the types
+declared in \listingref{subtype}:\\
+\begin{tabular}{llll}
+  \textbf{type A} & \textbf{type B}   & \textbf{subtypes?}  & \textbf{reason}\\
+\hline
+  \texttt{subInt}     & \texttt{subInt}   & yes             & subtyping is reflexive for \namedtypesterm{}\\
+  \texttt{subInt}     & \texttt{superInt} & yes             & declared as a \subtypeterm{}\\
+  \texttt{superInt}   & \texttt{subInt}   & no              & subtyping is anti-symmetric\\
+  \texttt{subsubInt}  & \texttt{superInt} & yes             & subtyping is transitive\\
+  \texttt{otherInt}   & \texttt{superInt} & no              & no chain of subtyping between the types\\
+  \texttt{superInt}   & \texttt{integer}  & no              & \texttt{integer} is not a \namedtypeterm{}\\
+  \texttt{integer}    & \texttt{integer}  & no              & \texttt{integer} is not a \namedtypeterm{}\\
+\end{tabular}
+
 \ASLListing{Subtypes and Supertypes}{subtype}{\typingtests/TypingRule.Subtype.asl}
 
 \hypertarget{def-subtypesrel}{}
@@ -101,9 +114,25 @@ The predicate
   \subtypesat(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
   \aslto \overname{\Bool}{\vb} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-tests whether a type $\vt$ \emph{subtype-satisfies} a type $\vs$ in environment $\tenv$,
-returning the result $\vb$ or a type error, if one is detected.
+determines whether a type $\vt$ \emph{subtype-satisfies} a type $\vs$ in environment $\tenv$,
+returning the result in $\vb$.
+\ProseOtherwiseTypeError
+
 The function assumes that both $\vt$ and $\vs$ are well-typed according to \chapref{Types}.
+
+\ExampleDef{Subtype Satisfaction}
+\listingref{subtypesat1} shows examples
+where the types of the right-hand-side expressions \subtypesatisfy{}
+the types of the left-hand-side expressions.
+\ASLListing{Subtype Satisfaction}{subtypesat1}{\typingtests/TypingRule.SubtypeSatisfaction1.asl}
+
+\listingref{subtypesat2} shows examples of legal and illegal assignments involving
+subtyping.
+\ASLListing{More Examples of Subtype Satisfaction}{subtypesat2}{\typingtests/TypingRule.SubtypeSatisfaction2.asl}
+
+\listingref{subtypesat3} shows more examples of legal and illegal assignments involving
+subtyping.
+\ASLListing{Even More Examples of More Subtype Satisfaction}{subtypesat3}{\typingtests/TypingRule.SubtypeSatisfaction3.asl}
 
 \ProseParagraph
 \OneApplies
@@ -350,13 +379,14 @@ if there is a unique one, as follows:
 \CodeSubsection{\SubtypeSatisfactionBegin}{\SubtypeSatisfactionEnd}{../types.ml}
 
 \TypingRuleDef{TypeSatisfaction}
+\identr{FMXK}
 \hypertarget{def-typesatisfies}{}
 The predicate
 \[
   \typesat(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
   \aslto \overname{\Bool}{\vb} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-tests whether a type $\vt$ \emph{\typesatisfies} a type $\vs$ in environment $\tenv$,
+determines whether a type $\vt$ \emph{\typesatisfies} a type $\vs$ in environment $\tenv$,
 returning the result $\vb$.
 \ProseOtherwiseTypeError
 
@@ -501,14 +531,7 @@ type \texttt{pairT}.
   \typesat(\tenv, \vt, \vs) \typearrow \overname{\False}{\vb}
 }
 \end{mathpar}
-
 \CodeSubsection{\TypeSatisfactionBegin}{\TypeSatisfactionEnd}{../types.ml}
-
-\subsubsection{Comments}
-Since the subtype relation is a partial order, it is reflexive. Therefore
-every type $\vt$ is a subtype of itself, and as a consequence, every type $\vt$
-\typesatisfies\  itself.
-\identr{FMXK}  \identi{NLFD}
 
 \TypingRuleDef{CheckTypeSatisfaction}
 \hypertarget{def-checktypesat}{}
@@ -520,6 +543,15 @@ We also define
 which is the same as $\typesat$, but yields a type error when \\ $\typesat(\tenv, \vt, \vs)$ is $\False$.
 
 The function assumes that both $\vt$ and $\vs$ are well-typed according to \secref{Types}.
+
+\ExampleDef{Checking Type Satisfaction}
+In \listingref{typing-typesat1},
+checking whether \verb|(integer, T1)| \typesatisfies{} \verb|pairT|
+for the assignment \verb|var pair: pairT = (1, dataT1)| yields $\True$.
+
+In \listingref{typing-typesat3}, checking whether \verb|(intege, T2)|
+\typesatisfies{} \verb|pairT| for the assignment \verb|pair = (1, dataT2);|
+yields a \typingerrorterm.
 
 \ProseParagraph
 \OneApplies
@@ -561,8 +593,25 @@ The predicate
   \typeclashes(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
   \aslto \overname{\Bool}{\vb} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-tests whether a type $\vt$ \emph{type-clashes} with a type $\vs$ in environment $\tenv$,
-returning the result $\vb$ or a type error, if one is detected.
+determines whether a type $\vt$ \emph{\Prosetypeclashes} with a type $\vs$ in environment $\tenv$,
+returning the result $\vb$.
+\ProseOtherwiseTypeError
+
+This is used in \TypingRuleRef{HasArgClash} to determine whether the signatures
+of two subprograms allow them to be declared simultaneously.
+
+\identd{VPZZ} \identi{PQCT}  \identi{WZKM}
+\RequirementDef{TypeClashEquivalence}
+\identi{WZKM}
+Note that \Prosetypeclashing{} is an equivalence relation.
+In particular note that if $T$ \Prosetypeclashes{} with $A$ and $B$ then $A$ and
+$B$ \Prosetypeclash{}.
+
+\ExampleDef{Type Clash}
+\listingref{type-clashes} shows examples of types ---
+the arguments of procedures -- that do not clash and types that do clash
+(shown in comments).
+\ASLListing{Examples of Type Clashing}{type-clashes}{\typingtests/TypingRule.TypeClashes.asl}
 
 \ProseParagraph
  \OneApplies
@@ -579,7 +628,7 @@ returning the result $\vb$ or a type error, if one is detected.
     \item obtaining the \structure\ of $\vt$ in $\tenv$ yields $\vtstruct$\ProseOrTypeError;
     \item obtaining the \structure\ of $\vs$ in $\tenv$ yields $\vsstruct$\ProseOrTypeError;
     \item both $\vtstruct$ and $\vsstruct$ are one of the following types: \\
-          \integertypeterm{}, \realtypeterm{}, or \stringtypeterm{};
+          \booleantypesterm{}, \integertypeterm{}, \realtypeterm{}, or \stringtypeterm{};
     \item $\vb$ is $\True$.
   \end{itemize}
 
@@ -628,10 +677,6 @@ returning the result $\vb$ or a type error, if one is detected.
   \end{itemize}
 \end{itemize}
 
-
-
-\CodeSubsection{\TypeClashBegin}{\TypeClashEnd}{../types.ml}
-
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[subtype]{
@@ -648,7 +693,7 @@ returning the result $\vb$ or a type error, if one is detected.
   \tstruct(\tenv, \vt) \typearrow \vtstruct \OrTypeError \\
   \tstruct(\tenv, \vs) \typearrow \vsstruct \OrTypeError \\
   \astlabel(\vtstruct)=\astlabel(\vsstruct)\\
-  \astlabel(\vtstruct) \in \{\TInt, \TReal, \TString, \TBits\}
+  \astlabel(\vtstruct) \in \{\TBool, \TInt, \TReal, \TString, \TBits\}
 }{
   \typeclashes(\tenv, \vt, \vs) \typearrow \overname{\True}{\vb}
 }
@@ -715,27 +760,31 @@ returning the result $\vb$ or a type error, if one is detected.
   \typeclashes(\tenv, \vt, \vs) \typearrow \overname{\False}{\vb}
 }
 \end{mathpar}
+\CodeSubsection{\TypeClashBegin}{\TypeClashEnd}{../types.ml}
 
-\subsubsection{Comments}
-Note that if $\vt$ subtype-satisfies $\vs$ then $\vt$ and $\vs$ type-clash, but not the other
+\subsubsection{Comment}
+Note that if $\vt$ \subtypesatisfies{} $\vs$ then $\vt$ and $\vs$ \Prosetypeclash, but not the other
 way around.
-
-Note that type-clashing is an equivalence relation. Therefore if $\vt$
-type-clashes with \texttt{A} and \texttt{B} then it is also the case that \texttt{A} and \texttt{B} type-clash.
-
-\identd{VPZZ} \identi{PQCT}  \identi{WZKM}
 
 \TypingRuleDef{LowestCommonAncestor}
 \hypertarget{def-lowestcommonancestor}{}
 Annotating a conditional expression (see \TypingRuleRef{ECond}),
 requires finding a single type that can be used to annotate the results of both subexpressions.
+We refer to such a type as a \emph{\Proselca}, or LCA, for short, and define it next.
+
 The function
 \[
   \lca(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
   \aslto \overname{\ty}{\tty} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-returns the \emph{lowest common ancestor} of types $\vt$ and $\vs$ in $\tenv$ --- $\tty$.
-The result is a type error if a lowest common ancestor does not exist or a type error is detected.
+returns the \Proselca{} of types $\vt$ and $\vs$ in $\tenv$ --- $\tty$.
+The result is a type error if a \Proselca{} does not exist or a type error is detected.
+
+\ExampleDef{Lowest Common Ancestor}
+\listingref{example-lca} shows examples of conditional expressions and the resulting
+\emph{\Proselca}.
+\pagebreak
+\ASLListing{Lowest Common Ancestor}{example-lca}{\typingtests/TypingRule.LowestCommonAncestor.asl}
 
 \ProseParagraph
 \OneApplies
@@ -1019,6 +1068,10 @@ determines the result type of applying a unary operator when the type of its ope
 Similarly, we determine the negation of integer constraints.
 \ProseOtherwiseTypeError
 
+\ExampleDef{Applying Unary Operations to Types}
+\listingref{apply-unop-type} shows examples of typing applications of unary operations.
+\ASLListing{Applying unary operations to types}{apply-unop-type}{\typingtests/TypingRule.ApplyUnopType.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -1078,27 +1131,6 @@ Similarly, we determine the negation of integer constraints.
 \end{mathpar}
 \CodeSubsection{\ApplyUnopTypeBegin}{\ApplyUnopTypeEnd}{../Typing.ml}
 
-\hypertarget{def-negateconstraint}{}
-We now define the helper function
-\[
-  \negateconstraint(\intconstraint) \aslto \intconstraint
-\]
-which takes an integer constraint and returns the constraint that corresponds to the negation of all
-the values it represents:
-
-\begin{mathpar}
-\inferrule{}
-{
-  \negateconstraint(\ConstraintExact(\ve)) \typearrow \ConstraintExact(\EUnop(\MINUS, \ve))
-}
-\and
-\inferrule{}
-{
-  \negateconstraint(\ConstraintRange(\vvtop, \vbot)) \typearrow \\
-  \ConstraintRange(\EUnop(\MINUS, \vbot), \EUnop(\MINUS, \vvtop))
-}
-\end{mathpar}
-
 \begin{mathpar}
 \inferrule[neg\_error]{
   \typesat(\tenv, \vt, \unconstrainedinteger) \typearrow \False \OrTypeError\\\\
@@ -1142,6 +1174,52 @@ the values it represents:
 }
 \end{mathpar}
 
+\TypingRuleDef{NegateConstraint}
+\hypertarget{def-negateconstraint}{}
+The helper function
+\[
+  \negateconstraint(\overname{\intconstraint}{\vc}) \aslto \overname{\intconstraint}{\newc}
+\]
+takes an integer constraint $\vc$ and returns the constraint $\newc$,
+which corresponds to the negation of all the values that $\vc$ represents.
+
+\ExampleRef{Applying Unary Operations to Types} shows examples of negating single expression
+constraints and range constraints.
+
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{exact}
+  \begin{itemize}
+    \item $\vc$ is the \Proseexactconstraint{$\ve$};
+    \item \Proseeqdef{$\newc$}{the \Proseexactconstraint{the unary expression negating $\ve$}}.
+  \end{itemize}
+
+  \item \AllApplyCase{range}
+  \begin{itemize}
+    \item $\vc$ is the \Proserangeconstraint{$\vstart$}{$\vend$}
+    \item \Proseeqdef{$\newc$}{the \Proserangeconstraint{that is the unary expression negating $\vend$}
+    {that is the unary expression negating $\vstart$}}.
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[exact]{}
+{
+  \negateconstraint(\overname{\ConstraintExact(\ve)}{\vc}) \typearrow
+  \overname{\ConstraintExact(\EUnop(\MINUS, \ve))}{\newc}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[range]{}
+{
+  \negateconstraint(\overname{\ConstraintRange(\vstart, \vend)}{\vc}) \typearrow \\
+  \overname{\ConstraintRange(\EUnop(\MINUS, \vend), \EUnop(\MINUS, \vstart))}{\newc}
+}
+\end{mathpar}
+
 \TypingRuleDef{ApplyBinopTypes}
 \hypertarget{def-applybinoptypes}{}
 The function
@@ -1153,6 +1231,25 @@ The function
 determines the result type $\vt$ of applying the binary operator $\op$
 to operands of type $\vtone$ and $\vttwo$ in the static environment $\tenv$.
 \ProseOtherwiseTypeError
+
+\ExampleDef{Applying Binary Operations to Types}
+\listingref{apply-binop-type} shows examples of typing binary operations.
+\ASLListing{Applying binary operations to types}{apply-binop-type}
+          {\typingtests/TypingRule.ApplyBinopTypes.asl}
+
+\ExampleDef{Applying Binary Operations to Constrained Integers}
+\listingref{apply-binop-constraints} shows examples of typing binary operations
+applied to \constrainedinteger{} types.
+
+Importantly, note that the AST for constraints is not closed under binary operations.
+For example, given a range constraint \verb|A..B| and an exact constraint |2|,
+there is no AST to express \verb|(A..B) * 2|. Therefore, they constraints for typing
+\verb|ab_times_2| approximate the set of values for \verb|(A..B) * 2| via four
+range constraints. More precisely, they are a superset of the values for \verb|(A..B) * 2|.
+
+\pagebreak
+\ASLListing{Applying binary operations to constrained integers}{apply-binop-constraints}
+          {\typingtests/TypingRule.ApplyBinopTypes.constraints.asl}
 
 \ProseParagraph
 \OneApplies
@@ -1588,13 +1685,14 @@ The function
 \]
 returns the lowest common named super type --- $\tty$ --- of the types $\vt$ and $\vs$ in $\tenv$.
 
-\newcommand\supers[0]{\texttt{supers}}
+\newcommand\supers[0]{\hyperlink{def-supers}{\textfunc{supers}}}
 The helper function
 \[
   \supers(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt})
   \aslto \pow{\ty}
 \]
-returns the set of \emph{named supertypes} given via the $\subtypes$ function of the global environment:
+returns the set of \emph{named supertypes} of a type $\vt$
+in the $\subtypes$ function of a global static environment $\tenv$:
 \[
   \supers(\tenv, \vt) \triangleq
   \begin{cases}
@@ -1602,6 +1700,16 @@ returns the set of \emph{named supertypes} given via the $\subtypes$ function of
     \{\vt\}  & \text{ otherwise } (\text{that is, }G^\tenv.\subtypes(\vt) = \bot)\\
   \end{cases}
 \]
+
+\ExampleDef{Finding Named Lowest Common Ancestors}
+In \listingref{find-named-lca},
+the set of named supertypes for \verb|B2| is \verb|{A1, A2, B1, B2}|,
+set of named supertypes for \verb|C2| is \verb|{A1, A2, C1, C2}|,
+therefore the named lowest common ancestor of \verb|B2| and \verb|C2|
+is \verb|A2|, while \verb|B2| and \verb|D1| have no
+named lowest common ancestor.
+
+\ASLListing{Finding named lowest common ancestors}{find-named-lca}{\typingtests/TypingRule.FindNamedLCA.asl}
 
 \ProseParagraph
 \OneApplies
@@ -1679,16 +1787,20 @@ $\{\SHL, \SHR, \POW, \MOD, \DIVRM, \MINUS, \MUL, \PLUS, \DIV\}$.
 The rule employs $\binopisexploding$ to decide whether range constraints can be maintained
 as range constraints or have to be converted to a list of exact constraints.
 
-For example, applying $\PLUS$ to
+\ExampleDef{Annotating Constraints for Binary Operations}
+Applying $\PLUS$ to
 $\{ \AbbrevConstraintRange{\ELInt{2}}{\ELInt{4}}\}$ and
-$\{\AbbrevConstraintExact{\ELInt{2}}\}$ results in
+$\{\AbbrevConstraintExact{\ELInt{2}}\}$ results in\\
 $\{\AbbrevConstraintRange{\ELInt{4}}{\ELInt{6}}\}$,
+since $\binopisexploding(\PLUS) \typearrow \False$
 while applying $\MUL$ to the same lists of constraints results in
 $\{\AbbrevConstraintExact{\ELInt{4}}, \AbbrevConstraintExact{\ELInt{6}}, \AbbrevConstraintExact{\ELInt{8}}\}$,
-which is why $\binopisexploding(\MUL) \typearrow \True$.
+since $\binopisexploding(\MUL) \typearrow \True$.
 
 Annotating the constraints involves applying symbolic reasoning and in particular filtering out values that
 will definitely result in a dynamic error.
+
+Also see \ExampleRef{Applying Binary Operations to Constrained Integers}.
 
 \ProseParagraph
 \AllApply
@@ -1771,6 +1883,12 @@ filters the list of constraints $\cs$ by removing values that will definitely re
 error if found on the right-hand-side of a binary operation expression with the operator $\op$
 in any environment consisting of the static environment $\tenv$.
 The result is the filtered list of constraints $\newcs$.
+
+\ExampleDef{Filtering Right-hand-side Constraints}
+An example of filtering constraints appears in \listingref{apply-binop-constraints},
+where the constraints inferred for \verb|a_div| filter out \verb|-5..0|
+from the constraint \verb|-5..3|, thus avoiding including constraints
+\verb|A DIV -5| and \verb|A DIV 0|.
 
 \ProseParagraph
 \OneApplies
@@ -2427,7 +2545,7 @@ The function
 \[
 \intervaltoolarge(\overname{\Z}{\vzone} \aslsep \overname{\Z}{\vztwo}) \aslto \overname{\Bool}{\vb}
 \]
-tests whether the set of numbers between $\vzone$ and $\vztwo$, inclusive, contains more than $\maxexplodedintervalsize$
+determines whether the set of numbers between $\vzone$ and $\vztwo$, inclusive, contains more than $\maxexplodedintervalsize$
 integers, yielding the result in $\vb$.
 
 \ProseParagraph
@@ -2450,6 +2568,8 @@ determines whether the binary operation $\op$ should lead to applying $\explodei
 when the $\op$ is applied to a pair of constraint lists.
 It is assumed that $\op$ is one of $\MUL$, $\SHL$, $\POW$, $\PLUS$, $\DIV$, $\MINUS$, $\MOD$, $\SHR$,
 and $\DIVRM$.
+
+See \ExampleRef{Annotating Constraints for Binary Operations}.
 
 \ProseParagraph
 The value $\vb$ is $\True$ if and only if $\op$ is one of $\MUL$, $\SHL$, and $\POW$.
@@ -2672,6 +2792,8 @@ The function
 \]
 returns $\True$ is $\vt$ is has the \structure\ a of type corresponding to the AST label $\vl$ and a type error otherwise.
 
+See \ExampleRef{The Structure of a Type}.
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -2715,7 +2837,21 @@ The function
 \[
   \towellconstrained(\overname{\ty}{\vt}) \aslto \overname{\ty}{\vtp}
 \]
-returns the \wellconstrainedversion\ of a type $\vt$ --- $\vtp$, which is defined as follows.
+returns the \wellconstrainedversion\ of a type $\vt$ --- $\vtp$,
+which converts \parameterizedintegertypes{} to \wellconstrainedintegertypes{},
+and leaves all other types as are.
+
+\ExampleDef{Converting Parameterized Integer Types to Well-constrainted Integer Types}
+The following table shows examples of applying $\towellconstrained$ to various types:
+\[
+\begin{array}{rl}
+\textbf{input type}           & \textbf{output type}\\
+\hline
+\TInt(\parameterized(\vx))    & \TInt(\wellconstrained(\ConstraintExact(\EVar(\vx))))\\
+\TInt(\unconstrainedinteger)  & \TInt(\unconstrainedinteger)\\
+\TReal                        & \TReal\\
+\end{array}
+\]
 
 \ProseParagraph
 \OneApplies

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -207,7 +207,7 @@ This rule covers all assignment statements, except the ones where the
 right-hand side expression is a function call, which is covered by
 \SemanticsRuleRef{SAssignCall}.  Although
 the sequential semantics of both statements is the same,
-SemanticsRule.SAssignCall generates a different execution graph.
+\SemanticsRuleRef{SAssignCall} generates a different execution graph.
 
 Notice that this rule first produces a value for the right-hand side expression
 and then completes the update via an appropriate rule for evaluating the

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -624,12 +624,22 @@ The \underlyingtype{} of \texttt{(integer, T2)} and \texttt{T3} is
 \CodeSubsection{\MakeAnonymousBegin}{\MakeAnonymousEnd}{../types.ml}
 
 \TypingRuleDef{CheckConstrainedInteger}
+A type is a \emph{\constrainedinteger} if it is either a \wellconstrainedintegertype{}
+or a \parameterizedintegertype.
+
 \hypertarget{def-checkconstrainedinteger}{}
 The function
 \[
   \checkconstrainedinteger(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\tty}) \aslto \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-checks whether the type $\vt$ is a \constrainedinteger. If so, the result is $\True$, otherwise a type error is returned.
+checks whether the type $\vt$ is a \constrainedinteger{} type.
+If so, the result is $\True$, otherwise the result is a \typingerrorterm.
+
+\ExampleDef{Checking for Constrained Integers}
+\listingref{check-constrained-integer}
+shows examples of checking whether a type (used for the width of a bitvector type)
+is a \constrainedinteger{} type.
+\ASLListing{Checking for constrained integers}{check-constrained-integer}{\typingtests/TypingRule.CheckConstrainedInteger.asl}
 
 \ProseParagraph
 \OneApplies

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -450,18 +450,25 @@ In \listingref{annotate-constraint-unconstrained}, the constraint
 }{
   \annotateconstraint(\tenv, \overname{\ConstraintExact(\ve)}{\vc}) \typearrow (\overname{\ConstraintExact(\vep)}{\newc}, \vses)
 }
-\and
+\end{mathpar}
+
+\begin{mathpar}
 \inferrule[range]{
   \annotatesymbolicconstrainedinteger(\tenv, \veone) \typearrow (\veonep, \vsesone) \OrTypeError\\\\
   \annotatesymbolicconstrainedinteger(\tenv, \vetwo) \typearrow (\vetwop, \vsestwo) \OrTypeError\\\\
   \vses \eqdef \vsesone \cup \vsestwo
 }{
-  \annotateconstraint(\tenv, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \overname{\ConstraintRange(\veonep, \vetwop)}{\newc}
+  {
+  \begin{array}{r}
+    \annotateconstraint(\tenv, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \\
+    (\overname{\ConstraintRange(\veonep, \vetwop)}{\newc}, \vses)
+  \end{array}
+  }
 }
 \end{mathpar}
 
-\hypertarget{realtypeterm}{}
 \section{The Real Type\label{sec:RealType}}
+\hypertarget{realtypeterm}{}
 The \emph{\realtypeterm{}} represents mathematical rational number values.
 There is no bound on the minimum and maximum rational value that can be represented,
 and there is no bound on their precision.

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -84,6 +84,7 @@ analyzers
 analyzes
 analyzing
 ancestor
+ancestors
 and
 annotate
 annotated
@@ -171,6 +172,7 @@ auxiliary
 available
 avoid
 avoidance
+avoiding
 avoids
 away
 axiom
@@ -196,6 +198,7 @@ behave
 behavior
 behaviors
 being
+belongs
 below
 better
 between
@@ -622,6 +625,7 @@ ensure
 ensured
 ensures
 ensuring
+entails
 entire
 entirely
 entries
@@ -702,6 +706,7 @@ export
 exposes
 express
 expressed
+expressible
 expressing
 expression
 expressionless
@@ -1196,6 +1201,7 @@ now
 number
 numbered
 numbers
+numeral
 numerator
 object
 observe
@@ -1378,6 +1384,7 @@ priori
 priorities
 priority
 procedure
+procedures
 process
 processed
 processes
@@ -1460,6 +1467,7 @@ reference
 references
 referred
 referring
+refers
 refine
 refinement
 refines
@@ -1486,9 +1494,6 @@ relies
 rely
 relying
 remain
-relies
-rely
-relying
 remainder
 remaining
 remove
@@ -1766,6 +1771,7 @@ summation
 summing
 sums
 super
+supers
 superset
 supertypes
 support

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -1486,6 +1486,9 @@ relies
 rely
 relying
 remain
+relies
+rely
+relying
 remainder
 remaining
 remove

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -163,8 +163,6 @@ def check_repeated_words(filename: str) -> int:
         line_number += 1
         line = line.strip()
         tokens = re.split(" |{|}", line)
-        if not tokens:
-            continue
         for current_token in tokens:
             current_token_lower = current_token.lower()
             last_token_lower = last_token.lower()
@@ -190,6 +188,11 @@ def detect_incorrect_latex_macros_spacing(filename: str) -> int:
     """
     num_errors = 0
     file_str = read_file_str(filename)
+    double_backslash_matches = re.findall(r"\\\\[a-zA-Z]+", file_str)
+    for match in double_backslash_matches:
+        print(f"./{filename}: double \\ in macro {match}")
+        num_errors += 1
+
     patterns_to_remove = [
         # Patterns for known math environments:
         r"\$.*?\$",  # $...$
@@ -420,7 +423,10 @@ def check_rule_has_example(rule_block: RuleBlock) -> List[str]:
         RuleBlock.CONVENTION_RULE,
     ]:
         return []
-    if not rule_block.filename == "RelationsOnTypes.tex":
+    if not rule_block.filename in [
+        # "RelationsOnTypes.tex"
+        # "Bitfields.tex"
+    ]:
         return []
     example_found = False
     for line_number in range(rule_block.begin, rule_block.end + 1):
@@ -429,6 +435,7 @@ def check_rule_has_example(rule_block: RuleBlock) -> List[str]:
             line.startswith("\\ExampleDef")
             or "\\ExampleRef" in line
             or "\\subsubsection{Example}" in line
+            or "\\listingref" in line
         ):
             example_found = True
             break
@@ -446,7 +453,7 @@ def check_rules(filename: str) -> int:
     checks = [
         check_rule_prose_formally_structure,
         # check_rule_case_consistency,
-        # check_rule_has_example,
+        check_rule_has_example,
     ]
     num_errors = 0
     rule_blocks: List[RuleBlock] = match_rules(filename)
@@ -468,7 +475,7 @@ def check_rules(filename: str) -> int:
 def spellcheck(reference_dictionary_path: str, latex_files: list[str]) -> int:
     r"""
     Attempts to find spelling error in the files listed in 'latex_files'
-    by consulting the internal dictionary file iINTERNAL_DICTIONARY_FILENAME
+    by consulting the internal dictionary file INTERNAL_DICTIONARY_FILENAME
     and an optional reference dictionary in 'reference_dictionary_path'.
     """
     dict_word_list = read_file_str(INTERNAL_DICTIONARY_FILENAME).splitlines()
@@ -597,9 +604,9 @@ def main():
     num_spelling_errors = spellcheck(args.dictionary, content_latex_sources)
     if num_spelling_errors > 0:
         print(
-            f"There were possible spelling errors. "
+            "There were possible spelling errors. "
             "Please either fix them or add new words to "
-            "{INTERNAL_DICTIONARY_FILENAME}."
+            f"{INTERNAL_DICTIONARY_FILENAME}."
         )
     num_errors += num_spelling_errors
     num_errors += check_hyperlinks_and_hypertargets(all_latex_sources)

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import List, Set
 import argparse
 import pathlib
+import pathlib
 
 cli_parser = argparse.ArgumentParser(prog="ASL Reference Linter")
 cli_parser.add_argument(

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -275,10 +275,10 @@ class RuleBlock:
     rule_end_pattern = re.compile("|".join(end_patterns))
 
     def __init__(self, filename, file_lines: list[str], begin: int, end: int):
-        self.filename : str = filename
-        self.file_lines : list[str] = file_lines
-        self.begin : int = begin
-        self.end : int = end
+        self.filename: str = filename
+        self.file_lines: list[str] = file_lines
+        self.begin: int = begin
+        self.end: int = end
 
         begin_line = file_lines[begin]
         name_match = re.match(RuleBlock.rule_begin_pattern, begin_line)
@@ -420,7 +420,7 @@ def check_rule_has_example(rule_block: RuleBlock) -> List[str]:
         RuleBlock.CONVENTION_RULE,
     ]:
         return []
-    if not rule_block.filename == 'RelationsOnTypes.tex':
+    if not rule_block.filename == "RelationsOnTypes.tex":
         return []
     example_found = False
     for line_number in range(rule_block.begin, rule_block.end + 1):
@@ -446,7 +446,7 @@ def check_rules(filename: str) -> int:
     checks = [
         check_rule_prose_formally_structure,
         # check_rule_case_consistency,
-        check_rule_has_example,
+        # check_rule_has_example,
     ]
     num_errors = 0
     rule_blocks: List[RuleBlock] = match_rules(filename)

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -259,6 +259,8 @@ class RuleBlock:
     SEMANTICS_RULE = "Semantics"
     GUIDE_RULE = "Guide"
     CONVENTION_RULE = "Convention"
+    GUIDE_RULE = "Guide"
+    CONVENTION_RULE = "Convention"
 
     rule_begin_pattern = re.compile(
         r"\\(TypingRuleDef|SemanticsRuleDef|ASTRuleDef|ConventionDef|RequirementDef){(.*?)}"
@@ -273,10 +275,10 @@ class RuleBlock:
     rule_end_pattern = re.compile("|".join(end_patterns))
 
     def __init__(self, filename, file_lines: list[str], begin: int, end: int):
-        self.filename: str = filename
-        self.file_lines: list[str] = file_lines
-        self.begin: int = begin
-        self.end: int = end
+        self.filename : str = filename
+        self.file_lines : list[str] = file_lines
+        self.begin : int = begin
+        self.end : int = end
 
         begin_line = file_lines[begin]
         name_match = re.match(RuleBlock.rule_begin_pattern, begin_line)
@@ -418,7 +420,7 @@ def check_rule_has_example(rule_block: RuleBlock) -> List[str]:
         RuleBlock.CONVENTION_RULE,
     ]:
         return []
-    if not rule_block.filename == "RelationsOnTypes.tex":
+    if not rule_block.filename == 'RelationsOnTypes.tex':
         return []
     example_found = False
     for line_number in range(rule_block.begin, rule_block.end + 1):
@@ -444,7 +446,7 @@ def check_rules(filename: str) -> int:
     checks = [
         check_rule_prose_formally_structure,
         # check_rule_case_consistency,
-        # check_rule_has_example,
+        check_rule_has_example,
     ]
     num_errors = 0
     rule_blocks: List[RuleBlock] = match_rules(filename)

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ECall.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ECall.asl
@@ -1,13 +1,18 @@
-func Return42() => integer 
+func Increment(x: integer) => integer
 begin
-  return 42;
+  return x + 1;
+end;
+
+func DoubleBitvectorLength{N}(x: bits(N)) => integer{2*N}
+begin
+  return 2*N;
 end;
 
 func main () => integer
 begin
-
-  let x = Return42();
+  let x : integer               = Increment(41);
   assert x == 42;
-
+  let y : integer{30}           = DoubleBitvectorLength{15}(Zeros{15});
+  assert y == 30;
   return 0;
-end; 
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGetItem.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EGetItem.asl
@@ -1,0 +1,10 @@
+func main() => integer
+begin
+    var t = (1, 2);
+    assert t.item0 + t.item1 == 3;
+
+    // The following statement is illegal: item01 is treated
+    // by the type system as a field.
+    // let - = t.item01;
+    return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EPattern.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EPattern.asl
@@ -1,5 +1,22 @@
 func main () => integer
 begin
+  // Pattern matching against bitmasks.
+  // All of the following pattern matching expressions are equivalent:
+  let bv = '11010';
+  assert   bv IN {'11xx0'};
+  assert   bv IN {'11(00)0'};
+  assert   bv IN {'11(01)0'};
+  assert   bv IN {'11(10)0'};
+  assert   bv IN {'11(11)0'};
+  assert   bv IN {'11(00)0'};
+  assert   bv IN {'11(01)0'};
+  assert   bv IN {'11(10)0'};
+  assert   bv IN {'11(11)0'};
+  assert   bv == '11xx0';
+  assert   bv == '11(00)0';
+
+  assert !(bv IN {'11x00'});
+  assert !(bv IN {'11(00)1'});
 
   let match_true = 42 IN {0..3, 42};
   assert match_true == TRUE;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ERecord.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ERecord.asl
@@ -6,5 +6,8 @@ begin
   let my_record = MyRecordType{a=3, b=42};
   assert my_record.a == 3;
 
+  // The following statement is illegal as every record field
+  // needs to be initialized exactly once.
+  // let - = MyRecordType{a=3, a=4, b=42};
   return 0;
-end; 
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ESlice.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ESlice.asl
@@ -1,8 +1,12 @@
 func main () => integer
 begin
+  let x: bits(5){} = '1 1110 000'[6:3, 7];
+  assert x == '1110 1';
 
-  let x = '11110000'[6:3];
-  assert x == '1110';
+  let y: bits(5){} = 240[6:3, 7];
+  assert y == x;
 
+  let z: bits(5){} = 496[6:3, 7];
+  assert z == x;
   return 0;
-end; 
+end;

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -45,6 +45,7 @@ ASL Semantics Tests:
     value 3 does not belong to type integer {0..2}.
   [1]
   $ aslref SemanticsRule.ERecord.asl
+  $ aslref SemanticsRule.EGetItem.asl
   $ aslref SemanticsRule.EConcat.asl
   $ aslref SemanticsRule.ETuple.asl
   $ aslref SemanticsRule.EArbitraryInteger0.asl

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ATC.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ATC.asl
@@ -1,0 +1,36 @@
+type Color of enumeration {RED, GREEN, BLUE};
+type SubColor subtypes Color;
+
+type Packet of record { data: bits(8), status: boolean};
+type ExtendedPacket subtypes Packet;
+
+func main() => integer
+begin
+    //      Expression                          Annotated expression
+    // The following assertion is statically proved by the type
+    // system and therefore no dynamic check occurs.
+    var - = 1 as integer{1, 2};                     // 1
+    // The following assertion is not statically proved by the type
+    // system and therefore a dynamic check occurs, which always fails.
+    var - = 3 as integer{1, 2};                     // 3 as integer{1, 2}
+    var - = 3 as integer{2 as integer{2, 3}};       // 3 as integer{2}
+
+    var - = RED as Color;                           // RED
+    var - = RED as SubColor;                        // RED
+    var - = (RED, 3) as (SubColor, integer{2, 3});  // (RED, 3)
+    // The following right-hand-side expression is annotated as
+    // (RED, 3) as (enumeration {RED, GREEN, BLUE}, integer {1, 2})
+    var - = (RED, 3) as (SubColor, integer{1, 2});
+
+    var x = Packet{data = Zeros{8}, status = TRUE};
+    var - = x as ExtendedPacket;                    // x
+
+    var arr : array[[5]] of integer;
+    var - = arr as array[[5]] of integer;           // arr
+
+    // The following is illegal as '2 as integer{3}'
+    // is considered side-effecting, which is not allowed in type
+    // definitions.
+    // var - = 3 as integer{2 as integer{3}};
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.asl
@@ -1,7 +1,37 @@
+type Color of enumeration {RED, GREEN, BLUE};
+type SubColor subtypes Color;
+type Status of enumeration {OK, ERROR};
+
 func main() => integer
 begin
-  var a: bits(10);
-  var b: bits(10);
-  var c: bits(10) = a XOR b;
+  var b1: boolean = TRUE as boolean && FALSE as boolean;
+  // Binary operations on bitvectors remove all bitfields from the result type.
+  var - : bits(8) = Ones{8} as bits(8) {[0] flag} XOR Zeros{8} as bits(8) {[7] flag};
+  // The next statement is illegal: both bitvectors must have the same length for XOR.
+  // var - : bits(8) = Ones{8} XOR Zeros{7};
+  var - : bits(8) = Ones{8} as bits(8) {[0] flag} + (1024 as integer);
+  var - : bits(16) =  (Ones{8} as bits(8) {[0] flag}) ::
+                      (Zeros{8} as bits(8) {[0] flag});
+
+  var - : boolean = (5 as integer{1..10}) < (6 as integer{1..10});
+  var - : boolean = (Ones{8} as bits(8) {[0] flag}) ==
+                    (Ones{8} as bits(8) {[7] flag});
+  // The next statement is illegal: both bitvectors must have the same length for ==.
+  // var - : boolean = Ones{8} == Zeros{9};
+  var - : boolean = (RED as Color) != (GREEN as SubColor);
+  // The next statement is illegal: comparing labels declared in
+  // different enumerations is not allowed.
+  // var - : boolean = RED != OK;
+
+  var - : integer{25} = (5 as integer{5}) * (5 as integer{5});
+  var - : integer = (5 as integer{5}) * (5 as integer);
+  var - : integer{20, 24..25, 28, 30, 35..36, 42} =
+          (5 as integer{5..7}) * (5 as integer{4..6});
+  // The next statement is illegal, since 5 does not divide by 2.
+  // var -  = (5 as integer{5..10}) DIV (2 as integer{2});
+
+  var - : real = 5.5 ^ 7;
+  var real_pow_int : real = 5.0 ^ (5 as integer{0..10});
+
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.constraints.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.constraints.asl
@@ -1,0 +1,43 @@
+func constraint_ops{A,B,C,D}(
+    bv_a: bits(A),
+    bv_b: bits(B),
+    bv_c: bits(C),
+    bv_d: bits(D))
+begin
+    var ab : integer{A..B} = A as integer{A..B};
+    var a : integer{A} = A as integer{A};
+    var cd : integer{C..D} = C as integer{C..D};
+
+    var ab_plus_cd  : integer{(C + A)..(D + B)} = ab + cd;
+    var ab_minus_cd : integer{(- D + A)..(- C + B)} = ab - cd;
+
+    // Notice how the set of integers A*2, (A+1)*2, ..., B*2 is approximated
+    // by the following range constraints:
+    var ab_times_2  : integer{(2 * A)..(2 * A), (2 * A)..(2 * B), (2 * B)..(2 * A),
+                              (2 * B)..(2 * B)} = ab * 2;
+    var a_times_cd  : integer{(A * C)..(A * C), (A * C)..(A * D), (A * D)..(A * C),
+                              (A * D)..(A * D)} = a * cd;
+    // Notice how in the next statement, 0 has been filtered out
+    // from the left-hand-side constraints.
+    var a_div : integer{A, (A DIV 2), (A DIV 3)} = a DIV (1 as integer{-5..3});
+
+    // Notice how in the next statement, the left-hand-side constraints
+    // only depend on the right operand constraint 0..3.
+    var a_mod_0_to_3 : integer{0..2} = a MOD (1 as integer{0..3});
+    var mod_0_to_3_a : integer{0..(A - 1)} = (1 as integer{0..3}) MOD a;
+    var mod_0_to_3_ab : integer{0..(B - 1)} = (1 as integer{0..3}) MOD ab;
+
+    var a_div_cd : integer{A..(A DIV D), (A DIV D)..A} = a DIV cd;
+    var cd_div_a : integer{(C DIV A)..(D DIV A)} = cd DIV a;
+    var a_mod_cd : integer{0..(D - 1)} = a MOD cd;
+    var cd_mod_a : integer{0..(A - 1)} = cd MOD a;
+
+    var a_pow_cd : integer{0..(A ^ D), 1, (- ((- A) ^ D))..((- A) ^ D)} = (a ^ cd) as
+                   integer{0..(A ^ D), 1, (- ((- A) ^ D))..((- A) ^ D)};
+    var cd_pow_a : integer{0..(D ^ A), (- ((- C) ^ A))..((- C) ^ A)} = cd ^ a;
+
+    // Notice how large sets of constraints (more than 2^17)
+    // are approximated via ranges.
+    var - : integer{0..2^28} = (1 as integer{0..2^14}) * (2 as integer{0..2^14});
+    var - : integer{0..2^14} = (1 as integer{0..2^14}) DIV (2 as integer{0..2^14});
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ApplyUnopType.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ApplyUnopType.asl
@@ -1,0 +1,18 @@
+func main() => integer
+begin
+    //        result type                               input type
+    var b   : boolean                       = ! TRUE    as boolean;
+    var i1  : integer{-5}                   = - (5      as integer{5});
+    var i2  : integer{-(-5)}                = - i1;
+    var ci1 : integer{0..5, 9, 10..8}       = 4         as integer{0..5, 9, 10..8};
+    var ci2 : integer{-9, -8..-10, -5..0}   = - (ci1    as integer{0..5, 9, 10..8});
+    var ui1 : integer                       = 9         as integer;
+    var ui2 : integer                       = - ui1     as integer;
+
+    var r1  : real                          = - 5.0     as real;
+    var r2  : real                          = - r1      as real;
+
+    var bv1 : bits(8) {[0] flag}            = Zeros{8}  as bits(8) {[0] flag};
+    var bv2 : bits(8) {[0] flag}            = NOT bv1   as bits(8) {[0] flag};
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckATC.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckATC.asl
@@ -1,0 +1,20 @@
+type Packet of record { data: bits(8), status: boolean};
+type ExtendedPacket subtypes Packet with {time: integer};
+
+func main() => integer
+begin
+    // Illegal: can only perform ATC on real and integer:
+    // ATC is not a type-to-type cast.
+    var - = 3.0 as integer{1, 2};
+
+    // Illegal: cannot perform ATC on record types unless they
+    // are exactly they are equivalent.
+    var rec = Packet{data = Zeros{8}, status = TRUE};
+    var - = rec as ExtendedPacket;
+
+    var arr : array[[5]] of integer;
+    // Illegal: cannot perform ATC on array types unless they
+    // are equivalent.
+    var - = arr as array[[6]] of integer;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckConstrainedInteger.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckConstrainedInteger.asl
@@ -1,0 +1,21 @@
+func foo{N}(bv : bits(N))
+begin
+    // The next declaration is legal as a parameterized integer type
+    // is a constrained integer type.
+    var - : bits(N) = Zeros{N};
+    let x : integer{0..N} = N as integer{0..N};
+    // The next declaration is legal as the type of 'x' is a well-constrained
+    // integer type, which is considered a constrained integer type.
+    var - : bits(x) = Zeros{x};
+    // The next declaration is legal as 5 has the type integer{5},
+    // which is a constrained integer type.
+    var - : bits(5) = Zeros{5};
+
+    let y : integer = 7;
+
+    // Only constrained integer types allowed as bitvector widths.
+    // The next declaration is illegal: real is not a constrained integer type.
+    // var - : bits(5.0) = Zeros{N};
+    // The next declaration is illegal: integer is not a constrained integer type.
+    // var - = Zeros{y};
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadBitField.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadBitField.asl
@@ -1,0 +1,9 @@
+type Packet of bits(8) { [0] flag, [7:1] data };
+
+func main() => integer
+begin
+    var p : Packet;
+    // Illegal: field 'undeclared_bitfield' is not declared for Packet.
+    var - = p.undeclared_bitfield;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadField.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadField.asl
@@ -1,0 +1,8 @@
+func main() => integer
+begin
+    var a: array[[5]] of integer;
+    // The next statement is illegal as 'a' not a bitvector type,
+    // a structured type, or a tuple type.
+    var - = a.f;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadRecordField.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadRecordField.asl
@@ -1,0 +1,9 @@
+type MyRecordType of record {i: integer, b: boolean};
+
+func main () => integer
+begin
+  let my_record = MyRecordType{i=3, b=TRUE};
+  // Illegal as field 'undeclared_field' does not exist in MyRecordType.
+  var x = my_record.undeclared_field;
+  return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EGetBitfield.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EGetBitfield.asl
@@ -1,0 +1,21 @@
+type Packet of bits(8) {
+    [0] flag,
+    [7:1] data,
+    [7:1] detailed_data {
+        [6:3] info : bits(4) {
+            [0] info_0
+        },
+        [2:0] crc
+    }
+};
+
+func main() => integer
+begin
+    var p : Packet;
+    //      Bitfield expression         inferred type
+    var - = p.flag                  as  bits(1);
+    var - = p.data                  as  bits(7);
+    var - = p.detailed_data         as  bits(7) { [3+:4] info, [0+:3] crc };
+    var - = p.detailed_data.info    as  bits(4) { [0] info_0 };
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EGetFields.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EGetFields.asl
@@ -1,0 +1,35 @@
+type BitvectorType of bits(8) {
+    [0] bit0,
+    [1] bit1,
+    [3:2] bits3_2,
+    [7:6] info,
+    [7:6, 1:0] info_and_bits
+};
+
+type RecordWithBits of record {
+    bit0: bits(1),
+    bit1: bits(1),
+    bits3_2: bits(2),
+    info: bits(2),
+    r: real
+};
+
+func main() => integer
+begin
+    var bits_var : BitvectorType = '10100010';
+    //              Multi-field expression                          inferred type
+    let bits_flds = bits_var.[bits3_2, bit1, bit0, info_and_bits]   as bits(8);
+    assert bits_flds == '00101010';
+
+    var record_var : RecordWithBits = RecordWithBits{
+        bit0    = '0',
+        bit1    = '1',
+        bits3_2 = '00',
+        info    = '10',
+        r       = 6.7
+    };
+    //                  Multi-field expression                      inferred type
+    let record_flds =   record_var.[bits3_2, bit1, bit0, info]      as bits(6);
+    assert record_flds == '001010';
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EGetRecordField.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EGetRecordField.asl
@@ -1,0 +1,10 @@
+type MyRecordType of record {i: integer, b: boolean};
+
+func main () => integer
+begin
+  let my_record = MyRecordType{i=3, b=TRUE};
+  //      array access expression   inferred type
+  var x = my_record.i               as integer;
+  var y = my_record.b               as boolean;
+  return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EVar.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EVar.asl
@@ -1,0 +1,12 @@
+constant GLOBAL_CONSTANT = 5;
+var global_non_constant = 19;
+
+func main() => integer
+begin
+    constant LOCAL_CONSTANT = 7;
+    var var_x = LOCAL_CONSTANT; // The annotated expression for LOCAL_CONSTANT is 7.
+    var y = var_x; // The annotated expression for var_x is var_x.
+    var local_non_constant = LOCAL_CONSTANT;
+    var - = local_non_constant + GLOBAL_CONSTANT + global_non_constant;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EVar.undefined.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EVar.undefined.asl
@@ -1,0 +1,5 @@
+func main() => integer
+begin
+    var x = t;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.FindNamedLCA.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.FindNamedLCA.asl
@@ -1,0 +1,16 @@
+type A1 of integer;
+type A2 subtypes A1;
+type B1 subtypes A2;
+type B2 subtypes B1;
+type C1 subtypes A2;
+type C2 subtypes C1;
+type D1 of real;
+
+func main() => integer
+begin
+    var - : A2 = if ARBITRARY: boolean then (1 as B2) else (2 as C2);
+    // The following line is illegal. In particular B2 and D1 have no
+    // named lowest common ancestor.
+    // var - = if ARBITRARY: boolean then (1 as B2) else (2.0 as D1);
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LowestCommonAncestor.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LowestCommonAncestor.asl
@@ -1,0 +1,61 @@
+type Word1 of integer{0..31};
+type Word2 of integer{32..64};
+
+type SuperInt of integer;
+type SubInt1 of integer subtypes SuperInt;
+type SubInt2 of integer subtypes SuperInt;
+
+func nondet() => boolean
+begin
+    return ARBITRARY: boolean;
+end;
+
+func lca_parameterized{N, M}(bv_n: bits(N), bv_m: bits(M))
+begin
+    // The type of 'N' is integer{N}
+    // The type of 'M' is integer{M}
+    //      LCA type                         Type 1         Type 2
+    var - : integer{N, M} = if nondet() then N         else M;
+end;
+
+type BitsA of bits(8) {[0] f1, [7] f2};
+type BitsB of bits(8) {[5:0] f3};
+
+type SuperRec of record {i: integer};
+type SubRec1 subtypes SuperRec with {b: boolean};
+type SubRec2 subtypes SuperRec with {c: real};
+type Exc of exception {i: integer};
+
+func main() => integer
+begin
+    // LCA type                                  Type 1                 Type 2
+    var - : SuperInt = if nondet() then 1     as SubInt1     else 2  as SubInt2;
+    var - : SubInt1 = if nondet() then (1     as SubInt1)    else (2 as integer);
+    var - : SubInt2 = if nondet() then (1     as integer)    else (2 as SubInt2);
+    var - : integer = if nondet() then (1     as integer{1}) else (2 as integer);
+    var - : integer = if nondet() then 1      as integer{1}  else (2 as integer);
+    var - : integer = if nondet() then 1                     else 2  as integer;
+    var - : integer{1,2} = if nondet()   then 1              else 2  as integer{1,2};
+    var - : integer{0..64} = if nondet() then 1 as Word1     else 32 as Word2;
+    var - : bits(8) = if nondet() then Zeros{8} as BitsA     else Zeros{8} as BitsB;
+    var - : bits(8) = if nondet() then Zeros{8}              else Zeros{8} as BitsB;
+
+    var arr1 : array[[8]] of Word1;
+    var arr2 : array[[8]] of Word2;
+    var - : array [[8]] of integer {0..31, 32..64} = if nondet() then arr1 else arr2;
+
+    var - : (SuperInt, SuperInt) = if nondet()  then (1 as SubInt1, 2 as SubInt2)
+                                                else (2 as SubInt2, 1 as SubInt1);
+
+    var sup : SuperRec;
+    var r1 : SubRec1;
+    var r2 : SubRec2;
+    //      LCA type                            Type 1              Type 2
+    var - : SuperRec =  if nondet() then sup as SuperRec else r1 as SubRec1;
+    var - : SuperRec =  if nondet() then r1  as SubRec1  else r2 as SubRec2;
+    var ex : Exc;
+    // The following statement is illegal as SuperRec and Exc do not have
+    // lowest common ancestor.
+    // var -  = if nondet() then r1 else ex;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.Subtype.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.Subtype.asl
@@ -1,2 +1,4 @@
-type superInt of integer;
-type subInt of integer subtypes superInt;
+type superInt   of integer;
+type subInt     of integer subtypes superInt;
+type subsubInt  of integer subtypes subInt;
+type otherInt   of integer;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction1.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction1.asl
@@ -1,0 +1,43 @@
+type Color of enumeration {RED, GREEN, BLUE};
+type SubColor subtypes Color;
+
+type Word64WithLSB  of bits(64) { [63:32] upper,  [31:0] lower, [0] lsb};
+type Word64         of bits(64) { [63:32] upper,  [31:0] lower};
+
+func main() => integer
+begin
+    // real / string / boolean
+    //     LHS type                     RHS type
+    let q: real     = 5.0               as real;
+    let s: string   = "hello"           as string;
+    let b: boolean  = TRUE              as boolean;
+
+    // Integers
+    //     LHS type                     RHS type
+    let i: integer = 5                  as integer;
+    let j: integer = 5                  as integer{5, 7};
+    let k: integer{5, 7, 8, 64} = 64    as integer{5, 7, 64};
+    let m: integer{1..8} = 5            as integer{2..6};
+
+    // Enumerations
+    //     LHS type                     RHS type
+    let e: Color = RED                  as SubColor;
+
+    // Bitvectors
+    //          LHS type                        RHS type
+    let - :     bits(64) = Zeros{64}            as Word64;
+    let sub_k:  integer{5, 64} = 64             as integer{5, 64};
+    let - :     bits(k) = Zeros{64}             as bits(sub_k);
+    let bv2:    bits(64) {[0] flag} = Zeros{64} as bits(64);
+
+    // integer-indexed arrays
+    var int_indexed_arr1 :  array[[3]] of integer;
+    var int_indexed_arr2 :  array[[i-2]] of integer;
+    int_indexed_arr2 = int_indexed_arr1 as array[[3]] of integer;
+    var enum_indexed_arr1 :  array[[Color]] of integer;
+    var enum_indexed_arr2 :  array[[Color]] of integer;
+    enum_indexed_arr1 = enum_indexed_arr2;
+
+    var data: (Color, integer{1..8}) = (RED as SubColor, 5 as integer{2..6});
+return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction2.asl
@@ -1,0 +1,36 @@
+// Declare some named types
+type superInt of integer;
+type subInt of integer subtypes superInt ;
+type uniqueInt of superInt;
+
+func assign()
+begin
+    // Integer is subtype-satisfied by all the named types,
+    // so it can be assigned to them by the assignment and
+    // initialization type checking rules
+    var myInt: integer;
+    var mySuperInt : superInt = myInt;
+    var mySubInt : subInt = myInt;
+    var myUniqueInt: uniqueInt = myInt;
+    // Integer is subtype-satisfied by all the named types,
+    // so it can be assigned from them by the assignment and
+    // initialization type checking rules
+    myInt = mySuperInt;
+    myInt = mySubInt;
+    myInt = myUniqueInt;
+
+    // superInt is not a subtype of anything (apart from itself)
+    // so it cannot be assigned to any other named type
+    // Illegal: mySubInt = mySuperInt;
+    // Illegal: myUniqueInt = mySuperInt;
+    // subInt is a subtype of superInt, so the assignment and
+    // initialization type checking rules permit the following:
+    mySuperInt = mySubInt;
+    // But subInt and uniqueInt are not subtype related
+    // so do not type-satisfy each other.
+    // Illegal: myUniqueInt = mySubInt;
+    // uniqueInt has no related subtype or supertype
+    // so it cannot be assigned to any named type
+    // Illegal: mySuperInt = myUniqueInt;
+    // Illegal: mySubInt = myUniqueInt;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction3.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction3.asl
@@ -1,0 +1,13 @@
+type aNumberOfThings of integer;
+type ShapeSides of aNumberOfThings;
+type AnimalLegs of aNumberOfThings;
+type InsectLegs of integer subtypes AnimalLegs;
+func subtyping()
+begin
+    var myCircleSides: ShapeSides = 1; // legal
+    var myInt : integer = myCircleSides; // legal
+    var dogLegs : AnimalLegs = myCircleSides; // illegal: unrelated types
+    var centipedeLegs: InsectLegs = 100; // legal
+    var animalLegs : AnimalLegs = centipedeLegs; // legal
+    var insectLegs : InsectLegs = animalLegs; // illegal: subtype is wrong way
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TArray.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TArray.asl
@@ -2,8 +2,8 @@
 type arr1 of array [[4]] of real;
 
 // Declare an array with two entries arr2[[big]] and arr2[[little]]
-type labels of enumeration {big, little};
-type arr2 of array [[labels]] of bits(4);
+type Labels of enumeration {BIG, LITTLE};
+type BitsArray of array [[Labels]] of bits(4);
 
 func foo(x: array [[4]] of integer) => array [[4]] of integer
 begin
@@ -14,10 +14,13 @@ end;
 
 func main () => integer
 begin
-  var x: array [[4]] of integer;
-  x[[1]] = 1;
+  var int_arr: array [[4]] of integer;
+  var big_little_arr: BitsArray;
+  // Array write expression   Array read expression
+  int_arr[[1]]              = int_arr[[3]] as integer;
+  big_little_arr[[BIG]]     = big_little_arr[[LITTLE]] as bits(4);
 
-  x = foo (x as array [[4]] of integer);
-  let y: array [[4]] of integer = x;
+  int_arr = foo(int_arr as array [[4]] of integer);
+  let y: array [[4]] of integer = int_arr;
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TIntWellConstrained.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TIntWellConstrained.asl
@@ -22,5 +22,9 @@ begin
 
   var c = 3; // The type of 'c' is inferred to be integer{3}.
 
+  // The following is illegal as '2 as integer{3}'
+  // is considered side-effecting, which is not allowed in type
+  // definitions.
+  // var - = 3 as integer{2 as integer{3}};
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypeClashes.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypeClashes.asl
@@ -1,0 +1,36 @@
+func simple_procedure(i: integer) begin pass; end;
+// The following declaration is illegal as the argument is integer-typed:
+// func simple_procedure(i: integer{0..32}) begin pass; end;
+func simple_procedure(b: boolean) begin pass; end;
+func simple_procedure(r: real) begin pass; end;
+func simple_procedure(s: string) begin pass; end;
+func simple_procedure(bv: bits(8)) begin pass; end;
+
+type Color of enumeration {RED, GREEN, BLUE};
+type Status of enumeration {OKAY, ERROR};
+func enum_procedure(c : Color) begin pass; end;
+func enum_procedure(s : Status) begin pass; end;
+
+func array_procedure(int_arr2 : array[[2]] of integer) begin pass; end;
+// The following declarations are illegal as the array index does not distinguish
+// between array types for the purpose of determining type-clashing.
+// func array_procedure(int_arr3 : array[[3]] of integer) begin pass; end;
+// func array_procedure(enum_arr : array[[Color]] of integer) begin pass; end;
+
+func array_procedure(boolean_arr : array[[2]] of boolean) begin pass; end;
+func array_procedure(real_arr : array[[2]] of real) begin pass; end;
+
+type Rec1 of record;
+type Rec2 of record;
+type Exc1 of exception;
+type Exc2 of exception;
+func structured_procedure(r: Rec1) begin pass; end;
+func structured_procedure(r: Rec2) begin pass; end;
+func structured_procedure(e: Exc1) begin pass; end;
+func structured_procedure(e: Exc2) begin pass; end;
+
+func tuple_procedure(t: (integer, boolean, real)) begin pass; end;
+// The following is illegal as the argument clashes with (integer, boolean, real).
+// func tuple_procedure(t: (integer{5..7}, boolean, real)) begin pass; end;
+func tuple_procedure(t: (integer, boolean)) begin pass; end;
+func tuple_procedure(t: (integer, real)) begin pass; end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -4,6 +4,12 @@ Hello world should work:
   Hello, world!
 
 ASL Typing Tests:
+  $ aslref TypingRule.SubtypeSatisfaction1.asl
+  $ aslref --no-exec TypingRule.SubtypeSatisfaction2.asl
+  $ aslref TypingRule.SubtypeSatisfaction3.asl
+  File TypingRule.SubtypeSatisfaction3.asl, line 9, characters 4 to 45:
+  ASL Typing error: a subtype of AnimalLegs was expected, provided ShapeSides.
+  [1]
   $ aslref TypingRule.TypeSatisfaction1.asl
   $ aslref TypingRule.TypeSatisfaction2.asl
   $ aslref TypingRule.TypeSatisfaction3.asl
@@ -11,8 +17,32 @@ ASL Typing Tests:
   ASL Typing error: a subtype of pairT was expected,
     provided (integer {1}, T2).
   [1]
+  $ aslref --no-exec TypingRule.TypeClashes.asl
+  $ aslref TypingRule.LowestCommonAncestor.asl
+  $ aslref TypingRule.FindNamedLCA.asl
+  $ aslref TypingRule.ApplyUnopType.asl
 //  $ aslref TypingRule.EConcatUnresolvableToInteger.asl
   $ aslref TypingRule.ApplyBinopTypes.asl
+  $ aslref TypingRule.ApplyBinopTypes.constraints.asl
+  File TypingRule.ApplyBinopTypes.constraints.asl, line 22, characters 51 to 78:
+  Warning: Removing some values that would fail with op DIV from constraint set
+  {-5..3} gave {1..3}. Continuing with this constraint set.
+  File TypingRule.ApplyBinopTypes.constraints.asl, line 26, characters 39 to 65:
+  Warning: Removing some values that would fail with op MOD from constraint set
+  {0..3} gave {1..3}. Continuing with this constraint set.
+  File TypingRule.ApplyBinopTypes.constraints.asl, line 41, characters 31 to 80:
+  Exploding sets for the binary operation * could result in a constraint set
+  bigger than 2^17 with constraints 0..16384 and 0..16384. Continuing with the
+  non-expanded constraints.
+  File TypingRule.ApplyBinopTypes.constraints.asl, line 42, characters 31 to 82:
+  Warning: Removing some values that would fail with op DIV from constraint set
+  {0..16384} gave {1..16384}. Continuing with this constraint set.
+  File TypingRule.ApplyBinopTypes.constraints.asl, line 42, characters 31 to 82:
+  Exploding sets for the binary operation DIV could result in a constraint set
+  bigger than 2^17 with constraints 0..16384 and 1..16384. Continuing with the
+  non-expanded constraints.
+  ASL Error: Undefined identifier: 'main'
+  [1]
   $ aslref TypingRule.LDDiscard.asl
   $ aslref TypingRule.LDVar.asl
   $ aslref TypingRule.LDTyped.asl
@@ -93,6 +123,7 @@ ASL Typing Tests / annotating types:
   ASL Typing error: a subtype of integer {0..2} was expected,
     provided integer {3}.
   [1]
+  $ aslref --no-exec TypingRule.CheckConstrainedInteger.asl
 
   $ aslref TypingRule.BaseValue.asl
   global_base = 0, unconstrained_integer_base = 0, constrained_integer_base = -3
@@ -218,3 +249,31 @@ ASL Typing Tests / annotating types:
   eq_enum: RED == GREEN = FALSE
   eq_enum: RED != RED = FALSE
   eq_enum: RED != GREEN = TRUE
+
+  $ aslref TypingRule.EVar.asl
+  $ aslref TypingRule.EVar.undefined.asl
+  File TypingRule.EVar.undefined.asl, line 3, characters 12 to 13:
+  ASL Error: Undefined identifier: 't'
+  [1]
+
+  $ aslref TypingRule.EGetRecordField.asl
+  $ aslref TypingRule.EGetBadRecordField.asl
+  File TypingRule.EGetBadRecordField.asl, line 7, characters 10 to 36:
+  ASL Error: There is no field 'undeclared_field' on type MyRecordType.
+  [1]
+  $ aslref TypingRule.EGetBitfield.asl
+  $ aslref TypingRule.EGetBadBitField.asl
+  File TypingRule.EGetBadBitField.asl, line 7, characters 12 to 33:
+  ASL Error: There is no field 'undeclared_bitfield' on type Packet.
+  [1]
+  $ aslref TypingRule.EGetBadField.asl
+  File TypingRule.EGetBadField.asl, line 6, characters 12 to 15:
+  ASL Error: There is no field 'f' on type array [[5]] of integer.
+  [1]
+  $ aslref TypingRule.EGetFields.asl
+  $ aslref --no-exec TypingRule.ATC.asl
+  $ aslref --no-exec TypingRule.CheckATC.asl
+  File TypingRule.CheckATC.asl, line 8, characters 12 to 32:
+  ASL Typing error: cannot perform Asserted Type Conversion on real by
+    integer {1, 2}.
+  [1]


### PR DESCRIPTION
* Added examples to the Types chapter and Expressions chapter.
* Add a lint check for double backslash in a macro instance.
* A few fixes to rules and typos.