### PR TITLE
[all] Bump minimum OCaml version to 4.14

### DIFF
--- a/.github/workflows/check-opam-minimals.yml
+++ b/.github/workflows/check-opam-minimals.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Checkout tree
         uses: actions/checkout@v4
 
-      - name: Set-up OCaml 4.08
+      - name: Set-up OCaml 4.14
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 4.08.1
+          ocaml-compiler: 4.14.0
       - run: |
           opam install . --deps-only --with-test --solver=builtin-mccs+glpk --criteria="-new"
           opam exec -- make build test install DUNE_PROFILE=dev

--- a/.github/workflows/make-test-all.yml
+++ b/.github/workflows/make-test-all.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-version:
-          - "4.08.1"
           - "4.14"
           - "5.3"
 

--- a/.github/workflows/make-test-diy.yml
+++ b/.github/workflows/make-test-diy.yml
@@ -24,7 +24,7 @@ jobs:
           - ubuntu-latest
         cfg:
             # Minimal versions: we want to test both ends of the supported space
-          - ocaml-version: "ocaml-base-compiler.4.14.0,dune.3.10.0,zarith.1.13,menhir.20220210,logs.0.7.0"
+          - ocaml-version: "ocaml-base-compiler.4.14.0,dune.3.10.0,zarith.1.13,menhir.20231231,logs.0.7.0"
             job-name: "OCaml v4.14.0"
             dune-cache: "enabled"
 

--- a/.github/workflows/make-test-diy.yml
+++ b/.github/workflows/make-test-diy.yml
@@ -24,8 +24,8 @@ jobs:
           - ubuntu-latest
         cfg:
             # Minimal versions: we want to test both ends of the supported space
-          - ocaml-version: "ocaml-base-compiler.4.08.1,dune.3.10.0,zarith.1.13,menhir.20220210,logs.0.7.0"
-            job-name: "OCaml v4.08"
+          - ocaml-version: "ocaml-base-compiler.4.14.0,dune.3.10.0,zarith.1.13,menhir.20220210,logs.0.7.0"
+            job-name: "OCaml v4.14.0"
             dune-cache: "enabled"
 
             # Maximal version: this will automatically select the most recent version compatible.

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           - ubuntu-latest
         cfg:
-            # Minimal versions: we want to test both ends of the supported space
-          - ocaml-compiler: "ocaml-base-compiler.4.14.0,dune.3.10.0,zarith.1.13,menhir.20220210,logs.0.7.0"
+          # Minimal versions: we want to test both ends of the supported space
+          - ocaml-compiler: "ocaml-base-compiler.4.14.0,dune.3.10.0,zarith.1.13,menhir.20231231,logs.0.7.0"
             with-type-check-asl: false
             job-name: "OCaml v4.14.0"
             dune-cache: "enabled"

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -24,9 +24,9 @@ jobs:
           - ubuntu-latest
         cfg:
             # Minimal versions: we want to test both ends of the supported space
-          - ocaml-compiler: "ocaml-base-compiler.4.08.1,dune.3.10.0,zarith.1.13,menhir.20220210,logs.0.7.0"
+          - ocaml-compiler: "ocaml-base-compiler.4.14.0,dune.3.10.0,zarith.1.13,menhir.20220210,logs.0.7.0"
             with-type-check-asl: false
-            job-name: "OCaml v4.08"
+            job-name: "OCaml v4.14.0"
             dune-cache: "enabled"
 
             # Maximal version: this will automatically select the most recent version compatible.
@@ -83,4 +83,3 @@ jobs:
           dune-cache: true
 
       - run: opam exec -- dune fmt
-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,9 +20,9 @@ You can change PREFIX by editing the Makefile, or by running ``make ...`` as ``m
 Requirements
 ------------
 
-- OCaml (version >= 4.08.0)
+- OCaml (version >= 4.14.0)
 - dune (version >= 3.10.0)
-- menhir (version >= 20220210)
+- menhir (version >= 20231231)
 - zarith
 - logs
 

--- a/asllib/aslspec/dune-project
+++ b/asllib/aslspec/dune-project
@@ -9,6 +9,5 @@
  (depends
    (ocaml (>= 4.08))
    dune
-   (menhir (>= 20220210))
+   (menhir (>= 20231231))
    (conf-python-3 (= 9.0.0))))
-

--- a/asllib/dune-project
+++ b/asllib/dune-project
@@ -20,7 +20,7 @@
  (depends
    (ocaml (>= 4.08))
    dune
-   (menhir (>= 20220210))
+   (menhir (>= 20231231))
    (zarith (>= 1.13)))
  (depopts
    (qcheck :with-test)
@@ -38,4 +38,3 @@ For more details, and for a downloadable version of the ASL language reference
 document, please see
 https://developer.arm.com/Architectures/Architecture%20Specification%20Language
 "))
-

--- a/asllib/menhir2bnfc/dune-project
+++ b/asllib/menhir2bnfc/dune-project
@@ -4,4 +4,6 @@
 (cram enable)
 (package
  (name menhir2bnfc)
- (allow_empty))
+ (allow_empty)
+ (depends
+  (menhir (>= 20231231))))

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -17,7 +17,7 @@ install: [make "install-herdtools" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.14.0"}
   "dune"  {>= "3.10.0" }
-  "menhir" {>= "20220210"}
+  "menhir" {>= "20231231"}
   "zarith" {>= "1.13"}
   "conf-which"
   "logs"

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -15,7 +15,7 @@ install: [make "install-herdtools" "PREFIX=%{prefix}%"]
 # @todo Add "build-doc" field
 # @todo Add "build-test" field
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "dune"  {>= "3.10.0" }
   "menhir" {>= "20220210"}
   "zarith" {>= "1.13"}


### PR DESCRIPTION
OCaml < 4.11 is [no longer supported](https://github.com/ocaml/opam-repository/pull/29848) on `opam` and won't build with it. See also [this](https://github.com/herd/herdtools7/actions/runs/25429247642/job/74590828906?pr=1812) failing CI run.

I take this as a good opportunity to bump the minimum version of OCaml supported by the project. In light of [this discussion](https://github.com/herd/herdtools7/issues/1783), I'm proposing to bump the minimum to 4.14.0, as a version that is still conservatively < 5 but that also brings significant advantages in terms of stdlib improvements.