### PR TITLE
[herd,aarch64] Split NZCV into 4 1bit registers

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -368,6 +368,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
         -> [r1;r2;]
       | I_WHILELT (r,_,_,_) | I_WHILELE (r,_,_,_)
       | I_WHILELO (r,_,_,_) | I_WHILELS (r,_,_,_)
+      | I_OP3 (_,(ADDS|SUBS|ANDS),r,_,_)
+      | I_ADDSUBEXT (_,(Ext.(ADDS|SUBS)),r,_,_,_)
         ->
           r::nzcv_regs
       | I_LDR (_,r,_,_)

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -373,27 +373,17 @@ module Make (C : Config) = struct
      * Notice that the value is casted into an integer.
      *)
 
-    let is_nzcv =
-      if is_experimental then
-        fun x scope ->
-          match (x, scope) with
-          | "_NZCV", Scope.Global false -> true
-          | _ -> false
-      else
-        fun x scope ->
-          match (x, scope) with
-          | "PSTATE", Scope.Global false -> true
-          | _ -> false
-
-    let is_resaddr x scope =
-      match (x, scope) with "RESADDR", Scope.Global false -> true | _ -> false
+    let reg_of_scoped_id x scope =
+      match (x, scope) with
+      | "_PSTATE_N", Scope.Global false -> ASLBase.ArchReg AArch64Base.(PState PSTATE.N)
+      | "_PSTATE_Z", Scope.Global false -> ASLBase.ArchReg AArch64Base.(PState PSTATE.Z)
+      | "_PSTATE_C", Scope.Global false -> ASLBase.ArchReg AArch64Base.(PState PSTATE.C)
+      | "_PSTATE_V", Scope.Global false -> ASLBase.ArchReg AArch64Base.(PState PSTATE.V)
+      | "RESADDR", Scope.Global false -> ASLBase.ArchReg AArch64Base.ResAddr
+      | _ -> ASLBase.ASLLocalId (scope, x)
 
     let loc_of_scoped_id ii x scope =
-      if is_nzcv x scope then
-        A.Location_reg (ii.A.proc, ASLBase.ArchReg AArch64Base.NZCV)
-      else if is_resaddr x scope then
-        A.Location_reg (ii.A.proc, ASLBase.ArchReg AArch64Base.ResAddr)
-      else A.Location_reg (ii.A.proc, ASLBase.ASLLocalId (scope, x))
+      A.Location_reg (ii.A.proc, reg_of_scoped_id x scope)
 
     (* AArch64 registers hold integers, not bitvectors *)
     let is_aarch64_reg = function

--- a/herd/libdir/asl-pseudocode/pstate-exp.asl
+++ b/herd/libdir/asl-pseudocode/pstate-exp.asl
@@ -1,12 +1,10 @@
 // Experimental implementation of PSTATE as two independant variables.
 
 var _PSTATE : ProcState;
-var _NZCV : ProcState;
-
-func isNZCV(n:integer) => boolean
-begin
-  return 0 <= n && n < 4 ;
-end;
+var _PSTATE_N: bits(1);
+var _PSTATE_Z: bits(1);
+var _PSTATE_C: bits(1);
+var _PSTATE_V: bits(1);
 
 accessor PSTATE() <=> ProcState
 begin
@@ -22,16 +20,28 @@ end;
 accessor PSTATE(n:integer) <=> bits(1)
 begin
   getter begin
-    if isNZCV(n) then
-      return _NZCV[n];
+    if n == 3 then
+      return _PSTATE_N;
+    elsif n == 2 then
+      return _PSTATE_Z;
+    elsif n == 1 then
+      return _PSTATE_C;
+    elsif n == 0 then
+      return _PSTATE_V;
     else
       return _PSTATE[n];
     end;
   end;
 
   setter = v begin
-    if isNZCV(n) then
-      _NZCV[n] = v;
+    if n == 3 then
+      _PSTATE_N = v;
+    elsif n == 2 then
+      _PSTATE_Z = v;
+    elsif n == 1 then
+      _PSTATE_C = v;
+    elsif n == 0 then
+      _PSTATE_V = v;
     else
       _PSTATE[n] = v;
     end;
@@ -41,56 +51,38 @@ end;
 accessor PSTATE(n:integer,m:integer) <=> bits(2)
 begin
   getter begin
-    if isNZCV(n) && isNZCV(m) then
-      return _NZCV[n,m];
-    else
-      return _PSTATE[n,m];
-    end;
+    return PSTATE(n) :: PSTATE(m);
   end;
 
   setter = v begin
-    if isNZCV(n) && isNZCV(m) then
-      _NZCV[n,m] = v;
-    else
-      _PSTATE[n,m] = v;
-    end;
+    PSTATE(n) = v[1];
+    PSTATE(m) = v[0];
   end;
 end;
 
 accessor PSTATE(n:integer,m:integer,o:integer) <=> bits(3)
 begin
   getter begin
