### PR TITLE
[asl] add the recurselimit expression as a used expression

### DIFF
--- a/asllib/DependencyAnalysis.ml
+++ b/asllib/DependencyAnalysis.ml
@@ -164,12 +164,20 @@ and use_decl d =
   | D_GlobalStorage { initial_value; ty; name = _; keyword = _ } ->
       use_option use_e initial_value $ use_option use_ty ty
   | D_Func
-      { body; name = _; args; return_type; parameters; subprogram_type = _ }
-    -> (
+      {
+        body;
+        name = _;
+        args;
+        return_type;
+        parameters;
+        subprogram_type = _;
+        recurse_limit;
+      } ->
       use_named_list use_ty args
       $ use_option use_ty return_type
       $ use_named_list (use_option use_ty) parameters
-      $ match body with SB_ASL s -> use_s s | SB_Primitive _ -> Fun.id)
+      $ (match body with SB_ASL s -> use_s s | SB_Primitive _ -> Fun.id)
+      $ use_option use_e recurse_limit
   | D_Pragma (name, args) -> NameSet.add (Other name) $ use_es args
 
 and use_subtypes (x, subfields) =

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -1136,10 +1136,11 @@ used by each global declaration via comments above it.
   \item \AllApplyCase{D\_Func}
   \begin{itemize}
     \item $\vd$ declares a subprogram with arguments $\vargs$, \optional\ return type \\
-          $\rettyopt$, parameters $\vparams$, and body statement $\body$;
+          $\rettyopt$, parameters $\vparams$, body statement $\body$, and optional recursion limit expression $\vrecurselimit$;
     \item define $\ids$ as the union of applying $\usety$ to each type of an argument in $\vargs$,
           applying $\usety$ to $\rettyopt$, applying $\usety$ to each type of a parameter in $\vparams$,
-          and applying $\usestmt$ to $\body$.
+          applying $\usestmt$ to $\body$,
+          and applying $\useexpr$ to $\vrecurselimit$.
   \end{itemize}
 \end{itemize}
 
@@ -1164,7 +1165,8 @@ used by each global declaration via comments above it.
   \ids &\eqdef& \{ (\Ignore, \vt) \in \vargs : \usety(\vt) \} &\cup\\
   && \usety(\rettyopt) &\cup\\
   && \{ (\Ignore, \vt) \in \vparams : \usety(\vt) \} &\cup \\
-  && \usestmt(\body) &
+  && \usestmt(\body) &\cup\\
+  && \useexpr(\vrecurselimit) &
     \end{array}
   }
 }{
@@ -1177,6 +1179,7 @@ used by each global declaration via comments above it.
     \funcargs: \vargs,\\
     \funcreturntype: \rettyopt,\\
     \funcparameters: \vparams,\\
+    \funcrecurselimit: \vrecurselimit,\\
     \ldots\\
     \end{array}
   \right\}


### PR DESCRIPTION
The recursion limit expression should be considered as a "used expression" for a subprogram declaration.
An example will be added to https://github.com/herd/herdtools7/pull/1249

* Updated implementation
* Updated ASL Reference