### PR TITLE
[herd test] Test diymicro output in ASL mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ diymicro-test:: diymicro-test-aarch64
 diymicro-test-aarch64:
 	$(eval DIYMICRO_EDGES = $(shell $(DIYMICROENUM) -list-iico | sed -n 's/^iico\[\([^ ]*\).*/iico[\1]/p'))
 	$(eval DIYMICRO_EDGES_ARG := $(foreach arg,$(DIYMICRO_EDGES),-diycross-arg $(arg)))
-	@ echo
+	@ echo $(DIYMICRO_EDGES_ARG)
 	$(HERD_DIYCROSS_REGRESSION_TEST) \
 		-herd-path $(HERD) \
 		-diycross-path $(DIYMICROENUM) \
@@ -372,6 +372,21 @@ diymicro-test-aarch64:
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64 diymicro7 tests: OK"
 
+test-all:: diymicro-test-aarch64-asl
+diymicro-test-aarch64-asl: asl-pseudocode
+	$(eval DIYMICRO_EDGES = $(shell $(DIYMICROENUM) -list-iico | sed -n 's/^iico\[\([^ ]*\).*/iico[\1]/p'))
+	$(eval DIYMICRO_EDGES_ARG := $(foreach arg,$(DIYMICRO_EDGES),-diycross-arg $(arg)))
+	@ echo
+	$(HERD_DIYCROSS_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-diycross-path $(DIYMICROENUM) \
+		-libdir-path ./herd/libdir \
+		-expected-dir ./herd/tests/diymicro/AArch64 \
+		-conf ./herd/tests/diymicro/AArch64/asl.cfg \
+		-j $(J) \
+		$(DIYMICRO_EDGES_ARG) \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64 diymicro7 tests: OK"
 
 test-bnfc:
 	@ echo

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:NO-MRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:NO-MRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:NO-MRs Allowed
 States 5
 0:X2=0; 0:X3=0; 1:X2=0;
 0:X2=0; 0:X3=0; 1:X2=1;
@@ -9,6 +9,6 @@ No
 Witnesses
 Positive: 0 Negative: 10
 Condition exists (0:X2=1 /\ 0:X3=1 /\ 1:X2=1)
-Observation LB+rel+CAS Never 0 10
+Observation LB+rel+CAS:NO-MRs Never 0 10
 Hash=060b2fd19df2675455bb9772620bdd17
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:NO-RnRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:NO-RnRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:NO-RnRs Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X4=0;
 0:X3=0; 1:X3=1; 1:X4=0;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=0)
-Observation LB+rel+CAS Never 0 6
+Observation LB+rel+CAS:NO-RnRs Never 0 6
 Hash=5b11ecb6268beb879fd5ebe5660ed705
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:NO-RsRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:NO-RsRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:NO-RsRs Allowed
 States 4
 0:X3=0; 1:X3=0; 1:X4=0;
 0:X3=0; 1:X3=1; 1:X4=0;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=0)
-Observation LB+rel+CAS Sometimes 2 6
+Observation LB+rel+CAS:NO-RsRs Sometimes 2 6
 Hash=c185cf3303642a5e99d8b828efc9951f
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:NO-RtRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:NO-RtRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:NO-RtRs Allowed
 States 4
 0:X3=0; 1:X3=0; 1:X4=0;
 0:X3=0; 1:X3=1; 1:X4=0;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=0)
-Observation LB+rel+CAS Sometimes 2 6
+Observation LB+rel+CAS:NO-RtRs Sometimes 2 6
 Hash=ffb2d7fdc09928e8e6c3b42c95b258b2
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-MM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-MM.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:OK-MM Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X4=0; 1:X5=0;
 0:X3=0; 1:X3=1; 1:X4=2; 1:X5=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=2 /\ 1:X5=1)
-Observation LB+rel+CAS Never 0 6
+Observation LB+rel+CAS:OK-MM Never 0 6
 Hash=ec97b7fd2eb62777d4c5f0999c986e6e
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-MRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-MRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:OK-MRs Allowed
 States 5
 0:X2=0; 0:X3=0; 1:X2=0;
 0:X2=0; 0:X3=0; 1:X2=1;
