### PR TITLE
Align the tranliteration of aarch64.cat with the Arm ARM issue L.b

### DIFF
--- a/herd/libdir/aarch64loc.cat
+++ b/herd/libdir/aarch64loc.cat
@@ -17,5 +17,5 @@ let scl = loc
   | (M | DC.CVAU | IC) * (IC.IALLU | IC.IALLUIS)
   | (IC.IALLU | IC.IALLUIS) * (M | DC.CVAU | IC)
  
-let va-loc = (tr-ib; same-low-order-bits; tr-ib^-1) & loc
+let va-loc = ([Imp & TTD & R]; tr-ib; same-low-order-bits; tr-ib^-1; [Imp & TTD & R]) & loc
 let po-va-loc = po & va-loc

--- a/herd/libdir/catdefinitions.tex
+++ b/herd/libdir/catdefinitions.tex
@@ -199,7 +199,10 @@
 
 \newcommand{\sameoa}[2]{#1 and #2 have the Same Output Address}
 \newcommand{\sameloworderbits}[2]{#1 and #2 have the Same Low Order Bits}
+
+\newcommand{\valocemph}[2]{#1 and #2 are to the \emph{Same Virtual Address}}
 \newcommand{\valoc}[2]{#1 and #2 are to the Same Virtual Address}
+\newcommand{\loc}[2]{#1 and #2 are to the same Physical Address}
 \newcommand{\lrsname}{a Local read successor of}
 \newcommand{\lrs}[2]{#2 is a Local read successor of #1}
 \newcommand{\lwfsname}{a Local write or MMU Fault successor of}

--- a/herd/libdir/catdefinitions.tex
+++ b/herd/libdir/catdefinitions.tex
@@ -284,11 +284,11 @@
 \newcommand{\localhwreqsemph}[2]{#1 is \emph{Locally-hardware-required-ordered-before} #2}
 
 \newcommand{\hazobname}{Hazard-ordered-before}
-\newcommand{\hazob}[2]{#1 is Hazard-ordered-before #2}
-\newcommand{\hazobemph}[2]{#1 is \emph{Hazard-ordered-before} #2}
-\newcommand{\Exphazobname}{Explicitly-hazard-ordered-before}
-\newcommand{\Exphazob}[2]{#1 is Explicitly-hazard-ordered-before #2}
-\newcommand{\Exphazobemph}[2]{#1 is \emph{Explicitly-hazard-ordered-before} #2}
+\newcommand{\hazob}[2]{#1 is \hazobname{} #2}
+\newcommand{\hazobemph}[2]{#1 is \emph{\hazobname} #2}
+\newcommand{\Exphazobname}{Explicit-hazard-ordered-before}
+\newcommand{\Exphazob}[2]{#1 is \Exphazobname{} #2}
+\newcommand{\Exphazobemph}[2]{#1 is \emph{\Exphazobname} #2}
 \newcommand{\TTDreadobname}{TTD-read-ordered-before}
 \newcommand{\TTDreadob}[2]{#1 is TTD-read-ordered-before #2}
 \newcommand{\TTDreadobemph}[2]{#1 is \emph{TTD-read-ordered-before} #2}
@@ -305,11 +305,11 @@
 \newcommand{\hwreqs}[2]{#1 is Hardware-required-ordered-before #2}
 \newcommand{\hwreqsemph}[2]{#1 is \emph{Hardware-required-ordered-before} #2}
 \newcommand{\obsname}{Observed-by}
-\newcommand{\obs}[2]{#1 is Observed-by #2}
-\newcommand{\obsemph}[2]{#1 is \emph{Observed-by} #2}
-\newcommand{\Expobsname}{Explicitly-Observed-by}
-\newcommand{\Expobs}[2]{#1 is Explicitly-Observed-by #2}
-\newcommand{\Expobsemph}[2]{#1 is \emph{Explicitly-Observed-by} #2}
+\newcommand{\obs}[2]{#1 is \obsname{} #2}
+\newcommand{\obsemph}[2]{#1 is \emph{\obsname} #2}
+\newcommand{\Expobsname}{Explicit-Observed-by}
+\newcommand{\Expobs}[2]{#1 is \Expobsname{} #2}
+\newcommand{\Expobsemph}[2]{#1 is \emph{\Expobsname} #2}
 \newcommand{\Tagobsname}{Tag-Observed-by}
 \newcommand{\Tagobs}[2]{#1 is \Tagobsname{} #2}
 \newcommand{\Tagobsemph}[2]{#1 is \emph{\Tagobsname{}} #2}

--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -328,7 +328,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
              | Pos s -> sprintf "\\Variant{%s}" s
              | Neg s -> sprintf "\\NotVariant{%s}" s)
             a |> String.concat " and ")
-        d |> String.concat "{} or "
+        d |> String.concat " or "
 
     let pp_vc vc = variant_dnf false vc |> pp_dnf
 

--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -221,10 +221,15 @@ and cons_seqs (fs:exp list) (es:exp list) =
     module Next : sig
       val reset : unit -> unit
       val next : unit -> int
+      val push : unit -> unit
+      val pop : unit -> unit
     end = struct
       let c = ref 1
+      let s = Stack.create ()
       let reset () = c := 1
       let next () = let r = !c in incr c ; r
+      let push () = Stack.push !c s
+      let pop () = c := Stack.pop s
     end
 
     let pp_evt k = sprintf "E\\textsubscript{%d}" k
@@ -452,7 +457,13 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | Op1 (_,ToId,e) -> tr_evts_not e1 @@ flatten_if_not e
       | e -> notItem (tr_rel e1 e2 e)
 
-    and tr_op e1 e2 op es = List.map (tr_rel e1 e2) es |> mk_list op
+    and tr_op e1 e2 op es =
+      let f e = match op with
+      | Union ->
+         Next.push (); let t = tr_rel e1 e2 e in Next.pop () ; t
+      | _ ->
+         tr_rel e1 e2 e in
+      List.map f es |> mk_list op
 
     and tr_plus e1 e2 loc = function
       | Var (_,id) ->


### PR DESCRIPTION
* Fixes the way miaou7 handles indices and whenever possible reuses the same indices as per the behaviour prior to PR #1312.
* Minor fix in the definition of va-loc to improve its transliteration in English.
* Rename the Explicitly-Observed-by and Explicitly-Hazard-ordered-before to Explicit-Observed-by and Explicit-hazard-ordered-before