### PR TITLE
[herd] Fix non explicit atomic pairs

### DIFF
--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -140,7 +140,7 @@ module type S = sig
     S.E.event -> S.E.A.location
 
   val make_atomic_load_store :
-    S.E.event_structure -> S.E.EventRel.t
+    S.test -> S.E.event_structure -> S.E.EventRel.t
 
 end
 
@@ -1911,11 +1911,11 @@ let add_eq v1 v2 eqs =
 (*
  * Reconstruct load/store atomic pairs,
  *   By definition such a pair exists when the
- * store precedes the load in generalised program order
+ * load precedes the store in generalised program order
  * (_i.e._ the union of program order and of iico), and
  * that there is no atomic effect to the same location
  * in-between (w.r.t generalised po) the load and the store.
- *   Computation proceeds as follows:
+ *   Computation for explicit accesses proceeds as follows:
  *   First, atomic events are grouped first by thread
  * and then by location. Then, to each atomic load, we
  * associate the closest generalised po successor store,
@@ -1925,15 +1925,25 @@ let add_eq v1 v2 eqs =
  * to use a set of all atomic events (by a given thread and
  * with a given location) ordered by po because some atomic loads
  * may be unrelated.
- *   Finally, such atomic pairs can be spurious, that is not performed
- * by a specific thread. In that case, pairs are given
- * simply by the intra causality data relation.
+ *   Finally, the computation is simpler for non-explicit such atomic
+ * pairs. In that case, pairs are given simply by the intra causality
+ * data relation. Namely, those pairs all stem from the atomic modification
+ * of page table entries.
  *)
 
-    let make_atomic_load_store es =
-      let atms,spurious = U.collect_atomics es in
+    let make_atomic_load_store _test es =
+      let atms,nexps = U.collect_atomics es in
+
       let module StoreSet = EvtSetByPo(struct let es = es end) in
-      let make_atomic_pairs es k =
+
+      let make_atomic_pairs_nexp evts =
+        let rs,ws = List.partition E.is_load evts in
+        let rs = E.EventSet.of_list rs
+        and ws = E.EventSet.of_list ws in
+        E.EventRel.restrict_domains_to_sets
+             rs ws es.E.intra_causality_data
+
+      and make_atomic_pairs es k =
         let rs,ws = List.partition E.is_load es in
         let ws = StoreSet.of_list ws
         and intervening_read er ew =
@@ -1958,23 +1968,10 @@ let add_eq v1 v2 eqs =
         List.map
           (fun (_,m) ->
            U.LocEnv.fold
-             (fun _loc es k ->
-                let exps,nexps = List.partition E.is_explicit es in
-                make_atomic_pairs exps @@ make_atomic_pairs nexps k)
+             (fun _loc exps k -> make_atomic_pairs exps k)
              m E.EventRel.empty)
         atms |> E.EventRel.unions
-      and r2 =
-        let iico = es.E.intra_causality_data in
-        List.map
-          (fun e ->
-             if E.is_load e then
-               match
-                 E.EventRel.succs iico e |> E.EventSet.as_singleton
-               with
-               | None -> assert false (* spurious updates are by pairs *)
-               | Some w -> E.EventRel.singleton (e,w)
-             else E.EventRel.empty)
-          spurious |> E.EventRel.unions in
+      and r2 = make_atomic_pairs_nexp nexps in
       E.EventRel.union r1 r2
 
 (* Retrieve last store from rfmap *)
@@ -2549,7 +2546,7 @@ let add_eq v1 v2 eqs =
                     | OptAce.True -> check_rfmap es rfm
                   then
                     (* Atomic load/store pairs *)
-                    let atomic_load_store = make_atomic_load_store es in
+                    let atomic_load_store = make_atomic_load_store test es in
                     if
                       C.variant Variant.OptRfRMW
                       && some_same_rf_rmw rfm atomic_load_store

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -2547,6 +2547,17 @@ let add_eq v1 v2 eqs =
                   then
                     (* Atomic load/store pairs *)
                     let atomic_load_store = make_atomic_load_store test es in
+                    let () =
+                      if dbg then
+                        E.EventRel.iter_succs
+                          (fun _er ews ->
+                             if E.EventSet.cardinal ews <> 1 then begin
+                               let module PP = Pretty.Make(S) in
+                               eprintf "Non-affine rmw relation!\n%!" ;
+                               PP.show_es_rfm test es S.RFMap.empty ;
+                               Warn.fatal "Non-affine rmw relation!"
+                             end)
+                          atomic_load_store in
                     if
                       C.variant Variant.OptRfRMW
                       && some_same_rf_rmw rfm atomic_load_store

--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -2549,15 +2549,21 @@ let add_eq v1 v2 eqs =
                     let atomic_load_store = make_atomic_load_store test es in
                     let () =
                       if dbg then