-    if isNZCV(n) && isNZCV(m) && isNZCV(o) then
-      return _NZCV[n,m,o];
-    else
-      return _PSTATE[n,m,o];
-    end;
+    return PSTATE(n) :: PSTATE(m) :: PSTATE(o);
   end;
 
   setter = v begin
-    if isNZCV(n) && isNZCV(m) && isNZCV(o) then
-      _NZCV[n,m,o] = v;
-    else
-      _PSTATE[n,m,o] = v;
-    end;
+    PSTATE(n) = v[2];
+    PSTATE(m) = v[1];
+    PSTATE(o) = v[0];
   end;
 end;
 
 accessor PSTATE(n:integer,m:integer,o:integer,p:integer) <=> bits(4)
 begin
   getter begin
-    if isNZCV(n) && isNZCV(m) && isNZCV(o) && isNZCV(p) then
-      return _NZCV[n,m,o,p];
-    else
-      return _PSTATE[n,m,o,p];
-    end;
+    return PSTATE(n) :: PSTATE(m) :: PSTATE(o) :: PSTATE(p);
   end;
 
   setter = v begin
-    if isNZCV(n) && isNZCV(m) && isNZCV(o) && isNZCV(p) then
-      _NZCV[n,m,o,p] = v;
-    else
-      _PSTATE[n,m,o,p] = v;
-    end;
+    PSTATE(n) = v[3];
+    PSTATE(m) = v[2];
+    PSTATE(o) = v[1];
+    PSTATE(p) = v[0];
   end;
 end;

--- a/herd/tests/instructions/ASL/assign1.litmus.expected
+++ b/herd/tests/instructions/ASL/assign1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3)
 Observation assign1 Always 1 0
-Hash=239918d15065818c420ead18b4123575
+Hash=fc25773744be9bfa53298865f85ba5e2
 

--- a/herd/tests/instructions/ASL/assign2.litmus.expected
+++ b/herd/tests/instructions/ASL/assign2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c1=3 /\ 0:main.0.c2=5 /\ 0:main.0.c3=15 /\ 0:main.0.c4=3)
 Observation assign2 Always 1 0
-Hash=98e2c8198685d716f084370c6d93dfe7
+Hash=ffe1b20a379665ec9a55eb84b8c89938
 

--- a/herd/tests/instructions/ASL/assign3.litmus.expected
+++ b/herd/tests/instructions/ASL/assign3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.eq=1 /\ 0:main.0.ne=1 /\ 0:main.0.lt=1 /\ 0:main.0.al=1)
 Observation assign3 Always 1 0
-Hash=b403f3b0ce942458aa8e0a98b882c25e
+Hash=814fcf39305c24dbb6cfb61d16399d6f
 

--- a/herd/tests/instructions/ASL/bitfields1.litmus.expected
+++ b/herd/tests/instructions/ASL/bitfields1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.b=1 /\ 0:main.0.d=1 /\ 0:main.0.e=1)
 Observation bitfields1 Always 1 0
-Hash=f6bb584e083b68646159fb3791b28248
+Hash=63a0d5dbc13bc333c638a694ed5098b5
 

--- a/herd/tests/instructions/ASL/case1.litmus.expected
+++ b/herd/tests/instructions/ASL/case1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=1 /\ 0:main.0.b=0)
 Observation case1 Always 1 0
-Hash=e5bb32d52148afa4e9154ccf882a1289
+Hash=bc7e316d0f7ae8ee9656672ffdfc79cb
 

--- a/herd/tests/instructions/ASL/concat.litmus.expected
+++ b/herd/tests/instructions/ASL/concat.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation Concatenation Always 1 0
-Hash=997fe11b177bc91173a4dfdf882b43e5
+Hash=10f813fa2bf3de56505d0748b0feed85
 

--- a/herd/tests/instructions/ASL/data-return-01.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-01.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation no Always 1 0
-Hash=baf58be4152af0fc668276b372af6b7b
+Hash=fabf88f59baa1eb07f283c19615b26c2
 

--- a/herd/tests/instructions/ASL/data-return-02.litmus.expected
+++ b/herd/tests/instructions/ASL/data-return-02.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation no Always 1 0
-Hash=50d8bbf023547487542974b2cf857480
+Hash=7956f0d2106eb8f1a955de9ac3fca50b
 

--- a/herd/tests/instructions/ASL/double-load.litmus.expected
+++ b/herd/tests/instructions/ASL/double-load.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.three=3)
 Observation double-load Always 1 0
-Hash=e6d7dfff400d582cb5789f1bf40d2b0b
+Hash=325fa3ea5bfb163c9e12e71b91e111eb
 

--- a/herd/tests/instructions/ASL/enum-array.litmus.expected
+++ b/herd/tests/instructions/ASL/enum-array.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation enum-arrays Always 1 0
-Hash=be5ae986ade4b6f6e1a9fc497ec9008a
+Hash=1afe33d23cab0ad659f7a38d83d84bac
 

