### PR TITLE
[herd-www] Add .opam file specifying dependencies

### DIFF
--- a/herd-www/herd-www.opam
+++ b/herd-www/herd-www.opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "Dependencies for herd-www (web interface for herdtools7)"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: [
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+]
+homepage: "https://developer.arm.com/herd7"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+license: "CECILL-B"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune"
+  "menhir"
+  "js_of_ocaml" {= "5.4.0"}
+  "js_of_ocaml-ppx" {= "5.4.0"}
+  "zarith_stubs_js" {>= "v0.16.1"}
+]


### PR DESCRIPTION
This PR addresses a mismatch between zarith versions >=1.13, required by herdtools7.opam, and zarith_stubs_js, required by herd-www. The oldest version of zarith_stubs_js that does not conflict with zarith 1.13 is v.0.16.1. This version requires Ocaml >=4.14.0.
This .opam file specifies these requirements, giving the user the ability to automatically install the right versions of the packages through `opam install ($OPAM_FILE_PATH) --deps-only` for herd-www, such that these will not conflict with the versions required by herdtools7.opam in the root of the repository.