### PR TITLE
[asl] fix control-flow analysis bug

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -3753,7 +3753,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             union abs_of_expr (union configs1 configs2)
         | S_Repeat (body, _, _) | S_For { body } | S_While (_, _, body) ->
             let body_configs = approx_stmt tenv body in
-            union abs_of_expr body_configs
+            union (union abs_of_expr body_configs) continuing
         | S_Try (body, catchers, otherwise) ->
             let body_abs_configs = approx_stmt tenv body in
             let try_abs_configs =

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -2303,7 +2303,8 @@ can be added, for example, an \unreachablestatementterm.
     \item $\vs$ matches one of the following statements: a \repeatstatementsterm{} with body statement $\vbody$,
           a \forstatementterm{} with body statement $\vbody$, or a \whilestatementterm{} with body statement $\vbody$;
     \item applying $\approxstmt$ to $\tenv$ and $\vbody$ yields $\bodyconfigs$;
-    \item \Proseeqdef{$\absconfigs$}{the union of $\bodyconfigs$ and $\AbsAbnormal$}.
+    \item \Proseeqdef{$\absconfigs$}{the union of $\bodyconfigs$, $\AbsAbnormal$, \\
+          and $\AbsContinuing$}.
   \end{itemize}
 
   \item \AllApplyCase{s\_cond}
@@ -2400,7 +2401,12 @@ can be added, for example, an \unreachablestatementterm.
   }\\
   \approxstmt(\tenv, \vbody) \typearrow \bodyconfigs\\
 }{
-  \approxstmt(\tenv, \overname{\SCond(\Ignore, \vsone, \vstwo)}{\vs}) \typearrow \overname{\bodyconfigs \cup \{\AbsAbnormal\}}{\absconfigs}
+  {
+  \begin{array}{r}
+  \approxstmt(\tenv, \overname{\SCond(\Ignore, \vsone, \vstwo)}{\vs}) \typearrow \\
+  \overname{\bodyconfigs \cup \{\AbsAbnormal,\AbsContinuing\}}{\absconfigs}
+  \end{array}
+  }
 }
 \end{mathpar}
 


### PR DESCRIPTION
The analysis did not raise an error on the following example, since it did not consider that a loop may exit without any iterations.
```
type myexception of exception{-};

noreturn func f3()
begin
    while FALSE looplimit 10 do
        throw myexception{-};
    end;
    // implicit `return` here
end; 
```
