### PR TITLE
[tools] Preserve negated miaou list wrapper

### DIFF
--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -549,15 +549,15 @@ and cons_seqs (fs:exp list) (es:exp list) =
          and a = tr_evts e1 a
          and b =  tr_evts e1 b in
          IfCond (c,a,b)
-      | App (_,Var (_,"range"), Op (loc2,Seq,es)) ->
+      | App (_,Var (_,"range"),Var (_,"lxsx")) ->
+         pp_evts_id e1 "rangelxsx"
+      | App (_,Var (_,"range"), rel) ->
         let e3 = Next.next () in
-        begin match tr_rel e3 e1 (Op (loc2,Seq,es)) with
+        begin match tr_rel e3 e1 rel with
         | List ({ items; _ } as l) ->
            List { l with items = List.rev items; }
         | _ as i -> i
         end
-      | App (_,Var (_,"range"),Var (_,"lxsx")) ->
-         pp_evts_id e1 "rangelxsx"
       | e ->
          Item (fail (ASTUtils.exp2loc e) "ignoring expression")
 

--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -341,25 +341,12 @@ and cons_seqs (fs:exp list) (es:exp list) =
       and b = tr b in
       DiffPair (a,b)
 
-    let tr_diff tr tr_not tr_id a b =
-      match a,b with
-      | Var (loc1,id1),Op (_,Seq,[c;Var (_,id2);])
-           when String.equal id1 id2
-        ->
-        begin
-          match tr_not c with
-          | None -> do_tr_diff tr a b
-          | Some c ->
-             mk_list Inter [tr_id loc1 id1 ;c]
-        end
-      | _,_ ->
-         begin
-           match tr_not b with
-           | None ->
-              do_tr_diff tr a b
-           | Some c ->
-              mk_list Inter [tr a; c;]
-         end
+    let tr_diff tr tr_not a b =
+      match tr_not b with
+      | None ->
+        do_tr_diff tr a b
+      | Some c ->
+        mk_list Inter [tr a; c;]
 
     let flatten_if_not =
       if O.flatten then Fun.id
@@ -485,7 +472,6 @@ and cons_seqs (fs:exp list) (es:exp list) =
       tr_diff
         (fun e -> tr_rel e1 e2 e)
         (fun e -> tr_rel_not e1 e2 e)
-        (fun loc id -> tr_rel_id e1 e2 loc id)
         a b
 
     and tr_seq e1 e2 = function
@@ -581,7 +567,6 @@ and cons_seqs (fs:exp list) (es:exp list) =
       tr_diff
         (fun e -> tr_evts e1 e)
         (fun e -> tr_evts_not e1 e)
-        (fun loc id -> tr_evts_id e1 loc id)
         a b
 
     let tr_rel e1 e2 e = tr_rel e1 e2 @@ norm_rel e

--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -270,13 +270,14 @@ and cons_seqs (fs:exp list) (es:exp list) =
           op : AST.op2;
           intro_txt : string;
           sep_txt : string * string;
+          flattenable : bool;
           items : t list;
         }
       | DiffPair of t * t
       | IfCond of string * t * t
 
-    let mk_list op items =
-      List { op; intro_txt = intro op; sep_txt = sep op; items; }
+    let mk_list ?(flattenable=true) op items =
+      List { op; intro_txt = intro op; sep_txt = sep op; flattenable; items; }
 
     type atom = Pos of string | Neg of string
 
@@ -376,7 +377,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | Op (_,(Union|Inter as op),es) ->
          tr_op e1 e2 op es
       | Op (_,(Seq as op),es) ->
-         List { op; intro_txt = intro op; sep_txt = sep op; items = tr_seq e1 e2 es; }
+         mk_list op (tr_seq e1 e2 es)
       | Op (_,Diff,[a;b]) ->
          tr_rel_diff e1 e2 a b
       | Op (_,Cartesian,[a;b;]) ->
@@ -427,8 +428,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
          let top = List.map (tr_rel e1 e3) es in
          let bottom = List.map (tr_rel e3 e2) es in
          let items = top @ [tr_evts e3 evts] @ bottom in
-         (* Use Union to prevent flattening into surrounding Inter list, so the intro text survives. *)
-         List { op = Union; intro_txt = intro op; sep_txt = sep op; items; }
+         mk_list ~flattenable:false op items
       | App (_,Var (locf,("intervening-write" as f)),Var (loc,id)) ->
          let txt1 = do_pp_rel_id e1 e2 (pp_id locf f) in
          let txt2 = sprintf "{\\%s}" (pp_id loc id) in
@@ -547,7 +547,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
            |> pp_id loc in
          Item (sprintf "\\%s{%s}" id (pp_evt e1))
       | Op (_,(Union|Inter as op),es) ->
