### PR TITLE
[asl][reference] fixes to rules, found during attempt to import them to aslspec

### DIFF
--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -413,7 +413,7 @@ In \listingref{welltypedbitvectortypes}, all the uses of bitvector types with bi
   \commonprefixline\\\\
   \checkslicesinwidth(\tenv, \width, \slicesone) \typearrow \True \OrTypeError
 }{
-  \annotatebitfield(\tenv, \width, \BitFieldSimple(\name, \vslices)) \typearrow \\
+  \annotatebitfield(\tenv, \width, \overname{\BitFieldSimple(\name, \vslices)}{\vfield}) \typearrow \\
   (\overname{\BitFieldSimple(\name, \slicesone)}{\newfield}, \overname{\vsesslices}{\vses})
 }
 \end{mathpar}
@@ -432,7 +432,7 @@ In \listingref{welltypedbitvectortypes}, all the uses of bitvector types with bi
   }\\
   \vses \eqdef \vsesslices \cup \vsesbitfields
 }{
-  \annotatebitfield(\tenv, \width, \BitFieldNested(\name, \vslices, \bitfieldsp)) \typearrow \\
+  \annotatebitfield(\tenv, \width, \overname{\BitFieldNested(\name, \vslices, \bitfieldsp)}{\vfield}) \typearrow \\
   (\overname{\BitFieldNested(\slicesone, \bitfieldspp)}{\newfield}, \vses)
 }
 \end{mathpar}
@@ -449,7 +449,7 @@ In \listingref{welltypedbitvectortypes}, all the uses of bitvector types with bi
   \checkbitsequalwidth(\TBits(\widthp, \emptylist), \vt) \typearrow \True \OrTypeError\\\\
   \vses \eqdef \vsesslices \cup \vsesty
 }{
-  \annotatebitfield(\tenv, \width, \BitFieldType(\name, \vslices, \vt)) \typearrow \\
+  \annotatebitfield(\tenv, \width, \overname{\BitFieldType(\name, \vslices, \vt)}{\vfield}) \typearrow \\
   (\overname{\BitFieldType(\name, \slicesone, \vtp)}{\newfield}, \vses)
 }
 \end{mathpar}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -838,7 +838,7 @@ of well-typed unary operation expressions.
   \annotateexpr(\tenv, \vep) \typearrow (\vtpp, \vepp, \vses) \OrTypeError\\\\
   \applyunoptype(\tenv, \op, \vtpp) \typearrow \vt \OrTypeError
 }{
-  \annotateexpr(\tenv, \EUnop(\op, \vep)) \typearrow (\vt, \EUnop(\op, \vepp), \vses)
+  \annotateexpr(\tenv, \overname{\EUnop(\op, \vep)}{\ve}) \typearrow (\vt, \EUnop(\op, \vepp), \vses)
 }
 \end{mathpar}
 \CodeSubsection{\UnopBegin}{\UnopEnd}{../Typing.ml}
@@ -937,7 +937,7 @@ an example of typing a conditional expression.
 }{
   {
     \begin{array}{r}
-  \annotateexpr(\ECond(\econd, \etrue, \efalse)) \typearrow \\
+  \annotateexpr(\tenv, \overname{\ECond(\econd, \etrue, \efalse)}{\ve}) \typearrow \\
   (\vt, \ECond(\econdp, \etruep, \efalsep), \vses)
     \end{array}
   }
@@ -1625,7 +1625,7 @@ and the types inferred for them via the added \verb|as <inferred type>|.
 }{
   {
     \begin{array}{r}
-      \annotateexpr(\tenv, \EGetField(\veone, \fieldname)) \typearrow \\
+      \annotateexpr(\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}) \typearrow \\
       (\vt, \EGetField(\vetwo, \fieldname), \overname{\vsesone}{\vses})
     \end{array}
   }
@@ -1659,7 +1659,7 @@ and the types inferred for them via the added \verb|as <inferred type>|.
   L \in \{\TRecord, \TException\}\\
   \assocopt(\fields, \fieldname) \typearrow \None
 }{
-  \annotateexpr(\tenv, \EGetField(\veone, \fieldname)) \typearrow \TypeErrorVal{\BadField}
+  \annotateexpr(\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}) \typearrow \TypeErrorVal{\BadField}
 }
 \end{mathpar}
 \CodeSubsection{\EGetBadRecordFieldBegin}{\EGetBadRecordFieldEnd}{../Typing.ml}
