### PR TITLE
[tools] AARCH-25405: Clarification οf the IC-Coherence-before and Instruction-read-ordered-before definitions

### DIFF
--- a/herd/libdir/catdefinitions.tex
+++ b/herd/libdir/catdefinitions.tex
@@ -1,6 +1,12 @@
 \newcommand{\notthecase}[1]{it is not the case that #1}
-\newcommand{\Variant}[1]{#1 is implemented}
-\newcommand{\NotVariant}[1]{it is not the case that #1 is implemented}
+\newcommand{\ETSTwo}{FEAT_ETS2 is implemented}
+\newcommand{\NotETSTwo}{\notthecase{\ETSTwo{}}}
+\newcommand{\ETSThree}{FEAT_ETS3 is implemented}
+\newcommand{\NotETSThree}{\notthecase{\ETSThree{}}}
+\newcommand{\DIC}{The Effective value of DIC is 1}
+\newcommand{\NotDIC}{The Effective value of DIC is 0}
+\newcommand{\IDC}{The Effective value of IDC is 1}
+\newcommand{\NotIDC}{The Effective value of IDC is 0}
 \newcommand{\flag}[1]{By construction, #1}
 \newcommand{\assert}[1]{By construction, #1}
 %
@@ -42,7 +48,6 @@
 \newcommand{\M}[1]{#1 is a \ME{}}
 \newcommand{\W}[1]{#1 is a \MWE{}}
 \newcommand{\R}[1]{#1 is a \MRE{}}
-\renewcommand{\_}{any Effect}
 \newcommand{\B}[1]{#1 is a Branching Effect}
 \newcommand{\IntrBranching}[1]{the Intrinsic Branching Effect which checks #1}
 \newcommand{\BccBranching}{the Branching Effect of the instruction}

--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -290,24 +290,30 @@ and cons_seqs (fs:exp list) (es:exp list) =
          variant_dnf neg vc1 @ variant_dnf neg vc2
       | OpAnd (vc1,vc2) ->
          let d1 = variant_dnf neg vc1
-         and d2  =variant_dnf neg vc2 in
+         and d2 = variant_dnf neg vc2 in
          List.fold_right
            (fun a1 k ->
              List.fold_right
                (fun a2 k -> (a1@a2)::k) d2 k)
            d1 []
 
+    let pp_atom = function
+    | Pos s -> sprintf "\\%s{}" (MiaouNames.to_variant_csname s)
+    | Neg s -> sprintf "\\Not%s{}" (MiaouNames.to_variant_csname s)
+
     let pp_dnf d =
       List.map
         (fun a ->
-          List.map
-            (function
-             | Pos s -> sprintf "\\Variant{%s}" s
-             | Neg s -> sprintf "\\NotVariant{%s}" s)
-            a |> String.concat " and ")
+          List.map pp_atom a |> String.concat " and ")
         d |> String.concat " or "
 
     let pp_vc vc = variant_dnf false vc |> pp_dnf
+
+    let vc_to_items vc =
+      match variant_dnf false vc with
+      | [conjs] -> List.map (fun a -> Item (pp_atom a)) conjs
+      | [] -> Warn.fatal "variant_dnf returned empty list"
+      | d -> [Item (pp_dnf d)]
 
     let do_pp_rel_id  e1 e2 id =
       sprintf "\\%s{%s}{%s}" id (pp_evt e1) (pp_evt e2)
@@ -375,11 +381,11 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | If (_,VariantCond vc,Konst (_,Empty _),e) ->
          let op = Inter in
          mk_list op
-           [Item (pp_vc (OpNot vc)); tr_rel e1 e2 e;]
+           (vc_to_items (OpNot vc) @ [tr_rel e1 e2 e;])
       | If (_,VariantCond vc,e,Konst (_,Empty _)) ->
          let op = Inter in
          mk_list op
-           [Item (pp_vc vc); tr_rel e1 e2 e;]
+           (vc_to_items vc @ [tr_rel e1 e2 e;])
       | If (_,VariantCond vc,a,b) ->
          let c = pp_vc vc
          and a = tr_rel e1 e2 a
@@ -539,11 +545,11 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | If (_,VariantCond vc,Konst (_,Empty _),e) ->
          let op = Inter in
          mk_list op
-           [Item (pp_vc (OpNot vc)); tr_evts e1 e;]
+           (vc_to_items (OpNot vc) @ [tr_evts e1 e;])
       | If (_,VariantCond vc,e,Konst (_,Empty _)) ->
          let op = Inter in
          mk_list op
-           [Item (pp_vc vc); tr_evts e1 e;]
+           (vc_to_items vc @ [tr_evts e1 e;])
       | If (_,VariantCond vc,a,b) ->
          let c = pp_vc vc
          and a = tr_evts e1 a

--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -283,24 +283,30 @@ and cons_seqs (fs:exp list) (es:exp list) =
          variant_dnf neg vc1 @ variant_dnf neg vc2
       | OpAnd (vc1,vc2) ->
          let d1 = variant_dnf neg vc1
-         and d2  =variant_dnf neg vc2 in
+         and d2 = variant_dnf neg vc2 in
          List.fold_right
            (fun a1 k ->
              List.fold_right
                (fun a2 k -> (a1@a2)::k) d2 k)
            d1 []
 
+    let pp_atom = function
+    | Pos s -> sprintf "\\Variant{%s}" s
+    | Neg s -> sprintf "\\NotVariant{%s}" s
+
     let pp_dnf d =
       List.map
         (fun a ->
-          List.map
-            (function
-             | Pos s -> sprintf "\\Variant{%s}" s
-             | Neg s -> sprintf "\\NotVariant{%s}" s)
-            a |> String.concat " and ")
+          List.map pp_atom a |> String.concat " and ")
         d |> String.concat " or "
 
     let pp_vc vc = variant_dnf false vc |> pp_dnf
+
+    let vc_to_items vc =
+      match variant_dnf false vc with
+      | [conjs] -> List.map (fun a -> Item (pp_atom a)) conjs
+      | [] -> Warn.fatal "variant_dnf returned empty list"
+      | d -> [Item (pp_dnf d)]
 
     let do_pp_rel_id  e1 e2 id =
       sprintf "\\%s{%s}{%s}" id (pp_evt e1) (pp_evt e2)
@@ -381,11 +387,11 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | If (_,VariantCond vc,Konst (_,Empty _),e) ->
          let op = Inter in
          mk_list op
-           [Item (pp_vc (OpNot vc)); tr_rel e1 e2 e;]
+           (vc_to_items (OpNot vc) @ [tr_rel e1 e2 e;])
       | If (_,VariantCond vc,e,Konst (_,Empty _)) ->
          let op = Inter in
          mk_list op
-           [Item (pp_vc vc); tr_rel e1 e2 e;]
+           (vc_to_items vc @ [tr_rel e1 e2 e;])
       | If (_,VariantCond vc,a,b) ->
          let c = pp_vc vc
          and a = tr_rel e1 e2 a
@@ -551,11 +557,11 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | If (_,VariantCond vc,Konst (_,Empty _),e) ->
          let op = Inter in
          mk_list op
-           [Item (pp_vc (OpNot vc)); tr_evts e1 e;]
+           (vc_to_items (OpNot vc) @ [tr_evts e1 e;])
       | If (_,VariantCond vc,e,Konst (_,Empty _)) ->
          let op = Inter in
          mk_list op
-           [Item (pp_vc vc); tr_evts e1 e;]
+           (vc_to_items vc @ [tr_evts e1 e;])
       | If (_,VariantCond vc,a,b) ->
          let c = pp_vc vc
          and a = tr_evts e1 a

--- a/tools/miaouNames.ml
+++ b/tools/miaouNames.ml
@@ -27,6 +27,27 @@ let toalpha s =
   done ;
   Buffer.contents buff
 
+let to_variant_csname s =
+  let add = Buffer.add_string in
+  let buff = Buffer.create (String.length s) in
+  for k = 0 to String.length s - 1 do
+    match s.[k] with
+    | 'a'..'z' | 'A'..'Z' as c ->
+        Buffer.add_char buff c
+    | '0' -> add buff "Zero"
+    | '1' -> add buff "One"
+    | '2' -> add buff "Two"
+    | '3' -> add buff "Three"
+    | '4' -> add buff "Four"
+    | '5' -> add buff "Five"
+    | '6' -> add buff "Six"
+    | '7' -> add buff "Seven"
+    | '8' -> add buff "Eight"
+    | '9' -> add buff "Nine"
+    | _ -> ()
+  done ;
+  Buffer.contents buff
+
 let vocabulary =
   StringMap.empty
   |> StringMap.add "dmb.full" "DMBFULL"

--- a/tools/miaouNames.mli
+++ b/tools/miaouNames.mli
@@ -18,3 +18,7 @@
 
 (* Translate name to a valid LaTeX command name *)
 val to_csname : string -> string
+
+(* Translate variant name to a valid LaTeX command name.
+   Keeps letters, maps digits to words. *)
+val to_variant_csname : string -> string

--- a/tools/tests/miaou.t
+++ b/tools/tests/miaou.t
@@ -108,7 +108,7 @@
     \end{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \Variant{ETS2} or \Variant{ETS3}.
+    \item \ETSTwo{} or \ETSThree{}.
     \item One of the following applies:
       \begin{itemize}
       \item \M{E\textsubscript{1}}.
@@ -143,7 +143,7 @@
     \end{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \Variant{ETS2} or \Variant{ETS3}.
+    \item \ETSTwo{} or \ETSThree{}.
     \item \ExpR{E\textsubscript{1}}.
     \item \expandafter{\MakeUppercase\notthecase{\NoRet{E\textsubscript{1}}}}.
     \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
@@ -165,7 +165,7 @@
     \end{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \Variant{ETS2} or \Variant{ETS3}.
+    \item \ETSTwo{} or \ETSThree{}.
     \item \ExpW{E\textsubscript{1}}.
     \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
     \item \DSBST{E\textsubscript{3}}.
@@ -198,7 +198,8 @@
   \begin{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \NotVariant{DIC} and \NotVariant{IDC}.
+    \item \NotDIC{}.
+    \item \NotIDC{}.
     \item \IC{E\textsubscript{1}}.
     \item \expandafter{\MakeUppercase\ICafter{E\textsubscript{1}}{E\textsubscript{3}}}.
     \item \ImpInstrR{E\textsubscript{3}}.
@@ -209,7 +210,8 @@
     \end{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \NotVariant{DIC} and \Variant{IDC}.
+    \item \NotDIC{}.
+    \item \IDC{}.
     \item \IC{E\textsubscript{1}}.
     \item \expandafter{\MakeUppercase\ICafter{E\textsubscript{1}}{E\textsubscript{3}}}.
     \item \ImpInstrR{E\textsubscript{3}}.
@@ -218,7 +220,8 @@
     \end{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \Variant{DIC} and \Variant{IDC}.
+    \item \DIC{}.
+    \item \IDC{}.
     \item \ImpInstrR{E\textsubscript{1}}.
     \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
     \item \W{E\textsubscript{2}}.
@@ -275,7 +278,7 @@
     \end{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \Variant{DIC}.
+    \item \DIC{}.
     \item \expandafter{\MakeUppercase\ca{E\textsubscript{1}}{E\textsubscript{2}}}.
     \end{itemize}
   \end{itemize}
@@ -1001,7 +1004,7 @@
   \begin{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \Variant{ETS2}.
+    \item \ETSTwo{}.
     \item \ExpM{E\textsubscript{1}}.
     \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
     \item \TLBUncacheableFAULT{E\textsubscript{3}}.
@@ -1010,7 +1013,7 @@
     \end{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \Variant{ETS3}.
+    \item \ETSThree{}.
     \item \ExpM{E\textsubscript{1}}.
     \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
     \item \MMUFAULT{E\textsubscript{3}}.
@@ -1019,7 +1022,7 @@
     \end{itemize}
   \item All of the following apply:
     \begin{itemize}
-    \item \Variant{ETS3}.
+    \item \ETSThree{}.
     \item \ExpM{E\textsubscript{1}}.
     \item \expandafter{\MakeUppercase\po{E\textsubscript{1}}{E\textsubscript{3}}}.
     \item \TagCheckEXCENTRY{E\textsubscript{3}}.


### PR DESCRIPTION
This changes the way `miaou7` transliterates variants into LaTeX. In the case of a conjunction of multiple variants as part of a condition, each variant is now a separate `\item`, which is then translated into exactly one line of markdown. In addition, each variant needs to be uniquely defined in `catdefinitions.tex`. The generic `Variant[1]` and `NotVariant[1]` commands have been removed.