### PR TITLE
[gen] Change CSEL dependency instruction sequences

### DIFF
--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -225,9 +225,9 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let cmpi r i = do_cmpi vloc r i
 
     let do_csel v r1 r2 r3 = I_CSEL (v,r1,r2,r3,EQ,Cpy)
-    let do_cinc v r1 r2 r3 = I_CSEL (v,r1,r2,r3,EQ,Inc)
 
-    let cmp r1 r2 = op3r vloc SUBS ZR r1 r2
+    let do_cmp v r1 r2 = op3r v SUBS ZR r1 r2
+    let cmp r1 r2 = do_cmp vloc r1 r2
 
     let b lbl = I_B (BranchTarget.Lbl lbl)
     let bne lbl = I_BC (NE,BranchTarget.Lbl lbl)
@@ -2275,10 +2275,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | NoCsel -> fun src dst -> [calc0 vdep src dst],st
       | OkCsel ->
          fun dst src ->
-           let r3,st = next_reg st in
-           let r4,st = next_reg st in
-           [do_movi vdep r3 1; do_cmpi vdep src 0;
-            do_csel vdep dst r3 r4; andi vdep dst dst 2;],st
+           [do_cmp vdep src src; do_csel vdep dst ZR ZR;],st
 
     let emit_access_dep_addr csel vdep st p init e rd =
       let r2,st = next_reg st in
@@ -2751,10 +2748,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | NoCsel -> emit_ctrl vdep r,st
       | OkCsel ->
          let r2,st = next_reg st in
-         let r3,st = next_reg st in
-         pseudo
-           [do_cmpi vdep r 0; do_cinc vdep r2 r3 r2;]@
-           emit_ctrl vdep r2,
+         let cs0,st = calc0_gen csel st vdep r2 r in
+         pseudo cs0@emit_ctrl vdep r2,
          st
 
     let emit_access_ctrl csel vdep isb st p init e r1 =

--- a/gen/tests/AArch64/LB+addrcsel+amo.cas-po.litmus.expected
+++ b/gen/tests/AArch64/LB+addrcsel+amo.cas-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 2 Negative: 6
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+addrcsel+amo.cas-po Sometimes 2 6
-Hash=02245ba4589a21c7fa36c90126de0fd3
+Hash=83229284fff7df08bffd4288bb41ca27
 

--- a/gen/tests/AArch64/LB+addrcsel+amo.casap-po.litmus.expected
+++ b/gen/tests/AArch64/LB+addrcsel+amo.casap-po.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+addrcsel+amo.casap-po Never 0 6
-Hash=885ab13a41d64bcaa54e2d4ae49d05d8
+Hash=b74ce67cddc325ab6c7c3d9d876a7221
 

--- a/gen/tests/AArch64/LB+addrcsel+amo.stadd-po.litmus.expected
+++ b/gen/tests/AArch64/LB+addrcsel+amo.stadd-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([y]=3 /\ 0:X1=1)
 Observation LB+addrcsel+amo.stadd-po Sometimes 1 3
-Hash=f27020b4f8043aee37e42a4c57a6c35a
+Hash=0786bcf32b7f5e1aa14c72a63e71f381
 

--- a/gen/tests/AArch64/LB+addrcsel+amo.swp-po.litmus.expected
+++ b/gen/tests/AArch64/LB+addrcsel+amo.swp-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+addrcsel+amo.swp-po Sometimes 1 3
-Hash=0d951dc8c3e1718c3cefad88397a2032
+Hash=ab9a9eb3e798bd12c1e968f44f634ae3
 

--- a/gen/tests/AArch64/LB+addrcsel+amo.swpap-po.litmus.expected
+++ b/gen/tests/AArch64/LB+addrcsel+amo.swpap-po.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+addrcsel+amo.swpap-po Never 0 3
-Hash=7a2f79ef6eacf6b9c65f921ce890f0e8
+Hash=962b0882628e2767cd863b9097dec519
 

--- a/gen/tests/AArch64/LB+addrcsel+po.litmus.expected
+++ b/gen/tests/AArch64/LB+addrcsel+po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+addrcsel+po Sometimes 1 3
-Hash=a5451fcb4fc04233f7880a22c938a0f4
+Hash=167ac71dd8d4f6c12f57d11d57ef3b8d
 

--- a/gen/tests/AArch64/LB+addrcsel+poap.litmus.expected
+++ b/gen/tests/AArch64/LB+addrcsel+poap.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+addrcsel+poap Never 0 3
-Hash=da7c1dcdd309a04e51950708d380c8ca
+Hash=e6163b1fd43b53d99c8bfe85479a1e67
 

--- a/gen/tests/AArch64/LB+addrcsel+rmw-po.litmus.expected
+++ b/gen/tests/AArch64/LB+addrcsel+rmw-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 6 Negative: 12
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+addrcsel+rmw-po Sometimes 6 12
-Hash=48532424f53115df8316b9786e74b04c
+Hash=4122fcdb84918e34c95062178608803f
 

--- a/gen/tests/AArch64/LB+addrcsel+rmwap-po.litmus.expected
+++ b/gen/tests/AArch64/LB+addrcsel+rmwap-po.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 12
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+addrcsel+rmwap-po Never 0 12
-Hash=06d4de799887fa6bb0499f3d44e55921
+Hash=aaec3398e6f02f3ca914297a97608141
 

--- a/gen/tests/AArch64/LB+ctrlcsel+amo.cas-po.litmus.expected
+++ b/gen/tests/AArch64/LB+ctrlcsel+amo.cas-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 2 Negative: 6
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+ctrlcsel+amo.cas-po Sometimes 2 6
-Hash=5765bef51d22597ad3d0788b4a5bdd1b
+Hash=f7bd7a8985d73b80137a9acf640ebb77
 

