### PR TITLE
[asl] Display error context

### DIFF
--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -24,22 +24,30 @@ Examples used in ASL High-level Definition:
   $ aslref CaseStatement.no_otherwise.asl
   num_tests: 0
   File CaseStatement.no_otherwise.asl, line 17, characters 9 to 30:
+      case test_and_increment(x) of
+           ^^^^^^^^^^^^^^^^^^^^^
   ASL Dynamic error: Unreachable reached.
   [1]
 
   $ aslref UnreachableStatement.asl
   diagnostic assertion failed: example message
   File UnreachableStatement.asl, line 5, characters 8 to 22:
+          Unreachable();
+          ^^^^^^^^^^^^^^
   ASL Dynamic error: Unreachable reached.
   [1]
 
   $ aslref AssertionStatement.asl
   File AssertionStatement.asl, line 5, characters 11 to 22:
+      assert a + b < 256;
+             ^^^^^^^^^^^
   ASL Execution error: Assertion failed: ((a + b) < 256).
   [1]
 
   $ aslref TypingErrorReporting.asl
   File TypingErrorReporting.asl, line 3, characters 11 to 22:
+      return 5 + "hello";
+             ^^^^^^^^^^^
   ASL Typing error: Illegal application of operator + on types integer {5}
     and string.
   [1]
@@ -52,6 +60,10 @@ Examples used in ASL High-level Definition:
   $ aslref --no-exec Overriding.asl
   $ aslref --no-exec OverridingBad.asl
   File OverridingBad.asl, line 1, character 0 to line 4, character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: multiple overlapping `implementation` functions for Foo:
     File OverridingBad.asl, line 1, character 0 to line 4, character 4
     File OverridingBad.asl, line 11, character 0 to line 14, character 4
@@ -81,20 +93,28 @@ Examples used in ASL High-level Definition:
   $ aslref GuideRule.TupleElementAccess.asl
   $ aslref GuideRule.AnonymousEnumerations.bad.asl
   File GuideRule.AnonymousEnumerations.bad.asl, line 4, characters 12 to 23:
+      var x : enumeration {RED, GREEN, BLUE};
+              ^^^^^^^^^^^
   ASL Error: Cannot parse.
   [1]
   $ aslref GuideRule.TupleImmutability.asl
   File GuideRule.TupleImmutability.asl, line 7, characters 6 to 11:
+      x.item1 = '1'; // Illegal: tuples are immutable.
+        ^^^^^
   ASL Typing error: cannot assign to the (immutable) tuple value x.
   [1]
 
   $ aslref ParameterElision.asl
   $ aslref ParameterElision.bad.asl
   File ParameterElision.bad.asl, line 13, characters 25 to 35:
+      var foo : bits(64) = X(data, n);
+                           ^^^^^^^^^^
   ASL Static Error: Arity error while calling 'X':
     1 parameters expected and 0 provided
   [1]
   $ aslref ParameterOmission.bad.asl
   File ParameterOmission.bad.asl, line 6, characters 18 to 19:
+      result = LSL{}(result, 3);
+                    ^
   ASL Error: Cannot parse.
   [1]

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -10,6 +10,8 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.EGlobalVarError.asl
   $ aslref SemanticsRule.EUndefIdent.asl
   File SemanticsRule.EUndefIdent.asl, line 5, characters 9 to 10:
+    assert y;
+           ^
   ASL Error: Undefined identifier: 'y'
   [1]
 //  $ aslref SemanticsRule.EBinopPlusPrint.asl
@@ -21,6 +23,8 @@ ASL Semantics Tests:
   fail.
   File SemanticsRule.EBinopDIVBackendDefinedError.asl, line 4,
     characters 10 to 17:
+    let x = 3 DIV 0;
+            ^^^^^^^
   ASL Typing error: Illegal application of operator DIV on types integer {3}
     and integer {0}.
   [1]
@@ -35,6 +39,8 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.ECondFALSE.asl
   $ aslref SemanticsRule.ECondARBITRARY3or42.asl
   File SemanticsRule.ECondARBITRARY3or42.asl, line 10, characters 9 to 13:
+    assert x==3;
+           ^^^^
   ASL Execution error: Assertion failed: (x == 3).
   [1]
   $ aslref SemanticsRule.ESlice.asl
@@ -51,12 +57,16 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.EArbitraryInteger0.asl
   $ aslref SemanticsRule.EArbitraryInteger3.asl
   File SemanticsRule.EArbitraryInteger3.asl, line 5, characters 9 to 13:
+    assert x==3;
+           ^^^^
   ASL Execution error: Assertion failed: (x == 3).
   [1]
   $ aslref SemanticsRule.EArbitraryIntegerRange3-42-3.asl
   $ aslref SemanticsRule.EArbitraryIntegerRange3-42-42.asl
   File SemanticsRule.EArbitraryIntegerRange3-42-42.asl, line 5,
     characters 9 to 14:
+    assert x==42;
+           ^^^^^
   ASL Execution error: Assertion failed: (x == 42).
   [1]
   $ aslref SemanticsRule.EArbitraryArray.asl
@@ -81,10 +91,22 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.SWhile.limit_reached.asl
   File SemanticsRule.SWhile.limit_reached.asl, line 4, character 2 to line 7,
     character 7:
+    while i <= 3 looplimit 2 do
+      assert i <= 3;
+      i = i + 1;
+     end;
   ASL Dynamic error: loop limit reached.
   [1]
   $ aslref SemanticsRule.SRepeat.asl
   File SemanticsRule.SRepeat.asl, line 24, character 4 to line 31, character 17:
+      repeat
+          println("i = ", i);
+          assert i < 5;
+          if x[i] == '1' then
+              ones = ones + 1;
+          end;
+          i = i + 1;
+      until i == 5;
   ASL Warning: Loop does not have a limit.
   j = 0
   j = 1
@@ -141,10 +163,14 @@ ASL Semantics Tests:
   Otherwise
   $ aslref SemanticsRule.CatchNone.asl
   File SemanticsRule.CatchNone.asl, line 15, characters 8 to 24:
+    catch MyExceptionType1;
+          ^^^^^^^^^^^^^^^^
   ASL Error: Cannot parse.
   [1]
   $ aslref SemanticsRule.FUndefIdent.asl
   File SemanticsRule.FUndefIdent.asl, line 4, characters 5 to 12:
+       foo ();
+       ^^^^^^^
   ASL Error: Undefined identifier: 'foo'
   [1]
   $ aslref SemanticsRule.FCall.asl
@@ -161,6 +187,8 @@ ASL Semantics Tests:
   $ aslref -0 SemanticsRule.LEUndefIdentV0.asl
   $ aslref SemanticsRule.LEUndefIdentV1.asl
   File SemanticsRule.LEUndefIdentV1.asl, line 5, characters 2 to 3:
+    y = 3;
+    ^
   ASL Error: Undefined identifier: 'y'
   [1]
   $ aslref SemanticsRule.LESlice.asl
@@ -194,11 +222,15 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.SAssertOk.asl
   $ aslref SemanticsRule.SAssertNo.asl
   File SemanticsRule.SAssertNo.asl, line 4, characters 10 to 17:
+    assert (42 == 3);
+            ^^^^^^^
   ASL Execution error: Assertion failed: (42 == 3).
   [1]
   $ aslref SemanticsRule.LEDiscard.asl
   $ aslref SemanticsRule.LDDiscard.asl
   File SemanticsRule.LDDiscard.asl, line 4, characters 6 to 7:
+    var - : integer;
+        ^
   ASL Grammar error: Obsolete syntax: Discarded storage declaration.
   [1]
 
@@ -207,6 +239,8 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.ATCNotDynamicErrorIfFalse.asl
   $ aslref SemanticsRule.ATCVariousErrors.asl
   File SemanticsRule.ATCVariousErrors.asl, line 4, characters 2 to 30:
+    var b: integer{4, 5, 6} = 2;                     // A type error
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {4, 5, 6} was expected,
     provided integer {2}.
   [1]
@@ -217,6 +251,8 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.SCond2.asl
   $ aslref SemanticsRule.SCond3.asl
   File SemanticsRule.SCond3.asl, line 3, characters 9 to 14:
+    assert FALSE;
+           ^^^^^
   ASL Execution error: Assertion failed: FALSE.
   [1]
   $ aslref SemanticsRule.SCond4.asl
@@ -233,11 +269,17 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.CheckRecurseLimit.no_limit.asl
   File SemanticsRule.CheckRecurseLimit.no_limit.asl, line 1, character 0 to
     line 4, character 4:
+  func factorial(n: integer) => integer
+  begin
+      return if n == 0 then 1 else n * factorial(n - 1);
+  end;
   ASL Warning: the recursive function factorial has no recursive limit
   annotation.
   $ aslref SemanticsRule.CheckRecurseLimit.limit_reached.asl
   File SemanticsRule.CheckRecurseLimit.limit_reached.asl, line 3,
     characters 37 to 53:
+      return if n == 0 then 1 else n * factorial(n - 1);
+                                       ^^^^^^^^^^^^^^^^
   ASL Dynamic error: recursion limit reached.
   [1]
   $ aslref SemanticsRule.AssignArgs.asl

--- a/asllib/tests/ASLSyntaxReference.t/run.t
+++ b/asllib/tests/ASLSyntaxReference.t/run.t
@@ -11,6 +11,8 @@ Examples used to test syntax and AST building rules:
   [1]
   $ aslref GuideRule.IdentifiersKeywords.bad.asl
   File GuideRule.IdentifiersKeywords.bad.asl, line 3, characters 8 to 12:
+      var case = 5;
+          ^^^^
   ASL Error: Cannot parse.
   [1]
   $ aslref ConventionRule.IdentifiersDifferingByCase.asl
@@ -19,10 +21,14 @@ Examples used to test syntax and AST building rules:
   $ aslref GuideRule.DiscardingLocalStorageDeclarations.asl
   File GuideRule.DiscardingLocalStorageDeclarations.asl, line 4,
     characters 6 to 7:
+    let - = 42;
+        ^
   ASL Grammar error: Obsolete syntax: Discarded storage declaration.
   [1]
   $ aslref GuideRule.DiscardingGlobalStorageDeclarations.asl
   File GuideRule.DiscardingGlobalStorageDeclarations.asl, line 1,
     characters 4 to 5:
+  let - = 42;
+      ^
   ASL Grammar error: Obsolete syntax: Discarded storage declaration.
   [1]

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -8,15 +8,21 @@ ASL Typing Tests:
   $ aslref --no-exec TypingRule.SubtypeSatisfaction2.asl
   $ aslref TypingRule.SubtypeSatisfaction3.asl
   File TypingRule.SubtypeSatisfaction3.asl, line 9, characters 4 to 45:
+      var dogLegs : AnimalLegs = myCircleSides; // illegal: unrelated types
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of AnimalLegs was expected, provided ShapeSides.
   [1]
   $ aslref TypingRule.SubtypeSatisfaction.bad1.asl
   File TypingRule.SubtypeSatisfaction.bad1.asl, line 8, characters 0 to 31:
+  var x : integer{Int12} = Int12;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {2} was expected,
     provided integer {1..2}.
   [1]
   $ aslref TypingRule.SubtypeSatisfaction.bad2.asl
   File TypingRule.SubtypeSatisfaction.bad2.asl, line 7, characters 4 to 13:
+      return N;
+      ^^^^^^^^^
   ASL Typing error: a subtype of integer {N} was expected,
     provided integer {2, 4}.
   [1]
@@ -24,12 +30,16 @@ ASL Typing Tests:
   $ aslref TypingRule.TypeSatisfaction2.asl
   $ aslref TypingRule.TypeSatisfaction3.asl
   File TypingRule.TypeSatisfaction3.asl, line 14, characters 2 to 6:
+    pair = (1, dataT2);
+    ^^^^
   ASL Typing error: a subtype of pairT was expected,
     provided (integer {1}, T2).
   [1]
   $ aslref --no-exec TypingRule.TypeClashes.asl
   $ aslref --no-exec TypingRule.TypeClashes.bad.asl
   File TypingRule.TypeClashes.bad.asl, line 3, characters 0 to 55:
+  func structured_procedure(r: SuperRec) begin pass; end;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: cannot declare already declared element
     "structured_procedure".
   [1]
@@ -40,18 +50,26 @@ ASL Typing Tests:
   $ aslref TypingRule.ApplyBinopTypes.asl
   $ aslref TypingRule.ApplyBinopTypes.constraints.asl
   File TypingRule.ApplyBinopTypes.constraints.asl, line 22, characters 51 to 78:
+      var a_div : integer{A, (A DIV 2), (A DIV 3)} = a DIV (1 as integer{-5..3});
+                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Warning: Removing some values that would fail with op DIV from constraint set
   {-5..3} gave {1..3}. Continuing with this constraint set.
   File TypingRule.ApplyBinopTypes.constraints.asl, line 26, characters 39 to 65:
+      var a_mod_0_to_3 : integer{0..2} = a MOD (1 as integer{0..3});
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Warning: Removing some values that would fail with op MOD from constraint set
   {0..3} gave {1..3}. Continuing with this constraint set.
   File TypingRule.ApplyBinopTypes.constraints.asl, line 42, characters 31 to 82:
+      var y : integer{0..2^14} = (1 as integer{0..2^14}) DIV (2 as integer{0..2^14});
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Warning: Removing some values that would fail with op DIV from constraint set
   {0..16384} gave {1..16384}. Continuing with this constraint set.
   ASL Error: Undefined identifier: 'main'
   [1]
   $ aslref TypingRule.LDDiscard.asl
   File TypingRule.LDDiscard.asl, line 4, characters 6 to 7:
+    let - = 42;
+        ^
   ASL Grammar error: Obsolete syntax: Discarded storage declaration.
   [1]
   $ aslref TypingRule.LDVar.asl
@@ -61,6 +79,12 @@ ASL Typing Tests:
   $ aslref TypingRule.CheckCommonBitfieldsAlign.Error.asl
   File TypingRule.CheckCommonBitfieldsAlign.Error.asl, line 1, character 20 to
     line 6, character 1:
+  type Nested_Type of bits(2) {
+      [1:0] sub {
+          [0,1] common
+      },
+      [1:0] common
+  };
   ASL Typing error:
     bitfields `sub.common` and `common` are in the same scope but define different slices of the containing bitvector type: [0, 1] and [1:0], respectively.
   [1]
@@ -76,24 +100,32 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.InheritIntegerConstraints.unconstrained.bad.asl
   File TypingRule.InheritIntegerConstraints.unconstrained.bad.asl, line 5,
     characters 4 to 27:
+      var g : integer{-} = a;
+      ^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: constrained integer expected, provided integer.
   [1]
 
   $ aslref --no-exec TypingRule.TInt.config_pending_constrained.bad.asl
   File TypingRule.TInt.config_pending_constrained.bad.asl, line 1,
     characters 0 to 27:
+  config x : integer{-} =  1;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a pending constrained integer is illegal here.
   [1]
 
   $ aslref TypingRule.TInt.rhs_pending_constrained.bad.asl
   File TypingRule.TInt.rhs_pending_constrained.bad.asl, line 5,
     characters 28 to 43:
+      var x : integer{1..2} = 3 as integer{-};
+                              ^^^^^^^^^^^^^^^
   ASL Typing error: a pending constrained integer is illegal here.
   [1]
 
   $ aslref TypingRule.AnnotateConstraint.asl
   $ aslref TypingRule.AnnotateConstraint.bad.asl
   File TypingRule.AnnotateConstraint.bad.asl, line 4, characters 17 to 18:
+    let t: integer{x..x+1} = 2; // illegal as 'x' is not constrained.
+                   ^
   ASL Typing error: a pure expression was expected, found x, which produces the
     following side-effects: [ReadsLocal "x"].
   [1]
@@ -103,6 +135,8 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.TArray.asl
   $ aslref TypingRule.TArray.bad.asl
   File TypingRule.TArray.bad.asl, line 9, characters 31 to 57:
+      var illegal_array: array [[non_symbolically_evaluable]] of integer;
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected,
     found non_symbolically_evaluable, which produces the following
     side-effects: [ReadsLocal "non_symbolically_evaluable"].
@@ -111,6 +145,8 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.TEnumDecl.asl
   $ aslref --no-exec TypingRule.TEnumDecl.bad.asl
   File TypingRule.TEnumDecl.bad.asl, line 2, characters 0 to 49:
+  type Color of enumeration { GREEN, ORANGE, RED }; // Illegal: GREEN already declared.
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: cannot declare already declared element "RED".
   [1]
   $ aslref --no-exec TypingRule.Subtype.asl
@@ -120,12 +156,16 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.TCollection.asl
   $ aslref TypingRule.TNonDecl.asl
   File TypingRule.TNonDecl.asl, line 1, characters 5 to 6:
+  func (x: record { a: integer, b: boolean }) => integer
+       ^
   ASL Error: Cannot parse.
   [1]
   $ aslref TypingRule.TBitField.asl
   $ aslref --no-exec TypingRule.AnnotateFuncSig.asl
   $ aslref --no-exec TypingRule.AnnotateFuncSig.bad.asl
   File TypingRule.AnnotateFuncSig.bad.asl, line 4, characters 60 to 63:
+  func signature_example(bv: bits(8)) => bits(16) recurselimit(W)
+                                                              ^^^
   ASL Typing error: a pure expression was expected, found (W), which produces
     the following side-effects: [ReadsGlobal "W"].
   [1]
@@ -136,6 +176,8 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.TString.asl
   $ aslref TypingRule.ConstraintMod.bad.asl
   File TypingRule.ConstraintMod.bad.asl, line 9, characters 4 to 5:
+      z = 3; // Illegal: the type inferred for z is integer{0..2}
+      ^
   ASL Typing error: a subtype of integer {0..2} was expected,
     provided integer {3}.
   [1]
@@ -154,10 +196,14 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.BaseValue.parameterized.asl
   $ aslref TypingRule.BaseValue.bad_negative_width.asl
   File TypingRule.BaseValue.bad_negative_width.asl, line 1, characters 0 to 24:
+  var bits_base: bits(-3);
+  ^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: base value of empty type bits((- 3)).
   [1]
   $ aslref TypingRule.BaseValue.bad_empty.asl
   File TypingRule.BaseValue.bad_empty.asl, line 1, characters 0 to 22:
+  var x : integer{5..0};
+  ^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: base value of empty type integer {5..0}.
   [1]
 
