### PR TITLE
[herd] Save dot/neato output with a shell redirection

### DIFF
--- a/herd/show.ml
+++ b/herd/show.ml
@@ -72,7 +72,7 @@ module Make(O:PrettyConf.S) = struct
     with_temp_file ~keep:keep_tmp_pdf name_ps @@ fun () ->
     run_cmds
       [
-        sprintf "%s -T%s %s -o %s" generator ext name_dot name_ps;
+        sprintf "%s -T%s %s > %s" generator ext name_dot name_ps;
         sprintf "%s %s" prog name_ps;
       ]
 


### PR DESCRIPTION
Small bug fix: for some reason using the option `-o filename` or `-ofilename` sometimes results into a segfault. Replacing the option with a redirection looks to be a workaround.