### PR TITLE
[herd] Expose GCS effect event sets to cat

### DIFF
--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -134,11 +134,11 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     let ifetch_value_sets = [("Restricted-CMODX",is_cmodx_restricted_value)]
 
     let barrier_sets =
-      do_fold_dmb_dsb
+      fold_barrier
         (fun b k ->
           let tag = pp_barrier_dot b in
           (tag,is_barrier b)::k)
-        ["ISB",is_barrier ISB]
+        []
 
     let cmo_sets =
       DC.fold_op

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -50,6 +50,10 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
       | NExp IFetch -> true
       | NExp (AF|DB|AFDB|Other|GCS)|Exp -> false
 
+    let is_gcs = function
+      | NExp GCS -> true
+      | NExp (AF|DB|AFDB|IFetch|Other)|Exp -> false
+
     let is_barrier b1 b2 = barrier_compare b1 b2 = 0
 
     let is_af = function (* Setting of access flag *)

--- a/herd/ARMArch_herd.ml
+++ b/herd/ARMArch_herd.ml
@@ -85,6 +85,8 @@ module Make (C:Arch_herd.Config) (V:Value.S) =
 
     and is_ifetch_annot _ = false
 
+    and is_gcs _ = false
+
     let nexp_annot = NExp
     let exp_annot = Exp
 

--- a/herd/explicit.ml
+++ b/herd/explicit.ml
@@ -24,6 +24,7 @@ module type S = sig
   val is_explicit_annot : explicit -> bool
   val is_not_explicit_annot : explicit -> bool
   val is_ifetch_annot : explicit -> bool
+  val is_gcs : explicit -> bool
   val pp_explicit : explicit -> string
   val explicit_sets : (string * (explicit -> bool)) list
 end
@@ -36,6 +37,7 @@ module No = struct
   let is_explicit_annot _ = true
   let is_not_explicit_annot _ = false
   let is_ifetch_annot _ = false
+  let is_gcs _ = false
   let pp_explicit _ = ""
   let explicit_sets = []
 end

--- a/herd/explicit.mli
+++ b/herd/explicit.mli
@@ -24,6 +24,7 @@ module type S = sig
   val is_explicit_annot : explicit -> bool
   val is_not_explicit_annot : explicit -> bool
   val is_ifetch_annot : explicit -> bool
+  val is_gcs : explicit -> bool
   val pp_explicit : explicit -> string
   val explicit_sets : (string * (explicit -> bool)) list
 end

--- a/herd/machAction.ml
+++ b/herd/machAction.ml
@@ -302,6 +302,11 @@ end = struct
     | Access _|Barrier _|Commit _
     | Amo _|Fault _|CutOff _|Inv _|CMO _|Arch _|NoAction-> false
 
+  let is_gcs = function
+    | Access (_,A.Location_global _,_,_,exp,_,_) ->
+      A.is_gcs exp
+    | _ -> false
+
   let is_inv = function
     | Inv _ -> true
     | Access _|Amo _|Commit _|Barrier _|Fault _|CutOff _|CMO _|Arch _|NoAction -> false
@@ -562,6 +567,7 @@ end = struct
         A.TLBI.sets
     in
     ("T",is_tag)::
+    ("GCS",is_gcs)::
     ("TLBI",is_inv)::
     ("no-loc", fun a -> Misc.is_none (location_of a))::
     (if kvm then


### PR DESCRIPTION
This PR adds a dedicated `GCS` event set for herd and exposes AArch64 GCS barrier effects to cat files.

  The change:
  - Adds `is_gcs` to the explicit annotation interface.
  - Classifies AArch64 `NExp GCS` annotations as GCS events.
  - Adds the `GCS` set to the generated action sets exposed to cat.
  - Switches AArch64 barrier set generation to include the full barrier fold, exposing `GCSB.DSYNC` via its barrier tag.
