### PR TITLE
[aslspec] added attribute to specify macros for short-circuit terms

### DIFF
--- a/asllib/aslspec/AST.ml
+++ b/asllib/aslspec/AST.ml
@@ -112,6 +112,10 @@ module AttributeKey = struct
             format [{var}]. *)
     | Math_Macro  (** A LaTeX macro name for the element. *)
     | Math_Layout  (** The visual layout of the element. *)
+    | Short_Circuit_Macro
+        (** A LaTeX macro name to succinctly denote any value of a type [T].
+            This is used to denote the short-circuit result of a relation
+            application yielding a value of type [T]. *)
 
   (* A total ordering on attribute keys. *)
   let compare a b =
@@ -120,6 +124,7 @@ module AttributeKey = struct
       | Prose_Application -> 1
       | Math_Macro -> 2
       | Math_Layout -> 3
+      | Short_Circuit_Macro -> 4
     in
     let a_int = key_to_int a in
     let b_int = key_to_int b in
@@ -132,6 +137,7 @@ module AttributeKey = struct
     | Prose_Application -> "prose_application"
     | Math_Macro -> "math_macro"
     | Math_Layout -> "math_layout"
+    | Short_Circuit_Macro -> "short_circuit_macro"
 end
 
 (** A value associated with an attribute key. *)
@@ -227,6 +233,7 @@ module Type : sig
   val attributes_to_list : t -> (AttributeKey.t * attribute) list
   val prose_description : t -> string
   val math_macro : t -> string option
+  val short_circuit_macro : t -> string option
 
   val math_layout : t -> layout option
   (** The layout used when rendered as a stand-alone type definition. *)
@@ -265,6 +272,11 @@ end = struct
 
   let math_macro self =
     match find_opt AttributeKey.Math_Macro self.att with
+    | Some (MathMacroAttribute s) -> Some s
+    | _ -> None
+
+  let short_circuit_macro self =
+    match find_opt AttributeKey.Short_Circuit_Macro self.att with
     | Some (MathMacroAttribute s) -> Some s
     | _ -> None
 

--- a/asllib/aslspec/SpecLexer.mll
+++ b/asllib/aslspec/SpecLexer.mll
@@ -49,6 +49,7 @@ rule token = parse
     | "relation"          { RELATION }
     | "render"            { RENDER }
     | "semantics"         { SEMANTICS }
+    | "short_circuit_macro" { SHORT_CIRCUIT_MACRO }
     | "typedef"           { TYPEDEF }
     | "typing"            { TYPING }
 

--- a/asllib/aslspec/SpecParser.mly
+++ b/asllib/aslspec/SpecParser.mly
@@ -36,6 +36,7 @@ let check_definition_name name =
 %token RENDER
 %token RELATION
 %token SEMANTICS
+%token SHORT_CIRCUIT_MACRO
 %token TYPEDEF
 %token TYPING
 
@@ -163,6 +164,7 @@ let type_attribute :=
     | template=STRING; { (Prose_Description, StringAttribute template) }
     | MATH_MACRO; EQ; macro=LATEX_MACRO; { (Math_Macro, MathMacroAttribute macro) }
     | MATH_LAYOUT; EQ; ~=math_layout; { (Math_Layout, MathLayoutAttribute math_layout) }
+    | SHORT_CIRCUIT_MACRO; EQ; macro=LATEX_MACRO; { (Short_Circuit_Macro, MathMacroAttribute macro) }
 
 let relation_attributes ==
     LBRACE; pairs=tclist0(relation_attribute); RBRACE; { pairs }

--- a/asllib/aslspec/tests.t/relations.expected
+++ b/asllib/aslspec/tests.t/relations.expected
@@ -13,6 +13,7 @@
 \newcommand\expr[0]{ \hyperlink{ast-expr}{\textsf{expr}} } % Generated from expr
 \newcommand\Number[0]{ \hyperlink{ast-Number}{\textsc{Number}} } % Generated from Number
 \newcommand\Plus[0]{ \hyperlink{ast-Plus}{\textsc{Plus}} } % Generated from Plus
+\newcommand\typeerror[0]{ \hyperlink{type-typeerror}{\textsf{type\_error}} } % Generated from type_error
 \newcommand\annotateexpr[0]{ \hyperlink{relation-annotateexpr}{\textit{annotate\_expr}} } % Generated from annotate_expr
 \newcommand\annotateplus[0]{ \hyperlink{relation-annotateplus}{\textit{annotate\_plus}} } % Generated from annotate_plus
 \newcommand\evalplus[0]{ \hyperlink{relation-evalplus}{\textit{eval\_plus}} } % Generated from eval_plus
@@ -33,11 +34,13 @@
 \expr\texthypertarget{ast-expr} \derives\ & \mathhypertarget{ast-Number}\Number\left(\overtext{\Num}{\texttt{v}}\right)\\
 |\ & \Plus\left(\overtext{\expr}{\texttt{lhs}}, \overtext{\expr}{\texttt{rhs}}\right)\mathhypertarget{ast-Plus}\end{flalign*}} % EndDefineType
 
