### PR TITLE
[asl][reference] fixes to comments raised on PR#1477

### DIFF
--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -101,7 +101,7 @@ The function $\sign : \overname{\Q}{q} \rightarrow \Sign$ returns the sign of $\
 \end{definition}
 
 \begin{definition}[Empty Set]
-  The \emph{empty set} --- the set that does not contain any element --- is denoted as \RenderType{empty_set}.
+  The \emph{empty set} --- the set that does not contain any element --- is denoted as \RenderConstant{empty_set}.
 \end{definition}
 
 \hypertarget{def-cardinality}{}
@@ -227,7 +227,7 @@ is defined as follows:
 \subsection{Lists}
 In the remainder of this document, we use the term \emph{list} and \emph{sequence} interchangeably.
 
-A list of elements \hypertarget{def-emptylist}{is either empty, denoted by $\emptylist$}, or non-empty.
+A list of elements \hypertarget{constant-emptylist}{is either empty, denoted by $\emptylist$}, or non-empty.
 A non-empty list is either denoted by listing the elements in sequence, $v_1 \ldots\ v_k$,
 or in bracketed form, $[v_1,\ldots,v_k]$, which is used to aesthetically separate it from surrounding mathematical expressions.
 The commas carry no special meaning.

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -269,7 +269,7 @@
 \renewcommand\neg[0]{\hyperlink{def-neg}{\OldNeg}}
 \let\OldTriangleq\triangleq
 \let\OldEmptyset\emptyset
-\renewcommand\emptyset[0]{\hyperlink{type-emptyset}{\OldEmptyset}}
+\renewcommand\emptyset[0]{\hyperlink{constant-emptyset}{\OldEmptyset}}
 \let\OldBot\bot
 \renewcommand\bot[0]{\hyperlink{constant-bot}{\OldBot}}
 \renewcommand\triangleq[0]{\hyperlink{def-triangleq}{\OldTriangleq}}
