### PR TITLE
[herd] Introduce basic support for AArch64 Guarded Control Stack 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,18 @@ test.self:
 		$(REGRESSION_TEST_MODE)
 	@ echo "herd7 AArch64 variant -self instructions tests: OK"
 
+test:: test.gcs
+test-local:: test.gcs
+test.gcs::
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-j $(J) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/AArch64.gcs \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64 GCS instructions tests: OK"
+
 test:: test.kvm
 test-local:: test.kvm
 test.kvm:

--- a/catalogue/aarch64-GCS/tests/Co+gcsss1+gcsss1.litmus
+++ b/catalogue/aarch64-GCS/tests/Co+gcsss1+gcsss1.litmus
@@ -1,0 +1,18 @@
+AArch64 Co+gcsss1+gcsss1
+variant=shadowstack
+{
+  SS(x,2);
+  SS(y,2) = ssval_t: {0,SSCap(y,1)};
+
+  0:GCSPR_EL1=&x[1];
+  0:X1=&y[1];
+  0:X2=y;
+}
+
+P0             ;
+GCSSS1 X1      ; (* GCSSS1 Memory effect, GCSPR = y[1], y[1] = SSCap(x[1],5)   *)
+ADD X3,X2,#1   ; (* Synthesize "valid" cap                                     *)
+GCSSTR X3,[X1] ; (* GCS (Write) effect                                         *)
+GCSSS1 X1      ; (* GCSSS1 Memory effect, GCSPR = y[1], y[1] = SSCap(y[1],5) q *)
+
+forall ~fault(P0)

--- a/catalogue/aarch64-GCS/tests/LB+gcspop-gcsb-dmb.sy+dmb.ld-gcsb.litmus
+++ b/catalogue/aarch64-GCS/tests/LB+gcspop-gcsb-dmb.sy+dmb.ld-gcsb.litmus
@@ -1,0 +1,18 @@
+AArch64 LB+gcspop-gcsb-dmb.sy+dmb.ld-gcsb
+variant=shadowstack
+{
+SS(x,1);
+
+0:GCSPR_EL1=x;
+0:X3=y;
+
+1:X0=x;
+1:X3=y;
+}
+ P0                                      | P1                                      ;
+ GCSPOPM X1  (* GCS (Read) effect     *) | LDR W1,[X3]    (* Memory Read effect *) ;
+ GCSB DSYNC  (* GCSB effect           *) | DMB LD                                  ;
+ DMB SY                                  | GCSB DSYNC     (* GCSB effect        *) ;
+ MOV W2,#1                               | MOV X2,#4                               ;
+ STR W2,[X3] (* Memory (Write) effect *) | GCSSTR X2,[X0] (* GCS (Write) effect *) ;
+exists (0:X1=4 /\ 1:X1=1)

--- a/catalogue/aarch64-GCS/tests/LB+gcsss2-dmb.sy+dmb.ld-gcsss1.litmus
+++ b/catalogue/aarch64-GCS/tests/LB+gcsss2-dmb.sy+dmb.ld-gcsss1.litmus
@@ -1,0 +1,22 @@
+AArch64 LB+gcsss2-dmb.sy+dmb.ld-gcsss1
+variant=shadowstack
+{
+SS(x,2);
+SS(z,1) = ssval_t: {SSCap(z,1)};
+
+0:X0=z;
+0:X3=y;
+0:GCSPR_EL1=z;
+
+1:X0=z;
+1:X3=y;
+1:GCSPR_EL1=&x[1];
+
+}
+ P0                                      | P1                                      ;
+ GCSSS2 X0   (* GCS + GCSSB effect    *) | LDR W1,[X3]    (* Memory Read effect *) ;
+ DMB SY                                  | DMB LD                                  ;
+ MOV W2,#1                               | GCSSS1 X0      (* GCSSS1 effect      *) ;
+ STR W2,[X3] (* Memory (Write) effect *) |                                         ;
+                                         |                                         ;
+exists ~fault(P0,GCS:SS2) /\ 1:X1=1

--- a/catalogue/aarch64-GCS/tests/LB+ret-gcsb-dmb.sy+dmb.ld-gcsb.litmus
+++ b/catalogue/aarch64-GCS/tests/LB+ret-gcsb-dmb.sy+dmb.ld-gcsb.litmus
@@ -1,0 +1,21 @@
+AArch64 LB+ret-gcsb-dmb.sy+dmb.ld-gcsb
+variant=shadowstack
+{
+SS(x,1);
+
+0:GCSPR_EL1=x;
+0:X3=y;
+0:LR=label:"P0:L0";
+
+1:X0=x;
+1:X2=label:"P0:L0";
+1:X3=y;
+}
+ P0                                      | P1                                      ;
+ RET         (* GCS (Read) effect     *) | LDR W1,[X3]    (* Memory Read effect *) ;
+ L0:                                     | DMB LD                                  ;
+ GCSB DSYNC  (* GCSB effect           *) | GCSB DSYNC     (* GCSB effect        *) ;
+ DMB SY                                  | GCSSTR X2,[X0] (* GCS (Write) effect *) ;
+ MOV W2,#1                               |                                         ;
+ STR W2,[X3] (* Memory (Write) effect *) |                                         ;
+exists ~fault(P0,GCS:PRET) /\ 1:X1=1

--- a/catalogue/aarch64-GCS/tests/MP+bl-gcsb-dmb.sy+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+bl-gcsb-dmb.sy+dmb.ld.litmus
@@ -1,0 +1,23 @@
+AArch64 MP+bl-gcsb-dmb.sy+dmb.ld
+variant=shadowstack
+{
+
+SS(x,1);
+
+0:X2=y;
+0:GCSPR_EL1=&x[1];
+
+1:X2=y;
+1:X4=x;
+
+}
+
+P0                                       | P1          ;
+BL L0        (* GCS (Write) Effect    *) | LDR W1,[X2] ;
+L0:                                      | DMB LD      ;
+GCSB DSYNC   (* GCSB Effect           *) | LDR X3,[X4] ;
+DMB SY                                   |             ;
+MOV W1,#1                                |             ;
+STR W1,[X2]  (* Memory (Write) Effect *) |             ;
+
+exists 1:X1=1 /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+bl-gcsb-rel+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+bl-gcsb-rel+dmb.ld.litmus
@@ -1,0 +1,20 @@
+AArch64 MP+bl-gcsb-rel+dmb.ld
+variant=shadowstack
+{
+SS(x,1);
+
+0:X2=y;
+0:GCSPR_EL1=&x[1];
+
+1:X2=y;
+1:X4=x;
+}
+
+P0                                                            | P1          ;
+BL L0        (* GCS (Write) effect                         *) | LDR W1,[X2] ;
+L0:                                                           | DMB LD      ;
+GCSB DSYNC   (* GCSB effect                                *) | LDR X3,[X4] ;
+MOV W1,#1                                                     |             ;
+STLR W1,[X2] (* Memory Write effect with Release semantics *) |             ;
+
+exists 1:X1=1 /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st+acq-gcsb-gcspop.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st+acq-gcsb-gcspop.litmus
@@ -1,0 +1,24 @@
+AArch64 MP+dmb.st+acq-gcsb-gcspop
+variant=shadowstack,vmsa
+{
+uint64_t z=0;
+
+SS(x,1);
+
+[PTE(z)]=(oa:PA(x)); (* Alias z to x, otherwise STR would fault *)
+
+0:X2=y;
+0:X4=z;
+
+1:X2=y;
+1:GCSPR_EL1=x;
+}
+
+P0            | P1;
+MOV X0,#4     | LDAR W1,[X2] (* Memory Read effect (with Acquire) *);
+STR X0,[X4]   | GCSB DSYNC   (* GCSB effect                       *);
+DMB ST        | GCSPOPM X3   (* GCS (Read) effect                 *);
+MOV W1,#1     |                                                     ;
+STR W1,[X2]   |                                                     ;
+
+exists 1:X1=1 /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st+acq-gcsb-ret.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st+acq-gcsb-ret.litmus
@@ -1,0 +1,25 @@
+AArch64 MP+dmb.st+acq-gcsb-ret
+variant=shadowstack,vmsa
+{
+uint64_t z=0;
+
+SS(x,1);
+
+[PTE(z)]=(oa:PA(x)); (* Alias z to x, otherwise STR would fault *)
+
+0:X0=label:"P1:L0";
+0:X2=y;
+0:X4=z;
+
+1:LR=label:"P1:L0";
+1:X2=y;
+1:GCSPR_EL1=x;
+}
+
+P0            | P1;
+STR X0,[X4]   | LDAR W1,[X2] (* Memory Read effect (with Acquire) *);
+DMB ST        | GCSB DSYNC   (* GCSB effect                       *);
+MOV W1,#1     | RET          (* GCS (Read) effect                 *);
+STR W1,[X2]   | L0:                                                 ;
+
+exists 1:X1=1 /\ fault(P1, GCS:PRET)

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st+acq-gcsss1.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st+acq-gcsss1.litmus
@@ -1,0 +1,27 @@
+AArch64 MP+dmb.st+acq-gcsss1
+variant=shadowstack,vmsa
+{
+uint64_t z=0;
+
+SS(x,1);
+SS(k,1);
+
+[PTE(z)]=(oa:PA(k)); (* Alias z to k, otherwise STR would fault *)
+
+0:X2=y;
+0:X3=k;
+0:X4=z;
+
+1:X2=y;
+1:X3=k;
+1:GCSPR_EL1=x;
+}
+
+P0            | P1;
+ADD X0,X3,#1  | LDAR W1,[X2] (* Memory Read effect (with Acquire) *);
+STR X0,[X4]   | GCSSS1 X3    (* GCSSS1                            *);
+DMB ST        |                                                     ;
+MOV W1,#1     |                                                     ;
+STR W1,[X2]   |                                                     ;
+
+exists 1:X1=1 /\ fault(P1,GCS:SS1)

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.ld-gcsb-gcspop.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.ld-gcsb-gcspop.litmus
@@ -1,0 +1,24 @@
+AArch64 MP+dmb.st+dmb.ld-gcsb-gcspop
+variant=shadowstack,vmsa
+{
+uint64_t z=0;
+
+SS(x,1);
+
+[PTE(z)]=(oa:PA(x)); (* Alias z to x, otherwise STR would fault *)
+
+0:X2=y;
+0:X4=z;
+
+1:X2=y;
+1:GCSPR_EL1=x;
+}
+
+P0            | P1                                  ;
+MOV X0,#4     | LDR W1,[X2] (* Memory Read effect *);
+STR X0,[X4]   | DMB LD                              ;
+DMB ST        | GCSB DSYNC  (* GCSB effect        *);
+MOV W1,#1     | GCSPOPM X3  (* GCS (Read) effect  *);
+STR W1,[X2]   |                                     ;
+
+exists 1:X1=1 /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.ld-gcsb-ret.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.ld-gcsb-ret.litmus
@@ -1,0 +1,26 @@
+AArch64 MP+dmb.st+dmb.ld-gcsb-ret
+variant=shadowstack
+{
+uint64_t z=0;
+
+SS(x,1);
+
+[PTE(z)]=(oa:PA(x)); (* Alias z to x, otherwise STR would fault *)
+
+0:X0=label:"P1:L0";
+0:X2=y;
+0:X4=z;
+
+1:LR=label:"P1:L0";
+1:X2=y;
+1:GCSPR_EL1=x;
+}
+
+P0            | P1                                  ;
+STR X0,[X4]   | LDR W1,[X2] (* Memory Read effect *);
+DMB ST        | DMB LD                              ;
+MOV W1,#1     | GCSB DSYNC  (* GCSB effect        *);
+STR W1,[X2]   | RET         (* GCS (Read) effect  *);
+              | L0:                                 ;
+
+exists 1:X1=1 /\ fault(P1,GCS:PRET)

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.ld-gcsss1.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.ld-gcsss1.litmus
@@ -1,0 +1,27 @@
+AArch64 MP+dmb.st+dmb.ld-gcsss1
+variant=shadowstack,vmsa
+{
+uint64_t z=0;
+
+SS(x,1);
+SS(k,1);
+
+[PTE(z)]=(oa:PA(k)); (* Alias z to k, otherwise STR would fault *)
+
+0:X2=y;
+0:X3=k;
+0:X4=z;
+
+1:X2=y;
+1:X3=k;
+1:GCSPR_EL1=x;
+}
+
+P0            | P1                                  ;
+ADD X0,X3,#1  | LDR W1,[X2] (* Memory Read effect *);
+STR X0,[X4]   | DMB LD                              ;
+DMB ST        | GCSSS1 X3   (* GCSSS1 effect      *);
+MOV W1,#1     |                                     ;
+STR W1,[X2]   |                                     ;
+
+exists 1:X1=1 /\ fault(P1,GCS:SS1)

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.sy-gcsb-gcspop.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.sy-gcsb-gcspop.litmus
@@ -1,0 +1,27 @@
+AArch64 MP+dmb.st+dmb.sy-gcsb-gcspop
+variant=shadowstack,vmsa
+{
+
+uint64_t z=0;
+
+SS(x,1);
+
+[PTE(z)]=(oa:PA(x)); (* Alias z to x, otherwise STR would fault *)
+
+0:X2=y;
+0:X4=z;
+
+1:X2=y;
+1:GCSPR_EL1=x;
+
+
+}
+
+P0            | P1                                    ;
+MOV X0,#4     | LDR W1,[X2] (* Memory (Read) Effect *);
+STR X0,[X4]   | DMB SY                                ;
+DMB ST        | GCSB DSYNC  (* GCSB Effect          *);
+MOV W1,#1     | GCSPOPM X3  (* GCS (Read) Effect    *);
+STR W1,[X2]   |                                       ;
+
+exists 1:X1=1 /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.sy-gcsb-ret.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.sy-gcsb-ret.litmus
@@ -1,0 +1,29 @@
+AArch64 MP+dmb.st+dmb.sy-gcsb-ret
+variant=shadowstack,vmsa
+{
+
+uint64_t z=0;
+
+SS(x,1);
+
+[PTE(z)]=(oa:PA(x)); (* Alias z to x, otherwise STR would fault *)
+
+0:X0=label:"P1:L0";
+0:X2=y;
+0:X4=z;
+
+1:LR=label:"P1:L0";
+1:X2=y;
+1:GCSPR_EL1=x;
+
+
+}
+
+P0            | P1                                    ;
+STR X0,[X4]   | LDR W1,[X2] (* Memory (Read) Effect *);
+DMB ST        | DMB SY                                ;
+MOV W1,#1     | GCSB DSYNC  (* GCSB Effect          *);
+STR W1,[X2]   | RET         (* GCS (Read) Effect    *);
+              | L0:                                   ;
+
+exists 1:X1=1 /\ fault(P1,GCS:PRET)

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.sy-gcsss1.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st+dmb.sy-gcsss1.litmus
@@ -1,0 +1,30 @@
+AArch64 MP+dmb.st+dmb.sy-gcsss1
+variant=shadowstack,vmsa
+{
+
+uint64_t z=0;
+
+SS(x,1);
+SS(k,1);
+
+[PTE(z)]=(oa:PA(k)); (* Alias z to k, otherwise STR would fault *)
+
+0:X2=y;
+0:X3=k;
+0:X4=z;
+
+1:X2=y;
+1:X3=k;
+1:GCSPR_EL1=x;
+
+
+}
+
+P0            | P1                                    ;
+ADD X0,X3,#1  | LDR W1,[X2] (* Memory (Read) Effect *);
+STR X0,[X4]   | DMB SY                                ;
+DMB ST        | GCSSS1 X3   (* GCSSS1 Memory Effect *);
+MOV W1,#1     |                                       ;
+STR W1,[X2]   |                                       ;
+
+exists 1:X1=1 /\ fault(P1,GCS:SS1)

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st-gcsb-bl+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st-gcsb-bl+dmb.ld.litmus
@@ -1,0 +1,21 @@
+AArch64 MP+dmb.st-gcsb-bl+dmb.ld
+variant=shadowstack
+{
+SS(x,1);
+
+0:X2=y;
+0:GCSPR_EL1=&x[1];
+
+1:X2=x;
+1:X4=y;
+}
+
+P0                                       | P1          ;
+MOV W1,#1                                | LDR X1,[X2] ;
+STR W1,[X2]  (* Memory (Write) Effect *) | DMB LD      ;
+DMB ST                                   | LDR W3,[X4] ;
+GCSB DSYNC   (* GCSB Effect           *) |             ;
+BL L0        (* GCS (Write) Effect    *) |             ;
+L0:                                      |             ;
+
+exists 1:X1=label:"P0:L0" /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st-gcsb-gcspush+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st-gcsb-gcspush+dmb.ld.litmus
@@ -1,0 +1,21 @@
+AArch64 MP+dmb.st-gcsb-gcspush+dmb.ld
+variant=shadowstack
+{
+SS(x,1);
+
+0:X2=y;
+0:GCSPR_EL1=&x[1];
+
+1:X2=x;
+1:X4=y;
+}
+
+P0                                       | P1          ;
+MOV W1,#1                                | LDR X1,[X2] ;
+STR W1,[X2]  (* Memory (Write) Effect *) | DMB LD      ;
+DMB ST                                   | LDR W3,[X4] ;
+GCSB DSYNC   (* GCSB Effect           *) |             ;
+MOV X0,#4                                |             ;
+GCSPUSHM X0  (* GCS (Write) Effect    *) |             ;
+
+exists 1:X1=4 /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+dmb.st-gcsss1+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+dmb.st-gcsss1+dmb.ld.litmus
@@ -1,0 +1,21 @@
+AArch64 MP+dmb.st-gcsss1+dmb.ld
+variant=shadowstack
+{
+SS(x,1) = ssval_t: {SSCap(x,1)};
+SS(z,1);
+
+0:X0=x;
+0:X2=y;
+0:GCSPR_EL1=z;
+
+1:X2=x;
+1:X4=y;
+}
+
+P0                                       | P1          ;
+MOV W1,#1                                | LDR X1,[X2] ;
+STR W1,[X2]  (* Memory (Write) Effect *) | DMB LD      ;
+DMB ST                                   | LDR W3,[X4] ;
+GCSSS1 X0    (* GCSSS1 Effect         *) |             ;
+
+exists 1:X1=SSCap(z,5) /\ 1:X3=0  (* SSCap not supported in herd, yet *)

