### PR TITLE
[gen] Use explicit equality helpers for edge comparison

### DIFF
--- a/gen/CArch_gen.ml
+++ b/gen/CArch_gen.ml
@@ -245,6 +245,11 @@ let pp_rmw compat = function
   | Exch -> if compat then "Rmw" else "Exch"
   | Add -> "Fetch.Add"
 
+let equal_rmw rmw1 rmw2 = match rmw1,rmw2 with
+  | Exch,Exch
+  | Add,Add -> true
+  | (Exch|Add),_ -> false
+
 let is_one_instruction _ = true
 
 let fold_rmw _b f r = let r = f Add r in  f Exch r

--- a/gen/MIPSArch_gen.ml
+++ b/gen/MIPSArch_gen.ml
@@ -60,6 +60,12 @@ let var_fence f r = f default r
 
 type dp = ADDR | DATA | CTRL
 
+let equal_dp dp1 dp2 = match dp1,dp2 with
+  | ADDR,ADDR
+  | DATA,DATA
+  | CTRL,CTRL -> true
+  | (ADDR|DATA|CTRL),_ -> false
+
 let pp_dp = function
   | ADDR -> "Addr"
   | DATA -> "Data"

--- a/gen/X86Arch_gen.ml
+++ b/gen/X86Arch_gen.ml
@@ -96,6 +96,7 @@ let var_fence f r = f default r
 
 type dp
 
+let equal_dp _ _ = assert false
 let pp_dp _ = assert false
 
 let fold_dpr _f r =  r

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -222,6 +222,7 @@ module Make
 
       type dp
 
+      let equal_dp _ _ = assert false
       let pp_dp _ = assert false
 
       let fold_dpr _f r =  r

--- a/gen/cDep.ml
+++ b/gen/cDep.ml
@@ -18,6 +18,12 @@
 
 type dp = ADDR | DATA | CTRL
 
+let equal_dp dp1 dp2 = match dp1,dp2 with
+  | ADDR,ADDR
+  | DATA,DATA
+  | CTRL,CTRL -> true
+  | (ADDR|DATA|CTRL),_ -> false
+
 let fold_dpr f r =  f ADDR (f CTRL r)
 let fold_dpw f r =  f ADDR (f DATA (f CTRL r))
 

--- a/gen/cDep.mli
+++ b/gen/cDep.mli
@@ -17,6 +17,7 @@
 (* C dependencies *)
 type dp = ADDR | DATA | CTRL
 
+val equal_dp : dp -> dp -> bool
 val fold_dpr : (dp -> 'a -> 'a) -> 'a -> 'a
 val fold_dpw : (dp -> 'a -> 'a) -> 'a -> 'a
 

--- a/gen/classicDep.ml
+++ b/gen/classicDep.ml
@@ -18,6 +18,12 @@
 
 type dp = ADDR | DATA | CTRL
 
+let equal_dp dp1 dp2 = match dp1,dp2 with
+  | ADDR,ADDR
+  | DATA,DATA
+  | CTRL,CTRL -> true
+  | (ADDR|DATA|CTRL),_ -> false
+
 let fold_dpr f r =  f ADDR (f CTRL r)
 let fold_dpw f r =  f ADDR (f DATA (f CTRL r))
 

--- a/gen/classicDep.mli
+++ b/gen/classicDep.mli
@@ -17,6 +17,7 @@
 (* Classical dependencies *)
 type dp = ADDR | DATA | CTRL
 
+val equal_dp : dp -> dp -> bool
 val pp_dp : dp -> string
 
 val fold_dpr : (dp -> 'a -> 'a) -> 'a -> 'a

--- a/gen/common/AArch64Arch_gen.ml
+++ b/gen/common/AArch64Arch_gen.ml
@@ -949,6 +949,13 @@ type csel = OkCsel|NoCsel
 
 type dp = D.dp * csel
 
+let equal_csel c1 c2 = match c1,c2 with
+  | OkCsel,OkCsel
+  | NoCsel,NoCsel -> true
+  | (OkCsel|NoCsel),_ -> false
+
+let equal_dp (d1,c1) (d2,c2) = D.equal_dp d1 d2 && equal_csel c1 c2
+
 let fold_dpr f r =
   D.fold_dpr
     (fun d r -> f (d,NoCsel) (f (d,OkCsel) r))
@@ -1033,6 +1040,27 @@ let pp_rmw compat = function
   | StOp op -> sprintf "Amo.St%s" (pp_aop op)
   | AllAmo -> sprintf "Amo"
   | SafeAmo -> sprintf "Amo.Safe"
