### PR TITLE
[aslspec] output variants

### DIFF
--- a/asllib/aslspec/spec.ml
+++ b/asllib/aslspec/spec.ml
@@ -5,6 +5,27 @@ open AST
 module StringMap = Map.Make (String)
 module StringSet = Set.Make (String)
 
+let raise_not_type_name_error relation_name term =
+  let msg =
+    Format.asprintf
+      "In relation '%s', output type term '%a' is not a type name or a set of \
+       constants. All relation output types, except for the first one, must be \
+       type names or a set of constants."
+      relation_name PP.pp_type_term term
+  in
+  raise (SpecError msg)
+
+let raise_missing_short_circuit_attribute relation_name term type_name =
+  let msg =
+    Format.asprintf
+      "In relation '%s', output type term '%a' references type '%s' which does \
+       not have a short-circuit macro defined. All relation output types, \
+       except for the first one, must reference types with short-circuit \
+       macros."
+      relation_name PP.pp_type_term term type_name
+  in
+  raise (SpecError msg)
+
 (** [vars_of_type_term term] returns the list of term-naming variables that
     occur at any depth inside [term]. *)
 let rec vars_of_type_term term =
@@ -352,6 +373,30 @@ module Check = struct
         ids_referenced_by_elem
     in
     List.iter (check_no_undefined_ids_in_elem id_to_defining_node) elements
+
+  let check_relations_outputs elems id_to_defining_node =
+    let relations_defs =
+      List.filter_map
+        (function Elem_Relation def -> Some def | _ -> None)
+        elems
+    in
+    let check_alternative_outputs { Relation.name; output } =
+      let alternative_outputs = ListLabels.tl output in
+      List.iter
+        (fun term ->
+          match term with
+          | Label id -> (
+              match StringMap.find id id_to_defining_node with
+              | Node_Type typedef -> (
+                  match Type.short_circuit_macro typedef with
+                  | None -> raise_missing_short_circuit_attribute name term id
+                  | Some _ -> ())
+              | _ -> raise_not_type_name_error name term)
+          | ConstantsSet _ -> ()
+          | _ -> raise_not_type_name_error name term)
+        alternative_outputs
+    in
+    List.iter check_alternative_outputs relations_defs
 
   (** A module for checking that each prose template string ([prose_description]
       and [prose_application] attributes) to ensure it does not contain a
@@ -857,6 +902,7 @@ let from_ast ast =
   let defined_ids = List.map definition_node_name definition_nodes in
   let id_to_defining_node = make_id_to_definition_node definition_nodes in
   let () = Check.check_no_undefined_ids ast id_to_defining_node in
+  let () = Check.check_relations_outputs ast id_to_defining_node in
   let () = Check.CheckTypeInstantiations.check id_to_defining_node ast in
   let () = Check.check_math_layout definition_nodes in
   let () = Check.CheckProseTemplates.check definition_nodes in

--- a/asllib/aslspec/utils.ml
+++ b/asllib/aslspec/utils.ml
@@ -17,6 +17,12 @@ let list_tl_or_empty list = match list with [] -> [] | _ :: t -> t
 *)
 let list_concat_map f l = List.concat (List.map f l)
 
+(** [list_tail list] returns the tail of [list], or raises an [Invalid_argument]
+    exception if [list] is empty. *)
+let list_tail = function
+  | [] -> raise (Invalid_argument "list_tail: empty list")
+  | _ :: t -> t
+
 (** [string_exists p s] checks if at least one character of [s] satisfies the
     predicate [p]. *)
 let string_exists p s =

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -1795,7 +1795,7 @@ typing relation annotate_catcher(tenv: static_envs, ses_in: powerset(TSideEffect
 };
 
 semantics relation eval_catchers(env: envs, catchers: list0(catcher), otherwise_opt: option(stmt), s_m: TOutConfig) ->
-  TReturning | TContinuing | TThrowing | TDynError
+  TContinuing | TReturning | TThrowing | TDynError
 {
    prose_description = "evaluates a list of \texttt{catch} clauses
                         {catchers}, an optional \texttt{otherwise} clause,
@@ -3136,16 +3136,20 @@ typing relation get_for_constraints(
   math_layout = [_,_],
 };
 
-semantics relation eval_stmt(env: envs, s: stmt) -> Returning((vs: list0(native_value), new_g: XGraphs), new_env: envs)
-    | Continuing(new_g: XGraphs, new_env: envs) | TThrowing | TDynError | TDiverging
+semantics relation eval_stmt(env: envs, s: stmt) ->
+    | Continuing(new_g: XGraphs, new_env: envs)
+    | TReturning
+    | TThrowing
+    | TDynError
+    | TDiverging
 {
    prose_description = "evaluates a statement {s} in an environment {env},
                         resulting in one of four types of configurations (see
                         more details in
                         \secref{KindsOfSemanticConfigurations}):
                         \begin{itemize}
-                        \item returning configurations with values {vs}, execution graph {new_g}, and a modified environment {new_env};
                         \item continuing configurations with an execution graph {new_g} and modified environment {new_env};
+                        \item returning configurations;
                         \item throwing configurations;
                         \item error configurations;
                         \item diverging configurations.
@@ -3179,7 +3183,7 @@ semantics relation eval_for(
   v_start: tint,
   dir: constants_set(UP,DOWN),
   v_end: tint,
-  body: stmt) -> TReturning | TContinuing | TThrowing | TDynError | TDiverging
+  body: stmt) -> TContinuing | TReturning | TThrowing | TDynError | TDiverging
 {
    prose_description = "evaluates the \texttt{for} loop with the index
                         variable {index_name}, optional limit value\\


### PR DESCRIPTION
In order to automatically add short-circuit configurations to transition judgments, we need to automatically figure those for each relation. This PR makes a design desicison for aslspec: each relation has the form `name(arguments) -> T1 | T2 ... Tn` where `T1` is allowed to be any type term, but `T2..Tn` are allowed to be either type names or sets of constants (`constants_set`), and each such type name must define the `short_circuit_term` attribute. This way, each constant in a given set of constants is used as a short-circuit configuration, and for type names we have the attribute to use.

`spec.ml` has a new check for the condition described above.
`asl.spec` requires a few minor changes to adhere to the new design.

[The ASL Reference build fine locally, but the asldoc workflow is temporarily broken.]