### PR TITLE
[asl] Forbid storage declarations that discard all names

### DIFF
--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -532,6 +532,9 @@ let string_starts_with ~prefix s =
 let global_ignored_prefix = "__global_ignored"
 let global_ignored () = fresh_var global_ignored_prefix
 let is_global_ignored s = string_starts_with ~prefix:global_ignored_prefix s
+let local_ignored_prefix = "__ldi_discard"
+let local_ignored () = fresh_var local_ignored_prefix
+let is_local_ignored s = string_starts_with ~prefix:local_ignored_prefix s
 let slice_is_single = function Slice_Single _ -> true | _ -> false
 
 let slice_as_single = function

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -216,11 +216,17 @@ val fresh_var : string -> identifier
 val global_ignored : unit -> identifier
 (** Creates a fresh dummy variable for a global ignored variable. *)
 
+val local_ignored : unit -> identifier
+(** Creates a fresh dummy variable for a local ignored variable. *)
+
 val string_starts_with : prefix:string -> string -> bool
 (** A copy of String.starts_with out of stdlib 4.12 *)
 
 val is_global_ignored : identifier -> bool
 (** [is_global_ignored s] is true iff [s] has been created with [global_ignored ()]. *)
+
+val is_local_ignored : identifier -> bool
+(** [is_local_ignored s] is true iff [s] has been created with [local_ignored ()]. *)
 
 (** {1 Fields, masks and slices handling} *)
 

--- a/asllib/ParserConfig.mli
+++ b/asllib/ParserConfig.mli
@@ -27,4 +27,7 @@ module type CONFIG = sig
 
   val allow_expression_elsif : bool
   (** Allow [elsif] at the expression level. *)
+
+  val allow_storage_discards : bool
+  (** Allow storage declarations to discard their right-hand sides. *)
 end

