### PR TITLE
[gen] Simplify macro and edge parsing lookup logic

### DIFF
--- a/gen/PPCCompile_gen.ml
+++ b/gen/PPCCompile_gen.ml
@@ -61,8 +61,8 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
 
     let cons r rs = r (fun r -> r::rs)
 
-    let single f r = f (ERS [plain_edge r])
-    let seq rs f = f (ERS (List.map plain_edge rs))
+    let single f r = f [plain_edge r]
+    let seq rs f = f (List.map plain_edge rs)
 
     let do_ppo f k =
       let k = dp (single f) k in
@@ -88,9 +88,7 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
       do_ppo f
         (if ppoext then
           do_ppo
-            (fun r k -> match r with
-            | ERS rs -> f (ERS (rs@[plain_edge (Rf Ext)])) k
-            | PPO -> assert false)
+            (fun rs k -> f (rs@[plain_edge (Rf Ext)]) k)
             k
         else k)
 

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -204,7 +204,7 @@ struct
           let r =
             not
               (List.exists
-                 (fun es -> C.R.Set.mem (C.R.ERS es) safes)
+                 (fun es -> C.R.Set.mem es safes)
                  cs) in
           r
       | _,_ -> true
@@ -307,8 +307,11 @@ module Make(C:Builder.S)
              |> String.concat list_list_sep )
         |> String.concat list_sep
 
-    let edges_of_relax_list rs =
-      List.map (fun r -> (r, edges_of r)) rs
+    (* Pair each relax with the working edge list used by the generator.
+       The first component preserves the original relax for reporting/filtering;
+       the second component may be modified while building candidate cycles. *)
+    let relaxs_with_work_edges rs =
+      List.map (fun r -> (r, r)) rs
 
 (* Functional for recursive call of generators *)
 
@@ -360,7 +363,7 @@ module Make(C:Builder.S)
           O.prefix
       end
 
-    let prefixes = List.map edges_of_relax_list O.prefix
+    let prefixes = List.map relaxs_with_work_edges O.prefix
 
     let rec mk_can_prefix = function
       | [] -> (fun _ _ -> true)
@@ -429,7 +432,7 @@ module Make(C:Builder.S)
           let d2 =
             List.fold_right
               (fun (r,_) k -> match r with
-              | ERS [{edge=Po (sd,e1,e2); _}] -> SdDir2Set.add (sd,e1,e2) k
+              | [{edge=Po (sd,e1,e2); _}] -> SdDir2Set.add (sd,e1,e2) k
               | _ -> k)
               rs SdDir2Set.empty in
           if dbg then
@@ -447,8 +450,8 @@ module Make(C:Builder.S)
 
     let zyva prefix aset relax safe reject n f =
 (*      let safes = C.R.Set.of_list safe in *)
-      let relax = edges_of_relax_list relax in
-      let safe = edges_of_relax_list safe in
+      let relax = relaxs_with_work_edges relax in
+      let safe = relaxs_with_work_edges safe in
       let po_safe = extract_po safe in
 
       (* ********************************** *)
@@ -682,7 +685,6 @@ module Make(C:Builder.S)
       let sset = C.R.Set.of_list safe in
       let rset = C.R.Set.of_list relax in
       let aset = C.R.Set.union sset rset in
