### PR TITLE
[aslspec] extended relations with property (relation/function) and category (none/typing/semantics)

### DIFF
--- a/asllib/aslspec/AST.ml
+++ b/asllib/aslspec/AST.ml
@@ -268,8 +268,18 @@ end
 
 (** A datatype for a relation definition. *)
 module Relation : sig
+  type relation_property =
+    | RelationProperty_Relation
+    | RelationProperty_Function
+
+  type relation_category =
+    | RelationCategory_Typing
+    | RelationCategory_Semantics
+
   type t = {
     name : string;
+    property : relation_property;
+    category : relation_category option;
     input : opt_named_type_term list;
     output : type_term list;
     att : Attributes.t;
@@ -277,6 +287,8 @@ module Relation : sig
 
   val make :
     string ->
+    relation_property ->
+    relation_category option ->
     opt_named_type_term list ->
     type_term list ->
     (AttributeKey.t * attribute) list ->
@@ -290,15 +302,32 @@ module Relation : sig
   val math_layout : t -> layout option
   (** The layout used when rendered as a stand-alone relation definition. *)
 end = struct
+  type relation_property =
+    | RelationProperty_Relation
+    | RelationProperty_Function
+
+  type relation_category =
+    | RelationCategory_Typing
+    | RelationCategory_Semantics
+
   type t = {
     name : string;
+    property : relation_property;
+    category : relation_category option;
     input : opt_named_type_term list;
     output : type_term list;
     att : Attributes.t;
   }
 
-  let make name input output attributes =
-    { name; input; output; att = Attributes.of_list attributes }
+  let make name property category input output attributes =
+    {
+      name;
+      property;
+      category;
+      input;
+      output;
+      att = Attributes.of_list attributes;
+    }
 
   let attributes_to_list self = Attributes.bindings self.att
 

--- a/asllib/aslspec/PP.ml
+++ b/asllib/aslspec/PP.ml
@@ -92,9 +92,20 @@ let pp_variants_with_attributes fmt variants =
 
 let pp_variants fmt variants = pp_sep_list ~sep:" | " pp_type_term fmt variants
 
-let pp_relation_definition fmt ({ Relation.name; input; output } as relation) =
+let pp_relation_category fmt = function
+  | None -> ()
+  | Some Relation.RelationCategory_Typing -> fprintf fmt "%s " (tok_str TYPING)
+  | Some Relation.RelationCategory_Semantics ->
+      fprintf fmt "%s " (tok_str SEMANTICS)
+
+let pp_relation_definition fmt
+    ({ Relation.name; property; category; input; output } as relation) =
   let module Rel = Relation in
-  fprintf fmt "@[<v>%s %s(%a) -> %a@,%a@];" (tok_str RELATION) name
+  fprintf fmt "@[<v>%a%s %s(%a) -> %a@,%a@];" pp_relation_category category
+    (match property with
+    | RelationProperty_Relation -> tok_str RELATION
+    | RelationProperty_Function -> tok_str FUNCTION)
+    name
     (pp_sep_list ~sep:", " pp_opt_named_type_term)
     input pp_variants output pp_attribute_key_values
     (Rel.attributes_to_list relation)

--- a/asllib/aslspec/SpecLexer.mll
+++ b/asllib/aslspec/SpecLexer.mll
@@ -34,6 +34,7 @@ rule token = parse
     | "ast"               { AST }
     | "constant"          { CONSTANT }
     | "constants_set"     { CONSTANTS_SET }
+    | "function"          { FUNCTION }
     | "list0"             { LIST0 }
     | "list1"             { LIST1 }
     | "math_macro"        { MATH_MACRO }
@@ -47,7 +48,9 @@ rule token = parse
     | "prose_description" { PROSE_DESCRIPTION }
     | "relation"          { RELATION }
     | "render"            { RENDER }
+    | "semantics"         { SEMANTICS }
     | "typedef"           { TYPEDEF }
+    | "typing"            { TYPING }
 
     (* Punctuation and operators *)
     | ','            { COMMA }

--- a/asllib/aslspec/SpecParser.mly
+++ b/asllib/aslspec/SpecParser.mly
@@ -22,6 +22,7 @@ let check_definition_name name =
 %token CONSTANT
 %token CONSTANTS_SET
 %token FUN
+%token FUNCTION
 %token PARTIAL
 %token LIST0
 %token LIST1
@@ -34,7 +35,9 @@ let check_definition_name name =
 %token PROSE_DESCRIPTION
 %token RENDER
 %token RELATION
+%token SEMANTICS
 %token TYPEDEF
+%token TYPING
 
 (* Punctuation and operator tokens *)
 %token ARROW
@@ -133,14 +136,23 @@ let type_definition :=
         raise (SpecError msg) }
 
 let relation_definition :=
