### PR TITLE
Menhir parser warnings should be errors

### DIFF
--- a/asllib/dune
+++ b/asllib/dune
@@ -25,11 +25,11 @@
 (menhir
  (modules Tokens Parser)
  (merge_into Parser)
- (flags --cmly --external-tokens Tokens --exn-carries-state))
+ (flags --cmly --external-tokens Tokens --exn-carries-state --strict))
 
 (menhir
  (modules Parser0)
- (flags --unused-tokens --table))
+ (flags --unused-tokens --table --strict))
 
 (rule
  (target parser_errors.ml)

--- a/diymicro/dune
+++ b/diymicro/dune
@@ -10,4 +10,4 @@
 
 (menhir
  (modules parser)
- (flags --explain --inspection --table --dump))
+ (flags --explain --inspection --table --dump --strict))

--- a/lib/dune
+++ b/lib/dune
@@ -26,63 +26,63 @@
 
 (menhir
  (modules PPCParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules ARMParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules BPFParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules MIPSParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules X86Parser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules X86_64Parser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules modelParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules RISCVParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules JavaParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules stateParser)
- (flags --explain --fixed-exception))
+ (flags --explain --fixed-exception --strict))
 
 (menhir
  (modules procRules scopeRules BellExtraRules AArch64Parser)
  (merge_into AArch64Parser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules procRules scopeRules BellExtraRules LISAParser)
  (merge_into LISAParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules scopeRules scopeParser)
  (merge_into scopeParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (menhir
  (modules scopeRules BellExtraRules CParser)
  (merge_into CParser)
- (flags --fixed-exception))
+ (flags --fixed-exception --strict))
 
 (library
  (name herdtools)


### PR DESCRIPTION
Added `--strict` to all parser-generating menhir stanzas:
- `lib`
- `diymmicro`
- `asllib`
- `aslspec`