### PR TITLE
[gen] Update baseline configuration that generates forbidden litmus

### DIFF
--- a/gen/libdir/forbidden.conf
+++ b/gen/libdir/forbidden.conf
@@ -45,11 +45,171 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -arch AArch64
-
 -nprocs 2
-
--size 8
-
+-size 6
+# the generated file name is in format `Armv8-ext-forbidden********.litmus`,
+# where `********` are 8 digit numbers.
 -name Armv8-ext-forbidden
+-fmt 8
+# present value in hex
+#-hexa
+# If only want to generate cycles rather than litmus tests
+#-cycleonly true
 
--relaxlist Rfe Fre Wse Hat DpAddrdR DpAddrdW DpAddrsR DpAddrsW DpDatadW DpDatasW DpCtrldW DpCtrlsW DpCtrlIsbdR [DpAddrdR, ISBd*R] [DpAddrdW, ISBd*R] DpCtrlIsbsR [DpAddrsR, ISBs*R] [DpAddrsW, ISBs*R] [DpAddrsR, ISBd*R] [DpAddrsW, ISBd*R] [DpAddrdR, ISBs*R] [DpAddrdW, ISBs*R] [DpAddrdR, Pod*W] [DpAddrdW, Pod*W] [DpAddrsR, Pos*W] [DpAddrsW, Pos*W] [DpAddrsR, Pod*W] [DpAddrsW, Pod*W] [DpAddrdR, Pos*W] [DpAddrdW, Pos*W] [DpAddrdW, Rfi] [DpDatadW, Rfi] [DpAddrsW, Rfi] [DpDatasW, Rfi] DMB.SYd** DMB.SYs** PodWRLA PosWRLA DMB.LDdR* DMB.LDsR* PodR*AP PodR*QP PosR*AP PosR*QP PodRRAA PodRRQA PosRRAA PosRRQA PodRRAQ PodRRQQ PosRRAQ PosRRQQ PodRWAL PodRWQL PosRWAL PosRWQL DMB.STdWW DMB.STsWW Pod*WPL Pos*WPL PodWWLL PosWWLL Pos*W LxSx LxSxAP LxSxPL LxSxAL [LxSx, RfiPA] [LxSx, RfiPQ] [LxSxAP, RfiPA] [LxSxAP, RfiPQ] [LxSxPL, RfiLA] [LxSxPL, RfiLQ] [LxSxAL, RfiLA] [LxSxAL, RfiLQ] Amo.Swp Amo.Cas Amo.LdAdd Amo.LdEor Amo.LdClr Amo.LdSet Amo.StAdd Amo.StEor Amo.StClr Amo.StSet Amo.SwpAP Amo.CasAP Amo.LdAddAP Amo.LdEorAP Amo.LdClrAP Amo.LdSetAP Amo.SwpPL Amo.CasPL Amo.LdAddPL Amo.LdEorPL Amo.LdClrPL Amo.LdSetPL Amo.StAddPL Amo.StEorPL Amo.StClrPL Amo.StSetPL Amo.SwpAL Amo.CasAL Amo.LdAddAL Amo.LdEorAL Amo.LdClrAL Amo.LdSetAL [Amo.Swp, RfiPA] [Amo.Cas, RfiPA] [Amo.LdAdd, RfiPA] [Amo.LdEor, RfiPA] [Amo.LdClr, RfiPA] [Amo.LdSet, RfiPA] [Amo.StAdd, RfiPA] [Amo.StEor, RfiPA] [Amo.StClr, RfiPA] [Amo.StSet, RfiPA] [Amo.Swp, RfiPQ] [Amo.Cas, RfiPQ] [Amo.LdAdd, RfiPQ] [Amo.LdEor, RfiPQ] [Amo.LdClr, RfiPQ] [Amo.LdSet, RfiPQ] [Amo.StAdd, RfiPQ] [Amo.StEor, RfiPQ] [Amo.StClr, RfiPQ] [Amo.StSet, RfiPQ] [Amo.SwpAP, RfiPA] [Amo.CasAP, RfiPA] [Amo.LdAddAP, RfiPA] [Amo.LdEorAP, RfiPA] [Amo.LdClrAP, RfiPA] [Amo.LdSetAP, RfiPA] [Amo.SwpAP, RfiPQ] [Amo.CasAP, RfiPQ] [Amo.LdAddAP, RfiPQ] [Amo.LdEorAP, RfiPQ] [Amo.LdClrAP, RfiPQ] [Amo.LdSetAP, RfiPQ] [Amo.SwpPL, RfiLA] [Amo.CasPL, RfiLA] [Amo.LdAddPL, RfiLA] [Amo.LdEorPL, RfiLA] [Amo.LdClrPL, RfiLA] [Amo.LdSetPL, RfiLA] [Amo.StAddPL, RfiLA] [Amo.StEorPL, RfiLA] [Amo.StClrPL, RfiLA] [Amo.StSetPL, RfiLA] [Amo.SwpPL, RfiLQ] [Amo.CasPL, RfiLQ] [Amo.LdAddPL, RfiLQ] [Amo.LdEorPL, RfiLQ] [Amo.LdClrPL, RfiLQ] [Amo.LdSetPL, RfiLQ] [Amo.StAddPL, RfiLQ] [Amo.StEorPL, RfiLQ] [Amo.StClrPL, RfiLQ] [Amo.StSetPL, RfiLQ] [Amo.SwpAL, RfiLA] [Amo.CasAL, RfiLA] [Amo.LdAddAL, RfiLA] [Amo.LdEorAL, RfiLA] [Amo.LdClrAL, RfiLA] [Amo.LdSetAL, RfiLA] [Amo.SwpAL, RfiLQ] [Amo.CasAL, RfiLQ] [Amo.LdAddAL, RfiLQ] [Amo.LdEorAL, RfiLQ] [Amo.LdClrAL, RfiLQ] [Amo.LdSetAL, RfiLQ] [Pod**, Amo.SwpAL] [Pod**, Amo.CasAL] [Pod**, Amo.LdAddAL] [Pod**, Amo.LdEorAL] [Pod**, Amo.LdClrAL] [Pod**, Amo.LdSetAL] [Pos**, Amo.SwpAL] [Pos**, Amo.CasAL] [Pos**, Amo.LdAddAL] [Pos**, Amo.LdEorAL] [Pos**, Amo.LdClrAL] [Pos**, Amo.LdSetAL] [Amo.SwpAL, Pod**] [Amo.CasAL, Pod**] [Amo.LdAddAL, Pod**] [Amo.LdEorAL, Pod**] [Amo.LdClrAL, Pod**] [Amo.LdSetAL, Pod**] [Amo.SwpAL, Pos**] [Amo.CasAL, Pos**] [Amo.LdAddAL, Pos**] [Amo.LdEorAL, Pos**] [Amo.LdClrAL, Pos**] [Amo.LdSetAL, Pos**] [Pod**, Amo.SwpAL, Pod**] [Pod**, Amo.CasAL, Pod**] [Pod**, Amo.LdAddAL, Pod**] [Pod**, Amo.LdEorAL, Pod**] [Pod**, Amo.LdClrAL, Pod**] [Pod**, Amo.LdSetAL, Pod**] [Pos**, Amo.SwpAL, Pos**] [Pos**, Amo.CasAL, Pos**] [Pos**, Amo.LdAddAL, Pos**] [Pos**, Amo.LdEorAL, Pos**] [Pos**, Amo.LdClrAL, Pos**] [Pos**, Amo.LdSetAL, Pos**]
+# If `-relax` is enabled, tests will be required to have a relaxation from the list specified as its argument.
+#-relax {RELAX_LIST}
+
+
+# let ca = fr | co
+# let Exp-obs =
+#   [Exp & M]; rf & ext; [Exp & M]
+#   | [Exp & M]; ca & ext; [Exp & M]
+-safe Rfe Fre Coe
+
+#let Exp-haz-ob = [Exp & R]; (po & same-loc); [Exp & R]; (ca & ext); [Exp & W]
+-safe [PosRR Fre]
+
+#let lwfs = [Exp & M | Imp & Tag & R]; (po & same-loc); [Exp & W]
+-safe Pos*W
+
+### Data and address dependance
+# let data = [Exp & R]; (basic-dep; [DATA]; iico_data+; [Exp & W]) & ~same-instance
+# let dob = data
+-safe DpDatadW DpDatasW
+
+# let addr = [Exp & R]; (basic-dep; [ADDR]; iico_data+; [Exp & M | Imp & Tag & R | Imp & TTD & R | HU | TLBI | DC.CVAU | IC.IVAU]) & ~same-instance
+# let dob = addr
+-safe DpAddrdR DpAddrdW DpAddrsR DpAddrsW
+
+# let ctrl = [Exp & R]; basic-dep; [BCC]; po
+# let dob = ctrl; [Exp & W | HU | TLBI | DC.CVAU | IC]
+# mcat2config7 aarch64.cat -let dob
+-safe DpCtrldW DpCtrlsW
+
+# let dob = addr; [Exp & M]; po; [Exp & W | HU]
+-safe [DpAddrdW PodWW] [DpAddrdW PosWW] [DpAddrsW PodWW] [DpAddrsW PosWW] [DpAddrdR PodRW] [DpAddrdR PosRW] [DpAddrsR PodRW] [DpAddrsR PosRW]
+
+# let dob = addr; [Exp & M]; lrs; [Exp & R | Imp & Tag & R]
+# let lrs = [W]; ((po & same-loc) & ~(intervening(W,(po & same-loc)))); [R]
+-safe [DpAddrdW Rfi] [DpAddrsW Rfi]
+
+# let dob = data; [Exp & M]; lrs; [Exp & R | Imp & Tag & R]
+# let lrs = [W]; ((po & same-loc) & ~(intervening(W,(po & same-loc)))); [R]
+-safe [DpDatadW Rfi] [DpDatasW Rfi]
+
+# let ctrl = [Exp & R]; basic-dep; [BCC]; po
+# let IFB-ob = [Exp & R]; ctrl; [IFB]; po
+# let IFB = ISB | EXC-ENTRY-IFB | EXC-RET-IFB
+-safe [DpCtrldR ISB] [DpCtrldW ISB] [DpCtrlsR ISB] [DpCtrlsW ISB]
+
+# let IFB-ob = [Exp & R]; pick-ctrl-dep; [IFB]; po
+# let IFB = ISB | EXC-ENTRY-IFB | EXC-RET-IFB
+-safe [DpCtrlCseldR ISB] [DpCtrlCseldW ISB] [DpCtrlCselsR ISB] [DpCtrlCselsW ISB]
+
+# let IFB-ob = [Exp & R]; addr; [Exp & M]; po; [IFB]; po
+-safe [DpAddrdR ISBd**] [DpAddrdR ISBs**] [DpAddrdW ISBd**] [DpAddrdW ISBs**] [DpAddrsR ISBd**] [DpAddrsR ISBs**] [DpAddrsW ISBd**] [DpAddrsW ISBs**]
+# let IFB-ob = [Exp & R]; pick-addr-dep; [Exp & M]; po; [IFB]; po
+-safe [DpAddrCseldR ISBd**] [DpAddrCseldR ISBs**] [DpAddrCseldW ISBd**] [DpAddrCseldW ISBs**] [DpAddrCselsR ISBd**] [DpAddrCselsR ISBs**] [DpAddrCselsW ISBd**] [DpAddrCselsW ISBs**]
+#
+# let pob = pick-addr-dep; [Exp & W | HU | TLBI | DC.CVAU | IC]
+# mcat2config7 aarch64.cat -let pob
+-safe DpAddrCseldW DpAddrCselsW
+
+# let pob = pick-data-dep
+-safe DpDataCseldW DpDataCselsW
+
+# let pob = pick-ctrl-dep; [Exp & W | HU | TLBI | DC.CVAU | IC]
+-safe DpCtrlCseldW DpCtrlCselsW
+
+# let pob = pick-addr-dep; [Exp & M]; po; [Exp & W | HU]
+-safe [DpAddrCseldR PodRW] [DpAddrCseldR PosRW] [DpAddrCseldW PodWW] [DpAddrCseldW PosWW] [DpAddrCselsR PodRW] [DpAddrCselsR PosRW] [DpAddrCselsW PodWW] [DpAddrCselsW PosWW]
+
+### Fence
+# DMB.ISH*** DMB.OSH*** in `-moreedges` in `diy7`; these two edges also satisfy `dmb.full`
+###
+# `DSB` is stronger than `DMB`
+###
+
+# let bob = [Exp & M | Imp & Tag & R]; po; [dmb.full]; po; [Exp & M | Imp & Tag & R | MMU & FAULT]
+-safe DMB.SYd** DMB.SYs**
+-safe DSB.SYd** DSB.SYs**
+
+# let bob = [Exp & (R \ NoRet) | Imp & Tag & R]; po; [dmb.ld]; po; [Exp & M | Imp & Tag & R | MMU & FAULT]
+-safe DMB.LDdR* DMB.LDsR*
+-safe DSB.LDdR* DSB.LDsR*
+
+# let bob = [Exp & W]; po; [dmb.st]; po; [Exp & W | MMU & FAULT]
+-safe DMB.STdWW DMB.STsWW
+-safe DSB.STdWW DSB.STsWW
+
+### Acquire-Release load and store
+# let bob = [L]; po; [A]
+-safe [L PodWR A] [L PosWR A]
+
+### Atomic operation
+# Amo.Swp
+# Amo.Cas
+# Amo.LdAdd Amo.LdClr Amo.LdEor Amo.LdSet Amo.LdSmax Amo.LdSmin Amo.LdUmax Amo.LdUmin
+# Amo.StAdd Amo.StClr Amo.StEor Amo.StSet
+# There is a known problem for `Amo.Ld*` and `Amo.St*` relaxations,
+# because commutative of those relaxations leads to value collision.
+# For this reason, these relaxations are not included.
+
+# let bob = [A | Q]; po; [Exp & M | Imp & Tag & R | MMU & FAULT]
+-safe [A PodR*] [A PosR*] [Q PodR*] [Q PosR*]
+# An acquire atomic operation followed by a memory access also matches above
+-safe [A Amo.Swp PodW*] [A Amo.Swp PosW*]
+-safe [A Amo.Cas PodW*] [A Amo.Cas PosW*]
+-safe [Q Amo.Swp PodW*] [Q Amo.Swp PosW*]
+-safe [Q Amo.Cas PodW*] [Q Amo.Cas PosW*]
+
+# let bob = [Exp & M | Imp & Tag & R]; po; [L]
+-safe [Pod*W L] [Pos*W L]
+# A memory access followed by a release atomic operation also matches above.
+-safe [Pod*R Amo.Swp L] [Pos*R Amo.Swp L]
+-safe [Pod*R Amo.Cas L] [Pos*R Amo.Cas L]
+
+# let aob = [Exp & M]; rmw; [Exp & M]
+-safe LxSx Amo.Swp Amo.Cas
+
+# le aob = [Exp & M]; rmw; lrs; [A | Q]
+# let lrs = [W]; ((po & same-loc) & ~(intervening(W,(po & same-loc)))); [R]
+-safe [LxSx Rfi A] [Amo.Swp Rfi A] [Amo.Cas Rfi A]
+-safe [LxSx Rfi Q] [Amo.Swp Rfi Q] [Amo.Cas Rfi Q]
+
+#let bob = [range([A];amo;[L])]; po; [Exp & M | Imp & Tag & R | MMU & FAULT]
+# This relation cannot be directly mapped to a relaxation in `diy`,
+# however, the individual `amo` relation is a suset of `rmw`, and is in `aob`,
+# which means it is ordered.
+# For this reason, here, we map
+# `[A]; amo; [range([A];amo;[L])]; po; [Exp & M | Imp & Tag & R | MMU & FAULT]`
+-safe [A Amo.Swp L PodW*] [A Amo.Swp L PosW*]
+-safe [A Amo.Cas L PodW*] [A Amo.Cas L PosW*]
+#
+# let bob = [Exp & M | Imp & Tag & R]; po; [L] for `Pos*** A Amo.* L` Note that `A` is irrelevant
+# then let [range([A];amo;[L])]; po; [Exp & M | Imp & Tag & R | MMU & FAULT] for `A Amo.* L Po***`
+# This particular edges cannot be auto generated from other safe edges.
+-safe [Pod*R A Amo.Swp L PodW*] [Pod*R A Amo.Swp L PosW*] [Pos*R A Amo.Swp L PodW*] [Pos*R A Amo.Swp L PosW*]
+-safe [Pod*R A Amo.Cas L PodW*] [Pod*R A Amo.Cas L PosW*] [Pos*R A Amo.Cas L PodW*] [Pos*R A Amo.Cas L PosW*]
+
+### Hat
+# `Hat` is an a read-read communication edge in `diy`, namely
+# the end of a thread and the beginning of antoher thread are both read events
+# and they will read the same value.
+###
+-safe [Hat Fre]
+-safe [Hat DpAddrdR] [Hat DpAddrdW]
+-safe [Hat DpDatadW]
+-safe [Hat DpCtrldW]
+-safe [Hat DMB.SYdR*]
+-safe [Hat DSB.SYdR*]
+-safe [Hat DMB.LDdR*]
+-safe [Hat DSB.LDdR*]
+-safe [Hat A PodR*] [Hat Q PodR*]
+-safe [Hat Amo.Swp] [Hat Amo.Cas]
+
+### Note for consuming the generated tests
+# When verifying all the generated tests are indeed forbidden via `herd7`,
+# `LxSx` and its variants take more time for `herd7` to simulate due to loop.
+# It recommends pass `-unroll 0` to `herd7` for better performance.
+###


### PR DESCRIPTION
Update baseline configuration that generates forbidden litmus.

- Add comment for auditing the connect between cat file and the forbidden file.
- Fix the problem on `Hat`.
- Add a missing `[A|Q Amo.* Po*W*]`.
- replace `[Pod** Amo.SwpAL]` by `[Po**R Amo.Swp L]` for example, where the latter is weaker then the former.
- Remove all `Amo.St*` and `Amo.Ld*` that causes problems due to commutative where the cycle is not correctly formed or observable.
- Add `DSB` edges too, whenever there is `DMB`.