### PR TITLE
[asl] maintain a type annotation for every typechecked expression

### DIFF
--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -33,13 +33,6 @@
 type version = V0 | V1
 type position = Lexing.position
 
-type 'a annotated = {
-  desc : 'a;
-  pos_start : position;
-  pos_end : position;
-  version : version;
-}
-
 type identifier = string
 (** Type of local identifiers in the AST. *)
 
@@ -146,8 +139,22 @@ type subprogram_type =
       (** A setter is a special procedure called with a syntax similar to slice
           assignment. *)
 
+type 'a annotated = {
+  desc : 'a;
+  pos_start : position;
+  pos_end : position;
+  version : version;
+  ty_opt : ty option;
+      (** An optional type annotation, added only to typed versions of [expr]
+          and [lexpr] types. This is added by the typechecker once the type is
+          inferred, and never used by the typechecker itself. In particular,
+          expressions synthesized by the typechecker are not associated with a
+          type annotation. The intended usage is for tools built on top of
+          aslref. *)
+}
+
 (** Expressions. Parametric on the type of literals. *)
-type expr_desc =
+and expr_desc =
   | E_Literal of literal
   | E_Var of identifier
   | E_ATC of expr * ty  (** Asserted type conversion *)

--- a/asllib/AST.mli
+++ b/asllib/AST.mli
@@ -50,6 +50,27 @@ type precision_loss_flag =
       (** A loss of precision comes with a list of warnings that can explain why
           the loss of precision happened. *)
 
+type ('a, 't) t_annotated = {
+  desc : 'a;
+  pos_start : position;
+  pos_end : position;
+  version : version;
+  ty_opt : 't option;
+      (** An optional type annotation, added only to typed versions of [expr]
+          and [lexpr] types. This is added by the typechecker once the type is
+          inferred, and never used by the typechecker itself. In particular,
+          expressions synthesized without a corresponding typing step, such as
+          during symbolic normalization, may have no type annotation. The
+          intended usage is for tools built on top of aslref. *)
+}
+
+(** An empty type to force the type annotation to [None]. *)
+type no_type_annotation = |
+
+type 'a annotated = ('a, no_type_annotation) t_annotated
+(** A ['a annotated] type is a type wrapped in position annotation but without a
+    type annotation. *)
+
 (* -------------------------------------------------------------------------
 
                                    Operations
@@ -139,22 +160,8 @@ type subprogram_type =
       (** A setter is a special procedure called with a syntax similar to slice
           assignment. *)
 
-type 'a annotated = {
-  desc : 'a;
-  pos_start : position;
-  pos_end : position;
-  version : version;
-  ty_opt : ty option;
-      (** An optional type annotation, added only to typed versions of [expr]
-          and [lexpr] types. This is added by the typechecker once the type is
-          inferred, and never used by the typechecker itself. In particular,
-          expressions synthesized by the typechecker are not associated with a
-          type annotation. The intended usage is for tools built on top of
-          aslref. *)
-}
-
 (** Expressions. Parametric on the type of literals. *)
-and expr_desc =
+type expr_desc =
   | E_Literal of literal
   | E_Var of identifier
   | E_ATC of expr * ty  (** Asserted type conversion *)
@@ -179,7 +186,7 @@ and expr_desc =
   | E_Arbitrary of ty
   | E_Pattern of expr * pattern_matcher
 
-and expr = expr_desc annotated
+and expr = (expr_desc, ty) t_annotated
 
 and pattern_desc =
   | Pattern_All
@@ -301,7 +308,7 @@ type lexpr_desc =
           Third argument is a type annotation. *)
   | LE_Destructuring of lexpr list
 
-and lexpr = lexpr_desc annotated
+and lexpr = (lexpr_desc, ty) t_annotated
 
 type local_decl_keyword = LDK_Var | LDK_Let
 

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -67,7 +67,7 @@ let default_version = V1
 let desc v = v.desc
 
 let annotated desc pos_start pos_end version =
-  { desc; pos_start; pos_end; version }
+  { desc; pos_start; pos_end; version; ty_opt = None }
 
 let add_dummy_annotation ?(version = default_version) desc =
   annotated desc dummy_pos dummy_pos version
@@ -88,8 +88,12 @@ let add_pos_range_from pos_from pos_to desc =
     pos_start = pos_from.pos_start;
     pos_end = pos_to.pos_end;
     version = pos_from.version;
+    ty_opt = None;
   }
 
+let expr_ty_annot_from ~src expr = { expr with ty_opt = src.ty_opt }
+let expr_with_ty_annot ty expr = { expr with ty_opt = Some ty }
+let lexpr_with_ty_annot ty lexpr = { lexpr with ty_opt = Some ty }
 let map_desc f thing = f thing |> add_pos_from thing
 let map_annotated thing f = f thing.desc |> add_pos_from thing
 
@@ -108,6 +112,7 @@ let add_pos_from_pos_of ((fname, lnum, cnum, enum), desc) =
     pos_start = { common with pos_cnum = cnum };
     pos_end = { common with pos_cnum = enum };
     version = default_version (* used only in testing *);
+    ty_opt = None;
   }
 
 let list_fold_lefti f accu l =
@@ -184,6 +189,8 @@ let map2_desc f thing1 thing2 =
     pos_start = thing1.pos_start;
     pos_end = thing2.pos_end;
     version = thing1.version;
+    ty_opt =
+      (match thing1.ty_opt with Some t1 -> Some t1 | None -> thing2.ty_opt);
   }
 
 let s_pass = add_dummy_annotation S_Pass
@@ -437,28 +444,33 @@ and pattern_matcher_equal eq (ps1, pk1) (ps2, pk2) =
   List.equal (pattern_equal eq) ps1 ps2 && pattern_kind_equal pk1 pk2
 
 let qualifier_equal (q1 : func_qualifier option) q2 = Option.equal ( = ) q1 q2
-let var_ x = E_Var x |> add_dummy_annotation
+let expr_of_var x = E_Var x |> add_dummy_annotation
 let binop op = map2_desc (fun e1 e2 -> E_Binop (op, e1, e2))
-let unop op = map_desc (fun e -> E_Unop (op, e))
+let neg e = E_Unop (NEG, e) |> add_pos_from e
 let literal v = E_Literal v |> add_dummy_annotation
 let expr_of_int i = literal (L_Int (Z.of_int i))
 let expr_of_z z = literal (L_Int z)
-let e_true = literal (L_Bool true)
-let e_false = literal (L_Bool false)
+let e_true = literal (L_Bool true) |> expr_with_ty_annot boolean
+let e_false = literal (L_Bool false) |> expr_with_ty_annot boolean
 let expr_of_bool b = if b then e_true else e_false
 let zero_expr = expr_of_z Z.zero
 let one_expr = expr_of_z Z.one
 let minus_one_expr = expr_of_z Z.minus_one
 
 let expr_of_rational q =
+  expr_with_ty_annot real
+  @@
   if Z.equal (Q.den q) Z.one then expr_of_z (Q.num q)
   else binop `DIV (expr_of_z (Q.num q)) (expr_of_z (Q.den q))
 
+(** [mul_expr e1 e2] symbolically multiplies the two expression [e1] and [e2].
+*)
 let mul_expr e1 e2 =
   if expr_equal (fun _ _ -> false) e1 one_expr then e2
   else if expr_equal (fun _ _ -> false) e2 one_expr then e1
   else binop `MUL e1 e2
 
+(** [pow_expr e p] symbolically raises the expression [e] to the power [p]. *)
 let pow_expr e = function
   | 0 -> one_expr
   | 1 -> e
@@ -529,12 +541,12 @@ let slice_as_single = function
   | Slice_Single e -> e
   | _ -> raise @@ Invalid_argument "slice_as_single"
 
-let default_t_bits = T_Bits (E_Var "-" |> add_dummy_annotation, [])
+let discard_expr = E_Var "-" |> add_dummy_annotation
+let default_t_bits = T_Bits (discard_expr, [])
 
 let default_array_ty =
-  let len = E_Var "-" |> add_dummy_annotation in
   let ty = T_Named "-" |> add_dummy_annotation in
