### PR TITLE
[ASL-839] Add a flag for enabling GNU-style errors

### DIFF
--- a/asllib/tests/regressions.t/gnu-errors.asl
+++ b/asllib/tests/regressions.t/gnu-errors.asl
@@ -1,0 +1,12 @@
+func fact()
+begin
+  fact();
+end;
+
+func main() => integer
+begin
+  var x : array[[10]] of integer;
+  var y : integer = 11;
+  - = x[[y]];
+  return 0;
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -513,6 +513,11 @@ Required tests:
   ASL Grammar error: Obsolete syntax: Expression-level 'elsif'.
   [1]
 
+  $ aslref --gnu-errors gnu-errors.asl
+  aslref: gnu-errors.asl:1:0: ASL Warning: the recursive function fact has no recursive limit annotation.
+  aslref: :0:-1: ASL Dynamic error: Mismatch type: value 11 does not belong to type integer {0..9}.
+  [1]
+
 Base values
   $ aslref base_values.asl
   File base_values.asl, line 5, characters 2 to 28:


### PR DESCRIPTION
The flag is `--gnu-errors`. Required slight refactoring in `aslref.ml`, as the default error printing mechanism for any use of `fatal_from` (appearing in e.g. both `Typing.ml` and `Native.ml`) was not sensitive to the specified `output_format`.