### PR TITLE
[ASL Reference] Fixes due to mising str concat operations

### DIFF
--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1510,6 +1510,13 @@
 
 \newcommand\eqstring[0]{\hyperlink{def-eqstring}{\text{eq\_string}}}
 \newcommand\nestring[0]{\hyperlink{def-nestring}{\text{ne\_string}}}
+\newcommand\bitsname[0]{bits}
+\newcommand\boolname[0]{bool}
+\newcommand\intname[0]{int}
+\newcommand\labelname[0]{label}
+\newcommand\realname[0]{real}
+\newcommand\stringname[0]{string}
+\newcommand\concatstringop[2]{\hyperlink{def-concatstring}{\text{concat\_str\_#1\_#2}}}
 
 \newcommand\eqenum[0]{\hyperlink{def-eqenum}{\text{eq\_enum}}}
 \newcommand\neenum[0]{\hyperlink{def-neenum}{\text{ne\_enum}}}

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -438,12 +438,49 @@ $\Tcoloncolon$  & $\LBitvector$ & $\LBitvector$ & $\LBitvector$ & $\concatbits$\
 \centering
 \hypertarget{def-eqstring}{}
 \hypertarget{def-nestring}{}
+\hypertarget{def-concatstring}{}
 \begin{tabular}{lllll}
 \hline
 \textbf{Operator} & \textbf{Operand 1} & \textbf{Operand 2} & \textbf{Result} & \textbf{Name}\\
 \hline
 $\Teqop$  & $\LString$ & $\LString$ & $\LBool$ & $\eqstring$\\
 $\Tneq$   & $\LString$ & $\LString$ & $\LBool$ & $\nestring$\\
+$\Tplusplus$ & $\LBitvector$ & $\LBitvector$ & $\LString$ & $\concatstringop{\bitsname}{\bitsname}$\\
+$\Tplusplus$ & $\LBitvector$ & $\LBool$      & $\LString$ & $\concatstringop{\bitsname}{\boolname}$\\
+$\Tplusplus$ & $\LBitvector$ & $\LInt$       & $\LString$ & $\concatstringop{\bitsname}{\intname}$\\
+$\Tplusplus$ & $\LBitvector$ & $\LLabel$     & $\LString$ & $\concatstringop{\bitsname}{\labelname}$\\
+$\Tplusplus$ & $\LBitvector$ & $\LReal$      & $\LString$ & $\concatstringop{\bitsname}{\realname}$\\
+$\Tplusplus$ & $\LBitvector$ & $\LString$    & $\LString$ & $\concatstringop{\bitsname}{\stringname}$\\
+$\Tplusplus$ & $\LBool$      & $\LBitvector$ & $\LString$ & $\concatstringop{\boolname}{\bitsname}$\\
+$\Tplusplus$ & $\LBool$      & $\LBool$      & $\LString$ & $\concatstringop{\boolname}{\boolname}$\\
+$\Tplusplus$ & $\LBool$      & $\LInt$       & $\LString$ & $\concatstringop{\boolname}{\intname}$\\
+$\Tplusplus$ & $\LBool$      & $\LLabel$     & $\LString$ & $\concatstringop{\boolname}{\labelname}$\\
+$\Tplusplus$ & $\LBool$      & $\LReal$      & $\LString$ & $\concatstringop{\boolname}{\realname}$\\
+$\Tplusplus$ & $\LBool$      & $\LString$    & $\LString$ & $\concatstringop{\boolname}{\stringname}$\\
+$\Tplusplus$ & $\LInt$       & $\LBitvector$ & $\LString$ & $\concatstringop{\intname}{\bitsname}$\\
+$\Tplusplus$ & $\LInt$       & $\LBool$      & $\LString$ & $\concatstringop{\intname}{\boolname}$\\
+$\Tplusplus$ & $\LInt$       & $\LInt$       & $\LString$ & $\concatstringop{\intname}{\intname}$\\
+$\Tplusplus$ & $\LInt$       & $\LLabel$     & $\LString$ & $\concatstringop{\intname}{\labelname}$\\
+$\Tplusplus$ & $\LInt$       & $\LReal$      & $\LString$ & $\concatstringop{\intname}{\realname}$\\
+$\Tplusplus$ & $\LInt$       & $\LString$    & $\LString$ & $\concatstringop{\intname}{\stringname}$\\
+$\Tplusplus$ & $\LLabel$     & $\LBitvector$ & $\LString$ & $\concatstringop{\labelname}{\bitsname}$\\
+$\Tplusplus$ & $\LLabel$     & $\LBool$      & $\LString$ & $\concatstringop{\labelname}{\boolname}$\\
+$\Tplusplus$ & $\LLabel$     & $\LInt$       & $\LString$ & $\concatstringop{\labelname}{\intname}$\\
+$\Tplusplus$ & $\LLabel$     & $\LLabel$     & $\LString$ & $\concatstringop{\labelname}{\labelname}$\\
+$\Tplusplus$ & $\LLabel$     & $\LReal$      & $\LString$ & $\concatstringop{\labelname}{\realname}$\\
+$\Tplusplus$ & $\LLabel$     & $\LString$    & $\LString$ & $\concatstringop{\labelname}{\stringname}$\\
+$\Tplusplus$ & $\LReal$      & $\LBitvector$ & $\LString$ & $\concatstringop{\realname}{\bitsname}$\\
+$\Tplusplus$ & $\LReal$      & $\LBool$      & $\LString$ & $\concatstringop{\realname}{\boolname}$\\
+$\Tplusplus$ & $\LReal$      & $\LInt$       & $\LString$ & $\concatstringop{\realname}{\intname}$\\
+$\Tplusplus$ & $\LReal$      & $\LLabel$     & $\LString$ & $\concatstringop{\realname}{\labelname}$\\
+$\Tplusplus$ & $\LReal$      & $\LReal$      & $\LString$ & $\concatstringop{\realname}{\realname}$\\
+$\Tplusplus$ & $\LReal$      & $\LString$    & $\LString$ & $\concatstringop{\realname}{\stringname}$\\
+$\Tplusplus$ & $\LString$    & $\LBitvector$ & $\LString$ & $\concatstringop{\stringname}{\bitsname}$\\
+$\Tplusplus$ & $\LString$    & $\LBool$      & $\LString$ & $\concatstringop{\stringname}{\boolname}$\\
+$\Tplusplus$ & $\LString$    & $\LInt$       & $\LString$ & $\concatstringop{\stringname}{\intname}$\\
+$\Tplusplus$ & $\LString$    & $\LLabel$     & $\LString$ & $\concatstringop{\stringname}{\labelname}$\\
+$\Tplusplus$ & $\LString$    & $\LReal$      & $\LString$ & $\concatstringop{\stringname}{\realname}$\\
+$\Tplusplus$ & $\LString$    & $\LString$    & $\LString$ & $\concatstringop{\stringname}{\stringname}$\\
 \hline
 \end{tabular}
 \end{table}

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -5998,7 +5998,6 @@ typing function binop_literals(op: binop, v1: literal, v2: literal) ->
 
     case concat {
       op = STR_CONCAT;
-      binary_or(ast_label(v1) != label_L_Bitvector, ast_label(v2) != label_L_Bitvector);
       literal_to_string(v1) -> s1;
       literal_to_string(v2) -> s2;
       --
@@ -6598,7 +6597,6 @@ typing relation apply_binop_types(tenv: static_envs, op: binop, t1: ty, t2: ty) 
 
   case string_concat {
     op = STR_CONCAT;
-    binary_or(ast_label(t1) != label_T_Bits, ast_label(t2) != label_T_Bits);
     is_singular(tenv, t1) -> t1_singular;
     is_singular(tenv, t2) -> t2_singular;
     te_check(t1_singular, TE_UT) -> True;

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BinopLiterals.strings_labels.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BinopLiterals.strings_labels.asl
@@ -11,5 +11,6 @@ begin
     println "ne_enum: RED != GREEN = ", RED != GREEN;
     println "concat_string: 0 ++ '1' ++ 2.0 ++ TRUE ++ \"foo\" ++ RED = ",
             0 ++ '1' ++ 2.0 ++ TRUE ++ "foo" ++ RED;
+    println "concat_string: '10' ++ '1' = ", '10' ++ '1';
     return 0;
 end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -367,6 +367,7 @@ ASL Typing Tests / annotating types:
   ne_enum: RED != RED = FALSE
   ne_enum: RED != GREEN = TRUE
   concat_string: 0 ++ '1' ++ 2.0 ++ TRUE ++ "foo" ++ RED = 00x12TRUEfooRED
+  concat_string: '10' ++ '1' = 0x20x1
 
   $ aslref TypingRule.EVar.asl
   $ aslref TypingRule.EVar.undefined.asl


### PR DESCRIPTION
Updates the ASL reference for string concatenation to include all `STR_CONCAT` operand combinations, including bits ++ bits:
* Added missing string-concatenation signatures to "Table 11.5: String Operation Signatures" in`PrimitiveOperations.tex`. Thanks Laurent Desnogues for flagging this issue.
* Removed conditions in `asl.spec` that excluded `STR_CONCAT` over two bitvectors.
* Added testing for '10' ++ '1'.