### PR TITLE
[ASL][Reference] Fixed recursive side effects rule and some other rules

### DIFF
--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -841,7 +841,7 @@ let rec transitive_closure m0 =
         let zs =
           ISet.fold
             (fun y k -> try IMap.find y m :: k with Not_found -> k)
-            ys []
+            ys [ ys ]
         in
         IMap.add x (ISet.unions zs) m)
       m0 m0

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -4074,7 +4074,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             IMap.find func.name transitive_call_graph |> ISet.elements
           in
           let sess =
-            List.map (fun x -> IMap.find x func_id_to_ses_minus_rec) callees
+            List.filter_map
+              (fun x -> IMap.find_opt x func_id_to_ses_minus_rec)
+              callees
           in
           (func, SES.unions (SES.remove_calls_recursives ses :: sess)))
         sess

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -4007,9 +4007,11 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
               && Option.is_none f.recurse_limit
             then warn_from ~loc Error.(NoRecursionLimit [ f.name ])
           in
-          let ses_f = SES.remove_calls_recursives ses_f in
+          let ses_f_no_recursives = SES.remove_calls_recursives ses_f in
           let new_d = D_Func new_f |> here
-          and new_env = StaticEnv.add_subprogram new_f.name new_f ses_f env1 in
+          and new_env =
+            StaticEnv.add_subprogram new_f.name new_f ses_f_no_recursives env1
+          in
           (new_d, new_env.global) |: TypingRule.TypecheckDecl
       | D_Func ({ body = SB_Primitive _; _ } as f) ->
           let (new_env, new_f), _ = annotate_and_declare_func ~loc f genv in

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -4052,16 +4052,20 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         let pp f ((func_sig : func), ses) =
           fprintf f "@[<h 2>%s:@ %a@]" func_sig.name SES.pp_print ses
         in
-        eprintf "@[<v 2>Propagating side-effects from:@ @[<v 2>[%a]@]@]@."
+        eprintf
+          "propagate_recursive_calls_sess BEGIN: @[<v 2>Propagating \
+           side-effects from:@ @[<v 2>[%a]@]@]@."
           (pp_print_list ~pp_sep pp) sess
     in
-    let map0 =
+    let func_id_to_ses =
       List.map (fun ((f : func), ses) -> (f.name, ses)) sess |> IMap.of_list
     in
-    let call_graph = IMap.map (fun ses -> SES.get_calls_recursives ses) map0 in
+    let call_graph =
+      IMap.map (fun ses -> SES.get_calls_recursives ses) func_id_to_ses
+    in
     let transitive_call_graph = transitive_closure call_graph in
-    let map0_without_recursive_calls =
-      IMap.map (fun ses -> SES.remove_calls_recursives ses) map0
+    let func_id_to_ses_minus_rec =
+      IMap.map (fun ses -> SES.remove_calls_recursives ses) func_id_to_ses
     in
     let res =
       List.map
@@ -4070,7 +4074,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             IMap.find func.name transitive_call_graph |> ISet.elements
           in
           let sess =
-            List.map (fun x -> IMap.find x map0_without_recursive_calls) callees
+            List.map (fun x -> IMap.find x func_id_to_ses_minus_rec) callees
           in
           (func, SES.unions (SES.remove_calls_recursives ses :: sess)))
         sess
@@ -4082,7 +4086,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         let pp f ((func_sig : func), ses) =
           fprintf f "@[<h 2>%s:@ %a@]" func_sig.name SES.pp_print ses
         in
-        eprintf "@[<v 2>Propagating side-effects from:@ @[<v 2>[%a]@]@]@."
+        eprintf
+          "propagate_recursive_calls_sess END: @[<v 2>Propagating side-effects \
+           from:@ @[<v 2>[%a]@]@]@."
           (pp_print_list ~pp_sep pp) res
     in
     res

--- a/asllib/acl2/aslreftests/dune-project
+++ b/asllib/acl2/aslreftests/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.17)
+(lang dune 3.16)
 
 (name acl2test)
 

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -116,8 +116,15 @@ which is defined next is named $q$.
 
 \hypertarget{def-cartimes}{}
 \begin{definition}[Cartesian Product]
-    The \emph{Cartesian product} of sets $A$ and $B$, denoted $A \cartimes B$
+    The \emph{Cartesian product} of sets $A$ and $B$, denoted $A \cartimes B$,
     is $A \cartimes B \triangleq \{(a,b) \;|\; a \in A, b \in B\}$.
