### PR TITLE
[gen] Add pair-cell offset annotation for AArch64.

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1619,7 +1619,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     let emit_ldp_reg opt st init rA =
       let r1,r2,st = next_reg2 st in
-      r1,init,pseudo [do_ldp opt r1 r2 rA;add vloc r1 r1 r2;],st
+      let st = A.set_friends r1 [r2] st in
+      r1,init,pseudo [do_ldp opt r1 r2 rA;],st
 
     let emit_ldp_reg opt idx st _p init rA =
       match opt,idx with

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1673,7 +1673,11 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
 
     let emit_obs t = match t with
-    | Code.Ord | Code.Instr-> emit_load_mixed naturalsize 0
+    | Code.Ord | Code.Instr->
+        fun st p init loc ->
+        let r,init,cs,st = emit_load_mixed naturalsize 0 st p init loc in
+        let st = A.add_type (A.of_reg p r) Cfg.typ st in
+        r,init,cs,st
     | Code.Pte->
         fun st p init loc ->
         let r,init,cs,st = LDR.emit_load_var A64.V64 st p init (Misc.add_pte loc) in

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -536,7 +536,9 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       if is_morello then [gcvalue r r] else []
 
     let get_access_size atom =
-      match get_access_atom (Some atom) with
+      match atom with
+      | ArrayCellAccess (_,i) -> szloc,i * MachSize.nbytes szloc
+      | _ -> match get_access_atom (Some atom) with
       | Some sz -> sz
       | None -> MachSize.S128,0
 
@@ -1319,20 +1321,24 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let get_xload_addon atom r1 = match atom with
       | (OrdinaryAccess (`Plain|`Acquire)
         |MixedSizeAccess ((`Plain|`Acquire),_)
+        |ArrayCellAccess ((`Plain|`Acquire),_)
         |MorelloAccess (`Plain|`Acquire)) as atom ->
           emit_ldr_addon (is_morello_access atom) r1
       | _ -> []
 
     let get_xload = function
       | OrdinaryAccess `Plain -> ldxr
-      | (MorelloAccess `Plain|MixedSizeAccess (`Plain,_)) as atom ->
+      | (MorelloAccess `Plain|MixedSizeAccess (`Plain,_)
+        |ArrayCellAccess (`Plain,_)) as atom ->
           let sz,_ = get_access_size atom in
           ldxr_sz XX sz
       | OrdinaryAccess `Acquire -> ldaxr
-      | (MorelloAccess `Acquire|MixedSizeAccess (`Acquire,_)) as atom ->
+      | (MorelloAccess `Acquire|MixedSizeAccess (`Acquire,_)
+        |ArrayCellAccess (`Acquire,_)) as atom ->
           let sz,_ = get_access_size atom in
           ldxr_sz AX sz
       | (OrdinaryAccess `AcquirePC|MixedSizeAccess (`AcquirePC,_)
+        |ArrayCellAccess (`AcquirePC,_)
         |MorelloAccess `AcquirePC) -> Warn.fatal "AcqPC annotation on xload"
       | (MemoryTagAccess|MorelloTagAccess|MorelloSealAccess) -> Warn.fatal "variant annotation on xload"
       | atom -> Warn.fatal "Bad annotation for Lx: %s\n" (pp atom)
@@ -1340,11 +1346,13 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     and get_xstore = function
       | OrdinaryAccess `Plain -> stxr
-      | (MorelloAccess `Plain|MixedSizeAccess (`Plain,_)) as atom ->
+      | (MorelloAccess `Plain|MixedSizeAccess (`Plain,_)
+        |ArrayCellAccess (`Plain,_)) as atom ->
           let sz,_ = get_access_size atom in
           stxr_sz YY sz
       | OrdinaryAccess `Release -> stlxr
-      | (MorelloAccess `Release|MixedSizeAccess (`Release,_)) as atom ->
+      | (MorelloAccess `Release|MixedSizeAccess (`Release,_)
+        |ArrayCellAccess (`Release,_)) as atom ->
           let sz,_ = get_access_size atom in
           stxr_sz LY sz
       | (MemoryTagAccess|MorelloTagAccess|MorelloSealAccess) -> Warn.fatal "variant annotation on xstore"
@@ -1353,6 +1361,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let get_xstore_addon atom r2 r3 e init st p = match atom with
       | (OrdinaryAccess (`Plain|`Release)
         |MixedSizeAccess ((`Plain|`Release),_)
+        |ArrayCellAccess ((`Plain|`Release),_)
         |MorelloAccess (`Plain|`Release)) as atom ->
           emit_str_addon st p init r2 r3 (is_morello_access atom) e
       | _ -> init,[],st
@@ -1692,7 +1701,11 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
 
     let emit_obs t = match t with
-    | Code.Ord | Code.Instr-> emit_load_mixed naturalsize 0
+    | Code.Ord | Code.Instr->
+        fun st p init loc ->
+        let r,init,cs,st = emit_load_mixed naturalsize 0 st p init loc in
+        let st = A.add_type (A.of_reg p r) Cfg.typ st in
+        r,init,cs,st
     | Code.Pte->
         fun st p init loc ->
         let r,init,cs,st = LDR.emit_load_var A64.V64 st p init (Misc.add_pte loc) in
@@ -1811,8 +1824,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | R,OrdinaryAccess `Acquire ->
             let r,init,cs,st = LDAR.emit_load st p init loc in
             Some (Some r,init,cs,st)
-        | R,(MorelloAccess `Acquire as atom)
-        | R,(MixedSizeAccess (`Acquire,_) as atom) ->
+        | R,((MorelloAccess `Acquire|MixedSizeAccess (`Acquire,_)
+             |ArrayCellAccess (`Acquire,_)) as atom) ->
             let sz,o = get_access_size atom in
             let module L =
               LOAD
@@ -1829,8 +1842,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | R,OrdinaryAccess `AcquirePC ->
             let r,init,cs,st = LDAPR.emit_load st p init loc in
             Some (Some r,init,cs,st)
-        | R,(MorelloAccess `AcquirePC as atom)
-        | R,(MixedSizeAccess (`AcquirePC,_) as atom) ->
+        | R,((MorelloAccess `AcquirePC|MixedSizeAccess (`AcquirePC,_)
+             |ArrayCellAccess (`AcquirePC,_)) as atom) ->
             let sz,o = get_access_size atom in
             let module L =
               LOAD
@@ -1850,8 +1863,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | R,Atomic (rw,AtomicSize (sz,o)) ->
             let r,init,cs,st = emit_lda_mixed sz o rw st p init loc in
             Some (Some r,init,cs,st)
