### PR TITLE
[aslspec] parameterized types

### DIFF
--- a/asllib/aslspec/AST.ml
+++ b/asllib/aslspec/AST.ml
@@ -211,6 +211,10 @@ module Term = struct
     | Label of { loc : source_location; label : string }
         (** Either a set containing the single value named by the given string
             or a reference to a type with the given name. *)
+    | Parameter of { loc : source_location; name : string }
+        (** A named type parameter. The parser constructs an instance of
+            [Label], which is later substituted by an instance of [Parameter] in
+            [SubstituteTypeParameters]. *)
     | TypeOperator of {
         loc : source_location;
         op : type_operator;
@@ -218,6 +222,22 @@ module Term = struct
       }
         (** A set containing all types formed by applying the type operator [op]
             to the type given by [term]. *)
+    | ParamType of {
+        loc : source_location;
+        typename : string;
+        term : opt_named_type_term;
+      }
+        (** A set containing all types formed by instantiating the parameterized
+            type [typename] with the parameter [term]. For example, if we have
+            {[
+              typedef Tree[[T]] =
+              | Leaf(value: T)
+              | Node(left: Tree[[T]], right: Tree[[T]])
+
+              relation walk_tree(x: Tree[[Z]]) -> list0(Z) = ...
+            ]}
+            then {[ Tree[[Z]] ]} is represented by a [ParamType] with [typename] =
+            "Tree" and [term] represented by the type parameter [Z]. *)
     | Tuple of {
         loc : source_location;
         label_opt : string option;
@@ -263,7 +283,9 @@ module Term = struct
   let loc_of term =
     match term with
     | Label { loc }
+    | Parameter { loc }
     | TypeOperator { loc }
+    | ParamType { loc }
     | Tuple { loc }
     | Record { loc }
     | Function { loc }
@@ -277,6 +299,8 @@ module Term = struct
   (** [make_type_operation loc op term] constructs a type term in which [op] is
       applied to [term] at source location [loc]. *)
   let make_type_operation loc op term = TypeOperator { loc; op; term }
+
+  let make_param_type loc typename term = ParamType { loc; typename; term }
 
   (** [make_tuple loc args] constructs an unlabelled tuple with arguments [args]
       at source location [loc]. *)
@@ -544,6 +568,7 @@ module Type : sig
   type t = {
     loc : source_location;
     name : string;
+    param_opt : string option;
     type_kind : Term.type_kind;
     variants : TypeVariant.t list;
     att : Attributes.t;
@@ -551,10 +576,11 @@ module Type : sig
 
   val make :
     source_location ->
-    Term.type_kind ->
-    string ->
-    TypeVariant.t list ->
-    attribute_pairs ->
+    type_kind:Term.type_kind ->
+    name:string ->
+    param_opt:string option ->
+    variants:TypeVariant.t list ->
+    attribute_pairs:attribute_pairs ->
     t
 
   val attributes_to_list : t -> attribute_pairs
@@ -568,12 +594,13 @@ end = struct
   type t = {
     loc : source_location;
     name : string;
+    param_opt : string option;
     type_kind : Term.type_kind;
     variants : TypeVariant.t list;
     att : Attributes.t;
   }
 
-  let make loc type_kind name variants attribute_pairs =
+  let make loc ~type_kind ~name ~param_opt ~variants ~attribute_pairs =
     (* The [type_kind] of the variants is the [type_kind] given above. *)
     let variants_with_parent_type_kind =
       List.map
@@ -586,6 +613,7 @@ end = struct
       loc;
       type_kind;
       name;
+      param_opt;
       variants = variants_with_parent_type_kind;
       att = Attributes.of_list attribute_pairs;
     }

--- a/asllib/aslspec/ASTUtils.ml
+++ b/asllib/aslspec/ASTUtils.ml
@@ -12,8 +12,9 @@ let rec vars_of_type_term term =
   let open Term in
   let listed_vars =
     match term with
-    | Label _ | ConstantsSet _ -> []
+    | Label _ | Parameter _ | ConstantsSet _ -> []
     | TypeOperator { term } -> opt_named_term_to_var_list term
+    | ParamType { term } -> opt_named_term_to_var_list term
     | Tuple { args } -> vars_of_opt_named_type_terms args
     | Record { fields } ->
         List.concat_map

--- a/asllib/aslspec/PP.ml
+++ b/asllib/aslspec/PP.ml
@@ -54,10 +54,13 @@ let rec pp_type_term fmt =
   let open Term in
   function
   | Label { label } -> pp_print_string fmt label
+  | Parameter { name } -> pp_print_string fmt name
   | TypeOperator { op; term } ->
       fprintf fmt "%s(%a)"
         (type_operator_to_token op |> tok_str)
         pp_opt_named_type_term term
+  | ParamType { typename; term } ->
+      fprintf fmt "%s[[%a]]" typename pp_opt_named_type_term term
   | Tuple { label_opt; args } ->
       fprintf fmt "%s(%a)"
         (Option.value label_opt ~default:"")
@@ -219,13 +222,18 @@ let type_kind_to_string =
   let open Term in
   function TypeKind_Generic -> tok_str TYPEDEF | TypeKind_AST -> tok_str AST
 
-let pp_type_definition fmt ({ Type.name; type_kind; variants } as def) =
-  let eq_str = if Utils.list_is_empty variants then "" else " = " in
-  fprintf fmt "%s %s@.%a@.%s@,@[<v>  %a@]@,;"
-    (type_kind_to_string type_kind)
-    name pp_attribute_key_values
+let pp_type_parameter fmt = function
+  | Some param -> fprintf fmt "[[%s]]" param
+  | None -> ()
+
+let pp_type_definition fmt def =
+  let open Type in
+  let eq_str = if Utils.list_is_empty def.variants then "" else " = " in
+  fprintf fmt "%s %s%a@.%a@.%s@,@[<v>  %a@]@,;"
+    (type_kind_to_string def.type_kind)
+    def.name pp_type_parameter def.param_opt pp_attribute_key_values
     (Type.attributes_to_list def)
-    eq_str pp_variants_with_attributes variants
+    eq_str pp_variants_with_attributes def.variants
 
 let pp_constant_definition fmt
     ({ Constant.name; opt_type; opt_value_and_attributes } as def) =

--- a/asllib/aslspec/SpecLexer.mll
+++ b/asllib/aslspec/SpecLexer.mll
@@ -78,7 +78,9 @@ rule token = parse
     | '('            { LPAR }
     | ')'            { RPAR }
     | '['            { LBRACKET }
+    | "[["           { LLBRACKET }
     | ']'            { RBRACKET }
+    | "]]"           { RRBRACKET }
     | '{'            { LBRACE }
     | '}'            { RBRACE }
     | '-'            { MINUS }

--- a/asllib/aslspec/SpecParser.mly
+++ b/asllib/aslspec/SpecParser.mly
@@ -105,7 +105,9 @@ let check_balanced_braces loc s =
 %token LPAR
 %token RPAR
 %token LBRACKET
+%token LLBRACKET
 %token RBRACKET
+%token RRBRACKET
 %token LBRACE
 %token RBRACE
 %token MINUS
@@ -225,11 +227,21 @@ let type_kind := TYPEDEF; { Term.TypeKind_Generic }
 let checked_identifier == id=IDENTIFIER; { check_definition_name (loc $sloc) id; id }
 
 let type_definition :=
-    | ~=type_kind; type_name=checked_identifier; ~=type_attributes; ~=type_variants_with_attributes;
-    {   Elem_Type (Type.make (loc $sloc) type_kind type_name type_variants_with_attributes type_attributes) }
+    | ~=type_kind; type_name=checked_identifier; ~=type_parameter; ~=type_attributes; ~=type_variants_with_attributes;
+    {   Elem_Type (Type.make
+            (loc $sloc)
+            ~type_kind
+            ~name:type_name
+            ~param_opt:type_parameter
+            ~variants:type_variants_with_attributes
+            ~attribute_pairs:type_attributes) }
     | type_kind; type_name=IDENTIFIER; type_attributes; list1(type_variant_with_attributes);
     {   let msg = Format.sprintf "Definition of 'typedef %s' is missing '='" type_name in
         raise (SpecError { loc = (loc $sloc); msg }) }
+
+let type_parameter ==
+    | LLBRACKET; param=IDENTIFIER; RRBRACKET; { Some param }
+    | { None }
 
 let relation_definition :=
     ~=relation_category; ~=relation_property; name=checked_identifier; input=plist0(opt_named_type_term); ARROW; output=type_variants;
@@ -357,6 +369,7 @@ let type_term_with_attributes := ~=type_term; ~=type_attributes;
 let type_term :=
     | name=checked_identifier; { Term.make_label (loc $sloc) name }
     | op=type_operator; LPAR; ~=opt_named_type_term; RPAR; { Term.make_type_operation (loc $sloc) op opt_named_type_term }
+    | typename=IDENTIFIER; LLBRACKET; ~=opt_named_type_term; RRBRACKET; { Term.make_param_type (loc $sloc) typename opt_named_type_term }
     | LPAR; args=tclist1(opt_named_type_term); RPAR; { Term.make_tuple (loc $sloc) args }
     | label=checked_identifier; LPAR; args=tclist1(opt_named_type_term); RPAR;
     {   Term.make_labelled_tuple (loc $sloc) label args }

--- a/asllib/aslspec/error.ml
+++ b/asllib/aslspec/error.ml
@@ -80,6 +80,18 @@ let non_constant_used_as_constant_set context_term id =
   @@ Format.asprintf
        "%s is used as a constant even though it is not defined as one" id
 
+let type_not_parameterized context_term id =
+  spec_error_loc_of_term context_term
+  @@ Format.asprintf "Type %s is not a parameterized type, but is used as one"
+       id
+
+let expected_type_name context_term id =
+  spec_error_loc_of_term context_term
+  @@ Format.asprintf "Expected a type name, found %s" id
+
+let undefined_type context_term id =
+  spec_error_loc_of_term context_term @@ Format.asprintf "Undefined type %s" id
+
 let tuple_instantiation_length_failure term args label def_components =
   spec_error_loc_of_term term
   @@ Format.asprintf
@@ -246,6 +258,13 @@ let type_operator_instantiation_failure ~relation_name formal_type arg_type =
   @@ Format.asprintf
        "The type term `%a` cannot be instantiated with `%a` for operator `%s` \
         since there are incompatible argument types for it"
+       PP.pp_type_term formal_type PP.pp_type_term arg_type relation_name
+
+let param_type_instantiation_failure ~relation_name formal_type arg_type =
+  spec_error_loc_of_term arg_type
+  @@ Format.asprintf
+       "The type term `%a` cannot be instantiated with `%a` in relation `%s` \
+        since the parameterized types do not match"
        PP.pp_type_term formal_type PP.pp_type_term arg_type relation_name
 
 let uninstantiated_parameter_in_relation param relation_name ~context_expr =

--- a/asllib/aslspec/render.ml
+++ b/asllib/aslspec/render.ml
@@ -82,6 +82,12 @@ module Make (S : SPEC_VALUE) = struct
     in
     pp_one_arg_macro (operator_to_macro_name op) pp_arg fmt arg
 
+  (** [pp_parameterized_type fmt typename pp_arg arg] renders the application of
+      the parameterized type [typename] to [arg] with [fmt]. *)
+  let pp_parameterized_type fmt typename pp_arg arg =
+    let type_name_macro = get_or_gen_math_macro typename in
+    fprintf fmt "%s{%a}" type_name_macro pp_arg arg
+
   let pp_field_name fmt field_name = pp_id_as_macro fmt field_name
 
   (** [pp_type_term fmt (type_term, layout)] renders [type_term] with [fmt],
@@ -96,8 +102,11 @@ module Make (S : SPEC_VALUE) = struct
             pp_overtext fmt pp_id_as_macro label pp_print_string
               short_circuit_macro
         | None -> pp_id_as_macro fmt label)
+    | Parameter { name } -> pp_var fmt name
     | TypeOperator { op; term = sub_term } ->
         pp_type_operator fmt op pp_opt_named_type_term (sub_term, layout)
+    | ParamType { typename; term } ->
+        pp_parameterized_type fmt typename pp_opt_named_type_term (term, layout)
     | Tuple { label_opt = None; args = [ type_term ] } ->
         (* Singleton unlabelled tuples are a special case -
            they are used to reference type terms, rather than defining them. *)
@@ -209,14 +218,30 @@ module Make (S : SPEC_VALUE) = struct
     in
     pp_type_term fmt (term, layout)
 
+  (** [get_type_parameter_name_opt type_name] returns the name of the type
+      parameter for the type [type_name], if it has one. *)
+  let get_type_parameter_name_opt type_name =
+    match Spec.defining_node_for_id S.spec type_name with
+    | Node_Type { Type.param_opt = Some param } -> Some param
+    | _ -> None
+
+  (** [pp_type fmt type_name] renders the type name [type_name] in the context
+      of rendering a type definition, with special handling for types with
+      parameters, using the formatter [fmt]. *)
+  let pp_type fmt type_name =
+    match get_type_parameter_name_opt type_name with
+    | Some param ->
+        (* Special handling for types with parameters. *)
+        pp_parameterized_type fmt type_name pp_var param
+    | None -> pp_id_as_macro fmt type_name
+
   (** [pp_typename_with_hypertarget fmt type_name] renders the type name
       [type_name] along with its hypertarget. *)
   let pp_typename_with_hypertarget fmt type_name =
     let hyperlink_target = hypertarget_for_id type_name in
     (* The hypertarget macro must come after the type name macro.
        Otherwise LaTeX compilation fails. *)
-    fprintf fmt "%a%a" pp_id_as_macro type_name pp_mathhypertarget
-      hyperlink_target
+    fprintf fmt "%a%a" pp_type type_name pp_mathhypertarget hyperlink_target
 
   (** [pp_variant_with_hypertarget fmt variant] renders the variant [variant]
       along with its hypertarget. *)
@@ -292,7 +317,7 @@ module Make (S : SPEC_VALUE) = struct
       variants) [basic_type] with the formatter [fmt]. *)
   let pp_basic_type fmt { Type.name } =
     let hyperlink_target = hypertarget_for_id name in
