### PR TITLE
[asl] Syntax for empty structured type declarations

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -357,7 +357,6 @@ let pattern_set :=
 let fields :=
     braced(MINUS); { [] }
   | braced(tclist1(typed_identifier))
-let fields_opt := { [] } | fields
 
 (* Slices *)
 let slices := bracketed(clist1(slice))
@@ -393,8 +392,14 @@ let ty :=
 let ty_decl := ty |
   annotated (
     | ENUMERATION; l=braced(tclist1(IDENTIFIER));       < T_Enum       >
-    | RECORD; l=fields_opt;                             < T_Record     >
-    | EXCEPTION; l=fields_opt;                          < T_Exception  >
+    | RECORD [@internal true];
+      { if Config.allow_empty_structured_type_declarations then T_Record []
+        else Error.fatal_here $startpos $endpos @@ Error.ObsoleteSyntax "Empty record type declaration." }
+    | EXCEPTION [@internal true];
+      { if Config.allow_empty_structured_type_declarations then T_Exception []
+        else Error.fatal_here $startpos $endpos @@ Error.ObsoleteSyntax "Empty exception type declaration." }
+    | RECORD; l=fields;                                 < T_Record     >
+    | EXCEPTION; l=fields;                              < T_Exception  >
   )
 
 (* Constructs on ty *)
@@ -406,7 +411,10 @@ let as_ty := COLON; ty
 let ty_or_collection :=
   | ty
   | annotated (
-    | COLLECTION; l=fields_opt;                         < T_Collection >
+    | COLLECTION [@internal true];
+      { if Config.allow_empty_structured_type_declarations then T_Collection []
+        else Error.fatal_here $startpos $endpos @@ Error.ObsoleteSyntax "Empty collection type declaration." }
+    | COLLECTION; l=fields;                         < T_Collection >
   )
 (* End *)
 

--- a/asllib/ParserConfig.mli
+++ b/asllib/ParserConfig.mli
@@ -36,4 +36,7 @@ module type CONFIG = sig
 
   val allow_local_constants : bool
   (** Allow declarations of local constant storage. *)
+
+  val allow_empty_structured_type_declarations : bool
+  (** Allow declarations of structured types with implicitly empty fields. *)
 end

--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -50,6 +50,7 @@ type args = {
   override_mode : override_mode;
   no_primitives : bool;
   control_flow_analysis : bool;
+  allow_empty_structured_type_declarations : bool;
 }
 
 let push thing ref = ref := thing :: !ref
@@ -83,6 +84,7 @@ let parse_args () =
   let use_conflincting_side_effects_extension = ref false in
   let control_flow_analysis = ref true in
   let allow_single_arrows = ref false in
+  let allow_empty_structured_type_declarations = ref false in
 
   let speclist =
     [
@@ -189,6 +191,10 @@ let parse_args () =
         Arg.Clear control_flow_analysis,
         " Do not use control-flow analysis to check that subprograms \
          return/throw/execute `Unreachable()`." );
+      ( "--allow-empty-structured-type-declarations",
+        Arg.Set allow_empty_structured_type_declarations,
+        " Allow declarations of structured types with implicitly empty fields."
+      );
     ]
     |> Arg.align ?limit:None
   in
@@ -232,6 +238,8 @@ let parse_args () =
       override_mode = !override_mode;
       no_primitives = !no_primitives;
       control_flow_analysis = !control_flow_analysis;
+      allow_empty_structured_type_declarations =
+        !allow_empty_structured_type_declarations;
     }
   in
 
@@ -279,6 +287,9 @@ let () =
     in
     let allow_local_constants = args.allow_local_constants in
     let allow_single_arrows = args.allow_single_arrows in
+    let allow_empty_structured_type_declarations =
+      args.allow_empty_structured_type_declarations
+    in
     let open Builder in
     {
       allow_no_end_semicolon;
@@ -289,6 +300,7 @@ let () =
       allow_hyphenated_pending_constraint;
       allow_local_constants;
       allow_single_arrows;
+      allow_empty_structured_type_declarations;
     }
   in
 