@@ -282,7 +282,7 @@
 \newcommand\emptyfunc[0]{\hyperlink{def-emptyfunc}{{\emptyset}_\lambda}}
 \newcommand\restrictfunc[2]{{#1}\hyperlink{def-restrictfunc}{|}_{#2}}
 
-\newcommand\emptylist[0]{\hyperlink{def-emptylist}{[\ ]}}
+\newcommand\emptylist[0]{\hyperlink{constant-emptylist}{[\ ]}}
 \newcommand\Proseemptylist[1]{#1 is the empty list}
 \newcommand\choice[3]{\hyperlink{def-choice}{\textsf{choice}}(#1,#2,#3)}
 \newcommand\choicename[0]{\hyperlink{def-choice}{\textfunc{choice}}}
@@ -806,7 +806,7 @@
 \newcommand\funcsubprogramtype[0]{\text{subprogram\_type}}
 \newcommand\funcrecurselimit[0]{\text{recurse\_limit}}
 \newcommand\funcbuiltin[0]{\text{builtin}}
-\newcommand\funcqualifier[0]{\text{qualifier}}
+\newcommand\funcqualifierfield[0]{\text{qualifier}}
 \newcommand\funcoverride[0]{\text{override}}
 \newcommand\GDkeyword[0]{\text{keyword}}
 \newcommand\GDname[0]{\text{name}}
@@ -953,7 +953,6 @@
 \newcommand\ProseReturningOrAbnormal[0]{\ProseTerminateAs{\TReturning, \ThrowingConfig, \DynErrorConfig, \DivergingConfig}}
 \newcommand\ProseOrError[0]{\ProseTerminateAs{\DynErrorConfig}}
 \newcommand\ProseOrDynErrorDiverging[0]{\ProseTerminateAs{\DynErrorConfig, \DivergingConfig}}
-\newcommand\TOutConfig[0]{\hyperlink{def-toutconfig}{\textsf{TOutConfig}}}
 
 \newcommand\evalexpr[0]{\hyperlink{def-evalexpr}{\textfunc{eval\_expr}}}
 \newcommand\Proseevalexpr[3]{

--- a/asllib/doc/AbstractSyntax.tex
+++ b/asllib/doc/AbstractSyntax.tex
@@ -431,7 +431,7 @@ the local declaration item is
 \end{flalign*}
 }
 
-\RenderType{qualifier}
+\RenderType{func_qualifier}
 
 \BackupOriginalAST{
 \begin{flalign*}

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -174,10 +174,12 @@ and a catch clause for the named exception value for the exception type \verb|Ex
 The semantic relation for evaluating catchers employs an argument
 that is an output configuration. This argument corresponds to the result
 of evaluating a \trystatementterm{} and its type is defined as follows:
-\hypertarget{def-toutconfig}{}
+\RenderType{TOutConfig}
+\BackupOriginalType{
 \[
   \TOutConfig \triangleq \TNormal \cup  \TThrowing \cup \TContinuing \cup \TReturning \enspace.
 \]
+} % END_OF_BACKUP_TYPE
 
 The relation
 \hypertarget{def-evalcatchers}{}

--- a/asllib/doc/GlobalStorageDeclarations.tex
+++ b/asllib/doc/GlobalStorageDeclarations.tex
@@ -626,6 +626,10 @@ The case where both $\tyopt$ and $\initialvalue$ are $\None$ is considered a syn
 \end{mathpar}
 
 \TypingRuleDef{UpdateGlobalStorage}
+This helper function is applied following
+$\addglobalstorage(\tenv, \name, \gdk, \vt)$ where $\vt$ is the type associated with
+$\name$.
+
 \hypertarget{def-updateglobalstorage}{}
 The function
 \[

--- a/asllib/doc/RelationsOnTypes.tex
+++ b/asllib/doc/RelationsOnTypes.tex
@@ -1689,7 +1689,7 @@ $\{\AbbrevConstraintRange{\ELInt{2}}{\ELInt{4}}\}$ and
 $\{\AbbrevConstraintExact{\ELInt{2}}\}$ results in\\
 $\{\AbbrevConstraintRange{\ELInt{4}}{\ELInt{6}}\}$,
 since $\binopisexploding(\ADD) \typearrow \False$
-while applying $\MUL$ to the same lists of constraints results in
+while applying $\MUL$ to the same lists of constraints results in\\
 $\{\AbbrevConstraintExact{\ELInt{4}}, \AbbrevConstraintExact{\ELInt{6}}, \AbbrevConstraintExact{\ELInt{8}}\}$,
 since $\binopisexploding(\MUL) \typearrow \True$.
 

--- a/asllib/doc/SideEffects.tex
+++ b/asllib/doc/SideEffects.tex
@@ -418,7 +418,7 @@ appearing in bitvector widths for bitvector types with bitfields must be pure.
 \hypertarget{def-sesforsubprogram}{}
 The function
 \[
-  \sesforsubprogram(\overname{\Option{\qualifier}}{\vqualifier}) \aslto \overname{\pow{\TSideEffect}}{\vs}
+  \sesforsubprogram(\overname{\Option{\funcqualifier}}{\vqualifier}) \aslto \overname{\pow{\TSideEffect}}{\vs}
 \]
 produces a \sideeffectsetterm{} given a subprogram qualifier $\vqualifier$.
 

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -108,7 +108,7 @@ For example, \listingref{NoEmptyBody} shows a subprogram declaration whose body 
  \funcsubprogramtype &:& \subprogramtype,\\
  \funcrecurselimit    &:& \expr?\\
  \funcbuiltin &:& \Bool\\
- \funcqualifier &:& \Some{\qualifier}\\
+ \funcqualifierfield &:& \Some{\funcqualifier}\\
  \funcoverride &:& \Some{\overrideinfo}\\
 \end{array}
 \right\}
@@ -165,7 +165,7 @@ In particular, rather than directly building the abstract syntax for accessors, 
             \funcsubprogramtype &:& \STFunction,\\
             \funcrecurselimit   &:& \astof{\vrecurselimit}\\
             \funcbuiltin &:& \False\\
-            \funcqualifier &:& \astversion{\vp}\\
+            \funcqualifierfield &:& \astversion{\vp}\\
             \funcoverride &:& \astof{\voverride}
     \end{array}
   \right\}\right)\right]}{\vastnode}
@@ -196,7 +196,7 @@ In particular, rather than directly building the abstract syntax for accessors, 
             \funcsubprogramtype &:& \STProcedure,\\
             \funcrecurselimit   &:& \astof{\vrecurselimit}\\
             \funcbuiltin &:& \False\\
-            \funcqualifier &:& \astof{\vqualifier}\\
+            \funcqualifierfield &:& \astof{\vqualifier}\\
             \funcoverride &:& \astof{\voverride}
     \end{array}
   \right\}\right)\right]
