### PR TITLE
[all] Clean-up utils following update to ocaml 4.14

### DIFF
--- a/gen/BellArch_gen.ml
+++ b/gen/BellArch_gen.ml
@@ -127,7 +127,7 @@ let pp_annots a = match a with
 let pp_atom a =  pp_annots a
 
 let compare_atom a1 a2 =
-  Misc.list_compare String.compare a1 a2
+  List.compare String.compare a1 a2
 
 include MachMixed.No
 

--- a/gen/cat2config/ir.ml
+++ b/gen/cat2config/ir.ml
@@ -31,7 +31,7 @@ let union : 'a union -> 'a union -> 'a union =
  fun (Union x) (Union y) -> Union (List.append x y)
 
 let union_flat_map (f : 'a -> 'b union) (Union u : 'a union) : 'b union =
-  Union (Util.List.concat_map (fun x -> get_union (f x)) u)
+  Union (List.concat_map (fun x -> get_union (f x)) u)
 
 let union_l : 'a union list -> 'a union =
  fun l -> List.fold_right union l (Union [])
@@ -390,7 +390,7 @@ let expand_domain_range (nf : rel_nf) : rel_nf =
         | None -> [ Set (Inter x) ])
     | x -> [ x ]
   in
-  map_union (fun (Seq seq) -> Seq (Util.List.concat_map expand_item seq)) nf
+  map_union (fun (Seq seq) -> Seq (List.concat_map expand_item seq)) nf
 
 let expand_acq_rel (nf : rel_nf) : rel_nf =
   let mem = to_id (prim_set (Prim "M")) in

--- a/gen/cat2config/mcat2config.ml
+++ b/gen/cat2config/mcat2config.ml
@@ -166,7 +166,7 @@ struct
   let rec find_parse_deep (file_path : string) : AST.ins list =
     let _, (_, _, ast) = Parser.find_parse file_path in
     let includes = get_includes ast in
-    let included_asts = Util.List.concat_map find_parse_deep includes in
+    let included_asts = List.concat_map find_parse_deep includes in
     included_asts @ ast
 end
 

--- a/gen/cat2config/translation.ml
+++ b/gen/cat2config/translation.ml
@@ -257,8 +257,8 @@ let try_match_edge (left : prim_set list) (core : seq_item list)
   let* _ = Util.Option.guard left.explicit_mem in
   let* right = build_effect initial_effect (right @ implied_right) in
   let* _ = Util.Option.guard right.explicit_mem in
