### PR TITLE
Link ASLRef to Arm's ASL specs webpage

### DIFF
--- a/asllib/README.mld
+++ b/asllib/README.mld
@@ -1,18 +1,20 @@
 {0 Getting started with ASLRef}
 
 {1 Disclaimer}
-This material covers both ASLv0 (viz, the existing ASL pseudocode language
-which appears in the Arm Architecture Reference Manual) and ASLv1, a new,
-experimental, and as yet unreleased version of ASL.
+This material covers:
 
-This material is work in progress, more precisely at pre-Alpha quality as
+- ASLv0, viz the existing ASL pseudocode language which appears in the Arm Architecture Reference Manual:
+{:https://developer.arm.com/documentation/ddi0487/latest}
+- ASLv1, a new, experimental, and as yet unreleased version of ASL. In addition to making contributions to
+this repository, Arm officially maintains and regularly releases the ASL Reference Specification for ASLv1 at
+{:https://developer.arm.com/Architectures/Architecture%20Specification%20Language}
+
+This material is work in progress, more precisely at Alpha quality as
 per Arm’s quality standards. In particular, this means that it would be
 premature to base any production tool development on this material.
 
-However, any feedback, question, query and feature request would be most
-welcome; those can be sent to Arm’s Architecture Formal Team Lead Jade
-Alglave <jade.alglave@arm.com> or by raising issues or PRs to the herdtools7
-github repository.
+We welcome feedback, questions, and feature requests — please contact us by writing
+to {{:mailto:atg-formal@arm.com}atg-formal@arm.com} or raise issues and pull requests to the herdtools7 GitHub repository.
 
 {1 Installation}
 

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -33,6 +33,7 @@ achieves
 across
 act
 action
+actively
 actual
 adapt
 add
@@ -432,6 +433,7 @@ constructing
 construction
 constructively
 constructs
+contact
 contain
 contained
 containing
@@ -443,6 +445,7 @@ continue
 continues
 continuing
 contrast
+contributes
 control
 convenient
 convention
@@ -1477,6 +1480,7 @@ provide
 provided
 provides
 prs
+pull
 punctuation
 pure
 purity
@@ -1552,6 +1556,7 @@ relations
 relationship
 relative
 relatively
+release
 relevant
 reliable
 relied
@@ -1587,6 +1592,7 @@ representing
 represents
 reproduced
 request
+requests
 require
 required
 requirement
@@ -2100,6 +2106,7 @@ was
 way
 ways
 we
+welcome
 well
 were
 what

--- a/asllib/doc/disclaimer.tex
+++ b/asllib/doc/disclaimer.tex
@@ -1,23 +1,18 @@
 \chapter{Disclaimer}
 
-This document is part of the ASLRef material.
+This document is part of the ASLRef material, maintained in the
+\href{https://github.com/herd/herdtools7}{herdtools7 GitHub repository}.
 
 This material covers ASLv1, a new, experimental, and as yet unreleased version of ASL.
-
-The development version of ASLRef can be found here: \\
+In addition to the release of this document, Arm actively contributes to
 \url{https://github.com/herd/herdtools7}.
-
-A list of open items being worked on can be found in \appendixref{UnimplementedInASLRef}
-and \appendixref{MissingTransliteration}.
-% here: \\
-% \url{https://github.com/herd/herdtools7/blob/master/asllib/doc/ASLRefProgress.tex}.
 
 This material is work in progress, more precisely at Alpha quality as
 per Arm’s quality standards. In particular, this means that it would be
 premature to base any production tool development on this material.
+A list of open items being worked on can be found in \appendixref{UnimplementedInASLRef}
+and \appendixref{MissingTransliteration}.
 
-However, any feedback, question, query and feature request would be most
-welcome; those can be sent to Arm’s Architecture Formal Team
-(\href{mailto:atg-formal@arm.com}{\tt atg-formal@arm.com})
-or by raising issues or PRs to the
-\href{https://github.com/herd/herdtools7}{herdtools7 github repository}.
+We welcome feedback, questions, and feature requests — please contact us by writing
+to (\href{mailto:atg-formal@arm.com}{\tt atg-formal@arm.com}) or raise issues and
+pull requests to the \href{https://github.com/herd/herdtools7}{herdtools7 GitHub repository}.


### PR DESCRIPTION
As requested by some people, adding links on ASLRef to where the transliterated specs are published.