### PR TITLE
[ASL][ACL2] ACL2 ASL interpreter updates in order to pass ASLRef tests

### DIFF
--- a/acl2/asl/ast.lisp
+++ b/acl2/asl/ast.lisp
@@ -638,7 +638,8 @@ by name.</p>")
   (:throwsexception ((name identifier)))
   (:callsrecursive ((name identifier)))
   (:performsassertions ())
-  (:nondeterministic ()))
+  (:nondeterministic ())
+  (:prints ()))
 
 (deflist ses :elt-type side_effect :true-listp t)
 

--- a/acl2/asl/bin/run-aslref-test.sh
+++ b/acl2/asl/bin/run-aslref-test.sh
@@ -28,8 +28,9 @@ if [[ ${#aslargs[@]} -gt 0 ]]; then
     aslfile=${aslargs[${#aslargs[@]}-1]}
     unset aslargs[${#aslargs[@]}-1]  # Remove last element from aslargs
 else
-    echo "not enough arguments"
-    exit 1;
+    # there's a test that says what happens when run without arguments, so
+    # just do aslref's behavior
+    exec aslref ${aslargs[@]} ;
 fi
 
 # echo "incompatible=$incompatible"
@@ -50,7 +51,7 @@ export PATH="$acl2asldir"/bin:$PATH
 # echo aslref ${aslargs[@]} "$aslfile --print-lisp --no-exec";
 
 # echo aslref ${aslargs[@]} "$aslfile" --print-lisp --no-exec
-aslref_out=$( ( aslref ${aslargs[@]} "$aslfile" --no-primitives --print-lisp --no-exec > "$astfile" ) 2>&1 )
+aslref_out=$( ( aslref ${aslargs[@]} "$aslfile" --print-lisp --no-exec > "$astfile" ) 2>&1 )
 status=$?
 if [[ $status != 0 ]]; then
     # echo "aslref_out (fail before exec):"

--- a/acl2/asl/interp-types.lisp
+++ b/acl2/asl/interp-types.lisp
@@ -280,3 +280,39 @@ error/throwing results."
 
 (defxdoc ev
   :short "@(csee B*) binder: see @(see patbind-ev)")
+
+
+
+(defprod expr_result
+  :short "Type of the result from evaluating an ASL expression"
+  ((val val)
+   (env env)))
+
+(def-eval_result expr_eval_result-p expr_result-p)
+
+(defprod exprlist_result
+  :short "Type of the result from evaluating a list of ASL expressions"
+  ((val vallist)
+   (env env)))
+
+(def-eval_result exprlist_eval_result-p exprlist_result-p)
+
+(deftagsum control_flow_state
+  :short "Type of result from evaluating a statement"
+  (:returning ((vals vallist)
+               (env global-env))
+   :short "Indicates that a return has been encountered")
+  (:continuing ((env env))
+   :short "Indicates that no return has been encountered and execution of the current
+function continues"))
+
+(def-eval_result stmt_eval_result-p control_flow_state-p)
+
+(defprod func_result ((vals vallist ;; val_read_from-list
+                            )
+                      (env global-env))
+  :short "Type of result from evaluating a function call: a list of return values and an
+updated global environment")
+
+(def-eval_result func_eval_result-p func_result-p)
+

--- a/acl2/asl/static-env-preserved.lisp
+++ b/acl2/asl/static-env-preserved.lisp
@@ -116,22 +116,30 @@
   :fn rethrow_implicit)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind i) :ev_throwing))
+  (and (not (equal (eval_result-kind i) :ev_throwing))
+       (implies (not (equal (eval_result-kind i) :ev_normal))
+                (equal (eval_result-kind i) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn v_to_bool)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind i) :ev_throwing))
+  (and (not (equal (eval_result-kind i) :ev_throwing))
+       (implies (not (equal (eval_result-kind i) :ev_normal))
+                (equal (eval_result-kind i) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn v_to_int)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind i) :ev_throwing))
+  (and (not (equal (eval_result-kind i) :ev_throwing))
+       (implies (not (equal (eval_result-kind i) :ev_normal))
+                (equal (eval_result-kind i) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn v_to_label)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind res) :ev_throwing))
+  (and (not (equal (eval_result-kind res) :ev_throwing))
+       (implies (not (equal (eval_result-kind res) :ev_normal))
+                (equal (eval_result-kind res) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn tick_loop_limit)
 
@@ -141,44 +149,60 @@
   :fn env-find-global)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind v) :ev_throwing))
+  (and (not (equal (eval_result-kind v) :ev_throwing))
+       (implies (not (equal (eval_result-kind v) :ev_normal))
+                (equal (eval_result-kind v) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn bitvec_fields_to_record!)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind v) :ev_throwing))
+  (and (not (equal (eval_result-kind v) :ev_throwing))
+       (implies (not (equal (eval_result-kind v) :ev_normal))
+                (equal (eval_result-kind v) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn bitvec_fields_to_record)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind err) :ev_throwing))
+  (and (not (equal (eval_result-kind err) :ev_throwing))
+       (implies (not (equal (eval_result-kind err) :ev_normal))
+                (equal (eval_result-kind err) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn check_two_ranges_non_overlapping)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind err) :ev_throwing))
+  (and (not (equal (eval_result-kind err) :ev_throwing))
+       (implies (not (equal (eval_result-kind err) :ev_normal))
+                (equal (eval_result-kind err) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn check_non_overlapping_slices-1)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind err) :ev_throwing))
+  (and (not (equal (eval_result-kind err) :ev_throwing))
+       (implies (not (equal (eval_result-kind err) :ev_normal))
+                (equal (eval_result-kind err) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn check_non_overlapping_slices)
 
 (local (in-theory (disable loghead logtail floor logior logmask lognot)))
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind res) :ev_throwing))
+  (and (not (equal (eval_result-kind res) :ev_throwing))
+       (implies (not (equal (eval_result-kind res) :ev_normal))
+                (equal (eval_result-kind res) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn check-bad-slices)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind res) :ev_throwing))
+  (and (not (equal (eval_result-kind res) :ev_throwing))
+       (implies (not (equal (eval_result-kind res) :ev_normal))
+                (equal (eval_result-kind res) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn vbv-to-int)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind res) :ev_throwing))
+  (and (not (equal (eval_result-kind res) :ev_throwing))
+       (implies (not (equal (eval_result-kind res) :ev_normal))
+                (equal (eval_result-kind res) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn write_to_bitvector)
 
@@ -198,12 +222,16 @@
 ;;   :fn env-push-stack)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind res) :ev_throwing))
