### PR TITLE
[herd,cat] Fix some problems with the C architecture

### DIFF
--- a/herd/CAction.ml
+++ b/herd/CAction.ml
@@ -321,9 +321,11 @@ end = struct
   | _ -> false
 
 (* Architecture-specific sets *)
+  let is_rmw_or_atomic e = is_rmw e || is_atomic e
 
   let arch_sets = [
-    "RMW",(fun e -> is_rmw e || is_atomic e);
+(* Both names below are needed for stdlib.cat and LKMM model respectively *)
+    "X",is_rmw_or_atomic; "RMW",is_rmw_or_atomic;
     "LK", is_lock; "LKR", is_lock_read; "LKW",is_lock_write;
     "LS", is_successful_lock;"LF", is_failed_lock;
     "UL", is_unlock;

--- a/herd/tests/instructions/C/C14.litmus
+++ b/herd/tests/instructions/C/C14.litmus
@@ -1,0 +1,12 @@
+C C14
+{}
+
+P0 (atomic_int* y) {
+  atomic_fetch_add_explicit(y,1,memory_order_relaxed);
+}
+
+P1 (atomic_int* y) {
+  atomic_fetch_add_explicit(y,1,memory_order_relaxed);
+}
+
+forall y=2

--- a/herd/tests/instructions/C/C14.litmus.expected
+++ b/herd/tests/instructions/C/C14.litmus.expected
@@ -1,0 +1,10 @@
+Test C14 Required
+States 1
+[y]=0x2;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition forall ([y]=0x2)
+Observation C14 Always 2 0
+Hash=4ba3dd96c70ac3dd5dac4c7337261858
+

--- a/herd/tests/instructions/C/C15.litmus
+++ b/herd/tests/instructions/C/C15.litmus
@@ -1,0 +1,12 @@
+C C15
+{}
+
+P0 (atomic_int* y) {
+  atomic_store_explicit(y,1,memory_order_relaxed);
+}
+
+P1 (atomic_int* y) {
+  int r1 = atomic_exchange_explicit(y,2,memory_order_relaxed);
+}
+
+~exists 1:r1=0 /\ y=2

--- a/herd/tests/instructions/C/C15.litmus.expected
+++ b/herd/tests/instructions/C/C15.litmus.expected
@@ -1,0 +1,11 @@
+Test C15 Forbidden
+States 2
+1:r1=0x0; [y]=0x1;
+1:r1=0x1; [y]=0x2;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition ~exists (1:r1=0x0 /\ [y]=0x2)
+Observation C15 Never 0 2
+Hash=39a09669dfbf2aaf26417bf1bd2480c6
+

--- a/herd/tests/instructions/C/C16.litmus
+++ b/herd/tests/instructions/C/C16.litmus
@@ -1,0 +1,12 @@
+C C16
+{}
+
+P0 (atomic_int* y) {
+  atomic_store_explicit(y,1,memory_order_relaxed);
+}
+
+P1 (atomic_int* y,int *z) {
+  atomic_compare_exchange_strong(y,z,2);
+}
+
+~exists z=0 /\ y=2

--- a/herd/tests/instructions/C/C16.litmus.expected
+++ b/herd/tests/instructions/C/C16.litmus.expected
@@ -1,0 +1,11 @@
+Test C16 Forbidden
+States 2
+[y]=0x1; [z]=0x0;
+[y]=0x1; [z]=0x1;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition ~exists ([z]=0x0 /\ [y]=0x2)
+Observation C16 Never 0 2
+Hash=ab2f8e6026f219ae47eec68e6e2ba7a5
+

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -690,14 +690,26 @@ module Make
         if fail then error env.EV.silent loc "unbound var: %s" k
         else raise Not_found
 
-    let as_rel ks = function
+    let do_as_rel error ks = function
       | Rel r -> r
       | TransRel tr -> E.EventRel.transitive_closure tr
       | Empty -> E.EventRel.empty
       | Unv -> Lazy.force ks.unv
-      | v ->
-          eprintf "this is not a relation: '%s'" (pp_val v) ;
-          assert false
+      | v -> error v
+
+    and do_as_set error ks = function
+      | Set s -> s
+      | Empty -> E.EventSet.empty
+      | Unv -> ks.evts
+      | v -> error v
+
+
+    let error_as what v =
+      eprintf "this is not a %s: '%s'" what (pp_val v) ;
+      assert false
+
+    let as_rel = do_as_rel (error_as "relation")
+    and as_set = do_as_set (error_as "set of events")
 
     let as_notrans ks = function
       | Rel r -> r
@@ -708,19 +720,13 @@ module Make
           eprintf "this is not a relation: '%s'" (pp_val v) ;
           assert false
 
-    let as_classrel = function
+    let do_as_classrel error = function
       | ClassRel r -> r
       | Empty -> ClassRel.empty
       | Unv -> Warn.fatal "No universal class relation"
-      | v ->
-          eprintf "this is not a relation: '%s'" (pp_val v) ;
-          assert false
+      | v -> error v
 
-    let as_set ks = function
-      | Set s -> s
-      | Empty -> E.EventSet.empty
-      | Unv -> ks.evts
-      | _ -> assert false
+    let as_classrel = do_as_classrel (error_as "relation over classes")
 
     let as_valset = function
       | ValSet (_,v) -> v
@@ -923,25 +929,28 @@ module Make
    let typ = TClassRel
    end
  *)