@@ -1723,7 +1723,7 @@ All of the collection field expressions in
 }{
   {
     \begin{array}{r}
-      \annotateexpr(\tenv, \EGetField(\veone, \fieldname)) \typearrow \\
+      \annotateexpr(\tenv, \overname{\EGetField(\veone, \fieldname)}{\ve}) \typearrow \\
       (\vt, \EGetCollectionFields(\vbase, [\fieldname]), \overname{\vsesone}{\vses})
     \end{array}
   }
@@ -3051,7 +3051,7 @@ Note that there are two important consequences of producing an arbitrary value w
   \tstruct(\tenv, \ttyone) \typearrow \ttytwo \OrTypeError\\\\
   \vses \eqdef \vsesty \cup \{ \LocalEffect(\SEReadonly), \GlobalEffect(\SEReadonly), \Immutability(\False) \}
 }{
-  \annotateexpr(\tenv, \EArbitrary(\tty)) \typearrow (\ttyone, \EArbitrary(\ttytwo), \vses)
+  \annotateexpr(\tenv, \overname{\EArbitrary(\tty)}{\ve}) \typearrow (\ttyone, \EArbitrary(\ttytwo), \vses)
 }
 \end{mathpar}
 \CodeSubsection{\EArbitraryBegin}{\EArbitraryEnd}{../Typing.ml}

--- a/asllib/doc/GlobalPragmas.tex
+++ b/asllib/doc/GlobalPragmas.tex
@@ -112,7 +112,7 @@ without matching any operation.
   \withemptylocal(\genv) \typearrow \tenv \\
   \annotateexprlist(\tenv, \vargs) \typearrow \vargsp \OrTypeError \\
 }{
-  \checkglobalpragma(\genv, \overtext{\DPragma(\Ignore, \vargs)}{\vd}) \typearrow \True
+  \checkglobalpragma(\genv, \overname{\DPragma(\Ignore, \vargs)}{\vd}) \typearrow \True
 }
 \end{mathpar}
 \CodeSubsection{\CheckGlobalPragmaBegin}{\CheckGlobalPragmaEnd}{../Typing.ml}

--- a/asllib/doc/Literals.tex
+++ b/asllib/doc/Literals.tex
@@ -155,29 +155,33 @@ See \ExampleRef{Literals}.
 
 \FormallyParagraph
 \begin{mathpar}
-  \begin{array}{r}
-\inferrule[int]{}{\annotateliteral(\Ignore, \LInt(n)) \typearrow\\
-\TInt(\WellConstrained([\ConstraintExact(\ELInt{n})]))}
-  \end{array}
+\inferrule[int]{}{
+{
+\begin{array}{r}
+  \annotateliteral(\overname{\Ignore}{\tenv}, \overname{\LInt(n)}{\vl}) \typearrow\\
+  \TInt(\WellConstrained([\ConstraintExact(\ELInt{n})]))
+\end{array}
+}
+}
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[bool]{}{\annotateliteral(\Ignore, \LBool(\Ignore))\typearrow \TBool}
+\inferrule[bool]{}{\annotateliteral(\overname{\Ignore}{\tenv}, \overname{\LBool(\Ignore)}{\vl})\typearrow \TBool}
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[real]{}{\annotateliteral(\Ignore, \LReal(\Ignore))}\typearrow \TReal
+\inferrule[real]{}{\annotateliteral(\overname{\Ignore}{\tenv}, \overname{\LReal(\Ignore)}{\vl})}\typearrow \TReal
 \end{mathpar}
 
 \begin{mathpar}
-\inferrule[string]{}{\annotateliteral(\Ignore, \LString(\Ignore))\typearrow \TString}
+\inferrule[string]{}{\annotateliteral(\overname{\Ignore}{\tenv}, \overname{\LString(\Ignore)}{\vl})\typearrow \TString}
 \end{mathpar}
 
 \begin{mathpar}
 \inferrule[bits]{
   n \eqdef \listlen{\bits}
 }{
-  \annotateliteral(\Ignore, \LBitvector(\bits))\typearrow \TBits(\ELInt{n}, \emptylist)
+  \annotateliteral(\overname{\Ignore}{\tenv}, \overname{\LBitvector(\bits)}{\vl})\typearrow \TBits(\ELInt{n}, \emptylist)
 }
 \end{mathpar}
 
