### PR TITLE
[herd] Event Register Semantics

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -32,6 +32,9 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
 
     let is_kvm = C.variant Variant.VMSA
 
+    let is_wfe = function
+      | I_WFE -> true
+      | _ -> false
     let pp_barrier_short = pp_barrier
     let reject_mixed = true
 
@@ -103,6 +106,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | I_SWP _| I_SWPBH _| I_SXTW _| I_TLBI _ | I_AT _ | I_UBFM _
     | I_UDF _| I_UNSEAL _ | I_ADDSUBEXT _ | I_ABS _ | I_REV _ | I_EXTR _
     | I_MOPL _ | I_MOP _
+    | I_WFE | I_SEV | I_SEVL
     | I_WHILELT _ | I_WHILELE _ | I_WHILELO _ | I_WHILELS _
     | I_UADDV _
     | I_LD1SP _ | I_LD2SP _ | I_LD3SP _ | I_LD4SP _
@@ -291,7 +295,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_CASBH (v,_,_,_,_) | I_SWPBH (v,_,_,_,_)
       | I_LDOPBH (_,v,_,_,_,_) | I_STOPBH (_,v,_,_,_) ->
           Some (bh_to_sz v)
-      | I_NOP|I_B _|I_BR _|I_BC (_, _)|I_CBZ (_, _, _)
+      | I_NOP | I_WFE | I_SEV | I_SEVL
+      | I_B _|I_BR _|I_BC (_, _)|I_CBZ (_, _, _)
       | I_CBNZ (_, _, _)|I_BL _|I_BLR _|I_RET _|I_ERET| I_SVC _ | I_LDAR (_, _, _, _)
       | I_TBNZ(_,_,_,_) | I_TBZ (_,_,_,_) | I_MOVZ (_,_,_,_) | I_MOVK(_,_,_,_)
       | I_MOVN _
@@ -352,7 +357,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_FENCE _
       | I_IC _|I_DC _|I_TLBI _ | I_AT _
       | I_NOP|I_TBZ _|I_TBNZ _
-      | I_ERET | I_SVC _  | I_UDF _
+      | I_WFE | I_SEV | I_SEVL
+      | I_ERET | I_SVC _ | I_UDF _
       | I_ST1SP _ | I_ST2SP _ | I_ST3SP _ | I_ST4SP _
       | I_ST1SPT _ | I_CTERM _
         -> [] (* For -variant self only ? *)
@@ -465,7 +471,8 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | I_LDARBH (bh,(XX|AX),_,_) -> MachSize.Ld (bh_to_sz bh)
       | I_STXR _|I_STXRBH _ | I_STXP _ -> MachSize.St
       | I_LDAR (_, (AA|AQ), _, _)|I_LDARBH (_, (AA|AQ), _, _)
-      | I_NOP|I_B _|I_BR _|I_BC _|I_CBZ _|I_CBNZ _
+      | I_NOP | I_WFE | I_SEV | I_SEVL
+      |I_B _|I_BR _|I_BC _|I_CBZ _|I_CBNZ _
       | I_TBNZ _|I_TBZ _|I_BL _|I_BLR _|I_RET _|I_ERET | I_SVC _
       | I_UBFM _ | I_SBFM _
       | I_LDR _|I_LDRSW _|I_LDRS _|I_LDUR _|I_LD1 _|I_LDAP1 _

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -636,6 +636,16 @@ module Make
         if mixed then fun _sz -> write_reg
         else write_reg_sz
 
+(* Create a symbolic event register for a given proc id `proc_id` *)
+      let ev_loc proc_id =
+        A.Location_global (V.Val (Constant.mk_ev_reg (Printf.sprintf "%d" proc_id)))
+
+(* Write to the event register of a given proc id `proc_id`, a given value `v` *)
+      let set_ev proc_id v ii =
+        M.write_loc
+        (mk_write quad Annot.N aexp Access.VIR (V.intToV v))
+        (ev_loc proc_id) ii
+
 (* Emit commit event *)
       let commit_bcc ii = M.mk_singleton_es (Act.Commit (Act.Bcc,None)) ii
       and commit_pred_txt txt ii =
