### PR TITLE
Bundler syntax upgrades

### DIFF
--- a/herd/libdir/asl-pseudocode/bundler.py
+++ b/herd/libdir/asl-pseudocode/bundler.py
@@ -254,7 +254,7 @@ def make_function(name: str, body: str) -> Iterable[str]:
             f"func {name} (instruction: bits(32))",
             "begin",
             textwrap.indent(body, "  "),
-            "end",
+            "end;",
             "",
         )
     )


### PR DESCRIPTION
As of today, the bundler generate instruction decoding without respecting the
precedence rule. This makes code looks like the following:

```
let foo = instruction[42 : (42 - 10 + 1)];
```

This is not accepted by ASLRef as the operators `+` and `-` have the same
precendence.

This PR changes this to add an extra parenthesis around `(42 - 10)`.


This PR also uses new syntax for function bodies to use a semi-colon after the `end` keyword.

