### PR TITLE
[ci] Workaround a problem with js_of_ocaml by pinning to 5.4.0

### DIFF
--- a/.github/workflows/build-www.yml
+++ b/.github/workflows/build-www.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Set-up OCaml 5
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5
+          ocaml-compiler: 5.1
       - run: |
-          opam install dune menhir zarith js_of_ocaml js_of_ocaml-ppx zarith_stubs_js
+          opam install dune menhir zarith js_of_ocaml.5.4.0 js_of_ocaml-ppx zarith_stubs_js
           opam exec -- make Version.ml
           opam exec -- dune build tools/cat2html.exe
           opam exec -- make -C herd-www

--- a/.github/workflows/check-build-www.yml
+++ b/.github/workflows/check-build-www.yml
@@ -12,12 +12,6 @@ on:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        ocaml-compiler:
-          - "5.1"
-
     runs-on: ubuntu-latest
 
     steps:
@@ -34,9 +28,9 @@ jobs:
       - name: Set-up OCaml 5
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5
+          ocaml-compiler: 5.1
       - run: |
-          opam install dune menhir zarith js_of_ocaml js_of_ocaml-ppx zarith_stubs_js
+          opam install dune menhir zarith js_of_ocaml.5.4.0 js_of_ocaml-ppx zarith_stubs_js
           opam exec -- make Version.ml
           opam exec -- dune build tools/cat2html.exe
           opam exec -- make -C herd-www


### PR DESCRIPTION
When we build the herd-www interface with js_of_ocaml starting from 5.5.2 (due to
https://github.com/ocsigen/js_of_ocaml/commit/29c693ba166962725d209123bd80bd1793c7ff78) causes a stack overflow on certain browsers (for example, when using Firefox on MacOS). As a temporary, workaround pin js_of_ocaml to 5.4.0 until we get to the root cause.