### PR TITLE
[litmus] add new tests that record the programs' output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,10 @@ repos:
             )|
 
             # Expected files should be left verbatim.
-            \.expected(-failure)?$
+            \.expected(-failure)?$|
+
+            # cram tests should be left verbatim
+            \.t$
           )
 
     -   id: trailing-whitespace
@@ -45,7 +48,7 @@ repos:
             \.expected(-failure)?$|
 
             # Cram tests may include trailing whitespace.
-            (^|/)run\.t$
+            \.t$
           )
 - repo: https://github.com/arenadotio/pre-commit-ocamlformat
   rev: 0439858f79b3bcb49e757278eb1312e212d7dd4f

--- a/asllib/aslspec/dune-project
+++ b/asllib/aslspec/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.11)
+(lang dune 3.12)
 (name aslspec)
 (using menhir 2.0)
 (cram enable)

--- a/asllib/dune-project
+++ b/asllib/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.11)
+(lang dune 3.12)
 (using menhir 2.0)
 (cram enable)
 

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.11)
+(lang dune 3.12)
 (name herdtools7)
 (using menhir 2.0)
 (cram enable)

--- a/herd/dune
+++ b/herd/dune
@@ -1,6 +1,8 @@
-(dirs :standard \ tests/instructions libdir)
-
 (data_only_dirs libdir)
+
+(subdir
+ tests
+ (data_only_dirs instructions))
 
 (rule
  (copy ../Version.ml Version.ml))

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -22,6 +22,7 @@ depends: [
   "conf-which"
   "logs"
   "conf-python-3" {= "9.0.0" & with-test}
+  "conf-gcc" {with-test}
 ]
 conflicts: ["ocaml-option-bytecode-only"]
 url {

--- a/internal/herd_catalogue_regression_test.ml
+++ b/internal/herd_catalogue_regression_test.ml
@@ -14,7 +14,6 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-module Fun = Base.Fun
 module Option = Base.Option
 
 exception Error of string

--- a/internal/herd_regression_test.ml
+++ b/internal/herd_regression_test.ml
@@ -16,9 +16,6 @@
 
 (** A tool that runs regression tests of herd7, against .expected files. *)
 
-module Fun = Base.Fun
-
-
 (* Flags. *)
 
 type path = string

--- a/internal/lib/base.ml
+++ b/internal/lib/base.ml
@@ -18,30 +18,9 @@
  *  earlier versions of OCaml, or to add extra functionality. *)
 
 module Fun = struct
-  exception Finally_raised of exn
-
-  let negate f =
-    fun a -> not (f a)
-
-  let protect ~finally f =
-    let finally' () =
-      try finally ()
-      with e -> raise (Finally_raised e)
-    in
-    let ret =
-      try
-        f ()
-      with e -> begin
-        finally' () ;
-        raise e
-      end
-    in
-    finally' () ;
-    ret
-
   let open_out_protect f name =
     let out = open_out name in
-    protect ~finally:(fun () -> close_out out) (fun () -> f out)
+    Stdlib.Fun.protect ~finally:(fun () -> close_out out) (fun () -> f out)
 
 end
 

--- a/internal/lib/base.mli
+++ b/internal/lib/base.mli
@@ -18,21 +18,6 @@
  *  earlier versions of OCaml, or to add extra functionality. *)
 
 module Fun : sig
-  (** [Finally_raised e] is raised by [protect ~finally f] if [~finally] raises
-   *  an exception [e], to disambiguate it from exceptions raised by [f].
-   *  If [Finally_raised] is raised, it is either an unexpected exception (e.g.
-   *  [Out_of_memory]), or programmer error. *)
-  exception Finally_raised of exn
-
-  (** [negate f] negates the predicate function [f]. *)
-  val negate : ('a -> bool) -> ('a -> bool)
-
-  (** [protect ~finally f] calls [f], then calls [~finally]. If [f] raises an
-   *  exception [e], it calls [~finally] before re-raising [e]. If [~finally]
-   *  raises an exception [e], [e] is re-raised as [Finally_raised e].
-   *  It is equivalent to [Fun.protect] from OCaml >= 4.08. *)
-  val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
-
   (** [open_out_protect f name] applies f to a channel
    *  to file whose name is [name]. Close the file under
       all circumstances. *)

