### PR TITLE
[herd] Expose herd as a dune library

### DIFF
--- a/herd/cli.ml
+++ b/herd/cli.ml
@@ -14,6 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
+open Herd_core
 module TR = Top_herd.TestResult
 
 let iter_count (i : ('a -> unit) -> 'b) : ('a -> unit) -> int * 'b =

--- a/herd/dune
+++ b/herd/dune
@@ -22,10 +22,12 @@
 
 (ocamllex lexConf_herd)
 
-(executable
- (name herd)
- (public_name herd7)
+(library
+ (name herd_core)
  (libraries unix herdtools)
+ (wrapped true)
+ (modules
+  (:standard \ herd cli itimer))
  (modules_without_implementation
   AArch64Sig
   action
@@ -34,3 +36,10 @@
   sem
   XXXMem
   port))
+
+(executable
+ (name herd)
+ (public_name herd7)
+ (package herdtools7)
+ (modules herd cli itimer)
+ (libraries unix herdtools herd_core))

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -16,6 +16,7 @@
 
 (** Entry point to Herd  *)
 
+open Herd_core
 open Printf
 open Archs
 open Opts

--- a/herd/rc11.ml
+++ b/herd/rc11.ml
@@ -77,7 +77,7 @@ module Make (O:Cfg)(S:Sem.Semantics)
       let proc_ws ws0 res =
         let ws = ER.transitive_closure ws0 in
         let unv = ER.cartesian conc.S.str.E.events conc.S.str.E.events in
-        let rf = pr.rf in
+        let rf = pr.S.rf in
         let mo = ws in
         let sb = conc.S.po in
         let rb = U.make_fr conc ws in
@@ -87,7 +87,7 @@ module Make (O:Cfg)(S:Sem.Semantics)
         let rmw = conc.S.atomic_load_store in
 
         let aux = fun x ->
-          try List.assoc x S.E.Act.arch_sets with Not_found -> fun x -> true in
+          try List.assoc x S.E.Act.arch_sets with Not_found -> fun _ -> true in
 
         let rlx = aux "RLX" in
         let acq = aux "ACQ" in
@@ -103,9 +103,9 @@ module Make (O:Cfg)(S:Sem.Semantics)
 
         let rs0 = ER.sequence rf rmw in
         let rs1 = ER.transitive_closure rs0 in
-        let rs2 = ER.restrict_domain (fun x -> E.is_mem_store x && (rlx x.action|| na x.action)) rs1 in
+        let rs2 = ER.restrict_domain (fun x -> E.is_mem_store x && (rlx x.E.action|| na x.E.action)) rs1 in
         let rs3 = ER.inter sb loc in
-        let rs4 = ER.restrict_domains E.is_mem_store (fun x -> E.is_mem_store x && (rlx x.action|| na x.action)) rs3 in
+        let rs4 = ER.restrict_domains E.is_mem_store (fun x -> E.is_mem_store x && (rlx x.E.action|| na x.E.action)) rs3 in
         let rs5 = ER.sequence rs4 rs2 in
         let rs = ER.union rs2 rs5 in
 
@@ -113,11 +113,11 @@ module Make (O:Cfg)(S:Sem.Semantics)
         let sw1 = ER.restrict_domain f sb in
         let sw2 = ER.sequence sw1 sw0 in
         let sw3 = ER.union sw0 sw2 in
-        let sw4 = ER.restrict_domains (fun x -> rel x.action || acq_rel x.action || sc x.action) (fun x -> E.is_mem_store x && (rlx x.action || na x.action)) sw3 in
+        let sw4 = ER.restrict_domains (fun x -> rel x.E.action || acq_rel x.E.action || sc x.E.action) (fun x -> E.is_mem_store x && (rlx x.E.action || na x.E.action)) sw3 in
         let sw5 = ER.restrict_codomain f sb in
         let sw6 = ER.sequence sw4 sw5 in
         let sw7 = ER.union sw4 sw6 in
-        let sw = ER.restrict_codomain (fun x -> acq x.action || acq_rel x.action || sc x.action) sw7 in
+        let sw = ER.restrict_codomain (fun x -> acq x.E.action || acq_rel x.E.action || sc x.E.action) sw7 in
 
         let hb0 = ER.union sb sw in
         let hb = ER.transitive_closure hb0 in
@@ -126,21 +126,21 @@ module Make (O:Cfg)(S:Sem.Semantics)
 
         let scb = ER.unions [sb; ER.sequences [sbl; hb; sbl]; ER.inter sb loc; mo; rb] in
 
-        let pscb0 = ER.restrict_domain (fun x -> sc x.action) scb in
-        let pscb1 = ER.restrict_domain (fun x -> f x && sc x.action) unv in
+        let pscb0 = ER.restrict_domain (fun x -> sc x.E.action) scb in
+        let pscb1 = ER.restrict_domain (fun x -> f x && sc x.E.action) unv in
         let pscb2 = ER.inter pscb1 hb in
         let pscb3 = ER.sequence pscb2 scb in
         let pscb4 = ER.inter pscb1 scb in
         let pscb5 = ER.union3 pscb0 pscb3 pscb4 in
 
-        let pscb6 = ER.restrict_codomain (fun x -> sc x.action) pscb5 in
+        let pscb6 = ER.restrict_codomain (fun x -> sc x.E.action) pscb5 in
         let pscb7 = ER.sequence pscb5 hb in
         let pscb8 = ER.union pscb5 pscb7 in
-        let pscb9 = ER.restrict_codomain (fun x -> f x && sc x.action) pscb8 in
+        let pscb9 = ER.restrict_codomain (fun x -> f x && sc x.E.action) pscb8 in
         let pscb = ER.union pscb6 pscb9 in
 
         let pscf0 = ER.union hb (ER.sequences [hb; eco; hb]) in
-        let fsc = fun x -> f x && sc x.action in
+        let fsc = fun x -> f x && sc x.E.action in
         let pscf = ER.restrict_domains fsc fsc pscf0 in
 
         let psc = ER.union pscb pscf in
@@ -165,7 +165,7 @@ module Make (O:Cfg)(S:Sem.Semantics)
 
         let dr0 = ER.inter cnf ext in
         let dr1 = ER.diff dr0 (ER.union hb (ER.inverse hb)) in
-        let dr = ER.restrict_rel (fun x y -> not (a x.action) && not (a y.action)) dr1 in
+        let dr = ER.restrict_rel (fun x y -> not (a x.E.action) && not (a y.E.action)) dr1 in
 
         let pp_relns =
           lazy begin


### PR DESCRIPTION
This PR implements step 4 of the plan documented in issue #1782: it makes herd available as a dune library, `herd_core`, so that other OCaml tools in the repository can depend on its internals directly.

Note that the broader plan to make herd's core code properly library-like and client-agnostic is still work in progress. In other words, this PR does not claim to provide a polished or stable API, nor does it address all remaining issues and TODOs described in the aforementioned issue #1782.

That said, the API that herd _does_ currently offer (mainly through its modules `ParseTest` and `Top_herd`) is already useful enough for other internal tools to take advantage of it. See, for example, my upcoming tool litmus2desc (#1903), which runs herd directly in OCaml via the `herd_core` library added here.

Since the proposed `herd_core` library is intended for internal use only (at least of now), I think it is reasonable to expose it now as an incremental step, while continuing the remaining refactoring work tracked in #1782.

Let me know your thoughts.

PS: This PR also updates `herd/rc11.ml` to use explicit namespacing for record field accessors. Adding the module to the wrapped `herd_core` library made the compiler report warnings 40 and 42 for various record accesses. The PR only adds explicit module names to those field accesses, it does not change any of the logic. As an aside, `rc11.ml` does not currently appear to be used anywhere in herd.