@@ -491,7 +491,7 @@ transforms an $\accessorpair$ into an AST node $\vastnode$.
         \funcsubprogramtype &:& \STGetter,\\
         \funcrecurselimit   &:& \None\\
         \funcbuiltin &:& \False\\
-        \funcqualifier &:& \vqualifier\\
+        \funcqualifierfield &:& \vqualifier\\
         \funcoverride &:& \voverride
       \end{array}
       \right\}
@@ -509,7 +509,7 @@ transforms an $\accessorpair$ into an AST node $\vastnode$.
         \funcsubprogramtype &:& \STSetter,\\
         \funcrecurselimit   &:& \None\\
         \funcbuiltin &:& \False\\
-        \funcqualifier &:& \None\\
+        \funcqualifierfield &:& \None\\
         \funcoverride &:& \voverride
       \end{array}
       \right\}
@@ -537,7 +537,7 @@ transforms an $\accessorpair$ into an AST node $\vastnode$.
 The function
 \[
 \buildqualifier(\overname{\parsenode{\Nqualifier}}{\vparsednode}) \aslto
-  \overname{\Option{\qualifier}}{\vastnode}
+  \overname{\Option{\funcqualifier}}{\vastnode}
 \]
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
@@ -763,8 +763,8 @@ is not a constrained expression.
   \item annotating the return type of $\funcsig$ in $\tenvwithparams$ using \\ $\annotatereturntype$ and $\vseswithargs$, yields\\
         $(\newtenv, \vreturntype, \vseswithreturn)$\ProseOrTypeError;
   \item \Proseeqdef{$\vsesp$}{$\vseswithreturn$ with every \LocalEffectTerm\ removed};
-  \item checking that the \sideeffectsetterm{} $\vsesp$ adheres to the subprogram's \purity{} qualifier $\funcsig.\funcqualifier$ yields $\True$\ProseOrTypeError;
-  \item the \sideeffectsetterm{} corresponding to $\funcsig.\funcqualifier$ (via $\sesforsubprogram$) is $\vses$;
+  \item checking that the \sideeffectsetterm{} $\vsesp$ adheres to the subprogram's \purity{} qualifier $\funcsig.\funcqualifierfield$ yields $\True$\ProseOrTypeError;
+  \item the \sideeffectsetterm{} corresponding to $\funcsig.\funcqualifierfield$ (via $\sesforsubprogram$) is $\vses$;
   \item $\newfuncsig$ is $\funcsig$ with the annotated parameters $\vparams$, annotated arguments $\vargs$, annotated return type $\vreturntype$,
         and $\vrecurselimit$ as its recursion limit.
 \end{itemize}
@@ -809,8 +809,8 @@ is not a constrained expression.
     \end{array}
   }\\\\
   \vsesp \eqdef \vseswithreturn \setminus \{ \vs \;|\; \configdomain{\vs} = \LocalEffect \}\\
