### PR TITLE
[asl][reference] a fix + discuss typechecker non-determinism

### DIFF
--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -439,20 +439,21 @@ We use the following rule notation, where $P_{1..k}$ are the rule premises and $
 For example, the rule \TypingRuleRef{ELit} has one premise:
 \begin{mathpar}
 \inferrule{
-  \annotateliteral(\vv) \typearrow \vt
+  \annotateliteral(\tenv, \vv) \typearrow \vt
 }{
-  \annotateexpr(\tenv, \ELiteral(\vv)) \typearrow (\vt, \ELiteral(\vv))
+  \annotateexpr(\tenv, \ELiteral(\vv)) \typearrow (\vt, \ELiteral(\vv), \emptyset)
 }
 \end{mathpar}
 
-and the rule \TypingRuleRef{EBinop} (somewhat simplified here) has three premises:
+and the rule \TypingRuleRef{EBinop} (somewhat simplified here) has four premises:
 \begin{mathpar}
 \inferrule{
-  \annotateexpr(\tenv, \veone) \typearrow (\vtone, \veone') \\\\
-  \annotateexpr(\tenv, \vetwo) \typearrow (\vttwo, \vetwo') \\\\
-  \applybinoptypes(\tenv, \op, \vtone, \vttwo) \typearrow \vt
+  \annotateexpr(\tenv, \veone) \typearrow (\vtone, \veonep, \vsesone)\\
+  \annotateexpr(\tenv, \vetwo) \typearrow (\vttwo, \vetwop, \vsestwo)\\
+  \applybinoptypes(\tenv, \op, \vtone, \vttwo) \typearrow \vt\\
+  \vses \eqdef \vsesone \cup \vsestwo
 }{
-  \annotateexpr(\tenv, \EBinop(\op, \veone, \vetwo)) \typearrow (\vt, \EBinop(\op, \veone', \vetwo'))
+  \annotateexpr(\tenv, \EBinop(\op, \veone, \vetwo)) \typearrow (\vt, \EBinop(\op, \veone', \vetwo'), \vses)
 }
 \end{mathpar}
 

--- a/asllib/doc/TypeChecking.tex
+++ b/asllib/doc/TypeChecking.tex
@@ -20,6 +20,20 @@ a \emph{\staticenvironmentterm{}} and a \emph{typed AST},
 which are used in defining the ASL semantics (\chapref{Semantics}).
 Otherwise, the typechecker returns a \typingerrorterm{}.
 
+\paragraph{Type System Non-determinism:}
+We note that the type system is non-deterministic in the following sense:
+\begin{itemize}
+  \item If a specification is not well-typed due to more than one error, the typechecker
+        may return any one of the possible errors. This is because the global declarations
+        are processed by applying a topological sort to the dependency graph (see \secref{Dependencies}).
+  \item The order of global declarations in the resulting \typedast{} depends on the topological sort
+        of the dependency graph (see \secref{Dependencies}), and thus is non-deterministic.
+  \item If a specification is well-typed the resulting \typedast{} may contain
+        newly generated local storage elements. The identifiers for those elements
+        are not in themselves important as they represent temporary values,
+        and they are not deterministically determined by the type system.
+\end{itemize}
+
 \hypertarget{def-annotaterel}{}
 The type system of ASL is given by the relation $\annotaterel$, which is defined as the disjoint union
 of the functions and relations defined in this reference.

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -594,6 +594,7 @@ determined
 determines
 determining
 deterministic
+deterministically
 dev
 development
 diagnostic
@@ -1346,6 +1347,7 @@ never
 new
 newline
 newlines
+newly
 next
 no
 node
@@ -2050,6 +2052,7 @@ team
 technical
 technically
 technique
+temporary
 term
 terminal
 terminals
@@ -2069,6 +2072,7 @@ that
 the
 their
 them
+themselves
 then
 theory
 there


### PR DESCRIPTION
- Fixed a bug in "5.2 Inference Rules" reported by Alex Coplan: the example for inference rules was missing the environment and side-effects components.
- Added a paragraph "Type System Non-determinism" to "Chapter 9: Type System Definitions", which describes the sources of non-determinism in the type system.