### PR TITLE
[asl][reference] fixed a bug in doclint.py and added missing hypertargets

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1242,6 +1242,7 @@
 \newcommand\Proselca[0]{\hyperlink{def-lowestcommonancestor}{lowest common ancestor}}
 \newcommand\namedlca[0]{\hyperlink{def-namedlowestcommonancestor}{\textfunc{named\_lowest\_common\_ancestor}}}
 \newcommand\Supers{\textsf{Supers}}
+\newcommand\supers[0]{\hyperlink{def-supers}{\textfunc{supers}}}
 \newcommand\bitfieldsincluded[0]{\hyperlink{def-bitfieldsincluded}{\textfunc{bitfields\_included}}}
 \newcommand\membfs[0]{\hyperlink{def-membfs}{\textfunc{mem\_bfs}}}
 \newcommand\instantiate[0]{\textfunc{instantiate}}
@@ -1916,7 +1917,7 @@
 
 \newcommand\Prosetypecheckast[4]{\hyperlink{def-typecheckast}{typechecking} #1 in #2 yields the typed AST #3 and static environment #4}
 \newcommand\typecheckast[0]{\hyperlink{def-typecheckast}{\textfunc{type\_check\_ast}}}
-\newcommand\Proseoverridesubprograms[0]{\hyperlink{def-overriding}{overriding subprograms}}
+\newcommand\Proseoverridesubprograms[0]{\hyperlink{def-overridesubprograms}{overriding subprograms}}
 \newcommand\overridesubprograms[0]{\hyperlink{def-overridesubprograms}{\textfunc{override\_subprograms}}}
 \newcommand\Proseprocessoverrides[2]{\hyperlink{def-processoverrides}{processing overrides} in #1 and #2}
 \newcommand\processoverrides[0]{\hyperlink{def-processoverrides}{\textfunc{process\_overrides}}}

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -3,6 +3,7 @@
 Bitvector types allow defining bitslices of bitvectors, to be treated as named
 fields, which can be read or written. \identi{KGMC}
 
+\hypertarget{bitfieldterm}{}
 Individual bitfields are grammatically derived from $\Nbitfield$ and represented as ASTs by $\bitfield$.
 Bitfields are not associated with a semantic relation.
 

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -1691,7 +1691,7 @@ The function
 \]
 returns the lowest common named super type --- $\tty$ --- of the types $\vt$ and $\vs$ in $\tenv$.
 
-\newcommand\supers[0]{\hyperlink{def-supers}{\textfunc{supers}}}
+\hypertarget{def-supers}{}
 The helper function
 \[
   \supers(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt})

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -106,6 +106,7 @@ use the term \integertypeterm{} to refer to them collectively:
 \emph{pending constrained}, and \emph{parameterized}.
 
 \subsection{Unconstrained Integer Types}
+\hypertarget{def-unconstrainedintegertype}{}
 The type \verb|integer| represents all integer values.
 \identi{HJBH}%
 There is no bound on the minimum and maximum integer value that can be represented.
@@ -124,10 +125,12 @@ A constraint can either be an \emph{\exactconstraintterm}, consisting of a singl
 or a \emph{\rangeconstraintterm}, consisting of a pair of expressions like \texttt{1..10}.
 
 \ExampleDef{Well-constrained Integer Types}
+\hypertarget{def-wellconstrainedintegertype}{}
 \listingref{typing-wellconstrained} shows examples of well-constrained integer types.
 \ASLListing{Well-typed well-constrained integer types}{typing-wellconstrained}{\typingtests/TypingRule.TIntWellConstrained.asl}
 
 \subsection{Pending-constrained Integer Types}
+\hypertarget{def-pendingconstrainedintegertype}{}
 The type \verb|integer{-}| represents a well-constrained integer type whose
 constraints have yet to be determined.
 These constraints are inferred by the type system based on the expression used to initialize
@@ -146,6 +149,7 @@ integer types.
 \ASLListing{Well-typed pending-constrained integer types}{typing-pendingconstrained}{\typingtests/TypingRule.InheritIntegerConstraints.asl}
 
 \subsection{Parameterized Integer Types}
+\hypertarget{def-parameterizedintegertype}{}
 Subprogram parameters are implicitly \emph{parameterized integer types},
 which represent a singleton set for the integer passed to the parameter
 at the call site.
@@ -523,8 +527,9 @@ See \ExampleRef{Well-typed Real Types} for examples of well-typed \realtypeterm{
 \end{mathpar}
 \CodeSubsection{\TRealBegin}{\TRealEnd}{../Typing.ml}
 
-\hypertarget{stringtypeterm}{}
 \section{The String Type\label{sec:StringType}}
+\hypertarget{stringtypeterm}{}
+\hypertarget{stringtypesterm}{}
 The \emph{\stringtypeterm{}} represents strings of characters.
 
 Strings play relatively little role in specifications and the only operations

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -65,7 +65,7 @@ def check_hyperlinks_and_hypertargets(latex_files: list[str]):
     hyperlink_labels: set[str] = set()
     hypertarget_labels: set[str] = set()
     for latex_source in latex_files:
-        for line in read_file_str(latex_source):
+        for line in read_file_lines(latex_source):
             extract_labels_from_line(line, "\\hyperlink{", hyperlink_labels)
             extract_labels_from_line(line, "\\hypertarget{", hypertarget_labels)
     num_errors = 0
@@ -74,8 +74,7 @@ def check_hyperlinks_and_hypertargets(latex_files: list[str]):
         num_missing_hypertargets = len(missing_hypertargets)
         num_errors += num_missing_hypertargets
         print(
-            f"ERROR: found {num_missing_hypertargets} hyperlinks without \
-              matching hypertargets: ",
+            f"ERROR: found {num_missing_hypertargets} hyperlinks without matching hypertargets: ",
             file=sys.stderr,
         )
         for label in missing_hypertargets:


### PR DESCRIPTION
* Fixed a bug in `doclint.py` which effectively disabled the check for matching hyperlinks and hypertargets.
* FIxed 8 hyperlinks/hypertargets issues.