@@ -268,27 +314,37 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.EVar.asl
   $ aslref TypingRule.EVar.undefined.asl
   File TypingRule.EVar.undefined.asl, line 3, characters 12 to 13:
+      var x = t;
+              ^
   ASL Error: Undefined identifier: 't'
   [1]
 
   $ aslref TypingRule.EGetRecordField.asl
   $ aslref TypingRule.EGetBadRecordField.asl
   File TypingRule.EGetBadRecordField.asl, line 7, characters 10 to 36:
+    var x = my_record.undeclared_field;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Error: There is no field 'undeclared_field' on type MyRecordType.
   [1]
   $ aslref TypingRule.EGetBitfield.asl
   $ aslref TypingRule.EGetBadBitField.asl
   File TypingRule.EGetBadBitField.asl, line 7, characters 12 to 33:
+      var x = p.undeclared_bitfield;
+              ^^^^^^^^^^^^^^^^^^^^^
   ASL Error: There is no field 'undeclared_bitfield' on type Packet.
   [1]
   $ aslref TypingRule.EGetBadField.asl
   File TypingRule.EGetBadField.asl, line 6, characters 12 to 15:
+      var x = a.f;
+              ^^^
   ASL Error: There is no field 'f' on type array [[5]] of integer.
   [1]
   $ aslref TypingRule.EGetFields.asl
   $ aslref --no-exec TypingRule.ATC.asl
   $ aslref --no-exec TypingRule.CheckATC.asl
   File TypingRule.CheckATC.asl, line 8, characters 12 to 32:
+      var a = 3.0 as integer{1, 2};
+              ^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: cannot perform Asserted Type Conversion on real by
     integer {1, 2}.
   [1]
@@ -299,6 +355,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.StaticEval.bad.asl, line 3, characters 5 to 20: Division will
   result in empty constraint set, so will always fail.
   File TypingRule.StaticEval.bad.asl, line 3, characters 5 to 20:
+      [WORD_SIZE DIV 3 - 1:WORD_SIZE DIV 2] upper,
+       ^^^^^^^^^^^^^^^
   ASL Typing error: Illegal application of operator DIV on types integer {64}
     and integer {3}.
   [1]
@@ -310,15 +368,21 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.LEVar.asl
   $ aslref TypingRule.LEVar.undefined.asl
   File TypingRule.LEVar.undefined.asl, line 3, characters 4 to 5:
+      x = 42;
+      ^
   ASL Error: Undefined identifier: 'x'
   [1]
   $ aslref TypingRule.LESetBadField.asl
   File TypingRule.LESetBadField.asl, line 6, characters 4 to 5:
+      x.RED = 42;
+      ^
   ASL Typing error: array [[Color]] of integer does not subtype any of:
     bits(-), record {  }, exception {  }, collection {  }.
   [1]
   $ aslref TypingRule.LESetBadField.asl
   File TypingRule.LESetBadField.asl, line 6, characters 4 to 5:
+      x.RED = 42;
+      ^
   ASL Typing error: array [[Color]] of integer does not subtype any of:
     bits(-), record {  }, exception {  }, collection {  }.
   [1]
@@ -327,76 +391,121 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.LESetFields.asl
   $ aslref TypingRule.LESlice.bad.asl
   File TypingRule.LESlice.bad.asl, line 4, characters 3 to 11:
+    x[3:0, 3] = '0 0000';
+     ^^^^^^^^
   ASL Static error: overlapping slices 0+:4, 3+:1.
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.asl
   $ aslref TypingRule.SDecl.asl
   $ aslref TypingRule.SAssert.bad.asl
   File TypingRule.SAssert.bad.asl, line 11, characters 10 to 23:
+      assert(increment()); // Illegal, since increment is not pure.
+            ^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found (increment()), which
     produces the following side-effects: [WritesGlobal "g", ReadsGlobal "g"].
   [1]
   $ aslref TypingRule.SWhile.asl
   File TypingRule.SWhile.asl, line 23, character 4 to line 29, character 8:
+      while i < 20 do
+          assert i < 20;
+          if x[i] == '1' then
+              ones = ones + 1;
+          end;
+          i = i + 1;
+      end;
   ASL Warning: Loop does not have a limit.
   20
   20
   $ aslref TypingRule.SWhile.bad_limit.asl
   File TypingRule.SWhile.bad_limit.asl, line 8, characters 26 to 33:
+      while i < N looplimit i_limit do
+                            ^^^^^^^
   ASL Typing error: a pure expression was expected, found i_limit, which
     produces the following side-effects: [ReadsLocal "i_limit"].
   [1]
   $ aslref TypingRule.SFor.bad1.asl
   File TypingRule.SFor.bad1.asl, line 5, character 4 to line 7, character 8:
+      for i = 0 to 4 do
+          pass;
+      end;
   ASL Typing error: cannot declare already declared element "i".
   [1]
   $ aslref TypingRule.SFor.bad2.asl
   File TypingRule.SFor.bad2.asl, line 5, characters 8 to 9:
+          i = i + 1;
+          ^
   ASL Typing error: cannot assign to immutable storage "i".
   [1]
   $ aslref TypingRule.SFor.bad3.asl
   File TypingRule.SFor.bad3.asl, line 7, characters 4 to 5:
+      j = 0; // Illegal: 'j' is in scope only in the loop body.
+      ^
   ASL Error: Undefined identifier: 'j'
   [1]
   $ aslref TypingRule.SFor.bad4.asl
   File TypingRule.SFor.bad4.asl, line 11, characters 17 to 30:
+      for j = 0 to upper_bound() do
+                   ^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found upper_bound(), which
     produces the following side-effects: [WritesGlobal "g"].
   [1]
   $ aslref TypingRule.SReturn.bad.asl
   File TypingRule.SReturn.bad.asl, line 3, characters 4 to 13:
+      return 0;
+      ^^^^^^^^^
   ASL Typing error: cannot return something from a procedure.
   [1]
   $ aslref --no-exec TypingRule.SPragma.asl
   File TypingRule.SPragma.asl, line 3, characters 4 to 39:
+      pragma implementation_hidden x + 1;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma implementation_hidden will be ignored.
   $ aslref --no-exec TypingRule.BitfieldSliceToPositions.asl
   $ aslref TypingRule.DisjointSlicesToPositions.bad.asl
   File TypingRule.DisjointSlicesToPositions.bad.asl, line 1, character 0 to
     line 6, character 2:
+  var myData: bits(16) {
+      [4] flag,
+      // Illegal: slices declared for the same bitfield must not overlap
+      [3:0, 5:3] data,
+      [3*:4] value
+  };
   ASL Static error: overlapping slices 0+:4, 3+:3.
   [1]
   $ aslref --no-exec TypingRule.CheckPositionsInWidth.bad.asl
   File TypingRule.CheckPositionsInWidth.bad.asl, line 1, character 0 to line 5,
     character 2:
+  var myData: bits(16) {
+      [4] flag,
+      [3:0, 5+:3] data,
+      [3*:5] value // Illegal: position 19 exceeds 15
+  };
   ASL Static error: Cannot extract from bitvector of length 16 slice (3 * 5)+:5.
   [1]
 
   $ aslref TypingRule.CheckNoPrecisionLoss.asl
   File TypingRule.CheckNoPrecisionLoss.asl, line 3, characters 8 to 13:
+  var b = a * a;
+          ^^^^^
   Exploding sets for the binary operation * could result in a constraint set
   bigger than 2^17 with constraints 1..1024 and 1..1024. Continuing with the
   non-expanded constraints.
   File TypingRule.CheckNoPrecisionLoss.asl, line 3, characters 0 to 14:
+  var b = a * a;
+  ^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref TypingRule.PrecisionJoin.asl
   File TypingRule.PrecisionJoin.asl, line 3, characters 9 to 14:
+  var b = (a * a) + 2;
+           ^^^^^
   Exploding sets for the binary operation * could result in a constraint set
   bigger than 2^17 with constraints 1..1024 and 1..1024. Continuing with the
   non-expanded constraints.
   File TypingRule.PrecisionJoin.asl, line 3, characters 0 to 20:
+  var b = (a * a) + 2;
+  ^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
@@ -404,44 +513,60 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.PSingle.asl
   $ aslref TypingRule.PSingle.bad.asl
   File TypingRule.PSingle.bad.asl, line 4, characters 11 to 30:
+      assert '101' IN { '1100' };
+             ^^^^^^^^^^^^^^^^^^^
   ASL Typing error: cannot find a common ancestor to those two types bits(3)
     and bits(4).
   [1]
   $ aslref TypingRule.PRange.asl
   $ aslref TypingRule.PRange.bad.asl
   File TypingRule.PRange.bad.asl, line 4, characters 11 to 32:
+      assert 42.4 IN { -1.8..143 };
+             ^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: Erroneous pattern (- (9.0 / 5.0)) .. 143 for expression of
     type real.
   [1]
   $ aslref TypingRule.PLeq.asl
   $ aslref TypingRule.PLeq.bad.asl
   File TypingRule.PLeq.bad.asl, line 4, characters 12 to 28:
+       assert 3 IN { <= 42.0 };
+              ^^^^^^^^^^^^^^^^
   ASL Typing error: Erroneous pattern <= (42.0 / 1.0) for expression of type
     integer {3}.
   [1]
   $ aslref TypingRule.PGeq.asl
   $ aslref TypingRule.PGeq.bad.asl
   File TypingRule.PGeq.bad.asl, line 4, characters 11 to 27:
+      assert 42 IN { >= 3.0 };
+             ^^^^^^^^^^^^^^^^
   ASL Typing error: Erroneous pattern >= (3.0 / 1.0) for expression of type
     integer {42}.
   [1]
   $ aslref TypingRule.PTuple.bad.asl
   File TypingRule.PTuple.bad.asl, line 8, characters 11 to 45:
+      assert (3, '101010') IN { ('xx1010', 5) };
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(-) was expected, provided integer {3}.
   [1]
   $ aslref TypingRule.PMask.asl
   $ aslref TypingRule.PMask.bad.asl
   File TypingRule.PMask.bad.asl, line 5, characters 11 to 34:
+      assert '101010' IN {'xx10101'};
+             ^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(7) was expected, provided bits(6).
   [1]
   $ aslref TypingRule.PAny.asl
   $ aslref TypingRule.PAny.bad.asl
   File TypingRule.PAny.bad.asl, line 5, characters 11 to 29:
+      assert TRUE IN {FALSE, 5};
+             ^^^^^^^^^^^^^^^^^^
   ASL Typing error: Erroneous pattern 5 for expression of type boolean.
   [1]
 
   $ aslref TypingRule.CheckIsNotCollection.asl
   File TypingRule.CheckIsNotCollection.asl, line 8, characters 2 to 25:
+    var test: MyCollection; // Illegal: local storage elements cannot have collection types.
+    ^^^^^^^^^^^^^^^^^^^^^^^
   ASL typing error: unexpected collection.
   [1]
   $ aslref TypingRule.LESetCollectionFields.asl
@@ -454,45 +579,74 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.CheckStmtReturnsOrThrows.bad.asl
   File TypingRule.CheckStmtReturnsOrThrows.bad.asl, line 6, character 4 to
     line 16, character 8:
+      if v != Zeros{N} then
+          if flag then
+              return Ones{N} XOR v;
+          end;
+      else
+          if flag then
+              return v;
+          else
+              throw invalid_state{};
+          end;
+      end;
   ASL Typing error: the function "incorrect_terminating_path" may not terminate
     by returning a value or raising an exception..
   [1]
   $ aslref TypingRule.ControlFlowFromStmt.asl
   File TypingRule.ControlFlowFromStmt.asl, line 8, characters 4 to 30:
+      pragma require_positive x;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma require_positive will be ignored.
   $ aslref TypingRule.ControlFlowFromStmt.bad1.asl
   File TypingRule.ControlFlowFromStmt.bad1.asl, line 8, character 4 to line 10,
     character 8:
+      while (TRUE) do
+          pass;
+      end;
   ASL Warning: Loop does not have a limit.
   File TypingRule.ControlFlowFromStmt.bad1.asl, line 8, character 4 to line 10,
     character 8:
+      while (TRUE) do
+          pass;
+      end;
   ASL Typing error: the function "loop_forever" may not terminate by returning
     a value or raising an exception..
   [1]
   $ aslref --no-exec TypingRule.DeclareType.asl
   $ aslref TypingRule.AnnotateExtraFields.bad.asl
   File TypingRule.AnnotateExtraFields.bad.asl, line 1, characters 15 to 39:
+  type SubRecord subtypes Record with { };
+                 ^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Error: Undefined identifier: 'Record'
   [1]
   $ aslref --no-exec TypingRule.DeclaredType.asl
   $ aslref --no-exec TypingRule.DeclaredType.bad.asl
   File TypingRule.DeclaredType.bad.asl, line 3, characters 12 to 23:
+      var x = 20 as MyInt;
+              ^^^^^^^^^^^
   ASL Error: Undefined identifier: 'MyInt'
   [1]
   $ aslref --no-exec TypingRule.DeclareConst.asl
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.config.asl
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad1.asl
   File TypingRule.DeclareGlobalStorage.bad1.asl, line 3, characters 0 to 29:
+  config c : integer{1..5} = x;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got x as integer {1..5},
     which produces the following side-effects: [ReadsGlobal "x"].
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad2.asl
   File TypingRule.DeclareGlobalStorage.bad2.asl, line 3, characters 0 to 29:
+  config c : integer{1..x} = 2;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got 2 as integer {1..5},
     which produces the following side-effects: [ReadsGlobal "x"].
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad3.asl
   File TypingRule.DeclareGlobalStorage.bad3.asl, line 2, characters 37 to 38:
+  config uninitialized_config : integer;
+                                       ^
   ASL Error: Cannot parse.
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.non_config.asl
@@ -501,6 +655,8 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.UpdateGlobalStorage.config.bad.asl
   File TypingRule.UpdateGlobalStorage.config.bad.asl, line 3,
     characters 0 to 38:
+  config d: MyException = MyException{};
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected singular type, found MyException.
   [1]
   $ aslref --no-exec TypingRule.DefDecl.asl
@@ -517,20 +673,30 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.DeclDependencies.asl
   $ aslref --no-exec TypingRule.CheckGlobalPragma.asl
   File TypingRule.CheckGlobalPragma.asl, line 2, characters 0 to 32:
+  pragma good_pragma 1, (2==3), x;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma good_pragma will be ignored.
   $ aslref --no-exec TypingRule.CheckGlobalPragma.bad.asl
   File TypingRule.CheckGlobalPragma.bad.asl, line 2, characters 0 to 33:
+  pragma bad_pragma 1, (2==3.0), x;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma bad_pragma will be ignored.
   File TypingRule.CheckGlobalPragma.bad.asl, line 2, characters 22 to 28:
+  pragma bad_pragma 1, (2==3.0), x;
+                        ^^^^^^
   ASL Typing error: Illegal application of operator == on types integer {2}
     and real.
   [1]
   $ aslref --no-exec TypingRule.AddSubprogramDecls.asl
   $ aslref --no-exec TypingRule.TypeCheckAST.asl
   File TypingRule.TypeCheckAST.asl, line 8, characters 0 to 15:
+  pragma pragma1;
+  ^^^^^^^^^^^^^^^
   ASL Warning: pragma pragma1 will be ignored.
   $ aslref --no-exec TypingRule.TypeCheckMutuallyRec.bad.asl
   File TypingRule.TypeCheckMutuallyRec.bad.asl, line 1, characters 0 to 15:
+  var g = foo(5);
+  ^^^^^^^^^^^^^^^
   ASL Typing error: multiple recursive declarations: "foo", "g".
   [1]
   $ aslref --no-exec TypingRule.DeclareSubprograms.asl
@@ -540,11 +706,15 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.SubprogramForName.bad.undefined.asl
   File TypingRule.SubprogramForName.bad.undefined.asl, line 3,
     characters 8 to 17:
+      - = add_10(5);
+          ^^^^^^^^^
   ASL Error: Undefined identifier: 'add_10'
   [1]
   $ aslref TypingRule.SubprogramForName.bad.no_candidates.asl
   File TypingRule.SubprogramForName.bad.no_candidates.asl, line 8,
     characters 8 to 19:
+      - = add_10(5.0);
+          ^^^^^^^^^^^
   ASL Typing error: No subprogram declaration matches the invocation:
     add_10(real).
   [1]
@@ -555,65 +725,100 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.ParametersOfExpr.asl
   $ aslref --no-exec TypingRule.ParametersOfExpr.bad.asl
   File TypingRule.ParametersOfExpr.bad.asl, line 4, characters 19 to 40:
+      x: integer{A..(if TRUE then B else C)}, // Illegal expression in argument type
+                     ^^^^^^^^^^^^^^^^^^^^^
   ASL Static Error: Unsupported expression if TRUE then B else C.
   [1]
   $ aslref --no-exec TypingRule.FuncSigTypes.asl
   $ aslref --no-exec TypingRule.SubprogramTypesClash.asl
   $ aslref TypingRule.SubprogramTypesClash.bad1.asl
   File TypingRule.SubprogramTypesClash.bad1.asl, line 4, characters 8 to 22:
+          return '1000';
+          ^^^^^^^^^^^^^^
   ASL Typing error: cannot declare already declared element "X".
   [1]
   $ aslref TypingRule.SubprogramTypesClash.bad2.asl
   File TypingRule.SubprogramTypesClash.bad2.asl, line 1, characters 0 to 40:
+  func X() => integer begin return 0; end;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: cannot declare already declared element "X".
   [1]
   $ aslref TypingRule.CheckParamDecls.bad.asl
   File TypingRule.CheckParamDecls.bad.asl, line 3, character 0 to line 9,
     character 4:
+  func parameter_lists{A, B, C, D}(
+      x: integer{A..B},
+      y: bits(C)) =>
+      bits(D)
+  begin
+      return Ones{D};
+  end;
   ASL Typing error: incorrect parameter declaration for "parameter_lists",
     expected {D, A, B, C} but {A, B, C, D} provided
   [1]
   $ aslref TypingRule.AnnotateReturnType.bad.asl
   File TypingRule.AnnotateReturnType.bad.asl, line 4, character 0 to line 7,
     character 4:
