### PR TITLE
[gen] Bye-bye Joker

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1714,8 +1714,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 (* Access *)
 (**********)
 
-    let emit_joker st init = None,init,[],st
-
     let add_tag =
       if do_memtag then
         fun loc tag -> Code.add_tag loc tag
@@ -1901,7 +1899,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               (A.pp_atom a) (Code.pp_dir d)
         | _,Some (Plain _,None) -> assert false
         | _,Some (Tag,_) -> assert false
-        | J,_ -> emit_joker st init
         | W,Some (CapaTag,None) ->
             let init,cs,st = STCT.emit_store st p init loc value in
             None,init,cs,st
@@ -2436,7 +2433,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
              let init,cs,st = emit_store_idx vdep st p init loc r2 value in
               None,init,pseudo cs0@cs,st
           | W,Some (Neon _,Some _) -> assert false
-          | J,_ -> emit_joker st init
           | _,Some (Plain _,None) -> assert false
           end
       | _,Code _ -> Warn.fatal "No dependency to code location"
@@ -2649,7 +2645,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
              None,init,cs2@cs,st
           | Some (Pair _,Some _) -> assert false
           end
-      | Some J,_ -> emit_joker st init
       | _,Code _ -> Warn.fatal "Not Yet (%s,dep_data)" (C.debug_evt e)
       (* END of emit_access_dep_data *)
 

--- a/gen/ARMCompile_gen.ml
+++ b/gen/ARMCompile_gen.ml
@@ -248,8 +248,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 (* Acccesses *)
 (*************)
 
-    let emit_joker st init = None,init,[],st
-
     let emit_access  st p init e =  
     (* collapse the value `v` in event `e` to integer *)
     let value = Code.value_to_int e.v in
@@ -274,7 +272,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let ro,init,cs,st = emit_sta st p init loc value in
             ro,init,cs,st
         | _,Some (Mixed _),Data _ -> assert false
-        | Code.J,_,Data _ -> emit_joker st init
         | _,_,Code _ -> Warn.fatal "No code location in ARM"
 
     let emit_exch st p init er ew =
@@ -315,7 +312,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           let ro,init,cs,st = emit_sta_idx st p init loc r2 value in
           ro,init,Instruction c::cs,st
       | _,Some (Mixed _),Data _ -> assert false
-      | Code.J,_,Data _ -> emit_joker st init
       | _,_,Code _ -> Warn.fatal "No code location for arch ARM"
 
     let emit_exch_dep_addr st p init er ew rd =
@@ -349,7 +345,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | Some (Mixed _),Data _ -> assert false
           | _,Code _ -> Warn.fatal "No code location for arch ARM"
           end
-     | Some Code.J -> assert false
 
     let insert_isb isb cs1 cs2 =
       if isb then cs1@[Instruction I_ISB]@cs2

--- a/gen/BellArch_gen.ml
+++ b/gen/BellArch_gen.ml
@@ -111,7 +111,6 @@ let instr_atom = None
 let tr_dir = function
   | R -> BellName.r
   | W -> BellName.w
-  | J -> BellName.j
 
 let applies_atom = match bi with
 | None -> (fun a _d -> match a with [] -> true | _ -> false)

--- a/gen/BellCompile.ml
+++ b/gen/BellCompile.ml
@@ -70,8 +70,6 @@ module Make(Cfg:Config)(BO:BellArch_gen.Config) : XXXCompile_gen.S =
 (* Export *)
 (**********)
 
-let emit_joker st init = None,init,[],st
-
 (* Loads (some specific added) *)
     let emit_load_tagged st _p init x a =
       let rA,st = next_reg st in
@@ -181,7 +179,6 @@ zz        (fun r lab -> bcc Ne r rP lab)
         | W,Some a,Data loc ->
             let init,cs,st = emit_store_tagged st p init loc value a in
             None,init,cs,st
-        | J,_,_ -> emit_joker st init
         | _,_,Code _ -> Warn.fatal "No code location in Bell"
 
 (* Dubious... *)
@@ -238,7 +235,6 @@ let emit_rmw _ = assert false
       | W,Some a,Data loc ->
           let init,cs,st = emit_store_idx_tagged st p init loc value idx a in
           None,init,cA::cs,st
-      | J,_,Data _ -> emit_joker st init
       | _,_,Code _ -> Warn.fatal "No code location for Bell"
       end
 
@@ -256,7 +252,6 @@ let emit_rmw _ = assert false
             let init,cs,st = emit_store_reg_tagged st p init loc r2 a in
             None,init,cs2@cs,st
         end