-          List { op; intro_txt = intro op; sep_txt = sep op; items = List.map (tr_evts e1) es; }
+          mk_list op (List.map (tr_evts e1) es)
       | Op (_,Diff,[a;b;]) ->
          tr_evts_diff e1 a b
       | If (_,VariantCond vc,Konst (_,Empty _),e) ->
@@ -597,7 +597,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | _,_ -> false
 
     let rec flatten_out = function
-      | List ({ op = (Inter|Union|Seq as op); items; _ } as lst)
+      | List ({ op = (Inter|Union|Seq as op); flattenable = true; items; _ } as lst)
         ->
          List { lst with items = flatten_op op items; }
       | List ({ items; _ } as lst) ->
@@ -613,7 +613,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | e::es ->
          begin
            match flatten_out e with
-           | List { op = op0; items; _ } when same_op op op0
+           | List { flattenable = true; op = op0; items; _ } when same_op op op0
              ->
               items @ flatten_op op es
            | t ->
@@ -688,6 +688,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
               op = op2;
               intro_txt = txt1 ^ " except when " ^ Misc.uncapitalize txt2;
               sep_txt = s2;
+              flattenable = true;
               items = ts2;
             })
       | DiffPair (t1,t2) ->
@@ -701,6 +702,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
                  op = op2;
                  intro_txt = "Except when " ^ Misc.uncapitalize txt2;
                  sep_txt = s2;
+                 flattenable = true;
                  items = ts2;
                }]
            | _ ->
@@ -710,6 +712,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
                 op = Diff;
                 intro_txt = "The following applies";
                 sep_txt = ("","");
+                flattenable = true;
                 items = ts;
               })
       | IfCond (txt,a,b) ->
@@ -720,6 +723,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
               op = Inter;
               intro_txt = txt;
               sep_txt = ("","");
+              flattenable = true;
               items = ts;
             })
 

--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -521,7 +521,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
          Some (Item txt)
       | List ({ intro_txt; _ } as l) ->
           let intro_txt =  makeuppercase @@ sprintf "\\notthecase{%s}" intro_txt in
-          Some (List { l with intro_txt })
+          Some (List { l with intro_txt; flattenable=false; })
       | DiffPair _|IfCond _ ->
          None
 

--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -266,11 +266,17 @@ and cons_seqs (fs:exp list) (es:exp list) =
 
     type t =
       | Item of string
-      | List of AST.op2 * string * (string * string) * t list
+      | List of {
+          op : AST.op2;
+          intro_txt : string;
+          sep_txt : string * string;
+          items : t list;
+        }
       | DiffPair of t * t
       | IfCond of string * t * t
 
-    let mk_list op itms = List (op,intro op,sep op,itms)
+    let mk_list op items =
+      List { op; intro_txt = intro op; sep_txt = sep op; items; }
 
     type atom = Pos of string | Neg of string
 
@@ -370,7 +376,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | Op (_,(Union|Inter as op),es) ->
          tr_op e1 e2 op es
       | Op (_,(Seq as op),es) ->
-         List (op,intro op,sep op,tr_seq e1 e2 es)
+         List { op; intro_txt = intro op; sep_txt = sep op; items = tr_seq e1 e2 es; }
       | Op (_,Diff,[a;b]) ->
          tr_rel_diff e1 e2 a b
       | Op (_,Cartesian,[a;b;]) ->
@@ -422,7 +428,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
          let bottom = List.map (tr_rel e3 e2) es in
          let items = top @ [tr_evts e3 evts] @ bottom in
          (* Use Union to prevent flattening into surrounding Inter list, so the intro text survives. *)
-         List (Union,intro op,sep op,items)
+         List { op = Union; intro_txt = intro op; sep_txt = sep op; items; }
       | App (_,Var (locf,("intervening-write" as f)),Var (loc,id)) ->
          let txt1 = do_pp_rel_id e1 e2 (pp_id locf f) in
          let txt2 = sprintf "{\\%s}" (pp_id loc id) in
@@ -511,15 +517,11 @@ and cons_seqs (fs:exp list) (es:exp list) =
 
     and notItem = function
       | Item txt ->
-         Some
-           (Item
-              (makeuppercase @@ sprintf "\\notthecase{%s}" txt))
-      | List (op,intro_txt,sep_txt,es) ->
-          Some
-            (List
-               (op,
-                makeuppercase @@ sprintf "\\notthecase{%s}" intro_txt,
-                sep_txt,es))
+        let txt =  makeuppercase @@ sprintf "\\notthecase{%s}" txt in
+         Some (Item txt)
+      | List ({ intro_txt; _ } as l) ->
+          let intro_txt =  makeuppercase @@ sprintf "\\notthecase{%s}" intro_txt in
+          Some (List { l with intro_txt })
       | DiffPair _|IfCond _ ->
          None
 
@@ -545,7 +547,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
            |> pp_id loc in
          Item (sprintf "\\%s{%s}" id (pp_evt e1))
       | Op (_,(Union|Inter as op),es) ->
