### PR TITLE
[asl] Permit more forms on left-hand sides

### DIFF
--- a/asllib/doc/ASLRefALP3.1ChangeLog.tex
+++ b/asllib/doc/ASLRefALP3.1ChangeLog.tex
@@ -157,3 +157,8 @@ The signatures are now as follows:
 \end{lstlisting}
 
 The constraints are also removed from the signatures of \texttt{AlignDownSize} and \texttt{AlignUpSize}.
+
+\subsection{ASL-824: relax left-hand sides}
+
+The permitted syntax for left-hand sides of assignments has been relaxed.
+See \chapref{Syntax} (particularly non-terminals $\Nlexpr$ and $\Nstmt$) for details.

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -490,11 +490,11 @@
 \newcommand\Nignoredoridentifier[0]{\hyperlink{def-nignoredoridentifier}{\nonterminal{ignored\_or\_identifier}}}
 \newcommand\Nty[0]{\hyperlink{def-nty}{\nonterminal{ty}}}
 \newcommand\Nexpr[0]{\hyperlink{def-nexpr}{\nonterminal{expr}}}
+\newcommand\Naccess[0]{\hyperlink{def-naccess}{\nonterminal{access}}}
 \newcommand\Nbasiclexpr[0]{\hyperlink{def-nbasiclexpr}{\nonterminal{basic\_lexpr}}}
-\newcommand\Nnestedfields[0]{\hyperlink{def-nnestedfields}{\nonterminal{nested\_fields}}}
-\newcommand\Nslicedbasiclexpr[0]{\hyperlink{def-nslicedbasiclexpr}{\nonterminal{sliced\_basic\_lexpr}}}
-\newcommand\Ndiscardorslicedbasiclexpr[0]{\hyperlink{def-ndiscardorslicedbasiclexpr}{\nonterminal{discard\_or\_sliced\_basic\_lexpr}}}
+\newcommand\Ndiscardorbasiclexpr[0]{\hyperlink{def-ndiscardorbasiclexpr}{\nonterminal{discard\_or\_basic\_lexpr}}}
 \newcommand\Ndiscardoridentifier[0]{\hyperlink{def-ndiscardoridentifier}{\nonterminal{discard\_or\_identifier}}}
+\newcommand\Nsetteraccess[0]{\hyperlink{def-nsetteraccess}{\nonterminal{setter\_access}}}
 \newcommand\Nlexpr[0]{\hyperlink{def-nlexpr}{\nonterminal{lexpr}}}
 \newcommand\Nfields[0]{\hyperlink{def-nfields}{\nonterminal{fields}}}
 \newcommand\Nfieldsopt[0]{\hyperlink{def-nfieldsopt}{\nonterminal{fields\_opt}}}
@@ -615,6 +615,9 @@
 \newcommand\spec[0]{\hyperlink{ast-spec}{\textsf{spec}}}
 \newcommand\typedidentifier[0]{\hyperlink{ast-typedidentifier}{\textsf{typed\_identifier}}}
 \newcommand\lhsaccess[0]{\hyperlink{ast-lhsaccess}{\textsf{lhs\_access}}}
+\newcommand\fieldorarrayaccess[0]{\hyperlink{ast-fieldorarrayaccess}{\textsf{field\_or\_array\_access}}}
+\newcommand\FieldAccess[0]{\hyperlink{ast-fieldaccess}{\textsf{FieldAccess}}}
+\newcommand\ArrayAccess[0]{\hyperlink{ast-arrayaccess}{\textsf{ArrayAccess}}}
 \newcommand\localdeclkeyword[0]{\hyperlink{ast-localdeclkeyword}{\textsf{local\_decl\_keyword}}}
 \newcommand\globaldeclkeyword[0]{\hyperlink{ast-globaldeclkeyword}{\textsf{global\_decl\_keyword}}}
 \newcommand\localdeclitem[0]{\hyperlink{ast-localdeclitem}{\textsf{local\_decl\_item}}}
@@ -788,6 +791,8 @@
 \newcommand\builddeclitem[0]{\hyperlink{build-declitem}{\textfunc{build\_decl\_item}}}
 \newcommand\makesetter[0]{\hyperlink{def-makesetter}{\textfunc{make\_setter}}}
 \newcommand\desugarsetter[0]{\hyperlink{def-desugarsetter}{\textfunc{desugar\_setter}}}
+\newcommand\desugarsettersetfields[0]{\hyperlink{def-desugarsettersetfields}{\textfunc{desugar\_setter\_setfields}}}
+\newcommand\readmodifywrite[0]{\hyperlink{def-readmodifywrite}{\textfunc{read\_modify\_write}}}
 \newcommand\desugaraccessorpair[0]{\hyperlink{def-desugaraccessorpair}{\textfunc{desugar\_accessor\_pair}}}
 \newcommand\buildlooplimit[0]{\hyperlink{build-looplimit}{\textfunc{build\_looplimit}}}
 \newcommand\buildrecurselimit[0]{\hyperlink{build-recurselimit}{\textfunc{build\_recurselimit}}}
@@ -796,9 +801,8 @@
 \newcommand\buildexpr[0]{\hyperlink{build-expr}{\textfunc{build\_expr}}}
 \newcommand\buildlexpr[0]{\hyperlink{build-lexpr}{\textfunc{build\_lexpr}}}
 \newcommand\buildbasiclexpr[0]{\hyperlink{build-basiclexpr}{\textfunc{build\_basic\_lexpr}}}
-\newcommand\buildnestedfields[0]{\hyperlink{build-nestedfields}{\textfunc{build\_nested\_fields}}}
-\newcommand\buildslicedbasiclexpr[0]{\hyperlink{build-slicedbasiclexpr}{\textfunc{build\_sliced\_basic\_lexpr}}}
-\newcommand\builddiscardorslicedbasiclexpr[0]{\hyperlink{build-discardorslicedbasiclexpr}{\textfunc{build\_discard\_or\_sliced\_basic\_lexpr}}}
+\newcommand\builddiscardorbasiclexpr[0]{\hyperlink{build-discardorbasiclexpr}{\textfunc{build\_discard\_or\_basic\_lexpr}}}
+\newcommand\buildaccess[0]{\hyperlink{build-access}{\textfunc{build\_access}}}
 \newcommand\builddiscardoridentifier[0]{\hyperlink{build-discardoridentifier}{\textfunc{build\_discard\_or\_identifier}}}
 \newcommand\desugarlhsaccess[0]{\hyperlink{def-desugarlhsaccess}{\textfunc{desugar\_lhs\_access}}}
 \newcommand\desugarlhsaccessopt[0]{\hyperlink{def-desugarlhsaccessopt}{\textfunc{desugar\_lhs\_access\_opt}}}
