### PR TITLE
[all] Add LDAP/STLP instructions

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1461,8 +1461,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let load ar (r1,r2) rA =
         let a =
           match ar with
-          | Pair (Pa,_),None -> XP
-          | Pair (PaI,_),None -> AXP
+          | Pair ((`Pa),_),None -> XP
+          | Pair ((`PaIQ),_),None -> AXP
           | _ ->
              Warn.fatal
                "Illegal %s annotaton on load exclusive pair" (pp_atom ar)  in
@@ -1476,8 +1476,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let store aw r (r1,r2) rA =
         let a =
           match aw with
-          | Pair (Pa,_),_ -> YY
-          | Pair (PaI,_),_ -> LY
+          | Pair ((`Pa),_),_ -> YY
+          | Pair ((`PaIL),_),_ -> LY
           | _ ->
              Warn.fatal
                "Illegal %s annotaton on store exclusive pair" (pp_atom aw)  in
@@ -1695,7 +1695,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
          | _ -> LDN.emit_load n
        in
        emit_load
-    | Code.Pair -> emit_ldp Pa UnspecLoc
+    | Code.Pair -> emit_ldp (`Pa) UnspecLoc
 
 
     let emit_obs_not_value = OBS.emit_load_not_value
@@ -1858,8 +1858,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             Some r,init,cs,st
         | R,Some (Neon _,Some _) -> assert false
         | R,Some (Pair (opt,idx),None) ->
-          let r,init,cs,st = emit_ldp opt idx st p init loc in
-          Some r,init,cs,st
+          let ld_opt = match opt with
+            | `Pa -> `Pa | `PaN -> `PaN | `PaIQ -> `PaIQ
+            | `PaIL -> assert false
+          in
+    let r,init,cs,st = emit_ldp ld_opt idx st p init loc in
+    Some r,init,cs,st
         | R,Some (Pair _,Some _) -> assert false
         | W,None ->
             let init,cs,st =
@@ -1899,8 +1903,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let init,cs,st = STG.emit_store st p init e in
             None,init,cs,st
         | W,Some (Pair (opt,idx),None) ->
-            let init,cs,st = emit_stp opt idx st p init loc e in
-            None,init,cs,st
+            let st_opt = match opt with
+              | `Pa -> `Pa | `PaN -> `PaN | `PaIL -> `PaIL
+              | `PaIQ -> assert false
+            in
+    let init,cs,st = emit_stp st_opt idx st p init loc e in
+    None,init,cs,st
         | W,Some (Pair _,Some _) -> assert false
         | (R|W), Some (Instr, _) -> Warn.fatal "Instr annotation did not create code location %s" (C.debug_evt e)
         | R,Some (Pte (Read|ReadAcq|ReadAcqPc as rk),None) ->
@@ -2356,7 +2364,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               Some rB,init,pseudo cs0@cs,st
           | R,Some (Pair (opt,idx),None) ->
               let r,init,cs,st =
-                emit_ldp_idx_var opt idx vdep st p init loc r2 in
+                emit_ldp_idx_var (pair_opt_to_ld opt) idx vdep st p init loc r2 in
               Some r,init, pseudo cs0@cs,st
           | R,Some ((Neon _|Pair _),Some _) -> assert false
           | W,None ->
@@ -2439,9 +2447,9 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               None,init,pseudo cs0@cs,st
           | W,Some (Pair (opt,idx),None) ->
               let init,cs,st =
-                emit_stp_idx_var opt idx vdep st p init loc e r2 in
+                emit_stp_idx_var (pair_opt_to_st opt) idx vdep st p init loc e r2 in
               None,init, pseudo cs0@cs,st
-          | W,Some (Pair _,_) -> assert false
+          | W,Some (Pair _,Some _) -> assert false
           | (W,(Some (Pte (Set _),None))) ->
               let init,cs,st =
                 emit_set_pteval_idx false vdep r2 st p init (Value.to_pte e.C.v) (Misc.add_pte loc) in
@@ -2539,7 +2547,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let ar,_ = tr_none er.C.atom
       and aw,_ = tr_none ew.C.atom in
       match ar,aw with
-      | (Pair _,Pair _)->
+      | (Pair _,Pair _) ->
          emit_exch_dep_addr22 csel vdep st p init er ew rd
       | (Pair _,_) ->
          check_cu (not A64.do_cu);
@@ -2713,7 +2721,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
              None,init,cs2@cs,st
           | Some (Neon _,Some _) -> assert false
           | Some (Pair (opt,idx),None) ->
-             let init,cs,st = stp_emit_store_reg opt idx st p init loc r2 in
+             let init,cs,st = stp_emit_store_reg (pair_opt_to_st opt) idx st p init loc r2 in
              None,init,cs2@cs,st
           | Some (Pair _,Some _) -> assert false
           end

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1463,6 +1463,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           match ar with
           | Pair ((`Pa),_),None -> XP
           | Pair ((`PaIQ),_),None -> AXP
+          | Pair ((`PaA),_),None -> AXP
           | _ ->
              Warn.fatal
                "Illegal %s annotaton on load exclusive pair" (pp_atom ar)  in
