### PR TITLE
[aslspec] improvements to layouts: checks, tests, and documentation

### DIFF
--- a/asllib/aslspec/aslspec.md
+++ b/asllib/aslspec/aslspec.md
@@ -5,9 +5,9 @@ to be included in the ASL Reference.
 aslspec allows specifying the following kinds of elements:
 - Types
 - Constants
-- Relation signatures
+- Relations with or without inference rules
+- Operators
 - Rendering elements
-- Inference rules
 
 # Type definitions
 Types definitions define mathematical types (like Booleans) and AST node types.
@@ -110,7 +110,7 @@ constant empty_tenv {
 # Relation definitions
 Relations define the type, or *signature* of a relation symbol.
 
-FOr example:
+For example:
 ```
 relation annotate_expr(tenv: static_envs, e: expr) -> (t: ty, new_e: expr, ses: powerset(TSideEffect)) | type_error
 {
@@ -134,6 +134,160 @@ Relation definitions support the following attributes, with the same meaning as 
     and outputs (in the premise/conclusion of an inference rule).
 - `math_macro`: Optional LaTeX macro name to use in LaTeX math mode.
 
+# Operator definitions
+Operators define typed expression forms. They are written like function
+signatures, may have type parameters, and do not have inference rules:
+
+```
+operator equal[T](a: T, b: T) -> Bool
+{
+    math_macro = \equal,
+    prose_application = "{a} is equal to {b}",
+};
+```
+
+An operator application can use ordinary application syntax, such as
+`equal(a, b)`. Some operator names are also produced by built-in expression
+syntax; for example, `a = b` is an application of the operator `equal`, and
+`a + b` is an application of `num_plus`.
+
+The keyword `variadic` defines an operator that accepts any number of actual
+arguments. A variadic operator should have a single formal argument whose type
+is `list0(T)` or `list1(T)`:
+
+```
+variadic operator union[T](sets: list1(powerset(T))) -> powerset(T)
+{
+    associative = true,
+    math_macro = \unionop,
+    prose_application = "the union of {sets}",
+};
+```
+
+Operator definitions support the following attributes:
+
+- `math_macro`: Optional LaTeX macro name used when rendering the operator.
+- `prose_application`: A LaTeX string describing the operator applied to its
+  arguments.
+- `associative`: A Boolean attribute. When `true` on a variadic operator,
+  rendering separates the arguments with the operator macro instead of rendering
+  the macro as a function applied to a comma-separated argument list.
+- `custom`: A Boolean attribute. When `true`, binary operators use the general
+  custom-operator rendering form instead of the default infix rendering form.
+- `typecast`: A Boolean attribute used to guide typechecking for operators
+  that behave as type conversions. It is transparent for rendering.
+
+# Expressions
+Expressions are used in constant initializers, rule premises, transition
+outputs, and rule conclusions. Applications are resolved after parsing: a named
+application such as `r(a)` becomes a relation or operator application if `r`
+names a relation or operator; it becomes a labelled tuple construction if `r`
+names a tuple variant; and application of a non-name expression becomes a map
+application.
+
+aslspec supports the following expression forms:
+
+- Variables: `x`.
+- Tuples: `(e1, e2)` and labelled tuples such as `Pair(e1, e2)`.
+- Relation and operator applications: `r(e1, e2)`, `op(e)`, and nullary
+  operator applications such as `always_true()`.
+- Map applications, where the left-hand side is itself an expression:
+  `ctx.pred(a)`.
+- Field access: `r.f`.
+- List indexing: `xs[i]`.
+- Record construction: `[f: e1, g: e2]` and labelled records such as
+  `Rec[f: e1, g: e2]`.
+- Record updates: `r(f: e1, g: e2)`, meaning the record value `r` with the
+  listed fields updated.
+- Conditional expressions: `if c then e1 else e2`.
+- Multi-way conditional expressions: `cond(c1: e1, c2: e2)`.
+- Infix operator forms:
+  `lhs := rhs`, `lhs =: rhs`, `lhs = rhs`, `lhs - rhs`, `lhs + rhs`,
+  `lhs * rhs`, `lhs / rhs`, `lhs ^ rhs`, `lhs && rhs`, `lhs || rhs`,
+  `lhs in rhs`, `lhs not_in rhs`, `lhs <=> rhs`, `lhs <= rhs`, `lhs < rhs`,
+  `lhs >= rhs`, `lhs > rhs`, and `lhs != rhs`.
+- Transition judgments: `lhs -> rhs`. These are only rule judgments, not
+  general sub-expressions.
+- Indexed judgments: `INDEX(i, xs: step(xs[i]) -> ys[i])`. These are also only
+  rule judgments.
+
+Transition judgments can optionally override short-circuiting alternatives:
+
+```
+eval_expr(env, e) -> ResultExpr((v, g), _) | DynErrorConfig(), DivergingConfig();
+```
+
+Writing `| ;` after the transition gives an explicit empty list of alternatives.
+If no `|` is written, aslspec inserts the alternatives from the relation
+definition, when applicable.
+
+Transition outputs intentionally use a smaller expression language than general
+premises. They can contain variables, tuples, labelled tuple constructors, list
+indexing, and infix operators.
+
+# Inference rules
+Relations can include inference rules after their attributes by adding `=`
+followed by one or more rule elements:
+
+```
+relation if_then_else(flag: Bool, a: Num, b: Num) -> Num {} =
+    case Left {
+        flag = True;
+        --
+        a;
+    }
+    case Right {
+        flag = False;
+        --
+        b;
+    }
+;
+```
+
+A rule element is either a judgment followed by `;`, or a named `case`.
+Cases can be nested. When rules are rendered, nested case names form a
+dot-separated path such as `Outer.Inner`.
+
+Judgments that are not prefixed by `--` are premises. A judgment prefixed by
+`--` is the rule conclusion. Each expanded rule path must have exactly one
+conclusion, and it must be the final judgment on that path.
+
+The conclusion is written as an expression, but it is checked and rendered as
+an application of the surrounding relation to its inputs. For example, in:
+
+```
+relation id(x: Num) -> Num {} =
+    --
+    x;
+;
+```
+
+the conclusion `x` is treated as the transition judgment `id(x) -> x`. This is
+why a conclusion-level `math_layout` has a top-level left/right pair, as
+described in the layout section below.
+
+Premises can be ordinary Boolean expressions, transition judgments, or indexed
+judgments. A transition judgment has the form `lhs -> rhs`:
+
+```
+relation step_one(x: Num) -> Num {} =
+    id(x) -> y;
+    --
+    y;
+;
+```
+
+An indexed judgment binds an index and a list variable for the body transition:
+
+```
+INDEX(i, xs: step(xs[i]) -> ys[i]);
+```
+
+Inference-rule checking type-checks every premise and conclusion. Ordinary
+premises must have type `Bool`. Transition premises and conclusions must match
+the signature of the relation they apply, including tuple-shaped outputs.
+Judgment attributes currently support `math_layout`, which is checked against
+the resolved judgment shape before rendering.
 
 # Type rendering definitions
 Type rendering controls how types and their variants are displayed.
@@ -143,22 +297,224 @@ They also allow rendering types with just a subset of their variants.
 
 For example:
 - `render calls = expr(E_Call), stmt(S_Call);` defines `calls` as a handle for rendering
-   how `expr` with juts its `E_Call` variant together with `stmt` with just its `S_Call` variant.
+   how `expr` with just its `E_Call` variant together with `stmt` with just its `S_Call` variant.
 - `render ty_int_constraint_and_kind = ty(T_Int), int_constraint(-), constraint_kind(-);`
   specifies three types, where the notation `(-)` for `int_constraint` is used to select
   all of its variants.
 
 Type renders do not support any attributes.
 
+# Inference rule rendering definitions
+Rule rendering definitions select which inference rules are emitted as LaTeX
+macros. The simplest form renders all expanded rules for a relation under the
+same name:
+
+```
+render rule if_then_else;
+```
+
+This produces rule and prose macros named `if_then_else` for the relation `if_then_else`.
+If a relation has inference rules and no explicit rule rendering definition,
+aslspec adds this default form automatically.
+
+The explicit form gives the generated macro a different name and selects a
+case path from a relation:
+
+```
+render rule if_then_else_left = if_then_else(Left);
+render rule if_then_else_nested = if_then_else(Outer.Inner);
+render rule if_then_else_all = if_then_else(-);
+```
+
+The path in parentheses is a dot-separated prefix of the expanded case path.
+For example, `if_then_else(Outer)` selects rules under `Outer` and
+`if_then_else(Outer.Inner)` selects only rules under `Outer.Inner`. The special path
+`-` is the empty path, which is a prefix of every expanded rule path, so
+`if_then_else(-)` selects all rules of `if_then_else`.
+
+# Laying out mathematical expressions
+
+The `math_layout` attribute controls whether a compound mathematical object is
+rendered horizontally or vertically, and how layouts are passed to its
+sub-objects. A layout is structural: it must have the same shape as the term or
+expression it is attached to.
+
+Layouts use the following notation:
+
+- `_`: no specific layout. This can always be used as the default layout for any
+  term or expression.
+- `(_, ..., _)`: a horizontal layout. Each cell is the layout for the
+  corresponding sub-object.
+- `[_, ..., _]`: a vertical layout. Each cell is the layout for the corresponding
+  sub-object.
+
+For example, `(a, (b, c)) { (_, (_, _)) }` lays out the outer tuple
+horizontally, passes `_` to `a`, and passes `(_, _)` to the nested tuple
+`(b, c)`.
+
+## Default-layout shorthands
+
+The single-cell layouts `(_)` and `[_]` are also accepted as default-layout
+shorthands. For a list-shaped term or expression, the single `_` is repeated to
+match the number of immediate components being rendered. Thus, `[_]` means
+`[_, ..., _]`, with one `_` for each immediate component, and similarly `(_)`
+means `(_, ..., _)`. The enclosing parentheses or brackets control only the
+layout of those immediate components; each `_` gives its corresponding
+component the default layout rather than recursively making it horizontal or
+vertical. For example, `(a, (b, c)) { [_] }` is equivalent to
+`(a, (b, c)) { [_, _] }`: `a` and `(b, c)` are arranged vertically, while the
+nested tuple `(b, c)` uses its default layout. Consequently, `x { [_] }`,
+`r(a, b) { (_) }`, and `make_set(a, b, c) { [_] }` are all valid.
+
+## Layouts for type terms
+
+For type terms, `_` is always valid. Any more specific layout follows the type
+constructor:
+
+- Atomic type terms such as `Num` or `Bool` accept only the default layouts `_`,
+  `(_)`, and `[_]`.
+- Tuple and labelled tuple terms use one layout cell per component:
+  `Pair(Num, (Bool, Num))` can use `(_, (_, _))`. The shorthand `(_)` or `[_]`
+  defaults all components.
+- Record terms use one layout cell per field value, in field order:
+  `[f: Num, g: (Bool, Num)]` can use `(_, (_, _))`. The shorthand `(_)` or
+  `[_]` defaults all fields.
+- Function terms use two layout cells, one for the left-hand side and one for
+  the right-hand side: `fun (A, B) -> C` can use `((_, _), _)`. As with other
+  pair renderers, `(_)` or `[_]` defaults both sides.
+- Type operators such as `powerset(T)` and parameterized types pass their layout
+  through to the enclosed term.
+
+Relation `math_layout` attributes are checked against a pair consisting of the
+relation inputs and outputs. For example, this relation has a top-level
+input/output pair; the input side has two arguments, and the output side has two
+components:
+
+```
+relation r(a: Num, b: Num) -> (c: Num, d: Num)
+{
+    math_layout = ((_, _), (_, _)),
+};
+```
+
+## Layouts for rule expressions
+
+For rule judgments and premises, `_` is always valid. Any more specific layout
+follows the resolved expression:
+
+- Variables are atomic leaves: `x { _ }` and `x { (_) }` are valid, but
+  `x { (_, _) }` is not.
+- Nullary operators are also atomic leaves: `op { _ }`, `op { (_) }`, and
+  `op { [_] }` are valid, but `op { () }` and `op { [] }` are not.
+- Unary operators pass their layout to their single argument.
+- Relations, tuples, maps, and non-unary operators use one layout cell per
+  argument: `r(a, (b, c)) { (_, (_, _)) }` is valid. The shorthand `(_)` or
+  `[_]` defaults all arguments, so `r(a, b) { (_) }` is also valid, while
+  `r(a, b) { (_, _, _) }` is not.
+- Records use one layout cell per field value:
+  `[f: a, g: (b, c)] { (_, (_, _)) }`. The shorthand `(_)` or `[_]` defaults
+  all field values.
+- Record updates are a pair of the base record expression and the update fields:
+  `r(f: a, g: b) { (_, (_, _)) }`. Record updates do not use the pair-renderer
+  shorthand, so `r(f: a) { (_) }` is not valid.
+- List indexing and field access pass the layout through to the expression they
+  contain: `xs[(a, b)] { (_, _) }` checks the index expression, and
+  `r.f { _ }` checks the base expression.
+- Transition judgments are a pair around the arrow:
+  `r(a) -> (b, c) { (_, (_, _)) }`. The shorthand `(_)` or `[_]` defaults both
+  sides.
+
+Constant initializer layouts are checked as expression layouts. For example,
+`constant c = (True, False) { math_layout = (_, _) };` is valid, and
+`constant c = (True, False) { math_layout = (_, _, _) };` is not.
+
+## Layouts for conclusion judgments
+
+Output judgments in rules are written as expressions:
+
+```
+--
+(b, c) { (_, (_, _)) };
+```
+
+Before rendering and layout checking, aslspec rewrites the output expression into
+a transition judgment whose left-hand side is the relation applied to its input
+arguments:
+
+```
+r(a) -> (b, c)
+```
+
+Therefore, the layout attached to an output judgment is checked against the
+rewritten transition, not just against the output expression. A specific
+top-level layout must be a pair: one cell for the left-hand side of `->`, and
+one cell for the right-hand side. The single-cell layouts `(_)` and `[_]` are
+also accepted as shorthands for defaulting both sides.
+
+For a relation `r(a: Num) -> (b: Num, c: Num)`, this is legal:
+
+```
+--
+(b, c) { (_, (_, _)) };
+```
+
+The first `_` is the layout for the implicit left-hand side `r(a)`, and
+`(_, _)` is the layout for the output tuple `(b, c)`. This is illegal:
+
+```
+--
+(b, c) { (_, _, _) };
+```
+
+because the rewritten transition has two top-level parts, not three.
+
 # A note on attributes
 A string with an unspecified attribute name, for example, `"description"` is shorthand
 for `prose_description = "description"`.
 
 # Using definitions in LaTeX
-Each kind of definition produces a definition of a LaTeX macro:
-- A type `T` produces a macro `\RenderType{T}`
-- A constant `c` produces a macro `\RenderConstant{c}`
-- A relation `r` produces a macro `\RenderRelation{r}`
-- A rendering definition `d` produces a macro `RenderTypes{d}`
+Running aslspec with `--render` writes a generated LaTeX file, named
+`generated_macros.tex` by default. The generated file contains `\Define...`
+commands for the checked specification. The wrapper macros in
+[rendering_macros.sty](../doc/rendering_macros.sty) expose those definitions
+through `\Render...` commands.
 
-These macros are defined in [here](../doc/rendering_macros.tex)
+A standalone `.tex` file should load the wrapper macros and then input the
+generated definitions:
+
+```
+\usepackage{rendering_macros}
+\input{generated_macros.tex}
+```
+
+Each kind of definition produces a render command:
+
+- A type `T` produces `\RenderType{T}`.
+- A constant `c` produces `\RenderConstant{c}`.
+- A relation `r` produces `\RenderRelation{r}`.
+- A type rendering definition `d` produces `\RenderTypes{d}`.
+- A rule rendering definition `rr` produces `\RenderRule{rr}` and
+  `\RenderProse{rr}`.
+
+For example, a `.tex` file that has loaded the generated macros can use:
+
+```
+\RenderType{expr}
+\RenderTypes[remove_hypertargets]{expr_literal}
+\RenderConstant{empty_tenv}
+\RenderRelation{annotate_expr}
+\RenderRule{annotate_expr_ELit}
+\RenderProse{annotate_expr_ELit}
+```
+
+When the ASL document macros are also loaded,
+`\RenderProseAndFormally{name}` renders the prose form followed by the formal
+inference rule for the same rule-rendering name:
+
+```
+\RenderProseAndFormally{annotate_expr_ELit}
+```
+
+The optional argument `[remove_hypertargets]` is supported by `\RenderType`,
+`\RenderTypes`, and `\RenderConstant`. It is not supported by `\RenderRule`,
+`\RenderProse`, or `\RenderRelation`.

--- a/asllib/aslspec/error.ml
+++ b/asllib/aslspec/error.ml
@@ -27,6 +27,13 @@ let bad_layout term layout ~consistent_layout =
        "layout %a is inconsistent with %a. Here's a consistent layout: %a"
        PP.pp_layout layout PP.pp_type_term term PP.pp_layout consistent_layout
 
+let bad_expr_layout expr layout ~consistent_layout =
+  spec_error_loc_of_expr expr
+  @@ Format.asprintf
+       "layout %a is inconsistent with expression %a. Here's a consistent \
+        layout: %a"
+       PP.pp_layout layout PP.pp_expr expr PP.pp_layout consistent_layout
+
 let undefined_reference loc id context =
   spec_error loc @@ Format.asprintf "Undefined reference to %s in %s" id context
 

--- a/asllib/aslspec/spec.ml
+++ b/asllib/aslspec/spec.ml
@@ -804,65 +804,272 @@ let filter_rule_for_path { Relation.name; rule_opt; loc } path_str =
   filter_rule_elements (Option.get rule_opt) path
 
 module Check = struct
-  (** [check_layout term layout] checks that the given [layout] is structurally
-      consistent with the given [term]. If not, raises a [SpecError] describing
-      the issue. *)
-  let rec check_layout term layout =
-    let consistent_layout = Layout.for_type_term term in
-    let open Layout in
-    let open Term in
-    match (term, layout) with
-    | (Label _ | Parameter _), Unspecified -> ()
-    | (Label _ | Parameter _), _ ->
-        Error.bad_layout term layout ~consistent_layout
-    | TypeOperator { term = _, t }, _ -> check_layout t layout
-    | ParamType { term = _, t }, _ -> check_layout t layout
-    | Tuple { args }, Horizontal cells | Tuple { args }, Vertical cells ->
-        if List.compare_lengths args cells <> 0 then
-          Error.bad_layout term layout ~consistent_layout
-        else
-          List.iter2 (fun (_, term) cell -> check_layout term cell) args cells
-    | Record { fields }, Horizontal cells | Record { fields }, Vertical cells ->
-        if List.compare_lengths fields cells <> 0 then
-          Error.bad_layout term layout ~consistent_layout
-        else
-          List.iter2
-            (fun { Term.term } cell -> check_layout term cell)
-            fields cells
-    | ConstantsSet { loc; labels }, (Horizontal cells | Vertical cells) ->
-        if List.compare_lengths labels cells <> 0 then
-          Error.bad_layout term layout ~consistent_layout
-        else
-          List.iter2
-            (fun _ cell -> check_layout (Label { loc; label = "" }) cell)
-            labels cells
-    | ( Function { from_type = _, from_term; to_type = _, to_term; _ },
-        (Horizontal cells | Vertical cells) ) ->
-        if List.length cells <> 2 then
-          Error.bad_layout term layout ~consistent_layout
-        else check_layout from_term (List.nth cells 0);
-        check_layout to_term (List.nth cells 1)
-    | _, Unspecified -> ()
+  (** [check spec] checks that all math layout attributes in [spec] match the
+      structure of their respective AST nodes, raising a [SpecError] if any
+      check fails. *)
+  module CheckLayout : sig
+    val check : t -> unit
+  end = struct
+    let is_default_layout = function
+      | Unspecified | Horizontal [ Unspecified ] | Vertical [ Unspecified ] ->
+          true
+      | Horizontal _ | Vertical _ -> false
 
-  (** [check_math_layout spec] checks that the math layouts for all defining
-      nodes in [spec] are structurally consistent with their type terms. *)
-  let check_math_layout spec =
-    let check_math_layout_for_definition_node node =
-      let loc = loc_of_definition_node node in
+    (** [check_term term layout] checks that the given [layout] is structurally
+        consistent with the given [term]. If not, raises a [SpecError]
+        describing the issue. *)
+    let rec check_term term layout =
+      let consistent_layout = Layout.for_type_term term in
       let open Layout in
-      match node with
-      | Node_Type { Type.name } ->
-          check_layout (Label { loc; label = name }) (math_layout_for_node node)
-      | Node_Constant { Constant.name } ->
-          check_layout (Label { loc; label = name }) (math_layout_for_node node)
-      | Node_TypeVariant { TypeVariant.term } ->
-          check_layout term (math_layout_for_node node)
-      | Node_Relation def ->
-          check_layout (relation_to_tuple def) (math_layout_for_node node)
-      | Node_RecordField { term } ->
-          check_layout term (math_layout_for_node node)
-    in
-    iter_defined_nodes spec check_math_layout_for_definition_node
+      let open Term in
+      let check_term_list terms cells =
+        if List.compare_lengths terms cells <> 0 then
+          Error.bad_layout term layout ~consistent_layout
+        else List.iter2 check_term terms cells
+      in
+      match (term, layout) with
+      (* Default layouts are valid for every term. *)
+      | _, (Unspecified | Horizontal [ Unspecified ] | Vertical [ Unspecified ])
+        ->
+          ()
+      | (Label _ | Parameter _), _ ->
+          Error.bad_layout term layout ~consistent_layout
+      | TypeOperator { term = _, t }, _ -> check_term t layout
+      | ParamType { term = _, t }, _ -> check_term t layout
+      | Tuple { args }, Horizontal cells | Tuple { args }, Vertical cells ->
+          check_term_list (List.map snd args) cells
+      | Record { fields }, Horizontal cells | Record { fields }, Vertical cells
+        ->
+          check_term_list (List.map (fun { Term.term } -> term) fields) cells
+      | ConstantsSet { labels }, (Horizontal cells | Vertical cells) ->
+          if
+            List.compare_lengths labels cells = 0
+            && List.for_all is_default_layout cells
+          then ()
+          else Error.bad_layout term layout ~consistent_layout
+      | ( Function { from_type = _, from_term; to_type = _, to_term; _ },
+          ( Horizontal [ from_layout; to_layout ]
+          | Vertical [ from_layout; to_layout ] ) ) ->
+          check_term from_term from_layout;
+          check_term to_term to_layout
+      | Function _, _ -> Error.bad_layout term layout ~consistent_layout
+
+    let rec check_expr_list spec exprs layout ~expr_for_error =
+      let consistent_layout =
+        Horizontal (LayoutUtils.unspecified_for_elements exprs)
+      in
+      match layout with
+      (* List renderers treat a single default cell as "use the default layout
+         for every element", regardless of list length. For example, both
+         "r(a, b) { (_) }" and "r(a, b) { [_] }" are valid. *)
+      | Unspecified | Horizontal [ Unspecified ] | Vertical [ Unspecified ] ->
+          ()
+      | Horizontal cells | Vertical cells ->
+          if List.compare_lengths exprs cells <> 0 then
+            Error.bad_expr_layout expr_for_error layout ~consistent_layout
+          else List.iter2 (check_expr spec) exprs cells
+
+    (* Pair renderers such as transitions use pp_connect_pair, not the generic
+       list renderer. Like list renderers, they accept a single default cell as
+       shorthand: "r(a) -> b { (_) }" defaults both sides. Record updates are not
+       rendered through pp_connect_pair, so this shorthand is disabled for them. *)
+    and check_expr_pair ?(allow_single_unspecified = true) spec lhs rhs layout
+        ~expr_for_error =
+      match layout with
+      | Unspecified -> ()
+      | (Horizontal [ Unspecified ] | Vertical [ Unspecified ])
+        when allow_single_unspecified ->
+          ()
+      | Horizontal [ lhs_layout; rhs_layout ]
+      | Vertical [ lhs_layout; rhs_layout ] ->
+          check_expr spec lhs lhs_layout;
+          check_expr spec rhs rhs_layout
+      | Horizontal _ | Vertical _ ->
+          let consistent_layout =
+            Horizontal [ layout_for_expr lhs; layout_for_expr rhs ]
+          in
+          Error.bad_expr_layout expr_for_error layout ~consistent_layout
+
+    and check_operator_expr spec expr name args layout =
+      let operator = relation_for_id spec name in
+      match (operator.Relation.input, args) with
+      | [], [] ->
+          (* Nullary operators render as atomic expressions, so they accept only
+             default layouts. For example, "op() { _ }" is valid, but
+             "op() { () }" is not. *)
+          if is_default_layout layout then ()
+          else Error.bad_expr_layout expr layout ~consistent_layout:Unspecified
+      | [ _ ], [ arg ] ->
+          if operator.Relation.is_variadic then
+            (* A variadic operator has one formal input even when it has multiple
+               actual arguments, which the renderer lays out as a list. For
+               example, "make_set((a, b)) { (_, _) }" is invalid because it
+               provides two list cells for one argument; the valid layout is
+               "((_, _))". *)
+            check_expr_list spec args layout ~expr_for_error:expr
+          else
+            (* A non-variadic unary operator passes its layout directly to its
+               argument. For example, "some((a, b)) { (_, _) }" is valid because
+               the pair layout applies directly to the tuple. *)
+            check_expr spec arg layout
+      | _ -> check_expr_list spec args layout ~expr_for_error:expr
+
+    and check_expr spec expr layout =
+      let open Expr in
+      match expr with
+      | NamedExpr { expr = sub_expr } ->
+          (* Internal names are layout-transparent. The layout applies to the
+             wrapped expression: "x /* y */ { _ }" is checked like "x { _ }". *)
+          check_expr spec sub_expr layout
+      | Var _ ->
+          (* Variables are atomic layout leaves. They have no child expressions
+             to distribute layout cells to, so only the default layout is valid:
+             "x { _ }" and "x { (_) }" are valid, but "x { (_, _) }" is not. *)
+          if is_default_layout layout then ()
+          else Error.bad_expr_layout expr layout ~consistent_layout:Unspecified
+      | Relation { name; is_operator = true; args } ->
+          (* Operators have a few renderer-specific forms: nullary operators are
+             atomic leaves, simple unary operators pass their layout to their
+             sole argument, and other operators distribute layout cells over
+             arguments. For example, "a + (b, c) { (_, (_, _)) }" lays out the
+             left and right operands separately. *)
+          check_operator_expr spec expr name args layout
+      | Relation { args } | Tuple { args } | Map { args } ->
+          (* Relations, tuples, and maps render their arguments as a list, so
+             layout cells are distributed over that list. A single default cell
+             covers the whole list. For example, "r(a, b) { (_) }" and
+             "r(a, (b, c)) { (_, (_, _)) }" are valid, while "r(a, b) { (_, _,
+             _) }" is not. *)
+          check_expr_list spec args layout ~expr_for_error:expr
+      | Record { fields } ->
+          (* Records render their field values as a list in field order, with
+             the field names outside the expression layout. For example,
+             "[f: a, g: (b, c)] { (_, (_, _)) }" is valid. *)
+          check_expr_list spec (List.map snd fields) layout ~expr_for_error:expr
+      | RecordUpdate { record_expr; updates } ->
+          (* Record updates are a pair: the base record expression and the
+             update fields. The update fields then have their own list layout.
+             For example, "r(f: a, g: b) { (_, (_, _)) }" is valid. Since record
+             updates are not rendered through pp_connect_pair, "r(f: a) { (_) }"
+             is not. *)
+          let updates_expr =
+            Expr.Record
+              { loc = Expr.loc_of expr; label_opt = None; fields = updates }
+          in
+          check_expr_pair ~allow_single_unspecified:false spec record_expr
+            updates_expr layout ~expr_for_error:expr
+      | ListIndex { index = sub_expr } | FieldAccess { base = sub_expr } ->
+          (* List indexing and field access are layout-transparent wrappers
+             around their sub-expression: "xs[(a, b)] { (_, _) }" checks the
+             index layout, and "r.f { _ }" checks the base expression layout. *)
+          check_expr spec sub_expr layout
+      | Indexed { body } -> (
+          if
+            is_default_layout layout
+            (* Indexed judgments render as an index binder paired with the body.
+             The binder itself has no expression layout, so either the default
+             layout or a two-cell pair is valid:
+             "INDEX(i, xs: body) { (_, body_layout) }". *)
+          then ()
+          else
+            match layout with
+            | Horizontal [ index_layout; body_layout ]
+            | Vertical [ index_layout; body_layout ] ->
+                if not (is_default_layout index_layout) then
+                  Error.bad_expr_layout expr layout
+                    ~consistent_layout:(layout_for_expr expr)
+                else check_expr spec body body_layout
+            | _ ->
+                Error.bad_expr_layout expr layout
+                  ~consistent_layout:
+                    (Horizontal [ Unspecified; layout_for_expr body ]))
+      | Transition { lhs; rhs } ->
+          (* Transitions render as a top-level lhs/rhs pair around the arrow.
+             This is why output judgments are checked after resolution as
+             "r(args) -> out": "r(a) -> (b, c) { (_, (_, _)) }" is valid. *)
+          check_expr_pair spec lhs rhs layout ~expr_for_error:expr
+      | UnresolvedApplication _ -> assert false
+
+    and layout_for_expr expr =
+      let open Expr in
+      match expr with
+      | NamedExpr { expr = sub_expr } -> layout_for_expr sub_expr
+      | Var _ -> Unspecified
+      | Relation { args } | Tuple { args } | Map { args } ->
+          Horizontal (List.map layout_for_expr args)
+      | Record { fields } ->
+          Horizontal (List.map (fun (_, expr) -> layout_for_expr expr) fields)
+      | RecordUpdate { record_expr; updates } ->
+          Horizontal
+            [
+              layout_for_expr record_expr;
+              Horizontal
+                (List.map (fun (_, expr) -> layout_for_expr expr) updates);
+            ]
+      | ListIndex { index } -> layout_for_expr index
+      | FieldAccess { base } -> layout_for_expr base
+      | Indexed { body } -> Horizontal [ Unspecified; layout_for_expr body ]
+      | Transition { lhs; rhs } ->
+          Horizontal [ layout_for_expr lhs; layout_for_expr rhs ]
+      | UnresolvedApplication _ -> Unspecified
+
+    let rec check_rule_element spec =
+      let open Rule in
+      function
+      | Judgment ({ expr } as judgment) ->
+          check_expr spec expr (Rule.judgment_layout judgment)
+      | Cases cases ->
+          List.iter
+            (fun { elements; _ } ->
+              List.iter (check_rule_element spec) elements)
+            cases
+
+    (** [check spec] checks that the math layouts for all defining nodes in
+        [spec] are structurally consistent with their type terms, and that rule
+        judgment layouts are structurally consistent with their expressions. *)
+    let check spec =
+      let check_math_layout_for_definition_node node =
+        let loc = loc_of_definition_node node in
+        let open Layout in
+        match node with
+        | Node_Type { Type.name } ->
+            check_term (Label { loc; label = name }) (math_layout_for_node node)
+        | Node_Constant ({ Constant.name; opt_value_and_attributes } as def) ->
+            check_term (Label { loc; label = name }) (math_layout_for_node node);
+            Option.iter
+              (fun (expr, _) ->
+                let layout =
+                  Option.value
+                    (Constant.value_math_layout def)
+                    ~default:Unspecified
+                in
+                check_expr spec expr layout)
+              opt_value_and_attributes
+        | Node_TypeVariant { TypeVariant.term } ->
+            check_term term (math_layout_for_node node)
+        | Node_Relation def ->
+            check_term (relation_to_tuple def) (math_layout_for_node node)
+        | Node_RecordField { term } ->
+            check_term term (math_layout_for_node node)
+      in
+      let check_rule_layout_for_elem = function
+        | Elem_Relation { Relation.rule_opt = Some elements } ->
+            List.iter (check_rule_element spec) elements
+        | _ -> ()
+      in
+      let check_type_variant_layout_for_elem = function
+        | Elem_Type { Type.variants } ->
+            List.iter
+              (fun ({ TypeVariant.term } as variant) ->
+                check_term term
+                  (Layout.math_layout_for_node (Node_TypeVariant variant)))
+              variants
+        | _ -> ()
+      in
+      iter_defined_nodes spec check_math_layout_for_definition_node;
+      List.iter check_type_variant_layout_for_elem spec.ast;
+      List.iter check_rule_layout_for_elem spec.ast
+  end
 
   (** Returns all the identifiers referencing nodes that define identifiers. *)
   let rec referenced_ids =
@@ -3682,12 +3889,12 @@ let from_ast ast =
   let () = Check.check_no_undefined_ids spec in
   let () = Check.check_relation_outputs spec in
   let () = Check.CheckTypeInstantiations.check spec in
-  let () = Check.check_math_layout spec in
   let () = Check.CheckProseTemplates.check spec in
   let () = Check.relation_named_arguments_if_exists_rule ast in
   let spec = ResolveApplicationExpr.resolve spec in
   let spec = ExtendConstantsWithTypes.extend spec in
   let spec = ResolveRules.resolve spec in
+  let () = Check.CheckLayout.check spec in
   let spec = ExtendNames.extend spec in
   let () = Check.CheckRules.check spec in
   let spec = add_default_rule_renders spec in

--- a/asllib/aslspec/tests.t/expressions_correct.spec
+++ b/asllib/aslspec/tests.t/expressions_correct.spec
@@ -1,0 +1,72 @@
+typedef N;
+
+typedef Rec =
+    | R[rf: N, rg: N]
+;
+
+typedef Ctx =
+    | [pred: fun N -> Bool]
+;
+
+operator assign[T](lhs: T, rhs: T) -> Bool {};
+operator reverse_assign[T](lhs: T, rhs: T) -> Bool {};
+operator equal[T](lhs: T, rhs: T) -> Bool {};
+operator num_minus(lhs: N, rhs: N) -> N {};
+operator num_plus(lhs: N, rhs: N) -> N {};
+operator num_times(lhs: N, rhs: N) -> N {};
+operator num_divide(lhs: N, rhs: N) -> N {};
+operator num_exponent(lhs: N, rhs: N) -> N {};
+operator and(lhs: Bool, rhs: Bool) -> Bool {};
+operator or(lhs: Bool, rhs: Bool) -> Bool {};
+operator iff(lhs: Bool, rhs: Bool) -> Bool {};
+operator member[T](x: T, s: powerset(T)) -> Bool {};
+operator not_member[T](x: T, s: powerset(T)) -> Bool {};
+operator less_or_equal(lhs: N, rhs: N) -> Bool {};
+operator less_than(lhs: N, rhs: N) -> Bool {};
+operator greater_or_equal(lhs: N, rhs: N) -> Bool {};
+operator greater_than(lhs: N, rhs: N) -> Bool {};
+operator not_equal[T](lhs: T, rhs: T) -> Bool {};
+operator if_then_else[T](c: Bool, then_branch: T, else_branch: T) -> T {};
+operator cond_case[T](c: Bool, result: T) -> T {};
+variadic operator cond_op[T](cases: list1(T)) -> T {};
+variadic operator make_set[T](members: list1(T)) -> powerset(T) {};
+
+relation step(x: N) -> N {};
+
+relation expression_forms(
+    a: N,
+    b: N,
+    flag: Bool,
+    xs: list0(N),
+    r: Rec,
+    ctx: Ctx
+) -> (out: N, ok: Bool)
+{} =
+    sum := a + b;
+    diff := a - b;
+    product := a * b;
+    quotient := a / b;
+    power := a ^ b;
+    chosen := if flag then sum else diff;
+    cond_chosen := cond(flag: chosen, True: product);
+    tuple_value := (chosen, cond_chosen);
+    rec_value := R[rf: chosen, rg: cond_chosen];
+    updated := r(rf: rec_value.rg);
+    indexed := xs[a + b];
+    updated.rf =: reverse_target;
+    ctx.pred(indexed);
+    flag && True;
+    flag || False;
+    flag <=> True;
+    a in make_set(a, b);
+    a not_in make_set(b);
+    a <= b;
+    a < b;
+    a >= b;
+    a > b;
+    a != b;
+    step(a) -> stepped | ;
+    INDEX(i, xs: step(xs[i]) -> ys[i]);
+    --
+    (stepped, flag);
+;

--- a/asllib/aslspec/tests.t/field_access_unknown.bad
+++ b/asllib/aslspec/tests.t/field_access_unknown.bad
@@ -1,0 +1,9 @@
+typedef Rec =
+    | [rf: N]
+;
+
+relation bad_field_access(r: Rec) -> N
+{} =
+    --
+    r.rg;
+;

--- a/asllib/aslspec/tests.t/layout_correct.spec
+++ b/asllib/aslspec/tests.t/layout_correct.spec
@@ -1,0 +1,72 @@
+typedef LayoutTerm
+{ math_layout = _ } =
+    | (N)
+    { math_layout = _ }
+    | (N, (Bool, N))
+    { math_layout = (_, (_, _)) }
+    | Pair(N, (Bool, N))
+    { math_layout = (_, (_, _)) }
+    | [lt_f: N, lt_g: (Bool, N)]
+    { math_layout = (_, (_, _)) }
+    | fun (N, Bool) -> (N, N)
+    { math_layout = ((_, _), (_, _)) }
+    | powerset((N, Bool))
+    { math_layout = (_, _) }
+    | constants_set(True, False)
+    { math_layout = (_, _) }
+;
+
+typedef Ctx
+{ math_layout = _ } =
+    | [pred: fun N -> Bool]
+    { math_layout = _ }
+;
+
+typedef RecN
+{ math_layout = _ } =
+    | [rf: N, rg: N]
+    { math_layout = (_, _) }
+;
+
+typedef RecPair
+{ math_layout = _ } =
+    | [pf: N, pg: (N, N)]
+    { math_layout = (_, (_, _)) }
+;
+
+constant layout_constant_value = (True, False)
+{ math_layout = (_, _) };
+
+relation bool_rel(x: N) -> Bool
+{};
+
+relation step(x: N) -> N
+{};
+
+operator always_true() -> Bool
+{};
+
+relation layout_exprs(
+    a: N,
+    b: N,
+    c: N,
+    flag: Bool,
+    r: RecN,
+    xs: list0(N),
+    ctx: Ctx
+) -> (out1: N, out2: N)
+{} =
+    flag { _ };
+    always_true() { _ };
+    not(flag) { _ };
+    bool_rel(a + b) { ((_, _)) };
+    ctx.pred(a) { (_) };
+    [pf: a, pg: (b, c)] = [pf: a, pg: (b, c)]
+    { ((_, (_, _)), (_, (_, _))) };
+    r(rf: a, rg: b) = r { ((_, (_, _)), _) };
+    xs[a + b] = c { ((_, _), _) };
+    r.rf = a { (_, _) };
+    INDEX(i, xs: step(xs[i]) -> _) { (_, (_, _)) };
+    --
+    (a, b) { (_, (_, _)) };
+;

--- a/asllib/aslspec/tests.t/layout_expr_atomic.bad
+++ b/asllib/aslspec/tests.t/layout_expr_atomic.bad
@@ -1,0 +1,10 @@
+operator always_true() -> Bool
+{};
+
+relation bad_atomic_expr(flag: Bool) -> Bool
+{} =
+    flag { math_layout = (_, _) };
+    always_true() { math_layout = () };
+    --
+    flag;
+;

--- a/asllib/aslspec/tests.t/layout_expr_list.bad
+++ b/asllib/aslspec/tests.t/layout_expr_list.bad
@@ -1,0 +1,9 @@
+relation two_args(a: N, b: N) -> Bool
+{};
+
+relation bad_expr_list(a: N, b: N) -> Bool
+{} =
+    two_args(a, b) { math_layout = (_, _, _) };
+    --
+    True;
+;

--- a/asllib/aslspec/tests.t/layout_expr_nullary.bad
+++ b/asllib/aslspec/tests.t/layout_expr_nullary.bad
@@ -1,0 +1,9 @@
+operator always_true() -> Bool
+{};
+
+relation bad_nullary_expr() -> Bool
+{} =
+    always_true() { math_layout = () };
+    --
+    True;
+;

--- a/asllib/aslspec/tests.t/layout_record_update.bad
+++ b/asllib/aslspec/tests.t/layout_record_update.bad
@@ -1,0 +1,10 @@
+typedef RecN =
+    | [rf: N, rg: N]
+;
+
+relation bad_record_update(r: RecN, a: N, b: N) -> Bool
+{} =
+    r(rf: a, rg: b) = r { math_layout = ((_), _) };
+    --
+    True;
+;

--- a/asllib/aslspec/tests.t/layout_tuple.bad
+++ b/asllib/aslspec/tests.t/layout_tuple.bad
@@ -1,0 +1,4 @@
+typedef BadTuple =
+    | (N, Bool)
+    { math_layout = (_, _, _) }
+;

--- a/asllib/aslspec/tests.t/layout_type.bad
+++ b/asllib/aslspec/tests.t/layout_type.bad
@@ -1,0 +1,2 @@
+typedef BadAtomicType
+{ math_layout = (_, _) };

--- a/asllib/aslspec/tests.t/operator_arity.bad
+++ b/asllib/aslspec/tests.t/operator_arity.bad
@@ -1,0 +1,10 @@
+typedef N;
+
+operator unary(x: N) -> N {};
+
+relation bad_operator_arity(a: N, b: N) -> N
+{} =
+    x := unary(a, b);
+    --
+    x;
+;

--- a/asllib/aslspec/tests.t/record_extra_field.bad
+++ b/asllib/aslspec/tests.t/record_extra_field.bad
@@ -1,0 +1,9 @@
+typedef Rec =
+    | [rf: N]
+;
+
+relation bad_record_field(a: N) -> Rec
+{} =
+    --
+    [rf: a, rg: a];
+;

--- a/asllib/aslspec/tests.t/record_update_unknown_field.bad
+++ b/asllib/aslspec/tests.t/record_update_unknown_field.bad
@@ -1,0 +1,9 @@
+typedef Rec =
+    | [rf: N]
+;
+
+relation bad_record_update(r: Rec, a: N) -> Rec
+{} =
+    --
+    r(rg: a);
+;

--- a/asllib/aslspec/tests.t/rule_layout.bad
+++ b/asllib/aslspec/tests.t/rule_layout.bad
@@ -1,0 +1,6 @@
+typedef Num;
+
+relation r(a: Num) -> (b: Num, c: Num) {} =
+    --
+    (a, a) { math_layout = (_, _, _) };
+;

--- a/asllib/aslspec/tests.t/run.t
+++ b/asllib/aslspec/tests.t/run.t
@@ -7,6 +7,8 @@
   Generated LaTeX macros into generated_macros.tex
   $ aslspec operators.spec --render; diff -w generated_macros.tex operators.expected; rm -f generated_macros.tex
   Generated LaTeX macros into generated_macros.tex
+  $ aslspec layout_correct.spec
+  $ aslspec expressions_correct.spec
   $ aslspec type_name.bad
   Syntax Error: type_name.bad:1:9: illegal element-defining identifier: t2
   [1]
@@ -24,8 +26,10 @@
   [1]
 
 # Check that all type terms are well-formed
-  $ aslspec instantiation_expansion.spec
-  $ aslspec instantiation_expansion_depth.spec
+  $ aslspec --render instantiation_expansion.spec
+  Generated LaTeX macros into generated_macros.tex
+  $ aslspec --render instantiation_expansion_depth.spec
+  Generated LaTeX macros into generated_macros.tex
   $ aslspec instantiation_labelled_tuple2.bad
   Specification Error: instantiation_labelled_tuple2.bad:9:8: The type term `L(O, A, B)` cannot be instantiated since it has 3 type terms and `L` requires 2 type terms
   [1]
@@ -53,5 +57,43 @@
   $ aslspec relation_unnamed_arguments.bad
   Specification Error: relation_unnamed_arguments.bad:6:38: The term Num in relation unnamed_arg_has_rule does not provide a name for at least one of its sub-terms.
   [1]
-  $ aslspec constants.spec
-  $ aslspec parameterized_types.spec
+  $ aslspec operator_arity.bad
+  Specification Error: operator_arity.bad:7:10: The application of relation unary in expression unary(a, b) has an invalid number of arguments: expected 1 but found 2
+  [1]
+  $ aslspec variadic_operator_type.bad
+  Specification Error: variadic_operator_type.bad:3:46: Could not unify types N and Bool for parameter T of relation make_set
+  [1]
+  $ aslspec record_extra_field.bad
+  Specification Error: record_extra_field.bad:8:5: The record expression [rf : a, rg : a] has missing or invalid field names: expected rf but found rf, rg
+  [1]
+  $ aslspec field_access_unknown.bad
+  Specification Error: field_access_unknown.bad:8:5: The non-field identifier rg is used as a field in r.rg
+  [1]
+  $ aslspec record_update_unknown_field.bad
+  Specification Error: record_update_unknown_field.bad:8:5: The non-field identifier rg is used as a field in r[rg : a]
+  [1]
+  $ aslspec layout_type.bad
+  Specification Error: layout_type.bad:1:1: layout (_,_) is inconsistent with BadAtomicType. Here's a consistent layout: _
+  [1]
+  $ aslspec layout_tuple.bad
+  Specification Error: layout_tuple.bad:2:7: layout (_,_,_) is inconsistent with (N, Bool). Here's a consistent layout: (_,_)
+  [1]
+  $ aslspec layout_expr_atomic.bad
+  Specification Error: layout_expr_atomic.bad:6:5: layout (_,_) is inconsistent with expression flag. Here's a consistent layout: _
+  [1]
+  $ aslspec layout_expr_nullary.bad
+  Specification Error: layout_expr_nullary.bad:6:5: layout () is inconsistent with expression always_true(). Here's a consistent layout: _
+  [1]
+  $ aslspec layout_expr_list.bad
+  Specification Error: layout_expr_list.bad:6:5: layout (_,_,_) is inconsistent with expression two_args(a, b). Here's a consistent layout: (_,_)
+  [1]
+  $ aslspec layout_record_update.bad
+  Specification Error: layout_record_update.bad:7:5: layout (_) is inconsistent with expression r[rf : a, rg : b]. Here's a consistent layout: (_,(_,_))
+  [1]
+  $ aslspec rule_layout.bad
+  Specification Error: rule_layout.bad:5:5: layout (_,_,_) is inconsistent with expression r(a) -> (a, a). Here's a consistent layout: ((_),(_,_))
+  [1]
+  $ aslspec --render constants.spec
+  Generated LaTeX macros into generated_macros.tex
+  $ aslspec --render parameterized_types.spec
+  Generated LaTeX macros into generated_macros.tex

--- a/asllib/aslspec/tests.t/variadic_operator_type.bad
+++ b/asllib/aslspec/tests.t/variadic_operator_type.bad
@@ -1,0 +1,9 @@
+typedef N;
+
+variadic operator make_set[T](members: list1(T)) -> powerset(T) {};
+
+relation bad_variadic_type(a: N, flag: Bool) -> powerset(N)
+{} =
+    --
+    make_set(a, flag);
+;


### PR DESCRIPTION
Added missing checks to layout (`math_layout` attributes) of expressions and rules.
Also, fixed the checks to type variants.
Added positive and negative tests.
Add documentation.

This PR was assisted by AI.