### PR TITLE
[herd,asl] Represent RESADDR as a bitvector

### DIFF
--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -1051,18 +1051,20 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
     let tr_cst tr =
       Constant.map tr Misc.identity Misc.identity Misc.identity
 
-    let aarch64_to_asl_bv_cst sz = function
+    let aarch64_to_asl_bv var_ val_ sz = function
       | V.Var _ as v ->
           let nv = V.fresh_var () in
-          let nid =
-            match nv with
-            | V.Var n -> n
-            | _ -> assert false in
+          let nid = match nv with V.Var n -> n | _ -> assert false in
           let eq =
             let op = AArch64Op.Extra1 (ASLOp.ToBV sz) in
             M.VC.Assign (nv,M.VC.Unop (Op.ArchOp1 op,v))  in
-          (ASLS.A.V.freeze nid, [eq])
-      | V.Val cst -> (tr_cst (ASLScalar.convert_to_bv sz) cst, [])
+          (var_ nid, [eq])
+      | V.Val cst -> (val_ (tr_cst (ASLScalar.convert_to_bv sz) cst), [])
+
+    let aarch64_to_asl_bv_cst = aarch64_to_asl_bv ASLS.A.V.freeze Fun.id
+
+    let aarch64_to_asl_bv_v =
+      aarch64_to_asl_bv (fun n -> ASLS.A.V.Var n) (fun cst -> ASLS.A.V.Val cst)
 
     let aarch64_to_asl = function
       | V.Var v -> ASLS.A.V.Var v
@@ -1133,13 +1135,10 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
       let state_add loc v st =
         ASLS.A.state_add st (ASLS.A.Location_reg (ii.A.proc, loc)) v
       in
-      let add_reg_if_present ?(setzero=false) reg loc st =
+      let add_reg_if_present reg loc st =
         match A.look_reg reg ii.A.env.A.regs with
         | Some v -> state_add loc (aarch64_to_asl v) st
-        | _ ->
-           if setzero then
-             state_add loc ASLS.V.zero st
-           else st
+        | _ -> st
       in
       let add_arch_reg_if_present reg =
         add_reg_if_present reg (ASLBase.ArchReg reg)
@@ -1152,12 +1151,21 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
       let pc_val =
         ASLS.A.V.scalarToV (ASLScalar.bv_of_int_sized 64 ii.A.addr)
       in
+      let resaddr_val, eqs =
+        match A.look_reg AArch64Base.ResAddr ii.A.env.A.regs with
+        | Some v ->
+          let v, eqs2  = aarch64_to_asl_bv_v (if is_vmsa then 56 else 64) v in
+          Some v, eqs2 @ eqs
+       | None -> None, eqs
+      in
       let st =
         ASLS.A.state_empty
         |> state_add (global_loc "PSTATE") pstate_val
         |> state_add (global_loc "_PC") pc_val
         |> List.fold_right add_arch_reg_if_present ASLBase.gregs
