### PR TITLE
[lib] Fix parser for Morello

### DIFF
--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -691,6 +691,8 @@ instr:
 /* Memory */
 | LDR wxreg COMMA mem_ea
   { let (v,r)   = $2 and (ra,ext) = $4 in I_LDR (v,r,ra,ext) }
+| LDR creg COMMA mem_ea
+  { let (ra,ext) = $4 in I_LDR (V128,$2,ra,ext) }
 | LDRSW xreg COMMA mem_ea
   { let r = $2 and (ra,ext) = $4 in I_LDRSW (r,ra,ext) }
 | LDRSB reg COMMA mem_ea
@@ -759,6 +761,8 @@ instr:
   { I_LDARBH (H,AQ,$2,$5) }
 | STR wxreg COMMA mem_ea
   { let (v,r)   = $2 and (ra,ext) = $4 in I_STR (v,r,ra,ext) }
+| STR creg COMMA mem_ea
+  { let (ra,ext) = $4 in I_STR (V128,$2,ra,ext) }
 | STRB wreg COMMA mem_ea
   { let (ra,idx) = $4 in I_STRBH (B,$2,ra,idx) }
 | STRH wreg COMMA mem_ea


### PR DESCRIPTION
It looks like commit c89a5b581f5d ("[all] AST restructuring for some AArch64 instructions.") accidentally made Morello's C registers not being recognised by LDR/STR instructions. For instance

```
AArch64 A
"DpAddrdWPCs RfeCsCs PodRWCsP Rfe"
Generator=diyone7 (version 7.58+1)
Prefetch=0:x=F,0:y=W,1:y=F,1:x=W
Com=Rf Rf
Orig=DpAddrdWPCs RfeCsCs PodRWCsP Rfe
{
__uint128 y; __uint128 x; __uint128 1:X1;

0:X0=0xffffc0000:x:1; 0:X3=0xffffc0000:y:1;
1:X3=0xffffc0000:y:1; 1:X0=0xffffc0000:x:1;
}
 P0               | P1           ;
 LDR X1,[C0]      | LDR C1,[C3]  ;
 SUB X4,X1,#1     | GCTYPE X1,C1 ;
 AND X4,X4,#4095  | MOV X2,#1    ;
 SCVALUE C4,C3,X4 | STR X2,[C0]  ;
 CSEAL C4,C3,C4   |              ;
 MOV X5,#0        |              ;
 MOV X6,#1        |              ;
 SCVALUE C5,C3,X5 |              ;
 SEAL C5,C5,C6    |              ;
 STR C5,[C4]      |              ;
exists (0:X1=1 /\ 1:X1=1) /\ ~Fault(P0,y)
```

result in

```
$ herd7 -variant morello A.litmus
Warning: File "A.litmus", line 14, characters 24-26: unexpected 'C1' (in prog) (User error)
```

Let's bring C registers back to parser rules for LDR/STR