### PR TITLE
[gen] add `@before` and `@after` predicates for relaxations in `diy7`

### DIFF
--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -26,9 +26,9 @@ module type AltConfig = sig
   val max_relax : int
   val min_relax : int
   val choice : check
-  type relax
-  val prefix : relax list list
+  val prefix : string list
   val variant : Variant_gen.t -> bool
+  val varatom : string list
   type fence
   val cumul : fence list Config.cumul
   val wildcard : bool
@@ -270,10 +270,20 @@ struct
 end
 
 module Make(C:Builder.S)
-    (O:AltConfig with type relax = C.R.relax and type fence = C.A.fence) :
+    (O:AltConfig with type fence = C.A.fence) :
     sig
-      val gen : ?relax:C.R.relax list -> ?safe:C.R.relax list -> ?reject:C.R.relax list -> int -> unit
-      val filter_check: relax:C.R.relax list -> safe:C.R.relax list -> C.E.edge list -> C.E.edge list -> bool
+      type predicate_relax
+
+      val plain : predicate_relax -> C.R.relax
+      val lift : C.R.relax -> predicate_relax
+      val gen : ?relax:predicate_relax list -> ?safe:predicate_relax list -> ?reject:predicate_relax list -> int -> unit
+      val parse_argument : string -> predicate_relax list
+      val parse_input :
+        relax:string list -> safe:string list ->
+        reject:string list -> predicate_relax list * predicate_relax list * predicate_relax list
+      val remove_invalid_relaxes : predicate_relax list -> predicate_relax list
+      val pp_predicate_relax_list : predicate_relax list -> string
+      val filter_check: safe:predicate_relax list -> predicate_relax -> predicate_relax -> bool
     end
 
     =
@@ -284,6 +294,27 @@ module Make(C:Builder.S)
     open C.E
     open C.R
 
+    type edge_predicate =
+      | Before
+      | After
+
+    type predicate_edge = {
+      plain : C.E.edge;
+      pred : edge_predicate option;
+    }
+
+    type predicate_relax = predicate_edge list
+
+    let parse_predicate = function
+      | "before" -> Before
+      | "after" -> After
+      | s -> Warn.user_error "predicate %s is not supported." s
+
+    let predicate_edge plain = { plain; pred = None }
+
+    let plain relax = List.map (fun e -> e.plain) relax
+    let with_plain relax = plain relax, relax
+
     let dbg = false
 
     let is_int e = match get_ie e with
@@ -293,25 +324,140 @@ module Make(C:Builder.S)
 
     let can_precede safes po_safe (_,xs) k = match k with
     | [] -> true
+    | (_,ys)::_ ->
+        FilterImpl.can_precede safes po_safe (plain xs) (plain ys)
+
+    let can_precede_plain safes po_safe (_,xs) k = match k with
+    | [] -> true
     | (_,ys)::_ -> FilterImpl.can_precede safes po_safe xs ys
 
     (* List.is_empty only supports for ocaml 5.1 afterwards *)
     let is_empty_list l = (l = [])
+
+    let parse_argument_ast input =
+      String.trim input |> C.R.parse_ast Parser.diy7
+
+    let varatom_ess =
+      if C.A.bellatom then Misc.identity
+      else match O.varatom with
+      | [] -> Misc.identity
+      | ["all"] ->
+          let module Fold = struct
+            type atom = C.E.atom
+            let fold = C.E.fold_atomo
+          end in
+          let module V = VarAtomic.Make(C.E)(Fold) in
+          V.varatom_es
+      | atoms ->
+          let atoms = C.E.parse_atoms atoms in
+          let module Fold = struct
+            type atom = C.E.atom
+            let fold f k = C.E.fold_atomo_list atoms f k
+          end in
+          let module V = VarAtomic.Make(C.E)(Fold) in
+          V.varatom_es
+
+    let reattach_predicates template edges =
+      try
+        List.map2 (fun predicate_edge edge -> { predicate_edge with plain = edge }) template edges
+      with Invalid_argument _ ->
+        Warn.fatal "predicate expansion changed relaxation length"
+
+    let varatom_predicate_ess predicate_relaxes =
+      List.concat_map
+        (fun predicate_relax ->
+          let edges = plain predicate_relax in
+          varatom_ess [edges]
+          |> List.map (reattach_predicates predicate_relax))
+        predicate_relaxes
+
+    let compare_predicate lhs rhs = match lhs,rhs with
+    | Before,Before
+    | After,After -> 0
+    | Before,After -> -1
+    | After,Before -> 1
+
+    let compare_predicate_opt = Option.compare compare_predicate
+
+    let compare_predicate_edge lhs rhs =
+      match C.E.compare lhs.plain rhs.plain with
+      | 0 -> compare_predicate_opt lhs.pred rhs.pred
+      | r -> r
+
+    let compare_predicate_relax = List.compare compare_predicate_edge
+
+    module PredicateRelaxSet =
+      MySet.Make
+        (struct
+          type t = predicate_relax
+          let compare = compare_predicate_relax
+        end)
+
+    let remove_invalid_relaxes relaxes =
+      let valid_relaxes =
+        List.map plain relaxes
+        |> C.R.remove_invalid_relaxes
+        |> C.R.Set.of_list in
+      (* Predicate-only edges are only meaningful at relaxation boundaries:
+         `before(...)` predicates must form a leading prefix, and `after(...)`
+         predicates must form a trailing suffix. Once a plain edge appears,
+         no later `before(...)` is valid; once an `after(...)` appears, only
+         more `after(...)` predicates may follow. *)
+      let leading_before_trailing_after_predicate list =
+        let valid,_,_ =
+          List.fold_left
+            (fun (valid, leading_before, trailing_after) edge ->
+              match valid, leading_before, trailing_after, edge.pred with
+              | false, _, _, _ -> false, leading_before, trailing_after
+              | true, true, _, pred ->
+                  true, pred = Some Before, pred = Some After
+              | true, false, trailing_after, Some Before ->
+                  false, false, trailing_after
+              | true, false, false, pred ->
+                  true, false, pred = Some After
+              | true, false, true, pred ->
+                  pred = Some After, false, true)
+            (true,true,false) list in
+        valid in
+      let has_plain_edge =
+        List.exists (fun edge -> edge.pred = None) in
+      List.filter
+        (fun relax ->
+          has_plain_edge relax
+          && C.R.Set.mem (plain relax) valid_relaxes
+          && leading_before_trailing_after_predicate relax)
+        relaxes
+
+    let parse_argument_ast_expanded ast =
+      let add_predicate pred edge =
+        { edge with pred = Some (parse_predicate pred) } in
+      ast
+      |> C.R.parse_expand_relaxs_ast ~ppo:C.ppo
+      |> fun ast -> Ast.bind ast (fun edge -> Ast.One (predicate_edge edge))
+      |> Ast.expand add_predicate
+      |> varatom_predicate_ess
+
+    let parse_argument input_argument =
+      parse_argument_ast input_argument
+      |> parse_argument_ast_expanded
+
+    let parse_arguments input_argument_list =
+      List.map parse_argument input_argument_list
+      |> List.flatten
+      |> remove_invalid_relaxes
+      |> List.sort_uniq compare_predicate_relax
 
     let pp_ess ess =
       let list_sep = " " in
       let list_list_sep = " " in
       ess |> List.map
         ( fun (_,es) ->
-          es |> List.map (fun e -> pp_edge e)
+          es |> plain |> List.map (fun e -> pp_edge e)
              |> String.concat list_list_sep )
         |> String.concat list_sep
 
-    (* Pair each relax with the working edge list used by the generator.
-       The first component preserves the original relax for reporting/filtering;
-       the second component may be modified while building candidate cycles. *)
-    let relaxs_with_work_edges rs =
-      List.map (fun r -> (r, r)) rs
+    let lift r = List.map predicate_edge r
+    let lift_list rs = List.map lift rs
 
     (* Check whether `list` starts with `expected`, using `pred` for element
        comparison. *)
@@ -338,14 +484,14 @@ module Make(C:Builder.S)
       (* Separate the trailing `after` predicate from `next` *)
       let after =
         List.fold_right ( fun e (after,seen_non_after) ->
-          match seen_non_after, C.E.get_predicate e = Some C.E.After with
+          match seen_non_after, e.pred = Some After with
           | true, _ | _, false -> after, true
           | false, true -> e :: after, false ) next ([],false)
         |> fst in
       (* Separate the beginning `before` predicate from `exist` *)
       let before =
         List.fold_left ( fun (before,seen_non_before) e ->
-          match seen_non_before, C.E.get_predicate e = Some C.E.Before with
+          match seen_non_before, e.pred = Some Before with
           | true, _ | _, false -> before, true
           | false, true -> e :: before, false ) ([],false) exist
         |> fst |> List.rev in
@@ -353,17 +499,23 @@ module Make(C:Builder.S)
       match after, before with
       | [], [] -> true
       | after, [] ->
-          starts_with C.E.equal_edge_atoms exist after
+          starts_with
+            (fun (lhs:predicate_edge) (rhs:predicate_edge) ->
+              C.E.equal_edge_atoms lhs.plain rhs.plain)
+            exist after
       | [], before ->
-          ends_with C.E.equal_edge_atoms next before
+          ends_with
+            (fun (lhs:predicate_edge) (rhs:predicate_edge) ->
+              C.E.equal_edge_atoms lhs.plain rhs.plain)
+            next before
       (* Reject an `after` predicate directly meeting a `before` predicate. *)
       | _, _ -> false
 
     let needs_merge next_edges exist_edges =
       match List.rev next_edges, exist_edges with
       | next_last::_, exist_first::_ ->
-          C.E.get_predicate next_last = Some C.E.After ||
-          C.E.get_predicate exist_first = Some C.E.Before
+          next_last.pred = Some After ||
+          exist_first.pred = Some Before
       | _ -> false
 
     (* Check whether `next_edges` may be placed immediately before
@@ -374,11 +526,12 @@ module Make(C:Builder.S)
     let check_precede can_precede next_edges exist_edges =
       if O.verbose > 2 then
         eprintf "next: %s, exists: %s\n"
-          (C.E.pp_edges next_edges) (C.E.pp_edges exist_edges);
+          (C.E.pp_edges (plain next_edges))
+          (C.E.pp_edges (plain exist_edges));
       if needs_merge next_edges exist_edges then
         merge_predicate next_edges exist_edges
       else
-        can_precede next_edges exist_edges
+        can_precede (plain next_edges) (plain exist_edges)
 
     (* Check whether a candidate relaxation `next` can be prepended to the
        current suffix `exist`. The suffix is stored newest-first, so only
@@ -395,11 +548,11 @@ module Make(C:Builder.S)
 (* Functional for recursive call of generators *)
 
     let sz (_,es) =
-      if List.for_all (fun e -> is_id e.edge) es then 0 else 1
+      if List.for_all (fun e -> is_id e.plain.edge) es then 0 else 1
 
     let c_minprocs_es c =
       List.fold_left ( fun c e ->
-        match e.C.E.pred,e.C.E.edge,get_ie e with
+        match e.pred,e.plain.C.E.edge,get_ie e.plain with
         | Some _,_,_
         | None,(Back _|Leave _),_
         | None,_,Int -> c
@@ -418,9 +571,9 @@ module Make(C:Builder.S)
     let rec c_minint_es c = function
       | [] -> false,c
       | {pred=Some _; _}::es
-      | {edge=Id; _}::es ->  c_minint_es c es
+      | {plain={edge=Id; _}; _}::es ->  c_minint_es c es
       | e::es ->
-          match get_ie e with
+          match get_ie e.plain with
           | Ext -> true,c
           | Int -> c_minint_es (c+1) es
           | UnspecCom -> assert false
@@ -435,16 +588,29 @@ module Make(C:Builder.S)
     let minint suff = c_minint 0 suff
 
 (* Prefix *)
+    let parse_prefixes prefix =
+      (* Parse each `-prefix` argument separately, then combine them as one
+         top-level choice. Thus `-prefix A -prefix B` is interpreted as
+         `-prefix [A|B]`. *)
+      let prefixes =
+        List.map parse_argument_ast prefix
+        |> fun prefixes -> Ast.Choice prefixes
+        |> parse_argument_ast_expanded
+        |> List.map (fun predicate_relax -> [plain predicate_relax, predicate_relax]) in
+      match prefixes with
+      | [] -> [[]] (* No prefix <=> one empty prefix *)
+      | prefixes -> prefixes
+
     let () =
       if O.verbose > 0 && O.prefix <> [] then begin
         eprintf "Prefixes:\n" ;
         List.iter
           (fun rs ->
-            eprintf "  %s\n" (C.R.pp_relax_list rs))
-          O.prefix
+            eprintf "  %s\n" (C.R.pp_relax_list (List.map fst rs)))
+          (parse_prefixes O.prefix)
       end
 
-    let prefixes = List.map relaxs_with_work_edges O.prefix
+    let prefixes = parse_prefixes O.prefix
 
     let rec mk_can_prefix = function
       | [] -> (fun _ _ -> true)
@@ -461,7 +627,7 @@ module Make(C:Builder.S)
 
 
     let check_cycle rsuff rl =
-      let rsuff = List.split rsuff |> snd |> List.concat in
+      let rsuff = List.split rsuff |> snd |> List.concat |> plain in
       not (List.exists (fun rl -> is_prefix rsuff rl) rl)
 
 
@@ -488,9 +654,12 @@ module Make(C:Builder.S)
                calling `test_generator`. *)
             let tr =
               List.map ( fun (relax,edges) ->
-                let edges = List.filter ( function
-                  | { pred = Some _; _ } -> false
-                  | _ -> true ) edges in
+                let edges =
+                  List.filter_map
+                    (function
+                      | { pred = Some _; _ } -> None
+                      | { plain; pred = None } -> Some plain)
+                    edges in
                 (relax,edges)
               ) (prefix@suff) in
             if O.verbose > 2 then
@@ -541,8 +710,6 @@ module Make(C:Builder.S)
 
     let zyva prefix aset relax safe reject n f =
 (*      let safes = C.R.Set.of_list safe in *)
-      let relax = relaxs_with_work_edges relax in
-      let safe = relaxs_with_work_edges safe in
       let po_safe = extract_po safe in
 
       (* ********************************** *)
@@ -683,7 +850,7 @@ module Make(C:Builder.S)
     let last_check_call rej aset f rs po_safe res k =
       if is_empty_list res then k else
           let lst = Misc.last res in
-          if can_precede aset po_safe lst res then
+          if can_precede_plain aset po_safe lst res then
             let es = List.map snd res in
             let le = List.flatten es in
             try
@@ -773,42 +940,52 @@ module Make(C:Builder.S)
       List.fold_left ( fun k pref -> zyva pref aset relax safe reject n f k ) k prefixes
 
     let do_gen relax safe rej n =
-      let sset = C.R.Set.of_list safe in
-      let rset = C.R.Set.of_list relax in
-      let aset = C.R.Set.union sset rset in
+      let predicate_aset =
+        PredicateRelaxSet.union (PredicateRelaxSet.of_list (List.map snd safe))
+          (PredicateRelaxSet.of_list (List.map snd relax)) in
+      let aset =
+        PredicateRelaxSet.fold
+          (fun pred -> C.R.Set.add (plain pred))
+          predicate_aset C.R.Set.empty in
+      let rej = List.map (fun (_,predicate_relax) -> plain predicate_relax) rej in
       D.all
         ~check:(last_minute rej)
         (fun f ->
           zyva_prefix prefixes aset relax safe rej n
             (last_check_call rej aset f))
 
-    let debug_rs chan rs =
-      List.iter (fun r -> fprintf chan "%s\n" (pp_relax r)) rs
+    let debug_predicate_rs chan rs =
+      List.iter (fun r -> fprintf chan "%s\n" (pp_relax (plain r))) rs
 
     let parse_input ~relax ~safe ~reject =
+      let r_nempty = Misc.consp relax in
+      let relax = parse_arguments relax
+      and safe = parse_arguments safe
+      and reject = parse_arguments reject in
+      if Misc.nilp relax && r_nempty then
+        Warn.fatal "relaxations provided in relaxlist could not be used to generate cycles" ;
       if O.verbose > 0 then begin
         eprintf "** Relax0 **\n" ;
-        debug_rs stderr relax ;
+        debug_predicate_rs stderr relax ;
         eprintf "** Safe0 **\n" ;
-        debug_rs stderr safe
+        debug_predicate_rs stderr safe
       end ;
-      let relax_set = C.R.Set.of_list relax
-      and safe_set = C.R.Set.of_list safe
-      and reject_set = C.R.Set.of_list reject in
-      let relax = C.R.Set.elements relax_set
-      and safe = C.R.Set.elements (C.R.Set.diff safe_set relax_set)
-      and reject = C.R.Set.elements reject_set in
+      let relax_set = PredicateRelaxSet.of_list relax
+      and safe_set = PredicateRelaxSet.of_list safe
+      and reject_set = PredicateRelaxSet.of_list reject in
+      let safe = PredicateRelaxSet.elements (PredicateRelaxSet.diff safe_set relax_set)
+      and reject = PredicateRelaxSet.elements reject_set in
       if O.verbose > 0 then begin
         eprintf "** Relax **\n" ;
-        debug_rs stderr relax ;
+        debug_predicate_rs stderr relax ;
         eprintf "** Safe **\n" ;
-        debug_rs stderr safe
+        debug_predicate_rs stderr safe
       end ;
       relax, safe, reject
 
     let secret_gen relax safe reject n =
-      let relax,safe,reject = parse_input ~relax ~safe ~reject in
-      do_gen relax safe reject n
+      do_gen (List.map with_plain relax) (List.map with_plain safe)
+        (List.map with_plain reject) n
 
 (**********************)
 (* Default edge lists *)
@@ -851,15 +1028,18 @@ module Make(C:Builder.S)
       let k = er (Hat)::k in
       k
 
-    let gen ?(relax=relax) ?(safe=safe) ?(reject=[]) n =
+    let gen ?(relax=lift_list relax) ?(safe=lift_list safe) ?(reject=[]) n =
       try secret_gen relax safe reject n
       with e ->
         eprintf "Exc: '%s'\n" (Printexc.to_string e) ;
         raise e
 
-    let filter_check ~relax ~safe lhs rhs =
-      let safe,_,_ = parse_input ~relax ~safe ~reject:[] in
-      let safe_set = C.R.Set.of_list safe in
-      let po_safe = relaxs_with_work_edges safe |> extract_po in
-      FilterImpl.can_precede safe_set po_safe lhs rhs
+    let pp_predicate_relax_list relaxes =
+      List.map plain relaxes |> C.R.pp_relax_list
+
+    let filter_check ~safe lhs rhs =
+      let safe = List.map with_plain safe in
+      let safe_set = C.R.Set.of_list (List.map fst safe) in
+      let po_safe = extract_po safe in
+      FilterImpl.can_precede safe_set po_safe (plain lhs) (plain rhs)
   end

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -313,6 +313,85 @@ module Make(C:Builder.S)
     let relaxs_with_work_edges rs =
       List.map (fun r -> (r, r)) rs
 
+    (* Check whether `list` starts with `expected`, using `pred` for element
+       comparison. *)
+    let rec starts_with pred list expected =
+      match list, expected with
+      | _, [] -> true
+      | [], _::_  -> false
+      | hd :: tail, hd_expected :: tail_expected ->
+          pred hd hd_expected
+          && starts_with pred tail tail_expected
+
+    (* Check whether `list` ends with `expected`, using `pred` for element
+       comparison. *)
+    let ends_with pred list expected =
+      starts_with pred (List.rev list) (List.rev expected)
+
+    (* Given `next = [....; after(..); after(..)]` and
+       `exist = [before(..); before(..); ....]`, check whether the optional
+       boundary predicates can be merged with the neighbouring concrete edge:
+         - `before` merges with concrete if edge matches.
+         - `after` merges with concrete if edge matches.
+         - `before` pairing with `after` fails. *)
+    let merge_predicate next exist =
+      (* Separate the trailing `after` predicate from `next` *)
+      let after =
+        List.fold_right ( fun e (after,seen_non_after) ->
+          match seen_non_after, C.E.get_predicate e = Some C.E.After with
+          | true, _ | _, false -> after, true
+          | false, true -> e :: after, false ) next ([],false)
+        |> fst in
+      (* Separate the beginning `before` predicate from `exist` *)
+      let before =
+        List.fold_left ( fun (before,seen_non_before) e ->
+          match seen_non_before, C.E.get_predicate e = Some C.E.Before with
+          | true, _ | _, false -> before, true
+          | false, true -> e :: before, false ) ([],false) exist
+        |> fst |> List.rev in
+      (* Match `after` or `before` predicates when present. *)
+      match after, before with
+      | [], [] -> true
+      | after, [] ->
+          starts_with C.E.equal_edge_atoms exist after
+      | [], before ->
+          ends_with C.E.equal_edge_atoms next before
+      (* Reject an `after` predicate directly meeting a `before` predicate. *)
+      | _, _ -> false
+
+    let needs_merge next_edges exist_edges =
+      match List.rev next_edges, exist_edges with
+      | next_last::_, exist_first::_ ->
+          C.E.get_predicate next_last = Some C.E.After ||
+          C.E.get_predicate exist_first = Some C.E.Before
+      | _ -> false
+
+    (* Check whether `next_edges` may be placed immediately before
+       `exist_edges`: if `next_edges` contains trailing `after` predicates
+       or `exist_edges` contains leading `before` predicates,
+       match those predicates against the neighbouring concrete edges;
+       otherwise use the ordinary `can_precede` relation. *)
+    let check_precede can_precede next_edges exist_edges =
+      if O.verbose > 2 then
+        eprintf "next: %s, exists: %s\n"
+          (C.E.pp_edges next_edges) (C.E.pp_edges exist_edges);
+      if needs_merge next_edges exist_edges then
+        merge_predicate next_edges exist_edges
+      else
+        can_precede next_edges exist_edges
+
+    (* Check whether a candidate relaxation `next` can be prepended to the
+       current suffix `exist`. The suffix is stored newest-first, so only
+       its head must be checked against `next`; an empty suffix accepts any
+       first relaxation. *)
+    let precede_relax_edge_list safes po_safe next exist =
+      match exist with
+      | [] -> true
+      | (_,exist_edges) :: _ ->
+          check_precede
+            (FilterImpl.can_precede safes po_safe)
+            (snd next) exist_edges
+
 (* Functional for recursive call of generators *)
 
     let sz (_,es) =
@@ -320,11 +399,12 @@ module Make(C:Builder.S)
 
     let c_minprocs_es c =
       List.fold_left ( fun c e ->
-        match e.C.E.edge,get_ie e with
-        | (Back _|Leave _),_
-        | _,Int -> c
-        | _,Ext -> c + 1
-        | _,UnspecCom -> assert false
+        match e.C.E.pred,e.C.E.edge,get_ie e with
+        | Some _,_,_
+        | None,(Back _|Leave _),_
+        | None,_,Int -> c
+        | None,_,Ext -> c + 1
+        | None,_,UnspecCom -> assert false
       ) c
 
     let c_minprocs_suff c =
@@ -337,6 +417,7 @@ module Make(C:Builder.S)
 
     let rec c_minint_es c = function
       | [] -> false,c
+      | {pred=Some _; _}::es
       | {edge=Id; _}::es ->  c_minint_es c es
       | e::es ->
           match get_ie e with
@@ -387,7 +468,7 @@ module Make(C:Builder.S)
     (* This function is used `zyva` *)
     let call_rec_base prefix f0 safes po_safe over n r suff f_rec k ?(reject=[])=
       if
-        can_precede safes po_safe r suff &&
+        precede_relax_edge_list safes po_safe r suff &&
         minprocs suff <= O.nprocs &&
         minint (r::suff) <= O.max_ins-1 &&
         check_cycle (r::suff) reject
@@ -397,11 +478,21 @@ module Make(C:Builder.S)
         if O.verbose > 2 then eprintf "CALL: %i %s\n%!" n (pp_ess suff) ;
         let k =
           if
+            precede_relax_edge_list safes po_safe (Misc.last suff) suff &&
             over &&
             (n = 0 || (n > 0 && O.upto)) &&
             can_prefix prefix (can_precede safes po_safe) suff
           then begin
-            let tr =  prefix@suff in
+            (* Find an actual candidate cycle and add `prefix`. Predicate
+               edges have been resolved at this point, so remove them before
+               calling `test_generator`. *)
+            let tr =
+              List.map ( fun (relax,edges) ->
+                let edges = List.filter ( function
+                  | { pred = Some _; _ } -> false
+                  | _ -> true ) edges in
+                (relax,edges)
+              ) (prefix@suff) in
             if O.verbose > 2 then
             eprintf "TRY: '%s'\n"
               (C.E.pp_edges (List.flatten (List.map snd tr))) ;

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -283,6 +283,7 @@ module Make(C:Builder.S)
         relax:string list -> safe:string list ->
         reject:string list ->
         predicate_relax list * predicate_relax list * predicate_relax list
+      val remove_invalid_relaxes : predicate_relax list -> predicate_relax list
       val pp_ess : predicate_relax list -> string
       val filter_check:
         safe:predicate_relax list -> predicate_relax -> predicate_relax -> bool
@@ -417,6 +418,34 @@ module Make(C:Builder.S)
           |> List.map (reattach_predicates predicate_relax))
         predicate_relaxes
 