-  T_Array (len, ty)
+  T_Array (discard_expr, ty)
 
 let identifier_of_decl d =
   match d.desc with

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -69,15 +69,15 @@ let desc v = v.desc
 let annotated desc pos_start pos_end version =
   { desc; pos_start; pos_end; version; ty_opt = None }
 
-let add_dummy_annotation ?(version = default_version) desc =
+let add_dummy_pos ?(version = default_version) desc =
   annotated desc dummy_pos dummy_pos version
 
-let dummy_annotated = add_dummy_annotation ()
+let dummy_annotated = add_dummy_pos ()
 let to_pos pos = { pos with desc = (); ty_opt = None }
-let is_dummy_annotated x = x.pos_end == dummy_pos || x.pos_start == dummy_pos
+let is_dummy_pos x = x.pos_end == dummy_pos || x.pos_start == dummy_pos
 
 let add_pos_from_st pos desc =
-  if pos.desc == desc then pos else { pos with desc }
+  if pos.desc == desc then pos else { pos with desc; ty_opt = None }
 
 let add_pos_from pos desc = { pos with desc; ty_opt = None }
 
@@ -98,7 +98,7 @@ let map_annotated thing f = f thing.desc |> add_pos_from thing
 
 let add_maybe_loc ?loc thing =
   match loc with
-  | None -> add_dummy_annotation thing
+  | None -> add_dummy_pos thing
   | Some loc -> add_pos_from loc thing
 
 let add_pos_from_pos_of ((fname, lnum, cnum, enum), desc) =
@@ -188,16 +188,16 @@ let map2_desc f v1 v2 =
     pos_start = v1.pos_start;
     pos_end = v2.pos_end;
     version = v1.version;
-    ty_opt = (match v1.ty_opt with Some t -> Some t | None -> v2.ty_opt);
+    ty_opt = None;
   }
 
-let s_pass = add_dummy_annotation S_Pass
+let s_pass = add_dummy_pos S_Pass
 let s_then = map2_desc (fun s1 s2 -> S_Seq (s1, s2))
-let boolean = T_Bool |> add_dummy_annotation
-let string = T_String |> add_dummy_annotation
-let real = T_Real |> add_dummy_annotation
+let boolean = T_Bool |> add_dummy_pos
+let string = T_String |> add_dummy_pos
+let real = T_Real |> add_dummy_pos
 let integer' = T_Int UnConstrained
-let integer = integer' |> add_dummy_annotation
+let integer = integer' |> add_dummy_pos
 
 let well_constrained' ?(precision = Precision_Full) cs =
   T_Int (WellConstrained (cs, precision))
@@ -442,10 +442,10 @@ and pattern_matcher_equal eq (ps1, pk1) (ps2, pk2) =
   List.equal (pattern_equal eq) ps1 ps2 && pattern_kind_equal pk1 pk2
 
 let qualifier_equal (q1 : func_qualifier option) q2 = Option.equal ( = ) q1 q2
-let expr_of_var x = E_Var x |> add_dummy_annotation
+let expr_of_var x = E_Var x |> add_dummy_pos
 let binop op = map2_desc (fun e1 e2 -> E_Binop (op, e1, e2))
 let neg e = E_Unop (NEG, e) |> add_pos_from e
-let literal v = E_Literal v |> add_dummy_annotation
+let literal v = E_Literal v |> add_dummy_pos
 let expr_of_int i = literal (L_Int (Z.of_int i))
 let expr_of_z z = literal (L_Int z)
 let e_true = literal (L_Bool true) |> with_ty_annot boolean
@@ -539,11 +539,11 @@ let slice_as_single = function
   | Slice_Single e -> e
   | _ -> raise @@ Invalid_argument "slice_as_single"
 
-let discard_expr = E_Var "-" |> add_dummy_annotation
+let discard_expr = E_Var "-" |> add_dummy_pos
 let default_t_bits = T_Bits (discard_expr, [])
 
 let default_array_ty =
-  let ty = T_Named "-" |> add_dummy_annotation in
+  let ty = T_Named "-" |> add_dummy_pos in
   T_Array (discard_expr, ty)
 
 let identifier_of_decl d =

--- a/asllib/ASTUtils.ml
+++ b/asllib/ASTUtils.ml
@@ -73,13 +73,13 @@ let add_dummy_annotation ?(version = default_version) desc =
   annotated desc dummy_pos dummy_pos version
 
 let dummy_annotated = add_dummy_annotation ()
-let to_pos pos = { pos with desc = () }
+let to_pos pos = { pos with desc = (); ty_opt = None }
 let is_dummy_annotated x = x.pos_end == dummy_pos || x.pos_start == dummy_pos
 
 let add_pos_from_st pos desc =
   if pos.desc == desc then pos else { pos with desc }
 
-let add_pos_from pos desc = { pos with desc }
+let add_pos_from pos desc = { pos with desc; ty_opt = None }
 
 let add_pos_range_from pos_from pos_to desc =
   let () = assert (pos_from.version = pos_to.version) in
@@ -92,8 +92,7 @@ let add_pos_range_from pos_from pos_to desc =
   }
 
 let expr_ty_annot_from ~src expr = { expr with ty_opt = src.ty_opt }
-let expr_with_ty_annot ty expr = { expr with ty_opt = Some ty }
-let lexpr_with_ty_annot ty lexpr = { lexpr with ty_opt = Some ty }
+let with_ty_annot ty node = { node with ty_opt = Some ty }
 let map_desc f thing = f thing |> add_pos_from thing
 let map_annotated thing f = f thing.desc |> add_pos_from thing
 
@@ -183,14 +182,13 @@ let pair x y = (x, y)
 let pair' y x = (x, y)
 let pair_equal f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 
-let map2_desc f thing1 thing2 =
+let map2_desc f v1 v2 =
   {
-    desc = f thing1 thing2;
-    pos_start = thing1.pos_start;
-    pos_end = thing2.pos_end;
-    version = thing1.version;
-    ty_opt =
-      (match thing1.ty_opt with Some t1 -> Some t1 | None -> thing2.ty_opt);
+    desc = f v1 v2;
+    pos_start = v1.pos_start;
+    pos_end = v2.pos_end;
+    version = v1.version;
+    ty_opt = (match v1.ty_opt with Some t -> Some t | None -> v2.ty_opt);
   }
 
 let s_pass = add_dummy_annotation S_Pass
@@ -450,15 +448,15 @@ let neg e = E_Unop (NEG, e) |> add_pos_from e
 let literal v = E_Literal v |> add_dummy_annotation
 let expr_of_int i = literal (L_Int (Z.of_int i))
 let expr_of_z z = literal (L_Int z)
-let e_true = literal (L_Bool true) |> expr_with_ty_annot boolean
-let e_false = literal (L_Bool false) |> expr_with_ty_annot boolean
+let e_true = literal (L_Bool true) |> with_ty_annot boolean
+let e_false = literal (L_Bool false) |> with_ty_annot boolean
 let expr_of_bool b = if b then e_true else e_false
 let zero_expr = expr_of_z Z.zero
 let one_expr = expr_of_z Z.one
 let minus_one_expr = expr_of_z Z.minus_one
 
 let expr_of_rational q =
