### PR TITLE
[herd] Measure some timings

### DIFF
--- a/herd-www/jerd.ml
+++ b/herd-www/jerd.ml
@@ -217,6 +217,7 @@ let run_herd bell cat litmus cfg cat_label =
     let check_filter = !check_filter
     let debug = !debug
     let debuglexer = debug.Debug_herd.lexer
+    module Timer = Timer.No
     let verbose = !verbose
     let hexa = !PP.hexa
     let unroll = !unroll

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -1663,10 +1663,12 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
           profile "build AArch64 semantics from ASL" @@ fun () ->
           let test_asl, eqs_test = fake_test ii fname args in
           let model = build_model_from_file "asl.cat" in
+          TopConf.C.Timer.start Timer.sem_key ;
           let { MC.event_structures = rfms; _ }, test_asl =
             profile "run ASL Semantics" @@ fun () ->
             MC.glommed_event_structures ~is_pgm:false test_asl
           in
+          TopConf.C.Timer.stop Timer.sem_key ;
           let () =
             if _dbg then
               Printf.eprintf "Got rfms back: %d of them.\n%!" (List.length rfms)
@@ -1693,7 +1695,10 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
               let () = end_profile t0 "ASL cat, success" in
               Translator.tr_execution ii eqs_test c :: acc
             in
-            check_event_structure model test_asl conc kfail ksuccess acc
+            TopConf.C.Timer.start Timer.model_key ;
+            let c = check_event_structure model test_asl conc kfail ksuccess acc in
+            TopConf.C.Timer.stop Timer.model_key ;
+            c
           in
           let check_and_translate acc c =
             profile "check and translate" @@ fun () ->

--- a/herd/cli.ml
+++ b/herd/cli.ml
@@ -161,7 +161,7 @@ end) = struct
           | Some msg ->
               Warn.warn_always
                 "%a: unrolling limit exceeded at %s, legal outcomes may be missing."
-                Pos.pp_pos0   test.Test_herd.name.Name.file
+                Pos.pp_pos0 test.Test_herd.name.Name.file
                 msg
           | None -> ()
         end

--- a/herd/debug_herd.ml
+++ b/herd/debug_herd.ml
@@ -36,6 +36,7 @@ type t = {
     asl_stack: bool ;
     profile_mem: bool ;
     exc : bool ;
+    timers : bool ;
   }
 
 let tags =
@@ -59,6 +60,7 @@ let tags =
   "asl_stack";
   "profile_mem";
   "exception";
+  "timers";
 ]
 
 let none =
@@ -82,6 +84,7 @@ let none =
    asl_stack = false;
    profile_mem = false;
    exc = false ;
+   timers = false ;
  }
 
 let parse t tag = match tag with
@@ -105,4 +108,5 @@ let parse t tag = match tag with
   | "asl_symb" -> Some { t with asl_symb = true }
   | "asl_stack" -> Some { t with asl_stack = true }
   | "profile_mem" -> Some { t with profile_mem = true }
+  | "timers" -> Some { t with timers = true ; }
   | _ -> None

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -386,7 +386,6 @@ let setup_options = Arg.align ~limit:40 ([
     | Some t -> debug := t ; true)
     Debug_herd.tags
     "Show debug messages for specific parts" ;
-
   (* Input *)
   ("\nInput options:", Arg.Unit Fun.id, "\n");
 
@@ -597,6 +596,9 @@ let conds = LR.read_from_files !conds (fun s -> Some s)
 
 (* Configure parser/models/etc. *)
 let () =
+  let timer =
+    if !debug.Debug_herd.timers then (module Timer.Ok:Timer.S)
+    else (module Timer.No:Timer.S) in
   let module Config = struct
     let timeout = !timeout
     let candidates = !candidates
@@ -633,6 +635,7 @@ let () =
     let check_filter = !check_filter
     let debug = !debug
     let debuglexer = debug.Debug_herd.lexer
+    module Timer = (val timer : Timer.S)
     let verbose = !verbose
     let hexa = !PP.hexa
     let unroll = !unroll

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -29,6 +29,7 @@ module type CommonConfig = sig
   val unroll : int option
   val speedcheck : Speed.t
   val debug : Debug_herd.t
+  module Timer : Timer.S
   val observed_finals_only : bool
   val initwrites : bool
   val check_filter : bool

--- a/herd/runTest.ml
+++ b/herd/runTest.ml
@@ -65,7 +65,7 @@ module Make
 
     let run dirty ~filename ~contents env splitted =
       try
-         let parsed = P.parse_string contents splitted in
+        let parsed = P.parse_string contents splitted in
         let name = splitted.Splitter.name in
         let hash = MiscParser.get_hash parsed in
         let env = match hash, filename with

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -102,6 +102,7 @@ end
 
 module type PrinterConfig = sig
   module PC : PrettyConf.S
+  module Timer : Timer.S
   val candidates : bool
   val verbose : int
   val show : PrettyConf.show
@@ -221,6 +222,7 @@ module Printer (O : PrinterConfig) (S : SemExtra.S) = struct
         if Misc.string_eq k "Hash" then
           fprintf fmt "%s=%s\n" k v)
       test.Test_herd.info ;
