### PR TITLE
[aslspec] Minor improvements and fixes to aslspec

### DIFF
--- a/asllib/aslspec/AST.ml
+++ b/asllib/aslspec/AST.ml
@@ -17,10 +17,10 @@ type type_term =
   | Label of string
       (** Either a set containing the single value named by the given string or
           a reference to a type with the given name. *)
-  | Powerset of { term : type_term; finite : bool }
+  | Powerset of { term : opt_named_type_term; finite : bool }
       (** A set containing all subsets of the given type. If [finite] is true
           then only the finite subsets are included. *)
-  | Option of type_term
+  | Option of opt_named_type_term
       (** Either the empty set of a set containing a single value of the given
           type. *)
   | LabelledTuple of {
@@ -37,12 +37,16 @@ type type_term =
     }
       (** A set containing all optionally-labelled records formed by the given
           fields. *)
-  | List of { maybe_empty : bool; member_type : type_term }
+  | List of { maybe_empty : bool; member_type : opt_named_type_term }
       (** A set containing all sequences of the given member type. If
           [maybe_empty] is true, the list may also be empty. *)
   | ConstantsSet of string list
       (** A set containing all constants formed by the given names. *)
-  | Function of { from_type : type_term; to_type : type_term; total : bool }
+  | Function of {
+      from_type : opt_named_type_term;
+      to_type : opt_named_type_term;
+      total : bool;
+    }
       (** A set containing all functions formed by the given types. If [total]
           is true, the function is total, otherwise it is partial. *)
 
@@ -114,7 +118,10 @@ module AttributeKey = struct
 end
 
 (** A value associated with an attribute key. *)
-type attribute = StringAttribute of string | MathLayoutAttribute of layout
+type attribute =
+  | StringAttribute of string
+  | MathMacroAttribute of string
+  | MathLayoutAttribute of layout
 
 (** A module for associating attributes with attribute keys. *)
 module Attributes = struct

--- a/asllib/aslspec/SpecParser.mly
+++ b/asllib/aslspec/SpecParser.mly
@@ -152,7 +152,7 @@ let type_attributes ==
 let type_attribute :=
     | PROSE_DESCRIPTION; EQ; template=STRING; { (Prose_Description, StringAttribute template) }
     | template=STRING; { (Prose_Description, StringAttribute template) }
-    | MATH_MACRO; EQ; macro=LATEX_MACRO; { (Math_Macro, StringAttribute macro) }
+    | MATH_MACRO; EQ; macro=LATEX_MACRO; { (Math_Macro, MathMacroAttribute macro) }
     | MATH_LAYOUT; EQ; ~=math_layout; { (Math_Layout, MathLayoutAttribute math_layout) }
 
 let relation_attributes ==
@@ -162,7 +162,7 @@ let relation_attribute :=
     | PROSE_DESCRIPTION; EQ; template=STRING; { (Prose_Description, StringAttribute template) }
     | template=STRING; { (Prose_Description, StringAttribute template) }
     | PROSE_APPLICATION; EQ; template=STRING; { (Prose_Application, StringAttribute template) }
-    | MATH_MACRO; EQ; macro=LATEX_MACRO; { (Math_Macro, StringAttribute macro) }
+    | MATH_MACRO; EQ; macro=LATEX_MACRO; { (Math_Macro, MathMacroAttribute macro) }
     | MATH_LAYOUT; EQ; ~=math_layout; { (Math_Layout, MathLayoutAttribute math_layout) }
 
 let type_variants_with_attributes :=
@@ -183,22 +183,22 @@ let type_term_with_attributes := ~=type_term; ~=type_attributes;
 
 let type_term :=
     | name=IDENTIFIER; { check_definition_name name; Label name }
