### PR TITLE
 [gen] Add `store-only` variant

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -25,8 +25,6 @@ end
 module Make(Cfg:Config) : XXXCompile_gen.S =
   struct
 
-    let do_memtag = Cfg.variant Variant_gen.MemTag
-
 (* Common *)
     let naturalsize = TypBase.get_size Cfg.typ
     module A64 =
@@ -1709,14 +1707,14 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 (* Access *)
 (**********)
 
-    let add_tag =
-      if do_memtag then
-        fun loc tag -> Code.add_tag loc tag
-      else if do_morello then
-        fun loc _ -> Code.add_capability loc 0
-      else fun loc _ -> loc
+    let add_tag atom loc tag = match atom with
+      | Some (Pte _,_) -> loc
+      | _ ->
+        if do_memtag then Code.add_tag loc tag
+        else if do_morello then Code.add_capability loc 0
+        else loc
 
-    let get_tagged_loc e = add_tag (as_data e.C.loc) e.C.tag
+    let get_tagged_loc e = add_tag e.C.atom (as_data e.C.loc) e.C.tag
 
     let add_label_to_last_instructions e cs =
       match e.C.check_fault with
@@ -1730,21 +1728,35 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         do_rec cs
       | None -> cs
 
-    (* If there is a fault label in `e`, add the `index`-th label
-       to the first instruction in `cs` *)
-    let add_label_to_first_instructions e cs =
-      match e.C.check_fault with
-      | Some (label_name, _) ->
-        (* find the first non-label instruction *)
-        let rec do_rec cs = match cs with
-          | [] -> assert false (* the `cs` should not be empty *)
-          | instr::rem -> begin match instr with
-            (* skip label or instruction that is already labelled *)
-            | Label(_) -> instr::do_rec rem
-            |_ -> Label(label_name, instr)::rem
-        end in
-        do_rec cs
-      | None -> cs
+    let is_ldxr = function
+      | Instruction (I_LDAR (_, (XX|AX), _, _))
+      | Instruction (I_LDARBH (_, (XX|AX), _, _))
+      | Instruction (I_LDXP _) -> true
+      | _ -> false
+
+    let is_stxr = function
+      | Instruction (I_STXR _)
+      | Instruction (I_STXRBH _)
+      | Instruction (I_STXP _) -> true
+      | _ -> false
+
+    (* The fault label is carried by the read event `er`; in `store-only`,
+       attach it to the following exclusive store instead. *)
+    let add_label_to_exclusive_load_and_store er cs =
+      let add_label e instr =
+        match e.C.check_fault with
+        | Some (label_name, _) -> Label(label_name, instr)
+        | None -> instr in
+      let rec do_rec = function
+        | [] -> assert false (* the `cs` should not be empty *)
+        | (Label(_) as label)::rem -> label :: do_rec rem
+        | instr::rem ->
+            if (not do_store_only && is_ldxr instr)
+               || (do_store_only && is_stxr instr) then
+              (add_label er instr) :: rem
+            else instr :: do_rec rem
+      in
+      do_rec cs
 
     let emit_access st p init e =
     let open WPTE in
@@ -1768,7 +1780,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               (pp_dir d) (C.debug_evt e)
         end
     | Some d,Data loc ->
-        let loc = add_tag loc e.C.tag in
+        let loc = add_tag e.C.atom loc e.C.tag in
         let atom = match e.C.atom with
         | None -> None
         | Some (a,m) -> begin match a with
@@ -1981,7 +1993,6 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | W,Some (Neon _,Some _) -> assert false
         end in
         (* Add a label to instructions `cs`, when a fault check is required. *)
-          (* Add a label to instructions `cs`, when a fault check is required. *)
         let cs = add_label_to_last_instructions e cs in
         regs,inits,cs,st
     (* END of emit_access *)
