### PR TITLE
[asl][reference] fixed SemanticsRule.GetIndex and SemanticsRule.SetIndex

### DIFF
--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -994,13 +994,14 @@ of \\
   \item $\mindex$ consists of the native integer $\vindex$ and the execution graph $\vgone$;
   \item $\vindex$ is the native integer for $\vi$;
   \item $\rmarray$ consists of the native vector $\rvarray$ and the execution graph $\vgtwo$;
-  \item setting the value $\vv$ at index $\vi$ of $\rvarray$ is the native vector $\vvone$;
+  \item setting the value $\vv$ at index $\vi$ of $\rvarray$ yields the native vector $\vvone$\ProseOrError;
   \item $\vmone$ is the pair consisting of $\vvone$ and the parallel composition of $\vgone$ and $\vgtwo$;
   \item the steps so far computed the updated array, but have not assigned it to the variable
   bound to the array given by $\rearray$, which is achieved next.
   Evaluating the left-hand-side expression $\rearray$ in an environment $\envtwo$ with $\vmone$
   is the output configuration $C$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
@@ -1009,7 +1010,7 @@ of \\
   \mindex \eqname (\vindex, \vgone)\\
   \vindex \eqname \nvint(\vi)\\
   \rmarray \eqname (\rvarray, \vgtwo)\\
