### PR TITLE
 [gen] Add `diy7 -unfold-only`

### DIFF
--- a/gen/common/config.ml
+++ b/gen/common/config.ml
@@ -53,6 +53,7 @@ let variant = ref (fun (_:Variant_gen.t) -> false)
 let rejects = ref ([] : string list)
 let stdout = ref false
 let cycleonly = ref false
+let unfold_only = ref false
 let metadata = ref true
 let numeric = ref true
 let varatom = ref ([] : string list)
@@ -389,6 +390,7 @@ let diy_spec () =
           Arg.String (fun s -> filter_check := !filter_check @ [s]);
         ],
    "<lhs> <rhs> show whether the internal filter prohibits the two relaxations in the mode specified by `-mode` argument, however, all other constraints between <lhs> and <rhs>, such as edge compatibility, are ignored. Passing the internal filter is a necessary but not sufficient condition when sequence `<lhs> <rhs>` appears in the generated tests. This argument overrides other arguments but is overrided by `-show`.")::
+     ("-unfold-only", Arg.Set unfold_only, "unfold the wildcard.")::
    []
 
 let valid_stdout_flag is_diyone =

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -83,6 +83,7 @@ open C.R
   let parse_argument_list input_argument_list =
     List.map parse_argument input_argument_list
     |> List.flatten
+    |> remove_invalid_relaxes
 
   module AltConfig = struct
     include O

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -316,7 +316,11 @@ let () =
             ( Code.pp_check Co.choice )
         )
     | _ -> (* The common path to generate tests *)
-      M.go !Config.size reject relax safe;
+      if !Config.unfold_only then
+        printf "***relax***\n%s\n***safe***\n%s\n***reject***\n%s\n"
+        (Builder.R.pp_relax_list relax) (Builder.R.pp_relax_list safe) (Builder.R.pp_relax_list reject)
+      else
+        M.go !Config.size reject relax safe;
     exit 0
   with
   | Misc.Fatal msg ->

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -327,7 +327,8 @@ and type edge = E.edge
 
         (* After wildcard and macro expansion, remove invalid relaxations
            whose adjacent concrete edges cannot appear consecutively.
-           Pseudo-edges (annotations and insert edge) are ignoredin the check. *)
+           Pseudo-edges (annotations and insert edge) are ignored in the check.
+           Duplications are removed as well. *)
         let remove_invalid_relaxes relaxes =
           let rec for_all_adjacent_concrete_edge predicate = function
             | [] | [_] -> true
@@ -342,12 +343,15 @@ and type edge = E.edge
                     for_all_adjacent_concrete_edge predicate (rhs :: list)
                 | false, false ->
                     for_all_adjacent_concrete_edge predicate list in
-          List.filter_map
+          List.filter
           ( fun relax ->
-              let is_valid = edges_of relax
-                  |> for_all_adjacent_concrete_edge E.can_precede in
-              if is_valid then Some relax else None
+            let edges = edges_of relax in
+            (* Drop empty alternatives introduced by `?`; they do not
+               describe an actual relaxation. *)
+            edges <> []
+            && for_all_adjacent_concrete_edge E.can_precede edges
           ) relaxes
+          |> List.sort_uniq compare
 
         let parse_expand_relax ?(ppo=(fun _ k -> k)) str =
           match str with

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -622,7 +622,7 @@ Alignment filter behaviour between local `Pos**` and internal communication in `
   
   $ diy7 -arch AArch64 -relax 'PodWR?' -unfold-only 2>&1
   ***relax***
-  [] PodWR
+  PodWR
   ***safe***
   
   ***reject***
@@ -662,7 +662,7 @@ Alignment filter behaviour between local `Pos**` and internal communication in `
   ***relax***
   
   ***safe***