-    | POWERSET; LPAR; member_type=type_term; RPAR; { Powerset {term=member_type; finite=false} }
-    | POWERSET_FINITE; LPAR; member_type=type_term; RPAR; { Powerset {term=member_type; finite=true} }
-    | OPTION; LPAR; member_type=type_term; RPAR; { Option member_type }
+    | POWERSET; LPAR; ~=opt_named_type_term; RPAR; { Powerset {term=opt_named_type_term; finite=false} }
+    | POWERSET_FINITE; LPAR; ~=opt_named_type_term; RPAR; { Powerset {term=opt_named_type_term; finite=true} }
+    | OPTION; LPAR; ~=opt_named_type_term; RPAR; { Option opt_named_type_term }
     | LPAR; components=tclist1(opt_named_type_term); RPAR; { LabelledTuple {label_opt = None; components} }
     | label=IDENTIFIER; LPAR; components=tclist1(opt_named_type_term); RPAR;
     {   check_definition_name label;
         LabelledTuple {label_opt = Some label; components} }
-    | LIST0; LPAR; member_type=type_term; RPAR; { List { maybe_empty=true; member_type} }
-    | LIST1; LPAR; member_type=type_term; RPAR; { List { maybe_empty=false; member_type}}
+    | LIST0; LPAR; member_type=opt_named_type_term; RPAR; { List { maybe_empty=true; member_type} }
+    | LIST1; LPAR; member_type=opt_named_type_term; RPAR; { List { maybe_empty=false; member_type}}
     | LBRACKET; fields=tclist1(named_type_term); RBRACKET; { make_record fields }
     | label=IDENTIFIER; LBRACKET; fields=tclist1(named_type_term); RBRACKET;
     {   check_definition_name label;
         make_labelled_record label fields }
     | CONSTANTS_SET; LPAR; constants=tclist1(IDENTIFIER); RPAR; { ConstantsSet constants }
-    | FUN; from_type=type_term; ARROW; to_type=type_term; { Function {from_type; to_type; total = true}}
-    | PARTIAL; from_type=type_term; ARROW; to_type=type_term; { Function {from_type; to_type; total = false}}
+    | FUN; from_type=opt_named_type_term; ARROW; to_type=opt_named_type_term; { Function {from_type; to_type; total = true}}
+    | PARTIAL; from_type=opt_named_type_term; ARROW; to_type=opt_named_type_term; { Function {from_type; to_type; total = false}}
 
 let named_type_term ==
     name=IDENTIFIER; COLON; ~=type_term; { (name, type_term) }

--- a/asllib/aslspec/tests.t/relations.spec
+++ b/asllib/aslspec/tests.t/relations.spec
@@ -18,3 +18,10 @@ relation annotate_expr'(input: expr) -> (inferred_type: type)
     prose_description = "infers the type {inferred_type} for the expression {input}",
     prose_application = "annotating the expression {input} yields the type {inferred_type}",
 };
+
+relation annotate_plus(input: Plus(lhs: expr, rhs: expr)) -> (inferred_type: type)
+{
+    prose_description = "infers the type {inferred_type} for the plus expression {input}",
+    prose_application = "annotating the plus expression {input} yields the type {inferred_type}",
+};
+

--- a/asllib/aslspec/tests.t/run.t
+++ b/asllib/aslspec/tests.t/run.t
@@ -13,5 +13,5 @@
   $ aslspec relations.spec --pp > tmp.spec; aslspec tmp.spec
 
 # Test that --pp is idempotent
-  $ aslspec typedefs.spec --pp > tmp1.spec; aslspec tmp1.spec --pp > tmp2.spec; diff tmp1.spec tmp2.spec
-  $ aslspec relations.spec --pp > tmp1.spec; aslspec tmp1.spec --pp > tmp2.spec; diff tmp1.spec tmp2.spec
+  $ aslspec typedefs.spec --pp > tmp1.spec; aslspec tmp1.spec --pp > tmp2.spec; diff --ignore-all-space tmp1.spec tmp2.spec
+  $ aslspec relations.spec --pp > tmp1.spec; aslspec tmp1.spec --pp > tmp2.spec; diff --ignore-all-space tmp1.spec tmp2.spec


### PR DESCRIPTION
- Added proper support for macro attributes in terms of pretty-printing.
- Added identation to attributes in pretty-printing.
- Allowed (optional) naming sub-terms for `option`, `list0`, `list1`, `powerset`, `fun`, and `partial`.
- Droped the check `check_only_top_level_types`, since it looks like we do want to use constants and types defined as variants in relations signatures.
- Removed extra spaces around `\BeginDefineConstant` and `\BeginDefineType`, since they create redundant extra spaces in the PDF. 