### PR TITLE
[herd][AArch64+ASL] Do not force UDF variant to use ASL

### DIFF
--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -352,5 +352,4 @@ let set_sme_length r = function
 
 let check_tag = function
 | ASLExperimental -> [ASL;ASLExperimental;]
-| ASL_AArch64_UDF -> [ASL;ASL_AArch64_UDF;]
 | tag -> [tag]


### PR DESCRIPTION
This PR removes the implication `-variant AArch64+ASL+UDF` to `-variant ASL` on the architecture `AArch64`. This is because we want to be able to try the `UDF` specific tests without the `ASL` variant.

This comes from cdbacf6e600005d771a57c1fef435d1da478b629 and was spotted by @maranget.

Note: the variant `AArch64+ASL+UDF` does not have any effect if the variant `ASL` is not specified.