@@ -9,6 +9,6 @@ No
 Witnesses
 Positive: 0 Negative: 10
 Condition exists (0:X2=2 /\ 0:X3=1 /\ 1:X2=1)
-Observation LB+rel+CAS Never 0 10
+Observation LB+rel+CAS:OK-MRs Never 0 10
 Hash=66dbb69802e5392564503f39a6b4b4ba
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RnM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RnM.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:OK-RnM Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X4=1;
 0:X3=0; 1:X3=1; 1:X4=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=1)
-Observation LB+rel+CAS Never 0 6
+Observation LB+rel+CAS:OK-RnM Never 0 6
 Hash=e82c3b531f92a8ec6de9b7d0119ef10b
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RnRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RnRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:OK-RnRs Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X4=2;
 0:X3=0; 1:X3=1; 1:X4=2;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=2)
-Observation LB+rel+CAS Never 0 6
+Observation LB+rel+CAS:OK-RnRs Never 0 6
 Hash=7a22b0dc04e6060f8d3008f0ebb2700b
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RsM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RsM.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:OK-RsM Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X4=1;
 0:X3=0; 1:X3=1; 1:X4=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=1)
-Observation LB+rel+CAS Never 0 6
+Observation LB+rel+CAS:OK-RsM Never 0 6
 Hash=514a01e2e7164775d69fde9b7ca9b990
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RsRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RsRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:OK-RsRs Allowed
 States 4
 0:X3=0; 1:X3=0; 1:X4=2;
 0:X3=0; 1:X3=1; 1:X4=2;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=2)
-Observation LB+rel+CAS Sometimes 1 6
+Observation LB+rel+CAS:OK-RsRs Sometimes 1 6
 Hash=fd668c0d4b3fb7dce5999ae27847a440
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RtM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RtM.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:OK-RtM Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X4=0;
 0:X3=0; 1:X3=1; 1:X4=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=1)
-Observation LB+rel+CAS Never 0 6
+Observation LB+rel+CAS:OK-RtM Never 0 6
 Hash=e522e980130bd05a7b5af2f7cf1a1456
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RtRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CAS:OK-RtRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CAS Allowed
+Test LB+rel+CAS:OK-RtRs Allowed
 States 4
 0:X3=0; 1:X3=0; 1:X4=2;
 0:X3=0; 1:X3=1; 1:X4=2;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 6
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X4=2)
-Observation LB+rel+CAS Sometimes 2 6
+Observation LB+rel+CAS:OK-RtRs Sometimes 2 6
 Hash=f3c355958c463027f1b4fc6db76c67ea
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CSEL:NO-CmpRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CSEL:NO-CmpRd.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CSEL Allowed
+Test LB+rel+CSEL:NO-CmpRd Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X7=1;
 0:X3=0; 1:X3=1; 1:X7=2;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X7=2)
-Observation LB+rel+CSEL Never 0 3
+Observation LB+rel+CSEL:NO-CmpRd Never 0 3
 Hash=9c403264eccda1f87bb05d8d3a7593ce
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CSEL:NO-RmRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CSEL:NO-RmRd.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CSEL Allowed
+Test LB+rel+CSEL:NO-RmRd Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X8=2;
 0:X3=0; 1:X3=1; 1:X8=2;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X8=2)
-Observation LB+rel+CSEL Never 0 3
+Observation LB+rel+CSEL:NO-RmRd Never 0 3
 Hash=16b2cb156066aff826c45ceaa3b69e8e
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CSEL:NO-RnRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CSEL:NO-RnRd.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CSEL Allowed
+Test LB+rel+CSEL:NO-RnRd Allowed
 States 4
 0:X3=0; 1:X3=0; 1:X7=2;
 0:X3=0; 1:X3=1; 1:X7=2;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X7=2)
