### PR TITLE
[INSTALL.md] Provide more instructions on how to build and install herdtools

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,10 +13,6 @@ Then, to get the newest version:
 Source build
 ============
 
-Tools will be installed in PREFIX/bin, and various files in PREFIX/share/herdtools7.
-By default (see Makefile) PREFIX is $HOME.
-You can change PREFIX by editing the Makefile, or by running ``make ...`` as ``make PREFIX=yourprefix ...``.
-
 Requirements
 ------------
 
@@ -27,11 +23,12 @@ Requirements
 - logs
 
 We strongly recommend to have this base software installed through the opam
-package manager.
+package manager. This means an opam switch needs to be prepared before
+installing the dependencies of the project. For example:
 
-    % opam install dune menhir zarith logs
-
-Make sure to run `eval $(opam config env)` to make tools available in your PATH.
+    % opam switch create herdtools7 --empty
+    % eval $(opam config env --switch=herdtool7 --set-switch)
+    % opam install . --deps-only
 
 Notice: Compilation with ocamlbuild is not longer possible
 
@@ -43,7 +40,7 @@ Build
 Testing
 -------
 
-The optionnal dependency `qcheck` can be installed with `opam` as follows:
+The optional dependency `qcheck` can be installed with `opam` as follows:
 
     % opam install qcheck
 
@@ -52,7 +49,15 @@ runs the tests, skipping the ones that necessitate non-available dependencies.
 
     % make test
 
+More information on running more kinds of tests can be found at
+[README-tests.md](README-tests.md)
+
 Install
 -------
 
-    % make install
+Tools will be installed in PREFIX/bin, and various files in PREFIX/share/herdtools7.
+By default (see Makefile) PREFIX is $HOME.
+You can change PREFIX by editing the Makefile, or by explicitly defining it
+when calling `make`, like so:
+
+    % make PREFIX="$HOME/.local/" install

--- a/README-tests.md
+++ b/README-tests.md
@@ -16,6 +16,8 @@
 
 The basic litmus test consists in compiling series of tests. Some series are also executed but not all of them. Tests that are not run by default would take too much time or raise errors.
 
+The litmus tests require the package `qemu-system` in order to run the tests that use kvm mode.
+
   + `make litmus-x86_64-test`, for x86_64. All tests are executed by default.
   + `make litmus-aarch64-test`, for armv8. Some tests are executed some other are not.
       - `make litmus-aarch64-run` to compile and execute the test series that are executed by default.


### PR DESCRIPTION
The instructions on creating the switch and activating it were missing. There's no need for users to explicitly install the dependency packages (and maintain that list) when opam can determine the list using existing metadata.

The explanation on changing PREFIX has been moved to the Install section and now it contains a full command on doing an installation while changing the variable.