### PR TITLE
[ASL] Tying loose ends

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -2869,9 +2869,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
   (* End *)
 
   (* Begin DeclareLocalConstant *)
-  let declare_local_constant env v = function
+  let declare_local_constant ~loc env v = function
     | LDI_Var x -> add_local_constant x v env
-    | LDI_Tuple _ -> (* Not yet implemented *) env
+    | LDI_Tuple _ -> fatal_from ~loc UnrespectedParserInvariant
   (* End *)
 
   let rec annotate_stmt env s : stmt * env * SES.t =
@@ -3101,7 +3101,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                   let+ () = check_is_pure ~loc:s typed_e in
                   try
                     let v = StaticInterpreter.static_eval env1 e in
-                    declare_local_constant env1 v ldi
+                    declare_local_constant ~loc:s env1 v ldi
                   with Error.(ASLException _) -> env1)
             in
             (S_Decl (ldk, ldi, ty_opt', Some e') |> here, new_env, ses)

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -16,7 +16,7 @@ We define the following sets:
 }
 
 \item \hypertarget{def-Npos}{
-    $\Npos$ is the set of natural numbers, excluding $0$.
+    $\Npos$ is the set of positive natural numbers (that is, excluding $0$).
 }
 
 \item

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1422,7 +1422,7 @@
 \newcommand\addpolynomials[0]{\hyperlink{def-addpolynomials}{\textfunc{add\_polynomials}}}
 \newcommand\mulpolynomials[0]{\hyperlink{def-mulpolynomials}{\textfunc{mul\_polynomials}}}
 \newcommand\mulmonomials[0]{\hyperlink{def-mulmonomials}{\textfunc{mul\_monomials}}}
-\newcommand\polynomialdividebyterm[0]{\tododefine{polynomial\_divide\_by\_term}}
+\newcommand\polynomialdividebyterm[0]{\hyperlink{def-polynomialdividebyterm}{polynomial\_divide\_by\_term}}
 
 \newcommand\declaredtype[0]{\hyperlink{def-declaredtype}{\textfunc{declared\_type}}}
 

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -156,6 +156,11 @@ adds a list of polynomials:
 }
 \end{mathpar}
 
+For example, if $\alpha(\vpone) = 3\cdot{}x^2\cdot{}y$,
+$\alpha(\vptwo) = 4\cdot{}x^2\cdot{}y$, and
+$\alpha(\vptwo) = x\cdot{}y^2$,
+then $\alpha(\addpolynomials([\vpone, \vptwo, \vpthree])) = 7\cdot{}x^2\cdot{}y + x\cdot{}y^2$.
+
 The function
 \hypertarget{def-mulpolynomials}{}
 \[
@@ -178,6 +183,49 @@ multiplies two polynomials.
   \mulpolynomials(\overname{\vfone}{\vpone}, \overname{\vftwo}{\vptwo}) \typearrow \vp
 }
 \end{mathpar}
+
+The function
+\hypertarget{def-polynomialdividebyterm}{}
+\[
+  \polynomialdividebyterm :
+  \overname{\polynomial}{\vpone} \times
+  \overname{\unitarymonomial}{\vm} \times
+  \overname{\Q}{\vf}
+  \rightarrow \overname{\polynomial}{\vp} \cup \CannotBeTransformed
+\]
+returns the result of dividing the polynomial $\vpone$ by the number $\vf$ and unitary monomial $\vm$,
+yielding the polynomial $\vp$. Otherwise, the result is $\CannotBeTransformed$.
+
+\begin{mathpar}
+\inferrule[divides]{
+  \vptwo \eqdef [\vm \mapsto \vf]\\
+  \vpone = \mulpolynomials(\vp, \vptwo)
+}{
+  \polynomialdividebyterm(\vpone, \vm, \vf) \typearrow \vp
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[does\_not\_divide]{
+  \vptwo \eqdef [\vm \mapsto \vf]\\
+  \forall \vp\in\polynomial.\ \vpone \neq \mulpolynomials(\vp, \vptwo)
+}{
+  \polynomialdividebyterm(\vpone, \vm, \vf) \typearrow \CannotBeTransformed
+}
+\end{mathpar}
+
+For example,
+if $\alpha(\vpone) = 6\cdot{}x^2\cdot{}y + 2\cdot{}x\cdot{}z$
+and $\alpha(\vm) = x$ and $\vf=2$ then
+\[
+\alpha(\polynomialdividebyterm(\vpone, \vm, \vf)) =  3\cdot{}x\cdot{}y + z \enspace.
+\]
+%
+In contrast, if $\alpha(\vpone) = x$
+and $\alpha(\vm) = x^2$ and $\vf=1$ then
+\[
+\alpha(\polynomialdividebyterm(\vpone, \vm, \vf)) =  \CannotBeTransformed \enspace.
+\]
 
 \section{Typing Rules\label{sec:SymbolicReductionAndEquivalenceTestingRules}}
 We employ the following rules:
@@ -715,6 +763,7 @@ Intuitively, $\toir$ conducts a case analysis to determine whether the ASL expre
   \toir(\tenv, \overname{\EBinop(\DIV, \veone, \vetwo)}{\ve}) \typearrow \vp
 }
 \end{mathpar}
+
 \begin{mathpar}
 \inferrule[ebinop\_div\_non\_monomial\_denominator]{
   \toir(\tenv, \veone) \typearrow \irone \OrTypeError, \CannotBeTransformed\\\\


### PR DESCRIPTION
* Defined missing function `polynomial_divide_by_term`
* Catch code that should be rejected by the parser with a safety-net exception.