### PR TITLE
[all] Turn labels into symbols

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -123,7 +123,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | V.Val Instruction i -> is_cmodx_restricted_instruction i
       | V.Val
            (Symbolic _|Concrete _|ConcreteVector _|ConcreteRecord _|
-            Label _|Tag _|PteVal _|AddrReg _|Frozen _)
+            Tag _|PteVal _|AddrReg _|Frozen _)
       | V.Var _ -> false
 
     let ifetch_value_sets = [("Restricted-CMODX",is_cmodx_restricted_value)]

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -3438,7 +3438,7 @@ Arguments:
 (*********************)
 
       let make_label_value proc lbl_str =
-        A.V.cstToV (Constant.Label (proc, lbl_str))
+        A.V.cstToV (Constant.mk_sym_virtual_label proc lbl_str)
 
       let read_loc_instr a ii =
         M.read_loc Port.No (mk_fetch Annot.N) a ii
@@ -3450,7 +3450,7 @@ Arguments:
       let v2tgt =
         let open Constant in
         function
-        | M.A.V.Val(Label (_, lbl)) -> Some (B.Lbl lbl)
+        | M.A.V.Val (Symbolic (Virtual {name=Symbol.Label (_, lbl); _})) -> Some (B.Lbl lbl)
         | M.A.V.Val (Concrete i) -> Some (B.Addr (M.A.V.Cst.Scalar.to_int i))
         | _ -> None
 
@@ -3628,7 +3628,7 @@ Arguments:
             >>= do_indirect_jump test [] i ii
 
         | I_ERET ->
-            let eret_to_addr v =
+           let eret_to_addr v =
               match v2tgt v with
               | Some tgt -> B.faultRetT tgt
               | _ ->

--- a/herd/ARMSem.ml
+++ b/herd/ARMSem.ml
@@ -52,9 +52,12 @@ module
     let v2tgt =
       let open Constant in
       function
-      | M.A.V.Val(Label (_, lbl)) -> Some (B.Lbl lbl)
-      | M.A.V.Val (Concrete i) -> Some (B.Addr (M.A.V.Cst.Scalar.to_int i))
-      | _ -> None
+      | M.A.V.Val (Symbolic (Virtual ({name=Symbol.Label (_,lbl); _}))) ->
+        Some (B.Lbl lbl)
+      | M.A.V.Val (Concrete i) ->
+        Some (B.Addr (M.A.V.Cst.Scalar.to_int i))
+      | _ ->
+        None
 
 
 (********************)

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -400,7 +400,7 @@ module Make (Conf : Config) = struct
 
     let binop_mod v1 v2 =
       match (v1, v2) with
-      | ( (V.Val Constant.(Symbolic _ | Label _) | V.Var _),
+      | ( (V.Val Constant.(Symbolic _) | V.Var _),
           V.Val (Constant.Concrete (ASLScalar.S_Int z)) )
         when is_valid_trailing_bits z ->
           return V.zero

--- a/herd/MIPSSem.ml
+++ b/herd/MIPSSem.ml
@@ -100,9 +100,12 @@ module
       let v2tgt =
         let open Constant in
         function
-        | M.A.V.Val(Label (_, lbl)) -> Some (B.Lbl lbl)
-        | M.A.V.Val (Concrete i) -> Some (B.Addr (M.A.V.Cst.Scalar.to_int i))
-        | _ -> None
+        | M.A.V.Val(Symbolic (Virtual ({name=Symbol.Label (_,lbl); _}))) ->
+          Some (B.Lbl lbl)
+        | M.A.V.Val (Concrete i) ->
+          Some (B.Addr (M.A.V.Cst.Scalar.to_int i))
+        | _ -> 
+          None
 
       let do_indirect_jump test bds i v =
         match  v2tgt v with

--- a/herd/X86_64Sem.ml
+++ b/herd/X86_64Sem.ml
@@ -284,9 +284,12 @@ module
       let v2tgt =
         let open Constant in
         function
-        | M.A.V.Val(Label (_, lbl)) -> Some (B.Lbl lbl)
-        | M.A.V.Val (Concrete i) -> Some (B.Addr (M.A.V.Cst.Scalar.to_int i))
-        | _ -> None
+        | M.A.V.Val (Symbolic (Virtual ({name=Symbol.Label (_,lbl); _}))) ->
+          Some (B.Lbl lbl)
+        | M.A.V.Val (Concrete i) ->
+          Some (B.Addr (M.A.V.Cst.Scalar.to_int i))
+        | _ ->
+          None
 
       let do_indirect_jump test bds i v =
         match  v2tgt v with

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -414,8 +414,10 @@ module Make(C:Config) (I:I) : S with module I = I
       let get_symbol_name loc =
         let open Constant in
         match global loc with
-        | Some (I.V.Val (Symbolic (Physical (name,_)|Virtual {name;_})))
+        | Some (I.V.Val (Symbolic (Physical (name,_))))
           -> Some name
+        | Some (I.V.Val (Symbolic (Virtual {name;_})))
+          -> Some (Symbol.pp name)
         | _ -> None
 
       let of_symbolic_data s =
@@ -486,8 +488,10 @@ module Make(C:Config) (I:I) : S with module I = I
 (* Compare id in fault and other id, at least one id must be allowed in fault *)
         let same_sym_fault sym1 sym2 = match sym1,sym2 with
 (* Both ids allowed in fault, compare *)
-          |(Virtual {name=s1;_},Virtual {name=s2;_})
-          |(System (PTE,s1),System (PTE,s2))
+          | (Virtual {name=s1;_},Virtual {name=s2;_})
+            -> Symbol.compare s1 s2 = 0
+          | (System (PTE,s1),System (PTE,s2))
+          (* | (System (TAG,s1),System (TAG,s2)) *)
            -> Misc.string_eq s1 s2
 (* One id allowed, the other on forbidden, does not match *)
           | (Virtual _,(System ((PTE|TLB|PTE2),_)|Physical _|TagAddr _))
@@ -508,11 +512,6 @@ module Make(C:Config) (I:I) : S with module I = I
         let same_id_fault v1 v2 = match v1,v2 with
           | I.V.Val (Symbolic sym1), I.V.Val (Symbolic sym2)
             -> same_sym_fault sym1 sym2
-          | I.V.Val (Constant.Label (_, l1)),I.V.Val (Constant.Label (_, l2))
-            -> Misc.string_eq l1 l2
-          | I.V.Val (Symbolic _), I.V.Val (Constant.Label (_, _))
-          | I.V.Val (Constant.Label (_, _)), I.V.Val (Symbolic _)
-            -> false
           | _,_
             ->
               Warn.fatal
@@ -762,7 +761,7 @@ module Make(C:Config) (I:I) : S with module I = I
                   let tag = None in
                   let cap = 0L in
                   let sym_data =
-                    { Constant.name=s ;
+                    { Constant.name=Constant.Symbol.Data s ;
                       tag=tag ;
                       cap=cap ;
                       offset=i*nbytes;
@@ -835,11 +834,15 @@ module Make(C:Config) (I:I) : S with module I = I
           | Location_global
               (I.V.Val
                  (Concrete _|ConcreteVector _|ConcreteRecord _
-                 |Label _|Instruction _|Frozen _
+                 |Instruction _|Frozen _
                  |Tag _|PteVal _|AddrReg _))
             ->
               Warn.user_error
                 "Very strange location (look_address) %s\n"
+                (pp_location loc)
+          | Location_global (I.V.Val (Symbolic (Virtual {name=n;_}))) when Symbol.is_label n ->
+              Warn.user_error
+                "No default value defined for location %s\n"
                 (pp_location loc)
           | Location_global (I.V.Val (Symbolic (Virtual _|Physical _)))
           | Location_reg _ -> reg_default_value
@@ -870,7 +873,7 @@ module Make(C:Config) (I:I) : S with module I = I
 
       let look_size_location env loc =
         match symbolic_data loc with
-        | Some {Constant.name=s;_} -> look_size env s
+        | Some {Constant.name=s;_} -> look_size env (Constant.Symbol.pp s)
         | _ -> assert false
 
       let build_size_env bds =
@@ -878,7 +881,7 @@ module Make(C:Config) (I:I) : S with module I = I
           (fun m (loc,(t,_)) ->
             match symbolic_data loc with
             | Some sym ->
-                StringMap.add sym.Constant.name (mem_access_size_of_t t) m
+                StringMap.add (Constant.Symbol.pp sym.Constant.name) (mem_access_size_of_t t) m
             | _ -> m)
           size_env_empty bds
 
@@ -1081,7 +1084,7 @@ module Make(C:Config) (I:I) : S with module I = I
               | Location_global
                 (I.V.Val (Symbolic (Virtual {name=s; offset=_;_})) as a)
                 ->
-                  let sz = look_size senv s in
+                  let sz = look_size senv (Constant.Symbol.pp s) in
                   let eas = byte_eas sz a in
                   let vs = List.map (get_of_val st) eas in
                   let v = recompose vs in

--- a/herd/eventsMonad.ml
+++ b/herd/eventsMonad.ml
@@ -886,7 +886,8 @@ Monad type:
         let eiid,(act,_) = g lbl eiid in
         let f (r,cs,es) =
           let cs =
-            VC.Assign (v,VC.Atom (V.Val (Constant.Label (p,lbl))))::cs in
+            let symb = Constant.mk_sym_virtual_label p lbl in
+            VC.Assign (v,VC.Atom (V.Val symb))::cs in
           r,cs,es in
         eiid,(Evt.map f act,None) in
       (* Rec *)
@@ -1403,8 +1404,9 @@ Monad type:
         | _ -> false
 
       let is_instrloc a =
+        let open Constant in
         match a with
-        | V.Val (Constant.Label _) -> true
+        | V.Val (Symbolic (Virtual {name=n; _})) -> Symbol.is_label n
         | _ -> false
 
 (*
@@ -1461,7 +1463,7 @@ Monad type:
           E.action =
             E.Act.mk_init_write
               (A.of_symbolic_data
-                 {default_symbolic_data with name=Misc.add_ctag s})
+                 {default_symbolic_data with name=Symbol.Data (Misc.add_ctag s)})
               (def_size v) v; }
 
       let debug_env env =
@@ -1505,6 +1507,7 @@ Monad type:
             | A.Location_global
               (V.Val
                  (Symbolic (Virtual {name=s; tag=None; offset=o;_}))) ->
+               let s = Symbol.pp s in
                (phy_loc s o,v)::env,
                (StringSet.add s virt,pte)
             | A.Location_global (V.Val (Symbolic (System (PTE,s)))) ->
@@ -1580,7 +1583,7 @@ Monad type:
                       if morello then
                         let eiid,em =
                           morello_init_tag
-                            s (V.op1 Op.CapaGetTag v) eiid in
+                            (Constant.Symbol.pp s) (V.op1 Op.CapaGetTag v) eiid in
                         eiid,(em::[ew])
                       else eiid,[ew] in
                     (eiid,ews@es)
@@ -1615,9 +1618,9 @@ Monad type:
                      (Symbolic
                         (Virtual
                            {name=s;offset=_;_})) as a)
-                      when not (Misc.check_atag s) ->
+                      when not (Misc.check_atag (Symbol.pp s)) ->
                     (* Suffix encoding of tag addresses, sufficient for now *)
-                    let sz = A.look_size size_env s in
+                    let sz = A.look_size size_env (Symbol.pp s) in
                     let ds = AM.explode sz v
                     and eas = AM.byte_eas sz a in
                     let eiid,ews =
@@ -1634,7 +1637,7 @@ Monad type:
                       if morello then
                         let eiid,em =
                           morello_init_tag
-                            s (V.op1 Op.CapaGetTag v)
+                            (Symbol.pp s) (V.op1 Op.CapaGetTag v)
                             eiid in
                         eiid,em::ews
                       else eiid,ews in

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -104,8 +104,6 @@ end = struct
           if kvm then Access.PTE
           else Warn.fatal "PTE %s while -variant kvm is not active"
                  (A.pp_location loc)
-    | A.Location_global (V.Val (Label(_,_)))
-      -> Access.VIR
     | A.Location_global v ->
         Warn.fatal
           "access_of_location_std on non-standard symbol '%s'"
@@ -611,7 +609,7 @@ end = struct
           | Some
               (A.V.Val
                  (ConcreteVector _|Concrete _|Symbolic _|ConcreteRecord _
-                  |Label (_, _)|Tag _|Instruction _|AddrReg _
+                  |Tag _|Instruction _|AddrReg _
                   |Frozen _))
           | None
             -> None

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -259,8 +259,11 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
             try
               match A.V.as_virtual v with
               | Some s ->
-                 let sym = Constant.mk_sym_virtual s in
-                 A.Location_global (A.V.Val sym)::locs
+                  if A.V.is_instrloc v then
+                    locs
+                  else
+                    let sym = Constant.mk_sym_virtual s in
+                    A.Location_global (A.V.Val sym)::locs
               | None -> locs
             with V.Undetermined -> locs)
           init [] in