@@ -185,7 +189,7 @@ See \ExampleRef{Literals}.
 \inferrule[label]{
   G^\tenv.\declaredtypes(\vlabel) = (\vt, \Ignore)
 }{
-  \annotateliteral(\tenv, \LLabel(\vlabel))\typearrow \vt
+  \annotateliteral(\tenv, \overname{\LLabel(\vlabel)}{\vl}) \typearrow \vt
 }
 \end{mathpar}
 \CodeSubsection{\LitBegin}{\LitEnd}{../Typing.ml}

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -562,9 +562,9 @@ not_bits: NOT '11 01' = 0x2
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[error]{
-  (\op, \vl) \not\in \unopsignatures
+  (\op, \astlabel(\vl)) \not\in \unopsignatures
 }{
-  \unopliterals(\op, \astlabel(\vl)) \typearrow \TypeErrorVal{\BadOperands}
+  \unopliterals(\op, \vl) \typearrow \TypeErrorVal{\BadOperands}
 }
 \and
 \inferrule[negate\_int]{}{

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -79,7 +79,7 @@ yielding the result in $\vb$.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[reflexive]{}{
-  \subtypesrel(\tenv, \TNamed(\id), \TNamed(\id)) \typearrow \True
+  \subtypesrel(\tenv, \overname{\TNamed(\id)}{\vtone}, \overname{\TNamed(\id)}{\vttwo}) \typearrow \True
 }
 \and
 \inferrule[transitive]{
@@ -87,14 +87,14 @@ yielding the result in $\vb$.
   G^\tenv.\subtypes(\idone) = \idthree\\
   \subtypesrel(\tenv, \TNamed(\idthree), \vttwo) \typearrow \vb
 }{
-  \subtypesrel(\tenv, \TNamed(\idone), \TNamed(\idtwo)) \typearrow \vb
+  \subtypesrel(\tenv, \overname{\TNamed(\idone)}{\vtone}, \overname{\TNamed(\idtwo)}{\vttwo}) \typearrow \vb
 }
 \and
 \inferrule[no\_supertype]{
   \idone \neq \idtwo\\
   G^\tenv.\subtypes(\idone) = \bot
 }{
-  \subtypesrel(\tenv, \TNamed(\idone), \TNamed(\idtwo)) \typearrow \False
+  \subtypesrel(\tenv, \overname{\TNamed(\idone)}{\vtone}, \overname{\TNamed(\idtwo)}{\vttwo}) \typearrow \False
 }
 \and
 \inferrule[not\_named]{
@@ -2991,13 +2991,13 @@ The following table shows examples of applying $\towellconstrained$ to various t
 \begin{mathpar}
 \inferrule[t\_int\_parameterized]{}
 {
-  \towellconstrained(\TInt(\Parameterized(\vv))) \typearrow\\ \TInt(\WellConstrained(\ConstraintExact(\EVar(\vv))))
+  \towellconstrained(\overname{\TInt(\Parameterized(\vv))}{\vt}) \typearrow\\ \TInt(\WellConstrained(\ConstraintExact(\EVar(\vv))))
 }
 \and
 \inferrule[t\_int\_other]{
   \astlabel(\vi) \neq \Parameterized
 }{
-  \towellconstrained(\TInt(\vi)) \typearrow \vt
+  \towellconstrained(\overname{\TInt(\vi)}{\vt}) \typearrow \vt
 }
 \and
 \inferrule[other]{
@@ -3224,13 +3224,13 @@ precision lost, the type of \verb|(a * a) + 2| also denotes a precision lost.
     \vpone = \PrecisionLost \lor
     \vptwo = \PrecisionLost
   }{
-    \vp = \PrecisionLost
+    \precisionjoin(\vpone, \vptwo) \typearrow \PrecisionLost
   }
   \and
   \inferrule[Full]{
     \vpone = \PrecisionFull \\
     \vptwo = \PrecisionFull
   }{
-    \vp = \PrecisionFull
+    \precisionjoin(\vpone, \vptwo) \typearrow \PrecisionFull
   }
 \end{mathpar}

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -1368,13 +1368,13 @@ $\{\ \Other(\RecordBase), \Other(\HalfWordBits)\ \}$.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[none]{}{
-  \usesubtypes(\None) \typearrow \overname{\emptyset}{\ids}
+  \usesubtypes(\overname{\None}{\fields}) \typearrow \overname{\emptyset}{\ids}
 }
 \and
 \inferrule[some]{
   \ids \eqdef \{\Other(\vx)\} \cup \bigcup_{(\Ignore, \vt) \in \subfields}\usety(\vt)
 }{
-  \usesubtypes(\some{(\vx, \subfields)}) \typearrow \ids
+  \usesubtypes(\overname{\some{(\vx, \subfields)}}{\fields}) \typearrow \ids
 }
 \end{mathpar}
 
@@ -2238,7 +2238,7 @@ and the identifiers used by them, appearing in comments to their right.
 
 \begin{mathpar}
 \inferrule[s\_decl]{}{
-  \usestmt(\overname{\SDecl(\Ignore, \ldi, \vt, \ve)}\vs)
+  \usestmt(\overname{\SDecl(\Ignore, \ldi, \vt, \ve)}{\vs})
   \typearrow
   \overname{\useldi(\ldi) \cup \usety(\vt) \cup \useexpr(\ve)}{\ids}
 }
@@ -2246,7 +2246,7 @@ and the identifiers used by them, appearing in comments to their right.
 
 \begin{mathpar}
 \inferrule[s\_throw]{}{
-  \usestmt(\overname{\SThrow(\ve)}\vs) \typearrow \overname{\useexpr(\ve)}{\ids}
+  \usestmt(\overname{\SThrow(\ve)}{\vs}) \typearrow \overname{\useexpr(\ve)}{\ids}
 }
 \end{mathpar}
 

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -705,7 +705,7 @@ See \ExampleRef{Typing Declaration Statements}.
 \inferrule[none]{
   \annotatelocaldeclitem(\tenv, \vte, \ldk, \some{\vep}, \ldi) \typearrow \newtenv \OrTypeError
 }{
-  \annotatelocaldecltypeannot(\tenv, \None, \vte, \ldk, \vep, \ldi) \typearrow (\newtenv, \overname{\None}{\tyoptp}, \overname{\emptyset}{\vses})
+  \annotatelocaldecltypeannot(\tenv, \overname{\None}{\tyopt}, \vte, \ldk, \vep, \ldi) \typearrow (\newtenv, \overname{\None}{\tyoptp}, \overname{\emptyset}{\vses})
 }
 \end{mathpar}
 
@@ -717,7 +717,7 @@ See \ExampleRef{Typing Declaration Statements}.
   \checkcanbeinitializedwith(\tenv, \vtpp, \vte) \typearrow \True \OrTypeError\\\\
   \annotatelocaldeclitem(\tenv, \vtpp, \ldk, \some{ \vep }, \ldip) \typearrow \newtenv \OrTypeError
 }{
-  \annotatelocaldecltypeannot(\tenv, \some{\vt}, \vte, \ldk, \vep, \ldi) \typearrow (\newtenv, \overname{\some{\vtpp}}{\tyoptp}, \vses)
+  \annotatelocaldecltypeannot(\tenv, \overname{\some{\vt}}{\tyopt}, \vte, \ldk, \vep, \ldi) \typearrow (\newtenv, \overname{\some{\vtpp}}{\tyoptp}, \vses)
 }
 \end{mathpar}
 

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -1216,7 +1216,7 @@ in \listingref{ParametersOfTy} are as follows:
 \inferrule[tbits]{
   \paramsofexpr(\tenv, \ve) \typearrow \ids
 }{
-  \paramsofty(\tenv, \TBits(\ve, \Ignore)) \typearrow \ids
+  \paramsofty(\tenv, \overname{\TBits(\ve, \Ignore)}{\tty}) \typearrow \ids
 }
 \end{mathpar}
 
@@ -1225,7 +1225,7 @@ in \listingref{ParametersOfTy} are as follows:
   \tty_i \in \tys: \paramsofty(\tenv, \tty_i) \typearrow \ids_i \OrTypeError\\\\
   \ids \eqdef \ids_1 \concat \ldots \concat \ids_{\listlen{\tys}}
 }{
-  \paramsofty(\tenv, \TTuple(\tys)) \typearrow \ids
+  \paramsofty(\tenv, \overname{\TTuple(\tys)}{\tty}) \typearrow \ids
 }
 \end{mathpar}
 
