### PR TITLE
[asl] Update accessor syntax

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -606,12 +606,12 @@ let override ==
     | IMPLEMENTATION; { Implementation })
 
 let accessors :=
-  | GETTER; getter=func_body;
-    SETTER; EQ; setter_arg=IDENTIFIER; setter=func_body;
-    { { getter; setter; setter_arg } }
-  | SETTER; EQ; setter_arg=IDENTIFIER; setter=func_body;
-    GETTER; getter=func_body;
-    { { getter; setter; setter_arg } }
+  | GETTER; getter=maybe_empty_stmt_list; end_semicolon;
+    SETTER; setter=maybe_empty_stmt_list; end_semicolon;
+    { { getter; setter } }
+  | SETTER; setter=maybe_empty_stmt_list; end_semicolon;
+    GETTER; getter=maybe_empty_stmt_list; end_semicolon;
+    { { getter; setter } }
 
 let decl :=
   | d=annotated (
@@ -674,9 +674,9 @@ let decl :=
       (* End *)
     )
   ); { [d] }
-  | ~=override; ACCESSOR; name=IDENTIFIER; ~=params_opt; ~=func_args; BIARROW; ~=ty;
+  | ~=override; ACCESSOR; name=IDENTIFIER; ~=params_opt; ~=func_args; BIARROW; setter_arg=IDENTIFIER; ~=as_ty;
     ~=accessor_body;
-    { desugar_accessor_pair override name params_opt func_args ty accessor_body }
+    { desugar_accessor_pair override name params_opt func_args setter_arg as_ty accessor_body }
 
 let accessor_body == BEGIN; ~=accessors; end_semicolon;
   { accessors }

--- a/asllib/desugar.ml
+++ b/asllib/desugar.ml
@@ -158,9 +158,10 @@ let desugar_case_stmt e0 cases otherwise =
       S_Seq (decl_x |> add_pos_from e0, cases_to_cond (var_ x) cases)
 (* End *)
 
-type accessor_pair = { getter : stmt; setter : stmt; setter_arg : identifier }
+type accessor_pair = { getter : stmt; setter : stmt }
 
