### PR TITLE
[litmus] Fix reference to PTE as data symbol

### DIFF
--- a/litmus/compCond.ml
+++ b/litmus/compCond.ml
@@ -64,7 +64,7 @@ module Make (O:Indent.S) (I:CompCondUtils.I) =
            | Some lbl -> OutUtils.fmt_lbl_var proc lbl
            | None -> "UNKNOWN"
            and loc = match loc with
-           | Some loc -> V.pp O.hexa loc
+           | Some loc -> V.pp_v_old loc
            | None -> "UNKNOWN"
            and ft = match ft with
            | None -> "Unknown"

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -449,7 +449,7 @@ module Make
                  let ((p, lbl), loc, ftype) = f in
                  let lbl_cond = match lbl with
                    | None -> ""
-                   | Some s -> sprintf " && instr_symb == %s" (SkelUtil.instr_symb_id (sprintf "P%d_%s" p s))
+                   | Some s -> sprintf " && instr_symb == %s" (SkelUtil.instr_symb_id (OutUtils.fmt_lbl_var p s))
                  and loc_cond = match loc with
                    | None -> ""
                    | Some s -> sprintf " && data_symb == %s" (SkelUtil.data_symb_id (A.V.pp_v_old s))
@@ -976,7 +976,7 @@ module Make
             let ((p, lbl), loc, ft) = f in
             let lbl = match lbl with
               | None -> "UNKNOWN"
-              | Some s -> sprintf "P%d_%s" p s
+              | Some s -> OutUtils.fmt_lbl_var p s
             and loc = match loc with
               | None -> "UNKNOWN"
               | Some s -> A.V.pp_v_old s


### PR DESCRIPTION
Yet another litmus glitch.

Some parenthesis were making their way into a C symbol, resulting in an output C file that does not compile. Fix this.