### PR TITLE
[asl] refactored accessors grammar

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -661,8 +661,11 @@ let decl :=
     )
   ); { [d] }
   | ~=override; ACCESSOR; name=IDENTIFIER; ~=params_opt; ~=func_args; BIARROW; ~=ty;
-    BEGIN; ~=accessors; end_semicolon;
-    { desugar_accessor_pair override name params_opt func_args ty accessors }
+    ~=accessor_body;
+    { desugar_accessor_pair override name params_opt func_args ty accessor_body }
+
+let accessor_body == BEGIN; ~=accessors; end_semicolon;
+  { accessors }
 
 (* Begin AST *)
 let spec := ~=terminated(list(decl), EOF); < List.concat >

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -475,6 +475,7 @@
 \newcommand\Ncall[0]{\hyperlink{def-ncall}{\nonterminal{call}}}
 \newcommand\Nelidedparamcall[0]{\hyperlink{def-nelidedparamcall}{\nonterminal{elided\_param\_call}}}
 \newcommand\Nfuncargs[0]{\hyperlink{def-nfuncargs}{\nonterminal{func\_args}}}
+\newcommand\Naccessorbody[0]{\hyperlink{def-naccessorbody}{\nonterminal{accessor\_body}}}
 \newcommand\Naccessors[0]{\hyperlink{def-naccessors}{\nonterminal{accessors}}}
 \newcommand\Noverride[0]{\hyperlink{def-noverride}{\nonterminal{override}}}
 \newcommand\Nreturntype[0]{\hyperlink{def-nreturntype}{\nonterminal{return\_type}}}
@@ -811,6 +812,7 @@
 \newcommand\setcalltype[0]{\hyperlink{def-setcalltype}{\textfunc{set\_call\_type}}}
 \newcommand\buildreturntype[0]{\hyperlink{build-returntype}{\textfunc{build\_return\_type}}}
 \newcommand\buildfuncbody[0]{\hyperlink{build-funcbody}{\textfunc{build\_func\_body}}}
+\newcommand\buildaccessorbody[0]{\hyperlink{build-accessorbody}{\textfunc{build\_accessor\_body}}}
 \newcommand\buildaccessors[0]{\hyperlink{build-accessors}{\textfunc{build\_accessors}}}
 \newcommand\buildoverride[0]{\hyperlink{build-override}{\textfunc{build\_override}}}
 \newcommand\buildtypedidentifier[0]{\hyperlink{build-typedidentifier}{\textfunc{build\_typed\_identifier}}}
@@ -2997,7 +2999,7 @@
 \newcommand\vread[0]{\texttt{read}}
 \newcommand\vmodify[0]{\texttt{modify}}
 \newcommand\vsetter[0]{\texttt{setter}}
-\newcommand\vgetter[0]{\texttt{sgtter}}
+\newcommand\vgetter[0]{\texttt{sgetter}}
 \newcommand\vcode[0]{\texttt{code}}
 \newcommand\vAbf[0]{\textbf{A}}
 \newcommand\vBbf[0]{\textbf{B}}

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -25,7 +25,8 @@ Subprogram declarations:
 \Ndecl  \derives \ & \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nreturntype \parsesep \Nfuncbody &\\
 |\ & \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nfuncbody &\\
 |\ & \Taccessor \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Tbiarrow \parsesep \Nty &\\
