### PR TITLE
[herd] Measure some timings 2

### DIFF
--- a/herd-www/jerd.ml
+++ b/herd-www/jerd.ml
@@ -217,6 +217,7 @@ let run_herd bell cat litmus cfg cat_label =
     let check_filter = !check_filter
     let debug = !debug
     let debuglexer = debug.Debug_herd.lexer
+    module Timer = Timer.No
     let verbose = !verbose
     let hexa = !PP.hexa
     let unroll = !unroll

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -66,6 +66,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
   let _dbg = TopConf.C.debug.Debug_herd.monad
   let _profile = TopConf.C.debug.Debug_herd.profile_asl
 
+  module Timer = TopConf.C.Timer
   let start_profile = if _profile then Sys.time else Fun.const 0.
   let end_profile = if _profile then end_profile else fun _ _ -> ()
 
@@ -1686,12 +1687,14 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
       | Some _ when AArch64.is_mixed -> check_strict test_aarch64 ii
       | Some (fname, args) -> (
           profile "build AArch64 semantics from ASL" @@ fun () ->
+          Timer.start Timer.semantics;
           let test_asl, eqs_test = fake_test ii fname args in
           let model = build_model_from_file "asl.cat" in
           let { MC.event_structures = rfms; _ }, test_asl =
             profile "run ASL Semantics" @@ fun () ->
             MC.glommed_event_structures ~is_pgm:false test_asl
           in
+          Timer.stop Timer.semantics;
           let () =
             if _dbg then
               Printf.eprintf "Got rfms back: %d of them.\n%!" (List.length rfms)
@@ -1718,7 +1721,10 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
               let () = end_profile t0 "ASL cat, success" in
               Translator.tr_execution ii eqs_test c :: acc
             in
-            check_event_structure model test_asl conc kfail ksuccess acc
+            Timer.start Timer.model;
+            let c = check_event_structure model test_asl conc kfail ksuccess acc in
+            Timer.stop Timer.model;
+            c
           in
           let check_and_translate acc c =
             profile "check and translate" @@ fun () ->

--- a/herd/cli.ml
+++ b/herd/cli.ml
@@ -154,7 +154,12 @@ end) = struct
         Itimer.stop O.timeout ;
 (* Now output *)
         let time = Sys.time () -. start_time in
-        Format.printf "%a\n" (fun fmt () -> PP.pp_stats ~time test c fmt) ();
+        Format.printf "%a@." (fun fmt () -> PP.pp_stats ~time test c fmt) ();
+        if O.debug.Debug_herd.timers then
+          Format.printf "Timers: %a, %a, %a@."
+            O.Timer.pp O.Timer.run
+            O.Timer.pp O.Timer.semantics
+            O.Timer.pp O.Timer.model;
         do_show ();
         begin
           match TR.cutoff c with

--- a/herd/debug_herd.ml
+++ b/herd/debug_herd.ml
@@ -35,6 +35,7 @@ type t = {
     asl_symb: bool ;
     asl_stack: bool ;
     profile_mem: bool ;
+    timers : bool ;
     exc : bool ;
   }
 
@@ -58,6 +59,7 @@ let tags =
   "asl_symb";
   "asl_stack";
   "profile_mem";
+  "timers";
   "exception";
 ]
 
@@ -81,6 +83,7 @@ let none =
    asl_symb = false;
    asl_stack = false;
    profile_mem = false;
+   timers = false;
    exc = false ;
  }
 
@@ -105,4 +108,5 @@ let parse t tag = match tag with
   | "asl_symb" -> Some { t with asl_symb = true }
   | "asl_stack" -> Some { t with asl_stack = true }
   | "profile_mem" -> Some { t with profile_mem = true }
+  | "timers" -> Some { t with timers = true }
   | _ -> None

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -597,6 +597,9 @@ let conds = LR.read_from_files !conds (fun s -> Some s)
 
 (* Configure parser/models/etc. *)
 let () =
+  let timer_module =
+    if !debug.Debug_herd.timers then (module Timer.Ok:Timer.S)
+    else (module Timer.No:Timer.S) in
   let module Config = struct
     let timeout = !timeout
     let candidates = !candidates
