### PR TITLE
[asl] remove check for multiple candidates for a call expression

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -305,7 +305,9 @@ module FunctionRenaming (C : ANNOTATE_CONFIG) = struct
         | V1 -> ([], name', func_sig, ses) |: TypingRule.SubprogramForName)
     | [] -> fatal_from ~loc (Error.NoCallCandidate (name, caller_arg_types))
     | _ :: _ ->
-        fatal_from ~loc (Error.TooManyCallCandidates (name, caller_arg_types))
+        (* If more than one candidate exists, the candidate signature should clash,
+           which is detected when typechecking the corresponding declarations. *)
+        assert false
   (* End *)
 
   let try_subprogram_for_name =
@@ -3729,12 +3731,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         in
         let _, _, func_sig', _ =
           try Fn.subprogram_for_name ~loc env V1 func_sig.name arg_types
-          with
-          | Error.(
-              ASLException
-                { desc = NoCallCandidate _ | TooManyCallCandidates _; _ })
-          ->
-            fail ()
+          with Error.(ASLException { desc = NoCallCandidate _ }) -> fail ()
         in
         (* Check that func_sig' is a getter *)
         let wanted_getter_type =

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1047,9 +1047,14 @@ cases holds:
 \begin{itemize}
   \item there is no declared subprogram that matches $\name$ and $\calleeargtypes$;
   \item there is exactly one subprogram that matches $\name$ and $\calleeargtypes$;
-  \item there is more than one subprogram that matches $\name$ and $\calleeargtypes$;
 \end{itemize}
-The first and last cases result in a \typingerrorterm{}.
+If more than one subprogram that matches $\name$ and $\calleeargtypes$,
+this is detected by the rule \TypingRuleRef{DeclareSubprograms},
+which invokes the rule \TypingRuleRef{DeclareOneFunc},
+which invokes the rule \TypingRuleRef{AddNewFunc},
+which results in a \typingerrorterm{}.
+
+The first case results in a \typingerrorterm{}.
 If the second case holds, the function returns a tuple which comprises:
 \begin{itemize}
 \item $\namep$ --- the string that uniquely identifies this subprogram;
@@ -1075,16 +1080,6 @@ If the second case holds, the function returns a tuple which comprises:
           in $\tenv$ (see \TypingRuleRef{FilterCallCandidates}) yields an empty set\ProseOrTypeError;
     \item the result is a \typingerrorterm{} indicating that the call given by $\name$ and \\ $\callerargtypes$
           does not match any defined subprogram.
-  \end{itemize}
-
-  \item \AllApplyCase{too\_many\_candidates}
-  \begin{itemize}
-    \item $\tenv$ binds $\name$ via $\overloadedsubprograms$ map to $\renamingset$ and $\vses$;
-    \item filtering the subprograms in $\renamingset$ with the caller argument types $\callerargtypes$
-          in $\tenv$ (see \TypingRuleRef{FilterCallCandidates}) yields $\matchingrenamings$\ProseOrTypeError;
-    \item $\matchingrenamings$ contains at least two elements;
-    \item the result is a \typingerrorterm{} indicating that the call given by $\name$ and \\
-          $\callerargtypes$ matches more than one defined subprogram.
   \end{itemize}
 
   \item \AllApplyCase{one\_candidate}
@@ -1113,20 +1108,6 @@ If the second case holds, the function returns a tuple which comprises:
       \filtercallcandidates(\tenv, \callerargtypes, \renamingset) \typearrow \emptyset \OrTypeError
     \end{array}
   }
-}{
-  \subprogramforname(\tenv, \name, \callerargtypes) \typearrow \TypeErrorVal{\BadCall}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[too\_many\_candidates]{
-  G^\tenv.\overloadedsubprograms(\name) = (\renamingset, \vses)\\
-  {
-    \begin{array}{r}
-      \filtercallcandidates(\tenv, \callerargtypes, \renamingset) \typearrow \\ \matchingrenamings \OrTypeError
-    \end{array}
-  }\\\\
-  \cardinality{\matchingrenamings} \geq 2
 }{
   \subprogramforname(\tenv, \name, \callerargtypes) \typearrow \TypeErrorVal{\BadCall}
 }

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -51,7 +51,6 @@ type error_desc =
   | CannotParse
   | UnknownSymbol
   | NoCallCandidate of string * ty list
-  | TooManyCallCandidates of string * ty list
   | BadTypesForBinop of binop * ty * ty
   | CircularDeclarations of string
   | ImpureExpression of expr * SideEffect.SES.t
@@ -170,7 +169,6 @@ let error_label = function
   | CannotParse -> "CannotParse"
   | UnknownSymbol -> "UnknownSymbol"
   | NoCallCandidate _ -> "NoCallCandidate"
-  | TooManyCallCandidates _ -> "TooManyCallCandidates"
   | BadTypesForBinop _ -> "BadTypesForBinop"
   | CircularDeclarations _ -> "CircularDeclarations"
   | ImpureExpression _ -> "ImpureExpression"
@@ -340,11 +338,6 @@ module PPrint = struct
     | NoCallCandidate (name, types) ->
         fprintf f
           "ASL Typing error: No subprogram declaration matches the \
-           invocation:@ %s(%a)."
-          name (pp_comma_list pp_ty) types
-    | TooManyCallCandidates (name, types) ->
-        fprintf f
-          "ASL Typing error: Too many subprogram declaration match the \
            invocation:@ %s(%a)."
           name (pp_comma_list pp_ty) types
     | BadTypesForBinop (op, t1, t2) ->


### PR DESCRIPTION
The typechecker used to check that a given call expression matches at most one subprogram and emit a typing error if more than one candidate subprogram matches the call expression. However, if two candidate subprograms exist, it would mean their signatures clash, which would be detected upon their declaration.

This PR removes the check and adds an explanation to the ASL Reference why this check is not needed.