--- a/gen/tests/AArch64/LB+ctrlcsel+amo.casap-po.litmus.expected
+++ b/gen/tests/AArch64/LB+ctrlcsel+amo.casap-po.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+ctrlcsel+amo.casap-po Never 0 6
-Hash=12e31b84ce442c85d51fdeec15e6cda2
+Hash=a8223d52a57555d26df319f7d44a612f
 

--- a/gen/tests/AArch64/LB+ctrlcsel+amo.stadd-po.litmus.expected
+++ b/gen/tests/AArch64/LB+ctrlcsel+amo.stadd-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([y]=3 /\ 0:X1=1)
 Observation LB+ctrlcsel+amo.stadd-po Sometimes 1 3
-Hash=b218cd63a8a04a669ef4c5b05239015d
+Hash=6bbee0b84a4cc15187bb754dc30563b7
 

--- a/gen/tests/AArch64/LB+ctrlcsel+amo.swp-po.litmus.expected
+++ b/gen/tests/AArch64/LB+ctrlcsel+amo.swp-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+ctrlcsel+amo.swp-po Sometimes 1 3
-Hash=a36fcbe46df43fd772aef45af2f4f548
+Hash=b1a23a72478e26d4d8262cbc913f2123
 

--- a/gen/tests/AArch64/LB+ctrlcsel+amo.swpap-po.litmus.expected
+++ b/gen/tests/AArch64/LB+ctrlcsel+amo.swpap-po.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+ctrlcsel+amo.swpap-po Never 0 3
-Hash=adf790fd7d737e7370c54b10ca597cb8
+Hash=9ef6fa9c13a0f52a9426bb36ab408fda
 

--- a/gen/tests/AArch64/LB+ctrlcsel+po.litmus.expected
+++ b/gen/tests/AArch64/LB+ctrlcsel+po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+ctrlcsel+po Sometimes 1 3
-Hash=6bad754ff6766b6099f3a97b9eb86529
+Hash=efbb95c3dad6b9dabf2c988b14f5ab50
 

--- a/gen/tests/AArch64/LB+ctrlcsel+poap.litmus.expected
+++ b/gen/tests/AArch64/LB+ctrlcsel+poap.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+ctrlcsel+poap Never 0 3
-Hash=25f46d2ee2a502c3f5e1e3bc5dc5f9f9
+Hash=ad526c1c6b7f64eda543117202c33b37
 

--- a/gen/tests/AArch64/LB+ctrlcsel+rmw-po.litmus.expected
+++ b/gen/tests/AArch64/LB+ctrlcsel+rmw-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 6 Negative: 12
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+ctrlcsel+rmw-po Sometimes 6 12
-Hash=d05c953dd1aab9530a2d49d443d36f57
+Hash=0f540fbf19eeb2b5e3a577daa7f9a874
 

--- a/gen/tests/AArch64/LB+ctrlcsel+rmwap-po.litmus.expected
+++ b/gen/tests/AArch64/LB+ctrlcsel+rmwap-po.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 12
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+ctrlcsel+rmwap-po Never 0 12
-Hash=43af816509aa0c7723f96447f9f75fb4
+Hash=5cf44987b496bfbd05a1b0297bb40c3e
 

--- a/gen/tests/AArch64/LB+datacsel+amo.cas-po.litmus.expected
+++ b/gen/tests/AArch64/LB+datacsel+amo.cas-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 2 Negative: 6
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+datacsel+amo.cas-po Sometimes 2 6
-Hash=8051661ca4bacd7ce86229dd373d231a
+Hash=73db665e5affd4fb35277eca065dd3d0
 

--- a/gen/tests/AArch64/LB+datacsel+amo.casap-po.litmus.expected
+++ b/gen/tests/AArch64/LB+datacsel+amo.casap-po.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 6
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+datacsel+amo.casap-po Never 0 6
-Hash=1776fbafbce911debbef6f3d40d77555
+Hash=cebc874064834e6a881d9dafa17ec417
 

--- a/gen/tests/AArch64/LB+datacsel+amo.stadd-po.litmus.expected
+++ b/gen/tests/AArch64/LB+datacsel+amo.stadd-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([y]=3 /\ 0:X1=1)
 Observation LB+datacsel+amo.stadd-po Sometimes 1 3
-Hash=785926611259edec8e0a4165c9c08a76
+Hash=9484b71f823d33616d5b961e42d008f8
 

--- a/gen/tests/AArch64/LB+datacsel+amo.swp-po.litmus.expected
+++ b/gen/tests/AArch64/LB+datacsel+amo.swp-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+datacsel+amo.swp-po Sometimes 1 3
-Hash=a8b4535e1998297f980b869286761a48
+Hash=7082926bcf5744d04a1d076b5f6dbe9d
 

--- a/gen/tests/AArch64/LB+datacsel+amo.swpap-po.litmus.expected
+++ b/gen/tests/AArch64/LB+datacsel+amo.swpap-po.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+datacsel+amo.swpap-po Never 0 3
-Hash=90e95e4dcb6707fc1a389048a17b3636
+Hash=876bb9db046306dca3a181676691b842
 

--- a/gen/tests/AArch64/LB+datacsel+po.litmus.expected
+++ b/gen/tests/AArch64/LB+datacsel+po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+datacsel+po Sometimes 1 3
-Hash=d65cd4dfc09a8011ebf12208603562cb
+Hash=2492b4f1564ae0084b19f051bd6d87e2
 

--- a/gen/tests/AArch64/LB+datacsel+poap.litmus.expected
+++ b/gen/tests/AArch64/LB+datacsel+poap.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+datacsel+poap Never 0 3
-Hash=f5ab7efcd1685c4b601010df6df73bc6
+Hash=d4d8225c8914698590711045932e1f32
 

