### PR TITLE
[gen] Wire in `-o` and `-stdout` argument in `diyone7`.

### DIFF
--- a/gen/common/config.ml
+++ b/gen/common/config.ml
@@ -271,18 +271,18 @@ let common_specs () =
 let name_spec is_diyone =
   if is_diyone then
    ("-name",Arg.String (fun s -> name := Some s),
-     "<s> specify the name of test and output to file (`-stdout false`). Note `-norm` overrides this flag.")
+     "<s> specify the name of the test. Outputs to file by default, unless `-stdout` is set. Note: `-norm` overrides this flag.")
   else
    ("-name",Arg.String (fun s -> name := Some s),
      "<s> specify base name of tests.")
 
 let stdout_spec is_diyone =
   if is_diyone then
-    ("-stdout", Arg.Bool (fun b ->  stdout := b),
-     "output to stdout, when `-name` and `-norm` is specified. It overrides `-o`. (default true)")
+    ("-stdout", Arg.Set stdout,
+     "when `-name` or `-norm` is set, control whether output is written to stdout, error otherwise.")
   else
-    ("-stdout", Arg.Bool (fun b ->  stdout := b),
-     "output to stdout. It overrides `-o`. If `-cycleonly` is true, then this is implied to be true. (default false)")
+    ("-stdout", Arg.Set stdout,
+     "output to stdout. It overrides `-o`. If `-cycleonly` is true, then this is implied to be true.")
 
 let varatomspec =
   ("-varatom", Arg.String (fun s -> varatom := !varatom @ [s]),
@@ -294,7 +294,7 @@ let diyone_spec () =
   common_specs () @
   name_spec true
   :: stdout_spec true
-  :: ("-norm",Arg.Set norm, "a normalised name for test name and output to file (`-stdout false`)")
+  :: ("-norm",Arg.Set norm, "find a normalised name for the test. Outputs to file by default, unless `-stdout` is set.")
   :: []
 
 let diycross_spec () =
@@ -356,6 +356,13 @@ let diy_spec () =
    varatomspec ::
    []
 
+let valid_stdout_flag is_diyone =
+  if !stdout &&
+  (* it should only be used with `-norm` or `-name`, and no `-o` in `diyone7` *)
+    ( ( is_diyone && ( (!name = None && not !norm) || !tarfile <> None ) )
+  (* it should not be used with `-o` and `-cycleonly` in `diy7` and `diycross7`*)
+      || ( !cycleonly || !tarfile <> None ) )
+  then Warn.user_error "-stdout will be ignored."
 
 let prog = if Array.length Sys.argv > 0 then Sys.argv.(0) else "XXX"
 let baseprog = sprintf "%s (version %s)" (Filename.basename prog) (Version.version)

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -203,6 +203,7 @@ let () =
   | None -> ()
   | Some s -> exec_conf s
   end;
+  Config.valid_stdout_flag false ;
   let relax_list = split_cands !Config.relaxs
   and safe_list = split_cands !Config.safes
   and reject_list = split !Config.rejects in

--- a/gen/diycross.ml
+++ b/gen/diycross.ml
@@ -84,7 +84,8 @@ let pp_es = ref []
 let () =
   Util.parse_cmdline
     (Config.diycross_spec ())
-    (fun x -> pp_es := x :: !pp_es)
+    (fun x -> pp_es := x :: !pp_es);
+  Config.valid_stdout_flag false
 
 let pp_es = List.rev !pp_es
 

--- a/gen/diyone.ml
+++ b/gen/diyone.ml
@@ -180,7 +180,8 @@ let pp_es = ref []
 let () =
   Util.parse_cmdline
     (Config.diyone_spec ())
-    (fun x -> pp_es := x :: !pp_es)
+    (fun x -> pp_es := x :: !pp_es) ;
+    Config.valid_stdout_flag true
 
 let pp_es = List.rev !pp_es
 let cpp = match !Config.arch with


### PR DESCRIPTION
This PR wires in`-o` and `-stdout` arguments in `diyone7`, which maintains the same behaviour as in `diy7`. (ref #1549)

- `-stdout true` redirects output to `stdout` rather than file, when `-norm` is on or `-name {test_name}` is specified. 
- `-o` will have the expected behaviour as documented in https://diy.inria.fr/doc/gen.html#sec72. That is,
```
Redirect output to <dest>. This option applies when tools generate 
a set of tests and an index file @all, .i.e. in all situations except 
for diyone7 simplest operating mode.

If argument <dest> is an archive (extension .tar) or a compressed 
archive (extension .tgz), the tool builds an archive. Otherwise, 
<dest> is interpreted as the name of an existing directory. 
Default is “.”, that is tool output goes into the current directory.
```

Example:
- `diyone7 -arch AArch64  PodWR Fre PodWR Fre -norm` generates a normalised test and save to a normalised file name under the current directory. This preserves the existing behaviour. Similar for `-name specific_file_name`.
- `diyone7 -arch AArch64  PodWR Fre PodWR Fre -norm -o dir` assuming `dir` is a directory, the generated file will be put under the `dir`.
- `diyone7 -arch AArch64  PodWR Fre PodWR Fre -norm -o pack.tar` the generated file will be wrap into `pack.tar`
- `diyone7 -arch AArch64  PodWR Fre PodWR Fre -norm -stdout`  generates a normalised test yet it will print to `stdout` rather than the file system.

Minor:
- A minor code simplification on parsing `es` in `do_zyva` in `diyone7`.