### PR TITLE
[asl][reference] Defined semantics for diverging specifications

### DIFF
--- a/asllib/doc/ASL.bib
+++ b/asllib/doc/ASL.bib
@@ -115,3 +115,18 @@ address = {USA}
   publisher    = {INRIA},
   version      = {20240715},
 }
+
+@article{LeroyG:IC09,
+  author       = {Xavier Leroy and Herv{\'{e}} Grall},
+  title        = {Coinductive big-step operational semantics},
+  journal      = {Inf. Comput.},
+  volume       = {207},
+  number       = {2},
+  pages        = {284--304},
+  year         = {2009},
+  url          = {https://doi.org/10.1016/j.ic.2007.12.004},
+  doi          = {10.1016/J.IC.2007.12.004},
+  timestamp    = {Fri, 12 Feb 2021 22:15:37 +0100},
+  biburl       = {https://dblp.org/rec/journals/iandc/LeroyG09.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -75,7 +75,7 @@ Finally, $\neg\True\triangleq\False$ and $\neg\False\triangleq\True$.
 We utilize the notation $\overname{a}{b}$ to enable us to name the mathematical term $a$ as $b$ so that
 we can refer to it in text. We especially use this to name the input arguments and
 output results of functions and relations. For example, the input argument of $\sign$,
-which is defined next is named $q$.
+defined next, is named $q$.
 
 \hypertarget{def-sign}{}
 \begin{definition}[Sign of a Rational Number]
@@ -100,10 +100,10 @@ which is defined next is named $q$.
 
 \hypertarget{def-pow}{}
 \begin{definition}[Powerset]
-  The \emph{powerset} of a set $A$, denoted as $\pow{A}$, is the set of all subsets of $A$, including the empty set and $A$ itself:
-  \[
-     \pow{A} \triangleq \{ B \;|\; B \subseteq A\} \enspace.
-  \]
+The \emph{powerset} of a set $A$, denoted as $\pow{A}$, is the set of all subsets of $A$, including the empty set and $A$ itself:
+\[
+    \pow{A} \triangleq \{ B \;|\; B \subseteq A\} \enspace.
+\]
 \end{definition}
 
 \hypertarget{def-powfin}{}
@@ -187,18 +187,18 @@ This makes convenient to refer to arguments by referring to the corresponding na
 the expressions corresponding to the arguments.
 For example,
 \[
-    \textsf{choice} : \overname{\Bool}{b} \cartimes \overname{T}{x} \cartimes \overname{T}{y} \rightarrow \overname{T}{z}
+    \choicename : \overname{\Bool}{b} \cartimes \overname{T}{x} \cartimes \overname{T}{y} \rightarrow \overname{T}{z}
 \]
 defines a function type and lets us refer to the first argument as $b$, the second argument as $x$,
 the third argument as $y$, and to the result as $z$.
 
 A \emph{parametric function} is a function whose domain is not a priori fixed but rather
-parameterized by the type of its arguments. An example is the $\textsf{choice}$ function where the type $T$ of
+parameterized by the type of its arguments. An example is the $\choicename$ function where the type $T$ of
 $x$, $y$, and $z$ is unspecified and inferred from the context where the function is used.
 
 \hypertarget{def-choice}{}
 \begin{definition}[Choice]
-The parametric function $\textsf{choice} : \overname{\Bool}{b} \cartimes \overname{T}{x} \cartimes \overname{T}{y} \rightarrow \overname{T}{z}$,
+The parametric function $\choicename : \overname{\Bool}{b} \cartimes \overname{T}{x} \cartimes \overname{T}{y} \rightarrow \overname{T}{z}$,
 is defined as follows:
 \[
   \choice{\vb}{x}{y} \triangleq
@@ -422,14 +422,14 @@ type $T$}, or shortly as an \emph{\optional}.
 \section{Inference Rules}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \hypertarget{def-inferencerule}{}
-An \emph{\inferencerule} (rule, for short) is an implication between a set of logical assertions,
+An \emph{\inferencerule} (rule, for short) is an implication between a list of judgments,
 called the \emph{premises} of the rule,
-and a \emph{conclusion} assertion.
-The conclusion holds when the \underline{conjunction} of its premises holds.
+and a \emph{conclusion} judgment.
+The conclusion holds when the \underline{conjunction} of the rule premises holds.
 
 We use the following rule notation, where $P_{1..k}$ are the rule premises and $C$ is the conclusion:
 \begin{mathpar}
-  \inferrule{P_1 \and \ldots \and P_k}{C}
+\inferrule{P_1 \and \ldots \and P_k}{C}
 \end{mathpar}
 
 For example, the rule \TypingRuleRef{ELit} has one premise:
@@ -461,8 +461,8 @@ $\veone$, $\vetwo$, $\veone'$, $\vetwo'$ (expressions),
 $\vt$, $\vtone$, and $\vttwo$ (types).
 
 \begin{definition}[Grounding]
-Assertions can be \emph{grounded} by substituting their free variables with values.
-A \emph{ground rule} is a rule with all its assertions (premises and conclusion) grounded.
+Judgments can be \emph{grounded} by substituting their free variables with values.
+A \emph{ground rule} is a rule with all its judgments (premises and conclusion) grounded.
 \end{definition}
 For example,
 the following is a grounding of \TypingRuleRef{EBinop}
@@ -503,34 +503,37 @@ An example of an axiom in the ASL type system is \TypingRuleRef{SPass}:
 \inferrule{}{\annotatestmt(\tenv, \SPass) \typearrow (\SPass,\tenv)}
 \end{mathpar}
 \hypertarget{SemanticsRule.PAll-example}{}
-An example of an axiom in the ASL semantics is \SemanticsRuleRef{PAll}:
+An example of an axiom in the ASL dynamic semantics is \SemanticsRuleRef{PAll}:
 \begin{mathpar}
 \inferrule{}{
-  \evalpattern{\env, \Ignore, \PatternAll} \evalarrow \Normal(\nvbool(\True), \emptygraph)
+  \evalpattern{\env, \Ignore, \PatternAll} \evalarrow \ResultPattern(\nvbool(\True), \emptygraph)
 }
 \end{mathpar}
 
-To show that a specification is correct, with respect to the set of type rules,
+To show that a specification is correct, with respect to the set of type system rules,
 or to show that a specification evaluates to a certain value, with respect to
-the set of semantic rules, we must apply rules to form a \emph{derivation tree}.
+the set of dynamic semantic rules, we must apply those rules to form a \emph{\derivationtreeterm}.
 
 \hypertarget{def-derivationtree}{}
 \begin{definition}[Derivation Tree]
-  A \emph{derivation tree} is a tree whose vertices correspond to ground assertions.
-  More specifically, the leaves of a derivation tree correspond to ground axioms,
-  and an internal vertex corresponds to a ground conclusion of a rule with its children
-  corresponding to the ground premises of the same rule.
+A \emph{\derivationtreeterm} is a tree whose vertices correspond to ground judgments.
+Each non-leaf vertex $c$ with children $p_{1..k}$ correspond to a ground rule
+$\inferrule{c_{1..k}}{c}$ and each leaf vertex $c$ corresponds to a ground axiom rule
+$c$. There is one root vertex, which intuitively is the goal of the derivation tree.
+Derivation trees can be finite or infinite.
+Infinite derivation tree are used for defining diverging evaluations
+(see \secref{Semantics of Diverging Specifications}).
 \end{definition}
 
 \subsection{Transitions\label{sec:transitions}}
 
 We use rules as a structured way for defining relations (and therefore functions, as a special case).
 
-To define a relation $R \subseteq X \cartimes Y$, we use assertions of the form $\termx \rulearrow \termy$
+To define a relation $R \subseteq X \cartimes Y$, we use judgments of the form $\termx \rulearrow \termy$
 where $\termx$ and $\termy$ are logical terms denoting sets of elements from $X$ and $Y$, respectively.
 %
-We call such assertions \emph{transitions}.
-A set of rules $M$ with transition assertions defines the relation
+We call such judgments \emph{transitions}.
+A set of rules $M$ with transition judgments defines the relation
 \[
     R = \{ (x,y) \;|\; x \rulearrow y \text{ can be derived from rules in } M\} \enspace.
 \]
@@ -543,10 +546,9 @@ $\vv$) to the infinite set of pairs of the form $(\vt,
 \ELiteral(\vv))$, such that the premise holds.
 
 \paragraph{Mutual Exclusion Principle:}
-Our rules follow (with very few deviations, which we point out
-in context) a mutual exclusion principle, where each rule
+Our rules follow a mutual exclusion principle, where each rule
 defines a relation disjoint from the ones defined by the other
-rules.  This makes it easy to determine the rule responsible
+rules. This makes it easy to determine the rule responsible
 for a given transition.
 
 \hypertarget{def-configuration}{}
@@ -599,14 +601,14 @@ This section explains the equality notations used in rules, two of which are use
 shown here:
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \econd} \evalarrow \Normal(\mcond, \envone) \OrAbnormal\\\\
+  \evalexpr{\env, \econd} \evalarrow \ResultExpr(\mcond, \envone) \OrAbnormal\\\\
   \mcond \eqname (\nvbool(\vb), \vgone)\\
   \vep \eqdef \choice{\vb}{\veone}{\vetwo}\\\\
-  \evalexpr{\envone, \vep} \evalarrow \Normal((\vv, \vgtwo), \newenv)  \OrAbnormal\\\\
+  \evalexpr{\envone, \vep} \evalarrow \ResultExpr((\vv, \vgtwo), \newenv)  \OrAbnormal\\\\
   \vg \eqdef \ordered{\vgone}{\aslctrl}{\vgtwo}
 }{
   \evalexpr{\env, \overname{\ECond(\econd, \veone, \vetwo)}{\ve}} \evalarrow
-  \Normal((\vv, \vg), \newenv)
+  \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 
@@ -646,20 +648,20 @@ shown here:
   Given that a variable $v$ represents a list, we write $v \eqname v_{1..k}$ to list its elements and allow
   referring to them by index.
 
-  \hypertarget{def-eqdef}{}
-  \item[Definition / ``Define as'':] the notation $\vx \eqdef \ve$ denotes that $\vx$ is a new name serving as an alias for the expression $\ve$.
-  For example, in the rule \SemanticsRuleRef{ECond}, we use $\vg$ to name the mathematical expression
-  $\ordered{\vgone}{\aslctrl}{\vgtwo}$.
-  Aliases allow us to break down complex expressions, but rules can always be rewritten without them,
-  by inlining their right-hand sides:
+\hypertarget{def-eqdef}{}
+\item[Definition / ``Define as'':] the notation $\vx \eqdef \ve$ denotes that $\vx$ is a new name serving as an alias for the expression $\ve$.
+For example, in the rule \SemanticsRuleRef{ECond}, we use $\vg$ to name the mathematical expression
+$\ordered{\vgone}{\aslctrl}{\vgtwo}$.
+Aliases allow us to break down complex expressions, but rules can always be rewritten without them,
+by inlining their right-hand sides:
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \econd} \evalarrow \Normal(\mcond, \envone) \OrAbnormal\\\\
+  \evalexpr{\env, \econd} \evalarrow \ResultExpr(\mcond, \envone) \OrAbnormal\\\\
   \mcond \eqname (\nvbool(\vb), \vgone)\\
-  \evalexpr{\envone, \choice{\vb}{\veone}{\vetwo}} \evalarrow \Normal((\vv, \vgtwo), \newenv) \OrAbnormal
+  \evalexpr{\envone, \choice{\vb}{\veone}{\vetwo}} \evalarrow \ResultExpr((\vv, \vgtwo), \newenv) \OrAbnormal
 }{
   \evalexpr{\env, \overname{\ECond(\econd, \veone, \vetwo)}{\ve}} \evalarrow
-  \Normal((\vv, \ordered{\vgone}{\aslctrl}{\vgtwo}), \newenv)
+  \ResultExpr((\vv, \ordered{\vgone}{\aslctrl}{\vgtwo}), \newenv)
 }
 \end{mathpar}
 \end{description}
@@ -671,7 +673,7 @@ we sometimes only care about a subset of the fields $\{f_{i_1},\ldots,f_{i_m}\} 
 In such cases, we write $\{f_{i_1}:t_{i_1},\ldots,f_{i_m}:t_{i_m},\ldots\}$,
 where $\ldots$ stands for fields that are irrelevant for the rule.
 
-For example, the \func\ non-terminal is
+For example, the \func{} non-terminal is
 of a record type and has the following fields:
 $\funcname$, $\funcparameters$, $\funcargs$, $\funcbody$, $\funcreturntype$, $\funcsubprogramtype$,
 $\funcrecurselimit$, and $\funcbuiltin$.
@@ -686,25 +688,24 @@ For example, $\astlabel(\TBool) = \TBool$ and $\astlabel(\TNamed(\vx)) = \TNamed
 \subsection{How to Parse Rules Efficiently}
 Consider the following examples, which is a simplified version of \SemanticsRuleRef{Binop}
 \begin{mathpar}
-  \inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
-    \evalexpr{ \env, \veone} \evalarrow \Normal(\vmone, \envone) \\\\
-    \evalexpr{ \envone, \vetwo } \evalarrow \Normal(\vmtwo, \newenv) \\\\
-    \vmone \eqname (\vvone, \vgone) \\
-    \vmtwo \eqname (\vvtwo, \vgtwo) \\
-    \binoprel(\op, \vvone, \vvtwo) \evalarrow \vv \\\\
-    \vg \eqdef \vgone \parallelcomp \vgtwo
-  }
-  {
-    \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
-    \Normal((\vv, \vg), \newenv)
-  }
+\inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
+  \evalexpr{ \env, \veone} \evalarrow \ResultExpr(\vmone, \envone) \\\\
+  \evalexpr{ \envone, \vetwo } \evalarrow \ResultExpr(\vmtwo, \newenv) \\\\
+  \vmone \eqname (\vvone, \vgone) \\
+  \vmtwo \eqname (\vvtwo, \vgtwo) \\
+  \binoprel(\op, \vvone, \vvtwo) \evalarrow \vv \\\\
+  \vg \eqdef \vgone \parallelcomp \vgtwo
+}{
+  \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
+  \ResultExpr((\vv, \vg), \newenv)
+}
 \end{mathpar}
 
 To parse a rule, start by examining the conclusion and the variables appearing in the rule.
 In this case, the rule describes a transition from an input configuration \\
 $\evalexpr{ \env, \EBinop(\op, \veone, \vetwo) }$,
-whose configuration domain is \texttt{eval\_expr}, to an output configuration $\Normal((\vv, \vg), \newenv)$
-whose configuration domain is $\Normal$.
+whose configuration domain is \texttt{eval\_expr}, to an output configuration $\ResultExpr((\vv, \vg), \newenv)$
+whose configuration domain is $\ResultExpr$.
 %
 A rule uses the free variables appearing in the input configuration of the conclusion
 ($\env$, $\op$, $\veone$, and $\vetwo$ in our example),
@@ -714,21 +715,21 @@ of the conclusion ($\vv$, $\vg$, and $\newenv$, in our example).
 Now, scan the premises in order to see where $\env$, $\op$, $\veone$, and $\vetwo$ are used and how
 premises assign values to $\vv$, $\vg$, and $\newenv$.
 %
-In this case, $\vv$ is assigned as the result of the transition assertion
+In this case, $\vv$ is assigned as the result of the transition judgment
 $\binoprel(\op, \vvone, \vvtwo) \evalarrow \vv$,
 $\vg$ is assigned the expression $\vgone \parallelcomp \vgtwo$,
-and $\newenv$ is assigned as the result of the transition assertion
-$\evalexpr{ \envone, \vetwo } \evalarrow \Normal(\vmtwo, \newenv)$.
+and $\newenv$ is assigned as the result of the transition judgment
+$\evalexpr{ \envone, \vetwo } \evalarrow \ResultExpr(\vmtwo, \newenv)$.
 %
 Notice that to assign values to the variables $\vv$, $\vg$, and $\newenv$,
 intermediate values have to be assigned first.
-For example, $\evalexpr{ \env, \veone} \evalarrow \Normal(\vmone, \envone)$
+For example, $\evalexpr{ \env, \veone} \evalarrow \ResultExpr(\vmone, \envone)$
 assigned values to $\envone$, which is then used by the transition \\
-$\evalexpr{ \envone, \vetwo } \evalarrow \Normal(\vmtwo, \newenv)$.
+$\evalexpr{ \envone, \vetwo } \evalarrow \ResultExpr(\vmtwo, \newenv)$.
 Similarly, $\vg$ requires first assigning values to $\vgone$ and $\vgtwo$,
 which are components of the previously assigned variables $\vmone$ and $\vmtwo$.
 
-\subsection{Short-Circuit Rule Macros\label{sec:ShortCircuitRuleMacros}}
+\subsection{Short-circuit Rule Macros\label{sec:ShortCircuitRuleMacros}}
 
 \emph{Short-circuit rule macros}, or \emph{rule macros}, for short, allow us to succinctly define sets of rules.
 Specifically, they allow us to capture situations where
@@ -776,7 +777,7 @@ Intuitively, if $C$ transitions to $C'$ then $\sslash E$ can be ignored
 and the rule is interpreted as usual (Option 1).
 However, if $C$ transitions into $E$ (Option 2) then the premises $\XQ$ are ignored,
 thereby short-circuiting the rule, and the input configuration
-in the conclusion also transitions into $E$.
+in the conclusion transitions into $E$.
 
 We allow more than one premise to include short-circuiting alternatives and also
 a single premise to include several alternatives.
@@ -827,115 +828,131 @@ In English prose, we use
 As an example, consider the rule \SemanticsRuleRef{Binop}.
 This time, not simplified:
 \begin{mathpar}
-  \inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
-    \evalexpr{ \env, \veone} \evalarrow \Normal(\vmone, \envone) \OrAbnormal \\\\
-    \evalexpr{ \envone, \vetwo } \evalarrow \Normal(\vmtwo, \newenv) \OrAbnormal \\\\
-    \vmone \eqname (\vvone, \vgone) \\
-    \vmtwo \eqname (\vvtwo, \vgtwo) \\
-    \binoprel(\op, \vvone, \vvtwo) \evalarrow \vv \terminateas \DynErrorConfig\\\\
-    \vg \eqdef \vgone \parallelcomp \vgtwo
-  }
-  {
-    \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
-    \Normal((\vv, \vg), \newenv)
-  }
+\inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
+  \evalexpr{ \env, \veone} \evalarrow \ResultExpr(\vmone, \envone) \OrAbnormal \\\\
+  \evalexpr{ \envone, \vetwo } \evalarrow \ResultExpr(\vmtwo, \newenv) \OrAbnormal \\\\
+  \vmone \eqname (\vvone, \vgone) \\
+  \vmtwo \eqname (\vvtwo, \vgtwo) \\
+  \binoprel(\op, \vvone, \vvtwo) \evalarrow \vv \terminateas \DynErrorConfig\\\\
+  \vg \eqdef \vgone \parallelcomp \vgtwo
+}{
+  \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
+  \ResultExpr((\vv, \vg), \newenv)
+}
 \end{mathpar}
 
 In this rule, $\ThrowingConfig$ and $\DynErrorConfig$ are just shorthand notations for
 actual configurations, which are properly defined in \chapref{Semantics}.
-Intuitively, the alternative configurations $\ThrowingConfig$ and $\DynErrorConfig$
-represent situations where a transition may result in a raised exception and a dynamic error,
-respectively.
+Intuitively, the alternative configurations $\ThrowingConfig$, $\DynErrorConfig$,
+and $\DivergingConfig$
+represent situations where a transition may result in a raised exception,
+a \dynamicerrorterm, and a diverging evaluation, respectively.
 
 One may first read the rule ignoring these alternative configurations, to see how the
 goal of transitioning into the output configuration appearing in the conclusion ---
-$\Normal((\vv, \vg), \newenv)$ --- is achieved.
-Then, re-reading the rule would indicate where exceptions and dynamic errors may result
-in other output configurations.
+$\ResultExpr((\vv, \vg), \newenv)$ --- is achieved.
+Then, re-reading the rule would indicate where exceptions, \dynamicerrorsterm,
+and diverging evaluation may result in other output configurations.
 %
-For example, if the first transition assertion results in a throwing configuration $\ThrowingConfig$
+For example, if the first transition judgment results in a throwing configuration $\ThrowingConfig$
 then the output configuration of the conclusion is also $\ThrowingConfig$.
 This corresponds to the following rule in the expanded macro:
 
 \begin{mathpar}
-  \inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
-    \evalexpr{ \env, \veone} \evalarrow \ThrowingConfig
-  }
-  {
-    \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
-    \ThrowingConfig
-  }
+\inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
+  \evalexpr{ \env, \veone} \evalarrow \ThrowingConfig
+}{
+  \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
+  \ThrowingConfig
+}
 \end{mathpar}
 
-Similarly, if the first transition assertion results in a dynamic error, the output configuration of
-the conclusion is that dynamic error, which corresponds to the following rule in the expansion:
+Similarly, if the first transition judgment results in a \dynamicerrorterm, the output configuration of
+the conclusion is \dynamicerrorterm, which corresponds to the following rule in the expansion:
 \begin{mathpar}
-  \inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
-    \evalexpr{ \env, \veone} \evalarrow \DynErrorConfig
-  }
-  {
-    \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
-    \DynErrorConfig
-  }
+\inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
+  \evalexpr{ \env, \veone} \evalarrow \DynErrorConfig
+}{
+  \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
+  \DynErrorConfig
+}
+\end{mathpar}
+
+Finally, if the first transition judgment results in a diverging configuration, the output configuration of
+the conclusion is also a diverging configuration, which corresponds to the following rule in the expansion:
+\begin{mathpar}
+\inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
+  \evalexpr{ \env, \veone} \evalarrow \DivergingConfig
+}{
+  \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
+  \DivergingConfig
+}
 \end{mathpar}
 
 The following rules correspond to the cases where the first transition results in \\
-$\Normal(\vmone, \envone)$, but the second transition assertion results in either
-$\ThrowingConfig$ or $\DynErrorConfig$, respectively:
+$\ResultExpr(\vmone, \envone)$, but the second transition judgment results in either
+$\ThrowingConfig$, $\DynErrorConfig$, or $\DivergingConfig$, respectively:
 \begin{mathpar}
-  \inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
-    \evalexpr{ \env, \veone} \evalarrow \Normal(\vmone, \envone) \\\\
-    \evalexpr{ \envone, \vetwo } \evalarrow \ThrowingConfig
-  }
-  {
-    \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
-    \ThrowingConfig
-  }
+\inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
+  \evalexpr{ \env, \veone} \evalarrow \ResultExpr(\vmone, \envone) \\\\
+  \evalexpr{ \envone, \vetwo } \evalarrow \ThrowingConfig
+}{
+  \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
+  \ThrowingConfig
+}
 \end{mathpar}
 
 \begin{mathpar}
-  \inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
-    \evalexpr{ \env, \veone} \evalarrow \Normal(\vmone, \envone) \\\\
-    \evalexpr{ \envone, \vetwo } \evalarrow \DynErrorConfig
-  }
-  {
-    \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
-    \DynErrorConfig
-  }
+\inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
+  \evalexpr{ \env, \veone} \evalarrow \ResultExpr(\vmone, \envone) \\\\
+  \evalexpr{ \envone, \vetwo } \evalarrow \DynErrorConfig
+}{
+  \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
+  \DynErrorConfig
+}
 \end{mathpar}
 
-Expanding the last transition assertion, gives us the case:
 \begin{mathpar}
-  \inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
-    \evalexpr{ \env, \veone} \evalarrow \Normal(\vmone, \envone) \\\\
-    \evalexpr{ \envone, \vetwo } \evalarrow \Normal(\vmtwo, \newenv) \\\\
-    \vmone \eqname (\vvone, \vgone) \\
-    \vmtwo \eqname (\vvtwo, \vgtwo) \\
-    \binoprel(\op, \vvone, \vvtwo) \evalarrow \DynErrorConfig
-  }
-  {
-    \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
-    \DynErrorConfig
-  }
+\inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
+  \evalexpr{ \env, \veone} \evalarrow \ResultExpr(\vmone, \envone) \\\\
+  \evalexpr{ \envone, \vetwo } \evalarrow \DivergingConfig
+}{
+  \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
+  \DivergingConfig
+}
+\end{mathpar}
+
+Expanding the last transition judgment, gives us the case:
+\begin{mathpar}
+\inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\\\
+  \evalexpr{ \env, \veone} \evalarrow \ResultExpr(\vmone, \envone) \\\\
+  \evalexpr{ \envone, \vetwo } \evalarrow \ResultExpr(\vmtwo, \newenv) \\\\
+  \vmone \eqname (\vvone, \vgone) \\
+  \vmtwo \eqname (\vvtwo, \vgtwo) \\
+  \binoprel(\op, \vvone, \vvtwo) \evalarrow \DynErrorConfig
+}{
+  \evalexpr{ \env, \EBinop(\op, \veone, \vetwo) } \evalarrow
+  \DynErrorConfig
+}
 \end{mathpar}
 
 All these cases are succinctly encoded in a single rule with the alternative output configurations.
 
-\subsection{Boolean Transition Assertions}
+\subsection{Boolean Transition Judgments}
 \hypertarget{def-booltrans}{}
-We define the following rules to allow us to treat assertions as transition assertions:
+We define the following rules to allow us to treat assertions as transition judgments:
 \begin{mathpar}
-  \inferrule[bool\_trans\_true]{}{ \booltrans{\True} \booltransarrow\True }
-  \and
-  \inferrule[bool\_trans\_false]{}{ \booltrans{\False} \booltransarrow\False }
+\inferrule[bool\_trans\_true]{}{ \booltrans{\True} \booltransarrow\True }
+\and
+\inferrule[bool\_trans\_false]{}{ \booltrans{\False} \booltransarrow\False }
 \end{mathpar}
 This is useful in that it allows us to use assertions in rule macros.
 
 \subsection{Assertions Over Optional Data Types}
 \hypertarget{def-mapopt}{}
 Optional data types are prevalent in the AST.
