### PR TITLE
[ASL][Reference] Fixes following PDF review - phase 2

### DIFF
--- a/asllib/bitvector.mli
+++ b/asllib/bitvector.mli
@@ -47,28 +47,28 @@ val zeros : int -> t
 (** [zeros n] is a bitvector of length [n] without any bit set. *)
 
 val of_string : string -> t
-(** [of_string s] interpretes [s] as a right-indexed representation of a
+(** [of_string s] interprets [s] as a right-indexed representation of a
     bitvector. Characters others than '0' or '1' are ignored. The length of
     [of_string s] is equal to the number of such characters in [s]. *)
 
 val of_int : int -> t
 (** [of_int i] is the bitvector of length [Sys.int_size] (e.g. 63) that
-    corresponds to [i] in little-endian, i.e. index 0 (for slicing operations
-    corresponds to [i mod 2]. *)
+    corresponds to [i] in two's complement little-endian, i.e. index 0
+    (for slicing operations corresponds to [i mod 2]. *)
 
 val of_int_sized : int -> int -> t
 (** [of_int n i] is the bitvector of length [n] that corresponds to [i] in
-    little-endian, i.e. index 0 (for slicing operations corresponds to
-    [i mod 2]. *)
+    two's complement little-endian, i.e. index 0 (for slicing operations
+    corresponds to [i mod 2]. *)
 
 val of_int64 : int64 -> t
 (** [of_int i] is the bitvector of length 64 that corresponds to [i] in
-    little-endian, i.e. index 0 (for slicing operations corresponds to
+    two's complement little-endian, i.e. index 0 (for slicing operations corresponds to
     [i mod 2]. *)
 
 val of_z : int -> Z.t -> t
 (** [of_int sz i] is the bitvector of length [sz] that corresponds to [i] in
-    little-endian. *)
+    two's complement little-endian. *)
 
 (* --------------------------------------------------------------------------*)
 (** {2 Exports} *)

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -323,7 +323,7 @@
 \newcommand\terminateas[0]{\hyperlink{def-terminateas}{\sslash}\;}
 \newcommand\booltrans[1]{\hyperlink{def-booltrans}{\textfunc{bool\_transition}}(#1)}
 \newcommand\booltransarrow[0]{\longrightarrow}
-\newcommand\checktrans[2]{\hyperlink{def-checktrans}{\textfunc{check}}(#1, \texttt{#2})}
+\newcommand\checktrans[2]{\hyperlink{def-checktrans}{\textfunc{check}}\left(#1, \texttt{#2}\right)}
 \newcommand\Prosechecktrans[2]{\hyperlink{def-checktrans}{checking} #1 yields $\True$\ProseTerminateAs{#2}}
 \newcommand\checktransarrow[0]{\longrightarrow}
 
@@ -1290,7 +1290,6 @@
 \newcommand\isglobalundefined[0]{\hyperlink{def-isglobalundefined}{\textfunc{is\_global\_undefined}}}
 \newcommand\islocalundefined[0]{\hyperlink{def-islocalundefined}{\textfunc{is\_local\_undefined}}}
 \newcommand\isundefined[0]{\hyperlink{def-isundefined}{\textfunc{is\_undefined}}}
-\newcommand\issubprogram[0]{\hyperlink{def-issubprogram}{\textfunc{is\_subprogram}}}
 \newcommand\lookupimmutableexpr[0]{\hyperlink{def-lookupimmutableexpr}{\textfunc{lookup\_immutable\_expr}}}
 \newcommand\addglobalimmutableexpr[0]{\hyperlink{def-addglobalimmutableexpr}{\textfunc{add\_global\_immutable\_expr}}}
 \newcommand\addlocalimmutableexpr[0]{\hyperlink{def-addlocalimmutableexpr}{\textfunc{add\_local\_immutable\_expr}}}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1976,10 +1976,10 @@
 %% Build Error Codes
 \newcommand\BuildErrorPrefix[0]{\texttt{BE}}
 \newcommand\BuildErrorCode[1]{\texttt{\BuildErrorPrefix\_#1}}
-\newcommand\LexicalError[0]{\hyperlink{def-lexicalerrorresult}{\BuildErrorCode{LE}}}
-\newcommand\LexicalErrorConfig[0]{\texttt{\#}\LexicalError}
+\newcommand\LexicalError[0]{\hyperlink{def-lexicalerrorresult}{\texttt{\#}\BuildErrorCode{LE}}}
+\newcommand\LexicalErrorConfig[0]{\LexicalError}
 \newcommand\ParseError[0]{\hyperlink{def-parseerror}{\BuildErrorCode{PE}}}
-\newcommand\ParseErrorConfig[0]{\hyperlink{def-parseerror}{\#\BuildErrorCode{PE}}}
+\newcommand\ParseErrorConfig[0]{\hyperlink{def-parseerror}{\texttt{\#}\BuildErrorCode{PE}}}
 \newcommand\ReservedIdentifier[0]{\hyperlink{def-reservedidentifier}{\BuildErrorCode{RI}}}
 \newcommand\BinopPrecedence[0]{\hyperlink{def-binopprecedence}{\BuildErrorCode{BOP}}}
 \newcommand\BuildBadDeclaration[0]{\hyperlink{def-buildbaddeclaration}{\BuildErrorCode{BD}}}

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -768,8 +768,8 @@ See \ExampleRef{Multi-assignments}.
 
 \begin{mathpar}
 \inferrule[non\_empty]{
-  \vlelist \eqname [\vle] \concat \vlelistone\\
-  \vmlist \eqname [\vm] \concat \vmlistone\\
+  \vlelist = [\vle] \concat \vlelistone\\
+  \vmlist = [\vm] \concat \vmlistone\\
   \evallexpr{\env, \vle, \vm} \evalarrow \Normal(\envone, \vgone) \OrAbnormal\\\\
   \evalmultiassignment(\envone, \vlelistone, \vmlistone) \evalarrow \Normal(\newenv, \vgtwo) \OrAbnormal\\\\
   \newg \eqdef \ordered{\vgone}{\aslpo}{\vgtwo}

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -430,12 +430,12 @@ resulting in a \dynamicerrorterm{}.
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[empty]{}{\findcatcher(\tenv, \vvty, \emptylist) \evalarrow \None}
+\inferrule[empty]{}{\findcatcher(\tenv, \vvty, \overname{\emptylist}{\catchers}) \evalarrow \None}
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[match]{
-  \catchers \eqname [\vc] \concat \catchersone\\
+  \catchers = [\vc] \concat \catchersone\\
   \vc \eqname (\nameopt, \ety, \vs) \\
   \subtypes(\tenv, \vvty, \ety)
 }{
@@ -445,7 +445,7 @@ resulting in a \dynamicerrorterm{}.
 
 \begin{mathpar}
 \inferrule[no\_match]{
-  \catchers \eqname [\vc] \concat \catchersone\\
+  \catchers = [\vc] \concat \catchersone\\
   \vc \eqname (\nameopt, \ety, \vs) \\
   \neg\subtypes(\tenv, \vvty, \ety)\\
   d \eqdef \findcatcher(\tenv, \vvty, \catchersone)

--- a/asllib/doc/GlobalDeclarations.tex
+++ b/asllib/doc/GlobalDeclarations.tex
@@ -207,7 +207,8 @@ and an example of a well-typed function --- \verb|flip_bits|.
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item annotating $\vf.\funcbody$ in $\tenv$ as per \TypingRuleRef{Block} yields $(\newbody, \vsesbody)$\ProseOrTypeError;
+  \item annotating $\vf.\funcbody$ in $\tenv$ as per \TypingRuleRef{Block} yields \\
+        $(\newbody, \vsesbody)$\ProseOrTypeError;
   \item \OneApplies
   \begin{itemize}
     \item \AllApplyCase{procedure}
@@ -236,7 +237,7 @@ and an example of a well-typed function --- \verb|flip_bits|.
   \vfp \eqdef \substrecordfield(\vf, \funcbody, \newbody)\\
   \vses \eqdef \vsesfuncsig \cup (\vsesbody \setminus \{ \vs \;|\; \configdomain{\vs} \in \{\ReadLocal, \WriteLocal\} \})
 }{
-  \annotatesubprogram(\tenv, \vf, \vsesfuncsig) \typearrow \vfp
+  \annotatesubprogram(\tenv, \vf, \vsesfuncsig) \typearrow (\vfp, \vses)
 }
 \end{mathpar}
 
@@ -250,7 +251,7 @@ and an example of a well-typed function --- \verb|flip_bits|.
   \vfp \eqdef \substrecordfield(\vf, \funcbody, \newbody)\\
   \vses \eqdef \vsesfuncsig \cup (\vsesbody \setminus \{ \vs \;|\; \configdomain{\vs} \in \{\ReadLocal, \WriteLocal\} \})
 }{
-  \annotatesubprogram(\tenv, \vf, \vsesfuncsig) \typearrow \vfp
+  \annotatesubprogram(\tenv, \vf, \vsesfuncsig) \typearrow (\vfp, \vses)
 }
 \end{mathpar}
 \identi{GHGK} \identr{HWTV} \identr{SCHV} \identr{VDPC}

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -131,20 +131,26 @@ All the global storage declarations in \listingref{local-storage-discards} are i
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[global\_uninit\_var]{
-}{
+\inferrule[global\_uninit\_var]{}{
   {
     \begin{array}{r}
       \builddecl(\overname{\Ndecl(\Tvar, \Tidentifier(\name), \Nasty, \Tsemicolon)}{\vparsednode}) \astarrow
     \end{array}
   } \\
-  \overname{\left[\DGlobalStorage(\{\GDkeyword: \GDKVar, \GDname: \name, \GDty: \langle\astof{\Nasty}\rangle, \GDinitialvalue: \None\})\right]}{\vastnode}
+  \overname{\left[\DGlobalStorage\left(
+    \left\{
+    \begin{array}{rcl}
+      \GDkeyword&:& \GDKVar,\\
+      \GDname&:& \name,\\
+      \GDty&:& \langle\astof{\Nasty}\rangle,\\
+      \GDinitialvalue&:& \None
+    \end{array}
+    \right\}\right)\right]}{\vastnode}
 }
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[global\_storage\_config]{
-}{
+\inferrule[global\_storage\_config]{}{
   {
     \begin{array}{r}
       \builddecl(\overname{\Ndecl(\Tconfig, \Tidentifier(\name), \Tcolon, \punnode{\Nty}, \Teq, \punnode{\Nexpr}, \Tsemicolon)}{\vparsednode}) \astarrow
@@ -198,7 +204,7 @@ The function
 \[
   \declareglobalstorage(\overname{\globalstaticenvs}{\tenv} \aslsep \overname{\globaldecl}{\gsd})
   \aslto
-  \overname{\globalstaticenvs}{\newgenv} \aslsep \overname{\globaldecl}{\newgsd}
+  (\overname{\globalstaticenvs}{\newgenv} \aslsep \overname{\globaldecl}{\newgsd})
   \cup
   \overname{\TTypeError}{\TypeErrorConfig}
 \]

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -404,8 +404,8 @@ See \ExampleRef{Evaluation of Tuple Declarations}.
 
 \begin{mathpar}
 \inferrule[non\_empty]{
-  \vids \eqname [\id] \concat \vids'\\
-  \liv \eqname [\vm] \concat \liv'\\
+  \vids = [\id] \concat \vids'\\
+  \liv = [\vm] \concat \liv'\\
   \vm \eqname (\vv, \vgone)\\\\
   \declarelocalidentifier(\env, \id, \vv) \evalarrow (\envone, \vgtwo)\\
   \ldituplefolder(\envone, \vids', \liv') \evalarrow \Normal(\vgthree, \newenv)\\

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -680,17 +680,15 @@ is defined by the following table:
 \]
 
 \begin{mathpar}
-\inferrule[empty]{
-  \vv \eqname \nvbitvector(\emptylist)
-}{
-  \evalpattern{\env, \vv, \PatternMask(\emptylist)} \evalarrow \Normal(\True, \emptygraph)
+\inferrule[empty]{}{
+  \evalpattern{\env, \overname{\nvbitvector(\emptylist)}{\vv}, \PatternMask(\emptylist)} \evalarrow \Normal(\True, \emptygraph)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[non\_empty]{
-  \vm \eqname \vm_{1..n}\\
-  \vv \eqname \nvbitvector(\vu_{1..n})\\
+  \vm = \vm_{1..n}\\
+  \vv = \nvbitvector(\vu_{1..n})\\
   \vb \eqdef \nvbool(\bigwedge_{i=1..n} \maskmatch(\vm_i, \vu_i))
 }{
   \evalpattern{\env, \vv, \PatternMask(\vm)} \evalarrow \Normal(\vb, \emptygraph)

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -482,7 +482,7 @@ of the subprogram declarations.
 }
 \and
 \inferrule[non\_empty]{
-  \tenv \eqdef (\genv, \lenv)\\
+  \tenv \eqname (\genv, \lenv)\\
   \declareonefunc(\tenv, \vf) \typearrow (\tenvone, \vfone) \OrTypeError\\\\
   \declaresubprograms(G^\tenvone, \envandfsone) \typearrow (\newgenv, \envandfstwo) \OrTypeError\\\\
   \newenvandfs \eqdef [(\lenv, \vfone, \vsesf)] \concat \envandfstwo

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -3696,7 +3696,7 @@ are evaluated in left-to-right order in the statement \verb|return (3 , 42);|.
 \subsubsection{Semantics}
 \begin{mathpar}
 \inferrule[non\_empty]{
-  \vEs \eqname [\ve] \concat \vesone\\
+  \vEs = [\ve] \concat \vesone\\
   \evalexpr{\env, \ve} \evalarrow \Normal(\vmone, \envone) \OrAbnormal\\
   \evalexprlistm(\envone, \vesone) \evalarrow \Normal(\vmsone, \newenv) \OrAbnormal
 }{

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -443,14 +443,13 @@ the type of \verb|EIGHT|, which is \verb|integer{8}|, \typesatisfies{} $\TInt(\p
 
 \FormallyParagraph
 \begin{mathpar}
-\inferrule[empty]{
-}{
+\inferrule[empty]{}{
   \checkparamstypesat(\tenv, \overname{\emptylist}{\funcsigparams}, \Ignore) \typearrow \True
 }
 \and
 \inferrule[parameterized]{
-  \funcsigparams \eqname [(\vx, \tydeclopt)] \concat \funcsigparamsone\\
-  \params \eqname [(\tyactual, \eactual, \vsesactual)] \concat \paramsone\\
+  \funcsigparams = [(\vx, \tydeclopt)] \concat \funcsigparamsone\\
+  \params = [(\tyactual, \eactual, \vsesactual)] \concat \paramsone\\
   \checksymbolicallyevaluable(\vsesactual) \typearrow \True\OrTypeError\\\\
   \checkconstrainedinteger(\tenv, \tyactual) \typearrow \True\OrTypeError\\\\
   \commonprefixline\\\\
@@ -461,8 +460,8 @@ the type of \verb|EIGHT|, which is \verb|integer{8}|, \typesatisfies{} $\TInt(\p
 }
 \and
 \inferrule[other]{
-  \funcsigparams \eqname [(\vx, \tydeclopt)] \concat \funcsigparamsone\\
-  \params \eqname [(\tyactual, \eactual, \vsesactual)] \concat \paramsone\\
+  \funcsigparams = [(\vx, \tydeclopt)] \concat \funcsigparamsone\\
+  \params = [(\tyactual, \eactual, \vsesactual)] \concat \paramsone\\
   \checksymbolicallyevaluable(\vsesactual) \typearrow \True\OrTypeError\\\\
   \checkconstrainedinteger(\tenv, \tyactual) \typearrow \True\OrTypeError\\\\
   \commonprefixline\\\\
@@ -1117,8 +1116,8 @@ that $\funcsigargs$ and $\argtypes$ have the same length.
 }
 \and
 \inferrule[non\_empty]{
-  \funcsigargs \eqname [(\Ignore, \tydecl)] \concat \funcsigargsone\\
-  \argtypes \eqname [\tyactual] \concat \argtypesone\\
+  \funcsigargs = [(\Ignore, \tydecl)] \concat \funcsigargsone\\
+  \argtypes = [\tyactual] \concat \argtypesone\\
   \renametyeqs(\tenv, \eqs, \tydecl) \typearrow \tydeclp\OrTypeError\\\\
   \checktypesat(\tenv, \tyactual, \tydeclp) \typearrow \True\OrTypeError\\\\
   \checkargstypesat(\tenv, \funcsigargsone, \argtypesone, \eqs) \typearrow \True\OrTypeError

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -741,7 +741,7 @@ Therefore, $\tenvwithparams$ effectively reflects the added declarations \\
 }
 \and
 \inferrule[non\_empty]{
-  \params \eqname [(\vx,\tyopt)] \concat \paramsp\\\\
+  \params = [(\vx,\tyopt)] \concat \paramsp\\\\
   \annotateoneparam(\tenv, \newtenv, (\vx, \tyopt)) \typearrow (\newtenvp, \tty) \OrTypeError \\\\
   \accp \eqdef \acc \concat [(\vx, \tty)] \\\\
   \annotateparams(\tenv, \paramsp, (\newtenvp, \accp)) \typearrow (\tenvwithparams, \paramsone) \OrTypeError
@@ -1347,7 +1347,7 @@ In \listingref{typing-parameterofconstraint}, the annotated arguments are
 }
 \and
 \inferrule[non\_empty]{
-  \vargs \eqname [(\vx,\tty)] \concat \vargsp\\\\
+  \vargs = [(\vx,\tty)] \concat \vargsp\\\\
   \annotateonearg(\tenv, \newtenv, (\vx, \tty)) \typearrow (\newtenvp, \ttyp, \vsesty) \OrTypeError \\\\
   \accp \eqdef \acc \concat [(\vx, \ttyp)] \\\\
   \annotateargs(\tenv, \vargsp, (\newtenvp, \accp), \vsesin) \typearrow (\tenvwithargs, \newargs, \newses) \OrTypeError\\\\

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -197,12 +197,12 @@ transforms a parse node $\vparsednode$ into an $\accessorpair$.
 \inferrule{
   \buildaccessors(\vaccessors) \astarrow \vaccessorpair
 }{
-    \builddecl\left(\overname{\Ndecl\left(
+    \buildaccessorbody\left(\overname{\Ndecl\left(
       \begin{array}{l}
         \Tbegin, \namednode{\vaccessors}{\Naccessors}, \Tend, \Tsemicolon
       \end{array}
     \right)}{\vparsednode}\right)
-  \astarrow \vastnode
+  \astarrow \vaccessorpair
 }
 \end{mathpar}
 

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -628,7 +628,7 @@ based on the \approximationdirectionterm\ $\vapprox$.
 \inferrule[under]{
   \vc \in \cs: \approxconstraint(\tenv, \vapprox, \vc) \typearrow \vs_\vc
 }{
-  \approxconstraints(\tenv, \vapprox, \cs) \typearrow
+  \approxconstraints(\tenv, \overname{\Under}{\vapprox}, \cs) \typearrow
   \overname{\bigcap_{\vc \in \cs} \vs_\vc}{\vs}
 }
 \end{mathpar}

--- a/asllib/doc/TopLevel.tex
+++ b/asllib/doc/TopLevel.tex
@@ -1237,7 +1237,7 @@ yielding the \assignableexpression\ $\newle$.
 \hypertarget{def-renamelocalsldi}{}
 The helper function
 \[
-\renamelocalsldi(\overname{\localdeclarationitem}{\ldi}) \aslto \overname{\localdeclarationitem}{\newldi}
+\renamelocalsldi(\overname{\localdeclitem}{\ldi}) \aslto \overname{\localdeclitem}{\newldi}
 \]
 renames the local storage elements appearing in the local declaration item $\ldi$,
 yielding the local declaration item $\newldi$.

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -538,27 +538,6 @@ Define $\vb$ as $\True$ if and only if $\vx$ is not bound in the $\localstoraget
 \end{mathpar}
 \CodeSubsection{\IsLocalUndefinedBegin}{\IsLocalUndefinedEnd}{../StaticEnv.ml}
 
-\TypingRuleDef{IsSubprogram}
-\hypertarget{def-issubprogram}{}
-The function
-\[
-\issubprogram(\overname{\staticenvs}{\tenv} \aslsep \overname{\identifier}{vx}) \aslto \overname{\Bool}{\vb}
-\]
-checks whether the identifier $\vx$ has been declared as a subprogram in the static environment $\tenv$,
-yielding an answer in $\vb$.
-
-\ProseParagraph
-Define $\vb$ as $\True$ if and only if $\vx$ is bound in the $\subprograms$ map in the global static
-environment of $\tenv$.
-
-\FormallyParagraph
-\begin{mathpar}
-\inferrule{}{
-  \issubprogram(\tenv, \vx) \typearrow \overname{G^\tenv.\subprograms[\vx] \neq \bot}{\vb}
-}
-\end{mathpar}
-\CodeSubsection{\IsSubprogramBegin}{\IsSubprogramEnd}{../StaticEnv.ml}
-
 \TypingRuleDef{LookupConstant}
 \hypertarget{def-lookupconstant}{}
 The function

--- a/asllib/tests/ASLTypingReference.t/TypingRule.Normalize.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.Normalize.asl
@@ -1,6 +1,6 @@
 func main() => integer
 begin
-                                // normalizes rhs expression
+                                // normalized rhs expression
     constant ONE = 1;           // 1
     var o = ONE;                // 1
     - = 5.0;                    // 5.0
@@ -10,10 +10,10 @@ begin
 
     var y : integer{1, 2, 3};
     var z : integer{4, 5, 6};
-    var p1 = (y + 5) - z;        // 5 + y - x
-    var p2 = (z DIV 2) * y;      // (z * y) DIV 2
-    var p3 = z * (y DIV 2);      // (z * y) DIV 2
-    var p4 = z * (z * y);        // z^2 * y
+    var p1 = (y + 5) - z;        // (y + 5) - z
+    var p2 = (z DIV 2) * y;      // (z DIV 2) * y
+    var p3 = z * (y DIV 2);      // z * (y DIV 2)
+    var p4 = z * (z * y);        // z * (z * y)
     var p5 = z as integer{4, 5}; // z
     var p6 = z ^ y;              // z ^ y
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ToIR.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ToIR.asl
@@ -10,10 +10,10 @@ begin
 
     var y : integer{1, 2, 3};
     var z : integer{4, 5, 6};
-    var p1 = (y + 5) - z;        // 5 + y - x
-    var p2 = (z DIV 2) * y;      // (z * y) DIV 2
-    var p3 = z * (y DIV 2);      // (z * y) DIV 2
-    var p4 = z * (z * y);        // z^2 * y
+    var p1 = (y + 5) - z;        // ((y + 5) - z)
+    var p2 = (z DIV 2) * y;      // ((z DIV 2) * y)
+    var p3 = z * (y DIV 2);      // (z * (y DIV 2))
+    var p4 = z * (z * y);        // (z * (z * y))
     var p5 = z as integer{4, 5}; // z
     var p6 = z ^ y;              // Top
 


### PR DESCRIPTION
* Fixed [asl][reference] fixed `\eqname` vs. `=` errors.
* Other fixed, following PDF review.