### PR TITLE
[asl] Remove unique identifiers for parameters

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -273,7 +273,7 @@ and constraint_kind =
           constraint in the list. *)
   | PendingConstrained
       (** An integer type whose constraint will be inferred during type-checking. *)
-  | Parameterized of uid * identifier
+  | Parameterized of identifier
       (** A parameterized integer, the default type for parameters of
           function at compile time, with a unique identifier and the variable
           bearing its name. *)

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -409,7 +409,7 @@ and type_equal eq t1 t2 =
   | T_String, T_String
   | T_Int UnConstrained, T_Int UnConstrained ->
       true
-  | T_Int (Parameterized (i1, _)), T_Int (Parameterized (i2, _)) -> i1 == i2
+  | T_Int (Parameterized x1), T_Int (Parameterized x2) -> String.equal x1 x2
   | T_Int (WellConstrained (c1, _)), T_Int (WellConstrained (c2, _)) ->
       constraints_equal eq c1 c2
   | T_Bits (w1, bf1), T_Bits (w2, bf2) ->

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -449,7 +449,7 @@ module DeterministicBackend = struct
     | T_Int UnConstrained -> NV_Literal (L_Int Z.zero)
     | T_Int (WellConstrained (constraints, _)) ->
         deterministic_unknown_of_constraints ~eval_expr_sef ty constraints
-    | T_Int (Parameterized (_, x)) -> eval_expr_sef (E_Var x |> add_pos_from ty)
+    | T_Int (Parameterized x) -> eval_expr_sef (E_Var x |> add_pos_from ty)
     | T_Bits (e, _) -> (
         match eval_expr_sef e with
         | NV_Literal (L_Int n) ->

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -196,7 +196,7 @@ and pp_ty f t =
   | T_Int (WellConstrained (cs, _)) ->
       fprintf f "@[integer {%a}@]" pp_int_constraints cs
   | T_Int PendingConstrained -> pp_print_string f "integer{-}"
-  | T_Int (Parameterized (_uid, var)) -> fprintf f "@[integer {%s}@]" var
+  | T_Int (Parameterized var) -> fprintf f "@[integer {%s}@]" var
   | T_Real -> pp_print_string f "real"
   | T_String -> pp_print_string f "string"
   | T_Bool -> pp_print_string f "boolean"

--- a/asllib/Serialize.ml
+++ b/asllib/Serialize.ml
@@ -237,7 +237,7 @@ and pp_int_constraints f = function
         (pp_list pp_int_constraint)
         cs pp_precision_loss precision_loss
   | PendingConstrained -> addb f "PendingConstrained"
-  | Parameterized (i, x) -> bprintf f "Parameterized (%d, %S)" i x
+  | Parameterized x -> bprintf f "Parameterized %S" x
 
 and pp_precision_loss f = function
   | Precision_Full -> addb f "PrecisionFull"

--- a/asllib/lispobj.ml
+++ b/asllib/lispobj.ml
@@ -423,7 +423,7 @@ and of_constraint_kind (x : constraint_kind) =
           of_precision_loss_flag flg;
         ]
     | PendingConstrained -> [ key "PENDINGCONSTRAINED" ]
-    | Parameterized (u, i) -> [ key "PARAMETRIZED"; of_uid u; of_identifier i ])
+    | Parameterized i -> [ key "PARAMETRIZED"; of_identifier i ])
 
 and of_bitfield x =
   tagged_list_of_list

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -153,19 +153,11 @@ let rec is_non_primitive ty =
 let is_primitive ty = (not (is_non_primitive ty)) |: TypingRule.PrimitiveType
 (* End *)
 
-let parameterized_constraints =
-  let next_uid = ref 0 in
-  fun var ->
-    let uid = !next_uid in
-    incr next_uid;
-    Parameterized (uid, var)
-
-let parameterized_ty ~loc var =
-  T_Int (parameterized_constraints var) |> add_pos_from loc
+let parameterized_ty ~loc var = T_Int (Parameterized var) |> add_pos_from loc
 
 let to_well_constrained ty =
   match ty.desc with
-  | T_Int (Parameterized (_uid, var)) -> var_ var |> integer_exact
+  | T_Int (Parameterized var) -> var_ var |> integer_exact
   | _ -> ty
 
 let get_well_constrained_structure env ty =
@@ -237,7 +229,7 @@ module Domain = struct
     let ty = make_anonymous env ty in
     match ty.desc with
     | T_Int UnConstrained -> Top
-    | T_Int (Parameterized (_uid, var)) ->
+    | T_Int (Parameterized var) ->
         Subdomains [ ConstrainedDom (Constraint_Exact (var_ var)) ]
     | T_Int (WellConstrained (constraints, _)) ->
         Subdomains (List.map (symdom_of_constraint env) constraints)


### PR DESCRIPTION
These do not seem to be used significantly, and are not documented in the ASL Reference.