### PR TITLE
[herd] Fail when `-variant mixed` is not implemented

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -506,6 +506,9 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
 
     include ArchExtra_herd.Make(C)
         (struct
+
+          let arch = arch
+
           module V = V
           let endian = endian
 

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -125,6 +125,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     include ArchExtra_herd.Make(C)
         (struct
+
+          let arch = arch
+
           module V = V
           let endian = endian
 

--- a/herd/BPFArch_herd.ml
+++ b/herd/BPFArch_herd.ml
@@ -83,6 +83,9 @@ struct
     ArchExtra_herd.Make
       (C)
       (struct
+
+        let arch = arch
+
         module V = V
 
         let endian = endian

--- a/herd/BellArch_herd.ml
+++ b/herd/BellArch_herd.ml
@@ -36,6 +36,9 @@ module Make
 
   include ArchExtra_herd.Make(C)
       (struct
+
+        let arch = arch
+
         module V = V
         let endian = endian
 

--- a/herd/CArch_herd.ml
+++ b/herd/CArch_herd.ml
@@ -30,6 +30,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
 
   include ArchExtra_herd.Make(C)
       (struct
+
+        let arch = arch
+
         module V = V
         let endian = endian
 

--- a/herd/GenericArch_herd.ml
+++ b/herd/GenericArch_herd.ml
@@ -40,6 +40,9 @@ module Make (B : ArchBaseHerd) (C : Arch_herd.Config) (V : Value.S) = struct
     ArchExtra_herd.Make
       (C)
       (struct
+
+        let arch = B.arch
+
         module V = V
         module FaultType = FaultType.No
 

--- a/herd/JavaArch_herd.ml
+++ b/herd/JavaArch_herd.ml
@@ -33,6 +33,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
 
   include ArchExtra_herd.Make(C)
       (struct
+        let arch = arch
         module V = V
         let endian            = endian
         type arch_reg         = reg

--- a/herd/MIPSArch_herd.ml
+++ b/herd/MIPSArch_herd.ml
@@ -59,6 +59,9 @@ module Make
 
     include ArchExtra_herd.Make(C)
 	(struct
+
+          let arch = arch
+
 	  module V = V
           let endian = endian
 

--- a/herd/PPCArch_herd.ml
+++ b/herd/PPCArch_herd.ml
@@ -82,6 +82,9 @@ module Make (C:Arch_herd.Config) (V:Value.S)
 
     include ArchExtra_herd.Make(C)
         (struct
+
+          let arch = arch
+
           module V = V
           let endian = endian
 

--- a/herd/RISCVArch_herd.ml
+++ b/herd/RISCVArch_herd.ml
@@ -121,6 +121,9 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     include ArchExtra_herd.Make(C)
         (struct
+
+          let arch = arch
+
           module V = V
           let endian = endian
 

--- a/herd/X86Arch_herd.ml
+++ b/herd/X86Arch_herd.ml
@@ -68,6 +68,9 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
 
     include ArchExtra_herd.Make
         (C)(struct
+
+          let arch = arch
+
           module V = V
           let endian = endian
 

--- a/herd/X86_64Arch_herd.ml
+++ b/herd/X86_64Arch_herd.ml
@@ -102,6 +102,9 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
 
     include ArchExtra_herd.Make (C)
               (struct
+
+                let arch = arch
+
                 module V = V
                 let endian = endian
 

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -18,6 +18,9 @@
 
 (** Input signature, a reduced [Arch.ARCH] *)
 module type I = sig
+
+  val arch : Archs.t
+
   module V : Value.S
   val endian : Endian.t
 
@@ -262,6 +265,11 @@ module Make(C:Config) (I:I) : S with module I = I
     = struct
 
       let is_mixed = C.variant Variant.Mixed || C.variant Variant.Morello
+
+      let () =
+        if is_mixed && not (Archs.has_mixed_mode I.arch) then
+          Warn.user_error "Mixed mode not implemented for architecture %s"
+            (Archs.pp I.arch)
 
       module I = I
       type v = I.V.v

--- a/lib/Archs.ml
+++ b/lib/Archs.ml
@@ -124,6 +124,10 @@ let asl = `ASL
 
 let compare = compare
 
+let has_mixed_mode = function
+  | `AArch64|`X86_64 -> true
+  | _ -> false
+
 let get_sysarch a ca = match a with
   | #System.arch as a -> a
   |`CPP|`LISA | `JAVA | `ASL -> `Unknown

--- a/lib/Archs.mli
+++ b/lib/Archs.mli
@@ -73,5 +73,7 @@ val  lisa : t
 val  x86_64 : t
 val  asl : t
 
+val has_mixed_mode : t -> bool
+
 val get_sysarch : [< t ] ->  System.t -> System.t
 val check_carch : [< System.t ] -> System.arch


### PR DESCRIPTION
Fail with an explicit error message when mixed size mode is specified for an architecture that does not implement it..

Currently, mixed size mode is implemented for AArch64 and X86_64.

This PR fixes a problem reported by Andrea Parri.