### PR TITLE
[tests] Two enhancements for catalogue regression test

### DIFF
--- a/internal/lib/index.ml
+++ b/internal/lib/index.ml
@@ -1,0 +1,20 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris, France.                                       *)
+(*                                                                          *)
+(* Copyright 2025-present Institut National de Recherche en Informatique et *)
+(* en Automatique, ARM Ltd and the authors. All rights reserved.            *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Manage "@..." index files *)
+
+let of_file idx = Misc.expand_argv [idx]
+

--- a/internal/lib/index.mli
+++ b/internal/lib/index.mli
@@ -1,0 +1,19 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris, France.                                       *)
+(*                                                                          *)
+(* Copyright 2025-present Institut National de Recherche en Informatique et *)
+(* en Automatique, ARM Ltd and the authors. All rights reserved.            *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+(** Manage "@..." index files *)
+
+val of_file : string -> string list


### PR DESCRIPTION
  1. Specify tests with the new option -index-path. Using this option overrides the default behaviour of reading test names from the shelf file.
  2. Better formatted error message when some errors occurred while running herd7.