### PR TITLE
[herd] rec as plus

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -1602,7 +1602,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
 
         let libfind = ASLConf.libfind
       end) in
-      let fname,m = P.find_parse fname in
+      let fname,m = P.find_parse ~opt:true fname in
       Model.Generic (fname,m)
 
     let is_strict = C.variant Variant.Strict

--- a/herd/getModel.ml
+++ b/herd/getModel.ml
@@ -40,7 +40,7 @@ let parse archcheck arch libfind variant model =
             include LexUtils.Default
             let libfind = libfind
           end) in
-      let fname,ast = P.find_parse fname in
+      let fname,ast = P.find_parse ~opt:true fname in
       Model.Generic (fname,ast)
   | _ -> m in
   if archcheck then check_arch_model arch m

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -561,7 +561,7 @@ let model,model_opts = match !model with
 | Some (Model.File fname) ->
     let module P = ParseModel.Make(ParserConfig) in
     begin try
-      let (fname,((b,_,_) as r)) = P.find_parse fname in
+      let (fname,((b,_,_) as r)) = P.find_parse ~opt:true fname in
       Some (Model.Generic (fname,r)),b
     with
     | Misc.Fatal msg -> eprintf "%s: %s\n" prog msg ; exit 2

--- a/lib/ASTUtils.ml
+++ b/lib/ASTUtils.ml
@@ -16,6 +16,8 @@
 
 open AST
 
+let _dbg = false
+
 (* Select "all variables" *)
 let is_var = function
   | Var _ -> true
@@ -202,3 +204,45 @@ let free_body xs e =
     (fun r p0 -> remove_pat0 p0 r)
     (free e)
     xs
+
+
+let rec as_plus_args saw_seq x = function
+  | [] -> [],saw_seq
+  | e::es ->
+      if StringSet.mem x (free e) then
+        match e with
+        | Op (_,Seq,[Var (_,x1);Var (_,x2)]) ->
+            if String.equal x1 x && String.equal x2 x then
+              as_plus_args true x es
+            else raise Exit
+        | _ -> raise Exit
+      else
+        let es,saw_seq = as_plus_args saw_seq x es in
+        e::es,saw_seq
+
+let as_plus = function
+  | [loc_x,(Pvar (Some x) as px),Op (loc_union,Union,es)] ->
+      begin
+        try
+          let es,saw_seq = as_plus_args false x es in
+          if saw_seq then Some ((loc_x,px),(loc_union,es)) else None
+        with Exit -> None
+      end
+  | _ -> None
+
+
+let tr_def d =
+  match d with
+  | Rec (loc,bds,None) ->
+      begin
+        match as_plus bds with
+        | Some ((loc_x,px),(loc_es,es)) ->
+            if _dbg then
+              Printf.eprintf "%a: found implicit transitive closure\n%!"
+                TxtLoc.pp loc ;
+            Let (loc,[loc_x,px,Op1(loc_es,Plus,Op (loc_es,Union,es))])
+        | None -> d
+      end
+  | _ -> d
+
+let rec2plus defs = List.map tr_def defs

--- a/lib/ASTUtils.mli
+++ b/lib/ASTUtils.mli
@@ -30,3 +30,11 @@ val flatten : AST.exp -> AST.exp
 
 (* Get free variables *)
 val free_body : AST.var option list -> AST.exp -> AST.varset
+
+(*
+ * Translate recursive definitions `let rec r = r1 | r2 | rn | r;r`
+ * into non-recursive definition of r as a transitive closure:
+ * `let r = (r1 | r2 | ... | rn)  +
+ *)
+val rec2plus : AST.ins list -> AST.ins list
+

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -2644,7 +2644,7 @@ module Make
                       let libfind = O.libfind
                     end) in
                 let (_,_,iprog) =
-                  try P.parse fname
+                  try P.parse ~opt:true fname
                   with Misc.Fatal msg | Misc.UserError msg ->
                     error_not_silent loc "%s" msg  in
                 let stst = st.st in

--- a/lib/parseModel.ml
+++ b/lib/parseModel.ml
@@ -63,23 +63,25 @@ module Make(O:Config) = struct
 
   module ML = ModelLexer.Make(O)
 
-  let do_parse fname chan =
+  let do_parse opt fname chan =
     let buff,lexbuf = mk_lexbuf chan in
     lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname=fname;};
     let model = GenParserUtils.call_parser "model" lexbuf ML.token
         ModelParser.main in
     let pp = Buffer.contents buff in
     let opts,txt,code = model in
-    (opts,txt,set_text pp code)
+    let code = set_text pp code  in
+    let code = if opt then ASTUtils.rec2plus code else code in
+    (opts,txt,code)
 
-  let find_parse fname =
+  let find_parse ?(opt=false) fname =
     let fname = O.libfind fname in
     try fname, Hashtbl.find t fname
     with Not_found ->
-      let r = Misc.input_protect (do_parse fname) fname in
+      let r = Misc.input_protect (do_parse opt fname) fname in
       Hashtbl.add t fname r ;
       fname,r
 
-  let parse fname = let _,r = find_parse fname in r
+  let parse ?opt fname = let _,r = find_parse ?opt fname in r
 
 end

--- a/lib/parseModel.mli
+++ b/lib/parseModel.mli
@@ -22,6 +22,6 @@ module type Config = sig
 end
 
 module Make : functor (O:Config)  -> sig
-  val find_parse : string -> string * AST.t
-  val parse : string -> AST.t
+  val find_parse : ?opt:bool -> string -> string * AST.t
+  val parse : ?opt:bool -> string -> AST.t
 end


### PR DESCRIPTION
An attempt to optimise the cat interpreter: Perform the transformation of recursive definition `let rec r = r1|r2|...|rn|(r;r)` into `let r = (r1|r2|..|rn)+`.

Note: supersedes PR #1719. Preliminary to PR #1856.