### PR TITLE
[asl][reference] fixes to operator precedence

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -500,7 +500,7 @@
 \newcommand\Tboollit[0]{\hyperlink{def-tboollit}{\terminal{BOOL\_LIT}}}
 \newcommand\Tlexeme[0]{\hyperlink{def-tlexeme}{\terminal{LEXEME}}}
 
-\newcommand\Tunops[0]{\terminal{UNOPS}}
+\newcommand\Tunops[0]{\hyperlink{def-tunops}{\terminal{UNOPS}}}
 \newcommand\precedence[1]{\textsf{precedence: }#1}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -363,11 +363,14 @@ $x\ \opone\ y\ \optwo\ z$, is interpreted as
 $(x\ \opone\ y)\ \optwo\ z$
 if $\opone$ has higher precedence than $\optwo$ and as $x\ \opone\ (y\ \optwo\ z)$ if $\opone$ has lower precedence than $\optwo$.
 If $\opone$ is associative and $\opone$ = $\optwo$ then the expression may be interpreted as either
-$(x\ \opone\ y)\ \optwo\ z$ or as $x \opone\ (y\ \optwo\ z)$ since there is no difference.
+$(x\ \opone\ y)\ \optwo\ z$ or as $x\ \opone\ (y\ \optwo\ z)$ since there is no difference.
 Otherwise it is a static operator precedence error (\BinopPrecedence).
 See \ASTRuleRef{EBinop} for the formal details.
 
-The operator classes and precedence order is defined by the following table:
+The operator classes and precedence order is defined by the following table
+(a subset of the table in \secref{PriorityAndAssociativity},
+which contains tokens that are not operators, but are needed for parsing disambiguation):
+
 \begin{center}
 \begin{tabular}{lll}
 \hline
@@ -376,11 +379,11 @@ The operator classes and precedence order is defined by the following table:
 7 (Highest) & \textbf{Membership} & \Tin\\
 6 & \textbf{Unary}                & \Tminus, \Tnot, \Tbnot\\
 5 & \textbf{Power}                & \Tpow\\
-4 & \textbf{Mul-Div-Shift}        & \Tmul, \Tdiv, \Trdiv, \Tdivrm, \Tmod, \Tshl, \Tshr\\
-3 & \textbf{Add-Sub-Logic}        & \Tplus, \Tminus, \Tand, \Tor, \Txor, \Tcoloncolon, \Tplusplus\\
+4 & \textbf{Mul-Div-Shift}        & \Tmul, \Tdiv, \Tdivrm, \Trdiv, \Tmod, \Tshl, \Tshr\\
+3 & \textbf{Add-Sub-Logic}        & \Tplus, \Tminus, \Tor, \Tand, \Txor, \Tcoloncolon, \Tplusplus\\
 2 & \textbf{Relational}           & \Tgt, \Tgeq, \Tlt, \Tleq\\
-1 & \textbf{Equality-Inequality}  & \Teqop, \Tneq\\
-0 & \textbf{Boolean}              & \Tband, \Tbor, \Timpl, \Tbeq\\
+1 & \textbf{(In-)Equality}        & \Teqop, \Tneq\\
+0 & \textbf{Boolean}              & \Tbor, \Tband, \Timpl, \Tbeq\\
 \hline
 \end{tabular}
 \end{center}

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -194,6 +194,7 @@ We now present the list of derivations for the ASL Grammar where the start non-t
 The derivations allow certain parse trees where lists may have invalid sizes.
 Those parse trees must be rejected in a later phase.
 
+\hypertarget{def-tunops}{}
 Notice that two of the derivations (for $\Nexprpattern$ and for $\Nexpr$) end with \\
 $\precedence{\Tunops}$.
 This is a precedence annotation, which is not part of the right-hand-side sentence, and is explained in \secref{PriorityAndAssociativity}
@@ -731,8 +732,8 @@ reduce-reduce conflicts).
 The priority of a grammar derivation is defined as the priority of its rightmost token.
 Derivations that do not contain tokens do not require a priority as they do not induce shift-reduce conflicts.
 
-The table below assigns priorities to tokens in increasing order, starting from the lowest priority (for $\Telse$)
-to the highest priority (for $\Tdot$).
+The table below assigns priorities to tokens in descending order, starting from the highest priority (for $\Tdot$)
+to the lowest priority (for $\Telse$).
 When a shift-reduce conflict arises during the LR(1) grammar construction
 it resolve in favor of the action (shift or reduce) associated with the derivation that has the higher priority.
 If two derivations have the same priority due to them both having the same rightmost token,
@@ -748,17 +749,17 @@ which is never returned by the scanner.
 
 \begin{center}
 \begin{tabular}{ll}
-\textbf{Terminals} & \textbf{Associativity}\\
+\textbf{Tokens} & \textbf{Associativity}\\
 \hline
-$\Telse$ & $\nonassoc$\\
-$\Tbor$, $\Tband$, $\Timpl$, $\Tas$ & $\leftassoc$\\
-$\Teqop$, $\Tneq$ & $\leftassoc$\\
-$\Tgt$, $\Tgeq$, $\Tlt$, $\Tleq$ & $\nonassoc$\\
-$\Tplus$, $\Tminus$, $\Tor$, $\Txor$, $\Tand$, $\Tcoloncolon$, $\Tplusplus$ & $\leftassoc$\\
-$\Tmul$, $\Tdiv$, $\Tdivrm$, $\Trdiv$, $\Tmod$, $\Tshl$, $\Tshr$ & $\leftassoc$\\
-$\Tpow$ & $\leftassoc$\\
-$\Tunops$ & $\nonassoc$\\
-$\Tin$ & $\nonassoc$\\
-$\Tdot$, $\Tlbracket$, $\Tllbracket$ & $\leftassoc$
+$\Tdot$, $\Tlbracket$, $\Tllbracket$                                          & $\leftassoc$\\
+$\Tin$                                                                        & $\nonassoc$\\
+$\Tunops$                                                                     & $\nonassoc$\\
+$\Tpow$                                                                       & $\leftassoc$\\
+$\Tmul$, $\Tdiv$, $\Tdivrm$, $\Trdiv$, $\Tmod$, $\Tshl$, $\Tshr$              & $\leftassoc$\\
+$\Tplus$, $\Tminus$, $\Tor$, $\Tand$, $\Txor$, $\Tcoloncolon$, $\Tplusplus$   & $\leftassoc$\\
+$\Tgt$, $\Tgeq$, $\Tlt$, $\Tleq$                                              & $\nonassoc$\\
+$\Teqop$, $\Tneq$                                                             & $\leftassoc$\\
+$\Tbor$, $\Tband$, $\Timpl$, $\Tbeq$, $\Tas$                                  & $\leftassoc$\\
+$\Telse$                                                                      & $\nonassoc$
 \end{tabular}
 \end{center}

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -569,6 +569,7 @@ derivation
 derivations
 derive
 derived
+descending
 describe
 described
 describes


### PR DESCRIPTION
Addressing issue raised by Adam Clark: https://github.com/herd/herdtools7/issues/1498#issuecomment-3405790711

- The tables specifying the priority of tokens for parsing and precedence of operators for building the AST are now in the same order (higher at the top of the table) and the tokens appear in the same order in each row.
- Added missing "<=>" to the operator precedence table.
- Added an explanation why the token priorities table contains extra tokens. This is needed to help the parser, but is irrelevant for building the AST.
- Added a hyperlink to UNOPS to make it easier to understand while reading the grammar.