### PR TITLE
Bump `dune` version

### DIFF
--- a/.github/workflows/make-test-diy.yml
+++ b/.github/workflows/make-test-diy.yml
@@ -24,7 +24,7 @@ jobs:
           - ubuntu-latest
         cfg:
             # Minimal versions: we want to test both ends of the supported space
-          - ocaml-version: "ocaml-base-compiler.4.14.0,dune.3.12.1,zarith.1.13,menhir.20231231,logs.0.7.0"
+          - ocaml-version: "ocaml-base-compiler.4.14.0,dune.3.15.3,zarith.1.13,menhir.20231231,logs.0.7.0"
             job-name: "OCaml v4.14.0"
             dune-cache: "enabled"
 

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -24,7 +24,7 @@ jobs:
           - ubuntu-latest
         cfg:
           # Minimal versions: we want to test both ends of the supported space
-          - ocaml-compiler: "ocaml-base-compiler.4.14.0,dune.3.12.1,zarith.1.13,menhir.20231231,logs.0.7.0"
+          - ocaml-compiler: "ocaml-base-compiler.4.14.0,dune.3.15.3,zarith.1.13,menhir.20231231,logs.0.7.0"
             with-type-check-asl: false
             job-name: "OCaml v4.14.0"
             dune-cache: "enabled"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ Requirements
 ------------
 
 - OCaml (version >= 4.14.0)
-- dune (version >= 3.11.0)
+- dune (version >= 3.14.0)
 - menhir (version >= 20231231)
 - zarith
 - logs

--- a/acl2/asl/aslreftests/dune-project
+++ b/acl2/asl/aslreftests/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.16)
+(lang dune 3.14)
 
 (name acl2test)
 

--- a/asllib/dune-project
+++ b/asllib/dune-project
@@ -19,7 +19,7 @@
  (synopsis "Architecture Specification Language reference implementation")
  (depends
    (ocaml (>= 4.14))
-   dune
+   (dune (>= 3.14))
    (menhir (>= 20231231))
    (zarith (>= 1.13)))
  (depopts

--- a/herd-www/herd-www.opam
+++ b/herd-www/herd-www.opam
@@ -10,7 +10,7 @@ bug-reports: "http://github.com/herd/herdtools7/issues/"
 license: "CECILL-B"
 depends: [
   "ocaml" {>= "5.1.0"}
-  "dune"  {>= "3.11.0" }
+  "dune"  {>= "3.14.0" }
   "menhir" {>= "20231231"}
   "js_of_ocaml" {>= "6.4.0"}
   "js_of_ocaml-ppx" {>= "6.4.0"}

--- a/herdtools7.opam
+++ b/herdtools7.opam
@@ -16,7 +16,7 @@ install: [make "install-herdtools" "PREFIX=%{prefix}%"]
 # @todo Add "build-test" field
 depends: [
   "ocaml" {>= "4.14.0"}
-  "dune"  {>= "3.11.0" }
+  "dune"  {>= "3.14.0" }
   "menhir" {>= "20231231"}
   "zarith" {>= "1.13"}
   "conf-which"


### PR DESCRIPTION
Require 3.14 minimum. In practice, this means getting 3.15.3 from `opam`.

The motivation for this is that `dynamic_include` was introduced in 3.14, which allows dune files to be generated on-the-fly and included without checking in to the source repo - see [these docs](https://dune.readthedocs.io/en/stable/howto/rule-generation.html#using-dynamic-include). This allows for a pattern where e.g.
- test files and their expected outputs are checked in
- `dune runtest` generates a `dune` file on-the-fly, containing a rule for each test + expected output, and each rule runs a test harness to check actual vs. expected outputs
- `dune` functionality such as diffing and promotion work as expected