### PR TITLE
[herd] Fix showing graphs with preview on macos

### DIFF
--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -869,6 +869,11 @@ module Make(C:Config) (S:Sem.Semantics) : S with module S = S	=
             else relabel es in
           let es =
             { es with E.procs = procs; E.po = if do_deps then transitive_po es else es.E.po } in
+          let () =
+            if C.debug.Debug_herd.monad then
+              let module PP = Pretty.Make(S) in
+              PP.show_es_rfm test es S.RFMap.empty
+          in
           (i,vcl,es)::index xs (i+1) in
       let r =
         EM.get_output_check

--- a/herd/show.ml
+++ b/herd/show.ml
@@ -49,25 +49,30 @@ module Make(O:PrettyConf.S) = struct
   module G = Generator(O)
   let generator = G.generator
 
-  let do_show_file name_dot prog ext =
+  let do_show_file ?(rm_tmp_pdf = not O.debug) name_dot prog ext : unit =
     let name_ps = extfile name_dot ext in
-    Handler.push (fun () -> my_remove name_ps) ;
+    if rm_tmp_pdf then Handler.push (fun () -> my_remove name_ps) ;
     let cmd =
       sprintf
-        "%s -T%s %s > %s 2>/dev/null ; %s %s 2>/dev/null%s"
+        "%s -T%s %s > %s 2>/dev/null ; %s %s 2>/dev/null"
       generator ext
       name_dot name_ps prog name_ps
-        (if O.debug then "" else sprintf " && /bin/rm -f %s" name_ps) in
+    in
+    let cmd =
+      if rm_tmp_pdf then
+        sprintf "%s && /bin/rm -f %s" cmd name_ps
+      else cmd
+    in
     let r = Sys.command cmd in
     if O.debug then eprintf "Command: [%s] -> %i\n" cmd r ;
-    Handler.pop ()
+    if rm_tmp_pdf then Handler.pop ()
 
-let show_file_with_view view name_dot =
-  let open View in
-  match view with
-  | GV -> do_show_file name_dot "gv"  "ps"
-  | Evince -> do_show_file name_dot "evince" "pdf"
-  | Preview -> do_show_file name_dot "open -a Preview" "pdf"
+  let show_file_with_view view name_dot : unit =
+    let open View in
+    match view with
+    | GV -> do_show_file name_dot "gv"  "ps"
+    | Evince -> do_show_file name_dot "evince" "pdf"
+    | Preview -> do_show_file ~rm_tmp_pdf:false name_dot "open -a Preview" "pdf"
 
 let show_file name_dot =
   match O.view with

--- a/herd/show.ml
+++ b/herd/show.ml
@@ -35,59 +35,53 @@ module Make(O:PrettyConf.S) = struct
   module W = Warn.Make(O)
 
   let my_remove name =
-    if not O.debug then
-      try Sys.remove name
-      with e ->
-        W.warn "remove failed: %s" (Printexc.to_string e)
+    try Sys.remove name
+    with e -> W.warn "remove failed: %s" (Printexc.to_string e)
 
-  let extfile name_dot ext =
-    let base =
-      try Filename.chop_extension name_dot
-      with Invalid_argument _ -> name_dot in
-    base ^ "." ^ ext
+  let extfile name_dot ext = (Filename.remove_extension name_dot) ^ "." ^ ext
 
   module G = Generator(O)
   let generator = G.generator
 
-  let do_show_file ?(rm_tmp_pdf = not O.debug) name_dot prog ext : unit =
+  let with_temp_file ?(keep = O.debug) name f =
+    if keep then (
+      if O.debug then
+        Printf.eprintf "The file %s will not be removed.\n%!" name;
+      f ())
+    else (
+      if O.debug then Printf.eprintf "Using tempfile %s\n%!" name;
+      Handler.push (fun () -> my_remove name);
+      f ();
+      my_remove name;
+      Handler.pop ())
+
+  let do_show_file ?(keep_tmp_pdf = O.debug) name_dot prog ext : unit =
     let name_ps = extfile name_dot ext in
-    if rm_tmp_pdf then Handler.push (fun () -> my_remove name_ps) ;
+    with_temp_file ~keep:keep_tmp_pdf name_ps @@ fun () ->
     let cmd =