@@ -275,7 +278,8 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
            | A.Location_global _ -> true
            | A.Location_reg _ -> false)
           (S.observed_locations test)
-      and locs_init = get_all_locs_init test.Test_herd.init_state in
+      and locs_init = get_all_locs_init test.Test_herd.init_state
+      in
       let () =
         if dbg then begin
           let pp_locs locs =
@@ -308,7 +312,8 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
         A.LocSet.fold
           (fun loc env ->
             try
-              let v = A.look_address_in_state test.Test_herd.init_state loc in
+              let v = A.look_address_in_state test.Test_herd.init_state loc
+              in
               (loc,v)::env
             with A.LocUndetermined -> assert false)
           locs [] in
@@ -428,12 +433,12 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
                   match Label.norm lbls with
                   | None -> assert false (* as lbls is non-empty *)
                   | Some lbl ->
-                      let loc =
-                        A.Location_global
-                          (A.V.cstToV (Constant.Label (proc, lbl)))
+                      let symb = Constant.mk_sym_virtual_label proc lbl in
+                      let loc = A.Location_global (A.V.cstToV symb)
                       and v = A.V.instructionToV i in
                       A.state_add env loc v)
-                init_state lbls2i in
+                init_state lbls2i
+            in
             { test with init_state; } in
 
 (*****************************************************)
@@ -493,7 +498,7 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
 
         let addr2v proc s =
           try (* Look for label to overwritable instruction *)
-            V.Val (Constant.Label (proc,norm_lbl s))
+            V.Val (Constant.mk_sym_virtual_label proc (norm_lbl s))
           with
             e -> (* No, look for data location *)
               let v =  A.V.nameToV s in
@@ -1152,7 +1157,7 @@ let match_reg_events es =
             let ws =
               let v = S.E.global_loc_of er in
               match v with
-              | None|Some (V.Val (Constant.(Symbolic _|Label _))) -> ws
+              | None|Some (V.Val (Constant.Symbolic _)) -> ws
               | Some v -> NoSymbol v::ws in
             (* Add reading from nowhere for speculated reads *)
             let ws = if is_spec es er then NoWrite::ws else ws in
@@ -1225,12 +1230,21 @@ let match_reg_events es =
       let compat_locs = compatible_locs_mem in
       if self then
         let code_store e =
-        E.is_store e &&
-        match
-          Misc.seq_opt A.global (E.location_of e)
-        with
-        | Some (V.Val (Constant.Label _)|V.Var _) -> true
-        | Some _|None -> false in
+          let open Constant in
+            E.is_mem_store e &&
+            match
+              Misc.seq_opt A.global (E.location_of e)
+            with
+            | Some (V.Var _) -> true
+            | Some (V.Val (Symbolic (Virtual {name=n;_}))) when Symbol.is_label n -> true
+            | Some _|None -> false
+        in
+        (* let code_access e =
+          match
+            Misc.seq_opt A.global (E.location_of e)
+          with
+          | Some (V.Val c) when Constant.is_label c -> true
+          | Some _|None -> false in *)
         (* Select code accesses *)
         let code_loads =
           E.EventSet.filter E.is_ifetch es.E.events
@@ -1276,9 +1290,10 @@ let match_reg_events es =
     let get_base a =
       let open Constant in
       match A.symbolic_data a with
-      | Some ({name=s;_} as sym) ->
+      | Some ({name=n;_} as sym) ->
+          let s = Symbol.pp n in
           let s = if Misc.check_ctag s then Misc.tr_ctag s else s in
-          A.of_symbolic_data {sym with name=s; offset=0;}
+          A.of_symbolic_data {sym with name=Symbol.of_string s; offset=0;}
       | _ -> raise CannotSca
 
 (* Sort same_base *)
@@ -1289,9 +1304,11 @@ let match_reg_events es =
             Misc.seq_opt A.symbolic_data loc2
       with
       | Some {name=s1;offset=i1;_},Some {name=s2;offset=i2;_}
-            when  Misc.string_eq s1 s2 ->
+            when Symbol.equal s1 s2 ->
           Misc.int_compare i1 i2
       | Some {name=s1;_},Some {name=s2;_} when morello ->
+          let s1 = Symbol.pp s1
+          and s2 = Symbol.pp s2 in
           if Misc.check_ctag s1 && Misc.string_eq (Misc.tr_ctag s1) s2 then 1
           else if Misc.check_ctag s2 && Misc.string_eq s1 (Misc.tr_ctag s2) then -1
           else if Misc.check_ctag s1 && Misc.check_ctag s2 && Misc.string_eq s1 s2 then 0
@@ -1380,6 +1397,7 @@ let match_reg_events es =
       let s,idx= match  E.global_loc_of fst with
       |  Some (V.Val (Symbolic (Virtual {name=s; offset=i;_})))
          ->
+           let s = Constant.Symbol.pp s in
            (if morello && Misc.check_ctag s then Misc.tr_ctag s else s),i
       | _ -> raise CannotSca in
       let sz = List.length sca*byte_sz in
@@ -1559,7 +1577,7 @@ let match_reg_events es =
       if kvm then
         (function
          | A.Location_global (V.Val (Symbolic (Physical (s,idx)))) ->
-             let sym = { default_symbolic_data with name=s; offset=idx; } in
+             let sym = { default_symbolic_data with name=Symbol.of_string s; offset=idx; } in
              A.of_symbolic_data sym
          | A.Location_global (V.Val (Symbolic (TagAddr (PHY,s,o)))) ->
              A.Location_global (V.Val (Symbolic (TagAddr (VIR,s,o))))
@@ -1723,7 +1741,7 @@ let match_reg_events es =
                   | A.Location_global
                     (V.Val (Symbolic (Virtual {name=s;_})) as a)
                     ->
-                      let eas = AM.byte_eas (A.look_size senv s) a in
+                      let eas = AM.byte_eas (A.look_size senv (Symbol.pp s)) a in
                       A.LocSet.of_list
                         (List.map (fun a -> A.Location_global a) eas)
                   | _ -> A.LocSet.singleton loc)
@@ -1739,7 +1757,7 @@ let match_reg_events es =
                           (Virtual ({name=s; offset=0; _} as sym))))
                         ->
                         A.LocSet.add
-                          (A.of_symbolic_data {sym with name=Misc.add_ctag s})
+                          (A.of_symbolic_data {sym with name=Symbol.map Misc.add_ctag s})
                           (A.LocSet.singleton loc)
                     | _ -> A.LocSet.singleton loc)
                 locs
@@ -1797,7 +1815,7 @@ let match_reg_events es =
             let open Constant in
             match Misc.seq_opt A.symbolic_data (E.location_of e) with
             | Some {name=s; offset=i; _} ->
-                if Misc.check_ctag s then  Misc.int_compare idx max_int (* always -1 ??? *)
+                if Misc.check_ctag (Constant.Symbol.pp s) then  Misc.int_compare idx max_int (* always -1 ??? *)
                 else  Misc.int_compare idx i
             | _ -> assert false
 