-        | R,(MorelloAccess `Plain as atom)
-        | R,(MixedSizeAccess (`Plain,_) as atom) ->
+        | R,((MorelloAccess `Plain|MixedSizeAccess (`Plain,_)
+             |ArrayCellAccess (`Plain,_)) as atom) ->
             let sz,o = get_access_size atom in
             let r,init,cs,st = emit_load_mixed sz o st p init loc in
             let cs2 = emit_ldr_addon (is_morello_access atom) r in
@@ -1896,15 +1909,15 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | W,Atomic (rw,AtomicSize (sz,o)) ->
             let r,init,cs,st = emit_sta_mixed sz o rw st p init loc (Value.to_int e.C.v) in
             Some (Some r,init,cs,st)
-        | W,(MorelloAccess `Plain as atom)
-        | W,(MixedSizeAccess (`Plain,_) as atom) ->
+        | W,((MorelloAccess `Plain|MixedSizeAccess (`Plain,_)
+             |ArrayCellAccess (`Plain,_)) as atom) ->
             let sz,o = get_access_size atom in
             let is_morello = is_morello_access atom in
             let init,cs,st =
               emit_store_mixed sz o st p init loc (Value.to_int e.C.v) is_morello e in
             Some (None,init,cs,st)
-        | W,(MorelloAccess `Release as atom)
-        | W,(MixedSizeAccess (`Release,_) as atom) ->
+        | W,((MorelloAccess `Release|MixedSizeAccess (`Release,_)
+             |ArrayCellAccess (`Release,_)) as atom) ->
             let sz,o = get_access_size atom in
             let is_morello = is_morello_access atom in
             let module S =
@@ -2122,7 +2135,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     let do_rmw_type a1 a2 =
       let capa_opt = function
-      | OrdinaryAccess o|MixedSizeAccess (o,_) -> Some (false,o)
+      | OrdinaryAccess o|MixedSizeAccess (o,_)|ArrayCellAccess (o,_) ->
+          Some (false,o)
       | MorelloAccess o -> Some (true,o)
       | _ -> None in
       match capa_opt a1,capa_opt a2 with
@@ -2345,8 +2359,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let r,init,cs,st =
                 LDAR.emit_load_idx_var vloc vdep st p init loc r2 in
               Some (Some r,init,pseudo cs0@cs,st)
-          | R,(MorelloAccess `Acquire as atom)
-          | R,(MixedSizeAccess (`Acquire,_) as atom) ->
+          | R,((MorelloAccess `Acquire|MixedSizeAccess (`Acquire,_)
+               |ArrayCellAccess (`Acquire,_)) as atom) ->
               let sz,o = get_access_size atom in
              let load =
                do_emit_load_idx_var
@@ -2360,8 +2374,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let r,init,cs,st =
                 LDAPR.emit_load_idx_var vloc vdep st p init loc r2 in
               Some (Some r,init,pseudo cs0@cs,st)
-          | R,(MorelloAccess `AcquirePC as atom)
-          | R,(MixedSizeAccess (`AcquirePC,_) as atom) ->
+          | R,((MorelloAccess `AcquirePC|MixedSizeAccess (`AcquirePC,_)
+               |ArrayCellAccess (`AcquirePC,_)) as atom) ->
               let sz,o = get_access_size atom in
              let load =
                do_emit_load_idx_var
@@ -2432,8 +2446,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
                   end) in
               let init,cs,st = STLR.emit_store_idx st p init loc r2 (Value.to_int e.C.v) false C.evt_null in
               Some (None,init,pseudo cs0@cs,st)
-          | W,(MorelloAccess `Release as atom)
-          | W,(MixedSizeAccess (`Release,_) as atom) ->
+          | W,((MorelloAccess `Release|MixedSizeAccess (`Release,_)
+               |ArrayCellAccess (`Release,_)) as atom) ->
               let sz,o = get_access_size atom in
               let is_morello = is_morello_access atom in
               let module S =
@@ -2460,8 +2474,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let r,init,cs,st =
                 emit_sta_mixed_idx sz o rw st p init loc r2 (Value.to_int e.C.v) in
               Some (Some r,init,pseudo cs0@cs,st)
-          | R,(MorelloAccess `Plain as atom)
-          | R,(MixedSizeAccess (`Plain,_) as atom) ->
+          | R,((MorelloAccess `Plain|MixedSizeAccess (`Plain,_)
+               |ArrayCellAccess (`Plain,_)) as atom) ->
              let sz,o = get_access_size atom in
              let load_idx sz _ st r1 r2 idx =
                let cs = [ldr_mixed_idx vdep r1 r2 idx sz] in
@@ -2474,8 +2488,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
              let r,init,cs,st = load st p init loc r2 in
              let cs2 = emit_ldr_addon (is_morello_access atom) r in
              Some (Some r,init,pseudo cs0@cs@pseudo cs2,st)
-          | W,(MorelloAccess `Plain as atom)
-          | W,(MixedSizeAccess (`Plain,_) as atom) ->
+          | W,((MorelloAccess `Plain|MixedSizeAccess (`Plain,_)
+               |ArrayCellAccess (`Plain,_)) as atom) ->
               let sz,o = get_access_size atom in
               let is_morello = is_morello_access atom in
               let module S =
@@ -2551,12 +2565,15 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | Some result -> result
           | None -> begin match d,structured_atom with
           | R,(OrdinaryAccess `Release|MixedSizeAccess (`Release,_)
+            |ArrayCellAccess (`Release,_)
             |MorelloAccess `Release) ->
               Warn.fatal "No load release"
           | W,(OrdinaryAccess `Acquire|MixedSizeAccess (`Acquire,_)
+            |ArrayCellAccess (`Acquire,_)
             |MorelloAccess `Acquire) ->
               Warn.fatal "No store acquire"
           | W,(OrdinaryAccess `AcquirePC|MixedSizeAccess (`AcquirePC,_)
+            |ArrayCellAccess (`AcquirePC,_)
             |MorelloAccess `AcquirePC) ->
               Warn.fatal "No store acquirePc"
           | (W|R) as d,atom -> fatal_annotation d atom
@@ -2660,6 +2677,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
                 rB,pseudo (cs0@cB),init,st,[]
             | (MixedSizeAccess (`Plain,_)
               |MixedSizeAccess (`Release,_)
+              |ArrayCellAccess ((`Plain|`Release),_)
               |Atomic (_,AtomicSize _)
               |MorelloAccess `Plain|MorelloAccess `Release) as atom ->
                 let sz,_ = get_access_size atom in
@@ -2698,8 +2716,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let init,cs,st =
                 STLR.emit_store_reg st p init loc r2 false C.evt_null in
               Some (None,init,cs2@cs,st)
-          | (MorelloAccess `Release as atom)
-          | (MixedSizeAccess (`Release,_) as atom) ->
+          | ((MorelloAccess `Release|MixedSizeAccess (`Release,_)
+             |ArrayCellAccess (`Release,_)) as atom) ->
               let sz,o = get_access_size atom in
               let is_morello = is_morello_access atom in
               let module S =
@@ -2720,8 +2738,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               Some (Some r,init,cs2@cs,st)
           | InstrAccess ->
               Warn.fatal "No Plain Write to label (code location)"
-          | (MorelloAccess `Plain as atom)
-          | (MixedSizeAccess (`Plain,_) as atom) ->
+          | ((MorelloAccess `Plain|MixedSizeAccess (`Plain,_)
+             |ArrayCellAccess (`Plain,_)) as atom) ->
               let sz,o = get_access_size atom in
               let is_morello = is_morello_access atom in
               let module S =
@@ -2794,9 +2812,11 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | Some result -> result
           | None -> begin match structured_atom with
           | (OrdinaryAccess `Acquire|MixedSizeAccess (`Acquire,_)
+            |ArrayCellAccess (`Acquire,_)
             |MorelloAccess `Acquire) ->
               Warn.fatal "No store acquire"
           | (OrdinaryAccess `AcquirePC|MixedSizeAccess (`AcquirePC,_)
+            |ArrayCellAccess (`AcquirePC,_)
             |MorelloAccess `AcquirePC) ->
               Warn.fatal "No store acquirePc"
           | atom -> fatal_annotation W atom

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -1657,7 +1657,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     let emit_ldp_reg opt st init rA =
       let r1,r2,st = next_reg2 st in
-      r1,init,pseudo [do_ldp opt r1 r2 rA;add vloc r1 r1 r2;],st
+      let st = A.set_friends r1 [r2] st in
+      r1,init,pseudo [do_ldp opt r1 r2 rA;],st
 
     let emit_ldp opt st p init loc =
       let rA,init,st =  U.next_init st p init loc in

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -946,10 +946,16 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     let do_emit_mov_sz emit_mov_sz sz st p init v =
       let rA,init,csi,st = emit_mov_sz sz st p init v in
-      let st =
+      let needs_type = match csi with
+      | [] -> true
+      | _::_ ->
+          Variant_gen.is_mixed Cfg.variant ||
+          Cfg.variant Variant_gen.Morello in
+      let st = if needs_type then
         let loc = A.of_reg p rA in
         let t = type_of_sz sz in
-        A.add_type loc t st in
+        A.add_type loc t st
+      else st in
       rA,init,csi,st
 
       let emit_mov_sz = do_emit_mov_sz U.emit_mov_sz

--- a/gen/common/AArch64Arch_gen.ml
+++ b/gen/common/AArch64Arch_gen.ml
@@ -629,7 +629,11 @@ let is_tthm fields =
      let r = fold_atom_rw (fun rw -> f (Atomic rw)) r in
      r
 
-   let fold_non_mixed f r = fold_acc false (fun acc r -> f (acc,None) r) r
+   let fold_non_mixed f r =
+     let r = fold_acc false (fun acc r -> f (acc,None) r) r in
+     if do_mixed then r
+     (* Add an annotation to access the second cell of a pair. *)
+     else f (Plain None,Some (C.naturalsize,MachSize.nbytes C.naturalsize)) r
 
    let fold_atom f r =
      let r = fold_non_mixed f r in
@@ -805,6 +809,7 @@ let overwrite_value v ao w = match ao with
 
 (* Wide accesses *)
 
+   (* Return the number of cells required by size-access `atom`. *)
    let as_integers a =
      Misc.seq_opt
        (function
@@ -812,6 +817,9 @@ let overwrite_value v ao w = match ao with
                        | 1 -> None
                        | n -> Some n)
         | Pair _,_ -> Some 2
+        | (Plain _|Acq _|AcqPc _|Rel _|Atomic _),Some (_,o) ->
+            let n = o / MachSize.nbytes C.naturalsize + 1 in
+            if n > 1 then Some n else None
         | _ -> None)
        a
 

--- a/gen/common/AArch64Arch_gen.ml
+++ b/gen/common/AArch64Arch_gen.ml
@@ -288,6 +288,7 @@ module StructuredAtom : sig
   type t =
     | OrdinaryAccess of access_order
     | MixedSizeAccess of access_order * MachMixed.t
+    | ArrayCellAccess of access_order * int
     | MorelloAccess of access_order
     | PteAccess of atom_pte
     | NeonAccess of neon_opt
@@ -339,6 +340,8 @@ end = struct
     | OrdinaryAccess of access_order
     (* Mixed-size slice of an ordinary access, as in `b0`, `h0`, or `w0`. *)
     | MixedSizeAccess of access_order * MachMixed.t
+    (* Natural-sized scalar access to a zero-based cell projection. *)
+    | ArrayCellAccess of access_order * int
     (* Morello capability data access, as in `Pc`, `Ac`, `Qc`, or `Lc`. *)
     | MorelloAccess of access_order
     (* VMSA PTE access, as in `Pte`, `PteA`, `PteV1`, or `PteHA`. *)
@@ -393,9 +396,11 @@ end = struct
     | MemoryTagAccess -> 8
     | PairAccess _ -> 9
     | InstrAccess -> 10
+    | ArrayCellAccess _ -> 11
 
   let access_order = function
     | OrdinaryAccess o|MixedSizeAccess (o,_)|MorelloAccess o -> Some o
+    | ArrayCellAccess (o,_) -> Some o
     | PteAccess (Read o|ReadHA o) -> Some (o :> access_order)
     | PteAccess (Set (o,_)) -> Some (o :> access_order)
     | Atomic _|MorelloTagAccess|MorelloSealAccess|MemoryTagAccess