+  func returns_value() => MyCollection
+  begin
+      return ARBITRARY: MyCollection;
+  end;
   ASL typing error: unexpected collection.
   [1]
   $ aslref --no-exec TypingRule.AnnotateOneParam.asl
   $ aslref TypingRule.AnnotateOneParam.bad1.asl
   File TypingRule.AnnotateOneParam.bad1.asl, line 4, characters 0 to 50:
+  func parameterized{A}(x: bits(A)) begin pass; end;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: cannot declare already declared element "A".
   [1]
   $ aslref --no-exec TypingRule.AnnotateOneArg.asl
   $ aslref TypingRule.AnnotateOneArg.bad1.asl
   File TypingRule.AnnotateOneArg.bad1.asl, line 4, character 0 to line 9,
     character 4:
+  func arguments(b: boolean, i: integer, r: real)
+  begin
+      - = b;
+      - = i;
+      - = r;
+  end;
   ASL Typing error: cannot declare already declared element "b".
   [1]
   $ aslref TypingRule.AnnotateOneArg.bad2.asl
   File TypingRule.AnnotateOneArg.bad2.asl, line 4, character 0 to line 5,
     character 16:
+  func arguments(b: MyCollection)
+  begin pass; end;
   ASL typing error: unexpected collection.
   [1]
   $ aslref TypingRule.AnnotateRetTy.asl
   $ aslref TypingRule.AnnotateRetTy.bad.asl
   File TypingRule.AnnotateRetTy.bad.asl, line 15, characters 4 to 17:
+      flip{64}(bv); // Illegal: the returned value must be consumed.
+      ^^^^^^^^^^^^^
   ASL Error: Mismatched use of return value from call to 'flip'.
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad1.asl
   File TypingRule.AnnotateCallActualsTyped.bad1.asl, line 11,
     characters 8 to 32:
+      - = xor_extend{64}(bv1, bv2); // Illegal: missing parameter for `M`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Static Error: Arity error while calling 'xor_extend':
     2 parameters expected and 1 provided
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad2.asl
   File TypingRule.AnnotateCallActualsTyped.bad2.asl, line 13,
     characters 8 to 31:
+      - = xor_extend{64, 32}(bv1);
+          ^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: No subprogram declaration matches the invocation:
     xor_extend(bits(64)).
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad3.asl
   File TypingRule.AnnotateCallActualsTyped.bad3.asl, line 14,
     characters 8 to 24:
+      - = plus{64}(bv1, w);
+          ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..64} was expected,
     provided integer {0..128}.
   [1]
@@ -622,6 +827,8 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.CheckSymbolicallyEvaluable.bad.asl
   File TypingRule.CheckSymbolicallyEvaluable.bad.asl, line 10,
     characters 5 to 28:
+      [symbolic_throwing{4}(4)] data
+       ^^^^^^^^^^^^^^^^^^^^^^^
   ASL Static Error: Unsupported expression symbolic_throwing{4}(4).
   [1]
   $ aslref TypingRule.EvalSliceExpr.asl
@@ -633,12 +840,16 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.SESIsPure.asl
   $ aslref TypingRule.SESIsPure.bad1.asl
   File TypingRule.SESIsPure.bad1.asl, line 17, characters 11 to 37:
+      assert y > write_side_effecting();
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected,
     found (y > write_side_effecting()), which produces the following
     side-effects: [WritesGlobal "g", ReadsLocal "y", ReadsGlobal "g"].
   [1]
   $ aslref TypingRule.SESIsPure.bad2.asl
   File TypingRule.SESIsPure.bad2.asl, line 16, characters 17 to 39:
+      for i = x to write_side_effecting() do
+                   ^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected,
     found write_side_effecting(), which produces the following side-effects:
     [WritesGlobal "g", ReadsGlobal "g"].
@@ -646,6 +857,8 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.SESIsDeterministic.asl
   $ aslref TypingRule.SESIsDeterministic.bad.asl
   File TypingRule.SESIsDeterministic.bad.asl, line 10, characters 17 to 45:
+      for i = x to ARBITRARY : integer{1..1000} do
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected,
     found ARBITRARY : integer {1..1000}, which produces the following
     side-effects: [NonDeterministic].
@@ -654,6 +867,9 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.SESIsBefore.bad.asl
   File TypingRule.SESIsBefore.bad.asl, line 4, character 0 to line 6,
     character 2:
+  type Data of bits(g * 2) {
+      [0] LSB
+  };
   ASL Typing error: expected constant-time expression, got (g * 2), which
     produces the following side-effects: [ReadsGlobal "g"].
   [1]

--- a/asllib/tests/allow_no_end_semicolon.t
+++ b/asllib/tests/allow_no_end_semicolon.t
@@ -10,6 +10,8 @@ We should be able to make semicolons after 'end' optional
   > EOF
   $ aslref no_semicolon.asl
   File no_semicolon.asl, line 5, characters 2 to 5:
+    end
+    ^^^
   ASL Grammar error: Obsolete syntax: Missing ';' after 'end' keyword.
   [1]
   $ aslref --allow-no-end-semicolon no_semicolon.asl

--- a/asllib/tests/atcs.t
+++ b/asllib/tests/atcs.t
@@ -8,6 +8,8 @@ Deferred to execution ATCs
 
   $ aslref atcs1.asl
   File atcs1.asl, line 2, characters 11 to 12:
+    let x = (3 as integer {42});
+             ^
   ASL Execution error: Mismatch type:
     value 3 does not belong to type integer {42}.
   [1]
@@ -22,6 +24,8 @@ Bad structure ATCs
 
   $ aslref atcs2.asl
   File atcs2.asl, line 2, characters 11 to 23:
+    let x = (3 as boolean);
+             ^^^^^^^^^^^^
   ASL Typing error: cannot perform Asserted Type Conversion on integer {3} by
     boolean.
   [1]
@@ -58,6 +62,8 @@ ATCs on other types
 
   $ aslref atcs5.asl
   File atcs5.asl, line 5, characters 10 to 20:
+    let y = x as myty2;
+            ^^^^^^^^^^
   ASL Typing error: cannot perform Asserted Type Conversion on myty by myty2.
   [1]
 
@@ -71,6 +77,8 @@ ATCs on other types
 
   $ aslref atcs6.asl
   File atcs6.asl, line 3, characters 11 to 25:
+    let x = ((42, Zeros{4}) as myty);
+             ^^^^^^^^^^^^^^
   ASL Execution error: Mismatch type:
     value [42, 0x0] does not belong to type (integer {0..10}, bits(4)).
   [1]
@@ -106,6 +114,8 @@ ATCs in types:
 
   $ aslref atcs9.asl
   File atcs9.asl, line 1, characters 14 to 29:
+  let bv : bits(1 as integer{2}) = Ones{1};
+                ^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found 1 as integer {2},
     which produces the following side-effects: [PerformsAssertions].
   [1]

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -5,6 +5,8 @@ Bad enumeration
 
   $ aslref bad-types1.asl
   File bad-types1.asl, line 1, characters 23 to 24:
+  type t of enumeration {};
+                         ^
   ASL Error: Cannot parse.
   [1]
 
@@ -21,6 +23,10 @@ Bad fields
 
   $ aslref bad-types2.asl
   File bad-types2.asl, line 1, character 0 to line 4, character 2:
+  type t of bits(12) {
+    [10: 3] a,
+    [2+:1] a,
+  };
   ASL Typing error: cannot declare already declared element "a".
   [1]
 
@@ -34,6 +40,10 @@ Overlapping slices
 
   $ aslref bad-types3.asl
   File bad-types3.asl, line 1, character 0 to line 4, character 2:
+  type t of bits(64) {
+    [23: 0] a,
+    [10: 0, 3+: 2] b,
+  };
   ASL Static error: overlapping slices 0+:11, 3+:2.
   [1]
 
@@ -47,6 +57,10 @@ Bad slices
 
   $ aslref bad-types4.asl
   File bad-types4.asl, line 1, character 0 to line 4, character 2:
+  type t of bits(12) {
+    [10: 3] a,
+    [14:12] b,
+  };
   ASL Static error: Cannot extract from bitvector of length 12 slice 12+:3.
   [1]
 
@@ -59,6 +73,10 @@ Bad slices
 
   $ aslref bad-types5.asl
   File bad-types5.asl, line 1, character 0 to line 4, character 2:
+  type t of bits(12) {
+    [10: 3] a,
+    [-2+:1] b,
+  };
   ASL Static error: Cannot extract from bitvector of length 12 slice (- 2)+:1.
   [1]
 
@@ -74,6 +92,13 @@ Bad slices
 
   $ aslref bad-types6.asl
   File bad-types6.asl, line 1, character 0 to line 7, character 2:
+  type t of bits(12) {
+    [10: 3] a,
+    [7+:3] b {
+      [1] d,
+      [10:8] c,
+    },
+  };
   ASL Static error: Cannot extract from bitvector of length 3 slice 8+:3.
   [1]
 
@@ -92,6 +117,8 @@ Arbitrary of empty type
 
   $ aslref bad-types7.asl
   File bad-types7.asl, line 3, characters 38 to 52:
+     let b: integer {1..0} = ARBITRARY: integer {1..0};
+                                        ^^^^^^^^^^^^^^
   ASL Execution error: ARBITRARY of empty type integer {1..0}.
   [1]
 
@@ -107,5 +134,7 @@ Base value of empty type
 
   $ aslref bad-types8.asl
   File bad-types8.asl, line 3, characters 2 to 24:
+    var b: integer {1..0};
+    ^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: base value of empty type integer {1..0}.
   [1]

--- a/asllib/tests/bitfield-alignment.t/run.t
+++ b/asllib/tests/bitfield-alignment.t/run.t
@@ -3,35 +3,64 @@
 
   $ aslref --no-exec bad-scope1.asl
   File bad-scope1.asl, line 1, character 20 to line 5, character 1:
+  type Nested_Type of bits(2) {
+      [1:0] sub {
+          [0] sub
+      }
+  };
   ASL Typing error:
     bitfields `sub` and `sub.sub` are in the same scope but define different slices of the containing bitvector type: [1:0] and [0], respectively.
   [1]
 
   $ aslref --no-exec bad-scope2.asl
   File bad-scope2.asl, line 1, character 20 to line 7, character 1:
+  type Nested_Type of bits(2) {
+      [1:0] sub {
+          [1:0] sub {
+              [1] sub
+          }
+      }
+  };
   ASL Typing error:
     bitfields `sub` and `sub.sub.sub` are in the same scope but define different slices of the containing bitvector type: [1:0] and [1], respectively.
   [1]
 
   $ aslref --no-exec bad-scope3.asl
   File bad-scope3.asl, line 1, character 20 to line 9, character 1:
+  type Nested_Type of bits(2) {
+      [1:0] sub {
+          [1:0] sub {
+              [0,1] lowest
+          }
+      },
+  
+      [1,0] lowest
+  };
   ASL Typing error:
     bitfields `sub.sub.lowest` and `lowest` are in the same scope but define different slices of the containing bitvector type: [0, 1] and [1:0], respectively.
   [1]
 
   $ aslref non-constant-width.asl
   File non-constant-width.asl, line 4, characters 10 to 47:
+    let x = Zeros{64} as (bits(sub_k) {[0] flag});
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got sub_k, which
     produces the following side-effects: [ReadsLocal "sub_k"].
   [1]
   $ aslref non-constant-global-width.asl
   File non-constant-global-width.asl, line 3, character 0 to line 5,
     character 2:
+  type my_type of bits(sub_k) {
+    [0] flag
+  };
   ASL Typing error: expected constant-time expression, got sub_k, which
     produces the following side-effects: [ReadsGlobal "sub_k"].
   [1]
   $ aslref config-global-width.asl
   File config-global-width.asl, line 3, character 0 to line 5, character 2:
+  type my_type of bits(sub_k) {
+    [0] flag
+  };
   ASL Typing error: expected constant-time expression, got sub_k, which
     produces the following side-effects: [ReadsGlobal "sub_k"].
   [1]

--- a/asllib/tests/collections.t/run.t
+++ b/asllib/tests/collections.t/run.t
@@ -1,17 +1,31 @@
   $ aslref on-arbitrary.asl
   File on-arbitrary.asl, line 8, characters 12 to 35:
+    let col = ARBITRARY: MyCollection;
+              ^^^^^^^^^^^^^^^^^^^^^^^
   ASL typing error: unexpected collection.
   [1]
   $ aslref on-local-func-arg.asl
   File on-local-func-arg.asl, line 6, character 0 to line 11, character 4:
+  func foo (col: MyCollection) => integer
+  begin
+    let bv = col.field1;
+  
+    return 0;
+  end;
   ASL typing error: unexpected collection.
   [1]
   $ aslref on-local-var.asl
   File on-local-var.asl, line 8, characters 2 to 24:
+    var col: MyCollection;
+    ^^^^^^^^^^^^^^^^^^^^^^
   ASL typing error: unexpected collection.
   [1]
   $ aslref with-non-bitvector-arg.asl
   File with-non-bitvector-arg.asl, line 1, character 0 to line 4, character 2:
