### PR TITLE
[herd] Include faults in events displayed by mode `-showevents memf`

### DIFF
--- a/herd/Pretty.ml
+++ b/herd/Pretty.ml
@@ -1519,7 +1519,8 @@ module Make (S:SemExtra.S) : S with module S = S  = struct
   | AllEvents -> (fun _ -> true)
   | MemEvents ->  E.is_mem
   | NonRegEvents -> (fun e -> not (E.is_reg_any e))
-  | MemFenceEvents -> let open Misc in E.is_mem ||| E.is_barrier
+  | MemFenceEvents -> let open Misc in E.is_mem ||| E.is_barrier ||| E.is_fault
+
   let select_event = let open Misc in select_event &&& select_non_init
 
   let select_events = E.EventSet.filter select_event

--- a/herd/prettyConf.ml
+++ b/herd/prettyConf.ml
@@ -82,7 +82,11 @@ let parse_dotcom = function
   | _ -> None
 
 (* Events shown in figures *)
-type showevents = AllEvents | MemEvents | NonRegEvents | MemFenceEvents
+type showevents =
+  | AllEvents
+  | MemEvents
+  | NonRegEvents
+  | MemFenceEvents
 
 let tags_showevents = ["all"; "mem"; "noregs";"memf";]
 
@@ -96,7 +100,7 @@ let parse_showevents = function
   | "all"  -> Some AllEvents
   | "mem"|"memory" -> Some MemEvents
   | "noregs" -> Some NonRegEvents
-  | "memf"|"memfence" -> Some MemFenceEvents
+  | "memf"|"memfence"|"memfault" -> Some MemFenceEvents
   | _ -> None
 
 


### PR DESCRIPTION
This mode is also selected by the synonyms `memfence` and `memfault`.