### PR TITLE
[gen] Refactor communication edge representation

### DIFF
--- a/gen/PPCCompile_gen.ml
+++ b/gen/PPCCompile_gen.ml
@@ -88,7 +88,7 @@ module Make(O:Config)(C:sig val eieio : bool end) : XXXCompile_gen.S =
       do_ppo f
         (if ppoext then
           do_ppo
-            (fun rs k -> f (rs@[plain_edge (Rf Ext)]) k)
+            (fun rs k -> f (rs@[plain_edge (Communication (Rf,Ext))]) k)
             k
         else k)
 

--- a/gen/alt.ml
+++ b/gen/alt.ml
@@ -68,9 +68,9 @@ struct
   Also notice that we are more tolerant for Rfi.
  *)
 (* Assuming Dp is safe *)
-    | (Rf Int|Po(Same,Dir W,Dir R)),Dp _
-    | Dp _,(Rf Int|Po(Same,Dir W,Dir R)) -> true
-    | Dp (_,sd,_),(Ws Int|Po(Same,Dir W,Dir W)|Fr Int|Po(Same,Dir R,Dir W)) ->
+    | (Communication (Rf,Int)|Po(Same,Dir W,Dir R)),Dp _
+    | Dp _,(Communication (Rf,Int)|Po(Same,Dir W,Dir R)) -> true
+    | Dp (_,sd,_),(Communication (Co,Int)|Po(Same,Dir W,Dir W)|Communication (Fr,Int)|Po(Same,Dir R,Dir W)) ->
         not (po_safe sd (dir_src e1) (dir_tgt e2))
     | Po (sd1,_,_), Dp (_,sd2,_) ->
         not (po_safe sd1 (dir_src e1) (dir_tgt e1)) &&
@@ -81,10 +81,10 @@ struct
 (* Check Po is safe *)
     | Po (sd1,_,_),Po (sd2,_,_) ->
         not (po_safe (seq_sd sd1 sd2) (dir_src e1) (dir_tgt e2))
-    | Rf Int,Po (sd,_,_) ->
+    | Communication (Rf,Int),Po (sd,_,_) ->
         po_safe sd (dir_src e2) (dir_tgt e2) &&
         not (po_safe sd (dir_src e1) (dir_tgt e2))
-    | Po (sd,_,_),Rf Int ->
+    | Po (sd,_,_),Communication (Rf,Int) ->
         po_safe sd (dir_src e1) (dir_tgt e1) &&
         not (po_safe sd (dir_src e1) (dir_tgt e2))
 (* Allow Rmw *)
@@ -104,17 +104,17 @@ struct
 (*
   Now accept some internal with internal composition
  *)
-      | (Ws Int|Po(Same,Dir W,Dir W)
-        |Rf Int|Po(Same,Dir W,Dir R)
-        |Fr Int|Po(Same,Dir R,Dir W)|Insert _),(Dp (_,_,_)|Po (Diff,_,_))
+      | (Communication (Co,Int)|Po(Same,Dir W,Dir W)
+        |Communication (Rf,Int)|Po(Same,Dir W,Dir R)
+        |Communication (Fr,Int)|Po(Same,Dir R,Dir W)|Insert _),(Dp (_,_,_)|Po (Diff,_,_))
       | (Dp (_,_,_)|Po (Diff,_,_)),
-        (Ws Int|Po(Same,Dir W,Dir W)
-        |Rf Int|Po(Same,Dir W,Dir R)
-        |Fr Int|Po(Same,Dir R,Dir W)|Insert _)
+        (Communication (Co,Int)|Po(Same,Dir W,Dir W)
+        |Communication (Rf,Int)|Po(Same,Dir W,Dir R)
+        |Communication (Fr,Int)|Po(Same,Dir R,Dir W)|Insert _)
       | Dp (_,Diff,_),Po (Diff,_,_)
       | Po (Diff,_,_),Dp (_,Diff,_)
-      | (Rf Int|Po(Same,Dir W,Dir R)),Po (Same,_,_)
-      | Po (Same,_,_),(Rf Int|Po(Same,Dir W,Dir R))
+      | (Communication (Rf,Int)|Po(Same,Dir W,Dir R)),Po (Same,_,_)
+      | Po (Same,_,_),(Communication (Rf,Int)|Po(Same,Dir W,Dir R))
       | (Rmw _,_)|(_,Rmw _) -> true
       | _,_ ->
           (* Reject other internal followed by internal sequences *)
@@ -131,8 +131,8 @@ struct
       let r =
         match e1.edge,e2.edge with
 (* Two cases of allowed com composition *)
-        | (Ws _|Leave CWs|Back CWs|Fr _|Leave CFr|Back CFr),
-          (Rf _|Leave CRf|Back CRf) -> true
+        | (Communication (Co,_)|Leave Co|Back Co|Communication (Fr,_)|Leave Fr|Back Fr),
+          (Communication (Rf,_)|Leave Rf|Back Rf) -> true
 (* Rmw allowed to compose arbitrarily *)
         | (Rmw _,_)|(_,Rmw _) -> true
 (* Otherwise require alternance *)
@@ -143,8 +143,8 @@ struct
       let r =
         match e1.edge,e2.edge with
 (* Two cases of allowed com composition *)
-        | (Ws _|Leave CWs|Back CWs|Fr _|Leave CFr|Back CFr),
-          (Rf _|Leave CRf|Back CRf) -> true
+        | (Communication (Co,_)|Leave Co|Back Co|Communication (Fr,_)|Leave Fr|Back Fr),
+          (Communication (Rf,_)|Leave Rf|Back Rf) -> true
 (* Rmw allowed to compose arbitrarily *)
         | (Rmw _,_)|(_,Rmw _) -> true
 (* Otherwise accept composition *)
@@ -164,11 +164,11 @@ struct
 (*      eprintf "Choice: %s %s -> %b\n" (C.E.pp_edge e1) (C.E.pp_edge e2) r ; *)
       r
     let choice_uni e1 e2 =  match e1.edge,e2.edge with
-    | (Ws _,Ws _)
-    | (Fr _,Ws _)
-    | (Rf _,Fr _)
-    | (Rf _,Hat)
-    | (Hat,Fr _)
+    | (Communication (Co,_),Communication (Co,_))
+    | (Communication (Fr,_),Communication (Co,_))
+    | (Communication (Rf,_),Communication (Fr,_))
+    | (Communication (Rf,_),Hat)
+    | (Hat,Communication (Fr,_))
       -> C.E.get_ie e1 <> C.E.get_ie e2 (* Allow alternance *)
     | Po _,Po _ -> false
     | _,_ -> true
@@ -176,16 +176,16 @@ struct
     let choice_id _ _ = true
 
     let choice_free e1 e2 = match e1.edge,e2.edge with
-    | (Ws _,Ws _)
-    | (Fr _,Ws _)
-    | (Rf _,Fr _)
+    | (Communication (Co,_),Communication (Co,_))
+    | (Communication (Fr,_),Communication (Co,_))
+    | (Communication (Rf,_),Communication (Fr,_))
       -> false
     | _,_ -> true
 
     let choice_free_alt e1 e2 = match e1.edge,e2.edge with
-    | (Ws _,Ws _)
-    | (Fr _,Ws _)
-    | (Rf _,Fr _)
+    | (Communication (Co,_),Communication (Co,_))
+    | (Communication (Fr,_),Communication (Co,_))
+    | (Communication (Rf,_),Communication (Fr,_))
       -> C.E.get_ie e1 <> C.E.get_ie e2 (* Allow alternance *)
     | _,_ -> true
 
@@ -252,10 +252,10 @@ struct
  *)
     | Hat,Hat   (* Hat *)
 (* Ext Ext Only? *)