@@ -2012,7 +2023,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let rW,init,csi,st = U.emit_mov st p init (Value.to_int ew.C.v) in
       let arw = check_arw_lxsx er ew in
       let init,cs,st = XSingle.emit_pair arw p st init rR rW rA ew in
-      let cs = add_label_to_first_instructions er cs in
+      let cs = add_label_to_exclusive_load_and_store er cs in
       rR,init,csi@caddr@cs,st
 
     let emit_exch1 = do_emit_exch1 emit_addr_simple
@@ -2025,7 +2036,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let arw = check_arw_lxsx er ew in
       let init,cs,st =
         XPair.emit_pair arw p st init (rR1,rR2) (rW1,rW2) rA ew in
-      let cs = add_label_to_first_instructions er cs in
+      let cs = add_label_to_exclusive_load_and_store er cs in
       rR1,init,csi@caddr@cs,st
 
     let emit_exch22 = do_emit_exch22 emit_addr_simple
@@ -2038,7 +2049,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let module X = ExclusivePair(XLoadPair)(XStore) in
       let init,cs,st =
         X.emit_pair arw p st init (rR1,rR2) rW rA ew in
-      let cs = add_label_to_first_instructions er cs in
+      let cs = add_label_to_exclusive_load_and_store er cs in
       rR1,init,csi@caddr@cs,st
 
     let emit_exch21 = do_emit_exch21 emit_addr_simple
@@ -2052,7 +2063,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let module X = ExclusivePair(XLoad)(XStorePair) in
       let init,cs,st =
         X.emit_pair arw p st init rR (rW1,rW2) rA ew in
-      let cs = add_label_to_first_instructions er cs in
+      let cs = add_label_to_exclusive_load_and_store er cs in
       rR,init,csi@caddr@cs,st
 
     let emit_exch12 = do_emit_exch12 emit_addr_simple
@@ -2275,7 +2286,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       match e.C.dir,e.C.loc with
       | None,_ -> Warn.fatal "TODO"
       | Some d,Data loc ->
-          let loc = add_tag loc e.C.tag in
+          let loc = add_tag e.C.atom loc e.C.tag in
           let atom = match e.C.atom with
           | None -> None
           | Some (a,m) -> begin match a with
@@ -2573,7 +2584,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             match atom with
             | Some (Tag,None) ->
                 let cs0,st = calc0_gen csel st vdep r2 r1 in
-                let rA,init,st = U.next_init st p init (add_tag loc (Value.to_int e.C.v)) in
+                let rA,init,st = U.next_init st p init (add_tag e.C.atom loc (Value.to_int e.C.v)) in
                 let rB,cB,st = sum_addr st rA r2 in
                 rB,pseudo (cs0@cB),init,st,[]
             | Some (_,Some (sz,_)) ->
@@ -2619,7 +2630,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           let r2,cs2,init,st = match atom with
             | Some(Neon _, None) -> r2,cs2,init,st
             | _ -> r2,cs2@pseudo addi,init,st in
-          let loc = add_tag loc e.C.tag in
+          let loc = add_tag e.C.atom loc e.C.tag in
           begin match atom with
           | None ->
               let init,cs,st =

--- a/gen/common/AArch64Arch_gen.ml
+++ b/gen/common/AArch64Arch_gen.ml
@@ -30,7 +30,8 @@ module Make
     end) = struct
 
 let do_self = C.variant Variant_gen.Self
-let do_tag = C.variant Variant_gen.MemTag
+let do_memtag = C.variant Variant_gen.MemTag
+let do_store_only = C.variant Variant_gen.StoreOnly
 let do_morello = C.variant Variant_gen.Morello
 let do_kvm = C.variant Variant_gen.KVM
 let do_neon = C.variant Variant_gen.Neon
@@ -563,7 +564,7 @@ let is_tthm fields =
    let fold_atom_rw f r = f PP (f PL (f AP (f AL r)))
 
    let fold_tag =
-     if do_tag then fun f r -> f Tag r
+     if do_memtag then fun f r -> f Tag r
      else fun _f r -> r
 
    let fold_morello =