@@ -4093,6 +4103,32 @@ Arguments:
         match inst with
         | I_NOP ->(* Instructions nop and branch below do not generate events, use a placeholder *)
            !(M.mk_singleton_es (Act.NoAction) ii)
+        (* Event Register Instructions *)
+        | I_WFE ->
+            let loc = ev_loc ii.A.proc in
+            let read_ev = M.read_loc Port.No (mk_read quad Annot.N aexp) loc ii in
+            let rec wfe_loop n =
+            if n <= 0 then M.zeroT
+            else
+              M.altT
+                (* Read 1: clear and proceed *)
+                (M.seq_mem
+                  (read_ev >>= fun v -> M.eqT v (V.intToV 1))
+                  (set_ev ii.A.proc 0 ii)
+                >>= fun ((), ()) -> M.unitT ())
+                (* Read 0: loop *)
+                (M.seq_mem
+                  (read_ev >>= fun v -> M.eqT v (V.intToV 0))
+                  (wfe_loop (n-1))
+                >>= fun ((), ()) -> M.unitT ())
+            in
+          !(wfe_loop 3)
+        | I_SEV ->
+           let all_procs = List.map (fun (p, _, _) -> p) test.Test_herd.start_points in
+           let writes = List.map (fun p -> set_ev p 1 ii) all_procs in
+           !!!(List.fold_right (>>::) writes (M.unitT []) >>| M.unitT ())
+        | I_SEVL ->
+           !(set_ev ii.A.proc 1 ii)
         (* Branches *)
         | I_B l ->
            M.mk_singleton_es (Act.NoAction) ii
@@ -4141,8 +4177,9 @@ Arguments:
            let commit_eret ii =
              M.mk_singleton_es (Act.Commit (Act.ExcReturn,None)) ii in
            commit_eret ii >>=
-             fun () -> read_reg_ord AArch64.elr_el1 ii >>=
-             eret_to_addr
+             fun () ->
+              (set_ev ii.A.proc 1 ii >>| read_reg_ord AArch64.elr_el1 ii)
+             >>= fun ((), v) -> eret_to_addr v
 
         | I_SVC imm ->
           let (>>!) = M.(>>!) in

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -26,6 +26,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
   struct
     include ARMBase
 
+    let is_wfe _ = false
     let pp_barrier_short = pp_barrier
     let reject_mixed = false
 

--- a/herd/ASLExtra.ml
+++ b/herd/ASLExtra.ml
@@ -31,6 +31,7 @@ module Make (B : ArchBaseHerd) (C : Arch_herd.Config) (V : Value.S) = struct
   include NoSemEnv
   include NoLevelNorTLBI
 
+  let is_wfe _ = false
   let pp_barrier_short = pp_barrier
   let reject_mixed = false
   let mem_access_size _ = None

--- a/herd/BPFArch_herd.ml
+++ b/herd/BPFArch_herd.ml
@@ -21,6 +21,7 @@ struct
 
   module CS = ConstraintSolver.No(V)
 
+  let is_wfe _ = false
   let pp_barrier_short = pp_barrier
   let reject_mixed = false
   let get_machsize _ = V.Cst.Scalar.machsize

--- a/herd/BellArch_herd.ml
+++ b/herd/BellArch_herd.ml
@@ -21,6 +21,7 @@ module Make
          (V:Value.S with type Cst.Instr.exec  = BellBase.instruction) = struct
   include BellBase
 
+  let is_wfe _ = false
   let pp_barrier_short = pp_barrier
   let reject_mixed = false
   let mem_access_size _ = None

--- a/herd/CArch_herd.ml
+++ b/herd/CArch_herd.ml
@@ -17,6 +17,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
   include CBase
   (* Not so simple, should consider expressions... *)
 
+  let is_wfe _ = false
   let pp_barrier_short = pp_barrier
   let reject_mixed = false
   let mem_access_size _ = None

