### PR TITLE
[asl] Fix a divergence between documentation/implementation

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -1360,8 +1360,8 @@ module Make (B : Backend.S) (C : Config) = struct
     (* Continuation in the positive case. *)
     let loop env =
       let loop_desc = ("for loop", body) in
-      bind_maybe_unroll loop_desc undet (eval_block env body) @@ fun env1 ->
       let* next_limit_opt = tick_loop_limit body env limit_opt in
+      bind_maybe_unroll loop_desc undet (eval_block env body) @@ fun env1 ->
       let*| v_step, env2 = step env1 index_name v_start dir in
       eval_for loop_msg undet env2 index_name next_limit_opt v_step dir v_end
         body

--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -1200,8 +1200,8 @@ module Make (B : Backend.S) (C : Config) = struct
             |> Option.some
         in
         let*> env3 =
-          eval_for loop_msg undet env2 index_name limit_opt start_v dir end_v
-            body
+          eval_for ~loc:s loop_msg undet env2 index_name limit_opt start_v dir
+            end_v body
         in
         let env4 = if undet then IEnv.tick_pop env3 else env3 in
         IEnv.remove_local index_name env4
@@ -1341,8 +1341,8 @@ module Make (B : Backend.S) (C : Config) = struct
   (* Evaluation of for loops *)
   (* ----------------------- *)
   (* Begin EvalFor *)
-  and eval_for loop_msg undet env index_name limit_opt v_start dir v_end body :
-      stmt_eval_type =
+  and eval_for ~loc loop_msg undet env index_name limit_opt v_start dir v_end
+      body : stmt_eval_type =
     (* Evaluate the condition: "has the for loop terminated?" *)
     let cond_m =
       let comp_for_dir = match dir with Up -> `LT | Down -> `GT in
@@ -1360,11 +1360,11 @@ module Make (B : Backend.S) (C : Config) = struct
     (* Continuation in the positive case. *)
     let loop env =
       let loop_desc = ("for loop", body) in
-      let* next_limit_opt = tick_loop_limit body env limit_opt in
+      let* next_limit_opt = tick_loop_limit loc env limit_opt in
       bind_maybe_unroll loop_desc undet (eval_block env body) @@ fun env1 ->
       let*| v_step, env2 = step env1 index_name v_start dir in
-      eval_for loop_msg undet env2 index_name next_limit_opt v_step dir v_end
-        body
+      eval_for ~loc loop_msg undet env2 index_name next_limit_opt v_step dir
+        v_end body
     in
     (* Real logic: if the condition holds, we continue to the next
        loop iteration, otherwise we loop. *)

--- a/asllib/tests/loop-limits.t/for-loop-zero.asl
+++ b/asllib/tests/loop-limits.t/for-loop-zero.asl
@@ -1,0 +1,7 @@
+func main() => integer
+begin
+  for index = 0 to 0 looplimit 0 do
+      println "BODY";
+  end;
+  return 0;
+end;

--- a/asllib/tests/loop-limits.t/run.t
+++ b/asllib/tests/loop-limits.t/run.t
@@ -108,9 +108,10 @@ Double loops
 For loops
   $ aslref for-correct.asl
   $ aslref for-incorrect.asl
-  File for-incorrect.asl, line 5, characters 4 to 26:
+  File for-incorrect.asl, line 4, character 2 to line 6, character 6:
+    for i = 1 to n looplimit 10 do
       counter = counter + 1;
-      ^^^^^^^^^^^^^^^^^^^^^^
+    end;
   ASL Dynamic error: loop limit reached.
   [1]
   $ aslref for-exact.asl
@@ -167,8 +168,9 @@ Recursion limits:
   [1]
 
   $ aslref for-loop-zero.asl
-  File for-loop-zero.asl, line 4, characters 6 to 21:
+  File for-loop-zero.asl, line 3, character 2 to line 5, character 6:
+    for index = 0 to 0 looplimit 0 do
         println "BODY";
-        ^^^^^^^^^^^^^^^
+    end;
   ASL Dynamic error: loop limit reached.
   [1]

--- a/asllib/tests/loop-limits.t/run.t
+++ b/asllib/tests/loop-limits.t/run.t
@@ -165,3 +165,10 @@ Recursion limits:
                     ^^^^^^^^^^^^^
   ASL Dynamic error: recursion limit reached.
   [1]
+
+  $ aslref for-loop-zero.asl
+  File for-loop-zero.asl, line 4, characters 6 to 21:
+        println "BODY";
+        ^^^^^^^^^^^^^^^
+  ASL Dynamic error: loop limit reached.
+  [1]


### PR DESCRIPTION
Regarding for-loop limits:
  - Documentation: SemanticsRule.EvalFor ticks the limit before SemanticsRule.EvalForLoop executes the body.
  - Implementation: loop within eval_for seems to execute body then tick loop limit.