### PR TITLE
[asl] new subsumption test

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1390,7 +1390,6 @@
 \newcommand\compareidentifier[0]{\hyperlink{def-compareidentifier}{\textfunc{compare\_identifier}}}
 
 \newcommand\domainsubset[0]{\hyperlink{def-domainsubset}{\textfunc{domain\_subset}}}
-\newcommand\symdomainsubset[0]{\hyperlink{def-symdomainsubset}{\textfunc{sym\_domain\_subset}}}
 
 \newcommand\toir[0]{\hyperlink{def-toir}{\textfunc{to\_ir}}}
 \newcommand\ProseOrTypeErrorOrCannotBeTransformed[0]{\ProseTerminateAs{\CannotBeTransformed,\TypeErrorConfig}}
@@ -1912,23 +1911,22 @@
 \newcommand\inttobits[0]{\hyperlink{def-inttobits}{\textfunc{int\_to\_bits}}}
 
 % Symbolic domain subsumption
-\newcommand\symdom[0]{\hyperlink{def-symdom}{\textsf{sym\_dom}}}
-\newcommand\syntax[0]{\hyperlink{def-syntax}{\textsf{syntax}}}
+\newcommand\symdom[0]{\hyperlink{def-symdom}{\textsf{symdom}}}
+\newcommand\symdomortop[0]{\hyperlink{def-symdomortop}{\textsf{symdom\_or\_top}}}
 
 \newcommand\Finite[0]{\hyperlink{def-finite}{\textsf{Finite}}}
 \newcommand\Top[0]{\hyperlink{def-top}{\textsf{Top}}}
-\newcommand\FromSyntax[0]{\hyperlink{def-fromsymtax}{\textsf{FromSyntax}}}
+\newcommand\ConstrainedDom[0]{\hyperlink{def-constraineddom}{\textsf{ConstrainedDom}}}
+\newcommand\Subdomains[0]{\hyperlink{def-subdomains}{\textsf{Subdomains}}}
 
 \newcommand\symdomoftype[0]{\hyperlink{def-symdomoftype}{\textfunc{symdom\_of\_type}}}
-\newcommand\symdomofexpr[0]{\hyperlink{def-symdomofexpr}{\textfunc{symdom\_of\_expr}}}
-\newcommand\symdomofwidth[0]{\hyperlink{def-symdomofwidth}{\textfunc{symdom\_of\_width}}}
-\newcommand\symdomofliteral[0]{\hyperlink{def-symdomofliteral}{\textfunc{symdom\_of\_literal}}}
-\newcommand\intsetofintconstraints[0]{\hyperlink{def-intsetofintconstraintse}{\textfunc{intset\_of\_intconstraints}}}
-\newcommand\symdomissubset[0]{\hyperlink{def-symdomissubset}{\textfunc{symdom\_is\_subset}}}
-\newcommand\constrainttointset[0]{\hyperlink{def-constrainttointset}{\textfunc{constraint\_to\_intset}}}
-\newcommand\normalizetoint[0]{\hyperlink{def-normalizetoint}{\textfunc{normalize\_to\_int}}}
-\newcommand\intsetop[0]{\hyperlink{def-intsetop}{\textfunc{intset\_op}}}
-\newcommand\intsettointconstraints[0]{\hyperlink{def-intsettointconstraints}{\textfunc{int\_set\_to\_int\_constraints}}}
+\newcommand\symdomofwidthexpr[0]{\hyperlink{def-symdomofwidthexpr}{\textfunc{symdom\_of\_width\_expr}}}
+\newcommand\symdomofconstraint[0]{\hyperlink{def-symdomofconstraint}{\textfunc{symdom\_of\_constraint}}}
+\newcommand\symdomsubsettest[0]{\hyperlink{def-symdomsubsettest}{\textfunc{symdom\_subset\_test}}}
+\newcommand\symdomsubset[0]{\hyperlink{def-symdomsubset}{\textfunc{symdom\_subset}}}
+\newcommand\symdomsubsetunions[0]{\hyperlink{def-symdomsubsetunions}{\textfunc{symdom\_subset\_unions}}}
+\newcommand\symdomnormalize[0]{\hyperlink{def-symdomnormalize}{\textfunc{symdom\_normalize}}}
+\newcommand\symdomeval[0]{\hyperlink{def-symdomeval}{\textfunc{symdom\_eval}}}
 \newcommand\Under[0]{\hyperlink{def-Under}{\textsf{Under}}}
 \newcommand\Over[0]{\hyperlink{def-Over}{\textsf{Over}}}
 \newcommand\approxconstraints[0]{\hyperlink{def-approxconstraints}{\textfunc{approx\_constraints}}}