-      let rej = List.map (fun a -> edges_of a) rej in
       D.all
         ~check:(last_minute rej)
         (fun f ->
@@ -734,7 +736,7 @@ module Make(C:Builder.S)
       fold_sd_dir2 (fun sd d1 d2 -> C.A.fold_cumul_fences (fun fe -> f fe sd d1 d2))
     let fold_cum f =  fold_cumul_fences f
 
-    let er e = ERS [plain_edge e]
+    let er e = [plain_edge e]
     let safe =
       let k = [] in
       let k = fold_ie (fun ie k -> er (Ws ie)::er (Fr ie)::k) k in k
@@ -767,6 +769,6 @@ module Make(C:Builder.S)
     let filter_check ~relax ~safe lhs rhs =
       let safe,_,_ = parse_input ~relax ~safe ~reject:[] in
       let safe_set = C.R.Set.of_list safe in
-      let po_safe = edges_of_relax_list safe |> extract_po in
+      let po_safe = relaxs_with_work_edges safe |> extract_po in
       FilterImpl.can_precede safe_set po_safe lhs rhs
   end

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -77,11 +77,7 @@ module type S = sig
   val plain_edge : tedge -> edge
 
   val fold_atomo : (atom option -> 'a -> 'a) -> 'a -> 'a
-  val fold_mixed : (atom option -> 'a -> 'a) -> 'a -> 'a
   val fold_atomo_list : atom option list -> (atom option -> 'a -> 'a) -> 'a -> 'a
-
-  val fold_edges : (edge -> 'a -> 'a) -> 'a -> 'a
-  val iter_edges : (edge -> unit) -> unit
 
   val pp_tedge : tedge -> string
   val pp_atom_option : atom option -> string
@@ -96,6 +92,7 @@ module type S = sig
   val get_access_atom: atom option -> MachMixed.t option
 
   val parse_fence : string -> fence
+  val parse_edge_annotations : string -> (atom option * atom option) option
   val parse_edge : string -> edge
   val parse_edges : string -> edge list
 
@@ -185,7 +182,6 @@ and module RMW = A.RMW = struct
   let do_strict_overlap = Cfg.variant Variant_gen.MixedStrictOverlap
   let wildcard = Cfg.wildcard
 
-  let debug = false
   open Code
 
   type fence = F.fence
@@ -219,10 +215,6 @@ and module RMW = A.RMW = struct
   let set_pteval ao p = match ao with
   | None -> fun _ -> p
   | Some a -> A.Value.set_pteval a p
-
-  let applies_atom ao d = match ao,d with
-  | (None,_)|(_,(Irr|NoDir)) -> true
-  | Some a,Dir d -> A.applies_atom a d
 
   let merge_atoms = A.merge_atoms
   let is_ifetch = A.is_ifetch
@@ -282,33 +274,18 @@ and module RMW = A.RMW = struct
 
   let plain_edge e = { a1=None; a2=None; edge=e; }
 
-  let pp_as_a = A.pp_as_a
   let pp_plain = A.pp_plain
 
   let pp_atom_option = function
     | None -> pp_plain
     | Some a -> pp_atom a
 
-  let pp_one_or_two pp_a e a1 a2 = match e with
-  | Id -> pp_a a1
-  | _ -> sprintf "%s%s" (pp_a a1) (pp_a a2)
+  let pp_annotations edge a1 a2 = match edge, a1, a2 with
+  | Id, _, _ -> pp_atom_option a1
+  | _, None, None -> ""
+  | _, _, _ -> sprintf "%s%s" (pp_atom_option a1) (pp_atom_option a2)
 
-  let pp_aa e a1 a2 = match a1, a2 with
-  | None,None  when not (is_id e) -> ""
-  | _,_ -> pp_one_or_two pp_atom_option e a1 a2
-
-  let pp_a_ter = function
-    | None -> pp_plain
-    | Some a as ao ->
-        if ao = pp_as_a then "A"
-        else pp_atom a
-
-  let pp_aa_ter e a1 a2 = match a1,a2 with
-  | None,None  when not (is_id e) -> ""
-  | _,_ -> pp_one_or_two pp_a_ter e a1 a2
-
-
-  let do_pp_tedge compat = function
+  let pp_tedge_compat compat = function
     | Rf UnspecCom -> sprintf "Rf"
     | Fr UnspecCom -> sprintf "Fr"
     | Ws UnspecCom -> if compat then sprintf "Ws" else sprintf "Co"
@@ -333,25 +310,21 @@ and module RMW = A.RMW = struct
     | Node W -> "Write"
     | Node R -> "Read"
 
-  let pp_tedge = do_pp_tedge false
+  let pp_tedge = pp_tedge_compat false
 
   let debug_edge e =
     sprintf
       "{edge=%s, a1=%s, a2=%s}"
-      (do_pp_tedge false e.edge) (pp_atom_option e.a1) (pp_atom_option e.a2)
+      (pp_tedge e.edge) (pp_atom_option e.a1) (pp_atom_option e.a2)
 
-  let do_pp_edge compat pp_atom_functor e =
-    let annotation = pp_atom_functor e.edge e.a1 e.a2 in
+  let pp_edge_compat compat e =
     let edge = match e.edge with
     | Id -> ""
-    | _ -> do_pp_tedge compat e.edge in
+    | _ -> pp_tedge_compat compat e.edge in
+    let annotation = pp_annotations e.edge e.a1 e.a2 in
     edge ^ annotation
 
-  let pp_edge_with_xx compat e = do_pp_edge compat pp_aa e
-
-  let pp_edge_with_a compat e = do_pp_edge compat pp_aa_ter e
-
-  let pp_edge e = pp_edge_with_xx false e
+  let pp_edge e = pp_edge_compat false e
 
   let compare_atomo = Option.compare A.compare_atom
 
@@ -441,7 +414,6 @@ let fold_tedges f r =
   r
 
   let fold_atomo f k = f None (A.fold_atom (fun a k -> f  (Some a) k) k)
-  let fold_mixed f k = A.fold_mixed (fun a k -> f  (Some a) k) k
   let fold_atomo_list aos f k = List.fold_right (fun a k -> f a k) aos k
 
   let overlap_atoms a1 a2 =
@@ -476,64 +448,6 @@ let fold_tedges f r =
     (* Situation is controlled by variant for other relaxations *)
         ok_non_rmw e a1 a2
 
-
-  let do_fold_edges fold_tedges f =
-   fold_atomo
-      (fun a1 ->
-        fold_atomo
-          (fun a2 ->
-            (fold_tedges
-               (fun te k ->
-                 match te with
-                 | Rmw rmw -> (* Allowed source and target atomicity for rmw *)
-                     if RMW.applies_atom_rmw rmw a1 a2 then begin
-                       let e =  {a1; a2; edge=te;} in
-                       f e k
-                     end else k
-                 | Id -> begin
-                     match a1,a2 with
-                     | Some x1,Some x2 when
-                         A.compare_atom x1 x2=0
-                         && not (is_ifetch a1) ->
-                         f { a1; a2;edge=te; } k
-                     | None,None ->
-                         let e =  { a1; a2;edge=te; } in
-                         f e k
-                     | _,_ -> k
-                 end
-                 | Insert _|Node _|Store  ->
-                     begin match a1,a2 with
-                     | None,None ->
-                         let e =  { a1; a2;edge=te; } in
-                         f e k
-                     | _,_ -> k
-                     end
-                 | _ ->
-                     let d1 = do_dir_src te
-                     and d2 = do_dir_tgt te in
-                     if
-                       applies_atom a1 d1 &&
-                       applies_atom a2 d2 &&
-                       (Misc.is_none (get_access_atom a1) &&
-                        Misc.is_none (get_access_atom a2)||
-                       ok_non_rmw te a1 a2)
-                     then
-                       f {a1; a2; edge=te;} k
-                     else begin
-                       if debug then
-                         eprintf "Not %s\n" (debug_edge  {a1; a2; edge=te;}) ;
-                       k
-                     end ))))
-
-  let fold_edges f = do_fold_edges fold_tedges f
-
-(* checked later... because rmw accepts all atomicity
-                     let d1 = do_dir_src te
-                     and d2 = do_dir_tgt te in
-                     if applies_atom a1 d1 && applies_atom a2 d2 then
-                       f {a1; a2; edge=te;} k
-                     else k *)
-
   let dir_tgt e = do_dir_tgt e.edge
   and dir_src e = do_dir_src e.edge
   and safe_dir e =
@@ -555,7 +469,7 @@ let fold_tedges f r =
       let old = Hashtbl.find annotation_lookup_table lxm in
       assert (compare_atomo old a = 0) ;
     with Not_found ->
-      if not (is_ifetch a) then Hashtbl.add annotation_lookup_table lxm a
+      Hashtbl.add annotation_lookup_table lxm a
 
   let () = iter_atom (fun a -> add_lxm_atom (pp_atom_option a) a)
 
@@ -578,9 +492,6 @@ let fold_tedges f r =
 (* Lexing *)
 (**********)
 
-  let iter_edges = Misc.fold_to_iter fold_edges
-
-
   let edge_lookup_table = Hashtbl.create 40000
 
   let add_lxm_edge lxm e =
@@ -599,21 +510,12 @@ let fold_tedges f r =
 (* Fill lexeme table *)
   let iter_ie = Misc.fold_to_iter (fold_ie wildcard)
 
-  let four_times_iter_edges compat iter_edges =
-    iter_edges  (fun e -> add_lxm_edge (pp_edge_with_xx compat e) e) ;
-    iter_edges
-      (fun e -> match e.a1,e.a2 with
-      | (None,(Some _ as a))
-      | ((Some _ as a),None) when a = pp_as_a ->
-          add_lxm_edge (pp_edge_with_a compat e) e
-      | _,_ -> ())
-
   let iter_tedges compat fold =
     Misc.fold_to_iter fold
       (fun te -> add_lxm_edge (pp_tedge_compat compat te) (plain_edge te))
 
   let () =
-   four_times_iter_edges false iter_edges;
+   iter_tedges false fold_tedges;
    fold_sd_extr_extr wildcard
       (fun sd e1 e2 () ->
         add_lxm_edge

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -547,20 +547,20 @@ let fold_tedges f r =
 
   let iter_atom = Misc.fold_to_iter fold_atomo
 
-  let ta = Hashtbl.create  37
+  let annotation_lookup_table = Hashtbl.create 37
 
   let add_lxm_atom lxm a =
     if dbg > 1 then eprintf "ATOM: %s\n" lxm ;
     try
-      let old = Hashtbl.find ta lxm in
+      let old = Hashtbl.find annotation_lookup_table lxm in
       assert (compare_atomo old a = 0) ;
     with Not_found ->
-      if not (is_ifetch a) then Hashtbl.add ta lxm a
+      if not (is_ifetch a) then Hashtbl.add annotation_lookup_table lxm a
 
   let () = iter_atom (fun a -> add_lxm_atom (pp_atom_option a) a)
 
   let parse_atom s =
-    try Hashtbl.find ta s
+    try Hashtbl.find annotation_lookup_table s
     with Not_found -> Warn.fatal "Bad atom: %s" s
 
   let parse_atoms xs =
@@ -581,12 +581,12 @@ let fold_tedges f r =
   let iter_edges = Misc.fold_to_iter fold_edges
 
 
-  let t = Hashtbl.create 40000
+  let edge_lookup_table = Hashtbl.create 40000
 
   let add_lxm_edge lxm e =
     if dbg > 1 then eprintf "LXM: %s\n" lxm ;
     try
-      let old = Hashtbl.find t lxm in
+      let old = Hashtbl.find edge_lookup_table lxm in
       if compare old e <> 0 then begin
         Warn.warn_always "ambiguous lexeme: %s" lxm ;
         eprintf "%s\n%s\n" (debug_edge old) (debug_edge e) ;
@@ -594,7 +594,7 @@ let fold_tedges f r =
       end
 
     with Not_found ->
-      Hashtbl.add t lxm e
+      Hashtbl.add edge_lookup_table lxm e
 
 (* Fill lexeme table *)
   let iter_ie = Misc.fold_to_iter (fold_ie wildcard)
@@ -607,6 +607,10 @@ let fold_tedges f r =
       | ((Some _ as a),None) when a = pp_as_a ->
           add_lxm_edge (pp_edge_with_a compat e) e
       | _,_ -> ())
+
+  let iter_tedges compat fold =
+    Misc.fold_to_iter fold
+      (fun te -> add_lxm_edge (pp_tedge_compat compat te) (plain_edge te))
 
   let () =
    four_times_iter_edges false iter_edges;
@@ -629,10 +633,10 @@ let fold_tedges f r =
         fill_opt "Dp" F.ddw_default sd (Dir W) ;
         fill_opt "Ctrl" F.ctrlw_default sd (Dir W) ;
         ()) () ;