@@ -1478,6 +1479,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           match aw with
           | Pair ((`Pa),_),_ -> YY
           | Pair ((`PaIL),_),_ -> LY
+          | Pair ((`PaL),_),_ -> LY
           | _ ->
              Warn.fatal
                "Illegal %s annotaton on store exclusive pair" (pp_atom aw)  in
@@ -1858,12 +1860,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             Some r,init,cs,st
         | R,Some (Neon _,Some _) -> assert false
         | R,Some (Pair (opt,idx),None) ->
-          let ld_opt = match opt with
-            | `Pa -> `Pa | `PaN -> `PaN | `PaIQ -> `PaIQ
-            | `PaIL -> assert false
-          in
-    let r,init,cs,st = emit_ldp ld_opt idx st p init loc in
-    Some r,init,cs,st
+          let r,init,cs,st = emit_ldp (pair_opt_to_ld opt) idx st p init loc in
+          Some r,init,cs,st
         | R,Some (Pair _,Some _) -> assert false
         | W,None ->
             let init,cs,st =
@@ -1903,12 +1901,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let init,cs,st = STG.emit_store st p init e in
             None,init,cs,st
         | W,Some (Pair (opt,idx),None) ->
-            let st_opt = match opt with
-              | `Pa -> `Pa | `PaN -> `PaN | `PaIL -> `PaIL
-              | `PaIQ -> assert false
-            in
-    let init,cs,st = emit_stp st_opt idx st p init loc e in
-    None,init,cs,st
+          let init,cs,st = emit_stp (pair_opt_to_st opt) idx st p init loc e in
+          None,init,cs,st
         | W,Some (Pair _,Some _) -> assert false
         | (R|W), Some (Instr, _) -> Warn.fatal "Instr annotation did not create code location %s" (C.debug_evt e)
         | R,Some (Pte (Read|ReadAcq|ReadAcqPc as rk),None) ->
@@ -2547,7 +2541,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let ar,_ = tr_none er.C.atom
       and aw,_ = tr_none ew.C.atom in
       match ar,aw with
-      | (Pair _,Pair _) ->
+      | (Pair _,Pair _)->
          emit_exch_dep_addr22 csel vdep st p init er ew rd
       | (Pair _,_) ->
          check_cu (not A64.do_cu);

--- a/gen/common/AArch64Arch_gen.ml
+++ b/gen/common/AArch64Arch_gen.ml
@@ -477,12 +477,21 @@ let is_tthm fields =
      | Some Capability -> "c"
 
    let pp_pair_opt = function
-     | Pa -> ""
-     | PaN -> "N"
-     | PaI -> "I"
+     | `Pa -> ""
+     | `PaN -> "N"
+     | `PaIQ -> "IQ"
+     | `PaIL -> "IL"
 
    and pp_pair_idx = function
      | UnspecLoc -> ""
+
+   let pair_opt_to_ld : pair_opt -> ld_pair_opt = function
+     | `Pa -> `Pa | `PaN -> `PaN | `PaIQ -> `PaIQ
+     | `PaIL -> assert false
+
+   let pair_opt_to_st : pair_opt -> st_pair_opt = function
+     | `Pa -> `Pa | `PaN -> `PaN | `PaIL -> `PaIL
+     | `PaIQ -> assert false
 
    let pp_atom_acc = function
      | Atomic rw -> sprintf "X%s" (pp_atom_rw rw)
@@ -575,15 +584,16 @@ let is_tthm fields =
      else
        fun _ r -> r
 
-      let fold_pair f r =
-        if do_mixed then r
-        else
-          let f opt idx r =
-            f (Pair (opt,idx)) r in
-          r |>
-          f Pa UnspecLoc |>
-          f PaN UnspecLoc |>
-          f PaI UnspecLoc
+    let fold_pair f r =
+      if do_mixed then r
+      else
+        let f opt idx r =
+          f (Pair (opt, idx)) r in
+        r |>
+        f `Pa UnspecLoc |>
+        f `PaN UnspecLoc |>
+        f `PaIQ UnspecLoc |>
+        f `PaIL UnspecLoc
 
       let fold_acc_opt o f r =
         let r = f (Acq o) r in

--- a/gen/common/AArch64Arch_gen.ml
+++ b/gen/common/AArch64Arch_gen.ml
@@ -240,7 +240,7 @@ type pair_idx = UnspecLoc
 type atom_acc =
   | Plain of capa_opt | Acq of capa_opt | AcqPc of capa_opt | Rel of capa_opt
   | Atomic of atom_rw | Tag | CapaTag | CapaSeal | Pte of atom_pte | Neon of neon_opt
-  | Pair of pair_opt * pair_idx | Instr
+  | Pair of [ld_pair_opt | st_pair_opt] * pair_idx | Instr
 
 let  plain = Plain None
 
@@ -446,8 +446,10 @@ let applies_atom (a,_) d =
   | Rel _,W
   | Pte (Read|ReadAcq|ReadAcqPc),R
   | Instr, R
-  | (Plain _|Atomic _|Tag|CapaTag|CapaSeal|Neon _|Pair _),(R|W)
+  | (Plain _|Atomic _|Tag|CapaTag|CapaSeal|Neon _),(R|W)
     -> true
+  | Pair ((`Pa|`PaN|`PaIQ|`PaA),_),R -> true
+  | Pair ((`Pa|`PaN|`PaIL|`PaL),_),W -> true
   (* special case for TTHM HA for read *)
   | Pte (Set p),R when WPTESet.mem HA p -> true
   | Pte (ReadHAAcq|ReadHAAcqPc),R -> true
@@ -481,17 +483,19 @@ let is_tthm fields =
      | `PaN -> "N"
      | `PaIQ -> "IQ"
      | `PaIL -> "IL"
+     | `PaA -> "A"
+     | `PaL -> "L"
 
    and pp_pair_idx = function
      | UnspecLoc -> ""
 
-   let pair_opt_to_ld : pair_opt -> ld_pair_opt = function
-     | `Pa -> `Pa | `PaN -> `PaN | `PaIQ -> `PaIQ
-     | `PaIL -> assert false
+   let pair_opt_to_ld : [ld_pair_opt | st_pair_opt] -> ld_pair_opt = function
+     | `Pa -> `Pa | `PaN -> `PaN | `PaIQ -> `PaIQ | `PaA -> `PaA
+     | `PaIL | `PaL -> assert false
 
-   let pair_opt_to_st : pair_opt -> st_pair_opt = function
-     | `Pa -> `Pa | `PaN -> `PaN | `PaIL -> `PaIL
-     | `PaIQ -> assert false
+   let pair_opt_to_st : [ld_pair_opt | st_pair_opt] -> st_pair_opt = function
+     | `Pa -> `Pa | `PaN -> `PaN | `PaIL -> `PaIL | `PaL -> `PaL
+     | `PaIQ | `PaA -> assert false
 
    let pp_atom_acc = function
      | Atomic rw -> sprintf "X%s" (pp_atom_rw rw)
@@ -584,16 +588,18 @@ let is_tthm fields =
      else
        fun _ r -> r
 
-    let fold_pair f r =
-      if do_mixed then r
-      else
-        let f opt idx r =
-          f (Pair (opt, idx)) r in
-        r |>
-        f `Pa UnspecLoc |>
-        f `PaN UnspecLoc |>
-        f `PaIQ UnspecLoc |>
-        f `PaIL UnspecLoc
+      let fold_pair f r =
+        if do_mixed then r
+        else
+          let f opt idx r =
+            f (Pair (opt, idx)) r in
+          r |>
+          f `Pa UnspecLoc |>
+          f `PaN UnspecLoc |>
+          f `PaIQ UnspecLoc |>
+          f `PaIL UnspecLoc |>
+          f `PaA UnspecLoc |>
+          f `PaL UnspecLoc
 
       let fold_acc_opt o f r =
         let r = f (Acq o) r in

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -866,42 +866,60 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
                   "rt_unknown" ^= litb false;
                   "wb_unknown" ^= litb false;
                 ] )