--- a/gen/common/variant_gen.ml
+++ b/gen/common/variant_gen.ml
@@ -38,6 +38,8 @@ type t =
   | KVM | NoFault
 (* Synchronisation mode *)
   | Sync | Async
+(* Store-only mode *)
+  | StoreOnly
 (* Neon AArch64 extension *)
   | Neon
 (* Scalable Vector extension (AArch64) *)
@@ -52,12 +54,12 @@ let tags =
    "Mixed";"FullMixed";"MixedDisjoint"; "MixedStrictOverlap";
    "Ifetch(Self)"; "MemTag";
    "NoVolatile"; "Morello"; "VMSA(KVM)"; "NoFault";
-   "Sync"; "Async"; "Neon"; "ConstrainedUnpredictable"; ]
+   "Sync"; "Async"; "StoreOnly"; "Neon"; "ConstrainedUnpredictable"; ]
 
 let all_t =
   [ AsAmo ; ConstsInInit ; Mixed ; FullMixed ; MixedDisjoint ; MixedStrictOverlap ;
     Self ; MemTag ; NoVolatile ; Morello ; KVM ; NoFault ;
-    Sync ; Async ; Neon ; SVE ; SME ; ConstrainedUnpredictable ]
+    Sync ; Async ; StoreOnly ; Neon ; SVE ; SME ; ConstrainedUnpredictable ]
 
 let parse tag = match Misc.lowercase tag with
 | "asamo" -> Some AsAmo
@@ -74,6 +76,7 @@ let parse tag = match Misc.lowercase tag with
 | "nofault" -> Some NoFault
 | "sync" -> Some Sync
 | "async" -> Some Async
+| "storeonly" | "store-only" -> Some StoreOnly
 | "neon" -> Some Neon
 | "sve" -> Some SVE
 | "sme" -> Some SME
@@ -95,6 +98,7 @@ let pp = function
   | NoFault -> "NoFault"
   | Sync -> "Sync"
   | Async -> "Async"
+  | StoreOnly -> "StoreOnly"
   | Neon -> "Neon"
   | SVE -> "sve"
   | SME -> "sme"
@@ -110,6 +114,7 @@ let pp_herd_variant = function
   | MemTag -> Some "memtag"
   | Sync -> Some "sync"
   | Async -> Some "async"
+  | StoreOnly -> Some "store-only"
   | Morello -> Some "morello"
   | KVM  -> Some "vmsa"
   | ConstrainedUnpredictable -> Some "ConstrainedUnpredictable"
@@ -118,5 +123,6 @@ let is_mixed v = v Mixed || v FullMixed
 let is_kvm v = v KVM
 
 let validate v =
-  if (v Sync || v Async) && not (v MemTag) then
-    Warn.user_error "variants `Sync` and `Async` must be used with `MemTag`"
+  if (v Sync || v Async || v StoreOnly) && not (v MemTag) then
+    Warn.user_error
+      "variants `Sync`, `Async` and `StoreOnly` require `MemTag`"

--- a/gen/common/variant_gen.mli
+++ b/gen/common/variant_gen.mli
@@ -40,6 +40,8 @@ type t =
   | NoFault
 (* Synchronisation mode *)
   | Sync | Async
+(* Store-only mode *)
+  | StoreOnly
 (* Neon AArch64 extension *)
   | Neon
 (* SVE AArch64 extension *)

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -157,6 +157,7 @@ module Make (O:Config) (E:Edge.S) :
   let do_sve = O.variant Variant_gen.SVE
   let do_sme = O.variant Variant_gen.SME
   let do_no_fault = O.variant Variant_gen.NoFault
+  let do_store_only = O.variant Variant_gen.StoreOnly
 
   type fence = E.fence
   type edge = E.edge