@@ -408,6 +413,8 @@ end = struct
         | MorelloAccess o1,MorelloAccess o2 -> compare_access_order o1 o2
         | MixedSizeAccess (o1,m1),MixedSizeAccess (o2,m2) ->
             Misc.pair_compare compare_access_order compare_mixed (o1,m1) (o2,m2)
+        | ArrayCellAccess (o1,i1),ArrayCellAccess (o2,i2) ->
+            Misc.pair_compare compare_access_order Misc.int_compare (o1,i1) (o2,i2)
         | PteAccess p1,PteAccess p2 -> compare_atom_pte p1 p2
         | NeonAccess n1,NeonAccess n2 -> SIMD.compare n1 n2
         | Atomic (rw1,a1),Atomic (rw2,a2) ->
@@ -446,6 +453,11 @@ end = struct
     | MixedSizeAccess (`Plain,m) -> pp_mixed m
     | MixedSizeAccess (access_order,m) ->
         sprintf "%s.%s" (pp_access_order "" access_order) (pp_mixed m)
+    | ArrayCellAccess (`Plain,i) ->
+        pp_mixed (C.naturalsize,i * MachSize.nbytes C.naturalsize)
+    | ArrayCellAccess (access_order,i) ->
+        sprintf "%s.%s" (pp_access_order "" access_order)
+          (pp_mixed (C.naturalsize,i * MachSize.nbytes C.naturalsize))
     | Atomic (rw,AtomicSize m) ->
         sprintf "X%s.%s" (pp_atom_rw rw) (pp_mixed m)
     | MorelloAccess access_order ->
@@ -476,6 +488,8 @@ end = struct
     | None -> None
     | Some (MixedSizeAccess (_,m)
       |Atomic (_,AtomicSize m)) -> Some m
+    | Some (ArrayCellAccess (_,i)) ->
+        Some (C.naturalsize,i * MachSize.nbytes C.naturalsize)
     | Some _ -> None
 
   let set_access_atom atom m =
@@ -518,6 +532,11 @@ end = struct
         | n -> Some n
         end
     | Some (PairAccess _) -> Some 2
+    | Some (ArrayCellAccess (_,i)) -> Some (i+1)
+    | Some (MixedSizeAccess (_,(_,o))
+           |Atomic (_,AtomicSize (_,o))) ->
+        let n = o / MachSize.nbytes C.naturalsize + 1 in
+        if n > 1 then Some n else None
     | Some _|None -> None
 
   let worth_final = function
@@ -542,14 +561,17 @@ end = struct
     | NeonAccess SIMD.NeRel,R -> false
     | (OrdinaryAccess (`Acquire|`AcquirePC)
       |MixedSizeAccess ((`Acquire|`AcquirePC),_)
+      |ArrayCellAccess ((`Acquire|`AcquirePC),_)
       |MorelloAccess (`Acquire|`AcquirePC)),R -> true
     | (OrdinaryAccess `Release|MixedSizeAccess (`Release,_)