+  (and (not (equal (eval_result-kind res) :ev_throwing))
+       (implies (not (equal (eval_result-kind res) :ev_normal))
+                (equal (eval_result-kind res) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn eval_binop)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind res) :ev_throwing))
+  (and (not (equal (eval_result-kind res) :ev_throwing))
+       (implies (not (equal (eval_result-kind res) :ev_normal))
+                (equal (eval_result-kind res) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn eval_unop)
 
@@ -213,27 +241,37 @@
   :fn eval_pattern_mask)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind v) :ev_throwing))
+  (and (not (equal (eval_result-kind v) :ev_throwing))
+       (implies (not (equal (eval_result-kind v) :ev_normal))
+                (equal (eval_result-kind v) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn get_field!)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind v) :ev_throwing))
+  (and (not (equal (eval_result-kind v) :ev_throwing))
+       (implies (not (equal (eval_result-kind v) :ev_normal))
+                (equal (eval_result-kind v) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn map-get_field!)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind v) :ev_throwing))
+  (and (not (equal (eval_result-kind v) :ev_throwing))
+       (implies (not (equal (eval_result-kind v) :ev_normal))
+                (equal (eval_result-kind v) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn map-get_field)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind v) :ev_throwing))
+  (and (not (equal (eval_result-kind v) :ev_throwing))
+       (implies (not (equal (eval_result-kind v) :ev_normal))
+                (equal (eval_result-kind v) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn concat_bitvectors)
 
 (defret <fn>-not-throwing
-  (not (equal (eval_result-kind v) :ev_throwing))
+  (and (not (equal (eval_result-kind v) :ev_throwing))
+       (implies (not (equal (eval_result-kind v) :ev_normal))
+                (equal (eval_result-kind v) :ev_error)))
   :hints(("Goal" :in-theory (enable <fn>)))
   :fn get_field)
 

--- a/acl2/asl/trace-interp.lisp
+++ b/acl2/asl/trace-interp.lisp
@@ -439,10 +439,11 @@ interior tracespec @('new-ts') from some matching call or statement tracespec."
 (defmacro evo_normal-*t (arg)
   `(mv (ev_normal ,arg) orac trace))
 
-(define pass-error-*t (val &optional (orac 'orac) (trace 'trace))
+(define pass-error-*t ((val eval_result-p) &optional (orac 'orac) (trace 'trace))
+  :guard (eval_result-case val :ev_error)
   :inline t
   :enabled t
-  (mv val orac trace))
+  (mv (ev_error-fix val) orac trace))
 
 (defmacro evo_error-*t (&rest args)
   `(pass-error-*t (ev_error . ,args) orac trace))
@@ -498,10 +499,13 @@ interior tracespec @('new-ts') from some matching call or statement tracespec."
        :ev_normal (b* ,(and (not (eq (car acl2::args) '&))
                            `((,(car acl2::args) evresult.res)))
                     ,acl2::rest-expr)
-       
+       :ev_throwing (mv (init-backtrace
+                       (ev_throwing-fix evresult)
+                       pos)
+                      orac trace)
        :otherwise (pass-error-*t
                    (init-backtrace
-                    (eval_result-nonnormal-fix evresult)
+                    (ev_error-fix evresult)
                     pos) orac))))
 
 (defmacro evbody-*t (body)


### PR DESCRIPTION
 - added "prints" side effect descriptor for AST compatibility
 - switched order of checking for loop counter and limit conditions
 - find the main function with the correct signature instead of using the one called "main"
 - add the AsciiStr primitive
 - run tests with primitives allowed, to allow for primitive functions that don't have stdlib defs.