@@ -572,25 +573,22 @@ module CoSt = struct
     Some ( (Label.next_label "L"), (Value.can_fault dir pte_val) )
 
   (* Helper function returns a fresh label and a boolean for if it should fault,
-     if a fault check is need. Otherwise return `None`. *)
+     if a fault check is needed. Otherwise return `None`. *)
   let fault_update st dir =
     let unset_check_fault st = {st with check_fault = NoDir } in
     let pte_val = get_pte_value st in
-    match () with
-    | _ when (st.check_fault = NoDir || do_no_fault) -> None,unset_check_fault st
-      (* Need to check fault *)
-    | _ when do_kvm ->
-      let fault,check_fault = match dir,st.check_fault with
-      | _,NoDir -> None,NoDir
-      | (R|W),Irr | W,Dir W | R,Dir R -> label_pte_fault dir pte_val,NoDir
-      | W,Dir R -> None,Dir R
-      | R,Dir W -> None,Dir W in
-      fault,{st with check_fault}
-      (* In variants `memtag` and `morello`, the cycles are constructed such that
-         no fault occurs *)
-    | _ when do_memtag || do_morello ->
+    match st.check_fault,dir with
+    | _,_ when do_no_fault -> None,unset_check_fault st
+    | NoDir,_ -> None,st
+    | Irr,(R|W) | Dir W,W | Dir R,R when do_kvm ->
+        label_pte_fault dir pte_val,unset_check_fault st
+    | Dir R,W | Dir W,R when do_kvm ->
+        None,st
+    | _,R when do_store_only ->
+        None,st
+    | _,_ when do_memtag || do_morello ->
       Some ((Label.next_label "L"), false),unset_check_fault st
