### PR TITLE
fix(lib): wait for process before calling channel functions

### DIFF
--- a/internal/lib/command.ml
+++ b/internal/lib/command.ml
@@ -93,14 +93,14 @@ let do_run must_succeed ?stdin:in_f ?stdout:out_f ?stderr:err_f bin args =
         bin (String.concat " " args) in
   let pid =
     Fun.protect
-      ~finally:(fun _ -> close_in_pipe () ; close_out_pipe () ; close_err_pipe ())
-      (fun _ ->
-        let pid = Unix.create_process bin (Array.of_list (bin :: args)) in_fd out_fd err_fd in
+      ~finally:(fun _ ->
         in_f () ;
+        close_in_pipe () ;
         out_f () ;
+        close_out_pipe () ;
         err_f () ;
-        pid
-      )
+        close_err_pipe ())
+      (fun _ -> Unix.create_process bin (Array.of_list (bin :: args)) in_fd out_fd err_fd)
   in
   let _, status = Unix.waitpid [] pid in
   match status with


### PR DESCRIPTION
Running `make test` directly will result in the following failure:

```
Fatal error: exception Failure("Herd returned stderr: Warning: File \"catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+acqrel_and_ctrl--async.litmus\": unrolling limit exceeded at L0, legal outcomes may be missing.")
```

`make test DUNE_PROFILE=dev` on the other hand succeeds (as is used in the CI).

I suspect the reason is the `dev` profile doesn't wait for the spawned `herd` process to finish before calling the function to collect the `stderr` result.

This commit moves the function calls to after the process is finished or an exception is raised.