### PR TITLE
[gen] Remove `use_symbolic`, a bug fix for `3b3acf9`. 

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -208,7 +208,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let movi_reg r1 i = I_MOVI_V (r1,i,S_NOEXT)
 
     module Extra = struct
-      let use_symbolic = false
       type reg = A64.reg
       type instruction = A64.pseudo
 

--- a/gen/ARMCompile_gen.ml
+++ b/gen/ARMCompile_gen.ml
@@ -40,7 +40,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let next_reg x = ARM.alloc_reg x
 
    module Extra = struct
-     let use_symbolic = true
      type reg = ARM.reg
      type instruction = ARM.pseudo
      let mov r v = Instruction (I_MOVI (r,v,AL))

--- a/gen/MIPSCompile_gen.ml
+++ b/gen/MIPSCompile_gen.ml
@@ -43,7 +43,6 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
 
 
     module Extra = struct
-      let use_symbolic = true
       type reg = MIPS.reg
       type instruction = MIPS.pseudo
       let mov r v = Instruction (li r v)

--- a/gen/PPCCompile_gen.ml
+++ b/gen/PPCCompile_gen.ml
@@ -155,7 +155,6 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
 
 
     module Extra = struct
-      let use_symbolic = false
       type reg = PPC.reg
       type instruction = PPC.pseudo
       let mov r v = PPC.Instruction (PPC.Pli (r,v))

--- a/gen/RISCVCompile_gen.ml
+++ b/gen/RISCVCompile_gen.ml
@@ -109,7 +109,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
     and sc mo r1 r2 r3 = AV.StoreConditional (wloc,mo,r1,r2,r3)
 
     module Extra = struct
-      let use_symbolic = false
       type reg = AV.reg
       type instruction = AV.pseudo
 

--- a/gen/X86_64Compile_gen.ml
+++ b/gen/X86_64Compile_gen.ml
@@ -102,7 +102,6 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
       I_EFF (I_INC,size_to_inst_size sz,Effaddr_rm64 (Rm64_reg r))
 
     module Extra = struct
-      let use_symbolic = false
       type reg = X86_64.reg
       type instruction = X86_64.pseudo
 

--- a/gen/genUtils.ml
+++ b/gen/genUtils.ml
@@ -23,7 +23,6 @@ end
 
 
 module type Extra = sig
-  val use_symbolic : bool
   type reg
   type instruction
   val mov : reg -> int -> instruction
@@ -48,7 +47,8 @@ module Make(Cfg:Config)(A:Arch_gen.S)
             hence `A.alloc_reg st` will never return `r0`. Given this assumption,
             it is safe to bind `r0` to `loc` (`loc` = `loc0`) here. *)
          let same_loc_match = List.find_opt ( function
-           | (Reg (_,_),Some (A.S loc0)) -> Misc.string_eq loc0 loc
+           | (Reg (_,_),Some (A.S loc0)) ->
+             Misc.string_eq loc0 loc
            | _ -> false ) init in
          match exact_match,same_loc_match with
          | Some (Reg (_,r),Some _), _ -> r,init,st
@@ -56,10 +56,7 @@ module Make(Cfg:Config)(A:Arch_gen.S)
            r,(Reg (p,r),Some (A.S loc))::init,st
          | None, None ->
            (* no previous register assignment, so add new *)
-           let r,st =
-             if Extra.use_symbolic then
-               A.symb_reg (Printf.sprintf "%s%i" loc p),st
-             else A.alloc_reg st in
+           let r,st = A.alloc_reg st in
            r,(Reg (p,r),Some (A.S loc))::init,st
          | _,_ -> Warn.user_error "Unexpected error in `next_init`."
 

--- a/gen/genUtils.mli
+++ b/gen/genUtils.mli
@@ -24,7 +24,6 @@ module type Config = sig
 end
 
 module type Extra = sig
-  val use_symbolic : bool
   type reg
   type instruction
   val mov : reg -> int -> instruction


### PR DESCRIPTION
Fix a problem #1455, introduced by a previous commit, `3b3acf9`. Remove symbolic registers functionality in generation since it is not in use.