+    let remove_invalid_relaxes relaxes =
+      let valid_relaxes =
+        List.map to_relax relaxes
+        |> C.R.remove_invalid_relaxes
+        |> C.R.Set.of_list in
+      (* Predicate-only edges are only meaningful at relaxation boundaries:
+         `before(...)` predicates must form a leading prefix, and `after(...)`
+         predicates must form a trailing suffix. Once a plain edge appears,
+         no later `before(...)` is valid; once an `after(...)` appears, only
+         more `after(...)` predicates may follow. *)
+      let rec leading_before_trailing_after_predicate = function
+        | Before _::rest ->
+            leading_before_trailing_after_predicate rest
+        | rest -> plain_then_after rest
+      and plain_then_after = function
+        | [] -> true
+        | Plain _::rest -> plain_then_after rest
+        | After _::rest -> List.for_all (function After _ -> true | _ -> false) rest
+        | Before _::_ -> false in
+      let has_plain_edge =
+        List.exists (function Plain _ -> true | _ -> false) in
+      List.filter
+        (fun relax ->
+          has_plain_edge relax
+          && C.R.Set.mem (to_relax relax) valid_relaxes
+          && leading_before_trailing_after_predicate relax)
+        relaxes
+
     let parse_argument_ast_expanded ast =
       let parse_one str =
         C.R.parse_expand_relaxs_ast ~ppo:C.ppo (Ast.One str)
@@ -436,6 +465,7 @@ module Make(C:Builder.S)
     let parse_arguments input_argument_list =
       List.map parse_argument input_argument_list
       |> List.flatten
+      |> remove_invalid_relaxes
       |> List.sort_uniq compare_predicate_relax
 
     let pp_ess ess = String.concat " " (List.map pp_predicate_relax ess)

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -374,9 +374,93 @@ module Make(C:Builder.S)
     | Ext -> false
     | UnspecCom -> assert false
 
+    (* Check whether `list` starts with `expected`, using `pred` for element
+       comparison. *)
+    let rec starts_with pred list expected =
+      match list, expected with
+      | _, [] -> true
+      | [], _::_  -> false
+      | hd :: tail, hd_expected :: tail_expected ->
+          pred hd hd_expected
+          && starts_with pred tail tail_expected
+
+    (* Check whether `list` ends with `expected`, using `pred` for element
+       comparison. *)
+    let ends_with pred list expected =
+      starts_with pred (List.rev list) (List.rev expected)
+
+    (* Given `next = [....; after(..); after(..)]` and
+       `exist = [before(..); before(..); ....]`, check whether the optional
+       boundary predicates can be merged with the neighbouring concrete edge:
+         - `before` merges with concrete if edge matches.
+         - `after` merges with concrete if edge matches.
+         - `before` pairing with `after` fails. *)
+    let merge_predicate next exist =
+      (* Separate the trailing `after` predicate from `next` *)
+      let after =
+        List.fold_right ( fun e (after,seen_non_after) ->
+          match seen_non_after,e with
+          | false,After _ -> e::after,false
+          | _,_ -> after,true) next ([],false)
+        |> fst in
+      (* Separate the beginning `before` predicate from `exist` *)
+      let before =
+        List.fold_left ( fun (before,seen_non_before) e ->
+          match seen_non_before,e with
+          | false,Before _ -> e::before,false
+          | _,_ -> before,true) ([],false) exist
+        |> fst |> List.rev in
+      (* Match `after` or `before` predicates when present. *)
+      match after,before with
+      | (_::_ as after),[] ->
+          starts_with
+            (fun lhs rhs -> match lhs,rhs with
+              | (Plain lhs|Before lhs|After lhs),After rhs ->
+                  C.E.equal_edge_atoms lhs rhs
+              | _,_ -> false)
+            exist after
+      | [],(_::_ as before) ->
+          ends_with
+            (fun lhs rhs -> match lhs,rhs with
+              | (Plain lhs|Before lhs|After lhs),Before rhs ->
+                  C.E.equal_edge_atoms lhs rhs
+              | _,_ -> false)
+            next before
+      (* Reject an `after` predicate directly meeting a `before` predicate. *)
+      | [],[] | _::_,_::_ -> false
+
+    let needs_merge next exist =
+      let trailing_edge =
+        List.fold_left (fun _ edge -> Some edge) None next in
+      let leading_edge = match exist with
+        | edge::_ -> Some edge
+        | [] -> None in
+      match trailing_edge,leading_edge with
+      | Some (After _),_ | _,Some (Before _) -> true
+      | _,_ -> false
+
+    (* Check whether `next_edges` may be placed immediately before
+       `exist_edges`: if `next_edges` contains trailing `after` predicates
+       or `exist_edges` contains leading `before` predicates,
+       match those predicates against the neighbouring concrete edges;
+       otherwise use the ordinary `can_precede` relation. *)
+    let check_precede can_precede next_edges exist_edges =
+      if O.verbose > 2 then
+        eprintf "next: %s, exists: %s\n"
+          (pp_predicate_relax next_edges)
+          (pp_predicate_relax exist_edges);
+      if needs_merge next_edges exist_edges then
+        merge_predicate next_edges exist_edges
+      else
+        can_precede (to_relax next_edges) (to_relax exist_edges)
+
+    (* Check whether a candidate relaxation `next` can be prepended to the
+       current suffix `exist`. The suffix is stored newest-first, so only
+       its head must be checked against `next`; an empty suffix accepts any
+       first relaxation. *)
     let can_precede safes po_safe xs k = match k with
     | [] -> true
-    | ys::_ -> FilterImpl.can_precede safes po_safe (to_relax xs) (to_relax ys)
+    | ys::_ -> check_precede (FilterImpl.can_precede safes po_safe) xs ys
 
     (* List.is_empty only supports for ocaml 5.1 afterwards *)
     let is_empty_list l = (l = [])
@@ -563,13 +647,15 @@ module Make(C:Builder.S)
 
     let rec is_prefix l rl =
       match rl,l with
-      | hrl::trl, hl::tl -> if hl = hrl then  is_prefix tl trl else false
+      | hrl::trl, hl::tl ->
+          if compare_predicate_edge hl hrl = 0 then is_prefix tl trl
+          else false
       | [], _ -> true (* end of rl before or at the end of l *)
       | _, [] -> false (* end of l before end of rl*)
 
 
     let check_cycle rsuff rl =
-      let rsuff = List.concat rsuff |> to_relax in
+      let rsuff = List.concat rsuff in
       not (List.exists (fun rl -> is_prefix rsuff rl) rl)
 
 
@@ -776,6 +862,19 @@ module Make(C:Builder.S)
       with Result b -> b
 
     let substring_spanp rej pss =