-      sprintf
-        "%s -T%s %s > %s 2>/dev/null ; %s %s 2>/dev/null"
-      generator ext
-      name_dot name_ps prog name_ps
-    in
-    let cmd =
-      if rm_tmp_pdf then
-        sprintf "%s && /bin/rm -f %s" cmd name_ps
-      else cmd
+      sprintf "%s -T%s %s > %s 2>/dev/null ; %s %s 2>/dev/null" generator ext
+        name_dot name_ps prog name_ps
     in
     let r = Sys.command cmd in
-    if O.debug then eprintf "Command: [%s] -> %i\n" cmd r ;
-    if rm_tmp_pdf then Handler.pop ()
+    if O.debug then eprintf "Command: [%s] -> %i\n" cmd r
 
   let show_file_with_view view name_dot : unit =
     let open View in
     match view with
-    | GV -> do_show_file name_dot "gv"  "ps"
+    | GV -> do_show_file name_dot "gv" "ps"
     | Evince -> do_show_file name_dot "evince" "pdf"
-    | Preview -> do_show_file ~rm_tmp_pdf:false name_dot "open -a Preview" "pdf"
+    | Preview ->
+        do_show_file ~keep_tmp_pdf:true name_dot "open -a Preview" "pdf"
 
-let show_file name_dot =
-  match O.view with
-  | None -> ()
-  | Some v -> show_file_with_view v name_dot
+  let show_file name_dot =
+    match O.view with None -> () | Some v -> show_file_with_view v name_dot
 
-let show ouput_dot =
-  match O.view with
-  | None -> ()
-  | Some view ->
-     let name_dot = Filename.temp_file "herd" ".dot" in
-     Handler.push (fun () -> my_remove name_dot) ;
-     Misc.output_protect ouput_dot name_dot ;
-     show_file_with_view view name_dot ;
-     my_remove name_dot ;
-     Handler.pop ()
-
+  let show ouput_dot =
+    match O.view with
+    | None -> ()
+    | Some view ->
+        let name_dot = Filename.temp_file "herd" ".dot" in
+        with_temp_file name_dot @@ fun () ->
+        Misc.output_protect ouput_dot name_dot;
+        show_file_with_view view name_dot
 end


### PR DESCRIPTION
This PR disable the suppression of the temporary files when viewing with Preview. This leaves the other viewing methods untouched.

I've also added another way of viewing intermediate graphs when `-debug monad` is activated, which shows the anarchic semantics.

The third commit is optional: I've included it because I think the refactoring simplifies the logic and makes it easier to follow. It slightly changes the debug output (more specifically the output on `-debug pretty`). If reviewers don't think it makes sense, I can drop it.

## Notes on the first commit

Justification that this does not cause too much problem is that the default temporary directory is in `/var/folders/.../T` which is [cleaned after 3 days by MacOS](https://apple.stackexchange.com/questions/404355/when-are-per-user-temp-files-in-var-folders-removed).

Other options considered:
1. Using a pipe to remove the temporary file altogether. I think this is a bit too brittle, for example if there are multiple PDFs produced by `dot`. Code could look like the following:
```ocaml
  let do_show_file_pipe ~name_dot ~ext ~prog =
    let cmd = sprintf "bash -c '%s -T%s %s | %s'" generator ext name_dot prog in
    Sys.command cmd |> ignore

  let show_file_with_view view name_dot =
    match view with
    (* ... Untouched other options ... *)
    | Preview -> do_show_file_pipe ~name_dot ~ext:"pdf" ~prog:"open -a Preview -f"
```

2. Leave the process waiting until Preview is closed. This can be done by using the `--wait-apps` argument of `open`. I tend not to close preview at all so that would leave the temporary file until I restart my computer or it is cleaned by MacOS. The waiting process can be interrupted in the command line with `Ctrl+C`, but I think this would prevent the removing of the `pdf` file. 
Another slight different option would be to start a new Preview (with the `--new` argument of `open`) and wait until this one is closed, but this is not how I use Preview so I didn't want to force this usage pattern.
Another slight different option would be to try and leave a children process waiting for Preview to close, by adding a `&` at the end of the command line. This has the same problems as the main variant here, which is that I don't close Preview at all.