### PR TITLE
[asl] Fixes for environments in evaluation of blocks

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1113,6 +1113,8 @@
 \newcommand\evalslice[0]{\hyperlink{def-evalslice}{\textfunc{eval\_slice}}}
 \newcommand\evalstmt[1]{\hyperlink{def-evalstmt}{\textfunc{eval\_stmt}}(#1)}
 \newcommand\evalblock[1]{\hyperlink{def-evalblock}{\textfunc{eval\_block}}(#1)}
+\newcommand\poplocalscope[0]{\hyperlink{def-poplocalscope}{\textfunc{pop\_local\_scope}}}
+\newcommand\Prosepoplocalscope[2]{#2 after \hyperlink{def-poplocalscope}{restoring} the variable bindings of #1 with the updated values of #2}
 \newcommand\evalloop[1]{\hyperlink{def-evalloop}{\textfunc{eval\_loop}}(#1)}
 \newcommand\evalfor[0]{\hyperlink{def-evalfor}{\textfunc{eval\_for}}}
 \newcommand\evalforloop[0]{\hyperlink{def-evalforloop}{\textfunc{eval\_for\_loop}}}
@@ -2234,10 +2236,12 @@
 \newcommand\envandfs[0]{\texttt{env\_and\_fs}}
 \newcommand\envandfsone[0]{\texttt{env\_and\_fs1}}
 \newcommand\envandfstwo[0]{\texttt{env\_and\_fs2}}
+\newcommand\envcont[0]{\texttt{env\_cont}}
 \newcommand\envfour[0]{\texttt{env4}}
 \newcommand\envm[0]{\texttt{envm}}
 \newcommand\envone[0]{\texttt{env1}}
 \newcommand\envp[0]{\texttt{env'}}
+\newcommand\envret[0]{\texttt{env\_ret}}
 \newcommand\envthree[0]{\texttt{env3}}
 \newcommand\envthrow[0]{\texttt{env\_throw}}
 \newcommand\envthrowone[0]{\texttt{env\_throw1}}
@@ -2836,6 +2840,7 @@
 \newcommand\vindex[0]{\texttt{index}}
 \newcommand\vindexname[0]{\texttt{index\_name}}
 \newcommand\vinitialvalue[0]{\texttt{initial\_value}}
+\newcommand\vinnerenv[0]{\texttt{inner\_env}}
 \newcommand\vione[0]{\texttt{i1}}
 \newcommand\vis[0]{\texttt{vis}}
 \newcommand\visone[0]{\texttt{is1}}
@@ -2930,6 +2935,7 @@
 \newcommand\voptfields[0]{\texttt{opt\_fields}}
 \newcommand\voptlimit[0]{\texttt{opt\_limit}}
 \newcommand\votherwiseopt[0]{\texttt{otherwise\_opt}}
+\newcommand\vouterenv[0]{\texttt{outer\_env}}
 \newcommand\vp[0]{\texttt{p}}
 \newcommand\vprefixcases[0]{\texttt{prefix\_cases}}
 \newcommand\vprev[0]{\texttt{prev}}

--- a/asllib/doc/BlockStatements.tex
+++ b/asllib/doc/BlockStatements.tex
@@ -67,26 +67,84 @@ which drops back to the original local environment of $\env$ when the evaluation
 \SemanticsRuleDef{Block}
 See \ExampleRef{Block Statements}.
 
+We first define the helper function $\poplocalscope$:
+\hypertarget{def-poplocalscope}{}
+\[
+  \begin{array}{c}
+    \poplocalscope : \overname{\dynamicenvs}{\vouterenv} \cartimes \overname{\dynamicenvs}{\vinnerenv} \rightarrow \dynamicenvs \\
+    \poplocalscope(\vouterenv, \vinnerenv) \triangleq
+      (G^{\vinnerenv}, \restrictfunc{L^{\vinnerenv}}{{\dom(L^\vouterenv)}})
+  \end{array}
+\]
+The $\poplocalscope$ function is used below to effectively discard the bindings for variables declared inside the block statement $\stm$.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
     \item evaluating $\stm$ in $\env$, as per \chapref{Statements},
-          is $\Continuing(\newg, \envone)$\ProseTerminateAs{\ReturningConfig,\ThrowingConfig,\DynErrorConfig};
-    \item $\newenv$ is formed from $\envone$ after restoring the
-          variable bindings of $\env$ with the updated values of $\envone$.
-          The effect is that of discarding the bindings for variables declared inside $\stm$;
-    \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
+          is $\vres$;
+    \item \OneApplies
+      \begin{itemize}
+        \item \AllApplyCase{returning}
+        \begin{itemize}
+          \item $\vres$ is $\Returning((\vvs, \newg), \envret)$;
+          \item \Proseeqdef{$\newenv$}{\Prosepoplocalscope{$\env$}{$\envret$}}.
+          \item the result of the entire evaluation is $\Returning((\vvs, \newg), \newenv)$.
+        \end{itemize}
+
+        \item \AllApplyCase{continuing}
+        \begin{itemize}
+          \item $\vres$ is $\Continuing(\newg, \envcont)$;
+          \item \Proseeqdef{$\newenv$}{\Prosepoplocalscope{$\env$}{$\envcont$}}.
+          \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
+        \end{itemize}
+
+        \item \AllApplyCase{throwing}
+        \begin{itemize}
+          \item $\vres$ is $\Throwing((\vv, \newg), \envthrow)$;
+          \item \Proseeqdef{$\newenv$}{\Prosepoplocalscope{$\env$}{$\envthrow$}}.
+          \item the result of the entire evaluation is $\Throwing((\vv, \newg), \newenv)$.
+        \end{itemize}
+      \end{itemize}
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule{
+\inferrule[returning]{
   \env \eqname (\tenv,\denv)\\
-  \evalstmt{\env, \stm} \evalarrow \Continuing(\newg, \envone) \terminateas \ReturningConfig,\ThrowingConfig,\DynErrorConfig\\\\
-  \envone\eqname(\tenvone, \denvone)\\
-  \newenv \eqdef(\tenv, (G^{\denvone}, \restrictfunc{L^{\denvone}}{{\dom(L^\denv)}}))
+  \evalstmt{\env, \stm} \evalarrow \vres \\\\
+  \commonprefixline \\\\
+  \vres = \Returning((\vvs, \newg), \envret) \\
+  \envret \eqname (\tenvone, \denvone) \\
+  \newenv \eqdef (\tenv, \poplocalscope(\denv,\denvone))
+}{
+  \evalblock{\env, \stm} \evalarrow \Returning((\vvs, \newg), \newenv)
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[continuing]{
+  \env \eqname (\tenv,\denv)\\
+  \evalstmt{\env, \stm} \evalarrow \vres \\\\
+  \commonprefixline \\\\
+  \vres = \Continuing(\newg, \envcont) \\
+  \envcont \eqname (\tenvone, \denvone) \\
+  \newenv \eqdef (\tenv, \poplocalscope(\denv,\denvone))
 }{
   \evalblock{\env, \stm} \evalarrow \Continuing(\newg, \newenv)
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[throwing]{
+  \env \eqname (\tenv,\denv)\\
+  \evalstmt{\env, \stm} \evalarrow \vres \\\\
+  \commonprefixline \\\\
+  \vres = \Throwing((\vv,\newg), \envthrow) \\
+  \envthrow \eqname (\tenvone, \denvone) \\
+  \newenv \eqdef (\tenv, \poplocalscope(\denv,\denvone))
+}{
+  \evalblock{\env, \stm} \evalarrow \Throwing((\vv,\newg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalBlockBegin}{\EvalBlockEnd}{../Interpreter.ml}

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -374,6 +374,11 @@ Required tests:
   $ aslref subprogram-global-name-clash.asl
   $ aslref subprogram-local-name-clash.asl
 
+  $ aslref --no-type-check throw-local-env.asl
+  File throw-local-env.asl, line 10, characters 13 to 14:
+  ASL Error: Undefined identifier: 'y'
+  [1]
+
   $ aslref undeclared-variable.asl
   File undeclared-variable.asl, line 3, characters 2 to 5:
   ASL Error: Undefined identifier: 'bar'

--- a/asllib/tests/regressions.t/throw-local-env.asl
+++ b/asllib/tests/regressions.t/throw-local-env.asl
@@ -1,0 +1,16 @@
+type Ex of exception{};
+
+func main () => integer
+begin
+  try
+    var y : integer = 5;
+    throw Ex {};
+  catch
+    when exn: Ex =>
+      assert y == 5; // y should not be found in dynamic environment here
+      var y : integer = 6;
+      assert y == 6;
+  end;
+
+  return 0;
+end;


### PR DESCRIPTION
Thanks to @solswords for a bug report.

- Delete block-local variables after evaluating a block, even when an exception is thrown.
- Add a test using `--no-typecheck`. This previously passed, exposing that block-local variables were persisting across their block boundaries. Now it correctly fails with an "undefined identifier" error.