### PR TITLE
[catalogue] Remove reference to nonexistent LB-tagfault+ctrl+dmb.ldpt…

### DIFF
--- a/catalogue/aarch64-MTE/tests/from-tagcheck-async/@all
+++ b/catalogue/aarch64-MTE/tests/from-tagcheck-async/@all
@@ -1,6 +1,5 @@
 LB-notagfault+po+dmb.ldpt--async.litmus
 LB-tagfault+addr+dmb.ldpt--async.litmus
-LB-tagfault+ctrl+dmb.ldpt--async.litmus
 LB-tagfault+ctrl+dmb.ldpt--async.mod.litmus
 LB-tagfault+data+dmb.ldpt--async.litmus
 LB-tagfault+dmb.ish+dmb.ldpt--async.litmus


### PR DESCRIPTION
…--async.litmus

`LB-tagfault+ctrl+dmb.ldpt--async.litmus` got replaced with `LB-tagfault+ctrl+dmb.ldpt--async.mod.litmus` in 1931c62ce5b4 ("Updates to the aarch64-MTE catalogue in order to avoid spurious warnings into stderr when running herd regression tests"), yet has remained referenced in @all which triggers

Warning: File "catalogue/aarch64-MTE/tests/from-tagcheck-async/LB-tagfault+ctrl+dmb.ldpt--async.litmus": open_in failed: catalogue/aarch64-MTE/tests/from-tagcheck-async/LB-tagfault+ctrl+dmb.ldpt--async.litmus: No such file or directory

Let's remove reference to nonexistent `LB-tagfault+ctrl+dmb.ldpt--async.litmus`