+\end{definition}
+
+\hypertarget{def-graphtransitive}{}
+\hypertarget{def-graphtransitivereflexive}{}
+\begin{definition}[Transitive Closure of a Relation]
+We denote the transitive closure of a relation $E = V \times V$ by $\graphtransitive{E}$
+and the reflexive-transitive closure of $E$ by $\graphtransitivereflexive{E}$.
 \end{definition}
 
 \hypertarget{def-partialfunc}{}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1846,7 +1846,9 @@
 \newcommand\precisionjoin[0]{\hyperlink{def-precisionjoin}{\textfunc{precision\_join}}}
 \newcommand\Prosenoprecisionloss[1]{determining whether #1 has been computed with no precision loss using $\checknoprecisionloss$ yields $\True$\ProseOrTypeError}
 \newcommand\annotatesubprogram[0]{\hyperlink{def-annotatesubprogram}{\textfunc{annotate\_subprogram}}}
-\newcommand\Proseannotatesubprogram[3]{\hyperlink{def-annotatesubprogram}{annotating} the subprogram definition #1 in the static environment #2 yields the subprogram definition #3}
+\newcommand\Proseannotatesubprogram[5]{\hyperlink{def-annotatesubprogram}{annotating} the subprogram definition #2
+  in the static environment #1 with \sideeffectdescriptorsetsterm{} #3 yields the subprogram definition #4
+  and \sideeffectdescriptorsetsterm{} #5}
 \newcommand\checkstmtreturnsorthrows[0]{\hyperlink{def-checkstmtreturnsorthrows}{\textfunc{check\_stmt\_returns\_or\_throws}}}
 
 \newcommand\controlflowfromstmt[0]{\hyperlink{def-controlflowfromstmt}{\textfunc{control\_flow\_from\_stmt}}}
@@ -2279,6 +2281,7 @@
 \newcommand\neweopt[0]{\texttt{new\_e\_opt}}
 \newcommand\newenv[0]{\texttt{new\_env}}
 \newcommand\newenvandfs[0]{\texttt{new\_env\_and\_fs}}
+\newcommand\newf[0]{\texttt{new\_f}}
 \newcommand\newfield[0]{\texttt{new\_field}}
 \newcommand\newfields[0]{\texttt{new\_fields}}
 \newcommand\newfuncdef[0]{\texttt{new\_func\_def}}
@@ -2776,6 +2779,7 @@
 \newcommand\vsesinitialvalue[0]{\texttt{ses\_initial\_value}}
 \newcommand\vsesbase[0]{\texttt{ses\_base}}
 \newcommand\vsesf[0]{\texttt{ses\_f}}
+\newcommand\vsesfnorecursives[0]{\texttt{ses\_f\_no\_recursives}}
 \newcommand\vsesfone[0]{\texttt{ses\_f1}}
 \newcommand\vsescatchers[0]{\texttt{ses\_catchers}}
 \newcommand\vseswithparams[0]{\texttt{ses\_with\_params}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -313,7 +313,8 @@
 \newcommand\funcgraph[0]{\hyperlink{def-funcgraph}{\texttt{func\_graph}}}
 \DeclareMathOperator{\dom}{\hyperlink{def-dom}{dom}}
 \newcommand\sign[0]{\hyperlink{def-sign}{\texttt{sign}}}
-\newcommand\graphtransitive[1]{#1^{\hyperlink{def-graphtransitive}{*}}}
+\newcommand\graphtransitive[1]{#1^{\hyperlink{def-graphtransitive}{+}}}
+\newcommand\graphtransitivereflexive[1]{#1^{\hyperlink{def-graphtransitivereflexive}{*}}}
 
 \newcommand\configdomain[1]{\hyperlink{def-configdomain}{\texttt{config\_dom}}({#1})}
 
@@ -1362,8 +1363,6 @@
 \newcommand\PerformsAssertions[0]{\hyperlink{def-performsassertions}{\textsf{PerformsAssertions}}}
 \newcommand\NonDeterministic[0]{\hyperlink{def-nondeterministic}{\textsf{NonDeterministic}}}
 
-\newcommand\propagatedeffects[0]{\textfunc{propagated\_effects}}
-
 % sets of side effect descriptors
 \newcommand\timeframe[0]{\hyperlink{def-sideeffecttimeframe}{\textfunc{time\_frame}}}
 \newcommand\sideeffectispure[0]{\hyperlink{def-sideeffectispure}{\textfunc{side\_effect\_is\_pure}}}
@@ -1768,7 +1767,8 @@
 \newcommand\ReadGlobalTerm[0]{\hyperlink{def-readglobalterm}{global read side effect descriptor}}
 \newcommand\WriteGlobalTerm[0]{\hyperlink{def-writeglobalterm}{global write side effect descriptor}}
 \newcommand\ThrowExceptionTerm[0]{\hyperlink{def-throwexceptionterm}{exception side effect descriptor}}
-\newcommand\RecursiveCallTerm[0]{\hyperlink{def-recursivecallterm}{recursive call side effect  descriptor}}
+\newcommand\RecursiveCallTerm[0]{\hyperlink{def-recursivecallterm}{recursive call side effect descriptor}}
+\newcommand\RecursiveCallTerms[0]{\hyperlink{def-recursivecallterm}{recursive call side effect descriptors}}
 \newcommand\PerformsAssertionsTerm[0]{\hyperlink{def-performsassertionsterm}{assertion side effect descriptor}}
 \newcommand\NonDeterministicTerm[0]{\hyperlink{def-nondeterministicterm}{non-determinism side effect descriptor}}
 
@@ -3030,7 +3030,6 @@
 \newcommand\addten[0]{\texttt{add\_10}}
 \newcommand\addtenone[0]{\texttt{add\_10-1}}
 \newcommand\factorial[0]{\texttt{factorial}}
-\newcommand\rotate[0]{\texttt{rotate}}
 \newcommand\declaredparam[0]{\texttt{declared\_param}}
 \newcommand\caninsertstdlibparam[0]{\texttt{can\_insert\_stdlib\_param}}
 \newcommand\inferredparameters[0]{\texttt{inferred\_parameters}}
@@ -3054,3 +3053,11 @@
 \newcommand\plf[0]{\texttt{plf}}
 \newcommand\vsapprox[0]{\texttt{s\_approx}}
 \newcommand\intervals[0]{\texttt{intervals}}
+\newcommand\funcidtoses[0]{\texttt{func\_id\_to\_ses}}
+\newcommand\funcidtosesminusrec[0]{\texttt{func\_id\_to\_ses\_minus\_rec}}
+\newcommand\callgraph[0]{\texttt{call\_graph}}
+\newcommand\transitivecallgraph[0]{\texttt{transitive\_call\_graph}}
+\newcommand\callees[0]{\texttt{callees}}
+\newcommand\vsucc[0]{\texttt{succ}}
+\newcommand\countgone[0]{\texttt{count\_g1}}
+\newcommand\countgtwo[0]{\texttt{count\_g2}}

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -119,10 +119,12 @@ All global declarations in \listingref{TypecheckDecl} are well-typed.
     \item $\vd$ is a subprogram AST node with a subprogram definition $\vf$, that is, $\DFunc(\vf)$;
     \item annotating and declaring the subprogram for $\vf$ in $\genv$ as per \\
           \TypingRuleRef{AnnotateAndDeclareFunc}
-          yields the environment $\tenvone$ and a subprogram definition $\vfone$\ProseOrTypeError;
-    \item \Proseannotatesubprogram{$\vfone$}{$\tenv$}{$\vftwo$\ProseOrTypeError};
-    \item applying $\addsubprogram$ to bind $\vftwo.\funcname$ to $\vftwo$ in $\tenvone$ yields $\newtenv$;
-    \item define $\newd$ as the subprogram AST node with $\vftwo$, that is, $\DFunc(\vftwo)$;
+          yields the environment $\tenvone$, a subprogram definition $\vfone$,
+          and a \sideeffectdescriptorsetsterm{} $\vsesfuncsig$\ProseOrTypeError;
+    \item \Proseannotatesubprogram{$\tenv$}{$\vfone$}{\vsesfuncsig}{$\newf$}{$\vsesf$}\ProseOrTypeError;
+    \item \Proseeqdef{$\vsesfnorecursives$}{$\vsesf$ with every \RecursiveCallTerm{} removed};
+    \item applying $\addsubprogram$ to $\tenvone$, $\newf.\funcname$, $\newf$, and $\vsesfnorecursives$ yields $\newtenv$;
+    \item define $\newd$ as the subprogram AST node with $\newf$, that is, $\DFunc(\newf)$;
     \item define $\newgenv$ as the global component of $\newtenv$.
   \end{itemize}
 
@@ -149,12 +151,13 @@ All global declarations in \listingref{TypecheckDecl} are well-typed.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[func]{
-  \annotateanddeclarefunc(\genv, \vf) \typearrow (\tenvone, \vfone) \OrTypeError\\\\
-  \annotatesubprogram(\tenvone, \vfone) \typearrow \vftwo \OrTypeError\\\\
-  \addsubprogram(\tenvone, \vftwo.\funcname, \vftwo) \typearrow \newtenv
+  \annotateanddeclarefunc(\genv, \vf) \typearrow (\tenvone, \vfone, \vsesfuncsig) \OrTypeError\\\\
+  \annotatesubprogram(\tenvone, \vfone, \vsesfuncsig) \typearrow (\newf,\vsesf) \OrTypeError\\\\
+  \vsesfnorecursives \eqdef \vsesf \setminus \{ \vs \;|\; \configdomain{\vs} = \RecursiveCall \}\\
+  \addsubprogram(\tenvone, \newf.\funcname, \newf, \vsesfnorecursives) \typearrow \newtenv
 }{
   \typecheckdecl(\genv, \overname{\DFunc(\vf)}{\vd})
-  \typearrow (\overname{\DFunc(\vftwo)}{\newd}, \overname{G^\newtenv}{\newgenv})
+  \typearrow (\overname{\DFunc(\newf)}{\newd}, \overname{G^\newtenv}{\newgenv})
 }
 \end{mathpar}
 

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -26,7 +26,7 @@ The language supports such overriding mechanisms (and in particular, simplifies 
   \item The \texttt{config} keyword syntactically identifies configurable storage elements.
   \item Types of \texttt{config} storage elements must be \emph{both} explicitly declared \emph{and} singular (\TypingRuleRef{SingularType}).
   \item The \timeframeterm{} of \texttt{config} storage elements is $\timeframeexecution$, so their values are not relied upon by typechecking.
-  \item Values of \texttt{config} storage elements must have \timeframeterm{} less than of equal to $\timeframeconstant$, so they can depend only on constant values (and not other \texttt{config} storage elements for example).
+  \item Values of \texttt{config} storage elements must have \timeframeterm{} less than or equal to $\timeframeconstant$, so they can depend only on constant values (and not other \texttt{config} storage elements for example).
 \end{itemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -226,7 +226,7 @@ are ill-typed since
 \texttt{config} storage elements have the $\timeframeconstant$ \timeframeterm,
 which requires that all expressions used in its type annotation and initializing expression
 also have the $\timeframeconstant$ \timeframeterm,
-whereas \verb|b| has the $\timeframeexecution$ \timeframeterm.
+whereas \verb|x| has the $\timeframeexecution$ \timeframeterm.
 \ASLListing{Ill-typed configuration storage declaration}{DeclareGlobalStorage-bad1}{\typingtests/TypingRule.DeclareGlobalStorage.bad1.asl}
 \ASLListing{Ill-typed configuration storage declaration}{DeclareGlobalStorage-bad2}{\typingtests/TypingRule.DeclareGlobalStorage.bad2.asl}
 

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -554,111 +554,135 @@ The helper relation
 \aslrel
 \overname{(\func\times\TSideEffectSet)^*}{\vsessnew}
 \]
-accepts a list of $\func$ AST nodes and their associated \sideeffectdescriptorsetsterm\ and
-ensures that the \sideeffectdescriptorsterm\ of a given $\func$
-consists of the \sideeffectdescriptorsterm\ of all the $\func$ AST nodes of the
+accepts a list that associates $\func$ AST nodes to \sideeffectdescriptorsetsterm\ and
+generates a list that associates each $\func$ AST nodes to the union of all
+\sideeffectdescriptorsterm\ associated with the
 recursive functions it may transitively call.
 
+We assume each $\func$ AST node occurs in exactly one pair of $\vsess$.
+
 \ExampleDef{Propagating Recursive Call Side Effects}
-Given the specification in \listingref{TypeCheckAST},
-the following sets of \sideeffectdescriptorsterm{} are inferred for each subprogram
-separately:
+Consider the specification in \listingref{PropagateRecursiveCallsSess}.
+\ASLListing{Propagating recursive call side effects}{PropagateRecursiveCallsSess}{\typingtests/TypingRule.PropagateRecursiveCallsSess.asl}
+
+\TypingRuleRef{TypeCheckMutuallyRec} applies $\propagaterecursivecallssess$
+to the following subprograms and their associated \sideeffectdescriptorsterm{} are inferred for each subprogram
+separately ($\funcidtoses$ in the rules below):
 \begin{center}
-\begin{tabular}{c}
-$\left(\vmain,  \left\{\begin{array}{l}
-                \ReadGlobal(\vg, \timeframeexecution, \False),\\
-                \ReadLocal(\vx, \timeframeexecution, \False),\\
-                \WriteLocal(\vx, \timeframeexecution, \True),\\
-                \RecursiveCall(\rotatezero)
+\[
+\left[
+\begin{array}{ll}
+\countgone, &  \left\{\begin{array}{l}
+                \ReadGlobal(\vgone, \timeframeexecution, \False),\\
+                \WriteGlobal(\vgone),\\
+                \RecursiveCall(\countgtwo)
+                \end{array}\right\}\\
+&,\\
+\countgtwo, & \left\{\begin{array}{l}
+                \ReadGlobal(\vgtwo, \timeframeexecution, \False),\\
+                \WriteGlobal(\vgtwo),\\
+                \ReadGlobal(\vgthree, \timeframeexecution, \False),\\
+                \RecursiveCall(\vgone)\\
                 \end{array}\right\}
-                \right)$\\
-$\left(\rotatecolor  ,\left\{ \begin{array}{l} \ReadLocal(\vc, \timeframeexecution, \True) \end{array}\right\}\right)$\\
-$\left(\rotatezero   ,\left\{\begin{array}{l}
-                \ReadLocal(\vc, \timeframeexecution, \True),\\
-                \ReadLocal(\rotate, \timeframeexecution, \True),\\
-                \RecursiveCall(\rotateone)
-                \end{array}\right\}\right)$\\
-$\left(\rotateone    ,\left\{\begin{array}{l}
-                \ReadLocal(\vc, \timeframeexecution, \True),\\
-                \ReadLocal(\rotate, \timeframeexecution, \True),\\
-                \RecursiveCall(\rotatezero)
-                \end{array}\right\}\right)$\\
-\end{tabular}
+\end{array}
+\right]
+\]
 \end{center}
 
-$\propagaterecursivecallssess$ first infers the following edges between the following subprograms:
+$\propagaterecursivecallssess$ then infers the following relation between the subprograms
+based on their associated \sideeffectdescriptorsetsterm{} ($\callgraph$ in the rules below):
 \begin{center}
 \begin{tabular}{lcl}
-$(\vmain$       &,& $\rotatecolor)$\\
-$(\vmain$       &,& $\rotatezero)$\\
-$(\vmain$       &,& $\rotateone)$\\
-$(\rotateone$   &,& $\rotateone)$\\
-$(\rotateone$   &,& $\rotatezero)$\\
-$(\rotateone$   &,& $\rotatecolor)$\\
-$(\rotatezero$  &,& $\rotateone)$\\
-$(\rotatezero$  &,& $\rotatezero)$\\
-$(\rotatezero$  &,& $\rotatecolor)$\\
+$(\countgone$   &,& $\countgtwo)$\\
+$(\countgtwo$   &,& $\countgone)$
 \end{tabular}
 \end{center}
 
-Then, the \sideeffectdescriptorterm{} are accumulated, resulting in the following:
+$\propagaterecursivecallssess$ then computes the transitive closure of the relation above
+($\transitivecallgraph$ in the rules below):
 \begin{center}
-\begin{tabular}{c}
-$\left(\vmain,  \left\{\begin{array}{l}
-                \ReadGlobal(\vg, \timeframeexecution, \False),\\
-                \ReadLocal(\vx, \timeframeexecution, \False),\\
-                \WriteLocal(\vx, \timeframeexecution, \True),\\
-                \RecursiveCall(\rotatezero),\\
-                \RecursiveCall(\rotateone),\\
-                \ReadLocal(\vc, \timeframeexecution, \True),\\
-                \ReadLocal(\rotate, \timeframeexecution, \True),\\
-                \end{array}\right\}
-                \right)$\\
-$\left(\rotatecolor,\left\{ \begin{array}{l}
-                \ReadLocal(\vc, \timeframeexecution, \True)
-              \end{array}\right\}\right)$\\
-$\left(\rotatezero   ,\left\{\begin{array}{l}
-                \ReadLocal(\vc, \timeframeexecution, \True),\\
-                \ReadLocal(\rotate, \timeframeexecution, \True),\\
-                \RecursiveCall(\rotateone),
-                \RecursiveCall(\rotatezero)
-                \end{array}\right\}\right)$\\
-$\left(\rotateone    ,\left\{\begin{array}{l}
-                \ReadLocal(\vc, \timeframeexecution, \True),\\
-                \ReadLocal(\rotate, \timeframeexecution, \True),\\
-                \RecursiveCall(\rotatezero),
-                \RecursiveCall(\rotateone)
-                \end{array}\right\}\right)$\\
+\begin{tabular}{lcl}
+$(\countgone$   &,& $\countgone)$\\
+$(\countgone$   &,& $\countgtwo)$\\
+$(\countgtwo$   &,& $\countgone)$\\
+$(\countgtwo$   &,& $\countgtwo)$
 \end{tabular}
+\end{center}
+
+Then, the \sideeffectdescriptorterm{} are accumulated, excluding \RecursiveCallTerms,
+which yields the final result:
+\begin{center}
+\[
+\left[
+\begin{array}{ll}
+\countgone, &  \left\{\begin{array}{l}
+                \ReadGlobal(\vgone, \timeframeexecution, \False),\\
+                \WriteGlobal(\vgone),\\
+                \ReadGlobal(\vgtwo, \timeframeexecution, \False),\\
+                \WriteGlobal(\vgtwo),\\
+                \ReadGlobal(\vgthree, \timeframeexecution, \False),\\
+                \WriteGlobal(\vgthree),\\
+                \end{array}\right\}\\
+&,\\
+\countgtwo, & \left\{\begin{array}{l}
+                \ReadGlobal(\vgone, \timeframeexecution, \False),\\
+                \WriteGlobal(\vgone),\\
+                \ReadGlobal(\vgtwo, \timeframeexecution, \False),\\
+                \WriteGlobal(\vgtwo),\\
+                \ReadGlobal(\vgthree, \timeframeexecution, \False),\\
+                \WriteGlobal(\vgthree),\\
+                \end{array}\right\}
+\end{array}
+\right]
+\]
 \end{center}
 
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item define the set $V$ as the set that includes an AST node $\vf$ if and only if $(\vf, \Ignore)$ exists in $\vsess$.
-        Intuitively, this is the set of all function definitions in associated with \sideeffectdescriptorsterm\ in $\vsess$;
-  \item define the relation $E : \func \times \func$ as follows:
-        a pair $(\vfone, \vftwo)$ is included in $E$ if the pair $(\vfone, \vses_\vfone)$ exists in $\vsess$
-        and the \RecursiveCallTerm\ for $\vftwo.\funcname$ exists in $\vses_\vfone$.
-        Intuitively, there exists an edge $(\vfone, \vftwo)$ if the \sideeffectdescriptorsterm\ of $\vfone$ indicate that it
-        may call the recursive function $\vftwo$;
-  \item recall that $\graphtransitive{E}$ is the transitive closure of $E$, which intuitively means that
-        $(\vfone, \vftwo)$ is included in $\graphtransitive{E}$ if there exists a path of edges in $E$ connecting $\vfone$
-        to $\vftwo$;
-  \item define the function $\propagatedeffects : \func \aslto \TSideEffectSet$, which binds a function definition $\vfone$
-        to the set including any \sideeffectdescriptorsterm\ $\vs$ such that $(\vfone, \vftwo) \in \graphtransitive{E}$ and
-        $\vs$ is associated with $\vftwo$ in $\vsess$;
-  \item define $\vsesnew$ as any listing of the set of pairs $(\vf, \propagatedeffects(\vf))$ such $\vf$ is a member of $V$.
+  \item \Proseeqdef{$\funcidtoses$}{the function that maps a subprogram name of $\vf$ to its associated \sideeffectdescriptorsetsterm{}
+        $\vs$, for each pair $(\vf, \vs)$ in $\vsess$};
+  \item \Proseeqdef{$\callgraph$}{the relation between subprogram names $\vfone$ and $\vftwo$ such that
+        the \sideeffectdescriptorsetsterm{} associated with $\vfone$ includes the \RecursiveCallTerm{} for $\vftwo$};
+  \item \Proseeqdef{$\transitivecallgraph$}{the transitive closure of $\callgraph$};
+  \item \Proseeqdef{$\funcidtosesminusrec$}{the function where for each mapping of subprogram name $\id$
+        to \sideeffectdescriptorsetsterm{} $\vs$ in $\funcidtoses$, there exists a mapping of $\id$
+        to $\vs$ with all \RecursiveCallTerms{} removed};
+  \item \Proseeqdef{$\callees$}{the function where for each pair $(\vf, \vses)$ in $\vsess$ there exists a mapping
+        of $\vf$ to the set of subprogram names such that for each such subprogram name $\vsucc$,
+        $(\vf.\funcname, \vsucc)$ is a member of $\transitivecallgraph$};
+  \item \Proseeqdef{$\vsessnew$}{the list constructed from each pair $(\vf, \vs)$ in $\vsess$
+        by associating $\vf$ to the union of \sideeffectdescriptorsetsterm{} given by the \sideeffectdescriptorsetsterm{}
+        of $\funcidtosesminusrec(\vc)$ for each successor of $\vf$ in $\callees$, with all \RecursiveCallTerms{} removed}.
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  V \eqdef \{ (\vf, \Ignore) \in \vsess\}\\
-  E \eqdef \{ (\vfone, \vftwo) \;|\; \exists (\vfone, \vses_\vfone) \in \vsess \text{ and } \RecursiveCall(\vftwo.\funcname) \in \vses_\vfone\}\\
-  \vfone\in V: \propagatedeffects(\vfone) \eqdef \bigcup \{ \vses_\vftwo \;|\; (\vfone, \vftwo) \in \graphtransitive{E} \text{ and } (\vftwo, \vses_\vftwo \in \vsess)\}\\
+  \funcidtoses \eqdef \{ \vf.\funcname \mapsto \vs \;|\; (\vf, \vs) \in \vsess \}\\
+  \callgraph \eqdef \{ (\vfone, \vftwo) \;|\; (\vfone, \vses) \in \funcidtoses \land \RecursiveCall(\vftwo) \in \vses\}\\
+  \transitivecallgraph \eqdef \graphtransitive{\callgraph}\\
+  {
+  \begin{array}{l}
+  \funcidtosesminusrec \eqdef \\ \{ \id \mapsto \vs \setminus \RecursiveCall(\Identifiers) \;|\; (\id, \vs) \in \funcgraph(\funcidtoses)\}
+  \end{array}
+  }\\
+  {
+  \begin{array}{l}
+  \callees \eqdef \\
+  \{ \vf \mapsto \{\vsucc \;|\; (\vf.\funcname, \vsucc) \in \transitivecallgraph\} \;|\; (\vf, \vses) \in \vsess \}
+  \end{array}
+  }\\
+  {
+  \begin{array}{l}
+  \vsessnew \eqdef \\
+  \left[ (\vf, \vs) \in \vsess :
+  \left(\vf, \bigcup_{\vc \in \callees(\vf)} \funcidtosesminusrec(\vc) \setminus \RecursiveCall(\Identifiers)\right)
+  \right]
+  \end{array}
+  }
 }{
-  \propagaterecursivecallssess(\vsess) \typearrow \overname{[\vf\in V: (\vf, \propagatedeffects(\vf))]}{\vsessnew}
+  \propagaterecursivecallssess(\vsess) \typearrow \vsessnew
 }
 \end{mathpar}
 
@@ -2312,9 +2336,6 @@ and the identifiers used by it, appearing in comments to its right.
 
 \section{Ordering Global Declarations via Def-Use Dependencies\label{sec:Dependencies}}
 
-\hypertarget{def-graphtransitive}{}
-We denote the reflexive-transitive closure of a relation $E$ as $\graphtransitive{E}$.
-
 \begin{definition}[Strongly Connected Components]
 \hypertarget{def-scc}{}
 Given a graph $G=(V, E)$, a \\ subset of its nodes $C \subseteq V$ is called
@@ -2324,7 +2345,7 @@ every pair of nodes $u,v \in C$ reachable from one another.
 The \emph{strongly connected components} of a graph $(V, E)$ uniquely partitions its set of
 nodes $V$ into a set of strongly connected components:
 \[
-\SCC(V, E) \triangleq \{ C \subseteq V \;|\; \forall u,v\in C.\ (u,v), (v,u) \in \graphtransitive{E} \} \enspace.
+\SCC(V, E) \triangleq \{ C \subseteq V \;|\; \forall u,v\in C.\ (u,v), (v,u) \in \graphtransitivereflexive{E} \} \enspace.
 \]
 \end{definition}
 
@@ -2337,7 +2358,7 @@ $C_{1..k}$ --- is a \emph{topological ordering of components},
 denoted \\
 $C_{1..k} \in \topologicalorderingcomps(\comps, E)$, if the following condition holds:
 \[
-  \forall 1 \leq i \leq j \leq k.\ \exists c_i\in C_i.\ c_j\in C_j.\ (c_i,c_j) \in \graphtransitive{E} \;\;\Longrightarrow\;\;
+  \forall 1 \leq i \leq j \leq k.\ \exists c_i\in C_i.\ c_j\in C_j.\ (c_i,c_j) \in \graphtransitivereflexive{E} \;\;\Longrightarrow\;\;
   i \leq j \enspace .
 \]
 \end{definition}

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1797,7 +1797,7 @@ while calling \verb|throwing_func| terminates by throwing an exception.
       \item evaluating the subprogram named $\name$ with parameters $\vvparams$ and arguments $\vvargs$ in
       $\denvtwo'$ is $\Normal(\vms, (\vglobal, \Ignore))$ (that is, we ignore the local environment
       of the callee)\ProseOrError;
-      \item applying the helper relation $\readvaluefrom$ to $\vms$ yields $\vmstwo$;
+      \item applying the helper relation $\readvaluefrom$ to each element of the list $\vms$ yields the list $\vmstwo$;
       \item applying $\decrstacksize$ to $\vglobal$ and $\name$ yields $\genvtwo$;
       \item define $\newenv$ as the environment where the static environment is $\tenv$ and the dynamic environment consists
             of the dynamic global environment $\genvtwo$ and the dynamic local environment is taken from $\denvtwo$
@@ -1831,7 +1831,7 @@ while calling \verb|throwing_func| terminates by throwing an exception.
   \envtwo' \eqdef (\tenv, (\genv, \emptyfunc))\\\\
   \commonprefixline\\\\
   \evalsubprogram(\envtwo', \name, \vvparams, \vvargs) \evalarrow \Normal(\vms, (\vglobal, \Ignore)) \OrDynError\\\\
-  \readvaluefrom(\vms) \evalarrow \vmstwo\\
+  \vmstwo \eqdef [\vm \in \vms: \readvaluefrom(\vms)]\\
   \decrstacksize(\vglobal, \name) \evalarrow \genvtwo\\
   \newenv \eqdef (\tenv, (\genvtwo, L^{\denvtwo}))
 }{

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -1580,7 +1580,7 @@ See \ExampleRef{Updating the Static Environment for a Subprogram}.
     \initses \eqdef \vsesfuncsig \cup\ \{ \RecursiveCall(\namep) \}\\
     \addsubprogram(\tenvone, \namep, \funcsigone, \initses) \typearrow \newtenv \OrTypeError
 }{
-  \declareonefunc(\tenv, \funcsig) \typearrow (\newtenv, \newfuncsig)
+  \declareonefunc(\tenv, \funcsig, \vsesfuncsig) \typearrow (\newtenv, \newfuncsig)
 }
 \end{mathpar}
 \CodeSubsection{\DeclareOneFuncBegin}{\DeclareOneFuncEnd}{../Typing.ml}

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -1560,7 +1560,7 @@ Specifically, the lists of bitfields for the \verb|bv| argument in both signatur
 of \verb|Foo| are equivalent.
 \ASLListing{Equivalent lists of bitfields}{BitFieldsEqual}{\typingtests/TypingRule.BitFieldsEqual.asl}
 
-The specification in \listingref{BitFieldsEqual} is ill-typed,
+The specification in \listingref{BitFieldsEqual-bad} is ill-typed,
 the lists of bitfields for the \verb|bv| argument in both signatures
 of \verb|Foo| are not equivalent.
 \ASLListing{Non-equivalent lists of bitfields}{BitFieldsEqual-bad}{\typingtests/TypingRule.BitFieldsEqual.bad.asl}

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -375,6 +375,7 @@ computation
 computational
 compute
 computed
+computes
 concatenated
 concatenates
 concatenating
@@ -1288,6 +1289,7 @@ occur
 occurrence
 occurrences
 occurring
+occurs
 of
 offers
 offset
@@ -1868,6 +1870,7 @@ success
 successful
 successfully
 successive
+successor
 succinctly
 such
 sufficient

--- a/asllib/tests/ASLTypingReference.t/TypingRule.PropagateRecursiveCallsSess.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.PropagateRecursiveCallsSess.asl
@@ -1,0 +1,31 @@
+var g1 : integer;
+var g2 : integer;
+var g3 : integer;
+
+func main() => integer
+begin
+    - = count_g1(10);
+    return 0;
+end;
+
+func increment_g3()
+begin
+    g3 = g3 + 1;
+end;
+
+func count_g1(counter: integer) => integer recurselimit 100
+begin
+    g1 = g1 + 1;
+    if counter > 0 then
+        - = count_g2(counter - 1);
+    end;
+    return g1;
+end;
+
+func count_g2(counter: integer) => integer recurselimit 100
+begin
+    g2 = g2 + 1;
+    increment_g3();
+    - = count_g1(counter - 1);
+    return g2;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -928,3 +928,4 @@ ASL Typing Tests / annotating types:
   $ aslref --no-exec TypingRule.ToIR.asl
   $ aslref --no-exec TypingRule.Normalize.asl
   $ aslref --no-exec TypingRule.UnitaryMonomialsToExpr.asl
+  $ aslref --no-exec TypingRule.PropagateRecursiveCallsSess.asl

--- a/herd/tests/instructions/ASL/concat.litmus.expected
+++ b/herd/tests/instructions/ASL/concat.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation Concatenation Always 1 0
-Hash=10f813fa2bf3de56505d0748b0feed85
+Hash=5634ac93661cca0593834281e3527a6e
 


### PR DESCRIPTION
* Rewrote the inference rule and prose for `TypingRule.PropagateRecursiveCallsSess` to closer match the impementation and fix some bugs.
* Use a new example for `TypingRule.PropagateRecursiveCallsSess`.
* Fixed bugs in `TypingRule.TypecheckDecl`
* Fixes to section `Configurable Global Storage Declarations`
* Fixed a bug in `SemanticsRule.Call`.
* Fixed a bug in `TypingRule.DeclareOneFunc`
* Fixed a reference to an example in `TypingRule.BitFieldsEqual`
* A fix to the transitive closure utility function in `ASTUtils.ml`