+  type MyCollection of collection {
+    field1: bits(1),
+    field2: integer,
+  };
   ASL Static Error: Unsupported type collection {
                                        field1: bits(1),
                                        field2: integer
@@ -19,6 +33,10 @@
   [1]
   $ aslref on-function-return-type.asl
   File on-function-return-type.asl, line 8, character 0 to line 11, character 4:
+  func foo () => MyCollection
+  begin
+    return col;
+  end;
   ASL typing error: unexpected collection.
   [1]
 

--- a/asllib/tests/constraint-size-limits.t/run.t
+++ b/asllib/tests/constraint-size-limits.t/run.t
@@ -1,12 +1,16 @@
 (* Constraint multiplication *)
   $ aslref constraint-mul-00.asl
   File constraint-mul-00.asl, line 10, characters 4 to 6:
+      b1 = (A * B) - 1; // Test if discrete or interval representation
+      ^^
   ASL Typing error: a subtype of integer {0..4, 6, 8..9, 12, 16} was expected,
     provided integer {15}.
   [1]
 
   $ aslref constraint-mul-01.asl
   File constraint-mul-01.asl, line 10, characters 4 to 6:
+      b1 = (A * B) - 1; // Test if discrete or interval representation
+      ^^
   ASL Typing error: a subtype of
     integer {0..16, 18, 20..22, 24..28, 30, 32..33, 35..36, 39..40, 42, 
              44..45, ...} was expected, provided integer {255}.
@@ -14,6 +18,8 @@
 
   $ aslref constraint-mul-02.asl
   File constraint-mul-02.asl, line 10, characters 4 to 6:
+      b1 = (A * B) - 1; // Test if discrete or interval representation
+      ^^
   ASL Typing error: a subtype of
     integer {0..36, 38..40, 42, 44..46, 48..52, 54..58, 60, 62..66, 68..70, 72,
              ...} was expected, provided integer {1023}.
@@ -21,6 +27,8 @@
 
   $ aslref constraint-mul-03.asl
   File constraint-mul-03.asl, line 10, characters 4 to 6:
+      b1 = (A * B) - 1; // Test if discrete or interval representation
+      ^^
   ASL Typing error: a subtype of
     integer {0..66, 68..70, 72, 74..78, 80..82, 84..88, 90..96, 98..100, 102,
              104..106, ...} was expected, provided integer {4095}.
@@ -28,6 +36,8 @@
 
   $ aslref constraint-mul-04.asl
   File constraint-mul-04.asl, line 10, characters 4 to 6:
+      b1 = (A * B) - 1; // Test if discrete or interval representation
+      ^^
   ASL Typing error: a subtype of
     integer {0..130, 132..136, 138, 140..148, 150, 152..156, 158..162,
              164..166, 168..172, 174..178, ...} was expected,
@@ -36,6 +46,8 @@
 
   $ aslref constraint-mul-05.asl
   File constraint-mul-05.asl, line 10, characters 4 to 6:
+      b1 = (A * B) - 1; // Test if discrete or interval representation
+      ^^
   ASL Typing error: a subtype of
     integer {0..256, 258..262, 264..268, 270, 272..276, 278..280, 282,
              284..292, 294..306, 308..310, ...} was expected,
@@ -44,50 +56,70 @@
 
   $ aslref constraint-mul-06.asl
   File constraint-mul-06.asl, line 6, characters 12 to 21:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+              ^^^^^^^^^
   Exploding sets for the binary operation DIVRM could result in a constraint
   set bigger than 2^17 with constraints 0..512 and 1..512. Continuing with the
   non-expanded constraints.
   File constraint-mul-06.asl, line 6, characters 4 to 22:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+      ^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
 
   $ aslref constraint-mul-07.asl
   File constraint-mul-07.asl, line 6, characters 12 to 21:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+              ^^^^^^^^^
   Exploding sets for the binary operation DIVRM could result in a constraint
   set bigger than 2^17 with constraints 0..1024 and 1..1024. Continuing with
   the non-expanded constraints.
   File constraint-mul-07.asl, line 6, characters 4 to 22:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+      ^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
 
   $ aslref constraint-mul-08.asl
   File constraint-mul-08.asl, line 6, characters 12 to 21:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+              ^^^^^^^^^
   Exploding sets for the binary operation DIVRM could result in a constraint
   set bigger than 2^17 with constraints 0..2048 and 1..2048. Continuing with
   the non-expanded constraints.
   File constraint-mul-08.asl, line 6, characters 4 to 22:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+      ^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
 
   $ aslref constraint-mul-09.asl
   File constraint-mul-09.asl, line 6, characters 12 to 21:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+              ^^^^^^^^^
   Exploding sets for the binary operation DIVRM could result in a constraint
   set bigger than 2^17 with constraints 0..4096 and 1..4096. Continuing with
   the non-expanded constraints.
   File constraint-mul-09.asl, line 6, characters 4 to 22:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+      ^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
 
   $ aslref constraint-mul-10.asl
   File constraint-mul-10.asl, line 6, characters 12 to 21:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+              ^^^^^^^^^
   Exploding sets for the binary operation DIVRM could result in a constraint
   set bigger than 2^17 with constraints 0..8192 and 1..8192. Continuing with
   the non-expanded constraints.
   File constraint-mul-10.asl, line 6, characters 4 to 22:
+      let n = a DIVRM b;     // 10 DIVRM 3 == 3
+      ^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
@@ -95,27 +127,39 @@
 Other operations
   $ aslref constraint-div.asl
   File constraint-div.asl, line 7, characters 10 to 17:
+    var z = a DIV b;
+            ^^^^^^^
   Exploding sets for the binary operation DIV could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 1..1024. Continuing with the
   non-expanded constraints.
   File constraint-div.asl, line 7, characters 2 to 18:
+    var z = a DIV b;
+    ^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref constraint-divrm.asl
   File constraint-divrm.asl, line 7, characters 10 to 19:
+    var z = a DIVRM b;
+            ^^^^^^^^^
   Exploding sets for the binary operation DIVRM could result in a constraint
   set bigger than 2^17 with constraints 0..1024 and 1..1024. Continuing with
   the non-expanded constraints.
   File constraint-divrm.asl, line 7, characters 2 to 20:
+    var z = a DIVRM b;
+    ^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref constraint-minus.asl
   $ aslref constraint-mod.asl
   File constraint-mod.asl, line 7, characters 10 to 17:
+    var z = a MOD b;
+            ^^^^^^^
   Interval too large: [ 1 .. 1048576 ]. Keeping it as an interval.
   File constraint-mod.asl, line 7, characters 2 to 18:
+    var z = a MOD b;
+    ^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
@@ -123,91 +167,131 @@ Other operations
   $ aslref constraint-plus.asl
   $ aslref constraint-pow.asl
   File constraint-pow.asl, line 7, characters 10 to 15:
+    var z = a ^ b;
+            ^^^^^
   Exploding sets for the binary operation ^ could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 0..1024. Continuing with the
   non-expanded constraints.
   File constraint-pow.asl, line 7, characters 2 to 16:
+    var z = a ^ b;
+    ^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref constraint-shl.asl
   File constraint-shl.asl, line 7, characters 10 to 16:
+    var z = a << b;
+            ^^^^^^
   Exploding sets for the binary operation << could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 0..1024. Continuing with the
   non-expanded constraints.
   File constraint-shl.asl, line 7, characters 2 to 17:
+    var z = a << b;
+    ^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref constraint-shr.asl
   File constraint-shr.asl, line 7, characters 10 to 16:
+    var z = a >> b;
+            ^^^^^^
   Exploding sets for the binary operation >> could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 0..1024. Continuing with the
   non-expanded constraints.
   File constraint-shr.asl, line 7, characters 2 to 17:
+    var z = a >> b;
+    ^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref global-constraint-div.asl
   File global-constraint-div.asl, line 8, characters 8 to 15:
+  var z = a DIV b;
+          ^^^^^^^
   Exploding sets for the binary operation DIV could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 1..1024. Continuing with the
   non-expanded constraints.
   File global-constraint-div.asl, line 8, characters 0 to 16:
+  var z = a DIV b;
+  ^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref global-constraint-divrm.asl
   File global-constraint-divrm.asl, line 8, characters 8 to 17:
+  var z = a DIVRM b;
+          ^^^^^^^^^
   Exploding sets for the binary operation DIVRM could result in a constraint
   set bigger than 2^17 with constraints 0..1024 and 1..1024. Continuing with
   the non-expanded constraints.
   File global-constraint-divrm.asl, line 8, characters 0 to 18:
+  var z = a DIVRM b;
+  ^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref global-constraint-minus.asl
   $ aslref global-constraint-mod.asl
   File global-constraint-mod.asl, line 8, characters 8 to 15:
+  var z = a MOD b;
+          ^^^^^^^
   Interval too large: [ 1 .. 1048576 ]. Keeping it as an interval.
   File global-constraint-mod.asl, line 8, characters 0 to 16:
+  var z = a MOD b;
+  ^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref global-constraint-plus.asl
   $ aslref global-constraint-pow.asl
   File global-constraint-pow.asl, line 8, characters 8 to 13:
+  var z = a ^ b;
+          ^^^^^
   Exploding sets for the binary operation ^ could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 0..1024. Continuing with the
   non-expanded constraints.
   File global-constraint-pow.asl, line 8, characters 0 to 14:
+  var z = a ^ b;
+  ^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref global-constraint-shl.asl
   File global-constraint-shl.asl, line 8, characters 8 to 14:
+  var z = a << b;
+          ^^^^^^
   Exploding sets for the binary operation << could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 0..1024. Continuing with the
   non-expanded constraints.
   File global-constraint-shl.asl, line 8, characters 0 to 15:
+  var z = a << b;
+  ^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref global-constraint-shr.asl
   File global-constraint-shr.asl, line 8, characters 8 to 14:
+  var z = a >> b;
+          ^^^^^^
   Exploding sets for the binary operation >> could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 0..1024. Continuing with the
   non-expanded constraints.
   File global-constraint-shr.asl, line 8, characters 0 to 15:
+  var z = a >> b;
+  ^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref global-constraint-mul.asl
   File global-constraint-mul.asl, line 7, characters 8 to 13:
+  var z = a * b;
+          ^^^^^
   Exploding sets for the binary operation * could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 1..1024. Continuing with the
   non-expanded constraints.
   File global-constraint-mul.asl, line 7, characters 0 to 14:
+  var z = a * b;
+  ^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
@@ -215,17 +299,25 @@ Other operations
 With pending constraints
   $ aslref pending.asl
   File pending.asl, line 6, characters 24 to 29:
+    var z : integer {-} = a * b;
+                          ^^^^^
   Interval too large: [ 1 .. 1048576 ]. Keeping it as an interval.
   File pending.asl, line 6, characters 2 to 30:
+    var z : integer {-} = a * b;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref global-pending.asl
   File global-pending.asl, line 7, characters 21 to 26:
+  var z: integer {-} = a * b;
+                       ^^^^^
   Exploding sets for the binary operation * could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 1..1024. Continuing with the
   non-expanded constraints.
   File global-pending.asl, line 7, characters 0 to 27:
+  var z: integer {-} = a * b;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]

--- a/asllib/tests/control-flow.t/run.t
+++ b/asllib/tests/control-flow.t/run.t
@@ -1,5 +1,7 @@
   $ aslref no-return.asl
   File no-return.asl, line 2, character 5:
+  begin
+       
   ASL Typing error: the function "main" may not terminate by returning a value
     or raising an exception..
   [1]
@@ -10,12 +12,16 @@
 
   $ aslref inherited-always-throw.asl
   File inherited-always-throw.asl, line 10, characters 2 to 27:
+    let x = always_throws ();
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: the function "inherited_always_throws" may not terminate by
     returning a value or raising an exception..
   [1]
 
   $ aslref if-return.asl
   File if-return.asl, line 3, characters 2 to 31:
+    if n >= 0 then return 1; end;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: the function "sign" may not terminate by returning a value
     or raising an exception..
   [1]
@@ -26,6 +32,9 @@
 
   $ aslref if-return-if.asl
   File if-return-if.asl, line 3, character 2 to line 5, character 6:
+    if n <= 0 then return -1;
+    else if n >= 0 then return 1; end;
+    end;
   ASL Typing error: the function "sign" may not terminate by returning a value
     or raising an exception..
   [1]
@@ -34,6 +43,8 @@
 
   $ aslref try-01.asl
   File try-01.asl, line 5, character 2 to line 6, character 41:
+    try return 0;
+    catch when E => print("caught E"); end;
   ASL Typing error: the function "test0" may not terminate by returning a value
     or raising an exception..
   [1]
@@ -44,18 +55,34 @@
 
   $ aslref try-04.asl
   File try-04.asl, line 5, character 2 to line 9, character 6:
+    try return 0;
+    catch
+      when E => return 1;
+      otherwise => println("Otherwise");
+    end;
   ASL Typing error: the function "test0" may not terminate by returning a value
     or raising an exception..
   [1]
 
   $ aslref try-05.asl
   File try-05.asl, line 6, character 2 to line 11, character 6:
+    try throw E {};
+    catch
+      when E => return 1;
+      when F => println("Caught F");
+      otherwise => throw E {};
+    end;
   ASL Typing error: the function "test0" may not terminate by returning a value
     or raising an exception..
   [1]
 
   $ aslref try-06.asl
   File try-06.asl, line 5, character 2 to line 9, character 6:
+    try print("body");
+    catch
+      when E => return 1;
+      otherwise => throw E {};
+    end;
   ASL Typing error: the function "test0" may not terminate by returning a value
     or raising an exception..
   [1]

--- a/asllib/tests/division.t/run.t
+++ b/asllib/tests/division.t/run.t
@@ -7,6 +7,8 @@ Division by zero:
   File static-div-zero.asl, line 3, characters 19 to 26: All values in
   constraints {0} would fail with op DIV, operation will always fail.
   File static-div-zero.asl, line 3, characters 19 to 26:
+    let x: integer = 6 DIV 0;
+                     ^^^^^^^
   ASL Typing error: Illegal application of operator DIV on types integer {6}
     and integer {0}.
   [1]
@@ -15,6 +17,8 @@ Division by zero:
   File static-divrm-zero.asl, line 3, characters 19 to 28: All values in
   constraints {0} would fail with op DIVRM, operation will always fail.
   File static-divrm-zero.asl, line 3, characters 19 to 28:
+    let x: integer = 6 DIVRM 0;
+                     ^^^^^^^^^
   ASL Typing error: Illegal application of operator DIVRM on types integer {6}
     and integer {0}.
   [1]
@@ -23,6 +27,8 @@ Division by zero:
   File static-mod-zero.asl, line 3, characters 19 to 26: All values in
   constraints {0} would fail with op MOD, operation will always fail.
   File static-mod-zero.asl, line 3, characters 19 to 26:
+    let x: integer = 6 MOD 0;
+                     ^^^^^^^
   ASL Typing error: Illegal application of operator MOD on types integer {6}
     and integer {0}.
   [1]
@@ -33,6 +39,8 @@ Unsupported divisions (caught at type-checking time):
   File static-div-neg.asl, line 3, characters 19 to 27: All values in
   constraints {(- 3)} would fail with op DIV, operation will always fail.
   File static-div-neg.asl, line 3, characters 19 to 27:
+    let x: integer = 6 DIV -3;
+                     ^^^^^^^^
   ASL Typing error: Illegal application of operator DIV on types integer {6}
     and integer {(- 3)}.
   [1]
@@ -41,6 +49,8 @@ Unsupported divisions (caught at type-checking time):
   File static-divrm-neg.asl, line 3, characters 19 to 29: All values in
   constraints {(- 3)} would fail with op DIVRM, operation will always fail.
   File static-divrm-neg.asl, line 3, characters 19 to 29:
+    let x: integer = 6 DIVRM -3;
+                     ^^^^^^^^^^
   ASL Typing error: Illegal application of operator DIVRM on types integer {6}
     and integer {(- 3)}.
   [1]
@@ -49,6 +59,8 @@ Unsupported divisions (caught at type-checking time):
   File static-mod-neg.asl, line 3, characters 19 to 27: All values in
   constraints {(- 3)} would fail with op MOD, operation will always fail.
   File static-mod-neg.asl, line 3, characters 19 to 27:
+    let x: integer = 6 MOD -3;
+                     ^^^^^^^^
   ASL Typing error: Illegal application of operator MOD on types integer {6}
     and integer {(- 3)}.
   [1]
@@ -57,6 +69,8 @@ Unsupported divisions (caught at type-checking time):
   File static-div-undiv.asl, line 3, characters 19 to 26: Division will result
   in empty constraint set, so will always fail.
   File static-div-undiv.asl, line 3, characters 19 to 26:
+    let x: integer = 5 DIV 3;
+                     ^^^^^^^
   ASL Typing error: Illegal application of operator DIV on types integer {5}
     and integer {3}.
   [1]
@@ -64,6 +78,8 @@ Unsupported divisions (caught at type-checking time):
   File static-div-undiv-bis.asl, line 3, characters 11 to 18: Division will
   result in empty constraint set, so will always fail.
   File static-div-undiv-bis.asl, line 3, characters 11 to 18:
+    let x = (1 DIV 2) as integer {3, 4};
+             ^^^^^^^
   ASL Typing error: Illegal application of operator DIV on types integer {1}
     and integer {2}.
   [1]
@@ -71,6 +87,8 @@ Unsupported divisions (caught at type-checking time):
   File static-div-undiv-bis.asl, line 3, characters 11 to 18: Division will
   result in empty constraint set, so will always fail.
   File static-div-undiv-bis.asl, line 3, characters 11 to 18:
+    let x = (1 DIV 2) as integer {3, 4};
+             ^^^^^^^
   ASL Typing error: Illegal application of operator DIV on types integer {1}
     and integer {2}.
   [1]
@@ -128,6 +146,8 @@ Examples with multiple constraints in slices:
 
   $ aslref div-multi-slices-zero.asl
   File div-multi-slices-zero.asl, line 6, characters 10 to 17:
+    let z = x DIV y;
+            ^^^^^^^
   Warning: Removing some values that would fail with op DIV from constraint set
   {0, 1, 2} gave {1, 2}. Continuing with this constraint set.
 
@@ -135,12 +155,16 @@ Example with constant:
 
   $ aslref div-constants.asl
   File div-constants.asl, line 3, characters 22 to 29:
+  constant z: integer = x DIV y;
+                        ^^^^^^^
   ASL Static error: Illegal application of operator DIV for values 1 and 2.
   [1]
 
 Other example from typing.t:
   $ aslref --no-exec TNegative9-1.asl
   File TNegative9-1.asl, line 3, characters 4 to 59:
+      let testB : bits(N) = Zeros{N DIV 4} :: Zeros{N DIV 2}; // bits(3N/4) != bits(N)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(N) was expected,
     provided bits(((3 * N) DIV 4)).
   [1]
@@ -149,6 +173,8 @@ Other example from typing.t:
 Other polynomial equations:
   $ aslref rat-poly-00.asl
   File rat-poly-00.asl, line 15, characters 9 to 19:
+    assert c == '000';
+           ^^^^^^^^^^
   ASL Typing error: Illegal application of operator == on types bits((7 DIV 2))
     and bits(3).
   [1]

--- a/asllib/tests/explicit-parameters.t/run.t
+++ b/asllib/tests/explicit-parameters.t/run.t
@@ -3,45 +3,71 @@ Explicit parameter tests:
 
   $ aslref bad-declaration-order.asl
   File bad-declaration-order.asl, line 4, character 0 to line 7, character 4:
+  func Bad{D,E,A,B,C}(x: bits(D), y: bits(E)) => bits(A * B + C)
+  begin
+    return Zeros{A * B + C};
+  end;
   ASL Typing error: incorrect parameter declaration for "Bad", expected
     {A, B, C, D, E} but {D, E, A, B, C} provided
   [1]
 
   $ aslref unused-parameter.asl
   File unused-parameter.asl, line 1, character 0 to line 4, character 4:
+  func BadUnused{N}(x: integer) => integer
+  begin
+    return 0;
+  end;
   ASL Typing error: incorrect parameter declaration for "BadUnused", expected
     {} but {N} provided
   [1]
 
   $ aslref undeclared-parameter.asl
   File undeclared-parameter.asl, line 1, character 0 to line 4, character 4:
+  func BadUndeclared(N: integer{3}) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: incorrect parameter declaration for "BadUndeclared",
     expected {N} but {} provided
   [1]
 
   $ aslref duplicate-parameter.asl
   File duplicate-parameter.asl, line 1, character 0 to line 4, character 4:
+  func BadDuplicated{N}(N: integer{3}) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: cannot declare already declared element "N".
   [1]
 
   $ aslref bad-argument-omission.asl
   File bad-argument-omission.asl, line 3, characters 21 to 24:
+    let x : bits(64) = Foo{}; // tries to construct empty record `Foo`
+                       ^^^
   ASL Error: Undefined identifier: 'Foo'
   [1]
 
   $ aslref bad-elided-parameter.asl
   File bad-elided-parameter.asl, line 8, characters 20 to 30:
+    let x : bits(4) = Foo{,3}(0);
+                      ^^^^^^^^^^
   ASL Static Error: Arity error while calling 'Foo':
     1 parameters expected and 2 provided
   [1]
 
   $ aslref omit-output-stdlib-param.asl
   File omit-output-stdlib-param.asl, line 3, characters 21 to 41:
+    let x : bits(64) = Extend('1111', TRUE);
+                       ^^^^^^^^^^^^^^^^^^^^
   ASL Static Error: Arity error while calling 'Extend-1':
     2 parameters expected and 1 provided
   [1]
 
   $ aslref shadowed-parameter.asl
   File shadowed-parameter.asl, line 3, character 0 to line 6, character 4:
+  func MyBits{N}(x: bits(N)) => integer {N+1}
+  begin
+    return N + 1;
+  end;
   ASL Typing error: cannot declare already declared element "N".
   [1]

--- a/asllib/tests/intersecting_slices.t
+++ b/asllib/tests/intersecting_slices.t
@@ -26,6 +26,8 @@ Two intersecting slices...
 
   $ aslref intersecting_slices2.asl
   File intersecting_slices2.asl, line 5, characters 3 to 9:
+    x[i, j] = '10';
+     ^^^^^^
   ASL Static error: overlapping slices i+:1, j+:1.
   [1]
 
@@ -80,5 +82,7 @@ Two intersecting bitfields
 
   $ aslref intersecting_slices4.asl
   File intersecting_slices4.asl, line 5, characters 2 to 12:
+    x.[f1, f2] = '10';
+    ^^^^^^^^^^
   ASL Static error: overlapping slices 0+:1, 0+:1.
   [1]

--- a/asllib/tests/lca.t
+++ b/asllib/tests/lca.t
@@ -10,6 +10,8 @@
 
   $ aslref lca1.asl
   File lca1.asl, line 6, characters 2 to 18:
+    let c: real = x;
+    ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of real was expected, provided integer {2, 3}.
   [1]
 
@@ -24,6 +26,8 @@
 
   $ aslref lca2.asl
   File lca2.asl, line 5, characters 2 to 28:
+    let b: integer {2, 3} = x;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {2, 3} was expected, provided integer.
   [1]
 
@@ -38,6 +42,8 @@
 
   $ aslref lca3.asl
   File lca3.asl, line 5, characters 2 to 25:
+    let b: integer {N} = x;
+    ^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {N} was expected,
     provided integer {3, N}.
   [1]
@@ -52,6 +58,8 @@
 
   $ aslref lca4.asl
   File lca4.asl, line 4, characters 2 to 18:
+    let a: real = x;
+    ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of real was expected, provided integer {0..N, 3}.
   [1]
 