@@ -633,6 +636,7 @@ let () =
     let check_filter = !check_filter
     let debug = !debug
     let debuglexer = debug.Debug_herd.lexer
+    module Timer = (val timer_module : Timer.S)
     let verbose = !verbose
     let hexa = !PP.hexa
     let unroll = !unroll

--- a/herd/top_herd.ml
+++ b/herd/top_herd.ml
@@ -28,6 +28,7 @@ module type CommonConfig = sig
   val statelessrc11 : bool
   val skipchecks : StringSet.t
   val dumpallfaults : bool
+  module Timer : Timer.S
 end
 
 module type Config = sig
@@ -220,7 +221,7 @@ module Printer (O : PrinterConfig) (S : SemExtra.S) = struct
       (fun (k,v) ->
         if Misc.string_eq k "Hash" then
           fprintf fmt "%s=%s\n" k v)
-      test.Test_herd.info ;
+      test.Test_herd.info
 
   module PP = Pretty.Make (S)
 
@@ -460,8 +461,11 @@ module Make(O:Config)(M:XXXMem.S) =
 
     (* Driver *)
     let run test =
+      O.Timer.start O.Timer.run;
+      O.Timer.start O.Timer.semantics;
       let { MC.event_structures=rfms; MC.overwritable_labels=owls; },test =
         MC.glommed_event_structures ~is_pgm:true test in
+      O.Timer.stop O.Timer.semantics;
 
       let restrict_faults =
         if !Opts.dumpallfaults then
@@ -490,18 +494,20 @@ module Make(O:Config)(M:XXXMem.S) =
         (* Thanks to the existence of check_test, XXMem modules
            apply their internal functors once *)
         let call_model conc ofail solver c =
-        let check_test = M.check_event_structure test in
-        (* Checked pruned executions before even calling model *)
-        let cutoff =  S.find_cutoff conc.S.str.S.E.events in
+          O.Timer.start O.Timer.model ;
+          let check_test = M.check_event_structure test in
+          (* Checked pruned executions before even calling model *)
+          let cutoff =  S.find_cutoff conc.S.str.S.E.events in
+          let c =
+            if Misc.is_some cutoff then Count.{ c with cutoff = cutoff }
+            else c in
+          (* Discard pruned executions if not explicitely required *)
+          let c = check_test
+              conc kfail
+              (check_failed_model_kont cutoff
+                 ofail solver emit_exec test final_state_restrict_locs) c in
+          O.Timer.stop O.Timer.model; c in
         let c =
-          if Misc.is_some cutoff then Count.{ c with cutoff = cutoff }
-          else c in
-        (* Discard pruned executions if not explicitely required *)
-        check_test
-          conc kfail
-          (check_failed_model_kont cutoff
-             ofail solver emit_exec test final_state_restrict_locs) c in
-      let c =
         if O.statelessrc11
         then let module SL = Slrc11.Make(struct include MC let skipchecks = O.skipchecks end) in
              SL.check_event_structure test rfms kfail (fun _ c -> c)
@@ -527,6 +533,7 @@ module Make(O:Config)(M:XXXMem.S) =
                 st,flts,solver in
           A.StateSet.map do_restrict c.states
         else c.states in
