### PR TITLE
[asl] Some superficial fixes

### DIFF
--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -261,7 +261,7 @@ module NativeBackend (C : Config) = struct
       | [ v ] -> mismatch_type v [ integer' ]
       | li ->
           Error.fatal_unknown_pos
-          @@ Error.BadArity (Dynamic, "DecStr", 1, List.length li)
+          @@ Error.BadArity (Dynamic, "HexStr", 1, List.length li)
 
     let ascii_integer = integer_range' !$0 !$127
 
@@ -275,12 +275,12 @@ module NativeBackend (C : Config) = struct
           else
             Error.fatal_unknown_pos
             @@ Error.BadPrimitiveArgument
-                 ( "DecStr",
+                 ( "AsciiStr",
                    "greater than or equal to 0 and less than or equal to 127" )
       | [ v ] -> mismatch_type v [ ascii_integer ]
       | li ->
           Error.fatal_unknown_pos
-          @@ Error.BadArity (Dynamic, "DecStr", 1, List.length li)
+          @@ Error.BadArity (Dynamic, "AsciiStr", 1, List.length li)
 
     let floor_log2 = function
       | [ NV_Literal (L_Int i) ] ->

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -265,11 +265,9 @@ module NativeBackend (C : Config) = struct
 
     let ascii_integer = integer_range' !$0 !$127
 
-    let ascii_str =
-      let open! Z in
-      function
+    let ascii_str = function
       | [ NV_Literal (L_Int i) ] ->
-          if geq zero i && leq ~$127 i then
+          if Z.(zero <= i && i <= of_int 127) then
             L_String (char_of_int (Z.to_int i) |> String.make 1)
             |> nv_literal |> return_one
           else

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -2410,7 +2410,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     let here = add_pos_from ~loc in
     let lit v = here (E_Literal v) in
     let fatal_non_static e =
-      fatal_from ~loc (Error.BaseValueNonStatic (t, e))
+      fatal_from ~loc (Error.BaseValueNonSymbolic (t, e))
     in
     let fatal_is_empty () = fatal_from ~loc (Error.BaseValueEmptyType t) in
     let reduce_to_z e =

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -786,7 +786,12 @@ is not a constrained expression.
 \begin{mathpar}
 \inferrule{
   \withemptylocal(\genv) \typearrow \tenv\\
-  \annotatelimitexpr(\tenvone, \funcsig.\funcrecurselimit) \typearrow (\vrecurselimit, \vsesrecurselimit) \OrTypeError\\\\
+  {
+    \begin{array}{r}
+    \annotatelimitexpr(\tenvone, \funcsig.\funcrecurselimit) \typearrow \\
+    (\vrecurselimit, \vsesrecurselimit) \OrTypeError
+    \end{array}
+  }\\\\
   {
     \begin{array}{r}
     \annotateparams(\tenv, \funcsig.\funcparameters, (\tenv, \emptylist)) \typearrow \\
@@ -796,13 +801,23 @@ is not a constrained expression.
   \checkparamdecls(\tenv, \funcsig) \typearrow \True \OrTypeError \\
   {
     \begin{array}{r}
-    \annotateargs(\tenvwithparams, \funcsig.\funcargs, (\tenvwithparams, \emptylist), \vseswithparams) \typearrow \\
+    \annotateargs\left(
+      \begin{array}{l}
+        \tenvwithparams, \funcsig.\funcargs,\\
+        (\tenvwithparams, \emptylist), \vseswithparams
+      \end{array}
+      \right) \typearrow \\
     (\tenvwithargs, \vseswithargs, \vargs) \OrTypeError
       \end{array}
   }\\\\
   {
     \begin{array}{r}
-  \annotatereturntype(\tenvwithargs, \tenvwithparams, \funcsig.\funcreturntype, \vseswithargs) \typearrow \\
+    \annotatereturntype\left(
+      \begin{array}{l}
+        \tenvwithargs, \tenvwithparams, \\
+        \funcsig.\funcreturntype, \vseswithargs
+      \end{array}
+      \right) \typearrow \\
     (\newtenv, \vreturntype, \vseswithreturn) \OrTypeError
     \end{array}
   }\\\\

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -353,11 +353,12 @@ module PPrint = struct
           (pp_comma_list pp_type_desc)
           li
     | BadField (s, ty) ->
-        fprintf f "ASL Error: There is no field '%s'@ on type %a." s pp_ty ty
+        fprintf f "ASL Typing Error: There is no field '%s'@ on type %a." s
+          pp_ty ty
     | MissingField (fields, ty) ->
         fprintf f
-          "ASL Error: Fields mismatch for creating a value of type %a@ -- \
-           Passed fields are:@ %a"
+          "ASL Typing Error: Fields mismatch for creating a value of type %a@ \
+           -- Passed fields are:@ %a"
           pp_ty ty
           (pp_print_list ~pp_sep:pp_print_space pp_print_string)
           fields
@@ -416,8 +417,8 @@ module PPrint = struct
           expected
     | AssertionFailed e ->
         fprintf f "ASL Execution error: Assertion failed:@ %a." pp_expr e
-    | CannotParse -> pp_print_string f "ASL Error: Cannot parse."
-    | UnknownSymbol -> pp_print_string f "ASL Error: Unknown symbol."
+    | CannotParse -> pp_print_string f "ASL Grammar Error: Cannot parse."
+    | UnknownSymbol -> pp_print_string f "ASL Grammar Error: Unknown symbol."
     | NoCallCandidate (name, types) ->
         fprintf f
           "ASL Type error: No subprogram declaration matches the invocation:@ \
@@ -594,7 +595,7 @@ module PPrint = struct
            length@a: %i."
           pp_expr e_length length
     | MultipleWrites id ->
-        fprintf f "ASL Type error:@ multiple@ writes@ to@ %S." id
+        fprintf f "ASL Grammar error:@ multiple@ writes@ to@ %S." id
     | MultipleImplementations (impl1, impl2) ->
         fprintf f
           "ASL Type error:@ multiple@ overlapping@ `implementation`@ \

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -75,7 +75,7 @@ type error_desc =
       (** name, expected, actual *)
   | BaseValueEmptyType of ty
   | ArbitraryEmptyType of ty
-  | BaseValueNonStatic of ty * expr
+  | BaseValueNonSymbolic of ty * expr
   | SettingIntersectingSlices of bitfield list
   | SetterWithoutCorrespondingGetter of func
   | NonReturningFunction of identifier
@@ -195,7 +195,7 @@ let error_label = function
   | BadParameterDecl _ -> "BadParameterDecl"
   | BaseValueEmptyType _ -> "BaseValueEmptyType"
   | ArbitraryEmptyType _ -> "ArbitraryEmptyType"
-  | BaseValueNonStatic _ -> "BaseValueNonStatic"
+  | BaseValueNonSymbolic _ -> "BaseValueNonSymbolic"
   | SettingIntersectingSlices _ -> "SettingIntersectingSlices"
   | SetterWithoutCorrespondingGetter _ -> "SetterWithoutCorrespondingGetter"
   | NonReturningFunction _ -> "NonReturningFunction"
@@ -494,10 +494,10 @@ module PPrint = struct
         fprintf f "ASL Execution error: ARBITRARY of empty type %a." pp_ty t
     | BaseValueEmptyType t ->
         fprintf f "ASL Type error: base value of empty type %a." pp_ty t
-    | BaseValueNonStatic (t, e) ->
+    | BaseValueNonSymbolic (t, e) ->
         fprintf f
-          "ASL Type error:@ base@ value@ of@ type@ %a@ cannot@ be@ statically@ \
-           determined@ since@ it@ consists@ of@ %a."
+          "ASL Type error:@ base@ value@ of@ type@ %a@ cannot@ be@ \
+           symbolically@ reduced@ since@ it@ consists@ of@ %a."
           pp_ty t pp_expr e
     | BadATC (t1, t2) ->
         fprintf f

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -612,9 +612,8 @@ module PPrint = struct
            `implementation`:@ %a"
           (pp_print_list pp_pos) impdefs
     | BadPrimitiveArgument (name, reason) ->
-        pp_print_text f
-          ("ASL Execution error: " ^ name ^ " (primitive) expected an argument "
-         ^ reason));
+        fprintf f "ASL Execution error: %s (primitive) expected an argument %s"
+          name reason);
     pp_close_box f ()
 
   let pp_warning_desc f w =

--- a/asllib/libdir/stdlib.asl
+++ b/asllib/libdir/stdlib.asl
@@ -363,11 +363,6 @@ end;
 //------------------------------------------------------------------------------
 // Standard bitvector functions and procedures
 
-// For most of these functions, some implicitly dependently typed version
-// exists in the specification. We do not yet support those.
-
-// Externals
-
 pure func ReplicateBit{N}(isZero: boolean) => bits(N)
 begin
   return if isZero then Zeros{N} else Ones{N};

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -93,13 +93,13 @@ Examples used in ASL High-level Definition:
   File GuideRule.TupleElementAccess.bad.asl, line 5, characters 18 to 25:
       x = (x.item1, x.item2);
                     ^^^^^^^
-  ASL Error: There is no field 'item2' on type (integer, integer).
+  ASL Typing Error: There is no field 'item2' on type (integer, integer).
   [1]
   $ aslref GuideRule.AnonymousEnumerations.bad.asl
   File GuideRule.AnonymousEnumerations.bad.asl, line 4, characters 12 to 23:
       var x : enumeration {RED, GREEN, BLUE};
               ^^^^^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref GuideRule.TupleImmutability.asl
   File GuideRule.TupleImmutability.asl, line 7, characters 6 to 11:
@@ -120,7 +120,7 @@ Examples used in ASL High-level Definition:
   File ParameterOmission.bad.asl, line 6, characters 17 to 18:
       result = LSL{}(result, 3);
                    ^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref --no-exec NamedTypes.asl
   $ aslref --no-exec NamedTypes2.asl

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -141,7 +141,7 @@ ASL Semantics Tests:
   File SemanticsRule.CatchNone.asl, line 15, characters 8 to 24:
     catch MyExceptionType1;
           ^^^^^^^^^^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref SemanticsRule.FUndefIdent.asl
   File SemanticsRule.FUndefIdent.asl, line 4, characters 5 to 12:

--- a/asllib/tests/ASLSyntaxReference.t/run.t
+++ b/asllib/tests/ASLSyntaxReference.t/run.t
@@ -13,7 +13,7 @@ Examples used to test syntax and AST building rules:
   File GuideRule.IdentifiersKeywords.bad.asl, line 3, characters 8 to 12:
       var case = 5;
           ^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref ConventionRule.IdentifiersDifferingByCase.asl
   $ aslref --no-exec ConventionRule.IdentifierSingleUnderscore.asl
@@ -39,35 +39,35 @@ Examples used to test syntax and AST building rules:
   File ASTRule.EBinop.bad1.asl, line 6, characters 20 to 25:
           let p_a_s = a + b - c;
                       ^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref ASTRule.EBinop.bad2.asl
   File ASTRule.EBinop.bad2.asl, line 6, characters 20 to 25:
           let p_s_a = a - b + c;
                       ^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref ASTRule.EBinop.bad3.asl
   File ASTRule.EBinop.bad3.asl, line 6, characters 23 to 30:
           let p_and_or = d AND e OR f;
                          ^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref ASTRule.EBinop.bad4.asl
   File ASTRule.EBinop.bad4.asl, line 6, characters 22 to 28:
           let p_eq_eq = a == b != g;
                         ^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref ASTRule.EBinop.bad5.asl
   File ASTRule.EBinop.bad5.asl, line 6, characters 24 to 29:
           let p_sub_sub = a - b - c;
                           ^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref CaseStatement.bad.asl
   File CaseStatement.bad.asl, line 7, characters 8 to 12:
           when '11' => X[30] = 0;
           ^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -222,7 +222,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.TNonDecl.asl, line 1, characters 5 to 6:
   func (x: record { a: integer, b: boolean }) => integer
        ^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref TypingRule.TBitField.asl
   $ aslref --no-exec TypingRule.AnnotateFuncSig.asl
@@ -393,20 +393,20 @@ ASL Typing Tests / annotating types:
   File TypingRule.EGetBadRecordField.asl, line 7, characters 10 to 36:
     var x = my_record.undeclared_field;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Error: There is no field 'undeclared_field' on type MyRecordType.
+  ASL Typing Error: There is no field 'undeclared_field' on type MyRecordType.
   [1]
   $ aslref TypingRule.EGetBitfield.asl
   $ aslref TypingRule.EGetBadBitField.asl
   File TypingRule.EGetBadBitField.asl, line 7, characters 12 to 33:
       var x = p.undeclared_bitfield;
               ^^^^^^^^^^^^^^^^^^^^^
-  ASL Error: There is no field 'undeclared_bitfield' on type Packet.
+  ASL Typing Error: There is no field 'undeclared_bitfield' on type Packet.
   [1]
   $ aslref TypingRule.EGetBadField.asl
   File TypingRule.EGetBadField.asl, line 6, characters 12 to 15:
       var x = a.f;
               ^^^
-  ASL Error: There is no field 'f' on type array [[5]] of integer.
+  ASL Typing Error: There is no field 'f' on type array [[5]] of integer.
   [1]
   $ aslref TypingRule.EGetFields.asl
   $ aslref --no-exec TypingRule.ATC.asl
@@ -487,7 +487,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.SDecl.bad2.asl, line 4, characters 18 to 19:
       let y: integer;
                     ^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref TypingRule.SAssert.bad.asl
   File TypingRule.SAssert.bad.asl, line 11, characters 10 to 23:
@@ -656,7 +656,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.CheckIsNotCollection.asl, line 3, characters 12 to 22:
     var test: collection {
               ^^^^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref TypingRule.LESetCollectionFields.asl
   $ aslref TypingRule.TypecheckDecl.asl
@@ -742,7 +742,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.DeclareGlobalStorage.bad3.asl, line 2, characters 37 to 38:
   config uninitialized_config : integer;
                                        ^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.non_config.asl
   $ aslref --no-exec TypingRule.UpdateGlobalStorage.constant.asl
@@ -871,7 +871,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateReturnType.bad.asl, line 3, characters 24 to 34:
   func returns_value() => collection { foo: bits(32)};
                           ^^^^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref --no-exec TypingRule.AnnotateOneParam.asl
   $ aslref TypingRule.AnnotateOneParam.bad1.asl
@@ -896,7 +896,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateOneArg.bad2.asl, line 2, characters 18 to 28:
   func arguments(b: collection {a: bits(7)})
                     ^^^^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref TypingRule.AnnotateRetTy.asl
   $ aslref TypingRule.AnnotateRetTy.bad.asl

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -38,8 +38,8 @@ ASL Typing Tests:
   File TypingRule.TypeSatisfaction.bad1.asl, line 3, characters 4 to 25:
       var a: integer{0..N};
       ^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: base value of type integer {0..N} cannot be statically
-    determined since it consists of N.
+  ASL Type error: base value of type integer {0..N} cannot be symbolically
+    reduced since it consists of N.
   [1]
   $ aslref --no-exec TypingRule.TypeClashes.asl
   $ aslref --no-exec TypingRule.TypeClashes.bad.asl

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -7,7 +7,7 @@ Bad enumeration
   File bad-types1.asl, line 1, characters 23 to 24:
   type t of enumeration {};
                          ^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
 
 Invalid bitfields

--- a/asllib/tests/collections.t/run.t
+++ b/asllib/tests/collections.t/run.t
@@ -2,13 +2,13 @@
   File on-arbitrary.asl, line 3, characters 23 to 33:
     var col = ARBITRARY: collection {
                          ^^^^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref on-local-func-arg.asl
   File on-local-func-arg.asl, line 6, characters 15 to 25:
   func foo (col: collection {
                  ^^^^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref on-local-var.asl
   File on-local-var.asl, line 8, characters 2 to 25:
@@ -31,7 +31,7 @@
   File on-function-return-type.asl, line 6, characters 15 to 25:
   func foo () => collection {
                  ^^^^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
 
   $ aslref on-local-tuple.asl
@@ -52,5 +52,5 @@
   File on-type-declaration.asl, line 1, characters 21 to 31:
   type MyCollection of collection {
                        ^^^^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -37,7 +37,7 @@
   File println5.asl, line 1, characters 32 to 33:
   constant msg = "Something with \p bad characters.";
                                   ^
-  ASL Error: Unknown symbol.
+  ASL Grammar Error: Unknown symbol.
   [1]
   $ cat >println6.asl <<EOF
   > constant msg = "Some unterminated string;
@@ -134,7 +134,7 @@ Forbidden patterns
   File forbiddenhex01.asl, line 1, characters 8 to 11:
   let x = 0xh12;
           ^^^
-  ASL Error: Unknown symbol.
+  ASL Grammar Error: Unknown symbol.
   [1]
 
   $ cat >forbiddenhex02.asl <<EOF
@@ -144,7 +144,7 @@ Forbidden patterns
   File forbiddenhex02.asl, line 1, characters 8 to 11:
   let x = 0x_12;
           ^^^
-  ASL Error: Unknown symbol.
+  ASL Grammar Error: Unknown symbol.
   [1]
 
   $ cat >forbiddenhex03.asl <<EOF
@@ -154,7 +154,7 @@ Forbidden patterns
   File forbiddenhex03.asl, line 1, characters 8 to 13:
   let x = 0x12h12;
           ^^^^^
-  ASL Error: Unknown symbol.
+  ASL Grammar Error: Unknown symbol.
   [1]
 
   $ cat >forbiddenhex04.asl <<EOF
@@ -165,7 +165,7 @@ Forbidden patterns
   File forbiddenhex04.asl, line 2, characters 8 to 11:
   let x = 0x_foo;
           ^^^
-  ASL Error: Unknown symbol.
+  ASL Grammar Error: Unknown symbol.
   [1]
 
   $ cat >forbiddenreal01.asl <<EOF
@@ -175,7 +175,7 @@ Forbidden patterns
   File forbiddenreal01.asl, line 1, characters 8 to 11:
   let x = 1.h12;
           ^^^
-  ASL Error: Unknown symbol.
+  ASL Grammar Error: Unknown symbol.
   [1]
 
   $ cat >forbiddenreal02.asl <<EOF
@@ -185,7 +185,7 @@ Forbidden patterns
   File forbiddenreal02.asl, line 1, characters 8 to 11:
   let x = 1._12;
           ^^^
-  ASL Error: Unknown symbol.
+  ASL Grammar Error: Unknown symbol.
   [1]
 
   $ cat >forbiddenreal03.asl <<EOF
@@ -195,7 +195,7 @@ Forbidden patterns
   File forbiddenreal03.asl, line 1, characters 8 to 13:
   let x = 1.12h12;
           ^^^^^
-  ASL Error: Unknown symbol.
+  ASL Grammar Error: Unknown symbol.
   [1]
 
   $ cat >forbiddenreal04.asl <<EOF
@@ -206,5 +206,5 @@ Forbidden patterns
   File forbiddenreal04.asl, line 2, characters 8 to 11:
   let x = 1._foo;
           ^^^
-  ASL Error: Unknown symbol.
+  ASL Grammar Error: Unknown symbol.
   [1]

--- a/asllib/tests/regressions.t/asciistr.asl
+++ b/asllib/tests/regressions.t/asciistr.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+  for i = 0 to 127 do
+    - = AsciiStr(i);
+  end;
+  return 0;
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -285,14 +285,14 @@ Parameterized integers:
   File setter_without_getter.asl, line 6, characters 0 to 3:
   end;
   ^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
 
   $ aslref getter_without_setter.asl
   File getter_without_setter.asl, line 6, characters 0 to 3:
   end;
   ^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
 
   $ aslref tuple_items.asl
@@ -301,7 +301,7 @@ Parameterized integers:
   File duplicated-otherwise.asl, line 7, characters 8 to 12:
           when 0.0 => println "2.0";
           ^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref duplicate_expr_record.asl
   File duplicate_expr_record.asl, line 5, characters 12 to 27:
@@ -314,21 +314,21 @@ Parameterized integers:
   File same-precedence.asl, line 6, characters 10 to 15:
     let x = a + b - c;
             ^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
 
   $ aslref same-precedence2.asl
   File same-precedence2.asl, line 6, characters 10 to 17:
     let d = a ==> b <=> c;
             ^^^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
 
   $ aslref binop-non-assoc.asl
   File binop-non-assoc.asl, line 3, characters 6 to 11:
     - = 3 - 2 - 1;
         ^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
 
   $ aslref rdiv_checks.asl
@@ -416,7 +416,7 @@ Required tests:
   File asl0-patterns.asl, line 7, characters 25 to 29:
       if x[0+:4] IN '10x1' then // invalid
                            ^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref -0 unreachable-v0.asl
   $ aslref assign1.asl
@@ -428,7 +428,7 @@ Required tests:
   File concat-empty.asl, line 3, characters 45 to 46:
     let empty_concatenation_should_not_parse = [];
                                                ^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
   $ aslref concat01.asl
   $ aslref concat02.asl
@@ -541,7 +541,7 @@ Getters/setters
   File pattern-masks-no-braces.asl, line 4, characters 19 to 24:
     assert ('111' IN '1xx') == TRUE;
                      ^^^^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
 
 ASLRef Field getter extension
@@ -584,7 +584,7 @@ Left-hand sides
   File lhs-tuple-fields-same-field.asl, line 8, characters 2 to 4:
     bv.(fld, -, fld) = ('11', TRUE, '11');
     ^^
-  ASL Type error: multiple writes to "bv.fld".
+  ASL Grammar error: multiple writes to "bv.fld".
   [1]
   $ aslref lhs-tuple-same-var.asl
   $ aslref lhs-expressivity.asl
@@ -628,5 +628,5 @@ Outdated syntax
   File noreturn_function.asl, line 2, characters 26 to 28:
   noreturn func returning() => integer
                             ^^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -469,6 +469,7 @@ Required tests:
   $ aslref subprogram-local-name-clash.asl
   $ aslref string_concat.asl
   $ aslref approx-expr-binop.asl
+  $ aslref asciistr.asl
 
   $ aslref --no-type-check throw-local-env.asl
   File throw-local-env.asl, line 10, characters 13 to 14:

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -496,16 +496,16 @@ Base values
   File base_values.asl, line 5, characters 2 to 28:
     var x: integer {N..M, 42};
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: base value of type integer {42, N..M} cannot be statically
-    determined since it consists of N.
+  ASL Type error: base value of type integer {42, N..M} cannot be symbolically
+    reduced since it consists of N.
   [1]
 
   $ aslref base_values_empty.asl
   File base_values_empty.asl, line 3, characters 2 to 24:
     var x: integer {N..M};
     ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: base value of type integer {N..M} cannot be statically
-    determined since it consists of N.
+  ASL Type error: base value of type integer {N..M} cannot be symbolically
+    reduced since it consists of N.
   [1]
 
   $ aslref base_values_tuple.asl

--- a/asllib/tests/stdlib.t/run.t
+++ b/asllib/tests/stdlib.t/run.t
@@ -47,8 +47,7 @@ Tests using ASLRef OCaml primitives for some stdlib functions
 Checking that --no-primitives option actually removes OCaml primitives
 (different errors are produced)
   $ aslref no-primitives-test.asl
-  ASL Execution error: FloorLog2 (primitive) expected an argument greater than
-    0
+  ASL Execution error: FloorLog2 (primitive) expected an argument greater than 0
   [1]
   $ aslref --no-primitives no-primitives-test.asl
   File ASL Standard Library, line 57, characters 11 to 16:

--- a/asllib/tests/typing.t/run.t
+++ b/asllib/tests/typing.t/run.t
@@ -482,7 +482,7 @@ C Tests
   File CNegative12.asl, line 2, characters 56 to 57:
   func negative12{N}(bv : bits(N), N: integer, bv2 : bits({0..N}))
                                                           ^
-  ASL Error: Cannot parse.
+  ASL Grammar Error: Cannot parse.
   [1]
 
 Extra tests by ASLRef team


### PR DESCRIPTION
- Error messages
  - Increase precision in some messages (e.g. "typing" vs. "grammar" errors)
  - Change error message for non-symbolic base values
  - Correct a previous error message where I had used `pp_print_text` instead of `fprintf`
  - Primitive error messages for `HexStr` and `AsciiStr` were being reported as `DecStr`
- Fix a rule that overflowed into page margins
- Fix `AsciiStr` to make the right check on its input (`0 <= input <= 127`)