### PR TITLE
[aslref][asl reference] fixed incorrect error message + example

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -1638,10 +1638,12 @@ module Make (B : Backend.S) (C : Config) = struct
     in
     (match res with
       | Normal ([ v ], _genv) -> read_value_from v
-      | Normal _ ->
+      | Normal (values, _genv) ->
+          (* A safety net for cases where the specification is evaluated without
+             being type checked. *)
           Error.(
             fatal_unknown_pos
-              (MismatchedReturnValue (C.error_handling_time, main_name)))
+              (BadArity (C.error_handling_time, main_name, 1, List.length values)))
       | Throwing ((v, _, _), ty, _genv) ->
           let msg = Format.asprintf "%a %s" PP.pp_ty ty (B.debug_value v) in
           Error.fatal_unknown_pos (Error.UncaughtException msg)

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -314,22 +314,50 @@ module FunctionRenaming (C : ANNOTATE_CONFIG) = struct
       try IMap.find name env.global.overloaded_subprograms
       with Not_found -> undefined_identifier ~loc name
     in
-    let get_func_sig name' =
+    (* From a specification perspective, [filter_by_call_type] can be
+       ignored. It is used below to distinguish between different
+       error message, which in the specification are mapped to the same
+       error code [TE_BC]. *)
+    let get_func_sig ~filter_by_call_type name' =
       match IMap.find_opt name' env.global.subprograms with
       | Some (func_sig, ses)
