### PR TITLE
[build] Remove dependency from build to install

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install opam dependencies
         run: opam install . --deps-only --yes --with-test
 
-      - run: opam exec -- make build DUNE_PROFILE=dev
+      - run: opam exec -- make all DUNE_PROFILE=dev
 
       - run: opam exec -- make test DUNE_PROFILE=dev
 

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ install-herdtools:
 build-aslref:
 	dune build -p aslref --profile $(DUNE_PROFILE)
 
-install-aslref: build-aslref
+install-aslref:
 	# There are no lib files for aslref so we don't need dune-install.sh
 	dune install aslref --prefix $(PREFIX)
 
-install: install-herdtools install-aslref
+install: install-herdtools
 
 uninstall:
 	sh ./dune-uninstall.sh $(PREFIX)


### PR DESCRIPTION
When developing I repetitively use the command
```
% make all install PREFIX=/opt/WIP
```

If some install target in Makefile depends on some build target, as it was the case for aslref, the command above
triggers unnecessary recompilations.

Suppressing this dependency should not be a problem, when one follows the usual practice of separating build and installation.