### PR TITLE
[asl] simplified case matching for handling annotated slices

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -2220,6 +2220,7 @@
 \newcommand\ldk[0]{\texttt{ldk}}
 \newcommand\length[0]{\texttt{length}}
 \newcommand\lengthp[0]{\texttt{length'}}
+\newcommand\offset[0]{\texttt{offset}}
 \newcommand\lenv[0]{\texttt{lenv}}
 \newcommand\lenvtwo[0]{\texttt{lenv2}}
 \newcommand\les[0]{\texttt{les}}

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -574,6 +574,9 @@ returns the set of integers defined by the bitfield slice $\vslice$ in $\positio
 if they can be statically evaluated, or $\None$ if they cannot be statically evaluated.
 \ProseOtherwiseTypeError
 
+The function assumes that AST nodes labelled with $\SliceSingle$, $\SliceRange$, and $\SliceStar$ have been reduced
+to $\SliceLength$ (via $\annotateslices$).
+
 \ExampleDef{Converting Bitfield Slices to Positions}
 \taref{bitfieldslicetopositions} shows the optional set of positions associated with each slice
 in \listingref{bitfieldslicetopositions}, followed by examples of erroneous slices.
@@ -590,93 +593,34 @@ in \listingref{bitfieldslicetopositions}, followed by examples of erroneous slic
   \hline
   \verb|0:3|  & $\BadSlices$\\
   \verb|5+:0| & $\BadSlices$\\
-  \verb|0*:4| & $\BadSlices$\\
+  \verb|4*:0| & $\BadSlices$\\
 \end{tabular}
 \end{table}
 
 \ASLListing{Converting bitfield slices to positions}{bitfieldslicetopositions}{\typingtests/TypingRule.BitfieldSliceToPositions.asl}
 
 \ProseParagraph
-\OneApplies
+\AllApply
 \begin{itemize}
-  \item \AllApplyCase{single}
-  \begin{itemize}
-    \item $\vslice$ is a \singleslice\ defined by the expression $\ve$, that is, $\SliceSingle(\ve)$;
-    \item applying $\reducetozopt$ to $\ve$ in $\tenv$ yields the integer literal for $\vx$\ProseTerminateAs{\None};
-    \item $\positions$ is the singleton set for $\vx$.
-  \end{itemize}
-
-  \item \AllApplyCase{range}
-  \begin{itemize}
-    \item $\vslice$ is \rangeslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
-          $\SliceRange(\veone, \vetwo)$;
-    \item applying $\reducetozopt$ to $\veone$ in $\tenv$ yields the integer literal for $\vx$\ProseTerminateAs{\None};
-    \item applying $\reducetozopt$ to $\vetwo$ in $\tenv$ yields the integer literal for $\vy$\ProseTerminateAs{\None};
-    \item checking that $\vx$ is less than or equal to $\vy$ yields $\True$\ProseTerminateAs{\BadSlices};
-    \item $\positions$ is the set of integers between $\vx$ and $\vy$, inclusive.
-  \end{itemize}
-
-  \item \AllApplyCase{length}
-  \begin{itemize}
-    \item $\vslice$ is \lengthslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
-          $\SliceLength(\veone, \vetwo)$;
-    \item applying $\reducetozopt$ to $\veone$ in $\tenv$ yields the integer literal for $\vx$\ProseTerminateAs{\None};
-    \item applying $\reducetozopt$ to $\vetwo$ in $\tenv$ yields the integer literal for $\vy$\ProseTerminateAs{\None};
-    \item checking that $\vy > 0$ holds (which implies that $\vx \leq \vx+\vy-1$ holds) yields $\True$\ProseTerminateAs{\BadSlices};
-    \item $\positions$ is the set of integers between $\vx$ and $\vx+\vy-1$, inclusive.
-  \end{itemize}
-
-  \item \AllApplyCase{scaled}
-  \begin{itemize}
-    \item $\vslice$ is \scaledslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
-          $\SliceStar(\veone, \vetwo)$;
-    \item applying $\reducetozopt$ to $\veone$ in $\tenv$ yields the integer literal for $\vx$\ProseTerminateAs{\None};
-    \item applying $\reducetozopt$ to $\vetwo$ in $\tenv$ yields the integer literal for $\vy$\ProseTerminateAs{\None};
-    \item checking that $\vx > 0$ holds (which implies that $\vx \times \vy \leq \vx \times (\vy + 1) - 1$ holds) yields $\True$\ProseTerminateAs{\BadSlices};
-    \item $\positions$ is the set of integers between $\vx \times \vy$ and $\vx \times (\vy + 1) - 1$, inclusive.
-  \end{itemize}
+  \item $\vslice$ is \lengthslice\ defined by expressions $\veone$ and $\vetwo$, that is, \\
+        $\SliceLength(\veone, \vetwo)$;
+  \item applying $\reducetozopt$ to $\veone$ in $\tenv$ yields the integer literal for $\offset$\ProseTerminateAs{\None};
+  \item applying $\reducetozopt$ to $\vetwo$ in $\tenv$ yields the integer literal for $\length$\ProseTerminateAs{\None};
+  \item checking that $\offset$ is less than or equal to $\offset + \length - 1$ holds yields $\True$\ProseTerminateAs{\BadSlices};
+  \item $\positions$ is the set of integers between $\offset$ and $\offset+\length-1$, inclusive.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[single]{
-  \reducetozopt(\tenv, \ve) \typearrow \langle\vx\rangle \terminateas\None
-}{
-  \bitfieldslicetopositions(\tenv, \overname{\SliceSingle(\ve)}{\vslice}) \typearrow \overname{\langle\{\vx\}\rangle}{\positions}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[range]{
-  \reducetozopt(\tenv, \veone) \typearrow \langle\vx\rangle \terminateas\None\\\\
-  \reducetozopt(\tenv, \vetwo) \typearrow \langle\vy\rangle \terminateas\None\\\\
-  \checktrans{\vy \leq \vx}{\BadSlices} \checktransarrow \True \OrTypeError\\\\
-}{
-  \bitfieldslicetopositions(\tenv, \overname{\SliceRange(\veone, \vetwo)}{\vslice}) \typearrow
-  \overname{\langle\{n \;|\; \vy \leq n \leq \vx\}\rangle}{\positions}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[length]{
-  \reducetozopt(\tenv, \veone) \typearrow \langle\vx\rangle \terminateas\None\\\\
-  \reducetozopt(\tenv, \vetwo) \typearrow \langle\vy\rangle \terminateas\None\\\\
-  \checktrans{\vy > 0}{\BadSlices} \checktransarrow \True \OrTypeError\\\\
-}{
-  \bitfieldslicetopositions(\tenv, \overname{\SliceLength(\veone, \vetwo)}{\vslice}) \typearrow
-  \overname{\langle\{n \;|\; \vx \leq n \leq \vx+\vy-1\}\rangle}{\positions}
-}
-\end{mathpar}
-\begin{mathpar}
-
-\inferrule[scaled]{
-  \reducetozopt(\tenv, \veone) \typearrow \langle\vx\rangle \terminateas\None\\\\
-  \reducetozopt(\tenv, \vetwo) \typearrow \langle\vy\rangle \terminateas\None\\\\
-  \checktrans{\vx > 0}{\BadSlices} \checktransarrow \True \OrTypeError
+\inferrule{
+  \reducetozopt(\tenv, \veone) \typearrow \langle\offset\rangle \terminateas\None\\\\
+  \reducetozopt(\tenv, \vetwo) \typearrow \langle\length\rangle \terminateas\None\\\\
+  \checktrans{\offset \leq \offset + \length - 1}{\BadSlices} \checktransarrow \True \OrTypeError
 }{
   {
   \begin{array}{r}
-  \bitfieldslicetopositions(\tenv, \overname{\SliceStar(\veone, \vetwo)}{\vslice}) \typearrow \\
-  \overname{\langle\{n \;|\; \vx \times \vy \leq n \leq \vx \times (\vy + 1) - 1\}\rangle}{\positions}
+  \bitfieldslicetopositions(\tenv, \overname{\SliceLength(\veone, \vetwo)}{\vslice}) \typearrow\\
+  \overname{\langle\{n \;|\; \offset \leq n \leq \offset+\length-1\}\rangle}{\positions}
   \end{array}
   }
 }


### PR DESCRIPTION
Simplified `interval_of_slice` and `to_singles` in `Typing.ml` by removing the cases for `Slice_Single`, `Slice_Range`, and `Slice_Star`. This is okay, since these functions are applied on annotated slices, which have all been converted to `Slice_Length`.