-      | I_LDP (pa, v, rt, rt2, rn, (k, idx))
-      | I_STP (pa, v, rt, rt2, rn, (k, idx))
-        ->
-          let wback, postindex = decode_wback_postindex idx in
-          let fname =
-            match pa, ii.A.inst with
-            | Pa, I_LDP _ -> "ldstpair_post/LDP_32_ldstpair_post.opn"
-            | Pa, I_STP _ -> "ldstpair_post/STP_32_ldstpair_post.opn"
-            | PaI, I_LDP _ -> "ldiappstilp/LDIAPP_32LE_ldiappstilp.opn"
-            | PaI, I_STP _ -> "ldiappstilp/STILP_32SE_ldiappstilp.opn"
-            | PaN, I_LDP _ -> "ldstnapair_offs/LDNP_32_ldstnapair_offs.opn"
-            | PaN, I_STP _ -> "ldstnapair_offs/STNP_32_ldstnapair_offs.opn"
-            | _ -> assert false
-          and acqrel =
-            match ii.A.inst with
-            | I_LDP _ -> pa = PaI && rt != ZR && rt2 != ZR
-            | _ -> false
-          and offset = if pa = PaI then liti k else litbv 64 k in
-          Some
-            ( "ldst/" ^ fname,
-              stmt
-                [
-                  "wback" ^= litb wback;
-                  "postindex" ^= litb postindex;
-                  "ispair" ^= litb true;
-                  "t" ^= reg rt;
-                  "t2" ^= reg rt2;
-                  "n" ^= reg rn;
-                  "datasize" ^= variant v;
-                  "nontemporal" ^= litb (pa = PaN);
-                  "offset" ^= offset;
-                  "tagchecked" ^= litb (wback || rn <> SP);
-                  "acqrel" ^= litb acqrel;
-                  "rt_unknown" ^= litb false;
-                  "wb_unknown" ^= litb false;
-                ])
+      | I_LDP (pa, v, rt, rt2, rn, (k, idx)) ->
+        let wback, postindex = decode_wback_postindex idx in
+        let fname =
+          match pa with
+          | `Pa -> "ldstpair_post/LDP_32_ldstpair_post.opn"
+          | `PaIQ -> "ldiappstilp/LDIAPP_32LE_ldiappstilp.opn"
+          | `PaN -> "ldstnapair_offs/LDNP_32_ldstnapair_offs.opn"
+        and acquire = pa = `PaIQ && rt != ZR && rt2 != ZR
+        and offset = if pa = `PaIQ then liti k else litbv 64 k in
+        Some
+          ( "ldst/" ^ fname,
+            stmt
+              [
+                "wback" ^= litb wback;
+                "postindex" ^= litb postindex;
+                "ispair" ^= litb true;
+                "t" ^= reg rt;
+                "t2" ^= reg rt2;
+                "n" ^= reg rn;
+                "datasize" ^= variant v;
+                "nontemporal" ^= litb (pa = `PaN);
+                "offset" ^= offset;
+                "tagchecked" ^= litb (wback || rn <> SP);
+                "acquire" ^= litb acquire;
+                "rt_unknown" ^= litb false;
+                "wb_unknown" ^= litb false;
+              ])
+      | I_STP (pa, v, rt, rt2, rn, (k, idx)) ->
+        let wback, postindex = decode_wback_postindex idx in
+        let fname =
+          match pa with
+          | `Pa -> "ldstpair_post/STP_32_ldstpair_post.opn"
+          | `PaIL -> "ldiappstilp/STILP_32SE_ldiappstilp.opn"
+          | `PaN -> "ldstnapair_offs/STNP_32_ldstnapair_offs.opn"
+        and acquire = false
+        and offset = if pa = `PaIL then liti k else litbv 64 k in
+        Some
+          ( "ldst/" ^ fname,
+            stmt
+              [
+                "wback" ^= litb wback;
+                "postindex" ^= litb postindex;
+                "ispair" ^= litb true;
+                "t" ^= reg rt;
+                "t2" ^= reg rt2;
+                "n" ^= reg rn;
+                "datasize" ^= variant v;
+                "nontemporal" ^= litb (pa = `PaN);
+                "offset" ^= offset;
+                "tagchecked" ^= litb (wback || rn <> SP);
+                "acquire" ^= litb acquire;
+                "rt_unknown" ^= litb false;
+                "wb_unknown" ^= litb false;
+              ])
       | I_LDRS ((v, bh), rt, rn, MemExt.Reg (_vm, rm, e, s)) ->
           let fname =
             match bh with

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -224,6 +224,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
       let variant v = AArch64Base.variant_raw v |> liti in
       let cond c = tr_cond c |> litbv 4 in
       let stmt = Asllib.ASTUtils.stmt_from_list in
+      let pass = with_pos S_Pass in
       let open AArch64Base in
       let reg = function
         (* To use with caution, sometimes it doesn't work. *)
@@ -873,7 +874,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
           | `Pa -> "ldstpair_post/LDP_32_ldstpair_post.opn"
           | `PaIQ -> "ldiappstilp/LDIAPP_32LE_ldiappstilp.opn"
           | `PaN -> "ldstnapair_offs/LDNP_32_ldstnapair_offs.opn"
-        and acquire = pa = `PaIQ && rt != ZR && rt2 != ZR
+          | `PaA -> "ldiappstilp/LDAP_64_ldiappstilp.opn"
         and offset = if pa = `PaIQ then liti k else litbv 64 k in
         Some
           ( "ldst/" ^ fname,
@@ -889,7 +890,10 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
                 "nontemporal" ^= litb (pa = `PaN);
                 "offset" ^= offset;
                 "tagchecked" ^= litb (wback || rn <> SP);
-                "acquire" ^= litb acquire;
+                (match pa with
+                  | `Pa | `PaN -> pass
+                  | (`PaA) -> "acquire" ^= litb true
+                  | (`PaIQ) -> "acqrel" ^= litb true);
                 "rt_unknown" ^= litb false;
                 "wb_unknown" ^= litb false;
               ])