--- a/gen/tests/AArch64/LB+datacsel+rmw-po.litmus.expected
+++ b/gen/tests/AArch64/LB+datacsel+rmw-po.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 6 Negative: 12
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+datacsel+rmw-po Sometimes 6 12
-Hash=882421675d601ee034ca5f1fb7061000
+Hash=406f1346c36dd1f738c026b6263a6cab
 

--- a/gen/tests/AArch64/LB+datacsel+rmwap-po.litmus.expected
+++ b/gen/tests/AArch64/LB+datacsel+rmwap-po.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 12
 Condition exists ([y]=2 /\ 0:X1=1 /\ 1:X1=1)
 Observation LB+datacsel+rmwap-po Never 0 12
-Hash=8065427579f058a3a447e759632ae2cc
+Hash=6df0810676c23fb53aa4563292bea0b6
 

--- a/gen/tests/AArch64/LB+dmb.sy+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dmb.sy+addrcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dmb.sy+addrcsel Never 0 3
-Hash=403c5ba8e5df1af21f9743394c4e8d5d
+Hash=6c73cc1d1a21fad73e16607ae8544c5b
 

--- a/gen/tests/AArch64/LB+dmb.sy+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dmb.sy+ctrlcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dmb.sy+ctrlcsel Never 0 3
-Hash=06962e41cd67e11d865d02f90396898e
+Hash=5253dc2f604638fd0e9c262912fdf4a0
 

--- a/gen/tests/AArch64/LB+dmb.sy+datacsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dmb.sy+datacsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dmb.sy+datacsel Never 0 3
-Hash=7e0608d289574d691d6f1b57a3be187d
+Hash=db0d1fdd7793532746d7744a021a4084
 

--- a/gen/tests/AArch64/LB+dmb.syap+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dmb.syap+addrcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dmb.syap+addrcsel Never 0 3
-Hash=7bd5510e73355d51c6147fd655818cf4
+Hash=f7608a0bf22ee6f472fe9229f5b8019a
 

--- a/gen/tests/AArch64/LB+dmb.syap+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dmb.syap+ctrlcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dmb.syap+ctrlcsel Never 0 3
-Hash=f555137e87928213311b8e66a6eda42e
+Hash=9a8cc5735e9c63fc28a78d09e07f7877
 

--- a/gen/tests/AArch64/LB+dmb.syap+datacsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dmb.syap+datacsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dmb.syap+datacsel Never 0 3
-Hash=20484117d969c1eb488f945dfd92ff9e
+Hash=7f7f6f5a6679d0116e6562b007155b4d
 

--- a/gen/tests/AArch64/LB+dsb.sy+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dsb.sy+addrcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dsb.sy+addrcsel Never 0 3
-Hash=87c9f469567df2762574a970435fa2a0
+Hash=f995f28c3b94e40e9cf0af60961f8a8b
 

--- a/gen/tests/AArch64/LB+dsb.sy+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dsb.sy+ctrlcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dsb.sy+ctrlcsel Never 0 3
-Hash=5347374c0ee3323ace0a5051b563de5d
+Hash=1c66ca909b8693fb01186e9ac54652e6
 

--- a/gen/tests/AArch64/LB+dsb.sy+datacsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dsb.sy+datacsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dsb.sy+datacsel Never 0 3
-Hash=e79ba5b13a9fa501a69956c4ca0e00d0
+Hash=75e0485f8ff15643a721f9e6ff44d490
 

--- a/gen/tests/AArch64/LB+dsb.syap+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dsb.syap+addrcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dsb.syap+addrcsel Never 0 3
-Hash=533bb8ec78dc16b502a209ce39d0196d
+Hash=bf652ee0057d5cfa660e939bde6b5bb9
 

--- a/gen/tests/AArch64/LB+dsb.syap+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dsb.syap+ctrlcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dsb.syap+ctrlcsel Never 0 3
-Hash=f0a6981c5a647634251417c39ad476f4
+Hash=bf1946b00189022d684b7258c9a819e3
 

--- a/gen/tests/AArch64/LB+dsb.syap+datacsel.litmus.expected
+++ b/gen/tests/AArch64/LB+dsb.syap+datacsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+dsb.syap+datacsel Never 0 3
-Hash=3e9a5364ebea99fd4be4cbe76b83e14b
+Hash=f30c0749d7f5396b9886e90a97e38cc8
 

--- a/gen/tests/AArch64/LB+isb+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+isb+addrcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+isb+addrcsel Sometimes 1 3
-Hash=800b47ffacfc364b29d04b282ea310a1
+Hash=1020af982a16e91259111fc7f01e6510
 

--- a/gen/tests/AArch64/LB+isb+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+isb+ctrlcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+isb+ctrlcsel Sometimes 1 3
-Hash=862cda10118d7ae979ea4239c6e9d02f
+Hash=4711bd9d81dc2b0726f2d0bb399c8e72
 

--- a/gen/tests/AArch64/LB+isb+datacsel.litmus.expected
+++ b/gen/tests/AArch64/LB+isb+datacsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+isb+datacsel Sometimes 1 3
-Hash=7e09beba2b24ed5fc7b295e8931bc751
+Hash=d447771bcaa2c7d77ca7e1bb77785692
 

--- a/gen/tests/AArch64/LB+isbap+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+isbap+addrcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+isbap+addrcsel Never 0 3
-Hash=6ad1d6bb68de4a800a3629f802f1929c
+Hash=5bdd4300f416f4e0895d149defd14fe4
 

--- a/gen/tests/AArch64/LB+isbap+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/LB+isbap+ctrlcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+isbap+ctrlcsel Never 0 3
-Hash=750bec0049f723833278a11ef11a7614
+Hash=95b1c8b6122a49b68925003766eb2164
 

--- a/gen/tests/AArch64/LB+isbap+datacsel.litmus.expected
+++ b/gen/tests/AArch64/LB+isbap+datacsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:X1=1 /\ 1:X1=1)
 Observation LB+isbap+datacsel Never 0 3
