### PR TITLE
[herd-www] Simplify build process

### DIFF
--- a/.github/workflows/check-build-www.yml
+++ b/.github/workflows/check-build-www.yml
@@ -40,6 +40,9 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: dune,menhir,zarith,js_of_ocaml,js_of_ocaml-ppx,zarith_stubs_js,logs
+      - name: Install herd-www dependencies
+        working-directory: herd-www
+        run: opam install . --deps-only --yes
       - run: |
           opam exec -- make Version.ml
           opam exec -- dune build tools/cat2html.exe

--- a/herd-www/README.md
+++ b/herd-www/README.md
@@ -12,12 +12,10 @@ Contact: diy-devel@inria.fr
 Compilation and installation
 ============================
 
-Dependencies.
-- ocaml, dune, menhir, js_of_ocaml, js_of_ocaml-ppx, zarith_stubs_js
-
-Install all those with opam!
+Dependencies are declared in `herd-www.opam`. From this directory, use opam to
+solve and install them:
 ```
-% opam install dune menhir js_of_ocaml js_of_ocaml-ppx  zarith_stubs_js
+% opam install . --deps-only
 ```
 
 Build

--- a/herd-www/dune
+++ b/herd-www/dune
@@ -1,30 +1,13 @@
-(copy_files
- (files ../herd/*.{ml,mli}))
-
 (executable
  (name jerd)
  (modes js)
  (optional)
- (libraries herdtools js_of_ocaml zarith_stubs_js)
- (preprocessor_deps
-  (file notwww.awk))
+ (libraries herdtools herd_core js_of_ocaml zarith_stubs_js)
+ (modules jerd webInput webRun)
  (preprocess
   (per_module
    ((pps js_of_ocaml-ppx)
     jerd
-    webInput)
-   ((action
-     (system "awk -f herd-www/notwww.awk %{input-file}"))
-    AArch64ParseTest
-    ParseTest
-    Top_herd)))
+    webInput)))
  (js_of_ocaml
-  (flags --disable genprim))
- (modules_without_implementation
-  AArch64Sig
-  action
-  arch_herd
-  monad
-  sem
-  XXXMem
-  port))
+  (flags --disable genprim)))

--- a/herd-www/herd-www.opam
+++ b/herd-www/herd-www.opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Dependencies for herd-www (web interface for herdtools7)"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: [
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+]
+homepage: "https://developer.arm.com/herd7"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+license: "CECILL-B"
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune"  {>= "3.11.0" }
+  "menhir" {>= "20231231"}
+  "js_of_ocaml" {>= "6.4.0"}
+  "js_of_ocaml-ppx" {>= "6.4.0"}
+  "zarith" {>= "1.13"}
+  "zarith_stubs_js" {>= "v0.17.0"}
+]

--- a/herd-www/jerd.ml
+++ b/herd-www/jerd.ml
@@ -345,7 +345,35 @@ let run_herd bell cat litmus cfg cat_label =
         let bell_model_info = bi
         include Config end) in
 
+  let module SP =
+    Splitter.Make
+      (struct
+        let debug = Config.debug.Debug_herd.lexer
+        let check_rename = Config.check_rename
+      end) in
+
+  (* Standalone (non-AArch64) ASL tests are outside Jerd's supported architectures.
+     AArch64+ASL additionally needs pseudocode assets that are not deployed.
+     See also: https://github.com/herd/herdtools7/pull/1933 *)
+  let check_supported_litmus f =
+    let splitted = SP.split_string f litmus in
+    match splitted.Splitter.arch with
+    | `ASL -> Warn.user_error "ASL architecture is not supported"
+    | _ ->
+        let module TestConf =
+          TestVariant.Make
+            (struct
+              include Config
+              module Opt = Variant
+              let info = splitted.Splitter.info
+            end)
+        in
+        if TestConf.variant Variant.ASL then
+          Warn.user_error "ASL variant is not supported"
+  in
+
   let from_file f =
+    check_supported_litmus f ;
     SymbValue.reset_gensym () ;
     T.from_file f in
 

--- a/herd-www/jerd.ml
+++ b/herd-www/jerd.ml
@@ -17,6 +17,7 @@
 (** Entry point to Herd  *)
 open Js_of_ocaml
 open Printf
+open Herd_core
 open Opts
 open OptNames
 

--- a/herd-www/notwww.awk
+++ b/herd-www/notwww.awk
@@ -1,4 +1,0 @@
-BEGIN { out=1 ; }
-/\(\* END NOTWWW/   { out=1; }
-{ if (out)  { print $0; } else { printf("(* %s *)\n",$0); } }
-/\(\* START NOTWWW/ { out=0; }

--- a/herd-www/webRun.ml
+++ b/herd-www/webRun.ml
@@ -14,6 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
+open Herd_core
 module TR = Top_herd.TestResult
 
 module Make (O : sig

--- a/herd/AArch64ParseTest.ml
+++ b/herd/AArch64ParseTest.ml
@@ -63,13 +63,7 @@ module Make(Conf:RunTest.Config)(ModelConfig:MemCat.Config) = struct
             end
           module X = RunTest.Make (AArch64S) (P) (AArch64M) (Conf)
         end
-(*
- * Markers START/END below are for excluding source
- * when compiling the web interface
- *)
-
         let run =
-(* START NOTWWW *)
           if is_morello then
             let module  AArch64Value = CapabilityValue.Make(ConfMorello) in
             let module X = AArch64Make(AArch64Value) in
@@ -83,7 +77,6 @@ module Make(Conf:RunTest.Config)(ModelConfig:MemCat.Config) = struct
             let module X = AArch64Make(AArch64Value) in
             X.X.run
           else
-(* END NOTWWW *)
             let module AArch64Value = AArch64Value.Make(ConfMorello) in
             let module X = AArch64Make(AArch64Value) in
             X.X.run

--- a/herd/parseTest.ml
+++ b/herd/parseTest.ml
@@ -206,11 +206,9 @@ end) = struct
       | `LISA ->
          let module X = LISAParseTest.Make(Conf)(ModelConfig) in
          X.run dirty ~filename ~contents env splitted
-(* START NOTWWW *)
       | `ASL ->
          let module X = ASLParseTest.Make(Conf)(ModelConfig) in
          X.run dirty ~filename ~contents env splitted
-(* END NOTWWW *)
       | arch -> Warn.fatal "no support for arch '%s'" (Archs.pp arch)
     end else env, None
 


### PR DESCRIPTION
This PR simplifies `herd-www`'s build process: instead of copying and patching Herd sources, Jerd now depends directly on the newly-added `herd_core` Dune library. We also remove the `notwww.awk` preprocessing pass and the corresponding `NOTWWW` markers. This also fixes some jerd-related errors when running `dune build @herd-www/check`.

I don't have the full historical context of the reasons for introducing `notwww.awk` (please chime in if you do), but with Codex's help I've done some archeology and run some experiments to make sure the removal of `notwww.awk` wouldn't introduce any regressions.

Git history suggests that the script began as a workaround for an old `Stdint`/js_of_ocaml build problem (cb980e41f; see 365a55f04). `Stdint` was replaced shortly afterwards (8cd04096a), but the filtering remained and was later extended to hide the specialised Morello, Neon, SVE, and SME pattern matching paths in `herd/AArch64ParseTest.ml`. ASL support was separately excluded from `herd/parseTest.ml` in abc5b4fee; that commit does not record a technical reason.

To better understand the consequences of removing `notwww.awk`, I've tried building `jerd.js` without the `notwww.awk` preprocessing step and running it on all litmus tests in `herd/tests/instructions`, as well as all catalogue tests in scope of `make test`. These are the results:

1. Various tests in `herd/tests/instructions/AArch64.sme` and `herd/tests/instructions/AArch64.sve` fail due to missing js stubs for the `zarith` function `ml_z_to_int64_unsigned`. This problem can be addressed by requiring that herd-www be built with `zarith_stubs_js` v0.17, which does define stubs for that function. In turn, this means requiring OCaml >= 5.1 for herd-www builds (as required by `zarith_stubs_js`).

2. Two ASL tests in `herd/tests/instructions/AArch64.ASL` (`MOVI01.litmus` and `MOVI02.litmus`) fail during lexing: some of the numeric literals used in the tests are too big to fit `js_of_ocaml`'s [ 32-bit representation of `int` ](https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/runtime-representation.html). This issue is unrelated to anything ASL-specific and applies to any litmus test containing big integer literals. It is thus orthogonal to `notwww.awk`.

3. No other test raises failures/exceptions

In light of these results, this PR proposes the following:

- simplify the herd-www build process and remove the `notwww.awk` script;
- set herd-www's minimum version of `zarith_stubs_js` to v0.17 and of OCaml to 5.1, so that SME/SVE tests don't fail due to missing js stubs;
- Add a dedicated `.opam` file for herd-www (cherry-picked from [this PR](https://github.com/herd/herdtools7/pull/1728)), to make herd-www's dependency requirements explicit.

Let me know if this all makes sense.

Note: none of the changes proposed here should affect the functionality of herd-www's deployment at developer.arm.com/herd7, since they do not affect the interface or input/output protocol of `jerd.js`.