-let desugar_accessor_pair override name parameters args ty accessor_pair =
+let desugar_accessor_pair override name parameters args setter_arg ty
+    accessor_pair =
   let getter_func =
     {
       name;
@@ -178,7 +179,7 @@ let desugar_accessor_pair override name parameters args ty accessor_pair =
     {
       name;
       parameters;
-      args = (accessor_pair.setter_arg, ty) :: args;
+      args = (setter_arg, ty) :: args;
       return_type = None;
       body = SB_ASL accessor_pair.setter;
       subprogram_type = ST_Setter;

--- a/asllib/desugar.mli
+++ b/asllib/desugar.mli
@@ -93,7 +93,6 @@ val desugar_case_stmt :
 type accessor_pair = {
   getter : stmt;  (** getter body *)
   setter : stmt;  (** setter body *)
-  setter_arg : identifier;  (** name of setter input argument *)
 }
 (** A getter/setter pair *)
 
@@ -102,9 +101,11 @@ val desugar_accessor_pair :
   identifier ->
   (identifier * ty option) list ->
   typed_identifier list ->
+  identifier ->
   ty ->
   accessor_pair ->
   decl list
-(** [desugar_accessor_pair override name params args ty accessor_pair] desugars
-    the accessor pair into two function declarations, with shared [override],
-    [name], [params], [args], and input/return type [ty]. *)
+(** [desugar_accessor_pair override name params args setter_arg ty accessor_pair]
+    desugars the accessor pair into two function declarations, with shared
+    [override], [name], [params], [args], and input/return type [ty].
+    The name of the setter argument is given by [setter_arg]. *)

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -962,7 +962,6 @@
 \newcommand\lhsaccessslices[0]{\text{slices}}
 \newcommand\accessorpairgetter[0]{\text{getter}}
 \newcommand\accessorpairsetter[0]{\text{setter}}
-\newcommand\accessorpairsetterarg[0]{\text{setter\_arg}}
 
 \newcommand\itemprefix[0]{\texttt{item}}
 
@@ -2767,6 +2766,7 @@
 \newcommand\vret[0]{\texttt{ret}}
 \newcommand\vreturntype[0]{\texttt{return\_type}}
 \newcommand\vs[0]{\texttt{s}}
+\newcommand\vsetterarg[0]{\texttt{setter\_arg}}
 \newcommand\vsetterargs[0]{\texttt{setter\_args}}
 \newcommand\vscopeone[0]{\texttt{scope1}}
 \newcommand\vscopetwo[0]{\texttt{scope2}}
@@ -3004,7 +3004,7 @@
 \newcommand\vread[0]{\texttt{read}}
 \newcommand\vmodify[0]{\texttt{modify}}
 \newcommand\vsetter[0]{\texttt{setter}}
-\newcommand\vgetter[0]{\texttt{sgetter}}
+\newcommand\vgetter[0]{\texttt{getter}}
 \newcommand\vcode[0]{\texttt{code}}
 \newcommand\vAbf[0]{\textbf{A}}
 \newcommand\vBbf[0]{\textbf{B}}

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -24,7 +24,7 @@ Subprogram declarations:
 \begin{flalign*}
 \Ndecl  \derives \ & \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nreturntype \parsesep \Nfuncbody &\\
 |\ & \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nfuncbody &\\
-|\ & \Taccessor \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Tbiarrow \parsesep \Nty &\\
+|\ & \Taccessor \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Tbiarrow \parsesep \Tidentifier \parsesep \Nasty &\\
    & \wrappedline\ \Naccessorbody &\\
 \Naccessorbody \derives \ & \Tbegin \parsesep \Naccessors \parsesep \Tend \parsesep \Tsemicolon&
 \end{flalign*}

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -15,7 +15,7 @@ Subprogram declarations have no associated semantics.
 \Ndecl  \derives \ & \Noverride \parsesep \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nreturntype \\
 & \wrappedline\ \Nrecurselimit \parsesep \Nfuncbody &\\
 |\ & \Noverride \parsesep \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nfuncbody &\\
-|\ & \Noverride \parsesep \Taccessor \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Tbiarrow \parsesep \Nty &\\
+|\ & \Noverride \parsesep \Taccessor \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Tbiarrow \parsesep \Tidentifier \parsesep \Nasty &\\
    & \wrappedline\ \Naccessorbody &\\
 \Naccessorbody \derives \ & \Tbegin \parsesep \Naccessors \parsesep \Tend \parsesep \Tsemicolon&
 \end{flalign*}
@@ -31,10 +31,10 @@ Subprogram declarations have no associated semantics.
 \Nfuncbody          \derives \ & \Tbegin \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 \Nmaybeemptystmtlist \derives \ & \emptysentence \;|\; \Nstmtlist &\\
 \Naccessors \derives \ &
-  \Tgetter \parsesep \Nfuncbody \parsesep
-  \Tsetter \parsesep \Teq \parsesep \Tidentifier \parsesep \Nfuncbody &\\
-|\ & \Tsetter \parsesep \Teq \parsesep \Tidentifier \parsesep \Nfuncbody \parsesep
-    \Tgetter \parsesep \Nfuncbody &\\
+  \Tgetter \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon \parsesep \\ & \wrappedline
+  \Tsetter \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
+|\ & \Tsetter \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon \parsesep \\ & \wrappedline
+    \Tgetter \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 \Noverride \derivesinline\ & \emptysentence \;|\; \Timpdef \;|\;\Timplementation &
 \end{flalign*}
 
@@ -85,8 +85,7 @@ In particular, rather than directly building the abstract syntax for accessors, 
 \left\{
   \begin{array}{rcl}
     \accessorpairgetter &:& \stmt, \\
-    \accessorpairsetter &:& \stmt,\\
-    \accessorpairsetterarg &:& \identifier
+    \accessorpairsetter &:& \stmt
 \end{array}
 \right\}
 } &
@@ -157,6 +156,7 @@ In particular, rather than directly building the abstract syntax for accessors, 
     \name,\\
     \astof{\vparamsopt},\\
     \astof{\vfuncargs},\\
+    \vsetterarg,\\
     \astof{\tty},\\
     \vaccessorpair
     \end{array}
@@ -169,7 +169,7 @@ In particular, rather than directly building the abstract syntax for accessors, 
       \begin{array}{l}
         \punnode{\Noverride}, \Taccessor, \Tidentifier(\name), \punnode{\Nparamsopt},  \\
         \wrappedline\ \punnode{\Nfuncargs},
-        \Tbiarrow, \punnode{\Nty}, \namednode{\vbody}{\Naccessorbody}
+        \Tbiarrow, \Tidentifier(\vsetterarg), \punnode{\Nasty}, \namednode{\vbody}{\Naccessorbody}
       \end{array}
     \right)}{\vparsednode}\right)
   \\ \astarrow \vastnode
@@ -384,8 +384,7 @@ transforms a parse node $\vparsednode$ into an $\accessorpair$.
   \left\{
   \begin{array}{rcl}
     \accessorpairgetter    &:& \astversion{\vgetter},\\
-    \accessorpairsetter    &:& \astversion{\vsetter},\\
-    \accessorpairsetterarg &:& \name
+    \accessorpairsetter    &:& \astversion{\vsetter}
   \end{array}
   \right\}
   }