-To facilitate transition assertions over optional data types,
-we introduce the parametric function,
+To facilitate transition judgments over optional data types,
+we introduce the following parametric function,
 which accepts a one-argument relation (or function) $f : A \aslrel B$
 and applies it to an optional value $A?$:
 \[

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -251,6 +251,7 @@
 \newcommand\emptylist[0]{\hyperlink{def-emptylist}{[\ ]}}
 \newcommand\Proseemptylist[1]{#1 is the empty list}
 \newcommand\choice[3]{\hyperlink{def-choice}{\textsf{choice}}(#1,#2,#3)}
+\newcommand\choicename[0]{\hyperlink{def-choice}{\textfunc{choice}}}
 \newcommand\ifthenelse[3]{
   \left\{\begin{array}{ll}
   \hyperlink{def-choice}{\textbf{if}} & #1\\
@@ -320,6 +321,9 @@
 \newcommand\mapopt[1]{\hyperlink{def-mapopt}{\textsf{optional}}[#1]}
 \newcommand\Prosemapopt[3]{\hyperlink{def-mapopt}{applying} #1 to the optional value #2 via \hyperlink{def-mapopt}{\textsf{optional}}
   yields #3}
+
+\newcommand\derivationtreeterm[0]{\hyperlink{def-derivationtree}{derivation tree}}
+\newcommand\derivationtreesterm[0]{\hyperlink{def-derivationtree}{derivation trees}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Syntax macros
@@ -916,6 +920,7 @@
 \newcommand\Lang[0]{\hyperlink{def-lang}{\textsf{Lang}}}
 \newcommand\RegExp[0]{\hyperlink{def-regex}{\textsf{RegExp}}}
 \newcommand\ascii[1]{\hyperlink{def-ascii}{\textsf{ASCII}}\texttt{\{#1\}}}
+\newcommand\vnewline[0]{\hyperlink{def-newline}{\texttt{newline}}}
 
 \newcommand\spectoken[0]{\hyperlink{def-spectoken}{\textsc{spec\_token}}}
 \newcommand\specstring[0]{\hyperlink{def-specstring}{\textsc{spec\_string}}}
@@ -1078,19 +1083,31 @@
 \newcommand\ReturningConfig[0]{\hyperlink{def-returningconfig}{\texttt{\#R}}}
 \newcommand\ThrowingConfig[0]{\hyperlink{def-throwingconfig}{\texttt{\#T}}}
 \newcommand\DynErrorConfig[0]{\hyperlink{def-errorconfig}{\texttt{\#DE}}}
-\newcommand\OrAbnormal[0]{\;\terminateas \ThrowingConfig, \DynErrorConfig}
+\newcommand\DivergingConfig[0]{\hyperlink{def-divergingconfig}{\texttt{\#DIV}}}
+\newcommand\OrAbnormal[0]{\;\terminateas \ThrowingConfig, \DynErrorConfig, \DivergingConfig}
+\newcommand\OrAbnormalReturning[0]{\;\terminateas \ReturningConfig, \ThrowingConfig, \DynErrorConfig, \DivergingConfig}
+\newcommand\OrReturningOrAbnormal[0]{\;\terminateas \ReturningConfig, \ThrowingConfig, \DynErrorConfig, \DivergingConfig}
 \newcommand\OrDynError[0]{\;\terminateas \DynErrorConfig}
+\newcommand\OrDynErrorDiverging[0]{\;\terminateas \DynErrorConfig, \DivergingConfig}
+\newcommand\ProseOtherwiseReturningOrAbnormal[0]{Otherwise, the result is either a returning configuration or abnormal.}
+\newcommand\ProseOtherwiseAbnormal[0]{Otherwise, the result is abnormal.}
 \newcommand\ProseOtherwiseDynamicError[0]{Otherwise, the result is a \dynamicerrorterm.}
-\newcommand\ProseOrAbnormal[0]{\ProseTerminateAs{\ThrowingConfig, \DynErrorConfig}}
+\newcommand\ProseOtherwiseDynamicErrorOrDiverging[0]{Otherwise, the result is either a \dynamicerrorterm{} or the evaluation diverges.}
+\newcommand\ProseOrAbnormal[0]{\ProseTerminateAs{\ThrowingConfig, \DynErrorConfig, \DivergingConfig}}
+\newcommand\ProseOrAbnormalReturning[0]{\ProseTerminateAs{\ReturningConfig, \ThrowingConfig, \DynErrorConfig, \DivergingConfig}}
+\newcommand\ProseReturningOrAbnormal[0]{\ProseTerminateAs{\TReturning, \ThrowingConfig, \DynErrorConfig, \DivergingConfig}}
 \newcommand\ProseOrError[0]{\ProseTerminateAs{\DynErrorConfig}}
+\newcommand\ProseOrDynErrorDiverging[0]{\ProseTerminateAs{\DynErrorConfig, \DivergingConfig}}
 \newcommand\TNormal[0]{\hyperlink{def-tnormal}{\textsf{TNormal}}}
 \newcommand\TDynError[0]{\hyperlink{def-tdynerror}{\textsf{TDynError}}}
 \newcommand\TThrowing[0]{\hyperlink{def-tthrowing}{\textsf{TThrowing}}}
 \newcommand\TContinuing[0]{\hyperlink{def-tcontinuing}{\textsf{TContinuing}}}
 \newcommand\TReturning[0]{\hyperlink{def-treturning}{\textsf{TReturning}}}
+\newcommand\TDiverging[0]{\hyperlink{def-tdiverging}{\textsf{TDiverging}}}
 \newcommand\TOutConfig[0]{\hyperlink{def-toutconfig}{\textsf{TOutConfig}}}
 
-\newcommand\evalexpr[1]{\hyperlink{def-evalexpr}{\textfunc{eval\_expr}}(#1)}
+\newcommand\evalexprname[0]{\hyperlink{def-evalexpr}{\textfunc{eval\_expr}}}
+\newcommand\evalexpr[1]{\evalexprname(#1)}
 \newcommand\Proseevalexpr[3]{
     \hyperlink{def-evalexpr}{evaluating} the expression #2 in the environment #1 yields #3}
 \newcommand\evalexprsef[1]{\hyperlink{def-evalexprsef}{\textfunc{eval\_expr\_sef}}(#1)}
@@ -1105,7 +1122,8 @@
 \newcommand\writefolder[0]{\hyperlink{def-writefolder}{\textfunc{write\_folder}}}
 \newcommand\evalslices[0]{\hyperlink{def-evalslices}{\textfunc{eval\_slices}}}
 \newcommand\evalslice[0]{\hyperlink{def-evalslice}{\textfunc{eval\_slice}}}
-\newcommand\evalstmt[1]{\hyperlink{def-evalstmt}{\textfunc{eval\_stmt}}(#1)}
+\newcommand\evalstmtname[0]{\hyperlink{def-evalstmt}{\textfunc{eval\_stmt}}}
+\newcommand\evalstmt[1]{\evalstmtname(#1)}
 \newcommand\evalblock[1]{\hyperlink{def-evalblock}{\textfunc{eval\_block}}(#1)}
 \newcommand\poplocalscope[0]{\hyperlink{def-poplocalscope}{\textfunc{pop\_local\_scope}}}
 \newcommand\Prosepoplocalscope[2]{#2 after \hyperlink{def-poplocalscope}{restoring} the variable bindings of #1 with the updated values of #2}
@@ -1174,11 +1192,22 @@
 \newcommand\findfunc[0]{\hyperlink{def-findfunc}{\textfunc{find\_func}}}
 
 \newcommand\valuereadfrom[0]{\hyperlink{def-valuereadfrom}{\textsf{value\_read\_from}}}
-\newcommand\Normal[0]{\hyperlink{def-normal}{\textsf{Normal}}}
 \newcommand\Throwing[0]{\hyperlink{def-throwing}{\textsf{Throwing}}}
 \newcommand\Continuing[0]{\hyperlink{def-continuing}{\textsf{Continuing}}}
 \newcommand\Returning[0]{\hyperlink{def-returning}{\textsf{Returning}}}
 \newcommand\Error[0]{\hyperlink{def-error}{\textsf{DynError}}}
+\newcommand\Diverging[0]{\hyperlink{def-diverging}{\textsf{Diverging}}}
+
+\newcommand\ResultExpr[0]{\hyperlink{def-resultexpr}{\textsf{R\_Expr}}}
+\newcommand\ResultExprList[0]{\hyperlink{def-resultexprlist}{\textsf{R\_ExprList}}}
+\newcommand\ResultExprListM[0]{\hyperlink{def-resultexprlistm}{\textsf{R\_ExprListM}}}
+\newcommand\ResultExprSEF[0]{\hyperlink{def-resultexprsef}{\textsf{R\_Expr\_SEF}}}
+\newcommand\ResultLexpr[0]{\hyperlink{def-resultlexpr}{\textsf{R\_LExpr}}}
+\newcommand\ResultSlices[0]{\hyperlink{def-resultslices}{\textsf{R\_Slices}}}
+\newcommand\ResultPattern[0]{\hyperlink{def-resultpattern}{\textsf{R\_Pattern}}}
+\newcommand\ResultLDI[0]{\hyperlink{def-resultldi}{\textsf{R\_LDI}}}
+\newcommand\ResultSubprogram[0]{\hyperlink{def-resultsubprogram}{\textsf{R\_Subprogram}}}
+\newcommand\ResultCall[0]{\hyperlink{def-resultcall}{\textsf{R\_Call}}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Typing macros
@@ -1475,6 +1504,7 @@
 
 % AST abbreviations
 \newcommand\abbrevfont[1]{\scriptscriptstyle{\textsf{#1}}}
+\newcommand{\ETrue}{\hyperlink{def-etrue}{\textsf{E\_True}}}
 \newcommand\ELInt[1]{\overbracket{#1}^{\hyperlink{def-elint}{\ELiteral(\lint)}}}
 \newcommand\AbbrevConstraintExact[1]{\overbracket{#1}^{\hyperlink{def-abbrevconstraintexact}{\abbrevfont{Constraint\_Exact}}}}
 \newcommand\AbbrevConstraintRange[2]{\overbracket{#1..#2}^{\hyperlink{def-abbrevconstraintrange}{\abbrevfont{Constraint\_Range}}}}
@@ -1710,7 +1740,7 @@
 \newcommand\tupleexpression[1]{\hyperlink{def-tupleexpressionterm}
   {tuple expression} for the list of expressions #1}
 \newcommand\arbitraryexpression[1]{\hyperlink{def-arbitraryexpressionterm}
-  {\texttt{ARBITRARY} expression} for the type #1}
+  {\ARBITRARY{} expression} for the type #1}
 \newcommand\patternexpressionterm[0]{\hyperlink{def-patternexpressionterm}{pattern expression}}
 
 %% Assignable expression macros
@@ -2724,7 +2754,6 @@
 \newcommand\vnonmatching[0]{\texttt{nonmatching}}
 \newcommand\vnormal[0]{\texttt{normal}}
 \newcommand\vnewargs[0]{\texttt{new\_args}}
-\newcommand\vnewline[0]{\texttt{newline}}
 \newcommand\voptlimit[0]{\texttt{opt\_limit}}
 \newcommand\votherwiseopt[0]{\texttt{otherwise\_opt}}
 \newcommand\vouterenv[0]{\texttt{outer\_env}}

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -929,8 +929,9 @@ We employ the following abbreviations for various AST nodes:
 \begin{tabular}{ll}
 \hline
 \textbf{Abbreviation} & \textbf{Meaning}
-\hypertarget{def-elint}{}\\
+\hypertarget{def-etrue}{}\\
 \hline
+$\ETrue$ & $\ELiteral(\lbool(\True))$ \hypertarget{def-elint}{}\\
 $\ELInt{n}$ & literal integer expression: $\ELiteral(\lint(n))$
 \hypertarget{def-abbrevevar}{}\\
 $\AbbrevEVar{\vx}$ & $\EVar(\vx)$

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -38,12 +38,12 @@ The relation
 \hypertarget{def-evallexpr}{}
 \[
   \evallexpr{\overname{\envs}{\env} \aslsep \overname{\lexpr}{\vle} \aslsep (\overname{\vals}{\vv} \times \overname{\XGraphs}{\vg})} \;\aslrel\;
-    \Normal(\overname{\XGraphs}{\newg},\overname{\envs}{\newenv}) \cup
+    \ResultLexpr(\overname{\XGraphs}{\newg},\overname{\envs}{\newenv}) \cup
     \overname{\TThrowing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
 \]
 evaluates the assignment of a value $\vv$
 to the left-hand-side expression $\vle$ in an environment $\env$,
-resulting in either a configuration $\Normal(\newg, \env)$ or an abnormal configuration.
+resulting in either a configuration $\ResultLexpr(\newg, \env)$ or an abnormal configuration.
 
 \paragraph{Semantics Rules Naming Convention:}
 In this chapter, variables containing $\vm$ range over $\vals\times\XGraphs$
@@ -555,7 +555,7 @@ In \listingref{semantics-lediscard}, the assignment \texttt{- = 42;} does not af
   \newg\eqdef\vg\\
   \newenv\eqdef\env
 }{
-  \evallexpr{\env, \LEDiscard, (\vv, \vg)} \evalarrow \Normal(\newg, \newenv)
+  \evallexpr{\env, \LEDiscard, (\vv, \vg)} \evalarrow \ResultLexpr(\newg, \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalLEDiscardBegin}{\EvalLEDiscardEnd}{../Interpreter.ml}
@@ -686,7 +686,7 @@ In \listingref{semantics-leglobalvar},
   \newenv \eqdef (\tenv, (G^\denv, L^\denv[\vx \mapsto \vv]))\\
   \newg \eqdef \ordered{\vg}{\asldata}{\WriteEffect(\vx)}
 }{
-  \evallexpr{\env, \LEVar(\vx), (\vv, \vg)} \evalarrow \Normal(\newg,\newenv)
+  \evallexpr{\env, \LEVar(\vx), (\vv, \vg)} \evalarrow \ResultLexpr(\newg,\newenv)
 }
 \end{mathpar}
 
@@ -697,7 +697,7 @@ In \listingref{semantics-leglobalvar},
   \newenv \eqdef(\tenv, (G^\denv.\storage[\vx \mapsto \vv], L^\denv))\\
   \newg \eqdef \ordered{\vg}{\asldata}{\WriteEffect(\vx)}
 }{
-  \evallexpr{\env, \LEVar(\vx), (\vv, \vg)} \evalarrow \Normal(\newg,\newenv)
+  \evallexpr{\env, \LEVar(\vx), (\vv, \vg)} \evalarrow \ResultLexpr(\newg,\newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalLEVarBegin}{\EvalLEVarEnd}{../Interpreter.ml}
@@ -788,7 +788,7 @@ The helper relation
 \hypertarget{def-evalmultiassign}{}
 \[
   \evalmultiassignment(\overname{\envs}{\env} \aslsep \overname{\expr^*}{\vlelist} \aslsep \overname{(\vals \times \XGraphs)^*}{\vmlist}) \;\aslrel\;
-  \Normal(\overname{\XGraphs}{\newg} \aslsep \overname{\envs}{\newenv}) \cup
+  \ResultLexpr(\overname{\XGraphs}{\newg} \aslsep \overname{\envs}{\newenv}) \cup
   \overname{\TThrowing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
 \]
 evaluates multi-assignments.
@@ -811,10 +811,10 @@ See \ExampleRef{Multi-assignments}.
   \begin{itemize}
     \item $\vle$ is a \Proselist{$\vle$}{$\vlelistone$};
     \item $\vmlist$ is a \Proselist{$\vm$}{$\vmlistone$};
-    \item \Proseevallexpr{$\env$}{$\vle$}{$\vm$}{$\Normal(\envone, \vgone)$}\ProseOrAbnormal;
+    \item \Proseevallexpr{$\env$}{$\vle$}{$\vm$}{$\ResultLexpr(\vgone, \envone)$}\ProseOrAbnormal;
     \item applying $\evalmultiassignment$ to $\envone$, $\vlelistone$, and $\vmlistone$
           yields \\
-          $\Normal(\newenv, \vgtwo)$\ProseOrAbnormal;
+          $\ResultLexpr(\vgtwo, \newenv)$\ProseOrAbnormal;
     \item \Proseeqdef{$\newg$}{the ordered composition of $\vgone$ and $\vgtwo$
           with the edge $\aslpo$}.
   \end{itemize}
@@ -825,7 +825,7 @@ See \ExampleRef{Multi-assignments}.
 \inferrule[empty]{}
 {
   \evalmultiassignment(\env, \overname{\emptylist}{\vlelist}, \overname{\emptylist}{\vmlist}) \evalarrow
-  \Normal(\overname{\emptygraph}{\newg}, \overname{\env}{\newenv})
+  \ResultLexpr(\overname{\emptygraph}{\newg}, \overname{\env}{\newenv})
 }
 \end{mathpar}
 
@@ -833,11 +833,11 @@ See \ExampleRef{Multi-assignments}.
 \inferrule[non\_empty]{
   \vlelist = [\vle] \concat \vlelistone\\
   \vmlist = [\vm] \concat \vmlistone\\
-  \evallexpr{\env, \vle, \vm} \evalarrow \Normal(\envone, \vgone) \OrAbnormal\\\\
-  \evalmultiassignment(\envone, \vlelistone, \vmlistone) \evalarrow \Normal(\newenv, \vgtwo) \OrAbnormal\\\\
+  \evallexpr{\env, \vle, \vm} \evalarrow \ResultLexpr(\vgone, \envone) \OrAbnormal\\\\
+  \evalmultiassignment(\envone, \vlelistone, \vmlistone) \evalarrow \ResultLexpr(\vgtwo, \newenv) \OrAbnormal\\\\
   \newg \eqdef \ordered{\vgone}{\aslpo}{\vgtwo}
 }{
-  \evalmultiassignment(\env, \vlelist, \vmlist) \evalarrow \Normal(\newg, \newenv)
+  \evalmultiassignment(\env, \vlelist, \vmlist) \evalarrow \ResultLexpr(\newg, \newenv)
 }
 \end{mathpar}
 Notice that this rule is only defined when the lists $\vlelist$ and $\vmlist$ have the same length.
@@ -989,8 +989,8 @@ of \\
 \begin{itemize}
   \item $\vle$ denotes an array update expression, $\LESetArray(\rearray, \eindex)$;
   \item evaluating the right-hand-side expression corresponding to $\rearray$ in $\env$
-  is \Normal(\rmarray, \envone)\ProseOrAbnormal;
-  \item evaluating $\eindex$ in $\envone$ is \Normal(\mindex, \envtwo)\ProseOrAbnormal;
+  is \ResultExpr(\rmarray, \envone)\ProseOrAbnormal;
+  \item evaluating $\eindex$ in $\envone$ is \ResultExpr(\mindex, \envtwo)\ProseOrAbnormal;
   \item $\mindex$ consists of the native integer $\vindex$ and the execution graph $\vgone$;
   \item $\vindex$ is the native integer for $\vi$;
   \item $\rmarray$ consists of the native vector $\rvarray$ and the execution graph $\vgtwo$;
@@ -1005,8 +1005,8 @@ of \\
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \torexpr(\rearray)} \evalarrow \Normal(\rmarray, \envone) \OrAbnormal\\
-  \evalexpr{\envone, \eindex} \evalarrow \Normal(\mindex, \envtwo) \OrAbnormal\\
+  \evalexpr{\env, \torexpr(\rearray)} \evalarrow \ResultExpr(\rmarray, \envone) \OrAbnormal\\
+  \evalexpr{\envone, \eindex} \evalarrow \ResultExpr(\mindex, \envtwo) \OrAbnormal\\
   \mindex \eqname (\vindex, \vgone)\\
   \vindex \eqname \nvint(\vi)\\
   \rmarray \eqname (\rvarray, \vgtwo)\\
@@ -1048,8 +1048,8 @@ cell of
 \begin{itemize}
   \item $\vle$ denotes an array update expression, $\LESetEnumArray(\rearray, \eindex)$;
   \item evaluating the right-hand-side expression corresponding to $\rearray$ in $\env$
-  is \Normal(\rmarray, \envone)\ProseOrAbnormal;
-  \item evaluating $\eindex$ in $\envone$ is \Normal(\mindex, \envtwo)\ProseOrAbnormal;
+  is \ResultExpr(\rmarray, \envone)\ProseOrAbnormal;
+  \item evaluating $\eindex$ in $\envone$ is \ResultExpr(\mindex, \envtwo)\ProseOrAbnormal;
   \item $\mindex$ consists of the native value $\vindex$ and the execution graph $\vgone$;
   \item $\vindex$ is the native label for $\vl$;
   \item $\rmarray$ consists of the native value $\rvarray$ and the execution graph $\vgtwo$;
@@ -1064,8 +1064,8 @@ cell of
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \torexpr(\rearray)} \evalarrow \Normal(\rmarray, \envone) \OrAbnormal\\
-  \evalexpr{\envone, \eindex} \evalarrow \Normal(\mindex, \envtwo) \OrAbnormal\\
+  \evalexpr{\env, \torexpr(\rearray)} \evalarrow \ResultExpr(\rmarray, \envone) \OrAbnormal\\
+  \evalexpr{\envone, \eindex} \evalarrow \ResultExpr(\mindex, \envtwo) \OrAbnormal\\
   \mindex \eqname (\vindex, \vgone)\\
   \vindex \eqname \nvlabel(\vl)\\
   \rmarray \eqname (\rvarray, \vgtwo)\\
@@ -1180,11 +1180,11 @@ in the environment where \texttt{x} is bound to $\nvbitvector(11111111)$.
 \begin{itemize}
   \item $\vle$ denotes a left-hand-side slicing expression, $\LESlice(\ebv, \slices)$;
   \item evaluating the right-hand-side expression that corresponds to $\ebv$
-  (given by applying $\torexpr$ to $\ebv$) in $\env$
-    is $\Normal(\mbv,\envone)$\ProseOrAbnormal;
-  \item evaluating $\slices$ in $\envone$ is $\Normal(\msliceranges, \envtwo)$\ProseOrAbnormal;
+        (given by applying $\torexpr$ to $\ebv$) in $\env$
+        is $\ResultExpr(\mbv,\envone)$\ProseOrAbnormal;
+  \item evaluating $\slices$ in $\envone$ is $\ResultSlices(\msliceranges, \envtwo)$\ProseOrAbnormal;
   \item $\msliceranges$ consists of the execution graph $\vgone$ and the list of indices\\
-         $\sliceranges$;
+        $\sliceranges$;
   \item applying $\checknonoverlappingslices$ to $\sliceranges$ yields $\True$\ProseOrError;
   \item $\mbv$ consists of the native bitvector $\vbv$ and the execution graph $\vgtwo$;
   \item writing to the bitvector $\vbv$ at indices $\sliceranges$ using the values from $\vv$
@@ -1196,11 +1196,12 @@ in the environment where \texttt{x} is bound to $\nvbitvector(11111111)$.
   Evaluating the left-hand-side expression $\ebv$ with
   $\newmbv$ in an environment $\envtwo$ is the output configuration $C$,
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \torexpr(\ebv)} \evalarrow \Normal(\mbv,\envone) \OrAbnormal\\
-  \evalslices(\envone, \slices) \evalarrow \Normal(\msliceranges, \envtwo) \OrAbnormal\\
+  \evalexpr{\env, \torexpr(\ebv)} \evalarrow \ResultExpr(\mbv,\envone) \OrAbnormal\\
+  \evalslices(\envone, \slices) \evalarrow \ResultSlices(\msliceranges, \envtwo) \OrAbnormal\\
   \msliceranges \eqname (\sliceranges, \vgone)\\
   \mbv \eqname (\vbv, \vgtwo)\\\\
   \checknonoverlappingslices(\sliceranges) \evalarrow \True \OrDynError\\\\
@@ -1234,11 +1235,11 @@ The helper function
 \[
   \checknonoverlappingslices(
     \overname{(\tint\times\tint)^*}{\valueranges}
-  ) \evalarrow \{\True\} \cup \overname{\TDynError}{\DynErrorConfig}
+  ) \aslto \{\True\} \cup \overname{\TDynError}{\DynErrorConfig}
 \]
 checks whether the sets of integers represented by the list of ranges $\valueranges$
 overlap, yielding $\True$.
-\ProseOtherwiseDynamicError
+\ProseOtherwiseDynamicErrorOrDiverging
 
 \ExampleDef{Checking Slices for Overlaps}
 In \listingref{semantics-checknonoverlappingslices},
@@ -1284,14 +1285,14 @@ The helper function
 \begin{array}{r}
   \checktworangesnonoverlapping(
     (\overname{\tint}{\vsone}\times\overname{\tint}{\vlone}) \aslsep
-    (\overname{\tint}{\vstwo}\times\overname{\tint}{\vltwo}) \aslsep
-  ) \evalarrow \\
+    (\overname{\tint}{\vstwo}\times\overname{\tint}{\vltwo})
+  ) \aslto \\
   \{\True\} \cup \overname{\TDynError}{\DynErrorConfig}
 \end{array}
 \]
 checks whether two sets of integers represented by the
 ranges $(\vsone, \vlone)$ and $(\vstwo, \vltwo)$ do not intersect, yielding $\True$.
-\ProseOrError
+\ProseOtherwiseDynamicErrorOrDiverging
 
 See \ExampleRef{Checking Slices for Overlaps}.
 
@@ -1823,7 +1824,7 @@ All of the collection field assignable expressions in
   \newenv \eqdef (\tenv, (G^\denv[\vx \mapsto \recordone], L^\denv))\\
   \newg \eqdef \ordered{\vg}{\asldata}{\vgzero} \\
 }{
-  \evallexpr{\env, \overname{\LESetCollectionFields(\vbase, \fields, \vslices)}{\vle}, (\vv,\vg)} \evalarrow \Normal(\newg,\newenv)
+  \evallexpr{\env, \overname{\LESetCollectionFields(\vbase, \fields, \vslices)}{\vle}, (\vv,\vg)} \evalarrow \ResultLexpr(\newg,\newenv)
 }
 \end{mathpar}
 
@@ -1979,7 +1980,7 @@ in the environment where \verb|my_record| is bound to \verb|{a: 3, b: 100}|.
 \begin{itemize}
   \item $\vle$ denotes a field update expression, $\LESetField(\rerecord, \fieldname)$;
   \item evaluating the right-hand-side expression corresponding to $\rerecord$
-  in $\env$ is $\Normal(\rmrecord, \envone)$\ProseOrAbnormal;
+  in $\env$ is $\ResultExpr(\rmrecord, \envone)$\ProseOrAbnormal;
   \item $\rmrecord$ is a pair consisting of the native record $\rvrecord$ and
   the execution graph $\vgone$;
   \item setting the field $\fieldname$ in the native record $\rvrecord$ to $\vv$
@@ -1995,7 +1996,7 @@ in the environment where \verb|my_record| is bound to \verb|{a: 3, b: 100}|.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-    \evalexpr{\env, \torexpr(\rerecord)} \evalarrow \Normal(\rmrecord, \envone) \OrAbnormal\\
+    \evalexpr{\env, \torexpr(\rerecord)} \evalarrow \ResultExpr(\rmrecord, \envone) \OrAbnormal\\
     \rmrecord \eqname (\rvrecord, \vgone)\\
     \setfield(\fieldname, \vv, \rvrecord) \evalarrow \vvone\\
     \vmone \eqdef (\vvone, \vg \parallelcomp \vgone)\\

--- a/asllib/doc/BlockStatements.tex
+++ b/asllib/doc/BlockStatements.tex
@@ -56,13 +56,19 @@ The relation
 \hypertarget{def-evalblock}{}
 \[
   \evalblock{\overname{\envs}{\env} \times \overname{\stmt}{\stm}} \;\aslrel\;
-  \overname{\TContinuing}{\Continuing(\newg, \newenv)} \cup
-  \overname{\TReturning}{\ReturningConfig} \cup
-  \overname{\TThrowing}{\ThrowingConfig} \cup
-  \overname{\TDynError}{\DynErrorConfig}
+  \left(
+  \begin{array}{cl}
+  \overname{\TContinuing}{\Continuing(\newg, \newenv)} &\cup\\
+  \overname{\TReturning}{\ReturningConfig} &\cup\\
+  \overname{\TThrowing}{\ThrowingConfig} &\cup\\
+  \overname{\TDynError}{\DynErrorConfig} &\cup\\
+  \overname{\TDiverging}{\DivergingConfig} &\cup\\
+  \end{array}
+  \right)
 \]
 evaluates a statement $\stm$ as a \emph{block}. That is, $\stm$ is evaluated in a fresh local environment,
 which drops back to the original local environment of $\env$ when the evaluation terminates.
+\ProseOtherwiseAbnormal
 
 \SemanticsRuleDef{Block}
 See \ExampleRef{Block Statements}.
@@ -82,7 +88,7 @@ The $\poplocalscope$ function is used below to effectively discard the bindings 
 \AllApply
 \begin{itemize}
     \item evaluating $\stm$ in $\env$, as per \chapref{Statements},
-          is $\vres$;
+          is $\vres$\ProseOrDynErrorDiverging;
     \item \OneApplies
       \begin{itemize}
         \item \AllApplyCase{returning}
@@ -112,7 +118,7 @@ The $\poplocalscope$ function is used below to effectively discard the bindings 
 \begin{mathpar}
 \inferrule[returning]{
   \env \eqname (\tenv,\denv)\\
-  \evalstmt{\env, \stm} \evalarrow \vres \\\\
+  \evalstmt{\env, \stm} \evalarrow \vres \OrDynErrorDiverging\\\\
   \commonprefixline \\\\
   \vres = \Returning((\vvs, \newg), \envret) \\
   \envret \eqname (\tenvone, \denvone) \\
@@ -125,7 +131,7 @@ The $\poplocalscope$ function is used below to effectively discard the bindings 
 \begin{mathpar}
 \inferrule[continuing]{
   \env \eqname (\tenv,\denv)\\
-  \evalstmt{\env, \stm} \evalarrow \vres \\\\
+  \evalstmt{\env, \stm} \evalarrow \vres \OrDynErrorDiverging\\\\
   \commonprefixline \\\\
   \vres = \Continuing(\newg, \envcont) \\
   \envcont \eqname (\tenvone, \denvone) \\
@@ -138,7 +144,7 @@ The $\poplocalscope$ function is used below to effectively discard the bindings 
 \begin{mathpar}
 \inferrule[throwing]{
   \env \eqname (\tenv,\denv)\\
-  \evalstmt{\env, \stm} \evalarrow \vres \\\\
+  \evalstmt{\env, \stm} \evalarrow \vres \OrDynErrorDiverging\\\\
   \commonprefixline \\\\
   \vres = \Throwing((\vv,\newg), \envthrow) \\
   \envthrow \eqname (\tenvone, \denvone) \\

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -211,9 +211,9 @@ That is, no dynamic error occurs.
   \item $\env$ consists of the static environment $\tenv$ and dynamic environment $\denv$;
   \item $\envthrow$ consists of the static environment $\tenv$ and dynamic environment \\ $\denvthrow$;
   \item finding the first catcher with the static environment $\tenv$, the exception type $\vvty$,
-  and the list of catchers $\catchers$ gives a catcher that does not declare a name ($\None$) and gives a statement $\vs$;
+        and the list of catchers $\catchers$ gives a catcher that does not declare a name ($\None$) and gives a statement $\vs$;
   \item evaluating $\vs$ in $\envthrow$ as a block (\SemanticsRuleRef{Block}) yields a (non-error)
-        configuration $C$\ProseOrError;
+        configuration $C$\ProseOrDynErrorDiverging;
   \item editing potential implicit throwing configurations via $\rethrowimplicit(\vv, \vvty, C)$
         gives the configuration $D$;
   \item $\newg$ is the ordered composition of $\sg$ and the graph of $D$;
@@ -227,7 +227,7 @@ That is, no dynamic error occurs.
   \env \eqname (\tenv, (G^\denv, L^\denv))\\
   \envthrow \eqname (\tenv, (G^{\denvthrow}, L^{\denvthrow}))\\
   \findcatcher(\tenv, \vvty, \catchers) \eqname \langle (\None, \Ignore, \vs) \rangle\\
-  \evalblock{\envthrow, \vs} \evalarrow C \OrDynError\\\\
+  \evalblock{\envthrow, \vs} \evalarrow C \OrDynErrorDiverging\\\\
   D \eqdef \rethrowimplicit(\vv, \vvty, C)\\
   \newg \eqdef \ordered{\sg}{\aslpo}{\graphof{D}}
 }{
@@ -252,15 +252,15 @@ The specification in \listingref{semantics-catchnamed}, prints \texttt{My except
   \item applying $\readvaluefrom$ to $\vv$ yields $(\vv, \vgone)$;
   \item declaring a local identifier $\name$ with $(\vv, \vgone)$ in $\envthrow$ gives $(\envtwo, \vgtwo)$;
   \item evaluating $\vs$ in $\envtwo$ as a block (\SemanticsRuleRef{Block}) is not an error
-  configuration $C$\ProseOrError;
+        configuration $C$\ProseOrDynErrorDiverging;
   \item $\envthree$ is the environment of the configuration $C$;
   \item removing the binding for $\name$ from the local component of the dynamic environment in $\envthree$
-  gives $\envfour$;
+        gives $\envfour$;
   \item substituting the environment of $C$ with $\envfour$ gives $D$;
   \item editing potential implicit throwing configurations via $\rethrowimplicit(\vv, \vvty, D)$
-  gives the configuration $E$;
+        gives the configuration $E$;
   \item $\newg$ is the ordered composition of $\sg$, $\vgone$, $\vgtwo$, and the graph of $E$,
-  with the $\aslpo$ edges;
+        with the $\aslpo$ edges;
   \item the result of the entire evaluation is $E$ with its graph substituted with $\newg$.
 \end{itemize}
 \FormallyParagraph
@@ -272,7 +272,7 @@ The specification in \listingref{semantics-catchnamed}, prints \texttt{My except
   \findcatcher(\tenv, \vvty, \catchers) \eqname \langle (\langle\name\rangle, \Ignore, \vs) \rangle\\
   \readvaluefrom(\vv) \evalarrow (\vv, \vgone)\\
   \declarelocalidentifierm(\envthrow, \name, (\vv, \vgone)) \evalarrow (\envtwo, \vgtwo)\\
-  \evalblock{\envtwo, \vs} \evalarrow C \OrDynError\\\\
+  \evalblock{\envtwo, \vs} \evalarrow C \OrDynErrorDiverging\\\\
   \envthree \eqdef \environof{C}\\
   \removelocal(\envthree, \name) \evalarrow \envfour\\
   D \eqdef \withenviron{C}{\envfour}\\
@@ -296,14 +296,14 @@ The specification in \listingref{semantics-catchotherwise} prints \texttt{Otherw
   \item $\env$ consists of the static environment $\tenv$ and dynamic environment $\denv$;
   \item $\envthrow$ consists of the static environment $\tenv$ and dynamic environment \\ $\denvthrow$;
   \item finding the first catcher with the static environment $\tenv$, the exception type $\vvty$,
-  and the list of catchers $\catchers$ gives a catcher that declares the name $\name$ and gives $\None$
-  (that is, neither of the \texttt{catch} clauses matches the raised exception);
+        and the list of catchers $\catchers$ gives a catcher that declares the name $\name$ and gives $\None$
+        (that is, neither of the \texttt{catch} clauses matches the raised exception);
   \item evaluating the \texttt{otherwise} statement $\vs$ in $\envtwo$ as a block (\SemanticsRuleRef{Block})
-  is not an error configuration $C$\ProseOrError;
+        is not an error configuration $C$\ProseOrDynErrorDiverging;
   \item editing potential implicit throwing configurations via $\rethrowimplicit(\vv, \vvty, C)$
-  gives the configuration $D$;
+        gives the configuration $D$;
   \item $\newg$ is the ordered composition of $\sg$ and the graph of $D$,
-  with the $\aslpo$ edge;
+        with the $\aslpo$ edge;
   \item the result of the entire evaluation is $D$ with its graph substituted with $\newg$.
 \end{itemize}
 
@@ -314,7 +314,7 @@ The specification in \listingref{semantics-catchotherwise} prints \texttt{Otherw
   \env \eqname (\tenv, (G^\denv, L^\denv))\\
   \envthrow \eqname (\tenv, (G^{\denvthrow}, L^{\denvthrow}))\\
   \findcatcher(\tenv, \vvty, \catchers) = \None\\
-  \evalblock{\envthrow, \vs} \evalarrow C \OrDynError\\\\
+  \evalblock{\envthrow, \vs} \evalarrow C \OrDynErrorDiverging\\\\
   D \eqdef \rethrowimplicit(\vv, \vvty, C)\\
   \vg \eqdef \ordered{\sg}{\aslpo}{\graphof{D}}
 }{
@@ -362,14 +362,14 @@ The specification in \listingref{semantics-nothrow} prints \texttt{No exception 
 \AllApply
 \begin{itemize}
 \item $\sm$ is either $\Throwing((\None, \sg), \envthrow)$ (that is, an implicit throw) or
-    $\sm$ is a normal configuration (that is, the domain of $\sm$ is $\Normal$);
+      $\sm$ is a \Prosenormalconfiguration;
 \item \Proseeqdef{$\smnew$}{$\sm$}.
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \sm = \Throwing((\None, \sg), \envthrow) \lor \configdomain{\sm} = \Normal
+  \sm = \Throwing((\None, \sg), \envthrow) \lor \sm \in \TNormal
 }{
   \evalcatchers{\env, \catchers, \Ignore, \sm} \evalarrow \sm
 }

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -166,7 +166,7 @@ The following table summarises all error codes.
   \hline
   $\UnreachableError$            & Unreachable error              & Dynamic       \\
   $\DynamicTypeAssertionFailure$ & Dynamic type assertion failure & "             \\
-  $\ArbitraryEmptyType$          & \texttt{ARBITRARY} empty type  & "             \\
+  $\ArbitraryEmptyType$          & \ARBITRARY{} empty type        & "             \\
   $\DynamicBadOperands$          & Bad operands                   & "             \\
   $\LimitExceeded$               & Limit exceeded                 & "             \\
   $\UncaughtException$           & Uncaught exception             & "             \\
@@ -410,7 +410,7 @@ The following table summarises all error codes.
 
 \hypertarget{def-arbitraryemptytype}{}
 \item[$\ArbitraryEmptyType$]
-  \textit{\texttt{ARBITRARY} empty type.}
+  \textit{\ARBITRARY{} empty type.}
   An expression \texttt{ARBITRARY : $t$} is evaluated and $t$ is an empty type (see \SemanticsRuleRef{EArbitrary}).
 
 \hypertarget{def-dynamicbadoperands}{}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -41,12 +41,18 @@ The relation
 \hypertarget{def-evalexpr}{}
 \[
   \evalexpr{\overname{\envs}{\env} \aslsep \overname{\expr}{\ve}} \;\aslrel\;
-            \Normal((\overname{\vals}{\vv} \times \overname{\XGraphs}{\vg}) \aslsep \overname{\envs}{\newenv}) \cup
-            \overname{\TThrowing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
+  \left(
+  \begin{array}{ll}
+  \ResultExpr((\overname{\vals}{\vv} \times \overname{\XGraphs}{\vg}) \aslsep \overname{\envs}{\newenv}) & \cup\\
+  \overname{\TThrowing}{\ThrowingConfig} & \cup \\
+  \overname{\TDynError}{\DynErrorConfig} & \cup \\
+  \overname{\TDiverging}{\DivergingConfig} & \\
+  \end{array}
+  \right)
 \]
 evaluates the expression $\ve$ in an environment $\env$ and terminates normally with
 a \nativevalue{} $\vv$, an \executiongraph{} $\vg$, and a modified environment $\newenv$.
-Otherwise, the evaluation terminates abnormally.
+\ProseOtherwiseAbnormal.
 
 The rest of this chapter defines the syntax, abstract syntax, typing,
 and semantics of the following kinds of expressions:
@@ -138,7 +144,7 @@ In \listingref{literalssemantics}, each of the expressions \texttt{3} evaluates 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{}{
-  \evalexpr{\env, \overname{\ELiteral(\vl)}{\ve}} \evalarrow \Normal((\overname{\nvliteral{\vl}}{\vv},\overname{\emptygraph}{\vg}), \overname{\env}{\newenv})
+  \evalexpr{\env, \overname{\ELiteral(\vl)}{\ve}} \evalarrow \ResultExpr((\overname{\nvliteral{\vl}}{\vv},\overname{\emptygraph}{\vg}), \overname{\env}{\newenv})
 }
 \end{mathpar}
 \CodeSubsection{\EvalELitBegin}{\EvalELitEnd}{../Interpreter.ml}
@@ -299,7 +305,7 @@ uses the rule \SemanticsRuleRef{EVar}.GLOBAL.
   \env \eqname (\Ignore, \denv)\\
   \vx \in \dom(L^\denv)
 }{
-  \evalexpr{\env, \EVar(\vx)} \evalarrow \Normal((\overname{L^\denv(\vx)}{\vv}, \overname{\ReadEffect(\vx)}{\vg}), \overname{\env}{\newenv})
+  \evalexpr{\env, \EVar(\vx)} \evalarrow \ResultExpr((\overname{L^\denv(\vx)}{\vv}, \overname{\ReadEffect(\vx)}{\vg}), \overname{\env}{\newenv})
 }
 \end{mathpar}
 
@@ -308,7 +314,7 @@ uses the rule \SemanticsRuleRef{EVar}.GLOBAL.
   \env \eqname (\Ignore, \denv)\\
   \vx \in \dom(G^\denv.\storage)
 }{
-  \evalexpr{\env, \EVar(\vx)} \evalarrow \Normal((\overname{G^\denv.\storage(\vx)}{\vv}, \overname{\ReadEffect(\vx)}{\vg}), \overname{\env}{\newenv})
+  \evalexpr{\env, \EVar(\vx)} \evalarrow \ResultExpr((\overname{G^\denv.\storage(\vx)}{\vv}, \overname{\ReadEffect(\vx)}{\vg}), \overname{\env}{\newenv})
 }
 \end{mathpar}
 \CodeSubsection{\EvalEVarBegin}{\EvalEVarEnd}{../Interpreter.ml}
@@ -703,9 +709,9 @@ the expression \texttt{3 + 2} evaluates to the value \texttt{5}.
         \SemanticsRuleRef{BinopOr}, and
         \SemanticsRuleRef{BinopImpl};
   \item the evaluation of the expression $\veone$ in $\env$ is the configuration \\
-        $\Normal(\vmone, \envone)$\ProseOrAbnormal;
+        $\ResultExpr(\vmone, \envone)$\ProseOrAbnormal;
   \item the evaluation of the expression $\vetwo$ in $\envone$ is the configuration \\
-        $\Normal(\vmtwo, \newenv)$\ProseOrAbnormal;
+        $\ResultExpr(\vmtwo, \newenv)$\ProseOrAbnormal;
   \item $\vmone$ consists of the value $\vvone$ and the execution graph $\vgone$;
   \item $\vmtwo$ consists of the value $\vvtwo$ and the execution graph $\vgtwo$;
   \item applying the Binary Operator $\op$ to $\vvone$ and $\vvtwo$ results in $\vv$\ProseOrError;
@@ -715,15 +721,15 @@ the expression \texttt{3 + 2} evaluates to the value \texttt{5}.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{\op \not\in \{\BAND, \BOR, \IMPL\}\\
-  \evalexpr{ \env, \veone} \evalarrow \Normal(\vmone, \envone) \OrAbnormal \\\\
-  \evalexpr{ \envone, \vetwo } \evalarrow \Normal(\vmtwo, \newenv) \OrAbnormal \\\\
+  \evalexpr{ \env, \veone} \evalarrow \ResultExpr(\vmone, \envone) \OrAbnormal \\\\
+  \evalexpr{ \envone, \vetwo } \evalarrow \ResultExpr(\vmtwo, \newenv) \OrAbnormal \\\\
   \vmone \eqname (\vvone, \vgone) \\
   \vmtwo \eqname (\vvtwo, \vgtwo) \\
   \binoprel(\op, \vvone, \vvtwo) \evalarrow \vv \OrDynError\\\\
   \vg \eqdef \vgone \parallelcomp \vgtwo
 }{
   \evalexpr{ \env, \overname{\EBinop(\op, \veone, \vetwo)}{\ve} } \evalarrow
-  \Normal((\vv, \vg), \newenv)
+  \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalBinopBegin}{\EvalBinopEnd}{../Interpreter.ml}
@@ -791,18 +797,18 @@ the expression \texttt{NOT '1010'} evaluates to the value \texttt{'0101'}.
 \AllApply
 \begin{itemize}
 \item $\ve$ denotes a unary operator $\op$ over an expression, $\EUnop(\op, \veone)$;
-\item the evaluation of the expression $\veone$ in $\env$ yields \\ $\Normal((\vvone, \vg), \newenv)$\ProseOrAbnormal;
+\item the evaluation of the expression $\veone$ in $\env$ yields \\ $\ResultExpr((\vvone, \vg), \newenv)$\ProseOrAbnormal;
 \item applying the unary operator $\op$ to $\vvone$ is $\vv$.
 \end{itemize}
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{ \env, \veone} \evalarrow \Normal((\vvone,\vg), \newenv) \OrAbnormal\\\\
+  \evalexpr{ \env, \veone} \evalarrow \ResultExpr((\vvone,\vg), \newenv) \OrAbnormal\\\\
   \unoprel(\op, \vvone) \evalarrow \vv
 }
 {
   \evalexpr{ \env, \EUnop(\op, \veone) } \evalarrow
-  \Normal((\vv, \vg), \newenv)
+  \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalUnopBegin}{\EvalUnopEnd}{../Interpreter.ml}
@@ -906,23 +912,24 @@ evaluate to either \texttt{3} or \texttt{Return42()}, depending on the
   \item $\ve$ denotes a conditional expression $\econd$ with two options $\veone$ and $\vetwo$,
         that is, $\ECond(\econd, \veone, \vetwo)$;
   \item the evaluation of the conditional expression $\econd$ in $\env$ yields \\
-        $\Normal(\mcond, \envone)$\ProseOrAbnormal;
+        $\ResultExpr(\mcond, \envone)$\ProseOrAbnormal;
   \item $\mcond$ consists of a native Boolean for $\vb$ and execution graph $\vgone$;
   \item $\vep$ is $\veone$ if $\vb$ is $\True$ and $\vetwo$ otherwise;
-  \item the evaluation of $\vep$ in $\envone$ yields $\Normal((\vvtwo, \vgtwo), \newenv)$\ProseOrAbnormal;
+  \item the evaluation of $\vep$ in $\envone$ yields $\ResultExpr((\vvtwo, \vgtwo), \newenv)$\ProseOrAbnormal;
   \item $\vg$ is the parallel composition of $\vgone$ and $\vgtwo$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \econd} \evalarrow \Normal(\mcond, \envone) \OrAbnormal\\\\
+  \evalexpr{\env, \econd} \evalarrow \ResultExpr(\mcond, \envone) \OrAbnormal\\\\
   \mcond \eqname (\nvbool(\vb), \vgone)\\
   \vep \eqdef \choice{\vb}{\veone}{\vetwo}\\\\
-  \evalexpr{\envone, \vep} \evalarrow \Normal((\vv, \vgtwo), \newenv)  \OrAbnormal\\\\
+  \evalexpr{\envone, \vep} \evalarrow \ResultExpr((\vv, \vgtwo), \newenv)  \OrAbnormal\\\\
   \vg \eqdef \ordered{\vgone}{\aslctrl}{\vgtwo}
 }{
   \evalexpr{\env, \overname{\ECond(\econd, \veone, \vetwo)}{\ve}} \evalarrow
-  \Normal((\vv, \vg), \newenv)
+  \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalECondBegin}{\EvalECondEnd}{../Interpreter.ml}
@@ -1080,14 +1087,14 @@ and the values they evaluate to, as assertions on the values assigned.
 \AllApply
 \begin{itemize}
   \item $\ve$ denotes a subprogram call, $\ECall(\vcall)$;
-  \item the evaluation of that subprogram call in $\env$ is either
-  $\Normal(\vms, \newenv)$\ProseOrAbnormal;
+  \item the evaluation of that subprogram call in $\env$ is either\\
+  $\ResultExpr(\vms, \newenv)$\ProseOrAbnormal;
   \item \OneApplies
   \begin{itemize}
     \item \AllApplyCase{single\_returned\_value}
     \begin{itemize}
       \item $\vms$ consists of a single returned value $(\vv,\vg)$,
-      which goes into the output configuration $\Normal((\vv, \vg), \newenv)$.
+      which goes into the output configuration $\ResultExpr((\vv, \vg), \newenv)$.
     \end{itemize}
 
     \item \AllApplyCase{multiple\_returned\_values}
@@ -1095,7 +1102,7 @@ and the values they evaluate to, as assertions on the values assigned.
       \item $\vms$ consists of a list of returned value $(\vv_i,\vg_i)$, for $i=1..k$;
       \item $\vg$ is the parallel composition of $\vg_i$, for $i=1..k$;
       \item $\vv$ is the \nativevalue\  vector of values $\vv_i$, for $i=1..k$;
-      \item the resulting configuration is $\Normal((\vv, \vg), \newenv)$.
+      \item the resulting configuration is $\ResultExpr((\vv, \vg), \newenv)$.
     \end{itemize}
   \end{itemize}
 \end{itemize}
@@ -1103,21 +1110,21 @@ and the values they evaluate to, as assertions on the values assigned.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[single\_returned\_value]{
-  \evalcall(\env, \vcall.\name, \vcall.\params, \vcall.\args) \evalarrow \Normal(\vms, \newenv) \OrAbnormal\\
+  \evalcall(\env, \vcall.\name, \vcall.\params, \vcall.\args) \evalarrow \ResultExpr(\vms, \newenv) \OrAbnormal\\
   \vms \eqname [(\vv, \vg)]
 }{
-  \evalexpr{\env, \ECall(\vcall)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \ECall(\vcall)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[multiple\_returned\_values]{
-  \evalcall(\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs) \evalarrow \Normal(\vms, \newenv) \OrAbnormal\\
+  \evalcall(\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs) \evalarrow \ResultExpr(\vms, \newenv) \OrAbnormal\\
   \vms \eqname [i=1..k: (\vv_i, \vg_i)]\\
   \vg \eqdef \vg_1 \parallelcomp \ldots \parallelcomp \vg_k \\
   \vv \eqdef \nvvector{\vv_{1..k}}
 }{
-  \evalexpr{\env, \ECall(\vcall)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \ECall(\vcall)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalECallBegin}{\EvalECallEnd}{../Interpreter.ml}
@@ -1252,8 +1259,8 @@ the function $\readfrombitvector$ takes care of converting integers to bitvector
 \AllApply
 \begin{itemize}
 \item $\ve$ denotes a slicing expression, $\ESlice(\ebv, \slices)$;
-\item the evaluation of $\ebv$ in $\env$ yields $\Normal(\mbv, \envone)$\ProseOrAbnormal;
-\item the evaluation of $\slices$ in $\env$ yields $\Normal(\mpositions, \newenv)$\ProseOrAbnormal;
+\item the evaluation of $\ebv$ in $\env$ yields $\ResultExpr(\mbv, \envone)$\ProseOrAbnormal;
+\item the evaluation of $\slices$ in $\env$ yields $\ResultExpr(\mpositions, \newenv)$\ProseOrAbnormal;
 \item $\mpositions$ consists of $\positions$ --- all the indices that need to be added to the
 resulting bitvector --- and the execution graph $\vgone$;
 \item reading from $\vbv$ as a bitvector at the indices indicated by $\positions$
@@ -1265,14 +1272,14 @@ resulting bitvector --- and the execution graph $\vgone$;
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \ebv} \evalarrow \Normal(\mbv, \envone)  \OrAbnormal\\\\
+  \evalexpr{\env, \ebv} \evalarrow \ResultExpr(\mbv, \envone)  \OrAbnormal\\\\
   \mbv \eqname (\vbv,\vgone) \\
-  \evalslices(\envone, \slices) \evalarrow \Normal(\mpositions, \newenv)  \OrAbnormal \\
+  \evalslices(\envone, \slices) \evalarrow \ResultExpr(\mpositions, \newenv)  \OrAbnormal \\
   \mpositions \eqname (\positions, \vgtwo) \\
   \readfrombitvector(\vbv, \positions) \evalarrow \vv \OrDynError\\\\
   \vg \eqdef \vgone \parallelcomp \vgtwo
 }{
-  \evalexpr{\env, \ESlice(\ebv, \slices)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \ESlice(\ebv, \slices)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalESliceBegin}{\EvalESliceEnd}{../Interpreter.ml}
@@ -1436,8 +1443,8 @@ which has indexes \texttt{0}, \texttt{1} and \texttt{2} only.
 \AllApply
 \begin{itemize}
   \item $\ve$ denotes an array access expression, $\EGetArray(\earray, \eindex)$;
-  \item the evaluation of $\earray$ in $\env$ is $\Normal(\marray, \envone)$\ProseOrAbnormal;
-  \item the evaluation of $\eindex$ in $\env$ is  $\Normal(\mindex, \newenv)$\ProseOrAbnormal
+  \item the evaluation of $\earray$ in $\env$ is $\ResultExpr(\marray, \envone)$\ProseOrAbnormal;
+  \item the evaluation of $\eindex$ in $\env$ is  $\ResultExpr(\mindex, \newenv)$\ProseOrAbnormal
   \item $\marray$ consists of the native vector $\varray$ and execution graph $\vgone$;
   \item $\mindex$ consists of the native integer $\vindex$ and execution graph $\vgtwo$;
   \item $\vindex$ is the native integer for $\vi$;
@@ -1448,15 +1455,15 @@ which has indexes \texttt{0}, \texttt{1} and \texttt{2} only.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \earray} \evalarrow \Normal(\marray, \envone)  \OrAbnormal\\
-  \evalexpr{\envone, \eindex} \evalarrow \Normal(\mindex, \newenv)  \OrAbnormal\\
+  \evalexpr{\env, \earray} \evalarrow \ResultExpr(\marray, \envone)  \OrAbnormal\\
+  \evalexpr{\envone, \eindex} \evalarrow \ResultExpr(\mindex, \newenv)  \OrAbnormal\\
   \marray \eqname (\varray, \vgone)\\
   \mindex \eqname (\vindex, \vgtwo)\\
   \vindex \eqname \nvint(\vi)\\
   \getindex(\vi, \varray) \evalarrow \vv \OrDynError\\\\
   \vg \eqdef \vgone \parallelcomp \vgtwo\\
 }{
-  \evalexpr{\env, \EGetArray(\earray, \eindex)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \EGetArray(\earray, \eindex)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalEGetArrayBegin}{\EvalEGetArrayEnd}{../Interpreter.ml}
@@ -1473,8 +1480,8 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \AllApply
 \begin{itemize}
   \item $\ve$ denotes an array access expression, $\EGetArray(\earray, \eindex)$;
-  \item the evaluation of $\earray$ in $\env$ is $\Normal(\marray, \envone)$\ProseOrAbnormal;
-  \item the evaluation of $\eindex$ in $\env$ is  $\Normal(\mindex, \newenv)$\ProseOrAbnormal
+  \item the evaluation of $\earray$ in $\env$ is $\ResultExpr(\marray, \envone)$\ProseOrAbnormal;
+  \item the evaluation of $\eindex$ in $\env$ is  $\ResultExpr(\mindex, \newenv)$\ProseOrAbnormal
   \item $\marray$ consists of the native value $\varray$ and execution graph $\vgone$;
   \item $\mindex$ consists of the native value $\vindex$ and execution graph $\vgtwo$;
   \item $\vindex$ is the native literal for the label $\vl$;
@@ -1485,15 +1492,15 @@ with indices taken from the \enumerationtypeterm{} \texttt{Enum}.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \earray} \evalarrow \Normal(\marray, \envone)  \OrAbnormal\\
-  \evalexpr{\envone, \eindex} \evalarrow \Normal(\mindex, \newenv)  \OrAbnormal\\
+  \evalexpr{\env, \earray} \evalarrow \ResultExpr(\marray, \envone)  \OrAbnormal\\
+  \evalexpr{\envone, \eindex} \evalarrow \ResultExpr(\mindex, \newenv)  \OrAbnormal\\
   \marray \eqname (\varray, \vgone)\\
   \mindex \eqname (\vindex, \vgtwo)\\
   \vindex \eqname \nvlabel(\vl)\\
   \getfield(\vl, \varray) \evalarrow \vv\\
   \vg \eqdef \vgone \parallelcomp \vgtwo\\
 }{
-  \evalexpr{\env, \EGetEnumArray(\earray, \eindex)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \EGetEnumArray(\earray, \eindex)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalEGetEnumArrayBegin}{\EvalEGetEnumArrayEnd}{../Interpreter.ml}
@@ -1847,16 +1854,16 @@ the expression \verb|my_record.a| evaluates to the value \texttt{3}.
 \AllApply
 \begin{itemize}
 \item $\ve$ denotes a field access expression, $\EGetField(\erecord, \fieldname)$;
-\item the evaluation of $\erecord$ in $\env$ is $\Normal((\vrecord, \vg), \newenv)$\ProseOrAbnormal;
+\item the evaluation of $\erecord$ in $\env$ is $\ResultExpr((\vrecord, \vg), \newenv)$\ProseOrAbnormal;
 \item $\vv$ is the value mapped by $\fieldname$ in the native record $\vrecord$.
 \end{itemize}
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \erecord} \evalarrow \Normal((\vrecord, \vg), \newenv)  \OrAbnormal\\
+  \evalexpr{\env, \erecord} \evalarrow \ResultExpr((\vrecord, \vg), \newenv)  \OrAbnormal\\
   \getfield(\fieldname, \vrecord) \evalarrow \vv
 }{
-  \evalexpr{\env, \EGetField(\erecord, \fieldname)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \EGetField(\erecord, \fieldname)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalEGetFieldBegin}{\EvalEGetFieldEnd}{../Interpreter.ml}
@@ -1874,17 +1881,17 @@ the expression \verb|t.item1| evaluates to the value \texttt{2}.
 \begin{itemize}
   \item $\ve$ is an expression for accessing the component given by the index $\vindex$ of the tuple
         given by the expression $\etuple$, that is, $\EGetItem(\etuple, \vindex)$;
-  \item evaluating the expression $\etuple$ yields $\Normal((\vvtuple, \vg), \newenv)$\ProseOrAbnormal;
+  \item evaluating the expression $\etuple$ yields $\ResultExpr((\vvtuple, \vg), \newenv)$\ProseOrAbnormal;
   \item accessing the native tuple value $\vvtuple$ at index $\vindex$ via $\getindex$, yields
         the native value $\vv$.
 \end{itemize}
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \etuple} \evalarrow \Normal((\vvtuple, \vg), \newenv) \OrAbnormal\\\\
+  \evalexpr{\env, \etuple} \evalarrow \ResultExpr((\vvtuple, \vg), \newenv) \OrAbnormal\\\\
   \getindex(\vvtuple, \vindex) \evalarrow \vv
 }{
-  \evalexpr{\env, \overname{\EGetItem(\etuple, \vindex)}{\ve}} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \overname{\EGetItem(\etuple, \vindex)}{\ve}} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalEGetTupleItemBegin}{\EvalEGetTupleItemEnd}{../Interpreter.ml}
@@ -2546,8 +2553,8 @@ will never occur, but it is still classified as a \dynamicerrorterm{}.
 \AllApply
 \begin{itemize}
 \item $\ve$ denotes an asserted type conversion expression, $\EATC(\veone, \vt)$;
-\item evaluating $\veone$ in $\env$ results in $\Normal((\vv, \vgone), \newenv)$\ProseOrAbnormal;
-\item evaluating whether $\vv$ has type $\vt$ in $\env$ results in $(\vb, \vgtwo)$\ProseTerminateAs{\DynErrorConfig};
+\item evaluating $\veone$ in $\env$ results in $\ResultExpr((\vv, \vgone), \newenv)$\ProseOrAbnormal;
+\item evaluating whether $\vv$ has type $\vt$ in $\env$ results in $(\vb, \vgtwo)$\ProseOrDynErrorDiverging;
 \item \OneApplies
       \begin{itemize}
       \item \AllApplyCase{okay}
@@ -2566,16 +2573,16 @@ will never occur, but it is still classified as a \dynamicerrorterm{}.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[okay]{
-  \evalexpr{\env, \veone} \evalarrow \Normal((\vv, \vgone), \newenv) \OrAbnormal\\\\
-  \isvaloftype(\env, \vv, \vt) \evalarrow (\vb, \vgtwo) \OrDynError\\\\
+  \evalexpr{\env, \veone} \evalarrow \ResultExpr((\vv, \vgone), \newenv) \OrAbnormal\\\\
+  \isvaloftype(\env, \vv, \vt) \evalarrow (\vb, \vgtwo) \OrDynErrorDiverging\\\\
   \vb \eqname \nvbool(\True)\\
   \vg \eqdef \ordered{\vgone}{\asldata}{\vgtwo}
 }{
-  \evalexpr{\env, \EATC(\veone, \vt)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \EATC(\veone, \vt)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \and
 \inferrule[error]{
-  \evalexpr{\env, \veone} \evalarrow \Normal((\vv, \Ignore), \Ignore)\\
+  \evalexpr{\env, \veone} \evalarrow \ResultExpr((\vv, \Ignore), \Ignore)\\
   \isvaloftype(\env, \vv, \vt) \evalarrow (\vb, \Ignore)\\
   \vb \eqname \nvbool(\False)
 }{
@@ -2590,10 +2597,17 @@ will never occur, but it is still classified as a \dynamicerrorterm{}.
 The relation
 \[
   \isvaloftype(\overname{\envs}{\env} \aslsep \overname{\vals}{\vv} \aslsep \overname{\ty}{\vt}) \;\aslrel\;
-  (\overname{\Bool}{\vb} \times \overname{\XGraphs}{\vg}) \cup \overname{\TDynError}{\DynErrorConfig}
+  \left(
+  \begin{array}{ll}
+  (\overname{\Bool}{\vb} \times \overname{\XGraphs}{\vg}) & \cup \\
+  \overname{\TDynError}{\DynErrorConfig} & \cup \\
+  \overname{\TDiverging}{\DivergingConfig} & \\
+  \end{array}
+  \right)
 \]
 tests whether the value $\vv$ can be stored in a variable of type $\vt$ in the environment $\env$,
-resulting in a Boolean value $\vb$ and execution graph $\vg$ or a dynamic error.
+resulting in a Boolean value $\vb$ and execution graph $\vg$.
+\ProseOtherwiseDynamicErrorOrDiverging
 
 This relation is used in the context of a asserted type conversion,
 which means the typechecker rule \TypingRuleRef{ATC} was already applied,
@@ -2602,7 +2616,8 @@ does not type-satisfy $\vt$. The semantics takes this into account and
 only returns \False\ in cases where dynamic information is required.
 
 Recall that the $\vt$ is the result of $\annotatetype$, which ensures that
-all sub-expressions appearing in $\vt$ are side-effect-free.
+all \\
+sub-expressions appearing in $\vt$ are side-effect-free.
 
 \ExampleDef{Checking Whether a Value Belongs to a Type}
 In \listingref{semantics-variousatcs},
@@ -2632,7 +2647,7 @@ of the type \verb|integer{4, 5, 6}| fails.
     \item $\vt$ has the structure of a well-constrained integer with constraints $\vc_{1..k}$;
     \item $\vv$ is the \nativevalue\  integer for $n$;
     \item the evaluation of every constraint $\vc_i$ with $n$ in environment $\env$
-    yields a Boolean value $\vb_i$ and an execution graph $\vg_i$\ProseOrError;
+          yields a Boolean value $\vb_i$ and an execution graph $\vg_i$\ProseOrDynErrorDiverging;
     \item $\vb$ is the Boolean disjunction of all Boolean values $\vb_i$, for $i=1..k$;
     \item $\vg$ is the parallel composition of all execution graphs $\vg_i$, for $i=1..k$;
   \end{itemize}
@@ -2641,7 +2656,7 @@ of the type \verb|integer{4, 5, 6}| fails.
   \begin{itemize}
     \item $\vt$ is a bitvector type with expression $\ve$, that is, $\TBits(\ve, \Ignore)$;
     \item $\vv$ is a native bitvector value for the sequence of bits $\vbits$, that is, \\ $\nvbitvector(\vbits)$;
-    \item evaluating the side-effect-free expression $\ve$ in $\env$ yields $\Normal(\vvp, \vg)$\ProseOrError;
+    \item evaluating the side-effect-free expression $\ve$ in $\env$ yields $\ResultExpr(\vvp, \vg)$\ProseOrDynErrorDiverging;
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $\vvp$ is equal to the number of bits in $\vbits$}.
   \end{itemize}
 
@@ -2650,8 +2665,8 @@ of the type \verb|integer{4, 5, 6}| fails.
     \item $\vt$ is a tuple with types $\vt_i$, for $i=1..k$;
     \item the value at every index $i=1..k$ of $\vv$ is $\vu_i$, for $i=1..k$,
     \item the evaluation of $\isvaloftype$ for every value $\vu_i$
-    and corresponding type $\vt_i$, for $i=1..k$,
-    results in a Boolean $\vb_i$ and execution graph $\vg_i$\ProseOrError;
+          and corresponding type $\vt_i$, for $i=1..k$,
+          results in a Boolean $\vb_i$ and execution graph $\vg_i$\ProseOrDynErrorDiverging;
     \item $\vb$ is the Boolean conjunction of all Boolean values $\vb_i$, for $i=1..k$;
     \item $\vg$ is the parallel composition of all execution graphs $\vg_i$, for $i=1..k$;
     of the constraints.
@@ -2676,7 +2691,7 @@ of the type \verb|integer{4, 5, 6}| fails.
 \begin{mathpar}
 \inferrule[int\_wellconstrained]{
   \vv \eqname \nvint(n)\\
-  i=1..k: \isconstaintsat(\env, \vc_i, n) \evalarrow (\vb_i, \vg_i) \OrDynError\\\\
+  i=1..k: \isconstaintsat(\env, \vc_i, n) \evalarrow (\vb_i, \vg_i) \OrDynErrorDiverging\\\\
   \vb \eqdef \bigvee_{i=1}^k \vb_i\\
   \vg \eqdef \parallel_{i=1}^k \vg_i
 }{
@@ -2686,7 +2701,7 @@ of the type \verb|integer{4, 5, 6}| fails.
 
 \begin{mathpar}
 \inferrule[bits]{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\vvp, \vg) \OrDynError
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\vvp, \vg) \OrDynErrorDiverging
 }{
   \isvaloftype(\env, \overname{\nvbitvector(\vbits)}{\vv}, \overname{\TBits(\ve, \Ignore)}{\vt}) \evalarrow
   (\overname{\vvp = |\vbits|}{\vb}, \vg)
@@ -2696,7 +2711,7 @@ of the type \verb|integer{4, 5, 6}| fails.
 \begin{mathpar}
 \inferrule[tuple]{
   i=1..k: \getindex(i, \vv) \evalarrow \vu_i\\
-  i=1..k: \isvaloftype(\env, \vu_i, \vt_i) \evalarrow (\vb_i, \vg_i) \OrDynError\\\\
+  i=1..k: \isvaloftype(\env, \vu_i, \vt_i) \evalarrow (\vb_i, \vg_i) \OrDynErrorDiverging\\\\
   \vb \eqdef \bigwedge_{i=1}^k \vb_i \\
   \vg \eqdef\ \parallelcomp_{i=1}^k \vg_i
 }{
@@ -2739,7 +2754,7 @@ See \ExampleRef{Checking Whether a Value Belongs to a Type}.
   \begin{itemize}
     \item $\vc$ is a constraint for the expression $\ve$;
     \item evaluating the side-effect-free expression $\ve$ in $\env$ yields the \concurrentnativevalue\ given
-          by the native integer value for $m$ and the \executiongraph\ $\vg$\ProseOrError.
+          by the native integer value for $m$ and the \executiongraph\ $\vg$\ProseOrDynErrorDiverging.
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $m$ is equal to $n$}.
   \end{itemize}
 
@@ -2747,9 +2762,9 @@ See \ExampleRef{Checking Whether a Value Belongs to a Type}.
   \begin{itemize}
     \item $\vc$ is a constraint for the expressions $\veone$ and $\vetwo$;
     \item evaluating the side-effect-free expression $\veone$ in $\env$ yields the \concurrentnativevalue\ given
-          by the native integer value for $a$ and the \executiongraph\ $\vgone$\ProseOrError.
+          by the native integer value for $a$ and the \executiongraph\ $\vgone$\ProseOrDynErrorDiverging.
     \item evaluating the side-effect-free expression $\vetwo$ in $\env$ yields the \concurrentnativevalue\ given
-          by the native integer value for $b$ and the \executiongraph\ $\vgtwo$\ProseOrError.
+          by the native integer value for $b$ and the \executiongraph\ $\vgtwo$\ProseOrDynErrorDiverging.
     \item \Proseeqdef{$\vb$}{$\True$ if and only if $n$ is greater or equal to $a$ and less than or equal to $b$};
     \item \Proseeqdef{$\vg$}{the parallel composition of $\vgone$ and $\vgtwo$}.
   \end{itemize}
@@ -2761,7 +2776,7 @@ that expressions appearing in types are all side-effect-free.
 
 \begin{mathpar}
 \inferrule[Constraint\_Exact\_Sat]{
-  \evalexprsef{\env, \ve} \evalarrow (\nvint(m), \vg) \OrDynError
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\nvint(m), \vg) \OrDynErrorDiverging
 }{
   \isconstaintsat(\env, \overname{\constraintexact(\ve)}{\vc}, n) \evalarrow (\overname{m = n}{\vb}, \vg)
 }
@@ -2769,8 +2784,8 @@ that expressions appearing in types are all side-effect-free.
 
 \begin{mathpar}
 \inferrule[Constraint\_Range\_Sat]{
-  \evalexprsef{\env, \veone} \evalarrow (\nvint(a), \vgone) \OrDynError\\\\
-  \evalexprsef{\env, \vetwo} \evalarrow (\nvint(b), \vgtwo) \OrDynError\\\\
+  \evalexprsef{\env, \veone} \evalarrow \ResultExprSEF(\nvint(a), \vgone) \OrDynErrorDiverging\\\\
+  \evalexprsef{\env, \vetwo} \evalarrow \ResultExprSEF(\nvint(b), \vgtwo) \OrDynErrorDiverging\\\\
   \vb \eqdef \choice{a \leq n \land n \leq b}{\True}{\False}\\
   \vg \eqdef \vgone \parallelcomp \vgtwo
 }{
@@ -2875,20 +2890,21 @@ succeed.
 \begin{itemize}
   \item $\ve$ denotes a pattern expression, $\EPattern(\ve, \vp)$;
   \item evaluating the expression $\ve$ in an environment $\env$ results in \\
-  $\Normal((\vvone, \vgone), \newenv)$\ProseOrAbnormal;
+  $\ResultExpr((\vvone, \vgone), \newenv)$\ProseOrAbnormal;
   \item evaluating whether the pattern $\vp$ matches the value $\vvone$ in $\env$
-  results in $\Normal(\vv, \vgtwo)$ where is a native Boolean that determines
-  whether the is indeed a match;
+        results in \\
+        $\ResultPattern(\vv, \vgtwo)$\ProseOrAbnormal,
+        where $vv$ is a native Boolean that determines whether there is indeed a match;
   \item $\vg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge.
 \end{itemize}
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vvone, \vgone), \newenv) \OrAbnormal\\
-  \evalpattern{\env, \vvone, \vp} \evalarrow \Normal(\vv, \vgtwo)\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vvone, \vgone), \newenv) \OrAbnormal\\\\
+  \evalpattern{\env, \vvone, \vp} \evalarrow \ResultPattern(\vv, \vgtwo) \OrAbnormal\\\\
   \vg \eqdef \ordered{\vgone}{\asldata}{\vgtwo}
 }{
-  \evalexpr{\env, \EPattern(\ve, \vp)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \EPattern(\ve, \vp)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalEPatternBegin}{\EvalEPatternEnd}{../Interpreter.ml}
@@ -3006,7 +3022,7 @@ and how to obtain an arbitrary enumeration-indexed array, \texttt{enum\_array}.
   \dynamicdomain(\env, \vt) \neq \emptyset\\
   \vv \in \dynamicdomain(\env, \vt)
 }{
-  \evalexpr{\env, \overname{\EArbitrary (\vt)}{\ve}} \evalarrow \Normal((\vv, \overname{\emptygraph}{\vg}), \overname{\env}{\newenv})
+  \evalexpr{\env, \overname{\EArbitrary (\vt)}{\ve}} \evalarrow \ResultExpr((\vv, \overname{\emptygraph}{\vg}), \overname{\env}{\newenv})
 }
 \end{mathpar}
 
@@ -3198,21 +3214,22 @@ $\nvrecord{\va\mapsto\nvint(3), \vb\mapsto\nvint(42)}$.
 \item the names of the fields are $\id_{1..k}$;
 \item the expressions associated with the fields are $\ve_{1..k}$;
 \item evaluating the expressions of $\fields$ in order yields \\
-      $\Normal((\vvfields,\vg), \newenv)$\ProseOrAbnormal;
+      $\ResultExprList((\vvfields,\vg), \newenv)$\ProseOrAbnormal;
 \item $\vvfields$ is a list of \nativevalues\ $\vv_{1..k}$;
 \item $\vv$ is the native record that maps $\id_i$ to $\vv_i$, for $i=1..k$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \efields \eqname [i=1..k: (\id_i, \ve_i)]\\
   \names \eqdef \id_{1..k} \\
   \fields \eqdef \ve_{1..k} \\
-  \evalexprlist{\env, \fields} \evalarrow \Normal((\vvfields,\vg), \newenv)  \OrAbnormal\\
+  \evalexprlist{\env, \fields} \evalarrow \ResultExprList((\vvfields,\vg), \newenv)  \OrAbnormal\\
   \vvfields \eqname \vv_{1..k}\\
   \vv \eqdef \nvrecord{\{i=1..k: \id_i\mapsto \vv_i\}}
 }{
-  \evalexpr{\env, \ERecord(\Ignore, \efields)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \ERecord(\Ignore, \efields)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalERecordBegin}{\EvalERecordEnd}{../Interpreter.ml}
@@ -3299,16 +3316,17 @@ the expression \texttt{(3, Return42())} evaluates to the value \texttt{(3, 42)}.
 \AllApply
 \begin{itemize}
   \item $\ve$ denotes a tuple expression, $\ETuple(\elist)$;
-  \item the evaluation of $\elist$ in $\env$ is $\Normal((\vlist, \vg), \newenv)$\ProseOrAbnormal;
+  \item the evaluation of $\elist$ in $\env$ is $\ResultExprList((\vlist, \vg), \newenv)$\ProseOrAbnormal;
   \item $\vv$ is the native vector constructed from the values in $\vlist$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexprlist{\env, \elist} \evalarrow \Normal((\vlist, \vg), \newenv) \OrAbnormal\\
+  \evalexprlist{\env, \elist} \evalarrow \ResultExprList((\vlist, \vg), \newenv) \OrAbnormal\\
   \vv \eqdef \nvvector{\vlist}
 }{
-  \evalexpr{\env, \ETuple(\elist)} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexpr{\env, \ETuple(\elist)} \evalarrow \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalETupleBegin}{\EvalETupleEnd}{../Interpreter.ml}
@@ -3369,9 +3387,9 @@ which evaluates to
 \begin{itemize}
   \item $\ve$ is an array construction expression with length expression $\elength$ and value expression $\evalue$,
         that is, $\EArray\{\EArrayLength: \elength, \EArrayValue: \evalue\}$;
-  \item evaluating the expression $\evalue$ in $\env$ yields $\Normal((\vvalue, \vgone), \newenv)$\ProseOrAbnormal;
+  \item evaluating the expression $\evalue$ in $\env$ yields $\ResultExpr((\vvalue, \vgone), \newenv)$\ProseOrAbnormal;
   \item evaluating the side-effect-free expression $\elength$ in $\env$ yields \\
-        $\Normal((\vlength, \vgtwo))$\ProseOrError;
+        $\ResultExprSEF((\vlength, \vgtwo))$\ProseOrDynErrorDiverging;
   \item $\vlength$ is a native integer value for $\nlength$;
   \item checking that $\nlength$ is non-negative yields $\True$\ProseTerminateAs{\NegativeArrayLength};
   \item define $\vv$ as the native vector of length $\nlength$ where each position has the value $\vvalue$;
@@ -3381,15 +3399,19 @@ which evaluates to
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \evalue} \evalarrow \Normal((\vvalue, \vgone), \newenv) \OrAbnormal\\\\
-  \evalexprsef{\env, \elength} \evalarrow \Normal((\vlength, \vgtwo)) \OrDynError\\\\
+  \evalexpr{\env, \evalue} \evalarrow \ResultExpr((\vvalue, \vgone), \newenv) \OrAbnormal\\\\
+  \evalexprsef{\env, \elength} \evalarrow \ResultExprSEF((\vlength, \vgtwo)) \OrDynErrorDiverging\\\\
   \vlength \eqname \nvint(\nlength)\\
   \checktrans{\nlength \geq 0}{\NegativeArrayLength} \checktransarrow \True \OrDynError\\\\
   \vv \eqdef \nvvector{i=1..\nlength: \vvalue}\\
   \vg \eqdef \vgone \parallelcomp \vgtwo
 }{
-  \evalexpr{\env, \overname{\EArray\{\EArrayLength: \elength, \EArrayValue: \evalue\}}{\ve}} \evalarrow
-  \Normal((\vv, \vg), \newenv)
+  {
+  \begin{array}{r}
+  \evalexpr{\env, \overname{\EArray\{\EArrayLength: \elength, \EArrayValue: \evalue\}}{\ve}} \evalarrow \\
+  \ResultExpr((\vv, \vg), \newenv)
+  \end{array}
+  }
 }
 \end{mathpar}
 \CodeSubsection{\EvalEArrayBegin}{\EvalEArrayEnd}{../Typing.ml}
@@ -3411,20 +3433,20 @@ which evaluates to
         list of labels $\vlabels$ and value expression $\evalue$,
         that is, \\
         $\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \evalue\}$;
-  \item evaluating the expression $\evalue$ in $\env$ yields $\Normal((\vvalue, \vg), \newenv)$\ProseOrAbnormal;
+  \item evaluating the expression $\evalue$ in $\env$ yields $\ResultExpr((\vvalue, \vg), \newenv)$\ProseOrAbnormal;
   \item \Proseeqdef{$\vv$}{the native record mapping each label $\vl\in\vlabels$ to $\vvalue$}.
 \end{itemize}
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \evalue} \evalarrow \Normal((\vvalue, \vg), \newenv) \OrAbnormal\\\\
+  \evalexpr{\env, \evalue} \evalarrow \ResultExpr((\vvalue, \vg), \newenv) \OrAbnormal\\\\
   \vv \eqdef \nvrecord{\vl\in\vlabels: [\vl\mapsto \vvalue]}
 }{
   {
   \begin{array}{r}
     \evalexpr{\env, \overname{\EEnumArray\{\EArrayLabels: \vlabels, \EArrayValue: \evalue\}}{\ve}} \evalarrow\\
-    \Normal((\vv, \vg), \newenv)
+    \ResultExpr((\vv, \vg), \newenv)
   \end{array}
   }
 }
@@ -3440,13 +3462,17 @@ and $\vses$ is \readonly{}.
 
 \subsection{Semantics}
 \SemanticsRuleDef{ESideEffectFreeExpr}
-\ProseParagraph
 The helper relation
 \hypertarget{def-evalexprsef}{}
 \[
   \evalexprsef{\overname{\envs}{\env} \aslsep \overname{\expr}{\ve}} \;\aslrel\;
-  \Normal(\overname{\vals}{\vv}\aslsep\overname{\XGraphs}{\vg}) \cup
-  \overname{\TDynError}{\DynErrorConfig}
+  \left(
+  \begin{array}{ll}
+  \ResultExprSEF(\overname{\vals}{\vv}\aslsep\overname{\XGraphs}{\vg}) & \cup \\
+  \overname{\TDynError}{\DynErrorConfig} & \cup \\
+  \overname{\TDiverging}{\DivergingConfig} & \\
+  \end{array}
+  \right)
 \]
 specializes the expression evaluation relation for side-effect-free expressions
 by omitting throwing configurations as possible output configurations.
@@ -3454,14 +3480,18 @@ by omitting throwing configurations as possible output configurations.
 \ExampleDef{Evaluating a Side-effect-free Expression}
 Evaluating the literal expression $\lint(1)$ in any environment $\env$,
 yields \\
-$\Normal(\nvint(1), \emptygraph)$.
+$\ResultExprSEF(\nvint(1), \emptygraph)$.
+
+\ProseParagraph
+Evaluating $\ve$ in $\env$ yields the configuration $\ResultExpr((\vv,\vg), \env)$\ProseOrDynErrorDiverging,
+which is then converted to the configuration $\ResultExprSEF(\vv, \vg)$.
 
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vv,\vg), \env) \OrDynError
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vv,\vg), \env) \OrDynErrorDiverging
 }{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\vv, \vg)
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\vv, \vg)
 }
 \end{mathpar}
 Notice that the output configuration does not contain an environment,
@@ -3473,13 +3503,19 @@ since side-effect-free expressions do not modify the environment.
 The relation
 \[
   \evalexprlist{\overname{\envs}{\env} \aslsep \overname{\expr^*}{\vle}} \;\aslrel\;
-  \Normal((\overname{\vals^*}{\vv} \times \overname{\XGraphs}{\vg})\aslsep \overname{\envs}{\newenv}) \cup
-  \overname{\TThrowing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
+  \left(
+  \begin{array}{ll}
+  \ResultExprList((\overname{\vals^*}{\vv} \times \overname{\XGraphs}{\vg})\aslsep \overname{\envs}{\newenv}) & \cup\\
+  \overname{\TThrowing}{\ThrowingConfig}    & \cup\\
+  \overname{\TDynError}{\DynErrorConfig}    & \cup\\
+  \overname{\TDiverging}{\DivergingConfig}  & \\
+  \end{array}
+  \right)
 \]
 evaluates the list of expressions $\vle$ in left-to-right order in the initial environment $\env$
-and returns the resulting value $\vv$, the parallel composition of the execution graphs
+and returns the resulting list of values $\vv$, the parallel composition of the execution graphs
 generated from evaluating each expression, and the new environment $\newenv$.
-If the evaluation of any expression terminates abnormally then the abnormal configuration is returned.
+\ProseOtherwiseAbnormal
 
 \ExampleDef{Evaluating a List of Expressions}
 In \listingref{semantics-erecord},
@@ -3501,8 +3537,9 @@ the list of values $[\nvint(3), \nvint(42)]$.
   \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vle$ is a \Proselist{$\ve$}{$\vle1$};
-    \item \Proseevalexpr{$\env$}{$\ve$}{\\ $\Normal((\vvone, \vgone), \envone)$}\ProseOrAbnormal;
-    \item evaluating the list of expressions $\vle1$ in the environment $\envone$ yields $\Normal((\vvs, \vgtwo), \envtwo)$\ProseOrAbnormal;
+    \item \Proseevalexpr{$\env$}{$\ve$}{\\ $\ResultExpr((\vvone, \vgone), \envone)$}\ProseOrAbnormal;
+    \item evaluating the list of expressions $\vle1$ in the environment $\envone$ yields \\
+          $\ResultExprList((\vvs, \vgtwo), \envtwo)$\ProseOrAbnormal;
     \item \Proseeqdef{$\vg$}{the parallel composition of $\vgone$ and $\vgtwo$};
     \item \Proseeqdef{$\vv$}{the list with \head{} $\vvone$ and \tail{} $\vvs$}.
   \end{itemize}
@@ -3513,18 +3550,18 @@ the list of values $[\nvint(3), \nvint(42)]$.
 \inferrule[empty]{}
 {
   \evalexprlist{\env, \overname{\emptylist}{\vle}} \evalarrow
-  \Normal((\overname{\emptylist}{\vv}, \overname{\emptygraph}{\vg}), \overname{\env}{\newenv})
+  \ResultExprList((\overname{\emptylist}{\vv}, \overname{\emptygraph}{\vg}), \overname{\env}{\newenv})
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[non\_empty]{
   \vle = [\ve] \concat \vle1\\
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vvone, \vgone), \envone) \OrAbnormal\\\\
-  \evalexprlist{\envone, \vle1} \evalarrow \Normal((\vvs, \vgtwo), \newenv) \OrAbnormal\\\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vvone, \vgone), \envone) \OrAbnormal\\\\
+  \evalexprlist{\envone, \vle1} \evalarrow \ResultExprList((\vvs, \vgtwo), \newenv) \OrAbnormal\\\\
   \vg \eqdef \vgone \parallelcomp \vgtwo \\
   \vv \eqdef [\vvone] \concat \vvs
 }{
-  \evalexprlist{\env, \vle} \evalarrow \Normal((\vv, \vg), \newenv)
+  \evalexprlist{\env, \vle} \evalarrow \ResultExprList((\vv, \vg), \newenv)
 }
 \end{mathpar}

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -798,11 +798,18 @@ The relation
 \hypertarget{def-evalglobals}{}
 \[
   \evalglobals(\overname{\decl^*}{\vdecls}, (\overname{\overname{\envs}{\env} \times \overname{\XGraphs}{\vgone}}{\envm}))
-  \;\aslrel\; \overname{(\envs \times \XGraphs)}{C} \cup
-  \overname{\TThrowing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
+  \;\aslrel\;
+  \left(
+  \begin{array}{cl}
+  \overname{(\envs \times \XGraphs)}{C} & \cup\\
+  \overname{\TThrowing}{\ThrowingConfig} & \cup\\
+  \overname{\TDynError}{\DynErrorConfig} & \cup\\
+  \overname{\TDiverging}{\DivergingConfig} &
+  \end{array}
+  \right)
 \]
 updates the input environment and execution graph by initializing the global storage declarations.
-Otherwise, the evaluation terminates abnormally.
+\ProseOtherwiseAbnormal
 
 \ExampleDef{Evaluating a List of Global Declarations}
 Evaluating the global storage declarations in \listingref{EvalGlobals}
@@ -839,7 +846,7 @@ before having the chance to evaluate \verb|main|.
     \item $d$ is the AST node for declaring a global storage element with initial value $\ve$,
           name $\name$, and type $\vt$;
     \item $\envm$ is the environment-execution graph pair $(\env, \vgone)$;
-    \item the evaluation of the expression $\ve$ in $\env$ yields $\Normal((\vv, \vgtwo), \envtwo)$\ProseOrAbnormal;
+    \item the evaluation of the expression $\ve$ in $\env$ yields $\ResultExpr((\vv, \vgtwo), \envtwo)$\ProseOrAbnormal;
     \item declaring the global $\name$ with value $\vv$ in $\envtwo$ gives $\envthree$;
     \item evaluating the remaining global declarations $\vdecls'$ with the environment $\envthree$ and the execution graph
           that is the ordered composition of $\vgone$ and $\vgtwo$ with the $\aslpo$ label gives $C$;
@@ -858,7 +865,7 @@ before having the chance to evaluate \verb|main|.
 \inferrule[non\_empty]{
   \vd \eqname \DGlobalStorage(\{ \GDinitialvalue:\langle\ve\rangle, \GDname:\name, \ldots \})\\
   \envm \eqname (\env, \vgone)\\
-  \evalexpr{ \env, \ve} \evalarrow \Normal((\vv,\vgtwo), \envtwo) \OrAbnormal\\\\
+  \evalexpr{ \env, \ve} \evalarrow \ResultExpr((\vv,\vgtwo), \envtwo) \OrAbnormal\\\\
   \declareglobal(\name, \vv, \envtwo) \evalarrow \envthree\\
   \evalglobals(\vdecls', (\envthree, \ordered{\vgone}{\aslpo}{ \vgtwo })) \evalarrow C
 }{

--- a/asllib/doc/LocalStorageDeclarations.tex
+++ b/asllib/doc/LocalStorageDeclarations.tex
@@ -52,15 +52,15 @@ static environment.
     \overname{\localdeclitem}{\ldi} \aslsep
     \overname{\overname{\vals}{\vv}\times\overname{\XGraphs}{\vgone}}{\vm}
     } \;\aslrel\;
-    \Normal(\overname{\XGraphs}{\newg}, \overname{\envs}{\newenv})
+    \ResultLDI(\overname{\XGraphs}{\newg}, \overname{\envs}{\newenv})
 \]
 evaluates a \localdeclarationitem\ $\ldi$ in an environment
 $\env$ with an initialization value $\vm$.
 That is, the right-hand side of the declaration
 has already been evaluated, yielding $\vm$ (see, for example, \SemanticsRuleRef{SDeclSome}).
 Evaluation of the local variables $\ldi$
-in an environment $\env$ is either $\Normal(\vg, \newenv)$
-or an abnormal configuration.
+in an environment $\env$ is $\ResultLDI(\vg, \newenv)$.
+\ProseOtherwiseAbnormal
 
 While there are three different categories of local storage elements ---
 constants, mutable variables (declared via \texttt{var}), and immutable variables (declared via \texttt{let}) ---
@@ -301,7 +301,7 @@ to the evaluation of \texttt{3} in $\env$.
   \declarelocalidentifier(\env, \vx, \vv)\evalarrow(\newenv, \vgtwo)\\
   \newg \eqdef \ordered{\vgone}{\asldata}{\vgtwo}
 }{
-  \evallocaldecl{\env, \LDIVar(\vx), \vm} \evalarrow \Normal(\newg, \newenv)
+  \evallocaldecl{\env, \LDIVar(\vx), \vm} \evalarrow \ResultLDI(\newg, \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalLDVarBegin}{\EvalLDVarEnd}{../Interpreter.ml}
@@ -341,8 +341,12 @@ to the evaluation of \texttt{3} in $\env$.
   }\\\\
   \newtenv \eqdef \newtenv_0
 }{
+  {
+  \begin{array}{r}
   \annotatelocaldeclitem(\tenv, \tty, \ldk, \veopt, \overname{\LDITuple(\vids_{1..k})}{\ldi}) \typearrow \\
   \newtenv
+  \end{array}
+  }
 }
 \end{mathpar}
 \CodeSubsection{\LDTupleBegin}{\LDTupleEnd}{../Typing.ml}
@@ -387,7 +391,7 @@ evaluation of \texttt{3} in $\env$.
 The helper semantic relation
 \[
     \ldituplefolder(\overname{\envs}{\env} \aslsep \overname{\identifier^*}{\vids} \aslsep \overname{(\vals \times \XGraphs)^*}{\liv}) \;\aslrel\;
-     \Normal(\overname{\XGraphs}{\vg} \aslsep \overname{\envs}{\newenv})
+     \ResultLDI(\overname{\XGraphs}{\vg} \aslsep \overname{\envs}{\newenv})
 \]
 is defined as follows.
 
@@ -408,7 +412,7 @@ See \ExampleRef{Evaluation of Tuple Declarations}.
     \item $\vids$ is a list with \head{} $\id$ and \tail{} $\vids'$;
     \item $\liv$ is a list with \head{} $\vm$ and \tail{} $\liv'$;
     \item applying $\declarelocalidentifier$ to $\id$ and $\vv$ in $\env$ yields $(\envone, \vgtwo)$;
-    \item applying $\ldituplefolder$ to $\vids'$ and $\liv'$ in $\envone$ yields $\Normal(\vgthree, \newenv)$;
+    \item applying $\ldituplefolder$ to $\vids'$ and $\liv'$ in $\envone$ yields $\ResultLDI(\vgthree, \newenv)$;
     \item \Proseeqdef{$\newg$}{the parallel composition of the ordered composition of $\vgone$ and $\vgtwo$
           with the $\asldata$ edge, and $\vgthree$}.
   \end{itemize}
@@ -418,7 +422,7 @@ See \ExampleRef{Evaluation of Tuple Declarations}.
 \begin{mathpar}
 \inferrule[empty]{}
 {
-  \ldituplefolder(\env, \overname{\emptylist}{\vids}, \overname{\emptylist}{\liv}) \evalarrow \Normal(\emptygraph, \env)
+  \ldituplefolder(\env, \overname{\emptylist}{\vids}, \overname{\emptylist}{\liv}) \evalarrow \ResultLDI(\emptygraph, \env)
 }
 \end{mathpar}
 
@@ -428,9 +432,9 @@ See \ExampleRef{Evaluation of Tuple Declarations}.
   \liv = [\vm] \concat \liv'\\
   \vm \eqname (\vv, \vgone)\\\\
   \declarelocalidentifier(\env, \id, \vv) \evalarrow (\envone, \vgtwo)\\
-  \ldituplefolder(\envone, \vids', \liv') \evalarrow \Normal(\vgthree, \newenv)\\
+  \ldituplefolder(\envone, \vids', \liv') \evalarrow \ResultLDI(\vgthree, \newenv)\\
   \newg \eqdef (\ordered{\vgone}{\asldata}{\vgtwo}) \parallelcomp \vgthree\\
 }{
-  \ldituplefolder(\env, \vids, \liv) \evalarrow \Normal(\newg, \newenv)
+  \ldituplefolder(\env, \vids, \liv) \evalarrow \ResultLDI(\newg, \newenv)
 }
 \end{mathpar}

--- a/asllib/doc/PatternMatching.tex
+++ b/asllib/doc/PatternMatching.tex
@@ -27,10 +27,16 @@ The relation
 \hypertarget{def-evalpattern}{}
 \[
   \evalpattern{\overname{\envs}{\env} \aslsep \overname{\vals}{\vv} \aslsep \overname{\pattern}{\vp}} \;\aslrel\;
-  \Normal(\overname{\tbool}{\vb}, \overname{\XGraphs}{\newg})
+  \left(
+  \begin{array}{ll}
+  \ResultPattern(\overname{\tbool}{\vb}, \overname{\XGraphs}{\newg}) & \cup\\
+  \overname{\TDynError}{\DynErrorConfig} & \cup\\
+  \overname{\TDiverging}{\DivergingConfig} &
+  \end{array}
+  \right)
 \]
 determines whether a value $\vv$ matches the pattern $\vp$ in an environment $\env$
-resulting in either $\Normal(\vb, \newg)$ or an abnormal configuration.
+resulting in either $\ResultPattern(\vb, \newg)$ or an abnormal configuration.
 
 The rest of this chapter defines the syntax, abstract syntax, typing rules,
 and semantics rules for the following kinds of patterns:
@@ -117,7 +123,7 @@ since \texttt{-} matches any value and \texttt{42} in particular.
 \begin{mathpar}
 \inferrule{}
 {
-  \evalpattern{\env, \Ignore, \PatternAll} \evalarrow \Normal(\nvbool(\True), \emptygraph)
+  \evalpattern{\env, \Ignore, \PatternAll} \evalarrow \ResultPattern(\nvbool(\True), \emptygraph)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPAllBegin}{\EvalPAllEnd}{../Interpreter.ml}
@@ -267,17 +273,17 @@ whereas \\
   \item $\vp$ is the condition corresponding to being equal to the
     side-effect-free expression $\ve$, $\PatternSingle(\ve)$;
   \item the side-effect-free evaluation of $\ve$ in
-    environment $\env$ is \\ $\Normal(\vvone, \newg)$\ProseOrError;
+    environment $\env$ is \\ $\ResultExprSEF(\vvone, \newg)$\ProseOrDynErrorDiverging;
   \item $\vb$ is the Boolean value corresponding to whether $\vv$
     is equal to $\vvone$.
 \end{itemize}
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\vvone, \newg) \OrDynError\\\\
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\vvone, \newg) \OrDynErrorDiverging\\\\
   \binoprel(\EQOP, \vv, \vvone) \evalarrow \vb
 }{
-  \evalpattern{\env, \vv, \overname{\PatternSingle(\ve)}{\vp}} \evalarrow \Normal(\vb, \newg)
+  \evalpattern{\env, \vv, \overname{\PatternSingle(\ve)}{\vp}} \evalarrow \ResultPattern(\vb, \newg)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPSingleBegin}{\EvalPSingleEnd}{../Interpreter.ml}
@@ -369,8 +375,8 @@ range given by \texttt{3..42}.
   \item $\vp$ is the condition corresponding to being greater than or equal
     to $\veone$, and lesser or equal to $\vetwo$, that is, $\PatternRange(\veone, \vetwo)$;
   \item $\veone$ and $\vetwo$ are side-effect-free expressions;
-  \item the side-effect-free evaluation of $\veone$ in $\env$ is $\Normal(\vvone, \vgone)$\ProseOrError;
-  \item the side-effect-free evaluation of $\vetwo$ in $\env$ is $\Normal(\vvtwo, \vgtwo)$\ProseOrError;
+  \item the side-effect-free evaluation of $\veone$ in $\env$ is $\ResultExprSEF(\vvone, \vgone)$\ProseOrDynErrorDiverging;
+  \item the side-effect-free evaluation of $\vetwo$ in $\env$ is $\ResultExprSEF(\vvtwo, \vgtwo)$\ProseOrDynErrorDiverging;
   \item $\vbone$ is the Boolean value corresponding to whether
     $\vv$ is greater than or equal to $\vvone$;
     \item $\vbtwo$ is the Boolean value corresponding to whether
@@ -382,14 +388,14 @@ range given by \texttt{3..42}.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexprsef{\env, \veone} \evalarrow \Normal(\vvone, \vgone) \OrDynError\\\\
+  \evalexprsef{\env, \veone} \evalarrow \ResultExprSEF(\vvone, \vgone) \OrDynErrorDiverging\\\\
   \binoprel(\GEQ, \vv, \vvone) \evalarrow \vbone\\
-  \evalexprsef{\env, \veone} \evalarrow \Normal(\vvtwo, \vgtwo) \OrDynError\\\\
+  \evalexprsef{\env, \veone} \evalarrow \ResultExprSEF(\vvtwo, \vgtwo) \OrDynErrorDiverging\\\\
   \binoprel(\LEQ, \vv, \vvtwo) \evalarrow \vbtwo\\
   \binoprel(\BAND, \vbone, \vbtwo) \evalarrow \vb\\
   \newg \eqdef \vgone \parallelcomp \vgtwo
 }{
-  \evalpattern{\env, \vv, \PatternRange(\veone, \vetwo)} \evalarrow \Normal(\vb, \newg)
+  \evalpattern{\env, \vv, \PatternRange(\veone, \vetwo)} \evalarrow \ResultPattern(\vb, \newg)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPRangeBegin}{\EvalPRangeEnd}{../Interpreter.ml}
@@ -469,20 +475,21 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{42} is not less
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item $\vp$ is the condition corresponding to being less than or equal
-    to the side-effect-free expression $\ve$, $\PatternLeq(\ve)$;
-  \item the side-effect-free evaluation of $\ve$ is either
-  $\Normal(\vvone, \newg)$\ProseOrError;
-  \item $\vb$ is the Boolean value corresponding to whether $\vv$
-    is less than or equal to $\vvone$.
+\item $\vp$ is the condition corresponding to being less than or equal
+      to the side-effect-free expression $\ve$, $\PatternLeq(\ve)$;
+\item the side-effect-free evaluation of $\ve$ is
+      $\ResultExprSEF(\vvone, \newg)$\ProseOrDynErrorDiverging;
+\item $\vb$ is the Boolean value corresponding to whether $\vv$
+      is less than or equal to $\vvone$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\vvone, \newg) \OrDynError\\\\
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\vvone, \newg) \OrDynErrorDiverging\\\\
   \binoprel(\LEQ, \vv, \vvone) \evalarrow \vb
 }{
-  \evalpattern{\env, \vv, \PatternLeq(\ve)} \evalarrow \Normal(\vb, \newg)
+  \evalpattern{\env, \vv, \PatternLeq(\ve)} \evalarrow \ResultPattern(\vb, \newg)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPLeqBegin}{\EvalPLeqEnd}{../Interpreter.ml}
@@ -561,20 +568,21 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{3} is not great
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item $\vp$ is the condition corresponding to being greater than or equal
-    than the side-effect-free expression $\ve$, $\PatternGeq(\ve)$;
-  \item the side-effect-free evaluation of $\ve$ is either
-  $\Normal(\vvone, \newg)$\ProseOrError;
-  \item $\vb$ is the Boolean value corresponding to whether $\vv$
-    is greater than or equal to $\vvone$.
+\item $\vp$ is the condition corresponding to being greater than or equal
+      than the side-effect-free expression $\ve$, $\PatternGeq(\ve)$;
+\item the side-effect-free evaluation of $\ve$ is either
+      $\ResultExprSEF(\vvone, \newg)$\ProseOrDynErrorDiverging;
+\item $\vb$ is the Boolean value corresponding to whether $\vv$
+      is greater than or equal to $\vvone$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\vvone, \newg) \OrDynError\\\\
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\vvone, \newg) \OrDynErrorDiverging\\\\
   \binoprel(\GEQ, \vv, \vvone) \evalarrow \vb
 }{
-  \evalpattern{\env, \vv, \PatternGeq(\ve)} \evalarrow \Normal(\vb, \newg)
+  \evalpattern{\env, \vv, \PatternGeq(\ve)} \evalarrow \ResultPattern(\vb, \newg)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPGeqBegin}{\EvalPGeqEnd}{../Interpreter.ml}
@@ -681,7 +689,7 @@ is defined by the following table:
 
 \begin{mathpar}
 \inferrule[empty]{}{
-  \evalpattern{\env, \overname{\nvbitvector(\emptylist)}{\vv}, \PatternMask(\emptylist)} \evalarrow \Normal(\True, \emptygraph)
+  \evalpattern{\env, \overname{\nvbitvector(\emptylist)}{\vv}, \PatternMask(\emptylist)} \evalarrow \ResultPattern(\True, \emptygraph)
 }
 \end{mathpar}
 
@@ -691,7 +699,7 @@ is defined by the following table:
   \vv = \nvbitvector(\vu_{1..n})\\
   \vb \eqdef \nvbool(\bigwedge_{i=1..n} \maskmatch(\vm_i, \vu_i))
 }{
-  \evalpattern{\env, \vv, \PatternMask(\vm)} \evalarrow \Normal(\vb, \emptygraph)
+  \evalpattern{\env, \vv, \PatternMask(\vm)} \evalarrow \ResultPattern(\vb, \emptygraph)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPMaskBegin}{\EvalPMaskEnd}{../Interpreter.ml}
@@ -774,21 +782,22 @@ the tuple of expression \texttt{(3, '1101010')} does not match the tuple of patt
   \item $\vp$ gives a list of patterns $\vps$ of length $k$, $\PatternTuple(\vps)$;
   \item $\vv$ gives a tuple of values $\vvs$ of length $k$;
   \item for all $1 \leq i \leq n$, $\vb_i$ is the evaluation result
-    of $\vp_i$ with respect to the value $\vv_i$ in
-    environment $\env$;
+        of $\vp_i$ with respect to the value $\vv_i$ in
+        environment $\env$\ProseOrDynErrorDiverging;
   \item $\vbs$ is the list of all $\vb_i$ for $1 \leq i \leq k$;
   \item $\vb$ is the conjunction of the Boolean values of $\vbs$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \vps \eqname \vp_{1..k}\\
   i=1..k: \getindex(i, \vv) \evalarrow \vvs_i\\
-  i=1..k: \evalpattern{\env, \vvs_i, \vp_i} \evalarrow \Normal(\nvbool(\vbs_i), \vg_i) \OrDynError\\\\
+  i=1..k: \evalpattern{\env, \vvs_i, \vp_i} \evalarrow \ResultPattern(\nvbool(\vbs_i), \vg_i) \OrDynErrorDiverging\\\\
   \vres \eqdef \nvbool(\bigwedge_{i=1..k} \vbs_i)\\
   \vg \eqdef \vg_1 \parallelcomp \ldots \parallelcomp \vg_k
 }{
-  \evalpattern{\env, \vv, \PatternTuple(\vps)} \evalarrow \Normal(\vres, \emptygraph)
+  \evalpattern{\env, \vv, \PatternTuple(\vps)} \evalarrow \ResultPattern(\vres, \emptygraph)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPTupleBegin}{\EvalPTupleEnd}{../Interpreter.ml}
@@ -899,19 +908,20 @@ any pattern in \verb|{3, 4}|.
 \begin{itemize}
   \item $\vp$ is a list of patterns, $\PatternAny(\vps)$;
   \item $\vps$ is $\vp_{1..k}$;
-  \item evaluating each pattern $\vp_i$ in $\env$ results in $\Normal(\nvbool(\vb_i), \vg_i)$\ProseOrAbnormal;
+  \item evaluating each pattern $\vp_i$ in $\env$ results in $\ResultPattern(\nvbool(\vb_i), \vg_i)$\ProseOrDynErrorDiverging;
   \item $\vb$ is the native Boolean which is the disjunction of $\vb_i$, for $i=1..k$;
   \item $\newg$ is the parallel composition of all execution graphs $\vg_i$, for $i=1..k$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
   \vps \eqname \vp_{1..k}\\
-  i=1..k : \evalpattern{\env, \vv, \vp_i} \evalarrow \Normal(\nvbool(\vb_i), \vg_i) \OrDynError\\\\
+  i=1..k : \evalpattern{\env, \vv, \vp_i} \evalarrow \ResultPattern(\nvbool(\vb_i), \vg_i) \OrDynErrorDiverging\\\\
   \vb \eqdef \nvbool(\bigvee_{i=1..k} \vb_i)\\
   \newg \eqdef \vg_1 \parallelcomp \ldots \parallelcomp \vg_k
 }{
-  \evalpattern{\env, \vv, \PatternAny(\vps)} \evalarrow \Normal(\vb, \newg)
+  \evalpattern{\env, \vv, \PatternAny(\vps)} \evalarrow \ResultPattern(\vb, \newg)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPAnyBegin}{\EvalPAnyEnd}{../Interpreter.ml}
@@ -962,18 +972,18 @@ whereas \texttt{match\_false} evaluates to \False, since \texttt{42} does match 
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item $\vp$ is a negation pattern, $\PatternNot(\vpone)$;
-  \item evaluating that pattern $\vpone$ in an environment $\env$ is \\
-  $\Normal(\vbone, \newg)$\ProseOrError;
-  \item $\vb$ is the Boolean negation of $\vbone$.
+\item $\vp$ is a negation pattern, $\PatternNot(\vpone)$;
+\item evaluating the pattern $\vpone$ in an environment $\env$ is \\
+      $\ResultPattern(\vbone, \newg)$\ProseOrDynErrorDiverging;
+\item $\vb$ is the Boolean negation of $\vbone$.
 \end{itemize}
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexprsef{\env, \vpone} \evalarrow \Normal(\vbone, \newg) \OrDynError\\\\
+  \evalexprsef{\env, \vpone} \evalarrow \ResultExprSEF(\vbone, \newg) \OrDynErrorDiverging\\\\
   \unoprel(\BNOT, \vbone) \evalarrow \vb
 }{
-  \evalpattern{\env, \vv, \PatternNot(\vpone)} \evalarrow \Normal(\vb, \newg)
+  \evalpattern{\env, \vv, \PatternNot(\vpone)} \evalarrow \ResultPattern(\vb, \newg)
 }
 \end{mathpar}
 \CodeSubsection{\EvalPNotBegin}{\EvalPNotEnd}{../Interpreter.ml}

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -23,24 +23,26 @@ of the ASL dynamic semantics appears in \chapref{FormalSystem} and \secref{seman
 
 \section{When Do ASL Specifications Have Meaning\label{sec:MeaningfulASLSpecifications}}
 The ASL dynamic semantics defined here assign meaning only to \emph{well-typed specifications}.
-That is, specifications for which the typechecker produces a static environment rather than
-a \typingerrorterm{}.
+More specifically, the semantics is only defined for a \typedast{} produced by the typechecker
+from some \untypedast{} (rather than a \typingerrorterm{}).
 Specifications that are not well-typed have no defined semantics.
 In the rest of this reference, we assume well-typed specifications.
 
-ASL admits non-determinism, for example via the \texttt{ARBITRARY} expression.
+ASL admits non-determinism, for example via the \ARBITRARY{} expression.
 This means that a given specification might have (potentially infinitely) many
-\hyperlink{def-derivationtree}{derivation trees}.
+(potentially infinite) \derivationtreesterm.
 
-An ASL specification is \emph{terminating} when \underline{all} of its derivation trees are finite.
+An ASL specification is \emph{terminating} when \underline{all} of its \derivationtreesterm{} are finite.
+An ASL specification is \emph{diverging} when \underline{some} of its \derivationtreesterm{} are
+infinite.
 
-Although ASL does not require specifications to terminate, the semantics defined in this
-reference assign meaning only to terminating specifications.
-A future version of this reference, will assign meaning to non-terminating specifications.
+\secref{Semantics of Diverging Specifications} explains how to interpret
+the ASL dynamic semantics rules to assign meaning to both terminating specifications
+and diverging specifications.
 
 \section{Basic Semantic Concepts}
-The ASL dynamic semantics are given by relations between \emph{semantic configurations},
-or \hyperlink{def-configuration}{\emph{semantic configurations}}~\cite{SemanticsWithApplicationsBook}, for short.
+The ASL dynamic semantics are given by relations between
+\hyperlink{def-configuration}{\emph{semantic configurations}}~\cite{SemanticsWithApplicationsBook}.
 We refer to relations between semantic configurations as \emph{semantic relations}.
 Semantic configurations encapsulate information needed to transition into other semantic configurations, such as:
 \begin{itemize}
@@ -55,7 +57,7 @@ These semantic rules are defined by induction over the typed AST.
 \paragraph{Execution:}
 A valid execution of an ASL specification transitions from an \emph{initial semantic configuration},
 which consists of the given specification and the standard library specification, to an output semantic configuration
-consisting of an output value and a concurrent execution graph.\\
+consisting of an output value and a concurrent execution graph.
 
 We define two types of semantics --- \emph{sequential semantics} and \emph{concurrent semantics}.
 
@@ -73,12 +75,11 @@ of execution; notice that ASL does not contain any concurrency constructs.
 Technically, the sequential semantics are defined by omitting the concurrent execution graph components
 from all semantic configurations.
 
-\section{Semantics Building Blocks}
-\label{sec:semanticsbuildingblocks}
+\section{Semantics Building Blocks\label{sec:semanticsbuildingblocks}}
 This section defines the mathematical types over which our semantics are defined.
 An \hyperlink{eval-example}{example} of semantic evaluation appears at the end.
 
-\section{Semantic Configurations\label{sec:SemanticConfigurations}}
+\subsection{Semantic Configurations\label{sec:SemanticConfigurations}}
 
 Semantic configurations express intermediate states related by \emph{semantic relations}.
 %
@@ -211,7 +212,7 @@ However, the typechecker renames each function uniquely so that it can be access
 on its name alone.)
 %
 The function $\typesat(\vt, \vs)$ returns true
-if the type $\vt$ \emph{type-satisfies} the type $\vs$
+if the type $\vt$ \emph{\typesatisfies} the type $\vs$
 (see \TypingRuleRef{TypeSatisfaction}).
 This is used in matching a raised exception to a corresponding catch clause.
 
@@ -338,17 +339,21 @@ should be semantically evaluated, yielding an output semantic configuration.
 
 ASL dynamic semantics mainly utilize the following types of output semantic configurations:
 \begin{description}
-  \item[Normal Values.] \hypertarget{def-normal}{}
+  \item[Normal Values.]\hypertarget{def-normal}{}
   Semantic configurations consisting of different combinations of values,
-  execution graphs, and environments, representing intermediate results
-  generated while evaluating statements:
+  execution graphs, and environments. These represent intermediate results
+  generated while evaluating various constructs such as
+  expressions, side-effect-free expressions, \assignableexpressions,
+  local declaration items, slices, and expression lists
+  (which are evaluated in two different ways for the purpose of concurrency):
   \begin{itemize}
-  \item $\Normal(\vals \times \XGraphs)$,
-  \item $\Normal((\vals \times \XGraphs), \envs)$,
-  \item $\Normal(((\vals \times \vals)^* \times \XGraphs), \envs)$,
-  \item $\Normal(\XGraphs, \envs)$,
-  \item $\Normal((\vals^* \times \XGraphs), \envs)$, and
-  \item $\Normal((\vals\times\XGraphs)^*, \envs)$.
+  \item $\ResultExpr((\vals \times \XGraphs), \envs)$,
+  \item $\ResultExprSEF(\vals, \XGraphs)$,
+  \item $\ResultLexpr(\XGraphs, \envs)$,
+  \item $\ResultLDI(\XGraphs, \envs)$,
+  \item $\ResultSlices(((\vals \times \vals)^* \times \XGraphs))$,
+  \item $\ResultExprList((\vals^* \times \XGraphs), \envs)$,
+  \item $\ResultExprListM((\vals\times\XGraphs)^*, \envs)$,
   \end{itemize}
 
   \hypertarget{def-throwing}{}
@@ -382,37 +387,55 @@ ASL dynamic semantics mainly utilize the following types of output semantic conf
   represent dynamic errors (for example, division by zero).
   The ASL dynamic semantics are set up such that when these \emph{error semantic configurations} appear,
   the evaluation of the entire specification terminates by outputting them.
+
+  \hypertarget{def-diverging}{}
+  \item[Diverging Configurations.] The semantic configuration $\Diverging$
+  represents a diverging evaluation.
 \end{description}
 Helper relations often have output semantic configurations that are just tuples, without an associated configuration domain.
 
 We define the following shorthand notations for types of output semantic configurations:
 \hypertarget{def-tnormal}{}
+\hypertarget{def-resultexpr}{}
+\hypertarget{def-resultexprlist}{}
+\hypertarget{def-resultexprlistm}{}
+\hypertarget{def-resultexprsef}{}
+\hypertarget{def-resultlexpr}{}
+\hypertarget{def-resultslices}{}
+\hypertarget{def-resultpattern}{}
+\hypertarget{def-resultldi}{}
+\hypertarget{def-resultsubprogram}{}
+\hypertarget{def-resultcall}{}
 \hypertarget{def-tcontinuing}{}
 \hypertarget{def-tthrowing}{}
 \hypertarget{def-treturning}{}
 \hypertarget{def-tdynerror}{}
+\hypertarget{def-tdiverging}{}
 \[
-  \begin{array}{rcl}
-    \TNormal          & \triangleq & \Normal(\vals, \XGraphs) \cup \Normal((\vals \times \XGraphs), \envs)\ \cup \\
-                      &            & \Normal(((\vals \times \vals)^* \times \XGraphs), \envs) \cup  \Normal(\XGraphs, \envs)\ \cup   \\
-                      &            & \Normal((\vals^* \times \XGraphs), \envs) \cup \Normal((\vals\times\XGraphs)^*, \envs)\\
-    \TThrowing        & \triangleq & \Throwing(\langle\vals \times \ty\rangle \times \XGraphs, \envs)\\
-    \TContinuing      & \triangleq & \Continuing(\XGraphs, \envs)\\
-    \TReturning       & \triangleq & \Returning((\vals^* \times \XGraphs), \envs)\\
-    \TDynError           & \triangleq & \Error(\Strings)\\
+  \begin{array}{rcll}
+    \TNormal          & \triangleq & \ResultExpr((\vals \times \XGraphs), \envs)\  & \cup \\
+                      &            & \ResultExprSEF(\vals, \XGraphs)  & \cup \\
+                      &            & \ResultLexpr(\XGraphs, \envs) & \cup\\
+                      &            & \ResultLDI(\XGraphs, \envs)  & \cup \\
+                      &            & \ResultSlices(((\vals \times \vals)^* \times \XGraphs), \envs) &  \cup\\
+                      &            & \ResultExprList((\vals^* \times \XGraphs), \envs)  & \cup \\
+                      &            & \ResultExprListM((\vals\times\XGraphs)^*, \envs) & \\
+    \TThrowing        & \triangleq & \Throwing(\langle\vals \times \ty\rangle \times \XGraphs, \envs) &\\
+    \TContinuing      & \triangleq & \Continuing(\XGraphs, \envs) &\\
+    \TReturning       & \triangleq & \Returning((\vals^* \times \XGraphs), \envs) &\\
+    \TDynError        & \triangleq & \Error(\Strings) &\\
+    \TDiverging       & \triangleq & \{ \Diverging \}&\\
   \end{array}
 \]
 
-We will say that a semantic transition \emph{terminates}:
+We will say that a semantic transition
 \begin{itemize}
-\item \emph{normally} when the output semantic configuration domain is
-$\Normal$,
-\item \emph{exceptionally} when the output semantic configuration domain is
-$\Throwing$,
-\item \emph{erroneously} when the output semantic configuration domain is
-$\Error$, and
-\item \emph{abnormally} when it either terminates exceptionally or
-erroneously.
+\item \emph{terminates normally} when the output semantic configuration is a member of \\
+      $\TNormal$,
+\item \emph{terminates exceptionally} when the output semantic configuration is a member of $\TThrowing$,
+\item \emph{terminates erroneously} when the output semantic configuration is a member of $\TDynError$,
+\item \emph{diverges} when the output semantic configuration is a member of $\TDiverging$,
+\item is \emph{abnormal} when it either terminates exceptionally, terminates erroneously, or diverges.
 \end{itemize}
 
 We introduce the following shorthand notations for semantic configurations where all variables
@@ -420,13 +443,15 @@ appearing are \hyperlink{def-freshvariables}{fresh}:
 \begin{itemize}
 \hypertarget{def-throwingconfig}{}
 \item $\ThrowingConfig \triangleq \Throwing((\vv, \vg), \newenv)$.
-\hypertarget{def-errorconfig}{}
+      \hypertarget{def-errorconfig}{}
 \item $\DynErrorConfig \triangleq \Error(\vs)$.
-\hypertarget{def-returningconfig}{}
+      \hypertarget{def-returningconfig}{}
 \item $\ReturningConfig \triangleq \Returning((\vvs,\newg), \newenv)$
-is an early return semantic configuration.
+      is an early return semantic configuration.
 \hypertarget{def-continuingconfig}{}
 \item $\ContinuingConfig \triangleq \Continuing(\newg, \newenv)$.
+      \hypertarget{def-divergingconfig}{}
+\item $\DivergingConfig \triangleq \Diverging$ is a diverging configuration.
 \end{itemize}
 
 \subsection{Extracting and Substituting Elements of Semantic configurations}
@@ -439,15 +464,18 @@ $\graphof{C}$, and the environment of the semantic configuration, $\environof{C}
 \begin{array}{lcc}
   C & \graphof{C} & \environof{C}\\
   \hline
-  \Normal(\vv,\vg) & \vg & \text{undefined}\\
-  \Normal((\vv,\vg), \env) & \vg & \env\\
-  \Normal(([i=1..k: (\va_i,\vb)],\vg), \env) & \vg & \env\\
-  \Normal(\vg, \env) & \vg & \env\\
-  \Normal([\vv_{1..k}], \vg) & \vg & \env\\
-  \Normal([i=1..k: (\vv_i,\vg_i)], \env) & \text{undefined} & \env\\
+  \ResultExpr((\vv, \vg), \env) & \vg & \env\\
+  \ResultExprSEF(\vv, \vg) & \vg & \text{undefined}\\
+  \ResultLexpr(\vg, \env) & \vg & \env \\
+  \ResultLDI(\vg, \env) & \vg & \env \\
+  \ResultSlices(([i=1..k: (\va_i,\vb)], \vg), \env) & \vg & \env \\
+  \ResultExprList(([i=1..k: \vv_i], \vg), \env) & \vg & \env \\
+  \ResultExprListM([i=1..k: (\vv_i,\vg_i)], \env) & \text{undefined} & \env\\
   \Throwing((\valuereadfrom(\vx,\vv),\vg), \env) & \vg & \env\\
   \Returning(([\vv_{1..k}],\vg), \env) & \vg & \env\\
   \Continuing(\vg, \env) & \vg & \env\\
+  \Error(\vs) & \text{undefined} & \text{undefined}\\
+  \Diverging & \text{undefined} & \text{undefined}\\
 \end{array}
 \]
 
@@ -458,17 +486,21 @@ like $C$ where the graph component is substituted with $\vgp$:
 \begin{array}{ll}
   C & \withgraph{C}{\vgp}\\
   \hline
-  \Normal(\vv,\vg) & \Normal(\vv,\vgp)\\
-  \Normal((\vv,\vg), \env) & \Normal((\vv,\vgp), \env)\\
-  \Normal((i=1..k: (\va_i,\vb),\vg), \env) & \Normal((i=1..k: (\va_i,\vb),\vgp), \env)\\
-  \Normal(\vg, \env) & \Normal(\vgp, \env)\\
-  \Normal(i=1..k: \vv_i, \vg) & \Normal(i=1..k: \vv_i, \vgp)\\
-  \Normal([i=1..k: (\vv_i,\vg_i)], \env) & \text{undefined}\\
+  \ResultExpr((\vv, \vg), \env) & \ResultExpr((\vv, \vgp), \env)\\
+  \ResultExprSEF(\vv, \vg) & \ResultExprSEF(\vv, \vgp)\\
+  \ResultLexpr(\vg, \env) & \ResultLexpr(\vgp, \env)\\
+  \ResultLDI(\vg, \env) & \ResultLDI(\vgp, \env)\\
+  \ResultSlices(([i=1..k: (\va_i,\vb)], \vg), \env) & \ResultSlices(([i=1..k: (\va_i,\vb)], \vgp), \env)\\
+  \ResultExprList(([i=1..k: \vv_i], \vg), \env) & \ResultExprList(([i=1..k: \vv_i], \vgp), \env)\\
+  \ResultExprListM([i=1..k: (\vv_i,\vg_i)], \env) & \text{undefined}\\
   \Throwing((\valuereadfrom(\vx,\vv),\vg), \env) & \Throwing((\valuereadfrom(\vx,\vv),\vgp), \env)\\
   \Returning((i=1..k: \vv_i,\vg), \env) & \Returning((i=1..k: \vv_i,\vgp), \env)\\
   \Continuing(\vg, \env) & \Continuing(\vgp, \env)\\
+  \Error(\vs) & \text{undefined}\\
+  \Diverging & \text{undefined} \\
 \end{array}
 \]
+
 \hypertarget{def-withenviron}{}
 Similarly, we define the $\withenviron{C}{\envp}$ to be a semantic configuration
 like $C$ where the environment component, if one exists, is substituted with $\envp$:
@@ -476,24 +508,28 @@ like $C$ where the environment component, if one exists, is substituted with $\e
 \begin{array}{ll}
   \textbf{Semantic configuration} & \withenviron{C}{\envp}\\
   \hline
-  \Normal(\vv,\vg) & \text{undefined}\\
-  \Normal((\vv,\vg), \env) & \Normal((\vv,\vg), \envp)\\
-  \Normal((i=1..k: (\va_i,\vb),\vg), \env) & \Normal((i=1..k: (\va_i,\vb),\vg), \envp)\\
-  \Normal(\vg, \env) & \Normal(\vg, \envp)\\
-  \Normal(i=1..k: \vv_i, \vg) & \Normal(i=1..k: \vv_i, \vg)\\
-  \Normal([i=1..k: (\vv_i,\vg_i)], \env) & \Normal([i=1..k: (\vv_i,\vg_i)], \envp)\\
+  \ResultExpr((\vv, \vg), \env) & \ResultExpr((\vv, \vg), \envp)\\
+  \ResultExprSEF(\vv, \vg) & \text{undefined}\\
+  \ResultLexpr(\vg, \env) & \ResultLexpr(\vg, \envp)\\
+  \ResultLDI(\vg, \env) & \ResultLDI(\vg, \envp)\\
+  \ResultSlices(([i=1..k: (\va_i,\vb)], \vg), \env) & \ResultSlices(([i=1..k: (\va_i,\vb)], \vg), \envp)\\
+  \ResultExprList(([i=1..k: \vv_i], \vg), \env) & \ResultExprList(([i=1..k: \vv_i], \vg), \envp)\\
+  \ResultExprListM([i=1..k: (\vv_i,\vg_i)], \env) & \ResultExprListM([i=1..k: (\vv_i,\vg_i)], \envp)\\
   \Throwing((\valuereadfrom(\vx,\vv),\vg), \env) & \Throwing((\valuereadfrom(\vx,\vv),\vg), \envp)\\
   \Returning((i=1..k: \vv_i,\vg), \env) & \Returning((i=1..k: \vv_i,\vg), \envp)\\
   \Continuing(\vg, \env) & \Continuing(\vg, \envp)\\
+  \Error(\vs) & \text{undefined}\\
+  \Diverging & \text{undefined} \\
 \end{array}
 \]
 
 \section{Semantic Evaluation}
 \hypertarget{def-evalrel}{}
 The semantics of ASL is given by the relation\footnote{The reason that a relation, rather than a function, is used is due to
-the non-determinism inherent in the \texttt{ARBITRARY} expression.}
+the non-determinism inherent in the \ARBITRARY{} expression.}
 \evalrel.
-The relation \evalrel\ is defined as the disjoint union of the relations defined in this reference.
+The relation \evalrel\ is defined as the disjoint union of the relations defined in this reference:
+$\evalexprname$, $\evalstmtname$, etc.
 
 \subsection{Natural Operational Semantics}
 We define the ASL dynamic semantics in the style of \emph{natural operational semantics}~\cite{SemanticsWithApplicationsBook}
@@ -509,8 +545,8 @@ the semantic configuration is \emph{stuck} and the ASL dynamic semantics are und
 input semantic configuration.
 
 The ASL dynamic semantics are defined for well-typed ASL specifications
-and gets stuck only in cases of non-terminating specifications
-(due to non-terminating loops, or infinite recursion).
+and gets stuck only in cases of diverging specifications
+(due to diverging loops, or infinite recursion).
 Otherwise, for every input semantic configuration there is at least one rule that can be used to take a semantic transition.
 
 \hypertarget{eval-example}{}
@@ -544,39 +580,36 @@ Finally, the transitions for both of the subexpressions are used as premises for
 rule, along with the rule for binary operator (for multiplication), to evaluate the entire expression.
 
 \begin{mathpar}
-  \inferrule*[right=\ref{sec:SemanticsRule.Binop}]{
-    \inferrule*[right=\ref{sec:SemanticsRule.ELit}]{}{ \evalexpr{\emptyenv, \veone} \evalarrow \Normal(\nvint(1), \emptyenv) } \\\\
-    \inferrule*[right=\ref{sec:SemanticsRule.ELit}]{}{ \evalexpr{\emptyenv, \vetwo} \evalarrow \Normal(\nvint(2), \emptyenv) } \\\\
-    \inferrule*[right=\ref{sec:SemanticsRule.BinopValues}]{}{\binoprel(\PLUS, \nvint(1), \nvint(2)) \evalarrow \nvint(3)}
-  }
-  {
-    \evalexpr{ \emptyenv, \veonetwo } \evalarrow
-    \Normal(\nvint(3), \emptyenv)
-  }
+\inferrule*[right=\ref{sec:SemanticsRule.Binop}]{
+  \inferrule*[right=\ref{sec:SemanticsRule.ELit}]{}{ \evalexpr{\emptyenv, \veone} \evalarrow \ResultExpr(\nvint(1), \emptyenv) } \\\\
+  \inferrule*[right=\ref{sec:SemanticsRule.ELit}]{}{ \evalexpr{\emptyenv, \vetwo} \evalarrow \ResultExpr(\nvint(2), \emptyenv) } \\\\
+  \inferrule*[right=\ref{sec:SemanticsRule.BinopValues}]{}{\binoprel(\PLUS, \nvint(1), \nvint(2)) \evalarrow \nvint(3)}
+}{
+  \evalexpr{ \emptyenv, \veonetwo } \evalarrow
+  \ResultExpr(\nvint(3), \emptyenv)
+}
 \end{mathpar}
 
 \begin{mathpar}
-  \inferrule*[right=\ref{sec:SemanticsRule.Binop}]{
-    \inferrule*[right=\ref{sec:SemanticsRule.ELit}]{}{ \evalexpr{\emptyenv, \vefour} \evalarrow \Normal(\nvint(4), \emptyenv) } \\\\
-    \inferrule*[right=\ref{sec:SemanticsRule.ELit}]{}{ \evalexpr{\emptyenv, \vefive} \evalarrow \Normal(\nvint(5), \emptyenv) } \\\\
-    \inferrule*[right=\ref{sec:SemanticsRule.BinopValues}]{}{\binoprel(\PLUS, \nvint(4), \nvint(5)) \evalarrow \nvint(9)}
-  }
-  {
-    \evalexpr{ \emptyenv, \vefourfive } \evalarrow
-    \Normal(\nvint(9), \emptyenv)
-  }
+\inferrule*[right=\ref{sec:SemanticsRule.Binop}]{
+  \inferrule*[right=\ref{sec:SemanticsRule.ELit}]{}{ \evalexpr{\emptyenv, \vefour} \evalarrow \ResultExpr(\nvint(4), \emptyenv) } \\\\
+  \inferrule*[right=\ref{sec:SemanticsRule.ELit}]{}{ \evalexpr{\emptyenv, \vefive} \evalarrow \ResultExpr(\nvint(5), \emptyenv) } \\\\
+  \inferrule*[right=\ref{sec:SemanticsRule.BinopValues}]{}{\binoprel(\PLUS, \nvint(4), \nvint(5)) \evalarrow \nvint(9)}
+}{
+  \evalexpr{ \emptyenv, \vefourfive } \evalarrow
+  \ResultExpr(\nvint(9), \emptyenv)
+}
 \end{mathpar}
 
 \begin{mathpar}
-  \inferrule*[right=\ref{sec:SemanticsRule.Binop}]{
-    \evalexpr{ \emptyenv, \veonetwo } \evalarrow \Normal(\nvint(3), \emptyenv)\\
-    \evalexpr{ \emptyenv, \vefourfive } \evalarrow \Normal(\nvint(9), \emptyenv)\\
-    \inferrule*[right=\ref{sec:SemanticsRule.BinopValues}]{}{\binoprel(\MUL, \nvint(3), \nvint(9)) \evalarrow \nvint(27)}
-  }
-  {
-    \evalexpr{ \emptyenv, \EBinop(\MUL, \veonetwo, \vefourfive) } \evalarrow
-    \Normal(\nvint(27), \emptyenv)
-  }
+\inferrule*[right=\ref{sec:SemanticsRule.Binop}]{
+  \evalexpr{ \emptyenv, \veonetwo } \evalarrow \ResultExpr(\nvint(3), \emptyenv)\\
+  \evalexpr{ \emptyenv, \vefourfive } \evalarrow \ResultExpr(\nvint(9), \emptyenv)\\
+  \inferrule*[right=\ref{sec:SemanticsRule.BinopValues}]{}{\binoprel(\MUL, \nvint(3), \nvint(9)) \evalarrow \nvint(27)}
+}{
+  \evalexpr{ \emptyenv, \EBinop(\MUL, \veonetwo, \vefourfive) } \evalarrow
+  \ResultExpr(\nvint(27), \emptyenv)
+}
 \end{mathpar}
 
 \subsection{Evaluation Order\label{sec:EvaluationOrder}}
@@ -588,14 +621,14 @@ Further, the threading through of environments similarly impose an ordering.
 For example, \SemanticsRuleRef{ECond} is duplicated below:
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \econd} \evalarrow \Normal(\mcond, \envone) \OrAbnormal\\\\
+  \evalexpr{\env, \econd} \evalarrow \ResultExpr(\mcond, \envone) \OrAbnormal\\\\
   \mcond \eqname (\nvbool(\vb), \vgone)\\
   \vep \eqdef \choice{\vb}{\veone}{\vetwo}\\\\
-  \evalexpr{\envone, \vep} \evalarrow \Normal((\vv, \vgtwo), \newenv)  \OrAbnormal\\\\
+  \evalexpr{\envone, \vep} \evalarrow \ResultExpr((\vv, \vgtwo), \newenv)  \OrAbnormal\\\\
   \vg \eqdef \ordered{\vgone}{\aslctrl}{\vgtwo}
 }{
   \evalexpr{\env, \overname{\ECond(\econd, \veone, \vetwo)}{\ve}} \evalarrow
-  \Normal((\vv, \vg), \newenv)
+  \ResultExpr((\vv, \vg), \newenv)
 }
 \end{mathpar}
 The use of $\OrAbnormal$ rule macros here define an evaluation order:
@@ -653,3 +686,148 @@ For-loop start/end expressions:
 1234
 \end{Verbatim}
 % CONSOLE_END
+
+\section{Semantics of Diverging Specifications\label{sec:Semantics of Diverging Specifications}}
+While typical specifications are intended to always terminate,
+diverging specifications can be potentially useful.
+For example, simulating the fetch-decode-execute cycle of a given processor,
+which may look like the following partial specification:
+\begin{lstlisting}
+func main() => integer
+begin
+  while !stop_condition() do
+    let instr = fetch_next_instruction();
+    decode_and_execute(instr);
+  end;
+  return error_code;
+end;
+\end{lstlisting}
+
+\subsection{The Big-step Semantics of ASL}
+
+\begin{definition}[ASL Big-step Rules]
+The \emph{big-step semantics}\cite{SemanticsWithApplicationsBook} of terminating evaluations and diverging evaluations
+is given by two disjoint sets of rules:
+\begin{description}
+  \item[Inductive Rules] The set of \emph{inductive rules} are all dynamic semantics
+        rules that do not include configurations in $\TDiverging$; and
+  \item[Co-inductive Rules] The set of \emph{co-inductive rules}~\cite{LeroyG:IC09}
+       are all dynamic semantics rules whose output configurations are in $\TDiverging$.
+       Co-inductive rules have the property that, considering the list of premises that
+       are transition judgments, the last, and only the last one has an output configuration in $\TDiverging$.
+       This is ensured by the placement of $\DivergingConfig$ as short-circuiting alternatives
+       in macro rules.
+\end{description}
+\end{definition}
+
+As an example of an inductive rule, consider the following rule,
+obtained by expanding the macro rule for \SemanticsRuleRef{Loop}.CONTINUE:
+\begin{mathpar}
+\inferrule{
+  \evalexpr{\env, \econd} \evalarrow \ResultExpr(\condm, \envone)\\
+  \condm \eqname (\nvbool(\vb), \vgone)\\
+  \vb = \iswhile\\
+  \ticklooplimit(\vlimitopt) \evalarrow \vlimitoptp\\
+  \evalblock{\envone, \vbody} \evalarrow \Continuing(\vgtwo, \envtwo)\\
+  \evalloop{\envtwo, \iswhile, \vlimitoptp, \econd, \vbody} \evalarrow \Continuing(\vgthree, \newenv)\\
+  \newg \eqdef \ordered{\ordered{\vgone}{\aslctrl}{\vgtwo}}{\aslpo}{\vgthree}
+}{
+  \evalloop{\env, \iswhile, \vlimitopt, \econd, \vbody} \evalarrow \Continuing(\newg, \newenv)
+}
+\end{mathpar}
+
+As an example of a co-inductive rule, consider the following expansion
+for the same macro rule:
+\begin{mathpar}
+\inferrule{
+  \evalexpr{\env, \econd} \evalarrow \ResultExpr(\condm, \envone)\\
+  \condm \eqname (\nvbool(\vb), \vgone)\\
+  \vb = \iswhile\\
+  \ticklooplimit(\vlimitopt) \evalarrow \vlimitoptp\\
+  \evalblock{\envone, \vbody} \evalarrow \Continuing(\vgtwo, \envtwo)\\
+  \evalloop{\envtwo, \iswhile, \vlimitoptp, \econd, \vbody} \evalarrow \DivergingConfig\\
+  \newg \eqdef \ordered{\ordered{\vgone}{\aslctrl}{\vgtwo}}{\aslpo}{\vgthree}
+}{
+  \evalloop{\env, \iswhile, \vlimitopt, \econd, \vbody} \evalarrow \DivergingConfig
+}
+\end{mathpar}
+
+\begin{definition}[Meaning of ASL Big-step Rules]
+We say that a judgment\\
+$g = C \evalarrow D$ holds if and only if one of the following applies:
+\begin{itemize}
+  \item $D\not\in\TDiverging$ and there exists a \underline{finite} \derivationtreeterm{}
+        with root $g$, consisting of only inductive rules; or
+  \item $D\in\TDiverging$ and there exists an \underline{infinite} \derivationtreeterm{}
+        with root $g$, consisting of both inductive rules and co-inductive rules.
+\end{itemize}
+\end{definition}
+
+\ExampleDef{Diverging Evaluation of a Loop}
+
+To exemplify a diverging evaluation, consider the sequential semantics
+of the statement \verb|while TRUE do pass; end;| evaluated with
+an environment $\env$.
+The infinite \derivationtreeterm{} consists of vertices
+\[
+\{S_1, L_1, V_1\} \cup \{n \geq 2 \;|\; E_n, B_n, T_n, P_n, Q_n\} \enspace,
+\]
+which we use to annotate the vertices of the \derivationtreeterm{} defined below
+(we inline aliasing equalities and deconstructing equalities,
+leaving only asserting equalities and transitions, to simplify the presentation).
+
+The root of the infinite \derivationtreeterm{} is the following one:
+\begin{mathpar}
+\inferrule{
+  {
+  \begin{array}{rc}
+  L_1:& \evallimit(\env, \None) \evalarrow \None\\
+  V_1:& \evalloop{\env, \True, \None, \ETrue, \SPass} \evalarrow \Diverging
+  \end{array}
+  }
+}{
+  S_1: \evalstmt{\env, \SWhile(\ETrue, \None, \SPass)} \evalarrow \Diverging
+}
+\end{mathpar}
+
+and the rest of the \derivationtreeterm{} is given as:
+\begin{mathpar}
+\inferrule{
+  {
+  \begin{array}{rc}
+  E_{n+1}:& \evalexpr{\env, \ETrue} \evalarrow \ResultExpr(\nvbool(\vb), \env)\\
+  B_{n+1}:& \vb = \True\\
+  T_{n+1}:& \ticklooplimit(\None) \evalarrow \None\\
+          & \left(\inferrule{Q_{n+1}:\evalstmt{\env, \SPass}\evalarrow \Continuing(\env)}{P_{n+1}: \evalblock{\env, \SPass} \evalarrow \Continuing(\env)}\right)\\
+  V_{n+1}:& \evalloop{\env, \True, \None, \ETrue, \SPass} \evalarrow \Diverging
+  \end{array}
+  }
+}{
+  V_n: \evalloop{\env, \True, \None, \ETrue, \SPass} \evalarrow \Diverging
+}
+\end{mathpar}
+
+That is, the premise $V_{n+1}$ is given by copying the same sub-tree as above for each $n\geq 2$,
+which visually looks like the following:
+\begin{mathpar}
+\inferrule{
+  {
+  \begin{array}{rc}
+  E_{n+1}:& \evalexpr{\env, \ETrue} \evalarrow \ResultExpr(\nvbool(\vb), \env)\\
+  B_{n+1}:& \vb = \True\\
+  T_{n+1}:& \ticklooplimit(\None) \evalarrow \None\\
+  & \left(\inferrule{Q_{n+1}:\evalstmt{\env, \SPass}\evalarrow \Continuing(\env)}{P_{n+1}: \evalblock{\env, \SPass} \evalarrow \Continuing(\env)}\right)\\
+  &
+  \left(
+  \inferrule{
+    E_{n+2}\\ B_{n+2}\\ T_{n+2}\\ P_{n+2}\\ V_{n+2}\\ \inferrule{\vdots}{V_{n+2}}
+  }{
+    V_{n+1}: \evalloop{\env, \True, \None, \ETrue, \SPass} \evalarrow \Diverging
+  }
+  \right)
+  \end{array}
+  }
+}{
+  V_n: \evalloop{\env, \True, \None, \ETrue, \SPass} \evalarrow \Diverging
+}
+\end{mathpar}

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -80,16 +80,21 @@ In \listingref{ImpureBitvectorSlice}, the bit vector slice on \verb|x| is ill-ty
 The relation
 \hypertarget{def-evalslices}{}
 \[
-  \begin{array}{rl}
-  \evalslices(\overname{\envs}{\env} \aslsep \overname{\slice^*}{\slices}) \;\aslrel &
-    \Normal((\overname{(\vals \times \vals)^*}{\ranges} \times \overname{\XGraphs}{\newg}), \overname{\envs}{\newenv})\ \cup \\
-    & \overname{\Throwing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
+  \evalslices(\overname{\envs}{\env} \aslsep \overname{\slice^*}{\slices}) \;\aslrel\;
+  \left(
+  \begin{array}{ll}
+  \ResultSlices((\overname{(\vals \times \vals)^*}{\ranges} \times \overname{\XGraphs}{\newg}), \overname{\envs}{\newenv}) & \cup\\
+  \overname{\TThrowing}{\ThrowingConfig}    & \cup\\
+  \overname{\TDynError}{\DynErrorConfig}    & \cup\\
+  \overname{\TDiverging}{\DivergingConfig}  & \\
   \end{array}
+  \right)
 \]
 evaluates a list of slices $\slices$ in an environment $\env$, resulting in either \\
-$\Normal((\ranges, \newg), \newenv)$ or an abnormal configuration.
-\ProseParagraph
+$\ResultSlices((\ranges, \newg), \newenv)$.
+\ProseOtherwiseAbnormal
 
+\ProseParagraph
 $\evalslices(\env, \vslices)$ is the list of pairs \texttt{(start\_n, length\_n)} that
 correspond to the start (included) and the length of each slice in
 $\slices$.
@@ -114,9 +119,9 @@ yields the list of ranges $[(2,1), (5,2), (0,3)]$.
   \begin{itemize}
     \item the list of slices has $\vslice$ as the head and $\slicesone$ as the tail;
     \item evaluating the slice $\vslice$ in $\env$ results in \\
-    $\Normal((\range, \vgone), \envone)$\ProseOrAbnormal;
+          $\ResultSlices((\range, \vgone), \envone)$\ProseOrAbnormal;
     \item evaluating the tail list $\slicesone$ in $\envone$ results in \\
-    $\Normal((\rangesone, \vgtwo), \newenv)$\ProseOrAbnormal;
+          $\ResultSlices((\rangesone, \vgtwo), \newenv)$\ProseOrAbnormal;
     \item $\ranges$ is the concatenation of $\range$ to $\rangesone$;
     \item $\newg$ is the parallel composition of $\vgone$ and $\vgtwo$.
   \end{itemize}
@@ -126,18 +131,18 @@ yields the list of ranges $[(2,1), (5,2), (0,3)]$.
 \begin{mathpar}
 \inferrule[empty]{}
 {
-  \evalslices(\env, \emptylist) \evalarrow \Normal((\emptylist, \emptygraph), \env)
+  \evalslices(\env, \emptylist) \evalarrow \ResultSlices((\emptylist, \emptygraph), \env)
 }
 \end{mathpar}
 \begin{mathpar}
 \inferrule[nonempty]{
   \slices \eqname [\vslice] \concat \slicesone\\
-  \evalslice(\env, \vslice) \evalarrow \Normal((\range, \vgone), \envone) \OrAbnormal\\
-  \evalslices(\envone, \slicesone) \evalarrow \Normal((\rangesone, \vgtwo), \newenv) \OrAbnormal\\
+  \evalslice(\env, \vslice) \evalarrow \ResultSlices((\range, \vgone), \envone) \OrAbnormal\\\\
+  \evalslices(\envone, \slicesone) \evalarrow \ResultSlices((\rangesone, \vgtwo), \newenv) \OrAbnormal\\\\
   \ranges \eqdef [\range] \concat \rangesone\\
   \newg \eqdef \vgone \parallelcomp \vgtwo
 }{
-  \evalslices(\env, \slices) \evalarrow \Normal((\ranges, \newg), \newenv)
+  \evalslices(\env, \slices) \evalarrow \ResultSlices((\ranges, \newg), \newenv)
 }
 \end{mathpar}
 \CodeSubsection{\EvalSlicesBegin}{\EvalSlicesEnd}{../Interpreter.ml}
@@ -496,15 +501,20 @@ the parameter \verb|N|.
 The relation
 \hypertarget{def-evalslice}{}
 \[
-  \begin{array}{rl}
-  \evalslice(\overname{\envs}{\env} \aslsep \overname{\slice}{\vs}) \;\aslrel &
-    \Normal(((\overname{\tint}{\vstart} \times \overname{\tint}{\vlength}) \times \overname{\XGraphs}{\newg}), \overname{\envs}{\newenv})\ \cup \\
-    & \overname{\Throwing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
+  \evalslice(\overname{\envs}{\env} \aslsep \overname{\slice}{\vs}) \;\aslrel\;
+  \left(
+  \begin{array}{ll}
+  \ResultSlices(((\overname{\tint}{\vstart} \times \overname{\tint}{\vlength}) \times \overname{\XGraphs}{\newg}), \overname{\envs}{\newenv}) & \cup\\
+  \overname{\TThrowing}{\ThrowingConfig}    & \cup\\
+  \overname{\TDynError}{\DynErrorConfig}    & \cup\\
+  \overname{\TDiverging}{\DivergingConfig}  & \\
   \end{array}
+  \right)
 \]
 evaluates an individual slice $\vs$ in an environment $\env$ is,
 resulting either in \\
-$\Normal(((\vstart, \vlength), \vg), \newenv)$, a throwing configuration, or a dynamic error configuration.
+$\ResultSlices(((\vstart, \vlength), \vg), \newenv)$.
+\ProseOtherwiseAbnormal
 
 \ExampleDef{Evaluating Slices}
 In \listingref{semantics-slicesingle},
@@ -532,7 +542,7 @@ In \listingref{semantics-scaledfromzero},
   \item \AllApplyCase{single}
   \begin{itemize}
     \item $\vs$ is a \singleslice\ with the expression $\ve$, $\SliceSingle(\ve)$;
-    \item evaluating $\ve$ in $\env$ results in $\Normal((\vstart, \newg), \newenv)$\ProseOrAbnormal;
+    \item evaluating $\ve$ in $\env$ results in $\ResultExpr((\vstart, \newg), \newenv)$\ProseOrAbnormal;
     \item $\vlength$ is the integer value 1.
   \end{itemize}
 
@@ -540,11 +550,11 @@ In \listingref{semantics-scaledfromzero},
   \begin{itemize}
     \item $\vs$ is the \rangeslice\ between the
       expressions $\estart$ and $\etop$, that is, \\ $\SliceRange(\etop, \estart)$;
-    \item evaluating $\etop$ in $\env$ is $\Normal(\mtop, \envone)$\ProseOrAbnormal;
+    \item evaluating $\etop$ in $\env$ is $\ResultExpr(\mtop, \envone)$\ProseOrAbnormal;
     \item $\mtop$ is a pair consisting of the native integer $\vvsubtop$ and execution graph $\vgone$;
-    \item evaluating $\estart$ in $\envone$ is $\Normal(\mstart, \newenv)$\ProseOrAbnormal;
+    \item evaluating $\estart$ in $\envone$ is $\ResultExpr(\mstart, \newenv)$\ProseOrAbnormal;
     \item $\mstart$ is a pair consisting of the native integer $\vstart$ and execution graph $\vgtwo$;
-    \item $\vlength$ is the integer value \texttt{(v\_top - v\_start) + 1};
+    \item $\vlength$ is the integer value $(\vvsubtop - \vstart) + 1$;
     \item $\newg$ is the parallel composition of $\vgone$ and $\vgtwo$.
   \end{itemize}
 
@@ -552,8 +562,8 @@ In \listingref{semantics-scaledfromzero},
   \begin{itemize}
     \item $\vs$ is the \lengthslice, which starts at expression~$\estart$ with length~$\elength$,
     that is, $\SliceLength(\estart, \elength)$;
-    \item evaluating $\estart$ in $\env$ is \Normal(\mstart, \envone)\ProseOrAbnormal;
-    \item evaluating $\elength$ in $\envone$ is \Normal(\mlength, \newenv)\ProseOrAbnormal;
+    \item evaluating $\estart$ in $\env$ is $\ResultExpr(\mstart, \envone)$\ProseOrAbnormal;
+    \item evaluating $\elength$ in $\envone$ is $\ResultExpr(\mlength, \newenv)$\ProseOrAbnormal;
     \item $\mstart$ is a pair consisting of the native integer $\vstart$ and execution graph $\vgone$;
     \item $\mlength$ is a pair consisting of the native integer $\vlength$ and execution graph $\vgtwo$;
     \item $\newg$ is the parallel composition of $\vgone$ and $\vgtwo$.
@@ -564,9 +574,9 @@ In \listingref{semantics-scaledfromzero},
     \item $\vs$ is the \scaledslice\ with factor given by the
       expression $\efactor$ and length given by the
       expression $\elength$, that is, $\SliceStar(\efactor, \elength)$;
-    \item evaluating $\efactor$ in $\env$ is $\Normal(\mfactor, \envone)$\ProseOrAbnormal;
+    \item evaluating $\efactor$ in $\env$ is $\ResultExpr(\mfactor, \envone)$\ProseOrAbnormal;
     \item $\mfactor$ is a pair consisting of the native integer $\vfactor$ and execution graph $\vgone$;
-    \item evaluating $\elength$ in $\env$ is $\Normal(\mlength, \newenv)$\ProseOrAbnormal;
+    \item evaluating $\elength$ in $\env$ is $\ResultExpr(\mlength, \newenv)$\ProseOrAbnormal;
     \item $\mlength$ is a pair consisting of the native integer $\vlength$ and execution graph $\vgtwo$;
     \item $\vstart$ is the native integer $\vfactor \times \vlength$;
     \item $\newg$ is the parallel composition of $\vgone$ and $\vgtwo$.
@@ -576,48 +586,48 @@ In \listingref{semantics-scaledfromzero},
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[single]{
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vstart, \newg), \newenv) \OrAbnormal\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vstart, \newg), \newenv) \OrAbnormal\\
   \vlength \eqdef \nvint(1)
 }{
-  \evalslice(\env, \SliceSingle(\ve)) \evalarrow \Normal(((\vstart, \vlength), \newg), \newenv)
+  \evalslice(\env, \SliceSingle(\ve)) \evalarrow \ResultSlices(((\vstart, \vlength), \newg), \newenv)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[range]{
-  \evalexpr{\env, \etop} \evalarrow \Normal(\mtop, \envone) \OrAbnormal\\\\
+  \evalexpr{\env, \etop} \evalarrow \ResultExpr(\mtop, \envone) \OrAbnormal\\\\
   \mtop \eqname (\vvsubtop, \vgone)\\
-  \evalexpr{\envone, \estart} \evalarrow \Normal(\mstart, \newenv) \OrAbnormal\\\\
+  \evalexpr{\envone, \estart} \evalarrow \ResultExpr(\mstart, \newenv) \OrAbnormal\\\\
   \mstart \eqname (\vstart, \vgtwo)\\
   \binoprel(\MINUS, \vvsubtop, \vstart) \evalarrow \vdiff\\
   \binoprel(\PLUS, \nvint(1), \vdiff) \evalarrow \vlength\\
   \newg \eqdef \vgone \parallelcomp \vgtwo
 }{
-  \evalslice(\env, \SliceRange(\etop, \estart)) \evalarrow \\ \Normal(((\vstart, \vlength), \newg), \newenv)
+  \evalslice(\env, \SliceRange(\etop, \estart)) \evalarrow \\ \ResultSlices(((\vstart, \vlength), \newg), \newenv)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[length]{
-  \evalexpr{\env, \estart} \evalarrow \Normal(\mstart, \envone) \OrAbnormal\\
-  \evalexpr{\envone, \elength} \evalarrow \Normal(\mlength, \newenv) \OrAbnormal\\
+  \evalexpr{\env, \estart} \evalarrow \ResultExpr(\mstart, \envone) \OrAbnormal\\
+  \evalexpr{\envone, \elength} \evalarrow \ResultExpr(\mlength, \newenv) \OrAbnormal\\
   \mstart \eqname (\vstart, \vgone)\\
   \mlength \eqname (\vlength, \vgtwo)\\
   \newg \eqdef \vgone \parallelcomp \vgtwo
 }{
-  \evalslice(\env, \SliceLength(\estart, \elength)) \evalarrow \\ \Normal(((\vstart, \vlength), \newg), \newenv)
+  \evalslice(\env, \SliceLength(\estart, \elength)) \evalarrow \\ \ResultSlices(((\vstart, \vlength), \newg), \newenv)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[scaled]{
-  \evalexpr{\env, \efactor} \evalarrow \Normal(\mfactor, \envone) \OrAbnormal\\
+  \evalexpr{\env, \efactor} \evalarrow \ResultExpr(\mfactor, \envone) \OrAbnormal\\
   \mfactor \eqname (\vfactor, \vgone)\\
-  \evalexpr{\envone, \elength} \evalarrow \Normal(\mlength, \newenv) \OrAbnormal\\
+  \evalexpr{\envone, \elength} \evalarrow \ResultExpr(\mlength, \newenv) \OrAbnormal\\
   \mlength \eqname (\vlength, \vgtwo)\\
   \binoprel(\MUL, \vfactor, \vlength) \evalarrow \vstart \\
   \newg \eqdef \vgone \parallelcomp \vgtwo
 }{
-  \evalslice(\env, \SliceStar(\efactor, \elength)) \evalarrow \\ \Normal(((\vstart, \vlength), \newg), \newenv)
+  \evalslice(\env, \SliceStar(\efactor, \elength)) \evalarrow \\ \ResultSlices(((\vstart, \vlength), \newg), \newenv)
 }
 \end{mathpar}

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -2258,7 +2258,8 @@ results in a \dynamicerrorterm.
     \item \AllApplyCase{normal}
     \begin{itemize}
       \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
-      in $\env$ yields $\Normal([(\vv, \vgtwo)], \Ignore)$\ProseOrError;
+            in $\env$ yields \\
+            $\ResultSubprogram([(\vv, \vgtwo)], \Ignore)$\ProseOrDynErrorDiverging;
       \item $\vg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\aslpo$ edge;
       \item the result of the entire evaluation is $(\vv, \vg)$.
     \end{itemize}
@@ -2266,7 +2267,7 @@ results in a \dynamicerrorterm.
     \item \AllApplyCase{throwing}
     \begin{itemize}
       \item evaluating the subprogram \texttt{main} with an empty list of actual arguments and empty list of parameters
-      in $\env$ yields $\Throwing(\vvopt, \Ignore)$, which is an uncaught exception;
+            in $\env$ yields $\Throwing(\vvopt, \Ignore)$, which is an uncaught exception\ProseOrDynErrorDiverging;
       \item the result of the entire evaluation is an error indicating that an exception was not caught.
     \end{itemize}
   \end{itemize}
@@ -2275,8 +2276,8 @@ results in a \dynamicerrorterm.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[normal]{
-  \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynError\\\\
-  \evalsubprogram(\env, \vmain, \emptylist, \emptylist)\evalarrow \Normal([(\vv, \vgtwo)], \Ignore) \OrDynError\\\\
+  \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynErrorDiverging\\\\
+  \evalsubprogram(\env, \vmain, \emptylist, \emptylist)\evalarrow \ResultSubprogram([(\vv, \vgtwo)], \Ignore) \OrDynErrorDiverging\\\\
   \vg \eqdef \ordered{\vgone}{\aslpo}{\vgtwo}
 }{
   \evalspec(\tenv, \vspec) \evalarrow (\vv, \vg)
@@ -2285,8 +2286,8 @@ results in a \dynamicerrorterm.
 
 \begin{mathpar}
 \inferrule[throwing]{
-  \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynError\\\\
-  \evalsubprogram(\env, \vmain, \emptylist, \emptylist) \evalarrow \Throwing(\vvopt, \Ignore)
+  \buildgenv(\tenv, \vspec) \evalarrow (\env, \vgone) \OrDynErrorDiverging\\\\
+  \evalsubprogram(\env, \vmain, \emptylist, \emptylist) \evalarrow \Throwing(\vvopt, \Ignore) \OrDynErrorDiverging\\\\
 }{
   \evalspec(\tenv, \vspec) \evalarrow \DynamicErrorVal{\UncaughtException}
 }
@@ -2298,13 +2299,19 @@ The helper relation
 \hypertarget{def-buildgenv}{}
 \[
   \buildgenv(\overname{\staticenvs}{\tenv}, \overname{\spec}{\typedspec}) \;\aslrel\;
-  (\overname{\envs}{\newenv}\times\overname{\XGraphs}{\newg}) \cup \overname{\TDynError}{\DynErrorConfig}
+  \left(
+  \begin{array}{cl}
+  (\overname{\envs}{\newenv}\times\overname{\XGraphs}{\newg}) & \cup\\
+  \overname{\TDynError}{\DynErrorConfig} & \cup\\
+  \overname{\TDiverging}{\DivergingConfig} &
+  \end{array}
+  \right)
 \]
 populates the environment $\env$ and output execution graph $\newg$ with the global
 storage declarations in $\typedspec$, starting from the static environment $\tenv$.
 This works by traversing the global storage declarations
 and updating the environment accordingly.
-\ProseOtherwiseDynamicError
+\ProseOtherwiseDynamicErrorOrDiverging
 
 It is assumed that $\typedspec$ lists the declarations in reverse order with respect
 to the \defusedependencyterm\ order
@@ -2317,7 +2324,7 @@ See \ExampleRef{Evaluating a List of Global Declarations}.
 \begin{itemize}
   \item define the environment $\env$ as consisting of the static environment $\tenv$ and the empty dynamic environment $\emptydenv$;
   \item evaluating the global storage declarations in $\typedspec$ in $\env$ with the empty execution graph
-        is $(\newenv, \newg)$\ProseOrError.
+        is $(\newenv, \newg)$\ProseOrDynErrorDiverging.
   \item the result of the entire evaluation is $(\newenv, \newg)$.
 \end{itemize}
 
@@ -2325,7 +2332,7 @@ See \ExampleRef{Evaluating a List of Global Declarations}.
 \begin{mathpar}
 \inferrule{
   \env \eqdef (\tenv, \emptydenv)\\
-  \evalglobals(\typedspec, (\env, \emptygraph)) \evalarrow (\newenv, \newg) \OrDynError
+  \evalglobals(\typedspec, (\env, \emptygraph)) \evalarrow (\newenv, \newg) \OrDynErrorDiverging
 }{
   \buildgenv(\tenv, \typedspec) \evalarrow (\newenv, \newg)
 }

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -30,7 +30,8 @@ The relation
   \overname{\TReturning}{\Returning((\vvs,\newg), \newenv)} & \cup\\
   \overname{\TContinuing}{\Continuing(\newg,\newenv)} & \cup\\
   \overname{\TThrowing}{\ThrowingConfig} & \cup \\
-  \overname{\TDynError}{\DynErrorConfig} &
+  \overname{\TDynError}{\DynErrorConfig} & \cup \\
+  \overname{\TDiverging}{\DivergingConfig} & \\
   \end{array}
   \right)
 \]
@@ -221,9 +222,9 @@ $\nvint(2)$ to the mutable variable~\texttt{b}, and discards $\nvint(3)$.
   \item $\les$ is a list of \assignableexpressions, each of which is either \\ a variable ($\LEVar(\Ignore)$)
         or a discarded variable (\LEDiscard);
   \item evaluating the subprogram call as per \chapref{SubprogramCalls} is
-        $\Normal(\vms, \envone)$\ProseOrAbnormal;
+        $\ResultCall(\vms, \envone)$\ProseOrAbnormal;
   \item assigning each value in $\vms$ to the respective element of the tuple $\les$ is \\
-        $\Normal(\vgtwo, \newg)$\ProseOrAbnormal.
+        $\ResultLexpr(\vgtwo, \newg)$\ProseOrAbnormal.
 \end{itemize}
 
 \FormallyParagraph
@@ -244,8 +245,8 @@ from a subprogram call are as follows:
 \inferrule{
   \vles \eqdef \vle_{1..k}\\
   i=1..k: \lexprisvar(\vle_i) \evalarrow \True\\
-  \evalcall(\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs) \evalarrow \Normal(\vms, \envone) \OrAbnormal\\\\
-  \evalmultiassignment(\envone, \vles, \vms) \evalarrow \Normal(\newg, \newenv) \OrAbnormal
+  \evalcall(\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs) \evalarrow \ResultCall(\vms, \envone) \OrAbnormal\\\\
+  \evalmultiassignment(\envone, \vles, \vms) \evalarrow \ResultLexpr(\newg, \newenv) \OrAbnormal
 }{
   \evalstmt{\env, \SAssign(\LEDestructuring(\les),\ECall(\vcall))} \\
   \evalarrow \Continuing(\newg, \newenv)
@@ -272,9 +273,9 @@ $\nvint(42)$, and $\newenv$ is such that \texttt{x} is bound to $\nvint(3)$.
           nor a discarded variable.
   \end{itemize}
   \item evaluating the expression $\vre$ in $\env$ yields
-        $\Normal(\vm, \envone)$ (here, $\vm$ is a pair consisting of a value and an execution graph)\ProseOrAbnormal;
+        $\ResultExpr(\vm, \envone)$ (here, $\vm$ is a pair consisting of a value and an execution graph)\ProseOrAbnormal;
   \item evaluating the \assignableexpression\ $\vle$ with $\vm$ in $\envone$,
-        as per \chapref{AssignableExpressions}, yields $\Normal(\newg, \newenv)$\ProseOrAbnormal.
+        as per \chapref{AssignableExpressions}, yields $\ResultLexpr(\newg, \newenv)$\ProseOrAbnormal.
 \end{itemize}
 
 \FormallyParagraph
@@ -288,8 +289,8 @@ $\nvint(42)$, and $\newenv$ is such that \texttt{x} is bound to $\nvint(3)$.
   \end{array}
   \right)
   }\\
-  \evalexpr{\env, \vre} \evalarrow \Normal(\vm, \envone) \OrAbnormal\\
-  \evallexpr{\envone, \vle, \vm} \evalarrow \Normal(\newg, \newenv) \OrAbnormal
+  \evalexpr{\env, \vre} \evalarrow \ResultExpr(\vm, \envone) \OrAbnormal\\
+  \evallexpr{\envone, \vle, \vm} \evalarrow \ResultLexpr(\newg, \newenv) \OrAbnormal
 }{
   \evalstmt{\env, \SAssign(\vle, \vre)} \evalarrow \Continuing(\newg, \newenv)
 }
@@ -899,24 +900,26 @@ In \listingref{semantics-sdeclnone},
   \item \AllApplyCase{some}
   \begin{itemize}
     \item $\vs$ is a declaration with an initial value,
-    $\SDecl(\Ignore, \ldi, \Ignore, \langle\ve\rangle)$;
-    \item evaluating $\ve$ in $\env$ is $\Normal(\vm, \envone)$\ProseOrAbnormal;
+          $\SDecl(\Ignore, \ldi, \Ignore, \langle\ve\rangle)$;
+    \item evaluating $\ve$ in $\env$ is $\ResultExpr(\vm, \envone)$\ProseOrAbnormal;
     \item evaluating the local declaration $\ldi$ with $\vm$ as the initializing
-    value in $\envone$ as per \chapref{LocalStorageDeclarations} is $\Normal(\newg, \newenv)$;
+          value in $\envone$ as per \chapref{LocalStorageDeclarations} is
+          $\ResultLexpr(\newg, \newenv)$;
     \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
   \end{itemize}
 
   \item \AllApplyCase{none}
   \begin{itemize}
     \item $\vs$ is a declaration without an initial value, $\SDecl(\Ignore, \ldi, \Ignore, \None)$;
-    \item the result is a dynamic error.
+    \item the result is a \dynamicerrorterm.
   \end{itemize}
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[some]{
-  \evalexpr{\env, \ve} \evalarrow \Normal(\vm, \envone) \OrAbnormal\\
-  \evallocaldecl{\envone, \ldi, \vm} \evalarrow \Normal(\newg, \newenv)\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr(\vm, \envone) \OrAbnormal\\
+  \evallocaldecl{\envone, \ldi, \vm} \evalarrow \ResultLexpr(\newg, \newenv)\\
 }{
   \evalstmt{\env, \SDecl(\Ignore, \ldi, \Ignore, \langle\ve\rangle)} \evalarrow \Continuing(\newg, \newenv)
 }
@@ -929,7 +932,7 @@ In \listingref{semantics-sdeclnone},
 \end{mathpar}
 \CodeSubsection{\EvalSDeclBegin}{\EvalSDeclEnd}{../Interpreter.ml}
 
-\section{Declaration statements with an elided parameter \label{sec:DeclarationStatementsElidedParameter}}
+\section{Declaration statements with an elided parameter\label{sec:DeclarationStatementsElidedParameter}}
 \subsection{Syntax}
 \begin{flalign*}
 \Nstmt \derives \
@@ -1184,27 +1187,28 @@ evaluates \texttt{let y = x + 1}.
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item $\vs$ is a \emph{sequencing statement} \texttt{s1; s2}, that is, $\SSeq(\vsone, \vstwo)$;
+  \item $\vs$ is a \sequencingstatementterm{} \texttt{s1; s2}, that is, $\SSeq(\vsone, \vstwo)$;
   \item evaluating $\vsone$ in $\env$ is either $\Continuing(\vgone, \envone)$ in which case
-  the evaluation continues,
-  or a returning configuration ($\Returning((\vvs, \newg), \newenv)$)\ProseOrAbnormal;
+        the evaluation continues,
+        or a returning configuration ($\Returning((\vvs, \newg), \newenv)$)
+        or an abnormal configuration, which short-circuit the entire evaluation;
   \item evaluating $\vstwo$ in $\envone$ yields a non-abnormal configuration \\
-        (either $\Normal$ or $\Continuing$) $C$\ProseOrAbnormal;
+        (either $\Returning$ or $\Continuing$) $C$\ProseOrAbnormal;
   \item $\newg$ is the ordered composition of $\vgone$ and the execution graph of $C$ with the
-  $\aslpo$ edge;
+        $\aslpo$ edge;
   \item $D$ is the configuration $C$ with the execution graph component replaced with $\newg$.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
-  \inferrule{
-    \evalstmt{\env, \vsone} \evalarrow \Continuing(\vgone, \envone) \terminateas \ReturningConfig,\ThrowingConfig,\DynErrorConfig\\
-    \evalstmt{\envone, \vstwo} \evalarrow C \OrAbnormal\\
-    \newg \eqdef \ordered{\vgone}{\aslpo}{\graphof{C}}\\
-    D \eqdef \withgraph{C}{\newg}
-  }
-  {
-    \evalstmt{\env, \SSeq(\vsone, \vstwo)} \evalarrow D
-  }
+\inferrule{
+  \evalstmt{\env, \vsone} \evalarrow \Continuing(\vgone, \envone) \OrAbnormal,\ReturningConfig\\\\
+  \evalstmt{\envone, \vstwo} \evalarrow C \OrAbnormal\\\\
+  \newg \eqdef \ordered{\vgone}{\aslpo}{\graphof{C}}\\
+  D \eqdef \withgraph{C}{\newg}
+}{
+  \evalstmt{\env, \SSeq(\vsone, \vstwo)} \evalarrow D
+}
 \end{mathpar}
 \CodeSubsection{\EvalSSeqBegin}{\EvalSSeqEnd}{../Interpreter.ml}
 
@@ -1286,7 +1290,7 @@ can only be used for procedures, not functions.
 \begin{itemize}
   \item $\vs$ is a call statement, $\SCall(\vcall)$;
   \item evaluating the subprogram call as per \chapref{SubprogramCalls} is
-  \\ $\Normal(\newg, \newenv)$\ProseOrAbnormal;
+  \\ $\ResultCall(\newg, \newenv)$\ProseOrAbnormal;
   \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
 \end{itemize}
 
@@ -1296,7 +1300,7 @@ can only be used for procedures, not functions.
 {
 \begin{array}{r}
   \evalcall(\env, \vcall.\callname, \vcall.\callparams, \vcall.\callargs) \evalarrow \\
-  \Normal(\newg, \newenv) \OrAbnormal
+  \ResultCall(\newg, \newenv) \OrAbnormal
 \end{array}
 }
 }{
@@ -1429,13 +1433,13 @@ The specification in \listingref{semantics-scond4} does not result in any error.
 \AllApply
 \begin{itemize}
 \item $\vs$ is a condition statement, $\SCond(\ve, \vsone, \vstwo)$;
-\item evaluating $\ve$ in $\env$ is $\Normal(\vv, \vgone)$\ProseOrAbnormal;
+\item evaluating $\ve$ in $\env$ yields $\ResultExpr((\vv, \vgone), \envone)$\ProseOrAbnormal;
 \item $\vv$ is a native Boolean for $\vb$;
 \item the statement $\vsp$ is $\vsone$ is $\vb$ is $\True$ and $\vstwo$ otherwise
-(so that $\vsone$ will be evaluated if the condition evaluates to $\True$ and otherwise
-$\vstwo$ will be evaluated);
+      (so that $\vsone$ will be evaluated if the condition evaluates to $\True$ and otherwise
+      $\vstwo$ will be evaluated);
 \item evaluating $\vsp$ in $\envone$ as per \chapref{BlockStatements} is a non-abnormal configuration
-      (either $\Normal$ or $\Continuing$) $C$\ProseOrAbnormal;
+      (either $\Returning$ or $\Continuing$) $C$\ProseOrAbnormal;
 \item $\vg$ is the ordered composition of $\vgone$ and the execution graph of the configuration $C$;
 \item $D$ is the configuration $C$ with the execution graph component updated to be $\vg$.
 \end{itemize}
@@ -1443,7 +1447,7 @@ $\vstwo$ will be evaluated);
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vv, \vgone), \envone) \OrAbnormal\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vv, \vgone), \envone) \OrAbnormal\\\\
   \vv \eqname \nvbool(\vb)\\
   \vsp \eqdef \choice{\vb}{\vsone}{\vstwo}\\
   \evalblock{\envone, \vsp} \evalarrow C \OrAbnormal\\\\
