### PR TITLE
[herd] No more mandatory label  after SVC for ERET to operate

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -3601,10 +3601,11 @@ Arguments:
             >>= do_indirect_jump test [] i ii
 
         | I_ERET ->
-           let eret_to_addr = function
-             | M.A.V.Val(Constant.Label (_, l)) -> B.faultRetT l
-             | _ ->
-                Warn.fatal "Cannot determine ERET target" in
+            let eret_to_addr v =
+              match v2tgt v with
+              | Some tgt -> B.faultRetT tgt
+              | _ ->
+                 Warn.fatal "Cannot determine ERET target" in
            let commit_eret ii =
              M.mk_singleton_es (Act.Commit (Act.ExcReturn,None)) ii in
            commit_eret ii >>=

--- a/herd/branch.ml
+++ b/herd/branch.ml
@@ -58,7 +58,7 @@ module type S = sig
   val  indirectBranchT : v -> Label.Full.Set.t -> bds -> t monad
 (* Conditional branch *)
   val bccT : v -> lbl -> t monad
-  val faultRetT : lbl -> t monad
+  val faultRetT : tgt -> t monad
   (* Faults and syscalls *)
   val fault : bds -> t
   val syscall : bds -> t
@@ -103,7 +103,7 @@ module Make(M:Monad.S) = struct
   let branchT tgt = M.unitT (Jump (Lbl tgt,[]))
   let indirectBranchT v lbls bds = M.unitT (IndirectJump (v,lbls,bds))
   let bccT v lbl = M.unitT (CondJump (v,Lbl lbl))
-  let faultRetT lbl = M.unitT (FaultRet (Lbl lbl))
+  let faultRetT tgt = M.unitT (FaultRet tgt)
   let fault bds = Fault (false,bds)
   let syscall bds = Fault (true,bds)
 end

--- a/herd/tests/instructions/AArch64.kvm/F005.litmus
+++ b/herd/tests/instructions/AArch64.kvm/F005.litmus
@@ -1,0 +1,10 @@
+AArch64 F005
+EL0=P0
+{
+0:X0=0;
+}
+  P0           | P0.F           ;
+ ADD W0,W0,#1  | ADD W0,W0,#1   ;
+ SVC #0        | ERET           ;
+ ADD W0,W0,#1  |                ;
+forall 0:X0=3

--- a/herd/tests/instructions/AArch64.kvm/F005.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/F005.litmus.expected
@@ -1,0 +1,10 @@
+Test F005 Required
+States 1
+0:X0=3;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X0=3)
+Observation F005 Always 1 0
+Hash=da368a7cbd892872d6419160eb88a5f0
+

--- a/herd/tests/instructions/AArch64.kvm/F006.litmus
+++ b/herd/tests/instructions/AArch64.kvm/F006.litmus
@@ -1,0 +1,13 @@
+AArch64 F006
+{
+int x=1;
+0:X0=x;
+[PTE(x)]=(valid:0);
+}
+  P0          | P0.F           ;
+ MOV W1,#2    | MRS X4,ELR_EL1 ;
+ LDR W1,[X0]  | ADD X4,X4,#4   ;
+ MOV W3,#2    | MSR ELR_EL1,X4 ;
+              | ERET           ;
+
+forall 0:X1=2 /\ 0:X3=2

--- a/herd/tests/instructions/AArch64.kvm/F006.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/F006.litmus.expected
@@ -1,0 +1,10 @@
+Test F006 Required
+States 1
+0:X1=2; 0:X3=2;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:X1=2 /\ 0:X3=2)
+Observation F006 Always 1 0
+Hash=17b67b7ad6272e5123d8a392ec52856b
+

--- a/herd/tests/instructions/AArch64.kvm/asl-vmsa.cfg
+++ b/herd/tests/instructions/AArch64.kvm/asl-vmsa.cfg
@@ -10,8 +10,8 @@ nonames A020,A021,A022,F004
 # ADR not handled
 nonames F001,F003,A005
 # ERET not handled
-nonames A018
+nonames A018,F005
 # MRS not handled
-nonames A006
+nonames A006,F006
 # AT not handled
 nonames A024,A025


### PR DESCRIPTION
More specifically,  the instruction `ERET` was not accepting code addresses in the numeric form as introduced by PR #482.  This is now fixed. 

As a consequence a  label is no longer required after the instruction `SVC` or any faulting instruction for explicit handlers to return with `ERET`.