-                        E.EventRel.iter_succs
-                          (fun _er ews ->
-                             if E.EventSet.cardinal ews <> 1 then begin
-                               let module PP = Pretty.Make(S) in
-                               eprintf "Non-affine rmw relation!\n%!" ;
-                               PP.show_es_rfm test es S.RFMap.empty ;
-                               Warn.fatal "Non-affine rmw relation!"
-                             end)
-                          atomic_load_store in
+                        let open E.EventRel in
+                        try check_bijection atomic_load_store with
+                        | NonAffine (x, ys) ->
+                          let module PP = Pretty.Make(S) in
+                          eprintf "Non-affine rmw relation!\n%a related to all of (%a)\n%!"
+                            E.debug_event x E.debug_events ys;
+                          PP.show_es_rfm test es S.RFMap.empty ;
+                          Warn.fatal "Non-affine rmw relation!"
+                        | NonInjective (xs, y) ->
+                          let module PP = Pretty.Make(S) in
+                          eprintf "Non-injective rmw relation!\nall of (%a) related to %a%!"
+                            E.debug_events xs E.debug_event y;
+                          PP.show_es_rfm test es S.RFMap.empty ;
+                          Warn.fatal "Non-injective rmw relation!"
+                    in
                     if
                       C.variant Variant.OptRfRMW
                       && some_same_rf_rmw rfm atomic_load_store

--- a/herd/memUtils.ml
+++ b/herd/memUtils.ml
@@ -401,8 +401,15 @@ let lift_proc_info i evts =
         (fun e (m,sp as k) ->
            if E.is_atomic e then
              match E.proc_of e with
-             | None -> if E.is_spurious e then (m, e::sp) else k
-             | Some proc -> accumulate_loc_proc proc (get_loc e) e m, sp
+             | None ->
+                 if E.is_spurious e then
+                   m, e::sp
+                 else k
+             | Some proc ->
+                 if E.is_explicit e then
+                   accumulate_loc_proc proc (get_loc e) e m, sp
+                 else
+                   m,(e::sp)
            else k)
         es.E.events (IntMap.empty,[]) in
     IntMap.bindings m,sp

--- a/herd/memUtils.mli
+++ b/herd/memUtils.mli
@@ -91,13 +91,14 @@ module Make : functor (S: SemExtra.S) -> sig
    * When given an event structure as argument, the function
    * returns a pair [(maps,evts)], where:
    *  + [maps] is a list of location maps, one per thread.
-   *    The values of this map are the atomic effects
+   *    The values of this map are the explicit atomic effects
         of the given thread.
-   *  + [evts] is the list of spurious (atomic) effects.
+   *  + [evts] is the list of non-explicit (atomic) effects.
    *)
 
   val collect_atomics :
-    S.event_structure -> (Proc.t * S.event list LocEnv.t) list * S.event list
+    S.event_structure ->
+    (Proc.t * S.event list LocEnv.t) list * S.event list
 
 (* Partition by location *)
   val partition_events : S.event_set -> S.event_set list

--- a/herd/slrc11.ml
+++ b/herd/slrc11.ml
@@ -876,7 +876,7 @@ module Make (M:Cfg)
     let check_rfms test rfms _kfail _kont model_kont res =
       let (_, cs0, es0) = rfms in
       let (es, rfm, cs) = solve test es0 cs0 in
-      let rmws = M.make_atomic_load_store es in
+      let rmws = M.make_atomic_load_store test es in
       let evts = E.EventSet.filter real es.E.events in
       let inits = E.EventSet.filter E.is_mem_store_init evts in
       let po = U.po_iico es in

--- a/lib/innerRel.ml
+++ b/lib/innerRel.ml
@@ -33,6 +33,28 @@ module type S =  sig
 (* Inverse *)
   val inverse : t -> t
 
+  exception NonAffine of elt0 * Elts.t
+  (* raised if affinity assumption is broken, returning a witness [x, ys] when
+     [x] is in relation with each element of [ys]. *)
+
+  exception NonInjective of Elts.t * elt0
+  (* raised if injectivity assumption is broken, returning a witness [ys, x] when
+     each element of [ys] is in relation with [x]. *)
+
+  val inverse_bijection : t -> t
+  (* Inverse [t], assuming that it is a bijection.
+
+     If [t] is not injective, then [NonInjective] is raised.
+     If [t] is not affine, then [NonAffine] is raised.
+  *)
+
+  val check_bijection : t -> unit
+  (* [check_bijection t] checks that [t] is a bijection.
+
+     If [t] is not injective, then [NonInjective] is raised.
+     If [t] is not affine, then [NonAffine] is raised.
+   *)
+
 (* Set to relation *)
   val set_to_rln : Elts.t -> t
 
