### PR TITLE
[asl] Tweaks around new internal `BIC` operator

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -98,8 +98,9 @@ type binop =
   | `SHR  (** Shift right for ints *)
   | `BV_CONCAT  (** Bit vector concatenation *)
   | `STR_CONCAT  (** String concatenation *)
-  | `BIC  (** Bit clear operation: bitwise and with second argument inverted *)
-  ]
+  | `BIC
+    (** Internal only - bit clear operation: bitwise and with second argument
+        inverted *) ]
 (** Operations on base value of arity two. *)
 
 (* -------------------------------------------------------------------------

--- a/asllib/Interpreter.mli
+++ b/asllib/Interpreter.mli
@@ -77,6 +77,9 @@ module type Config = sig
 
   val track_symbolic_path : bool
   (** Keep track of symbolic paths during execution. *)
+
+  val bit_clear_optimisation : bool
+  (** Interpret [a AND NOT b] as [a BIC b]. *)
 end
 
 module Make (B : Backend.S) (C : Config) : S with module B = B

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -512,6 +512,7 @@ module NativeConfig (I : Instrumentation.SEMINSTR) = struct
   let log_nondet_choice = false
   let display_call_stack_on_error = false
   let track_symbolic_path = false
+  let bit_clear_optimisation = false
 
   module Instr = I
 end

--- a/asllib/Operations.ml
+++ b/asllib/Operations.ml
@@ -95,6 +95,7 @@ let binop_values pos t (op : binop) v1 v2 =
   | `XOR, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
       L_BitVector (Bitvector.logxor b1 b2)
   | `BIC, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
+      (* Internal usage of BIC operator *)
       L_BitVector (Bitvector.logand b1 (Bitvector.lognot b2))
   | `ADD, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
       L_BitVector

--- a/asllib/Operations.ml
+++ b/asllib/Operations.ml
@@ -94,6 +94,8 @@ let binop_values pos t (op : binop) v1 v2 =
       L_BitVector (Bitvector.logand b1 b2)
   | `XOR, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
       L_BitVector (Bitvector.logxor b1 b2)
+  | `BIC, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
+      L_BitVector (Bitvector.logand b1 (Bitvector.lognot b2))
   | `ADD, L_BitVector b1, L_BitVector b2 when bv_same_length b1 b2 ->
       L_BitVector
         Bitvector.(

--- a/asllib/StaticInterpreter.ml
+++ b/asllib/StaticInterpreter.ml
@@ -36,6 +36,7 @@ module InterpConf = struct
   let log_nondet_choice = false (* Not relevant here *)
   let display_call_stack_on_error = false
   let track_symbolic_path = false
+  let bit_clear_optimisation = false
 end
 
 module SB = Native.StaticBackend

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -134,6 +134,7 @@ module Make (Conf : Config) = struct
     let log_nondet_choice = Conf.C.debug.Debug_herd.asl_symb
     let display_call_stack_on_error = Conf.C.debug.Debug_herd.asl_symb
     let track_symbolic_path = true
+    let bit_clear_optimisation = true
 
     module Instr = Asllib.Instrumentation.SemanticsNoInstr
   end


### PR DESCRIPTION
Thanks to Laurent for spotting this bug!
- Add `BIC` to the native interpreter
- Gate usage of `BIC` behind interpreter configuration
- Add comments clarifying it is internal, and not part of ASL1.0

Follows on from #916