+\DefineType{type_error}{\texthypertarget{type-typeerror}$\typeerror$} % EndDefineType
+
 \DefineRelation{annotate_expr}{
 
 The relation
 \[
-\mathhypertarget{relation-annotateexpr}\annotateexpr\left(\overtext{\expr}{\texttt{input}}\right) \;\bigtimes\; \overtext{\type}{\texttt{inferred\_type}}
+\mathhypertarget{relation-annotateexpr}\annotateexpr\left(\overtext{\expr}{\texttt{input}}\right) \;\bigtimes\; \left(\overtext{\type}{\texttt{inferred\_type}} \cup \overtext{\typeerror}{\TypeErrorConfig}\right)
 \]
 infers the type $\texttt{inferred\_type}$ for the expression
 $\texttt{input}$} % EndDefineRelation

--- a/asllib/aslspec/tests.t/relations.spec
+++ b/asllib/aslspec/tests.t/relations.spec
@@ -14,8 +14,13 @@ ast expr { "expression" } =
     { "a binary expression for {lhs} and {rhs}" }
 ;
 
+typedef type_error
+{
+    short_circuit_macro = \TypeErrorConfig,
+};
+
 // A relation associates a tuple of types (the input) with an output type.
-typing relation annotate_expr(input: expr) -> (inferred_type: type)
+typing relation annotate_expr(input: expr) -> (inferred_type: type) | type_error
 {
     "infers the type {inferred_type} for the expression {input}",
     prose_application = "annotating the expression {input} yields the type {inferred_type}",

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -938,7 +938,6 @@
 \newcommand\environof[1]{\hyperlink{def-environof}{\textfunc{environ}}({#1})} % NO_SPECIFICATION_REQUIRED
 \newcommand\withenviron[2]{{#1}(\hyperlink{def-withenviron}{\textfunc{environ}}\mapsto{#2})} % NO_SPECIFICATION_REQUIRED
 
-\newcommand\ContinuingConfig[0]{\hyperlink{def-continuingconfig}{\texttt{\#C}}}
 \newcommand\ReturningConfig[0]{\hyperlink{def-returningconfig}{\texttt{\#R}}}
 \newcommand\ThrowingConfig[0]{\hyperlink{def-throwingconfig}{\texttt{\#T}}}
 \newcommand\DynErrorConfig[0]{\hyperlink{def-errorconfig}{\texttt{\#DE}}}

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -420,8 +420,6 @@ appearing are \hyperlink{def-freshvariables}{fresh}:
       \hypertarget{def-returningconfig}{}
 \item $\ReturningConfig \triangleq \Returning((\vvs,\newg), \newenv)$
       is an early return semantic configuration.
-\hypertarget{def-continuingconfig}{}
-\item $\ContinuingConfig \triangleq \Continuing(\newg, \newenv)$.
       \hypertarget{def-divergingconfig}{}
 \item $\DivergingConfig \triangleq \Diverging$ is a diverging configuration.
 \end{itemize}

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -824,6 +824,7 @@ constant empty_tenv {
 typedef type_error
     {
         "\typingerrorterm{}",
+        short_circuit_macro = \TypeErrorConfig,
     } =
     TypeError(error_code: type_error_code)
     {
@@ -1181,6 +1182,7 @@ typedef TNormal
 typedef TThrowing
 {
     "throwing execution result",
+    short_circuit_macro = \ThrowingConfig,
 } =
     Throwing(exception_value: native_value, exception_type: ty, graph: XGraphs, environment: envs)
     { "throwing result with exception value {exception_value}, type {exception_type}, {graph}, and {environment}" }
@@ -1197,6 +1199,7 @@ typedef TContinuing
 typedef TReturning
 {
     "returning execution result",
+    short_circuit_macro = \ReturningConfig,
 } =
     Returning(values_and_graph: (list0(native_value), XGraphs), environment: envs)
     { "returning result with values and graph {values_and_graph} and {environment}" }
@@ -1205,6 +1208,7 @@ typedef TReturning
 typedef TDynError
 {
     "dynamic error result",
+    short_circuit_macro = \DynErrorConfig,
 } =
     DynamicError(error_code: dynamic_error_code)
     { "dynamic error with error code {error_code}",
@@ -1233,6 +1237,7 @@ constant Diverging
 typedef TDiverging
 {
     "diverging execution result",
+    short_circuit_macro = \DivergingConfig,
 } =
     constants_set(Diverging)
     { "diverging execution result" }


### PR DESCRIPTION
Rendering inference rules requires knowing, for each type that may be the result of a short-circuit transition, how to render a term denoting a value of that type. For succinctness, ASL Reference uses macros denoting such short-circuit terms:
- For type errors,
- For dynamic errors,
- For diverging configurations,
- For throwing configurations,
- For returning configurations.

This PR allows specifying a `short_circuit_macro` attribute top-level types (that is, not for type variants).
`asl.spec` has been updated with attributes for the configurations listed above.
The `relations.spec` test has been extended to include an example of such a macro.
The macro `\ContinuingConfig` and associated definition in `semantics.tex` is removed, since continuing configurations never appear as short-circuit terms.

In terms of rendering, the effect is to display a short-circuit macro above the type term whenever that type term is used in the signature of a function/relation, and also when it is referenced in other type definitions.
When inference rules are rendered in the future, these macros will appear on the right-hand side of transition judgmenets.