### PR TITLE
Fix register identifier which causes warning on litmus7

### DIFF
--- a/herd/tests/instructions/AArch64.kvm/A025.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A025.litmus
@@ -10,5 +10,5 @@ L0:             ;
  AT S1E0W, X1   ;
  ISB            ;
  MRS X3, PAR_EL1;
-MOV X2,#1       ;
+MOV W2,#1       ;
 forall(0:X3=parel1_t:(f:1) /\ 0:X2=1)

--- a/herd/tests/instructions/AArch64.kvm/A025.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A025.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:X3=(parel1_t:(f:1)) /\ 0:X2=1)
 Observation A025 Always 1 0
-Hash=276482f76186d3913331805ee47dc615
+Hash=1fda2621ce7823df29288b9085d81031
 


### PR DESCRIPTION
Before the change the following warning was reported: "Register x2 has different types: <int> and <int64_t>". We agreed such warnings must be fixed.