-    | Some J,Data _ -> emit_joker st init
     | _,Code _ -> Warn.fatal "No code location for Bell"
 
     let emit_access_ctrl st p init e r1 v1 =

--- a/gen/CCompile_gen.ml
+++ b/gen/CCompile_gen.ml
@@ -282,7 +282,7 @@ module Make(O:Config) : Builder.S
               compile_exch_assertvalue n.C.edge e.C.v st p mo mo_w loc v in
             Some r,i,st
         | (Some W|None),_ -> None,A.Nop,st
-        | (Some J,_)|(_,Code _) -> assert false
+        | (_,Code _) -> assert false
         else match e.C.dir,e.C.loc with
         | Some R,Data loc ->
             let loc = A.Loc loc in
@@ -296,7 +296,7 @@ module Make(O:Config) : Builder.S
             let i = compile_store pdp e in
             None,i,st
         | (None,Data _) -> None,A.Nop,st
-        | (Some J,_)|(_,Code _) -> assert false
+        | (_,Code _) -> assert false
 
 (* Lift definitions *)
       module RegSet =
@@ -721,7 +721,7 @@ module Make(O:Config) : Builder.S
                       (i,A.If (ce,add_fence n ins,load_checked_not))),
                   st
             | (Some W|None),_  -> None,add_fence n,st
-            | (Some J,_)|(_,Code _) -> assert false
+            | (_,Code _) -> assert false
             else begin match e.C.dir,e.C.loc with
             | None,_ -> Warn.fatal "TODO"
             | Some R,Data x ->
@@ -745,7 +745,7 @@ module Make(O:Config) : Builder.S
                 None,
                 (fun ins -> A.Seq (compile_store No e,add_fence n ins)),
                 st
-            | (Some J,_)|(_,Code _) -> assert false
+            | (_,Code _) -> assert false
             end in
           let is,fs,st = do_compile_proc_check loc_writes st p ns in
           let obs,fs,st = observe_local_check st p fs n in

--- a/gen/MIPSCompile_gen.ml
+++ b/gen/MIPSCompile_gen.ml
@@ -251,8 +251,6 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
 (* Acccesses *)
 (*************)
 
-let emit_joker st init = None,init,[],st
-
     let emit_access  st p init e = match e.dir with
     | None -> Warn.fatal "MIPSCompile.emit_access"
     | Some d ->
@@ -276,7 +274,6 @@ let emit_joker st init = None,init,[],st
             let ro,init,cs,st = emit_sta st p init loc value in
             ro,init,cs,st
         | _,Some (Mixed _),Data _ -> assert false
-        | J, _,Data _ -> emit_joker st init
         | _,_,Code _ -> Warn.fatal "No code location for arch MIPS"
 
     let emit_exch st p init er ew =
@@ -316,7 +313,6 @@ let emit_joker st init = None,init,[],st
               let ro,init,cs,st = emit_sta_idx st p init loc r2 value in
               ro,init,Instruction c::cs,st
           | _,Some (Mixed _) -> assert false
-          | J,_ -> emit_joker st init
           end
       | _,Code _ -> Warn.fatal "No code location for MIPS"
 
@@ -352,7 +348,6 @@ let emit_joker st init = None,init,[],st
               Warn.fatal "No store with reservation"
           | Some (Mixed _) -> assert false
           end
-      | Some J,_ -> emit_joker st init
       | _,Code _ -> Warn.fatal "No code location for MIPS"
 
     let emit_access_ctrl st p init e r1 =

--- a/gen/PPCCompile_gen.ml
+++ b/gen/PPCCompile_gen.ml
@@ -307,8 +307,6 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
 
     let emit_one_stwcx st p init x v = emit_one_stwcx_idx st p init x PPC.r0 v
 
-    let emit_joker st init = None,init,[],st
-
     let emit_access st p init e = match e.dir with
     | None -> Warn.fatal "TODO"
     | Some d ->
@@ -342,7 +340,6 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
             | W,Some (PPC.Mixed (sz,o)) ->
                 let init,cs,st = emit_store_mixed sz o st p init loc value in
                 None,init,cs,st
-            | J,_ -> emit_joker st init
             end
         end
 
@@ -392,7 +389,6 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
               Warn.fatal "No store with reservation"
           | _,Some (PPC.Mixed _) ->
               Warn.fatal "addr dep with mixed"
-          | J,_ -> emit_joker st init
           end
 
     let emit_exch_dep_addr st  p init er ew rd =
@@ -432,7 +428,6 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
                 None,init,cs,st
             | Some PPC.Reserve -> Warn.fatal "No store with reservation" in
           ro,init,cs2@cs,st
