### PR TITLE
Refine AArch64 BBM modelling and add regression coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,19 @@ cata-test:: test.herd.cata.aarch64-readers-guide
 cata-test:: test.herd.cata.bpf
 cata-test:: test.herd.cata.x86_64
 
+test.herd.cata-extended.%:
+	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-j $(J) \
+		$(NOHASH) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir  catalogue/$*/tests \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 catalogue extended $* tests: OK"
+
+cata-test-all:: test.herd.cata-extended.aarch64-BBM
+
 test.herd-mixed.cata.%:
 	@ echo
 	$(HERD_CATALOGUE_REGRESSION_TEST) \

--- a/catalogue/aarch64-BBM/cats/aarch64.cat
+++ b/catalogue/aarch64-BBM/cats/aarch64.cat
@@ -1,0 +1,1 @@
+../../../herd/libdir/aarch64.cat

--- a/catalogue/aarch64-BBM/cfgs/web.cfg
+++ b/catalogue/aarch64-BBM/cfgs/web.cfg
@@ -1,0 +1,32 @@
+graph cluster
+showevents noregs
+withbox true
+labelbox true
+fontsize 12
+xscale 2.0
+yscale 1.5
+arrowsize 0.8
+splines spline
+pad 0.1
+
+doshow ets-ob
+doshow bob,DSB-ob
+unshow dmb.sy,dmb.st,dmb.ld,dsb.sy,isb,dsb.st,dsb.ld,isb
+
+edgeattr iico_data,color,violetred
+edgeattr iico_ctrl,color,lightblue
+edgeattr iico_order,color,teal
+edgeattr rmw,color,indigo
+
+edgeattr po,color,lightgray
+
+edgeattr tc-before,color,aquamarine4
+edgeattr sca-class,color,lightgray
+edgeattr DSB-ob,color,gray
+edgeattr IFB-ob,color,navyblue
+edgeattr dob,color,darkgoldenrod1
+edgeattr bob,color,orange3
+edgeattr aob,color,darkgoldenrod1
+edgeattr ets-ob,color,skyblue4
+edgeattr TLBI-ob,color,purple
+edgeattr TLBI-after,color,forestgreen

--- a/catalogue/aarch64-BBM/shelf.py
+++ b/catalogue/aarch64-BBM/shelf.py
@@ -1,0 +1,20 @@
+record = "AArch64 BBM"
+
+cats = [
+    "cats/aarch64.cat",
+]
+
+cfgs = [
+    "cfgs/web.cfg",
+]
+
+illustrative_tests = [
+    "tests/CoRR+PteGRE.litmus",
+    "tests/CoRR+PteNC.litmus",
+    "tests/CoRR+PteOA.DB0.litmus",
+    "tests/CoRR+PteOA.DB0.val.litmus",
+    "tests/CoRR+PteOA.DB1.val.litmus",
+    "tests/MP+tlbi-sync.ishspteaf0pteoa.af1+pos.litmus",
+    "tests/MP+tlbi-sync.ishsptev0pteoa.v1+pos.litmus",
+    "tests/MP+tlbi-sync.ishsRpteaf0pte-amo.casptepteoa.af1+pos.litmus",
+]

--- a/catalogue/aarch64-BBM/tests/CoRR+PteGRE.litmus
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteGRE.litmus
@@ -1,0 +1,12 @@
+AArch64 CoRR+PteOA.GRE
+Variant=vmsa
+{
+ [x]=1; [y]=2;
+ [PTE(x)]=(oa:PA(x),attrs:(Device-GRE));
+ 0:X4=(oa:PA(y),db:0); 0:X5=PTE(x); 
+ 1:X1=x;
+}
+ P0          | P1          ;
+ STR X4,[X5] | LDR W0,[X1] ;
+             | LDR W2,[X1] ;
+exists(1:X0=2 /\ 1:X2=1)

--- a/catalogue/aarch64-BBM/tests/CoRR+PteGRE.litmus.expected
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteGRE.litmus.expected
@@ -1,0 +1,14 @@
+Test CoRR+PteOA.GRE Allowed
+States 4
+1:X0=1; 1:X2=1;
+1:X0=1; 1:X2=2;
+1:X0=2; 1:X2=1;
+1:X0=2; 1:X2=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Flag Warning-BBM-expected
+Condition exists (1:X0=2 /\ 1:X2=1)
+Observation CoRR+PteOA.GRE Sometimes 1 3
+Hash=aa54ac8011406299c4dec5a099a0061f
+