@@ -393,8 +392,8 @@ transforms a parse node $\vparsednode$ into an $\accessorpair$.
   {
   \begin{array}{r}
     \buildaccessors(
-      \Tgetter, \namednode{\vgetter}{\Nfuncbody},
-      \Tsetter, \Tidentifier(\name), \namednode{\vsetter}{\Nfuncbody}
+      \Tgetter, \namednode{\vgetter}{\Nmaybeemptystmtlist}, \Tend, \Tsemicolon, \\
+      \Tsetter, \namednode{\vsetter}{\Nmaybeemptystmtlist}, \Tend, \Tsemicolon
     ) \\
     \astarrow \vaccessorpair
   \end{array}
@@ -411,8 +410,7 @@ transforms a parse node $\vparsednode$ into an $\accessorpair$.
   \left\{
   \begin{array}{rcl}
     \accessorpairgetter    &:& \astversion{\vgetter},\\
-    \accessorpairsetter    &:& \astversion{\vsetter},\\
-    \accessorpairsetterarg &:& \name
+    \accessorpairsetter    &:& \astversion{\vsetter}
   \end{array}
   \right\}
   }
@@ -420,8 +418,8 @@ transforms a parse node $\vparsednode$ into an $\accessorpair$.
   {
   \begin{array}{r}
     \buildaccessors(
-      \Tsetter, \Tidentifier(\name), \namednode{\vsetter}{\Nfuncbody},
-      \Tgetter, \namednode{\vgetter}{\Nfuncbody}
+      \Tsetter, \namednode{\vsetter}{\Nmaybeemptystmtlist}, \Tend, \Tsemicolon, \\
+      \Tgetter, \namednode{\vgetter}{\Nmaybeemptystmtlist}, \Tend, \Tsemicolon
     ) \\
     \astarrow \vaccessorpair
   \end{array}
@@ -433,17 +431,17 @@ transforms a parse node $\vparsednode$ into an $\accessorpair$.
 \hypertarget{def-desugaraccessorpair}{}
 The function
 \[
-\begin{array}{r}
-  \desugaraccessorpair(
-    \overname{\overrideinfo}{\voverride} \aslsep
-    \overname{\identifier}{\name} \aslsep
-    \overname{(\identifier \times \Some{\ty})^*}{\vparameters} \aslsep
-    \overname{\typedidentifier^*}{\vargs} \aslsep
-    \overname{\ty}{\tty} \aslsep
+  \desugaraccessorpair\left(
+    \begin{array}{l}
+    \overname{\overrideinfo}{\voverride} \aslsep \\
+    \overname{\identifier}{\name} \aslsep \\
+    \overname{(\identifier \times \Some{\ty})^*}{\vparameters} \aslsep \\
+    \overname{\typedidentifier^*}{\vargs} \aslsep \\
+    \overname{\identifier}{\vsetterarg} \aslsep \\
+    \overname{\ty}{\tty} \aslsep \\
     \overname{\accessorpair}{\vaccessorpair}
-  ) \\ \aslto
+  \end{array}\right) \aslto
   \overname{\decl^*}{\vastnode}
-\end{array}
 \]
 transforms an $\accessorpair$ into an AST node $\vastnode$.
 
@@ -465,7 +463,7 @@ transforms an $\accessorpair$ into an AST node $\vastnode$.
       \end{array}
       \right\}
   } \\\\
-  \vsetterargs \eqdef [(\vaccessorpair.\accessorpairsetterarg, \tty)] \concat \vargs \\\\
+  \vsetterargs \eqdef [(\vsetterarg, \tty)] \concat \vargs \\\\
   {
   \vsetter \eqdef
       \DFunc\left\{
@@ -484,10 +482,18 @@ transforms an $\accessorpair$ into an AST node $\vastnode$.
   }
 }{
   {
-  \begin{array}{r}
-    \desugaraccessorpair(\voverride, \name, \vparameters, \vargs, \tty, \vaccessorpair)
+    \desugaraccessorpair\left(
+      \begin{array}{l}
+        \voverride, \\
+        \name, \\
+        \vparameters, \\
+        \vargs, \\
+        \vsetterarg, \\
+        \tty, \\
+        \vaccessorpair
+      \end{array}
+    \right)
     \astarrow [\vgetter, \vsetter]
-  \end{array}
   }
 }
 \end{mathpar}

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -214,7 +214,7 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \Ndecl  \derives \ & \Noverride \parsesep \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nreturntype \parsesep \Nrecurselimit \parsesep &\\
                    & \wrappedline\ \Nfuncbody\\
 |\ & \Noverride \parsesep \Tfunc \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Nfuncbody &\\