-Hash=5e1ead73071b97169276147db40c7f82
+Hash=2c4b49b78e1653c635fe26f08e4c02b1
 

--- a/gen/tests/AArch64/MP+dmb.sy+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+dmb.sy+addrcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+dmb.sy+addrcsel Allowed
 States 4
-1:X0=0; 1:X6=0;
-1:X0=0; 1:X6=1;
-1:X0=1; 1:X6=0;
-1:X0=1; 1:X6=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X6=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+dmb.sy+addrcsel Sometimes 1 3
-Hash=decd4c0b3a494b0503d72cc525b995ff
+Hash=2a0f68387f29029e7221f226cfa192ec
 

--- a/gen/tests/AArch64/MP+dmb.sy+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+dmb.sy+ctrlcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+dmb.sy+ctrlcsel Allowed
 States 4
-1:X0=0; 1:X5=0;
-1:X0=0; 1:X5=1;
-1:X0=1; 1:X5=0;
-1:X0=1; 1:X5=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X5=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+dmb.sy+ctrlcsel Sometimes 1 3
-Hash=9935cefaffe63e5fda61984173ec072a
+Hash=2e2b4c16aeaec6acff4dbc83ce137625
 

--- a/gen/tests/AArch64/MP+dmb.sylp+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+dmb.sylp+addrcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+dmb.sylp+addrcsel Allowed
 States 4
-1:X0=0; 1:X6=0;
-1:X0=0; 1:X6=1;
-1:X0=1; 1:X6=0;
-1:X0=1; 1:X6=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X6=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+dmb.sylp+addrcsel Sometimes 1 3
-Hash=ccdcb1feb77e32d3547e31d9a68333be
+Hash=f77fb7ffbfe01202b3fcb2e4d77335f2
 

--- a/gen/tests/AArch64/MP+dmb.sylp+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+dmb.sylp+ctrlcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+dmb.sylp+ctrlcsel Allowed
 States 4
-1:X0=0; 1:X5=0;
-1:X0=0; 1:X5=1;
-1:X0=1; 1:X5=0;
-1:X0=1; 1:X5=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X5=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+dmb.sylp+ctrlcsel Sometimes 1 3
-Hash=f03f8dcd7414d87105d1eb636cd08c4a
+Hash=84a5ab981574fdce0d96a7132bab1605
 

--- a/gen/tests/AArch64/MP+dsb.sy+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+dsb.sy+addrcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+dsb.sy+addrcsel Allowed
 States 4
-1:X0=0; 1:X6=0;
-1:X0=0; 1:X6=1;
-1:X0=1; 1:X6=0;
-1:X0=1; 1:X6=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X6=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+dsb.sy+addrcsel Sometimes 1 3
-Hash=413315d73b784794dbf144e9c8826685
+Hash=c06c66ab26dab95dccd115cdb181cd9c
 

--- a/gen/tests/AArch64/MP+dsb.sy+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+dsb.sy+ctrlcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+dsb.sy+ctrlcsel Allowed
 States 4
-1:X0=0; 1:X5=0;
-1:X0=0; 1:X5=1;
-1:X0=1; 1:X5=0;
-1:X0=1; 1:X5=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X5=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+dsb.sy+ctrlcsel Sometimes 1 3
-Hash=8f50844759de0874c88760358b66ad44
+Hash=c4641cef2d4363eeb53b2ab7ea259581
 

--- a/gen/tests/AArch64/MP+dsb.sylp+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+dsb.sylp+addrcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+dsb.sylp+addrcsel Allowed
 States 4
-1:X0=0; 1:X6=0;
-1:X0=0; 1:X6=1;
-1:X0=1; 1:X6=0;
-1:X0=1; 1:X6=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X6=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+dsb.sylp+addrcsel Sometimes 1 3
-Hash=0e40cc01eef85f5c98a5e7be8fa79127
+Hash=40275b7ca43129c651ad8cc8bf42ee30
 

--- a/gen/tests/AArch64/MP+dsb.sylp+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+dsb.sylp+ctrlcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+dsb.sylp+ctrlcsel Allowed
 States 4
-1:X0=0; 1:X5=0;
-1:X0=0; 1:X5=1;
-1:X0=1; 1:X5=0;
-1:X0=1; 1:X5=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X5=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+dsb.sylp+ctrlcsel Sometimes 1 3
-Hash=fc88398a400cb53a38b31afbcf8f68c4
+Hash=b2132331abb4a3cf530ffe071b55473a
 

--- a/gen/tests/AArch64/MP+isb+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+isb+addrcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+isb+addrcsel Allowed
 States 4
-1:X0=0; 1:X6=0;
-1:X0=0; 1:X6=1;
-1:X0=1; 1:X6=0;
-1:X0=1; 1:X6=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X6=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+isb+addrcsel Sometimes 1 3
-Hash=927062efee1722d8bf09b3a10ec92103
+Hash=15eee3de233eff52da5fd82d3ae677c9
 

--- a/gen/tests/AArch64/MP+isb+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+isb+ctrlcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+isb+ctrlcsel Allowed
 States 4
-1:X0=0; 1:X5=0;
-1:X0=0; 1:X5=1;
-1:X0=1; 1:X5=0;
-1:X0=1; 1:X5=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X5=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+isb+ctrlcsel Sometimes 1 3
-Hash=db52e6347cb579ff0c749c78c8bf0bcd
+Hash=38560855645a5526f68426ad7b5e95d7
 

--- a/gen/tests/AArch64/MP+isblp+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+isblp+addrcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+isblp+addrcsel Allowed
 States 4
-1:X0=0; 1:X6=0;
-1:X0=0; 1:X6=1;
-1:X0=1; 1:X6=0;
-1:X0=1; 1:X6=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X6=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+isblp+addrcsel Sometimes 1 3
-Hash=3283118af53a889522e05eef28a3b076
+Hash=c9f5aa906fac9e1d53381d1109ed1676
 