--- a/catalogue/aarch64-BBM/tests/CoRR+PteNC.litmus
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteNC.litmus
@@ -1,0 +1,12 @@
+AArch64 CoRR+PteOA.NC
+Variant=vmsa
+{
+ [x]=1; [y]=2;
+ [PTE(x)]=(oa:PA(x),attrs:(Normal,iNC,oNC));
+ 0:X4=(oa:PA(y),db:0); 0:X5=PTE(x); 
+ 1:X1=x;
+}
+ P0          | P1          ;
+ STR X4,[X5] | LDR W0,[X1] ;
+             | LDR W2,[X1] ;
+exists(1:X0=2 /\ 1:X2=1)

--- a/catalogue/aarch64-BBM/tests/CoRR+PteNC.litmus.expected
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteNC.litmus.expected
@@ -1,0 +1,14 @@
+Test CoRR+PteOA.NC Allowed
+States 4
+1:X0=1; 1:X2=1;
+1:X0=1; 1:X2=2;
+1:X0=2; 1:X2=1;
+1:X0=2; 1:X2=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Flag Warning-BBM-expected
+Condition exists (1:X0=2 /\ 1:X2=1)
+Observation CoRR+PteOA.NC Sometimes 1 3
+Hash=046a94c79fa6f3bad19a820604cd5e6e
+

--- a/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB0.litmus
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB0.litmus
@@ -1,0 +1,12 @@
+AArch64 CoRR+PteOA.DB0
+Variant=vmsa
+{
+ [x]=1; [y]=2;
+ [PTE(x)]=(oa:PA(x),db:0);
+ 0:X4=(oa:PA(y),db:0); 0:X5=PTE(x); 
+ 1:X1=x;
+}
+ P0          | P1          ;
+ STR X4,[X5] | LDR W0,[X1] ;
+             | LDR W2,[X1] ;
+exists(1:X0=2 /\ 1:X2=1)

--- a/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB0.litmus.expected
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB0.litmus.expected
@@ -1,0 +1,14 @@
+Test CoRR+PteOA.DB0 Allowed
+States 4
+1:X0=1; 1:X2=1;
+1:X0=1; 1:X2=2;
+1:X0=2; 1:X2=1;
+1:X0=2; 1:X2=2;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Flag Warning-BBM-expected
+Condition exists (1:X0=2 /\ 1:X2=1)
+Observation CoRR+PteOA.DB0 Sometimes 1 3
+Hash=6be305e913d02515c5f0e3e4bc81ef26
+

--- a/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB0.val.litmus
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB0.val.litmus
@@ -1,0 +1,12 @@
+AArch64 CoRR+PteOA.DB0.val
+Variant=vmsa
+{
+ [x]=1; [y]=1;
+ [PTE(x)]=(oa:PA(x),db:0);
+ 0:X4=(oa:PA(y),db:0); 0:X5=PTE(x); 
+ 1:X1=x;
+}
+ P0          | P1          ;
+ STR X4,[X5] | LDR W0,[X1] ;
+             | LDR W2,[X1] ;
+exists(1:X0=1 /\ 1:X2=1)

--- a/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB0.val.litmus.expected
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB0.val.litmus.expected
@@ -1,0 +1,10 @@
+Test CoRR+PteOA.DB0.val Allowed
+States 1
+1:X0=1; 1:X2=1;
+Ok
+Witnesses
+Positive: 4 Negative: 0
+Condition exists (1:X0=1 /\ 1:X2=1)
+Observation CoRR+PteOA.DB0.val Always 4 0
+Hash=d8ae603b3f40d6e0ef5e808c22452434
+

--- a/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB1.val.litmus
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB1.val.litmus
@@ -1,0 +1,12 @@
+AArch64 CoRR+PteOA.DB1.val
+Variant=vmsa
+{
+ [x]=1; [y]=1;
+ [PTE(x)]=(oa:PA(x),db:0);
+ 0:X4=(oa:PA(y),db:1); 0:X5=PTE(x); 
+ 1:X1=x;
+}
+ P0          | P1          ;
+ STR X4,[X5] | LDR W0,[X1] ;
+             | LDR W2,[X1] ;
+exists(1:X0=1 /\ 1:X2=1)

--- a/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB1.val.litmus.expected
+++ b/catalogue/aarch64-BBM/tests/CoRR+PteOA.DB1.val.litmus.expected
@@ -1,0 +1,11 @@
+Test CoRR+PteOA.DB1.val Allowed
+States 1
+1:X0=1; 1:X2=1;
+Ok
+Witnesses
+Positive: 4 Negative: 0
+Flag Warning-BBM-expected
+Condition exists (1:X0=1 /\ 1:X2=1)
+Observation CoRR+PteOA.DB1.val Always 4 0
+Hash=dedcc3a3f218bd04eeae79c75470693e
+