-   & \wrappedline\ \Tbegin \parsesep \Naccessors \parsesep \Tend \parsesep \Tsemicolon &\\
+   & \wrappedline\ \Naccessorbody &\\
+\Naccessorbody \derives \ & \Tbegin \parsesep \Naccessors \parsesep \Tend \parsesep \Tsemicolon&
 \end{flalign*}
 
 Type declarations:

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -12,11 +12,12 @@ Subprogram declarations have no associated semantics.
 \section{Syntax\label{sec:SubprogramDeclarationsSyntax}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{flalign*}
-\Ndecl  \derives \ & \Noverride \parsesep \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nreturntype \parsesep \Nrecurselimit \\
-& \wrappedline\ \parsesep \Nfuncbody &\\
+\Ndecl  \derives \ & \Noverride \parsesep \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nreturntype \\
+& \wrappedline\ \Nrecurselimit \parsesep \Nfuncbody &\\
 |\ & \Noverride \parsesep \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nfuncbody &\\
 |\ & \Noverride \parsesep \Taccessor \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Tbiarrow \parsesep \Nty &\\
-   & \wrappedline\ \Tbegin \parsesep \Naccessors \parsesep \Tend \parsesep \Tsemicolon &\\
+   & \wrappedline\ \Naccessorbody &\\
+\Naccessorbody \derives \ & \Tbegin \parsesep \Naccessors \parsesep \Tend \parsesep \Tsemicolon&
 \end{flalign*}
 
 \begin{flalign*}
@@ -148,16 +149,27 @@ In particular, rather than directly building the abstract syntax for accessors, 
 
 \begin{mathpar}
 \inferrule[accessor]{
-  \buildaccessors(\vaccessors) \astarrow \vaccessorpair \\
-  \desugaraccessorpair(\voverride, \name, \astof{\vparamsopt}, \astof{\vfuncargs}, \astof{\tty}, \vaccessorpair) \astarrow \vastnode
+  \buildaccessorbody(\vbody) \astarrow \vaccessorpair \\
+  {
+  \desugaraccessorpair\left(
+    \begin{array}{l}
+    \voverride,\\
+    \name,\\
+    \astof{\vparamsopt},\\
+    \astof{\vfuncargs},\\
+    \astof{\tty},\\
+    \vaccessorpair
+    \end{array}
+    \right) \astarrow \vastnode
+  }
 }{
   {
   \begin{array}{r}
     \builddecl\left(\overname{\Ndecl\left(
       \begin{array}{l}
-        \punnode{\Noverride}, \Taccessor, \Tidentifier(\name), \punnode{\Nparamsopt}, \punnode{\Nfuncargs},
-        \Tbiarrow, \punnode{\Nty}, \\
-        \wrappedline\ \Tbegin, \namednode{\vaccessors}{\Naccessors}, \Tend, \Tsemicolon
+        \punnode{\Noverride}, \Taccessor, \Tidentifier(\name), \punnode{\Nparamsopt},  \\
+        \wrappedline\ \punnode{\Nfuncargs},
+        \Tbiarrow, \punnode{\Nty}, \namednode{\vbody}{\Naccessorbody}
       \end{array}
     \right)}{\vparsednode}\right)
   \\ \astarrow \vastnode
@@ -173,11 +185,32 @@ For example, this could model a register file consisting of 32 registers, each o
 
 \ASLListing{An accessor declaration}{AccessorDeclaration}{\definitiontests/Accessor.asl}
 
+\ASTRuleDef{AccessorBody}
+\hypertarget{build-accessorbody}{}
+The relation
+\[
+  \buildaccessorbody : \overname{\parsenode{\Naccessorbody}}{\vparsednode} \;\aslrel\; \overname{\accessorpair}{\vaccessorpair}
+\]
+transforms a parse node $\vparsednode$ into an $\accessorpair$.
+
+\begin{mathpar}
+\inferrule{
+  \buildaccessors(\vaccessors) \astarrow \vaccessorpair
+}{
+    \builddecl\left(\overname{\Ndecl\left(
+      \begin{array}{l}
+        \Tbegin, \namednode{\vaccessors}{\Naccessors}, \Tend, \Tsemicolon
+      \end{array}
+    \right)}{\vparsednode}\right)
+  \astarrow \vastnode
+}
+\end{mathpar}
+
 \ASTRuleDef{RecurseLimit}
 \hypertarget{build-recurselimit}{}
 The function
 \[
-\buildrecurselimit(\overname{\parsenode{\Nrecurselimit}}{\vparsednode}) \aslto \overname{\langle\expr\rangle}{\vastnode}
+\buildrecurselimit(\overname{\parsenode{\Nrecurselimit}}{\vparsednode}) \aslto \overname{\accessorpair}{\vaccessorpair}
 \]
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -215,7 +215,7 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
                    & \wrappedline\ \Nfuncbody\\
 |\ & \Noverride \parsesep \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nfuncbody &\\
 |\ & \Noverride \parsesep \Taccessor \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Tbiarrow \parsesep \Nty &\\
-   & \wrappedline\ \Tbegin \parsesep \Naccessors \parsesep \Tend \parsesep \Tsemicolon &\\
+   & \wrappedline\ \Naccessorbody &\\
 |\ & \Ttype \parsesep \Tidentifier \parsesep \Tof \parsesep \Ntydecl \parsesep \Nsubtypeopt \parsesep \Tsemicolon &\\
 |\ & \Ttype \parsesep \Tidentifier \parsesep \Nsubtype \parsesep \Tsemicolon &\\
 |\ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} &\\
@@ -303,6 +303,11 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \hypertarget{def-nignoredoridentifier}{}
 \begin{flalign*}
 \Nignoredoridentifier \derives \ & \Tminus \;|\; \Tidentifier &
+\end{flalign*}
+
+\hypertarget{def-naccessorbody}{}
+\begin{flalign*}
+\Naccessorbody \derives \ & \Tbegin \parsesep \Naccessors \parsesep \Tend \parsesep \Tsemicolon&
 \end{flalign*}
 
 \hypertarget{def-naccessors}{}


### PR DESCRIPTION
Made change to grammar of accessor declarations to match that of subprogram declarations:
* Changed 
`decl -> override "accessor" ID params_opt func_args "<=>" ty"begin" accessors "end" ";"`
into 
`decl -> override "accessor" ID params_opt func_args "<=>" ty" accessors_body`
and added
`accessors_body -> "begin" accessors "end" ";"`

* Updated ASL Reference.