--- a/gen/tests/AArch64/MP+isblp+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+isblp+ctrlcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+isblp+ctrlcsel Allowed
 States 4
-1:X0=0; 1:X5=0;
-1:X0=0; 1:X5=1;
-1:X0=1; 1:X5=0;
-1:X0=1; 1:X5=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X5=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+isblp+ctrlcsel Sometimes 1 3
-Hash=17197eaada1daad0444f5a35bf537cb7
+Hash=a31600a0c24283067d038ab8049e8fa6
 

--- a/gen/tests/AArch64/MP+po+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+po+addrcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+po+addrcsel Allowed
 States 4
-1:X0=0; 1:X6=0;
-1:X0=0; 1:X6=1;
-1:X0=1; 1:X6=0;
-1:X0=1; 1:X6=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X6=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+po+addrcsel Sometimes 1 3
-Hash=f9b9274b68b7501ef4b56ced7af9b029
+Hash=509cfb0e13581525a10b85f4989680aa
 

--- a/gen/tests/AArch64/MP+po+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+po+ctrlcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+po+ctrlcsel Allowed
 States 4
-1:X0=0; 1:X5=0;
-1:X0=0; 1:X5=1;
-1:X0=1; 1:X5=0;
-1:X0=1; 1:X5=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X5=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+po+ctrlcsel Sometimes 1 3
-Hash=4387dab0e460f9e509921fd7da221117
+Hash=1c7edae0d0f7a1db40e4afe665fe9a3b
 

--- a/gen/tests/AArch64/MP+polp+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+polp+addrcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+polp+addrcsel Allowed
 States 4
-1:X0=0; 1:X6=0;
-1:X0=0; 1:X6=1;
-1:X0=1; 1:X6=0;
-1:X0=1; 1:X6=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X6=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+polp+addrcsel Sometimes 1 3
-Hash=6d2544fcc98cb6a46c395b380f652225
+Hash=e906c8b71f591c89bcca84fde6e36448
 

--- a/gen/tests/AArch64/MP+polp+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/MP+polp+ctrlcsel.litmus.expected
@@ -1,13 +1,13 @@
 Test MP+polp+ctrlcsel Allowed
 States 4
-1:X0=0; 1:X5=0;
-1:X0=0; 1:X5=1;
-1:X0=1; 1:X5=0;
-1:X0=1; 1:X5=1;
+1:X0=0; 1:X4=0;
+1:X0=0; 1:X4=1;
+1:X0=1; 1:X4=0;
+1:X0=1; 1:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (1:X0=1 /\ 1:X5=0)
+Condition exists (1:X0=1 /\ 1:X4=0)
 Observation MP+polp+ctrlcsel Sometimes 1 3
-Hash=a63b360335a1fed92808dbda73b8c47a
+Hash=b7d5a48246113447f5fa81eabbe7b027
 

--- a/gen/tests/AArch64/RR+RW+addrcsel+amo.cas-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+addrcsel+amo.cas-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+addrcsel+amo.cas-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X3=0; 1:X1=0;
+0:X1=0; 0:X3=1; 1:X1=0;
+0:X1=1; 0:X3=0; 1:X1=0;
+0:X1=1; 0:X3=1; 1:X1=0;
 Ok
 Witnesses
 Positive: 2 Negative: 6
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X3=0 /\ 1:X1=0)
 Observation RR+RW+addrcsel+amo.cas-po Sometimes 2 6
-Hash=fa2405d2f615c67802d5fa45cfb84e97
+Hash=d44492b4e64e295a6dc913c0b40285f5
 

--- a/gen/tests/AArch64/RR+RW+addrcsel+amo.casap-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+addrcsel+amo.casap-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+addrcsel+amo.casap-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X3=0; 1:X1=0;
+0:X1=0; 0:X3=1; 1:X1=0;
+0:X1=1; 0:X3=0; 1:X1=0;
+0:X1=1; 0:X3=1; 1:X1=0;
 Ok
 Witnesses
 Positive: 2 Negative: 6
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X3=0 /\ 1:X1=0)
 Observation RR+RW+addrcsel+amo.casap-po Sometimes 2 6
-Hash=cd040b4f8eb2561d712836e6aa7943be
+Hash=268478e42844d05094c772d40fe814d4
 

--- a/gen/tests/AArch64/RR+RW+addrcsel+amo.stadd-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+addrcsel+amo.stadd-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+addrcsel+amo.stadd-po Allowed
 States 4
-0:X1=0; 0:X5=0;
-0:X1=0; 0:X5=1;
-0:X1=1; 0:X5=0;
-0:X1=1; 0:X5=1;
+0:X1=0; 0:X3=0;
+0:X1=0; 0:X3=1;
+0:X1=1; 0:X3=0;
+0:X1=1; 0:X3=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (0:X1=1 /\ 0:X5=0)
+Condition exists (0:X1=1 /\ 0:X3=0)
 Observation RR+RW+addrcsel+amo.stadd-po Sometimes 1 3
-Hash=d00c2c9f5ca4968fd27824a0d24f32e9
+Hash=66c8f10ee8c54e9a105374520f425377
 

--- a/gen/tests/AArch64/RR+RW+addrcsel+amo.swp-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+addrcsel+amo.swp-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+addrcsel+amo.swp-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X3=0; 1:X1=0;
+0:X1=0; 0:X3=1; 1:X1=0;
+0:X1=1; 0:X3=0; 1:X1=0;
+0:X1=1; 0:X3=1; 1:X1=0;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X3=0 /\ 1:X1=0)
 Observation RR+RW+addrcsel+amo.swp-po Sometimes 1 3