-          List (op,intro op,sep op,List.map (tr_evts e1) es)
+          List { op; intro_txt = intro op; sep_txt = sep op; items = List.map (tr_evts e1) es; }
       | Op (_,Diff,[a;b;]) ->
          tr_evts_diff e1 a b
       | If (_,VariantCond vc,Konst (_,Empty _),e) ->
@@ -564,7 +566,8 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | App (_,Var (_,"range"), Op (loc2,Seq,es)) ->
         let e3 = Next.next () in
         begin match tr_rel e3 e1 (Op (loc2,Seq,es)) with
-        | List (op,intro_txt,sep_txt,es) -> List (op,intro_txt,sep_txt,List.rev es)
+        | List ({ items; _ } as l) ->
+           List { l with items = List.rev items; }
         | _ as i -> i
         end
       | App (_,Var (_,"range"),Var (_,"lxsx")) ->
@@ -594,11 +597,11 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | _,_ -> false
 
     let rec flatten_out = function
-      | List ((Inter|Union|Seq as op),intro_txt,sep_txt,ts)
+      | List ({ op = (Inter|Union|Seq as op); items; _ } as lst)
         ->
-         List (op,intro_txt,sep_txt,(flatten_op op ts))
-      | List (op,txt,s,ts) ->
-         List (op,txt,s,List.map flatten_out ts)
+         List { lst with items = flatten_op op items; }
+      | List ({ items; _ } as lst) ->
+         List { lst with items = List.map flatten_out items; }
       | DiffPair (e1,e2) ->
          DiffPair (flatten_out e1,flatten_out e2)
       | IfCond (txt,e1,e2) ->
@@ -610,19 +613,16 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | e::es ->
          begin
            match flatten_out e with
-           | List (op0,_,_,ts) when same_op op op0
+           | List { op = op0; items; _ } when same_op op op0
              ->
-              ts@flatten_op op es
+              items @ flatten_op op es
            | t ->
               t::flatten_op op es
          end
 
     let rec rm_dups = function
-      | List ((Inter|Union|Seq as op),intro_txt,sep_txt,ts)
-        ->
-         List (op,intro_txt,sep_txt,rm_dups_args ts)
-      | List (op,txt,s,ts) ->
-         List (op,txt,s,List.map rm_dups ts)
+      | List ({ items; _ } as lst) ->
+         List { lst with items = rm_dups_args items; }
       | DiffPair (e1,e2) ->
          DiffPair (rm_dups e1,rm_dups e2)
       | IfCond (txt,e1,e2) ->
@@ -655,7 +655,7 @@ and cons_seqs (fs:exp list) (es:exp list) =
     let rec pp_def pref s = function
       | Item txt ->
          printf "%s %s%s\n" pref txt s
-      | List (_,txt,(s1,s2),ts) ->
+      | List { intro_txt = txt; sep_txt = (s1,s2); items = ts; _ } ->
          printf "%s %s:\n" pref txt ;
          printf "\\begin{itemize}\n" ;
          pp_txts "" s1 s2 s ts ;
@@ -672,9 +672,9 @@ and cons_seqs (fs:exp list) (es:exp list) =
 
     and pp_txt indent s = function
       | Item txt
-      | List (_,_,_,[Item txt]) ->
+      | List { items = [Item txt]; _ } ->
          printf "%s\\item %s%s\n" indent txt s
-      | List (_,txt,(s1,s2),txts) ->
+      | List { intro_txt = txt; sep_txt = (s1,s2); items = txts; _ } ->
          printf "%s\\item %s:\n" indent (Misc.capitalize txt) ;
          let indent = next_indent indent in
          printf "%s\\begin{itemize}\n" indent ;
@@ -682,33 +682,46 @@ and cons_seqs (fs:exp list) (es:exp list) =
          printf "%s\\end{itemize}\n" indent
       | DiffPair (Item txt1,Item txt2) ->
          printf "%s\\item %s except when %s%s\n" indent txt1 txt2 s
-      | DiffPair (Item txt1,List (op2,txt2,s2,ts2)) ->
+      | DiffPair (Item txt1,List { op = op2; intro_txt = txt2; sep_txt = s2; items = ts2; _ }) ->
          pp_txt indent s
-           (List
-              (op2,txt1 ^ " except when " ^ Misc.uncapitalize txt2,
-               s2,ts2))
+           (List {
+              op = op2;
+              intro_txt = txt1 ^ " except when " ^ Misc.uncapitalize txt2;
+              sep_txt = s2;
+              items = ts2;
+            })
       | DiffPair (t1,t2) ->
          let ts =
            match t2 with
            | Item txt2 ->
               [t1;Item ("Except when " ^ txt2)]