-      | Some J,_ -> emit_joker st init
 
     let insert_isync cs1 cs2 = cs1@[PPC.Instruction PPC.Pisync]@cs2
 
@@ -476,7 +471,6 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
                 let r,init,cs,st = emit_sta st p init loc value in
                 Some r,init,cs,st in
           ro,init,(if isync then insert_isync c cs else c@cs),st
-      | Some J,_ -> emit_joker st init
       | _,Code _ -> Warn.fatal "No code location for PPC"
 
     let emit_exch_ctrl isync st p init er ew rd =

--- a/gen/RISCVArch_gen.ml
+++ b/gen/RISCVArch_gen.ml
@@ -59,7 +59,6 @@ module Make
        | (Acq,Code.W)|(Rel,Code.R) -> false
        | (Rel, Code.W)|(Acq, Code.R)
        | ((Rlx|AcqRel), _) -> true
-       | _,Code.J -> assert false
        | Sc,_ -> assert false
        end
    | Atomic _|Mixed _ -> true
@@ -189,7 +188,6 @@ module Make
    | (W|OW),Code.R
    | (R|IR),Code.W
      -> false
-   | _ -> assert false
 
    let orders f d1 d2 = match f with
    | FenceI -> false

--- a/gen/RISCVCompile_gen.ml
+++ b/gen/RISCVCompile_gen.ml
@@ -363,8 +363,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
 (**********)
 (* Access *)
 (**********)
-    let emit_joker st init = None,init,[],st
-
     let emit_access  st p init e = match e.dir,e.loc with
     | None,_ -> Warn.fatal "TODO"
     | Some d,Data loc ->
@@ -395,7 +393,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
         | Code.W,Some (Mixed (sz,o)) ->
             let init,cs,st = emit_store_mixed sz o st p init loc value in
             None,init,cs,st
-        | Code.J, _ -> emit_joker st init
         end
     | _,Code _ -> Warn.fatal "No code location for RISCV"
 
@@ -482,7 +479,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
               Some r,init,Instruction c::cs,st
           | _,Some (Mixed _) ->
               Warn.fatal "addr dep with mixed"
-          | Code.J, _ -> emit_joker st init
           end
       | _,Code _ -> Warn.fatal "No code location for RISCV"
 
@@ -519,7 +515,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
           | Some (Mixed _) ->
               Warn.fatal "data dep with mixed"
           end
-      | Some Code.J,_ -> emit_joker st init
       | _,Code _ -> Warn.fatal "No code location for RISCV"
 
     let insert_isb st p init isb cs1 cs2 =

--- a/gen/X86Compile_gen.ml
+++ b/gen/X86Compile_gen.ml
@@ -110,8 +110,6 @@ struct
   let emit_obs_not_eq  st =  emit_load_not st
   let emit_obs_not_value  st = emit_load_not st
 
-  let emit_joker st init = None,init,[],st
-
   let emit_access st _p init e = 
   (* collapse the value `v` in event `e` to integer *)
   let value = Code.value_to_int e.C.v in
@@ -134,7 +132,6 @@ struct
         st
       else
         None,init,pseudo [emit_store loc value],st
-  | Some J,_ -> emit_joker st init
   | _,Code _ -> Warn.fatal "No code location for X86"
 
   let emit_exch st _p init er ew =

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -52,9 +52,9 @@ module Make
       let applies_atom a d = match a,d with
       | ((Atomic,_),Code.W)
       | (((Plain|NonTemporal),_),(Code.W|Code.R)) -> true
-      | ((Atomic,_),Code.R)
-      | (_,Code.J)-> false
-    let is_ifetch _ = false
+      | ((Atomic,_),Code.R) -> false
+
+      let is_ifetch _ = false
 
       let compare_atom = compare
 

--- a/gen/X86_64Compile_gen.ml
+++ b/gen/X86_64Compile_gen.ml
@@ -313,8 +313,6 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
     let emit_obs_not_eq = emit_load_not_eq
     let emit_obs_not_zero = emit_load_not_zero
 
-    let emit_joker st init = None,init,[],st
-
     let emit_access st _p init e = 
       (* collapse the value `v` in event `e` to integer *)
       let value = Code.value_to_int e.C.v in
@@ -366,7 +364,6 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
                   let init,cs,st = emit_store_mixed sz o st _p init loc value in
                   None,init,cs,st
                end
-            | J -> emit_joker st init
             end
          | Code _ -> Warn.fatal "No code location for X86_64"
          end

--- a/gen/code.ml
+++ b/gen/code.ml
@@ -81,7 +81,7 @@ let pp_proc p = Proc.pp p
 type env = (string * v) list
 
 (* Direction of event *)
