### PR TITLE
[ASL] added more source locations

### DIFF
--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -79,6 +79,16 @@ let add_pos_from_st pos desc =
   if pos.desc == desc then pos else { pos with desc }
 
 let add_pos_from pos desc = { pos with desc }
+
+let add_pos_range_from pos_from pos_to desc =
+  let () = assert (pos_from.version = pos_to.version) in
+  {
+    desc;
+    pos_start = pos_from.pos_start;
+    pos_end = pos_to.pos_end;
+    version = pos_from.version;
+  }
+
 let map_desc f thing = f thing |> add_pos_from thing
 let map_desc_st' thing f = f thing.desc |> add_pos_from thing
 

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -79,6 +79,10 @@ val add_pos_from_pos_of : (string * int * int * int) * 'a -> 'a annotated
 val add_pos_from : 'a annotated -> 'b -> 'b annotated
 (** [add_pos_from loc v] is [v] with the location data from [loc]. *)
 
+val add_pos_range_from : 'a annotated -> 'a annotated -> 'b -> 'b annotated
+(** [add_pos_range_from loc_from loc_to v] is [v] with the location data
+    given by the range of locations starting at [loc_from] and ending to [loc_to]. *)
+
 val add_pos_from_st : 'a annotated -> 'a -> 'a annotated
 (** [add_pos_from_st a' a] is [a] with the location from [a'].
 

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -193,7 +193,7 @@ module NativeBackend (C : Config) = struct
       positions
     |> slices_to_positions Fun.id
 
-  let read_from_bitvector slices bv =
+  let read_from_bitvector ~loc slices bv =
     let positions = slices_to_positions slices in
     let max_pos = List.fold_left int_max 0 positions in
     let () =
@@ -206,7 +206,7 @@ module NativeBackend (C : Config) = struct
       | NV_Literal (L_BitVector bv) when Bitvector.length bv > max_pos -> bv
       | NV_Literal (L_Int i) -> Bitvector.of_z (max_pos + 1) i
       | _ ->
-          let ( ~! ) = add_dummy_annotation in
+          let ( ~! ) = add_pos_from loc in
           let t = integer_range zero_expr (expr_of_int max_pos) in
           mismatch_type bv [ T_Bits (~!(E_ATC (~!(E_Var "-"), t)), []) ]
     in

--- a/asllib/backend.mli
+++ b/asllib/backend.mli
@@ -166,7 +166,8 @@ module type S = sig
   type value_range = value * value
   (** Represents a range by its first accessed index and its length. *)
 
-  val read_from_bitvector : value_range list -> value -> value m
+  val read_from_bitvector :
+    loc:'a AST.annotated -> value_range list -> value -> value m
   (** Read a slice (represented by a list of value ranges) from a bitvector. *)
 
   val write_to_bitvector : value_range list -> value -> value -> value m

--- a/asllib/tests/types.ml
+++ b/asllib/tests/types.ml
@@ -134,12 +134,12 @@ let lca_examples () =
   let bits_4 = !!(T_Bits (!$4, [])) in
   let bits_2 = !!(T_Bits (!$2, [])) in
 
-  assert (lowest_common_ancestor empty_env bits_4 bits_2 = None);
+  assert (lowest_common_ancestor ~loc:bits_4 empty_env bits_4 bits_2 = None);
 
   let integer_4 = integer_exact !$4 in
   let integer_2 = integer_exact !$2 in
 
-  let lca = lowest_common_ancestor empty_env integer_4 integer_2 in
+  let lca = lowest_common_ancestor ~loc:bits_4 empty_env integer_4 integer_2 in
   assert (Option.is_some lca);
   ()
 

--- a/asllib/types.mli
+++ b/asllib/types.mli
@@ -75,7 +75,7 @@ val get_structure : env -> ty -> ty
 (** The structure of a type is the primitive type that can hold the same
     values. *)
 
-val parameterized_ty : identifier -> ty
+val parameterized_ty : loc:'a annotated -> identifier -> ty
 (** Builds an parameterized integer type from a declared variable. *)
 
 val to_well_constrained : ty -> ty
@@ -116,7 +116,7 @@ val type_clashes : env -> ty -> ty -> bool
 val subprogram_clashes : env -> func -> func -> bool
 (** Subprogram clashing relation. *)
 
-val lowest_common_ancestor : env -> ty -> ty -> ty option
+val lowest_common_ancestor : loc:'a annotated -> env -> ty -> ty -> ty option
 (** Lowest common ancestor. *)
 
 val type_equal : env -> ty -> ty -> bool

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -433,7 +433,7 @@ module Make (C : Config) = struct
     let set_field name v record =
       M.op (Op.ArchOp (ASLOp.SetField name)) record (freeze v)
 
-    let read_from_bitvector positions bvs =
+    let read_from_bitvector ~loc:_ positions bvs =
       let positions = Asllib.ASTUtils.slices_to_positions v_as_int positions in
       let arch_op1 = ASLOp.BVSlice positions in
       M.op1 (Op.ArchOp1 arch_op1) bvs


### PR DESCRIPTION
* Replaced some dummy source locations with source code locations.
* Added `add_pos_range_from` to enable source code locations that start with one construct and end at another.
* There are still some dummy source locations in the parsers.