### PR TITLE
[asl] Update signatures of `UInt` and `SInt`

### DIFF
--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -344,17 +344,23 @@ module NativeBackend (C : Config) = struct
         (let two_pow_n_minus_one = minus_one (pow_2 (e_var "N")) in
          let returns = integer_range (eoi 0) two_pow_n_minus_one in
          p
-           ~parameters:[ ("N", Some (integer_range (eoi 1) (eoi 128))) ]
+           ~parameters:[ ("N", None) ]
            ~args:[ ("x", t_bits "N") ]
            ~returns "UInt" uint);
-        (let two_pow_n_minus_one = pow_2 (minus_one (e_var "N")) in
+        (let var_N = e_var "N" in
+         let two_pow_n_minus_one = pow_2 (minus_one var_N) in
          let minus_two_pow_n_minus_one = neg two_pow_n_minus_one
          and two_pow_n_minus_one_minus_one = minus_one two_pow_n_minus_one in
+         let if_0_then_0_else else_expr =
+           cond_expr (binop `EQ_OP var_N zero_expr) zero_expr else_expr
+         in
          let returns =
-           integer_range minus_two_pow_n_minus_one two_pow_n_minus_one_minus_one
+           integer_range
+             (if_0_then_0_else minus_two_pow_n_minus_one)
+             (if_0_then_0_else two_pow_n_minus_one_minus_one)
          in
          p
-           ~parameters:[ ("N", Some (integer_range (eoi 1) (eoi 128))) ]
+           ~parameters:[ ("N", None) ]
            ~args:[ ("x", t_bits "N") ]
            ~returns "SInt" sint);
         p ~args:[ ("x", integer) ] ~returns:string "DecStr" dec_str;

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -3428,6 +3428,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
              tuples - these are used to check binary operator precedence and are
              removed during typechecking) *)
           parameters_of_expr ~env e
+      | E_Cond (e, e1, e2) ->
+          parameters_of_expr ~env e @ parameters_of_expr ~env e1
+          @ parameters_of_expr ~env e2
       | E_Tuple _ | _ ->
           Error.fatal_from (to_pos e) (Error.UnsupportedExpr (Static, e))
     in

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -2209,6 +2209,7 @@
 \newcommand\id[0]{\texttt{id}}
 \newcommand\idone[0]{\texttt{id1}}
 \newcommand\ids[0]{\texttt{ids}}
+\newcommand\idsp[0]{\texttt{ids'}}
 \newcommand\idsone[0]{\texttt{ids1}}
 \newcommand\idstwo[0]{\texttt{ids2}}
 \newcommand\idthree[0]{\texttt{id3}}

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -1101,6 +1101,7 @@ in the types of signature arguments (starting with the return type) yield the fo
 \verb|-D|      & $[\texttt{D}]$\\
 \verb|E+F|      & $[\texttt{E}, \texttt{F}]$\\
 \verb|(G)|      & $[\texttt{G}]$\\
+\verb|if H == 0 then I else J|      & $[\texttt{H}, \texttt{I}, \texttt{J}]$\\
 \end{tabular}
 \end{center}
 Notice that, since \verb|A| is declared as a global storage element, it is not extracted as a parameter
@@ -1140,6 +1141,15 @@ for the expression \verb|A| appearing in the return type.
       \item checking that $\es$ is a singleton list yields $\True$\ProseTerminateAs{\BadSubprogramDeclaration};
       \item view $\es$ as the singleton list for the expression $\ve$;
       \item applying $\paramsofexpr$ to $\ve$ $\ids$\ProseOrTypeError.
+    \end{itemize}
+
+  \item \AllApplyCase{econd}
+    \begin{itemize}
+      \item $\ve$ is a conditional expression, that is, $\ECond(\ve, \veone, \vetwo)$;
+      \item applying $\paramsofexpr$ to $\ve$ in $\tenv$ yields $\idsp$\ProseOrTypeError;
+      \item applying $\paramsofexpr$ to $\veone$ in $\tenv$ yields $\idsone$\ProseOrTypeError;
+      \item applying $\paramsofexpr$ to $\vetwo$ in $\tenv$ yields $\idstwo$\ProseOrTypeError;
+      \item define $\ids$ as the concatenation of $\idsp$, $\idsone$, and $\idstwo$.
     \end{itemize}
 
   \item \AllApplyCase{other}
@@ -1183,6 +1193,16 @@ for the expression \verb|A| appearing in the return type.
   \paramsofexpr(\tenv, \ve) \typearrow \ids \OrTypeError\
 }{
   \paramsofexpr(\tenv, \ETuple(\es)) \typearrow \ids
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[econd]{
+  \paramsofexpr(\tenv, \ve) \typearrow \idsp \OrTypeError\\\\
+  \paramsofexpr(\tenv, \veone) \typearrow \idsone \OrTypeError\\\\
+  \paramsofexpr(\tenv, \vetwo) \typearrow \idstwo \OrTypeError
+}{
+  \paramsofexpr(\tenv, \ECond(\ve, \veone, \vetwo)) \typearrow \overname{\idsp \concat \idsone \concat \idstwo}{\ids}
 }
 \end{mathpar}
 

--- a/asllib/libdir/stdlib.asl
+++ b/asllib/libdir/stdlib.asl
@@ -11,7 +11,7 @@
 // ======
 // Convert a bitvector to an unsigned integer, where bit 0 is LSB.
 
-func UInt{N: integer{1..128}} (x: bits(N)) => integer{0..2^N-1}
+func UInt{N} (x: bits(N)) => integer{0..2^N-1}
 begin
     var result: integer = 0;
     for i = 0 to N-1 do
@@ -26,13 +26,14 @@ end;
 // ======
 // Convert a 2s complement bitvector to a signed integer.
 
-func SInt{N: integer{1..128}} (x: bits(N)) => integer{-(2^(N-1)) .. 2^(N-1)-1}
+func SInt{N} (x: bits(N))
+  => integer{(if N == 0 then 0 else -(2^(N-1))) .. (if N == 0 then 0 else 2^(N-1)-1)}
 begin
     var result: integer = UInt(x);
     if N > 0 && x[N-1] == '1' then
         result = result - 2^N;
     end;
-    return result as {-(2^(N-1)) .. 2^(N-1)-1};
+    return result as {(if N == 0 then 0 else -(2^(N-1))) .. (if N == 0 then 0 else 2^(N-1)-1)};
 end;
 
 func Min(a: integer, b: integer) => integer
@@ -549,7 +550,7 @@ end;
 // A variant of AlignDownSize where the bitvector x is viewed as an unsigned
 // integer and the resulting integer is represented by its first N bits.
 
-func AlignDownSize{N: integer{1..128}}(x: bits(N), size: integer {1..2^N}) => bits(N)
+func AlignDownSize{N}(x: bits(N), size: integer {1..2^N}) => bits(N)
 begin
     return AlignDownSize(UInt(x), size)[:N];
 end;
@@ -559,7 +560,7 @@ end;
 // A variant of AlignUpSize where the bitvector x is viewed as an unsigned
 // integer and the resulting integer is represented by its first N bits.
 
-func AlignUpSize{N: integer{1..128}}(x: bits(N), size: integer {1..2^N}) => bits(N)
+func AlignUpSize{N}(x: bits(N), size: integer {1..2^N}) => bits(N)
 begin
     return AlignUpSize(UInt(x), size)[:N];
 end;
@@ -570,7 +571,7 @@ end;
 // to a multiple of size (not necessarily a power of 2).
 // Otherwise, return FALSE.
 
-func IsAlignedSize{N: integer{1..128}}(x: bits(N), size: integer {1..2^N}) => boolean
+func IsAlignedSize{N}(x: bits(N), size: integer {1..2^N}) => boolean
 begin
     return IsAlignedSize(UInt(x), size);
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ParametersOfExpr.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ParametersOfExpr.asl
@@ -1,9 +1,10 @@
 constant A = 15;
 
-func parameters_of_expressions{B, C, D, E, F, G}(
-    x: integer{A..B},
-    y: integer{C .. (- D)},
-    z: integer{E+F .. (G)}) =>
+func parameters_of_expressions{B, C, D, E, F, G, H, I, J}(
+    w: integer{A..B},
+    x: integer{C .. (- D)},
+    y: integer{E+F .. (G)},
+    z: integer{if H == 0 then I else J}) =>
     bits(A)
 begin
     return Ones{A};

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ParametersOfExpr.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ParametersOfExpr.bad.asl
@@ -1,7 +1,6 @@
 constant A = 15;
 
 func parameters_of_expressions{B, C, D, E}(
-    x: integer{A..(if TRUE then B else C)}, // Illegal expression in argument type
     z: integer{(D, E).item0}) => // Illegal expression in argument type
     bits(A)
 begin

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -724,10 +724,10 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.ParametersOfTy.asl
   $ aslref --no-exec TypingRule.ParametersOfExpr.asl
   $ aslref --no-exec TypingRule.ParametersOfExpr.bad.asl
-  File TypingRule.ParametersOfExpr.bad.asl, line 4, characters 19 to 40:
-      x: integer{A..(if TRUE then B else C)}, // Illegal expression in argument type
-                     ^^^^^^^^^^^^^^^^^^^^^
-  ASL Static Error: Unsupported expression if TRUE then B else C.
+  File TypingRule.ParametersOfExpr.bad.asl, line 4, characters 15 to 27:
+      z: integer{(D, E).item0}) => // Illegal expression in argument type
+                 ^^^^^^^^^^^^
+  ASL Static Error: Unsupported expression (D, E).item0.
   [1]
   $ aslref --no-exec TypingRule.FuncSigTypes.asl
   $ aslref --no-exec TypingRule.SubprogramTypesClash.asl

--- a/asllib/tests/stdlib.t/run.t
+++ b/asllib/tests/stdlib.t/run.t
@@ -49,7 +49,7 @@ Checking that --no-primitives option actually removes OCaml primitives
   ASL Execution error: Mismatch type: value -1 does not belong to type integer.
   [1]
   $ aslref --no-primitives no-primitives-test.asl
-  File ASL Standard Library, line 59, characters 11 to 16:
+  File ASL Standard Library, line 60, characters 11 to 16:
   ASL Execution error: Assertion failed: (__stdlib_local_a > 0).
   [1]
 

--- a/asllib/tests/stdlib.t/sint.asl
+++ b/asllib/tests/stdlib.t/sint.asl
@@ -1,4 +1,4 @@
-func test_sint {N: integer{1..127}} (bv: bits(N))
+func test_sint {N} (bv: bits(N))
 begin
   for i = 0 to 1 << N - 1 do
     assert SInt ('0' :: i[N-1:0]) == i;
@@ -7,7 +7,7 @@ begin
 end;
 
 // Same as test_sint, but only test 2^m numbers on each side of the interval
-func test_big_sint {N: integer{1..127}} (bv: bits(N), m: integer {0..N})
+func test_big_sint {N} (bv: bits(N), m: integer {0..N})
 begin
   for i = 0 to 1 << m do
     assert SInt ('0' :: i[N-1:0]) == i;
@@ -32,8 +32,9 @@ begin
   assert SInt('000') == 0;
   assert SInt('0') == 0;
   assert SInt('1') == -1;
+  assert SInt('') == 0;
 
-  for N = 1 to 10 do
+  for N = 0 to 10 do
     test_sint{N}(Zeros{N});
   end;
 
@@ -47,6 +48,11 @@ begin
   test_big_sint{64}(Zeros{64}, 5);
   test_big_sint{65}(Zeros{65}, 5);
   test_big_sint{127}(Zeros{127}, 5);
+  test_big_sint{128}(Zeros{128}, 5);
+  test_big_sint{129}(Zeros{129}, 5);
+  test_big_sint{255}(Zeros{255}, 5);
+  test_big_sint{256}(Zeros{256}, 5);
+  test_big_sint{257}(Zeros{257}, 5);
 
   return 0;
 end;

--- a/asllib/tests/stdlib.t/uint.asl
+++ b/asllib/tests/stdlib.t/uint.asl
@@ -1,6 +1,6 @@
 // Test UInt on all bitvectors of length N;
 // bv is a phantom argument, only there to enable the parameter N
-func test_uint {N: integer{1..127}} (bv: bits(N))
+func test_uint {N} (bv: bits(N))
 begin
   for i = 0 to 1 << N do
     assert UInt (i[N:0]) == i;
@@ -8,7 +8,7 @@ begin
 end;
 
 // Same as test_uint, but only test 2^m numbers on each side of the interval
-func test_big_uint {N: integer{1..127}} (bv: bits(N), m: integer {0..N})
+func test_big_uint {N} (bv: bits(N), m: integer {0..N})
 begin
   for i = 0 to 1 << m do
     assert UInt (i[N:0]) == i;
@@ -21,9 +21,10 @@ end;
 func main () => integer
 begin
   assert UInt('110') == 6;
+  assert UInt('') == 0;
   assert UInt('100000000') == 0x100;
 
-  for N = 1 to 10 do
+  for N = 0 to 10 do
     test_uint{N}(Zeros{N});
   end;
 
@@ -37,6 +38,11 @@ begin
   test_big_uint{64}(Zeros{64}, 5);
   test_big_uint{65}(Zeros{65}, 5);
   test_big_uint{127}(Zeros{127}, 5);
+  test_big_uint{128}(Zeros{128}, 5);
+  test_big_uint{129}(Zeros{129}, 5);
+  test_big_uint{255}(Zeros{255}, 5);
+  test_big_uint{256}(Zeros{256}, 5);
+  test_big_uint{257}(Zeros{257}, 5);
 
   return 0;
 end;

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -763,8 +763,6 @@ module Make (C : Config) = struct
       let pow_2 = binop `POW (lit 2) in
       let t_named x = T_Named x |> with_pos in
       let side_effecting = true in
-      let uint_sint_parameter_type =
-        Asllib.ASTUtils.integer_range' (lit 1) (lit 128) |> with_pos in
       let uint_returns = int_ctnt (lit 0) (minus_one (pow_2 (var "N")))
       and sint_returns =
         let big_pow = pow_2 (minus_one (var "N")) in
@@ -801,11 +799,11 @@ module Make (C : Config) = struct
           write_memory_gen;
         (* Translations *)
         p1r "UInt"
-          ~parameters:[ ("N", Some uint_sint_parameter_type) ]
+          ~parameters:[ ("N", None) ]
           ("x", bv_var "N")
           ~returns:uint_returns uint;
         p1r "SInt"
-          ~parameters:[ ("N", Some uint_sint_parameter_type) ]
+          ~parameters:[ ("N", None) ]
           ("x", bv_var "N")
           ~returns:sint_returns sint;
         (* Misc *)


### PR DESCRIPTION
The new signatures are:
```
func UInt{N} (x: bits(N)) => integer{0..2^N-1}
func SInt{N} (x: bits(N))
  => integer{(if N == 0 then 0 else -(2^(N-1))) .. (if N == 0 then 0 else 2^(N-1)-1)}
```
As a result, the constraints on the parameters `N` of `Align{Down,Up}Size` and `IsAlignedSize` are also removed.