### PR TITLE
[asl] successful main should always return 0

### DIFF
--- a/asllib/tests/regressions.t/noreturn.asl
+++ b/asllib/tests/regressions.t/noreturn.asl
@@ -35,5 +35,5 @@ end;
 
 func main() => integer
 begin
-    return 1;
+    return 0;
 end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -617,7 +617,6 @@ Outdated syntax
   end;
   ASL Warning: the recursive function rec_noreturning has no recursive limit
   annotation.
-  [1]
   $ aslref noreturn_function.asl
   File noreturn_function.asl, line 2, characters 26 to 28:
   noreturn func returning() => integer


### PR DESCRIPTION
Changed the value returned from `main` to be `0` as `1` indicates an error of which there is none here.