### PR TITLE
[herd] Supress the variant ConstrainedUnpredictable

### DIFF
--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -39,7 +39,6 @@ module Make
     let kvm = C.variant Variant.VMSA
     let is_branching = kvm && not (C.variant Variant.NoPteBranch)
     let pte2 = kvm && (C.variant Variant.PTE2 || C.variant Variant.ASL)
-    let do_cu = C.variant Variant.ConstrainedUnpredictable
     let self = C.variant Variant.Ifetch
     let pauth1 = C.variant (Variant.PacVersion `PAuth1)
     let pauth2 = C.variant (Variant.PacVersion `PAuth2)
@@ -1273,7 +1272,7 @@ module Make
       let write_mem_atomic sz an anexp ac a v resa ii =
         check_morello_for_write
           (fun a ->
-            ((if do_cu (* If CU allowed, write may succeed whatever the address _a_ is *)
+            ((if false (* Write canot succeed without checking reservation. *)
               then M.unitT () else M.assign a resa)
              >>| check_mixed_write_mem sz an anexp ac a v ii)
             >>! ())
@@ -2185,8 +2184,8 @@ Arguments:
                 match ii.env.lx_sz with
                 | None -> true (* No LoadExcl at all. always fail *)
                 | Some szr ->
-                   (* Some, must fail when size differ and cu is disallowed *)
-                   not (do_cu || MachSize.equal szr sz)
+                   (* Some, must fail when size differ *)
+                   not (MachSize.equal szr sz)
               end in
             M.aarch64_store_conditional must_fail
               (read_reg_ord ResAddr ii)

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -72,9 +72,6 @@ type t =
   | PTE2
 (* Optimise Rf enumeration leading to rmw *)
   | OptRfRMW
-(* Allow some constrained unpredictable, behaviours.
-   AArch64: LDXR / STXR of different size or address may succeed. *)
-  | ConstrainedUnpredictable
 (* Perform experiment *)
   | Exp
 (* Instruction-fetch support (AKA "self-modifying code" mode) *)
@@ -167,7 +164,6 @@ let (mode_variants, arch_variants) : t list * t list =
   | NoPteBranch -> NoPteBranch
   | PTE2 -> PTE2
   | OptRfRMW -> OptRfRMW
-  | ConstrainedUnpredictable -> ConstrainedUnpredictable
   | Exp -> Exp
   | Ifetch -> Ifetch
   | DIC -> DIC
@@ -204,7 +200,7 @@ let (mode_variants, arch_variants) : t list * t list =
         NotWeakPredicated;
         LKMMVersion `lkmmv1; LKMMVersion `lkmmv2;
         CutOff; Morello; Deps; Instances;
-        OptRfRMW; ConstrainedUnpredictable;
+        OptRfRMW;
         Exp; CosOpt; Test; T 0;
         ASL; ASL_AArch64; ASLVersion `ASLv0; ASLVersion `ASLv1;
         S128; Strict; Warn;
@@ -275,7 +271,6 @@ let parse s = match Misc.lowercase s with
 | "noptebranch"|"nobranch" -> Some NoPteBranch
 | "pte2" | "pte-squared" -> Some PTE2
 | "optrfrmw" -> Some OptRfRMW
-| "constrainedunpredictable"|"cu" -> Some ConstrainedUnpredictable
 | "exp" -> Some Exp
 | "ifetch"|"self" -> Some Ifetch
 | "dic" -> None
@@ -385,7 +380,6 @@ let pp = function
   | NoPteBranch -> "NoPteBranch"
   | PTE2 -> "pte-squared"
   | OptRfRMW -> "OptRfRMW"
-  | ConstrainedUnpredictable -> "ConstrainedUnpredictable"
   | Exp -> "exp"
   | Ifetch -> "ifetch"
   | DIC -> "dic"
@@ -470,7 +464,6 @@ let pp = function
   | NoPteBranch -> "Disable branching events between PTE reads and accesses"
   | PTE2 -> "Perform a table walk for each memory access, including page tables"
   | OptRfRMW -> ""
-  | ConstrainedUnpredictable -> ""
   | Exp -> ""
   | Ifetch -> "Enable instruction fetch for self-modifying code"
   | DIC -> "Skip instruction cache invalidation for data to instruction coherence"

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -70,9 +70,6 @@ type t =
   | PTE2
 (* Optimise Rf enumeration leading to rmw *)
   | OptRfRMW
-(* Allow some constrained unpredictable, behaviours.
-   AArch64: LDXR / STXR of different size or address may succeed. *)
-  | ConstrainedUnpredictable
 (* Perform experiment *)
   | Exp
 (* Instruction-fetch support (AKA "self-modifying code" mode) *)


### PR DESCRIPTION
The purpose of this variant was unclear. In practice it was permitting issuing invalid behaviours architecturally speaking. (see https://github.com/herd/herdtools7/pull/1896#issuecomment-4902783917) We thus supress it as a prelude to PR #1896.