### PR TITLE
[asl][reference] make names with underscore PDF-searchable

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1,3 +1,4 @@
+\usepackage[T1]{fontenc} % makes names with underscore searchable in the PDF.
 \usepackage{amsmath}  % Classic math package
 \usepackage{amssymb}  % Classic math package
 \usepackage{mathtools}  % Additional math package


### PR DESCRIPTION
Included `\usepackage[T1]{fontenc}` to make names with underscores searchable in the generated PDF.
For example, now, searching for "eval_expr" finds its instances whereas before one had to look for "eval expr".