-            | List (op2,txt2,s2,ts2) ->
-               [t1;
-                List
-                  (op2,
-                   "Except when " ^ Misc.uncapitalize txt2,
-                   s2,ts2)]
-            | _ ->
-               [t1;Item "Except when";t2;] in
-            pp_txt indent s
-              (List
-              (Diff,
-               "The following applies",("",""),
-               ts))
+           | List { op = op2; intro_txt = txt2; sep_txt = s2; items = ts2; _ } ->
+              [t1;
+                List {
+                 op = op2;
+                 intro_txt = "Except when " ^ Misc.uncapitalize txt2;
+                 sep_txt = s2;
+                 items = ts2;
+               }]
+           | _ ->
+              [t1;Item "Except when";t2;] in
+           pp_txt indent s
+             (List {
+                op = Diff;
+                intro_txt = "The following applies";
+                sep_txt = ("","");
+                items = ts;
+              })
       | IfCond (txt,a,b) ->
          let txt = sprintf "When %s" txt
          and ts = [a; Item "Otherwise"; b;] in
-         pp_txt indent s (List (Inter,txt,("",""),ts))
+         pp_txt indent s
+           (List {
+              op = Inter;
+              intro_txt = txt;
+              sep_txt = ("","");
+              items = ts;
+            })
 
         and pp_txts indent s1 s2 s3 = function
       | [] -> ()

--- a/tools/tests/dune
+++ b/tools/tests/dune
@@ -1,0 +1,5 @@
+(cram
+ (deps
+  (source_tree libdir)
+  %{bin:miaou7})
+ (enabled_if %{bin-available:miaou7}))

--- a/tools/tests/libdir
+++ b/tools/tests/libdir
@@ -1,0 +1,1 @@
+../../herd/libdir