@@ -64,6 +72,8 @@
 
   $ aslref lca5.asl
   File lca5.asl, line 3, characters 10 to 48:
+    let x = if ARBITRARY: boolean then TRUE else 3;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: cannot find a common ancestor to those two types boolean
     and integer {3}.
   [1]
@@ -81,6 +91,8 @@
 
   $ aslref lca6.asl
   File lca6.asl, line 7, characters 2 to 18:
+    let a: real = x;
+    ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of real was expected, provided integer.
   [1]
 
@@ -95,6 +107,8 @@
 
   $ aslref lca7.asl
   File lca7.asl, line 5, characters 50 to 57:
+    let x = if ARBITRARY: boolean then 3 as T1 else 2 as T2;
+                                                    ^^^^^^^
   ASL Typing error: cannot perform Asserted Type Conversion on integer {2} by
     T2.
   [1]
@@ -110,6 +124,8 @@
 
   $ aslref lca8.asl
   File lca8.asl, line 5, characters 2 to 18:
+    let a: real = x;
+    ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of real was expected, provided bits(3).
   [1]
 
@@ -125,6 +141,8 @@
 
   $ aslref lca9.asl
   File lca9.asl, line 6, characters 2 to 18:
+    let b: real = x;
+    ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of real was expected, provided T1.
   [1]
 
@@ -141,6 +159,8 @@
 
   $ aslref lca10.asl
   File lca10.asl, line 7, characters 2 to 18:
+    let b: real = x;
+    ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of real was expected, provided integer.
   [1]
 
@@ -191,5 +211,7 @@
 
   $ aslref lca14.asl
   File lca14.asl, line 7, characters 2 to 18:
+    let c: real = x;
+    ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of real was expected, provided array [[4]] of T1.
   [1]

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -35,6 +35,8 @@
   > EOF
   $ aslref println5.asl
   File println5.asl, line 1, characters 32 to 33:
+  constant msg = "Something with \p bad characters.";
+                                  ^
   ASL Error: Unknown symbol.
   [1]
   $ cat >println6.asl <<EOF
@@ -42,9 +44,8 @@
   > func main () => integer begin println(msg); return 0; end;
   > EOF
   $ aslref println6.asl
-  File println6.asl, line 3, character 0:
-  ASL Error: Unknown symbol.
-  [1]
+  Fatal error: exception End_of_file
+  [2]
 
 C-Style comments
   $ cat >comments1.asl <<EOF
@@ -77,6 +78,8 @@ C-Style comments
 
   $ aslref comments2.asl
   File comments2.asl, line 11, characters 8 to 9:
+  let a = b;
+          ^
   ASL Error: Undefined identifier: 'b'
   [1]
 
@@ -95,6 +98,8 @@ Some problems with bitvectors and bitmasks:
 
   $ aslref masks0.asl
   File masks0.asl, line 4, characters 17 to 28:
+      let expr_a = '' IN {'1'};
+                   ^^^^^^^^^^^
   ASL Typing error: cannot find a common ancestor to those two types bits(0)
     and bits(1).
   [1]

--- a/asllib/tests/loop-limits.t/run.t
+++ b/asllib/tests/loop-limits.t/run.t
@@ -12,6 +12,10 @@ While loops:
   4
   5
   File while-incorrect.asl, line 4, character 2 to line 7, character 6:
+    while (i < 10) looplimit 5 do
+      i = i + 1;
+      println(i);
+    end;
   ASL Dynamic error: loop limit reached.
   [1]
 
@@ -19,11 +23,17 @@ While loops:
 
   $ aslref while-exact-minus-one.asl
   File while-exact-minus-one.asl, line 4, character 2 to line 6, character 6:
+    while (i < 10) looplimit 9 do
+      i = i + 1;
+    end;
   ASL Dynamic error: loop limit reached.
   [1]
 
   $ aslref while-no-limit.asl
   File while-no-limit.asl, line 4, character 2 to line 6, character 6:
+    while (i < 10) do
+      i = i + 1;
+    end;
   ASL Warning: Loop does not have a limit.
 
 Repeat loops:
@@ -37,6 +47,10 @@ Repeat loops:
   4
   5
   File repeat-incorrect.asl, line 4, character 2 to line 7, character 30:
+    repeat
+      i = i + 1;
+      println(i);
+    until (i >= 10) looplimit 5;
   ASL Dynamic error: loop limit reached.
   [1]
 
@@ -44,11 +58,17 @@ Repeat loops:
 
   $ aslref repeat-exact-minus-one.asl
   File repeat-exact-minus-one.asl, line 4, character 2 to line 6, character 30:
+    repeat
+      i = i + 1;
+    until (i >= 10) looplimit 9;
   ASL Dynamic error: loop limit reached.
   [1]
 
   $ aslref repeat-no-limit.asl
   File repeat-no-limit.asl, line 4, character 2 to line 6, character 18:
+    repeat
+      i = i + 1;
+    until (i >= 10);
   ASL Warning: Loop does not have a limit.
 
 Double loops
@@ -57,18 +77,31 @@ Double loops
   $ aslref double-while-correct-incorrect.asl
   File double-while-correct-incorrect.asl, line 9, character 4 to line 11,
     character 8:
+      while (j < 10) looplimit 5 do
+        j = j + 1;
+      end;
   ASL Dynamic error: loop limit reached.
   [1]
 
   $ aslref double-while-incorrect-correct.asl
   File double-while-incorrect-correct.asl, line 6, character 2 to line 12,
     character 6:
+    while (i < 10) looplimit 5 do
+      i = i + 1;
+      j = 0;
+      while (j < 10) looplimit 20 do
+        j = j + 1;
+      end;
+    end;
   ASL Dynamic error: loop limit reached.
   [1]
 
   $ aslref double-while-incorrect-incorrect.asl
   File double-while-incorrect-incorrect.asl, line 9, character 4 to line 11,
     character 8:
+      while (j < 10) looplimit 5 do
+        j = j + 1;
+      end;
   ASL Dynamic error: loop limit reached.
   [1]
 
@@ -76,10 +109,14 @@ For loops
   $ aslref for-correct.asl
   $ aslref for-incorrect.asl
   File for-incorrect.asl, line 5, characters 4 to 26:
+      counter = counter + 1;
+      ^^^^^^^^^^^^^^^^^^^^^^
   ASL Dynamic error: loop limit reached.
   [1]
   $ aslref for-exact.asl
   File for-exact.asl, line 5, characters 4 to 26:
+      counter = counter + 1;
+      ^^^^^^^^^^^^^^^^^^^^^^
   ASL Dynamic error: loop limit reached.
   [1]
   $ aslref for-exact-minus-one.asl
@@ -90,6 +127,11 @@ Recursion limits:
 
   $ aslref recursion-no-limit.asl
   File recursion-no-limit.asl, line 1, character 0 to line 5, character 4:
+  func recurse (n: integer) => integer
+  begin
+    if n >= 10 then return 1;
+    else return 1 + recurse (n+1); end;
+  end;
   ASL Warning: the recursive function recurse has no recursive limit
   annotation.
   Number of calls: 11
@@ -106,6 +148,8 @@ Recursion limits:
   3
   4
   File recursion-incorrect.asl, line 6, characters 18 to 31:
+    else return 1 + recurse (n+1); end;
+                    ^^^^^^^^^^^^^
   ASL Dynamic error: recursion limit reached.
   [1]
 
@@ -115,5 +159,7 @@ Recursion limits:
 
   $ aslref recursion-exact-minus-one.asl
   File recursion-exact-minus-one.asl, line 5, characters 18 to 31:
+    else return 1 + recurse (n+1); end;
+                    ^^^^^^^^^^^^^
   ASL Dynamic error: recursion limit reached.
   [1]

--- a/asllib/tests/overriding.t/run.t
+++ b/asllib/tests/overriding.t/run.t
@@ -2,6 +2,10 @@ Single impdef only
   $ aslref --no-exec --overriding-permissive impdef-only.asl
   $ aslref --no-exec --overriding-all-impdefs-overridden impdef-only.asl
   File impdef-only.asl, line 1, character 0 to line 4, character 4:
+  impdef func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Warning: Missing `implementation` for `impdef` function.
   $ aslref --no-exec --overriding-no-implementations impdef-only.asl
 
@@ -10,24 +14,44 @@ Single impdef overridden by single implementation
   $ aslref --no-exec --overriding-all-impdefs-overridden impdef-overridden.asl
   $ aslref --no-exec --overriding-no-implementations impdef-overridden.asl
   File impdef-overridden.asl, line 6, character 0 to line 9, character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Ones{N};
+  end;
   ASL Warning: Unexpected `implementation` function.
 
 Implementation without impdef
   $ aslref --no-exec --overriding-permissive implementation-only.asl
   File implementation-only.asl, line 1, character 0 to line 4, character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-all-impdefs-overridden implementation-only.asl
   File implementation-only.asl, line 1, character 0 to line 4, character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-no-implementations implementation-only.asl
   File implementation-only.asl, line 1, character 0 to line 4, character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Warning: Unexpected `implementation` function.
 
 Clashing implementations
   $ aslref --no-exec --overriding-permissive clashing-implementations.asl
   File clashing-implementations.asl, line 1, character 0 to line 4, character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: multiple overlapping `implementation` functions for Foo:
     File clashing-implementations.asl, line 1, character 0 to line 4,
       character 4
@@ -36,6 +60,10 @@ Clashing implementations
   [1]
   $ aslref --no-exec --overriding-all-impdefs-overridden clashing-implementations.asl
   File clashing-implementations.asl, line 1, character 0 to line 4, character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: multiple overlapping `implementation` functions for Foo:
     File clashing-implementations.asl, line 1, character 0 to line 4,
       character 4
@@ -44,6 +72,10 @@ Clashing implementations
   [1]
   $ aslref --no-exec --overriding-no-implementations clashing-implementations.asl
   File clashing-implementations.asl, line 1, character 0 to line 4, character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: multiple overlapping `implementation` functions for Foo:
     File clashing-implementations.asl, line 1, character 0 to line 4,
       character 4
@@ -54,6 +86,10 @@ Clashing implementations
 Clashing impdefs
   $ aslref --no-exec --overriding-permissive clashing-impdefs.asl
   File clashing-impdefs.asl, line 11, character 0 to line 14, character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: multiple `impdef` candidates for `implementation`:
     File clashing-impdefs.asl, line 1, character 0 to line 4, character 4
     File clashing-impdefs.asl, line 6, character 0 to line 9, character 4
@@ -61,25 +97,45 @@ Clashing impdefs
   $ aslref --no-exec --overriding-permissive clashing-impdefs-without-implementation.asl
   File clashing-impdefs-without-implementation.asl, line 6, character 0 to
     line 9, character 4:
+  impdef func Foo{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Zeros{N};
+  end;
   ASL Typing error: cannot declare already declared element "Foo".
   [1]
 
 Bad implementations
   $ aslref --no-exec --overriding-permissive bad-implementation-name.asl
   File bad-implementation-name.asl, line 6, character 0 to line 9, character 4:
+  implementation func Bar{N: integer{32,64}}(n : boolean) => bits(N)
+  begin
+    return Ones{N};
+  end;
   ASL Typing error: no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-permissive bad-implementation-param.asl
   File bad-implementation-param.asl, line 6, character 0 to line 9, character 4:
+  implementation func Foo{N: integer{64}}(n : boolean) => bits(N)
+  begin
+    return Ones{N};
+  end;
   ASL Typing error: no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-permissive bad-implementation-arg.asl
   File bad-implementation-arg.asl, line 6, character 0 to line 9, character 4:
+  implementation func Foo{N: integer{32,64}}(m : boolean) => bits(N)
+  begin
+    return Ones{N};
+  end;
   ASL Typing error: no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-permissive bad-implementation-return.asl
   File bad-implementation-return.asl, line 6, character 0 to line 9,
     character 4:
+  implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N+1)
+  begin
+    return Ones{N};
+  end;
   ASL Typing error: no `impdef` for `implementation` function.
   [1]
 

--- a/asllib/tests/pragma.t/run.t
+++ b/asllib/tests/pragma.t/run.t
@@ -1,30 +1,50 @@
 Simple pragma examples
   $ aslref pragma.asl
   File pragma.asl, line 3, characters 4 to 25:
+      pragma p1 "with arg";
+      ^^^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma p1 will be ignored.
   File pragma.asl, line 4, characters 4 to 14:
+      pragma p2;
+      ^^^^^^^^^^
   ASL Warning: pragma p2 will be ignored.
   File pragma.asl, line 5, characters 4 to 32:
+      pragma p3 "multi arg", TRUE;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma p3 will be ignored.
   File pragma.asl, line 11, characters 0 to 30:
+  pragma p3 TRUE, 2 + 2, test();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma p3 will be ignored.
   File pragma.asl, line 10, characters 0 to 15:
+  pragma p2 TRUE;
+  ^^^^^^^^^^^^^^^
   ASL Warning: pragma p2 will be ignored.
   File pragma.asl, line 9, characters 0 to 10:
+  pragma p1;
+  ^^^^^^^^^^
   ASL Warning: pragma p1 will be ignored.
 
   $ aslref pragma_invalid.asl
   File pragma_invalid.asl, line 1, characters 0 to 19:
+  pragma p1 2 + TRUE;
+  ^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma p1 will be ignored.
   File pragma_invalid.asl, line 1, characters 10 to 18:
+  pragma p1 2 + TRUE;
+            ^^^^^^^^
   ASL Typing error: Illegal application of operator + on types integer {2}
     and boolean.
   [1]
 
   $ aslref pragma_invalid_stmt.asl
   File pragma_invalid_stmt.asl, line 3, characters 4 to 27:
+      pragma fail "test" + 1;
+      ^^^^^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma fail will be ignored.
   File pragma_invalid_stmt.asl, line 3, characters 21 to 26:
+      pragma fail "test" + 1;
+                       ^^^^^
   ASL Typing error: Illegal application of operator + on types string
     and integer {1}.
   [1]

--- a/asllib/tests/print.t
+++ b/asllib/tests/print.t
@@ -21,6 +21,8 @@
 
   $ aslref printer2.asl
   File printer2.asl, line 2, characters 16 to 24:
+    print ("Wow", 2 + 3.14, "some other string");
+                  ^^^^^^^^
   ASL Typing error: Illegal application of operator + on types integer {2}
     and real.
   [1]
@@ -65,6 +67,8 @@
 
   $ aslref print4.asl
   File print4.asl, line 2, characters 11 to 17:
+    println ((1, 2));
+             ^^^^^^
   ASL Typing error: expected singular type, found (integer {1}, integer {2}).
   [1]
 

--- a/asllib/tests/recursive.t/run.t
+++ b/asllib/tests/recursive.t/run.t
@@ -3,6 +3,14 @@
   $ aslref simple-recursive-without-limit.asl
   File simple-recursive-without-limit.asl, line 1, character 0 to line 8,
     character 4:
+  func f (x: integer) => integer
+  begin
+    if x >= 0 then
+      return 1 + f (x - 1);
+    else
+      return 0;
+    end;
+  end;
   ASL Warning: the recursive function f has no recursive limit annotation.
 
   $ aslref double-recursive.asl
@@ -10,36 +18,52 @@
   $ aslref double-recursive-without-limit.asl
   File double-recursive-without-limit.asl, line 10, character 0 to line 13,
     character 4:
+  func g (x: integer) => integer
+  begin
+    return f (x);
+  end;
   ASL Warning: the mutually-recursive functions g, f have no recursive limit
   annotation.
 
   $ aslref recursive-constant.asl
   File recursive-constant.asl, line 1, characters 13 to 14:
+  constant x = x + 3;
+               ^
   ASL Error: Undefined identifier: 'x'
   [1]
 
   $ aslref double-recursive-constant.asl
   File double-recursive-constant.asl, line 2, characters 0 to 19:
+  constant y = x + 2;
+  ^^^^^^^^^^^^^^^^^^^
   ASL Typing error: multiple recursive declarations: "y", "x".
   [1]
 
   $ aslref recursive-type.asl
   File recursive-type.asl, line 1, characters 0 to 35:
+  type tree of (tree, integer, tree);
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Error: Undefined identifier: 'tree'
   [1]
 
   $ aslref double-recursive-types.asl
   File double-recursive-types.asl, line 2, characters 0 to 29:
+  type node of (integer, tree);
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: multiple recursive declarations: "node", "tree".
   [1]
 
   $ aslref fn-val-recursive.asl
   File fn-val-recursive.asl, line 1, characters 0 to 17:
+  var x = f (4, 5);
+  ^^^^^^^^^^^^^^^^^
   ASL Typing error: multiple recursive declarations: "f", "x".
   [1]
 
   $ aslref type-val-recursive.asl
   File type-val-recursive.asl, line 3, characters 0 to 24:
+  type MyT of integer {x};
+  ^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: multiple recursive declarations: "MyT", "x".
   [1]
 

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -7,27 +7,42 @@ Type-checking errors:
 
   $ aslref subtype-satisfaction-arrray-illegal.asl
   File subtype-satisfaction-arrray-illegal.asl, line 4, characters 0 to 38:
+  type o of array[[10]] of n subtypes m;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of m was expected, provided array [[10]] of n.
   [1]
 
   $ aslref anonymous-types-example.asl
   File anonymous-types-example.asl, line 21, characters 2 to 6:
+    pair = (1, dataT2);
+    ^^^^
   ASL Typing error: a subtype of pairT was expected,
     provided (integer {1}, T2).
   [1]
 
   $ aslref duplicate_function_args.asl
   File duplicate_function_args.asl, line 1, character 0 to line 4, character 4:
+  func foo(i: integer, i: integer)
+  begin
+    pass;
+  end;
   ASL Typing error: cannot declare already declared element "i".
   [1]
 
   $ aslref duplicate_record_fields.asl
   File duplicate_record_fields.asl, line 1, character 0 to line 5, character 2:
+  type MyRecord of record {
+    i: integer,
+    j: boolean,
+    i: integer
+  };
   ASL Typing error: cannot declare already declared element "i".
   [1]
 
   $ aslref duplicate_enumeration_items.asl
   File duplicate_enumeration_items.asl, line 1, characters 0 to 34:
+  type t of enumeration { i, j, i };
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: cannot declare already declared element "i".
   [1]
 