--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -33,6 +33,7 @@ type args = {
   allow_expression_elsif : bool;
   allow_double_underscore : bool;
   allow_unknown : bool;
+  allow_storage_discards : bool;
   print_ast : bool;
   print_serialized : bool;
   print_typed : bool;
@@ -55,6 +56,7 @@ let parse_args () =
   let allow_expression_elsif = ref false in
   let allow_double_underscore = ref false in
   let allow_unknown = ref false in
+  let allow_storage_discards = ref false in
   let print_ast = ref false in
   let print_serialized = ref false in
   let print_typed = ref false in
@@ -87,6 +89,9 @@ let parse_args () =
       ( "--allow-unknown",
         Arg.Set allow_unknown,
         " Allow the usage of 'UNKNOWN' instead of 'ARBITRARY'." );
+      ( "--allow-storage-discards",
+        Arg.Set allow_storage_discards,
+        " Allow storage declarations that discard their right-hand sides." );
       ( "--print",
         Arg.Set print_ast,
         " Print the parsed AST to stdout before executing it." );
@@ -177,6 +182,7 @@ let parse_args () =
       allow_expression_elsif = !allow_expression_elsif;
       allow_double_underscore = !allow_double_underscore;
       allow_unknown = !allow_unknown;
+      allow_storage_discards = !allow_storage_discards;
       print_ast = !print_ast;
       print_serialized = !print_serialized;
       print_typed = !print_typed;
@@ -228,12 +234,14 @@ let () =
     let allow_expression_elsif = args.allow_expression_elsif in
     let allow_double_underscore = args.allow_double_underscore in
     let allow_unknown = args.allow_unknown in
+    let allow_storage_discards = args.allow_storage_discards in
     let open Builder in
     {
       allow_no_end_semicolon;
       allow_expression_elsif;
       allow_double_underscore;
       allow_unknown;
+      allow_storage_discards;
     }
   in
 

--- a/asllib/builder.ml
+++ b/asllib/builder.ml
@@ -33,6 +33,7 @@ type parser_config = {
   allow_expression_elsif : bool;
   allow_double_underscore : bool;
   allow_unknown : bool;
+  allow_storage_discards : bool;
 }
 
 type version_selector = [ `ASLv0 | `ASLv1 | `Any ]
@@ -43,6 +44,7 @@ let default_parser_config =
     allow_expression_elsif = false;
     allow_double_underscore = false;
     allow_unknown = false;
+    allow_storage_discards = false;
   }
 
 let select_type ~opn ~ast = function
@@ -75,6 +77,7 @@ let from_lexbuf ast_type parser_config version (lexbuf : lexbuf) =
       let module Parser = Parser.Make (struct
         let allow_no_end_semicolon = parser_config.allow_no_end_semicolon
         let allow_expression_elsif = parser_config.allow_expression_elsif
+        let allow_storage_discards = parser_config.allow_storage_discards
       end) in
       let module Lexer = Lexer.Make (struct
         let allow_double_underscore = parser_config.allow_double_underscore

--- a/asllib/builder.mli
+++ b/asllib/builder.mli
@@ -34,6 +34,7 @@ type parser_config = {
   allow_expression_elsif : bool;
   allow_double_underscore : bool;
   allow_unknown : bool;
+  allow_storage_discards : bool;
 }
 
 val default_parser_config : parser_config

--- a/asllib/bundler.ml
+++ b/asllib/bundler.ml
@@ -54,6 +54,7 @@ let build_ast_from_file ?(is_opn = false) f =
   let module Parser = Parser.Make (struct
     let allow_no_end_semicolon = false
     let allow_expression_elsif = false
+    let allow_storage_discards = false
   end) in
   let module Lexer = Lexer.Make (struct
     let allow_double_underscore = false

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -2075,7 +2075,6 @@
 \newcommand\catchers[0]{\texttt{catchers}}
 \newcommand\catchersone[0]{\texttt{catchers1}}
 \newcommand\catchersp[0]{\texttt{catchers'}}
-\newcommand\cname[0]{\texttt{cname}}
 \newcommand\comp[0]{\texttt{comp}}
 \newcommand\compare[0]{\texttt{compare}}
 \newcommand\compdecls[0]{\texttt{comp\_decls}}
@@ -2628,7 +2627,6 @@
 \newcommand\vidasts[0]{\texttt{id\_asts}}
 \newcommand\vids[0]{\texttt{ids}}
 \newcommand\vidsone[0]{\texttt{ids1}}
-\newcommand\vignoredoridentifier[0]{\texttt{ignored\_or\_identifier}}
 \newcommand\vimpdefs[0]{\texttt{impdefs}}
 \newcommand\vimpdefsp[0]{\texttt{impdefs'}}
 \newcommand\vimpls[0]{\texttt{impls}}

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -37,10 +37,10 @@ Type declarations:
 
 Global storage declarations:
 \begin{flalign*}
-\Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep &\\
+\Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Tidentifier \parsesep &\\
     & \wrappedline\ \option{\Tcolon \parsesep \Nty} \parsesep \Teq \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Tconfig \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&\\
+|\ & \Tconfig \parsesep \Tidentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Tidentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&\\
 \end{flalign*}
 
 Pragmas:

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -31,6 +31,13 @@ The language supports such overriding mechanisms (and in particular, simplifies 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Syntax\label{sec:GlobalStorageDeclarationsSyntax}}
+
+\RequirementDef{DiscardingGlobalStorageDeclarations}
+Global storage declarations must bind a name.
+This is ensured by the ASL grammar.
+All the global storage declarations in \listingref{local-storage-discards} are illegal, as they discard their declared storage elements.
+\ASLListing{Illegal global storage declarations that discard storage elements}{global-storage-discards}{\syntaxtests/GuideRule.DiscardingGlobalStorageDeclarations.asl}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{flalign*}
 \Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Tidentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep &\\

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -33,18 +33,17 @@ The language supports such overriding mechanisms (and in particular, simplifies 
 \section{Syntax\label{sec:GlobalStorageDeclarationsSyntax}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{flalign*}
-\Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep &\\
+\Ndecl  \derives \ & \Nglobaldeclkeyword \parsesep \Tidentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep &\\
         & \wrappedline\ \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-  |\ & \Tconfig \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-	|\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
+  |\ & \Tconfig \parsesep \Tidentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+	|\ & \Tvar \parsesep \Tidentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep &\\
         & \wrappedline\ \Nexpr \parsesep \Tsemicolon &\\
-        |\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&\\
+        |\ & \Tvar \parsesep \Tidentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon&\\
         |\ & \Tpragma \parsesep \Tidentifier \parsesep \ClistZero{\Nexpr} \parsesep \Tsemicolon&
 \end{flalign*}
 
 \begin{flalign*}
-\Nglobaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant&\\
-\Nignoredoridentifier \derives \ & \Tminus \;|\; \Tidentifier &
+\Nglobaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant&
 \end{flalign*}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -76,7 +75,7 @@ The language supports such overriding mechanisms (and in particular, simplifies 
       \builddecl\left(\overname{\Ndecl\left(
       \begin{array}{r}
       \namednode{\vkeyword}{\Nglobaldeclkeyword}, \\
-      \wrappedline\ \namednode{\name}{\Nignoredoridentifier}, \\
+      \wrappedline\ \Tidentifier(\name), \\
       \wrappedline\ \namednode{\tty}{\option{\Nasty}}, \Teq, \namednode{\vinitialvalue}{\Nexpr}, \Tsemicolon
       \end{array}
   \right)}{\vparsednode}\right)
@@ -104,7 +103,7 @@ The language supports such overriding mechanisms (and in particular, simplifies 
   {
       \builddecl\left(\overname{\Ndecl\left(
       \begin{array}{r}
-      \Tvar, \namednode{\name}{\Nignoredoridentifier},  \\
+      \Tvar, \Tidentifier(\name),  \\
   \wrappedline\ \namednode{\tty}{\option{\Nasty}}, \Teq, \namednode{\vinitialvalue}{\Nexpr}, \Tsemicolon
       \end{array}
   \right)}{\vparsednode}\right)
@@ -126,11 +125,10 @@ The language supports such overriding mechanisms (and in particular, simplifies 
 
 \begin{mathpar}
 \inferrule[global\_uninit\_var]{
-  \buildignoredoridentifier(\cname) \astarrow \name
 }{
   {
     \begin{array}{r}
-      \builddecl(\overname{\Ndecl(\Tvar, \namednode{\cname}{\Nignoredoridentifier}, \Nasty, \Tsemicolon)}{\vparsednode}) \astarrow
+      \builddecl(\overname{\Ndecl(\Tvar, \Tidentifier(\name), \Nasty, \Tsemicolon)}{\vparsednode}) \astarrow
     \end{array}
   } \\
   \overname{\left[\DGlobalStorage(\{\GDkeyword: \GDKVar, \GDname: \name, \GDty: \langle\astof{\Nasty}\rangle, \GDinitialvalue: \None\})\right]}{\vastnode}
@@ -139,11 +137,10 @@ The language supports such overriding mechanisms (and in particular, simplifies 
 
 \begin{mathpar}
 \inferrule[global\_storage\_config]{
-  \buildignoredoridentifier(\cname) \astarrow \name
 }{
   {
     \begin{array}{r}
-      \builddecl(\overname{\Ndecl(\Tconfig, \namednode{\cname}{\Nignoredoridentifier}, \Tcolon, \punnode{\Nty}, \Teq, \punnode{\Nexpr}, \Tsemicolon)}{\vparsednode}) \astarrow
+      \builddecl(\overname{\Ndecl(\Tconfig, \Tidentifier(\name), \Tcolon, \punnode{\Nty}, \Teq, \punnode{\Nexpr}, \Tsemicolon)}{\vparsednode}) \astarrow
     \end{array}
   } \\
   \overname{\DGlobalStorage(\{ \GDkeyword: \GDKConfig, \GDname: \name, \GDty: \Some{\astof{\vt}}, \GDinitialvalue: \Some{\astof{\vexpr}}\})}{\vastnode}
@@ -175,31 +172,6 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
   \overname{\GDKConstant}{\vastnode}
 \end{array}
   }
-}
-\end{mathpar}
-
-\ASTRuleDef{IgnoredOrIdentifier}
-\hypertarget{build-ignoredoridentifier}{}
-The relation
-\[
-\buildfuncargs(\overname{\parsenode{\Nignoredoridentifier}}{\vparsednode}) \;\aslrel\;
-  \overname{\identifier}{\vastnode}
-\]
-transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
-
-\begin{mathpar}
-\inferrule[discard]{
-  \id \in \identifier \text{ is fresh}
-}{
-  \buildignoredoridentifier(\overname{\Nignoredoridentifier(\Tminus)}{\vparsednode}) \astarrow
-  \overname{\id}{\vastnode}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[id]{}{
-  \buildignoredoridentifier(\overname{\Nignoredoridentifier(\Tidentifier(\id))}{\vparsednode}) \astarrow
-  \overname{\id}{\vastnode}
 }
 \end{mathpar}
 

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -88,6 +88,11 @@ Declaring a local storage element is done via the following grammar rules:
   |\ & \LDITuple(\identifier^*) &
 \end{flalign*}
 
+\RequirementDef{DiscardingLocalStorageDeclarations}
+Local storage declarations must bind at least one name.
+All the local storage declarations in \listingref{local-storage-discards} are illegal, as they discard all declared storage elements.
+\ASLListing{Illegal local storage declarations that discard all storage elements}{local-storage-discards}{\syntaxtests/GuideRule.DiscardingLocalStorageDeclarations.asl}
+
 \ASTRuleDef{LocalDeclKeyword}
 \hypertarget{build-localdeclkeyword}{}
 The function

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -75,8 +75,9 @@ Declaring a local storage element is done via the following grammar rules:
 \begin{flalign*}
 \Nlocaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant&\\
 \Ndeclitem \derives\
-   & \Nignoredoridentifier &\\
-|\ & \Plisttwo{\Nignoredoridentifier} &
+   & \Tidentifier &\\
+|\ & \Plisttwo{\Nignoredoridentifier} &\\
+\Nignoredoridentifier \derives \ & \Tminus \;|\; \Tidentifier &
 \end{flalign*}
 
 \section{Abstract Syntax\label{sec:LocalStorageDeclarationsAbstractSyntax}}
@@ -118,13 +119,15 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[var]{}{
-  \builddeclitem(\Ndeclitem(\punnode{\Nignoredoridentifier})) \astarrow
-  \overname{\astof{\vignoredoridentifier}}{\vastnode}
+  \builddeclitem(\Ndeclitem(\Tidentifier(\name))) \astarrow
+  \overname{\name}{\vastnode}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[tuple]{
+  \vb \eqdef \bigwedge_{i \in \listrange(\vids)} \vids_i = \Tminus \\
+  \checktrans{\lnot \vb}{\BuildBadDeclaration} \checktransarrow \True \OrBuildError \\
   \buildclist[\buildignoredoridentifier](\vids) \astarrow \astversion{\vids}
 }{
   {
@@ -133,6 +136,31 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
   \overname{\LDITuple(\astversion{\vids})}{\vastnode}
     \end{array}
   }
+}
+\end{mathpar}
+
+\ASTRuleDef{IgnoredOrIdentifier}
+\hypertarget{build-ignoredoridentifier}{}
+The relation
+\[
+\buildfuncargs(\overname{\parsenode{\Nignoredoridentifier}}{\vparsednode}) \;\aslrel\;
+  \overname{\identifier}{\vastnode}
+\]
+transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
+
+\begin{mathpar}
+\inferrule[discard]{
+  \id \in \identifier \text{ is fresh}
+}{
+  \buildignoredoridentifier(\overname{\Nignoredoridentifier(\Tminus)}{\vparsednode}) \astarrow
+  \overname{\id}{\vastnode}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[id]{}{
+  \buildignoredoridentifier(\overname{\Nignoredoridentifier(\Tidentifier(\id))}{\vparsednode}) \astarrow
+  \overname{\id}{\vastnode}
 }
 \end{mathpar}
 

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -218,11 +218,11 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
    & \wrappedline\ \Naccessorbody &\\
 |\ & \Ttype \parsesep \Tidentifier \parsesep \Tof \parsesep \Ntydecl \parsesep \Nsubtypeopt \parsesep \Tsemicolon &\\
 |\ & \Ttype \parsesep \Tidentifier \parsesep \Nsubtype \parsesep \Tsemicolon &\\
-|\ & \Nglobaldeclkeyword \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} &\\
+|\ & \Nglobaldeclkeyword \parsesep \Tidentifier \parsesep \option{\Tcolon \parsesep \Nty} &\\
    & \wrappedline\ \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Tconfig \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Tvar \parsesep \Nignoredoridentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon &\\
+|\ & \Tconfig \parsesep \Tidentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Tidentifier \parsesep \option{\Tcolon \parsesep \Nty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Tvar \parsesep \Tidentifier \parsesep \Tcolon \parsesep \Nty \parsesep \Tsemicolon &\\
 |\ & \Tpragma \parsesep \Tidentifier \parsesep \ClistZero{\Nexpr} \parsesep \Tsemicolon&
 \end{flalign*}
 
@@ -457,7 +457,7 @@ it must declare a new variable.
 \hypertarget{def-ndeclitem}{}
 \begin{flalign*}
 \Ndeclitem \derives\
-   & \Nignoredoridentifier &\\
+   & \Tidentifier &\\
 |\ & \Plisttwo{\Nignoredoridentifier}  &
 \end{flalign*}
 

--- a/asllib/tests/ASLDefinition.t/EvaluationOrder.asl
+++ b/asllib/tests/ASLDefinition.t/EvaluationOrder.asl
@@ -38,24 +38,24 @@ begin
   println();
 
   println("Tuples:");
-  let - = (p{1}, p{2});
+  - = (p{1}, p{2});
   println();
 
   println("Non-short-circuiting binary operations:");
-  let - = p{1} + p{2} + p{3};
+  - = p{1} + p{2} + p{3};
   println();
 
   println("Array-indexing:");
-  let - = arr(1)[[p{2}]];
+  - = arr(1)[[p{2}]];
   println();
 
   println("Slicing:");
   var bv : bits(64);
-  let - = bv[p{1}, p{2}:p{3}, p{4}+:p{5}, p{6}*:p{7}];
+  - = bv[p{1}, p{2}:p{3}, p{4}+:p{5}, p{6}*:p{7}];
   println();
 
   println("Record construction:");
-  let - = Record{ a = p{1}, b = p{2} };
+  - = Record{ a = p{1}, b = p{2} };
   println();
 
   println("Print statements:");
@@ -63,7 +63,7 @@ begin
 
   println("For-loop start/end expressions:");
   for i = p{1} to p{2} do
-    let - = p{i + 2};
+    - = p{i + 2};
   end;
   println();
 

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -198,6 +198,9 @@ ASL Semantics Tests:
   [1]
   $ aslref SemanticsRule.LEDiscard.asl
   $ aslref SemanticsRule.LDDiscard.asl
+  File SemanticsRule.LDDiscard.asl, line 4, characters 6 to 7:
+  ASL Grammar error: Obsolete syntax: Discarded storage declaration.
+  [1]
 
   $ aslref EvalCatchers.asl
   21

--- a/asllib/tests/ASLSyntaxReference.t/ASTRule.DesugarElidedParameter.asl
+++ b/asllib/tests/ASLSyntaxReference.t/ASTRule.DesugarElidedParameter.asl
@@ -13,16 +13,16 @@ begin
     let bv = Zeros{64};
     let res : bits(64) = Bar{}(bv); // equivalent to Bar{64}(args)
     let sz = 32;
-    let - : bits(64) = Baz{,sz}(bv, sz); // equivalent to Baz{64,sz}(bv, sz);
+    let a : bits(64) = Baz{,sz}(bv, sz); // equivalent to Baz{64,sz}(bv, sz);
     // let res : bits(N) = Baz{}(bv); // illegal: - only 1 parameter can be omitted
 
-    let - = Zeros{64}; // can avoid empty argument list ()
-    let - : bits(64) = Zeros{}();
-    let - : bits(64) = Zeros{64};
+    - = Zeros{64}; // can avoid empty argument list ()
+    let b : bits(64) = Zeros{}();
+    let c : bits(64) = Zeros{64};
     // let - : bits(64) = Zeros{}; // illegal: parsing conflict with empty record
 
-    let - = UInt('1111'); // equivalent to UInt{4}('1111');
-    let - : bits(64) = ZeroExtend{64}('11'); // equivalent to ZeroExtend{64,2}
-    let - : bits(64) = ZeroExtend{}('11'); // can also elide the output parameter N
+    - = UInt('1111'); // equivalent to UInt{4}('1111');
+    let d : bits(64) = ZeroExtend{64}('11'); // equivalent to ZeroExtend{64,2}
+    let e : bits(64) = ZeroExtend{}('11'); // can also elide the output parameter N
     return 0;
 end;

--- a/asllib/tests/ASLSyntaxReference.t/GuideRule.DiscardingGlobalStorageDeclarations.asl
+++ b/asllib/tests/ASLSyntaxReference.t/GuideRule.DiscardingGlobalStorageDeclarations.asl
@@ -1,0 +1,4 @@
+let - = 42;
+var - = TRUE;
+constant - = "abc";
+config - = 1.0;

--- a/asllib/tests/ASLSyntaxReference.t/GuideRule.DiscardingLocalStorageDeclarations.asl
+++ b/asllib/tests/ASLSyntaxReference.t/GuideRule.DiscardingLocalStorageDeclarations.asl
@@ -1,0 +1,11 @@
+func main () => integer
+begin
+
+  let - = 42;
+  var - = TRUE;
+  constant - = "abc";
+  let (-, -, -) = ('1', 1.0, 1);
+
+  return 0;
+end;
+

--- a/asllib/tests/ASLSyntaxReference.t/expr1.asl
+++ b/asllib/tests/ASLSyntaxReference.t/expr1.asl
@@ -5,7 +5,7 @@ func main() => integer
 begin
   var v: integer = 4;
   // E_Var: v is a variable expression.
-  var - = v;
+  - = v;
 
   var b0 = '1111 1000'[3:1, 0]; // E_Slice 1: a bitvector slice.
   var b1 = 0xF8[3:1, 0]; // E_Slice 2: an integer slice.

--- a/asllib/tests/ASLSyntaxReference.t/run.t
+++ b/asllib/tests/ASLSyntaxReference.t/run.t
@@ -16,3 +16,13 @@ Examples used to test syntax and AST building rules:
   $ aslref ConventionRule.IdentifiersDifferingByCase.asl
   $ aslref --no-exec ConventionRule.IdentifierSingleUnderscore.asl
   $ aslref --no-exec ASTRule.DesugarElidedParameter.asl
+  $ aslref GuideRule.DiscardingLocalStorageDeclarations.asl
+  File GuideRule.DiscardingLocalStorageDeclarations.asl, line 4,
+    characters 6 to 7:
+  ASL Grammar error: Obsolete syntax: Discarded storage declaration.
+  [1]
+  $ aslref GuideRule.DiscardingGlobalStorageDeclarations.asl
+  File GuideRule.DiscardingGlobalStorageDeclarations.asl, line 1,
+    characters 4 to 5:
+  ASL Grammar error: Obsolete syntax: Discarded storage declaration.
+  [1]

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ATC.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ATC.asl
@@ -9,26 +9,26 @@ begin
     //      Expression                          Annotated expression
     // The following assertion is statically proved by the type
     // system and therefore no dynamic check occurs.
-    var - = 1 as integer{1, 2};                     // 1
+    var a = 1 as integer{1, 2};                     // 1
     // The following assertion is not statically proved by the type
     // system and therefore a dynamic check occurs, which always fails.
-    var - = 3 as integer{1, 2};                     // 3 as integer{1, 2}
+    var b = 3 as integer{1, 2};                     // 3 as integer{1, 2}
     // The following assertion will always fail.
-    var - = 3 as integer{2 as integer{2, 3}};       // 3 as integer{2}
+    var c = 3 as integer{2 as integer{2, 3}};       // 3 as integer{2}
 
-    var - = RED as Color;                           // RED
-    var - = RED as SubColor;                        // RED
-    var - = (RED, 3) as (SubColor, integer{2, 3});  // (RED, 3)
+    var d = RED as Color;                           // RED
+    var e = RED as SubColor;                        // RED
+    var f = (RED, 3) as (SubColor, integer{2, 3});  // (RED, 3)
     // The following right-hand-side expression is annotated as
     // (RED, 3) as (enumeration {RED, GREEN, BLUE}, integer {1, 2})
     // Evaluating this statement will result in a dynamic error.
-    var - = (RED, 3) as (SubColor, integer{1, 2});
+    var g = (RED, 3) as (SubColor, integer{1, 2});
 
     var x = Packet{data = Zeros{8}, status = TRUE};
-    var - = x as ExtendedPacket;                    // x
+    var h = x as ExtendedPacket;                    // x
 
     var arr : array[[5]] of integer;
-    var - = arr as array[[5]] of integer;           // arr
+    var i = arr as array[[5]] of integer;           // arr
 
     // The following statement in comment is illegal as '2 as integer{3}'
     // is considered side-effecting, which is not allowed in type

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateSymbolicallyEvaluableExpr.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateSymbolicallyEvaluableExpr.asl
@@ -23,17 +23,17 @@ begin
     // Right-hand-side expression is symbolically evaluable?
     let i : MyInteger = 9;          // Yes: literals are immutable.
     var x = pure_func(5, 6) + 9;    // Yes: 'pure_func' is side-effect-free.
-    var - = I;                      // Yes: 'I' is immutable.
-    var - = impure_func(5, 6);      // No: 'impure_func' may throw an exception.
-    var - = x;                      // No: 'x' is mutable.
-    var - = M;                      // No: 'M' is mutable.
+    var a = I;                      // Yes: 'I' is immutable.
+    var b = impure_func(5, 6);      // No: 'impure_func' may throw an exception.
+    var c = x;                      // No: 'x' is mutable.
+    var d = M;                      // No: 'M' is mutable.
 
     // Only symbolically evaluable expressions whose underlying type is an
     // integer type can be used as array length expressions:
-    var - : array[[pure_func(5, 6) + 9 + I]] of integer;
+    var e : array[[pure_func(5, 6) + 9 + I]] of integer;
     // Normalization simplifies (3*I + 9) - 2*I into I+9.
-    var - : array[[(3*I + 9) - 2*I]] of integer;
+    var f : array[[(3*I + 9) - 2*I]] of integer;
     // Normalization simplifies i-3 into 6.
-    var - : array[[i - 3]] of integer;
+    var g : array[[i - 3]] of integer;
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.asl
@@ -6,35 +6,35 @@ func main() => integer
 begin
   var b1: boolean = TRUE as boolean && FALSE as boolean;
   // Binary operations on bitvectors remove all bitfields from the result type.
-  var - : bits(8) = Ones{8} as bits(8) {[0] flag} XOR Zeros{8} as bits(8) {[7] flag};
+  var a : bits(8) = Ones{8} as bits(8) {[0] flag} XOR Zeros{8} as bits(8) {[7] flag};
   // The next statement is illegal: both bitvectors must have the same length for XOR.
   // var - : bits(8) = Ones{8} XOR Zeros{7};
-  var - : bits(8) = Ones{8} as bits(8) {[0] flag} + (1024 as integer);
-  var - : bits(16) =  (Ones{8} as bits(8) {[0] flag}) ::
+  var b : bits(8) = Ones{8} as bits(8) {[0] flag} + (1024 as integer);
+  var c : bits(16) =  (Ones{8} as bits(8) {[0] flag}) ::
                       (Zeros{8} as bits(8) {[0] flag});
 
-  var - : boolean = (5 as integer{1..10}) < (6 as integer{1..10});
-  var - : boolean = (Ones{8} as bits(8) {[0] flag}) ==
+  var d : boolean = (5 as integer{1..10}) < (6 as integer{1..10});
+  var e : boolean = (Ones{8} as bits(8) {[0] flag}) ==
                     (Ones{8} as bits(8) {[7] flag});
   // The next statement is illegal: both bitvectors must have the same length for ==.
   // var - : boolean = Ones{8} == Zeros{9};
-  var - : boolean = (RED as Color) != (GREEN as SubColor);
+  var f : boolean = (RED as Color) != (GREEN as SubColor);
   // The next statement is illegal: comparing labels declared in
   // different enumerations is not allowed.
   // var - : boolean = RED != OK;
 
-  var - : integer{25} = (5 as integer{5}) * (5 as integer{5});
-  var - : integer = (5 as integer{5}) * (5 as integer);
-  var - : integer{20, 24..25, 28, 30, 35..36, 42} =
+  var g : integer{25} = (5 as integer{5}) * (5 as integer{5});
+  var h : integer = (5 as integer{5}) * (5 as integer);
+  var i : integer{20, 24..25, 28, 30, 35..36, 42} =
           (5 as integer{5..7}) * (5 as integer{4..6});
   // The next statement is illegal, since 5 does not divide by 2.
   // var -  = (5 as integer{5..10}) DIV (2 as integer{2});
 
-  var - : real = 5.5 ^ 7;
+  var j : real = 5.5 ^ 7;
   var real_pow_int : real = 5.0 ^ (5 as integer{0..10});
 
   // String concatenation first converts literals to their string representation.
-  var - : string = 0 :: '1' :: 2.0 :: TRUE :: "foo" :: RED;
+  var k : string = 0 :: '1' :: 2.0 :: TRUE :: "foo" :: RED;
 
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.constraints.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.constraints.asl
@@ -38,6 +38,6 @@ begin
 
     // Notice how large sets of constraints (more than 2^17)
     // are approximated via ranges.
-    var - : integer{0..2^28} = (1 as integer{0..2^14}) * (2 as integer{0..2^14});
-    var - : integer{0..2^14} = (1 as integer{0..2^14}) DIV (2 as integer{0..2^14});
+    var x : integer{0..2^28} = (1 as integer{0..2^14}) * (2 as integer{0..2^14});
+    var y : integer{0..2^14} = (1 as integer{0..2^14}) DIV (2 as integer{0..2^14});
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BitwidthEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BitwidthEqual.asl
@@ -2,7 +2,7 @@ func foo{N}(bv: bits(N))
 begin
     var x : bits(N DIV 2 + 1) = bv[N DIV 2:0];
     var y : bits(N DIV 2 + N DIV 2) = bv;
-    var - : bits(3 * N + N) = Ones{4 * N};
+    var z : bits(3 * N + N) = Ones{4 * N};
     // The following statement in comment is illegal, since the current equivalence
     // test cannot determine that `N*N` is equal to `N^2`.
     // var - : bits(N^2) = Ones{N * N};

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckATC.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckATC.asl
@@ -5,16 +5,16 @@ func main() => integer
 begin
     // Illegal: can only perform ATC on real and integer:
     // ATC is not a type-to-type cast.
-    var - = 3.0 as integer{1, 2};
+    var a = 3.0 as integer{1, 2};
 
     // Illegal: cannot perform ATC on record types unless they
     // are exactly they are equivalent.
     var rec = Packet{data = Zeros{8}, status = TRUE};
-    var - = rec as ExtendedPacket;
+    var b = rec as ExtendedPacket;
 
     var arr : array[[5]] of integer;
     // Illegal: cannot perform ATC on array types unless they
     // are equivalent.
-    var - = arr as array[[6]] of integer;
+    var c = arr as array[[6]] of integer;
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckConstrainedInteger.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckConstrainedInteger.asl
@@ -2,14 +2,14 @@ func foo{N}(bv : bits(N))
 begin
     // The next declaration is legal as a parameterized integer type
     // is a constrained integer type.
-    var - : bits(N) = Zeros{N};
+    var a : bits(N) = Zeros{N};
     let x : integer{0..N} = N as integer{0..N};
     // The next declaration is legal as the type of 'x' is a well-constrained
     // integer type, which is considered a constrained integer type.
-    var - : bits(x) = Zeros{x};
+    var b : bits(x) = Zeros{x};
     // The next declaration is legal as 5 has the type integer{5},
     // which is a constrained integer type.
-    var - : bits(5) = Zeros{5};
+    var c : bits(5) = Zeros{5};
 
     let y : integer = 7;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.asl
@@ -1,4 +1,4 @@
-var - = 42;
-let - = 42;
-constant - = 42;
-config - : integer = 42;
+var a = 42;
+let b = 42;
+constant c = 42;
+config d : integer = 42;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclaredType.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclaredType.bad.asl
@@ -1,5 +1,5 @@
 func main() => integer
 begin
-    var - = 20 as MyInt;
+    var x = 20 as MyInt;
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EArbitrary.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EArbitrary.asl
@@ -2,10 +2,10 @@ type Color of enumeration {RED, GREEN, BLUE};
 
 func main() => integer
 begin
-    var - : boolean = ARBITRARY : boolean;
-    var - : real = ARBITRARY : real;
-    var - : string = ARBITRARY : string;
-    var - : integer = ARBITRARY : integer;
+    var a : boolean = ARBITRARY : boolean;
+    var b : real = ARBITRARY : real;
+    var c : string = ARBITRARY : string;
+    var d : integer = ARBITRARY : integer;
     var i : integer{-1000..1000} = ARBITRARY : integer{-1000..1000};
     assert -1000 <= i && i <= 1000;
     var e : Color = ARBITRARY : Color;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadBitField.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadBitField.asl
@@ -4,6 +4,6 @@ func main() => integer
 begin
     var p : Packet;
     // Illegal: field 'undeclared_bitfield' is not declared for Packet.
-    var - = p.undeclared_bitfield;
+    var x = p.undeclared_bitfield;
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadField.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EGetBadField.asl
@@ -3,6 +3,6 @@ begin
     var a: array[[5]] of integer;
     // The next statement is illegal as 'a' not a bitvector type,
     // a structured type, or a tuple type.
-    var - = a.f;
+    var x = a.f;
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EGetBitfield.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EGetBitfield.asl
@@ -13,9 +13,9 @@ func main() => integer
 begin
     var p : Packet;
     //      Bitfield expression         inferred type
-    var - = p.flag                  as  bits(1);
-    var - = p.data                  as  bits(7);
-    var - = p.detailed_data         as  bits(7) { [3+:4] info, [0+:3] crc };
-    var - = p.detailed_data.info    as  bits(4) { [0] info_0 };
+    - = p.flag                  as  bits(1);
+    - = p.data                  as  bits(7);
+    - = p.detailed_data         as  bits(7) { [3+:4] info, [0+:3] crc };
+    - = p.detailed_data.info    as  bits(4) { [0] info_0 };
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EVar.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EVar.asl
@@ -7,6 +7,6 @@ begin
     var var_x = LOCAL_CONSTANT; // The annotated expression for LOCAL_CONSTANT is 7.
     var y = var_x; // The annotated expression for var_x is var_x.
     var local_non_constant = LOCAL_CONSTANT;
-    var - = local_non_constant + GLOBAL_CONSTANT + global_non_constant;
+    var z = local_non_constant + GLOBAL_CONSTANT + global_non_constant;
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.FindNamedLCA.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.FindNamedLCA.asl
@@ -8,7 +8,7 @@ type D1 of real;
 
 func main() => integer
 begin
-    var - : A2 = if ARBITRARY: boolean then (1 as B2) else (2 as C2);
+    var x : A2 = if ARBITRARY: boolean then (1 as B2) else (2 as C2);
     // The following statement in comment is illegal.
     // In particular B2 and D1 have no named lowest common ancestor.
     // var - = if ARBITRARY: boolean then (1 as B2) else (2.0 as D1);

--- a/asllib/tests/ASLTypingReference.t/TypingRule.GetVariableEnum.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.GetVariableEnum.asl
@@ -4,7 +4,7 @@ type SubKey subtypes Key;
 func main() => integer
 begin            // The right-hand-side expression is | Reason:
     var x = 5;   // Not an enumeration variable       | not a variable expression
-    var - = x;   // Not an enumeration variable       | x is integer-typed
-    var - = One; // An enumeration variable           | the underlying type is Key
+    var y = x;   // Not an enumeration variable       | x is integer-typed
+    var z = One; // An enumeration variable           | the underlying type is Key
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LowestCommonAncestor.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LowestCommonAncestor.asl
@@ -15,7 +15,7 @@ begin
     // The type of 'N' is integer{N}
     // The type of 'M' is integer{M}
     //      LCA type                         Type 1         Type 2
-    var - : integer{N, M} = if nondet() then N         else M;
+    var x : integer{N, M} = if nondet() then N         else M;
 end;
 
 type BitsA of bits(8) {[0] f1, [7] f2};
@@ -29,33 +29,33 @@ type Exc of exception {i: integer};
 func main() => integer
 begin
     // LCA type                                  Type 1                 Type 2
-    var - : SuperInt = if nondet() then 1     as SubInt1     else 2  as SubInt2;
-    var - : SubInt1 = if nondet() then (1     as SubInt1)    else (2 as integer);
-    var - : SubInt2 = if nondet() then (1     as integer)    else (2 as SubInt2);
-    var - : integer = if nondet() then (1     as integer{1}) else (2 as integer);
-    var - : integer = if nondet() then 1      as integer{1}  else (2 as integer);
-    var - : integer = if nondet() then 1                     else 2  as integer;
-    var - : integer{1,2} = if nondet()   then 1              else 2  as integer{1,2};
-    var - : integer{0..64} = if nondet() then 1 as Word1     else 32 as Word2;
-    var - : bits(8) = if nondet() then Zeros{8} as BitsA     else Zeros{8} as BitsB;
-    var - : bits(8) = if nondet() then Zeros{8}              else Zeros{8} as BitsB;
+    var a : SuperInt = if nondet() then 1     as SubInt1     else 2  as SubInt2;
+    var b : SubInt1 = if nondet() then (1     as SubInt1)    else (2 as integer);
+    var c : SubInt2 = if nondet() then (1     as integer)    else (2 as SubInt2);
+    var d : integer = if nondet() then (1     as integer{1}) else (2 as integer);
+    var e : integer = if nondet() then 1      as integer{1}  else (2 as integer);
+    var f : integer = if nondet() then 1                     else 2  as integer;
+    var g : integer{1,2} = if nondet()   then 1              else 2  as integer{1,2};
+    var h : integer{0..64} = if nondet() then 1 as Word1     else 32 as Word2;
+    var i : bits(8) = if nondet() then Zeros{8} as BitsA     else Zeros{8} as BitsB;
+    var j : bits(8) = if nondet() then Zeros{8}              else Zeros{8} as BitsB;
 
     var arr1 : array[[8]] of Word1;
     var arr2 : array[[8]] of Word2;
-    var - : array [[8]] of integer {0..31, 32..64} = if nondet() then arr1 else arr2;
+    var k : array [[8]] of integer {0..31, 32..64} = if nondet() then arr1 else arr2;
 
-    var - : (SuperInt, SuperInt) = if nondet()  then (1 as SubInt1, 2 as SubInt2)
+    var l : (SuperInt, SuperInt) = if nondet()  then (1 as SubInt1, 2 as SubInt2)
                                                 else (2 as SubInt2, 1 as SubInt1);
 
     var sup : SuperRec;
     var r1 : SubRec1;
     var r2 : SubRec2;
     //      LCA type                            Type 1              Type 2
-    var - : SuperRec =  if nondet() then sup as SuperRec else r1 as SubRec1;
-    var - : SuperRec =  if nondet() then r1  as SubRec1  else r2 as SubRec2;
+    var m : SuperRec =  if nondet() then sup as SuperRec else r1 as SubRec1;
+    var n : SuperRec =  if nondet() then r1  as SubRec1  else r2 as SubRec2;
     var ex : Exc;
     // The following statement in comment is illegal as SuperRec and Exc do not have
     // lowest common ancestor.
-    // var -  = if nondet() then r1 else ex;
+    // var o  = if nondet() then r1 else ex;
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction.bad1.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction.bad1.asl
@@ -5,4 +5,4 @@ let Int12: integer{1..2} = 2;
 // which means both 1 and 2 can be assigned, whereas the left-hand-side
 // has type integer{Int12} which is can hold exactly one value ---
 // the runtime value of Int12.
-var - : integer{Int12} = Int12;
+var x : integer{Int12} = Int12;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction1.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SubtypeSatisfaction1.asl
@@ -25,9 +25,9 @@ begin
 
     // Bitvectors
     //          LHS type                        RHS type
-    let - :     bits(64) = Zeros{64}            as Word64;
+    let x :     bits(64) = Zeros{64}            as Word64;
     let sub_k:  integer{5, 64} = 64             as integer{5, 64};
-    let - :     bits(k) = Zeros{64}             as bits(sub_k);
+    let y :     bits(k) = Zeros{64}             as bits(sub_k);
     let bv2:    bits(64) {[0] flag} = Zeros{64} as bits(64);
 
     // integer-indexed arrays

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TCollection.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TCollection.asl
@@ -12,9 +12,9 @@ type CollectionWithoutFields of collection;
 // var - = MyCollection {a = Zeros{8}, b = Zeros{16}};
 // var - : MyCollection = MyCollection {a = Zeros{8}, b = Zeros{16}};
 
-var - : MyCollection;
-var - : CollectionWithEmptyFieldList;
-var - :CollectionWithoutFields;
+var x : MyCollection;
+var y : CollectionWithEmptyFieldList;
+var z :CollectionWithoutFields;
 
 func main() => integer
 begin

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TExceptionDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TExceptionDecl.asl
@@ -9,7 +9,7 @@ end;
 
 func main() => integer
 begin
-    var - = ExceptionWithEmptyFieldList {};
-    var - = BAD_OPCODE {};
+    - = ExceptionWithEmptyFieldList {};
+    - = BAD_OPCODE {};
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TRecordDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TRecordDecl.asl
@@ -4,8 +4,8 @@ type RecordWithoutFields of record;
 
 func main() => integer
 begin
-    var - = MyRecord {a = 3, b = TRUE};
-    var - = RecordWithEmptyFieldList {};
-    var - = RecordWithoutFields {};
+    - = MyRecord {a = 3, b = TRUE};
+    - = RecordWithEmptyFieldList {};
+    - = RecordWithoutFields {};
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UseConstraint.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UseConstraint.asl
@@ -4,7 +4,7 @@ let g = 3;
 
 func main() => integer
 begin
-    var - : integer{FIVE.. SEVEN}; // { Other(FIVE), Other(SEVEN) }
-    var - : integer{g}; // { Other(g) }
+    var a : integer{FIVE.. SEVEN}; // { Other(FIVE), Other(SEVEN) }
+    var b : integer{g}; // { Other(g) }
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UseExpr.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UseExpr.asl
@@ -11,17 +11,17 @@ type MyRecord of record { data: bits(8) };
 
 func main() => integer
 begin
-    var - = 5; // { }
-    var - = SEVEN as integer{FIVE..FIVE*2}; // { Other(SEVEN), Other(FIVE) }
-    var - = g; // { Other(g) }
+    - = 5; // { }
+    - = SEVEN as integer{FIVE..FIVE*2}; // { Other(SEVEN), Other(FIVE) }
+    - = g; // { Other(g) }
     var arr : array[[10]] of integer;
-    var - = arr[[FIVE]]; // { Other(arr), other(FIVE) }
-    var - = FIVE + SEVEN; // { Other(SEVEN), Other(FIVE) }
-    var - = add_3(FIVE); // { Subprogram(add_3), Other(FIVE) }
-    var - = (FIVE, SEVEN).item0; // { Other(SEVEN), Other(FIVE) }
+    - = arr[[FIVE]]; // { Other(arr), other(FIVE) }
+    - = FIVE + SEVEN; // { Other(SEVEN), Other(FIVE) }
+    - = add_3(FIVE); // { Subprogram(add_3), Other(FIVE) }
+    - = (FIVE, SEVEN).item0; // { Other(SEVEN), Other(FIVE) }
     var r : MyRecord;
-    var - = r.data; // { Other(r) }
-    var - = ARBITRARY : MyRecord; // { Other(MyRecord) }
-    var - = 5 IN { FIVE, SEVEN }; // { Other(SEVEN), Other(FIVE) }
+    - = r.data; // { Other(r) }
+    - = ARBITRARY : MyRecord; // { Other(MyRecord) }
+    - = 5 IN { FIVE, SEVEN }; // { Other(SEVEN), Other(FIVE) }
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UsePattern.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UsePattern.asl
@@ -3,14 +3,14 @@ constant SEVEN = 7;
 
 func main() => integer
 begin
-    var - = 5 IN { - }; // { }
-    var - = 5 IN { FIVE }; // { Other(FIVE) }
-    var - = 5 IN { FIVE..SEVEN }; // { Other(FIVE), Other(SEVEN) }
-    var - = 5 IN { <= SEVEN }; // { Other(SEVEN) }
-    var - = 5 IN { >= SEVEN }; // { Other(SEVEN) }
-    var - = 5 IN { <= FIVE, >= SEVEN }; // { Other(FIVE), Other(SEVEN) }
-    var - = 5 IN !{ FIVE, SEVEN }; // { Other(SEVEN), Other(FIVE) }
-    var - = (1, 2) IN { (-, <= FIVE) }; // { Other(FIVE) }
-    var - = '101' IN { 'x0x' }; // { }
+    - = 5 IN { - }; // { }
+    - = 5 IN { FIVE }; // { Other(FIVE) }
+    - = 5 IN { FIVE..SEVEN }; // { Other(FIVE), Other(SEVEN) }
+    - = 5 IN { <= SEVEN }; // { Other(SEVEN) }
+    - = 5 IN { >= SEVEN }; // { Other(SEVEN) }
+    - = 5 IN { <= FIVE, >= SEVEN }; // { Other(FIVE), Other(SEVEN) }
+    - = 5 IN !{ FIVE, SEVEN }; // { Other(SEVEN), Other(FIVE) }
+    - = (1, 2) IN { (-, <= FIVE) }; // { Other(FIVE) }
+    - = '101' IN { 'x0x' }; // { }
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UseSlice.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UseSlice.asl
@@ -4,9 +4,9 @@ constant SEVEN = 7;
 func main() => integer
 begin
     var bv = Ones{64};
-    var - = bv[FIVE]; // { Other(FIVE) }
-    var - = bv[SEVEN  : FIVE]; // { Other(FIVE), Other(SEVEN) }
-    var - = bv[SEVEN +: FIVE]; // { Other(FIVE), Other(SEVEN) }
-    var - = bv[SEVEN *: FIVE]; // { Other(FIVE), Other(SEVEN) }
+    - = bv[FIVE]; // { Other(FIVE) }
+    - = bv[SEVEN  : FIVE]; // { Other(FIVE), Other(SEVEN) }
+    - = bv[SEVEN +: FIVE]; // { Other(FIVE), Other(SEVEN) }
+    - = bv[SEVEN *: FIVE]; // { Other(FIVE), Other(SEVEN) }
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UseTy.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UseTy.asl
@@ -2,22 +2,22 @@ type Color of enumeration {RED, GREEN, BLUE}; // { }
 
 type MyRecord of record { c: Color }; // { Other(Color) }
 
-constant c = 15; // { }
+constant FIFTEEN = 15; // { }
 
 func foo{N}(bv: bits(N)) => integer
 begin
-    var - : Color; // { Other(Color) }
-    var - : boolean; // { }
-    var - : real; // { }
-    var - : string; // { }
-    var - : integer; // { }
-    var - : integer{0..N} = N as integer{0..N}; // { Other(N) }
-    var - : (integer{0..N}, boolean) = (0 as integer{0..N}, TRUE); // { Other(N) }
-    var - : MyRecord; // { Other(MyRecord) }
-    var - : array[[N]] of MyRecord; // { Other(N), Other(MyRecord) }
-    var - : array[[Color]] of MyRecord; // { Other(Color), Other(MyRecord) }
-    var - : bits(64) { [c] flag }; // { Other(c) }
-    var - : bits(N) = Zeros{N}; // { Other(N) }
+    var a : Color; // { Other(Color) }
+    var b : boolean; // { }
+    var c : real; // { }
+    var d : string; // { }
+    var e : integer; // { }
+    var f : integer{0..N} = N as integer{0..N}; // { Other(N) }
+    var g : (integer{0..N}, boolean) = (0 as integer{0..N}, TRUE); // { Other(N) }
+    var h : MyRecord; // { Other(MyRecord) }
+    var i : array[[N]] of MyRecord; // { Other(N), Other(MyRecord) }
+    var j : array[[Color]] of MyRecord; // { Other(Color), Other(MyRecord) }
+    var k : bits(64) { [FIFTEEN] flag }; // { Other(FIFTEEN) }
+    var l : bits(N) = Zeros{N}; // { Other(N) }
 
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -51,6 +51,9 @@ ASL Typing Tests:
   ASL Error: Undefined identifier: 'main'
   [1]
   $ aslref TypingRule.LDDiscard.asl
+  File TypingRule.LDDiscard.asl, line 4, characters 6 to 7:
+  ASL Grammar error: Obsolete syntax: Discarded storage declaration.
+  [1]
   $ aslref TypingRule.LDVar.asl
   $ aslref TypingRule.LDTyped.asl
   $ aslref TypingRule.LDTuple.asl

--- a/asllib/tests/bitfield-alignment.t/non-constant-width.asl
+++ b/asllib/tests/bitfield-alignment.t/non-constant-width.asl
@@ -1,7 +1,7 @@
 func main() => integer
 begin
   let sub_k = ARBITRARY: integer{5, 64};
-  let - = Zeros{64} as (bits(sub_k) {[0] flag});
+  let x = Zeros{64} as (bits(sub_k) {[0] flag});
 
   return 0;
 end;

--- a/asllib/tests/control-flow.t/inherited-always-throw.asl
+++ b/asllib/tests/control-flow.t/inherited-always-throw.asl
@@ -7,7 +7,7 @@ end;
 
 func inherited_always_throws () => integer
 begin
-  let - = always_throws ();
+  let x = always_throws ();
 end;
 
 func main () => integer

--- a/asllib/tests/division.t/param-div-2.asl
+++ b/asllib/tests/division.t/param-div-2.asl
@@ -10,7 +10,7 @@ begin
   assert foo{2}('10') == '01';
 
   // This one should fail at runtime
-  let - = foo{3}('101');
+  - = foo{3}('101');
 
   return 0;
 end;

--- a/asllib/tests/explicit-parameters.t/bad-argument-omission.asl
+++ b/asllib/tests/explicit-parameters.t/bad-argument-omission.asl
@@ -1,6 +1,6 @@
 func bad_elide_empty_argument_list()
 begin
-  let - : bits(64) = Foo{}; // tries to construct empty record `Foo`
+  let x : bits(64) = Foo{}; // tries to construct empty record `Foo`
 end;
 
 func main() => integer

--- a/asllib/tests/explicit-parameters.t/bad-elided-parameter.asl
+++ b/asllib/tests/explicit-parameters.t/bad-elided-parameter.asl
@@ -5,7 +5,7 @@ end;
 
 func bad_elide_parameter()
 begin
-  let - : bits(4) = Foo{,3}(0);
+  let x : bits(4) = Foo{,3}(0);
 end;
 
 func main() => integer

--- a/asllib/tests/explicit-parameters.t/explicit-parameters.asl
+++ b/asllib/tests/explicit-parameters.t/explicit-parameters.asl
@@ -44,18 +44,18 @@ end;
 // We do not need to provide () at a call site if we have explicit parameters
 func elide_empty_argument_list()
 begin
-  let - = Foo{64}();
-  let - = Foo{64};
+  - = Foo{64}();
+  - = Foo{64};
   // This can combine with eliding parameters, but only as follows:
-  let - : bits(64) = Foo{}();
+  let x : bits(64) = Foo{}();
 end;
 
 
 // We can elide parameters on right-hand sides
 func elide_parameters()
 begin
-  let - : bits(4) = Foo{}();
-  let - : bits(4) = Bar{,3}('111');
+  let x : bits(4) = Foo{}();
+  let y : bits(4) = Bar{,3}('111');
 end;
 
 
@@ -80,8 +80,8 @@ end;
 
 func good()
 begin
-  let - = X{64}(0);
-  let - : bits(64) = X{}(1);
+  let x = X{64}(0);
+  let y : bits(64) = X{}(1);
 
   X{64}(2) = Zeros{64};
 end;
@@ -92,67 +92,67 @@ end;
 func omit_lone_parameter_single_arity()
 begin
   // Explicit versions:
-  let - = UInt{2}('11');
-  let - = SInt{2}('11');
-  let - = Len{2}('11');
-  let - = BitCount{2}('11');
-  let - = LowestSetBit{2}('11');
-  let - = HighestSetBit{2}('11');
-  let - = IsZero{2}('11');
-  let - = IsOnes{2}('11');
-  let - = CountLeadingZeroBits{2}('11');
-  let - = CountLeadingSignBits{2}('11');
+  - = UInt{2}('11');
+  - = SInt{2}('11');
+  - = Len{2}('11');
+  - = BitCount{2}('11');
+  - = LowestSetBit{2}('11');
+  - = HighestSetBit{2}('11');
+  - = IsZero{2}('11');
+  - = IsOnes{2}('11');
+  - = CountLeadingZeroBits{2}('11');
+  - = CountLeadingSignBits{2}('11');
 
   // Equivalent to:
-  let - = UInt('11');
-  let - = SInt('11');
-  let - = Len('11');
-  let - = BitCount('11');
-  let - = LowestSetBit('11');
-  let - = HighestSetBit('11');
-  let - = IsZero('11');
-  let - = IsOnes('11');
-  let - = CountLeadingZeroBits('11');
-  let - = CountLeadingSignBits('11');
+  - = UInt('11');
+  - = SInt('11');
+  - = Len('11');
+  - = BitCount('11');
+  - = LowestSetBit('11');
+  - = HighestSetBit('11');
+  - = IsZero('11');
+  - = IsOnes('11');
+  - = CountLeadingZeroBits('11');
+  - = CountLeadingSignBits('11');
 end;
 
 func omit_lone_parameter_two_arity()
 begin
   // Explicit versions:
-  let - = AlignDown{3}('111', 1);
-  let - = AlignUp{3}('111', 1);
-  let - = LSL{3}('111', 1);
-  let - = LSL_C{3}('111', 1);
-  let - = LSR{3}('111', 1);
-  let - = LSR_C{3}('111', 1);
-  let - = ASR{3}('111', 1);
-  let - = ASR_C{3}('111', 1);
-  let - = ROR{3}('111', 1);
-  let - = ROR_C{3}('111', 1);
+  - = AlignDown{3}('111', 1);
+  - = AlignUp{3}('111', 1);
+  - = LSL{3}('111', 1);
+  - = LSL_C{3}('111', 1);
+  - = LSR{3}('111', 1);
+  - = LSR_C{3}('111', 1);
+  - = ASR{3}('111', 1);
+  - = ASR_C{3}('111', 1);
+  - = ROR{3}('111', 1);
+  - = ROR_C{3}('111', 1);
 
   // Equivalent to:
-  let - = AlignDown('111', 1);
-  let - = AlignUp('111', 1);
-  let - = LSL('111', 1);
-  let - = LSL_C('111', 1);
-  let - = LSR('111', 1);
-  let - = LSR_C('111', 1);
-  let - = ASR('111', 1);
-  let - = ASR_C('111', 1);
-  let - = ROR('111', 1);
-  let - = ROR_C('111', 1);
+  - = AlignDown('111', 1);
+  - = AlignUp('111', 1);
+  - = LSL('111', 1);
+  - = LSL_C('111', 1);
+  - = LSR('111', 1);
+  - = LSR_C('111', 1);
+  - = ASR('111', 1);
+  - = ASR_C('111', 1);
+  - = ROR('111', 1);
+  - = ROR_C('111', 1);
 end;
 
 func omit_one_of_two_parameters()
 begin
-  let - : bits(64) = SignExtend{64}('1111');
-  let - : bits(64) = ZeroExtend{64}('1111');
-  let - : bits(64) = Extend{64}('1111', TRUE);
+  let x : bits(64) = SignExtend{64}('1111');
+  let y : bits(64) = ZeroExtend{64}('1111');
+  let z : bits(64) = Extend{64}('1111', TRUE);
 end;
 
 func elide_output_parameters()
 begin
-  let - : bits(64) = SignExtend{}('1111');
-  let - : bits(64) = ZeroExtend{}('1111');
-  let - : bits(64) = Extend{}('1111', TRUE);
+  let x : bits(64) = SignExtend{}('1111');
+  let y : bits(64) = ZeroExtend{}('1111');
+  let z : bits(64) = Extend{}('1111', TRUE);
 end;

--- a/asllib/tests/explicit-parameters.t/omit-output-stdlib-param.asl
+++ b/asllib/tests/explicit-parameters.t/omit-output-stdlib-param.asl
@@ -1,6 +1,6 @@
 func omit_too_many_parameters()
 begin
-  let - : bits(64) = Extend('1111', TRUE);
+  let x : bits(64) = Extend('1111', TRUE);
 end;
 
 func main() => integer

--- a/asllib/tests/lca.t
+++ b/asllib/tests/lca.t
@@ -2,9 +2,9 @@
   > func main () => integer
   > begin
   >   let x = if ARBITRARY: boolean then 2 else 3;
-  >   let -: integer = x;
-  >   let -: integer {2, 3} = x;
-  >   let -: real = x;
+  >   let a: integer = x;
+  >   let b: integer {2, 3} = x;
+  >   let c: real = x;
   > end;
   > EOF
 
@@ -17,8 +17,8 @@
   > func main () => integer
   > begin
   >   let x = if ARBITRARY: boolean then 2 as integer else 3;
-  >   let -: integer = x;
-  >   let -: integer {2, 3} = x;
+  >   let a: integer = x;
+  >   let b: integer {2, 3} = x;
   > end;
   > EOF
 
@@ -31,8 +31,8 @@
   > func main {N} (bv: bits(N)) => integer
   > begin
   >   let x = if ARBITRARY: boolean then N else 3;
-  >   let -: integer = x;
-  >   let -: integer {N} = x;
+  >   let a: integer = x;
+  >   let b: integer {N} = x;
   > end;
   > EOF
 
@@ -46,7 +46,7 @@
   > func main {N} (bv: bits(N)) => integer
   > begin
   >   let x = if ARBITRARY: boolean then 3 as integer {0..N} else 3;
-  >   let -: real = x;
+  >   let a: real = x;
   > end;
   > EOF
 
@@ -75,7 +75,7 @@
   > func main () => integer
   > begin
   >   let x = if ARBITRARY: boolean then 3 as T3 else 2 as T2;
-  >   let -: real = x;
+  >   let a: real = x;
   > end;
   > EOF
 
@@ -89,7 +89,7 @@
   > type T2 of boolean;
   > func main () => integer
   > begin
-  >   let - = if ARBITRARY: boolean then 3 as T1 else 2 as T2;
+  >   let x = if ARBITRARY: boolean then 3 as T1 else 2 as T2;
   > end;
   > EOF
 
@@ -104,7 +104,7 @@
   > func main () => integer
   > begin
   >   let x = if ARBITRARY: boolean then '101' as T1 else '101' as bits(3);
-  >   let -: real = x;
+  >   let a: real = x;
   > end;
   > EOF
 
@@ -118,8 +118,8 @@
   > func main () => integer
   > begin
   >   let x = if ARBITRARY: boolean then '101' as T1 else '101' as bits (3) { [2] b1 };
-  >   let -: bits(3) { [2] b1 } = x;
-  >   let -: real = x;
+  >   let a: bits(3) { [2] b1 } = x;
+  >   let b: real = x;
   > end;
   > EOF
 
@@ -134,8 +134,8 @@
   > func main () => integer
   > begin
   >   let x = if ARBITRARY: boolean then 3 as T1 else 2 as T2;
-  >   let -: integer = x;
-  >   let -: real = x;
+  >   let a: integer = x;
+  >   let b: real = x;
   > end;
   > EOF
 
@@ -149,7 +149,7 @@
   > func main () => integer
   > begin
   >   let x = if ARBITRARY: boolean then 3 as T1 else 2 as integer;
-  >   let -: T1 = x;
+  >   let a: T1 = x;
   >   return 0;
   > end;
   > EOF
@@ -161,7 +161,7 @@
   > func main () => integer
   > begin
   >   let x = if ARBITRARY: boolean then (3 as integer, 2 as T1) else (3 as T1, 2 as integer);
-  >   let -: (T1, T1) = x;
+  >   let a: (T1, T1) = x;
   >   return 0;
   > end;
   > EOF
@@ -185,7 +185,7 @@
   >   var a: array[[4]] of integer;
   >   var b: array[[4]] of T1;
   >   let x = if ARBITRARY: boolean then a else b;
-  >   let -: real = x;
+  >   let c: real = x;
   > end;
   > EOF
 

--- a/asllib/tests/overriding.t/overriding-accessors.asl
+++ b/asllib/tests/overriding.t/overriding-accessors.asl
@@ -26,7 +26,7 @@ end;
 
 func main() => integer
 begin
-  let - = Foo();
+  - = Foo();
   assert called_override;
   Foo() = 1;
   assert state == 42;

--- a/asllib/tests/regressions.t/bad-underconstrained-call.asl
+++ b/asllib/tests/regressions.t/bad-underconstrained-call.asl
@@ -11,6 +11,6 @@ end;
 
 func main() => integer
 begin
-  let - = GetMiddleBit{8}('11110000');
+  - = GetMiddleBit{8}('11110000');
   return 0;
 end;

--- a/asllib/tests/regressions.t/bad-underconstrained-ctc.asl
+++ b/asllib/tests/regressions.t/bad-underconstrained-ctc.asl
@@ -5,6 +5,6 @@ end;
 
 func main () => integer
 begin
-  let - = GetLastBit{4}('1111');
+  - = GetLastBit{4}('1111');
   return 0;
 end;

--- a/asllib/tests/regressions.t/more-invocation-examples.asl
+++ b/asllib/tests/regressions.t/more-invocation-examples.asl
@@ -64,10 +64,10 @@ end;
 
 func main () => integer
 begin
-  let - = legal_fun_fixed_width_actual ();
-  let - = legal_fun_underconstrained_actual {4};
-  // let - = legal_fun_constrained_actual (Zeros{32});
-  // let - = legal_fun_constrained_actual (Zeros{64});
+  - = legal_fun_fixed_width_actual ();
+  - = legal_fun_underconstrained_actual {4};
+  // - = legal_fun_constrained_actual (Zeros{32});
+  // - = legal_fun_constrained_actual (Zeros{64});
   // illegal_fun_parameter_mismatch (32, 64);
 
   return 0;

--- a/asllib/tests/regressions.t/pstate-exp.asl
+++ b/asllib/tests/regressions.t/pstate-exp.asl
@@ -105,9 +105,9 @@ end;
 
 func main () => integer
 begin
-  let - = PSTATE();
-  let - = PSTATE().N;
-  let - = PSTATE().[N, Z];
+  - = PSTATE();
+  - = PSTATE().N;
+  - = PSTATE().[N, Z];
   PSTATE() = ARBITRARY: ProcState;
   PSTATE().N = '1';
   PSTATE().[N, Z] = '00';

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -53,9 +53,8 @@ Global ignored:
   > EOF
 
   $ aslref global_ignored.asl
-  File global_ignored.asl, line 1, characters 8 to 13:
-  ASL Typing error: Illegal application of operator / on types integer {3}
-    and integer {0}.
+  File global_ignored.asl, line 1, characters 4 to 5:
+  ASL Grammar error: Obsolete syntax: Discarded storage declaration.
   [1]
 
 Constrained-type satisfaction:
@@ -148,7 +147,7 @@ Runtime checks:
 
   $ cat >runtime-type-sat2.asl <<EOF
   > func test(size: integer {3, 4}) begin
-  >   let - = Zeros{4} as bits(size);
+  >   let x = Zeros{4} as bits(size);
   > end;
   > func main () => integer begin
   >   test(4);

--- a/asllib/tests/regressions.t/same-precedence.asl
+++ b/asllib/tests/regressions.t/same-precedence.asl
@@ -3,7 +3,7 @@ begin
   let a = 1;
   let b = 2;
   let c = 4;
-  let - = a + b - c;
+  let x = a + b - c;
 
   return 0;
 end;

--- a/asllib/tests/regressions.t/same-precedence2.asl
+++ b/asllib/tests/regressions.t/same-precedence2.asl
@@ -3,7 +3,7 @@ begin
   let a = TRUE;
   let b = TRUE;
   let c = TRUE;
-  let - = a --> b <-> c;
+  let d = a --> b <-> c;
 
   return 0;
 end;

--- a/asllib/tests/regressions.t/subprogram-global-name-clash.asl
+++ b/asllib/tests/regressions.t/subprogram-global-name-clash.asl
@@ -18,8 +18,8 @@ end;
 
 func main() => integer
 begin
-  let - = X;
-  let - = X(TRUE);
+  - = X;
+  - = X(TRUE);
   X() = X;
   X() = X + 1;
   assert X() == 1;

--- a/asllib/tests/side-effects.t/for-read.asl
+++ b/asllib/tests/side-effects.t/for-read.asl
@@ -12,7 +12,7 @@ begin
   var y: integer = 0;
 
   for i = 0 to read_X () do
-    let - = y * y + x ;
+    - = y * y + x ;
   end;
 
   return 0;

--- a/asllib/tests/side-effects.t/for-throw-throw.asl
+++ b/asllib/tests/side-effects.t/for-throw-throw.asl
@@ -11,7 +11,7 @@ begin
   var y: integer = 0;
 
   for i = 0 to throwing () do
-    let - = y * y + throwing () ;
+    - = y * y + throwing () ;
   end;
 
   return 0;

--- a/asllib/tests/side-effects.t/for-throw.asl
+++ b/asllib/tests/side-effects.t/for-throw.asl
@@ -11,7 +11,7 @@ begin
   var y: integer = 0;
 
   for i = 0 to throwing () do
-    let - = y * y + x ;
+    - = y * y + x ;
   end;
 
   return 0;

--- a/asllib/tests/side-effects.t/for-write.asl
+++ b/asllib/tests/side-effects.t/for-write.asl
@@ -13,7 +13,7 @@ begin
   var y: integer = 0;
 
   for i = 0 to write_X () do
-    let - = y * y + x ;
+    - = y * y + x ;
   end;
 
   return 0;

--- a/asllib/tests/side-effects.t/type-read-local-let.asl
+++ b/asllib/tests/side-effects.t/type-read-local-let.asl
@@ -2,7 +2,7 @@ func main () => integer
 begin
   let x: integer {0..100} = 0;
 
-  let -: integer {x} = 0;
+  let y: integer {x} = 0;
 
   return 0;
 end;

--- a/asllib/tests/side-effects.t/type-read-local.asl
+++ b/asllib/tests/side-effects.t/type-read-local.asl
@@ -2,7 +2,7 @@ func main () => integer
 begin
   var x: integer = 0;
 
-  let -: integer {x} = x;
+  let y: integer {x} = x;
 
   return 0;
 end;

--- a/asllib/tests/typing.t/HExample15.asl
+++ b/asllib/tests/typing.t/HExample15.asl
@@ -1,6 +1,6 @@
 func HExample15(x: integer {4, 8}, y: integer {4, 8}, a: integer)
 begin
   let d = x DIV y;
-  let - = a < d;
+  - = a < d;
 end;
 

--- a/asllib/tests/typing.t/HExample16.asl
+++ b/asllib/tests/typing.t/HExample16.asl
@@ -7,5 +7,5 @@ func HExemple16 (a: integer {8, 16, 32, 64}, b: integer {8, 16, 32, 64})
 begin
   if a < b then Unreachable(); end;
   let bv = Zeros{a};
-  let -: bits(a) = Reverse{}(bv, b);
+  let x: bits(a) = Reverse{}(bv, b);
 end;

--- a/asllib/tests/typing.t/HExample17.asl
+++ b/asllib/tests/typing.t/HExample17.asl
@@ -8,5 +8,5 @@ begin
   if a != 64 then Unreachable(); end;
   let b = 32;
   let bv = Zeros{a};
-  let -: bits(a) = Reverse{}(bv, b);
+  let x: bits(a) = Reverse{}(bv, b);
 end;

--- a/asllib/tests/typing.t/HExample18.asl
+++ b/asllib/tests/typing.t/HExample18.asl
@@ -9,6 +9,6 @@ begin
   let a2 = 8 << UInt(a);
   let bv = Zeros{a2};
   let b = 16;
-  let -: bits(a2) = Reverse{}(bv, a2);
+  let x: bits(a2) = Reverse{}(bv, a2);
 end;
 

--- a/asllib/tests/typing.t/order-insensitive.asl
+++ b/asllib/tests/typing.t/order-insensitive.asl
@@ -1,9 +1,9 @@
 func foo{N, M}(bv_n: bits(N), bv_m: bits(M))
 begin
-    let - : integer{N, M} = if ARBITRARY: boolean then N else M;
-    let - : integer{M, N} = if ARBITRARY: boolean then N else M;
-    let - : integer{M, N} = N;
-    let - : integer{M, N} = ARBITRARY: integer {N, M};
-    let - : integer{M, N} = ARBITRARY: integer {M, N};
-    let - : integer{M, 10, N} = ARBITRARY: integer {M, N};
+    let a : integer{N, M} = if ARBITRARY: boolean then N else M;
+    let b : integer{M, N} = if ARBITRARY: boolean then N else M;
+    let c : integer{M, N} = N;
+    let d : integer{M, N} = ARBITRARY: integer {N, M};
+    let e : integer{M, N} = ARBITRARY: integer {M, N};
+    let f : integer{M, 10, N} = ARBITRARY: integer {M, N};
 end;

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -224,6 +224,7 @@ let stmts_from_string s =
   let module Parser = Parser.Make(struct
     let allow_no_end_semicolon = false
     let allow_expression_elsif = false
+    let allow_storage_discards = false
   end) in
   let module Lexer = Lexer.Make(struct
     let allow_double_underscore = false


### PR DESCRIPTION
Forbid storage declarations that discard all names, both locally and globally - e.g.:
```
var - = ...;
let (-, -, -) = ...;
```
However, still permit discarding some names but not others:
```
let (-, x, -) = ...;
```
Guard this change behind a `--allow-storage-discards` flag for backwards compatibility.
