### PR TITLE
[all] Add CTERM{EQ,NE} instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,20 @@ test.sve::
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64 SVE instructions tests: OK"
 
+test:: test.asl.sve
+test-local:: test.asl.sve
+test.asl.sve: asl-pseudocode
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-j $(J) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/AArch64.sve \
+		-variant sve \
+		-conf  ./herd/tests/instructions/AArch64.sve/asl.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64 ASL SVE instructions tests: OK"
+
 test:: test.sme
 test-local:: test.sme
 test.sme::

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -116,7 +116,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
     | I_MOV_SV _
     | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
-    | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
+    | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _ | I_CTERM _
     | I_DUP_SV _ | I_ADD_SV _ | I_PTRUE _
     | I_NEG_SV _ | I_OP3_SV _ | I_MOVPRFX _
     | I_SMSTART _ | I_SMSTOP _ | I_LD1SPT _ | I_ST1SPT _
@@ -321,7 +321,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_MOV_SV _ | I_DUP_SV _ | I_ADD_SV _ | I_PTRUE _
       | I_NEG_SV _ | I_MOVPRFX _ | I_OP3_SV _
       | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
-      | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
+      | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _ | I_CTERM _
       | I_SMSTART _ | I_SMSTOP _ | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
       | I_PAC _ | I_AUT _ | I_XPACI _ | I_XPACD _
           -> None
@@ -359,7 +359,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_NOP|I_TBZ _|I_TBNZ _
       | I_BL _ | I_BLR _ | I_RET _ | I_ERET | I_SVC _ | I_UDF _
       | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
