### PR TITLE
[ASL Reference] fixed HTML (hevea-related) warnings

### DIFF
--- a/asllib/doc/ASLFormal.tex
+++ b/asllib/doc/ASLFormal.tex
@@ -1155,16 +1155,7 @@ and applies it to an optional value:
 
 \subsection{Conventional Notations}
 \hypertarget{def-wrapline}{}
-\begin{itemize}
-\item
 The notation $\wrappedline$ denotes that a line that is longer than the page width continues on the next line.
-
-\hypertarget{def-commonprefixline}{}
-\item The notation $\commonprefixline$ serves as a visual aid to delimit a common prefix of premises shared by rule cases.
-
-\hypertarget{def-commonsuffixline}{}
-\item The notation $\commonsuffixline$ serves as a visual aid to delimit a common suffix of premises shared by rule cases.
-\end{itemize}
 
 \section{Rule Naming\label{sec:Rule Naming}}
 To name a rule, we place it in a section with its name.

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -22,8 +22,10 @@
 % \mathhypertarget{} is suitable for math environments,
 % whereas the \texthypertarget{} is suitable for text environments.
 \makeatletter
-\newcommand\mathhypertarget[1]{\Hy@raisedlink{\hypertarget{#1}}} % DO NOT LINT
-\newcommand\texthypertarget[1]{\Hy@raisedlink{\hypertarget{#1}{}}} % DO NOT LINT
+% Use \providecommand so the HTML build can keep the HeVeA-specific definitions
+% from macros.hva without reporting redefinition warnings.
+\providecommand\mathhypertarget[1]{\Hy@raisedlink{\hypertarget{#1}}} % DO NOT LINT
+\providecommand\texthypertarget[1]{\Hy@raisedlink{\hypertarget{#1}{}}} % DO NOT LINT
 \makeatother
 
 \usepackage{listings}
@@ -104,7 +106,9 @@
     morestring=[b][\color{cyan}]",
     morestring=[d][\color{cyan}]',
 }
-\newcommand{\lightyellow}{\color{yellow!10}}
+% Use \providecommand so the HTML build can keep the HeVeA-specific definition
+% from macros.hva without reporting a redefinition warning.
+\providecommand{\lightyellow}{\color{yellow!10}}
 \lstset{
   language=ASL,
   basicstyle=\ttfamily\scriptsize,
@@ -122,7 +126,6 @@
 \usepackage[export]{adjustbox}  % For centering too wide figures
 \usepackage{mathpartir}  % For deduction rules and equations paragraphs
 \newcommand\hva[0]{} % Disable the macro, just for the current PR.
-\usepackage{comment}
 \usepackage{fancyvrb}
 \usepackage[
   % Notes on the right, should be less than outer
@@ -326,8 +329,6 @@
 \newcommand\ie{i.\,e.}
 \newcommand\eg{e.\,g.}
 \newcommand\wrappedline[0]{{\hyperlink{def-wrapline}{\color{red}\hookrightarrow}}}
-\newcommand\commonprefixline[0]{{\hyperlink{def-commonprefixline}{\color{cyan}{\text{\tiny******** common prefix ********}} }}}
-\newcommand\commonsuffixline[0]{{\hyperlink{def-commonsuffixline}{\color{cyan}{\text{\tiny******** common suffix ********}} }}}
 \newcommand\stdlibfunc[1]{standard library function \texttt{#1}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%$%%%%%
@@ -507,7 +508,9 @@
 \newcommand\opnot[1]{\hyperlink{relation-neg}{\neg}{\left(#1\right)}}
 \newcommand\opnotvar[1]{\hyperlink{relation-neg}{\neg}{#1}}
 \newcommand\IFF[0]{\hyperlink{relation-IFF}{\Leftrightarrow}}
-\renewcommand\implies[0]{\hyperlink{relation-implies}{\Rightarrow}}
+% Use \def rather than \renewcommand to avoid a HeVeA warning for redefining
+% the built-in \implies macro; the expansion remains the linked implication.
+\def\implies{\hyperlink{relation-implies}{\Rightarrow}}
 
 \newcommand\some[1]{\hyperlink{relation-some}{\textsf{some}}\left({#1}\right)} % The optional expression with one element
 \newcommand\makeset[1]{\left\{{#1}\right\}} % A set of expressions

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -23,8 +23,13 @@ ASLReference.pdf: generated_spec *.tex *.bib
 
 html: generated_spec *.tex *.bib *.hva
 	mkdir -p HTML
-	hevea -fix0 -O -o HTML/ASL.html book.hva macros.hva ASLReference.tex
+	@# The first run is expected to generate warnings because bibhva
+	@# and the second hevea pass have not run, so we silence them via -s.
+	hevea -fix0 -s -O -o HTML/ASL.html book.hva macros.hva ASLReference.tex
 	bibhva HTML/ASL
+	@# bibhva makes citations available after the first pass; run one more
+	@# silent pass so the final unsilenced pass starts from stable references.
+	hevea -fix0 -s -O -o HTML/ASL.html book.hva macros.hva ASLReference.tex
 	hevea -fix -O -o HTML/ASL.html book.hva macros.hva ASLReference.tex
 	cd HTML && hacha ASL.html
 

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -4,6 +4,27 @@ BIBTEX=bibtex
 
 GENERATED_MACROS_TEX=generated_macros.tex
 
+# HeVeA and Hacha can emit warnings on stderr while still exiting with success.
+# Capture stderr from the command, preserve real command failures, and make
+# warning diagnostics fatal.
+# Match both "Warning:" and "Warning," patterns because the tools use both forms.
+# We don't match just "Warning" to ignore ordinary text containing that word.
+# Argument 1: command to run.
+# Argument 2: tool name for the failure message.
+ASL_HTML_FAIL_ON_STDERR_WARNING = messages="$$($1 2>&1)"; \
+	rc="$$?"; \
+	: "Catch tool failure."; \
+	if [ "$$rc" -ne 0 ]; then \
+		printf '%s\n' "$$messages"; \
+		exit "$$rc"; \
+	fi; \
+	: "Detect warning message patterns."; \
+	if printf '%s\n' "$$messages" | grep -Eq "Warning[:,]"; then \
+		printf '%s\n' "$$messages"; \
+		echo "$2 warnings detected; failing HTML build."; \
+		exit 1; \
+	fi
+
 all: ASLReference.pdf
 
 LATEXMK=latexmk
@@ -30,8 +51,10 @@ html: generated_spec *.tex *.bib *.hva
 	@# bibhva makes citations available after the first pass; run one more
 	@# silent pass so the final unsilenced pass starts from stable references.
 	hevea -fix0 -s -O -o HTML/ASL.html book.hva macros.hva ASLReference.tex
-	hevea -fix -O -o HTML/ASL.html book.hva macros.hva ASLReference.tex
-	cd HTML && hacha ASL.html
+	@echo "hevea -fix -O -o HTML/ASL.html book.hva macros.hva ASLReference.tex"
+	@$(call ASL_HTML_FAIL_ON_STDERR_WARNING,hevea -fix -O -o HTML/ASL.html book.hva macros.hva ASLReference.tex,HeVeA)
+	@echo "cd HTML && hacha ASL.html"
+	@$(call ASL_HTML_FAIL_ON_STDERR_WARNING,cd HTML && hacha ASL.html,Hacha)
 
 generated_spec: asl.spec
 	dune exec -- aslspec asl.spec --render;

--- a/asllib/doc/Syntax.tex
+++ b/asllib/doc/Syntax.tex
@@ -390,7 +390,6 @@ For example, instead of $\Tidentifier(\id)$, we simply write $\Tidentifier$.
 \Noverride \derivesinline\ & \emptysentence \;|\; \Timpdef \;|\;\Timplementation &
 \end{flalign*}
 
-\vspace*{-\baselineskip}
 \hypertarget{def-nlocaldeclkeyword}{}
 \begin{flalign*}
 \Nlocaldeclkeyword \derives \ & \Tlet \;|\; \Tconstant \;|\; \Tvar &

--- a/asllib/doc/enumitem.hva
+++ b/asllib/doc/enumitem.hva
@@ -1,3 +1,4 @@
 \ProvidesPackage{enumitem}
+\newcommand{\setlistdepth}[1]{}
 \newcommand{\renewlist}[3]{}
 \newcommand{\setlist}[2][]{}

--- a/asllib/doc/macros.hva
+++ b/asllib/doc/macros.hva
@@ -1,85 +1,240 @@
+% Local color support used by ASLmacros.tex. The PDF build defines this through
+% normal LaTeX packages; the HTML build needs the same command names available
+% before ASLmacros.tex is read.
 \usepackage{color}
 \definecolor{ly}{cmyk}{0.0, 0.0, 0.20, 0.0}
 \newcommand{\lightyellow}{\color{ly}}
+
+% Keep the input encoding package harmless for HeVeA.
 \usepackage[utf8]{inputenc}
+
+% The LaTeX book class uses these to switch page-numbering and chapter state.
+% The split HTML output does not need that state, and HeVeA's book.hva does not
+% define the commands, so make them explicit no-ops for HTML.
+\providecommand{\frontmatter}{}
+\providecommand{\mainmatter}{}
+\providecommand{\backmatter}{}
+
+% ASLmacros.tex uses separate target macros for math and text mode. In HTML
+% both can be represented as empty anchors at the current position.
 \newcommand{\tgt@none}[1]{\hypertarget{#1}{}}
 \newcommand{\mathhypertarget}[1]{\tgt@none{#1}}
 \let\texthypertarget\tgt@none
+
+% HeVeA does not provide flalign*. Treat it as align* so displayed equations
+% still render as aligned math.
 \newenvironment{flalign*}{\align*}{\endalign*}
+
+% adjustbox is used around qtree diagrams only to constrain PDF widths. HeVeA
+% does not render qtree, but it should at least consume the adjustbox argument
+% so options such as max width=\textwidth do not appear as HTML text.
+\newenvironment{adjustbox}[1]{}{}
+
+% HeVeA does not support qtree's \Tree command. Leave the qtree bracket body as
+% plain HTML text for now, but define the command so the warning is suppressed.
+\newcommand{\Tree}{}
+
+% LaTeX's \DeclareMathOperator defines named math operators such as \dom.
+% This simple HTML version keeps the operator text upright.
 \newcommand{\DeclareMathOperator}[2]{\newcommand{#1}{\mathop{\mbox{#2}}}}
+
+% The PDF macro uses \xlongrightarrow, whose inline HTML rendering is poor for
+% this use. Render the inline derivation arrow directly.
 %\newcommand{\xlongrightarrow}[2][]{\longrightarrow^{#2}_{#1}}
-\newcommand{\derivesinline}{\longrightarrow^{\text{\scriptsize{}inline}}}
+\newcommand{\my@derivesinline}{\longrightarrow^{\text{\scriptsize{}inline}}}
+
+% Teach HeVeA how to render \not\derives, where \derives is the ASL
+% derivation arrow. Use -/-> rather than the shorter Unicode negated arrow,
+% since it renders much smaller than the non-negated arrow: -->.
+\expandafter\def\csname\not@name{\derives}\endcsname{\mbox{-/->}}
+
+% Use the Unicode n-ary times symbol for ASL relation signatures. The PDF macro
+% relies on a large math symbol; this gives HeVeA a concrete HTML character.
 \DeclareSymbolHtml{\mytimes}{X2A09}
 \newcommand{\bigtimes}{{\DisplayChoose\Huge\Large\mytimes}}
+
+% The PDF definitions of these ASL math operators use primitives that HeVeA
+% does not implement. Keep the hyperlinks, but use stable HTML symbols.
+\DeclareSymbolHtml{\disjointunionhtmlsymbol}{X228E}
+\newcommand{\my@disjointunion}
+  {\hyperlink{def-disjointunion}{\mathbin{\mbox{\Large \disjointunionhtmlsymbol}}}}
+\newcommand{\my@parallelgraphs}[1]
+  {\hyperlink{def-parallellist}{\mathbin{\mbox{\Large ||}}}{#1}}
+\AtBeginDocument
+  {\let\disjointunion\my@disjointunion
+   \let\parallelgraphs\my@parallelgraphs}
+
+% \inlist is a hyperlinked membership symbol. HeVeA's standard \not logic does
+% not see through that wrapper, so special-case \not\inlist and delegate all
+% other negations to HeVeA's original \not.
 \let\old@not\not
 \renewcommand{\not}[1]
 {\def\@arg{#1}\def\@cmp{\inlist}\ifx\@arg\@cmp\old@not\in\else\old@not#1\fi}
-%%%
-% Hml and PDF differs in one point, while anchors (hypertargets)
-% and references (hyperlinks) can nest,
-% nested "A" elements are not valid html...
-% Hence we do not generate hyperlinks inside local references
-% local anchor or anchors
+
+% HTML and PDF differ in one important point: hyperref can nest anchors and
+% links, but HTML cannot nest <a> elements. When building local anchors or
+% links, temporarily disable inner \hyperlink commands.
 \newcommand{\no@hyperlink}[2]{}
 \newcommand{\my@aname}[2]{\bgroup\let\hyperlink\no@hyperlink\aname{#1}{#2}\egroup}
 \newcommand{\my@hypertarget}[2]{\my@aname{#1}{#2}}
 \AtBeginDocument{\let\hypertarget\my@hypertarget}
+
 \newcommand{\my@ahrefloc}[2]{\bgroup\let\hyperlink\no@hyperlink\ahrefloc{#1}{#2}\egroup}
 \newcommand{\my@hyperlink}[2]{\my@ahrefloc{#1}{#2}}
 \AtBeginDocument{\let\hyperlink\my@hyperlink}
-%%%Complex hyperlinks in display mode may produce table elements inside
-%%% A elements, which is no valid HTML
-\newcommand{\Ignore}
+
+% ASLmacros.tex records rule-list entries by writing commands to the LaTeX aux
+% file. HeVeA does not support \immediate\write\@auxout, so write equivalent
+% entries through HeVeA's own .haux mechanism instead. The html target already
+% runs HeVeA to a fixpoint, so the next pass reads these entries before the
+% rule-list environments print their summaries.
+\newcommand{\my@ASLRuleListWrite}[5]{%
+  \@auxdowrite{\@print{\ASLRuleListEntry}\{#1\}\{#2\}\{#3\}\{#4\}\{\@subst{#5}\}\@print{
+}}}
+
+\newcommand{\my@ASLRecordASTRule}[2]{%
+  \ifx\ASLCurrentASTRuleList\@empty
+  \else
+    \my@ASLRuleListWrite{AST}{\ASLCurrentASTRuleList}{ASTRuleRef}{#2}{#1}%
+  \fi}
+
+\newcommand{\my@ASLRecordTypingRule}[2]{%
+  \ifx\ASLCurrentTypingRuleList\@empty
+  \else
+    \my@ASLRuleListWrite{Typing}{\ASLCurrentTypingRuleList}{TypingRuleRef}{#2}{#1}%
+  \fi}
+
+\newcommand{\my@ASLRecordSemanticsRule}[2]{%
+  \ifx\ASLCurrentSemanticsRuleList\@empty
+  \else
+    \my@ASLRuleListWrite
+      {Semantics}{\ASLCurrentSemanticsRuleList}{SemanticsRuleRef}{#2}{#1}%
+  \fi}
+
+\newcommand{\my@ASLRuleListEntry}[5]{%
+  \@ifundefined{ASLRuleList@#1@#2}{%
+    \newtokens{\csname ASLRuleList@#1@#2\endcsname}%
+  }{}%
+  \def\ASLRuleListDescription{#5}%
+  \ifx\ASLRuleListDescription\@empty
+    \addtokens{\csname ASLRuleList@#1@#2\endcsname}
+      {\item \csname #3\endcsname{#4}}%
+  \else
+    \addtokens{\csname ASLRuleList@#1@#2\endcsname}
+      {\item \csname #3\endcsname{#4} #5}%
+  \fi}
+
+% HeVeA reads .haux from an earlier AtBeginDocument hook. Prepend the rule-list
+% entry override so stored entries use the token-register accumulator.
+\addrevtokens{\@atbegindocument}
+  {\let\ASLRuleListEntry\my@ASLRuleListEntry}
+\AtBeginDocument
+  {\let\ASLRecordASTRule\my@ASLRecordASTRule
+   \let\ASLRecordTypingRule\my@ASLRecordTypingRule
+   \let\ASLRecordSemanticsRule\my@ASLRecordSemanticsRule}
+
+% Some hyperlinked math constructs produce tables in display mode. Put the link
+% inside the display-mode construct there, and around the compact inline
+% construct otherwise, to avoid invalid HTML.
+\newcommand{\my@Ignore}
 {\ifdisplay\underline{\hyperlink{def-ignore}{\;\;}}%
 \else\hyperlink{def-ignore}{\underline{\;\;}}\fi}
-\newcommand{\Option}[1]{%
+
+\newcommand{\my@Option}[1]{%
 \ifdisplay\textsf{\hyperlink{def-option}{Option}}\left({#1}\right)
 \else
 \hyperlink{def-Option}{\textsf{Option}}\left({#1}\right)\fi}
-\newcommand\reverseeqdef{%
+
+\newcommand\my@reverseeqdef{%
 \ifdisplay
   \stackrel{\hyperlink{relation-reverseassign}{\mathsf{is}}}{=}\else
 \hyperlink{relation-reverseassign}{\stackrel{\mathsf{is}}{=}}\fi}
+
+% Helper for macros where the PDF puts a hyperlink around an overline or
+% underline. In display mode, move the hyperlink inside that decoration to avoid
+% block-level HTML inside an anchor.
 \newcommand{\inside@out@link}[3]{\ifdisplay#2{\hyperlink{#1}{#3}}\else\hyperlink{#1}{#2{#3}}\fi}
-\newcommand{\CannotOverapproximate}
- {\inside@out@link{constant-CannotOverapproximate}{\overline}{\textsf{Approx}}}
-\newcommand{\CannotUnderapproximate}
+
+\newcommand{\my@CannotOverapproximate}
+ {\inside@out@link{type-CannotOverapproximate}{\overline}{\textsf{Approx}}}
+
+\newcommand{\my@CannotUnderapproximate}
  {\inside@out@link
-   {constant-CannotUnderapproximate}{\underline}{\textsf{Approx}}}
-%%
+   {type-CannotUnderapproximate}{\underline}{\textsf{Approx}}}
+
+% HeVeA's inline \xrightarrow warning and output are not helpful for these
+% labels. Render text x-arrows as a compact -(label)-> form in HTML.
 \newcommand{\my@textxrightarrow}[1]{-(#1)\rightarrow}
 \AtBeginDocument{\let\textxrightarrow\my@textxrightarrow}
-\newcommand{\ordered}[3]{{#1}\xrightarrow{#2}{#3}}
-%%%No def-ordered link, as there is another one inside
-\newcommand{\orderedctrl}{\xrightarrow{\aslctrl}}
-\newcommand{\ordereddata}{\xrightarrow{\asldata}}
-\newcommand{\orderedpo}{\xrightarrow{\aslpo}}
-%%% Small font size not recommended for HTML
-\newcommand\commonprefixline[0]{\hyperlink{def-commonprefixline}{\color{cyan}{\text{******** common prefix ********}}}}
-\newcommand\commonsuffixline[0]{\hyperlink{def-commonsuffixline}{\color{cyan}{\text{******** common suffix ********}}}}
+
+% The \ordered family already contains links in its labels. Avoid the outer
+% def-ordered hyperlink from ASLmacros.tex so HTML links do not nest.
+\newcommand{\my@ordered}[3]{{#1}\xrightarrow{#2}{#3}}
+\newcommand{\my@orderedctrl}{\xrightarrow{\aslctrl}}
+\newcommand{\my@ordereddata}{\xrightarrow{\asldata}}
+\newcommand{\my@orderedpo}{\xrightarrow{\aslpo}}
+
+% These macros are also defined in ASLmacros.tex. Defining the HTML versions
+% directly here would make HeVeA warn when ASLmacros.tex later tries to define
+% the PDF versions with \newcommand. Instead, give the HTML implementations
+% private names now and install them after ASLmacros.tex has loaded. This is
+% only safe for body-use macros; early helpers such as \mathhypertarget must
+% still be defined before ASLmacros.tex is read.
+\AtBeginDocument
+  {\let\reverseeqdef\my@reverseeqdef
+   \let\Ignore\my@Ignore
+   \let\Option\my@Option
+   \let\CannotOverapproximate\my@CannotOverapproximate
+   \let\CannotUnderapproximate\my@CannotUnderapproximate
+   \let\ordered\my@ordered
+   \let\orderedctrl\my@orderedctrl
+   \let\ordereddata\my@ordereddata
+   \let\orderedpo\my@orderedpo
+   \let\derivesinline\my@derivesinline}
+
+% The document intentionally suppresses section entries in the HTML table of
+% contents. Relaxing \l@section avoids conflicts with LaTeX's TOC formatting.
 \let\l@section\relax
-%% Not so great rendering of \overbracket in inline mode
+
+% HeVeA's inline bracket decorations are hard to read. Render underbracket-like
+% text with a CSS wavy underline for the lexical "any character" notation.
 \def\my@wavy{\@span{style="text-decoration:wavy underline;"}}
-\newcommand{\anycharacter}[1]{$\my@wavy{}#1$}
+\newcommand{\my@anycharacter}[1]{$\my@wavy{}#1$}
 \newcommand{\my@textunderbracket}[1]{{\my@wavy{#1}}}
-\AtBeginDocument{\let\textunderbracket\my@textunderbracket}
-%% Not so great rendering of \overbracket ininline mode
+\AtBeginDocument
+  {\let\anycharacter\my@anycharacter
+   \let\textunderbracket\my@textunderbracket}
+
+% Render inline overbrackets as a CSS overline. This is less exact than the PDF
+% output but avoids noisy HeVeA bracket markup in normal text.
 \newcommand{\over@line}{\@span{style="text-decoration:solid overline;"}}
 \newcommand{\my@textoverbracket}[1]{{\over@line{}#1}}
 \AtBeginDocument{\let\textoverbracket\my@textoverbracket}
+
+% \overname is an overbracket with a label above it. Keep the original display
+% rendering, but use a simpler inline rendering where the label is vertically
+% shifted above an overline.
 \newcommand{\text@top}{\@span{style="vertical-align:1.5em;"}}
 \newcommand{\textovername}[2]{\overline{#1}{\text@top{}#2}}
 \newcommand{\myovername}[2]{\ifdisplay\old@overname{#1}{#2}\else\textovername{#1}{#2}\fi}
 \AtBeginDocument{\let\old@overname\overname\let\overname\myovername}
-%%%% No warning (checked visualy)
+
+% HeVeA's large-delimiter helper can warn for constructs that render acceptably
+% without changing size. Drop the size wrapper in HTML.
 \renewcommand{\@@big}[1]{#1}
-%%%% Apparently \empty is... empty
+
+% HeVeA's \empty expands to nothing in places where the document needs a no-op
+% control sequence. Make that explicit.
 \let\empty\relax
-%%%% Console output.
-%Disable font size change in Verbatim environment
+
+% Ignore FancyVerb fontsize options in HTML. HeVeA does not need the PDF font
+% size adjustment for console snippets.
 \newcommand{\nokey}[1]{}
 \AtBeginDocument{\let\verb@fontsize@key\nokey}
-%Change vertical alignment of premise and conclusion in inference rules
+
+% HeVeA's mathpartir tables align inference rule premises and conclusions at
+% the bottom by default. Middle alignment gives the generated rules a closer
+% visual match to the PDF.
 \AtBeginDocument
     {\renewcommand{\mpr@vert@premise}{middle}%
      \renewcommand{\mpr@vert@conclusion}{middle}}


### PR DESCRIPTION
* Fixed warnings due to the difference between LaTeX and how Hevea emits HTML by overriding macros.
* Fixed bibliography-related warnings by running a silent HeVeA pass before calling `bibhva`.
* the Makefile now catches HeVeA and hacha warnings and then fails the build.

This PR is AI-assisted.

----------

Below is a detailed list of warnings and their corresponding fixes:
# ASL Reference HTML Warning Cleanup

- [x] First-pass undefined labels, citations, and fixpoint warnings.
  Example warning: `./introduction.tex:140: Warning: Undefined label:
  'chap:Specifications'`.
  Cause: the first `hevea -fix0` pass runs before `bibhva` and before HeVeA
  has enough information to reach a cross-reference fixpoint. Undefined labels,
  undefined citations, and rerun/fixpoint messages are therefore expected during
  this bootstrap pass.
  Fix: pass `-s` to this first HeVeA invocation in `asllib/doc/Makefile`. This
  silences only the bootstrap pass; later unsilenced output is still used to
  catch warnings that survive reference convergence.

- [x] Post-bibliography citation and fixpoint warnings.
  Example warning: `./LexicalStructure.tex:436: Warning: Undefined citation:
  'ASU86'`.
  Cause: `bibhva` makes bibliography entries available after the first HeVeA
  pass. The next HeVeA pass is therefore the first pass that can consume the
  generated bibliography data, resolve citations, and update HeVeA's own
  cross-reference state. If that pass is also the final unsilenced pass, HeVeA
  reports transient undefined-citation and changed-label warnings even though a
  subsequent pass would resolve them.
  Fix: add one silent `hevea -fix0 -s` pass immediately after `bibhva` in
  `asllib/doc/Makefile`. This lets HeVeA absorb the bibliography/citation state
  before the final unsilenced `hevea -fix` pass, so the visible final pass
  starts from stable references.

- [x] Broken `CannotOverapproximate` and `CannotUnderapproximate` anchors.
  Example warning: `ASL.html:27550: Warning, cannot find anchor:
  constant-CannotOverapproximate`.
  Cause: `macros.hva` linked these HTML-only macro definitions to
  `constant-CannotOverapproximate` and `constant-CannotUnderapproximate`, but
  the generated HTML anchors are `type-CannotOverapproximate` and
  `type-CannotUnderapproximate`.
  Fix: update the two `macros.hva` links to use the generated `type-*` anchors.

- [x] Unused `\commonprefixline` and `\commonsuffixline` overrides.
  Example warning: `./ASLmacros.tex:329: Warning: Ignoring (re-)definition of
  '\commonprefixline' by \newcommand`.
  Cause: these macros were no longer used in the TeX sources, but definitions
  remained in both `ASLmacros.tex` and `macros.hva`. HeVeA still processed those
  unused definitions and reported redefinition warnings.
  Fix: remove the unused definitions from both files.

- [x] Rule-list aux writes.
  Example warning: `./TypeAttributes.tex:9: Warning: Command not found:
  \immediate`.
  Cause: `ASLmacros.tex` records rule-list entries with
  `\immediate\write\@auxout{...\unexpanded{...}}`, which HeVeA does not
  support. In HTML builds this produced command warnings, leaked raw
  `\ASLRuleListEntry...` text into generated pages, and left rule-list outlines
  saying "Run LaTeX again".
  Fix: override the HTML-only rule-recording macros in `macros.hva` so they
  write equivalent `\ASLRuleListEntry` commands through HeVeA's `.haux`
  mechanism with `\@auxdowrite`, instead of using TeX's aux stream. Also
  override `\ASLRuleListEntry` for HTML to accumulate entries with HeVeA token
  registers (`\newtokens`/`\addtokens`) rather than LaTeX's unsupported
  `\g@addto@macro`; install that override before HeVeA reads `.haux`. The
  generated outlines now contain linked rule entries, the "Run LaTeX again"
  placeholders are gone, and the aux-write warnings are suppressed.

- [x] Parse-tree warning suppression.
  Example warning: `./Syntax.tex:845: Warning: Command not found:
  \adjustbox`.
  Cause: `Syntax.tex` uses `adjustbox` and qtree's `\Tree`, which HeVeA does
  not understand. Without HTML-specific handling, HeVeA reports unknown-command
  warnings and emits visible raw text such as `max width=...` alongside the raw
  qtree bracket syntax.
  Fix: define a one-argument no-op `adjustbox` environment in `macros.hva` so
  the width option is consumed instead of rendered as text, and define `\Tree`
  as a no-op so HeVeA stops warning about it. This keeps the source TeX
  unchanged and avoids special encodings for individual trees in `Syntax.tex`.
  This PR intentionally only suppresses the HeVeA warnings; it does not attempt
  to implement qtree rendering in HTML, so the generated HTML still shows the
  raw qtree bracket syntax.

- [x] Unsupported math primitives.
  Example warning: `./Semantics.tex:284: Warning: Command not found:
  \mathchoice`.
  Cause: some ASL macros use TeX primitives that HeVeA does not support,
  including `\mathchoice`, `\mathaccent`, and `\Big`. The affected forms
  include `\parallelgraphs` and `\disjointunion`.
  Fix: add HTML-only replacements in `macros.hva` after `ASLmacros.tex` has
  loaded. `\parallelgraphs` keeps its hyperlink but renders the list parallel
  operator as a larger ASCII `||`, avoiding `\mathchoice` and `\Big`;
  `\disjointunion` keeps its hyperlink but renders as a larger Unicode multiset
  union, avoiding `\mathaccent`. Representative definition and rule-use sites
  were visually inspected in the generated HTML, and the larger operator
  rendering was accepted.

- [x] HTML macro override warnings.
  Example warning: `./ASLmacros.tex:25: Warning: Ignoring (re-)definition of
  '\mathhypertarget' by \newcommand`.
  Cause: `macros.hva` intentionally defines HTML-specific versions of macros
  that are also defined in `ASLmacros.tex`, so HeVeA reports redefinition
  warnings when `ASLmacros.tex` later defines the same names.
  Fix: for body-use overrides that can be changed entirely within `macros.hva`,
  define private `\my@...` implementations and install them with
  `\AtBeginDocument` after `ASLmacros.tex` has loaded. This removes the
  redefinition warnings for `\reverseeqdef`, `\ordered`, `\orderedctrl`,
  `\ordereddata`, `\orderedpo`, `\Ignore`, `\Option`, `\derivesinline`,
  `\anycharacter`, `\CannotOverapproximate`, and `\CannotUnderapproximate`.
  For early-load helpers that must exist while `ASLmacros.tex` is being read
  (`\mathhypertarget`, `\texthypertarget`, and `\lightyellow`), change the
  shared TeX definitions to `\providecommand`. The PDF build still defines
  those helpers when no HTML override exists, while HeVeA keeps the definitions
  from `macros.hva` without reporting redefinition warnings.

- [x] HeVeA `comment` package status output.
  Example output: `Exclude comment 'comment'`.
  Cause: `ASLmacros.tex` loaded the LaTeX `comment` package, but the ASL
  document sources do not use `comment` environments or any
  `includecomment`/`excludecomment`/`specialcomment` commands. HeVeA's
  `comment.hva` defines the default `comment` environment by calling
  `\excludecomment`, and that shim emits this status line once per HeVeA
  invocation. This is not a `Warning:` line, but it still added noise to the
  captured HTML build messages.
  Fix: since the package was confirmed unused, remove
  `\usepackage{comment}` from `ASLmacros.tex`. The HTML build no longer loads
  `comment.hva`, so the status output disappears. The PDF build was rebuilt and
  spot-checked after the removal.

- [x] `\implies` `\renewcommand` warning.
  Example warning: `./ASLmacros.tex:508: Warning: Defining '\implies' by
  \renewcommand`.
  Cause: `ASLmacros.tex` redefined LaTeX's built-in `\implies` with
  `\renewcommand` to add a hyperlink to the ASL implication definition. HeVeA
  renders the macro correctly but warns about this `\renewcommand`.
  Fix: keep the same linked `\Rightarrow` expansion, but define it with `\def`
  instead of `\renewcommand`. The generated HTML was checked at the implication
  definition and a generated rule use to confirm the linked `⇒` rendering is
  unchanged. The PDF rendering was also inspected and accepted.

- [x] Incomplete `enumitem.hva` shim.
  Example warning: `./ASLmacros.tex:143: Warning: Command not found:
  \setlistdepth`.
  Cause: `ASLmacros.tex` loads `enumitem` to configure deeply nested inline
  itemize lists. HeVeA finds the local `enumitem.hva` package shim, which
  already ignores `\renewlist` and `\setlist`, but the shim did not define
  `\setlistdepth`. HeVeA therefore treated `\setlistdepth{20}` as an unknown
  command and emitted a warning.
  Fix: add a one-argument no-op definition to `enumitem.hva`:
  `\newcommand{\setlistdepth}[1]{}`. This matches the existing shim strategy:
  keep the LaTeX list customization for PDF output, while letting HeVeA ignore
  enumitem-specific list setup that it does not need to render the HTML.

- [x] `\not\derives`.
  Example warning: `./Syntax.tex:867: Warning: Cannot apply '\not' to
  '\derives'`.
  Cause: `Syntax.tex` uses `\not\derives`, and HeVeA cannot apply `\not` to
  the custom `\derives` macro.
  Fix: define HeVeA's internal negated form of `\derives` in `macros.hva`,
  rendering `\not\derives` as `-/->`. This suppresses the warning while
  producing a negated derivation arrow closer in width to the normal
  `\longrightarrow`-based `\derives` rendering.

- [x] Negative `\vspace`.
  Example warning: `./Syntax.tex:394: Warning: \vspace with arg
  '-\baselineskip'`.
  Cause: `Syntax.tex` used `\vspace*{-\baselineskip}`, which HeVeA reports as a
  spacing warning.
  Fix: remove the spacing command from `Syntax.tex`; visual inspection showed
  no meaningful difference in the surrounding grammar display.
  
- [x] frontmatter/mainmatter macros.
  warning: ./ASLReference.tex:30: Warning: Command not found: \frontmatter
./ASLReference.tex:33: Warning: Command not found: \mainmatter`
Fix: defined no-op shims