### PR TITLE
Release doc in tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 .gitattributes export-ignore
 .gitignore export-ignore
-doc/ export-ignore
 herd-www/  export-ignore
 catalogue/ export-ignore


### PR DESCRIPTION
Downstream distro cannot build herdtools7 with spec if using GitHub tarball, removing the export-ignore for doc