### PR TITLE
[build] Enable warning 9, except in asllib

### DIFF
--- a/asllib/dune
+++ b/asllib/dune
@@ -1,3 +1,11 @@
+(env
+ (release
+  (flags
+   (:standard -w +a-3-4-9-29-33-41-45-60-67-70)))
+ (dev
+  (flags
+   (:standard -warn-error +A -w +a-3-4-9-29-33-41-45-60-67-70))))
+
 (rule
  (copy ../Version.ml Version.ml))
 

--- a/diymicro/cycle.ml
+++ b/diymicro/cycle.ml
@@ -248,8 +248,8 @@ let set_significant_reads first_node =
     match node.prev.edge, node.edge with
     | Edge.Rf _, _
     | _, Edge.Fr _
-    | Edge.Iico Edge.{significant_dest = true}, _
-    | _, Edge.Iico Edge.{significant_source = true} ->
+    | Edge.Iico Edge.{significant_dest = true; _}, _
+    | _, Edge.Iico Edge.{significant_source = true; _} ->
         node.source_event.is_significant <- true
     | _ -> ()
   in

--- a/dune
+++ b/dune
@@ -3,10 +3,10 @@
 (env
  (release
   (flags
-   (:standard -w +a-3-4-9-29-33-41-45-60-67-70)))
+   (:standard -w +a-3-4-29-33-41-45-60-67-70)))
  (dev
   (flags
-   (:standard -warn-error +A -w +a-3-4-9-29-33-41-45-60-67-70))))
+   (:standard -warn-error +A -w +a-3-4-29-33-41-45-60-67-70))))
 
 (alias
  (name default)

--- a/lib/AArch64Op.ml
+++ b/lib/AArch64Op.ml
@@ -115,8 +115,8 @@ module
     (* Check that the PAC field of a virtual address is canonical *)
     let checkCanonical =
       let open Constant in function
-      | Symbolic (Virtual {pac}) ->
-          Some (boolToCst (PAC.is_canonical pac))
+      | Symbolic (Virtual a) ->
+          Some (boolToCst (PAC.is_canonical a.pac))
       | _ ->
           None
 
@@ -168,9 +168,9 @@ module
     let addOnePAC key pointer modifier =
       let open Constant in
       match pointer with
-      | Symbolic (Virtual {pac}) when not (PAC.is_canonical pac) ->
+      | Symbolic (Virtual a) when not (PAC.is_canonical a.pac) ->
           None
-      | Symbolic (Virtual ({pac; offset} as v)) ->
+      | Symbolic (Virtual ({pac; offset; _} as v)) ->
         let modifier = pp_cst true modifier in
         let pac = PAC.add key modifier offset pac in
         Some (Symbolic (Virtual {v with pac}))
@@ -184,7 +184,7 @@ module
     let addPAC key pointer modifier =
       let open Constant in
       match pointer with
-      | Symbolic (Virtual ({pac; offset} as v)) ->
+      | Symbolic (Virtual ({pac; offset; _} as v)) ->
         let modifier = pp_cst true modifier in
         let pac = PAC.add key modifier offset pac in
         Some (Symbolic (Virtual {v with pac}))

--- a/litmus/ASMLang.ml
+++ b/litmus/ASMLang.ml
@@ -499,8 +499,8 @@ module RegMap = A.RegMap)
       let compile_val_fun =
         let open Constant in
         fun ptevalEnv parel1Env v -> match v with
-        | Symbolic (Virtual {pac})
-          when not (PAC.is_canonical pac) ->
+        | Symbolic (Virtual a)
+          when not (PAC.is_canonical a.pac) ->
             Warn.user_error "Litmus cannot initialize a virtual address with a non-canonical PAC field"
         | Symbolic sym ->
             let s = Constant.pp_symbol_old sym in

--- a/litmus/dumpRun.ml
+++ b/litmus/dumpRun.ml
@@ -198,7 +198,7 @@ let run_tests names out_chan =
   | None -> None
   | Some exp -> Some (open_out exp) in
 
-  let  {one_arch; docs; srcs; nthreads; some_pac; some_self; } =
+  let  { one_arch; docs; srcs; nthreads; some_pac; some_self; hashes=_; } =
     Misc.fold_argv_or_stdin
       (fun name ({one_arch; docs; srcs; hashes;
                   nthreads; some_pac; some_self; } as st) ->

--- a/litmus/global_litmus.ml
+++ b/litmus/global_litmus.ml
@@ -46,7 +46,7 @@ let as_addr = function
 let tr_symbol =
   let open Constant in
   function
-    | Virtual {name=s; tag=None; cap=0L; offset=0;} -> Addr s
+    | Virtual {name=s; tag=None; cap=0L; offset=0; _} -> Addr s
     | Physical (s,0) -> Phy s
     | System (PTE,s) -> Pte s
     | c ->  Warn.fatal "litmus cannot handle symbol '%s'" (pp_symbol c)

--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -58,7 +58,7 @@ module Make(O:Config)(V:Constant.S) = struct
 
   let dump_v_std v = match v with
   | Concrete _ -> V.pp O.hexa v
-  | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=0;}) -> dump_addr a
+  | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=0; _}) -> dump_addr a
   | ConcreteVector _ -> V.pp O.hexa v
   | Instruction _ -> Misc.lowercase (V.pp false v)
   | ConcreteRecord _

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1032,7 +1032,7 @@ module Make
                 A.GetInstr.dump_instr (T.C.V.pp O.hexa) v
 
               let dump_value loc v = match v with
-              | Constant.Symbolic (Constant.Virtual {Constant.pac})
+              | Constant.(Symbolic (Virtual {pac; _}))
                 when not (PAC.is_canonical pac) ->
                   Warn.user_error "PAC not supported in post-conditions in litmus"
               | Constant.Symbolic _ -> SkelUtil.data_symb_id (T.C.V.pp O.hexa v)
@@ -1570,7 +1570,7 @@ module Make
             Warn.fatal "Vector used as scalar"
           | ConcreteRecord _ ->
             Warn.fatal "Record used as scalar"
-          | Symbolic (Virtual {pac}) when not (PAC.is_canonical pac) ->
+          | Symbolic (Virtual a) when not (PAC.is_canonical a.pac) ->
             Warn.user_error "Litmus cannot initialize a virtual address with a non-canonical PAC field"
           | Symbolic (Virtual {name=s; tag=None; offset=0; _}) ->
             sprintf "(%s)_vars->%s" (CType.dump at) s


### PR DESCRIPTION
Warning 9 "missing-record-field-pattern" flags missing fields in a record pattern.

I view it as usefull to find missing fields in complete record patterns when some field is added to a record.

Notice that uncomplete record patterns are still possible by ending patterns with the wildcard `_`.

As there are numerous such uncomplete patterns in `asllib`, warning 9 remains disabled there.