@@ -1949,6 +1947,7 @@
 \newcommand\Proseapproxexpr[4]{\hyperlink{def-approxexpr}
   {approximating} the set integers represented by the expression #3 in the static environment #1
   with the symbol #2 yields the set of integers #4}
+\newcommand\intsettoconstraints[0]{\hyperlink{def-intsettoconstraints}{intset\_to\_constraints}}
 \newcommand\approxexprmin[0]{\hyperlink{def-approxexprmin}{\textfunc{approx\_expr\_min}}}
 \newcommand\Proseapproxexprmin[3]{\hyperlink{def-approxexprmin}
   {approximating} the minimal integer in the set of integers represented by the expression #2
@@ -2522,7 +2521,6 @@
 \newcommand\vdiscarded[0]{\texttt{discarded}}
 \newcommand\vdiscardedp[0]{\texttt{discarded'}}
 \newcommand\vdone[0]{\texttt{d1}}
-\newcommand\vdtwo[0]{\texttt{d2}}
 \newcommand\ve[0]{\texttt{e}}
 \newcommand\vediscriminant[0]{\texttt{e\_discriminant}}
 \newcommand\veminusone[0]{\texttt{e\_minus\_1}}
@@ -3038,5 +3036,17 @@
 \newcommand\isstatic[0]{\texttt{is\_static}}
 \newcommand\vLone[0]{\texttt{L1}}
 \newcommand\vLtwo[0]{\texttt{L2}}
+\newcommand\symdomsone[0]{\texttt{symdoms1}}
+\newcommand\symdomstwo[0]{\texttt{symdoms1}}
+\newcommand\symdomsonenorm[0]{\texttt{symdoms1\_norm}}
+\newcommand\symdomstwonorm[0]{\texttt{symdoms2\_norm}}
+\newcommand\symdoms[0]{\texttt{symdoms}}
+\newcommand\newsymdoms[0]{\texttt{new\_symdoms}}
+\newcommand\vfinitedomains[0]{\texttt{finite\_domains}}
+\newcommand\cdone[0]{\texttt{cd1}}
+\newcommand\cdtwo[0]{\texttt{cd2}}
+\newcommand\sdone[0]{\texttt{sd1}}
+\newcommand\sdtwo[0]{\texttt{sd2}}
 \newcommand\plf[0]{\texttt{plf}}
 \newcommand\vsapprox[0]{\texttt{s\_approx}}
+\newcommand\intervals[0]{\texttt{intervals}}

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -176,7 +176,9 @@ subtyping.
   \begin{itemize}
   \item the \underlyingtype\ of $\vt$, $\vttwo$, is an \integertypeterm{} (any kind);
   \item the \underlyingtype\ of $\vs$, $\vstwo$, is an \integertypeterm{} (any kind);
-  \item determining whether $\vs$ subsumes $\vt$ in $\tenv$ via symbolic reasoning results in $\vb$.
+  \item applying $\symdomoftype$ to $\tenv$ and $\vs$ yields the \symbolicdomain{} $\ds$;
+  \item applying $\symdomoftype$ to $\tenv$ and $\vt$ yields the \symbolicdomain{} $\dt$;
+  \item applying $\symdomsubsetunions$ to $\tenv$, $\ds$, and $\dt$ yields $\vb$.
   \end{itemize}
 
 \item \AllApplyCase{t\_enum}
@@ -284,7 +286,9 @@ subtyping.
   \makeanonymous(\tenv, \vt) \typearrow \vttwo\\
   \makeanonymous(\tenv, \vs) \typearrow \vstwo\\
   \astlabel(\vttwo) = \astlabel(\vstwo) = \TInt\\
-  \symdomainsubset(\tenv, \vs, \vt) \typearrow \vb
+  \symdomoftype(\tenv, \vs) \typearrow \ds \\
+  \symdomoftype(\tenv, \vt) \typearrow \dt \\
+  \symdomsubsetunions(\tenv, \ds, \dt) \typearrow \vb
 }{
   \subtypesat(\tenv, \vt, \vs) \typearrow \vb
 }
@@ -305,9 +309,9 @@ subtyping.
   \makeanonymous(\tenv, \vs) \typearrow \TBits(\ws, \bfss)\\
   \makeanonymous(\tenv, \vt) \typearrow \TBits(\wt, \bfst)\\
   \bitfieldsincluded(\tenv, \bfss, \bfst) \typearrow \True \OrTypeError \\
-  \symdomofwidth(\tenv, \ws) \typearrow \ds \\
-  \symdomofwidth(\tenv, \wt) \typearrow \dt \\
-  \symdomissubset(\tenv, \ds, \dt) \typearrow \vb
+  \symdomofwidthexpr(\tenv, \ws) \typearrow \ds \\
+  \symdomofwidthexpr(\tenv, \wt) \typearrow \dt \\
+  \symdomsubsetunions(\tenv, \ds, \dt) \typearrow \vb
 }{
   \subtypesat(\tenv, \vt, \vs) \typearrow \vb
 }

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -193,7 +193,6 @@ We employ the following rules:
   \item \TypingRuleRef{BitwidthEqual}
   \item \TypingRuleRef{BitFieldsEqual}
   \item \TypingRuleRef{BitFieldEqual}
-  \item \TypingRuleRef{ConstraintsEqual}
   \item \TypingRuleRef{ConstraintEqual}
   \item \TypingRuleRef{SlicesEqual}
   \item \TypingRuleRef{SliceEqual}

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -1,87 +1,259 @@
 \chapter{Symbolic Domain Subset Testing\label{chap:SymbolicDomainSubsetTesting}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-This chapter is concerned with implementing a \hyperlink{def-sounddomainsubsettest}{sound domain subset test}
-for integer types, as defined in \secref{domainsubsettesting} and employed by
-\TypingRuleRef{SubtypeSatisfaction}.
 
+Whether an assignment statement is well-typed depends on whether the dynamic domain of the
+right hand side type is contained in the dynamic domain of the left hand side type,
+for any given dynamic environment.
+
+\begin{definition}[Domain Subset]
+For any given types $\vt$ and $\vs$ and static environment $\tenv$,
+we say that $\vt$ is a \emph{domain subset} of $\vs$ in $\tenv$,
+if the following condition holds:
+\hypertarget{def-domainsubset}{}
+\begin{equation}
+\begin{array}{l}
+\domainsubset(\tenv, \vt, \vs) \triangleq \\
+\qquad \forall \denv\in\dynamicenvs.\
+\dynamicdomain((\tenv, \denv), \vt) \subseteq \dynamicdomain((\tenv, \denv), \vs) \enspace.
+\end{array}
+\end{equation}
+\end{definition}
+
+For example, consider the assignment
+\begin{center}
+\texttt{var x : $\overname{\texttt{integer\{1,2,3\}}}{\vs}$ = ARBITRARY : $\overname{\texttt{integer\{1,2\}}}{\vt}$;}
+\end{center}
+
+It is well-typed, since the dynamic domain of \verb|integer{1,2,3}| is\\
+$\{\nvint(1), \nvint(2), \nvint(3)\}$ in every dynamic environment, which is a superset of
+the dynamic domain of \verb|integer{1,2}|, which is $\{\nvint(1), \nvint(2)\}$ in every dynamic environment.
+
+Since dynamic domains are potentially infinite, this requires \emph{symbolic reasoning}.
+Furthermore, since any (\symbolicallyevaluable{}) expressions may appear inside integer and bitvector
+types, domain subset testing is undecidable.
+We therefore approximate domain subset testing \emph{conservatively} via the predicate $\symdomsubsettest(\tenv, \vt, \vs)$.
+
+\hypertarget{def-symdomsubsettest}{}
+\begin{definition}[Sound Domain Subset Test]
+A predicate
+\[
+  \symdomsubsettest(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs}) \aslto \Bool
+\]
+is \emph{sound} if the following condition holds:
+\begin{equation}
+  \begin{array}{l}
+  \forall \vt,\vs\in\ty.\ \tenv\in\staticenvs. \\
+  \;\;\;\; \symdomsubsettest(\tenv, \vt, \vs) \typearrow \True \;\Longrightarrow\; \domainsubset(\tenv, \vt, \vs)  \enspace.
+  \end{array}
+\end{equation}
+\end{definition}
+
+That is, if a sound domain subset test returns a positive answer, it means that
+$\vt$ is definitely a domain subset of $\vs$ in the static environment $\tenv$.
+This is referred to as a \emph{true positive}.
+However, a negative answer means one of two things:
+\begin{description}
+  \item[True Negative:] indeed, $\vt$ is not a domain subset of $\vs$ in the static environment $\tenv$; or
+  \item[False Negative:] the symbolic reasoning is unable to decide.
+\end{description}
+
+In other words, $\symdomsubsettest(\tenv, \vt, \vs)$ errs on the \emph{safe side} ---
+it never answers $\True$ when the real answer is $\False$, which would (undesirably)
+determine the following statement as well-typed:
+\begin{center}
+\texttt{var x : $\overname{\texttt{integer\{1,2\}}}{\vs}$ = ARBITRARY : $\overname{\texttt{integer}}{\vt}$;}
+\end{center}
+
+A sound but trivial domain subset test is one that always returns $\False$.
+However, that would make all assignments be considered as not well-typed.
+Indeed, it has the maximal set of false negatives.
+Reducing the set of false negatives requires stronger symbolic reasoning algorithms,
+which inevitably leads to higher computational complexity.
+%
+The symbolic domain subset test in \chapref{SymbolicDomainSubsetTesting}
+attempts to accept a large enough set of true positives, based on empirical trial and error,
+while maintaining the computational complexity of the symbolic reasoning relatively low.
+%
+In particular, it serves as the definitive domain subset test that must be utilized
+by any implementation of the ASL type system.
+
+This chapter is concerned with implementing a \hyperlink{def-symdomsubsettest}{sound domain subset test}
+for \integertypesterm{} and \bitvectortypesterm, as defined above and as employed by \\
+\TypingRuleRef{SubtypeSatisfaction}.
+This is technically achieved by first transforming types (in the case of \integertypesterm{})
+and width expressions (in the case of \bitvectortypesterm{}) into symbolic representations
+that we refer to as \emph{symbolic domains} and then checking subsumption over the symbolic domains.
+
+\section{Symbolic Domains}
 \hypertarget{def-symbolicdomain}{}
-The symbolic reasoning operates by first transforming types into expressions in a \emph{symbolic domain} AST
-(defined next, reusing $\intconstraint$ from the untyped AST) over which it then operates:
+
+We define the \emph{symbolic domain} datatype, reusing $\intconstraint$ from the untyped AST,
+as follows:
 \hypertarget{def-symdom}{}
 \hypertarget{def-finite}{}
 \[
   \begin{array}{rcl}
-    \symdom &::=& \Finite(\powfin{\Z} \setminus \emptyset) \hypertarget{def-top}{}\\
-            &|  & \Top                      \hypertarget{def-fromsymtax}{}\\
-            &|  & \FromSyntax(\syntax)      \hypertarget{def-syntax}{}\\
-    \syntax &::=& \intconstraint^*
+  \symdom       &\derives & \Finite(\powfin{\Z} \setminus \emptyset) \hypertarget{def-constraineddom}{}\\
+                &|        & \ConstrainedDom(\intconstraint) \hypertarget{def-symdomortop}{} \hypertarget{def-top}{}\\
+  \symdomortop  &\derives & \Top \hypertarget{def-subdomains}{}\\
+                &|        & \Subdomains(\symdom^+)
   \end{array}
 \]
 
 \begin{itemize}
   \item We refer to an element of the form $\Finite(S)$ as a \emph{symbolic finite set integer domain},
-        which represents the set of integers $S$;
-  \item We refer to an element of the form $\FromSyntax(\vcs)$ as a \emph{symbolic constrained integer domain},
-        which represents the set of integers given by the list of constraints $\vcs$; and
+        which represents the non-empty set of integers $S$;
+  \item We refer to an element of the form $\ConstrainedDom(\vc)$ as a \emph{symbolic constrained integer domain},
+        which represents the set of integers given by the constraint $\vcs$; and
   \item We refer to an element of the form $\Top$ as a \emph{symbolic unconstrained integer domain},
         which represents the set of all integers.
 \end{itemize}
 
-The main rule is of this chapter is \TypingRuleRef{SymSubset}, which defines the function
-$\symdomainsubset$.
+\section{Symbolic Reasoning}
+
+The main rule is of this chapter is \TypingRuleRef{SymdomSubsetUnions}, which defines the function
+$\symdomsubsetunions$.
 
 Other helper rules are as follows:
 \begin{itemize}
-  \item \TypingRuleRef{SymDomOfType}
-  \item \TypingRuleRef{SymDomOfExpr}
-  \item \TypingRuleRef{SymDomOfWidth}
-  \item \TypingRuleRef{IntSetOp}
-  \item \TypingRuleRef{IntSetToIntConstraints}
-  \item \TypingRuleRef{SymDomOfLiteral}
-  \item \TypingRuleRef{SymIntSetOfConstraints}
-  \item \TypingRuleRef{ConstraintToIntSet}
-  \item \TypingRuleRef{NormalizeToInt}
-  \item \TypingRuleRef{SymDomIsSubset}
+  \item \TypingRuleRef{SymdomNormalize}
+  \item \TypingRuleRef{SymdomOfType}
+  \item \TypingRuleRef{SymdomOfWidthExpr}
+  \item \TypingRuleRef{SymdomOfConstraint}
+  \item \TypingRuleRef{SymdomEval}
+  \item \TypingRuleRef{SymdomSubset}
+  \item \TypingRuleRef{ApproxConstraints}
+  \item \TypingRuleRef{ApproxConstraint}
+  \item \TypingRuleRef{ApproxExprMin}
+  \item \TypingRuleRef{ApproxExprMax}
+  \item \TypingRuleRef{ApproxBottomTop}
+  \item \TypingRuleRef{IntsetToConstraints}
+  \item \TypingRuleRef{ApproxExpr}
+  \item \TypingRuleRef{ApproxType}
   \item \TypingRuleRef{ConstraintBinop}
+  \item \TypingRuleRef{ApplyBinopExtremities}
+  \item \TypingRuleRef{PossibleExtremitiesLeft}
+  \item \TypingRuleRef{PossibleExtremitiesRight}
+  \item \TypingRuleRef{ConstraintPow}
+  \item \TypingRuleRef{ConstraintMod}
 \end{itemize}
 
-\TypingRuleDef{SymSubset}
-\hypertarget{def-symdomainsubset}{}
-The predicate
+\TypingRuleDef{SymdomSubsetUnions}
+\hypertarget{def-symdomsubsetunions}{}
+The function
 \[
-  \symdomainsubset(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs})
-  \aslto \overname{\Bool}{\vb}
+\symdomsubsetunions(
+  \overname{\staticenvs}{\tenv},
+  \overname{\symdomortop}{\sdone},
+  \overname{\symdomortop}{\sdtwo}) \aslto \overname{\Bool}{\vb}
 \]
-soundly approximates $\domainsubset(\tenv, \vt, \vs)$ for integer types.
-\ProseOtherwiseTypeError
+conservatively tests whether the set of integers represented by $\sdone$
+is a subset of the set of integers represented by $\sdtwo$,
+in the context of the static environment $\tenv$,
+yielding the result in $\vb$.
 
-We assume that both $\vt$ and $\vs$ have been successfully annotated to integer types as per \chapref{Types}
-(otherwise a typing error prevents us from applying this function).
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{right\_top}
+  \begin{itemize}
+    \item $\sdtwo$ is $\Top$;
+    \item define $\vb$ as $\True$.
+  \end{itemize}
+
+  \item \AllApplyCase{left\_top\_right\_not\_top}
+  \begin{itemize}
+    \item $\sdone$ is $\Top$;
+    \item $\sdtwo$ is not $\Top$;
+    \item define $\vb$ as $\False$.
+  \end{itemize}
+
+  \item \AllApply
+  \begin{itemize}
+    \item $\symdomsone$ is a list of symbolic domains $\symdomsone$;
+    \item $\symdomstwo$ is a list of symbolic domains $\symdomstwo$;
+    \item applying $\symdomnormalize$ to $\symdomsone$ yields $\symdomsonenorm$;
+    \item applying $\symdomnormalize$ to $\symdomstwo$ yields $\symdomstwonorm$;
+    \item \Proseeqdef{$\vb$}{$\True$ if and only if for every symbolic domain $\vsone$
+          in $\symdomsonenorm$ there exists a symbolic domain $\vstwo$ in
+          $\symdomstwonorm$ such that \\
+          $\symdomsubset$ holds for $\vsone$ and $\vstwo$ in $\tenv$}.
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[right\_top]{}{
+  \symdomsubsetunions(\tenv, \sdone, \overname{\Top}{\sdtwo}) \typearrow
+  \overname{\True}{\vb}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[left\_top\_right\_not\_top]{
+  \sdone \neq \Top
+}{
+  \symdomsubsetunions(\tenv, \overname{\Top}{\sdone}, \sdtwo) \typearrow
+  \overname{\False}{\vb}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule{
+  \symdomnormalize(\symdomsone) \typearrow \symdomsonenorm\\
+  \symdomnormalize(\symdomstwo) \typearrow \symdomstwonorm\\
+  {
+  \begin{array}{rcl}
+  \vb &\eqdef& \forall \vsone\in\symdomsonenorm.\ \exists \vstwo\in\symdomstwonorm.\\
+      &      & \symdomsubset(\tenv, \vsone, \vstwo)
+  \end{array}
+  }
+}{
+  \symdomsubsetunions(\tenv, \overname{\Subdomains(\symdomsone)}{\sdone}, \overname{\Subdomains(\symdomstwo)}{\sdtwo}) \typearrow \vb
+}
+\end{mathpar}
+
+\TypingRuleDef{SymdomNormalize}
+\hypertarget{def-symdomnormalize}{}
+The function
+\[
+\symdomnormalize(\overname{\symdom^+}{\symdoms}) \aslto \overname{\symdom^+}{\newsymdoms}
+\]
+transforms the list of symbolic domain $\symdoms$ into an equivalent list of symbolic domains $\newsymdoms$
+(in the sense that they both represent the same set of integers)
+where all symbolic finite set integer domains are merged into a single symbolic finite set integer domain
+whose set of integers is the union of the sets of integers in the merged symbolic finite set integer domains.
 
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item applying $\symdomoftype$ to $\vt$ in $\tenv$ yields $\dt$;
-  \item applying $\symdomoftype$ to $\vs$ in $\tenv$ yields $\ds$;
-  \item applying $\symdomissubset$ to $\dt$ and $\ds$ in $\tenv$ yields $\vb$.
+  \item \Proseeqdef{$\others$}{the sublist of $\symdoms$ consisting of symbolic domains other than
+        symbolic finite set integer domains};
+  \item \Proseeqdef{$\vfinitedomains$}{the sublist of $\symdoms$ consisting of symbolic finite set integer domains};
+  \item \Proseeqdef{$\vxs$}{the union of sets in each symbolic finite set integer domain of \\
+        $\vfinitedomains$};
+  \item \Proseeqdef{$\newsymdoms$}{
+        the list with \head{} $\Finite(\vxs)$ and \tail{} $\others$, if $\vxs$ is non-empty, and
+        $\others$, otherwise}.
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \symdomoftype(\tenv, \vt) \typearrow \dt\\
-  \symdomoftype(\tenv, \vs) \typearrow \ds\\
-  \symdomissubset(\tenv, \dt, \ds) \typearrow \vb
+  \others = [\vs \in \symdoms \;|\; \configdomain{\vs} \neq \Finite]\\
+  \vfinitedomains = [\vs \in \symdoms \;|\; \configdomain{\vs} = \Finite]\\
+  \vxs \eqdef \bigcup_{\Finite(\vs) \in \vfinitedomains} \vs\\\\
+  \newsymdoms \eqdef \choice{\vxs \neq \emptyset}{[\Finite(\vxs)] \concat \others}{\others}
 }{
-  \symdomainsubset(\tenv, \vt, \vt) \typearrow \vb
+  \symdomnormalize(\symdoms) \typearrow \newsymdoms \newsymdoms
 }
 \end{mathpar}
 
-\TypingRuleDef{SymDomOfType}
+\TypingRuleDef{SymdomOfType}
 \hypertarget{def-symdomoftype}{}
 The function
 \[
-  \symdomoftype(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt}) \aslto \overname{\symdom}{\vd}
+  \symdomoftype(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt}) \aslto \overname{\symdomortop}{\vd}
 \]
 transforms a type $\vt$ in a static environment $\tenv$ into a symbolic domain $\vd$.
 It assumes its input type has an \underlyingtype{} which is an integer.