-  \checksubprogrampurity(\funcsig.\funcqualifier, \vsesp) \typearrow \True \OrTypeError \\
-  \sesforsubprogram(\funcsig.\funcqualifier) \typearrow \vses\\
+  \checksubprogrampurity(\funcsig.\funcqualifierfield, \vsesp) \typearrow \True \OrTypeError \\
+  \sesforsubprogram(\funcsig.\funcqualifierfield) \typearrow \vses\\
   {
     \newfuncsig \eqdef
     \left\{
@@ -1658,7 +1658,7 @@ as return types.
 The function
 \[
 \checksubprogrampurity(
-  \overname{\Option{\qualifier}}{\vqualifier} \aslsep
+  \overname{\Option{\funcqualifier}}{\vqualifier} \aslsep
   \overname{\TSideEffectSet}{\vses}
 )
 \aslto \overname{\Bool}{\vb} \cup\ \overname{\typeerror}{\TypeErrorConfig}
@@ -1757,7 +1757,7 @@ See \ExampleRef{Updating the Static Environment for a Subprogram}.
                       & \funcreturntype      &:& \vt,\\
                       & \funcsubprogramtype  &:& \subprogramtype, \\
                       & \funcbuiltin         &:& \vb \\
-                      & \funcqualifier       &:& \vqualifier \\
+                      & \funcqualifierfield       &:& \vqualifier \\
                   \}  & ; &&
         \end{array}
   \]
@@ -1783,7 +1783,7 @@ See \ExampleRef{Updating the Static Environment for a Subprogram}.
                     & \funcreturntype      &:& \vt,\\
                     & \funcsubprogramtype  &:& \subprogramtype, \\
                     & \funcbuiltin         &:& \vb \\
-                    & \funcqualifier       &:& \vqualifier \\
+                    & \funcqualifierfield       &:& \vqualifier \\
                     & \funcoverride        &:& \voverride \\
                 \} &&&
       \end{array}
@@ -1810,7 +1810,7 @@ The function
       \overname{\staticenvs}{\tenv} \aslsep
       \overname{\Strings}{\name} \aslsep
       \overname{\subprogramtype}{\subpgmtype} \aslsep
-      \overname{\qualifier}{\vqualifier} \aslsep
+      \overname{\funcqualifier}{\vqualifier} \aslsep
       \overname{\KleeneStar{\ty}}{\formaltypes}
     )
   & \aslto \\
