### PR TITLE
[herd][preview] Fix preview multiple files

### DIFF
--- a/herd/cli.ml
+++ b/herd/cli.ml
@@ -70,7 +70,7 @@ end) = struct
     | Some (chan,fname) ->
        match O.outputdir with
        | PrettyConf.NoOutputdir | PrettyConf.Outputdir _ ->
-          if O.PC.debug then Printf.eprintf "close %s\n" fname ;
+          if O.PC.debug then Printf.eprintf "close %s\n%!" fname ;
           close_out chan
        | PrettyConf.StdoutOutput ->
           Printf.fprintf stdout "\nDOTEND %s\n" fname
@@ -131,7 +131,7 @@ end) = struct
       begin match ochan with
       | Some (_,fname) when shown > 0 ->
           let module SH = Show.Make(S.O.PC) in
-          if O.PC.debug then Printf.eprintf "show %s file\n" fname ;
+          if O.PC.debug then Printf.eprintf "show %s file\n%!" fname ;
           SH.show_file fname
       | Some _|None -> ()
       end ;

--- a/herd/show.ml
+++ b/herd/show.ml
@@ -62,7 +62,10 @@ module Make(O:PrettyConf.S) = struct
     let r = Sys.command (suppress_stderr cmd) in
     if O.debug then eprintf "Command: [%s] -> %i\n%!" cmd r
 
-  let run_cmds cmds = String.concat " && " cmds |> run_cmd
+  let run_cmds cmds =
+    (* In debug mode, break lines so that command is easier to read *)
+    let and_ = if O.debug then " \\\n  && " else " && " in
+    String.concat and_ cmds |> run_cmd
 
   let do_show_file ?(keep_tmp_pdf = O.debug) name_dot prog ext : unit =
     let name_ps = extfile name_dot ext in
@@ -77,11 +80,21 @@ module Make(O:PrettyConf.S) = struct
     {|/System/Library/Automator/Combine\ PDF\ Pages.action/Contents/MacOS/join|}
 
   let do_show_file_preview name_dot =
+    let dirname, name_dot = Filename.(dirname name_dot, basename name_dot) in
     run_cmds
       [
+        (* cd in temp dir, just so that command is easier to read in debug mode *)
+        sprintf "cd %s" dirname;
+        (* Generate the pdfs *)
         sprintf "%s -Tpdf %s -O" generator name_dot;
-        sprintf "%s -o %s.all.pdf %s*.pdf" macos_join_pdf name_dot name_dot;
-        sprintf "open -a Preview %s.all.pdf" name_dot;
+        (* Merge the pdfs into one big pdf *)
+        sprintf "%s -o %s.all %s*.pdf" macos_join_pdf name_dot name_dot;
+        (* Remove the individual pdfs *)
+        sprintf "rm %s*.pdf" name_dot;
+        (* Move the big pdf into a .pdf file *)
+        sprintf "mv %s.all %s.pdf" name_dot name_dot;
+        (* Open the big pdf *)
+        sprintf "open -a Preview %s.pdf" name_dot;
       ]
 
   let show_file_with_view view name_dot : unit =

--- a/herd/show.ml
+++ b/herd/show.ml
@@ -55,18 +55,21 @@ module Make(O:PrettyConf.S) = struct
       my_remove name;
       Handler.pop ())
 
+  let suppress_stderr cmd =
+    if O.debug then cmd else sprintf "(%s) 2>/dev/null" cmd
+
   let run_cmd fmt =
     ksprintf
       (fun cmd ->
-         let r = Sys.command cmd in
+         let r = Sys.command (suppress_stderr cmd) in
          if O.debug then eprintf "Command: [%s] -> %i\n%!" cmd r)
       fmt
 
   let do_show_file ?(keep_tmp_pdf = O.debug) name_dot prog ext : unit =
     let name_ps = extfile name_dot ext in
     with_temp_file ~keep:keep_tmp_pdf name_ps @@ fun () ->
-    run_cmd "%s -T%s %s -o %s 2>/dev/null ; %s %s 2>/dev/null" generator ext
-      name_dot name_ps prog name_ps
+    run_cmd "%s -T%s %s -o %s && %s %s" generator ext name_dot name_ps prog
+      name_ps
 
   let show_file_with_view view name_dot : unit =
     let open View in
@@ -74,9 +77,8 @@ module Make(O:PrettyConf.S) = struct
     | GV -> do_show_file name_dot "gv" "ps"
     | Evince -> do_show_file name_dot "evince" "pdf"
     | Preview ->
