### PR TITLE
[gen][AArch64] Properly reserve X12 for SME

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -50,16 +50,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     (* Reserve SME's slice index register *)
     let x12 = Ireg R12
 
-    let next_reg x =
-      if do_sme then
-        begin
-          let r,x = A64.alloc_reg x in
-          match r with
-          | Ireg R12 -> A64.alloc_reg x
-          | _ -> r,x
-        end
-      else
-        A64.alloc_reg x
+    let next_reg x = A64.alloc_reg x
 
     let next_reg2 x =
       let r1,x = next_reg x in

--- a/gen/common/AArch64Arch_gen.ml
+++ b/gen/common/AArch64Arch_gen.ml
@@ -1109,6 +1109,13 @@ let is_valid_rmw rmw_list =
   List.length atomic_st_list = List.length (Util.List.uniq ~eq:atomic_op_equal atomic_st_list)
 end
 
+let free_registers =
+  if do_sme then
+    (* Reserve SME's slice index register *)
+    List.filter ( fun r -> r != Ireg R12) allowed_for_symb
+  else
+    allowed_for_symb
+
 include
     ArchExtra_gen.Make
     (struct
@@ -1119,7 +1126,7 @@ include
         | _ -> false
 
       let pp_reg = pp_reg
-      let free_registers = allowed_for_symb
+      let free_registers = free_registers
 
       type special = reg
       type special2 = reg


### PR DESCRIPTION
X12 is currently reserved only during litmus code emission, relying on the assumption that register allocation during initialization will not reach it.

Since 3b3acf91c6086a6fa66d45ae2fd5b258060a8354, locations use the same register across all PEs, making exhaustion of the available registers during initialization more likely.

Reserve X12 explicitly for SME by removing it from the register allocator.