-        when has_arg_clash env caller_arg_types func_sig.args
-             && call_type_matches func_sig call_type ->
-          Some (name', func_sig, ses)
+        when has_arg_clash env caller_arg_types func_sig.args ->
+          if (not filter_by_call_type) || call_type_matches func_sig call_type
+          then Some (name', func_sig, ses)
+          else None
       | _ -> None
     in
-    let matching_renamings = set_filter_map get_func_sig renaming_set in
+    let matching_renamings =
+      set_filter_map (get_func_sig ~filter_by_call_type:true) renaming_set
+    in
     match matching_renamings with
     | [ (name', func_sig, ses) ] -> (
         match version with
         | V0 ->
             (deduce_eqs env caller_arg_types func_sig.args, name', func_sig, ses)
         | V1 -> ([], name', func_sig, ses) |: TypingRule.SubprogramForName)
-    | [] -> fatal_from ~loc (Error.NoCallCandidate (name, caller_arg_types))
+    | [] -> (
+        (* If there are no candidates while filtering with [call_type] then
+           either there are no subprograms that match the signature,
+           or there are subprograms that match the signature but they have the
+           wrong call type. For example, a function used for a call statement,
+           or a procedure used in an expression. *)
+        let mismatched_renamings =
+          set_filter_map (get_func_sig ~filter_by_call_type:false) renaming_set
+        in
+        match mismatched_renamings with
+        | [] -> fatal_from ~loc (Error.NoCallCandidate (name, caller_arg_types))
+        | (_, func_sig, _) :: _ ->
+            (* All of the matches in [mismatched_renamings] have the wrong call type,
+               but we report only the first one found. *)
+            fatal_from ~loc
+              (Error.MismatchedCallType
+                 {
+                   error_handling_time = Static;
+                   subprogram_name = name;
+                   expected_call_type = call_type;
+                   found_call_type = func_sig.subprogram_type;
+                 }))
     | _ :: _ ->
         (* If more than one candidate exists, the candidate signature should clash,
            which is detected when typechecking the corresponding declarations. *)
@@ -1679,13 +1707,20 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         func_sig.args arg_types
       (* CheckArgsTypeSat) *)
     in
-    (* Check the function returns as expected, and substitute parameters into
-       the return type *)
+    (* Substitute parameters into the return type *)
     let return_type =
       match (call_type, func_sig.return_type) with
       | (ST_Function | ST_Getter), Some ty -> Some (rename_ty_eqs env eqs ty)
       | (ST_Procedure | ST_Setter), None -> None
-      | _ -> fatal_from ~loc @@ Error.MismatchedReturnValue (Static, name)
+      | _ ->
+          fatal_from ~loc
+            (Error.MismatchedCallType
+               {
+                 error_handling_time = Static;
+                 subprogram_name = name;
+                 expected_call_type = call_type;
+                 found_call_type = func_sig.subprogram_type;
+               })
     in
     ( {
         name;
@@ -1712,7 +1747,14 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     in
     let+ () =
       check_true (callee.subprogram_type = call_type) @@ fun () ->
-      fatal_from ~loc (MismatchedReturnValue (Static, name))
+      fatal_from ~loc
+        (MismatchedCallType
+           {
+             error_handling_time = Static;
+             subprogram_name = name;
+             expected_call_type = call_type;
+             found_call_type = callee.subprogram_type;
+           })
     in
     let () =
       if false then
@@ -1858,7 +1900,15 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       match (call_type, callee.return_type) with
       | (ST_Function | ST_Getter), Some ty -> Some (rename_ty_eqs env eqs3 ty)
       | (ST_Setter | ST_Procedure), None -> None
-      | _ -> fatal_from ~loc @@ Error.MismatchedReturnValue (Static, name)
+      | _ ->
+          fatal_from ~loc
+            (Error.MismatchedCallType
+               {
+                 error_handling_time = Static;
+                 subprogram_name = name;
+                 expected_call_type = call_type;
+                 found_call_type = callee.subprogram_type;
+               })
     in
     let () = if false then Format.eprintf "Annotated call to %S.@." name1 in
     let params =

--- a/asllib/carpenter/README.md
+++ b/asllib/carpenter/README.md
@@ -38,9 +38,13 @@ dune exec carpenter -- execute $(find tmp -name "$(date +"%Y-%m-%dT%H")*.asl")
 ```
 This should print a list of results for each file, for example:
 ```
-// results for file: tmp/2024-03-19T10:51:29-0000.asl
-Error: ASL Error: Mismatched use of return value from call to 'main'
-// end of results for file: tmp/2024-03-19T10:51:29-0000.asl
+// results for file: ../../tmp/2026-06-05T10:23:11-0006.asl
+Error: File ../../tmp/2026-06-05T10:23:11-0006.asl, line 7, characters 2 to 35:
+  var rwqhgkjdozr: boolean = FALSE;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ASL Type error: not all control flow paths of the function "main" are
+  guaranteed to either return, raise an exception, or invoke unreachable.
+// end of results for file: ../../tmp/2026-06-05T10:23:11-0006.asl
 
 ...
 ```

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -702,6 +702,11 @@ constructs a call expression AST from a parse tree for a subprogram call.
 \listingref{semantics-ecall} shows call expressions (on the right-hand-side of assignments)
 and the inferred types of the expressions, as type annotations on the left-hand-side variables.
 
+\ExampleDef{Calling a procedure in an expression}
+\listingref{ProcedureAsExpression} shows an illegal call to a procedure
+in an expression (the right-hand side of an assignment).
+\ASLListing{Illegal call expression}{ProcedureAsExpression}{\typingtests/TypingRule.ECall.bad.asl}
+
 \RenderProseAndFormally{annotate_expr_ECall}
 \CodeSubsection{\ECallBegin}{\ECallEnd}{../Typing.ml}
 

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -35,7 +35,12 @@ type error_desc =
   | EmptySlice
   | TypeInferenceNeeded
   | UndefinedIdentifier of error_handling_time * identifier
-  | MismatchedReturnValue of error_handling_time * string
+  | MismatchedCallType of {
+      error_handling_time : error_handling_time;
+      subprogram_name : string;
+      expected_call_type : subprogram_type;
+      found_call_type : subprogram_type;
+    }
   | BadArity of error_handling_time * identifier * int * int
   | BadParameterArity of error_handling_time * version * identifier * int * int
   | UnsupportedBinop of error_handling_time * binop * literal * literal
@@ -154,7 +159,7 @@ let error_label = function
   | EmptySlice -> "EmptySlice"
   | TypeInferenceNeeded -> "TypeInferenceNeeded"
   | UndefinedIdentifier _ -> "UndefinedIdentifier"
-  | MismatchedReturnValue _ -> "MismatchedReturnValue"
+  | MismatchedCallType _ -> "MismatchedCallType"
   | BadArity _ -> "BadArity"
   | BadParameterArity _ -> "BadParameterArity"
   | UnsupportedBinop _ -> "UnsupportedBinop"
@@ -378,10 +383,27 @@ module PPrint = struct
         pp_err internal "Interpreter blocked. Type inference needed."
     | UndefinedIdentifier (t, s) ->
         pp_err (error_handling_time_to_string t) "Undefined identifier:@ '%s'" s
-    | MismatchedReturnValue (t, s) ->
+    | MismatchedCallType
+        {
+          error_handling_time = t;
+          subprogram_name = s;
+          expected_call_type;
+          found_call_type;
+        } ->
+        let call_type_description call_type =
+          match call_type with
+          | ST_Function -> "function"
+          | ST_Getter -> "getter"
+          | ST_Setter -> "setter"
+          | ST_Procedure -> "procedure"
+        in
         pp_err
           (error_handling_time_to_string t)
-          "Mismatched use of return value from call to '%s'." s
+          "Mismatched call type for subprogram '%s': expected a %s and found a \
+           %s."
+          s
+          (call_type_description expected_call_type)
+          (call_type_description found_call_type)
     | BadArity (t, name, expected, provided) ->
         pp_err
           (error_handling_time_to_string t)

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ECall.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ECall.bad.asl
@@ -1,0 +1,11 @@
+func nop()
+begin
+  pass;
+end;
+
+func main() => integer
+begin
+    nop();
+    - = nop(); // Illegal: nop is a procedure, therefore no value to consume.
+    return 0;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -479,7 +479,15 @@ ASL Typing Tests / annotating types:
   File TypingRule.SCall.bad.asl, line 11, characters 4 to 11:
       zero();
       ^^^^^^^
-  ASL Type error: No subprogram declaration matches the invocation: zero().
+  ASL Static error:
+    Mismatched call type for subprogram 'zero': expected a procedure and found a function.
+  [1]
+  $ aslref --no-exec TypingRule.ECall.bad.asl
+  File TypingRule.ECall.bad.asl, line 9, characters 8 to 13:
+      - = nop(); // Illegal: nop is a procedure, therefore no value to consume.
+          ^^^^^
+  ASL Static error:
+    Mismatched call type for subprogram 'nop': expected a function and found a procedure.
   [1]
   $ aslref --no-exec TypingRule.SCond.asl
   $ aslref TypingRule.SDecl.asl
@@ -936,8 +944,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateRetTy.bad.asl, line 15, characters 4 to 17:
       flip{64}(bv); // Illegal: the returned value must be consumed.
       ^^^^^^^^^^^^^
-  ASL Type error: No subprogram declaration matches the invocation:
-    flip(bits(64)).
+  ASL Static error:
+    Mismatched call type for subprogram 'flip': expected a procedure and found a function.
   [1]
   $ aslref --no-exec TypingRule.AnnotateCall.asl
   $ aslref --no-exec TypingRule.AnnotateCall2.asl


### PR DESCRIPTION
This PR refines the error message for cases where a function/getter is used where a procedure/setter is expected (or vice versa). Specifically, a new error constructor is added and used to provide a more accurate description of the error.
* The `MismatchedReturnValue` error is replaced by `MismatchedCallType`.
* In `Interpreter.ml` the safety-net check that `main` does not return multiple values now replaces `MismatchedReturnValue` with the more fitting `BadArity` error.
* No changes are made to the ASL Reference, since it does not distinguish between the finding no call candidates and finding call candidates with the wrong call type - they all lead to the same error code `TE_BC`.

Here is how the error message changes:
1. The error message for `$ aslref --no-exec TypingRule.SCall.bad.asl` is changed from
`ASL Type error: No subprogram declaration matches the invocation: zero().` to `ASL Static error: Mismatched call type for subprogram 'zero': expected a procedure and found a function.`
2. The error message for `$ aslref TypingRule.AnnotateRetTy.bad.asl` is changed from
`ASL Type error: No subprogram declaration matches the invocation: flip(bits(64)).` to `ASL Static error: Mismatched call type for subprogram 'nop': expected a function and found a procedure.`