@@ -900,7 +904,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
           | `Pa -> "ldstpair_post/STP_32_ldstpair_post.opn"
           | `PaIL -> "ldiappstilp/STILP_32SE_ldiappstilp.opn"
           | `PaN -> "ldstnapair_offs/STNP_32_ldstnapair_offs.opn"
-        and acquire = false
+          | `PaL -> "ldiappstilp/STLP_64_ldiappstilp.opn"
         and offset = if pa = `PaIL then liti k else litbv 64 k in
         Some
           ( "ldst/" ^ fname,
@@ -916,7 +920,10 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
                 "nontemporal" ^= litb (pa = `PaN);
                 "offset" ^= offset;
                 "tagchecked" ^= litb (wback || rn <> SP);
-                "acquire" ^= litb acquire;
+                (match pa with
+                  | `Pa | `PaN -> pass
+                  | (`PaL) -> "acquire" ^= litb true
+                  | (`PaIL) -> "acqrel" ^= litb true);
                 "rt_unknown" ^= litb false;
                 "wb_unknown" ^= litb false;
               ])

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2008,6 +2008,7 @@ Arguments:
               let open Annot in
               match tnt with
               | (`PaIQ) -> Q
+              | (`PaA) -> A
               | (`Pa) -> N
               | (`PaN) -> NTA in
             let open AArch64 in