@@ -1859,7 +1859,7 @@ In \listingref{SubprogramClash-bad1}, the function \verb|X| and the procedure \v
 \inferrule{
   G^\tenv.\subprograms(\name) = (\otherfuncsig, \Ignore)\\
   \subprogramtypesclash(\otherfuncsig.\subprogramtype, \subpgmtype) \typearrow \vbone\\
-  \vbtwo \eqdef \otherfuncsig.\funcqualifier \neq \vqualifier \\
+  \vbtwo \eqdef \otherfuncsig.\funcqualifierfield \neq \vqualifier \\
   \hasargclash(\formaltypes, \otherfuncsig.\funcargs) \typearrow \vbthree
 }{
   \subprogramclash(\tenv, \name, \subpgmtype, \vqualifier, \formaltypes) \typearrow \overname{\vbone \land (\vbtwo \lor \vbthree)}{\vb}
@@ -1923,7 +1923,7 @@ The function
   \addnewfunc(
     \overname{\staticenvs}{\tenv} \aslsep
     \overname{\Identifier}{\name} \aslsep
-    \overname{\Option{\qualifier}}{\vqualifier} \aslsep
+    \overname{\Option{\funcqualifier}}{\vqualifier} \aslsep
     \overname{\KleeneStar{\typedidentifier}}{\formals} \aslsep
     \overname{\subprogramtype}{\subpgmtype})
   & \aslto\\
@@ -2058,8 +2058,8 @@ and an example of a well-typed function --- \verb|flip_bits|.
   \item applying $\checkcontrolflow$ to $\tenv$, $\vf$, and $\newbody$ yields $\True$\ProseOrTypeError;
   \item $\vfp$ is $\vf$ with the subprogram body substituted with $\newbody$;
   \item \Proseeqdef{$\vsesp$}{the union of $\vsesfuncsig$ and $\vsesbody$ with every \LocalEffectTerm{} removed};
-  \item checking that the \sideeffectsetterm{} $\vsesp$ adheres to the subprogram's \purity{} qualifier $\vf.\funcqualifier$ yields $\True$\ProseOrTypeError;
-  \item the \sideeffectsetterm{} corresponding to $\vf.\funcqualifier$ (via \\
+  \item checking that the \sideeffectsetterm{} $\vsesp$ adheres to the subprogram's \purity{} qualifier $\vf.\funcqualifierfield$ yields $\True$\ProseOrTypeError;
+  \item the \sideeffectsetterm{} corresponding to $\vf.\funcqualifierfield$ (via \\
         $\sesforsubprogram$) is $\vses$.
 \end{itemize}
 
@@ -2070,8 +2070,8 @@ and an example of a well-typed function --- \verb|flip_bits|.
   \checkcontrolflow(\tenv, \vf, \newbody) \typearrow \True \OrTypeError\\\\
   \vfp \eqdef \substrecordfield(\vf, \funcbody, \newbody)\\
   \vsesp \eqdef \vsesfuncsig \cup (\vsesbody \setminus \{ \vs \;|\; \configdomain{\vs} = \LocalEffect \}) \\
-  \checksubprogrampurity(\vf.\funcqualifier, \vsesp) \typearrow \True \OrTypeError \\
-  \sesforsubprogram(\vf.\funcqualifier) \typearrow \vses
+  \checksubprogrampurity(\vf.\funcqualifierfield, \vsesp) \typearrow \True \OrTypeError \\
+  \sesforsubprogram(\vf.\funcqualifierfield) \typearrow \vses
 }{
   \annotatesubprogram(\tenv, \vf, \vsesfuncsig) \typearrow (\vfp, \vses)
 }
@@ -2188,7 +2188,7 @@ by \verb|noreturn|.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[noreturn]{
-  \vf.\funcqualifier = \some{\Noreturn}
+  \vf.\funcqualifierfield = \some{\Noreturn}
 }{
   \allowedabsconfigs(\vf) \typearrow \overname{\{\AbsAbnormal\}}{\absconfigs}
 }
@@ -2196,7 +2196,7 @@ by \verb|noreturn|.
 
 \begin{mathpar}
 \inferrule[returning\_proc]{
-  \vf.\funcqualifier \neq \some{\Noreturn} \land \vf.\funcreturntype = \None
+  \vf.\funcqualifierfield \neq \some{\Noreturn} \land \vf.\funcreturntype = \None
 }{
   \allowedabsconfigs(\vf) \typearrow \overname{\{\AbsContinuing, \AbsReturning, \AbsAbnormal\}}{\absconfigs}
 }
@@ -2204,7 +2204,7 @@ by \verb|noreturn|.
 
 \begin{mathpar}
 \inferrule[func]{
-  \vf.\funcqualifier \neq \some{\Noreturn} \land \vf.\funcreturntype \neq \None
+  \vf.\funcqualifierfield \neq \some{\Noreturn} \land \vf.\funcreturntype \neq \None
 }{
   \allowedabsconfigs(\vf) \typearrow \overname{\{\AbsReturning, \AbsAbnormal\}}{\absconfigs}
 }
@@ -2362,7 +2362,7 @@ can be added, for example, an \unreachablestatementterm.
   {
   \absconfigs \eqdef
   \begin{cases}
-    \{\AbsAbnormal\} & \text{if }\vf.\funcqualifier = \some{\Noreturn}\\
+    \{\AbsAbnormal\} & \text{if }\vf.\funcqualifierfield = \some{\Noreturn}\\
     \{\AbsContinuing, \AbsAbnormal\} & \text{else}
   \end{cases}
   }

--- a/asllib/doc/TypeDeclarations.tex
+++ b/asllib/doc/TypeDeclarations.tex
@@ -298,7 +298,7 @@ The function
   \overname{\Option{(\overname{\Identifier}{\vsuper}\times\overname{\KleeneStar{\vfield}}{\extrafields})}}{\vs}
 )
 \aslto \\
-(\overname{\staticenvs}{\newtenv} \times \overname{\ty}{\newty})
+(\overname{\staticenvs}{\newtenv} \times \overname{\ty}{\newty} \times \overname{\KleeneStar{\vfield}}{\vsp})
 \cup \overname{\typeerror}{\TypeErrorConfig}
 \end{array}
 \]