@@ -91,21 +263,23 @@ It assumes its input type has an \underlyingtype{} which is an integer.
   \item \AllApplyCase{int\_unconstrained}
   \begin{itemize}
     \item $\vt$ is the unconstrained integer type;
-    \item define $\vd$ as $\Top$, which intuitively represents the entire set of integers.
+    \item \Proseeqdef{$\vd$}{$\Top$, which intuitively represents the entire set of integers}.
   \end{itemize}
 
   \item \AllApplyCase{int\_parameterized}
   \begin{itemize}
     \item $\vt$ is the \parameterizedintegertype\ for the identifier $\id$;
-    \item define $\vd$ as the symbolic constrained integer domain with a single constraint for the variable expression for $\id$,
-          that is, \\ $\FromSyntax([\ConstraintExact(\EVar(\id))])$.
+    \item define $\vd$ as the singleton list consisting of the
+          symbolic constrained integer domain with a single constraint for the variable expression for $\id$,
+          that is, \\ $\ConstrainedDom(\ConstraintExact(\EVar(\id)))$.
   \end{itemize}
 
   \item \AllApplyCase{int\_well\_constrained}
   \begin{itemize}
     \item $\vt$ is the well-constrained integer type for the list of constraints $\vcs$;
-    \item applying $\intsetofintconstraints$ to $\vcs$ in $\tenv$ yields $\vis$;
-    \item \Proseeqdef{$\vd$}{$\vis$}.
+    \item applying $\symdomofconstraint$ to $\tenv$ and $\vc_\vi$, for every \Proselistrange{$\vi$}{$\vcs$},
+          yields $\vd_\vi$;
+    \item \Proseeqdef{$\vd$}{the list symbolic integer domains consisting of $\vd_\vi$, for every \Proselistrange{$\vi$}{$\vcs$}}.
   \end{itemize}
 
   \item \AllApplyCase{t\_named}
@@ -118,21 +292,23 @@ It assumes its input type has an \underlyingtype{} which is an integer.
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[int\_unconstrained]{}{ \symdomoftype(\tenv, \overname{\unconstrainedinteger}{\vt}) \typearrow \overname{\Top}{\vd} }
+\inferrule[int\_unconstrained]{}{ \symdomoftype(\tenv, \overname{\unconstrainedinteger}{\vt}) \typearrow
+ \overname{\Top}{\vd} }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[int\_parameterized]{}{
   \symdomoftype(\tenv, \overname{\TInt(\parameterized(\id))}{\vt}) \typearrow \\
-  \overname{\FromSyntax([\ConstraintExact(\EVar(\id))])}{\vd}
+  \overname{\Subdomains([\ConstrainedDom(\ConstraintExact(\EVar(\id)))])}{\vd}
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[int\_well\_constrained]{
-  \intsetofintconstraints(\tenv, \vcs) \typearrow \vis
+  \vi\in\listrange(\vcs): \symdomofconstraint(\tenv, \vcs[\vi]) \typearrow \vd_\vi\\
+  \vc \eqdef \vi\in\listrange(\vcs) \vd_\vi
 }{
-  \symdomoftype(\tenv, \overname{\TInt(\wellconstrained(\vcs))}{\vt}) \typearrow \overname{\vis}{\vd}
+  \symdomoftype(\tenv, \overname{\TInt(\wellconstrained(\vcs))}{\vt}) \typearrow \overname{\Subdomains(\vis)}{\vd}
 }
 \end{mathpar}
 
@@ -146,499 +322,41 @@ It assumes its input type has an \underlyingtype{} which is an integer.
 }
 \end{mathpar}
 