@@ -1234,7 +1234,7 @@ in \listingref{ParametersOfTy} are as follows:
   \vc_i \in \cs: \paramsofconstraint(\tenv, \vc_i) \typearrow \ids_i \OrTypeError\\\\
   \ids \eqdef \ids_1 \concat \ldots \concat \ids_{\listlen{\tys}}
 }{
-  \paramsofty(\tenv, \TInt(\WellConstrained(\cs, \True))) \typearrow \ids
+  \paramsofty(\tenv, \overname{\TInt(\WellConstrained(\cs, \True))}{\tty}) \typearrow \ids
 }
 \end{mathpar}
 
@@ -1349,7 +1349,7 @@ for the expression \verb|A| appearing in the return type.
   \isundefined(\tenv, \vx) \typearrow \vb\\
   \ids \eqdef \choice{\vb}{[\vx]}{\emptylist}
 }{
-  \paramsofexpr(\tenv, \EVar(\vx)) \typearrow \ids
+  \paramsofexpr(\tenv, \overname{\EVar(\vx)}{\ve}) \typearrow \ids
 }
 \end{mathpar}
 
@@ -1357,7 +1357,7 @@ for the expression \verb|A| appearing in the return type.
 \inferrule[eunop]{
   \paramsofexpr(\tenv, \veone) \typearrow \ids \OrTypeError
 }{
-  \paramsofexpr(\tenv, \EUnop(\Ignore, \veone)) \typearrow \ids
+  \paramsofexpr(\tenv, \overname{\EUnop(\Ignore, \veone)}{\ve}) \typearrow \ids
 }
 \end{mathpar}
 
@@ -1366,7 +1366,7 @@ for the expression \verb|A| appearing in the return type.
   \paramsofexpr(\tenv, \veone) \typearrow \idsone \OrTypeError\\\\
   \paramsofexpr(\tenv, \vetwo) \typearrow \idstwo \OrTypeError
 }{
-  \paramsofexpr(\tenv, \EBinop(\Ignore, \veone, \vetwo)) \typearrow \overname{\idsone \concat \idstwo}{\ids}
+  \paramsofexpr(\tenv, \overname{\EBinop(\Ignore, \veone, \vetwo)}{\ve}) \typearrow \overname{\idsone \concat \idstwo}{\ids}
 }
 \end{mathpar}
 
