### PR TITLE
[herd] New effect selection in diagrams

### DIFF
--- a/herd/Pretty.ml
+++ b/herd/Pretty.ml
@@ -93,7 +93,7 @@ module Make (S:SemExtra.S) : S with module S = S  = struct
 
   let show_all_events = match PC.showevents with
   | AllEvents -> true
-  | MemEvents|NonRegEvents|MemFenceEvents -> false
+  | MemEvents|NonRegEvents|MemFenceEvents|NonBranchEvents -> false
 
 
 (* Printing the program with the nice_prog field *)
@@ -1520,6 +1520,7 @@ module Make (S:SemExtra.S) : S with module S = S  = struct
   | MemEvents ->  E.is_mem
   | NonRegEvents -> (fun e -> not (E.is_reg_any e))
   | MemFenceEvents -> let open Misc in E.is_mem ||| E.is_barrier ||| E.is_fault
+  | NonBranchEvents -> (fun e -> not (E.is_commit e))
 
   let select_event = let open Misc in select_event &&& select_non_init
 

--- a/herd/prettyConf.ml
+++ b/herd/prettyConf.ml
@@ -87,20 +87,23 @@ type showevents =
   | MemEvents
   | NonRegEvents
   | MemFenceEvents
+  | NonBranchEvents
 
-let tags_showevents = ["all"; "mem"; "noregs";"memf";]
+let tags_showevents = ["all"; "mem"; "noregs";"memf";"nobranches"]
 
 let pp_showevents = function
   | AllEvents -> "all"
   | MemEvents -> "mem"
   | NonRegEvents -> "noregs"
   | MemFenceEvents -> "memfence"
+  | NonBranchEvents -> "nobranches"
 
 let parse_showevents = function
   | "all"  -> Some AllEvents
   | "mem"|"memory" -> Some MemEvents
-  | "noregs" -> Some NonRegEvents
+  | "noregs"|"noreg" -> Some NonRegEvents
   | "memf"|"memfence"|"memfault" -> Some MemFenceEvents
+  | "nobranches"|"nobranch" -> Some NonBranchEvents
   | _ -> None
 
 

--- a/herd/prettyConf.mli
+++ b/herd/prettyConf.mli
@@ -52,7 +52,9 @@ val pp_dotcom : dotcom -> string
 val parse_dotcom : string -> dotcom option
 
 (* Events shown in figures *)
-type showevents = AllEvents | MemEvents | NonRegEvents | MemFenceEvents
+type showevents =
+  AllEvents | MemEvents | NonRegEvents | MemFenceEvents | NonBranchEvents
+
 
 val tags_showevents : string list
 val pp_showevents : showevents -> string


### PR DESCRIPTION
The new selector `nobranches` selects all effecsts except branch effects.

I can be useful to disaplay diagrams in AArch64+ASL mode, as those include many such effects.