--- a/herd/JavaArch_herd.ml
+++ b/herd/JavaArch_herd.ml
@@ -20,6 +20,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) = struct
 
   include JavaBase
 
+  let is_wfe _ = false
   let pp_barrier_short    = pp_barrier
   let reject_mixed        = false
   let mem_access_size _   = None

--- a/herd/MIPSArch_herd.ml
+++ b/herd/MIPSArch_herd.ml
@@ -22,6 +22,7 @@ module Make
   struct
     include MIPSBase
 
+    let is_wfe _ = false
     let pp_barrier_short = pp_barrier
     let reject_mixed = false
 

--- a/herd/PPCArch_herd.ml
+++ b/herd/PPCArch_herd.ml
@@ -21,6 +21,7 @@ module Make (C:Arch_herd.Config) (V:Value.S)
   struct
     include PPCBase
 
+    let is_wfe _ = false
     let pp_barrier_short = pp_barrier
     let reject_mixed = false
 

--- a/herd/RISCVArch_herd.ml
+++ b/herd/RISCVArch_herd.ml
@@ -22,6 +22,7 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
   struct
     include RISCVBase
 
+    let is_wfe _ = false
     let pp_barrier_short = function
       | FenceI -> "fence.i"
       | FenceTSO -> "fence.tso"

--- a/herd/X86Arch_herd.ml
+++ b/herd/X86Arch_herd.ml
@@ -20,6 +20,7 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
   struct
     include X86Base
 
+    let is_wfe _ = false
     let pp_barrier_short = pp_barrier
     let reject_mixed = false
 

--- a/herd/X86_64Arch_herd.ml
+++ b/herd/X86_64Arch_herd.ml
@@ -20,6 +20,7 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
   struct
     include X86_64Base
 
+    let is_wfe _ = false
     let pp_barrier_short = pp_barrier
     let reject_mixed = false
 

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -497,16 +497,19 @@ module Make(C:Config) (I:I) : S with module I = I
           (* | (System (TAG,s1),System (TAG,s2)) *)
            -> Misc.string_eq s1 s2
 (* One id allowed, the other on forbidden, does not match *)
-          | (Virtual _,(System ((PTE|TLB|PTE2),_)|Physical _|TagAddr _))
-          | ((TagAddr _|Physical _|System ((PTE|TLB|PTE2),_)),Virtual _)
+          | (Virtual _,(System ((PTE|TLB|PTE2),_)|Physical _|TagAddr _|EventReg _))
+          | ((TagAddr _|Physical _|System ((PTE|TLB|PTE2),_)|EventReg _),Virtual _)
           | (System (PTE,_),System ((TLB|PTE2),_))
           | (System ((TLB|PTE2),_),System (PTE,_))
-          | ((Physical _|TagAddr _),System (PTE,_))
-          | (System (PTE,_),(TagAddr _|Physical _))
+          | ((Physical _|TagAddr _|EventReg _),System (PTE,_))
+          | (System (PTE,_),(TagAddr _|Physical _|EventReg _))
+          | (EventReg _, (System _|Physical _|TagAddr _))
+          | ((System _|Physical _|TagAddr _), EventReg _)
             -> false
 (* Both forbidden, failure *)
           | (TagAddr _|Physical _|System ((TLB|PTE2),_)),
             (TagAddr _|Physical _|System ((TLB|PTE2),_))
+          | (EventReg _),(EventReg _)
             ->
               Warn.fatal
                 "Illegal id (%s or %s) in fault"
@@ -862,6 +865,11 @@ module Make(C:Config) (I:I) : S with module I = I
                 (pp_location loc)
           | Location_global (I.V.Val (Symbolic (Virtual _|Physical _)))
           | Location_reg _ -> reg_default_value
+          | Location_global (I.V.Val (Symbolic (EventReg _)))
+            ->
+              Warn.user_error
+                "No default value defined for location %s\n"
+                (pp_location loc)
 
       let get_of_val st a = State.safe_find I.V.zero (Location_global a) st
 

