### PR TITLE
[asl reference] replace console splicing by generated console macros

### DIFF
--- a/asllib/doc/.gitignore
+++ b/asllib/doc/.gitignore
@@ -11,7 +11,7 @@
 *.blg
 *.dvi
 generated_macros.tex
-generated_console_macros.tex
+generated_console_output.stamp
 generated_console_output/
 __pycache__
 ASLReference.synctex(busy)

--- a/asllib/doc/.gitignore
+++ b/asllib/doc/.gitignore
@@ -11,5 +11,7 @@
 *.blg
 *.dvi
 generated_macros.tex
+generated_console_macros.tex
+generated_console_output/
 __pycache__
 ASLReference.synctex(busy)

--- a/asllib/doc/ASLReference.tex
+++ b/asllib/doc/ASLReference.tex
@@ -12,6 +12,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage{rendering_macros}
 \input{generated_macros.tex}
+\input{generated_console_macros.tex}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Increase indentation of sections in the table of contents

--- a/asllib/doc/ASLReference.tex
+++ b/asllib/doc/ASLReference.tex
@@ -12,7 +12,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage{rendering_macros}
 \input{generated_macros.tex}
-\input{generated_console_macros.tex}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Increase indentation of sections in the table of contents

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -127,6 +127,37 @@
 \usepackage{mathpartir}  % For deduction rules and equations paragraphs
 \newcommand\hva[0]{} % Disable the macro, just for the current PR.
 \usepackage{fancyvrb}
