### PR TITLE
[herd] Fix port bug on STP

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1949,10 +1949,10 @@ Arguments:
                            assert (not post) ;
                            fun m1 m2 -> M.seq_mem m2 m1
                         | _ -> (>>|) in
-                      ((read_reg_ord_sz sz rs1 ii >>> fun v ->
+                      ((read_reg_data_sz sz rs1 ii >>> fun v ->
                         do_write_mem sz an aexp ac a v ii) >>|
                          (add_size a sz >>= fun a ->
-                          read_reg_ord_sz sz rs2 ii >>> fun v ->
+                          read_reg_data_sz sz rs2 ii >>> fun v ->
                           do_write_mem sz an aexp ac a v ii)))
                   sz Annot.N
                   ma (M.unitT V.zero)
@@ -1979,10 +1979,10 @@ Arguments:
             let (>>>) = M.data_input_next in
             do_str rd
               (fun ac a _ ii ->
-                (read_reg_ord_sz sz rs1 ii >>> fun v ->
+                (read_reg_data_sz sz rs1 ii >>> fun v ->
                   do_write_mem sz an aexp ac a v ii) >>|
                   (add_size a sz >>= fun a ->
-                    read_reg_ord_sz sz rs2 ii >>> fun v ->
+                    read_reg_data_sz sz rs2 ii >>> fun v ->
                       do_write_mem sz an aexp ac a v ii))
               sz Annot.N
               (get_ea_idx rd k ii)

--- a/herd/tests/instructions/AArch64/S+rel+STP-data.litmus
+++ b/herd/tests/instructions/AArch64/S+rel+STP-data.litmus
@@ -1,0 +1,14 @@
+AArch64 S+rel+STP-data
+
+{
+ int x[2]={0,0};
+ int y=0;
+ 0:X0=x; 0:X2=y;
+ 1:X0=x; 1:X2=y;
+}
+ P0           | P1             ;
+ MOV W1,#1    | LDR W1,[X2]    ;
+ STR W1,[X0]  | EOR W3,W1,W1   ;
+ STLR W1,[X2] | STP W3,W4,[X0] ;
+
+exists (1:X1=1 /\ x={1,0})

--- a/herd/tests/instructions/AArch64/S+rel+STP-data.litmus.expected
+++ b/herd/tests/instructions/AArch64/S+rel+STP-data.litmus.expected
@@ -1,0 +1,12 @@
+Test S+rel+STP-data Allowed
+States 3
+1:X1=0; x={0,0};
+1:X1=0; x={1,0};
+1:X1=1; x={0,0};
+No
+Witnesses
+Positive: 0 Negative: 3
+Condition exists (1:X1=1 /\ x={1,0})
+Observation S+rel+STP-data Never 0 3
+Hash=8fb398390820078c5399f251849fbc4c
+


### PR DESCRIPTION
Before this PR, data port on STP instructions were not correctly put. This PR
fixes this.

The test committed in `herd/tests/instructions/AArch64` is a witness of this
change. Before this PR, it was allowed:
```
$ herd7 herd/tests/instructions/AArch64/S+rel+STP-data.litmus
Test S+rel+STP-data Allowed
States 4
1:X1=0; x={0,0};
1:X1=0; x={1,0};
1:X1=1; x={0,0};
1:X1=1; x={1,0};
Ok
Witnesses
Positive: 1 Negative: 3
Condition exists (1:X1=1 /\ x={1,0})
Observation S+rel+STP-data Sometimes 1 3
Time S+rel+STP-data 0.01
Hash=8fb398390820078c5399f251849fbc4c
```

This test is now forbidden.

---

**Before**:

![S+rel+STP-2 before](https://github.com/user-attachments/assets/8f1cfdc2-5e12-499e-94b2-28601bb4b3fb)

**After** (with `-skipcheck external` to display this execution):

![S+rel+STP-2 after](https://github.com/user-attachments/assets/e6a5895c-a861-4e93-9dd6-79c90b74b5ba)

Notice the appearance of the `data` arrow on Thread 1.