@@ -36,11 +51,17 @@ Type-checking errors:
 Bad types:
   $ aslref overlapping-slices.asl
   File overlapping-slices.asl, line 1, character 0 to line 4, character 2:
+  type t of bits(64) {
+    [23: 0] a,
+    [10: 0, 3+: 2] b,
+  };
   ASL Static error: overlapping slices 0+:11, 3+:2.
   [1]
 
   $ aslref bad-inclusion-in-symbolic-type.asl
   File bad-inclusion-in-symbolic-type.asl, line 2, characters 0 to 26:
+  var ah: integer{2..A} = 1;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {2..A} was expected,
     provided integer {1}.
   [1]
@@ -54,6 +75,8 @@ Global ignored:
 
   $ aslref global_ignored.asl
   File global_ignored.asl, line 1, characters 4 to 5:
+  var - = 3 / 0;
+      ^
   ASL Grammar error: Obsolete syntax: Discarded storage declaration.
   [1]
 
@@ -69,6 +92,8 @@ Constrained-type satisfaction:
 
   $ aslref type-sat1.asl
   File type-sat1.asl, line 5, characters 2 to 3:
+    x = y; // illegal as domain of x is not a subset of domain of y
+    ^
   ASL Typing error: a subtype of integer {8, 16} was expected,
     provided integer {8, 16, 32}.
   [1]
@@ -84,18 +109,24 @@ Constrained-type satisfaction:
 
   $ aslref type-sat2.asl
   File type-sat2.asl, line 5, characters 2 to 3:
+    x = y; // illegal
+    ^
   ASL Typing error: a subtype of integer {8, 16} was expected,
     provided integer.
   [1]
 
   $ aslref type_satisfaction_illegal_f3.asl
   File type_satisfaction_illegal_f3.asl, line 9, characters 4 to 17:
+      invoke_me(x); // illegal as domains doesn't match
+      ^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {8, 16} was expected,
     provided integer.
   [1]
 
   $ aslref type_satisfaction_illegal_f4.asl
   File type_satisfaction_illegal_f4.asl, line 9, characters 4 to 17:
+      invoke_me(x);
+      ^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {8, 16} was expected,
     provided integer {8..64}.
   [1]
@@ -111,6 +142,8 @@ Constrained-type satisfaction:
 
   $ aslref type-sat3.asl
   File type-sat3.asl, line 4, characters 2 to 29:
+    var x: integer { 2, 4} = N;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {2, 4} was expected,
     provided integer {N}.
   [1]
@@ -126,6 +159,8 @@ Constrained-type satisfaction:
 
   $ aslref type-sat4.asl
   File type-sat4.asl, line 4, characters 2 to 29:
+    var x: integer { 2, 4} = N;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {2, 4} was expected,
     provided integer {N}.
   [1]
@@ -141,6 +176,8 @@ Runtime checks:
 
   $ aslref runtime-type-sat1.asl
   File runtime-type-sat1.asl, line 3, characters 23 to 24:
+    let x: integer {1} = 2 as integer {1};
+                         ^
   ASL Execution error: Mismatch type:
     value 2 does not belong to type integer {1}.
   [1]
@@ -158,6 +195,8 @@ Runtime checks:
 
   $ aslref runtime-type-sat2.asl
   File runtime-type-sat2.asl, line 2, characters 10 to 18:
+    let x = Zeros{4} as bits(size);
+            ^^^^^^^^
   ASL Execution error: Mismatch type:
     value 0x0 does not belong to type bits(size).
   [1]
@@ -167,31 +206,43 @@ Runtime checks:
 Parameterized integers:
   $ aslref bad-underconstrained-call.asl
   File bad-underconstrained-call.asl, line 9, characters 9 to 26:
+    return GetBitAt{M}(x, M);
+           ^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..(M - 1)} was expected,
     provided integer {M}.
   [1]
   $ aslref bad-underconstrained-call-02.asl
   File bad-underconstrained-call-02.asl, line 8, characters 2 to 15:
+    foo{M}(x, 3);
+    ^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {M} was expected,
     provided integer {3}.
   [1]
   $ aslref bad-underconstrained-call-03.asl
   File bad-underconstrained-call-03.asl, line 8, characters 2 to 19:
+    foo{M}(x, M + 1);
+    ^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {M} was expected,
     provided integer {(M + 1)}.
   [1]
   $ aslref bad-underconstrained-ctc.asl
   File bad-underconstrained-ctc.asl, line 3, characters 12 to 13:
+    return x[(N as integer {N - 1})];
+              ^
   ASL Execution error: Mismatch type:
     value 4 does not belong to type integer {(N - 1)}.
   [1]
   $ aslref bad-underconstrained-return.asl
   File bad-underconstrained-return.asl, line 3, characters 2 to 15:
+    return N + 1;
+    ^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {(N + 1)}.
   [1]
   $ aslref bad-underconstrained-return-02.asl
   File bad-underconstrained-return-02.asl, line 3, characters 2 to 11:
+    return 5;
+    ^^^^^^^^^
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {5}.
   [1]
@@ -213,28 +264,38 @@ Parameterized integers:
 
   $ aslref unreachable.asl
   File unreachable.asl, line 3, characters 2 to 17:
+    Unreachable ();
+    ^^^^^^^^^^^^^^^
   ASL Dynamic error: Unreachable reached.
   [1]
 
   $ aslref assign-to-global-immutable.asl
   File assign-to-global-immutable.asl, line 5, characters 2 to 21:
+    my_immutable_global = 4;
+    ^^^^^^^^^^^^^^^^^^^
   ASL Typing error: cannot assign to immutable storage "my_immutable_global".
   [1]
 
   $ aslref equality.asl
   $ aslref bad-equality.asl
   File bad-equality.asl, line 3, characters 10 to 25:
+    println((1, 2) == (1,2));
+            ^^^^^^^^^^^^^^^
   ASL Typing error: Illegal application of operator == on types
     (integer {1}, integer {2}) and (integer {1}, integer {2}).
   [1]
 
   $ aslref setter_without_getter.asl
   File setter_without_getter.asl, line 6, characters 0 to 3:
+  end;
+  ^^^
   ASL Error: Cannot parse.
   [1]
 
   $ aslref getter_without_setter.asl
   File getter_without_setter.asl, line 6, characters 0 to 3:
+  end;
+  ^^^
   ASL Error: Cannot parse.
   [1]
 
@@ -242,25 +303,35 @@ Parameterized integers:
   $ aslref cases_where.asl
   $ aslref duplicated-otherwise.asl
   File duplicated-otherwise.asl, line 7, characters 8 to 12:
+          when 0.0 => println("2.0");
+          ^^^^
   ASL Error: Cannot parse.
   [1]
   $ aslref duplicate_expr_record.asl
   File duplicate_expr_record.asl, line 5, characters 12 to 27:
+      var x = A{h = 5, h = 9};
+              ^^^^^^^^^^^^^^^
   ASL Typing error: cannot declare already declared element "h".
   [1]
 
   $ aslref same-precedence.asl
   File same-precedence.asl, line 6, characters 10 to 15:
+    let x = a + b - c;
+            ^^^^^
   ASL Error: Cannot parse.
   [1]
 
   $ aslref same-precedence2.asl
   File same-precedence2.asl, line 6, characters 10 to 17:
+    let d = a --> b <-> c;
+            ^^^^^^^
   ASL Error: Cannot parse.
   [1]
 
   $ aslref rdiv_checks.asl
   File rdiv_checks.asl, line 3, characters 12 to 25:
+      var x = 5.3 / "hello";
+              ^^^^^^^^^^^^^
   ASL Typing error: Illegal application of operator / on types real and string.
   [1]
 
@@ -268,6 +339,8 @@ Parameterized integers:
 
   $ aslref integer-accessed-bitvector.asl
   File integer-accessed-bitvector.asl, line 4, characters 2 to 3:
+    x[0] = '1';
+    ^
   ASL Typing error: a subtype of bits(-) was expected, provided integer.
   [1]
 
@@ -285,32 +358,46 @@ Arrays indexed by enumerations
 Parameters bugs:
   $ aslref bug1.asl
   File bug1.asl, line 5, characters 21 to 29:
+    let foo: bits(x) = Zeros{y};
+                       ^^^^^^^^
   ASL Typing error: constrained integer expected, provided integer.
   [1]
   $ aslref bug2.asl
   File bug2.asl, line 5, characters 10 to 17:
+    let t = y[x: 0];
+            ^^^^^^^
   ASL Typing error: constrained integer expected, provided integer.
   [1]
   $ aslref bug3.asl
   File bug3.asl, line 4, characters 10 to 18:
+    let t = Zeros{x};
+            ^^^^^^^^
   ASL Typing error: constrained integer expected, provided integer.
   [1]
   $ aslref bug4.asl
   File bug4.asl, line 5, characters 11 to 31:
+    let pb = Zeros{a} OR Zeros{b};
+             ^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: Illegal application of operator OR on types bits(3)
     and bits(4).
   [1]
   $ aslref arg-as-param-call.asl
   File arg-as-param-call.asl, line 8, characters 4 to 21:
+      test{10}('1111');
+      ^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(10) was expected, provided bits(4).
   [1]
   $ aslref typed-param-call.asl
   File typed-param-call.asl, line 8, characters 4 to 18:
+      test{2}('11');
+      ^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {5..10} was expected,
     provided integer {2}.
   [1]
   $ aslref typed-arg-as-param-call.asl
   File typed-arg-as-param-call.asl, line 8, characters 4 to 18:
+      test{2}('11');
+      ^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {5..10} was expected,
     provided integer {2}.
   [1]
@@ -324,6 +411,8 @@ Required tests:
   $ aslref -0 assign-v0.asl
   $ aslref -0 asl0-patterns.asl
   File asl0-patterns.asl, line 7, characters 25 to 29:
+      if x[0+:4] IN '10x1' then // invalid
+                           ^^^^
   ASL Error: Cannot parse.
   [1]
   $ aslref assign1.asl
@@ -333,6 +422,8 @@ Required tests:
   $ aslref case.asl
   $ aslref concat-empty.asl
   File concat-empty.asl, line 3, characters 45 to 46:
+    let empty_concatenation_should_not_parse = [];
+                                               ^
   ASL Error: Cannot parse.
   [1]
   $ aslref concat01.asl
@@ -376,28 +467,38 @@ Required tests:
 
   $ aslref --no-type-check throw-local-env.asl
   File throw-local-env.asl, line 10, characters 13 to 14:
+        assert y == 5; // y should not be found in dynamic environment here
+               ^
   ASL Error: Undefined identifier: 'y'
   [1]
 
   $ aslref undeclared-variable.asl
   File undeclared-variable.asl, line 3, characters 2 to 5:
+    bar = (32 - 46) * 0;
+    ^^^
   ASL Error: Undefined identifier: 'bar'
   [1]
 
   $ aslref no-expression-elsif.asl
   File no-expression-elsif.asl, line 12, characters 25 to 50:
+    let y = if TRUE then 1 elsif FALSE then 2 else 3;   // ERROR
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Grammar error: Obsolete syntax: Expression-level 'elsif'.
   [1]
 
 Base values
   $ aslref base_values.asl
   File base_values.asl, line 5, characters 2 to 28:
+    var x: integer {N..M, 42};
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: base value of type integer {42, N..M} cannot be statically
     determined since it consists of N.
   [1]
 
   $ aslref base_values_empty.asl
   File base_values_empty.asl, line 3, characters 2 to 24:
+    var x: integer {N..M};
+    ^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: base value of type integer {N..M} cannot be statically
     determined since it consists of N.
   [1]
@@ -408,15 +509,21 @@ Base values
 Getters/setters
   $ aslref nonempty-getter-called-without-slices.asl
   File nonempty-getter-called-without-slices.asl, line 14, characters 10 to 12:
+    let x = f1;
+            ^^
   ASL Error: Undefined identifier: 'f1'
   [1]
   $ aslref nonempty-setter-called-without-slices.asl
   File nonempty-setter-called-without-slices.asl, line 14, characters 2 to 4:
+    f1 = 4;
+    ^^
   ASL Error: Undefined identifier: 'f1'
   [1]
   $ aslref setter_subfield.asl
   $ aslref setter_subslice.asl
   File setter_subslice.asl, line 16, characters 5 to 6:
+    F()[2+:1] = '1';
+       ^
   ASL Error: Cannot parse.
   [1]
   $ aslref getter_subfield.asl
@@ -426,10 +533,14 @@ Getters/setters
 
   $ aslref bad-pattern.asl
   File bad-pattern.asl, line 4, characters 7 to 12:
+    when '101' => println ("Cannot happen");
+         ^^^^^
   ASL Typing error: Erroneous pattern '101' for expression of type integer {3}.
   [1]
   $ aslref pattern-masks-no-braces.asl
   File pattern-masks-no-braces.asl, line 4, characters 19 to 24:
+    assert ('111' IN '1xx') == TRUE;
+                     ^^^^^
   ASL Error: Cannot parse.
   [1]
 
@@ -438,6 +549,8 @@ ASLRef Field getter extension
   $ aslref --use-field-getter-extension pstate-exp.asl
   $ aslref atc-in-types.asl
   File atc-in-types.asl, line 1, characters 14 to 29:
+  let bv : bits(1 as integer{2}) = Ones{1};
+                ^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found 1 as integer {2},
     which produces the following side-effects: [PerformsAssertions].
   [1]
@@ -447,12 +560,16 @@ Inherit integer constraints on left-hand sides
   $ aslref inherit-integer-constraints.asl
   $ aslref inherit-integer-constraints-bad-basic.asl
   File inherit-integer-constraints-bad-basic.asl, line 4, characters 2 to 11:
+    return x;
+    ^^^^^^^^^
   ASL Typing error: a subtype of integer {43} was expected,
     provided integer {42}.
   [1]
 
   $ aslref inherit-integer-constraints-bad-tuple.asl
   File inherit-integer-constraints-bad-tuple.asl, line 4, characters 2 to 28:
+    return (y.item0, y.item2);
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of (integer {42}, integer {0}) was expected,
     provided (integer {42}, integer {43}).
   [1]
@@ -460,6 +577,10 @@ Inherit integer constraints on left-hand sides
   $ aslref inherit-integer-constraints-bad-type.asl
   File inherit-integer-constraints-bad-type.asl, line 1, character 0 to line 4,
     character 2:
+  type badtype of record {
+      a : integer{-},
+      c : integer
+  };
   ASL Typing error: a pending constrained integer is illegal here.
   [1]
 
@@ -467,9 +588,13 @@ Left-hand sides
   $ aslref lhs-tuple-fields.asl
   $ aslref lhs-tuple-fields-same-field.asl
   File lhs-tuple-fields-same-field.asl, line 8, characters 2 to 4:
+    bv.(fld, -, fld) = ('11', TRUE, '11');
+    ^^
   ASL Typing error: multiple writes to "bv.fld".
   [1]
   $ aslref lhs-tuple-same-var.asl
   File lhs-tuple-same-var.asl, line 8, characters 2 to 20:
+    (bv[7], -, bv.fld) = ('1', TRUE, '11');
+    ^^^^^^^^^^^^^^^^^^
   ASL Typing error: multiple writes to "bv".
   [1]

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -2,11 +2,15 @@
   $ aslref binop-read-write.asl
   $ aslref --use-conflicting-side-effects-extension binop-read-write.asl
   File binop-read-write.asl, line 11, characters 10 to 31:
+    let y = set_and_return () + X;
+            ^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects WritesGlobal "X" and ReadsGlobal "X"
   [1]
   $ aslref binop-write-write.asl
   $ aslref --use-conflicting-side-effects-extension binop-write-write.asl
   File binop-write-write.asl, line 11, characters 10 to 47:
+    let y = set_and_return () + set_and_return ();
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects WritesGlobal "X" and WritesGlobal "X"
   [1]
   $ aslref binop-read-write-diff.asl
@@ -22,12 +26,16 @@
   E caught
   $ aslref --use-conflicting-side-effects-extension binop-throw-write.asl
   File binop-throw-write.asl, line 18, characters 12 to 43:
+      let y = throwing () + set_and_return ();
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects ThrowsException "E" and WritesGlobal "X"
   [1]
   $ aslref binop-throw-throw.asl
   E caught
   $ aslref --use-conflicting-side-effects-extension binop-throw-throw.asl
   File binop-throw-throw.asl, line 11, characters 12 to 37:
+      let y = throwing () + throwing ();
+              ^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects ThrowsException "E" and ThrowsException "E"
   [1]
   $ aslref binop-throw-caught.asl
@@ -36,6 +44,8 @@
   E caught
   $ aslref --use-conflicting-side-effects-extension binop-throw-not-caught.asl
   File binop-throw-not-caught.asl, line 21, characters 12 to 37:
+      let x = throws_E () + caught_F ();
+              ^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects ThrowsException "E" and ThrowsException "E"
   [1]
   $ aslref binop-throw-otherwised.asl
@@ -50,10 +60,14 @@
   E caught
   $ aslref --use-conflicting-side-effects-extension binop-throw-atc.asl
   File binop-throw-atc.asl, line 16, characters 12 to 41:
+      let y = throwing () + performs_atc ();
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects ThrowsException "E" and PerformsAssertions
   [1]
   $ aslref binop-write-atc.asl
   File binop-write-atc.asl, line 5, characters 10 to 11:
+    return (1 as integer {2});
+            ^
   ASL Execution error: Mismatch type:
     value 1 does not belong to type integer {2}.
   [1]
@@ -63,21 +77,29 @@
   $ aslref constant-func.asl
   $ aslref constant-func-read.asl
   File constant-func-read.asl, line 9, characters 0 to 21:
+  constant C = foo (4);
+  ^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo(4), which
     produces the following side-effects: [WritesGlobal "X"].
   [1]
   $ aslref constant-func-write.asl
   File constant-func-write.asl, line 9, characters 0 to 21:
+  constant C = foo (4);
+  ^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo(4), which
     produces the following side-effects: [WritesGlobal "X"].
   [1]
   $ aslref constant-func-unknown.asl
   File constant-func-unknown.asl, line 7, characters 0 to 21:
+  constant C = foo (4);
+  ^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo(4), which
     produces the following side-effects: [NonDeterministic].
   [1]
   $ aslref constant-func-throw.asl
   File constant-func-throw.asl, line 8, characters 0 to 21:
+  constant C = foo (4);
+  ^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo(4), which
     produces the following side-effects: [ThrowsException "E"].
   [1]
