### PR TITLE
[ASL-828] Improve error messages for primitives

### DIFF
--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -106,6 +106,7 @@ type error_desc =
   | TooManyOverrideCandidates of func annotated list
   | PrecisionLostDefining
   | UnexpectedCollection
+  | BadPrimitiveArgument of identifier * string
 
 type error = error_desc annotated
 
@@ -219,6 +220,7 @@ let error_label = function
   | TooManyOverrideCandidates _ -> "TooManyOverrideCandidates"
   | PrecisionLostDefining -> "PrecisionLostDefining"
   | UnexpectedCollection -> "UnexpectedCollection"
+  | BadPrimitiveArgument _ -> "BadPrimitiveArgument"
 
 let warning_label = function
   | NoLoopLimit -> "NoLoopLimit"
@@ -607,7 +609,11 @@ module PPrint = struct
         fprintf f
           "ASL Type error:@ multiple@ `impdef`@ candidates@ for@ \
            `implementation`:@ %a"
-          (pp_print_list pp_pos) impdefs);
+          (pp_print_list pp_pos) impdefs
+    | BadPrimitiveArgument (name, reason) ->
+        pp_print_text f
+          ("ASL Execution error: " ^ name ^ " (primitive) expected an argument "
+         ^ reason));
     pp_close_box f ()
 
   let pp_warning_desc f w =

--- a/asllib/tests/stdlib.t/run.t
+++ b/asllib/tests/stdlib.t/run.t
@@ -47,7 +47,8 @@ Tests using ASLRef OCaml primitives for some stdlib functions
 Checking that --no-primitives option actually removes OCaml primitives
 (different errors are produced)
   $ aslref no-primitives-test.asl
-  ASL Execution error: Mismatch type: value -1 does not belong to type integer.
+  ASL Execution error: FloorLog2 (primitive) expected an argument greater than
+    0
   [1]
   $ aslref --no-primitives no-primitives-test.asl
   File ASL Standard Library, line 57, characters 11 to 16:


### PR DESCRIPTION
Rather than using "type mismatch" errors for primitives that expect e.g. positive inputs, use a new kind of error to report an appropriate message. 