--- a/catalogue/aarch64-GCS/tests/MP+gcspush-gcsb-dmb.sy+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+gcspush-gcsb-dmb.sy+dmb.ld.litmus
@@ -1,0 +1,23 @@
+AArch64 MP+gcspush-gcsb-dmb.sy+dmb.ld
+variant=shadowstack
+{
+
+SS(x,1);
+
+0:X2=y;
+0:GCSPR_EL1=&x[1];
+
+1:X2=y;
+1:X4=x;
+
+}
+
+P0                                       | P1          ;
+MOV X0,#4                                | LDR W1,[X2] ;
+GCSPUSHM X0  (* GCS (Write) Effect    *) | DMB LD      ;
+GCSB DSYNC   (* GCSB Effect           *) | LDR X3,[X4] ;
+DMB SY                                   |             ;
+MOV W1,#1                                |             ;
+STR W1,[X2]  (* Memory (Write) Effect *) |             ;
+
+exists 1:X1=1 /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+gcspush-gcsb-rel+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+gcspush-gcsb-rel+dmb.ld.litmus
@@ -1,0 +1,20 @@
+AArch64 MP+gcspush-gcsb-rel+dmb.ld
+variant=shadowstack
+{
+SS(x,1);
+
+0:X2=y;
+0:GCSPR_EL1=&x[1];
+
+1:X2=y;
+1:X4=x;
+}
+
+P0                                                            | P1          ;
+MOV X0,#4                                                     | LDR W1,[X2] ;
+GCSPUSHM X0  (* GCS (Write) effect                         *) | DMB LD      ;
+GCSB DSYNC   (* GCSB effect                                *) | LDR X3,[X4] ;
+MOV W1,#1                                                     |             ;
+STLR W1,[X2] (* Memory Write effect with Release semantics *) |             ;
+
+exists 1:X1=1 /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+gcsss1-dmb.sy+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+gcsss1-dmb.sy+dmb.ld.litmus
@@ -1,0 +1,25 @@
+AArch64 MP+gcsss1-dmb.sy+dmb.ld
+variant=shadowstack
+{
+
+SS(x,1) = ssval_t: {SSCap(x,1)};
+SS(z,1);
+
+0:X0=x;
+0:X2=y;
+0:GCSPR_EL1=&z[1];
+
+1:X2=y;
+1:X4=x;
+
+}
+
+P0                                       | P1          ;
+GCSSS1 X0    (* GCSSS1 Memory Effect  *) | LDR W1,[X2] ;
+DMB SY                                   | DMB LD      ;
+MOV W1,#1                                | LDR X3,[X4] ;
+STR W1,[X2]  (* Memory (Write) Effect *) |             ;
+
+exists 1:X1=1 /\ 1:X3=SSCap(x,1) (* SSCap not supported in herd, yet *)
+
+

--- a/catalogue/aarch64-GCS/tests/MP+gcsss1-rel+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+gcsss1-rel+dmb.ld.litmus
@@ -1,0 +1,20 @@
+AArch64 MP+gcsss1-rel+dmb.ld
+variant=shadowstack
+{
+SS(x,1) = ssval_t: {SSCap(x,1)};
+SS(z,1);
+
+0:X0=x;
+0:X2=y;
+0:GCSPR_EL1=&z[1];
+
+1:X2=y;
+1:X4=x;
+}
+
+P0                                                            | P1          ;
+GCSSS1 X0    (* GCSSS1 Memory effect                       *) | LDR W1,[X2] ;
+MOV W1,#1                                                     | DMB LD      ;
+STLR W1,[X2] (* Memory Write effect with Release semantics *) | LDR X3,[X4] ;
+
+exists 1:X1=1 /\ 1:X3=SSCap(x,1) (* SSCap not supported in herd, yet *)

--- a/catalogue/aarch64-GCS/tests/MP+swapal-gcsb+bl+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+swapal-gcsb+bl+dmb.ld.litmus
@@ -1,0 +1,20 @@
+AArch64 MP+swapal-gcsb+bl+dmb.ld
+variant=shadowstack
+{
+SS(x,1);
+
+0:X2=y;
+0:GCSPR_EL1=&x[1];
+
+1:X2=x;
+1:X4=y;
+}
+
+P0                                            | P1          ;
+MOV W1,#1                                     | LDR X1,[X2] ;
+SWPAL W1,W3,[X2]  (* Memory (Write) Effect *) | DMB LD      ;
+GCSB DSYNC        (* GCSB Effect           *) | LDR W3,[X4] ;
+BL L0             (* GCS (Write) Effect    *) |             ;
+L0:                                           |             ;
+
+exists 1:X1=label:"P0:L0" /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+swapal-gcsb-gcspush+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+swapal-gcsb-gcspush+dmb.ld.litmus
@@ -1,0 +1,20 @@
+AArch64 MP+swapal-gcsb-gcspush+dmb.ld
+variant=shadowstack
+{
+SS(x,1);
+
+0:X2=y;
+0:GCSPR_EL1=&x[1];
+
+1:X2=x;
+1:X4=y;
+}
+
+P0                                            | P1          ;
+MOV W1,#1                                     | LDR X1,[X2] ;
+SWPAL W1,W3,[X2]  (* Memory (Write) Effect *) | DMB LD      ;
+GCSB DSYNC        (* GCSB Effect           *) | LDR W3,[X4] ;
+MOV X0,#4                                     |             ;
+GCSPUSHM X0       (* GCS (Write) Effect    *) |             ;
+
+exists 1:X1=4 /\ 1:X3=0

--- a/catalogue/aarch64-GCS/tests/MP+swapal-gcsss1+dmb.ld.litmus
+++ b/catalogue/aarch64-GCS/tests/MP+swapal-gcsss1+dmb.ld.litmus
@@ -1,0 +1,20 @@
+AArch64 MP+swapal-gcsss1+dmb.ld
+variant=shadowstack
+{
+SS(x,1) = ssval_t: {SSCap(x,1)};
+SS(z,1);
+
+0:X0=x;
+0:X2=y;
+0:GCSPR_EL1=z;
+
+1:X2=x;
+1:X4=y;
+}
+
+P0                                            | P1          ;
+MOV W1,#1                                     | LDR X1,[X2] ;
+SWPAL W1,W3,[X2]  (* Memory (Write) Effect *) | DMB LD      ;
+GCSSS1 X0         (* GCSSS1 Effect         *) | LDR W3,[X4] ;
+
+exists 1:X1=SSCap(z,5) /\ 1:X3=0 (* SSCap not supported in herd, yet *)

--- a/catalogue/aarch64-GCS/tests/SB+dmb.st-gcsb+gcsb-dmb.sy.litmus
+++ b/catalogue/aarch64-GCS/tests/SB+dmb.st-gcsb+gcsb-dmb.sy.litmus
@@ -1,0 +1,19 @@
+AArch64 SB+dmb.st-gcsb+gcsb-dmb.sy
+variant=shadowstack
+{
+SS(x,1);
+
+0:GCSPR_EL1=x;
+0:X3=y;
+
+1:X1=x;
+1:X3=y;
+}
+P0                                      | P1                                        ;
+MOV W1,#1                               | MOV X2,#4                                 ;
+STR W1,[X3] (* Memory (Write) effect *) | GCSSTR X2,[X1] (* GCS (Write) effect   *) ;
+DMB ST                                  | GCSB DSYNC     (* GCSB effect          *) ;
+GCSB DSYNC  (* GCSB effect           *) | DMB SY                                    ;
+GCSPOPM X0  (* GCS (Read) effect     *) | LDR W0,[X3]    (* Memory (Read) effect *) ;
+
+exists (0:X0=0 /\ 1:X0=0)

--- a/catalogue/aarch64-GCS/tests/SB+dmb.st-gcsb-ret+gcsb-dmb.sy.litmus
+++ b/catalogue/aarch64-GCS/tests/SB+dmb.st-gcsb-ret+gcsb-dmb.sy.litmus
@@ -1,0 +1,21 @@
+AArch64 SB+dmb.st-gcsb-ret+gcsb-dmb.sy
+variant=shadowstack
+{
+SS(x,1);
+
+0:GCSPR_EL1=x;
+0:X3=y;
+0:LR=label:"P0:L0";
+
+1:X1=x;
+1:X2=label:"P0:L0";
+1:X3=y;
+}
+P0                                      | P1                                        ;
+MOV W1,#1                               | GCSSTR X2,[X1] (* GCS (Write) effect   *) ;
+STR W1,[X3] (* Memory (Write) effect *) | GCSB DSYNC     (* GCSB effect          *) ;
+DMB ST                                  | DMB SY                                    ;
+GCSB DSYNC  (* GCSB effect           *) | LDR W0,[X3]    (* Memory (Read) effect *) ;
+RET         (* GCS (Read) effect     *) |                                           ;
+L0:                                     |                                           ;
+exists fault(P0,GCS:PRET) /\ 1:X0=0

--- a/catalogue/aarch64-GCS/tests/SB+dmb.st-gcsss1+gcsb-dmb.sy.litmus
+++ b/catalogue/aarch64-GCS/tests/SB+dmb.st-gcsss1+gcsb-dmb.sy.litmus
@@ -1,0 +1,22 @@
+AArch64 SB+dmb.st-gcsss1+gcsb-dmb.sy
+variant=shadowstack
+{
+SS(x,1);
+SS(z,1);
+
+0:X1=x;
+0:X3=y;
+0:GCSPR_EL1=z;
+
+1:X1=x;
+1:X3=y;
+
+}
+P0                                      | P1                                        ;
+MOV W2,#1                               | ADD X2,X1,#1                              ;
+STR W2,[X3] (* Memory (Write) effect *) | GCSSTR X2,[X1] (* GCS (Write) effect   *) ;
+DMB ST                                  | GCSB DSYNC     (* GCSB effect          *) ;
+GCSSS1 X1   (* GCSSS1 effect         *) | DMB SY                                    ;
+                                        | LDR W0,[X3]    (* Memory (Read) effect *) ;
+
+exists fault(P0,GCS:SS1) /\ 1:X0=0

--- a/catalogue/aarch64-GCS/tests/coWR+gcsbblp.litmus
+++ b/catalogue/aarch64-GCS/tests/coWR+gcsbblp.litmus
@@ -1,0 +1,17 @@
+AArch64 coWR+gcsbblp
+variant=shadowstack
+{
+
+  SS(x,1);
+
+  0:GCSPR_EL1=&x[1];
+
+  0:X0=x;
+}
+P0         ;
+BL L1      ; (* GCS (Write) effect   *)
+L1:        ;
+GCSB DSYNC ; (* GCSB effect          *)
+LDR X2,[X0]; (* Memory (Read) effect *)
+
+forall (0:X2=label:"P0:L1")

--- a/catalogue/aarch64-GCS/tests/coWR+gcsbgcspushmp.litmus
+++ b/catalogue/aarch64-GCS/tests/coWR+gcsbgcspushmp.litmus
@@ -1,0 +1,17 @@
+AArch64 coWR+gcsbgcspushmp
+variant=shadowstack
+{
+
+  SS(x,1);
+
+  0:GCSPR_EL1=&x[1];
+
+  0:X0=x;
+}
+P0          ;
+MOV X1,#1   ;
+GCSPUSHM X1 ; (* GCS (Write) effect   *)
+GCSB DSYNC  ; (* GCSB effect          *)
+LDR X2,[X0] ; (* Memory (Read) effect *)
+
+forall (0:X2=1)

--- a/catalogue/aarch64-GCS/tests/coWR+gcsbpgcspopm.litmus
+++ b/catalogue/aarch64-GCS/tests/coWR+gcsbpgcspopm.litmus
@@ -1,0 +1,19 @@
+AArch64 coWR+gcsbpgcspopm
+variant=shadowstack,vmsa
+{
+  uint64_t y=1;
+
+  SS(x,1);
+
+  [PTE(y)]=(oa:PA(x)); (* Alias y to x, otherwise STR would fault *)
+
+  0:GCSPR_EL1=&x[0];
+  0:X0=y;
+}
+P0          ;
+MOV X1,#4   ;
+STR X1,[X0] ; (* Memory (Write) effect  *)
+GCSB DSYNC  ; (* GCSB effect            *)
+GCSPOPM X2  ; (* GCS (Read) effect      *)
+
+forall (0:X2=4)

--- a/catalogue/aarch64-GCS/tests/coWR+gcsbpret.litmus
+++ b/catalogue/aarch64-GCS/tests/coWR+gcsbpret.litmus
@@ -1,0 +1,20 @@
+AArch64 coWR+gcsbpret
+variant=shadowstack, vmsa
+{
+  uint64_t y=1;
+
+  SS(x,1);
+
+  [PTE(y)]=(oa:PA(x)); (* Alias y to x, otherwise STR would fault *)
+
+  0:GCSPR_EL1=&x[0];
+  0:X0=y;
+  0:LR=label:"P0:L0";
+}
+P0          ;
+STR LR,[X0] ; (* Memory (Write) effect *)
+GCSB DSYNC  ; (* GCSB effect           *)
+RET         ; (* GCS (Read) effect     *)
+L0:         ;
+
+forall ~fault(P0,GCS:PRET)