-Observation LB+rel+CSEL Sometimes 1 3
+Observation LB+rel+CSEL:NO-RnRd Sometimes 1 3
 Hash=b5e5c446b08fda706db9b92794b5e661
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CSEL:OK-CmpRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CSEL:OK-CmpRd.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CSEL Allowed
+Test LB+rel+CSEL:OK-CmpRd Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X7=2;
 0:X3=0; 1:X3=1; 1:X7=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X7=1)
-Observation LB+rel+CSEL Never 0 3
+Observation LB+rel+CSEL:OK-CmpRd Never 0 3
 Hash=1f3cfcc57ab69463ed95e2a39f48ef1d
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CSEL:OK-RmRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CSEL:OK-RmRd.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CSEL Allowed
+Test LB+rel+CSEL:OK-RmRd Allowed
 States 4
 0:X3=0; 1:X3=0; 1:X8=1;
 0:X3=0; 1:X3=1; 1:X8=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X8=1)
-Observation LB+rel+CSEL Sometimes 1 3
+Observation LB+rel+CSEL:OK-RmRd Sometimes 1 3
 Hash=61aacd74eedd197b48c61c9788840200
 

--- a/herd/tests/diymicro/AArch64/LB+rel+CSEL:OK-RnRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+CSEL:OK-RnRd.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+CSEL Allowed
+Test LB+rel+CSEL:OK-RnRd Allowed
 States 3
 0:X3=0; 1:X3=0; 1:X7=0;
 0:X3=0; 1:X3=1; 1:X7=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1 /\ 1:X7=1)
-Observation LB+rel+CSEL Never 0 3
+Observation LB+rel+CSEL:OK-RnRd Never 0 3
 Hash=57b5c5c1d0a1205508edf39aae580fcb
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-MM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-MM.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-MM Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-MM Never 0 3
 Hash=90450e2c6a2491db7f7900ae2f43500a
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-MRn.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-MRn.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-MRn Allowed
 States 2
 1:X2=0;
 1:X2=1;
@@ -6,6 +6,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (1:X2=1)
-Observation LB+rel+LDADD Sometimes 1 3
+Observation LB+rel+LDADD:ZR-MRn Sometimes 1 3
 Hash=dda20eb584f48e82c14ef9cb221e209a
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-MRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-MRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-MRs Allowed
 States 2
 1:X2=0;
 1:X2=1;
@@ -6,6 +6,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 2
 Condition exists (1:X2=1)
-Observation LB+rel+LDADD Sometimes 2 2
+Observation LB+rel+LDADD:ZR-MRs Sometimes 2 2
 Hash=38bf2008853b7b9617ac7349cac88689
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-MRt.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-MRt.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-MRt Allowed
 States 2
 1:X2=0;
 1:X2=1;
@@ -6,6 +6,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 2
 Condition exists (1:X2=1)
-Observation LB+rel+LDADD Sometimes 2 2
+Observation LB+rel+LDADD:ZR-MRt Sometimes 2 2
 Hash=1c29f414757a3c7606f7e7a1be6f8dbc
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RnM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RnM.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RnM Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-RnM Never 0 3
 Hash=2845940e9ae164492d57f12905578d8c
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RnRn.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RnRn.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RnRn Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-RnRn Never 0 3
 Hash=b7c8896f8a5d64b79fb44fa9faaa6353
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RnRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RnRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RnRs Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-RnRs Never 0 3
 Hash=0192daa53c16c1b58f85c23102293b50
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RnRt.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RnRt.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RnRt Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-RnRt Never 0 3
 Hash=2f015dc40c661303554206a6af6e24d2
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RsM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RsM.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RsM Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-RsM Never 0 3
 Hash=0d4af196de0541350d6a1a66649cb6c0
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RsRn.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RsRn.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RsRn Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-RsRn Never 0 3
 Hash=45ebe817c6b53fc4d197e81ce1a32ffd
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RsRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RsRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RsRs Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-RsRs Never 0 3
 Hash=792d167facd9259405103623e95901d1
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RsRt.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RsRt.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RsRt Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-RsRt Never 0 3
 Hash=6146a8e0fb16f307039fd029dcb9e688
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RtM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RtM.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RtM Allowed
 States 4
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Sometimes 1 3
+Observation LB+rel+LDADD:ZR-RtM Sometimes 1 3
 Hash=7f79cb94fb0510d163d0170f4344f8e4
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RtRn.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RtRn.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RtRn Allowed
 States 4
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Sometimes 1 3
+Observation LB+rel+LDADD:ZR-RtRn Sometimes 1 3
 Hash=9f2565e3fb8e2b37bb1ee8966b8f21ca
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RtRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RtRs.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RtRs Allowed
 States 4
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Sometimes 1 3
+Observation LB+rel+LDADD:ZR-RtRs Sometimes 1 3
 Hash=ed199560239f3d12ce71e2b5db10163d
 

