### PR TITLE
[test] Disable looping test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,6 +517,7 @@ mte-test:
 		-libdir-path ./herd/libdir \
 		-kinds-path catalogue/aarch64-MTE/tests/kinds.txt \
 		-shelf-path catalogue/aarch64-MTE/shelf.py \
+		-conf-path catalogue/aarch64-MTE/cfgs/test-MTE.cfg \
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 catalogue aarch64-MTE tests: OK"
 

--- a/catalogue/aarch64-MTE/cfgs/test-MTE.cfg
+++ b/catalogue/aarch64-MTE/cfgs/test-MTE.cfg
@@ -1,0 +1,4 @@
+variant memtag,precise
+# Loop inside
+nonames MP+dmb.st+acqrel_and_ctrl.async
+timeout 60


### PR DESCRIPTION
Disable some (catalogue) test. This test contains an (unresolved) loop resulting in a warning message on standard error. As a consequence `make mte-test` may fail on fast machines.

At the moment, tests from the catalogue that output onto standard error trigger a failure of the test
driver `internal/herd_catalogue_regression_test.ml`. This can be seen as a shortcomming of this driver.

By lack of time, simply disable the problematic test.

Hi @artkhyzha. Another solution to this problem may be to rewrite the test `catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+acqrel_and_ctrl--async.litmus` so that it does not loop anymore. As the author of the test, you may be iin the best position to consider this alternative.