@@ -1376,7 +1376,7 @@ for the expression \verb|A| appearing in the return type.
   \es \eqname [\ve]\\
   \paramsofexpr(\tenv, \ve) \typearrow \ids \OrTypeError\
 }{
-  \paramsofexpr(\tenv, \ETuple(\es)) \typearrow \ids
+  \paramsofexpr(\tenv, \overname{\ETuple(\es)}{\ve}) \typearrow \ids
 }
 \end{mathpar}
 
@@ -1386,7 +1386,7 @@ for the expression \verb|A| appearing in the return type.
   \paramsofexpr(\tenv, \veone) \typearrow \idsone \OrTypeError\\\\
   \paramsofexpr(\tenv, \vetwo) \typearrow \idstwo \OrTypeError
 }{
-  \paramsofexpr(\tenv, \ECond(\ve, \veone, \vetwo)) \typearrow \overname{\idsp \concat \idsone \concat \idstwo}{\ids}
+  \paramsofexpr(\tenv, \overname{\ECond(\ve, \veone, \vetwo)}{\ve}) \typearrow \overname{\idsp \concat \idsone \concat \idstwo}{\ids}
 }
 \end{mathpar}
 
@@ -1436,7 +1436,7 @@ See also \ExampleRef{Extracting the Parameters from Expressions}.
 \inferrule[exact]{
   \paramsofexpr(\tenv, \ve) \typearrow \ids
 }{
-  \paramsofconstraint(\tenv, \ConstraintExact(\ve)) \typearrow \ids
+  \paramsofconstraint(\tenv, \overname{\ConstraintExact(\ve)}{\vc}) \typearrow \ids
 }
 \end{mathpar}
 
@@ -1445,7 +1445,7 @@ See also \ExampleRef{Extracting the Parameters from Expressions}.
   \paramsofexpr(\tenv, \veone) \typearrow \idsone \\
   \paramsofexpr(\tenv, \vetwo) \typearrow \idstwo \\
 }{
-  \paramsofconstraint(\tenv, \ConstraintRange(\veone, \vetwo)) \typearrow \overname{\idsone \concat \idstwo}{\ids}
+  \paramsofconstraint(\tenv, \overname{\ConstraintRange(\veone, \vetwo)}{\vc}) \typearrow \overname{\idsone \concat \idstwo}{\ids}
 }
 \end{mathpar}
 

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -1545,13 +1545,13 @@ of \verb|Foo|.
 \inferrule[tint\_parameterized]{
   \vb \eqdef \vione = \vitwo
 }{
-  \typeequal(\tenv, \TInt(\Parameterized(\vione)), \TInt(\Parameterized(\vitwo))) \typearrow \vb
+  \typeequal(\tenv, \overname{\TInt(\Parameterized(\vione))}{\vtone}, \overname{\TInt(\Parameterized(\vitwo))}{\vttwo}) \typearrow \vb
 }
 \and
 \inferrule[tint\_wellconstrained]{
   \constraintsequal(\tenv, \vcone, \vctwo) \typearrow \vb \OrTypeError
 }{
-  \typeequal(\tenv, \TInt(\WellConstrained(\vcone)), \TInt(\WellConstrained(\vctwo))) \typearrow \vb
+  \typeequal(\tenv, \overname{\TInt(\WellConstrained(\vcone))}{\vtone}, \overname{\TInt(\WellConstrained(\vctwo))}{\vttwo}) \typearrow \vb
 }
 \end{mathpar}
 
@@ -1561,7 +1561,7 @@ of \verb|Foo|.
   \bitfieldsequal(\tenv, \bfone, \bftwo) \typearrow \vbtwo \OrTypeError\\\\
   \vb \eqdef \vbone \land \vbtwo
 }{
-  \typeequal(\tenv, \TBits(\vwone, \bfone), \TBits(\vwtwo, \bftwo)) \typearrow \vb
+  \typeequal(\tenv, \overname{\TBits(\vwone, \bfone)}{\vtone}, \overname{\TBits(\vwtwo, \bftwo)}{\vttwo}) \typearrow \vb
 }
 \end{mathpar}
 
@@ -1571,7 +1571,7 @@ of \verb|Foo|.
   \typeequal(\tenv, \vtone, \vttwo) \typearrow \vbtwo \OrTypeError\\\\
   \vb \eqdef \vbone \land \vbtwo
 }{
-  \typeequal(\tenv, \TArray(\vlone, \vtone), \TArray(\vltwo, \vttwo)) \typearrow \vb
+  \typeequal(\tenv, \overname{\TArray(\vlone, \vtone)}{\vtone}, \overname{\TArray(\vltwo, \vttwo)}{\vttwo}) \typearrow \vb
 }
 \end{mathpar}
 
@@ -1579,7 +1579,7 @@ of \verb|Foo|.
 \inferrule[tnamed]{
   \vb \eqdef \vsone = \vstwo
 }{
-  \typeequal(\tenv, \TNamed(\vsone), \TNamed(\vstwo)) \typearrow \vb
+  \typeequal(\tenv, \overname{\TNamed(\vsone)}{\vtone}, \overname{\TNamed(\vstwo)}{\vttwo}) \typearrow \vb
 }
 \end{mathpar}
 
