### PR TITLE
Anchor doc export-ignore attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 .gitattributes export-ignore
 .gitignore export-ignore
-doc/ export-ignore
+/doc/ export-ignore
 herd-www/  export-ignore
 catalogue/ export-ignore


### PR DESCRIPTION
`.gitattributes` was filtering out both the top-level `doc` as well as `asllib/doc` from being included in archives of the repository. I changed it to filter only the top-level `doc`.