--- a/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishsRpteaf0pte-amo.casptepteoa.af1+pos.litmus
+++ b/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishsRpteaf0pte-amo.casptepteoa.af1+pos.litmus
@@ -1,0 +1,18 @@
+AArch64 MP+tlbi-sync.ishsRpteaf0pte-posptepteoa.af1+pos
+Variant=vmsa
+TTHM=P1:HA
+{
+ [x]=1;
+ [y]=2;
+ 0:X0=PTE(x); 0:X1=(oa:PA(x), af:0); 0:X3=(oa:PA(y));
+ 0:X4=x; 1:X4=x;
+}
+ P0              | P1               ;
+ STR X1,[X0]     | L01: LDR W2,[X4] ;
+ DSB ISH         | L00: LDR W5,[X4] ;
+ LSR X5,X4,#12   |                  ;
+ TLBI VAAE1IS,X5 |                  ;
+ DSB ISH         |                  ;
+ CAS X1,X3,[X0]  |                  ;
+
+exists (1:X2=2 /\ 1:X5=1)

--- a/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishsRpteaf0pte-amo.casptepteoa.af1+pos.litmus.expected
+++ b/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishsRpteaf0pte-amo.casptepteoa.af1+pos.litmus.expected
@@ -1,0 +1,12 @@
+Test MP+tlbi-sync.ishsRpteaf0pte-posptepteoa.af1+pos Allowed
+States 3
+1:X2=1; 1:X5=1;
+1:X2=1; 1:X5=2;
+1:X2=2; 1:X5=2;
+No
+Witnesses
+Positive: 0 Negative: 70
+Condition exists (1:X2=2 /\ 1:X5=1)
+Observation MP+tlbi-sync.ishsRpteaf0pte-posptepteoa.af1+pos Never 0 70
+Hash=792a21eec3abc30030523ccc94e513e4
+

--- a/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishspteaf0pteoa.af1+pos.litmus
+++ b/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishspteaf0pteoa.af1+pos.litmus
@@ -1,0 +1,17 @@
+AArch64 MP+tlbi-sync.ishspteaf0pteoa.af1+pos
+Variant=vmsa
+{
+ [x]=1;
+ [y]=2;
+ 0:X0=PTE(x); 0:X1=(oa:PA(x), af:0); 0:X2=(oa:PA(y)); 0:X3=x;
+ 1:X3=x;
+}
+ P0              | P1               ;
+ STR X1,[X0]     | L01: LDR W4,[X3] ;
+ DSB ISH         | L00: LDR W5,[X3] ;
+ LSR X4,X3,#12   |                  ;
+ TLBI VAAE1IS,X4 |                  ;
+ DSB ISH         |                  ;
+ STR X2,[X0]     |                  ;
+
+exists (1:X4=2 /\ 1:X5=1)

--- a/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishspteaf0pteoa.af1+pos.litmus.expected
+++ b/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishspteaf0pteoa.af1+pos.litmus.expected
@@ -1,0 +1,15 @@
+Test MP+tlbi-sync.ishspteaf0pteoa.af1+pos Allowed
+States 6
+1:X4=0; 1:X5=0;
+1:X4=1; 1:X5=0;
+1:X4=1; 1:X5=1;
+1:X4=1; 1:X5=2;
+1:X4=2; 1:X5=0;
+1:X4=2; 1:X5=2;
+No
+Witnesses
+Positive: 0 Negative: 9
+Condition exists (1:X4=2 /\ 1:X5=1)
+Observation MP+tlbi-sync.ishspteaf0pteoa.af1+pos Never 0 9
+Hash=e6ef300b6f55d2300ac976c99b0e5c3e
+

--- a/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishsptev0pteoa.v1+pos.litmus
+++ b/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishsptev0pteoa.v1+pos.litmus
@@ -1,0 +1,17 @@
+AArch64 MP+tlbi-sync.ishsptev0pteoa.v1+pos
+Variant=vmsa
+{
+ [x]=1;
+ [y]=2;
+ 0:X0=PTE(x); 0:X1=(oa:PA(x), valid:0); 0:X2=(oa:PA(y)); 0:X3=x;
+ 1:X3=x;
+}
+ P0              | P1               ;
+ STR X1,[X0]     | L01: LDR W4,[X3] ;
+ DSB ISH         | L00: LDR W5,[X3] ;
+ LSR X4,X3,#12   |                  ;
+ TLBI VAAE1IS,X4 |                  ;
+ DSB ISH         |                  ;
+ STR X2,[X0]     |                  ;
+
+exists (1:X4=2 /\ 1:X5=1)

