### PR TITLE
[github] Update action versions

### DIFF
--- a/.github/workflows/build-asl-reference.yml
+++ b/.github/workflows/build-asl-reference.yml
@@ -49,7 +49,7 @@ jobs:
         run: opam exec -- make asldoc
 
       - name: Upload PDF
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
          name: ASL Reference Document
          path: asllib/doc/ASLReference.pdf
@@ -82,7 +82,7 @@ jobs:
           opam exec -- make html
 
       - name: Upload HTML
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
          name: ASL Reference Document in HTML
          path: asllib/doc/HTML

--- a/.github/workflows/build-asl-reference.yml
+++ b/.github/workflows/build-asl-reference.yml
@@ -30,7 +30,7 @@ jobs:
           apt-get install -y build-essential m4 gcc libgmp-dev pkg-config python3 bzip2
 
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
@@ -64,7 +64,7 @@ jobs:
           sudo apt-get install -y texlive-bibtex-extra
 
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/check-build-www.yml
+++ b/.github/workflows/check-build-www.yml
@@ -49,7 +49,7 @@ jobs:
           opam exec -- make -C herd-www
       - name: Upload www artifact (manual only)
         if: ${{ inputs.upload_artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: www
           path: |

--- a/.github/workflows/check-build-www.yml
+++ b/.github/workflows/check-build-www.yml
@@ -28,13 +28,13 @@ jobs:
     steps:
       - name: Checkout PR head ref (if provided)
         if: ${{ github.event.inputs.pr_number != '' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.inputs.pr_number }}/head
 
       - name: Checkout default branch
         if: ${{ github.event.inputs.pr_number == '' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml 5
         uses: ocaml/setup-ocaml@v3
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml 5
         uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/check-opam-minimals.yml
+++ b/.github/workflows/check-opam-minimals.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml 4.14
         uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/make-test-all.yml
+++ b/.github/workflows/make-test-all.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v3
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml 5
         uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/make-test-diy.yml
+++ b/.github/workflows/make-test-diy.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/menhir2bnfc.yml
+++ b/.github/workflows/menhir2bnfc.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/run-litmus.yml
+++ b/.github/workflows/run-litmus.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/static-binaries.yml
+++ b/.github/workflows/static-binaries.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag }}
 

--- a/.github/workflows/static-binaries.yml
+++ b/.github/workflows/static-binaries.yml
@@ -53,7 +53,7 @@ jobs:
 
       # NOTE: -set-libdir will need to be passed to various binaries, including `herd7` and `litmus7`
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binaries
           path: |


### PR DESCRIPTION
There are 3 actions in use by the github workflow, the setup-ocaml ones, and two from github ones. While the ocaml one keept updating the versions with the latest node versions, this is not the case for the gihub ones, which consider it a breaking change. This means that in order to use the latest node version, the versions need to be bumped.

Github also decided to deprecate node 20 late last year and will remove the runtime in the coming months. Since the action versions we use only support node 20, we're forced to update the github actions before the runtime is removed.