### PR TITLE
[tools] Fix the pretty-printing of the transitive closure operator '+' by miaou.

### DIFF
--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -394,25 +394,17 @@ module Make
            match ASTUtils.as_vars es with
            | None -> raise Exit
            | Some ids ->
-              let itms =
-                List.map
-                  (fun (loc,id) -> tr_rel_id e1 e2  loc id)
-                  ids
-              and lst =
-                let names =
-                  List.map (fun (_,id) -> id_name id) ids
-                  |> String.concat pp_op in
-                pp_rel_id e1 e2 (pp_transitive names) in
-              itms,lst in
+               let names =
+                 List.map (fun (_,id) -> id_name id) ids
+                 |> String.concat pp_op in
+               pp_rel_id e1 e2 (pp_transitive names) in
          begin
            try
              match op with
              | Union ->
-                let itms,lst = tr_es "{} or " in
-                mk_list Union (itms@[lst])
+                tr_es "{} or "
              | Inter ->
-                let itms,lst = tr_es "{} and " in
-                mk_list Union [mk_list Inter itms;lst;]
+                tr_es "{} and "
              | _ -> tr_fail loc
            with Exit -> tr_fail loc
          end


### PR DESCRIPTION
Yet another problem with **miaou**: useless and disturbing expansion of transitive closure. Currently, **miaou** only accepts transitive closures when applied to disjunctions and conjunctions of names. But it does so in a contrived way, applying some expansion.

For instance, the tool **miaou** described `let frel = (erel|drel)+` as:
```
There is a *f-rel* from an Effect E~1~ to an Effect E~2~ if one of the following applies:
-   There is a d-rel from E~1~ to E~2~.
-   There is a e-rel from E~1~ to E~2~.
-   There exists a chain of d-rel or e-rel from E~1~ to E~2~.
```
After this PR, output is:
```
There is a *f-rel* from an Effect E~1~ to an Effect E~2~ if There exists a chain of d-rel or e-rel from E~1~ to E~2~.
```