-    RELATION; name=IDENTIFIER; input=plist0(opt_named_type_term); ARROW; output=type_variants;
+    ~=relation_category; ~=relation_property; name=IDENTIFIER; input=plist0(opt_named_type_term); ARROW; output=type_variants;
     attributes=relation_attributes; SEMI;
     {   check_definition_name name;
-        Elem_Relation (Relation.make name input output attributes) }
+        Elem_Relation (Relation.make name relation_property relation_category input output attributes) }
 
 let constant_definition := CONSTANT; name=IDENTIFIER; att=type_attributes; SEMI;
     {   check_definition_name name;
         Elem_Constant (Constant.make name att) }
+
+let relation_property :=
+    | RELATION; { Relation.RelationProperty_Relation }
+    | FUNCTION; { Relation.RelationProperty_Function }
+
+let relation_category :=
+    | { None }
+    | TYPING; { Some Relation.RelationCategory_Typing }
+    | SEMANTICS; { Some Relation.RelationCategory_Semantics }
 
 let type_attributes ==
     LBRACE; pairs=tclist0(type_attribute); RBRACE; { pairs }

--- a/asllib/aslspec/tests.t/relations.expected
+++ b/asllib/aslspec/tests.t/relations.expected
@@ -6,18 +6,22 @@
 % Macros for symbols
 % ------------------
 
+\newcommand\Num[0]{ \hyperlink{type-Num}{\textsf{Num}} } % Generated from Num
 \newcommand\type[0]{ \hyperlink{ast-type}{\textsf{type}} } % Generated from type
 \newcommand\Int[0]{ \hyperlink{ast-Int}{\textsc{Int}} } % Generated from Int
 \newcommand\String[0]{ \hyperlink{ast-String}{\textsc{String}} } % Generated from String
 \newcommand\expr[0]{ \hyperlink{ast-expr}{\textsf{expr}} } % Generated from expr
 \newcommand\Number[0]{ \hyperlink{ast-Number}{\textsc{Number}} } % Generated from Number
 \newcommand\Plus[0]{ \hyperlink{ast-Plus}{\textsc{Plus}} } % Generated from Plus
-\newcommand\annotateexpr'[0]{ \hyperlink{relation-annotateexpr'}{\textit{annotate\_expr'}} } % Generated from annotate_expr'
+\newcommand\annotateexpr[0]{ \hyperlink{relation-annotateexpr}{\textit{annotate\_expr}} } % Generated from annotate_expr
 \newcommand\annotateplus[0]{ \hyperlink{relation-annotateplus}{\textit{annotate\_plus}} } % Generated from annotate_plus
+\newcommand\evalplus[0]{ \hyperlink{relation-evalplus}{\textit{eval\_plus}} } % Generated from eval_plus
 
 % -------------------
 % Macros for elements
 % -------------------
+
+\DefineType{Num}{\texthypertarget{type-Num}$\Num$} % EndDefineType
 
 \DefineType{type}{
 \begin{flalign*}
@@ -29,11 +33,11 @@
 \expr\texthypertarget{ast-expr} \derives\ & \mathhypertarget{ast-Number}\Number(\overtext{\Int}{\texttt{v}})\\
 |\ & \Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})\mathhypertarget{ast-Plus}\end{flalign*}} % EndDefineType
 