@@ -85,12 +107,16 @@
   $ aslref constant-func-local-var.asl
   $ aslref constant-func-local-type-global-let.asl
   File constant-func-local-type-global-let.asl, line 12, characters 0 to 21:
+  constant C = foo (8);
+  ^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo(8), which
     produces the following side-effects: [ReadsGlobal "K", PerformsAssertions].
   [1]
   $ aslref constant-func-local-type-local-let.asl
   $ aslref constant-func-sig-let.asl
   File constant-func-sig-let.asl, line 8, characters 0 to 20:
+  constant C = foo(3);
+  ^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo(3), which
     produces the following side-effects: [ReadsGlobal "K"].
   [1]
@@ -99,11 +125,17 @@
   $ aslref for-var-edits.asl
   $ aslref --use-conflicting-side-effects-extension for-var-edits.asl
   File for-var-edits.asl, line 6, character 2 to line 8, character 6:
+    for i = 0 to x do
+      x = y * y + x;
+    end;
   ASL Typing error: conflicting side effects ReadsLocal "x" and WritesLocal "x"
   [1]
   $ aslref for-read-write-global.asl
   $ aslref --use-conflicting-side-effects-extension for-read-write-global.asl
   File for-read-write-global.asl, line 14, character 2 to line 16, character 6:
+    for i = 0 to read_X () do
+      X = y * y + x ;
+    end;
   ASL Typing error: conflicting side effects ReadsGlobal "X" and WritesGlobal "X"
   [1]
   $ aslref while-var-edits.asl
@@ -112,42 +144,58 @@
   $ aslref for-read.asl
   $ aslref for-write.asl
   File for-write.asl, line 15, characters 15 to 25:
+    for i = 0 to write_X () do
+                 ^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found write_X(), which
     produces the following side-effects: [WritesGlobal "X", ReadsGlobal "X"].
   [1]
   $ aslref for-write-throw.asl
   File for-write-throw.asl, line 13, characters 15 to 26:
+    for i = 0 to throwing () do
+                 ^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found throwing(), which
     produces the following side-effects: [ThrowsException "E"].
   [1]
   $ aslref for-throw-throw.asl
   File for-throw-throw.asl, line 13, characters 15 to 26:
+    for i = 0 to throwing () do
+                 ^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found throwing(), which
     produces the following side-effects: [ThrowsException "E"].
   [1]
   $ aslref for-throw.asl
   File for-throw.asl, line 13, characters 15 to 26:
+    for i = 0 to throwing () do
+                 ^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found throwing(), which
     produces the following side-effects: [ThrowsException "E"].
   [1]
   $ aslref for-unknown.asl
   File for-unknown.asl, line 8, characters 15 to 25:
+    for i = 0 to unknown () do
+                 ^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found unknown(), which
     produces the following side-effects: [NonDeterministic].
   [1]
 
   $ aslref config-uses-var.asl
   File config-uses-var.asl, line 2, characters 0 to 26:
+  config Y: integer = X + 3;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got (X + 3) as integer,
     which produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-config.asl
   File config-uses-config.asl, line 2, characters 0 to 22:
+  config Y: integer = X;
+  ^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got X as integer, which
     produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-let.asl
   File config-uses-let.asl, line 2, characters 0 to 22:
+  config Y: integer = X;
+  ^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got X as integer, which
     produces the following side-effects: [ReadsGlobal "X"].
   [1]
@@ -157,27 +205,37 @@
   $ aslref config-uses-local-constant.asl
   $ aslref config-uses-var-through-func.asl
   File config-uses-var-through-func.asl, line 8, characters 0 to 27:
+  config Y: integer = foo ();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo() as integer,
     which produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-config-through-func.asl
   File config-uses-config-through-func.asl, line 8, characters 0 to 27:
+  config Y: integer = foo ();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo() as integer,
     which produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-let-through-func.asl
   File config-uses-let-through-func.asl, line 8, characters 0 to 27:
+  config Y: integer = foo ();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo() as integer,
     which produces the following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref config-uses-constant-through-func.asl
   $ aslref config-uses-atc.asl
   File config-uses-atc.asl, line 3, characters 9 to 10:
+    return 0 as integer {10};
+           ^
   ASL Execution error: Mismatch type:
     value 0 does not belong to type integer {10}.
   [1]
   $ aslref config-uses-unknown.asl
   File config-uses-unknown.asl, line 6, characters 0 to 27:
+  config Y: integer = foo ();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo() as integer,
     which produces the following side-effects: [NonDeterministic].
   [1]
@@ -185,17 +243,23 @@
   $ aslref assert-read.asl
   $ aslref assert-write.asl
   File assert-write.asl, line 12, characters 9 to 24:
+    assert write_X () == 0;
+           ^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found (write_X() == 0),
     which produces the following side-effects:
     [WritesGlobal "X", ReadsGlobal "X"].
   [1]
   $ aslref assert-throw.asl
   File assert-throw.asl, line 10, characters 9 to 25:
+    assert throwing () == 0;
+           ^^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found (throwing() == 0),
     which produces the following side-effects: [ThrowsException "E"].
   [1]
   $ aslref assert-atc.asl
   File assert-atc.asl, line 3, characters 9 to 10:
+    assert 0 as integer {3} == 2;
+           ^
   ASL Execution error: Mismatch type:
     value 0 does not belong to type integer {3}.
   [1]
@@ -205,55 +269,75 @@
   $ aslref type-read-let.asl
   $ aslref type-read-local.asl
   File type-read-local.asl, line 5, characters 18 to 19:
+    let y: integer {x} = x;
+                    ^
   ASL Typing error: a pure expression was expected, found x, which produces the
     following side-effects: [ReadsLocal "x"].
   [1]
   $ aslref type-read-local-let.asl
   $ aslref type-read.asl
   File type-read.asl, line 3, characters 19 to 20:
+  type T of integer {X};
+                     ^
   ASL Typing error: a pure expression was expected, found X, which produces the
     following side-effects: [ReadsGlobal "X"].
   [1]
   $ aslref type-write.asl
   File type-write.asl, line 10, characters 19 to 29:
+  type T of integer {write_X ()};
+                     ^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found write_X(), which
     produces the following side-effects: [ReadsGlobal "X", WritesGlobal "X"].
   [1]
   $ aslref type-unknown.asl
   File type-unknown.asl, line 8, characters 23 to 33:
+    let x = 0 as integer{unknown ()};
+                         ^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found unknown(), which
     produces the following side-effects: [NonDeterministic].
   [1]
   $ aslref type-func-atc.asl
   File type-func-atc.asl, line 3, characters 9 to 10:
+    assert 0 as integer {3} == 2;
+           ^
   ASL Execution error: Mismatch type:
     value 0 does not belong to type integer {3}.
   [1]
   $ aslref type-func-local-var.asl
   $ aslref type-local-var.asl
   File type-local-var.asl, line 5, characters 15 to 16:
+    var y: bits (x);
+                 ^
   ASL Typing error: a pure expression was expected, found x, which produces the
     following side-effects: [ReadsLocal "x"].
   [1]
   $ aslref type-throw.asl
   File type-throw.asl, line 8, characters 19 to 30:
+  type T of integer {throwing ()};
+                     ^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found throwing(), which
     produces the following side-effects: [ThrowsException "E"].
   [1]
 
   $ aslref assert-atc.asl
   File assert-atc.asl, line 3, characters 9 to 10:
+    assert 0 as integer {3} == 2;
+           ^
   ASL Execution error: Mismatch type:
     value 0 does not belong to type integer {3}.
   [1]
   $ aslref assert-read.asl
   $ aslref assert-throw.asl
   File assert-throw.asl, line 10, characters 9 to 25:
+    assert throwing () == 0;
+           ^^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found (throwing() == 0),
     which produces the following side-effects: [ThrowsException "E"].
   [1]
   $ aslref assert-write.asl
   File assert-write.asl, line 12, characters 9 to 24:
+    assert write_X () == 0;
+           ^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found (write_X() == 0),
     which produces the following side-effects:
     [WritesGlobal "X", ReadsGlobal "X"].
@@ -262,105 +346,185 @@
 
   $ aslref rec-assert-throw.asl
   File rec-assert-throw.asl, line 15, characters 9 to 37:
+    assert throwing (n - 1, FALSE) == 3;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected,
     found (throwing((n - 1), FALSE) == 3), which produces the following
     side-effects: [CallsRecursive "throwing", ReadsLocal "n"].
   [1]
   $ aslref rec-binop-atc-throw.asl
   File rec-binop-atc-throw.asl, line 3, character 0 to line 10, character 4:
+  func throwing (n: integer, b: boolean) => integer
+  begin
+    if b then
+      throw E {};
+    else
+      return foo (n);
+    end;
+  end;
   ASL Warning: the mutually-recursive functions throwing, foo have no recursive
   limit annotation.
   File rec-binop-atc-throw.asl, line 15, characters 37 to 38:
+    let x = throwing (n - 1, FALSE) * (2 as integer {3});
+                                       ^
   ASL Execution error: Mismatch type:
     value 2 does not belong to type integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-binop-atc-throw.asl
   File rec-binop-atc-throw.asl, line 15, characters 10 to 54:
+    let x = throwing (n - 1, FALSE) * (2 as integer {3});
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects CallsRecursive "throwing" and PerformsAssertions
   [1]
   $ aslref rec-binop-read-throw.asl
   File rec-binop-read-throw.asl, line 4, character 0 to line 11, character 4:
+  func throwing (n: integer, b: boolean) => integer
+  begin
+    if b then
+      throw E {};
+    else
+      return foo (n);
+    end;
+  end;
   ASL Warning: the mutually-recursive functions throwing, foo have no recursive
   limit annotation.
   $ aslref --use-conflicting-side-effects-extension rec-binop-read-throw.asl
   File rec-binop-read-throw.asl, line 22, characters 10 to 45:
+    let x = throwing (n - 1, FALSE) * read_X ();
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects CallsRecursive "throwing" and ReadsGlobal "X"
   [1]
   $ aslref rec-binop-unknown.asl
   $ aslref rec-binop-read.asl
   File rec-binop-read.asl, line 3, character 0 to line 6, character 4:
+  func not_throwing (n: integer) => integer
+  begin
+    return foo (n);
+  end;
   ASL Warning: the mutually-recursive functions not_throwing, foo have no
   recursive limit annotation.
   $ aslref --use-conflicting-side-effects-extension rec-binop-read.asl
   File rec-binop-read.asl, line 17, characters 10 to 42:
+    let x = not_throwing (n - 1) * read_X ();
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects CallsRecursive "not_throwing" and ReadsGlobal "X"
   [1]
   $ aslref rec-binop-read-local.asl
   $ aslref rec-binop-write.asl
   File rec-binop-write.asl, line 3, character 0 to line 6, character 4:
+  func not_throwing (n: integer) => integer
+  begin
+    return foo (n);
+  end;
   ASL Warning: the mutually-recursive functions not_throwing, foo have no
   recursive limit annotation.
   $ aslref --use-conflicting-side-effects-extension rec-binop-write.asl
   File rec-binop-write.asl, line 18, characters 10 to 43:
+    let x = not_throwing (n - 1) * write_X ();
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects CallsRecursive "not_throwing" and WritesGlobal "X"
   [1]
   $ aslref rec-assert.asl
   File rec-assert.asl, line 1, character 0 to line 4, character 4:
+  func not_throwing (n: integer) => integer
+  begin
+    return foo (n);
+  end;
   ASL Warning: the mutually-recursive functions not_throwing, foo have no
   recursive limit annotation.
   File rec-assert.asl, line 9, characters 34 to 35:
+    let x = not_throwing (n - 1) * (2 as integer {3});
+                                    ^
   ASL Execution error: Mismatch type:
     value 2 does not belong to type integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-assert.asl
   File rec-assert.asl, line 9, characters 10 to 51:
+    let x = not_throwing (n - 1) * (2 as integer {3});
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects CallsRecursive "not_throwing" and PerformsAssertions
   [1]
   $ aslref rec-binop-atc.asl
   File rec-binop-atc.asl, line 1, character 0 to line 4, character 4:
+  func not_throwing (n: integer) => integer
+  begin
+    return foo (n);
+  end;
   ASL Warning: the mutually-recursive functions not_throwing, foo have no
   recursive limit annotation.
   File rec-binop-atc.asl, line 9, characters 34 to 35:
+    let x = not_throwing (n - 1) * (2 as integer {3});
+                                    ^
   ASL Execution error: Mismatch type:
     value 2 does not belong to type integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-binop-atc.asl
   File rec-binop-atc.asl, line 9, characters 10 to 51:
+    let x = not_throwing (n - 1) * (2 as integer {3});
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects CallsRecursive "not_throwing" and PerformsAssertions
   [1]
   $ aslref rec-binop-read-write.asl
   File rec-binop-read-write.asl, line 3, character 0 to line 6, character 4:
+  func not_throwing (n: integer) => integer
+  begin
+    return foo (n);
+  end;
   ASL Warning: the mutually-recursive functions not_throwing, foo have no
   recursive limit annotation.
   $ aslref --use-conflicting-side-effects-extension rec-binop-read-write.asl
   File rec-binop-read-write.asl, line 17, characters 10 to 42:
+    let x = not_throwing (n - 1) * read_X ();
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects CallsRecursive "not_throwing" and ReadsGlobal "X"
   [1]
   $ aslref rec-binop-write-throw.asl
   File rec-binop-write-throw.asl, line 4, character 0 to line 11, character 4:
+  func throwing (n: integer, b: boolean) => integer
+  begin
+    if b then
+      throw E {};
+    else
+      return foo (n);
+    end;
+  end;
   ASL Warning: the mutually-recursive functions throwing, foo have no recursive
   limit annotation.
   $ aslref --use-conflicting-side-effects-extension rec-binop-write-throw.asl
   File rec-binop-write-throw.asl, line 23, characters 10 to 46:
+    let x = throwing (n - 1, FALSE) * write_X ();
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects CallsRecursive "throwing" and WritesGlobal "X"
   [1]
   $ aslref rec-constant.asl
   $ aslref constant-rec.asl
   File constant-rec.asl, line 12, characters 2 to 23:
+    constant r = foo (1);
+    ^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got foo(1), which
     produces the following side-effects: [CallsRecursive "foo"].
   [1]
   $ aslref rec-local-type.asl
   File rec-local-type.asl, line 12, characters 16 to 23:
+    let r = Zeros{foo (0)};
+                  ^^^^^^^
   ASL Typing error: a pure expression was expected, found foo(0), which
     produces the following side-effects: [CallsRecursive "foo"].
   [1]
   $ aslref rec-binop-rec.asl
   File rec-binop-rec.asl, line 6, character 0 to line 11, character 4:
+  func foo (n: integer) => integer
+  begin
+    if n <= 0 then return 1; end;
+    let x = bar (n - 1) * bar (n - 2);
+    return 2 * x;
+  end;
   ASL Warning: the mutually-recursive functions foo, bar have no recursive
   limit annotation.
   $ aslref --use-conflicting-side-effects-extension rec-binop-rec.asl
   File rec-binop-rec.asl, line 9, characters 10 to 35:
+    let x = bar (n - 1) * bar (n - 2);
+            ^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: conflicting side effects CallsRecursive "bar" and CallsRecursive "bar"
   [1]
 
@@ -378,12 +542,16 @@
   Y4 = 4
   $ aslref global-throw-initialisation.asl
   File global-throw-initialisation.asl, line 8, characters 0 to 29:
+  let X: integer = throwing ();
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Execution error: unexpected exception E thrown during the evaluation of
     the initialisation of the global storage element "X".
   [1]
 
   $ aslref config-type-uses-let.asl
   File config-type-uses-let.asl, line 2, characters 0 to 36:
+  config Y : integer {0 .. 2 * X} = 0;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: expected constant-time expression, got 0 as integer {0..2},
     which produces the following side-effects: [ReadsGlobal "X"].
   [1]

--- a/asllib/tests/stdlib.t/run.t
+++ b/asllib/tests/stdlib.t/run.t
@@ -10,6 +10,8 @@ Tests using ASLRef OCaml primitives for some stdlib functions
   $ aslref round.asl
   $ aslref set-bits.asl
   File set-bits.asl, line 29, characters 15 to 28:
+          assert k MOD 2^(m+1) == 2^m;
+                 ^^^^^^^^^^^^^
   Warning: Removing some values that would fail with op MOD from constraint set
   {0..(2 ^ (n + 1)), 1, (- ((- 2) ^ (n + 1)))..((- 2) ^ (n + 1))} gave
   {1, 1..(2 ^ (n + 1)), (- ((- 2) ^ (n + 1)))..((- 2) ^ (n + 1))}. Continuing
@@ -63,6 +65,8 @@ Tests using ASL stdlib only
   $ aslref --no-primitives round.asl
   $ aslref --no-primitives set-bits.asl
   File set-bits.asl, line 29, characters 15 to 28:
+          assert k MOD 2^(m+1) == 2^m;
+                 ^^^^^^^^^^^^^
   Warning: Removing some values that would fail with op MOD from constraint set
   {0..(2 ^ (n + 1)), 1, (- ((- 2) ^ (n + 1)))..((- 2) ^ (n + 1))} gave
   {1, 1..(2 ^ (n + 1)), (- ((- 2) ^ (n + 1)))..((- 2) ^ (n + 1))}. Continuing

--- a/asllib/tests/typing.t/run.t
+++ b/asllib/tests/typing.t/run.t
@@ -16,16 +16,22 @@ H Examples
   $ aslref --no-exec HExample15.asl
   $ aslref --no-exec HExample16.asl
   File HExample16.asl, line 10, characters 19 to 35:
+    let x: bits(a) = Reverse{}(bv, b);
+                     ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {1..a} was expected,
     provided integer {8, 16, 32, 64}.
   [1]
   $ aslref --no-exec HExample17.asl
   File HExample17.asl, line 11, characters 19 to 35:
+    let x: bits(a) = Reverse{}(bv, b);
+                     ^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {1..a} was expected,
     provided integer {32}.
   [1]
   $ aslref --no-exec HExample18.asl
   File HExample18.asl, line 12, characters 20 to 37:
+    let x: bits(a2) = Reverse{}(bv, a2);
+                      ^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {1..a2} was expected,
     provided integer {8, 16, 32, 64}.
   [1]