+
+let equal_aop op1 op2 = match op1,op2 with
+  | A_ADD,A_ADD
+  | A_EOR,A_EOR
+  | A_SET,A_SET
+  | A_CLR,A_CLR
+  | A_SMAX,A_SMAX
+  | A_SMIN,A_SMIN
+  | A_UMAX,A_UMAX
+  | A_UMIN,A_UMIN -> true
+  | (A_ADD|A_EOR|A_SET|A_CLR|A_SMAX|A_SMIN|A_UMAX|A_UMIN),_ -> false
+
+let equal_rmw rmw1 rmw2 = match rmw1,rmw2 with
+  | LrSc,LrSc
+  | Swp,Swp
+  | Cas,Cas
+  | AllAmo,AllAmo
+  | SafeAmo,SafeAmo -> true
+  | LdOp op1,LdOp op2
+  | StOp op1,StOp op2 -> equal_aop op1 op2
+  | (LrSc|LdOp _|StOp _|Swp|Cas|AllAmo|SafeAmo),_ -> false
 
 let is_one_instruction = function
   | LrSc -> false

--- a/gen/common/atom.mli
+++ b/gen/common/atom.mli
@@ -33,6 +33,7 @@ module type RMW = sig
   type atom
 
   val pp_rmw : bool (* backward compatibility *) -> rmw -> string
+  val equal_rmw : rmw -> rmw -> bool
   val is_one_instruction : rmw -> bool
   (* The first boolean indicates whether wildcard syntax is included in the fold *)
   val fold_rmw : bool -> (rmw -> 'a -> 'a) -> 'a -> 'a

--- a/gen/common/code.ml
+++ b/gen/common/code.ml
@@ -75,6 +75,25 @@ type sd = Same|Diff|UnspecLoc
 (* Direction of related events *)
 type extr = Dir of dir | Irr | NoDir
 
+let equal_ie ie1 ie2 = match ie1,ie2 with
+  | Int,Int
+  | Ext,Ext
+  | UnspecCom,UnspecCom -> true
+  | (Int|Ext|UnspecCom),_ -> false
+
+let equal_sd sd1 sd2 = match sd1,sd2 with
+  | Same,Same
+  | Diff,Diff
+  | UnspecLoc,UnspecLoc -> true
+  | (Same|Diff|UnspecLoc),_ -> false
+
+let equal_extr e1 e2 = match e1,e2 with
+  | Dir W,Dir W
+  | Dir R,Dir R
+  | Irr,Irr
+  | NoDir,NoDir -> true
+  | (Dir _|Irr|NoDir),_ -> false
+
 (* Associated pretty print & generators *)
 let pp_dir = function
   | W -> "W"
@@ -154,6 +173,12 @@ let checks =
 
 (* Com relation *)
 type com =  CRf | CFr | CWs
+
+let equal_com c1 c2 = match c1,c2 with
+  | CRf,CRf
+  | CFr,CFr
+  | CWs,CWs -> true
+  | (CRf|CFr|CWs),_ -> false
 
 let pp_com = function
   | CRf -> "Rf"

--- a/gen/common/code.mli
+++ b/gen/common/code.mli
@@ -48,7 +48,9 @@ type sd = Same|Diff|UnspecLoc
 (* Direction of related events *)
 type extr = Dir of dir | Irr | NoDir
 
-
+val equal_ie : ie -> ie -> bool
+val equal_sd : sd -> sd -> bool
+val equal_extr : extr -> extr -> bool
 
 (* Associated pretty print & generators *)
 val pp_ie : ie -> string
@@ -76,6 +78,7 @@ val checks : string list
 (* Com *)
 type com =  CRf | CFr | CWs
 
+val equal_com : com -> com -> bool
 val pp_com : com -> string
 val fold_com : (com -> 'a -> 'a) -> 'a -> 'a
 

--- a/gen/common/dep.ml
+++ b/gen/common/dep.ml
@@ -18,6 +18,13 @@
 
 type dp = ADDR | DATA | CTRL | CTRLISYNC
 
+let equal_dp dp1 dp2 = match dp1,dp2 with
+  | ADDR,ADDR
+  | DATA,DATA
+  | CTRL,CTRL
+  | CTRLISYNC,CTRLISYNC -> true
+  | (ADDR|DATA|CTRL|CTRLISYNC),_ -> false
+
 let fold_dpr f r =  f ADDR (f CTRL (f CTRLISYNC r))
 let fold_dpw f r =  f ADDR (f DATA (f CTRL (f CTRLISYNC r)))
 