-|\ & \Noverride \parsesep \Taccessor \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Tbiarrow \parsesep \Nty &\\
+|\ & \Noverride \parsesep \Taccessor \parsesep \Tidentifier \parsesep \Nparamsopt \parsesep \Nfuncargs \parsesep \Tbiarrow \parsesep \Tidentifier \parsesep \Nasty &\\
    & \wrappedline\ \Naccessorbody &\\
 |\ & \Ttype \parsesep \Tidentifier \parsesep \Tof \parsesep \Ntydecl \parsesep \Nsubtypeopt \parsesep \Tsemicolon &\\
 |\ & \Ttype \parsesep \Tidentifier \parsesep \Nsubtype \parsesep \Tsemicolon &\\
@@ -313,10 +313,10 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \hypertarget{def-naccessors}{}
 \begin{flalign*}
    \Naccessors \derives \ &
-      \Tgetter \parsesep \Nfuncbody \parsesep
-      \Tsetter \parsesep \Teq \parsesep \Tidentifier \parsesep \Nfuncbody &\\
-   |\ & \Tsetter \parsesep \Teq \parsesep \Tidentifier \parsesep \Nfuncbody \parsesep
-        \Tgetter \parsesep \Nfuncbody &\\
+      \Tgetter \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon \parsesep \\ & \wrappedline
+      \Tsetter \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
+   |\ & \Tsetter \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon \parsesep \\ & \wrappedline
+        \Tgetter \parsesep \Nmaybeemptystmtlist \parsesep \Tend \parsesep \Tsemicolon &\\
 \end{flalign*}
 
 \hypertarget{def-noverride}{}

--- a/asllib/tests/ASLDefinition.t/Accessor.asl
+++ b/asllib/tests/ASLDefinition.t/Accessor.asl
@@ -2,9 +2,9 @@
 var R : array [[32]] of bits(64);
 
 // Accessor, X
-accessor X(regno: integer{0..31}) <=> bits(64)
+accessor X(regno: integer{0..31}) <=> value: bits(64)
 begin
-  getter begin
+  getter
     if regno == 31 then
       return Zeros{64};
     else
@@ -12,7 +12,7 @@ begin
     end;
   end;
 
-  setter = value begin
+  setter
     if regno != 31 then
       R[[regno]] = value;
     end;

--- a/asllib/tests/ASLDefinition.t/EvaluationOrder.asl
+++ b/asllib/tests/ASLDefinition.t/EvaluationOrder.asl
@@ -14,13 +14,13 @@ begin
 end;
 
 // A helper accessor pair taking two arguments
-accessor Foo(a: integer, b: integer) <=> integer
+accessor Foo(a: integer, b: integer) <=> value_in: integer
 begin
-  getter begin
+  getter
     return 0;
   end;
 
-  setter = value_in begin
+  setter
     pass;
   end;
 end;

--- a/asllib/tests/ASLSyntaxReference.t/expr2.asl
+++ b/asllib/tests/ASLSyntaxReference.t/expr2.asl
@@ -1,21 +1,21 @@
-accessor g0_bits() <=> bits(4)
+accessor g0_bits() <=> value_in: bits(4)
 begin
-  getter begin
+  getter
     return '1000';
   end;
 
-  setter = value_in begin
+  setter
     Unreachable();
   end;
 end;
 
-accessor g1_bits(p: integer) <=> bits(4)
+accessor g1_bits(p: integer) <=> value_in: bits(4)
 begin
-  getter begin
+  getter
     return '1000'[p, 2:0];
   end;
 
-  setter = value_in begin
+  setter
     Unreachable();
   end;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SubprogramTypesClash.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SubprogramTypesClash.asl
@@ -1,9 +1,9 @@
-accessor X() <=> bits (4)
+accessor X() <=> value_in: bits (4)
 begin
-    getter begin
+    getter
         return '1000';
     end;
-    setter = value_in begin
+    setter
         Unreachable();
     end;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SubprogramTypesClash.bad1.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SubprogramTypesClash.bad1.asl
@@ -1,9 +1,9 @@
-accessor X() <=> bits (4)
+accessor X() <=> value_in: bits (4)
 begin
-    getter begin
+    getter
         return '1000';
     end;
-    setter = value_in begin
+    setter
         Unreachable();
     end;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypecheckDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypecheckDecl.asl
@@ -16,13 +16,13 @@ var rec: MyRecord;
 var exc: MyException;
 var coll: MyCollection;
 
-accessor Rec() <=> bits (64)
+accessor Rec() <=> values: bits (64)
 begin
-    getter begin
+    getter
         return rec.high_bits :: rec.low_bits;
     end;
 
