### PR TITLE
[herd,aarch64,ASL] Execute IC/DC/TLBI instructions

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -1344,13 +1344,17 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
     let is_warn = C.variant Variant.Warn && not is_strict
 
     let check_strict test ii =
-      if is_strict then
-        Warn.fatal "No ASL implemention for instruction %s"
-          (A.dump_instruction ii.A.inst);
-      if is_warn then
-        Warn.warn_always "No ASL implemention for instruction %s"
-          (A.dump_instruction ii.A.inst);
-      AArch64Mixed.build_semantics test ii
+      match ii.A.inst with
+      | AArch64Base.(I_IC _|I_DC _|I_TLBI _) -> (* Always execute *)
+          AArch64Mixed.build_semantics test ii
+      | _ ->
+          if is_strict then
+            Warn.fatal "No ASL implemention for instruction %s"
+              (A.dump_instruction ii.A.inst);
+          if is_warn then
+            Warn.warn_always "No ASL implemention for instruction %s"
+              (A.dump_instruction ii.A.inst);
+          AArch64Mixed.build_semantics test ii
 
     let check_cutoff test =
       if not_cutoff then Fun.const true


### PR DESCRIPTION
As, from our standpoint, those instruction do little more than generating specific events, let standard AArch64 semantics handle them.