@@ -37,16 +43,22 @@ Assignments of constrained integers
   $ aslref --no-exec TPositive2.asl
   $ aslref --no-exec TNegative2-0.asl
   File TNegative2-0.asl, line 4, characters 4 to 41:
+      let testA : integer {0..2}    = size;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..2} was expected,
     provided integer {0..3}.
   [1]
   $ aslref --no-exec TNegative2-1.asl
   File TNegative2-1.asl, line 4, characters 4 to 42:
+      let testB : integer {8,16,32} = size2;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {8, 16, 32} was expected,
     provided integer {8, 16, 32, 64}.
   [1]
   $ aslref --no-exec TNegative2-2.asl
   File TNegative2-2.asl, line 4, characters 4 to 42:
+      let testC : integer {8,16,32} = myInt; // assignment of unconstrained integers to constrained integers is also illegal without a ATC
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {8, 16, 32} was expected,
     provided integer.
   [1]
@@ -61,39 +73,53 @@ Use of global vars in constraints
   $ aslref --no-exec TPositive4.asl
   $ aslref --no-exec TPositive4-1.asl
   File TPositive4-1.asl, line 5, characters 4 to 54:
+      let testB : integer {LET_ALLOWED_NUMS_B}     = 16;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {8} was expected,
     provided integer {16}.
   [1]
   $ aslref --no-exec TPositive4-2.asl
   File TPositive4-2.asl, line 8, characters 4 to 54:
+      let testC : integer {LET_ALLOWED_NUMS_C}     = 16;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {LET_ALLOWED_NUMS_C} was expected,
     provided integer {16}.
   [1]
   $ aslref --no-exec TPositive4-3.asl
   $ aslref --no-exec TPositive4-4.asl
   File TPositive4-4.asl, line 9, characters 4 to 54:
+      let testF : integer {CONFIG_ALLOWED_NUMS}    = 16;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {CONFIG_ALLOWED_NUMS} was expected,
     provided integer {16}.
   [1]
   $ aslref --no-exec TPositive4-5.asl
   $ aslref --no-exec TReconsider4-0.asl
   File TReconsider4-0.asl, line 13, characters 4 to 54:
+      let testA : integer {CONST_ALLOWED_NUMS}     = 16;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {8} was expected,
     provided integer {16}.
   [1]
   $ aslref --no-exec TReconsider4-1.asl
   File TReconsider4-1.asl, line 14, characters 4 to 54:
+      let testB : integer {0..CONST_ALLOWED_NUMS}  = 10;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..8} was expected,
     provided integer {10}.
   [1]
   $ aslref --no-exec TNegative4.asl
   File TNegative4.asl, line 5, characters 25 to 41:
+      let testA : integer {VAR_ALLOWED_NUMS} = 8; // illegal var's aren't allowed in constraints
+                           ^^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found VAR_ALLOWED_NUMS,
     which produces the following side-effects:
     [ReadsGlobal "VAR_ALLOWED_NUMS"].
   [1]
   $ aslref --no-exec TNegative4-bis.asl
   File TNegative4-bis.asl, line 5, characters 25 to 41:
+      let testA : integer {VAR_ALLOWED_NUMS} = 8; // illegal var's aren't allowed in constraints
+                           ^^^^^^^^^^^^^^^^
   ASL Typing error: a pure expression was expected, found VAR_ALLOWED_NUMS,
     which produces the following side-effects:
     [ReadsGlobal "VAR_ALLOWED_NUMS"].
@@ -103,11 +129,15 @@ Asserted type conversions
   $ aslref --no-exec TPositive5.asl
   $ aslref --no-exec TNegative5-0.asl
   File TNegative5-0.asl, line 5, characters 4 to 38:
+      let testA : integer {0..3} = temp; // illegal as value of type integer {8,16} can't be assigned to var of type integer {0..3}.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..3} was expected,
     provided integer {8, 16}.
   [1]
   $ aslref --no-exec TNegative5-1.asl
   File TNegative5-1.asl, line 4, characters 26 to 41:
+      let testB : integer = TRUE as integer;
+                            ^^^^^^^^^^^^^^^
   ASL Typing error: cannot perform Asserted Type Conversion on boolean by
     integer.
   [1]
@@ -120,6 +150,8 @@ Named types
   $ aslref --no-exec TPositive7.asl
   $ aslref --no-exec TNegative7.asl
   File TNegative7.asl, line 7, characters 4 to 36:
+      let testA : MyOtherSizes = size; // illegal as testA and size are different named types, even though they are the same structure and domain
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of MyOtherSizes was expected,
     provided MyBitsSizes.
   [1]
@@ -129,24 +161,34 @@ Loops
   $ aslref --no-exec TPositive8.asl
   $ aslref --no-exec TPositive8-1.asl
   File TPositive8-1.asl, line 5, characters 8 to 40:
+          let testK : integer {8..31} = i;
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {8..31} was expected,
     provided integer {100..110}.
   [1]
   $ aslref --no-exec TNegative8-0.asl
   File TNegative8-0.asl, line 5, characters 8 to 40:
+          let testA : integer {0..7}  = i; // N is an unconstrained integer, so i is also unconstrained
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..7} was expected, provided integer.
   [1]
   $ aslref --no-exec TNegative8-1.asl
   File TNegative8-1.asl, line 5, characters 8 to 40:
+          let testB : integer {0..7}  = i; // N is an unconstrained integer, so i is also unconstrained
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..7} was expected, provided integer.
   [1]
   $ aslref --no-exec TNegative8-2.asl
   File TNegative8-2.asl, line 5, characters 8 to 40:
+          let testC : integer {7..31} = i; // N is an unconstrained integer, so i is also unconstrained
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {7..31} was expected,
     provided integer.
   [1]
   $ aslref --no-exec TNegative8-3.asl
   File TNegative8-3.asl, line 5, characters 8 to 40:
+          let testD : integer {7..31} = i; // N is an unconstrained integer, so i is also unconstrained
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {7..31} was expected,
     provided integer.
   [1]
@@ -156,23 +198,33 @@ Bit vector widths defined by constrained integers
   $ aslref --no-exec TPositive9-1.asl
   $ aslref --no-exec TNegative9-0.asl
   File TNegative9-0.asl, line 3, characters 4 to 36:
+      let testA : bits(8) = Zeros{16};
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(8) was expected, provided bits(16).
   [1]
   $ aslref --no-exec TNegative9-1.asl
   File TNegative9-1.asl, line 3, characters 4 to 59:
+      let testB : bits(N) = Zeros{N DIV 4} :: Zeros{N DIV 2}; // bits(3N/4) != bits(N)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(N) was expected,
     provided bits(((3 * N) DIV 4)).
   [1]
   $ aslref --no-exec TNegative9-2.asl
   File TNegative9-2.asl, line 3, characters 4 to 35:
+      let testC : bits(M) = Zeros{N};
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(M) was expected, provided bits(N).
   [1]
   $ aslref --no-exec TNegative9-3.asl
   File TNegative9-3.asl, line 3, characters 26 to 34:
+      let testD : bits(X) = Zeros{X}; // X isn't a constrained integer, so can't be used as bit width
+                            ^^^^^^^^
   ASL Typing error: constrained integer expected, provided integer.
   [1]
   $ aslref --no-exec TNegative9-4.asl
   File TNegative9-4.asl, line 3, characters 4 to 35:
+      let testE : bits(N) = Zeros{8}; // N != 8, even though 8 is in the constraint set for N. N could be 16 after all.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(N) was expected, provided bits(8).
   [1]
 
@@ -182,16 +234,22 @@ Symbolic execution of bit vector widths expressions
   $ aslref --no-exec TPositive10-1.asl
   $ aslref --no-exec TNegative10.asl
   File TNegative10.asl, line 8, characters 32 to 38:
+      let testA : bits(N) = Zeros{widthN};
+                                  ^^^^^^
   ASL Typing error: a pure expression was expected, found widthN, which
     produces the following side-effects: [ReadsLocal "widthN"].
   [1]
   $ aslref --no-exec TNegative10-0.asl
   File TNegative10-0.asl, line 16, characters 4 to 53:
+      let testB : bits(letWidthN1) = Zeros{letWidthN2}; // illegal as type bits(letWidthN1) is different from bits(letWidthN2).
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(letWidthN1) was expected,
     provided bits(letWidthN2).
   [1]
   $ aslref --no-exec TNegative10-1.asl
   File TNegative10-1.asl, line 28, characters 4 to 49:
+      let testC : bits(tempC3A)   = Zeros{tempC3B}; // illegal, type bits(tempC1) != bits(tempC3B)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(tempC3A) was expected,
     provided bits(tempC3B).
   [1]
@@ -199,6 +257,8 @@ Symbolic execution of bit vector widths expressions
 Complex symbolic execution of bit vector widths expressions
   $ aslref --no-exec TPositive11.asl
   File TPositive11.asl, line 11, characters 4 to 64:
+      let testA : bits(numBits)            = ZerosBytes{numBytes};
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(numBits) was expected,
     provided bits((8 * numBytes)).
   [1]
@@ -209,6 +269,8 @@ ATC's on bit vectors
   $ aslref --no-exec TPositive12.asl
   $ aslref --no-exec TNegative12.asl
   File TNegative12.asl, line 3, characters 16 to 32:
+      let testA = N     as bits(8); // ATC's can't change structure.
+                  ^^^^^^^^^^^^^^^^
   ASL Typing error: cannot perform Asserted Type Conversion on integer {8, 16}
     by bits(8).
   [1]
@@ -216,37 +278,61 @@ ATC's on bit vectors
 Large constraint sets
   $ aslref TPositive13.asl
   File TPositive13.asl, line 8, characters 17 to 34:
+      let testA =  UInt(a) * UInt(b);
+                   ^^^^^^^^^^^^^^^^^
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
   File TPositive13.asl, line 8, characters 17 to 34:
+      let testA =  UInt(a) * UInt(b);
+                   ^^^^^^^^^^^^^^^^^
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
   File TPositive13.asl, line 8, characters 4 to 35:
+      let testA =  UInt(a) * UInt(b);
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref --no-exec TDegraded13.asl
   File TDegraded13.asl, line 7, characters 29 to 46:
+      let temp               = UInt(a) * UInt(b);
+                               ^^^^^^^^^^^^^^^^^
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
   File TDegraded13.asl, line 7, characters 29 to 46:
+      let temp               = UInt(a) * UInt(b);
+                               ^^^^^^^^^^^^^^^^^
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
   File TDegraded13.asl, line 7, characters 4 to 47:
+      let temp               = UInt(a) * UInt(b);
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref --no-exec TDegraded13-sets1.asl
   File TDegraded13-sets1.asl, line 3, characters 10 to 27:
+    var z = UInt(a) * UInt(b);
+            ^^^^^^^^^^^^^^^^^
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
   File TDegraded13-sets1.asl, line 3, characters 10 to 27:
+    var z = UInt(a) * UInt(b);
+            ^^^^^^^^^^^^^^^^^
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
   File TDegraded13-sets1.asl, line 3, characters 2 to 28:
+    var z = UInt(a) * UInt(b);
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref --no-exec TDegraded13-sets2.asl
   File TDegraded13-sets2.asl, line 3, characters 10 to 27:
+    var z = UInt(a) * UInt(b);
+            ^^^^^^^^^^^^^^^^^
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
   File TDegraded13-sets2.asl, line 3, characters 10 to 27:
+    var z = UInt(a) * UInt(b);
+            ^^^^^^^^^^^^^^^^^
   Interval too large: [ 0 .. 18446744073709551615 ]. Keeping it as an interval.
   File TDegraded13-sets2.asl, line 3, characters 2 to 28:
+    var z = UInt(a) * UInt(b);
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: type used to define storage item is the result of precision
     loss.
   [1]
@@ -255,10 +341,14 @@ Named types for bit vector widths
   $ aslref --no-exec TPositive14.asl
   $ aslref --no-exec TNegative14-0.asl
   File TNegative14-0.asl, line 6, characters 4 to 32:
+      let tempA : NamedTypeB = w1;        // illegal, not the same type
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of NamedTypeB was expected, provided NamedTypeA.
   [1]
   $ aslref --no-exec TNegative14-1.asl
   File TNegative14-1.asl, line 7, characters 4 to 39:
+      let testB : bits(w1)   = Zeros{w2}; // illegal, just because w1 and w2 are the same type doesn't mean they are the same value, so
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of bits(w1) was expected, provided bits(w2).
   [1]
 
@@ -267,18 +357,26 @@ Bit slice expressions
   $ aslref --no-exec TReconsider15.asl
   $ aslref --no-exec TNegative15-0.asl
   File TNegative15-0.asl, line 6, characters 20 to 37:
+      let testA     = 0xA55A1234[x+7:x];  // The RHS width express does not result in a constrained integer, so even though the width is
+                      ^^^^^^^^^^^^^^^^^
   ASL Typing error: constrained integer expected, provided integer.
   [1]
   $ aslref --no-exec TNegative15-1.asl
   File TNegative15-1.asl, line 6, characters 20 to 38:
+      let testB     = 0xA55A1234[0 +: x]; // illegal, bit width isn't a constrained integer
+                      ^^^^^^^^^^^^^^^^^^
   ASL Typing error: constrained integer expected, provided integer.
   [1]
   $ aslref --no-exec TNegative15-2.asl
   File TNegative15-2.asl, line 6, characters 20 to 38:
+      let testC     = 0xA55A1234[0 *: x]; // illegal, bit width isn't a constrained integer
+                      ^^^^^^^^^^^^^^^^^^
   ASL Typing error: constrained integer expected, provided integer.
   [1]
   $ aslref --no-exec TNegative15-3.asl
   File TNegative15-3.asl, line 7, characters 20 to 28:
+      testD[0 *: x] = Zeros{x}; // Same rules apply to bit slices on LHS
+                      ^^^^^^^^
   ASL Typing error: constrained integer expected, provided integer.
   [1]
 
@@ -286,11 +384,15 @@ C Tests
   $ aslref --no-exec CPositive1.asl
   $ aslref --no-exec CPositive1-1.asl
   File CPositive1-1.asl, line 5, characters 4 to 30:
+      let z: integer {0..N} = y;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..N} was expected, provided integer.
   [1]
   $ aslref --no-exec CPositive2.asl
   $ aslref --no-exec CPositive3.asl
   File CPositive3.asl, line 5, characters 4 to 31:
+      var a : integer {0..N} = b;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {0}.
   [1]
@@ -299,6 +401,8 @@ C Tests
   $ aslref --no-exec CPositive6.asl
   $ aslref --no-exec CPositive7.asl
   File CPositive7.asl, line 4, characters 4 to 31:
+      var a: integer{0..2*N} = x;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..(2 * N)} was expected,
     provided integer {0..N}.
   [1]
@@ -309,63 +413,95 @@ C Tests
   $ aslref --no-exec CPositive12.asl
   $ aslref --no-exec CNegative1.asl
   File CNegative1.asl, line 5, characters 4 to 31:
+      var a : integer {0..N} = b; // illegal
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {-1}.
   [1]
   $ aslref --no-exec CNegative2.asl
   File CNegative2.asl, line 4, characters 2 to 11:
+    return 3; // illegal
+    ^^^^^^^^^
   ASL Typing error: a subtype of integer {N} was expected,
     provided integer {3}.
   [1]
   $ aslref --no-exec CNegative3.asl
   File CNegative3.asl, line 8, character 4 to line 13, character 8:
+      while x*x + y*y <= 2.0*2.0 do
+          let xtemp = (x*x - y*y) + x0;
+          y = 2.0*x*y + y0;
+          x = xtemp;
+          z = z + 1; // should be illegal without ATC
+      end;
   ASL Warning: Loop does not have a limit.
   File CNegative3.asl, line 12, characters 8 to 9:
+          z = z + 1; // should be illegal without ATC
+          ^
   ASL Typing error: a subtype of integer {N} was expected,
     provided integer {(N + 1)}.
   [1]
   $ aslref --no-exec CNegative4.asl
   File CNegative4.asl, line 5, character 4 to line 8, character 6:
+      return (
+          Ones{5} ::
+          x
+      );
   ASL Typing error: a subtype of bits(64) was expected, provided bits((N + 5)).
   [1]
   $ aslref --no-exec CNegative5.asl
   File CNegative5.asl, line 13, characters 2 to 33:
+    printLengths{12}(3, Zeros{12}); // illegal
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {12} was expected,
     provided integer {3}.
   [1]
   $ aslref --no-exec CNegative6.asl
   File CNegative6.asl, line 4, characters 2 to 15:
+    return N + 1; // illegal
+    ^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {(N + 1)}.
   [1]
   $ aslref --no-exec CNegative7.asl
   File CNegative7.asl, line 8, characters 9 to 26:
+    return GetBitAt{M}(x, M); // illegal
+           ^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..(M - 1)} was expected,
     provided integer {M}.
   [1]
   $ aslref --no-exec CNegative8.asl
   File CNegative8.asl, line 7, characters 4 to 5:
+      a = b; // illegal, would require ATC
+      ^
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {0..M}.
   [1]
   $ aslref --no-exec CNegative10.asl
   File CNegative10.asl, line 7, characters 8 to 9:
+          a = b; // illegal; only the static type is considered for type-checking
+          ^
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {0..M}.
   [1]
   $ aslref --no-exec CNegative11.asl
   File CNegative11.asl, line 5, characters 4 to 5:
+      z = M; // illegal
+      ^
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {M}.
   [1]
   $ aslref --no-exec CNegative12.asl
   File CNegative12.asl, line 2, characters 56 to 57:
+  func negative12{N}(bv : bits(N), N: integer, bv2 : bits({0..N}))
+                                                          ^
   ASL Error: Cannot parse.
   [1]
 
 Extra tests by ASLRef team
   $ aslref NegParam.asl
   File NegParam.asl, line 3, characters 2 to 28:
+    let x: integer {0..N} = 0;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Typing error: a subtype of integer {0..N} was expected,
     provided integer {0}.
   [1]


### PR DESCRIPTION
This PR implements a quote system for error displays, with the relevant lines displayed. For example:
```
  $ aslref AssertionStatement.asl
  File AssertionStatement.asl, line 5, characters 11 to 22:
      assert a + b < 256;
             ^^^^^^^^^^^
  ASL Execution error: Assertion failed: ((a + b) < 256).
  [1]
```