--- a/catalogue/aarch64-GCS/tests/coWR+poblret.litmus
+++ b/catalogue/aarch64-GCS/tests/coWR+poblret.litmus
@@ -1,0 +1,16 @@
+AArch64 coWR+poblret
+variant=shadowstack
+{
+
+  SS(x,1);
+
+  0:GCSPR_EL1=&x[1];
+}
+P0    ;
+BL L0 ; (* GCS (Write) effect *)
+B L1  ;
+L0:   ;
+RET   ; (* GCS (Read) effect  *)
+L1:   ;
+
+forall ~fault(P0,GCS:PRET)

--- a/catalogue/aarch64-GCS/tests/coWR+pogcspushmgcspopm.litmus
+++ b/catalogue/aarch64-GCS/tests/coWR+pogcspushmgcspopm.litmus
@@ -1,0 +1,14 @@
+AArch64 coWR+pogcspushmgcspopm
+variant=shadowstack
+{
+
+  SS(x,1);
+
+  0:GCSPR_EL1=&x[1];
+}
+P0         ;
+MOV X1,#4  ;
+GCSPUSHM X1; (* GCS (Write) effect *)
+GCSPOPM X2 ; (* GCS (Read) effect  *)
+
+forall 0:X2=4

--- a/catalogue/aarch64-GCS/tests/coWR+pogcsss1gcsss2.litmus
+++ b/catalogue/aarch64-GCS/tests/coWR+pogcsss1gcsss2.litmus
@@ -1,0 +1,14 @@
+AArch64 coWR+pogcsss1gcsss2
+variant=shadowstack
+{
+  SS(x,2);
+  SS(y,1) = ssval_t: {SSCap(y,1)};
+
+  0:GCSPR_EL1=&x[1];
+  0:X0=y;
+}
+P0        ;
+GCSSS1 X0 ; (* GCSSS1 Memory effect, GCSPR = y[0], y[0] = SSCap(x[1],5)  *)
+GCSSS2 X0 ; (* GCS effect                                                *)
+
+forall ~fault(P0,GCS:SS2)

--- a/catalogue/aarch64-GCS/tests/coWR+pogcsstrgcsss1.litmus
+++ b/catalogue/aarch64-GCS/tests/coWR+pogcsstrgcsss1.litmus
@@ -1,0 +1,17 @@
+AArch64 coWR+pogcsstrgcsss1
+variant=shadowstack
+{
+
+  SS(x,1);
+  SS(y,1);
+
+  0:GCSPR_EL1=&x[1];
+  0:X0=y;
+
+}
+P0             ;
+ADD X1,X0,#1   ; (* Syntesize "valid" cap *)
+GCSSTR X1,[X0] ; (* GCS (Write) effect    *)
+GCSSS1 X0      ; (* GCSSS1 Memory effect  *)
+
+forall ~fault(P0,GCS:SS1)

--- a/catalogue/aarch64-GCS/tests/coWR+popgcsss1.litmus
+++ b/catalogue/aarch64-GCS/tests/coWR+popgcsss1.litmus
@@ -1,0 +1,20 @@
+AArch64 coWR+popgcsss1
+variant=shadowstack,vmsa
+{
+  uint64_t z=0;
+
+  SS(x,1);
+  SS(y,1);
+
+  [PTE(z)]=(oa:PA(y)); (* Alias z to y, otherwise STR would fault *)
+
+  0:GCSPR_EL1=&x[1];
+  0:X0=y;
+  0:X2=z;
+}
+P0           ;
+ADD X1,X0,#1 ; (* Syntesize "valid" cap *)
+STR X1,[X2]  ; (* Memory (Write) effect *)
+GCSSS1 X0    ; (* GCSSS1 Memory effect  *)
+
+forall ~fault(P0,GCS:SS1)

--- a/gen/common/AArch64Arch_gen.ml
+++ b/gen/common/AArch64Arch_gen.ml
@@ -909,6 +909,7 @@ let fold_some_fences f k =
   k
 
 let orders f d1 d2 = match f,d1,d2 with
+| Barrier GCSB,_,_
 | Barrier ISB,_,_ -> false
 | Barrier (DSB (_,FULL)|DMB (_,FULL)),_,_ -> true
 | Barrier (DSB (_,ST)|DMB (_,ST)),W,W -> true

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -48,17 +48,17 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
 
     let is_ifetch_annot = function
       | NExp IFetch -> true
-      | NExp (AF|DB|AFDB|Other)|Exp -> false
+      | NExp (AF|DB|AFDB|Other|GCS)|Exp -> false
 
     let is_barrier b1 b2 = barrier_compare b1 b2 = 0
 
     let is_af = function (* Setting of access flag *)
       | NExp (AF|AFDB)-> true
-      | NExp (DB|IFetch|Other)|Exp -> false
+      | NExp (DB|IFetch|Other|GCS)|Exp -> false
 
     and is_db = function (* Setting of dirty bit flag *)
       | NExp (DB|AFDB) -> true
-      | NExp (AF|IFetch|Other)|Exp -> false
+      | NExp (AF|IFetch|Other|GCS)|Exp -> false
 
     module CMO = struct
       type t = | DC of AArch64Base.DC.op | IC of AArch64Base.IC.op

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -115,6 +115,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_SMSTART _ | I_SMSTOP _ | I_LD1SPT _ | I_ST1SPT _
     | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
     | I_PAC _ | I_AUT _ | I_XPACI _ | I_XPACD _
+    | I_GCSPOPM _ | I_GCSPUSHM _ | I_GCSSTR _ | I_GCSSS1 _ | I_GCSSS2 _
       -> true
 
     let is_cmodx_restricted_value =
@@ -317,6 +318,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_RDVL _ | I_ADDVL _ | I_CNT_INC_SVE _ | I_CTERM _
       | I_SMSTART _ | I_SMSTOP _ | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
       | I_PAC _ | I_AUT _ | I_XPACI _ | I_XPACD _
+      | I_GCSPOPM _ | I_GCSPUSHM _ | I_GCSSTR _ | I_GCSSS1 _ | I_GCSSS2 _
           -> None
 
     let all_regs =
@@ -350,7 +352,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_FENCE _
       | I_IC _|I_DC _|I_TLBI _ | I_AT _
       | I_NOP|I_TBZ _|I_TBNZ _
-      | I_BL _ | I_BLR _ | I_RET _ | I_ERET | I_SVC _ | I_UDF _
+      | I_ERET | I_SVC _  | I_UDF _
       | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
       | I_ST1SPT _ | I_CTERM _
         -> [] (* For -variant self only ? *)
@@ -400,11 +402,24 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD1SPT (_,r,_,_,_,_,_) | I_MOVA_TV (r,_,_,_,_) | I_MOVA_VT (r,_,_,_,_)
       | I_ADDA (_,r,_,_,_)
       | I_IRG (r,_,_)
+      | I_GCSSTR (r,_)
         -> [r]
       | I_LDAR (_,(XX|AX),r,_) |I_LDARBH (_,(XX|AX),r,_)
         -> [r;ResAddr;]
       | I_STXR (_,_,r,_,_) | I_STXP (_,_,r,_,_, _) | I_STXRBH (_,_,r,_,_)
         -> [r;ResAddr;]
+      | I_BL _ | I_BLR _  when C.variant Variant.ShadowStack
+        -> [Ireg R30; SysReg GCSPR_EL1]
+      | I_RET _ when C.variant Variant.ShadowStack
+        -> [SysReg GCSPR_EL1]
+      | I_BL _ | I_BLR _
+        -> [Ireg R30]
+      | I_RET _
+        -> []
+      | I_GCSPUSHM _  | I_GCSSS1 _
+        -> [SysReg GCSPR_EL1]
+      | I_GCSPOPM r | I_GCSSS2 r
+        -> [r; SysReg GCSPR_EL1]
       | I_MSR (SYS_NZCV,_)
         ->
           nzcv_regs
@@ -495,6 +510,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LD1SPT _ | I_ST1SPT _
       | I_MOVA_TV _| I_MOVA_VT _ | I_ADDA _
       | I_PAC _ | I_AUT _ | I_XPACI _ | I_XPACD _
+      | I_GCSPOPM _ | I_GCSPUSHM _ | I_GCSSTR _ | I_GCSSS1 _ | I_GCSSS2 _
         -> MachSize.No
 
     let reg_defaults =

--- a/herd/AArch64Explicit.ml
+++ b/herd/AArch64Explicit.ml
@@ -14,7 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type nexp =  AF|DB|AFDB|IFetch|Other
+type nexp =  AF|DB|AFDB|IFetch|GCS|Other
 type explicit = Exp | NExp of nexp
 
 let pp = function
@@ -24,6 +24,7 @@ let pp = function
   | NExp AF-> "NExpAF"
   | NExp DB-> "NExpDB"
   | NExp AFDB-> "NExpAFDB"
+  | NExp GCS-> "GCS"
 
 let is_explicit_annot = function
   | Exp -> true

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -44,6 +44,7 @@ module Make
     let pac = C.variant Variant.Pac
     let const_pac_field = C.variant Variant.ConstPacField
     let fpac = C.variant Variant.FPac
+    let gcs = C.variant Variant.ShadowStack
 
     let check_kvm ins =
       if not kvm then
@@ -79,6 +80,12 @@ module Make
       if not sme then
         Warn.user_error
           "SME instruction %s requires -variant sme"
+          (AArch64.dump_instruction inst)
+
+    let check_gcs inst =
+      if not gcs then
+        Warn.user_error
+          "GCS instruction %s requires -variant shadowstack"
           (AArch64.dump_instruction inst)
 
 (* Barrier pretty print *)
@@ -943,7 +950,7 @@ module Make
           (fun _ ->
              set_elr_el1 lbl_v ii
              >>|
-             mk_fault (Some a) dir an ii ft msg) None ii
+             mk_fault a dir an ii ft msg) None ii
         >>!  B.fault [AArch64Base.elr_el1, lbl_v]
 
       (* Specific fault when accessing PTE from EL0. *)
@@ -951,7 +958,7 @@ module Make
         let open FaultType.AArch64 in
         let ft = Some (MMU (domain, Permission))
         and msg = Some "EL0" in
-        emit_fault a ma dir an ft msg ii
+        emit_fault (Some a) ma dir an ft msg ii
 
       let an_xpte =
         let open Annot in
@@ -1216,7 +1223,6 @@ module Make
 (* Page tables and TLBs *)
       let do_inv op a ii = inv_loc op (A.Location_global a) ii
 
-
 (************************)
 (* Conditions and flags *)
 (************************)
@@ -1458,7 +1464,7 @@ module Make
         | _ -> true)
 
       let lift_kvm _tag dir updatedb mop ma an ii mphy branch domain =
-        let mfault ma a ft = emit_fault a ma dir an ft None ii in
+        let mfault ma a ft = emit_fault (Some a) ma dir an ft None ii in
         let maccess a ma =
           check_ptw ii.AArch64.proc dir updatedb false a ma an ii
             (mop (Access.PTE domain) ma |> branch)
@@ -2184,7 +2190,7 @@ Arguments:
           (rmw_to_read rmw)
           ii
 
-      let do_cas_fail do_wb sz an rn ma mv mop ii =
+      let do_cas_fail do_wb sz an rn ma mv mop tagcheck ii =
         let action checked ma =
           let do_action updatedb checked ma =
               (* Dir.W would force check for dbm bit:                  *)
@@ -2208,7 +2214,7 @@ Arguments:
           end
         in
 
-        if memtag && C.mte_store_only then
+        if tagcheck && C.mte_store_only then
           (* If FEAT_MTE_STORE_ONLY is implemented it is              *)
           (* CONSTRAINED UNPREDICTABLE whether the Tag Check          *)
           (* operation is performed.                                  *)
@@ -2227,18 +2233,18 @@ Arguments:
       let do_cas_fail_with_wb = do_cas_fail true
       let do_cas_fail_no_wb = do_cas_fail false
 
-      let do_cas sz an rn ma mv mop_success mop_fail_with_wb mop_fail_no_wb ii =
+      let do_cas sz an rn ma mv mop_success mop_fail_with_wb mop_fail_no_wb tagcheck ii =
         M.altT (
           (* CAS succeeds and generates an Explicit Write Effect *)
           (* there must be an update to the dirty bit of the TTD *)
-          lift_memop ~tag:"CAS" rn Dir.W true memtag mop_success (to_perms "rw" sz) ma mv an ii
+          lift_memop ~tag:"CAS" rn Dir.W true tagcheck mop_success (to_perms "rw" sz) ma mv an ii
         )( (* CAS fails *)
           M.altT (
             (* CAS generates an Explicit Write Effect              *)
-            do_cas_fail_with_wb sz an rn ma mv mop_fail_with_wb ii
+            do_cas_fail_with_wb sz an rn ma mv mop_fail_with_wb tagcheck ii
           )(
             (* CAS does not generate an Explicit Write Effect      *)
-            do_cas_fail_no_wb sz an rn ma mv mop_fail_no_wb ii
+            do_cas_fail_no_wb sz an rn ma mv mop_fail_no_wb tagcheck ii
           )
         )
 
@@ -2283,7 +2289,7 @@ Arguments:
         in
         let ma = read_reg_addr rn ii
         and mv = read_reg_data_sz sz rt ii in
-        do_cas sz an rn ma mv mop_success mop_fail_with_wb mop_fail_no_wb ii
+        do_cas sz an rn ma mv mop_success mop_fail_with_wb mop_fail_no_wb memtag ii
 
       let casp sz rmw rs1 rs2 rt1 rt2 rn ii =
         let an = rmw_to_read rmw in
@@ -2344,7 +2350,7 @@ Arguments:
         in
         let ma = read_reg_addr rn ii
         and mv = read_reg_data_sz sz rt1 ii >>> fun _ -> read_reg_data_sz sz rt2 ii in
-        do_cas sz an rn ma mv mop_success mop_fail_with_wb mop_fail_no_wb ii
+        do_cas sz an rn ma mv mop_success mop_fail_with_wb mop_fail_no_wb memtag ii
 
       (* Temporary morello variation of CAS *)
       let cas_morello sz rmw rs rt rn ii =
@@ -3624,6 +3630,143 @@ Arguments:
         write_reg_dest r v ii >>= fun v ->
         B.nextSetT r v
 