--- a/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RtRt.litmus.expected
+++ b/herd/tests/diymicro/AArch64/LB+rel+LDADD:ZR-RtRt.litmus.expected
@@ -1,4 +1,4 @@
-Test LB+rel+LDADD Allowed
+Test LB+rel+LDADD:ZR-RtRt Allowed
 States 3
 0:X3=0; 1:X3=0;
 0:X3=0; 1:X3=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X3=1 /\ 1:X3=1)
-Observation LB+rel+LDADD Never 0 3
+Observation LB+rel+LDADD:ZR-RtRt Never 0 3
 Hash=600e438dd96308a87dc3c52746dc52aa
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:NO-MRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:NO-MRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:NO-MRs Allowed
 States 5
 0:X2=0; 0:X3=0; 0:X6=0;
 0:X2=0; 0:X3=0; 0:X6=1;
@@ -9,6 +9,6 @@ No
 Witnesses
 Positive: 0 Negative: 10
 Condition exists (0:X2=1 /\ 0:X3=1 /\ 0:X6=0)
-Observation MP+rel+CAS Never 0 10
+Observation MP+rel+CAS:NO-MRs Never 0 10
 Hash=5dec87bab280a6d8954f0d1e4424f00c
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:NO-RnRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:NO-RnRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:NO-RnRs Allowed
 States 3
 1:X3=0; 1:X4=0; 1:X11=0;
 1:X3=0; 1:X4=0; 1:X11=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=0 /\ 1:X11=0)
-Observation MP+rel+CAS Never 0 6
+Observation MP+rel+CAS:NO-RnRs Never 0 6
 Hash=c6fff52a5bc1b0e79f64a6d14842f5b8
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:NO-RsRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:NO-RsRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:NO-RsRs Allowed
 States 4
 1:X3=0; 1:X4=0; 1:X10=0;
 1:X3=0; 1:X4=0; 1:X10=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=0 /\ 1:X10=0)
-Observation MP+rel+CAS Sometimes 2 6
+Observation MP+rel+CAS:NO-RsRs Sometimes 2 6
 Hash=483225dbb8d4cbf92ffeab4ad7313f58
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:NO-RtRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:NO-RtRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:NO-RtRs Allowed
 States 4
 1:X3=0; 1:X4=0; 1:X8=0;
 1:X3=0; 1:X4=0; 1:X8=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=0 /\ 1:X8=0)
-Observation MP+rel+CAS Sometimes 2 6
+Observation MP+rel+CAS:NO-RtRs Sometimes 2 6
 Hash=34ba2448659f29fb191dabade6d371e8
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-MM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-MM.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:OK-MM Allowed
 States 4
 1:X3=0; 1:X4=0; 1:X5=0; 1:X9=0;
 1:X3=0; 1:X4=0; 1:X5=0; 1:X9=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=2 /\ 1:X5=1 /\ 1:X9=0)
-Observation MP+rel+CAS Sometimes 2 6
+Observation MP+rel+CAS:OK-MM Sometimes 2 6
 Hash=4a053384e7ac706b89f64f0f2c15351a
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-MRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-MRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:OK-MRs Allowed
 States 6
 0:X2=0; 0:X3=0; 0:X6=0;
 0:X2=0; 0:X3=0; 0:X6=1;
@@ -10,6 +10,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 10
 Condition exists (0:X2=2 /\ 0:X3=1 /\ 0:X6=0)
