### PR TITLE
[tools] Add no-hash option to mprog

### DIFF
--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -573,6 +573,7 @@ let () =
     let module T =
       ParseTest.Top
         (struct
+          include GenParser.DefaultConfig
           let bell_model_info = bi
           include Config end) in
     SymbValue.reset_gensym () ;

--- a/lib/genParser.ml
+++ b/lib/genParser.ml
@@ -22,6 +22,7 @@
 module type Config = sig
   val debuglexer : bool
   val verbose : int
+  val set_hash : bool
   val check_kind : string -> ConstrGen.kind option
   val check_cond : string -> string option
 end
@@ -30,6 +31,7 @@ module DefaultConfig = struct
   let debuglexer = false let verbose = 0
   let check_kind _ = None
   let check_cond _ = None
+  let set_hash = true
 end
 
 (* input signature, a lexer and a parser for a given architecture *)
@@ -237,6 +239,7 @@ module Make
               MiscParser.condition =
               ConstrGen.set_kind k parsed.MiscParser.condition; } in
       let parsed =
+        if not O.set_hash then parsed else
         match MiscParser.get_hash parsed with
         | None ->
              let info = parsed.MiscParser.info in

--- a/lib/genParser.mli
+++ b/lib/genParser.mli
@@ -20,6 +20,7 @@
 module type Config = sig
   val debuglexer : bool
   val verbose : int
+  val set_hash : bool (* Set the hash of the parsed test, default to true. *)
   val check_kind : string -> ConstrGen.kind option
   val check_cond : string -> string option
 end

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -47,6 +47,7 @@ end
 module Top(O:Config)(Tar:Tar.S) = struct
 
   module OX = struct
+    include GenParser.DefaultConfig
     let debuglexer = O.verbose > 2
     let debug = debuglexer
     include O

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -433,6 +433,7 @@ end = struct
           let precision = TestConf.fault_handling
         end in
         let module Cfg = struct
+          include GenParser.DefaultConfig
           include OT
           let precision = TestConf.fault_handling
           let variant = TestConf.variant

--- a/tools/madd.ml
+++ b/tools/madd.ml
@@ -46,7 +46,7 @@ module Top
           hash = hash; }
     end
 
-    module Z = ToolParse.Top(T)(Make)
+    module Z = ToolParse.Top(GenParser.DefaultConfig)(T)(Make)
 
     type name = {fname:string; tname:string;}
 

--- a/tools/mhash.ml
+++ b/tools/mhash.ml
@@ -69,7 +69,7 @@ module Top
           map=map; }
     end
 
-    module Z = ToolParse.Top(T)(Make)
+    module Z = ToolParse.Top(GenParser.DefaultConfig)(T)(Make)
 
     let do_test name (kh,km as k) =
       try

--- a/tools/mselect.ml
+++ b/tools/mselect.ml
@@ -49,7 +49,7 @@ module Top
 
     end
 
-    module Z = ToolParse.Top(T)(Make)
+    module Z = ToolParse.Top(GenParser.DefaultConfig)(T)(Make)
 
     let do_test name  =
       try

--- a/tools/msort.ml
+++ b/tools/msort.ml
@@ -78,7 +78,7 @@ module Top
           hash = MiscParser.get_hash  parsed; }
     end
 
-    module Z = ToolParse.Top(T)(Make)
+    module Z = ToolParse.Top(GenParser.DefaultConfig)(T)(Make)
 
     type name = {fname:string; tname:string;}
 

--- a/tools/testInfo.ml
+++ b/tools/testInfo.ml
@@ -48,4 +48,4 @@ module Make(A:ArchBase.S)(Pte:PteVal.S)(AddrReg:AddrReg.S) = struct
     { T.tname = tname ; fname=fname; hash = hash; }
 end
 
-module Z = ToolParse.Top(T)(Make)
+module Z = ToolParse.Top(GenParser.DefaultConfig)(T)(Make)

--- a/tools/toolParse.ml
+++ b/tools/toolParse.ml
@@ -24,6 +24,7 @@ module LexConf = struct
 end
 
 module Top
+    (PCfg: GenParser.Config)
     (T:sig type t end) (* Return type, must be abstracted *)
     (B: functor(A:ArchBase.S)-> functor (Pte:PteVal.S) -> functor (AddrReg:AddrReg.S) ->
       (sig val zyva : Name.t -> A.pseudo MiscParser.t -> T.t end)) :
@@ -35,7 +36,7 @@ end = struct
       (A:ArchBase.S)(Pte:PteVal.S)(AddrReg:AddrReg.S)
       (L:GenParser.LexParse with type instruction = A.parsedPseudo) =
     struct
-      module P = GenParser.Make(GenParser.DefaultConfig)(A)(L)
+      module P = GenParser.Make(PCfg)(A)(L)
       module X = B(A)(Pte)(AddrReg)
 
 

--- a/tools/toolParse.mli
+++ b/tools/toolParse.mli
@@ -19,7 +19,7 @@
 (***************************************)
 
 module Top :
-    functor (T:sig type t end) -> (* Return type, must be abstracted *)
+    functor (PCfg: GenParser.Config) (T:sig type t end) -> (* Return type, must be abstracted *)
       functor (B: functor(A:ArchBase.S) -> functor (Pte:PteVal.S) -> functor (AddrReg:AddrReg.S) ->
         (sig val zyva : Name.t -> A.pseudo MiscParser.t -> T.t end)) ->
 sig


### PR DESCRIPTION
`mprog` is a great tool to automatically format litmus tests. However, it adds the hash of the litmus test to the information provided in the test, which is not always wanted, for example in regression tests.

This PR changes the default behaviour of `mprog7` **not** to add the hash of a test.
This PR also adds an option to `mprog7` to add the hash of a test.

For example, on a test that does not contain a hash before:
```
❯ mprog7 -mode text ./herd/tests/instructions/AArch64/A01.litmus
AArch64 A01

{
 uint64_t x=0;
 uint64_t 0:X0=0; 0:X1=x; 0:X2=0;
}
 P0                   ;
 LDRB W0,[X1,X2,UXTW] ;

exists (0:X0=0)

❯ mrpog7 -mode text -set-hash true ./herd/tests/instructions/AArch64/A01.litmus
AArch64 A01
Hash=fac9c0d41ef2dc619014a5f8545de0ad

{
 uint64_t x=0;
 uint64_t 0:X0=0; 0:X1=x; 0:X2=0;
}
 P0                   ;
 LDRB W0,[X1,X2,UXTW] ;

exists (0:X0=0)

```

This PR does not change the behaviour of `mprog7` when the hash is already in the litmus test (which is not to recompute nor change it).