+      let prefix_spanp xs (p,s) =
+        let rec is_prefix xs ys = match xs,ys with
+          | [],_ -> raise (Result true)
+          | _::_,[] -> xs
+          | x::xs,y::ys ->
+              if compare_predicate_edge x y = 0 then is_prefix xs ys
+              else raise (Result false) in
+        try
+          let xs = is_prefix xs s in
+          match is_prefix xs p with
+          | [] -> true
+          | _::_ -> false
+        with Result b -> b in
       List.exists
         (fun xs ->
           List.exists
@@ -792,8 +891,7 @@ module Make(C:Builder.S)
           let le = List.concat_map to_cycle_edges res in
           if procedure_count 0 le <= O.nprocs &&
              (max_edges_in_procedure (0,0) (le@le) |> snd) <= O.max_ins-1 &&
-             FilterImpl.can_precede aset po_safe
-               (to_relax lst) (to_relax head) then
+             check_precede (FilterImpl.can_precede aset po_safe) lst head then
             try
               if
                 (match O.choice with
@@ -813,7 +911,7 @@ module Make(C:Builder.S)
                   | _::_ ->
                      let max_sz =
                        List.fold_left (fun  k xs -> max k (List.length xs)) 0 rej in
-                     let pss = Misc.cuts max_sz le in
+                     let pss = Misc.cuts max_sz (List.concat res) in
                      not (substring_spanp rej pss) in
                 if ok then
                   let ss = build_safe rs res in
@@ -887,9 +985,15 @@ module Make(C:Builder.S)
         PredicateRelaxSet.fold
           (fun pred -> C.R.Set.add (to_relax pred))
           predicate_aset C.R.Set.empty in
-      let rej = List.map to_relax rej in
+      let plain_rej =
+        List.filter_map
+          (fun reject ->
+            if List.for_all (function Plain _ -> true | _ -> false) reject
+            then Some (to_relax reject)
+            else None)
+          rej in
       D.all
-        ~check:(last_minute rej)
+        ~check:(last_minute plain_rej)
         (fun f ->
           zyva_prefix prefixes aset relax safe rej n
             (last_check_call rej aset f))
@@ -977,5 +1081,5 @@ module Make(C:Builder.S)
     let filter_check ~safe lhs rhs =
       let safe_set = C.R.Set.of_list (List.map to_relax safe) in
       let po_safe = extract_po safe in
-      FilterImpl.can_precede safe_set po_safe (to_relax lhs) (to_relax rhs)
+      check_precede (FilterImpl.can_precede safe_set po_safe) lhs rhs
   end

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -26,9 +26,9 @@ module type AltConfig = sig
   val max_relax : int
   val min_relax : int
   val choice : check
-  type relax
-  val prefix : relax list list
+  val prefix : string list
   val variant : Variant_gen.t -> bool
+  val varatom : string list
   type fence
   val cumul : fence list Config.cumul
   val wildcard : bool
@@ -270,10 +270,22 @@ struct
 end
 
 module Make(C:Builder.S)
-    (O:AltConfig with type relax = C.R.relax and type fence = C.A.fence) :
+    (O:AltConfig with type fence = C.A.fence) :
     sig
-      val gen : ?relax:C.R.relax list -> ?safe:C.R.relax list -> ?reject:C.R.relax list -> int -> unit
-      val filter_check: relax:C.R.relax list -> safe:C.R.relax list -> C.E.edge list -> C.E.edge list -> bool
+      type predicate_relax
+
+      val to_relax : predicate_relax -> C.R.relax
+      val lift : C.R.relax -> predicate_relax
+      val gen : ?relax:predicate_relax list -> ?safe:predicate_relax list ->
+        ?reject:predicate_relax list -> int -> unit
+      val parse_argument : string -> predicate_relax list
+      val parse_input :
+        relax:string list -> safe:string list ->
+        reject:string list ->
+        predicate_relax list * predicate_relax list * predicate_relax list
+      val pp_ess : predicate_relax list -> string
+      val filter_check:
+        safe:predicate_relax list -> predicate_relax -> predicate_relax -> bool
     end
 
     =
@@ -284,6 +296,76 @@ module Make(C:Builder.S)
     open C.E
     open C.R
 
+    type predicate_edge =
+      | Plain of C.E.edge
+      | Before of C.E.edge
+      | After of C.E.edge
+
+    let compare_predicate_edge lhs rhs =
+      let rank = function
+        | Plain _ -> 0 | Before _ -> 1 | After _ -> 2 in
+      match Misc.int_compare (rank lhs) (rank rhs) with
+      | 0 ->
+          begin match lhs,rhs with
+          | Plain lhs,Plain rhs
+          | Before lhs,Before rhs
+          | After lhs,After rhs -> C.E.compare lhs rhs
+          | _,_ -> assert false
+          end
+      | r -> r
+
+    let parse_predicate_node pred ast =
+      let decorate make same = function
+        | Plain edge -> make edge
+        | Before _ as edge when same edge -> edge
+        | After _ as edge when same edge -> edge
+        | Before _ | After _ ->
+            Warn.user_error
+              "before and after predicates cannot apply to the same edge" in
+      match pred with
+      | "before" ->
+          Ast.bind ast
+            (fun edge ->
+              Ast.One
+                (decorate
+                   (fun edge -> Before edge)
+                   (function Before _ -> true | _ -> false)
+                   edge))
+      | "after" ->
+          Ast.bind ast
+            (fun edge ->
+              Ast.One
+                (decorate
+                   (fun edge -> After edge)
+                   (function After _ -> true | _ -> false)
+                   edge))
+      | pred -> Warn.user_error "predicate %s is not supported." pred
+
+    let pp_predicate_edge = function
+      | Plain edge -> pp_edge edge
+      | Before edge -> sprintf "@before(%s)" (pp_edge edge)
+      | After edge -> sprintf "@after(%s)" (pp_edge edge)
+
+    type predicate_relax = predicate_edge list
+
+    let pp_predicate_relax = function
+      | [edge] -> pp_predicate_edge edge
+      | edges -> sprintf "[%s]" (String.concat "," (List.map pp_predicate_edge edges))
+
+    let compare_predicate_relax = List.compare compare_predicate_edge
+
+    module PredicateRelaxSet =
+      MySet.Make
+        (struct
+          type t = predicate_relax
+          let compare = compare_predicate_relax
+        end)
+
+    let to_relax relax =
+      List.map
+        (function Plain edge | Before edge | After edge -> edge)
+        relax
+
     let dbg = false
 
     let is_int e = match get_ie e with
@@ -291,27 +373,75 @@ module Make(C:Builder.S)
     | Ext -> false
     | UnspecCom -> assert false
 
-    let can_precede safes po_safe (_,xs) k = match k with
+    let can_precede safes po_safe xs k = match k with
     | [] -> true
-    | (_,ys)::_ -> FilterImpl.can_precede safes po_safe xs ys
+    | ys::_ -> FilterImpl.can_precede safes po_safe (to_relax xs) (to_relax ys)
 
     (* List.is_empty only supports for ocaml 5.1 afterwards *)
     let is_empty_list l = (l = [])
 
-    let pp_ess ess =
-      let list_sep = " " in
-      let list_list_sep = " " in
-      ess |> List.map
-        ( fun (_,es) ->
-          es |> List.map (fun e -> pp_edge e)
-             |> String.concat list_list_sep )
-        |> String.concat list_sep
+    let parse_argument_ast input =
+      String.trim input |> C.R.parse_ast Parser.diy7
 
-    (* Pair each relax with the working edge list used by the generator.
-       The first component preserves the original relax for reporting/filtering;
-       the second component may be modified while building candidate cycles. *)
-    let relaxs_with_work_edges rs =
-      List.map (fun r -> (r, r)) rs
+    let varatom_ess predicate_relaxes =
+      let varatom_es =
+        if C.A.bellatom then Misc.identity
+        else match O.varatom with
+        | [] -> Misc.identity
+        | ["all"] ->
+            let module Fold = struct
+              type atom = C.E.atom
+              let fold = C.E.fold_atomo
+            end in
+            let module V = VarAtomic.Make(C.E)(Fold) in
+            V.varatom_es
+        | atoms ->
+            let atoms = C.E.parse_atoms atoms in
+            let module Fold = struct
+              type atom = C.E.atom
+              let fold f k = C.E.fold_atomo_list atoms f k
+            end in
+            let module V = VarAtomic.Make(C.E)(Fold) in
+            V.varatom_es in
+      let reattach_predicates template_predicate_relax edges =
+        let rec do_rec template edges = match template,edges with
+          | [],[] -> []
+          | Plain _::template,edge::edges -> Plain edge::do_rec template edges
+          | Before _::template,edge::edges -> Before edge::do_rec template edges
+          | After _::template,edge::edges -> After edge::do_rec template edges
+          | _,_ -> Warn.fatal "predicate expansion changed relaxation length" in
+        do_rec template_predicate_relax edges in
+      List.concat_map
+        (fun predicate_relax ->
+          varatom_es [to_relax predicate_relax]
+          |> List.map (reattach_predicates predicate_relax))
+        predicate_relaxes
+
+    let parse_argument_ast_expanded ast =
+      let parse_one str =
+        C.R.parse_expand_relaxs_ast ~ppo:C.ppo (Ast.One str)
+        |> Ast.map
+             ~one:(fun edge -> Ast.One (Plain edge))
+             ~predicate:
+               (fun pred _ ->
+                 Warn.fatal "unexpected predicate %s in relaxation expansion" pred) in
+      Ast.map ~one:parse_one ~predicate:parse_predicate_node ast
+      |> Ast.expand (fun _ _ -> assert false)
+      |> varatom_ess
+
+    let parse_argument input_argument =
+      parse_argument_ast input_argument
+      |> parse_argument_ast_expanded
+
+    let parse_arguments input_argument_list =
+      List.map parse_argument input_argument_list
+      |> List.flatten
+      |> List.sort_uniq compare_predicate_relax
+
+    let pp_ess ess = String.concat " " (List.map pp_predicate_relax ess)
+
+    let lift r = List.map (fun edge -> Plain edge) r
+    let lift_list rs = List.map lift rs
 
     let make_adjacency safes po_safe chunks =
       let ids = Hashtbl.create (List.length chunks) in
@@ -355,10 +485,13 @@ module Make(C:Builder.S)
               | UnspecCom -> assert false)
         c es
 
+    let to_cycle_edges edges =
+      List.filter_map (function Plain edge -> Some edge | _ -> None) edges
+
     let procedure_count_chunks chunks =
       let r =
         List.fold_left
-          (fun c (_,edges) -> procedure_count c edges)
+          (fun c edges -> procedure_count c (to_cycle_edges edges))
           0 chunks in
       if O.verbose > 3 then eprintf "PROCS [%s] => %i\n" (pp_ess chunks) r ;
       r
@@ -366,21 +499,31 @@ module Make(C:Builder.S)
     let max_instruction_count_chunks chunks =
       let current,longest =
         List.fold_left
-          (fun c (_,edges) -> max_edges_in_procedure c edges)
+          (fun c edges -> max_edges_in_procedure c (to_cycle_edges edges))
           (0,0) chunks in
       max current longest
 
 (* Prefix *)
+    let parse_prefixes prefix =
+      (* Parse each `-prefix` argument separately, then combine them as one
+         top-level choice. Thus `-prefix A -prefix B` is interpreted as
+         `-prefix [A|B]`. *)
+      let prefixes =
+        parse_arguments prefix
+        |> List.map (fun chunk -> [chunk]) in
+      match prefixes with
+      | [] -> [[]] (* No prefix <=> one empty prefix *)
+      | prefixes -> prefixes
+
+    let prefixes = parse_prefixes O.prefix
+
     let () =
       if O.verbose > 0 && O.prefix <> [] then begin
         eprintf "Prefixes:\n" ;
         List.iter
-          (fun rs ->
-            eprintf "  %s\n" (C.R.pp_relax_list rs))
-          O.prefix
+          (fun rs -> eprintf "  %s\n" (pp_ess rs))
+          prefixes
       end
-
-    let prefixes = List.map relaxs_with_work_edges O.prefix
 
     let can_prefix prefix can_precede_relax r_suff = match prefix with
       | [] -> can_precede_relax (Misc.last r_suff) r_suff
@@ -396,7 +539,7 @@ module Make(C:Builder.S)
 
 
     let check_cycle rsuff rl =
-      let rsuff = List.split rsuff |> snd |> List.concat in
+      let rsuff = List.concat rsuff |> to_relax in
       not (List.exists (fun rl -> is_prefix rsuff rl) rl)
 
 
@@ -421,7 +564,7 @@ module Make(C:Builder.S)
             let tr = prefix@r_suff in
             if O.verbose > 2 then
             eprintf "TRY: '%s'\n"
-              (C.E.pp_edges (List.flatten (List.map snd tr))) ;
+              (C.E.pp_edges (List.concat_map to_cycle_edges tr)) ;
             try f0 po_safe tr k
             with  Misc.Exit -> k
             | Misc.Fatal msg |Misc.UserError msg ->
@@ -448,7 +591,7 @@ module Make(C:Builder.S)
       | Sc ->
           let d2 =
             List.fold_right
-              (fun (r,_) k -> match r with
+              (fun chunk k -> match to_relax chunk with
               | [{edge=Po (sd,e1,e2); _}] -> SdDir2Set.add (sd,e1,e2) k
               | _ -> k)
               rs SdDir2Set.empty in
@@ -467,8 +610,6 @@ module Make(C:Builder.S)
 
     let zyva prefix aset relax safe reject n f =
 (*      let safes = C.R.Set.of_list safe in *)
-      let relax = relaxs_with_work_edges relax in
-      let safe = relaxs_with_work_edges safe in
       let po_safe = extract_po safe in
       let can_precede_relax =
         make_adjacency aset po_safe (prefix@relax@safe) in
@@ -481,7 +622,7 @@ module Make(C:Builder.S)
         (* Build simple cycles for relaxation `relex_edge` *)
         (* Partially apply function `call_rec_base` *)
         let call_rec_add_safe =
-          call_rec_base prefix (f [fst relex_edge]) po_safe can_precede_relax
+          call_rec_base prefix (f [relex_edge]) po_safe can_precede_relax
             ~reject:reject in
         (* Add safe edge to suffix *)
         let rec add_safe over ss n suf k =
@@ -504,10 +645,11 @@ module Make(C:Builder.S)
       (* Alternative: mix relaxation from relax list *)
       (* ******************************************* *)
       let all_relax k =
-        let relax_set = RelaxSet.of_list (List.map fst relax) in
+        let relax_set = PredicateRelaxSet.of_list relax in
         let extract_relaxs suff =
-          let suff_set = RelaxSet.of_list (List.map fst suff)  in
-          RelaxSet.elements (RelaxSet.inter suff_set relax_set) in
+          let suff_set = PredicateRelaxSet.of_list suff in
+          PredicateRelaxSet.inter suff_set relax_set
+          |> PredicateRelaxSet.elements in
 
         (* Partially apply function `call_rec_base` *)
         let call_rec_all_relax =
@@ -579,11 +721,11 @@ module Make(C:Builder.S)
 
     let count_changes = count_p change_loc
 
-    let build_safe r0 es =
-      let rs =
-        List.fold_right (fun (r,_) -> RelaxSet.add r) es RelaxSet.empty in
-      let rs = RelaxSet.diff rs (RelaxSet.of_list r0) in
-      RelaxSet.elements rs
+    let build_safe relaxes candidate =
+      PredicateRelaxSet.diff
+        (PredicateRelaxSet.of_list candidate)
+        (PredicateRelaxSet.of_list relaxes)
+      |> PredicateRelaxSet.elements
 
     exception Result of bool
 
@@ -614,10 +756,14 @@ module Make(C:Builder.S)
     let last_check_call rej aset f rs po_safe res k =
       if is_empty_list res then k else
           let lst = Misc.last res in
-          let le = List.map snd res |> List.flatten in
+          let head = List.hd res in
+          (* Predicate edges are search-only metadata. Keep them until the
+             final candidate check, then retain only concrete cycle edges. *)
+          let le = List.concat_map to_cycle_edges res in
           if procedure_count 0 le <= O.nprocs &&
              (max_edges_in_procedure (0,0) (le@le) |> snd) <= O.max_ins-1 &&
-             can_precede aset po_safe lst res then
+             FilterImpl.can_precede aset po_safe
+               (to_relax lst) (to_relax head) then
             try
               if
                 (match O.choice with
@@ -640,14 +786,14 @@ module Make(C:Builder.S)
                      let pss = Misc.cuts max_sz le in
                      not (substring_spanp rej pss) in
                 if ok then
+                  let ss = build_safe rs res in
                   let mk_info =
-                    let ss = build_safe rs res in
                     let info =
                       [
-                        "Relax",pp_relax_list rs;
-                        "Safe", pp_relax_list ss;
+                        "Relax",pp_ess rs;
+                        "Safe",pp_ess ss;
                       ] in
-                    info,C.R.Set.of_list rs in
+                    info,pp_ess rs in
                   f le mk_info D.no_name D.no_scope k
                 else k
               end
@@ -705,9 +851,13 @@ module Make(C:Builder.S)
       List.fold_left ( fun k pref -> zyva pref aset relax safe reject n f k ) k prefixes
 
     let do_gen relax safe rej n =
-      let sset = C.R.Set.of_list safe in
-      let rset = C.R.Set.of_list relax in
-      let aset = C.R.Set.union sset rset in
+      let predicate_aset =
+        PredicateRelaxSet.union (PredicateRelaxSet.of_list safe) (PredicateRelaxSet.of_list relax) in
+      let aset =
+        PredicateRelaxSet.fold
+          (fun pred -> C.R.Set.add (to_relax pred))
+          predicate_aset C.R.Set.empty in
+      let rej = List.map to_relax rej in
       D.all
         ~check:(last_minute rej)
         (fun f ->
@@ -715,21 +865,23 @@ module Make(C:Builder.S)
             (last_check_call rej aset f))
 
     let debug_rs chan rs =
-      List.iter (fun r -> fprintf chan "%s\n" (pp_relax r)) rs
+      fprintf chan "%s\n" (pp_ess rs)
 
     let parse_input ~relax ~safe ~reject =
-      if O.verbose > 0 then begin
-        eprintf "** Relax0 **\n" ;
-        debug_rs stderr relax ;
-        eprintf "** Safe0 **\n" ;
-        debug_rs stderr safe
-      end ;
-      let relax_set = C.R.Set.of_list relax
-      and safe_set = C.R.Set.of_list safe
-      and reject_set = C.R.Set.of_list reject in
-      let relax = C.R.Set.elements relax_set
-      and safe = C.R.Set.elements (C.R.Set.diff safe_set relax_set)
-      and reject = C.R.Set.elements reject_set in
+      let r_nempty = Misc.consp relax in
+      let s_nempty = Misc.consp safe in
+      let relax_set = parse_arguments relax |> PredicateRelaxSet.of_list
+      and safe_set = parse_arguments safe |> PredicateRelaxSet.of_list
+      and reject_set = parse_arguments reject |> PredicateRelaxSet.of_list in
+      let relax_set = PredicateRelaxSet.diff relax_set reject_set in
+      let safe_set = PredicateRelaxSet.diff safe_set (PredicateRelaxSet.union relax_set reject_set) in
+      if PredicateRelaxSet.is_empty relax_set && r_nempty then
+        Warn.fatal "relaxations provided in relaxlist could not be used to generate cycles" ;
+      if PredicateRelaxSet.is_empty safe_set && s_nempty then
+        Warn.fatal "relaxations provided in safelist could not be used to generate cycles" ;
+      let relax = PredicateRelaxSet.elements relax_set
+      and safe = PredicateRelaxSet.elements safe_set
+      and reject = PredicateRelaxSet.elements reject_set in
       if O.verbose > 0 then begin
         eprintf "** Relax **\n" ;
         debug_rs stderr relax ;
@@ -739,7 +891,6 @@ module Make(C:Builder.S)
       relax, safe, reject
 
     let secret_gen relax safe reject n =
-      let relax,safe,reject = parse_input ~relax ~safe ~reject in
       do_gen relax safe reject n
 
 (**********************)
@@ -787,15 +938,14 @@ module Make(C:Builder.S)
       let k = er (Hat)::k in
       k
 
-    let gen ?(relax=relax) ?(safe=safe) ?(reject=[]) n =
+    let gen ?(relax=lift_list relax) ?(safe=lift_list safe) ?(reject=[]) n =
       try secret_gen relax safe reject n
       with e ->
         eprintf "Exc: '%s'\n" (Printexc.to_string e) ;
         raise e
 
-    let filter_check ~relax ~safe lhs rhs =
-      let safe,_,_ = parse_input ~relax ~safe ~reject:[] in
-      let safe_set = C.R.Set.of_list safe in
-      let po_safe = relaxs_with_work_edges safe |> extract_po in
-      FilterImpl.can_precede safe_set po_safe lhs rhs
+    let filter_check ~safe lhs rhs =
+      let safe_set = C.R.Set.of_list (List.map to_relax safe) in
+      let po_safe = extract_po safe in
+      FilterImpl.can_precede safe_set po_safe (to_relax lhs) (to_relax rhs)
   end

--- a/gen/cat2config/translation.ml
+++ b/gen/cat2config/translation.ml
@@ -262,7 +262,7 @@ let try_match_edge (left : prim_set list) (core : seq_item list)
   let relaxs =
     tedges
     |> List.map (fun (Tedge { edge; insert }) ->
-        let edge = E.{ edge; a1 = left.atom; a2 = right.atom } in
+        let edge = E.{ edge; a1 = left.atom; a2 = right.atom; pred = None } in
         let edge = set_src left.extr edge in
         let edge = set_tgt right.extr edge in
         let edges =

--- a/gen/cat2config/translation.ml
+++ b/gen/cat2config/translation.ml
@@ -262,7 +262,7 @@ let try_match_edge (left : prim_set list) (core : seq_item list)
   let relaxs =
     tedges
     |> List.map (fun (Tedge { edge; insert }) ->
-        let edge = E.{ edge; a1 = left.atom; a2 = right.atom; pred = None } in
+        let edge = E.{ edge; a1 = left.atom; a2 = right.atom } in
         let edge = set_src left.extr edge in
         let edge = set_tgt right.extr edge in
         let edges =

--- a/gen/common/ast.ml
+++ b/gen/common/ast.ml
@@ -1,8 +1,9 @@
-type 'prim t =
+type ('pred,'prim) t =
   | One of 'prim
-  | Opt of 'prim t
-  | Seq of 'prim t list
-  | Choice of 'prim t list
+  | Opt of ('pred,'prim) t
+  | Seq of ('pred,'prim) t list
+  | Choice of ('pred,'prim) t list
+  | Predicate of 'pred * ('pred,'prim) t
 
 let rec normalise ast =
   let normalise_seq_items items =
@@ -24,25 +25,39 @@ let rec normalise ast =
   | Opt opt -> Opt (normalise opt)
   | Seq ss -> Seq (normalise_seq_items ss)
   | Choice ss -> Choice (normalise_choice_items ss)
+  | Predicate (pred,t) -> Predicate (pred, normalise t)
 
 let rec bind ast func =
-  let bind_func ast = bind ast func in
+  let bind_func ss = bind ss func in
+  let bind_pred pred t = bind t ( fun e -> Predicate(pred, func e) ) in
   match ast with
   | One s -> func s
   | Opt opt -> Opt (bind_func opt)
   | Seq ss -> Seq (List.map bind_func ss)
   | Choice ss -> Choice (List.map bind_func ss)
+  | Predicate (pred,t) -> bind_pred pred t
 
-let rec pp pp_prim ast =
-  let pp_with_prim = pp pp_prim in
+let rec pp pp_pred pp_prim ast =
   let ast = normalise ast in
+  let pp_wrap = pp pp_pred pp_prim in
   match ast with
   | One s -> Printf.sprintf "%s" (pp_prim s)
-  | Opt opt -> Printf.sprintf "%s?" (pp_with_prim opt)
+  | Opt opt -> Printf.sprintf "%s?" (pp_wrap opt)
   | Seq ss ->
-      Printf.sprintf "[%s]" (String.concat "," (List.map pp_with_prim ss))
+      Printf.sprintf "[%s]" (String.concat "," (List.map pp_wrap ss))
   | Choice ss ->
-      Printf.sprintf "[%s]" (String.concat "|" (List.map pp_with_prim ss))
+      Printf.sprintf "[%s]" (String.concat "|" (List.map pp_wrap ss))
+  | Predicate (pred,t) ->
+      Printf.sprintf "%s(%s)" (pp_pred pred) (pp_wrap t)
+
+let rec map_predicate func ast =
+  let map_func = map_predicate func in
+  match ast with
+  | One s -> One s
+  | Opt opt -> Opt (map_func opt)
+  | Seq ss -> Seq (List.map map_func ss)
+  | Choice ss -> Choice (List.map map_func ss)
+  | Predicate (pred,t) -> Predicate(func pred, map_func t)
 
 let list_cross_product_map f lhs rhs =
   List.map ( fun l ->
@@ -52,14 +67,18 @@ let list_cross_product_map f lhs rhs =
   ) lhs
   |> List.flatten
 
-let rec expand t =
+let rec expand pred_func t =
+  let expand_pred = expand pred_func in
   let result = match t with
   | One str -> [[str]]
-  | Opt opt -> [] :: expand opt
+  | Opt opt -> [] :: expand_pred opt
   | Seq seq -> List.fold_left
     ( fun acc s ->
-      expand s
+      expand_pred s
       |> list_cross_product_map ( @ ) acc
     ) [[]] seq
-  | Choice choice -> List.map expand choice |> List.flatten in
+  | Choice choice -> List.map expand_pred choice |> List.flatten
+  | Predicate (pred,t) ->
+      expand_pred t
+      |> List.map (List.map (fun e -> pred_func pred e)) in
   result

--- a/gen/common/ast.ml
+++ b/gen/common/ast.ml
@@ -1,8 +1,9 @@
-type 'prim t =
+type ('pred,'prim) t =
   | One of 'prim
-  | Opt of 'prim t
-  | Seq of 'prim t list
-  | Choice of 'prim t list
+  | Opt of ('pred,'prim) t
+  | Seq of ('pred,'prim) t list
+  | Choice of ('pred,'prim) t list
+  | Predicate of 'pred * ('pred,'prim) t
 
 let rec normalise ast =
   let normalise_seq_items items =
@@ -24,25 +25,34 @@ let rec normalise ast =
   | Opt opt -> Opt (normalise opt)
   | Seq ss -> Seq (normalise_seq_items ss)
   | Choice ss -> Choice (normalise_choice_items ss)
+  | Predicate (pred,t) -> Predicate (pred, normalise t)
 
-let rec bind ast func =
-  let bind_func ast = bind ast func in
+let rec map ~one ~predicate ast =
+  let map_child ast = map ~one ~predicate ast in
   match ast with
-  | One s -> func s
-  | Opt opt -> Opt (bind_func opt)
-  | Seq ss -> Seq (List.map bind_func ss)
-  | Choice ss -> Choice (List.map bind_func ss)
+  | One prim -> one prim
+  | Opt opt -> Opt (map_child opt)
+  | Seq seq -> Seq (List.map map_child seq)
+  | Choice choice -> Choice (List.map map_child choice)
+  | Predicate (pred,t) -> predicate pred (map_child t)
 
-let rec pp pp_prim ast =
-  let pp_with_prim = pp pp_prim in
+let bind ast func =
+  map ~one:func
+    ~predicate:(fun pred child -> Predicate (pred, child))
+    ast
+
+let rec pp pp_pred pp_prim ast =
   let ast = normalise ast in
+  let pp_wrap = pp pp_pred pp_prim in
   match ast with
   | One s -> Printf.sprintf "%s" (pp_prim s)
-  | Opt opt -> Printf.sprintf "%s?" (pp_with_prim opt)
+  | Opt opt -> Printf.sprintf "%s?" (pp_wrap opt)
   | Seq ss ->
-      Printf.sprintf "[%s]" (String.concat "," (List.map pp_with_prim ss))
+      Printf.sprintf "[%s]" (String.concat "," (List.map pp_wrap ss))
   | Choice ss ->
-      Printf.sprintf "[%s]" (String.concat "|" (List.map pp_with_prim ss))
+      Printf.sprintf "[%s]" (String.concat "|" (List.map pp_wrap ss))
+  | Predicate (pred,t) ->
+      Printf.sprintf "@%s(%s)" (pp_pred pred) (pp_wrap t)
 
 let list_cross_product_map f lhs rhs =
   List.map ( fun l ->
@@ -52,14 +62,18 @@ let list_cross_product_map f lhs rhs =
   ) lhs
   |> List.flatten
 
-let rec expand t =
+let rec expand pred_func t =
+  let expand_pred = expand pred_func in
   let result = match t with
   | One str -> [[str]]
-  | Opt opt -> [] :: expand opt
+  | Opt opt -> [] :: expand_pred opt
   | Seq seq -> List.fold_left
     ( fun acc s ->
-      expand s
+      expand_pred s
       |> list_cross_product_map ( @ ) acc
     ) [[]] seq
-  | Choice choice -> List.map expand choice |> List.flatten in
+  | Choice choice -> List.map expand_pred choice |> List.flatten
+  | Predicate (pred,t) ->
+      expand_pred t
+      |> List.map (List.map (fun e -> pred_func pred e)) in
   result

--- a/gen/common/ast.mli
+++ b/gen/common/ast.mli
@@ -1,18 +1,27 @@
 (* Abstract syntax tree for the relax-input grammar.
    The type parameter `'prim` is the leaf token type produced by the parser.
+   The type parameter `'pred` is the predicate type.
    - `One x` is a single primitive token.
    - `Opt t` is an optional sub-expression, i.e., `(t)?`.
    - `Seq ts` is an ordered sequence of sub-expressions, i.e., `A B C`
      or `A,B,C`.
-   - `Choice ts` is a choice between alternatives, i.e., `A|B|C`. *)
-type 'prim t =
+   - `Choice ts` is a choice between alternatives, i.e., `A|B|C`.
+   - `Predicate pred t` is an ast `t` decorated by predicate `pred`,
+      i.e., `@after(t)` where `after` is the predicate,
+   *)
+type ('pred,'prim) t =
   | One of 'prim
-  | Opt of 'prim t
-  | Seq of 'prim t list
-  | Choice of 'prim t list
+  | Opt of ('pred,'prim) t
+  | Seq of ('pred,'prim) t list
+  | Choice of ('pred,'prim) t list
+  | Predicate of 'pred * ('pred,'prim) t
 
-val bind : 'a t -> ('a -> 'b t) -> 'b t
-val pp : ('a -> string) -> 'a t -> string
+val bind : ('pred,'prim) t -> ('prim -> ('pred,'new_prim) t) -> ('pred,'new_prim) t
+
+(* Transform predicate labels without changing primitive leaves or AST shape. *)
+val map_predicate : ('pred -> 'new_pred) -> ('pred,'prim) t -> ('new_pred,'prim) t
+
+val pp : ('pred -> string) -> ('prim -> string) -> ('pred,'prim) t -> string
 
 (* Flatten the AST into the list of concrete sequences.
    - `One x` expands to `[[x]]`.
@@ -23,6 +32,8 @@ val pp : ('a -> string) -> 'a t -> string
      If `A` expands to `[[X; Y]; [Z]]` and `B` to `[[K]; [M; N]]`,
      then `Seq [A; B]` expands to
      `[ [X; Y; K]; [X; Y; M; N]; [Z; K]; [Z; M; N] ]`.
+   - `Predicate (pred, t)` expands `t` first then calls the passed in
+      function to combine `pred` into the expanded `t`.
    A concrete example is
    `Seq [Choice [One x; One y]; Opt (Seq [One z; One k])]`,
    which expands to `[[x]; [x; z; k]; [y]; [y; z; k]]`, where:
@@ -31,4 +42,4 @@ val pp : ('a -> string) -> 'a t -> string
    - `[y]` comes from `One y` followed by the empty alternative of `Opt`.
    - `[y; z; k]` comes from `One y` followed by `Seq [One z; One k]`.
    *)
-val expand : 'a t -> 'a list list
+val expand : ('pred -> 'prim -> 'prim) -> ('pred,'prim) t -> 'prim list list

--- a/gen/common/ast.mli
+++ b/gen/common/ast.mli
@@ -1,18 +1,34 @@
 (* Abstract syntax tree for the relax-input grammar.
    The type parameter `'prim` is the leaf token type produced by the parser.
+   The type parameter `'pred` is the predicate type.
    - `One x` is a single primitive token.
    - `Opt t` is an optional sub-expression, i.e., `(t)?`.
    - `Seq ts` is an ordered sequence of sub-expressions, i.e., `A B C`
      or `A,B,C`.
-   - `Choice ts` is a choice between alternatives, i.e., `A|B|C`. *)
-type 'prim t =
+   - `Choice ts` is a choice between alternatives, i.e., `A|B|C`.
+   - `Predicate pred t` is an ast `t` decorated by predicate `pred`,
+      i.e., `@after(t)` where `after` is the predicate,
+   *)
+type ('pred,'prim) t =
   | One of 'prim
-  | Opt of 'prim t
-  | Seq of 'prim t list
-  | Choice of 'prim t list
+  | Opt of ('pred,'prim) t
+  | Seq of ('pred,'prim) t list
+  | Choice of ('pred,'prim) t list
+  | Predicate of 'pred * ('pred,'prim) t
 
-val bind : 'a t -> ('a -> 'b t) -> 'b t
-val pp : ('a -> string) -> 'a t -> string
+val bind : ('pred,'prim) t -> ('prim -> ('pred,'new_prim) t) -> ('pred,'new_prim) t
+
+(* Transform leaves and predicate nodes. *)
+val map :
+  one:('prim -> ('new_pred,'new_prim) t) ->
+  predicate:
+    ('pred ->
+     (* The result of recursively mapping the predicate's child AST. *)
+     ('new_pred,'new_prim) t ->
+     ('new_pred,'new_prim) t) ->
+  ('pred,'prim) t -> ('new_pred,'new_prim) t
+
+val pp : ('pred -> string) -> ('prim -> string) -> ('pred,'prim) t -> string
 
 (* Flatten the AST into the list of concrete sequences.
    - `One x` expands to `[[x]]`.
@@ -23,6 +39,8 @@ val pp : ('a -> string) -> 'a t -> string
      If `A` expands to `[[X; Y]; [Z]]` and `B` to `[[K]; [M; N]]`,
      then `Seq [A; B]` expands to
      `[ [X; Y; K]; [X; Y; M; N]; [Z; K]; [Z; M; N] ]`.
+   - `Predicate (pred, t)` expands `t` first then calls the passed in
+      function to combine `pred` into the expanded `t`.
    A concrete example is
    `Seq [Choice [One x; One y]; Opt (Seq [One z; One k])]`,
    which expands to `[[x]; [x; z; k]; [y]; [y; z; k]]`, where:
@@ -31,4 +49,4 @@ val pp : ('a -> string) -> 'a t -> string
    - `[y]` comes from `One y` followed by the empty alternative of `Opt`.
    - `[y; z; k]` comes from `One y` followed by `Seq [One z; One k]`.
    *)
-val expand : 'a t -> 'a list list
+val expand : ('pred -> 'prim -> 'prim) -> ('pred,'prim) t -> 'prim list list

--- a/gen/common/config.ml
+++ b/gen/common/config.ml
@@ -159,7 +159,8 @@ let diycross_parser_syntax_doc =
 
 let diy7_parser_syntax_doc =
   parser_syntax_doc ^ "\n\
-   In `diy7`, top-level plain separators denote choice, so '[A B] C [D E]' has canonical form `[[A,B]|C|[D,E]]`."
+   In `diy7`, top-level plain separators denote choice, so '[A B] C [D E]' has canonical form `[[A,B]|C|[D,E]]`.\n\
+   `diy7` also accepts predicate decorators such as `@before(...)` and `@after(...)`; these are not accepted by the shared `diyone7` or `diycross7` parsers."
 
 let cumul_parser_syntax_doc =
   " `false` disables non-explicit fence cumulativity, `true` enables all fence cumulativity, and any other value is parsed as a set of fences.\n\

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -862,7 +862,7 @@ let fold_tedges f r =
      - `remaining` is the unconsumed suffix of `es`. *)
   let rec merge_left (e:edge) (es:edge list) : (bool * edge option * edge list) =
     let is_default e = match e with
-      | { edge=Id; a1=None; a2=None } -> true
+      | { edge=Id; a1=None; a2=None; } -> true
       | _ -> false in
     try
       let store_insert,next,rest = find_next_merge es in
@@ -1103,7 +1103,7 @@ let fold_tedges f r =
             fold_atomo
               (fun ao k ->
                 if is_ifetch ao then k
-                else { edge=Id; a1=ao; a2=ao}::k)
+                else { edge=Id; a1=ao; a2=ao;}::k)
               [] in
           List.iter
             (fun e -> eprintf " %s" (pp_edge e))

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -64,6 +64,10 @@ module type S = sig
     | Hat
     | Rmw of RMW.rmw  (* Various sorts of read-modify-write *)
 
+  type edge_predicate =
+    | Before
+    | After
+
   val is_id : tedge -> bool
   val is_node : tedge -> bool
   val is_insert_store : tedge -> bool
@@ -72,7 +76,7 @@ module type S = sig
   val compute_rmw : RMW.rmw -> value -> value -> value
   val is_valid_rmw : RMW.rmw list -> bool
 
-  type edge = { edge: tedge;  a1:atom option; a2: atom option; }
+  type edge = { edge: tedge;  a1:atom option; a2: atom option; pred : edge_predicate option }
 
   val plain_edge : tedge -> edge
 
@@ -134,6 +138,12 @@ module type S = sig
 
 (* Resolve Irr directions and unspecified atom *)
   val resolve_edges : edge list -> edge list
+
+(* Add `predicate` to `edge` *)
+  val add_predicate : edge_predicate -> edge -> edge
+
+(* parse `predicate` *)
+  val parse_predicate : string -> edge_predicate
 
 (* Atomic variation over yet unspecified atoms *)
   val varatom : edge list -> (edge list -> 'a -> 'a) -> 'a -> 'a
@@ -199,7 +209,7 @@ and module RMW = A.RMW = struct
   let pre_parse_string s =
     let parsed_result = Lexing.from_string (String.trim s)
     |> LexUtil.parse Parser.main
-    |> Ast.expand in
+    |> Ast.expand (fun _ -> Warn.fatal "predicate should not exist.") in
     match parsed_result with
       | [x] -> x
       | _ ->
@@ -268,13 +278,17 @@ and module RMW = A.RMW = struct
     |Dp (dp, _, _) -> F.is_addr dp
     |_ -> false
 
-  type edge = { edge: tedge;  a1:atom option; a2: atom option; }
+  type edge_predicate =
+    | Before
+    | After
+
+  type edge = { edge: tedge;  a1:atom option; a2: atom option; pred : edge_predicate option }
 
   let can_merge e = not @@ is_insert_store e.edge
 
   open Printf
 
-  let plain_edge e = { a1=None; a2=None; edge=e; }
+  let plain_edge e = { a1=None; a2=None; edge=e; pred = None}
 
   let pp_plain = A.pp_plain
 
@@ -319,12 +333,26 @@ and module RMW = A.RMW = struct
       "{edge=%s, a1=%s, a2=%s}"
       (pp_tedge e.edge) (pp_atom_option e.a1) (pp_atom_option e.a2)
 
+  let pp_predicate = function
+    | Before -> "before"
+    | After -> "after"
+
   let pp_edge_compat compat e =
     let edge = match e.edge with
     | Id -> ""
     | _ -> pp_tedge_compat compat e.edge in
     let annotation = pp_annotations e.edge e.a1 e.a2 in
     edge ^ annotation
+
+  let do_pp_edge compat pp_atom_functor e =
+    let annotation = pp_atom_functor e.edge e.a1 e.a2 in
+    let edge = match e.edge with
+    | Id -> ""
+    | _ -> pp_edge_compat compat e.edge in
+    let edge_anno = edge ^ annotation in
+    match e.pred with
+    | None -> edge_anno
+    | Some pred -> sprintf "@%s(%s)" (pp_predicate pred) edge_anno
 
   let pp_edge e = pp_edge_compat false e
 
@@ -575,10 +603,10 @@ let fold_tedges f r =
     if do_self && instr_atom != None then
       iter_ie
         (fun ie ->
-           add_lxm_edge (sprintf "Iff%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); } ;
-           add_lxm_edge (sprintf "Irf%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); } ;
-           add_lxm_edge (sprintf "Fif%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); } ;
-           add_lxm_edge (sprintf "Ifr%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); });
+           add_lxm_edge (sprintf "Iff%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); pred = None} ;
+           add_lxm_edge (sprintf "Irf%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); pred = None} ;
+           add_lxm_edge (sprintf "Fif%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); pred = None} ;
+           add_lxm_edge (sprintf "Ifr%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); pred = None});
     ()
 
   let fold_pp_edges f =
@@ -862,7 +890,7 @@ let fold_tedges f r =
      - `remaining` is the unconsumed suffix of `es`. *)
   let rec merge_left (e:edge) (es:edge list) : (bool * edge option * edge list) =
     let is_default e = match e with
-      | { edge=Id; a1=None; a2=None; } -> true
+      | { edge=Id; a1=None; a2=None; pred=None } -> true
       | _ -> false in
     try
       let store_insert,next,rest = find_next_merge es in
@@ -969,6 +997,13 @@ let fold_tedges f r =
     let es = if do_mixed then List.map replace_plain es else es in
     validate_edges es ;
     es
+
+  let add_predicate pred e = {e with pred = Some pred}
+
+  let parse_predicate = function
+    | "before" -> Before
+    | "after" -> After
+    | s -> Warn.user_error "predicate %s is not supported." s
 
 (********************)
 (* Atomic variation *)
@@ -1103,7 +1138,7 @@ let fold_tedges f r =
             fold_atomo
               (fun ao k ->
                 if is_ifetch ao then k
-                else { edge=Id; a1=ao; a2=ao;}::k)
+                else { edge=Id; a1=ao; a2=ao;pred=None}::k)
               [] in
           List.iter
             (fun e -> eprintf " %s" (pp_edge e))

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -199,7 +199,7 @@ and module RMW = A.RMW = struct
   let pre_parse_string s =
     let parsed_result = Lexing.from_string (String.trim s)
     |> LexUtil.parse Parser.main
-    |> Ast.expand in
+    |> Ast.expand (fun _ -> Warn.fatal "predicate should not exist.") in
     match parsed_result with
       | [x] -> x
       | _ ->

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -144,6 +144,7 @@ module type S = sig
 
 (* parse `predicate` *)
   val parse_predicate : string -> edge_predicate
+  val get_predicate : edge -> edge_predicate option
 
 (* Atomic variation over yet unspecified atoms *)
   val varatom : edge list -> (edge list -> 'a -> 'a) -> 'a -> 'a
@@ -337,22 +338,17 @@ and module RMW = A.RMW = struct
     | Before -> "before"
     | After -> "after"
 
-  let pp_edge_compat compat e =
+  let do_pp_edge compat e =
     let edge = match e.edge with
     | Id -> ""
     | _ -> pp_tedge_compat compat e.edge in
     let annotation = pp_annotations e.edge e.a1 e.a2 in
-    edge ^ annotation
-
-  let do_pp_edge compat pp_atom_functor e =
-    let annotation = pp_atom_functor e.edge e.a1 e.a2 in
-    let edge = match e.edge with
-    | Id -> ""
-    | _ -> pp_edge_compat compat e.edge in
     let edge_anno = edge ^ annotation in
     match e.pred with
     | None -> edge_anno
     | Some pred -> sprintf "@%s(%s)" (pp_predicate pred) edge_anno
+
+  let pp_edge_compat compat e = do_pp_edge compat e
 
   let pp_edge e = pp_edge_compat false e
 
@@ -648,7 +644,7 @@ let fold_tedges f r =
   let lookup_atom_prefix string =
     fold_prefixes (fun prefix -> Hashtbl.find_opt annotation_lookup_table prefix) string
 
-  let annotation_edge a = { a1=a; a2=a; edge=Id }
+  let annotation_edge a = { a1=a; a2=a; edge=Id; pred=None }
 
   let parse_annotation input =
     match lookup_atom_prefix input with
@@ -1004,6 +1000,8 @@ let fold_tedges f r =
     | "before" -> Before
     | "after" -> After
     | s -> Warn.user_error "predicate %s is not supported." s
+
+  let get_predicate e = e.pred
 
 (********************)
 (* Atomic variation *)

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -64,10 +64,6 @@ module type S = sig
     | Hat
     | Rmw of RMW.rmw  (* Various sorts of read-modify-write *)
 
-  type edge_predicate =
-    | Before
-    | After
-
   val is_id : tedge -> bool
   val is_node : tedge -> bool
   val is_insert_store : tedge -> bool
@@ -76,7 +72,7 @@ module type S = sig
   val compute_rmw : RMW.rmw -> value -> value -> value
   val is_valid_rmw : RMW.rmw list -> bool
 
-  type edge = { edge: tedge;  a1:atom option; a2: atom option; pred : edge_predicate option }
+  type edge = { edge: tedge;  a1:atom option; a2: atom option; }
 
   val plain_edge : tedge -> edge
 
@@ -138,13 +134,6 @@ module type S = sig
 
 (* Resolve Irr directions and unspecified atom *)
   val resolve_edges : edge list -> edge list
-
-(* Add `predicate` to `edge` *)
-  val add_predicate : edge_predicate -> edge -> edge
-
-(* parse `predicate` *)
-  val parse_predicate : string -> edge_predicate
-  val get_predicate : edge -> edge_predicate option
 
 (* Atomic variation over yet unspecified atoms *)
   val varatom : edge list -> (edge list -> 'a -> 'a) -> 'a -> 'a
@@ -279,17 +268,13 @@ and module RMW = A.RMW = struct
     |Dp (dp, _, _) -> F.is_addr dp
     |_ -> false
 
-  type edge_predicate =
-    | Before
-    | After
-
-  type edge = { edge: tedge;  a1:atom option; a2: atom option; pred : edge_predicate option }
+  type edge = { edge: tedge;  a1:atom option; a2: atom option; }
 
   let can_merge e = not @@ is_insert_store e.edge
 
   open Printf
 
-  let plain_edge e = { a1=None; a2=None; edge=e; pred = None}
+  let plain_edge e = { a1=None; a2=None; edge=e; }
 
   let pp_plain = A.pp_plain
 
@@ -334,21 +319,12 @@ and module RMW = A.RMW = struct
       "{edge=%s, a1=%s, a2=%s}"
       (pp_tedge e.edge) (pp_atom_option e.a1) (pp_atom_option e.a2)
 
-  let pp_predicate = function
-    | Before -> "before"
-    | After -> "after"
-
-  let do_pp_edge compat e =
+  let pp_edge_compat compat e =
     let edge = match e.edge with
     | Id -> ""
     | _ -> pp_tedge_compat compat e.edge in
     let annotation = pp_annotations e.edge e.a1 e.a2 in
-    let edge_anno = edge ^ annotation in
-    match e.pred with
-    | None -> edge_anno
-    | Some pred -> sprintf "@%s(%s)" (pp_predicate pred) edge_anno
-
-  let pp_edge_compat compat e = do_pp_edge compat e
+    edge ^ annotation
 
   let pp_edge e = pp_edge_compat false e
 
@@ -599,10 +575,10 @@ let fold_tedges f r =
     if do_self && instr_atom != None then
       iter_ie
         (fun ie ->
-           add_lxm_edge (sprintf "Iff%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); pred = None} ;
-           add_lxm_edge (sprintf "Irf%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); pred = None} ;
-           add_lxm_edge (sprintf "Fif%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); pred = None} ;
-           add_lxm_edge (sprintf "Ifr%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); pred = None});
+           add_lxm_edge (sprintf "Iff%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); } ;
+           add_lxm_edge (sprintf "Irf%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); } ;
+           add_lxm_edge (sprintf "Fif%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); } ;
+           add_lxm_edge (sprintf "Ifr%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); });
     ()
 
   let fold_pp_edges f =
@@ -644,7 +620,7 @@ let fold_tedges f r =
   let lookup_atom_prefix string =
     fold_prefixes (fun prefix -> Hashtbl.find_opt annotation_lookup_table prefix) string
 
-  let annotation_edge a = { a1=a; a2=a; edge=Id; pred=None }
+  let annotation_edge a = { a1=a; a2=a; edge=Id }
 
   let parse_annotation input =
     match lookup_atom_prefix input with
@@ -886,7 +862,7 @@ let fold_tedges f r =
      - `remaining` is the unconsumed suffix of `es`. *)
   let rec merge_left (e:edge) (es:edge list) : (bool * edge option * edge list) =
     let is_default e = match e with
-      | { edge=Id; a1=None; a2=None; pred=None } -> true
+      | { edge=Id; a1=None; a2=None } -> true
       | _ -> false in
     try
       let store_insert,next,rest = find_next_merge es in
@@ -993,15 +969,6 @@ let fold_tedges f r =
     let es = if do_mixed then List.map replace_plain es else es in
     validate_edges es ;
     es
-
-  let add_predicate pred e = {e with pred = Some pred}
-
-  let parse_predicate = function
-    | "before" -> Before
-    | "after" -> After
-    | s -> Warn.user_error "predicate %s is not supported." s
-
-  let get_predicate e = e.pred
 
 (********************)
 (* Atomic variation *)
@@ -1136,7 +1103,7 @@ let fold_tedges f r =
             fold_atomo
               (fun ao k ->
                 if is_ifetch ao then k
-                else { edge=Id; a1=ao; a2=ao;pred=None}::k)
+                else { edge=Id; a1=ao; a2=ao}::k)
               [] in
           List.iter
             (fun e -> eprintf " %s" (pp_edge e))

--- a/gen/common/lexUtil.mll
+++ b/gen/common/lexUtil.mll
@@ -36,6 +36,7 @@ let is_singleton stack = List.length !stack = 1
 
 let blank = [' ''\t''\n''\r']
 let relexation = ['A'-'Z' 'a'-'z' '0'-'9' '-' '.' '*']+
+let predicate = ['A'-'Z' 'a'-'z' '0'-'9' '_']+
 
 (* The lexer consumes optional blanks around explicit syntax such as `[`, `]`,
    `,`, `|`, and `?`, because, for backward compatibility, standalone blanks
@@ -59,9 +60,21 @@ rule token has_previous_relaxation = parse
   modify true has_previous_relaxation;
   RELAXATION lxm
 }
+| '@' (predicate as pred) blank* {
+  PREDICATE pred
+}
+| '(' blank* {
+  LEFT_BRACKET
+}
+| blank* ')' {
+  RIGHT_BRACKET
+}
 | blank+ {
   if peak has_previous_relaxation then COMMA
   else token has_previous_relaxation lexbuf
+}
+| _ {
+  raise Parser.Error
 }
 {
 

--- a/gen/common/parser.mly
+++ b/gen/common/parser.mly
@@ -1,24 +1,26 @@
+%token <string> PREDICATE
+%token LEFT_BRACKET RIGHT_BRACKET
 %token <string> RELAXATION
 %token LEFT_SQUARE RIGHT_SQUARE
 %token COMMA
 %token CHOICE_BAR
 %token EOF
 %token OPTION
-%start <string Ast.t> main
-%start <string Ast.t> main_top_level_choice
-%start <string Ast.t> cumul
+%start <(string,string) Ast.t> main
+%start <(string,string) Ast.t> diycross7
+%start <(string,string) Ast.t> diy7
+%start <(string,string) Ast.t> cumul
 
 %%
 
 main:
   | r = relax EOF { r }
 
-  (* In `diycross7`, `diy7`,
-     the top level `,` and whitespace should be treated as `Choice`
+  (* In `diycross7`, the top level `,` and whitespace should be treated as `Choice`
      rather than the default `Seq` *)
-main_top_level_choice:
+diycross7:
   | r = choice EOF { r }
-  | lhs = choice COMMA rhs = main_top_level_choice { Ast.Choice [lhs ; rhs] }
+  | lhs = choice COMMA rhs = diycross7 { Ast.Choice [lhs ; rhs] }
 
 (* Explicit precedence, from highest to lowest:
    - `suffix` handles postfix `?` and atomic terms such as `[..]`,
@@ -37,6 +39,26 @@ suffix:
   | opt = suffix OPTION { Ast.Opt opt }
   | r = RELAXATION { Ast.One r }
   | LEFT_SQUARE r = relax RIGHT_SQUARE { r }
+
+(* In `diy7`, top level `,` and whitespace are `Choice`, and `@predicate(...)`
+   may decorate a relaxation expression. *)
+diy7:
+  | r = diy7_choice EOF { r }
+  | lhs = diy7_choice COMMA rhs = diy7 { Ast.Choice [lhs ; rhs] }
+
+diy7_relax:
+  | lhs = diy7_choice COMMA rhs = diy7_relax { Ast.Seq [lhs ; rhs] }
+  | r = diy7_choice { r }
+
+diy7_choice:
+  | lhs = diy7_suffix CHOICE_BAR rhs = diy7_choice { Ast.Choice [lhs ; rhs] }
+  | r = diy7_suffix { r }
+
+diy7_suffix:
+  | opt = diy7_suffix OPTION { Ast.Opt opt }
+  | r = RELAXATION { Ast.One r }
+  | LEFT_SQUARE r = diy7_relax RIGHT_SQUARE { r }
+  | pred = PREDICATE LEFT_BRACKET r = diy7_relax RIGHT_BRACKET { Ast.Predicate (pred,r) }
 
 
 (* In `diy7 -cumul`,

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -34,14 +34,14 @@ open C.E
 open C.R
 
   let parse_argument_ast input =
-    String.trim input |> parse_ast Parser.main_top_level_choice
+    String.trim input |> parse_ast Parser.diy7
 
   (* Parse the `-cumul` argument, which should be a list of individual fences. *)
   let parse_fences input_fences =
     let ast = String.trim input_fences |> parse_ast Parser.cumul in
     (* Note that `parse_fence` might fail *)
     let fences = Ast.bind ast ( fun input -> Ast.One(C.E.parse_fence input) )
-    |> Ast.expand in
+    |> Ast.expand ( fun _ -> Warn.user_error "cumul input: %s contains predicate." input_fences ) in
     (* Each expanded alternative must contain exactly one fence. *)
     if List.for_all ( function [_] -> true | _ -> false ) fences then
       List.flatten fences

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -41,7 +41,7 @@ open C.R
     let ast = String.trim input_fences |> parse_ast Parser.cumul in
     (* Note that `parse_fence` might fail *)
     let fences = Ast.bind ast ( fun input -> Ast.One(C.E.parse_fence input) )
-    |> Ast.expand ( fun _ -> Warn.user_error "cumul input: %s contains predicate." input_fences ) in
+    |> Ast.expand ( fun _ -> Warn.fatal "cumul input: %s contains predicate." input_fences ) in
     (* Each expanded alternative must contain exactly one fence. *)
     if List.for_all ( function [_] -> true | _ -> false ) fences then
       List.flatten fences

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -33,9 +33,6 @@ module Make(C:Builder.S)(O:DiyConfig) = struct
 open C.E
 open C.R
 
-  let parse_argument_ast input =
-    String.trim input |> parse_ast Parser.diy7
-
   (* Parse the `-cumul` argument, which should be a list of individual fences. *)
   let parse_fences input_fences =
     let ast = String.trim input_fences |> parse_ast Parser.cumul in
@@ -47,64 +44,14 @@ open C.R
       List.flatten fences
     else Warn.user_error "%s is not a list of fence" input_fences
 
-  let varatom_ess =
-    if C.A.bellatom then Misc.identity
-    else match O.varatom with
-    | [] -> Misc.identity
-    | ["all"] ->
-        let module Fold = struct
-          type atom = C.E.atom
-          let fold = C.E.fold_atomo
-        end in
-        let module V = VarAtomic.Make(C.E)(Fold) in
-        V.varatom_es
-    | atoms ->
-        let atoms = C.E.parse_atoms atoms in
-        let module Fold = struct
-          type atom = C.E.atom
-          let fold f k = C.E.fold_atomo_list atoms f k
-        end in
-        let module V = VarAtomic.Make(C.E)(Fold) in
-        V.varatom_es
-
-  (* Parse an input relaxation expression such as "[Po DpAddr] Fre".
-     In canonical form this is "[Po,DpAddr]|Fre": top-level whitespace denotes
-     a choice for backward compatibility. If an explicit top-level choice is
-     present, an explicit comma still keeps a sequence together. The result is
-     a list of unfolded relaxations, each represented as one or more edges in
-     sequence. *)
-  let parse_argument input_argument =
-    parse_argument_ast input_argument
-    |> parse_expand_relaxs ~ppo:C.ppo
-    |> varatom_ess
-    |> remove_invalid_relaxes
-
-  let parse_argument_list input_argument_list =
-    List.map parse_argument input_argument_list
-    |> List.flatten
-    |> remove_invalid_relaxes
-
   module AltConfig = struct
     include O
 
-    type relax = C.R.relax
     let mix = !Config.mix
     let max_relax = !Config.max_relax
     let min_relax = !Config.min_relax
 
-    let prefix =
-      (* Parse each `-prefix` argument separately, then combine them as one
-         top-level choice. Thus `-prefix A -prefix B` is interpreted as
-         `-prefix [A|B]`. *)
-      let prefixes =
-        List.map parse_argument_ast O.prefix
-        |> fun prefixes -> Ast.Choice prefixes
-        |> parse_expand_relaxs ~ppo:C.ppo
-        (* Wrap each relax into a list *)
-        |> List.map (fun prefix -> [prefix]) in
-      match prefixes with
-      | [] -> [[]] (* No prefix <=> one empty prefix *)
-      | prefixes -> prefixes
+    let prefix = O.prefix
 
     let variant = O.variant
 
@@ -121,28 +68,27 @@ open C.R
   end
 
 
-  module M =  Alt.Make(C)(AltConfig)
+  module M = Alt.Make(C)(AltConfig)
 
   let gen lr ls rl n =
     if O.verbose > 0 then begin
-      Printf.eprintf
-        "expanded relax=%s\n" (C.R.pp_relax_list lr)
+      let plain_relax = List.map M.plain lr in
+      Printf.eprintf "expanded relax=%s\n" (C.R.pp_relax_list plain_relax)
     end ;
     M.gen ~relax:lr ~safe:ls ~reject:rl n
 
-  let er e = [plain_edge e]
+  let er es = List.map (fun e -> M.lift [plain_edge e]) es
 
   let gen_thin n =
-    let lr = [er (Rf Int); er (Rf Ext)]
-    and ls = C.ppo Misc.cons [] in
+    let lr = er [Rf Int; Rf Ext]
+    and ls = List.map M.lift (C.ppo Misc.cons []) in
     M.gen ~relax:lr ~safe:ls n
 
 
   let gen_uni n =
-    let lr = [er (Rf Int); er (Rf Ext)]
+    let lr = er [Rf Int; Rf Ext]
     and ls =
-      [er (Ws Int); er (Ws Ext); er (Fr Int);
-       er (Fr Ext); er (Po (Same,Irr,Irr))] in
+      er [Ws Int; Ws Ext; Fr Int; Fr Ext; Po (Same,Irr,Irr)] in
     M.gen ~relax:lr ~safe:ls n
 
   let go n (*size*) orl olr ols (*relax and safe lists*) =
@@ -288,37 +234,33 @@ let () =
   in
   let module Builder = (val builder : Builder.S) in
   let module M = Make(Builder)(Co) in
+  let module Alt = M.M in
   try
     (* Parse inputs `relax` `safe` and `reject` *)
-    let r_nempty = Misc.consp !Config.relaxs in
-    let relax = M.parse_argument_list !Config.relaxs in
-    (* If the user supplied the `relax` argument,
-       raise an error when none expand to usable relaxations. *)
-    if Misc.nilp relax then if r_nempty then begin
-      Warn.fatal "relaxations provided in relaxlist could not be used to generate cycles"
-    end ;
-    let safe = M.parse_argument_list !Config.safes in
-    let reject = M.parse_argument_list !Config.rejects in
+    let relax,safe,reject =
+      Alt.parse_input ~relax:!Config.relaxs ~safe:!Config.safes ~reject:!Config.rejects in
     match !Config.filter_check with
     | [lhs;rhs] ->
-        let lhs_unfold = M.parse_argument lhs in
-        let rhs_unfold = M.parse_argument rhs in
+        let lhs_unfold = Alt.parse_argument lhs in
+        let rhs_unfold = Alt.parse_argument rhs in
         List.map ( fun l ->
           List.map ( fun r ->
-            l,r,M.M.filter_check ~relax ~safe l r
+            l,r,M.M.filter_check ~safe l r
           ) rhs_unfold
         ) lhs_unfold
         |> List.flatten
         |> List.iter ( fun (l, r, result) ->
             printf "Sequence `%s` `%s` %s the internal filter in mode `%s`\n"
-            (Builder.R.pp_relax l) (Builder.R.pp_relax r)
+            (Builder.R.pp_relax (Alt.plain l)) (Builder.R.pp_relax (Alt.plain r))
             ( if result then "passes" else "is prohibited in" )
             ( Code.pp_check Co.choice )
         )
     | _ -> (* The common path to generate tests *)
       if !Config.unfold_only then
         printf "***relax***\n%s\n***safe***\n%s\n***reject***\n%s\n"
-        (Builder.R.pp_relax_list relax) (Builder.R.pp_relax_list safe) (Builder.R.pp_relax_list reject)
+          (Alt.pp_predicate_relax_list relax)
+          (Alt.pp_predicate_relax_list safe)
+          (Alt.pp_predicate_relax_list reject)
       else
         M.go !Config.size reject relax safe;
     exit 0

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -33,78 +33,25 @@ module Make(C:Builder.S)(O:DiyConfig) = struct
 open C.E
 open C.R
 
-  let parse_argument_ast input =
-    String.trim input |> parse_ast Parser.main_top_level_choice
-
   (* Parse the `-cumul` argument, which should be a list of individual fences. *)
   let parse_fences input_fences =
     let ast = String.trim input_fences |> parse_ast Parser.cumul in
     (* Note that `parse_fence` might fail *)
     let fences = Ast.bind ast ( fun input -> Ast.One(C.E.parse_fence input) )
-    |> Ast.expand in
+    |> Ast.expand ( fun _ -> Warn.fatal "cumul input: %s contains predicate." input_fences ) in
     (* Each expanded alternative must contain exactly one fence. *)
     if List.for_all ( function [_] -> true | _ -> false ) fences then
       List.flatten fences
     else Warn.user_error "%s is not a list of fence" input_fences
 
-  let varatom_ess =
-    if C.A.bellatom then Misc.identity
-    else match O.varatom with
-    | [] -> Misc.identity
-    | ["all"] ->
-        let module Fold = struct
-          type atom = C.E.atom
-          let fold = C.E.fold_atomo
-        end in
-        let module V = VarAtomic.Make(C.E)(Fold) in
-        V.varatom_es
-    | atoms ->
-        let atoms = C.E.parse_atoms atoms in
-        let module Fold = struct
-          type atom = C.E.atom
-          let fold f k = C.E.fold_atomo_list atoms f k
-        end in
-        let module V = VarAtomic.Make(C.E)(Fold) in
-        V.varatom_es
-
-  (* Parse an input relaxation expression such as "[Po DpAddr] Fre".
-     In canonical form this is "[Po,DpAddr]|Fre": top-level whitespace denotes
-     a choice for backward compatibility. If an explicit top-level choice is
-     present, an explicit comma still keeps a sequence together. The result is
-     a list of unfolded relaxations, each represented as one or more edges in
-     sequence. *)
-  let parse_argument input_argument =
-    parse_argument_ast input_argument
-    |> parse_expand_relaxs ~ppo:C.ppo
-    |> varatom_ess
-    |> remove_invalid_relaxes
-
-  let parse_argument_list input_argument_list =
-    List.map parse_argument input_argument_list
-    |> List.flatten
-    |> remove_invalid_relaxes
-
   module AltConfig = struct
     include O
 
-    type relax = C.R.relax
     let mix = !Config.mix
     let max_relax = !Config.max_relax
     let min_relax = !Config.min_relax
 
-    let prefix =
-      (* Parse each `-prefix` argument separately, then combine them as one
-         top-level choice. Thus `-prefix A -prefix B` is interpreted as
-         `-prefix [A|B]`. *)
-      let prefixes =
-        List.map parse_argument_ast O.prefix
-        |> fun prefixes -> Ast.Choice prefixes
-        |> parse_expand_relaxs ~ppo:C.ppo
-        (* Wrap each relax into a list *)
-        |> List.map (fun prefix -> [prefix]) in
-      match prefixes with
-      | [] -> [[]] (* No prefix <=> one empty prefix *)
-      | prefixes -> prefixes
+    let prefix = O.prefix
 
     let variant = O.variant
 
@@ -121,29 +68,29 @@ open C.R
   end
 
 
-  module M =  Alt.Make(C)(AltConfig)
+  module M = Alt.Make(C)(AltConfig)
 
   let gen lr ls rl n =
     if O.verbose > 0 then begin
-      Printf.eprintf
-        "expanded relax=%s\n" (C.R.pp_relax_list lr)
+      let plain_relax = List.map M.to_relax lr in
+      Printf.eprintf "expanded relax=%s\n" (C.R.pp_relax_list plain_relax)
     end ;
     M.gen ~relax:lr ~safe:ls ~reject:rl n
 
-  let er e = [plain_edge e]
+  let er es = List.map (fun e -> M.lift [plain_edge e]) es
 
   let gen_thin n =
-    let lr = [er (Communication (Rf,Int)); er (Communication (Rf,Ext))]
-    and ls = C.ppo Misc.cons [] in
+    let lr = er [Communication (Rf,Int); Communication (Rf,Ext)]
+    and ls = List.map M.lift (C.ppo Misc.cons []) in
     M.gen ~relax:lr ~safe:ls n
 
 
   let gen_uni n =
-    let lr = [er (Communication (Rf,Int)); er (Communication (Rf,Ext))]
+    let lr = er [Communication (Rf,Int); Communication (Rf,Ext)]
     and ls =
-      [er (Communication (Co,Int)); er (Communication (Co,Ext));
-       er (Communication (Fr,Int)); er (Communication (Fr,Ext));
-       er (Po (Same,Irr,Irr))] in
+      er [Communication (Co,Int); Communication (Co,Ext);
+          Communication (Fr,Int); Communication (Fr,Ext);
+          Po (Same,Irr,Irr)] in
     M.gen ~relax:lr ~safe:ls n
 
   let go n (*size*) orl olr ols (*relax and safe lists*) =
@@ -289,37 +236,31 @@ let () =
   in
   let module Builder = (val builder : Builder.S) in
   let module M = Make(Builder)(Co) in
+  let module Alt = M.M in
   try
     (* Parse inputs `relax` `safe` and `reject` *)
-    let r_nempty = Misc.consp !Config.relaxs in
-    let relax = M.parse_argument_list !Config.relaxs in
-    (* If the user supplied the `relax` argument,
-       raise an error when none expand to usable relaxations. *)
-    if Misc.nilp relax then if r_nempty then begin
-      Warn.fatal "relaxations provided in relaxlist could not be used to generate cycles"
-    end ;
-    let safe = M.parse_argument_list !Config.safes in
-    let reject = M.parse_argument_list !Config.rejects in
+    let relax,safe,reject =
+      Alt.parse_input ~relax:!Config.relaxs ~safe:!Config.safes ~reject:!Config.rejects in
     match !Config.filter_check with
     | [lhs;rhs] ->
-        let lhs_unfold = M.parse_argument lhs in
-        let rhs_unfold = M.parse_argument rhs in
+        let lhs_unfold = Alt.parse_argument lhs in
+        let rhs_unfold = Alt.parse_argument rhs in
         List.map ( fun l ->
           List.map ( fun r ->
-            l,r,M.M.filter_check ~relax ~safe l r
+            l,r,M.M.filter_check ~safe l r
           ) rhs_unfold
         ) lhs_unfold
         |> List.flatten
         |> List.iter ( fun (l, r, result) ->
             printf "Sequence `%s` `%s` %s the internal filter in mode `%s`\n"
-            (Builder.R.pp_relax l) (Builder.R.pp_relax r)
+            (Alt.pp_ess [l]) (Alt.pp_ess [r])
             ( if result then "passes" else "is prohibited in" )
             ( Code.pp_check Co.choice )
         )
     | _ -> (* The common path to generate tests *)
       if !Config.unfold_only then
         printf "***relax***\n%s\n***safe***\n%s\n***reject***\n%s\n"
-        (Builder.R.pp_relax_list relax) (Builder.R.pp_relax_list safe) (Builder.R.pp_relax_list reject)
+          (Alt.pp_ess relax) (Alt.pp_ess safe) (Alt.pp_ess reject)
       else
         M.go !Config.size reject relax safe;
     exit 0

--- a/gen/diycross.ml
+++ b/gen/diycross.ml
@@ -60,7 +60,7 @@ module Make (Config:Config) (M:Builder.S) =
          `diycross` cycle. Parse those arguments separately, then rebuild one
          top-level `Seq` before expansion. For example, `diycross7 A 'B|C' D` is
          treated as `A,(B|C),D`. *)
-      List.map (M.R.parse_ast Parser.main_top_level_choice) input
+      List.map (M.R.parse_ast Parser.diycross7) input
       |> fun e -> Ast.Seq e
       |> M.R.parse_expand_relaxs ~ppo:M.ppo
       |> varatom_ess

--- a/gen/dumpAll.ml
+++ b/gen/dumpAll.ml
@@ -171,7 +171,7 @@ module Make(Config:Config)(T:Builder.S)
            sigs : sigs ;     (* Signatures of compiled tests *)
            env : int Env.t ;     (* State for getting numeric names *)
            dup : int Env.t ;     (* State for getting fresh names *)
-           relaxed : T.R.SetSet.t ;
+           relaxed : StringSet.t ;
          }
 
       type check = edge list list -> bool
@@ -179,8 +179,8 @@ module Make(Config:Config)(T:Builder.S)
       (* `mk_info` is part of the prepared-test stage and should stay pure:
          it should only contain metadata derived earlier, not touch global
          state, perform I/O, or depend on output ordering. *)
-      type mk_info = info * T.R.Set.t
-      let no_info = [],T.R.Set.empty
+      type mk_info = info * string
+      let no_info = [],""
 
       type mk_name =  edge list -> string option
       let no_name _ = None
@@ -212,7 +212,7 @@ module Make(Config:Config)(T:Builder.S)
         { ntests = 0 ;
           sigs = sigs_init Config.no ;
           env = Env.empty; dup = Env.empty;
-          relaxed = T.R.SetSet.empty; }
+          relaxed = StringSet.empty; }
 
 (************************************** ****)
 (* Check duplicates, compile and dump test *)
@@ -228,7 +228,7 @@ module Make(Config:Config)(T:Builder.S)
       type prepared =
           {
            es : T.E.edge list ;
-           relax_set : T.R.Set.t ;
+           relax : string ;
            t : T.test ;
          }
 
@@ -254,10 +254,10 @@ module Make(Config:Config)(T:Builder.S)
         let es,c = T.C.resolve_edges es in
         let c,init = T.C.finish c in
         let cy = T.E.pp_edges es in
-        let info,relaxed = mk_info in
+        let info,relax = mk_info in
         let info = Config.info@("Cycle",cy)::info in
         let t = T.test_of_cycle "__tmp__" ~info ~check ~init es c in
-        { es; relax_set=relaxed; t; }
+        { es; relax; t; }
 
 (* Dump from prepared test, with specified scope tree *)
       let dump_test_st keep_name all_chan generated_test env n mk_st res =
@@ -271,7 +271,7 @@ module Make(Config:Config)(T:Builder.S)
         let t = T.set_scope t st in
         let res =
           { res with
-            env; dup; relaxed= T.R.SetSet.add generated_test.relax_set res.relaxed; } in
+            env; dup; relaxed=StringSet.add generated_test.relax res.relaxed; } in
         do_dump_test all_chan t res
 
       let dump_test all_chan mk_name mk_scope generated_test res =
@@ -290,7 +290,7 @@ module Make(Config:Config)(T:Builder.S)
             let t = T.set_name generated_test.t n in
             let res =
               { res with
-                env; dup; relaxed= T.R.SetSet.add generated_test.relax_set res.relaxed; } in
+                env; dup; relaxed=StringSet.add generated_test.relax res.relaxed; } in
             do_dump_test all_chan t res
         | Scope.Default ->
             let keep_name,mk_st =
@@ -304,7 +304,7 @@ module Make(Config:Config)(T:Builder.S)
         | Scope.Gen scs ->
             let res =
               { res with
-                env; relaxed= T.R.SetSet.add generated_test.relax_set res.relaxed; } in
+                env; relaxed=StringSet.add generated_test.relax res.relaxed; } in
             T.A.ScopeGen.gen scs (T.get_nprocs generated_test.t)
               (fun st res ->
                 let n = n ^ "+" ^ Namer.of_scope st in
@@ -317,7 +317,7 @@ module Make(Config:Config)(T:Builder.S)
         | Scope.All ->
             let res =
               { res with
-                env; relaxed= T.R.SetSet.add generated_test.relax_set res.relaxed; } in
+                env; relaxed=StringSet.add generated_test.relax res.relaxed; } in
             T.A.ScopeGen.all (T.get_nprocs generated_test.t)
               (fun st res ->
                 let n = n ^ "+" ^ Namer.of_scope st in
@@ -388,11 +388,9 @@ module Make(Config:Config)(T:Builder.S)
             print
               "Generator produced %d tests\n%!"
               res.ntests ;
-            if
-              T.R.SetSet.exists (fun r -> not (T.R.Set.is_empty r)) res.relaxed
-            then
-              print "Relaxations tested: %a\n"
-                T.R.pp_set_set res.relaxed) ;
+            if StringSet.exists (fun relax -> relax <> "") res.relaxed then
+              print "Relaxations tested: %s\n"
+                (StringSet.pp_str " " (sprintf "{%s}") res.relaxed)) ;
         Tar.tar () ;
         Hint.close_out Config.hout
 

--- a/gen/dumpAll.mli
+++ b/gen/dumpAll.mli
@@ -39,7 +39,7 @@ module Make(Config:Config) (T:Builder.S) : sig
   type info = (string * string) list
 
 (* Compute information *)
-  type mk_info = info * T.R.Set.t
+  type mk_info = info * string
   val no_info : mk_info
 
 (* Compute name *)

--- a/gen/logRelax.ml
+++ b/gen/logRelax.ml
@@ -17,7 +17,7 @@
 
 module type I = sig
   type relax
-  val parse : string Ast.t -> relax
+  val parse : (string,string) Ast.t -> relax
 end
 
 module type S = sig

--- a/gen/readRelax.ml
+++ b/gen/readRelax.ml
@@ -41,10 +41,10 @@ module Top = struct
 
   module R = struct
 
-    type relax = string Ast.t
+    type relax = (string,string) Ast.t
     let parse r = r
 
-    let pp_relax = Ast.pp Fun.id
+    let pp_relax = Ast.pp Fun.id Fun.id
 
 
     module Set =

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -46,6 +46,9 @@ module type S = sig
   val parse_sequence_ast : ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> (string,string) Ast.t) -> string list -> (string,string) Ast.t
   (* Parse the input relaxation (or relaxations sequences), and expand the wildcard
      syntax into primitive edges and annotations *)
+  val parse_expand_relaxs_ast :
+    ?ppo:((relax -> relax list -> relax list) -> relax list -> relax list)
+        -> (string,string) Ast.t -> (string,edge) Ast.t
   val parse_expand_relaxs :
     ?ppo:((relax -> relax list -> relax list) -> relax list -> relax list)
         -> (string,string) Ast.t -> relax list
@@ -121,18 +124,18 @@ and type edge = E.edge
           let open E in
           match r with
           | [e] -> E.pp_edge e
-          | [{edge=Rf Ext; a1=None;a2=None;pred=None};
-             {edge=Fenced _;a1=None; a2=None;pred=None} as e] when backward_compatibility ->
+          | [{edge=Rf Ext; a1=None;a2=None};
+             {edge=Fenced _;a1=None; a2=None} as e] when backward_compatibility ->
                  sprintf "AC%s" (pp_edge e)
-          | [{edge=Fenced _; a1=None;a2=None;pred=None} as e;
-             {edge=Rf Ext; a1=None; a2=None;pred=None}] when backward_compatibility ->
+          | [{edge=Fenced _; a1=None;a2=None} as e;
+             {edge=Rf Ext; a1=None; a2=None}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
-          | [{edge=Rf Ext; a1=None; a2=None;pred=None};
-             {edge=Fenced _; a1=None; a2=None;pred=None} as e;
-             {edge=Rf Ext; a1=None; a2=None;pred=None}] when backward_compatibility ->
+          | [{edge=Rf Ext; a1=None; a2=None};
+             {edge=Fenced _; a1=None; a2=None} as e;
+             {edge=Rf Ext; a1=None; a2=None}] when backward_compatibility ->
                    sprintf "ABC%s" (pp_edge e)
-          | [{edge=Dp _; a1=None; a2=None;pred=None} as e;
-             {edge=Rf Ext; a1=None; a2=None;pred=None}] when backward_compatibility ->
+          | [{edge=Dp _; a1=None; a2=None} as e;
+             {edge=Rf Ext; a1=None; a2=None}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
           | es ->
               sprintf "[%s]" (String.concat "," (List.map pp_edge es))
@@ -363,11 +366,15 @@ and type edge = E.edge
           expand_relaxs parsed_edges
           |> relax_list_to_choice
 
-          let parse_expand_relaxs ?(ppo=(fun _ k -> k)) ast =
-            let add_predicate pred =
-              E.add_predicate (E.parse_predicate pred) in
+          let parse_expand_relaxs_ast ?(ppo=(fun _ k -> k)) ast =
             Ast.bind ast (parse_expand_relax ~ppo)
-              |> Ast.expand add_predicate
+
+          let parse_expand_relaxs ?(ppo=(fun _ k -> k)) ast =
+            parse_expand_relaxs_ast ~ppo ast
+              |> Ast.expand
+                   (fun pred _ ->
+                     Warn.user_error
+                       "predicate %s is only supported by diy7 search." pred)
 
         (* After wildcard and macro expansion, remove invalid relaxations
            whose adjacent concrete edges cannot appear consecutively.
@@ -387,33 +394,12 @@ and type edge = E.edge
                     for_all_adjacent_concrete_edge predicate (rhs :: list)
                 | false, false ->
                     for_all_adjacent_concrete_edge predicate list in
-          (* `before` predicates must form a leading prefix and
-             `after` predicates must form a trailing suffix. *)
-          let leading_before_trailing_after_predicate list =
-            let valid,_,_ = List.fold_left
-            ( fun ( valid, leading_before, trailing_after ) l ->
-              match valid, leading_before, trailing_after, E.get_predicate l with
-              (* Propagate invalid flag *)
-              | false, _, _,_ -> (false, leading_before, trailing_after)
-              (* Process the leading edges while they are before predicates,
-                 until the first non-before edge. *)
-              | true, true, _, pred -> true, pred = Some E.Before, pred = Some E.After
-              (* A before predicate in the middle of the list *)
-              | true, false, trailing_after, pred when pred = Some E.Before ->
-                  false, false, trailing_after
-              (* Until find the first after predicate *)
-              | true, false, false, pred -> true, false, pred = Some E.After
-              (* Once trailing after predicates start, only after predicates may follow. *)
-              | true, false, true, pred -> pred = Some E.After, false, true
-            ) (true,true,false) list in
-            valid in
           List.filter
             (fun relax ->
               (* Drop empty alternatives introduced by `?`; they do not
                  describe an actual relaxation. *)
               relax <> []
               && for_all_adjacent_concrete_edge E.can_precede relax
-              && leading_before_trailing_after_predicate relax
             ) relaxes
           |> List.sort_uniq compare
 
@@ -439,13 +425,13 @@ and type edge = E.edge
         let is_cumul r =
           let open E in
           match r with
-          | [{edge=Rf Code.Ext; a1=None; a2=None; pred=None};
-             {edge=Fenced _; a1=None; a2=None; pred=None}]
-          | [{edge=Fenced _; a1=None; a2=None; pred=None};
-             {edge=Rf Code.Ext; a1=None; a2=None; pred=None};]
-          | [{edge=Rf Code.Ext; a1=None; a2=None; pred=None};
-             {edge=Fenced _; a1=None; a2=None; pred=None};
-             {edge=Rf Code.Ext; a1=None; a2=None; pred=None};]
+          | [{edge=Rf Code.Ext; a1=None; a2=None};
+             {edge=Fenced _; a1=None; a2=None}]
+          | [{edge=Fenced _; a1=None; a2=None};
+             {edge=Rf Code.Ext; a1=None; a2=None};]
+          | [{edge=Rf Code.Ext; a1=None; a2=None};
+             {edge=Fenced _; a1=None; a2=None};
+             {edge=Rf Code.Ext; a1=None; a2=None};]
             -> true
           | _ -> false
 

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -42,13 +42,13 @@ module type S = sig
   val po : relax list
 
   (* Parse the `input` to `Ast.t` using the input grammar *)
-  val parse_ast : ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> string Ast.t) -> string -> string Ast.t
+  val parse_ast : ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> (string,string) Ast.t) -> string -> (string,string) Ast.t
+  val parse_sequence_ast : ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> (string,string) Ast.t) -> string list -> (string,string) Ast.t
   (* Parse the input relaxation (or relaxations sequences), and expand the wildcard
      syntax into primitive edges and annotations *)
-  val parse_sequence_ast : ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> string Ast.t) -> string list -> string Ast.t
   val parse_expand_relaxs :
     ?ppo:((relax -> relax list -> relax list) -> relax list -> relax list)
-        -> string Ast.t -> relax list
+        -> (string,string) Ast.t -> relax list
 
   (* Remove invalid relax from the list *)
   val remove_invalid_relaxes : relax list -> relax list
@@ -121,18 +121,18 @@ and type edge = E.edge
           let open E in
           match r with
           | [e] -> E.pp_edge e
-          | [{edge=Rf Ext; a1=None;a2=None;};
-             {edge=Fenced _;a1=None; a2=None;} as e] when backward_compatibility ->
+          | [{edge=Rf Ext; a1=None;a2=None;pred=None};
+             {edge=Fenced _;a1=None; a2=None;pred=None} as e] when backward_compatibility ->
                  sprintf "AC%s" (pp_edge e)
-          | [{edge=Fenced _; a1=None;a2=None;} as e;
-             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
+          | [{edge=Fenced _; a1=None;a2=None;pred=None} as e;
+             {edge=Rf Ext; a1=None; a2=None;pred=None}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
-          | [{edge=Rf Ext; a1=None; a2=None;};
+          | [{edge=Rf Ext; a1=None; a2=None;pred=None};
              {edge=Fenced _; a1=None; a2=None;} as e;
-             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
+             {edge=Rf Ext; a1=None; a2=None;pred=None}] when backward_compatibility ->
                    sprintf "ABC%s" (pp_edge e)
-          | [{edge=Dp _; a1=None; a2=None;} as e;
-             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
+          | [{edge=Dp _; a1=None; a2=None;pred=None} as e;
+             {edge=Rf Ext; a1=None; a2=None;pred=None}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
           | es ->
               sprintf "[%s]" (String.concat "," (List.map pp_edge es))
@@ -416,13 +416,13 @@ and type edge = E.edge
         let is_cumul r =
           let open E in
           match r with
-          | [{edge=Rf Code.Ext; a1=None; a2=None;};
-             {edge=Fenced _; a1=None; a2=None;}]
-          | [{edge=Fenced _; a1=None; a2=None;};
-             {edge=Rf Code.Ext; a1=None; a2=None;};]
-          | [{edge=Rf Code.Ext; a1=None; a2=None;};
-             {edge=Fenced _; a1=None; a2=None;};
-             {edge=Rf Code.Ext; a1=None; a2=None;};]
+          | [{edge=Rf Code.Ext; a1=None; a2=None; pred=None};
+             {edge=Fenced _; a1=None; a2=None; pred=None}]
+          | [{edge=Fenced _; a1=None; a2=None; pred=None};
+             {edge=Rf Code.Ext; a1=None; a2=None; pred=None};]
+          | [{edge=Rf Code.Ext; a1=None; a2=None; pred=None};
+             {edge=Fenced _; a1=None; a2=None; pred=None};
+             {edge=Rf Code.Ext; a1=None; a2=None; pred=None};]
             -> true
           | _ -> false
 

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -387,6 +387,8 @@ and type edge = E.edge
                     for_all_adjacent_concrete_edge predicate (rhs :: list)
                 | false, false ->
                     for_all_adjacent_concrete_edge predicate list in
+          (* `before` predicates must form a leading prefix and
+             `after` predicates must form a trailing suffix. *)
           let leading_before_trailing_after_predicate list =
             let valid,_,_ = List.fold_left
             ( fun ( valid, leading_before, trailing_after ) l ->

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -387,13 +387,32 @@ and type edge = E.edge
                     for_all_adjacent_concrete_edge predicate (rhs :: list)
                 | false, false ->
                     for_all_adjacent_concrete_edge predicate list in
+          let leading_before_trailing_after_predicate list =
+            let valid,_,_ = List.fold_left
+            ( fun ( valid, leading_before, trailing_after ) l ->
+              match valid, leading_before, trailing_after, E.get_predicate l with
+              (* Propagate invalid flag *)
+              | false, _, _,_ -> (false, leading_before, trailing_after)
+              (* Process the leading edges while they are before predicates,
+                 until the first non-before edge. *)
+              | true, true, _, pred -> true, pred = Some E.Before, pred = Some E.After
+              (* A before predicate in the middle of the list *)
+              | true, false, trailing_after, pred when pred = Some E.Before ->
+                  false, false, trailing_after
+              (* Until find the first after predicate *)
+              | true, false, false, pred -> true, false, pred = Some E.After
+              (* Once trailing after predicates start, only after predicates may follow. *)
+              | true, false, true, pred -> pred = Some E.After, false, true
+            ) (true,true,false) list in
+            valid in
           List.filter
             (fun relax ->
               (* Drop empty alternatives introduced by `?`; they do not
                  describe an actual relaxation. *)
               relax <> []
-              && for_all_adjacent_concrete_edge E.can_precede relax)
-            relaxes
+              && for_all_adjacent_concrete_edge E.can_precede relax
+              && leading_before_trailing_after_predicate relax
+            ) relaxes
           |> List.sort_uniq compare
 
 (********)

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -124,18 +124,18 @@ and type edge = E.edge
           let open E in
           match r with
           | [e] -> E.pp_edge e
-          | [{edge=Rf Ext; a1=None;a2=None};
-             {edge=Fenced _;a1=None; a2=None} as e] when backward_compatibility ->
+          | [{edge=Rf Ext; a1=None;a2=None;};
+             {edge=Fenced _;a1=None; a2=None;} as e] when backward_compatibility ->
                  sprintf "AC%s" (pp_edge e)
-          | [{edge=Fenced _; a1=None;a2=None} as e;
-             {edge=Rf Ext; a1=None; a2=None}] when backward_compatibility ->
+          | [{edge=Fenced _; a1=None;a2=None;} as e;
+             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
-          | [{edge=Rf Ext; a1=None; a2=None};
-             {edge=Fenced _; a1=None; a2=None} as e;
-             {edge=Rf Ext; a1=None; a2=None}] when backward_compatibility ->
+          | [{edge=Rf Ext; a1=None; a2=None;};
+             {edge=Fenced _; a1=None; a2=None;} as e;
+             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
                    sprintf "ABC%s" (pp_edge e)
-          | [{edge=Dp _; a1=None; a2=None} as e;
-             {edge=Rf Ext; a1=None; a2=None}] when backward_compatibility ->
+          | [{edge=Dp _; a1=None; a2=None;} as e;
+             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
           | es ->
               sprintf "[%s]" (String.concat "," (List.map pp_edge es))
@@ -399,8 +399,8 @@ and type edge = E.edge
               (* Drop empty alternatives introduced by `?`; they do not
                  describe an actual relaxation. *)
               relax <> []
-              && for_all_adjacent_concrete_edge E.can_precede relax
-            ) relaxes
+              && for_all_adjacent_concrete_edge E.can_precede relax)
+            relaxes
           |> List.sort_uniq compare
 
 (********)
@@ -425,13 +425,13 @@ and type edge = E.edge
         let is_cumul r =
           let open E in
           match r with
-          | [{edge=Rf Code.Ext; a1=None; a2=None};
-             {edge=Fenced _; a1=None; a2=None}]
-          | [{edge=Fenced _; a1=None; a2=None};
-             {edge=Rf Code.Ext; a1=None; a2=None};]
-          | [{edge=Rf Code.Ext; a1=None; a2=None};
-             {edge=Fenced _; a1=None; a2=None};
-             {edge=Rf Code.Ext; a1=None; a2=None};]
+          | [{edge=Rf Code.Ext; a1=None; a2=None;};
+             {edge=Fenced _; a1=None; a2=None;}]
+          | [{edge=Fenced _; a1=None; a2=None;};
+             {edge=Rf Code.Ext; a1=None; a2=None;};]
+          | [{edge=Rf Code.Ext; a1=None; a2=None;};
+             {edge=Fenced _; a1=None; a2=None;};
+             {edge=Rf Code.Ext; a1=None; a2=None;};]
             -> true
           | _ -> false
 

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -42,13 +42,16 @@ module type S = sig
   val po : relax list
 
   (* Parse the `input` to `Ast.t` using the input grammar *)
-  val parse_ast : ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> string Ast.t) -> string -> string Ast.t
+  val parse_ast : ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> (string,string) Ast.t) -> string -> (string,string) Ast.t
+  val parse_sequence_ast : ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> (string,string) Ast.t) -> string list -> (string,string) Ast.t
   (* Parse the input relaxation (or relaxations sequences), and expand the wildcard
      syntax into primitive edges and annotations *)
-  val parse_sequence_ast : ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> string Ast.t) -> string list -> string Ast.t
+  val parse_expand_relaxs_ast :
+    ?ppo:((relax -> relax list -> relax list) -> relax list -> relax list)
+        -> (string,string) Ast.t -> (string,edge) Ast.t
   val parse_expand_relaxs :
     ?ppo:((relax -> relax list -> relax list) -> relax list -> relax list)
-        -> string Ast.t -> relax list
+        -> (string,string) Ast.t -> relax list
 
   (* Remove invalid relax from the list *)
   val remove_invalid_relaxes : relax list -> relax list
@@ -363,9 +366,15 @@ and type edge = E.edge
           expand_relaxs parsed_edges
           |> relax_list_to_choice
 
-          let parse_expand_relaxs ?(ppo=(fun _ k -> k)) ast =
+          let parse_expand_relaxs_ast ?(ppo=(fun _ k -> k)) ast =
             Ast.bind ast (parse_expand_relax ~ppo)
+
+          let parse_expand_relaxs ?(ppo=(fun _ k -> k)) ast =
+            parse_expand_relaxs_ast ~ppo ast
               |> Ast.expand
+                   (fun pred _ ->
+                     Warn.user_error
+                       "predicate %s is only supported by diy7 search." pred)
 
         (* After wildcard and macro expansion, remove invalid relaxations
            whose adjacent concrete edges cannot appear consecutively.

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -128,7 +128,7 @@ and type edge = E.edge
              {edge=Rf Ext; a1=None; a2=None;pred=None}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
           | [{edge=Rf Ext; a1=None; a2=None;pred=None};
-             {edge=Fenced _; a1=None; a2=None;} as e;
+             {edge=Fenced _; a1=None; a2=None;pred=None} as e;
              {edge=Rf Ext; a1=None; a2=None;pred=None}] when backward_compatibility ->
                    sprintf "ABC%s" (pp_edge e)
           | [{edge=Dp _; a1=None; a2=None;pred=None} as e;
@@ -364,8 +364,10 @@ and type edge = E.edge
           |> relax_list_to_choice
 
           let parse_expand_relaxs ?(ppo=(fun _ k -> k)) ast =
+            let add_predicate pred =
+              E.add_predicate (E.parse_predicate pred) in
             Ast.bind ast (parse_expand_relax ~ppo)
-              |> Ast.expand
+              |> Ast.expand add_predicate
 
         (* After wildcard and macro expansion, remove invalid relaxations
            whose adjacent concrete edges cannot appear consecutively.

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -15,6 +15,33 @@ A test for no metadata, `-metadata false`
    L00: LDR W4,[X3] ;
   
   exists (fault(P0:L00,x))
+A diy7 predicate merge test for before/after boundary predicates
+  $ diy7 -arch AArch64 -cycleonly true -size 4 -relax '[@before(Po) PodRW Rfe @after(Po)]' -safe Po 2>&1 | grep -v '^# Version' | grep -v '^Relaxations tested:'
+  # diy7 -arch AArch64 -cycleonly true -size 4 -relax [@before(Po) PodRW Rfe @after(Po)] -safe Po
+  Generator produced 2 tests
+  LB000: PosRR PodRW Rfe PosRR PodRW Rfe
+  LB001: PodRR PodRW Rfe PodRR PodRW Rfe
+A diy7 predicate merge test for repeated after predicates
+  $ diy7 -arch AArch64 -cycleonly true -size 4 -relax '[PodRW Rfe @after(PodRW) @after(Rfe)]' 2>&1 | grep -v '^# Version' | grep -v '^Relaxations tested:'
+  # diy7 -arch AArch64 -cycleonly true -size 4 -relax [PodRW Rfe @after(PodRW) @after(Rfe)]
+  Generator produced 3 tests
+  LB000: PodRW Rfe PodRW Rfe
+  3.LB000: PodRW Rfe PodRW Rfe PodRW Rfe
+  4.LB000: PodRW Rfe PodRW Rfe PodRW Rfe PodRW Rfe
+A diy7 predicate merge test for after on composite relaxations
+  $ diy7 -arch AArch64 -cycleonly true -size 4 -relax '[PodRW Rfe @after([PodRW Rfe])]' 2>&1 | grep -v '^# Version' | grep -v '^Relaxations tested:'
+  # diy7 -arch AArch64 -cycleonly true -size 4 -relax [PodRW Rfe @after([PodRW Rfe])]
+  Generator produced 3 tests
+  LB000: PodRW Rfe PodRW Rfe
+  3.LB000: PodRW Rfe PodRW Rfe PodRW Rfe
+  4.LB000: PodRW Rfe PodRW Rfe PodRW Rfe PodRW Rfe
+A diy7 predicate merge test for before on composite relaxations
+  $ diy7 -arch AArch64 -cycleonly true -size 4 -relax '[@before([PodRW Rfe]) PodRW Rfe]' 2>&1 | grep -v '^# Version' | grep -v '^Relaxations tested:'
+  # diy7 -arch AArch64 -cycleonly true -size 4 -relax [@before([PodRW Rfe]) PodRW Rfe]
+  Generator produced 3 tests
+  LB000: PodRW Rfe PodRW Rfe
+  3.LB000: PodRW Rfe PodRW Rfe PodRW Rfe
+  4.LB000: PodRW Rfe PodRW Rfe PodRW Rfe PodRW Rfe
 A VMSA test for a negated exists check, `-neg true`
   $ diyone7 -arch AArch64 -variant vmsa Amo.Cas TLBI-sync.ISHdWW PteV1 PteAF0 PteOA Rfe Pte PodRW PteHD Rfe -neg true -info "User-define=User-define"
   AArch64 LB+popteptehd+amo.cas-tlbi-sync.ishppteoa.v1.af0

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -15,6 +15,10 @@ A test for no metadata, `-metadata false`
    L00: LDR W4,[X3] ;
   
   exists (fault(P0:L00,x))
+A diy7 predicate reject cannot silently fall back to default relaxations
+  $ diy7 -arch AArch64 -safe '[@before([PodRW Rfe]) PodRW Rfe]' -reject '[@before([PodRW Rfe]) PodRW Rfe]' -size 2 -exact -stdout 2>&1
+  diy7: Fatal error: relaxations provided in safelist could not be used to generate cycles
+  [2]
 A VMSA test for a negated exists check, `-neg true`
   $ diyone7 -arch AArch64 -variant vmsa Amo.Cas TLBI-sync.ISHdWW PteV1 PteAF0 PteOA Rfe Pte PodRW PteHD Rfe -neg true -info "User-define=User-define"
   AArch64 LB+popteptehd+amo.cas-tlbi-sync.ishppteoa.v1.af0
@@ -857,7 +861,7 @@ An `ABC` relax macro unfolds before raw edge parsing
 `diy7 -unfold-only` unfolds relaxations and drops invalid composites
   $ diy7 -arch AArch64 -relax '[Po,DpAddr?]' -unfold-only 2>&1
   ***relax***
-  PosWW PosWR [PosWR,DpAddrsW] [PosWR,DpAddrsR] [PosWR,DpAddrdW] [PosWR,DpAddrdR] PosRW PosRR [PosRR,DpAddrsW] [PosRR,DpAddrsR] [PosRR,DpAddrdW] [PosRR,DpAddrdR] PodWW PodWR [PodWR,DpAddrsW] [PodWR,DpAddrsR] [PodWR,DpAddrdW] [PodWR,DpAddrdR] PodRW PodRR [PodRR,DpAddrsW] [PodRR,DpAddrsR] [PodRR,DpAddrdW] [PodRR,DpAddrdR]
+  PosWW [PosWW,DpAddrsW] [PosWW,DpAddrsR] [PosWW,DpAddrdW] [PosWW,DpAddrdR] PosWR [PosWR,DpAddrsW] [PosWR,DpAddrsR] [PosWR,DpAddrdW] [PosWR,DpAddrdR] PosRW [PosRW,DpAddrsW] [PosRW,DpAddrsR] [PosRW,DpAddrdW] [PosRW,DpAddrdR] PosRR [PosRR,DpAddrsW] [PosRR,DpAddrsR] [PosRR,DpAddrdW] [PosRR,DpAddrdR] PodWW [PodWW,DpAddrsW] [PodWW,DpAddrsR] [PodWW,DpAddrdW] [PodWW,DpAddrdR] PodWR [PodWR,DpAddrsW] [PodWR,DpAddrsR] [PodWR,DpAddrdW] [PodWR,DpAddrdR] PodRW [PodRW,DpAddrsW] [PodRW,DpAddrsR] [PodRW,DpAddrdW] [PodRW,DpAddrdR] PodRR [PodRR,DpAddrsW] [PodRR,DpAddrsR] [PodRR,DpAddrdW] [PodRR,DpAddrdR]
   ***safe***
   
   ***reject***
@@ -872,7 +876,7 @@ An `ABC` relax macro unfolds before raw edge parsing
   
   $ diy7 -arch AArch64 -relax 'PodWR?' -unfold-only 2>&1
   ***relax***
-  PodWR
+  [] PodWR
   ***safe***
   
   ***reject***
@@ -912,7 +916,7 @@ An `ABC` relax macro unfolds before raw edge parsing
   ***relax***
   
   ***safe***
-  Fre
+  [] Fre
   ***reject***
   
   $ diy7 -arch AArch64 -safe '[PodWR Fre]' -unfold-only 2>&1

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -15,6 +15,16 @@ A test for no metadata, `-metadata false`
    L00: LDR W4,[X3] ;
   
   exists (fault(P0:L00,x))
+A diy7 test for repeated nested predicates
+  $ diy7 -arch AArch64 -relax '[@before(@before(Po)) PodRW]' -unfold-only 2>&1 | grep -v '^$'
+  ***relax***
+  [@before(PosWR),PodRW] [@before(PosRR),PodRW] [@before(PodWR),PodRW] [@before(PodRR),PodRW]
+  ***safe***
+  ***reject***
+A diy7 test for conflicting nested predicates
+  $ diy7 -arch AArch64 -relax '[@before(@after(Po)) PodRW]' -unfold-only 2>&1
+  diy7: before and after predicates cannot apply to the same edge
+  [2]
 A diy7 predicate reject cannot silently fall back to default relaxations
   $ diy7 -arch AArch64 -safe '[@before([PodRW Rfe]) PodRW Rfe]' -reject '[@before([PodRW Rfe]) PodRW Rfe]' -size 2 -exact -stdout 2>&1
   diy7: Fatal error: relaxations provided in safelist could not be used to generate cycles
@@ -861,7 +871,7 @@ An `ABC` relax macro unfolds before raw edge parsing
 `diy7 -unfold-only` unfolds relaxations and drops invalid composites
   $ diy7 -arch AArch64 -relax '[Po,DpAddr?]' -unfold-only 2>&1
   ***relax***
-  PosWW [PosWW,DpAddrsW] [PosWW,DpAddrsR] [PosWW,DpAddrdW] [PosWW,DpAddrdR] PosWR [PosWR,DpAddrsW] [PosWR,DpAddrsR] [PosWR,DpAddrdW] [PosWR,DpAddrdR] PosRW [PosRW,DpAddrsW] [PosRW,DpAddrsR] [PosRW,DpAddrdW] [PosRW,DpAddrdR] PosRR [PosRR,DpAddrsW] [PosRR,DpAddrsR] [PosRR,DpAddrdW] [PosRR,DpAddrdR] PodWW [PodWW,DpAddrsW] [PodWW,DpAddrsR] [PodWW,DpAddrdW] [PodWW,DpAddrdR] PodWR [PodWR,DpAddrsW] [PodWR,DpAddrsR] [PodWR,DpAddrdW] [PodWR,DpAddrdR] PodRW [PodRW,DpAddrsW] [PodRW,DpAddrsR] [PodRW,DpAddrdW] [PodRW,DpAddrdR] PodRR [PodRR,DpAddrsW] [PodRR,DpAddrsR] [PodRR,DpAddrdW] [PodRR,DpAddrdR]
+  PosWW PosWR [PosWR,DpAddrsW] [PosWR,DpAddrsR] [PosWR,DpAddrdW] [PosWR,DpAddrdR] PosRW PosRR [PosRR,DpAddrsW] [PosRR,DpAddrsR] [PosRR,DpAddrdW] [PosRR,DpAddrdR] PodWW PodWR [PodWR,DpAddrsW] [PodWR,DpAddrsR] [PodWR,DpAddrdW] [PodWR,DpAddrdR] PodRW PodRR [PodRR,DpAddrsW] [PodRR,DpAddrsR] [PodRR,DpAddrdW] [PodRR,DpAddrdR]
   ***safe***
   
   ***reject***
@@ -876,7 +886,7 @@ An `ABC` relax macro unfolds before raw edge parsing
   
   $ diy7 -arch AArch64 -relax 'PodWR?' -unfold-only 2>&1
   ***relax***
-  [] PodWR
+  PodWR
   ***safe***
   
   ***reject***
@@ -916,7 +926,7 @@ An `ABC` relax macro unfolds before raw edge parsing
   ***relax***
   
   ***safe***
-  [] Fre
+  Fre
   ***reject***
   
   $ diy7 -arch AArch64 -safe '[PodWR Fre]' -unfold-only 2>&1

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -25,6 +25,33 @@ A diy7 test for conflicting nested predicates
   $ diy7 -arch AArch64 -relax '[@before(@after(Po)) PodRW]' -unfold-only 2>&1
   diy7: before and after predicates cannot apply to the same edge
   [2]
+A diy7 predicate merge test for before/after boundary predicates
+  $ diy7 -arch AArch64 -cycleonly true -size 4 -relax '[@before(Po) PodRW Rfe @after(Po)]' -safe Po 2>&1 | grep -v '^# Version' | grep -v '^Relaxations tested:'
+  # diy7 -arch AArch64 -cycleonly true -size 4 -relax [@before(Po) PodRW Rfe @after(Po)] -safe Po
+  Generator produced 2 tests
+  LB000: PosRR PodRW Rfe PosRR PodRW Rfe
+  LB001: PodRR PodRW Rfe PodRR PodRW Rfe
+A diy7 predicate merge test for repeated after predicates
+  $ diy7 -arch AArch64 -cycleonly true -size 4 -relax '[PodRW Rfe @after(PodRW) @after(Rfe)]' 2>&1 | grep -v '^# Version' | grep -v '^Relaxations tested:'
+  # diy7 -arch AArch64 -cycleonly true -size 4 -relax [PodRW Rfe @after(PodRW) @after(Rfe)]
+  Generator produced 3 tests
+  LB000: PodRW Rfe PodRW Rfe
+  3.LB000: PodRW Rfe PodRW Rfe PodRW Rfe
+  4.LB000: PodRW Rfe PodRW Rfe PodRW Rfe PodRW Rfe
+A diy7 predicate merge test for after on composite relaxations
+  $ diy7 -arch AArch64 -cycleonly true -size 4 -relax '[PodRW Rfe @after([PodRW Rfe])]' 2>&1 | grep -v '^# Version' | grep -v '^Relaxations tested:'
+  # diy7 -arch AArch64 -cycleonly true -size 4 -relax [PodRW Rfe @after([PodRW Rfe])]
+  Generator produced 3 tests
+  LB000: PodRW Rfe PodRW Rfe
+  3.LB000: PodRW Rfe PodRW Rfe PodRW Rfe
+  4.LB000: PodRW Rfe PodRW Rfe PodRW Rfe PodRW Rfe
+A diy7 predicate merge test for before on composite relaxations
+  $ diy7 -arch AArch64 -cycleonly true -size 4 -relax '[@before([PodRW Rfe]) PodRW Rfe]' 2>&1 | grep -v '^# Version' | grep -v '^Relaxations tested:'
+  # diy7 -arch AArch64 -cycleonly true -size 4 -relax [@before([PodRW Rfe]) PodRW Rfe]
+  Generator produced 3 tests
+  LB000: PodRW Rfe PodRW Rfe
+  3.LB000: PodRW Rfe PodRW Rfe PodRW Rfe
+  4.LB000: PodRW Rfe PodRW Rfe PodRW Rfe PodRW Rfe
 A diy7 predicate reject cannot silently fall back to default relaxations
   $ diy7 -arch AArch64 -safe '[@before([PodRW Rfe]) PodRW Rfe]' -reject '[@before([PodRW Rfe]) PodRW Rfe]' -size 2 -exact -stdout 2>&1
   diy7: Fatal error: relaxations provided in safelist could not be used to generate cycles

--- a/gen/tests/test_parser.expected
+++ b/gen/tests/test_parser.expected
@@ -406,3 +406,21 @@ remove_invalid_relaxes test (AArch64): [Rfe,Rfe]
 remove_invalid_relaxes test (AArch64): [Rfe,Fre]
 [[Rfe,Fre]]
 
+remove_invalid_relaxes test (AArch64): [PodRW @before(Rfe)]
+[]
+
+remove_invalid_relaxes test (AArch64): [@after(PodRW) Rfe]
+[]
+
+remove_invalid_relaxes test (AArch64): [PodRW @before(Rfe) @before(Fre)]
+[]
+
+remove_invalid_relaxes test (AArch64): [@after(PodRW) @after(Rfe) Fre]
+[]
+
+remove_invalid_relaxes test (AArch64): [PodRW @after(Rfe) Fre]
+[]
+
+remove_invalid_relaxes test (AArch64): [PodRW @before([Rfe Fre])]
+[]
+

--- a/gen/tests/test_parser.expected
+++ b/gen/tests/test_parser.expected
@@ -1,181 +1,401 @@
-default parser (for diyone7): A|B,C|[D,[E,F]?,G]?
+diyone7 parser: A|B,C|[D,[E,F]?,G]?
 [[A|B],[C|[D,[E,F]?,G]?]]
 [[A;C];[A];[A;D;G];[A;D;E;F;G];[B;C];[B];[B;D;G];[B;D;E;F;G]]
-top level choice parser (for diycross7 and diy7): A|B,C|[D,[E,F]?,G]?
+diycross7 parser: A|B,C|[D,[E,F]?,G]?
 [A|B|C|[D,[E,F]?,G]?]
 [[A];[B];[C];[];[D;G];[D;E;F;G]]
+diy7 parser: A|B,C|[D,[E,F]?,G]?
+[A|B|C|[D,[E,F]?,G]?]
+[[A];[B];[C];[];[D;G];[D;E;F;G]]
+cumul parser (for -cumul in diy7): A|B,C|[D,[E,F]?,G]?
+[A|B|C|[D|[E|F]?|G]?]
+[[A];[B];[C];[];[D];[];[E];[F];[G]]
 
-default parser (for diyone7): A|B?
+diyone7 parser: A|B?
 [A|B?]
 [[A];[];[B]]
-top level choice parser (for diycross7 and diy7): A|B?
+diycross7 parser: A|B?
+[A|B?]
+[[A];[];[B]]
+diy7 parser: A|B?
+[A|B?]
+[[A];[];[B]]
+cumul parser (for -cumul in diy7): A|B?
 [A|B?]
 [[A];[];[B]]
 
-default parser (for diyone7): A|B,C
+diyone7 parser: A|B,C
 [[A|B],C]
 [[A;C];[B;C]]
-top level choice parser (for diycross7 and diy7): A|B,C
+diycross7 parser: A|B,C
+[A|B|C]
+[[A];[B];[C]]
+diy7 parser: A|B,C
+[A|B|C]
+[[A];[B];[C]]
+cumul parser (for -cumul in diy7): A|B,C
 [A|B|C]
 [[A];[B];[C]]
 
-default parser (for diyone7): [A|B],C
+diyone7 parser: [A|B],C
 [[A|B],C]
 [[A;C];[B;C]]
-top level choice parser (for diycross7 and diy7): [A|B],C
+diycross7 parser: [A|B],C
+[A|B|C]
+[[A];[B];[C]]
+diy7 parser: [A|B],C
+[A|B|C]
+[[A];[B];[C]]
+cumul parser (for -cumul in diy7): [A|B],C
 [A|B|C]
 [[A];[B];[C]]
 
-default parser (for diyone7): A,B?
+diyone7 parser: A,B?
 [A,B?]
 [[A];[A;B]]
-top level choice parser (for diycross7 and diy7): A,B?
+diycross7 parser: A,B?
+[A|B?]
+[[A];[];[B]]
+diy7 parser: A,B?
+[A|B?]
+[[A];[];[B]]
+cumul parser (for -cumul in diy7): A,B?
 [A|B?]
 [[A];[];[B]]
 
-default parser (for diyone7): A,[B,C]
+diyone7 parser: A,[B,C]
 [A,B,C]
 [[A;B;C]]
-top level choice parser (for diycross7 and diy7): A,[B,C]
+diycross7 parser: A,[B,C]
 [A|[B,C]]
 [[A];[B;C]]
-
-default parser (for diyone7): [A|B]?
-[A|B]?
-[[];[A];[B]]
-top level choice parser (for diycross7 and diy7): [A|B]?
-[A|B]?
-[[];[A];[B]]
-
-default parser (for diyone7): [A,B]?
-[A,B]?
-[[];[A;B]]
-top level choice parser (for diycross7 and diy7): [A,B]?
-[A,B]?
-[[];[A;B]]
-
-default parser (for diyone7): [A B]
-[A,B]
-[[A;B]]
-top level choice parser (for diycross7 and diy7): [A B]
-[A,B]
-[[A;B]]
-
-default parser (for diyone7): [A,B]
-[A,B]
-[[A;B]]
-top level choice parser (for diycross7 and diy7): [A,B]
-[A,B]
-[[A;B]]
-
-default parser (for diyone7): [A B C]
-[A,B,C]
-[[A;B;C]]
-top level choice parser (for diycross7 and diy7): [A B C]
-[A,B,C]
-[[A;B;C]]
-
-default parser (for diyone7): [A,B,C]
-[A,B,C]
-[[A;B;C]]
-top level choice parser (for diycross7 and diy7): [A,B,C]
-[A,B,C]
-[[A;B;C]]
-
-default parser (for diyone7): [A,B C]
-[A,B,C]
-[[A;B;C]]
-top level choice parser (for diycross7 and diy7): [A,B C]
-[A,B,C]
-[[A;B;C]]
-
-default parser (for diyone7): [A B,C]
-[A,B,C]
-[[A;B;C]]
-top level choice parser (for diycross7 and diy7): [A B,C]
-[A,B,C]
-[[A;B;C]]
-
-default parser (for diyone7): [A|B|C]
-[A|B|C]
-[[A];[B];[C]]
-top level choice parser (for diycross7 and diy7): [A|B|C]
-[A|B|C]
-[[A];[B];[C]]
-
-default parser (for diyone7): [A|B C]
-[[A|B],C]
-[[A;C];[B;C]]
-top level choice parser (for diycross7 and diy7): [A|B C]
-[[A|B],C]
-[[A;C];[B;C]]
-
-default parser (for diyone7): A,
-A
-[[A]]
-top level choice parser (for diycross7 and diy7): A,
-A
-[[A]]
-
-equivalent syntax test for (diycross7 and diy7): A [B C] D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A,[B C] D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A [B C] D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A,[B,C] D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A [B C],D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A,[B C],D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A [B,C],D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A,[B,C],D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-cumul parser (for -cumul in diy7): A B
-[A|B]
-[[A];[B]]
-
-cumul parser (for -cumul in diy7): A,B
-[A|B]
-[[A];[B]]
-
-cumul parser (for -cumul in diy7): [A,B]
-[A|B]
-[[A];[B]]
-
-cumul parser (for -cumul in diy7): [A,[B]]
-[A|B]
-[[A];[B]]
-
-cumul parser (for -cumul in diy7): A B C
-[A|B|C]
-[[A];[B];[C]]
-
+diy7 parser: A,[B,C]
+[A|[B,C]]
+[[A];[B;C]]
 cumul parser (for -cumul in diy7): A,[B,C]
 [A|B|C]
 [[A];[B];[C]]
 
+diyone7 parser: [A|B]?
+[A|B]?
+[[];[A];[B]]
+diycross7 parser: [A|B]?
+[A|B]?
+[[];[A];[B]]
+diy7 parser: [A|B]?
+[A|B]?
+[[];[A];[B]]
+cumul parser (for -cumul in diy7): [A|B]?
+[A|B]?
+[[];[A];[B]]
+
+diyone7 parser: [A,B]?
+[A,B]?
+[[];[A;B]]
+diycross7 parser: [A,B]?
+[A,B]?
+[[];[A;B]]
+diy7 parser: [A,B]?
+[A,B]?
+[[];[A;B]]
+cumul parser (for -cumul in diy7): [A,B]?
+[A|B]?
+[[];[A];[B]]
+
+diyone7 parser: [A B]
+[A,B]
+[[A;B]]
+diycross7 parser: [A B]
+[A,B]
+[[A;B]]
+diy7 parser: [A B]
+[A,B]
+[[A;B]]
+cumul parser (for -cumul in diy7): [A B]
+[A|B]
+[[A];[B]]
+
+diyone7 parser: [A,B]
+[A,B]
+[[A;B]]
+diycross7 parser: [A,B]
+[A,B]
+[[A;B]]
+diy7 parser: [A,B]
+[A,B]
+[[A;B]]
+cumul parser (for -cumul in diy7): [A,B]
+[A|B]
+[[A];[B]]
+
+diyone7 parser: [A B C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A B C]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A B C]
+[A,B,C]
+[[A;B;C]]
+cumul parser (for -cumul in diy7): [A B C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A,B,C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A,B,C]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A,B,C]
+[A,B,C]
+[[A;B;C]]
+cumul parser (for -cumul in diy7): [A,B,C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A,B C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A,B C]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A,B C]
+[A,B,C]
+[[A;B;C]]
+cumul parser (for -cumul in diy7): [A,B C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A B,C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A B,C]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A B,C]
+[A,B,C]
+[[A;B;C]]
+cumul parser (for -cumul in diy7): [A B,C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A|B|C]
+[A|B|C]
+[[A];[B];[C]]
+diycross7 parser: [A|B|C]
+[A|B|C]
+[[A];[B];[C]]
+diy7 parser: [A|B|C]
+[A|B|C]
+[[A];[B];[C]]
+cumul parser (for -cumul in diy7): [A|B|C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A|B C]
+[[A|B],C]
+[[A;C];[B;C]]
+diycross7 parser: [A|B C]
+[[A|B],C]
+[[A;C];[B;C]]
+diy7 parser: [A|B C]
+[[A|B],C]
+[[A;C];[B;C]]
+cumul parser (for -cumul in diy7): [A|B C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: A,
+A
+[[A]]
+diycross7 parser: A,
+A
+[[A]]
+diy7 parser: A,
+A
+[[A]]
+cumul parser (for -cumul in diy7): A,
+A
+[[A]]
+
+diyone7 parser: A B C
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: A B C
+[A|B|C]
+[[A];[B];[C]]
+diy7 parser: A B C
+[A|B|C]
+[[A];[B];[C]]
+cumul parser (for -cumul in diy7): A B C
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A,[B]]
+[A,B]
+[[A;B]]
+diycross7 parser: [A,[B]]
+[A,B]
+[[A;B]]
+diy7 parser: [A,[B]]
+[A,B]
+[[A;B]]
+cumul parser (for -cumul in diy7): [A,[B]]
+[A|B]
+[[A];[B]]
+
+diyone7 parser: A,[B,C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: A,[B,C]
+[A|[B,C]]
+[[A];[B;C]]
+diy7 parser: A,[B,C]
+[A|[B,C]]
+[[A];[B;C]]
+cumul parser (for -cumul in diy7): A,[B,C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A,[B,C]]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A,[B,C]]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A,[B,C]]
+[A,B,C]
+[[A;B;C]]
 cumul parser (for -cumul in diy7): [A,[B,C]]
 [A|B|C]
 [[A];[B];[C]]
+
+diyone7 parser: @before(A)
+Parser.Error
+diycross7 parser: @before(A)
+Parser.Error
+diy7 parser: @before(A)
+before(A)
+[[@before(A)]]
+cumul parser (for -cumul in diy7): @before(A)
+Parser.Error
+
+diyone7 parser: A @after(B)
+Parser.Error
+diycross7 parser: A @after(B)
+Parser.Error
+diy7 parser: A @after(B)
+[A|after(B)]
+[[A];[@after(B)]]
+cumul parser (for -cumul in diy7): A @after(B)
+Parser.Error
+
+diyone7 parser: [A @before(B)]
+Parser.Error
+diycross7 parser: [A @before(B)]
+Parser.Error
+diy7 parser: [A @before(B)]
+[A,before(B)]
+[[A;@before(B)]]
+cumul parser (for -cumul in diy7): [A @before(B)]
+Parser.Error
+
+diyone7 parser: @before(A) @before(B)
+Parser.Error
+diycross7 parser: @before(A) @before(B)
+Parser.Error
+diy7 parser: @before(A) @before(B)
+[before(A)|before(B)]
+[[@before(A)];[@before(B)]]
+cumul parser (for -cumul in diy7): @before(A) @before(B)
+Parser.Error
+
+diyone7 parser: A @after(B) @after(C)
+Parser.Error
+diycross7 parser: A @after(B) @after(C)
+Parser.Error
+diy7 parser: A @after(B) @after(C)
+[A|after(B)|after(C)]
+[[A];[@after(B)];[@after(C)]]
+cumul parser (for -cumul in diy7): A @after(B) @after(C)
+Parser.Error
+
+diyone7 parser: @before([A B])
+Parser.Error
+diycross7 parser: @before([A B])
+Parser.Error
+diy7 parser: @before([A B])
+before([A,B])
+[[@before(A);@before(B)]]
+cumul parser (for -cumul in diy7): @before([A B])
+Parser.Error
+
+diyone7 parser: @after([A B])
+Parser.Error
+diycross7 parser: @after([A B])
+Parser.Error
+diy7 parser: @after([A B])
+after([A,B])
+[[@after(A);@after(B)]]
+cumul parser (for -cumul in diy7): @after([A B])
+Parser.Error
+
+equivalent syntax test for diycross7: A [B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A [B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A,[B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A,[B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A [B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A [B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A,[B,C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A,[B,C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A [B C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A [B C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A,[B C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A,[B C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A [B,C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A [B,C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A,[B,C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A,[B,C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
 
 remove_invalid_relaxes test (AArch64): [Po,Rfe]
 [[PosWW,Rfe];[PosRW,Rfe];[PodWW,Rfe];[PodRW,Rfe]]

--- a/gen/tests/test_parser.expected
+++ b/gen/tests/test_parser.expected
@@ -424,3 +424,6 @@ remove_invalid_relaxes test (AArch64): [PodRW @after(Rfe) Fre]
 remove_invalid_relaxes test (AArch64): [PodRW @before([Rfe Fre])]
 []
 
+remove_invalid_relaxes test (AArch64): [@before([Rfe PodRW])]
+[]
+

--- a/gen/tests/test_parser.expected
+++ b/gen/tests/test_parser.expected
@@ -1,181 +1,421 @@
-default parser (for diyone7): A|B,C|[D,[E,F]?,G]?
+diyone7 parser: A|B,C|[D,[E,F]?,G]?
 [[A|B],[C|[D,[E,F]?,G]?]]
 [[A;C];[A];[A;D;G];[A;D;E;F;G];[B;C];[B];[B;D;G];[B;D;E;F;G]]
-top level choice parser (for diycross7 and diy7): A|B,C|[D,[E,F]?,G]?
+diycross7 parser: A|B,C|[D,[E,F]?,G]?
 [A|B|C|[D,[E,F]?,G]?]
 [[A];[B];[C];[];[D;G];[D;E;F;G]]
+diy7 parser: A|B,C|[D,[E,F]?,G]?
+[A|B|C|[D,[E,F]?,G]?]
+[[A];[B];[C];[];[D;G];[D;E;F;G]]
+cumul parser (for -cumul in diy7): A|B,C|[D,[E,F]?,G]?
+[A|B|C|[D|[E|F]?|G]?]
+[[A];[B];[C];[];[D];[];[E];[F];[G]]
 
-default parser (for diyone7): A|B?
+diyone7 parser: A|B?
 [A|B?]
 [[A];[];[B]]
-top level choice parser (for diycross7 and diy7): A|B?
+diycross7 parser: A|B?
+[A|B?]
+[[A];[];[B]]
+diy7 parser: A|B?
+[A|B?]
+[[A];[];[B]]
+cumul parser (for -cumul in diy7): A|B?
 [A|B?]
 [[A];[];[B]]
 
-default parser (for diyone7): A|B,C
+diyone7 parser: A|B,C
 [[A|B],C]
 [[A;C];[B;C]]
-top level choice parser (for diycross7 and diy7): A|B,C
+diycross7 parser: A|B,C
+[A|B|C]
+[[A];[B];[C]]
+diy7 parser: A|B,C
+[A|B|C]
+[[A];[B];[C]]
+cumul parser (for -cumul in diy7): A|B,C
 [A|B|C]
 [[A];[B];[C]]
 
-default parser (for diyone7): [A|B],C
+diyone7 parser: [A|B],C
 [[A|B],C]
 [[A;C];[B;C]]
-top level choice parser (for diycross7 and diy7): [A|B],C
+diycross7 parser: [A|B],C
+[A|B|C]
+[[A];[B];[C]]
+diy7 parser: [A|B],C
+[A|B|C]
+[[A];[B];[C]]
+cumul parser (for -cumul in diy7): [A|B],C
 [A|B|C]
 [[A];[B];[C]]
 
-default parser (for diyone7): A,B?
+diyone7 parser: A,B?
 [A,B?]
 [[A];[A;B]]
-top level choice parser (for diycross7 and diy7): A,B?
+diycross7 parser: A,B?
+[A|B?]
+[[A];[];[B]]
+diy7 parser: A,B?
+[A|B?]
+[[A];[];[B]]
+cumul parser (for -cumul in diy7): A,B?
 [A|B?]
 [[A];[];[B]]
 
-default parser (for diyone7): A,[B,C]
+diyone7 parser: A,[B,C]
 [A,B,C]
 [[A;B;C]]
-top level choice parser (for diycross7 and diy7): A,[B,C]
+diycross7 parser: A,[B,C]
 [A|[B,C]]
 [[A];[B;C]]
-
-default parser (for diyone7): [A|B]?
-[A|B]?
-[[];[A];[B]]
-top level choice parser (for diycross7 and diy7): [A|B]?
-[A|B]?
-[[];[A];[B]]
-
-default parser (for diyone7): [A,B]?
-[A,B]?
-[[];[A;B]]
-top level choice parser (for diycross7 and diy7): [A,B]?
-[A,B]?
-[[];[A;B]]
-
-default parser (for diyone7): [A B]
-[A,B]
-[[A;B]]
-top level choice parser (for diycross7 and diy7): [A B]
-[A,B]
-[[A;B]]
-
-default parser (for diyone7): [A,B]
-[A,B]
-[[A;B]]
-top level choice parser (for diycross7 and diy7): [A,B]
-[A,B]
-[[A;B]]
-
-default parser (for diyone7): [A B C]
-[A,B,C]
-[[A;B;C]]
-top level choice parser (for diycross7 and diy7): [A B C]
-[A,B,C]
-[[A;B;C]]
-
-default parser (for diyone7): [A,B,C]
-[A,B,C]
-[[A;B;C]]
-top level choice parser (for diycross7 and diy7): [A,B,C]
-[A,B,C]
-[[A;B;C]]
-
-default parser (for diyone7): [A,B C]
-[A,B,C]
-[[A;B;C]]
-top level choice parser (for diycross7 and diy7): [A,B C]
-[A,B,C]
-[[A;B;C]]
-
-default parser (for diyone7): [A B,C]
-[A,B,C]
-[[A;B;C]]
-top level choice parser (for diycross7 and diy7): [A B,C]
-[A,B,C]
-[[A;B;C]]
-
-default parser (for diyone7): [A|B|C]
-[A|B|C]
-[[A];[B];[C]]
-top level choice parser (for diycross7 and diy7): [A|B|C]
-[A|B|C]
-[[A];[B];[C]]
-
-default parser (for diyone7): [A|B C]
-[[A|B],C]
-[[A;C];[B;C]]
-top level choice parser (for diycross7 and diy7): [A|B C]
-[[A|B],C]
-[[A;C];[B;C]]
-
-default parser (for diyone7): A,
-A
-[[A]]
-top level choice parser (for diycross7 and diy7): A,
-A
-[[A]]
-
-equivalent syntax test for (diycross7 and diy7): A [B C] D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A,[B C] D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A [B C] D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A,[B,C] D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A [B C],D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A,[B C],D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A [B,C],D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-equivalent syntax test for (diycross7 and diy7): A,[B,C],D
-[A|[B,C]|D]
-[[A];[B;C];[D]]
-
-cumul parser (for -cumul in diy7): A B
-[A|B]
-[[A];[B]]
-
-cumul parser (for -cumul in diy7): A,B
-[A|B]
-[[A];[B]]
-
-cumul parser (for -cumul in diy7): [A,B]
-[A|B]
-[[A];[B]]
-
-cumul parser (for -cumul in diy7): [A,[B]]
-[A|B]
-[[A];[B]]
-
-cumul parser (for -cumul in diy7): A B C
-[A|B|C]
-[[A];[B];[C]]
-
+diy7 parser: A,[B,C]
+[A|[B,C]]
+[[A];[B;C]]
 cumul parser (for -cumul in diy7): A,[B,C]
 [A|B|C]
 [[A];[B];[C]]
 
+diyone7 parser: [A|B]?
+[A|B]?
+[[];[A];[B]]
+diycross7 parser: [A|B]?
+[A|B]?
+[[];[A];[B]]
+diy7 parser: [A|B]?
+[A|B]?
+[[];[A];[B]]
+cumul parser (for -cumul in diy7): [A|B]?
+[A|B]?
+[[];[A];[B]]
+
+diyone7 parser: [A,B]?
+[A,B]?
+[[];[A;B]]
+diycross7 parser: [A,B]?
+[A,B]?
+[[];[A;B]]
+diy7 parser: [A,B]?
+[A,B]?
+[[];[A;B]]
+cumul parser (for -cumul in diy7): [A,B]?
+[A|B]?
+[[];[A];[B]]
+
+diyone7 parser: [A B]
+[A,B]
+[[A;B]]
+diycross7 parser: [A B]
+[A,B]
+[[A;B]]
+diy7 parser: [A B]
+[A,B]
+[[A;B]]
+cumul parser (for -cumul in diy7): [A B]
+[A|B]
+[[A];[B]]
+
+diyone7 parser: [A,B]
+[A,B]
+[[A;B]]
+diycross7 parser: [A,B]
+[A,B]
+[[A;B]]
+diy7 parser: [A,B]
+[A,B]
+[[A;B]]
+cumul parser (for -cumul in diy7): [A,B]
+[A|B]
+[[A];[B]]
+
+diyone7 parser: [A B C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A B C]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A B C]
+[A,B,C]
+[[A;B;C]]
+cumul parser (for -cumul in diy7): [A B C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A,B,C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A,B,C]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A,B,C]
+[A,B,C]
+[[A;B;C]]
+cumul parser (for -cumul in diy7): [A,B,C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A,B C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A,B C]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A,B C]
+[A,B,C]
+[[A;B;C]]
+cumul parser (for -cumul in diy7): [A,B C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A B,C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A B,C]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A B,C]
+[A,B,C]
+[[A;B;C]]
+cumul parser (for -cumul in diy7): [A B,C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A|B|C]
+[A|B|C]
+[[A];[B];[C]]
+diycross7 parser: [A|B|C]
+[A|B|C]
+[[A];[B];[C]]
+diy7 parser: [A|B|C]
+[A|B|C]
+[[A];[B];[C]]
+cumul parser (for -cumul in diy7): [A|B|C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A|B C]
+[[A|B],C]
+[[A;C];[B;C]]
+diycross7 parser: [A|B C]
+[[A|B],C]
+[[A;C];[B;C]]
+diy7 parser: [A|B C]
+[[A|B],C]
+[[A;C];[B;C]]
+cumul parser (for -cumul in diy7): [A|B C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: A,
+A
+[[A]]
+diycross7 parser: A,
+A
+[[A]]
+diy7 parser: A,
+A
+[[A]]
+cumul parser (for -cumul in diy7): A,
+A
+[[A]]
+
+diyone7 parser: A B C
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: A B C
+[A|B|C]
+[[A];[B];[C]]
+diy7 parser: A B C
+[A|B|C]
+[[A];[B];[C]]
+cumul parser (for -cumul in diy7): A B C
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A,[B]]
+[A,B]
+[[A;B]]
+diycross7 parser: [A,[B]]
+[A,B]
+[[A;B]]
+diy7 parser: [A,[B]]
+[A,B]
+[[A;B]]
+cumul parser (for -cumul in diy7): [A,[B]]
+[A|B]
+[[A];[B]]
+
+diyone7 parser: A,[B,C]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: A,[B,C]
+[A|[B,C]]
+[[A];[B;C]]
+diy7 parser: A,[B,C]
+[A|[B,C]]
+[[A];[B;C]]
+cumul parser (for -cumul in diy7): A,[B,C]
+[A|B|C]
+[[A];[B];[C]]
+
+diyone7 parser: [A,[B,C]]
+[A,B,C]
+[[A;B;C]]
+diycross7 parser: [A,[B,C]]
+[A,B,C]
+[[A;B;C]]
+diy7 parser: [A,[B,C]]
+[A,B,C]
+[[A;B;C]]
 cumul parser (for -cumul in diy7): [A,[B,C]]
 [A|B|C]
 [[A];[B];[C]]
+
+diyone7 parser: @before(A)
+Parser.Error
+diycross7 parser: @before(A)
+Parser.Error
+diy7 parser: @before(A)
+@before(A)
+[[@before(A)]]
+cumul parser (for -cumul in diy7): @before(A)
+Parser.Error
+
+diyone7 parser: A @after(B)
+Parser.Error
+diycross7 parser: A @after(B)
+Parser.Error
+diy7 parser: A @after(B)
+[A|@after(B)]
+[[A];[@after(B)]]
+cumul parser (for -cumul in diy7): A @after(B)
+Parser.Error
+
+diyone7 parser: [A @before(B)]
+Parser.Error
+diycross7 parser: [A @before(B)]
+Parser.Error
+diy7 parser: [A @before(B)]
+[A,@before(B)]
+[[A;@before(B)]]
+cumul parser (for -cumul in diy7): [A @before(B)]
+Parser.Error
+
+diyone7 parser: @before(A) @before(B)
+Parser.Error
+diycross7 parser: @before(A) @before(B)
+Parser.Error
+diy7 parser: @before(A) @before(B)
+[@before(A)|@before(B)]
+[[@before(A)];[@before(B)]]
+cumul parser (for -cumul in diy7): @before(A) @before(B)
+Parser.Error
+
+diyone7 parser: A @after(B) @after(C)
+Parser.Error
+diycross7 parser: A @after(B) @after(C)
+Parser.Error
+diy7 parser: A @after(B) @after(C)
+[A|@after(B)|@after(C)]
+[[A];[@after(B)];[@after(C)]]
+cumul parser (for -cumul in diy7): A @after(B) @after(C)
+Parser.Error
+
+diyone7 parser: @before([A B])
+Parser.Error
+diycross7 parser: @before([A B])
+Parser.Error
+diy7 parser: @before([A B])
+@before([A,B])
+[[@before(A);@before(B)]]
+cumul parser (for -cumul in diy7): @before([A B])
+Parser.Error
+
+diyone7 parser: @after([A B])
+Parser.Error
+diycross7 parser: @after([A B])
+Parser.Error
+diy7 parser: @after([A B])
+@after([A,B])
+[[@after(A);@after(B)]]
+cumul parser (for -cumul in diy7): @after([A B])
+Parser.Error
+
+diyone7 parser: @before(@before(A))
+Parser.Error
+diycross7 parser: @before(@before(A))
+Parser.Error
+diy7 parser: @before(@before(A))
+@before(@before(A))
+[[@before(@before(A))]]
+cumul parser (for -cumul in diy7): @before(@before(A))
+Parser.Error
+
+diyone7 parser: @before(@after(A))
+Parser.Error
+diycross7 parser: @before(@after(A))
+Parser.Error
+diy7 parser: @before(@after(A))
+@before(@after(A))
+[[@before(@after(A))]]
+cumul parser (for -cumul in diy7): @before(@after(A))
+Parser.Error
+
+equivalent syntax test for diycross7: A [B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A [B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A,[B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A,[B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A [B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A [B C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A,[B,C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A,[B,C] D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A [B C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A [B C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A,[B C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A,[B C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A [B,C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A [B,C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+
+equivalent syntax test for diycross7: A,[B,C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
+equivalent syntax test for diy7: A,[B,C],D
+[A|[B,C]|D]
+[[A];[B;C];[D]]
 
 remove_invalid_relaxes test (AArch64): [Po,Rfe]
 [[PosWW,Rfe];[PosRW,Rfe];[PodWW,Rfe];[PodRW,Rfe]]

--- a/gen/tests/test_parser.expected
+++ b/gen/tests/test_parser.expected
@@ -426,3 +426,24 @@ remove_invalid_relaxes test (AArch64): [Rfe,Rfe]
 remove_invalid_relaxes test (AArch64): [Rfe,Fre]
 [[Rfe,Fre]]
 
+remove_invalid_relaxes test (AArch64): [PodRW @before(Rfe)]
+[]
+
+remove_invalid_relaxes test (AArch64): [@after(PodRW) Rfe]
+[]
+
+remove_invalid_relaxes test (AArch64): [PodRW @before(Rfe) @before(Fre)]
+[]
+
+remove_invalid_relaxes test (AArch64): [@after(PodRW) @after(Rfe) Fre]
+[]
+
+remove_invalid_relaxes test (AArch64): [PodRW @after(Rfe) Fre]
+[]
+
+remove_invalid_relaxes test (AArch64): [PodRW @before([Rfe Fre])]
+[]
+
+remove_invalid_relaxes test (AArch64): [@before([Rfe PodRW])]
+[]
+

--- a/gen/tests/test_parser.ml
+++ b/gen/tests/test_parser.ml
@@ -85,14 +85,20 @@ let () =
 module TestAArch64 = AutoArch.Make(AArch64Arch_gen.Make(AArch64Arch_gen.Config))
 
 let remove_invalid_relaxes_inputs = [
-  "[Po,Rfe]";
-  "[Rfe,Rfe]";
-  "[Rfe,Fre]";
+  Parser.main, "[Po,Rfe]";
+  Parser.main, "[Rfe,Rfe]";
+  Parser.main, "[Rfe,Fre]";
+  Parser.diy7, "[PodRW @before(Rfe)]";
+  Parser.diy7, "[@after(PodRW) Rfe]";
+  Parser.diy7, "[PodRW @before(Rfe) @before(Fre)]";
+  Parser.diy7, "[@after(PodRW) @after(Rfe) Fre]";
+  Parser.diy7, "[PodRW @after(Rfe) Fre]";
+  Parser.diy7, "[PodRW @before([Rfe Fre])]";
 ]
 
-let remove_invalid_relaxes_test input =
+let remove_invalid_relaxes_test parser_grammar input =
   Printf.printf "remove_invalid_relaxes test (AArch64): %s\n" input ;
-  let ast = TestAArch64.R.parse_ast Parser.main input in
+  let ast = TestAArch64.R.parse_ast parser_grammar input in
   let filtered =
     TestAArch64.R.parse_expand_relaxs ast
     |> TestAArch64.R.remove_invalid_relaxes in
@@ -100,7 +106,7 @@ let remove_invalid_relaxes_test input =
 
 let () =
   List.iter
-    (fun input ->
-      remove_invalid_relaxes_test input;
+    (fun (parser_grammar,input) ->
+      remove_invalid_relaxes_test parser_grammar input;
       Printf.printf "\n")
     remove_invalid_relaxes_inputs

--- a/gen/tests/test_parser.ml
+++ b/gen/tests/test_parser.ml
@@ -20,29 +20,46 @@ let parser_tests =
     "[A|B|C]";
     "[A|B C]";
     "A,";
+    "A B C";
+    "[A,[B]]";
+    "A,[B,C]";
+    "[A,[B,C]]";
+    "@before(A)";
+    "A @after(B)";
+    "[A @before(B)]";
+    "@before(A) @before(B)";
+    "A @after(B) @after(C)";
+    "@before([A B])";
+    "@after([A B])";
   ]
 
 let unit_test parser_grammar label input =
   Printf.printf "%s: %s\n" label input ;
-  let ast =
-    Lexing.from_string input
-    |> LexUtil.parse parser_grammar in
-  Printf.printf "%s\n" (Ast.pp Fun.id ast) ;
-  Ast.expand ast
-  |> pp_list (pp_list Fun.id)
-  |> Printf.printf "%s\n"
+  try
+    let ast =
+      Lexing.from_string input
+      |> LexUtil.parse parser_grammar in
+    Printf.printf "%s\n" (Ast.pp Fun.id Fun.id ast) ;
+    Ast.expand ( fun pred prim -> Printf.sprintf "@%s(%s)" pred prim ) ast
+    |> pp_list (pp_list Fun.id)
+    |> Printf.printf "%s\n"
+  with Parser.Error ->
+    Printf.printf "Parser.Error\n"
+
+let parser_configs = [
+  "diyone7 parser", Parser.main;
+  "diycross7 parser", Parser.diycross7;
+  "diy7 parser", Parser.diy7;
+  "cumul parser (for -cumul in diy7)", Parser.cumul;
+]
 
 let () =
   List.iter
     (fun input ->
       List.iter
         (fun (label, parser_grammar) ->
-          unit_test parser_grammar label input
-          )
-        [
-          "default parser (for diyone7)", Parser.main;
-          "top level choice parser (for diycross7 and diy7)", Parser.main_top_level_choice;
-        ] ;
+          unit_test parser_grammar label input)
+        parser_configs ;
       Printf.printf "\n")
     parser_tests
 
@@ -60,26 +77,10 @@ let equivalent_syntax_tests = [
 let () =
   List.iter
     (fun input ->
-      unit_test Parser.main_top_level_choice "equivalent syntax test for (diycross7 and diy7)" input;
+      unit_test Parser.diycross7 "equivalent syntax test for diycross7" input;
+      unit_test Parser.diy7 "equivalent syntax test for diy7" input;
       Printf.printf "\n")
     equivalent_syntax_tests
-
-let cumul_tests = [
-  "A B";
-  "A,B";
-  "[A,B]";
-  "[A,[B]]";
-  "A B C";
-  "A,[B,C]";
-  "[A,[B,C]]";
-]
-
-let () =
-  List.iter
-    (fun input ->
-      unit_test Parser.cumul "cumul parser (for -cumul in diy7)" input;
-      Printf.printf "\n")
-    cumul_tests
 
 module TestAArch64 = AutoArch.Make(AArch64Arch_gen.Make(AArch64Arch_gen.Config))
 

--- a/gen/tests/test_parser.ml
+++ b/gen/tests/test_parser.ml
@@ -82,31 +82,119 @@ let () =
       Printf.printf "\n")
     equivalent_syntax_tests
 
-module TestAArch64 = AutoArch.Make(AArch64Arch_gen.Make(AArch64Arch_gen.Config))
+module TestGeneratorConfig = struct
+  let verbose = 0
+  let generator = "test_parser"
+  let debug = Debug_gen.none
+  let hout = Hint.none
+  let family : string option = None
+  let canonical_only = true
+  let fmt = 3
+  let no : string list = []
+  let cond = Config.Cycle
+  let tarfile : string option = None
+  let sufname : string option = None
+  let addnum = true
+  let numeric = true
+  let lowercase = false
+  let stdout = true
+  let cycleonly = false
+  let metadata = true
+  let choice = Code.Default
+  let prefix : string list = []
+  let variant (_ : Variant_gen.t) = false
+  let upto = true
+  let varatom : string list = []
+  let max_ins = 4
+  let overload : int option = None
+  let poll = false
+  let optcoherence = false
+  let optcond = true
+  let obs_type = Config.Straight
+  let do_observers = Config.Avoid
+  let eprocs = false
+  let nprocs = 4
+  let neg = false
+  let cpp = false
+  let scope = Scope.No
+  let info : MiscParser.info = []
+  let docheck = false
+  let typ = TypBase.default
+  let hexa = false
+  let same_loc = false
+  let mix = false
+  let max_relax = 100
+  let min_relax = 1
+end
 
-let remove_invalid_relaxes_inputs = [
-  Parser.main, "[Po,Rfe]";
-  Parser.main, "[Rfe,Rfe]";
-  Parser.main, "[Rfe,Fre]";
-  Parser.diy7, "[PodRW @before(Rfe)]";
-  Parser.diy7, "[@after(PodRW) Rfe]";
-  Parser.diy7, "[PodRW @before(Rfe) @before(Fre)]";
-  Parser.diy7, "[@after(PodRW) @after(Rfe) Fre]";
-  Parser.diy7, "[PodRW @after(Rfe) Fre]";
-  Parser.diy7, "[PodRW @before([Rfe Fre])]";
+module TestCompileConfig = struct
+  let verbose = TestGeneratorConfig.verbose
+  let show : ShowGen.t option = None
+  let same_loc = TestGeneratorConfig.same_loc
+  let unrollatomic : int option = None
+  let allow_back = false
+  let typ = TestGeneratorConfig.typ
+  let hexa = TestGeneratorConfig.hexa
+  let moreedges = false
+  let realdep = false
+  let variant = TestGeneratorConfig.variant
+  let wildcard = true
+end
+
+module TestBuilder =
+  Top_gen.Make(TestGeneratorConfig)(AArch64Compile_gen.Make(TestCompileConfig))
+
+module TestAltConfig = struct
+  include TestGeneratorConfig
+
+  let cumul = Config.All
+  let wildcard = true
+
+  type fence = TestBuilder.A.fence
+end
+
+let remove_invalid_relaxes_inputs_main = [
+  "[Po,Rfe]";
+  "[Rfe,Rfe]";
+  "[Rfe,Fre]";
 ]
 
-let remove_invalid_relaxes_test parser_grammar input =
+let remove_invalid_relaxes_test_main input =
   Printf.printf "remove_invalid_relaxes test (AArch64): %s\n" input ;
-  let ast = TestAArch64.R.parse_ast parser_grammar input in
+  let ast = TestBuilder.R.parse_ast Parser.main input in
   let filtered =
-    TestAArch64.R.parse_expand_relaxs ast
-    |> TestAArch64.R.remove_invalid_relaxes in
-  Printf.printf "%s\n" (pp_list TestAArch64.R.pp_relax filtered)
+    TestBuilder.R.parse_expand_relaxs ast
+    |> TestBuilder.R.remove_invalid_relaxes in
+  Printf.printf "%s\n" (pp_list TestBuilder.R.pp_relax filtered)
+
+let remove_invalid_relaxes_inputs_diy7 = [
+  "[PodRW @before(Rfe)]";
+  "[@after(PodRW) Rfe]";
+  "[PodRW @before(Rfe) @before(Fre)]";
+  "[@after(PodRW) @after(Rfe) Fre]";
+  "[PodRW @after(Rfe) Fre]";
+  "[PodRW @before([Rfe Fre])]";
+  "[@before([Rfe PodRW])]";
+]
+
+module TestAlt = Alt.Make(TestBuilder)(TestAltConfig)
+
+let remove_invalid_relaxes_test_diy7 input =
+  Printf.printf "remove_invalid_relaxes test (AArch64): %s\n" input ;
+  let filtered =
+    TestAlt.parse_argument input
+    |> TestAlt.remove_invalid_relaxes in
+  let filtered = List.map TestAlt.plain filtered in
+  Printf.printf "%s\n" (pp_list TestBuilder.R.pp_relax filtered)
 
 let () =
   List.iter
-    (fun (parser_grammar,input) ->
-      remove_invalid_relaxes_test parser_grammar input;
+    (fun input ->
+      remove_invalid_relaxes_test_main input;
       Printf.printf "\n")
-    remove_invalid_relaxes_inputs
+    remove_invalid_relaxes_inputs_main ;
+  List.iter
+    (fun input ->
+      remove_invalid_relaxes_test_diy7 input;
+      Printf.printf "\n")
+    remove_invalid_relaxes_inputs_diy7

--- a/gen/tests/test_parser.ml
+++ b/gen/tests/test_parser.ml
@@ -20,29 +20,48 @@ let parser_tests =
     "[A|B|C]";
     "[A|B C]";
     "A,";
+    "A B C";
+    "[A,[B]]";
+    "A,[B,C]";
+    "[A,[B,C]]";
+    "@before(A)";
+    "A @after(B)";
+    "[A @before(B)]";
+    "@before(A) @before(B)";
+    "A @after(B) @after(C)";
+    "@before([A B])";
+    "@after([A B])";
+    "@before(@before(A))";
+    "@before(@after(A))";
   ]
 
 let unit_test parser_grammar label input =
   Printf.printf "%s: %s\n" label input ;
-  let ast =
-    Lexing.from_string input
-    |> LexUtil.parse parser_grammar in
-  Printf.printf "%s\n" (Ast.pp Fun.id ast) ;
-  Ast.expand ast
-  |> pp_list (pp_list Fun.id)
-  |> Printf.printf "%s\n"
+  try
+    let ast =
+      Lexing.from_string input
+      |> LexUtil.parse parser_grammar in
+    Printf.printf "%s\n" (Ast.pp Fun.id Fun.id ast) ;
+    Ast.expand ( fun pred prim -> Printf.sprintf "@%s(%s)" pred prim ) ast
+    |> pp_list (pp_list Fun.id)
+    |> Printf.printf "%s\n"
+  with Parser.Error ->
+    Printf.printf "Parser.Error\n"
+
+let parser_configs = [
+  "diyone7 parser", Parser.main;
+  "diycross7 parser", Parser.diycross7;
+  "diy7 parser", Parser.diy7;
+  "cumul parser (for -cumul in diy7)", Parser.cumul;
+]
 
 let () =
   List.iter
     (fun input ->
       List.iter
         (fun (label, parser_grammar) ->
-          unit_test parser_grammar label input
-          )
-        [
-          "default parser (for diyone7)", Parser.main;
-          "top level choice parser (for diycross7 and diy7)", Parser.main_top_level_choice;
-        ] ;
+          unit_test parser_grammar label input)
+        parser_configs ;
       Printf.printf "\n")
     parser_tests
 
@@ -60,26 +79,10 @@ let equivalent_syntax_tests = [
 let () =
   List.iter
     (fun input ->
-      unit_test Parser.main_top_level_choice "equivalent syntax test for (diycross7 and diy7)" input;
+      unit_test Parser.diycross7 "equivalent syntax test for diycross7" input;
+      unit_test Parser.diy7 "equivalent syntax test for diy7" input;
       Printf.printf "\n")
     equivalent_syntax_tests
-
-let cumul_tests = [
-  "A B";
-  "A,B";
-  "[A,B]";
-  "[A,[B]]";
-  "A B C";
-  "A,[B,C]";
-  "[A,[B,C]]";
-]
-
-let () =
-  List.iter
-    (fun input ->
-      unit_test Parser.cumul "cumul parser (for -cumul in diy7)" input;
-      Printf.printf "\n")
-    cumul_tests
 
 module TestAArch64 = AutoArch.Make(AArch64Arch_gen.Make(AArch64Arch_gen.Config))
 

--- a/gen/tests/test_parser.ml
+++ b/gen/tests/test_parser.ml
@@ -84,25 +84,119 @@ let () =
       Printf.printf "\n")
     equivalent_syntax_tests
 
-module TestAArch64 = AutoArch.Make(AArch64Arch_gen.Make(AArch64Arch_gen.Config))
+module TestGeneratorConfig = struct
+  let verbose = 0
+  let generator = "test_parser"
+  let debug = Debug_gen.none
+  let hout = Hint.none
+  let family : string option = None
+  let canonical_only = true
+  let fmt = 3
+  let no : string list = []
+  let cond = Config.Cycle
+  let tarfile : string option = None
+  let sufname : string option = None
+  let addnum = true
+  let numeric = true
+  let lowercase = false
+  let stdout = true
+  let cycleonly = false
+  let metadata = true
+  let choice = Code.Default
+  let prefix : string list = []
+  let variant (_ : Variant_gen.t) = false
+  let upto = true
+  let varatom : string list = []
+  let max_ins = 4
+  let overload : int option = None
+  let poll = false
+  let optcoherence = false
+  let optcond = true
+  let obs_type = Config.Straight
+  let do_observers = Config.Avoid
+  let eprocs = false
+  let nprocs = 4
+  let neg = false
+  let cpp = false
+  let scope = Scope.No
+  let info : MiscParser.info = []
+  let docheck = false
+  let typ = TypBase.default
+  let hexa = false
+  let same_loc = false
+  let mix = false
+  let max_relax = 100
+  let min_relax = 1
+end
 
-let remove_invalid_relaxes_inputs = [
+module TestCompileConfig = struct
+  let verbose = TestGeneratorConfig.verbose
+  let show : ShowGen.t option = None
+  let same_loc = TestGeneratorConfig.same_loc
+  let unrollatomic : int option = None
+  let allow_back = false
+  let typ = TestGeneratorConfig.typ
+  let hexa = TestGeneratorConfig.hexa
+  let moreedges = false
+  let realdep = false
+  let variant = TestGeneratorConfig.variant
+  let wildcard = true
+end
+
+module TestBuilder =
+  Top_gen.Make(TestGeneratorConfig)(AArch64Compile_gen.Make(TestCompileConfig))
+
+module TestAltConfig = struct
+  include TestGeneratorConfig
+
+  let cumul = Config.All
+  let wildcard = true
+
+  type fence = TestBuilder.A.fence
+end
+
+let remove_invalid_relaxes_inputs_main = [
   "[Po,Rfe]";
   "[Rfe,Rfe]";
   "[Rfe,Fre]";
 ]
 
-let remove_invalid_relaxes_test input =
+let remove_invalid_relaxes_test_main input =
   Printf.printf "remove_invalid_relaxes test (AArch64): %s\n" input ;
-  let ast = TestAArch64.R.parse_ast Parser.main input in
+  let ast = TestBuilder.R.parse_ast Parser.main input in
   let filtered =
-    TestAArch64.R.parse_expand_relaxs ast
-    |> TestAArch64.R.remove_invalid_relaxes in
-  Printf.printf "%s\n" (pp_list TestAArch64.R.pp_relax filtered)
+    TestBuilder.R.parse_expand_relaxs ast
+    |> TestBuilder.R.remove_invalid_relaxes in
+  Printf.printf "%s\n" (pp_list TestBuilder.R.pp_relax filtered)
+
+let remove_invalid_relaxes_inputs_diy7 = [
+  "[PodRW @before(Rfe)]";
+  "[@after(PodRW) Rfe]";
+  "[PodRW @before(Rfe) @before(Fre)]";
+  "[@after(PodRW) @after(Rfe) Fre]";
+  "[PodRW @after(Rfe) Fre]";
+  "[PodRW @before([Rfe Fre])]";
+  "[@before([Rfe PodRW])]";
+]
+
+module TestAlt = Alt.Make(TestBuilder)(TestAltConfig)
+
+let remove_invalid_relaxes_test_diy7 input =
+  Printf.printf "remove_invalid_relaxes test (AArch64): %s\n" input ;
+  let filtered =
+    TestAlt.parse_argument input
+    |> TestAlt.remove_invalid_relaxes in
+  let filtered = List.map TestAlt.to_relax filtered in
+  Printf.printf "%s\n" (pp_list TestBuilder.R.pp_relax filtered)
 
 let () =
   List.iter
     (fun input ->
-      remove_invalid_relaxes_test input;
+      remove_invalid_relaxes_test_main input;
       Printf.printf "\n")
-    remove_invalid_relaxes_inputs
+    remove_invalid_relaxes_inputs_main ;
+  List.iter
+    (fun input ->
+      remove_invalid_relaxes_test_diy7 input;
+      Printf.printf "\n")
+    remove_invalid_relaxes_inputs_diy7


### PR DESCRIPTION
Add `diy7`-only predicate syntax for relax inputs:
  - `@before(...)`
  - `@after(...)`

The parser entry points are split so predicate syntax is accepted only by `diy7`. The shared `main`/`diyone7`, `diycross7`, and `cumul` parsers reject predicate syntax.

During relax expansion, invalid predicate placement is filtered before search:
  - `@before(...)` is only valid at the start of a relaxation sequence
  - `@after(...)` is only valid at the end of a relaxation sequence
  - predicates in the middle of a concrete composition are discarded

During `diy7` cycle search, boundary predicates are checked against neighbouring concrete edges. Once checked, predicates are stripped before passing candidate cycles to the normal test generator.

Added tests for:
  - `diy7` parser acceptance of `@before(...)` and `@after(...)`, while other parsers reject of predicate syntax
  - filtering invalid predicate placement to `[]`
  - In `diy7` cycle generation, the predicates `@before`and `@after` merge as expected
  
# Example
```
diy7 -arch AArch64 -cycleonly true -size 4 -relax '[@before(Po) PodRW Rfe @after(Po)]' -safe Po
```
This constrains the generated boundary edges to match the predicates. `Po` will match `@before(Po)` and `after(Po)` during the searching.
```
Generator produced 2 tests
Relaxations tested: {[@before(PosRR),PodRW,Rfe,@after(PosRR)]} {[@before(PodRR),PodRW,Rfe,@after(PodRR)]}
LB000: PosRR PodRW Rfe PosRR PodRW Rfe
LB001: PodRR PodRW Rfe PodRR PodRW Rfe
```
Another example contains composite relax:
```
diy7 -arch AArch64 -cycleonly true -size 4 -relax '[PodRW Rfe @after([PodRW Rfe])]'
```
In this case, the only relaxation will be match with themselves, i.e., the leading `PodRW Rfe` matches the trailing `@after([PodRW Rfe])`.
```
Generator produced 3 tests
Relaxations tested: {[PodRW,Rfe,@after(PodRW),@after(Rfe)]}
LB000: PodRW Rfe PodRW Rfe
3.LB000: PodRW Rfe PodRW Rfe PodRW Rfe
4.LB000: PodRW Rfe PodRW Rfe PodRW Rfe PodRW Rfe
```