-Observation MP+rel+CAS Sometimes 1 10
+Observation MP+rel+CAS:OK-MRs Sometimes 1 10
 Hash=e7d6bc5a121f0e76544e29a2228c9614
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RnM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RnM.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:OK-RnM Allowed
 States 3
 1:X3=0; 1:X4=1; 1:X11=0;
 1:X3=0; 1:X4=1; 1:X11=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=1 /\ 1:X11=0)
-Observation MP+rel+CAS Never 0 6
+Observation MP+rel+CAS:OK-RnM Never 0 6
 Hash=624eb869fed8bea38d917cb748bc1909
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RnRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RnRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:OK-RnRs Allowed
 States 4
 1:X3=0; 1:X4=2; 1:X11=0;
 1:X3=0; 1:X4=2; 1:X11=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=2 /\ 1:X11=0)
-Observation MP+rel+CAS Sometimes 1 6
+Observation MP+rel+CAS:OK-RnRs Sometimes 1 6
 Hash=7cfc7286680d5ac9102dd9071140b2d8
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RsM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RsM.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:OK-RsM Allowed
 States 4
 1:X3=0; 1:X4=1; 1:X10=0;
 1:X3=0; 1:X4=1; 1:X10=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=1 /\ 1:X10=0)
-Observation MP+rel+CAS Sometimes 2 6
+Observation MP+rel+CAS:OK-RsM Sometimes 2 6
 Hash=c4cd1007ef03f4f187d5c698dcc77612
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RsRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RsRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:OK-RsRs Allowed
 States 4
 1:X3=0; 1:X4=2; 1:X10=0;
 1:X3=0; 1:X4=2; 1:X10=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=2 /\ 1:X10=0)
-Observation MP+rel+CAS Sometimes 1 6
+Observation MP+rel+CAS:OK-RsRs Sometimes 1 6
 Hash=5af0272ef156430b57e5e229c4c80460
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RtM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RtM.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:OK-RtM Allowed
 States 3
 1:X3=0; 1:X4=0; 1:X8=0;
 1:X3=0; 1:X4=0; 1:X8=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=1 /\ 1:X8=0)
-Observation MP+rel+CAS Never 0 6
+Observation MP+rel+CAS:OK-RtM Never 0 6
 Hash=418aa6b4b0a789419b316fe5b0627095
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RtRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CAS:OK-RtRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CAS Allowed
+Test MP+rel+CAS:OK-RtRs Allowed
 States 4
 1:X3=0; 1:X4=2; 1:X9=0;
 1:X3=0; 1:X4=2; 1:X9=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 6
 Condition exists (1:X3=1 /\ 1:X4=2 /\ 1:X9=0)
-Observation MP+rel+CAS Sometimes 2 6
+Observation MP+rel+CAS:OK-RtRs Sometimes 2 6
 Hash=d90d490605f3a4a64d1c5780139c3fa1
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CSEL:NO-CmpRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CSEL:NO-CmpRd.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CSEL Allowed
+Test MP+rel+CSEL:NO-CmpRd Allowed
 States 4
 1:X3=0; 1:X7=1; 1:X9=0;
 1:X3=0; 1:X7=1; 1:X9=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (1:X3=1 /\ 1:X7=2 /\ 1:X9=0)
-Observation MP+rel+CSEL Sometimes 1 3
+Observation MP+rel+CSEL:NO-CmpRd Sometimes 1 3
 Hash=4f5da0f97fc3760d0daeb166c91f7e12
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CSEL:NO-RmRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CSEL:NO-RmRd.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CSEL Allowed
+Test MP+rel+CSEL:NO-RmRd Allowed
 States 3
 1:X3=0; 1:X8=2; 1:X10=0;
 1:X3=0; 1:X8=2; 1:X10=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X8=2 /\ 1:X10=0)
