### PR TITLE
ASL-786, ASL-787, ASL-788: update standard library

### DIFF
--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -287,10 +287,8 @@ module NativeBackend (C : Config) = struct
           Error.fatal_unknown_pos
           @@ Error.BadArity (Dynamic, "DecStr", 1, List.length li)
 
-    let is_power_of_2 z = Int.equal (Z.log2 z) (Z.log2up z)
-
-    let log2 = function
-      | [ NV_Literal (L_Int i) ] when Z.gt i Z.zero && is_power_of_2 i ->
+    let floor_log2 = function
+      | [ NV_Literal (L_Int i) ] when Z.gt i Z.zero ->
           [ L_Int (Z.log2 i |> Z.of_int) |> nv_literal ]
       | [ v ] -> mismatch_type v [ integer' ]
       | li ->
@@ -373,7 +371,7 @@ module NativeBackend (C : Config) = struct
         p ~args:[ ("x", integer) ] ~returns:string "DecStr" dec_str;
         p ~args:[ ("x", integer) ] ~returns:string "HexStr" hex_str;
         p ~args:[ ("x", integer) ] ~returns:string "AsciiStr" ascii_str;
-        p ~args:[ ("x", integer) ] ~returns:integer "Log2" log2;
+        p ~args:[ ("x", integer) ] ~returns:integer "FloorLog2" floor_log2;
         p ~args:[ ("x", real) ] ~returns:integer "RoundDown" round_down;
         p ~args:[ ("x", real) ] ~returns:integer "RoundUp" round_up;
         p

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -355,7 +355,7 @@ module NativeBackend (C : Config) = struct
         (let two_pow_n_minus_one = minus_one (pow_2 (e_var "N")) in
          let returns = integer_range (eoi 0) two_pow_n_minus_one in
          p
-           ~parameters:[ ("N", None) ]
+           ~parameters:[ ("N", Some (integer_range (eoi 1) (eoi 128))) ]
            ~args:[ ("x", t_bits "N") ]
            ~returns "UInt" uint);
         (let two_pow_n_minus_one = pow_2 (minus_one (e_var "N")) in
@@ -365,7 +365,7 @@ module NativeBackend (C : Config) = struct
            integer_range minus_two_pow_n_minus_one two_pow_n_minus_one_minus_one
          in
          p
-           ~parameters:[ ("N", None) ]
+           ~parameters:[ ("N", Some (integer_range (eoi 1) (eoi 128))) ]
            ~args:[ ("x", t_bits "N") ]
            ~returns "SInt" sint);
         p ~args:[ ("x", integer) ] ~returns:string "DecStr" dec_str;

--- a/asllib/libdir/stdlib.asl
+++ b/asllib/libdir/stdlib.asl
@@ -609,21 +609,55 @@ begin
   return (ASR{N}(x, shift), x[Min(shift-1, N-1)]);
 end;
 
-// Rotate right.
-// This function shifts by [shift] bits to the right, the bits deleted are
-// reinserted on the left. This makes it operate effectively modulo N.
+// ROR()
+// =====
+// Rotate right by [shift] bits. The bits are deleted on the right and
+// reinserted on the left, so the operation is effectively modulo N.
+
 func ROR{N}(x: bits(N), shift: integer) => bits(N)
 begin
   assert shift >= 0;
+  if N == 0 then return x; end;
   let cshift = (shift MOD N) as integer{0..N-1};
   return x[0+:cshift] :: x[N-1:cshift];
 end;
 
+
+// ROR_C()
+// =======
 // Rotate right with carry out.
-// As ROR, the function effectively operates modulo N.
+// As with [ROR], the operation is effectively modulo N.
+// The carry bit is equal to the MSB of the result.
+
 func ROR_C{N}(x: bits(N), shift: integer) => (bits(N), bit)
 begin
   assert shift > 0;
+  if N == 0 then return (x, '0'); end;
   let cpos = (shift-1) MOD N;
   return (ROR{N}(x, shift), x[cpos]);
+end;
+
+// ROL()
+// =====
+// Rotate left by [shift] bits.
+// This corresponds to a right rotation by [-shift] bits.
+
+func ROL{N}(x: bits(N), shift: integer) => bits(N)
+begin
+  assert shift >= 0;
+  if N == 0 then return x; end;
+  return ROR{N}(x, -shift MOD N);
+end;
+
+// ROL_C()
+// =======
+// Rotate left with carry out.
+// The carry bit is equal to the LSB of the result.
+
+func ROL_C{N}(x: bits(N), shift: integer) => (bits(N), bit)
+begin
+  assert shift > 0;
+  if N == 0 then return (x, '0'); end;
+  let rshift = -shift MOD N;
+  return (ROR{N}(x, rshift), x[rshift]);
 end;

--- a/asllib/libdir/stdlib.asl
+++ b/asllib/libdir/stdlib.asl
@@ -11,7 +11,7 @@
 // ======
 // Convert a bitvector to an unsigned integer, where bit 0 is LSB.
 
-func UInt{N}(x: bits(N)) => integer{0..2^N-1}
+func UInt{N: integer{1..128}} (x: bits(N)) => integer{0..2^N-1}
 begin
     var result: integer = 0;
     for i = 0 to N-1 do
@@ -26,7 +26,7 @@ end;
 // ======
 // Convert a 2s complement bitvector to a signed integer.
 
-func SInt{N}(x: bits(N)) => integer{-(2^(N-1)) .. 2^(N-1)-1}
+func SInt{N: integer{1..128}} (x: bits(N)) => integer{-(2^(N-1)) .. 2^(N-1)-1}
 begin
     var result: integer = UInt(x);
     if N > 0 && x[N-1] == '1' then
@@ -527,7 +527,7 @@ end;
 // A variant of AlignDownSize where the bitvector x is viewed as an unsigned
 // integer and the resulting integer is represented by its first N bits.
 
-func AlignDownSize{N}(x: bits(N), size: integer {1..2^N}) => bits(N)
+func AlignDownSize{N: integer{1..128}}(x: bits(N), size: integer {1..2^N}) => bits(N)
 begin
     return AlignDownSize(UInt(x), size)[:N];
 end;
@@ -537,7 +537,7 @@ end;
 // A variant of AlignUpSize where the bitvector x is viewed as an unsigned
 // integer and the resulting integer is represented by its first N bits.
 
-func AlignUpSize{N}(x: bits(N), size: integer {1..2^N}) => bits(N)
+func AlignUpSize{N: integer{1..128}}(x: bits(N), size: integer {1..2^N}) => bits(N)
 begin
     return AlignUpSize(UInt(x), size)[:N];
 end;

--- a/asllib/libdir/stdlib.asl
+++ b/asllib/libdir/stdlib.asl
@@ -50,13 +50,32 @@ begin
   return if x < 0 then -x else x;
 end;
 
-// Log2()
+// FloorLog2()
 // ======
-// Calculate the logarithm base 2 of the input integer.
-// Input must be a power of 2.
+// Calculate the logarithm base 2 of the input integer, rounded down.
 
-func Log2(a: integer) => integer
+func FloorLog2(a: integer) => integer
 begin
+    assert a > 0;
+
+    var result : integer = 0;
+    var current : integer = 2;
+
+    while a >= current looplimit 2^128 do // i.e. unbounded
+        current = current * 2;
+        result = result + 1;
+    end;
+
+    return result;
+end;
+
+// CeilLog2()
+// ==========
+// Calculate the logarithm base 2 of the input integer, rounded up.
+
+func CeilLog2(a: integer) => integer
+begin
+    assert a > 0;
 
     var result : integer = 0;
     var current : integer = 1;
@@ -66,7 +85,6 @@ begin
         result = result + 1;
     end;
 
-    assert a == current;
     return result;
 end;
 

--- a/asllib/tests/stdlib.t/align.asl
+++ b/asllib/tests/stdlib.t/align.asl
@@ -25,7 +25,7 @@ begin
   assert AlignUpP2('001000', 5) == '100000';
   assert AlignUpP2('001000', 6) == '000000';
 
-  for N = 0 to 5 do
+  for N = 1 to 5 do
     let pN = 2 ^ N;
     for x = -pN to pN do
       for y = 0 to N do

--- a/asllib/tests/stdlib.t/ilog2.asl
+++ b/asllib/tests/stdlib.t/ilog2.asl
@@ -10,12 +10,12 @@ begin
     let lgx = ILog2(x);
     assert (Abs(lgx + ILog2(1.0 / x)) < 2);
     if i >= 0 then
-      assert Log2(FloorPow2(3 ^ (i as integer))) == lgx;
+      assert FloorLog2(3 ^ (i as integer)) == lgx;
     end;
   end;
 
   for i = 10 to 1000 do
-    assert Log2(FloorPow2(i DIVRM 10)) == ILog2 (Real (i) / 10.0);
+    assert FloorLog2(i DIVRM 10) == ILog2 (Real (i) / 10.0);
   end;
 
   return 0;

--- a/asllib/tests/stdlib.t/log2.asl
+++ b/asllib/tests/stdlib.t/log2.asl
@@ -1,10 +1,13 @@
 func main () => integer
 begin
-  assert Log2(1) == 0;
-  assert Log2(2) == 1;
+  for exp = 0 to 10 do
+    assert FloorLog2(2^exp) == exp;
+    assert CeilLog2(2^exp) == exp;
 
-  for n = 2 to 25 do
-    assert Log2(2 ^ n) == n;
+    for i = 2^exp + 1 to 2^(exp+1) - 1 do
+      assert FloorLog2(i) == exp;
+      assert CeilLog2(i) == exp + 1;
+    end;
   end;
 
   return 0;

--- a/asllib/tests/stdlib.t/no-primitives-test.asl
+++ b/asllib/tests/stdlib.t/no-primitives-test.asl
@@ -1,4 +1,4 @@
 func main() => integer
 begin
-  return Log2(3);
+  return FloorLog2(-1);
 end;

--- a/asllib/tests/stdlib.t/rotate.asl
+++ b/asllib/tests/stdlib.t/rotate.asl
@@ -1,0 +1,60 @@
+func print_bv{N}(bv: bits(N))
+begin
+  print("'");
+  for i = N-1 downto 0 do
+    print(if bv[i] == '0' then "0" else "1");
+  end;
+  print("'");
+end;
+
+func main () => integer
+begin
+  assert ROL('', 42) == '';
+  assert ROR('', 42) == '';
+
+  let (res_l, carry_l) = ROL_C('', 42);
+  assert (res_l == '' && carry_l == '0');
+  let (res_r, carry_r) = ROR_C('', 42);
+  assert (res_r == '' && carry_r == '0');
+
+  let V : bits(3) = '100';
+  print("V = ");
+  print_bv{3}(V);
+  println("\n");
+
+  for i = 0 to 3 do
+    print("ROR(V,", i, ") = ");
+    print_bv{3}(ROR(V,i));
+    println();
+  end;
+  println();
+
+  for i = 1 to 4 do
+    print("ROR_C(V,", i, ") = (");
+    let (res,carry) = ROR_C(V,i);
+    print_bv{3}(res);
+    print(", ");
+    print_bv{1}(carry);
+    println(")");
+  end;
+  println();
+
+  for i = 0 to 3 do
+    print("ROL(V,", i, ") = ");
+    print_bv{3}(ROL(V,i));
+    println();
+  end;
+  println();
+
+  for i = 1 to 4 do
+    print("ROL_C(V,", i, ") = (");
+    let (res,carry) = ROL_C(V,i);
+    print_bv{3}(res);
+    print(", ");
+    print_bv{1}(carry);
+    println(")");
+  end;
+  println();
+
+  return 0;
+end;

--- a/asllib/tests/stdlib.t/run.t
+++ b/asllib/tests/stdlib.t/run.t
@@ -15,6 +15,30 @@ Tests using ASLRef OCaml primitives for some stdlib functions
   {1, 1..(2 ^ (n + 1)), (- ((- 2) ^ (n + 1)))..((- 2) ^ (n + 1))}. Continuing
   with this constraint set.
 
+  $ aslref rotate.asl
+  V = '100'
+  
+  ROR(V,0) = '100'
+  ROR(V,1) = '010'
+  ROR(V,2) = '001'
+  ROR(V,3) = '100'
+  
+  ROR_C(V,1) = ('010', '0')
+  ROR_C(V,2) = ('001', '0')
+  ROR_C(V,3) = ('100', '1')
+  ROR_C(V,4) = ('010', '0')
+  
+  ROL(V,0) = '100'
+  ROL(V,1) = '001'
+  ROL(V,2) = '010'
+  ROL(V,3) = '100'
+  
+  ROL_C(V,1) = ('001', '1')
+  ROL_C(V,2) = ('010', '0')
+  ROL_C(V,3) = ('100', '0')
+  ROL_C(V,4) = ('001', '1')
+  
+
   $ aslref misc.asl
 
 Checking that --no-primitives option actually removes OCaml primitives
@@ -46,6 +70,30 @@ Tests using ASL stdlib only
   {0..(2 ^ (n + 1)), 1, (- ((- 2) ^ (n + 1)))..((- 2) ^ (n + 1))} gave
   {1, 1..(2 ^ (n + 1)), (- ((- 2) ^ (n + 1)))..((- 2) ^ (n + 1))}. Continuing
   with this constraint set.
+
+  $ aslref --no-primitives rotate.asl
+  V = '100'
+  
+  ROR(V,0) = '100'
+  ROR(V,1) = '010'
+  ROR(V,2) = '001'
+  ROR(V,3) = '100'
+  
+  ROR_C(V,1) = ('010', '0')
+  ROR_C(V,2) = ('001', '0')
+  ROR_C(V,3) = ('100', '1')
+  ROR_C(V,4) = ('010', '0')
+  
+  ROL(V,0) = '100'
+  ROL(V,1) = '001'
+  ROL(V,2) = '010'
+  ROL(V,3) = '100'
+  
+  ROL_C(V,1) = ('001', '1')
+  ROL_C(V,2) = ('010', '0')
+  ROL_C(V,3) = ('100', '0')
+  ROL_C(V,4) = ('001', '1')
+  
 
   $ aslref --no-primitives misc.asl
 

--- a/asllib/tests/stdlib.t/run.t
+++ b/asllib/tests/stdlib.t/run.t
@@ -44,12 +44,11 @@ Tests using ASLRef OCaml primitives for some stdlib functions
 Checking that --no-primitives option actually removes OCaml primitives
 (different errors are produced)
   $ aslref no-primitives-test.asl
-  ASL Execution error: Mismatch type: value 3 does not belong to type integer.
+  ASL Execution error: Mismatch type: value -1 does not belong to type integer.
   [1]
   $ aslref --no-primitives no-primitives-test.asl
-  File ASL Standard Library, line 69, characters 11 to 23:
-  ASL Execution error: Assertion failed:
-    (__stdlib_local_a == __stdlib_local_current).
+  File ASL Standard Library, line 59, characters 11 to 16:
+  ASL Execution error: Assertion failed: (__stdlib_local_a > 0).
   [1]
 
 Tests using ASL stdlib only

--- a/asllib/tests/stdlib.t/run.t
+++ b/asllib/tests/stdlib.t/run.t
@@ -54,8 +54,6 @@ Checking that --no-primitives option actually removes OCaml primitives
 Tests using ASL stdlib only
   $ aslref --no-primitives uint.asl
   $ aslref --no-primitives sint.asl
-  ASL Dynamic error: Illegal application of operator ^ for values 2 and -1.
-  [1]
   $ aslref --no-primitives pow2.asl
   $ aslref --no-primitives log2.asl
   $ aslref --no-primitives ilog2.asl

--- a/asllib/tests/stdlib.t/sint.asl
+++ b/asllib/tests/stdlib.t/sint.asl
@@ -1,4 +1,4 @@
-func test_sint {N} (bv: bits(N))
+func test_sint {N: integer{1..127}} (bv: bits(N))
 begin
   for i = 0 to 1 << N - 1 do
     assert SInt ('0' :: i[N-1:0]) == i;
@@ -7,7 +7,7 @@ begin
 end;
 
 // Same as test_sint, but only test 2^m numbers on each side of the interval
-func test_big_sint {N} (bv: bits(N), m: integer {0..N})
+func test_big_sint {N: integer{1..127}} (bv: bits(N), m: integer {0..N})
 begin
   for i = 0 to 1 << m do
     assert SInt ('0' :: i[N-1:0]) == i;
@@ -32,9 +32,8 @@ begin
   assert SInt('000') == 0;
   assert SInt('0') == 0;
   assert SInt('1') == -1;
-  assert SInt('') == 0;
 
-  for N = 0 to 10 do
+  for N = 1 to 10 do
     test_sint{N}(Zeros{N});
   end;
 
@@ -48,11 +47,6 @@ begin
   test_big_sint{64}(Zeros{64}, 5);
   test_big_sint{65}(Zeros{65}, 5);
   test_big_sint{127}(Zeros{127}, 5);
-  test_big_sint{128}(Zeros{128}, 5);
-  test_big_sint{129}(Zeros{129}, 5);
-  test_big_sint{255}(Zeros{255}, 5);
-  test_big_sint{256}(Zeros{256}, 5);
-  test_big_sint{257}(Zeros{257}, 5);
 
   return 0;
 end;

--- a/asllib/tests/stdlib.t/uint.asl
+++ b/asllib/tests/stdlib.t/uint.asl
@@ -1,6 +1,6 @@
 // Test UInt on all bitvectors of length N;
 // bv is a phantom argument, only there to enable the parameter N
-func test_uint {N} (bv: bits(N))
+func test_uint {N: integer{1..127}} (bv: bits(N))
 begin
   for i = 0 to 1 << N do
     assert UInt (i[N:0]) == i;
@@ -8,7 +8,7 @@ begin
 end;
 
 // Same as test_uint, but only test 2^m numbers on each side of the interval
-func test_big_uint {N} (bv: bits(N), m: integer {0..N})
+func test_big_uint {N: integer{1..127}} (bv: bits(N), m: integer {0..N})
 begin
   for i = 0 to 1 << m do
     assert UInt (i[N:0]) == i;
@@ -21,10 +21,9 @@ end;
 func main () => integer
 begin
   assert UInt('110') == 6;
-  assert UInt('') == 0;
   assert UInt('100000000') == 0x100;
 
-  for N = 0 to 10 do
+  for N = 1 to 10 do
     test_uint{N}(Zeros{N});
   end;
 
@@ -38,12 +37,6 @@ begin
   test_big_uint{64}(Zeros{64}, 5);
   test_big_uint{65}(Zeros{65}, 5);
   test_big_uint{127}(Zeros{127}, 5);
-  test_big_uint{128}(Zeros{128}, 5);
-  test_big_uint{129}(Zeros{129}, 5);
-  test_big_uint{255}(Zeros{255}, 5);
-  test_big_uint{256}(Zeros{256}, 5);
-  test_big_uint{257}(Zeros{257}, 5);
 
   return 0;
 end;
-

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -773,6 +773,8 @@ module Make (C : Config) = struct
       let pow_2 = binop `POW (lit 2) in
       let t_named x = T_Named x |> with_pos in
       let side_effecting = true in
+      let uint_sint_parameter_type =
+        Asllib.ASTUtils.integer_range' (lit 1) (lit 128) |> with_pos in
       let uint_returns = int_ctnt (lit 0) (minus_one (pow_2 (var "N")))
       and sint_returns =
         let big_pow = pow_2 (minus_one (var "N")) in
@@ -809,11 +811,11 @@ module Make (C : Config) = struct
           write_memory_gen;
         (* Translations *)
         p1r "UInt"
-          ~parameters:[ ("N", None) ]
+          ~parameters:[ ("N", Some uint_sint_parameter_type) ]
           ("x", bv_var "N")
           ~returns:uint_returns uint;
         p1r "SInt"
-          ~parameters:[ ("N", None) ]
+          ~parameters:[ ("N", Some uint_sint_parameter_type) ]
           ("x", bv_var "N")
           ~returns:sint_returns sint;
         (* Misc *)


### PR DESCRIPTION
- Add `ROL` and `ROL_C`
- Add `FloorLog2`, `CeilLog2`; remove `Log2`
- Update signatures of `UInt` and `SInt`: parameter `N` now has constraints `integer{1..128}`. This also requires introducing the same constraint to `Align{Up,Down}Size`