@@ -2151,14 +2152,14 @@ Arguments:
           let open AArch64 in
           let open Annot in
           match tnt with
-          | (`PaIL) -> L
+          | (`PaIL) | (`PaL) -> L
           | (`Pa) -> N
           | (`PaN) -> NTA in
         match md with
         | AArch64.Idx ->
             let (>>|) =
               match tnt with
-              | AArch64.(`Pa|`PaN) -> (>>|)
+              | AArch64.(`Pa|`PaN|`PaL) -> (>>|)
               | AArch64.(`PaIL) -> M.seq_mem in
             let (>>>) = M.data_input_next in
             do_str rd

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -2007,9 +2007,9 @@ Arguments:
               let open AArch64 in
               let open Annot in
               match tnt with
-              | Pa -> N
-              | PaN -> NTA
-              | PaI -> Q in
+              | (`PaIQ) -> Q
+              | (`Pa) -> N
+              | (`PaN) -> NTA in
             let open AArch64 in
             match md with
             | Idx ->
@@ -2045,7 +2045,7 @@ Arguments:
             (struct
               let read_mem = do_read_mem_op sxtw_op
             end) in
-        LDPSW.ldp AArch64.Pa MachSize.Word
+        LDPSW.ldp AArch64.(`Pa) MachSize.Word
 
       let ldxp sz t rd1 rd2 rs ii =
         let open AArch64 in
@@ -2151,15 +2151,15 @@ Arguments:
           let open AArch64 in
           let open Annot in
           match tnt with
-          | Pa -> N
-          | PaN -> NTA
-          | PaI -> L in
+          | (`PaIL) -> L
+          | (`Pa) -> N
+          | (`PaN) -> NTA in
         match md with
         | AArch64.Idx ->
             let (>>|) =
               match tnt with
