### PR TITLE
[asl,herd] Improve ASL interface by not overriding FetchDescriptor

### DIFF
--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -659,8 +659,10 @@ module Make (Conf : Config) = struct
     let read_memory ii datasize_m addr_m =
       do_read_memory ii addr_m datasize_m aneutral aexp avir
 
-    let read_pte ii addr_m =
-      do_read_memory ii addr_m  (M.unitT (V.intToV 64))
+    let read_pte ii n_m addr_m =
+      (* We do all the operations with 64 bits, even if the argument passed is different. *)
+      let* _ = n_m in
+      do_read_memory ii addr_m (M.unitT (V.intToV 64))
         aneutral (AArch64Explicit.(NExp Other)) apte
 
     let read_memory_gen ii datasize_m addr_m accdesc_m access_m =
@@ -1017,8 +1019,8 @@ module Make (Conf : Config) = struct
 (* VMSA *)
         p1r ~side_effecting "ComputePtePrimitive"
           ("addr", bv_64) ~returns:bv_64 compute_pte;
-        p1r ~side_effecting "ReadPtePrimitive"
-          ("addr", bv_64) ~returns:bv_64 read_pte;
+        p1a1r ~side_effecting "ReadPtePrimitive" ("N", None)
+          ("addr", bv_64) ~returns:(bv_var "N") read_pte;
         p1r ~side_effecting "GetOAPrimitive"
           ("addr", bv_64) ~returns:(bv_lit (64-ia_msb)) get_oa;
         p1r ~side_effecting "OffsetPrimitive"

--- a/herd/libdir/asl-pseudocode/patches-vmsa.asl
+++ b/herd/libdir/asl-pseudocode/patches-vmsa.asl
@@ -37,24 +37,6 @@ begin
   end;
 end;
 
-// FetchDescriptor()
-// =================
-// Fetch a translation table descriptor
-
-func FetchDescriptor(ee:bit, walkaddress:AddressDescriptor,
-                     walkacces:AccessDescriptor,
-                     fault_in:FaultRecord,N:integer)
-  => (FaultRecord, bits(N))
-    // 32-bit descriptors for AArch32 Short-descriptor format
-    // 64-bit descriptors for AArch64 or AArch32 Long-descriptor format
-    // 128-bit descriptors for AArch64 when FEAT_D128 is set and {V}TCR_ELx.d128 is set
-begin
-//   __DEBUG__(walkaddress.paddress.address);
-   let desc = ReadPtePrimitive(walkaddress.paddress.address);
-//   __DEBUG__(walkaddress.paddress.address,desc);
-   return (fault_in,desc);
-end;
-
 // AArch64.S1SLTTEntryAddress()
 // ============================
 // Compute the first stage 1 translation table descriptor address within the


### PR DESCRIPTION
This PR suggests an implementation of `PhysMemRead` which differentiate the
different access types that are passed to it. This makes is possible to use the
`FetchDescriptor` function from the manual.

---

Commit list:

- **[asl,herd] Use PhysMemRead for FetchDescriptor**