### PR TITLE
[herd] Complete tracking of the NZCV "register"

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -327,7 +327,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
           -> None
 
     let all_regs =
-      all_gprs@vregs (* Should be enough, only those are tracked *)
+      nzcv_regs@all_gprs@vregs (* Should be enough, only those are tracked *)
 
     let all_streaming_regs =
       zregs@pregs
@@ -366,6 +366,10 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDRSW (r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
       | I_LDRS (_,r1,r2,MemExt.Imm (_,(PreIdx|PostIdx)))
         -> [r1;r2;]
+      | I_WHILELT (r,_,_,_) | I_WHILELE (r,_,_,_)
+      | I_WHILELO (r,_,_,_) | I_WHILELS (r,_,_,_)
+        ->
+          r::nzcv_regs
       | I_LDR (_,r,_,_)
       | I_LDRSW (r,_,_)
       | I_LDRBH (_,r,_,_)
@@ -393,7 +397,6 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_ADDV (_,r,_)
       | I_DUP (r,_,_)
       | I_FMOV_TG (_,r,_,_)
-      | I_WHILELT (r,_,_,_) | I_WHILELE (r,_,_,_) | I_WHILELO (r,_,_,_) | I_WHILELS (r,_,_,_)
       | I_UADDV (_,r,_,_)
       | I_MOV_SV (r,_,_)
       | I_DUP_SV (r,_,_) | I_ADD_SV (r,_,_) | I_PTRUE (r,_)
@@ -403,6 +406,9 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD1SPT (_,r,_,_,_,_,_) | I_MOVA_TV (r,_,_,_,_) | I_MOVA_VT (r,_,_,_,_)
       | I_ADDA (_,r,_,_,_)
         -> [r]
+      | I_MSR (SYS_NZCV,_)
+        ->
+          nzcv_regs
       | I_MSR (sr,_)
         -> [(SysReg sr)]
       | I_LDXP (_,_,r1,r2,_)

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2584,8 +2584,8 @@ module Make
             let flags = n >>| z >>= fun (v1,v2) ->
               M.op Op.Or v1 v2 >>| c >>= fun (v1,v2) ->
                 M.op Op.Or v1 v2 in
-            flags >>= fun flags -> write_reg AArch64Base.NZCV flags ii
-          ) >>! new_val
+            flags >>= fun flags -> write_reg_dest AArch64Base.NZCV flags ii
+          ) >>= fun ((),nzcv_val) -> M.unitT [AArch64Base.NZCV,nzcv_val; p,new_val]
 
       let ptrue p pattern ii =
         let psize = predicate_psize p in
@@ -3887,16 +3887,16 @@ module Make
           >>= nextSet p
         | I_WHILELT(p,var,r1,r2) ->
           check_sve inst;
-          while_op (M.op Op.Lt) false p var r1 r2 ii >>= nextSet p
+          while_op (M.op Op.Lt) false p var r1 r2 ii >>= B.nextBdsT
         | I_WHILELO(p,var,r1,r2) ->
           check_sve inst;
-          while_op (M.op Op.Lt) true p var r1 r2 ii >>= nextSet p
+          while_op (M.op Op.Lt) true p var r1 r2 ii >>= B.nextBdsT
         | I_WHILELE(p,var,r1,r2) ->
           check_sve inst;
-          while_op (M.op Op.Le) false p var r1 r2 ii >>= nextSet p
+          while_op (M.op Op.Le) false p var r1 r2 ii >>= B.nextBdsT
         | I_WHILELS(p,var,r1,r2) ->
           check_sve inst;
-          while_op (M.op Op.Le) true p var r1 r2 ii >>= nextSet p
+          while_op (M.op Op.Le) true p var r1 r2 ii >>= B.nextBdsT
         |  I_ADD_SV (r1,r2,r3) ->
           check_sve inst;
           !(add_sv r1 r2 r3 ii)

--- a/herd/branch.ml
+++ b/herd/branch.ml
@@ -51,6 +51,7 @@ module type S = sig
   val next3T : ((unit * unit) * unit) -> t monad
   val next4T : (((unit * unit) * unit) * unit) -> t monad
   val nextSetT : reg -> v -> t monad
