### PR TITLE
ASL-716 accessibility enhancements phase 18: examples and fixes

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1483,6 +1483,7 @@
 \newcommand\AbbrevTArray[2]{\overbracket{\texttt{array }[#1]\texttt{ of }#2}^{\hyperlink{def-abbrevtarray}{\abbrevfont{T\_Array}}}}
 \newcommand\AbbrevTArrayLengthExpr[2]{\overbracket{\texttt{array [[}#1\texttt{]] of }#2}^{\hyperlink{def-abbrevtarraylengthexpr}{\abbrevfont{T\_Array(ArrayLength\_Expr)}}}}
 \newcommand\AbbrevTArrayLengthEnum[3]{\overbracket{\texttt{array [[}#1 \# #2\texttt{]] of }#3}^{\hyperlink{def-abbrevtarraylengthenum}{\abbrevfont{T\_Array(Array\_Length\_Enum)}}}}
+\newcommand\AbbrevEVar[1]{\overbracket{#1}^{\hyperlink{def-abbrevevar}{\abbrevfont{E\_Var}}}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Top level macros

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -927,6 +927,8 @@ We employ the following abbreviations for various AST nodes:
 \hypertarget{def-elint}{}\\
 \hline
 $\ELInt{n}$ & literal integer expression: $\ELiteral(\lint(n))$
+\hypertarget{def-abbrevevar}{}\\
+$\AbbrevEVar{\vx}$ & $\EVar(\vx)$
 \hypertarget{def-abbrevconstraintexact}{}\\
 $\AbbrevConstraintExact{\ve}$ & $\ConstraintExact(\ve)$
 \hypertarget{def-abbrevconstraintrange}{}\\

--- a/asllib/doc/BaseValues.tex
+++ b/asllib/doc/BaseValues.tex
@@ -371,7 +371,7 @@ The minimal absolute value of \verb|{-2..2, 5}| is \verb|0|.
         \begin{cases}
            \emptylist & \vvone > \vvtwo\\
            [\vvtwo] & \vvone \leq \vvtwo < 0\\
-           [0] & \vvone < 0 \leq \vvtwo < 0\\
+           [0] & \vvone < 0 \leq \vvtwo\\
            [\vvone] & 0 \leq \vvone \leq \vvtwo\\
         \end{cases}
     }

--- a/asllib/doc/SideEffects.tex
+++ b/asllib/doc/SideEffects.tex
@@ -249,10 +249,19 @@ an expression evaluates without modifying values of storage elements.
 The specification in \listingref{SideEffectIsPure} shows examples of expressions
 and statements, and their corresponding \sideeffectdescriptorsterm{} and whether
 those are \pure{} or not and whether they are \symbolicallyevaluable{} or not (in comments).
+
+Notice that the call to \verb|factorial(10)| is \pure, even though it is recursive.
+The side-effect analysis adds $\RecursiveCall$ in \TypingRuleRef{DeclareOneFunc},
+while annotating a strongly-connected component of (mutually-recursive) subprograms,
+until finally removing it in \TypingRuleRef{TypecheckDecl}.
+In this example, \verb|factorial| is annotated before \verb|main|, which contains the
+call to \verb|factorial(10)|, which is why the analysis is able to determine that the
+call expression is \pure{} and the \sideeffectdescriptorsetsterm{} is empty.
+
 \ASLListing{Side effect descriptors and whether they are pure and symbolically evaluable}{SideEffectIsPure}{\typingtests/TypingRule.SideEffectIsPure.asl}
 
 \ProseParagraph
-Define $\vb$ as $\True$ if and only if $\vt$ is either a \ReadLocalTerm, a \ReadGlobalTerm,
+Define $\vb$ as $\True$ if and only if $\vs$ is either a \ReadLocalTerm, a \ReadGlobalTerm,
 a \NonDeterministicTerm, or a \PerformsAssertionsTerm.
 
 \FormallyParagraph
@@ -260,7 +269,7 @@ a \NonDeterministicTerm, or a \PerformsAssertionsTerm.
 \inferrule{
     \vb \eqdef \configdomain{\vs} \in \{\ReadLocal, \ReadGlobal, \NonDeterministic, \PerformsAssertions\}
 }{
-    \sideeffectispure(\vt) \typearrow \vb
+    \sideeffectispure(\vs) \typearrow \vb
 }
 \end{mathpar}
 

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -212,6 +212,11 @@ yielding an expression $\newe$.
 \hypertarget{def-normalizedterm}{}
 We refer to an expression in the image of $\normalize$ as a \emph{\normalizedexpressionterm}.
 
+\ExampleDef{Normalize}
+The specification in \listingref{Normalize} shows examples of expressions (on the right-hand-sides of assignments and declarations)
+and their corresponding normalized expressions.
+\ASLListing{Normalizing expressions}{Normalize}{\typingtests/TypingRule.Normalize.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -258,6 +263,11 @@ The function
 \]
 \symbolicallysimplifies\ an integer constraint $\vc$, yielding the integer constraint $\newc$
 
+\ExampleDef{Symbolically Simplifying Constraints}
+The specification in \listingref{ReduceConstraint} shows examples of constraints
+and their simplified counterparts.
+\ASLListing{Symbolically simplifying constraints}{ReduceConstraint}{\typingtests/TypingRule.ReduceConstraint.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -277,8 +287,6 @@ The function
   \end{itemize}
 \end{itemize}
 
-\CodeSubsection{\ReduceConstraintBegin}{\ReduceConstraintEnd}{../StaticOperations.ml}
-
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[exact]{
@@ -296,6 +304,7 @@ The function
   \reduceconstraint(\tenv, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \overname{\ConstraintRange(\veonep, \vetwop)}{\newc}
 }
 \end{mathpar}
+\CodeSubsection{\ReduceConstraintBegin}{\ReduceConstraintEnd}{../StaticOperations.ml}
 
 \TypingRuleDef{ReduceConstraints}
 \hypertarget{def-reduceconstraints}{}
@@ -309,6 +318,8 @@ The function
 \]
 \symbolicallysimplifies\ a list of integer constraints $\cs$, yielding a list of integer constraints $\newcs$
 
+See \ExampleRef{Symbolically Simplifying Constraints}.
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -316,8 +327,6 @@ The function
         $\listrange(\cs)$ yields $\vc_\vi$;
   \item define $\newcs$ as the list containing $\vc_\vi$ for every $\vi$ in $\listrange(\cs)$.
 \end{itemize}
-
-\CodeSubsection{\ReduceConstraintsBegin}{\ReduceConstraintsEnd}{../StaticOperations.ml}
 
 \FormallyParagraph
 \begin{mathpar}
@@ -328,6 +337,7 @@ The function
   \reduceconstraints(\tenv, \cs) \typearrow \newcs
 }
 \end{mathpar}
+\CodeSubsection{\ReduceConstraintsBegin}{\ReduceConstraintsEnd}{../StaticOperations.ml}
 
 \TypingRuleDef{ToIR}
 \hypertarget{def-toir}{}
@@ -339,6 +349,11 @@ The function
 transforms a subset of ASL expressions into symbolic expressions. If an ASL expression cannot be represented
 by a symbolic expression (because, for example, it contains operations that are not available in symbolic expressions),
 the special value $\CannotBeTransformed$ is returned.
+
+\ExampleDef{Transforming Expressions into Symbolic Expressions}
+The specification in \listingref{ToIR} shows examples of expressions (on the right-hand-sides of assignments and declarations)
+and their corresponding symbolic representations (in comments, as ASL expressions).
+\ASLListing{Transforming expressions into symbolic expressions}{ToIR}{\typingtests/TypingRule.ToIR.asl}
 
 \ProseParagraph
 Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expression corresponds to a polynomial.
@@ -357,13 +372,11 @@ Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expre
     \item $\vp$ is $\CannotBeTransformed$.
   \end{itemize}
 
-  \item \AllApplyCase{evar\_int\_constant}
+  \item \AllApplyCase{evar\_constant}
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ via $\lookupconstant$ yields the literal expression for $\vv$, that is, $\ELiteral(\vv)$;
-    \item checking whether $\vv$ is an integer literal yields $\True$\ProseOrTypeError;
-    \item $\vv$ is an integer literal for $\vi$;
-    \item $\vp$ is the symbolic expression for $\vi$, that is, $\{ \emptyfunc\mapsto \vi \}$.
+    \item \Proseeqdef{$\vp$}{$\{ \emptyfunc\mapsto \vi \}$ if $\vv$ is an integer literal for $\vi$ and $\CannotBeTransformed$, otherwise}.
   \end{itemize}
 
   \item \AllApplyCase{evar\_immutable\_expr}
@@ -383,20 +396,31 @@ Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expre
           $\lookupimmutableexpr$ yields $\bot$;
     \item determining the type of $\vs$ yields $\vt$\ProseOrTypeError;
     \item the \underlyingtype\ of $\vt$ is $\ttyone$\ProseOrTypeError;
-    \item checking whether $\ttyone$ is an integer type yields $\True$\ProseOrTypeError;
+    \item $\ttyone$ is an integer type;
     \item $\ttyone$ is a well-constrained integer with the exact constraint $\ve$, that is, \\ $\TInt(\wellconstrained([\ConstraintExact(\ve)]))$;
     \item converting $\ve$ to a symbolic expression yields $\vp$\ProseTerminateAs{\CannotBeTransformed}.
   \end{itemize}
 
-  \item \AllApplyCase{int\_var}
+  \item \AllApplyCase{evar\_int}
   \begin{itemize}
     \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
     \item looking up the constant associated with $\vs$ in $\tenv$ yields $\bot$;
     \item determining the type of $\vs$ yields $\vt$\ProseOrTypeError;
     \item the \underlyingtype\ of $\vt$ is $\ttyone$\ProseOrTypeError;
-    \item checking whether $\ttyone$ is an integer type yields $\True$\ProseOrTypeError;
+    \item $\ttyone$ is an integer type;
     \item $\ttyone$ is not a well-constrained integer with a single exact constraint;
     \item $\vp$ is the symbolic expression for the variable $\vs$, that is, $\{ \{\vs\mapsto 1\}\mapsto 1 \}$.
+  \end{itemize}
+
+  \item \AllApplyCase{evar\_non\_int}
+  \begin{itemize}
+    \item $\ve$ is a variable expression with identifier $\vs$, that is, $\EVar(\vs)$;
+    \item applying $\lookupimmutableexpr$ to $\tenv$ and $\vs$ yields $\bot$;
+    \item looking up the constant associated with $\vs$ in $\tenv$ yields $\bot$;
+    \item determining the type of $\vs$ yields $\vt$\ProseOrTypeError;
+    \item the \underlyingtype\ of $\vt$ is $\ttyone$\ProseOrTypeError;
+    \item $\ttyone$ is not an integer type;
+    \item the result is $\CannotBeTransformed$.
   \end{itemize}
 
   \item \AllApplyCase{ebinop\_plus}
@@ -565,18 +589,17 @@ Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expre
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[evar\_int\_constant]{
+\inferrule[evar\_constant]{
   \lookupconstant(\tenv, \vs) \typearrow \ELiteral(\vv)\\
-  \checktrans{\astlabel(\vv) = \lint}{ExpectedIntegerLiteral} \typearrow \True \OrTypeError\\\\
-  \vv \eqname \lint(\vi)
+  \vp \eqdef \choice{\vv = \lint(\vi)}{\{ \emptyfunc\mapsto \vi \}}{\CannotBeTransformed}
 }{
-  \toir(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \overname{\{ \emptyfunc\mapsto \vi \}}{\vp}
+  \toir(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \vp
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[evar\_immutable\_expr]{
-  \lookupconstant(\tenv, \vs) \typearrow \CannotBeTransformed\\
+  \lookupconstant(\tenv, \vs) \typearrow \bot\\
   \lookupimmutableexpr(\tenv, \vs) \typearrow \vep\\
   \toir(\vep) \typearrow \vp
 }{
@@ -586,11 +609,11 @@ Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expre
 
 \begin{mathpar}
 \inferrule[evar\_exact\_constraint]{
-  \lookupconstant(\tenv, \vs) \typearrow \CannotBeTransformed\\
+  \lookupconstant(\tenv, \vs) \typearrow \bot\\
   \lookupimmutableexpr(\tenv, \vs) \typearrow \bot\\
   \typeof(\vs) \typearrow \vt \OrTypeError\\\\
   \makeanonymous(\vt) \typearrow \ttyone \OrTypeError\\\\
-  \checktrans{\astlabel(\ttyone) = \TInt}{ExpectedIntegerType} \typearrow \True \OrTypeError\\\\
+  \astlabel(\ttyone) = \TInt\\
   \ttyone = \TInt(\wellconstrained([\ConstraintExact(\ve)]))\\
   \toir(\ve) \typearrow \vp \terminateas \CannotBeTransformed
 }{
@@ -599,15 +622,27 @@ Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expre
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[int\_var]{
-  \lookupconstant(\tenv, \vs) \typearrow \CannotBeTransformed\\
+\inferrule[evar\_int]{
+  \lookupconstant(\tenv, \vs) \typearrow \bot\\
   \lookupimmutableexpr(\tenv, \vs) \typearrow \bot\\
   \typeof(\vs) \typearrow \vt\\
   \makeanonymous(\vt) \typearrow \ttyone\\
-  \checktrans{\astlabel(\ttyone) = \TInt}{ExpectedIntegerType} \typearrow \True\\
+  \astlabel(\ttyone) = \TInt\\
   \ttyone \neq \TInt(\wellconstrained([\ConstraintExact(\Ignore)]))
 }{
   \toir(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \overname{\{ \{\vs\mapsto 1\}\mapsto 1 \}}{\vp}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[evar\_non\_int]{
+  \lookupconstant(\tenv, \vs) \typearrow \bot\\
+  \lookupimmutableexpr(\tenv, \vs) \typearrow \bot\\
+  \typeof(\vs) \typearrow \vt\\
+  \makeanonymous(\vt) \typearrow \ttyone\\
+  \astlabel(\ttyone) \neq \TInt
+}{
+  \toir(\tenv, \overname{\EVar(\vs)}{\ve}) \typearrow \CannotBeTransformed
 }
 \end{mathpar}
 
@@ -784,6 +819,11 @@ The function
 conservatively checks whether the expression $\veone$ is equivalent to the expression $\vetwo$ in environment $\tenv$.
 The result is given in $\vb$ or a \typingerrorterm{}, if one is detected.
 
+\ExampleDef{Expression Equivalence}
+The specification in \listingref{ExprEqual} is well-typed as the expressions
+comprising the array lengths are equivalent, as details in comments.
+\ASLListing{Equivalent expressions}{ExprEqual}{\typingtests/TypingRule.ExprEqual.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -827,6 +867,8 @@ conservatively tests whether the expression $\veone$ is equivalent to the expres
 by attempting to transform both expressions to their symbolic expression form
 and, if successful, comparing the resulting normal forms for equality.
 The result is given in $\vb$ or a \typingerrorterm{}, if one is detected.
+
+See \ExampleRef{Expression Equivalence}.
 
 \ProseParagraph
 \OneApplies
@@ -885,6 +927,8 @@ The helper function
 specializes the equivalence test for expressions $\veone$ and $\vetwo$ in $\tenv$
 for the different types of expressions.
 The result is given in $\vb$ or a \typingerrorterm{}, if one is detected.
+
+See \ExampleRef{Expression Equivalence}.
 
 \ProseParagraph
 \OneApplies
@@ -1274,6 +1318,13 @@ The function
 conservatively tests whether the type $\vtone$ is equivalent to the type $\vttwo$ in environment $\tenv$
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
+\ExampleDef{Equivalent Types}
+The specification in \listingref{TypeEqual} is well-typed.
+Specifically, the types of the arguments for the \verb|impdef| declaration
+of \verb|Foo| match types of the corresponding arguments for the overridden declaration
+of \verb|Foo|.
+\ASLListing{Equivalent Types}{TypeEqual}{\typingtests/TypingRule.TypeEqual.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -1502,6 +1553,18 @@ The function
 conservatively tests whether the list of bitfields $\bfone$ is equivalent to the list of bitfields $\bftwo$
 in environment $\tenv$ and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
+\ExampleDef{Equivalent Lists of Bitfields}
+
+The specification in \listingref{BitFieldsEqual} is well-typed.
+Specifically, the lists of bitfields for the \verb|bv| argument in both signatures
+of \verb|Foo| are equivalent.
+\ASLListing{Equivalent lists of bitfields}{BitFieldsEqual}{\typingtests/TypingRule.BitFieldsEqual.asl}
+
+The specification in \listingref{BitFieldsEqual} is ill-typed,
+the lists of bitfields for the \verb|bv| argument in both signatures
+of \verb|Foo| are not equivalent.
+\ASLListing{Non-equivalent lists of bitfields}{BitFieldsEqual-bad}{\typingtests/TypingRule.BitFieldsEqual.bad.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -1546,6 +1609,19 @@ The function
 \]
 conservatively tests whether the bitfield $\bfone$ is equivalent to the bitfield $\bftwo$ in environment $\tenv$
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
+
+\ExampleDef{Bitfield Equivalence}
+In \listingref{BitFieldEqual}, the bitfields of the \bitvectortypesterm{} on the left-hand-side
+of assignments and the bitfields of the same name in the \bitvectortypesterm{} on the right-hand-side
+of the same assignment are equivalent.
+\ASLListing{Equivalent bitfields}{BitFieldEqual}{\typingtests/TypingRule.BitFieldEqual.asl}
+
+The specifications in \listingref{BitFieldEqual-bad1} and \listingref{BitFieldEqual-bad2}
+show cases where the \verb|data| bitfields of the \bitvectortypesterm{} on the two sides
+of an assignment are not equivalent. This is due to either having different slices
+or different nested bitfields.
+\ASLListing{Bitfields with differing slices}{BitFieldEqual-bad1}{\typingtests/TypingRule.BitFieldEqual.bad1.asl}
+\ASLListing{Bitfields with differing nested bitfields}{BitFieldEqual-bad2}{\typingtests/TypingRule.BitFieldEqual.bad2.asl}
 
 \ProseParagraph
 \OneApplies
@@ -1640,6 +1716,19 @@ The function
 conservatively tests whether the constraint list $\csone$ is equivalent to the constraint list $\cstwo$ in environment $\tenv$
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
 
+\ExampleDef{Equivalent Lists of Constraints}
+The specification in \listingref{ConstraintsEqual}
+shows two lists of constraints --- the ones used to type \verb|x| and the ones used to type \verb|y|.
+The expression \verb|x as integer{w..2 * w + z, w + w + w}|
+compares the list \verb|3 * w, w..w + z + w| to the list \verb|w..2 * w + z, w + w + w|.
+Since the corresponding constraints are determined to be equivalent,
+the expression is well-typed.
+The expression \verb|x as integer{w + w + w, w..2 * w + z}| on the other hand
+has the constraints in a different order, which means that the two lists of constraints
+are not considered equivalent. This is still considered well-typed (see \TypingRuleRef{CheckATC}),
+and the typing assertion will be checked dynamically (see \SemanticsRuleRef{ATC}).
+\ASLListing{Equivalent lists of constraints}{ConstraintsEqual}{\typingtests/TypingRule.ConstraintsEqual.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -1670,6 +1759,12 @@ The function
 \]
 conservatively tests whether the constraint $\vcone$ is equivalent to the constraint $\vctwo$ in environment $\tenv$
 and yields the result in $\vb$.  \ProseOtherwiseTypeError
+
+\ExampleDef{Equivalent Constraints}
+The specification in \listingref{ConstraintEqual} is well-typed,
+since each constraint on a right-hand-side of an assignment is equivalent to the
+corresponding constraint on the left-hand-side of that assignment.
+\ASLListing{Equivalent constraints}{ConstraintEqual}{\typingtests/TypingRule.ConstraintEqual.asl}
 
 \ProseParagraph
 \OneApplies
@@ -1865,6 +1960,14 @@ The function
 tests whether the array lengths $\vlone$ and $\vltwo$ are equivalent and yields the result
 in $\vb$. \ProseOtherwiseTypeError
 
+\ExampleDef{Array Length Expression Equivalence}
+See \ExampleRef{Expression Equivalence} for examples of equivalent array length expressions.
+
+The specification in \listingref{ArrayLengthEqual-bad} is ill-typed since the array length
+expressions are of different kinds (\integertypeterm{} and \enumerationtypeterm),
+even though they both contain three elements each.
+\ASLListing{Non-equivalent array length expressions}{ArrayLengthEqual-bad}{\typingtests/TypingRule.ArrayLengthEqual.bad.asl}
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -1923,6 +2026,8 @@ The function
 \polynomialtoexpr(\overname{\polynomial}{\vp}) \typearrow \overname{\expr}{\ve}
 \]
 transforms a polynomial $\vp$ into the corresponding expression $\ve$.
+
+See \ExampleRef{Transforming Expressions into Symbolic Expressions}.
 
 \ProseParagraph
 \OneApplies
@@ -1984,6 +2089,12 @@ compares two monomial bindings given by $(\vmone, \vqone)$ and $(\vmtwo, \vqtwo)
 and yields in $\vs$ $-1$ to mean that the first monomial binding should be ordered before the second,
 $0$ to mean that any ordering of the monomial bindings is acceptable,
 and $1$ to mean that the second monomial binding should be ordered before the first.
+
+\ExampleDef{Comparing Monomial Bindings}
+Comparing $(\vx, -1)$ to $(\vx, -1)$ yields $0$.
+
+Comparing $(\vx, 1)$ to $(\vy, 1)$ yields $-1$ as $\vx$ comes before $\vy$ and $\vx$ is the
+first identifier for which the two monomials differ.
 
 \ProseParagraph
 \OneApplies
@@ -2051,6 +2162,12 @@ transforms a list consisting of pairs of unitary monomials and rational factors 
 into an expression $\ve$, which represents the absolute value of the sum of all the monomials,
 and a sign value $\vs$, which indicates the sign of the resulting sum.
 
+\ExampleDef{Transforming a List of Unitary Monomials}
+Transforming the list of unitary monomials whose formulae are given by
+$(\vx \times \vy^2, 2)$,
+$(\vx \times \vy^2, 3)$ and $(\vx \times \vy, -5)$
+yields the expression \verb|5 * x * y * y - 5 * x * y|.
+
 \ProseParagraph
 \OneApplies
 \begin{itemize}
@@ -2096,6 +2213,28 @@ The function
 \]
 transforms an expression $\ve$ and rational $q$ into the expression $\newe$,
 which represents the absolute value of $\ve$ multiplied by $q$, and the sign of $q$ as $\vs$.
+
+\ExampleDef{Transforming Expressions and Rationals}
+The following are examples of inputs and outputs of $\monomialtoexpr$:
+\[
+\monomialtoexpr(\EVar(\vx), 0) \typearrow (\ELiteral(\lint(0)), 0)
+\]
+
+\[
+\monomialtoexpr(\EVar(\vx), 5) \typearrow (\AbbrevEBinop{*}{\ELInt{5}}{\AbbrevEVar{\vx}}, 1)
+\]
+
+\[
+\monomialtoexpr(\EVar(\vx), 9/12) \typearrow
+(\AbbrevEBinop{/}
+{ (\AbbrevEBinop{*}{\AbbrevEVar{\vx}}{3}) }
+{ \ELInt{4} }, 1)
+\]
+
+\[
+\monomialtoexpr(\EVar(\vx), -1) \typearrow (\EUnop(\NEG, \AbbrevEVar{\vx}), -1)
+\]
+
 
 \ProseParagraph
 \OneApplies
@@ -2271,6 +2410,12 @@ The function
 \]
 transforms a list of single-variable unitary monomials $\monoms$ into an expression $\ve$.
 Intuitively, $\monoms$ represented a multiplication of the single-variable unitary monomials.
+
+\ExampleDef{Transforming Unitary Monomials to Expressions}
+The specification in \listingref{UnitaryMonomialsToExpr}
+shows examples of unitary monomials (as right-hand-side of assignments)
+and the corresponding expressions, in comments.
+\ASLListing{Transforming unitary monomials to expressions}{UnitaryMonomialsToExpr}{\typingtests/TypingRule.UnitaryMonomialsToExpr.asl}
 
 \ProseParagraph
 \OneApplies
@@ -2496,6 +2641,8 @@ The helper function
 is similar to $\normalize$, except that it returns $\None$ when $\ve$ is not an
 expression that can be symbolically simplified.
 \ProseOtherwiseTypeError
+
+See \ExampleRef{Normalize}.
 
 \ProseParagraph
 \OneApplies

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -1786,6 +1786,9 @@ in environment $\tenv$ and yields the result in $\vb$. \ProseOtherwiseTypeError
 This function operates both on \typedast{} nodes, where both slices are only
 of the form $\SliceLength(\ \cdot\ ,\ \cdot\ )$, as well as \untypedast{} nodes where all slice forms
 are possible. The latter is used during checking overriding subprograms (\secref{Overriding}).
+This function operates both on \typedast{} nodes, where both slices are only
+of the form $\SliceLength(\ \cdot\ ,\ \cdot\ )$, as well as \untypedast{} nodes where all slice forms
+are possible. The latter is used during checking overriding subprograms (\secref{Overriding}).
 
 \ExampleDef{Equivalent Slices}
 The specification in \listingref{SliceEqual} shows examples of equivalent slices.

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -335,6 +335,7 @@ combine
 combined
 combines
 come
+comes
 commas
 comment
 commented
@@ -831,6 +832,7 @@ formals
 formed
 forms
 formula
+formulae
 found
 four
 fraction
@@ -1257,6 +1259,7 @@ none
 nonempty
 nor
 normal
+normalize
 normalized
 normalizing
 normally

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -511,8 +511,7 @@ def check_rules(filename: str) -> int:
     file_to_num_expected_errors = {
         "RelationsOnTypes.tex" : 15,
         "SubprogramCalls.tex" : 1,
-        "SymbolicEquivalenceTesting.tex" : 19,
-        "SymbolicSubsumptionTesting.tex" : 23,
+        "SymbolicSubsumptionTesting.tex" : 19,
         "TypeSystemUtilities.tex" : 23,
         "SemanticsUtilities.tex" : 19,
     }

--- a/asllib/doc/introduction.tex
+++ b/asllib/doc/introduction.tex
@@ -100,7 +100,7 @@ Each construct is defined via a subset of the following:
 \begin{description}
     \item[Preamble] A high-level explanation of what the construct is intended for using
         prose and code examples;
-    \item[Requirements] High-level rules that provide informal guidance.
+    \item[Guidelines] Rules that provide informal high-level guidance.
         These rules follow the naming convention \RequirementDefExample{Name};
     \item[Syntax] Rules that define how the construct is expressed in syntax;
     \item[AST] Rules that define how the construct is expressed in the AST;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ArrayLengthEqual.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ArrayLengthEqual.bad.asl
@@ -1,0 +1,12 @@
+type Color of enumeration { RED, GREEN, BLUE };
+
+func main() => integer
+begin
+    var x : array[[3]] of integer;
+    var y : array[[Color]] of integer;
+    // Illegal as integer and enumeration are different
+    // kinds of indices.
+    x = y;
+
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldEqual.asl
@@ -1,0 +1,35 @@
+type Nested_Type of bits(32) {       // absolute fields
+   [31:16] fmt0 {                    // [31:16] fmt0
+        [15] common,                 // [31:31] fmt0.common
+        [14:13, 12:2, 1, 0] layer1 { // [30:16] fmt0.layer1
+            [14:13] remainder {      // [30:29] fmt0.layer1.remainder
+               [1]  moving,          // [30:30] fmt0.layer1.remainder.moving
+               [0]  extra            // [29:29] fmt0.layer1.remainder.extra
+            },
+        },
+        [13] extra                   // [29:29] fmt0.extra
+   },
+   [31:16] fmt1 {                    // [31:16] fmt1
+       [15] common,                  // [31:31] fmt1.common
+       [0]  moving                   // [16:16] fmt1.moving
+   },
+   [31] common,                      // [31:31] common
+   [0]  fmt                          // [0:0] fmt
+};
+
+var nested : Nested_Type = '10101010101010101010101010101010';
+
+// select the correct view of moving
+// nested.fmt is '0'
+//    nested.fmt0.moving is nested[30]
+// nested.fmt is '1'
+//    nested.fmt1.moving is nested[16]
+let moving = if nested.fmt == '0' then nested.fmt0.layer1.remainder.moving
+    else nested.fmt1.moving;
+
+func main() => integer
+begin
+    var - : bits(64) { [0] lsb } = Zeros{64} as bits(64) { [0] lsb };
+    var - : bits(64) { [31:16] data { [0] lsb } } = Zeros{64} as bits(64) { [31:16] data { [0] lsb } };
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldEqual.asl
@@ -1,35 +1,10 @@
-type Nested_Type of bits(32) {       // absolute fields
-   [31:16] fmt0 {                    // [31:16] fmt0
-        [15] common,                 // [31:31] fmt0.common
-        [14:13, 12:2, 1, 0] layer1 { // [30:16] fmt0.layer1
-            [14:13] remainder {      // [30:29] fmt0.layer1.remainder
-               [1]  moving,          // [30:30] fmt0.layer1.remainder.moving
-               [0]  extra            // [29:29] fmt0.layer1.remainder.extra
-            },
-        },
-        [13] extra                   // [29:29] fmt0.extra
-   },
-   [31:16] fmt1 {                    // [31:16] fmt1
-       [15] common,                  // [31:31] fmt1.common
-       [0]  moving                   // [16:16] fmt1.moving
-   },
-   [31] common,                      // [31:31] common
-   [0]  fmt                          // [0:0] fmt
-};
-
-var nested : Nested_Type = '10101010101010101010101010101010';
-
-// select the correct view of moving
-// nested.fmt is '0'
-//    nested.fmt0.moving is nested[30]
-// nested.fmt is '1'
-//    nested.fmt1.moving is nested[16]
-let moving = if nested.fmt == '0' then nested.fmt0.layer1.remainder.moving
-    else nested.fmt1.moving;
-
 func main() => integer
 begin
-    var - : bits(64) { [0] lsb } = Zeros{64} as bits(64) { [0] lsb };
-    var - : bits(64) { [31:16] data { [0] lsb } } = Zeros{64} as bits(64) { [31:16] data { [0] lsb } };
+    var x : bits(64) { [16+:16] data } = Zeros{64} as bits(64) { [31:16] data };
+
+    var y : bits(64) { [16+:16] data { [0] lsb } } =  Zeros{64} as
+            bits(64) { [31:16] data { [0] lsb } };
+
+    var z : bits(64) { [0] lsb : bits(1) } = Zeros{64} as bits(64) { [0] lsb : bit };
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldEqual.bad1.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldEqual.bad1.asl
@@ -1,0 +1,6 @@
+func main() => integer
+begin
+    // Illegal: bitfields of the same name must have the same slices.
+    var x : bits(64) { [1] data } = Zeros{64} as bits(64) { [2] data };
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldEqual.bad2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldEqual.bad2.asl
@@ -1,0 +1,8 @@
+func main() => integer
+begin
+    // Illegal: bitfields of the same name must have the same
+    // set of nested bitfields.
+    var x : bits(64) { [16+:16] data { [0] lsb } } =  Zeros{64} as
+            bits(64) { [31:16] data {  } };
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldsEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldsEqual.asl
@@ -1,0 +1,2 @@
+impdef          func Foo(bv : bits(2) { [0] lsb, [1] msb }) begin pass; end;
+implementation  func Foo(bv : bits(2) { [0] lsb, [1] msb }) begin pass; end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldsEqual.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BitFieldsEqual.bad.asl
@@ -1,0 +1,6 @@
+impdef func Foo(bv : bits(2) { [0] lsb, [1] msb }) begin pass; end;
+
+// Illegal: signature does not match impdef, since the order
+// of bitfields for `bv` is different than the one in the
+// signature above.
+implementation func Foo(bv : bits(64) { [1] msb, [0] lsb }) begin pass; end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ConstraintEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ConstraintEqual.asl
@@ -1,0 +1,9 @@
+func main() => integer
+begin
+    let z = ARBITRARY: integer{0..1000};
+    let w = ARBITRARY: integer{0..1000};
+
+    var x : integer{3 * w} = ARBITRARY : integer{w + w + w};
+    var y : integer{w..w + z + w} = ARBITRARY : integer{w..2 * w + z};
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ConstraintsEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ConstraintsEqual.asl
@@ -1,0 +1,14 @@
+let z = ARBITRARY: integer{0..1000};
+let w = ARBITRARY: integer{0..1000};
+
+func main() => integer
+begin
+    var y : integer{w..2 * w + z, w + w + w} = 3 * w as
+            integer{w..2 * w + z, w + w + w};
+    var x : integer{3 * w,      w..w + z + w} = 3 * w as
+            integer{3 * w,      w..w + z + w};
+
+    - = x as integer{w..2 * w + z, w + w + w};
+    - = x as integer{w + w + w, w..2 * w + z};
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ExprEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ExprEqual.asl
@@ -1,0 +1,27 @@
+func f(x: integer) => integer
+begin
+    return x * 8;
+end;
+
+type Color of enumeration { RED, GREEN, BLUE };
+
+func main() => integer
+begin
+    let z = ARBITRARY: integer{0..1000};
+    var x1 : array[[z+z]] of integer;
+    var y1 : array[[2*z]] of integer;
+    // Legal as `z+z` is equivalent to `2*z`.
+    x1 = y1;
+
+    var x2 : array[[f(z+z)]] of integer;
+    var y2 : array[[f(2*z)]] of integer;
+    // Legal as `f(z+z)` is equivalent to `f(2*z)`.
+    x2 = y2;
+
+    var x3 : array[[Color]] of integer;
+    var y3 : array[[Color]] of integer;
+    // Legal as the same enumeration is used.
+    x3 = y3;
+
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.Normalize.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.Normalize.asl
@@ -1,0 +1,21 @@
+func main() => integer
+begin
+                                // normalizes rhs expression
+    constant ONE = 1;           // 1
+    var o = ONE;                // 1
+    - = 5.0;                    // 5.0
+
+    let x = 3;                  // 3
+    - = 3 * x;                  // 9
+
+    var y : integer{1, 2, 3};
+    var z : integer{4, 5, 6};
+    var p1 = (y + 5) - z;        // 5 + y - x
+    var p2 = (z DIV 2) * y;      // (z * y) DIV 2
+    var p3 = z * (y DIV 2);      // (z * y) DIV 2
+    var p4 = z * (z * y);        // z^2 * y
+    var p5 = z as integer{4, 5}; // z
+    var p6 = z ^ y;              // z ^ y
+
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ReduceConstraint.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ReduceConstraint.asl
@@ -1,0 +1,12 @@
+func main() => integer
+begin
+    let z = ARBITRARY: integer{0..1000};
+    let w = ARBITRARY: integer{0..1000};
+
+    var x : integer{3 * w, 0..5 * z - z - 2 * z,  w + z} = w + z;
+    // The constraints for `x` are internally converted to the ones below
+    // for `y`.
+    var y : integer{0..z*2,            z + w, w * 3} = w + z;
+    y = x;
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SideEffectIsPure.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SideEffectIsPure.asl
@@ -30,7 +30,7 @@ begin       // Side effect for RHS expression   Pure?   Symbolically Evaluable?
             // PerformsAssertions               TRUE    FALSE
     - = x as integer{0};
 
-            // RecursiveCall                    FALSE   FALSE
+            // None                             TRUE   FALSE
     - = factorial(10);
 
              // Side effect for LHS expression  Pure?

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ToIR.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ToIR.asl
@@ -1,0 +1,21 @@
+func main() => integer
+begin
+                                // to_ir of rhs expression
+    constant ONE = 1;           // 1
+    var o = ONE;                // 1
+    - = 5.0;                    // Top
+
+    let x = 3;                  // 3
+    - = 3 * x;                  // 9
+
+    var y : integer{1, 2, 3};
+    var z : integer{4, 5, 6};
+    var p1 = (y + 5) - z;        // 5 + y - x
+    var p2 = (z DIV 2) * y;      // (z * y) DIV 2
+    var p3 = z * (y DIV 2);      // (z * y) DIV 2
+    var p4 = z * (z * y);        // z^2 * y
+    var p5 = z as integer{4, 5}; // z
+    var p6 = z ^ y;              // Top
+
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypeEqual.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypeEqual.asl
@@ -1,0 +1,26 @@
+type Color of enumeration { RED, GREEN, BLUE };
+type MyRecord of record { flag: boolean };
+
+impdef          func Foo{N}(
+    s: string,
+    r: real,
+    i: integer,
+    ci: integer{0..N},
+    bv : bits(2) { [0] lsb, [1] msb },
+    a: array[[10]] of integer,
+    c: Color,
+    rec: MyRecord,
+    t: (boolean, integer)
+) begin pass; end;
+
+implementation  func Foo{N}(
+    s: string,
+    r: real,
+    i: integer,
+    ci: integer{0..N},
+    bv : bits(2) { [0] lsb, [1] msb },
+    a: array[[10]] of integer,
+    c: Color,
+    rec: MyRecord,
+    t: (boolean, integer)
+) begin pass; end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UnitaryMonomialsToExpr.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UnitaryMonomialsToExpr.asl
@@ -1,0 +1,12 @@
+func main() => integer
+begin
+                        // the expressions corresponding
+                        // to the rhs monomials
+    var x : integer;
+    var y : integer;
+    - = x ^ 0 * y;      // y
+    - = x ^ 1 * y;      // x * y
+    - = x ^ 2 * y;      // x * x * y
+    - = x ^ 3 * y;      // x^3 * y
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -884,3 +884,47 @@ ASL Typing Tests / annotating types:
   ASL Typing error: a subtype of boolean was expected, provided integer {1}.
   [1]
   $ aslref TypingRule.ApproxConstraint.asl
+  $ aslref TypingRule.BitFieldEqual.asl
+  $ aslref TypingRule.BitFieldEqual.bad1.asl
+  File TypingRule.BitFieldEqual.bad1.asl, line 4, characters 4 to 71:
+      var x : bits(64) { [1] data } = Zeros{64} as bits(64) { [2] data };
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ASL Typing error: a subtype of bits (64) { [1+:1] data } was expected,
+    provided bits (64) { [2+:1] data }.
+  [1]
+  $ aslref TypingRule.BitFieldEqual.bad2.asl
+  File TypingRule.BitFieldEqual.bad2.asl, line 5, character 4 to line 6,
+    character 43:
+      var x : bits(64) { [16+:16] data { [0] lsb } } =  Zeros{64} as
+              bits(64) { [31:16] data {  } };
+  ASL Typing error: a subtype of bits (64) { [16+:16] data { [0+:1] lsb } }
+    was expected, provided bits (64) { [16+:16] data {  } }.
+  [1]
+  $ aslref --no-exec TypingRule.BitFieldsEqual.asl
+  $ aslref TypingRule.BitFieldsEqual.bad.asl
+  File TypingRule.BitFieldsEqual.bad.asl, line 6, characters 0 to 76:
+  implementation func Foo(bv : bits(64) { [1] msb, [0] lsb }) begin pass; end;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ASL Typing error: no `impdef` for `implementation` function.
+  [1]
+  $ aslref --no-exec TypingRule.TypeEqual.asl
+  $ aslref TypingRule.ExprEqual.asl
+  $ aslref TypingRule.ArrayLengthEqual.bad.asl
+  File TypingRule.ArrayLengthEqual.bad.asl, line 9, characters 4 to 5:
+      x = y;
+      ^
+  ASL Typing error: a subtype of array [[3]] of integer was expected,
+    provided array [[Color]] of integer.
+  [1]
+  $ aslref TypingRule.ReduceConstraint.asl
+  File TypingRule.ReduceConstraint.asl, line 6, characters 4 to 65:
+      var x : integer{3 * w, 0..5 * z - z - 2 * z,  w + z} = w + z;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ASL Typing error: a subtype of integer {0..(2 * z), (3 * w), (z + w)}
+    was expected, provided integer {0..2000}.
+  [1]
+  $ aslref TypingRule.ConstraintEqual.asl
+  $ aslref TypingRule.ConstraintsEqual.asl
+  $ aslref --no-exec TypingRule.ToIR.asl
+  $ aslref --no-exec TypingRule.Normalize.asl
+  $ aslref --no-exec TypingRule.UnitaryMonomialsToExpr.asl


### PR DESCRIPTION
* Fixed example "Pure and Symbolically Evaluable Side Effect Descriptors" + an explanation why `factorial` is a pure function.
* Fixed a bug in `Typing.ToIR`.
* Added examples to the Symbolic Equivalence Testing chapter.