### PR TITLE
[herd] Add rmw to po, except for the model `aarch64.cat`

### DIFF
--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -351,10 +351,19 @@ module Make
           (if O.wide_po then
              E.EventRel.filter_nodes relevant
            else
-             E.EventRel.restrict_rel
-               (fun e1 e2 ->
-                  relevant e1 && relevant e2
-                  && not (E.same_instance e1 e2)))
+             fun po ->
+               let po =
+                 E.EventRel.restrict_rel
+                   (fun e1 e2 ->
+                     relevant e1 && relevant e2
+                     && (not (E.same_instance e1 e2)))
+                   po in
+               if catdep then po
+               else
+                 (* Non-catdep models do not explicit include
+                    rmw into po where appropriate,
+                    for instance in their internal check. *)
+                 E.EventRel.union conc.S.atomic_load_store po)
           conc.S.po in
       let partial_po =
         lazy begin

--- a/herd/tests/instructions/AArch64/A264.litmus
+++ b/herd/tests/instructions/AArch64/A264.litmus
@@ -1,0 +1,9 @@
+AArch64 A264
+{
+0:X2=y;
+1:X2=y;
+}
+ P0          | P1            ;
+ MOV W1,#1   | MOV W3,#2     ;
+ STR W1,[X2] | SWP W3,W1,[X2] ;
+~exists [y]=1 /\ 1:X1=1

--- a/herd/tests/instructions/AArch64/A264.litmus.expected
+++ b/herd/tests/instructions/AArch64/A264.litmus.expected
@@ -1,0 +1,11 @@
+Test A264 Forbidden
+States 2
+1:X1=0; [y]=1;
+1:X1=1; [y]=2;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition ~exists ([y]=1 /\ 1:X1=1)
+Observation A264 Never 0 2
+Hash=8ec24d4aa48ba8b0bb75b0fad6e50f4f
+

--- a/herd/tests/instructions/X86_64/A011.litmus
+++ b/herd/tests/instructions/X86_64/A011.litmus
@@ -1,0 +1,9 @@
+X86_64 A011
+{
+  int y;
+}
+  P0         |  P1            ;
+ movl $1,(y) | movl $2,%eax   ;
+             | xchgl (y),%eax ;
+~exists 1:rax=1 /\ [y]=1
+

--- a/herd/tests/instructions/X86_64/A011.litmus.expected
+++ b/herd/tests/instructions/X86_64/A011.litmus.expected
@@ -1,0 +1,11 @@
+Test A011 Forbidden
+States 2
+1:rax=0; [y]=1;
+1:rax=1; [y]=2;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition ~exists (1:rax=1 /\ [y]=1)
+Observation A011 Never 0 2
+Hash=49bac67e78712413113b7c93e987b364
+


### PR DESCRIPTION
The simulator herd computes the program order by itself.

In the case of hardware semantics, effects from the same instruction were excluded from po. This is wrong for atomic pairs, where this order is important, _e.g._ for the internal check. However, in the case of the `aarch64.cat` model, this situation is handled correctly by inserting `rmw` where appropriate, _i.e._ in the internal check coRW1-Exp.

As the model `aarch64.cat` identifies itself with the `catdep` flag, we add `rmw` to `po` by default, except for `catdep` models.

As a consequence, the meaning of catdep is now as follows:
  1. The model computes the dependencies by itself,
  2. and it considers that the po relation always relates effects generated by different instruction executions.
