### PR TITLE
[asl] Binary operator for string concatenation

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -95,7 +95,7 @@ type binop =
   | `RDIV  (** Division for reals *)
   | `SHL  (** Shift left for ints *)
   | `SHR  (** Shift right for ints *)
-  | `BV_CONCAT  (** Bit vector concatenation *) ]
+  | `CONCAT  (** Bit vector or string concatenation *) ]
 (** Operations on base value of arity two. *)
 
 (* -------------------------------------------------------------------------

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -42,22 +42,11 @@ type native_value =
 
 let nv_literal l = NV_Literal l
 
-let pp_literal f =
-  let open Format in
-  function
-  | L_Int i -> Z.pp_print f i
-  | L_Bool true -> pp_print_string f "TRUE"
-  | L_Bool false -> pp_print_string f "FALSE"
-  | L_Real r -> Q.pp_print f r
-  | L_BitVector bv -> pp_print_string f (Bitvector.to_string_hexa bv)
-  | L_String s -> pp_print_string f s
-  | L_Label l -> pp_print_string f l
-
 let rec pp_native_value f =
   let open Format in
   let pp_comma f () = fprintf f ",@ " in
   function
-  | NV_Literal lit -> pp_literal f lit
+  | NV_Literal lit -> pp_print_string f (Operations.literal_to_string lit)
   | NV_Vector li ->
       fprintf f "@[[%a]@]" (pp_print_list ~pp_sep:pp_comma pp_native_value) li
   | NV_Record map -> IMap.pp_print pp_native_value f map

--- a/asllib/Operations.ml
+++ b/asllib/Operations.ml
@@ -104,7 +104,7 @@ let binop_values pos t (op : binop) v1 v2 =
       L_BitVector
         Bitvector.(
           of_z (length b1) (Z.sub (to_z_unsigned b1) (to_z_unsigned b2)))
-  | `BV_CONCAT, L_BitVector b1, L_BitVector b2 ->
+  | `CONCAT, L_BitVector b1, L_BitVector b2 ->
       L_BitVector (Bitvector.concat [ b1; b2 ])
   (* bits -> integer -> bits *)
   | `PLUS, L_BitVector b1, L_Int z2 ->
@@ -117,6 +117,10 @@ let binop_values pos t (op : binop) v1 v2 =
   (* enum -> enum -> bool *)
   | `EQ_OP, L_Label s1, L_Label s2 -> L_Bool (String.equal s1 s2)
   | `NEQ, L_Label s1, L_Label s2 -> L_Bool (not (String.equal s1 s2))
+  (* string concatenation *)
+  | `CONCAT, _, _ ->
+      let str = literal_to_string v1 ^ literal_to_string v2 in
+      L_String str
   (* Failure *)
   | _ -> fatal_from pos (Error.UnsupportedBinop (t, op, v1, v2))
 

--- a/asllib/Operations.ml
+++ b/asllib/Operations.ml
@@ -25,6 +25,15 @@ let exp_real q z =
     let res_num = Z.pow num i and res_den = Z.pow den i in
     Q.(res_num /// res_den)
 
+let literal_to_string = function
+  | L_Int i -> Z.to_string i
+  | L_Bool true -> "TRUE"
+  | L_Bool false -> "FALSE"
+  | L_Real r -> Q.to_string r
+  | L_BitVector bv -> Bitvector.to_string_hexa bv
+  | L_String s -> s
+  | L_Label l -> l
+
 let binop_values pos t (op : binop) v1 v2 =
   match (op, v1, v2) with
   (* int -> int -> int *)

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -113,7 +113,7 @@ let binop_to_string : binop -> string = function
   | `SHL -> "<<"
   | `SHR -> ">>"
   | `POW -> "^"
-  | `BV_CONCAT -> "::"
+  | `CONCAT -> "::"
 
 let unop_to_string = function BNOT -> "!" | NEG -> "-" | NOT -> "NOT"
 

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -90,7 +90,7 @@ let prec =
   function
   | `BOR | `BAND | `IMPL | `BEQ -> 1
   | `EQ_OP | `NEQ -> 2
-  | `PLUS | `MINUS | `OR | `XOR | `AND | `BV_CONCAT -> 3
+  | `PLUS | `MINUS | `OR | `XOR | `AND | `CONCAT -> 3
   | `MUL | `DIV | `DIVRM | `RDIV | `MOD | `SHL | `SHR -> 4
   | `POW -> 5
   | `GT | `GEQ | `LT | `LEQ -> 0 (* Non assoc *)
