### PR TITLE
[ASL] Completed functionality for renaming locals in standard library subprograms

### DIFF
--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -1031,7 +1031,4 @@ The notation $\wrappedline$ denotes that a line that is longer than the page wid
 
 \hypertarget{def-commonsuffixline}{}
 \item The notation $\commonsuffixline$ serves as a visual aid to delimit a common suffix of premises shared by rule cases.
-
-\hypertarget{tododefine}{} % DO NOT LINT
-\item \tododefine{Missing:} Red hyperlinks indicate items that are yet to be defined.
 \end{itemize}

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -155,7 +155,6 @@
 \setlist[itemize,19]{label=\textendash}
 \setlist[itemize,20]{label=\textendash}
 
-\newcommand\tododefine[1]{\hyperlink{tododefine}{\color{red}{\texttt{#1}}}} % DO NOT LINT
 \newcommand\lrmcomment[1]{}
 \newcommand\textfunc[1]{\textit{#1}}
 \newcommand\ProseParagraph[0]{\subsubsection{Prose}}
@@ -1557,6 +1556,10 @@
   the local storage elements in the type #1 yields the type #2}
 \newcommand\renamelocalsslice[0]{\hyperlink{def-renamelocalsslice}{\textfunc{rename\_locals\_slice}}}
 \newcommand\renamelocalsconstraint[0]{\hyperlink{def-renamelocalsconstraint}{\textfunc{rename\_locals\_constraint}}}
+\newcommand\renamelocalsarrayindex[0]{\hyperlink{def-renamelocalsarrayindex}{\textfunc{rename\_locals\_array\_index}}}
+\newcommand\renamelocalspattern[0]{\hyperlink{def-renamelocalspattern}{\textfunc{rename\_locals\_pattern}}}
+\newcommand\renamelocalscatcher[0]{\hyperlink{def-renamelocalscatcher}{\textfunc{rename\_locals\_catcher}}}
+
 \newcommand\stdliblocalprefix[0]{\texttt{\_\_stdlib\_local\_}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2354,6 +2357,7 @@
 \newcommand\others[0]{\texttt{others}}
 \newcommand\otherwise[0]{\texttt{otherwise}}
 \newcommand\otherwiseopt[0]{\texttt{otherwise\_opt}}
+\newcommand\otherwiseoptp[0]{\texttt{otherwise\_opt'}}
 \newcommand\otherwisep[0]{\texttt{otherwise'}}
 \newcommand\pairs[0]{\texttt{pairs}}
 \newcommand\triples[0]{\texttt{triples}}
@@ -3091,3 +3095,17 @@
 \newcommand\otherwiseconfigs[0]{\texttt{otherwise\_configs}}
 \newcommand\otherwises[0]{\texttt{otherwise\_s}}
 \newcommand\catchconfigs[0]{\texttt{catch\_configs}}
+\newcommand\paramname[0]{\texttt{param\_name}}
+\newcommand\elemty[0]{\texttt{elem\_ty}}
+\newcommand\newindex[0]{\texttt{new\_index}}
+\newcommand\newelength[0]{\texttt{new\_e\_length}}
+\newcommand\pl[0]{\texttt{pl}}
+\newcommand\newpl[0]{\texttt{newpl}}
+\newcommand\vpe[0]{\texttt{p\_e}}
+\newcommand\vnewpe[0]{\texttt{new\_p\_e}}
+\newcommand\optexnname[0]{\texttt{opt\_exn\_name}}
+\newcommand\optexnnamep[0]{\texttt{opt\_exn\_name'}}
+\newcommand\whenstmt[0]{\texttt{when\_stmt}}
+\newcommand\whenstmtp[0]{\texttt{when\_stmt'}}
+\newcommand\exnty[0]{\texttt{exn\_ty}}
+\newcommand\exntyp[0]{\texttt{exn\_ty'}}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -920,6 +920,14 @@ evaluate to either \texttt{3} or \texttt{Return42()}, depending on the
 \end{itemize}
 
 \FormallyParagraph
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newcommand\internalcomment[1]{}
+
+\internalcomment{
+\paragraph{Condition evaluation rule with observations:}
+\newcommand\plusctrl[0]{\hyperlink{def-aslpo}{$+^\mathtt{ctrl}}$}
+\newcommand\plusdata[0]{\hyperlink{def-aslpo}{$+^\mathtt{data}}$}
 \begin{mathpar}
 \inferrule{
   \evalexpr{\env, \econd} \evalarrow \ResultExpr(\mcond, \envone) \OrAbnormal\\\\

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -920,14 +920,6 @@ evaluate to either \texttt{3} or \texttt{Return42()}, depending on the
 \end{itemize}
 
 \FormallyParagraph
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\newcommand\internalcomment[1]{}
-
-\internalcomment{
-\paragraph{Condition evaluation rule with observations:}
-\newcommand\plusctrl[0]{\hyperlink{def-aslpo}{$+^\mathtt{ctrl}}$}
-\newcommand\plusdata[0]{\hyperlink{def-aslpo}{$+^\mathtt{data}}$}
 \begin{mathpar}
 \inferrule{
   \evalexpr{\env, \econd} \evalarrow \ResultExpr(\mcond, \envone) \OrAbnormal\\\\

--- a/asllib/doc/TopLevel.tex
+++ b/asllib/doc/TopLevel.tex
@@ -366,8 +366,9 @@ yielding the type $\newty$.
 
   \item \AllApplyCase{t\_int\_parameterized}
   \begin{itemize}
-    \item $\tty$ is the \parameterizedintegertype.
-    \item this case is not implemented yet.
+    \item $\tty$ is the \parameterizedintegertype{} for the parameter $\paramname$;
+    \item \Proseeqdef{$\newty$}{is the \parameterizedintegertype{} for the renamed parameter
+          name obtained by applying $\renamelocalsname$ to $\paramname$}.
   \end{itemize}
 
   \item \AllApplyCase{t\_int\_wellconstrained}
@@ -391,10 +392,12 @@ yielding the type $\newty$.
     \item \Proseeqdef{$\newty$}{the \tupletypeterm\ for the list of types $\newli$}.
   \end{itemize}
 
-  \item \AllApplyCase{tarray}
+  \item \AllApplyCase{t\_array}
   \begin{itemize}
-    \item $\tty$ is the \arraytypeterm;
-    \item this case is not implemented yet
+    \item $\tty$ is the \arraytypeterm{} with index $\vindex$ and element type $\elemty$;
+    \item applying $\renamelocalsarrayindex$ to $\vindex$ yields $\newindex$;
+    \item applying $\renamelocalsty$ to $\elemty$ yields $\newty$;
+    \item \Proseeqdef{$\newty$}{the \arraytypeterm{} with index $\newindex$ and element type $\newty$}.
   \end{itemize}
 
   \item \AllApplyCase{structured}
@@ -421,10 +424,13 @@ yielding the type $\newty$.
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[t\_int\_parameterized]{
-  \astlabel(\vc) = \parameterized
-}{
-  \renamelocalsty(\overname{\TInt(\vc)}{\tty}) \astarrow \tododefine{unimplemented}
+\inferrule[t\_int\_parameterized]{}{
+  {
+  \begin{array}{r}
+  \renamelocalsty(\overname{\TInt(\parameterized(\paramname))}{\tty}) \astarrow\\
+  \TInt(\parameterized(\renamelocalsname(\paramname)))
+  \end{array}
+  }
 }
 \end{mathpar}
 
@@ -454,9 +460,11 @@ yielding the type $\newty$.
 
 \begin{mathpar}
 \inferrule[t\_array]{
-  \astlabel(\tty) = \TArray
+  \renamelocalsarrayindex(\vindex) \astarrow \newindex\\
+  \renamelocalsty(\elemty) \astarrow \newty
 }{
-  \renamelocalsty(\tty) \astarrow \tododefine{unimplemented}
+  \renamelocalsty(\TArray(\vindex, \elemty)) \astarrow
+  \TArray(\newindex, \newty)
 }
 \end{mathpar}
 
@@ -579,8 +587,14 @@ yielding the statement $\news$.
 
   \item \AllApplyCase{s\_try}
   \begin{itemize}
-    \item $\vs$ is a \trystatementterm;
-    \item this case is not implemented.
+    \item $\vs$ is a \trystatementterm{} with statement $\vsone$, list of catch clauses $\catchers$,
+          and optional \Totherwise{} statement $\otherwiseopt$;
+    \item \Proserenamelocalsstmt{$\vsone$}{$\vsonep$};
+    \item \Proseeqdef{$\catchersp$}{the list of catchers obtained by applying \\
+          $\renamelocalscatcher$ to each catcher in $\catchers$};
+    \item \Prosemapopt{$\renamelocalsstmt$}{$\otherwiseopt$}{$\otherwiseoptp$};
+    \item \Proseeqdef{$\news$}{\trystatementterm{} with statement $\vsonep$, list of catch clauses \\
+          $\catchersp$, and optional \Totherwise{} statement  $\otherwiseoptp$}.
   \end{itemize}
 
   \item \AllApplyCase{s\_print}
@@ -771,9 +785,16 @@ yielding the statement $\news$.
 
 \begin{mathpar}
 \inferrule[s\_try]{
-  \astlabel(\vs) = \STry
+  \renamelocalsstmt(\vsone) \astarrow \vsonep\\
+  \catchersp \eqdef [\vc\in\catchers: \renamelocalscatcher(\vc)]\\
+  \mapopt{\renamelocalsstmt}(\otherwiseopt) \astarrow \otherwiseoptp
 }{
-  \renamelocalsstmt(\vs) \astarrow \tododefine{not implemented yet}
+  {
+  \begin{array}{r}
+  \renamelocalsstmt(\overname{\STry(\vsone, \catchers, \otherwiseopt)}{\vs}) \astarrow \\
+  \STry(\vsonep, \catchersp, \otherwiseoptp)
+  \end{array}
+  }
 }
 \end{mathpar}
 
@@ -938,8 +959,10 @@ yielding the expression $\newe$.
 
   \item \AllApplyCase{e\_pattern}
   \begin{itemize}
-    \item $\ve$ is a \patternexpressionterm;
-    \item this case is not implemented.
+    \item $\ve$ is a \patternexpressionterm{} with expression $\veone$ and pattern $\vp$;
+    \item \Proserenamelocals{$\ve$}{$\vep$};
+    \item applying $\renamelocalspattern$ to $\vp$ yields $\vpp$;
+    \item \Proseeqdef{$\newe$}{the \patternexpressionterm{} with expression $\veonep$ and pattern $\vpp$}.
   \end{itemize}
 \end{itemize}
 
@@ -1109,8 +1132,12 @@ yielding the expression $\newe$.
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[e\_pattern]{}{
-  \renamelocalsexpr(\overname{\EPattern(\Ignore, \Ignore)}{\ve}) \astarrow \tododefine{not implemented yet}
+\inferrule[e\_pattern]{
+  \renamelocalsexpr(\veone) \astarrow \veonep\\
+  \renamelocalspattern(\vp) \astarrow \vpp
+}{
+  \renamelocalsexpr(\overname{\EPattern(\veone, \vp)}{\ve}) \astarrow
+  \EPattern(\veonep, \vpp)
 }
 \end{mathpar}
 
@@ -1391,8 +1418,173 @@ yielding the identifier $\newname$.
 }
 \end{mathpar}
 
+\ASTRuleDef{RenameLocalsArrayIndex}
+\hypertarget{def-renamelocalsarrayindex}{}
+The helper function
+\[
+\renamelocalsarrayindex(\overname{\arrayindex}{\vindex}) \aslto \overname{\arrayindex}{\newindex}
+\]
+renames the identifiers corresponding to local storage elements that appear in the
+array index $\vindex$, yielding the array index $\newindex$.
+
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{enum}
+  \begin{itemize}
+    \item $\vindex$ is an index of an enumeration-indexed array type;
+    \item \Proseeqdef{$\newindex$}{$\vindex$}.
+  \end{itemize}
+
+  \item \AllApplyCase{expr}
+  \begin{itemize}
+    \item $\vindex$ is an index of an integer-indexed array type with length expression $\elength$;
+    \item \Proserenamelocalsexpr{$\elength$}{$\newelength$};
+    \item \Proseeqdef{$\newindex$}{index of an integer-indexed array type with length expression $\newelength$}.
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[enum]{
+  \astlabel(\vindex) = \ArrayLengthEnum
+}{
+  \renamelocalsarrayindex(\vindex) \astarrow \overname{\vindex}{\newindex}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[expr]{
+  \renamelocalsexpr(\elength) \astarrow \newelength
+}{
+  {
+  \begin{array}{r}
+  \renamelocalsarrayindex(\overname{\ArrayLengthExpr(\elength)}{\vindex}) \astarrow \\
+  \overname{\ArrayLengthExpr(\newelength)}{\newindex}
+  \end{array}
+  }
+}
+\end{mathpar}
+
+\ASTRuleDef{RenameLocalsPattern}
+\hypertarget{def-renamelocalspattern}{}
+The helper function
+\[
+\renamelocalspattern(\overname{\pattern}{\vp}) \aslto \overname{\pattern}{\newp}
+\]
+renames the identifiers corresponding to local storage elements that appear in the
+pattern $\vp$, yielding the pattern $\newp$.
+
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{all\_mask}
+  \begin{itemize}
+    \item $\vp$ is either $\PatternAll$ or $\PatternMask$;
+    \item \Proseeqdef{$\newp$}{$\vp$}.
+  \end{itemize}
+
+  \item \AllApplyCase{pattern\_list}
+  \begin{itemize}
+    \item $\vp$ is a pattern with AST label $L$ and list of patterns $\pl$,
+          where $L$ is one of $\PatternAny$ and $\PatternTuple$;
+    \item \Proseeqdef{$\newpl$}{the list obtained by applying $\renamelocalspattern$ to each pattern in $\pl$};
+    \item the pattern with AST label $L$ and list of patterns $\newpl$.
+  \end{itemize}
+
+  \item \AllApplyCase{single\_expr}
+  \begin{itemize}
+    \item $\vp$ is a pattern with AST label $L$ and expression $\vpe$,
+          where $L$ is one of $\PatternGeq$, $\PatternLeq$, $\PatternNot$, and
+          $\PatternSingle$;
+    \item \Proserenamelocalsexpr{$\veone$}{$\veonep$};
+    \item \Proseeqdef{$\newp$}{the pattern with AST label $L$ and expression $\veonep$}.
+  \end{itemize}
+
+  \item \AllApplyCase{range}
+  \begin{itemize}
+    \item $\vp$ is the range pattern with expressions $\veone$ and $\vetwo$;
+    \item \Proserenamelocalsexpr{$\veone$}{$\veonep$};
+    \item \Proserenamelocalsexpr{$\vetwo$}{$\vetwop$};
+    \item \Proseeqdef{$\newp$}{the range pattern with expressions $\veonep$ and $\vetwop$}.
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[all\_mask]{
+  \astlabel(\vp) \in \{\PatternAll, \PatternMask\}
+}{
+  \renamelocalspattern(\vp) \astarrow \overname{\vp}{\newp}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[pattern\_list]{
+  \vp = L(\pl)\\
+  \astlabel(\vp) \in \{\PatternAny, \PatternTuple\}\\
+  \newpl \eqdef [ \vi\in\indices(\pl): \renamelocalspattern(\pl[\vi]) ]
+}{
+  \renamelocalspattern(\vp) \astarrow \overname{L(\newpl)}{\newp}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[single\_expr]{
+  \vp = L(\vpe)\\
+  \astlabel(\vp) \in \{\PatternGeq, \PatternLeq, \PatternNot, \PatternSingle\}\\
+  \renamelocalsexpr(\vpe) \astarrow \vnewpe
+}{
+  \renamelocalspattern(\vp) \astarrow \overname{L(\vnewpe)}{\newp}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[range]{
+  \renamelocalsexpr(\veone) \astarrow \veonep\\
+  \renamelocalsexpr(\vetwo) \astarrow \vetwop\\
+}{
+  \renamelocalspattern(\overname{\PatternRange(\veone, \vetwo)}{\vp}) \astarrow \overname{\PatternRange(\veonep, \vetwop)}{\newp}
+}
+\end{mathpar}
+
+\ASTRuleDef{RenameLocalsCatcher}
+\hypertarget{def-renamelocalscatcher}{}
+The helper function
+\[
+\renamelocalscatcher(\overname{\catcher}{\vc}) \aslto \overname{\catcher}{\newc}
+\]
+renames the identifiers corresponding to local storage elements that appear in the
+catcher clause $\vc$, yielding the catcher clause $\newc$.
+
+\ProseParagraph
+\AllApply
+\begin{itemize}
+  \item $\vc$ is a catcher clause with optional exception name $\optexnname$, exception type $\exnty$,
+        and \Twhen{} statement $\whenstmt$;
+  \item \Prosemapopt{$\renamelocalsname$}{$\optexnname$}{$\optexnnamep$};
+  \item \Proserenamelocalsty{$\exnty$}{$\exntyp$};
+  \item \Proserenamelocalsstmt{$\whenstmt$}{$\whenstmtp$}.
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule{
+  \mapopt{\renamelocalsname}(\optexnname) \astarrow \optexnnamep\\
+  \renamelocalsty(\exnty) \astarrow \exntyp\\
+  \renamelocalsstmt(\whenstmt) \astarrow \whenstmtp
+}{
+  {
+  \begin{array}{r}
+  \renamelocalscatcher(\overname{(\optexnname, \exnty, \whenstmt)}{\vc}) \astarrow\\
+  (\optexnnamep, \exntyp, \whenstmtp)
+  \end{array}
+  }
+}
+\end{mathpar}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Beginning of rename locals-related functions
+%% End of rename locals-related functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \section{Marking Standard Library Functions}

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -1675,6 +1675,7 @@ removed
 removes
 removing
 rename
+renamed
 renames
 renaming
 repeat

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -156,31 +156,6 @@ def check_undefined_references_and_multiply_defined_labels():
         num_errors += 1
     return num_errors
 
-
-def check_tododefines(latex_files: list[str]):
-    r"""
-    Checks that there are no more than the expected number of \tododefine
-    instances.
-    """
-    MAX_TODODEFINE_INSTANCES = 5
-    num_todo_define = 0
-    for latex_source in latex_files:
-        lines = read_file_lines(latex_source)
-        for line in lines:
-            if DO_NOT_LINT_STR in line:
-                continue
-            num_todo_define += line.count("\\tododefine")
-    if num_todo_define > MAX_TODODEFINE_INSTANCES:
-        # Disallow adding new \tododefines
-        print(
-            f"ERROR: There are {num_todo_define} occurrences of \\tododefine,\
-               expected at most {MAX_TODODEFINE_INSTANCES}"
-        )
-        return num_todo_define
-    else:
-        print(f"WARNING: There are {num_todo_define} occurrences of \\tododefine")
-        return 0
-
 def check_repeated_lines(filename: str) -> int:
     r"""
     Checks whether `file` contains the same line appearing twice in a row.
@@ -704,7 +679,6 @@ def main():
     num_errors += num_spelling_errors
     num_errors += check_hyperlinks_and_hypertargets(all_latex_sources)
     num_errors += check_undefined_references_and_multiply_defined_labels()
-    num_errors += check_tododefines(content_latex_sources)
     num_errors += check_unused_latex_macros(all_latex_sources)
     num_errors += check_per_file(
         content_latex_sources,


### PR DESCRIPTION
* Renamed `map_desc_st'` to `map_annotated` since it is generic and used for constructs other than statements.
* Added renaming for patterns and pattern statements, catchers and try statements, array indices and array types, parameterized integer types, and collection types.