### PR TITLE
[ASL-878] Fix a bug in control-flow analysis

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -3755,9 +3755,12 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             let configs1 = approx_stmt tenv s1 in
             let configs2 = approx_stmt tenv s2 in
             union abs_of_expr (union configs1 configs2)
-        | S_Repeat (body, _, _) | S_For { body } | S_While (_, _, body) ->
+        | S_Repeat (body, _, _) ->
             let body_configs = approx_stmt tenv body in
             union abs_of_expr body_configs
+        | S_For { body } | S_While (_, _, body) ->
+            let body_configs = approx_stmt tenv body in
+            union continuing (union abs_of_expr body_configs)
         | S_Try (body, catchers, otherwise) ->
             let body_abs_configs = approx_stmt tenv body in
             let try_abs_configs =

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -2298,12 +2298,19 @@ can be added, for example, an \unreachablestatementterm.
     \item \Proseeqdef{$\absconfigs$}{the union of the sets $\vs_\vc$ for each \Proseabstractconfiguration{} $\vc$ in $\configsone$}.
   \end{itemize}
 
-  \item \AllApplyCase{loop}
+  \item \AllApplyCase{s\_repeat}
   \begin{itemize}
-    \item $\vs$ matches one of the following statements: a \repeatstatementsterm{} with body statement $\vbody$,
-          a \forstatementterm{} with body statement $\vbody$, or a \whilestatementterm{} with body statement $\vbody$;
+    \item $\vs$ is a \repeatstatementsterm{} with body statement $\vbody$;
     \item applying $\approxstmt$ to $\tenv$ and $\vbody$ yields $\bodyconfigs$;
     \item \Proseeqdef{$\absconfigs$}{the union of $\bodyconfigs$ and $\AbsAbnormal$}.
+  \end{itemize}
+
+  \item \AllApplyCase{s\_while\_for}
+  \begin{itemize}
+    \item $\vs$ matches one of the following statements:
+          a \forstatementterm{} with body statement $\vbody$, or a \whilestatementterm{} with body statement $\vbody$;
+    \item applying $\approxstmt$ to $\tenv$ and $\vbody$ yields $\bodyconfigs$;
+    \item \Proseeqdef{$\absconfigs$}{the union of $\bodyconfigs$, $\AbsAbnormal$, and \\ $\AbsContinuing$}.
   \end{itemize}
 
   \item \AllApplyCase{s\_cond}
@@ -2388,11 +2395,18 @@ can be added, for example, an \unreachablestatementterm.
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[loop]{
+\inferrule[s\_repeat]{
+  \approxstmt(\tenv, \vbody) \typearrow \bodyconfigs
+}{
+  \approxstmt(\tenv, \overname{\SRepeat(\vbody, \Ignore, \Ignore)}{\vs}) \typearrow \overname{\bodyconfigs \cup \{\AbsAbnormal\}}{\absconfigs}
+}
+\end{mathpar}
+
+\begin{mathpar}
+\inferrule[s\_while\_for]{
   {
   \left(
   \begin{array}{rcll}
-    \vs &=& \SRepeat(\vbody, \Ignore, \Ignore) &\lor\\
     \vs &=& \SFor \{ \Forbody : \vbody, \ldots \} &\lor\\
     \vs &=& \SWhile(\Ignore, \Ignore, \vbody) &
   \end{array}
@@ -2400,7 +2414,7 @@ can be added, for example, an \unreachablestatementterm.
   }\\
   \approxstmt(\tenv, \vbody) \typearrow \bodyconfigs\\
 }{
-  \approxstmt(\tenv, \overname{\SCond(\Ignore, \vsone, \vstwo)}{\vs}) \typearrow \overname{\bodyconfigs \cup \{\AbsAbnormal\}}{\absconfigs}
+  \approxstmt(\tenv, \vs) \typearrow \overname{\bodyconfigs \cup \{\AbsAbnormal, \AbsContinuing\}}{\absconfigs}
 }
 \end{mathpar}
 
@@ -2409,7 +2423,7 @@ can be added, for example, an \unreachablestatementterm.
   \approxstmt(\tenv, \vsone) \typearrow \configsone\\
   \approxstmt(\tenv, \vstwo) \typearrow \configstwo
 }{
-  \approxstmt(\tenv, \overname{\STry(\vbody, \vsone, \vstwo)}{\vs}) \typearrow \overname{\{\AbsAbnormal\} \cup \vsone \cup \vstwo}{\absconfigs}
+  \approxstmt(\tenv, \overname{\SCond(\Ignore, \vsone, \vstwo)}{\vs}) \typearrow \overname{\{\AbsAbnormal\} \cup \vsone \cup \vstwo}{\absconfigs}
 }
 \end{mathpar}
 

--- a/asllib/tests/control-flow.t/for-noreturn.asl
+++ b/asllib/tests/control-flow.t/for-noreturn.asl
@@ -1,0 +1,9 @@
+type myexception of exception{-};
+
+noreturn func Foo()
+begin
+  for i = 1 to 0 do
+    throw myexception{-};
+  end;
+  // implicit `return` here
+end;

--- a/asllib/tests/control-flow.t/repeat-noreturn.asl
+++ b/asllib/tests/control-flow.t/repeat-noreturn.asl
@@ -1,0 +1,11 @@
+type myexception of exception{-};
+
+var b : boolean;
+
+noreturn func Foo()
+begin
+  repeat
+    throw myexception{-};
+  until b looplimit 10;
+  // implicit `return` here
+end;

--- a/asllib/tests/control-flow.t/run.t
+++ b/asllib/tests/control-flow.t/run.t
@@ -84,3 +84,23 @@
   ASL Type error: not all control flow paths of the function "test0" are
     guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
+
+  $ aslref --no-exec while-noreturn.asl
+  File while-noreturn.asl, line 7, character 2 to line 9, character 6:
+    while b looplimit 10 do
+      throw myexception{-};
+    end;
+  ASL Type error: the function "Foo" is qualified with noreturn but may return
+    on some control flow path.
+  [1]
+
+  $ aslref --no-exec for-noreturn.asl
+  File for-noreturn.asl, line 5, character 2 to line 7, character 6:
+    for i = 1 to 0 do
+      throw myexception{-};
+    end;
+  ASL Type error: the function "Foo" is qualified with noreturn but may return
+    on some control flow path.
+  [1]
+
+  $ aslref --no-exec repeat-noreturn.asl

--- a/asllib/tests/control-flow.t/while-noreturn.asl
+++ b/asllib/tests/control-flow.t/while-noreturn.asl
@@ -1,0 +1,11 @@
+type myexception of exception{-};
+
+var b : boolean;
+
+noreturn func Foo()
+begin
+  while b looplimit 10 do
+    throw myexception{-};
+  end;
+  // implicit `return` here
+end;


### PR DESCRIPTION
`while`- and `for`-loop bodies may never execute, so conservatively they must be considered possibly "continuing".