-    setter = values begin
+    setter
         rec.high_bits = values[63:32];
         rec.low_bits = values[31:0];
     end;

--- a/asllib/tests/explicit-parameters.t/explicit-parameters.asl
+++ b/asllib/tests/explicit-parameters.t/explicit-parameters.asl
@@ -63,15 +63,15 @@ end;
 var _R : array [[31]] of bits(64);
 
 
-accessor X{N}(regno: integer) <=> bits(N)
+accessor X{N}(regno: integer) <=> value: bits(N)
 begin
-  getter begin
+  getter
     assert N == 64;
     assert 0 <= regno && regno <= 31;
     return _R[[regno]][0+:N];
   end;
 
-  setter = value begin
+  setter
     assert N == 64;
     assert 0 <= regno && regno <= 31;
     _R[[regno]] = value as bits(64);

--- a/asllib/tests/overriding.t/overriding-accessors.asl
+++ b/asllib/tests/overriding.t/overriding-accessors.asl
@@ -1,25 +1,25 @@
 var state : integer = 0;
 var called_override = FALSE;
 
-impdef accessor Foo() <=> integer
+impdef accessor Foo() <=> v: integer
 begin
-  getter begin
+  getter
     return state;
   end;
 
-  setter = v begin
+  setter
     state = v;
   end;
 end;
 
-implementation accessor Foo() <=> integer
+implementation accessor Foo() <=> v: integer
 begin
-  getter begin
+  getter
     called_override = TRUE;
     return state;
   end;
 
-  setter = v begin
+  setter
     state = 42;
   end;
 end;

--- a/asllib/tests/regressions.t/func2.asl
+++ b/asllib/tests/regressions.t/func2.asl
@@ -1,10 +1,10 @@
-accessor X(i:integer) <=> integer
+accessor X(i:integer) <=> v: integer
 begin
-  getter begin
+  getter
       return i;
   end;
 
-  setter = v begin
+  setter
       let internal_i = i;
       let internal_v = v;
   end;

--- a/asllib/tests/regressions.t/func3.asl
+++ b/asllib/tests/regressions.t/func3.asl
@@ -1,44 +1,44 @@
-accessor f1() <=> integer
+accessor f1() <=> v: integer
 begin
-  getter begin
+  getter
     return 3;
   end;
 
-  setter = v begin
+  setter
     assert v == 3;
   end;
 end;
 
-accessor f1b() <=> integer
+accessor f1b() <=> v: integer
 begin
-  getter begin
+  getter
     return 4;
   end;
 
-  setter = v begin
+  setter
     assert v == 4;
   end;
 end;
 
-accessor f2(x:integer) <=> integer
+accessor f2(x:integer) <=> v: integer
 begin
-  getter begin
+  getter
     return f1b() + x;
   end;
 
-  setter = v begin
+  setter
     f1b() = 4 * (v - x);
   end;
 end;
 
 
-accessor f3(x:integer) <=> integer
+accessor f3(x:integer) <=> v: integer
 begin
-  getter begin
+  getter
     return 0;
   end;
 
-  setter = v begin
+  setter
     assert x == 12;
     assert v == 13;
   end;

--- a/asllib/tests/regressions.t/getter_sub_tuple.asl
+++ b/asllib/tests/regressions.t/getter_sub_tuple.asl
@@ -1,12 +1,12 @@
 type MyBV of bits(8) { [5] bitfield };
 
-accessor F() <=> MyBV
+accessor F() <=> v: MyBV
 begin
-  getter begin
+  getter
     return Zeros{8} as MyBV;
   end;
 
-  setter = v begin
+  setter
     assert v[0] == '0';
   end;
 end;

--- a/asllib/tests/regressions.t/getter_subfield.asl
+++ b/asllib/tests/regressions.t/getter_subfield.asl
@@ -1,12 +1,12 @@
 type MyBV of bits(8) { [5] bitfield };
 
-accessor F() <=> MyBV
+accessor F() <=> v: MyBV
 begin
-  getter begin
+  getter
     return Zeros{8} as MyBV;
   end;
 
-  setter = v begin
+  setter
     assert v[0] == '0';
   end;
 end;

--- a/asllib/tests/regressions.t/getter_subfields.asl
+++ b/asllib/tests/regressions.t/getter_subfields.asl
@@ -1,12 +1,12 @@
 type MyBV of bits(8) { [5] b1, [4] b2 };
 
-accessor F() <=> MyBV
+accessor F() <=> v: MyBV
 begin
-  getter begin
+  getter
     return Zeros{8} as MyBV;
   end;
 
-  setter = v begin
+  setter
     assert v[0] == '0';
   end;
 end;