+  val nextBdsT : (reg *v) list -> t monad
 (* Non-conditional branch *)
   val branchT : lbl ->  t monad
 (* Indirect branch *)
@@ -98,6 +99,7 @@ module Make(M:Monad.S) = struct
   let next3T (((),()),()) = nextT
   let next4T ((((),()),()), ()) = nextT
   let nextSetT r v = M.unitT (Next [r,v])
+  let nextBdsT bds = M.unitT (Next bds)
   let branchT tgt = M.unitT (Jump (Lbl tgt,[]))
   let indirectBranchT v lbls bds = M.unitT (IndirectJump (v,lbls,bds))
   let bccT v lbl = M.unitT (CondJump (v,Lbl lbl))

--- a/herd/tests/instructions/AArch64.sve/V31.litmus
+++ b/herd/tests/instructions/AArch64.sve/V31.litmus
@@ -1,0 +1,11 @@
+AArch64 V31
+{
+uint64_t 0:X3;
+0:X0=0; 0:X1=1;
+}
+   P0               ;
+ CMP W0,W1          ;
+ WHILELT P0.S,W0,W1 ;
+ MRS X3,NZCV        ;
+
+forall 0:X3=0xa0000000

--- a/herd/tests/instructions/AArch64.sve/V31.litmus.expected
+++ b/herd/tests/instructions/AArch64.sve/V31.litmus.expected
@@ -1,0 +1,11 @@
+Test V31 Required
+States 1
+0:X3=2684354560;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Scalable-Vector-Extensions-is-work-in-progress
+Condition forall (0:X3=2684354560)
+Observation V31 Always 1 0
+Hash=8c2fa76386c9fbda4a6bbe9961e4dbed
+

--- a/herd/tests/instructions/AArch64/L104.litmus
+++ b/herd/tests/instructions/AArch64/L104.litmus
@@ -1,0 +1,12 @@
+AArch64 L104
+{
+0:X2=0;
+uint64_t 0:X0;
+uint64_t 0:X1;
+}
+   P0        ;
+ CMP W2,WZR  ;
+ MSR NZCV,X0 ;
+ MRS X1,NZCV ;
+forall 0:X1=0
+

--- a/herd/tests/instructions/AArch64/L104.litmus.expected
+++ b/herd/tests/instructions/AArch64/L104.litmus.expected
@@ -1,0 +1,10 @@
+Test L104 Required
+States 1
+0:X1=0;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=0)
+Observation L104 Always 1 0
+Hash=b0ffca39eb125a5af375bb60a2e6e7fd
+

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -200,6 +200,8 @@ let gprs =
   R28; R29; R30;
 ]
 
+let nzcv_regs = [NZCV;]
+
 let vec_regs =
 [
   V0 ; V1 ; V2 ; V3 ;


### PR DESCRIPTION
This PR fixes a bug found by @murzinv while reviewing PR #1258.

Namely, herd crashes on the following test:
```
AArch64 NZCV-03
Variant=sve
{
uint64_t 0:X3;
0:X0=0; 0:X1=1;
}
   P0               ;
 CMP W0,W1          ;
 WHILELT P0.S,W0,W1 ;
 MRS X3,NZCV        ;

forall 0:X3=0xa0000000
```

The root cause of the crash is a discrepancy between the interpretation time  and solver time values of the `NZCV` flags. More precisely, the `MRS X3,NZCV ` uses the interpretation time value; while the `WHILELT` instruction does not signal that it destroys the previous values of the flags.

Instructions that write into the NZCV "register" must signal it as follows:
  1. Include the `NZCV` into the kill list of the instruction, (function `killed` in AArch64Arch_herd.ml`)
  2. Include the new binding as a result of instruction interpretation.

Notice that 1. or 2. alone are enough, 1. is simpler; while 2: leads to potential optimisations while interpreting the instructions that follow. Having both enhances code robustness, especially in the presence of alternative means of instruction interpretation such as ASL.

A quick way to implement 1. above is to kill all registers as we do for all morello instructions.

As far as we have checked, instructions that write the NZCV flags are: Some operations, namely ADDS, SUBS, ANDS, BICS, the SVE WHILE.. instructions, the Morello CSEAL instruction. and the MSR NZCV,... instruction.
