### PR TITLE
[aslspec] allow defining operators

### DIFF
--- a/asllib/aslspec/LayoutUtils.ml
+++ b/asllib/aslspec/LayoutUtils.ml
@@ -32,8 +32,15 @@ let rec contains_vertical = function
 let apply_layout_to_list layout elements =
   let args_layout =
     match layout with
+    | (Horizontal [ _ ] | Vertical [ _ ]) when List.length elements > 1 ->
+        unspecified_for_elements elements
     | Horizontal l | Vertical l -> l
     | Unspecified -> unspecified_for_elements elements
   in
-  assert (List.compare_lengths elements args_layout = 0);
+  if List.compare_lengths elements args_layout <> 0 then
+    failwith
+      (Format.asprintf
+         "LayoutUtils.apply_layout_to_list: number of layouts (%d) does not \
+          match number of elements (%d) for layout %a"
+         (List.length args_layout) (List.length elements) PP.pp_layout layout);
   List.combine elements args_layout

--- a/asllib/aslspec/SpecLexer.mll
+++ b/asllib/aslspec/SpecLexer.mll
@@ -31,19 +31,26 @@ rule token = parse
                                }
 
     (* Keywords *)
+    | "associative"         { ASSOCIATIVE }
     | "ast"                 { AST }
     | "case"                { CASE }
     | "constant"            { CONSTANT }
     | "constants_set"       { CONSTANTS_SET }
+    | "custom"              { CUSTOM }
     | "function"            { FUNCTION }
+    | "if"                  { IF }
+    | "in"                  { IN }
     | "INDEX"               { INDEX }
+    | "else"                { ELSE }
     | "latex"               { LATEX }
     | "lhs_hypertargets"    { LHS_HYPERTARGETS }
     | "list0"               { LIST0 }
     | "list1"               { LIST1 }
     | "math_macro"          { MATH_MACRO }
     | "math_layout"         { MATH_LAYOUT }
+    | "not_in"              { NOT_IN }
     | "option"              { OPTION }
+    | "operator"            { OPERATOR }
     | "fun"                 { FUN }
     | "partial"             { PARTIAL }
     | "powerset"            { POWERSET }
@@ -55,15 +62,9 @@ rule token = parse
     | "rule"                { RULE }
     | "semantics"           { SEMANTICS }
     | "short_circuit_macro" { SHORT_CIRCUIT_MACRO }
+    | "then"                { THEN }
     | "typedef"             { TYPEDEF }
     | "typing"              { TYPING }
-    | "UNION"             { UNION }
-    | "UNION_LIST"        { UNION_LIST }
-    | "IFF"               { IFF }
-    | "LIST"              { LIST }
-    | "SET"               { SET }
-    | "SIZE"              { SIZE }
-    | "SOME"              { SOME }
 
     (* Punctuation and operators *)
     | '.'            { DOT }
@@ -71,8 +72,6 @@ rule token = parse
     | ':'            { COLON }
     | ';'            { SEMI }
     | '|'            { VDASH }
-    | "=:"           { EQ }
-    | '='            { EQ }
     | '('            { LPAR }
     | ')'            { RPAR }
     | '['            { LBRACKET }
@@ -82,7 +81,22 @@ rule token = parse
     | '-'            { MINUS }
     | "->"           { ARROW }
     | "--"           { MINUS_MINUS }
+    (* Operator tokens *)
     | ":="           { COLON_EQ }
+    | "=:"           { EQ }
+    | '='            { EQ }
+    | '+'            { PLUS }
+    | '*'            { TIMES }
+    | '/'            { DIVIDE }
+    | '^'            { EXPONENT }
+    | "&&"           { AND }
+    | "||"           { OR }
+    | "<=>"          { IFF }
+    | "<="           { LE }
+    | "<"            { LT }
+    | ">="           { GE }
+    | ">"            { GT }
+    | "!="           { NEQ }
 
     | identifier as lxm { IDENTIFIER(lxm) }
     | latex_macro as lxm { LATEX_MACRO(lxm) }

--- a/asllib/aslspec/latex.ml
+++ b/asllib/aslspec/latex.ml
@@ -38,11 +38,16 @@ let pp_one_arg_macro macro_name pp_arg fmt arg =
   assert (Str.string_match regexp_only_letters macro_name 0);
   fprintf fmt "\\%s{%a}" macro_name pp_arg arg
 
-(** [pp_macro fmt macro_name] renders a LaTeX macro by prefixing it with a
-    backslash. *)
+(** [pp_macro fmt macro_name] renders a LaTeX macro by making sure it starts
+    with a backslash. *)
 let pp_macro fmt macro_name =
+  let macro, macro_name =
+    if Utils.string_starts_with ~prefix:"\\" macro_name then
+      (macro_name, String.sub macro_name 1 (String.length macro_name - 1))
+    else ("\\" ^ macro_name, macro_name)
+  in
   assert (Str.string_match regexp_only_letters macro_name 0);