@@ -1864,14 +1868,14 @@ evaluating \texttt{assert (42 == 3);} results in an \DynamicAssertionFailure{} e
   \begin{itemize}
     \item \AllApplyCase{okay}
     \begin{itemize}
-      \item evaluating $\ve$ in $\env$ is $\Normal((\vv, \newg), \newenv)$\ProseOrAbnormal;
+      \item evaluating $\ve$ in $\env$ is $\ResultExpr((\vv, \newg), \newenv)$\ProseOrAbnormal;
       \item $\vv$ is a native Boolean value for $\True$;
       \item the resulting configuration is $\Continuing(\newg, \newenv)$.
     \end{itemize}
 
     \item \AllApplyCase{error}
     \begin{itemize}
-      \item evaluating $\ve$ in $\env$ is $\Normal((\vv, \newg), \newenv)$;
+      \item evaluating $\ve$ in $\env$ is $\ResultExpr((\vv, \newg), \newenv)$;
       \item $\vv$ is a native Boolean value for $\False$;
       \item the result is a dynamic error indicating the assertion failure returned (\DynamicAssertionFailure).
     \end{itemize}
@@ -1881,7 +1885,7 @@ evaluating \texttt{assert (42 == 3);} results in an \DynamicAssertionFailure{} e
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[okay]{
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vv, \newg), \newenv) \OrAbnormal\\\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vv, \newg), \newenv) \OrAbnormal\\\\
   \vv \eqname \nvbool(\True)
 }{
   \evalstmt{\env, \SAssert(\ve)} \evalarrow \Continuing(\newg, \newenv)
@@ -1890,7 +1894,7 @@ evaluating \texttt{assert (42 == 3);} results in an \DynamicAssertionFailure{} e
 
 \begin{mathpar}
   \inferrule[error]{
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vv, \Ignore), \Ignore)\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vv, \Ignore), \Ignore)\\
   \vv \eqname \nvbool(\False)
 }{
   \evalstmt{\env, \SAssert(\ve)} \evalarrow \DynamicErrorVal{\DynamicAssertionFailure}
@@ -2097,10 +2101,10 @@ the output configuration $C$.
 \begin{itemize}
   \item $\vs$ is a \texttt{while} statement, $\SWhile(\ve, \velimitopt, \vbody)$;
   \item evaluating the optional limit expression $\velimitopt$ via $\evallimit$ in $\env$
-        yields $(\vlimitopt, \vgone)$\ProseOrError;
+        yields $(\vlimitopt, \vgone)$\ProseOrDynErrorDiverging;
   \item evaluating the loop as per \SemanticsRuleRef{Loop} in an environment $\env$,
   with the arguments $\True$ (which conveys that this is a \texttt{while} statement), $\vlimitopt$, $\ve$, and $\vbody$
-  yields the (non-error configuration) $C$\ProseOrError;
+  yields the (non-error configuration) $C$\ProseOrDynErrorDiverging;
   \item $\vgtwo$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge;
   \item the output configuration $D$ is the output configuration $C$ with its execution graph
         substituted with $\vgtwo$.
@@ -2108,8 +2112,8 @@ the output configuration $C$.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evallimit(\env, \velimitopt) \evalarrow (\vlimitopt, \vgone) \OrDynError\\\\
-  \evalloop{\env, \True, \vlimitopt, \ve, \vbody} \evalarrow C \OrDynError\\\\
+  \evallimit(\env, \velimitopt) \evalarrow (\vlimitopt, \vgone) \OrDynErrorDiverging\\\\
+  \evalloop{\env, \True, \vlimitopt, \ve, \vbody} \evalarrow C \OrDynErrorDiverging\\\\
   \vgtwo \eqdef \ordered{\vgone}{\asldata}{\graphof{C}}\\
   D \eqdef \withgraph{C}{\vgtwo}
 }{
@@ -2158,7 +2162,7 @@ and the specification terminates with exit code $0$.
 \begin{itemize}
 \item \AllApplyCase{exit}
   \begin{itemize}
-    \item evaluating $\econd$ in $\env$ is $\Normal(\condm, \newenv)$\ProseOrAbnormal;
+    \item evaluating $\econd$ in $\env$ is $\ResultExpr(\condm, \newenv)$\ProseOrAbnormal;
     \item $\condm$ consists of a native Boolean for $\vb$ and an execution graph $\newg$;
     \item $\vb$ is not equal to $\iswhile$;
     \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$
@@ -2166,16 +2170,16 @@ and the specification terminates with exit code $0$.
   \end{itemize}
 \item \AllApplyCase{continue}
   \begin{itemize}
-    \item evaluating $\econd$ in $\env$ is $\Normal(\condm, \envone)$;
+    \item evaluating $\econd$ in $\env$ is $\ResultExpr(\condm, \envone)$\ProseOrAbnormal;
     \item $\mcond$ consists of a native Boolean for $\vb$ and an execution graph $\vgone$;
     \item $\vb$ is equal to $\iswhile$;
     \item \Proseticklooplimit{$\vlimitopt$}{$\vlimitoptp$}\ProseOrError;
     \item evaluating $\vbody$ in $\envone$ as per \SemanticsRuleRef{Block} is either \\
-    $\Continuing(\vgtwo, \envtwo)$\ProseTerminateAs{\ReturningConfig, \ThrowingConfig, \DynErrorConfig};
+          $\Continuing(\vgtwo, \envtwo)$\ProseTerminateAs{\ReturningConfig, \ThrowingConfig, \DynErrorConfig, \TDiverging};
     \item evaluating $(\iswhile, \vlimitoptp, \econd, \vbody)$ in $\envtwo$ as a loop is \\
-    $\Continuing(\vgthree, \newenv)$\ProseTerminateAs{\ReturningConfig, \ThrowingConfig, \DynErrorConfig};
+          $\Continuing(\vgthree, \newenv)$\ProseTerminateAs{\ReturningConfig, \ThrowingConfig, \DynErrorConfig, \TDiverging};
     \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\aslctrl$ label
-    and then the ordered composition of the result and $\vgthree$ with the $\aslpo$ edge;
+          and then the ordered composition of the result and $\vgthree$ with the $\aslpo$ edge;
     \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
   \end{itemize}
 \end{itemize}
@@ -2188,7 +2192,7 @@ The negation of the condition is used to decide whether to continue the loop ite
 
 \begin{mathpar}
 \inferrule[exit]{
-  \evalexpr{\env, \econd} \evalarrow \Normal(\condm, \newenv) \OrAbnormal\\
+  \evalexpr{\env, \econd} \evalarrow \ResultExpr(\condm, \newenv) \OrAbnormal\\\\
   \condm \eqname (\nvbool(\vb), \newg)\\
   \vb \neq \iswhile
 }{
@@ -2198,15 +2202,15 @@ The negation of the condition is used to decide whether to continue the loop ite
 
 \begin{mathpar}
 \inferrule[continue]{
-  \evalexpr{\env, \econd} \evalarrow \Normal(\condm, \envone)\\
+  \evalexpr{\env, \econd} \evalarrow \ResultExpr(\condm, \envone) \OrAbnormal\\\\
   \condm \eqname (\nvbool(\vb), \vgone)\\
   \vb = \iswhile\\
   \ticklooplimit(\vlimitopt) \evalarrow \vlimitoptp \OrDynError\\\\
-  \evalblock{\envone, \vbody} \evalarrow \Continuing(\vgtwo, \envtwo) \terminateas \ReturningConfig, \ThrowingConfig, \DynErrorConfig\\
+  \evalblock{\envone, \vbody} \evalarrow \Continuing(\vgtwo, \envtwo) \OrAbnormal, \ReturningConfig\\\\
   {
     \begin{array}{r}
       \evalloop{\envtwo, \iswhile, \vlimitoptp, \econd, \vbody} \evalarrow \\
-      \Continuing(\vgthree, \newenv) \terminateas \ReturningConfig, \ThrowingConfig, \DynErrorConfig\\
+      \Continuing(\vgthree, \newenv) \OrAbnormal, \ReturningConfig\\
     \end{array}
   }\\
   \newg \eqdef \ordered{\ordered{\vgone}{\aslctrl}{\vgtwo}}{\aslpo}{\vgthree}
@@ -2221,12 +2225,18 @@ The relation
 \hypertarget{def-evallimit}{}
 \[
 \evallimit(\overname{\env}{\envs} \aslsep \overname{\velimitopt}{\expr?})
-\aslto (\overname{\langle\N\rangle}{\vvopt}, \overname{\vg}{\XGraphs})
-\cup \overname{\TDynError}{\DynErrorConfig}
+\;\aslrel\;
+\left(
+\begin{array}{ll}
+(\overname{\langle\N\rangle}{\vvopt}, \overname{\XGraphs}{\vg}) & \cup\\
+\overname{\TDynError}{\DynErrorConfig} & \cup\\
+\overname{\TDiverging}{\DivergingConfig} & \\
+\end{array}
+\right)
 \]
 evaluates the optional expression $\velimitopt$ in the environment $\env$, yielding
 the optional integer value $\vvopt$ and execution graph $\vg$.
-\ProseOrError
+\ProseOtherwiseDynamicErrorOrDiverging
 
 The evaluation uses the function $\evalexprsef$ because limit expressions are
 guaranteed side-effect-free by the typechecker,
@@ -2249,8 +2259,8 @@ of the \whilestatementterm.
   \item \AllApplyCase{some}
   \begin{itemize}
     \item $\velimitopt$ is the expression $\velimit$;
-    \item evaluating the side-effect-free expression $\velimitopt$ in $denv$ yields the native integer for $\vv$ and
-          the execution graph $\vg$;
+    \item evaluating the side-effect-free expression $\velimitopt$ in $\denv$ yields the native integer for $\vv$ and
+          the execution graph $\vg$\ProseOrDynErrorDiverging;
     \item $\vvopt$ is $\langle\vv\rangle$.
   \end{itemize}
 \end{itemize}
@@ -2264,7 +2274,7 @@ of the \whilestatementterm.
 
 \begin{mathpar}
 \inferrule[some]{
-  \evalexprsef{\env, \velimit} \evalarrow (\nvint(\vv), \vg) \OrDynError
+  \evalexprsef{\env, \velimit} \evalarrow (\nvint(\vv), \vg) \OrDynErrorDiverging
 }{
   \evallimit(\env, \overname{\langle\velimit\rangle}{\velimitopt}) \evalarrow (\overname{\langle\vv\rangle}{\vvopt}, \vg)
 }
@@ -2433,10 +2443,10 @@ either \\ $\Returning((\vvs, \newg), \newenv)$ or an output configuration $D$.
 \begin{itemize}
   \item $\vs$ is a \texttt{repeat} statement, $\SRepeat(\ve, \vbody, \velimitopt)$;
   \item evaluating the optional limit expression $\velimitopt$ via $\evallimit$ in $\env$
-        yields $(\vlimitopt, \vgone)$\ProseOrError;
+        yields $(\vlimitopt, \vgone)$\ProseOrDynErrorDiverging;
   \item \Proseticklooplimit{$\vlimitoptone$}{$\vlimitopttwo$}\ProseOrError;
   \item evaluating $\vbody$ in $\env$ as per \chapref{BlockStatements}
-        yields $\Continuing(\vgtwo, \envone)$\ProseTerminateAs{\ReturningConfig,\ThrowingConfig,\DynErrorConfig};
+        yields $\Continuing(\vgtwo, \envone)$\ProseTerminateAs{\ReturningConfig,\ThrowingConfig,\DynErrorConfig,\DivergingConfig};
   \item evaluating the loop as per \secref{SemanticsRule.Loop} in an environment $\envone$,
         with the arguments $\False$ (which conveys that this is a \texttt{repeat} statement),
         $\vlimitopttwo$,
@@ -2451,9 +2461,9 @@ either \\ $\Returning((\vvs, \newg), \newenv)$ or an output configuration $D$.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evallimit(\env, \velimitopt) \evalarrow (\vlimitoptone, \vgone) \OrDynError\\\\
+  \evallimit(\env, \velimitopt) \evalarrow (\vlimitoptone, \vgone) \OrDynErrorDiverging\\\\
   \ticklooplimit(\vlimitoptone) \evalarrow \vlimitopttwo \OrDynError\\\\
-  \evalblock{\env, \vbody} \evalarrow \Continuing(\vgtwo, \envone) \terminateas \ReturningConfig,\ThrowingConfig,\DynErrorConfig\\\\
+  \evalblock{\env, \vbody} \evalarrow \Continuing(\vgtwo, \envone) \OrAbnormal, \ReturningConfig\\\\
   \evalloop{\envone, \False, \vlimitopttwo, \ve, \vbody} \evalarrow C\\
   \vgthree \eqdef \ordered{\vgone}{\asldata}{\ordered{\vgtwo}{\aslpo}{\graphof{C}}}\\
   D \eqdef \withgraph{C}{\vgthree}
@@ -2784,14 +2794,16 @@ whose body does not evaluate since its lower bound is greater than its upper bou
     \Forbody &:& \vbody\\
     \Forlimit &:& \Ignore
   \end{array}\right\}$;
-  \item evaluating the side-effect-free expression $\vstarte$ in $\env$ yields
-        $\Normal(\vstartv, \vgone)$\ProseOrError;
-  \item evaluating the side-effect-free expression $\vende$ in $\env$ yields
-        $\Normal(\vendv, \vgtwo)$\ProseOrError;
-  \item \Proseevallimit{$\env$}{$\velimitopt$}{$\Normal(\vlimitopt, \vgthree)$}\ProseOrError;
+  \item evaluating the side-effect-free expression $\vstarte$ in $\env$ yields\\
+        $\ResultExprSEF(\vstartv, \vgone)$\ProseOrDynErrorDiverging;
+  \item evaluating the side-effect-free expression $\vende$ in $\env$ yields\\
+        $\ResultExprSEF(\vendv, \vgtwo)$\ProseOrError;
+  \item \Proseevallimit{$\env$}{$\velimitopt$}{$(\vlimitopt, \vgthree)$}\ProseOrDynErrorDiverging;
   \item declaring the local identifier $\vindexname$ in $\env$ with value $\vstartv$ is $(\vgfour, \envone)$;
-  \item evaluating the \texttt{for} loop with arguments $(\vindexname, \vlimitopt, \vstartv, \dir, \vendv, \vbody)$ in $\envone$,
-        as per \SemanticsRuleRef{EvalFor} yields $\Normal(\vgfive, \envtwo)$\ProseOrAbnormal;
+  \item applying the \texttt{for} loop with arguments \\
+        $(\vindexname, \vlimitopt, \vstartv, \dir, \vendv, \vbody)$ in $\envone$,
+        as per \\
+        \SemanticsRuleRef{EvalFor} yields $\Continuing(\vgfive, \envtwo)$\ProseReturningOrAbnormal;
   \item removing the local $\vindexname$ from $\envtwo$ is $\envthree$;
   \item $\newg$ is formed as follows:
         the parallel composition of $\vgone$, $\vgtwo$, and $\vgthree$;
@@ -2807,14 +2819,14 @@ side-effect-free, as guaranteed by \TypingRuleRef{SFor}, which is why
 they are evaluated via the rule for evaluating side-effect-free expressions.
 \begin{mathpar}
 \inferrule{
-  \evalexprsef{\env, \vstarte} \evalarrow \Normal(\vstartv, \vgone) \OrDynError\\\\
-  \evalexprsef{\env, \vende} \evalarrow \Normal(\vendv, \vgtwo) \OrDynError\\\\
-  \evallimit(\env, \velimitopt) \evalarrow \Normal(\vlimitopt, \vgthree) \OrDynError\\\\
+  \evalexprsef{\env, \vstarte} \evalarrow \ResultExprSEF(\vstartv, \vgone) \OrDynErrorDiverging\\\\
+  \evalexprsef{\env, \vende} \evalarrow \ResultExprSEF(\vendv, \vgtwo) \OrDynErrorDiverging\\\\
+  \evallimit(\env, \velimitopt) \evalarrow (\vlimitopt, \vgthree) \OrDynErrorDiverging\\\\
   \declarelocalidentifier(\env, \vindexname, \vstartv) \evalarrow (\vgfour,\envone)\\
   {
     \begin{array}{r}
       \evalfor(\envone, \vindexname, \vlimitopt, \vstartv, \dir, \vendv, \vbody) \evalarrow \\
-      \Normal(\vgfive, \envtwo) \OrAbnormal
+      \Continuing(\vgfive, \envtwo) \OrReturningOrAbnormal
     \end{array}
   }\\
   \removelocal(\envtwo, \vindexname) \evalarrow \envthree\\
@@ -2823,7 +2835,7 @@ they are evaluated via the rule for evaluating side-effect-free expressions.
 }{
   {
   \begin{array}{r}
-  \evalstmt{\env,
+  \evalstmtname\left(\env,
   \overname{
   \SFor\left\{\begin{array}{rcl}
     \Forindexname &:& \vindexname\\
@@ -2832,7 +2844,8 @@ they are evaluated via the rule for evaluating side-effect-free expressions.
     \Forende &:& \vende\\
     \Forbody &:& \vbody\\
     \Forlimit &:& \velimitopt\\
-  \end{array}\right\}}{\vs}} \evalarrow \\ \Continuing(\newg, \newenv)
+  \end{array}\right\}}{\vs}
+  \right) \evalarrow \\ \Continuing(\newg, \newenv)
   \end{array}
   }
 }