-Observation MP+rel+CSEL Never 0 3
+Observation MP+rel+CSEL:NO-RmRd Never 0 3
 Hash=c72b2f9fc2ad66b63804e874a1bdb886
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CSEL:NO-RnRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CSEL:NO-RnRd.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CSEL Allowed
+Test MP+rel+CSEL:NO-RnRd Allowed
 States 4
 1:X3=0; 1:X7=2; 1:X9=0;
 1:X3=0; 1:X7=2; 1:X9=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (1:X3=1 /\ 1:X7=2 /\ 1:X9=0)
-Observation MP+rel+CSEL Sometimes 1 3
+Observation MP+rel+CSEL:NO-RnRd Sometimes 1 3
 Hash=91e9f6b139c2d9beb87305b5c55f3892
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CSEL:OK-CmpRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CSEL:OK-CmpRd.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CSEL Allowed
+Test MP+rel+CSEL:OK-CmpRd Allowed
 States 4
 1:X3=0; 1:X7=2; 1:X9=0;
 1:X3=0; 1:X7=2; 1:X9=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (1:X3=1 /\ 1:X7=1 /\ 1:X9=0)
-Observation MP+rel+CSEL Sometimes 1 3
+Observation MP+rel+CSEL:OK-CmpRd Sometimes 1 3
 Hash=f8006da897e6111f39faacd817c2460e
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CSEL:OK-RmRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CSEL:OK-RmRd.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CSEL Allowed
+Test MP+rel+CSEL:OK-RmRd Allowed
 States 4
 1:X3=0; 1:X8=1; 1:X10=0;
 1:X3=0; 1:X8=1; 1:X10=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (1:X3=1 /\ 1:X8=1 /\ 1:X10=0)
-Observation MP+rel+CSEL Sometimes 1 3
+Observation MP+rel+CSEL:OK-RmRd Sometimes 1 3
 Hash=806efd4e2726bc6dcf920d97c92ab49b
 

--- a/herd/tests/diymicro/AArch64/MP+rel+CSEL:OK-RnRd.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+CSEL:OK-RnRd.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+CSEL Allowed
+Test MP+rel+CSEL:OK-RnRd Allowed
 States 3
 1:X3=0; 1:X7=0; 1:X9=0;
 1:X3=0; 1:X7=0; 1:X9=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X7=1 /\ 1:X9=0)
-Observation MP+rel+CSEL Never 0 3
+Observation MP+rel+CSEL:OK-RnRd Never 0 3
 Hash=026a23fec19c8d4307f6147f779dde77
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-MM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-MM.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-MM Allowed
 States 3
 1:X3=0; 1:X7=0;
 1:X3=0; 1:X7=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X7=0)
-Observation MP+rel+LDADD Never 0 3
+Observation MP+rel+LDADD:ZR-MM Never 0 3
 Hash=b5e04623e9961d5bc3f013d24f741662
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-MRn.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-MRn.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-MRn Allowed
 States 2
 0:X5=0;
 0:X5=1;
@@ -6,6 +6,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X5=0)
-Observation MP+rel+LDADD Sometimes 1 3
+Observation MP+rel+LDADD:ZR-MRn Sometimes 1 3
 Hash=abbeaa8f196d812dd8fcdb26601b19a1
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-MRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-MRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-MRs Allowed
 States 2
 0:X4=0;
 0:X4=1;
@@ -6,6 +6,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 2
 Condition exists (0:X4=0)
-Observation MP+rel+LDADD Sometimes 2 2
+Observation MP+rel+LDADD:ZR-MRs Sometimes 2 2
 Hash=6209147b7e8b1ece54c65f0227e1427a
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-MRt.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-MRt.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-MRt Allowed
 States 2
 0:X5=0;
 0:X5=1;
@@ -6,6 +6,6 @@ Ok
 Witnesses
 Positive: 2 Negative: 2
 Condition exists (0:X5=0)
-Observation MP+rel+LDADD Sometimes 2 2
+Observation MP+rel+LDADD:ZR-MRt Sometimes 2 2
 Hash=d62316204b6c376836cdbbe9672864f9
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RnM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RnM.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RnM Allowed
 States 3
 1:X3=0; 1:X8=0;
 1:X3=0; 1:X8=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X8=0)
