### PR TITLE
[lib] Improve performance of MyLib.find

### DIFF
--- a/lib/myLib.ml
+++ b/lib/myLib.ml
@@ -14,7 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(* Open my files *)
+(* Find my files *)
 
 module type Config = sig
   val includes : string list
@@ -23,26 +23,23 @@ module type Config = sig
   val debug : bool
 end
 
-let pp_debug name = Printf.eprintf "Found and opened: '%s'\n%!" name
+let pp_debug name = Printf.eprintf "Found: '%s'\n%!" name
 
 module Make =
   functor (C:Config) -> struct
 
     let debug = C.debug
 
-    let try_open dir name =
-      let rname = Filename.concat dir name in
-      try
-        let r = rname,open_in rname in
-        if debug then pp_debug rname ;
-        r
-      with _ -> raise Exit
+    (* TODO: could refine this to check whether the file is a regular file or symlink *)
+    let nondir_file_exists path =
+      Sys.file_exists path && not (Sys.is_directory path)
 
-    let rec try_opens dirs name = match dirs with
-    | [] -> raise Exit
-    | dir::dirs ->
-        try try_open dir name
-        with Exit -> try_opens dirs name
+    let try_find name dir =
+      let rname = Filename.concat dir name in
+      if nondir_file_exists rname then begin
+        if debug then pp_debug rname ;
+        Some rname
+      end else None
 
     let envlib = match C.env with
     | None -> None
@@ -58,20 +55,14 @@ module Make =
           else d)
         C.includes
 
-    let open_lib name =
-      try try_opens ("."::includes) name
-      with Exit -> try match envlib with
-      | Some lib -> try_open lib name
-      | None -> raise Exit
-      with Exit -> try try_open C.libdir name
-      with Exit -> Warn.fatal "Cannot find file %s" name
+    let all_locations =
+      List.concat [ ["."] ; includes ; Option.to_list envlib; [ C.libdir ] ]
 
-    let do_find name =
-      let r,chan = open_lib name in
-      begin try close_in chan with _ -> () end ;
-      r
+    let find_lib name =
+      match List.find_map (try_find name) all_locations with
+      | Some path -> path
+      | None -> Warn.fatal "Cannot find file %s" name
 
     let find path =
-      if Filename.is_implicit path then do_find path
-      else path
+      if Filename.is_implicit path then find_lib path else path
   end

--- a/lib/myLib.mli
+++ b/lib/myLib.mli
@@ -14,7 +14,8 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Open my files *)
+(** Resolve library file names against configured search paths. *)
+
 module type Config = sig
   val includes : string list
   val env : string option
@@ -28,4 +29,11 @@ module Make :
   functor (C:Config) ->
     sig
       val find : string -> string
+      (** [find path] resolves [path] to a concrete the library file path.
+
+          If [path] is implicit, it is searched in the current directory,
+          {!C.includes}, {!C.env}, and finally {!C.libdir}. The first existing
+          candidate is returned. Non-implicit paths are returned unchanged.
+
+          @raise Misc.Fatal on implicit paths that cannot be resolved. *)
     end


### PR DESCRIPTION
This PR makes `MyLib.find` cheaper by replacing its `open_in`/`close_in`-based filesystem checks with `Sys.file_exists`, and by caching resolved implicit paths. This in turn fixes a recent performance regression in `ParseModel.find_parse`.

### Motivation

The motivation is to address a performance issue that showed up while running `herd7` on this litmus test:

```text
AArch64 test
{
0:X1=x;
1:X1=x;
}
P0          | P1           ;
L0:         | MOV W6,#1    ;
LDR W2,[X1] | STR W6,[X1]  ;
MOV W4,#0   | MOV W6,#1    ;
STR W4,[X1] | STR W6,[X1]  ;
CBNZ W2,L0  | MOV W6,#2    ;
            | STR W6,[X1]  ;
```

On OCaml 4.14, a simple `time` run showed substantial time spent in system calls:

```text
       36.91 real        20.48 user         8.85 sys
```

More in-depth profiling traced the issue back to `ParseModel.find_parse` and `MyLib.find`. Since #1686, `ParseModel.find_parse` resolves model paths through `O.libfind` so that herd can support multiple libdirs, which is needed by `herd-www`. `O.libfind` is usually implemented via `MyLib.find`. Since `find_parse` gets invoked _many_ times when simulating tests like the above, a consequence of that PR is that `MyLib.find` is now part of a hot path.

It seems the current implementation of `MyLib.find` is doing more work than perhaps needed, hence the large time spent on syscalls for the test above. In particular, the function does not cache previous results, and checks existence of paths via `open_in` and `close_in` , which are costly operations.

This PR speeds up `MyLib.find` by using `Sys.file_exists` instead, as well as caching resolved implicit paths.

Here's some benchmarks collected on OCaml 4.14, targeting either the litmus test above, or the full `make test`, using three different variants of `MyLib.find`: cache-only (i.e. the old `MyLib.find`, just memoized), fs-only (i.e. `Sys.file_exists` instead of open/close, but no memoization), and cache+fs.

| Variant    | Benchmark   | Runs | Median real | Median user | Median sys | Min real | Max real |
| ---------- | ----------- | ---: | ----------: | ----------: | ---------: | -------: | -------: |
| baseline   | single test |    5 |      37.804 |      21.250 |      9.175 |   37.270 |   38.413 |
| cache+fs   | single test |    5 |      14.228 |      14.158 |      0.037 |   14.185 |   14.353 |
| cache-only | single test |    5 |      14.080 |      14.011 |      0.044 |   13.956 |   14.289 |
| fs-only    | single test |    5 |      14.874 |      14.260 |      0.573 |   14.780 |   14.900 |
| baseline   | make-test   |    5 |      45.486 |     156.299 |     35.843 |   44.798 |   45.791 |
| cache+fs   | make-test   |    5 |      41.926 |     150.775 |     28.954 |   41.390 |   42.134 |
| cache-only | make-test   |    5 |      42.566 |     151.224 |     29.480 |   42.369 |   42.874 |
| fs-only    | make-test   |    5 |      42.359 |     149.598 |     28.333 |   41.892 |   42.423 |

The fs-only change by itself nearly matches the performance improvement of the cache-only change, which suggests removing `open_in`/`close_in` might be the main factor here. Combining both changes is not a huge win compared to just applying one of the two, but still worthwhile IMO.

NOTE: `Sys.file_exists` only checks whether the path exists at lookup time, not whether it can be opened successfully. Therefore this PR changes the semantics of `MyLib.find` slightly: the function resolves an input path to the first _existing_ candidate path it finds, rather than the first _openable_ candidate path. I don't think this is a big deal, since even in cases where `MyLib.find` resolves to an un-openable path, such path would generate an error later in the code anyway.

NOTE2: I've verified that this module still works fine when compiled to javascript with `js_of_ocaml`, as needed for herd-www.