### PR TITLE
[ci][asl] Use non-latest `texlive` image for ASL reference CI

### DIFF
--- a/.github/workflows/build-asl-reference.yml
+++ b/.github/workflows/build-asl-reference.yml
@@ -19,7 +19,8 @@ concurrency:
 jobs:
   make-asldoc:
     runs-on: ubuntu-latest
-    container: texlive/texlive:latest-full
+    container: texlive/texlive:TL2024-historic
+               # `latest-full` started producing surprising errors when installing OCaml
 
     env:
       OPAMROOTISOK: 1 # Suppress warnings about running opam as root


### PR DESCRIPTION
Attempt to fix recent breakages due to a change in the `texlive` image by fixing on (hopefully) a more stable tag. In particular, we saw errors when OCaml installation was running `./configure`:
```
  # checking whether the C compiler works... no
  # configure: error: in `/__w/herdtools7/herdtools7/_opam/.opam-switch/build/ocaml-compiler.5.4.0':
  # configure: error: C compiler cannot create executables
```