+(*************************)
+(* Guarded Control Stack *)
+(*************************)
+      module GCSSem = struct
+        let mk_fault action ft ii =
+          emit_fault None action Dir.R Annot.N (Some ft) None ii
+
+        let get_cap mask v =
+          M.op1 Op.Offset v >>= M.op Op.And mask
+
+        let set_cap cap mask v =
+          let invert = V.op1 Op.Inv mask in
+          M.op1 Op.Offset v >>= fun offset ->
+            (* Strip offset *)
+            M.op Op.Sub v offset >>|
+            (* Extract index *)
+            (M.op Op.And offset invert >>|
+              (* Make sure cap fits into mask *)
+              M.op Op.And cap mask >>= fun (index, cap) ->
+                (* Make new offset *)
+                M.op Op.Or index cap) >>= fun (v, offset) ->
+                (* Write it back *)
+                M.op Op.Add v offset
+
+        let reset_cap = set_cap V.zero
+        let make_valid = set_cap V.one (V.intToV 0xfff)
+        let make_inprogress = set_cap (V.intToV 0x5) (V.intToV 0x7)
+
+        let read an a ii = do_read_mem_ret quad an aexp Access.VIR a ii
+        and write an a v ii = do_write_mem quad an aexp Access.VIR a v ii
+      end
+
+      let gcsss1 r ii =
+        let open AArch64Base in
+        let rA = SysReg GCSPR_EL1 in
+        M.delay_kont "gcsss1"
+        (read_reg_addr r ii)
+        (fun incoming ma ->
+          (* Valid cap entry is expected *)
+          let cmpoperand = read_reg_data r ii >>= GCSSem.make_valid in (* incoming_pointer[63:12]:'000000000001' *)
+          let branch v =
+            let cond = Printf.sprintf "(data==[%s])" (V.pp_v v) in
+            commit_pred_txt (Some cond) ii in
+          let update data =
+             GCSSem.make_valid incoming >>= fun v ->
+              let(>>*=) = M.bind_control_set_data_input_first in
+              let mok =
+                branch v >>*=
+                fun () -> write_reg rA incoming ii >>= fun () -> B.nextSetT rA incoming in
+              M.op Op.Eq data v >>= fun cond ->  (* if data == cmpoperand then                             *)
+              M.assertT cond mok >>= M.ignore   (*     SetCurrentGCSPointer(incoming_pointer[63:3]:'000'); *)
+          in
+          let fault data =
+             GCSSem.make_valid incoming >>= fun v ->
+              M.delay_kont "gcsss1(fault)"
+              (M.op Op.Ne data v)             (* if data != cmpoperand then                   *)
+              (fun cond action ->
+                let open FaultType.AArch64 in (*     GCSDataCheckException(GCSInstType_SS1);  *)
+                let mno = GCSSem.mk_fault action (GCSCheck SS1) ii in
+                M.assertT cond mno >>= M.ignore)
+          in
+          let branch a =
+            let cond = Printf.sprintf "Valid([%s])" (V.pp_v a) in
+            commit_pred_txt (Some cond) ii in
+          let mop_fail_no_wb _ ma _ =
+            (* GCSSS1 fails, there is no Explicit Write Effect *)
+            let read_mem a = GCSSem.read Annot.N a ii in
+            let noact _ _ = M.mk_singleton_es Act.NoAction ii in
+            M.altT (
+              M.aarch64_cas_no false ma cmpoperand update read_mem noact branch M.neqT
+            )(
+              M.aarch64_cas_no false ma cmpoperand fault read_mem noact branch M.neqT
+            )
+          in
+          let mop_fail_with_wb _ ma _ =
+            (* GCSSS1 fails, there is an Explicit Write Effect writing back *)
+            (* the value that is already in memory                          *)
+            let read_mem a = GCSSem.read Annot.X a ii
+            and write_mem a v = GCSSem.write Annot.X a v ii in
+            M.altT(
+                M.aarch64_cas_no false ma cmpoperand update read_mem write_mem branch M.neqT
+              )(
+                M.aarch64_cas_no false ma cmpoperand fault read_mem write_mem branch M.neqT
+              )
+          in
+          let mop_success _ ma mv =
+            (* GCSSS1 succeeds, there is an Explicit Write Effect *)
+            (* mv is read new value from reg, not important       *)
+            (* as this code is not executed in morello mode       *)
+            (* In-progress cap entry should be stored if the comparison is successful *)
+            let operand = mv >>= GCSSem.make_inprogress (* outgoing_pointer[63:3]:'101' *)
+            and read_mem a = GCSSem.read Annot.X a ii
+            and write_mem a v = GCSSem.write Annot.X a v ii in
+           M.altT(
+             M.aarch64_cas_ok false ma cmpoperand operand update read_mem write_mem branch M.eqT
+            )(
+              M.aarch64_cas_ok false ma cmpoperand operand fault read_mem write_mem branch M.eqT
+            )
+          in
+          let mv = read_reg_data rA ii in
+          do_cas quad Annot.N r ma mv mop_success mop_fail_with_wb mop_fail_no_wb false ii)
+
+    let gcsss2 r ii =
+      let open AArch64Base in
+      let rA = SysReg GCSPR_EL1
+      and off = MachSize.nbytes quad in
+      read_reg_addr rA ii >>= fun incoming ->
+        let m = GCSSem.read Annot.N incoming ii >>= fun outgoing ->
+          let mask = V.intToV 0x7 in
+            GCSSem.get_cap mask outgoing >>= fun cap ->
+              let(>>*=) = M.bind_control_set_data_input_first in
+              let commit =
+                let cond = Printf.sprintf "InProgress([%s])" (V.pp_v incoming) in
+                commit_pred_txt (Some cond) ii in
+              let mok =
+                commit >>*= fun () ->
+                  (GCSSem.reset_cap mask outgoing >>= M.add (V.intToV (-off))) >>|
+                    GCSSem.make_valid outgoing >>= fun (addr, v) ->
+                      write_reg r addr ii >>|
+                      (M.add (V.intToV (off)) incoming >>= fun new_addr ->
+                        write_reg rA new_addr ii) >>|
+                          (GCSSem.write Annot.N addr v ii >>=
+                           M.ignore >>= fun() -> create_barrier GCSB ii) >>=
+                       M.ignore >>= fun() -> B.nextT in
+              let inprogress = V.intToV 0x5 in
+              M.delay_kont "gcsss2(fault)"
+              (M.op Op.Ne cap inprogress)
+              (fun notvalid action ->
+                let open FaultType.AArch64 in
+                let mno = GCSSem.mk_fault action (GCSCheck SS2) ii in
+                let mok = action >>= fun _ -> mok in
+                M.choiceT notvalid mno mok)
+          in
+          (* Register write and write to other stack depend on load from Shadow Stack *)
+          let store e = (E.is_mem_store e) || (is_this_reg r e) in
+          M.short (E.is_mem_load) store m
+
 (********************)
 (* Main entry point *)
 (********************)
@@ -3662,26 +3805,80 @@ Arguments:
            let v_ret = get_link_addr test ii in
            let write_linkreg = write_reg AArch64Base.linkreg v_ret ii in
            let branch () = M.unitT (B.Jump (tgt2tgt ii l,[AArch64Base.linkreg,v_ret])) in
-           M.bind_order write_linkreg branch
-
+           let op =
+            if not gcs then
+              write_linkreg
+            else
+              let open AArch64Base in
+              let rA = SysReg GCSPR_EL1
+              and off = MachSize.nbytes quad in
+              (read_reg_addr rA ii >>= M.add (V.intToV (-off)) >>= fun new_addr ->
+                GCSSem.write Annot.N new_addr v_ret ii
+                >>| write_reg rA new_addr ii)
+              >>| write_linkreg >>= M.ignore
+            in
+           M.bind_order op branch
         | I_BR r as i ->
             read_reg_ord r ii >>= do_indirect_jump test [] i ii
-
         | I_BLR r as i ->
            let v_ret = get_link_addr test ii in
            let read_rn = read_reg_ord r ii in
            let branch = read_rn >>= do_indirect_jump test [AArch64Base.linkreg,v_ret] i ii in
            let write_linkreg = write_reg AArch64Base.linkreg v_ret ii in
-           write_linkreg >>| branch >>= fun (_, b) -> M.unitT b
+           let op =
+            if not gcs then
+              M.unitT()
+            else
+              let open AArch64Base in
+              let rA = SysReg GCSPR_EL1
+              and off = MachSize.nbytes quad in
+              read_reg_addr rA ii >>= M.add (V.intToV (-off)) >>= fun new_addr ->
+                GCSSem.write Annot.N new_addr v_ret ii
+                >>| write_reg rA new_addr ii >>= M.ignore
+            in
+           op >>| write_linkreg >>| branch >>= fun (_, b) -> M.unitT b
         | I_RET None when C.variant Variant.Telechat ->
            M.unitT B.Exit
         | I_RET ro as i ->
             let r = match ro with
             | None -> AArch64Base.linkreg
             | Some r -> r in
-            read_reg_ord r ii
-            >>= do_indirect_jump test [] i ii
-
+              if not gcs then
+                read_reg_ord r ii >>= do_indirect_jump test [] i ii
+              else
+              begin
+                let open AArch64Base in
+                let rA = SysReg GCSPR_EL1
+                and off = MachSize.nbytes quad in
+                let m =
+                  read_reg_ord r ii >>|
+                    (read_reg_addr rA ii >>= fun addr->
+                      M.unitT addr >>|
+                      GCSSem.read Annot.N addr ii) >>= fun (target,(addr,v)) ->
+                        let commit =
+                          let cond = Printf.sprintf "target==%d:%s" ii.A.proc (A.pp_reg r) in
+                          commit_pred_txt (Some cond) ii in
+                        let mok =
+                          let(>>*=) = M.bind_control_set_data_input_first in
+                          commit >>*= fun () ->
+                            (M.add addr (V.intToV off) >>= fun new_addr ->
+                            write_reg rA new_addr ii) >>|
+                            do_indirect_jump test [] i ii target >>= fun (_, b) -> M.unitT b in
+                        M.delay_kont "ret(fault)"
+                        (M.op Op.Ne v target)
+                        (fun cond action ->
+                          let open FaultType.AArch64 in
+                          let mno = GCSSem.mk_fault action (GCSCheck PRET) ii in
+                          let mok = action >>= fun _ -> mok in
+                          M.choiceT cond mno mok)
+                in
+                (* Value writen to GCSPR depends on previous read *)
+                let read e = (is_this_reg rA e) && (E.is_reg_load e ii.A.proc)
+                and write e = (is_this_reg rA e) && (E.is_reg_store e ii.A.proc) in
+                let m = M.short read write m in
+                (* Branch depends on destination register (or LR) *)
+                M.short (is_this_reg r) (E.is_bcc) m
+              end
         | I_ERET ->
            let eret_to_addr v =
               match v2tgt v with
@@ -4552,6 +4749,10 @@ Arguments:
            >>= nextSet rd
         (* Barrier *)
         | I_FENCE b ->
+            begin match b with
+            | AArch64Base.GCSB -> check_gcs inst
+            | _ -> ()
+            end;
             !(create_barrier b ii)
               (* Conditional selection *)
         | I_CSEL (var,r1,r2,r3,c,op) ->
@@ -4689,6 +4890,57 @@ Arguments:
             do_aut key rd rn ii
         | I_XPACI r | I_XPACD r ->
             do_xpac r ii