+    O.Timer.pp fmt
 
   module PP = Pretty.Make (S)
 
@@ -245,6 +247,19 @@ module Make(O:Config)(M:XXXMem.S) =
     module W = Warn.Make(O)
 
     let showcutoff = O.variant Variant.CutOff
+
+(* Create timers *)
+    let sem_key = Timer.sem_key
+    and model_key = Timer.model_key
+    and run_key = Timer.run_key
+
+    module Timer = O.Timer
+
+    let () =
+      Timer.create sem_key ;
+      Timer.create model_key ;
+      Timer.create run_key ;
+      ()
 
 (* Utilities *)
     open Restrict
@@ -460,8 +475,11 @@ module Make(O:Config)(M:XXXMem.S) =
 
     (* Driver *)
     let run test =
+      Timer.start run_key ;
+      Timer.start sem_key ;
       let { MC.event_structures=rfms; MC.overwritable_labels=owls; },test =
         MC.glommed_event_structures ~is_pgm:true test in
+      Timer.stop sem_key ;
 
       let restrict_faults =
         if !Opts.dumpallfaults then
@@ -490,6 +508,7 @@ module Make(O:Config)(M:XXXMem.S) =
         (* Thanks to the existence of check_test, XXMem modules
            apply their internal functors once *)
         let call_model conc ofail solver c =
+        Timer.start model_key ;
         let check_test = M.check_event_structure test in
         (* Checked pruned executions before even calling model *)
         let cutoff =  S.find_cutoff conc.S.str.S.E.events in
@@ -497,10 +516,12 @@ module Make(O:Config)(M:XXXMem.S) =
           if Misc.is_some cutoff then Count.{ c with cutoff = cutoff }
           else c in
         (* Discard pruned executions if not explicitely required *)
-        check_test
-          conc kfail
-          (check_failed_model_kont cutoff
-             ofail solver emit_exec test final_state_restrict_locs) c in
+        let c =
+          check_test
+            conc kfail
+            (check_failed_model_kont cutoff
+               ofail solver emit_exec test final_state_restrict_locs) c in
+        Timer.stop model_key ; c in
       let c =
         if O.statelessrc11
         then let module SL = Slrc11.Make(struct include MC let skipchecks = O.skipchecks end) in
@@ -527,6 +548,7 @@ module Make(O:Config)(M:XXXMem.S) =
                 st,flts,solver in
           A.StateSet.map do_restrict c.states
         else c.states in
