### PR TITLE
[herd] [litmus] Refactoring the help command

### DIFF
--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -47,7 +47,7 @@ let gen_model_opt s =
     | None -> false
     | Some _ as m -> model :=  m ; true)
     Model.tags
-    (sprintf " select model, defaults %s, %s, %s, %s, %s, %s, %s"
+    (sprintf " Select model, defaults %s, %s, %s, %s, %s, %s, %s"
        (pp_default_model x86)
        (pp_default_model x86_64)
        (pp_default_model ppc)
@@ -56,76 +56,30 @@ let gen_model_opt s =
        (pp_default_model riscv)
        (pp_default_model Archs.c))
 
-let options = [
-(* Basic *)
-  ("-version", Arg.Unit
-     (fun () -> printf "%s, Rev: %s\n" Version.version Version.rev ; exit 0),
-   " show version number and exit") ;
-  ("-libdir", Arg.Unit (fun () -> print_endline !Opts.libdir; exit 0),
-    " show installation directory and exit");
-  ("-set-libdir", Arg.String (fun s -> Opts.libdir := s),
-    "<path> set installation directory to <path>");
-  ("-v", Arg.Unit (fun _ -> incr verbose),
-   "<non-default> show various diagnostics, repeat to increase verbosity");
-  ("-q", Arg.Unit (fun _ -> verbose := -1; debug := Debug_herd.none),
-   "<default> do not show diagnostics");
-  ("-I", Arg.String (fun s -> includes := !includes @ [s]),
-   "<dir> add <dir> to search path");
-  parse_bool "-exit" Opts.exit_if_failed "exit in case of failure";
-  parse_float_opt "-timeout" Opts.timeout "timeout (CPU time)";
-  ("-conf",
-   Arg.String load_config,
-   "<name> read configuration file <name>") ;
-  ("-bell",
-   Arg.String (fun x -> Opts.bell := (Some x)),
-   "<name> read bell file <name>") ;
-  ("-macros",
-   Arg.String (fun x -> Opts.macros := (Some x)),
-   "<name> read macro (.def) file <name>") ;
-  ("-o", Arg.String
-     (fun s -> match s with
-     | "-" -> outputdir := PrettyConf.StdoutOutput
-     | _ -> outputdir := PrettyConf.Outputdir s),
-   "<dir> generated files will go into <dir>, default: do not generate") ;
-  ("-suffix", Arg.String (fun s -> suffix := s),
-   "<suf> add <suf> at the end of the base of generated files") ;
-  parse_bool "-dumpes" Opts.dumpes "dump event structures";
-  begin let module ParseView = ParseTag.Make(View) in
-  ParseView.parse_opt "-view" PP.view
-    "fork specified viewer to show output graphs" end ;
-  ( "-gv",
-    Arg.Unit (fun _ -> PP.view := Some View.GV),
-    "<non-default>  alias for -view gv") ;
-  ( "-evince",
-    Arg.Unit (fun _ -> PP.view := Some View.Evince),
-    "<non-default>  alias for -view evince") ;
-  ( "-preview",
-    Arg.Unit (fun _ -> PP.view := Some View.Preview),
-    "<non-default>  alias for -view preview") ;
-  ("-unroll",
-   Arg.Int (fun x -> unroll := Some x),
-   sprintf "<int> branch unrolling upper limit, default ASL: %i, others: %i"
-     (unroll_default `ASL)  (unroll_default `Others));
-  parse_bool "-hexa" PP.hexa "print numbers in hexadecimal";
-(* undocumented *)
-  ("-switch",
-   Arg.Unit (fun () -> Misc.switch := true),
-   "switch something") ;
-  ("-web",
-   Arg.Unit (fun () -> load_config "web.cfg")," alias for -conf web.cfg");
-  ("-c11",
-   Arg.Unit (fun () -> load_config "cpp11.cfg")," alias for -conf cpp11.cfg");
-  parse_tags
-    "-debug"
-    (fun tag -> match Debug_herd.parse !debug tag with
+
+(*Common options*)
+let variant_option =
+  begin
+    let module ParseVariant = ParseTag.MakeS(Opts.OptS) in
+    ParseVariant.parse "-variant" variant
+      "<tags> select an architecture variation. Use '-help variant' for the list of tags" end 
+let showevents_option =
+  parse_tag "-showevents"
+    (fun tag -> match PrettyConf.parse_showevents tag with
     | None -> false
-    | Some t -> debug := t ; true)
-    Debug_herd.tags
-    "show debug messages for specific parts" ;
-  parse_bool "-morefences" (ref false) "does nothing (deprecated)" ;
-(* Engine control *)
-  gen_model_opt "-model";
-  gen_model_opt "-cat";
+    | Some t -> PP.showevents := t ; true)
+     PrettyConf.tags_showevents
+     (sprintf "Select events shown in figures, default %s"
+       (PrettyConf.pp_showevents !PP.showevents)) 
+let show_option =
+  parse_tag "-show"
+    (fun tag -> match PrettyConf.parse_show tag with
+    | None -> false
+    | Some t -> show := t ; true)
+    PrettyConf.tags_show
+    (sprintf "Executions shown in figure, default %s"
+       (PrettyConf.pp_show !show)) 
+let through_option =
   parse_tag
     "-through"
     (fun tag -> match Model.parse_through tag with
@@ -133,182 +87,191 @@ let options = [
     | Some t -> through :=  t ; true)
     Model.tags_through
     (sprintf
-       "what to let through in addition to valid executions, default %s"
-       (Model.pp_through !through)) ;
-  parse_string_opt
-    "-throughflag"
-    throughflag
-    "let through executions flagged with string, and only those" ;
+       "Allow additional executions to reach the final stage of the simulation in addition to valid ones, default %s"
+       (Model.pp_through !through)) 
+let v_option =
+  ("-v", Arg.Unit (fun _ -> incr verbose), " show various diagnostics. Repeat to increase verbosity")
+let view_option =
+  begin 
+    let module ParseView = ParseTag.Make(View) in
+    ParseView.parse_opt "-view" PP.view
+    "fork specified viewer to show output graphs" end 
+let o_option =
+  ("-o", Arg.String
+     (fun s -> match s with
+     | "-" -> outputdir := PrettyConf.StdoutOutput
+     | _ -> outputdir := PrettyConf.Outputdir s),
+   " select the <dir> in which output files are saved. If not set, then files are not generated.") 
+let hexa_option =
+  parse_bool "-hexa" PP.hexa "print numbers in hexadecimal"
+let doshow_option =
+  parse_stringsetfun "-doshow" PP.add_doshow "show those edges"
+let unshow_option =
+  parse_stringsetfun "-unshow" PP.add_unshow "do not show those edges" 
+let skipcheck_option =
   ("-skipcheck",
    Arg.String (fun tag -> skipchecks := StringSet.add tag !skipchecks),
-   "<name> do not apply check, cumulates") ;
-  parse_stringset "-skipchecks" skipchecks "do not apply listed checks, cumulative" ;
-  parse_bool "-strictskip" strictskip "retain outcomes allowed by ALL skipped checks" ;
-  parse_stringset "-cycles" cycles  "<name1,...,nameN> show failing checks as cycles, cumulates" ;
+   "<name> do not apply check, cumulates") 
+let conf_option =
+  ("-conf", Arg.String load_config, 
+  "<name> read configuration file <name>. Example: -conf herd/libdir/file.cfg") 
+let cat_option =
+  gen_model_opt "-cat"
 
-(* Model control *)
-  begin
-    let module ParseVariant = ParseTag.MakeS(Opts.OptS) in
-    ParseVariant.parse "-variant" variant
-      "select an architecture variation" end ;
-  begin let module ParseMachSize = ParseTag.Make(MachSize.Tag) in
-  ParseMachSize.parse "-machsize" byte "set basic machine size" end ;
-  begin let module ParseEndian = ParseTag.Make(Endian) in
-  ParseEndian.parse_opt "-endian" endian "set endianness" end ;
-  parse_bool "-archcheck" archcheck "check compatibility of test and cat model architectures" ;
-  parse_tag "-optace"
-    (fun tag -> match OptAce.parse tag with
-    | None -> false
-    | Some t -> optace := Some t ; true)
-    OptAce.tags
-    "optimize axiomatic candidate generation, default is iico";
-  "-initwrites", Arg.Bool (fun b -> initwrites := Some b),
-    "<bool> represent init writes as write events, this option should not be used except for debugging model options";
-  parse_tag "-show"
-    (fun tag -> match PrettyConf.parse_show tag with
-    | None -> false
-    | Some t -> show := t ; true)
-    PrettyConf.tags_show
-    (sprintf "executions shown in figure, default %s"
-       (PrettyConf.pp_show !show)) ;
-  "-showflag",
-  Arg.String  (fun flag -> show := PrettyConf.ShowFlag flag),
-  "<string>  show executions flagged by string in figure" ;
-(* Discard some observations *)
+let common_options = Arg.align ~limit:40 [
+  variant_option ;
+  showevents_option ;
+  show_option ;
+  through_option ;
+  v_option ;
+  view_option ;
+  o_option ;
+  hexa_option ;
+  doshow_option ;
+  unshow_option ;
+  skipcheck_option ;
+  conf_option ;
+  cat_option ;
+  "-help", Arg.Unit Fun.id, "" ;
+  "--help", Arg.Unit Fun.id, "";
+]
+let runmode_options = Arg.align ~limit:40 [
+  "-help", Arg.Unit Fun.id, "" ;
+  "--help", Arg.Unit Fun.id, "" ;
+  "", Arg.Unit Fun.id, "\n";
   parse_tag "-speedcheck"
     (fun tag -> match Speed.parse tag with
     | None -> false
     | Some t -> speedcheck := t ; true)
     Speed.tags
-    "aim at checking condition in place of listing final states" ;
-  "-nshow",
-  Arg.Int (fun n -> nshow := Some n),
-  "<n> collect at most <n> pictures, default is to collect all (specified) pictures";
-  parse_bool "-badexecs" badexecs "give output for tests that have bad executions (see -badflag)" ;
-  parse_string_opt "-badflag" badflag "executions with flag <string> are bad" ;
-  parse_bool "-checkfilter" check_filter "discard outcomes that negate filter proposition (if any)" ;
-(* undocumented *)
-  "-showone",
-  Arg.Bool (fun b -> if b then nshow := Some 1),
-  "<bool> alias for -nshow 1";
+    "Aim at checking condition in place of listing final states" ;
+  variant_option ;
+  begin 
+    let module ParseMachSize = ParseTag.Make(MachSize.Tag) in
+  ParseMachSize.parse "-machsize" byte "set basic machine size" end ;
+  begin 
+    let module ParseEndian = ParseTag.Make(Endian) in
+  ParseEndian.parse_opt "-endian" endian "set endianness" end ;
+  parse_float_opt "-timeout" Opts.timeout "timeout (CPU time)";
+  ("-unroll",
+   Arg.Int (fun x -> unroll := Some x),
+   sprintf "<int> branch unrolling upper limit, default ASL: %i, others: %i"
+     (unroll_default `ASL)  (unroll_default `Others));
+  parse_tag "-optace"
+    (fun tag -> match OptAce.parse tag with
+    | None -> false
+    | Some t -> optace := Some t ; true)
+    OptAce.tags
+    "Optimize axiomatic candidate generation, default is iico";
   parse_int_opt
     "-maxphantom" maxphantom "maximum phantom update (per variable)";
+  parse_bool "-archcheck" archcheck "check compatibility of test and cat model architectures" ;
+    ("-switch",
+   Arg.Unit (fun () -> Misc.switch := true),
+   " switch something") ;
+  parse_tag "-restrict"
+    (fun tag -> match Restrict.parse tag with
+    | None -> false
+    | Some t -> restrict := t ; true)
+    Restrict.tags
+    (sprintf "Restrict outcomes, default %s" (Restrict.pp !restrict));
+    ]  
+
+let filter_options = Arg.align ~limit:40 [
+  "-help", Arg.Unit Fun.id, "" ;
+  "--help", Arg.Unit Fun.id, "" ;
+  ("", Arg.Unit Fun.id, "\n");
+  gen_model_opt "-model";
+  cat_option ;
+  through_option;
+  parse_string_opt
+    "-throughflag"
+    throughflag
+    "let through executions flagged with string, and only those" ;
+  skipcheck_option ;
+  parse_stringset "-skipchecks" skipchecks "do not apply listed checks, cumulative" ;
+  parse_bool "-strictskip" strictskip "retain outcomes allowed by ALL skipped checks" ;
+  show_option;
+  "-showflag",
+  Arg.String  (fun flag -> show := PrettyConf.ShowFlag flag),
+  "<string>  show executions flagged by string in figure" ;
+  parse_bool "-badexecs" badexecs "give output for tests that have bad executions (see -badflag)" ;
+  parse_string_opt "-badflag" badflag "executions with flag <string> are bad" ;
   "-statelessrc11",
   Arg.Bool (fun b -> if b then statelessrc11 := true),
   "<bool> enable stateless RC11 model checking, use with -variant normw, SC check can be skipped";
   "-dumpallfaults",
   Arg.Bool (fun b -> dumpallfaults := b),
-  "Dump final states with all faults that that happenned regardless of the post-condition";
+  "<bool> show all faults in the output regardless of the post-condition";
+  "-nshow",
+  Arg.Int (fun n -> nshow := Some n),
+  "<n> generate at most <n> execution graph. By default all execution graphs specified by -show are generated.";
+  "-showone",
+  Arg.Bool (fun b -> if b then nshow := Some 1),
+  "<bool> alias for -nshow 1";
+  parse_bool "-checkfilter" check_filter "discard outcomes that negate filter proposition (if any)" ;
+  ]
 
-(************************)
-(* Control dot pictures *)
-(************************)
-(* General *)
-  parse_tag "-graph"
-    (fun tag -> match Graph.parse tag with
-    | None -> false
-    | Some t -> PP.graph := t ; true)
-     Graph.tags
-     (sprintf "select sort of graph, default %s" (Graph.pp !PP.graph)) ;
-  parse_tag "-dotmode"
-    (fun tag -> match PrettyConf.parse_dotmode tag with
-    | None -> false
-    | Some t -> PP.dotmode := t ; true)
-    PrettyConf.tags_dotmode
-    (sprintf "control text in dot figures, default %s"
-       (PrettyConf.pp_dotmode !PP.dotmode)) ;
-  parse_tag "-dotcom"
-    (fun tag -> match PrettyConf.parse_dotcom tag with
-    | None -> false
-    | Some _ as t -> PP.dotcom := t ; true)
-    PrettyConf.tags_dotcom
-    "select command to translate dot, default depends on other modes" ;
-  parse_tag "-showevents"
-    (fun tag -> match PrettyConf.parse_showevents tag with
-    | None -> false
-    | Some t -> PP.showevents := t ; true)
-     PrettyConf.tags_showevents
-     (sprintf "select events shown in figures, default %s"
-       (PrettyConf.pp_showevents !PP.showevents)) ;
-  parse_bool "-mono" PP.mono "monochrome figures" ;
-  parse_float "-scale" PP.scale "global scale factor for graphs" ;
-  parse_float "-xscale" PP.xscale
-    "global scale factor for graphs, x direction" ;
-  parse_float "-yscale" PP.yscale
-    "global scale factor for graphs, y direction" ;
-  parse_float "-dsiy" PP.dsiy "vertical variation for events generated by the same instruction" ;
-  parse_float "-siwidth" PP.siwidth "width occupied by events generated by the same instruction" ;
-  parse_float "-ptscale" PP.ptscale "scale factor for points" ;
-  parse_float "-boxscale" PP.ptscale "scale factor box width" ;
-  parse_bool "-showthread" PP.showthread
-    "show thread numbers in figures" ;
-  "-shift",
-  Arg.String
-    (fun tag ->
-      let fs = Misc.split_comma tag in
-      let fs =
-        List.map
-          (fun f ->
-            try float_of_string f with
-            | _ ->
-                raise
-                  (Arg.Bad
-                     (sprintf "bad argument for option -shift: '%s'" tag)))
-          fs in
-      PP.shift := Array.of_list fs),
-  "<float,...,float> add vertical space at thread start (column mode only)";
+let graph_content_options = Arg.align ~limit:40 [
+  "-help", Arg.Unit (Fun.id), "" ;
+  "--help", Arg.Unit (Fun.id), "" ;
+  (* Edges *)
+  ("", Arg.Unit Fun.id, "\n");
+  ("Edge options", Arg.Unit Fun.id, " ");
+  parse_bool "-showinitrf" PP.showinitrf "show read-from edges from initial state in pictures" ;
+  parse_bool "-showfinalrf" PP.showfinalrf "show read-from edges to final state in pictures" ;
+  doshow_option ;
+  parse_bool "-showpo" PP.showpo "show po edges in pictures" ;
+  unshow_option ;
+  parse_stringset "-symetric" PP.symetric "declare those edges as symetric" ;
+  parse_stringset "-noid" PP.noid "like -symetric, additionally do not show identity edges" ;
+  parse_stringset "-showraw" PP.showraw "do not perform transitivity removal on those edges" ;
+
+  (* Events *)
+  ("", Arg.Unit Fun.id, "\n");
+  ("Event options", Arg.Unit Fun.id, " ");
+  parse_bool "-oneinit" PP.oneinit "show an init writes pseudo-event, with all initial writes grouped" ;
+  showevents_option;
+  parse_bool "-showinitwrites" PP.showinitwrites
+    "show init write events in pictures" ;
+  parse_stringset "-cycles" cycles  "<name1,...,nameN> show failing checks as cycles, cumulates" ;
+  parse_bool "-dumpes" Opts.dumpes "dump event structures";
+ "-initwrites", Arg.Bool (fun b -> initwrites := Some b),
+    "<bool> represent init writes as write events. This option should not be used except for debugging model options";
+  parse_string_opt "-classes" PP.classes "show classes of this equivalence (do not cumulate)" ;
+]
+let graph_presentation_options = Arg.align ~limit:40 [
+  "-help", Arg.Unit Fun.id, "" ;
+  "--help", Arg.Unit Fun.id, "" ;
+  ("", Arg.Unit Fun.id, "\n");
+  parse_bool "-showobserved" PP.showobserved
+    "highlight observed memory reads in execution graphs" ;
   parse_bool "-edgemerge" PP.edgemerge "merge edges, cppmem style" ;
-  parse_bool "-labelinit" PP.labelinit "show labels on the init node" ;
-(* Legend *)
   parse_bool "-showlegend" PP.showlegend  "show legend in pictures" ;
   parse_bool "-showkind" showkind  "show test kind in legends" ;
   parse_bool "-shortlegend" shortlegend "show test name only in legends";
-(* Nodes *)
- parse_bool "-squished" PP.squished "limit information in graph nodes" ;
+  parse_bool "-labelinit" PP.labelinit "show labels on the init node" ;
+  parse_bool "-showthread" PP.showthread "show thread numbers in execution graphs" ;
+  parse_bool "-squished" PP.squished "limit information in graph nodes" ;
   parse_bool "-fixedsize" PP.fixedsize
     "fixedsize attribute for nodes in graph" ;
   parse_float "-extrachars" PP.extrachars
     "additional space for computing node width, can be negative" ;
-  parse_bool "-showobserved" PP.showobserved
-    "highlight observed memory reads in pictures" ;
   parse_bool "-brackets" PP.brackets
     "show brackets around locations in pictures" ;
-  parse_bool "-texmacros" PP.texmacros "use latex commands in output";
-  parse_bool "-tikz" PP.tikz "generate dot files suitable for processing with TikZ";
-(* Edge selection *)
-  parse_bool "-showpo" PP.showpo "show po edges in pictures" ;
-  parse_bool "-showinitrf" PP.showinitrf
-    "show read-from edges from initial state in pictures" ;
-  parse_bool "-showfinalrf" PP.showfinalrf
-    "show read-from edges to final state in pictures" ;
   parse_pos "-initrfpos" PP.initdotpos
     "position of pseudo source event for initial rf" ;
   parse_pos "-finalrfpos" PP.initdotpos
     "position of pseudo target event for final rf" ;
-  parse_bool "-oneinit" PP.oneinit
-    "show a init writes pseudo-event, with all initial writes grouped" ;
   parse_pos_opt "-initpos" PP.initpos
     "position of the init writes pseudo-event" ;
-  parse_bool "-showinitwrites" PP.showinitwrites
-    "show init write events in pictures" ;
-  parse_float "-threadposy" PP.threadposy
-    "thread number position in the y direction" ;
- parse_stringsetfun "-doshow" PP.add_doshow "show those edges";
- parse_stringsetfun "-unshow" PP.add_unshow "do not show those edges" ;
- parse_stringset "-symetric" PP.symetric "declare those edges as symetric" ;
- parse_stringset "-noid" PP.noid "like -symetric, additionally do not show identity edges" ;
- parse_string_opt "-classes" PP.classes "show classes of this equivalence (no not cumulate)" ;
- parse_stringset "-showraw" PP.showraw
-    "do not perform transitivity removal on those edges" ;
-
-(* DOT contents control *)
   parse_tag "-splines"
     (fun tag -> match Splines.parse tag with
     | None -> false
     | Some Splines.No -> PP.splines := None; true
     | Some t -> PP.splines := Some t ; true)
     Splines.tags
-    "specify splines graph attribute, default none" ;
+    "Specify splines graph attribute, default none" ;
   parse_float_opt "-margin" PP.margin "margin attribute of graphs";
   parse_float_opt "-pad" PP.pad "pad attribute of graphs";
   parse_string_opt "-sep" PP.sep "specify graph sep attribute" ;
@@ -325,27 +288,48 @@ let options = [
         raise
           (Arg.Bad
              (sprintf "bad argument for option -edgeattr: '%s'" tag))),
-  "<label,attribute,value> specify an attribute for edges labelled by label";]
-(* Select input *)
-  @parse_noselect
-(* Change input *)
-  @[( "-kinds",
-    Arg.String (fun s -> kinds := !kinds @ [s]),
-    "<name> specify kind of tests (can be repeated)");
-  ( "-conds",
-    Arg.String  (fun s -> conds := !conds @ [s]),
-    "<name> specify conditions of tests (can be repeated)");
-(* Undocumented *)
-  parse_bool "-candidates" candidates
-  "show complete candidate count in output" ;
-  parse_tag "-restrict"
-    (fun tag -> match Restrict.parse tag with
-    | None -> false
-    | Some t -> restrict := t ; true)
-    Restrict.tags
-    (sprintf "restrict outcomes, default %s" (Restrict.pp !restrict));
-  parse_bool "-outcomereads" outcomereads "include all memory reads in outcomes" ;
+  "<label,attribute,value> specify an attribute for edges labelled by label";
   parse_string_opt "-overlap" PP.overlap "specify graph overlap attribute" ;
+   parse_tag "-graph"
+    (fun tag -> match Graph.parse tag with
+    | None -> false
+    | Some t -> PP.graph := t ; true)
+     Graph.tags
+     (sprintf "Select sort of graph, default %s" (Graph.pp !PP.graph)) ;
+  parse_tag "-dotmode"
+    (fun tag -> match PrettyConf.parse_dotmode tag with
+    | None -> false
+    | Some t -> PP.dotmode := t ; true)
+    PrettyConf.tags_dotmode
+    (sprintf "Control text in dot figures, default %s"
+       (PrettyConf.pp_dotmode !PP.dotmode)) ;
+  parse_bool "-mono" PP.mono "monochrome figures" ;
+  parse_float "-scale" PP.scale "global scale factor for graphs" ;
+  parse_float "-xscale" PP.xscale
+    "global scale factor for graphs, x direction" ;
+  parse_float "-yscale" PP.yscale
+    "global scale factor for graphs, y direction" ;
+  parse_float "-dsiy" PP.dsiy "vertical variation for events generated by the same instruction" ;
+  parse_float "-siwidth" PP.siwidth "width occupied by events generated by the same instruction" ;
+  parse_float "-ptscale" PP.ptscale "scale factor for points" ;
+  parse_float "-boxscale" PP.ptscale "scale factor box width" ;
+  "-shift",
+  Arg.String
+    (fun tag ->
+      let fs = Misc.split_comma tag in
+      let fs =
+        List.map
+          (fun f ->
+            try float_of_string f with
+            | _ ->
+                raise
+                  (Arg.Bad
+                     (sprintf "bad argument for option -shift: '%s'" tag)))
+          fs in
+      PP.shift := Array.of_list fs),
+  "<float,...,float> add vertical space at thread start (column mode only)";
+ parse_float "-threadposy" PP.threadposy
+    "thread number position in the y direction" ;
   parse_bool "-relabel" PP.relabel
     "merge power/arm labels(e.g sync -> sync/dmb)" ;
   parse_bool "-withbox" PP.withbox
@@ -354,17 +338,198 @@ let options = [
     "label instruction instruction boxes with instruction" ;
   parse_bool "-movelabel" PP.movelabel
     "apply various tricks to enhance edge label placement in pictures" ;
+  ]
+
+let setup_options = Arg.align ~limit:40 ([
+   "-help", Arg.Unit Fun.id, "" ;
+  "--help", Arg.Unit Fun.id, "";
+  ("", Arg.Unit Fun.id, "\n");
+  ("-version", Arg.Unit
+     (fun () -> printf "%s, Rev: %s\n" Version.version Version.rev ; exit 0),
+   " ") ;
+  ("-libdir", Arg.Unit (fun () -> print_endline !Opts.libdir; exit 0),
+    " show the default search path for .cat files and ASL pseudocode files");
+  ("-set-libdir", Arg.String (fun s -> Opts.libdir := s),
+    "<path> set the default search path for .cat files and ASL pseudocode files to <path>");
+  v_option ;
+  ("-q", Arg.Unit (fun _ -> verbose := -1; debug := Debug_herd.none),
+   "<default> do not show diagnostics");
+  ("-I", Arg.String (fun s -> includes := !includes @ [s]),
+   "<dir> add <dir> to the search path for .cat files and ASL pseudocode files, takes precedence over libdir ");
+  parse_bool "-exit" Opts.exit_if_failed "exit in case of failure";
+  conf_option ;
+  ("-web",
+   Arg.Unit (fun () -> load_config "web.cfg")," alias for -conf web.cfg");
+  ("-c11",
+   Arg.Unit (fun () -> load_config "cpp11.cfg")," alias for -conf cpp11.cfg");
+  ("-bell",
+   Arg.String (fun x -> Opts.bell := (Some x)),
+   "<name> read bell file <name>") ;
+  ("-macros",
+   Arg.String (fun x -> Opts.macros := (Some x)),
+   "<name> read macro (.def) file <name>") ;
+  o_option ;
+  view_option ;
+  ( "-gv",
+    Arg.Unit (fun _ -> PP.view := Some View.GV),
+    " alias for -view gv") ;
+  ( "-evince",
+    Arg.Unit (fun _ -> PP.view := Some View.Evince),
+    " alias for -view evince") ;
+  ( "-preview",
+    Arg.Unit (fun _ -> PP.view := Some View.Preview),
+    " alias for -view preview") ;
+  parse_tag "-dotcom"
+    (fun tag -> match PrettyConf.parse_dotcom tag with
+    | None -> false
+    | Some _ as t -> PP.dotcom := t ; true)
+    PrettyConf.tags_dotcom
+    "Select command to translate dot, default depends on other modes " ;
+  parse_tags
+    "-debug"
+    (fun tag -> match Debug_herd.parse !debug tag with
+    | None -> false
+    | Some t -> debug := t ; true)
+    Debug_herd.tags
+    "Show debug messages for specific parts" ;
+
+  (* Input *)
+  ("", Arg.Unit Fun.id, "\n");
+  ("Input options", Arg.Unit Fun.id, " ");
+
+  ( "-kinds",
+    Arg.String (fun s -> kinds := !kinds @ [s]),
+    "<name> specify kind of tests (can be repeated)");
+  ( "-conds",
+    Arg.String  (fun s -> conds := !conds @ [s]),
+    "<name> specify conditions of tests (can be repeated)");
+    ]
+   @ parse_noselect @ [
+  (* Output *)
+  ("", Arg.Unit Fun.id, "\n");
+  ("Output options", Arg.Unit Fun.id, " ");
+
   ("-dotheader",Arg.String (fun s -> PP.dotheader := Some s),
    "<name> insert the contents of <name> at the beginning of generated dot files");
+  parse_bool "-tikz" PP.tikz "generate dot files suitable for processing with TikZ";
+  parse_bool "-texmacros" PP.texmacros "use latex commands in output";
+  ("-suffix", Arg.String (fun s -> suffix := s),
+   "<suf> add <suf> at the end of the base of generated files");
+  parse_bool "-candidates" candidates
+  "show complete candidate count in output" ;
+  parse_bool "-outcomereads" outcomereads "include all memory reads in outcomes" ;
+  hexa_option ;
+   ])
+  let help_options = Arg.align ~limit:40 [
+  ("", Arg.Unit Fun.id, "\n");
+  ("-help", Arg.Unit Fun.id, " show option categories");
+  ("--help", Arg.Unit Fun.id, " show all options" )
+]
+(*Usage messages*)
+let usg_setup = (sprintf "\n Control the command environment: paths, config, input and output handling")
+let usg_runmode = (sprintf "\n Configure herd")
+let usg_filter = (sprintf"\n Select model and control which executions are filtered or allowed")
+let usg_graph_content = (sprintf "\n Control what events and edges are included in the graph")
+let usg_graph_presentation = (sprintf "\n Control graph layout, sizing, annotations and visual clarity")
+
+let usg_default = String.concat "\n"
+  [
+  Arg.usage_string common_options "Common herd options: \n";
+"For advanced options, use `-help <category>`:
+  setup               Control the command environment: paths, config, input and
+                      output handling
+  runmode             Configure herd
+  filter              Select model and control which executions are filtered or 
+                      allowed
+  graph_content       Control what events and edges are included in the 
+                      graph
+  graph_presentation  Control graph layout, sizing, annotations, and visual 
+                      clarity
+  Help commands
+    -help        Show this help message
+    -help all    Show all available options
+    --help       Show all available options
+"
 ]
 
+let show_short_help () =
+  print_endline usg_default;
+  exit 0
+
+let show_long_help () =
+  print_endline "Available options:";
+  Printf.printf "%s" (Arg.usage_string setup_options usg_setup);
+  Printf.printf "%s" (Arg.usage_string runmode_options usg_runmode);
+  Printf.printf "%s" (Arg.usage_string filter_options usg_filter);
+  Printf.printf "%s" (Arg.usage_string graph_content_options usg_graph_content);
+  Printf.printf "%s" (Arg.usage_string graph_presentation_options usg_graph_presentation);
+  Printf.printf "%s" (Arg.usage_string help_options "\n Help commands");
+  exit 0
+
+let help_exists () =
+  Array.exists (fun s -> s = "-help" || s = "--help") Sys.argv
+
+let options = setup_options @
+  runmode_options @
+  filter_options @
+  graph_content_options @
+  graph_presentation_options @
+  help_options
+
+let is_known_category = function
+  | "setup" 
+  | "runmode" 
+  | "filter"
+  | "graph_content" 
+  | "graph_presentation"
+  | "variant" 
+  | "all" -> true
+  | _ -> false
+
+let display_help = function
+  | "setup" ->
+      Printf.printf "%s" (Arg.usage_string setup_options usg_setup); exit 0
+  | "runmode" ->
+      Printf.printf "%s" (Arg.usage_string runmode_options usg_runmode); exit 0
+  | "filter" ->
+      Printf.printf "%s" (Arg.usage_string filter_options usg_filter); exit 0
+  | "graph_content" ->
+     Printf.printf "%s" (Arg.usage_string graph_content_options usg_graph_content); exit 0  
+  | "graph_presentation" ->
+     Printf.printf "%s" (Arg.usage_string graph_presentation_options usg_graph_presentation); exit 0
+  | "variant" ->
+     Printf.printf "%s" (Variant.variants_help_page); exit 0
+  | "all" ->
+     show_long_help ()
+  |  _ -> 
+      show_short_help ()
+
+let handle_help_or_return () =
+  let inputs = Array.to_list Sys.argv |> List.tl in
+  let has_long_help = List.exists ((=) "--help") inputs in
+  let has_short_help = List.exists ((=) "-help") inputs in
+
+  if has_long_help then  show_long_help () else
+    if has_short_help then 
+      let rest = List.filter (fun s -> s <> "-help") inputs in
+      let (categories, others) = List.partition is_known_category rest in
+      match (categories, others) with      
+      | ([category], []) -> display_help category         
+      | _ -> show_short_help ()              
+  
 (* Parse command line *)
 let () =
   try
-    Arg.parse options
-      get_cmd_arg
-      (sprintf "Usage %s [options] [test]*" prog)
+    handle_help_or_return ();
+    let current = ref 0 in
+    Arg.parse_argv ~current Sys.argv (Arg.align options) get_cmd_arg usg_default;
   with
+  | Arg.Bad msg -> 
+    begin
+      let first_line = String.trim msg |> String.split_on_char '\n' |> List.hd in
+        Printf.eprintf "Error: %s\n %s \n" first_line usg_default;
+        exit 2
+      end
   | Misc.Fatal msg -> eprintf "%s: %s\n" prog msg ; exit 2
 
 (* Read generic model, if any *)

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -117,17 +117,98 @@ type t =
 (* Allow to use pac(pac(...)) using the XOR of two pac fields *)
   | ConstPacField
 
-let tags =
-  ["success";"instr";"specialx0";"normw";"acqrelasfence";"backcompat";
-   "fullscdepend";"splittedrmw";"switchdepscwrite";"switchdepscresult";"lrscdiffok";
-   "mixed";"dontcheckmixed";"weakpredicated"; "lkmmv1"; "lkmmv2"; "memtag";"vmsa";"kvm";]@
-    Precision.tags @ Fault.Handling.tags @
-   ["CutOff"; "deps"; "morello"; "instances"; "noptebranch"; "pte2";
-   "pte-squared"; "PhantomOnLoad"; "OptRfRMW"; "ConstrainedUnpredictable";
-    "exp"; "self"; "cos-opt"; "test"; "T[0-9][0-9]"; "asl"; "strict";
-    "warn"; "S128"; "ASLType+Warn";    "ASLType+Silence"; "ASLType+Check";
-    "ASL+AArch64+UDF"; "telechat"; "OldSolver"; "oota";
-    "pac"; "fpac"; "const-pac-field";]
+(* Identity function to prompt developers to insert variant into list used for help message when adding a new variant*)
+let (mode_variants, arch_variants) : t list * t list =
+  let f = function 
+  | Success -> Success
+  | Instr -> Instr
+  | SpecialX0 -> SpecialX0
+  | NoRMW -> NoRMW
+  | AcqRelAsFence -> AcqRelAsFence
+  | BackCompat ->BackCompat
+  | FullScDepend -> FullScDepend
+  | SplittedRMW -> SplittedRMW
+  | SwitchDepScWrite -> SwitchDepScWrite
+  | SwitchDepScResult -> SwitchDepScResult
+  | LrScDiffOk -> LrScDiffOk
+  | Mixed -> Mixed
+  | Unaligned -> Unaligned
+  | DontCheckMixed -> DontCheckMixed
+  | NotWeakPredicated -> NotWeakPredicated
+  | LKMMVersion `lkmmv1 -> LKMMVersion `lkmmv1
+  | LKMMVersion `lkmmv2 -> LKMMVersion `lkmmv2
+  | MemTag -> MemTag
+  | MTEPrecision p -> MTEPrecision p
+  | FaultHandling p -> FaultHandling p 
+  | CutOff -> CutOff
+  | Morello -> Morello
+  | Neon -> Neon
+  | SVE -> SVE
+  | SVELength k ->  SVELength k 
+  | SME -> SME
+  | SMELength k ->  SMELength k 
+  | Deps -> Deps
+  | Instances -> Instances
+  | VMSA -> VMSA
+  | ETS -> ETS
+  | ETS2 -> ETS2
+  | ETS3 -> ETS3
+  | ExS -> ExS
+  | EIS -> EIS
+  | EOS -> EOS
+  | NoPteBranch -> NoPteBranch
+  | PTE2 -> PTE2
+  | PhantomOnLoad -> PhantomOnLoad
+  | OptRfRMW -> OptRfRMW
+  | ConstrainedUnpredictable -> ConstrainedUnpredictable
+  | Exp -> Exp
+  | Ifetch -> Ifetch
+  | DIC -> DIC
+  | IDC -> IDC
+  | CosOpt -> CosOpt
+  | Test -> Test
+  | T n -> T n 
+  | ASL -> ASL
+  | ASL_AArch64 -> ASL_AArch64
+  | ASLVersion `ASLv0 ->  ASLVersion `ASLv0
+  | ASLVersion `ASLv1 -> ASLVersion `ASLv1
+  | S128 -> S128
+  | Strict -> Strict
+  | Warn -> Warn
+  | ASLType `Warn -> ASLType `Warn 
+  | ASLType `Silence ->  ASLType `Silence 
+  | ASLType `TypeCheck -> ASLType `TypeCheck
+  | ASL_AArch64_UDF -> ASL_AArch64_UDF 
+  | Telechat -> Telechat
+  | NV2 -> NV2
+  | OldSolver -> OldSolver
+  | OOTA -> OOTA
+  | Pac -> Pac
+  | ConstPacField -> ConstPacField
+  | FPac -> FPac
+
+in 
+  (*Modes of operation*)
+ (List.map f 
+ [ Success;  Instr;  SpecialX0;  NoRMW;  AcqRelAsFence;
+   BackCompat;  FullScDepend;  SplittedRMW; SwitchDepScWrite;
+   SwitchDepScResult; LrScDiffOk; Mixed; Unaligned; DontCheckMixed; NotWeakPredicated;
+   LKMMVersion `lkmmv1; LKMMVersion `lkmmv2;
+  CutOff; Morello; Neon;  Deps; Instances; VMSA; 
+  SVE; SVELength 128; SME; SMELength 128;
+  NoPteBranch; PTE2;
+  PhantomOnLoad; OptRfRMW; ConstrainedUnpredictable;
+  Exp; Ifetch; CosOpt; Test; T 0; ASL;
+  ASL_AArch64; ASLVersion `ASLv0; ASLVersion `ASLv1; S128; Strict; Warn;
+  ASLType `Warn; ASLType `Silence; ASLType `TypeCheck; ASL_AArch64_UDF;
+  Telechat; OldSolver; OOTA], 
+  (*Architectural Features*)
+  List.map f 
+  [MemTag; MTEPrecision Precision.default; FaultHandling  Fault.Handling.default;
+  ETS; ETS2; ETS3; ExS; EIS; EOS;
+  DIC; IDC; NV2;
+  Pac; ConstPacField; FPac])
+
 
 let parse s = match Misc.lowercase s with
 | "success" -> Some Success
@@ -237,10 +318,10 @@ let pp = function
   | AcqRelAsFence -> "acqrelasfence"
   | BackCompat ->"backcompat"
   | FullScDepend -> "FullScDepend"
-  | SplittedRMW -> "SplittedRWM"
+  | SplittedRMW -> "SplittedRMW"
   | SwitchDepScWrite -> "SwitchDepScWrite"
   | SwitchDepScResult -> "SwitchDepScResult"
-  | LrScDiffOk -> " LrScDiffOk"
+  | LrScDiffOk -> "LrScDiffOk"
   | Mixed -> "mixed"
   | Unaligned -> "unaligned"
   | DontCheckMixed -> "DontCheckMixed"
@@ -297,6 +378,109 @@ let pp = function
   | ConstPacField -> "const-pac-field"
   | FPac -> "fpac"
 
+  let under_development = true
+  let variant_descriptions = function
+  | Success -> "Riscv Model with explicit success dependency"
+  | Instr -> "Define instr (or same-instance) relation"
+  | SpecialX0 -> ""
+  | NoRMW -> ""
+  | AcqRelAsFence -> ""
+  | BackCompat ->""
+  | FullScDepend -> ""
+  | SplittedRMW -> ""
+  | SwitchDepScWrite -> ""
+  | SwitchDepScResult -> ""
+  | LrScDiffOk -> ""
+  | Mixed -> ""
+  | Unaligned -> ""
+  | DontCheckMixed -> ""
+  | NotWeakPredicated -> ""
+  | LKMMVersion `lkmmv1 -> ""
+  | LKMMVersion `lkmmv2 -> ""
+  | MemTag -> ""
+  | MTEPrecision _ -> ""
+  | FaultHandling _-> ""
+  | CutOff -> ""
+  | Morello -> ""
+  | Neon -> ""
+  | SVE -> ""
+  | SVELength _ -> ""
+  | SME -> ""
+  | SMELength _ -> ""
+  | Deps -> ""
+  | Instances -> ""
+  | VMSA -> ""
+  | ETS -> ""
+  | ETS2 -> ""
+  | ETS3 -> ""
+  | ExS -> ""
+  | EIS -> ""
+  | EOS -> ""
+  | NoPteBranch -> ""
+  | PTE2 -> ""
+  | PhantomOnLoad -> ""
+  | OptRfRMW -> ""
+  | ConstrainedUnpredictable -> ""
+  | Exp -> ""
+  | Ifetch -> ""
+  | DIC -> ""
+  | IDC -> ""
+  | CosOpt -> ""
+  | Test -> ""
+  | T _ -> ""
+  | ASL -> ""
+  | ASL_AArch64 -> ""
+  | ASLVersion `ASLv0 -> ""
+  | ASLVersion `ASLv1 -> ""
+  | S128 -> ""
+  | Strict -> ""
+  | Warn -> ""
+  | ASLType `Warn -> ""
+  | ASLType `Silence -> ""
+  | ASLType `TypeCheck -> ""
+  | ASL_AArch64_UDF -> ""
+  | Telechat -> ""
+  | NV2 -> ""
+  | OldSolver -> ""
+  | OOTA -> ""
+  | Pac -> ""
+  | ConstPacField -> ""
+  | FPac -> ""
+
+let mode_tags =
+  let normalise_T00 = function
+    | "T00" -> "T[0-9][0-9]"
+    | s -> s in
+      List.map( normalise_T00) (List.map pp mode_variants)
+let arch_tags =
+  List.map pp arch_variants
+
+let mode_help_tags =
+  List.map2
+    (fun variant description ->
+      variant ^ ": " ^ description)
+    mode_tags
+    (List.map variant_descriptions mode_variants)
+
+ let arch_help_tags =
+  List.map2 
+    (fun variant  description ->
+      variant ^ ": " ^ description)
+    arch_tags
+    (List.map variant_descriptions arch_variants)
+
+let help_message tags1 tags2 space =
+   Printf.sprintf "\n Use -variant <tags> where:\n Mode of Operation tags:\n  %s 
+    \n Architecture Feature tags:\n  %s \n" 
+  (String.concat space tags1) (String.concat space tags2) 
+let variants_help_page =
+  if under_development then
+    help_message mode_tags arch_tags ","
+  else
+    help_message mode_help_tags arch_help_tags "\n  "
+
+
+let tags = mode_tags @ arch_tags
 let compare = compare
 let equal v1 v2 = compare v1 v2 = 0
 

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -123,6 +123,7 @@ type t =
 val compare : t -> t -> int
 val equal : t -> t -> bool
 val tags : string list
+val variants_help_page: string 
 val parse : string -> t option
 val pp : t -> string
 

--- a/lib/argUtils.ml
+++ b/lib/argUtils.ml
@@ -129,11 +129,11 @@ let do_tag opt set tags tag =
 let parse_tag opt set tags msg =
   opt,
   Arg.String (do_tag opt set tags),
-  sprintf "<%s> %s" (String.concat "|" tags) msg
+  sprintf "<tags> where tags is <%s>. %s" (String.concat "|" tags) msg
 
 let parse_tags opt set tags msg =
   let do_tag = do_tag opt set tags in
   opt,
   Arg.String
     (fun tags -> Misc.split_comma tags |>  List.iter do_tag),
-  sprintf "<%s> (comma separated list) %s" (String.concat "|" tags) msg
+  sprintf "<tags> where tags is <%s> (comma separated list). %s" (String.concat "|" tags) msg

--- a/lib/parseTag.ml
+++ b/lib/parseTag.ml
@@ -38,11 +38,11 @@ module Make (O:Opt) =
       match d with
       | Some d ->
           sprintf
-            "<%s> %s, default %s"
+            "<tags> where tags is <%s> %s, default %s"
             (String.concat "|" O.tags) msg
             (O.pp d)
       | None ->
-          sprintf "<%s> %s" (String.concat "|" O.tags) msg
+          sprintf "<tags> where tags is <%s>. %s" (String.concat "|" O.tags) msg
 
     let parse_withfun opt f msg d =
       complete opt msg
@@ -107,8 +107,7 @@ module MakeS (O:OptS)
 
       let parse opt add msg =
         let spec = do_parse_tag_set opt (add_tag add) in
-        opt,Arg.String spec,
-        Printf.sprintf "<tags> where tags in {%s}, %s" taglist msg
+        opt,Arg.String spec, msg
     end
 
 module type SArg = sig

--- a/litmus/litmus.ml
+++ b/litmus/litmus.ml
@@ -73,7 +73,7 @@ let opts =
        let reducetag = check_tag
      end in
      let module P = ParseTag.MakeS(Opt) in
-   P.parse "-variant" Option.variant "select a variation" end ;
+   P.parse "-variant" Option.variant Variant_litmus.helper_message end ;
    begin let module P = ParseTag.Make(Barrier) in
    P.parse "-barrier" Option.barrier "set type of barriers" end ;
    "-delay", Arg.Int set_delay,

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -28,11 +28,25 @@ type t =
   | FPac (* Fault on pointer authentication *)
   | ConstPacField (* Bit 55 is used to compute the VA-range in ComputePAC *)
 
-let compare = compare
+let (mode_variants, arch_variants) : t list * t list =
+  let f = function 
+  | Self -> Self
+  | FaultHandling p -> FaultHandling p 
+  | S128 -> S128
+  | Mixed -> Mixed
+  | Vmsa -> Vmsa
+  | Telechat -> Telechat
+  | SVE -> SVE
+  | SME -> SME
+  | NoInit -> NoInit
+  | Pac -> Pac
+  | FPac -> FPac
+  | ConstPacField -> ConstPacField
+in
+(List.map f [Self; FaultHandling Fault.Handling.default; S128; Mixed; Vmsa; 
+ Telechat; NoInit], List.map f [SVE; SME; Pac; FPac; ConstPacField])
 
-let tags =
-  "noinit"::"s128"::"self"::"mixed"::"vmsa"::"telechat"::"pac"
-  ::"const-pac-field"::"fpac"::Fault.Handling.tags
+let compare = compare
 
 let parse s = match Misc.lowercase s with
 | "noinit" -> Some NoInit
@@ -92,3 +106,16 @@ let set_mte_precision _ _ = false
 let set_sve_length _ _ = None
 let set_sme_length _ _ = None
 let check_tag tag = [tag]
+
+let mode_tags =
+  List.map pp mode_variants
+
+let arch_tags =
+  List.map pp arch_variants
+
+let tags = 
+  mode_tags @ arch_tags
+
+
+let helper_message =
+  Printf.sprintf "<tags> where:\n Mode tags:\n  {%s}\n Arch tags:\n {%s}" (String.concat "," mode_tags) (String.concat "," arch_tags) 

--- a/litmus/variant_litmus.mli
+++ b/litmus/variant_litmus.mli
@@ -29,6 +29,7 @@ type t =
   | ConstPacField (* Bit 55 is used to compute the VA-range in ComputePAC *)
 
 val tags : string list
+val helper_message: string 
 val parse : string -> t option
 val pp : t -> string
 val ok : t -> Archs.t -> bool


### PR DESCRIPTION
This PR improves the herd -help command to make it easier for users to discover and understand available options when using herd.
- Options are grouped into separate lists (setup, runmode, filter, graph content, graph presentation) to support displaying them by category in the help output.
- Each group of options and details about their behavior can be displayed using the command `-help <category>` .
- The -help command displays a short list of commonly used options and a summary of all option categories.
- The --help command (or -help all) displays a full list of all options separated by category.
- If -help or --help appears in the command line, all other arguments are ignored and only the help message is shown.

This PR also updates the presentation of variant tags in the herd and litmus -help commands.
- Missing variants from the help output tag list have been added, along with an identity function to prompt developers to add new variants into the list.
- Variants are now grouped into two categories: modes of operation and architectural features.
- In herd there is a dedicated help page (-help variant) that lists all variants separated by category. The option to display the list of variants with their descriptions is guarded by a conditional, which should be removed when the blank descriptions are populated.