### PR TITLE
ASL examples from the ASL Reference predecessor - phase 3

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1619,11 +1619,13 @@
 \newcommand\collectiontypesterm[0]{\hyperlink{collectiontypeterm}{collection types}}
 \newcommand\recordtypesterm[0]{\hyperlink{recordtypeterm}{record types}}
 \newcommand\unconstrainedintegertype[0]{\hyperlink{def-unconstrainedintegertype}{unconstrained integer type}}
+\newcommand\unconstrainedintegertypes[0]{\hyperlink{def-unconstrainedintegertype}{unconstrained integer types}}
 \newcommand\parameterizedintegertype[0]{\hyperlink{def-parameterizedintegertype}{parameterized integer type}}
 \newcommand\parameterizedintegertypes[0]{\hyperlink{def-parameterizedintegertype}{parameterized integer types}}
 \newcommand\wellconstrainedintegertype[0]{\hyperlink{def-wellconstrainedintegertype}{well-constrained integer type}}
 \newcommand\wellconstrainedintegertypes[0]{\hyperlink{def-wellconstrainedintegertype}{well-constrained integer types}}
 \newcommand\pendingconstrainedintegertype[0]{\hyperlink{def-pendingconstrainedintegertype}{pending constrained integer type}}
+\newcommand\pendingconstrainedintegertypes[0]{\hyperlink{def-pendingconstrainedintegertype}{pending constrained integer types}}
 \newcommand\structuredtype[0]{\hyperlink{def-structuredtype}{structured type}}
 \newcommand\structure[0]{\hyperlink{def-structure}{structure}}
 \newcommand\underlyingtype[0]{\hyperlink{def-underlyingtype}{underlying type}}
