### PR TITLE
[litmus] Fix array index anomalies in litmus

### DIFF
--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -119,6 +119,10 @@ let pp_index base o = match o with
 | 0 -> base
 | i -> sprintf "%s+%i" base i
 
+let pp_index_init base o = match o with
+| 0 -> base
+| i -> sprintf "%s[%i]" base i
+
 let pp_tagaddr t s o =
   let s =
     match t with
@@ -143,6 +147,9 @@ let pp_symbol = function
   | System (PTE,s) -> sprintf "PTE(%s)" s
   | System (PTE2,s) -> sprintf "PTE(PTE(%s))" s
 
+let pp_symbol_init = function
+  | Virtual s -> pp_index_init (pp_symbolic_data s) s.offset
+  | sym -> pp_symbol sym
 
 let compare_id_offset s1 o1 s2 o2 =
   match String.compare s1 s2 with
@@ -340,9 +347,14 @@ let collision s1 s2 = match s1,s2 with
 let pp pp_scalar pp_pteval pp_addrreg pp_instr =
   let pp_label = sprintf "label:\"P%i:%s\"" in
   mk_pp pp_symbol pp_scalar pp_label pp_pteval pp_addrreg pp_instr
+
 and pp_old pp_scalar pp_pteval pp_addrreg pp_instr =
   let pp_label = sprintf "%i:%s" in
   mk_pp pp_symbol_old pp_scalar pp_label pp_pteval pp_addrreg pp_instr
+
+let check_pp_init dump = function
+  | Symbolic sym -> pp_symbol_init sym
+  | c -> dump c
 
 let _debug = function
   | Concrete _ -> "Concrete _"

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -66,6 +66,7 @@ type symbol =
 val get_index : symbol -> int option
 val pp_symbol_old : symbol -> string
 val pp_symbol : symbol -> string
+
 val compare_symbol : symbol -> symbol -> int
 val symbol_eq : symbol -> symbol -> bool
 val as_address : symbol -> string
@@ -120,10 +121,16 @@ val collision :
 val pp :
   ('scalar -> string) -> ('pte -> string) -> ('addrreg -> string) -> ('instr -> string) ->
     ('scalar,'pte, 'addrreg,'instr) t  -> string
+
 (* Old style: pte_s, phy_s, etc. *)
 val pp_old :
   ('scalar -> string) ->  ('pte -> string) -> ('addrreg -> string) -> ('instr -> string) ->
     ('scalar,'pte, 'addrreg,'instr) t  -> string
+
+(* Print symbol t+o as t[o], for init section *)
+val check_pp_init :
+  (('scalar,'pte, 'addrreg,'instr) t  -> string)
+  -> ('scalar,'pte, 'addrreg,'instr) t -> string
 
 (* Do nothing on non-scalar *)
 val map_scalar : ('a -> 'b) -> ('a,'pte, 'addrreg,'instr) t -> ('b,'pte, 'addrreg,'instr) t

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -778,7 +778,7 @@ module A.FaultType = A.FaultType)
             match t,v with
             | (TestType.TyDef|TestType.TyDefPointer),
               Constant.Symbolic s ->
-                let a = G.tr_symbol s in
+                let a = G.get_base_symbol s in
                 begin try
                   let _ = G.Map.find a env in
                   env

--- a/litmus/dumpRun.ml
+++ b/litmus/dumpRun.ml
@@ -231,6 +231,7 @@ let run_tests names out_chan =
               some_self = self || some_self; }
         | Absent -> st
         | Interrupted e ->
+            if Cfg.nocatch then raise e ;
             let msg =  match e with
             | Misc.Exit -> "None"
             | Misc.Fatal msg
@@ -238,7 +239,6 @@ let run_tests names out_chan =
                 eprintf "%a %s\n%!" Pos.pp_pos0 name msg ;
                 msg
             | e ->
-                if Cfg.nocatch then raise e ;
                 let msg = sprintf "exception %s"  (Printexc.to_string e) in
                 eprintf "%a %s\n%!" Pos.pp_pos0 name msg ;
                 msg in

--- a/litmus/global_litmus.ml
+++ b/litmus/global_litmus.ml
@@ -51,6 +51,14 @@ let tr_symbol =
     | System (PTE,s) -> Pte s
     | c ->  Warn.fatal "litmus cannot handle symbol '%s'" (pp_symbol c)
 