-Observation MP+rel+LDADD Never 0 3
+Observation MP+rel+LDADD:ZR-RnM Never 0 3
 Hash=13e8ffc870cc22eeca35d051cb9a4776
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RnRn.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RnRn.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RnRn Allowed
 States 3
 1:X3=0; 1:X9=0;
 1:X3=0; 1:X9=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X9=0)
-Observation MP+rel+LDADD Never 0 3
+Observation MP+rel+LDADD:ZR-RnRn Never 0 3
 Hash=c90a884446f2390fe81636e4b380a4d5
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RnRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RnRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RnRs Allowed
 States 4
 1:X3=0; 1:X8=0;
 1:X3=0; 1:X8=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (1:X3=1 /\ 1:X8=0)
-Observation MP+rel+LDADD Sometimes 1 3
+Observation MP+rel+LDADD:ZR-RnRs Sometimes 1 3
 Hash=8077cfc1d0bb152fc5a0c5586810d497
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RnRt.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RnRt.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RnRt Allowed
 States 3
 1:X3=0; 1:X9=0;
 1:X3=0; 1:X9=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X9=0)
-Observation MP+rel+LDADD Never 0 3
+Observation MP+rel+LDADD:ZR-RnRt Never 0 3
 Hash=61811091f55c2ee36c4a1401e059c8e0
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RsM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RsM.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RsM Allowed
 States 3
 1:X3=0; 1:X6=0;
 1:X3=0; 1:X6=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X6=0)
-Observation MP+rel+LDADD Never 0 3
+Observation MP+rel+LDADD:ZR-RsM Never 0 3
 Hash=95e0096e053e446ff4b9cad1b2a6288b
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RsRn.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RsRn.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RsRn Allowed
 States 3
 1:X3=0; 1:X7=0;
 1:X3=0; 1:X7=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X7=0)
-Observation MP+rel+LDADD Never 0 3
+Observation MP+rel+LDADD:ZR-RsRn Never 0 3
 Hash=bd2a9d2fb7d62a2d4684966fc74705b2
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RsRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RsRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RsRs Allowed
 States 3
 1:X3=0; 1:X6=0;
 1:X3=0; 1:X6=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X6=0)
-Observation MP+rel+LDADD Never 0 3
+Observation MP+rel+LDADD:ZR-RsRs Never 0 3
 Hash=5d5d3345e1c77c9073426c080e1c2d54
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RsRt.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RsRt.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RsRt Allowed
 States 3
 1:X3=0; 1:X7=0;
 1:X3=0; 1:X7=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X7=0)
-Observation MP+rel+LDADD Never 0 3
+Observation MP+rel+LDADD:ZR-RsRt Never 0 3
 Hash=7a12219cd93b96b7e5a962a09bd1bff4
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RtM.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RtM.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RtM Allowed
 States 4
 1:X3=0; 1:X7=0;
 1:X3=0; 1:X7=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (1:X3=1 /\ 1:X7=0)
-Observation MP+rel+LDADD Sometimes 1 3
+Observation MP+rel+LDADD:ZR-RtM Sometimes 1 3
 Hash=c7708eeb17678b5710be98f9f89c6038
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RtRn.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RtRn.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RtRn Allowed
 States 4
 1:X3=0; 1:X8=0;
 1:X3=0; 1:X8=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (1:X3=1 /\ 1:X8=0)
-Observation MP+rel+LDADD Sometimes 1 3
+Observation MP+rel+LDADD:ZR-RtRn Sometimes 1 3
 Hash=ab79b50ef1fa5c0e1412ec796a934ff5
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RtRs.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RtRs.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RtRs Allowed
 States 4
 1:X3=0; 1:X7=0;
 1:X3=0; 1:X7=1;
@@ -8,6 +8,6 @@ Ok
 Witnesses
 Positive: 1 Negative: 3
 Condition exists (1:X3=1 /\ 1:X7=0)
-Observation MP+rel+LDADD Sometimes 1 3
+Observation MP+rel+LDADD:ZR-RtRs Sometimes 1 3
 Hash=aac674d75b89a20b84fbd5a72e82a96b
 