@@ -1691,6 +1693,7 @@
 \newcommand\literalexpressionterm[0]{\hyperlink{def-literalexpressionterm}{literal expression}}
 \newcommand\variableexpressionterm[0]{\hyperlink{def-variableexpressionterm}{variable expression}}
 \newcommand\variableexpression[1]{\hyperlink{def-variableexpressionterm}{variable expression} for the identifier #1}
+\newcommand\atcexpressionterm[0]{\hyperlink{def-atceexpressionterm}{asserting type conversion}}
 \newcommand\atcexpression[2]{\hyperlink{def-atceexpressionterm}{asserting type conversion} for the expression #1 and type #2}
 \newcommand\binopexpressionterm[0]{\hyperlink{def-binopexpressionterm}{binary operation expression}}
 \newcommand\binopexpression[3]{\hyperlink{def-binopexpressionterm}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -505,6 +505,18 @@ according to the signature of $\divint$, \Tdiv{} can only be applied to \integer
 whereas \verb|0.0| is a \realtypeterm.
 \ASLListing{An ill-typed binary expression}{typing-binoperror}{\typingtests/TypingRule.EBinop.bad.asl}
 
+\ExampleDef{Comparing Well-constrained Integers}
+The specification in \listingref{EBinop} is well-typed.
+Specifically, it is legal to compare \wellconstrainedintegertypes{}
+with different lists of constraints and a \wellconstrainedintegertype{} to an \unconstrainedintegertype{}.
+\ASLListing{Comparing well-constrained integers}{EBinop}{\typingtests/TypingRule.EBinop.asl}
+
+\ExampleDef{Typing Bitvector Concatenation}
+The specification in \listingref{EBinop-2} is well-typed, since
+the sum of widths of the two concatenated \bitvectortypesterm{}
+is equal to the width of the \bitvectortypeterm{} of the return type.
+\ASLListing{Concatenating bitvectors}{EBinop-2}{\typingtests/TypingRule.EBinop2.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -830,7 +842,12 @@ the expression \texttt{NOT '1010'} evaluates to the value \texttt{'0101'}.
 
 \subsection{Typing}
 \TypingRuleDef{ECond}
-\ExampleRef{Lowest Common Ancestor} shows examples of typing conditional expressions.
+\ExampleDef{Typing Conditional Expressions}
+The specification in \listingref{ECond} is well-typed and shows
+an example of typing a conditional expression.
+\ASLListing{Typing conditional expressions}{ECond}{\typingtests/TypingRule.ECond.asl}
+
+\ExampleRef{Lowest Common Ancestor} shows more examples of typing conditional expressions.
 
 \ProseParagraph
 \AllApply
@@ -2330,6 +2347,29 @@ is a dynamic error.
 \listingref{typing-atc} shows examples of ATC expressions
 and the corresponding annotated expressions in comments.
 
+\ExampleDef{Asserting Type Conversion of Well-constrained Integers}
+The specification in \listingref{typing-atc2} is well-typed,
+showing how to convert one \\
+\wellconstrainedintegertype{} into another
+\wellconstrainedintegertype{}.
+\ASLListing{ATC of well-constrained integers}{typing-atc2}{\typingtests/TypingRule.ATC2.asl}
+
+\ExampleDef{Safely Applying Asserting Type Conversion to Bitvectors}
+The specification in \listingref{typing-atc3} is well-typed,
+showing how a \bitvectortypeterm{} may be safely converted
+into another \bitvectortypeterm.
+\ASLListing{Safely applying ATC to bitvector types}{typing-atc3}{\typingtests/TypingRule.ATC3.asl}
+
+Similarly, the specification in \listingref{typing-atc4} is well-typed,
+showing that even literals may require an asserting type conversion to ensure they meet
+type-satisfaction requirements.
+\ASLListing{Safely applying ATC to a bitvector literal}{typing-atc4}{\typingtests/TypingRule.ATC4.asl}
+
+\ExampleDef{Ill-typed Asserting Type Conversion}
+The specification in \listingref{typing-atc-bad} is ill-typed,
+as it is applied to unrelated kinds of types.
+\ASLListing{Ill-typed ATC of a bitvector type}{typing-atc-bad}{\typingtests/TypingRule.ATC.bad.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}
@@ -2348,6 +2388,7 @@ and the corresponding annotated expressions in comments.
   \item $\vses$ is $\vsese$ if $\vallwayssucceeds$ is $\True$ and $\vses$ otherwise;
   \item $\vt$ is $\ttyp$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
@@ -2427,6 +2468,7 @@ are compatible for a typing assertion in the static environment $\tenv$, yieldin
     \item the result is a \typingerrorterm{} indicating that the type assertion will always fail ($\TypeAssertionFailure$).
   \end{itemize}
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[equal]{
@@ -2492,12 +2534,13 @@ evaluated:
 \ASLListing{A asserting type conversion that is never evaluated}{semantics-atcnotevaluated}
 {\semanticstests/SemanticsRule.ATCNotDynamicErrorIfFalse.asl}
 
-\ExampleDef{Asserting Type Conversions with Type Errors and Dynamic Errors}
-\listingref{semantics-variousatcs} shows various \typingerrorsterm{} and \dynamicerrorsterm{}.
+\ExampleDef{Asserting Type Conversions with Dynamic Errors}
+\listingref{semantics-variousatcs} shows various \dynamicerrorsterm{}.
 Note that the \dynamicerrorterm{} appearing in the statement
-\verb|var e: integer{4, 5, 6} = 2 as integer{4, 5, 6};|, which is nested in the \verb|if FALSE then|
+\verb|var e: integer{4, 5, 6} = 2 as integer{4, 5, 6};|, \\
+which is nested in the \verb|if FALSE then|
 will never occur, but it is still classified as a \dynamicerrorterm{}.
-\ASLListing{Various type errors and dynamic errors}{semantics-variousatcs}{\semanticstests/SemanticsRule.ATCVariousErrors.asl}
+\ASLListing{Various dynamic errors}{semantics-variousatcs}{\semanticstests/SemanticsRule.ATCVariousErrors.asl}
 
 \ProseParagraph
 \AllApply
@@ -3049,7 +3092,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \subsection{Typing}
 \TypingRuleDef{ERecord}
 \listingref{semantics-erecord} shows an example of a well-typed record construction expression
-and an example (in comment) where the same field is initialized twice, which is incalid..
+and an example (in comment) where the same field is initialized twice, which is invalid.
 
 \ProseParagraph
 \AllApply

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -616,11 +616,16 @@ The function
 returns the \Proselca{} of types $\vt$ and $\vs$ in $\tenv$ --- $\tty$.
 The result is a \typingerrorterm{} if a \Proselca{} does not exist or a \typingerrorterm{} is detected.
 
-\ExampleDef{Lowest Common Ancestor}
+\ExampleDef{Lowest Common Ancestor Examples}
 \listingref{example-lca} shows examples of conditional expressions and the resulting
 \emph{\Proselca}.
 \pagebreak
-\ASLListing{Lowest Common Ancestor}{example-lca}{\typingtests/TypingRule.LowestCommonAncestor.asl}
+\ASLListing{Lowest common ancestor}{example-lca}{\typingtests/TypingRule.LowestCommonAncestor.asl}
+
+\ExampleDef{Lowest Common Ancestor of Two Bitvectors}
+\listingref{example-lca2} shows an example of a lowest common ancestor of two \bitvectortypesterm{}
+of different widths.
+\ASLListing{Lowest common ancestor of two bitvectors}{example-lca2}{\typingtests/TypingRule.LowestCommonAncestor2.asl}
 
 \ProseParagraph
 \OneApplies
@@ -1070,6 +1075,19 @@ determines the result type $\vt$ of applying the binary operator $\op$
 to operands of type $\vtone$ and $\vttwo$ in the static environment $\tenv$.
 \ProseOtherwiseTypeError
 
+\ExampleDef{Filtering Constraints for Binary Operations}
+Since binary operations may dynamically fail, the typechecker may remove values
+that will definitely lead to \dynamicerrorsterm.
+For example, in \listingref{apply-binop-constraints2},
+the constraint \verb|integer{-1..1}| serves for the denominator in \verb|x DIV y|,
+and since \verb|-1| and \verb|0| will always lead to a \dynamicerrorterm,
+the typechecker removes them for the purpose of typing \verb|x DIV y|,
+which leaves only \verb|1| and the final type for \verb|z| is therefore
+\verb|integer{2, 4}|.
+
+\ASLListing{Removing values from constraints}{apply-binop-constraints2}
+{\typingtests/TypingRule.ApplyBinopTypes.constraints2.asl}
+
 \ExampleDef{Applying Binary Operations to Types}
 \listingref{apply-binop-type} shows examples of typing binary operations.
 \ASLListing{Applying binary operations to types}{apply-binop-type}
@@ -1079,9 +1097,10 @@ to operands of type $\vtone$ and $\vttwo$ in the static environment $\tenv$.
 \listingref{apply-binop-constraints} shows examples of typing binary operations
 applied to \constrainedinteger{} types.
 
-Importantly, note that the AST for constraints is not closed under binary operations.
+Importantly, note that there is no AST for applying binary operations on
+constraints.
 For example, given a range constraint \verb|A..B| and an exact constraint |2|,
-there is no AST to express \verb|(A..B) * 2|. Therefore, they constraints for typing
+there is no AST to express \verb|(A..B) * 2|. Therefore, the constraints for typing
 \verb|ab_times_2| approximate the set of values for \verb|(A..B) * 2| via four
 range constraints. More precisely, they are a superset of the values for \verb|(A..B) * 2|.
 
@@ -3032,6 +3051,13 @@ the width defined by the corresponding slice \verb|[6:3]|.
 In addition, annotating the expression \verb|x AND y| requires checking that
 the widths of \verb|x| and \verb|y| are equal.
 \ASLListing{Ensuring that two bitvectors Have equal width}{CheckBitsEqualWidth}{\typingtests/TypingRule.CheckBitsEqualWidth.asl}
+
+The specification in \listingref{CheckBitsEqualWidth-bad}
+is ill-typed, since \verb|M| and \verb|N| are not necessarily equal, even though they have the same type.
+\ASLListing{Two bitvectors of possibly different widths}{CheckBitsEqualWidth-bad}{\typingtests/TypingRule.CheckBitsEqualWidth.bad.asl}
+
+The specification in \listingref{CheckBitsEqualWidth-bad2} is ill-typed for a similar reason.
+\ASLListing{Two bitvectors of possibly different widths}{CheckBitsEqualWidth-bad2}{\typingtests/TypingRule.CheckBitsEqualWidth.bad2.asl}
 
 \ProseParagraph
 \AllApply

--- a/asllib/doc/SideEffects.tex
+++ b/asllib/doc/SideEffects.tex
@@ -269,6 +269,12 @@ yielding the result in $\vb$.
 
 See \ExampleRef{Checking Whether Expressions are Symbolically Evaluable}.
 
+\ExampleDef{Why Symbolically Evaluability Matters}
+The specification in \listingref{SESIsSymbolicallyEvaluable} is well-typed.
+Specifically, it shows how the fact that an expression is \symbolicallyevaluable{}
+is used to reason about the equivalence of bitwidth expressions.
+\ASLListing{Why Symbolically Evaluability Matters}{SESIsSymbolicallyEvaluable}{\typingtests/TypingRule.SESIsSymbolicallyEvaluable.asl}
+
 \ProseParagraph
 Define $\vb$ as $\True$ if and only if every \sideeffectdescriptorterm\ $\vs$ in $\vses$
 is \symbolicallyevaluable.

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -1372,6 +1372,13 @@ The specifications in \listingref{semantics-scond},
 \listingref{semantics-scond3}, and
 \listingref{semantics-scond4} are all well-typed.
 
+\ExampleDef{Typing Conditional Statements with Two Bitvector Types}
+The specification in \listingref{SCond} is well-typed
+and shows examples of how \bitvectortypesterm{} either \typesatisfy{}
+the return type or do not \typesatisfy{} the return type and require
+an \atcexpressionterm{}.
+\ASLListing{Typing conditional statements with two bitvector types}{SCond}{\typingtests/TypingRule.SCond.asl}
+
 \ProseParagraph
 \AllApply
 \begin{itemize}

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -188,7 +188,7 @@ A named type is a type that is declared by using the \texttt{type ... of ...} sy
 
 \TypingRuleDef{AnonymousType}
 \hypertarget{def-isanonymous}{}
-\identd{VMZX}%
+\identd{VMZX} \identi{SBCK}%
 The predicate
 \[
   \isanonymous(\overname{\ty}{\tty}) \;\aslto\; \Bool
@@ -196,7 +196,9 @@ The predicate
 tests whether the type $\tty$ is an \anonymoustype.
 
 \ExampleDef{Anonymous Types}
-The \tupletypeterm{} \texttt{(integer, integer)} is an \anonymoustype.
+The well-typed specification in \listingref{AnonymousType} illustrates the use
+of anonymous types as permitted by \TypingRuleRef{TypeSatisfaction}.
+\ASLListing{Well-typed anonymous types}{AnonymousType}{\typingtests/TypingRule.AnonymousType.asl}
 
 \ProseParagraph
 \Anonymoustypes\ are types that are not declared using the \texttt{type ... of ...} syntax:

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -425,8 +425,6 @@ $\{\nvlabel(\texttt{GREEN}), \nvlabel(\texttt{ORANGE}), \nvlabel(\texttt{RED})\}
 of \\
 \verb|type TrafficLights of enumeration {GREEN, ORANGE, RED}|.
 
-The domain of \texttt{bits({2,16})} is the set containing native bitvectors of all 2-bit and all 16-bit binary sequences.
-
 The domain of \texttt{(integer, integer)} is the set containing all pairs of native integer values.
 
 The domain of \verb|record {a: integer;  b: boolean}| contains all native records

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -114,8 +114,10 @@ The \emph{\integertypesterm{}} represent mathematical integer value.
 
 There are four kinds of integer types, and we
 use the term \integertypeterm{} to refer to them collectively:
-\emph{unconstrained}, \emph{well-constrained},
-\emph{pending constrained}, and \emph{parameterized}.
+\emph{\unconstrainedintegertypes},
+\emph{\wellconstrainedintegertypes},
+\emph{\pendingconstrainedintegertypes},
+and \emph{\parameterizedintegertypes}.
 
 \subsection{Unconstrained Integer Types}
 \hypertarget{def-unconstrainedintegertype}{}
@@ -138,8 +140,19 @@ or a \emph{\rangeconstraintterm}, consisting of a pair of expressions like \text
 
 \ExampleDef{Well-constrained Integer Types}
 \hypertarget{def-wellconstrainedintegertype}{}
-\listingref{typing-wellconstrained} shows examples of well-constrained integer types.
-\ASLListing{Well-typed well-constrained integer types}{typing-wellconstrained}{\typingtests/TypingRule.TIntWellConstrained.asl}
+The well-typed specification in \listingref{constrainedintegers1} shows examples of \wellconstrainedintegertypes.
+\ASLListing{Well-typed well-constrained integer types}{constrainedintegers1}{\definitiontests/ConstrainedIntegers1.asl}
+
+The well-typed specification in \listingref{constrainedintegers2} shows examples of \wellconstrainedintegertypes{}
+and \unconstrainedintegertypes{} for \verb|config|s.
+\ASLListing{Well-constrained integer types and \texttt{config}s}{constrainedintegers2}{\definitiontests/ConstrainedIntegers2.asl}
+
+The specifications in \listingref{constrainedintegers-bad}
+and \listingref{constrainedintegers-bad2}
+show examples of ill-typed
+assignment between two \wellconstrainedintegertypes{}.
+\ASLListing{Ill-typed well-constrained integer types}{constrainedintegers-bad}{\definitiontests/ConstrainedIntegers.bad.asl}
+\ASLListing{Ill-typed well-constrained integer types}{constrainedintegers-bad2}{\definitiontests/ConstrainedIntegers.bad2.asl}
 
 \subsection{Pending-constrained Integer Types}
 \hypertarget{def-pendingconstrainedintegertype}{}
@@ -647,6 +660,13 @@ where \texttt{N} may specify a fixed width or a constrained width.
 %
 The \texttt{bit} type is syntactic sugar for \texttt{bits(1)} (see \ASTRuleRef{Ty.TBits}.\texttt{BIT}).
 
+\identr{RXYN}%
+Bitvectors can be converted to unsigned integers and signed integer
+via the standard library functions
+\verb|UInt| and \verb|SInt|, respectively.
+Converting integers into bitvectors can be done via slicing
+(see \ExampleRef{Evaluation of Slicing Expressions}).
+
 \identi{KGMC}%
 The syntax for \bitvectortypesterm{} has an optional $\Nbitfields$,
 which allows specifying \emph{\bitfieldsterm} ---
@@ -744,6 +764,10 @@ bv=0x14, rotated twice=0x05
 \ExampleDef{Well-typed Bitvector Types}
 In \listingref{typing-tbits}, all the uses of bitvector types are well-typed.
 \ASLListing{Well-typed Bitvector types}{typing-tbits}{\typingtests/TypingRule.TBits.asl}
+
+The specification in \listingref{typing-tbits-bad} is ill-typed, since widths need
+to be \constrainedintegers.
+\ASLListing{An ill-typed Bitvector type}{typing-tbits-bad}{\typingtests/TypingRule.TBits.bad.asl}
 
 \ExampleRef{A bitvector type with bitfields} shows a well-typed \bitvectortypeterm{} with bitfields.
 
@@ -1490,6 +1514,9 @@ collection types in comments.
 
 \section{Named Types\label{sec:NamedTypes}}
 Named type declarations allow declaring new types names with a given type.
+The intent is that, by default, any named type should not be assignable to or from any other named type, even
+if they coincidentally have the same \structure. Where assignment between named types is desired it is usually
+achieved by grouping related types via a common supertype.
 
 The specification in \listingref{named-types2}, declares two unique types with the same
 \structure. Note that the two types are not related in
@@ -1498,6 +1525,18 @@ any way and are not interchangeable. See also \TypingRuleRef{TypeSatisfaction}.
 
 In \listingref{named-types}, \verb|TypeC.f| and \verb|TypeD.f| have the same type: \verb|TypeB| (and not integer).
 \ASLListing{Two unique well-typed types}{named-types}{\definitiontests/NamedTypes.asl}
+
+In \listingref{named-types3}, the assignments \verb|addr = physical;|
+and \verb|physical = addr;| would be illegal.
+\ASLListing{Two unique well-typed types}{named-types3}{\definitiontests/NamedTypes3.asl}
+
+The well-typed specification in \listingref{named-types4}
+demonstrates how a constant can be given a named type.
+\ASLListing{Naming types for constants}{named-types4}{\definitiontests/NamedTypes4.asl}
+
+The specification in \listingref{named-types-bad} is ill-typed
+due to an assignment between two different named types (\verb|Char| and \verb|Byte|).
+\ASLListing{Named types and illegal assignments}{named-types-bad}{\definitiontests/NamedTypes.bad.asl}
 
 \hypertarget{namedtypeterm}{}
 \subsection{Syntax}

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -330,6 +330,7 @@ closing
 closure
 code
 codes
+coincidentally
 collection
 collections
 collectively
@@ -705,6 +706,7 @@ essentially
 establish
 establishing
 estoppel
+evaluability
 evaluable
 evaluate
 evaluated
@@ -896,6 +898,7 @@ ground
 grounded
 grounding
 group
+grouping
 groups
 guarantee
 guaranteed
@@ -948,6 +951,7 @@ ignoring
 illegal
 illegally
 illustrated
+illustrates
 image
 immediately
 immutability
@@ -1204,6 +1208,7 @@ matches
 matching
 material
 mathematical
+matters
 maximal
 maximum
 may
@@ -1213,6 +1218,7 @@ means
 meant
 mechanism
 mechanisms
+meet
 meets
 member
 members
@@ -1261,6 +1267,7 @@ naming
 native
 natural
 nearest
+necessarily
 necessary
 necessitates
 need
@@ -1720,6 +1727,7 @@ runtime
 runtimes
 s
 safe
+safely
 said
 same
 satisfaction
@@ -2113,7 +2121,9 @@ unpredictable
 unprintable
 unreachable
 unrecognized
+unrelated
 unreleased
+unsigned
 unspecified
 unsupported
 until

--- a/asllib/doc/notice.tex
+++ b/asllib/doc/notice.tex
@@ -51,7 +51,7 @@ guidelines at
 
 \url{https://www.arm.com/company/policies/trademarks.}
 
-Copyright © [2023,2024] Arm Limited (or its affiliates). All rights reserved.
+Copyright © [2023--2025] Arm Limited (or its affiliates). All rights reserved.
 
 Arm Limited. Company 02557590 registered in England.  110 Fulbourn Road,
 Cambridge, England CB1 9NJ.  (LES-PRE-20349)

--- a/asllib/tests/ASLDefinition.t/ConstrainedIntegers.bad.asl
+++ b/asllib/tests/ASLDefinition.t/ConstrainedIntegers.bad.asl
@@ -1,0 +1,8 @@
+type Ity of integer {2,4,8};
+
+func not_subset()
+begin
+    var A: integer {2,4,8};
+    var B: integer {2,4};
+    B = A; // illegal: {2,4,8} is not a subset of {2,4}.
+end;

--- a/asllib/tests/ASLDefinition.t/ConstrainedIntegers.bad2.asl
+++ b/asllib/tests/ASLDefinition.t/ConstrainedIntegers.bad2.asl
@@ -1,0 +1,11 @@
+var gInt: integer; // unconstrained global integer
+
+func g()
+begin
+    var myInt: integer = gInt;
+    var myIntA: integer {1..10} = myInt as integer {1..10};
+    var myIntB: integer {0..20} = myIntA;
+    myIntA = myIntB; // Illegal even though at this point
+                     // the value stored in myIntB is always
+                     // in 1..10.
+end;

--- a/asllib/tests/ASLDefinition.t/ConstrainedIntegers1.asl
+++ b/asllib/tests/ASLDefinition.t/ConstrainedIntegers1.asl
@@ -1,0 +1,24 @@
+type Ity of integer {2,4,8};
+
+func f()
+begin
+    var A: integer {2,4,8};
+    var B: integer {2,4};
+    // A and B have anonymous types
+    A = B;
+    var I: Ity;
+    I = A;
+    I = B;
+    A = I;
+end;
+
+var gInt: integer; // unconstrained global integer
+
+func g()
+begin
+    var myInt: integer = gInt; // Legal
+    var myIntA: integer {1..10} = myInt as integer {1..10};
+    // Legal: incurs execution-time check that (myInt IN {1..10})
+    var myIntB: integer {0..20} = myIntA;
+    // Legal: type satisfaction and no execution-time check required
+end;

--- a/asllib/tests/ASLDefinition.t/ConstrainedIntegers2.asl
+++ b/asllib/tests/ASLDefinition.t/ConstrainedIntegers2.asl
@@ -1,0 +1,18 @@
+// a global which may only hold the values 8, 16 or 32
+var gWid: integer {8,16,32};
+
+// a global constant which holds the value 64 and has type integer {64}
+constant constantValue = 64;
+
+// Constraints are propagated through basic arithmetic operations,
+// so constantValue DIV 2 has type integer {32} which type checks
+// against the type of configWid
+config configWid: integer {8,16,32} = constantValue DIV 2;
+
+// A config variable that has the type integer {64} and can only hold
+// the value 64.
+config configValueFixed: integer{64} = 64;
+
+// A config variable that has the type integer and can hold any
+// integer value.
+config configValue: integer = 64;

--- a/asllib/tests/ASLDefinition.t/NamedTypes.bad.asl
+++ b/asllib/tests/ASLDefinition.t/NamedTypes.bad.asl
@@ -1,0 +1,9 @@
+type Char of integer{0..255};
+type Byte of integer{0..255};
+constant K: Char = 210;
+var b: Byte;
+
+func f()
+begin
+    b = K; // Illegal: a Char cannot be directly assigned to a Byte
+end;

--- a/asllib/tests/ASLDefinition.t/NamedTypes3.asl
+++ b/asllib/tests/ASLDefinition.t/NamedTypes3.asl
@@ -1,0 +1,32 @@
+// Neither ADDR nor PHYSICAL_ADDR is a subtype of the other.
+type ADDR of bits (32) {};
+type PHYSICAL_ADDR of ADDR;
+var addr: ADDR;
+var physical: PHYSICAL_ADDR;
+
+// For the function "raw_addr",
+func raw_addr(x: ADDR) => bits(32)
+begin
+    // x may be used as the expression in the return statement
+    // since the return type is type satisfied by the type of x
+    return x;
+end;
+
+func raw_physical_addr(x: PHYSICAL_ADDR) => bits(32)
+begin
+    return x;
+end;
+
+func addresses()
+begin
+    var tmp: bits(32);
+    // primitive type bits(32) is type-satisfied by both ADDR and PHYSICAL_ADDR
+    tmp = addr;
+    physical = tmp;
+    tmp = '0' :: tmp[30:0];
+    addr = tmp;
+    physical = raw_addr(addr);
+    addr = raw_physical_addr(physical);
+    physical = addr[31:0]; // a bitslice is of type bits(N)
+    addr = physical[31:0];
+end;

--- a/asllib/tests/ASLDefinition.t/NamedTypes4.asl
+++ b/asllib/tests/ASLDefinition.t/NamedTypes4.asl
@@ -1,0 +1,11 @@
+type Char of integer{0..255};
+type Byte of integer{0..255};
+constant K: Char = 210;
+var c: Char;
+var b: Byte;
+
+func f()
+begin
+    c = 210; // legal: c has the structure of integer and can be assigned an integer
+    c = K; // legal: K has type Char and can be assigned to a Char
+end;

--- a/asllib/tests/ASLDefinition.t/constrained_bitwidth.asl
+++ b/asllib/tests/ASLDefinition.t/constrained_bitwidth.asl
@@ -4,6 +4,14 @@ config configWid: integer {32, 64} = 32;
 config gExtra: integer {0, 8} = 0;
 
 // Since configWid is a constrained integer we can declare:
-var gReg: bits(configWid); // i.e. bits({32,64})
-var gRegF: bits(configWid + gExtra); // i.e. bits({32,40,64,72})
-// The expression (configWid+gExtra) is an integer {32,40,64,72}
+var gReg: bits(configWid);
+var gRegF: bits(configWid + gExtra);
+
+constant wid = 32;
+type busTy of bits(wid);
+type recTy of record {bus: busTy, valid: bit};
+
+func constType()
+begin
+    var R: bits(wid); // Legal since wid is a constant.
+end;

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -128,6 +128,14 @@ Examples used in ASL High-level Definition:
   [1]
   $ aslref --no-exec NamedTypes.asl
   $ aslref --no-exec NamedTypes2.asl
+  $ aslref --no-exec NamedTypes3.asl
+  $ aslref --no-exec NamedTypes4.asl
+  $ aslref --no-exec NamedTypes.bad.asl
+  File NamedTypes.bad.asl, line 8, characters 4 to 5:
+      b = K; // Illegal: a Char cannot be directly assigned to a Byte
+      ^
+  ASL Type error: a subtype of Byte was expected, provided Char.
+  [1]
   $ aslref --no-exec GuideRule.GlobalStorageCycles.bad1.asl
   File GuideRule.GlobalStorageCycles.bad1.asl, line 4, characters 0 to 10:
   var b = a;
@@ -174,3 +182,19 @@ Examples used in ASL High-level Definition:
   $ aslref --no-exec ParametricFunction2.asl
   $ aslref --no-exec symbolic_bitwidth.asl
   $ aslref --no-exec constrained_bitwidth.asl
+  $ aslref --no-exec ConstrainedIntegers1.asl
+  $ aslref --no-exec ConstrainedIntegers2.asl
+  $ aslref --no-exec ConstrainedIntegers.bad.asl
+  File ConstrainedIntegers.bad.asl, line 7, characters 4 to 5:
+      B = A; // illegal: {2,4,8} is not a subset of {2,4}.
+      ^
+  ASL Type error: a subtype of integer {2, 4} was expected,
+    provided integer {2, 4, 8}.
+  [1]
+  $ aslref --no-exec ConstrainedIntegers.bad2.asl
+  File ConstrainedIntegers.bad2.asl, line 8, characters 4 to 10:
+      myIntA = myIntB; // Illegal even though at this point
+      ^^^^^^
+  ASL Type error: a subtype of integer {1..10} was expected,
+    provided integer {0..20}.
+  [1]

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCVariousErrors.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.ATCVariousErrors.asl
@@ -1,11 +1,10 @@
-func ErrorExample()
+func main() => integer
 begin
   var a: integer{1, 2, 3} = 2 as integer{1, 2, 3}; // Legal
-  var b: integer{4, 5, 6} = 2;                     // A type error
-  var c: integer{4, 5, 6} = 2 as integer{4, 5, 6}; // A dynamic error
   if FALSE then
-      var d: integer{4, 5, 6} = 2; // A type error
       // A dynamic error
       var e: integer{4, 5, 6} = 2 as integer{4, 5, 6};
   end;
+  var c: integer{4, 5, 6} = 2 as integer{4, 5, 6}; // A dynamic error
+  return 0;
 end;

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -220,11 +220,11 @@ ASL Semantics Tests:
   21
   $ aslref SemanticsRule.ATCNotDynamicErrorIfFalse.asl
   $ aslref SemanticsRule.ATCVariousErrors.asl
-  File SemanticsRule.ATCVariousErrors.asl, line 4, characters 2 to 30:
-    var b: integer{4, 5, 6} = 2;                     // A type error
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {4, 5, 6} was expected,
-    provided integer {2}.
+  File SemanticsRule.ATCVariousErrors.asl, line 8, characters 28 to 29:
+    var c: integer{4, 5, 6} = 2 as integer{4, 5, 6}; // A dynamic error
+                              ^
+  ASL Execution error: Mismatch type:
+    value 2 does not belong to type integer {4, 5, 6}.
   [1]
   $ aslref SemanticsRule.CatchNoThrow.asl
   No exception raised

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ATC.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ATC.bad.asl
@@ -1,0 +1,5 @@
+func TypeAssertions()
+begin
+    var A: bit;
+    let B: integer = A as integer; // Illegal: bit cannot be an integer.
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ATC2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ATC2.asl
@@ -1,0 +1,10 @@
+func main() => integer
+begin
+    var a: integer{1, 2, 3} = 2;
+    var b: integer{2, 3, 4} = a as integer{2, 3, 4};
+
+    let c: integer {2, 3, 4} = b as {2, 3, 4};
+    // b is already an integer{2, 3, 4}.
+    // The asserting type conversion is redundant but legal.
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ATC3.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ATC3.asl
@@ -1,0 +1,12 @@
+func widCheck{N, M}(b: bits(M)) => bits(N)
+begin
+    if (N == M) then
+        // b has the type bits(M), but we know from the previous line that N==M
+        // so it is safe to assert that b is within the domain of bits(N).
+        // The resulting type of the asserting type conversion expression is bits(N),
+        // matching the required return type.
+        return b as bits(N);
+    else
+        return Zeros{N};
+    end;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ATC4.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ATC4.asl
@@ -1,0 +1,26 @@
+func invokedN{N: integer{8,16,32}}(x: bits(N)) => bits(N)
+begin
+    var myBits: bits(N);
+    // The type of myBits is bits(N as {8,16,32})
+    if N == 8 then // "GUARD"
+        // myBits = '10101010'; // Illegal
+        // since the type of myBits is not of width 8
+
+        myBits = '10101010' as bits(N); // Legal
+        // This would be a dynamic error if `N != 8` but we can safely assert
+        // this due to the guard `N == 8` above.
+    else
+        myBits = Zeros{N};
+    end;
+    return myBits;
+end;
+
+func test{M: integer{8, 16, 32}}(bv: bits(M))
+begin
+    var myVal: bits(M as integer{16,32}); // A dynamic error if (M IN !{16,32}).
+    var myResult: bits(M as integer{8,16}); // A dynamic error if (M IN !{8,16}).
+
+    // The return type of invokedN{M}(myVal) is bits(M)
+    // which type-satisfies bits(M as integer {8, 16})
+    myResult = invokedN{M}(myVal);
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateCallActualsTyped.bad4.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateCallActualsTyped.bad4.asl
@@ -7,13 +7,11 @@ begin
     // as a parameterized integer then the following would fail since it is
     // illegal to declare `bits(expr)` if expr is an unconstrained integer.
     var ans: bits(N) = Zeros{N};
-    // for any invocation, the returned bitvector's width has the same
-    // constraint as the actual argument which provides the parameter value.
+    // for any invocation, the returned bitvector's width is the actual
+    // expression passed to the parameter.
     // For example:
-    // If N is 1 in the invocation,
-    // then the returned value is bits(1: integer{1}).
-    // If N is an `integer {4,8}` in the invocation
-    // then the returned value is bits({4,8})
+    // If N is 1 in the invocation, then the returned value is bits(1).
+    // If N is `x` in the invocation then the returned value is bits(x).
     return (NOT ans);
 end;
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnonymousType.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnonymousType.asl
@@ -1,0 +1,15 @@
+type T1 of integer; // the named type `T1` whose structure is integer
+type T2 of integer; // the named type `T2` whose structure is integer
+type pairT of (integer, T1); // the named type `pairT` whose structure
+                             // is (integer, integer)
+
+func tsub01()
+begin
+    var dataT1: T1;
+    var pair: pairT = (1,dataT1);
+    // legal since right hand side has anonymous, non-primitive type (integer, T1)
+    let dataAsInt: integer = dataT1;
+    pair = (1, dataAsInt);
+    // legal since right hand side has anonymous, primitive type (integer, integer)
+    let dataT2: T2 = 10;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.constraints2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ApplyBinopTypes.constraints2.asl
@@ -1,0 +1,7 @@
+func f(x: integer{2, 4}, y: integer{-1..1})
+begin
+    // typing `x DIV y` involves removing 0 and 1
+    // from {-1..1}, leaving only 1.
+    // `z` is typed as `integer{2, 4}`.
+    let z = x DIV y;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckBitsEqualWidth.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckBitsEqualWidth.bad.asl
@@ -1,0 +1,11 @@
+func check{M: integer{4,8}, N: integer{4,8}}(
+    flag: boolean,
+    x: bits(M),
+    y: bits(N)) => boolean
+begin
+    if flag then
+        return (x as bits(N)) == y; // Legal
+    else
+        return x == y; // Illegal: M and N are not necessarily equal.
+    end;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckBitsEqualWidth.bad2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckBitsEqualWidth.bad2.asl
@@ -1,0 +1,11 @@
+func compare{
+    int1: integer {1,2},
+    int2: integer {1,2}}
+    (
+    bit1: bits(int1),
+    bit2: bits(int2)
+)
+begin
+    var cond: boolean;
+    cond = bit1 == bit2; // Illegal
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EBinop.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EBinop.asl
@@ -1,0 +1,9 @@
+func compare_integers{
+    int1: integer {1,2},
+    int2: integer {4,5},
+    int3: integer}(a: bits(int1), b: bits(int2), c: bits(int3))
+begin
+    var cond: boolean;
+    cond = int1 == int2; // Legal
+    cond = int1 == int3; // Legal
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EBinop2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EBinop2.asl
@@ -1,0 +1,13 @@
+func f{N}(a: bits(N), i: integer {1..N -1})
+begin
+    // a is an under-constrained bitvector of width `N`
+    let b: bits(N) = a[i -1:0] :: // bitvector of width (i)
+        a[N -1:i] // bitvector of width (N-i)
+    ; // result is constrained of width N
+end;
+
+func g{P: integer {2,4,8}}() => bits(P)
+begin
+    var opA = Zeros{P-1}() :: '1';
+    return opA;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.EConcatUnresolvableToInteger.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.EConcatUnresolvableToInteger.asl
@@ -8,7 +8,7 @@ config LIMIT2: integer{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} = 7;
 
 func bar() => integer{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 begin
-    var ret: integer = 0;
+    var ret: integer = 1;
     while ret < LIMIT1 do
         ret = ret + ret * 2;
     end;
@@ -19,8 +19,8 @@ func main() => integer
 begin
     let N = bar();
     let M = LIMIT2;
-    let x = Zeros(N);
-    let y = Zeros(M);
-    let z = foo([x, y]);
+    let x = Zeros{N};
+    let y = Zeros{M};
+    let z = foo{M+N}(x :: y);
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ECond.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ECond.asl
@@ -1,0 +1,21 @@
+func main() => integer
+begin
+    let value: integer{8, 16} = ARBITRARY: integer{8, 16};
+
+    // *Mutable* storage elements of type integer {2} are not very useful.
+    var factor2 = 2; // typed as integer{2}
+
+    // c is typed as integer {8, 16, 32}.
+    var c = if (factor2 == 2) then value * 2 else value;
+
+    let j = value * (1 + 1);
+
+    // (1+1) is a compile-time-constant expression
+    // hence the type of (1+1) is integer {2}
+    // and j is of type integer {16,32}
+    var factor: integer = 2; // factor is of type integer
+
+    // Note that without the explicit type, factor would be integer{2}
+    let k = value * factor; // k is of type integer
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.LowestCommonAncestor2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.LowestCommonAncestor2.asl
@@ -1,0 +1,7 @@
+func conditionalExpression{N: integer {1,2}}(argT: bits(1), argF: bits(2)) => bits(N)
+begin
+    return (if (N == 1) then
+        argT as bits(N) // asserting type conversion is required
+    else
+        argF as bits(N)); // asserting type conversion is required
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SCond.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SCond.asl
@@ -1,0 +1,19 @@
+func conditionalStmt{N: integer {1,2}}(argT: bits(1), argF: bits(2)) => bits(N)
+begin
+    if (N == 1) then
+        return argT as bits(N); // asserting type conversion is required
+    else
+        return argF as bits(N); // asserting type conversion is required
+    end;
+end;
+
+func conditionalFun(N: integer {1,2}, argT: integer{1}, argF: integer{2}) => integer {1,2}
+begin
+    if (N == 1) then
+        return argT;
+    else
+        return argF;
+    end;
+    // The return expression integer {1,2} satisfies the return type
+    // No asserting type conversion is required.
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SESIsSymbolicallyEvaluable.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SESIsSymbolicallyEvaluable.asl
@@ -1,0 +1,27 @@
+// The notation <x>--><e> is used to indicate that an occurrence of <x> can be
+// rewritten to <e>
+
+func FPZero{N: integer {16,32,64}}(sign: bit) => bits(N)
+begin
+    // type checker knows N-->N
+    let E: integer{} = if N == 16 then 5 else (if N == 32 then 8 else 11);
+    // type checker knows E-->if N == 16 then 5 elsif N == 32 then 8 else 11
+    let F: integer{} = (N - E) - 1;
+    // type checker knows F-->N-(if N == 16 then 5 elsif N == 32 then 8 else 11) - 1
+    // which is F-->(if N == 16 then (N -5) elsif N == 32 then ( N-8) else (N-11)) - 1
+    // which is F-->(if N == 16 then (16-5) elsif N == 32 then (32-8) else (N-11)) - 1
+    // which is F-->(if N == 16 then ( 11) elsif N == 32 then ( 24) else (N-11)) - 1
+    // which is F-->(if N == 16 then ( 10) elsif N == 32 then ( 23) else (N-12)) - 1
+    var exp = Zeros{E};
+    var frac = Zeros{F};
+    return sign :: exp :: frac;
+    // type checker knows width of return expression is 1 + E + F
+    // which is 1
+    // + (if N == 16 then 5 elsif N == 32 then 8 else 11 )
+    // + (if N == 16 then 10 elsif N == 32 then 23 else (N-12))
+    // which is 1
+    // + (if N == 16 then 15 elsif N == 32 then 31 else (N- 1))
+    // which is
+    // (if N == 16 then 16 elsif N == 32 then 32 else N )
+    // which is N
+end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TBits.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TBits.bad.asl
@@ -1,0 +1,4 @@
+func foo(I: integer)
+begin
+    var R: bits(I); // Illegal since I is unconstrained.
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -50,11 +50,18 @@ ASL Typing Tests:
     "structured_procedure".
   [1]
   $ aslref TypingRule.LowestCommonAncestor.asl
+  $ aslref --no-exec TypingRule.LowestCommonAncestor2.asl
   $ aslref TypingRule.FindNamedLCA.asl
   $ aslref TypingRule.ApplyUnopType.asl
-//  $ aslref TypingRule.EConcatUnresolvableToInteger.asl
+  $ aslref TypingRule.EConcatUnresolvableToInteger.asl
+  File TypingRule.EConcatUnresolvableToInteger.asl, line 12, character 4 to
+    line 14, character 8:
+      while ret < LIMIT1 do
+          ret = ret + ret * 2;
+      end;
+  ASL Warning: Loop does not have a limit.
   $ aslref TypingRule.ApplyBinopTypes.asl
-  $ aslref TypingRule.ApplyBinopTypes.constraints.asl
+  $ aslref --no-exec TypingRule.ApplyBinopTypes.constraints.asl
   File TypingRule.ApplyBinopTypes.constraints.asl, line 22, characters 51 to 78:
       var a_div : integer{A, (A DIV 2), (A DIV 3)} = a DIV (1 as integer{-5..3});
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,8 +77,12 @@ ASL Typing Tests:
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Warning: Removing some values that would fail with op DIV from constraint set
   {0..16384} gave {1..16384}. Continuing with this constraint set.
-  ASL Error: Undefined identifier: 'main'
-  [1]
+  $ aslref --no-exec TypingRule.ApplyBinopTypes.constraints2.asl
+  File TypingRule.ApplyBinopTypes.constraints2.asl, line 6, characters 12 to 19:
+      let z = x DIV y;
+              ^^^^^^^
+  Warning: Removing some values that would fail with op DIV from constraint set
+  {-1..1} gave {1..1}. Continuing with this constraint set.
   $ aslref TypingRule.LDDiscard.asl
   File TypingRule.LDDiscard.asl, line 4, characters 6 to 7:
     let - = 42;
@@ -148,6 +159,12 @@ ASL Typing Tests / annotating types:
   [1]
 
   $ aslref TypingRule.TBits.asl
+  $ aslref TypingRule.TBits.bad.asl
+  File TypingRule.TBits.bad.asl, line 3, characters 16 to 17:
+      var R: bits(I); // Illegal since I is unconstrained.
+                  ^
+  ASL Type error: constrained integer expected, provided integer.
+  [1]
   $ aslref TypingRule.TTuple.asl
   $ aslref TypingRule.TArray.asl
   $ aslref TypingRule.TArray.bad.asl
@@ -393,6 +410,16 @@ ASL Typing Tests / annotating types:
   [1]
   $ aslref TypingRule.EGetFields.asl
   $ aslref --no-exec TypingRule.ATC.asl
+  $ aslref --no-exec TypingRule.ATC2.asl
+  $ aslref --no-exec TypingRule.ATC3.asl
+  $ aslref --no-exec TypingRule.ATC4.asl
+  $ aslref --no-exec TypingRule.ATC.bad.asl
+  File TypingRule.ATC.bad.asl, line 4, characters 21 to 33:
+      let B: integer = A as integer; // Illegal: bit cannot be an integer.
+                       ^^^^^^^^^^^^
+  ASL Type error: cannot perform Asserted Type Conversion on bits(1) by
+    integer.
+  [1]
   $ aslref --no-exec TypingRule.CheckATC.asl
   File TypingRule.CheckATC.asl, line 8, characters 12 to 32:
       var a = 3.0 as integer{1, 2};
@@ -448,6 +475,7 @@ ASL Typing Tests / annotating types:
   ASL Static error: overlapping slices 0+:4, 3+:1.
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.asl
+  $ aslref --no-exec TypingRule.SCond.asl
   $ aslref TypingRule.SDecl.asl
   $ aslref TypingRule.SDecl.bad1.asl
   File TypingRule.SDecl.bad1.asl, line 4, characters 4 to 12:
@@ -931,7 +959,7 @@ ASL Typing Tests / annotating types:
     provided integer {0..128}.
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad4.asl
-  File TypingRule.AnnotateCallActualsTyped.bad4.asl, line 25,
+  File TypingRule.AnnotateCallActualsTyped.bad4.asl, line 23,
     characters 14 to 27:
       var arg = ones{myWid}();
                 ^^^^^^^^^^^^^
@@ -972,6 +1000,7 @@ ASL Typing Tests / annotating types:
   ASL Type error: expected a pure expression/subprogram.
   [1]
   $ aslref --no-exec TypingRule.SESForSubprogram.asl
+  $ aslref --no-exec TypingRule.SESIsSymbolicallyEvaluable.asl
   $ aslref TypingRule.SliceEqual.asl
   $ aslref TypingRule.SlicesEqual.asl
   $ aslref TypingRule.BitwidthEqual.asl
@@ -1072,6 +1101,20 @@ ASL Typing Tests / annotating types:
   ASL Type error: cannot declare already declared element "y".
   [1]
   $ aslref TypingRule.CheckBitsEqualWidth.asl
+  $ aslref TypingRule.CheckBitsEqualWidth.bad.asl
+  File TypingRule.CheckBitsEqualWidth.bad.asl, line 9, characters 15 to 21:
+          return x == y; // Illegal: M and N are not necessarily equal.
+                 ^^^^^^
+  ASL Type error: Illegal application of operator == on types bits(M)
+    and bits(N).
+  [1]
+  $ aslref TypingRule.CheckBitsEqualWidth.bad2.asl
+  File TypingRule.CheckBitsEqualWidth.bad2.asl, line 10, characters 11 to 23:
+      cond = bit1 == bit2; // Illegal
+             ^^^^^^^^^^^^
+  ASL Type error: Illegal application of operator == on types bits(int1)
+    and bits(int2).
+  [1]
   $ aslref --no-exec TypingRule.GetWellConstrainedStructure.asl
   $ aslref --no-exec TypingRule.MemBfs.asl
   $ aslref --no-exec TypingRule.MemBfs.bad.asl
@@ -1119,6 +1162,8 @@ ASL Typing Tests / annotating types:
   Warning: Removing some values that would fail with op DIV from constraint set
   {-4..-3, -1..2, -1..B, 0, 1, 3..4, A..B, B, B..-1} gave
   {1..2, 1..B, 1, 3..4, A..B, B, B..-1}. Continuing with this constraint set.
+  $ aslref --no-exec TypingRule.EBinop.asl
+  $ aslref --no-exec TypingRule.EBinop2.asl
   $ aslref TypingRule.EBinop.bad.asl
   File TypingRule.EBinop.bad.asl, line 3, characters 10 to 19:
     let x = 3 DIV 0.0;
@@ -1126,6 +1171,7 @@ ASL Typing Tests / annotating types:
   ASL Type error: Illegal application of operator DIV on types integer {3}
     and real.
   [1]
+  $ aslref --no-exec TypingRule.ECond.asl
   $ aslref TypingRule.ESlice.bad1.asl
   File TypingRule.ESlice.bad1.asl, line 16, characters 4 to 7:
       dst = src[w:1];
@@ -1141,6 +1187,7 @@ ASL Typing Tests / annotating types:
     provided bits(offset).
   [1]
   $ aslref --no-exec TypingRule.Structure.asl
+  $ aslref --no-exec TypingRule.AnonymousType.asl
   $ aslref TypingRule.AnnotateSlices.bad-impure.asl
   File TypingRule.AnnotateSlices.bad-impure.asl, line 12, characters 12 to 28:
     let y = x[side_effecting()];


### PR DESCRIPTION
Last batch of examples from the ASL Reference predecessor.