### PR TITLE
[asl] Relaxing the symbolic evaluability check for slices on the left-hand side of assignments

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1210,11 +1210,15 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
   let rec annotate_bitfield ~loc env width bitfield : bitfield * SES.t =
     match bitfield with
     | BitField_Simple (name, slices) ->
-        let slices1, ses_slices = annotate_slices ~loc env slices in
+        let slices1, ses_slices =
+          annotate_slices ~is_rhs:true ~loc env slices
+        in
         let+ () = check_slices_in_width ~loc env width slices1 in
         (BitField_Simple (name, slices1), ses_slices) |: TypingRule.TBitField
     | BitField_Nested (name, slices, bitfields') ->
-        let slices1, ses_slices = annotate_slices ~loc env slices in
+        let slices1, ses_slices =
+          annotate_slices ~is_rhs:true ~loc env slices
+        in
         let diet = disjoint_slices_to_positions ~loc ~static:true env slices1 in
         let+ () = check_diet_in_width ~loc slices1 width diet in
         let width' = Diet.Int.cardinal diet |> expr_of_int in
@@ -1226,7 +1230,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         |: TypingRule.TBitField
     | BitField_Type (name, slices, ty) ->
         let ty', ses_ty = annotate_type ~loc env ty in
-        let slices1, ses_slices = annotate_slices ~loc env slices in
+        let slices1, ses_slices =
+          annotate_slices ~is_rhs:true ~loc env slices
+        in
         let diet = disjoint_slices_to_positions ~loc ~static:true env slices1 in
         let+ () = check_diet_in_width ~loc slices1 width diet in
         let width' = Diet.Int.cardinal diet |> expr_of_int in
@@ -1424,13 +1430,20 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         (Constraint_Range (e1', e2'), ses)
   (* End *)
 
-  and annotate_slices env ~loc =
-    (* Rule:
-      The width of a bitslice must be any non-negative,
-      symbolically evaluable integer expression (including zero).
+  (** [annotate_slices env ~is_rhs ~loc slices] annotates [slices] in the
+      context of [env]. The [is_rhs] flag is true when the slices are on the
+      right-hand side of an assignment. *)
+  and annotate_slices env ~is_rhs ~loc slices =
+    (* Rules:
+      - The width of a bitslice must be a non-negative integer expression, including zero.
+      - The width of a bitslice must be constrained.
+      - If the bitslice is on the right-hand side of an assignment, then the width must be
+        symbolically evaluable, and if it is on the left-hand side, the normalized expression
+        must be symbolically evaluable.
     *)
+
     (* Begin Slice *)
-    let rec annotate_slice s =
+    let rec annotate_slice ~is_rhs s =
       let () =
         if false then
           Format.eprintf "Annotating slice %a@." PP.pp_slice_list [ s ]
@@ -1440,11 +1453,30 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           (* Rule:
              The notation b[i] is syntactic sugar for b[i +: 1].
           *)
-          annotate_slice (Slice_Length (i, one_expr)) |: TypingRule.Slice
+          annotate_slice ~is_rhs (Slice_Length (i, one_expr))
+          |: TypingRule.Slice
       | Slice_Length (offset, length) ->
-          let t_offset, offset', ses_offset = annotate_expr env offset
-          and length', ses_length =
-            annotate_symbolic_constrained_integer ~loc env length
+          let t_offset, offset', ses_offset = annotate_expr env offset in
+          let length', ses_length =
+            if is_rhs then annotate_symbolic_constrained_integer ~loc env length
+            else
+              (* This case is similar to the one above, except that check
+                whether the length is symbolically evaluable is performed
+                on the normalized expression. *)
+              let t_length, length_annot, ses_length =
+                annotate_expr env length
+              in
+              let normalized_length =
+                StaticModel.try_normalize env length_annot
+              in
+              let _, _, normalized_length_ses =
+                annotate_expr env normalized_length
+              in
+              let+ () =
+                check_symbolically_evaluable length normalized_length_ses
+              in
+              let+ () = check_constrained_integer ~loc env t_length in
+              (normalized_length, ses_length)
           in
           let+ () = check_is_readonly offset ses_offset in
           let+ () = check_is_readonly length ses_length in
@@ -1456,19 +1488,19 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
              The notation b[j:i] is syntactic sugar for b[i +: j-i+1].
           *)
           let length = binop `SUB j i |> binop `ADD !$1 in
-          annotate_slice (Slice_Length (i, length)) |: TypingRule.Slice
+          annotate_slice ~is_rhs (Slice_Length (i, length)) |: TypingRule.Slice
       | Slice_Star (factor, length) ->
           (* Rule:
              The notation b[i *: n] is syntactic sugar for b[i*n +: n]
           *)
           let offset = binop `MUL factor length in
-          annotate_slice (Slice_Length (offset, length)) |: TypingRule.Slice
+          annotate_slice ~is_rhs (Slice_Length (offset, length))
+          |: TypingRule.Slice
       (* End *)
     in
-    fun slices ->
-      let slices, sess = list_map_split annotate_slice slices in
-      let ses = ses_non_conflicting_unions ~loc sess in
-      (slices, ses)
+    let slices, sess = list_map_split (annotate_slice ~is_rhs) slices in
+    let ses = ses_non_conflicting_unions ~loc sess in
+    (slices, ses)
 
   and annotate_pattern ~loc env t p =
     let here = add_pos_from ~loc:p in
@@ -2083,7 +2115,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                 *)
                 let slices', ses2 =
                   best_effort (slices, SES.empty) (fun _ ->
-                      annotate_slices env slices ~loc)
+                      annotate_slices env ~is_rhs:true ~loc slices)
                 in
                 let w = slices_width env slices' in
                 let ses = SES.union ses1 ses2 in
@@ -2552,7 +2584,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             let le2, ses1 = annotate_lexpr env le1 t_le1 in
             let slices_annotated, ses_slices =
               best_effort (slices, SES.empty) @@ fun _ ->
-              annotate_slices env slices ~loc
+              annotate_slices env ~is_rhs:false slices ~loc
             in
             let+ () =
              fun () ->

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -406,7 +406,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       that different slices do not overlap and that slices are not defined in
       reverse. Determining the set of positions requires evaluating the
       expressions comprising the slices. [static] indicates that the expressions
-      defining the slices must be statically evaluable, in which case they are
+      defining the slices must be symbolically evaluable, in which case they are
       statically evaluated to accurately determine the set of positions.
       Otherwise, normalization is used in an attempt to reduce them to literals.
       Slices for which the expressions cannot be reduced to literals do not
@@ -1199,7 +1199,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       let width = get_bitvector_width ~loc env (List.hd arg_types) in
       let param_type = integer_exact' width |> add_pos_from ~loc:width in
       let ses_param =
-        (* This is enough as the bitvector width is statically evaluable and
+        (* This is enough as the bitvector width is symbolically evaluable and
            its timeframe is earlier than the argument itself. *)
         SES.empty
       in
@@ -1270,7 +1270,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     (* Begin TNamed *)
     | T_Named x ->
         let ses =
-          (* As expression on which types depend are statically evaluable,
+          (* As expression on which types depend are symbolically evaluable,
              using a named type is as reading a global immutable storage
              element. *)
           let time_frame =
@@ -1425,9 +1425,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
   (* End *)
 
   and annotate_slices env ~loc =
-    (* Rules:
-       - Rule WZCS: The width of a bitslice must be any non-negative,
-         statically evaluable integer expression (including zero).
+    (* Rule:
+      The width of a bitslice must be any non-negative,
+      symbolically evaluable integer expression (including zero).
     *)
     (* Begin Slice *)
     let rec annotate_slice s =
@@ -1437,7 +1437,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       in
       match s with
       | Slice_Single i ->
-          (* LRM R_GXKG:
+          (* Rule:
              The notation b[i] is syntactic sugar for b[i +: 1].
           *)
           annotate_slice (Slice_Length (i, one_expr)) |: TypingRule.Slice
@@ -1452,13 +1452,13 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           let ses = SES.union ses_length ses_offset in
           (Slice_Length (offset', length'), ses |: TypingRule.Slice)
       | Slice_Range (j, i) ->
-          (* LRM R_GXKG:
+          (* Rule:
              The notation b[j:i] is syntactic sugar for b[i +: j-i+1].
           *)
           let length = binop `SUB j i |> binop `ADD !$1 in
           annotate_slice (Slice_Length (i, length)) |: TypingRule.Slice
       | Slice_Star (factor, length) ->
-          (* LRM R_GXQG:
+          (* Rule:
              The notation b[i *: n] is syntactic sugar for b[i*n +: n]
           *)
           let offset = binop `MUL factor length in
@@ -1480,7 +1480,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     | Pattern_Any li ->
         let new_li, sess = list_map_split (annotate_pattern ~loc env t) li in
         let ses =
-          (* They can't be conflicting because they are statically evaluable *)
+          (* They can't be conflicting because they are symbolically evaluable *)
           SES.unions sess
         in
         (Pattern_Any new_li |> here, ses) |: TypingRule.PAny
@@ -1544,7 +1544,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         let t_e1, e1', ses1 = annotate_symbolically_evaluable_expr env e1
         and t_e2, e2', ses2 = annotate_symbolically_evaluable_expr env e2 in
         let ses =
-          (* They can't be conflicting because they are statically evaluable *)
+          (* They can't be conflicting because they are symbolically evaluable *)
           SES.union ses1 ses2
         in
         let+ () =
@@ -1636,7 +1636,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         @@ Error.BadArity
              (Static, name, List.length func_sig.args, List.length args)
     in
-    (* Check that call parameters are statically evaluable and type-satisfy the
+    (* Check that call parameters are symbolically evaluable and type-satisfy the
        declaration parameters *)
     let () =
       (* CheckParamsTypeSat( *)
@@ -1996,10 +1996,10 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     | E_Array _ -> fatal_from ~loc UnrespectedParserInvariant
     (* Begin ERecord *)
     | E_Record (ty, fields) ->
-        (* Rule WBCQ: The identifier in a record expression must be a named type
+        (* Rule: The identifier in a record expression must be a named type
            with the structure of a record type, and whose fields have the values
            given in the field_assignment_list.
-           Rule WZWC: The identifier in a exception expression must be a named
+           Rule: The identifier in a exception expression must be a named
            type with the structure of an exception type, and whose fields have
            the values given in the field_assignment_list.
         *)
@@ -2013,7 +2013,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           | T_Exception fields | T_Record fields | T_Collection fields -> fields
           | _ -> conflict ~loc [ T_Record [] ] ty
         in
-        (* Rule DYQZ: A record expression shall assign every field of the record. *)
+        (* Rule: A record expression shall assign every field of the record. *)
         let () =
           if
             List.for_all
@@ -2077,7 +2077,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                   fatal_from ~loc Error.EmptySlice
                 in
                 (* TODO: check that:
-                   - Rule SNQJ: An expression or subexpression which
+                   - Rule: An expression or subexpression which
                      may result in a zero-length bitvector must not be
                      side-effecting.
                 *)
@@ -2271,8 +2271,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     (* Begin EPattern *)
     | E_Pattern (e1, pat) ->
         (*
-         Rule ZNDL states that
-
+         Rule:
          The IN operator is equivalent to testing its first operand for
          equality against each value in the (possibly infinite) set denoted
          by the second operand, and taking the logical OR of the result.
@@ -2807,7 +2806,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     match ldi with
     (* Begin LDVar *)
     | LDI_Var x ->
-        (* Rule LCFD: A ~local declaration shall not declare an identifier
+        (* Rule: A local declaration shall not declare an identifier
            which is already in scope at the point of declaration. *)
         let+ () = check_is_not_collection ~loc env ty in
         let+ () = check_var_not_in_env ~loc env x in
@@ -2917,9 +2916,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     (* End *)
     (* Begin SReturn *)
     | S_Return e_opt ->
-        (* Rule NYWH: A return statement appearing in a setter or procedure must
+        (* Rule: A return statement appearing in a setter or procedure must
            have no return value expression. *)
-        (* Rule PHNZ: A return statement appearing in a getter or function
+        (* Rule: A return statement appearing in a getter or function
            requires a return value expression that type-satisfies the return
            type of the subprogram. *)
         (match (env.local.return_type, e_opt) with

--- a/asllib/doc/Slicing.tex
+++ b/asllib/doc/Slicing.tex
@@ -126,6 +126,15 @@ The slices in
 \listingref{semantics-scaledfromzero}
 are all well-typed.
 
+\ExampleDef{Annotating Left-hand Side Slices}
+\listingref{typing-annotatelhsslices} shows an example of annotating a slice
+on the left-hand side of an assignment.
+The slice is well-typed because the normalized length expression of the slice
+is symbolically evaluable.
+
+\ASLListing{Annotating left-hand side slices}{typing-annotatelhsslices}
+{\typingtests/TypingRule.AnnotateSlices_lhs.asl}
+
 \RenderProseAndFormally{annotate_slice}
 
 \TypingRuleDef{SlicesWidth}

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -2274,7 +2274,7 @@ typing relation annotate_expr(tenv: static_envs, e: expr) -> (t: ty, new_e: expr
     case okay {
       ast_label(struct_t_e') in make_set(label_T_Bits, label_T_Int);
       te_check(slices != empty_list, TE_BS) -> True;
-      annotate_slices(tenv, slices) -> (slices', ses2);
+      annotate_slices(tenv, True, slices) -> (slices', ses2);
       slices_width(tenv, slices) -> w;
       ses := union(ses1, ses2);
       --
@@ -3202,7 +3202,7 @@ typing relation annotate_lexpr(tenv: static_envs, le: lexpr, t_e: ty) ->
     make_anonymous(tenv, t_le1) -> t_le1_anon;
     te_check(ast_label(t_le1_anon) = label_T_Bits, TE_UT) -> True;
     annotate_lexpr(tenv, le1, t_le1) -> (le2, ses1);
-    annotate_slices(tenv, slices) -> (slices_annot, ses_slices);
+    annotate_slices(tenv, False, slices) -> (slices_annot, ses_slices);
     slices_width(tenv, slices_annot) -> e_w;
     normalize(tenv, e_w) -> v_w;
     t := T_Bits(v_w, empty_list);
@@ -3993,7 +3993,7 @@ typing relation annotate_bitfield(tenv: static_envs, width: Z, field: bitfield) 
 } =
   case simple {
     field =: BitField_Simple(name, slices);
-    annotate_slices(tenv, slices) -> (slices1, ses_slices);
+    annotate_slices(tenv, True, slices) -> (slices1, ses_slices);
     check_slices_in_width(tenv, width, slices1) -> True;
     --
     (BitField_Simple(name, slices1), ses_slices)
@@ -4002,7 +4002,7 @@ typing relation annotate_bitfield(tenv: static_envs, width: Z, field: bitfield) 
 
   case nested {
     field =: BitField_Nested(name, slices, bitfields');
-    annotate_slices(tenv, slices) -> (slices1, ses_slices);
+    annotate_slices(tenv, True, slices) -> (slices1, ses_slices);
     disjoint_slices_to_positions(tenv, True, slices1) -> positions;
     check_positions_in_width(width, positions) -> True;
     width' := ELint(cardinality(positions));
@@ -4016,7 +4016,7 @@ typing relation annotate_bitfield(tenv: static_envs, width: Z, field: bitfield) 
 
   case type {
     field =: BitField_Type(name, slices, t);
-    annotate_slices(tenv, slices) -> (slices1, ses_slices);
+    annotate_slices(tenv, True, slices) -> (slices1, ses_slices);
     annotate_type(False, tenv, t) -> (t', ses_ty);
     check_slices_in_width(tenv, width, slices1) -> True;
     disjoint_slices_to_positions(tenv, True, slices1) -> positions;
@@ -7755,29 +7755,42 @@ typing function ses_for_subprogram(qualifier: option(func_qualifier)) ->
 //////////////////////////////////////////////////
 // Relations for Slicing
 
-typing relation annotate_slice(tenv: static_envs, s: slice) -> (s': slice, ses: powerset(TSideEffect)) | type_error
+typing relation annotate_slice(tenv: static_envs, is_rhs: Bool, s: slice) -> (s': slice, ses: powerset(TSideEffect)) | type_error
 {
-  "annotates a single slice {s} in the \staticenvironmentterm{} {tenv},
+  "annotates a single slice {s} in the \staticenvironmentterm{} {tenv} with the flag {is_rhs},
   resulting in an annotated slice {s'} and a \sideeffectsetterm{}
   {ses}. \ProseOtherwiseTypeError",
-  prose_transition = "annotating {s} in the context of {tenv} yields"
+  prose_transition = "annotating {s} in the context of {tenv} with flag {is_rhs} yields"
 } =
   case single {
     s =: Slice_Single(i);
-    annotate_slice(tenv, Slice_Length(i, ELint(one))) -> (s', ses);
+    annotate_slice(tenv, is_rhs, Slice_Length(i, ELint(one))) -> (s', ses);
   }
 
   case range {
     s =: Slice_Range(j, i);
     length' := AbbrevEBinop(SUB, j, i);
     length  := AbbrevEBinop(ADD, length', ELint(one));
-    annotate_slice(tenv, Slice_Length(i, length)) -> (s', ses);
+    annotate_slice(tenv, is_rhs, Slice_Length(i, length)) -> (s', ses);
   }
 
   case length {
     s =: Slice_Length(offset, length);
     annotate_expr(tenv, offset) -> (t_offset, offset', ses_offset);
-    annotate_symbolic_constrained_integer(tenv, length) -> (length', ses_length) { math_layout = [_] };
+    case rhs {
+      annotate_symbolic_constrained_integer(tenv, length) ->
+        (length', ses_length) { math_layout = [_] };
+    }
+    case lhs {
+      annotate_expr(tenv, length) -> (t_length, length_annot, ses_length)
+      { math_layout = [_] };
+      normalize(tenv, length_annot) -> normalized_length;
+      annotate_expr(tenv, normalized_length) -> (_, _, normalized_length_ses)
+      { math_layout = [_] };
+      check_symbolically_evaluable(normalized_length_ses) -> True;
+      check_constrained_integer(tenv, t_length) -> True;
+      length' := normalized_length;
+    }
     te_check(ses_is_readonly(ses_offset), TE_SEV) -> True;
     te_check(ses_is_readonly(ses_length), TE_SEV) -> True;
     check_underlying_integer(tenv, t_offset) -> True;
@@ -7788,7 +7801,7 @@ typing relation annotate_slice(tenv: static_envs, s: slice) -> (s': slice, ses: 
   case scaled {
     s =: Slice_Star(factor, length);
     offset := AbbrevEBinop(MUL, factor, length);
-    annotate_slice(tenv, Slice_Length(offset, length)) -> (s', ses);
+    annotate_slice(tenv, is_rhs, Slice_Length(offset, length)) -> (s', ses);
   }
   --
   (s', ses);
@@ -7869,18 +7882,20 @@ typing relation annotate_symbolic_constrained_integer(tenv: static_envs, e: expr
   (e'', ses);
 ;
 
-typing relation annotate_slices(tenv: static_envs, slices: list0(slice)) ->
-         (slices': list0(slice), ses: powerset(TSideEffect))
+typing relation annotate_slices(tenv: static_envs, is_rhs: Bool, slices: list0(slice)) ->
+         (slices': list0(slice), ses: powerset(TSideEffect)) | type_error
 {
   "annotates a list of slices {slices} in the
-  \staticenvironmentterm{} {tenv}, yielding a list of
+  \staticenvironmentterm{} {tenv} with flag {is_rhs}, yielding a list of
   annotated slices (that is, slices in the \typedast)
   and a \sideeffectsetterm{} {ses}.
+  The flag {is_rhs} indicates whether {slices} appear in a \rhsexpression{} ($\True$)
+  or in an \assignableexpression{} ($\False$).
   \ProseOtherwiseTypeError",
-  prose_application = "the annotated slices for {slices} in {tenv}",
-  prose_transition = "annotating {slices} in the context of {tenv} yields",
+  prose_application = "the annotated slices for {slices} in {tenv} with {is_rhs}",
+  prose_transition = "annotating {slices} in the context of {tenv} with {is_rhs} yields",
 } =
-  INDEX(i, slices: annotate_slice(tenv, slices[i]) -> (slices'[i], xs[i]));
+  INDEX(i, slices: annotate_slice(tenv, is_rhs, slices[i]) -> (slices'[i], xs[i]));
   ses := union_list(xs);
   --
   (slices', ses);

--- a/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateSlices_lhs.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.AnnotateSlices_lhs.asl
@@ -1,0 +1,17 @@
+func write_chunks(message: bits(64), code: bits(8)) => bits(64)
+begin
+        var chunk_index : integer{0..8}  = 0;
+        var new_message: bits(64);
+
+        while (TRUE) looplimit 5 do
+            // The slice expression on the left-hand side of the assignment
+            // is not syntactically symbolically evaluable because it contains
+            // the mutable variable chunk_index, but it is semantically
+            // symbolically evaluable because chunk_index does not affect
+            // the length of the slice, which is a constant 8
+            // (8 * chunk_index - 8 * chunk_index + 7 + 1 = 8).
+            new_message[8 * chunk_index + 7 : 8 * chunk_index] = code;
+            chunk_index = chunk_index + 1 as integer{0..8};
+        end;
+        return new_message;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -1231,6 +1231,7 @@ ASL Typing Tests / annotating types:
               ^^^^^^^^^^^^^^^^
   ASL Type error: expected a readonly expression/subprogram.
   [1]
+  $ aslref --no-exec TypingRule.AnnotateSlices_lhs.asl
   $ aslref --no-exec TypingRule.AddNewFunc.bad1.asl
   File TypingRule.AddNewFunc.bad1.asl, line 8, character 0 to line 11,
     character 4:


### PR DESCRIPTION
Annotating the length of slices that appear on the left-hand side of assignments is too strict to allow converting `[ .. +: .. ]` and `[ .. *: .. ]` slices into `[ .. : .. ]` slices.
Specifically, the length is currently required to be symbolically evaluable, which fails to type check examples like the one below:
```
func write_chunks(message: bits(64), code: bits(8)) => bits(64)
begin
        var chunk_index : integer{0..8}  = 0;
        var new_message: bits(64);

        while (TRUE) looplimit 5 do
            // The slice expression on the left-hand side of the assignment
            // is not syntactically symbolically evaluable because it contains
            // the mutable variable chunk_index, but it is semantically
            // symbolically evaluable because chunk_index does not affect
            // the length of the slice, which is a constant 8
            // (8 * chunk_index - 8 * chunk_index + 7 + 1 = 8).
            new_message[8 * chunk_index + 7 : 8 * chunk_index] = code;
            chunk_index = chunk_index + 1 as integer{0..8};
        end;
        return new_message;
end;
```
This PR performs the check on the normalized length expression, which may contain fewer mutable variables.