@@ -2843,21 +2856,25 @@ they are evaluated via the rule for evaluating side-effect-free expressions.
 The relation
 \hypertarget{def-evalfor}{}
 \[
-  \evalfor(
-    \overname{\envs}{\env} \aslsep
-    \overname{\Identifiers}{\vindexname} \aslsep
-    \overname{\langle\tint\rangle}{\vlimitopt} \aslsep
-    \overname{\tint}{\vstart} \aslsep
-    \overname{\{\UP, \DOWN\}}{\dir} \aslsep
-    \overname{\tint}{\vend} \aslsep
-    \overname{\stmt}{\vbody})
+  \evalfor\left(
+  \begin{array}{cl}
+    \overname{\envs}{\env}                      & \aslsep\\
+    \overname{\Identifiers}{\vindexname}        & \aslsep\\
+    \overname{\langle\tint\rangle}{\vlimitopt}  & \aslsep\\
+    \overname{\tint}{\vstart}                   & \aslsep\\
+    \overname{\{\UP, \DOWN\}}{\dir}             & \aslsep\\
+    \overname{\tint}{\vend}                     & \aslsep\\
+    \overname{\stmt}{\vbody}                    &
+  \end{array}
+  \right)
   \;\aslrel\;
   \left(
     \begin{array}{cl}
     \overname{\TReturning}{\ReturningConfig} & \cup\\
     \overname{\TContinuing}{\ContinuingConfig} & \cup\\
     \overname{\TThrowing}{\ThrowingConfig} & \cup\\
-    \overname{\TDynError}{\DynErrorConfig} &
+    \overname{\TDynError}{\DynErrorConfig} & \cup\\
+    \overname{\TDiverging}{\DivergingConfig} & \\
     \end{array}
     \right)
 \]