-      run_cmd
-        "%s -Tpdf %s -O %s 2>/dev/null; open -a Preview %s.*pdf %s 2>/dev/null"
-        generator name_dot suppress_output name_dot suppress_output
+      run_cmd "%s -Tpdf %s -O && open -a Preview %s.*pdf" generator name_dot
+        name_dot
 
   let show_file name_dot =
     match O.view with None -> () | Some v -> show_file_with_view v name_dot

--- a/herd/show.ml
+++ b/herd/show.ml
@@ -55,15 +55,18 @@ module Make(O:PrettyConf.S) = struct
       my_remove name;
       Handler.pop ())
 
+  let run_cmd fmt =
+    ksprintf
+      (fun cmd ->
+         let r = Sys.command cmd in
+         if O.debug then eprintf "Command: [%s] -> %i\n%!" cmd r)
+      fmt
+
   let do_show_file ?(keep_tmp_pdf = O.debug) name_dot prog ext : unit =
     let name_ps = extfile name_dot ext in
     with_temp_file ~keep:keep_tmp_pdf name_ps @@ fun () ->
-    let cmd =
-      sprintf "%s -T%s %s > %s 2>/dev/null ; %s %s 2>/dev/null" generator ext
-        name_dot name_ps prog name_ps
-    in
-    let r = Sys.command cmd in
-    if O.debug then eprintf "Command: [%s] -> %i\n" cmd r
+    run_cmd "%s -T%s %s -o %s 2>/dev/null ; %s %s 2>/dev/null" generator ext
+      name_dot name_ps prog name_ps
 
   let show_file_with_view view name_dot : unit =
     let open View in
@@ -71,7 +74,9 @@ module Make(O:PrettyConf.S) = struct
     | GV -> do_show_file name_dot "gv" "ps"
     | Evince -> do_show_file name_dot "evince" "pdf"
     | Preview ->
-        do_show_file ~keep_tmp_pdf:true name_dot "open -a Preview" "pdf"
+      run_cmd
+        "%s -Tpdf %s -O %s 2>/dev/null; open -a Preview %s.*pdf %s 2>/dev/null"
+        generator name_dot suppress_output name_dot suppress_output
 
   let show_file name_dot =
     match O.view with None -> () | Some v -> show_file_with_view v name_dot

--- a/herd/show.ml
+++ b/herd/show.ml
@@ -58,27 +58,38 @@ module Make(O:PrettyConf.S) = struct
   let suppress_stderr cmd =
     if O.debug then cmd else sprintf "(%s) 2>/dev/null" cmd
 
-  let run_cmd fmt =
-    ksprintf
-      (fun cmd ->
-         let r = Sys.command (suppress_stderr cmd) in
-         if O.debug then eprintf "Command: [%s] -> %i\n%!" cmd r)
-      fmt
+  let run_cmd cmd =
+    let r = Sys.command (suppress_stderr cmd) in
+    if O.debug then eprintf "Command: [%s] -> %i\n%!" cmd r
+
+  let run_cmds cmds = String.concat " && " cmds |> run_cmd
 
   let do_show_file ?(keep_tmp_pdf = O.debug) name_dot prog ext : unit =
     let name_ps = extfile name_dot ext in
     with_temp_file ~keep:keep_tmp_pdf name_ps @@ fun () ->
-    run_cmd "%s -T%s %s -o %s && %s %s" generator ext name_dot name_ps prog
-      name_ps
+    run_cmds
+      [
+        sprintf "%s -T%s %s -o %s" generator ext name_dot name_ps;
+        sprintf "%s %s" prog name_ps;
+      ]
+
+  let macos_join_pdf =
+    {|/System/Library/Automator/Combine\ PDF\ Pages.action/Contents/MacOS/join|}
+
+  let do_show_file_preview name_dot =
+    run_cmds
+      [
+        sprintf "%s -Tpdf %s -O" generator name_dot;
+        sprintf "%s -o %s.all.pdf %s*.pdf" macos_join_pdf name_dot name_dot;
+        sprintf "open -a Preview %s.all.pdf" name_dot;
+      ]
 
   let show_file_with_view view name_dot : unit =
     let open View in
     match view with
     | GV -> do_show_file name_dot "gv" "ps"
     | Evince -> do_show_file name_dot "evince" "pdf"
-    | Preview ->
-      run_cmd "%s -Tpdf %s -O && open -a Preview %s.*pdf" generator name_dot
-        name_dot
+    | Preview -> do_show_file_preview name_dot
 
   let show_file name_dot =
     match O.view with None -> () | Some v -> show_file_with_view v name_dot


### PR DESCRIPTION
Also:
- do not try to open the pdf viewer if the pdf generator failed
- do not suppress error output from sub-commands when in `-debug pretty`

After implementing the changes suggested in review:
- merge the generated files into a single PDF using a MacOS builtin app
- remove temporary generated pdf file, so that only the pdf file opened by preview is kept