### PR TITLE
ASL-716 accessibility enhancements phase 8: examples and fixes

### DIFF
--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -584,7 +584,7 @@ Since the rule does not need to refer to the value, we do not name it and use an
 instead.
 
 \subsection{Flavors of Equality In Rules \label{sec:FlavoursOfEqualityInRules}}
-We now explain the equality notations in rules, two of which are used in \SemanticsRuleRef{ECond},
+This section explains the equality notations used in rules, two of which are used in \SemanticsRuleRef{ECond},
 shown here:
 \begin{mathpar}
 \inferrule{

--- a/asllib/doc/ASLRefALP3ChangeLog.tex
+++ b/asllib/doc/ASLRefALP3ChangeLog.tex
@@ -15,7 +15,8 @@ The following changes have been made.
 Introduce \texttt{impdef} keyword for a subprogram that can be overridden by a corresponding \texttt{implementation} keyword (see \secref{Overriding}).
 
 \subsection{ASL-736: paired syntax for getters/setters}
-Require getters/setters to be declared together using a dedicated syntax, as follows:
+Require getters/setters to be declared together using a dedicated syntax, as follows
+(see \chapref{SubprogramDeclarations}):
 \begin{lstlisting}
 accessor Name{params}(args) <=> return_type
 begin

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -2066,7 +2066,7 @@
 \newcommand\OverridingError[0]{\hyperlink{def-overridingerror}{\TypeErrorCode{OE}}}
 
 %% Dynamic Error Codes
-\newcommand\DynamicErrorPrefix[1]{\texttt{DE}}
+\newcommand\DynamicErrorPrefix[0]{\texttt{DE}}
 \newcommand\DynamicErrorVal[1]{\Error(\texttt{#1})}
 \newcommand\DynamicErrorCode[1]{\texttt{\DynamicErrorPrefix\_#1}}
 \newcommand\UnreachableError[0]{\hyperlink{def-unreachableerror}{\DynamicErrorCode{UNR}}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -27,6 +27,7 @@
       boolean,
       case,
       catch,
+      collection,
       config,
       constant,
       DIV,

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1414,8 +1414,8 @@
 \newcommand\unitarymonomialstoexpr[0]{\hyperlink{def-unitarymonomialstoexpr}{\textfunc{unitary\_monomials\_to\_expr}}}
 \newcommand\compareidentifier[0]{\hyperlink{def-compareidentifier}{\textfunc{compare\_identifier}}}
 
-\newcommand\subsumes[0]{\hyperlink{def-subsumes}{\textfunc{subsumes}}}
-\newcommand\symsubsumes[0]{\hyperlink{def-symsubsumes}{\textfunc{sym\_subsumes}}}
+\newcommand\domainsubset[0]{\hyperlink{def-domainsubset}{\textfunc{domain\_subset}}}
+\newcommand\symdomainsubset[0]{\hyperlink{def-symdomainsubset}{\textfunc{sym\_domain\_subset}}}
 
 \newcommand\toir[0]{\hyperlink{def-toir}{\textfunc{to\_ir}}}
 \newcommand\ProseOrTypeErrorOrCannotBeTransformed[0]{\ProseTerminateAs{\CannotBeTransformed,\TypeErrorConfig}}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -639,7 +639,7 @@ Global pragma declarations $\DPragma$ are removed from the \untypedast\ once the
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Building Abstract Syntax Trees\label{sec:BuildingAbstractSyntaxTrees}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-We now define how to transform a parse tree into the corresponding AST
+This section defines how to transform a parse tree into the corresponding AST
 via recursively traversing the parse tree and applying a \emph{builder} function
 for each non-terminal node.
 

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -565,7 +565,7 @@ The rules for expressions have the following extra derivation rules:
 \expr \derives\ & \EGetItem(\expr, \N) &\\ \hypertarget{ast-earray}{}
              |\ & \EArray \{\EArrayLength: \expr, \EArrayValue: \expr\} & \hypertarget{ast-eenumarray}{}\\
              |\ & \EEnumArray \{\EArrayLabels: \identifier^+, \EArrayValue: \expr\} & \hypertarget{ast-egetenumarray}{}\\
-             |\ & \EGetEnumArray(\overtext{\expr}{base}, \overtext{\expr}{key}) &\hypertarget{ast-egetcollectionfields}{}\\ 
+             |\ & \EGetEnumArray(\overtext{\expr}{base}, \overtext{\expr}{key}) &\hypertarget{ast-egetcollectionfields}{}\\
              |\ & \EGetCollectionFields(\overtext{\identifier}{collection}, \overtext{\identifier^{*}}{field names}) & \\
 \end{flalign*}
 
@@ -681,13 +681,13 @@ We also employ the following rule:
   \buildexpr(\ve) \astarrow \astversion{\ve}\\
   \buildstmtlist(\vstmtlist) \astarrow \astversion{\vstmtlist}
 }{
-{
-\begin{array}{r}
-  \buildstmt(\Nstmt(\Twhile, \namednode{\ve}{\Nexpr}, \Tdo, \namednode{\vstmtlist}{\Nstmtlist}, \Tend, \Tsemicolon))
-  \astarrow\\
-  \SWhile(\astversion{\ve}, \None, \astversion{\vstmtlist})
-\end{array}
-}
+  {
+  \begin{array}{r}
+    \buildstmt(\Nstmt(\Twhile, \namednode{\ve}{\Nexpr}, \Tdo, \namednode{\vstmtlist}{\Nstmtlist}, \Tend, \Tsemicolon))
+    \astarrow\\
+    \SWhile(\astversion{\ve}, \None, \astversion{\vstmtlist})
+  \end{array}
+  }
 }
 \end{mathpar}
 That is, we apply the $\buildexpr$ to transform the condition parse node $\ve$ into the corresponding AST node,

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -391,6 +391,7 @@ transforms an $\lhsaccess$ into an AST node $\vlexpr$.
   }{\vlhsaccess} \astarrow \overname{\vsliced}{\vlexpr}
 }
 \end{mathpar}
+
 \ASTRuleDef{DesugarLHSTuple}
 \hypertarget{def-desugarlhstuple}{}
 The function
@@ -399,12 +400,26 @@ The function
 \]
 transforms a list of \optional{} $\lhsaccess$ elements into an AST node $\vlexpr$. \\
 
+\begin{mathpar}
+\inferrule{
+  \vlhsaccesses \eqdef \filteroptionlist(\vlhsaccessopts) \\
+  \vids \eqdef [i \in 1..|\vlhsaccesses|: \vlhsaccesses_i.\lhsaccessbase] \\
+  \checknoduplicates(\vids) \typearrow \True \OrTypeError \\
+  i \in 1..|\vlhsaccessopts|: \desugarlhsaccessopt(\vlhsaccessopt_i) \astarrow \vlexpr_i \\
+  \vlexprs \eqdef [i \in 1..|\vlhsaccessopts|: \vlexpr_i]
+}{
+  \desugarlhstuple(\vlhsaccessopts) \astarrow \overname{\LEDestructuring(\vlexprs)}{\vlexpr}
+}
+\end{mathpar}
+
+\ASTRuleDef{DesugarLHSAccessOpt}
 \hypertarget{def-desugarlhsaccessopt}{}
-\noindent We first define the helper AST function
+The helper AST function
 \[
     \desugarlhsaccessopt(\overname{\langle\lhsaccess\rangle}{\vlhsaccessopt}) \;\aslto\; \overname{\lexpr}{\vlexpr}
 \]
-via the following rules:
+is defined via the following rules:
+
 \begin{mathpar}
 \inferrule[none]{}
 {
@@ -420,19 +435,6 @@ via the following rules:
 }
 \end{mathpar}
 
-\noindent We now use the helper rules to define $\desugarlhstuple$:
-\begin{mathpar}
-\inferrule{
-  \vlhsaccesses \eqdef \filteroptionlist(\vlhsaccessopts) \\
-  \vids \eqdef [i \in 1..|\vlhsaccesses|: \vlhsaccesses_i.\lhsaccessbase] \\
-  \checknoduplicates(\vids) \typearrow \True \OrTypeError \\
-  i \in 1..|\vlhsaccessopts|: \desugarlhsaccessopt(\vlhsaccessopt_i) \astarrow \vlexpr_i \\
-  \vlexprs \eqdef [i \in 1..|\vlhsaccessopts|: \vlexpr_i]
-}{
-  \desugarlhstuple(\vlhsaccessopts) \astarrow \overname{\LEDestructuring(\vlexprs)}{\vlexpr}
-}
-\end{mathpar}
-
 \ASTRuleDef{DesugarLHSFieldsTuple}
 \hypertarget{def-desugarlhsfieldstuple}{}
 The function
@@ -441,12 +443,24 @@ The function
 \]
 transforms an assignment to a tuple of fields $\fields$ of variable $\id$ into an AST node $\vlexpr$. \\
 
+\begin{mathpar}
+\inferrule{
+  \fields \eqdef \filteroptionlist(\fieldopts) \\
+  \checknoduplicates(\fields) \typearrow \True \OrTypeError \\
+  i \in 1..|\fieldopts|: \desugarlhsfieldopt(\fieldopts_i) \astarrow \vlexpr_i \\
+  \vlexprs \eqdef [i \in 1..|\fieldopts|: \vlexpr_i]
+}{
+  \desugarlhsfieldstuple(\id, \fieldopts) \astarrow \overname{\LEDestructuring(\vlexprs)}{\vlexpr}
+}
+\end{mathpar}
+
+\ASTRuleDef{DesugarLHSFieldOpt}
 \hypertarget{def-desugarlhsfieldopt}{}
-\noindent We first define the helper AST function
+The helper AST function
 \[
     \desugarlhsfieldopt(\overname{\identifier}{\id} \aslsep \overname{\langle\identifier\rangle}{\fieldopt}) \;\aslto\; \overname{\lexpr}{\vlexpr}
 \]
-via the following rules:
+is defined via the following rules:
 \begin{mathpar}
 \inferrule[none]{}
 {
@@ -457,18 +471,6 @@ via the following rules:
 \begin{mathpar}
 \inferrule{}{
   \desugarlhsfieldopt(\id, \overname{\langle\vfield\rangle}{\fieldopt}) \astarrow \overname{\LESetField(\LEVar(\id), \vfield)}{\vlexpr}
-}
-\end{mathpar}
-
-\noindent We now use the helper rules to define $\desugarlhsfieldstuple$:
-\begin{mathpar}
-\inferrule{
-  \fields \eqdef \filteroptionlist(\fieldopts) \\
-  \checknoduplicates(\fields) \typearrow \True \OrTypeError \\
-  i \in 1..|\fieldopts|: \desugarlhsfieldopt(\fieldopts_i) \astarrow \vlexpr_i \\
-  \vlexprs \eqdef [i \in 1..|\fieldopts|: \vlexpr_i]
-}{
-  \desugarlhsfieldstuple(\id, \fieldopts) \astarrow \overname{\LEDestructuring(\vlexprs)}{\vlexpr}
 }
 \end{mathpar}
 
@@ -815,7 +817,7 @@ which is when the \textsc{empty} axiom case is used.
 \section{Array Assignment Expressions\label{sec:ArrayAssignmentExpressions}}
 This section details the syntax, abstract syntax, semantics, and typing of array write expressions.
 In the untyped AST, a write to either an integer-indexed array or an enumeration-indexed array is represented
-the same way. They type system infers the kind of array and outputs a typed AST node differentiating
+the same way. The type system infers the kind of array and outputs a typed AST node differentiating
 the two kinds of arrays, either a $\LESetArray$ or a $\LESetEnumArray$, via \TypingRuleRef{LESetArray}.
 The semantics utilizes a rule matching the corresponding type of array ---
 \SemanticsRuleRef{LESetArray} for integer-indexed arrays and

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -1043,6 +1043,8 @@ cell of
 
 \hypertarget{def-slicelexprterm}{}
 \section{Bitvector Slice Assignment Expressions\label{sec:BitvectorSliceAssignmentExpressions}}
+\ASLListing{Assignable slice expressions}{semantics-leslice}{\semanticstests/SemanticsRule.LESlice.asl}
+
 \subsection{Abstract Syntax}
 \begin{flalign*}
 \lexpr \derives\ & \LESlice(\lexpr, \slice^*) &
@@ -1051,8 +1053,7 @@ cell of
 \subsection{Typing}
 \TypingRuleDef{LESlice}
 \ExampleDef{Typing Assignable Slice Expression}
-In \listingref{typing-leslice}, the assignable slice expression \verb|x[3:0, 7:6]| is well-typed.
-\ASLListing{Well-typed assignable slice expression}{typing-leslice}{\typingtests/TypingRule.LESlice.asl}
+In \listingref{semantics-leslice}, the assignable slice expression \verb|x[3:0, 7:6]| is well-typed.
 
 In \listingref{typing-leslice-bad}, the assignable slice expression \verb|x[3:0, 3]| is ill-typed,
 since the slice \verb|3:0| overlaps with the slice \verb|3| at position $3$.
@@ -1130,12 +1131,10 @@ See \ExampleRef{Typing Assignable Slice Expression}.
 \subsection{Semantics}
 \SemanticsRuleDef{LESlice}
 \ExampleDef{Slice Assignments}
-In \listingref{semantics-leslice}, the assignment \texttt{x[3:0] = '0000'} binds
-\texttt{x} to $\nvbitvector(11110000)$
+In \listingref{semantics-leslice}, the assignment \texttt{x[3:0, 7:6] = '000000';} binds
+\texttt{x} to \\ $\nvbitvector(00110000)$
 via the rule \SemanticsRuleRef{LESlice}
 in the environment where \texttt{x} is bound to $\nvbitvector(11111111)$.
-
-\ASLListing{Assignment to a slice}{semantics-leslice}{\semanticstests/SemanticsRule.LESlice.asl}
 
 \ProseParagraph
 \AllApply

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -34,7 +34,7 @@ and slice of the form \texttt{[$\veone$*:$\vetwo$]} as a \scaledslice.
 Bitfields may have nested bitfields. This can have several uses, one of which being able to define two
 different views of a register.
 
-We now define several properties of bitfields, illustrated by the example below.
+This section defines several properties of bitfields, illustrated by the example below.
 These are used to define \RequirementRef{BitfieldAlignment}.
 
 The \hypertarget{def-absolutename}{\absolutename} of a (possibly-nested) bitfield is the list of identifiers starting from the

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -122,13 +122,12 @@ ASL includes the following error kinds:
     Their error codes, listed in \secref{DynamicErrors}, are prefixed with \DynamicErrorPrefix.
 \end{description}
 
-\Builderrorsterm{} and \typingerrorsterm{} are known collectively as .
+\Builderrorsterm{} and \typingerrorsterm{} are known collectively as \staticerrorsterm.
 
 \section{Error Codes Summary\label{sec:ErrorCodesSummary}}
 The following table summarises all error codes.
 
 \begin{center}
-\newcommand{\qq}{\symbol{34}} % ascii code for "
 \begin{tabular}{clc}
 \hline
 \textbf{Code} & \textbf{Name} & \textbf{Kind} \\

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -48,7 +48,8 @@ evaluates the expression $\ve$ in an environment $\env$ and terminates normally 
 a \nativevalue{} $\vv$, an \executiongraph{} $\vg$, and a modified environment $\newenv$.
 Otherwise, the evaluation terminates abnormally.
 
-We now define the syntax, abstract syntax, typing, and semantics of the following kinds of expressions:
+The rest of this chapter defines the syntax, abstract syntax, typing,
+and semantics of the following kinds of expressions:
 \begin{itemize}
   \item Literal expressions (see \secref{LiteralExpressions})
   \item Variable expressions (see \secref{VariablExpressions})
@@ -1296,7 +1297,7 @@ resulting bitvector --- and the execution graph $\vgone$;
 \hypertarget{def-getenumarrayexpression}{}
 This section details the syntax, abstract syntax, semantics, and typing of array read expressions.
 In the untyped AST, a read from either an integer-indexed array or an enumeration-indexed arrays is represented
-the same way. They type system infers the kind of array and outputs a typed AST node differentiating
+the same way. The type system infers the kind of array and outputs a typed AST node differentiating
 the two kinds of arrays, either a $\EGetArray$ or a $\EGetEnumArray$, via \TypingRuleRef{EGetArray}.
 The semantics utilizes a rule matching the corresponding type of array ---
 \SemanticsRuleRef{EGetArray} for integer-indexed arrays and

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -14,7 +14,7 @@ The typing of global declarations is defined in \secref{GlobalDeclarationsTyping
 As the only kind of global declarations that are associated with semantics are global storage declarations,
 their semantics is given in \secref{GlobalStorageDeclarationsSemantics}.
 
-Global pragmas are statically checked by the typechecker, but do not produce type AST nodes,
+Global pragmas are statically checked by the typechecker, but do not produce \typedast{} nodes,
 and thus are not associated with a dynamic semantics.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -104,6 +104,12 @@ yielding an annotated global declaration $\newd$ and modified global static envi
 \ProseOtherwiseTypeError
 
 \TypingRuleDef{TypecheckDecl}
+\ExampleDef{Typing Global Declarations}
+\listingref{TypecheckDecl} exemplifies various kinds of global declarations ---
+types, global storage elements, and subprograms.
+All global declarations in \listingref{TypecheckDecl} are well-typed.
+\ASLListing{Typing global declarations}{TypecheckDecl}{\typingtests/TypingRule.TypecheckDecl.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -189,6 +195,11 @@ and inferred \sideeffectsetterm\ $\vses$.
 
 Note that the return type in $\vf$ has already been annotated by $\annotatefuncsig$.
 
+\ExampleDef{Annotating Subprograms}
+\listingref{typing-subprogram} shows an example of a well-typed procedure --- \verb|my_procedure|
+and an example of a well-typed function --- \verb|flip_bits|.
+\ASLListing{Typing subprograms}{typing-subprogram}{\typingtests/TypingRule.Subprogram.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -252,6 +263,20 @@ The helper function
 checks whether all control-flow paths defined by the statement $\vs$ terminate by either
 a statement returning a value, a \texttt{throw} statement, or the \texttt{Unreachable()} statement.
 
+\ExampleDef{Ensuring All Terminating Paths Terminate Correctly}
+In \listingref{CheckStmtReturnsOrThrows}, every evaluation of the function body for\\
+\verb|all_terminating_paths_correct| terminates by either returning
+a value, throwing an exception, or evaluating an \unreachablestatementterm.
+\ASLListing{All terminating paths terminate correctly}{CheckStmtReturnsOrThrows}{\typingtests/TypingRule.CheckStmtReturnsOrThrows.asl}
+
+In \listingref{CheckStmtReturnsOrThrows-bad}, the path through the function body
+for \verb|incorrect_terminating_path|
+where \verb|v != Zeros{N}| evaluates to
+$\True$ and \verb|flag| evaluates to $\False$ terminates without
+returning a value, throwing an exception, or evaluating an \unreachablestatementterm,
+which is a \typingerrorterm.
+\ASLListing{An incorrectly terminating path}{CheckStmtReturnsOrThrows-bad}{\typingtests/TypingRule.CheckStmtReturnsOrThrows.bad.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -282,6 +307,19 @@ We define \controlflowsymbolsterm\ as follows:
 \[
   \assertednotinterrupt\ \controlflowleq \interrupt \controlflowleq \maynotinterrupt \enspace.
 \]
+
+\ExampleDef{Determining the Control-flow State of Statements}
+In \listingref{ControlFlowFromStmt}, the function bodies of all functions
+terminate by either returning a value, throwing an exception, or executing
+the \unreachablestatementterm.
+\ASLListing{Determining the control-flow state of statements}{ControlFlowFromStmt}{\typingtests/TypingRule.ControlFlowFromStmt.asl}
+
+In \listingref{ControlFlowFromStmt-bad1}, the function body of \verb|loop_forever|
+is ill-typed, since the conservative analysis of \TypingRuleRef{ControlFlowFromStmt}
+cannot determine that the \whilestatementterm{} never terminates.
+To make the function body well-typed, another statement following the loop
+can be added, for example, an \unreachablestatementterm.
+\ASLListing{An ill-typed function body}{ControlFlowFromStmt-bad1}{\typingtests/TypingRule.ControlFlowFromStmt.bad1.asl}
 
 \hypertarget{def-controlflowfromstmt}{}
 The helper function
@@ -484,6 +522,19 @@ combines two \controlflowsymbolterm{s} considering them as part of a control flo
 path prefix yields $\vtone$ and the analysis of the path suffix yields $\vttwo$,
 into a single \controlflowsymbolterm\ $\vctrlflow$.
 
+\ExampleDef{Determining the Control-flow State of a Sequence of Statements}
+In \listingref{ControlFlowFromStmt},
+the function body of \verb|sequencing1| is determined to have
+the control-flow state $\interrupt$ by the statement
+\verb|throw invalid_state{}|, effectively ignoring the succeeding statement
+\verb|var x = 5;|
+
+On the other hand, in the function body of \verb|sequencing2|,
+analysis of the \passstatementterm{} yields the control-flow state
+$\maynotinterrupt$, but analysis of the statement \\ \verb|return 5;|
+yields control-flow state $\interrupt$, which is why the analysis
+of the sequence of these two statements yields $\interrupt$.
+
 \ProseParagraph
 Define $\vctrlflow$ as $\vttwo$ if $\vtone$ is $\maynotinterrupt$ and $\vtone$, otherwise.
 
@@ -499,13 +550,19 @@ Define $\vctrlflow$ as $\vttwo$ if $\vtone$ is $\maynotinterrupt$ and $\vtone$, 
 \TypingRuleDef{ControlFlowJoin}
 \hypertarget{def-controlflowjoin}{}
 The helper function
-The helper function
 \[
 \controlflowjoin(\overname{\pow{\controlflowstate}}{\vs})
 \aslto \overname{\controlflowstate}{\vctrlflow}
 \]
 returns the maximal element in the set of \controlflowsymbolsterm\ $\vs$,
 with respect to $\controlflowleq$ in $\vctrlflow$.
+
+\ExampleDef{Determining the Control-flow State of a Conditional Statement}
+In \listingref{ControlFlowFromStmt},
+the function body for \verb|conditional| is well-typed, since the
+control-flow state analysis
+for both statements \verb|return 5;| and \verb|throw invalid_state{};|
+yields the control-flow state $\interrupt$.
 
 \ProseParagraph
 \Proseeqdef{$\vctrlflow$}{the maximal element in the set of \controlflowsymbolsterm\ $\vs$,

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -18,8 +18,8 @@ In particular, implementations may provide mechanisms to override \texttt{config
   \item Internally modifying \texttt{config} values after typechecking but before evaluation of a specification.
 \end{itemize}
 Note that if modifying values after typechecking, care must be taken to ensure that the modified values remain compatible with the expected types of the original values.
-For example, a \texttt{config} value declared with type \texttt{integer{0..10}} can be modified to \texttt{5} but should not be modified to \texttt{11}.
-This is because as \texttt{5} is compatible with \texttt{integer{0..10}}, but \texttt{11} is not.
+For example, a \texttt{config} value declared with type \verb|integer{0..10}| can be modified to \texttt{5} but should not be modified to \texttt{11}.
+This is because as \texttt{5} is compatible with \verb|integer{0..10}|, but \texttt{11} is not.
 
 The language supports such overriding mechanisms (and in particular, simplifies tracking of types for \texttt{config} storage elements) as follows:
 \begin{itemize}
@@ -707,7 +707,7 @@ is bound to the global storage keyword $\keyword$ and type $\declaredt$.
 \section{Semantics\label{sec:GlobalStorageDeclarationsSemantics}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-We now define the following relations:
+This section defines the following relations:
 \begin{itemize}
   \item \SemanticsRuleRef{EvalGlobals}
   \item \SemanticsRuleRef{DeclareGlobal}

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -401,7 +401,7 @@ Lexical analysis of ASL follows this approach by defining three specifications:
 Additionally, lexical analysis of string literals carries the extra state ---
 the string characters encountered along the way.
 
-We now define each of the lexical specifications and related lexeme actions.
+The rest of this section defines each of the lexical specifications and related lexeme actions.
 
 Each lexical specification is depicted by a table where the order of elements
 of a specification corresponds to the order of rows in the table.

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -314,33 +314,8 @@ evaluation of \texttt{3} in $\env$.
   \item the output configuration is obtained by declaring each identifier $\id_i$
   with the corresponding value ($\vm$ component) $(\vv_i, \vg)$.
 \end{itemize}
-\FormallyParagraph
-\hypertarget{def-ldituplefolder}{}
-We first define the helper semantic relation
-\[
-    \ldituplefolder(\overname{\envs}{\env} \aslsep \overname{\identifier^*}{\vids} \aslsep \overname{(\vals \times \XGraphs)^*}{\liv}) \;\aslrel\;
-     \Normal(\overname{\XGraphs}{\vg} \aslsep \overname{\envs}{\newenv})
-\]
-via the following rules:
-\begin{mathpar}
-\inferrule{}
-{
-  \ldituplefolder(\env, \emptylist, \emptylist) \evalarrow \Normal(\emptygraph, \env)
-}
-\and
-\inferrule{
-  \vids \eqname [\id] \concat \vids'\\
-  \liv \eqname [\vm] \concat \liv'\\
-  \vm \eqname (\vv, \vgone)\\\\
-  \declarelocalidentifier(\env, \id, \vv) \evalarrow (\envone, \vgtwo)\\
-  \ldituplefolder(\envone, \vids', \liv') \evalarrow \Normal(\vgthree, \newenv)\\
-  \newg \eqdef (\ordered{\vgone}{\asldata}{\vgtwo}) \parallelcomp \vgthree\\
-}{
-  \ldituplefolder(\env, \vids, \liv) \evalarrow \Normal(\newg, \newenv)
-}
-\end{mathpar}
 
-We now use the helper rules to define the rule for local declaration item tuples:
+\FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \vm \eqname (\vv, \vg)\\
@@ -353,3 +328,56 @@ We now use the helper rules to define the rule for local declaration item tuples
 }
 \end{mathpar}
 \CodeSubsection{\EvalLDTupleBegin}{\EvalLDTupleEnd}{../Interpreter.ml}
+
+\SemanticsRuleDef{LDITupleFolder}
+\hypertarget{def-ldituplefolder}{}
+The helper semantic relation
+\[
+    \ldituplefolder(\overname{\envs}{\env} \aslsep \overname{\identifier^*}{\vids} \aslsep \overname{(\vals \times \XGraphs)^*}{\liv}) \;\aslrel\;
+     \Normal(\overname{\XGraphs}{\vg} \aslsep \overname{\envs}{\newenv})
+\]
+is defined as follows.
+
+See \ExampleRef{Evaluation of Tuple Declarations}.
+
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{empty}
+  \begin{itemize}
+    \item both $\vids$ and $\liv$ are empty lists;
+    \item \Proseeqdef{$\vg$}{the empty \executiongraph};
+    \item \Proseeqdef{$\newenv$}{$\env$}.
+  \end{itemize}
+
+  \item \AllApplyCase{non\_empty}
+  \begin{itemize}
+    \item $\vids$ is a list with \head{} $\id$ and \tail{} $\vids'$;
+    \item $\liv$ is a list with \head{} $\vm$ and \tail{} $\liv'$;
+    \item applying $\declarelocalidentifier$ to $\id$ and $\vv$ in $\env$ yields $(\envone, \vgtwo)$;
+    \item applying $\ldituplefolder$ to $\vids'$ and $\liv'$ in $\envone$ yields $\Normal(\vgthree, \newenv)$;
+    \item \Proseeqdef{$\newg$}{the parallel composition of the ordered composition of $\vgone$ and $\vgtwo$
+          with the $\asldata$ edge, and $\vgthree$}.
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[empty]{}
+{
+  \ldituplefolder(\env, \overname{\emptylist}{\vids}, \overname{\emptylist}{\liv}) \evalarrow \Normal(\emptygraph, \env)
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_empty]{
+  \vids \eqname [\id] \concat \vids'\\
+  \liv \eqname [\vm] \concat \liv'\\
+  \vm \eqname (\vv, \vgone)\\\\
+  \declarelocalidentifier(\env, \id, \vv) \evalarrow (\envone, \vgtwo)\\
+  \ldituplefolder(\envone, \vids', \liv') \evalarrow \Normal(\vgthree, \newenv)\\
+  \newg \eqdef (\ordered{\vgone}{\asldata}{\vgtwo}) \parallelcomp \vgthree\\
+}{
+  \ldituplefolder(\env, \vids, \liv) \evalarrow \Normal(\newg, \newenv)
+}
+\end{mathpar}

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -32,7 +32,8 @@ The relation
 determines whether a value $\vv$ matches the pattern $\vp$ in an environment $\env$
 resulting in either $\Normal(\vb, \newg)$ or an abnormal configuration.
 
-We now define the syntax, abstract syntax, typing rules, and semantics rules for the following kinds of patterns:
+The rest of this chapter defines the syntax, abstract syntax, typing rules,
+and semantics rules for the following kinds of patterns:
 \begin{itemize}
 \item Matching All Values (\secref{MatchingAllValues})
 \item Matching a Single Value (\secref{MatchingASingleValue})

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -1082,13 +1082,13 @@ transforms a pattern expression parse node $\vparsednode$ into a pattern AST nod
 \end{mathpar}
 
 \begin{mathpar}
-  \inferrule[atc\_int\_constraints]{}{
-    {
-      \begin{array}{r}
-  \buildexprpattern(\Nexprpattern(\punnode{\Nexprpattern}, \Tas, \punnode{\Nconstraintkind})) \astarrow\\
-  \overname{\EATC(\astof{\vexprpattern}, \TInt(\astof{\vconstraintkind}))}{\vastnode}
-\end{array}
-}
+\inferrule[atc\_int\_constraints]{}{
+  {
+  \begin{array}{r}
+    \buildexprpattern(\Nexprpattern(\punnode{\Nexprpattern}, \Tas, \punnode{\Nconstraintkind})) \astarrow\\
+    \overname{\EATC(\astof{\vexprpattern}, \TInt(\astof{\vconstraintkind}))}{\vastnode}
+  \end{array}
+  }
 }
 \end{mathpar}
 
@@ -1134,16 +1134,16 @@ transforms a pattern expression parse node $\vparsednode$ into a pattern AST nod
 
 \begin{mathpar}
   \inferrule[record\_empty]{}{
-    {
-      \begin{array}{r}
+  {
+  \begin{array}{r}
   \buildexprpattern\left(\Nexprpattern\left(
     \begin{array}{l}
     \Tidentifier(\vt), \Tlbrace, \Trbrace \\
     \end{array}
     \right)\right) \\
     \astarrow\ \overname{\ERecord(\TNamed(\vt), \emptylist)}{\vastnode}
-\end{array}
-}
+  \end{array}
+  }
 }
 \end{mathpar}
 

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -284,7 +284,7 @@ subtyping.
   \makeanonymous(\tenv, \vt) \typearrow \vttwo\\
   \makeanonymous(\tenv, \vs) \typearrow \vstwo\\
   \astlabel(\vttwo) = \astlabel(\vstwo) = \TInt\\
-  \symsubsumes(\tenv, \vs, \vt) \typearrow \vb
+  \symdomainsubset(\tenv, \vs, \vt) \typearrow \vb
 }{
   \subtypesat(\tenv, \vt, \vs) \typearrow \vb
 }
@@ -3109,7 +3109,7 @@ precision lost, the type of \verb|(a * a) + 2| also denotes a precision lost.
 \FormallyParagraph
 \begin{mathpar}
   \inferrule[Loss]{
-    \vpone = \PrecisionLost \lor 
+    \vpone = \PrecisionLost \lor
     \vptwo = \PrecisionLost
   }{
     \vp = \PrecisionLost

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -90,7 +90,7 @@ determine the semantic relation they pertain to, while output semantic configura
 domains distinguish between conceptually different kinds of outputs, for example
 ones where an exception was raised, ones when a dynamic error occurred, etc.
 
-We now explain the components over which semantic configurations are defined:
+The rest of this section defines the components comprising semantic configurations:
 \begin{itemize}
     \item Native values.
     \item Static Environments, which consist of the information inferred

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -255,6 +255,105 @@ Define $\newvs$ as the concatenation of bitvectors listed in $\vvs$.
 }
 \end{mathpar}
 
+\SemanticsRuleDef{SlicesToPositions}
+\hypertarget{def-slicestopositions}{}
+The relation
+\[
+  \slicestopositions(\overname{\N}{\vn} \aslsep \overname{(\overname{\tint}{\vs_i}\times\overname{\tint}{\vl_i})^+}{\slices}) \;\aslrel\;
+  (\overname{\N^*}{\positions} \cup\ \TDynError)
+\]
+returns the list of positions (indices) specified by the slices $\slices$
+and the bitvector width $\vn$, if all slices are within the range $0$ to $\vn-1$.
+\ProseOtherwiseDynamicError
+
+\hypertarget{def-positioninrange}{}
+The helper predicate $\positioninrange(\vs, \vl, n)$ checks whether the indices starting at index $\vs$ and
+up to $\vs + \vl$, inclusive, would refer to actual indices of a bitvector of length $n$:
+\[
+  \positioninrange(\vs, \vl, \vn) \triangleq (\vs \geq 0) \land (\vl \geq 0) \land (\vs + \vl < \vn) \enspace.
+\]
+
+\ProseParagraph
+\AllApply
+\begin{itemize}
+  \item $slices$ is the list of pairs $(\vs_i, \vl_i)$, for $i=1..k$;
+  \item \OneApplies
+  \begin{itemize}
+    \item \AllApplyCase{InRange}
+    \begin{itemize}
+      \item the predicate $\positioninrange$ holds for $\vn$ and every $\vs_i$, $\vl_i$,
+            for every $i=1..k$;
+      \item \Proseeqdef{$\positions$}{the concatenation of lists starting from $\vs_i$ up to and
+            including $\vs_i+vl_i$, for every $i=1..k$}.
+    \end{itemize}
+
+    \item \AllApplyCase{OutOfRange}
+    \begin{itemize}
+      \item there exists $j\in 1..k$ such that
+            $\positioninrange$ does not hold for $\vn$ and $\vs_j$, $\vl_j$;
+      \item the result is a dynamic error ($\BadIndex$).
+    \end{itemize}
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[InRange]{
+  \slices \eqname [i=1..k: (\nvint(\vs_i), \nvint(\vl_i))]\\
+  i=1..k: \positioninrange(\vs_i, \vl_i, \vn)\\
+  \positions \eqdef [\vs_1,\ldots,\vs_1+\vl_1] \concat \ldots \concat [\vs_k,\ldots,\vs_k+\vl_k]\\
+}{
+  \slicestopositions(\vn, \slices) \evalarrow \positions
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[OutOfRange]{
+  \slices \eqname [i=1..k: (\nvint(\vs_i), \nvint(\vl_i))]\\
+  j \in 1..k: \neg\positioninrange(\vs_j, \vl_j, \vn)
+}{
+  \slicestopositions(\vn, \slices) \evalarrow \DynamicErrorVal{\BadIndex}
+}
+\end{mathpar}
+
+\SemanticsRuleDef{AsBitvector}
+\hypertarget{def-asbitvector}{}
+The function
+\[
+\asbitvector : (\overname{\tbitvector\cup\tint}{\vv}) \rightarrow \overname{\{0,1\}^*}{\vbits}
+\]
+transforms a \nativevalue{} $\vv$, which either represents an integer or a bitvectors into
+a sequence of binary values $\vbits$.
+
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{bits}
+  \begin{itemize}
+    \item $\vv$ is a native bitvector for the sequence of bits $\vbits$.
+  \end{itemize}
+
+  \item \AllApplyCase{int}
+  \begin{itemize}
+    \item $\vv$ is a native integer for the integer $n$;
+    \item \Proseeqdef{$\vbits$}{the two's complement representation of $n$}.
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[bits]{}
+{
+  \asbitvector(\overname{\nvbitvector(\bv)}{\vv}) \evalarrow \overname{\bv}{\vbits}
+}
+\and
+\inferrule[int]{
+  \vbits \eqdef \text{ two's complement representation of }n
+}{
+  \asbitvector(\overname{\nvint(n)}{\vv}) \evalarrow \bv
+}
+\end{mathpar}
+
 \SemanticsRuleDef{ReadFromBitvector}
 \hypertarget{def-readfrombitvector}{}
 The relation
@@ -265,91 +364,50 @@ The relation
 reads from a bitvector $\bv$, or an integer seen as a bitvector, the indices specified by the list of slices $\slices$,
 thereby concatenating their values.
 
-\ProseParagraph
-\OneApplies
-\begin{itemize}
-  \item all indices are in range for $\bv$ and the returned bitvector consists of the concatenated bits specified
-  by the slices.
-  \item there exists an out-of-range index and an error is returned.
-\end{itemize}
-
-\FormallyParagraph
-We start by introducing a few helper relations.
-
-\hypertarget{def-positioninrange}{}
-The predicate $\positioninrange(\vs, \vl, n)$ checks whether the indices starting at index $\vs$ and
-up to $\vs + \vl$, inclusive, would refer to actual indices of a bitvector of length $n$:
-\[
-  \positioninrange(\vs, \vl, \vn) \triangleq (\vs \geq 0) \land (\vl \geq 0) \land (\vs + \vl < \vn) \enspace.
-\]
-
-The relation
-\hypertarget{def-slicestopositions}{}
-\[
-  \slicestopositions(\overname{\N}{\vn} \aslsep \overname{(\overname{\tint}{\vs_i}\times\overname{\tint}{\vl_i})^+}{\slices}) \;\aslrel\;
-  (\overname{\N^*}{\positions} \cup\ \TDynError)
-\]
-returns the list of positions (indices) specified by the slices $\slices$,
-unless an index would be out of range for a bitvector of length $\vn$, in which case it returns an error configuration.
-
-\begin{mathpar}
-  \inferrule[SlicesToPositionsOutOfRange]{
-    \slices \eqname [i=1..k: (\nvint(\vs_i), \nvint(\vl_i))]\\
-    j \in 1..k: \neg\positioninrange(\vs_j, \vl_j, \vn)
-  }
-  {
-    \slicestopositions(\vn, \slices) \evalarrow \DynamicErrorVal{\BadIndex}
-  }
-  \and
-  \inferrule[SlicesToPositionsInRange]{
-    \slices \eqname [i=1..k: (\nvint(\vs_i), \nvint(\vl_i))]\\
-    i=1..k: \positioninrange(\vs_i, \vl_i, \vn)\\
-    \positions \eqdef [\vs_1,\ldots,\vs_1+\vl_1] \concat \ldots \concat [\vs_k,\ldots,\vs_k+\vl_k]\\
-  }
-  {
-    \slicestopositions(\vn, \slices) \evalarrow \positions
-  }
-\end{mathpar}
-
-\hypertarget{def-asbitvector}{}
-The function $\asbitvector : (\tbitvector\cup\tint) \rightarrow \{0,1\}^*$ transforms \nativevalue\  integers and \nativevalue\  bitvectors into
-a sequence of binary values:
-\begin{mathpar}
-  \inferrule[AsBitvectorBitvector]{}
-  {
-    \asbitvector(\nvbitvector(\bv)) \evalarrow \bv
-  }
-  \and
-  \inferrule[AsBitvectorInt]{
-    \bv \eqdef \text{ two's complement representation of }n
-  }
-  {
-    \asbitvector(\nvint(n)) \evalarrow \bv
-  }
-\end{mathpar}
-
-Finally, the rules below distinguish between empty bitvectors and non-empty bitvectors.
-\begin{mathpar}
-  \inferrule[ReadFromBitvector.Empty]{}
-  {
-    \readfrombitvector(\bv, \emptylist) \evalarrow \nvbitvector(\emptylist)
-  }
-  \and
-  \inferrule[ReadFromBitvector.NonEmpty]{
-    \asbitvector(\bv) \eqdef \vb_n \ldots \vb_1\\
-    \slicestopositions(n, \slices) \evalarrow [j_{1..m}] \OrDynError\\\\
-    \vv \eqdef \nvbitvector(\vb_{j_m + 1}\ldots\vb_{j_1 + 1})
-  }
-  {
-    \readfrombitvector(\bv, \slices) \evalarrow \vv
-  }
-\end{mathpar}
 Notice that the bits of a bitvector go from the least significant bit being on the right to the most significant bit being on the left,
 which is reflected by how the rules list the bits.
 The effect of placing the bits in sequence is that of concatenating the results
 from all of the given slices.
 Also notice that bitvector bits are numbered from 1 and onwards, which is why we add 1 to the indices specified
 by the slices when accessing a bit.
+
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{empty}
+  \begin{itemize}
+    \item $\slices$ is the empty list;
+    \item \Proseeqdef{$\vv$}{the native bitvector for the empty list of bits}.
+  \end{itemize}
+
+  \item \AllApplyCase{non\_empty}
+  \begin{itemize}
+    \item $\slices$ is not the empty list;
+    \item applying $\asbitvector$ to $\bv$ yields the list of bits $\vb_n \ldots \vb_1$;
+    \item applying $\slicestopositions$ to $n$ and $\slices$ yields the list of positions $j_{1..m}$
+    \item \Proseeqdef{$\vv$}{the native bitvector for the list of bits from $\vb_n \ldots \vb_1$
+          indicated by the positions $j_{1..m}$, that is, $\vb_{j_m + 1}\ldots\vb_{j_1 + 1}$}.
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[empty]{}
+{
+  \readfrombitvector(\bv, \overname{\emptylist}{\slices}) \evalarrow \overname{\nvbitvector(\emptylist)}{\vv}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_empty]{
+  \slices \neq \emptylist;
+  \asbitvector(\bv) \eqdef \vb_n \ldots \vb_1\\
+  \slicestopositions(n, \slices) \evalarrow [j_{1..m}] \OrDynError\\\\
+  \vv \eqdef \nvbitvector(\vb_{j_m + 1}\ldots\vb_{j_1 + 1})
+}{
+  \readfrombitvector(\bv, \slices) \evalarrow \vv
+}
+\end{mathpar}
 
 \SemanticsRuleDef{WriteToBitvector}
 \hypertarget{def-writetobitvector}{}
@@ -360,34 +418,75 @@ The relation
 \]
 overwrites the bits of $\dst$ at the positions given by $\slices$ with the bits of $\src$.
 
+See \ExampleRef{Writing to a Bitvector}, following the definition of $\writetobitvector$.
+
+\newcommand\bitfunc[0]{\textfunc{bit}}
+
 \ProseParagraph
-\OneApplies
+\AllApply
 \begin{itemize}
-  \item all positions specified by $\slices$ are within range for $\dst$ and the modified version
-  of $\dst$ with the bits of $\src$ at the specified positions is returned;
-  \item there exists a position in $\slices$ that is not in range for $\dst$ and an error is returned.
+  \item applying $\asbitvector$ to $\src$ yields the list of bits $\vs_m \ldots \vs_0$;
+  \item applying $\asbitvector$ to $\dst$ yields the list of bits $\vd_n \ldots \vd_0$;
+  \item applying $\slicestopositions$ to $n$ and $\slices$ yields the list of indices $\positions$;
+  \item view $\positions$ as the list $I_m \ldots I_0$;
+  \item define the function $\bitfunc$ as mapping an index $i$ in $0$ to $n$ to
+        $\vs_j$, if there exists an index $I_j$ in $\positions$ such that $I_j$ is equal to $i$,
+        and $\vd_i$, otherwise.
+  \item \Proseeqdef{$\vbits$}{the list of bits defined as
+        $\bitfunc(n)\ldots\bitfunc(0)$};
+  \item \Proseeqdef{$\vv$}{the native bitvector for $\vbits$}.
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
-  \inferrule[empty]{}
+\inferrule{
+  \vs_m \ldots \vs_0 \eqdef \asbitvector(\src)\\
+  \vd_n \ldots \vd_0 \eqdef \asbitvector(\dst)\\
+  \slicestopositions(n, \slices) \evalarrow \positions \OrDynError\\\\
+  \positions \eqname I_m \ldots I_0 \\
+  {\bitfunc = \lambda i \in 0..n.\left\{ \begin{array}{ll}
+    \vs_j & \exists j\in 1..m.\ i = I_j\\
+    \vd_i & \text{otherwise}
+  \end{array} \right.}\\\\
+  \vbits\eqdef [i=n..0: \bitfunc(i)]\\
+}{
+  \writetobitvector(\slices, \src, \dst) \evalarrow \overname{\nvbitvector(\vbits)}{\vv}
+}
+\end{mathpar}
+
+\ExampleDef{Writing to a Bitvector}
+In reference to \listingref{semantics-leslice}, we have the following application of the current rule:
+\begin{mathpar} % SUPPRESS_TEXTTT_LINTER
+\inferrule{
+  \asbitvector(\nvbitvector(000000)) = \overname{0}{\vs_5}\overname{0}{\vs_4}\overname{0}{\vs_3}\overname{0}{\vs_2}\overname{0}{\vs_1}\overname{0}{\vs_0}\\
+  \asbitvector(\nvbitvector(11111111)) = \overname{1}{\vd_7}\overname{1}{\vd_6}\overname{1}{\vd_5}\overname{1}{\vd_4}\overname{1}{\vd_3}\overname{1}{\vd_2}\overname{1}{\vd_1}\overname{1}{\vd_0}\\
+  \slicestopositions(8, [\overname{(0, 4)}{\texttt{3:0}}, \overname{(6, 2)}{\texttt{7:6}}]) \evalarrow
+  [3, 2, 1, 0, 7, 6]\\
+  \positions \eqdef [\overname{3}{I_5}, \overname{2}{I_4}, \overname{1}{I_3}, \overname{0}{I_2}, \overname{7}{I_1}, \overname{6}{I_0}]\\
+  {\bitfunc = \lambda i \in 0..7.\left\{ \begin{array}{ll}
+    \vs_j & \exists j\in 1..5.\ i = I_j\\
+    \vd_i & \text{otherwise}
+  \end{array} \right.}\\
+  \vbits \eqdef \bitfunc(7)\ \bitfunc(6)\ \bitfunc(5)\ \bitfunc(4)\ \bitfunc(3)\ \bitfunc(2)\ \bitfunc(1)\ \bitfunc(0)
+}{
   {
-    \writetobitvector(\emptylist, \nvbitvector(\emptylist), \nvbitvector(\emptylist)) \evalarrow \nvbitvector(\emptylist)
+  \begin{array}{r}
+    \writetobitvector(
+      [\overname{(0, 4)}{\texttt{3:0}}, \overname{(6, 2)}{\texttt{7:6}}],
+      \nvbitvector(000000),
+      \nvbitvector(11111111)) \evalarrow\\
+    \nvbitvector(
+      \overname{0}{\vs_1}
+      \overname{0}{\vs_0}
+      \overname{1}{\vd_5}
+      \overname{1}{\vd_4}
+      \overname{0}{\vs_5}
+      \overname{0}{\vs_4}
+      \overname{0}{\vs_3}
+      \overname{0}{\vs_2})
+  \end{array}
   }
-  \and
-  \inferrule[non\_empty]{
-    \vs_n \ldots \vs_1 \eqdef \asbitvector(\src)\\
-    \vd_n \ldots \vd_1 \eqdef \asbitvector(\dst)\\
-    \slicestopositions(n, \slices) \evalarrow \positions \OrDynError\\\\
-    {\mathit{bit} = \lambda i \in 1..n.\left\{ \begin{array}{ll}
-     \vs_i & i \in \positions\\
-     \vd_i & \text{otherwise}
-    \end{array} \right.}\\
-    \vv\eqdef\nvbitvector(\mathit{bit}(n-1)\ldots \mathit{bit}(0))\\
-  }
-  {
-    \writetobitvector(\slices, \src, \dst) \evalarrow \vv
-  }
+}
 \end{mathpar}
 
 \SemanticsRuleDef{GetIndex}

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -2,10 +2,8 @@
 \chapter{Semantics Utility Rules\label{chap:SemanticsUtilityRules}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-In this chapter, we define helper relations for operating on \nativevalues,
-\hyperlink{def-envs}{environments}, and operations involving values and types.
-
-We now define the following relations:
+This chapter defines the following helper relations for operating on \nativevalues,
+\hyperlink{def-envs}{environments}, and operations involving values and types:
 \begin{itemize}
   \item \SemanticsRuleRef{GetStackSize}
   \item \SemanticsRuleRef{SetStackSize}

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -457,11 +457,13 @@ recursive functions it may transitively call.
 \end{mathpar}
 
 \section{Overriding Subprograms\label{sec:Overriding}}
-We now define how to override subprograms in a specification.
-In particular, a subprogram marked by \texttt{impdef} can be overridden by a subprogram marked by \texttt{implementation}.
+This section defines how to override subprograms in a specification.
+In particular, a subprogram marked by \texttt{impdef} can be overridden by a subprogram marked by \\
+\texttt{implementation}.
 
 \RequirementDef{OverridingMatch}
-An overriding \Proseimplementationsubprogram{} subprogram must match the overridden \Proseimpdefsubprogram{} subprogram in all of the following:
+An overriding \Proseimplementationsubprogram{} subprogram \\
+must match the overridden \Proseimpdefsubprogram{} subprogram in all of the following:
 \begin{itemize}
   \item name of subprogram;
   \item number, names, types, and order of arguments;
@@ -479,12 +481,15 @@ The definition of \verb|Foo| is overridden by a corresponding \Proseimplementati
 Subprograms marked with \texttt{implementation} are subject to the following restrictions.
 
 \RequirementDef{NonClashingImplementations}
-No two \Proseimplementationsubprograms{} can match each other according to \RequirementRef{OverridingMatch}.
-In \ExampleRef{Invalid Overriding}, the \verb|Foo| subprograms marked \texttt{implementation} match and are therefore invalid.
+No two \Proseimplementationsubprograms{} can \\
+match each other according to \RequirementRef{OverridingMatch}.
+In \ExampleRef{Invalid Overriding}, the \verb|Foo| subprograms marked \texttt{implementation}
+match and are therefore invalid.
 
 \RequirementDef{SingleOverrideCandidate}
-Each \Proseimplementationsubprogram{} subprogram must override exactly one \Proseimpdefsubprogram{} subprogram. \\
-In \ExampleRef{Invalid Overriding}, the \Proseimplementationsubprogram{} \verb|Bar| is invalid as it has no corresponding \Proseimpdefsubprogram{}.
+Each \Proseimplementationsubprogram{} must override exactly one \Proseimpdefsubprogram.
+In \ExampleRef{Invalid Overriding}, the \Proseimplementationsubprogram{} \verb|Bar| is
+invalid as it has no corresponding \Proseimpdefsubprogram{}.
 
 \ExampleDef{Invalid Overriding}
 \listingref{overriding-bad} shows a specification which attempts to define clashing \Proseimplementationsubprograms{} named \verb|Foo|, and define a \Proseimplementationsubprogram{} \verb|Bar| without a corresponding \Proseimpdefsubprogram{}.
@@ -676,8 +681,8 @@ See \ExampleRef{Overriding Subprograms} for an example of valid replacement of a
 }
 \end{mathpar}
 
-\section{Establishing Def-Use Dependencies Between Global Declarations\label{sec:TopologicalOrdering}}
-We now define how to construct a graph of \defusedependenciesterm\ between the identifiers associated
+\section{Establishing Def-Use Dependencies \\ Between Global Declarations\label{sec:TopologicalOrdering}}
+This section defines how to construct a graph of \defusedependenciesterm\ between the identifiers associated
 with global declarations.
 This is achieved by associating, for each declaration $d$, the set identifiers \emph{used} by $d$,
 which is formally defined by $\usedecl$, and the identifier \emph{defined} by $d$,
@@ -688,10 +693,10 @@ $\decldependencies(\vd)$ (see \TypingRuleRef{DeclDependencies}).
 
 \RequirementDef{GlobalNamespace}
 The global namespace effectively consists of two independent namespaces: one for subprogram names, and the other for all other identifiers.
-In \ExampleRef{Global Namespace}, the \verb|X| subprogram does not interfere with the variable declaration also named \verb|X|.
 
 \ExampleDef{Global Namespace}
-\listingref{globalnamespace} shows a specification which defines a subprogram \verb|X| and a variable \verb|X|.
+\listingref{globalnamespace} shows a specification which defines a subprogram \verb|X|
+that does not interfere with the variable declaration also named \verb|X|.
 \ASLListing{Global namespace}{globalnamespace}{\definitiontests/GlobalNamespace.asl}
 
 We distinguish between subprogram identifiers, and all other identifiers (storage elements and \namedtypes{}).

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -1801,6 +1801,12 @@ returns the set of identifiers $\ids$ which the statement $\vs$ depends on.
     \item define $\ids$ as the union of applying $\usety$ to $\vt$ and $\useexpr$ to $\ve$.
   \end{itemize}
 
+  \item \AllApplyCase{s\_throw\_some}
+  \begin{itemize}
+    \item $\vs$ is a \throwstatementsterm{} with an \optional{} expression $\ve$;
+    \item \Proseeqdef{$\ids$}{the result of applying $\useexpr$ to $\ve$}.
+  \end{itemize}
+
   \item \AllApplyCase{s\_try}
   \begin{itemize}
     \item $\vs$ is a try statement with statement $\vsone$, catcher list $\catchers$, and otherwise statement $\vstwo$;

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -452,12 +452,12 @@ As given by applying the relevant rules to the desugared AST.
   \buildoption[\buildexpr](\ve) \astarrow \astversion{\ve}
 }{
   {
-    \begin{array}{r}
-  \buildstmt(\overname{\Nstmt(\Tvar, \Ndeclitem, \namednode{\vt}{\option{\Nasty}}, \namednode{\ve}{\option{\Teq, \Nexpr}}, \Tsemicolon)}{\vparsednode})
-  \astarrow \\
-  \overname{\SDecl(\LDKVar, \astof{\vdeclitem}, \astversion{\vt}, \astversion{\ve})}{\vastnode}
-\end{array}
-}
+  \begin{array}{r}
+    \buildstmt(\overname{\Nstmt(\Tvar, \Ndeclitem, \namednode{\vt}{\option{\Nasty}}, \namednode{\ve}{\option{\Teq, \Nexpr}}, \Tsemicolon)}{\vparsednode})
+    \astarrow \\
+    \overname{\SDecl(\LDKVar, \astof{\vdeclitem}, \astversion{\vt}, \astversion{\ve})}{\vastnode}
+  \end{array}
+  }
 }
 \end{mathpar}
 
@@ -3270,7 +3270,6 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \ExampleDef{Typing Try Statements}
 \TypingRuleDef{STry}
 In
-\listingref{semantics-catchnamed},
 \listingref{semantics-catchnamed},
 \listingref{semantics-catchotherwise},
 \listingref{semantics-catchnone},

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -43,7 +43,8 @@ evaluates a statement $\vs$ in an environment $\env$, resulting in one of four t
   \item error configurations.
 \end{itemize}
 
-We now define the syntax, abstract syntax, typing, and semantics for the following kinds of statements:
+The rest of this chapter defines the syntax, abstract syntax, typing,
+and semantics for the following kinds of statements:
 \begin{itemize}
 \item Pass statements (see \secref{PassStatements})
 \item Assignment statements (see \secref{AssignmentStatements})
@@ -227,7 +228,7 @@ $\nvint(2)$ to the mutable variable~\texttt{b}, and discards $\nvint(3)$.
 
 \FormallyParagraph
 \hypertarget{def-lexprisvar}{}
-We first define the syntactic predicate
+The rule uses the syntactic predicate defined as follows:
 \[
   \lexprisvar(\lexpr) \aslto \True
 \]
@@ -237,7 +238,8 @@ represents a variable or a discarded left-hand-side expression:
 \inferrule{}{ \lexprisvar(\vle) \evalarrow \astlabel(\vle) \in \{\LEVar, \LEDiscard\}}
 \end{mathpar}
 
-We now define the evaluation of assigning from a subprogram call:
+The inference rules defining the evaluation of assigning
+from a subprogram call are as follows:
 \begin{mathpar}
 \inferrule{
   \vles \eqdef \vle_{1..k}\\
@@ -793,7 +795,7 @@ in the \CaseName{int} below.
 \hypertarget{def-checknoprecisionloss}{}
 The helper function
 \[
-  \checknoprecisionloss(\overname{\ty}{\vt})
+  \checknoprecisionloss{\overname{\ty}{\vt}}
   \typearrow \{\True\} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
 checks whether the type $\vt$ is the result of a precision loss in its

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1532,7 +1532,7 @@ Otherwise, the result is a dynamic error indicating that the recursion limit has
     \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrError;
     \item view $\env$ as $(\tenv, \denv)$;
     \item applying $\getstacksize$ to $\name$ in $\denv$ yields $\vstacksize$;
-    \item $\vlimit$ is less than $\vstacksize$.
+    \item $\vstacksize$ is less than $\vlimit$.
   \end{itemize}
 
   \item \AllApplyCase{some\_error}
@@ -1540,7 +1540,7 @@ Otherwise, the result is a dynamic error indicating that the recursion limit has
     \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrError;
     \item view $\env$ as $(\tenv, \denv)$;
     \item applying $\getstacksize$ to $\name$ in $\denv$ yields $\vstacksize$;
-    \item $\vlimit$ is greater or equal to $\vstacksize$;
+    \item $\vstacksize$ is greater or equal to $\vlimit$;
     \item the result is a dynamic
   \end{itemize}
 \end{itemize}
@@ -1559,7 +1559,7 @@ Otherwise, the result is a dynamic error indicating that the recursion limit has
   \evallimit(\env, \velimitopt) \evalarrow (\langle\vlimit\rangle, \vg) \OrDynError\\\\
   \env \eqname (\tenv, \denv)\\
   \getstacksize(\denv, \name) \evalarrow \vstacksize\\
-  \vlimit < \vstacksize
+  \vstacksize < \vlimit
 }{
   \checkrecurselimit(\env, \name, \velimitopt) \evalarrow \vg
 }
@@ -1570,7 +1570,7 @@ Otherwise, the result is a dynamic error indicating that the recursion limit has
   \evallimit(\env, \velimitopt) \evalarrow (\langle\vlimit\rangle, \vg) \OrDynError\\\\
   \env \eqname (\tenv, \denv)\\
   \getstacksize(\denv, \name) \evalarrow \vstacksize\\
-  \vlimit \geq \vstacksize
+  \vstacksize \geq \vlimit
 }{
   \checkrecurselimit(\env, \name, \velimitopt) \evalarrow \DynamicErrorVal{\LimitExceeded}
 }

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1028,17 +1028,17 @@ The function
     \overname{\staticenvs}{\tenv} \aslsep
     \overname{\Strings}{\name} \aslsep
     \overname{\ty^*}{\callerargtypes}
-  )
-  \aslto &
-  \begin{array}{l}
-    (
-    \overname{\Strings}{\namep} \aslsep
-    \overname{\func}{\callee} \aslsep
-    \overname{\TSideEffectSet}{\vses}
-    )\
-  \cup\\
-   \overname{\TTypeError}{\TypeErrorConfig}
-  \end{array}
+    )
+    \aslto &
+    \begin{array}{l}
+      (
+      \overname{\Strings}{\namep} \aslsep
+      \overname{\func}{\callee} \aslsep
+      \overname{\TSideEffectSet}{\vses}
+      )\
+    \cup\\
+    \overname{\TTypeError}{\TypeErrorConfig}
+    \end{array}
   \end{array}
 \]
 looks up the static environment $\tenv$ for a subprogram associated with $\name$

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -1,8 +1,8 @@
-\chapter{Symbolic Subsumption Testing\label{chap:SymbolicSubsumptionTesting}}
+\chapter{Symbolic Domain Subset Testing\label{chap:SymbolicDomainSubsetTesting}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-This chapter is concerned with implementing a \hyperlink{def-soundsubsumptiontest}{sound subsumption test}
-for integer types, as defined in \secref{subsumptiontesting} and employed by
-TypingRule.SubtypeSatisfaction (see \TypingRuleRef{SubtypeSatisfaction}).
+This chapter is concerned with implementing a \hyperlink{def-sounddomainsubsettest}{sound domain subset test}
+for integer types, as defined in \secref{domainsubsettesting} and employed by
+\TypingRuleRef{SubtypeSatisfaction}.
 
 \hypertarget{def-symbolicdomain}{}
 The symbolic reasoning operates by first transforming types into expressions in a \emph{symbolic domain} AST
@@ -27,8 +27,8 @@ The symbolic reasoning operates by first transforming types into expressions in 
         which represents the set of all integers.
 \end{itemize}
 
-The main rule is of this chapter is \TypingRuleRef{SymSubsumes}, which defines the function
-$\symsubsumes$.
+The main rule is of this chapter is \TypingRuleRef{SymSubset}, which defines the function
+$\symdomainsubset$.
 
 Other helper rules are as follows:
 \begin{itemize}
@@ -45,14 +45,14 @@ Other helper rules are as follows:
   \item \TypingRuleRef{ConstraintBinop}
 \end{itemize}
 
-\TypingRuleDef{SymSubsumes}
-\hypertarget{def-symsubsumes}{}
+\TypingRuleDef{SymSubset}
+\hypertarget{def-symdomainsubset}{}
 The predicate
 \[
-  \symsubsumes(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
+  \symdomainsubset(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
   \aslto \overname{\Bool}{\vb}
 \]
-soundly approximates $\subsumes(\tenv, \vt, \vs)$ for integer types.
+soundly approximates $\domainsubset(\tenv, \vt, \vs)$ for integer types.
 \ProseOtherwiseTypeError
 
 We assume that both $\vt$ and $\vs$ have been successfully annotated to integer types as per \chapref{Types}
@@ -73,7 +73,7 @@ We assume that both $\vt$ and $\vs$ have been successfully annotated to integer 
   \symdomoftype(\tenv, \vs) \typearrow \ds\\
   \symdomissubset(\tenv, \dt, \ds) \typearrow \vb
 }{
-  \symsubsumes(\tenv, \vt, \vs) \typearrow \vb
+  \symdomainsubset(\tenv, \vt, \vt) \typearrow \vb
 }
 \end{mathpar}
 
@@ -101,20 +101,11 @@ It assumes its input type has an \underlyingtype{} which is an integer.
           that is, \\ $\FromSyntax([\ConstraintExact(\EVar(\id))])$.
   \end{itemize}
 
-  \item \AllApplyCase{int\_well\_constrained\_finite}
+  \item \AllApplyCase{int\_well\_constrained}
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type for the list of constraints $\vcs$;
     \item applying $\intsetofintconstraints$ to $\vcs$ in $\tenv$ yields $\vis$;
-    \item $\vis$ is a set of integers, that is, $\astlabel(\vis)$ is $\Finite$;
-    \item define $\vd$ as the symbolic finite set integer domain for $\vis$.
-  \end{itemize}
-
-  \item \AllApplyCase{int\_well\_constrained\_symbolic}
-  \begin{itemize}
-    \item $\vt$ is the well-constrained integer type for the list of constraints $\vcs$;
-    \item applying $\intsetofintconstraints$ to $\vcs$ in $\tenv$ yields $\vis$;
-    \item $\vis$ is not a set of integers, that is, $\astlabel(\vis)$ is not $\Finite$;
-    \item define $\vd$ as the symbolic constrained integer domain for the list of constraints $\vcs$, that is, $\FromSyntax(\vcs)$.
+    \item \Proseeqdef{$\vd$}{$\vis$}.
   \end{itemize}
 
   \item \AllApplyCase{t\_named}
@@ -138,20 +129,10 @@ It assumes its input type has an \underlyingtype{} which is an integer.
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[int\_well\_constrained\_finite]{
-  \intsetofintconstraints(\tenv, \vcs) \typearrow \vis\\
-  \astlabel(\vis) = \Finite
+\inferrule[int\_well\_constrained]{
+  \intsetofintconstraints(\tenv, \vcs) \typearrow \vis
 }{
   \symdomoftype(\tenv, \overname{\TInt(\wellconstrained(\vcs))}{\vt}) \typearrow \overname{\vis}{\vd}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[int\_well\_constrained\_symbolic]{
-  \intsetofintconstraints(\tenv, \vcs) \typearrow \vis\\
-  \astlabel(\vis) \neq \Finite
-}{
-  \symdomoftype(\tenv, \overname{\TInt(\wellconstrained(\vcs))}{\vt}) \typearrow \overname{\FromSyntax(\vcs)}{\vd}
 }
 \end{mathpar}
 
@@ -760,7 +741,7 @@ The function
 conservatively tests whether the values represented by the \symbolicdomain\ $\visone$
 is a subset of the values represented by the \symbolicdomain\ $\vistwo$ in any environment
 consisting of the static environment $\tenv$
-(see \secref{subsumptiontesting} for a precise definition).
+(see \secref{domainsubsettesting} for a precise definition).
 
 The test first \emph{overapproximates} $\visone$ by a set of integers $\vsone$.
 That is, $\vsone$ represents a superset of the set of numbers represented by $\visone$.
@@ -1226,7 +1207,7 @@ based on the \approximationdirectionterm\ $\vapprox$.
 \end{mathpar}
 
 In the following inference rule, the application of $\typeof$ is guaranteed not
-to result in a type error, since $\symsubsumes$ is only applied to annotated
+to result in a type error, since $\symdomainsubset$ is only applied to annotated
 types.
 \begin{mathpar}
 \inferrule[var\_over]{

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -444,77 +444,81 @@ is the infinite set of all native integer values.
 \identi{WPWL} \identi{CDVY} \identi{KFCR} \identi{BBQR} \identr{ZWGH}
 \identr{DKGQ} \identr{DHZT} \identi{HSWR} \identd{YZBQ}
 
-\subsection{Subsumption Testing\label{sec:subsumptiontesting}}
+\subsection{Domain Subset Testing\label{sec:domainsubsettesting}}
 Whether an assignment statement is well-typed depends on whether the dynamic domain of the
 right hand side type is contained in the dynamic domain of the left hand side type,
 for any given dynamic environment
 (see \TypingRuleRef{SubtypeSatisfaction} where this is checked).
 
-\begin{definition}[Subsumption]
+\begin{definition}[Domain Subset]
 For any given types $\vt$ and $\vs$ and static environment $\tenv$,
-we say that $\vt$ \emph{subsumes} $\vs$ in $\tenv$,
+we say that $\vt$ is a \emph{domain subset} of $\vs$ in $\tenv$,
 if the following condition holds:
-\hypertarget{def-subsumes}{}
+\hypertarget{def-domainsubset}{}
 \begin{equation}
-  \subsumes(\tenv, \vt, \vs) \triangleq \forall \denv\in\dynamicenvs.\ \dynamicdomain((\tenv, \denv), \vt) \supseteq \dynamicdomain((\tenv, \denv), \vs) \enspace.
+\begin{array}{l}
+\domainsubset(\tenv, \vt, \vs) \triangleq \\
+\qquad \forall \denv\in\dynamicenvs.\
+\dynamicdomain((\tenv, \denv), \vt) \subseteq \dynamicdomain((\tenv, \denv), \vs) \enspace.
+\end{array}
 \end{equation}
 \end{definition}
 
 For example, consider the assignment
 \begin{center}
-\verb|var x : integer{1,2,3} = ARBITRARY : integer{1,2};|
+\texttt{var x : $\overname{\texttt{integer\{1,2,3\}}}{\vs}$ = ARBITRARY : $\overname{\texttt{integer\{1,2\}}}{\vt}$;}
 \end{center}
 
-It is legal, since (in any static environment), the domain of \verb|integer{1,2,3}|
+It is well-typed, since (in any static environment), the domain of \verb|integer{1,2,3}|
 is \\
 $\{\nvint(1), \nvint(2), \nvint(3)\}$, which subsumes
 the domain of \verb|integer{1,2}|, which is \\ $\{\nvint(1), \nvint(2)\}$.
 
 Since dynamic domains are potentially infinite, this requires \emph{symbolic reasoning}.
 Furthermore, since any (\symbolicallyevaluable{}) expressions may appear inside integer and bitvector
-types, testing subsumption is undecidable.
-We therefore approximate subsumption testing \emph{conservatively} via the predicate $\symsubsumes(\tenv, \vt, \vs)$.
+types, domain subset testing is undecidable.
+We therefore approximate domain subset testing \emph{conservatively} via the predicate $\symdomainsubset(\tenv, \vt, \vs)$.
 
-\hypertarget{def-soundsubsumptiontest}{}
-\begin{definition}[Sound Subsumption Test]
+\hypertarget{def-sounddomainsubsettest}{}
+\begin{definition}[Sound Domain Subset Test]
 A predicate
 \[
-  \symsubsumes(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs}) \aslto \Bool
+  \symdomainsubset(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs}) \aslto \Bool
 \]
 is \emph{sound} if the following condition holds:
 \begin{equation}
   \begin{array}{l}
   \forall \vt,\vs\in\ty.\ \tenv\in\staticenvs. \\
-  \;\;\;\; \symsubsumes(\tenv, \vt, \vs) \typearrow \True \;\Longrightarrow\; \subsumes(\tenv, \vt, \vs)  \enspace.
+  \;\;\;\; \symdomainsubset(\tenv, \vt, \vs) \typearrow \True \;\Longrightarrow\; \domainsubset(\tenv, \vt, \vs)  \enspace.
   \end{array}
 \end{equation}
 \end{definition}
 
-That is, if a sound subsumption test returns a positive answer, it means that
-$\vt$ definitely \emph{subsumes} $\vs$ in the static environment $\tenv$.
+That is, if a sound domain subset test returns a positive answer, it means that
+$\vt$ is definitely a domain subset of $\vs$ in the static environment $\tenv$.
 This is referred to as a \emph{true positive}.
 However, a negative answer means one of two things:
 \begin{description}
-  \item[True Negative:] indeed, $\vt$ does not subsume $\vs$ in the static environment $\tenv$; or
+  \item[True Negative:] indeed, $\vt$ is not a domain subset of $\vs$ in the static environment $\tenv$; or
   \item[False Negative:] the symbolic reasoning is unable to decide.
 \end{description}
 
-In other words, $\symsubsumes(\tenv, \vt, \vs)$ errs on the \emph{safe side} ---
+In other words, $\symdomainsubset(\tenv, \vt, \vs)$ errs on the \emph{safe side} ---
 it never answers $\True$ when the real answer is $\False$, which would (undesirably)
 determine the following statement as well-typed:
 \begin{center}
-  \verb|var x : integer{1,2} = ARBITRARY: integer;|
+\texttt{var x : $\overname{\texttt{integer\{1,2\}}}{\vs}$ = ARBITRARY : $\overname{\texttt{integer}}{\vt}$;}
 \end{center}
 
-A sound but trivial subsumption test is one that always returns $\False$.
+A sound but trivial domain subset test is one that always returns $\False$.
 However, that would make all assignments be considered as not well-typed.
 Indeed, it has the maximal set of false negatives.
 Reducing the set of false negatives requires stronger symbolic reasoning algorithms,
 which inevitably leads to higher computational complexity.
 %
-The symbolic subsumption test in \chapref{SymbolicSubsumptionTesting}
+The symbolic domain subset test in \chapref{SymbolicDomainSubsetTesting}
 attempts to accept a large enough set of true positives, based on empirical trial and error,
 while maintaining the computational complexity of the symbolic reasoning relatively low.
 %
-In particular, it serves as the definitive subsumption test that must be utilized
+In particular, it serves as the definitive domain subset test that must be utilized
 by any implementation of the ASL type system.

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -10,7 +10,7 @@ for one type is included in the set of values for another type.
 \subsection{Dynamic Domain of a Type\label{sec:DynDomain}}
 \hypertarget{def-dyndomain}{}
 
-We now define the concept of a \emph{dynamic domain} of a type
+We define the concept of a \emph{dynamic domain} of a type
 and the \emph{static domain} of a type.
 Intuitively, domains assign potentially infinite sets of \nativevalues\ to types.
 Dynamic domains are used by the semantics to evaluate expressions of the form \texttt{ARBITRARY: t}

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -1,7 +1,7 @@
 \chapter{Type System Utility Rules\label{chap:TypeSystemUtilityRules}}
 
-\hypertarget{def-checktrans}{}
 \subsection{Checked Transitions}
+\hypertarget{def-checktrans}{}
 We define the following rules to allow us asserting that a condition holds,
 returning a type error otherwise:
 \begin{mathpar}
@@ -12,8 +12,8 @@ returning a type error otherwise:
 \inferrule[check\_trans\_false]{}{ \checktrans{\False}{\vcode} \checktransarrow \TypeErrorVal{\vcode} }
 \end{mathpar}
 
-\hypertarget{def-pairstomap}{}
 \subsection{Converting a List of Pairs to a Map \label{sec:PairsToMap}}
+\hypertarget{def-pairstomap}{}
 The parametric function
 \[
   \pairstomap(\overname{(\identifier\times T)^*}{\pairs}) \aslto \overname{(\identifier\partialto T)}{f} \cup \TTypeError
@@ -71,8 +71,8 @@ If a duplicate identifier exists in $\pairs$ then a type error is returned.
 }
 \end{mathpar}
 
-\hypertarget{def-checknoduplicates}{}
 \TypingRuleDef{CheckNoDuplicates}
+\hypertarget{def-checknoduplicates}{}
 The function
 \[
   \checknoduplicates(\overname{\identifier^*}{\id_{1..k}}) \aslto \{\True\} \cup \TTypeError
@@ -274,8 +274,8 @@ if there is one. Otherwise, the result is $\None$.
 }
 \end{mathpar}
 
-\hypertarget{def-typeofarraylength}{}
 \TypingRuleDef{TypeOfArrayLength}
+\hypertarget{def-typeofarraylength}{}
 The function
 \[
   \typeofarraylength(\overname{\arrayindex}{\size}) \aslto
@@ -374,8 +374,8 @@ is the local static environment of $\emptytenv$.
 \end{mathpar}
 \CodeSubsection{\WithEmptyLocalBegin}{\WithEmptyLocalEnd}{../types.ml}
 
-\hypertarget{def-checkvarnotinenv}{}
 \TypingRuleDef{CheckVarNotInEnv}
+\hypertarget{def-checkvarnotinenv}{}
 The function
 \[
   \checkvarnotinenv{\overname{\staticenvs}{\tenv} \aslsep \overname{\Strings}{\id}}
@@ -429,8 +429,8 @@ If it is, the result is a type error, and otherwise the result is $\True$.
 \end{mathpar}
 \CodeSubsection{\CheckVarNotInGEnvBegin}{\CheckVarNotInGEnvEnd}{../Interpreter.ml}
 
-\hypertarget{def-addlocal}{}
 \TypingRuleDef{AddLocal}
+\hypertarget{def-addlocal}{}
 The function
 \[
   \addlocal(

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -16,8 +16,8 @@ how it is represented in the syntax and AST, and how it is typechecked:
   \item \Enumerationtypesterm{} (see \secref{EnumerationTypes})
   \item Array types (see \secref{ArrayTypes})
   \item Record types (see \secref{RecordTypes})
-  \item Collection types (see \secref{CollectionTypes})
   \item Exception types (see \secref{ExceptionTypes})
+  \item Collection types (see \secref{CollectionTypes})
   \item Named types (see \secref{NamedTypes})
 \end{itemize}
 
@@ -1346,38 +1346,10 @@ In \listingref{typing-trecord}, all the uses of record types are well-typed.
   \fieldsp \eqdef [i=1..k: (\vx_i, \vtp_i)]\\
   \vses \eqdef \bigcup_{i=1..k} \vxs_i
 }{
-  \annotatetype{\True, \tenv, L(\fields)} \typearrow (\overname{L(\fieldsp)}{\newty}, \vses)
+  \annotatetype{\True, \tenv, \overname{L(\fields)}{\tty}} \typearrow (\overname{L(\fieldsp)}{\newty}, \vses)
 }
 \end{mathpar}
 \CodeSubsection{\TStructuredDeclBegin}{\TStructuredDeclEnd}{../Typing.ml}
-
-\section{Collection Types\label{sec:CollectionTypes}}%
-\hypertarget{collectiontypeterm}{}
-
-A collection is a \structuredtype{} consisting of a list of field identifiers
-which denote individual storage elements.
-
-\RequirementDef{CollectionsGlobal}
-Collections can only be used for global storage elements.
-See \listingref{checkisnotcollection} for an ill-typed specification.
-
-\subsection{Syntax}
-\begin{flalign*}
-  \Ntydecl \derives\ & \Tcollection \parsesep \Nfieldsopt &
-\end{flalign*}
-
-\subsection{Abstract Syntax}
-\begin{flalign*}
-  \ty \derives\ & \TCollection(\Field^{*}) &
-\end{flalign*}
-
-\ASTRuleDef{TyDecl.TCollection}
-\begin{mathpar}
-\inferrule{}{%
-  \buildtydecl(\Ntydecl(\Tcollection, \punnode{\Nfieldsopt})) \astarrow
-  \overname{\TCollection(\astof{\vfieldsopt})}{\vastnode}
-}
-\end{mathpar}
 
 \section{Exception Types\label{sec:ExceptionTypes}}
 \hypertarget{exceptiontypeterm}{}
@@ -1412,8 +1384,78 @@ In \listingref{typing-texception}, all the uses of exception types are well-type
 \subsection{Typing Exception Types}
 The rule for typing exception types is \TypingRuleRef{TStructuredDecl}.
 
-\hypertarget{namedtypeterm}{}
+\section{Collection Types\label{sec:CollectionTypes}}
+\hypertarget{collectiontypeterm}{}
+
+\ASLListing{Collection types}{TCollection}{\typingtests/TypingRule.TCollection.asl}
+
+A collection is a \structuredtype{} consisting of a list of field identifiers
+which denote individual storage elements.
+
+\RequirementDef{CollectionsGlobal}
+Collections can only be used for global storage elements.
+See \listingref{checkisnotcollection} for an ill-typed specification.
+
+\subsection{Syntax}
+\begin{flalign*}
+  \Ntydecl \derives\ & \Tcollection \parsesep \Nfieldsopt &
+\end{flalign*}
+
+\subsection{Abstract Syntax}
+\begin{flalign*}
+  \ty \derives\ & \TCollection(\Field^{*}) &
+\end{flalign*}
+
+\ASTRuleDef{TyDecl.TCollection}
+\begin{mathpar}
+\inferrule{}{
+  \buildtydecl(\Ntydecl(\Tcollection, \punnode{\Nfieldsopt})) \astarrow
+  \overname{\TCollection(\astof{\vfieldsopt})}{\vastnode}
+}
+\end{mathpar}
+
+\section{Typing Collection Types}
+\ExampleDef{Typing Collection Types}
+\listingref{TCollection} shows examples of well-typed collection types
+and ill-typed collection types in comments.
+In addition, \listingref{TCollection} shows well-typed storage declarations
+utilizing collection types and ill-typed storage declarations utilizing
+collection types in comments.
+
+\ProseParagraph
+\AllApply
+\begin{itemize}
+  \item $\tty$ is a \collectiontypeterm{} with the list of fields of $\fields$;
+  \item $\decl$ is $\True$, indicating that $\tty$ should be considered in the context of a declaration;
+  \item $\fields$ is a list of pairs where the first element is an identifier and the second is a type --- $(\vx_i, \vt_i)$, for $i=1..k$;
+  \item checking that the list of field identifiers $\vx_{1..k}$ does not contain duplicates
+  yields $\True$\ProseOrTypeError;
+  \item annotating each field type $\vt_i$, for $i=1..k$, yields $(\vtp_i, \vxs_i)$
+        \ProseOrTypeError;
+  \item $\fieldsp$ is the list with $(\vx_i, \vtp_i)$, for $i=1..k$;
+  \item checking that the \structure{} of the type $\vtp_i$ in the static environment $\tenv$
+        is a \bitvectortypeterm, for every $i$ in $1..k$, yields $\True$\ProseOrTypeError;
+  \item $\newty$ is the AST node with AST label $L$ (either record type or exception type,
+        corresponding to the type $\tty$) and fields $\fieldsp$;
+  \item define $\vses$ as the union of all $\vxs_i$, for $i=1..k$.
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule{
+  \fields \eqname [i=1..k: (\vx_i, \vt_i)]\\
+  \checknoduplicates(\vx_{1..k}) \typearrow \True \OrTypeError\\\\
+  i=1..k: \annotatetype{\False, \tenv, \vt_i} \typearrow (\vtp_i, \vxs_i) \OrTypeError\\\\
+  \fieldsp \eqdef [i=1..k: (\vx_i, \vtp_i)]\\
+  i=1..k: \checkstructurelabel(\tenv, \vtp_i, \TBits) \typearrow \True \OrTypeError\\\\
+  \vses \eqdef \bigcup_{i=1..k} \vxs_i
+}{
+  \annotatetype{\True, \tenv, \overname{\TCollection(\fields)}{\tty}} \typearrow (\overname{\TCollection(\fieldsp)}{\newty}, \vses)
+}
+\end{mathpar}
+
 \section{Named Types\label{sec:NamedTypes}}
+\hypertarget{namedtypeterm}{}
 \subsection{Syntax}
 \begin{flalign*}
 \Nty \derives\ & \Tidentifier &

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -463,6 +463,7 @@ create
 creates
 creating
 creation
+current
 currently
 custom
 customers

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -224,6 +224,7 @@ bitwidths
 bitwise
 block
 blocks
+bodies
 body
 boolean
 both
@@ -695,6 +696,7 @@ executes
 executing
 execution
 exemplified
+exemplifies
 exemplify
 exist
 existence
@@ -1793,6 +1795,7 @@ subtraction
 subtype
 subtypes
 succeed
+succeeding
 succeeds
 success
 successfully

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -359,6 +359,7 @@ composition
 compound
 comprised
 comprises
+comprising
 computation
 computational
 compute
@@ -712,6 +713,7 @@ expects
 explain
 explained
 explaining
+explains
 explanation
 explicit
 explicitly
@@ -749,6 +751,7 @@ favor
 feasible
 feasibly
 feature
+features
 feed
 few
 field

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -147,6 +147,27 @@ def check_tododefines(latex_files: list[str]):
         print(f"WARNING: There are {num_todo_define} occurrences of \\tododefine")
         return 0
 
+def check_repeated_lines(filename: str) -> int:
+    r"""
+    Checks whether `file` contains the same line appearing twice in a row.
+    The exception is inside `CONSOLE_BEGIN...CONSOLE_END` blocks.
+    Errors are reported for the file name 'filename' and the total
+    number of found errors is returned.
+    """
+    num_errors = 0
+    line_number = 0
+    last_line = ""
+    inside_console_outout = False
+    for line in read_file_lines(filename):
+        line_number += 1
+        if r"CONSOLE_BEGIN" in line:
+            inside_console_outout = True
+        if r"CONSOLE_END" in line:
+            inside_console_outout = False
+        if not inside_console_outout and line and line == last_line and line.strip() and line.strip() != "}":
+            print(f"./{filename} line {line_number}: repeated twice")
+        last_line = line
+    return num_errors
 
 def check_repeated_words(filename: str) -> int:
     r"""
@@ -460,7 +481,6 @@ def check_rules(filename: str) -> int:
     # Treat existing issues as warnings and new issues as errors.
     file_to_num_expected_errors = {
         "TypeDeclarations.tex" : 8,
-        "GlobalDeclarations.tex" : 6,
         "GlobalStorageDeclarations.tex" : 7,
         "RelationsOnTypes.tex" : 15,
         "Specifications.tex" : 25,
@@ -641,7 +661,7 @@ def main():
     print("Linting files...")
     all_latex_sources = get_latex_sources(False)
     content_latex_sources = get_latex_sources(True)
-    # content_latex_sources = ["SubprogramCalls.tex"]
+    # content_latex_sources = ["GlobalDeclarations.tex"]
     num_errors = 0
     num_spelling_errors = spellcheck(args.dictionary, content_latex_sources)
     if num_spelling_errors > 0:
@@ -658,6 +678,7 @@ def main():
         content_latex_sources,
         [
             check_repeated_words,
+            check_repeated_lines,
             detect_incorrect_latex_macros_spacing,
             check_teletype_in_rule_math_mode,
             check_rules,

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -464,12 +464,11 @@ def check_rules(filename: str) -> int:
         "RelationsOnTypes.tex" : 15,
         "Specifications.tex" : 26,
         "SubprogramCalls.tex" : 19,
-        "SubprogramCalls.tex" : 19,
         "SubprogramDeclarations.tex" : 13,
         "SymbolicEquivalenceTesting.tex" : 26,
         "SymbolicSubsumptionTesting.tex" : 23,
         "Types.tex" : 9,
-        "SideEffects.tex" : 16,
+        "SideEffects.tex" : 13,
         "TypeSystemUtilities.tex" : 23,
         "SemanticsUtilities.tex" : 20,
     }

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -243,12 +243,13 @@ def check_teletype_in_rule_math_mode(filename) -> int:
     teletype_pattern = re.compile(r"\\texttt{.*}")
     matches = math_mode_pattern.findall(file_str)
     for match in matches:
-        teletype_vars = teletype_pattern.findall(match)
-        for tt_var in teletype_vars:
-            print(
-                f"ERROR! {filename}: teletype font not allowed in rules, substitute {tt_var} with a proper macro"
-            )
-            num_errors += 1
+        if not "SUPPRESS_TEXTTT_LINTER" in match:
+            teletype_vars = teletype_pattern.findall(match)
+            for tt_var in teletype_vars:
+                print(
+                    f"ERROR! {filename}: teletype font not allowed in rules, substitute {tt_var} with a proper macro"
+                )
+                num_errors += 1
     return num_errors
 
 
@@ -462,7 +463,7 @@ def check_rules(filename: str) -> int:
         "GlobalDeclarations.tex" : 6,
         "GlobalStorageDeclarations.tex" : 7,
         "RelationsOnTypes.tex" : 15,
-        "Specifications.tex" : 26,
+        "Specifications.tex" : 25,
         "SubprogramCalls.tex" : 19,
         "SubprogramDeclarations.tex" : 13,
         "SymbolicEquivalenceTesting.tex" : 26,
@@ -470,7 +471,7 @@ def check_rules(filename: str) -> int:
         "Types.tex" : 9,
         "SideEffects.tex" : 13,
         "TypeSystemUtilities.tex" : 23,
-        "SemanticsUtilities.tex" : 20,
+        "SemanticsUtilities.tex" : 19,
     }
     total_expected = 0
     for num_expected in file_to_num_expected_errors.values():

--- a/asllib/doc/extended_macros.py
+++ b/asllib/doc/extended_macros.py
@@ -7,7 +7,7 @@ import re
 
 ASLREF_EXE = "aslref"
 
-debug = False
+debug = True
 
 
 def yellow_error_message(msg: str) -> str:
@@ -107,8 +107,8 @@ class BlockMacro(ABC):
             all_blocks.append((block, True))
             last_end_line = block.end + 1
         # Append any lines after the last block to transform.
-        if last_end_line < num_lines - 1:
-            all_blocks.append((Block(last_end_line, num_lines), False))
+        if last_end_line < num_lines:
+            all_blocks.append((Block(last_end_line, num_lines - 1), False))
         return all_blocks
 
     @classmethod
@@ -122,7 +122,7 @@ class BlockMacro(ABC):
             assert block.end >= block.begin
             assert block.begin == last_line_number + 1
             last_line_number = block.end
-        assert last_line_number == num_lines
+        assert last_line_number == num_lines - 1
 
     @classmethod
     def apply_to_file(cls, source: str):

--- a/asllib/doc/introduction.tex
+++ b/asllib/doc/introduction.tex
@@ -15,7 +15,7 @@ ASL is:
     \item imperative.
 \end{itemize}
 
-ASL has support for:
+ASL has support for the following features (non-exhaustive list):
 \begin{itemize}
     \item bitvectors:
     \begin{itemize}
@@ -27,20 +27,21 @@ ASL has support for:
         \item dependent types to support function overloading using bitvector lengths.
         \item dependent types to reason about lengths of bitvectors.
     \end{itemize}
-    \item unbounded arithmetic types “integer” and “real”.
-    \item exceptions.
-    \item enumerations.
-    \item arrays.
-    \item records.
-    \item call-by-value.
+    \item unbounded arithmetic types “integer” and “real”;
+    \item explicit non-determinism;
+    \item exceptions;
+    \item enumerations;
+    \item arrays;
+    \item records;
+    \item call-by-value;
     \item type inference.
 \end{itemize}
 
 ASL does not have support for:
 \begin{itemize}
-    \item references or pointers.
-    \item macros.
-    \item templates.
+    \item references or pointers;
+    \item macros;
+    \item templates;
     \item virtual functions.
 \end{itemize}
 

--- a/asllib/tests/ASLDefinition.t/Overriding.asl
+++ b/asllib/tests/ASLDefinition.t/Overriding.asl
@@ -16,7 +16,5 @@ end;
 func main() => integer
 begin
   let res = Foo{32}(TRUE);
-  assert IsOnes(res);
-
   return 0;
 end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LESlice.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.LESlice.asl
@@ -1,9 +1,7 @@
 func main () => integer
 begin
-
-  var x = '11111111';
-  x[3:0] = '0000';
-  assert x == '11110000';
-
+  var x = '11 11 1111';
+  x[3:0, 7:6] = '000000';
+  assert x == '00110000';
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckStmtReturnsOrThrows.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckStmtReturnsOrThrows.asl
@@ -1,0 +1,19 @@
+
+type invalid_state of exception;
+
+func all_terminating_paths_correct{N}(v: bits(N), flag: boolean) => bits(N)
+begin
+    if v != Zeros{N} then
+        if flag then
+            return Ones{N} XOR v;
+        else
+            Unreachable();
+        end;
+    else
+        if flag then
+            return v;
+        else
+            throw invalid_state{};
+        end;
+    end;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckStmtReturnsOrThrows.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckStmtReturnsOrThrows.bad.asl
@@ -1,0 +1,17 @@
+
+type invalid_state of exception;
+
+func incorrect_terminating_path{N}(v: bits(N), flag: boolean) => bits(N)
+begin
+    if v != Zeros{N} then
+        if flag then
+            return Ones{N} XOR v;
+        end;
+    else
+        if flag then
+            return v;
+        else
+            throw invalid_state{};
+        end;
+    end;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ControlFlowFromStmt.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ControlFlowFromStmt.asl
@@ -1,0 +1,96 @@
+func falls_through()
+begin
+    pass;
+    var x : integer = 5;
+    x = 7;
+    assert x == 7;
+    println(x);
+    pragma require_positive x;
+end;
+
+func unreachable() => integer
+begin
+    Unreachable();
+end;
+
+func returns_value() => integer
+begin
+    return 42;
+end;
+
+type invalid_state of exception;
+func throws_exception() => integer
+begin
+    throw invalid_state{};
+end;
+
+func sequencing1() => integer
+begin
+    // The control-flow state is determined by the first statement.
+    throw invalid_state{};
+    var x = 5;
+end;
+
+func sequencing2() => integer
+begin
+    // The control-flow state is determined by the second statement.
+    pass;
+    return 5;
+end;
+
+func conditional(flag: boolean) => integer
+begin
+    // The control-flow state is determined by "joining"
+    // the control-flow states of each of the statements
+    // comprising the conditional. statement.
+    if flag then
+        return 5;
+    else
+        throw invalid_state{};
+    end;
+end;
+
+func while_loop(flag: boolean) => integer
+begin
+    // The loop is conservatively treated as not terminating
+    // by returning a value, throwing an exception or executing Unreachable().
+    while (flag) looplimit 2^128 do
+        pass;
+    end;
+    return 0;
+end;
+
+func for_loop(upper_limit: integer) => integer
+begin
+    // The loop is conservatively treated as not terminating
+    // by returning a value, throwing an exception or executing Unreachable().
+    for i = 0 to upper_limit do
+        pass;
+    end;
+    return 0;
+end;
+
+func repeat_loop(upper_limit: integer) => integer
+begin
+    // The loop is conservatively treated as not terminating
+    // by returning a value, throwing an exception or executing Unreachable().
+    repeat
+        pass;
+    until TRUE looplimit 2^128;
+    return 0;
+end;
+
+func throwing_function() => integer
+begin
+    try
+        return repeat_loop(1000);
+    catch
+        when invalid_state => return 0;
+        otherwise => return 1;
+    end;
+end;
+
+func main() => integer
+begin
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ControlFlowFromStmt.bad1.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ControlFlowFromStmt.bad1.asl
@@ -1,0 +1,14 @@
+func loop_forever() => integer
+begin
+    // Even though the following loop will never terminate,
+    // the typechecker conservatively determines that there
+    // may be terminating paths that do not terminate
+    // by either returning a value, throwing an exception, or
+    // executing Unreachable().
+    while (TRUE) do
+        pass;
+    end;
+    // The following commented statement is needed to appease
+    // the typechecker.
+    // Unreachable();
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LESlice.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LESlice.asl
@@ -1,7 +1,0 @@
-func main () => integer
-begin
-  var x = '11 11 1111';
-  x[3:0, 7:6] = '000000';
-  assert x == '00110000';
-  return 0;
-end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.Subprogram.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.Subprogram.asl
@@ -1,0 +1,19 @@
+
+var state: bits(8) = '01000110';
+
+func my_procedure(mask: bits(8))
+begin
+    state = state AND mask;
+end;
+
+func flip_bits{N}(v: bits(N)) => bits(N)
+begin
+    return Ones{N} XOR v;
+end;
+
+func main() => integer
+begin
+    my_procedure(flip_bits{8}('11001010'));
+    println(state);
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TCollection.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TCollection.asl
@@ -1,0 +1,25 @@
+type MyCollection of collection { a: bits(8), b: bits(16) };
+type CollectionWithEmptyFieldList of collection {};
+type CollectionWithoutFields of collection;
+
+// The next type declaration in comment is illegal:
+// only bitvector types are allowed as collection fields.
+// type IllegalCollection of collection { non_bitvector: integer };
+
+// The next two declarations in comments are illegal:
+// a global storage element of collection
+// type must supply a type annotation and no initialization expression.
+// var - = MyCollection {a = Zeros{8}, b = Zeros{16}};
+// var - : MyCollection = MyCollection {a = Zeros{8}, b = Zeros{16}};
+
+var - : MyCollection;
+var - : CollectionWithEmptyFieldList;
+var - :CollectionWithoutFields;
+
+func main() => integer
+begin
+    // The next declaration in comment is illegal:
+    // local storage elements of collection types are forbidden.
+    // var - : MyCollection;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypecheckDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypecheckDecl.asl
@@ -1,0 +1,37 @@
+type MyRecord of record {
+    high_bits: bits(32),
+    low_bits: bits(32),
+};
+
+type MyException of exception {
+    msg: string,
+};
+
+type MyCollection of collection {
+    high_bits: bits(32),
+    low_bits: bits(32),
+};
+
+var rec: MyRecord;
+var exc: MyException;
+var coll: MyCollection;
+
+accessor Rec() <=> bits (64)
+begin
+    getter begin
+        return rec.high_bits :: rec.low_bits;
+    end;
+
+    setter = values begin
+        rec.high_bits = values[63:32];
+        rec.low_bits = values[31:0];
+    end;
+end;
+
+func main() => integer
+begin
+    println(Rec());
+    Rec() = Ones{64};
+    println(Rec());
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -314,7 +314,6 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.LESetStructuredField.asl
   $ aslref TypingRule.LESetField.asl
   $ aslref TypingRule.LESetFields.asl
-  $ aslref TypingRule.LESlice.asl
   $ aslref TypingRule.LESlice.bad.asl
   File TypingRule.LESlice.bad.asl, line 4, characters 3 to 11:
   ASL Static error: overlapping slices 0+:4, 3+:1.

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -109,6 +109,7 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.GetVariableEnum.asl
   $ aslref TypingRule.TRecordDecl.asl
   $ aslref TypingRule.TExceptionDecl.asl
+  $ aslref TypingRule.TCollection.asl
   $ aslref TypingRule.TNonDecl.asl
   File TypingRule.TNonDecl.asl, line 1, characters 5 to 6:
   ASL Error: Cannot parse.

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -434,3 +434,27 @@ ASL Typing Tests / annotating types:
   ASL typing error: unexpected collection.
   [1]
   $ aslref TypingRule.LESetCollectionFields.asl
+  $ aslref TypingRule.TypecheckDecl.asl
+  0x0000000000000000
+  0xffffffffffffffff
+  $ aslref TypingRule.Subprogram.asl
+  0x04
+  $ aslref --no-exec TypingRule.CheckStmtReturnsOrThrows.asl
+  $ aslref TypingRule.CheckStmtReturnsOrThrows.bad.asl
+  File TypingRule.CheckStmtReturnsOrThrows.bad.asl, line 6, character 4 to
+    line 16, character 8:
+  ASL Typing error: the function "incorrect_terminating_path" may not terminate
+    by returning a value or raising an exception..
+  [1]
+  $ aslref TypingRule.ControlFlowFromStmt.asl
+  File TypingRule.ControlFlowFromStmt.asl, line 8, characters 4 to 30:
+  ASL Warning: pragma require_positive will be ignored.
+  $ aslref TypingRule.ControlFlowFromStmt.bad1.asl
+  File TypingRule.ControlFlowFromStmt.bad1.asl, line 8, character 4 to line 10,
+    character 8:
+  ASL Warning: Loop does not have a limit.
+  File TypingRule.ControlFlowFromStmt.bad1.asl, line 8, character 4 to line 10,
+    character 8:
+  ASL Typing error: the function "loop_forever" may not terminate by returning
+    a value or raising an exception..
+  [1]


### PR DESCRIPTION
* Added examples to rules.
* Fixed bugs reported for the rules `TypingRule.SymDomOfType`, `SemanticsRUle.CheckRecurseLimit`, `SemanticsRule.ReadFromBitvector, and `SemanticsRule.WriteToBitvector`.
* Added the missing `TypingRule.TCollection`.
* Added a linter for duplicate lines in a row.
* Fixed a bug in validation code in `extended_macros.py`