### PR TITLE
[asl] removed '-' from pending constrained integer syntax

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -292,7 +292,11 @@ let expr :=
 let constraint_kind_opt := constraint_kind | { UnConstrained }
 let constraint_kind :=
   | cs=braced(clist1(int_constraint)); { WellConstrained (cs, Precision_Full) }
-  | braced(MINUS); { PendingConstrained }
+  | braced(MINUS); {
+    if Config.allow_hyphenated_pending_constraint then PendingConstrained
+      else Error.fatal_here $startpos $endpos @@ Error.ObsoleteSyntax "Hyphenated pending constraint."
+  }
+  | LBRACE; RBRACE; { PendingConstrained }
 
 let int_constraint :=
   | ~=expr;                     < Constraint_Exact >

--- a/asllib/ParserConfig.mli
+++ b/asllib/ParserConfig.mli
@@ -30,4 +30,7 @@ module type CONFIG = sig
 
   val allow_storage_discards : bool
   (** Allow storage declarations to discard their right-hand sides. *)
+
+  val allow_hyphenated_pending_constraint : bool
+  (** Allow pending constrained integer types to be denoted by a hyphen. *)
 end

--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -34,6 +34,7 @@ type args = {
   allow_double_underscore : bool;
   allow_unknown : bool;
   allow_storage_discards : bool;
+  allow_hyphenated_pending_constraint : bool;
   print_ast : bool;
   print_lisp : bool;
   print_serialized : bool;
@@ -59,6 +60,7 @@ let parse_args () =
   let allow_double_underscore = ref false in
   let allow_unknown = ref false in
   let allow_storage_discards = ref false in
+  let allow_hyphenated_pending_constraint = ref false in
   let print_ast = ref false in
   let print_serialized = ref false in
   let print_typed = ref false in
@@ -96,6 +98,9 @@ let parse_args () =
       ( "--allow-storage-discards",
         Arg.Set allow_storage_discards,
         " Allow storage declarations that discard their right-hand sides." );
+      ( "--allow-hyphenated-pending-constraint",
+        Arg.Set allow_hyphenated_pending_constraint,
+        " Allow pending constraints to be denoted by a hyphen." );
       ( "--print",
         Arg.Set print_ast,
         " Print the parsed AST to stdout before executing it." );
@@ -194,6 +199,7 @@ let parse_args () =
       allow_double_underscore = !allow_double_underscore;
       allow_unknown = !allow_unknown;
       allow_storage_discards = !allow_storage_discards;
+      allow_hyphenated_pending_constraint = !allow_hyphenated_pending_constraint;
       print_ast = !print_ast;
       print_serialized = !print_serialized;
       print_typed = !print_typed;
@@ -248,6 +254,9 @@ let () =
     let allow_double_underscore = args.allow_double_underscore in
     let allow_unknown = args.allow_unknown in
     let allow_storage_discards = args.allow_storage_discards in
+    let allow_hyphenated_pending_constraint =
+      args.allow_hyphenated_pending_constraint
+    in
     let open Builder in
     {
       allow_no_end_semicolon;
@@ -255,6 +264,7 @@ let () =
       allow_double_underscore;
       allow_unknown;
       allow_storage_discards;
+      allow_hyphenated_pending_constraint;
     }
   in
 

--- a/asllib/builder.ml
+++ b/asllib/builder.ml
@@ -34,6 +34,7 @@ type parser_config = {
   allow_double_underscore : bool;
   allow_unknown : bool;
   allow_storage_discards : bool;
+  allow_hyphenated_pending_constraint : bool;
 }
 
 type version_selector = [ `ASLv0 | `ASLv1 | `Any ]
@@ -45,6 +46,7 @@ let default_parser_config =
     allow_double_underscore = false;
     allow_unknown = false;
     allow_storage_discards = false;
+    allow_hyphenated_pending_constraint = false;
   }
 
 let select_type ~opn ~ast = function
@@ -78,6 +80,9 @@ let from_lexbuf ast_type parser_config version (lexbuf : lexbuf) =
         let allow_no_end_semicolon = parser_config.allow_no_end_semicolon
         let allow_expression_elsif = parser_config.allow_expression_elsif
         let allow_storage_discards = parser_config.allow_storage_discards
+
+        let allow_hyphenated_pending_constraint =
+          parser_config.allow_hyphenated_pending_constraint
       end) in
       let module Lexer = Lexer.Make (struct
         let allow_double_underscore = parser_config.allow_double_underscore

--- a/asllib/builder.mli
+++ b/asllib/builder.mli
@@ -35,6 +35,7 @@ type parser_config = {
   allow_double_underscore : bool;
   allow_unknown : bool;
   allow_storage_discards : bool;
+  allow_hyphenated_pending_constraint : bool;
 }
 
 val default_parser_config : parser_config

--- a/asllib/bundler.ml
+++ b/asllib/bundler.ml
@@ -55,6 +55,7 @@ let build_ast_from_file ?(is_opn = false) f =
     let allow_no_end_semicolon = false
     let allow_expression_elsif = false
     let allow_storage_discards = false
+    let allow_hyphenated_pending_constraint = false
   end) in
   let module Lexer = Lexer.Make (struct
     let allow_double_underscore = false

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -476,7 +476,7 @@ it must declare a new variable.
 \begin{flalign*}
 \Nconstraintkind \derives \ &
        \Tlbrace \parsesep \ClistOne{\Nintconstraint} \parsesep \Trbrace &\\
-  |\ & \Tlbrace \parsesep \Tminus \parsesep \Trbrace &
+  |\ & \Tlbrace \parsesep \Trbrace &
 \end{flalign*}
 
 \hypertarget{def-nintconstraint}{}

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -167,7 +167,7 @@ is a parameterized integer type, \underline{not} an unconstrained integer type.
 \Nty \derives\ & \Tinteger \parsesep \Nconstraintkindopt &\\
 \Nconstraintkindopt \derives \ & \Nconstraintkind \;|\; \emptysentence &\\
 \Nconstraintkind \derives \ & \Tlbrace \parsesep \ClistOne{\Nintconstraint} \parsesep \Trbrace &\\
-|\ & \Tlbrace \parsesep \Tminus \parsesep \Trbrace &\\
+|\ & \Tlbrace \parsesep \Trbrace &\\
 \Nintconstraint \derives \ & \Nexpr &\\
 |\ & \Nexpr \parsesep \Tslicing \parsesep \Nexpr &
 \end{flalign*}
@@ -244,7 +244,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
 \begin{mathpar}
 \inferrule[pending\_constrained]{}{
-  \buildconstraintkind(\Nconstraintkind(\Tlbrace, \Tminus, \Trbrace)) \astarrow
+  \buildconstraintkind(\Nconstraintkind(\Tlbrace, \Trbrace)) \astarrow
   \overname{\pendingconstrained}{\vastnode}
 }
 \end{mathpar}

--- a/asllib/menhir2bnfc/tests/integration/parser_cmp.expected
+++ b/asllib/menhir2bnfc/tests/integration/parser_cmp.expected
@@ -1,3 +1,4 @@
+FAIL - aslref false | bnfc true: asllib/tests/regressions.t/hyphenated-pending-constraint.asl
 FAIL - aslref false | bnfc true: asllib/tests/regressions.t/lhs-tuple-fields-same-field.asl
 FAIL - aslref false | bnfc true: asllib/tests/regressions.t/same-precedence.asl
 FAIL - aslref false | bnfc true: asllib/tests/regressions.t/same-precedence2.asl

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.config.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.config.asl
@@ -6,4 +6,4 @@ config c_unconstrained_int : integer = 5;
 // The next declaration in comment is illegal,
 // since pending constraints are not allowed
 // for configuration storage elements.
-// config c_inherited_constrained : integer{-} = 5;
+// config c_inherited_constrained : integer{} = 5;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.non_config.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DeclareGlobalStorage.non_config.asl
@@ -3,18 +3,18 @@ constant x = 5;
 var c_var : integer{1..x} = (x - 1) + y;
 var c_var_unconstrained_int : integer = 5;
 var c_var_well_constrained : integer{0..10} = 5;
-var c_var_inherited_constrained : integer{-} = 2^128;
+var c_var_inherited_constrained : integer{} = 2^128;
 var c_var_no_type_annotation = (x - 1) + y;
 
 // The next two declarations in comment are illegal,
 // as inherited constraints require an initializing
 // expression.
-// var c_var_inherited_illegal : integer{-};
-// var c_let_illegal : integer{-};
+// var c_var_inherited_illegal : integer{};
+// var c_let_illegal : integer{};
 
 let c_let : integer{1..x} = (x - 1) + y;
 let c_let_unconstrained_int : integer = 5;
-let c_let_inherited_constrained : integer{-} = c_var;
+let c_let_inherited_constrained : integer{} = c_var;
 let c_let_well_constrained : integer{0..10} = 5;
 
 let c_let_no_type_annotation = (x - 1) + y;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ExplodeIntervals.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ExplodeIntervals.bad.asl
@@ -4,8 +4,8 @@ constant C = -(1 << 12);
 
 func foo(a: integer {C..0, 0..A}, b: integer{C..0, 0..B})
 begin
-    var y: integer {-} = a * 2;
+    var y: integer{} = a * 2;
 
     // Illegal: the storage type for z includes precision loss.
-    var z: integer {-} = b * 2;
+    var z: integer{} = b * 2;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.FilterReduceConstraintDiv.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.FilterReduceConstraintDiv.asl
@@ -2,7 +2,7 @@ func foo{A, B}(a: integer{A}, b: integer{B})
 begin
     var x: integer{2, 3, 5..A, A..10, A..B, 7..10, 14..17, 16..15} = 2;
     var y = 2;
-    var z: integer{-} = x DIV y;
+    var z: integer{} = x DIV y;
     var z_typed : integer{
         1,
         3..(A DIV 2),

--- a/asllib/tests/ASLTypingReference.t/TypingRule.InheritIntegerConstraints.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.InheritIntegerConstraints.asl
@@ -2,11 +2,11 @@ constant max_bits = 64;
 var b : integer{1..5, 7, 20..max_bits};
 var c : integer{6..9};
 
-var d : integer{-} = b + c;
+var d : integer{} = b + c;
 
 func main() => integer
 begin
-    var e : integer{-} = b + c;
-    var f : integer{-} = 5;
+    var e : integer{} = b + c;
+    var f : integer{} = 5;
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.InheritIntegerConstraints.unconstrained.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.InheritIntegerConstraints.unconstrained.bad.asl
@@ -2,6 +2,6 @@ func main() => integer
 begin
     var a : integer;
     // The following is illegal as 'a' is not a constrained integer.
-    var g : integer{-} = a;
+    var g : integer{} = a;
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.IntervalTooLarge.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.IntervalTooLarge.asl
@@ -2,7 +2,7 @@ constant A = 1 << 2;
 
 func foo(a: integer {0..A})
 begin
-    var z: integer {-} = a * 2;
+    var z: integer{} = a * 2;
     // The type of z is detailed in the type of w below.
     var w: integer {0, 2, 4, 6, 8} = (a * 2);
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.IntervalTooLarge.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.IntervalTooLarge.bad.asl
@@ -3,8 +3,8 @@ constant B = 1 + 1 << 14;
 
 func foo(a: integer {0..A}, b: integer{0..B})
 begin
-    var y: integer {-} = a * 2;
+    var y: integer{} = a * 2;
 
     // Illegal: the storage type for z includes precision loss.
-    var z: integer {-} = b * 2;
+    var z: integer{} = b * 2;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.RefineConstraintBySign.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.RefineConstraintBySign.asl
@@ -11,7 +11,7 @@ begin
         B.. -1,
         A..B
     } = 0;
-    var z: integer{-} = A DIV y;
+    var z: integer{} = A DIV y;
     // The following type represents the type constraints generated for `A DIV y`
     // with each constraints followed by a comment denoting the corresponding
     // constraint of `y`.

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TInt.config_pending_constrained.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TInt.config_pending_constrained.bad.asl
@@ -1,1 +1,1 @@
-config x : integer{-} =  1;
+config x : integer{} =  1;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TInt.rhs_pending_constrained.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TInt.rhs_pending_constrained.bad.asl
@@ -2,6 +2,6 @@ func main() => integer
 begin
     // Pending-constrained integer types are illegal
     // in right-hand-side expressions.
-    var x : integer{1..2} = 3 as integer{-};
+    var x : integer{1..2} = 3 as integer{};
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -98,25 +98,25 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.InheritIntegerConstraints.asl
   $ aslref TypingRule.InheritIntegerConstraints.unconstrained.bad.asl
   File TypingRule.InheritIntegerConstraints.unconstrained.bad.asl, line 5,
-    characters 4 to 27:
-      var g : integer{-} = a;
-      ^^^^^^^^^^^^^^^^^^^^^^^
+    characters 4 to 26:
+      var g : integer{} = a;
+      ^^^^^^^^^^^^^^^^^^^^^^
   ASL Type error: constrained integer expected, provided integer.
   [1]
 
   $ aslref --no-exec TypingRule.TInt.config_pending_constrained.bad.asl
   File TypingRule.TInt.config_pending_constrained.bad.asl, line 1,
-    characters 0 to 27:
-  config x : integer{-} =  1;
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    characters 0 to 26:
+  config x : integer{} =  1;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Type error: a pending constrained integer is illegal here.
   [1]
 
   $ aslref TypingRule.TInt.rhs_pending_constrained.bad.asl
   File TypingRule.TInt.rhs_pending_constrained.bad.asl, line 5,
-    characters 28 to 43:
-      var x : integer{1..2} = 3 as integer{-};
-                              ^^^^^^^^^^^^^^^
+    characters 28 to 42:
+      var x : integer{1..2} = 3 as integer{};
+                              ^^^^^^^^^^^^^^
   ASL Type error: a pending constrained integer is illegal here.
   [1]
 
@@ -1004,33 +1004,33 @@ ASL Typing Tests / annotating types:
   [1]
   $ aslref --no-exec TypingRule.IntervalTooLarge.asl
   $ aslref --no-exec TypingRule.IntervalTooLarge.bad.asl
-  File TypingRule.IntervalTooLarge.bad.asl, line 9, characters 25 to 30:
-      var z: integer {-} = b * 2;
-                           ^^^^^
+  File TypingRule.IntervalTooLarge.bad.asl, line 9, characters 23 to 28:
+      var z: integer{} = b * 2;
+                         ^^^^^
   Interval too large: [ 0 .. 16385 ]. Keeping it as an interval.
-  File TypingRule.IntervalTooLarge.bad.asl, line 9, characters 4 to 31:
-      var z: integer {-} = b * 2;
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File TypingRule.IntervalTooLarge.bad.asl, line 9, characters 4 to 29:
+      var z: integer{} = b * 2;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Type error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref --no-exec TypingRule.ExplodeIntervals.bad.asl
-  File TypingRule.ExplodeIntervals.bad.asl, line 10, characters 25 to 30:
-      var z: integer {-} = b * 2;
-                           ^^^^^
+  File TypingRule.ExplodeIntervals.bad.asl, line 10, characters 23 to 28:
+      var z: integer{} = b * 2;
+                         ^^^^^
   Interval too large: [ 0 .. 16385 ]. Keeping it as an interval.
-  File TypingRule.ExplodeIntervals.bad.asl, line 10, characters 4 to 31:
-      var z: integer {-} = b * 2;
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File TypingRule.ExplodeIntervals.bad.asl, line 10, characters 4 to 29:
+      var z: integer{} = b * 2;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Type error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref --no-exec TypingRule.FilterReduceConstraintDiv.asl
   $ aslref TypingRule.ReduceToZOpt.asl
   $ aslref --no-exec TypingRule.RefineConstraintBySign.asl
-  File TypingRule.RefineConstraintBySign.asl, line 14, characters 24 to 31:
-      var z: integer{-} = A DIV y;
-                          ^^^^^^^
+  File TypingRule.RefineConstraintBySign.asl, line 14, characters 23 to 30:
+      var z: integer{} = A DIV y;
+                         ^^^^^^^
   Warning: Removing some values that would fail with op DIV from constraint set
   {-4..-3, -1..2, -1..B, 0, 1, 3..4, A..B, B, B..-1} gave
   {1..2, 1..B, 1, 3..4, A..B, B, B..-1}. Continuing with this constraint set.

--- a/asllib/tests/constraint-size-limits.t/global-pending.asl
+++ b/asllib/tests/constraint-size-limits.t/global-pending.asl
@@ -4,7 +4,7 @@ constant B = 1 << 10;
 let a = ARBITRARY: integer {0..A};
 let b = ARBITRARY: integer {1..B};
 
-var z: integer {-} = a * b;
+var z: integer{} = a * b;
 
 func main () => integer
 begin

--- a/asllib/tests/constraint-size-limits.t/pending.asl
+++ b/asllib/tests/constraint-size-limits.t/pending.asl
@@ -3,7 +3,7 @@ constant B = 1 << 20;
 
 func myfunction(a: integer {0..A}, b: integer {1..B})
 begin
-  var z : integer {-} = a * b;
+  var z : integer{} = a * b;
 end;
 
 func main () => integer

--- a/asllib/tests/constraint-size-limits.t/run.t
+++ b/asllib/tests/constraint-size-limits.t/run.t
@@ -298,26 +298,26 @@ Other operations
 
 With pending constraints
   $ aslref pending.asl
-  File pending.asl, line 6, characters 24 to 29:
-    var z : integer {-} = a * b;
-                          ^^^^^
+  File pending.asl, line 6, characters 22 to 27:
+    var z : integer{} = a * b;
+                        ^^^^^
   Interval too large: [ 1 .. 1048576 ]. Keeping it as an interval.
-  File pending.asl, line 6, characters 2 to 30:
-    var z : integer {-} = a * b;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File pending.asl, line 6, characters 2 to 28:
+    var z : integer{} = a * b;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Type error: type used to define storage item is the result of precision
     loss.
   [1]
   $ aslref global-pending.asl
-  File global-pending.asl, line 7, characters 21 to 26:
-  var z: integer {-} = a * b;
-                       ^^^^^
+  File global-pending.asl, line 7, characters 19 to 24:
+  var z: integer{} = a * b;
+                     ^^^^^
   Exploding sets for the binary operation * could result in a constraint set
   bigger than 2^17 with constraints 0..1024 and 1..1024. Continuing with the
   non-expanded constraints.
-  File global-pending.asl, line 7, characters 0 to 27:
-  var z: integer {-} = a * b;
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File global-pending.asl, line 7, characters 0 to 25:
+  var z: integer{} = a * b;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Type error: type used to define storage item is the result of precision
     loss.
   [1]

--- a/asllib/tests/regressions.t/hyphenated-pending-constraint.asl
+++ b/asllib/tests/regressions.t/hyphenated-pending-constraint.asl
@@ -1,0 +1,5 @@
+func main() => integer
+begin
+    let x: integer{-} = 5;
+    return 0;
+end;

--- a/asllib/tests/regressions.t/inherit-integer-constraints-bad-basic.asl
+++ b/asllib/tests/regressions.t/inherit-integer-constraints-bad-basic.asl
@@ -1,6 +1,6 @@
 func bad_basic() => integer{43}
 begin
-  let x : integer{-} = 42;
+  let x : integer{} = 42;
   return x;
 end;
 

--- a/asllib/tests/regressions.t/inherit-integer-constraints-bad-tuple.asl
+++ b/asllib/tests/regressions.t/inherit-integer-constraints-bad-tuple.asl
@@ -1,6 +1,6 @@
 func bad_tuple() => (integer{42}, integer{0})
 begin
-  let y : (integer{-}, boolean, integer{-}) = (42, TRUE, 43);
+  let y : (integer{}, boolean, integer{}) = (42, TRUE, 43);
   return (y.item0, y.item2);
 end;
 

--- a/asllib/tests/regressions.t/inherit-integer-constraints-bad-type.asl
+++ b/asllib/tests/regressions.t/inherit-integer-constraints-bad-type.asl
@@ -1,5 +1,5 @@
 type badtype of record {
-    a : integer{-},
+    a : integer{},
     c : integer
 };
 

--- a/asllib/tests/regressions.t/inherit-integer-constraints.asl
+++ b/asllib/tests/regressions.t/inherit-integer-constraints.asl
@@ -2,27 +2,27 @@ type foo of (integer{1}, boolean);
 
 func good_basic() => integer{42}
 begin
-  let x : integer{-} = 42;
+  let x : integer{} = 42;
   return x;
 end;
 
 func good_tuple() => (integer{42}, integer{43})
 begin
-  let y : (integer{-}, boolean, integer{-}) = (42, TRUE, 43);
+  let y : (integer{}, boolean, integer{}) = (42, TRUE, 43);
   return (y.item0, y.item2);
 end;
 
 func good_named_tuple() => (integer{1}, boolean)
 begin
   var f : foo;
-  let z : (integer{-}, boolean) = f;
+  let z : (integer{}, boolean) = f;
   return z;
 end;
 
 // Globals
-var A : integer{-} = 1;
-let B : integer{-} = 1;
-constant C : integer{-} = 1;
+var A : integer{} = 1;
+let B : integer{} = 1;
+constant C : integer{} = 1;
 
 func acceptOnlyOne(x: integer{1})
 begin

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -570,7 +570,7 @@ Inherit integer constraints on left-hand sides
   File inherit-integer-constraints-bad-type.asl, line 1, character 0 to line 4,
     character 2:
   type badtype of record {
-      a : integer{-},
+      a : integer{},
       c : integer
   };
   ASL Type error: a pending constrained integer is illegal here.
@@ -586,3 +586,10 @@ Left-hand sides
   [1]
   $ aslref lhs-tuple-same-var.asl
   $ aslref lhs-expressivity.asl
+  $ aslref --allow-hyphenated-pending-constraint hyphenated-pending-constraint.asl
+  $ aslref hyphenated-pending-constraint.asl
+  File hyphenated-pending-constraint.asl, line 3, characters 18 to 21:
+      let x: integer{-} = 5;
+                    ^^^
+  ASL Grammar error: Obsolete syntax: Hyphenated pending constraint.
+  [1]

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -225,6 +225,7 @@ let stmts_from_string s =
     let allow_no_end_semicolon = false
     let allow_expression_elsif = false
     let allow_storage_discards = false
+    let allow_hyphenated_pending_constraint = false
   end) in
   let module Lexer = Lexer.Make(struct
     let allow_double_underscore = false


### PR DESCRIPTION
This PR changes the syntax of pending integer constraints from `integer{-}` to `integer{}`. 
The change does not incur any conflicts during parser building.
More specifically:
* The old `integer{-}` syntax is hidden behind the new `--allow-hyphenated-pending-constraint` command line flag.
* Updated `Parser.mly`
* Updated ASL Reference.
* Updated the relevant tests.
* Added the test `regressions.t/hyphenated-pending-constraint.asl` to test the behaviour of the new command line flag.