### PR TITLE
[litmus,vmsa] Less radical attribute change check

### DIFF
--- a/lib/AArch64PteVal.ml
+++ b/lib/AArch64PteVal.ml
@@ -174,6 +174,9 @@ module Attrs = struct
   let as_kvm_symbols = function
     | Normal n -> NormalAttrs.as_kvm_symbols n
     | Device d -> DeviceAttrs.as_kvm_symbols d
+
+  let is_default = eq default
+
 end
 
 
@@ -237,7 +240,9 @@ and pp_el0 hexa ok = pp_int_field hexa ok "el0" (fun p -> p.el0)
 and pp_attrs compat ok = pp_field ok
     (fun a -> sprintf (if compat then "%s" else "attrs:(%s)") (Attrs.pp a)) Attrs.eq (fun p -> p.attrs)
 
-let is_default t =  eq_props prot_default t
+let is_default t = eq_props prot_default t
+
+let is_default_attrs t = Attrs.is_default t.attrs
 
 (* If showall is true, field will always be printed.
    Otherwise, field will be printed only if non-default.

--- a/lib/AArch64PteVal.mli
+++ b/lib/AArch64PteVal.mli
@@ -56,6 +56,9 @@ val of_pte : string -> t (* Default value for pte page table entry *)
 (* Flags have default values *)
 val is_default : t -> bool
 
+(* Attributes have the defaults values *)
+val is_default_attrs : t -> bool
+
 (* Finish parsing *)
 val tr : ParsedPteVal.t -> t
 val pp_norm : ParsedPteVal.t -> string

--- a/lib/pteVal.ml
+++ b/lib/pteVal.ml
@@ -22,6 +22,8 @@ module type S = sig
   val default : string -> t
   val of_pte : string -> t
   val is_default : t -> bool
+  (*  Attributes have the default values *)
+  val is_default_attrs : t -> bool
 
   val pp : bool -> t -> string
   val pp_v : t -> string
@@ -58,6 +60,7 @@ module No = struct
     let default _ = ()
     let of_pte _ = ()
     let is_default _ = true
+    let is_default_attrs _ = true
     let pp _ _ = "()"
     let pp_v _ = "()"
     let pp_hash _ = "()"

--- a/lib/pteVal.mli
+++ b/lib/pteVal.mli
@@ -22,6 +22,8 @@ module type S = sig
   val default : string -> t
   val of_pte : string -> t
   val is_default : t -> bool
+  (* Attributes have the default values *)
+  val is_default_attrs : t -> bool
 
   val pp : bool -> t -> string
   val pp_v : t -> string

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1546,11 +1546,8 @@ module Make
 
       let memattrs_change a pte_init =
         match Misc.Simple.assoc_opt a pte_init with
-        | Some (V (_,pteval)) when not (A.V.PteVal.is_default pteval) -> begin
-            match A.V.PteVal.get_attrs pteval with
-            | _::_ -> true
-            | [] -> false
-        end
+        | Some (V (_,pteval)) ->
+            not (A.V.PteVal.is_default_attrs pteval)
         | _ -> false
 
       let init_mem_loc indent clean env test a =


### PR DESCRIPTION
According to some comment in code introduced by PR #1117, some cache flush after test run is performed when there is a risk of writing to some location with non-default attributes.

This risk is identified the predicate `memattrs_change` that checks the following two properties:
 1. The location PTE value is set to a non-default initial value. Notice that this check does not take attributes into account.
 2. This initial value has some attributes.

Running a test on a Raspberry P5B, we experienced some deadlock, or extreme slowdown due to the extra cache flush. Notice that the test ignores memory attributes:
```
AArch64 MP+UpdateAF
TTHM=P0:HD
{
0:X1=x; 1:X1=x;
0:X3=y; 1:X3=y;
1:X2=1;
pte_x=(af:0);
1:X6=pte_x;
1:X4=(oa:phy_x,af:0)
}
P0          | P1              ;
LDR W0,[X1] | STR W2,[X3]     ;
DMB LD      | SWPL X4,X5,[X6] ;
LDR W2,[X3] |                 ;

exists
  0:X2=0 /\ 1:X5=(oa:phy_x,af:0) /\ [PTE(x)] = (oa:PA(x))

```

We attempt to fix the problem by changing the predicate `memattrs_change` that now checks, as its name suggests, that a page table entry attributes are initialised to non-default values. As a result no corrective cache flush is emitted and the test runs in decent time.