@@ -2872,36 +2889,52 @@ The evaluation utilizes two helper relations: $\evalforstep$ and $\evalforloop$.
 \hypertarget{def-evalforstep}{}
 The helper relation
 \[
-  \evalforstep(
-    \overname{\envs}{\env},
-    \overname{\Identifiers}{\vindexname},
-    \overname{\langle\tint\rangle}{\vlimitopt} \aslsep
-    \overname{\tint}{\vstart},
-    \overname{\{\UP,\DOWN\}}{\dir})
-    \;\aslrel\;
-    ((\overname{\tint}{\vstep} \times \overname{\envs}{\newenv}) \times \overname{\XGraphs}{\newg})
+  \evalforstep\left(
+  \begin{array}{cl}
+  \overname{\envs}{\env}                      & \aslsep\\
+  \overname{\Identifiers}{\vindexname}        & \aslsep\\
+  \overname{\langle\tint\rangle}{\vlimitopt}  & \aslsep\\
+  \overname{\tint}{\vstart}                   & \aslsep\\
+  \overname{\{\UP,\DOWN\}}{\dir}              &
+  \end{array}
+  \right)
+  \;\aslrel\;
+  \left(
+  \begin{array}{cl}
+  ((\overname{\tint}{\vstep} \times \overname{\envs}{\newenv}) \times \overname{\XGraphs}{\newg}) & \cup\\
+  \overname{\TReturning}{\ReturningConfig}  & \cup\\
+  \overname{\TThrowing}{\ThrowingConfig}    & \cup \\
+  \overname{\TDynError}{\DynErrorConfig}    & \cup\\
+  \overname{\TDiverging}{\DivergingConfig}  &
+  \end{array}
+  \right)
 \]
 either increments or decrements the index variable,
 returning the new value of the index variable, the modified environment,
 and the resulting execution graph.