-    let arg_mismatch () = raise (PrimError "argument mismatch")
+    let arg_mismatch _ = raise (PrimError "argument mismatch")
+    let prim_as_rel = do_as_rel arg_mismatch
+    and prim_as_set = do_as_set arg_mismatch
+    and prim_as_classrel = do_as_classrel arg_mismatch
 
-    let partition arg = match arg with
-    | Set evts ->
-        let r = U.partition_events evts in
-        let vs = List.map (fun es -> Set es) r in
-        ValSet (TEvents,ValSet.of_list vs)
-    | _ -> arg_mismatch ()
+    let partition ks arg =
+      let evts = prim_as_set ks arg in
+      let r = U.partition_events evts in
+      let vs = List.map (fun es -> Set es) r in
+      ValSet (TEvents,ValSet.of_list vs)
 
-    and classes arg =  match arg with
-    | Rel r ->
-        let r = E.EventRel.classes r in
-        let vs = List.map (fun es -> Set es) r in
-        ValSet (TEvents,ValSet.of_list vs)
-    | _ -> arg_mismatch ()
+    and classes ks arg =
+      let cls =
+        prim_as_rel ks arg
+        |> E.EventRel.classes
+        |> List.map (fun es -> Set es) in
+      ValSet (TEvents,ValSet.of_list cls)
 
 (* Lift a relation from events to event classes *)