--- a/asllib/doc/TypeSystemUtilities.tex
+++ b/asllib/doc/TypeSystemUtilities.tex
@@ -418,7 +418,7 @@ is declared both as a global variable and as an enumeration label.
 \ProseParagraph
 \AllApply
 \begin{itemize}
-  \item applying $\isglobalundefined$ to $\vx$ in $\genv$ yields $\vb$;
+  \item applying $\isglobalundefined$ to $\id$ in $\genv$ yields $\vb$;
   \item checking whether $\vb$ is $\True$ yields $\True$\ProseTerminateAs{\IdentifierAlreadyDeclared}.
 \end{itemize}
 

--- a/asllib/doc/rendering_macros.tex
+++ b/asllib/doc/rendering_macros.tex
@@ -8,11 +8,20 @@
 \newcommand{\DefineConstant}[2]{%
   \expandafter\newcommand\csname RenderConstant@#1\endcsname{#2}%
 }
-\newcommand{\RenderConstant}[1]{%
-  \@ifundefined{RenderConstant@#1}{%
-    \textbf{Error: RenderConstant '#1' not defined}%
+
+% Main RenderConstant command with optional parameter
+\newcommand{\RenderConstant}[2][]{%
+  \@ifundefined{RenderConstant@#2}{%
+    \PackageError{rendering_macros}{RenderConstant '#2' is not defined! Check that you have defined constant '#2' and applied aslspec to generate \string\DefineConstant}{}%
   }{%
-    \csname RenderConstant@#1\endcsname%
+    \expandafter\let\expandafter\@current@content\csname RenderConstant@#2\endcsname%
+    \def\@renderconstant@option{#1}%
+    \def\@test@remove{remove_hypertargets}%
+    \ifx\@renderconstant@option\@test@remove%
+      \expandafter\remove@hypertargets\expandafter{\@current@content}%
+    \else%
+      \@current@content%
+    \fi%
   }%
 }
 \makeatother
@@ -44,7 +53,7 @@
 % Main RenderType command with optional parameter
 \newcommand{\RenderType}[2][]{%
   \@ifundefined{RenderType@#2}{%
-    \textbf{Error: RenderType '#2' not defined}%
+    \PackageError{rendering_macros}{RenderType '#2' is not defined! Check that you have defined type '#2' and applied aslspec to generate \string\DefineType}{}%
   }{%
     \expandafter\let\expandafter\@current@content\csname RenderType@#2\endcsname%
     \def\@rendertype@option{#1}%
@@ -67,7 +76,7 @@
 }
 \newcommand{\RenderRelation}[1]{%
   \@ifundefined{RenderRelation@#1}{%
-    \textbf{Error: RenderRelation '#1' not defined}%
+    \PackageError{rendering_macros}{RenderRelation '#1' is not defined! Check that you have defined relation '#1' and applied aslspec to generate \string\DefineRelation}{}%
   }{%
     \csname RenderRelation@#1\endcsname%
   }%
@@ -93,7 +102,7 @@
 % Main RenderTypes command with optional parameter
 \newcommand{\RenderTypes}[2][]{%
   \@ifundefined{RenderTypes@#2}{%
-    \textbf{Error: RenderTypes '#2' not defined}%
+    \PackageError{rendering_macros}{RenderTypes '#2' is not defined! Check that you have defined render '#2' and applied aslspec to generate \string\DefineRenderTypes}{}%
   }{%
     \expandafter\let\expandafter\@current@content\csname RenderTypes@#2\endcsname%
     \def\@rendertypes@option{#1}%


### PR DESCRIPTION
This PR factors out the fixes to comments and issues raised for #1477:
* Changed `empty_set` from a type into a constant.
* Defined the `TOutConfig`.
* Fixed the signature of `annotate_extra_fields`.
* Fixed a mistake in the prose paragraph for `CheckVarNotInGEnv`.
* Added an explanation to `UpdateGlobalStorage`.
* Renamed `qualifier` to `func_qualifier` in `asl.spec`
  and `\funcqualifier` to `\funcqualifierfield` to avoid the name clash.
* Defined the helper type `slice_as_pair`
* The macros in `rendering_macros.tex` now fail LaTeX compilation if a non-existent parameter is given.