-      | I_ST1SPT _
+      | I_ST1SPT _ | I_CTERM _
         -> [] (* For -variant self only ? *)
       | I_LDR (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
       | I_LDRBH (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
@@ -493,7 +493,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_NEG_SV _ | I_MOVPRFX _ | I_OP3_SV _
       | I_MOV_SV _ | I_DUP_SV _
       | I_INDEX_SI _ | I_INDEX_IS _ | I_INDEX_SS _ | I_INDEX_II _
-      | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
+      | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _ | I_CTERM _
       | I_SMSTART _ | I_SMSTOP _
       | I_LD1SPT _ | I_ST1SPT _
       | I_MOVA_TV _| I_MOVA_VT _ | I_ADDA _

--- a/herd/libdir/asl-pseudocode/patches.asl
+++ b/herd/libdir/asl-pseudocode/patches.asl
@@ -274,3 +274,14 @@ func MemSingleGranule() => integer
     return size;
   end;
 
+// CheckOriginalSVEEnabled()
+// =========================
+// Checks for traps on SVE instructions and instructions that access SVE System
+// registers.
+// LUC, just allow
+
+func CheckOriginalSVEEnabled()
+begin
+  return;
+end;
+

--- a/herd/tests/instructions/AArch64.sve/V32.litmus
+++ b/herd/tests/instructions/AArch64.sve/V32.litmus
@@ -1,0 +1,16 @@
+AArch64 V32
+{
+int x=1;
+0:X0=x;
+uint64_t 0:X3;
+uint64_t 0:X4;
+}
+  P0           ;
+ MSR NZCV,XZR  ;
+ LDR W1,[X0]   ;
+ CTERMEQ W1,W2 ;
+ MRS X3,NZCV   ;
+ CTERMNE W1,W2 ;
+ MRS X4,NZCV   ;
+
+forall 0:X3=0x10000000 /\ 0:X4=0x80000000

--- a/herd/tests/instructions/AArch64.sve/V32.litmus.expected
+++ b/herd/tests/instructions/AArch64.sve/V32.litmus.expected
@@ -1,0 +1,11 @@
+Test V32 Required
+States 1
+0:X3=268435456; 0:X4=2147483648;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Scalable-Vector-Extensions-is-work-in-progress
+Condition forall (0:X3=268435456 /\ 0:X4=2147483648)
+Observation V32 Always 1 0
+Hash=5243803bc7f067763d465df67b76fa7a
+

--- a/herd/tests/instructions/AArch64.sve/V33.litmus
+++ b/herd/tests/instructions/AArch64.sve/V33.litmus
@@ -1,0 +1,16 @@
+AArch64 V33
+(* Allowed. as CTERM sets PSTATE.N,
+   overwritting the value written by CMP *)
+{
+0:X1=x; 0:X3=y;
+1:X0=y; 1:X2=x;
+}
+ P0           | P1             ;
+ MOV W0,#1    | LDR W1,[X0]    ;
+ STR W0,[X1]  | CMP W1,WZR     ;
+ MOV W2,#1    | CTERMEQ W4,WZR ;
+ STLR W2,[X3] | B.PL L1        ;
+              | ISB            ;
+              | LDR W6,[X2]    ;
+              |L1:             ;
+exists (1:X1=1 /\ 1:X6=0)

--- a/herd/tests/instructions/AArch64.sve/V33.litmus.expected
+++ b/herd/tests/instructions/AArch64.sve/V33.litmus.expected
@@ -1,0 +1,14 @@
+Test V33 Allowed
+States 4
+1:X1=0; 1:X6=0;
+1:X1=0; 1:X6=1;
+1:X1=1; 1:X6=0;
+1:X1=1; 1:X6=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Flag Scalable-Vector-Extensions-is-work-in-progress
+Condition exists (1:X1=1 /\ 1:X6=0)
+Observation V33 Sometimes 1 3
+Hash=915bafc00284d7bda6bae357bdfc48ee
+

--- a/herd/tests/instructions/AArch64.sve/V34.litmus
+++ b/herd/tests/instructions/AArch64.sve/V34.litmus
@@ -1,0 +1,18 @@
+AArch64 V34
+(* Forbidden, as
+   B.VS  reads PSTATE.V avlue  written
+   by CTERMNE as the negation of
+   PSTATE.C value set by CMP *)
+{
+0:X1=x; 0:X3=y;
+1:X0=y; 1:X2=x;
+}
+ P0           | P1             ;
+ MOV W0,#1    | LDR W1,[X0]    ;
+ STR W0,[X1]  | CMP W1,WZR     ;
+ MOV W2,#1    | CTERMNE W4,WZR ;
+ STLR W2,[X3] | B.VS L1        ;
+              | ISB            ;
+              | LDR W6,[X2]    ;
+              |L1:             ;
+~exists (1:X1=1 /\ 1:X6=0)

--- a/herd/tests/instructions/AArch64.sve/V34.litmus.expected
+++ b/herd/tests/instructions/AArch64.sve/V34.litmus.expected
@@ -1,0 +1,13 @@
+Test V34 Forbidden
+States 3
+1:X1=0; 1:X6=0;
+1:X1=0; 1:X6=1;
+1:X1=1; 1:X6=1;
+Ok
+Witnesses
+Positive: 3 Negative: 0
+Flag Scalable-Vector-Extensions-is-work-in-progress
+Condition ~exists (1:X1=1 /\ 1:X6=0)
+Observation V34 Never 0 3
+Hash=1f30fab72ebb595f711d8e383dd94a1f
+

--- a/herd/tests/instructions/AArch64.sve/asl.cfg
+++ b/herd/tests/instructions/AArch64.sve/asl.cfg
@@ -1,0 +1,2 @@
+variant asl,sve
+oknames V32,V33,V34

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -694,7 +694,7 @@ include Arch.MakeArch(struct
     | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
     | I_MOV_SV _ | I_PTRUE _
     | I_INDEX_SI _ | I_INDEX_IS _  | I_INDEX_SS _ | I_INDEX_II _
-    | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _
+    | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _ | I_CTERM _
     -> Warn.fatal "SVE instructions are not implemented yet"
     | I_SMSTART _ | I_SMSTOP _ | I_LD1SPT _ | I_ST1SPT _
     | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -248,7 +248,9 @@ match name with
 | "mul3" | "MUL3" -> TOK_MUL3
 | "all" | "ALL" -> TOK_ALL
 | "movprfx" | "MOVPRFX" -> MOVPRFX
-(* Scalabel Matrix Extension *)
+| "ctermeq"|"CTERMEQ" -> CTERM AArch64Base.CTERM.EQ
+| "ctermne"|"CTERMNE" -> CTERM AArch64Base.CTERM.NE
+(* Scalable Matrix Extension *)
 | "addva" | "ADDVA" -> ADDA (AArch64Base.Vertical)
 | "addha" | "ADDHA" -> ADDA (AArch64Base.Horizontal)
 | "mova" | "MOVA" -> MOVA

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -138,6 +138,7 @@ let check_op3 op e =
 %token <AArch64Base.cnt_inc_op_variant> CNT_INC_SVE
 %token <AArch64Base.adda_op_variant> ADDA
 %token SMSTART SMSTOP TOK_SM TOK_ZA MOVA
+%token <AArch64Base.CTERM.cond> CTERM
 /*
 /*
 %token LDUMAX LDUMAXA LDUMAXL LDUMAXAL LDUMAXH LDUMAXAH LDUMAXLH LDUMAXALH
@@ -1079,6 +1080,10 @@ instr:
   { I_NEG_SV ($2,$4,$6) }
 | MOVPRFX zreg COMMA pmreg COMMA zreg
   { I_MOVPRFX ($2,$4,$6) }
+| CTERM xreg COMMA xreg
+  { I_CTERM ($1,V64,$2,$4) }
+| CTERM wreg COMMA wreg
+  { I_CTERM ($1,V32,$2,$4) }
 /* Scalable Matrix Extention */
 | SMSTART smopt
   { I_SMSTART $2}

--- a/lib/ASLScalar.ml
+++ b/lib/ASLScalar.ml
@@ -212,15 +212,22 @@ let abs = function
 
 let shift_left = function
   | S_Int i -> fun k -> S_Int (Z.shift_left i k)
-  | s1 -> Warn.fatal "ASLScalar invalid op: %s shift_left" (pp false s1)
+  | s1 ->
+      Warn.fatal "ASLScalar invalid op: %s (shift_left %d)" (pp false s1)
 
-let shift_right_logical s1 _k =
-  Warn.fatal "ASLScalar invalid op: %s shift_right_logical" (pp false s1)
+let shift_right_logical = function
+  | S_Int i  when Z.sign i >= 0 -> fun k -> S_Int (Z.shift_right i k)
+  | s1 ->
+      Warn.fatal
+        "ASLScalar invalid op: %s (shift_right_logical %d)"
+        (pp false s1)
 
 let shift_right_arithmetic = function
   | S_Int i -> fun k -> S_Int (Z.shift_right i k)
   | s1 ->
-      Warn.fatal "ASLScalar invalid op: %s shift_right_arithmetic" (pp false s1)
+      Warn.fatal
+        "ASLScalar invalid op: %s shift_right_arithmetic %d"
+        (pp false s1)
 
 let addk = function
 | S_Int i -> fun k -> S_Int (Z.add i (Z.of_int k))

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1286,6 +1286,12 @@ module Make(V:Constant.S)(C:Config) =
            | INC -> rd);
         reg_env = add_q rd; }
 
+    let cterm cond v r1 r2 =
+       let rs,f1,f2 = do_arg2i v r1 r2 0 in
+       { empty_ins with
+         memo = sprintf "%s %s,%s" (CTERM.pp cond |> Misc.lowercase) f1 f2;
+         inputs = rs; reg_env = add_v v rs; }
+
     let adda s rD p1 p2 rS =
       { empty_ins with
         memo = sprintf "add%sa %s,%s,%s,%s"
@@ -1864,6 +1870,7 @@ module Make(V:Constant.S)(C:Config) =
     | I_RDVL (r1,k1) -> rdvl r1 k1::k
     | I_ADDVL (r1,r2,k1) -> addvl r1 r2 k1::k
     | I_CNT_INC_SVE  (op,rd,pat,k1) -> cnt_inc_sve op rd pat k1::k
+    | I_CTERM (cond,v,rn,rm) -> cterm cond v rn rm::k
 (* Scalable Matrix Extension *)
     | I_LD1SPT (v,r,ri,k1,p,ra,idx) -> ld1spt v r ri k1 p ra idx::k
     | I_ST1SPT (v,r,ri,k1,p,ra,idx) -> st1spt v r ri k1 p ra idx::k


### PR DESCRIPTION
These SVE instructions are special as they alter some of the NZCV "flags" but not all of them. 