### PR TITLE
[asl] Fix an omission in #1402

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1644,7 +1644,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
            looks like a function call may really be a getter call *)
         | _, ST_Getter, ST_Function -> true
         (* V0 compatibility: support for calling empty getters/setters *)
-        | V0, ST_EmptyGetter, ST_Function -> true
+        | V0, ST_EmptyGetter, (ST_Getter | ST_Function) -> true
         | V0, ST_EmptySetter, ST_Setter -> true
         | _ -> false)
       @@ fun () -> fatal_from ~loc (MismatchedReturnValue (Static, name))

--- a/asllib/tests/regressions.t/asl1-calls-asl0-accessor.asl
+++ b/asllib/tests/regressions.t/asl1-calls-asl0-accessor.asl
@@ -2,5 +2,6 @@ func main() => integer
 begin
     - = ZeroExtend{64}(Foo());
     Foo() = Zeros{32};
+    Foo()[0] = '1';
     return 0;
 end;


### PR DESCRIPTION
Desugaring of read-modify-write produces an `ST_Getter` call, which was missed in #1402.