### PR TITLE
[catalogue/asl] Fix ASL SVC-ifetch tests

### DIFF
--- a/catalogue/aarch64-faults/cfgs/asl.cfg
+++ b/catalogue/aarch64-faults/cfgs/asl.cfg
@@ -5,5 +5,6 @@ nonames SVC,MP+dmb.st+ctrl-svc.exs1eis0,MP+dmb.st+ctrl-svc.exs1eis1
 nonames 3faults,UDF
 #No??
 nonames SVC-ifetch.exs1eis0,SVC-ifetch.exs1eis1
+nonames SVC-ifetch.dic0idc0-exs1eis0,SVC-ifetch.dic0idc0-exs1eis1
 #Tag fault
 nonames LDRredF


### PR DESCRIPTION
The Makefile target `test.herd-asl.cata.aarch64-faults` that runs as part of `make test-all` contains two failing tests:

```
$ make test.herd-asl.cata.aarch64-faults

Fatal error: Herd returned stderr:
Warning: File "catalogue/aarch64-faults/tests/SVC-ifetch.dic0idc0-exs1eis0.litmus": Label L2 is undefined, yet it is used as constant (User error)
Warning: File "catalogue/aarch64-faults/tests/SVC-ifetch.dic0idc0-exs1eis1.litmus": Label L2 is undefined, yet it is used as constant (User error)
make: *** [test.herd-asl.cata.aarch64-faults] Error 1
```

The failure had been happening silently and thus not detected in CI until recently, after [this commit](https://github.com/herd/herdtools7/commit/3155721d5b167c24b954e9e930c55a43067a5b87) which made it surface.

As I'm not very familiar with the ASL side of things, I've asked Codex to have a go at this. It came up with a fix for the 'label is undefined' error (17fc7ff7fdb6), but even after that the tests keep failing due to missing ASL implementation of SVC:

```
$ make test.herd-asl.cata.aarch64-faults

Fatal error: Herd returned stderr:
Warning: File "catalogue/aarch64-faults/tests/SVC-ifetch.dic0idc0-exs1eis1.litmus": No ASL implemention for instruction SVC #0
Warning: File "catalogue/aarch64-faults/tests/SVC-ifetch.dic0idc0-exs1eis0.litmus": No ASL implemention for instruction SVC #0
make: *** [test.herd-asl.cata.aarch64-faults] Error 1
```

The `catalogue/aarch64-faults/cfg/asl.cfg` file already excludes some other SVC tests, which fail with the same error when run through `herd7`. I take that perhaps these two tests ought to be excluded as well? In any case, I include Codex's label fix in case it is useful.