-Hash=50d2bbd92541d0b813a69919c2f96724
+Hash=d250e2304e78118b30f07f89e284e9e0
 

--- a/gen/tests/AArch64/RR+RW+addrcsel+amo.swpap-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+addrcsel+amo.swpap-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+addrcsel+amo.swpap-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X3=0; 1:X1=0;
+0:X1=0; 0:X3=1; 1:X1=0;
+0:X1=1; 0:X3=0; 1:X1=0;
+0:X1=1; 0:X3=1; 1:X1=0;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X3=0 /\ 1:X1=0)
 Observation RR+RW+addrcsel+amo.swpap-po Sometimes 1 3
-Hash=622affcb1dc5c069a28184ac5ce87f52
+Hash=b598f653347eba8e3eb44cc20aa716af
 

--- a/gen/tests/AArch64/RR+RW+addrcsel+rmw-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+addrcsel+rmw-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+addrcsel+rmw-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X3=0; 1:X1=0;
+0:X1=0; 0:X3=1; 1:X1=0;
+0:X1=1; 0:X3=0; 1:X1=0;
+0:X1=1; 0:X3=1; 1:X1=0;
 Loop Ok
 Witnesses
 Positive: 3 Negative: 9
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X3=0 /\ 1:X1=0)
 Observation RR+RW+addrcsel+rmw-po Sometimes 3 9
-Hash=b7e8cf76fefdfbf9a9a2404b9b6731f4
+Hash=de87bd4f5752227836782ac438dfe11a
 

--- a/gen/tests/AArch64/RR+RW+addrcsel+rmwap-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+addrcsel+rmwap-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+addrcsel+rmwap-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X3=0; 1:X1=0;
+0:X1=0; 0:X3=1; 1:X1=0;
+0:X1=1; 0:X3=0; 1:X1=0;
+0:X1=1; 0:X3=1; 1:X1=0;
 Loop Ok
 Witnesses
 Positive: 3 Negative: 9
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X3=0 /\ 1:X1=0)
 Observation RR+RW+addrcsel+rmwap-po Sometimes 3 9
-Hash=a2305eb774387ce00e4052378bfe0b27
+Hash=be9d2c96f78b8773427f93cf9af03219
 

--- a/gen/tests/AArch64/RR+RW+ctrlcsel+amo.cas-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+ctrlcsel+amo.cas-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+ctrlcsel+amo.cas-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X4=0; 1:X1=0;
+0:X1=0; 0:X4=1; 1:X1=0;
+0:X1=1; 0:X4=0; 1:X1=0;
+0:X1=1; 0:X4=1; 1:X1=0;
 Ok
 Witnesses
 Positive: 2 Negative: 6
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X4=0 /\ 1:X1=0)
 Observation RR+RW+ctrlcsel+amo.cas-po Sometimes 2 6
-Hash=894e0cd50ebe0a44c42eed1d858d9be8
+Hash=1894cd048dd5c401d6973bf86d6e0edc
 

--- a/gen/tests/AArch64/RR+RW+ctrlcsel+amo.casap-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+ctrlcsel+amo.casap-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+ctrlcsel+amo.casap-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X4=0; 1:X1=0;
+0:X1=0; 0:X4=1; 1:X1=0;
+0:X1=1; 0:X4=0; 1:X1=0;
+0:X1=1; 0:X4=1; 1:X1=0;
 Ok
 Witnesses
 Positive: 2 Negative: 6
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X4=0 /\ 1:X1=0)
 Observation RR+RW+ctrlcsel+amo.casap-po Sometimes 2 6
-Hash=83dc0b2d609bc53395336fd92e9ec707
+Hash=4f4d957a0308dc434f09e43fbe587d88
 

--- a/gen/tests/AArch64/RR+RW+ctrlcsel+amo.stadd-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+ctrlcsel+amo.stadd-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+ctrlcsel+amo.stadd-po Allowed
 States 4
-0:X1=0; 0:X5=0;
-0:X1=0; 0:X5=1;
-0:X1=1; 0:X5=0;
-0:X1=1; 0:X5=1;
+0:X1=0; 0:X4=0;
+0:X1=0; 0:X4=1;
+0:X1=1; 0:X4=0;
+0:X1=1; 0:X4=1;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (0:X1=1 /\ 0:X5=0)
+Condition exists (0:X1=1 /\ 0:X4=0)
 Observation RR+RW+ctrlcsel+amo.stadd-po Sometimes 1 3
-Hash=b261981322a0a25c932dd1513b085781
+Hash=6911ea3377b10de4dfa020fd7fb254bd
 

--- a/gen/tests/AArch64/RR+RW+ctrlcsel+amo.swp-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+ctrlcsel+amo.swp-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+ctrlcsel+amo.swp-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X4=0; 1:X1=0;
+0:X1=0; 0:X4=1; 1:X1=0;
+0:X1=1; 0:X4=0; 1:X1=0;
+0:X1=1; 0:X4=1; 1:X1=0;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X4=0 /\ 1:X1=0)
 Observation RR+RW+ctrlcsel+amo.swp-po Sometimes 1 3
-Hash=9269dcce847c91d027bffba79d028c34
+Hash=62b9b678f55a8e5ea584c48484f64277
 

--- a/gen/tests/AArch64/RR+RW+ctrlcsel+amo.swpap-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+ctrlcsel+amo.swpap-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+ctrlcsel+amo.swpap-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X4=0; 1:X1=0;
+0:X1=0; 0:X4=1; 1:X1=0;
+0:X1=1; 0:X4=0; 1:X1=0;
+0:X1=1; 0:X4=1; 1:X1=0;
 Ok
 Witnesses
 Positive: 1 Negative: 3
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X4=0 /\ 1:X1=0)
 Observation RR+RW+ctrlcsel+amo.swpap-po Sometimes 1 3
-Hash=ae5887701bfb4be29d4ba00a5228326f
+Hash=2d7c192a1195727a8d159c87360fe502
 

