### PR TITLE
[gen] Update the baseline forbidden configuration file on `Pos*W`.

### DIFF
--- a/gen/libdir/forbidden.conf
+++ b/gen/libdir/forbidden.conf
@@ -94,8 +94,9 @@
 # let dob = addr; [Exp & M]; po; [Exp & W | HU]
 -safe [DpAddrdW PodWW] [DpAddrsW PodWW] [DpAddrdR PodRW] [DpAddrsR PodRW]
 # `[DpAddrsW PosWW] [DpAddrsR PosRW]` are stronger than `Pos*W` as the former are a read followed by a write to the same location.
-# `[DpAddrdW PosWW] [DpAddrdR PosRW]` can be combined by `diy`
 #-safe [DpAddrsW PosWW] [DpAddrsR PosRW]
+# `[DpAddrdW PosWW] [DpAddrdR PosRW]` can be combined by `diy`
+#-safe [DpAddrdW PosWW] [DpAddrdR PosRW]
 
 # let dob = addr; [Exp & M]; lrs; [Exp & R | Imp & Tag & R]
 # let lrs = [W]; ((po & same-loc) & ~(intervening(W,(po & same-loc)))); [R]
@@ -152,8 +153,9 @@
 # let pob = pick-addr-dep; [Exp & M]; po; [Exp & W | HU]
 -safe [DpAddrCseldR PodRW] [DpAddrCseldR PosRW] [DpAddrCseldW PodWW] [DpAddrCselsR PodRW] [DpAddrCselsW PodWW]
 # `[DpAddrCselsW PosWW] [DpAddrCselsR PosRW]` are stronger than `Pos*W` as the former are a read followed by a write to the same location.
-#`[DpAddrCseldW PosWW]` can be combined by `diy`.
 #-safe [DpAddrCselsW PosWW] [DpAddrCselsR PosRW]
+#`[DpAddrCseldW PosWW]` can be combined by `diy`.
+#-safe [DpAddrCseldW PosWW]
 
 ### Fence
 


### PR DESCRIPTION
We remove relaxation that is stronger than `Pos*W` in the baseline configuration file, which generates smaller test suites.
This removed edges includes:
- Fence on same location and end with write, e.g. `DMB.SY*W`.
- `Data`, `Addr`, and `Ctrl` dependency, with or without `Csel`, on the same location and end with write, e.g. `DpDatasW`.
- We remove some relaxations that `diy` can automatically generate.