--- a/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishsptev0pteoa.v1+pos.litmus.expected
+++ b/catalogue/aarch64-BBM/tests/MP+tlbi-sync.ishsptev0pteoa.v1+pos.litmus.expected
@@ -1,0 +1,15 @@
+Test MP+tlbi-sync.ishsptev0pteoa.v1+pos Allowed
+States 6
+1:X4=0; 1:X5=0;
+1:X4=1; 1:X5=0;
+1:X4=1; 1:X5=1;
+1:X4=1; 1:X5=2;
+1:X4=2; 1:X5=0;
+1:X4=2; 1:X5=2;
+No
+Witnesses
+Positive: 0 Negative: 9
+Condition exists (1:X4=2 /\ 1:X5=1)
+Observation MP+tlbi-sync.ishsptev0pteoa.v1+pos Never 0 9
+Hash=3334f24571de5375d4587a1f8961673f
+

--- a/herd-www/Makefile
+++ b/herd-www/Makefile
@@ -1,7 +1,7 @@
 CAT2HTML7=$(if $(shell which cat2html7), cat2html7, ../_build/default/tools/cat2html.exe)
 AARCH64_BOOKS=aarch64 aarch64-ifetch aarch64-mixed aarch64-MTE \
 							aarch64-MTE-mixed aarch64-VMSA aarch64-ETS2 aarch64-ETS3 \
-							aarch64-faults aarch64-readers-guide
+							aarch64-BBM aarch64-faults aarch64-readers-guide
 BOOKS= $(AARCH64_BOOKS) bpf x86 linux
 WWW_CATALOGUE=www/catalogue
 HERD_CATALOGUE=../catalogue

--- a/herd-www/www/index.html
+++ b/herd-www/www/index.html
@@ -84,6 +84,7 @@
                    <li><a href="#" onclick="readRecord('aarch64-MTE');">AArch64 MTE</a></li>
                    <li><a href="#" onclick="readRecord('aarch64-MTE-mixed');">AArch64 MTE mixed</a></li>
                    <li><a href="#" onclick="readRecord('aarch64-VMSA');">AArch64 VMSA</a></li>
+                   <li><a href="#" onclick="readRecord('aarch64-BBM');">AArch64 BBM</a></li>
                    <li><a href="#" onclick="readRecord('aarch64-ETS2');">AArch64 ETS2</a></li>
                    <li><a href="#" onclick="readRecord('aarch64-ETS3');">AArch64 ETS3</a></li>
                    <li><a href="#" onclick="readRecord('aarch64-faults');">AArch64 faults</a></li>

--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -167,8 +167,8 @@ irreflexive [Exp & Tag & W]; (po & same-loc); [Imp & Tag & R]; (ca & int) as coW
 empty (rmw & (fr; co)) \ (([Exp]; rmw; [Exp]) & (fri ; [Exp & W]; coi)) as atomic
 
 (*** Break Before Make ***)
-let BBM = ([TTDV]; ca; [TTDINV]; co; [TTDV])
-flag ~empty (TTD-update-needsBBM & ~BBM) as requires-BBM
+let BBM = [TLBCacheableTTD]; ca; [TLBUncacheableTTD]; ob; [TLBI]; ob & inv-scope; [TLBCacheableTTD]
+flag ~empty (TTD-update-needsBBM \ BBM) as Warning-BBM-expected
 
 (*** Additional synchronisation requirements for CMODX ***)
 let CMODX-conflicts = same-loc & (

--- a/herd/libdir/aarch64.cat
+++ b/herd/libdir/aarch64.cat
@@ -48,9 +48,6 @@ catdep (* This option says that the cat file computes dependencies *)
 
 include "aarch64hwreqs.cat"
 
-(*** Coherence-after ***)
-let ca = fr | co
-
 (*** TLBI-after, DC-after, IC-after ***)
 include "enumerations.cat"
 with TLBI-after from (all-TLBI-Imp_TTD_R-enums local-hw-reqs)

--- a/herd/libdir/aarch64bbm.cat
+++ b/herd/libdir/aarch64bbm.cat
@@ -46,43 +46,46 @@
  *)
 include "aarch64memattrs.cat"
 
-(* Can we move this to stdlib? *)
-(* Coherence-after *)
-let ca = fr | co
-
-let PTE-MT-update =
+let TTD-MT-update =
   [Normal]; ca; [Device]
   | [Device]; ca; [Normal]
 
-let PTE-SH-update =
+let TTD-SH-update =
   [NSH]; ca; [ISH | OSH]
   | [ISH]; ca; [OSH | NSH]
   | [OSH]; ca; [NSH | ISH]
 
-let PTE-ICH-update =
+let TTD-ICH-update =
   [iNC]; ca; [iWT | iWB]
   | [iWT]; ca; [iWB | iNC]
   | [iWB]; ca; [iNC | iWT]
 
-let PTE-OCH-update =
+let TTD-OCH-update =
   [oNC]; ca; [oWT | oWB]
   | [oWT]; ca; [oWB | oNC]
   | [oWB]; ca; [oNC | oWT]
 