--- a/asllib/builder.ml
+++ b/asllib/builder.ml
@@ -37,6 +37,7 @@ type parser_config = {
   allow_hyphenated_pending_constraint : bool;
   allow_local_constants : bool;
   allow_single_arrows : bool;
+  allow_empty_structured_type_declarations : bool;
 }
 
 type version_selector = [ `ASLv0 | `ASLv1 | `Any ]
@@ -51,6 +52,7 @@ let default_parser_config =
     allow_hyphenated_pending_constraint = false;
     allow_local_constants = false;
     allow_single_arrows = false;
+    allow_empty_structured_type_declarations = false;
   }
 
 let select_type ~opn ~ast = function
@@ -89,6 +91,9 @@ let from_lexbuf ast_type parser_config version (lexbuf : lexbuf) =
           parser_config.allow_hyphenated_pending_constraint
 
         let allow_local_constants = parser_config.allow_local_constants
+
+        let allow_empty_structured_type_declarations =
+          parser_config.allow_empty_structured_type_declarations
       end) in
       let module Lexer = Lexer.Make (struct
         let allow_double_underscore = parser_config.allow_double_underscore

--- a/asllib/builder.mli
+++ b/asllib/builder.mli
@@ -38,6 +38,7 @@ type parser_config = {
   allow_hyphenated_pending_constraint : bool;
   allow_local_constants : bool;
   allow_single_arrows : bool;
+  allow_empty_structured_type_declarations : bool;
 }
 
 val default_parser_config : parser_config

--- a/asllib/bundler.ml
+++ b/asllib/bundler.ml
@@ -57,6 +57,7 @@ let build_ast_from_file ?(is_opn = false) f =
     let allow_storage_discards = false
     let allow_hyphenated_pending_constraint = false
     let allow_local_constants = false
+    let allow_empty_structured_type_declarations = false
   end) in
   let module Lexer = Lexer.Make (struct
     let allow_double_underscore = false

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -504,7 +504,6 @@
 \newcommand\Nsetteraccess[0]{\hyperlink{def-nsetteraccess}{\nonterminal{setter\_access}}}
 \newcommand\Nlexpr[0]{\hyperlink{def-nlexpr}{\nonterminal{lexpr}}}
 \newcommand\Nfields[0]{\hyperlink{def-nfields}{\nonterminal{fields}}}
-\newcommand\Nfieldsopt[0]{\hyperlink{def-nfieldsopt}{\nonterminal{fields\_opt}}}
 \newcommand\Nopttypedidentifier[0]{\hyperlink{def-nopttypeidentifier}{\nonterminal{opt\_typed\_identifier}}}
 \newcommand\Nstmtlist[0]{\hyperlink{def-nstmtlist}{\nonterminal{stmt\_list}}}
 \newcommand\Nmaybeemptystmtlist[0]{\hyperlink{def-nmaybeemptystmtlist}{\nonterminal{maybe\_empty\_stmt\_list}}}
@@ -860,7 +859,6 @@
 \newcommand\buildpatternlist[0]{\hyperlink{build-patternlist}{\textfunc{build\_pattern\_list}}}
 \newcommand\buildpattern[0]{\hyperlink{build-pattern}{\textfunc{build\_pattern}}}
 \newcommand\buildfields[0]{\hyperlink{build-fields}{\textfunc{build\_fields}}}
-\newcommand\buildfieldsopt[0]{\hyperlink{build-fieldsopt}{\textfunc{build\_fields\_opt}}}
 \newcommand\buildslices[0]{\hyperlink{build-slices}{\textfunc{build\_slices}}}
 \newcommand\buildslice[0]{\hyperlink{build-slice}{\textfunc{build\_slice}}}
 \newcommand\buildbitfields[0]{\hyperlink{build-bitfields}{\textfunc{build\_bitfields}}}
@@ -2605,7 +2603,6 @@
 \newcommand\vlefieldsone[0]{\texttt{le\_fields1}}
 \newcommand\vlerecord[0]{\texttt{le\_record}}
 \newcommand\vfieldsone[0]{\texttt{fields1}}
-\newcommand\vfieldsopt[0]{\texttt{fields\_opt}}
 \newcommand\vfieldss[0]{\texttt{fields\_s}}
 \newcommand\vfieldst[0]{\texttt{fields\_t}}
 \newcommand\vfieldstwo[0]{\texttt{fields2}}

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -554,11 +554,6 @@ except they do not derive tuples, which are the last derivation for $\Nexpr$.
                     & \Tlbrace \parsesep \TClistOne{\Ntypedidentifier} \parsesep \Trbrace &
 \end{flalign*}
 
-\hypertarget{def-nfieldsopt}{}
-\begin{flalign*}
-\Nfieldsopt \derives \ & \Nfields \;|\; \emptysentence &
-\end{flalign*}
-
 \hypertarget{def-nslices}{}
 \begin{flalign*}
 \Nslices \derives \ & \Tlbracket \parsesep \ClistOne{\Nslice} \parsesep \Trbracket &
@@ -602,8 +597,8 @@ except they do not derive tuples, which are the last derivation for $\Nexpr$.
 \begin{flalign*}
 \Ntydecl \derives\ & \Nty &\\
             |\ & \Tenumeration \parsesep \Tlbrace \parsesep \TClistOne{\Tidentifier} \parsesep \Trbrace &\\
-            |\ & \Trecord \parsesep \Nfieldsopt &\\
-            |\ & \Texception \parsesep \Nfieldsopt &
+            |\ & \Trecord \parsesep \Nfields &\\
+            |\ & \Texception \parsesep \Nfields &
 \end{flalign*}
 
 \hypertarget{def-nfieldassign}{}
@@ -613,7 +608,7 @@ except they do not derive tuples, which are the last derivation for $\Nexpr$.
 
 \hypertarget{def-ntyorcollection}{}
 \begin{flalign*}
-  \Ntyorcollection \derives \ & \Nty \;|\; \Tcollection \parsesep \Nfieldsopt &\\
+  \Ntyorcollection \derives \ & \Nty \;|\; \Tcollection \parsesep \Nfields &\\
 \end{flalign*}
 
 \hypertarget{def-nexpr}{}

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -18,7 +18,6 @@ Type declarations have no associated semantics.
             |\              & \Tsubtypes \parsesep \Tidentifier &\\
 \Nfields \derives \ & \Tlbrace \parsesep \Tminus \parsesep \Trbrace &\\
                     & \Tlbrace \parsesep \TClistOne{\Ntypedidentifier} \parsesep \Trbrace &\\
-\Nfieldsopt \derives \ & \Nfields \;|\; \emptysentence &\\
 \Ntypedidentifier \derives \ & \Tidentifier \parsesep \Nasty &\\
 \Nasty \derives \ & \Tcolon \parsesep \Nty &
 \end{flalign*}
@@ -130,28 +129,6 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 }{
   \buildfields(\Nfields(\Tlbrace, \namednode{\vfields}{\TClistOne{\Ntypedidentifier}}, \Trbrace)) \astarrow
   \overname{\vfieldasts}{\vastnode}
-}
-\end{mathpar}
-
-\ASTRuleDef{FieldsOpt}
-\hypertarget{build-fieldsopt}{}
-The function
-\[
-  \buildfieldsopt(\overname{\parsenode{\Nfieldsopt}}{\vparsednode}) \;\aslto\; \overname{\Field^*}{\vastnode}
-\]
-transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
-
-\begin{mathpar}
-\inferrule[fields]{}{
-  \buildfieldsopt(\Nfieldsopt(\punnode{\Nfields})) \astarrow
-  \overname{\astof{\vfields}}{\vastnode}
-}
-\end{mathpar}
-
-\begin{mathpar}
-\inferrule[empty]{}{
-  \buildfieldsopt(\Nfieldsopt(\emptysentence)) \astarrow
-  \overname{\emptylist}{\vastnode}
 }
 \end{mathpar}
 

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -1328,7 +1328,7 @@ is ill-typed, since the field \verb|v| repeats.
 
 \subsection{Syntax}
 \begin{flalign*}
-\Ntydecl \derives\ & \Trecord \parsesep \Nfieldsopt &
+\Ntydecl \derives\ & \Trecord \parsesep \Nfields &
 \end{flalign*}
 
 \subsection{Abstract Syntax}
@@ -1339,8 +1339,8 @@ is ill-typed, since the field \verb|v| repeats.
 \ASTRuleDef{TyDecl.TRecord}
 \begin{mathpar}
 \inferrule{}{
-  \buildtydecl(\Ntydecl(\Trecord, \punnode{\Nfieldsopt})) \astarrow
-  \overname{\TRecord(\astof{\vfieldsopt})}{\vastnode}
+  \buildtydecl(\Ntydecl(\Trecord, \punnode{\Nfields})) \astarrow
+  \overname{\TRecord(\astof{\vfields})}{\vastnode}
 }
 \end{mathpar}
 
@@ -1394,7 +1394,7 @@ In \listingref{typing-texception}, all the uses of exception types are well-type
 
 \subsection{Syntax}
 \begin{flalign*}
-\Ntydecl \derives\ & \Texception \parsesep \Nfieldsopt &
+\Ntydecl \derives\ & \Texception \parsesep \Nfields &
 \end{flalign*}
 
 \subsection{Abstract Syntax}
@@ -1405,8 +1405,8 @@ In \listingref{typing-texception}, all the uses of exception types are well-type
 \ASTRuleDef{TyDecl.TException}
 \begin{mathpar}
 \inferrule{}{
-  \buildtydecl(\Ntydecl(\Texception, \punnode{\Nfieldsopt})) \astarrow
-  \overname{\TException(\astof{\vfieldsopt})}{\vastnode}
+  \buildtydecl(\Ntydecl(\Texception, \punnode{\Nfields})) \astarrow
+  \overname{\TException(\astof{\vfields})}{\vastnode}
 }
 \end{mathpar}
 
@@ -1427,7 +1427,7 @@ See \listingref{checkisnotcollection} for an ill-typed specification.
 
 \subsection{Syntax}
 \begin{flalign*}
-  \Ntyorcollection \derives\ & \Nty \;|\; \Tcollection \parsesep \Nfieldsopt & \\
+  \Ntyorcollection \derives\ & \Nty \;|\; \Tcollection \parsesep \Nfields & \\
 \end{flalign*}
 
 \subsection{Abstract Syntax}
@@ -1438,8 +1438,8 @@ See \listingref{checkisnotcollection} for an ill-typed specification.
 \ASTRuleDef{TyDecl.TCollection}
 \begin{mathpar}
 \inferrule{}{
-  \buildtyorcollection(\Ntyorcollection(\Tcollection, \punnode{\Nfieldsopt})) \astarrow
-  \overname{\TCollection(\astof{\vfieldsopt})}{\vastnode}
+  \buildtyorcollection(\Ntyorcollection(\Tcollection, \punnode{\Nfields})) \astarrow
+  \overname{\TCollection(\astof{\vfields})}{\vastnode}
 }
 \and
 \inferrule{}{

--- a/asllib/tests/ASLDefinition.t/CatchingExceptions.asl
+++ b/asllib/tests/ASLDefinition.t/CatchingExceptions.asl
@@ -15,8 +15,8 @@ begin
     return 0;
 end;
 
-type Excp of exception;
-type Excp2 of exception;
+type Excp of exception{-};
+type Excp2 of exception{-};
 
 func could_throw_exception()
 begin

--- a/asllib/tests/ASLDefinition.t/CatchingExceptions2.asl
+++ b/asllib/tests/ASLDefinition.t/CatchingExceptions2.asl
@@ -1,4 +1,4 @@
-type BAD_OPCODE of exception;
+type BAD_OPCODE of exception{-};
 
 func decode_instruction(op: bits(32))
 begin
@@ -17,7 +17,7 @@ begin
     end;
 end;
 
-type IsExceptionTaken of exception;
+type IsExceptionTaken of exception{-};
 
 func handle_exception()
 begin

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Call.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.Call.asl
@@ -1,4 +1,4 @@
-type MyException of exception;
+type MyException of exception{-};
 
 func throwing_func()
 begin

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EvalGlobals.bad1.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.EvalGlobals.bad1.asl
@@ -1,4 +1,4 @@
-type MyException of exception;
+type MyException of exception{-};
 
 func f() => integer
 begin

--- a/asllib/tests/ASLSemanticsReference.t/SemanticsRule.RemoveLocal.asl
+++ b/asllib/tests/ASLSemanticsReference.t/SemanticsRule.RemoveLocal.asl
@@ -1,4 +1,4 @@
-type MyException of exception;
+type MyException of exception{-};
 
 func main() => integer
 begin

--- a/asllib/tests/ASLSyntaxReference.t/expr1.asl
+++ b/asllib/tests/ASLSyntaxReference.t/expr1.asl
@@ -1,5 +1,5 @@
 type point of record{x: bits(4), y: bits(4)};
-type except of exception;
+type except of exception{-};
 
 func main() => integer
 begin

--- a/asllib/tests/ASLSyntaxReference.t/expr2.asl
+++ b/asllib/tests/ASLSyntaxReference.t/expr2.asl
@@ -21,7 +21,7 @@ begin
 end;
 
 type point of record{x: bits(4), y: bits(4)};
-type except of exception;
+type except of exception{-};
 
 func main() => integer
 begin

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AddLocal.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AddLocal.asl
@@ -1,4 +1,4 @@
-type MyException of exception;
+type MyException of exception{-};
 
 func foo{N}(bv: bits(N))
 begin

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ApproxStmt.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ApproxStmt.asl
@@ -18,7 +18,7 @@ begin
     return 42;
 end;
 
-type invalid_state of exception;
+type invalid_state of exception{-};
 func throws_exception() => integer
 begin
     throw invalid_state{-};

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinExceptionType.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BuiltinExceptionType.asl
@@ -1,4 +1,4 @@
-type Not_found of exception;
+type Not_found of exception{-};
 type SyntaxException of exception { message:string };
 
 func main () => integer

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckControlFlow.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckControlFlow.asl
@@ -1,5 +1,5 @@
 
-type invalid_state of exception;
+type invalid_state of exception{-};
 
 func all_terminating_paths_correct{N}(v: bits(N), flag: boolean) => bits(N)
 begin

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckControlFlow.bad2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckControlFlow.bad2.asl
@@ -1,5 +1,5 @@
 
-type invalid_state of exception;
+type invalid_state of exception{-};
 
 func incorrect_terminating_path{N}(v: bits(N), flag: boolean) => bits(N)
 begin

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckControlFlow.noreturn.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckControlFlow.noreturn.asl
@@ -7,7 +7,7 @@ begin
     end;
 end;
 
-type myexception of exception;
+type myexception of exception{-};
 
 noreturn func doesnotreturn()
 begin

--- a/asllib/tests/ASLTypingReference.t/TypingRule.CheckSymbolicallyEvaluable.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.CheckSymbolicallyEvaluable.bad.asl
@@ -1,4 +1,4 @@
-type MyException of exception;
+type MyException of exception{-};
 
 func symbolic_throwing{N}(x: integer{N}) => integer{N}
 begin

--- a/asllib/tests/ASLTypingReference.t/TypingRule.DefDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.DefDecl.asl
@@ -1,4 +1,4 @@
-type MyRecord of record; // { Other(MyRecord) }
+type MyRecord of record{-}; // { Other(MyRecord) }
 
 var g : MyRecord; // { Other(g) }
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.SideEffectIsPure.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.SideEffectIsPure.asl
@@ -3,7 +3,7 @@ let lg = 30;
 config cfg : integer{0..100} = 40;
 var vg : integer = 50;
 
-type MyException of exception;
+type MyException of exception{-};
 
 readonly func factorial(n: integer) => integer recurselimit 100
 begin

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TCollection.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TCollection.asl
@@ -1,6 +1,5 @@
 var MyCollection: collection { a: bits(8), b: bits(16) };
-var CollectionWithEmptyFieldList: collection {-};
-var CollectionWithoutFields: collection;
+var CollectionWithoutFields: collection{-};
 
 // The next declaration in comment is illegal:
 // only bitvector types are allowed as collection fields.

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TExceptionDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TExceptionDecl.asl
@@ -1,4 +1,4 @@
-type BAD_OPCODE of exception;
+type BAD_OPCODE of exception{-};
 type UNDEFINED_OPCODE of exception {reason: string, opcode: bits(16)};
 type ExceptionWithEmptyFieldList of exception {-};
 

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TRecordDecl.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TRecordDecl.asl
@@ -1,11 +1,9 @@
 type MyRecord of record { a: integer, b: boolean };
-type RecordWithEmptyFieldList of record {-};
-type RecordWithoutFields of record;
+type RecordWithoutFields of record{-};
 
 func main() => integer
 begin
     - = MyRecord {a = 3, b = TRUE};
-    - = RecordWithEmptyFieldList {-};
     - = RecordWithoutFields {-};
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypeClashes.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypeClashes.asl
@@ -21,10 +21,10 @@ func array_procedure(int_arr2 : array[[2]] of integer) begin pass; end;
 func array_procedure(boolean_arr : array[[2]] of boolean) begin pass; end;
 func array_procedure(real_arr : array[[2]] of real) begin pass; end;
 
-type Rec1 of record;
-type Rec2 of record;
-type Exc1 of exception;
-type Exc2 of exception;
+type Rec1 of record{-};
+type Rec2 of record{-};
+type Exc1 of exception{-};
+type Exc2 of exception{-};
 func structured_procedure(r: Rec1) begin pass; end;
 func structured_procedure(r: Rec2) begin pass; end;
 func structured_procedure(e: Exc1) begin pass; end;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.TypeClashes.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.TypeClashes.bad.asl
@@ -1,4 +1,4 @@
-type SuperRec of record;
+type SuperRec of record{-};
 type SubRec subtypes SuperRec;
 func structured_procedure(r: SuperRec) begin pass; end;
 // Illegal as `SubRec` subtype-satisfies `SuperRec`.

--- a/asllib/tests/ASLTypingReference.t/TypingRule.UpdateGlobalStorage.config.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.UpdateGlobalStorage.config.bad.asl
@@ -1,3 +1,3 @@
-type MyException of exception;
+type MyException of exception{-};
 // Illegal: only singular types can be used for config storage elements.
 config d: MyException = MyException{-};

--- a/asllib/tests/regressions.t/exceptions.asl
+++ b/asllib/tests/regressions.t/exceptions.asl
@@ -1,4 +1,4 @@
-type BAD_OPCODE of exception;
+type BAD_OPCODE of exception{-};
 
 type UNDEFINED_OPCODE of exception {reason: string, opcode: bits(16)};
 

--- a/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus
@@ -7,7 +7,7 @@ ASL catch-exec-twice
 
 {}
 
-type Bonga of exception;
+type Bonga of exception{-};
 
 func g() => integer
 begin

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus
@@ -10,7 +10,7 @@ ASL throw-assign
 
 var z = 0;
 
-type Coucou of exception;
+type Coucou of exception{-};
 
 func f() => integer
 begin

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus
@@ -10,8 +10,8 @@ var z = 0;
 var t = 2;
 var aa=1;
 
-type Coucou of exception;
-type Bonga of exception;
+type Coucou of exception{-};
+type Bonga of exception{-};
 
 func f() => integer
 begin

--- a/lib/ASLBase.ml
+++ b/lib/ASLBase.ml
@@ -227,6 +227,7 @@ let stmts_from_string s =
     let allow_storage_discards = false
     let allow_hyphenated_pending_constraint = false
     let allow_local_constants = false
+    let allow_empty_structured_type_declarations = false
   end) in
   let module Lexer = Lexer.Make(struct
     let allow_double_underscore = false


### PR DESCRIPTION
Require declarations of empty structured types to explicitly declare an empty field list:
```
type Foo of record;    // ERROR
type Bar of exception; // ERROR
var x : collection;    // ERROR

type Foo of record{-};    // OK
type Bar of exception{-}; // OK
var x : collection{-};    // OK
```
Gate this change behind a flag: `--allow-empty-structured-type-declarations`