### PR TITLE
[asl][reference][aslspec] fixed hypertarget one-line-off issue

### DIFF
--- a/asllib/aslspec/tests.t/hello.expected
+++ b/asllib/aslspec/tests.t/hello.expected
@@ -15,12 +15,12 @@
 % Macros for elements
 % -------------------
 
-\DefineType{t}{\hypertarget{type-t}{}$\t$} % EndDefineType
+\DefineType{t}{\texthypertarget{type-t}$\t$} % EndDefineType
 
-\DefineType{s}{\hypertarget{type-s}{}
+\DefineType{s}{
 \begin{flalign*}
-\s \triangleq\ & \pow{\t}\hypertarget{type-A}{}\\
-\cup\ & \A\hypertarget{type-B}{}\\
-\cup\ & \B(\s, \s)\end{flalign*}} % EndDefineType
+\s\texthypertarget{type-s} \triangleq\ & \pow{\t}\\
+\cup\ & \A\mathhypertarget{type-A}\\
+\cup\ & \B(\s, \s)\mathhypertarget{type-B}\end{flalign*}} % EndDefineType
 
 

--- a/asllib/aslspec/tests.t/relations.expected
+++ b/asllib/aslspec/tests.t/relations.expected
@@ -19,31 +19,31 @@
 % Macros for elements
 % -------------------
 
-\DefineType{type}{\hypertarget{ast-type}{}\hypertarget{ast-Int}{}
+\DefineType{type}{
 \begin{flalign*}
-\type \derives\ & \Int\hypertarget{ast-String}{}\\
-|\ & \String\end{flalign*}} % EndDefineType
+\type\texthypertarget{ast-type} \derives\ & \mathhypertarget{ast-Int}\Int\\
+|\ & \String\mathhypertarget{ast-String}\end{flalign*}} % EndDefineType
 
-\DefineType{expr}{\hypertarget{ast-expr}{}\hypertarget{ast-Number}{}
+\DefineType{expr}{
 \begin{flalign*}
-\expr \derives\ & \Number(\overtext{\Int}{\texttt{v}})\hypertarget{ast-Plus}{}\\
-|\ & \Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})\end{flalign*}} % EndDefineType
+\expr\texthypertarget{ast-expr} \derives\ & \mathhypertarget{ast-Number}\Number(\overtext{\Int}{\texttt{v}})\\
+|\ & \Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})\mathhypertarget{ast-Plus}\end{flalign*}} % EndDefineType
 
 \DefineRelation{annotate_expr'}{
-\hypertarget{relation-annotateexpr'}{}
+
 The relation
 \[
-\annotateexpr'(\overtext{\expr}{\texttt{input}}) \;\bigtimes\; \overtext{\type}{\texttt{inferred\_type}}
+\mathhypertarget{relation-annotateexpr'}\annotateexpr'(\overtext{\expr}{\texttt{input}}) \;\bigtimes\; \overtext{\type}{\texttt{inferred\_type}}
 \]
 infers the type $\texttt{inferred\_type}$ for the expression
 $\texttt{input}$
 } % EndDefineRelation
 
 \DefineRelation{annotate_plus}{
-\hypertarget{relation-annotateplus}{}
+
 The relation
 \[
-\annotateplus(\overtext{\Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})}{\texttt{input}}) \;\bigtimes\; \overtext{\type}{\texttt{inferred\_type}}
+\mathhypertarget{relation-annotateplus}\annotateplus(\overtext{\Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})}{\texttt{input}}) \;\bigtimes\; \overtext{\type}{\texttt{inferred\_type}}
 \]
 infers the type $\texttt{inferred\_type}$ for the plus expression
 $\texttt{input}$

--- a/asllib/aslspec/tests.t/typedefs.expected
+++ b/asllib/aslspec/tests.t/typedefs.expected
@@ -21,15 +21,15 @@
 % Macros for elements
 % -------------------
 