-  expr_with_ty_annot real
+  with_ty_annot real
   @@
   if Z.equal (Q.den q) Z.one then expr_of_z (Q.num q)
   else binop `DIV (expr_of_z (Q.num q)) (expr_of_z (Q.den q))

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -56,59 +56,69 @@ val dummy_pos : Lexing.position
 val default_version : version
 (** The default version, [V1]. *)
 
-val annotated : 'a -> position -> position -> version -> 'a annotated
+val annotated : 'a -> position -> position -> version -> ('a, _) t_annotated
 (** [annotated v start end version] is [v] with location specified as from
     [start] to [end] and version specified by [version]. *)
 
-val desc : 'a annotated -> 'a
+val desc : ('a, _) t_annotated -> 'a
 (** [desc v] is [v.desc] *)
 
-val add_dummy_annotation : ?version:version -> 'a -> 'a annotated
-(** Add a dummy annotation to a value. The default version is [default_version].
-*)
+val add_dummy_annotation : ?version:version -> 'a -> ('a, _) t_annotated
+(** Add a dummy annotation to a value.
 
-val dummy_annotated : unit annotated
-(** A dummy annotation *)
+    The default version is [default_version]. The default type annotation is
+    [None]. *)
 
-val is_dummy_annotated : 'a annotated -> bool
+val dummy_annotated : (unit, _) t_annotated
+(** A dummy annotation.
+
+    Type annotation is always [None]. *)
+
+val is_dummy_annotated : _ t_annotated -> bool
 (** Returns true if its argument is annotated with [dummy_pos]. *)
 
-val to_pos : 'a annotated -> unit annotated
-(** Removes the value from an annotated record. *)
+val to_pos : _ t_annotated -> (unit, _) t_annotated
+(** Removes the value from an annotated record.
 
-val add_pos_from_pos_of : (string * int * int * int) * 'a -> 'a annotated
+    Also removes the type annotation, which is replaced by [None]. *)
+
+val add_pos_from_pos_of : (string * int * int * int) * 'a -> ('a, _) t_annotated
 (** [add_pos_from_pos_of (__POS_OF__ e)] is [annotated s s' e] where [s] and
-    [s'] correspond to [e]'s position in the ocaml file. *)
+    [s'] correspond to [e]'s position in the ocaml file.
 
-val add_pos_from : 'a annotated -> 'b -> 'b annotated
-(** [add_pos_from loc v] is [v] with the location data from [loc]. *)
+    Type annotation is always [None]. *)
 
-val add_pos_range_from : 'a annotated -> 'a annotated -> 'b -> 'b annotated
+val add_pos_from : _ t_annotated -> 'b -> ('b, _) t_annotated
+(** [add_pos_from loc v] is [v] with the location data from [loc].
+
+    Type annotation in the result is always [None]. *)
+
+val add_pos_range_from :
+  ('a, _) t_annotated -> ('a, _) t_annotated -> 'b -> ('b, _) t_annotated
 (** [add_pos_range_from loc_from loc_to v] is [v] with the location data given
     by the range of locations starting at [loc_from] and ending to [loc_to]. *)
 
-val add_pos_from_st : 'a annotated -> 'a -> 'a annotated
+val add_pos_from_st : ('a, 't) t_annotated -> 'a -> ('a, 't) t_annotated
 (** [add_pos_from_st a' a] is [a] with the location from [a'].
 
     If both arguments are physically equal, then the result is also physically
     equal. *)
 
-val expr_ty_annot_from : src:'a annotated -> expr -> expr
+val expr_ty_annot_from : src:(_, ty) t_annotated -> expr -> expr
 (** [expr_ty_annot_from ~src:a b] is the expression [b] with the type annotation
     from [a]. *)
 
-val expr_with_ty_annot : AST.ty -> expr -> expr
-(** [expr_with_ty_annot ty e] is [e] with the type annotation [ty]. *)
-
-val lexpr_with_ty_annot : AST.ty -> lexpr -> lexpr
-(** [lexpr_with_ty_annot ty le] is [le] with the type annotation [ty]. *)
+val with_ty_annot : AST.ty -> ('term, ty) t_annotated -> ('term, ty) t_annotated
+(** [with_ty_annot ty v] is [v] with the type annotation [ty]. *)
 
 val map2_desc :
-  ('a annotated -> 'b annotated -> 'c) ->
-  'a annotated ->
-  'b annotated ->
-  'c annotated
-(** Folder on two annotated types. *)
+  (('a, 'ty) t_annotated -> ('b, 'ty) t_annotated -> 'c) ->
+  ('a, 'ty) t_annotated ->
+  ('b, 'ty) t_annotated ->
+  ('c, 'ty) t_annotated
+(** [map2_desc f v1 v2] folds two annotated values via [f] and yields a value
+    with positions ranging from the start of [v1] to the end of [v2] and the
+    first type annotation of [v1] and [v2] that is not [None]. *)
 
 (** {1 Type utils} *)
 (*-----------------*)
@@ -119,13 +129,13 @@ val integer : ty
 val integer' : type_desc
 (** [integer], without the position annotation. *)
 
-val integer_exact : ?loc:'a annotated -> expr -> ty
+val integer_exact : ?loc:_ t_annotated -> expr -> ty
 (** [integer_exact e] is the integer type constrained to be equal to [e]. *)
 
 val integer_exact' : expr -> type_desc
 (** [integer_exact' e] is [integer_exact e] without the position annotation. *)
 
-val integer_range : ?loc:'a annotated -> expr -> expr -> ty
+val integer_range : ?loc:_ t_annotated -> expr -> expr -> ty
 (* [integer_range e1 e2] is the integer type constrained to be in the range
    [e1..e2]. *)
 
@@ -134,7 +144,7 @@ val integer_range' : expr -> expr -> type_desc
     annotation. *)
 
 val well_constrained :
-  ?loc:'a annotated ->
+  ?loc:_ t_annotated ->
   ?precision:precision_loss_flag ->
   int_constraint list ->
   ty

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -93,6 +93,16 @@ val add_pos_from_st : 'a annotated -> 'a -> 'a annotated
     If both arguments are physically equal, then the result is also physically
     equal. *)
 
+val expr_ty_annot_from : src:'a annotated -> expr -> expr
+(** [expr_ty_annot_from ~src:a b] is the expression [b] with the type annotation
+    from [a]. *)
+
+val expr_with_ty_annot : AST.ty -> expr -> expr
+(** [expr_with_ty_annot ty e] is [e] with the type annotation [ty]. *)
+
+val lexpr_with_ty_annot : AST.ty -> lexpr -> lexpr
+(** [lexpr_with_ty_annot ty le] is [le] with the type annotation [ty]. *)
+
 val map2_desc :
   ('a annotated -> 'b annotated -> 'c) ->
   'a annotated ->
@@ -166,14 +176,14 @@ val expr_of_int : int -> expr
 val literal : literal -> expr
 (** [literal v] is the expression evaluated to [v]. *)
 
-val var_ : identifier -> expr
-(** [var_ x] is the expression [x]. *)
+val expr_of_var : identifier -> expr
+(** [expr_of_var x] is the expression for the identifier [x]. *)
 
 val binop : binop -> expr -> expr -> expr
 (** Builds a binary operation from to subexpressions. *)
 
-val unop : unop -> expr -> expr
-(** Builds a unary operation from its subexpression. *)
+val neg : expr -> expr
+(** Builds a negation operation from its subexpression. *)
 
 val expr_of_z : Z.t -> expr
 (** [expr_of_z z] is the integer literal for [z]. *)

--- a/asllib/ASTUtils.mli
+++ b/asllib/ASTUtils.mli
@@ -50,9 +50,6 @@ end
 (** {1 Position utils} *)
 (*---------------------*)
 
-val dummy_pos : Lexing.position
-(** A dummy position. *)
-
 val default_version : version
 (** The default version, [V1]. *)
 
@@ -63,19 +60,19 @@ val annotated : 'a -> position -> position -> version -> ('a, _) t_annotated
 val desc : ('a, _) t_annotated -> 'a
 (** [desc v] is [v.desc] *)
 
-val add_dummy_annotation : ?version:version -> 'a -> ('a, _) t_annotated
-(** Add a dummy annotation to a value.
+val add_dummy_pos : ?version:version -> 'a -> ('a, _) t_annotated
+(** [add_dummy_pos version term] returns [term] annotated with a dummy source
+    position and [None] as the type annotation.
 
     The default version is [default_version]. The default type annotation is
     [None]. *)
 
 val dummy_annotated : (unit, _) t_annotated
-(** A dummy annotation.
+(** A dummy annotation with a [None] type annotation. *)
 
-    Type annotation is always [None]. *)
-
-val is_dummy_annotated : _ t_annotated -> bool
-(** Returns true if its argument is annotated with [dummy_pos]. *)
+val is_dummy_pos : _ t_annotated -> bool
+(** [is_dummy_pos v] is true if [v] has the dummy position (that of
+    [Lexing.dummy_pos]). *)
 
 val to_pos : _ t_annotated -> (unit, _) t_annotated
 (** Removes the value from an annotated record.
@@ -102,10 +99,10 @@ val add_pos_from_st : ('a, 't) t_annotated -> 'a -> ('a, 't) t_annotated
 (** [add_pos_from_st a' a] is [a] with the location from [a'].
 
     If both arguments are physically equal, then the result is also physically
-    equal. *)
+    equal, otherwise the type annotation is set to [None]. *)
 
 val expr_ty_annot_from : src:(_, ty) t_annotated -> expr -> expr
-(** [expr_ty_annot_from ~src:a b] is the expression [b] with the type annotation
+(** [expr_ty_annot_from ~src:a e] is the expression [e] with the type annotation
     from [a]. *)
 
 val with_ty_annot : AST.ty -> ('term, ty) t_annotated -> ('term, ty) t_annotated
@@ -118,7 +115,7 @@ val map2_desc :
   ('c, 'ty) t_annotated
 (** [map2_desc f v1 v2] folds two annotated values via [f] and yields a value
     with positions ranging from the start of [v1] to the end of [v2] and the
-    first type annotation of [v1] and [v2] that is not [None]. *)
+    [None] type annotation. *)
 
 (** {1 Type utils} *)
 (*-----------------*)

--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -111,7 +111,7 @@ module Make (B : Backend.S) (C : Config) = struct
       let pp_stack fmt stack =
         let stack = List.rev stack in
         let pp_call fmt call =
-          if is_dummy_annotated call then pp_print_string fmt call.desc
+          if is_dummy_pos call then pp_print_string fmt call.desc
           else
             fprintf fmt "@[<2>%s@ (called@ at@ %a)@]" call.desc PP.pp_pos call
         in
@@ -121,7 +121,7 @@ module Make (B : Backend.S) (C : Config) = struct
         let spath = List.rev spath in
         let pp_choice fmt choice =
           let open IEnv in
-          if is_dummy_annotated choice.location then
+          if is_dummy_pos choice.location then
             fprintf fmt "%s<-%B" choice.description choice.decision
           else
             fprintf fmt "@[<2>%s<-%B@ decided@ at@ %a@]" choice.description
@@ -373,7 +373,7 @@ module Make (B : Backend.S) (C : Config) = struct
     |> Hashtbl.of_seq
 
   let primitive_decls =
-    List.map (fun (f, _) -> D_Func f |> add_dummy_annotation) B.primitives
+    List.map (fun (f, _) -> D_Func f |> add_dummy_pos) B.primitives
 
   let () =
     if false then

--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -283,6 +283,7 @@ let fatal lexbuf desc =
       version = V1;
       pos_start = Lexing.lexeme_start_p lexbuf;
       pos_end = Lexing.lexeme_end_p lexbuf;
+      ty_opt = None;
     }
   |> Error.fatal
 

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -311,14 +311,14 @@ module NativeBackend (C : Config) = struct
     let round_towards_zero = wrap_real_to_int "RoundTowardsZero" truncate
 
     let primitives =
-      let e_var x = E_Var x |> add_dummy_annotation in
+      let e_var x = E_Var x |> add_dummy_pos in
       let eoi i = expr_of_int i in
       let binop = ASTUtils.binop in
       let minus_one e = binop `SUB e (eoi 1) in
       let pow_2 = binop `POW (eoi 2) in
       let neg e = E_Unop (NEG, e) |> add_pos_from e in
       (* [t_bits "N"] is the bitvector type of length [N]. *)
-      let t_bits x = T_Bits (e_var x, []) |> add_dummy_annotation in
+      let t_bits x = T_Bits (e_var x, []) |> add_dummy_pos in
       (* [p ~parameters ~args ~returns name f] declares a primtive named [name]
          with body [f], and signature specified by [parameters] [args] and
          [returns]. *)

--- a/asllib/PP.ml
+++ b/asllib/PP.ml
@@ -48,7 +48,7 @@ let pp_pos f ({ pos_start; pos_end; _ } as x) =
   let pp_char_num f { pos_cnum; pos_bol; _ } =
     pp_print_int f (pos_cnum - pos_bol)
   in
-  if ASTUtils.is_dummy_annotated x then ()
+  if ASTUtils.is_dummy_pos x then ()
   else (
     pp_open_hovbox f 2;
     fprintf f "File %s,@ " pos_start.pos_fname;

--- a/asllib/PP.mli
+++ b/asllib/PP.mli
@@ -29,10 +29,10 @@ open AST
 type 'a printer = Format.formatter -> 'a -> unit
 (** A general pretty-printer type. *)
 
-val pp_pos : 'a annotated printer
-val pp_pos_str : 'a annotated -> string
+val pp_pos : _ t_annotated printer
+val pp_pos_str : _ t_annotated -> string
 
-val pp_pos_str_no_char : 'a annotated -> string
+val pp_pos_str_no_char : _ t_annotated -> string
 (** Print a position. *)
 
 (** {1 AST pretty-printers} *)

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -167,7 +167,7 @@ let some(x) == ~ = x ; <Some>
 let terminated_by(x, y) == terminated(y, x)
 
 (* Position annotation *)
-let annotated(x) == desc = x; { { desc; pos_start=$symbolstartpos; pos_end=$endpos; version } }
+let annotated(x) == desc = x; { { desc; pos_start=$symbolstartpos; pos_end=$endpos; version; ty_opt=None } }
 
 (* ------------------------------------------------------------------------- *)
 (* List handling *)

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -439,7 +439,7 @@ let access :=
 
 let basic_lexpr :=
   | base=annotated(IDENTIFIER); ~=access;
-    { ( base, {access; slices=add_dummy_annotation ~version []} ) }
+    { ( base, {access; slices=add_dummy_pos ~version []} ) }
   | base=annotated(IDENTIFIER); ~=access; slices=annotated(slices);
     { ( base, {access; slices} ) }
 
@@ -554,7 +554,7 @@ let stmt :=
       | ~=local_decl_keyword; ~=decl_item; ~=ty_opt; EQ; ~=some(expr); < S_Decl   >
       | le=lexpr; EQ; e=expr;                                < S_Assign >
       | call=annotated(call); ~=setter_access; EQ; rhs=expr;
-        { desugar_setter call { access=setter_access; slices=add_dummy_annotation ~version [] } rhs }
+        { desugar_setter call { access=setter_access; slices=add_dummy_pos ~version [] } rhs }
       | call=annotated(call); ~=setter_access; slices=annotated(slices); EQ; rhs=expr;
         { desugar_setter call { access=setter_access; slices } rhs }
       | call=annotated(call); DOT; flds=bracketed(clist2(IDENTIFIER)); EQ; rhs=expr;
@@ -734,7 +734,7 @@ let opn [@internal true] := body=stmt_list0; EOF;
             parameters = [];
             body = SB_ASL body;
             return_type =
-              Some (T_Int UnConstrained |> add_dummy_annotation ~version);
+              Some (T_Int UnConstrained |> add_dummy_pos ~version);
             subprogram_type = ST_Function;
             recurse_limit = None;
             qualifier = None;

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -265,7 +265,7 @@ let decl ==
   | setter_decl
   | type_decl
 
-let annotated(x) == desc = x; { AST.{ desc; pos_start=$symbolstartpos; pos_end=$endpos; version }}
+let annotated(x) == desc = x; { AST.{ desc; pos_start=$symbolstartpos; pos_end=$endpos; version; ty_opt=None }}
 
 let unimplemented_decl(x) == x; { None }
 let unimplemented_ty(x) == x; { AST.(T_Bits (ASTUtils.expr_of_int 0, [])) }

--- a/asllib/Parser0.mly
+++ b/asllib/Parser0.mly
@@ -40,13 +40,13 @@
       List.fold_right (map2_desc folder) s_elsifs s_else
 
     let t_bit =
-      T_Bits (E_Literal (L_Int Z.one) |> add_dummy_annotation ~version, [])
+      T_Bits (E_Literal (L_Int Z.one) |> add_dummy_pos ~version, [])
 
 
     let make_ldi_vars (ty, xs) =
       let make_one x =
         S_Decl (LDK_Var, LDI_Var x, Some ty, None)
-        |> add_dummy_annotation ~version
+        |> add_dummy_pos ~version
       in
       List.map make_one xs |> stmt_from_list |> desc
 
@@ -247,7 +247,7 @@ let opn := list(EOL); body=list(stmts); EOF;
           parameters = [];
           body = SB_ASL body;
           return_type =
-            Some (T_Int UnConstrained |> ASTUtils.add_dummy_annotation ~version);
+            Some (T_Int UnConstrained |> ASTUtils.add_dummy_pos ~version);
           subprogram_type = ST_Function;
           recurse_limit = None;
           override = None;
@@ -441,7 +441,7 @@ let variable_decl ==
             keyword = GDK_Var;
             name = x;
             ty = Some (T_Array (e, ty)
-                       |> ASTUtils.add_dummy_annotation ~version);
+                       |> ASTUtils.add_dummy_pos ~version);
             initial_value = None;
           })}
       )))

--- a/asllib/StaticInterpreter.ml
+++ b/asllib/StaticInterpreter.ml
@@ -44,7 +44,7 @@ module SI = Interpreter.Make (Native.StaticBackend) (InterpConf)
 
 let eval_from ~loc env e =
   try SI.eval_expr env e
-  with Error.(ASLException exn) when is_dummy_annotated exn ->
+  with Error.(ASLException exn) when is_dummy_pos exn ->
     Error.fatal_from loc exn.desc
 
 (* Begin StaticEval *)

--- a/asllib/StaticModel.ml
+++ b/asllib/StaticModel.ml
@@ -58,7 +58,8 @@ end = struct
     let start = expr_of_z (Q.num factor) in
     let numerator =
       AtomMap.fold
-        (fun atom exponent acc -> mul_expr acc (pow_expr (var_ atom) exponent))
+        (fun atom exponent acc ->
+          mul_expr acc (pow_expr (expr_of_var atom) exponent))
         monos start
     in
     div_expr numerator (Q.den factor)
@@ -238,7 +239,8 @@ let rec to_ir env (e : expr) =
 (* Begin Normalize *)
 let normalize env e =
   let { desc } = e |> to_ir env |> Polynomial.to_expr in
-  add_pos_from e desc
+  let normalized_expr = add_pos_from e desc in
+  { normalized_expr with ty_opt = e.ty_opt }
 (* End *)
 
 let try_normalize env e =

--- a/asllib/StaticOperations.ml
+++ b/asllib/StaticOperations.ml
@@ -90,7 +90,7 @@ let apply_binop_extremities (op : extremities_binops) c1 c2 =
 
 (** [constraint_pow c1 c2] applies [POW] to [c1] and [c2]. *)
 let constraint_pow c1 c2 =
-  let pow = binop `POW and neg = unop NEG in
+  let pow = binop `POW in
   match (c1, c2) with
   | Constraint_Exact a, Constraint_Exact c ->
       [ exact (pow a c) ] |: TypingRule.ConstraintPow

--- a/asllib/StaticOperations.ml
+++ b/asllib/StaticOperations.ml
@@ -180,7 +180,7 @@ let filter_reduce_constraint_div =
 
 module type CONFIG = sig
   val fail : string -> 'a
-  val warn_from : loc:'a annotated -> Error.warning_desc -> unit
+  val warn_from : loc:_ t_annotated -> Error.warning_desc -> unit
 end
 
 module Make (C : CONFIG) = struct

--- a/asllib/StaticOperations.mli
+++ b/asllib/StaticOperations.mli
@@ -13,12 +13,12 @@ val constraint_binop :
 
 module type CONFIG = sig
   val fail : string -> 'a
-  val warn_from : loc:'a annotated -> Error.warning_desc -> unit
+  val warn_from : loc:_ t_annotated -> Error.warning_desc -> unit
 end
 
 module Make : functor (C : CONFIG) -> sig
   val annotate_constraint_binop :
-    loc:'a annotated ->
+    loc:_ t_annotated ->
     StaticEnv.env ->
     int3_binop ->
     int_constraint list ->

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -36,11 +36,16 @@ let undefined_identifier ~loc x =
 
 let invalid_expr e = fatal_from ~loc:e (Error.InvalidExpr e)
 let add_pos_from ~loc = add_pos_from loc
+let set_expr_type_annotation (t, e, ses) = (t, expr_with_ty_annot t e, ses)
+
+let set_lexpr_type_annotation t ((le, ses) : AST.lexpr * SES.t) =
+  (lexpr_with_ty_annot t le, ses)
 
 let conflict ~loc expected provided =
   fatal_from ~loc (Error.ConflictingTypes (expected, provided))
 
-let plus = binop `ADD
+let plus e1 e2 = binop `ADD e1 e2
+let minus e1 e2 = binop `SUB e1 e2
 let t_bits_bitwidth e = T_Bits (e, [])
 
 let func_version f =