+      |ArrayCellAccess (`Release,_)
       |MorelloAccess `Release),W -> true
     | PteAccess (Read _|ReadHA _),R -> true
     | PteAccess (Set (`Plain,pte)),R when WPTESet.mem WPTE.HA pte -> true
     | PteAccess (Set _),W -> true
     | InstrAccess,R -> true
     | (OrdinaryAccess `Plain|MixedSizeAccess (`Plain,_)
+      |ArrayCellAccess (`Plain,_)
       |MorelloAccess `Plain),(R|W)
     | Atomic _,(R|W)
     | (MemoryTagAccess|MorelloTagAccess|MorelloSealAccess),(R|W)
@@ -562,16 +584,20 @@ end = struct
     let ok_rw ar aw = match ar,aw with
       | (None|Some (OrdinaryAccess (`Plain|`Acquire))
         |Some (MixedSizeAccess ((`Plain|`Acquire),_))
+        |Some (ArrayCellAccess ((`Plain|`Acquire),_))
         |Some (MorelloAccess (`Plain|`Acquire))),
         (None|Some (OrdinaryAccess (`Plain|`Release))
         |Some (MixedSizeAccess ((`Plain|`Release),_))
+        |Some (ArrayCellAccess ((`Plain|`Release),_))
         |Some (MorelloAccess (`Plain|`Release))) -> true
       | _,_ -> false in
     let ok_w ar aw = match ar,aw with
       | (None|Some (OrdinaryAccess `Plain)
-        |Some (MixedSizeAccess (`Plain,_))|Some (MorelloAccess `Plain)),
+        |Some (MixedSizeAccess (`Plain,_))|Some (ArrayCellAccess (`Plain,_))
+        |Some (MorelloAccess `Plain)),
         (None|Some (OrdinaryAccess (`Plain|`Release))
         |Some (MixedSizeAccess ((`Plain|`Release),_))
+        |Some (ArrayCellAccess ((`Plain|`Release),_))
         |Some (MorelloAccess (`Plain|`Release))) -> true
       | _,_ -> false in
     let same_mixed =
@@ -597,7 +623,8 @@ end = struct
     | NeonAccess n -> Code.VecReg n
     | PairAccess _ -> Code.Pair
     | InstrAccess -> Code.Instr
-    | (OrdinaryAccess _|MixedSizeAccess _|MorelloAccess _|Atomic _) -> Code.Ord
+    | (OrdinaryAccess _|MixedSizeAccess _|ArrayCellAccess _
+      |MorelloAccess _|Atomic _) -> Code.Ord
 
   let merge a1 a2 =
     let open WPTE in
@@ -619,6 +646,11 @@ end = struct
           | Some order -> Some (MixedSizeAccess (order,m))
           | None -> None
         end
+    | ArrayCellAccess (o1,i),OrdinaryAccess o2
+    | OrdinaryAccess o2,ArrayCellAccess (o1,i) ->
+        Option.map (fun order -> ArrayCellAccess (order,i)) (merge_order o1 o2)
+    | ArrayCellAccess (o1,i1),ArrayCellAccess (o2,i2) when i1 = i2 ->
+        Option.map (fun order -> ArrayCellAccess (order,i1)) (merge_order o1 o2)
     | MixedSizeAccess (o1,m1),MixedSizeAccess (o2,m2) -> begin
           match o1,o2 with
           | `Plain,order -> Some (MixedSizeAccess (order,m1))
@@ -672,7 +704,9 @@ end = struct
 
   let fold_pair_access f r =
     let add opt = f (PairAccess opt) in
-    r |> add `Pa |> add `PaN |> add `PaIQ |> add `PaIL |> add `PaA |> add `PaL
+    r
+    |> f (ArrayCellAccess (`Plain,1))
+    |> add `Pa |> add `PaN |> add `PaIQ |> add `PaIL |> add `PaA |> add `PaL
 
   let fold_mixed f r =
     let open MachSize in

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -458,7 +458,11 @@ let find_non_pseudo_prev m = find_edge_prev non_pseudo m
 
   let is_pair n = match n.evt.loc with
       | Data loc ->
-         if E.is_pair n.edge then Some loc
+         if E.is_pair n.edge ||
+            match E.get_access_atom n.evt.atom with
+            | Some (sz,_) -> sz = O.naturalsize
+            | None -> false
+         then Some loc
          else None
       | Code _ -> None
 

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -443,6 +443,19 @@ let find_non_pseudo_prev m = find_edge_prev non_pseudo m
         | None-> k)
     m StringMap.empty
 
+  (* Map a size annotation to the cell index.
+     Return the residual annotation after selecting the cell,
+     - `w4` over `int32_t` selects cell 1, (1, None)
+     - `w4` over `int64_t` and `fullmixed` selects cell 0, but keep the atom
+        for the mixed access (0, Some `w4`) *)
+  let split_access_atom atom =
+    match E.get_access_atom atom with
+    | Some (_,o) ->
+        let cell_idx = o / MachSize.nbytes O.naturalsize in
+        let atom = if cell_idx = 0 then atom else None in
+        cell_idx,atom
+    | None -> 0,atom
+
   let is_pair n = match n.evt.loc with
       | Data loc ->
          if E.is_pair n.edge then Some loc
@@ -535,7 +548,8 @@ module CoSt = struct
   let update_cell_on_write st n =
     let e = n.evt in match e.bank with
     | Ord|Pair -> begin
-       let old = st.co_cell.(0) in
+       let idx,atom = split_access_atom e.atom in
+       let old = st.co_cell.(idx) in
        let co_cell = Array.copy st.co_cell in
        let cell2 =
          match n.prev.edge.E.edge with
@@ -546,7 +560,7 @@ module CoSt = struct
        begin
          match e.bank with
          | Ord ->
-            co_cell.(0) <- E.overwrite_value old e.atom cell2
+            co_cell.(idx) <- E.overwrite_value old atom cell2
          | Pair -> (* No Rmw for pairs *)
             let width = Value.from_int ((Value.to_int e.v) - 1) in
             co_cell.(0) <- E.overwrite_value old e.atom width;
@@ -913,7 +927,9 @@ let check_cycle c =
     if v = n.evt.v then
       Warn.fatal "Updated value remains the same. An issue should be reported.";
     let st = CoSt.implicit_pte_update st W in
-    n.evt <- { n.evt with v = tr_value n.evt v; } ;
+    let idx,_ = split_access_atom n.evt.atom in
+    let v = if idx = 0 then tr_value n.evt v else v in
+    n.evt <- { n.evt with v; } ;
     (* Writing Ord resets morello tag *)
     let st = CoSt.set_co st CapaTag evt_null.ctag in
     let e,st = CoSt.update_cell_on_write st n in
@@ -1149,7 +1165,8 @@ let set_dep_v nss =
 (* TODO: this is wrong for Store CR's: consider Rfi Store PosRR *)
 let set_read_individual_v n cell check_value =
   let e = n.evt in
-  let v = E.extract_value cell.(0) e.atom in
+  let idx,atom = split_access_atom e.atom in
+  let v = E.extract_value cell.(idx) atom in
 (* eprintf "SET READ: cell=0x%x, v=0x%x\n" cell v ; *)
   let e = { e with v=v; check_value } in
   n.evt <- e

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -1172,7 +1172,7 @@ let set_read_individual_v n cell check_value =
   let idx,atom = split_access_atom e.atom in
   let v = E.extract_value cell.(idx) atom in
 (* eprintf "SET READ: cell=0x%x, v=0x%x\n" cell v ; *)
-  let e = { e with v=v; check_value } in
+  let e = { e with v=v; cell=[|v|]; check_value } in
   n.evt <- e
 (* eprintf "AFTER %a\n" debug_node n *)
 
@@ -1180,8 +1180,7 @@ let set_read_pair_v n cell check_value =
   let e = n.evt in
   let v0 = E.extract_value cell.(0) e.atom
   and v1 = E.extract_value cell.(1) e.atom in
-  let v = Value.from_int (Value.to_int v0 + Value.to_int v1) in
-  let e = { e with v; cell=[|v0;v1|]; check_value } in
+  let e = { e with v=v0; cell=[|v0;v1|]; check_value } in
   n.evt <- e
 
 (* Assume all the events are for the same location,

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -1174,10 +1174,10 @@ let set_read_individual_v n cell check_value =
 
 let set_read_pair_v n cell check_value =
   let e = n.evt in
-  let v0 = E.extract_value cell.(0) e.atom |> Value.to_int
-  and v1 =  E.extract_value cell.(1) e.atom |> Value.to_int in
-  let v = v0 + v1 |> Value.from_int in
-  let e = { e with v=v; check_value } in
+  let v0 = E.extract_value cell.(0) e.atom
+  and v1 = E.extract_value cell.(1) e.atom in
+  let v = Value.from_int (Value.to_int v0 + Value.to_int v1) in
+  let e = { e with v; cell=[|v0;v1|]; check_value } in
   n.evt <- e
 
 (* Assume all the events are for the same location,

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -1172,16 +1172,15 @@ let set_read_individual_v n cell check_value =
   let idx,atom = split_access_atom e.atom in
   let v = E.extract_value cell.(idx) atom in
 (* eprintf "SET READ: cell=0x%x, v=0x%x\n" cell v ; *)
-  let e = { e with v=v; check_value } in
+  let e = { e with v=v; cell=[|v|]; check_value } in
   n.evt <- e
 (* eprintf "AFTER %a\n" debug_node n *)
 
 let set_read_pair_v n cell check_value =
   let e = n.evt in
-  let v0 = E.extract_value cell.(0) e.atom |> Value.to_int
-  and v1 =  E.extract_value cell.(1) e.atom |> Value.to_int in
-  let v = v0 + v1 |> Value.from_int in
-  let e = { e with v=v; check_value } in
+  let v0 = E.extract_value cell.(0) e.atom
+  and v1 = E.extract_value cell.(1) e.atom in
+  let e = { e with v=v0; cell=[|v0;v1|]; check_value } in
   n.evt <- e
 
 (* Assume all the events are for the same location,

--- a/gen/cycle.ml
+++ b/gen/cycle.ml
@@ -443,9 +443,26 @@ let find_non_pseudo_prev m = find_edge_prev non_pseudo m
         | None-> k)
     m StringMap.empty
 
+  (* Map a size annotation to the cell index.
+     Return the residual annotation after selecting the cell,
+     - `w4` over `int32_t` selects cell 1, (1, None)
+     - `w4` over `int64_t` and `fullmixed` selects cell 0, but keep the atom
+        for the mixed access (0, Some `w4`) *)
+  let split_access_atom atom =
+    match E.get_access_atom atom with
+    | Some (_,o) ->
+        let cell_idx = o / MachSize.nbytes O.naturalsize in
+        let atom = if cell_idx = 0 then atom else None in
+        cell_idx,atom
+    | None -> 0,atom
+
   let is_pair n = match n.evt.loc with
       | Data loc ->
-         if E.is_pair n.edge then Some loc
+         if E.is_pair n.edge ||
+            match E.get_access_atom n.evt.atom with
+            | Some (sz,_) -> sz = O.naturalsize
+            | None -> false
+         then Some loc
          else None
       | Code _ -> None
 
@@ -535,7 +552,8 @@ module CoSt = struct
   let update_cell_on_write st n =
     let e = n.evt in match e.bank with
     | Ord|Pair -> begin
-       let old = st.co_cell.(0) in
+       let idx,atom = split_access_atom e.atom in
+       let old = st.co_cell.(idx) in
        let co_cell = Array.copy st.co_cell in
        let cell2 =
          match n.prev.edge.E.edge with
@@ -546,7 +564,7 @@ module CoSt = struct
        begin
          match e.bank with
          | Ord ->
-            co_cell.(0) <- E.overwrite_value old e.atom cell2
+            co_cell.(idx) <- E.overwrite_value old atom cell2
          | Pair -> (* No Rmw for pairs *)
             let width = Value.from_int ((Value.to_int e.v) - 1) in
             co_cell.(0) <- E.overwrite_value old e.atom width;
@@ -913,7 +931,9 @@ let check_cycle c =
     if v = n.evt.v then
       Warn.fatal "Updated value remains the same. An issue should be reported.";
     let st = CoSt.implicit_pte_update st W in
-    n.evt <- { n.evt with v = tr_value n.evt v; } ;
+    let idx,_ = split_access_atom n.evt.atom in
+    let v = if idx = 0 then tr_value n.evt v else v in
+    n.evt <- { n.evt with v; } ;
     (* Writing Ord resets morello tag *)
     let st = CoSt.set_co st CapaTag evt_null.ctag in
     let e,st = CoSt.update_cell_on_write st n in
@@ -1149,7 +1169,8 @@ let set_dep_v nss =
 (* TODO: this is wrong for Store CR's: consider Rfi Store PosRR *)
 let set_read_individual_v n cell check_value =
   let e = n.evt in
-  let v = E.extract_value cell.(0) e.atom in
+  let idx,atom = split_access_atom e.atom in
+  let v = E.extract_value cell.(idx) atom in
 (* eprintf "SET READ: cell=0x%x, v=0x%x\n" cell v ; *)
   let e = { e with v=v; check_value } in
   n.evt <- e

--- a/gen/final.ml
+++ b/gen/final.ml
@@ -178,11 +178,12 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
             | Code.CapaTag
             | Code.CapaSeal
             | Code.Ord
-            | Code.Pair
             | Code.Instr
             | Code.Pte
               ->
                 Some (I evt.C.C.v)
+            | Code.Pair ->
+                Some (I evt.C.C.cell.(0))
             | Code.VecReg _->
                let v0 =
                  match evt.C.C.vecreg with
@@ -216,6 +217,10 @@ module Make : functor (O:Config) -> functor (C:ArchRun.S) ->
                      |> Code.add_vector O.hexa ) ) vs
                 | _ -> assert false
                 end
+             | Code.Pair ->
+                Array.to_list evt.C.C.cell
+                |> List.tl
+                |> List.map (fun v -> I v)
              | _ -> [] in
            let m = C.C.EventMap.add n.C.C.evt (C.A.of_reg p r) m in
            let fs =

--- a/gen/tests/AArch64/CoRW1+amo.casq8q8-rfiq8q8.litmus
+++ b/gen/tests/AArch64/CoRW1+amo.casq8q8-rfiq8q8.litmus
@@ -1,0 +1,13 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc -type int64_t q8 Amo.Cas q8 Rfi *)
+AArch64 CoRW1+amo.casq8q8-rfiq8q8
+{
+ int64_t x[2]={0,0};
+ 0:X0=x; uint64_t 0:X1=0; uint64_t 0:X2=0;
+}
+ P0             ;
+ MOV X1,#1      ;
+ MOV X2,#1      ;
+ ADD X3,X0,#8   ;
+ CAS X1,X2,[X3] ;
+
+exists (0:X1=1)

--- a/gen/tests/AArch64/CoRW1+amo.casq8q8-rfiq8q8.litmus
+++ b/gen/tests/AArch64/CoRW1+amo.casq8q8-rfiq8q8.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+amo.casq8q8-rfiq8q8
 {
  int64_t x[2]={0,0};
- 0:X0=x; uint64_t 0:X1=0; uint64_t 0:X2=0;
+ 0:X0=x; int64_t 0:X1=0;
 }
  P0             ;
  MOV X1,#1      ;

--- a/gen/tests/AArch64/CoRW1+amo.casw4w4-rfiw4w4.litmus
+++ b/gen/tests/AArch64/CoRW1+amo.casw4w4-rfiw4w4.litmus
@@ -1,0 +1,13 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc w4 Amo.Cas w4 Rfi *)
+AArch64 CoRW1+amo.casw4w4-rfiw4w4
+{
+ int x[2]={0,0};
+ 0:X0=x; uint32_t 0:X1=0; uint32_t 0:X2=0;
+}
+ P0             ;
+ MOV W1,#1      ;
+ MOV W2,#1      ;
+ ADD X3,X0,#4   ;
+ CAS W1,W2,[X3] ;
+
+exists (0:X1=1)

--- a/gen/tests/AArch64/CoRW1+amo.casw4w4-rfiw4w4.litmus
+++ b/gen/tests/AArch64/CoRW1+amo.casw4w4-rfiw4w4.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+amo.casw4w4-rfiw4w4
 {
  int x[2]={0,0};
- 0:X0=x; uint32_t 0:X1=0; uint32_t 0:X2=0;
+ 0:X0=x;
 }
  P0             ;
  MOV W1,#1      ;

--- a/gen/tests/AArch64/CoRW1+amo.swpq8q8-rfiq8q8.litmus
+++ b/gen/tests/AArch64/CoRW1+amo.swpq8q8-rfiq8q8.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+amo.swpq8q8-rfiq8q8
 {
  int64_t x[2]={0,0};
- 0:X0=x; int64_t 0:X1=0; uint64_t 0:X2=0;
+ 0:X0=x; int64_t 0:X1=0;
 }
  P0             ;
  MOV X2,#1      ;

--- a/gen/tests/AArch64/CoRW1+amo.swpq8q8-rfiq8q8.litmus
+++ b/gen/tests/AArch64/CoRW1+amo.swpq8q8-rfiq8q8.litmus
@@ -1,0 +1,12 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc -type int64_t q8 Amo.Swp q8 Rfi *)
+AArch64 CoRW1+amo.swpq8q8-rfiq8q8
+{
+ int64_t x[2]={0,0};
+ 0:X0=x; int64_t 0:X1=0; uint64_t 0:X2=0;
+}
+ P0             ;
+ MOV X2,#1      ;
+ ADD X3,X0,#8   ;
+ SWP X2,X1,[X3] ;
+
+exists (0:X1=1)

--- a/gen/tests/AArch64/CoRW1+amo.swpw4w4-rfiw4w4.litmus
+++ b/gen/tests/AArch64/CoRW1+amo.swpw4w4-rfiw4w4.litmus
@@ -1,0 +1,12 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc w4 Amo.Swp w4 Rfi *)
+AArch64 CoRW1+amo.swpw4w4-rfiw4w4
+{
+ int x[2]={0,0};
+ 0:X0=x; uint32_t 0:X2=0;
+}
+ P0             ;
+ MOV W2,#1      ;
+ ADD X3,X0,#4   ;
+ SWP W2,W1,[X3] ;
+
+exists (0:X1=1)

--- a/gen/tests/AArch64/CoRW1+amo.swpw4w4-rfiw4w4.litmus
+++ b/gen/tests/AArch64/CoRW1+amo.swpw4w4-rfiw4w4.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+amo.swpw4w4-rfiw4w4
 {
  int x[2]={0,0};
- 0:X0=x; uint32_t 0:X2=0;
+ 0:X0=x;
 }
  P0             ;
  MOV W2,#1      ;

--- a/gen/tests/AArch64/CoRW1+ctrlspaap-rfippaa.litmus
+++ b/gen/tests/AArch64/CoRW1+ctrlspaap-rfippaa.litmus
@@ -6,10 +6,9 @@ AArch64 CoRW1+ctrlspaap-rfippaa
 }
  P0              ;
  LDAP W1,W2,[X0] ;
- ADD W1,W1,W2    ;
  CBNZ W1,LC00    ;
  LC00:           ;
  MOV W3,#1       ;
  STR W3,[X0]     ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+ctrlspaiqp-rfippaiq.litmus
+++ b/gen/tests/AArch64/CoRW1+ctrlspaiqp-rfippaiq.litmus
@@ -6,10 +6,9 @@ AArch64 CoRW1+ctrlspaiqp-rfippaiq
 }
  P0                ;
  LDIAPP W1,W2,[X0] ;
- ADD W1,W1,W2      ;
  CBNZ W1,LC00      ;
  LC00:             ;
  MOV W3,#1         ;
  STR W3,[X0]       ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+ctrlspanp-rfippan.litmus
+++ b/gen/tests/AArch64/CoRW1+ctrlspanp-rfippan.litmus
@@ -6,10 +6,9 @@ AArch64 CoRW1+ctrlspanp-rfippan
 }
  P0              ;
  LDNP W1,W2,[X0] ;
- ADD W1,W1,W2    ;
  CBNZ W1,LC00    ;
  LC00:           ;
  MOV W3,#1       ;
  STR W3,[X0]     ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+ctrlspap-rfippa.litmus
+++ b/gen/tests/AArch64/CoRW1+ctrlspap-rfippa.litmus
@@ -6,10 +6,9 @@ AArch64 CoRW1+ctrlspap-rfippa
 }
  P0             ;
  LDP W1,W2,[X0] ;
- ADD W1,W1,W2   ;
  CBNZ W1,LC00   ;
  LC00:          ;
  MOV W3,#1      ;
  STR W3,[X0]    ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+dataspaap-rfippaa.litmus
+++ b/gen/tests/AArch64/CoRW1+dataspaap-rfippaa.litmus
@@ -6,9 +6,8 @@ AArch64 CoRW1+dataspaap-rfippaa
 }
  P0              ;
  LDAP W1,W2,[X0] ;
- ADD W1,W1,W2    ;
  EOR W3,W1,W1    ;
  ADD W3,W3,#1    ;
  STR W3,[X0]     ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+dataspaiqp-rfippaiq.litmus
+++ b/gen/tests/AArch64/CoRW1+dataspaiqp-rfippaiq.litmus
@@ -6,9 +6,8 @@ AArch64 CoRW1+dataspaiqp-rfippaiq
 }
  P0                ;
  LDIAPP W1,W2,[X0] ;
- ADD W1,W1,W2      ;
  EOR W3,W1,W1      ;
  ADD W3,W3,#1      ;
  STR W3,[X0]       ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+dataspanp-rfippan.litmus
+++ b/gen/tests/AArch64/CoRW1+dataspanp-rfippan.litmus
@@ -6,9 +6,8 @@ AArch64 CoRW1+dataspanp-rfippan
 }
  P0              ;
  LDNP W1,W2,[X0] ;
- ADD W1,W1,W2    ;
  EOR W3,W1,W1    ;
  ADD W3,W3,#1    ;
  STR W3,[X0]     ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+dataspap-rfippa.litmus
+++ b/gen/tests/AArch64/CoRW1+dataspap-rfippa.litmus
@@ -6,9 +6,8 @@ AArch64 CoRW1+dataspap-rfippa
 }
  P0             ;
  LDP W1,W2,[X0] ;
- ADD W1,W1,W2   ;
  EOR W3,W1,W1   ;
  ADD W3,W3,#1   ;
  STR W3,[X0]    ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+posa.w4p-rfipa.w4.litmus
+++ b/gen/tests/AArch64/CoRW1+posa.w4p-rfipa.w4.litmus
@@ -1,0 +1,13 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc w4 A PosRW Rfi *)
+AArch64 CoRW1+posa.w4p-rfipa.w4
+{
+ int x[2]={0,0};
+ 0:X0=x;
+}
+ P0           ;
+ ADD X2,X0,#4 ;
+ LDAR W1,[X2] ;
+ MOV W3,#1    ;
+ STR W3,[X0]  ;
+
+exists (0:X1=0)

--- a/gen/tests/AArch64/CoRW1+pospaap-rfippaa.litmus
+++ b/gen/tests/AArch64/CoRW1+pospaap-rfippaa.litmus
@@ -6,8 +6,7 @@ AArch64 CoRW1+pospaap-rfippaa
 }
  P0              ;
  LDAP W1,W2,[X0] ;
- ADD W1,W1,W2    ;
  MOV W3,#1       ;
  STR W3,[X0]     ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+pospaiqp-rfippaiq.litmus
+++ b/gen/tests/AArch64/CoRW1+pospaiqp-rfippaiq.litmus
@@ -6,8 +6,7 @@ AArch64 CoRW1+pospaiqp-rfippaiq
 }
  P0                ;
  LDIAPP W1,W2,[X0] ;
- ADD W1,W1,W2      ;
  MOV W3,#1         ;
  STR W3,[X0]       ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+pospanp-rfippan.litmus
+++ b/gen/tests/AArch64/CoRW1+pospanp-rfippan.litmus
@@ -6,8 +6,7 @@ AArch64 CoRW1+pospanp-rfippan
 }
  P0              ;
  LDNP W1,W2,[X0] ;
- ADD W1,W1,W2    ;
  MOV W3,#1       ;
  STR W3,[X0]     ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+pospap-rfippa.litmus
+++ b/gen/tests/AArch64/CoRW1+pospap-rfippa.litmus
@@ -6,8 +6,7 @@ AArch64 CoRW1+pospap-rfippa
 }
  P0             ;
  LDP W1,W2,[X0] ;
- ADD W1,W1,W2   ;
  MOV W3,#1      ;
  STR W3,[X0]    ;
 
-exists (0:X1=1)
+exists (0:X1=1 /\ 0:X2=0)

--- a/gen/tests/AArch64/CoRW1+pospaw4-rfiw4pa.litmus
+++ b/gen/tests/AArch64/CoRW1+pospaw4-rfiw4pa.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+pospaw4-rfiw4pa
 {
  int x[2]={0,0};
- 0:X0=x; uint32_t 0:X3=0;
+ 0:X0=x;
 }
  P0             ;
  LDP W1,W2,[X0] ;

--- a/gen/tests/AArch64/CoRW1+pospaw4-rfiw4pa.litmus
+++ b/gen/tests/AArch64/CoRW1+pospaw4-rfiw4pa.litmus
@@ -1,0 +1,12 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc Pa PosRW w4 Rfi *)
+AArch64 CoRW1+pospaw4-rfiw4pa
+{
+ int x[2]={0,0};
+ 0:X0=x; uint32_t 0:X3=0;
+}
+ P0             ;
+ LDP W1,W2,[X0] ;
+ MOV W3,#1      ;
+ STR W3,[X0,#4] ;
+
+exists (0:X1=0 /\ 0:X2=1)

--- a/gen/tests/AArch64/CoRW1+pospl.w4-rfil.w4p.litmus
+++ b/gen/tests/AArch64/CoRW1+pospl.w4-rfil.w4p.litmus
@@ -1,0 +1,13 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc PosRW w4 L Rfi *)
+AArch64 CoRW1+pospl.w4-rfil.w4p
+{
+ int x[2]={0,0};
+ 0:X0=x; uint32_t 0:X2=0;
+}
+ P0           ;
+ LDR W1,[X0]  ;
+ MOV W2,#1    ;
+ ADD X3,X0,#4 ;
+ STLR W2,[X3] ;
+
+exists (0:X1=0)

--- a/gen/tests/AArch64/CoRW1+pospl.w4-rfil.w4p.litmus
+++ b/gen/tests/AArch64/CoRW1+pospl.w4-rfil.w4p.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+pospl.w4-rfil.w4p
 {
  int x[2]={0,0};
- 0:X0=x; uint32_t 0:X2=0;
+ 0:X0=x;
 }
  P0           ;
  LDR W1,[X0]  ;

--- a/gen/tests/AArch64/CoRW1+pospq8-rfiq8p.litmus
+++ b/gen/tests/AArch64/CoRW1+pospq8-rfiq8p.litmus
@@ -1,0 +1,12 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc -type int64_t PosRW q8 Rfi *)
+AArch64 CoRW1+pospq8-rfiq8p
+{
+ int64_t x[2]={0,0};
+ 0:X0=x; int64_t 0:X1=0; uint64_t 0:X2=0;
+}
+ P0             ;
+ LDR X1,[X0]    ;
+ MOV X2,#1      ;
+ STR X2,[X0,#8] ;
+
+exists (0:X1=0)

--- a/gen/tests/AArch64/CoRW1+pospq8-rfiq8p.litmus
+++ b/gen/tests/AArch64/CoRW1+pospq8-rfiq8p.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+pospq8-rfiq8p
 {
  int64_t x[2]={0,0};
- 0:X0=x; int64_t 0:X1=0; uint64_t 0:X2=0;
+ 0:X0=x; int64_t 0:X1=0;
 }
  P0             ;
  LDR X1,[X0]    ;

--- a/gen/tests/AArch64/CoRW1+pospw4-rfiw4p.litmus
+++ b/gen/tests/AArch64/CoRW1+pospw4-rfiw4p.litmus
@@ -1,0 +1,12 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc PosRW w4 Rfi *)
+AArch64 CoRW1+pospw4-rfiw4p
+{
+ int x[2]={0,0};
+ 0:X0=x; uint32_t 0:X2=0;
+}
+ P0             ;
+ LDR W1,[X0]    ;
+ MOV W2,#1      ;
+ STR W2,[X0,#4] ;
+
+exists (0:X1=0)

--- a/gen/tests/AArch64/CoRW1+pospw4-rfiw4p.litmus
+++ b/gen/tests/AArch64/CoRW1+pospw4-rfiw4p.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+pospw4-rfiw4p
 {
  int x[2]={0,0};
- 0:X0=x; uint32_t 0:X2=0;
+ 0:X0=x;
 }
  P0             ;
  LDR W1,[X0]    ;

--- a/gen/tests/AArch64/CoRW1+posq.w4p-rfipq.w4.litmus
+++ b/gen/tests/AArch64/CoRW1+posq.w4p-rfipq.w4.litmus
@@ -1,0 +1,13 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc w4 Q PosRW Rfi *)
+AArch64 CoRW1+posq.w4p-rfipq.w4
+{
+ int x[2]={0,0};
+ 0:X0=x;
+}
+ P0            ;
+ ADD X2,X0,#4  ;
+ LDAPR W1,[X2] ;
+ MOV W3,#1     ;
+ STR W3,[X0]   ;
+
+exists (0:X1=0)

--- a/gen/tests/AArch64/CoRW1+posq8p-rfipq8.litmus
+++ b/gen/tests/AArch64/CoRW1+posq8p-rfipq8.litmus
@@ -1,0 +1,12 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc -type int64_t q8 PosRW Rfi *)
+AArch64 CoRW1+posq8p-rfipq8
+{
+ int64_t x[2]={0,0};
+ uint64_t 0:X0=0; 0:X1=x;
+}
+ P0             ;
+ LDR X0,[X1,#8] ;
+ MOV X2,#1      ;
+ STR X2,[X1]    ;
+
+exists (0:X0=0)

--- a/gen/tests/AArch64/CoRW1+posq8q8-rfiq8q8.litmus
+++ b/gen/tests/AArch64/CoRW1+posq8q8-rfiq8q8.litmus
@@ -1,0 +1,12 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc -type int64_t q8 PosRW q8 Rfi *)
+AArch64 CoRW1+posq8q8-rfiq8q8
+{
+ int64_t x[2]={0,0};
+ uint64_t 0:X0=0; 0:X1=x; uint64_t 0:X2=0;
+}
+ P0             ;
+ LDR X0,[X1,#8] ;
+ MOV X2,#1      ;
+ STR X2,[X1,#8] ;
+
+exists (0:X0=1)

--- a/gen/tests/AArch64/CoRW1+posq8q8-rfiq8q8.litmus
+++ b/gen/tests/AArch64/CoRW1+posq8q8-rfiq8q8.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+posq8q8-rfiq8q8
 {
  int64_t x[2]={0,0};
- uint64_t 0:X0=0; 0:X1=x; uint64_t 0:X2=0;
+ uint64_t 0:X0=0; 0:X1=x;
 }
  P0             ;
  LDR X0,[X1,#8] ;

--- a/gen/tests/AArch64/CoRW1+posw4p-rfipw4.litmus
+++ b/gen/tests/AArch64/CoRW1+posw4p-rfipw4.litmus
@@ -1,0 +1,12 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc w4 PosRW Rfi *)
+AArch64 CoRW1+posw4p-rfipw4
+{
+ int x[2]={0,0};
+ uint32_t 0:X0=0; 0:X1=x;
+}
+ P0             ;
+ LDR W0,[X1,#4] ;
+ MOV W2,#1      ;
+ STR W2,[X1]    ;
+
+exists (0:X0=0)

--- a/gen/tests/AArch64/CoRW1+posw4pa-rfipaw4.litmus
+++ b/gen/tests/AArch64/CoRW1+posw4pa-rfipaw4.litmus
@@ -1,0 +1,13 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc w4 PosRW Pa Rfi *)
+AArch64 CoRW1+posw4pa-rfipaw4
+{
+ int x[2]={0,0};
+ uint32_t 0:X0=0; 0:X1=x;
+}
+ P0             ;
+ LDR W0,[X1,#4] ;
+ MOV W2,#2      ;
+ SUB W3,W2,#1   ;
+ STP W3,W2,[X1] ;
+
+exists (0:X0=2)

--- a/gen/tests/AArch64/CoRW1+posw4w4-rfiw4w4.litmus
+++ b/gen/tests/AArch64/CoRW1+posw4w4-rfiw4w4.litmus
@@ -1,0 +1,12 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc w4 PosRW w4 Rfi *)
+AArch64 CoRW1+posw4w4-rfiw4w4
+{
+ int x[2]={0,0};
+ uint32_t 0:X0=0; 0:X1=x; uint32_t 0:X2=0;
+}
+ P0             ;
+ LDR W0,[X1,#4] ;
+ MOV W2,#1      ;
+ STR W2,[X1,#4] ;
+
+exists (0:X0=1)

--- a/gen/tests/AArch64/CoRW1+posw4w4-rfiw4w4.litmus
+++ b/gen/tests/AArch64/CoRW1+posw4w4-rfiw4w4.litmus
@@ -2,7 +2,7 @@
 AArch64 CoRW1+posw4w4-rfiw4w4
 {
  int x[2]={0,0};
- uint32_t 0:X0=0; 0:X1=x; uint32_t 0:X2=0;
+ uint32_t 0:X0=0; 0:X1=x;
 }
  P0             ;
  LDR W0,[X1,#4] ;

--- a/gen/tests/AArch64/CoRW1+rmwq8q8-rfiq8q8.litmus
+++ b/gen/tests/AArch64/CoRW1+rmwq8q8-rfiq8q8.litmus
@@ -1,0 +1,15 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc -type int64_t q8 LxSx q8 Rfi *)
+AArch64 CoRW1+rmwq8q8-rfiq8q8
+{
+ int64_t x[2]={0,0};
+ 0:X0=x; int64_t 0:X1=0;
+}
+ P0              ;
+ MOV X2,#1       ;
+ ADD X3,X0,#8    ;
+ Loop00:         ;
+ LDXR X1,[X3]    ;
+ STXR W4,X2,[X3] ;
+ CBNZ X4,Loop00  ;
+
+exists (0:X1=1)

--- a/gen/tests/AArch64/CoRW1+rmww4w4-rfiw4w4.litmus
+++ b/gen/tests/AArch64/CoRW1+rmww4w4-rfiw4w4.litmus
@@ -1,0 +1,15 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc w4 LxSx w4 Rfi *)
+AArch64 CoRW1+rmww4w4-rfiw4w4
+{
+ int x[2]={0,0};
+ 0:X0=x;
+}
+ P0              ;
+ MOV W2,#1       ;
+ ADD X3,X0,#4    ;
+ Loop00:         ;
+ LDXR W1,[X3]    ;
+ STXR W4,W2,[X3] ;
+ CBNZ W4,Loop00  ;
+
+exists (0:X1=1)

--- a/gen/tests/AArch64/R+popq8+po.litmus
+++ b/gen/tests/AArch64/R+popq8+po.litmus
@@ -1,0 +1,15 @@
+(* diyone7 -arch AArch64 -metadata false -type int64_t PodWW q8 Coe PodWR Fre *)
+AArch64 R+popq8+po
+{
+ int64_t x=0;
+ int64_t y[2]={0,0};
+ 0:X1=x; uint64_t 0:X2=0; 0:X3=y;
+ 1:X1=x; int64_t 1:X2=0; 1:X3=y;
+}
+ P0             | P1          ;
+ MOV X0,#1      | MOV X0,#2   ;
+ STR X0,[X1]    | STR X0,[X3] ;
+ MOV X2,#1      | LDR X2,[X1] ;
+ STR X2,[X3,#8] |             ;
+
+exists (y={2,1} /\ 1:X2=0)

--- a/gen/tests/AArch64/R+popq8+po.litmus
+++ b/gen/tests/AArch64/R+popq8+po.litmus
@@ -3,7 +3,7 @@ AArch64 R+popq8+po
 {
  int64_t x=0;
  int64_t y[2]={0,0};
- 0:X1=x; uint64_t 0:X2=0; 0:X3=y;
+ 0:X1=x; 0:X3=y;
  1:X1=x; int64_t 1:X2=0; 1:X3=y;
 }
  P0             | P1          ;

--- a/gen/tests/AArch64/R+popw4+po.litmus
+++ b/gen/tests/AArch64/R+popw4+po.litmus
@@ -1,0 +1,14 @@
+(* diyone7 -arch AArch64 -metadata false PodWW w4 Coe PodWR Fre *)
+AArch64 R+popw4+po
+{
+ int y[2]={0,0};
+ 0:X1=x; uint32_t 0:X2=0; 0:X3=y;
+ 1:X1=x; 1:X3=y;
+}
+ P0             | P1          ;
+ MOV W0,#1      | MOV W0,#2   ;
+ STR W0,[X1]    | STR W0,[X3] ;
+ MOV W2,#1      | LDR W2,[X1] ;
+ STR W2,[X3,#4] |             ;
+
+exists (y={2,1} /\ 1:X2=0)

--- a/gen/tests/AArch64/R+popw4+po.litmus
+++ b/gen/tests/AArch64/R+popw4+po.litmus
@@ -2,7 +2,7 @@
 AArch64 R+popw4+po
 {
  int y[2]={0,0};
- 0:X1=x; uint32_t 0:X2=0; 0:X3=y;
+ 0:X1=x; 0:X3=y;
  1:X1=x; 1:X3=y;
 }
  P0             | P1          ;

--- a/gen/tests/AArch64/obs-local-R+popq8+po.litmus
+++ b/gen/tests/AArch64/obs-local-R+popq8+po.litmus
@@ -1,0 +1,16 @@
+(* diyone7 -arch AArch64 -metadata false -type int64_t -obs local PodWW q8 Coe PodWR Fre *)
+AArch64 R+popq8+po
+{
+ int64_t x=0;
+ int64_t y[2]={0,0};
+ 0:X1=x; uint64_t 0:X2=0; 0:X3=y; int64_t 0:X4=0; int64_t 0:X5=0;
+ 1:X1=x; int64_t 1:X2=0; 1:X3=y;
+}
+ P0             | P1          ;
+ MOV X0,#1      | MOV X0,#2   ;
+ STR X0,[X1]    | STR X0,[X3] ;
+ MOV X2,#1      | LDR X2,[X1] ;
+ STR X2,[X3,#8] |             ;
+ LDP X4,X5,[X3] |             ;
+
+exists (0:X5=1 /\ 0:X4=2 /\ 1:X2=0)

--- a/gen/tests/AArch64/obs-local-R+popq8+po.litmus
+++ b/gen/tests/AArch64/obs-local-R+popq8+po.litmus
@@ -3,7 +3,7 @@ AArch64 R+popq8+po
 {
  int64_t x=0;
  int64_t y[2]={0,0};
- 0:X1=x; uint64_t 0:X2=0; 0:X3=y; int64_t 0:X4=0; int64_t 0:X5=0;
+ 0:X1=x; 0:X3=y; int64_t 0:X4=0; int64_t 0:X5=0;
  1:X1=x; int64_t 1:X2=0; 1:X3=y;
 }
  P0             | P1          ;

--- a/gen/tests/AArch64/obs-local-R+popw4+po.litmus
+++ b/gen/tests/AArch64/obs-local-R+popw4+po.litmus
@@ -1,0 +1,15 @@
+(* diyone7 -arch AArch64 -metadata false -obs local PodWW w4 Coe PodWR Fre *)
+AArch64 R+popw4+po
+{
+ int y[2]={0,0};
+ 0:X1=x; uint32_t 0:X2=0; 0:X3=y;
+ 1:X1=x; 1:X3=y;
+}
+ P0             | P1          ;
+ MOV W0,#1      | MOV W0,#2   ;
+ STR W0,[X1]    | STR W0,[X3] ;
+ MOV W2,#1      | LDR W2,[X1] ;
+ STR W2,[X3,#4] |             ;
+ LDP W4,W5,[X3] |             ;
+
+exists (0:X5=1 /\ 0:X4=2 /\ 1:X2=0)

--- a/gen/tests/AArch64/obs-local-R+popw4+po.litmus
+++ b/gen/tests/AArch64/obs-local-R+popw4+po.litmus
@@ -2,7 +2,7 @@
 AArch64 R+popw4+po
 {
  int y[2]={0,0};
- 0:X1=x; uint32_t 0:X2=0; 0:X3=y;
+ 0:X1=x; 0:X3=y;
  1:X1=x; 1:X3=y;
 }
  P0             | P1          ;

--- a/gen/tests/AArch64/reject-pa-q8-posrw-rfi.litmus
+++ b/gen/tests/AArch64/reject-pa-q8-posrw-rfi.litmus
@@ -1,0 +1,5 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc -type int64_t Pa q8 PosRW Rfi *)
+(*
+[2]
+diyone7: Fatal error: Incompatible annotations Pa and q8
+*)

--- a/gen/tests/AArch64/reject-pa-w4-posrw-rfi.litmus
+++ b/gen/tests/AArch64/reject-pa-w4-posrw-rfi.litmus
@@ -1,0 +1,5 @@
+(* diyone7 -arch AArch64 -metadata false -oneloc Pa w4 PosRW Rfi *)
+(*
+[2]
+diyone7: Fatal error: Incompatible annotations Pa and w4
+*)

--- a/gen/tests/diy-basic-check.t
+++ b/gen/tests/diy-basic-check.t
@@ -244,18 +244,18 @@ A base test with int64 arrays
    int64_t x[2]={0,0};
    int64_t y=0;
    0:X0=x; int64_t 0:X2=0; 0:X5=y;
-   1:X0=x; int64_t 1:X2=0; 1:X5=y;
+   1:X0=x; int64_t 1:X2=0; int64_t 1:X3=0; 1:X5=y;
   }
    P0              | P1             ;
    MOV X1,#1       | MOV X1,#2      ;
    Loop00:         | STR X1,[X5]    ;
    LDXR X2,[X0]    | LDP X2,X3,[X0] ;
-   STXR W3,X1,[X0] | ADD X2,X2,X3   ;
+   STXR W3,X1,[X0] |                ;
    CBNZ X3,Loop00  |                ;
    MOV X4,#1       |                ;
    STR X4,[X5]     |                ;
   
-  exists (x={1,0} /\ [y]=2 /\ 0:X2=0 /\ 1:X2=0)
+  exists (x={1,0} /\ [y]=2 /\ 0:X2=0 /\ 1:X2=0 /\ 1:X3=0)
 A C test for exists
   $ diyone7 -arch C PodWW Coe PodWR Fre
   Warning: optimised conditions are not supported by C arch

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -545,25 +545,31 @@ let max_set = IntSet.max_elt
 
       (* Local check of coherence *)
 
-  let do_add_load bank st p i f x v =
+  let observer_bank_of_cell cell = match Array.length cell with
+    | 1 -> Ord
+    | 2 -> Pair
+    | n -> Warn.fatal "No local observer for %d coherence cells" n
+
+  let do_add_load bank st p i f x cell =
     let r,i,c,st = Comp.emit_obs bank st p i x in
-    let v =
-      match bank with
-      | Pair -> v+v
-      | _ -> v in
-    i,c,F.add_final_v p r (IntSet.singleton v) f,st
+    let rs = match bank with Pair -> r::A.get_friends st r | _ -> [r] in
+    let f = List.fold_left2
+      (fun f r v -> F.add_final_v p r (IntSet.singleton (C.Value.to_int v)) f)
+      f rs (Array.to_list cell) in
+    i,c,f,st
 
   let do_add_loop st p i f x v w =
     let r,i,c,st = Comp.emit_obs_not_value st p i x v in
     i,c,F.add_final_v p r (IntSet.singleton w) f,st
 
-  let rec do_observe_local bank obs_type st p i code f x prev_v v =
+  let rec do_observe_local bank obs_type st p i code f x prev_v cell =
+    let v = C.Value.to_int cell.(0) in
     match obs_type with
     | Config.Straight ->
-        let i,c,f,st = do_add_load bank st p i f x v in
+        let i,c,f,st = do_add_load bank st p i f x cell in
         i,code@c,f,st
     |  Config.Fenced ->
-        let i,c,f,st = do_add_load bank st p i f x v in
+        let i,c,f,st = do_add_load bank st p i f x cell in
         let i,c',st = Comp.emit_fence st p i C.nil Comp.stronger_fence in
         let c = c'@c in
         i,code@c,f,st
@@ -578,7 +584,7 @@ let max_set = IntSet.max_elt
           let i,c,f,st = do_add_loop st p i f x prev_v v in
           i,code@c,f,st
        | None ->
-          do_observe_local bank Config.Fenced st p i code f x None v
+          do_observe_local bank Config.Fenced st p i code f x None cell
        end
 
   let do_observe_local_simd st p i code f x bank nxt =
@@ -611,7 +617,7 @@ let max_set = IntSet.max_elt
     let lst = Misc.last ns in
     if U.check_here lst then
       match lst.C.evt.C.loc,lst.C.evt.C.bank with
-      | Data x,(Ord|Pair|Instr) -> (* TODO check for -obs local mode and pairs *)
+      | Data x,(Ord|Pair|Instr) ->
          let nxt = lst.C.next.C.evt in
          let bank = nxt.C.bank in
          begin match bank with
@@ -627,11 +633,8 @@ let max_set = IntSet.max_elt
             then
               i,code,F.cons_int_set (A.Location.Location_global x,IntSet.singleton v) f,st
             else
-              let bank =
-                match bank with
-                | Pair -> Pair
-                | _ -> Ord in
-              do_observe_local  bank O.obs_type st p i code f x (Some prev_v) v
+              let bank = observer_bank_of_cell nxt.C.cell in
+              do_observe_local bank O.obs_type st p i code f x (Some prev_v) nxt.C.cell
          end
       | Data x,Tag ->
           let v = C.Value.to_int lst.C.next.C.evt.C.v in
@@ -652,8 +655,8 @@ let max_set = IntSet.max_elt
          let bank = nxt.C.bank in
          begin match bank with
          | Ord|Pair ->
-            let v = C.Value.to_int nxt.C.v in
-            do_observe_local bank O.obs_type st p i code f x None v
+            let bank = observer_bank_of_cell nxt.C.cell in
+            do_observe_local bank O.obs_type st p i code f x None nxt.C.cell
          | VecReg _ ->
             do_observe_local_simd st p i code f x bank nxt
          | _ -> Warn.user_error "Mixing SIMD and other variants"

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -545,29 +545,26 @@ let max_set = IntSet.max_elt
 
       (* Local check of coherence *)
 
-  let do_add_load bank st p i f x v =
+  let do_add_load bank st p i f x cell =
     let r,i,c,st = Comp.emit_obs bank st p i x in
-    let f =
-      match bank with
-      | Pair ->
-          (* Add both pair-load result checks to the final condition. *)
-          List.fold_left
-            (fun f r -> F.add_final_v p r (IntSet.singleton v) f)
-            f (r::A.get_friends st r)
-      | _ -> F.add_final_v p r (IntSet.singleton v) f in
+    let rs = match bank with Pair -> r::A.get_friends st r | _ -> [r] in
+    let f = List.fold_left2
+      (fun f r v -> F.add_final_v p r (IntSet.singleton (C.Value.to_int v)) f)
+      f rs (Array.to_list cell) in
     i,c,f,st
 
   let do_add_loop st p i f x v w =
     let r,i,c,st = Comp.emit_obs_not_value st p i x v in
     i,c,F.add_final_v p r (IntSet.singleton w) f,st
 
-  let rec do_observe_local bank obs_type st p i code f x prev_v v =
+  let rec do_observe_local bank obs_type st p i code f x prev_v cell =
+    let v = C.Value.to_int cell.(0) in
     match obs_type with
     | Config.Straight ->
-        let i,c,f,st = do_add_load bank st p i f x v in
+        let i,c,f,st = do_add_load bank st p i f x cell in
         i,code@c,f,st
     |  Config.Fenced ->
-        let i,c,f,st = do_add_load bank st p i f x v in
+        let i,c,f,st = do_add_load bank st p i f x cell in
         let i,c',st = Comp.emit_fence st p i C.nil Comp.stronger_fence in
         let c = c'@c in
         i,code@c,f,st
@@ -582,7 +579,7 @@ let max_set = IntSet.max_elt
           let i,c,f,st = do_add_loop st p i f x prev_v v in
           i,code@c,f,st
        | None ->
-          do_observe_local bank Config.Fenced st p i code f x None v
+          do_observe_local bank Config.Fenced st p i code f x None cell
        end
 
   let do_observe_local_simd st p i code f x bank nxt =
@@ -635,7 +632,7 @@ let max_set = IntSet.max_elt
                 match bank with
                 | Pair -> Pair
                 | _ -> Ord in
-              do_observe_local  bank O.obs_type st p i code f x (Some prev_v) v
+              do_observe_local bank O.obs_type st p i code f x (Some prev_v) nxt.C.cell
          end
       | Data x,Tag ->
           let v = C.Value.to_int lst.C.next.C.evt.C.v in
@@ -656,8 +653,7 @@ let max_set = IntSet.max_elt
          let bank = nxt.C.bank in
          begin match bank with
          | Ord|Pair ->
-            let v = C.Value.to_int nxt.C.v in
-            do_observe_local bank O.obs_type st p i code f x None v
+            do_observe_local bank O.obs_type st p i code f x None nxt.C.cell
          | VecReg _ ->
             do_observe_local_simd st p i code f x bank nxt
          | _ -> Warn.user_error "Mixing SIMD and other variants"

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -612,7 +612,7 @@ let max_set = IntSet.max_elt
     let lst = Misc.last ns in
     if U.check_here lst then
       match lst.C.evt.C.loc,lst.C.evt.C.bank with
-      | Data x,(Ord|Pair|Instr) -> (* TODO check for -obs local mode and pairs *)
+      | Data x,(Ord|Pair|Instr as prev_bank) ->
          let nxt = lst.C.next.C.evt in
          let bank = nxt.C.bank in
          begin match bank with
@@ -629,8 +629,8 @@ let max_set = IntSet.max_elt
               i,code,F.cons_int_set (A.Location.Location_global x,IntSet.singleton v) f,st
             else
               let bank =
-                match bank with
-                | Pair -> Pair
+                match prev_bank,bank with
+                | Pair,_|_,Pair -> Pair
                 | _ -> Ord in
               do_observe_local bank O.obs_type st p i code f x (Some prev_v) nxt.C.cell
          end

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -547,11 +547,15 @@ let max_set = IntSet.max_elt
 
   let do_add_load bank st p i f x v =
     let r,i,c,st = Comp.emit_obs bank st p i x in
-    let v =
+    let f =
       match bank with
-      | Pair -> v+v
-      | _ -> v in
-    i,c,F.add_final_v p r (IntSet.singleton v) f,st
+      | Pair ->
+          (* Add both pair-load result checks to the final condition. *)
+          List.fold_left
+            (fun f r -> F.add_final_v p r (IntSet.singleton v) f)
+            f (r::A.get_friends st r)
+      | _ -> F.add_final_v p r (IntSet.singleton v) f in
+    i,c,f,st
 
   let do_add_loop st p i f x v w =
     let r,i,c,st = Comp.emit_obs_not_value st p i x v in


### PR DESCRIPTION
Expose a non-mixed AArch64 offset annotation to generate ordinary accesses to the second cell of a pair-backed location. The surface spelling follows the current natural type size. 
- with the default 32-bit `int`, the added annotation is `w4`
- with `-type int64_t`, it is `q8`.

We also remove the synthetic `ADD` after `AArch64` pair loads but check both register values in the final condition. 
Given the new annotation and change, we can generate test, e.g. `diyone7 -metadata false -arch AArch64 -oneloc Rfe PaIQ Fre w4 PosWW`
```
AArch64 WW+R+posw4p+PaIQ
{
 int x[2]={0,0};
 uint32_t 0:X0=0; 0:X1=x;
 1:X1=x;
}
 P0                                                      | P1                ;
 MOV W0,#2                                               | LDIAPP W0,W2,[X1] ;
 STR W0,[X1,#4] (* w4 annotation to access second cell *)|                   ; (* Add W0,W0,W2 is removed *)
 MOV W2,#1                                               |                   ;
 STR W2,[X1]                                             |                   ;

exists (x={1,2} /\ 1:X0=1 /\ 1:X2=0) (* Value check for both 1:X0 and 1:X2 *)
```