-    and lift arg = match arg with
-    | V.Tuple [ValSet (TEvents,cls);Rel r] ->
+    and lift ks arg = match arg with
+    | V.Tuple [ValSet (TEvents,cls); vr; ] ->
+        let r = prim_as_rel ks vr in
         let m =
           ValSet.fold
             (fun v m ->  match v with
@@ -964,18 +973,19 @@ module Make
     | _ -> arg_mismatch ()
 
 (* Delift a relation from event classes to events *)
-    and delift arg = match arg with
-    | ClassRel clsr ->
-        let r =
-          ClassRel.fold
-            (fun (cl1,cl2) k -> E.EventRel.cartesian cl1 cl2::k)
-            clsr [] in
-        Rel (E.EventRel.unions r)
-    | _ -> arg_mismatch ()
+    and delift arg =
+    let clsr = prim_as_classrel arg in
+    let r =
+      ClassRel.fold
+        (fun (cl1,cl2) k -> E.EventRel.cartesian cl1 cl2::k)
+        clsr [] in
+    Rel (E.EventRel.unions r)
 
 (* Restrict delift by intersection (fulldeflift(clsr) & loc) *)
-    and deliftinter arg = match arg with
-    | V.Tuple[Rel m;ClassRel clsr] ->
+    and deliftinter ks arg = match arg with
+    | V.Tuple[vm; vclsr; ] ->
+        let clsr = prim_as_classrel vclsr
+        and m = prim_as_rel ks vm in
         let make_rel_from_classpair (cl1,cl2) =
           E.EventRel.restrict_domains_to_sets cl1 cl2 m in
         let r =
@@ -1020,24 +1030,42 @@ module Make
                 ValSet.empty in
             ValSet (In.typ,rs)
         end in
+
+      let on_classrel ks es r =
+        let module L = Make(ClassArg) in
+        let es =
+          let sets = ValSet.fold (fun v k -> as_set ks v::k) es [] in
+          ClassRel.Elts.of_list sets in
+        L.zyva es r
+
+      and on_rel es r =
+        let module L = Make(EventArg) in
+        L.zyva es r in
+
       fun ks arg -> match arg with
-      | V.Tuple [Set es;Rel r;] ->
-          let module L = Make(EventArg) in
-          L.zyva es r
-      | V.Tuple [ValSet (TEvents,es);ClassRel r;] ->
-          let module L = Make(ClassArg) in
-          let es =
-            let sets = ValSet.fold (fun v k -> as_set ks v::k) es [] in
-            ClassRel.Elts.of_list sets in
-          L.zyva es r
+      | V.Tuple [ValSet (TEvents,es); vr; ] ->
+          let r = prim_as_classrel vr in
+          on_classrel ks es r
+      | V.Tuple [V.Empty; ClassRel r; ] ->
+          on_classrel ks ValSet.empty r
+      | V.Tuple [ves;vr;] ->
+          let es = prim_as_set ks ves
+          and r = prim_as_rel ks vr in
+          on_rel es r
       | _ -> arg_mismatch ()
 
-    and bisimulation =
-      fun arg -> match arg with
-      | V.Tuple [Rel t; Rel e; ] ->
-          Rel (E.EventRel.bisimulation t e)
+    and bisimulation ks arg =
+      match arg with
+      | V.Tuple [V.Empty; ClassRel e] ->
+         ClassRel (ClassRel.bisimulation ClassRel.empty e)
+      | V.Tuple [ClassRel t;V.Empty] ->
+         ClassRel (ClassRel.bisimulation t ClassRel.empty)
       | V.Tuple [ClassRel t; ClassRel e; ] ->
           ClassRel (ClassRel.bisimulation t e)
+      | V.Tuple [vt; ve; ] ->
+          let t = prim_as_rel ks vt
+          and e = prim_as_rel ks ve in
+          Rel (E.EventRel.bisimulation t e)
       | _ -> arg_mismatch ()
 
     and tag2scope env arg = match arg with
@@ -1045,7 +1073,7 @@ module Make
         begin try
           let v = Lazy.force (StringMap.find tag env.vals) in
           match v with
-          | V.Empty|V.Unv|V.Rel _ ->  v
+          | V.Empty|V.Unv|V.Rel _|V.TransRel _ ->  v
           | _ ->
               raise
                 (PrimError
@@ -1079,11 +1107,11 @@ module Make
         end
     | _ -> arg_mismatch ()
 
-    and fromto ks arg = match arg with
-    | V.Set es -> V.Rel (U.fromto ks.po es)
-    | _ -> arg_mismatch ()
+    and fromto ks arg =
+      let es = prim_as_set ks arg in
+      V.Rel (U.fromto ks.po es)
 
-    and tag2fenced env arg = match arg with
+    and tag2fenced ks env arg = match arg with
     | V.Tag (_,tag) ->
         let not_a_set_of_events x v =
           raise
@@ -1091,9 +1119,8 @@ module Make
                (sprintf
                   "value %s is not a set of events, found %s"
                   x  (pp_type_val v))) in
-        let find_rel id = match Lazy.force (StringMap.find id env.vals) with
-        | V.Rel rel -> rel
-        | _ -> assert false
+        let find_rel id =
+          Lazy.force (StringMap.find id env.vals) |> prim_as_rel ks
         in
         let po = find_rel "po" in
         let fromto = find_rel "fromto" in
@@ -1143,46 +1170,29 @@ module Make
       let msg = sprintf "fail on %s" pp in
       raise (PrimError msg)
 
-    and different_values arg =
+    and different_values ks arg =
       let different_val e1 e2 = not (U.same_value e1 e2) in
-      match arg with
-      | V.Rel r ->
-          let r = E.EventRel.restrict_rel different_val r in
-          V.Rel r
-      | V.TransRel tr ->
-          let r = E.EventRel.transitive_closure tr in
-          let r = E.EventRel.restrict_rel different_val r in
-          V.Rel r
-      | _ -> arg_mismatch ()
+      let r = prim_as_rel ks arg in
+      V.Rel (E.EventRel.restrict_rel different_val r)
 
-    and same_oaRel arg =
-      match arg with
-      | V.Rel r ->
-          V.Rel (E.EventRel.restrict_rel U.same_oa r)
-      | V.TransRel tr ->
-          V.Rel
-            E.EventRel.
-              (restrict_rel U.same_oa @@ transitive_closure tr)
-      | _ -> arg_mismatch ()
+    and same_oaRel ks arg =
+      let r = prim_as_rel ks arg in
+      V.Rel (E.EventRel.restrict_rel U.same_oa r)
 
-    and check_two pred arg = match arg with
-      | V.Tuple [V.Set ws; (V.Rel _ | V.TransRel _) as prec; ] ->
-          let m =
-            match prec with
-            | V.Rel m -> m
-            | V.TransRel m -> E.EventRel.transitive_closure m
-            | _ -> assert false
-          in
+    and check_two pred ks arg = match arg with
+      | V.Tuple [vset; vrel; ] ->
+          let ws = prim_as_set ks vset
+          and m = prim_as_rel ks vrel in
           let ws =
             E.EventSet.filter
               (fun w ->
-                E.is_store w && E.is_pt w &&
-                begin
-                  match E.EventSet.as_singleton (E.EventRel.succs m w) with
-                  | Some p -> pred w p
- (* w does not qualify when zero of two or more prec-related events *)
-                  | None -> false
-                end)
+                 E.is_store w && E.is_pt w &&
+                 begin
+                   match E.EventSet.as_singleton (E.EventRel.succs m w) with
+                   | Some p -> pred w p
+  (* w does not qualify when zero of two or more prec-related events *)
+                   | None -> false
+                 end)
               ws in
           V.Set ws
       | _ -> arg_mismatch ()
