### PR TITLE
ASL-716 accessibility enhancements phase 15: examples and fixes

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1102,8 +1102,8 @@
 \newcommand\evalforloop[0]{\hyperlink{def-evalforloop}{\textfunc{eval\_for\_loop}}}
 \newcommand\evalforstep[0]{\hyperlink{def-evalforstep}{\textfunc{eval\_for\_step}}}
 \newcommand\evalcatchers[1]{\hyperlink{def-evalcatchers}{\textfunc{eval\_catchers}}(#1)}
-\newcommand\evalsubprogram[1]{\hyperlink{def-evalsubprogram}{\textfunc{eval\_subprogram}}(#1)}
-\newcommand\evalcall[1]{\hyperlink{def-evalcall}{\textfunc{eval\_call}}(#1)}
+\newcommand\evalsubprogram[0]{\hyperlink{def-evalsubprogram}{\textfunc{eval\_subprogram}}}
+\newcommand\evalcall[0]{\hyperlink{def-evalcall}{\textfunc{eval\_call}}}
 \newcommand\evalmultiassignment[0]{\hyperlink{def-evalmultiassign}{\textfunc{multi\_assign}}}
 \newcommand\rethrowimplicit[0]{\hyperlink{def-rethrowimplicit}{\textfunc{rethrow\_implicit}}}
 \newcommand\assignargs[0]{\hyperlink{def-assignargs}{\textfunc{assign\_args}}}

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -662,9 +662,7 @@ Specifically, the \absoluteslice\ for the bitfield \texttt{common} is \texttt{[1
 whereas the \absoluteslice\ for the bitfield \texttt{sub.common} is \texttt{[0, 1]}.
 Typechecking this example results in the \typingerrorterm{} \BadSlices.
 
-\ASLListing{An example where two bitfields of the same name (\texttt{common}) exist in the same scope
-but have different absolute slices}
-{CommonBitfieldsAlignError}{\typingtests/TypingRule.CheckCommonBitfieldsAlign.Error.asl}
+\ASLListing{An example where two bitfields of the same name (\texttt{common}) exist in the same scope but have different absolute slices}{CommonBitfieldsAlignError}{\typingtests/TypingRule.CheckCommonBitfieldsAlign.Error.asl}
 
 \ProseParagraph
 \OneApplies

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -1126,7 +1126,7 @@ and the values they evaluate to, as assertions on the values assigned.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[single\_returned\_value]{
-  \evalcall{\env, \vcall.\name, \vcall.\params, \vcall.\args} \evalarrow \Normal(\vms, \newenv) \OrAbnormal\\
+  \evalcall(\env, \vcall.\name, \vcall.\params, \vcall.\args) \evalarrow \Normal(\vms, \newenv) \OrAbnormal\\
   \vms \eqname [(\vv, \vg)]
 }{
   \evalexpr{\env, \ECall(\vcall)} \evalarrow \Normal((\vv, \vg), \newenv)
@@ -1135,7 +1135,7 @@ and the values they evaluate to, as assertions on the values assigned.
 
 \begin{mathpar}
 \inferrule[multiple\_returned\_values]{
-  \evalcall{\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs} \evalarrow \Normal(\vms, \newenv) \OrAbnormal\\
+  \evalcall(\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs) \evalarrow \Normal(\vms, \newenv) \OrAbnormal\\
   \vms \eqname [i=1..k: (\vv_i, \vg_i)]\\
   \vg \eqdef \vg_1 \parallelcomp \ldots \parallelcomp \vg_k \\
   \vv \eqdef \nvvector{\vv_{1..k}}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -2917,7 +2917,7 @@ Note that there are two important consequences of producing an arbitrary value w
 \TypingRuleDef{EArbitrary}
 \ExampleDef{Well-typed Arbitrary Value Expressions}
 \listingref{typing-arbitrary} show examples of well-typed arbitrary value expressions.
-\ASLListing{Well-typed arbirary value expressions}{typing-arbitrary}{\typingtests/TypingRule.EArbitrary.asl}
+\ASLListing{Well-typed arbitrary value expressions}{typing-arbitrary}{\typingtests/TypingRule.EArbitrary.asl}
 
 \ProseParagraph
 \AllApply
@@ -2951,7 +2951,7 @@ the expression \verb|ARBITRARY : integer| evaluates to an arbitrary integer valu
 \ASLListing{Evaluating an \texttt{ARBITRARY} expression for an unconstrained integer}{semantics-earbitraryunconstrained}
 {\semanticstests/SemanticsRule.EArbitraryInteger3.asl}
 
-\subsubsection{Evaluation of ARBITRARY for a Costrained Integer Type}
+\subsubsection{Evaluation of ARBITRARY for a Constrained Integer Type}
 In \listingref{semantics-earbitraryconstrained},
 the expression \verb|ARBITRARY : integer {3, 42}| evaluates to either \\
 $\nvint(3)$ or $\nvint(42)$.

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -231,7 +231,7 @@ yielding a modified global static environment $\newgenv$ and annotated global st
 \listingref{DeclareGlobalStorage-config} shows examples of well-typed global storage declarations
 and ill-typed global storage declarations in comments,
 focused on \verb|config| storage elements.
-\ASLListing{Config storage elements}{DeclareGlobalStorage-config}{\typingtests/TypingRule.DeclareGlobalStorage.config.asl}
+\ASLListing{Configuration storage elements}{DeclareGlobalStorage-config}{\typingtests/TypingRule.DeclareGlobalStorage.config.asl}
 
 \listingref{DeclareGlobalStorage-non-config} shows examples of well-typed global storage declarations,
 and ill-typed global storage declarations in comments,
@@ -240,7 +240,7 @@ focused on storage elements that are not \verb|config|.
 
 The specification in \listingref{DeclareGlobalStorage-bad3} is illegal since
 \texttt{config} storage elements must have an initializing expression.
-\ASLListing{Uninitialized config declaration}{DeclareGlobalStorage-bad3}{\typingtests/TypingRule.DeclareGlobalStorage.bad3.asl}
+\ASLListing{Uninitialized configuration storage declaration}{DeclareGlobalStorage-bad3}{\typingtests/TypingRule.DeclareGlobalStorage.bad3.asl}
 
 The specifications in \listingref{DeclareGlobalStorage-bad1} and \listingref{DeclareGlobalStorage-bad2}
 are ill-typed since
@@ -248,8 +248,8 @@ are ill-typed since
 which requires that all expressions used in its type annotation and initializing expression
 also have the $\timeframeconstant$ \timeframeterm,
 whereas \verb|b| has the $\timeframeexecution$ \timeframeterm.
-\ASLListing{Ill-typed config declaration}{DeclareGlobalStorage-bad1}{\typingtests/TypingRule.DeclareGlobalStorage.bad1.asl}
-\ASLListing{Ill-typed config declaration}{DeclareGlobalStorage-bad2}{\typingtests/TypingRule.DeclareGlobalStorage.bad2.asl}
+\ASLListing{Ill-typed configuration storage declaration}{DeclareGlobalStorage-bad1}{\typingtests/TypingRule.DeclareGlobalStorage.bad1.asl}
+\ASLListing{Ill-typed configuration storage declaration}{DeclareGlobalStorage-bad2}{\typingtests/TypingRule.DeclareGlobalStorage.bad2.asl}
 
 See \ExampleRef{Rejected Declaration Because of Precision Loss} for an example
 of an ill-typed global storage declaration due to precision loss.
@@ -530,11 +530,11 @@ binds $\vy$ to $\lint(5040)$ in the $\constantvalues$ map of the global static e
 \ExampleDef{Updating the Global Storage for Configuration Storage Elements}
 The specification in \listingref{UpdateGlobalStorage-config}
 shows well-typed global storage \texttt{config} elements.
-\ASLListing{Updating the global storage for config storage elements}{UpdateGlobalStorage-config}{\typingtests/TypingRule.UpdateGlobalStorage.config.asl}
+\ASLListing{Updating the global storage for configuration storage elements}{UpdateGlobalStorage-config}{\typingtests/TypingRule.UpdateGlobalStorage.config.asl}
 
 The specification in \listingref{UpdateGlobalStorage-config-bad}
 is ill-typed, since only a \Prosesingulartype{} can be used for \texttt{config} storage elements.
-\ASLListing{An ill-typed global storage config storage element}{UpdateGlobalStorage-config-bad}{\typingtests/TypingRule.UpdateGlobalStorage.config.bad.asl}
+\ASLListing{An ill-typed configuration storage element}{UpdateGlobalStorage-config-bad}{\typingtests/TypingRule.UpdateGlobalStorage.config.bad.asl}
 
 \ProseParagraph
 \OneApplies

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -2336,7 +2336,7 @@ results in a \dynamicerrorterm.
 \begin{mathpar}
 \inferrule[normal]{
   \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynError\\\\
-  \evalsubprogram{\env, \vmain, \emptylist, \emptylist} \evalarrow \Normal([(\vv, \vgtwo)], \Ignore) \OrDynError\\\\
+  \evalsubprogram(\env, \vmain, \emptylist, \emptylist)\evalarrow \Normal([(\vv, \vgtwo)], \Ignore) \OrDynError\\\\
   \vg \eqdef \ordered{\vgone}{\aslpo}{\vgtwo}
 }{
   \evalspec(\tenv, \vspec) \evalarrow (\vv, \vg)
@@ -2346,7 +2346,7 @@ results in a \dynamicerrorterm.
 \begin{mathpar}
 \inferrule[throwing]{
   \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynError\\\\
-  \evalsubprogram{\env, \vmain, \emptylist, \emptylist} \evalarrow \Throwing(\vvopt, \Ignore)
+  \evalsubprogram(\env, \vmain, \emptylist, \emptylist) \evalarrow \Throwing(\vvopt, \Ignore)
 }{
   \evalspec(\tenv, \vspec) \evalarrow \DynamicErrorVal{\UncaughtException}
 }

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -244,7 +244,7 @@ from a subprogram call are as follows:
 \inferrule{
   \vles \eqdef \vle_{1..k}\\
   i=1..k: \lexprisvar(\vle_i) \evalarrow \True\\
-  \evalcall{\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs} \evalarrow \Normal(\vms, \envone) \OrAbnormal\\\\
+  \evalcall(\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs) \evalarrow \Normal(\vms, \envone) \OrAbnormal\\\\
   \evalmultiassignment(\envone, \vles, \vms) \evalarrow \Normal(\newg, \newenv) \OrAbnormal
 }{
   \evalstmt{\env, \SAssign(\LEDestructuring(\les),\ECall(\vcall))} \\
@@ -1330,7 +1330,7 @@ can only be used for procedures, not functions.
 \inferrule{
 {
 \begin{array}{r}
-  \evalcall{\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs} \evalarrow \\
+  \evalcall(\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs) \evalarrow \\
   \Normal(\newg, \newenv) \OrAbnormal
 \end{array}
 }

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -19,6 +19,26 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Typing}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+The rule for typing calls is \TypingRuleRef{AnnotateCall}.
+
+We also define helper functions via respective rules:
+\begin{itemize}
+  \item \TypingRuleRef{AnnotateCallActualsTyped}
+  \item \TypingRuleRef{InsertStdlibParam}
+  \item \TypingRuleRef{CheckParamsTypeSat}
+  \item \TypingRuleRef{RenameTyEqs}
+  \item \TypingRuleRef{SubstExprNormalize}
+  \item \TypingRuleRef{SubstExpr}
+  \item \TypingRuleRef{SubstConstraint}
+  \item \TypingRuleRef{CheckArgsTypeSat}
+  \item \TypingRuleRef{AnnotateRetTy}
+  \item \TypingRuleRef{SubprogramForName}
+  \item \TypingRuleRef{FilterCallCandidates}
+  \item \TypingRuleRef{HasArgClash}
+  \item \TypingRuleRef{ExpressionList}
+\end{itemize}
+
+\TypingRuleDef{AnnotateCall}
 \hypertarget{def-annotatecall}{}
 The function
 \[
@@ -40,26 +60,8 @@ annotates the call $\vcall$ to a subprogram with call type $\calltype$, resultin
 \end{itemize}
 \ProseOtherwiseTypeError
 
-The function is defined by the rule \TypingRuleRef{AnnotateCall}.
+See \ExampleRef{Annotating Calls with Typed Parameters and Typed Arguments}.
 
-We also define helper functions via respective rules:
-\begin{itemize}
-  \item \TypingRuleRef{AnnotateCallActualsTyped}
-  \item \TypingRuleRef{InsertStdlibParam}
-  \item \TypingRuleRef{CheckParamsTypeSat}
-  \item \TypingRuleRef{RenameTyEqs}
-  \item \TypingRuleRef{SubstExprNormalize}
-  \item \TypingRuleRef{SubstExpr}
-  \item \TypingRuleRef{SubstConstraint}
-  \item \TypingRuleRef{CheckArgsTypeSat}
-  \item \TypingRuleRef{AnnotateRetTy}
-  \item \TypingRuleRef{SubprogramForName}
-  \item \TypingRuleRef{FilterCallCandidates}
-  \item \TypingRuleRef{HasArgClash}
-  \item \TypingRuleRef{ExpressionList}
-\end{itemize}
-
-\TypingRuleDef{AnnotateCall}
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -102,7 +104,7 @@ The function
       \overname{\staticenvs}{\tenv} \aslsep\\
       \overname{\identifier}{\name} \aslsep\\
       \overname{(\ty \times\expr \times \TSideEffectSet)^*}{\params} \aslsep\\
-      \overname{(\ty \times\expr)^*}{\typedargs} \aslsep\\
+      \overname{(\ty \times\expr \times \TSideEffectSet)^*}{\typedargs} \aslsep\\
       \overname{\subprogramtype}{\calltype}
     \end{array}
   \right) \aslto
@@ -112,8 +114,29 @@ The function
   \cup\ \overname{\TTypeError}{\TypeErrorConfig}
   \end{array}
 \]
-is similar to $\annotatecall$, except that it accepts annotated version of parameter/argument expressions as inputs (that is, pairs consisting of a type and an expression).
+is similar to $\annotatecall$, except that it accepts the annotated versions of
+the parameter and argument expressions as inputs,
+that is, tuples consisting of types, annotated expressions, and \sideeffectdescriptorsetsterm.
 \ProseOtherwiseTypeError
+
+\ExampleDef{Annotating Calls with Typed Parameters and Typed Arguments}
+In \listingref{AnnotateCallActualsTyped-bad1}, the call expression \verb|xor_extend{64}(bv1, bv2)|
+is ill-typed, since \\
+\verb|xor_extend| has two parameters and only one was supplied.
+\ASLListing{An ill-typed call expression}{AnnotateCallActualsTyped-bad1}{\typingtests/TypingRule.AnnotateCallActualsTyped.bad1.asl}
+
+In \listingref{AnnotateCallActualsTyped-bad2}, the call expression \verb|xor_extend{64, 32}(bv1)|
+is ill-typed, since \\
+\verb|xor_extend| has two arguments and only one was supplied.
+\ASLListing{An ill-typed call expression}{AnnotateCallActualsTyped-bad2}{\typingtests/TypingRule.AnnotateCallActualsTyped.bad2.asl}
+
+In \listingref{AnnotateCallActualsTyped-bad3}, the call expression \verb|plus{64}(bv1, w)|
+is ill-typed, since \\
+the type of the argument \verb|w|, which is \verb|integer{0..128}|, does not \typesatisfy{}
+the type of the formal argument \verb|z| (\verb|integer{0..N}|), with \verb|N| substituted by \verb|64|.
+That is, \\
+\verb|integer{0..64}|.
+\ASLListing{An ill-typed call expression}{AnnotateCallActualsTyped-bad3}{\typingtests/TypingRule.AnnotateCallActualsTyped.bad3.asl}
 
 \ProseParagraph
 \AllApply
@@ -124,8 +147,8 @@ is similar to $\annotatecall$, except that it accepts annotated version of param
   \item applying $\subprogramforname$ to match $\name$ and $\argtypes$ in $\tenv$
         yields \\ $(\namep, \funcsig, \vsescall)$\ProseOrTypeError;
   \item define $\vses$ as the union of $\vsesargs$ and $\vsescall$;
-  \item either the $\subprogramtype$ of $\funcsig$ equals $\calltype$,
-        or the $\subprogramtype$ of $\funcsig$ is $\STGetter$ and $\calltype$ is $\STFunction$\ProseTerminateAs{\BadCall};
+  \item checking that either the $\subprogramtype$ of $\funcsig$ equals $\calltype$,
+        or the $\subprogramtype$ of $\funcsig$ is $\STGetter$ and $\calltype$ is $\STFunction$ yields $\True$\ProseTerminateAs{\BadCall};
   \item applying $\insertstdlibparam$ to $\funcsig$, $\params$, and $\argtypes$ yields new parameters $\paramsone$;
   \item checking that the lengths of $\funcsig.\funcparameters$ and $\paramsone$ are the same yields $\True$\ProseTerminateAs{\BadCall};
   \item checking that the lengths of $\funcsig.\funcargs$ and $\args$ are the same yields $\True$\ProseTerminateAs{\BadCall};
@@ -142,6 +165,7 @@ is similar to $\annotatecall$, except that it accepts annotated version of param
   \item define $\vcall$ as the call with name $\namep$, parameters taken from $\paramsone$, arguments $\vargs$,
         and call type $\funcsig.\funcsubprogramtype$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
@@ -150,23 +174,22 @@ is similar to $\annotatecall$, except that it accepts annotated version of param
   \subprogramforname(\tenv, \name, \argtypes) \typearrow
   (\nameone, \funcsig, \vsescall) \OrTypeError \\
   {
-    \vb \eqdef
+    \checktrans{
     \left(
     \begin{array}{l}
       \funcsig.\funcsubprogramtype = \calltype \; \lor \\
       (\funcsig.\funcsubprogramtype = \STGetter \; \land \\ \quad \calltype = \STFunction)
     \end{array}
-    \right)
+    \right)}{\BadCall} \checktransarrow \True \OrTypeError
   }\\\\
   \vses \eqdef \vsesargs \cup \vsescall\\
-  \checktrans{\vb}{\BadCall} \checktransarrow \True \OrTypeError \\
   \insertstdlibparam(\funcsig, \params, \argtypes) \typearrow \paramsone\\\\
   \equallength(\funcsig.\funcparameters, \paramsone) \typearrow \paramaritymatch \\\\
   \checktrans{\paramaritymatch}{\BadCall} \checktransarrow \True \OrTypeError\\\\
   \equallength(\funcsig.\funcargs, \args) \typearrow \aritymatch\\
   \checktrans{\aritymatch}{\BadCall} \checktransarrow \True \OrTypeError\\\\
   \checkparamstypesat(\tenv, \funcsig.\funcparameters, \paramsone) \typearrow \True \OrTypeError\\\\
-  \eqs \eqdef [(\vx_i, \Ignore) \in \funcsig.\funcargs_i ,\; (\Ignore, \vv_i, \Ignore) \in \paramsone: (\vx_i, \vv_i) ] \\
+  \eqs \eqdef [(\vx_i, \Ignore) \in \funcsig.\funcsigparams_i ,\; (\Ignore, \vv_i, \Ignore) \in \paramsone: (\vx_i, \vv_i) ] \\
   \checkargstypesat(\tenv, \funcsig.\funcargs, \argtypes, \eqs) \typearrow \True \OrTypeError\\\\
   \annotateretty(\tenv, \calltype, \funcsig.\funcreturntype, \eqs) \typearrow \rettyopt \OrTypeError
 }{
@@ -565,6 +588,14 @@ by substituting parameter names with their corresponding expressions in
 $\eqs$, and then attempting to symbolically simplify the result, yielding the expression $\newe$.
 \ProseOtherwiseTypeError
 
+\ExampleDef{Substituting Parameter Expressions and Normalizing}
+In \listingref{SubstExpr},
+considering the call expression \verb|plus{z + 22}(bv1, z)|,
+the expression \verb|z + 22| is substituted for the parameter \verb|N| in the type
+\verb|bits(N + 2)| used for the argument \verb|x| and as the return type of \verb|plus|,
+resulting in the expression \verb|(40 + 22) + 2|, which is then normalized into \verb|64|.
+\ASLListing{Substituting Parameter Expressions}{SubstExpr}{\typingtests/TypingRule.SubstExpr.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -600,6 +631,8 @@ $\substs$, yielding the expression $\newe$.
 
 The function assumes that $\ve$ appears in the declaration of a parameter,
 which means it is in the subset allowed by $\extractparameters$.
+
+See \ExampleRef{Substituting Parameter Expressions and Normalizing}.
 
 \ProseParagraph
 \OneApplies
@@ -722,7 +755,8 @@ which means it is in the subset allowed by $\extractparameters$.
   \begin{itemize}
     \item $\ve$ is the slicing expression for subexpression $\veone$ and list of slices $\vslices$, that is, $\ESlice(\veone, \vslices)$;
     \item applying $\substexpr$ to $\veone$ in $\tenv$ yields $\veonep$;
-    \item define $\newe$ as slicing expression for subexpression $\veonep$ and list of slices $\vslices$, that is, $\ESlice(\veonep, \vslices)$.
+    \item define $\newe$ as slicing expression for subexpression $\veonep$ and list of slices \\
+          $\vslices$, that is, $\ESlice(\veonep, \vslices)$.
   \end{itemize}
 
   \item \AllApplyCase{e\_tuple}
@@ -964,6 +998,13 @@ $\eqs$, and then attempting to symbolically simplify the result,
 yielding the integer constraint $\newc$.
 \ProseOtherwiseTypeError
 
+\ExampleDef{Substituting Parameter Expressions in Constraints}
+In \listingref{SubstExpr},
+considering the call expression \verb|plus{z + 22}(bv1, z)|,
+the expression \verb|z + 22| is substituted for the parameter \verb|N| in the type
+\verb|integer{0..N}| used for the argument \verb|z|,
+resulting in the type \verb|integer{0..64}|.
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -1095,6 +1136,19 @@ annotates the \optional\ return type $\funcsigrettyopt$ given with the subprogra
 $\calltype$ with respect to the parameter expressions $\eqs$,
 yielding the \optional\ annotated type $\rettyopt$.
 \ProseOtherwiseTypeError
+
+\ExampleDef{Annotating the Return Type of a Subprogram Call}
+In \listingref{AnnotateRetTy}, annotating the return type \verb|bits(N)| of the subprogram \verb|flip|
+for call expression \verb|flip{64}(bv)|, yields the annotated type \verb|bits(64)|.
+
+Since \verb|proc| does not have a return type, the call statement \verb|proc()| does not require
+annotating a return type (thus $\annotateretty$ yields $\None$ for $\rettyopt$).
+\ASLListing{Annotating the Return Type of a Subprogram Call}{AnnotateRetTy}{\typingtests/TypingRule.AnnotateRetTy.asl}
+
+\listingref{AnnotateRetTy-bad} shows an example of an ill-typed call statement \verb|flip{64}(bv);|
+and an ill-typed call expression \verb|proc()|, since procedures can only be used in call statements
+and functions can only be used in call expressions.
+\ASLListing{Ill-typed Subprogram Calls}{AnnotateRetTy-bad}{\typingtests/TypingRule.AnnotateRetTy.bad.asl}
 
 \ProseParagraph
 \OneApplies
@@ -1638,14 +1692,25 @@ is annotated as
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Semantics}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+The rule for evaluating subprogram calls is \SemanticsRuleRef{Call}.
+
+We also define the following helper rules:
+\begin{itemize}
+  \item \SemanticsRuleRef{EvalSubprogram}
+  \item \SemanticsRuleRef{ReadValueFrom}
+  \item \SemanticsRuleRef{AssignArgs}
+  \item \SemanticsRuleRef{MatchFuncRes}
+\end{itemize}
+
+\SemanticsRuleDef{Call}
 The relation
 \hypertarget{def-evalcall}{}
 \[
   \begin{array}{c}
-    \evalcall{\overname{\envs}{\env} \aslsep
+    \evalcall(\overname{\envs}{\env} \aslsep
     \overname{\Identifiers}{\name} \aslsep
     \overname{\expr^*}{\params} \aslsep
-    \overname{\expr^*}{\args}} \;\aslrel\; \\
+    \overname{\expr^*}{\args}) \;\aslrel\; \\
     \Normal(\overbracket{(\vals\times\XGraphs)^*}^{\vmstwo}, \overname{\envs}{\newenv}) \cup
     \overname{\TThrowing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
   \end{array}
@@ -1659,44 +1724,13 @@ or an abnormal configuration.
 
 The evaluation first evaluates the expressions corresponding to the arguments
 and parameters and then passes their values in a resulting configuration
-to the helper relation \texttt{eval\_subprogram}.
+to the helper relation $\evalsubprogram$.
 
-The relation
-\hypertarget{def-evalsubprogram}{}
-\[
-  \begin{array}{c}
-    \evalsubprogram{\overname{\envs}{\env} \aslsep
-    \overname{\Identifiers}{\name} \aslsep
-    \overname{(\vals \times \XGraphs)^*}{\params} \aslsep
-    \overname{(\vals \times \XGraphs)^*}{\args}} \aslrel \\
-    \Normal(\overname{(\vals^* \aslsep \XGraphs)}{\vvs}, \overname{\envs}{\newenv}) \cup
-    \overname{\TThrowing}{\ThrowingConfig} \cup
-    \overname{\TDynError}{\DynErrorConfig}
-  \end{array}
-\]
-evaluates the subprogram named $\name$ in the environment $\env$, with
-$\actualargs$ the list of actual arguments, and $\params$ the
-list of arguments deduced by type equality.
-The result is either a normal configuration or an abnormal configuration.
-In the case of a normal configuration, it consists of a list of pairs
-with a value and an identifier, and a new environment $\newenv$.
-The values represent values returned by the subprogram call and the
-identifiers are used in generating execution graph constraints for the
-returned values.
+\ExampleDef{Calling Subprograms}
+In \listingref{Call}, calling \verb|non_throwing_func| terminates normally,
+while calling \verb|throwing_func| terminates by throwing an exception.
+\ASLListing{Calling subprograms}{Call}{\semanticstests/SemanticsRule.Call.asl}
 
-The main subprogram call relation is given by
-SemanticsRule.Call (see \SemanticsRuleRef{Call}).
-%
-This relies on the helper rule \SemanticsRuleRef{FCall}.
-
-We also define the following helper rules:
-\begin{itemize}
-  \item \SemanticsRuleRef{ReadValueFrom}
-  \item \SemanticsRuleRef{AssignArgs}
-  \item \SemanticsRuleRef{MatchFuncRes}
-\end{itemize}
-
-\SemanticsRuleDef{Call}
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1750,12 +1784,12 @@ We also define the following helper rules:
   \incrstacksize(G^\denvtwo, \name) \evalarrow \genv\\\\
   \envtwo' \eqdef (\tenv, (\genv, \emptyfunc))\\\\
   \commonprefixline\\\\
-  \evalsubprogram{\envtwo', \name, \vvparams, \vvargs} \evalarrow \Normal(\vms, (\vglobal, \Ignore)) \OrDynError\\\\
+  \evalsubprogram(\envtwo', \name, \vvparams, \vvargs) \evalarrow \Normal(\vms, (\vglobal, \Ignore)) \OrDynError\\\\
   \readvaluefrom(\vms) \evalarrow \vmstwo\\
   \decrstacksize(\vglobal, \name) \evalarrow \genvtwo\\
   \newenv \eqdef (\tenv, (\genvtwo, L^{\denvtwo}))
 }{
-  \evalcall{\env, \name, \params, \args} \evalarrow \Normal(\vmstwo, \newenv)
+  \evalcall(\env, \name, \params, \args) \evalarrow \Normal(\vmstwo, \newenv)
 }
 \end{mathpar}
 
@@ -1767,17 +1801,40 @@ We also define the following helper rules:
   \incrstacksize(G^\denvtwo, \name) \evalarrow \genv\\\\
   \envtwo' \eqdef (\tenv, (\genv, \emptyfunc))\\\\
   \commonprefixline\\\\
-  \evalsubprogram{\envtwo', \name, \vvparams, \vvargs} \evalarrow \Throwing(\vv, \envthrow) \OrDynError\\\\
+  \evalsubprogram(\envtwo', \name, \vvparams, \vvargs) \evalarrow \Throwing(\vv, \envthrow) \OrDynError\\\\
   \envthrow \eqname (\tenv, (\vglobal, \Ignore))\\
   \decrstacksize(\vglobal, \name) \evalarrow \genvtwo\\
   \newenv \eqdef (\tenv, (\genvtwo, L^{\denvtwo}))
 }{
-  \evalcall{\env, \name, \params, \args} \evalarrow \Throwing(\vv, \newenv)
+  \evalcall(\env, \name, \params, \args) \evalarrow \Throwing(\vv, \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalCallBegin}{\EvalCallEnd}{../Interpreter.ml}
 
-\SemanticsRuleDef{FCall}
+\SemanticsRuleDef{EvalSubprogram}
+The relation
+\hypertarget{def-evalsubprogram}{}
+\[
+  \begin{array}{c}
+    \evalsubprogram(\overname{\envs}{\env} \aslsep
+    \overname{\Identifiers}{\name} \aslsep
+    \overname{(\vals \times \XGraphs)^*}{\params} \aslsep
+    \overname{(\vals \times \XGraphs)^*}{\args}) \aslrel \\
+    \Normal(\overname{(\vals^* \aslsep \XGraphs)}{\vvs}, \overname{\envs}{\newenv}) \cup
+    \overname{\TThrowing}{\ThrowingConfig} \cup
+    \overname{\TDynError}{\DynErrorConfig}
+  \end{array}
+\]
+evaluates the subprogram named $\name$ in the environment $\env$, with
+$\actualargs$ the list of actual arguments, and $\params$ the
+list of arguments deduced by type equality.
+The result is either a normal configuration or an abnormal configuration.
+In the case of a normal configuration, it consists of a list of pairs
+with a value and an identifier, and a new environment $\newenv$.
+The values represent values returned by the subprogram call and the
+identifiers are used in generating execution graph constraints for the
+returned values.
+
 \ExampleDef{Subprogram Calls}
 In \listingref{semantics-fcall},
 the function \texttt{main} calls the function \texttt{foo} and the procedure \texttt{bar}.
@@ -1837,7 +1894,7 @@ the function \texttt{main} calls the function \texttt{foo} and the procedure \te
   \matchfuncres(\vres) \evalarrow C\\
   \newg \eqdef \ordered{\vgone}{\asldata}{\ordered{\vgtwo}{\aslpo}{\vgthree}}\\
 }{
-  \evalsubprogram{\env, \name, \actualargs, \params} \evalarrow \withgraph{C}{\newg}
+  \evalsubprogram(\env, \name, \actualargs, \params) \evalarrow \withgraph{C}{\newg}
 }
 \end{mathpar}
 \CodeSubsection{\EvalFCallBegin}{\EvalFCallEnd}{../Interpreter.ml}
@@ -1858,6 +1915,19 @@ checks whether the value in the optional expression $\velimitopt$ has reached th
 in $\env$, yielding the execution graph resulting from evaluating the optional expression in $\vg$.
 Otherwise, the result is a dynamic error indicating that the recursion limit has been reached.
 
+\ExampleDef{Checking the Recursion Limit of a Subprogram Call}
+In \listingref{CheckRecurseLimit-nolimit}, the function \verb|factorial| is specified without a limit expression,
+and evaluating \verb|main| terminates normally.
+\ASLListing{A recursive function with no limit expression}{CheckRecurseLimit-nolimit}{\semanticstests/SemanticsRule.CheckRecurseLimit.no_limit.asl}
+
+In \listingref{CheckRecurseLimit}, the function \verb|factorial| specifies the limit expression \verb|11|,
+and evaluating \verb|main| terminates normally.
+\ASLListing{A recursive function with a limit expression}{CheckRecurseLimit}{\semanticstests/SemanticsRule.CheckRecurseLimit.asl}
+
+In \listingref{CheckRecurseLimit-limitreached}, the function \verb|factorial| specifies the limit expression \verb|10|,
+and evaluating \verb|main| terminates with a \dynamicerrorterm{} (\LimitExceeded), since the limit is exceeded.
+\ASLListing{A recursive call exceeding the specified limit}{CheckRecurseLimit-limitreached}{\semanticstests/SemanticsRule.CheckRecurseLimit.limit_reached.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -1875,13 +1945,13 @@ Otherwise, the result is a dynamic error indicating that the recursion limit has
     \item $\vstacksize$ is less than $\vlimit$.
   \end{itemize}
 
-  \item \AllApplyCase{some\_error}
+  \item \AllApplyCase{limit\_exceeded}
   \begin{itemize}
     \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrError;
     \item view $\env$ as $(\tenv, \denv)$;
     \item applying $\getstacksize$ to $\name$ in $\denv$ yields $\vstacksize$;
     \item $\vstacksize$ is greater or equal to $\vlimit$;
-    \item the result is a dynamic
+    \item the result is a \dynamicerrorterm{} (\LimitExceeded).
   \end{itemize}
 \end{itemize}
 
@@ -1906,7 +1976,7 @@ Otherwise, the result is a dynamic error indicating that the recursion limit has
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[some\_error]{
+\inferrule[limit\_exceeded]{
   \evallimit(\env, \velimitopt) \evalarrow (\langle\vlimit\rangle, \vg) \OrDynError\\\\
   \env \eqname (\tenv, \denv)\\
   \getstacksize(\denv, \name) \evalarrow \vstacksize\\
@@ -1932,8 +2002,6 @@ by the identifier, and pairs it with the given value.
   \item the result is $(\vv, \newg)$.
 \end{itemize}
 
-\CodeSubsection{\EvalReadValueFromBegin}{\EvalReadValueFromEnd}{../Interpreter.ml}
-
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
@@ -1942,9 +2010,10 @@ by the identifier, and pairs it with the given value.
   \readvaluefrom(\vv, \id) \evalarrow (\vv, \newg)
 }
 \end{mathpar}
+\CodeSubsection{\EvalReadValueFromBegin}{\EvalReadValueFromEnd}{../Interpreter.ml}
 
 \SemanticsRuleDef{AssignArgs}
-The helper relation
+The relation
 \hypertarget{def-assignargs}{}
 \[
   \assignargs(
@@ -1956,6 +2025,12 @@ The helper relation
 updates the pair consisting of the environments $\env$ and \executiongraph\ $\vgone$
 by assigning the values given by $\actuals$ to the identifiers given by $\vids$,
 yielding the updated pair $(\newenv, \newg)$.
+
+\ExampleDef{Assigning Arguments}
+In \listingref{AssignArgs}, the call expression \verb|plus(10, 5)| binds \verb|x| to $\nvint(10)$
+and $\verb|y|$ to $\nvint(5)$. The expression \verb|x + y| then accesses
+these variable values and evaluates to $\nvint(15)$.
+\ASLListing{Assigning arguments}{AssignArgs}{\semanticstests/SemanticsRule.AssignArgs.asl}
 
 \ProseParagraph
 \OneApplies

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -500,7 +500,7 @@ checks whether the identifier $\vx$ is defined in the global static environment 
 \ExampleDef{Global Undefined}
 \listingref{isglobalundefined} shows a specification which defines a variable \verb|X| and a subprogram \verb|Y|.
 In the typing environment obtained by typechecking this specification, $\isglobalundefined$ will yield $\False$ for \verb|X| and $\True$ for \verb|Y|.
-\ASLListing{IsGlobalUndefined}{isglobalundefined}{\typingtests/TypingRule.IsGlobalUndefined.asl}
+\ASLListing{Checking whether an identifier is defined in the global static environment}{isglobalundefined}{\typingtests/TypingRule.IsGlobalUndefined.asl}
 
 \ProseParagraph
 Define $\vb$ as $\True$ if and only if $\vx$ is not bound in any of the following maps of $\genv$:

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -677,7 +677,7 @@ or \emph{constrained}. That is, a \symbolicallyevaluable{} \constrainedinteger{}
 constrained (\verb|bits(N)|, \verb|bits(i)|, and \verb|bits(N-i)|),
 and related operations,
 followed by the output to the console.
-\ASLListing{Rotating a bitevector}{bits-rotate}{\definitiontests/Bitvector_rotate.asl}
+\ASLListing{Rotating a bitvector}{bits-rotate}{\definitiontests/Bitvector_rotate.asl}
 % CONSOLE_BEGIN aslref \definitiontests/Bitvector_rotate.asl
 \begin{Verbatim}[fontsize=\footnotesize, frame=single]
 bv=0x14, rotated twice=0x05
@@ -724,7 +724,7 @@ bv=0x14, rotated twice=0x05
 \TypingRuleDef{TBits}
 \ExampleDef{Well-typed Bitvector Types}
 In \listingref{typing-tbits}, all the uses of bitvector types are well-typed.
-\ASLListing{Well-typed Bitevector types}{typing-tbits}{\typingtests/TypingRule.TBits.asl}
+\ASLListing{Well-typed Bitvector types}{typing-tbits}{\typingtests/TypingRule.TBits.asl}
 
 \ExampleRef{A bitvector type with bitfields} shows a well-typed \bitvectortypeterm{} with bitfields.
 
@@ -842,7 +842,7 @@ as long as $0 \leq k < n$.
 
 \listingref{TupleElementAccess} shows examples of accessing the elements
 of the tuple stored in \verb|x|.
-\ASLListing{Accesssing tuple elements}{TupleElementAccess}{\definitiontests/GuideRule.TupleElementAccess.asl}
+\ASLListing{Accessing tuple elements}{TupleElementAccess}{\definitiontests/GuideRule.TupleElementAccess.asl}
 
 \subsection{Syntax}
 \begin{flalign*}

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -315,6 +315,7 @@ classify
 classifying
 clause
 clauses
+closed
 closer
 closest
 closing
@@ -554,6 +555,7 @@ difference
 different
 differentiating
 differently
+differing
 digits
 directive
 directly
@@ -563,6 +565,7 @@ discarding
 discards
 disclaimer
 disclosure
+discriminant
 discussed
 disjoint
 disjunction
@@ -729,6 +732,7 @@ explicitly
 exploded
 exploding
 exponent
+exponentiation
 export
 exposes
 express
@@ -938,6 +942,7 @@ includes
 including
 incomplete
 incorrect
+incorrectly
 increasing
 increments
 indeed
@@ -1828,6 +1833,7 @@ succeed
 succeeding
 succeeds
 success
+successful
 successfully
 successive
 succinctly
@@ -2005,6 +2011,7 @@ understanding
 undertaken
 unevaluated
 unexpected
+uninitialized
 unintended
 union
 unique

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -693,6 +693,7 @@ example
 examples
 exceed
 exceeded
+exceeding
 except
 exception
 exceptional
@@ -2076,6 +2077,7 @@ verifiers
 verifying
 verilog
 version
+versions
 vertex
 vertices
 very

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -510,7 +510,7 @@ def check_rules(filename: str) -> int:
     # Treat existing issues as warnings and new issues as errors.
     file_to_num_expected_errors = {
         "RelationsOnTypes.tex" : 15,
-        "SubprogramCalls.tex" : 15,
+        "SubprogramCalls.tex" : 1,
         "SymbolicEquivalenceTesting.tex" : 26,
         "SymbolicSubsumptionTesting.tex" : 23,
         "SideEffects.tex" : 13,

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -571,8 +571,8 @@ def spellcheck(reference_dictionary_path: str, latex_files: list[str]) -> int:
 
     patterns_to_remove = [
         # Patterns for environments inside which spellchecking is not needed:
-        r"\$.*?\$",  # $...$
-        r"\\\[.*?\\\]",  # \[...\]
+        r"\$.*?\$",
+        r"\\\[.*?\\\]",
         r"\\begin\{mathpar\}.*?\\end\{mathpar\}",
         r"\\begin\{equation\}.*?\\end\{equation\}",
         r"\\begin\{flalign\*\}.*?\\end\{flalign\*\}",
@@ -586,7 +586,6 @@ def spellcheck(reference_dictionary_path: str, latex_files: list[str]) -> int:
         r"\\lrmcomment{.*?}",
         r"\\stdlibfunc{.*?}",
         r"\\defref{.*?}",
-        r"\\ASLListing{.*?}{.*?}{.*?}",
         r"\\LexicalRuleDef{.*?}",
         r"\\LexicalRuleRef{.*?}",
         r"\\ASTRuleRef{.*?}",
@@ -618,6 +617,7 @@ def spellcheck(reference_dictionary_path: str, latex_files: list[str]) -> int:
         r"\\listingref{.*?}",
         r"\\appendixref{.*?}",
     ]
+    asl_listing_pattern = r"\\ASLListing\{(.*?)\}\{.*?\}\{.*?\}"
 
     num_errors = 0
     for filename in latex_files:
@@ -630,6 +630,8 @@ def spellcheck(reference_dictionary_path: str, latex_files: list[str]) -> int:
         # Remove text blocks where spelling is not needed.
         for pattern in patterns_to_remove:
             file_str = re.sub(pattern, "", file_str, flags=re.DOTALL)
+        # Replace instances of \ASLListing with just the caption.
+        file_str = re.sub(asl_listing_pattern, r"\1", file_str)
         file_lines = file_str.splitlines()
         for line in file_lines:
             tokens = re.split(" |{|}", line)

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.AssignArgs.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.AssignArgs.asl
@@ -1,0 +1,10 @@
+func plus(x: integer, y: integer) => integer
+begin
+    return x + y;
+end;
+
+func main() => integer
+begin
+    - = plus(10, 5);
+    return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Call.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Call.asl
@@ -1,0 +1,22 @@
+type MyException of exception;
+
+func throwing_func()
+begin
+    throw MyException{};
+end;
+
+func non_throwing_func()
+begin
+    pass;
+end;
+
+func main() => integer
+begin
+    non_throwing_func();
+    try
+        throwing_func();
+    catch
+        when MyException => pass;
+    end;
+    return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CheckRecurseLimit.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CheckRecurseLimit.asl
@@ -1,0 +1,10 @@
+func factorial(n: integer) => integer recurselimit 11
+begin
+    return if n == 0 then 1 else n * factorial(n - 1);
+end;
+
+func main() => integer
+begin
+    assert factorial(10) == 3628800;
+    return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CheckRecurseLimit.limit_reached.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CheckRecurseLimit.limit_reached.asl
@@ -1,0 +1,10 @@
+func factorial(n: integer) => integer recurselimit 10
+begin
+    return if n == 0 then 1 else n * factorial(n - 1);
+end;
+
+func main() => integer
+begin
+    assert factorial(10) == 3628800;
+    return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CheckRecurseLimit.no_limit.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.CheckRecurseLimit.no_limit.asl
@@ -1,0 +1,10 @@
+func factorial(n: integer) => integer
+begin
+    return if n == 0 then 1 else n * factorial(n - 1);
+end;
+
+func main() => integer
+begin
+    assert factorial(10) == 3628800;
+    return 0;
+end;

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -226,3 +226,16 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.DeclareGlobal.asl
   $ aslref SemanticsRule.EvalGlobals.asl
   $ aslref SemanticsRule.MatchFuncRes.asl
+  $ aslref SemanticsRule.CheckRecurseLimit.asl
+  $ aslref SemanticsRule.CheckRecurseLimit.no_limit.asl
+  File SemanticsRule.CheckRecurseLimit.no_limit.asl, line 1, character 0 to
+    line 4, character 4:
+  ASL Warning: the recursive function factorial has no recursive limit
+  annotation.
+  $ aslref SemanticsRule.CheckRecurseLimit.limit_reached.asl
+  File SemanticsRule.CheckRecurseLimit.limit_reached.asl, line 3,
+    characters 37 to 53:
+  ASL Dynamic error: recursion limit reached.
+  [1]
+  $ aslref SemanticsRule.AssignArgs.asl
+  $ aslref SemanticsRule.Call.asl

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateCallActualsTyped.bad1.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateCallActualsTyped.bad1.asl
@@ -1,0 +1,13 @@
+func xor_extend{N, M}(x: bits(N), y: bits(M)) => bits(N)
+begin
+    return x XOR ZeroExtend{N, M}(y);
+end;
+
+func main() => integer
+begin
+    var bv1 = Zeros{64};
+    var bv2 = Zeros{32};
+    - = xor_extend{64, 32}(bv1, bv2);
+    - = xor_extend{64}(bv1, bv2); // Illegal: missing parameter for `M`.
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateCallActualsTyped.bad2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateCallActualsTyped.bad2.asl
@@ -1,0 +1,15 @@
+func xor_extend{N, M}(x: bits(N), y: bits(M)) => bits(N)
+begin
+    return x XOR ZeroExtend{N, M}(y);
+end;
+
+func main() => integer
+begin
+    var bv1 = Zeros{64};
+    var bv2 = Zeros{32};
+    // Legal: all parameters and arguments are given.
+    - = xor_extend{64, 32}(bv1, bv2);
+    // Illegal: both parameters are given, but missing argument for `y`.
+    - = xor_extend{64, 32}(bv1);
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateCallActualsTyped.bad3.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateCallActualsTyped.bad3.asl
@@ -1,0 +1,16 @@
+func plus{N}(x: bits(N), z: integer{0..N}) => bits(N)
+begin
+    return x + z;
+end;
+
+func main() => integer
+begin
+    var bv1 = Zeros{64};
+    var z: integer{0..31, 32..64} = 40;
+    - = plus{64}(bv1, z);
+    var w: integer{0..128};
+    // The following statement is illegal as the type of `w`, integer{0..128},
+    // does not type-satisfy the type of `z`, integer{0..64}.
+    - = plus{64}(bv1, w);
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateRetTy.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateRetTy.asl
@@ -1,0 +1,17 @@
+func flip{N}(x: bits(N)) => bits(N)
+begin
+    return x XOR Ones{N};
+end;
+
+func proc()
+begin
+    pass;
+end;
+
+func main() => integer
+begin
+    var bv = Zeros{64};
+    bv = flip{64}(bv);
+    proc();
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateRetTy.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateRetTy.bad.asl
@@ -1,0 +1,18 @@
+func flip{N}(x: bits(N)) => bits(N)
+begin
+    return x XOR Ones{N};
+end;
+
+func proc()
+begin
+    pass;
+end;
+
+func main() => integer
+begin
+    var bv = Zeros{64};
+    - = flip{64}(bv);
+    flip{64}(bv); // Illegal: the returned value must be consumed.
+    - = proc(); // Illegal: `proc` does not return a value.
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SubstExpr.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SubstExpr.asl
@@ -1,0 +1,12 @@
+func plus{N}(x: bits(N + 2), z: integer{0..N}) => bits(N + 2)
+begin
+    return x + z;
+end;
+
+func main() => integer
+begin
+    var bv1 = Zeros{64};
+    let z = 40;
+    - = plus{z + 22}(bv1, z);
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -589,3 +589,27 @@ ASL Typing Tests / annotating types:
     character 16:
   ASL typing error: unexpected collection.
   [1]
+  $ aslref TypingRule.AnnotateRetTy.asl
+  $ aslref TypingRule.AnnotateRetTy.bad.asl
+  File TypingRule.AnnotateRetTy.bad.asl, line 15, characters 4 to 17:
+  ASL Error: Mismatched use of return value from call to 'flip'.
+  [1]
+  $ aslref TypingRule.AnnotateCallActualsTyped.bad1.asl
+  File TypingRule.AnnotateCallActualsTyped.bad1.asl, line 11,
+    characters 8 to 32:
+  ASL Static Error: Arity error while calling 'xor_extend':
+    2 parameters expected and 1 provided
+  [1]
+  $ aslref TypingRule.AnnotateCallActualsTyped.bad2.asl
+  File TypingRule.AnnotateCallActualsTyped.bad2.asl, line 13,
+    characters 8 to 31:
+  ASL Typing error: No subprogram declaration matches the invocation:
+    xor_extend(bits(64)).
+  [1]
+  $ aslref TypingRule.AnnotateCallActualsTyped.bad3.asl
+  File TypingRule.AnnotateCallActualsTyped.bad3.asl, line 14,
+    characters 8 to 24:
+  ASL Typing error: a subtype of integer {0..64} was expected,
+    provided integer {0..128}.
+  [1]
+  $ aslref TypingRule.SubstExpr.asl


### PR DESCRIPTION
* Added examples to the Subprogram Calls chapter.
* Extended spellchecking to be applied to captions of code examples and fixed some spelling errors.