### PR TITLE
[build] Update minimal versions in the .opam file

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -25,9 +25,13 @@ jobs:
         cfg:
           - ocaml-version: "4.08.1"
             with-fmt: false
+            with-mins: true
+            dune-cache: "enabled"
             job-name: "OCaml v4.08"
           - ocaml-version: "5.2"
             with-fmt: true
+            with-mins: false
+            dune-cache: "enabled-except-user-rules"
             job-name: "OCaml v5.2, with formatting check"
 
     name: Make test on ${{ matrix.cfg.job-name }}
@@ -35,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      DUNE_CACHE: 'enabled-except-user-rules'
+      DUNE_CACHE: ${{ matrix.cfg.dune-cache }}
 
     steps:
       - name: Checkout tree
@@ -47,7 +51,11 @@ jobs:
           ocaml-compiler: ${{ matrix.cfg.ocaml-version }}
           dune-cache: true
 
+      - run: opam install . --deps-only --with-test --solver=builtin-mccs+glpk --criteria="-new"
+        if: ${{ matrix.cfg.with-mins }}
+
       - run: opam install . --deps-only --with-test
+        if: ${{ !matrix.cfg.with-mins }}
 
       - run: opam exec -- make build DUNE_PROFILE=dev
 

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -16,9 +16,10 @@ install: [make "install" "PREFIX=%{prefix}%"]
 # @todo Add "build-test" field
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune"  {= "3.19.0" }
-  "menhir" {= "20200123"}
+  "dune"  {>= "3.17" }
+  "menhir" {>= "20240715"}
   "zarith" {>= "1.13"}
+  "ocamlfind" {>= "1.9.8"}
   "conf-which"
 ]
 conflicts: ["ocaml-option-bytecode-only"]

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -16,8 +16,8 @@ install: [make "install" "PREFIX=%{prefix}%"]
 # @todo Add "build-test" field
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune"  {>= "2.7" }
-  "menhir" {>= "20200123"}
+  "dune"  {= "3.19.0" }
+  "menhir" {= "20200123"}
   "zarith" {>= "1.13"}
   "conf-which"
 ]


### PR DESCRIPTION
Tested with script:
```
opam switch create  TST 4.08.1
eval $(opam env --switch=TST)
opam install conf-which
opam pin dune 2.9.3
opam pin menhir 20200123
opam pin zarith  1.13
make all test PREFIX=/opt/TST
```