### PR TITLE
[asl] Alternative syntax for masks

### DIFF
--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -297,7 +297,7 @@ exception LexerError
 
 let new_line lexbuf = Lexing.new_line lexbuf; lexbuf
 let bitvector_lit lxm = BITVECTOR_LIT (Bitvector.of_string lxm)
-let mask_lit lxm = MASK_LIT (Bitvector.mask_of_string lxm)
+let mask_lit lxm = MASK_LIT (lxm |> Bitvector.preprocess_mask_string |> Bitvector.mask_of_string)
 let reserved_err s = Error.fatal_unknown_pos @@ (Error.ReservedIdentifier s)
 
 let fatal lexbuf desc =
@@ -395,7 +395,7 @@ let real_lit = int_lit '.' int_lit
 let alpha = ['a'-'z' 'A'-'Z']
 let string_lit = '"' [^ '"']* '"'
 let bits = ['0' '1' ' ']*
-let mask = ['0' '1' 'x' ' ']*
+let mask = ['0' '1' 'x' ' ']* | ( ['0' '1' ' ' ]+ | '(' ['0' '1' ' ' ]+ ')')*
 let identifier = (alpha | '_') (alpha|digit|'_')*
 
 (*

--- a/asllib/bitvector.ml
+++ b/asllib/bitvector.ml
@@ -611,6 +611,24 @@ type mask = {
 
 let mask_length mask = mask.length
 
+let preprocess_mask_string s =
+  let buffer = Buffer.create (String.length s) in
+  let process_parentheses s =
+    let convert_to_x in_parens = function
+      | '(' ->
+          if in_parens then raise (Invalid_argument "Mask preprocess") else true
+      | ')' ->
+          if not in_parens then raise (Invalid_argument "Mask preprocess")
+          else false
+      | c ->
+          Buffer.add_char buffer (if in_parens then 'x' else c);
+          in_parens
+    in
+    let _ = String.fold_left convert_to_x false s in
+    Buffer.contents buffer
+  in
+  process_parentheses s
+
 let mask_of_string s =
   let length_set, set =
     String.map (function 'x' -> '0' | '0' -> '0' | '1' -> '1' | c -> c) s

--- a/asllib/bitvector.mli
+++ b/asllib/bitvector.mli
@@ -196,6 +196,9 @@ type mask
 val mask_length : mask -> int
 (** Returns the length of bitvectors matched by this mask. *)
 
+val preprocess_mask_string : string -> string
+(** Preprocess a string which uses parentheses to represent a mask, and convert into "x"s. *)
+
 val mask_of_string : string -> mask
 (** Build a mask from its ASL representation. *)
 

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -155,17 +155,23 @@ The spaces in a bitvector are not significant and are only used to improve reada
 For example, \texttt{'1111 1111 1111 1111'} is the same as \texttt{'1111111111111111'}.
 
 \section{Bitmasks}
-Constant bitmasks are written using \texttt{1}, \texttt{0}, \texttt{x} and spaces surrounded by single-quotes.
-The \texttt{x} represents a don’t care character.
+Constant bitmasks are written in one of two ways:
+\begin{itemize}
+  \item Using \texttt{1}, \texttt{0}, \texttt{x} and spaces surrounded by single-quotes.
+    The \texttt{x} represents a don't care character.
+  \item Using \texttt{1}, \texttt{0}, spaces surrounded by single-quotes, with don't care characters enclosed in parentheses.
+\end{itemize}
 
 \hypertarget{def-rebitmasklit}{}
 \begin{center}
 \begin{tabular}{rcl}
 $\REbitmasklit$ &$\triangleq$& \anycharacter{\texttt{'}} (\anycharacter{\texttt{01x}\square})* \anycharacter{\texttt{'}}
+\texttt{ | } \anycharacter{\texttt{'}} \big( (\anycharacter{\texttt{01}\square})+ \texttt{|} \anycharacter{\texttt{(}} (\anycharacter{\texttt{01}\square})+ \anycharacter{\texttt{)}} \big)* \anycharacter{\texttt{'}}
 \end{tabular}
 \end{center}
 
 The spaces in a constant bitmask are not significant and are only used to improve readability.
+Similarly, the specific characters enclosed within parentheses are not significant, as each \texttt{0} or \texttt{1} is equivalent to an \texttt{x}.
 
 \section{String Literals}
 

--- a/asllib/tests/regressions.t/alt-mask-syntax.asl
+++ b/asllib/tests/regressions.t/alt-mask-syntax.asl
@@ -1,0 +1,32 @@
+func assert_same(b1: boolean, b2: boolean)
+begin
+  assert b1 == b2;
+end;
+
+func main() => integer
+begin
+  // Loop over all bits(4) bit vectors
+  for i = 0 to 2^4 - 1 do
+    let bv = i[:4];
+
+    assert_same (bv == '1(0)(0)1', bv IN {'1xx1'});
+    assert_same (bv == '1(0)(1)1', bv IN {'1xx1'});
+    assert_same (bv == '1(1)(0)1', bv IN {'1xx1'});
+    assert_same (bv == '1(1)(1)1', bv IN {'1xx1'});
+
+    assert_same (bv == '1(00)1', bv IN {'1xx1'});
+    assert_same (bv == '1(01)1', bv IN {'1xx1'});
+    assert_same (bv == '1(10)1', bv IN {'1xx1'});
+    assert_same (bv == '1(11)1', bv IN {'1xx1'});
+
+    assert_same (bv != '0(0)1(0)', !(bv IN {'0x1x'}));
+    assert_same (bv != '0(0)1(1)', !(bv IN {'0x1x'}));
+    assert_same (bv != '0(1)1(0)', !(bv IN {'0x1x'}));
+    assert_same (bv != '0(1)1(1)', !(bv IN {'0x1x'}));
+
+    assert_same (bv IN {'1(0)(0)1', '0(1)1(1)'}, bv IN {'1xx1', '0x1x'});
+    assert_same (bv IN {'1(0)(1)1', '0(1)1(0)'}, bv IN {'1xx1', '0x1x'});
+  end;
+
+  return 0;
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -370,6 +370,7 @@ Required tests:
   $ aslref declaration-primitive-local.asl
   $ aslref --no-type-check -0 typing-assign-v0.asl
   $ aslref constant-functions.asl
+  $ aslref alt-mask-syntax.asl
 
   $ aslref undeclared-variable.asl
   File undeclared-variable.asl, line 3, characters 2 to 5:


### PR DESCRIPTION
Add an alternative syntax for masks, where `0`s` and `1`s in parentheses are treated as `x`s. For example, `'10(1)0(10)'` is the same as `10x0xx`.