-              | AArch64.(Pa|PaN) -> (>>|)
-              | AArch64.PaI -> M.seq_mem in
+              | AArch64.(`Pa|`PaN) -> (>>|)
+              | AArch64.(`PaIL) -> M.seq_mem in
             let (>>>) = M.data_input_next in
             do_str rd
               (fun ac a _ ii ->

--- a/herd/tests/instructions/AArch64/Y006.litmus
+++ b/herd/tests/instructions/AArch64/Y006.litmus
@@ -1,0 +1,15 @@
+AArch64 Y006
+{
+ uint64_t x=0;
+ uint64_t y[2]={0,0};
+ 0:X0=x; 0:X1=y;
+ 1:X0=y; 1:X2=x;
+ uint64_t 1:X3; uint64_t 1:X4;
+}
+ P0              | P1              ;
+ MOV X2,#1       | LDAP X3,X4,[X0] ;
+ STR X2,[X0]     | LDR X5,[X2]     ;
+ MOV X3,#1       |                 ;
+ MOV X4,#99      |                 ;
+ STLP X3,X4,[X1] |                 ;
+exists (1:X3=1 /\ 1:X4=99 /\ 1:X5=0)

--- a/herd/tests/instructions/AArch64/Y006.litmus.expected
+++ b/herd/tests/instructions/AArch64/Y006.litmus.expected
@@ -1,0 +1,14 @@
+Test Y006 Allowed
+States 5
+1:X3=0; 1:X4=0; 1:X5=0;
+1:X3=0; 1:X4=0; 1:X5=1;
+1:X3=0; 1:X4=99; 1:X5=1;
+1:X3=1; 1:X4=0; 1:X5=1;
+1:X3=1; 1:X4=99; 1:X5=1;
+No
+Witnesses
+Positive: 0 Negative: 5
+Condition exists (1:X3=1 /\ 1:X4=99 /\ 1:X5=0)
+Observation Y006 Never 0 5
+Hash=bca78e0617eea4b1c2d22dd057fca71e
+

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -189,12 +189,12 @@ include Arch.MakeArch(struct
         add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')]
 
     | I_LDP (t,a,r1,r2,r3,idx),I_LDP (t',a',r1',r2',r3',idx')
-        when ld_pair_opt_eq t t' && a=a'
+         when ld_pair_opt_eq t t' && a=a'
       ->
        match_idx idx idx' subs >>>
        add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2'); Reg (sr_name r3,r3')]
     | I_STP (t,a,r1,r2,r3,idx),I_STP (t',a',r1',r2',r3',idx')
-        when st_pair_opt_eq t t' && a=a'
+         when st_pair_opt_eq t t' && a=a'
       ->
        match_idx idx idx' subs >>>
        add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2'); Reg (sr_name r3,r3')]

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -189,8 +189,12 @@ include Arch.MakeArch(struct
         add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2')]
 
     | I_LDP (t,a,r1,r2,r3,idx),I_LDP (t',a',r1',r2',r3',idx')
+        when ld_pair_opt_eq t t' && a=a'
+      ->
+       match_idx idx idx' subs >>>
+       add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2'); Reg (sr_name r3,r3')]
     | I_STP (t,a,r1,r2,r3,idx),I_STP (t',a',r1',r2',r3',idx')
-         when t=t' && a=a'
+        when st_pair_opt_eq t t' && a=a'
       ->
        match_idx idx idx' subs >>>
        add_subs [Reg(sr_name r1,r1'); Reg(sr_name r2,r2'); Reg (sr_name r3,r3')]

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1232,7 +1232,23 @@ let tr_simd_variant = function
 let simd_variant_nbytes v = tr_simd_variant v |> MachSize.nbytes
 
 type temporal = TT | NT
-type pair_opt = Pa | PaN | PaI
+type pair_opt = [`Pa | `PaN | `PaIQ | `PaIL]
+type ld_pair_opt = [`Pa | `PaN | `PaIQ]
+type st_pair_opt = [`Pa | `PaN | `PaIL]
+
+let ld_pair_opt_eq (a: ld_pair_opt) (b: ld_pair_opt) : bool =
+  match (a, b) with
+  | (`Pa, `Pa)
+  | (`PaN, `PaN)
+  | (`PaIQ, `PaIQ) -> true
+  | _ -> false
+
+let st_pair_opt_eq (a: st_pair_opt) (b: st_pair_opt) : bool =
+  match (a, b) with
+  | (`Pa, `Pa)
+  | (`PaN, `PaN)
+  | (`PaIL, `PaIL) -> true
+  | _ -> false
 
 type ld_type = AA | XX | AX | AQ
 
@@ -1249,14 +1265,14 @@ let ldxp_memo = function
   | AXP -> "LDAXP"
 
 let ldp_memo = function
-  | Pa -> "LDP"
-  | PaN -> "LDNP"
-  | PaI -> "LDIAPP"
+  | `Pa -> "LDP"
+  | `PaN -> "LDNP"
+  | `PaIQ -> "LDIAPP"
 
 let stp_memo = function
-  | Pa -> "STP"
-  | PaN -> "STNP"
-  | PaI -> "STILP"
+  | `Pa -> "STP"
+  | `PaN -> "STNP"
+  | `PaIL -> "STILP"
 
 type st_type = YY | LY
 
@@ -1420,13 +1436,13 @@ type 'k kinstruction =
   | I_ADD_SIMD of reg * reg * reg
   | I_ADD_SIMD_S of reg * reg * reg
   (* More loads *)
-  | I_LDP of pair_opt * variant * reg * reg * reg * 'k idx
+  | I_LDP of ld_pair_opt * variant * reg * reg * reg * 'k idx
   | I_LDPSW of reg * reg * reg * 'k idx
   | I_LDAR of variant * ld_type * reg * reg
   | I_LDXP of variant * ldxp_type * reg * reg * reg
   (* Stores *)
   | I_STR of variant * reg * reg * 'k MemExt.ext
-  | I_STP of pair_opt * variant * reg * reg * reg * 'k idx
+  | I_STP of st_pair_opt * variant * reg * reg * reg * 'k idx
   | I_STLR of variant * reg * reg
   | I_STXR of variant * st_type * reg * reg * reg
   | I_STXP of variant * st_type * reg * reg * reg * reg

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1232,22 +1232,23 @@ let tr_simd_variant = function
 let simd_variant_nbytes v = tr_simd_variant v |> MachSize.nbytes
 
 type temporal = TT | NT
-type pair_opt = [`Pa | `PaN | `PaIQ | `PaIL]
-type ld_pair_opt = [`Pa | `PaN | `PaIQ]
-type st_pair_opt = [`Pa | `PaN | `PaIL]
+type ld_pair_opt = [`Pa | `PaN | `PaIQ | `PaA]
+type st_pair_opt = [`Pa | `PaN | `PaIL | `PaL]
 
 let ld_pair_opt_eq (a: ld_pair_opt) (b: ld_pair_opt) : bool =
   match (a, b) with
   | (`Pa, `Pa)
   | (`PaN, `PaN)
-  | (`PaIQ, `PaIQ) -> true
+  | (`PaIQ, `PaIQ)
+  | (`PaA, `PaA) -> true
   | _ -> false
 
 let st_pair_opt_eq (a: st_pair_opt) (b: st_pair_opt) : bool =
   match (a, b) with
   | (`Pa, `Pa)
   | (`PaN, `PaN)
-  | (`PaIL, `PaIL) -> true
+  | (`PaIL, `PaIL) 
+  | (`PaL, `PaL) -> true
   | _ -> false
 
 type ld_type = AA | XX | AX | AQ
@@ -1268,11 +1269,13 @@ let ldp_memo = function
   | `Pa -> "LDP"
   | `PaN -> "LDNP"
   | `PaIQ -> "LDIAPP"
+  | `PaA -> "LDAP"
 
 let stp_memo = function
   | `Pa -> "STP"
   | `PaN -> "STNP"
   | `PaIL -> "STILP"
+  | `PaL -> "STLP"
 
 type st_type = YY | LY
 
@@ -3440,6 +3443,16 @@ let is_valid i =
   | I_LDAR (_,_,_,ZR)
   | I_STXR (_,_,_,_,ZR)
     -> false
+  | I_LDP ((`PaA),v,_,_,_,(k,idx)) ->
+    begin match v,k,idx with
+    | (V64,0,Idx) -> true
+    | _ -> false
+    end
+  | I_STP ((`PaL),v,_,_,_,(k,idx)) ->
+    begin match v,k,idx with
+    | (V64,0,Idx) -> true
+    | _ -> false
+    end
   | I_LDRBH (_,_,ZR,_)
   | I_STRBH (_,_,ZR,_)
   | I_LDRBH (_,_,_,MemExt.(Reg(V32,_,LSL,_)))

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -92,9 +92,11 @@ let keyword_list = [
   "ldpsw", LDPSW;
   "ldnp", LDNP;
   "ldiapp", LDIAPP;
+  "ldap", LDAP;
   "stp", STP;
   "stnp", STNP;
   "stilp", STILP;
+  "stlp", STLP;
   "ldrb", LDRB;
   "ldrh", LDRH;
   "ldrsb", LDRSB;

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -566,9 +566,9 @@ zeroopt:
 
 ldp_instr:
 | LDP
-  { (fun v r1 r2 (r3,idx) -> I_LDP (Pa,v,r1,r2,r3,idx)) }
+  { (fun v r1 r2 (r3,idx) -> I_LDP ((`Pa),v,r1,r2,r3,idx)) }
 | LDNP
