### PR TITLE
ASL fix expression approximation overflow bug

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1255,10 +1255,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
   (* End *)
 
   and annotate_type ?(decl = false) ~(loc : 'a annotated) env ty : ty * SES.t =
-    let () =
-      if false then
-        Format.eprintf "Annotating@ %a@ in env:@ %a@." PP.pp_ty ty pp_env env
-    in
+    let () = if false then Format.eprintf "Annotating@ type %a@." PP.pp_ty ty in
     let here t = add_pos_from ~loc:ty t in
     best_effort (ty, SES.empty) @@ fun _ ->
     match ty.desc with
@@ -2824,7 +2821,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
 
   let annotate_local_decl_item ~loc (env : env) ty ldk ?e ldi =
     let () =
-      if false then Format.eprintf "Annotating %a.@." PP.pp_local_decl_item ldi
+      if false then
+        Format.eprintf "Annotating LDI %a with type %a.@." PP.pp_local_decl_item
+          ldi PP.pp_ty ty
     in
     match ldi with
     (* Begin LDVar *)
@@ -2872,7 +2871,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       if false then
         match s.desc with
         | S_Seq _ -> ()
-        | _ -> Format.eprintf "@[<3>Annotating@ @[%a@]@]@." PP.pp_stmt s
+        | _ -> Format.eprintf "@[<3>Annotating@ stmt@ @[%a@]@]@." PP.pp_stmt s
     in
     let here x = add_pos_from ~loc:s x and loc = to_pos s in
     match s.desc with

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -3038,3 +3038,5 @@
 \newcommand\isstatic[0]{\texttt{is\_static}}
 \newcommand\vLone[0]{\texttt{L1}}
 \newcommand\vLtwo[0]{\texttt{L2}}
+\newcommand\plf[0]{\texttt{plf}}
+\newcommand\vsapprox[0]{\texttt{s\_approx}}

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -1167,9 +1167,11 @@ based on the \approximationdirectionterm\ $\vapprox$.
     \item $\ve$ is a \binopexpression{$\op$}{$\veone$}{$\vetwo$};
     \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\veone$}{$\vsone$};
     \item \Proseapproxexpr{$\tenv$}{$\vapprox$}{$\vetwo$}{$\vstwo$};
-    \item \Proseeqdef{$\vs$}{the set obtained by applying $\binopliterals$ to $\op$ and
-      every pair of integers from the $\vsone$ and $\vstwo$, respectively,
-      and maintaining only the values for which $\binopliterals$ does not produce a \typingerrorterm{}}.
+    \item applying $\annotateconstraintbinop$ to $\tenv$, $\vsone$, and $\vstwo$ yields $(\vsp, \plf)$;
+    \item applying $\approxconstraints$ to $\tenv$, $\vapprox$, and $\vsp$ yields $\vsapprox$;
+    \item \Proseeqdef{$\vs$}{
+      $\vsapprox$ if $\plf$ is $\PrecisionFull$ or $\plf$ is $\PrecisionLost$ and $\vapprox$ is $\Under$,
+      and as the set of all integers otherwise}.
   \end{itemize}
 
   \item \AllApplyCase{cond}
@@ -1237,11 +1239,14 @@ types.
 \inferrule[binop]{
   \approxexpr(\tenv, \vapprox, \veone) \typearrow \vsone\\
   \approxexpr(\tenv, \vapprox, \vetwo) \typearrow \vstwo\\
+  \annotateconstraintbinop(\tenv, \vsone, \vstwo) \typearrow (\vsp, \plf)\\
+  \approxconstraints(\tenv, \vapprox, \vsp) \typearrow \vsapprox\\
   {
-    \begin{array}{rl}
-  \vs \eqdef \{ \vz \not\in \TTypeError \;|\; & \vzone\in\vsone, \vztwo\in\vstwo, \\
-    & \binopliterals(\op, \lint(\vzone), \lint(\vztwo)) \typearrow \vz\}
-    \end{array}
+  \vs \eqdef
+  \begin{cases}
+    \vsapprox & \text{if }\plf = \PrecisionFull \lor (\plf = \PrecisionLost \land \vapprox = \Under)\\
+    \Z        & \text{if }\plf = \PrecisionLost \land \vapprox = \Over
+  \end{cases}
   }
 }{
   \approxexpr(\tenv, \vapprox, \overname{\EBinop(\op, \veone, \vetwo)}{\ve}) \typearrow \vs

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -1245,6 +1245,7 @@ types.
   \vs \eqdef
   \begin{cases}
     \vsapprox & \text{if }\plf = \PrecisionFull \lor (\plf = \PrecisionLost \land \vapprox = \Under)\\
+    % Transliteration comment: instead of the symbol CannotOverApproximate, we use the set of all integers.
     \Z        & \text{if }\plf = \PrecisionLost \land \vapprox = \Over
   \end{cases}
   }

--- a/asllib/tests/regressions.t/approx-expr-binop.asl
+++ b/asllib/tests/regressions.t/approx-expr-binop.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    let x: integer{0..2^64 - 1} = ARBITRARY: integer{0..2^64 - 1};
+    constant offset = 10;
+    var x_offset: integer{x..x + 10} = x as integer{x..x + offset};
+    return 0;
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -598,3 +598,4 @@ Left-hand sides
     ^^^^^^^^^^^^^^^^^^
   ASL Typing error: multiple writes to "bv".
   [1]
+  $ aslref approx-expr-binop.asl

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -355,11 +355,8 @@ module Domain = struct
   (** The [StaticApprox] module creates constant approximation of integer
       constraints as sets of integers. *)
   module StaticApprox = struct
-    (** The two possible types of approximations. *)
+    (** The two possible types of approximation. *)
     type approx = Over | Under
-
-    let approx_to_string = function Over -> "over" | Under -> "under"
-    let _ = approx_to_string
 
     exception CannotOverApproximate
     (** Raised if over approximation is not possible. *)

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -399,13 +399,13 @@ module Domain = struct
       | E_Binop ((#StaticOperations.int3_binop as op), e1, e2) -> (
           let s1 = approx_expr approx env e1 |> int_set_to_int_constraints in
           let s2 = approx_expr approx env e2 |> int_set_to_int_constraints in
-          let s, plf =
+          let s', plf =
             SOp.annotate_constraint_binop ~loc:ASTUtils.dummy_annotated env op
               s1 s2
           in
           match (plf, approx) with
           | Precision_Full, _ | Precision_Lost _, Under ->
-              approx_constraints approx env s
+              approx_constraints approx env s'
           | Precision_Lost _, Over -> raise CannotOverApproximate)
       | E_Cond (_econd, e2, e3) -> (
           let s2 = approx_expr approx env e2


### PR DESCRIPTION
The following specification causes aslref to hand, since it tries to approximate `x + 10` for every value of `0..2^64 - 1`
```
func main() => integer
begin
    let x: integer{0..2^64 - 1} = ARBITRARY: integer{0..2^64 - 1};
    constant offset = 10;
    var x_offset: integer{x..x + 10} = x as integer{x..x + offset};
    return 0;
end;
```
* The fix involves applying constraint approximation instead of the explicit Cartesian product.
* Updated the reference.
* Added the specification above to the regression tests.