+(* Guarded Control Stack *)
+        | I_GCSPOPM rd ->
+          check_gcs inst;
+          let open AArch64Base in
+          let rA = SysReg GCSPR_EL1
+          and off = MachSize.nbytes quad in
+          read_reg_addr rA ii >>= fun addr ->
+            let m = GCSSem.read Annot.N addr ii
+            >>= fun v ->
+              let commit =
+                commit_pred_txt (Some "PCAligned") ii in
+              let mok =
+                (* Write to GCSPR depends on earlier read *)
+                let(>>*=) = M.bind_control_set_data_input_first in
+                commit >>*=
+                fun () ->
+                  !!(M.add addr (V.intToV off) >>= fun new_addr ->
+                      write_reg rd v ii >>|
+                      write_reg rA new_addr ii) in
+              let mask = V.intToV 0x3 in
+              GCSSem.get_cap mask v >>= fun cap ->
+              M.delay_kont "gcspop(fault)"
+              (M.op Op.Ne cap V.zero)
+              (fun nonzero action ->
+                let open FaultType.AArch64 in
+                let mno = GCSSem.mk_fault action (GCSCheck POPM) ii in
+                let mok = action >>= fun _ -> mok in
+                M.choiceT nonzero mno mok)
+              (* Write to Rd depends on read from Shadow Stack *)
+              in M.short (E.is_mem_load) (is_this_reg rd) m
+        | I_GCSPUSHM rs ->
+          check_gcs inst;
+          !!( let open AArch64Base in
+              let rA = SysReg GCSPR_EL1
+              and off = MachSize.nbytes quad in
+              (read_reg_addr rA ii >>= fun a -> M.add a (V.intToV (-off))) >>= fun addr ->
+                write_reg rA addr ii >>|
+                M.data_input_next
+                (read_reg_data rs ii)
+                (fun v -> GCSSem.write Annot.N addr v ii))
+        | I_GCSSTR (r1,r2) ->
+          check_gcs inst;
+          !(read_reg_addr r2 ii >>|
+            read_reg_data r1 ii >>= fun (addr, v) ->
+              GCSSem.write Annot.N addr v ii)
+        | I_GCSSS1 r ->
+          check_gcs inst;
+          gcsss1 r ii
+        | I_GCSSS2 r ->
+          check_gcs inst;
+          gcsss2 r ii
 (*  Cannot handle *)
         (* | I_BL _|I_BLR _|I_BR _|I_RET _ *)
         | (I_STG _|I_ST2G _|I_STZG _|I_STZ2G _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -756,7 +756,7 @@ module Make
         function
         | AF -> AArch64Op.SetAF
         | DB -> AArch64Op.SetDB
-        | IFetch|Other|AFDB -> assert false
+        | IFetch|Other|AFDB|GCS -> assert false
 
       let do_test_and_set_bit v combine cond set a_pte iiid domain =
         let nexp = AArch64Explicit.NExp set in
@@ -3658,9 +3658,10 @@ Arguments:
         let make_valid = set_cap V.one (V.intToV 0xfff)
         let make_inprogress = set_cap (V.intToV 0x5) (V.intToV 0x7)
 
-        let read ac an a ii = do_read_mem_ret quad an aexp ac a ii
-        and write ac an a v ii = do_write_mem quad an aexp ac a v ii
+        let read ac an a ii = do_read_mem_ret quad an AArch64Explicit.(NExp GCS) ac a ii
+        and write ac an a v ii = do_write_mem quad an AArch64Explicit.(NExp GCS) ac a v ii
       end
+
 
       let gcsstr r1 r2 ii =
         let an = Annot.N in
@@ -3939,7 +3940,7 @@ Arguments:
       (read_reg_addr rA ii)
       (fun a_virt ma ->
       let mop ac incoming =
-        let m = GCSSem.read ac an incoming ii >>= fun outgoing ->
+        let m = GCSSem.read ac Annot.A incoming ii >>= fun outgoing ->
           let mask = V.intToV 0x7 in
           GCSSem.get_cap mask outgoing >>= fun cap ->
             let(>>*=) = M.bind_control_set_data_input_first in
@@ -3952,8 +3953,7 @@ Arguments:
                   (GCSSem.reset_cap mask outgoing >>= M.add (V.intToV (-off)) >>= fun v -> write_reg r v ii) >>|
                    (M.add a_virt (V.intToV (off)) >>= fun new_addr ->
                       write_reg rA new_addr ii) >>|
-                      (GCSSem.make_valid outgoing >>= fun outgoing_value -> GCSSem.write ac an a outgoing_value ii >>=
-                       M.ignore >>= fun() -> create_barrier GCSB ii)
+                      (GCSSem.make_valid outgoing >>= fun outgoing_value -> GCSSem.write ac Annot.L a outgoing_value ii)
                 in
                 lift_memop r Dir.W true false
                 (fun ac ma mv ->

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -3658,26 +3658,216 @@ Arguments:
         let make_valid = set_cap V.one (V.intToV 0xfff)
         let make_inprogress = set_cap (V.intToV 0x5) (V.intToV 0x7)
 
-        let read an a ii = do_read_mem_ret quad an aexp Access.VIR a ii
-        and write an a v ii = do_write_mem quad an aexp Access.VIR a v ii
+        let read ac an a ii = do_read_mem_ret quad an aexp ac a ii
+        and write ac an a v ii = do_write_mem quad an aexp ac a v ii
       end
+
+      let gcsstr r1 r2 ii =
+        let an = Annot.N in
+        let mop ac a v = GCSSem.write ac an a v ii in
+        lift_memop r2 Dir.W true false
+        (fun ac ma mv ->
+          if is_branching && Access.is_physical ac then
+            M.bind_ctrldata_data ma mv (fun a v -> mop ac a v)
+          else
+            ma >>| mv >>= fun (a,v) -> mop ac a v
+        )
+        (to_perms "w" quad)
+        (read_reg_addr r2 ii)
+        (read_reg_data r1 ii)
+        an
+        ii
+
+      let gcspushm rs ii =
+        let open AArch64Base in
+        let an = Annot.N
+        and rA = SysReg GCSPR_EL1
+        and off = MachSize.nbytes quad in
+        let m =
+          read_reg_addr rA ii >>= fun addr ->
+            M.add addr (V.intToV (-off)) >>= fun a_virt ->
+            let mop ac a _v =
+                write_reg rA a_virt ii >>|
+                M.data_input_next
+                (read_reg_data rs ii)
+                (fun v -> GCSSem.write ac an a v ii)
+                >>= M.ignore >>= fun () -> B.nextSetT rA a_virt in
+            lift_memop rA Dir.W true false
+            (fun ac ma mv ->
+              if is_branching && Access.is_physical ac then
+                M.bind_ctrldata_data ma mv (fun a v -> mop ac a v)
+              else
+                ma >>| mv >>= fun (a,v) -> mop ac a v)
+            (to_perms "w" quad)
+            (M.unitT a_virt)
+            mzero
+            an
+            ii in
+        (* Value writen to GCSPR depends on previous read *)
+        let read e = (is_this_reg rA e) && (E.is_reg_load e ii.A.proc)
+        and write e = (is_this_reg rA e) && (E.is_reg_store e ii.A.proc) in
+        M.short read write m
+
+      let gcspopm rd ii =
+        let open AArch64Base in
+        let an = Annot.N
+        and rA = SysReg GCSPR_EL1
+        and off = MachSize.nbytes quad in
+        let m =
+        read_reg_addr rA ii >>= fun a_virt ->
+          let mop ac a =
+            let m = GCSSem.read ac an a ii >>= fun v ->
+              let commit = commit_pred_txt (Some "PCAligned") ii in
+              let mok =
+                let(>>*=) = M.bind_control_set_data_input_first in
+                commit >>*= fun () ->
+                  M.add a_virt (V.intToV off) >>= fun new_addr ->
+                    write_reg rd v ii >>|
+                    write_reg rA new_addr ii
+                    >>= M.ignore >>= B.next1T in
+              let mask = V.intToV 0x3 in
+               GCSSem.get_cap mask v >>= fun cap ->
+               M.delay_kont "gcspopm(fault)"
+               (M.op Op.Ne cap V.zero)
+               (fun nonzero action ->
+                 let open FaultType.AArch64 in
+                 let mno = GCSSem.mk_fault action (GCSCheck POPM) ii in
+                 let mok = action >>= fun _ -> mok in
+                 M.choiceT nonzero mno mok)
+            in
+            (* Write to Rd depends on read from Shadow Stack *)
+            M.short (E.is_mem_load) (is_this_reg rd) m in
+          lift_memop rA Dir.R false false
+          (fun ac ma _mv ->
+            if Access.is_physical ac then
+              M.bind_ctrldata ma (mop ac)
+            else
+              ma >>= mop ac)
+          (to_perms "r" quad)
+          (M.unitT a_virt)
+          mzero
+          an
+          ii in
+        (* Value writen to GCSPR depends on previous read *)
+        let read e = (is_this_reg rA e) && (E.is_reg_load e ii.A.proc)
+        and write e = (is_this_reg rA e) && (E.is_reg_store e ii.A.proc) in
+        M.short read write m
+
+      (*
+       * Basically copy of lift_memop which allows mop to drive control flow
+       * (handy for BL{R}/RET instructions with GCS enabled)
+       *)
+      let lift_shadow_stack dir updatedb mop ma mv an ii =
+        let domain = DISide.Data in
+        let mop = apply_mv mop mv in
+        if kvm then
+          let mphy ma a_virt =
+            let ma = get_oa a_virt ma in
+              mop Access.PHY ma
+          in
+          (* lift_kvm dir updatedb mop ma an ii mphy in *)
+          let mfault ma a ft = emit_fault (Some a) ma dir an ft None ii in
+          let maccess a ma =
+            check_ptw ii.AArch64.proc dir updatedb false a ma an ii
+            (mop (Access.PTE domain) ma)
+            mphy
+            mfault
+            domain in
+          M.delay_kont "shadow_stack"
+          ma
+          (fun a ma ->
+            match Act.access_of_location_std (A.Location_global a) with
+            | Access.VIR|Access.PTE _ when not (A.V.is_instrloc a) ->
+              maccess a ma
+            | ac ->
+              mop ac ma)
+        else
+          mop Access.VIR ma
+
+      let blop v_ret write_linkreg branch bop ii =
+        let open AArch64Base in
+        let an = Annot.N
+        and rA = SysReg GCSPR_EL1
+        and off = MachSize.nbytes quad in
+        read_reg_addr rA ii >>= fun addr -> M.add addr (V.intToV (-off)) >>= fun a_virt ->
+          let mop ac a v =
+            GCSSem.write ac an a v ii >>|
+            write_reg rA a_virt ii >>|
+            write_linkreg >>= M.ignore in
+          lift_shadow_stack Dir.W true
+          (fun ac ma mv ->
+            let m =
+              if is_branching && Access.is_physical ac then
+                M.bind_ctrldata_data ma mv (fun a v -> bop (mop ac a v) branch)
+              else
+                ma >>| mv >>= fun (a,v) -> bop (mop ac a v) branch
+            in
+            (* Value writen to GCSPR depends on previous read *)
+            let read e = (is_this_reg rA e) && (E.is_reg_load e ii.A.proc)
+            and write e = (is_this_reg rA e) && (E.is_reg_store e ii.A.proc) in
+            M.short read write m)
+          (M.unitT a_virt)
+          (M.unitT v_ret)
+          an
+          ii
+
+      let retop test i r ii =
+        let open AArch64Base in
+        let an = Annot.N
+        and rA = SysReg GCSPR_EL1
+        and off = MachSize.nbytes quad in
+        read_reg_addr rA ii >>= fun a_virt ->
+          lift_shadow_stack Dir.R false
+          (fun ac ma mv ->
+            let m =
+              mv >>|
+              (let(>>=) = if Access.is_physical ac then M.bind_ctrldata else (>>=) in
+                ma >>= fun addr ->
+                  GCSSem.read ac an addr ii) >>= fun (target,v) ->
+                    let commit =
+                      let cond = Printf.sprintf "target==%d:%s" ii.A.proc (A.pp_reg r) in
+                        commit_pred_txt (Some cond) ii in
+                    let mok =
+                      let(>>*=) = M.bind_control_set_data_input_first in
+                      commit >>*= fun () ->
+                        (M.add a_virt (V.intToV off) >>= fun new_addr ->
+                          write_reg rA new_addr ii) >>|
+                        do_indirect_jump test [] i ii target >>= fun (_, b) -> M.unitT b in
+                    M.delay_kont "ret(fault)"
+                    (M.op Op.Ne v target)
+                    (fun cond action ->
+                      let open FaultType.AArch64 in
+                      let mno = GCSSem.mk_fault action (GCSCheck PRET) ii in
+                      let mok = action >>= fun _ -> mok in
+                      M.choiceT cond mno mok)
+              in
+              (* Value writen to GCSPR depends on previous read *)
+              let read e = (is_this_reg rA e) && (E.is_reg_load e ii.A.proc)
+              and write e = (is_this_reg rA e) && (E.is_reg_store e ii.A.proc) in
+              let m = M.short read write m in
+              (* Branch depends on destination register (or LR) *)
+              M.short (is_this_reg r) (E.is_bcc) m)
+          (M.unitT a_virt)
+          (read_reg_ord r ii)
+          an
+          ii
 
       let gcsss1 r ii =
         let open AArch64Base in
-        let rA = SysReg GCSPR_EL1 in
+        let an = Annot.X
+        and rA = SysReg GCSPR_EL1 in
         M.delay_kont "gcsss1"
         (read_reg_addr r ii)
         (fun incoming ma ->
           (* Valid cap entry is expected *)
           let cmpoperand = read_reg_data r ii >>= GCSSem.make_valid in (* incoming_pointer[63:12]:'000000000001' *)
-          let branch v =
-            let cond = Printf.sprintf "(data==[%s])" (V.pp_v v) in
-            commit_pred_txt (Some cond) ii in
+          let cond2 = Some "(data==cmpoperand)" in
+          let branch = commit_pred_txt cond2 ii in
           let update data =
              GCSSem.make_valid incoming >>= fun v ->
               let(>>*=) = M.bind_control_set_data_input_first in
               let mok =
-                branch v >>*=
+                branch >>*=
                 fun () -> write_reg rA incoming ii >>= fun () -> B.nextSetT rA incoming in
               M.op Op.Eq data v >>= fun cond ->  (* if data == cmpoperand then                             *)
               M.assertT cond mok >>= M.ignore   (*     SetCurrentGCSPointer(incoming_pointer[63:3]:'000'); *)
@@ -3692,41 +3882,48 @@ Arguments:
                 M.assertT cond mno >>= M.ignore)
           in
           let branch a =
-            let cond = Printf.sprintf "Valid([%s])" (V.pp_v a) in
-            commit_pred_txt (Some cond) ii in
-          let mop_fail_no_wb _ ma _ =
+            let cond1 = Some (Printf.sprintf "Valid([%s])" (V.pp_v a)) in
+            commit_pred_txt cond1 ii in
+          let shortcut =
+            let read_reg e =
+              let is_reg = is_this_reg r e
+              and is_load = E.is_reg_load e ii.A.proc in
+              is_reg && is_load
+            in
+            M.short read_reg (E.is_pred_txt cond2) in
+          let mop_fail_no_wb ac ma _ =
             (* GCSSS1 fails, there is no Explicit Write Effect *)
-            let read_mem a = GCSSem.read Annot.N a ii in
+            let read_mem a = GCSSem.read ac an a ii in
             let noact _ _ = M.mk_singleton_es Act.NoAction ii in
             M.altT (
-              M.aarch64_cas_no false ma cmpoperand update read_mem noact branch M.neqT
+              M.aarch64_cas_no (Access.is_physical ac) ma cmpoperand update read_mem noact branch M.neqT |> shortcut
             )(
-              M.aarch64_cas_no false ma cmpoperand fault read_mem noact branch M.neqT
+              M.aarch64_cas_no (Access.is_physical ac) ma cmpoperand fault read_mem noact branch M.neqT |> shortcut
             )
           in
-          let mop_fail_with_wb _ ma _ =
+          let mop_fail_with_wb ac ma _ =
             (* GCSSS1 fails, there is an Explicit Write Effect writing back *)
             (* the value that is already in memory                          *)
-            let read_mem a = GCSSem.read Annot.X a ii
-            and write_mem a v = GCSSem.write Annot.X a v ii in
+            let read_mem a = GCSSem.read ac Annot.X a ii
+            and write_mem a v = GCSSem.write ac Annot.X a v ii in
             M.altT(
-                M.aarch64_cas_no false ma cmpoperand update read_mem write_mem branch M.neqT
+                M.aarch64_cas_no (Access.is_physical ac) ma cmpoperand update read_mem write_mem branch M.neqT |> shortcut
               )(
-                M.aarch64_cas_no false ma cmpoperand fault read_mem write_mem branch M.neqT
+                M.aarch64_cas_no (Access.is_physical ac) ma cmpoperand fault read_mem write_mem branch M.neqT |> shortcut
               )
           in
-          let mop_success _ ma mv =
+          let mop_success ac ma mv =
             (* GCSSS1 succeeds, there is an Explicit Write Effect *)
             (* mv is read new value from reg, not important       *)
             (* as this code is not executed in morello mode       *)
             (* In-progress cap entry should be stored if the comparison is successful *)
             let operand = mv >>= GCSSem.make_inprogress (* outgoing_pointer[63:3]:'101' *)
-            and read_mem a = GCSSem.read Annot.X a ii
-            and write_mem a v = GCSSem.write Annot.X a v ii in
+            and read_mem a = GCSSem.read ac Annot.X a ii
+            and write_mem a v = GCSSem.write ac Annot.X a v ii in
            M.altT(
-             M.aarch64_cas_ok false ma cmpoperand operand update read_mem write_mem branch M.eqT
+             M.aarch64_cas_ok (Access.is_physical ac) ma cmpoperand operand update read_mem write_mem branch M.eqT |> shortcut
             )(
-              M.aarch64_cas_ok false ma cmpoperand operand fault read_mem write_mem branch M.eqT
+              M.aarch64_cas_ok (Access.is_physical ac) ma cmpoperand operand fault read_mem write_mem branch M.eqT |> shortcut
             )
           in
           let mv = read_reg_data rA ii in
@@ -3734,38 +3931,69 @@ Arguments:
 
     let gcsss2 r ii =
       let open AArch64Base in
-      let rA = SysReg GCSPR_EL1
+      let an = Annot.N
+      and rA = SysReg GCSPR_EL1
       and off = MachSize.nbytes quad in
-      read_reg_addr rA ii >>= fun incoming ->
-        let m = GCSSem.read Annot.N incoming ii >>= fun outgoing ->
+      let m =
+      M.delay_kont "gcsss2"
+      (read_reg_addr rA ii)
+      (fun a_virt ma ->
+      let mop ac incoming =
+        let m = GCSSem.read ac an incoming ii >>= fun outgoing ->
           let mask = V.intToV 0x7 in
-            GCSSem.get_cap mask outgoing >>= fun cap ->
-              let(>>*=) = M.bind_control_set_data_input_first in
-              let commit =
-                let cond = Printf.sprintf "InProgress([%s])" (V.pp_v incoming) in
-                commit_pred_txt (Some cond) ii in
-              let mok =
-                commit >>*= fun () ->
-                  (GCSSem.reset_cap mask outgoing >>= M.add (V.intToV (-off))) >>|
-                    GCSSem.make_valid outgoing >>= fun (addr, v) ->
-                      write_reg r addr ii >>|
-                      (M.add (V.intToV (off)) incoming >>= fun new_addr ->
-                        write_reg rA new_addr ii) >>|
-                          (GCSSem.write Annot.N addr v ii >>=
-                           M.ignore >>= fun() -> create_barrier GCSB ii) >>=
-                       M.ignore >>= fun() -> B.nextT in
-              let inprogress = V.intToV 0x5 in
-              M.delay_kont "gcsss2(fault)"
-              (M.op Op.Ne cap inprogress)
-              (fun notvalid action ->
-                let open FaultType.AArch64 in
-                let mno = GCSSem.mk_fault action (GCSCheck SS2) ii in
-                let mok = action >>= fun _ -> mok in
-                M.choiceT notvalid mno mok)
+          GCSSem.get_cap mask outgoing >>= fun cap ->
+            let(>>*=) = M.bind_control_set_data_input_first in
+            let commit =
+              let cond = Printf.sprintf "InProgress([%s])" (V.pp_v incoming) in
+              commit_pred_txt (Some cond) ii in
+            let mok =
+              commit >>*= fun () ->
+                let mop ac a outgoing =
+                  (GCSSem.reset_cap mask outgoing >>= M.add (V.intToV (-off)) >>= fun v -> write_reg r v ii) >>|
+                   (M.add a_virt (V.intToV (off)) >>= fun new_addr ->
+                      write_reg rA new_addr ii) >>|
+                      (GCSSem.make_valid outgoing >>= fun outgoing_value -> GCSSem.write ac an a outgoing_value ii >>=
+                       M.ignore >>= fun() -> create_barrier GCSB ii)
+                in
+                lift_memop r Dir.W true false
+                (fun ac ma mv ->
+                  if is_branching && Access.is_physical ac then
+                    M.bind_ctrldata_data ma mv (fun a v -> mop ac a v)
+                  else
+                    ma >>| mv >>= fun (a,v) -> mop ac a v)
+                (to_perms "w" quad)
+                (GCSSem.reset_cap mask outgoing >>= M.add (V.intToV (-off)))
+                (M.unitT outgoing)
+                an
+                ii in
+            let inprogress = V.intToV 0x5 in
+            M.delay_kont "gcsss2(fault)"
+            (M.op Op.Ne cap inprogress)
+            (fun notvalid action ->
+              let open FaultType.AArch64 in
+              let mno = GCSSem.mk_fault action (GCSCheck SS2) ii in
+              let mok = action >>= fun _ -> mok in
+              M.choiceT notvalid mno mok)
           in
-          (* Register write and write to other stack depend on load from Shadow Stack *)
-          let store e = (E.is_mem_store e) || (is_this_reg r e) in
-          M.short (E.is_mem_load) store m
+        (* Register write and write to other stack depend on load from Shadow Stack *)
+        let store e = (E.is_mem_store e) || (is_this_reg r e) in
+        M.short (E.is_mem_load) store m in
+      lift_memop rA Dir.R false false
+      (fun ac ma _mv ->
+        if Access.is_physical ac then
+          M.bind_ctrldata ma (mop ac)
+        else
+          ma >>= mop ac)
+      (to_perms "r" quad)
+      ma
+      mzero
+      an
+      ii) in
+      (* Value writen to GCSPR depends on previous read *)
+      let read e = (is_this_reg rA e) && (E.is_reg_load e ii.A.proc)
+      and write e = (is_this_reg rA e) && (E.is_reg_store e ii.A.proc) in
+      M.short read write m
+
 
 (********************)
 (* Main entry point *)
@@ -3805,19 +4033,11 @@ Arguments:
            let v_ret = get_link_addr test ii in
            let write_linkreg = write_reg AArch64Base.linkreg v_ret ii in
            let branch () = M.unitT (B.Jump (tgt2tgt ii l,[AArch64Base.linkreg,v_ret])) in
-           let op =
-            if not gcs then
-              write_linkreg
-            else
-              let open AArch64Base in
-              let rA = SysReg GCSPR_EL1
-              and off = MachSize.nbytes quad in
-              (read_reg_addr rA ii >>= M.add (V.intToV (-off)) >>= fun new_addr ->
-                GCSSem.write Annot.N new_addr v_ret ii
-                >>| write_reg rA new_addr ii)
-              >>| write_linkreg >>= M.ignore
-            in
-           M.bind_order op branch
+           let bop a b = M.bind_order a b in
+           if gcs then
+            blop v_ret write_linkreg branch bop ii
+           else
+            bop write_linkreg branch
         | I_BR r as i ->
             read_reg_ord r ii >>= do_indirect_jump test [] i ii
         | I_BLR r as i ->
@@ -3825,60 +4045,21 @@ Arguments:
            let read_rn = read_reg_ord r ii in
            let branch = read_rn >>= do_indirect_jump test [AArch64Base.linkreg,v_ret] i ii in
            let write_linkreg = write_reg AArch64Base.linkreg v_ret ii in
-           let op =
-            if not gcs then
-              M.unitT()
-            else
-              let open AArch64Base in
-              let rA = SysReg GCSPR_EL1
-              and off = MachSize.nbytes quad in
-              read_reg_addr rA ii >>= M.add (V.intToV (-off)) >>= fun new_addr ->
-                GCSSem.write Annot.N new_addr v_ret ii
-                >>| write_reg rA new_addr ii >>= M.ignore
-            in
-           op >>| write_linkreg >>| branch >>= fun (_, b) -> M.unitT b
+           let bop a b = a >>| b >>= fun (_, b) -> M.unitT b in
+           if gcs then
+            blop v_ret write_linkreg branch bop ii
+           else
+            bop write_linkreg branch
         | I_RET None when C.variant Variant.Telechat ->
            M.unitT B.Exit
         | I_RET ro as i ->
             let r = match ro with
             | None -> AArch64Base.linkreg
             | Some r -> r in
-              if not gcs then
-                read_reg_ord r ii >>= do_indirect_jump test [] i ii
+              if gcs then
+                retop test i r ii
               else
-              begin
-                let open AArch64Base in
-                let rA = SysReg GCSPR_EL1
-                and off = MachSize.nbytes quad in
-                let m =
-                  read_reg_ord r ii >>|
-                    (read_reg_addr rA ii >>= fun addr->
-                      M.unitT addr >>|
-                      GCSSem.read Annot.N addr ii) >>= fun (target,(addr,v)) ->
-                        let commit =
-                          let cond = Printf.sprintf "target==%d:%s" ii.A.proc (A.pp_reg r) in
-                          commit_pred_txt (Some cond) ii in
-                        let mok =
-                          let(>>*=) = M.bind_control_set_data_input_first in
-                          commit >>*= fun () ->
-                            (M.add addr (V.intToV off) >>= fun new_addr ->
-                            write_reg rA new_addr ii) >>|
-                            do_indirect_jump test [] i ii target >>= fun (_, b) -> M.unitT b in
-                        M.delay_kont "ret(fault)"
-                        (M.op Op.Ne v target)
-                        (fun cond action ->
-                          let open FaultType.AArch64 in
-                          let mno = GCSSem.mk_fault action (GCSCheck PRET) ii in
-                          let mok = action >>= fun _ -> mok in
-                          M.choiceT cond mno mok)
-                in
-                (* Value writen to GCSPR depends on previous read *)
-                let read e = (is_this_reg rA e) && (E.is_reg_load e ii.A.proc)
-                and write e = (is_this_reg rA e) && (E.is_reg_store e ii.A.proc) in
-                let m = M.short read write m in
-                (* Branch depends on destination register (or LR) *)
-                M.short (is_this_reg r) (E.is_bcc) m
-              end
+                read_reg_ord r ii >>= do_indirect_jump test [] i ii
         | I_ERET ->
            let eret_to_addr v =
               match v2tgt v with
@@ -4893,48 +5074,13 @@ Arguments:
 (* Guarded Control Stack *)
         | I_GCSPOPM rd ->
           check_gcs inst;
-          let open AArch64Base in
-          let rA = SysReg GCSPR_EL1
-          and off = MachSize.nbytes quad in
-          read_reg_addr rA ii >>= fun addr ->
-            let m = GCSSem.read Annot.N addr ii
-            >>= fun v ->
-              let commit =
-                commit_pred_txt (Some "PCAligned") ii in
-              let mok =
-                (* Write to GCSPR depends on earlier read *)
-                let(>>*=) = M.bind_control_set_data_input_first in
-                commit >>*=
-                fun () ->
-                  !!(M.add addr (V.intToV off) >>= fun new_addr ->
-                      write_reg rd v ii >>|
-                      write_reg rA new_addr ii) in
-              let mask = V.intToV 0x3 in
-              GCSSem.get_cap mask v >>= fun cap ->
-              M.delay_kont "gcspop(fault)"
-              (M.op Op.Ne cap V.zero)
-              (fun nonzero action ->
-                let open FaultType.AArch64 in
-                let mno = GCSSem.mk_fault action (GCSCheck POPM) ii in
-                let mok = action >>= fun _ -> mok in
-                M.choiceT nonzero mno mok)
-              (* Write to Rd depends on read from Shadow Stack *)
-              in M.short (E.is_mem_load) (is_this_reg rd) m
+          gcspopm rd ii
         | I_GCSPUSHM rs ->
           check_gcs inst;
-          !!( let open AArch64Base in
-              let rA = SysReg GCSPR_EL1
-              and off = MachSize.nbytes quad in
-              (read_reg_addr rA ii >>= fun a -> M.add a (V.intToV (-off))) >>= fun addr ->
-                write_reg rA addr ii >>|
-                M.data_input_next
-                (read_reg_data rs ii)
-                (fun v -> GCSSem.write Annot.N addr v ii))
+          gcspushm rs ii
         | I_GCSSTR (r1,r2) ->
           check_gcs inst;
-          !(read_reg_addr r2 ii >>|
-            read_reg_data r1 ii >>= fun (addr, v) ->
-              GCSSem.write Annot.N addr v ii)
+          gcsstr r1 r2 ii
         | I_GCSSS1 r ->
           check_gcs inst;
           gcsss1 r ii

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -679,7 +679,7 @@ module Make(C:Config) (I:I) : S with module I = I
              Warn.user_error
                "Location %s of type %s is used as an array"
                (pp_location_old loc) (TestType.pp t) in
-        if os < 0 || os >= n_elts then
+        if os < 0 || os > n_elts then
           Warn.user_error
             "Out of bounds access on array %s" (pp_location_old loc) ;
         if os = 0 then loc

--- a/herd/libdir/aarch64util.cat
+++ b/herd/libdir/aarch64util.cat
@@ -158,4 +158,6 @@ flag ~empty (if "sve" then _ else 0)
 flag ~empty (if "sme" then _ else 0)
   as Scalable-Matrix-Extensions-is-work-in-progress
 
+flag ~empty (if "shadowstack" then _ else 0)
+  as Guarded-Control-Stack-is-work-in-progress
 include "aarch64loc.cat"

--- a/herd/tests/instructions/AArch64.gcs/G000.litmus
+++ b/herd/tests/instructions/AArch64.gcs/G000.litmus
@@ -1,0 +1,13 @@
+AArch64 G000
+variant=shadowstack
+{
+  SS(x,1);
+  0:GCSPR_EL1=&x[1];
+  0:X0=4; (* bit[1:0] is 0b00, so no fault *)
+}
+
+P0               ;
+GCSPUSHM X0      ;
+GCSPOPM X1       ;
+
+forall 0:X1=4 /\ ~fault(P0)

--- a/herd/tests/instructions/AArch64.gcs/G000.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G000.litmus.expected
@@ -1,11 +1,12 @@
 Test G000 Required
-States 1
+States 2
+0:X1=0;  ~Fault(P0);
 0:X1=4;  ~Fault(P0);
-Ok
+No
 Witnesses
-Positive: 1 Negative: 0
+Positive: 1 Negative: 1
 Flag Guarded-Control-Stack-is-work-in-progress
 Condition forall (0:X1=4 /\ not (fault(P0)))
-Observation G000 Always 1 0
+Observation G000 Sometimes 1 1
 Hash=bbb803f126ac18b96561ecc28c790f82
 

--- a/herd/tests/instructions/AArch64.gcs/G000.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G000.litmus.expected
@@ -1,0 +1,11 @@
+Test G000 Required
+States 1
+0:X1=4;  ~Fault(P0);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Guarded-Control-Stack-is-work-in-progress
+Condition forall (0:X1=4 /\ not (fault(P0)))
+Observation G000 Always 1 0
+Hash=bbb803f126ac18b96561ecc28c790f82
+

--- a/herd/tests/instructions/AArch64.gcs/G001.litmus
+++ b/herd/tests/instructions/AArch64.gcs/G001.litmus
@@ -1,0 +1,14 @@
+AArch64 G001
+variant=shadowstack
+{
+  SS(x,1);
+  0:GCSPR_EL1=&x[1];
+  0:X0=1; (* bit[1:0] is not 0b00, so we must fault *)
+}
+
+P0               ;
+GCSPUSHM X0      ;
+L0:              ;
+GCSPOPM X1       ;
+
+forall fault(P0:L0,GCS:POPM)

--- a/herd/tests/instructions/AArch64.gcs/G001.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G001.litmus.expected
@@ -1,0 +1,11 @@
+Test G001 Required
+States 1
+ Fault(P0:L0,GCS:POPM);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Guarded-Control-Stack-is-work-in-progress
+Condition forall (fault(P0:L0,GCS:POPM))
+Observation G001 Always 1 0
+Hash=00c4e739f54e67ec1b5fa068a62f1df0
+

--- a/herd/tests/instructions/AArch64.gcs/G001.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G001.litmus.expected
@@ -1,11 +1,12 @@
 Test G001 Required
-States 1
+States 2
+  ~Fault(P0:L0,GCS:POPM);
  Fault(P0:L0,GCS:POPM);
-Ok
+No
 Witnesses
-Positive: 1 Negative: 0
+Positive: 1 Negative: 1
 Flag Guarded-Control-Stack-is-work-in-progress
 Condition forall (fault(P0:L0,GCS:POPM))
-Observation G001 Always 1 0
+Observation G001 Sometimes 1 1
 Hash=00c4e739f54e67ec1b5fa068a62f1df0
 

--- a/herd/tests/instructions/AArch64.gcs/G002.litmus
+++ b/herd/tests/instructions/AArch64.gcs/G002.litmus
@@ -1,0 +1,17 @@
+AArch64 G002
+variant=shadowstack
+{
+  SS(x,1);
+  0:GCSPR_EL1=&x[1];
+}
+
+P0               ;
+BL L0            ;
+B  L1            ;
+MOV W0,#2        ; (* unreachable *)
+L0:              ;
+RET              ;
+MOV W0,#1        ; (* unreachable *)
+L1:              ;
+
+forall 0:X0=0 /\ ~fault(P0)

--- a/herd/tests/instructions/AArch64.gcs/G002.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G002.litmus.expected
@@ -1,11 +1,12 @@
 Test G002 Required
-States 1
+States 2
 0:X0=0;  ~Fault(P0);
-Ok
+0:X0=0; Fault(P0:L0,GCS:PRET);
+No
 Witnesses
-Positive: 1 Negative: 0
+Positive: 1 Negative: 1
 Flag Guarded-Control-Stack-is-work-in-progress
 Condition forall (0:X0=0 /\ not (fault(P0)))
-Observation G002 Always 1 0
+Observation G002 Sometimes 1 1
 Hash=74dba07a9762b35d3675d7eaae620658
 

--- a/herd/tests/instructions/AArch64.gcs/G002.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G002.litmus.expected
@@ -1,0 +1,11 @@
+Test G002 Required
+States 1
+0:X0=0;  ~Fault(P0);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Guarded-Control-Stack-is-work-in-progress
+Condition forall (0:X0=0 /\ not (fault(P0)))
+Observation G002 Always 1 0
+Hash=74dba07a9762b35d3675d7eaae620658
+

--- a/herd/tests/instructions/AArch64.gcs/G003.litmus
+++ b/herd/tests/instructions/AArch64.gcs/G003.litmus
@@ -1,0 +1,17 @@
+AArch64 G003
+variant=shadowstack
+{
+  SS(x,1);
+
+  0:GCSPR_EL1=&x[0];
+  0:X1=&x[0];
+}
+
+P0               ;
+ADR X29,L1       ;
+GCSSTR X29,[X1]  ;
+RET X29          ;
+MOV W0,#1        ; (* unreachable *)
+L1:              ;
+
+forall 0:X0=0 /\ ~fault(P0)

--- a/herd/tests/instructions/AArch64.gcs/G003.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G003.litmus.expected
@@ -1,11 +1,12 @@
 Test G003 Required
-States 1
+States 2
 0:X0=0;  ~Fault(P0);
-Ok
+0:X0=0; Fault(P0,GCS:PRET);
+No
 Witnesses
-Positive: 1 Negative: 0
+Positive: 1 Negative: 1
 Flag Guarded-Control-Stack-is-work-in-progress
 Condition forall (0:X0=0 /\ not (fault(P0)))
-Observation G003 Always 1 0
+Observation G003 Sometimes 1 1
 Hash=4334fbce0aebc714831566c01a5f904d
 

--- a/herd/tests/instructions/AArch64.gcs/G003.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G003.litmus.expected
@@ -1,0 +1,11 @@
+Test G003 Required
+States 1
+0:X0=0;  ~Fault(P0);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Guarded-Control-Stack-is-work-in-progress
+Condition forall (0:X0=0 /\ not (fault(P0)))
+Observation G003 Always 1 0
+Hash=4334fbce0aebc714831566c01a5f904d
+

--- a/herd/tests/instructions/AArch64.gcs/G004.litmus
+++ b/herd/tests/instructions/AArch64.gcs/G004.litmus
@@ -1,0 +1,24 @@
+AArch64 G004
+variant=shadowstack
+{
+  SS(x,2);
+  0:GCSPR_EL1=&x[2];
+}
+
+P0               ;
+BL L1            ;
+L0:              ;
+B  L3            ;
+MOV W0,#3        ; (* unreachable *)
+L1:              ;
+BL L2            ;
+ADR X29,L0       ; (* Recover LR *)
+RET X29          ;
+MOV W0,#2        ; (* unreachable *)
+L2:              ;
+RET              ;
+MOV W0,#1        ; (* unreachable *)
+L3:              ;
+
+forall 0:X0=0 /\ ~fault(P0)
+

--- a/herd/tests/instructions/AArch64.gcs/G004.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G004.litmus.expected
@@ -1,0 +1,11 @@
+Test G004 Required
+States 1
+0:X0=0;  ~Fault(P0);
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Flag Guarded-Control-Stack-is-work-in-progress
+Condition forall (0:X0=0 /\ not (fault(P0)))
+Observation G004 Always 1 0
+Hash=43c38dd46aee5d34461cbe32fef2fce2
+

--- a/herd/tests/instructions/AArch64.gcs/G004.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G004.litmus.expected
@@ -1,11 +1,13 @@
 Test G004 Required
-States 1
+States 3
 0:X0=0;  ~Fault(P0);
-Ok
+0:X0=0; Fault(P0,GCS:PRET);
+0:X0=0; Fault(P0:L2,GCS:PRET);
+No
 Witnesses
-Positive: 1 Negative: 0
+Positive: 1 Negative: 2
 Flag Guarded-Control-Stack-is-work-in-progress
 Condition forall (0:X0=0 /\ not (fault(P0)))
-Observation G004 Always 1 0
+Observation G004 Sometimes 1 2
 Hash=43c38dd46aee5d34461cbe32fef2fce2
 

--- a/herd/tests/instructions/AArch64.gcs/G005.litmus
+++ b/herd/tests/instructions/AArch64.gcs/G005.litmus
@@ -1,0 +1,16 @@
+AArch64 G005
+variant=shadowstack
+{
+  SS(x,2);
+  SS(y,2) = ssval_t: {SSCap(y,1), 4};
+
+  0:GCSPR_EL1=&x[1];
+  0:X0=&y[0];
+}
+
+P0               ;
+GCSSS1 X0        ; (* GCSPR = y[0], y[0] = SSCap(x[1],5)  *)
+GCSSS2 X0        ; (* GCSPR = y[1], x = SSCap(x,1) *)
+GCSPOPM X1       ; (* Pop from y[1], must be 4 *)
+
+forall 0:X1=4 /\ ~fault(P0)

--- a/herd/tests/instructions/AArch64.gcs/G005.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G005.litmus.expected
@@ -1,0 +1,11 @@
+Test G005 Required
+States 1
+0:X1=4;  ~Fault(P0);
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Flag Guarded-Control-Stack-is-work-in-progress
+Condition forall (0:X1=4 /\ not (fault(P0)))
+Observation G005 Always 2 0
+Hash=e49698900201be45b23a8f9f3ac0cb91
+

--- a/herd/tests/instructions/AArch64.gcs/G005.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G005.litmus.expected
@@ -1,11 +1,12 @@
 Test G005 Required
-States 1
+States 2
+0:X1=0; Fault(P0,GCS:POPM); Fault(P0,GCS:SS2);
 0:X1=4;  ~Fault(P0);
-Ok
+No
 Witnesses
-Positive: 2 Negative: 0
+Positive: 2 Negative: 4
 Flag Guarded-Control-Stack-is-work-in-progress
 Condition forall (0:X1=4 /\ not (fault(P0)))
-Observation G005 Always 2 0
+Observation G005 Sometimes 2 4
 Hash=e49698900201be45b23a8f9f3ac0cb91
 

--- a/herd/tests/instructions/AArch64.gcs/G006.litmus
+++ b/herd/tests/instructions/AArch64.gcs/G006.litmus
@@ -1,0 +1,16 @@
+AArch64 G006
+variant=shadowstack
+{
+  SS(x,2);
+  SS(y,2) = ssval_t: {0, SSCap(y,1)};
+  0:GCSPR_EL1=&x[1];
+  0:X0=&y[1];
+}
+
+P0               ;
+GCSSS1 X0        ; (* GCSPR = y[1], y[1] = SSCap(x[1],5)  *)
+GCSSS2 X0        ; (* GCSPR = y[2], x = SSCap(x,1)  *)
+
+(* Must not fault *)
+
+forall ~fault(P0)

--- a/herd/tests/instructions/AArch64.gcs/G006.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G006.litmus.expected
@@ -1,0 +1,11 @@
+Test G006 Required
+States 1
+  ~Fault(P0);
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Flag Guarded-Control-Stack-is-work-in-progress
+Condition forall (not (fault(P0)))
+Observation G006 Always 2 0
+Hash=28b2cd2cfd9fa18a88aab0bf42319cd8
+

--- a/herd/tests/instructions/AArch64.gcs/G006.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G006.litmus.expected
@@ -1,11 +1,12 @@
 Test G006 Required
-States 1
+States 2
   ~Fault(P0);
-Ok
+ Fault(P0,GCS:SS2);
+No
 Witnesses
-Positive: 2 Negative: 0
+Positive: 2 Negative: 2
 Flag Guarded-Control-Stack-is-work-in-progress
 Condition forall (not (fault(P0)))
-Observation G006 Always 2 0
+Observation G006 Sometimes 2 2
 Hash=28b2cd2cfd9fa18a88aab0bf42319cd8
 

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -82,6 +82,9 @@ type t =
 (* CacheType features *)
   | DIC
   | IDC
+(* Shadow stack
+   AArch64: Guarded Control Stack *)
+  | ShadowStack
 (* Have cat interpreter to optimise generation of co's *)
   | CosOpt
 (* Test something *)
@@ -144,6 +147,7 @@ let (mode_variants, arch_variants) : t list * t list =
   | FaultHandling p -> FaultHandling p
   | CutOff -> CutOff
   | Morello -> Morello
+  | ShadowStack -> ShadowStack
   | Neon -> Neon
   | SVE -> SVE
   | SVELength k -> SVELength k
@@ -221,7 +225,7 @@ let (mode_variants, arch_variants) : t list * t list =
         VMSA; NoPteBranch; PTE2; D128;
         Neon; SVE; SVELength 128; SME; SMELength 128;
         Pac; ConstPacField; FPac;
-        MemTag; MTEStoreOnly; ]
+        MemTag; MTEStoreOnly; ShadowStack]
   in
   (base_modes, arch_feat @ precision_variants @ fault_variants)
 
@@ -268,6 +272,7 @@ let parse s = match Misc.lowercase s with
 | "ifetch"|"self" -> Some Ifetch
 | "dic" -> None
 | "idc" -> None
+| "shadowstack" -> Some ShadowStack
 | "cos-opt" -> Some CosOpt
 | "test" -> Some Test
 | "asl" -> Some ASL
@@ -372,6 +377,7 @@ let pp = function
   | Ifetch -> "ifetch"
   | DIC -> "dic"
   | IDC -> "idc"
+  | ShadowStack -> "shadowstack"
   | CosOpt -> "cos-opt"
   | Test -> "test"
   | T n -> Printf.sprintf "T%02i" n
@@ -428,6 +434,7 @@ let pp = function
             opt
   | CutOff -> "Check for cutoff in executions (AArch64+ASL only)"
   | Morello -> ""
+  | ShadowStack -> "Enable support for shadow stack (FEAT_GCS for AArch64)"
   | Neon -> "Enable Advanced SIMD instructions (AArch64 only)"
   | SVE -> "Enable FEAT_SVE, Scalable Vector Extension (AArch64 only)"
   | SVELength _ -> "Configure SVE vector length (AArch64 only)"

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -80,6 +80,9 @@ type t =
 (* CacheType features *)
   | DIC
   | IDC
+(* Shadow stack
+   AArch64: Guarded Control Stack *)
+  | ShadowStack
 (* Have cat interpreter to optimise generation of co's *)
   | CosOpt
 (* Test something *)

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -712,4 +712,6 @@ include Arch.MakeArch(struct
     | I_SMSTART _ | I_SMSTOP _ | I_LD1SPT _ | I_ST1SPT _
     | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
     -> Warn.fatal "SME instructions are not implemented yet"
+    | I_GCSPOPM _ | I_GCSPUSHM _ | I_GCSSTR _ | I_GCSSS1 _ | I_GCSSS2 _
+    -> Warn.fatal "GCS instructions are not implemented yet"
 end)

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -673,6 +673,7 @@ let do_fold_dmb_dsb f k =
 let fold_barrier f k =
   let k = do_fold_dmb_dsb f k in
   let k = f ISB k in
+  let k = f GCSB k in
   k
 
 let pp_option d t = match d,t with
@@ -684,7 +685,7 @@ let do_pp_barrier tag b = match b with
   | DMB (d,t) -> "DMB" ^ tag ^ pp_option d t
   | DSB (d,t) -> "DSB" ^ tag ^ pp_option d t
   | ISB -> "ISB"
-  | GCSB -> "GCSB DSYNC"
+  | GCSB -> "GCSB" ^ tag ^  "DSYNC"
 
 let pp_barrier b = do_pp_barrier " " b
 let pp_barrier_dot b = do_pp_barrier "." b

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -123,6 +123,7 @@ type sysreg =
   ELR_EL1 | ESR_EL1 | SYS_NZCV |
   TFSR_ELx | VNCR_EL2
   | PAR_EL1
+  | GCSPR_EL1
 
 let sysregs = [
     CTR_EL0, "CTR_EL0";
@@ -137,6 +138,7 @@ let sysregs = [
     TFSR_ELx, "TFSR_ELx";
     VNCR_EL2, "VNCR_EL2";
     PAR_EL1, "PAR_EL1";
+    GCSPR_EL1, "GCSPR_EL1";
   ]
 
 let sysregs_map = [
@@ -260,6 +262,7 @@ let elr_el1 = SysReg ELR_EL1
 let esr_el1 = SysReg ESR_EL1
 let tfsr = SysReg TFSR_ELx
 let par_el1 = SysReg PAR_EL1
+let gcspr_el1 = SysReg GCSPR_EL1
 
 let cgprs =
 [
@@ -648,6 +651,7 @@ type barrier =
   | DMB of mBReqDomain*mBReqTypes
   | DSB of mBReqDomain*mBReqTypes
   | ISB
+  | GCSB
 
 type syncType =
   | DC_CVAU
@@ -680,6 +684,7 @@ let do_pp_barrier tag b = match b with
   | DMB (d,t) -> "DMB" ^ tag ^ pp_option d t
   | DSB (d,t) -> "DSB" ^ tag ^ pp_option d t
   | ISB -> "ISB"
+  | GCSB -> "GCSB DSYNC"
 
 let pp_barrier b = do_pp_barrier " " b
 let pp_barrier_dot b = do_pp_barrier "." b
@@ -1700,6 +1705,17 @@ type 'k kinstruction =
   | I_SEAL of reg * reg * reg
   | I_STCT of reg * reg
   | I_UNSEAL of reg * reg * reg
+(* Guarded Control Stack Extention *)
+  (* GCSPOPM {<Xt>} *)
+  | I_GCSPOPM of reg
+  (* GCSPUSHM <Xt> *)
+  | I_GCSPUSHM of reg
+  (* GCSSTR <Xt>, [<Xn|SP>] *)
+  | I_GCSSTR of reg * reg
+  (* GCSSS1 <Xt> *)
+  | I_GCSSS1 of reg
+  (* GCSSS2 <Xt> *)
+  | I_GCSSS2 of reg
 (* Idem for bytes and half words *)
   | I_LDRBH of bh * reg * reg * 'k MemExt.ext
   | I_LDRS of (variant * bh) * reg * reg * 'k MemExt.ext
@@ -2368,6 +2384,19 @@ let do_pp_instruction m =
       sprintf "STCT %s,[%s]" (pp_xreg r1) (pp_xreg r2)
   | I_UNSEAL (r1,r2,r3) ->
       sprintf "UNSEAL %s,%s,%s" (pp_creg r1) (pp_creg r2) (pp_creg r3)
+(* Guarded Control Stack *)
+  | I_GCSPOPM (ZR) ->
+      "GCSPOPM"
+  | I_GCSPOPM (r) ->
+      sprintf "GCSPOPM %s" (pp_xreg r)
+  | I_GCSPUSHM (r) ->
+      sprintf "GCSPUSHM %s" (pp_xreg r)
+  | I_GCSSTR (r1,r2) ->
+      sprintf "GCSSTR %s,[%s]" (pp_xreg r1) (pp_xreg r2)
+  | I_GCSSS1 (r) ->
+      sprintf "GCSSS1 %s" (pp_xreg r)
+  | I_GCSSS2 (r) ->
+      sprintf "GCSSS2 %s" (pp_xreg r)
 (* CAS *)
   | I_CAS (v,rmw,r1,r2,r3) ->
       sprintf "%s %s,%s,[%s]" (cas_memo rmw) (pp_vreg v r1) (pp_vreg v r2) (pp_xreg r3)
@@ -2633,6 +2662,7 @@ let fold_regs (f_regs,f_sregs) =
   | I_CNT_INC_SVE (_,r,_,_)
   | I_PTRUE (r,_)
   | I_SMSTART (Some(r)) | I_SMSTOP (Some(r))
+  | I_GCSPOPM (r) | I_GCSPUSHM (r) | I_GCSSS1 (r) | I_GCSSS2 (r)
     -> fold_reg r c
   | I_MOV (_,r1,kr)
     -> fold_reg r1 (fold_kr kr c)
@@ -2655,6 +2685,7 @@ let fold_regs (f_regs,f_sregs) =
   | I_STZ2G (r1,r2,_) | I_STG (r1,r2,_) | I_ST2G (r1,r2,_)
   | I_ALIGND (r1,r2,_) | I_ALIGNU (r1,r2,_)
   | I_ADDVL (r1,r2,_) | I_CTERM (_,_,r1,r2)
+  | I_GCSSTR (r1,r2)
     -> fold_reg r1 (fold_reg r2 c)
   | I_MRS (r,sr) | I_MSR (sr,r)
     -> fold_reg (SysReg sr) (fold_reg r c)
@@ -3014,6 +3045,17 @@ let map_regs f_reg f_symb =
       I_STCT(map_reg r1,map_reg r2)
   | I_UNSEAL (r1,r2,r3) ->
       I_UNSEAL(map_reg r1,map_reg r2,map_reg r3)
+(* Guarded Control Stack *)
+  | I_GCSPOPM (r) ->
+      I_GCSPOPM (map_reg r)
+  | I_GCSPUSHM (r) ->
+      I_GCSPUSHM (map_reg r)
+  | I_GCSSTR (r1,r2) ->
+      I_GCSSTR (map_reg r1,map_reg r2)
+  | I_GCSSS1 (r) ->
+      I_GCSSS1 (map_reg r)
+  | I_GCSSS2 (r) ->
+      I_GCSSS2 (map_reg r)
 (* CAS *)
   | I_CAS (v,rmw,r1,r2,r3) ->
       I_CAS (v,rmw,map_reg r1,map_reg r2,map_reg r3)
@@ -3224,6 +3266,7 @@ let get_next =
   | I_MOVA_TV _ | I_MOVA_VT _ | I_ADDA _
   | I_PAC _ | I_AUT _
   | I_XPACI _ | I_XPACD _
+  | I_GCSPOPM _ | I_GCSPUSHM _ | I_GCSSTR _ | I_GCSSS1 _ | I_GCSSS2 _
     -> [Label.Next;]
 
 (* Check instruction validity, beyond parsing *)
@@ -3612,6 +3655,7 @@ module PseudoI = struct
         | I_XPACI _ | I_XPACD _
         | I_CTERM _
         | I_IRG _
+        | I_GCSPOPM _ | I_GCSPUSHM _ | I_GCSSTR _ | I_GCSSS1 _ | I_GCSSS2 _
             as keep -> keep
         | I_LDR (v,r1,r2,idx) -> I_LDR (v,r1,r2,ext_tr idx)
         | I_LDRSW (r1,r2,idx) -> I_LDRSW (r1,r2,ext_tr idx)
@@ -3735,6 +3779,7 @@ module PseudoI = struct
         | I_XPACI _
         | I_XPACD _
         | I_AT (_,_)
+        | I_GCSPOPM _  | I_GCSPUSHM _ | I_GCSSTR _ | I_GCSSS1 _ | I_GCSSS2 _
           -> 1
         | I_LDP _|I_LDPSW _|I_STP _|I_LDXP _|I_STXP _
         | I_CAS _ | I_CASBH _

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -541,6 +541,12 @@ match name with
 | "seal"|"SEAL" -> SEAL
 | "stct"|"STCT" -> STCT
 | "unseal"|"UNSEAL" -> UNSEAL
+(* Guarded Control Stack *)
+| "gcspopm" | "GCSPOPM" -> GCSPOPM
+| "gcspushm" | "GCSPUSHM" -> GCSPUSHM
+| "gcsstr" | "GCSSTR" -> GCSSTR
+| "gcsss1" | "GCSSS1" -> GCSSS1
+| "gcsss2" | "GCSSS2" -> GCSSS2
 (* Misc *)
 | "csel"|"CSEL" -> CSEL
 | "csinc"|"CSINC" -> CSINC
@@ -553,6 +559,7 @@ match name with
 | "dmb"|"DMB" -> TOK_DMB
 | "dsb"|"DSB" -> TOK_DSB
 | "isb"|"ISB" -> TOK_ISB
+| "gcsb"|"GCSB" -> TOK_GCSB
 (* Fence Operands *)
 | "sy"|"SY" -> TOK_SY
 | "st"|"ST" -> TOK_ST
@@ -566,6 +573,7 @@ match name with
 | "nsh"|"NSH" -> TOK_NSH
 | "nshst"|"NSHST" -> TOK_NSHST
 | "nshld"|"NSHLD" -> TOK_NSHLD
+| "dsync" | "DSYNC" -> TOK_DSYNC
 (* inline barrel shift operands *)
 | "msl" | "MSL" -> TOK_MSL
 (* Cache maintenance *)

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -114,11 +114,12 @@ let check_op3 op e =
 %token <AArch64Base.MOPExt.op> MOPZ
 %token <AArch64Base.MOPExt.op> MOP
 %token CSEL CSINC CSINV CSNEG CSET CSETM CINC
-%token TOK_DMB TOK_DSB TOK_ISB
+%token TOK_DMB TOK_DSB TOK_ISB TOK_GCSB
 %token TOK_SY TOK_ST TOK_LD
 %token TOK_OSH TOK_OSHST TOK_OSHLD
 %token TOK_ISH TOK_ISHST TOK_ISHLD
 %token TOK_NSH TOK_NSHST TOK_NSHLD
+%token TOK_DSYNC
 %token CAS CASA CASL CASAL CASB CASAB CASLB CASALB CASH CASAH CASLH CASALH
 %token CASP CASPA CASPL CASPAL
 %token SWP SWPA SWPL SWPAL SWPB SWPAB SWPLB SWPALB SWPH SWPAH SWPLH SWPALH
@@ -140,6 +141,7 @@ let check_op3 op e =
 %token <AArch64Base.adda_op_variant> ADDA
 %token SMSTART SMSTOP TOK_SM TOK_ZA MOVA
 %token <AArch64Base.CTERM.cond> CTERM
+%token GCSPOPM GCSPUSHM GCSSTR GCSSS1 GCSSS2
 /*
 /*
 %token LDUMAX LDUMAXA LDUMAXL LDUMAXAL LDUMAXH LDUMAXAH LDUMAXLH LDUMAXALH
@@ -1549,6 +1551,19 @@ instr:
   { I_CSEL (V32,$2,$4,$4,inverse_cond $6,Inc) }
 | CINC xreg COMMA xreg COMMA cond
   { I_CSEL (V64,$2,$4,$4,inverse_cond $6,Inc) }
+/* Control Guarded Stack */
+| GCSPOPM xreg
+  { I_GCSPOPM $2 }
+| GCSPOPM
+  { I_GCSPOPM ZR }
+| GCSPUSHM xreg
+  { I_GCSPUSHM $2 }
+| GCSSTR xreg COMMA LBRK xreg RBRK
+  { I_GCSSTR ($2,$5) }
+| GCSSS1 xreg
+  { I_GCSSS1 $2 }
+| GCSSS2 xreg
+  { I_GCSSS2 $2 }
 /* Fences */
 | TOK_DMB fenceopt
   { let d,t = $2 in I_FENCE (DMB (d,t)) }
@@ -1556,6 +1571,8 @@ instr:
   { let d,t = $2 in I_FENCE (DSB (d,t)) }
 | TOK_ISB
   { I_FENCE ISB }
+| TOK_GCSB TOK_DSYNC
+  { I_FENCE GCSB }
 /* Cache Maintenance */
 | IC IC_OP
   { I_IC ($2,ZR) }

--- a/lib/faultType.ml
+++ b/lib/faultType.ml
@@ -32,8 +32,19 @@ module type AArch64Sig = sig
     | Permission
     | Exclusive
 
+  type gcs_t =
+    | PRET
+    | POPM
+    | PRETAA
+    | PRETAB
+    | SS1
+    | SS2
+    | POPCX
+    | POPX
+
   type t =
     | MMU of DISide.t * mmu_t
+    | GCSCheck of gcs_t
     | TagCheck
     | UndefinedInstruction
     | SupervisorCall
@@ -49,14 +60,35 @@ module AArch64 = struct
     | Permission
     | Exclusive
 
+  type gcs_t =
+    | PRET
+    | POPM
+    | PRETAA
+    | PRETAB
+    | SS1
+    | SS2
+    | POPCX
+    | POPX
+
   let pp_mmu_t = function
     | Translation -> "Translation"
     | AccessFlag -> "AccessFlag"
     | Permission -> "Permission"
     | Exclusive -> "Exclusive"
 
+  let pp_gcs_t = function
+   | PRET -> "PRET"
+   | POPM -> "POPM"
+   | PRETAA -> "PRETAA"
+   | PRETAB -> "PRETAB"
+   | SS1 -> "SS1"
+   | SS2 -> "SS2"
+   | POPCX -> "POPCX"
+   | POPX -> "POPX"
+
   type t =
     | MMU of DISide.t * mmu_t
+    | GCSCheck of gcs_t
     | TagCheck
     | UndefinedInstruction
     | SupervisorCall
@@ -100,6 +132,14 @@ module AArch64 = struct
                    PacCheck PAC.IB];
       "UndefinedInstruction",[UndefinedInstruction];
       "SVC", [SupervisorCall];
+      "GCSCheck", [GCSCheck PRET;
+                   GCSCheck POPM;
+                   GCSCheck PRETAA;
+                   GCSCheck PRETAB;
+                   GCSCheck SS1;
+                   GCSCheck SS2;
+                   GCSCheck POPCX;
+                   GCSCheck POPX];
     ]
 
   let pp = function
@@ -107,6 +147,7 @@ module AArch64 = struct
         Printf.sprintf "MMU:%s" (pp_mmu_t m)
     | MMU (d, m) ->
         Printf.sprintf "%s-MMU:%s" (DISide.pp d) (pp_mmu_t m)
+    | GCSCheck m -> Printf.sprintf "GCS:%s" (pp_gcs_t m)
     | TagCheck -> "TagCheck"
     | UndefinedInstruction -> "UndefinedInstruction"
     | SupervisorCall -> "SupervisorCall"
@@ -127,6 +168,14 @@ module AArch64 = struct
       | "I-MMU:AccessFlag"  -> MMU (Instr, AccessFlag)
       | "I-MMU:Permission"  -> MMU (Instr, Permission)
       | "I-MMU:Exclusive"   -> MMU (Instr, Exclusive)
+      | "GCS:PRET" -> GCSCheck PRET
+      | "GCS:POPM" -> GCSCheck POPM
+      | "GCS:PRETAA" -> GCSCheck PRETAA
+      | "GCS:PRETAB" -> GCSCheck PRETAB
+      | "GCS:SS1" -> GCSCheck SS1
+      | "GCS:SS2" -> GCSCheck SS2
+      | "GCS:POPCX" -> GCSCheck POPCX
+      | "GCS:POPX" -> GCSCheck POPX
       | "TagCheck" -> TagCheck
       | "PacCheck:DA" -> PacCheck PAC.DA
       | "PacCheck:DB" -> PacCheck PAC.DB

--- a/lib/faultType.mli
+++ b/lib/faultType.mli
@@ -32,8 +32,19 @@ module type AArch64Sig = sig
     | Permission  (* db: 0 *)
     | Exclusive   (* memattr <> sharedWB *)
 
+  type gcs_t =
+    | PRET
+    | POPM
+    | PRETAA
+    | PRETAB
+    | SS1
+    | SS2
+    | POPCX
+    | POPX
+
   type t =
     | MMU of DISide.t * mmu_t
+    | GCSCheck of gcs_t
     | TagCheck
     | UndefinedInstruction
     | SupervisorCall

--- a/lib/stateLexer.mll
+++ b/lib/stateLexer.mll
@@ -79,12 +79,16 @@ rule token = parse
 | "PA"  { TOK_PA }
 (* PAR_EL1 *)
 | "parel1_t"|"PAREL1_T" { TOK_PAR }
+(* Shadow Stack keywords *)
+| "SS" { TOK_SS }
+| "SSCap"  { TOK_SSCAP }
 (* Typing *)
 | "_Atomic" { ATOMIC }
 | "ATOMIC_INIT" { ATOMICINIT }
 | "instr:" '"' ([^'"']+ as i) '"' { INSTR i }
 | "label:" '"' 'P'? (decimal as p) ':' ([^'"']+ as l)  '"' { LABEL ((int_of_string p), l) }
 | '`' ([^'`']+ as i) '`' { VALUE i }
+| "ssval_t:"  { TOK_SSVAL }
 (*for GPU*)
 | ".reg" {PTX_REG_DEC}
 | ".s32" as x

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -68,6 +68,7 @@ let mk_tag_mask t =
 %token TOK_PTE TOK_PA
 %token TOK_TAG
 %token TOK_NOP
+%token TOK_SS TOK_SSCAP TOK_SSVAL
 %token <string> INSTR
 %token <int * string> LABEL
 %token PTX_REG_DEC
@@ -181,6 +182,7 @@ maybev_notag:
 (* TODO: restrict to something like "NUM COLON BOOL"? *)
 | NUM COLON NUM { Concrete ($1 ^ ":" ^ $3) }
 | NAME LBRK NUM RBRK { Constant.mk_sym_with_index $1 (Misc.string_as_int $3) }
+| TOK_SSCAP LPAR NAME COMMA NUM RPAR { Constant.mk_sym_with_index $3 (Misc.string_as_int $5) }
 
 maybev_amper:
 | AMPER NAME { Constant.mk_sym $2 }
@@ -208,6 +210,10 @@ maybev_list:
 maybev_label:
 | maybev { $1 }
 | just_label { $1 }
+
+maybev_label_list:
+  | maybev_label COMMA maybev_label_list { $1::$3 }
+  | maybev_label { [$1] }
 
 %inline std_reg:
 | PROC COLON reg  {Location_reg ($1,$3)}
@@ -275,6 +281,19 @@ atom_init:
      else
        Warn.user_error
          "Declared size of array %s does not match initial value size"
+	 (dump_location t) }
+| ssspec
+   { let (t,sz) = $1 in
+     let v0 = Constant.mk_replicate sz ParsedConstant.zero in
+     (t,(TyArray ("uintptr_t",sz),v0)) }
+| ssspec EQUAL TOK_SSVAL LCURLY maybev_label_list RCURLY
+   { let (t,sz) = $1 and vs = $5 in
+     if sz = List.length vs then
+       let arr = (TyArray ("uintptr_t",sz),Constant.mk_vec sz vs) in
+       (t, arr)
+     else
+       Warn.user_error
+         "Declared size of shadow stack %s does not match initial value size"
 	 (dump_location t) }
 /* prohibit "v[i] = scalar" form in init allow only "v[i]={scalar_list}" */
 | locindex EQUAL maybev { raise Parsing.Parse_error }
@@ -423,6 +442,10 @@ locindex:
 arrayspec:
 | NAME LBRK NUM RBRK
     { (Location_global (Constant.mk_sym $1),Misc.string_as_int $3) }
+
+ssspec:
+| TOK_SS LPAR NAME COMMA NUM RPAR
+    { (Location_global (Constant.mk_sym $3),Misc.string_as_int $5) }
 
 %inline equal:
 | EQUAL { () }

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -594,8 +594,9 @@ module
         | Some o -> intToV o
         | None ->  illegal_offset v
       end
+  | Val (Concrete _) as v -> v
   | Val
-      (Concrete _|ConcreteRecord _|ConcreteVector _
+      (ConcreteRecord _|ConcreteVector _
       |Tag _
       |PteVal _|AddrReg _|Instruction _
       |Frozen _) ->

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -2014,6 +2014,7 @@ module Make(V:Constant.S)(C:Config) =
         inputs = [r1;r2]@r3;
         outputs = [r1];
         reg_env = (add_q ([r1;r2]@r3))}::k
+    | I_GCSPOPM _ | I_GCSPUSHM _ | I_GCSSTR _ | I_GCSSS1 _ | I_GCSSS2 _
     | I_ALIGND _|I_ALIGNU _|I_BUILD _|I_CHKEQ _|I_CHKSLD _|I_CHKTGD _|
       I_CLRTAG _|I_CPYTYPE _|I_CPYVALUE _|I_CSEAL _|I_GC _|I_LDCT _|I_SC _|
       I_SEAL _|I_STCT _|I_UNSEAL _ ->


### PR DESCRIPTION
Guarded Control Stack (GCS), an area of memory in which procedure return addresses and exception return addresses are stored and protected from modification.
When the processor executes a Branch with Link instruction, such as BL, the return address is pushed onto the GCS as well as being written into the Link Register (LR). On a procedure return, the latest stored return address is popped from the GCS. The processor either compares the popped value with the LR, or uses the popped value directly.
There are times when the software needs to make manual adjustments to the control stack to enable this, the architecture provides instructions for maintaining the GCS.