+\ProseOtherwiseReturningOrAbnormal
 
 \hypertarget{def-evalforloop}{}
 The helper relation
 \[
-  \evalforloop(\overname{
-    \envs}{\env},
-    \overname{\Identifiers}{\vindexname},
-    \overname{\langle\tint\rangle}{\vlimitopt},
-    \overname{\tint}{\vstart},
-    \overname{\{\UP,\DOWN\}}{\dir},
-    \overname{\tint}{\vend},
-    \overname{\stmt}{\vbody}) \;\aslrel\;
+  \evalforloop\left(
+    \begin{array}{cl}
+    \overname{\envs}{\env} \aslsep &\\
+    \overname{\Identifiers}{\vindexname} \aslsep &\\
+    \overname{\langle\tint\rangle}{\vlimitopt} \aslsep &\\
+    \overname{\tint}{\vstart} \aslsep &\\
+    \overname{\{\UP,\DOWN\}}{\dir} \aslsep &\\
+    \overname{\tint}{\vend} \aslsep &\\
+    \overname{\stmt}{\vbody} &
+    \end{array}
+    \right) \;\aslrel\;
     \left(
     \begin{array}{cl}
-      \overname{\TContinuing}{\Continuing(\newg, \newenv)} & \cup\\
-      \overname{\TReturning}{\ReturningConfig} & \cup\\
+    \overname{\TContinuing}{\Continuing(\newg, \newenv)} & \cup\\
+    \overname{\TReturning}{\ReturningConfig} & \cup\\
     \overname{\TThrowing}{\ThrowingConfig} & \cup \\
-    \overname{\TDynError}{\DynErrorConfig} &
+    \overname{\TDynError}{\DynErrorConfig} & \cup\\
+    \overname{\TDiverging}{\DivergingConfig} &
     \end{array}
     \right)
 \]