-  \setindex(\vi, \vv, \rvarray) \evalarrow \vvone\\
+  \setindex(\vi, \vv, \rvarray) \evalarrow \vvone \OrDynError\\\\
   \vmone \eqdef (\vvone, \vgone \parallelcomp \vgtwo)\\
   \evallexpr{\envtwo, \rearray, \vmone} \evalarrow C
 }{

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -1441,7 +1441,7 @@ which has indexes \texttt{0}, \texttt{1} and \texttt{2} only.
   \item $\marray$ consists of the native vector $\varray$ and execution graph $\vgone$;
   \item $\mindex$ consists of the native integer $\vindex$ and execution graph $\vgtwo$;
   \item $\vindex$ is the native integer for $\vi$;
-  \item evaluating the value at index $\vi$ of $\varray$ is $\vv$;
+  \item evaluating the value at index $\vi$ of $\varray$ yields $\vv$\ProseOrError;
   \item $\vg$ is the parallel composition of $\vgone$ and $\vgtwo$.
 \end{itemize}
 
@@ -1453,7 +1453,7 @@ which has indexes \texttt{0}, \texttt{1} and \texttt{2} only.
   \marray \eqname (\varray, \vgone)\\
   \mindex \eqname (\vindex, \vgtwo)\\
   \vindex \eqname \nvint(\vi)\\
-  \getindex(\vi, \varray) \evalarrow \vv\\
+  \getindex(\vi, \varray) \evalarrow \vv \OrDynError\\\\
   \vg \eqdef \vgone \parallelcomp \vgtwo\\
 }{
   \evalexpr{\env, \EGetArray(\earray, \eindex)} \evalarrow \Normal((\vv, \vg), \newenv)

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -507,13 +507,15 @@ $s$, which is given via a floating point representation.
 \item The function $\strtolit(s)$ returns $\Tstringlit(s')$ where $s'$ is the string value represented by $s$.
 \hypertarget{def-bitstolit}{}
 \item The function $\bitstolit(s)$ returns $\Tbitvectorlit(b)$ where $b$ is the sequence of bits
-given by $s$.
+      given by $s$.
 \hypertarget{def-masktolit}{}
 \item The function $\masktolit(s)$ returns $\Tmasklit(m)$ where $m$ is the bitmask given by $s$.
 \hypertarget{def-falsetolit}{}
-\item The function $\falsetolit(s)$ returns $\Tboollit(\False)$ ($s$ is ensured to be \texttt{FALSE}).
+\item The function $\falsetolit(s)$ returns $\Tboollit(\False)$ ($s$ is guaranteed to be \\
+      \texttt{FALSE}).
 \hypertarget{def-truetolit}{}
-\item The function $\truetolit(s)$ returns $\Tboollit(\True)$ ($s$ is ensured to be \texttt{TRUE}).
+\item The function $\truetolit(s)$ returns $\Tboollit(\True)$ ($s$ is guaranteed to be \\
+      \texttt{TRUE}).
 \hypertarget{def-tokenid}{}
 \item The function $\tokenid(s)$ returns $\Tlexeme(s)$.
 \hypertarget{def-lexicalerror}{}

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -554,13 +554,14 @@ In reference to \listingref{semantics-leslice}, we have the following applicatio
 \end{mathpar}
 
 \SemanticsRuleDef{GetIndex}
-\ProseParagraph
 The relation
 \hypertarget{def-getindex}{}
 \[
-  \getindex(\overname{\N}{\vi} \aslsep \overname{\tvector}{\vvec}) \;\aslrel\; \overname{\tvector}{\vv_{\vi}}
+  \getindex(\overname{\N}{\vi} \aslsep \overname{\tvector}{\vvec}) \;\aslrel\;
+  (\overname{\tvector}{\vr} \cup \overname{\TDynError}{\DynamicErrorVal{\BadIndex}})
 \]
-reads the value $\vv_i$ from the vector of values $\vvec$ at the index $\vi$.
+reads the value $\vr$ from the vector of values $\vvec$ at the index $\vi$.
+\ProseOtherwiseDynamicError
 
 \ExampleDef{Reading a Vector at an Index}
 The specification in \listingref{GetIndex} shows examples of accessing indices of native vectors:
@@ -575,39 +576,52 @@ The specification in \listingref{GetIndex} shows examples of accessing indices o
 \end{itemize}
 \ASLListing{Reading a vector at an index}{GetIndex}{\semanticstests/SemanticsRule.GetIndex.asl}
 
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{ok}
+  \begin{itemize}
+    \item $\vi$ is less than the number of elements in $\vvec$;
+    \item \Proseeqdef{$\vr$}{the element of $\vvec$ at index $\vi$}.
+  \end{itemize}
+
+  \item \AllApplyCase{error}
+  \begin{itemize}
+    \item $\vi$ is greater or equal to the number of elements in $\vvec$;
+    \item the result is the \dynamicerrorterm{} for an out of bounds index (\BadIndex).
+  \end{itemize}
+\end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
-\inferrule{
-  \vvec \eqname \vv_{0..k}\\
-  \vi \leq k\\
+\inferrule[ok]{
+  \vi < \listlen{\vvec}\\
 }{
-  \getindex(\vi, \vvec) \evalarrow \vv_{\vi}
+  \getindex(\vi, \vvec) \evalarrow \overname{\vv[\vi]}{\vr}
 }
 \end{mathpar}
 
-Notice that there is no rule to handle the case where the index is out of range ---
-this is guaranteed by the typechecker not to happen. Specifically,
-\begin{itemize}
-  \item \TypingRuleRef{EGetArray} ensures that an index is within the bounds of the array
-  being accessed via a check that the type of the index satisfies the type of the array size.
-  \item Typing rules \TypingRuleRef{LEDestructuring}, \TypingRuleRef{PTuple},
-  and \\ \TypingRuleRef{LDTuple} use the same index sequences for the tuples
-  involved and the corresponding lists of expressions.
-\end{itemize}
-If the rules listed above do not hold the typechecker fails.
+\begin{mathpar}
+\inferrule[error]{
+  \vi \geq \listlen{\vvec}\\
+}{
+  \getindex(\vi, \vvec) \evalarrow \DynamicErrorVal{\BadIndex}
+}
+\end{mathpar}
 
 \SemanticsRuleDef{SetIndex}
-\ProseParagraph
 The relation
 \hypertarget{def-setindex}{}
 \[
-  \setindex(\overname{\N}{\vi} \aslsep \overname{\vals}{\vv} \aslsep \overname{\tvector}{\vvec}) \;\aslrel\; \overname{\tvector}{\vres}
+  \setindex(\overname{\N}{\vi} \aslsep \overname{\vals}{\vv} \aslsep \overname{\tvector}{\vvec}) \;\aslrel\;
+  (\overname{\tvector}{\vres} \cup \overname{\TDynError}{\DynamicErrorVal{\BadIndex}})
 \]
 overwrites the value at the given index $\vi$ in a vector of values $\vvec$ with the new value $\vv$.
+\ProseOtherwiseDynamicError
 
 \ExampleDef{Writing a Vector at an Index}
 In \listingref{GetIndex}, evaluating the statement \verb|arr[[1]] = 3;|
-involves
+involves the following premise:
 \[
 \begin{array}{r}
 \setindex(1, \nvint(3), \nvvector{\nvint(0), \nvint(0), \nvint(0)}) \evalarrow\\
@@ -615,19 +629,44 @@ involves
 \end{array}
 \]
 
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{ok}
+  \begin{itemize}
+    \item $\vi$ is less than the number of elements in $\vvec$;
+    \item $\vvec$ is the sequence $\vu_{0..k}$;
+    \item $\vres$ is the sequence of values identical to $\vvec$,
+          except that at index $\vi$ the value is $\vv$.
+  \end{itemize}
+
+  \item \AllApplyCase{error}
+  \begin{itemize}
+    \item $\vi$ is greater or equal to the number of elements in $\vvec$;
+    \item the result is the \dynamicerrorterm{} for an out of bounds index (\BadIndex).
+  \end{itemize}
+\end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
-\inferrule{
+\inferrule[ok]{
+  \vi \leq \listlen{\vvec}\\
   \vvec \eqname \vu_{0..k}\\
-  \vi \leq k\\
-  \vres \eqname \vw_{0..k}\\
-  \vv \eqdef \vw_{\vi} \\
+  \vres = \vw_{0..k}\\
+  \vv = \vw_{\vi} \\
   j \in \{0..k\} \setminus \{\vi\}.\ \vw_{j} = \vu_j\\
 }{
   \setindex(\vi, \vv, \vvec) \evalarrow \vres
 }
 \end{mathpar}
-Similar to $\getindex$, there is no need to handle the out-of-range index case.
+
+\begin{mathpar}
+\inferrule[error]{
+  \vi > \listlen{\vvec}
+}{
+  \setindex(\vi, \vv, \vvec) \evalarrow \DynamicErrorVal{\BadIndex}
+}
+\end{mathpar}
 
 \SemanticsRuleDef{GetField}
 \ProseParagraph

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -676,7 +676,7 @@ fields that can be read or written.
 and \chapref{BitvectorSlicing} defines \bitslicesterm{}.
 
 \RequirementDef{BitvectorsMSB}
-In a bitvector, the most significant bit (\ProseMSB) is the leftmost value
+In a bitvector literal, the most significant bit (\ProseMSB) is the leftmost value
 and the least significant bit (\ProseLSB) is the rightmost value.
 % INLINED_EXAMPLE
 For example, in \verb|'10'| the \ProseMSB{} is \verb|1| and the \ProseLSB{} is \verb|0|.


### PR DESCRIPTION
The rules missed the cases where the index could be out of bounds, resulting in a dynamic error.