--- a/asllib/tests/regressions.t/getter_subslice.asl
+++ b/asllib/tests/regressions.t/getter_subslice.asl
@@ -1,12 +1,12 @@
 type MyBV of bits(8) { [5] bitfield };
 
-accessor F() <=> MyBV
+accessor F() <=> v: MyBV
 begin
-  getter begin
+  getter
     return Zeros{8} as MyBV;
   end;
 
-  setter = v begin
+  setter
     assert v[0] == '0';
   end;
 end;

--- a/asllib/tests/regressions.t/getter_without_setter.asl
+++ b/asllib/tests/regressions.t/getter_without_setter.asl
@@ -1,6 +1,6 @@
-accessor f() <=> integer
+accessor f() <=> v: integer
 begin
-  getter begin
+  getter
     return 0;
   end;
 end;

--- a/asllib/tests/regressions.t/nonempty-getter-called-without-slices.asl
+++ b/asllib/tests/regressions.t/nonempty-getter-called-without-slices.asl
@@ -1,10 +1,10 @@
-accessor f1() <=> integer
+accessor f1() <=> v: integer
 begin
-  getter begin
+  getter
     return 4;
   end;
 
-  setter = v begin
+  setter
     Unreachable();
   end;
 end;

--- a/asllib/tests/regressions.t/nonempty-setter-called-without-slices.asl
+++ b/asllib/tests/regressions.t/nonempty-setter-called-without-slices.asl
@@ -1,10 +1,10 @@
-accessor f1() <=> integer
+accessor f1() <=> v: integer
 begin
-  getter begin
+  getter
     return 4;
   end;
 
-  setter = v begin
+  setter
     pass;
   end;
 end;

--- a/asllib/tests/regressions.t/pstate-exp.asl
+++ b/asllib/tests/regressions.t/pstate-exp.asl
@@ -16,20 +16,20 @@ begin
   return 0 <= n && n < 4 ;
 end;
 
-accessor PSTATE() <=> ProcState
+accessor PSTATE() <=> v: ProcState
 begin
-  getter begin
+  getter
    return _PSTATE;
   end;
 
-  setter = v begin
+  setter
     _PSTATE = v;
   end;
 end;
 
-accessor PSTATE(n:integer) <=> bits(1)
+accessor PSTATE(n:integer) <=> v: bits(1)
 begin
-  getter begin
+  getter
     if isNZCV(n) then
       return _NZCV[n];
     else
@@ -37,7 +37,7 @@ begin
     end;
   end;
 
-  setter = v begin
+  setter
     if isNZCV(n) then
       _NZCV[n] = v;
     else
@@ -46,9 +46,9 @@ begin
   end;
 end;
 
-accessor PSTATE(n:integer,m:integer) <=> bits(2)
+accessor PSTATE(n:integer,m:integer) <=> v: bits(2)
 begin
-  getter begin
+  getter
     if isNZCV(n) && isNZCV(m) then
       return _NZCV[n,m];
     else
@@ -56,7 +56,7 @@ begin
     end;
   end;
 
-  setter = v begin
+  setter
     if isNZCV(n) && isNZCV(m) then
       _NZCV[n,m] = v;
     else
@@ -65,9 +65,9 @@ begin
   end;
 end;
 
-accessor PSTATE(n:integer,m:integer,o:integer) <=> bits(3)
+accessor PSTATE(n:integer,m:integer,o:integer) <=> v: bits(3)
 begin
-  getter begin
+  getter
     if isNZCV(n) && isNZCV(m) && isNZCV(o) then
       return _NZCV[n,m,o];
     else
@@ -75,7 +75,7 @@ begin
     end;
   end;
 
-  setter = v begin
+  setter
     if isNZCV(n) && isNZCV(m) && isNZCV(o) then
       _NZCV[n,m,o] = v;
     else
@@ -84,9 +84,9 @@ begin
   end;
 end;
 
-accessor PSTATE(n:integer,m:integer,o:integer,p:integer) <=> bits(4)
+accessor PSTATE(n:integer,m:integer,o:integer,p:integer) <=> v: bits(4)
 begin
-  getter begin
+  getter
     if isNZCV(n) && isNZCV(m) && isNZCV(o) && isNZCV(p) then
       return _NZCV[n,m,o,p];
     else
@@ -94,7 +94,7 @@ begin
     end;
   end;
 
-  setter = v begin
+  setter
     if isNZCV(n) && isNZCV(m) && isNZCV(o) && isNZCV(p) then
       _NZCV[n,m,o,p] = v;
     else

--- a/asllib/tests/regressions.t/setter_bitfields.asl
+++ b/asllib/tests/regressions.t/setter_bitfields.asl
@@ -1,12 +1,12 @@
 type MyBV of bits(8) { [5] bitfield };
 
