### PR TITLE
[litmus] Change handling of the self variant

### DIFF
--- a/litmus/answer.mli
+++ b/litmus/answer.mli
@@ -20,13 +20,15 @@
 type hash = { filename : string ;  hash : string ; }
 type hash_env = hash StringMap.t
 
+type completed = (* Answer for completed test *)
+  { arch : Archs.t ; (* Arch of test *)
+    doc : Name.t   ; (* Name of test *)
+    src : string   ; (* Name of emitted source file *)
+    fullhash : hash ; nprocs : int ; (* hash and numbre of threads *)
+    pac : bool     ; (* Requires pointer authentification *)
+  }
+
 type answer =
-  | Completed of
-      Archs.t * Name.t   (* Test arch and name *)
-        * string         (* C source file of test *)
-        * StringSet.t    (* cycles *)
-        * hash_env       (* name -> hash *)
-        * int            (* number of threads *)
-        * bool           (* require Pointer Authentication Code *)
-  | Interrupted of Archs.t * exn
-  | Absent of Archs.t
+  | Completed of completed
+  | Interrupted of exn (* Error *)
+  | Absent (* Test not compile for some reason under user control *)

--- a/litmus/answer.mli
+++ b/litmus/answer.mli
@@ -26,6 +26,7 @@ type completed = (* Answer for completed test *)
     src : string   ; (* Name of emitted source file *)
     fullhash : hash ; nprocs : int ; (* hash and numbre of threads *)
     pac : bool     ; (* Requires pointer authentification *)
+    self : bool    ; (* Self modying code *)
   }
 
 type answer =

--- a/litmus/dumpRun.mli
+++ b/litmus/dumpRun.mli
@@ -38,7 +38,6 @@ module type Config = sig
   val asmcommentaslabel : bool
   include RunUtils.CommonConfig
   val mkopt : Option.opt -> Option.opt
-  val variant : Variant_litmus.t -> bool
   val nocatch : bool
   val smt : int
   val nsockets : int

--- a/litmus/dumpRun.mli
+++ b/litmus/dumpRun.mli
@@ -47,8 +47,7 @@ end
 
 
 module type OneTest = sig
-  val from_file :
-      StringSet.t -> hash_env-> string -> out_channel -> answer
+  val from_file : hash_env -> string -> out_channel -> answer
 end
 
 module Make :

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -246,7 +246,7 @@ end = struct
 
       let compile
             parse count_procs compile allocate
-            cycles hash_env
+            hash_env
             name in_chan out_chan splitted =
         try begin
             check_variant Variant_litmus.Self splitted.Splitter.arch ;
@@ -263,13 +263,12 @@ end = struct
               cycle_ok && hash_ok && limit_ok
             then begin
                 warn_limit doc nprocs ;
-                let hash_env = StringMap.add tname hash hash_env in
                 let parsed = change_hint hint doc.Name.name parsed in
                 let allocated = allocate parsed in
                 let compiled = compile doc allocated in
-                let source = MyName.outname name ".c" in
+                let src = MyName.outname name ".c" in
                 let pac = O.variant Variant_litmus.Pac in
-                dump source doc compiled;
+                dump src doc compiled;
                 if not OT.is_out then begin
                     let _utils =
                       let module OO = struct
@@ -285,15 +284,16 @@ end = struct
                       Obj.dump pac in
                     ()
                   end ;
-                R.run name out_chan doc allocated source ;
-                Completed (A'.arch,doc,source,cycles,hash_env,nprocs,pac)
+                R.run name out_chan doc allocated src ;
+                Completed
+                  { arch = A'.arch; doc; src; fullhash = hash ; nprocs; pac; }
               end else begin
                 let cause = if limit_ok then "" else " (too many threads)" in
                 W.warn "%s test not compiled%s"
                   (Pos.str_pos0 doc.Name.file) cause ;
-                Absent A'.arch
+                Absent
               end
-          end with e -> if OT.nocatch then raise e ; Interrupted (A'.arch,e)
+          end with e -> if OT.nocatch then raise e ; Interrupted e
     end
 
 
@@ -390,7 +390,7 @@ end = struct
 
   module SP = Splitter.Make(LexConfig)
 
-  let from_chan cycles hash_env name in_chan out_chan =
+  let from_chan hash_env name in_chan out_chan =
     (* First split the input file in sections *)
     let { Splitter.arch=arch ; _ } as splitted =
       SP.split name in_chan in
@@ -597,14 +597,14 @@ end = struct
              X.compile
           | `CPP | `LISA | `JAVA | `ASL | `BPF -> assert false
         in
-        aux arch cycles hash_env name in_chan out_chan splitted
+        aux arch hash_env name in_chan out_chan splitted
       end else begin (* Excluded explicitely, (check_tname), do not warn *)
-        Absent arch
+        Absent
       end
 
-  let from_file cycles hash_env name out_chan =
+  let from_file hash_env name out_chan =
     Misc.input_protect
-      (fun in_chan -> from_chan cycles hash_env name in_chan out_chan)
+      (fun in_chan -> from_chan hash_env name in_chan out_chan)
       name
 
   (* Call generic tar builder/runner *)

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -286,7 +286,8 @@ end = struct
                   end ;
                 R.run name out_chan doc allocated src ;
                 Completed
-                  { arch = A'.arch; doc; src; fullhash = hash ; nprocs; pac; }
+                  { arch = A'.arch; doc; src; fullhash = hash ;
+                    nprocs; pac; self = O.variant Variant_litmus.Self; }
               end else begin
                 let cause = if limit_ok then "" else " (too many threads)" in
                 W.warn "%s test not compiled%s"


### PR DESCRIPTION
The variant `self` impacts (1) the C code of a test and  (2) gcc compilation flags. Compilation flags are now changed as soon as one test is compiled in self mode.

This departs from previous behaviour where compilation  flags were changed only when the variant was specified on the command line.
    
Change is minor and only applies when
     1. `-variant self` is *not* specified on the command line.
     2. Some of the compiled tests meta-data specifies `Variant=self`.
    
In that situation the previous behaviour was *not* changing the compilation flags, while the new behaviour is changing them.

As a technical note, the functor  `DumpRun.Make` configuration argument does not longer include a `variant` member.