--- a/herd/arch_herd.mli
+++ b/herd/arch_herd.mli
@@ -27,6 +27,7 @@ module type S =
     module V : Value.S with type Cst.Instr.exec = instruction
     module CS : ConstraintSolver.S with module V = V
 
+    val is_wfe : instruction -> bool
     val pp_barrier_short : barrier -> string
     val reject_mixed : bool (* perform a check that rejects mixed-size tests *)
     val mem_access_size : instruction -> MachSize.sz option

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -98,7 +98,7 @@ end = struct
     let open Constant in
     function
     | A.Location_reg _ -> REG
-    | A.Location_global (V.Val (Symbolic (Virtual _))|V.Var _)
+    | A.Location_global (V.Val (Symbolic (Virtual _|EventReg _))|V.Var _)
       -> Access.VIR
     | A.Location_global (V.Val (Symbolic ((System ((PTE|PTE2),_))))) as loc
         ->
@@ -278,6 +278,9 @@ end = struct
        | _ -> false
      end
   | _ -> false
+  let is_evreg a = match a with
+    | Access (_, A.Location_global (A.V.Val (Constant.Symbolic (Constant.EventReg _))), _, _, _, _, _) -> true
+    | _ -> false
   let is_pt_data = function
     | Access (_,A.Location_global (A.V.Val c),_,_,_,_,Access.PTE DISide.Data) ->
         Constant.is_pt c
@@ -563,6 +566,7 @@ end = struct
     in
     ("T",is_tag)::
     ("TLBI",is_inv)::
+    ("EVREG",is_evreg)::
     ("no-loc", fun a -> Misc.is_none (location_of a))::
     (if kvm then
       fun k ->

--- a/herd/semExtra.ml
+++ b/herd/semExtra.ml
@@ -302,6 +302,7 @@ module Make(C:Config) (A:Arch_herd.S) (Act:Action.S with module A = A)
        * (2) to ensure is_non_mixed_offset works with that *)
       | Physical (s,o) -> is_non_mixed_offset test s o
       | TagAddr _