-let PTE-DT-update =
+let TTD-DT-update =
   [Device-GRE]; ca; [Device-nGRE | Device-nGnRE | Device-nGnRnE]
   | [Device-nGRE]; ca; [Device-GRE | Device-nGnRE | Device-nGnRnE]
   | [Device-nGnRE]; ca; [Device-GRE | Device-nGRE | Device-nGnRnE]
   | [Device-nGnRnE]; ca; [Device-GRE | Device-nGRE | Device-nGnRE]
 
-let PTE-OA-update = ([PTE]; ca; [PTE & oa-changes(PTE, ca^-1)])
-let PTE-OA-update-writable = PTE-OA-update &
-        ([PTE]; ca; [PTE & at-least-one-writable(PTE, ca^-1)])
+let TTD-OA-update = [TTD & M]; ca \ same-oa((TTD & M) * (TTD & M)); [TTD & W]
+let TTD-at-least-one-writable = at-least-one-writable((TTD & M) * (TTD & M))
+let TTD-memory-contents-mismatch = 
+  ([TTD & M]; PTEtoPA; different-values(W * W); PTEtoPA^-1; [TTD & M]) & loc
 
-let PTE-update-needsBBM = ([PTEV]; ca \ (ca; [PTEV]; ca); [PTEV]) &
-  (PTE-MT-update | PTE-SH-update | PTE-ICH-update | PTE-OCH-update | PTE-DT-update
-  | PTE-OA-update)
+let TLBUncacheableTTD = TTDINV | TTDAF0
+let TLBCacheableTTD = TTD & M \ TLBUncacheableTTD
 
-let TTDV = PTEV
-let TTDINV = PTEINV
-let TTD-update-needsBBM = PTE-update-needsBBM
+let TTD-update-BBM-cand =
+  TTD-MT-update
+  | TTD-SH-update
+  | TTD-ICH-update
+  | TTD-OCH-update
+  | TTD-DT-update
+  | TTD-OA-update & (TTD-at-least-one-writable | TTD-memory-contents-mismatch)
+
+let TTD-update-needsBBM =
+  [TLBCacheableTTD]; TTD-update-BBM-cand; [TLBCacheableTTD]

--- a/herd/libdir/aarch64fences.cat
+++ b/herd/libdir/aarch64fences.cat
@@ -45,5 +45,5 @@ let dsb.full = DSB.NSH | DSB.ISH | DSB.OSH | DSB.SY
 let dsb.ld = DSB.NSHLD | DSB.ISHLD | DSB.OSHLD | DSB.LD
 flag ~empty (DSB.NSHLD | DSB.ISHLD | DSB.OSHLD) as Maintenance-scope-for-DSB-LD-is-deprecated
 let dsb.st = DSB.NSHST | DSB.ISHST | DSB.OSHST | DSB.ST
-flag ~empty (DSB.NSHST | DSB.ISHST | DSB.OSHST) as Maintnenace-scope-for-DSB-ST-is-deprecated
+flag ~empty (DSB.NSHST | DSB.ISHST | DSB.OSHST) as Maintenance-scope-for-DSB-ST-is-deprecated
 

--- a/herd/libdir/aarch64memattrs.cat
+++ b/herd/libdir/aarch64memattrs.cat
@@ -41,8 +41,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *)
 
-let TTD = PTE
-
 (*** Device Memory ***)
 
 (* Device Memory Types *)

--- a/herd/libdir/aarch64util.cat
+++ b/herd/libdir/aarch64util.cat
@@ -55,12 +55,13 @@ let ii_data = [DATA]; (iico_data|iico_ctrl)+
  * -variant vmsa
 *)
 
-let PTE = if "vmsa" then PTE else emptyset
-let PTEV = if "vmsa" then PTEV else emptyset
-let PTEINV = if "vmsa" then PTEINV else emptyset
+let TTD = if "vmsa" then PTE else emptyset
+let TTDV = if "vmsa" then PTEV else emptyset
+let TTDINV = if "vmsa" then PTEINV else emptyset
+let TTDAF0 = if "vmsa" then PTEAF0 else emptyset
 let inv-domain = if "vmsa" then inv-domain else 0
-let D-PTE = if "vmsa" then D-PTE else emptyset
-let I-PTE = if "vmsa" && "ifetch" then PTE \ D-PTE else emptyset
+let D-TTD = if "vmsa" then D-PTE else emptyset
+let I-TTD = if "vmsa" && "ifetch" then PTE \ D-PTE else emptyset
 let AF = if "vmsa" then AF else emptyset
 let DB = if "vmsa" then DB else emptyset
 let MMU = if "vmsa" then MMU else emptyset
@@ -97,7 +98,6 @@ let IC = IC.IALLUIS | IC.IALLU | IC.IVAU
 let Imp = NExp
 let SPONTANEOUS = SPURIOUS
 let inv-scope = inv-domain
