### PR TITLE
[catalogue] Fix types for some MTE tests

### DIFF
--- a/catalogue/aarch64-MTE/tests/asorted/LB+dmb.sypp+datapt-lrstt.litmus
+++ b/catalogue/aarch64-MTE/tests/asorted/LB+dmb.sypp+datapt-lrstt.litmus
@@ -1,12 +1,13 @@
 AArch64 LB+dmb.sypp+datapt-lrstt
 Variant=memtag,sync
 {
-    y=x:green;
+    int *y=x:green;
     0:X1=x:green; 0:X2=x:red; 0:X3=y;
     1:X1=x:red; 1:X3=y;
 }
 P0           | P1           ;
  LDR W0,[X1] |  LDR X2,[X3] ;
  DMB SY      |  STG X2,[X1] ;
- STR X2,[X3] |  STR W0,[X1] ;
+ STR X2,[X3] |  MOV W0,#1   ;
+             |  STR W0,[X1] ;
 exists (0:X0=1 /\ 1:X2=x:red /\ ~fault(P1))

--- a/catalogue/aarch64-MTE/tests/asorted/MP+dmb.sypp+datapt-lrstt-addrpp.litmus
+++ b/catalogue/aarch64-MTE/tests/asorted/MP+dmb.sypp+datapt-lrstt-addrpp.litmus
@@ -2,7 +2,7 @@ AArch64 MP+dmb.sypp+datapt-lrstt-addrpp
 (* PPODA feat. Imp Tag Read *)
 Variant=memtag,sync
 {
-    y=z:green;
+    int *y=z:green;
     0:X1=x; 0:X2=z:red; 0:X3=y;
     1:X1=x; 1:X3=y; 1:X5=z:red;
 }

--- a/catalogue/aarch64-MTE/tests/asorted/MP+dmb.sypp+datapt-lrstt.litmus
+++ b/catalogue/aarch64-MTE/tests/asorted/MP+dmb.sypp+datapt-lrstt.litmus
@@ -1,7 +1,7 @@
 AArch64 MP+dmb.sypp+datapt-lrstt
 Variant=memtag,sync
 {
-    y=x:green;
+    int *y=x:green;
     0:X1=x:green; 0:X2=x:red; 0:X3=y;
     1:X1=x:red; 1:X3=y;
 }

--- a/catalogue/aarch64-MTE/tests/asorted/S+dmb.sypp+datapt-lrstt.litmus
+++ b/catalogue/aarch64-MTE/tests/asorted/S+dmb.sypp+datapt-lrstt.litmus
@@ -1,7 +1,7 @@
 AArch64 S+dmb.sypp+datapt-lrstt
 Variant=memtag,sync
 {
-    y=x:green;
+    int *y=x:green;
     0:X1=x:green; 0:X2=x:red; 0:X3=y;
     1:X1=x:red; 1:X3=y;
 }

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+acq_and_ctrl--async.mod.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+acq_and_ctrl--async.mod.litmus
@@ -3,7 +3,7 @@ Hash=24993b413a72f0ef05ab25dee090d0ef
 Variant=memtag,async
 
 {
- int64_t y=z;
+ int *y=z;
  0:X3=x:red; 0:X1=x:green; 0:X2=y:green;
  1:X1=x:red; 1:X2=y:green;
 }

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+acqrel_and_ctrl--async.mod.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+acqrel_and_ctrl--async.mod.litmus
@@ -3,7 +3,7 @@ Hash=24754fde70fb1eab41e6ce7bfd9e41e7
 Variant=memtag,async
 
 {
- int64_t y=z;
+ int *y=z;
  0:X3=x:red; 0:X1=x:green; 0:X2=y:green;
  1:X1=x:red; 1:X2=y:green; 1:X9=w;
 }

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+ctrl--async.mod.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+ctrl--async.mod.litmus
@@ -3,7 +3,7 @@ Hash=7f9a4a610fcb41dde699c46719b74a12
 Variant=memtag,async
 
 {
- int64_t y=z;
+ int *y=z;
  0:X3=x:red; 0:X1=x:green; 0:X2=y:green;
  1:X1=x:red; 1:X2=y:green;
 }

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+dmb.ld_and_ctrl--async.mod.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP+dmb.st+dmb.ld_and_ctrl--async.mod.litmus
@@ -3,7 +3,7 @@ Hash=643ca08fe1608191f919b983cdb81929
 Variant=memtag,async
 
 {
- int64_t y=z;
+ int *y=z;
  0:X3=x:red; 0:X1=x:green; 0:X2=y:green;
  1:X1=x:red; 1:X2=y:green;
 }

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP-realloc--async.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-async/MP-realloc--async.litmus
@@ -3,7 +3,7 @@ Hash=e304328326d20870aae762684ffd84d5
 Variant=memtag,async
 
 {
- int64_t y=z;
+ int *y=z;
  0:X3=x:red; 0:X5=z; 0:X1=x:green; 0:X2=y:green;
  1:X5=z; 1:X1=x:red; 1:X11=x:red; 1:X2=y:green;
 }

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-async/S+dmb.st+acq_and_ctrl--async.mod.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-async/S+dmb.st+acq_and_ctrl--async.mod.litmus
@@ -3,7 +3,7 @@ Hash=0bd9ccac3cdfb7e247b60ea71d96f7f3
 Variant=memtag,async
 
 {
- int64_t y=z;
+ int *y=z;
  0:X3=x:red; 0:X1=x:green; 0:X2=y:green;
  1:X1=x:red; 1:X2=y:green;
 }

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-async/S+dmb.st+acqrel_and_ctrl--async.mod.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-async/S+dmb.st+acqrel_and_ctrl--async.mod.litmus
@@ -3,7 +3,7 @@ Hash=fb28d3ce8c066c05be9b4437d64af80d
 Variant=memtag,async
 
 {
- int64_t y=z;
+ int *y=z;
  0:X3=x:red; 0:X1=x:green; 0:X2=y:green;
  1:X1=x:red; 1:X2=y:green; 1:X9=w;
 }

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-async/S+dmb.st+dmb.ld_and_ctrl--async.mod.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-async/S+dmb.st+dmb.ld_and_ctrl--async.mod.litmus
@@ -3,7 +3,7 @@ Hash=bd125569c5780e9eecd6798f511674ad
 Variant=memtag,async
 
 {
- int64_t y=z;
+ int *y=z;
  0:X3=x:red; 0:X1=x:green; 0:X2=y:green;
  1:X1=x:red; 1:X2=y:green;
 }

--- a/catalogue/aarch64-MTE/tests/to-tagcheck-sync/MP-realloc--sync.litmus
+++ b/catalogue/aarch64-MTE/tests/to-tagcheck-sync/MP-realloc--sync.litmus
@@ -3,7 +3,7 @@ Hash=b4c36fd1761707b73ee557f156fa1286
 Variant=memtag,sync
 
 {
- int64_t y=z;
+ int *y=z;
  0:X3=x:red; 0:X5=z; 0:X1=x:green; 0:X2=y:green;
  1:X5=z; 1:X1=x:red; 1:X11=x:red; 1:X2=y:green;
 }


### PR DESCRIPTION
Some tests pass a tag as if it were a plain value. Since a tag travels with the address, these variables are effectively pointers. Two patterns show up:

- `y = x:green` where `y` is (implicitly) an integer but `x:green` is a tagged pointer;
- (an attempted workaround?) `int64_t y = z` to make the storage large enough for a pointer.

Switch the left-hand side to a pointer type, which handles both cases:

- `int *y = x:green;`
- `int *y = z;`

Update affected MTE tests accordingly.