@@ -2954,16 +2987,18 @@ or an abnormal configuration.
     \begin{itemize}
     \item \AllApplyCase{return}
     \begin{itemize}
-      \item using $\compfordir$ to compare $\vend$ to $\vstart$ gives the native Boolean for $\True$;
+      \item using $\compfordir$ to compare $\vend$ to $\vstart$ gives the native \\
+            Boolean for $\True$;
       \item $\newg$ is $\vgone$;
       \item $\newenv$ is $\env$;
       \item the result of the entire evaluation is $\Continuing(\newg, \newenv)$.
     \end{itemize}
     \item \AllApplyCase{continue}
     \begin{itemize}
-      \item using $\compfordir$ to compare $\vend$ to $\vstart$ gives the native Boolean for $\False$;
+      \item using $\compfordir$ to compare $\vend$ to $\vstart$ gives the native \\
+            Boolean for $\False$;
       \item evaluating the loop body via $\evalforloop$ with \\ $(\vindexname, \vlimitopt, \vstart, \dir, \vend, \vbody)$
-      in $\env$ is \\ $\Continuing(\vgtwo, \newenv)$\ProseTerminateAs{\ReturningConfig, \ThrowingConfig, \DynErrorConfig};
+      in $\env$ is \\ $\Continuing(\vgtwo, \newenv)$\ProseOrAbnormalReturning;
       \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\aslctrl$ label.
     \end{itemize}
   \end{itemize}
@@ -2993,12 +3028,12 @@ Advancing the loop counter one step towards the end of its range is achieved via
 Running the loop body is achieved via the following rule:
 \begin{mathpar}
 \inferrule{
-  \evalblock{\env, \vbody} \evalarrow \Continuing(\vgone, \envone) \terminateas \ReturningConfig, \ThrowingConfig, \DynErrorConfig\\
+  \evalblock{\env, \vbody} \evalarrow \Continuing(\vgone, \envone) \OrAbnormalReturning\\\\
   \evalforstep(\envone, \vindexname, \vlimitopt, \vstart, \dir) \evalarrow ((\vstep, \envtwo), \vgtwo)\\
   {
     \begin{array}{r}
       \evalfor(\envtwo, \vindexname, \vlimitopt, \vstep, \dir, \vend, \vbody) \evalarrow \\
-      \Continuing(\vgthree, \newenv) \terminateas \ReturningConfig, \ThrowingConfig, \DynErrorConfig
+      \Continuing(\vgthree, \newenv) \OrAbnormalReturning
     \end{array}
   }\\
   \newg \eqdef \ordered{\ordered{\vgone}{\aslpo}{\vgtwo}}{\aslpo}{\vgthree}
@@ -3040,7 +3075,7 @@ $\evalforloop$ (the latter in a mutually recursive manner):
   \commonprefixline\\\\
   \binoprel(\compfordir, \vend, \vstart) \evalarrow \nvint(\False)\\
   \evalforloop(\env, \vindexname, \vnextlimitopt, \vstart, \dir, \vend, \vbody) \evalarrow \\
-  \Continuing(\vgtwo, \newenv) \terminateas \ReturningConfig, \ThrowingConfig, \DynErrorConfig\\\\
+  \Continuing(\vgtwo, \newenv) \OrAbnormalReturning\\\\
   \newg \eqdef \ordered{\vgone}{\aslctrl}{\vgtwo}
 }{
   {
@@ -3119,7 +3154,7 @@ show examples of well-typed \throwstatementsterm.
   (\overname{\SThrow(\None)}{\news}, \overname{\tenv}{\newtenv}, \overname{\{\LocalEffect(\SEImpure), \GlobalEffect(\SEImpure)\}}{\vses})
 }
 \end{mathpar}
-\lrmcomment{Note that \identr{BRCJ} is done in~\cite[SemanticsRule.TopLevel]{ASLSemanticsReference}.}
+\identr{BRCJ}
 
 \begin{mathpar}
 \inferrule[some]{
@@ -3166,7 +3201,7 @@ terminates successfully. That is, no dynamic error occurs.
   \begin{itemize}
     \item $\vs$ is a \texttt{throw} statement that provides an expression and a type, \\
           $\SThrow(\langle(\ve, \vt)\rangle)$;
-    \item evaluating $\ve$ in $\env$ is $\Normal((\vv, \vgone), \newenv)$\ProseOrAbnormal;
+    \item evaluating $\ve$ in $\env$ is $\ResultExpr((\vv, \vgone), \newenv)$\ProseOrAbnormal;
     \item $\name$ is a fresh identifier (which conceptually holds the exception value);
     \item $\vgtwo$ is a Write Effect to $\name$;
     \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge;
@@ -3185,7 +3220,7 @@ terminates successfully. That is, no dynamic error occurs.
 
 \begin{mathpar}
 \inferrule[some]{
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vv, \vgone), \newenv) \OrAbnormal\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vv, \vgone), \newenv) \OrAbnormal\\
   \name\in\Identifiers \text{ is fresh}\\
   \vgtwo \eqdef \WriteEffect(\name)\\
   \newg \eqdef \ordered{\vgone}{\asldata}{\vgtwo}\\
@@ -3358,14 +3393,15 @@ does not result in any Assertion error, and the specification terminates with th
 \begin{itemize}
   \item $\vs$ is a \texttt{try} statement, $\STry(\vs, \catchers, \otherwiseopt)$;
   \item evaluating $\vsone$ in $\env$ as per \chapref{BlockStatements}
-        yields the configuration $\sm$\ProseOrError;
+        yields the configuration $\sm$\ProseOrDynErrorDiverging;
   \item evaluating $(\catchers, \otherwiseopt, \sm)$ as per \chapref{CatchingExceptions}
         is $C$, which is the result of the entire evaluation.
 \end{itemize}
+
 \FormallyParagraph
 \begin{mathpar}
 \inferrule{
-  \evalblock{\env, \vsone} \evalarrow \sm \OrDynError\\\\
+  \evalblock{\env, \vsone} \evalarrow \sm \OrDynErrorDiverging\\\\
   \evalcatchers{\env, \catchers, \otherwiseopt, \sm} \evalarrow C
 }{
   \evalstmt{\env, \STry(\vsone, \catchers, \otherwiseopt)} \evalarrow C
@@ -3507,7 +3543,7 @@ In \listingref{semantics-sreturntuple},
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement;
     \item $\vs$ is a \texttt{return} statement for a single expression, $\SReturn(\langle\ve\rangle)$;
-    \item evaluating $\ve$ in $\env$ is $\Normal((\vv, \vgone), \newenv)$\ProseOrAbnormal;
+    \item evaluating $\ve$ in $\env$ is $\ResultExpr((\vv, \vgone), \newenv)$\ProseOrAbnormal;
     \item $\vvs$ is $[\vv]$;
     \item $\vgtwo$ is the result of adding a Write Effect for a fresh identifier and the value $\vv$;
     \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\asldata$ edge.
@@ -3517,7 +3553,7 @@ In \listingref{semantics-sreturntuple},
   \begin{itemize}
     \item $\vs$ is a \texttt{return} statement for a list of expressions, $\SReturn(\langle\ETuple(\es)\rangle)$;
     \item evaluating each expression in $\es$ separately as per \secref{SemanticsRule.EExprListM}
-    is \\ $\Normal(\ms, \newenv)$\ProseOrAbnormal;
+    is \\ $\ResultExprListM(\ms, \newenv)$\ProseOrAbnormal;
     \item writing the list of values in $\vms$ results in $(\vvs, \newg)$.
   \end{itemize}
 \end{itemize}
@@ -3532,7 +3568,7 @@ In \listingref{semantics-sreturntuple},
 
 \begin{mathpar}
 \inferrule[one]{
-  \evalexpr{\env, \ve} \evalarrow \Normal((\vv, \vgone), \newenv) \OrAbnormal\\\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vv, \vgone), \newenv) \OrAbnormal\\\\
   \wid \in \Identifiers\text{ is fresh}\\
   \writeidentifier(\wid, \vv) \evalarrow \vgtwo\\
   \newg \eqdef \ordered{\vgone}{\asldata}{\vgtwo}
@@ -3543,7 +3579,7 @@ In \listingref{semantics-sreturntuple},
 
 \begin{mathpar}
 \inferrule[tuple]{
-  \evalexprlistm(\env, \es) \evalarrow \Normal(\ms, \newenv) \OrAbnormal\\
+  \evalexprlistm(\env, \es) \evalarrow \ResultExprListM(\ms, \newenv) \OrAbnormal\\
   \writefolder(\ms) \evalarrow (\vvs, \newg)
 }{
   \evalstmt{\env, \SReturn(\langle\ETuple(\es)\rangle)} \evalarrow \Returning((\vvs, \newg), \newenv)
@@ -3555,9 +3591,15 @@ In \listingref{semantics-sreturntuple},
 \hypertarget{def-evalexprlistm}{}
 The helper relation
 \[
-  \evalexprlistm(\overname{\envs}{\env} \aslsep \overname{\expr^*}{\vEs}) \;\aslrel\;
-          \Normal(\overname{(\vals\times\XGraphs)^* }{\vms} \aslsep \overname{\envs}{\newenv}) \cup
-          \overname{\TThrowing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
+\evalexprlistm(\overname{\envs}{\env} \aslsep \overname{\expr^*}{\vEs}) \;\aslrel\;
+\left(
+\begin{array}{cl}
+\ResultExprListM(\overname{(\vals\times\XGraphs)^* }{\vms} \aslsep \overname{\envs}{\newenv}) & \cup\\
+\overname{\TThrowing}{\ThrowingConfig} & \cup \\
+\overname{\TDynError}{\DynErrorConfig} & \cup \\
+\overname{\TDiverging}{\DivergingConfig}
+\end{array}
+\right)
 \]
 evaluates a list of expressions $\vEs$ in left-to-right in the initial environment $\env$
 and returns the list of values associated with graphs $\vms$ and the new environment $\newenv$.
@@ -3579,10 +3621,10 @@ are evaluated in left-to-right order in the statement \verb|return (3 , 42);|.
   \item \AllApplyCase{non\_empty}
   \begin{itemize}
     \item $\vEs$ is a list with \head\ $\ve$ and \tail\ $\vesone$;
-    \item evaluating $\ve$ in $\env$ yields $\Normal(\vmone, \envone)$\ProseOrAbnormal;
+    \item evaluating $\ve$ in $\env$ yields $\ResultExpr(\vmone, \envone)$\ProseOrAbnormal;
     \item evaluating $\vesone$ in $\envone$ via $\evalexprlistm$ yields \\
-          $\Normal(\vmsone, \newenv)$\ProseOrAbnormal;
-    \item the result is the normal configuration with the list consisting of $\vmone$ as its \head\ and $\vmsone$
+          $\ResultExprListM(\vmsone, \newenv)$\ProseOrAbnormal;
+    \item the result is a configuration consisting of a list with $\vmone$ as its \head\ and $\vmsone$
           as its \tail\ and $\newenv$.
   \end{itemize}
 \end{itemize}
@@ -3591,7 +3633,7 @@ are evaluated in left-to-right order in the statement \verb|return (3 , 42);|.
 \begin{mathpar}
 \inferrule[empty]{}
 {
-  \evalexprlistm(\env, \overname{\emptylist}{\vEs}) \evalarrow \Normal(\overname{\emptylist}{\vms}, \overname{\env}{\newenv})
+  \evalexprlistm(\env, \overname{\emptylist}{\vEs}) \evalarrow \ResultExprListM(\overname{\emptylist}{\vms}, \overname{\env}{\newenv})
 }
 \end{mathpar}
 
@@ -3599,10 +3641,10 @@ are evaluated in left-to-right order in the statement \verb|return (3 , 42);|.
 \begin{mathpar}
 \inferrule[non\_empty]{
   \vEs = [\ve] \concat \vesone\\
-  \evalexpr{\env, \ve} \evalarrow \Normal(\vmone, \envone) \OrAbnormal\\
-  \evalexprlistm(\envone, \vesone) \evalarrow \Normal(\vmsone, \newenv) \OrAbnormal
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr(\vmone, \envone) \OrAbnormal\\
+  \evalexprlistm(\envone, \vesone) \evalarrow \ResultExprListM(\vmsone, \newenv) \OrAbnormal
 }{
-  \evalexprlistm(\env, \vEs) \evalarrow \Normal([\vmone]\concat\vmsone, \newenv)
+  \evalexprlistm(\env, \vEs) \evalarrow \ResultExprListM([\vmone]\concat\vmsone, \newenv)
 }
 \end{mathpar}
 
@@ -3763,17 +3805,18 @@ Notice that empty bitvectors are displayed as \verb|0x|.
 \begin{itemize}
   \item \AllApplyCase{print}
   \begin{itemize}
-    \item $\vs$ denotes a Print statement with arguments $\elist$ and newline indicator $\False$;
-    \item the evaluation of $\elist$ in $\env$ is $\Normal((\vlist, \vg), \newenv)$\ProseOrAbnormal;
+    \item $\vs$ denotes a \printstatementterm{} with arguments $\elist$ and newline indicator $\False$;
+    \item the evaluation of $\elist$ in $\env$ is $\ResultExprList((\vlist, \vg), \newenv)$\ProseOrAbnormal;
     \item \Proseoutputtoconsole{all the elements in $\elist$, without a separator,};
     \item if $\vnewline$ is $\True$, \Proseoutputtoconsole{a newline character};
   \end{itemize}
 
   \item \AllApplyCase{println}
   \begin{itemize}
-    \item $\vs$ denotes a Print statement with arguments $\elist$ and newline indicator $\True$;
+    \item $\vs$ denotes a \printstatementterm{} with arguments $\elist$ and newline indicator $\True$;
     \item the evaluation of the same statement with a newline indicator set to $\False$, that is,
-          $\SPrint(\elist, \False)$ yields the configuration $\Continuing(\vg, \envone)$\ProseOrAbnormal;
+          $\SPrint(\elist, \False)$ yields the configuration \\
+          $\Continuing(\vg, \envone)$\ProseOrAbnormal;
     \item \Proseoutputtoconsole{a newline character};
   \end{itemize}
   \item the resulting configuration is $\Continuing(\vg, \newenv)$.
@@ -3782,7 +3825,7 @@ Notice that empty bitvectors are displayed as \verb|0x|.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[print]{
-  \evalexprlist{\env, \elist} \evalarrow \Normal((\vlist, \vg), \env_1) \OrAbnormal\\
+  \evalexprlist{\env, \elist} \evalarrow \ResultExprList((\vlist, \vg), \env_1) \OrAbnormal\\
   \vi\in\listrange(\vlist): \outputtoconsole(\env_\vi, \vlist[i]) \evalarrow \env_{\vi + 1} \\
   n \eqdef \listlen{\vlist}\\
   \newenv \eqdef \env_{n + 1}
@@ -3791,6 +3834,7 @@ Notice that empty bitvectors are displayed as \verb|0x|.
 }
 \end{mathpar}
 
+\hypertarget{def-newline}{}
 We define the newline character $\vnewline \triangleq \ascii{10}$.
 
 \begin{mathpar}

--- a/asllib/doc/StaticEvaluation.tex
+++ b/asllib/doc/StaticEvaluation.tex
@@ -46,12 +46,12 @@ of the bitfield \verb|upper|, which fails the static evaluation of the expressio
   \begin{itemize}
     \item \AllApplyCase{normal\_literal}
     \begin{itemize}
-      \item evaluating $\ve$ in $\env$ yields $\Normal(\nvliteral{\vv}, \Ignore)$.
+      \item evaluating $\ve$ in $\env$ yields $\ResultExpr(\nvliteral{\vv}, \Ignore)$.
     \end{itemize}
 
     \item \AllApplyCase{normal\_non\_literal}
     \begin{itemize}
-      \item evaluating $\ve$ in $\env$ yields $\Normal(\vx, \Ignore)$
+      \item evaluating $\ve$ in $\env$ yields $\ResultExpr((\vx, \Ignore), \Ignore)$
             where $\vx$ is not a native value for a literal;
       \item the result is a \typingerrorterm{} indicating that $\ve$ cannot be statically evaluated to a literal.
     \end{itemize}
@@ -68,7 +68,7 @@ of the bitfield \verb|upper|, which fails the static evaluation of the expressio
 \begin{mathpar}
 \inferrule[normal\_literal]{
   \staticenvtoenv(\tenv) \typearrow \env\\
-  \evalexpr{\env, \ve} \evalarrow \Normal(\nvliteral{\vv}, \Ignore)
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\nvliteral{\vv}, \Ignore), \Ignore)
 }{
   \staticeval(\tenv, \ve) \typearrow \vv
 }