-    if not (Hashtbl.mem t "R") then add_lxm_edge "R" (plain_edge (Node R)) ;
-    if not (Hashtbl.mem t "W") then add_lxm_edge "W" (plain_edge (Node W)) ;
+    add_lxm_edge "R" (plain_edge (Node R)) ;
+    add_lxm_edge "W" (plain_edge (Node W)) ;
 (*Co aka Ws and LxSx aka Rmw*)
-   four_times_iter_edges true (Misc.fold_to_iter (do_fold_edges fold_tedges_compat));
+   iter_tedges true fold_tedges_compat;
 (* Backward compatibility *)
     let instr_atom = A.instr_atom in
     if do_self && instr_atom != None then
@@ -650,7 +654,7 @@ let fold_tedges f r =
         if e.a1=None && e.a2=None && e.edge <> Id then
           f s k
         else k)
-      t
+      edge_lookup_table
 
   let fences_pp =
     F.fold_all_fences
@@ -661,9 +665,67 @@ let fold_tedges f r =
     try List.assoc s fences_pp
     with Not_found -> Warn.fatal "%s is not a fence" s
 
-  let parse_edge s =
-    try Hashtbl.find t s
-    with Not_found -> Warn.fatal "Bad edge: %s" s
+  (* Explore prefixes from longest to shortest until `func` returns `Some ..`.
+     For example, given the input `"PosWRPA"`, it applies
+     `func "PosWRPA"`, then `func "PosWRP"`, and so on, until `func`
+     returns `Some result`. The helper then returns that result together
+     with the untouched suffix, for example `Some (result, "PA")`. *)
+  let fold_prefixes func string =
+    let rec do_rec i =
+      if i <= 0 then None
+      else
+        let prefix = String.sub string 0 i in
+        match func prefix with
+        | Some x -> Some (x, (String.sub string i (String.length string - i)))
+        | None -> do_rec (i - 1)
+    in
+    do_rec (String.length string)
+
+  let lookup_edge_prefix string =
+    fold_prefixes (fun prefix -> Hashtbl.find_opt edge_lookup_table prefix) string
+
+  let lookup_atom_prefix string =
+    fold_prefixes (fun prefix -> Hashtbl.find_opt annotation_lookup_table prefix) string
+
+  let annotation_edge a = { a1=a; a2=a; edge=Id }
+
+  let parse_annotation input =
+    match lookup_atom_prefix input with
+    | Some (annotation, "") -> Some annotation
+    | _ -> None
+
+  (* Parse two edge annotations, for example `AL`. *)
+  let parse_edge_annotations string =
+    match lookup_atom_prefix string with
+    | None -> None
+    | Some (left_annotation, suffix) ->
+        match lookup_atom_prefix suffix with
+        | Some (right_annotation, "") ->
+            Some (left_annotation, right_annotation)
+        | _ -> None
+
+  (* Parse `input`.
+     - For an edge-only input such as `PosWW`, return the edge.
+     - For an annotation-only input such as `L`, return an annotated `Id` edge.
+     - For a composite input such as `PosWWLA`, attach `L` and `A` as
+       the edge annotations.
+     - Otherwise, fail. *)
+  let parse_edge input =
+    let parse_annotation_only () =
+      match parse_annotation input with
+      | Some annotation -> annotation_edge annotation
+      | None -> Warn.fatal "Bad edge: %s" input in
+    match lookup_edge_prefix input with
+    | None -> parse_annotation_only ()
+    | Some (edge, "") -> edge
+    (* If there is a suffix, it must parse as two annotations. Otherwise,
+       try parsing the whole input as an annotation-only edge, for annotation
+       names that start with an edge prefix. *)
+    | Some (edge, suffix) ->
+        begin match parse_edge_annotations suffix with
+        | Some (a1, a2) -> {edge with a1; a2}
+        | _ -> parse_annotation_only ()
+        end
 
   let parse_edges s =
     pre_parse_string s |> List.map parse_edge

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -69,15 +69,14 @@ open C.R
 
   (* Parse an input relaxation expression such as "[Po DpAddr] Fre".
      In canonical form this is "[Po,DpAddr]|Fre": top-level whitespace denotes
-     a choice for backward compatibility. The result is
-     a list of unfolded relaxations, each wrapped in `ERS` and containing one
-     or more edges in sequence. *)
+     a choice for backward compatibility. If an explicit top-level choice is
+     present, an explicit comma still keeps a sequence together. The result is
+     a list of unfolded relaxations, each represented as one or more edges in
+     sequence. *)
   let parse_argument input_argument =
     parse_argument_ast input_argument
     |> parse_expand_relaxs ~ppo:C.ppo