-type dir = W | R | J
+type dir = W | R
 
 (* Edges compoments that do not depend on architecture *)
 
@@ -98,7 +98,6 @@ type extr = Dir of dir | Irr | NoDir
 let pp_dir = function
   | W -> "W"
   | R -> "R"
-  | J -> "J"
 
 let pp_ie = function
   | Int -> "i"
@@ -120,11 +119,7 @@ let seq_sd sd1 sd2 =
 
 let fold_ie f r = f Ext (f Int r)
 let fold_sd f r = f Diff (f Same r)
-let do_fold_extr withj f r =
-  let r = f (Dir W) (f (Dir R) (f Irr r)) in
-  if withj then f (Dir J) r
-  else r
-let fold_extr f r = do_fold_extr false f r
+let fold_extr f r = f (Dir W) (f (Dir R) (f Irr r))
 let fold_sd_extr f = fold_sd (fun sd -> fold_extr (fun e -> f sd e))
 let fold_sd_extr_extr f =
   fold_sd_extr (fun sd e1 -> fold_extr (fun e2 -> f sd e1 e2))

--- a/gen/code.mli
+++ b/gen/code.mli
@@ -46,7 +46,7 @@ val pp_proc : proc -> string
 type env = (string * v) list
 
 (* Direction of event *)
-type dir = W | R | J
+type dir = W | R
 
 (* Edges compoments that do not depend on architecture *)
 
@@ -68,7 +68,6 @@ val pp_extr : extr -> string
 val pp_sd : sd -> string
 val seq_sd : sd -> sd -> sd
 val fold_ie : (ie -> 'a -> 'a) -> 'a -> 'a
-val do_fold_extr : bool -> (extr -> 'a -> 'a) -> 'a -> 'a
 val fold_extr : (extr -> 'a -> 'a) -> 'a -> 'a
 val fold_sd : (sd -> 'a -> 'a) -> 'a -> 'a
 val fold_sd_extr : (sd -> extr -> 'a -> 'a) -> 'a -> 'a

--- a/gen/diycross.ml
+++ b/gen/diycross.ml
@@ -78,7 +78,7 @@ module Make (Config:Config) (M:Builder.S) =
     let someR sd d =
       er (Po (sd,Dir R,Dir d))::
       app_def_dp
-        (match d with R|J -> M.A.ddr_default | W -> M.A.ddw_default)
+        (match d with R -> M.A.ddr_default | W -> M.A.ddw_default)
         (fun dp k -> er (Dp (dp,sd,Dir d))::k)
         (some_fences sd R d [])
 
@@ -90,7 +90,7 @@ module Make (Config:Config) (M:Builder.S) =
 (* ALL *)
     let allR sd d =
       er (Po (sd,Dir R,Dir d))::
-	      (match d with R|J -> M.A.fold_dpr | W -> M.A.fold_dpw)
+	      (match d with R -> M.A.fold_dpr | W -> M.A.fold_dpw)
         (fun dp k -> er (Dp (dp,sd,Dir d))::k)
         (all_fences sd R d [])
 

--- a/gen/edge.ml
+++ b/gen/edge.ml
@@ -146,7 +146,6 @@ module type S = sig
   val is_ext : edge -> bool
   val is_com : edge -> bool
   val is_fetch : edge -> bool
-  val is_po_or_fenced_joker : edge -> bool
 
 (* Set/Map *)
   module Set : MySet.S with type elt = edge
@@ -326,7 +325,6 @@ and type rmw = F.rmw = struct
     | Store -> "Store"
     | Node W -> "Write"
     | Node R -> "Read"
-    | Node J -> assert false
 
   let pp_tedge = do_pp_tedge false
 
@@ -747,10 +745,6 @@ let fold_tedges f r =
   let compat_atoms a1 a2 = match F.merge_atoms a1 a2 with
   | None -> false
   | Some _ -> true
-
-  let is_po_or_fenced_joker e = match e.edge with
-  | Po(_,Dir J,_) | Po(_,_,Dir J) | Fenced(_,_,Dir J,_) | Fenced(_,_,_,Dir J) -> true
-  | _ -> false
 
   let can_precede_atoms x y = match x.a2,y.a1 with
   | None,_

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -194,7 +194,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
         | Some Code.W ->
            assert (evt.C.C.bank = Code.Ord || evt.C.C.bank = Code.CapaSeal) ;
            Some (I ( evt.C.C.v |> Code.value_to_int |> prev_value |> Code.value_of_int ) )
-        | None|Some Code.J -> None in
+        | None -> None in
         if show_in_cond n then match v with
         | Some v ->
            let add_to_fs r v fs =

