### PR TITLE
[herd] Fix atomic pairs matching algorithm

### DIFF
--- a/herd/mem.ml
+++ b/herd/mem.ml
@@ -1978,11 +1978,8 @@ let add_eq v1 v2 eqs =
                 List.fold_left
                   (fun k er ->
                     match EvtSet.find_first_after er ws with
-                    | Some ew ->
-                       assert (E.same_instance er ew) ;
-                       (er,ew)::k
-                    | None -> (* Cann occur for failing CAS *)
-                       k)
+                    | Some ew when E.same_instance er ew -> (er, ew) :: k
+                    | _ -> k (* Can occur for failing CAS *))
                   k rs)
               atms k)
         [] atms |> E.EventRel.of_list

--- a/herd/tests/instructions/C/C17.litmus
+++ b/herd/tests/instructions/C/C17.litmus
@@ -1,0 +1,15 @@
+C C17
+
+{
+  atomic_t x = ATOMIC_INIT(0);
+}
+
+P0 (atomic_int* x) {
+  int r0;
+  r0 = __atomic_add_unless{mb}(x, 10, 0);
+
+  int r1;
+  r1 = __atomic_add_unless{mb}(x, 10, 10);
+}
+
+forall (0: r0 = 0 /\ 0: r1 = 1 /\ x = 10)

--- a/herd/tests/instructions/C/C17.litmus.expected
+++ b/herd/tests/instructions/C/C17.litmus.expected
@@ -1,0 +1,10 @@
+Test C17 Required
+States 1
+0:r0=0x0; 0:r1=0x1; [x]=0xa;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r0=0x0 /\ 0:r1=0x1 /\ [x]=0xa)
+Observation C17 Always 1 0
+Hash=43fb4fc4801554302d3544049fac3a99
+


### PR DESCRIPTION
The situation, reported by @akiyks, arrises when there is an atomic read that should stay unmatched, for example in the case of a failed compare-and-swap. However, if there is a second atomic instruction at the same location in the same thread, then the algorithm would try and match the read of the first atomic instruction with the second write, which hit an assertion error.
This commit transforms this assertion error in a condition where the pairs between atomic elements on different instructions are not matched.

---

On the test `C-atomic-04` given by @akiyks in [the bug report](https://github.com/herd/herdtools7/pull/1908#issuecomment-4977821169), results are identical now with on the following command line:
```bash
herd7 C-atomic-04.litmus -conf catalogue/linux/cfgs/linux-kernel.cfg -I catalogue/linux/cats -I herd-www/linux/
```