+let get_base_symbol =
+ let open Constant in
+  function
+    | Virtual {name=s; tag=None; cap=0L; _ } -> Addr s
+    | Physical (s,_) -> Phy s
+    | System (PTE,s) -> Pte s
+    | c ->  Warn.fatal "litmus cannot get base of symbol '%s'" (pp_symbol c)
+
 type u = t
 
 module Ordered = struct

--- a/litmus/global_litmus.mli
+++ b/litmus/global_litmus.mli
@@ -23,6 +23,7 @@ val pp : t -> string
 val compare : t -> t -> int
 val as_addr : t -> string (* assert false if not an addr *)
 val tr_symbol : Constant.symbol -> t
+val get_base_symbol : Constant.symbol -> t
 
 module Set : MySet.S with type elt = t
 module Map : MyMap.S with type key = t

--- a/litmus/litmus.ml
+++ b/litmus/litmus.ml
@@ -320,7 +320,7 @@ let () =
       let platform = "_linux"
       let affinity = match !mode with
       | Mode.Std|Mode.PreSi -> !affinity
-      | Mode.Kvm -> Affinity.No (* No effinity ever in kvm mode *)
+      | Mode.Kvm -> Affinity.No (* No affinity ever in kvm mode *)
       let logicalprocs = !logicalprocs
       let linkopt = !linkopt
       let barrier = !barrier
@@ -336,7 +336,12 @@ let () =
              | _,_ -> Alloc.Dynamic
            end
       let doublealloc = !doublealloc
-      let memory = !memory
+      let memory =
+        match !mode with
+        | Mode.Std -> !memory
+        | Mode.(Kvm|PreSi) ->
+            (* Indirect memory does not apply here *)
+            Memory.Direct
       let preload = !preload
       let safer = !safer
       let cautious = !cautious

--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -56,9 +56,18 @@ module Make(O:Config)(V:Constant.S) = struct
   | Direct -> sprintf "&_a->%s[_i]" a
   | Indirect -> sprintf "_a->%s[_i]" a
 
+  let full_dump_addr a o =
+    match o with
+    | 0 ->  dump_addr a
+    | _ ->
+        match O.memory with
+        | Direct -> sprintf "&(_a->%s[_i][%d])" a o
+        | Indirect -> sprintf "&(*(_a->%s[_i]))[%d]"  a o
+
   let dump_v_std v = match v with
   | Concrete _ -> V.pp O.hexa v
-  | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=0; _}) -> dump_addr a
+  | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=o; _})
+    -> full_dump_addr a o
   | ConcreteVector _ -> V.pp O.hexa v
   | Instruction _ -> Misc.lowercase (V.pp false v)
   | ConcreteRecord _

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -339,7 +339,11 @@ module Make
         ConstrGen.match_rloc
           (dump_ctx_loc pref)
           (fun loc i ->
-            sprintf "%s[%d]" (dump_ctx_loc pref loc) i)
+             let pp =
+               match memory with
+               | Direct -> sprintf "%s[%d]"
+               | Indirect -> sprintf "(%s)[%d]" in
+             pp (dump_ctx_loc pref loc) i)
 
       let dump_loc = dump_ctx_loc ""
 

--- a/litmus/test_litmus.ml
+++ b/litmus/test_litmus.ml
@@ -155,7 +155,8 @@ struct
                   MiscParser.dump_state_atom_no_init
                 else
                   MiscParser.dump_state_atom in
-              do_dump A.is_global A.pp_location dump_v
+              do_dump A.is_global A.pp_location
+                (Constant.check_pp_init dump_v)
 
             type state = A.fullstate
 

--- a/tools/dumperMiscParser.ml
+++ b/tools/dumperMiscParser.ml
@@ -31,7 +31,12 @@ module Make(Opt:Opt)(A:ArchBase.S) : CoreDumper.S
         module A = A
 
         type v = MiscParser.maybev
-        let dump_v = ParsedConstant.pp Opt.hexa
+
+        let dump_v =
+          if Opt.compat then
+            ParsedConstant.pp Opt.hexa
+          else
+            Constant.check_pp_init (ParsedConstant.pp Opt.hexa)
 
         let dump_loc = MiscParser.dump_location
 


### PR DESCRIPTION
This PR is inspired  PR #1371.  PR #1371 fixes array index problems with **herd7**, this PR will fix similar problems with **litmus7**.

The typical test is now compiled correctly in all litmus modes:
```
AArch64 T
{
  int x[2];
  0:X0=x[1]; (* Expect offset to 2nd element of x *)
}
P0;
MOV W1,#1  ;
STR W1,[X0];

forall x[1]=1
```