-    |> List.map edges_of
     |> varatom_ess
-    |> List.map ( fun edges -> ERS edges )
     |> remove_invalid_relaxes
 
   let parse_argument_list input_argument_list =
@@ -131,11 +130,11 @@ open C.R
     end ;
     M.gen ~relax:lr ~safe:ls ~reject:rl n
 
-  let er e = ERS [plain_edge e]
+  let er e = [plain_edge e]
 
   let gen_thin n =
     let lr = [er (Rf Int); er (Rf Ext)]
-    and ls = [PPO] in
+    and ls = C.ppo Misc.cons [] in
     M.gen ~relax:lr ~safe:ls n
 
 
@@ -306,7 +305,7 @@ let () =
         let rhs_unfold = M.parse_argument rhs in
         List.map ( fun l ->
           List.map ( fun r ->
-            l,r,M.M.filter_check ~relax ~safe (Builder.R.edges_of l) (Builder.R.edges_of r)
+            l,r,M.M.filter_check ~relax ~safe l r
           ) rhs_unfold
         ) lhs_unfold
         |> List.flatten

--- a/gen/diycross.ml
+++ b/gen/diycross.ml
@@ -63,7 +63,6 @@ module Make (Config:Config) (M:Builder.S) =
       List.map (M.R.parse_ast Parser.main_top_level_choice) input
       |> fun e -> Ast.Seq e
       |> M.R.parse_expand_relaxs ~ppo:M.ppo
-      |> List.map M.R.edges_of
       |> varatom_ess
 
     let zyva pp_rs =

--- a/gen/diyone.ml
+++ b/gen/diyone.ml
@@ -128,7 +128,7 @@ module Make(O:Config) (M:Builder.S) =
           |> M.R.parse_expand_relaxs ~ppo:M.ppo in
         let es =
           match parsed_cycle with
-            | [x] -> M.R.edges_of x
+            | [x] -> x
             | _ ->
               Warn.user_error "`diyone7` only accepts exactly one input cycle." in
         if O.verbose > 0 then

--- a/gen/norm.ml
+++ b/gen/norm.ml
@@ -73,7 +73,7 @@ module Make(Co:Config)(F:Fence.S)(A:Atom.S) = struct
     try
       let parsed_relax = R.parse_expand_relaxs (R.parse_sequence_ast Parser.main relaxs) in
       let es = match parsed_relax with
-        | [x] -> R.edges_of x
+        | [x] -> x
         | _ ->
           Warn.user_error "`norm7` only accepts exactly one input cycle." in
       let base,es,_ = Norm.normalise_family (E.resolve_edges es) in

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -23,10 +23,8 @@ module type S = sig
   type edge
 
 
-  type relax =
-(* Sequence of edges (eg Cumulativity) *)
-    | ERS of edge list
-    | PPO
+  (* `relax`, a sequence of edges. *)
+  type relax = edge list
 
   val ac_fence : fence -> sd -> extr -> extr -> relax
   val bc_fence : fence -> sd -> extr -> extr -> relax
@@ -38,7 +36,6 @@ module type S = sig
   val compare : relax -> relax -> int
   val pp_relax : relax -> string
   val pp_relax_list : relax list -> string
-  val edges_of : relax -> edge list
   val edges_of_relax_list : relax list -> edge list
 
   val com : relax list
@@ -102,57 +99,43 @@ and type edge = E.edge
         type dp = E.dp
         type edge = E.edge
 
-        type relax =
-          | ERS of edge list
-          | PPO
+        type relax = edge list
 
-        let edges_of r = match r with
-        | ERS es -> es
-        | PPO -> assert false
+        let edges_of_relax_list = List.flatten
 
-        let edges_of_relax_list = List.concat_map edges_of
-
-        let compare_edges es1 es2 =
-          List.compare E.compare es1 es2
-
-        let compare r1 r2 = match r1,r2 with
-        | PPO,PPO -> 0
-        | PPO,ERS _ -> -1
-        | ERS _,PPO -> 1
-        | ERS l1,ERS l2 -> compare_edges l1 l2
+        let compare r1 r2 =
+          List.compare E.compare r1 r2
 
 
 
 (* Cumulativity macros *)
         let rf = E.plain_edge (E.Rf Ext)
         and fenced  f sl d1 d2 = E.plain_edge (E.Fenced (f,sl,d1,d2))
-        let ac_fence f sl d1 d2 = ERS [rf; fenced f sl d1 d2]
-        let bc_fence f sl d1 d2 = ERS [fenced f sl d1 d2; rf]
-        let abc_fence f sl d1 d2 = ERS [rf; fenced f sl d1 d2; rf]
-        let bc_dp dp sl d = ERS [E.plain_edge (E.Dp (dp,sl,d)); rf]
+        let ac_fence f sl d1 d2 = [rf; fenced f sl d1 d2]
+        let bc_fence f sl d1 d2 = [fenced f sl d1 d2; rf]
+        let abc_fence f sl d1 d2 = [rf; fenced f sl d1 d2; rf]
+        let bc_dp dp sl d = [E.plain_edge (E.Dp (dp,sl,d)); rf]
 
 (* Pretty print, macros are filtered and printed specially *)
         let internal_pp_relax backward_compatibility r =
           let open E in
           match r with
-          | ERS [e] -> E.pp_edge e
-          | ERS
-              [{edge=Rf Ext; a1=None;a2=None;};
-               {edge=Fenced _;a1=None; a2=None;} as e] when backward_compatibility ->
+          | [e] -> E.pp_edge e
+          | [{edge=Rf Ext; a1=None;a2=None;};
+             {edge=Fenced _;a1=None; a2=None;} as e] when backward_compatibility ->
                  sprintf "AC%s" (pp_edge e)
