### PR TITLE
[asl][asl reference] a refinement to annotating symbolically evaluable expressions

### DIFF
--- a/asllib/StaticModel.ml
+++ b/asllib/StaticModel.ml
@@ -198,7 +198,6 @@ let rec to_ir env (e : expr) =
           in
           let ty1 = make_anonymous env t in
           match ty1.desc with
-          | T_Int (WellConstrained ([ Constraint_Exact e ], _)) -> to_ir env e
           | T_Int _ -> Polynomial.of_var s
           | _ -> raise NotSupported)))
   | E_Binop (`ADD, e1, e2) ->

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1401,7 +1401,13 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
   (* Begin AnnotateSymbolicallyEvaluableExpr *)
   and annotate_symbolically_evaluable_expr env e =
     let t, e', ses = annotate_expr env e in
-    let+ () = check_symbolically_evaluable e ses in
+    (* We check whether the normalized expression is symbolically evaluable,
+       since it allows eliminating mutable variables that do not affect
+       the result, we but return the un-normalized expression and its type,
+       since the eliminated variables may affect further analysis. *)
+    let normalized_e' = StaticModel.try_normalize env e' in
+    let _, _, ses_normalized = annotate_expr env normalized_e' in
+    let+ () = check_symbolically_evaluable e ses_normalized in
     (t, e', ses)
   (* End *)
 

--- a/asllib/doc/SymbolicEquivalenceTesting.tex
+++ b/asllib/doc/SymbolicEquivalenceTesting.tex
@@ -320,7 +320,6 @@ and their simplified counterparts.
 
 See \ExampleRef{Symbolically Simplifying Constraints}.
 
-
 \RenderProseAndFormally{reduce_constraints}
 \CodeSubsection{\ReduceConstraintsBegin}{\ReduceConstraintsEnd}{../StaticOperations.ml}
 

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -878,12 +878,22 @@ See \ExampleRef{Annotating Symbolically Evaluable Expressions}.
 \TypingRuleDef{AnnotateSymbolicallyEvaluableExpr}
 \RenderRelation{annotate_symbolically_evaluable_expr}
 
+An intricate detail of this rule is that the check for whether an expression is \symbolicallyevaluableterm{}
+is performed on the \normalizedexpressionterm{}.
+This is exemplified by \ExampleRef{Checking Symbolically Evaluability of Normalized Expressions} below.
+
 \ExampleDef{Annotating Symbolically Evaluable Expressions}
 \listingref{typing-annotatesymbolicallyevaluableexpr} shows examples of
 expressions and classifies them as either \symbolicallyevaluableterm{} or not.
 \ASLListing{Annotating symbolically evaluable Expressions}{typing-annotatesymbolicallyevaluableexpr}
 {\typingtests/TypingRule.AnnotateSymbolicallyEvaluableExpr.asl}
 
+\ExampleDef{Checking Symbolically Evaluability of Normalized Expressions}
+\listingref{typing-annotatesymbolicallyevaluableexpr2} shows how the determination
+of whether the length of a slice is \symbolicallyevaluableterm{}, involves normalization,
+which reasons away the mutable variable \verb|chunk_index|.
+\ASLListing{Annotating symbolically evaluable Expressions}{typing-annotatesymbolicallyevaluableexpr2}
+{\typingtests/TypingRule.AnnotateSymbolicallyEvaluableExpr2.asl}
 
 \RenderProseAndFormally{annotate_symbolically_evaluable_expr}
 \CodeSubsection{\AnnotateSymbolicallyEvaluableExprBegin}{\AnnotateSymbolicallyEvaluableExprEnd}{../Typing.ml}

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -12092,32 +12092,22 @@ typing function to_ir(tenv: static_envs, e: expr) ->
     some(p);
   }
 
-  case evar_exact_constraint {
+  case evar_mutable {
     e =: E_Var(s);
     lookup_constant(tenv, s) -> none;
     lookup_immutable_expr(tenv, s) -> none;
     type_of(tenv, s) -> t;
     make_anonymous(tenv, t) -> t1;
-    case int {
-      case exact {
-        ast_label(t1) = label_T_Int;
-        t1 =: T_Int(WellConstrained(make_singleton_list(Constraint_Exact(e1))));
-        to_ir(tenv, e1) -> p_opt;
-        --
-        p_opt;
-      }
-      case not_exact {
-        ast_label(t1) = label_T_Int;
-        not(t1 = T_Int(WellConstrained(make_singleton_list(Constraint_Exact(_)))));
-        polynomial_of_var(s) -> p;
-        --
-        some(p);
-      }
-      case evar_non_int {
-        ast_label(t1) != label_T_Int;
-        --
-        none;
-      }
+    case evar_int {
+      ast_label(t1) = label_T_Int;
+      polynomial_of_var(s) -> p;
+      --
+      some(p);
+    }
+    case evar_non_int {
+      ast_label(t1) != label_T_Int;
+      --
+      none;
     }
   }
 
@@ -14768,7 +14758,9 @@ typing relation annotate_symbolically_evaluable_expr(tenv: static_envs, e: expr)
   math_layout = [_,_],
 } =
   annotate_expr(tenv, e) -> (t, e', ses);
-  check_symbolically_evaluable(ses) -> True;
+  normalize(tenv, e') -> normalized_e';
+  annotate_expr(tenv, normalized_e') -> (_, _, ses_normalized);
+  check_symbolically_evaluable(ses_normalized) -> True;
   --
   (t, e', ses);
 ;

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -602,6 +602,7 @@ desugar
 desugared
 desugaring
 desugars
+detail
 detailed
 details
 detect
@@ -1151,6 +1152,7 @@ intersection
 interval
 intervals
 into
+intricate
 introduce
 introduced
 introduces

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateSymbolicallyEvaluableExpr2.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateSymbolicallyEvaluableExpr2.asl
@@ -1,0 +1,17 @@
+func write_chunks(message: bits(64), code: bits(8)) => bits(64)
+begin
+        var chunk_index : integer{0..8}  = 0;
+        var new_message: bits(64);
+
+        // Read until all bytes are read or until a fault is encountered.
+        while (TRUE) looplimit 5 do
+            // chunk_index is mutable, so not symbolically evaluable.
+            // However, it does not affect the length of the written slice
+            // (8 * chunk_index - 8 * chunk_index + 7 + 1 = 8)
+            // which is the constant 8, which is symbolically evaluable,
+            // so we consider the slice to be symbolically evaluable.
+            new_message[8 * chunk_index + 7 : 8 * chunk_index] = code;
+            chunk_index = chunk_index + 1 as integer{0..8};
+        end;
+        return new_message;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -180,6 +180,7 @@ ASL Typing Tests / annotating types:
   ASL Type error: constrained integer expected, provided integer.
   [1]
   $ aslref TypingRule.AnnotateSymbolicallyEvaluableExpr.asl
+  $ aslref --no-exec TypingRule.AnnotateSymbolicallyEvaluableExpr2.asl
   $ aslref --no-exec TypingRule.TEnumDecl.asl
   $ aslref --no-exec TypingRule.TEnumDecl.subtypes.asl
   $ aslref --no-exec TypingRule.TEnumDecl.bad.asl


### PR DESCRIPTION
Annotating symbolically evaluable expressions is not strong enough to determine that the length of a slice is symbolically evaluable when it syntactically contains a mutable variable, as in the example below
```
func write_chunks(message: bits(64), code: bits(8)) => bits(64)
begin
        var chunk_index : integer{0..8}  = 0;
        var new_message: bits(64);

        // Read until all bytes are read or until a fault is encountered.
        while (TRUE) looplimit 5 do
            // chunk_index is mutable, so not symbolically evaluable.
            // However, it does not affect the length of the written slice
            // (8 * chunk_index - 8 * chunk_index + 7 + 1 = 8)
            // which is the constant 8, which is symbolically evaluable,
            // so we consider the slice to be symbolically evaluable.
            new_message[8 * chunk_index + 7 : 8 * chunk_index] = code;
            chunk_index = chunk_index + 1 as integer{0..8};
        end;
        return new_message;
end;
```
This PR performs the check on the normalized expression, which may contain fewer mutable variables.

A nuance is that one normalization step in `to_ir`, which looks into the type of a variable, has to be removed, since it may remove variables that do affect the expression but can be reasoned away based on their type. This normalization step does not seem to have effect apart from interacting with the change described above.