### PR TITLE
[litmus] Enable check_dic_idc for PreSi and Kvm modes

### DIFF
--- a/Makefile.aarch64
+++ b/Makefile.aarch64
@@ -149,7 +149,13 @@ litmus-aarch64-run:: litmus-cata-aarch64-ifetch-test-kvm
 
 litmus-cata-aarch64-ifetch-test-kvm: litmus-aarch64-dep
 	mkdir $(KUT_DIR_AARCH64)/kvm-unit-tests/t
-	if $(RUN_TESTS); then NORUN=UDF+2FH; else NORUN=NO; fi ; \
+	if $(RUN_TESTS); then                                         \
+	  NORUN=UDF+2FH ;                                             \
+	  TESTS=catalogue/aarch64-ifetch/tests/@dic0-idc0 ;          \
+	else                                                         \
+	  NORUN=NO ;                                                 \
+	  TESTS=catalogue/aarch64-ifetch/tests/@all ;                \
+	fi ;                                                         \
 	$(LITMUS)					         \
 		-set-libdir $(LITMUS_LIB_DIR)	                 \
 		-o $(KUT_DIR_AARCH64)/kvm-unit-tests/t	         \
@@ -157,7 +163,7 @@ litmus-cata-aarch64-ifetch-test-kvm: litmus-aarch64-dep
                 -nonames $${NORUN}                               \
                 -driver C -ascall true                           \
                 -outnames $(KUT_NAMES)                           \
-		catalogue/aarch64-ifetch/tests/@all
+		$${TESTS}
 	cd $(KUT_DIR_AARCH64)/kvm-unit-tests/t; make $(SILENTOPT) -j $(J)
 	if $(RUN_TESTS); then \
           ( cd $(KUT_DIR_AARCH64)/kvm-unit-tests && sh t/run.sh ) | \

--- a/catalogue/aarch64-ifetch/tests/@dic0-idc0
+++ b/catalogue/aarch64-ifetch/tests/@dic0-idc0
@@ -1,0 +1,8 @@
+DIC0-IDC0/@all
+MP+rel+blr.litmus
+MP.FF+dc.cvau-dmb.ish+dsb.ish-ic.ivau-dsb.ish-rfiINSTNOP.litmus
+MP.FF+dc.cvau-dsb.ish-ic.ivau-dsb.ish+dmb.ish+rfiINST.litmus
+MP.FF+dc.cvau-dsb.ish-ic.ivau-dsb.ish+po.litmus
+MP.RF+dc.cvau-dmb.ish+dsb.ish.ic.ivau.dsb-rfiINSTRISB.litmus
+SM.udf+dc.cvau+dsb.ish-ic.vau-dsb.ish-isb.litmus
+mytest2.litmus

--- a/litmus/libdir/_aarch64/self.c
+++ b/litmus/libdir/_aarch64/self.c
@@ -44,14 +44,15 @@ inline static void isync(void) {
   asm __volatile__ ("isb" ::: "memory");
 }
 
-inline static void check_dic_idc(int need_dic, int need_idc) {
+inline static int check_dic_idc(int need_dic, int need_idc) {
   uint64_t ctr_el0;
   asm volatile ("mrs %0, ctr_el0" : "=r" (ctr_el0));
   int idc = (ctr_el0 >> 28) & 1;
   int dic = (ctr_el0 >> 29) & 1;
   if ((need_dic && !dic) || (need_idc && !idc)) {
-    fprintf(stderr, "Fatal error: hardware does not support the CacheType "
-            "feature IDC=%d, DIC=%d\n", need_idc, need_dic);
-    exit(0);
+    printf("Required hardware features not available on this system: "
+           "IDC=%d, DIC=%d\n", idc, dic);
+    return 0;
   }
+  return 1;
 }

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -2451,6 +2451,22 @@ module Make
           O.fi "if (!check_const_pac_field_variant(%S)) return 0;" doc.Name.name;
         if Cfg.is_kvm && Cfg.variant Variant_litmus.ExS then
           O.fi "if (!check_exs(%S)) return 0;" doc.Name.name ;
+        if do_self then begin
+          let cache_type = CacheType.get test.T.info in
+          let needs_dic, needs_idc =
+            let open CacheType in
+            match cache_type with
+            | None -> (fun _ -> false), (fun _ -> false)
+            | Some cache_type -> cache_type.dic, cache_type.idc in
+          (* Arm ARM: CTR_EL0.DIC/IDC are common within an Inner Shareable domain. *)
+          begin match forall_procs test needs_dic, forall_procs test needs_idc with
+          | Some dic, Some idc ->
+              O.fi "if (!check_dic_idc(%d, %d)) return 0;"
+                (if dic then 1 else 0)
+                (if idc then 1 else 0)
+          | _ -> ()
+          end
+        end ;
         if Cfg.is_kvm then begin
           match db with
           | None ->

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -1774,7 +1774,7 @@ module Make
                       (fun _ -> false), (fun _ -> false)
                   | Some cache_type ->
                       cache_type.dic, cache_type.idc in
-              O.fi "check_dic_idc(%d, %d);"
+              O.fi "if (!check_dic_idc(%d, %d)) return NULL;"
                 (if needs_dic proc then 1 else 0)
                 (if needs_idc proc then 1 else 0)
             end ;


### PR DESCRIPTION
This PR enables PreSi and Kvm modes to check whether a core has DIC/IDC implemented. It also runs tests with `DIC=0 & IDC=0` as part of `make-aarch64-litmus`, while only compiling tests that require either DIC or IDC. 

=====

This has been identified as part of #1716. This fix has been tested against that patch and the desired behaviour was observed on an M2:

```
Fatal error: hardware does not support the CacheType feature IDC=1, DIC=1

EXIT: STATUS=1
```

The missing call was not flagged by the compiler because GCC/Clang do not warn about unused `static inline` functions by default.