-accessor F() <=> MyBV
+accessor F() <=> v: MyBV
 begin
-  getter begin
+  getter
     return Ones{8} as MyBV;
   end;
 
-  setter = v begin
+  setter
     assert v.bitfield == '0';
   end;
 end;

--- a/asllib/tests/regressions.t/setter_subfield.asl
+++ b/asllib/tests/regressions.t/setter_subfield.asl
@@ -1,13 +1,13 @@
 type MyBV of bits(8) { [5] bitfield };
 
 
-accessor F() <=> MyBV
+accessor F() <=> v: MyBV
 begin
-  getter begin
+  getter
     return Zeros{8} as MyBV;
   end;
 
-  setter = v begin
+  setter
     assert v[0] == '0';
   end;
 end;

--- a/asllib/tests/regressions.t/setter_subslice.asl
+++ b/asllib/tests/regressions.t/setter_subslice.asl
@@ -1,12 +1,12 @@
 type MyBV of bits(8) { [5] bitfield };
 
-accessor F() <=> MyBV
+accessor F() <=> v: MyBV
 begin
-  getter begin
+  getter
     return Zeros{8} as MyBV;
   end;
 
-  setter = v begin
+  setter
     assert v[0] == '0';
   end;
 end;

--- a/asllib/tests/regressions.t/setter_without_getter.asl
+++ b/asllib/tests/regressions.t/setter_without_getter.asl
@@ -1,6 +1,6 @@
-accessor f() <=> integer
+accessor f() <=> v: integer
 begin
-  setter = v begin
+  setter
     pass;
   end;
 end;

--- a/asllib/tests/regressions.t/subprogram-global-name-clash.asl
+++ b/asllib/tests/regressions.t/subprogram-global-name-clash.asl
@@ -1,12 +1,12 @@
 var X : integer = 0;
 
-accessor X() <=> integer
+accessor X() <=> v: integer
 begin
-  getter begin
+  getter
     return X;
   end;
 
-  setter = v begin
+  setter
     X = v;
   end;
 end;

--- a/asllib/tests/regressions.t/subprogram-local-name-clash.asl
+++ b/asllib/tests/regressions.t/subprogram-local-name-clash.asl
@@ -1,10 +1,10 @@
-accessor X() <=> integer
+accessor X() <=> v: integer
 begin
-  getter begin
+  getter
     return 0;
   end;
 
-  setter = v begin
+  setter
     pass;
   end;
 end;

--- a/asllib/tests/typing.t/CPositive12.asl
+++ b/asllib/tests/typing.t/CPositive12.asl
@@ -5,14 +5,14 @@ type ExtendType of enumeration
   {ExtendType_SXTB, ExtendType_SXTH, ExtendType_SXTW, ExtendType_SXTX,
   ExtendType_UXTB, ExtendType_UXTH, ExtendType_UXTW, ExtendType_UXTX};
 
-accessor X{width : ElementSize}(n : Rnum_X) <=> bits(width)
+accessor X{width : ElementSize}(n : Rnum_X) <=> value_in: bits(width)
 begin
-  getter begin
+  getter
       assert width IN {8,16,32,64};
       return n[width-1:0];
   end;
 
-  setter = value_in begin
+  setter
     Unreachable();
   end;
 end;

--- a/asllib/tests/typing.t/HExample1.asl
+++ b/asllib/tests/typing.t/HExample1.asl
@@ -1,12 +1,12 @@
-accessor ReadMem{size}(address : integer, unknown : boolean) <=> bits(size*8)
+accessor ReadMem{size}(address : integer, unknown : boolean) <=> value_in: bits(size*8)
 begin
-    getter begin
+    getter
       var value : bits(size*8) = Zeros{}();
       value = Read{size}(address, unknown);
       return value;
     end;
 
-    setter = value_in begin
+    setter
       Unreachable();
     end;
 end;

--- a/herd/libdir/asl-pseudocode/implementations.asl
+++ b/herd/libdir/asl-pseudocode/implementations.asl
@@ -521,26 +521,26 @@ end;
 
 // =============================================================================
 
-accessor _R (n : integer) <=> bits(64)
+accessor _R (n : integer) <=> value: bits(64)
 begin
-  getter begin
+  getter
     return read_register(n);
   end;
 
-  setter = value begin
+  setter
     write_register(n, value);
   end;
 end;
 
 // =============================================================================
 
-accessor SCTLR_EL1() <=> SCTLRType
+accessor SCTLR_EL1() <=> v: SCTLRType
 begin
-  getter begin
+  getter
     return Zeros{64};
   end;
 