@@ -62,11 +67,13 @@ let rec list_mapi3 f i l1 l2 l3 =
       r :: list_mapi3 f (i + 1) l1 l2 l3
   | _, _, _ -> invalid_arg "List.mapi3"
 
-let sum = function [] -> !$0 | [ x ] -> x | h :: t -> List.fold_left plus h t
+let sum = function
+  | [] -> zero_expr
+  | [ x ] -> x
+  | h :: t -> List.fold_left plus h t
 
 (* Begin SlicesWidth *)
 let slices_width env =
-  let minus = binop `SUB in
   let slice_width = function
     | Slice_Single _ -> one_expr
     | Slice_Star (_, e) | Slice_Length (_, e) -> e
@@ -775,7 +782,6 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         match t_struct.desc with
         | T_Int UnConstrained -> T_Int UnConstrained |> here
         | T_Int (WellConstrained (cs, precision)) ->
-            let neg e = unop NEG e in
             let constraint_minus = function
               | Constraint_Exact e -> Constraint_Exact (neg e)
               | Constraint_Range (top, bot) ->
@@ -1452,7 +1458,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           (* LRM R_GXKG:
              The notation b[j:i] is syntactic sugar for b[i +: j-i+1].
           *)
-          let length = binop `SUB j i |> binop `ADD !$1 in
+          let length = plus (minus j i) one_expr in
           annotate_slice (Slice_Length (i, length)) |: TypingRule.Slice
       | Slice_Star (factor, length) ->
           (* LRM R_GXQG:
@@ -1868,9 +1874,13 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       ret_ty_opt,
       ses3 )
 
+  (** [annotate_expr] annotates the expression [e] in [env] and sets a type
+      annotation. *)
   and annotate_expr env (e : expr) : ty * expr * SES.t =
     let () = if false then Format.eprintf "@[Annotating %a@]@." PP.pp_expr e in
     let here x = add_pos_from ~loc:e x and loc = to_pos e in
+    set_expr_type_annotation
+    @@
     match e.desc with
     (* Begin ELit *)
     | E_Literal v ->
@@ -2359,6 +2369,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       [loc]. Note however that a bit vector with width [N] can always be
       generated using [0[:N]]. *)
   let rec base_value_v1 ~loc env t : expr =
+    expr_with_ty_annot t
+    @@
     let here = add_pos_from ~loc in
     let lit v = here (E_Literal v) in
     let fatal_non_static e =
@@ -2379,12 +2391,11 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             if length < 0 then fatal_from ~loc @@ Error.BaseValueEmptyType t
             else L_BitVector (Bitvector.zeros length) |> lit
         | _ ->
-            let zero = L_Int Z.zero |> lit in
-            let slice = Slice_Length (zero, e) in
-            E_Slice (zero, [ slice ]) |> here)
+            let slice = Slice_Length (zero_expr, e) in
+            E_Slice (zero_expr, [ slice ]) |> here)
     | T_Enum [] -> assert false
     | T_Enum (name :: _) -> lookup_constant env name |> lit
-    | T_Int UnConstrained -> L_Int Z.zero |> lit
+    | T_Int UnConstrained -> zero_expr
     | T_Int (Parameterized id) -> E_Var id |> here |> fatal_non_static
     | T_Int PendingConstrained -> assert false
     | T_Int (WellConstrained (cs, _)) ->
@@ -2404,7 +2415,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         if list_is_empty z_min_list then fatal_is_empty ()
         else
           let z_min = list_min_abs_z z_min_list in
-          L_Int z_min |> lit
+          expr_of_z z_min
     | T_Named _ -> Types.make_anonymous env t |> base_value_v1 ~loc env
     | T_Real -> L_Real Q.zero |> lit
     | T_Exception fields | T_Record fields | T_Collection fields ->
@@ -2448,12 +2459,12 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         let t = Types.make_anonymous env t in
         base_value_v0 ~loc env t
 
-  (** [base_value ~loc env e] is [base_value_v1 ~loc env e] if running for
-      ASLv1, or [base_value_v0 ~loc env e] if running for ASLv0. *)
-  let base_value ~loc env e =
+  (** [base_value ~loc env t] is [base_value_v1 ~loc env t] if running for
+      ASLv1, or [base_value_v0 ~loc env t] if running for ASLv0. *)
+  let base_value ~loc env t =
     match loc.version with
-    | V0 -> base_value_v0 ~loc env e
-    | V1 -> base_value_v1 ~loc env e
+    | V0 -> base_value_v0 ~loc env t
+    | V1 -> base_value_v1 ~loc env t
 
   (* Begin AnnotateSetArray *)
   let annotate_set_array ~loc env t_elem rhs_ty (e_base, ses_base, e_index) =
@@ -2465,6 +2476,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     (new_le |> add_pos_from ~loc, ses) |: TypingRule.AnnotateSetArray
   (* End *)
 
+  (** [annotate_lexpr env le t_e] annotates the assignable expression [le] in
+      [env] with the type [t_e] and sets [t_e] as the type annotation to the
+      resulting expression. *)
   let rec annotate_lexpr env le t_e =
     let () =
       if false then
@@ -2473,6 +2487,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     in
     let loc = to_pos le in
     let here x = add_pos_from ~loc x in
+    set_lexpr_type_annotation t_e
+    @@
     match le.desc with
     (* Begin LEDiscard *)
     | LE_Discard -> (le, SES.empty) |: TypingRule.LEDiscard

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -36,10 +36,13 @@ let undefined_identifier ~loc x =
 
 let invalid_expr e = fatal_from ~loc:e (Error.InvalidExpr e)
 let add_pos_from ~loc = add_pos_from loc
-let set_expr_type_annotation (t, e, ses) = (t, expr_with_ty_annot t e, ses)
+let set_expr_type_annotation (t, e, ses) = (t, with_ty_annot t e, ses)
 
-let set_lexpr_type_annotation t ((le, ses) : AST.lexpr * SES.t) =
-  (lexpr_with_ty_annot t le, ses)
+(** [set_lexpr_type_annotation (lexpr_ty, lexpr, ses)] sets [lexpr_ty] as the
+    type annotation of [lexpr] and returns the updated assignable expression
+    together with [lexpr_ty] and [ses]. *)
+let set_lexpr_type_annotation (lexpr_ty, lexpr, ses) =
+  (lexpr_ty, with_ty_annot lexpr_ty lexpr, ses)
 
 let conflict ~loc expected provided =
   fatal_from ~loc (Error.ConflictingTypes (expected, provided))
@@ -2369,7 +2372,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       [loc]. Note however that a bit vector with width [N] can always be
       generated using [0[:N]]. *)
   let rec base_value_v1 ~loc env t : expr =
-    expr_with_ty_annot t
+    with_ty_annot t
     @@
     let here = add_pos_from ~loc in
     let lit v = here (E_Literal v) in
@@ -2476,10 +2479,10 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     (new_le |> add_pos_from ~loc, ses) |: TypingRule.AnnotateSetArray
   (* End *)
 
-  (** [annotate_lexpr env le t_e] annotates the assignable expression [le] in
-      [env] with the type [t_e] and sets [t_e] as the type annotation to the
-      resulting expression. *)
-  let rec annotate_lexpr env le t_e =
+  (** [annotate_lexpr_ty env le t_e] annotates the assignable expression [le] in
+      [env], checks that it can be assigned a value of type [t_e], and returns
+      and sets its actual type. *)
+  let rec annotate_lexpr_ty env le t_e =
     let () =
       if false then
         Format.eprintf "Typing lexpr: @[%a@] to @[%a@]@." PP.pp_lexpr le
@@ -2487,11 +2490,11 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     in
     let loc = to_pos le in
     let here x = add_pos_from ~loc x in
-    set_lexpr_type_annotation t_e
+    set_lexpr_type_annotation
     @@
     match le.desc with
     (* Begin LEDiscard *)
-    | LE_Discard -> (le, SES.empty) |: TypingRule.LEDiscard
+    | LE_Discard -> (t_e, le, SES.empty) |: TypingRule.LEDiscard
     (* End *)
     (* Begin LEVar *)
     | LE_Var x ->
@@ -2506,7 +2509,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
               | None -> undefined_identifier ~loc x)
         in
         let+ () = check_type_satisfies ~loc env t_e ty in
-        (le, ses) |: TypingRule.LEVar
+        (ty, le, ses) |: TypingRule.LEVar
     (* End *)
     (* Begin LEDestructuring *)
     | LE_Destructuring les ->
@@ -2520,14 +2523,14 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                        List.length tys,
                        List.length les ))
               else
-                let les', sess =
-                  List.map2 (annotate_lexpr env) les tys |> List.split
+                let lhs_tys, les', sess =
+                  List.map2 (annotate_lexpr_ty env) les tys |> list_split3
                 in
                 let ses =
                   (* TODO left-hand-side conflicting union *)
                   SES.unions sess
                 in
-                (LE_Destructuring les' |> here, ses)
+                (T_Tuple lhs_tys |> here, LE_Destructuring les' |> here, ses)
           | _ -> conflict ~loc [ T_Tuple [] ] t_e)
         |: TypingRule.LEDestructuring
     (* End *)
@@ -2537,38 +2540,38 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         (* Begin LESlice *)
         match t_le1_anon.desc with
         | T_Bits _ ->
-            let le2, ses1 = annotate_lexpr env le1 t_le1 in
+            let _, le2, ses1 = annotate_lexpr_ty env le1 t_le1 in
             let slices_annotated, ses_slices =
               best_effort (slices, SES.empty) @@ fun _ ->
               annotate_slices env slices ~loc
             in
-            let+ () =
-             fun () ->
-              let width =
-                slices_width env slices_annotated
-                |> StaticModel.try_normalize env
-              in
-              let t = T_Bits (width, []) |> here in
-              check_type_satisfies ~loc env t_e t ()
+            let width =
+              slices_width env slices_annotated |> StaticModel.try_normalize env
             in
+            let t = T_Bits (width, []) |> here in
+            let+ () = check_type_satisfies ~loc env t_e t in
             let+ () = check_disjoint_slices ~loc env slices_annotated in
             let+ () =
               check_true (not (list_is_empty slices_annotated)) @@ fun () ->
               fatal_from ~loc Error.EmptySlice
             in
             let ses = ses_non_conflicting_union ~loc ses1 ses_slices in
-            (LE_Slice (le2, slices_annotated) |> here, ses |: TypingRule.LESlice)
+            (t, LE_Slice (le2, slices_annotated) |> here, ses)
+            |: TypingRule.LESlice
         | T_Array (_, t) when le.version = V0 -> (
             match slices with
             | [ Slice_Single e_index ] ->
-                let le2, ses2 = annotate_lexpr env le1 t_le1 in
-                annotate_set_array ~loc:le env t t_e (le2, ses2, e_index)
+                let _, le2, ses2 = annotate_lexpr_ty env le1 t_le1 in
+                let le3, ses3 =
+                  annotate_set_array ~loc:le env t t_e (le2, ses2, e_index)
+                in
+                (t, le3, ses3)
             | _ -> invalid_expr (expr_of_lexpr le1))
         | _ -> conflict ~loc:le1 [ default_t_bits ] t_le1
         (* End *))
     | LE_SetField (le1, field) ->
         (let t_le1, _, _ = expr_of_lexpr le1 |> annotate_expr env in
-         let le2, ses = annotate_lexpr env le1 t_le1 in
+         let _, le2, ses = annotate_lexpr_ty env le1 t_le1 in
          let t_le1_anon = Types.make_anonymous env t_le1 in
          match t_le1_anon.desc with
          (* Begin LESetStructuredField *)
@@ -2579,7 +2582,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                | Some t -> t
              in
              let+ () = check_type_satisfies ~loc env t_e t in
-             ( LE_SetField (le2, field) |> here,
+             ( t,
+               LE_SetField (le2, field) |> here,
                ses |: TypingRule.LESetStructuredField )
          (* End *)
          (* Begin LESetCollectionField *)
@@ -2594,7 +2598,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
              in
              let+ () = check_type_satisfies ~loc env t_e t in
              let n = get_bitvector_const_width ~loc env t in
-             ( LE_SetCollectionFields
+             ( t,
+               LE_SetCollectionFields
                  (collection_var_name, [ field ], [ (0, n) ])
                |> here,
                ses |: TypingRule.LESetCollectionField )
@@ -2619,7 +2624,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
              in
              let+ () = check_type_satisfies ~loc:le1 env t_e t in
              let le3 = LE_Slice (le1, slices) |> here in
-             annotate_lexpr env le3 t_e |: TypingRule.LESetBitField
+             annotate_lexpr_ty env le3 t_e |: TypingRule.LESetBitField
          (* End *)
          (* Begin LESetBadField *)
          | T_Tuple _ -> fatal_from ~loc @@ Error.AssignToTupleElement le1
@@ -2632,7 +2637,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     (* Begin LESetFields *)
     | LE_SetFields (le_base, le_fields, []) -> (
         let t_base, _, _ = expr_of_lexpr le_base |> annotate_expr env in
-        let le_base_annot, ses_base = annotate_lexpr env le_base t_base in
+        let _, le_base_annot, ses_base = annotate_lexpr_ty env le_base t_base in
         let t_base_anon = Types.make_anonymous env t_base in
         match t_base_anon.desc with
         | T_Bits (_, bitfields) ->
@@ -2646,7 +2651,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                 (le_base_annot, List.concat_map slices_of_bitfield le_fields)
               |> here
             in
-            annotate_lexpr env le_slice t_e |: TypingRule.LESetFields
+            annotate_lexpr_ty env le_slice t_e |: TypingRule.LESetFields
         | T_Record base_fields | T_Exception base_fields ->
             let fold_bitvector_fields field (start, slices) =
               match List.assoc_opt field base_fields with
@@ -2662,7 +2667,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             in
             let t_lhs = T_Bits (expr_of_int length, []) |> here in
             let+ () = check_type_satisfies ~loc env t_e t_lhs in
-            (LE_SetFields (le_base_annot, le_fields, slices) |> here, ses_base)
+            ( t_lhs,
+              LE_SetFields (le_base_annot, le_fields, slices) |> here,
+              ses_base )
         | T_Collection base_fields ->
             let collection_var_name =
               match le_base.desc with
@@ -2685,7 +2692,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             in
             let t_lhs = T_Bits (expr_of_int length, []) |> here in
             let+ () = check_type_satisfies ~loc env t_e t_lhs in
-            ( LE_SetCollectionFields (collection_var_name, le_fields, slices)
+            ( t_lhs,
+              LE_SetCollectionFields (collection_var_name, le_fields, slices)
               |> here,
               ses_base )
         | _ -> conflict ~loc [ default_t_bits ] t_base |: TypingRule.LESetFields
@@ -2697,11 +2705,21 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         let t_anon_base = Types.make_anonymous env t_base in
         match t_anon_base.desc with
         | T_Array (_, t_elem) ->
-            let e_base', ses_base = annotate_lexpr env e_base t_base in
-            annotate_set_array ~loc env t_elem t_e (e_base', ses_base, e_index)
+            let _, e_base', ses_base = annotate_lexpr_ty env e_base t_base in
+            let le', ses =
+              annotate_set_array ~loc env t_elem t_e (e_base', ses_base, e_index)
+            in
+            (t_elem, le', ses)
         | _ -> conflict ~loc [ default_array_ty ] t_base)
     (* End *)
     | LE_SetFields (_, _, _ :: _) | LE_SetCollectionFields _ -> assert false
+
+  (** [annotate_lexpr env le t_e] annotates the assignable expression [le] in
+      [env], checks that it can be assigned a value of type [t_e], and returns
+      the annotated expression and its side effects. *)
+  let annotate_lexpr env le t_e =
+    let _, le', ses = annotate_lexpr_ty env le t_e in
+    (le', ses)
 
   (* Begin CheckCanBeInitializedWith *)
   let can_be_initialized_with env s t =

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -36,13 +36,6 @@ let undefined_identifier ~loc x =
 
 let invalid_expr e = fatal_from ~loc:e (Error.InvalidExpr e)
 let add_pos_from ~loc = add_pos_from loc
-let set_expr_type_annotation (t, e, ses) = (t, with_ty_annot t e, ses)
-
-(** [set_lexpr_type_annotation (lexpr_ty, lexpr, ses)] sets [lexpr_ty] as the
-    type annotation of [lexpr] and returns the updated assignable expression
-    together with [lexpr_ty] and [ses]. *)
-let set_lexpr_type_annotation (lexpr_ty, lexpr, ses) =
-  (lexpr_ty, with_ty_annot lexpr_ty lexpr, ses)
 
 let conflict ~loc expected provided =
   fatal_from ~loc (Error.ConflictingTypes (expected, provided))
@@ -1882,6 +1875,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
   and annotate_expr env (e : expr) : ty * expr * SES.t =
     let () = if false then Format.eprintf "@[Annotating %a@]@." PP.pp_expr e in
     let here x = add_pos_from ~loc:e x and loc = to_pos e in
+    let set_expr_type_annotation (t, e, ses) = (t, with_ty_annot t e, ses) in
     set_expr_type_annotation
     @@
     match e.desc with
@@ -2490,6 +2484,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     in
     let loc = to_pos le in
     let here x = add_pos_from ~loc x in
+    let set_lexpr_type_annotation (lexpr_ty, lexpr, ses) =
+      (lexpr_ty, with_ty_annot lexpr_ty lexpr, ses)
+    in
     set_lexpr_type_annotation
     @@
     match le.desc with

--- a/asllib/backend.mli
+++ b/asllib/backend.mli
@@ -167,7 +167,7 @@ module type S = sig
   (** Represents a range by its first accessed index and its length. *)
 
   val read_from_bitvector :
-    loc:'a AST.annotated -> value_range list -> value -> value m
+    loc:_ AST.t_annotated -> value_range list -> value -> value m
   (** Read a slice (represented by a list of value ranges) from a bitvector. *)
 
   val write_to_bitvector : value_range list -> value -> value -> value m

--- a/asllib/carpenter/ASTEnums.ml
+++ b/asllib/carpenter/ASTEnums.ml
@@ -410,7 +410,7 @@ module Make (C : Config.S) = struct
 
   let gdks = scaled_finite [ GDK_Config; GDK_Let; GDK_Constant; GDK_Var ]
 
-  let decls =
+  let decls : decl enum =
     let d_func =
       let make_func (name, (body, (return_type, (args, subprogram_type)))) =
         let parameters = [] and body = SB_ASL body and recurse_limit = None in

--- a/asllib/carpenter/ASTEnums.ml
+++ b/asllib/carpenter/ASTEnums.ml
@@ -11,7 +11,7 @@ module Make (C : Config.S) = struct
   open Feat
   open Enum
 
-  let annot desc = ASTUtils.add_dummy_annotation desc
+  let annot desc = ASTUtils.add_dummy_pos desc
 
   (* Util not to forget to pay ==> make payment mandatory on recursion. *)
   let fix f = Fix.Memoize.Int.fix (fun blah -> f (pay blah))

--- a/asllib/carpenter/RandomAST.ml
+++ b/asllib/carpenter/RandomAST.ml
@@ -10,7 +10,7 @@ open QCheck2.Gen
 module SES = SideEffect.SES
 
 let _dbg = false
-let annot desc = ASTUtils.add_dummy_annotation desc
+let annot desc = ASTUtils.add_dummy_pos desc
 
 type 'a gen = 'a QCheck2.Gen.t
 type 'a sgen = 'a QCheck2.Gen.sized

--- a/asllib/desugar.mli
+++ b/asllib/desugar.mli
@@ -105,8 +105,7 @@ val desugar_setter_setfields :
     Case statements
    ------------------------------------------------------------------------- *)
 
-val desugar_case_stmt :
-  expr_desc annotated -> case_alt_desc annotated list -> stmt -> stmt_desc
+val desugar_case_stmt : expr -> case_alt list -> stmt -> stmt_desc
 (** [desugar_case_stmt e0 cases otherwise] desugars a case statement for the
     discriminant expression [e0], case alternatives [cases], and otherwise
     statement [otherwise]. The result is a conditional statement, possibly

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -126,7 +126,7 @@ let fatal_from pos e = fatal (ASTUtils.add_pos_from pos e)
 let fatal_here pos_start pos_end e =
   fatal (ASTUtils.annotated e pos_start pos_end ASTUtils.default_version)
 
-let fatal_unknown_pos e = fatal (ASTUtils.add_dummy_annotation e)
+let fatal_unknown_pos e = fatal (ASTUtils.add_dummy_pos e)
 let intercept f () = try Ok (f ()) with ASLException e -> Error e
 
 type warning_desc =
@@ -294,7 +294,7 @@ open struct
     and end_cnum = e.pos_end.pos_cnum
     and start_bol = e.pos_start.pos_bol
     and end_bol = e.pos_end.pos_bol in
-    if ASTUtils.is_dummy_annotated e then None
+    if ASTUtils.is_dummy_pos e then None
     else if String.equal filename end_filename && Sys.file_exists filename then
       let lines = fetch_lines ~start_bol ~end_bol filename in
       let lines =
@@ -316,7 +316,7 @@ module PPrint = struct
   let pp_comma_list pp_elt f li =
     pp_print_list ~pp_sep:(fun f () -> fprintf f ",@ ") pp_elt f li
 
-  let pp_type_desc f ty = pp_ty f (ASTUtils.add_dummy_annotation ty)
+  let pp_type_desc f ty = pp_ty f (ASTUtils.add_dummy_pos ty)
 
   let fprintf_err f kind =
     kdprintf (fun msg -> fprintf f "@[<hov 2>ASL %s error:@ %t@]" kind msg)
@@ -662,7 +662,7 @@ module PPrint = struct
 
   let pp_pos_begin f pos =
     match display_error_context pos with
-    | None when ASTUtils.is_dummy_annotated pos -> ()
+    | None when ASTUtils.is_dummy_pos pos -> ()
     | None -> fprintf f "@[<h>%a:@]@ " pp_pos pos
     | Some ctx -> fprintf f "@[<h>%a:@]@ %s@ " pp_pos pos ctx
 

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -671,7 +671,7 @@ module PPrint = struct
   let pp_warning f e =
     fprintf f "@[<v 0>%a%a@]" pp_pos_begin e pp_warning_desc e
 
-  let error_desc_to_string = asprintf "%a" pp_error_desc
+  let error_desc_to_string e = asprintf "%a" pp_error_desc e
 
   let desc_to_string_inf pp_desc =
     asprintf "%a" @@ fun f e ->

--- a/asllib/menhir2bnfc/tests/integration/cmp_binops.ml
+++ b/asllib/menhir2bnfc/tests/integration/cmp_binops.ml
@@ -39,13 +39,13 @@ let exprs : AST.expr enum =
   let ( let+ ) x f = map f x and ( and+ ) = ( ** ) in
   let e_binops exprs =
     let+ e1 = exprs and+ op = binops and+ e2 = exprs in
-    AST.E_Binop (op, e1, e2) |> ASTUtils.add_dummy_annotation
+    AST.E_Binop (op, e1, e2) |> ASTUtils.add_dummy_pos
   and e_unops exprs =
     let+ e = exprs and+ op = unops in
-    AST.E_Unop (op, e) |> ASTUtils.add_dummy_annotation
+    AST.E_Unop (op, e) |> ASTUtils.add_dummy_pos
   and e_conds exprs =
     let+ e = exprs in
-    AST.E_Cond (literal, literal, e) |> ASTUtils.add_dummy_annotation
+    AST.E_Cond (literal, literal, e) |> ASTUtils.add_dummy_pos
   in
   Fix.Memoize.Int.fix @@ fun exprs ->
   let exprs = pay exprs in

--- a/asllib/tests/helpers.ml
+++ b/asllib/tests/helpers.ml
@@ -4,7 +4,7 @@ module Infix = struct
   open AST
   include ASTUtils.Infix
 
-  let ( !! ) e = ASTUtils.add_dummy_annotation e
+  let ( !! ) e = ASTUtils.add_dummy_pos e
   let ( !% ) x = !!(E_Var x)
 end
 

--- a/asllib/tests/static.ml
+++ b/asllib/tests/static.ml
@@ -61,7 +61,7 @@ let normalize () =
       ( binop `ADD (binop `SUB !%"N" !%"m") (binop `SUB !%"m" !$1),
         binop `SUB !%"N" !$1,
         StaticEnv.add_local "m" integer LDK_Let env_with_N );
-      (unop NEG !$3, !$(-3), StaticEnv.empty);
+      (neg !$3, !$(-3), StaticEnv.empty);
     ]
 
 let () =

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -123,7 +123,7 @@ let parameterized_ty ~loc var = T_Int (Parameterized var) |> add_pos_from loc
 
 let to_well_constrained ty =
   match ty.desc with
-  | T_Int (Parameterized var) -> var_ var |> integer_exact
+  | T_Int (Parameterized var) -> expr_of_var var |> integer_exact
   | _ -> ty
 
 let get_well_constrained_structure env ty =
@@ -197,7 +197,7 @@ module Domain = struct
     match ty.desc with
     | T_Int UnConstrained -> Top
     | T_Int (Parameterized var) ->
-        Subdomains [ ConstrainedDom (Constraint_Exact (var_ var)) ]
+        Subdomains [ ConstrainedDom (Constraint_Exact (expr_of_var var)) ]
     | T_Int (WellConstrained (constraints, _)) ->
         Subdomains (List.map (symdom_of_constraint env) constraints)
     | T_Int PendingConstrained

--- a/asllib/types.mli
+++ b/asllib/types.mli
@@ -50,7 +50,7 @@ val get_structure : env -> ty -> ty
 (** The structure of a type is the primitive type that can hold the same values.
 *)
 
-val parameterized_ty : loc:'a annotated -> identifier -> ty
+val parameterized_ty : loc:_ t_annotated -> identifier -> ty
 (** Builds an parameterized integer type from a declared variable. *)
 
 val to_well_constrained : ty -> ty
@@ -80,7 +80,7 @@ val type_clashes : env -> ty -> ty -> bool
 val subprogram_clashes : env -> func -> func -> bool
 (** Subprogram clashing relation. *)
 
-val lowest_common_ancestor : loc:'a annotated -> env -> ty -> ty -> ty option
+val lowest_common_ancestor : loc:_ t_annotated -> env -> ty -> ty -> ty option
 (** Lowest common ancestor. *)
 
 val type_equal : env -> ty -> ty -> bool

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -24,7 +24,7 @@ let aarch64_iico_order = "aarch64_iico_order"
 let return_i i =
   let open Asllib.AST in
   let open Asllib.ASTUtils in
-  add_dummy_annotation (S_Return (Some (expr_of_int i)))
+  add_dummy_pos (S_Return (Some (expr_of_int i)))
 
 let return_0 = return_i 0
 
@@ -32,14 +32,14 @@ let catch_silent_exit body =
   let open Asllib.AST in
   let open Asllib.ASTUtils in
   let exit_type : Asllib.AST.ty =
-    add_dummy_annotation (T_Named "SilentExit") in
+    add_dummy_pos (T_Named "SilentExit") in
   let catcher = (None,exit_type,return_0) in
-  add_dummy_annotation (S_Try (body,[catcher],None))
+  add_dummy_pos (S_Try (body,[catcher],None))
 
 let setup_registers is_vmsa =
   let open Asllib.AST in
   let open Asllib.ASTUtils in
-  add_dummy_annotation
+  add_dummy_pos
     (S_Call
        {
          name = "_SetUpRegisters";
@@ -215,7 +215,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
     let decode_inst ii =
       let ii = unalias ii in
       let open Asllib.AST in
-      let with_pos desc = Asllib.ASTUtils.add_dummy_annotation ~version:V0 desc in
+      let with_pos desc = Asllib.ASTUtils.add_dummy_pos ~version:V0 desc in
       let ( ^= ) x e = S_Decl (LDK_Let, LDI_Var x, None, Some e) |> with_pos in
       let lit v = E_Literal v |> with_pos in
       let liti i = lit (L_Int (Z.of_int i)) in


### PR DESCRIPTION
This PR enables maintaining the type inferred for each expression during typechecking as an annotation attached to the expression. The intention is to make this available for tools built on top of `aslref`.