--- a/gen/tests/AArch64/RR+RW+ctrlcsel+rmw-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+ctrlcsel+rmw-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+ctrlcsel+rmw-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X4=0; 1:X1=0;
+0:X1=0; 0:X4=1; 1:X1=0;
+0:X1=1; 0:X4=0; 1:X1=0;
+0:X1=1; 0:X4=1; 1:X1=0;
 Loop Ok
 Witnesses
 Positive: 3 Negative: 9
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X4=0 /\ 1:X1=0)
 Observation RR+RW+ctrlcsel+rmw-po Sometimes 3 9
-Hash=ff351a8f6f0ef1f5621dc9f063094ed7
+Hash=0e88f314211e9e1e6fbff0cb9642d50e
 

--- a/gen/tests/AArch64/RR+RW+ctrlcsel+rmwap-po.litmus.expected
+++ b/gen/tests/AArch64/RR+RW+ctrlcsel+rmwap-po.litmus.expected
@@ -1,13 +1,13 @@
 Test RR+RW+ctrlcsel+rmwap-po Allowed
 States 4
-0:X1=0; 0:X5=0; 1:X1=0;
-0:X1=0; 0:X5=1; 1:X1=0;
-0:X1=1; 0:X5=0; 1:X1=0;
-0:X1=1; 0:X5=1; 1:X1=0;
+0:X1=0; 0:X4=0; 1:X1=0;
+0:X1=0; 0:X4=1; 1:X1=0;
+0:X1=1; 0:X4=0; 1:X1=0;
+0:X1=1; 0:X4=1; 1:X1=0;
 Loop Ok
 Witnesses
 Positive: 3 Negative: 9
-Condition exists (0:X1=1 /\ 0:X5=0 /\ 1:X1=0)
+Condition exists (0:X1=1 /\ 0:X4=0 /\ 1:X1=0)
 Observation RR+RW+ctrlcsel+rmwap-po Sometimes 3 9
-Hash=a5d9388ff292355a7b463ab88c94c8ec
+Hash=4f699da455d28720aaeb11a3376af66f
 

--- a/gen/tests/AArch64/S+dmb.sy+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/S+dmb.sy+addrcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dmb.sy+addrcsel Never 0 3
-Hash=3c9f4d3fb98b8d02c7ed7c6e8ea64ef3
+Hash=9a68ba6cd8e002b5d98b0b124e5c6ed8
 

--- a/gen/tests/AArch64/S+dmb.sy+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/S+dmb.sy+ctrlcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dmb.sy+ctrlcsel Never 0 3
-Hash=7b970b5fd85c159de6fd1911e77108d0
+Hash=8857efd75ddefe652de20d8f7a79dfce
 

--- a/gen/tests/AArch64/S+dmb.sy+datacsel.litmus.expected
+++ b/gen/tests/AArch64/S+dmb.sy+datacsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dmb.sy+datacsel Never 0 3
-Hash=6a1dbe5e612f2087b7ceda2fbcb7a5f4
+Hash=4323db4e7492fe42ddf7ee29887be197
 

--- a/gen/tests/AArch64/S+dmb.sylp+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/S+dmb.sylp+addrcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dmb.sylp+addrcsel Never 0 3
-Hash=a8b20dc57aceca29423454e4a104da71
+Hash=2129882afdeea1ade7c273588a359433
 

--- a/gen/tests/AArch64/S+dmb.sylp+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/S+dmb.sylp+ctrlcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dmb.sylp+ctrlcsel Never 0 3
-Hash=58f0015da6af4561701737781bebb611
+Hash=0f711b4ff58668d1ebddab8563eced51
 

--- a/gen/tests/AArch64/S+dmb.sylp+datacsel.litmus.expected
+++ b/gen/tests/AArch64/S+dmb.sylp+datacsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dmb.sylp+datacsel Never 0 3
-Hash=b4eaa26c95a745685d3afd9e35dab8b0
+Hash=c11584f23b2491e86e88ec67faf7b5ca
 

--- a/gen/tests/AArch64/S+dsb.sy+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/S+dsb.sy+addrcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dsb.sy+addrcsel Never 0 3
-Hash=e037bcbf4b95e70d1336ddb89bdfe62e
+Hash=6825930a43bf2bd5a728cad79ef835e0
 

--- a/gen/tests/AArch64/S+dsb.sy+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/S+dsb.sy+ctrlcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dsb.sy+ctrlcsel Never 0 3
-Hash=7eebb9cb79ab951432f49bf8fc7ae232
+Hash=d62e32889baab63c093346f783ddca92
 

--- a/gen/tests/AArch64/S+dsb.sy+datacsel.litmus.expected
+++ b/gen/tests/AArch64/S+dsb.sy+datacsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dsb.sy+datacsel Never 0 3
-Hash=b318a987e92b6f5960702fd0dc0bb22d
+Hash=486f438584635635dafdd3ef1964c7e8
 

--- a/gen/tests/AArch64/S+dsb.sylp+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/S+dsb.sylp+addrcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dsb.sylp+addrcsel Never 0 3
-Hash=04709dcc0fd17484ffacf59d77d0f3f5
+Hash=ede068cc096a20453232690794f32c64
 

--- a/gen/tests/AArch64/S+dsb.sylp+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/S+dsb.sylp+ctrlcsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dsb.sylp+ctrlcsel Never 0 3
-Hash=1096646119075193df0f6475d9928e0b
+Hash=7effea907fc5af56faee66569ee52bb3
 

--- a/gen/tests/AArch64/S+dsb.sylp+datacsel.litmus.expected
+++ b/gen/tests/AArch64/S+dsb.sylp+datacsel.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+dsb.sylp+datacsel Never 0 3
-Hash=ac2b1bafa96ae94762f90f1e140b32a7
+Hash=bf378857aaef8821a1744a87d407cb91
 

