### PR TITLE
[gen] update the baseline `forbidden.conf` file with `DSB-ob`.

### DIFF
--- a/gen/libdir/forbidden.conf
+++ b/gen/libdir/forbidden.conf
@@ -125,22 +125,26 @@
 -safe [DpAddrCseldR PodRW] [DpAddrCseldR PosRW] [DpAddrCseldW PodWW] [DpAddrCseldW PosWW] [DpAddrCselsR PodRW] [DpAddrCselsR PosRW] [DpAddrCselsW PodWW] [DpAddrCselsW PosWW]
 
 ### Fence
-# DMB.ISH*** DMB.OSH*** in `-moreedges` in `diy7`; these two edges also satisfy `dmb.full`
-###
-# `DSB` is stronger than `DMB`
-###
 
 # let bob = [Exp & M | Imp & Tag & R]; po; [dmb.full]; po; [Exp & M | Imp & Tag & R | MMU & FAULT]
+# DMB.ISH*** DMB.OSH*** in `-moreedges` in `diy7`; these two edges also satisfy `dmb.full`
 -safe DMB.SYd** DMB.SYs**
--safe DSB.SYd** DSB.SYs**
 
 # let bob = [Exp & (R \ NoRet) | Imp & Tag & R]; po; [dmb.ld]; po; [Exp & M | Imp & Tag & R | MMU & FAULT]
 -safe DMB.LDdR* DMB.LDsR*
--safe DSB.LDdR* DSB.LDsR*
 
 # let bob = [Exp & W]; po; [dmb.st]; po; [Exp & W | MMU & FAULT]
 -safe DMB.STdWW DMB.STsWW
--safe DSB.STdWW DSB.STsWW
+
+# let DSB-ob = [M | DC.CVAU | IC]; po; [dsb.full]; po; [~(Imp & TTD & M | Imp & Instr & R)]
+# DSB.ISH*** DSB.OSH*** in `-moreedges` in `diy7`; these two edges also satisfy `dsb.full`
+-safe DSB.SYd** DSB.SYs**
+
+# let DSB-ob = [(Exp & R) \ NoRet | Imp & Tag & R]; po; [dsb.ld]; po; [~(Imp & TTD & M | Imp & Instr & R)]
+-safe DSB.LDdR* DSB.LDsR*
+
+# let DSB-ob = [Exp & W]; po; [dsb.st]; po; [~(Imp & TTD & M | Imp & Instr & R)]
+-safe DSB.STdW* DSB.STsW*
 
 ### Acquire-Release load and store
 # let bob = [L]; po; [A]


### PR DESCRIPTION
Fix a mistake in the `forbidden.conf` on `DSB-ob`, i.e. `DSB.STdWW DSB.STsWW` to `DSB.STdW* DSB.STsW*`, which weaken the second memory event to both read and write. We also add the correct comment for those relaxations corresponding to `DSB-ob`.