### PR TITLE
[herd] More implicit transitive relations in the Cat interpreter

### DIFF
--- a/herd/Pretty.ml
+++ b/herd/Pretty.ml
@@ -74,19 +74,6 @@ module Make (S:SemExtra.S) : S with module S = S  = struct
   | Graph.Columns -> PC.oneinit
   | Graph.Free|Graph.Cluster -> false
 
-(* Attempt *)
-
-  let _reduces_more r1 r2 =
-    let open E.EventRel in
-    restrict_domain
-      (fun e1 ->
-        not
-          (E.EventSet.is_empty (succs r2 e1)) &&
-        not
-          (E.EventSet.is_empty (preds r2 e1)))
-      r1
-
-
   open PrettyConf
   open PPMode
 
@@ -551,11 +538,7 @@ module Make (S:SemExtra.S) : S with module S = S  = struct
              E.EventSet.union min min2,E.EventSet.union max max2) p ess
           )
         (E.EventSet.empty, E.EventSet.empty) by_proc_and_poi in
-     let r =
-       E.EventRel.restrict_domains
-         (fun e1 -> E.EventSet.mem e1 maxs)
-         (fun e2 -> E.EventSet.mem e2 mins) po
-     in
+     let r = E.EventRel.restrict_domains_to_sets maxs mins po in
      if dbg then
        eprintf "make_visible_po {%a} => \n {%a} \n%!" E.debug_rel po0 E.debug_rel r;
      r

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -1971,9 +1971,8 @@ let get_rf_value test read =
             (*jade: looks compatible with speculation, but there might be some
               unforeseen subtlety here so flagging it to be sure*)
              let ppoloc =
-               E.EventRel.restrict_rel
-                 (fun e1 e2 -> E.is_explicit e1 && E.is_explicit e2)
-                 ppoloc in
+               E.EventRel.restrict_domains
+                 E.is_explicit E.is_explicit ppoloc in
                match U.compute_pco rfm ppoloc with
                | None -> raise Exit
                | Some pco -> E.EventRel.union pco0 pco in

--- a/lib/ASTUtils.ml
+++ b/lib/ASTUtils.ml
@@ -227,3 +227,10 @@ let as_plus = function
         with Exit -> None
       end
   | _ -> None
+
+let rec check_accept_implicit = function
+  | Var _|Op1 (_,(Plus|Star|Opt|Inv),_) -> true
+  | Bind (_,_,e)|BindRec (_,_,e) -> check_accept_implicit e
+  | If (_,_,e1,e2) ->
+      check_accept_implicit e1 || check_accept_implicit e2
+  | _ -> false

--- a/lib/ASTUtils.mli
+++ b/lib/ASTUtils.mli
@@ -30,3 +30,7 @@ val flatten : AST.exp -> AST.exp
 
 (* Get free variables *)
 val free_body : AST.var option list -> AST.exp -> AST.varset
+
+(* Is a recursive binding equivalent to transitive closure? *)
+val as_plus : AST.binding list -> (AST.var * AST.exp list)  option
+    

--- a/lib/ASTUtils.mli
+++ b/lib/ASTUtils.mli
@@ -34,3 +34,9 @@ val free_body : AST.var option list -> AST.exp -> AST.varset
 (* Is a recursive binding equivalent to transitive closure? *)
 val as_plus : AST.binding list -> (AST.var * AST.exp list)  option
     
+(* Is it possible that the evaluaton of this expression returns
+ * and implicit transitive relation?
+ * Notice that this function is used for optimisation purposes
+ *  and this need not to be complete, nor even correct...
+ *)
+val check_accept_implicit : AST.exp -> bool

--- a/lib/innerRel.ml
+++ b/lib/innerRel.ml
@@ -682,10 +682,7 @@ module Make(O:MySet.OrderedType) : S
     (* Strata *)
 
     let strata es r =
-      let m =
-        restrict_rel
-          (fun e1 e2 -> Elts.mem e1 es && Elts.mem e2 es)
-          r in
+      let m = restrict_domains_to_sets es es r in
       let nss = M.fold (fun _ ns k -> ns::k) m [] in
       let st0 = Elts.diff es (Elts.unions nss) in
       if Elts.is_empty st0 then [es]

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -288,9 +288,11 @@ module Make
         | Tuple of  v list
 
       and env =
