### PR TITLE
[aslspec] Fix a `dune` file

### DIFF
--- a/asllib/aslspec/dune
+++ b/asllib/aslspec/dune
@@ -19,3 +19,6 @@
   (with-stdout-to
    %{target}
    (run python3 extract_tokens.py SpecLexer.mll))))
+
+(cram
+ (deps %{bin:aslspec}))


### PR DESCRIPTION
I had local errors as the tests could not find the `aslspec` command.