### PR TITLE
[ASL-888] Fix a implementation/documentation mismatch for ATCs

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -843,7 +843,11 @@ module Make (B : Backend.S) (C : Config) = struct
             (i + 1, m)
           in
           List.fold_left fold (0, m_true) tys |> snd
-      | _ -> fatal_from loc env TypeInferenceNeeded
+      | _ ->
+          (* In all other cases, type-checking should already have confirmed
+             that the ATC succeeds. This case should only arise when
+             non-bits/integer types are nested within tuple types. *)
+          m_true
     in
     choice ~pos:loc env (in_values v ty) true false >>= fun (_, res) ->
     return res

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -2621,7 +2621,7 @@ of the type \verb|integer{4, 5, 6}| fails.
 \FormallyParagraph
 \begin{mathpar}
 \inferrule[type\_equal]{
-  \astlabel(\vt) \not\in \{\TInt, \TBits\}
+  \astlabel(\vt) \not\in \{\TInt, \TBits, \TTuple \}
 }{
   \isvaloftype(\env, \vv, \vt) \evalarrow (\overname{\True}{\vb}, \overname{\emptygraph}{\vg})
 }

--- a/asllib/tests/regressions.t/atc-tuple.asl
+++ b/asllib/tests/regressions.t/atc-tuple.asl
@@ -1,0 +1,13 @@
+type Named of enumeration { Named_X, Named_Y };
+
+func Foo() => (Named, integer)
+begin
+  return (ARBITRARY : Named, 0);
+end;
+
+func main () => integer
+begin
+  var x : integer{0..31};
+  (-, x) = Foo() as (Named, integer{0..31});
+  return 0;
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -488,6 +488,7 @@ Required tests:
   $ aslref asciistr.asl
   $ aslref asl1-calls-asl0-accessor.asl -0 asl0-accessor.asl
   $ aslref --no-exec accessor-overloading-1.asl
+  $ aslref atc-tuple.asl
   $ aslref accessor-overloading-2.asl
   nullary setter
   unary getter


### PR DESCRIPTION
For the semantics of ATCs, if a type is not an integer/bits/tuple then the dynamic check should pass (as it has already been checked during type-checking). Also fix a typo in the reference, and add a test.