+      | EventReg _
       | System ((PTE|PTE2|TLB),_)  -> true
 
 (* Exported labels:

--- a/herd/test_herd.ml
+++ b/herd/test_herd.ml
@@ -87,6 +87,7 @@ module Make(A:Arch_herd.S) =
           | Physical (name, _) -> StringSet.add name acc
           | TagAddr (_, name, _) -> StringSet.add name acc
           | System (_, name) -> StringSet.add name acc
+          | EventReg name -> StringSet.add name acc
         end
       | PteVal p ->
           let open ParsedPteVal in
@@ -236,6 +237,18 @@ module Make(A:Arch_herd.S) =
 (* Entry point *)
 (***************)
 
+    let code_has_wfe code =
+      List.fold_left
+        (A.pseudo_fold
+          (fun found ins -> found || A.is_wfe ins))
+        false
+        code
+
+    let prog_has_wfe prog =
+      List.exists
+        (fun (_, code) -> code_has_wfe code)
+        prog
+
     let build name t =
       check_post_condition_symbols_exist t ;
       let t = Alloc.allocate_regs t in
@@ -269,6 +282,21 @@ module Make(A:Arch_herd.S) =
         fun addr -> IntMap.safe_find Label.Set.empty addr instr2labels in
       let type_env = A.build_type_env init in
       let init_state = A.build_state type_env init in
+      (* Initialize event registers only for tests that use WFE. *)
+      let init_state =
+        if prog_has_wfe nice_prog then
+          List.fold_left
+            (fun env (proc, _, _) ->
+              let loc =
+                A.Location_global
+                  (A.V.cstToV
+                    (Constant.mk_ev_reg (string_of_int proc))) in
+              let v = A.V.intToV 0 in
+              A.state_add env loc v)
+            init_state
+            starts
+        else
+          init_state in
       let flocs,ffaults = LocationsItem.locs_and_faults locs in
       let displayed =
         let flocs = A.RLocSet.of_list flocs in

--- a/jingle/AArch64Arch_jingle.ml
+++ b/jingle/AArch64Arch_jingle.ml
@@ -304,7 +304,7 @@ include Arch.MakeArch(struct
     end in
 
     function
-    | (I_FENCE _|I_NOP|I_RET None|I_ERET|I_SVC _|I_UDF _) as i -> unitT i
+    | (I_FENCE _|I_NOP|I_WFE|I_SEV|I_SEVL|I_RET None|I_ERET|I_SVC _|I_UDF _) as i -> unitT i
     | I_B l ->
         find_lab l >! fun l -> I_B l
     | I_BR r ->

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1379,6 +1379,10 @@ let pp_imm n = "#" ^ string_of_int n
 
 type 'k kinstruction =
   | I_NOP
+  (* Event Register Instructions *)
+  | I_SEV  
+  | I_SEVL
+  | I_WFE
 (* Branches *)
   | I_B of lbl | I_BR of reg
   | I_BC of condition * lbl
@@ -2141,6 +2145,10 @@ let do_pp_instruction m =
 
   fun i -> match i with
   | I_NOP -> "NOP"
+  (* Event Register Instructions *)
+  | I_WFE -> "WFE"
+  | I_SEV -> "SEV"
+  | I_SEVL -> "SEVL"
 (* Branches *)
   | I_B lbl ->
       sprintf "B %s" (pp_label lbl)
@@ -2666,7 +2674,7 @@ let fold_regs (f_regs,f_sregs) =
 
   fun c ins -> match ins with
   | I_NOP | I_B _ | I_BC _ | I_BL _ | I_FENCE _ | I_RET None | I_ERET | I_SVC _
-  | I_UDF _ |  I_SMSTART (None) | I_SMSTOP (None)
+  | I_UDF _ |  I_SMSTART (None) | I_SMSTOP (None) | I_WFE | I_SEV | I_SEVL
     -> c
   | I_CBZ (_,r,_) | I_CBNZ (_,r,_) | I_BLR r | I_BR r | I_RET (Some r)
   | I_MOVZ (_,r,_,_) | I_MOVN (_,r,_,_) | I_MOVK (_,r,_,_)
@@ -2812,7 +2820,11 @@ let map_regs f_reg f_symb =
 
   fun ins -> match ins with
   | I_NOP
-(* Branches *)
+  (* Event Register Instructions *)
+  | I_WFE 
+  | I_SEV 
+  | I_SEVL
+  (* Branches *)
   | I_B _
   | I_BC _
   | I_FENCE _
@@ -3204,6 +3216,7 @@ let get_next =
     -> tgt_cons Label.Next lbl
   | I_BLR _|I_BR _|I_RET _ |I_ERET -> [Label.Any]
   | I_NOP
+  | I_WFE | I_SEV | I_SEVL
   | I_LDR _
   | I_LDRSW _
   | I_LDRS _
@@ -3631,6 +3644,9 @@ module PseudoI = struct
 
       let parsed_tr i = match i with
         | I_NOP
+        | I_WFE
+        | I_SEV
+        | I_SEVL
         | I_B _
         | I_BR _
         | I_BC _
@@ -3832,6 +3848,9 @@ module PseudoI = struct
         | I_ST4 _ | I_STZ2G _
           -> 4
         | I_NOP
+        | I_WFE
+        | I_SEV
+        | I_SEVL
         | I_B _ | I_BR _
         | I_BL _ | I_BLR _
         | I_RET _

--- a/lib/AArch64Lexer.mll
+++ b/lib/AArch64Lexer.mll
@@ -33,6 +33,10 @@ let keyword_list = [
   "hint", HINT;
   (* Halt instructions are used by Debug mode, not needed here - NOP *)
   "hlt", HLT;
+  (* Event Register *)
+  "wfe", WFE;
+  "sev", SEV;
+  "sevl", SEVL;
   (* Branch *)
   "b", TOK_B;
   "br", BR;

--- a/lib/AArch64Parser.mly
+++ b/lib/AArch64Parser.mly
@@ -90,6 +90,7 @@ let check_op3 op e =
 
 /* Instructions */
 %token NOP HINT HLT
+%token WFE SEV SEVL
 %token TOK_B BR CBZ CBNZ TBZ TBNZ
 %token TOK_EQ TOK_NE TOK_GE TOK_GT TOK_LE TOK_LT
 %token TOK_CS TOK_CC TOK_MI TOK_PL TOK_VS TOK_VC TOK_HI TOK_LS TOK_AL
@@ -667,6 +668,10 @@ instr:
 | NOP { I_NOP }
 | HINT NUM { I_NOP }
 | HLT NUM { I_NOP }
+/* Event Register Instructions */
+| WFE { I_WFE }
+| SEV { I_SEV }
+| SEVL { I_SEVL }
 /* Branch */
 | TOK_B label_addr { I_B $2 }
 | BR xreg { I_BR $2 }

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -162,12 +162,14 @@ type symbol =
   | Physical of string * int                (* symbol, index *)
   | TagAddr of tagkind * string * int
   | System of syskind * string              (* System memory *)
+  | EventReg of string                      (* Event register *)
 
 let get_index = function
   | Virtual s -> Some s.offset
   | Physical (_,o)|TagAddr (_,_,o) -> Some o
   | System ((PTE|PTE2), _) -> Some 0
   | System (TLB, _) -> None
+  | EventReg _ -> None
 
 let pp_physical s = sprintf "PA(%s)" s
 
@@ -185,6 +187,7 @@ let pp_symbol_old = function
   | System (TLB,s) -> Misc.add_tlb s
   | System (PTE,s) -> Misc.add_pte s
   | System (PTE2,s) -> Misc.add_pte (Misc.add_pte s)
+  | EventReg s -> sprintf "ev(%s)" s
 
 
 let pp_symbol = function
@@ -194,6 +197,7 @@ let pp_symbol = function
   | System (TLB,s) -> sprintf "TLB(%s)" s
   | System (PTE,s) -> sprintf "PTE(%s)" s
   | System (PTE2,s) -> sprintf "PTE(PTE(%s))" s
+  | EventReg s -> sprintf "ev(%s)" s
 
 let pp_symbol_init = function
   | Virtual s -> pp_symbolic_data ~pp_index:pp_index_init s s.offset
@@ -206,6 +210,7 @@ let compare_id_offset s1 o1 s2 o2 =
 
 let compare_symbol sym1 sym2 = match sym1,sym2 with
 | Virtual s1,Virtual s2 -> compare_symbolic_data s1 s2
+| EventReg s1, EventReg s2 -> String.compare s1 s2
 | (Physical (s1,o1),Physical (s2,o2))
   ->
    compare_id_offset s1 o1 s2 o2
@@ -221,13 +226,15 @@ let compare_symbol sym1 sym2 = match sym1,sym2 with
     | 0 -> String.compare s1 s2
     | r -> r
     end
-| (Virtual _,(Physical _|TagAddr _|System _ ))
-| (Physical _,(TagAddr _|System _))
-| (TagAddr _,System _)
+| (Virtual _,(Physical _|TagAddr _|System _|EventReg _))
+| (Physical _,(TagAddr _|System _|EventReg _))
+| (TagAddr _,(System _|EventReg _))
+| (System _,EventReg _)
   -> -1
-| ((Physical _|TagAddr _|System _),Virtual _)
-| ((TagAddr _|System _),Physical _)
-| (System _,TagAddr _)
+| ((Physical _|TagAddr _|System _|EventReg _),Virtual _)
+| ((TagAddr _|System _|EventReg _),Physical _)
+| ((System _|EventReg _),TagAddr _)
+| (EventReg _,System _)
   -> 1
 
 let id_offset_eq s1 o1 s2 o2 =
@@ -235,16 +242,18 @@ let id_offset_eq s1 o1 s2 o2 =
 
 let symbol_eq s1 s2 = match s1,s2 with
   | Virtual s1,Virtual s2 -> symbolic_data_eq s1 s2
+  | EventReg s1, EventReg s2 -> Misc.string_eq s1 s2
   | (Physical (s1,o1),Physical (s2,o2)) ->
      id_offset_eq s1 o1 s2 o2
   | (TagAddr (t1,s1,o1),TagAddr (t2,s2,o2))  ->
      t1=t2 && id_offset_eq s1 o1 s2 o2
   | System (k1,s1),System (k2,s2) ->
       k1=k2 && Misc.string_eq s1 s2
-  | (Virtual _,(Physical _|TagAddr _|System _))
-  | (Physical _,(Virtual _|TagAddr _|System _))
-  | (System _,(Virtual _|TagAddr _|Physical _))
-  | (TagAddr _,(Virtual _|System _|Physical _))
+  | (Virtual _,(Physical _|TagAddr _|System _|EventReg _))
+  | (Physical _,(Virtual _|TagAddr _|System _|EventReg _))
+  | (System _,(Virtual _|TagAddr _|Physical _|EventReg _))
+  | (TagAddr _,(Virtual _|System _|Physical _|EventReg _))
+  | (EventReg _,(Virtual _|Physical _|TagAddr _|System _))
     -> false
 
 let as_address = function
@@ -466,6 +475,7 @@ let unmk_sym_virtual_label_with_offset = function
   | _ -> assert false
 
 let mk_sym_virtual s = Symbolic (do_mk_virtual s)
+let mk_ev_reg s = Symbolic (EventReg s)
 let mk_sym s = Symbolic (do_mk_sym s)
 
 let mk_sym_with_index s i =
@@ -544,6 +554,7 @@ let is_non_mixed_symbol = function
   | TagAddr (_,_,idx)
     -> idx=0
   | System _ -> true
+  | EventReg _ -> true
 
 let default_tag = Tag "green"
 

--- a/lib/constant.mli
+++ b/lib/constant.mli
@@ -75,6 +75,7 @@ type symbol =
   | Physical of string * int       (* symbol, index *)
   | TagAddr of tagkind * string * int
   | System of syskind * string     (* System memory *)
+  | EventReg of string             (* Event register *)
 
 val get_index : symbol -> int option
 val pp_symbol_old : symbol -> string
@@ -157,6 +158,7 @@ val mk_sym_virtual_label : Proc.t -> Label.t -> ('scalar,'pte,'addrreg,'instr) t
 val mk_sym_virtual_label_with_offset : Proc.t -> Label.t -> offset -> ('scalar,'pte,'addrreg,'instr) t
 val unmk_sym_virtual_label_with_offset : ('scalar,'pte,'addrreg,'instr) t -> Proc.t * Label.t * offset
 val mk_sym_virtual : string -> ('scalar,'pte,'addrreg,'instr) t
+val mk_ev_reg : string -> ('scalar,'pte,'addrreg,'instr) t
 val mk_sym : string -> ('scalar,'pte,'addrreg,'instr) t
 val mk_sym_with_index : string -> int -> ('scalar,'pte,'addrreg,'instr) t
 val mk_sym_pte : string -> ('scalar,'pte,'addrreg,'instr) t

--- a/lib/symbConstant.ml
+++ b/lib/symbConstant.ml
@@ -82,7 +82,7 @@ module Make
 
   let access_of_constant =
     function
-    | Symbolic (Virtual _) -> Access.VIR
+    | Symbolic (Virtual _) | Symbolic (EventReg _) -> Access.VIR
     | Symbolic (Physical _) -> Access.PHY
     | Symbolic (TagAddr _) -> Access.TAG
     | Symbolic (System ((PTE|PTE2),_)) -> Access.PTE DISide.Data

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -332,7 +332,7 @@ module
     Val (Symbolic (Virtual {s with offset=i+k}))
   | Val (Symbolic (Physical (s,i))) -> Val (Symbolic (Physical (s,i+k)))
   | Val (ConcreteVector _|ConcreteRecord _
-       | Symbolic ((TagAddr _|System _))
+       | Symbolic ((TagAddr _|System _|EventReg _))
        |Tag _|PteVal _|AddrReg _|Instruction _|Frozen _ as c) ->
       Warn.user_error "Illegal addition on constants %s +%d" (Cst.pp_v c) k
   | Var _ -> raise Undetermined
@@ -502,7 +502,7 @@ module
 
   let op_tagged op_op op v = match v with
   |  Val (Symbolic (Virtual ({offset=o;_} as a))) -> Val (op a o)
-  |  Val (Symbolic (Physical _|TagAddr _|System _)
+  |  Val (Symbolic (Physical _|TagAddr _|System _|EventReg _)
           |Concrete _
           |Tag _|ConcreteRecord _|ConcreteVector _
           |PteVal _|AddrReg _|Instruction _
@@ -525,7 +525,7 @@ module
        Val (Symbolic (TagAddr (PHY,a,MachSize.granule_align o)))
     | Val
         (Concrete _|ConcreteRecord _|ConcreteVector _
-         |Symbolic ((TagAddr _|System _))
+         |Symbolic ((TagAddr _|System _|EventReg _))
          |Tag _|PteVal _|AddrReg _
          |Instruction _|Frozen _)
       ->
@@ -534,7 +534,7 @@ module
 
   let check_ctag = function
     | Val (Symbolic (Virtual {name=s;_})) -> Misc.check_ctag (Symbol.pp s)
-    | Val (Symbolic (Physical _|System _|TagAddr _)) -> false
+    | Val (Symbolic (Physical _|System _|TagAddr _|EventReg _)) -> false
     | Var _
     | Val
         (Concrete _|ConcreteRecord _|ConcreteVector _

--- a/litmus/AArch64Compile_litmus.ml
+++ b/litmus/AArch64Compile_litmus.ml
@@ -1768,6 +1768,10 @@ module Make(V:Constant.S)(C:Config) =
 
       let compile_ins tr_lab ins k = match ins with
     | I_NOP -> { empty_ins with memo = "nop"; }::k
+(* Event Register Instructions *)
+    | I_WFE -> { empty_ins with memo = "wfe"; }::k
+    | I_SEV -> { empty_ins with memo = "sev"; }::k
+    | I_SEVL -> { empty_ins with memo = "sevl"; }::k
 (* Branches *)
     | I_B lbl -> b tr_lab lbl::k
     | I_BR r -> br r::k

--- a/tools/alpha.ml
+++ b/tools/alpha.ml
@@ -205,7 +205,7 @@ struct
     | PteVal _ -> nopte_value ()
     | AddrReg _ -> noaddrreg_value ()
     | Instruction _ -> noinstr_value ()
-    | Symbolic (Physical _|TagAddr _|System (TLB,_))
+    | Symbolic (Physical _|TagAddr _|System (TLB,_)|EventReg _)
     | Frozen _
       -> assert false
 
@@ -224,7 +224,7 @@ struct
     | PteVal _ -> nopte_value ()
     | AddrReg _ -> noaddrreg_value ()
     | Instruction _ -> noinstr_value ()
-    | Frozen _|Symbolic (Physical _|TagAddr _|System (TLB,_))
+    | Frozen _|Symbolic (Physical _|TagAddr _|System (TLB,_)|EventReg _)
       -> assert false
 
 


### PR DESCRIPTION
Adds semantics for the event register instructions: `WFE, SEV, SEVL `

#### Summary
The three instructions interact with event registers as follows:

SEVL: Send Event Local. Sets the current PE's event register to 1.
SEV: Send Event. Sets every PE's event register to 1 (broadcast wake-up).
WFE: Wait For Event. If the event register is 1, clear it and fall through. If it is 0, wait until some other PE issues SEV before clearing and continuing.

The event register is modelled as a per-thread symbolic memory location. A new `Constant.EventReg` of `string symbolic` kind is introduced, initialised to 0 at test start in `test_herd.ml.` An `Access.EVREG` access kind is added so reads/writes to these locations can be distinguished from ordinary memory.

SEVL: a single `write_loc` of 1 to the current thread's event register.
SEV: iterates over `test.start_points,` emitting one `write_loc` 1 per thread's event register in parallel.
WFE: a bounded loop (`wfe_loop 3`) non-deterministically branches on the value read.

#### Tests
Not added