@@ -77,7 +77,7 @@ of the bitfield \verb|upper|, which fails the static evaluation of the expressio
 \begin{mathpar}
 \inferrule[normal\_non\_literal]{
   \staticenvtoenv(\tenv) \typearrow \env\\
-  \evalexpr{\env, \ve} \evalarrow \Normal(\vx, \Ignore)\\
+  \evalexpr{\env, \ve} \evalarrow \ResultExpr((\vx, \Ignore), \Ignore)\\
   \vx \neq \nvliteral{\Ignore}
 }{
   \staticeval(\tenv, \ve) \typearrow \TypeErrorVal{\StaticEvaluationFailure}

--- a/asllib/doc/SubprogramCalls.tex
+++ b/asllib/doc/SubprogramCalls.tex
@@ -1793,21 +1793,24 @@ We also define the following helper rules:
 The relation
 \hypertarget{def-evalcall}{}
 \[
-  \begin{array}{c}
-    \evalcall(\overname{\envs}{\env} \aslsep
-    \overname{\Identifiers}{\name} \aslsep
-    \overname{\expr^*}{\params} \aslsep
-    \overname{\expr^*}{\args}) \;\aslrel\; \\
-    \Normal(\overbracket{(\vals\times\XGraphs)^*}^{\vmstwo}, \overname{\envs}{\newenv}) \cup
-    \overname{\TThrowing}{\ThrowingConfig} \cup \overname{\TDynError}{\DynErrorConfig}
+  \evalcall(\overname{\envs}{\env} \aslsep
+  \overname{\Identifiers}{\name} \aslsep
+  \overname{\expr^*}{\params} \aslsep
+  \overname{\expr^*}{\args}) \;\aslrel\;
+  \left(
+  \begin{array}{ll}
+  \ResultCall(\overbracket{(\vals\times\XGraphs)^*}^{\vmstwo}, \overname{\envs}{\newenv}) & \cup \\
+  \overname{\TDynError}{\DynErrorConfig} & \cup \\
+  \overname{\TDiverging}{\DivergingConfig} & \\
   \end{array}
+  \right)
 \]
 evaluates a call to the subprogram named $\name$ in the environment $\env$,
 with the parameter expressions $\params$ and the argument expressions
 $\args$.
 The evaluation results in either a list of returned values, each one associated
-with an execution graph, and a new environment;
-or an abnormal configuration.
+with an execution graph, and a new environment.
+\ProseOtherwiseAbnormal
 
 The evaluation first evaluates the expressions corresponding to the arguments
 and parameters and then passes their values in a resulting configuration
@@ -1815,16 +1818,17 @@ to the helper relation $\evalsubprogram$.
 
 \ExampleDef{Calling Subprograms}
 In \listingref{Call}, calling \verb|non_throwing_func| terminates normally,
-while calling \verb|throwing_func| terminates by throwing an exception.
+while calling \\
+\verb|throwing_func| terminates by throwing an exception.
 \ASLListing{Calling subprograms}{Call}{\semanticstests/SemanticsRule.Call.asl}
 
 \ProseParagraph
 \AllApply
 \begin{itemize}
   \item evaluating each expression in $\params$ separately in $\env$ as per\\
-        \SemanticsRuleRef{EExprListM} is $\Normal(\vvparams, \envone)$\ProseOrAbnormal;
+        \SemanticsRuleRef{EExprListM} is $\ResultExprListM(\vvparams, \envone)$\ProseOrAbnormal;
   \item evaluating each expression in $\args$ separately in $\envone$ as per \\
-        \SemanticsRuleRef{EExprListM} is $\Normal(\vvargs, \envtwo)$\ProseOrAbnormal;
+        \SemanticsRuleRef{EExprListM} is $\ResultExprListM(\vvargs, \envtwo)$\ProseOrAbnormal;
   \item $\envtwo$ consists of the static environment $\tenv$ and the dynamic environment $\denvtwo$;
   \item applying $\incrstacksize$ to $G^\denvtwo$ and $\name$ yields $\genv$;
   \item the environment $\envtwo'$ is defined as the environment
@@ -1836,20 +1840,20 @@ while calling \verb|throwing_func| terminates by throwing an exception.
     \item \AllApplyCase{normal}
     \begin{itemize}
       \item evaluating the subprogram named $\name$ with parameters $\vvparams$ and arguments $\vvargs$ in
-      $\denvtwo'$ is $\Normal(\vms, (\vglobal, \Ignore))$ (that is, we ignore the local environment
-      of the callee)\ProseOrError;
+            $\denvtwo'$ is $\ResultSubprogram(\vms, (\vglobal, \Ignore))$ (that is, we ignore the local environment
+            of the callee)\ProseOrDynErrorDiverging;
       \item applying the helper relation $\readvaluefrom$ to each element of the list $\vms$ yields the list $\vmstwo$;
       \item applying $\decrstacksize$ to $\vglobal$ and $\name$ yields $\genvtwo$;
       \item define $\newenv$ as the environment where the static environment is $\tenv$ and the dynamic environment consists
             of the dynamic global environment $\genvtwo$ and the dynamic local environment is taken from $\denvtwo$
             (that is, we restore the local environment to that of the caller and drop the local environment of the callee).
-      \item the entire evaluation results in $\Normal(\vmstwo, \newenv)$.
+      \item the entire evaluation results in $\ResultCall(\vmstwo, \newenv)$.
     \end{itemize}
 
     \item \AllApplyCase{throwing}
     \begin{itemize}
       \item evaluating the subprogram named $\name$ with arguments $\vvargs$ and parameters $\vvparams$ in
-            $\denvtwo'$ is $\Throwing(\vv, \envthrow)$\ProseOrError;
+            $\denvtwo'$ is $\Throwing(\vv, \envthrow)$\ProseOrDynErrorDiverging;
       \item view $\envthrow$ as the environment consisting of the static environment $\tenv$,
             and the dynamic environment whose global component is $\vglobal$;
       \item applying the helper relation $\readvaluefrom$ to $\vms$ yields $\vmstwo$;
@@ -1857,7 +1861,7 @@ while calling \verb|throwing_func| terminates by throwing an exception.
       \item define $\newenv$ as the environment where the static environment is $\tenv$ and the dynamic environment consists
             of the dynamic global environment $\genvtwo$ and the dynamic local environment is taken from $\denvtwo$
             (that is, we restore the local environment to that of the caller and drop the local environment of the callee).
-      \item the entire evaluation results in $\Normal(\vmstwo, \newenv)$.
+      \item the entire evaluation results in $\ResultCall(\vmstwo, \newenv)$.
     \end{itemize}
   \end{itemize}
 \end{itemize}
@@ -1865,30 +1869,30 @@ while calling \verb|throwing_func| terminates by throwing an exception.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[normal]{
-  \evalexprlistm(\env, \params) \evalarrow \Normal(\vvparams, \envone)\OrAbnormal\\
-  \evalexprlistm(\envone, \args) \evalarrow \Normal(\vvargs, \envtwo)\OrAbnormal\\
+  \evalexprlistm(\env, \params) \evalarrow \ResultExprListM(\vvparams, \envone)\OrAbnormal\\\\
+  \evalexprlistm(\envone, \args) \evalarrow \ResultExprListM(\vvargs, \envtwo)\OrAbnormal\\\\
   \envtwo \eqname (\tenv, \denvtwo)\\
   \incrstacksize(G^\denvtwo, \name) \evalarrow \genv\\\\
   \envtwo' \eqdef (\tenv, (\genv, \emptyfunc))\\\\
   \commonprefixline\\\\
-  \evalsubprogram(\envtwo', \name, \vvparams, \vvargs) \evalarrow \Normal(\vms, (\vglobal, \Ignore)) \OrDynError\\\\
+  \evalsubprogram(\envtwo', \name, \vvparams, \vvargs) \evalarrow \ResultSubprogram(\vms, (\vglobal, \Ignore)) \OrDynErrorDiverging\\\\
   \vmstwo \eqdef [\vm \in \vms: \readvaluefrom(\vms)]\\
   \decrstacksize(\vglobal, \name) \evalarrow \genvtwo\\
   \newenv \eqdef (\tenv, (\genvtwo, L^{\denvtwo}))
 }{
-  \evalcall(\env, \name, \params, \args) \evalarrow \Normal(\vmstwo, \newenv)
+  \evalcall(\env, \name, \params, \args) \evalarrow \ResultCall(\vmstwo, \newenv)
 }
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[throwing]{
-  \evalexprlistm(\env, \args) \evalarrow \Normal(\vvargs, \envone)\OrAbnormal\\
-  \evalexprlistm(\envone, \params) \evalarrow \Normal(\vvparams, \envtwo)\OrAbnormal\\
+  \evalexprlistm(\env, \args) \evalarrow \ResultExprListM(\vvargs, \envone)\OrAbnormal\\\\
+  \evalexprlistm(\envone, \params) \evalarrow \ResultExprListM(\vvparams, \envtwo)\OrAbnormal\\\\
   \envtwo \eqname (\tenv, \denvtwo)\\
   \incrstacksize(G^\denvtwo, \name) \evalarrow \genv\\\\
   \envtwo' \eqdef (\tenv, (\genv, \emptyfunc))\\\\
   \commonprefixline\\\\
-  \evalsubprogram(\envtwo', \name, \vvparams, \vvargs) \evalarrow \Throwing(\vv, \envthrow) \OrDynError\\\\
+  \evalsubprogram(\envtwo', \name, \vvparams, \vvargs) \evalarrow \ResultSubprogram(\vv, \envthrow) \OrDynErrorDiverging\\\\
   \envthrow \eqname (\tenv, (\vglobal, \Ignore))\\
   \decrstacksize(\vglobal, \name) \evalarrow \genvtwo\\
   \newenv \eqdef (\tenv, (\genvtwo, L^{\denvtwo}))
@@ -1902,21 +1906,29 @@ while calling \verb|throwing_func| terminates by throwing an exception.
 The relation
 \hypertarget{def-evalsubprogram}{}
 \[
-  \begin{array}{c}
-    \evalsubprogram(\overname{\envs}{\env} \aslsep
-    \overname{\Identifiers}{\name} \aslsep
-    \overname{(\vals \times \XGraphs)^*}{\params} \aslsep
-    \overname{(\vals \times \XGraphs)^*}{\args}) \aslrel \\
-    \Normal(\overname{(\vals^* \aslsep \XGraphs)}{\vvs}, \overname{\envs}{\newenv}) \cup
-    \overname{\TThrowing}{\ThrowingConfig} \cup
-    \overname{\TDynError}{\DynErrorConfig}
+  \evalsubprogram\left(
+  \begin{array}{cl}
+  \overname{\envs}{\env} & \aslsep\\
+  \overname{\Identifiers}{\name} & \aslsep\\
+  \overname{(\vals \times \XGraphs)^*}{\params} & \aslsep\\
+  \overname{(\vals \times \XGraphs)^*}{\args} &
   \end{array}
+  \right)
+  \;\aslrel\;
+  \left(
+  \begin{array}{cl}
+  \ResultSubprogram(\overname{(\vals^* \aslsep \XGraphs)}{\vvs}, \overname{\envs}{\newenv}) & \cup\\
+  \overname{\TThrowing}{\ThrowingConfig} & \cup\\
+  \overname{\TDynError}{\DynErrorConfig} & \cup\\
+  \overname{\TDiverging}{\DivergingConfig} &
+  \end{array}
+  \right)
 \]
 evaluates the subprogram named $\name$ in the environment $\env$, with
 $\actualargs$ the list of actual arguments, and $\params$ the
 list of arguments deduced by type equality.
-The result is either a normal configuration or an abnormal configuration.
-In the case of a normal configuration, it consists of a list of pairs
+The result is either a \Prosenormalconfiguration{} or an abnormal configuration.
+In the case of a \Prosenormalconfiguration{}, it consists of a list of pairs
 with a value and an identifier, and a new environment $\newenv$.
 The values represent values returned by the subprogram call and the
 identifiers are used in generating execution graph constraints for the
@@ -1937,7 +1949,8 @@ the function \texttt{main} calls the function \texttt{foo} and the procedure \te
         $\vbody$, parameters $\paramdecls$, arguments $\argdecls$, and optional recursion limit expression $\vrecurselimit$;
   \item $\envone$ is the environment consisting of the static environment $\tenv$ and the dynamic
         environment consisting of the dynamic component from $\denv$ and an empty local component;
-  \item applying $\checkrecurselimit$ to $\name$ and $\vrecurselimit$ in $\envone$ yields $\vgone$\ProseOrError;
+  \item applying $\checkrecurselimit$ to $\name$ and $\vrecurselimit$ in $\envone$ yields \\
+        $\vgone$\ProseOrDynErrorDiverging;
   \item \Proseeqdef{$\argnames$}{the identifiers appearing as the first component of each pair in $\argdecls$};
   \item assigning the actual arguments with $((\envone, \emptygraph), \argnames, \args)$
         as per \SemanticsRuleRef{AssignArgs} gives $(\envtwo, \vgtwo)$ and ensures that each
@@ -1950,7 +1963,7 @@ the function \texttt{main} calls the function \texttt{foo} and the procedure \te
         locally bound to the corresponding actual value in $\params$;
   \item evaluating the body of the subprogram $\vbody$ as a statement in $\envthree$
         is $\vres$\ProseOrAbnormal;
-  \item matching the result $\vres$ to obtain a normal configuration as per \\
+  \item matching the result $\vres$ to obtain a \Prosenormalconfiguration{} as per \\
         \SemanticsRuleRef{MatchFuncRes} gives $C$;
   \item $\newg$ is the ordered composition of $\vgone$ with the $\asldata$ and $\vgtwo$ and $\vgthree$ with the $\aslpo$ edge;
   \item the result is $C$ with its graph substituted for $\newg$.
@@ -1972,7 +1985,7 @@ the function \texttt{main} calls the function \texttt{foo} and the procedure \te
       \right\}
   }\\
   \envone \eqdef (\tenv, (G^\denv, \emptyfunc))\\
-  \checkrecurselimit(\envone, \name, \vrecurselimit) \evalarrow \vgone \OrDynError\\\\
+  \checkrecurselimit(\envone, \name, \vrecurselimit) \evalarrow \vgone \OrDynErrorDiverging\\\\
   \argnames \eqdef [(\vx, \Ignore) \in \argdecls: \vx]\\
   \assignargs((\envone, \emptygraph), \argnames, \actualargs) \evalarrow (\envtwo, \vgtwo)\\
   \paramnames \eqdef [(\vx, \Ignore) \in \params: \vx]\\
@@ -2020,13 +2033,13 @@ and evaluating \verb|main| terminates with a \dynamicerrorterm{} (\LimitExceeded
 \begin{itemize}
   \item \AllApplyCase{none}
   \begin{itemize}
-    \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\None, \vg)$\ProseOrError;
+    \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\None, \vg)$\ProseOrDynErrorDiverging;
     \item define $\vg$ as the empty graph.
   \end{itemize}
 
   \item \AllApplyCase{some\_ok}
   \begin{itemize}
-    \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrError;
+    \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrDynErrorDiverging;
     \item view $\env$ as $(\tenv, \denv)$;
     \item applying $\getstacksize$ to $\name$ in $\denv$ yields $\vstacksize$;
     \item $\vstacksize$ is less than $\vlimit$.
@@ -2034,7 +2047,7 @@ and evaluating \verb|main| terminates with a \dynamicerrorterm{} (\LimitExceeded
 
   \item \AllApplyCase{limit\_exceeded}
   \begin{itemize}
-    \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrError;
+    \item applying $\evallimit$ to $\velimitopt$ in $\env$ yields $(\langle\vlimit\rangle, \vg)$\ProseOrDynErrorDiverging;
     \item view $\env$ as $(\tenv, \denv)$;
     \item applying $\getstacksize$ to $\name$ in $\denv$ yields $\vstacksize$;
     \item $\vstacksize$ is greater or equal to $\vlimit$;
@@ -2045,7 +2058,7 @@ and evaluating \verb|main| terminates with a \dynamicerrorterm{} (\LimitExceeded
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[none]{
-  \evallimit(\env, \velimitopt) \evalarrow (\None, \vg) \OrDynError
+  \evallimit(\env, \velimitopt) \evalarrow (\None, \vg) \OrDynErrorDiverging
 }{
   \checkrecurselimit(\env, \name, \velimitopt) \evalarrow \overname{\emptygraph}{\vg}
 }
@@ -2053,7 +2066,7 @@ and evaluating \verb|main| terminates with a \dynamicerrorterm{} (\LimitExceeded
 
 \begin{mathpar}
 \inferrule[some\_ok]{
-  \evallimit(\env, \velimitopt) \evalarrow (\langle\vlimit\rangle, \vg) \OrDynError\\\\
+  \evallimit(\env, \velimitopt) \evalarrow (\langle\vlimit\rangle, \vg) \OrDynErrorDiverging\\\\
   \env \eqname (\tenv, \denv)\\
   \getstacksize(\denv, \name) \evalarrow \vstacksize\\
   \vstacksize < \vlimit
@@ -2064,7 +2077,7 @@ and evaluating \verb|main| terminates with a \dynamicerrorterm{} (\LimitExceeded
 
 \begin{mathpar}
 \inferrule[limit\_exceeded]{
-  \evallimit(\env, \velimitopt) \evalarrow (\langle\vlimit\rangle, \vg) \OrDynError\\\\
+  \evallimit(\env, \velimitopt) \evalarrow (\langle\vlimit\rangle, \vg) \OrDynErrorDiverging\\\\
   \env \eqname (\tenv, \denv)\\
   \getstacksize(\denv, \name) \evalarrow \vstacksize\\
   \vstacksize \geq \vlimit
@@ -2166,7 +2179,7 @@ The helper relation
 \hypertarget{def-matchfuncres}{}
 \[
     \matchfuncres(\TContinuing \cup \TReturning) \;\aslrel\;
-                  \Normal(((\Identifiers\times\vals)^*\times\XGraphs)\aslsep\envs)
+                  \ResultSubprogram(((\Identifiers\times\vals)^*\times\XGraphs)\aslsep\envs)
 \]
 converts continuing configurations and returning configurations
 into corresponding normal configurations that can be returned by a subprogram evaluation.
@@ -2190,7 +2203,7 @@ with the same value and a fresh identifier for it.
   \begin{itemize}
     \item the given configuration is $\Continuing(\vg, \env)$. This happens when,
     for example, the subprogram called is either a setter or a procedure;
-    \item the result is $\Normal((\emptylist, \vg), \env)$.
+    \item the result is $\ResultSubprogram((\emptylist, \vg), \env)$.
   \end{itemize}
 
   \item \AllApplyCase{returning}
@@ -2199,7 +2212,7 @@ with the same value and a fresh identifier for it.
     \item $\xs$ is the list $\vv_i$, for $i=1..k$;
     \item define the list of fresh identifiers $\id_i$, for $i=1..k$;
     \item define $\vvs$ to be $(\vv_i, \id_i)$, for $i=1..k$;
-    \item the result is $\Normal((\vvs, \emptygraph), \retenv)$.
+    \item the result is $\ResultSubprogram((\vvs, \emptygraph), \retenv)$.
   \end{itemize}
 \end{itemize}
 
@@ -2207,7 +2220,7 @@ with the same value and a fresh identifier for it.
 \begin{mathpar}
   \inferrule[continuing]{}
   {
-    \matchfuncres(\Continuing(\vg, \env)) \evalarrow \Normal((\emptylist, \vg), \env)
+    \matchfuncres(\Continuing(\vg, \env)) \evalarrow \ResultSubprogram((\emptylist, \vg), \env)
   }
   \and
   \inferrule[returning]{
@@ -2216,6 +2229,6 @@ with the same value and a fresh identifier for it.
     \vvs \eqdef [i=1..k: (\vv_i, \id_i)]
   }
   {
-    \matchfuncres(\Returning(\xs, \retenv)) \evalarrow \Normal((\vvs, \emptygraph), \retenv)
+    \matchfuncres(\Returning(\xs, \retenv)) \evalarrow \ResultSubprogram((\vvs, \emptygraph), \retenv)
   }
 \end{mathpar}

--- a/asllib/doc/TopLevel.tex
+++ b/asllib/doc/TopLevel.tex
@@ -20,13 +20,14 @@ replaced with a translation to a hardware description language.
 \hypertarget{def-checkandinterpret}{}
 The relation
 \[
-\checkandinterpret(\overname{\Strings}{\vspectext}, \overname{\Strings}{\vstdtext}) \aslrel
+\checkandinterpret(\overname{\Strings}{\vspectext}, \overname{\Strings}{\vstdtext}) \;\aslrel\;
 \left(
     \begin{array}{cc}
         (\overname{\tint}{\vret} \times \overname{\XGraphs}{\vg})   & \cup\\
         \{\ \LexicalErrorConfig, \ParseErrorConfig, \BuildErrorConfig\ \}    & \cup\\
         \overname{\TTypeError}{\TypeErrorConfig}    & \cup\\
-        \overname{\TDynError}{\DynErrorConfig}      &
+        \overname{\TDynError}{\DynErrorConfig}      & \cup\\
+        \overname{\TDiverging}{\DivergingConfig} &
     \end{array}
 \right)
 \]
@@ -55,7 +56,7 @@ or a dynamic error.
     \item define $\vuntypedast$ as the concatenation of the AST $\vstdasbuiltin$ and
           the AST $\vspecast$ (both are lists of $\decl$);
     \item \Prosetypecheckast{$\vuntypedast$}{empty static global environment}{$\vtypedast$}{$\tenv$\ProseOrTypeError};
-    \item \Proseevalspec{$\vtypedast$}{$\tenv$}{the integer $\vret$ and the execution graph $\vg$\ProseOrError}.
+    \item \Proseevalspec{$\vtypedast$}{$\tenv$}{the integer $\vret$ and the execution graph $\vg$\ProseOrDynErrorDiverging}.
 \end{itemize}
 
 \FormallyParagraph
@@ -77,7 +78,7 @@ or a dynamic error.
     \buildast(\vspecparse) \astarrow \vspecast \terminateas \BuildErrorConfig\\\\
     \vuntypedast \eqdef \vstdasbuiltin \concat \vspecast\\
     \typecheckast(G^{\emptytenv}, \vuntypedast) \typearrow (\vtypedast, \tenv) \OrTypeError\\\\
-    \evalspec(\tenv, \vtypedast) \evalarrow (\nvint(\vret), \vg) \OrDynError
+    \evalspec(\tenv, \vtypedast) \evalarrow (\nvint(\vret), \vg) \OrDynErrorDiverging
 }{
     \checkandinterpret(\vspectext, \vstdtext) \longrightarrow (\nvint(\vret), \vg)
 }

--- a/asllib/doc/TypeDomains.tex
+++ b/asllib/doc/TypeDomains.tex
@@ -43,7 +43,7 @@ function $\annotatetype$.
 %
 Evaluation is defined by the relation $\evalexprsef\empty$.
 which evaluates side-effect-free expressions and either returns
-a configuration of the form $\Normal(\vv,\vg)$ or a dynamic error configuration $\DynErrorConfig$.
+a configuration of the form $\ResultExprSEF(\vv,\vg)$ or a dynamic error configuration $\DynErrorConfig$.
 In the first case, $\vv$ is a \nativevalue\ and $\vg$
 is an \emph{execution graph}. Execution graphs are related to the concurrent semantics
 and can be ignored in the context of defining dynamic domains.
@@ -110,10 +110,10 @@ by overloading $\dynamicdomain$:
     \item $\vd$ is the set containing the single native integer value for $n$.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_exact\_dynamic\_error}
+  \item \AllApplyCase{constraint\_exact\_abnormal}
   \begin{itemize}
     \item $\vc$ is a constraint consisting of a single side-effect-free expression $\ve$, that is, $\ConstraintExact(\ve)$;
-    \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
+    \item evaluating $\ve$ in $\env$ results in either a dynamic error configuration or diverges;
     \item $\vd$ is the empty set.
   \end{itemize}
 
@@ -125,18 +125,18 @@ by overloading $\dynamicdomain$:
     \item $\vd$ is the set containing all native integer values for integers greater or equal to $a$ and less than or equal to $b$.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_range\_dynamic\_error1}
+  \item \AllApplyCase{constraint\_range\_abnormal1}
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
-    \item evaluating $\veone$ in $\env$ results in a dynamic error configuration;
+    \item evaluating $\veone$ in $\env$ results in either a dynamic error configuration or diverges;
     \item $\vd$ is the empty set.
   \end{itemize}
 
-  \item \AllApplyCase{constraint\_range\_dynamic\_error2}
+  \item \AllApplyCase{constraint\_range\_abnormal2}
   \begin{itemize}
     \item $\vc$ is a range constraint consisting of a two side-effect-free expressions $\veone$ and $\vetwo$, that is, $\ConstraintRange(\veone, \vetwo)$;
     \item evaluating $\veone$ in $\env$ results in a configuration with the native integer for $a$;
-    \item evaluating $\vetwo$ in $\env$ results in a dynamic error configuration;
+    \item evaluating $\vetwo$ in $\env$ results in either a dynamic error configuration or diverges;
     \item $\vd$ is the empty set.
   \end{itemize}
 
@@ -150,7 +150,7 @@ by overloading $\dynamicdomain$:
   \item \AllApplyCase{t\_bits\_dynamic\_error}
   \begin{itemize}
     \item $\vt$ is a bitvector type with size expression $\ve$, $\TBits(\ve, \Ignore)$;
-    \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
+    \item evaluating $\ve$ in $\env$ results in either a dynamic error configuration or diverges;
     \item $\vd$ is the empty set.
   \end{itemize}
 
@@ -193,7 +193,7 @@ by overloading $\dynamicdomain$:
       \begin{itemize}
       \item \AllApplyCase{t\_array\_dynamic\_error}
       \begin{itemize}
-        \item evaluating $\ve$ in $\env$ results in a dynamic error configuration;
+        \item evaluating $\ve$ in $\env$ results in either a dynamic error configuration or diverges;
         \item $\vd$ is the empty set.
       \end{itemize}
 
@@ -269,13 +269,14 @@ by overloading $\dynamicdomain$:
 
 \begin{mathpar}
 \inferrule[constraint\_exact\_okay]{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(n), \Ignore)
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\nvint(n), \Ignore)
 }{
   \dynamicdomain(\env, \overname{\ConstraintExact(\ve)}{\vc}) = \overname{\{ \nvint(n) \}}{\vd}
 }
 \and
-\inferrule[constraint\_exact\_dynamic\_error]{
-  \evalexprsef{\env, \ve} \evalarrow \DynErrorConfig
+\inferrule[constraint\_exact\_abnormal]{
+  \evalexprsef{\env, \ve} \evalarrow C\\
+  C \in \TDynError \cup \TDiverging
 }{
   \dynamicdomain(\env, \overname{\ConstraintExact(\ve)}{\vc}) = \overname{\emptyset}{\vd}
 }
@@ -283,21 +284,23 @@ by overloading $\dynamicdomain$:
 
 \begin{mathpar}
 \inferrule[constraint\_range\_okay]{
-  \evalexprsef{\env, \veone} \evalarrow \Normal(\nvint(a), \Ignore)\\
-  \evalexprsef{\env, \vetwo} \evalarrow \Normal(\nvint(b), \Ignore)
+  \evalexprsef{\env, \veone} \evalarrow \ResultExprSEF(\nvint(a), \Ignore)\\
+  \evalexprsef{\env, \vetwo} \evalarrow \ResultExprSEF(\nvint(b), \Ignore)
 }{
   \dynamicdomain(\env, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) = \overname{\{ \nvint(n) \;|\;  a \leq n \land n \leq b\}}{\vd}
 }
 \and
-\inferrule[constraint\_range\_dynamic\_error1]{
-  \evalexprsef{\env, \veone} \evalarrow \DynErrorConfig
+\inferrule[constraint\_range\_abnormal1]{
+  \evalexprsef{\env, \veone} \evalarrow C\\
+  C \in \TDynError \cup \TDiverging
 }{
   \dynamicdomain(\env, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) = \overname{\emptyset}{\vd}
 }
 \and
-\inferrule[constraint\_range\_dynamic\_error2]{
-  \evalexprsef{\env, \veone} \evalarrow \Normal(\Ignore, \Ignore)\\
-  \evalexprsef{\env, \vetwo} \evalarrow \DynErrorConfig
+\inferrule[constraint\_range\_abnormal2]{
+  \evalexprsef{\env, \veone} \evalarrow \ResultExprSEF(\Ignore, \Ignore)\\
+  \evalexprsef{\env, \vetwo} \evalarrow C\\
+  C \in \TDynError \cup \TDiverging
 }{
   \dynamicdomain(\env, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) = \overname{\emptyset}{\vd}
 }
@@ -314,27 +317,28 @@ in the \emph{local dynamic environment} of $\denv$.
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[t\_bits\_dynamic\_error]{
-  \evalexprsef{\env, \ve} \evalarrow \DynErrorConfig
+\inferrule[t\_bits\_abnormal]{
+  \evalexprsef{\env, \ve} \evalarrow C\\
+  C \in \TDynError \cup \TDiverging
 }{
   \dynamicdomain(\env, \overname{\TBits(\ve, \Ignore)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_bits\_negative\_width\_error]{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\nvint(k), \Ignore)\\
   k < 0
 }{
   \dynamicdomain(\env, \overname{\TBits(\ve, \Ignore)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_bits\_empty]{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(0), \Ignore)
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\nvint(0), \Ignore)
 }{
   \dynamicdomain(\env, \overname{\TBits(\ve, \Ignore)}{\vt}) = \overname{\{ \nvbitvector(\emptylist) \}}{\vd}
 }
 \and
 \inferrule[t\_bits\_non\_empty]{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\nvint(k), \Ignore)\\
   k > 0
 }{
   \dynamicdomain(\env, \overname{\TBits(\ve, \Ignore)}{\vt}) = \overname{\{ \nvbitvector(\vb_{1..k}) \;|\; \vb_1,\ldots,\vb_k \in \{0,1\} \}}{\vd}
@@ -351,21 +355,22 @@ in the \emph{local dynamic environment} of $\denv$.
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[t\_array\_dynamic\_error]{
-  \evalexprsef{\env, \ve} \evalarrow \DynErrorConfig
+\inferrule[t\_array\_abnormal]{
+  \evalexprsef{\env, \ve} \evalarrow C\\
+  C \in \TDynError \cup \TDiverging
 }{
   \dynamicdomain(\env, \overname{\TArray(\ArrayLengthExpr(\ve), \telem)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_array\_negative\_length\_error]{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\nvint(k), \Ignore)\\
   k < 0
 }{
   \dynamicdomain(\env, \overname{\TArray(\ArrayLengthExpr(\ve), \telem)}{\vt}) = \overname{\emptyset}{\vd}
 }
 \and
 \inferrule[t\_array\_okay]{
-  \evalexprsef{\env, \ve} \evalarrow \Normal(\nvint(k), \Ignore)\\
+  \evalexprsef{\env, \ve} \evalarrow \ResultExprSEF(\nvint(k), \Ignore)\\
   k \geq 0\\
   \dynamicdomain(\env, \telem) = D_\telem
 }{

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -63,6 +63,7 @@ aim
 aims
 alias
 aliases
+aliasing
 align
 all
 allow
@@ -477,6 +478,7 @@ converts
 conveying
 conveys
 copied
+copying
 copyright
 corporate
 correct
@@ -500,6 +502,7 @@ current
 currently
 custom
 customers
+cycle
 cyclic
 data
 datatype
@@ -555,6 +558,7 @@ derived
 describe
 described
 describes
+describing
 description
 descriptions
 descriptors
@@ -608,6 +612,8 @@ distinct
 distinction
 distinguish
 distinguishing
+diverges
+diverging
 divide
 divided
 dividing
@@ -695,6 +701,7 @@ enumerations
 environment
 environments
 equal
+equalities
 equality
 equals
 equate
@@ -720,6 +727,7 @@ evaluated
 evaluates
 evaluating
 evaluation
+evaluations
 even
 event
 every
@@ -1014,6 +1022,7 @@ individual
 induce
 induced
 induction
+inductive
 inequality
 inevitably
 infer
@@ -1022,6 +1031,7 @@ inferred
 inferring
 infers
 infinite
+infinitely
 infinity
 informal
 information
@@ -1072,6 +1082,7 @@ interfere
 intermediate
 internal
 internally
+interpret
 interpretation
 interpreted
 interpreter
@@ -1110,6 +1121,8 @@ iterations
 its
 itself
 join
+judgment
+judgments
 just
 justified
 keep
@@ -1135,6 +1148,7 @@ latter
 laws
 lead
 leads
+leaf
 least
 leaves
 leaving
@@ -1184,6 +1198,7 @@ looked
 looking
 looks
 loop
+looping
 loops
 loss
 lost
@@ -1460,6 +1475,7 @@ pertain
 pertaining
 phase
 place
+placement
 places
 placing
 platform
@@ -1519,6 +1535,7 @@ prior
 priori
 priorities
 priority
+problem
 procedure
 procedures
 proceeds
@@ -1685,6 +1702,7 @@ required
 requirement
 requirements
 requires
+requiring
 resemble
 reserved
 resolve
@@ -1830,6 +1848,7 @@ simplifies
 simplify
 simplifying
 simply
+simulating
 simultaneous
 simultaneously
 since
@@ -2095,6 +2114,7 @@ typechecking
 typechecks
 typed
 types
+typical
 typically
 typing
 typo
@@ -2205,6 +2225,7 @@ violation
 virtual
 vision
 visual
+visually
 walk
 want
 warn

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -162,7 +162,7 @@ def check_tododefines(latex_files: list[str]):
     Checks that there are no more than the expected number of \tododefine
     instances.
     """
-    MAX_TODODEFINE_INSTANCES = 6
+    MAX_TODODEFINE_INSTANCES = 5
     num_todo_define = 0
     for latex_source in latex_files:
         lines = read_file_lines(latex_source)


### PR DESCRIPTION
This PR extends the dynamic semantics for non-terminating specifications. Specifically, a new diverging configuration is defined and added to all semantic relations that could diverge and to all transitions that could diverge.
- Renamed "assertions" used for discuss inference rules to "judgments" to reduce the overloading of "assertions", which are also used for assertion statements.
- Fixed a few bugs found along the way.
