### PR TITLE
[aslspec] Fix prose rendering bugs

### DIFF
--- a/asllib/aslspec/render.ml
+++ b/asllib/aslspec/render.ml
@@ -1067,13 +1067,15 @@ module Make (S : SPEC_VALUE) = struct
     (** [pp_prose_rule_element fmt element] renders the prose for a single
         element of a rule with the formatter [fmt]. *)
     let rec pp_prose_rule_element fmt element =
-      let pp_case fmt { name; elements } =
-        pp_prose_rule_elements fmt ~case_name:name elements
-      in
       match element with
       | Judgment judgment -> pp_prose_judgment fmt judgment
       | Cases cases ->
           fprintf fmt "\\OneApplies@;<0 0>%a" (pp_itemized_list pp_case) cases
+
+    (** [pp_case fmt case] renders the prose for the single case [case] with the
+        formatter [fmt]. *)
+    and pp_case fmt { name; elements } =
+      pp_prose_rule_elements fmt ~case_name:name elements
 
     (** [pp_prose_rule_elements fmt ~case_name_opt elements] renders the prose
         for a list of rule elements [elements] with the formatter [fmt]. If
@@ -1103,10 +1105,18 @@ module Make (S : SPEC_VALUE) = struct
     let pp_render_rule_prose fmt { RuleRender.relation_name; path } =
       let relation = Spec.relation_for_id S.spec relation_name in
       let rule_elements = Spec.filter_rule_for_path relation path in
-      (* The case name is empty, since we are rendering at the top-level and
-        don't want to start with an "all of the following apply" or
-        "one of the following applies". *)
-      pp_prose_rule_elements fmt ~case_name:"" rule_elements
+      match rule_elements with
+      | [ Cases cases ] ->
+          (* When the top-level is just a list of cases, we want to start with
+             an "one of the following applies" without an extra level of nesting.
+          *)
+          fprintf fmt "\\OneApplies@;<0 0>%a" (pp_itemized_list pp_case) cases
+      | _ ->
+          (* The case name is empty, since we are rendering at the top-level and
+           don't want to start with an "all of the following apply" or
+           "one of the following applies".
+        *)
+          pp_prose_rule_elements fmt ~case_name:"" rule_elements
 
     (** [pp_render_rule_math_and_prose fmt def] renders both the mathematical
         inference rules and the prose description of the rules referenced by

--- a/asllib/aslspec/render.ml
+++ b/asllib/aslspec/render.ml
@@ -785,13 +785,16 @@ module Make (S : SPEC_VALUE) = struct
     let rec expr_to_prose expr =
       let open Expr in
       match expr with
-      | NamedExpr { expr = sub_expr; name } ->
+      | NamedExpr { expr = sub_expr; name; same_name } ->
           (* We strip names from the sub-expression to avoid prose like
             "... (for the output variable a) (for the output variable b)". *)
           let stripped_sub_expr = strip_names_from_expr sub_expr in
           let expr_prose = expr_to_prose stripped_sub_expr in
-          Format.asprintf "%s (for the output variable %s)" expr_prose
-            (var_to_prose name)
+          let pp_output_variable_prose fmt name =
+            if same_name then ()
+            else fprintf fmt " (for the output variable %s)" (var_to_prose name)
+          in
+          Format.asprintf "%s%a" expr_prose pp_output_variable_prose name
       | Var { id } when String.equal id Spec.ignore_var ->
           "some arbitrary value"
       | Var { id } -> (
@@ -1069,8 +1072,13 @@ module Make (S : SPEC_VALUE) = struct
     let rec pp_prose_rule_element fmt element =
       match element with
       | Judgment judgment -> pp_prose_judgment fmt judgment
-      | Cases cases ->
-          fprintf fmt "\\OneApplies@;<0 0>%a" (pp_itemized_list pp_case) cases
+      | Cases cases -> pp_prose_one_applies fmt cases
+
+    (** [pp_prose_one_applies fmt cases] renders the list [cases] with the
+        formatter [fmt] with the prose that implies only one of the cases should
+        apply. *)
+    and pp_prose_one_applies fmt cases =
+      fprintf fmt "\\OneApplies@;<0 0>%a" (pp_itemized_list pp_case) cases
 
     (** [pp_case fmt case] renders the prose for the single case [case] with the
         formatter [fmt]. *)
@@ -1109,13 +1117,15 @@ module Make (S : SPEC_VALUE) = struct
       | [ Cases cases ] ->
           (* When the top-level is just a list of cases, we want to start with
              an "one of the following applies" without an extra level of nesting.
+             (The case of a single judgment is already handled as an optimization
+             in [pp_prose_rule_elements].)
           *)
-          fprintf fmt "\\OneApplies@;<0 0>%a" (pp_itemized_list pp_case) cases
+          pp_prose_one_applies fmt cases
       | _ ->
           (* The case name is empty, since we are rendering at the top-level and
-           don't want to start with an "all of the following apply" or
-           "one of the following applies".
-        *)
+             don't want to start with an "all of the following apply" or
+             "one of the following applies".
+          *)
           pp_prose_rule_elements fmt ~case_name:"" rule_elements
 
     (** [pp_render_rule_math_and_prose fmt def] renders both the mathematical

--- a/asllib/aslspec/tests.t/rule.expected
+++ b/asllib/aslspec/tests.t/rule.expected
@@ -81,6 +81,6 @@ The relation
     \item define \texttt{y} as the rec record with $\Fieldf$ value \texttt{a} and $\Fieldg$ value \texttt{b}
     \item define \texttt{r\_f} as the sum of the field $\FIELDf$ of \texttt{r} and the field $\FIELDg$ of \texttt{r}
     \item define \texttt{r'} as \texttt{r} with $\FIELDf$ updated to \texttt{res}
-    \item \textbf{the result is:} the pair consisting of \texttt{res} (for the output variable \texttt{c}) and \texttt{r'} (for the output variable \texttt{r'}).
+    \item \textbf{the result is:} the pair consisting of \texttt{res} (for the output variable \texttt{c}) and \texttt{r'}.
   \end{itemize}
 } % EndDefineProse


### PR DESCRIPTION
Fixed a bug that resulted in redundant levels of nesting for prose with cases.
Fixed a bug that resulted in prose of the form `x (for the output variable x)`.