### PR TITLE
[gen] Fix a problem on `vmsa/kvm`+`moreedges`, caused by `pp` conflict.

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -2170,14 +2170,25 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
          I_FENCE (DSB (ISH,FULL))::
          (if isb then [I_FENCE ISB] else []))
 
-    let emit_shootdown dom op sync r =
-      match sync with
-      | Sync ->
-         pseudo
-           (I_FENCE (DSB(dom,FULL))::
-            I_TLBI(op,r)::I_FENCE (DSB(dom,FULL))::[])
-      | NoSync ->
-         pseudo (I_TLBI(op,r)::[])
+    let emit_shootdown_prefix st p init n op =
+      let loc = match n.C.evt.C.loc with
+      | Data loc -> loc
+      | Code _ -> Warn.user_error "TLBI/CacheSync" in
+      let open TLBI in
+      match op.TLBI.typ with
+      | ALL|VMALL|VMALLS12 -> ZR,init,[],st
+      | ASID|VA|VAL|VAA|VAAL|IPAS2|IPAS2L ->
+        let r,init,st = U.next_init st p init loc in
+        let r1,st = tempo1 st in
+        let cs = [Instruction (lsri64 r1 r 12)] in
+        r1,init,cs,st
+
+    let emit_shootdown_sync dom op r =
+      pseudo
+        (I_FENCE (DSB(dom,FULL))::
+        I_TLBI(op,r)::I_FENCE (DSB(dom,FULL))::[])
+
+    let emit_shootdown_nosync op r = pseudo (I_TLBI(op,r)::[])
 
     let emit_CMO t r = match t with
       | DC_CVAU -> pseudo ([I_DC (DC.cvau, r)])
@@ -2185,23 +2196,14 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     let emit_fence st p init n f = match f with
     | Barrier f -> init,[Instruction (I_FENCE f)],st
-    | Shootdown(dom,op,sync) ->
-        let loc = match n.C.evt.C.loc with
-        | Data loc -> loc
-        | Code _ -> Warn.user_error "TLBI/CacheSync" in
-        let open TLBI in
-        let r,init,csr,st =  match op.TLBI.typ with
-        | ALL|VMALL|VMALLS12
-            ->
-              ZR,init,[],st
-        | ASID|VA|VAL|VAA|VAAL|IPAS2|IPAS2L
-            ->
-              let r,init,st = U.next_init st p init loc in
-              let r1,st = tempo1 st in
-              let cs = [Instruction (lsri64 r1 r 12)] in
-              r1,init,cs,st in
-        let cs = emit_shootdown dom op sync r in
-        init,csr@cs,st
+    | ShootdownSync (dom,op) ->
+      let r,init,csr,st = emit_shootdown_prefix st p init n op in
+      let cs = emit_shootdown_sync dom op r in
+      init,csr@cs,st
+    | ShootdownNoSync (op) ->
+      let r,init,csr,st = emit_shootdown_prefix st p init n op in
+      let cs = emit_shootdown_nosync op r in
+      init,csr@cs,st
     | CacheSync (s,isb) -> begin
         try
           let lab = C.find_prev_code_write n in


### PR DESCRIPTION
Fix a problem when `-variant kvm` and `-moredeges true`, e.g. `diyone7 -arch AArch64 -variant kvm -moreedges true -show edges`, the booting stage of `diy*` fails. This is due to a `pp` function, printing the same output/target string despite different input data.

We introduce separate data types to replace `Shootdown`. The new datatype is `ShootdownSync` and `ShootdownNoSync`. The former corresponds to `TLBI-sync*` syntax, and takes a `domain` and `operation`. The latter corresponds to `TLBI*` syntax and only takes `operation` now. 

Due to new data type we also fix a problem in the `compare_fence` all together, where previously `CMO` is not ordered correctly as it always return +1 even in the situation both side is `CMO`. Now it use the `stdlib.compare`, which is good enough to provide correct ordering based on the definition of fence datatype.