@@ -267,6 +289,32 @@ module Make(O:MySet.OrderedType) : S
 
   (* Inverse *)
   let inverse t = fold (fun (x,y) k -> add (y,x) k) t empty
+
+  (* Bijections *)
+  exception NonAffine of O.t * Elts.t
+  exception NonInjective of Elts.t * O.t
+
+  let inverse_bijection m =
+    M.fold
+      (fun x ys res ->
+         let y =
+           match Elts.as_singleton ys with
+           | Some y -> y
+           | None ->
+             assert (Elts.cardinal ys > 1);
+             raise (NonAffine (x, ys))
+        in
+        M.update y
+          (function
+            | None -> Some (Elts.singleton x)
+            | Some xs ->
+              assert (Elts.cardinal xs > 0);
+              assert (not (Elts.mem x xs));
+              raise (NonInjective (Elts.add x xs, y)))
+          res)
+      m M.empty
+
+  let check_bijection t = inverse_bijection t |> ignore
 
   (* Set to relation *)
   let set_to_rln s =

--- a/lib/innerRel.mli
+++ b/lib/innerRel.mli
@@ -36,6 +36,28 @@ module type S =  sig
 (* Inverse *)
   val inverse : t -> t
 
+  exception NonAffine of elt0 * Elts.t
+  (* raised if affinity assumption is broken, returning a witness [x, ys] when
+     [x] is in relation with each element of [ys]. *)
+
+  exception NonInjective of Elts.t * elt0
+  (* raised if injectivity assumption is broken, returning a witness [ys, x] when
+     each element of [ys] is in relation with [x]. *)
+
+  val inverse_bijection : t -> t
+  (* Inverse [t], assuming that it is a bijection.
+
+     If [t] is not injective, then [NonInjective] is raised.
+     If [t] is not affine, then [NonAffine] is raised.
+  *)
+
+  val check_bijection : t -> unit
+  (* [check_bijection t] checks that [t] is a bijection.
+
+     If [t] is not injective, then [NonInjective] is raised.
+     If [t] is not affine, then [NonAffine] is raised.
+   *)
+
 (* Set to relation *)
   val set_to_rln : Elts.t -> t
 

--- a/lib/myRel.mli
+++ b/lib/myRel.mli
@@ -43,7 +43,9 @@ module type S = sig
   val cardinal : t -> int
 
   val iter : ((elt1 * elt2) -> unit) -> t -> unit
+  val iter_succs : (elt1 -> Elts2.t -> unit) -> t -> unit
   val fold : ((elt1 * elt2) -> 'a -> 'a) -> t -> 'a -> 'a
+  val fold_succs : (elt1 -> Elts2.t -> 'a -> 'a) -> t -> 'a -> 'a
   val exists :  ((elt1 * elt2) -> bool) -> t -> bool
   val for_all :  ((elt1 * elt2) -> bool) -> t -> bool
   val to_seq : t -> (elt1 * elt2) Seq.t

--- a/lib/rel.ml
+++ b/lib/rel.ml
@@ -109,10 +109,14 @@ and module Es2 = MySet.Make(O2)
     let iter f m =
       M.iter (fun x ys ->  Elts2.iter (fun y -> f (x,y)) ys) m
 
+    let iter_succs = M.iter
+
     let fold f m k =
       M.fold
         (fun x ys k -> Elts2.fold (fun y k -> f (x,y) k) ys k)
         m k
+
+    let fold_succs = M.fold
 
     let exists p m =
       M.exists (fun x ys -> Elts2.exists (fun y -> p (x,y)) ys) m

--- a/lib/tests/innerrel_test.ml
+++ b/lib/tests/innerrel_test.ml
@@ -127,3 +127,25 @@ let gs =
   do_rec n []
 
 let  () = assert (List.fold_left check true gs)
+
+let () = R.check_bijection @@ R.of_list []
+let () = R.check_bijection @@ R.of_list [ (1, 1) ]
+let () = R.check_bijection @@ R.of_list [ (1, 2); (3, 4); (5, 6); ]
+let () = R.check_bijection @@ R.of_list [ (1, 2); (2, 3); (3, 4); (4, 1) ]
+
+let () =
+  try
+    R.check_bijection @@ R.of_list [ (1, 2); (1, 3); ];
+    assert false;
+  with
+  | R.NonAffine _ -> ()
+  | R.NonInjective _ -> assert false
+
+let () =
+  try
+    R.check_bijection @@ R.of_list [ (2, 3); (1, 3); ];
+    assert false;
+  with
+  | R.NonAffine _ -> assert false
+  | R.NonInjective _ -> ()
+


### PR DESCRIPTION
Compute `rmw` on non-explicit memory accesses from `iico_data`