--- a/gen/common/dep.mli
+++ b/gen/common/dep.mli
@@ -17,6 +17,7 @@
 (* Power / ARM dependencies *)
 type dp = ADDR | DATA | CTRL | CTRLISYNC
 
+val equal_dp : dp -> dp -> bool
 val fold_dpr : (dp -> 'a -> 'a) -> 'a -> 'a
 val fold_dpw : (dp -> 'a -> 'a) -> 'a -> 'a
 

--- a/gen/common/edge.ml
+++ b/gen/common/edge.ml
@@ -91,6 +91,8 @@ module type S = sig
   val parse_atoms : string list -> atom option list
   val get_access_atom: atom option -> MachMixed.t option
 
+  val equal_edge_atoms : edge -> edge -> bool
+
   val parse_fence : string -> fence
   val parse_edge_annotations : string -> (atom option * atom option) option
   val parse_edge : string -> edge
@@ -422,6 +424,35 @@ let fold_tedges f r =
     | Some a1,Some a2 -> A.overlap_atoms a1 a2
 
   let get_access_atom = A.get_access_atom
+
+  let equal_atomo = Option.equal (fun a1 a2 -> A.compare_atom a1 a2 = 0)
+
+  let equal_tedge lhs rhs = match lhs,rhs with
+  | Rf ie1,Rf ie2
+  | Fr ie1,Fr ie2
+  | Ws ie1,Ws ie2 -> Code.equal_ie ie1 ie2
+  | Po (sd1,e11,e12),Po (sd2,e21,e22) ->
+      Code.equal_sd sd1 sd2 && Code.equal_extr e11 e21 &&
+      Code.equal_extr e12 e22
+  | Fenced (f1,sd1,e11,e12),Fenced (f2,sd2,e21,e22) ->
+      F.compare_fence f1 f2 = 0 && Code.equal_sd sd1 sd2 &&
+      Code.equal_extr e11 e21 && Code.equal_extr e12 e22
+  | Dp (dp1,sd1,e1),Dp (dp2,sd2,e2) ->
+      F.equal_dp dp1 dp2 && Code.equal_sd sd1 sd2 && Code.equal_extr e1 e2
+  | Leave c1,Leave c2
+  | Back c1,Back c2 -> Code.equal_com c1 c2
+  | Id,Id
+  | Store,Store
+  | Hat,Hat -> true
+  | Insert f1,Insert f2 -> F.compare_fence f1 f2 = 0
+  | Node d1,Node d2 -> Code.equal_extr (Dir d1) (Dir d2)
+  | Rmw rmw1,Rmw rmw2 -> RMW.equal_rmw rmw1 rmw2
+  | (Rf _|Fr _|Ws _|Po _|Fenced _|Dp _|Leave _|Back _|Id
+    |Insert _|Store|Node _|Hat|Rmw _),_ -> false
+
+  let equal_edge_atoms lhs rhs =
+    equal_tedge lhs.edge rhs.edge &&
+    equal_atomo lhs.a1 rhs.a1 && equal_atomo lhs.a2 rhs.a2
 
   let same_access_atoms a1 a2 =
     Misc.opt_eq MachMixed.equal (get_access_atom a1) (get_access_atom a2)

--- a/gen/common/fence.mli
+++ b/gen/common/fence.mli
@@ -36,6 +36,7 @@ module type S = sig
 
 (* Dependencies *)
   type dp
+  val equal_dp : dp -> dp -> bool
   val pp_dp : dp -> string
   val fold_dpr : (dp -> 'a -> 'a) -> 'a -> 'a
   val fold_dpw : (dp -> 'a -> 'a) -> 'a -> 'a

--- a/gen/common/rmw.ml
+++ b/gen/common/rmw.ml
@@ -22,6 +22,7 @@ module No(A:sig
   type atom = A.atom
 
   let pp_rmw _ _ = assert false
+  let equal_rmw () () = true
   let is_one_instruction _ = assert false
   let fold_rmw _ _ r = r
   let fold_rmw_compat _ r = r
@@ -46,6 +47,7 @@ module
     type atom = I.atom
 
     let pp_rmw compat () = if compat then "Rmw" else I.pp
+    let equal_rmw () () = true
 
     let is_one_instruction _ = I.is_one_instruction
 


### PR DESCRIPTION
Add equality helpers for code, edge components, dependencies, and RMWs. This avoids polymorphic equality for `tedge` internals. Use existing `compare_atom` for `atom` equality check.

This pull request separates from #1835 .