### PR TITLE
[herd] Fixing bug with -through all option in herd web interface

### DIFF
--- a/herd-www/jerd.ml
+++ b/herd-www/jerd.ml
@@ -39,6 +39,30 @@ let load_config s =
   LexConf_herd.lex found
 
 
+
+type webOpts = {
+  outputdir : PrettyConf.outputdir_mode;
+  dumpes : bool ;
+  variant : Variant.t -> bool ;
+  through : Model.through ;
+  show : PrettyConf.show ;
+  }
+
+let default : webOpts = {
+  outputdir = PrettyConf.StdoutOutput;
+  dumpes = false;
+  variant = (fun (_v:Variant.t) -> false);
+  through = Model.ThroughNone;
+  show = PrettyConf.ShowAll;
+}
+
+let set_defaults ()  =
+  outputdir := default.outputdir;
+  dumpes := default.dumpes;
+  variant := default.variant;
+  through := default.through;
+  show := default.show
+
 (* Configure parser/models/etc. *)
 let run_herd bell cat litmus cfg =
 
@@ -74,11 +98,8 @@ let run_herd bell cat litmus cfg =
   and litmus_fname = WebInput.set_litmus_str litmus in
   WebInput.register_autoloader ();
   (* web options *)
-  outputdir := PrettyConf.StdoutOutput;
-  dumpes := false;
-  variant := (fun (_v:Variant.t) -> false);
+  set_defaults ();
   load_config cfg_fname;
-  show := PrettyConf.ShowAll;
   (* Do not overide default or config settings by default arguments *)
   begin match cat with
   | "" -> ()


### PR DESCRIPTION
This PR fixes a bug with the `-through all` option in the herd web interface. When the option is added, it runs as expected. However, when it is subsequently removed, the output behaves as though it is still selected.

- The -through option is reset to its default value (none) every time the simulation runs.
- Other options with default values are grouped together with -through in a record.
- A record instance with the defaults is created, and a function sets these options back to defaults whenever a simulation is run.