-  [] Fre
+  Fre
   ***reject***
   
   $ diy7 -arch AArch64 -safe '[PodWR Fre]' -unfold-only 2>&1

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -603,3 +603,88 @@ Alignment filter behaviour between local `Pos**` and internal communication in `
   Sequence `DpAddrdW` `Coi` passes the internal filter in mode `sc`
   $ diy7 -arch AArch64 -mode sc -filter-check DpAddrdW PosWW
   Sequence `DpAddrdW` `PosWW` passes the internal filter in mode `sc`
+
+`diy7 -unfold-only` unfolds relaxations and drops invalid composites
+  $ diy7 -arch AArch64 -relax '[Po,DpAddr?]' -unfold-only 2>&1
+  ***relax***
+  PosWW PosWR [PosWR,DpAddrsW] [PosWR,DpAddrsR] [PosWR,DpAddrdW] [PosWR,DpAddrdR] PosRW PosRR [PosRR,DpAddrsW] [PosRR,DpAddrsR] [PosRR,DpAddrdW] [PosRR,DpAddrdR] PodWW PodWR [PodWR,DpAddrsW] [PodWR,DpAddrsR] [PodWR,DpAddrdW] [PodWR,DpAddrdR] PodRW PodRR [PodRR,DpAddrsW] [PodRR,DpAddrsR] [PodRR,DpAddrdW] [PodRR,DpAddrdR]
+  ***safe***
+  
+  ***reject***
+  
+`diy7 -unfold-only` expands choice, optional, and grouped syntax
+  $ diy7 -arch AArch64 -relax 'PodWR|Fre' -unfold-only 2>&1
+  ***relax***
+  Fre PodWR
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax 'PodWR?' -unfold-only 2>&1
+  ***relax***
+  [] PodWR
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax '[PodWR Fre]' -unfold-only 2>&1
+  ***relax***
+  [PodWR,Fre]
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax 'PodWR Fre' -unfold-only 2>&1
+  ***relax***
+  Fre PodWR
+  ***safe***
+  
+  ***reject***
+  
+
+`diy7 -unfold-only` removes duplicate relaxes after unfolding
+  $ diy7 -arch AArch64 -relax 'PodWR|PodWR' -unfold-only 2>&1
+  ***relax***
+  PodWR
+  ***safe***
+  
+  ***reject***
+  
+`diy7 -unfold-only` also unfolds `-safe`
+  $ diy7 -arch AArch64 -safe 'Fre|Coe' -unfold-only 2>&1
+  ***relax***
+  
+  ***safe***
+  Fre Coe
+  ***reject***
+  
+  $ diy7 -arch AArch64 -safe 'Fre?' -unfold-only 2>&1
+  ***relax***
+  
+  ***safe***
+  [] Fre
+  ***reject***
+  
+  $ diy7 -arch AArch64 -safe '[PodWR Fre]' -unfold-only 2>&1
+  ***relax***
+  
+  ***safe***
+  [PodWR,Fre]
+  ***reject***
+  
+  $ diy7 -arch AArch64 -safe 'Fre Coe' -unfold-only 2>&1
+  ***relax***
+  
+  ***safe***
+  Fre Coe
+  ***reject***
+  
+
+`diy7 -unfold-only` removes duplicate safe edges after unfolding
+  $ diy7 -arch AArch64 -safe 'Fre|Fre' -unfold-only 2>&1
+  ***relax***
+  
+  ***safe***
+  Fre
+  ***reject***
+  

--- a/gen/tests/test_parser.expected
+++ b/gen/tests/test_parser.expected
@@ -178,7 +178,7 @@ cumul parser (for -cumul in diy7): [A,[B,C]]
 [[A];[B];[C]]
 
 remove_invalid_relaxes test (AArch64): [Po,Rfe]
-[[PosWW,Rfe];[PodWW,Rfe];[PosRW,Rfe];[PodRW,Rfe]]
+[[PosWW,Rfe];[PosRW,Rfe];[PodWW,Rfe];[PodRW,Rfe]]
 
 remove_invalid_relaxes test (AArch64): [Rfe,Rfe]
 []


### PR DESCRIPTION
This PR adds `diy7 -unfold-only`, which expands and prints parsed relaxation expressions without running the normal search. For example `diy7 -arch AArch64 -unfold-only -relax 'DMB.SYd**' -safe 'Po' -rejectlist 'DpAddr' ` outputs:
```
***relax***
DMB.SYdWW DMB.SYdWR DMB.SYdRW DMB.SYdRR
***safe***
PosWW PosWR PosRW PosRR PodWW PodWR PodRW PodRR
***reject***
DpAddrsW DpAddrsR DpAddrdW DpAddrdR
``` 