-\TypingRuleDef{SymDomOfExpr}
-\hypertarget{def-symdomofexpr}{}
+\TypingRuleDef{SymdomOfWidthExpr}
+\hypertarget{def-symdomofwidthexpr}{}
 The function
 \[
-\symdomofexpr(
-  \overname{\staticenvs}{\tenv} \aslsep
+\symdomofwidthexpr(
   \overname{\expr}{\ve}
 ) \aslto
-\overname{\symdom}{\vd}
+\overname{\symdomortop}{\vd}
 \]
-assigns a symbolic domain $\vd$ to an \underline{integer typed} expression $\ve$ in the static environment $\tenv$.
+assigns a symbolic domain $\vd$ to an \underline{integer typed} expression $\ve$,
+where $\ve$ is assumed to be the expression conveying the width of a \bitvectortypeterm.
 
 \ProseParagraph
-\OneApplies
-\begin{itemize}
-  \item \AllApplyCase{e\_literal}
-  \begin{itemize}
-    \item $\ve$ is a literal expression for the literal $\vv$;
-    \item applying $\symdomofliteral$ to $\vv$ yields $\vd$.
-  \end{itemize}
-
-  \item \AllApplyCase{e\_var\_constant}
-  \begin{itemize}
-    \item $\ve$ is a variable expression for the identifier $\vx$;
-    \item applying $\lookupconstant$ to $\vx$ in $\tenv$ yields the literal $\vv$;
-    \item applying $\symdomofliteral$ to $\vv$ yields $\vd$.
-  \end{itemize}
-
-  \item \AllApplyCase{e\_var\_type}
-  \begin{itemize}
-    \item $\ve$ is a variable expression for the identifier $\vx$;
-    \item applying $\lookupconstant$ to $\vx$ in $\tenv$ yields $\bot$;
-    \item applying $\typeof$ to $\vx$ in $\tenv$ yields $\vtone$;
-    \item applying $\symdomoftype$ to $\vtone$ yields $\vd$.
-  \end{itemize}
-
-  \item \AllApplyCase{e\_unop\_minus}
-  \begin{itemize}
-    \item $\ve$ is a unary operation expression for the operation $\MINUS$ and subexpression $\veone$;
-    \item applying $\symdomofexpr$ to the binary operation expression with the operation $\MINUS$
-          and the literal expression for $0$ and $\veone$ in $\tenv$ yields $\vd$.
-  \end{itemize}
-
-  \item \AllApplyCase{e\_unop\_unknown}
-  \begin{itemize}
-    \item $\ve$ is a unary operation expression for an operation that is not $\MINUS$;
-    \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$
-  \end{itemize}
-
-  \item \AllApplyCase{e\_binop\_supported}
-  \begin{itemize}
-    \item $\ve$ is a binary operation expression for an operation that is one of $\PLUS$, $\MINUS$, or $\MUL$
-          and subexpressions $\veone$ and $\vetwo$;
-    \item applying $\symdomofexpr$ to $\veone$ in $\tenv$ yields a symbolic domain $\visone$;
-    \item applying $\symdomofexpr$ to $\vetwo$ in $\tenv$ yields a symbolic domain $\vistwo$;
-    \item applying $\intsetop$ to $\op$ and $\visone$ and $\vistwo$ yields $\vis$;
-    \item define $\vd$ as $\vis$.
-  \end{itemize}
-
-  \item \AllApplyCase{e\_binop\_unsupported}
-  \begin{itemize}
-    \item $\ve$ is a binary operation expression for an operation that is not one of $\PLUS$, $\MINUS$, or $\MUL$;
-    \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$
-  \end{itemize}
-
-  \item \AllApplyCase{unsupported}
-  \begin{itemize}
-    \item $\ve$ is not one of the following expression types a literal expression, a variable expression, a unary operation
-          expression, or a binary operation expression;
-    \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$
-  \end{itemize}
-\end{itemize}
-
-\FormallyParagraph
-\begin{mathpar}
-\inferrule[e\_literal]{
-  \symdomofliteral(\vv) \typearrow \vd
-}{
-  \symdomofexpr(\tenv, \overname{\ELiteral(\vv)}{\ve}) \typearrow \vd
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[e\_var\_constant]{
-  \lookupconstant(\tenv, \vx) \typearrow \vv\\
-  \symdomofliteral(\vv) \typearrow \vd
-}{
-  \symdomofexpr(\tenv, \overname{\EVar(\vx)}{\ve}) \typearrow \vd
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[e\_var\_type]{
-  \lookupconstant(\tenv, \vx) \typearrow \bot\\
-  \typeof(\tenv, \vx) \typearrow \vtone\\
-  \symdomoftype(\vtone) \typearrow \vd
-}{
-  \symdomofexpr(\tenv, \overname{\EVar(\vx)}{\ve}) \typearrow \vd
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[e\_unop\_minus]{
-  \symdomofexpr(\EBinop(\MINUS, \ELiteral(\lint(0)), \veone)) \typearrow \vd
-}{
-  \symdomofexpr(\tenv, \overname{\EUnop(\MINUS, \veone)}{\ve}) \typearrow \vd
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[e\_unop\_unknown]{
-  \op \neq \MINUS
-}{
-  \symdomofexpr(\tenv, \overname{\EUnop(\op, \veone)}{\ve}) \typearrow \overname{\FromSyntax([\ConstraintExact(\ve)])}{\vd}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[e\_binop\_supported]{
-  \op \in \{\PLUS, \MINUS, \MUL\}\\
-  \symdomofexpr(\tenv, \veone) \typearrow \visone\\
-  \symdomofexpr(\tenv, \vetwo) \typearrow \vistwo\\
-  \intsetop(\op, \visone, \vistwo) \typearrow \vis
-}{
-  \symdomofexpr(\tenv, \overname{\EBinop(\op, \veone, \vetwo)}{\ve}) \typearrow \overname{\vis}{\vd}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[e\_binop\_unsupported]{
-  \op \not\in \{\PLUS, \MINUS, \MUL\}\\
-}{
-  \symdomofexpr(\tenv, \overname{\EBinop(\op, \Ignore, \Ignore)}{\ve}) \typearrow \overname{\FromSyntax([\ConstraintExact(\ve)])}{\vd}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[unsupported]{
-  \astlabel(\ve) \not\in \{\ELiteral, \EVar, \EUnop, \EBinop\}
-}{
-  \symdomofexpr(\tenv, \ve) \typearrow \overname{\FromSyntax([\ConstraintExact(\ve)])}{\vd}
-}
-\end{mathpar}
-
-\TypingRuleDef{SymDomOfWidth}
-\hypertarget{def-symdomofwidth}{}
-The function
-\[
-\symdomofwidth(
-  \overname{\staticenvs}{\tenv} \aslsep
-  \overname{\expr}{\ve}
-) \aslto
-\overname{\symdom}{\vd}
-\]
-assigns a symbolic domain $\vd$ to an \underline{integer typed} expression $\ve$ in the static environment $\tenv$.
-In contrast to $\symdomofexpr$, $\symdomofwidth$ should be applied to expressions that represent a bitvector width.
-
-\ProseParagraph
-\OneApplies
-\begin{itemize}
-  \item \AllApplyCase{finite\_one\_width}
-  \begin{itemize}
-    \item applying $\symdomofexpr$ to $\ve$ in $\tenv$ yields $\vdone$;
-    \item $\vdone$ is a set of integers, that is, $\Finite(s)$;
-    \item the cardinality of $s$ is one;
-    \item $\vd$ is $\vdone$.
-  \end{itemize}
-
-  \item \AllApplyCase{finite\_multiple\_widths}
-  \begin{itemize}
-    \item applying $\symdomofexpr$ to $\ve$ in $\tenv$ yields $\vdone$;
-    \item $\vdone$ is a set of integers, that is, $\Finite(s)$;
-    \item the cardinality of $s$ is \emph{not} one;
-    \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$.
-  \end{itemize}
-
-  \item \AllApplyCase{non\_finite}
-  \begin{itemize}
-    \item applying $\symdomofexpr$ to $\ve$ in $\tenv$ yields $\vdone$;
-    \item $\vdone$ is not a set of integers, that is, $\astlabel(\vdone)$ is not $\Finite$;
-    \item define $\vd$ as $\FromSyntax([\ConstraintExact(\ve)])$.
-  \end{itemize}
-\end{itemize}
-
-\FormallyParagraph
-\begin{mathpar}
-\inferrule[finite\_one\_width]{
-  \symdomofexpr(\tenv, \ve) \typearrow \vdone \\
-  \vdone = \Finite(s) \\
-  \cardinality{s} = 1
-}{
-  \symdomofwidth(\tenv, \ve) \typearrow \overname{\vdone}{\vd}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[finite\_multiple\_widths]{
-  \symdomofexpr(\tenv, \ve) \typearrow \vdone \\
-  \vdone = \Finite(s) \\
-  \cardinality{s} \neq 1
-}{
-  \symdomofwidth(\tenv, \ve) \typearrow \overname{\FromSyntax([\ConstraintExact(\ve)])}{\vd}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[non\_finite]{
-  \symdomofexpr(\tenv, \ve) \typearrow \vdone \\
-  \astlabel(\vdone) \neq \Finite
-}{
-  \symdomofwidth(\tenv, \ve) \typearrow \overname{\FromSyntax([\ConstraintExact(\ve)])}{\vd}
-}
-\end{mathpar}
-
-\TypingRuleDef{IntSetOp}
-\hypertarget{def-intsetop}{}
-The function
-\[
-\intsetop(\overname{\binop}{\op} \aslsep \overname{\symdom}{\visone} \aslsep \overname{\symdom}{\vistwo})
-\aslto \overname{\symdom}{\vis}
-\]
-applies the binary operation $\op$ to the symbolic domains $\visone$ and $\vistwo$,
-yielding the symbolic domain $\vis$.
-
-\ProseParagraph
-\OneApplies
-\begin{itemize}
-  \item \AllApplyCase{top}
-  \begin{itemize}
-    \item at least one of $\visone$ and $\vistwo$ is $\Top$;
-    \item define $\vis$ as $\Top$.
-  \end{itemize}
-
-  \item \AllApplyCase{finite\_finite}
-  \begin{itemize}
-    \item $\visone$ is the symbolic finite set integer domain for $\vsone$;
-    \item $\vistwo$ is the symbolic finite set integer domain for $\vstwo$;
-    \item define $\vis$ as the symbolic finite set domain for the set obtained
-          by applying $\op$ to each element of $\vsone$ and each element of $\vstwo$.
-  \end{itemize}
-
-  \item \AllApplyCase{finite\_syntax}
-  \begin{itemize}
-    \item $\visone$ is the symbolic finite set integer domain for $\vsone$;
-    \item $\vistwo$ is the symbolic constrained integer domain for $\vstwo$;
-    \item applying $\intsettointconstraints$ to $\vsone$ yields the list of constraints $\csone$;
-    \item applying $\intsetop$ to $\op$, the symbolic constrained integer domain for $\csone$,
-          and $\vistwo$ yields $\vis$.
-  \end{itemize}
-
-  \item \AllApplyCase{syntax\_finite}
-  \begin{itemize}
-    \item $\visone$ is the symbolic constrained integer domain for $\csone$;
-    \item $\vistwo$ is the symbolic finite set integer domain for $\vstwo$;
-    \item applying $\intsettointconstraints$ to $\vstwo$ yields the list of constraints $\cstwo$;
-    \item applying $\intsetop$ to $\op$, $\visone$, and the symbolic constrained integer domain
-          for $\cstwo$, yields $\vis$.
-  \end{itemize}
-
-  \item \AllApplyCase{syntax\_syntax\_well\_constrained}
-  \begin{itemize}
-    \item $\visone$ is the symbolic constrained integer domain for $\csone$;
-    \item $\vistwo$ is the symbolic constrained integer domain for $\cstwo$;
-    \item applying $\constraintbinop$ to $\op$, $\csone$, and $\cstwo$ yields
-          a list of constraints $\vcs$;
-    \item define $\vis$ as the symbolic constrained integer domain for $\vcs$.
-  \end{itemize}
-\end{itemize}
-
-\FormallyParagraph
-\begin{mathpar}
-\inferrule[top]{
-  \visone = \Top \lor \vistwo = \Top
-}{
-  \intsetop(\op, \visone, \vistwo) \typearrow \overname{\Top}{\vis}
-}
-\and
-\inferrule[finite\_finite]{
-  \vis \eqdef \Finite(\{ \op(a, b) \;|\; a \in \vsone, b \in \vstwo \})
-}{
-  \intsetop(\op, \overname{\Finite(\vsone)}{\visone}, \overname{\Finite(\vstwo)}{\vistwo}) \typearrow \vis
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[finite\_syntax]{
-  \intsettointconstraints(\vsone) \typearrow \vcsone\\
-  \intsetop(\op, \FromSyntax(\vcsone), \FromSyntax(\vcstwo)) \typearrow \vis
-}{
-  \intsetop(\op, \overname{\Finite(\vsone)}{\visone}, \overname{\FromSyntax(\vcstwo)}{\vistwo}) \typearrow \vis
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[syntax\_finite]{
-  \intsettointconstraints(\vstwo) \typearrow \vcstwo\\
-  \intsetop(\op, \FromSyntax(\vcsone), \FromSyntax(\vcstwo)) \typearrow \vis
-}{
-  \intsetop(\op, \overname{\FromSyntax(\vcsone)}{\visone}, \overname{\Finite(\vstwo)}{\vistwo}) \typearrow \vis
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[syntax\_syntax\_well\_constrained]{
-  \constraintbinop(\op, \vcsone, \vcstwo) \typearrow \wellconstrained(\vcs)
-}{
-  \intsetop(\op, \overname{\FromSyntax(\vcsone)}{\visone}, \overname{\FromSyntax(\vcstwo)}{\vistwo}) \typearrow \overname{\FromSyntax(\vcs)}{\vis}
-}
-\end{mathpar}
-
-\TypingRuleDef{IntSetToIntConstraints}
-\hypertarget{def-intsettointconstraints}{}
-The function
-\[
-\intsettointconstraints(\overname{\powfin{\Z}}{\vs})
-\aslto \overname{\intconstraint^*}{\cs}
-\]
-transforms a finite set of integers into the equivalent list of integer constraints.
-
-\ProseParagraph
-\OneApplies
-\begin{itemize}
-  \item \AllApplyCase{empty}
-  \begin{itemize}
-    \item $\vs$ is the empty set;
-    \item define $\cs$ as the empty list.
-  \end{itemize}
-
-  \item \AllApplyCase{singleton}
-  \begin{itemize}
-    \item $\vs$ is the singleton set for $a$;
-    \item define $\cs$ as the list containing the single range constraint for the interval starting from $a$
-          and ending at $a$, that is, $\ConstraintRange(\ELInt{a}, \ELInt{a})$.
-  \end{itemize}
-
-  \item \AllApplyCase{new\_interval}
-  \begin{itemize}
-    \item define $a$ as the minimal element of $\vs$;
-    \item define $\vsone$ as the set $\vs$ with $a$ removed from it;
-    \item applying $\intsettointconstraints$ to $\vsone$ yields the list of constraints $\csone$;
-    \item $\csone$ is a list where its \head\ is a range constraint for the interval starting from $b$ and ending at $c$
-          and \tail\ $\cstwo$;
-    \item $b$ is greater than $a+1$;
-    \item define $\cs$ as the list with first element a range constraint for the interval from $a$ to $a$,
-          second element a range constraint for the interval from $b$ to $c$, and remaining elements given by $\cstwo$.
-  \end{itemize}
-
-  \item \AllApplyCase{merge\_interval}
-  \begin{itemize}
-    \item define $a$ as the minimal element of $\vs$;
-    \item define $\vsone$ as the set $\vs$ with $a$ removed from it;
-    \item applying $\intsettointconstraints$ to $\vsone$ yields the list of constraints $\csone$;
-    \item $\csone$ is a list where its \head\ is a range constraint for the interval starting from $b$ and ending at $c$
-          and \tail\ $\cstwo$;
-    \item $b$ is equal to $a+1$;
-    \item define $\cs$ as the list with \head\  a range constraint for the interval from $a$ to $c$
-          and \tail\ $\cstwo$.
-  \end{itemize}
-\end{itemize}
-
-\FormallyParagraph
-\begin{mathpar}
-\inferrule[empty]{}{
-  \intsettointconstraints(\overname{\emptyset}{\vs}) \typearrow \overname{\emptylist}{\cs}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[singleton]{}{
-  \intsettointconstraints(\overname{\{a\}}{\vs}) \typearrow \overname{[\ConstraintRange(\ELInt{a}, \ELInt{a})]}{\cs}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[new\_interval]{
-  a = \min(\vs)\\
-  \vsone \eqdef \vs \setminus \{a\}\\
-  \intsettointconstraints(\vsone) \typearrow \csone\\
-  \csone = [\ConstraintRange(\ELInt{b}, \ELInt{c})] \concat \cstwo\\
-  b > a + 1\\\\
-  {
-    \begin{array}{rcl}
-  \cs  &\eqdef & [\ConstraintRange(\ELInt{a}, \ELInt{a})]\ \concat\\
-        &       & [\ConstraintRange(\ELInt{b}, \ELInt{c})]\ \concat \\
-        &       & \cstwo
-    \end{array}
-  }
-}{
-  \intsettointconstraints(\vs) \typearrow \cs
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[merge\_interval]{
-  a = \min(\vs)\\
-  \vsone \eqdef \vs \setminus \{a\}\\
-  \intsettointconstraints(\vsone) \typearrow \csone\\
-  \csone = [\ConstraintRange(\ELInt{b}, \ELInt{c})] \concat \cstwo\\
-  b = a + 1\\
-  \cs \eqdef [\ConstraintRange(\ELInt{a}, \ELInt{c})] \concat \cstwo
-}{
-  \intsettointconstraints(\vs) \typearrow \cs
-}
-\end{mathpar}
-
-\TypingRuleDef{SymDomOfLiteral}
-\hypertarget{def-symdomofliteral}{}
-The function
-\[
-\symdomofliteral(\overname{\literal}{\vv}) \typearrow \overname{\symdom}{\vd}
-\]
-returns the symbolic domain $\vd$ that corresponds to the literal $\vv$.
-
-\ProseParagraph
-\AllApply
-\begin{itemize}
-  \item $\vv$ is an integer literal for $n$;
-  \item define $\vd$ as the symbolic finite set integer domain for the singleton set for $n$, that is, $\Finite(\{n\})$.
-\end{itemize}
+\Proseeqdef{$\vd$}{the singleton list for the constrained symbolic integer domain
+for the exact constraint for the expression $\ve$}.
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{}{
-  \symdomofliteral(\overname{\lint(n)}{\vv}) \typearrow \overname{\Finite(\{n\})}{\vd}
+  \symdomofwidthexpr(\ve) \typearrow \overname{\Subdomains([\ \ConstrainedDom(\ConstraintExact(\ve))\ ])}{\vd}
 }
 \end{mathpar}
 
-\TypingRuleDef{SymIntSetOfConstraints}
-\hypertarget{def-intsetofintconstraintse}{}
+\TypingRuleDef{SymdomOfConstraint}
+\hypertarget{def-symdomofconstraint}{}
 The function
 \[
-  \intsetofintconstraints(
-    \overname{\staticenvs}{\tenv} \aslsep
-    \overname{\constraints}{\vcs}
-  ) \aslto
-  \overname{\symdom}{\vis}
-\]
-returns the symbolic domain $\vis$ for the list of constraints $\vcs$
-in the static environment $\tenv$.
-
-\ProseParagraph
-\OneApplies
-\begin{itemize}
-  \item \AllApplyCase{finite}
-  \begin{itemize}
-    \item applying $\constrainttointset$ to every constraint $\vcs[\vi]$ in $\tenv$, for $\vi$ in \\ $\listrange(\vcs)$,
-          yields a finite set of integers $C_\vi$, that is, $\Finite(C_\vi)$;
-    \item define $\vis$ as the union of $C_\vi$ for all $\vi$ in $\listrange(\vcs)$.
-  \end{itemize}
-
-  \item \AllApplyCase{symbolic}
-  \begin{itemize}
-    \item there exists a constraint $\vc$ in $\vcs$ such that applying $\constrainttointset$ to $\vc$
-          in $\tenv$ does not yield a finite set of integers;
-    \item define $\vis$ as the symbolic constrained integer domain for $\vcs$, that is, \\
-          $\FromSyntax(\vcs)$.
-  \end{itemize}
-\end{itemize}
-
-\FormallyParagraph
-\begin{mathpar}
-\inferrule[finite]{
-  \vi\in\listrange(\vcs): \constrainttointset(\tenv, \vcs[\vi]) \typearrow \Finite(C_\vi)\\
-  C \eqdef \bigcup_{\vi\in\listrange(\vcs)} C_\vi
-}{
-  \intsetofintconstraints(\tenv, \vcs) \typearrow \overname{\Finite(C)}{\vis}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[symbolic]{
-  {
-    \begin{array}{r}
-  \exists \vi\in\listrange(\vcs): \constrainttointset(\tenv, \vcs[\vi]) \typearrow \\
-     \visone \land \astlabel(\visone) \neq \Finite
-    \end{array}
-  }
-}{
-  \intsetofintconstraints(\tenv, \vcs) \typearrow \overname{\FromSyntax(\vcs)}{\vis}
-}
-\end{mathpar}
-
-\TypingRuleDef{ConstraintToIntSet}
-\hypertarget{def-constrainttointset}{}
-The function
-\[
-  \constrainttointset(
+  \symdomofconstraint(
     \overname{\staticenvs}{\tenv} \aslsep
     \overname{\intconstraint}{\vc}
   ) \aslto
-  \overname{\symdom}{\vis}
+  \overname{\symdom}{\vd}
 \]
-transforms an integer constraint $\vc$ into a symbolic domain $\vis$.
+transforms an integer constraint $\vc$ into a symbolic domain $\vd$
+in the context of the static environment $\tenv$.
 It produces $\Top$ when the expressions involved in the integer constraints cannot be simplified
 to integers.
 
@@ -648,41 +366,49 @@ to integers.
   \item \AllApplyCase{exact}
   \begin{itemize}
     \item $\vc$ is a single expression constraint for $\ve$, that is, $\ConstraintExact(\ve)$;
-    \item applying $\normalizetoint$ to $\ve$ in $\tenv$ yields the integer $n$\ProseTerminateAs{\Top};
-    \item define $\vis$ as the singleton set for $n$, that is, $\Finite(\{n\})$.
+    \item applying $\symdomeval$ to $\ve$ in $\tenv$ yields $\vv$;
+    \item define $\vd$ as constrained symbolic integer domain for $\vc$
+          ($\ConstrainedDom(\vc)$) if $\vv$ is $\Top$
+          and otherwise as the finite symbolic integer domain for the singleton set for $\vv$ ($\Finite(\{n\})$).
   \end{itemize}
 
   \item \AllApplyCase{range}
   \begin{itemize}
     \item $\vc$ is a range constraint for $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
-    \item applying $\normalizetoint$ to $\veone$ in $\tenv$ yields the integer $b$\ProseTerminateAs{\Top};
-    \item applying $\normalizetoint$ to $\vetwo$ in $\tenv$ yields the integer $t$\ProseTerminateAs{\Top};
-    \item define $\vis$ as the set integers that are both greater or equal to $b$ and less than or equal to $t$.
+    \item applying $\symdomeval$ to $\veone$ in $\tenv$ yields $\vvone$;
+    \item applying $\symdomeval$ to $\vetwo$ in $\tenv$ yields $\vvtwo$;
+    \item define $\vd$ as the constrained symbolic integer domain for $\vc$ if either $\vvone$ or $\vvtwo$
+          are $\Top$ ($\ConstrainedDom(\vc)$) and otherwise the finite symbolic integer domain for the
+          set integers that are both greater or equal to $\vvone$ and less than or equal to $\vvtwo$
+          ($\Finite(\{ n \;|\; \vvone \leq n \leq \vvtwo\})$).
   \end{itemize}
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[exact]{
-  \normalizetoint(\tenv, \ve) \typearrow n \terminateas \Top
+  \symdomeval(\tenv, \ve) \typearrow \vv\\
+  \vd \eqdef \choice{\vv = \Top}{\ConstrainedDom(\vc)}{\Finite(\{\vv\})}
 }{
-  \constrainttointset(\tenv, \overname{\ConstraintExact(\ve)}{\vc}) \typearrow \overname{\Finite(\{n\})}{\vis}
-}
-\and
-\inferrule[range]{
-  \normalizetoint(\tenv, \veone) \typearrow b \terminateas \Top\\\\
-  \normalizetoint(\tenv, \vetwo) \typearrow t \terminateas \Top\\\\
-  \vis \eqdef \Finite(\{ n \;|\; b \leq n \leq t\})
-}{
-  \constrainttointset(\tenv, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \vis
+  \symdomofconstraint(\tenv, \overname{\ConstraintExact(\ve)}{\vc}) \typearrow \vd
 }
 \end{mathpar}
 
-\TypingRuleDef{NormalizeToInt}
-\hypertarget{def-normalizetoint}{}
+\begin{mathpar}
+\inferrule[range]{
+  \symdomeval(\tenv, \veone) \typearrow \vvone\\
+  \symdomeval(\tenv, \vetwo) \typearrow \vvtwo\\
+  \vd \eqdef \choice{\vvone = \Top \lor \vvtwo = \Top}{\ConstrainedDom(\vc)}{\Finite(\{ n \;|\; \vvone \leq n \leq \vvtwo\})}
+}{
+  \symdomofconstraint(\tenv, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \vd
+}
+\end{mathpar}
+
+\TypingRuleDef{SymdomEval}
+\hypertarget{def-symdomeval}{}
 The function
 \[
-\normalizetoint(
+\symdomeval(
   \overname{\staticenvs}{\tenv} \aslsep
   \overname{\expr}{\ve}
 ) \aslto \overname{\Z}{n} \cup \{\Top\}
@@ -716,32 +442,31 @@ and therefore applying $\normalize$ to it does not yield a \typingerrorterm{}.
   \normalize(\tenv, \ve) \typearrow \veone\\
   \staticeval(\tenv, \veone) \typearrow \lint(n)
 }{
-  \normalizetoint(\tenv, \ve) \typearrow n
+  \symdomeval(\tenv, \ve) \typearrow n
 }
 \and
 \inferrule[top]{
   \normalize(\tenv, \ve) \typearrow \veone\\
   \staticeval(\tenv, \veone) \typearrow \top
 }{
-  \normalizetoint(\tenv, \ve) \typearrow \Top
+  \symdomeval(\tenv, \ve) \typearrow \Top
 }
 \end{mathpar}
 
-\TypingRuleDef{SymDomIsSubset}
-\hypertarget{def-symdomissubset}{}
+\TypingRuleDef{SymdomSubset}
+\hypertarget{def-symdomsubset}{}
 The function
 \[
-  \symdomissubset(
+  \symdomsubset(
     \overname{\staticenvs}{\tenv} \aslsep
-    \overname{\symdom}{\vdone} \aslsep
-    \overname{\symdom}{\vdtwo}
+    \overname{\symdom}{\cdone} \aslsep
+    \overname{\symdom}{\cdtwo}
   ) \aslto
   \overname{\Bool}{\vb}
 \]
-conservatively tests whether the values represented by the \symbolicdomain\ $\visone$
-is a subset of the values represented by the \symbolicdomain\ $\vistwo$ in any environment
-consisting of the static environment $\tenv$
-(see \secref{domainsubsettesting} for a precise definition).
+conservatively tests whether the values represented by the \symbolicdomain\ $\cdone$
+is a subset of the values represented by the \symbolicdomain\ $\cdtwo$ in any environment
+consisting of the static environment $\tenv$, yielding the result in $\vb$.
 
 The test first \emph{overapproximates} $\visone$ by a set of integers $\vsone$.
 That is, $\vsone$ represents a superset of the set of numbers represented by $\visone$.
@@ -767,111 +492,91 @@ We refer such a symbol as an \approximationdirectionterm.
 \ProseParagraph
 \OneApplies
 \begin{itemize}
-  \item \AllApplyCase{right\_top}
-  \begin{itemize}
-    \item $\vistwo$ is $\Top$;
-    \item define $\vb$ as $\True$.
-  \end{itemize}
-
-  \item \AllApplyCase{left\_top\_right\_not\_top}
-  \begin{itemize}
-    \item $\visone$ is $\Top$;
-    \item $\vistwo$ is not $\Top$;
-    \item define $\vb$ as $\False$.
-  \end{itemize}
-
   \item \AllApplyCase{finite\_finite}
   \begin{itemize}
-    \item $\visone$ is a finite set of integers for $\vsone$, that is, $\Finite(\vsone)$;
-    \item $\vistwo$ is a finite set of integers for $\vstwo$, that is, $\Finite(\vstwo)$;
-    \item define $\vb$ as $\True$ if and only if $\vsone$ is a subset of $\vstwo$ or both sets are equal.
+    \item $\cdone$ is a finite set of integers for $\vsone$, that is, $\Finite(\vsone)$;
+    \item $\vstwo$ is a finite set of integers for $\vstwo$, that is, $\Finite(\vstwo)$;
+    \item define $\vb$ as $\True$ if and only if $\vsone$ is a subset of $\vstwo$.
   \end{itemize}
 
-  \item \AllApplyCase{syntax\_syntax}
+  \item \AllApplyCase{constrained\_constrained\_equal}
   \begin{itemize}
-    \item $\visone$ is a list of constraints $\csone$, that is, $\FromSyntax(\vsone)$;
-    \item $\vistwo$ is a list of constraints $\cstwo$, that is, $\FromSyntax(\vstwo)$;
-    \item \Proseapproxconstraint{$\tenv$}{$\csone[\vi]$}{$\Over$}{$\vsone_\vi$}, for every \Proselistrange{$\vi$}{$\csone$};
-    \item \Proseapproxconstraint{$\tenv$}{$\cstwo[\vj]$}{$\Under$}{$\vstwo_\vj$}, for every \Proselistrange{$\vj$}{$\cstwo$};
-    \item \Proseeqdef{$\vb$}{$\True$ if and only if
-          for every \Proselistrange{$\vi$}{$\csone$} there exists
-          an index $\vj$ in the list of indices for $\cstwo$ such that
-          either $\constraintequal$ determines that $\csone[\vi]$ is equivalent to $\cstwo[\vj]$
-          in $\tenv$ or $\vsone_\vi$ is a subset of $\vstwo_\vj$}.
+    \item $\cdone$ is a symbolic constrained integer domain for the constraint $\vcone$, that is, $\ConstrainedDom(\vcone)$;
+    \item $\cdtwo$ is a symbolic constrained integer domain for the constraint $\vctwo$, that is, $\ConstrainedDom(\vctwo)$;
+    \item applying $\constraintequal$ to $\tenv$, $\vcone$, and $\vctwo$ yields $\True$;
+    \item \Proseeqdef{$\vb$}{$\True$}.
   \end{itemize}
 
-  \item \AllApplyCase{finite\_syntax}
+  \item \AllApplyCase{constrained\_constrained\_non\_equal}
   \begin{itemize}
-    \item $\visone$ is a finite set of integers for $\vsone$, that is, $\Finite(\vsone)$;
-    \item $\vistwo$ is a list of constraints $\cstwo$, that is, $\FromSyntax(\vstwo)$;
-    \item \ProseapproxconstraintsUnder{$\tenv$}{$\cstwo$}{$\vstwo$};
+    \item $\cdone$ is a symbolic constrained integer domain for the constraint $\vcone$, that is, $\ConstrainedDom(\vcone)$;
+    \item $\cdtwo$ is a symbolic constrained integer domain for the constraint $\vctwo$, that is, $\ConstrainedDom(\vctwo)$;
+    \item applying $\constraintequal$ to $\tenv$, $\vcone$, and $\vctwo$ yields $\False$;
+    \item \Proseapproxconstraint{$\tenv$}{$\vcone$}{$\Over$}{$\vsone$};
+    \item \Proseapproxconstraint{$\tenv$}{$\vctwo$}{$\Under$}{$\vstwo$};
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vsone$ is a subset of $\vstwo$}.
   \end{itemize}
 
-  \item \AllApplyCase{syntax\_finite}
+  \item \AllApplyCase{finite\_constrained}
   \begin{itemize}
-    \item $\visone$ is a list of constraints $\csone$, that is, $\FromSyntax(\vsone)$;
+    \item $\visone$ is a finite symbolic integer domain for the set of integers $\vsone$, that is, $\Finite(\vsone)$;
+    \item $\cdtwo$ is a symbolic constrained integer domain for the constraint $\vctwo$, that is, $\ConstrainedDom(\vctwo)$;
+    \item \ProseapproxconstraintsUnder{$\tenv$}{$\vctwo$}{$\vstwo$};
+    \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vsone$ is a subset of $\vstwo$}.
+  \end{itemize}
+
+  \item \AllApplyCase{constrained\_finite}
+  \begin{itemize}
+    \item $\cdone$ is a symbolic constrained integer domain for the constraint $\vcone$, that is, $\ConstrainedDom(\vcone)$;
     \item $\vistwo$ is a finite set of integers for $\vstwo$, that is, $\Finite(\vstwo)$;
-    \item \ProseapproxconstraintsOver{$\tenv$}{$\csone$}{$\vsone$};
+    \item \ProseapproxconstraintsOver{$\tenv$}{$\vcone$}{$\vsone$};
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vsone$ is a subset of $\vstwo$}.
   \end{itemize}
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[right\_top]{}{
-  \symdomissubset(\tenv, \visone, \overname{\Top}{\vistwo}) \typearrow
-  \overname{\True}{\vb}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[left\_top\_right\_not\_top]{
-  \vistwo \neq \Top
-}{
-  \symdomissubset(\tenv, \overname{\Top}{\visone}, \vistwo) \typearrow
-  \overname{\False}{\vb}
-}
-\end{mathpar}
-
-\begin{mathpar}
 \inferrule[finite\_finite]{}{
-  \symdomissubset(\tenv, \overname{\Finite(\vsone)}{\visone}, \overname{\Finite(\vstwo)}{\vistwo}) \typearrow
+  \symdomsubset(\tenv, \overname{\Finite(\vsone)}{\cdone}, \overname{\Finite(\vstwo)}{\cdtwo}) \typearrow
   \overname{\vsone \subseteq \vstwo}{\vb}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[constrained\_constrained\_equal]{
+  \constraintequal(\tenv, \vcone, \vctwo) \typearrow \True
+}{
+  \symdomsubset(\tenv, \overname{\ConstrainedDom(\vcone)}{\cdone}, \overname{\ConstrainedDom(\vctwo)}{\cdtwo}) \typearrow
+  \overname{\True}{\vb}
 }
 \end{mathpar}
 
 % Transliteration comment: instead of the symbol CannotOverApproximate, we use the set of all integers.
 \begin{mathpar}
-\inferrule[syntax\_syntax]{
-  \vi\in\listrange(\csone): \approxconstraint(\tenv, \Over, \csone[\vi]) \typearrow \vsone_\vi\\
-  \vj\in\listrange(\cstwo): \approxconstraint(\tenv, \Under, \cstwo[\vi]) \typearrow \vstwo_\vj\\
-  {
-  \begin{array}{rl}
-  \vb \eqdef  & \forall \vi\in\listrange(\csone).\ \exists \vj\in\listrange(\cstwo).\\
-              & \constraintequal(\tenv, \csone[\vi], \cstwo[\vi]) \lor \vsone_\vi \subseteq \vstwo_\vj
-  \end{array}
-  }
+\inferrule[constrained\_constrained\_non\_equal]{
+  \constraintequal(\tenv, \vcone, \vctwo) \typearrow \False\\\\
+  \approxconstraint(\tenv, \Over, \vcone) \typearrow \vsone\\
+  \approxconstraint(\tenv, \Under, \vctwo) \typearrow \vstwo
 }{
-  \symdomissubset(\tenv, \overname{\FromSyntax(\csone)}{\visone}, \overname{\FromSyntax(\cstwo)}{\vistwo}) \typearrow
-  \vb
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[finite\_syntax]{
-  \approxconstraints(\tenv, \Under, \cstwo) \typearrow \vstwo
-}{
-  \symdomissubset(\tenv, \overname{\Finite(\vsone)}{\visone}, \overname{\FromSyntax(\cstwo)}{\vistwo}) \typearrow
+  \symdomsubset(\tenv, \overname{\ConstrainedDom(\vcone)}{\cdone}, \overname{\ConstrainedDom(\vctwo)}{\cdtwo}) \typearrow
   \overname{\vsone \subseteq \vstwo}{\vb}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[syntax\_finite]{
-  \approxconstraints(\tenv, \Over, \csone) \typearrow \vsone
+\inferrule[finite\_constrained]{
+  \approxconstraints(\tenv, \Under, \vctwo) \typearrow \vstwo
 }{
-  \symdomissubset(\tenv, \overname{\FromSyntax(\csone)}{\visone}, \overname{\Finite(\vstwo)}{\vistwo}) \typearrow
+  \symdomsubset(\tenv, \overname{\Finite(\cdone)}{\vsone}, \overname{\ConstrainedDom(\vctwo)}{\cdtwo}) \typearrow
+  \overname{\vsone \subseteq \vstwo}{\vb}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[constrained\_finite]{
+  \approxconstraints(\tenv, \Over, \vcone) \typearrow \vsone
+}{
+  \symdomsubset(\tenv, \overname{\ConstrainedDom(\vcone)}{\visone}, \overname{\Finite(\vstwo)}{\vistwo}) \typearrow
   \overname{\vsone \subseteq \vstwo}{\vb}
 }
 \end{mathpar}
@@ -897,7 +602,7 @@ based on the \approximationdirectionterm\ $\vapprox$.
   \item \AllApplyCase{over}
   \begin{itemize}
     \item $\vapprox$ is $\Over$;
-    \item \Proseapproxconstraint{$\tenv$}{$\vc$}{$\Over$}{$\vs_\vc$}, for every constraint $\vc$ in $\cs$;
+    \item \Proseapproxconstraint{$\tenv$}{$\vc$}{$\Over$}{$\vs_\vc$}, for every constraint $\vc$ in $\cs$\ProseTerminateAs{\Z};
     \item \Proseeqdef{$\vs$}{the union of all sets $\vs_\vc$, for every constraint $\vc$ in $\cs$}.
   \end{itemize}
 
@@ -912,7 +617,7 @@ based on the \approximationdirectionterm\ $\vapprox$.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[over]{
-  \vc \in \cs: \approxconstraint(\tenv, \Over, \vc) \typearrow \vs_\vc
+  \vc \in \cs: \approxconstraint(\tenv, \Over, \vc) \typearrow \vs_\vc \terminateas \Z
 }{
   \approxconstraints(\tenv, \overname{\Over}{\vapprox}, \cs) \typearrow
   \overname{\bigcup_{\vc \in \cs} \vs_\vc}{\vs}
@@ -944,6 +649,11 @@ The approximation is over all environments that consist of the static environmen
 The approximation is either overapproximation or underapproximation,
 based on the \approximationdirectionterm\ $\vapprox$.
 
+\ExampleDef{Approximating Constraints}
+The specification in \listingref{ApproxConstraint} is well-typed,
+showing how constraints are overapproximated and underapproximated.
+\ASLListing{Approximating constraints}{ApproxConstraint}{\typingtests/TypingRule.ApproxConstraint.asl}
+
 In the following inference rules, we use $\leq$ to compare both integers to integers
 and integers to infinity symbols. Specifically, the following hold:
 $\forall z\in\Z.\ -\infty < z$ and $\forall z\in\Z.\ z < +\infty$.
@@ -954,14 +664,14 @@ $\forall z\in\Z.\ -\infty < z$ and $\forall z\in\Z.\ z < +\infty$.
   \item \AllApplyCase{exact}
   \begin{itemize}
     \item $\vc$ is an \Proseexactconstraint{\ve};
-    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\ve$}{$\vs$}.
+    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\ve$}{$\vs$}\ProseTerminateAs{\Z}.
   \end{itemize}
 
   \item \AllApplyCase{range\_over}
   \begin{itemize}
     \item $\vc$ is a \Proserangeconstraint{\veone}{\vetwo};
-    \item \Proseapproxexprmin{$\tenv$}{$\veone$}{$\vzone$};
-    \item \Proseapproxexprmax{$\tenv$}{$\vetwo$}{$\vztwo$};
+    \item \Proseapproxexprmin{$\tenv$}{$\veone$}{$\vzone$}\ProseTerminateAs{\Z};
+    \item \Proseapproxexprmax{$\tenv$}{$\vetwo$}{$\vztwo$}\ProseTerminateAs{\Z};
     \item \Proseeqdef{$\vsinterval$}{the set of integers greater or equal to $\vzone$ and
           less than or equal to $\vztwo$};
     \item applying $\approxbottomtop$ to $\vapprox$ yields $\vsbottomtop$;
@@ -983,7 +693,7 @@ $\forall z\in\Z.\ -\infty < z$ and $\forall z\in\Z.\ z < +\infty$.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[exact]{
-  \approxexpr(\tenv, \vapprox, \ve) \typearrow
+  \approxexpr(\tenv, \vapprox, \ve) \typearrow \vs \terminateas \Z
 }{
   \approxconstraint(\tenv, \vapprox, \overname{\ConstraintExact(\ve)}{\vc}) \typearrow \vs
 }
@@ -994,8 +704,8 @@ $\forall z\in\Z.\ -\infty < z$ and $\forall z\in\Z.\ z < +\infty$.
 \begin{mathpar}
 \inferrule[range\_over]{
   \vapprox = \Over\\
-  \approxexprmin(\tenv, \veone) \typearrow \vzone\\
-  \approxexprmax(\tenv, \vetwo) \typearrow \vztwo\\
+  \approxexprmin(\tenv, \veone) \typearrow \vzone \terminateas \Z\\\\
+  \approxexprmax(\tenv, \vetwo) \typearrow \vztwo \terminateas \Z\\\\
   \vsinterval \eqdef \{ \vz \;|\; \vzone \leq \vz \leq \vztwo \}\\
   \approxbottomtop(\vapprox) \typearrow \vsbottomtop\\
   \vs \eqdef \choice{\vzone \leq \vztwo}{\vsinterval}{\vsbottomtop}
@@ -1109,6 +819,34 @@ if $\vapprox$ is $\Over$.}
 }
 \end{mathpar}
 
+\TypingRuleDef{IntsetToConstraints}
+\hypertarget{def-intsettoconstraints}{}
+The function
+\[
+\intsettoconstraints(\overname{\powfin{\Z}}{\vs}) \aslto \overname{\intconstraint^*}{\cs}
+\]
+converts a finite set of integers $\vs$ into an equivalent list of constraints.
+
+\ProseParagraph
+\AllApply
+\begin{itemize}
+  \item \Proseeqdef{$\intervals$}{the set of maximal intervals in $\vs$};
+  \item \Proseeqdef{$\cs$}{the list of constraints where for each interval $a..b$ in $\intervals$,
+        there is an exact constraint for $a$ if $a$ is equal to $b$ and a range constraint \\
+        $\AbbrevConstraintRange{\ELInt{a}}{\ELInt{b}}$, otherwise}.
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule{
+  \intervals \eqdef \{ a..b \;|\; a..b \in \vs \land \forall (c..d) \in \vs.\ a..b \not\subseteq c..d\}\\
+  \cs \eqdef [a..b \in \intervals: \choice{a=b}{
+    \AbbrevConstraintExact{\ELInt{a}}}{\AbbrevConstraintRange{\ELInt{a}}{\ELInt{b}}}]
+}{
+  \intsettoconstraints(\vs) \typearrow \cs
+}
+\end{mathpar}
+
 \TypingRuleDef{ApproxExpr}
 \hypertarget{def-approxexpr}{}
 The function
@@ -1157,7 +895,7 @@ based on the \approximationdirectionterm\ $\vapprox$.
   \item \AllApplyCase{unop}
   \begin{itemize}
     \item $\ve$ is a \unopexpression{$\op$}{$\vep$};
-    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\vep$}{$\vsp$};
+    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\vep$}{$\vsp$}\ProseTerminateAs{\Z};
     \item \Proseeqdef{$\vs$}{the set obtained by applying $\unopliterals$ to $\op$ and
       the integer literal for every integer in $\vsp$}.
   \end{itemize}
@@ -1165,8 +903,8 @@ based on the \approximationdirectionterm\ $\vapprox$.
   \item \AllApplyCase{binop}
   \begin{itemize}
     \item $\ve$ is a \binopexpression{$\op$}{$\veone$}{$\vetwo$};
-    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\veone$}{$\vsone$};
-    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\vetwo$}{$\vstwo$};
+    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\veone$}{$\vsone$}\ProseTerminateAs{\Z};
+    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\vetwo$}{$\vstwo$}\ProseTerminateAs{\Z};
     \item applying $\annotateconstraintbinop$ to $\tenv$, $\vsone$, and $\vstwo$ yields $(\vsp, \plf)$;
     \item applying $\approxconstraints$ to $\tenv$, $\vapprox$, and $\vsp$ yields $\vsapprox$;
     \item \Proseeqdef{$\vs$}{
@@ -1177,8 +915,8 @@ based on the \approximationdirectionterm\ $\vapprox$.
   \item \AllApplyCase{cond}
   \begin{itemize}
     \item $\ve$ is a \condexpression{any}{$\vetwo$}{$\vethree$};
-    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\vetwo$}{$\vstwo$};
-    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\vethree$}{$\vsthree$};
+    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\vetwo$}{$\vstwo$}\ProseTerminateAs{\Z};
+    \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\vethree$}{$\vsthree$}\ProseTerminateAs{\Z};
     \item \Proseeqdef{$\vs$}{the union of $\vstwo$ and $\vsthree$ if $\vapprox$ is $\Over$
     and the intersection of $\vstwo$ and $\vsthree$ if $\vapprox$ is $\Under$}.
   \end{itemize}
@@ -1209,7 +947,7 @@ based on the \approximationdirectionterm\ $\vapprox$.
 \end{mathpar}
 
 In the following inference rule, the application of $\typeof$ is guaranteed not
-to result in a \typingerrorterm{}, since $\symdomainsubset$ is only applied to annotated
+to result in a \typingerrorterm{}, since $\symdomsubset$ is only applied to annotated
 types.
 \begin{mathpar}
 \inferrule[var\_over]{
@@ -1228,7 +966,7 @@ types.
 
 \begin{mathpar}
 \inferrule[unop]{
-  \approxexpr(\tenv, \vapprox, \vep) \typearrow \vsp\\
+  \approxexpr(\tenv, \vapprox, \vep) \typearrow \vsp \terminateas \Z\\\\
   \vs \eqdef \{ \unopliterals(\op, \lint(\vz)) \;|\; \vz \in \vsp\}
 }{
   \approxexpr(\tenv, \vapprox, \overname{\EUnop(\op, \vep)}{\ve}) \typearrow \vs
@@ -1237,8 +975,8 @@ types.
 
 \begin{mathpar}
 \inferrule[binop]{
-  \approxexpr(\tenv, \vapprox, \veone) \typearrow \vsone\\
-  \approxexpr(\tenv, \vapprox, \vetwo) \typearrow \vstwo\\
+  \approxexpr(\tenv, \vapprox, \veone) \typearrow \vsone \terminateas \Z\\\\
+  \approxexpr(\tenv, \vapprox, \vetwo) \typearrow \vstwo \terminateas \Z\\\\
   \annotateconstraintbinop(\tenv, \vsone, \vstwo) \typearrow (\vsp, \plf)\\
   \approxconstraints(\tenv, \vapprox, \vsp) \typearrow \vsapprox\\
   {
@@ -1256,8 +994,8 @@ types.
 
 \begin{mathpar}
 \inferrule[cond]{
-  \approxexpr(\tenv, \vapprox, \vetwo) \typearrow \vstwo\\
-  \approxexpr(\tenv, \vapprox, \vethree) \typearrow \vsthree\\
+  \approxexpr(\tenv, \vapprox, \vetwo) \typearrow \vstwo \terminateas \Z\\\\
+  \approxexpr(\tenv, \vapprox, \vethree) \typearrow \vsthree \terminateas \Z\\\\
   \vs \eqdef \choice{\vapprox = \Over}{\vstwo \cup \vsthree}{\vstwo \cap \vsthree}
 }{
   \approxexpr(\tenv, \vapprox, \overname{\ECond(\Ignore, \vetwo, \vethree)}{\ve}) \typearrow \vs
@@ -1360,8 +1098,9 @@ yielding the integer constraints $\vics$.
   \item \AllApplyCase{extremities}
   \begin{itemize}
     \item $\op$ is either $\DIV$, $\DIVRM$, $\MUL$, $\PLUS$, $\MINUS$, $\SHR$, or $\SHL$;
-    \item applying $\applybinopextremities$ to every pair of constraints $\csone[\vi]$ and $\cstwo[\vj]$
-          where $\vi\in\listrange(\csone)$ and $\vj\in\listrange(\cstwo)$, yields $\vc_{\vi,\vj}$;
+    \item applying $\applybinopextremities$ to every pair of constraints \\
+          $\csone[\vi]$ and $\cstwo[\vj]$ where $\vi\in\listrange(\csone)$ and
+          $\vj\in\listrange(\cstwo)$, yields $\vc_{\vi,\vj}$;
     \item define $\newcs$ as the list of constraints $\vc_{\vi,\vj}$, for every
           $\vi\in\listrange(\csone)$ and $\vj\in\listrange(\cstwo)$.
   \end{itemize}

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -2,27 +2,25 @@
 \section{Domain of Values for Types\label{sec:DomainOfValuesForTypes}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 This section formalizes the concept of the set of values for a given type.
-The formalism is given in the form of rules.
-%
-The section also defines the concept of checking whether the set of values
-for one type is included in the set of values for another type.
-
-\subsection{Dynamic Domain of a Type\label{sec:DynDomain}}
-\hypertarget{def-dyndomain}{}
+The formalism is given in the form of inference rules, although those are not meant
+to be implemented.
 
 We define the concept of a \emph{dynamic domain} of a type
 and the \emph{static domain} of a type.
 Intuitively, domains assign potentially infinite sets of \nativevalues\ to types.
 Dynamic domains are used by the semantics to evaluate expressions of the form \texttt{ARBITRARY: t}
-by choosing a single value from the dynamic domain of $\vt$.
-Static domains are used to define subtype satisfaction in \TypingRuleRef{SubtypeSatisfaction}.
+by choosing a single value from the dynamic domain of $\vt$ (\SemanticsRuleRef{EArbitrary}).
+Static domains are used to define subtype satisfaction (\TypingRuleRef{SubtypeSatisfaction})
+via a conservative subsumption test as defined in \chapref{SymbolicDomainSubsetTesting}.
 
-Formally, the partial function
+\subsection{Dynamic Domain of a Type\label{sec:DynDomain}}
+\hypertarget{def-dyndomain}{}
+The dynamic domain is defined via the partial function
 \[
   \dynamicdomain : \overname{\envs}{\env} \times \overname{\ty}{\vt}
   \partialto \overname{\pow{\vals}}{\vd}
 \]
-assigns the set of values that a type $\vt$ can hold in a given environment $\env$.
+which assigns the set of values that a type $\vt$ can hold in a given environment $\env$.
 %
 We say that $\dynamicdomain(\env, \vt)$ is the \emph{dynamic domain} of $\vt$
 in the environment $\env$.
@@ -443,82 +441,3 @@ is the infinite set of all native integer values.
 \identr{RLQP} \identr{LYDS} \identr{SVDJ} \identi{WLPJ} \identr{FWMM}
 \identi{WPWL} \identi{CDVY} \identi{KFCR} \identi{BBQR} \identr{ZWGH}
 \identr{DKGQ} \identr{DHZT} \identi{HSWR} \identd{YZBQ}
-
-\subsection{Domain Subset Testing\label{sec:domainsubsettesting}}
-Whether an assignment statement is well-typed depends on whether the dynamic domain of the
-right hand side type is contained in the dynamic domain of the left hand side type,
-for any given dynamic environment
-(see \TypingRuleRef{SubtypeSatisfaction} where this is checked).
-
-\begin{definition}[Domain Subset]
-For any given types $\vt$ and $\vs$ and static environment $\tenv$,
-we say that $\vt$ is a \emph{domain subset} of $\vs$ in $\tenv$,
-if the following condition holds:
-\hypertarget{def-domainsubset}{}
-\begin{equation}
-\begin{array}{l}
-\domainsubset(\tenv, \vt, \vs) \triangleq \\
-\qquad \forall \denv\in\dynamicenvs.\
-\dynamicdomain((\tenv, \denv), \vt) \subseteq \dynamicdomain((\tenv, \denv), \vs) \enspace.
-\end{array}
-\end{equation}
-\end{definition}
-
-For example, consider the assignment
-\begin{center}
-\texttt{var x : $\overname{\texttt{integer\{1,2,3\}}}{\vs}$ = ARBITRARY : $\overname{\texttt{integer\{1,2\}}}{\vt}$;}
-\end{center}
-
-It is well-typed, since (in any static environment), the domain of \verb|integer{1,2,3}|
-is \\
-$\{\nvint(1), \nvint(2), \nvint(3)\}$, which subsumes
-the domain of \verb|integer{1,2}|, which is \\ $\{\nvint(1), \nvint(2)\}$.
-
-Since dynamic domains are potentially infinite, this requires \emph{symbolic reasoning}.
-Furthermore, since any (\symbolicallyevaluable{}) expressions may appear inside integer and bitvector
-types, domain subset testing is undecidable.
-We therefore approximate domain subset testing \emph{conservatively} via the predicate $\symdomainsubset(\tenv, \vt, \vs)$.
-
-\hypertarget{def-sounddomainsubsettest}{}
-\begin{definition}[Sound Domain Subset Test]
-A predicate
-\[
-  \symdomainsubset(\overname{\staticenvs}{\tenv} \aslsep \overname{\ty}{\vt} \aslsep \overname{\ty}{\vs}) \aslto \Bool
-\]
-is \emph{sound} if the following condition holds:
-\begin{equation}
-  \begin{array}{l}
-  \forall \vt,\vs\in\ty.\ \tenv\in\staticenvs. \\
-  \;\;\;\; \symdomainsubset(\tenv, \vt, \vs) \typearrow \True \;\Longrightarrow\; \domainsubset(\tenv, \vt, \vs)  \enspace.
-  \end{array}
-\end{equation}
-\end{definition}
-
-That is, if a sound domain subset test returns a positive answer, it means that
-$\vt$ is definitely a domain subset of $\vs$ in the static environment $\tenv$.
-This is referred to as a \emph{true positive}.
-However, a negative answer means one of two things:
-\begin{description}
-  \item[True Negative:] indeed, $\vt$ is not a domain subset of $\vs$ in the static environment $\tenv$; or
-  \item[False Negative:] the symbolic reasoning is unable to decide.
-\end{description}
-
-In other words, $\symdomainsubset(\tenv, \vt, \vs)$ errs on the \emph{safe side} ---
-it never answers $\True$ when the real answer is $\False$, which would (undesirably)
-determine the following statement as well-typed:
-\begin{center}
-\texttt{var x : $\overname{\texttt{integer\{1,2\}}}{\vs}$ = ARBITRARY : $\overname{\texttt{integer}}{\vt}$;}
-\end{center}
-
-A sound but trivial domain subset test is one that always returns $\False$.
-However, that would make all assignments be considered as not well-typed.
-Indeed, it has the maximal set of false negatives.
-Reducing the set of false negatives requires stronger symbolic reasoning algorithms,
-which inevitably leads to higher computational complexity.
-%
-The symbolic domain subset test in \chapref{SymbolicDomainSubsetTesting}
-attempts to accept a large enough set of true positives, based on empirical trial and error,
-while maintaining the computational complexity of the symbolic reasoning relatively low.
-%
-In particular, it serves as the definitive domain subset test that must be utilized
-by any implementation of the ASL type system.

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -117,6 +117,7 @@ approach
 appropriate
 approximate
 approximates
+approximating
 approximation
 arbitrary
 architecture
@@ -458,6 +459,7 @@ convert
 converted
 converting
 converts
+conveying
 conveys
 copied
 copyright
@@ -484,6 +486,7 @@ currently
 custom
 customers
 data
+datatype
 dealing
 debugging
 dec
@@ -1037,6 +1040,7 @@ interpreter
 interpreters
 intersection
 interval
+intervals
 into
 introduce
 introduces
@@ -1176,6 +1180,7 @@ may
 mean
 meaning
 means
+meant
 mechanism
 mechanisms
 meets
@@ -1184,6 +1189,7 @@ members
 memory
 menhir
 mentioned
+merged
 meta
 might
 minimal
@@ -1331,6 +1337,7 @@ outputting
 outside
 over
 overall
+overapproximated
 overapproximates
 overapproximation
 overcome
@@ -1726,6 +1733,7 @@ shorthand
 shortly
 should
 show
+showing
 shown
 shows
 side
@@ -1901,6 +1909,7 @@ takes
 taking
 team
 technical
+technically
 technique
 term
 terminal
@@ -2022,6 +2031,7 @@ unconstrained
 undeclared
 undefined
 under
+underapproximated
 underapproximates
 underapproximation
 underlying

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -480,7 +480,8 @@ module TypingRule = struct
     | ShouldRememberImmutableExpression
     | AddImmutableExpression
     | SymIntSetSubset
-    | SymDomIsSubset
+    | SymdomsSubset
+    | SymdomsSubsetUnions
     | ApproxConstraint
     | ApproxConstraints
     | LEBitSlice
@@ -671,7 +672,8 @@ module TypingRule = struct
     | ShouldRememberImmutableExpression -> "ShouldRememberImmutableExpression"
     | AddImmutableExpression -> "AddImmutableExpression"
     | SymIntSetSubset -> "SymIntSetSubset"
-    | SymDomIsSubset -> "SymDomIsSubset"
+    | SymdomsSubset -> "SymdomsSubset"
+    | SymdomsSubsetUnions -> "SymdomsSubsetUnions"
     | ApproxConstraint -> "ApproxConstraint"
     | ApproxConstraints -> "ApproxConstraints"
     | LEBitSlice -> "LEBitSlice"
@@ -846,7 +848,8 @@ module TypingRule = struct
       ShouldRememberImmutableExpression;
       AddImmutableExpression;
       SymIntSetSubset;
-      SymDomIsSubset;
+      SymdomsSubset;
+      SymdomsSubsetUnions;
       ApproxConstraint;
       ApproxConstraints;
       LEBitSlice;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ApproxConstraint.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ApproxConstraint.asl
@@ -1,0 +1,13 @@
+func main() => integer
+begin
+    let x: integer{0..10} = ARBITRARY: integer{0..10};
+    let y: integer{20..30} = ARBITRARY: integer{20..30};
+    let a: integer{12..15} = ARBITRARY: integer{12..15};
+    let b: integer{13..20} = ARBITRARY: integer{13..20};
+    let rhs_over_approx: integer{a..b} = ARBITRARY: integer{a..b};
+    var lhs_under_approx: integer{x..y} = rhs_over_approx;
+    // The constraint `x..y` is underapproximated as `10..20` whereas
+    // the constraint `a..b` is overapproximated  as `12..20`.
+    var lhs_explicit : integer{10..20} = rhs_over_approx as integer {12..20};
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -883,3 +883,4 @@ ASL Typing Tests / annotating types:
     ^^^^^^^^^
   ASL Typing error: a subtype of boolean was expected, provided integer {1}.
   [1]
+  $ aslref TypingRule.ApproxConstraint.asl

--- a/asllib/tests/types.ml
+++ b/asllib/tests/types.ml
@@ -141,12 +141,6 @@ let lca_examples () =
 
   let lca = lowest_common_ancestor empty_env integer_4 integer_2 in
   assert (Option.is_some lca);
-  let lca = Option.get lca in
-  let domain = Asllib.Types.Domain.of_type empty_env lca in
-
-  assert (Asllib.Types.Domain.mem ~$2 domain);
-  assert (Asllib.Types.Domain.mem ~$4 domain);
-
   ()
 
 let type_clashes () =

--- a/asllib/types.mli
+++ b/asllib/types.mli
@@ -84,33 +84,8 @@ val to_well_constrained : ty -> ty
     well-constrained integers) as they are. *)
 
 val get_well_constrained_structure : env -> ty -> ty
-(** [get_well_constrained_structure env ty] quivalent to
+(** [get_well_constrained_structure env ty] is equivalent to
     [get_structure env ty |> to_well_constrained]. *)
-
-(** {2 Domains} *)
-
-(** The domain of a type is the symbolic representation of the set of values which storage element of that type may hold. *)
-module Domain : sig
-  type t
-  (** Abstract value set. *)
-
-  val pp : Format.formatter -> t -> unit
-  (** A printer for the domain type. *)
-
-  val of_type : env -> ty -> t
-  (** Construct the domain of a type. *)
-
-  val mem : AST.literal -> t -> bool
-  (** [mem v d] is true if and only if [v] is in [d]. *)
-
-  val equal : t -> t -> bool
-  (** Wheather two domains are equal. *)
-
-  val compare : t -> t -> int option
-  (** The inclusion order on domains.
-
-      It is a partial order. *)
-end
 
 (** {2 Orders on types} *)
 
@@ -122,13 +97,13 @@ val subtypes_names : env -> identifier -> identifier -> bool
     declared subtype of the type named [s2].
 
     Equivalent to [subtypes env (T_Named s1 |> here) (T_Named s2 |> here)].
-    *)
+*)
 
 val subtype_satisfies : env -> ty -> ty -> bool
-(** Subtype-satisfation as per Definition TRVR. *)
+(** Subtype-satisfaction test. *)
 
 val type_satisfies : env -> ty -> ty -> bool
-(** Type-satisfation as per Rule FMXK. *)
+(** Type-satisfaction test. *)
 
 val type_clashes : env -> ty -> ty -> bool
 (** Type-clashing relation.
@@ -136,21 +111,13 @@ val type_clashes : env -> ty -> ty -> bool
     Notes:
       - T subtype-satisfies S implies T and S type-clash
       - This is an equivalence relation
-
-    per Definition VPZZ.
 *)
 
 val subprogram_clashes : env -> func -> func -> bool
-(** Subprogram clashing relation.
-
-    per Definition BTBR.
-*)
+(** Subprogram clashing relation. *)
 
 val lowest_common_ancestor : env -> ty -> ty -> ty option
-(** Lowest common ancestor.
-
-    As per Rule YZHM.
-*)
+(** Lowest common ancestor. *)
 
 val type_equal : env -> ty -> ty -> bool
-(** Equality in env for types. *)
+(** A conservative type equivalence test for types in env. *)


### PR DESCRIPTION
The new subsumption test converts each constraint in a list of constraints into a symbolic domain of its own, unlike previously where all resided in a single symbolic domain.