### PR TITLE
[asl] Fix another shadow banning bug

### DIFF
--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -2175,14 +2175,14 @@ and the identifiers used by them, appearing in comments to their right.
   \item \AllApplyCase{s\_for}
   \begin{itemize}
     \item $\vs$ is the for statement $\SFor\left\{\begin{array}{rcl}
-      \Forindexname &:& \Ignore\\
+      \Forindexname &:& \vindexname\\
       \Forstarte &:& \vstarte\\
       \fordirection &:& \vdirection\\
       \Forende &:& \vende\\
       \Forbody &:& \vbody\\
       \Forlimit &:& \vlimit
     \end{array}\right\}$;
-    \item define $\ids$ as the union of applying $\useexpr$ to $\vlimit$, $\vstarte$, and $\vende$ and applying $\usestmt$ to $\vsone$.
+    \item define $\ids$ as the union of $\vindexname$, and applying $\useexpr$ to $\vlimit$, $\vstarte$, and $\vende$ and applying $\usestmt$ to $\vsone$.
   \end{itemize}
 
   \item \AllApplyCase{while\_repeat}
@@ -2270,11 +2270,11 @@ and the identifiers used by them, appearing in comments to their right.
 
 \begin{mathpar}
 \inferrule[s\_for]{
-  \ids \eqdef \useexpr(\vlimit) \cup \useexpr(\vstarte) \cup \useexpr(\vende) \cup \usestmt(\vbody)
+  \ids \eqdef \{ \vindexname \} \cup \useexpr(\vlimit) \cup \useexpr(\vstarte) \cup \useexpr(\vende) \cup \usestmt(\vbody)
 }{
   {
   \usestmt\left(\overname{\SFor\left\{\begin{array}{rcl}
-    \Forindexname &:& \Ignore\\
+    \Forindexname &:& \vindexname\\
     \Forstarte &:& \vstarte\\
     \fordirection &:& \vdirection\\
     \Forende &:& \vende\\

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -86,6 +86,14 @@ Global ignored:
   ASL Type error: cannot declare already declared element "g".
   [1]
 
+  $ aslref shadow-banning-bug-2.asl
+  File shadow-banning-bug-2.asl, line 5, character 2 to line 7, character 6:
+    for i = 0 to 1 do
+     pass;
+    end;
+  ASL Type error: cannot declare already declared element "i".
+  [1]
+
 Constrained-type satisfaction:
   $ cat >type-sat1.asl <<EOF
   > func illegal_f1()

--- a/asllib/tests/regressions.t/shadow-banning-bug-2.asl
+++ b/asllib/tests/regressions.t/shadow-banning-bug-2.asl
@@ -1,0 +1,10 @@
+var i = 0;
+
+func main() => integer
+begin
+  for i = 0 to 1 do
+   pass;
+  end;
+  return 0;
+end;
+ 


### PR DESCRIPTION
This PR fixes another shadow banning bug: if unused, a for-loop index could not be reported even if it shadowed a global element name.

New specification rules
<img width="728" height="238" alt="Screenshot 2025-11-11 at 13 42 11" src="https://github.com/user-attachments/assets/f8f7943f-a126-4272-8f6c-f5531e3c763a" />
<img width="775" height="225" alt="Screenshot 2025-11-11 at 13 39 49" src="https://github.com/user-attachments/assets/e8f3908a-9bbc-4fb8-8199-7ca22e3bf7a7" />
