### PR TITLE
[asl] Forbid expression-level `elsif`

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -250,7 +250,10 @@ let field_assign := separated_pair(IDENTIFIER, EQ, expr)
 
 let e_else :=
   | ELSE; expr
-  | annotated ( ELSIF; c=expr; THEN; e=expr; ~=e_else; <E_Cond> )
+  | annotated ( ELSIF [@internal true]; c=expr; THEN; e1=expr; e2=e_else; {
+      if Config.allow_expression_elsif then E_Cond (c, e1, e2)
+      else Error.fatal_here $startpos $endpos @@ Error.ObsoleteSyntax "Expression-level 'elsif'."
+    } )
 
 let expr :=
   annotated (

--- a/asllib/ParserConfig.mli
+++ b/asllib/ParserConfig.mli
@@ -24,4 +24,7 @@
 module type CONFIG = sig
   val allow_no_end_semicolon : bool
   (** Allow no semicolon after [end]. *)
+
+  val allow_expression_elsif : bool
+  (** Allow [elsif] at the expression level. *)
 end

--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -30,6 +30,7 @@ type args = {
   files : (file_type * string) list;
   opn : string option;
   allow_no_end_semicolon : bool;
+  allow_expression_elsif : bool;
   allow_double_underscore : bool;
   allow_unknown : bool;
   print_ast : bool;
@@ -51,6 +52,7 @@ let parse_args () =
   let target_files = ref [] in
   let exec = ref true in
   let allow_no_end_semicolon = ref false in
+  let allow_expression_elsif = ref false in
   let allow_double_underscore = ref false in
   let allow_unknown = ref false in
   let print_ast = ref false in
@@ -75,6 +77,9 @@ let parse_args () =
       ( "--allow-no-end-semicolon",
         Arg.Set allow_no_end_semicolon,
         " Allow block statements to terminate with 'end' instead of 'end;'." );
+      ( "--allow-expression-elsif",
+        Arg.Set allow_expression_elsif,
+        " Allow 'elsif' at the expression level." );
       ( "--allow-double-underscore",
         Arg.Set allow_double_underscore,
         " Allow the usage of variables beginning with double underscores \
@@ -169,6 +174,7 @@ let parse_args () =
       files = !target_files;
       opn = (match !opn with "" -> None | s -> Some s);
       allow_no_end_semicolon = !allow_no_end_semicolon;
+      allow_expression_elsif = !allow_expression_elsif;
       allow_double_underscore = !allow_double_underscore;
       allow_unknown = !allow_unknown;
       print_ast = !print_ast;
@@ -219,10 +225,16 @@ let () =
 
   let parser_config =
     let allow_no_end_semicolon = args.allow_no_end_semicolon in
+    let allow_expression_elsif = args.allow_expression_elsif in
     let allow_double_underscore = args.allow_double_underscore in
     let allow_unknown = args.allow_unknown in
     let open Builder in
-    { allow_no_end_semicolon; allow_double_underscore; allow_unknown }
+    {
+      allow_no_end_semicolon;
+      allow_expression_elsif;
+      allow_double_underscore;
+      allow_unknown;
+    }
   in
 
   let extra_main =

--- a/asllib/builder.ml
+++ b/asllib/builder.ml
@@ -30,6 +30,7 @@ type version = [ `ASLv0 | `ASLv1 ]
 
 type parser_config = {
   allow_no_end_semicolon : bool;
+  allow_expression_elsif : bool;
   allow_double_underscore : bool;
   allow_unknown : bool;
 }
@@ -39,6 +40,7 @@ type version_selector = [ `ASLv0 | `ASLv1 | `Any ]
 let default_parser_config =
   {
     allow_no_end_semicolon = false;
+    allow_expression_elsif = false;
     allow_double_underscore = false;
     allow_unknown = false;
   }
@@ -72,6 +74,7 @@ let from_lexbuf ast_type parser_config version (lexbuf : lexbuf) =
   | `ASLv1 -> (
       let module Parser = Parser.Make (struct
         let allow_no_end_semicolon = parser_config.allow_no_end_semicolon
+        let allow_expression_elsif = parser_config.allow_expression_elsif
       end) in
       let module Lexer = Lexer.Make (struct
         let allow_double_underscore = parser_config.allow_double_underscore

--- a/asllib/builder.mli
+++ b/asllib/builder.mli
@@ -31,6 +31,7 @@ type version_selector = [ `ASLv0 | `ASLv1 | `Any ]
 
 type parser_config = {
   allow_no_end_semicolon : bool;
+  allow_expression_elsif : bool;
   allow_double_underscore : bool;
   allow_unknown : bool;
 }

--- a/asllib/bundler.ml
+++ b/asllib/bundler.ml
@@ -53,6 +53,7 @@ let build_ast_from_file ?(is_opn = false) f =
   (* For now expect the ASL input to adhere to the spec. *)
   let module Parser = Parser.Make (struct
     let allow_no_end_semicolon = false
+    let allow_expression_elsif = false
   end) in
   let module Lexer = Lexer.Make (struct
     let allow_double_underscore = false

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -524,7 +524,6 @@
 \newcommand\Nvalue[0]{\hyperlink{def-nvalue}{\nonterminal{value}}}
 \newcommand\Nbinop[0]{\hyperlink{def-nbinop}{\nonterminal{binop}}}
 \newcommand\Nunop[0]{\hyperlink{def-nunop}{\nonterminal{unop}}}
-\newcommand\Neelse[0]{\hyperlink{def-neelse}{\nonterminal{e\_else}}}
 \newcommand\Nfieldassign[0]{\hyperlink{def-nfieldassign}{\nonterminal{field\_assign}}}
 \newcommand\Nlooplimit[0]{\hyperlink{def-nlooplimit}{\nonterminal{loop\_limit}}}
 \newcommand\Nrecurselimit[0]{\hyperlink{def-nrecurselimit}{\nonterminal{recurse\_limit}}}
@@ -848,7 +847,6 @@
 \newcommand\buildbitfields[0]{\hyperlink{build-bitfields}{\textfunc{build\_bitfields}}}
 \newcommand\buildbitfield[0]{\hyperlink{build-bitfield}{\textfunc{build\_bitfield}}}
 \newcommand\buildty[0]{\hyperlink{build-ty}{\textfunc{build\_ty}}}
-\newcommand\buildeelse[0]{\hyperlink{build-eelse}{\textfunc{build\_e\_else}}}
 \newcommand\buildvalue[0]{\hyperlink{build-value}{\textfunc{build\_value}}}
 \newcommand\buildunop[0]{\hyperlink{build-unop}{\textfunc{build\_unop}}}
 \newcommand\buildbinop[0]{\hyperlink{build-binop}{\textfunc{build\_binop}}}
@@ -2527,7 +2525,6 @@
 \newcommand\veminusone[0]{\texttt{e\_minus\_1}}
 \newcommand\veupper[0]{\texttt{e\_upper}}
 \newcommand\veinit[0]{\texttt{e\_init}}
-\newcommand\veelse[0]{\texttt{e\_else}}
 \newcommand\vefive[0]{\texttt{e5}}
 \newcommand\vefour[0]{\texttt{e4}}
 \newcommand\vefourfive[0]{\texttt{e45}}
@@ -2535,6 +2532,7 @@
 \newcommand\velimitopt[0]{\texttt{e\_limit\_opt}}
 \newcommand\velimitoptp[0]{\texttt{e\_limit\_opt'}}
 \newcommand\velse[0]{\texttt{else}}
+\newcommand\velseexpr[0]{\texttt{else\_expr}}
 \newcommand\vend[0]{\texttt{v\_end}}
 \newcommand\vende[0]{\texttt{end\_e}}
 \newcommand\vendep[0]{\texttt{end\_e'}}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -803,9 +803,7 @@ the expression \texttt{NOT '1010'} evaluates to the value \texttt{'0101'}.
 \section{Conditional Expressions\label{sec:ConditionalExpressions}}
 \subsection{Syntax}
 \begin{flalign*}
-\Nexpr \derives\  & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nexpr \parsesep \Neelse &\\
-\Neelse \derives\ & \Telse \parsesep \Nexpr &\\
-|\ & \Telseif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nexpr \parsesep \Neelse &
+\Nexpr \derives\  & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nexpr \parsesep \Telse \parsesep \Nexpr &\\
 \end{flalign*}
 
 \subsection{Abstract Syntax}
@@ -818,53 +816,19 @@ the expression \texttt{NOT '1010'} evaluates to the value \texttt{'0101'}.
   \inferrule{
     \buildexpr(\vcondexpr) \astarrow \astversion{\vcondexpr} \OrBuildError\\\\
     \buildexpr(\vthenexpr) \astarrow \astversion{\vthenexpr} \OrBuildError\\\\
-    \buildeelse(\veelse) \astarrow \astversion{\veelse} \OrBuildError\\\\
+    \buildexpr(\velseexpr) \astarrow \astversion{\velseexpr} \OrBuildError\\\\
   }{
     {
       \begin{array}{r}
   \buildexpr\left(\overname{\Nexpr\left(
     \begin{array}{l}
     \Tif, \namednode{\vcondexpr}{\Nexpr}, \Tthen, \\
-    \wrappedline\ \namednode{\vthenexpr}{\Nexpr}, \veelse: \Neelse
+    \wrappedline\ \namednode{\vthenexpr}{\Nexpr}, \Telse, \namednode{\velseexpr}{\Nexpr}
     \end{array}
     \right)}{\vparsednode}\right) \astarrow\\
-  \overname{\ECond(\astversion{\vcondexpr}, \astversion{\vthenexpr}, \astversion{\veelse})}{\vastnode}
+  \overname{\ECond(\astversion{\vcondexpr}, \astversion{\vthenexpr}, \astversion{\velseexpr})}{\vastnode}
       \end{array}
     }
-}
-\end{mathpar}
-
-\ASTRuleDef{EElse}
-\hypertarget{build-eelse}{}
-The function
-\[
-  \buildeelse(\overname{\parsenode{\Nfieldassign}}{\vparsednode}) \;\aslto\; \overname{\expr}{\vastnode}
-\]
-transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
-
-\begin{mathpar}
-\inferrule[else]{}{
-  \buildeelse(\Neelse(\Telse, \punnode{\Nexpr})) \astarrow
-  \overname{\astof{\vexpr}}{\vastnode}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[else\_if]{
-  \buildexpr(\vcondexpr) \astarrow \astversion{\vcondexpr} \OrBuildError\\\\
-  \buildexpr(\vthenexpr) \astarrow \astversion{\vthenexpr} \OrBuildError
-}{
-  {
-    \begin{array}{r}
-  \buildeelse\left(\Neelse\left(
-    \begin{array}{l}
-    \Telseif, \namednode{\vcondexpr}{\Nexpr},  \\
-    \wrappedline\ \Tthen, \namednode{\vthenexpr}{\Nexpr}, \punnode{\Neelse}
-  \end{array}
-    \right)\right) \astarrow\\
-  \overname{\ECond(\astversion{\vcondexpr}, \astversion{\vthenexpr}, \astof{\veelse})}{\vastnode}
-\end{array}
-  }
 }
 \end{mathpar}
 

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -1024,17 +1024,18 @@ transforms a pattern expression parse node $\vparsednode$ into a pattern AST nod
 \begin{mathpar}
   \inferrule[cond]{
     \buildexpr(\vcondexpr) \astarrow \astversion{\vcondexpr}\\
-    \buildexpr(\vthenexpr) \astarrow \astversion{\vthenexpr}
+    \buildexpr(\vthenexpr) \astarrow \astversion{\vthenexpr}\\
+    \buildexpr(\velseexpr) \astarrow \astversion{\velseexpr}
   }{
     {
       \begin{array}{r}
   \buildexprpattern\left(\Nexprpattern\left(
     \begin{array}{l}
     \Tif, \namednode{\vcondexpr}{\Nexpr}, \Tthen, \\
-    \wrappedline\ \namednode{\vthenexpr}{\Nexpr}, \punnode{\Neelse}
+    \wrappedline\ \namednode{\vthenexpr}{\Nexpr}, \Telse, \namednode{\velseexpr}{\Nexpr}
     \end{array}
     \right)\right) \astarrow\\
-  \overname{\ECond(\astversion{\vcondexpr}, \astversion{\vthenexpr}, \astof{\veelse})}{\vastnode}
+  \overname{\ECond(\astversion{\vcondexpr}, \astversion{\vthenexpr}, \astversion{\velseexpr})}{\vastnode}
       \end{array}
     }
 }

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -488,7 +488,7 @@ except they do not derive tuples, which are the last derivation for $\Nexpr$.
                     |\  & \Tidentifier &\\
                     |\  & \Nexprpattern \parsesep \Nbinop \parsesep \Nexpr &\\
                     |\  & \Nunop \parsesep \Nexpr & \precedence{\Tunops}\\
-                    |\  & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nexpr \parsesep \Neelse &\\
+                    |\  & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nexpr \parsesep \Telse \parsesep \Nexpr &\\
                     |\  & \Ncall &\\
                     |\  & \Nexprpattern \parsesep \Nslices &\\
                     |\  & \Nexprpattern \parsesep \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket &\\
@@ -591,19 +591,13 @@ except they do not derive tuples, which are the last derivation for $\Nexpr$.
 \Nfieldassign \derives \ & \Tidentifier \parsesep \Teq \parsesep \Nexpr &
 \end{flalign*}
 
-\hypertarget{def-neelse}{}
-\begin{flalign*}
-\Neelse \derives\ & \Telse \parsesep \Nexpr &\\
-                     |\ & \Telseif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nexpr \parsesep \Neelse &
-\end{flalign*}
-
 \hypertarget{def-nexpr}{}
 \begin{flalign*}
 \Nexpr \derives\  & \Nvalue &\\
                     |\  & \Tidentifier &\\
                     |\  & \Nexpr \parsesep \Nbinop \parsesep \Nexpr &\\
                     |\  & \Nunop \parsesep \Nexpr & \precedence{\Tunops}\\
-                    |\  & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nexpr \parsesep \Neelse &\\
+                    |\  & \Tif \parsesep \Nexpr \parsesep \Tthen \parsesep \Nexpr \parsesep \Telse \parsesep \Nexpr &\\
                     |\  & \Ncall &\\
                     |\  & \Nexpr \parsesep \Nslices &\\
                     |\  & \Nexpr \parsesep \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket &\\

--- a/asllib/tests/regressions.t/no-expression-elsif.asl
+++ b/asllib/tests/regressions.t/no-expression-elsif.asl
@@ -1,0 +1,15 @@
+func main() => integer
+begin
+  if TRUE then
+    print("A");
+  elsif FALSE then // OK
+    print("B");
+  else
+    print("C");
+  end;
+
+  let x = if TRUE then 1 else if FALSE then 2 else 3; // OK
+  let y = if TRUE then 1 elsif FALSE then 2 else 3;   // ERROR
+
+  return 0;
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -384,6 +384,11 @@ Required tests:
   ASL Error: Undefined identifier: 'bar'
   [1]
 
+  $ aslref no-expression-elsif.asl
+  File no-expression-elsif.asl, line 12, characters 25 to 50:
+  ASL Grammar error: Obsolete syntax: Expression-level 'elsif'.
+  [1]
+
 Base values
   $ aslref base_values.asl
   File base_values.asl, line 5, characters 2 to 28:

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -223,6 +223,7 @@ let stmts_from_string s =
   let lexbuf = Lexing.from_string s in
   let module Parser = Parser.Make(struct
     let allow_no_end_semicolon = false
+    let allow_expression_elsif = false
   end) in
   let module Lexer = Lexer.Make(struct
     let allow_double_underscore = false


### PR DESCRIPTION
Remove support for the `elsif` keyword at the expression level. Guard this change behind a `--allow-expression-elsif` flag for backwards compatibility.