### PR TITLE
[aslref] Only put stdlib0 if there are ASL0 files

### DIFF
--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -163,7 +163,8 @@ let parse_args () =
         " Do not use ASL's standard library. Implies `--no-primitives`." );
       ( "--no-stdlib0",
         Arg.Set no_stdlib0,
-        " Do not use the ASL0 compatibility standard library." );
+        " Do not use the ASL0 compatibility standard library. Default if there \
+         is no ASLv0 file passed as argument." );
       ( "--v0-use-chunks",
         Arg.Set v0_use_split_chunks,
         " While lexing v0 files, split the files along separator comment \
@@ -207,6 +208,14 @@ let parse_args () =
       v0_use_split_chunks = !v0_use_split_chunks;
     }
   in
+
+  let all_v1 =
+    List.for_all
+      (function
+        | (NormalV1 | PatchV1), _ -> true | (NormalV0 | PatchV0), _ -> false)
+      args.files
+  in
+  let args = { args with no_stdlib0 = args.no_stdlib0 || all_v1 } in
 
   let () =
     let ensure_exists s =

--- a/asllib/tests/explicit-parameters.t/run.t
+++ b/asllib/tests/explicit-parameters.t/run.t
@@ -54,7 +54,7 @@ Explicit parameter tests:
   File omit-output-stdlib-param.asl, line 3, characters 21 to 41:
     let x : bits(64) = Extend('1111', TRUE);
                        ^^^^^^^^^^^^^^^^^^^^
-  ASL Static error: Arity error while calling 'Extend-1':
+  ASL Static error: Arity error while calling 'Extend':
     2 parameters expected and 1 provided
   [1]
 


### PR DESCRIPTION
**NOTICE** this PR has for target #1538, not `master`.

This PR makes `--no-stdlib0` default when there are no ASLv0 files passed as argument.