-    | Ws _,Ws _ (* -> Ws *)
-    | Fr _,Ws _ (* -> Fr*)
-    | Rf _,Fr _ (* -> Ws *)
-(*    Rf _,Fr _ (* -> Ws *) May be interesting, because
+    | Communication (Co,_),Communication (Co,_) (* -> Ws *)
+    | Communication (Fr,_),Communication (Co,_) (* -> Fr*)
+    | Communication (Rf,_),Communication (Fr,_) (* -> Ws *)
+(*    Communication (Rf,_),Communication (Fr,_) (* -> Ws *) May be interesting, because
       values are observed by outcome itself,
       also useful to add Fre after B-cumulativity *)
       ->  C.E.get_ie e1 <> C.E.get_ie e2 (* Allow alternance *)
@@ -263,8 +263,8 @@ struct
     | Id,_ -> compat_id e1.a2 (dir_src e2)
     | _,Id -> compat_id e2.a1 (dir_tgt e1)
 (* Fence cumulativity *)
-    | Rf _,Fenced (f,_,_,_)
-    | Fenced (f,_,_,_),Rf _ ->
+    | Communication (Rf,_),Fenced (f,_,_,_)
+    | Fenced (f,_,_,_),Communication (Rf,_) ->
         is_cumul f && choose O.choice safes po_safe xs ys e1 e2
     | _,_ -> choose O.choice safes po_safe xs ys e1 e2
 end
@@ -739,7 +739,11 @@ module Make(C:Builder.S)
     let er e = [plain_edge e]
     let safe =
       let k = [] in
-      let k = fold_ie (fun ie k -> er (Ws ie)::er (Fr ie)::k) k in k
+      let k =
+        fold_ie
+          (fun ie k ->
+            er (Communication (Co,ie))::er (Communication (Fr,ie))::k)
+          k in k
 
     let relax =
       let k = [] in
@@ -754,7 +758,7 @@ module Make(C:Builder.S)
         C.A.fold_dpw
           (fun dp k ->
             fold_sd (fun sd k -> er (Dp(dp,sd,Dir W))::k) k) k in
-      let k = fold_ie (fun ie k -> er (Rf ie)::k) k in
+      let k = fold_ie (fun ie k -> er (Communication (Rf,ie))::k) k in
       let k = fold_cum (fun fe sd d1 d2 k -> ac_fence fe sd d1 d2::k) k in
       let k = fold_cum (fun fe sd d1 d2 k -> bc_fence fe sd d1 d2::k) k in
       let k = er (Hat)::k in

--- a/gen/cat2config/translation.ml
+++ b/gen/cat2config/translation.ml
@@ -40,21 +40,19 @@ let get_ie edge =
   let open Code in
   match edge with
   | Id | Po _ | Dp _ | Fenced _ | Rmw _ -> Int
-  | Rf ie | Fr ie | Ws ie -> ie
+  | Communication (_, ie) -> ie
   | Leave _ | Back _ | Hat -> Ext
   | Insert _ | Store | Node _ -> Int
 
 let set_ie ie (edge : E.tedge) =
   match edge with
-  | Rf _ -> E.Rf ie
-  | Fr _ -> Fr ie
-  | Ws _ -> Ws ie
+  | Communication (com, _) -> E.Communication (com, ie)
   | _ -> raise (Invalid_argument "Cannot set ie on this edge kind")
 
 let get_sd (edge : E.tedge) =
   match edge with
   | Po (sd, _, _) | Dp (_, sd, _) | Fenced (_, sd, _, _) -> sd
-  | Leave _ | Back _ | Hat | Id | Rf _ | Fr _ | Ws _ | Rmw _ -> Same
+  | Leave _ | Back _ | Hat | Id | Communication _ | Rmw _ -> Same
   | Insert _ | Store | Node _ -> raise (Invalid_argument "Unexpected edge kind")
 
 let set_sd sd (edge : E.tedge) =
@@ -142,9 +140,9 @@ let build_tedges : prim_rel -> E.tedge list =
   let dp_tedges dp csel = [ E.Dp ((dp, csel), UnspecLoc, Code.Irr) ] in
   function
   | Prim "po" -> [ E.(Po (UnspecLoc, Code.Irr, Code.Irr)) ]
-  | Prim "fr" -> [ E.Fr UnspecCom ]
-  | Prim "co" -> [ E.Ws UnspecCom ]
-  | Prim "rf" -> [ E.Rf UnspecCom ]
+  | Prim "fr" -> [ E.Communication (Fr, UnspecCom) ]
+  | Prim "co" -> [ E.Communication (Co, UnspecCom) ]
+  | Prim "rf" -> [ E.Communication (Rf, UnspecCom) ]
   | Fence f -> [ E.Fenced (A.Barrier f, UnspecLoc, Code.Irr, Code.Irr) ]
   | Prim "amo" -> [ E.Rmw A.RMW.AllAmo ]
   | Prim "lxsx" -> [ E.Rmw A.RMW.LrSc ]

--- a/gen/common/code.ml
+++ b/gen/common/code.ml
@@ -160,7 +160,7 @@ let pp_com = function
   | Fr -> "Fr"
   | Co -> "Co"
 
-let fold_com f r = f Rf (f Fr (f Co r))
+let fold_com f r = f Co (f Fr (f Rf r))
 
 (* Info in tests *)
 type info = (string * string) list

--- a/gen/common/code.ml
+++ b/gen/common/code.ml
@@ -153,14 +153,14 @@ let checks =
 
 
 (* Com relation *)
-type com =  CRf | CFr | CWs
+type com =  Rf | Fr | Co
 
 let pp_com = function
-  | CRf -> "Rf"
-  | CFr -> "Fr"
-  | CWs -> "Co"
+  | Rf -> "Rf"
+  | Fr -> "Fr"
+  | Co -> "Co"
 
-let fold_com f r = f CRf (f CFr (f CWs r))
+let fold_com f r = f Rf (f Fr (f Co r))
 
 (* Info in tests *)
 type info = (string * string) list

--- a/gen/common/code.ml
+++ b/gen/common/code.ml
@@ -172,20 +172,20 @@ let checks =
 
 
 (* Com relation *)
-type com =  CRf | CFr | CWs
+type com =  Rf | Fr | Co
 
 let equal_com c1 c2 = match c1,c2 with
-  | CRf,CRf
-  | CFr,CFr
-  | CWs,CWs -> true
-  | (CRf|CFr|CWs),_ -> false
+  | Rf,Rf
+  | Fr,Fr
+  | Co,Co -> true
+  | (Rf|Fr|Co),_ -> false
 
 let pp_com = function
-  | CRf -> "Rf"
-  | CFr -> "Fr"
-  | CWs -> "Co"
+  | Rf -> "Rf"
+  | Fr -> "Fr"
+  | Co -> "Co"
 
-let fold_com f r = f CRf (f CFr (f CWs r))
+let fold_com f r = f Rf (f Fr (f Co r))
 
 (* Info in tests *)
 type info = (string * string) list

--- a/gen/common/code.mli
+++ b/gen/common/code.mli
@@ -76,7 +76,7 @@ val pp_check : check -> string
 val checks : string list
 
 (* Com *)
-type com =  CRf | CFr | CWs
+type com =  Rf | Fr | Co
 
 val equal_com : com -> com -> bool
 val pp_com : com -> string

--- a/gen/common/code.mli
+++ b/gen/common/code.mli
@@ -74,7 +74,7 @@ val pp_check : check -> string
 val checks : string list
 
 (* Com *)
-type com =  CRf | CFr | CWs
+type com =  Rf | Fr | Co
 
 val pp_com : com -> string
 val fold_com : (com -> 'a -> 'a) -> 'a -> 'a

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -50,7 +50,7 @@ module type S = sig
 
 (* edge proper *)
   type tedge =
-    | Rf of ie | Fr of ie | Ws of ie
+    | Communication of com * ie
     | Po of sd*extr*extr | Fenced of fence*sd*extr*extr
     | Dp of dp*sd*extr
     | Leave of com (* Leave thread *)
@@ -228,7 +228,7 @@ and module RMW = A.RMW = struct
 
 (* edge proper *)
   type tedge =
-    | Rf of ie | Fr of ie | Ws of ie
+    | Communication of com * ie
     | Po of sd*extr*extr | Fenced of fence*sd*extr*extr
     | Dp of dp*sd*extr
     | Leave of com
@@ -243,23 +243,23 @@ and module RMW = A.RMW = struct
 
   let is_id = function
     | Id -> true
-    | Store|Insert _|Hat|Rmw _|Rf _|Fr _|Ws _|Po (_, _, _)
+    | Store|Insert _|Hat|Rmw _|Communication _|Po (_, _, _)
     | Fenced (_, _, _, _)|Dp (_, _, _)|Leave _|Back _|Node _ -> false
 
   let is_insert_store = function
     | Store|Insert _ -> true
-    | Id|Hat|Rmw _|Rf _|Fr _|Ws _|Po (_, _, _)
+    | Id|Hat|Rmw _|Communication _|Po (_, _, _)
     | Fenced (_, _, _, _)|Dp (_, _, _)|Leave _|Back _|Node _ -> false
 
   let is_node = function
     | Node _ -> true
-    | Id|Hat|Rmw _|Rf _|Fr _|Ws _|Po (_, _, _)
+    | Id|Hat|Rmw _|Communication _|Po (_, _, _)
     | Fenced (_, _, _, _)|Dp (_, _, _)|Leave _|Back _|Insert _
     | Store -> false
 
   let is_non_pseudo = function
     | Store|Insert _ |Id|Node _-> false
-    | Hat|Rmw _|Rf _|Fr _|Ws _|Po (_, _, _)
+    | Hat|Rmw _|Communication _|Po (_, _, _)
     | Fenced (_, _, _, _)|Dp (_, _, _)|Leave _|Back _ -> true
 
   let is_dp_addr = function
@@ -285,13 +285,16 @@ and module RMW = A.RMW = struct
   | _, None, None -> ""
   | _, _, _ -> sprintf "%s%s" (pp_atom_option a1) (pp_atom_option a2)
 
+  let pp_communication_compat compat com ie =
+    let com = match com with
+    | Co when compat -> "Ws"
+    | _ -> pp_com com in
+    match ie with
+    | UnspecCom -> com
+    | _ -> sprintf "%s%s" com (pp_ie ie)
+
   let pp_tedge_compat compat = function
-    | Rf UnspecCom -> sprintf "Rf"
-    | Fr UnspecCom -> sprintf "Fr"
-    | Ws UnspecCom -> if compat then sprintf "Ws" else sprintf "Co"
-    | Rf ie -> sprintf "Rf%s" (pp_ie ie)
-    | Fr ie -> sprintf "Fr%s" (pp_ie ie)
-    | Ws ie -> if compat then sprintf "Ws%s" (pp_ie ie) else sprintf "Co%s" (pp_ie ie)
+    | Communication (com,ie) -> pp_communication_compat compat com ie
     | Po (UnspecLoc,Irr,Irr) -> "Po"
     | Po (sd,e1,e2) ->
       sprintf "Po%s%s%s" (pp_sd sd) (pp_extr e1) (pp_extr e2)
@@ -344,17 +347,17 @@ and module RMW = A.RMW = struct
 let pp_dp_default tag sd e = sprintf "%s%s%s" tag (pp_sd sd) (pp_extr e)
 
   let do_dir_tgt_com = function
-    | CRf -> Dir R
-    | CWs|CFr -> Dir W
+    | Rf -> Dir R
+    | Co|Fr -> Dir W
 
  and do_dir_src_com = function
-   | CRf|CWs -> Dir W
-   | CFr -> Dir R
+   | Rf|Co -> Dir W
+   | Fr -> Dir R
 
   let do_dir_tgt e = match e with
   | Po(_,_,e)| Fenced(_,_,_,e)|Dp (_,_,e) -> e
-  | Rf _| Hat -> Dir R
-  | Ws _|Fr _|Rmw _  -> Dir W
+  | Communication (Rf,_)| Hat -> Dir R
+  | Communication ((Co|Fr),_)|Rmw _  -> Dir W
   | Leave c|Back c -> do_dir_tgt_com c
   | Id -> NoDir
   | Insert _ -> NoDir
@@ -364,8 +367,8 @@ let pp_dp_default tag sd e = sprintf "%s%s%s" tag (pp_sd sd) (pp_extr e)
 
   and do_dir_src e = match e with
   | Po(_,e,_)| Fenced(_,_,e,_) -> e
-  | Dp _|Fr _|Hat|Rmw _ -> Dir R
-  | Ws _|Rf _ -> Dir W
+  | Dp _|Communication (Fr,_)|Hat|Rmw _ -> Dir R
+  | Communication ((Co|Rf),_) -> Dir W
   | Leave c|Back c -> do_dir_src_com c
   | Id -> NoDir
   | Insert _ -> NoDir
@@ -374,19 +377,17 @@ let pp_dp_default tag sd e = sprintf "%s%s%s" tag (pp_sd sd) (pp_extr e)
 
   let do_loc_sd e = match e with
   | Po (sd,_,_) | Fenced (_,sd,_,_) | Dp (_,sd,_) -> sd
-  | Insert _|Store|Node _|Fr _|Ws _|Rf _|Hat|Rmw _|Id|Leave _|Back _ -> Same
+  | Insert _|Store|Node _|Communication _|Hat|Rmw _|Id|Leave _|Back _ -> Same
 
   let do_is_diff e = Code.is_diff_loc @@ do_loc_sd e
 
 let fold_tedges_compat f r =
-  let r = fold_ie wildcard (fun ie -> f (Ws ie)) r in
+  let r = fold_ie wildcard (fun ie -> f (Communication (Co,ie))) r in
   let r = RMW.fold_rmw_compat (fun rmw -> f (Rmw rmw)) r
   in r
 
 let fold_tedges f r =
-  let r = fold_ie wildcard (fun ie -> f (Rf ie)) r in
-  let r = fold_ie wildcard (fun ie -> f (Fr ie)) r in
-  let r = fold_ie wildcard (fun ie -> f (Ws ie)) r in
+  let r = fold_com (fun com r -> fold_ie wildcard (fun ie -> f (Communication (com,ie))) r) r in
   let r = RMW.fold_rmw wildcard (fun rmw -> f (Rmw rmw)) r in
   let r = fold_sd_extr_extr wildcard (fun sd e1 e2 r -> f (Po (sd,e1,e2)) r) r in
   let r = F.fold_all_fences (fun fe -> f (Insert fe)) r in
@@ -544,10 +545,10 @@ let fold_tedges f r =
     if do_self && instr_atom != None then
       iter_ie
         (fun ie ->
-           add_lxm_edge (sprintf "Iff%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); } ;
-           add_lxm_edge (sprintf "Irf%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); } ;
-           add_lxm_edge (sprintf "Fif%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); } ;
-           add_lxm_edge (sprintf "Ifr%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); });
+           add_lxm_edge (sprintf "Iff%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Communication (Rf,ie)); } ;
+           add_lxm_edge (sprintf "Irf%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Communication (Rf,ie)); } ;
+           add_lxm_edge (sprintf "Fif%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Communication (Fr,ie)); } ;
+           add_lxm_edge (sprintf "Ifr%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Communication (Fr,ie)); });
     ()
 
   let fold_pp_edges f =
@@ -638,14 +639,14 @@ let fold_tedges f r =
   | Po(sd,src,_) -> Po (sd,src,Dir d)
   | Fenced(f,sd,src,_) -> Fenced(f,sd,src,Dir d)
   | Dp (dp,sd,_) -> Dp (dp,sd,Dir d)
-  | Rf _ | Hat
-  | Insert _|Store|Id|Node _|Ws _|Fr _|Rmw _|Leave _|Back _-> e
+  | Communication (Rf,_) | Hat
+  | Insert _|Store|Id|Node _|Communication ((Co|Fr),_)|Rmw _|Leave _|Back _-> e
 
   and do_set_src d e = match e with
   | Po(sd,_,tgt) -> Po(sd,Dir d,tgt)
   | Fenced(f,sd,_,tgt) -> Fenced(f,sd,Dir d,tgt)
-  | Fr _|Hat|Dp _
-  | Insert _|Store|Id|Node _|Ws _|Rf _|Rmw _|Leave _|Back _ -> e
+  | Communication (Fr,_)|Hat|Dp _
+  | Insert _|Store|Id|Node _|Communication ((Co|Rf),_)|Rmw _|Leave _|Back _ -> e
 
   let set_tgt d e = { e with edge = do_set_tgt d e.edge ; }
   and set_src d e = { e with edge = do_set_src d e.edge ; }
@@ -655,7 +656,7 @@ let fold_tedges f r =
 
   let get_ie e = match e.edge with
   | Id |Po _|Dp _|Fenced _|Rmw _ -> Int
-  | Rf ie|Fr ie|Ws ie -> ie
+  | Communication (_,ie) -> ie
   | Leave _|Back _|Hat -> Ext
   | Insert _|Store|Node _ -> Int
 
@@ -681,17 +682,17 @@ let fold_tedges f r =
       end
 
   let is_ext e = match e.edge with
-  | Rf Ext|Fr Ext|Ws Ext
+  | Communication (_,Ext)
   | Leave _|Back _ -> true
   | _ -> false
 
   let is_com e = match e.edge with
-  | Rf _|Fr _|Ws _|Leave _|Back _| Hat -> true
+  | Communication _|Leave _|Back _| Hat -> true
   | _ -> false
 
   let is_fetch e = match e.edge with
-  | Rf _ -> is_ifetch e.a2
-  | Fr _ -> is_ifetch e.a1
+  | Communication (Rf,_) -> is_ifetch e.a2
+  | Communication (Fr,_) -> is_ifetch e.a1
   | _ -> is_ifetch e.a1 || ( loc_sd e = Same && is_ifetch e.a2)
 
   let compat_atoms a1 a2 = match merge_atoms a1 a2 with
@@ -736,9 +737,8 @@ let fold_tedges f r =
     | Insert _|Store|Id|Node _
     | Hat |Leave _|Back _
       -> f e acc
-    | Rf com -> expand_com com ( fun new_com -> f {e with edge = Rf(new_com)}) acc
-    | Fr com -> expand_com com ( fun new_com -> f {e with edge = Fr(new_com)}) acc
-    | Ws com -> expand_com com ( fun new_com -> f {e with edge = Ws(new_com)}) acc
+    | Communication (com,ie) ->
+        expand_com ie (fun new_ie -> f {e with edge=Communication (com,new_ie)}) acc
     | Rmw rmw ->
         let expand_rmw_list = A.RMW.expand_rmw rmw in
         List.fold_left ( fun acc new_rmw -> f {e with edge=Rmw(new_rmw);} acc) acc expand_rmw_list
@@ -1028,9 +1028,10 @@ let fold_tedges f r =
     [plain_edge (Po (seq_sd e1 e2,dir_src e1,dir_tgt e2))]::k
 
   let com e1 e2 k = match e1.edge,e2.edge with
-  | Ws _,Ws _
-  | Fr _,Ws _ -> [e1]::k
-  | Rf _,Fr _ -> [plain_edge (Ws Int)]::k
+  | Communication (Co,_),Communication (Co,_)
+  | Communication (Fr,_),Communication (Co,_) -> [e1]::k
+  | Communication (Rf,_),Communication (Fr,_) ->
+      [plain_edge (Communication (Co,Int))]::k
   | _,_ -> k
 
   let compact_sequence xs ys e1 e2 =

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -356,8 +356,9 @@ let pp_dp_default tag sd e = sprintf "%s%s%s" tag (pp_sd sd) (pp_extr e)
 
   let do_dir_tgt e = match e with
   | Po(_,_,e)| Fenced(_,_,_,e)|Dp (_,_,e) -> e
-  | Communication (Rf,_)| Hat -> Dir R
-  | Communication ((Co|Fr),_)|Rmw _  -> Dir W
+  | Hat -> Dir R
+  | Rmw _  -> Dir W
+  | Communication (c, _)
   | Leave c|Back c -> do_dir_tgt_com c
   | Id -> NoDir
   | Insert _ -> NoDir
@@ -367,8 +368,8 @@ let pp_dp_default tag sd e = sprintf "%s%s%s" tag (pp_sd sd) (pp_extr e)
 
   and do_dir_src e = match e with
   | Po(_,e,_)| Fenced(_,_,e,_) -> e
-  | Dp _|Communication (Fr,_)|Hat|Rmw _ -> Dir R
-  | Communication ((Co|Rf),_) -> Dir W
+  | Dp _|Hat|Rmw _ -> Dir R
+  | Communication(c, _)
   | Leave c|Back c -> do_dir_src_com c
   | Id -> NoDir
   | Insert _ -> NoDir
@@ -639,14 +640,14 @@ let fold_tedges f r =
   | Po(sd,src,_) -> Po (sd,src,Dir d)
   | Fenced(f,sd,src,_) -> Fenced(f,sd,src,Dir d)
   | Dp (dp,sd,_) -> Dp (dp,sd,Dir d)
-  | Communication (Rf,_) | Hat
-  | Insert _|Store|Id|Node _|Communication ((Co|Fr),_)|Rmw _|Leave _|Back _-> e
+  | Communication _ | Hat
+  | Insert _|Store|Id|Node _|Rmw _|Leave _|Back _-> e
 
   and do_set_src d e = match e with
   | Po(sd,_,tgt) -> Po(sd,Dir d,tgt)
   | Fenced(f,sd,_,tgt) -> Fenced(f,sd,Dir d,tgt)
-  | Communication (Fr,_)|Hat|Dp _
-  | Insert _|Store|Id|Node _|Communication ((Co|Rf),_)|Rmw _|Leave _|Back _ -> e
+  | Communication _|Hat|Dp _
+  | Insert _|Store|Id|Node _|Rmw _|Leave _|Back _ -> e
 
   let set_tgt d e = { e with edge = do_set_tgt d e.edge ; }
   and set_src d e = { e with edge = do_set_src d e.edge ; }

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -50,7 +50,7 @@ module type S = sig
 
 (* edge proper *)
   type tedge =
-    | Rf of ie | Fr of ie | Ws of ie
+    | Communication of com * ie
     | Po of sd*extr*extr | Fenced of fence*sd*extr*extr
     | Dp of dp*sd*extr
     | Leave of com (* Leave thread *)
@@ -230,7 +230,7 @@ and module RMW = A.RMW = struct
 
 (* edge proper *)
   type tedge =
-    | Rf of ie | Fr of ie | Ws of ie
+    | Communication of com * ie
     | Po of sd*extr*extr | Fenced of fence*sd*extr*extr
     | Dp of dp*sd*extr
     | Leave of com
@@ -245,23 +245,23 @@ and module RMW = A.RMW = struct
 
   let is_id = function
     | Id -> true
-    | Store|Insert _|Hat|Rmw _|Rf _|Fr _|Ws _|Po (_, _, _)
+    | Store|Insert _|Hat|Rmw _|Communication _|Po (_, _, _)
     | Fenced (_, _, _, _)|Dp (_, _, _)|Leave _|Back _|Node _ -> false
 
   let is_insert_store = function
     | Store|Insert _ -> true
-    | Id|Hat|Rmw _|Rf _|Fr _|Ws _|Po (_, _, _)
+    | Id|Hat|Rmw _|Communication _|Po (_, _, _)
     | Fenced (_, _, _, _)|Dp (_, _, _)|Leave _|Back _|Node _ -> false
 
   let is_node = function
     | Node _ -> true
-    | Id|Hat|Rmw _|Rf _|Fr _|Ws _|Po (_, _, _)
+    | Id|Hat|Rmw _|Communication _|Po (_, _, _)
     | Fenced (_, _, _, _)|Dp (_, _, _)|Leave _|Back _|Insert _
     | Store -> false
 
   let is_non_pseudo = function
     | Store|Insert _ |Id|Node _-> false
-    | Hat|Rmw _|Rf _|Fr _|Ws _|Po (_, _, _)
+    | Hat|Rmw _|Communication _|Po (_, _, _)
     | Fenced (_, _, _, _)|Dp (_, _, _)|Leave _|Back _ -> true
 
   let is_dp_addr = function
@@ -287,13 +287,16 @@ and module RMW = A.RMW = struct
   | _, None, None -> ""
   | _, _, _ -> sprintf "%s%s" (pp_atom_option a1) (pp_atom_option a2)
 
+  let pp_communication_compat compat com ie =
+    let com = match com with
+    | Co when compat -> "Ws"
+    | _ -> pp_com com in
+    match ie with
+    | UnspecCom -> com
+    | _ -> sprintf "%s%s" com (pp_ie ie)
+
   let pp_tedge_compat compat = function
-    | Rf UnspecCom -> sprintf "Rf"
-    | Fr UnspecCom -> sprintf "Fr"
-    | Ws UnspecCom -> if compat then sprintf "Ws" else sprintf "Co"
-    | Rf ie -> sprintf "Rf%s" (pp_ie ie)
-    | Fr ie -> sprintf "Fr%s" (pp_ie ie)
-    | Ws ie -> if compat then sprintf "Ws%s" (pp_ie ie) else sprintf "Co%s" (pp_ie ie)
+    | Communication (com,ie) -> pp_communication_compat compat com ie
     | Po (UnspecLoc,Irr,Irr) -> "Po"
     | Po (sd,e1,e2) ->
       sprintf "Po%s%s%s" (pp_sd sd) (pp_extr e1) (pp_extr e2)
@@ -346,17 +349,18 @@ and module RMW = A.RMW = struct
 let pp_dp_default tag sd e = sprintf "%s%s%s" tag (pp_sd sd) (pp_extr e)
 
   let do_dir_tgt_com = function
-    | CRf -> Dir R
-    | CWs|CFr -> Dir W
+    | Rf -> Dir R
+    | Co|Fr -> Dir W
 
  and do_dir_src_com = function
-   | CRf|CWs -> Dir W
-   | CFr -> Dir R
+   | Rf|Co -> Dir W
+   | Fr -> Dir R
 
   let do_dir_tgt e = match e with
   | Po(_,_,e)| Fenced(_,_,_,e)|Dp (_,_,e) -> e
-  | Rf _| Hat -> Dir R
-  | Ws _|Fr _|Rmw _  -> Dir W
+  | Hat -> Dir R
+  | Rmw _  -> Dir W
+  | Communication (c, _)
   | Leave c|Back c -> do_dir_tgt_com c
   | Id -> NoDir
   | Insert _ -> NoDir
@@ -366,8 +370,8 @@ let pp_dp_default tag sd e = sprintf "%s%s%s" tag (pp_sd sd) (pp_extr e)
 
   and do_dir_src e = match e with
   | Po(_,e,_)| Fenced(_,_,e,_) -> e
-  | Dp _|Fr _|Hat|Rmw _ -> Dir R
-  | Ws _|Rf _ -> Dir W
+  | Dp _|Hat|Rmw _ -> Dir R
+  | Communication(c, _)
   | Leave c|Back c -> do_dir_src_com c
   | Id -> NoDir
   | Insert _ -> NoDir
@@ -376,19 +380,17 @@ let pp_dp_default tag sd e = sprintf "%s%s%s" tag (pp_sd sd) (pp_extr e)
 
   let do_loc_sd e = match e with
   | Po (sd,_,_) | Fenced (_,sd,_,_) | Dp (_,sd,_) -> sd
-  | Insert _|Store|Node _|Fr _|Ws _|Rf _|Hat|Rmw _|Id|Leave _|Back _ -> Same
+  | Insert _|Store|Node _|Communication _|Hat|Rmw _|Id|Leave _|Back _ -> Same
 
   let do_is_diff e = Code.is_diff_loc @@ do_loc_sd e
 
 let fold_tedges_compat f r =
-  let r = fold_ie wildcard (fun ie -> f (Ws ie)) r in
+  let r = fold_ie wildcard (fun ie -> f (Communication (Co,ie))) r in
   let r = RMW.fold_rmw_compat (fun rmw -> f (Rmw rmw)) r
   in r
 
 let fold_tedges f r =
-  let r = fold_ie wildcard (fun ie -> f (Rf ie)) r in
-  let r = fold_ie wildcard (fun ie -> f (Fr ie)) r in
-  let r = fold_ie wildcard (fun ie -> f (Ws ie)) r in
+  let r = fold_com (fun com r -> fold_ie wildcard (fun ie -> f (Communication (com,ie))) r) r in
   let r = RMW.fold_rmw wildcard (fun rmw -> f (Rmw rmw)) r in
   let r = fold_sd_extr_extr wildcard (fun sd e1 e2 r -> f (Po (sd,e1,e2)) r) r in
   let r = F.fold_all_fences (fun fe -> f (Insert fe)) r in
@@ -428,9 +430,8 @@ let fold_tedges f r =
   let equal_atomo = Option.equal (fun a1 a2 -> A.compare_atom a1 a2 = 0)
 
   let equal_tedge lhs rhs = match lhs,rhs with
-  | Rf ie1,Rf ie2
-  | Fr ie1,Fr ie2
-  | Ws ie1,Ws ie2 -> Code.equal_ie ie1 ie2
+  | Communication (c1,ie1),Communication (c2,ie2) ->
+      Code.equal_com c1 c2 && Code.equal_ie ie1 ie2
   | Po (sd1,e11,e12),Po (sd2,e21,e22) ->
       Code.equal_sd sd1 sd2 && Code.equal_extr e11 e21 &&
       Code.equal_extr e12 e22
@@ -447,7 +448,7 @@ let fold_tedges f r =
   | Insert f1,Insert f2 -> F.compare_fence f1 f2 = 0
   | Node d1,Node d2 -> Code.equal_extr (Dir d1) (Dir d2)
   | Rmw rmw1,Rmw rmw2 -> RMW.equal_rmw rmw1 rmw2
-  | (Rf _|Fr _|Ws _|Po _|Fenced _|Dp _|Leave _|Back _|Id
+  | (Communication _|Po _|Fenced _|Dp _|Leave _|Back _|Id
     |Insert _|Store|Node _|Hat|Rmw _),_ -> false
 
   let equal_edge_atoms lhs rhs =
@@ -575,10 +576,10 @@ let fold_tedges f r =
     if do_self && instr_atom != None then
       iter_ie
         (fun ie ->
-           add_lxm_edge (sprintf "Iff%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); } ;
-           add_lxm_edge (sprintf "Irf%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Rf ie); } ;
-           add_lxm_edge (sprintf "Fif%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); } ;
-           add_lxm_edge (sprintf "Ifr%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Fr ie); });
+           add_lxm_edge (sprintf "Iff%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Communication (Rf,ie)); } ;
+           add_lxm_edge (sprintf "Irf%s" (pp_ie ie)) { a1=None; a2=instr_atom; edge=(Communication (Rf,ie)); } ;
+           add_lxm_edge (sprintf "Fif%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Communication (Fr,ie)); } ;
+           add_lxm_edge (sprintf "Ifr%s" (pp_ie ie)) { a1=instr_atom; a2=None; edge=(Communication (Fr,ie)); });
     ()
 
   let fold_pp_edges f =
@@ -669,14 +670,14 @@ let fold_tedges f r =
   | Po(sd,src,_) -> Po (sd,src,Dir d)
   | Fenced(f,sd,src,_) -> Fenced(f,sd,src,Dir d)
   | Dp (dp,sd,_) -> Dp (dp,sd,Dir d)
-  | Rf _ | Hat
-  | Insert _|Store|Id|Node _|Ws _|Fr _|Rmw _|Leave _|Back _-> e
+  | Communication _ | Hat
+  | Insert _|Store|Id|Node _|Rmw _|Leave _|Back _-> e
 
   and do_set_src d e = match e with
   | Po(sd,_,tgt) -> Po(sd,Dir d,tgt)
   | Fenced(f,sd,_,tgt) -> Fenced(f,sd,Dir d,tgt)
-  | Fr _|Hat|Dp _
-  | Insert _|Store|Id|Node _|Ws _|Rf _|Rmw _|Leave _|Back _ -> e
+  | Communication _|Hat|Dp _
+  | Insert _|Store|Id|Node _|Rmw _|Leave _|Back _ -> e
 
   let set_tgt d e = { e with edge = do_set_tgt d e.edge ; }
   and set_src d e = { e with edge = do_set_src d e.edge ; }
@@ -686,7 +687,7 @@ let fold_tedges f r =
 
   let get_ie e = match e.edge with
   | Id |Po _|Dp _|Fenced _|Rmw _ -> Int
-  | Rf ie|Fr ie|Ws ie -> ie
+  | Communication (_,ie) -> ie
   | Leave _|Back _|Hat -> Ext
   | Insert _|Store|Node _ -> Int
 
@@ -712,17 +713,17 @@ let fold_tedges f r =
       end
 
   let is_ext e = match e.edge with
-  | Rf Ext|Fr Ext|Ws Ext
+  | Communication (_,Ext)
   | Leave _|Back _ -> true
   | _ -> false
 
   let is_com e = match e.edge with
-  | Rf _|Fr _|Ws _|Leave _|Back _| Hat -> true
+  | Communication _|Leave _|Back _| Hat -> true
   | _ -> false
 
   let is_fetch e = match e.edge with
-  | Rf _ -> is_ifetch e.a2
-  | Fr _ -> is_ifetch e.a1
+  | Communication (Rf,_) -> is_ifetch e.a2
+  | Communication (Fr,_) -> is_ifetch e.a1
   | _ -> is_ifetch e.a1 || ( loc_sd e = Same && is_ifetch e.a2)
 
   let compat_atoms a1 a2 = match merge_atoms a1 a2 with
@@ -767,9 +768,8 @@ let fold_tedges f r =
     | Insert _|Store|Id|Node _
     | Hat |Leave _|Back _
       -> f e acc
-    | Rf com -> expand_com com ( fun new_com -> f {e with edge = Rf(new_com)}) acc
-    | Fr com -> expand_com com ( fun new_com -> f {e with edge = Fr(new_com)}) acc
-    | Ws com -> expand_com com ( fun new_com -> f {e with edge = Ws(new_com)}) acc
+    | Communication (com,ie) ->
+        expand_com ie (fun new_ie -> f {e with edge=Communication (com,new_ie)}) acc
     | Rmw rmw ->
         let expand_rmw_list = A.RMW.expand_rmw rmw in
         List.fold_left ( fun acc new_rmw -> f {e with edge=Rmw(new_rmw);} acc) acc expand_rmw_list
@@ -1059,9 +1059,10 @@ let fold_tedges f r =
     [plain_edge (Po (seq_sd e1 e2,dir_src e1,dir_tgt e2))]::k
 
   let com e1 e2 k = match e1.edge,e2.edge with
-  | Ws _,Ws _
-  | Fr _,Ws _ -> [e1]::k
-  | Rf _,Fr _ -> [plain_edge (Ws Int)]::k
+  | Communication (Co,_),Communication (Co,_)
+  | Communication (Fr,_),Communication (Co,_) -> [e1]::k
+  | Communication (Rf,_),Communication (Fr,_) ->
+      [plain_edge (Communication (Co,Int))]::k
   | _,_ -> k
 
   let compact_sequence xs ys e1 e2 =

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -489,7 +489,7 @@ let diff_loc e = Code.is_diff_loc @@ E.loc_sd e
 let same_proc e = E.get_ie e = Int
 let diff_proc e = E.get_ie e = Ext
 let int_com e = match e.E.edge with
-  | E.Rf Int|E.Fr Int|E.Ws Int -> true
+  | E.Communication (_,Int) -> true
   | _ -> false
 
 
@@ -726,7 +726,7 @@ let remove_store n0 =
     begin
       let p = find_non_pseudo_prev m.prev in
       match p.edge.E.edge with
-      | (E.Rf Ext | E.Fr Ext) ->
+      | (E.Communication (Rf,Ext) | E.Communication (Fr,Ext)) ->
         Warn.fatal "Insert pseudo edge %s appears after external communication edge %s"
         (E.pp_edge m.edge) (E.pp_edge p.edge)
       | _ -> ()
@@ -1609,7 +1609,7 @@ let merge_changes n nss =
     let k = IntSet.empty in
     let k = if e.proc >= 0 then IntSet.add e.proc k else k in
     let k = match n.edge.E.edge with
-    | E.Rf _ -> IntSet.add n.next.evt.proc k
+    | E.Communication (Rf,_) -> IntSet.add n.next.evt.proc k
     | _ -> k in
     k
 

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -488,7 +488,7 @@ let diff_loc e = Code.is_diff_loc @@ E.loc_sd e
 let same_proc e = E.get_ie e = Int
 let diff_proc e = E.get_ie e = Ext
 let int_com e = match e.E.edge with
-  | E.Rf Int|E.Fr Int|E.Ws Int -> true
+  | E.Communication (_,Int) -> true
   | _ -> false
 
 
@@ -728,7 +728,7 @@ let remove_store n0 =
     begin
       let p = find_non_pseudo_prev m.prev in
       match p.edge.E.edge with
-      | (E.Rf Ext | E.Fr Ext) ->
+      | (E.Communication (Rf,Ext) | E.Communication (Fr,Ext)) ->
         Warn.fatal "Insert pseudo edge %s appears after external communication edge %s"
         (E.pp_edge m.edge) (E.pp_edge p.edge)
       | _ -> ()
@@ -1611,7 +1611,7 @@ let merge_changes n nss =
     let k = IntSet.empty in
     let k = if e.proc >= 0 then IntSet.add e.proc k else k in
     let k = match n.edge.E.edge with
-    | E.Rf _ -> IntSet.add n.next.evt.proc k
+    | E.Communication (Rf,_) -> IntSet.add n.next.evt.proc k
     | _ -> k in
     k
 

--- a/gen/diy.ml
+++ b/gen/diy.ml
@@ -133,16 +133,17 @@ open C.R
   let er e = [plain_edge e]
 
   let gen_thin n =
-    let lr = [er (Rf Int); er (Rf Ext)]
+    let lr = [er (Communication (Rf,Int)); er (Communication (Rf,Ext))]
     and ls = C.ppo Misc.cons [] in
     M.gen ~relax:lr ~safe:ls n
 
 
   let gen_uni n =
-    let lr = [er (Rf Int); er (Rf Ext)]
+    let lr = [er (Communication (Rf,Int)); er (Communication (Rf,Ext))]
     and ls =
-      [er (Ws Int); er (Ws Ext); er (Fr Int);
-       er (Fr Ext); er (Po (Same,Irr,Irr))] in
+      [er (Communication (Co,Int)); er (Communication (Co,Ext));
+       er (Communication (Fr,Int)); er (Communication (Fr,Ext));
+       er (Po (Same,Irr,Irr))] in
     M.gen ~relax:lr ~safe:ls n
 
   let go n (*size*) orl olr ols (*relax and safe lists*) =

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -118,7 +118,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           let e = m.C.C.edge in
           let open C.E in
           match e.edge with
-          | Rf _ | Fr _ | Ws _ | Hat
+          | Communication _ | Hat
           | Back _|Leave _ -> true
           | Rmw rmw -> RMW.show_rmw_reg rmw
           | Po _ | Fenced _ | Dp _ ->

--- a/gen/namer.ml
+++ b/gen/namer.ml
@@ -46,6 +46,8 @@ module Make
        open E
 
        let pp_com c = Misc.lowercase (pp_com c)
+       let pp_communication com ie =
+         Misc.lowercase (sprintf "%s%s" (pp_com com) (pp_ie ie))
        let pp_fence = F.pp_fence
        let pp_dp = F.pp_dp
        let pp_atom = A.pp_atom
@@ -57,12 +59,7 @@ module Make
          | Fenced (f,Diff,_,_) -> Some (Misc.lowercase (pp_fence f))
          | Dp (dp,Same,_) -> Some (Misc.lowercase (pp_dp dp) ^ "s")
          | Dp (dp,Diff,_) -> Some (Misc.lowercase (pp_dp dp))
-         | Rf Int -> Some "rfi"
-         | Ws Int -> Some "coi"
-         | Fr Int -> Some "fri"
-         | Rf Ext -> Some "rfe"
-         | Ws Ext -> Some "coe"
-         | Fr Ext -> Some "fre"
+         | Communication (com,(Int|Ext as ie)) -> Some (pp_communication com ie)
          | Rmw rmw ->
             (* Note: backward compatible item ("rmw") in names *)
             Some (Misc.lowercase (E.RMW.pp_rmw true rmw))
@@ -76,14 +73,14 @@ module Make
        let ambiguous_target = function
          | Po _|Fenced _|Dp _
            -> true
-         |Rf _|Ws _|Fr _
+         |Communication (_,_)
          |Id|Hat|Leave _|Back _
          |Insert _|Store|Node _|Rmw _
            -> false
        and ambiguous_source = function
          | Po _|Fenced _
            -> true
-         |Dp _| Rf _|Ws _|Fr _
+         |Dp _| Communication (_,_)
          |Id|Hat|Leave _|Back _
          |Insert _|Store|Node _|Rmw _
            -> false
@@ -116,25 +113,25 @@ module Make
          | [] -> None
 
        let rec count_a = function
-         | {edge=(Rf Ext|Fr Ext|Ws Ext); a2=Some a; _}::
-           ({edge=(Rf Ext|Fr Ext|Ws Ext);a1=Some _; _}::_ as es) ->
+         | {edge=Communication (_,Ext); a2=Some a; _}::
+           ({edge=Communication (_,Ext);a1=Some _; _}::_ as es) ->
              pp_atom a::count_a es
-         | {edge=(Rf Ext|Fr Ext|Ws Ext); a2=None; _}::
-           ({edge=(Rf Ext|Fr Ext|Ws Ext);a1=None; _}::_ as es) ->
+         | {edge=Communication (_,Ext); a2=None; _}::
+           ({edge=Communication (_,Ext);a1=None; _}::_ as es) ->
              Code.plain::count_a es
          | _::es -> count_a es
          | [] -> []
 
        let init_a = function
-         | {edge=(Rf Ext|Fr Ext|Ws Ext);a1=Some a; _}::_ as es ->
+         | {edge=Communication (_,Ext);a1=Some a; _}::_ as es ->
              begin match Misc.last es with
-             | {edge=(Rf Ext|Fr Ext|Ws Ext);a2=Some _; _} ->
+             | {edge=Communication (_,Ext);a2=Some _; _} ->
                  [pp_atom a]
              | _ -> []
              end
-         | {edge=(Rf Ext|Fr Ext|Ws Ext);a1=None; _}::_ as es ->
+         | {edge=Communication (_,Ext);a1=None; _}::_ as es ->
              begin match Misc.last es with
-             | {edge=(Rf Ext|Fr Ext|Ws Ext);a2=None; _} -> [Code.plain]
+             | {edge=Communication (_,Ext);a2=None; _} -> [Code.plain]
              | _ -> []
              end
          | _ -> []

--- a/gen/normaliser.ml
+++ b/gen/normaliser.ml
@@ -159,11 +159,11 @@ module Make : functor (C:Config) -> functor (E:Edge.S) ->
 
 (* Notice, do not halt on stores... *)
       let ext_com e = match e.E.edge with
-      | E.Rf Ext|E.Fr Ext|E.Ws Ext|E.Hat -> true
+      | E.Communication (_,Ext)|E.Hat -> true
       | _ -> false
 
       let int_com e = match e.E.edge with
-      | E.Rf Int|E.Fr Int|E.Ws Int -> true
+      | E.Communication (_,Int) -> true
       | _ -> false
 
 (* Find skipping Leave/Back *)
@@ -289,10 +289,10 @@ module Make : functor (C:Config) -> functor (E:Edge.S) ->
       let compare_edges e1 e2 =
         let open E in
         match e1.edge,e2.edge with
-        | (Po _|Rf _),(Fenced _|Dp _)
+        | (Po _|Communication (Rf,_)),(Fenced _|Dp _)
         | Dp _,Fenced _
           -> 1
-        | (Fenced _|Dp _),(Po _|Rf _)
+        | (Fenced _|Dp _),(Po _|Communication (Rf,_))
         | Fenced _,Dp _ -> -1
         | _,_ -> Misc.polymorphic_compare e1 e2
 

--- a/gen/relax.ml
+++ b/gen/relax.ml
@@ -109,7 +109,7 @@ and type edge = E.edge
 
 
 (* Cumulativity macros *)
-        let rf = E.plain_edge (E.Rf Ext)
+        let rf = E.plain_edge (E.Communication (Rf,Ext))
         and fenced  f sl d1 d2 = E.plain_edge (E.Fenced (f,sl,d1,d2))
         let ac_fence f sl d1 d2 = [rf; fenced f sl d1 d2]
         let bc_fence f sl d1 d2 = [fenced f sl d1 d2; rf]
@@ -121,18 +121,18 @@ and type edge = E.edge
           let open E in
           match r with
           | [e] -> E.pp_edge e
-          | [{edge=Rf Ext; a1=None;a2=None;};
+          | [{edge=Communication (Rf,Ext); a1=None;a2=None;};
              {edge=Fenced _;a1=None; a2=None;} as e] when backward_compatibility ->
                  sprintf "AC%s" (pp_edge e)
           | [{edge=Fenced _; a1=None;a2=None;} as e;
-             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
+             {edge=Communication (Rf,Ext); a1=None; a2=None;}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
-          | [{edge=Rf Ext; a1=None; a2=None;};
+          | [{edge=Communication (Rf,Ext); a1=None; a2=None;};
              {edge=Fenced _; a1=None; a2=None;} as e;
-             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
+             {edge=Communication (Rf,Ext); a1=None; a2=None;}] when backward_compatibility ->
                    sprintf "ABC%s" (pp_edge e)
           | [{edge=Dp _; a1=None; a2=None;} as e;
-             {edge=Rf Ext; a1=None; a2=None;}] when backward_compatibility ->
+             {edge=Communication (Rf,Ext); a1=None; a2=None;}] when backward_compatibility ->
                    sprintf "BC%s" (pp_edge e)
           | es ->
               sprintf "[%s]" (String.concat "," (List.map pp_edge es))
@@ -188,11 +188,11 @@ and type edge = E.edge
         let com =
           let open E in
           [
-           er (Rf Ext);
-           er (Fr Ext);
-           er (Ws Ext);
-           ers [Fr Ext ; Rf Ext;];
-           ers [Ws Ext; Rf Ext;];
+           er (Communication (Rf,Ext));
+           er (Communication (Fr,Ext));
+           er (Communication (Co,Ext));
+           ers [Communication (Fr,Ext) ; Communication (Rf,Ext);];
+           ers [Communication (Co,Ext); Communication (Rf,Ext);];
          ]
 
         let po =
@@ -202,10 +202,10 @@ and type edge = E.edge
             (fun f k ->
               er (Fenced (f,Diff,Irr,Irr))::
               (if F.orders f R R && not (F.orders f W R) then
-                [ers [Rf Int; Fenced (f,Diff,Dir R,Dir R)]]
+                [ers [Communication (Rf,Int); Fenced (f,Diff,Dir R,Dir R)]]
               else [])@
               (if F.orders f R W && not (F.orders f W W) then
-                [ers [Rf Int; Fenced (f,Diff,Dir R,Dir W)]]
+                [ers [Communication (Rf,Int); Fenced (f,Diff,Dir R,Dir W)]]
               else [])@k)
             []
 
@@ -416,13 +416,13 @@ and type edge = E.edge
         let is_cumul r =
           let open E in
           match r with
-          | [{edge=Rf Code.Ext; a1=None; a2=None;};
+          | [{edge=Communication (Rf,Ext); a1=None; a2=None;};
              {edge=Fenced _; a1=None; a2=None;}]
           | [{edge=Fenced _; a1=None; a2=None;};
-             {edge=Rf Code.Ext; a1=None; a2=None;};]
-          | [{edge=Rf Code.Ext; a1=None; a2=None;};
+             {edge=Communication (Rf,Ext); a1=None; a2=None;};]
+          | [{edge=Communication (Rf,Ext); a1=None; a2=None;};
              {edge=Fenced _; a1=None; a2=None;};
-             {edge=Rf Code.Ext; a1=None; a2=None;};]
+             {edge=Communication (Rf,Ext); a1=None; a2=None;};]
             -> true
           | _ -> false
 
@@ -437,12 +437,12 @@ and type edge = E.edge
           let open E in
           match r with
           | [{edge=Fenced (f,_,_,_); _}]
-          | [{edge=Rf Code.Ext; _};{edge=Fenced (f,_,_,_);_}]
+          | [{edge=Communication (Rf,Ext); _};{edge=Fenced (f,_,_,_);_}]
           | [{edge=Fenced (f,_,_,_); _};
-             {edge=Rf Code.Ext; _};]
-          | [{edge=Rf Code.Ext; _};
+             {edge=Communication (Rf,Ext); _};]
+          | [{edge=Communication (Rf,Ext); _};
              {edge=Fenced (f,_,_,_); _};
-             {edge=Rf Code.Ext; _};]
+             {edge=Communication (Rf,Ext); _};]
             -> FenceSet.add f k
           | _ -> k
 
@@ -455,12 +455,12 @@ and type edge = E.edge
         let add_cumul_fence r k =
           let open E in
           match r with
-          | [{edge=Rf Code.Ext; _};{edge=Fenced (f,_,_,_); _}]
+          | [{edge=Communication (Rf,Ext); _};{edge=Fenced (f,_,_,_); _}]
           | [{edge=Fenced (f,_,_,_); _};
-             {edge=Rf Code.Ext; _};]
-          | [{edge=Rf Code.Ext; _};
+             {edge=Communication (Rf,Ext); _};]
+          | [{edge=Communication (Rf,Ext); _};
              {edge=Fenced (f,_,_,_); _};
-             {edge=Rf Code.Ext; _};]
+             {edge=Communication (Rf,Ext); _};]
             -> FenceSet.add f k
           | _ -> k
 
@@ -479,10 +479,10 @@ and type edge = E.edge
               (fun r k ->
                 let open E in
                 match r with
-                | ([{edge=Rf Ext; _}; {edge=Fenced _; _};] as rs)
-                | ([{edge=Fenced _; _}; {edge=Rf Ext; _};] as rs)
-                | ([{edge=Rf Ext; _}; {edge=Fenced _; _};
-                    {edge=Rf Ext; _};] as rs)
+                | ([{edge=Communication (Rf,Ext); _}; {edge=Fenced _; _};] as rs)
+                | ([{edge=Fenced _; _}; {edge=Communication (Rf,Ext); _};] as rs)
+                | ([{edge=Communication (Rf,Ext); _}; {edge=Fenced _; _};
+                    {edge=Communication (Rf,Ext); _};] as rs)
                   ->
                     RSet.of_list (List.map er rs)::k
                 | _ -> RSet.singleton r::k)

--- a/gen/topUtils.ml
+++ b/gen/topUtils.ml
@@ -212,9 +212,9 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
           let wb = write_before n
           and wa = write_after n in
           begin match wb,wa with
-          | true,true -> Ws Ext
-          | true,false -> Rf Ext
-          | false,true -> Fr Ext
+          | true,true -> Communication (Co,Ext)
+          | true,false -> Communication (Rf,Ext)
+          | false,true -> Communication (Fr,Ext)
           | false,false ->
               Warn.fatal "Incorrect Hat: read chains are not allowed"
           end
@@ -225,9 +225,7 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
         (fun ns ->
           let open C.E in
           match last_edge ns with
-          | Fr _|Leave CFr|Back CFr -> "Fr"
-          | Rf _|Leave CRf|Back CRf -> "Rf"
-          | Ws _|Leave CWs|Back CWs -> "Co"
+          | Communication (com,_)|Leave com|Back com -> pp_com com
           | _ -> assert false)
         nss
 
@@ -287,10 +285,9 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
     let is_load_init e = e.C.C.dir = Some R && e.C.C.v = C.C.Value.from_int 0
 
     let check_edge = function
-      | C.E.Ws Ext
-      | C.E.Fr Ext
-      | C.E.Leave (CFr|CWs)
-      | C.E.Back(CFr|CWs)  -> true
+      | C.E.Communication ((Fr|Co),Ext)
+      | C.E.Leave (Fr|Co)
+      | C.E.Back(Fr|Co)  -> true
       | _-> false
 
     let check_here n = match n.C.C.evt.C.C.bank with
@@ -308,15 +305,15 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
     let do_poll n =
       match O.poll,n.C.C.prev.C.C.edge.C.E.edge,n.C.C.evt.C.C.v with
       | true,
-        (C.E.Rf Ext|C.E.Leave CRf|C.E.Back CRf),C.C.Value.Plain 1 -> true
+        (C.E.Communication (Rf,Ext)|C.E.Leave Rf|C.E.Back Rf),C.C.Value.Plain 1 -> true
       | _,_,_ -> false
 
     (* TODO is this simple lift from 2,1,0 to Plain * correct *)
     let fetch_val n =
       let n = C.C.find_node (fun n -> C.E.is_com n.C.C.edge) n.C.C.prev in
       ( match n.C.C.edge.C.E.edge with
-      | C.E.Rf _-> 2
-      | C.E.Fr _ -> 1
+      | C.E.Communication (Rf,_)-> 2
+      | C.E.Communication (Fr,_) -> 1
       | _ -> 0 )
       |> C.C.Value.from_int
   end


### PR DESCRIPTION
Unify constructors `Rf`, `Fr`, and `Ws`  in `relax.ml`  and the similar constructors `CRf`, `CFr` and `CWs` in `code.ml`. The former has been wrapped behind `Communication (com, ie)` and rename the latter constructors to `Rf`, `Fr`, and `Co`. Update edge folding, parsing, naming, relaxation handling, and generation code to use the unified communication representation while preserving existing printed syntax.