-          { vals  : v Lazy.t StringMap.t;
-            enums : string list StringMap.t;
-            tags  : string StringMap.t; }
+        { vals  : v Lazy.t StringMap.t; (* Standard bindings *)
+          (* Optionnal bindigs for (implicit) transitive relations *)
+          trans : v Lazy.t StringMap.t;
+          enums : string list StringMap.t;
+          tags  : string StringMap.t; }
       and closure =
           { clo_args : AST.pat ;
             mutable clo_env : env ;
@@ -322,7 +324,8 @@ module Make
         | Tuple of v list
 
       and env =
-          { vals  : v  Lazy.t StringMap.t;
+          { vals  : v Lazy.t StringMap.t;
+            trans : v Lazy.t StringMap.t;
             enums : string list StringMap.t;
             tags  : string StringMap.t; }
       and  closure =
@@ -509,6 +512,7 @@ module Make
 
     let env_empty =
       {vals=StringMap.empty;
+       trans=StringMap.empty;
        enums=StringMap.empty;
        tags=StringMap.empty; }
 
@@ -690,8 +694,15 @@ module Make
       end
 
     let find_env_loc loc env k =
-      try  find_env env.EV.env k
+      try find_env env.EV.env k
       with Misc.UserError msg -> error env.EV.silent loc "%s" msg
+
+    let find_env_loc_trans loc env k =
+      let e = env.EV.env in
+      try Lazy.force @@ StringMap.find k e.trans
+      with Not_found ->
+        try find_env e k
+        with Misc.UserError msg -> error env.EV.silent loc "%s" msg
 
 (* find without forcing lazy's *)
     let just_find_env fail loc env k =
@@ -811,7 +822,8 @@ module Make
 (* Tests are polymorphic, acting on relations, class relations and sets *)
     let test2pred env t e v = match t,v with
     | (Acyclic,(Rel r|TransRel r))
-    | (Irreflexive,TransRel r)  -> E.EventRel.is_acyclic r
+    | (Irreflexive,TransRel r)  ->
+        E.EventRel.is_acyclic r
     | Acyclic,ClassRel r -> ClassRel.is_acyclic r
     | Irreflexive,Rel r -> E.EventRel.is_irreflexive r
     | Irreflexive,ClassRel r -> ClassRel.is_irreflexive r
@@ -1290,10 +1302,20 @@ module Make
               error env.EV.silent loc "tag '%s is undefined" s
             end
         | Var (loc,k) ->
-            find_env_loc loc env k
+            if accept_implicit then
+              find_env_loc_trans loc env k
+            else
+              find_env_loc loc env k
         | Fun (loc,xs,body,name,fvs) ->
             Clo (eval_fun false env loc xs body name fvs)
 (* Unary operators *)
+        | Op1 (_,Plus,Op (_,Union,es)) ->
+            begin
+              match eval_union_plus env es with
+              | TransRel r when not accept_implicit ->
+                  Rel (E.EventRel.transitive_closure r)
+              | v -> v
+            end
         | Op1 (_,Plus,e) ->
             begin match eval true env e with
             | V.Empty -> V.Empty
@@ -1703,6 +1725,28 @@ module Make
             if eval_cond loc env cond then eval accept_implicit env ifso
             else eval accept_implicit env ifnot
 
+(*
+ * Evaluation of `(e1|..|en)+`
+ * Hence, `e1`, ...,`en` must be relations.
+ *)
+      and eval_union_plus env es =
+        try
+          let rs =
+            List.fold_right
+              (fun e k ->
+                 match eval true env e with
+                 | TransRel r (*  `(..|ei+|...)+` = `(...|ei|...)+` *)
+                 | Rel r -> r::k
+                 | V.Empty -> k
+                 | V.Unv -> raise Exit
+                 | v ->
+                     error_rel env.EV.silent (get_loc e) v)
+              es [] in
+          match rs with
+          | [] -> V.Empty
+          | _ -> TransRel (E.EventRel.unions rs)
+        with Exit -> Unv
+
       and eval_diff env loc e1 e2 =
         let loc1,v1 = eval_ord_loc env e1
         and loc2,v2 = eval_ord_loc env e2 in
@@ -2013,7 +2057,7 @@ module Make
           end ;
           let env,ws = fix_step env_bd env bds in
           let env = env_rec_funs { env_bd with EV.env=env;} loc funs in
-          let check_ok = check { env_bd with EV.env=env; } in
+          let check_ok = check {  env_bd with EV.env=env; } in
           if not check_ok then begin
             if O.debug then warn loc "Fix point interrupted" ;
             CheckFailed env
@@ -2214,7 +2258,7 @@ module Make
       let eval_test check env t e =
         let accept_implicit =
           match t with
-          | Yes Acyclic|No Acyclic -> true
+          | Yes (Acyclic|Irreflexive)|No (Acyclic|Irreflexive) -> true
           | _ -> false in
         check (test2pred env t e (eval_rel_set accept_implicit env e)) in
 
@@ -2337,44 +2381,63 @@ module Make
               let st = check_bell_order bds st in
               kont st res
           | Rec (loc,bds,testo) ->
-              let env =
-                match
-                  env_rec
-                    (make_eval_test testo) (from_st st)
-                    loc (fun pp -> pp@show_to_vbpp st) bds
-                with
-                | CheckOk env -> Some env
-                | CheckFailed env ->
-                    if O.debug then begin
+              begin
+                match testo,ASTUtils.as_plus bds with
+                | None,Some (x,es) ->
+                    let env = from_st st in
+                    let v = lazy (eval_union_plus env es) in
+                    let env = env.EV.env in
+                    let trans = StringMap.add x v env.trans
+                    and vals =
+                      let w =
+                        lazy begin
+                          match Lazy.force v with
+                          | TransRel r ->
+                              Rel (E.EventRel.transitive_closure r)
+                          | v -> v
+                        end in
+                      StringMap.add x w env.vals in
+                    let env = { env with vals; trans; } in
+                    kont { st with env; } res
+                | _,_ ->
+                    let env =
+                      match
+                        env_rec
+                          (make_eval_test testo) (from_st st)
+                          loc (fun pp -> pp@show_to_vbpp st) bds
+                      with
+                      | CheckOk env -> Some env
+                      | CheckFailed env ->
+                          if O.debug then begin
                       let st = { st with env; } in
                       let st = doshow bds st in
                       pp_check_failure st (Misc.as_some testo)
                     end ;
-                    None in
-              begin match env with
-              | None -> kfail res
-              | Some env ->
-                  let st = { st with env; } in
-                  let st = doshow bds st in
-
-(* Check again for strictskip *)
-                  let st = match testo with
-                  | None -> st
-                  | Some (_,_,t,e,name) ->
-                      if
-                        O.strictskip &&
-                        skip_this_check name &&
-                        not (eval_test Misc.identity (from_st st) t e)
-                      then begin
-                        { st with
-                          skipped =
-                          StringSet.add (Misc.as_some name) st.skipped;}
+                          None in
+                    begin match env with
+                      | None -> kfail res
+                      | Some env ->
+                          let st = { st with env; } in
+                          let st = doshow bds st in
+                          (* Check again for strictskip *)
+                          let st = match testo with
+                            | None -> st
+                            | Some (_,_,t,e,name) ->
+                                if
+                                  O.strictskip &&
+                                  skip_this_check name &&
+                                  not (eval_test Misc.identity (from_st st) t e)
+                                then begin
+                                  { st with
+                                    skipped =
+                                      StringSet.add
+                                        (Misc.as_some name) st.skipped;}
                       end else st in
-(* Check bell definitions *)
-                  let st = check_bell_order bds st in
-                  kont st res
+                          (* Check bell definitions *)
+                          let st = check_bell_order bds st in
+                          kont st res
+                    end
               end
-
           | InsMatch (loc,e,cls,d) ->
               let v = eval_st st e in
               begin match v with


### PR DESCRIPTION
We notice that `(...|r+|...)+` is `(...|r|...)+` and thus also that irrefexivity of  `(...|r+|...)+` is equivalent to acyclicity  of `(...|r|...)`
    
The process may be interesting because we also identify some of the recursive definitions that are equivalent to a transitive closure and represent them as (implicit) transitive closure, thereby saving some transitive closure operations.

However, to avoid the repetive evaluation of bound implicit transitive closures to explicit ones, we rely on an additionnal environment for implicitly   transitive relations, introducing minor extra costs.

 In the end, improvements are barely noticeable, but the interpreter should gain as regards performance robustness.