### PR TITLE
Add tests to the aarch64 catalogue for existing relations of the memory model

### DIFF
--- a/catalogue/aarch64/shelf.py
+++ b/catalogue/aarch64/shelf.py
@@ -88,4 +88,5 @@ illustrative_tests = [
 #    "tests/R+CAS-rfi-ctrl+DMBST.litmus",
 #    "tests/SB+CAS-rfi-addr+DMBSY.litmus",
 #    "tests/SB+SWP-rfi-addr+DMBSY.litmus",
+     "tests/MP+rel+addr-po-loc-addr.litmus",
 ]

--- a/catalogue/aarch64/shelf.py
+++ b/catalogue/aarch64/shelf.py
@@ -89,4 +89,8 @@ illustrative_tests = [
 #    "tests/SB+CAS-rfi-addr+DMBSY.litmus",
 #    "tests/SB+SWP-rfi-addr+DMBSY.litmus",
      "tests/MP+rel+addr-po-loc-addr.litmus",
+     "tests/MP+rel+addr-lrs-acq.litmus",
+     "tests/MP+rel+data-lrs-acq.litmus",
+     "tests/MP+rel+ctrl-lrs-acq.litmus",
+     "tests/MP+rel+rmw-lrs-acq.litmus",
 ]

--- a/catalogue/aarch64/tests/@all
+++ b/catalogue/aarch64/tests/@all
@@ -50,3 +50,4 @@ MP+rel+swp-acq.litmus
 # SB+dmb.sy+rel-acqpc.litmus
 # MP+rel+acqpc.litmus
 # MP+rel+swp-acqpc.litmus
+MP+rel+addr-po-loc-addr.litmus

--- a/catalogue/aarch64/tests/@all
+++ b/catalogue/aarch64/tests/@all
@@ -51,3 +51,7 @@ MP+rel+swp-acq.litmus
 # MP+rel+acqpc.litmus
 # MP+rel+swp-acqpc.litmus
 MP+rel+addr-po-loc-addr.litmus
+MP+rel+addr-lrs-acq.litmus
+MP+rel+data-lrs-acq.litmus
+MP+rel+ctrl-lrs-acq.litmus
+MP+rel+rmw-lrs-acq.litmus

--- a/catalogue/aarch64/tests/MP+rel+addr-lrs-acq.litmus
+++ b/catalogue/aarch64/tests/MP+rel+addr-lrs-acq.litmus
@@ -1,0 +1,14 @@
+AArch64 MP+rel+addr-lrs-acq
+{
+ 0:X1=x; 0:X3=y;
+ 1:X1=x; 1:X3=y; 1:X5=z;
+}
+ P0           | P1                  ;
+ MOV W0,#1    | LDR W2,[X3]         ;
+ STR W0,[X1]  | EOR W4,W2,W2        ;
+ MOV W2,#1    | MOV W6,#1           ;
+ STLR W2,[X3] | STR W6,[X5,W4,SXTW] ;
+              | LDAR W7,[X5]        ;
+              | EOR W8,W7,W7        ;
+              | LDR W0,[X1]         ;
+exists (1:X2=1 /\ 1:X0=0)

--- a/catalogue/aarch64/tests/MP+rel+addr-po-loc-addr.litmus
+++ b/catalogue/aarch64/tests/MP+rel+addr-po-loc-addr.litmus
@@ -1,0 +1,13 @@
+AArch64 MP+rel+addr-po-loc-addr
+{
+ 0:X1=x; 0:X3=y;
+ 1:X1=x; 1:X3=y; 1:X5=z;
+}
+ P0           | P1                  ;
+ MOV W0,#1    | LDR W2,[X3]         ;
+ STR W0,[X1]  | EOR W4,W2,W2        ;
+ MOV W2,#1    | LDR W6,[X5,W4,SXTW] ;
+ STLR W2,[X3] | LDR W7,[X5]         ;
+              | EOR W8,W7,W7        ;
+              | LDR W0,[X1,W8,SXTW] ;
+exists (1:X2=1 /\ 1:X0=0)