@@ -1193,34 +1203,34 @@ module Make
     let as_transitive =
       function
       | V.Rel r -> V.TransRel r
-      | V.TransRel _ as v -> v
+      | V.TransRel _|V.Empty|V.Unv as v -> v
       | _ -> arg_mismatch ()
 
     let add_primitives ks m =
       add_prims m
         [
-          "at-least-one-writable",at_least_one_writable;
-          "oa-changes",oa_changes;
-          "same-oa",same_oaRel;
-          "different-values",different_values;
-         "fromto",fromto ks;
-         "classes-loc",partition;
-         "classes",classes;
-         "lift",lift;
-         "delift",delift;
-         "deliftinter",deliftinter;
-         "linearisations",linearisations ks;
-         "bisimulation",bisimulation;
-         "tag2scope",tag2scope m;
-         "tag2level",tag2scope m;
-         "tag2events",tag2events m;
-         "tag2fenced",tag2fenced m;
-         "loc2events",loc2events ks;
-         "domain",domain;
-         "range",range;
-         "fail",fail;
-         "as_transitive", as_transitive;
-       ]
+          "at-least-one-writable",at_least_one_writable ks;
+          "oa-changes",oa_changes ks;
+          "same-oa",same_oaRel ks;
+          "different-values",different_values ks;
+          "fromto",fromto ks;
+          "classes-loc",partition ks;
+          "classes",classes ks;
+          "lift",lift ks;
+          "delift",delift;
+          "deliftinter",deliftinter ks;
+          "linearisations",linearisations ks;
+          "bisimulation",bisimulation ks;
+          "tag2scope",tag2scope m;
+          "tag2level",tag2scope m;
+          "tag2events",tag2events m;
+          "tag2fenced",tag2fenced ks m;
+          "loc2events",loc2events ks;
+          "domain",domain;
+          "range",range;
+          "fail",fail;
+          "as_transitive", as_transitive;
+        ]
 
 
 (***************)


### PR DESCRIPTION
This PR fixes two problems:

1. Since PR #1855, the polymorphic value `V.Empty`  circulates more. Some primitives were performing set and relation  normalisation by themselves, overlooking the cases of empty and universe. We fix this by using the already present and complete normalisation functions `as_set` and `as_rel` slightly generalised to handle different error reporting.
2. PR #1889 changed how the relation  `rmw` is computed  by defining it in stdlb.cat. The Cat definition of the relation `rmw` assumes that atomic effects are gathered in the set `X`, which was not the case of the C semantics. As a result the `rmw` relation was empty when the read-modify-write instructions are implemented by two (atomic) effects.