--- a/herd/tests/instructions/ASL/for1.litmus.expected
+++ b/herd/tests/instructions/ASL/for1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.s=110)
 Observation for1 Always 1 0
-Hash=bd45b66b820e45e40af86be6e26cee56
+Hash=ca041363e4fb47589ccab6785acf63e2
 

--- a/herd/tests/instructions/ASL/func1.litmus.expected
+++ b/herd/tests/instructions/ASL/func1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3 /\ 0:main.0.y=3)
 Observation func1 Always 1 0
-Hash=d9f68b63dd785d263d825c3b7f1144b0
+Hash=8691f30650389795666cc58c6364b149
 

--- a/herd/tests/instructions/ASL/func2.litmus.expected
+++ b/herd/tests/instructions/ASL/func2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=4 /\ 0:X-1.0.internal_i=2 /\ 0:X-1.0.internal_v=3)
 Observation func02 Always 1 0
-Hash=c79fcc3a1e8aa899c9c67f2ee5534a46
+Hash=e78b67c067f7ae6dd87912a587a649aa
 

--- a/herd/tests/instructions/ASL/func3.litmus.expected
+++ b/herd/tests/instructions/ASL/func3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=3 /\ 0:main.0.b=3 /\ 0:main.0.c=7 /\ 0:f3_storage=12 /\ 0:f4_storage=15)
 Observation func3 Always 1 0
-Hash=30075d488e0fe6c178d31ab2f1a840f3
+Hash=c5ce49ec91c0aa0740fde45c660f0c88
 

--- a/herd/tests/instructions/ASL/func4.litmus.expected
+++ b/herd/tests/instructions/ASL/func4.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=0 /\ 0:main.0.b=1 /\ 0:main.0.c=5)
 Observation func4 Always 1 0
-Hash=1725135c8954c6cee5841a83594eb5bf
+Hash=c1f23d7490501e528488968af67127b6
 

--- a/herd/tests/instructions/ASL/globals.litmus.expected
+++ b/herd/tests/instructions/ASL/globals.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation globals Always 1 0
-Hash=3e00d77ff2387cfd945f522c29c297f1
+Hash=d0563986d4dde6e106eea7a71b1746bd
 

--- a/herd/tests/instructions/ASL/records.litmus.expected
+++ b/herd/tests/instructions/ASL/records.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3)
 Observation records Always 1 0
-Hash=a525096870e854b910f1548037573a58
+Hash=be88b08727371471fa2eb78c2aef59e2
 

--- a/herd/tests/instructions/ASL/unknown.litmus.expected
+++ b/herd/tests/instructions/ASL/unknown.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation Unknown Always 2 0
-Hash=4820ca8b37c442cde159de5fd3d5972e
+Hash=4d6a6b7fe7820f41b4e29a461b627b51
 

--- a/herd/tests/instructions/ASL/while1.litmus.expected
+++ b/herd/tests/instructions/ASL/while1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.y=6 /\ 0:main.0.x=0)
 Observation while1 Always 1 0
-Hash=af6eec1dc3e63f59fe6450e6ac6316bf
+Hash=a4fc90ff446899aab352b3414f702faa
 

--- a/herd/tests/instructions/ASL/while2.litmus.expected
+++ b/herd/tests/instructions/ASL/while2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.z=0 /\ 0:main.0.x=2)
 Observation while2 Always 1 0
-Hash=d8cc7b9e128d32e53e4739fa5bf4ff73
+Hash=3a768392abfbae45e605362b59dff920
 

--- a/herd/tests/instructions/ASL/write_mem.litmus.expected
+++ b/herd/tests/instructions/ASL/write_mem.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 0 Negative: 1
 Condition forall ([x]=3)
 Observation write-mem Never 0 1
-Hash=e9513c0291b45e774106925af72a677e
+Hash=719313691fb4deaca7551f344859eafa
 

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -131,7 +131,7 @@ let parse_local_id =
 let parse_reg s =
   match (A64B.parse_reg s, s) with
   | Some r, _ -> Some (ArchReg r)
-  | None, "NZCV" -> Some (ArchReg AArch64Base.NZCV)
+  (* | None, "NZCV" -> Some (ArchReg AArch64Base.NZCV) *)
   | None, _ -> parse_local_id s
 
 (** A list of supported AArch64 registers. *)


### PR DESCRIPTION
This PR splits the NZCV register into 4 1-bit registers.

Only change on the AArch64 front is that where previously there was only one access to NZCV, there will now be multiple, for example:


**`CSEL X0, X1, X2, GE`:**
Before:
![csel-old.pdf](https://github.com/user-attachments/files/19755041/csel-old.pdf)
After:
![csel-new.pdf](https://github.com/user-attachments/files/19755043/csel-new.pdf)

**`CMP X0, X1`:**
Before:
![cmp-old.pdf](https://github.com/user-attachments/files/19755075/cmp-new.pdf)
After:
![cmp-new.pdf](https://github.com/user-attachments/files/19755076/cmp-old.pdf)