--- a/internal/lib/command.ml
+++ b/internal/lib/command.ml
@@ -16,7 +16,6 @@
 
 (** Utilities for running commands. *)
 
-module Fun = Base.Fun
 module Option = Base.Option
 
 type error = {

--- a/internal/lib/filesystem.ml
+++ b/internal/lib/filesystem.ml
@@ -47,7 +47,17 @@ let rec remove_recursive path =
       Sys.remove path
   end
 
+(* Seed the PRNG when loading the module. *)
+let () = Random.self_init ()
+
+let temp_name root =
+  let name = Random.bits64 () in
+  Printf.sprintf "%s/%Ld" root name
+
 let new_temp_dir () =
-  let path = ref "" in
-  Command.run ~stdout:(fun c -> path := input_line c) "mktemp" ["-d"] ;
-  !path
+  let rec try_name counter =
+    let name = temp_name (Filename.get_temp_dir_name ()) in
+    try Sys.mkdir name 0o700 ; name
+    with Sys_error _ as e ->
+      if counter >= 10 then raise e else try_name (counter + 1)
+  in try_name 0

--- a/internal/lib/tests/base_test.ml
+++ b/internal/lib/tests/base_test.ml
@@ -17,52 +17,6 @@
 (** Tests for the Base modules. *)
 
 let tests = [
-  "Base.Fun.protect calls both f and finally", (fun () ->
-    let called_f = ref false in
-    let called_finally = ref false in
-
-    Base.Fun.protect
-      ~finally:(fun () -> called_finally := true)
-      (fun () -> called_f := true) ;
-
-    if not !called_f then
-      Test.fail "did not call f" ;
-
-    if not !called_finally then
-      Test.fail "did not call finally"
-  );
-  "Base.Fun.protect calls finally before re-raising exception", (fun () ->
-    let called_finally = ref false in
-
-    let raised_exception =
-      try
-        Base.Fun.protect
-          ~finally:(fun () -> called_finally := true)
-          (fun () -> if true then raise Not_found ; ()) ;
-        false
-      with Not_found -> true
-    in
-
-    if not raised_exception then
-      Test.fail "did not re-raise exception" ;
-
-    if not !called_finally then
-      Test.fail "did not call finally"
-  );
-  "Base.Fun.protect wraps exceptions raised by finally", (fun () ->
-    let raised_exception =
-      try
-        Base.Fun.protect
-          ~finally:(fun () -> raise Not_found)
-          (fun () -> ()) ;
-        false
-      with Base.Fun.Finally_raised Not_found -> true
-    in
-
-    if not raised_exception then
-      Test.fail "did not wrap & re-raise exception" ;
-  );
-
   "Base.List.compare", (fun () ->
     let tests = [
       [], [], 0 ;

--- a/internal/lib/tests/log_test.ml
+++ b/internal/lib/tests/log_test.ml
@@ -16,8 +16,6 @@
 
 (** Tests for the Log module. *)
 
-module Fun = Base.Fun
-
 module LogList = struct
   let compare = Base.List.compare Log.compare
   let to_ocaml_string = Base.List.to_ocaml_string Log.to_ocaml_string

--- a/litmus/tests/AArch64.kvm/A001.t
+++ b/litmus/tests/AArch64.kvm/A001.t
@@ -1,0 +1,26 @@
+Use litmus7 to generate code from a litmus test
+
+  $ TEST="A001"
+  $ mkdir "$TEST"
+  $ litmus7 -set-libdir ../../libdir -o "$TEST" \
+  > -mode std -a 4 -s 1k -r 100 \
+  > "../../../herd/tests/instructions/AArch64.kvm/$TEST.litmus"  \
+  > -mach aarch64
+
+Compile and run the litmus test natively, avoid printing the timing, it's not
+stable
+
+  $ cd "$TEST"
+  $ make > /dev/null
+  $ "./$TEST.exe" | sed '$d'
+  Test A001 Required
+  Histogram (1 states)
+  4000000*>0:X0=1; 0:X2=1;
+  No
+  
+  Witnesses
+  Positive: 0, Negative: 4000000
+  Condition forall (0:X0=0 /\ 0:X2=0) is NOT validated
+  Hash=b4f76ddaf0ec77a089ddb069cb87815f
+  Variant=fatal
+  Observation A001 Never 0 4000000

--- a/litmus/tests/AArch64.kvm/A005.t
+++ b/litmus/tests/AArch64.kvm/A005.t
@@ -1,0 +1,40 @@
+Use litmus7 to generate code from a litmus test
+
+  $ TEST="A005"
+  $ mkdir "$TEST"
+  $ litmus7 -set-libdir ../../libdir -o "$TEST" \
+  > "../../../herd/tests/instructions/AArch64.kvm/$TEST.litmus"  \
+  > -mode std -a 4 -s 1k -r 100 \
+  > -mach aarch64
+
+Compile and run the litmus test natively, avoid printing the timing, it's not
+stable
+
+  $ cd $TEST
+  $ make > /dev/null
+  A005.c:305:83: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
+    305 | :[x3] "=&r" (*out_0_x3),[x2] "=&r" (*out_0_x2),[x0] "=&r" (*out_0_x0),[x4] "=&r" (trashed_x4)
+        |                                                                                   ^
+  A005.c:297:6: note: use constraint modifier "w"
+    297 | "adr %[x4],0b\n"
+        |      ^~~~~
+        |      %w[x4]
+  A005.c:305:83: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
+    305 | :[x3] "=&r" (*out_0_x3),[x2] "=&r" (*out_0_x2),[x0] "=&r" (*out_0_x0),[x4] "=&r" (trashed_x4)
+        |                                                                                   ^
+  A005.c:299:14: note: use constraint modifier "w"
+    299 | "msr elr_el1,%[x4]\n"
+        |              ^~~~~
+        |              %w[x4]
+  2 warnings generated.
+  $ "./$TEST.exe" | sed '$d'
+  Test A005 Required
+  Histogram (1 states)
+  4000000*>0:X0=1; 0:X2=0; 0:X3=1;
+  No
+  
+  Witnesses
+  Positive: 0, Negative: 4000000
+  Condition forall (0:X0=0 /\ 0:X2=1 /\ 0:X3=1) is NOT validated
+  Hash=63fe95c5d285e45a9e941fb36d381f70
+  Observation A005 Never 0 4000000

--- a/litmus/tests/AArch64.kvm/dune
+++ b/litmus/tests/AArch64.kvm/dune
@@ -1,0 +1,7 @@
+(cram
+ (enabled_if
+  (= %{ocaml-config:architecture} "arm64"))
+ (deps
+  %{bin:litmus7}
+  (glob_files %{workspace_root}/herd/tests/instructions/AArch64.kvm/*.litmus)
+  (source_tree %{workspace_root}/litmus/libdir)))

--- a/litmus/tests/AArch64/A04.t
+++ b/litmus/tests/AArch64/A04.t
@@ -1,0 +1,25 @@
+Use litmus7 to generate code from a litmus test
+
+  $ TEST="A04"
+  $ mkdir "$TEST"
+  $ litmus7 -set-libdir ../../libdir -o "$TEST" \
+  > "../../../herd/tests/instructions/AArch64/$TEST.litmus"  \
+  > -mode std -a 4 -s 1k -r 100 \
+  > -mach aarch64
+
+Compile and run the litmus test natively, avoid printing the timing, it's not
+stable
+
+  $ cd "$TEST"
+  $ make > /dev/null
+  $ "./$TEST.exe" | sed '$d'
+  Test A4 Allowed
+  Histogram (1 states)
+  4000000*>0:X0=0;
+  Ok
+  
+  Witnesses
+  Positive: 4000000, Negative: 0
+  Condition exists (0:X0=0) is validated
+  Hash=d64e911ddfaa8df8f0c4d17557b7562d
+  Observation A4 Always 4000000 0

--- a/litmus/tests/AArch64/dune
+++ b/litmus/tests/AArch64/dune
@@ -1,0 +1,7 @@
+(cram
+ (enabled_if
+  (= %{ocaml-config:architecture} "arm64"))
+ (deps
+  %{bin:litmus7}
+  (glob_files %{workspace_root}/herd/tests/instructions/AArch64/*.litmus)
+  (source_tree %{workspace_root}/litmus/libdir)))

--- a/litmus/tests/X86_64/A009.t
+++ b/litmus/tests/X86_64/A009.t
@@ -1,0 +1,26 @@
+Use litmus7 to generate code from a litmus test
+
+  $ TEST="A009"
+  $ mkdir "$TEST"
+  $ litmus7 -set-libdir ../../libdir -o "$TEST" \
+  > "../../../herd/tests/instructions/X86_64/$TEST.litmus"  \
+  > -mode std -a 4 -s 1k -r 100 \
+  > -mach x86_64
+
+Compile and run the litmus test natively, avoid printing the timing, it's not
+stable
+
+  $ cd $TEST
+  $ make > /dev/null
+  $ "./$TEST.exe" | sed '$d'
+  Test A009 Required
+  Histogram (1 states)
+  4000000:>0:rcx=-1;
+  Ok
+  
+  Witnesses
+  Positive: 4000000, Negative: 0
+  Condition forall (0:rcx=-1) is validated
+  Hash=7ca3c35015d75a877ccf509d75062e79
+  Observation A009 Always 4000000 0
+

--- a/litmus/tests/X86_64/dune
+++ b/litmus/tests/X86_64/dune
@@ -1,0 +1,7 @@
+(cram
+ (enabled_if
+  (= %{ocaml-config:architecture} "amd64"))
+ (deps
+  %{bin:litmus7}
+  (glob_files %{workspace_root}/herd/tests/instructions/X86_64/*.litmus)
+  (source_tree %{workspace_root}/litmus/libdir)))

--- a/litmus/tests/cross/AArch64/A04.t
+++ b/litmus/tests/cross/AArch64/A04.t
@@ -1,0 +1,27 @@
+Use litmus7 to generate code from a litmus test
+
+  $ TEST="A04"
+  $ RUNNER='qemu-aarch64'
+  $ GCC='aarch64-linux-gnu-gcc'
+  $ mkdir "$TEST"
+  $ litmus7 -set-libdir ../../../libdir -gcc="$GCC" -o "$TEST" \
+  > "../../../../herd/tests/instructions/AArch64/$TEST.litmus" \
+  > -mode std -a 4 -s 1k -r 100 \
+  > -mach aarch64 -ccopts='-march=armv8-a+lse'
+
+Compile using a cross-compiler and run the litmus test using qemu user mode, natively, avoid printing the timing, it's not
+stable
+
+  $ cd "$TEST"
+  $ make > /dev/null
+  $ $RUNNER -L /usr/aarch64-linux-gnu -- "./$TEST.exe" | sed '$d'
+  Test A4 Allowed
+  Histogram (1 states)
+  4000000*>0:X0=0;
+  Ok
+  
+  Witnesses
+  Positive: 4000000, Negative: 0
+  Condition exists (0:X0=0) is validated
+  Hash=d64e911ddfaa8df8f0c4d17557b7562d
+  Observation A4 Always 4000000 0

--- a/litmus/tests/cross/AArch64/dune
+++ b/litmus/tests/cross/AArch64/dune
@@ -1,0 +1,6 @@
+(cram
+ (alias runtest-cross-aarch64)
+ (deps
+  %{bin:litmus7}
+  (glob_files %{workspace_root}/herd/tests/instructions/AArch64/*.litmus)
+  (source_tree %{workspace_root}/litmus/libdir)))

--- a/litmus/tests/cross/AArch64/dune
+++ b/litmus/tests/cross/AArch64/dune
@@ -1,5 +1,6 @@
 (cram
- (alias runtest-cross-aarch64)
+ (alias runtest-litmus-cross-aarch64)
+ (runtest_alias false)
  (deps
   %{bin:litmus7}
   (glob_files %{workspace_root}/herd/tests/instructions/AArch64/*.litmus)

--- a/litmus/tests/cross/readme.md
+++ b/litmus/tests/cross/readme.md
@@ -1,0 +1,34 @@
+# Cross-architecture tests
+
+These tests are meant to be architecture-independent, but they are intended to
+run under Linux only.
+This is due to the availability of QEMU's user mode, which enables the
+architecture independence in the first place.
+
+# Use cases
+1. User adds new test case
+2. User wants to run tests while developing
+3. Tests are run when opening a PR, the code has been merged upstream, and when there's a release
+
+# Design
+The tests are defined as cram tests, which allows parallelization at the single test level, and helps reduce the amount of ad-hoc code by using dune's infrastructure.
+
+This means the tests can be run in a development loop, in a more targeted way by running `dune build @litmus/tests/cross/AArch64/runtest-litmus-cross-aarch64 -w`.
+The tests are organized by the architecture they test, and they are defined individually in a way that is easy to add new ones.
+This should be possible by duplicating an existing test, changing the name of the test, and running `dune build @runtest-litmus-cross-<arch> --autopromote`
+
+Cross-compiler packaging varies from distribution to distribution, here are some of the packages for distribution, and the command name, if it differs from the package:
+
+AArch64 cross-compiler packages:
+- debian, ubuntu: gcc-aarch64-linux-gnu (aarch64-linux-gnu-gcc)
+- rhel (epel), fedora: gcc-aarch64-linux-gnu (aarch64-linux-gnu-gcc)
+- alpine: gcc-aarch64-none-elf (aarch64-none-elf-gcc)
+
+x86_64 cross-compiler pacakges
+- debian, ubuntu: gcc-x86-64-linux-gnu (x86_64-linux-gnu-gcc)
+- rhel (epel), fedora: gcc-x86_64-linux-gnu (x86_64-linux-gnu-gcc)
+- alpine: gcc-x86_64 (x86_64-elf-gcc)
+
+Thankfully, the big two packaging traditions agree in the name of both the package and commands, so cram tests use these names.
+
+On top of that the packages are available for all the supported architectures, so no gating for them should be needed.


### PR DESCRIPTION
These tests capture the output of the resulting programs to detect
regressions and are meant to run in native architecture that the litmus
tests test. They are also run along the rest of unit tests driven by
dune.

Currently a few tests have been added to demonstrate how these can be
developed into a full suite.

The pre-commit hooks had to be changed to avoid modifying the output
present in the cram test, in both the endline and whitespace checks

Further enhancements for the tests include, adding more parameters to
test, more target architectures.

There's also the addition of cross-architecture tests, using cross-compilers and qemu-user package. These allow running litmus tests on arbitrary architectures, but the dependency setup is more complex. This is why they are not run by default. I've prepared an opam metapackage to submit upstream if we decide to proceed with the approach: https://github.com/ocaml/opam-repository/compare/master...psafont:opam-repository:dev/pau/qemu

The first two commits are code changes I made while inspecting the codebase, and may be dropped if they are too disruptive, I thought there were worthwhile since they show a style I like: they remove code by increasing shared code, and adds unit-tests for the newly shared code to ensure it behaves as expected and won't regress.