### PR TITLE
[ASL-857] Fix a loop limit bug

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -1271,7 +1271,6 @@ module Make (B : Backend.S) (C : Config) = struct
   and eval_for loop_msg undet env index_name limit_opt v_start dir v_end body :
       stmt_eval_type =
     (* Evaluate the condition: "has the for loop terminated?" *)
-    let* next_limit_opt = tick_loop_limit body limit_opt in
     let cond_m =
       let comp_for_dir = match dir with Up -> `LT | Down -> `GT in
       let* () = B.on_read_identifier index_name (IEnv.get_scope env) v_start in
@@ -1289,6 +1288,7 @@ module Make (B : Backend.S) (C : Config) = struct
     let loop env =
       let loop_desc = ("for loop", body) in
       bind_maybe_unroll loop_desc undet (eval_block env body) @@ fun env1 ->
+      let* next_limit_opt = tick_loop_limit body limit_opt in
       let*| v_step, env2 = step env1 index_name v_start dir in
       eval_for loop_msg undet env2 index_name next_limit_opt v_step dir v_end
         body

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -2992,7 +2992,6 @@ or an abnormal configuration.
 
 \AllApply
 \begin{itemize}
-  \item \Proseticklooplimit{$\vlimitopt$}{$\vnextlimitopt$}\ProseOrError;
   \item $\compfordir$ is either $\LT$ when $\dir$ is $\UP$ or $\GT$ when $\dir$ is $\DOWN$;
   \item reading $\vstart$ into the identifier $\vindexname$ gives $\vgone$;
   \item \OneApplies
@@ -3009,6 +3008,7 @@ or an abnormal configuration.
     \begin{itemize}
       \item using $\compfordir$ to compare $\vend$ to $\vstart$ gives the native \\
             Boolean for $\False$;
+      \item \Proseticklooplimit{$\vlimitopt$}{$\vnextlimitopt$}\ProseOrError;
       \item evaluating the loop body via $\evalforloop$ with \\ $(\vindexname, \vlimitopt, \vstart, \dir, \vend, \vbody)$
       in $\env$ is \\ $\Continuing(\vgtwo, \newenv)$\ProseOrAbnormalReturning;
       \item $\newg$ is the ordered composition of $\vgone$ and $\vgtwo$ with the $\aslctrl$ label.
@@ -3064,7 +3064,6 @@ and \\
 $\evalforloop$ (the latter in a mutually recursive manner):
 \begin{mathpar}
 \inferrule[return]{
-  \ticklooplimit(\vlimitopt) \evalarrow \vnextlimitopt \OrDynError\\\\
   \compfordir \eqdef \choice{\dir = \UP}{\LT}{\GT}\\
   \readidentifier(\vindexname, \vstart) \evalarrow \vgone\\\\
   \commonprefixline\\\\
@@ -3081,11 +3080,11 @@ $\evalforloop$ (the latter in a mutually recursive manner):
 
 \begin{mathpar}
 \inferrule[continue]{
-  \ticklooplimit(\vlimitopt) \evalarrow \vnextlimitopt \OrDynError\\\\
   \compfordir \eqdef \choice{\dir = \UP}{\LT}{\GT}\\
   \readidentifier(\vindexname, \vstart) \evalarrow \vgone\\\\
   \commonprefixline\\\\
   \binoprel(\compfordir, \vend, \vstart) \evalarrow \nvint(\False)\\
+  \ticklooplimit(\vlimitopt) \evalarrow \vnextlimitopt \OrDynError\\\\
   \evalforloop(\env, \vindexname, \vnextlimitopt, \vstart, \dir, \vend, \vbody) \evalarrow \\
   \Continuing(\vgtwo, \newenv) \OrAbnormalReturning\\\\
   \newg \eqdef \ordered{\vgone}{\aslctrl}{\vgtwo}

--- a/asllib/tests/loop-limits.t/run.t
+++ b/asllib/tests/loop-limits.t/run.t
@@ -114,11 +114,6 @@ For loops
   ASL Dynamic error: loop limit reached.
   [1]
   $ aslref for-exact.asl
-  File for-exact.asl, line 5, characters 4 to 26:
-      counter = counter + 1;
-      ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Dynamic error: loop limit reached.
-  [1]
   $ aslref for-exact-minus-one.asl
   $ aslref for-no-limit.asl
 

--- a/asllib/tests/loop-limits.t/run.t
+++ b/asllib/tests/loop-limits.t/run.t
@@ -116,6 +116,13 @@ For loops
   $ aslref for-exact.asl
   $ aslref for-exact-minus-one.asl
   $ aslref for-no-limit.asl
+  $ aslref while-for-repeat-comparison.asl
+  while loop:
+  1
+  repeat loop:
+  1
+  for loop:
+  1
 
 Recursion limits:
 =================

--- a/asllib/tests/loop-limits.t/while-for-repeat-comparison.asl
+++ b/asllib/tests/loop-limits.t/while-for-repeat-comparison.asl
@@ -1,0 +1,38 @@
+func run_while(n: integer)
+begin
+  var i : integer = 1;
+  while i <= n looplimit 1 do
+    println i;
+    i = i + 1;
+  end;
+end;
+
+func run_repeat(n: integer)
+begin
+  var i : integer = 1;
+  repeat
+    println i;
+    i = i + 1;
+  until !(i <= n) looplimit 1;
+end;
+
+func run_for(n: integer)
+begin
+  for i = 1 to n looplimit 1 do
+    println i;
+  end;
+end;
+
+func main() => integer
+begin
+  println "while loop:";
+  run_while(1);
+
+  println "repeat loop:";
+  run_repeat(1);
+
+  println "for loop:";
+  run_for(1);
+
+  return 0;
+end;


### PR DESCRIPTION
For-loops hit their limit one iteration too early - the following example produced a loop limit error.
```
for i = 1 to 1 looplimit 1 do
  println i;
end;
```
This PR moves the check + decrement of loop limits - rather than executing unconditionally, it executes only if another loop iteration is to follow.

Thanks to Skye Aubrey for the bug report!