-\DefineRelation{annotate_expr'}{
+\DefineRelation{annotate_expr}{
 
 The relation
 \[
-\mathhypertarget{relation-annotateexpr'}\annotateexpr'(\overtext{\expr}{\texttt{input}}) \;\bigtimes\; \overtext{\type}{\texttt{inferred\_type}}
+\mathhypertarget{relation-annotateexpr}\annotateexpr(\overtext{\expr}{\texttt{input}}) \;\bigtimes\; \overtext{\type}{\texttt{inferred\_type}}
 \]
 infers the type $\texttt{inferred\_type}$ for the expression
 $\texttt{input}$
@@ -41,12 +45,22 @@ $\texttt{input}$
 
 \DefineRelation{annotate_plus}{
 
-The relation
+The function
 \[
-\mathhypertarget{relation-annotateplus}\annotateplus(\overtext{\Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})}{\texttt{input}}) \;\bigtimes\; \overtext{\type}{\texttt{inferred\_type}}
+\mathhypertarget{relation-annotateplus}\annotateplus(\overtext{\Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})}{\texttt{input}}) \;\longrightarrow\; \overtext{\type}{\texttt{inferred\_type}}
 \]
 infers the type $\texttt{inferred\_type}$ for the plus expression
 $\texttt{input}$
+} % EndDefineRelation
+
+\DefineRelation{eval_plus}{
+
+The relation
+\[
+\mathhypertarget{relation-evalplus}\evalplus(\overtext{\Plus(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}})}{\texttt{input}}) \;\bigtimes\; \overtext{\Num}{\texttt{output\_val}}
+\]
+evaluates the expression $\texttt{input}$ and returns
+$\texttt{output\_val}$
 } % EndDefineRelation
 
 

--- a/asllib/aslspec/tests.t/relations.spec
+++ b/asllib/aslspec/tests.t/relations.spec
@@ -1,3 +1,5 @@
+typedef Num {""};
+
 ast type { prose_description = "type"} =
     | Int
     { prose_description = "integer type" }
@@ -13,15 +15,20 @@ ast expr { prose_description = "expression" } =
 ;
 
 // A relation associates a tuple of types (the input) with an output type.
-relation annotate_expr'(input: expr) -> (inferred_type: type)
+typing relation annotate_expr(input: expr) -> (inferred_type: type)
 {
     prose_description = "infers the type {inferred_type} for the expression {input}",
     prose_application = "annotating the expression {input} yields the type {inferred_type}",
 };
 
-relation annotate_plus(input: Plus(lhs: expr, rhs: expr)) -> (inferred_type: type)
+typing function annotate_plus(input: Plus(lhs: expr, rhs: expr)) -> (inferred_type: type)
 {
     prose_description = "infers the type {inferred_type} for the plus expression {input}",
     prose_application = "annotating the plus expression {input} yields the type {inferred_type}",
 };
 
+semantics relation eval_plus(input: Plus(lhs: expr, rhs: expr)) -> (output_val: Num)
+{
+    prose_description = "evaluates the expression {input} and returns {output_val}",
+    prose_application = "",
+};


### PR DESCRIPTION
Thi PR adds two properties to relation definitions:
1. A relation can be qualified as a function with the `function` keyword, e.g., `function annotate_plus(input: Plus(lhs: expr, rhs: expr)) -> (inferred_type: type)`. This allows adding extra information, which is already part of the ASL Reference. Relations qualified as functions are rendered with an arrow rather than a times symbol (see below).
2. A relation can be optionally added to a category. Right now the only categories are `typing` and `semantics`. This currently has no impact on rendering, but in future PRs it will be used to determine how to render the arrow symbols used in inference rules and in checking groups of relations.

<img width="1060" height="1370" alt="image" src="https://github.com/user-attachments/assets/cef71e9f-b8e3-4591-86c3-8bcba9639d12" />