### PR TITLE
[ASL] make dune ignore the asllib/acl2 subdirectory

### DIFF
--- a/asllib/dune
+++ b/asllib/dune
@@ -20,6 +20,8 @@
  (modules Parser0)
  (flags --unused-tokens --table))
 
+(data_only_dirs acl2)
+
 (rule
  (deps
   (:v1 libdir/stdlib.asl)


### PR DESCRIPTION
The dune/dune-project files under asllib/acl2/aslreftests should not be used by other dune builds. This change makes regular dune builds for herd and asllib ignore them.