@@ -956,9 +960,7 @@
 \newcommand\callparams[0]{\text{params}}
 \newcommand\callargs[0]{\text{args}}
 \newcommand\callcalltype[0]{\text{call\_type}}
-\newcommand\lhsaccessbase[0]{\text{base}}
-\newcommand\lhsaccessindex[0]{\text{index}}
-\newcommand\lhsaccessfields[0]{\text{fields}}
+\newcommand\lhsaccessaccess[0]{\text{access}}
 \newcommand\lhsaccessslices[0]{\text{slices}}
 \newcommand\accessorpairgetter[0]{\text{getter}}
 \newcommand\accessorpairsetter[0]{\text{setter}}
@@ -2423,11 +2425,13 @@
 \newcommand\va[0]{\texttt{a}}
 \newcommand\vapprox[0]{\texttt{approx}}
 \newcommand\vap[0]{\texttt{a'}}
+\newcommand\vaccess[0]{\texttt{access}}
 \newcommand\vaccessors[0]{\texttt{accessors}}
 \newcommand\vaccessorpair[0]{\texttt{accessor\_pair}}
 \newcommand\vabsname[0]{\texttt{absolute\_name}}
 \newcommand\vabsslice[0]{\texttt{absolute\_slice}}
 \newcommand\vabsslices[0]{\texttt{absolute\_slices}}
+\newcommand\vsetteraccess[0]{\texttt{setter\_access}}
 \newcommand\vslicesasindices[0]{\texttt{slices\_as\_indices}}
 \newcommand\vabsoluteparent[0]{\texttt{absolute\_parent}}
 \newcommand\vabsbitfields[0]{\texttt{abs\_bitfields}}
@@ -2613,7 +2617,6 @@
 \newcommand\vh[0]{\texttt{h}}
 \newcommand\vhp[0]{\texttt{h'}}
 \newcommand\vlhsaccess[0]{\texttt{lhs\_access}}
-\newcommand\vlhsaccesses[0]{\texttt{lhs\_accesses}}
 \newcommand\vlhsaccessopt[0]{\texttt{lhs\_access\_opt}}
 \newcommand\vlhsaccessopts[0]{\texttt{lhs\_access\_opts}}
 \newcommand\vlocal[0]{\texttt{local}}
@@ -2713,7 +2716,6 @@
 \newcommand\vnamet[0]{\texttt{name\_t}}
 \newcommand\vneg[0]{\texttt{neg}}
 \newcommand\vnested[0]{\texttt{nested}}
-\newcommand\vnestedfields[0]{\texttt{nested\_fields}}
 \newcommand\vnextlimitopt[0]{\texttt{next\_limit\_opt}}
 \newcommand\vnew[0]{\texttt{new}}
 \newcommand\vnonmatching[0]{\texttt{nonmatching}}
@@ -2820,9 +2822,7 @@
 \newcommand\newses[0]{\texttt{new\_ses}}
 \newcommand\vslice[0]{\texttt{slice}}
 \newcommand\vnewslice[0]{\texttt{new\_slice}}
-\newcommand\vsliced[0]{\texttt{sliced}}
 \newcommand\vsliceasts[0]{\texttt{slice\_asts}}
-\newcommand\vslicedbasiclexpr[0]{\texttt{sliced\_basic\_lexpr}}
 \newcommand\vsliceone[0]{\texttt{slice1}}
 \newcommand\vslicetwo[0]{\texttt{slice2}}
 \newcommand\vslices[0]{\texttt{slices}}

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -326,6 +326,10 @@ The function
 \]
 transforms an $\lhsaccess$ on an identifier $\name$ into an AST node $\vlexpr$.
 
+\ExampleDef{Desugaring a left-hand side access}
+\listingref{DesugarLHSAccess} shows an example of desugaring an $\lhsaccess$.
+\ASLListing{Desugaring a left-hand side access}{DesugarLHSAccess}{\syntaxtests/ASTRule.DesugarLHSAccess.asl}
+
 \begin{mathpar}
 \inferrule{
   \vlexprs_0 \eqdef \LEVar(\name) \\
@@ -361,6 +365,10 @@ The function
   \desugarlhstuple(\overname{\langle\lhsaccess\rangle^*}{\vlhsaccessopts}) \;\aslto\; \overname{\lexpr}{\vlexpr}
 \]
 transforms a list of \optional{} $\lhsaccess$ elements into an AST node $\vlexpr$. \\
+
+\ExampleDef{Desugaring a left-hand side tuple}
+\listingref{DesugarLHSTuple} shows an example of desugaring a left-hand side tuple.
+\ASLListing{Desugaring a left-hand side tuple}{DesugarLHSTuple}{\syntaxtests/ASTRule.DesugarLHSTuple.asl}
 
 \begin{mathpar}
 \inferrule{
@@ -401,6 +409,10 @@ The function
   \desugarlhsfieldstuple(\overname{\identifier}{\id} \aslsep \overname{\langle\identifier\rangle^*}{\fieldopts}) \;\aslto\; \overname{\lexpr}{\vlexpr}
 \]
 transforms an assignment to a tuple of fields $\fields$ of variable $\id$ into an AST node $\vlexpr$. \\
+
+\ExampleDef{Desugaring a left-hand side fields tuple}
+\listingref{DesugarLHSFieldsTuple} shows an example of desugaring a left-hand side fields tuple.
+\ASLListing{Desugaring a left-hand side fields tuple}{DesugarLHSFieldsTuple}{\syntaxtests/ASTRule.DesugarLHSFieldsTuple.asl}
 
 \begin{mathpar}
 \inferrule{

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -64,28 +64,27 @@ using $\texttt{eval\_expr}$ to evaluate it.
 \begin{flalign*}
 \Nlexpr \derives\
    & \Tminus &\\
-|\ & \Nslicedbasiclexpr &\\
-|\ & \Tlpar \parsesep \Clisttwo{\Ndiscardorslicedbasiclexpr} \parsesep \Trpar &\\
+|\ & \Nbasiclexpr &\\
+|\ & \Tlpar \parsesep \Clisttwo{\Ndiscardorbasiclexpr} \parsesep \Trpar &\\
 |\ & \Tidentifier \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clisttwo{\Tidentifier} \parsesep \Trbracket &\\
 |\ & \Tidentifier \parsesep \Tdot \parsesep \Tlpar \parsesep \Clisttwo{\Ndiscardoridentifier} \parsesep \Trpar &
 \end{flalign*}
 
 \begin{flalign*}
 \Nbasiclexpr \derives\
-   & \Tidentifier \parsesep \Nnestedfields &\\
-|\ & \Tidentifier \parsesep \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket \parsesep \Nnestedfields &
+   & \Tidentifier \parsesep \Naccess &\\
+|\ & \Tidentifier \parsesep \Naccess \parsesep \Nslices &
 \end{flalign*}
 
 \begin{flalign*}
-\Nnestedfields \derives\ & \emptysentence \;|\; \Tdot \parsesep \Tidentifier \parsesep \Nnestedfields &
+\Naccess \derives\
+   & \emptysentence  &\\
+|\ & \Tdot \parsesep \Tidentifier \parsesep \Naccess &\\
+|\ & \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket \parsesep \Naccess &\\
 \end{flalign*}
 
 \begin{flalign*}
-\Nslicedbasiclexpr \derives\ & \Nbasiclexpr \;|\; \Nbasiclexpr \parsesep \Nslices &
-\end{flalign*}
-
-\begin{flalign*}
-\Ndiscardorslicedbasiclexpr \derives\ & \Tminus \;|\; \Nslicedbasiclexpr &
+\Ndiscardorbasiclexpr \derives\ & \Tminus \;|\; \Nbasiclexpr &
 \end{flalign*}
 
 \begin{flalign*}
@@ -103,13 +102,16 @@ In particular, rather than directly building the abstract syntax for these \assi
 {
 \left\{
   \begin{array}{rcl}
-    \lhsaccessbase &:& \identifier, \\
-    \lhsaccessindex &:& \expr?,\\
-    \lhsaccessfields &:& \identifier^{*},\\
+    \lhsaccessaccess &:& \fieldorarrayaccess^{*}, \\
     \lhsaccessslices &:& \slice^{*}
 \end{array}
 \right\}
 } &
+\hypertarget{ast-fieldorarrayaccess}{}
+\hypertarget{ast-fieldaccess}{}
+\hypertarget{ast-arrayaccess}{}
+\\
+\fieldorarrayaccess \derives\ & \FieldAccess(\identifier)\ |\ \ArrayAccess(\expr)
 \end{flalign*}
 
 \ASTRuleDef{LExpr}
@@ -127,21 +129,21 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[sliced\_basic\_lexpr]{
-  \desugarlhsaccess(\astof{\vslicedbasiclexpr}) \astarrow \vastnode
+\inferrule[basic\_lexpr]{
+  \desugarlhsaccess(\astof{\vbasiclexpr}) \astarrow \vastnode
 }{
-  \buildlexpr(\Nlexpr(\punnode{\Nslicedbasiclexpr})) \astarrow \vastnode
+  \buildlexpr(\Nlexpr(\punnode{\Nbasiclexpr})) \astarrow \vastnode
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[multi\_lexpr]{
-  \buildclist[\builddiscardorslicedbasiclexpr](\vlexprs) \astarrow \vlexprasts \\
+  \buildclist[\builddiscardorbasiclexpr](\vlexprs) \astarrow \vlexprasts \\
   \desugarlhstuple(\vlexprasts) \astarrow \vastnode
 }{
   {
   \begin{array}{r}
-  \buildlexpr(\Nlexpr(\Tlpar, \namednode{\vlexprs}{\Clisttwo{\Ndiscardorslicedbasiclexpr}}, \Trpar)) \\
+  \buildlexpr(\Nlexpr(\Tlpar, \namednode{\vlexprs}{\Clisttwo{\Ndiscardorbasiclexpr}}, \Trpar)) \\
   \astarrow \vastnode
   \end{array}
   }
@@ -179,105 +181,81 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \hypertarget{build-basiclexpr}{}
 The function
 \[
-  \buildbasiclexpr(\overname{\parsenode{\Nbasiclexpr}}{\vparsednode}) \;\aslto\; \overname{\lhsaccess}{\vastnode}
+  \buildbasiclexpr(\overname{\parsenode{\Nbasiclexpr}}{\vparsednode}) \;\aslto\; (\overname{\identifier}{\vbase} \aslsep \overname{\lhsaccess}{\vlhsaccess})
 \]
-transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
+transforms a parse node $\vparsednode$ into a pair of AST nodes, $\vbase$ and $\vlhsaccess$.
 
 \begin{mathpar}
-\inferrule[no\_index]{
-  \vastnode \eqdef \left\{
+\inferrule[no\_slices]{
   {
-  \begin{array}{rcl}
-    \lhsaccessbase   &:& \id,\\
-    \lhsaccessindex  &:& \None,\\
-    \lhsaccessfields &:& \astof{\vnestedfields},\\
-    \lhsaccessslices &:& \emptylist
-  \end{array}
+  \vlhsaccess \eqdef
+    \left\{
+      \begin{array}{rcl}
+        \lhsaccessaccess &:& \astof{\vaccess},\\
+        \lhsaccessslices &:& \emptylist
+      \end{array}
+    \right\}
   }
-  \right\}
 }{
-  \buildbasiclexpr(\Nbasiclexpr(\Tidentifier(\id), \punnode{\Nnestedfields})) \astarrow
-  \vastnode
+  \buildbasiclexpr(\Nbasiclexpr(\Tidentifier(\vbase),\punnode{\Naccess})) \astarrow
+  (\vbase, \vlhsaccess)
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[index]{
-  \vastnode \eqdef \left\{
+\inferrule[slices]{
   {
-  \begin{array}{rcl}
-    \lhsaccessbase   &:& \id,\\
-    \lhsaccessindex  &:& \langle \astof{\vexpr} \rangle,\\
-    \lhsaccessfields &:& \astof{\vnestedfields},\\
-    \lhsaccessslices &:& \emptylist
-  \end{array}
+  \vlhsaccess \eqdef
+    \left\{
+      \begin{array}{rcl}
+              \lhsaccessaccess &:& \astof{\vaccess},\\
+              \lhsaccessslices &:& \astof{\vslices}
+      \end{array}
+    \right\}
   }
-  \right\}
 }{
-  \buildbasiclexpr(\Nbasiclexpr(\Tidentifier(\id), \Tllbracket, \punnode{\Nexpr}, \Trrbracket, \punnode{\Nnestedfields})) \astarrow
-  \vastnode
+  \buildbasiclexpr(\Nbasiclexpr(\Tidentifier(\vbase),\punnode{\Naccess}, \punnode{\Nslices})) \astarrow
+  (\vbase, \vlhsaccess)
 }
 \end{mathpar}
 
-\ASTRuleDef{NestedFields}
-\hypertarget{build-nestedfields}{}
+\ASTRuleDef{Access}
+
+\hypertarget{build-access}{}
 The function
 \[
-  \buildnestedfields(\overname{\parsenode{\Nnestedfields}}{\vparsednode}) \;\aslto\; \overname{\identifier^*}{\vastnode}
+  \buildaccess(\overname{\parsenode{\Naccess}}{\vparsednode}) \;\aslto
+  \overname{\fieldorarrayaccess^*}{\vastnode}
 \]
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[empty]{}{
-  \buildnestedfields(\Nnestedfields(\emptysentence)) \astarrow
-  \overname{\emptylist}{\vastnode}
+  \buildaccess(\Naccess(\emptysentence)) \astarrow \overname{\emptylist}{\vastnode}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[non\_empty]{}{
-  {
-    \begin{array}{r}
-      \buildnestedfields(\Nnestedfields(\Tdot, \Tidentifier(\id), \punnode{\Nnestedfields})) \astarrow\\
-      \overname{[\id] \concat \astof{\vnestedfields}}{\vastnode}
-    \end{array}
-  }
-}
-\end{mathpar}
-
-\ASTRuleDef{SlicedBasicLexpr}
-\hypertarget{build-slicedbasiclexpr}{}
-The function
-\[
-  \buildslicedbasiclexpr(\overname{\parsenode{\Nslicedbasiclexpr}}{\vparsednode}) \;\aslto\; \overname{\lhsaccess}{\vastnode}
-\]
-transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
-
-\begin{mathpar}
-\inferrule[no\_slices]{}{
-  \buildslicedbasiclexpr(\Nslicedbasiclexpr(\punnode{\Nbasiclexpr})) \astarrow
-  \overname{\astof{\vbasiclexpr}}{\vastnode}
+\inferrule[field\_access]{}{
+  \buildaccess(\Naccess(\Tdot, \Tidentifier(\vfield), \punnode{\Naccess})) \astarrow
+  \overname{[\FieldAccess(\vfield)] \concat \astof{\vaccess}}{\vastnode}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[slices]{}{
-  {
-    \begin{array}{r}
-      \buildslicedbasiclexpr(\Nslicedbasiclexpr(\punnode{\Nbasiclexpr}, \punnode{\Nslices})) \astarrow \\
-      \overname{\astof{\vbasiclexpr}[\lhsaccessslices \mapsto \astof{\vslices}]}{\vastnode}
-    \end{array}
-  }
+\inferrule[array\_access]{}{
+  \buildaccess(\Naccess(\Tllbracket, \punnode{\Nexpr}, \Trrbracket, \punnode{\Naccess})) \astarrow
+  \overname{[\ArrayAccess(\astof{\vexpr})] \concat \astof{\vaccess}}{\vastnode}
 }
 \end{mathpar}
 
-\ASTRuleDef{DiscardOrSlicedBasicLexpr}
+\ASTRuleDef{DiscardOrBasicLexpr}
 
-\hypertarget{build-discardorslicedbasiclexpr}{}
+\hypertarget{build-discardorbasiclexpr}{}
 The function
 \[
 \begin{array}{r}
-  \builddiscardorslicedbasiclexpr(\overname{\parsenode{\Ndiscardorslicedbasiclexpr}}{\vparsednode}) \;\aslto\\
+  \builddiscardorbasiclexpr(\overname{\parsenode{\Ndiscardorbasiclexpr}}{\vparsednode}) \;\aslto\\
   \overname{\langle\lhsaccess\rangle}{\vastnode}
 \end{array}
 \]
@@ -285,16 +263,16 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[discard]{}{
-  \builddiscardorslicedbasiclexpr(\Ndiscardorslicedbasiclexpr(\Tminus)) \astarrow \overname{\None}{\vastnode}
+  \builddiscardorbasiclexpr(\Ndiscardorbasiclexpr(\Tminus)) \astarrow \overname{\None}{\vastnode}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[sliced\_basic]{}{
+\inferrule[basic]{}{
   {
     \begin{array}{r}
-      \builddiscardorslicedbasiclexpr(\Ndiscardorslicedbasiclexpr(\punnode{\Nslicedbasiclexpr})) \astarrow \\
-      \overname{\langle \astof{\vslicedbasiclexpr} \rangle}{\vastnode}
+      \builddiscardorbasiclexpr(\Ndiscardorbasiclexpr(\punnode{\Nbasiclexpr})) \astarrow \\
+      \overname{\langle \astof{\vbasiclexpr} \rangle}{\vastnode}
     \end{array}
   }
 }
@@ -334,7 +312,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 This section defines three desugaring relations which produce assignable expression abstract syntax, that is, $\lexpr$.
 They are used in \secref{AssignableExpressionsAbstractSyntaxBuilders} to build $\lexpr$ abstract syntax.
 \begin{itemize}
-  \item $\desugarlhsaccess$, which desugars an $\lhsaccess$ into an $\lexpr$.
+  \item $\desugarlhsaccess$, which desugars a pair consisting of an $\identifier$ and an $\lhsaccess$ into an $\lexpr$.
   \item $\desugarlhstuple$, which desugars a tuple of optional $\lhsaccess$ elements into an $\lexpr$.
     This represents a multi-assignment of a tuple value, where $\None$ means that element of the tuple is discarded.
   \item $\desugarlhsfieldstuple$, which desugars a multi-assignment of a tuple value to multiple fields of an identifier.
@@ -344,51 +322,35 @@ They are used in \secref{AssignableExpressionsAbstractSyntaxBuilders} to build $
 \hypertarget{def-desugarlhsaccess}{}
 The function
 \[
-  \desugarlhsaccess(\overname{\lhsaccess}{\vlhsaccess}) \;\aslto\; \overname{\lexpr}{\vlexpr}
+  \desugarlhsaccess(\overname{\identifier}{\name}, \overname{\lhsaccess}{\vlhsaccess}) \;\aslto\; \overname{\lexpr}{\vlexpr}
 \]
-transforms an $\lhsaccess$ into an AST node $\vlexpr$.
+transforms an $\lhsaccess$ on an identifier $\name$ into an AST node $\vlexpr$.
 
 \begin{mathpar}
-\inferrule[index\_none]{
-  \vlexprs_0 \eqdef \EVar(\id) \\
-  i \in 1..|\vfields|: \vlexprs_i \eqdef \LESetField(\vlexprs_{i-1}, \vfields_i) \\
-  \vsliced \eqdef
-  \choice{\vslices = \emptylist}{\vlexprs_{|\vfields|}}{\ESlice(\vlexprs_{|\vfields|}, \vslices)} \\
+\inferrule{
+  \vlexprs_0 \eqdef \LEVar(\name) \\
+  {
+  i \in 1..|\vaccess|: \vlexprs_i \eqdef
+    \begin{cases}
+      \LESetField(\vlexprs_{i-1}, \vfield) \\
+        \qquad \text{if } \vaccess_i = \FieldAccess(\vfield) \\
+      \LESetArray(\vlexprs_{i-1}, \vexpr) \\
+        \qquad \text{if } \vaccess_i = \ArrayAccess(\vexpr) \\
+    \end{cases}
+  } \\
+  \vlexpr \eqdef
+  \choice{\vslices = \emptylist}{\vlexprs_{|\vaccess|}}{\LESlice(\vlexprs_{|\vaccess|}, \vslices)}
 }{
   \desugarlhsaccess\overname{
     \left\{
       {
         \begin{array}{rcl}
-          \lhsaccessbase &:& \id, \\
-          \lhsaccessindex &:& \None,\\
-          \lhsaccessfields &:& \vfields,\\
+          \lhsaccessaccess &:& \vaccess, \\
           \lhsaccessslices &:& \vslices
         \end{array}
       }
     \right\}
-  }{\vlhsaccess} \astarrow \overname{\vsliced}{\vlexpr}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[index\_some]{
-  \vlexprs_0 \eqdef \LESetArray(\EVar(\id), \vindex) \\
-  i \in 1..|\vfields|: \vlexprs_i \eqdef \LESetField(\vlexprs_{i-1}, \vfields_i) \\
-  \vsliced \eqdef
-  \choice{\vslices = \emptylist}{\vlexprs_{|\vfields|}}{\ESlice(\vlexprs_{|\vfields|}, \vslices)} \\
-}{
-  \desugarlhsaccess\overname{
-    \left\{
-      {
-        \begin{array}{rcl}
-          \lhsaccessbase &:& \id, \\
-          \lhsaccessindex &:& \langle\vindex\rangle,\\
-          \lhsaccessfields &:& \vfields,\\
-          \lhsaccessslices &:& \vslices
-        \end{array}
-      }
-    \right\}
-  }{\vlhsaccess} \astarrow \overname{\vsliced}{\vlexpr}
+  }{\vlhsaccess} \astarrow \vlexpr
 }
 \end{mathpar}
 
@@ -402,9 +364,6 @@ transforms a list of \optional{} $\lhsaccess$ elements into an AST node $\vlexpr
 
 \begin{mathpar}
 \inferrule{
-  \vlhsaccesses \eqdef \filteroptionlist(\vlhsaccessopts) \\
-  \vids \eqdef [i \in 1..|\vlhsaccesses|: \vlhsaccesses_i.\lhsaccessbase] \\
-  \checknoduplicates(\vids) \typearrow \True \OrTypeError \\
   i \in 1..|\vlhsaccessopts|: \desugarlhsaccessopt(\vlhsaccessopt_i) \astarrow \vlexpr_i \\
   \vlexprs \eqdef [i \in 1..|\vlhsaccessopts|: \vlexpr_i]
 }{

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -300,9 +300,12 @@ $\nvint(42)$, and $\newenv$ is such that \texttt{x} is bound to $\nvint(3)$.
 \subsection{Syntax}
 \begin{flalign*}
 \Nstmt \derives \
-   & \Ncall \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Ncall \parsesep \Tdot \parsesep \Tidentifier \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+   & \Ncall \parsesep \Nsetteraccess \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Ncall \parsesep \Nsetteraccess \parsesep \Nslices \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Ncall \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clisttwo{{\Tidentifier}} \parsesep \Trbracket \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+\Nsetteraccess \derives \
+   & \emptysentence &\\
+|\ & \Tdot \parsesep \Tidentifier \parsesep \Nsetteraccess &
 \end{flalign*}
 
 \ASTRuleDef{MakeSetter}
@@ -335,80 +338,136 @@ The helper function
 \[
 \desugarsetter(
   \overname{\call}{\vcall} \aslsep
-  \overname{\identifier^*}{\fields} \aslsep
+  \overname{\lhsaccess}{\vlhsaccess} \aslsep
   \overname{\expr}{\rhs}) \aslto \overname{\stmt}{\news}
 \]
-builds a statement $\news$ from an assignment of expression $\rhs$ to a setter invocation $\vcall$$\name$ with field accesses $\fields$.
+builds a statement $\news$ from an assignment of expression $\rhs$ to a setter invocation $\vcall.\callname$ with accesses given by $\vlhsaccess$.
 
 \begin{mathpar}
 \inferrule[empty]{
-  \fields \eqname \emptylist \\
+  \vlhsaccess.\lhsaccessaccess = \emptylist \\
+  \vlhsaccess.\lhsaccessslices = \emptylist \\\\
   \makesetter(\vcall, \rhs) \aslto \vcallp
 }{
-  \desugarsetter(\vcall, \fields, \rhs)
+  \desugarsetter(\vcall, \vlhsaccess, \rhs)
   \astarrow
   \SCall(\vcallp)
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[singleton]{
-  \fields \eqname [\field] \\
+\inferrule[non\_empty]{
+  \vlhsaccess.\lhsaccessaccess \neq \emptylist \lor
+  \vlhsaccess.\lhsaccessslices \neq \emptylist \\\\
   \vx \in \Identifiers \text{ is fresh} \\\\
-  \setcalltype(\vcall, \STGetter) \aslto \vgetter \\\\
-  \vread \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \None, \langle\vgetter\rangle) \\\\
-  \vmodify \eqdef \SAssign(\LESetField(\LEVar(\vx), \field), \rhs) \\\\
-  \makesetter(\vcall, \EVar(\vx)) \aslto \vsetter
+  \desugarlhsaccess(\vx, \vlhsaccess) \astarrow \lhs \\
+  \vmodify \eqdef \SAssign(\lhs, \rhs) \\
+  \readmodifywrite(\vcall, \vx, \vmodify) \astarrow \vcallp
 }{
-  \desugarsetter(\vcall, \fields, \rhs)
+  \desugarsetter(\vcall, \vlhsaccess, \rhs)
   \astarrow
-  \SSeq (\SSeq(\vread, \vmodify), \SCall(\vsetter))
+  \vcallp
 }
 \end{mathpar}
 
+\ASTRuleDef{DesugarSetterSetfields}
+\hypertarget{def-desugarsettersetfields}{}
+The helper function
+\[
+\desugarsettersetfields(
+  \overname{\call}{\vcall} \aslsep
+  \overname{\identifier^*}{\vfields} \aslsep
+  \overname{\expr}{\rhs}) \aslto \overname{\stmt}{\news}
+\]
+builds a statement $\news$ from an assignment of $\rhs$ to a setter invocation $\vcall.\callname$ with concatenated field accesses given by $\vfields$.
+
 \begin{mathpar}
-\inferrule[multiple]{
-  \listlen{\fields} > 1 \\
+\inferrule{
   \vx \in \Identifiers \text{ is fresh} \\\\
+  \lhs \eqdef \LESetFields(\LEVar(\vx), \vfields) \\
+  \vmodify \eqdef \SAssign(\lhs, \rhs) \\
+  \readmodifywrite(\vcall, \vx, \vmodify) \astarrow \vcallp
+}{
+  \desugarsettersetfields(\vcall, \fields, \rhs)
+  \astarrow
+  \vcallp
+}
+\end{mathpar}
+
+\ASTRuleDef{ReadModifyWrite}
+\hypertarget{def-readmodifywrite}{}
+The helper function
+\[
+\readmodifywrite(
+  \overname{\call}{\vcall} \aslsep
+  \overname{\identifier}{\vx} \aslsep
+  \overname{\stmt}{\vmodify}) \aslto \overname{\stmt}{\news}
+\]
+builds a sequence of statements to read from the getter invocation $\vcall.\callname$, modify the resulting value using $\vmodify$, and write it to a setter invocation $\vcall.\callname$.
+
+\begin{mathpar}
+\inferrule{
   \setcalltype(\vcall, \STGetter) \aslto \vgetter \\\\
-  \vread \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \None, \langle\vgetter\rangle) \\\\
-  \vmodify \eqdef \SAssign(\LESetFields(\LEVar(\vx), \fields), \rhs) \\\\
+  \vread \eqdef \SDecl(\LDKVar, \LDIVar(\vx), \None, \langle\ECall(\vgetter)\rangle) \\\\
   \makesetter(\vcall, \EVar(\vx)) \aslto \vsetter
 }{
-  \desugarsetter(\vcall, \fields, \rhs)
+  \readmodifywrite(\vcall, \vx, \vmodify)
   \astarrow
-  \SSeq (\SSeq(\vread, \vmodify), \SCall(\vsetter))
+  \overname{\SSeq (\SSeq(\vread, \vmodify), \SCall(\vsetter))}{\news}
 }
 \end{mathpar}
 
 \ASTRuleDef{SetterAssign}
 \begin{mathpar}
-\inferrule{
-  \desugarsetter(\astof{\vcall}, \emptylist, \astof{\vexpr}) \astarrow \vastnode
+\inferrule[no\_slices]{
+  \buildaccess(\vsetteraccess) \astarrow \vaccess \\\\
+  {
+  \vlhsaccess \eqdef
+    \left\{
+      \begin{array}{rcl}
+        \lhsaccessaccess &:& \vaccess,\\
+        \lhsaccessslices &:& \emptylist
+      \end{array}
+    \right\}
+  } \\
+  \desugarsetter(\astof{\vcall}, \vlhsaccess, \astof{\vexpr}) \astarrow \vastnode
 }{
-  \buildstmt(\overname{\Nstmt(\punnode{\call}, \Teq, \punnode{\Nexpr}, \Tsemicolon
+  \buildstmt(\overname{\Nstmt(\punnode{\Ncall}, \namednode{\vsetteraccess}{\Nsetteraccess}, \Teq, \punnode{\Nexpr}, \Tsemicolon
   )}{\vparsednode})
   \astarrow \vastnode
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule{
-  \desugarsetter(\astof{\vcall}, [\vfield], \astof{\vexpr}) \astarrow \vastnode
+\inferrule[slices]{
+  \buildaccess(\vsetteraccess) \astarrow \vaccess \\\\
+  {
+  \vlhsaccess \eqdef
+    \left\{
+      \begin{array}{rcl}
+        \lhsaccessaccess &:& \vaccess,\\
+        \lhsaccessslices &:& \astof{\vslices}
+      \end{array}
+    \right\}
+  } \\
+  \desugarsetter(\astof{\vcall}, \vlhsaccess, \astof{\vexpr}) \astarrow \vastnode
 }{
-  \buildstmt(\overname{\Nstmt(\punnode{\call}, \Tdot,
-    \Tidentifier(\vfield), \Teq, \punnode{\Nexpr}, \Tsemicolon
-  )}{\vparsednode})
-  \astarrow \vastnode
+  {
+    \begin{array}{r}
+      \buildstmt(\overname{\Nstmt(\punnode{\Ncall}, \namednode{\vsetteraccess}{\Nsetteraccess}, \punnode{\Nslices}, \Teq, \punnode{\Nexpr}, \Tsemicolon
+      )}{\vparsednode})
+      \astarrow \\ \vastnode
+    \end{array}
+  }
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule{
+\inferrule[setfields]{
   \buildclist[\buildidentity](\vfields) \astarrow \vfieldasts \\
-  \desugarsetter(\astof{\vcall}, \vfieldasts, \astof{\vexpr}) \astarrow \vastnode
+  \desugarsettersetfields(\astof{\vcall}, \vfieldasts, \astof{\vexpr}) \astarrow \vastnode
 }{
-  \buildstmt(\overname{\Nstmt(\punnode{\call}, \Tdot,
+  \buildstmt(\overname{\Nstmt(\punnode{\Ncall}, \Tdot,
     \Tlbracket, \namednode{\vfields}{\Clisttwo{\Tidentifier}}, \Trbracket, \Teq, \punnode{\Nexpr}, \Tsemicolon
   )}{\vparsednode})
   \astarrow \vastnode

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -387,8 +387,8 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 |\ & \Tassert \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \option{\Nasty} \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Nlexpr \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Ncall \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
-|\ & \Ncall \parsesep \Tdot \parsesep \Tidentifier \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Ncall \parsesep \Nsetteraccess \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
+|\ & \Ncall \parsesep \Nsetteraccess \parsesep \Nslices \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Ncall \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clisttwo{{\Tidentifier}} \parsesep \Trbracket \parsesep \Teq \parsesep \Nexpr \parsesep \Tsemicolon &\\
 |\ & \Nlocaldeclkeyword \parsesep \Ndeclitem \parsesep \Nasty \parsesep \Teq \parsesep \Nelidedparamcall \parsesep \Tsemicolon &\\
 |\ & \Tvar \parsesep \Ndeclitem \parsesep \option{\Nasty} \parsesep \option{\Teq \parsesep \Nexpr} \parsesep \Tsemicolon &\\
@@ -419,8 +419,8 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \begin{flalign*}
 \Nlexpr \derives\
    & \Tminus &\\
-|\ & \Nslicedbasiclexpr &\\
-|\ & \Tlpar \parsesep \Clisttwo{\Ndiscardorslicedbasiclexpr} \parsesep \Trpar &\\
+|\ & \Nbasiclexpr &\\
+|\ & \Tlpar \parsesep \Clisttwo{\Ndiscardorbasiclexpr} \parsesep \Trpar &\\
 |\ & \Tidentifier \parsesep \Tdot \parsesep \Tlbracket \parsesep \Clisttwo{\Tidentifier} \parsesep \Trbracket &\\
 |\ & \Tidentifier \parsesep \Tdot \parsesep \Tlpar \parsesep \Clisttwo{\Ndiscardoridentifier} \parsesep \Trpar &
 \end{flalign*}
@@ -428,28 +428,33 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \hypertarget{def-nbasiclexpr}{}
 \begin{flalign*}
 \Nbasiclexpr \derives\
-   & \Tidentifier \parsesep \Nnestedfields &\\
-|\ & \Tidentifier \parsesep \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket \parsesep \Nnestedfields &
+   & \Tidentifier \parsesep \Naccess &\\
+|\ & \Tidentifier \parsesep \Naccess \parsesep \Nslices &
 \end{flalign*}
 
-\hypertarget{def-nnestedfields}{}
+\hypertarget{def-naccess}{}
 \begin{flalign*}
-\Nnestedfields \derives\ & \emptysentence \;|\; \Tdot \parsesep \Tidentifier \parsesep \Nnestedfields &
+\Naccess \derives\
+   & \emptysentence  &\\
+|\ & \Tdot \parsesep \Tidentifier \parsesep \Naccess &\\
+|\ & \Tllbracket \parsesep \Nexpr \parsesep \Trrbracket \parsesep \Naccess &
 \end{flalign*}
 
-\hypertarget{def-nslicedbasiclexpr}{}
+\hypertarget{def-ndiscardorbasiclexpr}{}
 \begin{flalign*}
-\Nslicedbasiclexpr \derives\ & \Nbasiclexpr \;|\; \Nbasiclexpr \parsesep \Nslices &
-\end{flalign*}
-
-\hypertarget{def-ndiscardorslicedbasiclexpr}{}
-\begin{flalign*}
-\Ndiscardorslicedbasiclexpr \derives\ & \Tminus \;|\; \Nslicedbasiclexpr &
+\Ndiscardorbasiclexpr \derives\ & \Tminus \;|\; \Nbasiclexpr &
 \end{flalign*}
 
 \hypertarget{def-ndiscardoridentifier}{}
 \begin{flalign*}
 \Ndiscardoridentifier \derives \ & \Tminus \;|\; \Tidentifier &
+\end{flalign*}
+
+\hypertarget{def-nsetteraccess}{}
+\begin{flalign*}
+\Nsetteraccess \derives \
+   & \emptysentence &\\
+|\ & \Tdot \parsesep \Tidentifier \parsesep \Nsetteraccess &
 \end{flalign*}
 
 A $\Ndeclitem$ is another kind of left-hand-side expression,

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -1578,6 +1578,7 @@ relations
 relationship
 relative
 relatively
+relax
 release
 relevant
 reliable

--- a/asllib/menhir2bnfc/tests/integration/parser_cmp.expected
+++ b/asllib/menhir2bnfc/tests/integration/parser_cmp.expected
@@ -1,4 +1,3 @@
 FAIL - aslref false | bnfc true: asllib/tests/regressions.t/lhs-tuple-fields-same-field.asl
-FAIL - aslref false | bnfc true: asllib/tests/regressions.t/lhs-tuple-same-var.asl
 FAIL - aslref false | bnfc true: asllib/tests/regressions.t/same-precedence.asl
 FAIL - aslref false | bnfc true: asllib/tests/regressions.t/same-precedence2.asl

--- a/asllib/tests/ASLSyntaxReference.t/ASTRule.DesugarLHSAccess.asl
+++ b/asllib/tests/ASLSyntaxReference.t/ASTRule.DesugarLHSAccess.asl
@@ -1,0 +1,18 @@
+type MyBV of bits(16) {
+  [3:0] fld1 : bits(4) {
+    [3:0] fld2
+  }
+};
+
+var x: array[[4]] of MyBV;
+
+func main() => integer
+begin
+  x[[0]].fld1.fld2[:1] = '0';
+
+  // The above left-hand side desugars to the following `lexpr`:
+  // LE_Slice( LE_SetField( LE_SetField( LE_SetArray( LE_Var("x"),
+  //   0), "fld1"), "fld2"), [:1])
+
+  return 0;
+end;

--- a/asllib/tests/ASLSyntaxReference.t/ASTRule.DesugarLHSFieldsTuple.asl
+++ b/asllib/tests/ASLSyntaxReference.t/ASTRule.DesugarLHSFieldsTuple.asl
@@ -1,0 +1,19 @@
+type MyBV of bits(16) {
+  [3:0] fld1,
+  [15:12] fld2
+};
+
+func main() => integer
+begin
+  var x: MyBV;
+  x.(fld1, -, fld2) = ('0000', '0101', '1111');
+
+  // The above left-hand side desugars to:
+  // LE_Destructuring (
+  //   LE_SetField(LE_Var("x"), "fld1"),
+  //   LE_Discard,
+  //   LE_SetField(LE_Var("x"), "fld2")
+  // )
+
+  return 0;
+end;

--- a/asllib/tests/ASLSyntaxReference.t/ASTRule.DesugarLHSTuple.asl
+++ b/asllib/tests/ASLSyntaxReference.t/ASTRule.DesugarLHSTuple.asl
@@ -1,0 +1,21 @@
+type MyBV of bits(16) {
+  [3:0] fld
+};
+
+func main() => integer
+begin
+  var x: array[[4]] of integer;
+  var y: MyBV;
+  var z: bits(4);
+  (x[[0]], y.fld, -, z[:1]) = (0, '1111', TRUE, '0');
+
+  // The above left-hand side desugars to the following `lexpr`:
+  // LE_Destructuring (
+  //   LE_SetArray(LE_Var("x"), 0),
+  //   LE_SetField(LE_Var("y"), "fld"),
+  //   LE_Discard,
+  //   LE_Slice(LE_Var("z"), [:1])
+  // )
+
+  return 0;
+end;

--- a/asllib/tests/ASLSyntaxReference.t/run.t
+++ b/asllib/tests/ASLSyntaxReference.t/run.t
@@ -32,3 +32,6 @@ Examples used to test syntax and AST building rules:
       ^
   ASL Grammar error: Obsolete syntax: Discarded storage declaration.
   [1]
+  $ aslref ASTRule.DesugarLHSAccess.asl
+  $ aslref ASTRule.DesugarLHSTuple.asl
+  $ aslref ASTRule.DesugarLHSFieldsTuple.asl

--- a/asllib/tests/regressions.t/lhs-expressivity.asl
+++ b/asllib/tests/regressions.t/lhs-expressivity.asl
@@ -1,0 +1,56 @@
+/*--------------------*
+   Setters
+ *--------------------*/
+
+func setter_accesses()
+begin
+  X() = '1100';
+
+  X()[3:2] = '00';
+  X().fld = '11';
+  assert X() == '0011';
+  X().fld[0] = '0';
+  assert X() == '0010';
+end;
+
+var x: bits(4) { [1:0] fld };
+
+accessor X() <=> v: bits(4) { [1:0] fld }
+begin
+  getter
+    return x;
+  end;
+
+  setter
+    x = v;
+  end;
+end;
+
+
+/*--------------------*
+   Nested accesses
+ *--------------------*/
+
+func nested_accesses()
+begin
+  state.arr[[7]] = '0000';
+  state.arr[[7]][0] = '1';
+  assert state.arr[[7]] == '0001';
+end;
+
+type state_type of record {
+  arr: array[[31]] of bits(4)
+};
+
+var state: state_type;
+
+
+/*--------------------*/
+
+func main() => integer
+begin
+  setter_accesses();
+  nested_accesses();
+
+  return 0;
+end;

--- a/asllib/tests/regressions.t/lhs-tuple-same-var.asl
+++ b/asllib/tests/regressions.t/lhs-tuple-same-var.asl
@@ -5,8 +5,8 @@ type BV of bits (8) {
 func main() => integer
 begin
   var bv : BV;
-  (bv[7], -, bv.fld) = ('1', TRUE, '11');
+  (bv[7], -, bv.fld, bv.fld) = ('1', TRUE, '00', '11');
+  assert bv.fld == '11';
 
-  assert FALSE;
   return 0;
 end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -464,6 +464,7 @@ Required tests:
   $ aslref subprogram-global-name-clash.asl
   $ aslref subprogram-local-name-clash.asl
   $ aslref string_concat.asl
+  $ aslref approx-expr-binop.asl
 
   $ aslref --no-type-check throw-local-env.asl
   File throw-local-env.asl, line 10, characters 13 to 14:
@@ -521,11 +522,6 @@ Getters/setters
   [1]
   $ aslref setter_subfield.asl
   $ aslref setter_subslice.asl
-  File setter_subslice.asl, line 16, characters 5 to 6:
-    F()[2+:1] = '1';
-       ^
-  ASL Error: Cannot parse.
-  [1]
   $ aslref getter_subfield.asl
   $ aslref getter_sub_tuple.asl
   $ aslref getter_subslice.asl
@@ -593,9 +589,4 @@ Left-hand sides
   ASL Typing error: multiple writes to "bv.fld".
   [1]
   $ aslref lhs-tuple-same-var.asl
-  File lhs-tuple-same-var.asl, line 8, characters 2 to 20:
-    (bv[7], -, bv.fld) = ('1', TRUE, '11');
-    ^^^^^^^^^^^^^^^^^^
-  ASL Typing error: multiple writes to "bv".
-  [1]
-  $ aslref approx-expr-binop.asl
+  $ aslref lhs-expressivity.asl


### PR DESCRIPTION
Relax restrictions on left-hand sides:
- for accesses on variables `x`:
  - permit any nesting of field/array accesses - `x.fld`, `x[[idx]]`, `x.fld[[idx]]`, `x[[idx]].fld`, ...
  - optionally followed by slices - `x.fld[slices]`, `x[[idx]][slices]`, `x.fld[[idx]][slices]`, `x[[idx]].fld[slices]`, ...
- for access on setters `Setter(args)`:
  - permit nesting of field accesses - `Setter(args).fld`, `Setter(args).fld1.fld2`, ...
  - optionally followed by slices - `Setter(args).fld[slices]`, `Setter(args).fld1.fld2[slices]`, ...
- for multi-assignments: allow multiple assignments to the same variable, relying on evaluation order: `(x.fld1, x.fld2) = rhs;`

This required updates to the grammar and intermediate forms for desugaring. Also slightly tidied `desugar.{ml,mli}` along the way.