+        O.Timer.stop O.Timer.run;
         {
           states = finals;
           TestResult.cfail = c.Count.cfail;

--- a/herd/top_herd.mli
+++ b/herd/top_herd.mli
@@ -26,6 +26,7 @@ module type CommonConfig = sig
   val statelessrc11 : bool
   val skipchecks : StringSet.t
   val dumpallfaults : bool
+  module Timer : Timer.S
 end
 
 module type Config = sig

--- a/lib/timer.ml
+++ b/lib/timer.ml
@@ -1,0 +1,75 @@
+(****************************************************************************)
+(*                           the diy toolsuite                              *)
+(*                                                                          *)
+(* Jade Alglave, University College London, UK.                             *)
+(* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
+(*                                                                          *)
+(* Copyright 2026-present Institut National de Recherche en Informatique et *)
+(* en Automatique and the authors. All rights reserved.                     *)
+(*                                                                          *)
+(* This software is governed by the CeCILL-B license under French law and   *)
+(* abiding by the rules of distribution of free software. You can use,      *)
+(* modify and/ or redistribute the software under the terms of the CeCILL-B *)
+(* license as circulated by CEA, CNRS and INRIA at the following URL        *)
+(* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
+(****************************************************************************)
+
+module type S = sig
+  type t
+
+  val start : t -> unit
+  val stop : t -> unit
+
+  val pp : Format.formatter -> t -> unit
+
+  val semantics : t
+  val model : t
+  val run : t
+end
+
+module Ok = struct
+
+  type t = {
+    name : string;
+    mutable start_time : float option;
+    mutable total : float;
+    mutable depth : int;
+  }
+
+  let create name = { name; start_time = None; total = 0.0; depth = 0; }
+
+  let start t =
+    if t.depth = 0 then t.start_time <- Some (Sys.time ());
+    t.depth <- t.depth + 1
+
+  let stop t =
+    match t.start_time with
+    | None -> Warn.fatal "Timer %s has not been started" t.name
+    | Some start_time ->
+        let depth = t.depth - 1 in
+        if depth < 0 then Warn.fatal "Timer %s has been stopped too many times" t.name;
+        t.depth <- depth;
+        if depth = 0 then begin
+          t.total <- t.total +. Sys.time () -. start_time;
+          t.start_time <- None
+        end
+
+  let pp fmt t = Format.fprintf fmt "%s=%0.2f" t.name t.total
+
+  let semantics = create "semantics"
+  let model = create "model"
+  let run = create "run"
+end
+
+module No = struct
+  type t = unit
+
+  let start _ = ()
+  and stop _ = ()
+
+  let pp _ _ = ()
+
+  let semantics = ()
+  let model = ()
+  let run = ()
+end

--- a/lib/timer.mli
+++ b/lib/timer.mli
@@ -4,7 +4,7 @@
 (* Jade Alglave, University College London, UK.                             *)
 (* Luc Maranget, INRIA Paris-Rocquencourt, France.                          *)
 (*                                                                          *)
-(* Copyright 2013-present Institut National de Recherche en Informatique et *)
+(* Copyright 2026-present Institut National de Recherche en Informatique et *)
 (* en Automatique and the authors. All rights reserved.                     *)
 (*                                                                          *)
 (* This software is governed by the CeCILL-B license under French law and   *)
@@ -14,30 +14,20 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-(** Debug tags *)
 
-type t = {
-  solver : int ;
-  lexer : bool ;
-  top : bool ;
-  mem : bool ;
-  monad : bool ;
-  barrier : bool ;
-  res : bool ;
-  rfm : bool  ;
-  pretty : bool ;
-  mixed : bool ;
-  files : bool ;
-  timeout : bool ;
-  pac : bool ;
-  profile_cat: bool ;
-  profile_asl: bool ;
-  asl_symb: bool ;
-  asl_stack: bool ;
-  profile_mem: bool ;
-  timers : bool ;
-  exc : bool ;  }
+module type S = sig
+  type t
 
-val none : t
-val tags : string list
-val parse : t -> string -> t option
+  val start : t -> unit
+  val stop : t -> unit
+
+  val pp : Format.formatter -> t -> unit
+
+  val semantics : t
+  val model : t
+  val run : t
+end
+
+module Ok : S
+module No : S
+


### PR DESCRIPTION
Add timer support (cf. lib/timer.ml). The new feature is  used for timing:
  + Cat model execution and
  + code semantics, _i.e._ monad construction by the "Sem" modules.

Timers are activated by the command-line option `-debug timers`. For instance:
```
% herd7 catalogue/aarch64-VMSA/tests/Marc03.litmus -variant vmsa -speedcheck true -debug timers
Test Marc03 Forbidden
...
Timers: model=13.25, run=18.61, semantics=0.02
```

Supersedes PR #1865.