-  setter = v begin
+  setter
     Unreachable();
   end;
 end;

--- a/herd/libdir/asl-pseudocode/pstate-exp.asl
+++ b/herd/libdir/asl-pseudocode/pstate-exp.asl
@@ -6,20 +6,20 @@ var _PSTATE_Z: bits(1);
 var _PSTATE_C: bits(1);
 var _PSTATE_V: bits(1);
 
-accessor PSTATE() <=> ProcState
+accessor PSTATE() <=> v: ProcState
 begin
-  getter begin
+  getter
     return _PSTATE;
   end;
 
-  setter = v begin
+  setter
     _PSTATE = v;
   end;
 end;
 
-accessor PSTATE(n:integer) <=> bits(1)
+accessor PSTATE(n:integer) <=> v: bits(1)
 begin
-  getter begin
+  getter
     if n == 3 then
       return _PSTATE_N;
     elsif n == 2 then
@@ -33,7 +33,7 @@ begin
     end;
   end;
 
-  setter = v begin
+  setter
     if n == 3 then
       _PSTATE_N = v;
     elsif n == 2 then
@@ -48,38 +48,38 @@ begin
   end;
 end;
 
-accessor PSTATE(n:integer,m:integer) <=> bits(2)
+accessor PSTATE(n:integer,m:integer) <=> v: bits(2)
 begin
-  getter begin
+  getter
     return PSTATE(n) :: PSTATE(m);
   end;
 
-  setter = v begin
+  setter
     PSTATE(n) = v[1];
     PSTATE(m) = v[0];
   end;
 end;
 
-accessor PSTATE(n:integer,m:integer,o:integer) <=> bits(3)
+accessor PSTATE(n:integer,m:integer,o:integer) <=> v: bits(3)
 begin
-  getter begin
+  getter
     return PSTATE(n) :: PSTATE(m) :: PSTATE(o);
   end;
 
-  setter = v begin
+  setter
     PSTATE(n) = v[2];
     PSTATE(m) = v[1];
     PSTATE(o) = v[0];
   end;
 end;
 
-accessor PSTATE(n:integer,m:integer,o:integer,p:integer) <=> bits(4)
+accessor PSTATE(n:integer,m:integer,o:integer,p:integer) <=> v: bits(4)
 begin
-  getter begin
+  getter
     return PSTATE(n) :: PSTATE(m) :: PSTATE(o) :: PSTATE(p);
   end;
 
-  setter = v begin
+  setter
     PSTATE(n) = v[3];
     PSTATE(m) = v[2];
     PSTATE(o) = v[1];

--- a/herd/tests/instructions/ASL/func2.litmus
+++ b/herd/tests/instructions/ASL/func2.litmus
@@ -3,13 +3,13 @@ ASL func02
 
 {}
 
-accessor X(i:integer) <=> integer
+accessor X(i:integer) <=> v: integer
 begin
-  getter begin
+  getter
       return i;
   end;
 
-  setter = v begin
+  setter
       let internal_i = i;
       let internal_v = v;
   end;

--- a/herd/tests/instructions/ASL/func3.litmus
+++ b/herd/tests/instructions/ASL/func3.litmus
@@ -3,25 +3,25 @@ ASL func3
 
 {}
 
-accessor f1() <=> integer
+accessor f1() <=> v: integer
 begin
-  getter begin
+  getter
     return 3;
   end;
 
-  setter = v begin
+  setter
     pass;
     // Hahaha, as if I was to do anything with the value
   end;
 end;
 
-accessor f2(x:integer) <=> integer
+accessor f2(x:integer) <=> v: integer
 begin
-  getter begin
+  getter
     return f1() + x;
   end;
 
-  setter = v begin
+  setter
     f1() = v + x;
   end;
 end;
@@ -29,24 +29,24 @@ end;
 var f3_storage: integer = -1;
 var f4_storage: integer = -1;
 
-accessor f3(x:integer) <=> integer
+accessor f3(x:integer) <=> v: integer
 begin
-  getter begin
+  getter
     return f3_storage;
   end;
 
-  setter = v begin
+  setter
     f3_storage = x;
   end;
 end;
 
-accessor f4(x:integer) <=> integer
+accessor f4(x:integer) <=> v: integer
 begin
-  getter begin
+  getter
     return f4_storage;
   end;
 
-  setter = v begin
+  setter
     f4_storage = v;
   end;
 end;


### PR DESCRIPTION
- Reduce `begin` keywords.
- Lift declaration of setter input argument name to top-level.

The new syntax looks like:
```
accessor Foo{params}(args) <=> value_in : ty
begin
  getter
    ...
  end;

  setter
    ...
  end;
end;
```