-\DefineType{Int}{\hypertarget{type-Int}{}$\Int$} % EndDefineType
+\DefineType{Int}{\texthypertarget{type-Int}$\Int$} % EndDefineType
 
 \DefineConstant{One}{\hypertarget{constant-One}{} $\One$} % EndDefineConstant
 
 \DefineConstant{Two}{\hypertarget{constant-Two}{} $\Two$} % EndDefineConstant
 
-\DefineType{B}{\hypertarget{type-B}{}\hypertarget{type-C}{}
+\DefineType{B}{
 \begin{flalign*}
-\B \triangleq\ & \C\\
+\B\texthypertarget{type-B} \triangleq\ & \mathhypertarget{type-C}\C\\
 \cup\ & \pow{\Int}\\
 \cup\ & \some{\Int}\\
 \cup\ & \KleeneStar{\Int}\\
@@ -38,17 +38,17 @@
 \cup\ & \Int \rightarrow \Int\\
 \cup\ & \Int \partialto \Int\\
 \cup\ & \{\One, \Two\}\\
-\cup\ & (\Int, \Int)\hypertarget{type-Rec}{}\\
-\cup\ & \Rec(\Int, \Int)\\
+\cup\ & (\Int, \Int)\\
+\cup\ & \Rec(\Int, \Int)\mathhypertarget{type-Rec}\\
 \cup\ & \left[\begin{array}{lcl}
               \text{f} & : & \Int\\
               \text{g} & : & (\Int, \Int) \rightarrow \pow{\Int}
-              \end{array}\right]\hypertarget{type-LRec}{}\\
-\cup\ & \LRec\left[\text{f} : \Rec(\Int, \Int, \Int)\right]\end{flalign*}} % EndDefineType
+              \end{array}\right]\\
+\cup\ & \LRec\left[\text{f} : \Rec(\Int, \Int, \Int)\right]\mathhypertarget{type-LRec}\end{flalign*}} % EndDefineType
 
-\DefineType{expr}{\hypertarget{ast-expr}{}\hypertarget{ast-Number}{}
+\DefineType{expr}{
 \begin{flalign*}
-\expr \derives\ & \Number(\overtext{\Int}{\texttt{v}})\hypertarget{ast-Plus}{}\\
-|\ & \Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})\end{flalign*}} % EndDefineType
+\expr\texthypertarget{ast-expr} \derives\ & \mathhypertarget{ast-Number}\Number(\overtext{\Int}{\texttt{v}})\\
+|\ & \Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})\mathhypertarget{ast-Plus}\end{flalign*}} % EndDefineType
 
 

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -13,6 +13,16 @@
     urlcolor=cyan
 }
 
+% The \hypertarget macro suffers from having the corresponding \hyperlink
+% point one line below where they should, which is a known issue.
+% To fix this, the next two versions of \hypertarget use \Hy@raisedlink.
+% \mathhypertarget{} is suitable for math environments,
+% whereas the \texthypertarget{} is suitable for text environments.
+\makeatletter
+\newcommand\mathhypertarget[1]{\Hy@raisedlink{\hypertarget{#1}}} % DO NOT LINT
+\newcommand\texthypertarget[1]{\Hy@raisedlink{\hypertarget{#1}{}}} % DO NOT LINT
+\makeatother
+
 \usepackage{listings}
 \lstdefinelanguage{ASL}
 {


### PR DESCRIPTION
LaTeX's `\hypertarget` macro has the corresponding `\hyperlink` point one line below where it should. This is a [known issue](git push --set-upstream origin aslspec-fix-hypertarget).
**Old Solution:** Placing `\hypertarget`s one line above, which complicated the logic for rendering type definitions with variants and didn't work well for types without variants (since there is no obvious line above in the context of defining the macro for the type).
**New solution:** Defining two new dedicated macros: `\mathhypertarget` for math mode and `\texthypertarget` for text mode, which raise the hyperlink above as needed.
The code for `\render` has been adjusted and simplified for the case of rendering types with variants. 

A PDF comparison reveals no visual differences, only offsetting of elements (for exampe, a listing moving from one page to another), which is normal.