@@ -238,7 +238,7 @@ let binop ==
   | SHL         ; { `SHL    }
   | SHR         ; { `SHR    }
   | POW         ; { `POW    }
-  | COLON_COLON ; { `BV_CONCAT }
+  | COLON_COLON ; { `CONCAT }
 
 (* ------------------------------------------------------------------------
 

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -72,7 +72,7 @@
       match es with
       | [] -> E_Literal (L_BitVector Bitvector.empty)
       | [ bv ] -> bv |> desc
-      | bv :: bvs -> List.fold_left (binop `BV_CONCAT) bv bvs |> desc
+      | bv :: bvs -> List.fold_left (binop `CONCAT) bv bvs |> desc
 
   end
 
@@ -358,7 +358,7 @@ let expr :=
   | binop_expr(expr, binop)
   | annotated (
       e1=expr; COLON; e2=expr;
-          { AST.E_Binop (`BV_CONCAT, e1, e2) }
+          { AST.E_Binop (`CONCAT, e1, e2) }
   )
 
 let binop_expr(e, b) ==

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -84,7 +84,7 @@ let pp_binop : binop -> string = function
   | `SHL -> "SHL"
   | `SHR -> "SHR"
   | `POW -> "POW"
-  | `BV_CONCAT -> "BV_CONCAT"
+  | `CONCAT -> "CONCAT"
 
 let pp_unop = function BNOT -> "BNOT" | NOT -> "NOT" | NEG -> "NEG"
 

--- a/asllib/carpenter/ASTEnums.ml
+++ b/asllib/carpenter/ASTEnums.ml
@@ -68,7 +68,7 @@ module Make (C : Config.S) = struct
       (if C.Syntax.rdiv then Some `RDIV else None);
       (if C.Syntax.shl then Some `SHL else None);
       (if C.Syntax.shr then Some `SHR else None);
-      (if C.Syntax.bv_concat then Some `BV_CONCAT else None);
+      (if C.Syntax.bv_concat then Some `CONCAT else None);
     ]
     |> filter_none |> scaled_finite
 

--- a/asllib/carpenter/RandomAST.ml
+++ b/asllib/carpenter/RandomAST.ml
@@ -69,7 +69,7 @@ module Untyped (C : Config.S) = struct
       (if C.Syntax.rdiv then Some `RDIV else None);
       (if C.Syntax.shl then Some `SHL else None);
       (if C.Syntax.shr then Some `SHR else None);
-      (if C.Syntax.bv_concat then Some `BV_CONCAT else None);
+      (if C.Syntax.bv_concat then Some `CONCAT else None);
     ]
     |> protected_filter_oneofl
 
@@ -532,7 +532,7 @@ module Typed (C : Config.S) = struct
             |> map (fun op -> (op, real, real))
         | T_Bits _ ->
             [
-              [| `AND; `OR; `XOR; `BV_CONCAT |]
+              [| `AND; `OR; `XOR; `CONCAT |]
               |> oneofa
               |> map (fun op -> (op, ty, ty));
               [| `PLUS; `MINUS |] |> oneofa |> map (fun op -> (op, ty, integer));

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -563,7 +563,7 @@
 \newcommand\BAND[0]{\hyperlink{ast-band}{\texttt{BAND}}} % Boolean and
 \newcommand\BEQ[0]{\hyperlink{ast-beq}{\texttt{BEQ}}} % Boolean equivalence
 \newcommand\BOR[0]{\hyperlink{ast-bor}{\texttt{BOR}}} % Boolean or
-\newcommand\BVCONCAT[0]{\hyperlink{ast-bvconcat}{\texttt{BV\_CONCAT}}} % Concatenation for bitvectors
+\newcommand\CONCAT[0]{\hyperlink{ast-concat}{\texttt{CONCAT}}} % Concatenation for bitvectors and strings
 \newcommand\DIV[0]{\hyperlink{ast-div}{\texttt{DIV}}} % Integer division
 \newcommand\DIVRM[0]{\hyperlink{ast-divrm}{\texttt{DIVRM}}} % Inexact integer division, with rounding towards negative infinity.
 \newcommand\XOR[0]{\hyperlink{ast-xor}{\texttt{XOR}}} % Bitvector bitwise exclusive or

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -154,9 +154,9 @@ The following rules correspond to unary operations and binary operations that ca
 \\
         |\ & \overtext{\MUL}{\texttt{"*"}} \;|\; \overtext{\DIV}{\texttt{"DIV"}} \;|\; \overtext{\DIVRM}{\texttt{"DIVRM"}}
         \;|\; \overtext{\MOD}{\texttt{"MOD"}} \;|\; \overtext{\SHL}{\texttt{"<<"}}  \;|\; \overtext{\SHR}{\texttt{">>"}}
-        & \hypertarget{ast-rdiv}{} \hypertarget{ast-pow}{} \hypertarget{ast-bvconcat}{}
+        & \hypertarget{ast-rdiv}{} \hypertarget{ast-pow}{} \hypertarget{ast-concat}{}
 \\
-        |\ & \overtext{\RDIV}{\texttt{"/"}} \;|\; \overtext{\POW}{\texttt{"\^{}"}} \;|\; \overtext{\BVCONCAT}{\texttt{"::"}}
+        |\ & \overtext{\RDIV}{\texttt{"/"}} \;|\; \overtext{\POW}{\texttt{"\^{}"}} \;|\; \overtext{\CONCAT}{\texttt{"::"}}
         &
 \end{flalign*}
 

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -725,8 +725,14 @@ eq_enum: RED == RED = TRUE
 eq_enum: RED == GREEN = FALSE
 eq_enum: RED != RED = FALSE
 eq_enum: RED != GREEN = TRUE
+concat_string: 0 :: '1' :: 2.0 :: TRUE :: "foo" :: RED = 00x12TRUEfooRED
 \end{Verbatim}
 % CONSOLE_END
+
+\ExampleDef{String Concatenation}
+String concatenation operates over singular types, first converting them to strings using $\literaltostring$.
+\listingref{binary-operations-stringslabels} shows an example of string concatenation applied to literals of \integertypeterm{}, \bitvectortypeterm{}, \realtypeterm{}, \booleantypeterm{}, and \enumerationtypeterm{}.
+The literals are converted to strings, and these strings are concatenated.
 
 \hypertarget{def-binopsignatures}{}
 The following set defines the valid signatures of

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -47,7 +47,7 @@ on \nativevalues\ via $\unoprel$ and $\binoprel$.
         |\ & \overname{\MUL}{\texttt{"*"}} \;|\; \overname{\DIV}{\texttt{"DIV"}} \;|\; \overname{\DIVRM}{\texttt{"DIVRM"}}
         \;|\; \overname{\MOD}{\texttt{"MOD"}} \;|\; \overname{\SHL}{\texttt{"<<"}}  \;|\; \overname{\SHR}{\texttt{">>"}}
         & \\
-        |\ & \overname{\RDIV}{\texttt{"/"}} \;|\; \overname{\POW}{\texttt{"\^{}"}} \;|\; \overname{\BVCONCAT}{\texttt{"::"}}
+        |\ & \overname{\RDIV}{\texttt{"/"}} \;|\; \overname{\POW}{\texttt{"\^{}"}} \;|\; \overname{\CONCAT}{\texttt{"::"}}
         &
 \end{flalign*}
 
@@ -225,7 +225,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[]{}{
-  \buildbinop(\Nbinop(\Tcoloncolon)) \astarrow \overname{\BVCONCAT}{\vastnode}
+  \buildbinop(\Nbinop(\Tcoloncolon)) \astarrow \overname{\CONCAT}{\vastnode}
 }
 \end{mathpar}
 
@@ -776,7 +776,8 @@ and argument types of its operand literals:
   (\XOR       &,& \lbitvector &,& \lbitvector)&,\\
   (\MINUS     &,& \lbitvector &,& \lbitvector)&,\\
   (\PLUS      &,& \lbitvector &,& \lbitvector)&,\\
-  (\BVCONCAT  &,& \lbitvector &,& \lbitvector)&,\\
+  (\CONCAT    &,& \lbitvector &,& \lbitvector)&,\\
+  (\CONCAT    &,& \Ignore &,& \Ignore)&,\\
   (\MINUS     &,& \lbitvector &,& \lint)&,\\
   (\PLUS      &,& \lbitvector &,& \lint)&\\
   (\EQOP      &,& \lstring &,& \lstring)&,\\
@@ -1106,7 +1107,7 @@ and argument types of its operand literals:
   \begin{itemize}
     \item $\vvone$ is a bitvector literal for $a_{1..k}$;
     \item $\vvtwo$ is a bitvector literal for $b_{1..l}$;
-    \item $\op$ is $\BVCONCAT$;
+    \item $\op$ is $\CONCAT$;
     \item define $\vr$ as the bitvector literal for $a_{1..k}b_{1..l}$.
   \end{itemize}
 
@@ -1140,6 +1141,15 @@ and argument types of its operand literals:
   \begin{itemize}
     \item $\op$ is $\NEQ$, $\vlone$ is the literal string for $a$, and $\vltwo$ is the literal string for $b$;
     \item define $\vr$ as the Boolean literal that is $\True$ if and only if $a$ is different from $b$.
+  \end{itemize}
+
+  \item \AllApplyCase{concat\_strings}
+  \begin{itemize}
+    \item $\vvone$ and $\vvtwo$ are not both bitvector literals;
+    \item $\op$ is $\CONCAT$;
+    \item define $\vsone$ as $\literaltostring(\vvone)$;
+    \item define $\vstwo$ as $\literaltostring(\vvtwo)$;
+    \item define $\vr$ as the string literal for the concatenation of $\vsone$ and $\vstwo$.
   \end{itemize}
 
   \item \AllApplyCase{eq\_label}
@@ -1501,7 +1511,7 @@ of \texttt{width} bits.
 \inferrule[concat\_bits]{}{
   {
   \begin{array}{r}
-  \binopliterals(\overname{\BVCONCAT}{\op}, \overname{\lbitvector(a_{1..k})}{\vvone}, \overname{\lbitvector(b_{1..l})}{\vvtwo}) \typearrow \\
+  \binopliterals(\overname{\CONCAT}{\op}, \overname{\lbitvector(a_{1..k})}{\vvone}, \overname{\lbitvector(b_{1..l})}{\vvtwo}) \typearrow \\
   \overname{\lbitvector(a_{1..k})\lbitvector(b_{1..l})}{\vr}
   \end{array}
   }
@@ -1536,6 +1546,21 @@ of \texttt{width} bits.
 \begin{mathpar}
 \inferrule[ne\_string]{}{
   \binopliterals(\overname{\NEQ}{\op}, \overname{\lstring(a)}{\vvone}, \overname{\lstring(b)}{\vvtwo}) \typearrow \overname{\lbool(a \neq b)}{\vr}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[concat\_strings]{
+  \vvone \neq \lbitvector(\Ignore) \lor \vvtwo \neq \lbitvector(\Ignore) \\
+  \vsone \eqdef \literaltostring(\vvone) \\
+  \vstwo \eqdef \literaltostring(\vvtwo)
+}{
+  {
+  \begin{array}{r}
+  \binopliterals(\overname{\CONCAT}{\op}, \vvone, \vvtwo) \typearrow
+  \overname{\vsone \concat \vstwo}{\vr}
+  \end{array}
+  }
 }
 \end{mathpar}
 

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -1119,12 +1119,21 @@ range constraints. More precisely, they are a superset of the values for \verb|(
 
   \item \AllApplyCase{bits\_concat}
   \begin{itemize}
-    \item $\op$ is $\BVCONCAT$;
+    \item $\op$ is $\CONCAT$;
     \item $\vtone$ is a bitvector type with width expression $\vwone$;
     \item $\vttwo$ is a bitvector type with width expression $\vwtwo$;
     \item define $\vw$ as the addition of $\vwone$ and $\vwtwo$;
     \item applying \normalize{} to $\vw$ in $\tenv$ yields $\vwp$;
     \item $\vt$ is the bitvector type of width $\vwp$ and empty list of bitfields, that is, \\ $\TBits(\vw, \emptylist)$.
+  \end{itemize}
+
+  \item \AllApplyCase{string\_concat}
+  \begin{itemize}
+    \item $\op$ is $\CONCAT$;
+    \item $\vtone$ and $\vttwo$ are not both bit vector types;
+    \item checking that $\vtone$ is a \Prosesingulartype{} yields $\True$\ProseOrTypeError;
+    \item checking that $\vttwo$ is a \Prosesingulartype{} yields $\True$\ProseOrTypeError;
+    \item $\vt$ is the string type.
   \end{itemize}
 
   \item \AllApplyCase{rel}
@@ -1236,7 +1245,7 @@ range constraints. More precisely, they are a superset of the values for \verb|(
       \XOR     & \TBits  & \TBits\\
       \PLUS    & \TBits  & \TBits\\
       \MINUS   & \TBits  & \TBits\\
-      \BVCONCAT & \TBits  & \TBits\\
+      \CONCAT  & \Ignore & \Ignore\\
       %
       \PLUS    & \TBits  & \TInt\\
       \MINUS   & \TBits  & \TInt\\
@@ -1327,8 +1336,19 @@ range constraints. More precisely, they are a superset of the values for \verb|(
   \vw \eqdef \EBinop(\PLUS, \vwone, \vwtwo) \\
   \normalize(\tenv, \vw) \typearrow \vwp
 }{
-  \applybinoptypes(\tenv, \BVCONCAT, \overname{\TBits(\vwone, \Ignore)}{\vtone}, \overname{\TBits(\vwtwo, \Ignore)}{\vttwo}) \typearrow
+  \applybinoptypes(\tenv, \CONCAT, \overname{\TBits(\vwone, \Ignore)}{\vtone}, \overname{\TBits(\vwtwo, \Ignore)}{\vttwo}) \typearrow
   \overname{\TBits(\vwp, \emptylist)}{\vt}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[string\_concat]{
+  \vtone \neq \TBits(\Ignore, \Ignore) \lor \vttwo \neq \TBits(\Ignore, \Ignore) \\
+  \checktrans{\issingular(\vtone)}{\UnexpectedType} \typearrow \True \OrTypeError \\
+  \checktrans{\issingular(\vttwo)}{\UnexpectedType} \typearrow \True \OrTypeError
+}{
+  \applybinoptypes(\tenv, \CONCAT, \vtone, \vttwo) \typearrow
+  \overname{\TString}{\vt}
 }
 \end{mathpar}
 
@@ -1452,7 +1472,7 @@ range constraints. More precisely, they are a superset of the values for \verb|(
       (\XOR     &,& \TBits  &,& \TBits)\\
       (\PLUS    &,& \TBits  &,& \TBits)\\
       (\MINUS   &,& \TBits  &,& \TBits)\\
-      (\BVCONCAT &,& \TBits  &,& \TBits)\\
+      (\CONCAT  &,& \TBits  &,& \TBits)\\
       %
       (\PLUS    &,& \TBits  &,& \TInt)\\
       (\MINUS   &,& \TBits  &,& \TInt)\\

--- a/asllib/menhir2bnfc/tests/integration/cmp_binops.ml
+++ b/asllib/menhir2bnfc/tests/integration/cmp_binops.ml
@@ -28,7 +28,7 @@ let binops : AST.binop enum =
       `RDIV;
       `SHL;
       `SHR;
-      `BV_CONCAT;
+      `CONCAT;
     ]
 
 let unops : AST.unop enum = finite AST.[ BNOT; NEG; NOT ]

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.asl
@@ -33,5 +33,8 @@ begin
   var - : real = 5.5 ^ 7;
   var real_pow_int : real = 5.0 ^ (5 as integer{0..10});
 
+  // String concatenation first converts literals to their string representation.
+  var - : string = 0 :: '1' :: 2.0 :: TRUE :: "foo" :: RED;
+
   return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BinopLiterals.strings_labels.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BinopLiterals.strings_labels.asl
@@ -9,5 +9,7 @@ begin
     println("eq_enum: RED == GREEN = ", RED == GREEN);
     println("eq_enum: RED != RED = ", RED != RED);
     println("eq_enum: RED != GREEN = ", RED != GREEN);
+    println("concat_string: 0 :: '1' :: 2.0 :: TRUE :: \"foo\" :: RED = ",
+            0 :: '1' :: 2.0 :: TRUE :: "foo" :: RED);
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -264,6 +264,7 @@ ASL Typing Tests / annotating types:
   eq_enum: RED == GREEN = FALSE
   eq_enum: RED != RED = FALSE
   eq_enum: RED != GREEN = TRUE
+  concat_string: 0 :: '1' :: 2.0 :: TRUE :: "foo" :: RED = 00x12TRUEfooRED
 
   $ aslref TypingRule.EVar.asl
   $ aslref TypingRule.EVar.undefined.asl

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -373,6 +373,7 @@ Required tests:
   $ aslref alt-mask-syntax.asl
   $ aslref subprogram-global-name-clash.asl
   $ aslref subprogram-local-name-clash.asl
+  $ aslref string_concat.asl
 
   $ aslref --no-type-check throw-local-env.asl
   File throw-local-env.asl, line 10, characters 13 to 14:

--- a/asllib/tests/regressions.t/string_concat.asl
+++ b/asllib/tests/regressions.t/string_concat.asl
@@ -1,0 +1,5 @@
+func main() => integer
+begin
+  assert ("foo" :: 1 :: TRUE :: '1') == "foo1TRUE0x1";
+  return 0;
+end;

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -345,7 +345,7 @@ module Make (C : Config) = struct
       | `PLUS -> M.op Op.Add
       | `SHL -> M.op Op.ShiftLeft
       | `SHR -> M.op Op.ShiftRight
-      | `BV_CONCAT -> concat
+      | `CONCAT -> concat
       | (`POW | `IMPL | `RDIV) as op ->
           Warn.fatal "ASL operation %s not yet implement in ASLSem."
             (Asllib.PP.binop_to_string op)


### PR DESCRIPTION
Support string concatenation by overloading the existing `::` binary operator (previously only bit vector concatenation).