-  let tedges = tedges |> UList.concat_map (filter_by_sd pedge.sd) in
-  let tedges = tedges |> UList.concat_map (filter_by_ie pedge.ie) in
+  let tedges = tedges |> List.concat_map (filter_by_sd pedge.sd) in
+  let tedges = tedges |> List.concat_map (filter_by_ie pedge.ie) in
   let relaxs =
     tedges
     |> List.map (fun (Tedge { edge; insert }) ->

--- a/gen/common/util.ml
+++ b/gen/common/util.ml
@@ -62,9 +62,6 @@ let parse_cmdline options get_cmd_arg =
     (sprintf "Usage %s [options] [arg]*\noptions are:" Sys.argv.(0))
 
 module List = struct
-  let concat_map : ('a -> 'b list) -> 'a list -> 'b list =
-    fun f l -> List.concat (List.map f l)
-
   let uniq ~eq l =
     let rec uniq eq acc l =
       match l with
@@ -75,7 +72,7 @@ module List = struct
     uniq eq [] l
 
   module Infix = struct
-    let (let*) = fun x f -> concat_map f x
+    let (let*) = fun x f -> List.concat_map f x
   end
 
   let rec sequence : 'a list list -> 'a list list =

--- a/gen/common/util.mli
+++ b/gen/common/util.mli
@@ -33,11 +33,6 @@ val arch_opt : Archs.t ref -> spec
 val parse_cmdline : spec list -> (string -> unit) -> unit
 
 module List : sig
-  (** [concat_map f l] gives the same result as [List.concat (List.map f l)].
-
-      For compatibility with OCaml < 4.10 *)
-  val concat_map : ('a -> 'b list) -> 'a list -> 'b list
-
   (** [uniq ~eq l] removes duplicates in [l] w.r.t the equality predicate [eq]. *)
   val uniq : eq:('a -> 'a -> bool) -> 'a list -> 'a list
 

--- a/gen/norm.ml
+++ b/gen/norm.ml
@@ -73,10 +73,10 @@ module Make(Co:Config)(F:Fence.S)(A:Atom.S) = struct
     try
       let rs =
         relaxs
-        |> Util.List.concat_map LexUtil.split
+        |> List.concat_map LexUtil.split
         |> List.map R.parse_relax
       in
-      let es = Util.List.concat_map R.edges_of rs in
+      let es = List.concat_map R.edges_of rs in
       let base,es,_ = Norm.normalise_family (E.resolve_edges es) in
       let name =  N.mk_name base ?scope:None es in
       Printf.printf "%s: %s\n" name (E.pp_edges es)

--- a/gen/readRelax.ml
+++ b/gen/readRelax.ml
@@ -49,15 +49,8 @@ module Top = struct
       | One r -> r
       | Seq rs -> "[" ^ String.concat "," rs ^ "]"
 
-    let rec lex_str r1 r2 = match r1,r2 with
-    | [],[] -> 0
-    | _::_,[] -> 1
-    | [],_::_ -> -1
-    | r1::rs1,r2::rs2 ->
-        let c = String.compare r1 r2 in
-        match c with
-        | 0 -> lex_str rs1 rs2
-        | _ -> c
+    let lex_str r1 r2 =
+      List.compare String.compare r1 r2
 
     let compare r1 r2 = match r1,r2 with
     | One r1,Seq [r2]

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -111,15 +111,8 @@ and type edge = E.edge
         | PPO -> assert false
 
 
-        let rec compare_edges es1 es2 = match es1,es2 with
-        | [],[] -> 0
-        | [],_::_ -> -1
-        | _::_,[] -> 1
-        | e1::es1,e2::es2 ->
-            begin match E.compare e1 e2 with
-            | 0 -> compare_edges es1 es2
-            | r -> r
-            end
+        let compare_edges es1 es2 =
+          List.compare E.compare es1 es2
 
         let compare r1 r2 = match r1,r2 with
         | PPO,PPO -> 0

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -1053,7 +1053,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
       let open Asllib.AST in
       lazy
         (Lazy.force ASLS.built_shared_pseudocode
-        |> Misc.find_map (fun d ->
+        |> List.find_map (fun d ->
             match d.desc with
             | D_GlobalStorage
                 { keyword = GDK_Var; name = "PSTATE"; ty = Some ty; _ } -> (

--- a/herd/valconstraint.ml
+++ b/herd/valconstraint.ml
@@ -668,7 +668,7 @@ let get_failed cns =
               (sol, Failed exn :: eqs)
          end
 
-    let same_eqs eqs1 eqs2 =  Misc.list_compare OrderedEq.compare eqs1 eqs2 = 0
+    let same_eqs eqs1 eqs2 =  List.compare OrderedEq.compare eqs1 eqs2 = 0
 
     let topo_step =
       (* Perform a solving step on each equation in solve_step *)

--- a/internal/herd_assumptions_test.ml
+++ b/internal/herd_assumptions_test.ml
@@ -57,7 +57,7 @@ let get_raised_flags s =
   List.fold_left
     (fun acc line ->
       let line = String.trim line in
-      if String.length line >= 6 && Misc.string_starts_with ~prefix:"Flag " line
+      if String.length line >= 6 && String.starts_with ~prefix:"Flag " line
       then
         let name = String.sub line 5 (String.length line - 5) |> String.trim in
         name :: acc

--- a/internal/lib/base.ml
+++ b/internal/lib/base.ml
@@ -48,49 +48,14 @@ end
 module List = struct
   include List
 
-  let rec compare cf xs ys =
-    match xs, ys with
-    | [], [] -> 0
-    | [], _ -> -1
-    | _, [] -> 1
-    | x :: xs, y :: ys ->
-        match cf x y with
-        | 0 -> compare cf xs ys
-        | n -> n
-
   let to_ocaml_string f xs =
     Printf.sprintf "[%s]" (String.concat "; " (List.map f xs))
 end
 
 module Option = struct
+  include Option
+
   type 'a t = 'a option
-
-  let get o =
-    match o with
-    | None -> invalid_arg "option is None"
-    | Some v -> v
-
-  let value o ~default =
-    match o with
-    | None -> default
-    | Some v -> v
-
-  let map f o =
-    match o with
-    | None -> None
-    | Some v -> Some (f v)
-
-  let is_none o =
-    match o with
-    | None -> true
-    | Some _ -> false
-
-  let compare cf a b =
-    match a, b with
-    | None, None -> 0
-    | Some _, None -> 1
-    | None, Some _ -> -1
-    | Some a, Some b -> cf a b
 
   let to_ocaml_string f o =
     match o with

--- a/internal/lib/base.mli
+++ b/internal/lib/base.mli
@@ -43,11 +43,6 @@ end
 module List : sig
   include module type of List
 
-  (** [compare c xs ys] compares lists [xs] and [ys], first by length, then by
-   *  comparing each pair of elements of [xs] and [ys] with compare function [c]
-   *  until a pair differs. *)
-  val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
-
   (** [to_ocaml_string f xs] returns an OCaml syntax form of [xs], applying [f]
    *  to each element of [xs]. For example,
    *  [to_ocaml_string String.to_ocaml_string ["a"; "b"]] returns
@@ -64,24 +59,9 @@ module String : sig
 end
 
 module Option : sig
+  include module type of Option
+
   type 'a t = 'a option
-
-  (** [get o] is [v] if [o] is [Some v].
-   *  It raises [Invalid_argument] if [o] is [None]. *)
-  val get : 'a t -> 'a
-
-  (** [value o ~default] is [v] if [o] is [Some v] and [default] otherwise. *)
-  val value : 'a option -> default:'a -> 'a
-
-  (** [map f o] is [None] if [o] is [None] and [Some (f v)] if [o] is [Some v]. *)
-  val map : ('a -> 'b) -> 'a option -> 'b option
-
-  (** [is_none o] is [true] iff [o] is [None]. *)
-  val is_none : 'a option -> bool
-
-  (** [compare c x y] compares [x] and [y]. [None] is smaller than [Some _]. If
-   *  they are both [Some _] their elements are compared with function [c]. *)
-  val compare : ('a -> 'a -> int) -> 'a option -> 'a option -> int
 
   (** [to_ocaml_string f x] returns an OCaml syntax form of [x]. If [x] is
    * [Some x'], [f] is applied to the element [x'].

--- a/internal/lib/sexp.ml
+++ b/internal/lib/sexp.ml
@@ -31,16 +31,7 @@ let compare x y =
     | Atom x, Atom y -> String.compare x y
     | Atom _, List _ -> -1
     | List _, Atom _ -> 1
-    | List xs, List ys -> compare_sexp_list xs ys
-  and compare_sexp_list xs ys =
-    match xs, ys with
-    | [], [] -> 0
-    | [], _ -> -1
-    | _, [] -> 1
-    | x :: xs, y :: ys ->
-        match compare_sexp x y with
-        | 0 -> compare_sexp_list xs ys
-        | n -> n
+    | List xs, List ys -> List.compare compare_sexp xs ys
   in
   compare_sexp x y
 

--- a/internal/lib/testHerd.ml
+++ b/internal/lib/testHerd.ml
@@ -64,12 +64,8 @@ let compare_lines nohash l1 l2 =
    && Str.string_match hash_re l2 0)
   || String.equal l1 l2
 
-let rec log_equal nohash xs ys =
-  match xs,ys with
-  | [],[] -> true
-  | x::xs,y::ys ->
-      compare_lines nohash x y && log_equal nohash xs ys
-  | ([],_::_)|(_::_,[]) -> false
+let log_equal nohash xs ys =
+  List.equal (compare_lines nohash) xs ys
 
 let log_diff  nohash xs ys = not (log_equal nohash xs ys)
 
@@ -113,11 +109,11 @@ let norm_states xs =
        | [] -> k
        | ws -> List.sort String.compare ws::k)
     [] xs
-  |> List.sort (Misc.list_compare String.compare)
+  |> List.sort (List.compare String.compare)
 
 let states_equal litmus xs ys =
   let xs0 = norm_states xs and ys0 = norm_states ys in
-  let eq = Misc.list_eq (Misc.list_eq String.equal) xs0 ys0 in
+  let eq = List.equal (List.equal String.equal) xs0 ys0 in
   if _dbg || not eq then begin
     Printf.eprintf "%s on %s\n" (if eq then "Ok" else "Fail") litmus ;
     Printf.eprintf "** Expected:\n" ; pp_norm_states stderr ys0 ;

--- a/jingle/BellArch_jingle.ml
+++ b/jingle/BellArch_jingle.ml
@@ -18,11 +18,8 @@ include Arch.MakeArch(struct
 
   include Arch.MakeCommon(BellBase)
 
-  let rec annots_compare s s' =
-    match s,s' with
-    | [],[] -> true
-    | x::s,y::s' when String.compare x y = 0 -> annots_compare s s'
-    | _ -> false
+  let annots_compare s s' =
+    List.equal String.equal s s'
 
   let match_reg_or_imm subs ri ri' = match ri,ri' with
     | Regi r,Regi r'

--- a/lib/constant.ml
+++ b/lib/constant.ml
@@ -292,7 +292,7 @@ let rec compare scalar_compare pteval_compare addrreg_compare instr_compare c1 c
   match c1,c2 with
   | Concrete i1, Concrete i2 -> scalar_compare i1 i2
   | ConcreteVector v1, ConcreteVector v2 ->
-     Misc.list_compare
+    List.compare
        (compare scalar_compare pteval_compare addrreg_compare instr_compare) v1 v2
   | ConcreteRecord li1, ConcreteRecord li2 ->
      StringMap.compare
@@ -325,7 +325,7 @@ let rec compare scalar_compare pteval_compare addrreg_compare instr_compare c1 c
 let rec eq scalar_eq pteval_eq addrreg_eq instr_eq c1 c2 = match c1,c2 with
   | Concrete i1, Concrete i2 -> scalar_eq i1 i2
   | ConcreteVector v1, ConcreteVector v2 ->
-     Misc.list_eq (eq scalar_eq pteval_eq addrreg_eq instr_eq) v1 v2
+     List.equal (eq scalar_eq pteval_eq addrreg_eq instr_eq) v1 v2
   | ConcreteRecord li1, ConcreteRecord li2 ->
     StringMap.equal (eq scalar_eq pteval_eq addrreg_eq instr_eq) li1 li2
   | Symbolic s1, Symbolic s2 -> symbol_eq s1 s2
@@ -579,7 +579,7 @@ let is_pt v = match v with
 let make_canonical = function
   | Symbolic (Virtual v) -> Symbolic (Virtual {v with pac=PAC.canonical})
   | cst -> cst
-  
+
 let mk_sym_morello p s t =
   let p_int = Misc.string_as_int64 p in
   if

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -381,7 +381,7 @@ module Make
       | (Prim (_,i1,_),Prim (_,i2,_)) -> Misc.int_compare i1 i2
       | Clo _,Prim _ -> 1
       | Prim _,Clo _ -> -1
-      | Tuple vs,Tuple ws ->  compares vs ws
+      | Tuple vs,Tuple ws -> List.compare compare vs ws
 (* Errors *)
       | (Unv,_)|(_,Unv) -> error "Universe in compare"
       | _,_ ->
@@ -393,16 +393,6 @@ module Make
             error
               "Heterogeneous set elements: types %s and %s "
               (pp_typ t1) (pp_typ t2)
-
-      and compares vs ws = match vs,ws with
-      | [],[] -> 0
-      | [],_::_ -> -1
-      | _::_,[] -> 1
-      | v::vs,w::ws ->
-          begin match compare v w with
-          | 0 -> compares vs ws
-          | r -> r
-          end
 
     end and ValSet : (MySet.S with type elt = V.v) = MySet.Make(ValOrder)
 

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -133,34 +133,11 @@ let pair_compare cmpx cmpy (x1,y1) (x2,y2) =
 
 let pair_eq eqx eqy (x1,y1) (x2,y2) =  eqx x1 x2 &&  eqy y1 y2
 
-let rec list_compare cmp xs ys = match xs,ys with
-  | [],[] -> 0
-  | [],_::_ -> -1
-  | _::_,[] -> 1
-  | x::xs,y::ys ->
-      begin match cmp x y with
-      | 0 -> list_compare cmp xs ys
-      | r -> r
-      end
-
-let rec list_eq eq xs ys = match xs,ys with
-  | [],[] -> true
-  | ([],_::_)|(_::_,[]) -> false
-  | x::xs,y::ys -> eq x y && list_eq eq xs ys
-
 let char_uppercase = Char.uppercase_ascii
 let lowercase = String.lowercase_ascii
 let uppercase = String.uppercase_ascii
 let capitalize = String.capitalize_ascii
 let uncapitalize = String.uncapitalize_ascii
-
-(** [string_starts_with ~prefix s] checks if string [s] starts with [prefix].
-  Normally available natively in Ocaml 4.13. *)
-let string_starts_with ~prefix s =
-  let prefix_len = String.length prefix in
-  let s_len = String.length s in
-  if prefix_len > s_len then false
-  else String.equal (String.sub s 0 prefix_len) prefix
 
 let to_c_name =
   let tr c = match c with
@@ -172,12 +149,6 @@ let to_c_name =
 let find_opt = List.find_opt
 let filter_map = List.filter_map
 let split_on_char = String.split_on_char
-
-let rec find_map f = function
-  | [] -> None
-  | x :: t ->
-      let res = f x in
-      if is_some res then res else find_map f t
 
 (********************)
 (* Position parsing *)
@@ -881,7 +852,6 @@ module List = struct
   include List
 
   let empty = []
-  let concat_map f l = concat (map f l)
   let is_empty = function
     | [] -> true
     | _ -> false
@@ -895,15 +865,6 @@ module List = struct
       | x :: xs -> uniq eq (x :: acc) xs
     in
     uniq eq [] l
-
-
-  let fold_left_map f accu l =
-    let rec aux accu l_accu = function
-      | [] -> accu, rev l_accu
-      | x :: l ->
-          let accu, x = f accu x in
-          aux accu (x :: l_accu) l in
-    aux accu [] l
 
   module Syntax = struct
     let (let*) = fun l f -> concat_map f l

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -88,22 +88,18 @@ val pair_compare :
     ('a -> 'a -> int) -> ('b -> 'b -> int) -> 'a * 'b -> 'a * 'b -> int
 val pair_eq :
   ('a -> 'a -> bool) -> ('b -> 'b -> bool) -> 'a * 'b -> 'a * 'b -> bool
-val list_compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
-val list_eq : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
 
 val char_uppercase : char -> char
 val lowercase : string -> string
 val uppercase : string -> string
 val capitalize : string -> string
 val uncapitalize : string -> string
-val string_starts_with : prefix:string -> string -> bool
 
 (* strip characters to form a valid c variable/type/enum name *)
 val to_c_name : string -> string
 
 (* Backward compatibility *)
 val find_opt : ('a -> bool) -> 'a list -> 'a option
-val find_map : ('a -> 'b option) -> 'a list -> 'b option
 val split_on_char : char -> string -> string list
 val filter_map : ('a -> 'b option) -> 'a list -> 'b list
 (* Float pair (position) parsint *)
@@ -397,12 +393,6 @@ module List : sig
   (** [uniq ~eq l] removes duplicates in [l] w.r.t the equality predicate [eq].
       Complexity is quadratic in the length of the list, but the order
       of elements is preserved. *)
-
-  val fold_left_map :
-    ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
-  (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an
-      accumulator through calls to [f].
-      For compatibility with OCaml < 4.11. *)
 
   module Syntax : sig
     val (let*) : 'a list -> ('a -> 'b list) -> 'b list

--- a/litmus/switch.ml
+++ b/litmus/switch.ml
@@ -42,18 +42,14 @@ module Make (O:Indent.S) (I:CompCondUtils.I) :
     module S = struct
       type t = switch_node
 
-      let rec equal_cases cs1 cs2 = match cs1,cs2 with
-      | ([],_::_)|(_::_,[]) -> false
-      | [],[] -> true
-      | (i1,j1)::cs1,(i2,j2)::cs2 ->
-          Scalar.compare i1 i2 = 0 &&
-          Misc.int_eq j1 j2 &&
-          equal_cases cs1 cs2
+      let equal_cases cs1 cs2 =
+        List.equal
+          (fun (i1,j1) (i2,j2) ->
+             Scalar.compare i1 i2 = 0 && Misc.int_eq j1 j2)
+          cs1 cs2
 
-      let rec equal_rhs rhs1 rhs2 = match rhs1,rhs2 with
-      | ([],_::_)|(_::_,[]) -> false
-      | [],[] -> true
-      | r1::rhs1,r2::rhs2 -> r1 == r2 && equal_rhs rhs1 rhs2
+      let equal_rhs rhs1 rhs2 =
+        List.equal ( == ) rhs1 rhs2
 
       let equal s1 s2 = match s1,s2 with
       | (Return _,Switch _)|(Switch _,Return _) -> false

--- a/tools/cat2table.ml
+++ b/tools/cat2table.ml
@@ -162,7 +162,7 @@ struct
           do_compare_pairs (op1, e1) (op2, e2) compare do_compare_expr
       | Op (_, op1, es1), Op (_, op2, es2) ->
           do_compare_pairs (op1, es1) (op2, es2) compare
-            (Misc.list_compare do_compare_expr)
+            (List.compare do_compare_expr)
       | App (_, e11, e12), App (_, e21, e22) ->
           do_compare_expr_pairs (e11, e12) (e21, e22)
       | Try (_, e11, e12), Try (_, e21, e22) ->

--- a/tools/logState.ml
+++ b/tools/logState.ml
@@ -74,12 +74,9 @@ type parsed_topologies = topology list
 
 type sts = parsed_sts (* + sorted *)
 
-let rec do_equal_states xs ys = match xs,ys with
-  | [],[] -> true
-  | (_::_,[])|([],_::_) -> false
-  | x::xs,y::ys ->
-     x.p_st == y.p_st && (* Ignore counts, outcomes are hash-consed *)
-     do_equal_states xs ys
+let do_equal_states xs ys =
+  (* Ignore counts, outcomes are hash-consed. *)
+  List.equal (fun x y -> x.p_st == y.p_st) xs ys
 
 let equal_states sts1 sts2 = do_equal_states sts1.p_sts sts2.p_sts
 
@@ -1330,10 +1327,8 @@ let simple_diff_not_empty out t1 t2 k =
   simple_diff_gen diff_not_empty out t1 t2 k
 
 
-let rec diff_simple_states xs ys = match xs,ys with
-| [],[] -> false
-| x::xs,y::ys -> x != y || diff_simple_states xs ys
-| _,_ -> true
+let diff_simple_states xs ys =
+  not (List.equal ( == ) xs ys)
 
 let simple_diff out t1 t2 k =
   simple_diff_gen diff_simple_states out t1 t2 k

--- a/tools/msort.ml
+++ b/tools/msort.ml
@@ -87,15 +87,8 @@ module Top
 
     type name = {fname:string; tname:string;}
 
-    let rec compare_names xs ys = match xs,ys with
-    | [],[] -> 0
-    | [],_::_ -> -1
-    | _::_,[] -> 1
-    | x::xs,y::ys ->
-        begin match String.compare x.tname y.tname with
-        | 0 -> compare_names xs ys
-        | r -> r
-        end
+    let compare_names xs ys =
+      List.compare (fun x y -> String.compare x.tname y.tname) xs ys
 
       let get_base f = Filename.chop_extension (Filename.basename f)
 


### PR DESCRIPTION
Replacing various locally-defined utility functions with equivalents from the stdlib, following https://github.com/herd/herdtools7/pull/1819