--- a/gen/tests/AArch64/S+isb+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/S+isb+addrcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+isb+addrcsel Sometimes 1 3
-Hash=0e46878398837283618f3dbb5aff68ca
+Hash=50a1f40788541ca144adbfc6e24a988b
 

--- a/gen/tests/AArch64/S+isb+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/S+isb+ctrlcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+isb+ctrlcsel Sometimes 1 3
-Hash=75988a0c24405b40a438466003683940
+Hash=a451c8cafc2831b6c034135ac76e2a5b
 

--- a/gen/tests/AArch64/S+isb+datacsel.litmus.expected
+++ b/gen/tests/AArch64/S+isb+datacsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+isb+datacsel Sometimes 1 3
-Hash=a5c9c8c73dcb91bcb0ce9eec732f4b32
+Hash=69bc3cf44d3d7296fd6a2ee6c66b6b48
 

--- a/gen/tests/AArch64/S+isblp+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/S+isblp+addrcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+isblp+addrcsel Sometimes 1 3
-Hash=9deb6c0f72ad23a461ee6442bad5da36
+Hash=5d4ff17e202d448ed730838326976560
 

--- a/gen/tests/AArch64/S+isblp+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/S+isblp+ctrlcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+isblp+ctrlcsel Sometimes 1 3
-Hash=841cd058a70b83a26591fd01e07b8e47
+Hash=c4d39735ba9f2cd864b68b4a33992b73
 

--- a/gen/tests/AArch64/S+isblp+datacsel.litmus.expected
+++ b/gen/tests/AArch64/S+isblp+datacsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+isblp+datacsel Sometimes 1 3
-Hash=222defeac8c7700b90a1fdea0371bad4
+Hash=53d3f16fda7d075ead04fe99c11ee4a8
 

--- a/gen/tests/AArch64/S+po+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/S+po+addrcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+po+addrcsel Sometimes 1 3
-Hash=97be1b6110cb30fa66bed1cae90eb5eb
+Hash=14c73daeca0898be6a90f4a2d00c83fc
 

--- a/gen/tests/AArch64/S+po+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/S+po+ctrlcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+po+ctrlcsel Sometimes 1 3
-Hash=a000ceec3d80051478b9005781ea54b8
+Hash=dd05419fff1e8126210310b77af95560
 

--- a/gen/tests/AArch64/S+po+datacsel.litmus.expected
+++ b/gen/tests/AArch64/S+po+datacsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+po+datacsel Sometimes 1 3
-Hash=649c54b252e0df89f7eb752dc3f2cdf6
+Hash=2f1032722cb942f787f0b4e2e1cc786d
 

--- a/gen/tests/AArch64/S+polp+addrcsel.litmus.expected
+++ b/gen/tests/AArch64/S+polp+addrcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+polp+addrcsel Sometimes 1 3
-Hash=ff31d0e99ea326729353ae2354b2f1d5
+Hash=6ca9d97bf8fbbfbc58dd8df3ea9b5779
 

--- a/gen/tests/AArch64/S+polp+ctrlcsel.litmus.expected
+++ b/gen/tests/AArch64/S+polp+ctrlcsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+polp+ctrlcsel Sometimes 1 3
-Hash=2e789756b6fdfb6e8b1ebf11f34e25b7
+Hash=d937d45a95d276d57fb13c9b21a9c234
 

--- a/gen/tests/AArch64/S+polp+datacsel.litmus.expected
+++ b/gen/tests/AArch64/S+polp+datacsel.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists ([x]=2 /\ 1:X0=1)
 Observation S+polp+datacsel Sometimes 1 3
-Hash=6b6a09b4f914409a06126abb9bf01562
+Hash=54787728276deef58282a35c0db46b9d
 


### PR DESCRIPTION
To fix a problem that memory tag annotation combined with Csel such as `T DpDataCseldW` generates tests that triggered error `Illegal operation readbit63 on x:green (User error)` in `herd7`, we change the generated instruction sequences. In the new sequence, `AArch64` CSEL dependency uses register self-compare instead of hardcode comparison against zero. This makes the selected CSEL path deterministic. It also removes the extra register instruction, e.g., `diyone7 -arch AArch64 -variant memtag DpAddrCselsW Rfi -oneloc` now generates:
```
`AArch64 CoRW1+addrcsels-rfi
Variant=memtag
Generator=diyone7 (version 7.58+1)
Com=Rf
Orig=DpAddrCselsW Rfi
"DpAddrCselsW Rfi"
{
 0:X0=x:green;
}
 P0                  ;
 LDR W1,[X0]         ;
 CMP W1,W1           ; (* previously MOV W3,#1  CMP W1, #0 *)
 CSEL W2,W3,W4,EQ    ; (* previously an extra clear-up AND W2,W2,#2  to set W2=0 *)
 MOV W5,#1           ;
 STR W5,[X0,W2,SXTW] ;
```
The similar sequence is also applied to `DpDataCsel*`. While for `DpCtrlCsel*`, for example `diyone7 -arch AArch64 -variant memtag DpCtrlCselsW Rfi -oneloc`, now generates:
```
AArch64 CoRW1+ctrlcsels-rfi
Variant=memtag
Generator=diyone7 (version 7.58+1)
Com=Rf
Orig=DpCtrlCselsW Rfi
"DpCtrlCselsW Rfi"
{
 0:X0=x:green;
}
 P0                ;
 LDR W1,[X0]       ;
 CMP W1,W1         ; (* previously CMP W1,#0 *)
 CSINC W2,W3,W4,EQ ; (* previous the false branch is W2 but now is a fresh register W4 *)
 CBNZ W2,LC00      ;
 LC00:             ;
 MOV W5,#1         ;
 STR W5,[X0]       ;

exists (0:X1=1)
```