### PR TITLE
[litmus] Litmus postcondition offset checks fix

### DIFF
--- a/herd/tests/instructions/AArch64.kvm/A037.litmus
+++ b/herd/tests/instructions/AArch64.kvm/A037.litmus
@@ -1,0 +1,8 @@
+AArch64 A037
+
+{ 0:x0=x; uint64_t 0:x1=4; }
+P0;
+  add x0,x0,x1;
+
+forall
+  ( 0:x0=x )

--- a/herd/tests/instructions/AArch64.kvm/A037.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A037.litmus.expected
@@ -1,0 +1,10 @@
+Test A037 Required
+States 1
+0:X0=x+4;
+No
+Witnesses
+Positive: 0 Negative: 1
+Condition forall (0:X0=x)
+Observation A037 Never 0 1
+Hash=e75d267d4f8af2c3ffbd03e1c2799441
+

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -110,6 +110,7 @@ module Make
     module DC =
       CompCond.Make(O)
         (struct
+          let use_symbolic = false
           let with_ok = false
           module C = T.C
           let dump_value _loc (* ignored, see preSi.ml *) = C.V.pp O.hexa

--- a/litmus/compCond.ml
+++ b/litmus/compCond.ml
@@ -52,7 +52,7 @@ module Make (O:Indent.S) (I:CompCondUtils.I) =
             begin match v with
             | Constant.ConcreteVector vs ->
                 O.fprintf "(%s)" (dump_vec loc vs)
-            | Constant.Symbolic _ ->
+            | Constant.Symbolic _ when I.use_symbolic ->
                 O.fprintf "symbolic_equal(%s, %s)"
                   (I.Loc.dump loc)
                   (dump_v (Some (ConstrGen.loc_of_rloc loc)) v)

--- a/litmus/compCond.ml
+++ b/litmus/compCond.ml
@@ -52,6 +52,10 @@ module Make (O:Indent.S) (I:CompCondUtils.I) =
             begin match v with
             | Constant.ConcreteVector vs ->
                 O.fprintf "(%s)" (dump_vec loc vs)
+            | Constant.Symbolic _ ->
+                O.fprintf "symbolic_equal(%s, %s)"
+                  (I.Loc.dump loc)
+                  (dump_v (Some (ConstrGen.loc_of_rloc loc)) v)
             | _ ->
                 O.fprintf "%s == %s"
                   (I.Loc.dump loc)

--- a/litmus/compCond.ml
+++ b/litmus/compCond.ml
@@ -52,6 +52,14 @@ module Make (O:Indent.S) (I:CompCondUtils.I) =
             begin match v with
             | Constant.ConcreteVector vs ->
                 O.fprintf "(%s)" (dump_vec loc vs)
+            | Constant.(Symbolic (Virtual { name = Symbol.Label _; _ })) ->
+                O.fprintf "%s == %s"
+                  (I.Loc.dump loc)
+                  (dump_v (Some (ConstrGen.loc_of_rloc loc)) v)
+            | Constant.(Symbolic (Virtual { tag = Some _; _ })) ->
+                O.fprintf "%s == %s"
+                  (I.Loc.dump loc)
+                  (dump_v (Some (ConstrGen.loc_of_rloc loc)) v)
             | Constant.Symbolic _ when I.use_symbolic ->
                 O.fprintf "symbolic_equal(%s, %s)"
                   (I.Loc.dump loc)
@@ -74,7 +82,7 @@ module Make (O:Indent.S) (I:CompCondUtils.I) =
            | None -> "Unknown"
            | Some ft -> I.C.FaultType.pp ft in
            O.fprintf "exists_fault(&p->th_faults[%d], %s, %s, %s)"
-             proc (SkelUtil.instr_symb_id lbl) (SkelUtil.data_symb_id loc) (SkelUtil.fault_id ft) ;
+             proc (SkelUtil.instr_symb_id lbl) (SkelUtil.data_symb loc) (SkelUtil.fault_id ft) ;
         | Not p ->
             O.output "!(" ;
             dump_prop p ;

--- a/litmus/compCondUtils.mli
+++ b/litmus/compCondUtils.mli
@@ -27,6 +27,8 @@ end
 module type I = sig
   val with_ok : bool
   module C : Constr.S
+  (* Use `symbolic_eq` instead of `==` for pointer comparison *)
+  val use_symbolic : bool
   (* When present the first, location, argument allows retrieving type *)
   val dump_value : C.location option -> C.V.v -> string
   module Loc : X with type  location = C.location

--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -31,7 +31,7 @@ static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
   if (!is_iabt(esr) && get_far(esr, &far)) {
     flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
   } else {
-    flt.data_symb = unknown_symbolic();
+    flt.data_symb = symbolic_of_id(DATA_SYMB_ID_UNKNOWN);
   }
 
   if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {

--- a/litmus/libdir/_aarch64/kvm_fault_handler.c
+++ b/litmus/libdir/_aarch64/kvm_fault_handler.c
@@ -31,7 +31,7 @@ static void record_fault(who_t *w, unsigned long pc, unsigned long esr) {
   if (!is_iabt(esr) && get_far(esr, &far)) {
     flt.data_symb = idx_addr((intmax_t *)far, vars_ptr[w->instance]);
   } else {
-    flt.data_symb = DATA_SYMB_ID_UNKNOWN;
+    flt.data_symb = unknown_symbolic();
   }
 
   if (!log_fault(w->proc, flt.instr_symb, flt.data_symb, flt.type)) {

--- a/litmus/libdir/_aarch64/kvm_fault_type.c
+++ b/litmus/libdir/_aarch64/kvm_fault_type.c
@@ -107,7 +107,7 @@ static enum fault_type_t get_fault_type(unsigned long esr)
 
 typedef struct {
   int instr_symb;
-  int data_symb;
+  symb_t data_symb;
   enum fault_type_t type;
 } fault_info_t;
 
@@ -121,7 +121,7 @@ static void th_faults_info_init(th_faults_info_t *th_flts)
   for (int i = 0; i < MAX_FAULTS_PER_THREAD; i++) {
     fault_info_t *f = &th_flts->faults[i];
     f->instr_symb = INSTR_SYMB_ID_UNKNOWN;
-    f->data_symb = DATA_SYMB_ID_UNKNOWN;
+    f->data_symb = unknown_symbolic();
     f->type = FaultUnknown;
   }
   th_flts->n = 0;
@@ -139,7 +139,7 @@ static int th_faults_info_compare(th_faults_info_t *th_flts1, th_faults_info_t *
     if (i2 == th_flts2->n)
       return 0;
 
-    if (f1->instr_symb == f2->instr_symb && f1->data_symb == f2->data_symb &&
+    if (f1->instr_symb == f2->instr_symb && symbolic_equal(f1->data_symb, f2->data_symb) &&
         f1->type == f2->type) {
       i1++;
       i2 = 0;
@@ -150,15 +150,16 @@ static int th_faults_info_compare(th_faults_info_t *th_flts1, th_faults_info_t *
   return 1;
 }
 
-static void pp_fault(int proc, int instr_symb, int data_symb, int ftype)
+static void pp_fault(int proc, int instr_symb, symb_t data_symb, int ftype)
 {
   if (instr_symb != INSTR_SYMB_ID_UNKNOWN)
     printf("fault(P%s", instr_symb_name[instr_symb]);
   else
     printf("fault(P%d", proc);
-  if (data_symb != DATA_SYMB_ID_UNKNOWN)
+  if (!symbolic_equal(data_symb, unknown_symbolic())) {
+    printf(","); pp_symbolic(data_symb);
     printf(",%s", data_symb_name[data_symb]);
-  if (ftype != FaultUnknown)
+  } if (ftype != FaultUnknown)
     printf(",%s", fault_type_names[ftype]);
   printf(");");
 }
@@ -175,7 +176,7 @@ static void pp_log_faults_init(void)
 }
 
 static void pp_log_faults(FILE *chan, th_faults_info_t *th_flts, int proc, int instr_symb,
-                          int data_symb, int ftype)
+                          symb_t data_symb, int ftype)
 {
   int found = 0;
   for (int i = 0; i < th_flts->n; i++) {
@@ -184,8 +185,8 @@ static void pp_log_faults(FILE *chan, th_faults_info_t *th_flts, int proc, int i
     if (instr_symb != INSTR_SYMB_ID_UNKNOWN) {
       cond &= flt->instr_symb == instr_symb;
     }
-    if (data_symb != DATA_SYMB_ID_UNKNOWN) {
-      cond &= flt->data_symb == data_symb;
+    if (!symbolic_equal(data_symb, unknown_symbolic())) {
+      cond &= symbolic_equal(flt->data_symb, data_symb);
     }
     if (ftype != FaultUnknown) {
       cond &= flt->type == ftype;
@@ -215,7 +216,7 @@ static int eq_faults(th_faults_info_t *th_flts1, th_faults_info_t *th_flts2)
   return 1;
 }
 
-static int exists_fault(th_faults_info_t *th_flts, int instr_symb, int data_symb, int ftype)
+static int exists_fault(th_faults_info_t *th_flts, int instr_symb, symb_t data_symb, int ftype)
 {
   for (int i = 0; i < th_flts->n; i++) {
     fault_info_t *flt = &th_flts->faults[i];
@@ -223,8 +224,8 @@ static int exists_fault(th_faults_info_t *th_flts, int instr_symb, int data_symb
     if (instr_symb != INSTR_SYMB_ID_UNKNOWN) {
       cond &= flt->instr_symb == instr_symb;
     }
-    if (data_symb != DATA_SYMB_ID_UNKNOWN) {
-      cond &= flt->data_symb == data_symb;
+    if (!symbolic_equal(data_symb, unknown_symbolic())) {
+      cond &= symbolic_equal(flt->data_symb, data_symb);
     }
     if (ftype != FaultUnknown) {
       cond &= flt->type == ftype;

--- a/litmus/libdir/_aarch64/kvm_fault_type.c
+++ b/litmus/libdir/_aarch64/kvm_fault_type.c
@@ -158,7 +158,7 @@ static void pp_fault(int proc, int instr_symb, symb_t data_symb, int ftype)
     printf("fault(P%d", proc);
   if (!symbolic_equal(data_symb, symbolic_of_id(DATA_SYMB_ID_UNKNOWN))) {
     puts(","); puts(pp_symbolic(data_symb));
-  } if (ftype != FaultUnknown)
+  } if (ftype != FaultUnknown)
     printf(",%s", fault_type_names[ftype]);
   printf(");");
 }

--- a/litmus/libdir/_aarch64/kvm_fault_type.c
+++ b/litmus/libdir/_aarch64/kvm_fault_type.c
@@ -121,7 +121,7 @@ static void th_faults_info_init(th_faults_info_t *th_flts)
   for (int i = 0; i < MAX_FAULTS_PER_THREAD; i++) {
     fault_info_t *f = &th_flts->faults[i];
     f->instr_symb = INSTR_SYMB_ID_UNKNOWN;
-    f->data_symb = unknown_symbolic();
+    f->data_symb = symbolic_of_id(DATA_SYMB_ID_UNKNOWN);
     f->type = FaultUnknown;
   }
   th_flts->n = 0;
@@ -156,9 +156,8 @@ static void pp_fault(int proc, int instr_symb, symb_t data_symb, int ftype)
     printf("fault(P%s", instr_symb_name[instr_symb]);
   else
     printf("fault(P%d", proc);
-  if (!symbolic_equal(data_symb, unknown_symbolic())) {
-    printf(","); pp_symbolic(data_symb);
-    printf(",%s", data_symb_name[data_symb]);
+  if (!symbolic_equal(data_symb, symbolic_of_id(DATA_SYMB_ID_UNKNOWN))) {
+    puts(","); puts(pp_symbolic(data_symb));
   } if (ftype != FaultUnknown)
     printf(",%s", fault_type_names[ftype]);
   printf(");");
@@ -185,7 +184,7 @@ static void pp_log_faults(FILE *chan, th_faults_info_t *th_flts, int proc, int i
     if (instr_symb != INSTR_SYMB_ID_UNKNOWN) {
       cond &= flt->instr_symb == instr_symb;
     }
-    if (!symbolic_equal(data_symb, unknown_symbolic())) {
+    if (!symbolic_equal(data_symb, symbolic_of_id(DATA_SYMB_ID_UNKNOWN))) {
       cond &= symbolic_equal(flt->data_symb, data_symb);
     }
     if (ftype != FaultUnknown) {
@@ -224,7 +223,7 @@ static int exists_fault(th_faults_info_t *th_flts, int instr_symb, symb_t data_s
     if (instr_symb != INSTR_SYMB_ID_UNKNOWN) {
       cond &= flt->instr_symb == instr_symb;
     }
-    if (!symbolic_equal(data_symb, unknown_symbolic())) {
+    if (!symbolic_equal(data_symb, symbolic_of_id(DATA_SYMB_ID_UNKNOWN))) {
       cond &= symbolic_equal(flt->data_symb, data_symb);
     }
     if (ftype != FaultUnknown) {

--- a/litmus/libdir/_aarch64/kvm_fault_type.c
+++ b/litmus/libdir/_aarch64/kvm_fault_type.c
@@ -107,7 +107,7 @@ static enum fault_type_t get_fault_type(unsigned long esr)
 
 typedef struct {
   int instr_symb;
-  symb_t data_symb;
+  data_symb_t data_symb;
   enum fault_type_t type;
 } fault_info_t;
 
@@ -150,7 +150,7 @@ static int th_faults_info_compare(th_faults_info_t *th_flts1, th_faults_info_t *
   return 1;
 }
 
-static void pp_fault(int proc, int instr_symb, symb_t data_symb, int ftype)
+static void pp_fault(int proc, int instr_symb, data_symb_t data_symb, int ftype)
 {
   if (instr_symb != INSTR_SYMB_ID_UNKNOWN)
     printf("fault(P%s", instr_symb_name[instr_symb]);
@@ -175,7 +175,7 @@ static void pp_log_faults_init(void)
 }
 
 static void pp_log_faults(FILE *chan, th_faults_info_t *th_flts, int proc, int instr_symb,
-                          symb_t data_symb, int ftype)
+                          data_symb_t data_symb, int ftype)
 {
   int found = 0;
   for (int i = 0; i < th_flts->n; i++) {
@@ -215,7 +215,7 @@ static int eq_faults(th_faults_info_t *th_flts1, th_faults_info_t *th_flts2)
   return 1;
 }
 
-static int exists_fault(th_faults_info_t *th_flts, int instr_symb, symb_t data_symb, int ftype)
+static int exists_fault(th_faults_info_t *th_flts, int instr_symb, data_symb_t data_symb, int ftype)
 {
   for (int i = 0; i < th_flts->n; i++) {
     fault_info_t *flt = &th_flts->faults[i];

--- a/litmus/libdir/_aarch64/kvm_symb.c
+++ b/litmus/libdir/_aarch64/kvm_symb.c
@@ -7,20 +7,32 @@ typedef struct {
   int id; // id of the symbolic value
 } symb_t;
 
-static symb_t symbolic_of_id(int id) {
+inline static symb_t symbolic_of_id(int id) {
   symb_t ret = { .id = id, .offset = 0 };
   return ret;
 }
 
-static int symbolic_equal(symb_t s1, symb_t s2) {
+inline static int symbolic_equal(symb_t s1, symb_t s2) {
   return s1.id == s2.id && s1.offset == s2.offset;
 }
 
-// Pretty print a symbolic data and return it as a string
-static const char* pp_symbolic(symb_t s) {
-  char* buffer = (char*)malloc(sizeof(char) * 1024);
-  if (s.offset == 0) snprintf(buffer, 1024, "%s", data_symb_name[s.id]);
-  else snprintf(buffer, 1024, "%s+%ld", data_symb_name[s.id], s.offset);
+#define SYMBOLIC_BUFFER_SIZE 1024
+static char symbolic_buffer[SYMBOLIC_BUFFER_SIZE];
+
+// Pretty print a symbolic value and return it as a global string:
+// Always use the result immediately after calling this function
+// because calling it twice overwrite the result of the first call
+inline static const char* pp_symbolic(symb_t s) {
+  char* buffer = &symbolic_buffer[0];
+  int len;
+  if (s.offset == 0)
+    len = snprintf(buffer, SYMBOLIC_BUFFER_SIZE, "%s", data_symb_name[s.id]);
+  else
+    len = snprintf(buffer, SYMBOLIC_BUFFER_SIZE, "%s+%ld", data_symb_name[s.id], s.offset);
+
+  if (len < 0 || len >= SYMBOLIC_BUFFER_SIZE)
+    fatal("invalid variable length");
+
   return buffer;
 }
 

--- a/litmus/libdir/_aarch64/kvm_symb.c
+++ b/litmus/libdir/_aarch64/kvm_symb.c
@@ -1,0 +1,34 @@
+
+/* Generic type of symbolic value generated from the final state of a litmus
+ * test or the FAR_EL1 register in case of a fault.
+ *
+ * This type register all the data used for the pretty printing and checks of
+ * the final values like the `id` of the variable, it's `offset` and the raw
+ * pointer for a future usage in presence of a non-canonical MTE or PAC field
+ */
+typedef struct {
+  intmax_t* raw; // raw pointer value
+  uintptr_t offset; // offset between the raw value and the symbolic value
+  int id; // id of the symbolic value
+} symb_t;
+
+static symb_t symbolic_of_id(int id) {
+  symb_t ret = { .id = id, .offset = 0 };
+  return ret;
+}
+
+static symb_t unknown_symbolic() {
+  return symbolic_of_id(DATA_SYMB_ID_UNKNOWN);
+}
+
+static int symbolic_equal(symb_t s1, symb_t s2) {
+  return s1.id == s2.id && s1.offset == s2.offset;
+}
+
+static void pp_symbolic(symb_t s) {
+  printf("%s", data_symb_name[s.id]);
+
+  if (s.offset != 0)
+    printf("+%ld", s.offset);
+}
+

--- a/litmus/libdir/_aarch64/kvm_symb.c
+++ b/litmus/libdir/_aarch64/kvm_symb.c
@@ -1,13 +1,8 @@
 
 /* Generic type of symbolic value generated from the final state of a litmus
  * test or the FAR_EL1 register in case of a fault.
- *
- * This type register all the data used for the pretty printing and checks of
- * the final values like the `id` of the variable, it's `offset` and the raw
- * pointer for a future usage in presence of a non-canonical MTE or PAC field
  */
 typedef struct {
-  intmax_t* raw; // raw pointer value
   uintptr_t offset; // offset between the raw value and the symbolic value
   int id; // id of the symbolic value
 } symb_t;
@@ -17,18 +12,15 @@ static symb_t symbolic_of_id(int id) {
   return ret;
 }
 
-static symb_t unknown_symbolic() {
-  return symbolic_of_id(DATA_SYMB_ID_UNKNOWN);
-}
-
 static int symbolic_equal(symb_t s1, symb_t s2) {
   return s1.id == s2.id && s1.offset == s2.offset;
 }
 
-static void pp_symbolic(symb_t s) {
-  printf("%s", data_symb_name[s.id]);
-
-  if (s.offset != 0)
-    printf("+%ld", s.offset);
+// Pretty print a symbolic data, only print the
+static const char* pp_symbolic(symb_t s) {
+  char* buffer = (char*)malloc(sizeof(char) * 1024);
+  if (s.offset == 0) snprintf(buffer, 1024, "%s", data_symb_name[s.id]);
+  else snprintf(buffer, 1024, "%s+%ld", data_symb_name[s.id], s.offset);
+  return buffer;
 }
 

--- a/litmus/libdir/_aarch64/kvm_symb.c
+++ b/litmus/libdir/_aarch64/kvm_symb.c
@@ -16,7 +16,7 @@ static int symbolic_equal(symb_t s1, symb_t s2) {
   return s1.id == s2.id && s1.offset == s2.offset;
 }
 
-// Pretty print a symbolic data, only print the
+// Pretty print a symbolic data and return it as a string
 static const char* pp_symbolic(symb_t s) {
   char* buffer = (char*)malloc(sizeof(char) * 1024);
   if (s.offset == 0) snprintf(buffer, 1024, "%s", data_symb_name[s.id]);

--- a/litmus/libdir/_aarch64/kvm_symb.c
+++ b/litmus/libdir/_aarch64/kvm_symb.c
@@ -5,14 +5,14 @@
 typedef struct {
   uintptr_t offset; // offset between the raw value and the symbolic value
   int id; // id of the symbolic value
-} symb_t;
+} data_symb_t;
 
-inline static symb_t symbolic_of_id(int id) {
-  symb_t ret = { .id = id, .offset = 0 };
+inline static data_symb_t symbolic_of_id(int id) {
+  data_symb_t ret = { .id = id, .offset = 0 };
   return ret;
 }
 
-inline static int symbolic_equal(symb_t s1, symb_t s2) {
+inline static int symbolic_equal(data_symb_t s1, data_symb_t s2) {
   return s1.id == s2.id && s1.offset == s2.offset;
 }
 
@@ -22,7 +22,7 @@ static char symbolic_buffer[SYMBOLIC_BUFFER_SIZE];
 // Pretty print a symbolic value and return it as a global string:
 // Always use the result immediately after calling this function
 // because calling it twice overwrite the result of the first call
-inline static const char* pp_symbolic(symb_t s) {
+inline static const char* pp_symbolic(data_symb_t s) {
   char* buffer = &symbolic_buffer[0];
   int len;
   if (s.offset == 0)
@@ -35,4 +35,3 @@ inline static const char* pp_symbolic(symb_t s) {
 
   return buffer;
 }
-

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -458,27 +458,27 @@ module Make
                     O.o "static vars_t *vars_ptr[NEXE];"
                   end ;
                 O.o "" ;
+                O.o "static inline int log_fault(int proc, int instr_symb, symb_t data_symb, int ftype)" ;
+                O.o "{" ;
+                List.iter (fun f ->
+                    let ((p, lbl), loc, ftype) = f in
+                    let lbl_cond = match lbl with
+                      | None -> ""
+                      | Some s -> sprintf " && instr_symb == %s" (SkelUtil.instr_symb_id (OutUtils.fmt_lbl_var p s))
+                    and loc_cond = match loc with
+                      | None -> ""
+                      | Some s -> sprintf " && symbolic_equal(data_symb, %s)" (SkelUtil.data_symb (A.V.pp_v_old s))
+                    and ftype_cond = match ftype with
+                      | None -> ""
+                      | Some s -> sprintf " && ftype == %s" (SkelUtil.fault_id (A.FaultType.pp s))
+                    in
+                    O.fi "if (proc==%d%s%s%s)" p lbl_cond loc_cond ftype_cond;
+                    O.fii "return 1;" ;
+                  ) faults;
+                O.fi "return 0;" ;
+                O.o "}" ;
+                O.o "" ;
              end ;
-             O.o "static inline int log_fault(int proc, int instr_symb, int data_symb, int ftype)" ;
-             O.o "{" ;
-             List.iter (fun f ->
-                 let ((p, lbl), loc, ftype) = f in
-                 let lbl_cond = match lbl with
-                   | None -> ""
-                   | Some s -> sprintf " && instr_symb == %s" (SkelUtil.instr_symb_id (OutUtils.fmt_lbl_var p s))
-                 and loc_cond = match loc with
-                   | None -> ""
-                   | Some s -> sprintf " && data_symb == %s" (SkelUtil.data_symb_id (A.V.pp_v_old s))
-                 and ftype_cond = match ftype with
-                   | None -> ""
-                   | Some s -> sprintf " && ftype == %s" (SkelUtil.fault_id (A.FaultType.pp s))
-                 in
-                 O.fi "if (proc==%d%s%s%s)" p lbl_cond loc_cond ftype_cond;
-                 O.fii "return 1;" ;
-               ) faults;
-             O.fi "return 0;" ;
-             O.o "}" ;
-             O.o "" ;
              Insert.insert O.o "kvm_fault_handler.c" ;
              O.o "" ;
              if not (T.has_asmhandler test) then begin
@@ -723,6 +723,12 @@ module Make
           test.T.globals ;
         O.o "};" ;
         Insert.insert O.o "kvm_symb.c" ;
+        (* UNKNOWN and 0 are special values, so the symbols
+           need to be defined separately. *)
+        O.f "#define %-25s  symbolic_of_id(%-25s)"
+          (SkelUtil.data_symb pp_data_unknown) data_unknown ;
+        O.f "#define %-25s  symbolic_of_id(%-25s)"
+          (SkelUtil.data_symb pp_data_zero) data_zero ;
         (* Define global variables symbols *)
         List.iter
           (fun (a,_) ->
@@ -837,8 +843,13 @@ module Make
         List.iter
           (fun (t,rloc) ->
             if CType.is_ptr t then
+              let ty =
+                if U.is_rloc_label rloc env || U.is_rloc_tag_ptr rloc env then
+                  CType.dump (CType.pointer_type t)
+                else
+                  "symb_t" in
               O.fi "%s %s;"
-                (CType.dump (CType.pointer_type t)) (*todo: this might need more work*)
+                ty
                 (dump_loc_tag_coded (ConstrGen.loc_of_rloc rloc))
             else match rloc with
             | ConstrGen.Loc (A.Location_global a as loc) ->
@@ -921,7 +932,10 @@ module Make
             then begin
           List.iteri
             (fun k (a,_) ->
-              O.f "static const int %s = %i;" (SkelUtil.data_symb_id (Misc.add_physical a)) k)
+              O.f "static const int %s = %i;" (SkelUtil.data_symb_id (Misc.add_physical a)) k ;
+              O.f "#define %-25s  %s"
+                (SkelUtil.data_symb (Misc.add_physical a))
+                (SkelUtil.data_symb_id (Misc.add_physical a)))
             test.T.globals ;
           O.o "" ;
           if U.pte_in_outs env test then begin
@@ -966,11 +980,11 @@ module Make
                 ([sprintf "instr_symb_label[p->%s]" (dump_rloc_tag_coded rloc)], [])
             | Pointer _  when U.is_rloc_tag_ptr rloc env ->
                 None,
-                ([sprintf "pretty_addr[untagged(p->%s)]" (dump_rloc_tag_coded rloc);
+                ([sprintf "data_symb_name[untagged(p->%s)]" (dump_rloc_tag_coded rloc);
                  sprintf "pretty_tag(tag_of(p->%s))" (dump_rloc_tag_coded rloc)], [])
             | Pointer _ ->
                 None,
-                ([sprintf "pp_symbolic[p->%s.id]" (dump_rloc_tag_coded rloc)], [])
+                ([sprintf "pp_symbolic(p->%s)" (dump_rloc_tag_coded rloc)], [])
             | Array (_,sz) ->
                 let tag = A.dump_rloc_tag rloc in
                 let rec pp_rec k =
@@ -1055,7 +1069,7 @@ module Make
               | Some ft -> A.FaultType.pp ft
             in
             O.fi "pp_log_faults(chan, &p->th_faults[%d], %d, %s, %s, %s);" p p
-              (SkelUtil.instr_symb_id lbl) (SkelUtil.data_symb_id loc) (SkelUtil.fault_id ft)
+              (SkelUtil.instr_symb_id lbl) (SkelUtil.data_symb loc) (SkelUtil.fault_id ft)
           ) faults;
         O.o "}" ;
         O.o "" ;
@@ -1076,7 +1090,7 @@ module Make
                 pp_rec (k+1)
               end in
             pp_rec 0
-        | Pointer _ when not (U.is_rloc_label rloc env) ->
+        | Pointer _ when not (U.is_rloc_label rloc env || U.is_rloc_tag_ptr rloc env) ->
             let loc = choose_dump_rloc_tag rloc env in
             O.fii "symbolic_equal(p->%s, q->%s)%s" loc loc suf
         | _ -> do_eq rloc suf in
@@ -1113,7 +1127,7 @@ module Make
               | Constant.(Symbolic (Virtual { name = Symbol.Label(p, lbl); _ }))
                    -> SkelUtil.instr_symb_id (OutUtils.fmt_lbl_var p lbl)
               | Constant.(Symbolic (Virtual { name = Symbol.Data s; tag=Some(t); _})) ->
-                  sprintf "tagged((tag_t)%s,%d)" (SkelUtil.data_symb s) (Misc.int_of_tag t)
+                  sprintf "tagged((tag_t)%s,%d)" (SkelUtil.data_symb_id s) (Misc.int_of_tag t)
               | Constant.Symbolic _ -> SkelUtil.data_symb (T.C.V.pp O.hexa v)
               | Constant.PteVal p ->
                  A.V.PteVal.dump_pack SkelUtil.data_symb p
@@ -1994,7 +2008,9 @@ module Make
                    (OutUtils.fmt_presi_ptr_index (A.dump_rloc_tag rloc))
                else if U.is_rloc_tag_ptr rloc env then
                  let src = OutUtils.fmt_presi_ptr_index (A.dump_rloc_tag rloc) in
-                 O.fii "%s = tagged((tag_t)idx_addr((intmax_t *)%s,_vars),tag_of(%s));"
+                 (* Tagged symbolic values are stored as one tagged value,
+                 so only the base symbol id is kept, not the offset. *)
+                 O.fii "%s = tagged((tag_t)idx_addr((intmax_t *)%s,_vars).id,tag_of(%s));"
                   (OutUtils.fmt_presi_index (dump_rloc_tag_coded rloc)) src src
                else if U.is_rloc_ptr rloc env then
                  O.fii "%s = idx_addr((intmax_t *)%s,_vars);"

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1099,6 +1099,7 @@ module Make
             (struct
 
               let with_ok = true
+              let use_symbolic = true
 
               module C = T.C
 

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -891,7 +891,7 @@ module Make
               end in
             begin
               O.o "static symb_t idx_addr(intmax_t *v_addr,vars_t *p) {" ;
-               O.oi "symb_t ret = { .raw = v_addr, .id = -1, .offset = 0 };" ;
+              O.oi "symb_t ret = { .id = -1, .offset = 0 };" ;
               if Cfg.variant Variant_litmus.Pac then
                 O.oi "v_addr = (intmax_t*) strip_pauth_data((void*) v_addr);" ;
               if Cfg.variant Variant_litmus.MemTag then
@@ -968,7 +968,7 @@ module Make
                  sprintf "pretty_tag(tag_of(p->%s))" (dump_rloc_tag_coded rloc)], [])
             | Pointer _ ->
                 None,
-                ([sprintf "data_symb_name[p->%s.id]" (dump_rloc_tag_coded rloc)], [])
+                ([sprintf "pp_symbolic[p->%s.id]" (dump_rloc_tag_coded rloc)], [])
             | Array (_,sz) ->
                 let tag = A.dump_rloc_tag rloc in
                 let rec pp_rec k =
@@ -1074,6 +1074,9 @@ module Make
                 pp_rec (k+1)
               end in
             pp_rec 0
+        | Pointer _ when not (U.is_rloc_label rloc env) ->
+            let loc = choose_dump_rloc_tag rloc env in
+            O.fii "symbolic_equal(p->%s, q->%s)%s" loc loc suf
         | _ -> do_eq rloc suf in
         let do_eq_faults = function
           | [] -> O.oii "1;"

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -458,7 +458,7 @@ module Make
                     O.o "static vars_t *vars_ptr[NEXE];"
                   end ;
                 O.o "" ;
-                O.o "static inline int log_fault(int proc, int instr_symb, symb_t data_symb, int ftype)" ;
+                O.o "static inline int log_fault(int proc, int instr_symb, data_symb_t data_symb, int ftype)" ;
                 O.o "{" ;
                 List.iter (fun f ->
                     let ((p, lbl), loc, ftype) = f in
@@ -847,7 +847,7 @@ module Make
                 if U.is_rloc_label rloc env || U.is_rloc_tag_ptr rloc env then
                   CType.dump (CType.pointer_type t)
                 else
-                  "symb_t" in
+                  "data_symb_t" in
               O.fi "%s %s;"
                 ty
                 (dump_loc_tag_coded (ConstrGen.loc_of_rloc rloc))
@@ -903,8 +903,8 @@ module Make
                   (SkelUtil.data_symb_id (Misc.add_pte s))
               end in
             begin
-              O.o "static symb_t idx_addr(intmax_t *v_addr,vars_t *p) {" ;
-              O.oi "symb_t ret = { .id = -1, .offset = 0 };" ;
+              O.o "static data_symb_t idx_addr(intmax_t *v_addr,vars_t *p) {" ;
+              O.oi "data_symb_t ret = { .id = -1, .offset = 0 };" ;
               if Cfg.variant Variant_litmus.Pac then
                 O.oi "v_addr = (intmax_t*) strip_pauth_data((void*) v_addr);" ;
               if Cfg.variant Variant_litmus.MemTag then

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -885,8 +885,10 @@ module Make
               O.fi "if (%s == p->%s) ret.id = %s;"
                 addr s (SkelUtil.data_symb_id s) ;
               if Cfg.is_kvm then begin
-                O.fi "if ((pteval_t *)v_addr == p->%s) ret.id = %s;"
-                  (OutUtils.fmt_pte_tag s)
+                O.fi "if ((pteval_t *)v_addr == p->%s) {"
+                  (OutUtils.fmt_pte_tag s) ;
+                O.fii "ret.offset = 0;" ;
+                O.fii "ret.id = %s; }"
                   (SkelUtil.data_symb_id (Misc.add_pte s))
               end in
             begin

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -680,9 +680,9 @@ module Make
         | Base ("int"|"int32_t"|"uint32_t"|"int64_t"|"uint64_t") -> true
         | _ -> false
 
-      let dump_loc_tag_coded loc =  sprintf "%s_idx" (A.dump_loc_tag loc)
+      let dump_loc_tag_coded loc =  sprintf "%s_symb" (A.dump_loc_tag loc)
 
-      let dump_rloc_tag_coded loc =  sprintf "%s_idx" (A.dump_rloc_tag loc)
+      let dump_rloc_tag_coded loc =  sprintf "%s_symb" (A.dump_rloc_tag loc)
 
       let choose_dump_rloc_tag rloc env =
         if U.is_rloc_ptr rloc env then dump_rloc_tag_coded rloc
@@ -721,8 +721,21 @@ module Make
                 O.fi "\"%s\"," (Misc.pp_pte a)
               end)
           test.T.globals ;
-        O.o "};"
-
+        O.o "};" ;
+        Insert.insert O.o "kvm_symb.c" ;
+        (* Define global variables symbols *)
+        List.iter
+          (fun (a,_) ->
+            O.f "#define %-25s  symbolic_of_id(%-25s)"
+              (SkelUtil.data_symb a)
+              (SkelUtil.data_symb_id a);
+            if Cfg.is_kvm then begin
+                O.f "#define %-25s  symbolic_of_id(%-25s)"
+                  (SkelUtil.data_symb (Misc.add_pte a))
+                  (SkelUtil.data_symb_id (Misc.add_pte a))
+              end)
+          test.T.globals ;
+        O.o ""
 
       let dump_fault_type env test =
         if some_labels test then begin
@@ -825,7 +838,7 @@ module Make
           (fun (t,rloc) ->
             if CType.is_ptr t then
               O.fi "%s %s;"
-                (CType.dump (CType.pointer_type t))
+                (CType.dump (CType.pointer_type t)) (*todo: this might need more work*)
                 (dump_loc_tag_coded (ConstrGen.loc_of_rloc rloc))
             else match rloc with
             | ConstrGen.Loc (A.Location_global a as loc) ->
@@ -869,33 +882,33 @@ module Make
             (*  Translation to indices *)
             let addr = if Cfg.is_kvm then "p_addr" else "v_addr" in
             let dump_test (s,_) =
-              O.fi "if (%s == p->%s) return %s;"
+              O.fi "if (%s == p->%s) ret.id = %s;"
                 addr s (SkelUtil.data_symb_id s) ;
               if Cfg.is_kvm then begin
-                O.fi "if ((pteval_t *)v_addr == p->%s) return %s;"
+                O.fi "if ((pteval_t *)v_addr == p->%s) ret.id = %s;"
                   (OutUtils.fmt_pte_tag s)
                   (SkelUtil.data_symb_id (Misc.add_pte s))
               end in
             begin
-              O.o "static int idx_addr(intmax_t *v_addr,vars_t *p) {" ;
+              O.o "static symb_t idx_addr(intmax_t *v_addr,vars_t *p) {" ;
+               O.oi "symb_t ret = { .raw = v_addr, .id = -1, .offset = 0 };" ;
               if Cfg.variant Variant_litmus.Pac then
                 O.oi "v_addr = (intmax_t*) strip_pauth_data((void*) v_addr);" ;
               if Cfg.variant Variant_litmus.MemTag then
                 O.oi "v_addr = (intmax_t*)untagged(v_addr);" ;
               if Cfg.is_kvm then begin
                  O.oi  "intmax_t *p_addr =" ;
-                 O.oii "(intmax_t *)((uintptr_t)v_addr & PAGE_MASK);"
+                 O.oii "(intmax_t *)((uintptr_t)v_addr & PAGE_MASK);";
+                 O.oi "ret.offset = (uintptr_t)v_addr - (uintptr_t)p_addr;"
               end ;
-              (* Compatibility with standard mode, recognise NULL *)
-              O.fi "if (%s == NULL) return %s;" addr data_zero ;
+              if (not Cfg.is_kvm) then
+                (* Compatibility with standard mode, recognise NULL *)
+                O.fi "if (%s == NULL) ret.id = %s;" addr data_zero ;
               List.iter dump_test test.T.globals ;
-              O.oi "fatal(\"Cannot find symbol for address\"); return -1;" ;
+              O.oi "if (ret.id == -1)" ;
+              O.oii "fatal(\"Cannot find symbol for address\");" ;
+              O.oi "return ret;" ;
               O.o "}" ;
-              O.o ""
-            end ;
-(* Pretty-print indices *)
-            if some_ptr then begin
-              O.o "static const char **pretty_addr = data_symb_name;" ;
               O.o ""
             end
         end ;
@@ -955,7 +968,7 @@ module Make
                  sprintf "pretty_tag(tag_of(p->%s))" (dump_rloc_tag_coded rloc)], [])
             | Pointer _ ->
                 None,
-                ([sprintf "pretty_addr[p->%s]" (dump_rloc_tag_coded rloc)], [])
+                ([sprintf "data_symb_name[p->%s.id]" (dump_rloc_tag_coded rloc)], [])
             | Array (_,sz) ->
                 let tag = A.dump_rloc_tag rloc in
                 let rec pp_rec k =
@@ -1094,12 +1107,12 @@ module Make
               | Constant.(Symbolic (Virtual { name = Symbol.Label(p, lbl); _ }))
                    -> SkelUtil.instr_symb_id (OutUtils.fmt_lbl_var p lbl)
               | Constant.(Symbolic (Virtual { name = Symbol.Data s; tag=Some(t); _})) ->
-                  sprintf "tagged((tag_t)%s,%d)" (SkelUtil.data_symb_id s) (Misc.int_of_tag t)
-              | Constant.Symbolic _ -> SkelUtil.data_symb_id (T.C.V.pp O.hexa v)
+                  sprintf "tagged((tag_t)%s,%d)" (SkelUtil.data_symb s) (Misc.int_of_tag t)
+              | Constant.Symbolic _ -> SkelUtil.data_symb (T.C.V.pp O.hexa v)
               | Constant.PteVal p ->
-                 A.V.PteVal.dump_pack SkelUtil.data_symb_id p
+                 A.V.PteVal.dump_pack SkelUtil.data_symb p
               | Constant.AddrReg a ->
-                A.V.AddrReg.dump_pack SkelUtil.data_symb_id a
+                A.V.AddrReg.dump_pack SkelUtil.data_symb a
               | Constant.Tag t -> Misc.int_of_tag t |> string_of_int
               | _ ->
                   begin match loc with

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -928,7 +928,7 @@ module Make
                 O.fi "else if (v_addr == (void *)_a->%s[_i]) return %i;"
                   s k in
           O.o "static int idx_addr(ctx_t *_a,int _i,void *v_addr) {" ;
-          O.fi "if (v_addr == NULL) return 0;" ;
+          O.oi "if (v_addr == NULL) return 0;" ;
           Misc.iteri (fun k (s,_) -> dump_test (k+1) s) test.T.globals ;
           O.fi "else { fatal(\"%s, ???\"); return -1;}" doc.Name.name ;
           O.o "}" ;

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -874,6 +874,7 @@ module Make
       module DC =
         CompCond.Make(O)
           (struct
+            let use_symbolic = false
             let with_ok = true
             module C = C
  (* Location argument ignored, may be useful for null pointer.
@@ -927,7 +928,7 @@ module Make
                 O.fi "else if (v_addr == (void *)_a->%s[_i]) return %i;"
                   s k in
           O.o "static int idx_addr(ctx_t *_a,int _i,void *v_addr) {" ;
-          O.oi "if (v_addr == NULL) { return 0;}" ;
+          O.fi "if (v_addr == NULL) return 0;" ;
           Misc.iteri (fun k (s,_) -> dump_test (k+1) s) test.T.globals ;
           O.fi "else { fatal(\"%s, ???\"); return -1;}" doc.Name.name ;
           O.o "}" ;

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -75,6 +75,7 @@ let dump_fatom_tag d ((p,lbl),v,_) =
      | None -> ""
      | Some v -> "_" ^ d v)
 
+let data_symb s = sprintf "DATA_SYMB_%s" (String.uppercase_ascii s)
 let data_symb_id s = sprintf "DATA_SYMB_ID_%s" (String.uppercase_ascii s)
 let instr_symb_id s = sprintf "INSTR_SYMB_ID_%s" (String.uppercase_ascii s)
 let fault_id s = sprintf "Fault%s" (Misc.to_c_name s)


### PR DESCRIPTION
This PR continues the work in #1166. 

It addresses the same issue of fixing the bug in litmus7 when running the following test:

```
AArch64 offset_cex
{ 0:x0=x; uint64_t 0:x1=4; }

P0;
add x0,x0,x1;

forall ( 0:x0=x )
```

where `herd7` correctly distinguishes `x+4` from `x` in the postcondition but `litmus7` doesn't.

Compared to the original work, this PR enables the changes to pass regressions after rebasing. 

  - `log_fault` is only emitted when fault atoms are actually present
  - tagged values continue to use only the ID, without the offset. *This PR does not try to unify all symbolic value representations.*
  - PTE symbol definitions were completed
  - the old `pretty_addr` was changed in favour of `data_symb_name` for MTE path as well



  A regression test covering proving the benefit of this PR has been added:

  - `herd/tests/instructions/AArch64.kvm/A037.litmus`