-    fprintf fmt "%a$%a$" pp_texthypertarget hyperlink_target pp_id_as_macro name
+    fprintf fmt "%a$%a$" pp_texthypertarget hyperlink_target pp_type name
 
   (** [pp_type_definition fmt def] renders the type definition [def] with the
       formatter [fmt]. *)
@@ -1210,9 +1235,16 @@ module Make (S : SPEC_VALUE) = struct
     if Option.is_some (Spec.math_macro_opt_for_node node) then ()
     else
       let typeset_macro = Latex.spec_var_to_latex_var ~font_type id in
-      fprintf fmt
-        {|\newcommand%a[0]{ \hyperlink{%s}{%s} } %% Generated from %s|}
-        pp_id_as_macro id hyperlink_target typeset_macro id
+      match get_type_parameter_name_opt id with
+      | Some _ ->
+          (* Types with parameters require unary macros. *)
+          fprintf fmt
+            {|\newcommand%a[1]{ \hyperlink{%s}{%s}(#1) } %% Generated from %s|}
+            pp_id_as_macro id hyperlink_target typeset_macro id
+      | None ->
+          fprintf fmt
+            {|\newcommand%a[0]{ \hyperlink{%s}{%s} } %% Generated from %s|}
+            pp_id_as_macro id hyperlink_target typeset_macro id
 
   (** [generate_latex_macros fmt] generates LaTeX macros for all of the elements
       defined in [S.spec] using the formatter [fmt]. *)

--- a/asllib/aslspec/spec.ml
+++ b/asllib/aslspec/spec.ml
@@ -138,8 +138,9 @@ module Layout = struct
   let rec for_type_term term =
     let open Term in
     match term with
-    | Label _ -> Unspecified
-    | TypeOperator { term = _, t } -> for_type_term t
+    | Label _ | Parameter _ -> Unspecified
+    | TypeOperator { term = _, t } | ParamType { term = _, t } ->
+        for_type_term t
     | Tuple { args = [] | _ :: [] } -> Unspecified
     | Tuple { args } ->
         Horizontal (List.map (fun (_, t) -> for_type_term t) args)
@@ -186,6 +187,7 @@ let list_definition_nodes ast =
             List.fold_right
               (fun ({ TypeVariant.term } as variant) acc_nodes ->
                 match term with
+                | Parameter _ -> acc_nodes
                 | Label _ | Tuple { label_opt = Some _ } ->
                     Node_TypeVariant variant :: acc_nodes
                 | Record { label_opt; fields } ->
@@ -198,7 +200,7 @@ let list_definition_nodes ast =
                     in
                     variant_if_labelled @ field_nodes @ acc_nodes
                 | Tuple { label_opt = None }
-                | Function _ | ConstantsSet _ | TypeOperator _ ->
+                | Function _ | ConstantsSet _ | TypeOperator _ | ParamType _ ->
                     acc_nodes)
               variants acc_nodes
           in
@@ -359,7 +361,10 @@ let symbol_table_for_id id_to_defining_node id =
   | Some (Node_Relation { Relation.parameters; loc }) ->
       List.fold_left
         (fun curr_table param ->
-          let type_for_param = Type.make loc TypeKind_Generic param [] [] in
+          let type_for_param =
+            Type.make loc ~type_kind:TypeKind_Generic ~name:param
+              ~param_opt:None ~variants:[] ~attribute_pairs:[]
+          in
           StringMap.add param (Node_Type type_for_param) curr_table)
         id_to_defining_node parameters
   | _ -> id_to_defining_node
@@ -593,8 +598,9 @@ module ResolveRules = struct
           let args = List.map arg_of args in
           Expr.make_opt_labelled_tuple (Term.loc_of term) label_opt args
       | ( None,
-          ( Term.Label _ | Term.Record _ | Term.TypeOperator _ | Term.Function _
-          | Term.ConstantsSet _ ) ) ->
+          Term.(
+            ( Label _ | Parameter _ | Record _ | TypeOperator _ | ParamType _
+            | Function _ | ConstantsSet _ )) ) ->
           Format.kasprintf failwith "Unexpected un-named argument term: %a"
             PP.pp_type_term (snd opt_named_term)
     in
@@ -806,9 +812,11 @@ module Check = struct
     let open Layout in
     let open Term in
     match (term, layout) with
-    | Label _, Unspecified -> ()
-    | Label _, _ -> Error.bad_layout term layout ~consistent_layout
+    | (Label _ | Parameter _), Unspecified -> ()
+    | (Label _ | Parameter _), _ ->
+        Error.bad_layout term layout ~consistent_layout
     | TypeOperator { term = _, t }, _ -> check_layout t layout
+    | ParamType { term = _, t }, _ -> check_layout t layout
     | Tuple { args }, Horizontal cells | Tuple { args }, Vertical cells ->
         if List.compare_lengths args cells <> 0 then
           Error.bad_layout term layout ~consistent_layout
@@ -861,7 +869,10 @@ module Check = struct
     let open Term in
     function
     | Label { label } -> [ label ]
+    | Parameter _ -> []
+    (* A parameter is a variable, not a defined top-level entity. *)
     | TypeOperator { term = _, t } -> referenced_ids t
+    | ParamType { typename; term = _, t } -> typename :: referenced_ids t
     | Tuple { label_opt; args } -> (
         let component_ids =
           List.map snd args |> List.concat_map referenced_ids
@@ -915,7 +926,9 @@ module Check = struct
             Error.undefined_reference missing_location id elem_name)
         ids_referenced_by_elem
     in
-    List.iter (check_no_undefined_ids_in_elem id_to_defining_node) ast
+    List.iter
+      (fun elem -> check_no_undefined_ids_in_elem id_to_defining_node elem)
+      ast
 
   (** [check_relation_outputs elems id_to_defining_node] checks that, for each
       relation in [elems], the first output type term is arbitrary, and that all
@@ -1172,8 +1185,9 @@ module Check = struct
 
     (** [type_term_depth term] computes the depth of [term]. *)
     let rec type_term_depth = function
-      | Label _ | ConstantsSet _ -> 1
-      | TypeOperator { term = _, term; _ } -> 1 + type_term_depth term
+      | Label _ | Parameter _ | ConstantsSet _ -> 1
+      | TypeOperator { term = _, term; _ } | ParamType { term = _, term; _ } ->
+          1 + type_term_depth term
       | Tuple { args; _ } -> 1 + opt_named_type_terms_depth args
       | Record { fields; _ } ->
           1 + list_depth (fun { Term.term; _ } -> type_term_depth term) fields
@@ -1281,6 +1295,13 @@ module Check = struct
             operator_subsumed sub_op super_op
             && subsumed_rec spec expansion_limit expanded_types sub_term
                  super_term
+        | ( ParamType { typename = sub_typename; term = _, sub_term },
+            ParamType { typename = super_typename; term = _, super_term } ) ->
+            String.equal sub_typename super_typename
+            && subsumed_rec spec expansion_limit expanded_types sub_term
+                 super_term
+        | Parameter { name = sub_name }, Parameter { name = super_name } ->
+            String.equal sub_name super_name
         | ( Tuple { label_opt = sub_label_opt; args = sub_components },
             Tuple { label_opt = super_label_opt; args = super_components } ) ->
             Option.equal String.equal sub_label_opt super_label_opt
@@ -1408,6 +1429,15 @@ module Check = struct
       match term with
       | TypeOperator { term = _, operator_term } ->
           check_well_instantiated spec operator_term
+      | ParamType { typename; term = _, sub_term } -> (
+          let () = check_well_instantiated spec sub_term in
+          let type_def = StringMap.find_opt typename spec.id_to_defining_node in
+          match type_def with
+          | Some (Node_Type { Type.param_opt = Some _ }) -> ()
+          | Some (Node_Type { Type.param_opt = None }) ->
+              Error.type_not_parameterized term typename
+          | Some _ -> Error.expected_type_name term typename
+          | None -> Error.undefined_type term typename)
       | Tuple { label_opt; args } -> (
           let terms = List.map snd args in
           let () = List.iter (check_well_instantiated spec) terms in
@@ -1439,7 +1469,7 @@ module Check = struct
       | Function { from_type = _, from_term; to_type = _, to_term } ->
           check_well_instantiated spec from_term;
           check_well_instantiated spec to_term
-      | ConstantsSet _ | Label _ -> ()
+      | ConstantsSet _ | Label _ | Parameter _ -> ()
 
     (** [check_well_formed id_to_defining_node term] checks that [term] is
         well-formed with respect to the type definitions in the range of
@@ -1452,7 +1482,8 @@ module Check = struct
           structural induction on [term]. *)
     let rec check_well_formed id_to_defining_node term =
       match term with
-      | TypeOperator { term = _, sub_term } ->
+      | TypeOperator { term = _, sub_term } | ParamType { term = _, sub_term }
+        ->
           check_well_formed id_to_defining_node sub_term
       | Tuple { label_opt; args } -> (
           let terms = List.map snd args in
@@ -1503,6 +1534,7 @@ module Check = struct
           match variant_def with
           | Node_Type _ | Node_TypeVariant { TypeVariant.term = Label _ } -> ()
           | _ -> Error.instantiation_failure_not_a_type term label)
+      | Parameter _ -> ()
 
     let check_well_typed spec term =
       check_well_formed spec.id_to_defining_node term;
@@ -2101,6 +2133,15 @@ module Check = struct
             in
             infer_parameter_type spec ~relation_name parameters
               formal_inner_term arg_inner_term type_env
+        | ( ParamType { typename = formal_typename; term = _, formal_inner_term },
+            ParamType { typename = arg_typename; term = _, arg_inner_term } ) ->
+            let () =
+              if not (String.equal formal_typename arg_typename) then
+                Error.param_type_instantiation_failure ~relation_name
+                  formal_type arg_type
+            in
+            infer_parameter_type spec ~relation_name parameters
+              formal_inner_term arg_inner_term type_env
         | _ -> type_env
 
       (** [substitute_type_parameters term parameter_env] substitutes type
@@ -2109,8 +2150,8 @@ module Check = struct
       let rec substitute_type_parameters term parameter_env =
         let open Term in
         match term with
-        | Label { label } -> (
-            match StringMap.find_opt label parameter_env with
+        | Label { label = name } | Parameter { name } -> (
+            match StringMap.find_opt name parameter_env with
             | Some substituted_type -> substituted_type
             | None -> term)
         | Tuple ({ args } as node) ->
@@ -2153,6 +2194,11 @@ module Check = struct
             in
             TypeOperator
               { node with term = (term_name, substituted_inner_term) }
+        | ParamType ({ term = term_name, inner_term } as node) ->
+            let substituted_inner_term =
+              substitute_type_parameters inner_term parameter_env
+            in
+            ParamType { node with term = (term_name, substituted_inner_term) }
         | ConstantsSet _ -> term
 
       (** [make_operator_formals_for_actual_num_of_args spec operator_name
@@ -2901,8 +2947,8 @@ module Check = struct
           List.fold_left
             (fun curr_env arg -> update_env_for_term curr_env arg)
             type_env args
-      | Term.Label _ | Term.TypeOperator _ | Term.Record _ | Term.Function _
-      | Term.ConstantsSet _ ->
+      | Term.Label _ | Term.Parameter _ | Term.TypeOperator _ | Term.ParamType _
+      | Term.Record _ | Term.Function _ | Term.ConstantsSet _ ->
           type_env
 
     (** [generate_type_env_from_relation_args relation] generates a type
@@ -3411,6 +3457,78 @@ module ExtendConstantsWithTypes = struct
     update_spec_ast spec (List.rev ast)
 end
 
+(** A module for resolving type-parameter references inside type definitions.
+
+    Within a parameterized type definition, a term [Label param] denotes the
+    type parameter rather than a label/type with the same name. This pass makes
+    that distinction explicit by rewriting those occurrences to
+    [Parameter param]. *)
+module SubstituteTypeParameters : sig
+  val resolve : AST.t -> AST.t
+end = struct
+  let rec resolve_type_term param term =
+    let open Term in
+    match term with
+    | Label { loc; label } when String.equal label param ->
+        Parameter { loc; name = label }
+    | Label _ | Parameter _ | ConstantsSet _ -> term
+    | TypeOperator ({ term = name_opt, sub_term } as type_op) ->
+        TypeOperator
+          { type_op with term = (name_opt, resolve_type_term param sub_term) }
+    | ParamType ({ term = name_opt, sub_term } as param_type) ->
+        ParamType
+          {
+            param_type with
+            term = (name_opt, resolve_type_term param sub_term);
+          }
+    | Tuple ({ args } as tuple) ->
+        Tuple
+          {
+            tuple with
+            args =
+              List.map
+                (fun (name_opt, arg) -> (name_opt, resolve_type_term param arg))
+                args;
+          }
+    | Record ({ fields } as record_type) ->
+        Record
+          {
+            record_type with
+            fields =
+              List.map
+                (fun ({ Term.term = field_term; _ } as field) ->
+                  { field with term = resolve_type_term param field_term })
+                fields;
+          }
+    | Function
+        ({
+           from_type = from_name_opt, from_term;
+           to_type = to_name_opt, to_term;
+         } as function_type) ->
+        Function
+          {
+            function_type with
+            from_type = (from_name_opt, resolve_type_term param from_term);
+            to_type = (to_name_opt, resolve_type_term param to_term);
+          }
+
+  let resolve_variant param ({ TypeVariant.term } as variant) =
+    { variant with term = resolve_type_term param term }
+
+  let resolve_type ({ Type.param_opt; variants } as type_def) =
+    match param_opt with
+    | None -> type_def
+    | Some param ->
+        let variants = List.map (resolve_variant param) variants in
+        { type_def with variants }
+
+  let resolve ast =
+    List.map
+      (function
+        | Elem_Type type_def -> Elem_Type (resolve_type type_def) | elem -> elem)
+      ast
+end
+
 (** [add_default_rule_renders ast] adds default render rules for relations that
     have rules but do not have any rule render associated with them. That is,
     for a relation
@@ -3508,6 +3626,7 @@ let prepend_ast_with_builtins ast id_to_defining_node =
     Parsing.parse_spec_from_string ~spec:Builtins.builtin_spec_str
       ~filename:"builtins.ml"
   in
+  let builtin_ast = SubstituteTypeParameters.resolve builtin_ast in
   List.fold_right
     (fun elem acc_elems ->
       let elem_name = ASTUtils.elem_name elem in
@@ -3518,6 +3637,8 @@ let prepend_ast_with_builtins ast id_to_defining_node =
 (** [make_spec_with_builtins ast] constructs a specification containing the
     builtin definitions. *)
 let make_spec_with_builtins ast =
+  let ast = SubstituteTypeParameters.resolve ast in
+
   let id_to_defining_node = make_symbol_table ast in
   let ast = prepend_ast_with_builtins ast id_to_defining_node in
   let id_to_defining_node = make_symbol_table ast in

--- a/asllib/aslspec/tests.t/parameterized_type_instantiation.bad
+++ b/asllib/aslspec/tests.t/parameterized_type_instantiation.bad
@@ -1,0 +1,13 @@
+typedef Int;
+
+typedef Tree[[T]] =
+  | Leaf(value: T)
+;
+
+typing relation make_leaf(x: Int) -> (Tree[[Int]])
+{
+  prose_transition = ""
+} =
+  --
+  Leaf(x);
+;

--- a/asllib/aslspec/tests.t/parameterized_types.spec
+++ b/asllib/aslspec/tests.t/parameterized_types.spec
@@ -1,0 +1,4 @@
+typedef Tree[[T]] =
+    | Leaf(value: T)
+    | Node(left: Tree[[T]], right: Tree[[T]])
+;

--- a/asllib/aslspec/tests.t/run.t
+++ b/asllib/aslspec/tests.t/run.t
@@ -47,7 +47,11 @@
   $ aslspec instantiation_recursion.bad
   Specification Error: instantiation_recursion.bad:9:11: Unable to determine that `B` is subsumed by `A`
   [1]
+  $ aslspec parameterized_type_instantiation.bad
+  Specification Error: parameterized_type_instantiation.bad:12:3: Unable to determine that `Leaf(Int)` is subsumed by `Leaf(value: T)`
+  [1]
   $ aslspec relation_unnamed_arguments.bad
   Specification Error: relation_unnamed_arguments.bad:6:38: The term Num in relation unnamed_arg_has_rule does not provide a name for at least one of its sub-terms.
   [1]
   $ aslspec constants.spec
+  $ aslspec parameterized_types.spec

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -2414,7 +2414,7 @@ typing relation annotate_expr(tenv: static_envs, e: expr) -> (t: ty, new_e: expr
       width_plus(tenv, e_width) -> e_slice_width;
       --
       (T_Bits(e_slice_width, empty_list), E_GetCollectionFields(base_collection_name, fields), ses_base)
-      { math_layout = [_, [_]] };
+      { math_layout = [_, [_] ] };
     }
     case error {
       make_anonymous(tenv, t_base_annot) -> t_base_annot_anon;
@@ -2871,7 +2871,7 @@ semantics relation eval_expr(env: envs, e: expr) ->
     e =: E_GetFields(e_record, field_names);
     eval_expr(env, e_record) -> ResultExpr((v_record, g), new_env);
     ( INDEX(i, field_names: get_field(field_names[i], v_record) -> NV_Literal(L_Bitvector(field_bits[i]))) )
-    { ([_,[_]]) };
+    { ([_,[_] ]) };
     field_bitvectors := list_map(bits, field_bits, nvbitvector(bits));
     concat_bitvectors(field_bitvectors) -> v;
     --
@@ -2944,7 +2944,7 @@ semantics relation eval_expr(env: envs, e: expr) ->
     denv.dynamic_envs_G.storage(base) =: record;
     record =: NV_Record(field_map);
     ( INDEX(i, field_names: get_field(field_names[i], record) -> NV_Literal(L_Bitvector(bits[i]))) )
-    { ([_, [_]]) };
+    { ([_, [_] ]) };
     vs := list_map(b, bits, nvbitvector(b));
     concat_bitvectors(vs) -> v;
     field_ids := list_map(f, field_names, concat(base, dot_str, f));
@@ -3320,7 +3320,7 @@ typing relation annotate_lexpr(tenv: static_envs, le: lexpr, t_e: ty) ->
      check_type_satisfies(tenv, t_e, t_lhs) -> True;
      --
      (LE_SetCollectionFields(base_name, le_fields, slices), ses_base)
-     { math_layout = [_, [_]] };
+     { math_layout = [_, [_] ] };
    }
 
    case error {
@@ -3572,7 +3572,7 @@ typing relation annotate_set_array(
   and the index expression {e_index}.
   The result is the annotated \assignableexpression{} {new_le} and \sideeffectsetterm{} for the annotated expression {ses}. \ProseOtherwiseTypeError",
   prose_transition = "annotating the array update with {size}, {t_elem}, {rhs_ty}, {e_base}, {ses_base}, and {e_index} in {tenv} yields",
-  math_layout = [[_,_,_,_],_],
+  math_layout = [ [_,_,_,_],_],
 } =
   check_type_satisfies(tenv, rhs_ty, t_elem) -> True;
   annotate_expr(tenv, e_index) -> (t_index', e_index', ses_index);
@@ -3614,7 +3614,7 @@ semantics function check_non_overlapping_slices(value_ranges: list0((native_valu
   case non_empty {
     value_ranges =: match_cons(head_range, tail_ranges);
     ( INDEX(i, tail_ranges: check_two_ranges_non_overlapping(head_range, tail_ranges[i]) -> True) )
-    { ([_, [_]]) };
+    { ([_, [_] ]) };
     check_non_overlapping_slices(tail_ranges) -> True;
     --
     True;
@@ -4533,12 +4533,12 @@ typing relation declare_global_storage(genv: global_static_envs, gsd: global_dec
   with_empty_local(genv) -> tenv;
   must_be_pure := keyword in make_set(GDK_Config, GDK_Constant);
   annotate_ty_opt_initial_value(tenv, keyword, must_be_pure, ty_opt, initial_value) -> (typed_initial_value, ty_opt', declared_t)
-  { [[_], [_]] };
+  { [ [_], [_] ] };
   add_global_storage(genv, name, keyword, declared_t) -> genv1;
   with_empty_local(genv1) -> tenv1;
   typed_initial_value =: (initial_value', t_init, ses_initial_value);
   update_global_storage(tenv1, name, keyword, (t_init, initial_value', ses_initial_value)) -> tenv2
-  { [[_], _] };
+  { [ [_], _] };
   new_gsd := [keyword: keyword, global_decl_name: name, global_decl_ty: ty_opt', initial_value: some(initial_value')];
   new_genv := tenv2.static_envs_G;
   --
@@ -4605,7 +4605,7 @@ typing relation annotate_ty_opt_initial_value(
     typed_initial_value := (e', t', empty_set);
     --
     (typed_initial_value, some(t'), t')
-    { [[_], [_]] };
+    { [ [_], [_] ] };
   }
 
   case none_some {
@@ -4770,7 +4770,7 @@ typing relation annotate_local_decl_item(
   prose_transition = "annotating {ldi} and {ldk}
   with {ty} and {e_opt}
   in {tenv} yields",
-  math_layout = [[_,_,_,_,_], _],
+  math_layout = [ [_,_,_,_,_], _],
 } =
   case var {
     ldi =: LDI_Var(x);
@@ -6023,7 +6023,7 @@ typing function subtype_satisfies(tenv: static_envs, t: ty, s: ty) -> (b: Bool) 
     make_anonymous(tenv, t) -> T_Tuple(li_t);
     bool_transition(same_length(li_s, li_t)) -> True | False;
     ( INDEX(i, li_s: type_satisfies(tenv, li_t[i], li_s[i]) -> component_type_satisfies[i]) )
-    { ([_, [_]]) };
+    { ([_, [_] ]) };
     --
     list_and(component_type_satisfies);
   }
@@ -6044,7 +6044,7 @@ typing function subtype_satisfies(tenv: static_envs, t: ty, s: ty) -> (b: Bool) 
     INDEX(i, names_s: field_type(fields_t, names_s[i]) -> some(field_types_t[i]))
     { [_] };
     ( INDEX(i, field_types_s: type_equal(tenv, field_types_s[i], field_types_t[i]) -> field_tys_equal[i]) )
-    { ([_, [_]]) };
+    { ([_, [_] ]) };
     --
     list_and(field_tys_equal);
   }
@@ -6584,7 +6584,7 @@ typing relation annotate_constraint_binop(
   context of approximating lists of constraints).
   \ProseOtherwiseTypeError",
   prose_transition = "annotating the application of {op} to {cs1} and {cs2} in {tenv} with approximation mode {approx} yields",
-  math_layout = [[_,_,_,_,_],_],
+  math_layout = [ [_,_,_,_,_],_],
 } =
   case exploding {
     binop_filter_rhs(approx, tenv, op, cs2) -> cs2f;
@@ -6781,7 +6781,7 @@ typing relation filter_reduce_constraint_div(c: int_constraint) ->
       binary_and((z1_opt = none), (z2_opt =: some(z6e)))        : some(AbbrevConstraintRange(e1, ELint(z6e))),
       binary_and((z1_opt = none), (z2_opt = none))              : some(c)
     )
-    { (_, [c1[_, [_]], c2[_, [_]], c3[_, [_]],_]) };
+    { (_, [c1[_, [_] ], c2[_, [_] ], c3[_, [_] ],_]) };
     --
     c_opt;
   }
@@ -8087,13 +8087,13 @@ typing relation type_check_mutually_rec(genv: global_static_envs, decls: list0(d
   env_and_fs2 =: list_combine_three(lenvs2, fs2, ses_fs2);
   ( INDEX(i, fs2:
       annotate_subprogram(
-        [static_envs_G: genv2, static_envs_L: lenvs2[i]],
+        [static_envs_G: genv2, static_envs_L: lenvs2[i] ],
         fs2[i],
         ses_fs2[i]
       ) -> (new_fs[i], ses'[i])
     )
   )
-  { ( [_, [_]] ) };
+  { ( [_, [_] ] ) };
   new_decls := list_map(i, indices(new_fs), D_Func(new_fs[i]));
   sess := list_combine(new_fs, ses');
   with_empty_local(genv2) -> tenv2;
@@ -11204,14 +11204,14 @@ typing relation annotate_func_sig(genv: global_static_envs, func_sig: func) ->
     func_sig.args,
     (tenv_with_params, empty_list, ses_with_params)
   ) -> (tenv_with_args, args, ses_with_args)
-  { [[_], _] };
+  { [ [_], _] };
   annotate_return_type(
     tenv_with_args,
     tenv_with_params,
     func_sig.return_type,
     ses_with_args
   ) -> (new_tenv, return_type, ses_with_return)
-  { [[_], _]};
+  { [ [_], _]};
   ses_list := list_set(ses_with_return);
   ses_list_no_locals := list_filter(se, ses_list, not(se = LocalEffect(_)));
   ses' := list_to_set(ses_list_no_locals);
@@ -13800,7 +13800,7 @@ typing function approx_constraint_binop(tenv: static_envs, approx: constants_set
     {s2} with
     the \approximationdirectionterm{} given by {approx}
     in the context of {tenv} yields",
-  math_layout = [[_,_,_,_,_],_],
+  math_layout = [ [_,_,_,_,_],_],
 } =
   case over {
     approx = Over;
@@ -15079,7 +15079,7 @@ typing function add_immutable_expression(
     the initialization given by {e_opt},
     and {x} for the local storage element yields",
   math_macro = \addimmutableexpression,
-  math_layout = [[_,_,_,_],_],
+  math_layout = [ [_,_,_,_],_],
 } =
   case remember {
     ldk = LDK_Let;


### PR DESCRIPTION
Extended aslspec types to allow specifying a single optional parameter.
For example
```
ast clistone[[x]] { "a non-empty comma-separated list" } =
  | x
  | (x, Tok_comma, clistone[[x]])
;
```
This is needed to support generic types needed to represent parse trees, for example, comma-separated lists of an arbitrary type.

I acknowledge that the syntax is a bit weird and requires math layout to space out brackets to avoid clashing.
Also, the type system has not been fully adapted so some legal specifications might be rejected, like the one added to this PR. This is postponed to a later PR.