-    |_ -> None,unset_check_fault st
+    | _,_ -> None,st
 
   let implicit_pte_update st dir =
     match Value.implicitly_set_pteval dir st.machine_feature st.pte_value with

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -128,6 +128,84 @@ A memtag generation test with `Variant` duplicated in metadata, because of (1) `
    STG X6,[X3]       |                  ;
   
   exists ([tag(y)]=:blue /\ 0:X0=x:green /\ 1:X0=0 /\ not (fault(P1:L00,y)))
+A memtag `LxSx` oneloc comparison test
+  $ diyone7 -arch AArch64 -variant memtag -oneloc T PosWR LxSx Coi
+  AArch64 CoWW+postp-rmw-coipt
+  Variant=memtag
+  Generator=diyone7 (version 7.58+1)
+  Com=Co
+  Orig=PosWRTP LxSx CoiPT
+  "PosWRTP LxSx CoiPT"
+  {
+   0:X0=x:red; 0:X1=x:green;
+  }
+   P0                ;
+   STG X0,[X1]       ;
+   MOV W3,#1         ;
+   Loop00:           ;
+   L00: LDXR W2,[X1] ;
+   STXR W4,W3,[X1]   ;
+   CBNZ W4,Loop00    ;
+  
+  exists (0:X2=0 /\ not (fault(P0:L00,x)))
+
+  $ diyone7 -arch AArch64 -variant memtag,store-only -oneloc T PosWR LxSx Coi
+  AArch64 CoWW+postp-rmw-coipt
+  Variant=memtag store-only
+  Generator=diyone7 (version 7.58+1)
+  Com=Co
+  Orig=PosWRTP LxSx CoiPT
+  "PosWRTP LxSx CoiPT"
+  {
+   0:X0=x:red; 0:X1=x:green;
+  }
+   P0                   ;
+   STG X0,[X1]          ;
+   MOV W3,#1            ;
+   Loop00:              ;
+   LDXR W2,[X1]         ;
+   L00: STXR W4,W3,[X1] ;
+   CBNZ W4,Loop00       ;
+  
+  exists (0:X2=0 /\ not (fault(P0:L00,x)))
+
+A memtag `PosRW` oneloc comparison test
+  $ diyone7 -arch AArch64 -variant memtag -oneloc T PosWR PosRW Coi
+  AArch64 CoWW+posRtp-pos-coipt
+  Variant=memtag
+  Generator=diyone7 (version 7.58+1)
+  Com=Co
+  Orig=PosWRTP PosRW CoiPT
+  "PosWRTP PosRW CoiPT"
+  {
+   0:X0=x:red; 0:X1=x:green;
+  }
+   P0               ;
+   STG X0,[X1]      ;
+   L01: LDR W2,[X0] ;
+   MOV W3,#1        ;
+   L00: STR W3,[X1] ;
+  
+  exists (0:X2=1 /\ not (fault(P0:L00,x)) /\ not (fault(P0:L01,x)))
+
+  $ diyone7 -arch AArch64 -variant memtag,store-only -oneloc T PosWR PosRW Coi
+  AArch64 CoWW+posRtp-pos-coipt
+  Variant=memtag store-only
+  Generator=diyone7 (version 7.58+1)
+  Com=Co
+  Orig=PosWRTP PosRW CoiPT
+  "PosWRTP PosRW CoiPT"
+  {
+   0:X0=x:red; 0:X1=x:green;
+  }
+   P0               ;
+   STG X0,[X1]      ;
+   LDR W2,[X0]      ;
+   MOV W3,#1        ;
+   L00: STR W3,[X1] ;
+  
+  exists (0:X2=1 /\ not (fault(P0:L00,x)))
+
 An ifetch generation test
   $ diyone7 -arch AArch64 -variant ifetch CacheSyncStrongIsbdWRPI FreIP PodWR Fre
   AArch64 SB+cachesyncstrongisbpi+po


### PR DESCRIPTION
This adds a `StoreOnly` generator variant for `memtag` variant and emits it to `herd7` metadata as `store-only`. The parser accepts both `StoreOnly` and `store-only`, and validation requires it to be used together with `memtag`.

For multi-instruction RMWs, store-only carries the `memtag` fault check from the read event to the write event. In particular, on `Aarch64` `LxSx` instruction's generated fault label moves from the load-exclusive instruction to the store-exclusive instruction, for example, `diyone7 -arch AArch64 -variant memtag,store-only PodRW T Rfe LxSx PodWW Rfe`
```
AArch64 LB+popt+rmw-po
Variant=memtag store-only
Generator=diyone7 (version 7.58+1)
Prefetch=0:x=F,0:y=W,1:y=F,1:x=W
Com=Rf Rf
Orig=PodRWPT RfeTP LxSx PodWW Rfe
"PodRWPT RfeTP LxSx PodWW Rfe"
{
 0:X0=x:green; 0:X2=y:red; 0:X3=y:green;
 1:X0=x:green; 1:X2=y:red;
}
 P0          | P1                   ;
 LDR W1,[X0] | MOV W4,#1            ;
 STG X2,[X3] | Loop00:              ;
             | LDXR W1,[X2]         ;
             | L00: STXR W5,W4,[X2] ; (* <--- the label `L00` moves from `LDXR` to here ` STXR` *)
             | CBNZ W5,Loop00       ;
             | MOV W6,#1            ;
             | STR W6,[X0]          ;

exists ([y]=1 /\ 0:X1=1 /\ 1:X1=0 /\ not (fault(P1:L00,y)))
```

This means:
- In `cycle.ml`, we changed fault-label assignment to be event-aware rather than passing only a direction. The new logic detects multi-instruction RMWs, such as `LxSx`, and under store-only suppresses the read-side fault label while preserving the pending fault-check state for the write event.
- In `AArch64Compile_gen.ml`, we replaced the old “label the first instruction” via `add_label_to_first_instructions` handling for exclusive RMW code with logic that recognises exclusive loads and stores separately via `add_label_to_exclusive_load_and_store`. For `LxSx`, it can now attach the read event’s label to `LDXR`/`LDAXR`, and the write event’s label to `STXR`/`STLXR`/`STXP`.