--- a/gen/normaliser.ml
+++ b/gen/normaliser.ml
@@ -299,20 +299,18 @@ module Make : functor (C:Config) -> functor (E:Edge.S) ->
     end
 (* In/Out *)
     module Dir = struct
-      type t = R | W | F | J
+      type t = R | W | F
       let pp = function
         | R -> "R"
         | W -> "W"
         | F -> "F"
-        | J -> "J"
 
       let tr e =
         let d = Misc.as_some e.CE.dir in
         let r =
           match d with
           | Code.W -> W
-          | Code.R -> R
-          | Code.J -> J in
+          | Code.R -> R in
         if debug then
           eprintf "%s[%s] -> %s\n"
             (E.pp_edge e.CE.edge) (Code.pp_dir d)

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -311,8 +311,7 @@ and type edge = E.edge
         let someR sd d =
           er (E.Po (sd,Dir R,Dir d))::
           app_def_dp
-            (match d with R | J -> F.ddr_default
-                          | W -> F.ddw_default)
+            (match d with R -> F.ddr_default | W -> F.ddw_default)
             (fun dp k -> er (E.Dp (dp,sd,Dir d))::k)
             (some_fences sd R d [])
 
@@ -324,8 +323,7 @@ and type edge = E.edge
 (* ALL *)
         let allR sd d =
           er (E.Po (sd,Dir R,Dir d))::
-          (match d with R | J -> F.fold_dpr
-                        | W -> F.fold_dpw)
+          (match d with R -> F.fold_dpr | W -> F.fold_dpw)
             (fun dp k -> er (E.Dp (dp,sd,Dir d))::k)
             (all_fences sd R d [])
 

--- a/gen/run_gen.ml
+++ b/gen/run_gen.ml
@@ -146,7 +146,7 @@ module Make (O:Config) (C:ArchRun.S) :
       let ws_by_loc =
         by_loc
           (fun e -> match e.C.dir with
-          | Some Code.W -> true | None|Some Code.R|Some Code.J -> false)
+          | Some Code.W -> true | None|Some Code.R -> false)
           str.evts in
       let wsi_by_loc =
         ESet.fold

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -161,7 +161,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
                    (fun loc ->
                      sprintf "%i:%s=%s" p
                        (Code.pp_loc loc)
-                       (match o.pdir with W -> "W" | R -> "T" | J -> "I"))
+                       (match o.pdir with W -> "W" | R -> "T"))
                    o.ploc k) in
 
       fun fst ios -> String.concat "," (do_rec fst ios)
@@ -181,7 +181,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           | Same ->
               begin match  n.C.C.evt.C.C.dir with
               | Some W -> true
-              | None|Some R|Some J -> do_rec n.C.C.prev
+              | None|Some R -> do_rec n.C.C.prev
               end
           | Diff -> false in
       do_rec m.C.C.prev
@@ -192,7 +192,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
 (*        eprintf "After %s\n" (C.E.pp_edge e) ; *)
         begin match  n.C.C.evt.C.C.dir with
         | Some W -> true
-        | None|Some R|Some J ->
+        | None|Some R ->
             let nxt = n.C.C.next in
             if nxt == m then false else
             begin match C.E.loc_sd e with
@@ -245,7 +245,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           let e =  n.C.C.evt in
           match e.C.C.dir,e.C.C.loc with
           | Some W,Data loc -> StringSet.add loc k
-          | ((Some R|None|Some J),_)|(Some W,Code _) -> k in
+          | ((Some R|None),_)|(Some W,Code _) -> k in
          k in
       do_rec n0
 

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -128,7 +128,6 @@ module U = TopUtils.Make(O)(Comp)
           (as_rmw n) st p init e n.C.next.C.evt
     | Some W|None ->
         None,init,[],st
-    | Some J -> assert false
     else if
       match e.C.atom with
       | None -> true
@@ -150,7 +149,6 @@ module U = TopUtils.Make(O)(Comp)
      | Some R ->
          Comp.emit_rmw_dep (as_rmw n) st p init e n.C.next.C.evt dp r1 n1
      | Some W|None -> None,init,[],st
-     | Some J -> assert false
      else
        Comp.emit_access_dep st p init e dp r1 n1
 


### PR DESCRIPTION
J (joker) relaxation has been disabled for a while after 0b068a7e84ef ("gen: Avoid jokers (J) in generated edges, could be commanded by command line switch or arch, if needed."). #648 attempted to re-enable it yet it turned out it does not bring any benefits in current form. We might revisit it in future if we find legitimate use case, but so far it is dead code and seems it is time to say goodbye to joker.