--- a/catalogue/aarch64/tests/MP+rel+ctrl-lrs-acq.litmus
+++ b/catalogue/aarch64/tests/MP+rel+ctrl-lrs-acq.litmus
@@ -1,0 +1,15 @@
+AArch64 MP+rel+ctrl-lrs-acq
+{
+ 0:X1=x; 0:X3=y;
+ 1:X1=x; 1:X3=y; 1:X5=z;
+}
+ P0           | P1           ;
+ MOV W0,#1    | LDR W2,[X3]  ;
+ STR W0,[X1]  | CMP W2,#1    ;
+ MOV W2,#1    | B.EQ L0      ;
+ STLR W2,[X3] |L0:           ;
+              | MOV W6,#1    ;
+              | STR W6,[X5]  ;
+              | LDAR W7,[X5] ;
+              | LDR W0,[X1]  ;
+exists (1:X2=1 /\ 1:X0=0)

--- a/catalogue/aarch64/tests/MP+rel+data-lrs-acq.litmus
+++ b/catalogue/aarch64/tests/MP+rel+data-lrs-acq.litmus
@@ -1,0 +1,13 @@
+AArch64 MP+rel+data-lrs-acq
+{
+ 0:X1=x; 0:X3=y;
+ 1:X1=x; 1:X3=y; 1:X5=z;
+}
+ P0           | P1                  ;
+ MOV W0,#1    | LDR W2,[X3]         ;
+ STR W0,[X1]  | EOR W4,W2,W2        ;
+ MOV W2,#1    | ADD W6,W4,#1        ;
+ STLR W2,[X3] | STR W6,[X5]         ;
+              | LDAR W7,[X5]        ;
+              | LDR W0,[X1]         ;
+exists (1:X2=1 /\ 1:X0=0)

--- a/catalogue/aarch64/tests/MP+rel+rmw-lrs-acq.litmus
+++ b/catalogue/aarch64/tests/MP+rel+rmw-lrs-acq.litmus
@@ -1,0 +1,12 @@
+AArch64 MP+rel+rmw-lrs-acq
+{
+ 0:X1=x; 0:X3=y;
+ 1:X1=x; 1:X3=y;
+}
+ P0           | P1                  ;
+ MOV W0,#1    | MOV W6,#2           ;
+ STR W0,[X1]  | SWP W6,W2,[X3]      ;
+ MOV W2,#1    | LDAR W7,[X3]        ;
+ STLR W2,[X3] | EOR W8,W7,W7        ;
+              | LDR W0,[X1]         ;
+exists (1:X2=1 /\ 1:X0=0)

--- a/catalogue/aarch64/tests/kinds.txt
+++ b/catalogue/aarch64/tests/kinds.txt
@@ -62,3 +62,4 @@ MP+rel+acq                      Forbidden
 MP+rel+acqpc                    Forbidden
 MP+rel+swp-acq                  Forbidden
 MP+rel+swp-acqpc                Forbidden
+MP+rel+addr-po-loc-addr         Allowed

--- a/catalogue/aarch64/tests/kinds.txt
+++ b/catalogue/aarch64/tests/kinds.txt
@@ -63,3 +63,7 @@ MP+rel+acqpc                    Forbidden
 MP+rel+swp-acq                  Forbidden
 MP+rel+swp-acqpc                Forbidden
 MP+rel+addr-po-loc-addr         Allowed
+MP+rel+addr-lrs-acq             Forbidden
+MP+rel+data-lrs-acq             Forbidden
+MP+rel+ctrl-lrs-acq             Allowed
+MP+rel+rmw-lrs-acq              Forbidden


### PR DESCRIPTION
This PR adds 5 new tests to the aarch64 catalogue:
- MP+rel+addr-po-loc-addr is allowed and shows why po & same-loc is not in ob.
- MP+rel+addr-lrs-acq, MP+rel+data-lrs-acq and MP+rel+rmw-lrs-acq are forbidden due to the dependency ordered before relation.
- MP+rel+ctrl-lrs-acq is allowed in contrast to MP+rel+addr-lrs-acq and MP+rel+data-lrs-acq.