-let TTD = PTE
 let D-TTD = if "vmsa" then D-PTE else emptyset
 let I-TTD = if "vmsa" then I-PTE else emptyset
 let Tag = T

--- a/herd/libdir/catdefinitions.tex
+++ b/herd/libdir/catdefinitions.tex
@@ -98,6 +98,34 @@
 %
 %
 
+\newcommand{\TTDM}[1]{#1 is a TTD Memory Effect}
+\newcommand{\TTDR}[1]{#1 is a TTD Memory Read Effect}
+\newcommand{\TTDW}[1]{#1 is a TTD Memory Write Effect}
+\newcommand{\TTDAF}[1]{#1 is a TTD Memory Effect with the Access flag set to 0}
+\newcommand{\TTDINV}[1]{#1 is a TTD Memory Effect with the valid bit set to 0}
+\newcommand{\TTDupdateneedsBBM}[2]{The TTD update from #1 to #2 needs BBM}
+\newcommand{\TTDupdateneedsBBMemph}[2]{\TTDupdateneedsBBM{#1}{#2}}
+\newcommand{\TTDupdateBBMcand}[2]{The TTD update from #1 to #2 might need BBM}
+\newcommand{\TTDupdateBBMcandemph}[2]{\TTDupdateBBMcand{#1}{#2}}
+\newcommand{\TTDmemorycontentsmismatch}[2]{The memory contents at the OA of #1\
+do not match the memory contents at the OA of #2}
+\newcommand{\TTDmemorycontentsmismatchemph}[2]{\TTDmemorycontentsmismatch{#1}{#2}}
+\newcommand{\PTEtoPA}[2]{#2 is to a Location that maps into the OA of #1}
+\newcommand{\TLBCacheableTTD}[1]{The value of #1 is TLB Cacheable}
+\newcommand{\TLBUncacheableTTD}[1]{The value of #1 is TLB Uncacheable}
+\newcommand{\TTDV}[1]{The value of #1 is a valid TTD}
+\newcommand{\TTDMTupdate}[2]{#2 changes the memory type specified in #1}
+\newcommand{\TTDDTupdate}[2]{#2 changes the Device memory type specified in #1}
+\newcommand{\TTDSHupdate}[2]{#2 changes the Shareability specified in #1}
+\newcommand{\TTDICHupdate}[2]{#2 changes the inner Cacheability specified in #1}
+\newcommand{\TTDOCHupdate}[2]{#2 changes the outer Cacheability specified in #1}
+\newcommand{\TTDOAupdate}[2]{#2 changes the OA specified in #1}
+\newcommand{\TTDOAupdateemph}[2]{\TTDOAupdate{#1}{#2}}
+\newcommand{\TTDatleastonewritable}[2]{\atleastonewritable{#1}{#2}}
+\newcommand{\TTDatleastonewritableemph}[2]{\TTDatleastonewritable{#1}{#2}}
+\newcommand{\BBMemph}[2]{There is a \emph{Break-before-make sequence} between #1 and #2}
+\newcommand{\BBM}[2]{There is a Break-before-make sequence between #1 and #2}
+
 \newcommand{\Exp}[1]{#1 is an Explicit Effect}
 \newcommand{\ExpMREof}[1]{the Explicit \MRE{} of #1}
 \newcommand{\ImpMREof}[1]{the Implicit \MRE{} of #1}

--- a/herd/libdir/catdefinitions.tex
+++ b/herd/libdir/catdefinitions.tex
@@ -275,6 +275,8 @@ do not match the memory contents at the OA of #2}
 \newcommand{\introbemph}[2]{#1 is \emph{\introbname{}} #2}
 
 \newcommand{\sameoa}[2]{#1 and #2 have the Same Output Address}
+\newcommand{\atleastonewritable}[2]{Either #1 or #2 grant write permission}
+\newcommand{\differentvalues}[2]{#1 and #2 have different values}
 \newcommand{\sameloworderbits}[2]{#1 and #2 have the Same Low-order Bits}
 \newcommand{\sametranslationcontext}[2]{#1 and #2 are generated in the same translation context}
 

--- a/herd/libdir/cos.cat
+++ b/herd/libdir/cos.cat
@@ -5,3 +5,6 @@ if "cos-opt"
 else
   include "cos-no-opt.cat"
 end
+
+(*** Coherence-after ***)
+let ca = fr | co

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -648,7 +648,30 @@ end = struct
           | Some s1,Some s2 -> A.V.Cst.PteVal.same_oa s1 s2
           | _,_ -> false) in
 
-      [("inv-domain",inv_domain_act); ("alias",alias_act);]
+      let pte_to_pa_act =
+        let ptevals act =
+          let get_pteval =
+            let open Constant in
+            function
+            | Some (A.V.Val (PteVal v)) -> Some v
+            | Some _ | None -> None in
+          List.filter_map get_pteval [read_of act; written_of act] in
+        let is_physical_location pteval act =
+          match A.V.Cst.PteVal.as_physical pteval, location_of act with
+          | Some s, Some loc ->
+              begin match A.symbol loc with
+              | Some (Constant.Physical (s', _)) -> String.equal s s'
+              | _ -> false
+              end
+          | None, _ | _, None -> false in
+        fun act1 act2 ->
+          is_pt act1 && is_mem act2 &&
+          List.exists (fun pteval -> is_physical_location pteval act2)
+            (ptevals act1) in
+
+      [("inv-domain",inv_domain_act);
+       ("alias",alias_act);
+       ("PTEtoPA",pte_to_pa_act);]
     else []
 
   let arch_dirty =

--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -156,24 +156,17 @@ module Make
             S.A.V.Cst.PteVal.same_oa p1 p2
         | _ -> false
 
-      let writable2 =
-        let writable ha hd e = match S.E.value_of e with
+      let writable2 e1 e2 =
+        let writable e =
+          let open DirtyBit in
+          let ha, hd = match O.dirty with
+          | Some d -> d.some_ha, d.some_hd
+          | _ -> false, false in
+          match S.E.value_of e with
           | Some (S.A.V.Val (Constant.PteVal p)) ->
-              S.A.V.Cst.PteVal.writable ha hd p
+            S.A.V.Cst.PteVal.writable ha hd p
           | _ -> false in
-        fun e1 e2 ->
-        let p = S.E.proc_of e1 in
-        match p with
-        | None ->
-           Warn.user_error
-             "Init or spurious write as first argument of writable2"
-        | Some p ->
-            let ha,hd =
-              let open DirtyBit in
-              match O.dirty with
-              | Some d -> d.ha p,d.hd p
-              | None -> false,false in
-            writable ha hd e1 || writable ha hd e2
+        writable e1 || writable e2
 
     end
 

--- a/herd/tests/instructions/AArch64.kvm/A018.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A018.litmus.expected
@@ -4,7 +4,7 @@ States 1
 Loop Ok
 Witnesses
 Positive: 1 Negative: 0
-Flag Maintnenace-scope-for-DSB-ST-is-deprecated
+Flag Maintenance-scope-for-DSB-ST-is-deprecated
 Condition forall (0:X0=1)
 Observation A018 Always 1 0
 Hash=218f088f0c448c84eeeb7c12fcb86c43

--- a/herd/tests/instructions/AArch64.kvm/A031.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A031.litmus.expected
@@ -6,7 +6,7 @@ States 3
 Ok
 Witnesses
 Positive: 8 Negative: 0
-Flag requires-BBM
+Flag Warning-BBM-expected
 Condition ~exists ([PTE(z)]=(oa:PA(x), af:0) /\ 1:X5=2)
 Observation A031 Never 0 8
 Hash=b49f887241d4043b0d917f97925e00ab

--- a/herd/tests/instructions/AArch64.kvm/A032.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A032.litmus.expected
@@ -7,6 +7,7 @@ States 4
 Ok
 Witnesses
 Positive: 1 Negative: 5
+Flag Warning-BBM-expected
 Condition exists (0:X3=(oa:PA(x)) /\ [PTE(x)]=(oa:PA(y)))
 Observation A032 Sometimes 1 5
 Hash=4d4ebbbbd741d64b8bb4bcece91ef26d

--- a/herd/tests/instructions/AArch64.kvm/A036.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A036.litmus.expected
@@ -6,6 +6,7 @@ Ok
 Witnesses
 Positive: 8 Negative: 0
 Flag Shareability-argument-for-DMB-is-deprecated
+Flag Warning-BBM-expected
 Condition exists (0:X0=2 /\ 0:X1=1)
 Observation A036 Always 8 0
 Hash=cfe50b9b0465b36af5f17bad83823a0b

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -1179,26 +1179,9 @@ module Make
       let r = prim_as_rel ks arg in
       V.Rel (E.EventRel.restrict_rel U.same_oa r)
 
-    and check_two pred ks arg = match arg with
-      | V.Tuple [vset; vrel; ] ->
-          let ws = prim_as_set ks vset
-          and m = prim_as_rel ks vrel in
-          let ws =
-            E.EventSet.filter
-              (fun w ->
-                 E.is_store w && E.is_pt w &&
-                 begin
-                   match E.EventSet.as_singleton (E.EventRel.succs m w) with
-                   | Some p -> pred w p
-  (* w does not qualify when zero of two or more prec-related events *)
-                   | None -> false
-                 end)
-              ws in
-          V.Set ws
-      | _ -> arg_mismatch ()
-
-    let oa_changes = check_two (fun w p -> not (U.same_oa w p))
-    and at_least_one_writable = check_two U.writable2
+    and at_least_one_writable ks arg =
+      let r = prim_as_rel ks arg in
+      V.Rel (E.EventRel.restrict_rel U.writable2 r)
 
     let as_transitive =
       function
@@ -1210,7 +1193,6 @@ module Make
       add_prims m
         [
           "at-least-one-writable",at_least_one_writable ks;
-          "oa-changes",oa_changes ks;
           "same-oa",same_oaRel ks;
           "different-values",different_values ks;
           "fromto",fromto ks;

--- a/tools/miaou.ml
+++ b/tools/miaou.ml
@@ -237,6 +237,10 @@ and cons_seqs (fs:exp list) (es:exp list) =
     (************************************************)
 
 
+    let is_primitive_relation = function
+      | "same-oa" | "at-least-one-writable" | "different-values" -> true
+      | _ -> false
+
     let rec get_type = function
       | Konst (_,(Empty ty|Universe ty)) -> Some ty
       | Op (_,(Seq|Cartesian),_)
@@ -246,6 +250,8 @@ and cons_seqs (fs:exp list) (es:exp list) =
          get_type2 e1 e2
       | Op (_,(Union|Inter|Diff),es) ->
          get_types es
+      | App (_,Var (_,id),_) when is_primitive_relation id ->
+         Some RLN
       | Var (_,id) ->
          get_id_type id
       | _ -> None
@@ -415,6 +421,8 @@ and cons_seqs (fs:exp list) (es:exp list) =
          tr_rel e1 e2 (opt_expr loc e)
       | Op1 (loc,Star,e) ->
          tr_rel e1 e2 (star_expr loc e)
+      | App (_,Var (locf,id),arg) when is_primitive_relation id ->
+         tr_primitive_rel e1 e2 locf id arg
       | App (_, Var (_locf,"intervening"),
              Op (_loc,Tuple,[evts; Op (_,op,es)])) ->
          let e3 = Next.next () in
@@ -429,6 +437,14 @@ and cons_seqs (fs:exp list) (es:exp list) =
       | e -> tr_fail (ASTUtils.exp2loc e)
 
     and tr_evts_from_rel e1 e2 = tr_evts e1 @@ flatten_if_not e2
+
+    and tr_primitive_rel e1 e2 locf id arg =
+      let rel = tr_rel_id e1 e2 locf id in
+      match flatten_if_not arg with
+      | Op (_,Cartesian,[a;b]) ->
+         mk_list Inter [tr_evts_from_rel e1 a; rel; tr_evts_from_rel e2 b;]
+      | arg ->
+         mk_list Inter [tr_rel e1 e2 arg; rel;]
 
     and tr_rel_not e1 e2 = function
       | Op1 (_,ToId,e) -> tr_evts_not e1 @@ flatten_if_not e


### PR DESCRIPTION
  ## Summary

  This branch refines the AArch64 Break-Before-Make (BBM) modelling in `herd`, fixes related helper logic used by the model checker/interpreter, and adds a dedicated regression catalogue for BBM-oriented tests.

  Compared to `github/master`, the branch includes 7 commits covering:
  - BBM rule updates in the AArch64 cat files
  - a fix for `writable2` in `machModelChecker`
  - support for `PTEtoPA` in `machAction`
  - documentation/macros for the new BBM relations
  - a new `catalogue/aarch64-BBM` regression suite
  - a typo fix in `aarch64fences.cat`

  ## Main changes

  - Move the definition of `ca` out of `aarch64.cat` into `cos.cat` so it can be reused by the BBM-specific logic.
  - Rework BBM detection in `aarch64.cat` / `aarch64bbm.cat` around TTD/TLB-cacheability concepts rather than the older `PTE*` naming, including:
    - `TLBCacheableTTD` / `TLBUncacheableTTD`
    - `TTD-update-needsBBM`
    - updated BBM sequencing check and warning flag
  - Fix `writable2` in `herd/machModelChecker.ml` so writability is evaluated per event using the correct dirty-bit context.
  - Simplify the interpreter helpers by introducing shared relation filtering logic, and use it to implement `same_oa`, `oa_changes`, and `at_least_one_writable`.
  - Extend `tools/miaou.ml` to handle the `domain` procedure.
  - Add TeX macros documenting the new BBM/TTD relations in `catdefinitions.tex`.
  - Add a new `catalogue/aarch64-BBM/tests` suite with expected outputs and a `cata-test-all` target for running it.
  - Update the affected AArch64 KVM expected output to match the revised BBM behaviour.
  - Fix the typo in the deprecated DSB-ST maintenance-scope warning.

  ## Testing

  - `make test.herd.cata-ext.aarch64-BBM`