-        |> add_reg_if_present ~setzero:true AArch64Base.ResAddr (global_loc "RESADDR")
+        |> (match resaddr_val with
+            | Some v -> state_add (global_loc "RESADDR") v
+            | None -> Fun.id)
         |> add_reg_if_present AArch64Base.SP (global_loc "_SP_EL0")
         |> (if is_vmsa then
               state_add (global_loc "D128")

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -1133,10 +1133,13 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
       let state_add loc v st =
         ASLS.A.state_add st (ASLS.A.Location_reg (ii.A.proc, loc)) v
       in
-      let add_reg_if_present reg loc st =
+      let add_reg_if_present ?(setzero=false) reg loc st =
         match A.look_reg reg ii.A.env.A.regs with
         | Some v -> state_add loc (aarch64_to_asl v) st
-        | _ -> st
+        | _ ->
+           if setzero then
+             state_add loc ASLS.V.zero st
+           else st
       in
       let add_arch_reg_if_present reg =
         add_reg_if_present reg (ASLBase.ArchReg reg)
@@ -1154,7 +1157,7 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
         |> state_add (global_loc "PSTATE") pstate_val
         |> state_add (global_loc "_PC") pc_val
         |> List.fold_right add_arch_reg_if_present ASLBase.gregs
-        |> add_reg_if_present AArch64Base.ResAddr (global_loc "RESADDR")
+        |> add_reg_if_present ~setzero:true AArch64Base.ResAddr (global_loc "RESADDR")
         |> add_reg_if_present AArch64Base.SP (global_loc "_SP_EL0")
         |> (if is_vmsa then
               state_add (global_loc "D128")

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1274,7 +1274,7 @@ module Make
         check_morello_for_write
           (fun a ->
             ((if do_cu (* If CU allowed, write may succeed whatever the address _a_ is *)
-              then M.unitT () else M.assign a resa)
+              then M.unitT () else M.neqT V.zero resa)
              >>| check_mixed_write_mem sz an anexp ac a v ii)
             >>! ())
         a v ii
@@ -2175,7 +2175,10 @@ Arguments:
               begin
                 let open AArch64 in
                 match ii.env.lx_sz with
-                | None -> true (* No LoadExcl at all. always fail *)
+                | None ->
+                (* No LoadExcl at all, store may succeed
+                   when constrained unpredictable is allowed *)
+                   not do_cu
                 | Some szr ->
                    (* Some, must fail when size differ and cu is disallowed *)
                    not (do_cu || MachSize.equal szr sz)
@@ -2193,7 +2196,8 @@ Arguments:
       let stxr sz t rr rs rd ii =
         do_stxr
           (read_reg_ord_sz sz rs ii)
-          (fun an ac ea resa v  -> write_mem_atomic sz an aexp ac ea v resa ii)
+          (fun an ac ea resa v  ->
+            write_mem_atomic sz an aexp ac ea v resa ii)
           sz t rr rd ii
 
       let stxp sz t rr rs1 rs2 rd ii =
@@ -5213,7 +5217,7 @@ Arguments:
       let mk_mop_fetch exposed_page exposed_label test ii =
         let module InstrSet = AArch64.V.Cst.Instr.Set in
         let relevant_pagelbls = get_instr_ptevals test in
-       
+
         let default_cands =
           InstrSet.empty
           |> InstrSet.add ii.A.inst

--- a/herd/RISCVSem.ml
+++ b/herd/RISCVSem.ml
@@ -177,17 +177,15 @@ module
 
       let write_mem sz an = do_write_mem sz (RISCV.P an)
 
-      let lrscdiffok = C.variant Variant.LrScDiffOk
+
+(* Notice that LR/SC to different addresses can succeed. *)
 
       let write_mem_conditional sz an a v resa ii =
-        if  lrscdiffok then
-          (M.mk_singleton_es_eq
-             (Act.Access (Dir.W, A.Location_global a, v, RISCV.EX an, (), sz,Access.VIR)) [] ii >>|
-             M.neqT resa V.zero) >>! () (* resa = zero <-> no matching load reserve *)
-        else
-          let eq = [M.VC.Assign (a,M.VC.Atom resa)] in
-          M.mk_singleton_es_eq
-            (Act.Access (Dir.W, A.Location_global a, v, RISCV.EX an, (), sz,Access.VIR)) eq ii
+        (M.mk_singleton_es
+           (Act.Access
+              (Dir.W, A.Location_global a, v,
+               RISCV.EX an, (), sz,Access.VIR)) ii >>|
+           M.neqT resa V.zero) >>! () (* resa = zero <-> no matching load reserve *)
 
       let write_mem_atomic sz an = do_write_mem sz (RISCV.X an)
 

--- a/herd/libdir/asl-pseudocode/physmem-std.asl
+++ b/herd/libdir/asl-pseudocode/physmem-std.asl
@@ -123,7 +123,7 @@ begin
   SuccessVA = SomeBoolean();
 
   if SuccessVA then
-    CheckEq(address, reserved);
+    CheckProp(reserved != 0);
   end;
 
   return SuccessVA;

--- a/herd/libdir/asl-pseudocode/physmem-std.asl
+++ b/herd/libdir/asl-pseudocode/physmem-std.asl
@@ -123,7 +123,7 @@ begin
   SuccessVA = SomeBoolean();
 
   if SuccessVA then
-    CheckProp(reserved != 0);
+    CheckProp(reserved != Zeros{64});
   end;
 
   return SuccessVA;

--- a/herd/libdir/asl-pseudocode/physmem-vmsa.asl
+++ b/herd/libdir/asl-pseudocode/physmem-vmsa.asl
@@ -249,7 +249,7 @@ begin
   SuccessPA = SomeBoolean();
 
   if SuccessPA then
-    CheckEq(paddress.address, reserved);
+    CheckProp(reserved != 0);
     RegisterAddress(paddress.address);
   end;
 

--- a/herd/libdir/asl-pseudocode/physmem-vmsa.asl
+++ b/herd/libdir/asl-pseudocode/physmem-vmsa.asl
@@ -249,7 +249,7 @@ begin
   SuccessPA = SomeBoolean();
 
   if SuccessPA then
-    CheckProp(reserved != 0);
+    CheckProp(reserved != Zeros{56});
     RegisterAddress(paddress.address);
   end;
 

--- a/herd/tests/instructions/AArch64/L020.litmus
+++ b/herd/tests/instructions/AArch64/L020.litmus
@@ -1,6 +1,5 @@
 AArch64 L020
-(* LX/SX with different address, success is Constrained Upredictable.
-   Normaly excluded, appears with  -variant CU *)
+(* LX/SX with different address, observed on Raspberry Pi4B *)
 {
 int x=1;
 int y=2;
@@ -11,4 +10,4 @@ int y=2;
  LDXR W1,[X0]     ;
  MOV W3,#3        ;
  STXR W4,W3,[X2]  ;
-~exists y=3;
+exists [y]=3;

--- a/herd/tests/instructions/AArch64/L020.litmus
+++ b/herd/tests/instructions/AArch64/L020.litmus
@@ -1,5 +1,6 @@
 AArch64 L020
-(* LX/SX with different address, observed on Raspberry Pi4B *)
+(* LX/SX with different address, observed on many systems.
+   with -mode presi or -s <small> *)
 {
 int x=1;
 int y=2;

--- a/herd/tests/instructions/AArch64/L020.litmus.expected
+++ b/herd/tests/instructions/AArch64/L020.litmus.expected
@@ -1,10 +1,11 @@
-Test L020 Forbidden
-States 1
+Test L020 Allowed
+States 2
 [y]=2;
+[y]=3;
 Ok
 Witnesses
-Positive: 1 Negative: 0
-Condition ~exists ([y]=3)
-Observation L020 Never 0 1
+Positive: 1 Negative: 1
+Condition exists ([y]=3)
+Observation L020 Sometimes 1 1
 Hash=a98a9e6b957012feb7f4c25cd4c01d69
 

--- a/herd/tests/instructions/AArch64/L106.litmus
+++ b/herd/tests/instructions/AArch64/L106.litmus
@@ -1,0 +1,9 @@
+AArch64 L106
+(* Without -variant CU, this test fails *)
+Variant=CU
+{
+0:X0=x; 0:X1=1;
+}
+  P0             ;
+ STXR W2,W1,[X0] ;
+exists [x]=1

--- a/herd/tests/instructions/AArch64/L106.litmus.expected
+++ b/herd/tests/instructions/AArch64/L106.litmus.expected
@@ -1,0 +1,11 @@
+Test L106 Allowed
+States 2
+[x]=0;
+[x]=1;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists ([x]=1)
+Observation L106 Sometimes 1 1
+Hash=cb70be2de517dd2190958ea8c830b40c
+

--- a/herd/tests/instructions/AArch64/L107.litmus
+++ b/herd/tests/instructions/AArch64/L107.litmus
@@ -1,0 +1,14 @@
+AArch64 L107
+(* Can the second STXR succeeed? (Notice Variant=CU) *)
+Variant=CU
+{
+int x=1;
+0:X0=x;
+}
+ P0               ;
+ MOV W3,#2        ;
+ MOV W5,#3        ;
+ LDXR W1,[X0]     ;
+ STXR W4,W3,[X0]  ;
+ STXR W6,W5,[X0]  ;
+exists 0:X4=1 /\ 0:X6=0 /\ x=3

--- a/herd/tests/instructions/AArch64/L107.litmus.expected
+++ b/herd/tests/instructions/AArch64/L107.litmus.expected
@@ -1,0 +1,13 @@
+Test L107 Allowed
+States 4
+0:X4=0; 0:X6=0; [x]=3;
+0:X4=0; 0:X6=1; [x]=2;
+0:X4=1; 0:X6=0; [x]=3;
+0:X4=1; 0:X6=1; [x]=1;
+Ok
+Witnesses
+Positive: 1 Negative: 3
+Condition exists (0:X4=1 /\ 0:X6=0 /\ [x]=3)
+Observation L107 Sometimes 1 3
+Hash=7a4f826210407ee264f41a4a24ae888c
+

--- a/herd/tests/instructions/AArch64/L108.litmus
+++ b/herd/tests/instructions/AArch64/L108.litmus
@@ -1,0 +1,12 @@
+AArch64 L108
+(* Observed `-mode presi` or `-s <small>` *)
+{
+0:X0=x;
+0:X2=y;
+0:X1=1;
+}
+  P0             ;
+ LDXR W3,[X0]    ;
+ LDXR W5,[X2]    ;
+ STXR W7,W1,[X0] ;
+exists [x]=1

--- a/herd/tests/instructions/AArch64/L108.litmus.expected
+++ b/herd/tests/instructions/AArch64/L108.litmus.expected
@@ -1,0 +1,11 @@
+Test L108 Allowed
+States 2
+[x]=0;
+[x]=1;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists ([x]=1)
+Observation L108 Sometimes 1 1
+Hash=fe56da72b59776945a99551d9c110513
+

--- a/herd/tests/instructions/AArch64/L109.litmus
+++ b/herd/tests/instructions/AArch64/L109.litmus
@@ -1,0 +1,15 @@
+AArch64 L109
+(* Observed, `-mode presi` or `-s <small>`.
+   No "atomic" pairing of LR/SC by P0 *)
+{
+0:X0=x;
+0:X2=y;
+0:X1=1;
+1:X0=x;
+1:X1=2;
+}
+  P0             | P1          ;
+ LDXR W3,[X0]    | STR W1,[X0] ;
+ LDXR W5,[X2]    |             ;
+ STXR W7,W1,[X0] |             ;
+exists 0:X3=0 /\ [x]=1

--- a/herd/tests/instructions/AArch64/L109.litmus.expected
+++ b/herd/tests/instructions/AArch64/L109.litmus.expected
@@ -1,0 +1,13 @@
+Test L109 Allowed
+States 4
+0:X3=0; [x]=1;
+0:X3=0; [x]=2;
+0:X3=2; [x]=1;
+0:X3=2; [x]=2;
+Ok
+Witnesses
+Positive: 1 Negative: 4
+Condition exists (0:X3=0 /\ [x]=1)
+Observation L109 Sometimes 1 4
+Hash=f94ed99de5f12ff5b5634bbea7c0d5ee
+

--- a/herd/tests/instructions/AArch64/asl.cfg
+++ b/herd/tests/instructions/AArch64/asl.cfg
@@ -62,3 +62,5 @@ nonames L086
 nonames A259
 # Mixed mode non implemented
 nonames M001
+# `-variant ConstrainedUndefined` not available in ASL mode
+nonames L106,L107

--- a/herd/tests/instructions/RISCV/A021.litmus
+++ b/herd/tests/instructions/RISCV/A021.litmus
@@ -1,0 +1,11 @@
+RISCV A021
+(* Atomicity, LR/SC *)
+{
+ 0:x5=x;
+ 1:x5=x;
+}
+ P0                  | P1            ;
+ lr.w x1,(x5)        | ori x6,x0,2   ;
+ ori x2,x0,1         | sw x6,(x5)    ;
+ sc.w x6,x2,(x5)     |               ;
+~exists (0:x1=0 /\ [x]=1)

--- a/herd/tests/instructions/RISCV/A021.litmus.expected
+++ b/herd/tests/instructions/RISCV/A021.litmus.expected
@@ -1,0 +1,12 @@
+Test A021 Forbidden
+States 3
+0:x1=0; [x]=2;
+0:x1=2; [x]=1;
+0:x1=2; [x]=2;
+Ok
+Witnesses
+Positive: 4 Negative: 0
+Condition ~exists (0:x1=0 /\ [x]=1)
+Observation A021 Never 0 4
+Hash=8b72df1f97f7cccf6d9f8d0102c21653
+

--- a/herd/tests/instructions/RISCV/A022.litmus
+++ b/herd/tests/instructions/RISCV/A022.litmus
@@ -1,0 +1,11 @@
+RISCV A022
+(* Atomicity, amoswap *)
+{
+ 0:x5=x;
+ 1:x5=x;
+}
+ P0                  | P1            ;
+ lr.w x1,(x5)        | ori x6,x0,2   ;
+ ori x2,x0,1         | sw x6,(x5)    ;
+ sc.w x6,x2,(x5)     |               ;
+~exists (0:x1=0 /\ [x]=1)

--- a/herd/tests/instructions/RISCV/A022.litmus.expected
+++ b/herd/tests/instructions/RISCV/A022.litmus.expected
@@ -1,0 +1,12 @@
+Test A022 Forbidden
+States 3
+0:x1=0; [x]=2;
+0:x1=2; [x]=1;
+0:x1=2; [x]=2;
+Ok
+Witnesses
+Positive: 4 Negative: 0
+Condition ~exists (0:x1=0 /\ [x]=1)
+Observation A022 Never 0 4
+Hash=8b72df1f97f7cccf6d9f8d0102c21653
+

--- a/herd/tests/instructions/RISCV/A023.litmus
+++ b/herd/tests/instructions/RISCV/A023.litmus
@@ -1,0 +1,12 @@
+RISCV A023
+(* Atomicity LR/SC vs. amoswap *)
+{
+ 0:x5=x;
+ 1:x5=x;
+}
+ P0                  | P1                   ;
+ lr.w x1,(x5)        | ori x6,x0,2          ;
+ ori x2,x0,1         | amoswap.w x1,x6,(x5) ;
+ sc.w x6,x2,(x5)     |                      ;
+locations [x;]
+~exists (0:x6=0 /\ 0:x1=0 /\ 1:x1=0)

--- a/herd/tests/instructions/RISCV/A023.litmus.expected
+++ b/herd/tests/instructions/RISCV/A023.litmus.expected
@@ -1,0 +1,13 @@
+Test A023 Forbidden
+States 4
+0:x1=0; 0:x6=0; 1:x1=1; [x]=2;
+0:x1=0; 0:x6=1; 1:x1=0; [x]=2;
+0:x1=2; 0:x6=0; 1:x1=0; [x]=1;
+0:x1=2; 0:x6=1; 1:x1=0; [x]=2;
+Ok
+Witnesses
+Positive: 4 Negative: 0
+Condition ~exists (0:x6=0 /\ 0:x1=0 /\ 1:x1=0)
+Observation A023 Never 0 4
+Hash=1dfa63cd6e138edf69c3be7f9dcdefc4
+

--- a/herd/tests/instructions/RISCV/A024.litmus
+++ b/herd/tests/instructions/RISCV/A024.litmus
@@ -1,0 +1,11 @@
+RISCV A024
+(* SC may succeed on y when reservation is on x *)
+{
+ 0:x5=x;
+ 0:x7=y;
+}
+ P0                  ;
+ lr.w x1,(x5)        ;
+ ori x2,x0,1         ;
+ sc.w x6,x2,(x7)     ;
+exists [y]=1

--- a/herd/tests/instructions/RISCV/A024.litmus.expected
+++ b/herd/tests/instructions/RISCV/A024.litmus.expected
@@ -1,0 +1,11 @@
+Test A024 Allowed
+States 2
+[y]=0;
+[y]=1;
+Ok
+Witnesses
+Positive: 1 Negative: 1
+Condition exists ([y]=1)
+Observation A024 Sometimes 1 1
+Hash=d0e19174b76a6520c338d289c54f6f3e
+

--- a/herd/tests/instructions/RISCV/A025.litmus
+++ b/herd/tests/instructions/RISCV/A025.litmus
@@ -1,0 +1,12 @@
+RISCV A025
+(* SC cancels the reservation: the second SC never succeeds *)
+{
+ 0:x5=x;
+}
+ P0                  ;
+ lr.w x1,(x5)        ;
+ ori x2,x0,1         ;
+ sc.w x6,x2,(x5)     ;
+ ori x4,x0,2         ;
+ sc.w x8,x4,(x5)     ;
+~exists [x]=2

--- a/herd/tests/instructions/RISCV/A025.litmus.expected
+++ b/herd/tests/instructions/RISCV/A025.litmus.expected
@@ -1,0 +1,11 @@
+Test A025 Forbidden
+States 2
+[x]=0;
+[x]=1;
+Ok
+Witnesses
+Positive: 2 Negative: 0
+Condition ~exists ([x]=2)
+Observation A025 Never 0 2
+Hash=5834b5dd50ad482687f514e06a23a6cb
+

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -32,7 +32,6 @@ type t =
   | SplittedRMW     (* Splitted RMW events for riscv *)
   | SwitchDepScWrite  (* Switch dependency on sc mem write, riscv, aarch64 *)
   | SwitchDepScResult  (* Switch dependency from address read to sc result register,  aarch64 *)
-  | LrScDiffOk      (* Lr/Sc paired to <> addresses may succeed (!) *)
   | NotWeakPredicated (* NOT "Weak" predicated instructions, not performing non-selected events, aarch64 *)
   | LKMMVersion of [
         `lkmmv1 (* Legacy mode, e.g., wrapp rmw[Mb] instructions with explicit Mb fences *)
@@ -136,7 +135,6 @@ let (mode_variants, arch_variants) : t list * t list =
   | SplittedRMW -> SplittedRMW
   | SwitchDepScWrite -> SwitchDepScWrite
   | SwitchDepScResult -> SwitchDepScResult
-  | LrScDiffOk -> LrScDiffOk
   | Mixed -> Mixed
   | Unaligned -> Unaligned
   | DontCheckMixed -> DontCheckMixed
@@ -200,7 +198,7 @@ let (mode_variants, arch_variants) : t list * t list =
     List.map f
       [ Success; Instr; SpecialX0; NoRMW; AcqRelAsFence;
         BackCompat; FullScDepend; SplittedRMW; SwitchDepScWrite;
-        SwitchDepScResult; LrScDiffOk;
+        SwitchDepScResult;
         NotWeakPredicated;
         LKMMVersion `lkmmv1; LKMMVersion `lkmmv2;
         CutOff; Morello; Deps; Instances;
@@ -248,7 +246,6 @@ let parse s = match Misc.lowercase s with
 | "splittedrmw" -> Some SplittedRMW
 | "switchdepscwrite" -> Some  SwitchDepScWrite
 | "switchdepscresult" -> Some  SwitchDepScResult
-| "lrscdiffok" -> Some  LrScDiffOk
 | "mixed" -> Some Mixed
 | "unaligned" -> Some Unaligned
 | "dontcheckmixed" -> Some DontCheckMixed
@@ -355,7 +352,6 @@ let pp = function
   | SplittedRMW -> "SplittedRMW"
   | SwitchDepScWrite -> "SwitchDepScWrite"
   | SwitchDepScResult -> "SwitchDepScResult"
-  | LrScDiffOk -> "LrScDiffOk"
   | Mixed -> "mixed"
   | Unaligned -> "unaligned"
   | DontCheckMixed -> "DontCheckMixed"
@@ -430,7 +426,6 @@ let pp = function
   | SplittedRMW -> ""
   | SwitchDepScWrite -> ""
   | SwitchDepScResult -> ""
-  | LrScDiffOk -> ""
   | Mixed -> "Use mixed-sized semantics, where accesses can have different sizes"
   | Unaligned -> "When using mixed-sized semantics, allow unaligned accesses"
   | DontCheckMixed -> "Do not check (and reject early) mixed size tests in non-mixed-size mode"

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -31,7 +31,6 @@ type t =
   | SplittedRMW  (* Splitted RMW events for riscv *)
   | SwitchDepScWrite     (* Switch dependency on sc mem write, riscv *)
   | SwitchDepScResult    (* Switch dependency from address read to sc result write, riscv,aarch64 *)
-  | LrScDiffOk      (* Lr/Sc paired to <> addresses may succeed (!) *)
   | NotWeakPredicated (* NOT "Weak" predicated instructions, not performing non-selected events, aarch64 *)
   | LKMMVersion of [
         `lkmmv1 (* Legacy mode (wrapp rmw[Mb] instructions with explicit Mb fences, add noreturn tags) *)

--- a/lib/ASLOp.ml
+++ b/lib/ASLOp.ml
@@ -269,7 +269,9 @@ let do_op1 op cst =
   | ToBV sz -> (
       match cst,sz with
       | Constant.Concrete s,_ -> ASLScalar.convert_to_bv sz s |> return_concrete
-      | (Constant.(Symbolic _|PteVal _|Instruction _),64)
+      | (Constant.PteVal _,64)
+      | Constant.(Symbolic (Virtual _ | System (PTE, _)), 64)
+      | Constant.(Symbolic (Physical _), 56)
       | (Constant.Instruction _,32) (* Instructions are 32bit wide *)
         -> Some cst
       | _ -> None)


### PR DESCRIPTION
This PR has for target #1896.

It implements conversion from integers to bitvectors for the register `RESADDR` which stores the address of a reservation, zero otherwise.