### PR TITLE
Fix typos in post conditions of few MTE tests

### DIFF
--- a/catalogue/aarch64-MTE/tests/RtWtRt+WztWzt.litmus
+++ b/catalogue/aarch64-MTE/tests/RtWtRt+WztWzt.litmus
@@ -10,4 +10,4 @@ P0          | P1          ;
 LDG X1,[X0] | STZG X3,[X2];
 STZG X3,[X0]| STZG X3,[X2, #32];
 LDG X4, [X0]| ;
-exists(0:X1=red /\ 0:X4=red)
+exists(0:X1=:red /\ 0:X4=:red)

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-sync/2+2W+dmb.sttp+dsb.st--sync.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-sync/2+2W+dmb.sttp+dsb.st--sync.litmus
@@ -11,6 +11,7 @@ Variant=memtag,sync
  DMB ST      | STR W0,[X1] ;
  MOV W0,#1   | DSB ST      ;
  STR W0,[X1] | MOV W2,#1   ;
+             | L1:         ;
              | STR W2,[X3] ;
 
-exists ([y]=2 /\ fault(P1,L1))
+exists ([y]=2 /\ fault(P1:L1))

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-sync/MP+dmb.sttp+dsb.sy--sync.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-sync/MP+dmb.sttp+dsb.sy--sync.litmus
@@ -12,4 +12,4 @@ Variant=memtag,sync
  MOV W0,#1   | L1:         ;
  STR W0,[X1] | LDR W2,[X3] ;
 
-exists (1:X0=1 /\ fault(P1,L1))
+exists (1:X0=1 /\ fault(P1:L1))


### PR DESCRIPTION
Couple MTE tests in catalogue contained minor typos in their post condition checks, let's correct them.