@@ -1587,7 +1587,7 @@ of \verb|Foo|.
 \inferrule[tenum]{
   \vb \eqdef \vlone = \vltwo
 }{
-  \typeequal(\tenv, \TEnum(\vlone), \TEnum(\vltwo)) \typearrow \vb
+  \typeequal(\tenv, \overname{\TEnum(\vlone)}{\vtone}, \overname{\TEnum(\vltwo)}{\vttwo}) \typearrow \vb
 }
 \end{mathpar}
 
@@ -1602,7 +1602,7 @@ of \verb|Foo|.
   }\\\\
   \vb \eqdef \bigwedge_{\vf \in \fieldnames(\vfieldsone)} \vb_\vf
 }{
-  \typeequal(\tenv, L(\vfieldsone), L(\vfieldstwo)) \typearrow \vb
+  \typeequal(\tenv, \overname{L(\vfieldsone)}{\vtone}, \overname{L(\vfieldstwo)}{\vttwo}) \typearrow \vb
 }
 \end{mathpar}
 
@@ -1612,7 +1612,7 @@ of \verb|Foo|.
   i \in \listrange(\vtsone): \typeequal(\tenv, \vtsone[i], \vtstwo[i]) \typearrow \vb_i \OrTypeError\\\\
   \vb \eqdef \bigwedge_{i \in \listrange(\vtsone)} \vb_i
 }{
-  \typeequal(\tenv, \TTuple(\vtsone), \TTuple(\vtstwo)) \typearrow \vb
+  \typeequal(\tenv, \overname{\TTuple(\vtsone)}{\vtone}, \overname{\TTuple(\vtstwo)}{\vttwo}) \typearrow \vb
 }
 \end{mathpar}
 
@@ -2107,7 +2107,7 @@ even though they both contain three elements each.
 \inferrule[expr\_expr]{
   \exprequal(\veoneone, \vetwoone) \typearrow \vb \OrTypeError
 }{
-  \arraylengthequal(\ArrayLengthExpr(\veoneone), \ArrayLengthExpr(\vetwoone)) \typearrow \vb
+  \arraylengthequal(\overname{\ArrayLengthExpr(\veoneone)}{\vlone}, \overname{\ArrayLengthExpr(\vetwoone)}{\vltwo}) \typearrow \vb
 }
 \end{mathpar}
 
@@ -2115,7 +2115,7 @@ even though they both contain three elements each.
 \inferrule[enum\_enum]{
   \vb \eqdef (\venumone = \venumtwo)
 }{
-  \arraylengthequal(\ArrayLengthEnum(\venumone, \Ignore), \ArrayLengthEnum(\venumtwo, \Ignore)) \typearrow \vb
+  \arraylengthequal(\overname{\ArrayLengthEnum(\venumone, \Ignore)}{\vlone}, \overname{\ArrayLengthEnum(\venumtwo, \Ignore)}{\vltwo}) \typearrow \vb
 }
 \end{mathpar}
 
@@ -2201,15 +2201,13 @@ first identifier for which the two monomials differ.
 \begin{itemize}
   \item \AllApplyCase{equal\_monomials}
   \begin{itemize}
-    \item $\vmone$ is $f$ and $\vmtwo$ is $g$;
-    \item $f$ is equal to $g$;
+    \item $\vmone$ is equal to $\vmtwo$;
     \item $\vs$ is the sign of $\vqtwo - \vqone$.
   \end{itemize}
 
   \item \AllApplyCase{different\_monomials}
   \begin{itemize}