+
+% HeVeA defines \ifhevea itself. Define the false branch for LaTeX so the same
+% rendering macro can select the appropriate console-output representation.
+\makeatletter
+\@ifundefined{ifhevea}{\newif\ifhevea\heveafalse}{}
+\makeatother
+% Render the output produced by running aslref on a test file:
+%   \RenderConsoleFor[<options>]{<ID>}{<test-file>}
+%
+% <ID> must be unique and consist of letters, digits, and hyphens, beginning
+% with a letter. <test-file> must use one of \definitiontests, \syntaxtests,
+% \typingtests, or \semanticstests. Both identify the generated output; TeX
+% itself uses only <ID>.
+%
+% <options> contains options passed to aslref. It may additionally contain the
+% generator directives `expect-error`, to capture stdout and stderr from an
+% intentionally failing test, and `show-command`, to include the command in the
+% rendered output. The complete invocation must occupy one source line so that
+% doclint.py can find it. The Makefile regenerates generated_console_macros.tex
+% and the HTML console-output files before building the document.
+\newcommand\RenderConsoleFor[3][]{%
+  % HeVeA does not implement fancyvrb's SaveVerbatim/UseVerbatim mechanism, so
+  % it reads the separately generated text file instead. LaTeX uses the named
+  % SaveVerbatim block from generated_console_macros.tex.
+  \ifhevea
+    \VerbatimInput[fontsize=\footnotesize,frame=single]{generated_console_output/#2.txt}%
+  \else
+    \UseVerbatim[fontsize=\footnotesize,frame=single]{console-#2}%
+  \fi
+}
+
 \usepackage[
   % Notes on the right, should be less than outer
   marginparwidth=100pt,

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -128,11 +128,6 @@
 \newcommand\hva[0]{} % Disable the macro, just for the current PR.
 \usepackage{fancyvrb}
 
-% HeVeA defines \ifhevea itself. Define the false branch for LaTeX so the same
-% rendering macro can select the appropriate console-output representation.
-\makeatletter
-\@ifundefined{ifhevea}{\newif\ifhevea\heveafalse}{}
-\makeatother
 % Render the output produced by running aslref on a test file:
 %   \RenderConsoleFor[<options>]{<ID>}{<test-file>}
 %
@@ -141,21 +136,14 @@
 % \typingtests, or \semanticstests. Both identify the generated output; TeX
 % itself uses only <ID>.
 %
-% <options> contains options passed to aslref. It may additionally contain the
-% generator directives `expect-error`, to capture stdout and stderr from an
-% intentionally failing test, and `show-command`, to include the command in the
-% rendered output. The complete invocation must occupy one source line so that
-% doclint.py can find it. The Makefile regenerates generated_console_macros.tex
-% and the HTML console-output files before building the document.
+% <options> contains generator keys translated to aslref options by doclint.py.
+% Supported keys are `type-check-no-warn`; `expect-error`, to capture stdout and
+% stderr from an intentionally failing test; and `show-command`, to include the
+% command in the rendered output. The complete invocation must occupy one source
+% line so that doclint.py can find it. The Makefile regenerates the console-output
+% text files before building the document.
 \newcommand\RenderConsoleFor[3][]{%
-  % HeVeA does not implement fancyvrb's SaveVerbatim/UseVerbatim mechanism, so
-  % it reads the separately generated text file instead. LaTeX uses the named
-  % SaveVerbatim block from generated_console_macros.tex.
-  \ifhevea
-    \VerbatimInput[fontsize=\footnotesize,frame=single]{generated_console_output/#2.txt}%
-  \else
-    \UseVerbatim[fontsize=\footnotesize,frame=single]{console-#2}%
-  \fi
+  \VerbatimInput[fontsize=\footnotesize,frame=single]{generated_console_output/#2.txt}%
 }
 
 \usepackage[

--- a/asllib/doc/BaseValues.tex
+++ b/asllib/doc/BaseValues.tex
@@ -19,18 +19,7 @@ The following types do not have a \basevalueterm{}:
 \listingref{base-values} shows a specification with examples of well-typed \basevalueterm{}
 for various types, followed by the output to the console.
 \ASLListing{Well-typed Base Values}{base-values}{\typingtests/TypingRule.BaseValue.asl}
-% CONSOLE_BEGIN aslref \typingtests/TypingRule.BaseValue.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-global_base = 0, unconstrained_integer_base = 0, constrained_integer_base = -3
-bool_base = FALSE, real_base = 0, string_base = , enumeration_base = RED
-bits_base = 0x00
-tuple_base = (0, -3, RED)
-record_base      = {data=0x00, time=0, flag=FALSE}
-record_base_init = {data=0x00, time=0, flag=FALSE}
-exception_base = {msg=}
-integer_array_base = [[0, 0, 0, 0]]
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{typingrule-basevalue}{\typingtests/TypingRule.BaseValue.asl}
 
 \listingref{base-values-parameterised} shows a specification that relies on the base value of a \bitvectortypeterm{} whose width is a \parameterizedintegertypeterm{}.
 \ASLListing{Base Value for Parameterised Bitvector Width}{base-values-parameterised}{\typingtests/TypingRule.BaseValue.parameterized.asl}

--- a/asllib/doc/CatchingExceptions.tex
+++ b/asllib/doc/CatchingExceptions.tex
@@ -147,11 +147,7 @@ That is, no \dynamicerrorterm{} occurs.
 \SemanticsRuleDef{CatchNamed}
 \ExampleDef{Catching a Named Exception}
 The specification in \listingref{semantics-catchnamed} prints the following:
-% CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.CatchNamed.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-caught MyExceptionType with msg=42
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{semanticsrule-catchnamed}{\semanticstests/SemanticsRule.CatchNamed.asl}
 \ASLListing{Catching a named exception}{semantics-catchnamed}{\semanticstests/SemanticsRule.CatchNamed.asl}
 
 \RenderProseAndFormally{eval_catchers_catch_named}
@@ -160,11 +156,7 @@ caught MyExceptionType with msg=42
 \SemanticsRuleDef{CatchOtherwise}
 \ExampleDef{Evaluation of a Catch with an Otherwise}
 The specification in \listingref{semantics-catchotherwise} prints the following:
-% CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.CatchOtherwise.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-Otherwise
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{semanticsrule-catchotherwise}{\semanticstests/SemanticsRule.CatchOtherwise.asl}
 \ASLListing{Catching an exception with \texttt{otherwise}}{semantics-catchotherwise}{\semanticstests/SemanticsRule.CatchOtherwise.asl}
 
 \RenderProseAndFormally{eval_catchers_catch_otherwise}
@@ -183,11 +175,7 @@ that matches the exception type (\texttt{MyExceptionType1}).
 \SemanticsRuleDef{CatchNoThrow}
 \ExampleDef{Evaluation of a Try Statement that Does Not Raise an Exception}
 The specification in \listingref{semantics-nothrow} prints the following:
-% CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.CatchNoThrow.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-No exception raised
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{semanticsrule-catchnothrow}{\semanticstests/SemanticsRule.CatchNoThrow.asl}
 \ASLListing{A \texttt{try} statement that does not raise an exception}{semantics-nothrow}{\semanticstests/SemanticsRule.CatchNoThrow.asl}
 
 \RenderProseAndFormally{eval_catchers_no_throw}

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -31,16 +31,7 @@ and \typingerrorsterm{}.
 followed by an example of a report from \aslrefterm{} in a \linuxbashshellterm.
 
 \ASLListing{A specification resulting in a type error}{typing-error-reporting}{\definitiontests/TypingErrorReporting.asl}
-% CONSOLE_BEGIN CONSOLE_STDERR aslref \definitiontests/TypingErrorReporting.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-File ../tests/ASLDefinition.t/TypingErrorReporting.asl, line 3,
-  characters 11 to 22:
-    return 5 + "hello";
-           ^^^^^^^^^^^
-ASL Type error: Illegal application of operator + on types integer {5}
-  and string.
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor[expect-error]{typingerrorreporting}{\definitiontests/TypingErrorReporting.asl}
 
 \RequirementDef{DynamicErrorBehaviour} The behaviour of an implementation when a \dynamicerrorterm{}
 occurs is implementation-defined, including, but not limited to,
@@ -54,12 +45,7 @@ followed by an example of a report from \aslrefterm{} in a \linuxbashshellterm.
 
 \ASLListing{A specification resulting in a dynamic error}{dynamic-error-reporting}{\definitiontests/DynamicErrorReporting.asl}
 
-% CONSOLE_BEGIN CONSOLE_STDERR CONSOLE_CMD aslref \definitiontests/DynamicErrorReporting.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-> aslref ../tests/ASLDefinition.t/DynamicErrorReporting.asl
-ASL Dynamic error: Illegal application of operator DIV for values 128 and 7.
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor[expect-error show-command]{dynamicerrorreporting}{\definitiontests/DynamicErrorReporting.asl}
 
 \RequirementDef{DynamicErrorHost}
 If an implementation terminates execution in response to a \dynamicerrorterm{},
@@ -75,15 +61,7 @@ An assertion failure arising from an \assertionstatementterm\ is a \dynamicerror
 \listingref{AssertionStatement} shows an example of a specification failing
 an \assertionstatementterm{}.
 The report from \aslrefterm{} in a \linuxbashshellterm{} is shown next:
-% CONSOLE_BEGIN CONSOLE_STDERR aslref \definitiontests/AssertionStatement.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-File ../tests/ASLDefinition.t/AssertionStatement.asl, line 5,
-  characters 11 to 22:
-    assert a + b < 256;
-           ^^^^^^^^^^^
-ASL Dynamic error: Assertion failed: ((a + b) < 256).
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor[expect-error]{assertionstatement}{\definitiontests/AssertionStatement.asl}
 
 \RequirementDef{DynamicErrorUnreachable}
 Evaluation of the \unreachablestatementterm{} is a \dynamicerrorterm{}
@@ -93,16 +71,7 @@ Evaluation of the \unreachablestatementterm{} is a \dynamicerrorterm{}
 fails with a \dynamicerrorsterm{} due to evaluation of an \unreachablestatementterm{}.
 The report from \aslrefterm{} in a \linuxbashshellterm{} is shown next:
 
-% CONSOLE_BEGIN CONSOLE_STDERR aslref \definitiontests/UnreachableStatement.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-diagnostic assertion failed: example message
-File ../tests/ASLDefinition.t/UnreachableStatement.asl, line 5,
-  characters 8 to 20:
-        unreachable;
-        ^^^^^^^^^^^^
-ASL Dynamic error: unreachable reached.
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor[expect-error]{unreachablestatement}{\definitiontests/UnreachableStatement.asl}
 
 \section{Error Kinds\label{sec:Error Kinds}}
 \hypertarget{def-errorcodeterm}{}

--- a/asllib/doc/Expressions.tex
+++ b/asllib/doc/Expressions.tex
@@ -638,7 +638,7 @@ evaluate to either \texttt{3} or \texttt{Return42()}, depending on the
 \ASLListing{Evaluating a conditional expression with non-deterministic choice}{semantics-econdarbitrary}
 {\semanticstests/SemanticsRule.ECondARBITRARY3or42.asl}
 
-% Transliteration note: the code uses an optimized semantics for the case where
+% Transliteration note: the code uses an optimised semantics for the case where
 % true and false sub-expressions do not contain function calls. Since this is an
 % optimization, we do not document it.
 \RenderProseAndFormally{eval_expr_ECond}

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -1,4 +1,4 @@
-ASLREF=../../_build/install/default/bin/aslref
+ASLREF=../../_build/default/asllib/aslref.exe
 LATEX=pdflatex
 BIBTEX=bibtex
 
@@ -46,6 +46,10 @@ ASLReference.pdf: generated_spec $(GENERATED_CONSOLE_MACROS_TEX) *.tex *.bib
 
 $(GENERATED_CONSOLE_MACROS_TEX): extended_macros.py doclint.py $(ASLREF) $(ASL_TESTS) $(filter-out $(GENERATED_CONSOLE_MACROS_TEX),$(wildcard *.tex))
 	python3 doclint.py --console-macros-only --aslref $(ASLREF)
+
+$(ASLREF):
+	@# Build the aslref target in the parent asllib directory.
+	dune build ../aslref.exe
 
 html: generated_spec $(GENERATED_CONSOLE_MACROS_TEX) *.tex *.bib *.hva
 	mkdir -p HTML

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -3,6 +3,8 @@ LATEX=pdflatex
 BIBTEX=bibtex
 
 GENERATED_MACROS_TEX=generated_macros.tex
+GENERATED_CONSOLE_MACROS_TEX=generated_console_macros.tex
+ASL_TESTS=$(shell find ../tests -name '*.asl')
 
 # HeVeA and Hacha can emit warnings on stderr while still exiting with success.
 # Capture stderr from the command, preserve real command failures, and make
@@ -29,7 +31,7 @@ all: ASLReference.pdf
 
 LATEXMK=latexmk
 
-ASLReference.pdf: generated_spec *.tex *.bib
+ASLReference.pdf: generated_spec $(GENERATED_CONSOLE_MACROS_TEX) *.tex *.bib
 	if command -v $(LATEXMK) >/dev/null 2>&1; \
 	then \
 		$(LATEXMK) -pdf ASLReference.tex; \
@@ -40,9 +42,12 @@ ASLReference.pdf: generated_spec *.tex *.bib
 		$(BIBTEX) ASLReference; \
 		$(LATEX) ASLReference.tex; \
 	fi
-	python3 doclint.py --console_macros --aslref $(ASLREF)
+	python3 doclint.py
 
-html: generated_spec *.tex *.bib *.hva
+$(GENERATED_CONSOLE_MACROS_TEX): extended_macros.py doclint.py $(ASLREF) $(ASL_TESTS) $(filter-out $(GENERATED_CONSOLE_MACROS_TEX),$(wildcard *.tex))
+	python3 doclint.py --console-macros-only --aslref $(ASLREF)
+
+html: generated_spec $(GENERATED_CONSOLE_MACROS_TEX) *.tex *.bib *.hva
 	mkdir -p HTML
 	@# The first run is expected to generate warnings because bibhva
 	@# and the second hevea pass have not run, so we silence them via -s.
@@ -63,6 +68,8 @@ generated_spec: asl.spec
 clean:
 	/bin/rm -f $(PDFS)
 	/bin/rm -f $(GENERATED_MACROS_TEX)
+	/bin/rm -f $(GENERATED_CONSOLE_MACROS_TEX)
+	/bin/rm -rf generated_console_output
 	/bin/rm -f *.aux *.log *.fls *.log *.toc *.fdb_latexmk *~
 	/bin/rm -f $(CONTROLS)
 	/bin/rm -f comment.cut

--- a/asllib/doc/Makefile
+++ b/asllib/doc/Makefile
@@ -3,8 +3,13 @@ LATEX=pdflatex
 BIBTEX=bibtex
 
 GENERATED_MACROS_TEX=generated_macros.tex
-GENERATED_CONSOLE_MACROS_TEX=generated_console_macros.tex
-ASL_TESTS=$(shell find ../tests -name '*.asl')
+# Empty file marking successful generation of every file in generated_console_output/.
+GENERATED_CONSOLE_OUTPUT_STAMP=generated_console_output.stamp
+ASL_TESTS=$(wildcard \
+	../tests/ASLDefinition.t/*.asl \
+	../tests/ASLSyntaxReference.t/*.asl \
+	../tests/ASLTypingReference.t/*.asl \
+	../tests/ASLSemanticsReference.t/*.asl)
 
 # HeVeA and Hacha can emit warnings on stderr while still exiting with success.
 # Capture stderr from the command, preserve real command failures, and make
@@ -31,7 +36,7 @@ all: ASLReference.pdf
 
 LATEXMK=latexmk
 
-ASLReference.pdf: generated_spec $(GENERATED_CONSOLE_MACROS_TEX) *.tex *.bib
+ASLReference.pdf: generated_spec $(GENERATED_CONSOLE_OUTPUT_STAMP) *.tex *.bib
 	if command -v $(LATEXMK) >/dev/null 2>&1; \
 	then \
 		$(LATEXMK) -pdf ASLReference.tex; \
@@ -44,14 +49,16 @@ ASLReference.pdf: generated_spec $(GENERATED_CONSOLE_MACROS_TEX) *.tex *.bib
 	fi
 	python3 doclint.py
 
-$(GENERATED_CONSOLE_MACROS_TEX): extended_macros.py doclint.py $(ASLREF) $(ASL_TESTS) $(filter-out $(GENERATED_CONSOLE_MACROS_TEX),$(wildcard *.tex))
+$(GENERATED_CONSOLE_OUTPUT_STAMP): extended_macros.py doclint.py $(ASLREF) $(ASL_TESTS) $(wildcard *.tex)
 	python3 doclint.py --console-macros-only --aslref $(ASLREF)
+	touch $@
 
-$(ASLREF):
-	@# Build the aslref target in the parent asllib directory.
+.PHONY: FORCE_REMAKE
+$(ASLREF): FORCE_REMAKE
+	@# ASLREF may be overridden with an absolute build-output path.
 	dune build ../aslref.exe
 
-html: generated_spec $(GENERATED_CONSOLE_MACROS_TEX) *.tex *.bib *.hva
+html: generated_spec $(GENERATED_CONSOLE_OUTPUT_STAMP) *.tex *.bib *.hva
 	mkdir -p HTML
 	@# The first run is expected to generate warnings because bibhva
 	@# and the second hevea pass have not run, so we silence them via -s.
@@ -72,7 +79,7 @@ generated_spec: asl.spec
 clean:
 	/bin/rm -f $(PDFS)
 	/bin/rm -f $(GENERATED_MACROS_TEX)
-	/bin/rm -f $(GENERATED_CONSOLE_MACROS_TEX)
+	/bin/rm -f $(GENERATED_CONSOLE_OUTPUT_STAMP)
 	/bin/rm -rf generated_console_output
 	/bin/rm -f *.aux *.log *.fls *.log *.toc *.fdb_latexmk *~
 	/bin/rm -f $(CONTROLS)

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -553,17 +553,7 @@ for a given unary operator:
 followed by the resulting console output.
 \ASLListing{Applications of unary operations}{unary-operations}{\typingtests/TypingRule.UnopLiterals.asl}
 
-% CONSOLE_BEGIN aslref \typingtests/TypingRule.UnopLiterals.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-negate_int: -10 = -10
-negate_int: -0x0 = 0
-negate_int: -0xf = -15
-negate_rel: -2.3 = -23/10
-not_bool: !TRUE = FALSE
-not_bits: NOT '' = 0x
-not_bits: NOT '11 01' = 0x2
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{typingrule-unopliterals}{\typingtests/TypingRule.UnopLiterals.asl}
 
 \RenderProseAndFormally{unop_literals}
 
@@ -578,27 +568,7 @@ followed by the resulting console output.
   {binary-operations-boolean}
   {\typingtests/TypingRule.BinopLiterals.boolean.asl}
 
-% CONSOLE_BEGIN aslref \typingtests/TypingRule.BinopLiterals.boolean.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-and_bool: TRUE && TRUE = TRUE
-and_bool: TRUE && FALSE = FALSE
-or_bool: TRUE || FALSE = TRUE
-or_bool: FALSE || FALSE = FALSE
-eq_bool: FALSE == FALSE = TRUE
-eq_bool: TRUE == TRUE = TRUE
-eq_bool: FALSE == TRUE = FALSE
-ne_bool: FALSE != FALSE = FALSE
-ne_bool: TRUE != TRUE = FALSE
-ne_bool: FALSE != TRUE = TRUE
-implies_bool: FALSE ==> FALSE = TRUE
-implies_bool: FALSE ==> TRUE = TRUE
-implies_bool: TRUE ==> TRUE = TRUE
-implies_bool: TRUE ==> FALSE = FALSE
-equiv_bool: FALSE <=> FALSE = TRUE
-equiv_bool: TRUE <=> TRUE = TRUE
-equiv_bool: FALSE <=> TRUE = FALSE
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{typingrule-binopliterals-boolean}{\typingtests/TypingRule.BinopLiterals.boolean.asl}
 
 \ExampleDef{Integer Arithmetic}
 \listingref{binary-operations-integer-arithmetic} shows applications
@@ -608,31 +578,7 @@ followed by the resulting console output.
   {binary-operations-integer-arithmetic}
   {\typingtests/TypingRule.BinopLiterals.integer-arithmetic.asl}
 
-% CONSOLE_BEGIN aslref \typingtests/TypingRule.BinopLiterals.integer-arithmetic.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-add_int: 10 + 20 = 30
-sub_int: 10 - 20 = -10
-mul_int: 10 * 20 = 200
-div_int: 20 DIV 10 = 2
-fdiv_int: 20 DIVRM 3 = 6
-fdiv_int: -20 DIVRM 3 = -7
-frem_int: 20 MOD 3 = 2
-frem_int: -20 MOD 3 = 1
-exp_int: 2 ^ 10 = 1024
-exp_int: -2 ^ 10 = 1024
-exp_int: -2 ^ 11 = -2048
-exp_int: 0 ^ 0 = 1
-exp_int: -2 ^ 0 = 1
-shiftleft_int: 1 << 10 = 1024
-shiftleft_int: 1 << 0 = 1
-shiftleft_int: -1 << 10 = -1024
-shiftright_int: 1 >> 10 = 0
-shiftright_int: 16 >> 2 = 4
-shiftright_int: -16 >> 2 = -4
-shiftright_int: 1 >> 0 = 1
-shiftright_int: -1 >> 10 = -1
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{typingrule-binopliterals-integer-arithmetic}{\typingtests/TypingRule.BinopLiterals.integer-arithmetic.asl}
 
 \ExampleDef{Integer Comparison}
 \listingref{binary-operations-integer-relational} shows applications
@@ -642,19 +588,7 @@ followed by the resulting console output.
   {binary-operations-integer-relational}
   {\typingtests/TypingRule.BinopLiterals.integer-relational.asl}
 
-% CONSOLE_BEGIN aslref \typingtests/TypingRule.BinopLiterals.integer-relational.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-eq_int: 5 == 10 = FALSE
-ne_int: 5 != 10 = TRUE
-le_int: 10 <= 10 = TRUE
-lt_int: 10 < 10 = FALSE
-lt_int: 5 < 10 = TRUE
-gt_int: 10 > 10 = FALSE
-gt_int: 11 > 10 = TRUE
-ge_int: 11 >= 10 = TRUE
-ge_int: 6 >= 10 = FALSE
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{typingrule-binopliterals-integer-relational}{\typingtests/TypingRule.BinopLiterals.integer-relational.asl}
 
 \ExampleDef{Real Operations}
 \listingref{binary-operations-real} shows applications
@@ -664,23 +598,7 @@ followed by the resulting console output.
   {binary-operations-real}
   {\typingtests/TypingRule.BinopLiterals.real.asl}
 
-% CONSOLE_BEGIN aslref \typingtests/TypingRule.BinopLiterals.real.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-mul_int_real: 10 * 0.5 = 5
-mul_real_int: 0.5 * 10 = 5
-add_real: 10.0 + 0.5 = 21/2
-sub_real: 10.0 - 0.5 = 19/2
-mul_real: 10.0 * 0.5 = 5
-exp_real: 10.0 ^ 2 = 100
-div_real: 10.0 / 0.5 = 20
-eq_real: 10.0 == 0.5 = FALSE
-ne_real: 10.0 != 0.5 = TRUE
-le_real: 10.0 <= 0.5 = FALSE
-lt_real: 10.0 < 0.5 = FALSE
-gt_real: 10.0 > 0.5 = TRUE
-ge_real: 10.0 >= 0.5 = TRUE
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{typingrule-binopliterals-real}{\typingtests/TypingRule.BinopLiterals.real.asl}
 
 \ExampleDef{Bitvector Operations}
 \listingref{binary-operations-bitvector} shows applications
@@ -690,25 +608,7 @@ followed by the resulting console output.
   {binary-operations-bitvector}
   {\typingtests/TypingRule.BinopLiterals.bits.asl}
 
-% CONSOLE_BEGIN aslref \typingtests/TypingRule.BinopLiterals.bits.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-add_bits: '010' + '011' = 0x5
-add_bits: '10' + '11' = 0x1
-add_bits: '010' + 3 = 0x5
-add_bits: '10' + 3 = 0x1
-sub_bits: '100' - '010' = 0x2
-sub_bits: '100' - '111' = 0x5
-sub_bits: '100' - 7 = 0x5
-sub_bits: '100' - 8 = 0x4
-and_bits: '100' AND '111' = 0x4
-or_bits: '100' OR '110' = 0x6
-xor_bits: '100' XOR '110' = 0x2
-eq_bits: '100' == '110' = FALSE
-ne_bits: '100' != '110' = TRUE
-concat_bits: '100' :: '110' = 0x26
-concat_bits: '100' :: '' = 0x4
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{typingrule-binopliterals-bits}{\typingtests/TypingRule.BinopLiterals.bits.asl}
 
 \ExampleDef{String and Enumeration Label Operations}
 \listingref{binary-operations-stringslabels} shows applications
@@ -718,18 +618,7 @@ followed by the resulting console output.
   {binary-operations-stringslabels}
   {\typingtests/TypingRule.BinopLiterals.strings_labels.asl}
 
-% CONSOLE_BEGIN aslref \typingtests/TypingRule.BinopLiterals.strings_labels.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-eq_string: "hello" == "world" = FALSE
-eq_string: "hello" == "hello" = TRUE
-ne_string: "hello" != "world" = TRUE
-eq_enum: RED == RED = TRUE
-eq_enum: RED == GREEN = FALSE
-ne_enum: RED != RED = FALSE
-ne_enum: RED != GREEN = TRUE
-concat_string: 0 ++ '1' ++ 2.0 ++ TRUE ++ "foo" ++ RED = 00x12TRUEfooRED
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{typingrule-binopliterals-strings-labels}{\typingtests/TypingRule.BinopLiterals.strings_labels.asl}
 
 \ExampleDef{String Concatenation}
 String concatenation operates over singular types, first converting them to strings using $\literaltostring$.

--- a/asllib/doc/Semantics.tex
+++ b/asllib/doc/Semantics.tex
@@ -598,23 +598,7 @@ To assist reliable translation of ASL to other representations that may not spec
 \listingref{evaluation-order} shows examples of the constructs above, followed by output to the console from running the specification.
 \textbf{Note:} the ordering for slicing expressions may, at first glance, seem not to follow the evaluation order specification; this is because some forms of slice are elaborated during typechecking (see \TypingRuleRef{Slice}).
 \ASLListing{Evaluation order}{evaluation-order}{\definitiontests/EvaluationOrder.asl}
-% CONSOLE_BEGIN aslref \definitiontests/EvaluationOrder.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-Function calls:
-1234
-Tuples:
-12
-Non-short-circuiting binary operations:
-123
-Array-indexing:
-1
-2
-Record construction:
-12
-Print statements:
-12341234
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{evaluationorder}{\definitiontests/EvaluationOrder.asl}
 
 \ExampleDef{Evaluation Order and Parenthesis}
 
@@ -631,13 +615,7 @@ across all three statements, due to ASL's defined evaluation order.
 In particular, each line prints \verb|123| when executed.
 
 \ASLListing{Evaluation order and parenthesis}{evaluation-order-and-parenthesis}{\definitiontests/EvaluationOrderAndParenthesis.asl}
-% CONSOLE_BEGIN aslref \definitiontests/EvaluationOrderAndParenthesis.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-123
-123
-123
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{evaluationorderandparenthesis}{\definitiontests/EvaluationOrderAndParenthesis.asl}
 
 \section{Semantics of Diverging Specifications\label{sec:Semantics of Diverging Specifications}}
 While typical specifications are intended to always terminate,

--- a/asllib/doc/SemanticsUtilities.tex
+++ b/asllib/doc/SemanticsUtilities.tex
@@ -72,13 +72,7 @@ and the local storage element \verb|exn| is removed after the (only) \trystateme
 
 \ASLListing{Removing local storage elements from dynamic environments}{RemoveLocal}{\semanticstests/SemanticsRule.RemoveLocal.asl}
 The output to the console is the following:
-% CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.RemoveLocal.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-i=0
-i=11/2
-exn=TRUE
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{semanticsrule-removelocal}{\semanticstests/SemanticsRule.RemoveLocal.asl}
 
 \RenderProseAndFormally{remove_local}
 
@@ -161,23 +155,14 @@ The specification in \listingref{ReadFromBitvector} shows examples of reading sl
 and reading slices from an integer (first converted to a bitvector), followed by the output to the console.
 
 \ASLListing{Reading from a bitvector}{ReadFromBitvector}{\semanticstests/SemanticsRule.ReadFromBitvector.asl}
-% CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.ReadFromBitvector.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-empty_bv_slice = 0x, empty_i_slice = 0x
-slice_bv = 0x9c5, slice_i = 0x9c5
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{semanticsrule-readfrombitvector}{\semanticstests/SemanticsRule.ReadFromBitvector.asl}
 
 \ExampleDef{Conversion of Integers to Bitvectors}
 The specification in \listingref{AsBitvector} shows an example of converting a negative
 integer into a bitvector, followed by the output to the console.
 
 \ASLListing{Converting a signed integer into a bitvector}{AsBitvector}{\semanticstests/SemanticsRule.AsBitvector.asl}
-% CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.AsBitvector.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-bv = 0xfdf0, bv_i = 0xfdf0
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{semanticsrule-asbitvector}{\semanticstests/SemanticsRule.AsBitvector.asl}
 
 \RenderProseAndFormally{read_from_bitvector}
 

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -836,12 +836,7 @@ condition an expression satisfies.
 and the output to a console when it is evaluated.
 
 \ASLListing{A side-effecting case discriminant}{case-discriminant}{\definitiontests/CaseStatement.discriminant.asl}
-% CONSOLE_BEGIN aslref \definitiontests/CaseStatement.discriminant.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-num_tests: 0
-selected case x=51
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{casestatement-discriminant}{\definitiontests/CaseStatement.discriminant.asl}
 \listingref{case-discriminant} shows an example of a \casestatementterm{}
 and the output to a console when it is evaluated.
 %
@@ -887,12 +882,7 @@ It is not a static error if it can be statically determined that none of the pat
 \listingref{case-otherwise} demonstrates how the \otherwisecaseterm{} is evaluated.
 
 \ASLListing{Executing the \texttt{otherwise} case alternative}{case-otherwise}{\definitiontests/CaseStatement.otherwise.asl}
-% CONSOLE_BEGIN aslref \definitiontests/CaseStatement.otherwise.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-num_tests: 0
-selected otherwise
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{casestatement-otherwise}{\definitiontests/CaseStatement.otherwise.asl}
 
 \RequirementDef{CaseNoOtherwiseError} If no \casealternativeterm\ is selected,
 and there is no \otherwisecaseterm, it is a \dynamicerrorterm{}.
@@ -1375,14 +1365,7 @@ limit expressions.
 \ExampleDef{Evaluation of While Statements}
 The specification in \listingref{semantics-swhile} prints the
 following to the console:
-% CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.SWhile.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-i = 0
-i = 1
-i = 2
-i = 3
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{semanticsrule-swhile}{\semanticstests/SemanticsRule.SWhile.asl}
 
 The specification in \listingref{swhile-limit-reached} yields a dynamic
 error once the loop limit for the \whilestatementterm{} is reached.
@@ -1494,22 +1477,7 @@ The \repeatstatementsterm{} in \listingref{semantics-srepeat} are well-typed.
 \SemanticsRuleDef{SRepeat}
 \ExampleDef{Evaluation of Repeat Statements}
 The specification in \listingref{semantics-srepeat} produces the following output to the console.
-% CONSOLE_BEGIN aslref  --type-check-no-warn \semanticstests/SemanticsRule.SRepeat.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-j = 0
-j = 1
-j = 2
-j = 3
-j = 4
-#ones in x = 5
-i = 0
-i = 1
-i = 2
-i = 3
-i = 4
-#ones in x = 5
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor[--type-check-no-warn]{semanticsrule-srepeat}{\semanticstests/SemanticsRule.SRepeat.asl}
 
 
 \RenderProseAndFormally{eval_stmt_SRepeat}
@@ -1630,22 +1598,7 @@ statement.
 \pagebreak % To avoid cutting the example output.
 \ExampleDef{Evaluation of For Statements}
 The specification in \listingref{semantics-sfor} is followed by its output to the console.
-% CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.SFor.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-j = 0
-j = 1
-j = 2
-j = 3
-j = 4
-#ones in x = 5
-i = 4
-i = 3
-i = 2
-i = 1
-i = 0
-#ones in x = 5
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{semanticsrule-sfor}{\semanticstests/SemanticsRule.SFor.asl}
 
 The specification in \listingref{SFor-nop} shows a \forstatementterm{}
 whose body does not evaluate since its lower bound is greater than its upper bound.
@@ -1886,7 +1839,7 @@ In \listingref{semantics-sreturntuple},
 \SemanticsRuleDef{EExprListM}
 \RenderRelation{eval_expr_list_m}
 
-\ExampleDef{Seperately Evaluating a List of Expressions}
+\ExampleDef{Separately Evaluating a List of Expressions}
 In \listingref{semantics-sreturntuple}, the expressions \verb|3| and \verb|42|
 are evaluated in left-to-right order in the statement \verb|return (3 , 42);|.
 
@@ -1958,23 +1911,7 @@ empty \executiongraphterm{}.
 \listingref{semantics-literals} shows examples of printing various types of literals,
 followed by the output to the console resulting from running the specification.
 \ASLListing{Literals and how they are displayed}{semantics-literals}{\semanticstests/SemanticsRule.SPrint.asl}
-% CONSOLE_BEGIN aslref \semanticstests/SemanticsRule.SPrint.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-string_number_1
-0
-1000000
-53170898287292728730499578000
-TRUE
-FALSE
-12345678900123456789/10000000000
-0
-hello\world
-	 "here I am "
-0xd
-0x
-LABEL_B
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{semanticsrule-sprint}{\semanticstests/SemanticsRule.SPrint.asl}
 
 Notice that empty bitvectors are displayed as \verb|0x|.
 

--- a/asllib/doc/Statements.tex
+++ b/asllib/doc/Statements.tex
@@ -1477,7 +1477,7 @@ The \repeatstatementsterm{} in \listingref{semantics-srepeat} are well-typed.
 \SemanticsRuleDef{SRepeat}
 \ExampleDef{Evaluation of Repeat Statements}
 The specification in \listingref{semantics-srepeat} produces the following output to the console.
-\RenderConsoleFor[--type-check-no-warn]{semanticsrule-srepeat}{\semanticstests/SemanticsRule.SRepeat.asl}
+\RenderConsoleFor[type-check-no-warn]{semanticsrule-srepeat}{\semanticstests/SemanticsRule.SRepeat.asl}
 
 
 \RenderProseAndFormally{eval_stmt_SRepeat}

--- a/asllib/doc/Types.tex
+++ b/asllib/doc/Types.tex
@@ -563,11 +563,7 @@ constrained (\verb|bits(N)|, \verb|bits(i)|, and \verb|bits(N-i)|),
 and related operations,
 followed by the output to the console.
 \ASLListing{Rotating a bitvector}{bits-rotate}{\definitiontests/Bitvector_rotate.asl}
-% CONSOLE_BEGIN aslref \definitiontests/Bitvector_rotate.asl
-\begin{Verbatim}[fontsize=\footnotesize, frame=single]
-bv=0x14, rotated twice=0x05
-\end{Verbatim}
-% CONSOLE_END
+\RenderConsoleFor{bitvector-rotate}{\definitiontests/Bitvector_rotate.asl}
 
 \subsection{Syntax}
 \begin{flalign*}

--- a/asllib/doc/dictionary.txt
+++ b/asllib/doc/dictionary.txt
@@ -556,6 +556,7 @@ current
 currently
 custom
 customers
+cutting
 cycle
 cyclic
 data
@@ -745,6 +746,7 @@ encounters
 end
 endian
 ending
+ends
 enforce
 enforced
 england
@@ -798,12 +800,14 @@ event
 every
 exact
 exactly
+examined
 examining
 example
 examples
 exceed
 exceeded
 exceeding
+exceeds
 except
 exception
 exceptional
@@ -830,11 +834,13 @@ existent
 existing
 exists
 exit
+exits
 expand
 expanded
 expanding
 expands
 expansion
+expectations
 expected
 expecting
 expects
@@ -1000,6 +1006,7 @@ groups
 guarantee
 guaranteed
 guarantees
+guard
 guards
 guideline
 guidelines
@@ -1010,6 +1017,7 @@ handled
 handles
 handling
 hands
+happen
 happens
 hardware
 has
@@ -1455,6 +1463,7 @@ numeral
 numerator
 numeric
 numerous
+obey
 obeys
 object
 observable
@@ -1493,6 +1502,7 @@ operational
 operations
 operator
 operators
+opposite
 optimisation
 optimised
 option
@@ -1615,6 +1625,7 @@ positive
 possibility
 possible
 possibly
+postcondition
 potential
 potentially
 power
@@ -1628,6 +1639,7 @@ preceding
 precise
 precisely
 precision
+precondition
 predicate
 predicates
 predictability
@@ -1732,6 +1744,7 @@ re
 re-reading
 reachable
 reached
+reaching
 read
 readability
 readable
@@ -1857,6 +1870,7 @@ respect
 respected
 respective
 respectively
+response
 responsible
 rest
 restore
@@ -1931,6 +1945,7 @@ see
 seem
 seems
 seen
+selected
 selecting
 selection
 selectors
@@ -2054,6 +2069,7 @@ stand
 standard
 stands
 start
+started
 starting
 starts
 state
@@ -2069,9 +2085,11 @@ stay
 step
 steps
 still
+stopping
 storage
 store
 stored
+storing
 strictly
 string
 strings
@@ -2175,6 +2193,7 @@ terminals
 terminate
 terminates
 terminating
+termination
 terms
 test
 tested
@@ -2253,6 +2272,7 @@ translated
 translates
 translating
 translation
+transliterates
 transliteration
 traversing
 treat

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -23,6 +23,11 @@ cli_parser.add_argument(
     action="store_true",
 )
 cli_parser.add_argument(
+    "--console-macros-only",
+    help=argparse.SUPPRESS,
+    action="store_true",
+)
+cli_parser.add_argument(
     "-d",
     "--dictionary",
     help="Specifies reference dictionary file for spellchecking",
@@ -897,7 +902,7 @@ def spellcheck(reference_dictionary_path: str, latex_files: list[str]) -> int:
         r"\\SyntacticSugarRef{.*?}",
         r"\\ConventionDef{.*?}",
         r"\\AllApplyCase{.*?}",
-        r"\% CONSOLE_BEGIN.*\% CONSOLE_END",
+        r"\\RenderConsoleFor(?:\[.*?\])?{.*?}{.*?}",
         r"\\hypertarget{.*?}",
         r"\\texthypertarget{.*?}",
         r"\\mathhypertarget{.*?}",
@@ -1751,9 +1756,11 @@ def check_per_file(latex_files: list[str], checks):
 def main():
     start_time = time.time()
     args = cli_parser.parse_args()
-    if args.console_macros:
+    if args.console_macros or args.console_macros_only:
         aslref_path = args.aslref if args.aslref else "aslref"
         apply_console_macros(aslref_path)
+        if args.console_macros_only:
+            return
     print("Linting files...")
     all_latex_sources = get_latex_sources(False)
     content_latex_sources = get_latex_sources(True)

--- a/asllib/doc/doclint.py
+++ b/asllib/doc/doclint.py
@@ -934,7 +934,7 @@ def spellcheck(reference_dictionary_path: str, latex_files: list[str]) -> int:
     ]
     extract_patterns = [
         # Patterns for extracting words from specific macros:
-        r"\\ASLListing\{(.*?)\}\{.*?\}\{.*?\}",
+        r"\\ASLListing\{(.*?)\}\s*\{.*?\}\s*\{.*?\}",
         r"\\hyperlink{.*?}{(.*?)}",
     ]
     num_errors = 0

--- a/asllib/doc/extended_macros.py
+++ b/asllib/doc/extended_macros.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 import os, fnmatch, subprocess, shlex, shutil
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import re
 
@@ -22,28 +21,27 @@ def get_latex_sources(exclude) -> list[str]:
     If 'exclude' is True, common files that are not required
     for transformation and linting are excluded.
     """
-    latex_files = fnmatch.filter(os.listdir("."), "*.tex")
+    latex_files = sorted(fnmatch.filter(os.listdir("."), "*.tex"))
     if exclude:
         excluded_files = [
             "ASLReference.tex",
             "ASLmacros.tex",
+            "generated_console_macros.tex",
             "generated_macros.tex",
             "variable_name_macros.tex",
         ]
         for excluded_file in excluded_files:
-            latex_files.remove(excluded_file)
+            if excluded_file in latex_files:
+                latex_files.remove(excluded_file)
     return latex_files
 
 
-def execute_and_capture_output(command: str, error_expected: bool) -> str:
+def execute_and_capture_output(args: list[str], error_expected: bool) -> str:
     r"""
     Executes `command` and returns the output in a string.
     """
-    args = shlex.split(command)
     if not args:
-        raise ValueError(f"Missing command after CONSOLE_BEGIN!")
-    if "aslref" not in args[0]:
-        raise ValueError(f"Command {command} does not refer to aslref!")
+        raise ValueError("Missing aslref command")
     try:
         if error_expected:
             subprocess_result = subprocess.run(
@@ -54,238 +52,149 @@ def execute_and_capture_output(command: str, error_expected: bool) -> str:
             output = subprocess.check_output(args, text=True)
         return output
     except Exception as e:
-        print(yellow_error_message(f"Error: failed executing {command}! Aborting run"))
+        print(
+            yellow_error_message(
+                f"Error: failed executing {shlex.join(args)}! Aborting run"
+            )
+        )
         raise e
 
 
-@dataclass
-class Block:
-    r"""
-    Represents the range of lines in a source file
-    given by the (0-indexed) slice `[begin : end + 1]`.
-    """
-
-    begin: int
-    end: int
-
-
-def find_marked_blocks(lines: list[str], begin_marker: str, end_marker: str) -> list[Block]:
-    begin_lines = []
-    end_lines = []
-    for line_number, line in enumerate(lines):
-        if begin_marker in line:
-            begin_lines.append(line_number)
-        if end_marker in line:
-            end_lines.append(line_number)
-    if len(begin_lines) != len(end_lines):
-        error_message = (
-            f"there are {len(begin_lines)} occurrences of {begin_marker}"
-            f" and {len(end_lines)} occurrences of {end_marker}! Aborting."
-        )
-        raise ValueError(error_message)
-    blocks: list[Block] = []
-    for begin_line_number, end_line_number in zip(begin_lines, end_lines):
-        if begin_line_number >= end_line_number:
-            raise ValueError(f"{begin_marker} must appear before {end_marker}!")
-        blocks.append(Block(begin_line_number, end_line_number))
-    return blocks
+GENERATED_CONSOLE_MACROS = "generated_console_macros.tex"
+# HeVeA cannot consume SaveVerbatim blocks. Generate the same output as plain
+# text files for the \VerbatimInput fallback in \RenderConsoleFor.
+GENERATED_CONSOLE_OUTPUT_DIR = "generated_console_output"
+CONSOLE_INVOCATION_RE = re.compile(
+    r"^\s*\\RenderConsoleFor(?:\[([^]]*)\])?"
+    r"\{([A-Za-z][A-Za-z0-9-]*)\}\{([^{}]+)\}\s*$"
+)
+TEST_PATH_REPLACEMENTS = {
+    r"\definitiontests": "../tests/ASLDefinition.t",
+    r"\syntaxtests": "../tests/ASLSyntaxReference.t",
+    r"\typingtests": "../tests/ASLTypingReference.t",
+    r"\semanticstests": "../tests/ASLSemanticsReference.t",
+}
 
 
-class BlockMacro(ABC):
-    r"""
-    Represents a transformation to blocks (line ranges).
-    """
+@dataclass(frozen=True)
+class ConsoleInvocation:
+    identifier: str
+    test_path: str
+    aslref_options: tuple[str, ...]
+    expect_error: bool
+    show_command: bool
 
-    @abstractmethod
-    def find_blocks(cls, lines: list[str]) -> list[Block]:
-        r"""
-        Returns the blocks within `lines` that this macro should transform.
-        """
-        pass
 
-    @abstractmethod
-    def transform(cls, block_lines: list[str]) -> list[str]:
-        r"""
-        Transforms `block_lines` into another list of lines.
-        """
-        pass
-
-    @classmethod
-    def extend_to_all_blocks(
-        cls, blocks_to_transform: list[Block], num_lines
-    ) -> list[tuple[Block, bool]]:
-        r"""
-        Adds the blocks that should not be transformed between
-        `blocks_to_transform`. The output is a list of pairs, each consisting
-        of a block and a Boolean value signifying whether the block should be
-        transformed or not.
-        The blocks in the output list should partition the list of lines in a
-        given file.
-        """
-        assert blocks_to_transform
-        all_blocks: list[Block] = []
-        last_end_line = 0
-        for block in blocks_to_transform:
-            if block.begin > last_end_line:
-                all_blocks.append((Block(last_end_line, block.begin - 1), False))
-            all_blocks.append((block, True))
-            last_end_line = block.end + 1
-        # Append any lines after the last block to transform.
-        if last_end_line < num_lines:
-            all_blocks.append((Block(last_end_line, num_lines - 1), False))
-        return all_blocks
-
-    @classmethod
-    def validate_blocks(cls, blocks: list[tuple[Block, bool]], num_lines):
-        r"""
-        Ensures that the list of blocks form non-overlapping intervals
-        that partition the range (0, num_lines).
-        """
-        last_line_number = -1
-        for block, _ in blocks:
-            assert block.end >= block.begin
-            assert block.begin == last_line_number + 1
-            last_line_number = block.end
-        assert last_line_number == num_lines - 1
-
-    @classmethod
-    def apply_to_file(cls, source: str):
-        lines: list[str] = []
-        with open(source) as file:
-            lines = file.readlines()
-        blocks_to_transform = cls.find_blocks(lines)
-        if not blocks_to_transform:
-            return
-        if debug:
-            print(f"{source}: found {len(blocks_to_transform)} macro instance(s)")
-        all_blocks: list[Block] = cls.extend_to_all_blocks(
-            blocks_to_transform, len(lines)
-        )
-        cls.validate_blocks(all_blocks, len(lines))
-        output_lines: list[str] = []
-        number_of_changes = 0
-        for block, should_transform in all_blocks:
-            original_lines = lines[block.begin : block.end + 1]
-            block_output_lines: list[str] = []
-            if should_transform:
-                block_output_lines = cls.transform(original_lines)
-                # Ensure lines end with a newline character.
-                block_output_lines = [
-                    line + "\n" if not line.endswith("\n") else line
-                    for line in block_output_lines
-                ]
-                if block_output_lines != original_lines:
-                    first_changed_line_number = len(output_lines) + 1
-                    last_changed_line_number = first_changed_line_number + len(
-                        block_output_lines
+def find_console_invocations(sources: list[str]) -> list[ConsoleInvocation]:
+    invocations = []
+    identifiers = {}
+    for source in sources:
+        with open(source, encoding="utf-8") as file:
+            for line_number, line in enumerate(file, start=1):
+                if "\\RenderConsoleFor" not in line:
+                    continue
+                match = CONSOLE_INVOCATION_RE.fullmatch(line.rstrip("\n"))
+                if not match:
+                    raise ValueError(
+                        f"{source}:{line_number}: malformed RenderConsoleFor invocation; "
+                        "the invocation must occupy one line"
                     )
-                    print(
-                        f"{source} lines {first_changed_line_number}-{last_changed_line_number} are new."
-                    )
-                    number_of_changes += 1
-            else:
-                block_output_lines = original_lines
-            output_lines.extend(block_output_lines)
-        if number_of_changes > 0:  # Avoid changing file timestamps
-            with open(source, "w") as file:
-                file.writelines(output_lines)
-
-    @classmethod
-    def apply_to_files(cls, sources):
-        for source in sources:
-            try:
-                cls.apply_to_file(source)
-            except ValueError as e:
-                print(f"Error in ./{source}: ", e)
-
-
-class ConsoleMacro(BlockMacro):
-    r"""
-    A console macro starts with `% CONSOLE_BEGIN <cmd>`
-    and ends with `CONSOLE_END`.
-    The macro executes `<cmd>` and typesets its output.
-    """
-
-    CONSOLE_BEGIN = "CONSOLE_BEGIN"
-    CONSOLE_END = "CONSOLE_END"
-    CONSOLE_STDERR = "CONSOLE_STDERR"
-    CONSOLE_CMD = "CONSOLE_CMD"
-
-    @classmethod
-    def find_blocks(cls, lines: list[str]) -> list[Block]:
-        return find_marked_blocks(lines, cls.CONSOLE_BEGIN, cls.CONSOLE_END)
-
-    @classmethod
-    def transform(cls, block_lines: list[str]) -> list[str]:
-        assert block_lines
-        begin_line: str = block_lines[0]
-        error_expected = cls.CONSOLE_STDERR in begin_line
-        include_cmd = cls.CONSOLE_CMD in begin_line
-        command = begin_line.replace("aslref", ASLREF_EXE)
-
-        command = (
-            begin_line.replace("%", "")
-            .replace(cls.CONSOLE_BEGIN, "")
-            .replace(cls.CONSOLE_STDERR, "")
-            .replace(cls.CONSOLE_CMD, "")
-            .replace("\\definitiontests", "../tests/ASLDefinition.t")
-            .replace("\\syntaxtests", "../tests/ASLSyntaxReference.t")
-            .replace("\\typingtests", "../tests/ASLTypingReference.t")
-            .replace("\\semanticstests", "../tests/ASLSemanticsReference.t")
-            .replace("\n", "")
-            .strip()
-        )
-        # `command`` is potentially included in the LaTeX output (if `CONSOLE_CMD``
-        # appears in the macro).
-        # Since we don't want to include any user-specific paths `command` is used
-        # for inclusion whereas the command with the actual path to aslref is
-        # used in `executable_command`.
-        executable_command = command.replace("aslref", ASLREF_EXE)
-        if debug:
-            print(f"Executing {executable_command}")
-        transformed_lines = execute_and_capture_output(
-            executable_command, error_expected
-        ).splitlines()
-        end_line = block_lines[-1]
-        transformed_lines = (
-            [begin_line, "\\begin{Verbatim}[fontsize=\\footnotesize, frame=single]"]
-            + (["> " + command] if include_cmd else [])
-            + transformed_lines
-            + ["\\end{Verbatim}", end_line]
-        )
-        return transformed_lines
-
-
-def transform_by_line(filenames: list[str], from_pattern: str, to_pattern: str):
-    r"""
-    Performs a line-by-line transformation for all files in 'filenames'.
-    Lines matching 'from_pattern' are transformed using the 'to_pattern'.
-
-    For example, the following substitutes a LaTeX macro:
-    transform_by_line(
-        files,
-        r"All of the following apply \(\\textsc{(.*?)}\)",
-        r"\\AllApplyCase{\1}"
-    )
-    """
-    num_changes = 0
-    for filename in filenames:
-        new_lines: list[str] = []
-        lines: list[str] = []
-        with open(filename, "r", encoding="utf-8") as file:
-            lines = file.readlines()
-        for line_number, line in enumerate(lines, start=1):
-            new_line = re.sub(from_pattern, to_pattern, line)
-            new_lines.append(new_line)
-            if new_line != line:
-                print(
-                    f"{filename} {line_number}: transformed from '{line.strip()}' to '{new_line.strip()}'"
+                option_text, identifier, test_path = match.groups()
+                option_tokens = shlex.split(option_text or "")
+                expect_error = "expect-error" in option_tokens
+                show_command = "show-command" in option_tokens
+                aslref_options = tuple(
+                    option
+                    for option in option_tokens
+                    if option not in {"expect-error", "show-command"}
                 )
-                num_changes += 1
-        with open(filename, "w", encoding="utf-8") as file:
-            file.writelines(new_lines)
-    if num_changes > 0:
-        print(f"Performed {num_changes} line transformations")
+                if identifier in identifiers:
+                    previous_source, previous_line = identifiers[identifier]
+                    raise ValueError(
+                        f"{source}:{line_number}: duplicate console ID {identifier!r}; "
+                        f"first used at {previous_source}:{previous_line}"
+                    )
+                identifiers[identifier] = (source, line_number)
+                invocations.append(
+                    ConsoleInvocation(
+                        identifier,
+                        test_path,
+                        aslref_options,
+                        expect_error,
+                        show_command,
+                    )
+                )
+    return invocations
+
+
+def resolve_test_path(test_path: str) -> str:
+    for latex_macro, directory in TEST_PATH_REPLACEMENTS.items():
+        if test_path.startswith(latex_macro):
+            return directory + test_path[len(latex_macro) :]
+    raise ValueError(f"Unsupported test path {test_path!r}")
+
+
+def make_console_macro(identifier: str, output_lines: list[str]) -> list[str]:
+    r"""Constructs a SaveVerbatim block for one console invocation."""
+    if any(line.strip() == r"\end{SaveVerbatim}" for line in output_lines):
+        raise ValueError(f"Console output for {identifier!r} terminates SaveVerbatim")
+    return [
+        rf"\begin{{SaveVerbatim}}{{console-{identifier}}}",
+        *output_lines,
+        r"\end{SaveVerbatim}",
+        "",
+    ]
+
+
+def render_console_macros(invocations: list[ConsoleInvocation]) -> str:
+    lines = [
+        "% Automatically generated by doclint.py --console_macros. Do not edit.",
+        "",
+        # HeVeA renders the generated plain-text files instead. Hiding these
+        # blocks also prevents it from interpreting verbatim output as TeX.
+        r"\ifhevea",
+        r"\else",
+    ]
+    os.makedirs(GENERATED_CONSOLE_OUTPUT_DIR, exist_ok=True)
+    generated_output_files = set()
+    for invocation in invocations:
+        test_path = resolve_test_path(invocation.test_path)
+        display_args = ["aslref", *invocation.aslref_options, test_path]
+        executable_args = [ASLREF_EXE, *invocation.aslref_options, test_path]
+        if debug:
+            print(f"Executing {shlex.join(executable_args)}")
+        output = execute_and_capture_output(
+            executable_args, invocation.expect_error
+        ).splitlines()
+        output_lines = []
+        if invocation.show_command:
+            output_lines.append("> " + " ".join(display_args))
+        output_lines.extend(output)
+        output_filename = os.path.join(
+            GENERATED_CONSOLE_OUTPUT_DIR, invocation.identifier + ".txt"
+        )
+        write_if_changed(output_filename, "\n".join(output_lines) + "\n")
+        generated_output_files.add(os.path.basename(output_filename))
+        lines.extend(make_console_macro(invocation.identifier, output_lines))
+    for filename in os.listdir(GENERATED_CONSOLE_OUTPUT_DIR):
+        if filename not in generated_output_files:
+            os.remove(os.path.join(GENERATED_CONSOLE_OUTPUT_DIR, filename))
+    lines.append(r"\fi")
+    return "\n".join(lines)
+
+
+def write_if_changed(filename: str, content: str):
+    try:
+        with open(filename, encoding="utf-8") as file:
+            if file.read() == content:
+                return
+    except FileNotFoundError:
+        pass
+    temporary_filename = filename + ".tmp"
+    with open(temporary_filename, "w", encoding="utf-8") as file:
+        file.write(content)
+    os.replace(temporary_filename, filename)
+    print(f"Generated {filename}")
 
 
 def apply_console_macros(aslref_path: str):
@@ -298,28 +207,11 @@ def apply_console_macros(aslref_path: str):
             f"Unable to find aslref in path {aslref_path}. Perhaps you need to build it?"
         )
     ASLREF_EXE = resolved_aslref_path
-    if not os.path.isfile(ASLREF_EXE):
-        raise Exception(
-            f"Unable to find aslref in path {aslref_path}. Perhaps you need to build it?"
-        )
-    else:
-        print(f"Using aslref path {ASLREF_EXE}")
-    print("Extended macros: applying console macros... ")
+    print(f"Using aslref path {ASLREF_EXE}")
+    print("Extended macros: generating console macros... ")
     pruned_latex_sources = get_latex_sources(True)
-    ConsoleMacro.apply_to_files(pruned_latex_sources)
-    transform_by_line(
-        pruned_latex_sources,
-        r"\\AllApplyCase{(.*?)}:",
-        r"\\AllApplyCase{\1}",
-    )
-    transform_by_line(
-        pruned_latex_sources,
-        r"\\AllApply:",
-        r"\\AllApply",
-    )
-    transform_by_line(
-        pruned_latex_sources,
-        r"\\OneApplies:",
-        r"\\OneApplies",
+    invocations = find_console_invocations(pruned_latex_sources)
+    write_if_changed(
+        GENERATED_CONSOLE_MACROS, render_console_macros(invocations)
     )
     print("Extended macros: done")

--- a/asllib/doc/extended_macros.py
+++ b/asllib/doc/extended_macros.py
@@ -4,8 +4,6 @@ import os, fnmatch, subprocess, shlex, shutil
 from dataclasses import dataclass
 import re
 
-ASLREF_EXE: str = "aslref"
-
 debug = False
 
 
@@ -26,7 +24,6 @@ def get_latex_sources(exclude) -> list[str]:
         excluded_files = [
             "ASLReference.tex",
             "ASLmacros.tex",
-            "generated_console_macros.tex",
             "generated_macros.tex",
             "variable_name_macros.tex",
         ]
@@ -60,22 +57,6 @@ def execute_and_capture_output(args: list[str], error_expected: bool) -> str:
         raise e
 
 
-GENERATED_CONSOLE_MACROS = "generated_console_macros.tex"
-# HeVeA cannot consume SaveVerbatim blocks. Generate the same output as plain
-# text files for the \VerbatimInput fallback in \RenderConsoleFor.
-GENERATED_CONSOLE_OUTPUT_DIR = "generated_console_output"
-CONSOLE_INVOCATION_RE = re.compile(
-    r"^\s*\\RenderConsoleFor(?:\[([^]]*)\])?"
-    r"\{([A-Za-z][A-Za-z0-9-]*)\}\{([^{}]+)\}\s*$"
-)
-TEST_PATH_REPLACEMENTS = {
-    r"\definitiontests": "../tests/ASLDefinition.t",
-    r"\syntaxtests": "../tests/ASLSyntaxReference.t",
-    r"\typingtests": "../tests/ASLTypingReference.t",
-    r"\semanticstests": "../tests/ASLSemanticsReference.t",
-}
-
-
 @dataclass(frozen=True)
 class ConsoleInvocation:
     identifier: str
@@ -86,6 +67,14 @@ class ConsoleInvocation:
 
 
 def find_console_invocations(sources: list[str]) -> list[ConsoleInvocation]:
+    aslref_option_keys = {
+        "type-check-no-warn": "--type-check-no-warn",
+    }
+    generator_option_keys = {"expect-error", "show-command"}
+    console_invocation_re = re.compile(
+        r"^\s*\\RenderConsoleFor(?:\[([^]]*)\])?"
+        r"\{([A-Za-z][A-Za-z0-9-]*)\}\{([^{}]+)\}\s*$"
+    )
     invocations = []
     identifiers = {}
     for source in sources:
@@ -93,20 +82,28 @@ def find_console_invocations(sources: list[str]) -> list[ConsoleInvocation]:
             for line_number, line in enumerate(file, start=1):
                 if "\\RenderConsoleFor" not in line:
                     continue
-                match = CONSOLE_INVOCATION_RE.fullmatch(line.rstrip("\n"))
+                match = console_invocation_re.fullmatch(line.rstrip("\n"))
                 if not match:
                     raise ValueError(
                         f"{source}:{line_number}: malformed RenderConsoleFor invocation; "
                         "the invocation must occupy one line"
                     )
                 option_text, identifier, test_path = match.groups()
-                option_tokens = shlex.split(option_text or "")
-                expect_error = "expect-error" in option_tokens
-                show_command = "show-command" in option_tokens
+                option_keys = shlex.split(option_text or "")
+                unknown_option_keys = set(option_keys).difference(
+                    aslref_option_keys, generator_option_keys
+                )
+                if unknown_option_keys:
+                    raise ValueError(
+                        f"{source}:{line_number}: unknown RenderConsoleFor option(s): "
+                        + ", ".join(sorted(unknown_option_keys))
+                    )
+                expect_error = "expect-error" in option_keys
+                show_command = "show-command" in option_keys
                 aslref_options = tuple(
-                    option
-                    for option in option_tokens
-                    if option not in {"expect-error", "show-command"}
+                    aslref_option_keys[option]
+                    for option in option_keys
+                    if option in aslref_option_keys
                 )
                 if identifier in identifiers:
                     previous_source, previous_line = identifiers[identifier]
@@ -128,39 +125,26 @@ def find_console_invocations(sources: list[str]) -> list[ConsoleInvocation]:
 
 
 def resolve_test_path(test_path: str) -> str:
-    for latex_macro, directory in TEST_PATH_REPLACEMENTS.items():
+    test_path_replacements = {
+        r"\definitiontests": "../tests/ASLDefinition.t",
+        r"\syntaxtests": "../tests/ASLSyntaxReference.t",
+        r"\typingtests": "../tests/ASLTypingReference.t",
+        r"\semanticstests": "../tests/ASLSemanticsReference.t",
+    }
+    for latex_macro, directory in test_path_replacements.items():
         if test_path.startswith(latex_macro):
             return directory + test_path[len(latex_macro) :]
     raise ValueError(f"Unsupported test path {test_path!r}")
 
 
-def make_console_macro(identifier: str, output_lines: list[str]) -> list[str]:
-    r"""Constructs a SaveVerbatim block for one console invocation."""
-    if any(line.strip() == r"\end{SaveVerbatim}" for line in output_lines):
-        raise ValueError(f"Console output for {identifier!r} terminates SaveVerbatim")
-    return [
-        rf"\begin{{SaveVerbatim}}{{console-{identifier}}}",
-        *output_lines,
-        r"\end{SaveVerbatim}",
-        "",
-    ]
-
-
-def render_console_macros(invocations: list[ConsoleInvocation]) -> str:
-    lines = [
-        "% Automatically generated by doclint.py --console_macros. Do not edit.",
-        "",
-        # HeVeA renders the generated plain-text files instead. Hiding these
-        # blocks also prevents it from interpreting verbatim output as TeX.
-        r"\ifhevea",
-        r"\else",
-    ]
-    os.makedirs(GENERATED_CONSOLE_OUTPUT_DIR, exist_ok=True)
+def generate_console_outputs(invocations: list[ConsoleInvocation], aslref_exe: str):
+    output_dir = "generated_console_output"
+    os.makedirs(output_dir, exist_ok=True)
     generated_output_files = set()
     for invocation in invocations:
         test_path = resolve_test_path(invocation.test_path)
         display_args = ["aslref", *invocation.aslref_options, test_path]
-        executable_args = [ASLREF_EXE, *invocation.aslref_options, test_path]
+        executable_args = [aslref_exe, *invocation.aslref_options, test_path]
         if debug:
             print(f"Executing {shlex.join(executable_args)}")
         output = execute_and_capture_output(
@@ -171,16 +155,13 @@ def render_console_macros(invocations: list[ConsoleInvocation]) -> str:
             output_lines.append("> " + " ".join(display_args))
         output_lines.extend(output)
         output_filename = os.path.join(
-            GENERATED_CONSOLE_OUTPUT_DIR, invocation.identifier + ".txt"
+            output_dir, invocation.identifier + ".txt"
         )
         write_if_changed(output_filename, "\n".join(output_lines) + "\n")
         generated_output_files.add(os.path.basename(output_filename))
-        lines.extend(make_console_macro(invocation.identifier, output_lines))
-    for filename in os.listdir(GENERATED_CONSOLE_OUTPUT_DIR):
+    for filename in os.listdir(output_dir):
         if filename not in generated_output_files:
-            os.remove(os.path.join(GENERATED_CONSOLE_OUTPUT_DIR, filename))
-    lines.append(r"\fi")
-    return "\n".join(lines)
+            os.remove(os.path.join(output_dir, filename))
 
 
 def write_if_changed(filename: str, content: str):
@@ -190,15 +171,12 @@ def write_if_changed(filename: str, content: str):
                 return
     except FileNotFoundError:
         pass
-    temporary_filename = filename + ".tmp"
-    with open(temporary_filename, "w", encoding="utf-8") as file:
+    with open(filename, "w", encoding="utf-8") as file:
         file.write(content)
-    os.replace(temporary_filename, filename)
     print(f"Generated {filename}")
 
 
 def apply_console_macros(aslref_path: str):
-    global ASLREF_EXE
     resolved_aslref_path = (
         aslref_path if os.path.isfile(aslref_path) else shutil.which(aslref_path)
     )
@@ -206,12 +184,9 @@ def apply_console_macros(aslref_path: str):
         raise Exception(
             f"Unable to find aslref in path {aslref_path}. Perhaps you need to build it?"
         )
-    ASLREF_EXE = resolved_aslref_path
-    print(f"Using aslref path {ASLREF_EXE}")
-    print("Extended macros: generating console macros... ")
+    print(f"Using aslref path {resolved_aslref_path}")
+    print("Extended macros: generating console output... ")
     pruned_latex_sources = get_latex_sources(True)
     invocations = find_console_invocations(pruned_latex_sources)
-    write_if_changed(
-        GENERATED_CONSOLE_MACROS, render_console_macros(invocations)
-    )
+    generate_console_outputs(invocations, resolved_aslref_path)
     print("Extended macros: done")


### PR DESCRIPTION
Previously, console output was spliced directly into `.tex` files by manually running `doclint.py -cm`. Changes to referenced ASL tests could therefore leave the documented output stale. This change generates console output automatically as part of the document build.

Replace inline generated console output with `\RenderConsoleFor`:
* The makefile now regenerates console output automatically during PDF and HTML builds.
* Added HeVeA-compatible output files.
* Migrated existing console examples.
* Fixed bug with multiline `\ASLListing` spellchecking.
* Removed obsolete extended-macro code.
* Fixed HTML ASL Reference builds by using the correct dune build-tree path for `aslref`. Previous attempts to build aslref defaulted to a path that might not exist. `asllib/doc/Makefile` now builds `aslref` automatically.