+        Timer.stop run_key ;
         {
           states = finals;
           TestResult.cfail = c.Count.cfail;

--- a/herd/top_herd.mli
+++ b/herd/top_herd.mli
@@ -120,6 +120,7 @@ end
 
 module type PrinterConfig = sig
   module PC : PrettyConf.S
+  module Timer : Timer.S
   val candidates : bool
   val verbose : int
   val show : PrettyConf.show

--- a/lib/timer.ml
+++ b/lib/timer.ml
@@ -1,0 +1,98 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2026-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+module type S = sig
+  val create : string -> unit
+  val start : string -> unit
+  val stop : string -> unit
+  val pp : Format.formatter -> unit
+end
+
+let sem_key = "semantics"
+and model_key = "model"
+and run_key = "run"
+
+module Ok = struct
+
+  let _dbg = false
+
+  type timer = { start:float; total:float; }
+
+  let zero = { start=0.0; total=0.0; }
+
+  let error = Warn.fatal "Non-existant timer: %s"
+
+  let table = Hashtbl.create 17
+  let seen_t = Hashtbl.create 17
+
+  let seen key = Hashtbl.mem seen_t key
+  let push key = Hashtbl.add seen_t key ()
+  let pop key = Hashtbl.remove seen_t key
+
+  let create key =
+    if not (Hashtbl.mem table key) then
+      Hashtbl.add table key zero
+
+  let start_timer key t =
+    if seen key then begin
+      if _dbg then Warn.warn_always "Recursive timer start: %s\n%!" key ;
+      push key ;
+      t
+    end else begin
+      push key ;
+      { t with start=Sys.time (); }
+    end
+
+  and stop_timer key t =
+    if seen key then begin
+      pop key ;
+      if seen key then t
+      else { t with total=Sys.time () -. t.start +. t.total; }
+    end else
+      Warn.fatal "Timer %s has not been started!\n" key
+  let map_timer key f =
+    try
+      let t = Hashtbl.find table key in
+      Hashtbl.replace table key (f key t)
+    with Not_found -> error key
+
+
+  let start key = map_timer key start_timer
+  and stop key = map_timer key stop_timer
+
+  open Format
+
+  let do_pp fmt key t = fprintf fmt "%s=%0.2f" key t.total
+
+  let pp fmt =
+    let fst = ref true in
+    fprintf fmt "Timers: " ;
+    Hashtbl.iter
+          (fun key t ->
+          if not !fst then fprintf fmt ", " ;
+          do_pp fmt key t ;
+          fst := false)
+          table ;
+    fprintf fmt "\n"
+end
+
+module No = struct
+  let nofun _ = ()
+  let create = nofun
+  let start = nofun
+  let stop = nofun
+  let pp = nofun
+end

--- a/lib/timer.mli
+++ b/lib/timer.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2013-present Institut National de Recherche en Informatique et *)
+(* Copyright 2026-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,31 +14,33 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Debug tags *)
+(** Timers for global profiling, timers are re-entrant. *)
 
-type t = {
-  solver : int ;
-  lexer : bool ;
-  top : bool ;
-  mem : bool ;
-  monad : bool ;
-  barrier : bool ;
-  res : bool ;
-  rfm : bool  ;
-  pretty : bool ;
-  mixed : bool ;
-  files : bool ;
-  timeout : bool ;
-  pac : bool ;
-  profile_cat: bool ;
-  profile_asl: bool ;
-  asl_symb: bool ;
-  asl_stack: bool ;
-  profile_mem: bool ;
-  exc : bool ;
-  timers : bool ;
-}
+module type S = sig
+  (** [create key] Create and register timer,
+      must be called at most once for a given key. *)
+  val create : string -> unit
 
-val none : t
-val tags : string list
-val parse : t -> string -> t option
+  (** [start key] Start the timer [key].
+      If the timer is already running,
+      do not restart timer.
+      Alqways push a [key] marker. *)
+  val start : string -> unit
+
+(** [stop key] Stop the timer [key].
+    Always pop a [key] marker, if no [key] marker are pending,
+    accumulate the time spent. *)
+  val stop : string -> unit
+
+  (** Print all timers *)
+  val pp : Format.formatter -> unit
+
+end
+
+val sem_key : string
+val model_key : string
+val run_key : string
+
+module Ok : S
+module No : S
+


### PR DESCRIPTION
A timer support is addded (cf. lib/timer.ml). The new feature is  used for timing:
  + Cat model execution and
  + code semantics, _i.e._ monad construction by the "Sem" modules.

Timers are activated by the command-line option `-debug timers`. For instance:
```
% herd7 catalogue/aarch64-VMSA/tests/Marc03.litmus -variant vmsa -speedcheck true -debug timers
Test Marc03 Forbidden
...
Timers: model=13.25, run=18.61, semantics=0.02
```

