### PR TITLE
[asl][reference] Always make with -m option

### DIFF
--- a/.github/workflows/build-asl-reference.yml
+++ b/.github/workflows/build-asl-reference.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Install opam dependencies
         run: opam install . --deps-only --yes
 
+      - run: opam exec -- make build DUNE_PROFILE=dev
+
+      - run: opam exec -- make install
+
       - name: Build ASL Reference
         run: opam exec -- make asldoc
 

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -1,4 +1,5 @@
 BENTO=../../_build/default/tools/bento.exe
+ASLREF=../../_build/install/default/bin/aslref
 LATEX=pdflatex
 BIBTEX=bibtex
 
@@ -30,7 +31,7 @@ ASLReference.pdf: control\
 	$(LATEX) ASLReference.tex
 	$(BIBTEX) ASLReference
 	$(LATEX) ASLReference.tex
-	python3 doclint.py -m
+	python3 doclint.py -m --aslref $(ASLREF)
 
 ASLASTLines.tex: ../AST.mli
 	$(BENTO) $< > $@

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -30,7 +30,7 @@ ASLReference.pdf: control\
 	$(LATEX) ASLReference.tex
 	$(BIBTEX) ASLReference
 	$(LATEX) ASLReference.tex
-	python3 doclint.py
+	python3 doclint.py -m
 
 ASLASTLines.tex: ../AST.mli
 	$(BENTO) $< > $@

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -23,6 +23,12 @@ cli_parser.add_argument(
     metavar="<path-to-dictionary-file>",
     type=pathlib.Path,
 )
+cli_parser.add_argument(
+    "--aslref",
+    help="Specifies path to the aslref executable",
+    metavar="<path-to-aslref>",
+    type=str,
+)
 
 INTERNAL_DICTIONARY_FILENAME = "dictionary.txt"
 DO_NOT_LINT_STR = "DO NOT LINT"
@@ -681,8 +687,9 @@ def check_per_file(latex_files: list[str], checks):
 
 def main():
     args = cli_parser.parse_args()
+    aslref_path = args.aslref if args.aslref else "aslref"
     if args.macros:
-        apply_all_macros()
+        apply_all_macros(aslref_path)
     print("Linting files...")
     all_latex_sources = get_latex_sources(False)
     content_latex_sources = get_latex_sources(True)


### PR DESCRIPTION
Always use the `-m` flag to make sure that the console outputs are synchronized with the ASL Reference.
This requires building and installing aslref so that it can be run from `doclint.py`.
Also a `--aslref` option was added to `doclint.py` to point to the aslref binary path.