### PR TITLE
[ASL-869, asl] Bounds-checking and various minor fixes

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -460,7 +460,7 @@ module Make (B : Backend.S) (C : Config) = struct
         | Global v ->
             let* () = B.on_read_identifier x (B.Scope.global ~init:false) v in
             return_normal (v, env)
-        | NotFound -> fatal_from e @@ Error.UndefinedIdentifier x)
+        | NotFound -> fatal_from e @@ Error.UndefinedIdentifier (Dynamic, x))
         |: SemanticsRule.EVar
     (* End *)
     | E_Binop (((`BAND | `BOR | `IMPL) as op), e1, e2)
@@ -772,7 +772,7 @@ module Make (B : Backend.S) (C : Config) = struct
             match ver with
             (* Begin EvalLEUndefIdentOne *)
             | V1 ->
-                fatal_from le @@ Error.UndefinedIdentifier x
+                fatal_from le @@ Error.UndefinedIdentifier (Dynamic, x)
                 |: SemanticsRule.LEUndefIdentV1
             (* End *)
             (* Begin EvalLEUndefIdentZero *)
@@ -1412,7 +1412,7 @@ module Make (B : Backend.S) (C : Config) = struct
     match IMap.find_opt name genv.static.subprograms with
     (* Begin EvalFUndefIdent *)
     | None ->
-        fatal_from pos @@ Error.UndefinedIdentifier name
+        fatal_from pos @@ Error.UndefinedIdentifier (Dynamic, name)
         |: SemanticsRule.FUndefIdent
     (* End *)
     (* Begin EvalFPrimitive *)
@@ -1519,7 +1519,8 @@ module Make (B : Backend.S) (C : Config) = struct
     in
     (match res with
     | Normal ([ v ], _genv) -> read_value_from v
-    | Normal _ -> Error.(fatal_unknown_pos (MismatchedReturnValue "main"))
+    | Normal _ ->
+        Error.(fatal_unknown_pos (MismatchedReturnValue (Dynamic, "main")))
     | Throwing (v_opt, _genv) ->
         let msg =
           match v_opt with

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -139,14 +139,14 @@ module NativeBackend (C : Config) = struct
     match vec with
     | NV_Vector li ->
         let n = List.length li in
-        if i >= n then bad_index i n else List.nth li i |> return
+        if i < 0 || i >= n then bad_index i n else List.nth li i |> return
     | v -> non_tuple_exception v
 
   let set_index i v vec =
     match vec with
     | NV_Vector li ->
         let n = List.length li in
-        if i >= n then bad_index i n
+        if i < 0 || i >= n then bad_index i n
         else list_update i (Fun.const v) li |> v_tuple
     | v -> non_tuple_exception v
 
@@ -203,7 +203,9 @@ module NativeBackend (C : Config) = struct
     in
     let bv =
       match v with
-      | NV_Literal (L_BitVector bv) when Bitvector.length bv > max_pos -> bv
+      | NV_Literal (L_BitVector bv) ->
+          if max_pos < Bitvector.length bv then bv
+          else bad_index max_pos (Bitvector.length bv)
       | NV_Literal (L_Int i) -> Bitvector.of_z (max_pos + 1) i
       | _ ->
           let ( ~! ) = add_pos_from loc in
@@ -217,6 +219,24 @@ module NativeBackend (C : Config) = struct
     let dst = as_bitvector dst
     and src = as_bitvector src
     and positions = slices_to_positions slices in
+    let () =
+      List.iter
+        (fun x ->
+          if x < 0 then
+            mismatch_type (bitvector_to_value dst) [ default_t_bits ])
+        positions
+    in
+    let () =
+      if List.length positions != Bitvector.length src then
+        mismatch_type
+          (v_of_int (List.length positions))
+          [ integer_exact' (expr_of_int (Bitvector.length src)) ]
+    in
+    let max_pos = List.fold_left int_max 0 positions in
+    let () =
+      if not (max_pos < Bitvector.length dst) then
+        bad_index max_pos (Bitvector.length dst)
+    in
     Bitvector.write_slice dst src positions |> bitvector_to_value
 
   let concat_bitvectors bvs =

--- a/asllib/StaticModel.ml
+++ b/asllib/StaticModel.ml
@@ -180,7 +180,7 @@ let rec make_anonymous (env : StaticEnv.env) (ty : ty) : ty =
   | T_Named x -> (
       match IMap.find_opt x env.global.declared_types with
       | Some (ty', _) -> make_anonymous env ty'
-      | None -> fatal_from ty (Error.UndefinedIdentifier x))
+      | None -> fatal_from ty (Error.UndefinedIdentifier (Static, x)))
   | _ -> ty
 
 let of_lit = function L_Int i -> Polynomial.of_int i | _ -> raise NotSupported
@@ -196,7 +196,8 @@ let rec to_ir env (e : expr) =
         with Not_found | NotSupported -> (
           let t =
             try StaticEnv.type_of env s
-            with Not_found -> Error.fatal_from e (UndefinedIdentifier s)
+            with Not_found ->
+              Error.fatal_from e (UndefinedIdentifier (Static, s))
           in
           let ty1 = make_anonymous env t in
           match ty1.desc with

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -3180,7 +3180,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           |> List.split
         in
         let ses = ses_non_conflicting_unions ~loc sess in
-        let ses = SES.add_print ses in
+        let ses = if not debug then SES.add_print ses else ses in
         (S_Print { args = args'; newline; debug } |> here, env, ses)
         |: TypingRule.SPrint
     (* End *)

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -30,7 +30,10 @@ module TimeFrame = SideEffect.TimeFrame
 
 let ( |: ) = Instrumentation.TypingNoInstr.use_with
 let fatal_from ~loc = Error.fatal_from loc
-let undefined_identifier ~loc x = fatal_from ~loc (Error.UndefinedIdentifier x)
+
+let undefined_identifier ~loc x =
+  fatal_from ~loc (Error.UndefinedIdentifier (Static, x))
+
 let invalid_expr e = fatal_from ~loc:e (Error.InvalidExpr e)
 let add_pos_from ~loc = add_pos_from loc
 
@@ -1638,7 +1641,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         (* Getters are syntactically identical to functions in V1 - so what
            looks like a function call may really be a getter call *)
         || (func_sig.subprogram_type = ST_Getter && call_type = ST_Function))
-      @@ fun () -> fatal_from ~loc (MismatchedReturnValue name)
+      @@ fun () -> fatal_from ~loc (MismatchedReturnValue (Static, name))
     in
     (* Insert omitted parameter for standard library call *)
     let params = insert_stdlib_param ~loc env func_sig ~params ~arg_types in
@@ -1706,7 +1709,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       match (call_type, func_sig.return_type) with
       | (ST_Function | ST_Getter), Some ty -> Some (rename_ty_eqs env eqs ty)
       | (ST_Procedure | ST_Setter), None -> None
-      | _ -> fatal_from ~loc @@ Error.MismatchedReturnValue name
+      | _ -> fatal_from ~loc @@ Error.MismatchedReturnValue (Static, name)
     in
     ( {
         name;
@@ -1732,7 +1735,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     in
     let+ () =
       check_true (callee.subprogram_type = call_type) @@ fun () ->
-      fatal_from ~loc (MismatchedReturnValue name)
+      fatal_from ~loc (MismatchedReturnValue (Static, name))
     in
     let () =
       if false then
@@ -1880,7 +1883,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       | (ST_Function | ST_Getter | ST_EmptyGetter), Some ty ->
           Some (rename_ty_eqs env eqs3 ty)
       | (ST_Setter | ST_EmptySetter | ST_Procedure), None -> None
-      | _ -> fatal_from ~loc @@ Error.MismatchedReturnValue name
+      | _ -> fatal_from ~loc @@ Error.MismatchedReturnValue (Static, name)
     in
     let () = if false then Format.eprintf "Annotated call to %S.@." name1 in
     let params =

--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -181,10 +181,10 @@ let parse_args () =
       ( "--overriding-permissive",
         Arg.Unit (set_override_mode Permissive),
         " Allow both `impdef` and `implementation` functions (default)." );
-      ( "--overriding-no-implementations",
+      ( "--overriding-warn-implementations",
         Arg.Unit (set_override_mode NoImplementations),
         " Warn if any `implementation` functions are defined." );
-      ( "--overriding-all-impdefs-overridden",
+      ( "--overriding-warn-all-impdefs-overridden",
         Arg.Unit (set_override_mode AllImpdefsOverridden),
         " Warn if any `impdef` functions are not overridden by corresponding \
          `implementation`s." );

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1192,6 +1192,7 @@
 \newcommand\readfrombitvector[0]{\hyperlink{def-readfrombitvector}{\textfunc{read\_from\_bitvector}}}
 \newcommand\writetobitvector[0]{\hyperlink{def-writetobitvector}{\textfunc{write\_to\_bitvector}}}
 \newcommand\slicestopositions[0]{\hyperlink{def-slicestopositions}{\textfunc{slices\_to\_positions}}}
+\newcommand\maxposofslice[0]{\hyperlink{def-maxposofslice}{\textfunc{max\_pos\_of\_slice}}}
 \newcommand\getindex[0]{\hyperlink{def-getindex}{\textfunc{get\_index}}}
 \newcommand\setindex[0]{\hyperlink{def-setindex}{\textfunc{set\_index}}}
 \newcommand\getfield[0]{\hyperlink{def-getfield}{\textfunc{get\_field}}}

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -684,14 +684,10 @@ Non-short-circuiting binary operations:
 Array-indexing:
 1
 2
-Slicing:
-132345677
 Record construction:
 12
 Print statements:
 12341234
-For-loop start/end expressions:
-1234
 \end{Verbatim}
 % CONSOLE_END
 

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -440,7 +440,6 @@ bv = 0xfdf0, bv_i = 0xfdf0
     \item applying $\slicestopositions$ to $\slices$ yields the list $\positions$\ProseOrError;
     \item \Proseeqdef{$\maxpos$}{the maximal index in $\positions$};
     \item \Proseeqdef{$\bits$}{$\vi$  given as two's complement little endian form of $\maxpos + 1$ bits};
-    \item checking that $\maxpos$ is less than $n$ yields $\True$\ProseTerminateAs{\BadIndex};
     \item \Proseeqdef{$\newbits$}{the list of bits $\bits[j]$ for every \Proselistrange{$j$}{$\bits$}};
     \item \Proseeqdef{$\vv$}{the native bitvector for the list of bits $\newbits$}.
   \end{itemize}
@@ -493,6 +492,9 @@ See \ExampleRef{Writing to a Bitvector}, following the definition of $\writetobi
   \item $\src$ is a native bitvector consisting of bits $\vs_m \ldots \vs_0$;
   \item $\dst$ is a native bitvector consisting of bits $\vd_n \ldots \vd_0$;
   \item applying $\slicestopositions$ to $\slices$ yields the list of indices $\positions$;
+  \item checking that the length of $\positions$ is equal to the length of $\src$ yields $\True$\ProseTerminateAs{\BadIndex};
+  \item \Proseeqdef{$\maxpos$}{the maximal index in $\positions$};
+  \item checking that $\maxpos$ is less than the length of $\dst$ yields $\True$\ProseTerminateAs{\BadIndex};
   \item view $\positions$ as the list $I_m \ldots I_0$;
   \item define the function $\bitfunc$ as mapping an index $i$ in $0$ to $n$ to
         $\vs_j$, if there exists an index $I_j$ in $\positions$ such that $I_j$ is equal to $i$,
@@ -508,6 +510,9 @@ See \ExampleRef{Writing to a Bitvector}, following the definition of $\writetobi
   \src \eqname \nvbitvector(\vs_m \ldots \vs_0)\\
   \dst \eqname \nvbitvector(\vd_n \ldots \vd_0)\\
   \slicestopositions(\slices) \evalarrow \positions \OrDynError\\\\
+  \checktrans{\listlen{\positions} = m + 1}{\BadIndex} \checktransarrow \OrDynError\\\\
+  \maxpos \eqdef \max(\ \{ \vj\in\listrange(\positions) : \positions[\vj] \}\ )\\\\
+  \checktrans{\maxpos < n + 1}{\BadIndex} \checktransarrow \OrDynError\\\\
   \positions \eqname I_m \ldots I_0 \\
   {\bitfunc = \lambda i \in 0..n.\left\{ \begin{array}{ll}
     \vs_j & \exists j\in 1..m.\ i = I_j\\
@@ -582,13 +587,13 @@ The specification in \listingref{GetIndex} shows examples of accessing indices o
 \begin{itemize}
   \item \AllApplyCase{ok}
   \begin{itemize}
-    \item $\vi$ is less than the number of elements in $\vvec$;
+    \item $\vi$ is greater than or equal to zero and less than the number of elements in $\vvec$;
     \item \Proseeqdef{$\vr$}{the element of $\vvec$ at index $\vi$}.
   \end{itemize}
 
   \item \AllApplyCase{error}
   \begin{itemize}
-    \item $\vi$ is greater or equal to the number of elements in $\vvec$;
+    \item $\vi$ is less than zero or greater than or equal to the number of elements in $\vvec$;
     \item the result is the \dynamicerrorterm{} for an out of bounds index (\BadIndex).
   \end{itemize}
 \end{itemize}
@@ -596,7 +601,7 @@ The specification in \listingref{GetIndex} shows examples of accessing indices o
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[ok]{
-  \vi < \listlen{\vvec}\\
+  0 \leq \vi < \listlen{\vvec}\\
 }{
   \getindex(\vi, \vvec) \evalarrow \overname{\vv[\vi]}{\vr}
 }
@@ -604,7 +609,7 @@ The specification in \listingref{GetIndex} shows examples of accessing indices o
 
 \begin{mathpar}
 \inferrule[error]{
-  \vi \geq \listlen{\vvec}\\
+  \vi < 0 \lor \vi \geq \listlen{\vvec}\\
 }{
   \getindex(\vi, \vvec) \evalarrow \DynamicErrorVal{\BadIndex}
 }
@@ -635,7 +640,7 @@ involves the following premise:
 \begin{itemize}
   \item \AllApplyCase{ok}
   \begin{itemize}
-    \item $\vi$ is less than the number of elements in $\vvec$;
+    \item $\vi$ is greater than or equal to zero and less than the number of elements in $\vvec$;
     \item $\vvec$ is the sequence $\vu_{0..k}$;
     \item $\vres$ is the sequence of values identical to $\vvec$,
           except that at index $\vi$ the value is $\vv$.
@@ -643,7 +648,7 @@ involves the following premise:
 
   \item \AllApplyCase{error}
   \begin{itemize}
-    \item $\vi$ is greater or equal to the number of elements in $\vvec$;
+    \item $\vi$ is less than zero or greater than or equal to the number of elements in $\vvec$;
     \item the result is the \dynamicerrorterm{} for an out of bounds index (\BadIndex).
   \end{itemize}
 \end{itemize}
@@ -651,7 +656,7 @@ involves the following premise:
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[ok]{
-  \vi \leq \listlen{\vvec}\\
+  0 \leq \vi < \listlen{\vvec}\\
   \vvec \eqname \vu_{0..k}\\
   \vres = \vw_{0..k}\\
   \vv = \vw_{\vi} \\
@@ -663,7 +668,7 @@ involves the following premise:
 
 \begin{mathpar}
 \inferrule[error]{
-  \vi > \listlen{\vvec}
+  \vi < 0 \lor \vi \geq \listlen{\vvec}
 }{
   \setindex(\vi, \vv, \vvec) \evalarrow \DynamicErrorVal{\BadIndex}
 }

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -380,6 +380,53 @@ is illegal for a slice.
 }
 \end{mathpar}
 
+\SemanticsRuleDef{MaxPosOfSlice}
+\hypertarget{def-maxposofslice}{}
+The relation
+\[
+  \maxposofslice(\overname{\tint}{\vs}\times\overname{\tint}{\vl}) \;\aslrel\;
+  (\overname{\tint}{\maxpos})
+\]
+returns the maximum position specified by the slices $\slices$,
+assuming that all slices consist only of non-negative integers.
+
+\ExampleDef{Maximum positions of slices}
+The slice \verb|1+:3| has maximum position 3.
+The slice \verb|42+:0| has maximum position 42.
+
+\ProseParagraph
+\OneApplies
+\begin{itemize}
+  \item \AllApplyCase{zero\_width}
+  \begin{itemize}
+    \item $\vl$ is zero;
+    \item \Proseeqdef{$\maxpos$}{$\vs$}.
+  \end{itemize}
+
+  \item \AllApplyCase{non\_zero\_width}
+  \begin{itemize}
+    \item $\vl$ is not zero;
+    \item \Proseeqdef{$\maxpos$}{$\vs + \vl - 1$}.
+  \end{itemize}
+\end{itemize}
+
+\FormallyParagraph
+\begin{mathpar}
+\inferrule[zero\_width]{
+  \vl = 0
+}{
+  \maxposofslice(\vs, \vl) \evalarrow \vs
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[non\_zero\_width]{
+  \vl \neq 0
+}{
+  \maxposofslice(\vs, \vl) \evalarrow \vs + \vl - 1
+}
+\end{mathpar}
+
 \SemanticsRuleDef{ReadFromBitvector}
 \hypertarget{def-readfrombitvector}{}
 The relation
@@ -427,7 +474,7 @@ bv = 0xfdf0, bv_i = 0xfdf0
   \begin{itemize}
     \item $\vv$ is a native bitvector for the list of bits $\bv$;
     \item applying $\slicestopositions$ to $\slices$ yields the list $\positions$\ProseOrError;
-    \item \Proseeqdef{$\maxpos$}{the maximal index in $\positions$};
+    \item \Proseeqdef{$\maxpos$}{the maximal position in $\slices$};
     \item let $\bits$ be the sequence of bits $\bv[n] ... \bv[1]$;
     \item checking that $\maxpos$ is less than $n$ yields $\True$\ProseTerminateAs{\BadIndex};
     \item \Proseeqdef{$\newbits$}{the list of bits $\bits[j]$ for every \Proselistrange{$j$}{$\bits$}};
@@ -438,7 +485,7 @@ bv = 0xfdf0, bv_i = 0xfdf0
   \begin{itemize}
     \item $\vv$ is a native integer for the integer $\vi$;
     \item applying $\slicestopositions$ to $\slices$ yields the list $\positions$\ProseOrError;
-    \item \Proseeqdef{$\maxpos$}{the maximal index in $\positions$};
+    \item \Proseeqdef{$\maxpos$}{the maximal position in $\slices$};
     \item \Proseeqdef{$\bits$}{$\vi$  given as two's complement little endian form of $\maxpos + 1$ bits};
     \item \Proseeqdef{$\newbits$}{the list of bits $\bits[j]$ for every \Proselistrange{$j$}{$\bits$}};
     \item \Proseeqdef{$\vv$}{the native bitvector for the list of bits $\newbits$}.
@@ -449,7 +496,8 @@ bv = 0xfdf0, bv_i = 0xfdf0
 \begin{mathpar}
 \inferrule[bitvector]{
   \slicestopositions(\slices) \evalarrow \positions \OrDynError\\\\
-  \maxpos \eqdef \max(\ \{ \vj\in\listrange(\positions) : \positions[\vj] \}\ )\\\\
+  \vi \in \listrange(\slices): \maxposofslice(\slice[\vi]) \evalarrow \vp_\vi\\\\
+  \maxpos \eqdef \max(\ \{ \vi\in\listrange(\slices) : \vp_\vi \}\ )\\\\
   \commonprefixline\\\\
   \bits \eqname \bv[n] ... \bv[1]\\
   \checktrans{\maxpos < n}{\BadIndex} \checktransarrow \OrDynError\\\\
@@ -464,7 +512,8 @@ bv = 0xfdf0, bv_i = 0xfdf0
 \begin{mathpar}
 \inferrule[integer]{
   \slicestopositions(\slices) \evalarrow \positions \OrDynError\\\\
-  \maxpos \eqdef \max(\ \{ \vj\in\listrange(\positions) : \positions[\vj] \}\ )\\\\
+  \vi \in \listrange(\slices): \maxposofslice(\slice[\vi]) \evalarrow \vp_\vi\\\\
+  \maxpos \eqdef \max(\ \{ \vi\in\listrange(\slices) : \vp_\vi \}\ )\\\\
   \commonprefixline\\\\
   \bits \eqdef \vi\text{ given as two's complement little endian form of }(\maxpos + 1)\text{ bits}\\
   \commonsuffixline\\\\
@@ -493,7 +542,7 @@ See \ExampleRef{Writing to a Bitvector}, following the definition of $\writetobi
   \item $\dst$ is a native bitvector consisting of bits $\vd_n \ldots \vd_0$;
   \item applying $\slicestopositions$ to $\slices$ yields the list of indices $\positions$;
   \item checking that the length of $\positions$ is equal to the length of $\src$ yields $\True$\ProseTerminateAs{\BadIndex};
-  \item \Proseeqdef{$\maxpos$}{the maximal index in $\positions$};
+  \item \Proseeqdef{$\maxpos$}{the maximal position in $\slices$};
   \item checking that $\maxpos$ is less than the length of $\dst$ yields $\True$\ProseTerminateAs{\BadIndex};
   \item view $\positions$ as the list $I_m \ldots I_0$;
   \item define the function $\bitfunc$ as mapping an index $i$ in $0$ to $n$ to
@@ -511,7 +560,8 @@ See \ExampleRef{Writing to a Bitvector}, following the definition of $\writetobi
   \dst \eqname \nvbitvector(\vd_n \ldots \vd_0)\\
   \slicestopositions(\slices) \evalarrow \positions \OrDynError\\\\
   \checktrans{\listlen{\positions} = m + 1}{\BadIndex} \checktransarrow \OrDynError\\\\
-  \maxpos \eqdef \max(\ \{ \vj\in\listrange(\positions) : \positions[\vj] \}\ )\\\\
+  \vi \in \listrange(\slices): \maxposofslice(\slice[\vi]) \evalarrow \vp_\vi\\\\
+  \maxpos \eqdef \max(\ \{ \vi\in\listrange(\slices) : \vp_\vi \}\ )\\\\
   \checktrans{\maxpos < n + 1}{\BadIndex} \checktransarrow \OrDynError\\\\
   \positions \eqname I_m \ldots I_0 \\
   {\bitfunc = \lambda i \in 0..n.\left\{ \begin{array}{ll}

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -2089,16 +2089,10 @@ The specification in \listingref{semantics-swhile} prints the
 following to the console:
 % CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.SWhile.asl
 \begin{Verbatim}[fontsize=\footnotesize, frame=single]
-evaluated limit = 4
-testing 0 <= 3
 i = 0
-testing 1 <= 3
 i = 1
-testing 2 <= 3
 i = 2
-testing 3 <= 3
 i = 3
-testing 4 <= 3
 \end{Verbatim}
 % CONSOLE_END
 

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -34,8 +34,8 @@ type error_desc =
   | BadSlice of slice
   | EmptySlice
   | TypeInferenceNeeded
-  | UndefinedIdentifier of identifier
-  | MismatchedReturnValue of string
+  | UndefinedIdentifier of error_handling_time * identifier
+  | MismatchedReturnValue of error_handling_time * string
   | BadArity of error_handling_time * identifier * int * int
   | BadParameterArity of error_handling_time * version * identifier * int * int
   | UnsupportedBinop of error_handling_time * binop * literal * literal
@@ -122,10 +122,6 @@ let fatal_here pos_start pos_end e =
 
 let fatal_unknown_pos e = fatal (ASTUtils.add_dummy_annotation e)
 let intercept f () = try Ok (f ()) with ASLException e -> Error e
-
-let error_handling_time_to_string = function
-  | Static -> "Static"
-  | Dynamic -> "Dynamic"
 
 type warning_desc =
   | NoRecursionLimit of identifier list
@@ -315,306 +311,276 @@ module PPrint = struct
 
   let pp_type_desc f ty = pp_ty f (ASTUtils.add_dummy_annotation ty)
 
+  let fprintf_err f kind =
+    kdprintf (fun msg -> fprintf f "@[<hov 2>ASL %s error:@ %t@]" kind msg)
+
+  let lexical = "Lexical"
+  let parse = "Grammar"
+  let static = "Static"
+  let typing = "Type"
+  let dynamic = "Dynamic"
+  let internal = "Internal"
+
+  let error_handling_time_to_string = function
+    | Static -> static
+    | Dynamic -> dynamic
+
   let pp_error_desc f e =
-    pp_open_hovbox f 2;
-    (match e.desc with
-    | ReservedIdentifier id ->
-        fprintf f "ASL Lexical error: %S is a reserved keyword." id
+    let pp_err s fmt = fprintf_err f s fmt in
+    match e.desc with
+    | ReservedIdentifier id -> pp_err lexical "%S is a reserved keyword." id
     | UnsupportedBinop (t, op, v1, v2) ->
-        fprintf f
-          "ASL %s error: Illegal application of operator %s for values@ %a@ \
-           and %a."
+        pp_err
           (error_handling_time_to_string t)
+          "Illegal application of operator %s for values@ %a@ and %a."
           (binop_to_string op) pp_literal v1 pp_literal v2
     | UnsupportedUnop (t, op, v) ->
-        fprintf f
-          "ASL %s error: Illegal application of operator %s for value@ %a."
+        pp_err
           (error_handling_time_to_string t)
+          "Illegal application of operator %s for value@ %a."
           (unop_to_string op) pp_literal v
     | UnsupportedExpr (t, e) ->
-        fprintf f "ASL %s Error: Unsupported expression %a."
+        pp_err
           (error_handling_time_to_string t)
-          pp_expr e
+          "Unsupported expression %a." pp_expr e
     | UnsupportedTy (t, ty) ->
-        fprintf f "ASL %s Error: Unsupported type %a."
-          (error_handling_time_to_string t)
-          pp_ty ty
-    | InvalidExpr e -> fprintf f "ASL Error: invalid expression %a." pp_expr e
+        pp_err (error_handling_time_to_string t) "Unsupported type %a." pp_ty ty
+    | InvalidExpr e -> fprintf_err f typing "invalid expression %a." pp_expr e
     | MismatchType (v, [ ty ]) ->
-        fprintf f
-          "ASL Dynamic error: Mismatch type:@ value %s does not belong to type \
-           %a."
-          v pp_type_desc ty
+        pp_err dynamic "Mismatch type:@ value %s does not belong to type %a." v
+          pp_type_desc ty
     | MismatchType (v, li) ->
-        fprintf f
-          "ASL Dynamic error: Mismatch type:@ value %s@ does not subtype any \
-           of those types:@ %a"
-          v
+        pp_err dynamic
+          "Mismatch type:@ value %s@ does not subtype any of those types:@ %a" v
           (pp_comma_list pp_type_desc)
           li
     | BadField (s, ty) ->
-        fprintf f "ASL Typing Error: There is no field '%s'@ on type %a." s
-          pp_ty ty
+        pp_err typing "There is no field '%s'@ on type %a." s pp_ty ty
     | MissingField (fields, ty) ->
-        fprintf f
-          "ASL Typing Error: Fields mismatch for creating a value of type %a@ \
-           -- Passed fields are:@ %a"
+        pp_err typing
+          "Fields mismatch for creating a value of type %a@ -- Passed fields \
+           are:@ %a"
           pp_ty ty
           (pp_print_list ~pp_sep:pp_print_space pp_print_string)
           fields
     | EmptySlice ->
         assert (e.version = V0);
-        pp_print_text f
-          "ASL Static Error: cannot slice with empty slicing operator. This \
-           might also be due to an incorrect getter/setter invocation."
+        pp_err static
+          "cannot slice with empty slicing operator. This might also be due to \
+           an incorrect getter/setter invocation."
     | BadSlices (t, slices, length) ->
-        fprintf f
-          "ASL %s error: Cannot extract from bitvector of length %d slice %a."
+        pp_err
           (error_handling_time_to_string t)
-          length pp_slice_list slices
-    | BadSlice slice ->
-        fprintf f "ASL Static error: invalid slice %a." pp_slice slice
+          "Cannot extract from bitvector of length %d slice %a." length
+          pp_slice_list slices
+    | BadSlice slice -> pp_err static "invalid slice %a." pp_slice slice
     | TypeInferenceNeeded ->
-        pp_print_text f
-          "ASL Internal error: Interpreter blocked. Type inference needed."
-    | UndefinedIdentifier s ->
-        fprintf f "ASL Error: Undefined identifier:@ '%s'" s
-    | MismatchedReturnValue s ->
-        fprintf f "ASL Error: Mismatched use of return value from call to '%s'."
-          s
-    | BadArity (t, name, expected, provided) ->
-        fprintf f
-          "ASL %s Error: Arity error while calling '%s':@ %d arguments \
-           expected and %d provided."
+        pp_err internal "Interpreter blocked. Type inference needed."
+    | UndefinedIdentifier (t, s) ->
+        pp_err (error_handling_time_to_string t) "Undefined identifier:@ '%s'" s
+    | MismatchedReturnValue (t, s) ->
+        pp_err
           (error_handling_time_to_string t)
+          "Mismatched use of return value from call to '%s'." s
+    | BadArity (t, name, expected, provided) ->
+        pp_err
+          (error_handling_time_to_string t)
+          "Arity error while calling '%s':@ %d arguments expected and %d \
+           provided."
           name expected provided
     | BadParameterArity (t, version, name, expected, provided) -> (
         match (t, version) with
         | Static, V0 ->
-            fprintf f
-              "ASL %s Error: Could not infer all parameters while calling \
-               '%s':@ %d parameters expected and %d inferred"
+            pp_err
               (error_handling_time_to_string t)
+              "Could not infer all parameters while calling '%s':@ %d \
+               parameters expected and %d inferred"
               name expected provided
         | _ ->
-            fprintf f
-              "ASL %s Error: Arity error while calling '%s':@ %d parameters \
-               expected and %d provided"
+            pp_err
               (error_handling_time_to_string t)
+              "Arity error while calling '%s':@ %d parameters expected and %d \
+               provided"
               name expected provided)
-    | NotYetImplemented s ->
-        pp_print_text f @@ "ASL Internal error: Not yet implemented: " ^ s
-    | ObsoleteSyntax s ->
-        fprintf f "%a@ %s" pp_print_text "ASL Grammar error: Obsolete syntax:" s
+    | NotYetImplemented s -> pp_err internal "Not yet implemented: %s" s
+    | ObsoleteSyntax s -> pp_err parse "Obsolete syntax: %s" s
     | ConflictingTypes ([ expected ], provided) ->
-        fprintf f
-          "ASL Type error:@ a subtype of@ %a@ was expected,@ provided %a."
+        pp_err typing "a subtype of@ %a@ was expected,@ provided %a."
           pp_type_desc expected pp_ty provided
     | ConflictingTypes (expected, provided) ->
-        fprintf f "ASL Type error:@ %a does@ not@ subtype@ any@ of:@ %a." pp_ty
-          provided
+        pp_err typing "%a does@ not@ subtype@ any@ of:@ %a." pp_ty provided
           (pp_comma_list pp_type_desc)
           expected
-    | AssertionFailed e ->
-        fprintf f "ASL Dynamic error: Assertion failed:@ %a." pp_expr e
-    | CannotParse -> pp_print_string f "ASL Grammar Error: Cannot parse."
-    | UnknownSymbol -> pp_print_string f "ASL Grammar Error: Unknown symbol."
+    | AssertionFailed e -> pp_err dynamic "Assertion failed:@ %a." pp_expr e
+    | CannotParse -> pp_err parse "Cannot parse."
+    | UnknownSymbol -> pp_err lexical "Unknown symbol."
     | NoCallCandidate (name, types) ->
-        fprintf f
-          "ASL Type error: No subprogram declaration matches the invocation:@ \
-           %s(%a)."
-          name (pp_comma_list pp_ty) types
+        pp_err typing
+          "No subprogram declaration matches the invocation:@ %s(%a)." name
+          (pp_comma_list pp_ty) types
     | BadTypesForBinop (op, t1, t2) ->
-        fprintf f
-          "ASL Type error: Illegal application of operator %s on types@ %a@ \
-           and %a."
+        pp_err typing "Illegal application of operator %s on types@ %a@ and %a."
           (binop_to_string op) pp_ty t1 pp_ty t2
     | CircularDeclarations x ->
-        fprintf f
+        pp_err dynamic
           "ASL Evaluation error: circular definition of constants, including \
            %S."
           x
     | ImpureExpression (e, ses) ->
-        fprintf f
-          "ASL Type error:@ a pure expression was expected,@ found %a,@ which@ \
-           produces@ the@ following@ side-effects:@ %a."
+        pp_err typing
+          "a pure expression was expected,@ found %a,@ which@ produces@ the@ \
+           following@ side-effects:@ %a."
           pp_expr e SideEffect.SES.pp_print ses
     | MismatchedPurity s ->
-        fprintf f "ASL Type error:@ expected@ a@ %s@ expression/subprogram." s
+        pp_err typing "expected@ a@ %s@ expression/subprogram." s
     | UnreconcilableTypes (t1, t2) ->
-        fprintf f
-          "ASL Type error:@ cannot@ find@ a@ common@ ancestor@ to@ those@ two@ \
-           types@ %a@ and@ %a."
+        pp_err typing
+          "cannot@ find@ a@ common@ ancestor@ to@ those@ two@ types@ %a@ and@ \
+           %a."
           pp_ty t1 pp_ty t2
     | AssignToImmutable x ->
-        fprintf f "ASL Type error:@ cannot@ assign@ to@ immutable@ storage@ %S."
-          x
+        pp_err typing "cannot@ assign@ to@ immutable@ storage@ %S." x
     | AssignToTupleElement tuple_e ->
-        fprintf f
-          "ASL Type error:@ cannot@ assign@ to@ the@ (immutable)@ tuple@ \
-           value@ %a."
+        pp_err typing "cannot@ assign@ to@ the@ (immutable)@ tuple@ value@ %a."
           pp_lexpr tuple_e
     | AlreadyDeclaredIdentifier x ->
-        fprintf f
-          "ASL Type error:@ cannot@ declare@ already@ declared@ element@ %S." x
+        pp_err typing "cannot@ declare@ already@ declared@ element@ %S." x
     | BadReturnStmt None ->
-        pp_print_text f
-          "ASL Type error: cannot return something from a procedure."
-    | UnexpectedSideEffect s -> fprintf f "Unexpected side-effect: %s." s
-    | UncaughtException s -> fprintf f "Uncaught exception: %s." s
+        pp_err typing "cannot return something from a procedure."
+    | UnexpectedSideEffect s -> pp_err dynamic "Unexpected side-effect: %s." s
+    | UncaughtException s -> pp_err dynamic "Uncaught exception: %s." s
     | OverlappingSlices (slices, t) ->
-        fprintf f "ASL %s error:@ overlapping slices@ @[%a@]."
+        pp_err
           (error_handling_time_to_string t)
-          pp_slice_list slices
+          "overlapping slices@ @[%a@]." pp_slice_list slices
     | BadLDI ldi ->
-        fprintf f "Unsupported declaration:@ @[%a@]." pp_local_decl_item ldi
+        pp_err typing "Unsupported declaration:@ @[%a@]." pp_local_decl_item ldi
     | BadRecursiveDecls decls ->
-        fprintf f "ASL Type error:@ multiple recursive declarations:@ @[%a@]."
+        pp_err typing "multiple recursive declarations:@ @[%a@]."
           (pp_comma_list (fun f -> fprintf f "%S"))
           decls
-    | UnrespectedParserInvariant -> fprintf f "Parser invariant broke."
+    | UnrespectedParserInvariant -> pp_err typing "Parser invariant broke."
     | ConstrainedIntegerExpected t ->
-        fprintf f
-          "ASL Type error:@ constrained@ integer@ expected,@ provided@ %a."
-          pp_ty t
+        pp_err typing "constrained@ integer@ expected,@ provided@ %a." pp_ty t
     | ParameterWithoutDecl s ->
-        fprintf f
-          "ASL Type error:@ explicit@ parameter@ %S@ does@ not@ have@ a@ \
-           corresponding@ defining@ argument."
+        pp_err typing
+          "explicit@ parameter@ %S@ does@ not@ have@ a@ corresponding@ \
+           defining@ argument."
           s
     | BadParameterDecl (name, expected, actual) ->
-        fprintf f
-          "ASL Type error:@ incorrect@ parameter@ declaration@ for@ %S,@ \
-           expected@ @[{%a}@]@ but@ @[{%a}@]@ provided"
+        pp_err typing
+          "incorrect@ parameter@ declaration@ for@ %S,@ expected@ @[{%a}@]@ \
+           but@ @[{%a}@]@ provided"
           name
           (pp_comma_list pp_print_string)
           expected
           (pp_comma_list pp_print_string)
           actual
     | ArbitraryEmptyType t ->
-        fprintf f "ASL Dynamic error: ARBITRARY of empty type %a." pp_ty t
+        pp_err dynamic "ARBITRARY of empty type %a." pp_ty t
     | BaseValueEmptyType t ->
-        fprintf f "ASL Type error: base value of empty type %a." pp_ty t
+        pp_err typing "base value of empty type %a." pp_ty t
     | BaseValueNonSymbolic (t, e) ->
-        fprintf f
-          "ASL Type error:@ base@ value@ of@ type@ %a@ cannot@ be@ \
-           symbolically@ reduced@ since@ it@ consists@ of@ %a."
+        pp_err typing
+          "base@ value@ of@ type@ %a@ cannot@ be@ symbolically@ reduced@ \
+           since@ it@ consists@ of@ %a."
           pp_ty t pp_expr e
     | BadATC (t1, t2) ->
-        fprintf f
-          "ASL Type error:@ cannot@ perform@ Asserted@ Type@ Conversion@ on@ \
-           %a@ by@ %a."
-          pp_ty t1 pp_ty t2
+        pp_err typing
+          "cannot@ perform@ Asserted@ Type@ Conversion@ on@ %a@ by@ %a." pp_ty
+          t1 pp_ty t2
     | SettingIntersectingSlices bitfields ->
-        fprintf f "ASL Type error:@ setting@ intersecting@ bitfields@ [%a]."
-          pp_bitfields bitfields
+        pp_err typing "setting@ intersecting@ bitfields@ [%a]." pp_bitfields
+          bitfields
     | SetterWithoutCorrespondingGetter func ->
         let ret, args =
           match func.args with
           | (_, ret) :: args -> (ret, List.map snd args)
           | _ -> assert false
         in
-        fprintf f
-          "ASL Type error:@ setter@ \"%s\"@ does@ not@ have@ a@ corresponding@ \
-           getter@ of@ signature@ @[@[%a@]@ ->@ %a@]."
+        pp_err typing
+          "setter@ \"%s\"@ does@ not@ have@ a@ corresponding@ getter@ of@ \
+           signature@ @[@[%a@]@ ->@ %a@]."
           func.name (pp_comma_list pp_ty) args pp_ty ret
-    | UnexpectedATC -> pp_print_text f "ASL Type error: unexpected ATC."
+    | UnexpectedATC -> pp_err typing "unexpected ATC."
     | BadPattern (p, t) ->
-        fprintf f
-          "ASL Type error:@ Erroneous@ pattern@ %a@ for@ expression@ of@ type@ \
-           %a."
+        pp_err typing "Erroneous@ pattern@ %a@ for@ expression@ of@ type@ %a."
           pp_pattern p pp_ty t
-    | UnreachableReached ->
-        pp_print_text f "ASL Dynamic error: unreachable reached."
+    | UnreachableReached -> pp_err dynamic "unreachable reached."
     | NonReturningFunction name ->
-        fprintf f
-          "ASL Type error:@ not all control flow paths of the function %S@ %a."
-          name pp_print_text
+        pp_err typing "not all control flow paths of the function %S@ %a." name
+          pp_print_text
           "are guaranteed to either return, raise an exception, or invoke \
            unreachable"
     | NoreturnViolation name ->
-        fprintf f "ASL Type error:@ the@ function %S@ %a." name pp_print_text
+        pp_err typing "the@ function %S@ %a." name pp_print_text
           "is qualified with noreturn but may return on some control flow path"
-    | RecursionLimitReached ->
-        pp_print_text f "ASL Dynamic error: recursion limit reached."
-    | LoopLimitReached ->
-        pp_print_text f "ASL Dynamic error: loop limit reached."
+    | RecursionLimitReached -> pp_err dynamic "recursion limit reached."
+    | LoopLimitReached -> pp_err dynamic "loop limit reached."
     | ConflictingSideEffects (s1, s2) ->
-        fprintf f "ASL Type error: conflicting side effects %a and %a"
-          SideEffect.pp_print s1 SideEffect.pp_print s2
+        pp_err typing "conflicting side effects %a and %a" SideEffect.pp_print
+          s1 SideEffect.pp_print s2
     | ConfigTimeBroken (e, ses) ->
-        fprintf f
-          "ASL Type error:@ expected@ config-time@ expression,@ got@ %a,@ \
-           which@ produces@ the@ following@ side-effects:@ %a."
+        pp_err typing
+          "expected@ config-time@ expression,@ got@ %a,@ which@ produces@ the@ \
+           following@ side-effects:@ %a."
           pp_expr e SideEffect.SES.pp_print ses
     | ConstantTimeBroken (e, ses) ->
-        fprintf f
-          "ASL Type error:@ expected@ constant-time@ expression,@ got@ %a,@ \
-           which@ produces@ the@ following@ side-effects:@ %a."
+        pp_err typing
+          "expected@ constant-time@ expression,@ got@ %a,@ which@ produces@ \
+           the@ following@ side-effects:@ %a."
           pp_expr e SideEffect.SES.pp_print ses
     | BadReturnStmt (Some t) ->
-        fprintf f
-          "ASL Type error:@ cannot@ return@ nothing@ from@ a@ function,@ an@ \
-           expression@ of@ type@ %a@ is@ expected."
+        pp_err typing
+          "cannot@ return@ nothing@ from@ a@ function,@ an@ expression@ of@ \
+           type@ %a@ is@ expected."
           pp_ty t
     | EmptyConstraints ->
-        pp_print_text f
-          "ASL Type error: a well-constrained integer cannot have empty \
-           constraints."
+        pp_err typing
+          "a well-constrained integer cannot have empty constraints."
     | ExpectedSingularType t ->
-        fprintf f "ASL Type error:@ %a@ %a." pp_print_text
-          "expected singular type, found" pp_ty t
+        pp_err typing "%a@ %a." pp_print_text "expected singular type, found"
+          pp_ty t
     | ExpectedNamedType t ->
-        fprintf f "ASL Type error:@ %a@ %a." pp_print_text
-          "expected a named type, found" pp_ty t
+        pp_err typing "%a@ %a." pp_print_text "expected a named type, found"
+          pp_ty t
     | UnexpectedPendingConstrained ->
-        pp_print_text f
-          "ASL Type error: a pending constrained integer is illegal here."
+        pp_err typing "a pending constrained integer is illegal here."
     | BitfieldsDontAlign
         { field1_absname; field2_absname; field1_absslices; field2_absslices }
       ->
-        fprintf f
-          "ASL Type error:@ bitfields `%s` and `%s` are in the same scope but \
-           define different slices of the containing bitvector type: %s and \
-           %s, respectively."
+        pp_err typing
+          "bitfields `%s` and `%s` are in the same scope but define different \
+           slices of the containing bitvector type: %s and %s, respectively."
           field1_absname field2_absname field1_absslices field2_absslices
     | UnexpectedInitialisationThrow (exception_ty, global_storage_element_name)
       ->
-        fprintf f
-          "ASL Dynamic error:@ unexpected@ exception@ %a@ thrown@ during@ the@ \
-           evaluation@ of@ the@ initialisation@ of@ the global@ storage@ \
-           element@ %S."
+        pp_err dynamic
+          "unexpected@ exception@ %a@ thrown@ during@ the@ evaluation@ of@ \
+           the@ initialisation@ of@ the global@ storage@ element@ %S."
           pp_ty exception_ty global_storage_element_name
     | PrecisionLostDefining ->
-        fprintf f
-          "ASL Type error:@ type@ used@ to@ define@ storage@ item@ is@ the@ \
-           result@ of@ precision@ loss."
+        pp_err typing
+          "type@ used@ to@ define@ storage@ item@ is@ the@ result@ of@ \
+           precision@ loss."
     | NegativeArrayLength (e_length, length) ->
-        fprintf f
-          "ASL Dynamic error:@ array@ length@ expression@ %a@ has@ negative@ \
-           length@a: %i."
-          pp_expr e_length length
-    | MultipleWrites id ->
-        fprintf f "ASL Grammar error:@ multiple@ writes@ to@ %S." id
+        pp_err dynamic
+          "array@ length@ expression@ %a@ has@ negative@ length@a: %i." pp_expr
+          e_length length
+    | MultipleWrites id -> pp_err parse "multiple@ writes@ to@ %S." id
     | MultipleImplementations (impl1, impl2) ->
-        fprintf f
-          "ASL Type error:@ multiple@ overlapping@ `implementation`@ \
-           functions@ for@ %s:@ %a"
+        pp_err typing
+          "multiple@ overlapping@ `implementation`@ functions@ for@ %s:@ %a"
           impl1.desc.name (pp_print_list pp_pos) [ impl1; impl2 ]
     | NoOverrideCandidate ->
-        fprintf f "@[%a@]" pp_print_text
-          "ASL Type error: no `impdef` for `implementation` function."
-    | UnexpectedCollection ->
-        pp_print_text f "ASL Type error: unexpected collection."
+        pp_err typing "no `impdef` for `implementation` function."
+    | UnexpectedCollection -> pp_err typing "unexpected collection."
     | TooManyOverrideCandidates impdefs ->
-        fprintf f
-          "ASL Type error:@ multiple@ `impdef`@ candidates@ for@ \
-           `implementation`:@ %a"
+        pp_err typing
+          "multiple@ `impdef`@ candidates@ for@ `implementation`:@ %a"
           (pp_print_list pp_pos) impdefs
     | BadPrimitiveArgument (name, reason) ->
-        fprintf f "ASL Dynamic error: %s (primitive) expected an argument %s"
-          name reason);
-    pp_close_box f ()
+        pp_err dynamic "%s (primitive) expected an argument %s" name reason
 
   let pp_warning_desc f w =
     match w.desc with

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -342,12 +342,12 @@ module PPrint = struct
     | InvalidExpr e -> fprintf f "ASL Error: invalid expression %a." pp_expr e
     | MismatchType (v, [ ty ]) ->
         fprintf f
-          "ASL Execution error: Mismatch type:@ value %s does not belong to \
-           type %a."
+          "ASL Dynamic error: Mismatch type:@ value %s does not belong to type \
+           %a."
           v pp_type_desc ty
     | MismatchType (v, li) ->
         fprintf f
-          "ASL Execution error: Mismatch type:@ value %s@ does not subtype any \
+          "ASL Dynamic error: Mismatch type:@ value %s@ does not subtype any \
            of those types:@ %a"
           v
           (pp_comma_list pp_type_desc)
@@ -416,7 +416,7 @@ module PPrint = struct
           (pp_comma_list pp_type_desc)
           expected
     | AssertionFailed e ->
-        fprintf f "ASL Execution error: Assertion failed:@ %a." pp_expr e
+        fprintf f "ASL Dynamic error: Assertion failed:@ %a." pp_expr e
     | CannotParse -> pp_print_string f "ASL Grammar Error: Cannot parse."
     | UnknownSymbol -> pp_print_string f "ASL Grammar Error: Unknown symbol."
     | NoCallCandidate (name, types) ->
@@ -492,7 +492,7 @@ module PPrint = struct
           (pp_comma_list pp_print_string)
           actual
     | ArbitraryEmptyType t ->
-        fprintf f "ASL Execution error: ARBITRARY of empty type %a." pp_ty t
+        fprintf f "ASL Dynamic error: ARBITRARY of empty type %a." pp_ty t
     | BaseValueEmptyType t ->
         fprintf f "ASL Type error: base value of empty type %a." pp_ty t
     | BaseValueNonSymbolic (t, e) ->
@@ -581,8 +581,8 @@ module PPrint = struct
     | UnexpectedInitialisationThrow (exception_ty, global_storage_element_name)
       ->
         fprintf f
-          "ASL Execution error:@ unexpected@ exception@ %a@ thrown@ during@ \
-           the@ evaluation@ of@ the@ initialisation@ of@ the global@ storage@ \
+          "ASL Dynamic error:@ unexpected@ exception@ %a@ thrown@ during@ the@ \
+           evaluation@ of@ the@ initialisation@ of@ the global@ storage@ \
            element@ %S."
           pp_ty exception_ty global_storage_element_name
     | PrecisionLostDefining ->
@@ -591,7 +591,7 @@ module PPrint = struct
            result@ of@ precision@ loss."
     | NegativeArrayLength (e_length, length) ->
         fprintf f
-          "ASL Execution error:@ array@ length@ expression@ %a@ has@ negative@ \
+          "ASL Dynamic error:@ array@ length@ expression@ %a@ has@ negative@ \
            length@a: %i."
           pp_expr e_length length
     | MultipleWrites id ->
@@ -612,7 +612,7 @@ module PPrint = struct
            `implementation`:@ %a"
           (pp_print_list pp_pos) impdefs
     | BadPrimitiveArgument (name, reason) ->
-        fprintf f "ASL Execution error: %s (primitive) expected an argument %s"
+        fprintf f "ASL Dynamic error: %s (primitive) expected an argument %s"
           name reason);
     pp_close_box f ()
 

--- a/asllib/libdir/stdlib.asl
+++ b/asllib/libdir/stdlib.asl
@@ -552,8 +552,10 @@ end;
 // integer and the resulting integer is represented by its first N bits.
 pure func AlignDownP2{N}(x: bits(N), p2: integer{0..N}) => bits(N)
 begin
-    if N == 0 then return x; end;
-    return x[N-1:p2] :: Zeros{p2};
+    if N == 0 then return x;
+    elsif N == p2 then return Zeros{N};
+    else return x[N-1:p2] :: Zeros{p2};
+    end;
 end;
 
 // AlignUpP2()

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -1,7 +1,7 @@
 Examples used in ASL High-level Definition:
   $ aslref main0.asl
   $ aslref main_uncaught.asl
-  Uncaught exception: MyException {}.
+  ASL Dynamic error: Uncaught exception: MyException {}.
   [1]
   $ aslref --no-exec spec1.asl
   $ aslref --no-exec spec2.asl
@@ -93,13 +93,13 @@ Examples used in ASL High-level Definition:
   File GuideRule.TupleElementAccess.bad.asl, line 5, characters 18 to 25:
       x = (x.item1, x.item2);
                     ^^^^^^^
-  ASL Typing Error: There is no field 'item2' on type (integer, integer).
+  ASL Type error: There is no field 'item2' on type (integer, integer).
   [1]
   $ aslref GuideRule.AnonymousEnumerations.bad.asl
   File GuideRule.AnonymousEnumerations.bad.asl, line 4, characters 12 to 23:
       var x : enumeration {RED, GREEN, BLUE};
               ^^^^^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref GuideRule.TupleImmutability.asl
   File GuideRule.TupleImmutability.asl, line 7, characters 6 to 11:
@@ -113,14 +113,14 @@ Examples used in ASL High-level Definition:
   File ParameterElision.bad.asl, line 13, characters 25 to 35:
       var foo : bits(64) = X(data, n);
                            ^^^^^^^^^^
-  ASL Static Error: Arity error while calling 'X':
+  ASL Static error: Arity error while calling 'X':
     1 parameters expected and 0 provided
   [1]
   $ aslref ParameterOmission.bad.asl
   File ParameterOmission.bad.asl, line 6, characters 17 to 18:
       result = LSL{}(result, 3);
                    ^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref --no-exec NamedTypes.asl
   $ aslref --no-exec NamedTypes2.asl

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -43,7 +43,7 @@ Examples used in ASL High-level Definition:
   File AssertionStatement.asl, line 5, characters 11 to 22:
       assert a + b < 256;
              ^^^^^^^^^^^
-  ASL Execution error: Assertion failed: ((a + b) < 256).
+  ASL Dynamic error: Assertion failed: ((a + b) < 256).
   [1]
 
   $ aslref TypingErrorReporting.asl

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -22,13 +22,13 @@ ASL Semantics Tests:
   File SemanticsRule.ECondARBITRARY3or42.asl, line 10, characters 9 to 13:
     assert x==3;
            ^^^^
-  ASL Execution error: Assertion failed: (x == 3).
+  ASL Dynamic error: Assertion failed: (x == 3).
   [1]
   $ aslref SemanticsRule.ESlice.asl
   $ aslref SemanticsRule.ECall.asl
   $ aslref SemanticsRule.EGetArray.asl
   $ aslref SemanticsRule.EGetArrayTooSmall.asl
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 3 does not belong to type integer {0..2}.
   [1]
   $ aslref SemanticsRule.ERecord.asl
@@ -40,7 +40,7 @@ ASL Semantics Tests:
   File SemanticsRule.EArbitraryInteger3.asl, line 5, characters 9 to 13:
     assert x==3;
            ^^^^
-  ASL Execution error: Assertion failed: (x == 3).
+  ASL Dynamic error: Assertion failed: (x == 3).
   [1]
   $ aslref SemanticsRule.EArbitraryIntegerRange3-42-3.asl
   $ aslref SemanticsRule.EArbitraryIntegerRange3-42-42.asl
@@ -48,7 +48,7 @@ ASL Semantics Tests:
     characters 9 to 14:
     assert x==42;
            ^^^^^
-  ASL Execution error: Assertion failed: (x == 42).
+  ASL Dynamic error: Assertion failed: (x == 42).
   [1]
   $ aslref SemanticsRule.EArbitraryArray.asl
   $ aslref SemanticsRule.EPattern.asl
@@ -200,7 +200,7 @@ ASL Semantics Tests:
   File SemanticsRule.SAssertNo.asl, line 4, characters 10 to 17:
     assert (42 == 3);
             ^^^^^^^
-  ASL Execution error: Assertion failed: (42 == 3).
+  ASL Dynamic error: Assertion failed: (42 == 3).
   [1]
   $ aslref SemanticsRule.LEDiscard.asl
   $ aslref SemanticsRule.LDDiscard.asl
@@ -217,7 +217,7 @@ ASL Semantics Tests:
   File SemanticsRule.ATCVariousErrors.asl, line 8, characters 28 to 29:
     var c: integer{4, 5, 6} = 2 as integer{4, 5, 6}; // A dynamic error
                               ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 2 does not belong to type integer {4, 5, 6}.
   [1]
   $ aslref SemanticsRule.CatchNoThrow.asl
@@ -229,7 +229,7 @@ ASL Semantics Tests:
   File SemanticsRule.SCond3.asl, line 3, characters 9 to 14:
     assert FALSE;
            ^^^^^
-  ASL Execution error: Assertion failed: FALSE.
+  ASL Dynamic error: Assertion failed: FALSE.
   [1]
   $ aslref SemanticsRule.SCond4.asl
   $ aslref SemanticsRule.STry.asl
@@ -281,6 +281,6 @@ ASL Semantics Tests:
   File SemanticsRule.EvalGlobals.bad1.asl, line 10, characters 0 to 12:
   var x = f();
   ^^^^^^^^^^^^
-  ASL Execution error: unexpected exception MyException thrown during the
+  ASL Dynamic error: unexpected exception MyException thrown during the
     evaluation of the initialisation of the global storage element "x".
   [1]

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -12,7 +12,7 @@ ASL Semantics Tests:
   File SemanticsRule.EUndefIdent.asl, line 5, characters 9 to 10:
     assert y;
            ^
-  ASL Error: Undefined identifier: 'y'
+  ASL Static error: Undefined identifier: 'y'
   [1]
 //  $ aslref SemanticsRule.EBinopPlusPrint.asl
   $ aslref SemanticsRule.EBinopPlusAssert.asl
@@ -141,13 +141,13 @@ ASL Semantics Tests:
   File SemanticsRule.CatchNone.asl, line 15, characters 8 to 24:
     catch MyExceptionType1;
           ^^^^^^^^^^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref SemanticsRule.FUndefIdent.asl
   File SemanticsRule.FUndefIdent.asl, line 4, characters 5 to 12:
        foo ();
        ^^^^^^^
-  ASL Error: Undefined identifier: 'foo'
+  ASL Static error: Undefined identifier: 'foo'
   [1]
   $ aslref SemanticsRule.FCall.asl
   $ aslref SemanticsRule.PAll.asl
@@ -165,7 +165,7 @@ ASL Semantics Tests:
   File SemanticsRule.LEUndefIdentV1.asl, line 5, characters 2 to 3:
     y = 3;
     ^
-  ASL Error: Undefined identifier: 'y'
+  ASL Static error: Undefined identifier: 'y'
   [1]
   $ aslref SemanticsRule.LESlice.asl
   $ aslref SemanticsRule.LESetField.asl

--- a/asllib/tests/ASLSyntaxReference.t/run.t
+++ b/asllib/tests/ASLSyntaxReference.t/run.t
@@ -13,7 +13,7 @@ Examples used to test syntax and AST building rules:
   File GuideRule.IdentifiersKeywords.bad.asl, line 3, characters 8 to 12:
       var case = 5;
           ^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref ConventionRule.IdentifiersDifferingByCase.asl
   $ aslref --no-exec ConventionRule.IdentifierSingleUnderscore.asl
@@ -39,35 +39,35 @@ Examples used to test syntax and AST building rules:
   File ASTRule.EBinop.bad1.asl, line 6, characters 20 to 25:
           let p_a_s = a + b - c;
                       ^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref ASTRule.EBinop.bad2.asl
   File ASTRule.EBinop.bad2.asl, line 6, characters 20 to 25:
           let p_s_a = a - b + c;
                       ^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref ASTRule.EBinop.bad3.asl
   File ASTRule.EBinop.bad3.asl, line 6, characters 23 to 30:
           let p_and_or = d AND e OR f;
                          ^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref ASTRule.EBinop.bad4.asl
   File ASTRule.EBinop.bad4.asl, line 6, characters 22 to 28:
           let p_eq_eq = a == b != g;
                         ^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref ASTRule.EBinop.bad5.asl
   File ASTRule.EBinop.bad5.asl, line 6, characters 24 to 29:
           let p_sub_sub = a - b - c;
                           ^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref CaseStatement.bad.asl
   File CaseStatement.bad.asl, line 7, characters 8 to 12:
           when '11' => X[30] = 0;
           ^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -222,7 +222,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.TNonDecl.asl, line 1, characters 5 to 6:
   func (x: record { a: integer, b: boolean }) => integer
        ^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref TypingRule.TBitField.asl
   $ aslref --no-exec TypingRule.AnnotateFuncSig.asl
@@ -236,7 +236,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.ExtractParameters-bad1.asl, line 3, characters 15 to 36:
       arg0: bits(N as integer{8,16,32}),
                  ^^^^^^^^^^^^^^^^^^^^^
-  ASL Static Error: Unsupported expression N as integer {8, 16, 32}.
+  ASL Static error: Unsupported expression N as integer {8, 16, 32}.
   [1]
   $ aslref TypingRule.BuiltinAggregateTypes.asl
   $ aslref --no-exec TypingRule.BuiltinExceptionType.asl
@@ -385,7 +385,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.EVar.undefined.asl, line 3, characters 12 to 13:
       var x = t;
               ^
-  ASL Error: Undefined identifier: 't'
+  ASL Static error: Undefined identifier: 't'
   [1]
 
   $ aslref TypingRule.EGetRecordField.asl
@@ -393,20 +393,20 @@ ASL Typing Tests / annotating types:
   File TypingRule.EGetBadRecordField.asl, line 7, characters 10 to 36:
     var x = my_record.undeclared_field;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Typing Error: There is no field 'undeclared_field' on type MyRecordType.
+  ASL Type error: There is no field 'undeclared_field' on type MyRecordType.
   [1]
   $ aslref TypingRule.EGetBitfield.asl
   $ aslref TypingRule.EGetBadBitField.asl
   File TypingRule.EGetBadBitField.asl, line 7, characters 12 to 33:
       var x = p.undeclared_bitfield;
               ^^^^^^^^^^^^^^^^^^^^^
-  ASL Typing Error: There is no field 'undeclared_bitfield' on type Packet.
+  ASL Type error: There is no field 'undeclared_bitfield' on type Packet.
   [1]
   $ aslref TypingRule.EGetBadField.asl
   File TypingRule.EGetBadField.asl, line 6, characters 12 to 15:
       var x = a.f;
               ^^^
-  ASL Typing Error: There is no field 'f' on type array [[5]] of integer.
+  ASL Type error: There is no field 'f' on type array [[5]] of integer.
   [1]
   $ aslref TypingRule.EGetFields.asl
   $ aslref --no-exec TypingRule.ATC.asl
@@ -449,7 +449,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.LEVar.undefined.asl, line 3, characters 4 to 5:
       x = 42;
       ^
-  ASL Error: Undefined identifier: 'x'
+  ASL Static error: Undefined identifier: 'x'
   [1]
   $ aslref TypingRule.LESetBadField.asl
   File TypingRule.LESetBadField.asl, line 6, characters 4 to 5:
@@ -487,7 +487,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.SDecl.bad2.asl, line 4, characters 18 to 19:
       let y: integer;
                     ^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref TypingRule.SAssert.bad.asl
   File TypingRule.SAssert.bad.asl, line 11, characters 10 to 23:
@@ -530,7 +530,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.SFor.bad3.asl, line 7, characters 4 to 5:
       j = 0; // Illegal: 'j' is in scope only in the loop body.
       ^
-  ASL Error: Undefined identifier: 'j'
+  ASL Static error: Undefined identifier: 'j'
   [1]
   $ aslref TypingRule.SFor.bad4.asl
   File TypingRule.SFor.bad4.asl, line 11, characters 17 to 30:
@@ -569,7 +569,8 @@ ASL Typing Tests / annotating types:
       [3:0, 5+:3] data,
       [3*:5] value // Illegal: position 19 exceeds 15
   };
-  ASL Static error: Cannot extract from bitvector of length 16 slice (3 * 5)+:5.
+  ASL Static error:
+    Cannot extract from bitvector of length 16 slice (3 * 5)+:5.
   [1]
 
   $ aslref TypingRule.CheckNoPrecisionLoss.asl
@@ -656,7 +657,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.CheckIsNotCollection.asl, line 3, characters 12 to 22:
     var test: collection {
               ^^^^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref TypingRule.LESetCollectionFields.asl
   $ aslref TypingRule.TypecheckDecl.asl
@@ -715,14 +716,14 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateExtraFields.bad.asl, line 1, characters 15 to 39:
   type SubRecord subtypes Record with {-};
                  ^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Error: Undefined identifier: 'Record'
+  ASL Static error: Undefined identifier: 'Record'
   [1]
   $ aslref --no-exec TypingRule.DeclaredType.asl
   $ aslref --no-exec TypingRule.DeclaredType.bad.asl
   File TypingRule.DeclaredType.bad.asl, line 3, characters 12 to 23:
       var x = 20 as MyInt;
               ^^^^^^^^^^^
-  ASL Error: Undefined identifier: 'MyInt'
+  ASL Static error: Undefined identifier: 'MyInt'
   [1]
   $ aslref --no-exec TypingRule.DeclareConst.asl
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.config.asl
@@ -742,7 +743,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.DeclareGlobalStorage.bad3.asl, line 2, characters 37 to 38:
   config uninitialized_config : integer;
                                        ^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.non_config.asl
   $ aslref --no-exec TypingRule.UpdateGlobalStorage.constant.asl
@@ -809,7 +810,7 @@ ASL Typing Tests / annotating types:
     characters 8 to 17:
       - = add_10(5);
           ^^^^^^^^^
-  ASL Error: Undefined identifier: 'add_10'
+  ASL Static error: Undefined identifier: 'add_10'
   [1]
   $ aslref TypingRule.SubprogramForName.bad.no_candidates.asl
   File TypingRule.SubprogramForName.bad.no_candidates.asl, line 8,
@@ -828,7 +829,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.ParametersOfExpr.bad.asl, line 4, characters 15 to 27:
       z: integer{(D, E).item0}) => // Illegal expression in argument type
                  ^^^^^^^^^^^^
-  ASL Static Error: Unsupported expression (D, E).item0.
+  ASL Static error: Unsupported expression (D, E).item0.
   [1]
   $ aslref --no-exec TypingRule.FuncSigTypes.asl
   $ aslref --no-exec TypingRule.SubprogramTypesClash.asl
@@ -871,7 +872,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateReturnType.bad.asl, line 3, characters 24 to 34:
   func returns_value() => collection { foo: bits(32)};
                           ^^^^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref --no-exec TypingRule.AnnotateOneParam.asl
   $ aslref TypingRule.AnnotateOneParam.bad1.asl
@@ -896,14 +897,14 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateOneArg.bad2.asl, line 2, characters 18 to 28:
   func arguments(b: collection {a: bits(7)})
                     ^^^^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref TypingRule.AnnotateRetTy.asl
   $ aslref TypingRule.AnnotateRetTy.bad.asl
   File TypingRule.AnnotateRetTy.bad.asl, line 15, characters 4 to 17:
       flip{64}(bv); // Illegal: the returned value must be consumed.
       ^^^^^^^^^^^^^
-  ASL Error: Mismatched use of return value from call to 'flip'.
+  ASL Static error: Mismatched use of return value from call to 'flip'.
   [1]
   $ aslref --no-exec TypingRule.AnnotateCall.asl
   $ aslref --no-exec TypingRule.AnnotateCall2.asl
@@ -939,7 +940,7 @@ ASL Typing Tests / annotating types:
     characters 8 to 32:
       - = xor_extend{64}(bv1, bv2); // Illegal: missing parameter for `M`.
           ^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Static Error: Arity error while calling 'xor_extend':
+  ASL Static error: Arity error while calling 'xor_extend':
     2 parameters expected and 1 provided
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad2.asl

--- a/asllib/tests/atcs.t
+++ b/asllib/tests/atcs.t
@@ -10,7 +10,7 @@ Deferred to execution ATCs
   File atcs1.asl, line 2, characters 11 to 12:
     let x = (3 as integer {42});
              ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 3 does not belong to type integer {42}.
   [1]
 
@@ -79,7 +79,7 @@ ATCs on other types
   File atcs6.asl, line 3, characters 11 to 25:
     let x = ((42, Zeros{4}) as myty);
              ^^^^^^^^^^^^^^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value [42, 0x0] does not belong to type (integer {0..10}, bits(4)).
   [1]
 

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -7,7 +7,7 @@ Bad enumeration
   File bad-types1.asl, line 1, characters 23 to 24:
   type t of enumeration {};
                          ^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
 Invalid bitfields

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -119,7 +119,7 @@ Arbitrary of empty type
   File bad-types7.asl, line 3, characters 38 to 52:
      let b: integer {1..0} = ARBITRARY: integer {1..0};
                                         ^^^^^^^^^^^^^^
-  ASL Execution error: ARBITRARY of empty type integer {1..0}.
+  ASL Dynamic error: ARBITRARY of empty type integer {1..0}.
   [1]
 
 Base value of empty type

--- a/asllib/tests/collections.t/run.t
+++ b/asllib/tests/collections.t/run.t
@@ -2,13 +2,13 @@
   File on-arbitrary.asl, line 3, characters 23 to 33:
     var col = ARBITRARY: collection {
                          ^^^^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref on-local-func-arg.asl
   File on-local-func-arg.asl, line 6, characters 15 to 25:
   func foo (col: collection {
                  ^^^^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref on-local-var.asl
   File on-local-var.asl, line 8, characters 2 to 25:
@@ -22,16 +22,14 @@
     field1: bits(1),
     field2: integer,
   };
-  ASL Static Error: Unsupported type collection {
-                                       field1: bits(1),
-                                       field2: integer
-                                     }.
+  ASL Static error:
+    Unsupported type collection { field1: bits(1), field2: integer }.
   [1]
   $ aslref on-function-return-type.asl
   File on-function-return-type.asl, line 6, characters 15 to 25:
   func foo () => collection {
                  ^^^^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
   $ aslref on-local-tuple.asl
@@ -52,5 +50,5 @@
   File on-type-declaration.asl, line 1, characters 21 to 31:
   type MyCollection of collection {
                        ^^^^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]

--- a/asllib/tests/explicit-parameters.t/run.t
+++ b/asllib/tests/explicit-parameters.t/run.t
@@ -46,7 +46,7 @@ Explicit parameter tests:
   File bad-elided-parameter.asl, line 8, characters 20 to 30:
     let x : bits(4) = Foo{,3}(0);
                       ^^^^^^^^^^
-  ASL Static Error: Arity error while calling 'Foo':
+  ASL Static error: Arity error while calling 'Foo':
     1 parameters expected and 2 provided
   [1]
 
@@ -54,7 +54,7 @@ Explicit parameter tests:
   File omit-output-stdlib-param.asl, line 3, characters 21 to 41:
     let x : bits(64) = Extend('1111', TRUE);
                        ^^^^^^^^^^^^^^^^^^^^
-  ASL Static Error: Arity error while calling 'Extend-1':
+  ASL Static error: Arity error while calling 'Extend-1':
     2 parameters expected and 1 provided
   [1]
 

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -37,7 +37,7 @@
   File println5.asl, line 1, characters 32 to 33:
   constant msg = "Something with \p bad characters.";
                                   ^
-  ASL Grammar Error: Unknown symbol.
+  ASL Lexical error: Unknown symbol.
   [1]
   $ cat >println6.asl <<EOF
   > constant msg = "Some unterminated string;
@@ -80,7 +80,7 @@ C-Style comments
   File comments2.asl, line 11, characters 8 to 9:
   let a = b;
           ^
-  ASL Error: Undefined identifier: 'b'
+  ASL Static error: Undefined identifier: 'b'
   [1]
 
 Some problems with bitvectors and bitmasks:
@@ -134,7 +134,7 @@ Forbidden patterns
   File forbiddenhex01.asl, line 1, characters 8 to 11:
   let x = 0xh12;
           ^^^
-  ASL Grammar Error: Unknown symbol.
+  ASL Lexical error: Unknown symbol.
   [1]
 
   $ cat >forbiddenhex02.asl <<EOF
@@ -144,7 +144,7 @@ Forbidden patterns
   File forbiddenhex02.asl, line 1, characters 8 to 11:
   let x = 0x_12;
           ^^^
-  ASL Grammar Error: Unknown symbol.
+  ASL Lexical error: Unknown symbol.
   [1]
 
   $ cat >forbiddenhex03.asl <<EOF
@@ -154,7 +154,7 @@ Forbidden patterns
   File forbiddenhex03.asl, line 1, characters 8 to 13:
   let x = 0x12h12;
           ^^^^^
-  ASL Grammar Error: Unknown symbol.
+  ASL Lexical error: Unknown symbol.
   [1]
 
   $ cat >forbiddenhex04.asl <<EOF
@@ -165,7 +165,7 @@ Forbidden patterns
   File forbiddenhex04.asl, line 2, characters 8 to 11:
   let x = 0x_foo;
           ^^^
-  ASL Grammar Error: Unknown symbol.
+  ASL Lexical error: Unknown symbol.
   [1]
 
   $ cat >forbiddenreal01.asl <<EOF
@@ -175,7 +175,7 @@ Forbidden patterns
   File forbiddenreal01.asl, line 1, characters 8 to 11:
   let x = 1.h12;
           ^^^
-  ASL Grammar Error: Unknown symbol.
+  ASL Lexical error: Unknown symbol.
   [1]
 
   $ cat >forbiddenreal02.asl <<EOF
@@ -185,7 +185,7 @@ Forbidden patterns
   File forbiddenreal02.asl, line 1, characters 8 to 11:
   let x = 1._12;
           ^^^
-  ASL Grammar Error: Unknown symbol.
+  ASL Lexical error: Unknown symbol.
   [1]
 
   $ cat >forbiddenreal03.asl <<EOF
@@ -195,7 +195,7 @@ Forbidden patterns
   File forbiddenreal03.asl, line 1, characters 8 to 13:
   let x = 1.12h12;
           ^^^^^
-  ASL Grammar Error: Unknown symbol.
+  ASL Lexical error: Unknown symbol.
   [1]
 
   $ cat >forbiddenreal04.asl <<EOF
@@ -206,5 +206,5 @@ Forbidden patterns
   File forbiddenreal04.asl, line 2, characters 8 to 11:
   let x = 1._foo;
           ^^^
-  ASL Grammar Error: Unknown symbol.
+  ASL Lexical error: Unknown symbol.
   [1]

--- a/asllib/tests/overriding.t/run.t
+++ b/asllib/tests/overriding.t/run.t
@@ -1,18 +1,18 @@
 Single impdef only
   $ aslref --no-exec --overriding-permissive impdef-only.asl
-  $ aslref --no-exec --overriding-all-impdefs-overridden impdef-only.asl
+  $ aslref --no-exec --overriding-warn-all-impdefs-overridden impdef-only.asl
   File impdef-only.asl, line 1, character 0 to line 4, character 4:
   impdef func Foo{N: integer{32,64}}(n : boolean) => bits(N)
   begin
     return Zeros{N};
   end;
   ASL Warning: Missing `implementation` for `impdef` function.
-  $ aslref --no-exec --overriding-no-implementations impdef-only.asl
+  $ aslref --no-exec --overriding-warn-implementations impdef-only.asl
 
 Single impdef overridden by single implementation
   $ aslref --overriding-permissive impdef-overridden.asl
-  $ aslref --no-exec --overriding-all-impdefs-overridden impdef-overridden.asl
-  $ aslref --no-exec --overriding-no-implementations impdef-overridden.asl
+  $ aslref --no-exec --overriding-warn-all-impdefs-overridden impdef-overridden.asl
+  $ aslref --no-exec --overriding-warn-implementations impdef-overridden.asl
   File impdef-overridden.asl, line 6, character 0 to line 9, character 4:
   implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
   begin
@@ -29,7 +29,7 @@ Implementation without impdef
   end;
   ASL Type error: no `impdef` for `implementation` function.
   [1]
-  $ aslref --no-exec --overriding-all-impdefs-overridden implementation-only.asl
+  $ aslref --no-exec --overriding-warn-all-impdefs-overridden implementation-only.asl
   File implementation-only.asl, line 1, character 0 to line 4, character 4:
   implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
   begin
@@ -37,7 +37,7 @@ Implementation without impdef
   end;
   ASL Type error: no `impdef` for `implementation` function.
   [1]
-  $ aslref --no-exec --overriding-no-implementations implementation-only.asl
+  $ aslref --no-exec --overriding-warn-implementations implementation-only.asl
   File implementation-only.asl, line 1, character 0 to line 4, character 4:
   implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
   begin
@@ -58,7 +58,7 @@ Clashing implementations
     File clashing-implementations.asl, line 6, character 0 to line 9,
       character 4
   [1]
-  $ aslref --no-exec --overriding-all-impdefs-overridden clashing-implementations.asl
+  $ aslref --no-exec --overriding-warn-all-impdefs-overridden clashing-implementations.asl
   File clashing-implementations.asl, line 1, character 0 to line 4, character 4:
   implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
   begin
@@ -70,7 +70,7 @@ Clashing implementations
     File clashing-implementations.asl, line 6, character 0 to line 9,
       character 4
   [1]
-  $ aslref --no-exec --overriding-no-implementations clashing-implementations.asl
+  $ aslref --no-exec --overriding-warn-implementations clashing-implementations.asl
   File clashing-implementations.asl, line 1, character 0 to line 4, character 4:
   implementation func Foo{N: integer{32,64}}(n : boolean) => bits(N)
   begin

--- a/asllib/tests/recursive.t/run.t
+++ b/asllib/tests/recursive.t/run.t
@@ -29,7 +29,7 @@
   File recursive-constant.asl, line 1, characters 13 to 14:
   constant x = x + 3;
                ^
-  ASL Error: Undefined identifier: 'x'
+  ASL Static error: Undefined identifier: 'x'
   [1]
 
   $ aslref double-recursive-constant.asl
@@ -43,7 +43,7 @@
   File recursive-type.asl, line 1, characters 0 to 35:
   type tree of (tree, integer, tree);
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Error: Undefined identifier: 'tree'
+  ASL Static error: Undefined identifier: 'tree'
   [1]
 
   $ aslref double-recursive-types.asl

--- a/asllib/tests/regressions.t/bounds-checks-read-array-1.asl
+++ b/asllib/tests/regressions.t/bounds-checks-read-array-1.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    var arr: array[[4]] of integer;
+    - = arr[[-1]];
+
+    return 0;
+end;

--- a/asllib/tests/regressions.t/bounds-checks-read-array-2.asl
+++ b/asllib/tests/regressions.t/bounds-checks-read-array-2.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    var arr: array[[4]] of integer;
+    - = arr[[4]];
+
+    return 0;
+end;

--- a/asllib/tests/regressions.t/bounds-checks-read-bitvector-1.asl
+++ b/asllib/tests/regressions.t/bounds-checks-read-bitvector-1.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    var bv: bits(4) = Zeros{};
+     - = bv[-1];
+
+    return 0;
+end;

--- a/asllib/tests/regressions.t/bounds-checks-read-bitvector-2.asl
+++ b/asllib/tests/regressions.t/bounds-checks-read-bitvector-2.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    var bv: bits(4) = Zeros{};
+     - = bv[4];
+
+    return 0;
+end;

--- a/asllib/tests/regressions.t/bounds-checks-read-zero-width-slice.asl
+++ b/asllib/tests/regressions.t/bounds-checks-read-zero-width-slice.asl
@@ -1,0 +1,6 @@
+func main() => integer
+begin
+  var x : bits(4);
+  - = x[100+:0];
+  return 0;
+end;

--- a/asllib/tests/regressions.t/bounds-checks-write-array-1.asl
+++ b/asllib/tests/regressions.t/bounds-checks-write-array-1.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    var arr: array[[4]] of integer;
+    arr[[-1]] = 1;
+
+    return 0;
+end;

--- a/asllib/tests/regressions.t/bounds-checks-write-array-2.asl
+++ b/asllib/tests/regressions.t/bounds-checks-write-array-2.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    var arr: array[[4]] of integer;
+    arr[[4]] = 1;
+
+    return 0;
+end;

--- a/asllib/tests/regressions.t/bounds-checks-write-bitvector-1.asl
+++ b/asllib/tests/regressions.t/bounds-checks-write-bitvector-1.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    var bv: bits(4) = Zeros{};
+    bv[-1] = '1';
+
+    return 0;
+end;

--- a/asllib/tests/regressions.t/bounds-checks-write-bitvector-2.asl
+++ b/asllib/tests/regressions.t/bounds-checks-write-bitvector-2.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+    var bv: bits(4) = Zeros{};
+    bv[5] = '1';
+
+    return 0;
+end;

--- a/asllib/tests/regressions.t/bounds-checks-write-zero-width-slice.asl
+++ b/asllib/tests/regressions.t/bounds-checks-write-zero-width-slice.asl
@@ -1,0 +1,6 @@
+func main() => integer
+begin
+  var x : bits(4);
+  x[100+:0] = Zeros{0};
+  return 0;
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -663,3 +663,11 @@ Bounds checks
   ASL Dynamic error: Mismatch type:
     value 4 does not belong to type integer {0..3}.
   [1]
+  $ aslref bounds-checks-read-zero-width-slice.asl
+  ASL Dynamic error: Mismatch type:
+    value 100 does not belong to type integer {0..3}.
+  [1]
+  $ aslref bounds-checks-write-zero-width-slice.asl
+  ASL Dynamic error: Mismatch type:
+    value 100 does not belong to type integer {0..3}.
+  [1]

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -285,14 +285,14 @@ Parameterized integers:
   File setter_without_getter.asl, line 6, characters 0 to 3:
   end;
   ^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
   $ aslref getter_without_setter.asl
   File getter_without_setter.asl, line 6, characters 0 to 3:
   end;
   ^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
   $ aslref tuple_items.asl
@@ -301,7 +301,7 @@ Parameterized integers:
   File duplicated-otherwise.asl, line 7, characters 8 to 12:
           when 0.0 => println "2.0";
           ^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref duplicate_expr_record.asl
   File duplicate_expr_record.asl, line 5, characters 12 to 27:
@@ -314,21 +314,21 @@ Parameterized integers:
   File same-precedence.asl, line 6, characters 10 to 15:
     let x = a + b - c;
             ^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
   $ aslref same-precedence2.asl
   File same-precedence2.asl, line 6, characters 10 to 17:
     let d = a ==> b <=> c;
             ^^^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
   $ aslref binop-non-assoc.asl
   File binop-non-assoc.asl, line 3, characters 6 to 11:
     - = 3 - 2 - 1;
         ^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
   $ aslref rdiv_checks.asl
@@ -416,7 +416,7 @@ Required tests:
   File asl0-patterns.asl, line 7, characters 25 to 29:
       if x[0+:4] IN '10x1' then // invalid
                            ^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref -0 unreachable-v0.asl
   $ aslref assign1.asl
@@ -428,7 +428,7 @@ Required tests:
   File concat-empty.asl, line 3, characters 45 to 46:
     let empty_concatenation_should_not_parse = [];
                                                ^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
   $ aslref concat01.asl
   $ aslref concat02.asl
@@ -475,14 +475,14 @@ Required tests:
   File throw-local-env.asl, line 10, characters 13 to 14:
         assert y == 5; // y should not be found in dynamic environment here
                ^
-  ASL Error: Undefined identifier: 'y'
+  ASL Dynamic error: Undefined identifier: 'y'
   [1]
 
   $ aslref undeclared-variable.asl
   File undeclared-variable.asl, line 3, characters 2 to 5:
     bar = (32 - 46) * 0;
     ^^^
-  ASL Error: Undefined identifier: 'bar'
+  ASL Static error: Undefined identifier: 'bar'
   [1]
 
   $ aslref no-expression-elsif.asl
@@ -517,13 +517,13 @@ Getters/setters
   File nonempty-getter-called-without-slices.asl, line 14, characters 10 to 12:
     let x = f1;
             ^^
-  ASL Error: Undefined identifier: 'f1'
+  ASL Static error: Undefined identifier: 'f1'
   [1]
   $ aslref nonempty-setter-called-without-slices.asl
   File nonempty-setter-called-without-slices.asl, line 14, characters 2 to 4:
     f1 = 4;
     ^^
-  ASL Error: Undefined identifier: 'f1'
+  ASL Static error: Undefined identifier: 'f1'
   [1]
   $ aslref setter_subfield.asl
   $ aslref setter_subslice.asl
@@ -542,7 +542,7 @@ Getters/setters
   File pattern-masks-no-braces.asl, line 4, characters 19 to 24:
     assert ('111' IN '1xx') == TRUE;
                      ^^^^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
 ASLRef Field getter extension
@@ -609,7 +609,7 @@ Outdated syntax
   File outdated-implication.asl, line 6, characters 25 to 26:
     let z: boolean = x --> z;
                            ^
-  ASL Error: Undefined identifier: 'z'
+  ASL Static error: Undefined identifier: 'z'
   [1]
   $ aslref outdated-implication.asl
   File outdated-implication.asl, line 6, characters 21 to 24:
@@ -629,7 +629,7 @@ Outdated syntax
   File noreturn_function.asl, line 2, characters 26 to 28:
   noreturn func returning() => integer
                             ^^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
 Bounds checks

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -175,7 +175,7 @@ Runtime checks:
   File runtime-type-sat1.asl, line 3, characters 23 to 24:
     let x: integer {1} = 2 as integer {1};
                          ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 2 does not belong to type integer {1}.
   [1]
 
@@ -194,7 +194,7 @@ Runtime checks:
   File runtime-type-sat2.asl, line 2, characters 10 to 18:
     let x = Zeros{4} as bits(size);
             ^^^^^^^^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 0x0 does not belong to type bits(size).
   [1]
 
@@ -225,7 +225,7 @@ Parameterized integers:
   File bad-underconstrained-ctc.asl, line 3, characters 12 to 13:
     return x[(N as integer {N - 1})];
               ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 4 does not belong to type integer {(N - 1)}.
   [1]
   $ aslref bad-underconstrained-return.asl
@@ -354,7 +354,7 @@ Arrays indexed by enumerations
 
   $ aslref array-lca.asl
   $ aslref array-index-error.asl
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 14 does not belong to type integer {0..4}.
   [1]
 
@@ -637,29 +637,29 @@ Bounds checks
   ASL Dynamic error: Cannot extract from bitvector of length 0 slice -1+:1.
   [1]
   $ aslref bounds-checks-read-bitvector-2.asl
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 4 does not belong to type integer {0..3}.
   [1]
   $ aslref bounds-checks-write-bitvector-1.asl
   ASL Dynamic error: Cannot extract from bitvector of length 0 slice -1+:1.
   [1]
   $ aslref bounds-checks-write-bitvector-2.asl
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 5 does not belong to type integer {0..3}.
   [1]
   $ aslref bounds-checks-read-array-1.asl
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value -1 does not belong to type integer {0..3}.
   [1]
   $ aslref bounds-checks-read-array-2.asl
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 4 does not belong to type integer {0..3}.
   [1]
   $ aslref bounds-checks-write-array-1.asl
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value -1 does not belong to type integer {0..3}.
   [1]
   $ aslref bounds-checks-write-array-2.asl
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 4 does not belong to type integer {0..3}.
   [1]

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -631,3 +631,35 @@ Outdated syntax
                             ^^
   ASL Grammar Error: Cannot parse.
   [1]
+
+Bounds checks
+  $ aslref bounds-checks-read-bitvector-1.asl
+  ASL Dynamic error: Cannot extract from bitvector of length 0 slice -1+:1.
+  [1]
+  $ aslref bounds-checks-read-bitvector-2.asl
+  ASL Execution error: Mismatch type:
+    value 4 does not belong to type integer {0..3}.
+  [1]
+  $ aslref bounds-checks-write-bitvector-1.asl
+  ASL Dynamic error: Cannot extract from bitvector of length 0 slice -1+:1.
+  [1]
+  $ aslref bounds-checks-write-bitvector-2.asl
+  ASL Execution error: Mismatch type:
+    value 5 does not belong to type integer {0..3}.
+  [1]
+  $ aslref bounds-checks-read-array-1.asl
+  ASL Execution error: Mismatch type:
+    value -1 does not belong to type integer {0..3}.
+  [1]
+  $ aslref bounds-checks-read-array-2.asl
+  ASL Execution error: Mismatch type:
+    value 4 does not belong to type integer {0..3}.
+  [1]
+  $ aslref bounds-checks-write-array-1.asl
+  ASL Execution error: Mismatch type:
+    value -1 does not belong to type integer {0..3}.
+  [1]
+  $ aslref bounds-checks-write-array-2.asl
+  ASL Execution error: Mismatch type:
+    value 4 does not belong to type integer {0..3}.
+  [1]

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -11,7 +11,8 @@
   File binop-write-write.asl, line 11, characters 10 to 47:
     let y = set_and_return () + set_and_return ();
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects WritesGlobal "X" and WritesGlobal "X"
+  ASL Type error:
+    conflicting side effects WritesGlobal "X" and WritesGlobal "X"
   [1]
   $ aslref binop-read-write-diff.asl
   $ aslref binop-write-write-diff.asl
@@ -28,7 +29,8 @@
   File binop-throw-write.asl, line 18, characters 12 to 43:
       let y = throwing () + set_and_return ();
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects ThrowsException "E" and WritesGlobal "X"
+  ASL Type error:
+    conflicting side effects ThrowsException "E" and WritesGlobal "X"
   [1]
   $ aslref binop-throw-throw.asl
   E caught
@@ -36,7 +38,8 @@
   File binop-throw-throw.asl, line 11, characters 12 to 37:
       let y = throwing () + throwing ();
               ^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects ThrowsException "E" and ThrowsException "E"
+  ASL Type error:
+    conflicting side effects ThrowsException "E" and ThrowsException "E"
   [1]
   $ aslref binop-throw-caught.asl
   E caught
@@ -46,7 +49,8 @@
   File binop-throw-not-caught.asl, line 21, characters 12 to 37:
       let x = throws_E () + caught_F ();
               ^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects ThrowsException "E" and ThrowsException "E"
+  ASL Type error:
+    conflicting side effects ThrowsException "E" and ThrowsException "E"
   [1]
   $ aslref binop-throw-otherwised.asl
   E caught
@@ -62,7 +66,8 @@
   File binop-throw-atc.asl, line 16, characters 12 to 41:
       let y = throwing () + performs_atc ();
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects ThrowsException "E" and PerformsAssertions
+  ASL Type error:
+    conflicting side effects ThrowsException "E" and PerformsAssertions
   [1]
   $ aslref binop-write-atc.asl
   File binop-write-atc.asl, line 5, characters 10 to 11:
@@ -356,7 +361,8 @@
   File rec-binop-atc-throw.asl, line 15, characters 10 to 54:
     let x = throwing (n - 1, FALSE) * (2 as integer {3});
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects CallsRecursive "throwing" and PerformsAssertions
+  ASL Type error:
+    conflicting side effects CallsRecursive "throwing" and PerformsAssertions
   [1]
   $ aslref rec-binop-read-throw.asl
   File rec-binop-read-throw.asl, line 4, character 0 to line 11, character 4:
@@ -374,7 +380,8 @@
   File rec-binop-read-throw.asl, line 22, characters 10 to 45:
     let x = throwing (n - 1, FALSE) * read_X ();
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects CallsRecursive "throwing" and ReadsGlobal "X"
+  ASL Type error:
+    conflicting side effects CallsRecursive "throwing" and ReadsGlobal "X"
   [1]
   $ aslref rec-binop-unknown.asl
   $ aslref rec-binop-read.asl
@@ -389,7 +396,8 @@
   File rec-binop-read.asl, line 17, characters 10 to 42:
     let x = not_throwing (n - 1) * read_X ();
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects CallsRecursive "not_throwing" and ReadsGlobal "X"
+  ASL Type error:
+    conflicting side effects CallsRecursive "not_throwing" and ReadsGlobal "X"
   [1]
   $ aslref rec-binop-read-local.asl
   $ aslref rec-binop-write.asl
@@ -404,7 +412,8 @@
   File rec-binop-write.asl, line 18, characters 10 to 43:
     let x = not_throwing (n - 1) * write_X ();
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects CallsRecursive "not_throwing" and WritesGlobal "X"
+  ASL Type error:
+    conflicting side effects CallsRecursive "not_throwing" and WritesGlobal "X"
   [1]
   $ aslref rec-assert.asl
   File rec-assert.asl, line 1, character 0 to line 4, character 4:
@@ -424,7 +433,8 @@
   File rec-assert.asl, line 9, characters 10 to 51:
     let x = not_throwing (n - 1) * (2 as integer {3});
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects CallsRecursive "not_throwing" and PerformsAssertions
+  ASL Type error:
+    conflicting side effects CallsRecursive "not_throwing" and PerformsAssertions
   [1]
   $ aslref rec-binop-atc.asl
   File rec-binop-atc.asl, line 1, character 0 to line 4, character 4:
@@ -444,7 +454,8 @@
   File rec-binop-atc.asl, line 9, characters 10 to 51:
     let x = not_throwing (n - 1) * (2 as integer {3});
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects CallsRecursive "not_throwing" and PerformsAssertions
+  ASL Type error:
+    conflicting side effects CallsRecursive "not_throwing" and PerformsAssertions
   [1]
   $ aslref rec-binop-read-write.asl
   File rec-binop-read-write.asl, line 3, character 0 to line 6, character 4:
@@ -458,7 +469,8 @@
   File rec-binop-read-write.asl, line 17, characters 10 to 42:
     let x = not_throwing (n - 1) * read_X ();
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects CallsRecursive "not_throwing" and ReadsGlobal "X"
+  ASL Type error:
+    conflicting side effects CallsRecursive "not_throwing" and ReadsGlobal "X"
   [1]
   $ aslref rec-binop-write-throw.asl
   File rec-binop-write-throw.asl, line 4, character 0 to line 11, character 4:
@@ -476,7 +488,8 @@
   File rec-binop-write-throw.asl, line 23, characters 10 to 46:
     let x = throwing (n - 1, FALSE) * write_X ();
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects CallsRecursive "throwing" and WritesGlobal "X"
+  ASL Type error:
+    conflicting side effects CallsRecursive "throwing" and WritesGlobal "X"
   [1]
   $ aslref rec-constant.asl
   $ aslref constant-rec.asl
@@ -505,7 +518,8 @@
   File rec-binop-rec.asl, line 9, characters 10 to 35:
     let x = bar (n - 1) * bar (n - 2);
             ^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: conflicting side effects CallsRecursive "bar" and CallsRecursive "bar"
+  ASL Type error:
+    conflicting side effects CallsRecursive "bar" and CallsRecursive "bar"
   [1]
 
   $ aslref print-var.asl

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -68,7 +68,7 @@
   File binop-write-atc.asl, line 5, characters 10 to 11:
     return (1 as integer {2});
             ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 1 does not belong to type integer {2}.
   [1]
 // We don't need to decide about the following:
@@ -223,7 +223,7 @@
   File config-uses-atc.asl, line 3, characters 9 to 10:
     return 0 as integer {10};
            ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 0 does not belong to type integer {10}.
   [1]
   $ aslref config-uses-unknown.asl
@@ -251,7 +251,7 @@
   File assert-atc.asl, line 3, characters 9 to 10:
     assert 0 as integer {3} == 2;
            ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 0 does not belong to type integer {3}.
   [1]
 
@@ -288,7 +288,7 @@
   File type-func-atc.asl, line 3, characters 9 to 10:
     assert 0 as integer {3} == 2;
            ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 0 does not belong to type integer {3}.
   [1]
   $ aslref type-func-local-var.asl
@@ -309,7 +309,7 @@
   File assert-atc.asl, line 3, characters 9 to 10:
     assert 0 as integer {3} == 2;
            ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 0 does not belong to type integer {3}.
   [1]
   $ aslref assert-read.asl
@@ -349,7 +349,7 @@
   File rec-binop-atc-throw.asl, line 15, characters 37 to 38:
     let x = throwing (n - 1, FALSE) * (2 as integer {3});
                                        ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 2 does not belong to type integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-binop-atc-throw.asl
@@ -417,7 +417,7 @@
   File rec-assert.asl, line 9, characters 34 to 35:
     let x = not_throwing (n - 1) * (2 as integer {3});
                                     ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 2 does not belong to type integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-assert.asl
@@ -437,7 +437,7 @@
   File rec-binop-atc.asl, line 9, characters 34 to 35:
     let x = not_throwing (n - 1) * (2 as integer {3});
                                     ^
-  ASL Execution error: Mismatch type:
+  ASL Dynamic error: Mismatch type:
     value 2 does not belong to type integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-binop-atc.asl
@@ -524,8 +524,8 @@
   File global-throw-initialisation.asl, line 8, characters 0 to 29:
   let X: integer = throwing ();
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Execution error: unexpected exception E thrown during the evaluation of
-    the initialisation of the global storage element "X".
+  ASL Dynamic error: unexpected exception E thrown during the evaluation of the
+    initialisation of the global storage element "X".
   [1]
 
   $ aslref config-type-uses-let.asl

--- a/asllib/tests/stdlib.t/run.t
+++ b/asllib/tests/stdlib.t/run.t
@@ -47,11 +47,11 @@ Tests using ASLRef OCaml primitives for some stdlib functions
 Checking that --no-primitives option actually removes OCaml primitives
 (different errors are produced)
   $ aslref no-primitives-test.asl
-  ASL Execution error: FloorLog2 (primitive) expected an argument greater than 0
+  ASL Dynamic error: FloorLog2 (primitive) expected an argument greater than 0
   [1]
   $ aslref --no-primitives no-primitives-test.asl
   File ASL Standard Library, line 57, characters 11 to 16:
-  ASL Execution error: Assertion failed: (__stdlib_local_a > 0).
+  ASL Dynamic error: Assertion failed: (__stdlib_local_a > 0).
   [1]
 
 Tests using ASL stdlib only

--- a/asllib/tests/typing.t/run.t
+++ b/asllib/tests/typing.t/run.t
@@ -482,7 +482,7 @@ C Tests
   File CNegative12.asl, line 2, characters 56 to 57:
   func negative12{N}(bv : bits(N), N: integer, bv2 : bits({0..N}))
                                                           ^
-  ASL Grammar Error: Cannot parse.
+  ASL Grammar error: Cannot parse.
   [1]
 
 Extra tests by ASLRef team

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -32,7 +32,7 @@ module TypingRule = Instrumentation.TypingRule
 let ( |: ) = Instrumentation.TypingNoInstr.use_with
 
 let undefined_identifier pos x =
-  Error.fatal_from pos (Error.UndefinedIdentifier x)
+  Error.fatal_from pos (Error.UndefinedIdentifier (Static, x))
 
 let thing_equal astutil_equal env = astutil_equal (StaticModel.equal_in_env env)
 let expr_equal = thing_equal expr_equal

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=49ee6327b0e5fb3b96c4972f53ac397c
+Hash=a00efefc29a622abf8dea5ec7adcccdb
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=02737e9d5cff0dc28d65507363222aac
+Hash=4eb08550c3a10a4cc86046c3d40aad09
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=2cdcf8ad89c6b5f3b053f08464282bff
+Hash=975ab5bb1d68495b3432716d0dde7c07
 

--- a/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.res=1)
 Observation YL-01 Always 1 0
-Hash=e9033c7f344ddfc450c07d782801499f
+Hash=f3dd6af1bf415b4f3d06713f0aa82cc3
 

--- a/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation catch-exec-twice Always 1 0
-Hash=e5e5f2e8fbcbcde40b4e2732928a5050
+Hash=c81d90cf213aedd85fb3788475e4211c
 

--- a/herd/tests/instructions/ASL-pseudo-arch/collections-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/collections-01.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T1.0.a=1 /\ 0:T1.0.b=0)
 Observation collections-01 Sometimes 1 3
-Hash=4406602ca1742f126d5fc2909064a894
+Hash=8cc547cfa4493696116b09ca9dc46781
 

--- a/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation for-toofar Always 3 0
-Hash=5c768db5ce592033345db4e0f14fb519
+Hash=8430d4944c6cf4bb93186ce26d5b9fa6
 

--- a/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c=16)
 Observation frozen-tuple-arg Always 1 0
-Hash=314ab2eb500b73c9650161d3b0761e77
+Hash=4559d1c7dc1ba9e74660ae889d452b11
 

--- a/herd/tests/instructions/ASL-pseudo-arch/non-deterministic-optimised.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/non-deterministic-optimised.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation non-deterministic Always 1 0
-Hash=56aa083c71a7e0a71f0ea14c7e5eedcc
+Hash=a28e63ee1269e3e56a35851041d22e2b
 

--- a/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation repeat-toofar Always 3 0
-Hash=c8576b9bfe7ba764bc40326775f1f5f2
+Hash=f5c4f8322980f725f4f1afbf42a60386
 

--- a/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c=3)
 Observation return-tuple Always 1 0
-Hash=488886de3c7dc8b70f1f84a8218939a5
+Hash=9798b9b885e5fde385244558bf917a7c
 

--- a/herd/tests/instructions/ASL-pseudo-arch/try-non-deterministic.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/try-non-deterministic.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation try-non-deterministic Always 2 0
-Hash=1e49211c2970acee7a7ef3ffa6db7d6a
+Hash=2da84543be5d1c634da0b52030193b23
 

--- a/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation while-toofar Always 3 0
-Hash=1944371e3881e1faa3cd7e5e76ebbede
+Hash=c98af998cfb2205ef58ad672d8de3845
 

--- a/herd/tests/instructions/ASL/assign2.litmus.expected
+++ b/herd/tests/instructions/ASL/assign2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c1=3 /\ 0:main.0.c2=5 /\ 0:main.0.c3=15 /\ 0:main.0.c4=3)
 Observation assign2 Always 1 0
-Hash=ffe1b20a379665ec9a55eb84b8c89938
+Hash=3bd80c64eb7f852f6bf1f44f2e74fb1d
 

--- a/herd/tests/instructions/ASL/assign3.litmus.expected
+++ b/herd/tests/instructions/ASL/assign3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.eq=1 /\ 0:main.0.ne=1 /\ 0:main.0.lt=1 /\ 0:main.0.al=1)
 Observation assign3 Always 1 0
-Hash=814fcf39305c24dbb6cfb61d16399d6f
+Hash=b4a97bf2ed1d16fd62bfcf1cf5094b93
 

--- a/herd/tests/instructions/ASL/bitfields1.litmus.expected
+++ b/herd/tests/instructions/ASL/bitfields1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.b=1 /\ 0:main.0.d=1 /\ 0:main.0.e=1)
 Observation bitfields1 Always 1 0
-Hash=63a0d5dbc13bc333c638a694ed5098b5
+Hash=1a72c176d916c3e9e660450951a23d15
 

--- a/herd/tests/instructions/ASL/concat.litmus.expected
+++ b/herd/tests/instructions/ASL/concat.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation Concatenation Always 1 0
-Hash=5634ac93661cca0593834281e3527a6e
+Hash=10f813fa2bf3de56505d0748b0feed85
 

--- a/herd/tests/instructions/ASL/enum-array.litmus.expected
+++ b/herd/tests/instructions/ASL/enum-array.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation enum-arrays Always 1 0
-Hash=1afe33d23cab0ad659f7a38d83d84bac
+Hash=c423da04eb68efead87ea1ce4d7f0443
 

--- a/herd/tests/instructions/ASL/for1.litmus.expected
+++ b/herd/tests/instructions/ASL/for1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.s=110)
 Observation for1 Always 1 0
-Hash=ca041363e4fb47589ccab6785acf63e2
+Hash=443b8ee02aeecbe24c66beff7587eec4
 

--- a/herd/tests/instructions/ASL/func3.litmus.expected
+++ b/herd/tests/instructions/ASL/func3.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=3 /\ 0:main.0.b=3 /\ 0:main.0.c=7 /\ 0:f3_storage=12 /\ 0:f4_storage=15)
 Observation func3 Always 1 0
-Hash=c5ce49ec91c0aa0740fde45c660f0c88
+Hash=a6b5ea375c3b3b41b6c4a7dfbf5ffed2
 

--- a/herd/tests/instructions/ASL/func4.litmus.expected
+++ b/herd/tests/instructions/ASL/func4.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=0 /\ 0:main.0.b=1 /\ 0:main.0.c=5)
 Observation func4 Always 1 0
-Hash=c1f23d7490501e528488968af67127b6
+Hash=bf28da930a8c5c631cf947988c2d7b79
 

--- a/herd/tests/instructions/ASL/globals.litmus.expected
+++ b/herd/tests/instructions/ASL/globals.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation globals Always 1 0
-Hash=d0563986d4dde6e106eea7a71b1746bd
+Hash=6b94e12504c9246f4c9a249e1752aea7
 

--- a/herd/tests/instructions/ASL/no-main.litmus.expected-failure
+++ b/herd/tests/instructions/ASL/no-main.litmus.expected-failure
@@ -1,1 +1,1 @@
-Warning: ASL Error: Undefined identifier: 'main'
+Warning: ASL Dynamic error: Undefined identifier: 'main'

--- a/herd/tests/instructions/ASL/while1.litmus.expected
+++ b/herd/tests/instructions/ASL/while1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.y=6 /\ 0:main.0.x=0)
 Observation while1 Always 1 0
-Hash=a4fc90ff446899aab352b3414f702faa
+Hash=d421048c7b83c6fb37efef3f99dc9169
 

--- a/herd/tests/instructions/ASL/while2.litmus.expected
+++ b/herd/tests/instructions/ASL/while2.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.z=0 /\ 0:main.0.x=2)
 Observation while2 Always 1 0
-Hash=3a768392abfbae45e605362b59dff920
+Hash=46908835f4dd6e9a2744c506dbc1b4c9
 


### PR DESCRIPTION
**ASL-869** (thanks Alfie Powers for the report)
- Fix errors for out-of-bounds accesses of arrays/bit vectors
- Ensure that start positions of zero-width slices are still bounds-checked

**Error messages**
- Consistently use "dynamic error" (not "execution error") in line with the reference (thanks Alfie Powers for the report)
- Make error message prefixes more consistent

**Other fixes**
- Allow `debug` printing to be `pure`/`readonly` - it is implementation-specific, non-ASL1.0 behaviour
- Rename some flags to clarify they produce warnings (thanks Scott Douglass for the report)
- Fix test output in reference document - I'm not sure how this passed CI