### PR TITLE
ASL-716 accessibility enhancements phase 10: examples and fixes

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -3873,14 +3873,6 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     new_tenv.global
   (* End *)
 
-  (* Begin TryAddGlobalConstant *)
-  let try_add_global_constant name env e =
-    try
-      let v = StaticInterpreter.static_eval env e in
-      { env with global = add_global_constant name v env.global }
-    with Error.(ASLException { desc = UnsupportedExpr _; _ }) -> env
-  (* End *)
-
   (* Begin DeclareGlobalStorage *)
   let declare_global_storage ~loc gsd genv =
     let () = if false then Format.eprintf "Declaring %s@." gsd.name in
@@ -3941,7 +3933,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     (* UpdateGlobalStorage( *)
     let env2 =
       match keyword with
-      | GDK_Constant -> try_add_global_constant name env1 initial_value'
+      | GDK_Constant ->
+          let v = StaticInterpreter.static_eval env1 initial_value' in
+          { env1 with global = add_global_constant name v env1.global }
       | GDK_Let when should_remember_immutable_expression ses_initial_value -> (
           match StaticModel.normalize_opt env1 initial_value' with
           | Some e' -> add_global_immutable_expr name e' env1

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1327,7 +1327,6 @@
 \newcommand\declareconst[0]{\hyperlink{def-declareconst}{\textfunc{declare\_const}}}
 \newcommand\addlocalconstant[0]{\hyperlink{def-addlocalconstant}{\textfunc{add\_local\_constant}}}
 \newcommand\addglobalconstant[0]{\hyperlink{def-addglobalconstant}{\textfunc{add\_global\_constant}}}
-\newcommand\tryaddglobalconstant[0]{\hyperlink{def-tryaddglobalconstant}{\textfunc{try\_add\_global\_constant}}}
 \newcommand\annotateargs[0]{\hyperlink{def-annotateargs}{\textfunc{annotate\_args}}}
 \newcommand\annotateonearg[0]{\hyperlink{def-annotateonearg}{\textfunc{annotate\_one\_arg}}}
 \newcommand\annotatereturntype[0]{\hyperlink{def-annotatereturntype}{\textfunc{annotate\_return\_type}}}
@@ -1664,6 +1663,8 @@
 \newcommand\namedlowestcommonancestor[0]{\hyperlink{def-namedlowestcommonancestor}{named lowest common ancestor}}
 \newcommand\arrayaccess[0]{\hyperlink{def-arrayaccess}{array access}}
 \newcommand\symbolicallysimplifies[0]{\hyperlink{def-symbolicallysimplifies}{symbolically simplifies}}
+\newcommand\Prosesingulartype[0]{\hyperlink{def-issingular}{singular type}}
+
 \newcommand\nativevalue[0]{\hyperlink{def-nativevalue}{native value}}
 \newcommand\executiongraph[0]{\hyperlink{def-executiongraph}{execution graph}}
 \newcommand\executiongraphs[0]{\hyperlink{def-executiongraph}{execution graphs}}
@@ -3259,3 +3260,4 @@
 \newcommand\vBIG[0]{\textbf{BIG}}
 \newcommand\vLITTLE[0]{\textbf{LITTLE}}
 \newcommand\vHALFWORDSIZE[0]{\texttt{HALF\_WORD\_SIZE}}
+\newcommand\PI[0]{\texttt{PI}}

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -227,6 +227,23 @@ annotates the global storage declaration $\gsd$ in the global static environment
 yielding a modified global static environment $\newgenv$ and annotated global storage declaration $\newgsd$.
 \ProseOtherwiseTypeError
 
+\ExampleDef{Declaring Global Storage}
+\listingref{DeclareGlobalStorage} shows examples of well-typed global storage declarations.
+\ASLListing{Well-typed optional initial values}{DeclareGlobalStorage}{\typingtests/TypingRule.DeclareGlobalStorage.asl}
+
+The specification in \listingref{DeclareGlobalStorage-bad3} is illegal since
+\texttt{config} storage elements must have an initializing expression.
+\ASLListing{Uninitialized config declaration}{DeclareGlobalStorage-bad3}{\typingtests/TypingRule.DeclareGlobalStorage.bad3.asl}
+
+The specifications in \listingref{DeclareGlobalStorage-bad1} and \listingref{DeclareGlobalStorage-bad2}
+are ill-typed since
+\texttt{config} storage elements have the $\timeframeconstant$ \timeframeterm,
+which requires that all expressions used in its type annotation and initializing expression
+also have the $\timeframeconstant$ \timeframeterm,
+whereas \verb|b| has the $\timeframeexecution$ \timeframeterm.
+\ASLListing{Ill-typed config declaration}{DeclareGlobalStorage-bad1}{\typingtests/TypingRule.DeclareGlobalStorage.bad1.asl}
+\ASLListing{Ill-typed config declaration}{DeclareGlobalStorage-bad2}{\typingtests/TypingRule.DeclareGlobalStorage.bad2.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -236,7 +253,7 @@ yielding a modified global static environment $\newgenv$ and annotated global st
   \item applying $\withemptylocal$ to $\genv$ yields $\tenv$;
   \item define $\vtargettimeframe$ as $\timeframeconstant$ if $\keyword$ is $\GDKConstant$ or $\GDKConfig$, and $\timeframeexecution$ otherwise;
   \item applying $\annotatetyoptinitialvalue$ to $\keyword$, $\vtargettimeframe$, $\tyoptp$, \\
-        and $\initialvalue$ in $\tenv$ yields
+        and $\initialvalue$ in $\tenv$ yields\\
         $(\typedinitialvalue, \tyoptp, \declaredt)$\ProseOrTypeError;
   \item adding a global storage element with name $\name$, global declaration keyword \\ $\keyword$ and type $\declaredt$
         to $\tenv$ via $\addglobalstorage$ yields $\tenvone$\ProseOrTypeError;
@@ -248,6 +265,7 @@ yielding a modified global static environment $\newgenv$ and annotated global st
         ($\GDinitialvalue$) set to $\initialvaluep$;
   \item define $\newgenv$ as the global component of $\tenvtwo$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -228,8 +228,15 @@ yielding a modified global static environment $\newgenv$ and annotated global st
 \ProseOtherwiseTypeError
 
 \ExampleDef{Declaring Global Storage}
-\listingref{DeclareGlobalStorage} shows examples of well-typed global storage declarations.
-\ASLListing{Well-typed optional initial values}{DeclareGlobalStorage}{\typingtests/TypingRule.DeclareGlobalStorage.asl}
+\listingref{DeclareGlobalStorage-config} shows examples of well-typed global storage declarations
+and ill-typed global storage declarations in comments,
+focused on \verb|config| storage elements.
+\ASLListing{Config storage elements}{DeclareGlobalStorage-config}{\typingtests/TypingRule.DeclareGlobalStorage.config.asl}
+
+\listingref{DeclareGlobalStorage-non-config} shows examples of well-typed global storage declarations,
+and ill-typed global storage declarations in comments,
+focused on storage elements that are not \verb|config|.
+\ASLListing{Well-typed non-config storage elements}{DeclareGlobalStorage-non-config}{\typingtests/TypingRule.DeclareGlobalStorage.non_config.asl}
 
 The specification in \listingref{DeclareGlobalStorage-bad3} is illegal since
 \texttt{config} storage elements must have an initializing expression.
@@ -243,6 +250,9 @@ also have the $\timeframeconstant$ \timeframeterm,
 whereas \verb|b| has the $\timeframeexecution$ \timeframeterm.
 \ASLListing{Ill-typed config declaration}{DeclareGlobalStorage-bad1}{\typingtests/TypingRule.DeclareGlobalStorage.bad1.asl}
 \ASLListing{Ill-typed config declaration}{DeclareGlobalStorage-bad2}{\typingtests/TypingRule.DeclareGlobalStorage.bad2.asl}
+
+See \ExampleRef{Rejected Declaration Because of Precision Loss} for an example
+of an ill-typed global storage declaration due to precision loss.
 
 \ProseParagraph
 \AllApply
@@ -344,6 +354,8 @@ It determines $\typedinitialvalue$, which consists
 of an expression, a type, and a \sideeffectsetterm,
 the annotation of the type in $\tyoptp$ (in case there is a type), and the type
 that should be associated with the storage element $\declaredt$.
+
+See \ExampleRef{Declaring Global Storage}.
 
 \ProseParagraph
 \OneApplies
@@ -510,6 +522,20 @@ The result is the updated static environment $\newtenv$.
 This helper function is applied following $\addglobalstorage(\tenv, \name, \gdk, \vt)$ where $\vt$
 is the type associated with $\name$.
 
+\ExampleDef{Updating the Global Storage for a Constant}
+The specification in \listingref{UpdateGlobalStorage-constant}
+binds $\vy$ to $\lint(5040)$ in the $\constantvalues$ map of the global static environment.
+\ASLListing{Updating the global storage for a constant}{UpdateGlobalStorage-constant}{\typingtests/TypingRule.UpdateGlobalStorage.constant.asl}
+
+\ExampleDef{Updating the Global Storage for Configuration Storage Elements}
+The specification in \listingref{UpdateGlobalStorage-config}
+shows well-typed global storage \texttt{config} elements.
+\ASLListing{Updating the global storage for config storage elements}{UpdateGlobalStorage-config}{\typingtests/TypingRule.UpdateGlobalStorage.config.asl}
+
+The specification in \listingref{UpdateGlobalStorage-config-bad}
+is ill-typed, since only a \Prosesingulartype{} can be used for \texttt{config} storage elements.
+\ASLListing{An ill-typed global storage config storage element}{UpdateGlobalStorage-config-bad}{\typingtests/TypingRule.UpdateGlobalStorage.config.bad.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -517,7 +543,10 @@ is the type associated with $\name$.
   \begin{itemize}
     \item $\gdk$ is $\GDKConstant$;
     \item view $\typedinitialvalue$ as $(\Ignore, \initialvaluep, \vsesinitialvalue)$;
-    \item applying $\tryaddglobalconstant$ to $\name$ and $\initialvaluep$ in $\tenv$ yields $\newtenv$.
+    \item \Prosestaticeval{$\tenv$}{$\initialvaluep$}{$\vv$};
+    \item applying $\addglobalconstant$ to $G^\tenv$, $\name$ and $\vv$ yields $G'$;
+    \item \Proseeqdef{$\newtenv$}{the static environment whose global component is $G'$ and local component is
+    the local component of $\tenv$}.
   \end{itemize}
 
   \item \AllApplyCase{let\_normalizable}
@@ -553,7 +582,9 @@ is the type associated with $\name$.
 \begin{mathpar}
 \inferrule[constant]{
   \typedinitialvalue \eqname (\Ignore, \initialvaluep, \vsesinitialvalue)\\
-  \tryaddglobalconstant(\tenv, \name, \initialvaluep) \typearrow \newtenv
+  \staticeval(\tenv, \initialvaluep) \typearrow \vv\\
+  \addglobalconstant(G^\tenv, \name, \vv) \typearrow G'\\
+  \newtenv \eqdef (G', L^\tenv)
 }{
   {
     \begin{array}{r}
@@ -636,54 +667,6 @@ is the type associated with $\name$.
 }
 \end{mathpar}
 
-\TypingRuleDef{TryAddGlobalConstant}
-\hypertarget{def-tryaddglobalconstant}{}
-The helper function
-\[
-\tryaddglobalconstant(
-  \overname{\staticenvs}{\tenv} \aslsep
-  \overname{\identifier}{\name} \aslsep
-  \overname{\expr}{\ve}
-  )
-  \typearrow \overname{\staticenvs}{\newtenv}
-\]
-attempts to update $\tenv$ by binding $\name$ to a literal value when $\ve$ can be statically
-evaluated to one. The resulting static environment is $\newtenv$.
-
-\ProseParagraph
-\OneApplies
-\begin{itemize}
-  \item \AllApplyCase{okay}
-  \begin{itemize}
-    \item \Prosestaticeval{$\tenv$}{$\ve$}{the literal $\vv$};
-    \item applying $\addglobalconstant$ to $\ve$ and $\vv$ in $\tenv$ yields $\newtenv$;
-  \end{itemize}
-
-  \item \AllApplyCase{error}
-  \begin{itemize}
-    \item \Prosestaticeval{$\tenv$}{$\ve$}{a \typingerrorterm{}};
-    \item \Proseeqdef{$\newtenv$}{$\tenv$};
-  \end{itemize}
-\end{itemize}
-
-\FormallyParagraph
-\begin{mathpar}
-\inferrule[okay]{
-  \staticeval(\tenv, \ve) \typearrow \vv\\
-  \addglobalconstant(\tenv, \ve, \vv) \typearrow \newtenv
-}{
-  \tryaddglobalconstant(\tenv, \name, \ve) \typearrow \newtenv
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[error]{
-  \staticeval(\tenv, \ve) \typearrow \TypeErrorConfig
-}{
-  \tryaddglobalconstant(\tenv, \name, \ve) \typearrow \overname{\tenv}{\newtenv}
-}
-\end{mathpar}
-
 \TypingRuleDef{AddGlobalStorage}
 \hypertarget{def-addglobalstorage}{}
 The function
@@ -701,6 +684,18 @@ returns a global static environment $\newgenv$ which is identical to the global 
 except that the identifier $\name$, which is assumed to name a global storage element,
 is bound to the global storage keyword $\keyword$ and type $\declaredt$.
 \ProseOtherwiseTypeError
+
+\ExampleDef{Adding Global Storage Elements to the Static Environment}
+Adding the global storage elements in \listingref{EvalGlobals},
+adds the following bindings to the $\globalstoragetypes$ map of a given
+static environments:
+\[
+\begin{array}{rcl}
+  \PI &\mapsto& (\TReal, \GDKConstant)\\
+  \vx &\mapsto& (\unconstrainedinteger, \GDKVar)\\
+  \vc &\mapsto& (\TInt(\wellconstrained(\AbbrevConstraintExact{\lint(42)})), \GDKConfig)
+\end{array}
+\]
 
 \ProseParagraph
 \AllApply
@@ -739,6 +734,14 @@ The relation
 \]
 updates the input environment and execution graph by initializing the global storage declarations.
 
+\ExampleDef{Evaluating a List of Global Declarations}
+Evaluating the global storage declarations in \listingref{EvalGlobals}
+results in updating the $\storage$ map of global dynamic environment by binding
+\verb|PI| is bound to $\nvreal(157/50)$,
+\verb|x| is bound to $\nvint(5)$, and \verb|c| is bound to $\nvint(42)$.
+
+\ASLListing{Evaluating a list of global declarations}{EvalGlobals}{\semanticstests/SemanticsRule.EvalGlobals.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -752,12 +755,12 @@ updates the input environment and execution graph by initializing the global sto
   \begin{itemize}
     \item $\vdecls$ has $\vd$ as its head and $\vdecls'$ as its tail;
     \item $d$ is the AST node for declaring a global storage element with initial value $\ve$,
-    name $\name$, and type $\vt$;
+          name $\name$, and type $\vt$;
     \item $\envm$ is the environment-execution graph pair $(\env, \vgone)$;
     \item the evaluation of the expression $\ve$ in $\env$ yields $\Normal((\vv, \vgtwo), \envtwo)$\ProseOrAbnormal;
     \item declaring the global $\name$ with value $\vv$ in $\envtwo$ gives $\envthree$;
     \item evaluating the remaining global declarations $\vdecls'$ with the environment $\envthree$ and the execution graph
-    that is the ordered composition of $\vgone$ and $\vgtwo$ with the $\aslpo$ label gives $C$;
+          that is the ordered composition of $\vgone$ and $\vgtwo$ with the $\aslpo$ label gives $C$;
     \item the result of the entire evaluation is $C$.
   \end{itemize}
 \end{itemize}
@@ -765,13 +768,13 @@ updates the input environment and execution graph by initializing the global sto
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[empty]{}{
-  \evalglobals(\overname{\emptylist}{\vdecls}, \envm) \evalarrow \envm
+  \evalglobals(\overname{\emptylist}{\vdecls}, \envm) \evalarrow \overname{\envm}{C}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[non\_empty]{
-  \vd \eqname \DGlobalStorage(\{ \text{initial\_value}=\langle\ve\rangle, \text{name}:\name, \ldots \})\\
+  \vd \eqname \DGlobalStorage(\{ \GDinitialvalue:\langle\ve\rangle, \GDname:\name, \ldots \})\\
   \envm \eqname (\env, \vgone)\\
   \evalexpr{ \env, \ve} \evalarrow \Normal((\vv,\vgtwo), \envtwo) \OrAbnormal\\\\
   \declareglobal(\name, \vv, \envtwo) \evalarrow \envthree\\
@@ -790,6 +793,11 @@ The relation
   \declareglobal(\overname{\Identifiers}{\name} \aslsep \overname{\vals}{\vv} \aslsep \overname{\envs}{\env}) \;\aslrel\; \overname{\envs}{\newenv}
 \]
 updates the environment $\env$ by mapping $\name$ to $\vv$ in the $\storage$ map of the global dynamic environment $G^\denv$.
+
+\ExampleDef{Declaring a Global Storage Element}
+Evaluating the specification in \listingref{DeclareGlobal}, results in updating the $\storage$ map
+of the global dynamic environment by binding $\vx$ to $\nvint(5)$.
+\ASLListing{Declaring a global storage element}{DeclareGlobal}{\semanticstests/SemanticsRule.DeclareGlobal.asl}
 
 \FormallyParagraph
 \begin{mathpar}

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -274,10 +274,10 @@ whereas \\
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexprsef{\env, \veone} \evalarrow \Normal(\vvone, \newg) \OrDynError\\\\
-  \binoprel(\EQOP, \vvone, \vvone) \evalarrow \vb
+  \evalexprsef{\env, \ve} \evalarrow \Normal(\vvone, \newg) \OrDynError\\\\
+  \binoprel(\EQOP, \vv, \vvone) \evalarrow \vb
 }{
-  \evalpattern{\env, \vv, \PatternSingle(\ve)} \evalarrow \Normal(\vb, \newg)
+  \evalpattern{\env, \vv, \overname{\PatternSingle(\ve)}{\vp}} \evalarrow \Normal(\vb, \newg)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPSingleBegin}{\EvalPSingleEnd}{../Interpreter.ml}
@@ -730,7 +730,7 @@ The tuple patterns in \listingref{typing-ptuple-bad} are ill-typed.
   \vtstruct \eqname \TTuple(\vts)\\
   \checktrans{\equallength(\vli, \vts)}{\UnexpectedType} \checktransarrow \True \OrTypeError\\\\
   i\in\listrange(\vli): \annotatepattern(\tenv, \vts[i], \vli[i]) \typearrow (\vlip[i], \vxs_i) \OrTypeError\\\\
-  \newli \eqdef \vi\in\listrange(\vli): \vlip[\vi]\\
+  \newli \eqdef i\in\listrange(\vli): \vlip[i]\\
   \vses \eqdef \bigcup_{i\in\listrange(\vli)} \vxs_i
 }{
   \annotatepattern(\tenv, \vt, \overname{\PatternTuple(\vli)}{\vp}) \typearrow (\overname{\PatternTuple(\newli)}{\newp}, \vses)

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -578,7 +578,9 @@ rule, along with the rule for binary operator (for multiplication), to evaluate 
 
 \subsection{Evaluation Order\label{sec:EvaluationOrder}}
 ASL specifies an evaluation order to ensure predictability of side-effects and exceptions.
-In particular, semantic rules use short-circuiting rule macros to impose an ordering on premises and their associated side-effects, errors, and exceptions.
+In particular, semantic rules use short-circuiting rule macros to
+impose an ordering on premises and their associated side-effects, errors, and exceptions.
+Further, the threading through of environments similarly impose an ordering.
 
 For example, \SemanticsRuleRef{ECond} is duplicated below:
 \begin{mathpar}
@@ -593,7 +595,11 @@ For example, \SemanticsRuleRef{ECond} is duplicated below:
   \Normal((\vv, \vg), \newenv)
 }
 \end{mathpar}
-The use of $\OrAbnormal$ rule macros here define an evaluation order: $\econd$ must be evaluated first, then exactly one of $\veone$ or $\vetwo$.
+The use of $\OrAbnormal$ rule macros here define an evaluation order:
+$\econd$ must be evaluated first, then exactly one of $\veone$ or $\vetwo$.
+This order is also reflected by the fact that evaluation of the conditional
+expression produces the environment $\envone$, which is then used to evaluate
+the chosen expression $\vep$.
 
 For most ASL constructs, there is only one evaluation order that makes sense for the intended purpose of the construct.
 In the example above, it is not feasible to evaluate $\veone$ before evaluating $\econd$.

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -837,15 +837,19 @@ constant types would result in more than $2^17$ elements, see
   }{%
     \checknoprecisionloss{\overname{\TInt(\wellconstrained(_, p))}{\vt}} \typearrow \True
   }
-  \and
+\end{mathpar}
+
+\begin{mathpar}
   \inferrule[Integer]{%
-    \astlabel{\vc} \neq \wellconstrained
+    \astlabel(\vc) \neq \wellconstrained
   }{%
     \checknoprecisionloss{\overname{\TInt(\vc)}{\vt}} \typearrow \True
   }
-  \and
+\end{mathpar}
+
+\begin{mathpar}
   \inferrule[Other]{%
-    \astlabel{\vt} \neq \TInt
+    \astlabel(\vt) \neq \TInt
   }{%
     \checknoprecisionloss{\vt} \typearrow \True
   }
@@ -1317,7 +1321,12 @@ can only be used for procedures, not functions.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalcall{\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs} \evalarrow \Normal(\newg, \newenv) \OrAbnormal
+{
+\begin{array}{r}
+  \evalcall{\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs} \evalarrow \\
+  \Normal(\newg, \newenv) \OrAbnormal
+\end{array}
+}
 }{
   \evalstmt{\env, \overname{\SCall(\vcall)}{\vs}} \evalarrow \Continuing(\newg, \newenv)
 }

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -801,7 +801,7 @@ The helper function
 checks whether the type $\vt$ is the result of a precision loss in its
 constraint computation (see for example \TypingRuleRef{ApplyBinopTypes}).
 
-\ExampleDef{Rejected Declaration because of Precision Loss}
+\ExampleDef{Rejected Declaration Because of Precision Loss}
 In \listingref{typing-imprecisetype}, the statement \verb|var b = a * a;|
 corresponds to the \typingerrorterm{} raised in the \CaseName{Well-Constrained}
 below.
@@ -835,7 +835,7 @@ constant types would result in more than $2^17$ elements, see
   \inferrule[Well-Constrained]{%
     \checktrans{p = \PrecisionFull}{PrecisionLostDefining}
   }{%
-    \checknoprecisionloss{\overname{\TInt(\wellconstrained(_, p))}{\vt}} \typearrow \True
+    \checknoprecisionloss{\overname{\TInt(\wellconstrained(\Ignore, p))}{\vt}} \typearrow \True
   }
 \end{mathpar}
 

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1391,6 +1391,8 @@ We also define the following helper rules:
     \begin{itemize}
       \item evaluating the subprogram named $\name$ with arguments $\vvargs$ and parameters $\vvparams$ in
             $\denvtwo'$ is $\Throwing(\vv, \envthrow)$\ProseOrError;
+      \item view $\envthrow$ as the environment consisting of the static environment $\tenv$,
+            and the dynamic environment whose global component is $\vglobal$;
       \item applying the helper relation $\readvaluefrom$ to $\vms$ yields $\vmstwo$;
       \item applying $\decrstacksize$ to $\vglobal$ and $\name$ yields $\genvtwo$;
       \item define $\newenv$ as the environment where the static environment is $\tenv$ and the dynamic environment consists
@@ -1413,7 +1415,7 @@ We also define the following helper rules:
   \evalsubprogram{\envtwo', \name, \vvparams, \vvargs} \evalarrow \Normal(\vms, (\vglobal, \Ignore)) \OrDynError\\\\
   \readvaluefrom(\vms) \evalarrow \vmstwo\\
   \decrstacksize(\vglobal, \name) \evalarrow \genvtwo\\
-  \newenv \eqdef (\tenv, (\vglobal, L^{\denvtwo}))
+  \newenv \eqdef (\tenv, (\genvtwo, L^{\denvtwo}))
 }{
   \evalcall{\env, \name, \params, \args} \evalarrow \Normal(\vmstwo, \newenv)
 }
@@ -1428,7 +1430,7 @@ We also define the following helper rules:
   \envtwo' \eqdef (\tenv, (\genv, \emptyfunc))\\\\
   \commonprefixline\\\\
   \evalsubprogram{\envtwo', \name, \vvparams, \vvargs} \evalarrow \Throwing(\vv, \envthrow) \OrDynError\\\\
-  \envthrow \eqname (\tenv, \denvthrow)\\
+  \envthrow \eqname (\tenv, (\vglobal, \Ignore))\\
   \decrstacksize(\vglobal, \name) \evalarrow \genvtwo\\
   \newenv \eqdef (\tenv, (\genvtwo, L^{\denvtwo}))
 }{

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -221,7 +221,7 @@ The predicate
   \issingular(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\tty}) \;\aslto\;
   \overname{\Bool}{\vb} \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-tests whether the type $\tty$ is a \emph{singular type} in the static environment $\tenv$,
+tests whether the type $\tty$ is a \emph{\Prosesingulartype} in the static environment $\tenv$,
 yielding the result in $\vb$.
 \ProseOtherwiseTypeError
 

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -602,7 +602,6 @@ global static environment $\genv$, yielding the modified environment $\newgenv$.
 \ProseOtherwiseTypeError
 
 \ExampleDef{Declaring a Global Constant}
-\newcommand\PI[0]{\texttt{PI}}
 In \listingref{DeclareConst}, declaring the constant \PI{}
 in the empty global static environment yields the following global static environment:
 \[

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -300,6 +300,7 @@ choices
 choose
 chooses
 choosing
+chosen
 circular
 clash
 clashes
@@ -781,6 +782,7 @@ flavors
 floating
 flow
 flows
+focused
 fold
 follow
 followed
@@ -1695,6 +1697,7 @@ signifying
 signs
 similar
 similarity
+similarly
 simple
 simpler
 simplification
@@ -1885,6 +1888,7 @@ this
 those
 though
 thread
+threading
 three
 through
 throughout

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -665,7 +665,7 @@ def main():
     print("Linting files...")
     all_latex_sources = get_latex_sources(False)
     content_latex_sources = get_latex_sources(True)
-    # content_latex_sources = ["TypeDeclarations.tex"]
+    content_latex_sources = ["GlobalStorageDeclarations.tex"]
     num_errors = 0
     num_spelling_errors = spellcheck(args.dictionary, content_latex_sources)
     if num_spelling_errors > 0:

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -486,7 +486,6 @@ def check_rules(filename: str) -> int:
     """
     # Treat existing issues as warnings and new issues as errors.
     file_to_num_expected_errors = {
-        "GlobalStorageDeclarations.tex" : 7,
         "RelationsOnTypes.tex" : 15,
         "Specifications.tex" : 25,
         "SubprogramCalls.tex" : 19,
@@ -665,7 +664,7 @@ def main():
     print("Linting files...")
     all_latex_sources = get_latex_sources(False)
     content_latex_sources = get_latex_sources(True)
-    content_latex_sources = ["GlobalStorageDeclarations.tex"]
+    # content_latex_sources = ["GlobalStorageDeclarations.tex"]
     num_errors = 0
     num_spelling_errors = spellcheck(args.dictionary, content_latex_sources)
     if num_spelling_errors > 0:

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.DeclareGlobal.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.DeclareGlobal.asl
@@ -1,0 +1,6 @@
+var x : integer = 5;
+
+func main() => integer
+begin
+    return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EvalGlobals.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EvalGlobals.asl
@@ -1,0 +1,8 @@
+constant PI = 3.14;
+var x : integer = 5;
+config c : integer = 42;
+
+func main() => integer
+begin
+    return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCall.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.SCall.asl
@@ -22,7 +22,10 @@ begin
     catenate_into_g{4, 3}(x, y, TRUE);
     assert g == '1101 111';
 
-    // The following statement in comment is illegal as 'zero' is not a procedure.
+    - = zero();
+    // The following statement in comment is illegal as 'zero'
+    // a function, not a procedure, and its returned value
+    // must be consumed.
     // zero();
     return 0;
 end;

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -223,3 +223,5 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.CheckNonOverlappingSlices.bad.asl
   ASL Dynamic error: overlapping slices (N - 2)+:2, 0+:1.
   [1]
+  $ aslref SemanticsRule.DeclareGlobal.asl
+  $ aslref SemanticsRule.EvalGlobals.asl

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.asl
@@ -1,4 +1,4 @@
-var - = 42;
-let - = 42;
-constant - = 42;
-config - : integer = 42;
+constant y = 1;
+constant x = 5;
+config c : integer{1..x} = (x - 1) + y;
+config c_default_init : integer = 5;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.asl
@@ -1,4 +1,4 @@
-constant y = 1;
-constant x = 5;
-config c : integer{1..x} = (x - 1) + y;
-config c_default_init : integer = 5;
+var - = 42;
+let - = 42;
+constant - = 42;
+config - : integer = 42;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.bad1.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.bad1.asl
@@ -1,0 +1,3 @@
+let x = 5;
+// Illegal: initializing expression must be constant-time.
+config c : integer{1..5} = x;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.bad2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.bad2.asl
@@ -1,0 +1,3 @@
+let x = 5;
+// Illegal: expressions in type annotation must be constant-time.
+config c : integer{1..x} = 2;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.bad3.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.bad3.asl
@@ -1,0 +1,2 @@
+// Illegal (parse error): 'config' storage must be initialized.
+config uninitialized_config : integer;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.config.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.config.asl
@@ -1,0 +1,9 @@
+constant y = 1;
+constant x = 5;
+config c : integer{1..x} = (x - 1) + y;
+config c_unconstrained_int : integer = 5;
+
+// The next declaration in comment is illegal,
+// since pending constraints are not allowed
+// for configuration storage elements.
+// config c_inherited_constrained : integer{-} = 5;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.non_config.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.non_config.asl
@@ -1,0 +1,25 @@
+constant y = 1;
+constant x = 5;
+var c_var : integer{1..x} = (x - 1) + y;
+var c_var_unconstrained_int : integer = 5;
+var c_var_well_constrained : integer{0..10} = 5;
+var c_var_inherited_constrained : integer{-} = 2^128;
+var c_var_no_type_annotation = (x - 1) + y;
+
+// The next two declarations in comment are illegal,
+// as inherited constraints require an initializing
+// expression.
+// var c_var_inherited_illegal : integer{-};
+// var c_let_illegal : integer{-};
+
+let c_let : integer{1..x} = (x - 1) + y;
+let c_let_unconstrained_int : integer = 5;
+let c_let_inherited_constrained : integer{-} = c_var;
+let c_let_well_constrained : integer{0..10} = 5;
+
+let c_let_no_type_annotation = (x - 1) + y;
+let c_let_no_type_annotation_unconstrained_int = 5;
+let c_let_no_type_annotation_inherited_constrained = c_var;
+let c_let_no_type_annotation_well_constrained = 5;
+
+let c_let_large_constraint : integer{2^128..2^256} = 2^150;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UpdateGlobalStorage.config.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UpdateGlobalStorage.config.asl
@@ -1,0 +1,8 @@
+config i: integer = 1;
+config r: real = 1.0;
+config s: string = "hello";
+config b: boolean = TRUE;
+config bv: bits(8) = Zeros{8};
+
+type Color of enumeration {RED, GREEN, BLUE};
+config c: Color = RED;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UpdateGlobalStorage.config.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UpdateGlobalStorage.config.bad.asl
@@ -1,0 +1,3 @@
+type MyException of exception;
+// Illegal: only singular types can be used for config storage elements.
+config d: MyException = MyException{};

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UpdateGlobalStorage.constant.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UpdateGlobalStorage.constant.asl
@@ -1,0 +1,18 @@
+func factorial(x : integer) => integer
+begin
+    assert x >= 0;
+    var res : integer = 1;
+    for i = 1 to x do
+        res = res * i;
+    end;
+    return res;
+end;
+
+constant y = factorial(7);
+
+func main() => integer
+begin
+    var x = y;
+    println(y);
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -470,3 +470,18 @@ ASL Typing Tests / annotating types:
   ASL Error: Undefined identifier: 'MyInt'
   [1]
   $ aslref --no-exec TypingRule.DeclareConst.asl
+  $ aslref --no-exec TypingRule.DeclareGlobalStorage.asl
+  $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad1.asl
+  File TypingRule.DeclareGlobalStorage.bad1.asl, line 3, characters 0 to 29:
+  ASL Typing error: expected constant-time expression, got x as integer {1..5},
+    which produces the following side-effects: [ReadsGlobal "x"].
+  [1]
+  $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad2.asl
+  File TypingRule.DeclareGlobalStorage.bad2.asl, line 3, characters 0 to 29:
+  ASL Typing error: expected constant-time expression, got 2 as integer {1..5},
+    which produces the following side-effects: [ReadsGlobal "x"].
+  [1]
+  $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad3.asl
+  File TypingRule.DeclareGlobalStorage.bad3.asl, line 2, characters 37 to 38:
+  ASL Error: Cannot parse.
+  [1]

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -470,7 +470,7 @@ ASL Typing Tests / annotating types:
   ASL Error: Undefined identifier: 'MyInt'
   [1]
   $ aslref --no-exec TypingRule.DeclareConst.asl
-  $ aslref --no-exec TypingRule.DeclareGlobalStorage.asl
+  $ aslref --no-exec TypingRule.DeclareGlobalStorage.config.asl
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad1.asl
   File TypingRule.DeclareGlobalStorage.bad1.asl, line 3, characters 0 to 29:
   ASL Typing error: expected constant-time expression, got x as integer {1..5},
@@ -484,4 +484,12 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad3.asl
   File TypingRule.DeclareGlobalStorage.bad3.asl, line 2, characters 37 to 38:
   ASL Error: Cannot parse.
+  [1]
+  $ aslref --no-exec TypingRule.DeclareGlobalStorage.non_config.asl
+  $ aslref --no-exec TypingRule.UpdateGlobalStorage.constant.asl
+  $ aslref --no-exec TypingRule.UpdateGlobalStorage.config.asl
+  $ aslref --no-exec TypingRule.UpdateGlobalStorage.config.bad.asl
+  File TypingRule.UpdateGlobalStorage.config.bad.asl, line 3,
+    characters 0 to 38:
+  ASL Typing error: expected singular type, found MyException.
   [1]


### PR DESCRIPTION
* Added examples
* Addressed PDF review comments.
* Removed `try_add_global_constant` and inlined it.