### PR TITLE
[ASL-902] Add missing stdlib assertions for `Align{Up,Down}{Size,P2}`

### DIFF
--- a/asllib/libdir/stdlib.asl
+++ b/asllib/libdir/stdlib.asl
@@ -139,7 +139,7 @@ end;
 // multiple of size that is less than or equal to x.
 pure func AlignDownSize(x: integer, size: integer) => integer
 begin
-    assert size > 0;
+    assert x >= 0 && size > 0;
     return (x DIVRM size) * size;
 end;
 
@@ -149,7 +149,7 @@ end;
 // multiple of size that is greater than or equal to x.
 pure func AlignUpSize(x: integer, size: integer) => integer
 begin
-    assert size > 0;
+    assert x >= 0 && size > 0;
     return AlignDownSize(x + (size - 1), size);
 end;
 
@@ -169,7 +169,7 @@ end;
 // that is less than or equal to x.
 pure func AlignDownP2(x: integer, p2: integer) => integer
 begin
-    assert p2 >= 0;
+    assert x >= 0 && p2 >= 0;
     return AlignDownSize(x, 2^p2);
 end;
 
@@ -179,7 +179,7 @@ end;
 // that is greater than or equal to x.
 pure func AlignUpP2(x: integer, p2: integer) => integer
 begin
-    assert p2 >= 0;
+    assert x >= 0 && p2 >= 0;
     return AlignUpSize(x, 2^p2);
 end;
 

--- a/asllib/tests/stdlib.t/align.asl
+++ b/asllib/tests/stdlib.t/align.asl
@@ -51,7 +51,7 @@ begin
 
   for N = 1 to 5 do
     let pN = 2 ^ N;
-    for x = -pN to pN do
+    for x = 0 to pN do
       for y = 0 to N do
         let bv = x[0+:N];
         let p = 2^y as integer {1..2^N};


### PR DESCRIPTION
These should assert that their input argument `x` (the integer to align) is non-negative.