### PR TITLE
AARCH-25405: Add href to Effective value

### DIFF
--- a/herd/libdir/catdefinitions.tex
+++ b/herd/libdir/catdefinitions.tex
@@ -3,10 +3,12 @@
 \newcommand{\NotETSTwo}{\notthecase{\ETSTwo{}}}
 \newcommand{\ETSThree}{FEAT_ETS3 is implemented}
 \newcommand{\NotETSThree}{\notthecase{\ETSThree{}}}
-\newcommand{\DIC}{The Effective value of DIC is 1}
-\newcommand{\NotDIC}{The Effective value of DIC is 0}
-\newcommand{\IDC}{The Effective value of IDC is 1}
-\newcommand{\NotIDC}{The Effective value of IDC is 0}
+\newcommand{\EffectiveValue}{\href{#Effective_value}{Effective value}}
+\newcommand{\CTRELZero}{\href{#reg:AArch64-ctr_el0}{CTR_EL0}}
+\newcommand{\DIC}{The \EffectiveValue{} of \CTRELZero{}.DIC is 1}
+\newcommand{\NotDIC}{The \EffectiveValue{} of \CTRELZero{}.DIC is 0}
+\newcommand{\IDC}{The \EffectiveValue{} of \CTRELZero{}.IDC is 1}
+\newcommand{\NotIDC}{The \EffectiveValue{} of \CTRELZero{}.IDC is 0}
 \newcommand{\flag}[1]{By construction, #1}
 \newcommand{\assert}[1]{By construction, #1}
 %


### PR DESCRIPTION
Builds on top of [this PR](https://github.com/herd/herdtools7/pull/1788) and adds links to the section in the Arm ARM describing the "Effective Value", and the `CTR_EL0` register, which contains the `DIC` and `IDC` bits. This is for better clarity and accessibility when navigating the Arm ARM.