-  { (fun v r1 r2 (r3,idx) -> I_LDP (PaN,v,r1,r2,r3,idx)) }
+  { (fun v r1 r2 (r3,idx) -> I_LDP ((`PaN),v,r1,r2,r3,idx)) }
 | LDIAPP
   {
    (fun v r1 r2 (r3,idx) ->
@@ -577,7 +577,7 @@ ldp_instr:
      | (V32,(MetaConst.Int 8,PostIdx))
      | (V64,(MetaConst.Int 16,PostIdx))
           ->
-            I_LDP (PaI,v,r1,r2,r3,idx)
+            I_LDP ((`PaIQ),v,r1,r2,r3,idx)
       | _,_ -> raise Parsing.Parse_error)
   }
 
@@ -589,9 +589,9 @@ ldp_simd_instr:
 
 stp_instr:
 | STP
-  { (fun v r1 r2 (r3,idx) -> I_STP (Pa,v,r1,r2,r3,idx)) }
+  { (fun v r1 r2 (r3,idx) -> I_STP ((`Pa),v,r1,r2,r3,idx)) }
 | STNP
-  { (fun v r1 r2 (r3,idx) -> I_STP (PaN,v,r1,r2,r3,idx)) }
+  { (fun v r1 r2 (r3,idx) -> I_STP ((`PaN),v,r1,r2,r3,idx)) }
 | STILP
     {
      (fun v r1 r2 (r3,idx) ->
@@ -600,7 +600,7 @@ stp_instr:
       | (V32,(MetaConst.Int (-8),PreIdx))
       | (V64,(MetaConst.Int (-16),PreIdx))
           ->
-            I_STP (PaI,v,r1,r2,r3,idx)
+            I_STP ((`PaIL),v,r1,r2,r3,idx)
       | _, _ -> raise Parsing.Parse_error)
     }
 

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -98,6 +98,7 @@ let check_op3 op e =
 %token SVC
 %token LDR LDRSW LDP LDNP LDPSW LDIAPP STP STNP STILP
 %token LDRB LDRH LDUR STR STRB STRH STLR STLRB STLRH
+%token LDAP STLP
 %token LDRSB LDRSH
 %token LD1 LD1R LDAP1 LD2 LD2R LD3 LD3R LD4 LD4R STL1 ST1 ST2 ST3 ST4 STUR /* Neon load/store */
 %token ADDV DUP FMOV LDAPUR STLUR
@@ -569,6 +570,8 @@ ldp_instr:
   { (fun v r1 r2 (r3,idx) -> I_LDP ((`Pa),v,r1,r2,r3,idx)) }
 | LDNP
   { (fun v r1 r2 (r3,idx) -> I_LDP ((`PaN),v,r1,r2,r3,idx)) }
+| LDAP
+  { (fun v r1 r2 (r3,idx) -> I_LDP ((`PaA),v,r1,r2,r3,idx)) }
 | LDIAPP
   {
    (fun v r1 r2 (r3,idx) ->
@@ -592,6 +595,8 @@ stp_instr:
   { (fun v r1 r2 (r3,idx) -> I_STP ((`Pa),v,r1,r2,r3,idx)) }
 | STNP
   { (fun v r1 r2 (r3,idx) -> I_STP ((`PaN),v,r1,r2,r3,idx)) }
+| STLP
+  { (fun v r1 r2 (r3,idx) -> I_STP ((`PaL),v,r1,r2,r3,idx)) }
 | STILP
     {
      (fun v r1 r2 (r3,idx) ->


### PR DESCRIPTION
Adds support for LDAP (Load-Acquire Pair) and STLP (Store-Release Pair) instructions to herd.

#### Summary

LDAP Xt1, Xt2, [Xn]:  Load-Acquire Pair. Both loads take Acquire ordering, subsequent memory accesses on the same thread cannot be reordered before the pair.
STLP Xt1, Xt2, [Xn]: Store-Release Pair. The pair takes Release ordering, earlier memory accesses cannot be reordered after it.

The existing `pair_opt = Pa | PaN | PaI` is refactored into polymorphic variants split by direction:  `ld_pair_opt` gains \`PaA (LDAP) and `st_pair_opt` gains \`PaL (STLP), while the old \`PaI is split into \`PaIQ (load side) and \`PaIL (store side). Polymorphic variants let load-only and store-only tags be enforced at the instruction level on I_LDP / I_STP without duplicating constructors like `Pa` and `PaN`, which are used on both the store and load directions.

#### Test Added:
`Y006.litmus` is a message-passing test with STLP as writer and LDAP as reader:

If the Release on the STLP and the Acquire on the LDAP compose correctly, then observing the second element of the pair (1:X3=1) must imply observing the preceding store, so 1:X5=0 should be impossible.