### PR TITLE
[asl] Fix `menhir2bnfc` tests

### DIFF
--- a/.github/workflows/menhir2bnfc.yml
+++ b/.github/workflows/menhir2bnfc.yml
@@ -8,6 +8,7 @@ on:
       - 'asllib/Parser.mly'
       - 'asllib/Lexer.mll'
       - 'asllib/Tokens.mly'
+      - 'asllib/**.asl'
   # push:
   workflow_dispatch:
   schedule:

--- a/asllib/menhir2bnfc/tests/integration/parser_cmp.expected
+++ b/asllib/menhir2bnfc/tests/integration/parser_cmp.expected
@@ -1,3 +1,6 @@
+FAIL - aslref false | bnfc true: asllib/tests/ASLSyntaxReference.t/ASTRule.EBinop.bad1.asl
+FAIL - aslref false | bnfc true: asllib/tests/ASLSyntaxReference.t/ASTRule.EBinop.bad2.asl
+FAIL - aslref false | bnfc true: asllib/tests/ASLSyntaxReference.t/ASTRule.EBinop.bad3.asl
 FAIL - aslref false | bnfc true: asllib/tests/regressions.t/hyphenated-pending-constraint.asl
 FAIL - aslref false | bnfc true: asllib/tests/regressions.t/lhs-tuple-fields-same-field.asl
 FAIL - aslref false | bnfc true: asllib/tests/regressions.t/same-precedence.asl


### PR DESCRIPTION
New tests from https://github.com/herd/herdtools7/pull/1327 need to be added to the expected discrepancies.

This was missed as the `menhir2bnfc` CI did not trigger - so ensure that this runs whenever any `.asl` files change.