### PR TITLE
[gen] Do not expose `Store` edge in cycle value checks

### DIFF
--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -1174,7 +1174,6 @@ let do_set_read_v init =
        - plain value => CoSt.get_cell, CoSt.set_cell,
        - pte value => CoSt.get_pte_value, CoSt.set_pte_value *)
     List.fold_left ( fun st n ->
-      let st = if n.store == nil then st else CoSt.set_cell st n.store.evt.cell in
       let cell = CoSt.get_cell st in
       let bank = n.evt.bank in
       begin match n.evt.dir with
@@ -1581,13 +1580,7 @@ let merge_changes n nss =
             E.is_node m.edge.E.edge || not (pbank m.evt.bank)
           then k else (e.loc,m)::k
       | None| Some R -> k in
-      if m.store == nil then k
-      else begin
-        let e = m.store.evt in
-        if pbank e.bank then
-          (e.loc,m.store)::k
-        else k
-      end in
+      k in
     do_rec n
 
   let get_ord_writes =

--- a/gen/tests/AArch64.store/LB+dmb.sy+addrR-pos-store.litmus.expected
+++ b/gen/tests/AArch64.store/LB+dmb.sy+addrR-pos-store.litmus.expected
@@ -1,14 +1,14 @@
 Test LB+dmb.sy+addrR-pos-store Allowed
 States 5
-0:X1=0; 1:X1=0; 1:X4=1; [x]=2;
-0:X1=0; 1:X1=1; 1:X4=1; [x]=2;
-0:X1=1; 1:X1=0; 1:X4=1; [x]=2;
-0:X1=1; 1:X1=1; 1:X4=1; [x]=2;
-0:X1=2; 1:X1=0; 1:X4=1; [x]=2;
+0:X1=0; 1:X1=0; 1:X4=1;
+0:X1=0; 1:X1=1; 1:X4=1;
+0:X1=1; 1:X1=0; 1:X4=1;
+0:X1=1; 1:X1=1; 1:X4=1;
+0:X1=2; 1:X1=0; 1:X4=1;
 No
 Witnesses
 Positive: 0 Negative: 5
-Condition exists ([x]=2 /\ 0:X1=2 /\ 1:X1=1 /\ 1:X4=0)
+Condition exists (0:X1=2 /\ 1:X1=1 /\ 1:X4=0)
 Observation LB+dmb.sy+addrR-pos-store Never 0 5
-Hash=6764bc771945dd980b1c77ce8dee3c0b
+Hash=b6bf93e5a07ec05b1224d5ca78f2755b
 

--- a/gen/tests/AArch64.store/MP+dmb.sy+addrR-pos-store.litmus.expected
+++ b/gen/tests/AArch64.store/MP+dmb.sy+addrR-pos-store.litmus.expected
@@ -1,15 +1,14 @@
 Test MP+dmb.sy+addrR-pos-store Allowed
-States 6
-1:X0=0; 1:X4=1; 1:X5=1; [x]=1;
-1:X0=0; 1:X4=1; 1:X5=1; [x]=2;
-1:X0=0; 1:X4=1; 1:X5=2; [x]=2;
-1:X0=0; 1:X4=2; 1:X5=2; [x]=2;
-1:X0=1; 1:X4=1; 1:X5=1; [x]=1;
-1:X0=1; 1:X4=2; 1:X5=2; [x]=2;
+States 5
+1:X0=0; 1:X4=1; 1:X5=1;
+1:X0=0; 1:X4=1; 1:X5=2;
+1:X0=0; 1:X4=2; 1:X5=2;
+1:X0=1; 1:X4=1; 1:X5=1;
+1:X0=1; 1:X4=2; 1:X5=2;
 No
 Witnesses
 Positive: 0 Negative: 6
-Condition exists ([x]=2 /\ 1:X0=1 /\ 1:X4=0 /\ 1:X5=1)
+Condition exists (1:X0=1 /\ 1:X4=0 /\ 1:X5=0)
 Observation MP+dmb.sy+addrR-pos-store Never 0 6
-Hash=2af1b0897501af665450605488211634
+Hash=4ad81aba9d363e9e76327bb6303e23f4
 

--- a/gen/tests/AArch64.store/MP+dmb.sy+dataW-pos-store.litmus.expected
+++ b/gen/tests/AArch64.store/MP+dmb.sy+dataW-pos-store.litmus.expected
@@ -7,7 +7,7 @@ States 4
 No
 Witnesses
 Positive: 0 Negative: 6
-Condition exists ([x]=3 /\ 1:X0=1 /\ 1:X4=2)
+Condition exists ([x]=3 /\ 1:X0=1 /\ 1:X4=1)
 Observation MP+dmb.sy+dataW-pos-store Never 0 6
 Hash=a2d339b7cae200e4f07a5130948ea262
 

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -534,7 +534,7 @@ A valid cycle with annotations and a store edge
    STLR W0,[X1] |             ;
    LDR W3,[X2]  |             ;
   
-  exists ([x]=2 /\ 0:X3=0 /\ 1:X3=0)
+  exists (0:X3=0 /\ 1:X3=0)
 An invalid cycle with annotations and a store edge
   $ diyone7 -arch AArch64 A Store PodWR Fre PodWR Fre
   diyone7: Fatal error: Test SB+po+store-poap [Store PodWRAP Fre PodWR FrePA] failed:
@@ -560,7 +560,7 @@ A valid cycle with duplicate wraparound annotations plus insert and store edges
    ISB          |             ;
    LDAR W3,[X2] |             ;
   
-  exists ([x]=2 /\ 0:X3=0 /\ 1:X3=0)
+  exists (0:X3=0 /\ 1:X3=0)
 
 Alignment filter behaviour between local `Pos**` and internal communication in `diy7` in `default` mode
   $ diy7 -arch AArch64 -filter-check Rfi DpAddrdW


### PR DESCRIPTION
This PR changes inserted `Store` pseudo-edges so they are emitted in the generated program but hidden from cycle value checks. `Store` is used to insert a concrete write instruction into the generated test. That write should remain in the program, but it should not behave like a normal cycle write when deciding carried read values or final coherence conditions.

This means we can generate the following example `diyone7 -arch AArch64 PodWW L Rfe Store A PodRR Fre`:

```
AArch64 R+popl+store-poap
Generator=diyone7 (version 7.58+1)
Prefetch=0:x=F,0:y=W,1:y=F,1:x=T
Com=Rf Fr
Orig=PodWWPL RfeLA Store PodRRAP Fre
"PodWWPL RfeLA Store PodRRAP Fre"
{
 0:X1=x; 0:X3=y;
 1:X1=x; 1:X3=y;
}
 P0           | P1           ;
 MOV W0,#1    | MOV W4,#2    ;
 STR W0,[X1]  | STR W4,[X3]  ; (* This `STR` by `Store` edge is de facto not in the cycle *)
 MOV W2,#1    | LDAR W0,[X3] ;
 STLR W2,[X3] | LDR W2,[X1]  ;

exists (1:X0=1 /\ 1:X2=0)

```
In the example above, the `STR W4,[X3]` is de facto _not_ in the cycle, since the check `1:X0=1` observes the `STLR` from `P0`. Separately, there is no `[y]=2` check.