@@ -2095,8 +2113,9 @@ let match_reg_events es =
           (fun e -> E.is_mem_store e && not (E.is_mem_store_init e))
           es.E.events in
       E.EventSet.iter (fun e ->
+          let open Constant in
           match E.location_of e with
-          | Some (A.Location_global (V.Val(Constant.Label(p, lbl)))) ->
+          | Some (A.Location_global (V.Val(Symbolic (Virtual {name=Symbol.Label(p, lbl);_})))) ->
               Warn.user_error
                 "Store to %s:%s requires instruction fetch functionality.\n\
                  Please use `-variant self` as an argument to herd7 to enable it."
@@ -2109,8 +2128,10 @@ let match_reg_events es =
       let program = test.Test_herd.program
       and code_segment = test.Test_herd.code_segment in
       E.EventSet.iter (fun e ->
+        let open Constant in
         match E.location_of e with
-        | Some (A.Location_global (V.Val(Constant.Label(p, lbl))) as loc) ->
+        (* | Some (A.Location_global (V.Val(Constant.Label(p, lbl))) as loc) -> *)
+        | Some (A.Location_global (V.Val(Symbolic (Virtual {name=Symbol.Label (p,lbl);_}))) as loc) ->
           if Label.Set.mem lbl owls then begin
             if false then (* insert a proper test here *)
               Warn.user_error "Illegal store to '%s'; overwrite with the given argument not supported"

--- a/herd/memUtils.ml
+++ b/herd/memUtils.ml
@@ -538,7 +538,7 @@ let lift_proc_info i evts =
     match si with
     | {Constant.name=s; offset=idx;_}
       ->
-        let sz_s = A.look_size senv s in
+        let sz_s = A.look_size senv (Constant.Symbol.pp s) in
         let nbytes_s = MachSize.nbytes sz_s in
         if MachSize.less_than_or_equal sz_e sz_s then begin
           let ncell = idx / nbytes_s and idx0 = idx mod nbytes_s in

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -289,7 +289,7 @@ module Make(C:Config) (A:Arch_herd.S) (Act:Action.S with module A = A)
       let open Constant in
       match sym.offset with
       | 0 -> true
-      | o -> is_non_mixed_offset test sym.name o
+      | o -> is_non_mixed_offset test (Symbol.pp sym.name) o
 
     let is_non_mixed_symbol test sym =
       let open Constant in

--- a/herd/test_herd.ml
+++ b/herd/test_herd.ml
@@ -155,8 +155,10 @@ module Make(A:Arch_herd.S) =
       let prog,starts,rets = Load.load nice_prog in
       (* ensure labels in the init list are present in the body of the test*)
       List.iter (fun (_,(_,v)) ->
+        let open Constant in
         match v with
-        | A.V.Val (Constant.Label (p,s)) -> begin
+        | A.V.Val (Symbolic (Virtual {name=Symbol.Label(p,s); _}))
+          -> begin
           if not (Label.Map.mem s prog) then 
             Warn.user_error
               "Label %s not found on P%d, yet it is used in the initialization list" s p end

--- a/jingle/CArch_jingle.ml
+++ b/jingle/CArch_jingle.ml
@@ -42,7 +42,7 @@ include Arch.MakeArch(struct
         let c =
           try int_of_string c
           with Failure _ -> Warn.user_error "Int expected" in
-        add_subs [Cst(s, c)] subs
+        add_subs [Cst(Symbol.pp s, c)] subs
     | Const(Concrete s),Const(Concrete c)
       when c=s ->
        Some subs
@@ -152,9 +152,9 @@ include Arch.MakeArch(struct
     in
 
     let rec expl_expr = let open Constant in function
-      | Const(Symbolic (Virtual {name=s;_})) -> find_cst s >! fun k -> Const k
+      | Const(Symbolic (Virtual {name=s;_})) -> find_cst (Symbol.pp s) >! fun k -> Const k
       | Const
-          (Concrete _|ConcreteVector _|Label _|ConcreteRecord _
+          (Concrete _|ConcreteVector _|ConcreteRecord _
            |Tag _|Symbolic _|PteVal _|AddrReg _
            |Instruction _|Frozen _)
         as e -> unitT e

--- a/jingle/cDumper.ml
+++ b/jingle/cDumper.ml
@@ -116,7 +116,7 @@ let get_params init i =
      | (MiscParser.Location_reg(p,_),
 	(_,Symbolic (Virtual {name=s;_}))) when i = p ->
 	{ CAst.param_ty = CType.Volatile CType.word;
-	  CAst.param_name = s }::a
+	  CAst.param_name = (Symbol.pp s) }::a
      | _ -> a
     ) [] init
 

--- a/lib/ASLOp.ml
+++ b/lib/ASLOp.ml
@@ -239,30 +239,30 @@ let do_op1 op cst =
       match cst with
       | Constant.Concrete s ->
           ASLScalar.convert_to_int_signed s |> return_concrete
-      | Constant.(Symbolic _|PteVal _|Label _|Instruction _) -> Some cst
+      | Constant.(Symbolic _|PteVal _|Instruction _) -> Some cst
       | _ -> None)
   | ToAArch64 -> (
       match cst with
       | Constant.Concrete s ->
           ASLScalar.convert_to_sint64 s |> return_concrete
-      | Constant.(Symbolic _|PteVal _|Label _|Instruction _) -> Some cst
+      | Constant.(Symbolic _|PteVal _|Instruction _) -> Some cst
       | _ -> None)
   | FromAArch64 -> (
       match cst with
       | Constant.Concrete s ->
           ASLScalar.as_bv_64 s |> return_concrete
-      | Constant.(Symbolic _|PteVal _|Label _|Instruction _) -> Some cst
+      | Constant.(Symbolic _|PteVal _|Instruction _) -> Some cst
       | _ -> None)
   | ToIntU -> (
       match cst with
       | Constant.Concrete s ->
           ASLScalar.convert_to_int_unsigned s |> return_concrete
-      | Constant.(Symbolic _|PteVal _|Label _|Instruction _) -> Some cst
+      | Constant.(Symbolic _|PteVal _|Instruction _) -> Some cst
       | _ -> None)
   | ToBV sz -> (
       match cst,sz with
       | Constant.Concrete s,_ -> ASLScalar.convert_to_bv sz s |> return_concrete
-      | (Constant.(Symbolic _|PteVal _|Label _|Instruction _),64)
+      | (Constant.(Symbolic _|PteVal _|Instruction _),64)
       | (Constant.Instruction _,32) (* Instructions are 32bit wide *)
         -> Some cst
       | _ -> None)
@@ -307,7 +307,7 @@ let do_op1 op cst =
                 if is_address_mask positions then Some cst
                 else None
           end
-      | Constant.(Symbolic _|Label _ as cst) ->
+      | Constant.(Symbolic _ as cst) ->
           if is_address_mask positions || is_mask_64 positions then
             Some cst
           else begin
@@ -358,7 +358,7 @@ let mask c sz =
   let open Constant in
   match c,sz with
 (* The following are 64bits quantities, the last two being virtual addresses *)
-  | ((PteVal _|Symbolic _|Label _),Quad)
+  | ((PteVal _|Symbolic _),Quad)
 (* Non-signed 32bit quantity *)
   | (Instruction _,(Word|Quad))
     -> Some c

--- a/lib/CBase.ml
+++ b/lib/CBase.ml
@@ -260,7 +260,7 @@ include Pseudo.Make
         function
           | Const(Concrete _|ConcreteVector _) as k -> k
           | Const
-              (Symbolic _|Label _|Tag _|ConcreteRecord _
+              (Symbolic _|Tag _|ConcreteRecord _
               |PteVal _|AddrReg _ |Instruction _|Frozen _ as v) ->
              Warn.fatal "No constant '%s' allowed" (ParsedConstant.pp_v v)
           | LoadReg _ as l -> l

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -24,6 +24,43 @@ open Printf
 (*vector metadata - prim size (arg1) and total array size (arg2) *)
 (*needed for is-non-mixed-symbol and global vectors *)
 
+module Symbol = struct
+  type t = Data of string | Label of Label.Full.full
+
+  let compare n1 n2 = match n1, n2 with
+    | Data s1, Data s2 -> String.compare s1 s2
+    | Label l1, Label l2 -> Label.Full.compare l1 l2
+    | Data _, Label _ -> 1
+    | Label _, Data _ -> -1
+
+  let equal n1 n2 = match n1, n2 with
+    | Data s1, Data s2 -> String.equal s1 s2
+    | Label l1, Label l2 -> Label.Full.equal l1 l2
+    | _, _ -> false
+
+  let pp = function
+    | Data s -> s
+    | Label (p,lbl) -> sprintf "%d:%s" p lbl
+
+  let map f = function
+    | Data s -> Data (f s)
+    | Label (p,s) -> Label (p, f s)
+
+  let of_string s =
+    try
+      Scanf.sscanf s "%d:%s" (fun p lbl -> Label (p, lbl))
+    with Scanf.Scan_failure _ ->
+      Data s
+
+  let is_data = function
+    | Data _ -> true
+    | Label _ -> false
+
+  let is_label = function
+    | Data _ -> false
+    | Label _ -> true
+end
+
 type tag = string option
 type cap = Int64.t
 type offset = int
@@ -35,7 +72,7 @@ let compare_tag = Misc.opt_compare String.compare
 (* Memory cell, with optional tag, capability<128:95>,optional vector metadata, and offset *)
 type symbolic_data =
   {
-   name : string ;
+   name : Symbol.t ;
    tag : tag ;
    cap : cap ;
    offset : offset ;
@@ -44,7 +81,7 @@ type symbolic_data =
 
 let default_symbolic_data =
   {
-   name = "" ;
+   name = Symbol.Data "" ;
    tag = None ;
    cap = 0x0L ;
    offset = 0 ;
@@ -53,7 +90,10 @@ let default_symbolic_data =
 
 let capa_low c = Int64.shift_left (Int64.logand c 0x1ffffffffL)  3
 and capa_high c = Int64.shift_right_logical c 33
-let pp_symbolic_data {name=s; tag=t; cap=c; pac=p; _} = match t,c with
+
+let pp_symbolic_data {name=n; tag=t; cap=c; pac=p; _} =
+  let s = Symbol.pp n in
+  match t,c with
   | None, 0L ->
       PAC.pp p s
   | None, _ ->
@@ -64,7 +104,7 @@ let pp_symbolic_data {name=s; tag=t; cap=c; pac=p; _} = match t,c with
       sprintf "%#Lx:%s:%Li:%s" (capa_low c) s (capa_high c) t
 
 let compare_symbolic_data s1 s2 =
-  begin match String.compare s1.name s2.name with
+  begin match Symbol.compare s1.name s2.name with
   | 0 ->
       begin match compare_tag s1.tag s2.tag with
       | 0 ->
@@ -82,7 +122,7 @@ let compare_symbolic_data s1 s2 =
   end
 
 let symbolic_data_eq s1 s2 =
-  Misc.string_eq s1.name s2.name
+  Symbol.equal s1.name s2.name
   && Misc.opt_eq Misc.string_eq s1.tag s2.tag
   && Int64.equal s1.cap s2.cap
   && Misc.int_eq s1.offset s2.offset
@@ -92,7 +132,7 @@ let symbolic_data_eq s1 s2 =
  modulo a hash collision between two pac fields *)
 let symbolic_data_collision s1 s2 =
   if
-    Misc.string_eq s1.name s2.name
+    Symbol.equal s1.name s2.name
     && Misc.opt_eq Misc.string_eq s1.tag s2.tag
     && Int64.equal s1.cap s2.cap
     && Misc.int_eq s1.offset s2.offset
@@ -202,7 +242,7 @@ let symbol_eq s1 s2 = match s1,s2 with
     -> false
 
 let as_address = function
-  | Virtual {name=s; offset=0;_} -> s
+  | Virtual {name=n; offset=0;_} -> Symbol.pp n
   | sym -> Warn.fatal "symbol '%s' is not an address" (pp_symbol sym)
 
 let oa2symbol oa =
@@ -215,8 +255,9 @@ let oa2symbol oa =
      end
 
 let virt_match_phy s1 s2 = match s1,s2 with
-| Virtual {name=s1; offset=i1;_},Physical (s2,i2) ->
-    Misc.string_eq s1 s2 && Misc.int_eq i1 i2
+| Virtual {name=n1; offset=i1;_},Physical (s2,i2) ->
+    String.equal (Symbol.pp n1) s2 &&
+    Misc.int_eq i1 i2
 | TagAddr (VIR, s1, o1), TagAddr (PHY, s2, o2) ->
     Misc.string_eq s1 s2 &&
     Misc.int_eq (MachSize.granule_align o1) (MachSize.granule_align o2)
@@ -235,7 +276,6 @@ type ('scalar, 'pte, 'addrreg, 'instr) t =
   | ConcreteVector of ('scalar, 'pte, 'addrreg, 'instr) t list
   | ConcreteRecord of ('scalar, 'pte, 'addrreg, 'instr) t StringMap.t
   | Symbolic of symbol
-  | Label of Proc.t * string
   | Tag of string
   | PteVal of 'pte
   | AddrReg of 'addrreg
@@ -244,7 +284,7 @@ type ('scalar, 'pte, 'addrreg, 'instr) t =
 
 let as_scalar = function
   | Concrete c -> Some c
-  | ConcreteVector _|ConcreteRecord _|Symbolic _|Label _
+  | ConcreteVector _|ConcreteRecord _|Symbolic _
   | Tag _|PteVal _ |AddrReg _|Instruction _|Frozen _
       -> None
 
@@ -258,29 +298,25 @@ let rec compare scalar_compare pteval_compare addrreg_compare instr_compare c1 c
      StringMap.compare
        (compare scalar_compare pteval_compare addrreg_compare instr_compare) li1 li2
   | Symbolic sym1,Symbolic sym2 -> compare_symbol sym1 sym2
-  | Label (p1,s1),Label (p2,s2) ->
-      Misc.pair_compare Proc.compare String.compare (p1,s1) (p2,s2)
   | Tag t1,Tag t2 -> String.compare t1 t2
   | PteVal p1,PteVal p2 -> pteval_compare p1 p2
   | AddrReg p1, AddrReg p2 -> addrreg_compare p1 p2
   | Instruction i1,Instruction i2 -> instr_compare i1 i2
   | Frozen i1,Frozen i2 -> Int.compare i1 i2
-  | (Concrete _,(ConcreteRecord _|ConcreteVector _|Symbolic _|Label _|Tag _|PteVal _|AddrReg _|Instruction _|Frozen _))
-  | (ConcreteVector _,(ConcreteRecord _|Symbolic _|Label _|Tag _|PteVal _|AddrReg _|Instruction _|Frozen _))
-  | (ConcreteRecord _,(Symbolic _|Label _|Tag _|PteVal _|AddrReg _|Instruction _|Frozen _))
-  | (Symbolic _,(Label _|Tag _|PteVal _|AddrReg _|Instruction _|Frozen _))
-  | (Label _,(Tag _|PteVal _|AddrReg _|Instruction _|Frozen _))
+  | (Concrete _,(ConcreteRecord _|ConcreteVector _|Symbolic _|Tag _|PteVal _|AddrReg _|Instruction _|Frozen _))
+  | (ConcreteVector _,(ConcreteRecord _|Symbolic _|Tag _|PteVal _|AddrReg _|Instruction _|Frozen _))
+  | (ConcreteRecord _,(Symbolic _|Tag _|PteVal _|AddrReg _|Instruction _|Frozen _))
+  | (Symbolic _,(Tag _|PteVal _|AddrReg _|Instruction _|Frozen _))
   | (Tag _,(PteVal _|AddrReg _|Instruction _|Frozen _))
   | (PteVal _,(AddrReg _|Instruction _|Frozen _))
   | (AddrReg _, (Instruction _|Frozen _))
   | (Instruction _,Frozen _)
     -> -1
-  | (Frozen _,(Instruction _|PteVal _|AddrReg _|Tag _|Label _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
-  | (Instruction _,(PteVal _|AddrReg _|Tag _|Label _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
-  | (AddrReg _,(PteVal _|Tag _|Label _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
-  | (PteVal _,(Tag _|Label _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
-  | (Tag _,(Label _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
-  | (Label _,(Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (Frozen _,(Instruction _|PteVal _|AddrReg _|Tag _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (Instruction _,(PteVal _|AddrReg _|Tag _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (AddrReg _,(PteVal _|Tag _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (PteVal _,(Tag _|Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
+  | (Tag _,(Symbolic _|ConcreteRecord _|ConcreteVector _|Concrete _))
   | (Symbolic _,(ConcreteRecord _|ConcreteVector _|Concrete _))
   | (ConcreteRecord _,(ConcreteVector _|Concrete _))
   | (ConcreteVector _,Concrete _)
@@ -293,23 +329,20 @@ let rec eq scalar_eq pteval_eq addrreg_eq instr_eq c1 c2 = match c1,c2 with
   | ConcreteRecord li1, ConcreteRecord li2 ->
     StringMap.equal (eq scalar_eq pteval_eq addrreg_eq instr_eq) li1 li2
   | Symbolic s1, Symbolic s2 -> symbol_eq s1 s2
-  | Label (p1,s1),Label (p2,s2) ->
-      Misc.string_eq  s1 s2 && Misc.int_eq p1 p2
   | Tag t1,Tag t2 -> Misc.string_eq t1 t2
   | PteVal p1,PteVal p2 -> pteval_eq p1 p2
   | AddrReg p1,AddrReg p2 -> addrreg_eq p1 p2
   | Instruction i1,Instruction i2 -> instr_eq i1 i2
   | Frozen i1,Frozen i2 -> Misc.int_eq i1 i2
-  | (Frozen _,(Instruction _|Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Label _|Tag _|PteVal _|AddrReg _))
-  | (Instruction _,(Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Label _|Tag _|PteVal _|AddrReg _|Frozen _))
-  | (AddrReg _,(Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Label _|Tag _|PteVal _|Instruction _|Frozen _))
-  | (PteVal _,(Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Label _|Tag _|AddrReg _|Instruction _|Frozen _))
-  | (ConcreteRecord _,(ConcreteVector _|Symbolic _|Label _|Tag _|Concrete _|PteVal _|AddrReg _|Instruction _|Frozen _))
-  | (ConcreteVector _,(ConcreteRecord _|Symbolic _|Label _|Tag _|Concrete _|PteVal _|AddrReg _|Instruction _|Frozen _))
-  | (Concrete _,(Symbolic _|Label _|Tag _|ConcreteRecord _|ConcreteVector _|PteVal _|AddrReg _|Instruction _|Frozen _))
-  | (Symbolic _,(Concrete _|Label _|Tag _|ConcreteRecord _|ConcreteVector _|PteVal _|AddrReg _|Instruction _|Frozen _))
-  | (Label _,(Concrete _|Symbolic _|Tag _|ConcreteRecord _|ConcreteVector _|PteVal _|AddrReg _|Instruction _|Frozen _))
-  | (Tag _,(Concrete _|Symbolic _|Label _|ConcreteRecord _|ConcreteVector _|PteVal _|AddrReg _|Instruction _|Frozen _))
+  | (Frozen _,(Instruction _|Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Tag _|PteVal _|AddrReg _))
+  | (Instruction _,(Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Tag _|PteVal _|AddrReg _|Frozen _))
+  | (AddrReg _,(Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Tag _|PteVal _|Instruction _|Frozen _))
+  | (PteVal _,(Symbolic _|Concrete _|ConcreteRecord _|ConcreteVector _|Tag _|AddrReg _|Instruction _|Frozen _))
+  | (ConcreteRecord _,(ConcreteVector _|Symbolic _|Tag _|Concrete _|PteVal _|AddrReg _|Instruction _|Frozen _))
+  | (ConcreteVector _,(ConcreteRecord _|Symbolic _|Tag _|Concrete _|PteVal _|AddrReg _|Instruction _|Frozen _))
+  | (Concrete _,(Symbolic _|Tag _|ConcreteRecord _|ConcreteVector _|PteVal _|AddrReg _|Instruction _|Frozen _))
+  | (Symbolic _,(Concrete _|Tag _|ConcreteRecord _|ConcreteVector _|PteVal _|AddrReg _|Instruction _|Frozen _))
+  | (Tag _,(Concrete _|Symbolic _|ConcreteRecord _|ConcreteVector _|PteVal _|AddrReg _|Instruction _|Frozen _))
     -> false
 
 (* Return if two constants are syntactically different and can be semantically
@@ -338,8 +371,8 @@ let collision s1 s2 = match s1,s2 with
         vs;
       Buffer.add_char b '}';
       Buffer.contents b
+  | Symbolic (Virtual {name=Symbol.Label(p,lbl);_}) -> pp_label p lbl
   | Symbolic sym -> pp_symbol sym
-  | Label (p, lbl) -> pp_label p lbl
   | Tag s -> sprintf ":%s" s
   | PteVal p -> pp_pteval p
   | AddrReg sr -> pp_addrreg sr
@@ -365,7 +398,6 @@ let _debug = function
   | ConcreteRecord vs ->
       "ConcreteRecord (" ^ (StringMap.pp_str (fun key _v -> key) vs) ^ ")"
   | Symbolic sym -> sprintf "Symbol %s" (pp_symbol sym)
-  | Label (p, s) -> sprintf "Label (%s,%s)" (Proc.pp p) s
   | Tag s -> sprintf "Tag %s" s
   | PteVal _ -> "PteVal"
   | AddrReg _ -> "AddrReg"
@@ -376,11 +408,12 @@ let rec map_scalar f = function
   | Concrete s -> Concrete (f s)
   | ConcreteVector cs -> ConcreteVector (List.map (map_scalar f) cs)
   | ConcreteRecord cs -> ConcreteRecord (StringMap.map (map_scalar f) cs)
-  | (Symbolic _ | Label _ | Tag _ | PteVal _ | AddrReg _ | Instruction _ | Frozen _) as c ->
+  | (Symbolic _ | Tag _ | PteVal _ | AddrReg _ | Instruction _ | Frozen _) as c ->
       c
 
 let rec map_label f = function
-  | Label (p, lbl) -> Label (p, f lbl)
+  | Symbolic (Virtual ({name=Symbol.Label (p,lbl); _} as symb)) ->
+    Symbolic (Virtual ({symb with name=Symbol.Label (p,f lbl);}))
   | ConcreteVector cs -> ConcreteVector (List.map (map_label f) cs)
   | ConcreteRecord cs -> ConcreteRecord (StringMap.map (map_label f) cs)
   | (Symbolic _ | Concrete _ | Tag _ | PteVal _ | AddrReg _ | Instruction _ | Frozen _) as m
@@ -388,7 +421,7 @@ let rec map_label f = function
       m
 
 let rec map f_scalar f_pteval f_addrreg f_instr = function
-  | (Symbolic _ | Label _ | Tag _ | Frozen _) as m -> m
+  | (Symbolic _ | Tag _ | Frozen _) as m -> m
   | PteVal p -> PteVal (f_pteval p)
   | AddrReg sr -> AddrReg (f_addrreg sr)
   | Instruction i -> Instruction (f_instr i)
@@ -398,7 +431,11 @@ let rec map f_scalar f_pteval f_addrreg f_instr = function
   | ConcreteRecord cs ->
       ConcreteRecord (StringMap.map (map f_scalar f_pteval f_addrreg f_instr) cs)
 
-let do_mk_virtual s = Virtual { default_symbolic_data with name=s; }
+let do_mk_virtual_label_with_offset p s o =
+  Virtual { default_symbolic_data with name=Symbol.Label (p,s); offset=o }
+
+let do_mk_virtual s =
+  Virtual { default_symbolic_data with name=Symbol.of_string s; }
 
 let do_mk_sym sym = match Misc.tr_pte sym with
 | Some s -> System (PTE,s)
@@ -408,6 +445,8 @@ let do_mk_sym sym = match Misc.tr_pte sym with
     | Some s -> Physical (s,0)
     | None -> do_mk_virtual sym
 
+let mk_sym_virtual_label p lbl = Symbolic (do_mk_virtual_label_with_offset p lbl 0)
+let mk_sym_virtual_label_with_offset p lbl o = Symbolic (do_mk_virtual_label_with_offset p lbl o)
 let mk_sym_virtual s = Symbolic (do_mk_virtual s)
 let mk_sym s = Symbolic (do_mk_sym s)
 
@@ -415,7 +454,7 @@ let mk_sym_with_index s i =
   Symbolic
     (Virtual
       {default_symbolic_data
-      with name=s; offset=i})
+      with name=Symbol.Data s; offset=i})
 
 let as_virtual s =
   if Misc.is_pte s || Misc.is_physical s || Misc.is_atag s then
@@ -456,18 +495,25 @@ let mk_replicate sz v = ConcreteVector (Misc.replicate sz v)
 
 let is_symbol = function
   | Symbolic _ -> true
-  | Concrete _ | ConcreteVector _ | ConcreteRecord _ | Label _ | Tag _
+  | Concrete _ | ConcreteVector _ | ConcreteRecord _ | Tag _
   | PteVal _ | AddrReg _ | Instruction _ | Frozen _ ->
       false
 
+let is_data = function
+  | Symbolic (Virtual ({name=n; _})) ->
+    Symbol.is_data n
+  | Concrete _| ConcreteVector _| ConcreteRecord _| Symbolic _| Tag _|
+    PteVal _| AddrReg _| Instruction _| Frozen _ ->
+    false
+
 let is_label = function
-  | Label _ -> true
+  | Symbolic (Virtual ({name=n; _})) -> Symbol.is_label n
   | Concrete _ | ConcreteVector _ | ConcreteRecord _ | Symbolic _ | Tag _
   | PteVal _ | AddrReg _ | Instruction _ | Frozen _ ->
       false
 
 let as_label = function
-  | Label (p, lbl) -> Some (p, lbl)
+  | Symbolic (Virtual ({name=Symbol.Label (p,lbl); _})) -> Some (p,lbl)
   | Concrete _ | ConcreteVector _ | ConcreteRecord _ | Symbolic _ | Tag _
   | PteVal _ | AddrReg _ | Instruction _ | Frozen _ ->
       None
@@ -481,9 +527,12 @@ let is_non_mixed_symbol = function
 
 let default_tag = Tag "green"
 
+let mk_sym_tag s t =
+  Symbolic (Virtual {default_symbolic_data with name=Symbol.Data s; tag=Some t;})
+
 let check_sym v =
   match v with
-  | (Symbolic _ | Label _ | Tag _) as sym -> sym
+  | (Symbolic _ | Tag _) as sym -> sym
   | Concrete _ | ConcreteVector _ | ConcreteRecord _ | PteVal _ | AddrReg _ | Instruction _
   | Frozen _ ->
       assert false
@@ -493,7 +542,7 @@ let is_virtual v = match v with
 | _ -> false
 
 let as_virtual v = match v with
-| Symbolic (Virtual {name=s;_}) -> Some s
+| Symbolic (Virtual {name=symb;_}) -> Some (Symbol.pp symb)
 | _ -> None
 
 let as_symbol = function
@@ -501,7 +550,7 @@ let as_symbol = function
   | _ -> None
 
 let as_fault_base = function
-  | Symbolic (Virtual {name;_}) -> Some name
+  | Symbolic (Virtual {name;_}) -> Some (Symbol.pp name)
   | Symbolic (System (PTE,name)) -> Some (Misc.add_pte name)
   | _ -> None
 
@@ -522,6 +571,22 @@ let is_pt v = match v with
 let make_canonical = function
   | Symbolic (Virtual v) -> Symbolic (Virtual {v with pac=PAC.canonical})
   | cst -> cst
+  
+let mk_sym_morello p s t =
+  let p_int = Misc.string_as_int64 p in
+  if
+    not (Int64.equal (Int64.logand p_int 0x7L) 0L)
+    || Int64.compare p_int (Int64.shift_left 1L 36) >= 0
+    || Int64.compare p_int 0L < 0
+  then Printf.eprintf "Warning: incorrect address encoding: %#Lx\n" p_int ;
+  let truncated_perms = Int64.shift_right_logical p_int 3 in
+  let tag = if Misc.string_as_int t <> 0 then 1L else 0L in
+  Symbolic
+    (Virtual
+       {default_symbolic_data
+       with
+         name=Symbol.Data s;
+         cap=Int64.logor truncated_perms (Int64.shift_left tag 33); })
 
 module type S =  sig
 

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -16,6 +16,18 @@
 
 (** Constants, both symbolic (ie addresses) and concrete (eg integers)  *)
 
+module Symbol : sig
+  type t = Data of string | Label of Label.Full.full
+
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+  val pp : t -> string
+  val map : (string -> string) -> t -> t
+  val of_string : string -> t
+  val is_data : t -> bool
+  val is_label : t -> bool
+end
+
 type tag = string option
 type cap = Int64.t
 type offset = int
@@ -25,7 +37,7 @@ type offset = int
 (* Memory cell, with optional tag, capability<128:95>,optional vector metadata, and offset *)
 type symbolic_data =
   {
-   name : string ;
+   name : Symbol.t ;
    tag : tag ;
    cap : cap ;
    offset : offset ;
@@ -88,7 +100,6 @@ type ('scalar, 'pte, 'addrreg, 'instr) t =
   | ConcreteRecord of ('scalar, 'pte, 'addrreg, 'instr) t StringMap.t
       (** A record of constants, e.g. [{ addr: x; instr: NOP; index: 3 }] *)
   | Symbolic of symbol  (** A symbolic constant, e.g. [x] *)
-  | Label of Proc.t * string  (** A label in code. *)
   | Tag of string
   | PteVal of 'pte  (** A page table entry. *)
   | AddrReg of 'addrreg (** A register with fields *)
@@ -138,9 +149,11 @@ val map_label : (Label.t -> Label.t) -> ('s,'pte, 'addrreg,'instr) t -> ('s,'pte
 val map :
   ('a -> 'b) -> ('c -> 'd) -> ('e -> 'f) -> ('g -> 'h) -> ('a,'c,'e,'g) t -> ('b,'d,'f,'h) t
 
+val mk_sym_virtual_label : Proc.t -> Label.t -> ('scalar,'pte,'addrreg,'instr) t
+val mk_sym_virtual_label_with_offset : Proc.t -> Label.t -> offset -> ('scalar,'pte,'addrreg,'instr) t
 val mk_sym_virtual : string -> ('scalar,'pte,'addrreg,'instr) t
 val mk_sym : string -> ('scalar,'pte,'addrreg,'instr) t
-val mk_sym_with_index : string -> int -> ('scalar, 'pte,'addrreg, 'instr) t
+val mk_sym_with_index : string -> int -> ('scalar,'pte,'addrreg,'instr) t
 val mk_sym_pte : string -> ('scalar,'pte,'addrreg,'instr) t
 val mk_sym_pte2 : string -> ('scalar,'pte,'addrreg,'instr) t
 val mk_sym_pa : string -> ('scalar,'pte,'addrreg,'instr) t
@@ -150,6 +163,7 @@ val mk_vec : int -> ('scalar,'pte, 'addrreg,'instr) t list -> ('scalar,'pte,'add
 val mk_replicate : int -> ('scalar,'pte, 'addrreg,'instr) t -> ('scalar,'pte,'addrreg,'instr) t
 
 val is_symbol : ('scalar,'pte,'addrreg,'instr) t -> bool
+val is_data : ('scalar,'pte,'addrreg,'instr) t -> bool
 val is_label : ('scalar,'pte,'addrreg,'instr) t -> bool
 (* Extract label, if any *)
 val as_label :  ('scalar,'pte,'addrreg,'instr)  t -> Label.Full.full option
@@ -157,6 +171,7 @@ val as_label :  ('scalar,'pte,'addrreg,'instr)  t -> Label.Full.full option
 val is_non_mixed_symbol : symbol -> bool
 
 val default_tag : ('scalar,'pte,'addrreg,'instr) t
+val mk_sym_tag : string -> string -> ('scalar,'pte,'addrreg,'instr) t
 
 (* Check  non-concrete constant (and change type!) *)
 val check_sym : ('a,'pte,'addrreg,'instr) t -> ('b,'pte,'addrreg,'instr) t
@@ -174,6 +189,7 @@ val is_pt : ('scalar,'pte,'addrreg,'instr)  t -> bool
 (* Remove the Pac field of a virtual address *)
 val make_canonical : ('scalar,'pte,'addrreg,'instr) t -> ('scalar,'pte,'addrreg,'instr) t
 
+val mk_sym_morello : string -> string -> string -> ('scalar,'pte,'addrreg,'instr) t
 module type S =  sig
 
   module Scalar : Scalar.S

--- a/lib/stateParser.mly
+++ b/lib/stateParser.mly
@@ -21,9 +21,6 @@ open LocationsItem
 open MiscParser
 open ConstrGen
 
-let mk_sym_tag s t =
-  Symbolic (Virtual {default_symbolic_data with name=s;tag=Some t;})
-
 let do_mk_sym_tagloc s o =
   if
     o < 0 ||
@@ -39,29 +36,7 @@ let mk_sym_tagloc s o =
 
 let mk_sym_tagloc_zero s = do_mk_sym_tagloc s 0
 
-let mk_sym_morello p s t =
-  let p_int = Misc.string_as_int64 p in
-  if
-    not (Int64.equal (Int64.logand p_int 0x7L) 0L)
-    || Int64.compare p_int (Int64.shift_left 1L 36) >= 0
-    || Int64.compare p_int 0L < 0
-    then Printf.eprintf "Warning: incorrect address encoding: %#Lx\n" p_int ;
-  let truncated_perms = Int64.shift_right_logical p_int 3 in
-  let tag = if Misc.string_as_int t <> 0 then 1L else 0L in
-  Symbolic
-    (Virtual
-       {default_symbolic_data
-       with
-       name=s;
-       cap=Int64.logor truncated_perms (Int64.shift_left tag 33); })
-
-let mk_sym_with_index s i =
-  Symbolic
-    (Virtual
-       {default_symbolic_data
-       with name=s; offset=Misc.string_as_int i})
-
-let mk_lab (p, l) = Label (p, l)
+let mk_lab (p,s) = mk_sym_virtual_label p s
 %}
 
 %token EOF
@@ -128,12 +103,12 @@ location_global:
 | TOK_PTE LPAR NAME RPAR { Constant.mk_sym_pte  $3 }
 | TOK_PTE LPAR TOK_PTE LPAR NAME RPAR RPAR { Constant.mk_sym_pte2 $5 }
 | TOK_PA LPAR NAME RPAR { Constant.mk_sym_pa $3 }
-| NAME COLON NAME { mk_sym_tag $1 $3 }
+| NAME COLON NAME { Constant.mk_sym_tag $1 $3 }
 | TOK_TAG LPAR id=NAME RPAR { mk_sym_tagloc_zero id }
 | TOK_TAG LPAR id=NAME PLUS o=NUM RPAR { mk_sym_tagloc id o }
 (* TODO: have MTE and Morello tags be usable at the same time? *)
-| NUM COLON NAME COLON NUM {mk_sym_morello $1 $3 $5}
-| NAME COLON NUM { mk_sym_morello "0" $1 $3 }
+| NUM COLON NAME COLON NUM { Constant.mk_sym_morello $1 $3 $5}
+| NAME COLON NUM { Constant.mk_sym_morello "0" $1 $3 }
 
 name_or_num:
 | NAME { $1 }
@@ -184,11 +159,11 @@ maybev_notag:
 */
 (* TODO: restrict to something like "NUM COLON BOOL"? *)
 | NUM COLON NUM { Concrete ($1 ^ ":" ^ $3) }
-| NAME LBRK NUM RBRK { mk_sym_with_index $1 $3 }
+| NAME LBRK NUM RBRK { Constant.mk_sym_with_index $1 (Misc.string_as_int $3) }
 
 maybev_amper:
 | AMPER NAME { Constant.mk_sym $2 }
-| AMPER NAME LBRK NUM RBRK { mk_sym_with_index $2 $4 }
+| AMPER NAME LBRK NUM RBRK { Constant.mk_sym_with_index $2 (Misc.string_as_int $4)}
 
 maybev:
 | maybev_notag { $1 }

--- a/lib/symbConstant.ml
+++ b/lib/symbConstant.ml
@@ -40,7 +40,7 @@ module Make
   and is_zero = function
     | Concrete sc -> Scalar.is_zero sc
     | ConcreteVector _|ConcreteRecord _|Symbolic _
-    | Label (_, _)|Tag _|PteVal _|AddrReg _|Instruction _|Frozen _
+    | Tag _|PteVal _|AddrReg _|Instruction _|Frozen _
       -> false
   and one = Concrete Scalar.one
   and cst_true = Concrete Scalar.s_true
@@ -76,7 +76,7 @@ module Make
 (* For building code symbols. *)
   let vToName = function
     | Symbolic s-> Constant.as_address s
-    | Concrete _|ConcreteVector _|ConcreteRecord _| Label _|Tag _
+    | Concrete _|ConcreteVector _|ConcreteRecord _|Tag _
     | PteVal _|AddrReg _|Instruction _|Frozen _
         -> assert false
 
@@ -87,7 +87,6 @@ module Make
     | Symbolic (TagAddr _) -> Access.TAG
     | Symbolic (System ((PTE|PTE2),_)) -> Access.PTE
     | Symbolic (System (TLB,_)) -> Access.TLB
-    | Label _ -> Access.VIR
     | Tag _
     | ConcreteVector _|Concrete _|ConcreteRecord _
     | PteVal _|AddrReg _|Instruction _|Frozen _ as v

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -162,7 +162,7 @@ module
   let bit_at k = function
     | Val (Concrete v) -> Val (Concrete (Cst.Scalar.bit_at k v))
     | Val
-        (ConcreteVector _|ConcreteRecord _|Symbolic _|Label _|
+        (ConcreteVector _|ConcreteRecord _|Symbolic _|
          Tag _|PteVal _|AddrReg _|Instruction _|Frozen _ as x)
       ->
         Warn.user_error "Illegal operation on %s" (Cst.pp_v x)
@@ -174,7 +174,7 @@ module
   match v1 with
     | Val (Concrete i1) ->
         Val (Concrete (op i1))
-    | Val (ConcreteVector _|ConcreteRecord _|Symbolic _|Label _|Tag _|PteVal _|AddrReg _|Frozen _ as x) ->
+    | Val (ConcreteVector _|ConcreteRecord _|Symbolic _|Tag _|PteVal _|AddrReg _|Frozen _ as x) ->
         Warn.user_error "Illegal operation %s on %s"
           (pp_unop op_op) (Cst.pp_v x)
     | Val (Instruction _ as x) ->
@@ -298,9 +298,9 @@ module
     | (Val (Symbolic (Physical (s,i2))),Val (Concrete i1)) ->
         let i1 = Cst.Scalar.to_int i1 in
         Val (Symbolic (Physical (s,i1+i2)))
-    | (Val (Symbolic _|Label _) as v,Val cst)
+    | (Val (Symbolic _) as v,Val cst)
         when Cst.is_zero cst -> v
-    | (Val cst,(Val (Symbolic _|Label _) as v))
+    | (Val cst,(Val (Symbolic _) as v))
         when Cst.is_zero cst -> v
     | _,_ -> (* General case *)
         binop Op.Add Cst.Scalar.add v1 v2
@@ -309,7 +309,6 @@ module
     match v1,v2 with
     | (Val (Tag _),Val (Tag _))
     | (Val (Symbolic _),Val (Symbolic _))
-    | (Val (Label _),Val (Label _))
     | (Val (PteVal _),Val (PteVal _))
     | (Val (AddrReg _),Val (AddrReg _))
     | (Val (Instruction _),Val (Instruction _)) ->
@@ -339,7 +338,7 @@ module
     Val (Symbolic (Virtual {s with offset=i+k}))
   | Val (Symbolic (Physical (s,i))) -> Val (Symbolic (Physical (s,i+k)))
   | Val (ConcreteVector _|ConcreteRecord _
-       | Symbolic ((TagAddr _|System _))|Label _
+       | Symbolic ((TagAddr _|System _))
        |Tag _|PteVal _|AddrReg _|Instruction _|Frozen _ as c) ->
       Warn.user_error "Illegal addition on constants %s +%d" (Cst.pp_v c) k
   | Var _ -> raise Undetermined
@@ -376,7 +375,6 @@ module
     | (Val (Symbolic _ as c1),Val (Symbolic _ as c2))
     | (Val (PteVal _ as c1),Val (PteVal _ as c2))
     | (Val (Instruction _ as c1),Val (Instruction _ as c2))
-    | (Val (Label _ as c1),Val (Label _ as c2))
     | (Val (Tag _ as c1),Val (Tag _ as c2))
       when Cst.eq c1 c2
       -> zero
@@ -384,7 +382,7 @@ module
 
   and maskop op sz v = match v,sz with
   | Val (Tag _),_ -> v (* tags are small enough for any mask be idempotent *)
-  | Val (PteVal _|AddrReg _|Instruction _|Symbolic _|Label _ as c),_ ->
+  | Val (PteVal _|AddrReg _|Instruction _|Symbolic _ as c),_ ->
      begin
        match ArchOp.mask c sz with
        | Some c -> Val c
@@ -397,7 +395,7 @@ module
   and shift_right_logical v1 v2 = match v1,v2 with
     | Val (Symbolic (Virtual {name=s;_})),Val (Concrete c) ->
        begin
-         match ArchOp.shift_address_right s c with
+         match ArchOp.shift_address_right (Symbol.pp s) c with
          | Some c -> Val c
          | None ->
             Warn.user_error
@@ -455,11 +453,11 @@ module
 
   let eq v1 v2 = match v1,v2 with
   | Var i1,Var i2 when Misc.int_eq i1 i2 -> v_true
-  | Val (Symbolic _|Label _|Tag _|PteVal _|ConcreteVector _|Instruction _ as s1),Val (Symbolic _|Label _|Tag _|PteVal _|ConcreteVector _|Instruction _ as s2) ->
+  | Val (Symbolic _|Tag _|PteVal _|ConcreteVector _|Instruction _ as s1),Val (Symbolic _|Tag _|PteVal _|ConcreteVector _|Instruction _ as s2) ->
       Cst.eq s1 s2 |> bool_to_v
 (* Assume concrete and others always to differ *)
-  | (Val (Symbolic _|Label _|Tag _|ConcreteVector _|PteVal _|Instruction _), Val (Concrete _))
-  | (Val (Concrete _), Val (Symbolic _|Label _|Tag _|ConcreteVector _|PteVal _|Instruction _)) -> v_false
+  | (Val (Symbolic _|Tag _|ConcreteVector _|PteVal _|Instruction _), Val (Concrete _))
+  | (Val (Concrete _), Val (Symbolic _|Tag _|ConcreteVector _|PteVal _|Instruction _)) -> v_false
   | _,_ ->
       binop
         Op.Eq
@@ -511,7 +509,7 @@ module
   let op_tagged op_op op v = match v with
   |  Val (Symbolic (Virtual ({offset=o;_} as a))) -> Val (op a o)
   |  Val (Symbolic (Physical _|TagAddr _|System _)
-          |Concrete _|Label _
+          |Concrete _
           |Tag _|ConcreteRecord _|ConcreteVector _
           |PteVal _|AddrReg _|Instruction _
           |Frozen _)
@@ -520,32 +518,33 @@ module
 
   (*  Returns the location of the tag associated to a location *)
   let op_tagloc f {name=a;_} _ =
-    Symbolic (Virtual {default_symbolic_data with name=f a})
+    Symbolic (Virtual {default_symbolic_data with name=Symbol.map f a;})
   let capatagloc = op_tagged "capatagloc" (op_tagloc Misc.add_ctag)
 
   let tagloc v =  match v with
     | Val (Symbolic (Virtual {name=a;offset=o;_}))
       ->
-       Val (Symbolic (TagAddr (VIR,a,MachSize.granule_align o)))
+       Val (Symbolic (TagAddr (VIR,Symbol.pp a,MachSize.granule_align o)))
+
     | Val (Symbolic (Physical (a,o)))
       ->
        Val (Symbolic (TagAddr (PHY,a,MachSize.granule_align o)))
     | Val
         (Concrete _|ConcreteRecord _|ConcreteVector _
          |Symbolic ((TagAddr _|System _))
-         |Label _|Tag _|PteVal _|AddrReg _
+         |Tag _|PteVal _|AddrReg _
          |Instruction _|Frozen _)
       ->
        Warn.user_error "Illegal tagloc on %s" (pp_v v)
   | Var _ -> raise Undetermined
 
   let check_ctag = function
-    | Val (Symbolic (Virtual {name=s;_})) -> Misc.check_ctag s
+    | Val (Symbolic (Virtual {name=s;_})) -> Misc.check_ctag (Symbol.pp s)
     | Val (Symbolic (Physical _|System _|TagAddr _)) -> false
     | Var _
     | Val
         (Concrete _|ConcreteRecord _|ConcreteVector _
-        |Label _|Tag _
+        |Tag _
         |PteVal _|AddrReg _|Instruction _
         |Frozen _)
       ->
@@ -566,7 +565,7 @@ module
   |  Val (Symbolic (Virtual s)) -> Val (op s)
   |  Val
        (Concrete _|ConcreteRecord _|ConcreteVector _
-       |Label _|Tag _
+       |Tag _
        |Symbolic _|PteVal _|AddrReg _
        |Instruction _|Frozen _)
      ->
@@ -574,11 +573,11 @@ module
   | Var _ -> raise Undetermined
 
   let pteloc v = match v with
-  | Val (Symbolic (Virtual {name=a;_})) -> Val (Symbolic (System (PTE,a)))
+  | Val (Symbolic (Virtual {name=a;_})) -> Val (Symbolic (System (PTE, Symbol.pp a)))
   | Val (Symbolic (System (PTE,a))) -> Val (Symbolic (System (PTE2,a)))
   | Val
       (Concrete _|ConcreteRecord _|ConcreteVector _
-      |Label _|Tag _
+      |Tag _
       |Symbolic _|PteVal _|AddrReg _
       |Instruction _|Frozen _)
     ->
@@ -597,13 +596,13 @@ module
       end
   | Val
       (Concrete _|ConcreteRecord _|ConcreteVector _
-      |Label _|Tag _
+      |Tag _
       |PteVal _|AddrReg _|Instruction _
       |Frozen _) ->
       illegal_offset v
   | Var _ -> raise Undetermined
 
-  let op_tlbloc {name=a;_} = Symbolic (System (TLB,a))
+  let op_tlbloc {name=a;_} = Symbolic (System (TLB, Symbol.pp a))
   let tlbloc = op_pte_tlb "tlbloc" op_tlbloc
 
   let is_virtual v = match v with
@@ -628,7 +627,7 @@ module
 
   let check_symbolic_v =
     function
-    | Val (Constant.(Symbolic _|Label _)) -> v_true
+    | Val (Constant.Symbolic _) -> v_true
     | Val cst ->
        Warn.user_error
          "Non symbolic address: [%s]"
@@ -1004,7 +1003,7 @@ module
   | Val (Concrete x) -> if scalar_to_bool x then v2 else v3
   | Val
       (ConcreteVector _|ConcreteRecord _|Symbolic _
-      |Label _|Tag _
+      |Tag _
       |PteVal _|AddrReg _|Instruction _
       | Frozen _ as s) ->
       Warn.user_error "illegal if on symbolic constant %s" (Cst.pp_v s)

--- a/litmus/AArch64Arch_litmus.ml
+++ b/litmus/AArch64Arch_litmus.ml
@@ -158,11 +158,13 @@ module Make(O:Arch_litmus.Config)(V:Constant.S) = struct
 
     let fun_name i = sprintf "get%s" (instr_name i)
 
-    let dump_instr dump = function
-      | Constant.Instruction i -> instr_name i
-      | Constant.Label (p, l) ->
-          SkelUtil.instr_symb_id (OutUtils.fmt_lbl_var p l)
-      | v -> dump v
+    let dump_instr dump v =
+      let open Constant in
+      match v with
+      | Instruction i -> instr_name i
+      | Symbolic (Virtual {name=Symbol.Label(p,l);_})
+          -> SkelUtil.instr_symb_id (OutUtils.fmt_lbl_var p l)
+      | _ -> dump v
 
     module Make(O:Indent.S) = struct
 

--- a/litmus/CArch_litmus.ml
+++ b/litmus/CArch_litmus.ml
@@ -37,8 +37,8 @@ module Make(O:sig val memory : Memory.t val hexa : bool val mode : Mode.t end) =
     let open Constant in
     function
       | Concrete i -> "addr_" ^ V.Scalar.pp O.hexa i
-      | Symbolic (Virtual {name=s; tag=None; cap=0L;_ })-> s
-      | Label _|Symbolic _|Tag _|ConcreteVector _|ConcreteRecord _
+      | Symbolic (Virtual {name=Symbol.Data s; tag=None; cap=0L;_ })-> s
+      | Symbolic _|Tag _|ConcreteVector _|ConcreteRecord _
       | PteVal _|AddrReg _|Instruction _|Frozen _
         -> assert false
 

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -329,16 +329,16 @@ module Make
       let open Constant in
       match v with
       | Concrete i -> A.V.Scalar.pp Cfg.hexa i
-       | ConcreteVector vs->
+      | ConcreteVector vs->
           let pp_vs = List.map dump_a_v vs in
           sprintf "{%s}" (String.concat "," pp_vs) (* list initializer syntax *)
-      | Symbolic (Virtual {name=s;tag=None;cap=0L;offset=0;_})-> dump_a_addr s
       | ConcreteRecord _ ->
           Warn.user_error "No record value for klitmus"
-      | Label _ ->
+      | Symbolic _ as v when is_label v ->
           Warn.user_error "No label value for klitmus"
+      | Symbolic (Virtual {name=s;tag=None;cap=0L;offset=0;_}) -> dump_a_addr (Constant.Symbol.pp s)
       | Symbolic _|Tag _| PteVal _| AddrReg _ ->
-          Warn.user_error "No tag, indexed access, pteval nor addrreg for klitmus"
+          Warn.user_error "No tag, indexed access, nor pteval for klitmus"
       | Instruction _ ->
           Warn.fatal "FIXME: dump_a_v functionality for -variant self"
       | Frozen _ -> assert false

--- a/litmus/LISALang.ml
+++ b/litmus/LISALang.ml
@@ -90,9 +90,9 @@ module Make(V:Constant.S) = struct
   let compile_val_fun v =
     let open Constant in
     match v with
+    | Symbolic _ when Constant.is_label v -> Warn.user_error "No label value in LISA"
     | Symbolic sym -> sprintf "%s" (Constant.as_address sym)
     | Concrete _|ConcreteVector _ -> Tmpl.dump_v v
-    | Label _ -> Warn.user_error "No label value in LISA"
     | Tag _ -> Warn.user_error "No tag in LISA"
     | PteVal _ -> Warn.user_error "No pteval in LISA"
     | AddrReg _ -> Warn.user_error "No parel1 in LISA"

--- a/litmus/archExtra_litmus.ml
+++ b/litmus/archExtra_litmus.ml
@@ -116,9 +116,9 @@ module Make(O:Config)(I:I) : S with module I = I
   let tr_global (c:ParsedConstant.v) =
     let open Constant in
     match c with
-    | Symbolic sym -> Global_litmus.tr_symbol sym
-    | Tag _|Concrete _|ConcreteVector _|ConcreteRecord _
-    | Label _|PteVal _|AddrReg _|Instruction _
+    | Symbolic sym when not (is_label c) -> Global_litmus.tr_symbol sym
+    | Symbolic _| Tag _| Concrete _| ConcreteVector _| ConcreteRecord _
+    | PteVal _| AddrReg _| Instruction _
     | Frozen _
       ->
        Warn.fatal "Constant %s cannot be translated to a litmus adress"

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -61,8 +61,8 @@ module Generic
       let typeof = function
         | Constant.Concrete _ -> base
         | Constant.ConcreteVector vs -> base_array (List.length vs)
+        | Constant.Symbolic _ as symb when Constant.is_label symb -> code_pointer
         | Constant.Symbolic _ -> pointer
-        | Constant.Label _ -> code_pointer
         | Constant.Tag _ -> tag
         | Constant.PteVal _ -> pteval_t
         | Constant.AddrReg _ -> parel1_t
@@ -210,7 +210,7 @@ module Generic
         List.fold_left
           (fun env (loc,(t,v)) -> match loc,v with
           | _,Constant.Concrete _ -> env
-          | A.Location_global _,Symbolic s ->
+          | A.Location_global _,Symbolic s when (Constant.is_data v) ->
               let a = A.Location_global (G.tr_symbol s) in
               begin try
                 ignore (A.LocMap.find a env) ;
@@ -378,7 +378,7 @@ module A.FaultType = A.FaultType)
       List.fold_left
         (fun k (_,v) ->
           match v with
-          | Constant.Label (_,lbl) ->
+          | Symbolic (Virtual {Constant.name=Symbol.Label (_,lbl); _}) ->
               Label.Set.add lbl k
           |Concrete _|ConcreteVector _|ConcreteRecord _
           |Symbolic _|Tag _|PteVal _|AddrReg _
@@ -777,7 +777,7 @@ module A.FaultType = A.FaultType)
           (fun (_,(t,v)) env ->
             match t,v with
             | (TestType.TyDef|TestType.TyDefPointer),
-              Constant.Symbolic s ->
+              Constant.Symbolic s when (Constant.is_data v) ->
                 let a = G.get_base_symbol s in
                 begin try
                   let _ = G.Map.find a env in

--- a/litmus/constr.ml
+++ b/litmus/constr.ml
@@ -104,8 +104,10 @@ module RLocSet = A.RLocSet and module FaultType = A.FaultType =
       match a with
       | LV (_,v) ->
             let rec f v k = match v with
-            | Symbolic (Virtual {name=s;offset=0;tag=None;_}) -> Strings.add s k
-            | Concrete _|PteVal _|AddrReg _|Instruction _|Label _ -> k
+            | Symbolic (Virtual {name=s;offset=0;tag=None;_}) -> Strings.add (Symbol.pp s) k
+            | Concrete _|PteVal _|AddrReg _|Instruction _ -> k
+            | Symbolic (Virtual {name=s;_}) when Symbol.is_label s
+              -> k
             | ConcreteVector vs ->
                 List.fold_right f vs k
             | ConcreteRecord vs ->
@@ -147,7 +149,8 @@ module RLocSet = A.RLocSet and module FaultType = A.FaultType =
 
     let get_labels c =
       let fold_atom a k = match a with
-        | LV (_,Constant.Label (p, l)) -> Label.Full.Set.add (p, l) k
+        | LV (_,Symbolic (Virtual {name=Symbol.Label(p,l);_}))
+            -> Label.Full.Set.add (p, l) k
         | LV _ | LL _ | FF _ -> k in
       ConstrGen.fold_constr fold_atom c Label.Full.Set.empty
 

--- a/litmus/global_litmus.ml
+++ b/litmus/global_litmus.ml
@@ -46,7 +46,7 @@ let as_addr = function
 let tr_symbol =
   let open Constant in
   function
-    | Virtual {name=s; tag=None; cap=0L; offset=0; _} -> Addr s
+    | Virtual {name=Symbol.Data s; tag=None; cap=0L; offset=0; _} -> Addr s
     | Physical (s,0) -> Phy s
     | System (PTE,s) -> Pte s
     | c ->  Warn.fatal "litmus cannot handle symbol '%s'" (pp_symbol c)
@@ -54,7 +54,7 @@ let tr_symbol =
 let get_base_symbol =
  let open Constant in
   function
-    | Virtual {name=s; tag=None; cap=0L; _ } -> Addr s
+    | Virtual {name=Symbol.Data s; tag=None; cap=0L; _ } -> Addr s
     | Physical (s,_) -> Phy s
     | System (PTE,s) -> Pte s
     | c ->  Warn.fatal "litmus cannot get base of symbol '%s'" (pp_symbol c)

--- a/litmus/outUtils.ml
+++ b/litmus/outUtils.ml
@@ -66,14 +66,13 @@ module Make(O:Config)(V:Constant.S) = struct
 
   let dump_v_std v = match v with
   | Concrete _ -> V.pp O.hexa v
-  | Symbolic (Virtual {name=a;tag=None;cap=0L;offset=o; _})
+  | Symbolic (Virtual {name=Symbol.Data a;tag=None;cap=0L;offset=o; _})
     -> full_dump_addr a o
   | ConcreteVector _ -> V.pp O.hexa v
   | Instruction _ -> Misc.lowercase (V.pp false v)
   | ConcreteRecord _
   | Tag _
   | Symbolic _
-  | Label _
   | PteVal _
   | AddrReg _
   | Frozen _

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1573,8 +1573,8 @@ module Make
           | Symbolic (Virtual a) when not (PAC.is_canonical a.pac) ->
             Warn.user_error "Litmus cannot initialize a virtual address with a non-canonical PAC field"
           | Symbolic (Virtual {name=s; tag=None; offset=0; _}) ->
-            sprintf "(%s)_vars->%s" (CType.dump at) s
-          | Label (p,lbl) ->
+            sprintf "(%s)_vars->%s" (CType.dump at) (Symbol.pp s)
+          | Symbolic (Virtual {name=Constant.Symbol.Label(p,lbl);_}) ->
             sprintf "_vars->labels.%s" (OutUtils.fmt_lbl_var p lbl)
           | Tag _|Symbolic _ ->
             Warn.user_error "Litmus cannot handle this initial value %s"

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -368,7 +368,7 @@ module Make
 (* Right value, all cases *)
       let rec dump_a_v = function
         | Concrete i ->  A.V.Scalar.pp  Cfg.hexa i
-        | Symbolic (Virtual {name=s;tag=None; offset=0;_}) ->
+        | Symbolic (Virtual {name=Symbol.Data s;tag=None; offset=0;_}) ->
             dump_a_addr s
         | ConcreteVector vs ->
            let pps =
@@ -376,13 +376,13 @@ module Make
                (fun v -> sprintf "%s," (dump_a_v v))
                vs in
            sprintf "{%s}" (String.concat "" pps)
-        | Symbolic _|Tag _|PteVal _|AddrReg _|Frozen _|ConcreteRecord _ -> assert false
-        | Label (p,lab) ->
+        | Symbolic (Virtual {name=Symbol.Label(p,lab);_}) ->
           if do_self then
             sprintf "&_a->code%i[_i*_a->code%i_sz+_a->prelude%i+%s]" p p p (OutUtils.fmt_lbl_offset p lab)
           else
             sprintf "_a->%s" (OutUtils.fmt_lbl_var p lab)
         | Instruction i -> A.GetInstr.instr_name i
+        | Symbolic _|Tag _|PteVal _|AddrReg _|Frozen _|ConcreteRecord _ -> assert false
 
 (* Dump left & right values when context is available *)
 
@@ -779,7 +779,7 @@ module Make
                         (fun (loc,v) k ->
                           match loc,v with
                           | A.Location_reg(p,_),
-                            Symbolic (Virtual {name=s;_}) when s = a ->
+                            Symbolic (Virtual {name=Symbol.Data s;_}) when s = a ->
                               let cpy = A.Out.addr_cpy_name a p in
                               O.fi "%s* *%s ;" (CType.dump t) cpy ;
                               (cpy,a)::k
@@ -812,7 +812,7 @@ module Make
                 if Cfg.cautious then
                   List.iter
                     (fun (loc,v) -> match loc,v with
-                    | A.Location_reg(p,_),Symbolic (Virtual {name=s;_})
+                    | A.Location_reg(p,_),Symbolic (Virtual {name=Symbol.Data s;_})
                           when Misc.string_eq s a ->
                         let cpy = A.Out.addr_cpy_name a p in
                         O.f "static %s* %s[SIZE_OF_ALLOC];"

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -583,7 +583,7 @@ end
         try
           T.find_offset_out p lbl test
         with Not_found ->
-          let v = Constant.Label (p,lbl) in
+          let v = Constant.mk_sym_virtual_label p lbl in
           Warn.user_error "Non-existant label %s" (A.V.pp_v v)
 
 (* Instructions *)

--- a/litmus/switch.ml
+++ b/litmus/switch.ml
@@ -137,7 +137,7 @@ module Make (O:Indent.S) (I:CompCondUtils.I) :
     | Concrete i ->
         let vs = try M.find loc m with Not_found -> ScalarSet.empty in
         M.add loc (ScalarSet.add i vs) m
-    |ConcreteVector _|Symbolic _|Label _|Tag _|ConcreteRecord _
+    |ConcreteVector _|Symbolic _|Tag _|ConcreteRecord _
     |PteVal _|AddrReg _|Instruction _|Frozen _
      -> raise Cannot
 

--- a/litmus/template.ml
+++ b/litmus/template.ml
@@ -202,6 +202,7 @@ module Make(O:Config)(A:I) =
              (List.fold_left
                 (fun k (_,v) ->
                   let rec f v k = match v with
+                  | Symbolic _ when is_label v -> k
                   | Symbolic sym ->
                       begin match tr sym with
                       | Some s -> s::k
@@ -211,7 +212,7 @@ module Make(O:Config)(A:I) =
                       List.fold_right f vs k
                   | ConcreteRecord vs ->
                     StringMap.fold_values f vs k
-                  |Concrete _|Label _|Tag _
+                  |Concrete _|Tag _
                   |PteVal _|AddrReg _|Instruction _|Frozen _
                    -> k in
                   f v k)
@@ -221,7 +222,7 @@ module Make(O:Config)(A:I) =
     let get_addrs_only {init; addrs; _} =
       get_gen
         (function
-          | Virtual {Constant.name=s;_} -> Some s
+          | Virtual {Constant.name=Symbol.Data s;_} -> Some s
           | _ -> None)
         init addrs
 
@@ -262,7 +263,7 @@ module Make(O:Config)(A:I) =
     let get_labels t =
       let lbls = get_constants
         (function
-         | Label (p,s) -> Some (p,s)
+         | Symbolic (Virtual {Constant.name=Symbol.Label (p,s); _}) -> Some (p,s)
          | _ -> None)
         t in
       list_unique lbls

--- a/litmus/test_litmus.ml
+++ b/litmus/test_litmus.ml
@@ -200,7 +200,7 @@ struct
     List.fold_left
       (fun k (_,v) ->
         match v with
-        | Label (p,lbl) -> Label.Full.Set.add (p,lbl) k
+        | Symbolic (Virtual {name=Symbol.Label (p,lbl); _}) -> Label.Full.Set.add (p,lbl) k
         | _ -> k)
       Label.Full.Set.empty
 

--- a/tools/logConstr.ml
+++ b/tools/logConstr.ml
@@ -32,7 +32,7 @@ let rec tr_v v =
   | Concrete i -> Concrete (Int64.of_string i)
   | ConcreteVector vs -> ConcreteVector (List.map tr_v vs)
   | ConcreteRecord vs -> ConcreteRecord (StringMap.map tr_v vs)
-  | Symbolic _|Label _|Tag _
+  | Symbolic _|Tag _
   | PteVal _|AddrReg _|Instruction _|Frozen _
     as w -> w
 


### PR DESCRIPTION
This PR is a preparation for several strands of work, #1507 and #1518, which depend on treatment of labels as symbols rather than strings. With this PR, they would be treated more like virtual addresses, referred to as symbols like "x".

The use of labels in the syntax of litmus tests remains the same. No user-facing changes to the semantics of any feature of the tools are intended with this PR.