### PR TITLE
[asl] Typecheck discarded `impdef` subprograms

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1867,6 +1867,8 @@
 \newcommand\checkimplementationsunique[0]{\hyperlink{def-checkimplementationsunique}{\textfunc{check\_implementations\_unique}}}
 \newcommand\Prosesignaturesmatch[2]{\hyperlink{def-signaturesmatch}{checking} that the signatures of #1 and #2 match}
 \newcommand\signaturesmatch[0]{\hyperlink{def-signaturesmatch}{\textfunc{signatures\_match}}}
+\newcommand\Proserenamesubprograms[2]{\hyperlink{def-renamesubprograms}{renaming} subprograms in #1 yields #2}
+\newcommand\renamesubprograms[0]{\hyperlink{def-renamesubprograms}{\textfunc{rename\_subprograms}}}
 \newcommand\ProseSCC[3]{\hyperlink{def-scc}{partitioning} the set of declarations #1 with the set of edges #2 yields the list of strongly-connected components #3}
 \newcommand\SCC[0]{\hyperlink{def-scc}{\textfunc{SCC}}}
 \newcommand\topologicalorderingcomps[0]{\hyperlink{def-topologicalorderingcomps}{\textfunc{topological\_ordering\_comps}}}
@@ -2517,6 +2519,8 @@
 \newcommand\vdiff[0]{\texttt{v\_diff}}
 \newcommand\vdir[0]{\texttt{dir}}
 \newcommand\vdirection[0]{\texttt{direction}}
+\newcommand\vdiscarded[0]{\texttt{discarded}}
+\newcommand\vdiscardedp[0]{\texttt{discarded'}}
 \newcommand\vdone[0]{\texttt{d1}}
 \newcommand\vdtwo[0]{\texttt{d2}}
 \newcommand\ve[0]{\texttt{e}}
@@ -2607,6 +2611,7 @@
 \newcommand\vgfour[0]{\texttt{g4}}
 \newcommand\vgfive[0]{\texttt{g5}}
 \newcommand\vh[0]{\texttt{h}}
+\newcommand\vhp[0]{\texttt{h'}}
 \newcommand\vlhsaccess[0]{\texttt{lhs\_access}}
 \newcommand\vlhsaccesses[0]{\texttt{lhs\_accesses}}
 \newcommand\vlhsaccessopt[0]{\texttt{lhs\_access\_opt}}
@@ -2743,6 +2748,7 @@
 \newcommand\vqone[0]{\texttt{q1}}
 \newcommand\vqtwo[0]{\texttt{q2}}
 \newcommand\vr[0]{\texttt{r}}
+\newcommand\vrenameddiscarded[0]{\texttt{renamed\_discarded}}
 \newcommand\vrmrecord[0]{\texttt{rm\_record}}
 \newcommand\vrmrecordnew[0]{\texttt{rm\_record\_new}}
 \newcommand\vrmrecordone[0]{\texttt{rm\_record1}}

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -704,8 +704,7 @@ invalid as it has no corresponding \Proseimpdefsubprogram{}.
 \ASLListing{Invalid overriding}{overriding-bad}{\definitiontests/OverridingBad.asl}
 
 \noindent
-Note that overridden \Proseimpdefsubprograms{} are discarded and not typechecked.
-Therefore, implementations may wish to emit user-configurable warnings to check either:
+Implementations may wish to emit user-configurable warnings to check either:
 \begin{itemize}
   \item All \Proseimpdefsubprograms{} have been overridden by corresponding \Proseimplementationsubprograms{}.
   \item There are no \Proseimplementationsubprograms{}, so no \Proseimpdefsubprograms{} are overridden.
@@ -729,9 +728,10 @@ See \ExampleRef{Overriding Subprograms} for an example of valid overriding.
   \item define $\vimpls$ as the sublist of implementation subprogram declarations in $\decls$;
   \item define $\vnormal$ as the sublist of remaining functions in $\decls$;
   \item \Prosecheckimplementationsunique{$\vimpls$} yields $\True$\ProseOrTypeError;
-  \item \Proseprocessoverrides{$\vimpdefs$}{$\vimpls$} yields $\vimpdefsp$\ProseOrTypeError;
+  \item \Proseprocessoverrides{$\vimpdefs$}{$\vimpls$} yields $\vimpdefsp$ and $\vdiscarded$\ProseOrTypeError;
+  \item \Proserenamesubprograms{$\vdiscarded$}{$\vrenameddiscarded$};
   \item define $\voverridden$ as the concatenation of $\vimpdefsp$ and $\vimpls$;
-  \item $\declsp$ is concatenation of subprogram declarations in $\voverridden$ and $\vnormal$.
+  \item $\declsp$ is the concatenation of subprogram declarations in $\voverridden$, $\vrenameddiscarded$, and $\vnormal$.
 \end{itemize}
 
 \FormallyParagraph
@@ -741,9 +741,10 @@ See \ExampleRef{Overriding Subprograms} for an example of valid overriding.
   \vimpls \eqdef [\vd : \DFunc(\vd) \in \decls \land \vd.\funcoverride = \Implementation] \\
   \vnormal \eqdef [\vd : \DFunc(\vd) \in \decls \land \vd.\funcoverride \notin \{\Impdef, \Implementation\}] \\
   \checkimplementationsunique(\vimpls) \typearrow \True \OrTypeError \\\\
-  \processoverrides(\vimpdefs, \vimpls) \typearrow \vimpdefsp \OrTypeError \\
+  \processoverrides(\vimpdefs, \vimpls) \typearrow (\vimpdefsp, \vdiscarded) \OrTypeError \\\\
+  \renamesubprograms(\vdiscarded) \typearrow \vrenameddiscarded \\
   \voverridden \eqdef \vimpdefsp \concat \vimpls \\
-  \declsp \eqdef [\DFunc(\vd) : \vd \in \voverridden] \concat \vnormal
+  \declsp \eqdef [\DFunc(\vd) : \vd \in \voverridden] \concat [\DFunc(\vd) : \vd \in \vrenameddiscarded] \concat \vnormal
 }{
   \overridesubprograms(\decls) \typearrow \declsp
 }
@@ -844,10 +845,11 @@ See \ExampleRef{Overriding Subprograms} for an example of matching signatures.
 \hypertarget{def-processoverrides}{}
 The function
 \[
-\processoverrides(\overname{\func^*}{\vimpdefs} \aslsep \overname{\func^*}{\vimpls}) \aslto \overname{\func^*}{\vimpdefsp}
+\processoverrides(\overname{\func^*}{\vimpdefs} \aslsep \overname{\func^*}{\vimpls}) \aslto
+(\overname{\func^*}{\vimpdefsp} \times \overname{\func^*}{\vdiscarded})
 \cup \overname{\TTypeError}{\TypeErrorConfig}
 \]
-overrides the \Proseimpdefsubprograms{} $\vimpdefs$ with the \Proseimplementationsubprograms{} $\vimpls$, yielding the new \Proseimpdefsubprograms{} $\vimpdefs$.
+overrides the \Proseimpdefsubprograms{} $\vimpdefs$ with the \Proseimplementationsubprograms{} $\vimpls$, yielding the new \Proseimpdefsubprograms{} $\vimpdefs$ and the discarded subprograms $\vdiscarded$.
 \ProseOtherwiseTypeError{}
 See \ExampleRef{Overriding Subprograms} for an example of valid replacement of an \Proseimplementationsubprogram{}.
 
@@ -857,7 +859,8 @@ See \ExampleRef{Overriding Subprograms} for an example of valid replacement of a
   \item \AllApplyCase{empty}
     \begin{itemize}
       \item \Proseemptylist{$\vimpls$};
-      \item $\vimpdefsp$ is $\vimpdefs$.
+      \item $\vimpdefsp$ is $\vimpdefs$;
+      \item $\vdiscarded$ is the empty list.
     \end{itemize}
   \item \AllApplyCase{non\_empty}
     \begin{itemize}
@@ -866,14 +869,15 @@ See \ExampleRef{Overriding Subprograms} for an example of valid replacement of a
       \item define $\vmatching$ as the sublist of $\vimpdefs$ for which $\vb_i$ is $\True$;
       \item define $\vnonmatching$ as the sublist of $\vimpdefs$ for which $\vb_i$ is $\False$;
       \item \Prosechecktrans{the length of $\vmatching$ is 1}{\OverridingError};
-      \item \Proseprocessoverrides{$\vimpls$}{$\vnonmatching$} yields \vimpdefsp.
+      \item \Proseprocessoverrides{$\vimpls$}{$\vnonmatching$} yields $\vimpdefsp$ and $\vdiscardedp$;
+      \item define $\vdiscarded$ as the concatenation of $\vmatching$ and $\vdiscardedp$.
     \end{itemize}
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[empty]{}{
-  \processoverrides(\vimpdefs, \overname{\emptylist}{\vimpls}) \typearrow \overname{\vimpdefs}{\vimpdefsp}
+  \processoverrides(\vimpdefs, \overname{\emptylist}{\vimpls}) \typearrow (\overname{\vimpdefs}{\vimpdefsp}, \emptylist)
 }
 \end{mathpar}
 
@@ -883,9 +887,58 @@ See \ExampleRef{Overriding Subprograms} for an example of valid replacement of a
   \vmatching \eqdef [\vimpdefs[i] \;|\; i \in \listrange(\vimpdefs) \land \vb_i = \True] \\
   \vnonmatching \eqdef [\vimpdefs[i] \;|\; i \in \listrange(\vimpdefs) \land \vb_i = \False] \\
   \checktrans{\listlen{\vmatching} = 1}{\OverridingError} \checktransarrow \True \terminateas \OverridingError \\\\
-  \processoverrides(\vnonmatching, \vt) \typearrow \vimpdefsp
+  \processoverrides(\vnonmatching, \vt) \typearrow (\vimpdefsp, \vdiscardedp)
+  \vdiscarded \eqdef \vmatching \concat \vdiscardedp
 }{
-  \processoverrides(\vimpdefs, \overname{[\vh] \concat \vt}{\vimpls}) \typearrow \vimpdefsp
+  \processoverrides(\vimpdefs, \overname{[\vh] \concat \vt}{\vimpls}) \typearrow (\vimpdefsp, \vdiscarded)
+}
+\end{mathpar}
+
+\TypingRuleDef{RenameSubprograms}
+\hypertarget{def-renamesubprograms}{}
+The function
+\[
+\renamesubprograms(\overname{\func^*}{\vdiscarded}) \aslto \overname{\func^*}{\vrenameddiscarded}
+\]
+renames the subprograms $\vdiscarded$ to give them fresh names.
+
+\ExampleDef{Typechecking overridden subprograms}
+The specification in \listingref{RenameSubprograms} contains an ill-typed \Proseimpdefsubprogram{} that is overridden.
+This is given a fresh name by $\renamesubprograms$, so that it is still typechecked but never referred to in the resulting specification.
+In particular, though the ill-typed subprogram is overridden and will not be used in the annotated specification, it still results in a typing error.
+\ASLListing{Typechecking an overridden subprogram}{RenameSubprograms}{\typingtests/TypingRule.RenameSubprograms.asl}
+
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{empty}
+    \begin{itemize}
+      \item \Proseemptylist{$\vdiscarded$};
+      \item the result is the empty list.
+    \end{itemize}
+  \item \AllApplyCase{non\_empty}
+    \begin{itemize}
+      \item $\vdiscarded$ is a \Proselist{$\vh$}{$\vt$};
+      \item \Proserenamesubprograms{$\vt$}{$\vtp$};
+      \item define $\vhp$ as $\vh$ with the $\funcname$ field updated to a fresh name;
+      \item the result is the concatenation of $\vhp$ and $\vtp$.
+    \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[empty]{}{
+  \renamesubprograms(\overname{\emptylist}{\vdiscarded}) \typearrow \overname{\emptylist}{\vrenameddiscarded}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_empty]{
+  \renamesubprograms(\vt) \typearrow \vtp \\
+  \name \in \Identifiers \text{ is fresh} \\
+  \vhp \eqdef \vh[\funcname \mapsto \name] \\
+}{
+  \renamesubprograms(\overname{[\vh] \concat \vt}{\vdiscarded}) \typearrow \overname{[\vhp] \concat \vtp}{\vrenameddiscarded}
 }
 \end{mathpar}
 

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -853,6 +853,7 @@ gets
 getter
 getting
 github
+give
 given
 gives
 global

--- a/asllib/tests/ASLTypingReference.t/TypingRule.RenameSubprograms.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.RenameSubprograms.asl
@@ -1,0 +1,9 @@
+impdef func Foo() => boolean
+begin
+  return 1;
+end;
+
+implementation func Foo() => boolean
+begin
+  return TRUE;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -877,3 +877,9 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.SliceEqual.asl
   $ aslref TypingRule.SlicesEqual.asl
   $ aslref TypingRule.BitwidthEqual.asl
+  $ aslref TypingRule.RenameSubprograms.asl
+  File TypingRule.RenameSubprograms.asl, line 3, characters 2 to 11:
+    return 1;
+    ^^^^^^^^^
+  ASL Typing error: a subtype of boolean was expected, provided integer {1}.
+  [1]

--- a/asllib/tests/overriding.t/run.t
+++ b/asllib/tests/overriding.t/run.t
@@ -142,3 +142,9 @@ Bad implementations
 Interactions with other features
   $ aslref --overriding-permissive overriding-overloading.asl
   $ aslref --overriding-permissive overriding-accessors.asl
+  $ aslref --overriding-permissive --no-exec type-check-impdef.asl
+  File type-check-impdef.asl, line 3, characters 2 to 20:
+    return Zeros{N+1};
+    ^^^^^^^^^^^^^^^^^^
+  ASL Typing error: a subtype of bits(N) was expected, provided bits((N + 1)).
+  [1]

--- a/asllib/tests/overriding.t/type-check-impdef.asl
+++ b/asllib/tests/overriding.t/type-check-impdef.asl
@@ -1,0 +1,9 @@
+impdef func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+begin
+  return Zeros{N+1};
+end;
+
+implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+begin
+  return Ones{N};
+end;


### PR DESCRIPTION
Rather than discarding overridden `impdef` subprograms, ensure they are type-checked. In particular, give them fresh names so that they are never referred to, but still appear in the final type-checked specification.