--- a/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RtRt.litmus.expected
+++ b/herd/tests/diymicro/AArch64/MP+rel+LDADD:ZR-RtRt.litmus.expected
@@ -1,4 +1,4 @@
-Test MP+rel+LDADD Allowed
+Test MP+rel+LDADD:ZR-RtRt Allowed
 States 3
 1:X3=0; 1:X8=0;
 1:X3=0; 1:X8=1;
@@ -7,6 +7,6 @@ No
 Witnesses
 Positive: 0 Negative: 3
 Condition exists (1:X3=1 /\ 1:X8=0)
-Observation MP+rel+LDADD Never 0 3
+Observation MP+rel+LDADD:ZR-RtRt Never 0 3
 Hash=4efbf9bcaf4814cf639f183a5b1a6200
 

--- a/herd/tests/diymicro/AArch64/asl.cfg
+++ b/herd/tests/diymicro/AArch64/asl.cfg
@@ -1,0 +1,5 @@
+variant asl
+timeout 30
+#Output differs from non-asl mode for the two following tests.
+#ASL -> 1 positive execution vs. STD -> 2 positive executions.
+nonames LB+rel+LDADD:ZR-MRt,MP+rel+LDADD:ZR-MRt

--- a/lib/splitter.mll
+++ b/lib/splitter.mll
@@ -58,7 +58,7 @@ let blank = [' ' '\t' '\r']
 let bool = "true" | "false"
 let name  = alpha (alpha|digit|'_' | '/' | '.' | '-')*
  (* yes some test names are such *)
-let testname  = (alpha|digit|'_' | '/' | '.' | '-' | '+'|'['|']')+
+let testname  = (alpha|digit|'_' | '/' | '.' | '-' | '+'|'['|']'|':')+
 let num = digit+
 
 


### PR DESCRIPTION
Running the new diymicro generated tests in ASL mode is now part of the complete test suite (`make test-all`).  Those tests exercise fine points of intra-instruction dependencies. 

So as to integrate the new tests, we add ':' as an acceptable character in test names, as **diymicro7** generates such names.

We have identified  differing number of execution in the case of two tests, As a consequence, those tests are currently not run during the ASL testing. One of those tests is:
```
AArch64 MP+rel+LDADD:ZR-MRt
Generator=diymicroenum7 (version 7.58+1)
Orig='iico[ldadd:zr M->Rt]' DpAddrdrR Fre PodWW:L Rfe
{
  0: X0 = x;    0: X1 = y;
  1: X0 = x;    1: X1 = y;
}

 P0                  | P1           ;
 MOV W2,#0           | MOV W2,#1    ;
 STADD W2,[X0]       | STR W2,[X1]  ;
 DMB LD              | MOV W3,#1    ;
 EOR W4,W3,W3        | STLR W3,[X0] ;
 LDR W5,[X1,W4,SXTW] |              ;
exists (0: X5=0)
```

For instance, in standard mode we have four executions:
```
% herd7  /tmp/tmp.VG3ZNvRNkO/MP+rel+LDADD:ZR-MRt.litmus
Test MP+rel+LDADD Allowed
States 2
0:X5=0;
0:X5=1;
Ok
Witnesses
Positive: 2 Negative: 2
Condition exists (0:X5=0)
Observation MP+rel+LDADD Sometimes 2 2
Time MP+rel+LDADD 0.04
Hash=d62316204b6c376836cdbbe9672864f9
```
While in ASL mode we have three executions:
```
% herd7 -variant asl  /tmp/tmp.VG3ZNvRNkO/MP+rel+LDADD:ZR-MRt.litmus
Test MP+rel+LDADD:ZR-MRt Allowed
States 2
0:X5=0;
0:X5=1;
Ok
Witnesses
Positive: 1 Negative: 2
Condition exists (0:X5=0)
Observation MP+rel+LDADD:ZR-MRt Sometimes 1 2
Time MP+rel+LDADD:ZR-MRt 16.48
Hash=d62316204b6c376836cdbbe9672864f9
```