-    \item $\vmone$ is $f$ and $\vmtwo$ is $g$;
-    \item $f$ is different from to $g$;
+    \item $\vmone$ is different to $\vmtwo$;
     \item $\ids$ is the list obtained by taking the set of identifiers in the domain of $f$ and in the domain of $g$,
           and sorting them according to the lexical order for identifiers (ASCII string order);
     \item $\vv$ is the first identifier in $\ids$ for which $f$ and $g$ behave differently (either one of them is defined
@@ -2227,14 +2225,14 @@ via the lexicographic ordering.
 
 \begin{mathpar}
 \inferrule[equal\_monomials]{
-  f = g\\
+  \vmone = \vmtwo\\
   \vs \eqdef \sign(\vqtwo - \vqone)
 }{
-  \comparemonomialbindings((\overname{f}{\vmone}, \vqone), (\overname{g}{\vmtwo}, \vqtwo)) \typearrow \vs
+  \comparemonomialbindings((\vmone, \vqone), (\vmtwo, \vqtwo)) \typearrow \vs
 }
 \and
 \inferrule[different\_monomials]{
-  f \neq g\\
+  \vmone \neq \vmtwo\\
   \ids \eqdef \sort(\dom(f) \cup \dom(g), \compareidentifier)\\
   \ids \eqname \idsone \concat \idstwo\\
   \vi\in\listrange(\idsone): f(\idsone[\vi]) = g(\idsone[\vi])\\
@@ -2247,7 +2245,7 @@ via the lexicographic ordering.
     \end{cases}
 }
 }{
-  \comparemonomialbindings((\overname{f}{\vmone}, \vqone), (\overname{g}{\vmtwo}, \vqtwo)) \typearrow \vs
+  \comparemonomialbindings((\vmone, \vqone), (, \vqtwo)) \typearrow \vs
 }
 \end{mathpar}
 

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -368,8 +368,12 @@ is
 
 \begin{mathpar}
 \inferrule[int\_parameterized]{}{
-  \symdomoftype(\tenv, \overname{\TInt(\Parameterized(\id))}{\vt}) \typearrow \\
+  {
+  \begin{array}{r}
+  \symdomoftype(\tenv, \overname{\TInt(\Parameterized(\id))}{\vt}) \typearrow\\
   \overname{\Subdomains([\ConstrainedDom(\ConstraintExact(\EVar(\id)))])}{\vd}
+  \end{array}
+  }
 }
 \end{mathpar}
 

--- a/asllib/doc/TypeAttributes.tex
+++ b/asllib/doc/TypeAttributes.tex
@@ -514,7 +514,7 @@ this ensures that \TypingRuleRef{Structure} is a proper \emph{structural inducti
   \declaredtype(\tenv, \vx) \typearrow \vtone \OrTypeError\\\\
   \tstruct(\tenv, \vtone)\typearrow\vt \OrTypeError
 }{
-  \tstruct(\tenv, \TNamed(\vx)) \typearrow \vt
+  \tstruct(\tenv, \overname{\TNamed(\vx)}{\tty}) \typearrow \vt
 }
 \end{mathpar}
 
@@ -531,7 +531,7 @@ this ensures that \TypingRuleRef{Structure} is a proper \emph{structural inducti
   \tys \eqname \vt_{1..k}\\
   i=1..k: \tstruct(\tenv, \vt_i) \typearrow \vtp_i \OrTypeError
 }{
-  \tstruct(\tenv, \TTuple(\tys)) \typearrow  \TTuple(i=1..k: \vtp_i)
+  \tstruct(\tenv, \overname{\TTuple(\tys)}{\tty}) \typearrow  \TTuple(i=1..k: \vtp_i)
 }
 \end{mathpar}
 
