### PR TITLE
[aslref] Refacto runner to remove unnecessary indirection

### DIFF
--- a/asllib/Runner.ml
+++ b/asllib/Runner.ml
@@ -75,11 +75,11 @@ let default_args =
     version_eac1 = false;
   }
 
-exception Exit of int
+(** Run ASLRef with the supplied arguments, and returns the exit code from the
+    program.
 
-(** Run ASLRef with the supplied arguments. This function never returns: it
-    raises an [Exit] exception containing ASLRef's exit code. *)
-let run_with (args : args) : unit =
+    @raise Error.ASLException *)
+let run (args : args) : int =
   let parser_config =
     let v0_use_split_chunks = args.v0_use_split_chunks in
     let version_eac1 = args.version_eac1 in
@@ -87,25 +87,10 @@ let run_with (args : args) : unit =
     { v0_use_split_chunks; version_eac1 }
   in
 
-  let or_exit f =
-    if Printexc.backtrace_status () then f ()
-    else
-      match Error.intercept f () with
-      | Ok res -> res
-      | Error e ->
-          let module EP = Error.ErrorPrinter (struct
-            let output_format = args.output_format
-          end) in
-          EP.eprintln e;
-          raise (Exit 1)
-  in
-
   let extra_main =
     match args.opn with
     | None -> []
-    | Some fname ->
-        or_exit @@ fun () ->
-        Builder.from_file ~ast_type:`Opn ~parser_config `ASLv1 fname
+    | Some fname -> Builder.from_file ~ast_type:`Opn ~parser_config `ASLv1 fname
   in
 
   let ast =
@@ -120,7 +105,7 @@ let run_with (args : args) : unit =
       | NormalV0 | NormalV1 -> List.rev_append this_ast ast
       | PatchV1 | PatchV0 -> ASTUtils.patch ~src:ast ~patches:this_ast
     in
-    or_exit @@ fun () -> List.fold_right folder args.files []
+    List.fold_right folder args.files []
   in
 
   let ast = List.rev_append extra_main ast in
@@ -170,7 +155,7 @@ let run_with (args : args) : unit =
       args.use_conflicting_side_effects_extension
   end in
   let module T = Annotate (C) in
-  let typed_ast, static_env = or_exit @@ fun () -> T.type_check_ast ast in
+  let typed_ast, static_env = T.type_check_ast ast in
 
   let () =
     if args.print_serialized_typed then
@@ -204,7 +189,6 @@ let run_with (args : args) : unit =
   let exit_code, used_rules =
     if args.exec then
       let instrumentation = if args.show_rules then true else false in
-      or_exit @@ fun () ->
       let main_name = T.find_main static_env in
       Native.interpret ~instrumentation static_env main_name typed_ast
     else (0, [])
@@ -217,4 +201,15 @@ let run_with (args : args) : unit =
         (pp_print_list ~pp_sep:pp_print_cut Instrumentation.SemanticsRule.pp)
         used_rules
   in
-  raise (Exit exit_code)
+  exit_code
+
+(** Run ASLRef with the supplied arguments, and returns the exit code from the
+    program. Return error code 1 if an ASLException is raised. *)
+let safe_run args : int =
+  try run args
+  with Error.ASLException e ->
+    let module EP = Error.ErrorPrinter (struct
+      let output_format = args.output_format
+    end) in
+    EP.eprintln e;
+    1

--- a/asllib/asllib-www/jaslref.ml
+++ b/asllib/asllib-www/jaslref.ml
@@ -47,15 +47,10 @@ let run_asl code version exec =
       Js_of_ocaml.Sys_js.update_file ~name:"web-input.asl" ~content:_code
   in
 
-  try Runner.run_with argv with
-  | Asllib.Error.ASLException _ ->
-      (* Unreachable due to the use of [or_exit] in Runner.ml:
-         any [ASLException] is intercepted and re-raised as an [Exit]. *)
-      assert false
-  | Runner.Exit code ->
-      if not _exec then Printf.printf "ASL: parse/type-check completed.\n%!"
-      else
-        Printf.printf "ASL: interpretation completed (exit code %n).\n%!" code
+  let code = Runner.safe_run argv in
+  if _exec then
+    Printf.printf "ASL: interpretation completed (exit code %n).\n%!" code
+  else Printf.printf "ASL: parse/type-check completed.\n%!"
 
 (* Expose to JavaScript *)
 let () = Js.Unsafe.global##.runAsl := Js.wrap_callback run_asl

--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -219,7 +219,7 @@ let parse_args () =
   let () =
     if !show_version then
       let () = Printf.printf "aslref version %s\n%!" Version.version in
-      raise (Exit 0)
+      exit 0
   in
 
   let () =
@@ -228,13 +228,17 @@ let parse_args () =
         Printf.eprintf
           "No files supplied! Run `aslref --help` for information on usage.\n"
       in
-      raise (Exit 1)
+      exit 1
   in
 
   args
 
 let () =
-  try
-    let args = parse_args () in
-    run_with args
-  with Exit n -> exit n
+  let args = parse_args () in
+  let exit_code =
+    (* If the user wants to see a backtrace, we do not catch errors and OCaml
+       handle them. OCaml by default does not have backtrace on, so the default
+       behaviour for aslref is [safe_run]. *)
+    if Printexc.backtrace_status () then run args else safe_run args
+  in
+  exit exit_code


### PR DESCRIPTION
Goal is to ease implementation of compliance testsuite in #1946.