### PR TITLE
[herd] Add Empty effect generation for async MTE successful tag checks

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -1627,8 +1627,16 @@ module Make
           (fun a_virt ma  ->
              let mm = mop Access.VIR in
              let ft = Some FaultType.AArch64.TagCheck in
+             let noact = M.mk_singleton_es Act.NoAction ii in
              delayed_check_tags a_virt None ma ii
-               (fun ma -> mm ma |> branch)
+               (fun ma ->
+                  let open Precision in
+                  let ma = match C.mte_precision, dir with
+                  | Asynchronous, _
+                  | Asymmetric, Dir.W -> ma >>*== (fun a -> noact >>! a)
+                  | _, _ -> ma in
+                  mm ma |> branch
+                )
                (lift_fault_memtag
                   (mk_fault (Some a_virt) dir an ii ft None) mm dir ii))
 


### PR DESCRIPTION
This pull request adds an empty effect as the resulting "action" following a successful asynchronous MTE tag check. This is in accordance to the Arm ARM saying:

`Empty Effects are generated by instructions where a decision point, represented by a Branching Effect, leads to no further action resulting from that decision. For example, when FEAT_MTE_ASYNC is implemented and Tag Check Faults are reported asynchronously, a successful tag comparison generates an Empty Effect instead of a TagCheck Fault Effect.`

Consider the following litmus test:

```
AArch64 MTE-ASYNC-success-empty
Variant=mte,async
(*
 * The logical tag in X1 matches the allocation tag for x.
 * Under FEAT_MTE_ASYNC this successful tag comparison corresponds to
 * the no-further-action path after the Branching(pred)(color) effect.
 *)
{
  [tag(x)]=:green;
  0:X1=x:green;
}
 P0          ;
 MOV W0,#1   ;
 STR W0,[X1] ;
forall ([x]=1 /\ 0:TFSR_ELx=0 /\ ~fault(P0))
```

Prior to this patch, the branching effect checking the memory tag had no outgoing dependencies. This is not intended behaviour, as a branching effect should represent a change in control flow in the program.

Following this patch, there is an intrinsic control dependency between the branching effect and the (newly added) Empty effect.