@@ -539,7 +539,7 @@ this ensures that \TypingRuleRef{Structure} is a proper \emph{structural inducti
 \inferrule[array]{
   \tstruct(\tenv, \vt) \typearrow \vtone \OrTypeError
 }{
-  \tstruct(\tenv, \TArray(\ve, \vt)) \typearrow \TArray(\ve, \vtone)
+  \tstruct(\tenv, \overname{\TArray(\ve, \vt)}{\tty}) \typearrow \TArray(\ve, \vtone)
 }
 \end{mathpar}
 
@@ -548,7 +548,7 @@ this ensures that \TypingRuleRef{Structure} is a proper \emph{structural inducti
   L \in \{\TRecord, \TException, \TCollection\}\\\\
   (\id,\vt) \in \fields : \tstruct(\tenv, \vt) \typearrow \vt_\id \OrTypeError
 }{
-  \tstruct(\tenv, L(\fields)) \typearrow
+  \tstruct(\tenv, \overname{L(\fields)}{\tty}) \typearrow
  L([ (\id,\vt) \in \fields : (\id,\vt_\id) ])
 }
 \end{mathpar}
@@ -667,18 +667,18 @@ is a \constrainedintegerterm{} type.
 \begin{mathpar}
 \inferrule[well-constrained]{}
 {
-  \checkconstrainedinteger(\tenv, \TInt(\WellConstrained(\Ignore))) \typearrow \True
+  \checkconstrainedinteger(\tenv, \overname{\TInt(\WellConstrained(\Ignore))}{\tty}) \typearrow \True
 }
 \and
 \inferrule[parameterized]{}
 {
-  \checkconstrainedinteger(\tenv, \TInt(\Parameterized(\Ignore))) \typearrow \True
+  \checkconstrainedinteger(\tenv, \overname{\TInt(\Parameterized(\Ignore))}{\tty}) \typearrow \True
 }
 \and
 \inferrule[unconstrained]{
   \astlabel(\vc) = \Unconstrained \;\lor\; \astlabel(\vc) = \PendingConstrained
 }{
-  \checkconstrainedinteger(\tenv, \TInt(\vc)) \typearrow \TypeErrorVal{\UnexpectedType}
+  \checkconstrainedinteger(\tenv, \overname{\TInt(\vc)}{\tty}) \typearrow \TypeErrorVal{\UnexpectedType}
 }
 \and
 \inferrule[conflicting\_type]{

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -72,7 +72,7 @@ thus resulting in a \typingerrorterm.
 \inferrule[okay]{
   \cardinality{\{\id_{1..k}\}} = k
 }{
-  \checknoduplicates(\id_{1..k}) \typearrow \True
+  \checknoduplicates(\overname{\id_{1..k}}{\ids}) \typearrow \True
 }
 \end{mathpar}
 
@@ -82,7 +82,7 @@ thus resulting in a \typingerrorterm.
   i \neq j\\
   \id_i = \id_j
 }{
-  \checknoduplicates(\id_{1..k}) \typearrow \TypeErrorVal{\IdentifierAlreadyDeclared}
+  \checknoduplicates(\overname{\id_{1..k}}{\ids}) \typearrow \TypeErrorVal{\IdentifierAlreadyDeclared}
 }
 \end{mathpar}
 
@@ -257,11 +257,11 @@ $\ArrayLengthEnum(\BitsArray, [\vBIG, \vLITTLE])$, and
 \begin{mathpar}
 \inferrule[enum]{}
 {
-  \typeofarraylength(\ArrayLengthEnum(\vs, \Ignore)) \typearrow \TNamed(\vs)
+  \typeofarraylength(\overname{\ArrayLengthEnum(\vs, \Ignore)}{\size}) \typearrow \TNamed(\vs)
 }
 \and
 \inferrule[expr]{}{
-  \typeofarraylength(\ArrayLengthExpr(\Ignore)) \typearrow \TInt(\Unconstrained)
+  \typeofarraylength(\overname{\ArrayLengthExpr(\Ignore)}{\size}) \typearrow \TInt(\Unconstrained)
 }
 \end{mathpar}
 \CodeSubsection{\TypeOfArrayLengthBegin}{\TypeOfArrayLengthEnd}{../types.ml}

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -866,7 +866,7 @@ to be \constrainedintegersterm.
 }{
   {
     \begin{array}{r}
-  \annotatetype(\overname{\Ignore}{\vdecl}, \tenv, \TBits(\ewidth, \bitfields)) \typearrow \\
+  \annotatetype(\overname{\Ignore}{\vdecl}, \tenv, \overname{\TBits(\ewidth, \bitfields)}{\tty}) \typearrow \\
   (\overname{\TBits(\ewidthp, \bitfieldsp)}{\newty}, \vses)
     \end{array}
   }
@@ -883,7 +883,7 @@ to be \constrainedintegersterm.
 }{
   {
     \begin{array}{r}
-  \annotatetype(\overname{\Ignore}{\vdecl}, \tenv, \TBits(\ewidth, \bitfields)) \typearrow \\
+  \annotatetype(\overname{\Ignore}{\vdecl}, \tenv, \overname{\TBits(\ewidth, \bitfields)}{\tty}) \typearrow \\
   (\overname{\TBits(\ewidthp, \bitfieldsp)}{\newty}, \overname{\seswidth}{\seswidth})
     \end{array}
   }
@@ -978,7 +978,7 @@ See \ExampleRef{Well-typed Tuples} for examples of well-typed \tupletypesterm.
   i=1..k: \annotatetype(\False, \tenv, \tty_i) \typearrow (\ttyp_i, \vxs_i) \OrTypeError\\\\
   \vses \eqdef \bigcup_{i=1..k} \vxs_i
 }{
-  \annotatetype(\overname{\Ignore}{\vdecl}, \tenv, \TTuple(\tys)) \typearrow (\overname{\TTuple(\tysp)}{\newty}, \vses)
+  \annotatetype(\overname{\Ignore}{\vdecl}, \tenv, \overname{\TTuple(\tys)}{\tty}) \typearrow (\overname{\TTuple(\tysp)}{\newty}, \vses)
 }
 \end{mathpar}
 \CodeSubsection{\TTupleBegin}{\TTupleEnd}{../Typing.ml}
@@ -1109,7 +1109,7 @@ show examples of ill-typed enumeration type declarations.
   \checknoduplicates(\vli) \typearrow \True \OrTypeError\\\\
   \vl \in \vli: \checkvarnotingenv(G^\tenv, \vl) \typearrow \True \OrTypeError
 }{
-  \annotatetype(\True, \tenv, \TEnum(\vli)) \typearrow (\overname{\TEnum(\vli)}{\newty}, \overname{\emptyset}{\vses})
+  \annotatetype(\True, \tenv, \overname{\TEnum(\vli)}{\tty}) \typearrow (\overname{\TEnum(\vli)}{\newty}, \overname{\emptyset}{\vses})
 }
 \end{mathpar}
 \CodeSubsection{\TEnumDeclBegin}{\TEnumDeclEnd}{../Typing.ml}


### PR DESCRIPTION
While trying to import inference rules from LaTeX to the aslspec format, I realized some input arguments were missing the appropriate `\overname{expr}{var}` wrapper, which is needed to add the corresponding `var = expr` premise.
Also, some other bugs were found and fixed.