-  fprintf fmt "\\%s" macro_name
+  pp_print_string fmt macro
 
 (** [spec_var_to_latex_var ~font_type var_str] returns a version of the
     specification variable [var_str] suitable for LaTeX math mode using the
@@ -66,6 +71,7 @@ let elem_name_to_math_macro elem_name =
   Format.asprintf "%a" pp_macro (StringOps.remove_underscores elem_name)
 
 let pp_comma = fun fmt () -> fprintf fmt ", "
+let pp_noop = fun _fmt () -> ()
 
 (** [substitute_spec_vars_by_latex_vars math_mode s vars] returns a string [s]
     with every instance of [{my_var}] substituted by [\texttt{my\_var}]. If

--- a/asllib/aslspec/spec.mli
+++ b/asllib/aslspec/spec.mli
@@ -47,9 +47,6 @@ val elem_name : elem -> string
 type t
 (** A processed and validated specification. *)
 
-val ast : t -> AST.t
-(** [ast spec] returns the original AST from which [spec] was created. *)
-
 val from_ast : AST.t -> t
 (** [from_ast ast] converts an AST into a validated specification. Performs all
     correctness checks, and raises [SpecError] if any fail. *)
@@ -57,6 +54,9 @@ val from_ast : AST.t -> t
 val defined_ids : t -> string list
 (** [defined_ids spec] returns the list of all identifiers defined in [spec] in
     order of appearance. *)
+
+val elements : t -> elem list
+(** [elements spec] returns the list of all elements in [spec]. *)
 
 val defining_node_for_id : t -> string -> definition_node
 (** [defining_node_for_id spec id] returns the defining node for [id] in [spec].
@@ -74,6 +74,12 @@ val is_defined_id : t -> string -> bool
 (** [is_defined_id spec id] returns [true] if [id] is defined in [spec] and
     [false] otherwise. *)
 
+val is_operator : elem -> bool
+(** [is_operator elem] returns [true] if [elem] corresponds to an operator, and
+    [false] otherwise. *)
+
+(** A module for expanding rules with cases into multiple rules without cases.
+*)
 module ExpandRules : sig
   type expanded_rule = {
     name_opt : string option;

--- a/asllib/aslspec/tests.t/operators.expected
+++ b/asllib/aslspec/tests.t/operators.expected
@@ -1,0 +1,50 @@
+% ==================================================
+% AUTO-GENERATED - DO NOT EDIT
+% ==================================================
+
+% ------------------
+% Macros for symbols
+% ------------------
+
+\newcommand\N[0]{ \hyperlink{type-N}{\textsf{N}} } % Generated from N
+\newcommand\Bool[0]{ \hyperlink{type-Bool}{\textsf{Bool}} } % Generated from Bool
+
+
+
+
+
+\newcommand\f[0]{ \hyperlink{relation-f}{\textit{f}} } % Generated from f
+
+% -------------------
+% Macros for elements
+% -------------------
+
+\DefineType{N}{\texthypertarget{type-N}$\N$} % EndDefineType
+
+\DefineType{Bool}{\texthypertarget{type-Bool}$\Bool$} % EndDefineType
+
+
+
+
+
+
+
+
+
+
+
+\DefineRelation{f}{
+The relation
+\[
+\mathhypertarget{relation-f}\f\left(\overtext{\N}{\texttt{a}}, \overtext{\N}{\texttt{b}}, \overtext{\N}{\texttt{c}}, \overtext{\pow{\N}}{\texttt{S}}\right) \bigtimes \N
+\]
+} % EndDefineRelation
+
+\DefineRule{f}{\begin{mathpar}
+\inferrule{{\texttt{a}\intplus\texttt{b} \equal \texttt{c}}\\\\
+{\texttt{d} \eqdef \ifthenelseop{H}{\texttt{a} \member \texttt{S}}{\texttt{b}}{\texttt{c}}}}{
+{\f(\texttt{a}, \texttt{b}, \texttt{c}, \texttt{S}) \typearrow \texttt{d}}
+}
+\end{mathpar}} % EndDefineRule
+
+

--- a/asllib/aslspec/tests.t/operators.spec
+++ b/asllib/aslspec/tests.t/operators.spec
@@ -1,0 +1,38 @@
+typedef N;
+typedef Bool;
+
+operator assign[T](T, T) -> Bool
+{
+  math_macro = \eqdef,
+};
+
+operator if_then_else[T](Bool, T, T) -> T
+{
+  math_macro = \ifthenelseop,
+};
+
+operator equal[T](a: T, b: T) -> (c: Bool)
+{
+  math_macro = \equal,
+  prose_application = "equating {a} to {b} yields {c}",
+};
+
+operator member[T](x: T, s: powerset(T)) -> Bool
+{
+  math_macro = \member,
+};
+
+operator int_plus(list1(N)) -> N
+{
+  associative = true,
+  math_macro = \intplus,
+};
+
+typing relation f(a: N, b: N, c: N, S: powerset(N)) -> N {} =
+    a + b = c;
+    d := if a in S then b else c;
+    --
+    d;
+;
+
+render rule f;

--- a/asllib/aslspec/tests.t/run.t
+++ b/asllib/aslspec/tests.t/run.t
@@ -7,6 +7,8 @@
   Generated LaTeX macros into generated_macros.tex
   $ aslspec rule.spec --render; diff -w generated_macros.tex rule.expected; rm -f generated_macros.tex
   Generated LaTeX macros into generated_macros.tex
+  $ aslspec operators.spec --render; diff -w generated_macros.tex operators.expected; rm -f generated_macros.tex
+  Generated LaTeX macros into generated_macros.tex
 
   $ aslspec type_name.bad
   Syntax Error: illegal element-defining identifier: t2 around type_name.bad line 1 column 41

--- a/asllib/aslspec/utils.ml
+++ b/asllib/aslspec/utils.ml
@@ -10,9 +10,11 @@ let list_is_equal eq l1 l2 =
   in
   aux l1 l2
 
-let is_singleton_list list = 1 == List.length list
+let is_singleton_list = function [ _ ] -> true | _ -> false
 let list_tl_or_empty list = match list with [] -> [] | _ :: t -> t
 
+(** [split_last lst] returns a pair consisting of the prefix up to the last and
+    the last element, assuming the list is non-empty. *)
 let split_last lst =
   match List.rev lst with [] -> assert false | x :: xs -> (List.rev xs, x)
 

--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -41,8 +41,8 @@ is the set of rational numbers.
 is the set of ASL Boolean literals, which consists of $\True$ and $\False$.
 We employ these literals to represent the corresponding mathematical truth values,
 which are used to denote whether logical assertions hold or not.
-\hypertarget{def-land}{}
-\hypertarget{def-lor}{}
+\hypertarget{operator-land}{}
+\hypertarget{operator-lor}{}
 We also employ the mathematical meaning of logical conjunction $\land$, logical disjunction $\lor$,
 and logical negation $\neg$, given next.
 For a set of Boolean values $A$:
@@ -57,12 +57,16 @@ For a set of Boolean values $A$:
   \begin{cases}
     \False & \text{if all values in A are }\False\\
     \True & \text{otherwise}
-  \end{cases}\\
+  \end{cases}
 \end{array}
 \]
-\hypertarget{def-neg}{}
+\hypertarget{operator-neg}{}
+\hypertarget{operator-IFF}{}
+\hypertarget{operator-implies}{}
 For a pair of Boolean values $a,b\in\Bool$, we define $a \land b \triangleq \land\{a, b\}$
 and $a \lor b \triangleq \lor\{a, b\}$.
+We define implication as $a \implies b \triangleq (\neg a) \lor b$, and
+bi-implication as $a \IFF b \triangleq (a \implies b) \land (b \implies a)$.
 Finally, $\neg\True\triangleq\False$ and $\neg\False\triangleq\True$.
 
 \item \RenderType{Bit}
@@ -104,7 +108,7 @@ The function $\sign : \overname{\Q}{q} \rightarrow \Sign$ returns the sign of $\
   The \emph{empty set} --- the set that does not contain any element --- is denoted as \RenderConstant{empty_set}.
 \end{definition}
 
-\hypertarget{def-cardinality}{}
+\hypertarget{operator-cardinality}{}
 \begin{definition}[Set Cardinality]
   For a set $S$, the notation $\cardinality{S}$ stands for the number of elements in $S$.
 \end{definition}
@@ -239,7 +243,7 @@ and the \emph{\tail} of the list is the suffix obtained by removing $v_1$ from t
 
 We refer to individual elements of a non-empty list $V$ by the index notation $V[i]$ where $i\in\Npos$.
 
-\hypertarget{def-listlen}{}
+\hypertarget{operator-listlen}{}
 \begin{definition}[List Length]
 The \emph{length} of a list is the number of elements in that list:
 $\listlen{\emptylist} \triangleq 0$ and $\listlen{v_1,\ldots,v_k}=k$.
@@ -276,7 +280,7 @@ lists the elements of a set in an arbitrary order:
 \]
 \end{definition}
 
-\hypertarget{def-concat}{}
+\hypertarget{operator-concat}{}
 \begin{definition}[List Concatenation]
 The parametric function $\concat : \KleeneStar{T} \cartimes \KleeneStar{T} \rightarrow \KleeneStar{T}$ concatenates two lists:
 \[
@@ -288,7 +292,7 @@ The parametric function $\concat : \KleeneStar{T} \cartimes \KleeneStar{T} \righ
 \]
 \end{definition}
 
-\hypertarget{def-concatlist}{}
+\hypertarget{operator-concatlist}{}
 \begin{definition}[Concatenation of a List of Lists]
 The parametric function\\
 $\concatlist : \KleeneStar{\left(\KleeneStar{T}\right)} \rightarrow \KleeneStar{T}$ concatenates a list of lists:
@@ -298,6 +302,12 @@ $\concatlist : \KleeneStar{\left(\KleeneStar{T}\right)} \rightarrow \KleeneStar{
     \concatlist(l_{1..k}) &\triangleq& l_1 \concat \ldots \concat l_k \\
   \end{array}
 \]
+\end{definition}
+
+\begin{definition}[List Consing]
+\hypertarget{operator-cons}{}
+The notation $h \cons t$, where $h \in T$ and $t \in \KleeneStar{T}$,
+denotes $[h] \concat t$, that is, the list formed by prepending the element $h$ to the front of the list $t$.
 \end{definition}
 
 \hypertarget{def-equallength}{}
@@ -332,6 +342,7 @@ The parametric function $\listrange : \KleeneStar{T} \rightarrow \KleeneStar{\N}
 \]
 \end{definition}
 
+\hypertarget{operator-listcombine}{} % DO NOT LINT
 \hypertarget{def-unziplist}{}
 \begin{definition}[Unzipping a List of Pairs]
 The parametric function
@@ -416,7 +427,7 @@ $\{ L(v_{1..k}) \;|\; v_1\in T_1,\ldots,v_k\in T_k \}$.
 
 \hypertarget{def-Option}{}
 \begin{definition}[Optional Data Type]
-\hypertarget{def-some}{}
+\hypertarget{operator-some}{}
 The notation $\some{x} \triangleq \{x\}$ stands for a singleton
 set containing $x$.
 %

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -262,12 +262,6 @@
 %% Mathematical notations and Inference Rule macros
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%$%%%%%%
 \usepackage{relsize}
-\let\OldLand\land
-\renewcommand\land[0]{\hyperlink{def-land}{\OldLand}}
-\let\OldLor\lor
-\renewcommand\lor[0]{\hyperlink{def-lor}{\OldLor}}
-\let\OldNeg\neg
-\renewcommand\neg[0]{\hyperlink{def-neg}{\OldNeg}}
 \let\OldTriangleq\triangleq
 \let\OldEmptyset\emptyset
 \renewcommand\emptyset[0]{\hyperlink{constant-emptyset}{\OldEmptyset}}
@@ -276,9 +270,96 @@
 \renewcommand\triangleq[0]{\hyperlink{def-triangleq}{\OldTriangleq}}
 \newcommand\cartimes[0]{\hyperlink{def-cartimes}{\times}}
 
-\newcommand\equal[0]{=}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Operator macros
 \newcommand\eqname[0]{\hyperlink{def-deconstruction}{\stackrel{\mathsmaller{\mathsf{is}}}{=}}}
 \newcommand\eqdef[0]{\hyperlink{def-eqdef}{:=}}
+\newcommand\astlabelop[1]{\astlabel(#1)} % DO NOT LINT
+\newcommand\updateop[4][H]{ {#2}\left[{#3} \mapsto {#4}\right] } % DO NOT LINT
+
+\newcommand\equal[0]{\mathrel{=}}
+\newcommand\notequal[0]{\mathrel{\neq}} % DO NOT LINT
+% Old macro, still used but soon to be deprecated.
+\newcommand\ifthenelse[3]{
+  \left\{\begin{array}{ll}
+  \hyperlink{def-choice}{\textbf{if}} & #1\\
+  \hyperlink{def-choice}{\textbf{then}} & #2\\
+  \hyperlink{def-choice}{\textbf{else}} & #3\\
+  \end{array}\right.
+}
+
+% An if-then-else macro with optional layout parameter.
+% Usage:
+% \ifthenelseop[H]{condition}{then-clause}{else-clause}  % Horizontal layout
+% \ifthenelseop[V]{condition}{then-clause}{else-clause}  % Vertical layout
+% \ifthenelseop{condition}{then-clause}{else-clause}     % Default: Vertical layout
+\newcommand\ifthenelseop[4][V]{%
+  \ifnum\pdfstrcmp{#1}{H}=0\relax
+    \hyperlink{def-choice}{\textbf{if}} #2
+    \hyperlink{def-choice}{\textbf{then}} #3
+    \hyperlink{def-choice}{\textbf{else}} #4%
+  \else
+    \left\{\begin{array}{ll}
+    \hyperlink{def-choice}{\textbf{if}} & #2\\
+    \hyperlink{def-choice}{\textbf{then}} & #3\\
+    \hyperlink{def-choice}{\textbf{else}} & #4\\
+    \end{array}\right.%
+  \fi
+}
+
+
+\let\OldLand\land
+\renewcommand\land[0]{\hyperlink{operator-land}{\OldLand}}
+\let\OldLor\lor
+\renewcommand\lor[0]{\hyperlink{operator-lor}{\OldLor}}
+\let\OldNeg\neg
+\renewcommand\neg[0]{\hyperlink{operator-neg}{\OldNeg}}
+\newcommand\opnot[1]{\hyperlink{operator-neg}{\neg}{#1}} % DO NOT LINT
+\newcommand\IFF[0]{\hyperlink{operator-IFF}{\Leftrightarrow}}
+\renewcommand\implies[0]{\hyperlink{operator-implies}{\Rightarrow}}
+
+\newcommand\some[1]{\hyperlink{operator-some}{\textsf{Some}}\left({#1}\right)} % The optional expression with one element
+\newcommand\makeset[1]{\left\{{#1}\right\}} % A set of expressions
+\newcommand\cardinality[1]{\hyperlink{operator-cardinality}{|}#1\hyperlink{operator-cardinality}{|}}
+\newcommand\member[0]{\mathrel{\in}} % DO NOT LINT
+\newcommand\notmember[0]{\mathrel{\not\in}} % DO NOT LINT
+\newcommand\unionlist[0]{\hyperlink{def-unionlist}{\textfunc{union\_list}}}
+\newcommand\UNIONLIST[1]{\unionlist\left({#1}\right)} % A union of a list of sets
+
+\newcommand\intplus[0]{\mathbin{+}} % DO NOT LINT
+\newcommand\intminus[0]{\mathbin{-}} % DO NOT LINT
+\newcommand\intnegate[1]{\mathbin{\smash{-}}{#1}} % DO NOT LINT
+\newcommand\inttimes[0]{\mathbin{\times}} % DO NOT LINT
+\newcommand\intdivide[0]{\mathbin{\div}} % DO NOT LINT
+\newcommand\intexponent[0]{\mathbin{{^}}} % DO NOT LINT
+\newcommand\intlessthan[0]{\mathbin{<}} % DO NOT LINT
+\newcommand\intlessorequal[0]{\mathbin{\leq}} % DO NOT LINT
+\newcommand\intgreaterthan[0]{\mathbin{>}} % DO NOT LINT
+\newcommand\intgreaterorequal[0]{\mathbin{\geq}} % DO NOT LINT
+
+\newcommand\roundup[1]{\left\lceil {#1} \right\rceil} % DO NOT LINT
+\newcommand\rounddown[1]{\left\lfloor {#1} \right\rfloor} % DO NOT LINT
+
+\newcommand\makelist[1]{\left[{#1}\right]} % A list of expressions
+\newcommand\listlen[1]{\hyperlink{operator-listlen}{|}#1\hyperlink{operator-listlen}{|}}
+\newcommand\concat[0]{\hyperlink{operator-concat}{\mathbin{+}}}
+\newcommand\concatlist[0]{\hyperlink{operator-concatlist}{\textfunc{concat\_list}}}
+\newcommand\cons[0]{\hyperlink{operator-cons}{{+}{+}}}
+\newcommand\listcombine[0]{\hyperlink{operator-listcombine}{\textfunc{combine}}} % DO NOT LINT
+
+\newcommand\parallelcomp[0]{\hyperlink{def-parallel}{\mathbin{\parallel}}}
+\newcommand\ordered[3]{{#1}\hyperlink{def-ordered}{\xrightarrow{#2}}{#3}}
+\newcommand\orderedctrl[0]{\hyperlink{def-ordered}{\xrightarrow{\aslctrl}}} % DO NOT LINT
+\newcommand\ordereddata[0]{\hyperlink{def-ordered}{\xrightarrow{\asldata}}} % DO NOT LINT
+\newcommand\orderedpo[0]{\hyperlink{def-ordered}{\xrightarrow{\aslpo}}} % DO NOT LINT
+\newcommand\graphof[1]{\hyperlink{operator-graphof}{\textfunc{graph}}({#1})} % NO_SPECIFICATION_REQUIRED
+\newcommand\environof[1]{\hyperlink{operator-environof}{\textfunc{environ}}({#1})} % NO_SPECIFICATION_REQUIRED
+
+\newcommand\withgraph[3][H]{ {#2}(\hyperlink{operator-withgraph}{\textfunc{graph}}\mapsto{#3}) } % NO_SPECIFICATION_REQUIRED
+\newcommand\withenviron[3][H]{ {#2}(\hyperlink{def-withenviron}{\textfunc{environ}}\mapsto{#3}) } % NO_SPECIFICATION_REQUIRED
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \newcommand\overname[2]{\overbrace{#1}^{#2}}
 \newcommand\overtext[2]{\overbracket{#1}^{#2}}
 \newcommand\emptyfunc[0]{\hyperlink{def-emptyfunc}{{\emptyset}_\lambda}}
@@ -290,26 +371,15 @@
 \newcommand\Proseemptylist[1]{#1 is the empty list}
 \newcommand\choice[3]{\hyperlink{def-choice}{\textsf{choice}}(#1,#2,#3)}
 \newcommand\choicename[0]{\hyperlink{def-choice}{\textfunc{choice}}}
-\newcommand\ifthenelse[3]{
-  \left\{\begin{array}{ll}
-  \hyperlink{def-choice}{\textbf{if}} & #1\\
-  \hyperlink{def-choice}{\textbf{then}} & #2\\
-  \hyperlink{def-choice}{\textbf{else}} & #3\\
-  \end{array}\right.
-}
 \newcommand\equallength[0]{\hyperlink{def-equallength}{\textfunc{equal\_length}}}
 \newcommand\listrange[0]{\hyperlink{def-listrange}{\textfunc{indices}}}
 \newcommand\Proselistrange[2]{\hyperlink{def-listrange}{index} #1 in the list of indices for #2}
-\newcommand\listlen[1]{\hyperlink{def-listlen}{|}#1\hyperlink{def-listlen}{|}}
-\newcommand\cardinality[1]{\hyperlink{def-cardinality}{|}#1\hyperlink{def-cardinality}{|}}
 \newcommand\unziplist[0]{\hyperlink{def-unziplist}{\textfunc{unzip}}}
 \newcommand\unziplistthree[0]{\hyperlink{def-unziplistthree}{\textfunc{unzip3}}}
 \newcommand\inlist[0]{\hyperlink{def-inlist}{\in}}
 \newcommand\uniquep[0]{\hyperlink{def-uniquep}{\textfunc{unique'}}}
 \newcommand\uniquelist[0]{\hyperlink{def-uniquelist}{\textfunc{unique}}}
 \newcommand\listset[0]{\hyperlink{def-listset}{\textfunc{list\_set}}}
-\newcommand\concat[0]{\hyperlink{def-concat}{+}}
-\newcommand\concatlist[0]{\hyperlink{def-concatlist}{\textfunc{concat}}}
 \newcommand\listprefix[0]{\hyperlink{def-listprefix}{\textfunc{prefix}}}
 \newcommand\stringconcat[0]{\hyperlink{def-stringconcat}{\texttt{+}}}
 \newcommand\stringofnat[0]{\hyperlink{def-stringofnat}{\texttt{string\_of\_nat}}}
@@ -317,11 +387,6 @@
 \newcommand\Ignore[0]{\hyperlink{def-ignore}{\underline{\;\;}}}
 \newcommand\Option[1]{\hyperlink{def-Option}{\textsf{Option}}\left({#1}\right)} % The optional type term
 \newcommand\optionalterm[0]{\hyperlink{def-Option}{optional}}
-\newcommand\some[1]{\hyperlink{def-some}{\textsf{Some}}\left({#1}\right)} % The optional expression with one element
-\newcommand\LIST[1]{\left[{#1}\right]} % A list of expressions
-\newcommand\SET[1]{\left\{{#1}\right\}} % A set of expressions
-\newcommand\unionlist[0]{\hyperlink{def-unionlist}{\textfunc{union\_list}}}
-\newcommand\UNIONLIST[1]{\unionlist\left({#1}\right)} % A union of a list of sets
 \newcommand\KleeneStar[1]{{#1}^{\hyperlink{def-kleenestar}{*}}}
 \newcommand\KleenePlus[1]{{#1}^{\hyperlink{def-kleeneplus}{+}}}
 
@@ -945,13 +1010,6 @@
 \newcommand\ReadEffect[0]{\hyperlink{def-readeffect}{\textsf{ReadEffect}}}
 
 \newcommand\emptyenv[0]{\hyperlink{def-emptyenv}{\emptyset_{\mathbb{E}}}}
-\newcommand\ordered[3]{{#1}\hyperlink{def-ordered}{\xrightarrow{#2}}{#3}}
-\newcommand\parallelcomp[0]{\hyperlink{def-parallel}{\parallel}}
-
-\newcommand\graphof[1]{\hyperlink{def-graphof}{\textfunc{graph}}({#1})} % NO_SPECIFICATION_REQUIRED
-\newcommand\withgraph[2]{{#1}(\hyperlink{def-withgraph}{\textfunc{graph}}\mapsto{#2})} % NO_SPECIFICATION_REQUIRED
-\newcommand\environof[1]{\hyperlink{def-environof}{\textfunc{environ}}({#1})} % NO_SPECIFICATION_REQUIRED
-\newcommand\withenviron[2]{{#1}(\hyperlink{def-withenviron}{\textfunc{environ}}\mapsto{#2})} % NO_SPECIFICATION_REQUIRED
 
 \newcommand\ReturningConfig[0]{\hyperlink{def-returningconfig}{\texttt{\#R}}}
 \newcommand\ThrowingConfig[0]{\hyperlink{def-throwingconfig}{\texttt{\#T}}}

--- a/asllib/doc/Bitfields.tex
+++ b/asllib/doc/Bitfields.tex
@@ -841,7 +841,7 @@ and \ExampleRef{Ill-typed Bitfields} where not all \absolutebitfields{} align.
   \vscopeone \eqdef \vf_{1..k-1}\\
   \vscopetwo \eqdef \vg_{1..n-1}\\
   \vsamescope \eqdef \listprefix(\vscopeone, \vscopetwo) \lor \listprefix(\vscopetwo, \vscopeone)\\
-  \vb \eqdef (\nameone = \nametwo\ \land\ \vsamescope) \Longrightarrow (\vsliceone = \vslicetwo)
+  \vb \eqdef (\nameone = \nametwo\ \land\ \vsamescope) \implies (\vsliceone = \vslicetwo)
 }{
   \absolutebitfieldsalign(\overname{(\vf_{1..k}, \vsliceone)}{\vf}, \overname{(\vg_{1..n}, \vslicetwo)}{\vf})
   \typearrow \vb

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -377,8 +377,8 @@ appearing are \hyperlink{def-freshvariables}{fresh}:
 
 \subsection{Extracting and Substituting Elements of Semantic configurations}
 
-\hypertarget{def-graphof}{}
-\hypertarget{def-environof}{}
+\hypertarget{operator-graphof}{}
+\hypertarget{operator-environof}{}
 Given a semantic configuration $C$, we define the graph component of the semantic configuration, \\
 $\graphof{C}$, and the environment of the semantic configuration, $\environof{C}$, as follows:
 \[
@@ -402,7 +402,7 @@ $\graphof{C}$, and the environment of the semantic configuration, $\environof{C}
 \end{array}
 \]
 
-\hypertarget{def-withgraph}{}
+\hypertarget{operator-withgraph}{}
 Given a semantic configuration $C$, we define $\withgraph{C}{\vgp}$ to be a semantic configuration
 like $C$ where the graph component is substituted with $\vgp$:
 \begin{small}

--- a/asllib/doc/Specifications.tex
+++ b/asllib/doc/Specifications.tex
@@ -2136,7 +2136,7 @@ $C_{1..k}$ --- is a \emph{topological ordering of components},
 denoted \\
 $C_{1..k} \in \topologicalorderingcomps(\comps, E)$, if the following condition holds:
 \[
-  \forall 1 \leq i \leq j \leq k.\ \exists c_i\in C_i.\ c_j\in C_j.\ (c_i,c_j) \in \graphtransitivereflexive{E} \;\;\Longrightarrow\;\;
+  \forall 1 \leq i \leq j \leq k.\ \exists c_i\in C_i.\ c_j\in C_j.\ (c_i,c_j) \in \graphtransitivereflexive{E} \;\;\implies\;\;
   i \leq j \enspace .
 \]
 \end{definition}

--- a/asllib/doc/SymbolicSubsumptionTesting.tex
+++ b/asllib/doc/SymbolicSubsumptionTesting.tex
@@ -42,7 +42,7 @@ is \emph{sound} if the following condition holds:
 \begin{equation}
   \begin{array}{l}
   \forall \vt,\vs\in\ty.\ \tenv\in\staticenvs. \\
-  \;\;\;\; \symdomsubsettest(\tenv, \vt, \vs) \typearrow \True \;\Longrightarrow\; \domainsubset(\tenv, \vt, \vs)  \enspace.
+  \;\;\;\; \symdomsubsettest(\tenv, \vt, \vs) \typearrow \True \;\implies\; \domainsubset(\tenv, \vt, \vs)  \enspace.
   \end{array}
 \end{equation}
 \end{definition}

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -86,6 +86,261 @@ typedef def_use_name { "subprogram identifier kind" } =
 ;
 
 ////////////////////////////////////////////////////////////////////////////////
+// Operator definitions
+// Some of the operators below will be removed once type parameters
+// are made available to ordinary relations.
+
+// Assignment is special as it defines the left-hand side.
+operator assign[T](T, T) -> Bool
+{
+  math_macro = \eqdef,
+};
+
+operator ast_label[T](T) -> ASTLabels
+{
+  math_macro = \astlabelop,
+};
+
+operator update[K,V](partial K -> V, K, V) -> (partial K -> V)
+{
+  math_macro = \opupdate,
+};
+
+operator equal[T](a: T, b: T) -> (c: Bool)
+{
+  math_macro = \equal,
+  prose_application = "equating {a} to {b} yields {c}",
+};
+
+operator not_equal[T](T, T) -> Bool
+{
+  math_macro = \notequal,
+};
+
+operator if_then_else[T](Bool, T, T) -> T
+{
+  math_macro = \ifthenelseop,
+};
+
+operator some[T](T) -> option(T)
+{
+  math_macro = \some,
+};
+
+operator make_list[T](list0(T)) -> list0(T)
+{
+  math_macro = \makelist,
+};
+
+operator list_len[T](list0(T)) -> N
+{
+  math_macro = \listlen,
+};
+
+operator concat[T](list1(T)) -> list0(T)
+{
+  associative = true,
+  math_macro = \concat,
+};
+
+operator concat_list[T](list0(T)) -> list0(T)
+{
+  math_macro = \concatlist,
+};
+
+operator cons[T](T, list0(T)) -> list1(T)
+{
+  math_macro = \cons,
+};
+
+operator list_combine[A,B](list0(A), list0(B)) -> list0((A, B))
+{
+  math_macro = \listcombine,
+};
+
+// Constructs a set out of a fixed list of expressions.
+operator make_set[T](list1(T)) -> powerset(T)
+{
+  math_macro = \makeset,
+};
+
+// The size of a finite set.
+operator cardinality[T](powerset(T)) -> N
+{
+  math_macro = \cardinality,
+};
+
+operator member[T](x: T, s: powerset(T)) -> Bool
+{
+  math_macro = \member,
+};
+
+operator not_member[T](x: T, s: powerset(T)) -> Bool
+{
+  math_macro = \notmember,
+};
+
+operator subset[T](A: powerset(T), B: powerset(T)) -> Bool
+{
+  math_macro = \subset,
+};
+
+operator union[T](list1(powerset(T))) -> powerset(T)
+{
+  math_macro = \cup,
+  associative = true,
+};
+
+operator union_list[T](list1(powerset(T))) -> powerset(T)
+{
+  math_macro = \UNIONLIST,
+};
+
+operator not(Bool) -> Bool
+{
+  math_macro = \opnot,
+};
+
+operator and(list1(Bool)) -> Bool
+{
+  associative = true,
+  math_macro = \land,
+};
+
+operator or(list1(Bool)) -> Bool
+{
+  associative = true,
+  math_macro = \lor,
+};
+
+operator list_and(list1(Bool)) -> Bool
+{
+  math_macro = \land,
+};
+
+operator list_or(list1(Bool)) -> Bool
+{
+  math_macro = \lor,
+};
+
+operator iff(Bool, Bool) -> Bool
+{
+  math_macro = \IFF,
+};
+
+operator implies(Bool, Bool) -> Bool
+{
+  math_macro = \implies,
+};
+
+operator int_plus(list1(N)) -> N
+{
+  associative = true,
+  math_macro = \intplus,
+};
+
+operator int_minus(list1(N)) -> N
+{
+  associative = true,
+  math_macro = \intminus,
+};
+
+operator int_negate(N) -> N
+{
+  math_macro = \intnegate,
+};
+
+operator int_times(list1(N)) -> N
+{
+  math_macro = \inttimes,
+};
+
+operator int_divide(N, N) -> N
+{
+  math_macro = \intdivide,
+};
+
+operator int_exponent(N, N) -> N
+{
+  math_macro = \intexponent,
+};
+
+operator int_less_than(N, N) -> Bool
+{
+  math_macro = \intlessthan,
+};
+
+operator int_less_or_equal(N, N) -> Bool
+{
+  math_macro = \intlessorequal,
+};
+
+operator int_greater_than(N, N) -> Bool
+{
+  math_macro = \intgreaterthan,
+};
+
+operator int_greater_or_equal(N, N) -> Bool
+{
+  math_macro = \intgreaterorequal,
+};
+
+operator round_up(Q) -> N
+{
+  math_macro = \roundup,
+};
+
+operator round_down(Q) -> N
+{
+  math_macro = \rounddown,
+};
+
+operator parallel(XGraphs, XGraphs) -> XGraphs
+{
+  math_macro = \parallelcomp,
+};
+
+operator ordered_data(list1(XGraphs)) -> XGraphs
+{
+  associative = true,
+  math_macro = \ordereddata,
+};
+
+operator ordered_ctrl(list1(XGraphs)) -> XGraphs
+{
+  associative = true,
+  math_macro = \orderedctrl,
+};
+
+operator ordered_po(list1(XGraphs)) -> XGraphs
+{
+  associative = true,
+  math_macro = \orderedpo,
+};
+
+operator graph_of[T](T) -> XGraphs
+{
+  math_macro = \graphof,
+};
+
+operator with_graph[T](T, XGraphs) -> T
+{
+  custom = true,
+  math_macro = \withgraph,
+};
+
+operator environ_of[T](T) -> envs
+{
+  math_macro = \environof,
+};
+
+operator with_environ[T](T, envs) -> T
+{
+  custom = true,
+  math_macro = \withenviron,
+};
+
+////////////////////////////////////////////////////////////////////////////////
 // Types for Symbolic Equivalence Testing
 constant negative_sign { "negative sign", math_macro = \negativesign };
 constant positive_sign { "positive sign", math_macro = \positivesign };
@@ -193,10 +448,10 @@ ast expr { "expression" } =
     { "variable expression for {name}" }
     | E_ATC(source: expr, type: ty)
     { "asserting type conversion for the source expression {source} and type {type}" }
-    | E_Binop(operator: binop, left: expr, right: expr)
-    { "binary expression for the operator {operator}, left expression {left} and right expression {right}" }
-    | E_Unop(operator: unop, subexpression: expr)
-    { "unary expression for the unary operator {operator} and subexpression {subexpression}" }
+    | E_Binop(binary_operator: binop, left: expr, right: expr)
+    { "binary expression for the operator {binary_operator}, left expression {left} and right expression {right}" }
+    | E_Unop(unary_operator: unop, subexpression: expr)
+    { "unary expression for the unary operator {unary_operator} and subexpression {subexpression}" }
     | E_Call(call_descriptor: call)
     { "call expression for the call descriptor {call_descriptor}" }
     | E_Slice(base: expr, slices: list0(slice))
@@ -1330,7 +1585,7 @@ typing function annotate_literal(tenv: static_envs, l: literal) -> (t: ty)
 } =
   case Int {
     l = L_Int(n);
-    cs := LIST(Constraint_Exact(E_Literal(L_Int(n))));
+    cs := make_list(Constraint_Exact(E_Literal(L_Int(n))));
     --
     T_Int(WellConstrained(cs));
   }
@@ -1355,7 +1610,7 @@ typing function annotate_literal(tenv: static_envs, l: literal) -> (t: ty)
 
   case Bits {
     l = L_Bitvector(bits);
-    n := SIZE(bits);
+    n := cardinality(bits);
     --
     T_Bits(E_Literal(L_Int(n)), empty_list);
   }
@@ -1539,11 +1794,12 @@ semantics relation eval_multi_assignment(env: envs, lelist: list0(expr), vmlist:
         | ResultLexpr(new_g: XGraphs, new_env: envs)
         | TThrowing
         | TDynError
+        | TDiverging
 {
     "evaluates multi-assignments. That is, the simultaneous assignment of the list of value-\executiongraphterm{} pairs {vmlist} to the corresponding list of \assignableexpressions{} {lelist}, in the environment {env}. The result is either the \executiongraphterm{} {new_g} and new environment {new_env} or an abnormal configuration",
     prose_application = "evaluating multi-assignment of {vmlist} to {lelist} in {env} yields $\ResultLexpr({new_g}, {new_env})$ or abnormal configuration",
     math_macro = \evalmultiassignment,
-    math_layout = (_, [_,_,_]),
+    math_layout = (_, [_,_,_,_]),
 };
 
 typing relation annotate_set_array(tenv: static_envs, size_elem: (array_index, ty), rhs_ty: ty, base_ses_index: (e_base: expr, ses_base: powerset(TSideEffect), e_index: expr)) ->
@@ -3120,29 +3376,29 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     s = S_Assign(le, re);
     annotate_expr(tenv, re) -> (t_re, re1, ses_re);
     annotate_lexpr(tenv, le, t_re) -> (le1, ses_le);
-    ses := UNION(ses_re, ses_le);
+    ses := union(ses_re, ses_le);
     --
     (S_Assign(le1, re1), tenv, ses);
   }
 
   case SDecl {
     case Some {
-      s = S_Decl(ldk, ldi, ty_opt, SOME(e));
+      s = S_Decl(ldk, ldi, ty_opt, some(e));
       annotate_expr(tenv, e) -> (t_e, e', ses_e);
       annotate_local_decl_type_annot(tenv, ty_opt, t_e, ldk, e', ldi) -> (tenv1, ty_opt', ses_ldi)
       { math_layout = [_,_] };
-      ses := UNION(ses_e, ses_ldi);
-      new_s := S_Decl(ldk, ldi, ty_opt', SOME(e'));
+      ses := union(ses_e, ses_ldi);
+      new_s := S_Decl(ldk, ldi, ty_opt', some(e'));
       --
       (new_s, tenv1, ses);
     }
 
     case None {
       s = S_Decl(LDK_Var, ldi, ty_opt, None);
-      te_check(ty_opt = SOME(_), TE_BD) -> True;
+      te_check(ty_opt = some(_), TE_BD) -> True;
       base_value(tenv, t') -> e_init;
       annotate_local_decl_item(tenv, t', LDK_Var, None, ldi') -> new_tenv;
-      new_s := S_Decl(LDK_Var, ldi, SOME(t'), SOME(e_init));
+      new_s := S_Decl(LDK_Var, ldi, some(t'), some(e_init));
       --
       (new_s, new_tenv, ses);
     }
@@ -3152,7 +3408,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     s = S_Seq(s1, s2);
     annotate_stmt(tenv, s1) -> (new_s1, tenv1, ses1);
     annotate_stmt(tenv1, s2) -> (new_s2, new_tenv, ses2);
-    ses := UNION(ses1, ses2);
+    ses := union(ses1, ses2);
     --
     (S_Seq(new_s1, new_s2), new_tenv, ses);
   }
@@ -3170,7 +3426,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     checked_typesat(tenv, t_cond, T_Bool) -> True;
     annotate_block(tenv, s1) -> (s1', ses1);
     annotate_block(tenv, s2) -> (s2', ses2);
-    ses := UNION(ses_cond, ses1, ses2);
+    ses := union(ses_cond, ses1, ses2);
     --
     (S_Cond(e_cond, s1', s2'), tenv, ses);
   }
@@ -3191,7 +3447,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     annotate_limit_expr(tenv, limit1) -> (limit2, ses_limit);
     checked_typesat(tenv, t, T_Bool) -> True;
     annotate_block(tenv, s1) -> (s2, ses_block);
-    ses := UNION(ses_block, ses_e, ses_limit);
+    ses := union(ses_block, ses_e, ses_limit);
     --
     (S_While(e2, limit2, s2), tenv, ses);
   }
@@ -3202,7 +3458,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     annotate_limit_expr(tenv, limit1) -> (limit2, ses_limit);
     annotate_expr(tenv, e1) -> (t, e2, ses_e);
     checked_typesat(tenv, t, T_Bool) -> True;
-    ses := UNION(ses_block, ses_e, ses_limit);
+    ses := union(ses_block, ses_e, ses_limit);
     --
     (S_Repeat(s2, e2, limit2), tenv, ses);
   }
@@ -3221,7 +3477,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     annotate_limit_expr(tenv, limit) -> (limit', ses_limit);
     te_check(ses_is_readonly(ses_start), TE_SEV) -> True;
     te_check(ses_is_readonly(ses_end), TE_SEV) -> True;
-    ses_cond := UNION(ses_start, ses_end, ses_limit);
+    ses_cond := union(ses_start, ses_end, ses_limit);
     make_anonymous(tenv, start_t) -> start_struct;
     make_anonymous(tenv, end_t) -> end_struct;
     get_for_constraints(tenv, start_struct, end_struct, start_e', end_e', dir, cs) -> cs
@@ -3230,7 +3486,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     check_var_not_in_env(tenv, index_name) -> True;
     add_local(tenv, ty, index_name, LDK_Let) -> tenv';
     annotate_block(tenv', body) -> (body', ses_block);
-    ses := UNION(ses_block, ses_cond);
+    ses := union(ses_block, ses_cond);
     --
     (
       S_For[
@@ -3251,7 +3507,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     annotate_expr(tenv, e) -> (t_e, e', ses1);
     check_structure_label(tenv, t_e, T_Exception) -> True;
     t_e =: T_Named(exn_name);
-    ses := UNION(ses1, SET(LocalEffect(SE_Impure), GlobalEffect(SE_Impure)));
+    ses := union(ses1, make_set(LocalEffect(SE_Impure), GlobalEffect(SE_Impure)));
     --
     (S_Throw(e', t_e), tenv, ses);
   }
@@ -3265,7 +3521,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     annotate_block(tenv, s') -> (s'', ses1);
     (INDEX(i, catchers : annotate_catcher(tenv, catchers[i]) -> (catchers'[i], xs[i])))
     { math_layout =  ([_,_]) };
-    ses_catchers := UNION_LIST(catchers');
+    ses_catchers := union_list(catchers');
     case No_Otherwise {
       otherwise = None;
       otherwise' := None;
@@ -3273,13 +3529,13 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     }
 
     case Otherwise {
-      otherwise = SOME(block);
+      otherwise = some(block);
       annotate_block(tenv, block) -> (block', ses_block);
-      otherwise' := SOME(otherwise');
+      otherwise' := some(otherwise');
       ses_otherwise := ses_block;
       ses_otherwise := ses_block;
     }
-    ses := UNION(ses2, ses_catchers, ses_otherwise);
+    ses := union(ses2, ses_catchers, ses_otherwise);
     new_s := S_Try(s'', catchers', otherwise');
     --
     (new_s, tenv, ses);
@@ -3288,7 +3544,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
   case SReturn {
     case Error {
       s = S_Return(e_opt);
-      b := (tenv.static_envs_L.return_type = None) IFF (e_opt = None);
+      b := (tenv.static_envs_L.return_type = None) <=> (e_opt = None);
       b = False;
       --
       TypeError(TE_BSPD);
@@ -3302,12 +3558,12 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     }
 
     case Some {
-      s = S_Return(SOME(e));
-      tenv.static_envs_L.return_type = SOME(t);
+      s = S_Return(some(e));
+      tenv.static_envs_L.return_type = some(t);
       annotate_expr(tenv, e) -> (t_e', e', ses);
       checked_typesat(tenv, t_e', t) -> True;
       --
-      (S_Return(SOME(e')), tenv, ses);
+      (S_Return(some(e')), tenv, ses);
     }
   }
 
@@ -3315,7 +3571,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
     s = S_Print(args, newline);
     INDEX(i, args : annotate_expr(tenv, args[i]) -> (tys[i], args'[i], sess[i]));
     INDEX(i, args : te_check(is_singular(tys[i]), TE_UT) -> True);
-    ses := UNION(SET(LocalEffect(SE_Impure), GlobalEffect(SE_Impure)), UNION_LIST(sess));
+    ses := union(make_set(LocalEffect(SE_Impure), GlobalEffect(SE_Impure)), union_list(sess));
     --
     (S_Print(args', newline), tenv, ses);
   }
@@ -3329,7 +3585,7 @@ typing relation annotate_stmt(tenv: static_envs, s: stmt) ->
   case SPragma {
     s = S_Pragma(id, args);
     INDEX(i, args : annotate_expr(tenv, args[i]) -> (_, _, sess[i]));
-    ses := UNION_LIST(sess);
+    ses := union_list(sess);
     --
     (S_Pass, tenv, ses);
   }
@@ -3828,7 +4084,8 @@ typing relation annotate_exprs(tenv: static_envs, exprs: list0(expr)) ->
 };
 
 semantics relation eval_call(env: envs, name: Identifier, params: list0(expr), args: list0(expr)) ->
-    ResultCall(vms2: (list0(value_read_from), XGraphs), new_env: envs) | TDynError | TDiverging
+    ResultCall(vms2: (list0(value_read_from), XGraphs), new_env: envs)
+    | TThrowing | TDynError | TDiverging
 {
    prose_description = "evaluates a call to the subprogram named {name} in
                         the environment {env}, with the parameter expressions

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -897,6 +897,7 @@ frames
 free
 fresh
 from
+front
 fulbourn
 full
 fully
@@ -1554,6 +1555,7 @@ prefixed
 premature
 premise
 premises
+prepending
 preprocessing
 presence
 present


### PR DESCRIPTION
This PR allows defining operators - relation-like definitions that can be used to construct expressions.
Another change is allowing operators, but not relations just yet, to define type parameters.
An operator like
```
operator member[T](x: T, s: powerset(T)) -> Bool
{
  math_macro = \member,
};
```
allows rendering `x \in S`.
The rendering of operators follows some rules:
- If an operator is unary it expects a unary macro and rendered as `\macro{arg}`
- If an operator is binary is expects a nullary macro and rendered as `a \macro b`
- If an operator takes a list argument and has `associative = true` then it is considered a binary operator. It expects a nullary macro and rendered as `a1 \macro .... \macro an`
- If an operator has more than two arguments or has `custom = true` it is rendered as `\macro[H/V]{a1}...{an}` where `H`/`V` stands for horizontal/vertical layout. The layout argument should be optional for the macro.

Operators can always be specified with the `operator(a1,...,an)` syntax, but some binary operators and the `if_then_else` operators are directly supported by the parser as binary/ternary operators.
 
This PR defines a list of operators in `asl.spec`.

In terms of checking operators with type parameters - the checker modifies the symbol table while checking an operator by adding the type parameters for the duration of the check.