### PR TITLE
ASL-716 accessibility enhancements phase 17: examples and fixes

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -878,6 +878,7 @@
 \newcommand\REletter[0]{\hyperlink{def-reletter}{\texttt{<}\textsf{letter}\texttt{>}}}
 \newcommand\REidentifier[0]{\hyperlink{def-reidentifier}{\texttt{<}\textsf{identifier}\texttt{>}}}
 \newcommand\RElinecomment[0]{\hyperlink{def-relinecomment}{\texttt{<}\textsf{line\_comment}\texttt{>}}}
+\newcommand\REwhitespace[0]{\hyperlink{def-rewhitespace}{\texttt{<}\textsf{whitespace}\texttt{>}}}
 
 \newcommand\parsearrow[0]{\xrightarrow{\hyperlink{def-aslparse}{\textsf{parse}}}}
 \newcommand\aslparse[0]{\hyperlink{def-aslparse}{\textfunc{asl\_parse}}}
@@ -1091,6 +1092,7 @@
 \newcommand\evalexprlist[1]{\hyperlink{def-evalexprlist}{\textfunc{eval\_expr\_list}}(#1)}
 \newcommand\evalexprlistm[0]{\hyperlink{def-evalexprlistm}{\textfunc{eval\_expr\_list\_m}}}
 \newcommand\evalpattern[1]{\hyperlink{def-evalpattern}{\textfunc{eval\_pattern}}(#1)}
+\newcommand\maskmatch[0]{\hyperlink{def-maskmatch}{\textfunc{mask\_match}}}
 \newcommand\evallocaldecl[1]{\hyperlink{def-evallocaldecl}{\textfunc{eval\_local\_decl}}(#1)}
 \newcommand\ldituplefolder[0]{\hyperlink{def-ldituplefolder}{\textfunc{ldi\_tuple\_folder}}}
 \newcommand\writefolder[0]{\hyperlink{def-writefolder}{\textfunc{write\_folder}}}
@@ -1881,7 +1883,6 @@
 \newcommand\constraintsequal[0]{\hyperlink{def-constraintsequal}{\textfunc{constraints\_equal}}}
 \newcommand\constraintequal[0]{\hyperlink{def-constraintequal}{\textfunc{constraint\_equal}}}
 \newcommand\arraylengthequal[0]{\hyperlink{def-arraylengthequal}{\textfunc{array\_length\_equal}}}
-\newcommand\literalequal[0]{\hyperlink{def-literalequal}{\textfunc{literal\_equal}}}
 \newcommand\annotatebitfield[0]{\hyperlink{def-annotatebitfield}{\textfunc{annotate\_bitfield}}}
 \newcommand\annotatebitfields[0]{\hyperlink{def-annotatebitfields}{\textfunc{annotate\_bitfields}}}
 \newcommand\Prosecheckcommonbitfieldsalign[3]{\hyperlink{def-checkcommonbitfieldsalign}{checking} that all pairs of bitfields in #2 that are in the same scope

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -34,7 +34,7 @@ In particular, it is an error to use a tab character in ASL specification text (
 \hline
 \textbf{RegExp} & \textbf{Matches}\\
 \hline
-$\underbracket{\texttt{a\_string}}$   & Any character in \texttt{a\_string}\\
+\anycharacter{\texttt{a\_string}}     & Any character in \texttt{a\_string}\\
 $\square$                             & The space character (decimal 32) \hypertarget{def-ascii}{}\\
 \ascii{$a$}                           & The ASCII with decimal $a$\\
 \ascii{$a$-$b$}                       & The ASCII range between decimals $a$ and $b$\\
@@ -73,8 +73,10 @@ That is, the set of strings that match that regular expression.
 
 \section{Whitespace}
 \RequirementDef{Whitespace}
-Comments, newlines and space characters are treated as whitespace.
-%
+Comments and whitespace characters are collectively referred to as whitespace lexemes
+and are discarded. Technically, line comments and multi-line comments are treated
+separately from whitespace characters.
+
 For example,
 the specification in \listingref{syntax-whitespace1}
 is equivalent to \listingref{syntax-whitespace2}
@@ -82,6 +84,14 @@ in the sense that they both parse to the same AST.
 Of course, \listingref{syntax-whitespace2} is preferred in terms of style.
 \ASLListing{A badly-formatted specification}{syntax-whitespace1}{\syntaxtests/GuideRule.Whitespace1.asl}
 \ASLListing{A well-formatted specification}{syntax-whitespace2}{\syntaxtests/GuideRule.Whitespace2.asl}
+
+Formally, whitespace lexemes other than comments are defined via the following regular expression:
+\hypertarget{def-rewhitespace}{}
+\begin{center}
+\begin{tabular}{rcl}
+$\REwhitespace$ & $\triangleq$ & (\ascii{10} $|$ \ascii{13} $|$ \ascii{32})+\\
+\end{tabular}
+\end{center}
 
 \section{Comments}
 ASL supports comments in the style of C++:
@@ -95,12 +105,15 @@ as exemplified in \listingref{LexicalComments}.
 
 \ASLListing{Examples of comments}{LexicalComments}{\syntaxtests/Lexical.Comments.asl}
 
+Line comments are formally defined via the following regular expressions:
 \hypertarget{def-relinecomment}{}
 \begin{center}
 \begin{tabular}{rcl}
 $\RElinecomment$  &$\triangleq$& \texttt{"//"} (\REchar\ \texttt{-} \ascii{10})* \texttt{|} \texttt{"/*"} \REchar* \texttt{"*/"}\\
 \end{tabular}
 \end{center}
+
+Multi-line comments are defined via $\actionstartcomment$ and in \secref{scanningmultilinecomments}.
 
 \section{Integer Literals}
 Integers are written either in decimal using one or more of the characters \texttt{0-9} and underscore, or in hexadecimal
@@ -214,7 +227,7 @@ The escape sequences allowed in string literals appear in \taref{EscapeSequences
 \begin{center}
 \begin{tabular}{rcl}
 $\REstrchar$ &$\triangleq$& \ascii{32-126}\\
-$\REstringlit$ &$\triangleq$& \anycharacter{\texttt{"}} ( ($\REstrchar$ \texttt{-} $\underbracket{\texttt{"}\ \backslash\ }$) $|$ ($\underbracket{\backslash\ }$ $\underbracket{\texttt{" n t }\backslash\ }$)  )* \anycharacter{\texttt{"}}
+$\REstringlit$ &$\triangleq$& \anycharacter{\texttt{"}} ( ($\REstrchar$ \texttt{-} \anycharacter{\texttt{"}\ \backslash\ }) $|$ (\anycharacter{\backslash\ } \anycharacter{\texttt{" n t }\backslash\ })  )* \anycharacter{\texttt{"}}
 \end{tabular}
 \end{center}
 
@@ -421,7 +434,7 @@ The lexeme action
 \actiondiscard(s_1, s_2) \triangleq \aslscan(\spectoken, s_2)
 \]
 discards the string $s_1$ and continues scanning $s_2$ with $\spectoken$.
-This is used for whitespace.
+This is used for whitespace lexemes.
 
 \item
 \hypertarget{def-actiontoken}{}
@@ -527,9 +540,10 @@ token function.
 \begin{tabular}{ll}
 \textbf{Lexical Regular Expressions} & \textbf{Lexeme Action}\\
 \hline
-(\ascii{10} $|$ \ascii{13} $|$ \ascii{32})+         & $\discard$ \\
+$\REwhitespace$                       & $\discard$ \\
+$\RElinecomment$                      & $\discard$ \\
 $\texttt{"/*"}$                       & $\actionstartcomment$ \\
-$\underbracket{\texttt{"}}$           & $\actionstartstring$ \\
+\anycharacter{\texttt{"}}             & $\actionstartstring$ \\
 $\REintlit$                           & $\actiontoken(\decimaltolit)$ \\
 $\REhexlit$                           & $\actiontoken(\hextolit)$ \\
 $\REreallit$                          & $\actiontoken(\realtolit)$ \\
@@ -680,17 +694,17 @@ The lexical specification for string literals --- $\specstring$ --- is given by 
 \begin{tabular}{ll}
 \textbf{Lexical Regular Expression} & \textbf{Lexeme Action}\\
 \hline
-$\underbracket{\backslash\ }$ \anycharacter{{\color{white}\backslash}\texttt{n }}  &  $\stringescape$\\
-$\underbracket{\backslash\ }$ \anycharacter{{\color{white}\backslash}\texttt{t }}  &  $\stringescape$\\
-$\underbracket{\backslash\ }$ \anycharacter{{\color{white}\backslash}\texttt{" }}  &  $\stringescape$\\
-$\underbracket{\backslash\ }$ \anycharacter{\ \backslash\ }  & $\stringescape$ \\
+\anycharacter{\backslash\ } \anycharacter{{\color{white}\backslash}\texttt{n }}  &  $\stringescape$\\
+\anycharacter{\backslash\ } \anycharacter{{\color{white}\backslash}\texttt{t }}  &  $\stringescape$\\
+\anycharacter{\backslash\ } \anycharacter{{\color{white}\backslash}\texttt{" }}  &  $\stringescape$\\
+\anycharacter{\backslash\ } \anycharacter{\ \backslash\ }  & $\stringescape$ \\
 \anycharacter{{\color{white}\backslash}\texttt{" }}   &  $\stringfinish$\\
 $\REchar$                                             &  $\stringchar$\\
 \hline
 \end{tabular}
 \end{center}
 
-\subsection{Scanning Multi-line Comments}
+\subsection{Scanning Multi-line Comments\label{sec:scanningmultilinecomments}}
 The lexeme action
 \hypertarget{def-discardcommentchar}{}
 \[

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -604,7 +604,7 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{3} is not great
 \listingref{typing-pmask} shows examples of well-typed mask patterns.
 \ASLListing{Well-typed mask patterns}{typing-pmask}{\typingtests/TypingRule.PMask.asl}
 
-\listingref{typing-pmask-bad} shows an example of an ill-typed mask pattern.
+\listingref{typing-pmask-bad} shows examples of ill-typed mask patterns.
 \ASLListing{An Ill-typed mask pattern}{typing-pmask-bad}{\typingtests/TypingRule.PMask.bad.asl}
 
 \ProseParagraph
@@ -641,17 +641,29 @@ whereas \texttt{match\_false} evaluates to \False, since
 \ASLListing{Matching against a bitmask}{semantics-pmask}{\semanticstests/SemanticsRule.PMask.asl}
 
 \ProseParagraph
-\AllApply
+\OneApplies
 \begin{itemize}
-  \item $\vp$ is a mask pattern, $\PatternMask(\vm)$,
-  of length $n$ (with spaces removed);
-  \item $\vv$ is a native bitvector of bits $\vu_{1..n}$;
-  \item $\vb$ is the native Boolean formed from the conjunction of Boolean values for each $i$,
-  where the bit $\vu_i$ is checked for matching the mask character $\vm_i$;
-  \item $\newg$ is the empty graph.
+  \item \AllApplyCase{empty}
+  \begin{itemize}
+    \item $\vp$ is an empty mask pattern, $\PatternMask(\emptylist)$ (with spaces removed);
+    \item $\vv$ is an empty native bitvector ($\nvbitvector(\emptylist)$);
+    \item \Proseeqdef{$\vb$}{$\True$};
+    \item $\newg$ is the empty graph.
+  \end{itemize}
+
+  \item \AllApplyCase{non\_empty}
+  \begin{itemize}
+    \item $\vp$ is a mask pattern, $\PatternMask(\vm)$,
+    of length $n$ (with spaces removed);
+    \item $\vv$ is a native bitvector of bits $\vu_{1..n}$;
+    \item $\vb$ is the native Boolean formed from the conjunction of Boolean values for each $i$,
+    where the bit $\vu_i$ is checked for matching the mask character $\vm_i$;
+    \item $\newg$ is the empty graph.
+  \end{itemize}
 \end{itemize}
+
 \FormallyParagraph
-\newcommand\maskmatch[0]{\text{mask\_match}}
+\hypertarget{def-maskmatch}{}
 The helper function $\maskmatch : \{0, 1, \vx\} \times \{0,1\} \rightarrow \Bool$,
 checks whether a bit value (second operand) matches a mask value (first operand),
 is defined by the following table:
@@ -668,7 +680,15 @@ is defined by the following table:
 \]
 
 \begin{mathpar}
-\inferrule{
+\inferrule[empty]{
+  \vv \eqname \nvbitvector(\emptylist)
+}{
+  \evalpattern{\env, \vv, \PatternMask(\emptylist)} \evalarrow \Normal(\True, \emptygraph)
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_empty]{
   \vm \eqname \vm_{1..n}\\
   \vv \eqname \nvbitvector(\vu_{1..n})\\
   \vb \eqdef \nvbool(\bigwedge_{i=1..n} \maskmatch(\vm_i, \vu_i))

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -502,7 +502,7 @@ type \texttt{pairT}.
   \isanonymous(\tenv, \vs) \typearrow \vbtwo\\
   \subtypesat(\tenv, \vt, \vs) \typearrow \vbthree\\
   \neg((\vbone \lor \vbtwo) \land \vbthree)\\
-  \vt \eqname \TBits(\widtht, \emptylist)\\
+  \vt = \TBits(\widtht, \emptylist)\\
   \tstruct(\tenv, \vs) \typearrow \TBits(\widths, \Ignore) \OrTypeError\\\\
   \bitwidthequal(\tenv, \widtht, \widths) \typearrow \vb
 }{
@@ -533,7 +533,7 @@ type \texttt{pairT}.
   \neg((\vbone \lor \vbtwo) \land \vbthree)\\
   \tstruct(\tenv, \vs) \typearrow \vsstruct\\
   \astlabel(\vt) = \TBits \land \astlabel(\vsstruct) = \TBits\\
-  \vt \eqname \TBits(\widtht, \bitfields)\\
+  \vt = \TBits(\widtht, \bitfields)\\
   \bitfields \neq \emptylist
 }{
   \typesat(\tenv, \vt, \vs) \typearrow \overname{\False}{\vb}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -575,7 +575,7 @@ and ill-typed declaration statements in comments.
   \tyopt \eqname \langle\vt\rangle \\
   \annotatetype{\tenv, \vt} \typearrow (\vtp, \vses) \OrTypeError\\\\
   \basevalue(\tenv, \vtp) \typearrow \veinit \OrTypeError\\\\
-  \annotatelocaldeclitem{\tenv, \vtp, \LDKVar, \None, \ldip} \typearrow \newtenv \OrTypeError \\
+  \annotatelocaldeclitem(\tenv, \vtp, \LDKVar, \None, \ldip) \typearrow \newtenv \OrTypeError \\
   \news \eqdef \SDecl(\LDKVar, \ldi, \langle\vtp\rangle, \langle\veinit\rangle)
 }{
   \annotatestmt(\tenv, \overname{\SDecl(\LDKVar, \ldi, \tyopt, \None)}{\vs}) \typearrow (\news, \newtenv, \vses)
@@ -669,7 +669,7 @@ See \ExampleRef{Typing Declaration Statements}.
   \begin{itemize}
     \item $\tyopt$ is $\None$;
     \item \Prosenoprecisionloss{\vte};
-    \item $\newtenv$ is the result of $\annotatelocaldeclitem{\tenv, \vte, \ldk, \langle\vep\rangle, \ldi}$\ProseOrTypeError;
+    \item $\newtenv$ is the result of $\annotatelocaldeclitem(\tenv, \vte, \ldk, \langle\vep\rangle, \ldi)$\ProseOrTypeError;
     \item $\tyoptp$ is $\tyopt$;
     \item \Proseeqdef{$\vses$}{the empty set}.
   \end{itemize}

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1473,6 +1473,12 @@ $B$ \Prosetypeclash{}.
 
 See \ExampleRef{Argument Clashing}
 
+\ExampleDef{Ill-typed Subprogram Declarations}
+In specification \listingref{TypeClash-bad}, the type \verb|SuperRec| \emph{\Prosetypeclashes} \verb|SubRec|
+in the static environment where both types have been annotated,
+which is why both declarations of \verb|structured_procedure| clash and thus they are ill-typed.
+\ASLListing{Ill-typed Subprogram Declarations}{TypeClash-bad}{\typingtests/TypingRule.TypeClashes.bad.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -1615,7 +1621,7 @@ See \ExampleRef{Argument Clashing}
   \tstruct(\tenv, \vt) \typearrow \vtstruct \\
   \tstruct(\tenv, \vs) \typearrow \vsstruct \\
   \astlabel(\vtstruct) = \astlabel(\vsstruct)\\
-  \vb \eqdef \astlabel(\vtstruct) \in \{\TRecord, \TException, \TCollection\}\\
+  \astlabel(\vtstruct) \in \{\TRecord, \TException, \TCollection\}
 }{
   \typeclashes(\tenv, \vt, \vs) \typearrow \overname{\False}{\vb}
 }

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -198,7 +198,6 @@ We employ the following rules:
   \item \TypingRuleRef{SlicesEqual}
   \item \TypingRuleRef{SliceEqual}
   \item \TypingRuleRef{ArrayLengthEqual}
-  \item \TypingRuleRef{LiteralEqual}
 \end{itemize}
 
 \TypingRuleDef{Normalize}
@@ -993,7 +992,7 @@ The result is given in $\vb$ or a \typingerrorterm{}, if one is detected.
   \begin{itemize}
     \item $\veone$ is the literal expression with literal $\vvone$;
     \item $\vetwo$ is the literal expression with literal $\vvtwo$;
-    \item $\vb$ is $\True$ if and only if $\vvone$ is equivalent to $\vvtwo$ in $\tenv$.
+    \item $\vb$ is $\True$ if and only if $\vvone$ is equal to $\vvtwo$ in $\tenv$.
   \end{itemize}
 
   \item \AllApplyCase{e\_pattern}
@@ -1179,7 +1178,7 @@ The result is given in $\vb$ or a \typingerrorterm{}, if one is detected.
   \inferrule[e\_literal]{
   \veone = \ELiteral(\vvone)\\
   \vetwo = \ELiteral(\vvtwo)\\\\
-  \literalequal(\vvone, \vvtwo) \typearrow \vb
+  \vb \eqdef \vvone = \vvtwo
 }{
   \exprequalcase(\tenv, \veone, \vetwo) \typearrow \vb
 }
@@ -1477,6 +1476,11 @@ The function
 conservatively tests whether the bitwidth expression $\vwone$ is equivalent to the bitwidth expression $\vwtwo$
 in environment $\tenv$ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
+\ExampleDef{Equivalence of Bitwidth Expressions}
+\listingref{BitwidthEqual} shows examples of equivalent bitwidth expressions on both sides
+of the respective local declaration statements.
+\ASLListing{Equivalence of bitwidth expressions}{BitwidthEqual}{\typingtests/TypingRule.BitwidthEqual.asl}
+
 \ProseParagraph
 Testing whether the expressions $\vwone$ and $\vwtwo$ are equivalent in $\tenv$ yields $\vb$\ProseOrTypeError.
 
@@ -1731,6 +1735,10 @@ The function
 conservatively tests whether the list of slices $\slicesone$ is equivalent to the list of slices $\slicestwo$
 in environment $\tenv$ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
+\ExampleDef{Equivalent Lists of Slices}
+\listingref{SlicesEqual} shows an example of two equivalent lists of slices.
+\ASLListing{Equivalent lists of slices}{SlicesEqual}{\typingtests/TypingRule.SlicesEqual.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -1744,7 +1752,7 @@ in environment $\tenv$ and yields the result in $\vb$.  \ProseOtherwiseTypeError
   \begin{itemize}
     \item checking whether the number of slices in $\slicesone$ is equal to the number of slice in $\slicestwo$ yields $\True$;
     \item determining whether the expression $\slicesone[i]$ is equivalent to $\slicestwo[i]$ in $\tenv$
-          for each index in the indices for $\slicesone$ ($i \in \listrange(\slicesone$) yields $\vb_i$\ProseOrTypeError;
+          for each index in the indices for $\slicesone$ ($i \in \listrange(\slicesone$)), yields $\vb_i$\ProseOrTypeError;
     \item $\vb$ is $\True$ if and only if all $\vb_i$ are $\True$ for each index in the indices for $\slicesone$.
   \end{itemize}
 \end{itemize}
@@ -1778,6 +1786,10 @@ in environment $\tenv$ and yields the result in $\vb$. \ProseOtherwiseTypeError
 
 This function assumes both $\sliceone$ and $\slicetwo$ are \typedast{} nodes,
 which means that they have the form $\SliceLength(\ \cdot\ ,\ \cdot\ )$.
+
+\ExampleDef{Equivalent Slices}
+The specification in \listingref{SliceEqual} shows examples of equivalent slices.
+\ASLListing{Equivalent slices}{SliceEqual}{\typingtests/TypingRule.SliceEqual.asl}
 
 \ProseParagraph
 \AllApply
@@ -1858,26 +1870,6 @@ in $\vb$. \ProseOtherwiseTypeError
   \vb \eqdef (\venumone = \venumtwo)
 }{
   \arraylengthequal(\ArrayLengthEnum(\venumone, \Ignore), \ArrayLengthEnum(\venumtwo, \Ignore)) \typearrow \vb
-}
-\end{mathpar}
-
-\TypingRuleDef{LiteralEqual}
-\hypertarget{def-literalequal}{}
-The function
-\[
-  \literalequal(\overname{\literal}{\vvone} \aslsep \overname{\literal}{\vvtwo}) \rightarrow \overname{\Bool}{\vb}
-\]
-tests whether literal $\vvone$ is $\vvtwo$ by equating them.
-
-\ProseParagraph
-$\vb$ is $\True$ if and only if $\vvone$ is equal to $\vvtwo$.
-
-\FormallyParagraph
-\begin{mathpar}
-\inferrule{
-  \vb \eqdef \vvone = \vvtwo
-}{
-  \literalequal(\vvone, \vvtwo) \typearrow \vb
 }
 \end{mathpar}
 
@@ -2163,6 +2155,19 @@ $\vstwo$                      & -1                         & 0               & 1
 \end{tabular}
 \end{center}
 
+\ExampleDef{Symbolically Summing Signed Expressions}
+The following are some examples of inputs and outputs for symbolic addition:
+\begin{center}
+\begin{tabular}{rrrrrr}
+\textbf{$\vsone$} & \textbf{$\veone$} & \textbf{$\vstwo$} & \textbf{$\vetwo$} & \textbf{$\ve$} & \textbf{$\vs$}\\
+\hline
+-1 & \verb|x| & -1 & \verb|y| & \verb|x+y| & -1\\
+-1 & \verb|x| & 0 & \verb|y| & \verb|x| & -1\\
+-1 & \verb|x| & 1 & \verb|y| & \verb|x-y| & -1\\
+1 & \verb|x| & -1 & \verb|y| & \verb|x-y| & 1\\
+\end{tabular}
+\end{center}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -2323,6 +2328,19 @@ $
 produces an expression representing the multiplication of expressions $\veone$ and $\vetwo$,
 simplifying away the case where one of the operands is the literal one.
 
+\ExampleDef{Symbolic Multiplication}
+The following table shows examples of symbolically multiplying the expression $\veone$ by the expression $\vetwo$,
+yielding the result in $\ve$:
+\begin{center}
+\begin{tabular}{lll}
+\textbf{$\veone$} & \textbf{$\vetwo$} & \textbf{$\ve$}\\
+\hline
+\verb|x*0|  & \verb|1|    & \verb|x*0|\\
+\verb|1|    & \verb|x*0|  & \verb|x*0|\\
+\verb|x*0|  & \verb|x*0|  & \verb|(x*0)*(x*0)|
+\end{tabular}
+\end{center}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -2366,6 +2384,17 @@ The function
 \]
 looks up the environment $\tenv$ for a type $\tty$ associated with an identifier
 $\vs$. The result is \typingerrorterm{} if $\vs$ is not associated with any type.
+
+\ExampleDef{The Type Bound to an Identifier}
+In \listingref{expressions-evar}, the type bound to the global storage element
+\verb|global_non_constant| after annotating the global storage element declarations
+is \verb|integer{19}|,
+%
+the type bound to the local storage element \verb|var_x| in the static environment
+after annotating the local declaration \verb|var var_x = LOCAL_CONSTANT;| is \verb|integer{7}|.
+%
+Invoking $\typeof$ for the static environment just before annotating the local
+declaration \verb|var x = t;| in \listingref{expressions-evar-undefined} yields a \typingerrorterm.
 
 \ProseParagraph
 \OneApplies

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -326,6 +326,7 @@ codes
 collection
 collections
 collectively
+colloquially
 combination
 combinations
 combine
@@ -1726,6 +1727,7 @@ signal
 signals
 signature
 signatures
+signed
 significant
 signifying
 signs

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -511,7 +511,7 @@ def check_rules(filename: str) -> int:
     file_to_num_expected_errors = {
         "RelationsOnTypes.tex" : 15,
         "SubprogramCalls.tex" : 1,
-        "SymbolicEquivalenceTesting.tex" : 26,
+        "SymbolicEquivalenceTesting.tex" : 19,
         "SymbolicSubsumptionTesting.tex" : 23,
         "TypeSystemUtilities.tex" : 23,
         "SemanticsUtilities.tex" : 19,
@@ -686,7 +686,6 @@ def main():
     print("Linting files...")
     all_latex_sources = get_latex_sources(False)
     content_latex_sources = get_latex_sources(True)
-    # content_latex_sources = ["SymbolicEquivalenceTesting.tex"]
     num_errors = 0
     num_spelling_errors = spellcheck(args.dictionary, content_latex_sources)
     if num_spelling_errors > 0:

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMask.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.PMask.asl
@@ -4,8 +4,11 @@ begin
   let match_true = '101010' IN {'xx1010'};
   assert match_true == TRUE;
 
-  let match_false = '101010' IN {'0x1010' };
+  let match_false = '101010' IN {'0x1010'};
   assert match_false == FALSE;
+
+  let match_empty_mask = '' IN {''};
+  assert match_empty_mask == TRUE;
 
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BitwidthEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BitwidthEqual.asl
@@ -1,0 +1,17 @@
+func foo{N}(bv: bits(N))
+begin
+    var x : bits(N DIV 2 + 1) = bv[N DIV 2:0];
+    var y : bits(N DIV 2 + N DIV 2) = bv;
+    var - : bits(3 * N + N) = Ones{4 * N};
+    // The following statement in comment is illegal, since the current equivalence
+    // test cannot determine that `N*N` is equal to `N^2`.
+    // var - : bits(N^2) = Ones{N * N};
+end;
+
+constant FOUR = 4;
+
+func main() => integer
+begin
+    var bv: bits(2^FOUR) = Zeros{FOUR*FOUR};
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.PMask.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.PMask.bad.asl
@@ -3,5 +3,9 @@ begin
     // Illegal: the bitvector width and the mask
     // length must be equal.
     assert '101010' IN {'xx10101'};
+
+    // Illegal: the length of '1' and '' are different.
+    let match_empty_mask_false = '1' IN {''};
+
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SliceEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SliceEqual.asl
@@ -1,0 +1,17 @@
+func foo{N}(bv: bits(N))
+begin
+    var x : bits(N DIV 2 + 1) = bv[N DIV 2:0];
+end;
+
+func main() => integer
+begin
+    var bv: bits(64);
+    bv[5] = bv[5 +: 1];
+    bv[3 *: 4] = bv[(3 * 4 + 4) - 1 : 3 * 4];
+    // The next statement in comment is illegal as the current equivalence test
+    // is too conservative to establish that both slices are equivalent.
+    // bv[(3 * 4 + 4) - 1 : 3 * 4] = bv[3 *: 4];
+    bv[3 *: 4] = bv[15:12];
+    bv[15 : 12] = bv[3 *: 4];
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SlicesEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SlicesEqual.asl
@@ -1,0 +1,6 @@
+func main() => integer
+begin
+    var bv: bits(64);
+    bv[5, 4, 3, 2, 1, 0, 3 *: 4] = bv[:6, 15:12];
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypeClashes.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypeClashes.bad.asl
@@ -1,0 +1,5 @@
+type SuperRec of record;
+type SubRec subtypes SuperRec;
+func structured_procedure(r: SuperRec) begin pass; end;
+// Illegal as `SubRec` subtype-satisfies `SuperRec`.
+func structured_procedure(r: SubRec) begin pass; end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -28,6 +28,11 @@ ASL Typing Tests:
     provided (integer {1}, T2).
   [1]
   $ aslref --no-exec TypingRule.TypeClashes.asl
+  $ aslref --no-exec TypingRule.TypeClashes.bad.asl
+  File TypingRule.TypeClashes.bad.asl, line 3, characters 0 to 55:
+  ASL Typing error: cannot declare already declared element
+    "structured_procedure".
+  [1]
   $ aslref TypingRule.LowestCommonAncestor.asl
   $ aslref TypingRule.FindNamedLCA.asl
   $ aslref TypingRule.ApplyUnopType.asl
@@ -653,3 +658,6 @@ ASL Typing Tests / annotating types:
     produces the following side-effects: [ReadsGlobal "g"].
   [1]
   $ aslref --no-exec TypingRule.MaxTimeFrame.asl
+  $ aslref TypingRule.SliceEqual.asl
+  $ aslref TypingRule.SlicesEqual.asl
+  $ aslref TypingRule.BitwidthEqual.asl


### PR DESCRIPTION
* Added examples to the Symbolic Equivalence Testing chapter.
* Fixed `SemanticsRule.PMask` to account for empty bitmasks.
* Fixed definition of identifiers and real literals - use `\underbracket` instead of the undefined quote notation.
* Fixed definition of whitespace.
* Applied `\anycharacter` more widely in `LexicalStructure.tex`.