### PR TITLE
[ci][asl] Use latest `texlive` image for ASL reference CI

### DIFF
--- a/.github/workflows/build-asl-reference.yml
+++ b/.github/workflows/build-asl-reference.yml
@@ -19,8 +19,7 @@ concurrency:
 jobs:
   make-asldoc:
     runs-on: ubuntu-latest
-    container: texlive/texlive:TL2024-historic
-               # `latest-full` started producing surprising errors when installing OCaml
+    container: texlive/texlive:latest-full
 
     env:
       OPAMROOTISOK: 1 # Suppress warnings about running opam as root


### PR DESCRIPTION
As suggested by @HadrienRenaud in #1565, an open PR to revert commit 330a11b714403c54e7e02b30a4933a344ef54a2d and go back to using the latest `texlive` image for CI, once it starts working again.