--- a/tools/tests/miaou.t
+++ b/tools/tests/miaou.t
@@ -1,0 +1,1145 @@
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show IFB-ob aarch64.cat
+  \expandafter{\MakeUppercase\IFBobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\ctrl{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \IFB{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\pickctrldep{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \IFB{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\addr{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{4}}}.
+    \item \IFB{E\textsubscript{4}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{4}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\pickaddrdep{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{4}}}.
+    \item \IFB{E\textsubscript{4}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{4}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\pickaddrdep{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \expandafter{\MakeUppercase\tcib{E\textsubscript{3}}{E\textsubscript{4}}}.
+      \item \expandafter{\MakeUppercase\trib{E\textsubscript{3}}{E\textsubscript{4}}}.
+      \end{itemize}
+    \item \IFB{E\textsubscript{4}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{4}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\DSBob{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \IFB{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTTDR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\trib{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \IFB{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTagR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\tcib{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \IFB{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTTDR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\trib{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{4}}}.
+    \item \IFB{E\textsubscript{4}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{4}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTagR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\tcbefore{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{4}}}.
+    \item \IFB{E\textsubscript{4}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{4}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show DSB-ob aarch64.cat
+  \expandafter{\MakeUppercase\DSBobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item One of the following applies:
+      \begin{itemize}
+      \item \M{E\textsubscript{1}}.
+      \item \DCCVAU{E\textsubscript{1}}.
+      \item \IC{E\textsubscript{1}}.
+      \item \TLBI{E\textsubscript{1}}.
+      \end{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DSBFULL{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\notthecase{one of the following applies}}:
+      \begin{itemize}
+      \item \ImpTTDM{E\textsubscript{2}}.
+      \item \ImpInstrR{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \Variant{ETS2} or \Variant{ETS3}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \M{E\textsubscript{1}}.
+      \item \DCCVAU{E\textsubscript{1}}.
+      \item \IC{E\textsubscript{1}}.
+      \item \TLBI{E\textsubscript{1}}.
+      \end{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DSBFULL{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \ImpTTDM{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item One of the following applies:
+      \begin{itemize}
+      \item All of the following apply:
+        \begin{itemize}
+        \item \ExpR{E\textsubscript{1}}.
+        \item \expandafter{\MakeUppercase\notthecase{\NoRet{E\textsubscript{1}}}}.
+        \end{itemize}
+      \item \ImpTagR{E\textsubscript{1}}.
+      \end{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DSBLD{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\notthecase{one of the following applies}}:
+      \begin{itemize}
+      \item \ImpTTDM{E\textsubscript{2}}.
+      \item \ImpInstrR{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \Variant{ETS2} or \Variant{ETS3}.
+    \item \ExpR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\notthecase{\NoRet{E\textsubscript{1}}}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DSBLD{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \ImpTTDM{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpW{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DSBST{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\notthecase{one of the following applies}}:
+      \begin{itemize}
+      \item \ImpTTDM{E\textsubscript{2}}.
+      \item \ImpInstrR{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \Variant{ETS2} or \Variant{ETS3}.
+    \item \ExpW{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DSBST{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \ImpTTDM{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show Exp-obs aarch64.cat
+  \expandafter{\MakeUppercase\Expobsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\rf{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\ext{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpM{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\ext{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpM{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show IC-ca aarch64.cat
+  \expandafter{\MakeUppercase\ICcaemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \NotVariant{DIC} and \NotVariant{IDC}.
+    \item \IC{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\ICafter{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ImpInstrR{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\ca{E\textsubscript{3}}{E\textsubscript{4}}}.
+    \item \W{E\textsubscript{4}}.
+    \item \expandafter{\MakeUppercase\DCafter{E\textsubscript{4}}{E\textsubscript{2}}}.
+    \item \DCCVAU{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \NotVariant{DIC} and \Variant{IDC}.
+    \item \IC{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\ICafter{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ImpInstrR{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\ca{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \W{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \Variant{DIC} and \Variant{IDC}.
+    \item \ImpInstrR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \W{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show IC-ob aarch64.cat
+  \expandafter{\MakeUppercase\ICobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ImpInstrR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \ImpInstrR{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\Instrreadob{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show Instr-obs aarch64.cat
+  \expandafter{\MakeUppercase\Instrobsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\rf{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ImpInstrR{E\textsubscript{2}}.
+    \end{itemize}
+  \item \expandafter{\MakeUppercase\ICafter{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \DCCVAU{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\DCafter{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \W{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \W{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\DCafter{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \DCCVAU{E\textsubscript{2}}.
+    \end{itemize}
+  \item \expandafter{\MakeUppercase\ICca{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show Instr-read-ordered-before aarch64.cat
+  \expandafter{\MakeUppercase\Instrreadobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\ICafter{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \IC{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\DSBob{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\ICafter{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \IC{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\IFBob{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \Variant{DIC}.
+    \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show TLBI-ca aarch64.cat
+  \expandafter{\MakeUppercase\TLBIcaemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \TLBI{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\TLBIafter{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \ImpTTDR{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\ca{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item \W{E\textsubscript{2}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show TLBI-ob aarch64.cat
+  \expandafter{\MakeUppercase\TLBIobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\TTDreadorderedbefore{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\trib{E\textsubscript{3}}{E\textsubscript{1}}}.
+    \item \expandafter{\MakeUppercase\TTDreadorderedbefore{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\ext{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTTDR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\trib{E\textsubscript{1}}{E\textsubscript{4}}}.
+    \item \expandafter{\MakeUppercase\sameloworderbits{E\textsubscript{4}}{E\textsubscript{5}}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{4}}{E\textsubscript{5}}}.
+    \item \expandafter{\MakeUppercase\trib{E\textsubscript{3}}{E\textsubscript{5}}}.
+    \item \ImpTTDR{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\sametranslationcontext{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\TTDreadorderedbefore{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\ext{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show TTD-obs aarch64.cat
+  \expandafter{\MakeUppercase\TTDobsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTTD{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\rf{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\rf{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ImpTTD{E\textsubscript{2}}.
+    \end{itemize}
+  \item \expandafter{\MakeUppercase\TLBuncacheableca{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\HUca{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \HU{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \W{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \W{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \HU{E\textsubscript{2}}.
+    \end{itemize}
+  \item \expandafter{\MakeUppercase\TLBIca{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show TTD-read-ordered-before aarch64.cat
+  \expandafter{\MakeUppercase\TTDreadorderedbeforeemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\TLBIafter{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \TLBI{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\DSBob{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\TLBIafter{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \TLBI{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\IFBob{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show Tag-obs aarch64.cat
+  \expandafter{\MakeUppercase\Tagobsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpW{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\rf{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\ext{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ImpTagR{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTagR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\ext{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpW{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show addr aarch64.cat
+  \expandafter{\MakeUppercase\addremph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ExpR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\dtrm{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \Rreg{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\iiaddr{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item One of the following applies:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{2}}.
+    \item \ImpTagR{E\textsubscript{2}}.
+    \item \ImpTTDR{E\textsubscript{2}}.
+    \item \HU{E\textsubscript{2}}.
+    \item \TLBI{E\textsubscript{2}}.
+    \item \DCCVAU{E\textsubscript{2}}.
+    \item \ICIVAU{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show aob aarch64.cat
+  \expandafter{\MakeUppercase\aobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\rmw{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpM{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\rmw{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\lmrs{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpRA{E\textsubscript{2}}.
+      \item \ExpRQ{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTTDR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\rmw{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \HU{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show bob aarch64.cat
+  \expandafter{\MakeUppercase\bobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpM{E\textsubscript{1}}.
+      \item \ImpTagR{E\textsubscript{1}}.
+      \end{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DMBFULL{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpM{E\textsubscript{2}}.
+      \item \ImpTagR{E\textsubscript{2}}.
+      \item \MMUFAULT{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DMBFULL{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \DCCVAU{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \DCCVAU{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DMBFULL{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \ExpM{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \DCCVAU{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DMBFULL{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \DCCVAU{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item One of the following applies:
+      \begin{itemize}
+      \item All of the following apply:
+        \begin{itemize}
+        \item \Exp{E\textsubscript{1}}.
+        \item \R{E\textsubscript{1}}.
+        \item \expandafter{\MakeUppercase\notthecase{\NoRet{E\textsubscript{1}}}}.
+        \end{itemize}
+      \item \ImpTagR{E\textsubscript{1}}.
+      \end{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DMBLD{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpM{E\textsubscript{2}}.
+      \item \ImpTagR{E\textsubscript{2}}.
+      \item \MMUFAULT{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpW{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \DMBST{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpW{E\textsubscript{2}}.
+      \item \MMUFAULT{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpWL{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\amo{E\textsubscript{3}}{E\textsubscript{1}}}.
+    \item \ExpRA{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpM{E\textsubscript{2}}.
+      \item \ImpTagR{E\textsubscript{2}}.
+      \item \MMUFAULT{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpWL{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpRA{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpRA{E\textsubscript{1}}.
+      \item \ExpRQ{E\textsubscript{1}}.
+      \end{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpM{E\textsubscript{2}}.
+      \item \ImpTagR{E\textsubscript{2}}.
+      \item \MMUFAULT{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpRQ{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\iicoorder{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpRQ{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpM{E\textsubscript{1}}.
+      \item \ImpTagR{E\textsubscript{1}}.
+      \end{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpWL{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpWL{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\iicoorder{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpWL{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show ctrl aarch64.cat
+  \expandafter{\MakeUppercase\ctrlemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ExpR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\dtrm{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \Rreg{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{3}}{E\textsubscript{4}}}.
+  \item \BCC{E\textsubscript{4}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{4}}{E\textsubscript{2}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show data aarch64.cat
+  \expandafter{\MakeUppercase\dataemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ExpR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\dtrm{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \Rreg{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\iidata{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item \ExpW{E\textsubscript{2}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show dob aarch64.cat
+  \expandafter{\MakeUppercase\dobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\addr{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\data{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\ctrl{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpW{E\textsubscript{2}}.
+      \item \HU{E\textsubscript{2}}.
+      \item \TLBI{E\textsubscript{2}}.
+      \item \DCCVAU{E\textsubscript{2}}.
+      \item \IC{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\addr{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpW{E\textsubscript{2}}.
+      \item \HU{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\addr{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\lmrs{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpR{E\textsubscript{2}}.
+      \item \ImpTagR{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\data{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\lmrs{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpR{E\textsubscript{2}}.
+      \item \ImpTagR{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTTDR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\trib{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpW{E\textsubscript{2}}.
+      \item \HU{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTagR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\tcbefore{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpW{E\textsubscript{2}}.
+      \item \HU{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show dtrm aarch64.cat
+  \expandafter{\MakeUppercase\dtrmemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\notthecase{\rangelxsx{E\textsubscript{1}}}}.
+    \item \expandafter{\MakeUppercase\lrrs{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item \expandafter{\MakeUppercase\lmrs{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\dtrm{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\dtrm{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show Exp-haz-ob aarch64.cat
+  \expandafter{\MakeUppercase\Exphazobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ExpR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \expandafter{\MakeUppercase\sameloc{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \ExpR{E\textsubscript{3}}.
+  \item One of the following applies:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\sca{E\textsubscript{3}}{E\textsubscript{4}}}.
+    \item \expandafter{\MakeUppercase\sameEffect{E\textsubscript{3}}{E\textsubscript{4}}}.
+    \end{itemize}
+  \item \ExpR{E\textsubscript{4}}.
+  \item \expandafter{\MakeUppercase\ca{E\textsubscript{4}}{E\textsubscript{5}}}.
+  \item \expandafter{\MakeUppercase\ext{E\textsubscript{4}}{E\textsubscript{5}}}.
+  \item One of the following applies:
+    \begin{itemize}
+    \item \ExpW{E\textsubscript{5}}.
+    \item \HU{E\textsubscript{5}}.
+    \end{itemize}
+  \item One of the following applies:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\sca{E\textsubscript{5}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\sameEffect{E\textsubscript{5}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item One of the following applies:
+    \begin{itemize}
+    \item \ExpW{E\textsubscript{2}}.
+    \item \HU{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show f-ib aarch64.cat
+  \expandafter{\MakeUppercase\fibemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ImpInstrR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \B{E\textsubscript{3}}.
+  \item One of the following applies:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\iicoctrl{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item All of the following apply:
+      \begin{itemize}
+      \item \expandafter{\MakeUppercase\iicoctrl{E\textsubscript{3}}{E\textsubscript{4}}}.
+      \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{4}}{E\textsubscript{2}}}.
+      \end{itemize}
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show haz-ob aarch64.cat
+  \expandafter{\MakeUppercase\hazobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\Exphazob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\TLBIob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\ICob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show hw-reqs aarch64.cat
+  \expandafter{\MakeUppercase\hwreqsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\localhwreqs{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\hazob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show lob aarch64.cat
+  \expandafter{\MakeUppercase\lobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\tcib{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\trib{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\fib{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\etsob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\fob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\posclob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\DSBob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\IFBob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\lmws{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\lmws{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\sca{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item \expandafter{\MakeUppercase\dob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\pob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\aob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\bob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\lob{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\lob{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show local-hw-reqs aarch64.cat
+  \expandafter{\MakeUppercase\localhwreqsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\lob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\picklob{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\localhwreqs{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\localhwreqs{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show ob aarch64.cat
+  \expandafter{\MakeUppercase\obemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\hwreqs{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\obs{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\ob{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\ob{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show obs aarch64.cat
+  \expandafter{\MakeUppercase\obsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item \Expobs{E\textsubscript{1}}{either  E\textsubscript{2}} or \sca{an Effect which}{E\textsubscript{2}}.
+  \item \Tagobs{E\textsubscript{1}}{either  E\textsubscript{2}} or \sca{an Effect which}{E\textsubscript{2}}.
+  \item \expandafter{\MakeUppercase\TTDobs{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\Instrobs{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show pick-addr-dep aarch64.cat
+  \expandafter{\MakeUppercase\pickaddrdepemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ExpR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\pickdtrm{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \Rreg{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\iiaddr{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item One of the following applies:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{2}}.
+    \item \ImpTagR{E\textsubscript{2}}.
+    \item \ImpTTDR{E\textsubscript{2}}.
+    \item \HU{E\textsubscript{2}}.
+    \item \TLBI{E\textsubscript{2}}.
+    \item \DCCVAU{E\textsubscript{2}}.
+    \item \ICIVAU{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show pick-basic-dep aarch64.cat
+  \expandafter{\MakeUppercase\pickbasicdepemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ExpR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\pickdtrm{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show pick-ctrl-dep aarch64.cat
+  \expandafter{\MakeUppercase\pickctrldepemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ExpR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\pickdtrm{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \Rreg{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{3}}{E\textsubscript{4}}}.
+  \item \BCC{E\textsubscript{4}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{4}}{E\textsubscript{2}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show pick-data-dep aarch64.cat
+  \expandafter{\MakeUppercase\pickdatadepemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ExpR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\pickdtrm{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \Rreg{E\textsubscript{3}}.
+  \item One of the following applies:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item All of the following apply:
+      \begin{itemize}
+      \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{3}}{E\textsubscript{4}}}.
+      \item \expandafter{\MakeUppercase\iicoctrl{E\textsubscript{4}}{E\textsubscript{2}}}.
+      \end{itemize}
+    \end{itemize}
+  \item \expandafter{\MakeUppercase\iidata{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item \ExpW{E\textsubscript{2}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show pick-dep aarch64.cat
+  \expandafter{\MakeUppercase\pickdepemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item One of the following applies:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\pickbasicdep{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\pickaddrdep{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\pickdatadep{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\pickctrldep{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item \expandafter{\MakeUppercase\notthecase{\expandafter{\MakeUppercase\sameinstance{E\textsubscript{1}}{E\textsubscript{2}}}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show pick-dtrm aarch64.cat
+  \expandafter{\MakeUppercase\pickdtrmemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\dtrm{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\iicoctrl{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\pickdtrm{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\pickdtrm{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show pick-lob aarch64.cat
+  \expandafter{\MakeUppercase\picklobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\pickdep{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \expandafter{\MakeUppercase\lob{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item \ExpW{E\textsubscript{2}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show po-scl-ob aarch64.cat
+  \expandafter{\MakeUppercase\posclobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\scl{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \DCCVAU{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \DCCVAU{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\scl{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpM{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \DCCVAU{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\scl{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \DCCVAU{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show pob aarch64.cat
+  \expandafter{\MakeUppercase\pobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\pickaddrdep{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpW{E\textsubscript{2}}.
+      \item \HU{E\textsubscript{2}}.
+      \item \TLBI{E\textsubscript{2}}.
+      \item \DCCVAU{E\textsubscript{2}}.
+      \item \IC{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item \expandafter{\MakeUppercase\pickdatadep{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\pickctrldep{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpW{E\textsubscript{2}}.
+      \item \HU{E\textsubscript{2}}.
+      \item \TLBI{E\textsubscript{2}}.
+      \item \DCCVAU{E\textsubscript{2}}.
+      \item \IC{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\pickaddrdep{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \ExpM{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpW{E\textsubscript{2}}.
+      \item \HU{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show tc-ib aarch64.cat
+  \expandafter{\MakeUppercase\tcibemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \expandafter{\MakeUppercase\tcbefore{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\notthecase{\ExpR{E\textsubscript{2}}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show tr-ib aarch64.cat
+  \expandafter{\MakeUppercase\tribemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ImpTTDR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \B{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\iicoctrl{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item One of the following applies:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{2}}.
+    \item \MMUFAULT{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show f-ob aarch64.cat
+  \expandafter{\MakeUppercase\fobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ImpInstrR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\notthecase{\ImpInstrR{E\textsubscript{2}}}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show ets-ob aarch64.cat
+  \expandafter{\MakeUppercase\etsobemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \Variant{ETS2}.
+    \item \ExpM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \TLBUncacheableFAULT{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\trib{E\textsubscript{2}}{E\textsubscript{3}}}.
+    \item \ImpTTDR{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \Variant{ETS3}.
+    \item \ExpM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \MMUFAULT{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\trib{E\textsubscript{2}}{E\textsubscript{3}}}.
+    \item \ImpTTDR{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \Variant{ETS3}.
+    \item \ExpM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \TagCheckEXCENTRY{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\tcib{E\textsubscript{2}}{E\textsubscript{3}}}.
+    \item \ImpTagR{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show tc-before aarch64.cat
+  \expandafter{\MakeUppercase\tcbeforeemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ImpTagR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\iicodata{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \B{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\iicoctrl{E\textsubscript{3}}{E\textsubscript{2}}}.
+  \item One of the following applies:
+    \begin{itemize}
+    \item \ExpM{E\textsubscript{2}}.
+    \item \TagCheckFAULT{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show lrrs aarch64.cat
+  \expandafter{\MakeUppercase\lrrsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \Wreg{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\samegpr{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\notthecase{all of the following apply}}:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\samegpr{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \Wreg{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\samegpr{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item \Rreg{E\textsubscript{2}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show lmrs aarch64.cat
+  \expandafter{\MakeUppercase\lmrsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \W{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\sameloc{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \expandafter{\MakeUppercase\notthecase{all of the following apply}}:
+    \begin{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \expandafter{\MakeUppercase\sameloc{E\textsubscript{1}}{E\textsubscript{3}}}.
+    \item \W{E\textsubscript{3}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\sameloc{E\textsubscript{3}}{E\textsubscript{2}}}.
+    \end{itemize}
+  \item \R{E\textsubscript{2}}.
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show lmws aarch64.cat
+  \expandafter{\MakeUppercase\lmwsemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpM{E\textsubscript{1}}.
+      \item \ImpTagR{E\textsubscript{1}}.
+      \end{itemize}
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\sameloc{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \ExpW{E\textsubscript{2}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \ImpTTDR{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \expandafter{\MakeUppercase\sameloc{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item One of the following applies:
+      \begin{itemize}
+      \item \ExpW{E\textsubscript{2}}.
+      \item \HU{E\textsubscript{2}}.
+      \end{itemize}
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show same-loc aarch64.cat
+  \expandafter{\MakeUppercase\samelocemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if one of the following applies:
+  \begin{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \EvalidPA{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\notthecase{\TagM{E\textsubscript{1}}}}.
+    \item \expandafter{\MakeUppercase\loc{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \EvalidPA{E\textsubscript{2}}.
+    \item \expandafter{\MakeUppercase\notthecase{\TagM{E\textsubscript{2}}}}.
+    \end{itemize}
+  \item All of the following apply:
+    \begin{itemize}
+    \item \TagM{E\textsubscript{1}}.
+    \item \expandafter{\MakeUppercase\loc{E\textsubscript{1}}{E\textsubscript{2}}}.
+    \item \TagM{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show TLBuncacheable-ca aarch64.cat
+  \expandafter{\MakeUppercase\TLBuncacheablecaemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ImpTTDR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\trib{E\textsubscript{1}}{E\textsubscript{3}}}.
+  \item \TLBUncacheableFAULT{E\textsubscript{3}}.
+  \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item One of the following applies:
+    \begin{itemize}
+    \item \ExpW{E\textsubscript{2}}.
+    \item \HU{E\textsubscript{2}}.
+    \end{itemize}
+  \end{itemize}
+
+  $ miaou7 -q -set-libdir ./libdir -tex catdefinitions.tex -show HU-ca aarch64.cat
+  \expandafter{\MakeUppercase\HUcaemph{an Effect E\textsubscript{1}}{an Effect E\textsubscript{2}}} if all of the following apply:
+  \begin{itemize}
+  \item \ExpR{E\textsubscript{1}}.
+  \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
+  \item \HU{E\textsubscript{2}}.
+  \end{itemize}


### PR DESCRIPTION
Keep negated composite lists wrapped in a dedicated node instead of reusing the original list operator.

Without this, miaou can flatten the negated sub-list into the enclosing conjunction and lose the intended 'it is not the case that all of the following apply' structure.

For example:

  `let rel1 = [A]; rel2; [B \ range([C]; rel; [D])]`

should render as:
```
  - E1 is an A effect.
  - E1 is rel2-before E2.
  - E2 is a B effect.
  - It is not the case that all of the following apply:
    - E2 is a D effect.
    - E3 is rel-before E2.
    - E3 is a C effect.
```
Assisted-by: OpenAI Codex