### PR TITLE
[asl+aarch64] Fix noret decode for CAS

### DIFF
--- a/catalogue/aarch64/cfgs/asl.cfg
+++ b/catalogue/aarch64/cfgs/asl.cfg
@@ -2,8 +2,6 @@
 timeout 60
 #Fixed by PR #1179
 nonames LB+rel+CAS
-#Fixed by PR #1206
-nonames MP+rel+CASacq-noret-ok
 #All similar
 nonames MP+rel+CASnoret-ok-dmb.ld,MP+rel+SWPnoret-dmb.ld,MP+rel+LDADDnoret-dmb.ld
 #Different

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -259,7 +259,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
                   "n" ^= reg rn;
                   "datasize" ^= variant v;
                   "regsize" ^= variant v;
-                  "acquire" ^= litb (decode_acquire t);
+                  "acquire" ^= litb (decode_acquire t && rs <> ZR);
                   "release" ^= litb (decode_release t);
                   "tagchecked" ^= litb (rn <> SP);
                 ] )


### PR DESCRIPTION
This fixes the test `MP+rel+CASacq-noret-ok` identified in #1178.