### PR TITLE
[herd] Fix some remaining  integers-as-booleans

### DIFF
--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -865,7 +865,9 @@ Monad type:
         if V.is_var_determined v then begin
           match V.as_bool v with
           | Some b -> if b then l eiid else r eiid
-          | None -> assert false
+          | None ->
+              Warn.fatal
+                "Not a boolean constant %s" (V.pp_v v)
         end else
           let (eiid, (lact,lspec)) = l eiid in
           assert (lspec = None);


### PR DESCRIPTION
Some general operations were still using explicit one and zero for true and false. Fix this.

This is a followup to PR #1129.