-          | ERS [{edge=Fenced _; a1=None;a2=None;} as e;
-                 {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
+          | [{edge=Fenced _; a1=None;a2=None;} as e;
+             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
-          | ERS [{edge=Rf Ext; a1=None; a2=None;};
-                 {edge=Fenced _; a1=None; a2=None;} as e;
-                 {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
+          | [{edge=Rf Ext; a1=None; a2=None;};
+             {edge=Fenced _; a1=None; a2=None;} as e;
+             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
                    sprintf "ABC%s" (pp_edge e)
-          | ERS [{edge=Dp _; a1=None; a2=None;} as e;
-                 {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
+          | [{edge=Dp _; a1=None; a2=None;} as e;
+             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
-          | ERS es ->
+          | es ->
               sprintf "[%s]" (String.concat "," (List.map pp_edge es))
-          | PPO -> "PPO"
 
         let pp_relax = internal_pp_relax false
 
@@ -161,7 +144,7 @@ and type edge = E.edge
 (* Fold over all relaxations *)
 
         let fold_relax wildcard f k =
-          let k = E.fold_edges (fun e -> f (ERS [e])) k in
+          let k = E.fold_edges (fun e -> f [e]) k in
           let k =
             F.fold_cumul_fences
               (fun fe k ->
@@ -184,7 +167,6 @@ and type edge = E.edge
                 Code.fold_sd wildcard
                   (fun sd k -> f (bc_dp dpw sd (Dir W)) k)
                   k) k in
-          let k = f PPO k in
           k
 
         let iter_relax wildcard = Misc.fold_to_iter (fold_relax wildcard)
@@ -213,16 +195,12 @@ and type edge = E.edge
 (*************************************************************)
 (* Expansion of irrelevant direction specifications in edges *)
 (*************************************************************)
-        let rec do_expand_relax ppo r f = match r with
-        | ERS es -> E.expand_edges es (fun es -> f (ERS es))
-        | PPO  -> ppo (fun r -> do_expand_relax ppo r f)
-
-        let expand_relaxs ppo rs =
-          let expand_relax r = do_expand_relax ppo r Misc.cons in
+        let expand_relaxs rs =
+          let expand_relax r = E.expand_edges r Misc.cons in
           List.fold_right expand_relax rs []
 
-        let er e = ERS [E.plain_edge e]
-        let ers es = ERS (List.map E.plain_edge es)
+        let er e = [E.plain_edge e]
+        let ers es = List.map E.plain_edge es
         let com =
           let open E in
           [
@@ -249,7 +227,7 @@ and type edge = E.edge
 
 
 (* Expand relax macros *)
-        let er e = ERS [E.plain_edge e]
+        let er e = [E.plain_edge e]
 
         let all_fences sd d1 d2 =
           F.fold_all_fences
@@ -344,18 +322,26 @@ and type edge = E.edge
                 | false, false ->
                     for_all_adjacent_concrete_edge predicate list in
           List.filter
-          ( fun relax ->
-            let edges = edges_of relax in
-            (* Drop empty alternatives introduced by `?`; they do not
-               describe an actual relaxation. *)
-            edges <> []
-            && for_all_adjacent_concrete_edge E.can_precede edges
-          ) relaxes
+            (fun relax ->
+              (* Drop empty alternatives introduced by `?`; they do not
+                 describe an actual relaxation. *)
+              relax <> []
+              && for_all_adjacent_concrete_edge E.can_precede relax)
+            relaxes
           |> List.sort_uniq compare
 
         let parse_expand_relax ?(ppo=(fun _ k -> k)) str =
+          let unfold_ppo () =
+            let relaxs = ppo Misc.cons [] in
+            begin match relaxs with
+            | [] -> Warn.fatal "Bad relax: PPO"
+            | _ -> ()
+            end ;
+            expand_relaxs relaxs
+            |> relax_list_to_choice in
           match str with
           (* Directly unfold macro *)
+          | "PPO" -> unfold_ppo ()
           | "allRR" -> allR Diff R
           | "allRW" -> allR Diff W
           | "allWR" -> allW Diff R
@@ -365,20 +351,20 @@ and type edge = E.edge
           | "someWR" -> someW Diff R
           | "someWW" -> someW Diff W
           | str ->
-            let relax = try ERS ([E.parse_edge str])
+            let relax = try [E.parse_edge str]
             (* For backward compatibility, also accept the legacy pretty-printed
                names recorded in the special table `t`. *)
             with _ -> try Hashtbl.find t str
             with Not_found -> Warn.fatal "Bad relax: %s" str in
             [relax]
           (* expand the wildcard edges and annotations *)
-          |> expand_relaxs ppo
+          |> expand_relaxs
           |> relax_list_to_choice
 
           let parse_expand_relaxs ?(ppo=(fun _ k -> k)) ast =
             Ast.bind ast (parse_expand_relax ~ppo)
               |> Ast.expand
-              |> List.map ( fun e -> ERS (edges_of_relax_list e) )
+              |> List.map edges_of_relax_list
 
 (********)
 (* Sets *)
@@ -402,16 +388,13 @@ and type edge = E.edge
         let is_cumul r =
           let open E in
           match r with
-          | ERS
-              [{edge=Rf Code.Ext; a1=None; a2=None;};
-               {edge=Fenced _; a1=None; a2=None;}]
-          | ERS
-              [{edge=Fenced _; a1=None; a2=None;};
-               {edge=Rf Code.Ext; a1=None; a2=None;};]
-          | ERS
-              [{edge=Rf Code.Ext; a1=None; a2=None;};
-               {edge=Fenced _; a1=None; a2=None;};
-               {edge=Rf Code.Ext; a1=None; a2=None;};]
+          | [{edge=Rf Code.Ext; a1=None; a2=None;};
+             {edge=Fenced _; a1=None; a2=None;}]
+          | [{edge=Fenced _; a1=None; a2=None;};
+             {edge=Rf Code.Ext; a1=None; a2=None;};]
+          | [{edge=Rf Code.Ext; a1=None; a2=None;};
+             {edge=Fenced _; a1=None; a2=None;};
+             {edge=Rf Code.Ext; a1=None; a2=None;};]
             -> true
           | _ -> false
 
@@ -425,17 +408,13 @@ and type edge = E.edge
         let add_fence r k =
           let open E in
           match r with
-          | ERS
-              [{edge=Fenced (f,_,_,_); _}]
-          | ERS
-              [{edge=Rf Code.Ext; _};{edge=Fenced (f,_,_,_);_}]
-          | ERS
-              [{edge=Fenced (f,_,_,_); _};
-               {edge=Rf Code.Ext; _};]
-          | ERS
-              [{edge=Rf Code.Ext; _};
-               {edge=Fenced (f,_,_,_); _};
-               {edge=Rf Code.Ext; _};]
+          | [{edge=Fenced (f,_,_,_); _}]
+          | [{edge=Rf Code.Ext; _};{edge=Fenced (f,_,_,_);_}]
+          | [{edge=Fenced (f,_,_,_); _};
+             {edge=Rf Code.Ext; _};]
+          | [{edge=Rf Code.Ext; _};
+             {edge=Fenced (f,_,_,_); _};
+             {edge=Rf Code.Ext; _};]
             -> FenceSet.add f k
           | _ -> k
 
@@ -448,15 +427,12 @@ and type edge = E.edge
         let add_cumul_fence r k =
           let open E in
           match r with
-          | ERS
-              [{edge=Rf Code.Ext; _};{edge=Fenced (f,_,_,_); _}]
-          | ERS
-              [{edge=Fenced (f,_,_,_); _};
-               {edge=Rf Code.Ext; _};]
-          | ERS
-              [{edge=Rf Code.Ext; _};
-               {edge=Fenced (f,_,_,_); _};
-               {edge=Rf Code.Ext; _};]
+          | [{edge=Rf Code.Ext; _};{edge=Fenced (f,_,_,_); _}]
+          | [{edge=Fenced (f,_,_,_); _};
+             {edge=Rf Code.Ext; _};]
+          | [{edge=Rf Code.Ext; _};
+             {edge=Fenced (f,_,_,_); _};
+             {edge=Rf Code.Ext; _};]
             -> FenceSet.add f k
           | _ -> k
 
@@ -469,19 +445,16 @@ and type edge = E.edge
         let remove_cumul rs = Set.filter (fun r -> not (is_cumul r)) rs
 
         let expand_cumul rs =
-          let er e = ERS [e] in
+          let er e = [e] in
           let xs =
             Set.fold
               (fun r k ->
                 let open E in
                 match r with
-                | ERS
-                    ([{edge=Rf Ext; _}; {edge=Fenced _; _};] as rs)
-                | ERS
-                    ([{edge=Fenced _; _}; {edge=Rf Ext; _};] as rs)
-                | ERS
-                    ([{edge=Rf Ext; _}; {edge=Fenced _; _};
-                      {edge=Rf Ext; _};] as rs)
+                | ([{edge=Rf Ext; _}; {edge=Fenced _; _};] as rs)
+                | ([{edge=Fenced _; _}; {edge=Rf Ext; _};] as rs)
+                | ([{edge=Rf Ext; _}; {edge=Fenced _; _};
+                    {edge=Rf Ext; _};] as rs)
                   ->
                     RSet.of_list (List.map er rs)::k
                 | _ -> RSet.singleton r::k)
@@ -531,12 +504,11 @@ and type edge = E.edge
         let rec match_head rs es =
           Set.fold
             (fun r k ->
-              let ps = edges_of r in
-              match match_edges ps es with
+              match match_edges r es with
               | None -> k
               | Some (h,rem) ->
                   List.fold_left
-                    (fun k rs -> (ERS h::rs)::k)
+                    (fun k rs -> (h::rs)::k)
                     k (matches rs rem))
             rs []
 
@@ -553,15 +525,12 @@ and type edge = E.edge
           SetSet.unions (do_rec (List.length es) es)
 
 
-        let compact_sequence r1 r2 = match r1,r2 with
-        | ERS es1,ERS es2 ->
-            let e1 = Misc.last es1 and e2 = List.hd es2 in
-            begin match E.get_ie e1, E.get_ie e2 with
-            | Int,Int when E.can_precede e1 e2 ->
-                let ess = E.compact_sequence es1 es2 e1 e2 in
-                let rs = List.map (fun es -> ERS es) ess in
-                Set.of_list rs
-            | _,_ -> Set.empty
-            end
-        | _,_ -> assert false
+        let compact_sequence es1 es2 =
+          let e1 = Misc.last es1 and e2 = List.hd es2 in
+          begin match E.get_ie e1, E.get_ie e2 with
+          | Int,Int when E.can_precede e1 e2 ->
+              E.compact_sequence es1 es2 e1 e2
+              |> Set.of_list
+          | _,_ -> Set.empty
+          end
       end

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -144,7 +144,6 @@ and type edge = E.edge
 (* Fold over all relaxations *)
 
         let fold_relax wildcard f k =
-          let k = E.fold_edges (fun e -> f [e]) k in
           let k =
             F.fold_cumul_fences
               (fun fe k ->
@@ -315,6 +314,33 @@ and type edge = E.edge
           | [relax] -> relax
           | relax_list -> Ast.Choice relax_list
 
+        (* Apply an annotation suffix parsed from a macro name such as `PodW*LA`
+           to each singleton expansion of that macro. *)
+        let add_macro_annotations a1 a2 =
+          List.map
+            (function
+              | [e] -> [{e with E.a1; E.a2}]
+              | relax -> relax)
+
+        (* Find the longest prefix that is a macro.  Since the search starts
+           from the full string length, this also covers exact macro names. *)
+        let rec find_macro_prefix str i =
+          if i <= 0 then None
+          else
+            let prefix = String.sub str 0 i in
+            (* Macro table lookup. *)
+            match Hashtbl.find_opt macro_lookup_table prefix with
+            | Some relax ->
+                let suffix = String.sub str i (String.length str - i) in
+                if String.length suffix = 0 then Some relax
+                else
+                  (* If there is a suffix, try to parse it as two annotations. *)
+                  begin match E.parse_edge_annotations suffix with
+                  | Some (a1,a2) -> Some (add_macro_annotations a1 a2 relax)
+                  | None -> find_macro_prefix str (i - 1)
+                  end
+            | None -> find_macro_prefix str (i - 1)
+
         let parse_expand_relax ?(ppo=(fun _ k -> k)) str =
           let unfold_ppo () =
             let relaxs = ppo Misc.cons [] in
@@ -326,12 +352,13 @@ and type edge = E.edge
           | "PPO" -> unfold_ppo ()
           | str ->
               (* Macro lookup *)
-              match Hashtbl.find_opt macro_lookup_table str with
+              begin match find_macro_prefix str (String.length str) with
               | Some relax -> relax
-              (* Parse primitive edge *)
               | None ->
+                  (* Parse primitive edge *)
                   try [[E.parse_edge str]]
-                  with _ -> Warn.fatal "Bad relax: %s" str in
+                  with _ -> Warn.fatal "Bad relax: %s" str
+              end in
           (* expand the wildcard edges and annotations *)
           expand_relaxs parsed_edges
           |> relax_list_to_choice

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -181,24 +181,9 @@ and type edge = E.edge
   so as to build a table of recognized relaxations.
  *)
 
-(* Lexeme table *)
-        let t = Hashtbl.create 101
-
-(* Fill up lexeme table *)
-        let () =
-          iter_relax E.wildcard
-            (fun e ->
-              let pp = internal_pp_relax true e in
-              Hashtbl.add t pp e);
-          ()
-
 (*************************************************************)
 (* Expansion of irrelevant direction specifications in edges *)
 (*************************************************************)
-        let expand_relaxs rs =
-          let expand_relax r = E.expand_edges r Misc.cons in
-          List.fold_right expand_relax rs []
-
         let er e = [E.plain_edge e]
         let ers es = List.map E.plain_edge es
         let com =
@@ -237,14 +222,6 @@ and type edge = E.edge
           F.fold_some_fences
             (fun f k -> er (E.Fenced (f,sd,Dir d1,Dir d2))::k)
 
-        let relax_list_to_choice relax_list =
-          let ast_relax_list =
-            List.map (fun relax -> Ast.One relax) relax_list in
-          match ast_relax_list with
-              | [] -> assert false
-              | [relax] -> relax
-              | relax_list -> Ast.Choice relax_list
-
 (* Limited variations *)
         let app_def_dp o f r = match o with
         | None -> r
@@ -256,12 +233,10 @@ and type edge = E.edge
             (match d with R -> F.ddr_default | W -> F.ddw_default)
             (fun dp k -> er (E.Dp (dp,sd,Dir d))::k)
             (some_fences sd R d [])
-          |> relax_list_to_choice
 
         let someW sd d =
           er (E.Po (sd,Dir W,Dir d))::
           (some_fences sd W d [])
-          |> relax_list_to_choice
 
 
 (* ALL *)
@@ -270,12 +245,10 @@ and type edge = E.edge
           (match d with R -> F.fold_dpr | W -> F.fold_dpw)
             (fun dp k -> er (E.Dp (dp,sd,Dir d))::k)
             (all_fences sd R d [])
-          |> relax_list_to_choice
 
         let allW sd d =
           er (E.Po (sd,Dir W,Dir d))::
           (all_fences sd W d [])
-          |> relax_list_to_choice
 
         let atoms_key = "atoms"
 
@@ -303,6 +276,70 @@ and type edge = E.edge
         let parse_sequence_ast parser_grammar segments =
           Ast.Seq (List.map (parse_ast parser_grammar) segments)
 
+(* Macro lookup table. *)
+        let macro_lookup_table = Hashtbl.create 101
+
+(* Build the macro lookup table. *)
+        let () =
+          iter_relax E.wildcard
+            (fun e ->
+              let pp = internal_pp_relax true e in
+              Hashtbl.add macro_lookup_table pp [e]) ;
+          List.iter
+            (fun (name, macro) -> Hashtbl.add macro_lookup_table name macro)
+            [
+              "allRR", allR Diff R;
+              "allRW", allR Diff W;
+              "allWR", allW Diff R;
+              "allWW", allW Diff W;
+              "someRR", someR Diff R;
+              "someRW", someR Diff W;
+              "someWR", someW Diff R;
+              "someWW", someW Diff W;
+            ]
+
+        let expand_relaxs rs =
+          let expand_relax r = E.expand_edges r Misc.cons in
+          List.fold_right expand_relax rs []
+
+        let relax_to_sequence relax = match relax with
+        | [] -> Warn.fatal "Relax is parsed incorrectly."
+        | [edge] -> Ast.One edge
+        | edges -> Ast.Seq (List.map (fun edge -> Ast.One edge) edges)
+
+        let relax_list_to_choice relax_list =
+          let ast_relax_list =
+            List.map relax_to_sequence relax_list in
+          match ast_relax_list with
+          | [] -> assert false
+          | [relax] -> relax
+          | relax_list -> Ast.Choice relax_list
+
+        let parse_expand_relax ?(ppo=(fun _ k -> k)) str =
+          let unfold_ppo () =
+            let relaxs = ppo Misc.cons [] in
+            match relaxs with
+            | [] -> Warn.fatal "Bad relax: PPO"
+            | r -> r in
+          let parsed_edges = match str with
+          (* Directly unfold macro *)
+          | "PPO" -> unfold_ppo ()
+          | str ->
+              (* Macro lookup *)
+              match Hashtbl.find_opt macro_lookup_table str with
+              | Some relax -> relax
+              (* Parse primitive edge *)
+              | None ->
+                  try [[E.parse_edge str]]
+                  with _ -> Warn.fatal "Bad relax: %s" str in
+          (* expand the wildcard edges and annotations *)
+          expand_relaxs parsed_edges
+          |> relax_list_to_choice
+
+          let parse_expand_relaxs ?(ppo=(fun _ k -> k)) ast =
+            Ast.bind ast (parse_expand_relax ~ppo)
+              |> Ast.expand
+
         (* After wildcard and macro expansion, remove invalid relaxations
            whose adjacent concrete edges cannot appear consecutively.
            Pseudo-edges (annotations and insert edge) are ignored in the check.
@@ -329,42 +366,6 @@ and type edge = E.edge
               && for_all_adjacent_concrete_edge E.can_precede relax)
             relaxes
           |> List.sort_uniq compare
-
-        let parse_expand_relax ?(ppo=(fun _ k -> k)) str =
-          let unfold_ppo () =
-            let relaxs = ppo Misc.cons [] in
-            begin match relaxs with
-            | [] -> Warn.fatal "Bad relax: PPO"
-            | _ -> ()
-            end ;
-            expand_relaxs relaxs
-            |> relax_list_to_choice in
-          match str with
-          (* Directly unfold macro *)
-          | "PPO" -> unfold_ppo ()
-          | "allRR" -> allR Diff R
-          | "allRW" -> allR Diff W
-          | "allWR" -> allW Diff R
-          | "allWW" -> allW Diff W
-          | "someRR" -> someR Diff R
-          | "someRW" -> someR Diff W
-          | "someWR" -> someW Diff R
-          | "someWW" -> someW Diff W
-          | str ->
-            let relax = try [E.parse_edge str]
-            (* For backward compatibility, also accept the legacy pretty-printed
-               names recorded in the special table `t`. *)
-            with _ -> try Hashtbl.find t str
-            with Not_found -> Warn.fatal "Bad relax: %s" str in
-            [relax]
-          (* expand the wildcard edges and annotations *)
-          |> expand_relaxs
-          |> relax_list_to_choice
-
-          let parse_expand_relaxs ?(ppo=(fun _ k -> k)) ast =
-            Ast.bind ast (parse_expand_relax ~ppo)
-              |> Ast.expand
-              |> List.map edges_of_relax_list
 
 (********)
 (* Sets *)

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -604,6 +604,178 @@ Alignment filter behaviour between local `Pos**` and internal communication in `
   $ diy7 -arch AArch64 -mode sc -filter-check DpAddrdW PosWW
   Sequence `DpAddrdW` `PosWW` passes the internal filter in mode `sc`
 
+Backward-compatible edge aliases are accepted by the edge parser
+  $ diy7 -arch AArch64 -relax 'Dp** Ctrl** DpData' -unfold-only 2>&1
+  ***relax***
+  DpAddrsW DpAddrsR DpAddrdW DpAddrdR DpDatasW DpDatadW DpCtrlIsbsW DpCtrlIsbsR DpCtrlIsbdW DpCtrlIsbdR
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax 'DpAddr*W DpAddrd* DpData' -unfold-only 2>&1
+  ***relax***
+  DpAddrsW DpAddrdW DpAddrdR DpDatasW DpDatadW
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax R -unfold-only 2>&1
+  ***relax***
+  Read
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax W -unfold-only 2>&1
+  ***relax***
+  Write
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax Ws -unfold-only 2>&1
+  ***relax***
+  Coi Coe
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax 'Wse Wsi' -unfold-only 2>&1
+  ***relax***
+  Coi Coe
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax Rmw -unfold-only 2>&1
+  ***relax***
+  LxSx
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax Amo -unfold-only 2>&1
+  ***relax***
+  Amo.Swp Amo.Cas Amo.LdAdd Amo.LdEor Amo.LdSet Amo.LdClr Amo.StAdd Amo.StEor Amo.StSet Amo.StClr
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax Amo.Safe -unfold-only 2>&1
+  ***relax***
+  Amo.Swp Amo.Cas Amo.LdAdd Amo.StAdd
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax LxSx -unfold-only 2>&1
+  ***relax***
+  LxSx
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax FencedWW -unfold-only 2>&1
+  ***relax***
+  DMB.SYdWW
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -relax 'Fence***' -unfold-only 2>&1
+  ***relax***
+  DMB.SYsWW DMB.SYsWR DMB.SYsRW DMB.SYsRR DMB.SYdWW DMB.SYdWR DMB.SYdRW DMB.SYdRR
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -variant ifetch -relax 'Iff*' -unfold-only 2>&1
+  ***relax***
+  RfiPI RfePI
+  ***safe***
+  
+  ***reject***
+  
+  $ diy7 -arch AArch64 -variant ifetch -relax 'Iffi Irfi Fifi Ifri Iffe Irfe Fife Ifre' -unfold-only 2>&1
+  ***relax***
+  RfiPI RfePI FriIP FreIP
+  ***safe***
+  
+  ***reject***
+  
+
+`PPO` unfolds to concrete PPC relaxations in `diy7 -unfold-only`
+  $ diy7 -arch PPC -relax PPO -unfold-only
+  ***relax***
+  DpAddrdR [DpAddrdR,DpAddrdR] [DpAddrdR,DpDatadW] [DpAddrdR,DpCtrldW] [DpAddrdR,DpCtrlIsyncdR] DpDatadW [DpDatadW,PosWR] [DpDatadW,PosWR,DpAddrdR] [DpDatadW,PosWR,DpDatadW] [DpDatadW,PosWR,DpCtrldW] [DpDatadW,PosWR,DpCtrlIsyncdR] DpCtrldW DpCtrlIsyncdR
+  ***safe***
+  
+  ***reject***
+  
+
+A `BC` relax macro unfolds before raw edge parsing
+  $ diy7 -arch PPC -relax BCDpDatadW -unfold-only
+  ***relax***
+  [DpDatadW,Rfe]
+  ***safe***
+  
+  ***reject***
+  
+
+An `AC` relax macro unfolds before raw edge parsing
+  $ diy7 -arch AArch64 -relax ACDMB.SYdRW -unfold-only
+  ***relax***
+  [Rfe,DMB.SYdRW]
+  ***safe***
+  
+  ***reject***
+  
+
+An `ABC` relax macro unfolds before raw edge parsing
+  $ diy7 -arch AArch64 -relax ABCDMB.SYdRW -unfold-only
+  ***relax***
+  [Rfe,DMB.SYdRW,Rfe]
+  ***safe***
+  
+  ***reject***
+  
+
+`allRW` expands through the named relax lookup table
+  $ diy7 -arch AArch64 -relax allRW -unfold-only
+  ***relax***
+  PodRW ISBdRW GCSB.DSYNCdRW DMB.NSHLDdRW DMB.NSHSTdRW DMB.NSHdRW DMB.ISHLDdRW DMB.ISHSTdRW DMB.ISHdRW DMB.OSHLDdRW DMB.OSHSTdRW DMB.OSHdRW DMB.LDdRW DMB.STdRW DMB.SYdRW DSB.NSHLDdRW DSB.NSHSTdRW DSB.NSHdRW DSB.ISHLDdRW DSB.ISHSTdRW DSB.ISHdRW DSB.OSHLDdRW DSB.OSHSTdRW DSB.OSHdRW DSB.LDdRW DSB.STdRW DSB.SYdRW DpAddrCseldW DpAddrdW DpDataCseldW DpDatadW DpCtrlCseldW DpCtrldW DpCtrlIsbCseldW DpCtrlIsbdW
+  ***safe***
+  
+  ***reject***
+  
+
+`someRW` expands through the named relax lookup table
+  $ diy7 -arch AArch64 -relax someRW -unfold-only
+  ***relax***
+  PodRW ISBdRW DMB.LDdRW DMB.STdRW DMB.SYdRW DpDatadW
+  ***safe***
+  
+  ***reject***
+  
+
+`allWR` expands through the named relax lookup table
+  $ diy7 -arch AArch64 -relax allWR -unfold-only
+  ***relax***
+  PodWR ISBdWR GCSB.DSYNCdWR DMB.NSHLDdWR DMB.NSHSTdWR DMB.NSHdWR DMB.ISHLDdWR DMB.ISHSTdWR DMB.ISHdWR DMB.OSHLDdWR DMB.OSHSTdWR DMB.OSHdWR DMB.LDdWR DMB.STdWR DMB.SYdWR DSB.NSHLDdWR DSB.NSHSTdWR DSB.NSHdWR DSB.ISHLDdWR DSB.ISHSTdWR DSB.ISHdWR DSB.OSHLDdWR DSB.OSHSTdWR DSB.OSHdWR DSB.LDdWR DSB.STdWR DSB.SYdWR
+  ***safe***
+  
+  ***reject***
+  
+
+`someWW` expands through the named relax lookup table
+  $ diy7 -arch AArch64 -relax someWW -unfold-only
+  ***relax***
+  PodWW ISBdWW DMB.LDdWW DMB.STdWW DMB.SYdWW
+  ***safe***
+  
+  ***reject***
+  
+
 `diy7 -unfold-only` unfolds relaxations and drops invalid composites
   $ diy7 -arch AArch64 -relax '[Po,DpAddr?]' -unfold-only 2>&1
   ***relax***


### PR DESCRIPTION
This PR cleans up the first step of macro handling in the generator.

We added many tests for macros and wildcards, which safeguarded the following main changes:
- Remove the old `PPO` constructor but now represent `type relax` directly as an `edge list`. The `PPO` become a macro unfold.
- Parse edge names by longest prefix, then parse trailing annotations, for example `PosWRLA` will be parsed in three steps as `PosWR` `L` and `A`. This massively reduce the size of the lookup table for parsing. Also the old lookup table is split into two tables for `edge` and `annotation` respectively.
- Keep legacy macros such as `AllRW` and alias such as `CtrldW` available through the macro table.

This keeps the macro parsing/unfolding behavior explicit and table-driven, while preparing the later wildcard and alias migration work for a follow-up branch.

