### PR TITLE
Normalize machine-size names for 64-bit and 128-bit values

### DIFF
--- a/diymicro/AArch64_compile.ml
+++ b/diymicro/AArch64_compile.ml
@@ -36,10 +36,10 @@ module TypBase = struct
     | "uint32_t" -> Some (Std (Unsigned, Word))
     | "int64_t" -> Some (Std (Signed, Double))
     | "uint64_t" -> Some (Std (Unsigned, Double))
-    | "int128_t" -> Some (Std (Signed, S128))
-    | "uint128_t" -> Some (Std (Unsigned, S128))
-    | "__int128" -> Some (Std (Signed, S128))
-    | "__uint128" -> Some (Std (Unsigned, S128))
+    | "int128_t" -> Some (Std (Signed, Quad))
+    | "uint128_t" -> Some (Std (Unsigned, Quad))
+    | "__int128" -> Some (Std (Signed, Quad))
+    | "__uint128" -> Some (Std (Unsigned, Quad))
     | _ -> None
 
   let pp = function
@@ -52,8 +52,8 @@ module TypBase = struct
     | Std (Unsigned, Word) -> "uint32_t"
     | Std (Signed, Double) -> "int64_t"
     | Std (Unsigned, Double) -> "uint64_t"
-    | Std (Signed, S128) -> "__int128"
-    | Std (Unsigned, S128) -> "__uint128"
+    | Std (Signed, Quad) -> "__int128"
+    | Std (Unsigned, Quad) -> "__uint128"
     | Pteval -> "pteval_t"
 
   let sign_equal s1 s2 =
@@ -82,7 +82,7 @@ let pseudo l = List.map (fun i -> Instruction i) l
 let vloc =
   let open TypBase in
   match TypBase.default with
-  | Std (_, MachSize.S128) -> V128
+  | Std (_, MachSize.Quad) -> V128
   | Std (_, MachSize.Double) -> V64
   | Int | Std (_, MachSize.Word) -> V32
   | Std (_, (MachSize.Short | MachSize.Byte)) -> V32
@@ -90,11 +90,11 @@ let vloc =
 
 let sz2v =
   let open MachSize in
-  function Byte | Short | Word -> V32 | Double -> V64 | S128 -> V128
+  function Byte | Short | Word -> V32 | Double -> V64 | Quad -> V128
 
 and v2sz =
   let open MachSize in
-  function V128 -> S128 | V64 -> Double | V32 -> Word
+  function V128 -> Quad | V64 -> Double | V32 -> Word
 
 let szloc = v2sz vloc
 let do_movi vdep r (i : int) = I_MOV (vdep, r, K i)
@@ -104,7 +104,7 @@ let mov_mixed sz r i =
   let sz =
     let open MachSize in
     match sz with
-    | S128 -> Double (* MOV C?,#X is not recognized *)
+    | Quad -> Double (* MOV C?,#X is not recognized *)
     | Byte | Short | Word | Double -> sz
   in
   let v = sz2v sz in
@@ -181,7 +181,7 @@ let ldr_mixed r1 r2 sz o =
   | Short -> I_LDRBH (H, r1, r2, idx)
   | Word -> I_LDR (V32, r1, r2, idx)
   | Double -> I_LDR (V64, r1, r2, idx)
-  | S128 -> I_LDR (V128, r1, r2, idx)
+  | Quad -> I_LDR (V128, r1, r2, idx)
 
 let do_ldr v r1 r2 = I_LDR (v, r1, r2, MemExt.Imm (0, Idx))
 let ldg r1 r2 = I_LDG (r1, r2, 0)
@@ -205,7 +205,7 @@ let ldr_mixed_idx v r1 r2 idx sz =
   | Short -> I_LDRBH (H, r1, r2, idx)
   | Word -> I_LDR (V32, r1, r2, idx)
   | Double -> I_LDR (V64, r1, r2, idx)
-  | S128 -> I_LDR (V128, r1, r2, idx)
+  | Quad -> I_LDR (V128, r1, r2, idx)
 
 let str_mixed sz o r1 r2 =
   let idx = MemExt.Imm (o, Idx) in
@@ -215,7 +215,7 @@ let str_mixed sz o r1 r2 =
   | Short -> I_STRBH (H, r1, r2, idx)
   | Word -> I_STR (V32, r1, r2, idx)
   | Double -> I_STR (V64, r1, r2, idx)
-  | S128 -> I_STR (V128, r1, r2, idx)
+  | Quad -> I_STR (V128, r1, r2, idx)
 
 let do_str v r1 r2 = I_STR (v, r1, r2, MemExt.Imm (0, Idx))
 let str = do_str vloc
@@ -235,7 +235,7 @@ let stxr_sz t sz r1 r2 r3 =
   | Short -> I_STXRBH (H, t, r1, r2, r3)
   | Word -> I_STXR (V32, t, r1, r2, r3)
   | Double -> I_STXR (V64, t, r1, r2, r3)
-  | S128 -> I_STXR (V128, t, r1, r2, r3)
+  | Quad -> I_STXR (V128, t, r1, r2, r3)
 
 let ldxr_sz t sz r1 r2 =
   let open MachSize in
@@ -244,7 +244,7 @@ let ldxr_sz t sz r1 r2 =
   | Short -> I_LDARBH (H, t, r1, r2)
   | Word -> I_LDAR (V32, t, r1, r2)
   | Double -> I_LDAR (V64, t, r1, r2)
-  | S128 -> I_LDAR (V128, t, r1, r2)
+  | Quad -> I_LDAR (V128, t, r1, r2)
 
 let sumi_addr_gen tempo st rA o =
   match o with
@@ -261,7 +261,7 @@ let str_mixed_idx sz v r1 r2 idx =
   | Short -> I_STRBH (H, r1, r2, idx)
   | Word -> I_STR (V32, r1, r2, idx)
   | Double -> I_STR (V64, r1, r2, idx)
-  | S128 -> I_STR (V128, r1, r2, idx)
+  | Quad -> I_STR (V128, r1, r2, idx)
 
 let swp_mixed sz a rS rT rN =
   let open MachSize in
@@ -270,7 +270,7 @@ let swp_mixed sz a rS rT rN =
   | Short -> I_SWPBH (H, a, rS, rT, rN)
   | Word -> I_SWP (V32, a, rS, rT, rN)
   | Double -> I_SWP (V64, a, rS, rT, rN)
-  | S128 -> I_SWP (V128, a, rS, rT, rN)
+  | Quad -> I_SWP (V128, a, rS, rT, rN)
 
 let swp a rS rT rN = I_SWP (vloc, a, rS, rT, rN)
 let sctag a rN rM = I_SC (SCTAG, a, rN, rM)
@@ -282,7 +282,7 @@ let cas_mixed sz a rS rT rN =
   | Short -> I_CASBH (H, a, rS, rT, rN)
   | Word -> I_CAS (V32, a, rS, rT, rN)
   | Double -> I_CAS (V64, a, rS, rT, rN)
-  | S128 -> I_CAS (V128, a, rS, rT, rN)
+  | Quad -> I_CAS (V128, a, rS, rT, rN)
 
 let cas a rS rT rN = I_CAS (vloc, a, rS, rT, rN)
 
@@ -293,7 +293,7 @@ let ldop_mixed op sz a rS rT rN =
   | Short -> I_LDOPBH (op, H, a, rS, rT, rN)
   | Word -> I_LDOP (op, V32, a, rS, rT, rN)
   | Double -> I_LDOP (op, V64, a, rS, rT, rN)
-  | S128 -> I_LDOP (op, V128, a, rS, rT, rN)
+  | Quad -> I_LDOP (op, V128, a, rS, rT, rN)
 
 let ldop op a rS rT rN = I_LDOP (op, vloc, a, rS, rT, rN)
 
@@ -304,7 +304,7 @@ let stop_mixed op sz a rS rN =
   | Short -> I_STOPBH (op, H, a, rS, rN)
   | Word -> I_STOP (op, V32, a, rS, rN)
   | Double -> I_STOP (op, V64, a, rS, rN)
-  | S128 -> I_STOP (op, V128, a, rS, rN)
+  | Quad -> I_STOP (op, V128, a, rS, rN)
 
 let stop op a rS rN = I_STOP (op, vloc, a, rS, rN)
 
@@ -315,7 +315,7 @@ let stlr_of_sz sz r1 r2 =
   | Short -> I_STLRBH (H, r1, r2)
   | Word -> I_STLR (V32, r1, r2)
   | Double -> I_STLR (V64, r1, r2)
-  | S128 -> I_STLR (V128, r1, r2)
+  | Quad -> I_STLR (V128, r1, r2)
 
 let do_ldp opt r1 r2 rA = I_LDP (opt, vloc, r1, r2, rA, (0, Idx))
 and do_ldxp opt r1 r2 rA = I_LDXP (vloc, opt, r1, r2, rA)

--- a/diymicro/AArch64_compile.ml
+++ b/diymicro/AArch64_compile.ml
@@ -34,8 +34,8 @@ module TypBase = struct
     | "uint16_t" -> Some (Std (Unsigned, Short))
     | "int32_t" -> Some (Std (Signed, Word))
     | "uint32_t" -> Some (Std (Unsigned, Word))
-    | "int64_t" -> Some (Std (Signed, Quad))
-    | "uint64_t" -> Some (Std (Unsigned, Quad))
+    | "int64_t" -> Some (Std (Signed, Double))
+    | "uint64_t" -> Some (Std (Unsigned, Double))
     | "int128_t" -> Some (Std (Signed, S128))
     | "uint128_t" -> Some (Std (Unsigned, S128))
     | "__int128" -> Some (Std (Signed, S128))
@@ -50,8 +50,8 @@ module TypBase = struct
     | Std (Unsigned, Short) -> "uint16_t"
     | Std (Signed, Word) -> "int32_t"
     | Std (Unsigned, Word) -> "uint32_t"
-    | Std (Signed, Quad) -> "int64_t"
-    | Std (Unsigned, Quad) -> "uint64_t"
+    | Std (Signed, Double) -> "int64_t"
+    | Std (Unsigned, Double) -> "uint64_t"
     | Std (Signed, S128) -> "__int128"
     | Std (Unsigned, S128) -> "__uint128"
     | Pteval -> "pteval_t"
@@ -73,7 +73,7 @@ module TypBase = struct
   let is_default = function Int -> true | _ -> false
   let pteval_t = Pteval
   let is_pteval_t = function Pteval -> true | _ -> false
-  let get_size = function Int -> Word | Std (_, sz) -> sz | Pteval -> Quad
+  let get_size = function Int -> Word | Std (_, sz) -> sz | Pteval -> Double
 end
 
 let nop = "NOP"
@@ -83,18 +83,18 @@ let vloc =
   let open TypBase in
   match TypBase.default with
   | Std (_, MachSize.S128) -> V128
-  | Std (_, MachSize.Quad) -> V64
+  | Std (_, MachSize.Double) -> V64
   | Int | Std (_, MachSize.Word) -> V32
   | Std (_, (MachSize.Short | MachSize.Byte)) -> V32
   | Pteval -> V64
 
 let sz2v =
   let open MachSize in
-  function Byte | Short | Word -> V32 | Quad -> V64 | S128 -> V128
+  function Byte | Short | Word -> V32 | Double -> V64 | S128 -> V128
 
 and v2sz =
   let open MachSize in
-  function V128 -> S128 | V64 -> Quad | V32 -> Word
+  function V128 -> S128 | V64 -> Double | V32 -> Word
 
 let szloc = v2sz vloc
 let do_movi vdep r (i : int) = I_MOV (vdep, r, K i)
@@ -104,8 +104,8 @@ let mov_mixed sz r i =
   let sz =
     let open MachSize in
     match sz with
-    | S128 -> Quad (* MOV C?,#X is not recognized *)
-    | Byte | Short | Word | Quad -> sz
+    | S128 -> Double (* MOV C?,#X is not recognized *)
+    | Byte | Short | Word | Double -> sz
   in
   let v = sz2v sz in
   I_MOV (v, r, i)
@@ -180,7 +180,7 @@ let ldr_mixed r1 r2 sz o =
   | Byte -> I_LDRBH (B, r1, r2, idx)
   | Short -> I_LDRBH (H, r1, r2, idx)
   | Word -> I_LDR (V32, r1, r2, idx)
-  | Quad -> I_LDR (V64, r1, r2, idx)
+  | Double -> I_LDR (V64, r1, r2, idx)
   | S128 -> I_LDR (V128, r1, r2, idx)
 
 let do_ldr v r1 r2 = I_LDR (v, r1, r2, MemExt.Imm (0, Idx))
@@ -204,7 +204,7 @@ let ldr_mixed_idx v r1 r2 idx sz =
   | Byte -> I_LDRBH (B, r1, r2, idx)
   | Short -> I_LDRBH (H, r1, r2, idx)
   | Word -> I_LDR (V32, r1, r2, idx)
-  | Quad -> I_LDR (V64, r1, r2, idx)
+  | Double -> I_LDR (V64, r1, r2, idx)
   | S128 -> I_LDR (V128, r1, r2, idx)
 
 let str_mixed sz o r1 r2 =
@@ -214,7 +214,7 @@ let str_mixed sz o r1 r2 =
   | Byte -> I_STRBH (B, r1, r2, idx)
   | Short -> I_STRBH (H, r1, r2, idx)
   | Word -> I_STR (V32, r1, r2, idx)
-  | Quad -> I_STR (V64, r1, r2, idx)
+  | Double -> I_STR (V64, r1, r2, idx)
   | S128 -> I_STR (V128, r1, r2, idx)
 
 let do_str v r1 r2 = I_STR (v, r1, r2, MemExt.Imm (0, Idx))
@@ -234,7 +234,7 @@ let stxr_sz t sz r1 r2 r3 =
   | Byte -> I_STXRBH (B, t, r1, r2, r3)
   | Short -> I_STXRBH (H, t, r1, r2, r3)
   | Word -> I_STXR (V32, t, r1, r2, r3)
-  | Quad -> I_STXR (V64, t, r1, r2, r3)
+  | Double -> I_STXR (V64, t, r1, r2, r3)
   | S128 -> I_STXR (V128, t, r1, r2, r3)
 
 let ldxr_sz t sz r1 r2 =
@@ -243,7 +243,7 @@ let ldxr_sz t sz r1 r2 =
   | Byte -> I_LDARBH (B, t, r1, r2)
   | Short -> I_LDARBH (H, t, r1, r2)
   | Word -> I_LDAR (V32, t, r1, r2)
-  | Quad -> I_LDAR (V64, t, r1, r2)
+  | Double -> I_LDAR (V64, t, r1, r2)
   | S128 -> I_LDAR (V128, t, r1, r2)
 
 let sumi_addr_gen tempo st rA o =
@@ -260,7 +260,7 @@ let str_mixed_idx sz v r1 r2 idx =
   | Byte -> I_STRBH (B, r1, r2, idx)
   | Short -> I_STRBH (H, r1, r2, idx)
   | Word -> I_STR (V32, r1, r2, idx)
-  | Quad -> I_STR (V64, r1, r2, idx)
+  | Double -> I_STR (V64, r1, r2, idx)
   | S128 -> I_STR (V128, r1, r2, idx)
 
 let swp_mixed sz a rS rT rN =
@@ -269,7 +269,7 @@ let swp_mixed sz a rS rT rN =
   | Byte -> I_SWPBH (B, a, rS, rT, rN)
   | Short -> I_SWPBH (H, a, rS, rT, rN)
   | Word -> I_SWP (V32, a, rS, rT, rN)
-  | Quad -> I_SWP (V64, a, rS, rT, rN)
+  | Double -> I_SWP (V64, a, rS, rT, rN)
   | S128 -> I_SWP (V128, a, rS, rT, rN)
 
 let swp a rS rT rN = I_SWP (vloc, a, rS, rT, rN)
@@ -281,7 +281,7 @@ let cas_mixed sz a rS rT rN =
   | Byte -> I_CASBH (B, a, rS, rT, rN)
   | Short -> I_CASBH (H, a, rS, rT, rN)
   | Word -> I_CAS (V32, a, rS, rT, rN)
-  | Quad -> I_CAS (V64, a, rS, rT, rN)
+  | Double -> I_CAS (V64, a, rS, rT, rN)
   | S128 -> I_CAS (V128, a, rS, rT, rN)
 
 let cas a rS rT rN = I_CAS (vloc, a, rS, rT, rN)
@@ -292,7 +292,7 @@ let ldop_mixed op sz a rS rT rN =
   | Byte -> I_LDOPBH (op, B, a, rS, rT, rN)
   | Short -> I_LDOPBH (op, H, a, rS, rT, rN)
   | Word -> I_LDOP (op, V32, a, rS, rT, rN)
-  | Quad -> I_LDOP (op, V64, a, rS, rT, rN)
+  | Double -> I_LDOP (op, V64, a, rS, rT, rN)
   | S128 -> I_LDOP (op, V128, a, rS, rT, rN)
 
 let ldop op a rS rT rN = I_LDOP (op, vloc, a, rS, rT, rN)
@@ -303,7 +303,7 @@ let stop_mixed op sz a rS rN =
   | Byte -> I_STOPBH (op, B, a, rS, rN)
   | Short -> I_STOPBH (op, H, a, rS, rN)
   | Word -> I_STOP (op, V32, a, rS, rN)
-  | Quad -> I_STOP (op, V64, a, rS, rN)
+  | Double -> I_STOP (op, V64, a, rS, rN)
   | S128 -> I_STOP (op, V128, a, rS, rN)
 
 let stop op a rS rN = I_STOP (op, vloc, a, rS, rN)
@@ -314,7 +314,7 @@ let stlr_of_sz sz r1 r2 =
   | Byte -> I_STLRBH (B, r1, r2)
   | Short -> I_STLRBH (H, r1, r2)
   | Word -> I_STLR (V32, r1, r2)
-  | Quad -> I_STLR (V64, r1, r2)
+  | Double -> I_STLR (V64, r1, r2)
   | S128 -> I_STLR (V128, r1, r2)
 
 let do_ldp opt r1 r2 rA = I_LDP (opt, vloc, r1, r2, rA, (0, Idx))

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -156,7 +156,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     let vloc = let open TypBase in
       let sz = match Cfg.typ with
-      | Std (_,MachSize.S128) -> V128
+      | Std (_,MachSize.Quad) -> V128
       | Std (_,MachSize.Double) -> V64
       | Int |Std (_,MachSize.Word) -> V32
       | Std (_,(MachSize.Short|MachSize.Byte)) -> V32
@@ -169,12 +169,12 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       function
         | Byte|Short|Word -> V32
         | Double -> V64
-        | S128 -> V128
+        | Quad -> V128
 
     and v2sz =
       let open MachSize in
       function
-      | V128 -> S128
+      | V128 -> Quad
       | V64 -> Double
       | V32 -> Word
 
@@ -187,7 +187,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let sz =
         let open MachSize in
         match sz with
-        | S128 -> Double (* MOV C?,#X is not recognized *)
+        | Quad -> Double (* MOV C?,#X is not recognized *)
         | Byte|Short|Word|Double -> sz in
       let v = sz2v sz in I_MOV (v,r,i)
 
@@ -273,7 +273,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short -> I_LDRBH (H,r1,r2,idx)
       | Word -> I_LDR (V32,r1,r2,idx)
       | Double -> I_LDR (V64,r1,r2,idx)
-      | S128 -> I_LDR (V128,r1,r2,idx)
+      | Quad -> I_LDR (V128,r1,r2,idx)
 
     let do_ldr v r1 r2 = I_LDR (v,r1,r2,MemExt.Imm(0,Idx))
     let ldg r1 r2 = I_LDG (r1,r2,0)
@@ -317,7 +317,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short -> I_LDRBH (H,r1,r2,idx)
       | Word -> I_LDR (V32,r1,r2,idx)
       | Double -> I_LDR (V64,r1,r2,idx)
-      | S128 -> I_LDR (V128,r1,r2,idx)
+      | Quad -> I_LDR (V128,r1,r2,idx)
 
     let str_mixed sz o r1 r2 =
       let idx = MemExt.Imm (o,Idx) in
@@ -327,7 +327,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short -> I_STRBH (H,r1,r2,idx)
       | Word -> I_STR (V32,r1,r2,idx)
       | Double -> I_STR (V64,r1,r2,idx)
-      | S128 -> I_STR (V128,r1,r2,idx)
+      | Quad -> I_STR (V128,r1,r2,idx)
 
     let do_str v r1 r2 = I_STR (v,r1,r2,MemExt.Imm (0,Idx))
     let str = do_str vloc
@@ -365,7 +365,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short -> I_STXRBH (H,t,r1,r2,r3)
       | Word -> I_STXR (V32,t,r1,r2,r3)
       | Double -> I_STXR (V64,t,r1,r2,r3)
-      | S128 -> I_STXR (V128,t,r1,r2,r3)
+      | Quad -> I_STXR (V128,t,r1,r2,r3)
 
     let ldxr_sz t sz r1 r2 =
       let open MachSize in
@@ -374,7 +374,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short -> I_LDARBH (H,t,r1,r2)
       | Word -> I_LDAR (V32,t,r1,r2)
       | Double -> I_LDAR (V64,t,r1,r2)
-      | S128 -> I_LDAR (V128,t,r1,r2)
+      | Quad -> I_LDAR (V128,t,r1,r2)
 
     let sumi_addr_gen tempo st rA o = match o with
     | 0 -> rA,[],st
@@ -392,7 +392,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short -> I_STRBH (H,r1,r2,idx)
       | Word -> I_STR (V32,r1,r2,idx)
       | Double -> I_STR (V64,r1,r2,idx)
-      | S128 -> I_STR (V128,r1,r2,idx)
+      | Quad -> I_STR (V128,r1,r2,idx)
 
     let swp_mixed sz a rS rT rN =
       let open MachSize in
@@ -401,7 +401,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short ->  I_SWPBH (H,a,rS,rT,rN)
       | Word ->  I_SWP (V32,a,rS,rT,rN)
       | Double ->  I_SWP (V64,a,rS,rT,rN)
-      | S128 ->  I_SWP (V128,a,rS,rT,rN)
+      | Quad ->  I_SWP (V128,a,rS,rT,rN)
 
     let swp a rS rT rN =  I_SWP (vloc,a,rS,rT,rN)
 
@@ -414,7 +414,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short ->  I_CASBH (H,a,rS,rT,rN)
       | Word ->  I_CAS (V32,a,rS,rT,rN)
       | Double ->  I_CAS (V64,a,rS,rT,rN)
-      | S128 ->  I_CAS (V128,a,rS,rT,rN)
+      | Quad ->  I_CAS (V128,a,rS,rT,rN)
 
     let cas a rS rT rN =  I_CAS (vloc,a,rS,rT,rN)
 
@@ -425,7 +425,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short ->  I_LDOPBH (op,H,a,rS,rT,rN)
       | Word ->  I_LDOP (op,V32,a,rS,rT,rN)
       | Double ->  I_LDOP (op,V64,a,rS,rT,rN)
-      | S128 ->  I_LDOP (op,V128,a,rS,rT,rN)
+      | Quad ->  I_LDOP (op,V128,a,rS,rT,rN)
 
     let ldop op a rS rT rN =  I_LDOP (op,vloc,a,rS,rT,rN)
 
@@ -436,7 +436,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short ->  I_STOPBH (op,H,a,rS,rN)
       | Word ->  I_STOP (op,V32,a,rS,rN)
       | Double ->  I_STOP (op,V64,a,rS,rN)
-      | S128 ->  I_STOP (op,V128,a,rS,rN)
+      | Quad ->  I_STOP (op,V128,a,rS,rN)
 
     let stop op a rS rN =  I_STOP (op,vloc,a,rS,rN)
 
@@ -456,7 +456,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Short -> I_STLRBH (H,r1,r2)
       | Word -> I_STLR (V32,r1,r2)
       | Double -> I_STLR (V64,r1,r2)
-      | S128 -> I_STLR (V128,r1,r2)
+      | Quad -> I_STLR (V128,r1,r2)
 
     let stlr_mixed sz o st r1 r2 =
       let rA,cs_sum,st = sumi_addr st r2 o in
@@ -475,7 +475,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | Short -> I_LDARBH (H,t,r1,rA)
         | Word -> I_LDAR (V32,t,r1,rA)
         | Double -> I_LDAR (V64,t,r1,rA)
-        | S128 -> I_LDAR (V128,t,r1,rA) in
+        | Quad -> I_LDAR (V128,t,r1,rA) in
       cs@[ld],st
 
     let do_ldar_mixed_idx v t sz o st r1 r2 idx =
@@ -488,7 +488,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | Short -> I_LDARBH (H,t,r1,rA)
         | Word -> I_LDAR (V32,t,r1,rA)
         | Double -> I_LDAR (V64,t,r1,rA)
-        | S128 -> I_LDAR (V128,t,r1,rA) in
+        | Quad -> I_LDAR (V128,t,r1,rA) in
       cs1@cs2@[ld],st
 
     let ldar_mixed_idx = do_ldar_mixed_idx vloc
@@ -1310,10 +1310,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     let get_xload = function
       | (Plain None,None) ->ldxr
-      | (Plain Some Capability,None) -> ldxr_sz XX MachSize.S128
+      | (Plain Some Capability,None) -> ldxr_sz XX MachSize.Quad
       | (Plain None,Some (sz,_)) -> ldxr_sz XX sz
       | (Acq None,None)   -> ldaxr
-      | (Acq Some Capability,None) -> ldxr_sz AX MachSize.S128
+      | (Acq Some Capability,None) -> ldxr_sz AX MachSize.Quad
       | (Acq None,Some (sz,_)) -> ldxr_sz AX sz
       | (AcqPc _,_) -> Warn.fatal "AcqPC annotation on xload"
       | (Tag,_)|(CapaTag,_)|(CapaSeal,_) -> Warn.fatal "variant annotation on xload"
@@ -1323,10 +1323,10 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
 
     and get_xstore = function
       | (Plain None,None) -> stxr
-      | (Plain Some Capability,None) -> stxr_sz YY MachSize.S128
+      | (Plain Some Capability,None) -> stxr_sz YY MachSize.Quad
       | (Plain None,Some (sz,_)) -> stxr_sz YY sz
       | (Rel None,None) -> stlxr
-      | (Rel Some Capability,None) -> stxr_sz LY MachSize.S128
+      | (Rel Some Capability,None) -> stxr_sz LY MachSize.Quad
       | (Rel None,Some (sz,_)) -> stxr_sz LY sz
       | (Tag,_)|(CapaTag,_)|(CapaSeal,_) -> Warn.fatal "variant annotation on xstore"
       | a ->
@@ -1680,7 +1680,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     | Code.Tag -> LDG.emit_load
     | Code.CapaTag -> LDCT.emit_load
     | Code.CapaSeal -> fun st p init x ->
-      let r,init,cs,st = emit_load_mixed MachSize.S128 0 st p init x in
+      let r,init,cs,st = emit_load_mixed MachSize.Quad 0 st p init x in
       let cs2 = lift_code [gctype r r] in
       r,init,cs@cs2,st
     | Code.VecReg n ->
@@ -1789,7 +1789,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
           | AcqPc Some Capability
           | Rel Some Capability ->
             assert (Misc.is_none m) ;
-            Some (a,Some (MachSize.S128,0))
+            Some (a,Some (MachSize.Quad,0))
           | _ -> Some (a,m) end in
         (* Compile the node.
            - `regs`, registers
@@ -1853,7 +1853,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             Some r,init,cs,st
         | R,Some (CapaTag,Some _) -> assert false
         | R,Some (CapaSeal,None) ->
-            let r,init,cs,st = emit_load_mixed MachSize.S128 0 st p init loc in
+            let r,init,cs,st = emit_load_mixed MachSize.Quad 0 st p init loc in
             Some r,init,cs@lift_code [gctype r r],st
         | R,Some (CapaSeal,Some _) -> assert false
         | R,Some (Neon n, None) ->
@@ -1974,7 +1974,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             let init,cs,st =
               emit_str_addon
                 st p init rB rA (Some Capability) {e with C.cseal = (Value.to_int e.C.v)} in
-            None,init,csi@cs@lift_code [str_mixed MachSize.S128 0 rB rA],st
+            None,init,csi@cs@lift_code [str_mixed MachSize.Quad 0 rB rA],st
         | W,Some (CapaSeal,Some _) -> assert false
         | W,Some (Neon n, None) ->
            let emit_store = match n with
@@ -2117,7 +2117,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let rW,init,csi,st = mk_emit_mov sz st p init (Value.to_int ew.C.v) in
       let sz = match opt with
       | None -> sz
-      | Some Capability -> assert (Misc.is_none sz) ; Some (MachSize.S128, 0) in
+      | Some Capability -> assert (Misc.is_none sz) ; Some (MachSize.Quad, 0) in
       let init,csi2,st = emit_str_addon st p init rW rA opt ew in
       let cs,st = match sz with
       | None -> [ins a rW rR rA],st
@@ -2143,7 +2143,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let rT,init,csT,st = mk_emit_mov sz st p init (Value.to_int ew.C.v) in
       let sz = match opt with
       | None -> sz
-      | Some Capability -> assert (Misc.is_none sz) ; Some (MachSize.S128, 0) in
+      | Some Capability -> assert (Misc.is_none sz) ; Some (MachSize.Quad, 0) in
       let init,csS2,st = emit_str_addon st p init rS rA opt er in
       let init,csT2,st = emit_str_addon st p init rT rA opt ew in
       let cs,st = match sz with
@@ -2292,7 +2292,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
             | AcqPc Some Capability
             | Rel Some Capability ->
               assert (Misc.is_none m) ;
-              Some (a,Some (MachSize.S128,0))
+              Some (a,Some (MachSize.Quad,0))
             | _ -> Some (a,m) end in
           let regs,inits,cs,st = begin match d,atom with
           | R,None ->
@@ -2348,7 +2348,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               (* TODO: don't waste r2 *)
               let (_,rA),init,cs,st = seal_dp_addr init p loc st rd e.C.dep in
               let rB,st = next_reg st in
-              Some rB,init,cs@lift_code [ldr_mixed rB rA MachSize.S128 0; gctype rB rB],st
+              Some rB,init,cs@lift_code [ldr_mixed rB rA MachSize.Quad 0; gctype rB rB],st
           | R,Some (CapaSeal,Some _) -> assert false
           | R,Some (Neon n,None) ->
               let emit_load_idx = match n with
@@ -2490,7 +2490,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let init,cs,st = emit_str_addon st p init rC rA (Some Capability)
                 {e with C.cseal = (Value.to_int e.C.v)} in
               None,init,
-              csi@csi2@cs@lift_code [str_mixed MachSize.S128 0 rC rB],st
+              csi@csi2@cs@lift_code [str_mixed MachSize.Quad 0 rC rB],st
           | W,Some (CapaSeal,Some _) -> assert false
           | W,Some (Neon n,None) ->
              let emit_store_idx = match n with
@@ -2569,7 +2569,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | AcqPc Some Capability
         | Rel Some Capability ->
           assert (Misc.is_none m) ;
-          Some (a,Some (MachSize.S128,0))
+          Some (a,Some (MachSize.Quad,0))
         | _ -> Some (a,m) end in
       let regs,inits,cs,st = match e.C.dir,e.C.loc with
       | None,_ -> Warn.fatal "TODO"
@@ -2704,7 +2704,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
               let init,cs,st =
                 emit_str_addon
                   st p init r2 rA (Some Capability) {e with C.cseal = (Value.to_int e.C.v)} in
-              None,init,cs2@cs@lift_code [str_mixed MachSize.S128 0 r2 rA],st
+              None,init,cs2@cs@lift_code [str_mixed MachSize.Quad 0 r2 rA],st
           | Some (CapaSeal,Some _) -> assert false
           | Some (Neon n,None) ->
              let rA,init,st = U.next_init st p init loc in

--- a/gen/AArch64Compile_gen.ml
+++ b/gen/AArch64Compile_gen.ml
@@ -157,7 +157,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
     let vloc = let open TypBase in
       let sz = match Cfg.typ with
       | Std (_,MachSize.S128) -> V128
-      | Std (_,MachSize.Quad) -> V64
+      | Std (_,MachSize.Double) -> V64
       | Int |Std (_,MachSize.Word) -> V32
       | Std (_,(MachSize.Short|MachSize.Byte)) -> V32
       | Pteval -> V64 in
@@ -168,14 +168,14 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let open MachSize in
       function
         | Byte|Short|Word -> V32
-        | Quad -> V64
+        | Double -> V64
         | S128 -> V128
 
     and v2sz =
       let open MachSize in
       function
       | V128 -> S128
-      | V64 -> Quad
+      | V64 -> Double
       | V32 -> Word
 
     let szloc = v2sz vloc
@@ -187,8 +187,8 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       let sz =
         let open MachSize in
         match sz with
-        | S128 -> Quad (* MOV C?,#X is not recognized *)
-        | Byte|Short|Word|Quad -> sz in
+        | S128 -> Double (* MOV C?,#X is not recognized *)
+        | Byte|Short|Word|Double -> sz in
       let v = sz2v sz in I_MOV (v,r,i)
 
     let mov_reg_addr r1 r2 =  I_MOV (V64,r1,RV (V64,r2))
@@ -272,7 +272,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_LDRBH (B,r1,r2,idx)
       | Short -> I_LDRBH (H,r1,r2,idx)
       | Word -> I_LDR (V32,r1,r2,idx)
-      | Quad -> I_LDR (V64,r1,r2,idx)
+      | Double -> I_LDR (V64,r1,r2,idx)
       | S128 -> I_LDR (V128,r1,r2,idx)
 
     let do_ldr v r1 r2 = I_LDR (v,r1,r2,MemExt.Imm(0,Idx))
@@ -316,7 +316,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_LDRBH (B,r1,r2,idx)
       | Short -> I_LDRBH (H,r1,r2,idx)
       | Word -> I_LDR (V32,r1,r2,idx)
-      | Quad -> I_LDR (V64,r1,r2,idx)
+      | Double -> I_LDR (V64,r1,r2,idx)
       | S128 -> I_LDR (V128,r1,r2,idx)
 
     let str_mixed sz o r1 r2 =
@@ -326,7 +326,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_STRBH (B,r1,r2,idx)
       | Short -> I_STRBH (H,r1,r2,idx)
       | Word -> I_STR (V32,r1,r2,idx)
-      | Quad -> I_STR (V64,r1,r2,idx)
+      | Double -> I_STR (V64,r1,r2,idx)
       | S128 -> I_STR (V128,r1,r2,idx)
 
     let do_str v r1 r2 = I_STR (v,r1,r2,MemExt.Imm (0,Idx))
@@ -364,7 +364,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_STXRBH (B,t,r1,r2,r3)
       | Short -> I_STXRBH (H,t,r1,r2,r3)
       | Word -> I_STXR (V32,t,r1,r2,r3)
-      | Quad -> I_STXR (V64,t,r1,r2,r3)
+      | Double -> I_STXR (V64,t,r1,r2,r3)
       | S128 -> I_STXR (V128,t,r1,r2,r3)
 
     let ldxr_sz t sz r1 r2 =
@@ -373,7 +373,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_LDARBH (B,t,r1,r2)
       | Short -> I_LDARBH (H,t,r1,r2)
       | Word -> I_LDAR (V32,t,r1,r2)
-      | Quad -> I_LDAR (V64,t,r1,r2)
+      | Double -> I_LDAR (V64,t,r1,r2)
       | S128 -> I_LDAR (V128,t,r1,r2)
 
     let sumi_addr_gen tempo st rA o = match o with
@@ -391,7 +391,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_STRBH (B,r1,r2,idx)
       | Short -> I_STRBH (H,r1,r2,idx)
       | Word -> I_STR (V32,r1,r2,idx)
-      | Quad -> I_STR (V64,r1,r2,idx)
+      | Double -> I_STR (V64,r1,r2,idx)
       | S128 -> I_STR (V128,r1,r2,idx)
 
     let swp_mixed sz a rS rT rN =
@@ -400,7 +400,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_SWPBH (B,a,rS,rT,rN)
       | Short ->  I_SWPBH (H,a,rS,rT,rN)
       | Word ->  I_SWP (V32,a,rS,rT,rN)
-      | Quad ->  I_SWP (V64,a,rS,rT,rN)
+      | Double ->  I_SWP (V64,a,rS,rT,rN)
       | S128 ->  I_SWP (V128,a,rS,rT,rN)
 
     let swp a rS rT rN =  I_SWP (vloc,a,rS,rT,rN)
@@ -413,7 +413,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_CASBH (B,a,rS,rT,rN)
       | Short ->  I_CASBH (H,a,rS,rT,rN)
       | Word ->  I_CAS (V32,a,rS,rT,rN)
-      | Quad ->  I_CAS (V64,a,rS,rT,rN)
+      | Double ->  I_CAS (V64,a,rS,rT,rN)
       | S128 ->  I_CAS (V128,a,rS,rT,rN)
 
     let cas a rS rT rN =  I_CAS (vloc,a,rS,rT,rN)
@@ -424,7 +424,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_LDOPBH (op,B,a,rS,rT,rN)
       | Short ->  I_LDOPBH (op,H,a,rS,rT,rN)
       | Word ->  I_LDOP (op,V32,a,rS,rT,rN)
-      | Quad ->  I_LDOP (op,V64,a,rS,rT,rN)
+      | Double ->  I_LDOP (op,V64,a,rS,rT,rN)
       | S128 ->  I_LDOP (op,V128,a,rS,rT,rN)
 
     let ldop op a rS rT rN =  I_LDOP (op,vloc,a,rS,rT,rN)
@@ -435,7 +435,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte -> I_STOPBH (op,B,a,rS,rN)
       | Short ->  I_STOPBH (op,H,a,rS,rN)
       | Word ->  I_STOP (op,V32,a,rS,rN)
-      | Quad ->  I_STOP (op,V64,a,rS,rN)
+      | Double ->  I_STOP (op,V64,a,rS,rN)
       | S128 ->  I_STOP (op,V128,a,rS,rN)
 
     let stop op a rS rN =  I_STOP (op,vloc,a,rS,rN)
@@ -455,7 +455,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
       | Byte  -> I_STLRBH (B,r1,r2)
       | Short -> I_STLRBH (H,r1,r2)
       | Word -> I_STLR (V32,r1,r2)
-      | Quad -> I_STLR (V64,r1,r2)
+      | Double -> I_STLR (V64,r1,r2)
       | S128 -> I_STLR (V128,r1,r2)
 
     let stlr_mixed sz o st r1 r2 =
@@ -474,7 +474,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | Byte -> I_LDARBH (B,t,r1,rA)
         | Short -> I_LDARBH (H,t,r1,rA)
         | Word -> I_LDAR (V32,t,r1,rA)
-        | Quad -> I_LDAR (V64,t,r1,rA)
+        | Double -> I_LDAR (V64,t,r1,rA)
         | S128 -> I_LDAR (V128,t,r1,rA) in
       cs@[ld],st
 
@@ -487,7 +487,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S =
         | Byte -> I_LDARBH (B,t,r1,rA)
         | Short -> I_LDARBH (H,t,r1,rA)
         | Word -> I_LDAR (V32,t,r1,rA)
-        | Quad -> I_LDAR (V64,t,r1,rA)
+        | Double -> I_LDAR (V64,t,r1,rA)
         | S128 -> I_LDAR (V128,t,r1,rA) in
       cs1@cs2@[ld],st
 

--- a/gen/RISCVCompile_gen.ml
+++ b/gen/RISCVCompile_gen.ml
@@ -56,7 +56,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
       | Std (_,MachSize.Double) -> AV.Double
       | Int |Std (_,(Word|Short|Byte)) -> AV.Word
       | Pteval
-      | Std (_,MachSize.S128) -> assert false
+      | Std (_,MachSize.Quad) -> assert false
 
     let bne r1 r2 lab =  AV.Bcc (AV.NE,r1,r2,lab)
     let cbz r lab = AV.Bcc (AV.EQ,r,zero,lab)
@@ -100,7 +100,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
       | MachSize.Short -> AV.Half
       | MachSize.Word -> AV.Word
       | MachSize.Double -> AV.Double
-      | MachSize.S128 -> assert false
+      | MachSize.Quad -> assert false
 
     let ldr_mixed r1 r2 sz o = AV.Load (tr_sz sz,Signed,AV.Rlx,r1,o,r2)
     and str_mixed r1 r2 sz o = AV.Store (tr_sz sz,AV.Rlx,r1,o,r2)

--- a/gen/RISCVCompile_gen.ml
+++ b/gen/RISCVCompile_gen.ml
@@ -53,7 +53,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
       let open TypBase in
       let open MachSize in
       match Cfg.typ with
-      | Std (_,MachSize.Quad) -> AV.Double
+      | Std (_,MachSize.Double) -> AV.Double
       | Int |Std (_,(Word|Short|Byte)) -> AV.Word
       | Pteval
       | Std (_,MachSize.S128) -> assert false
@@ -99,7 +99,7 @@ module Make(Cfg:Config) : XXXCompile_gen.S  =
       | MachSize.Byte -> AV.Byte
       | MachSize.Short -> AV.Half
       | MachSize.Word -> AV.Word
-      | MachSize.Quad -> AV.Double
+      | MachSize.Double -> AV.Double
       | MachSize.S128 -> assert false
 
     let ldr_mixed r1 r2 sz o = AV.Load (tr_sz sz,Signed,AV.Rlx,r1,o,r2)

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -87,7 +87,7 @@ module Make
         fold_acc (fun acc r -> f (acc,None) r) r
 
       let apply_mix f acc m r = match acc,m with
-      | (NonTemporal,(None|Some ((MachSize.Quad|MachSize.Word),_)))
+      | (NonTemporal,(None|Some ((MachSize.Double|MachSize.Word),_)))
       | ((Plain|Atomic),_) ->
           f (acc,m) r
       |  (NonTemporal,Some ((MachSize.Short|MachSize.Byte),_))

--- a/gen/X86_64Arch_gen.ml
+++ b/gen/X86_64Arch_gen.ml
@@ -92,7 +92,7 @@ module Make
           f (acc,m) r
       |  (NonTemporal,Some ((MachSize.Short|MachSize.Byte),_))
         -> r
-      | (NonTemporal,Some (MachSize.S128,_)) -> assert false
+      | (NonTemporal,Some (MachSize.Quad,_)) -> assert false
 
       let fold_atom f r =
         fold_acc

--- a/gen/X86_64Compile_gen.ml
+++ b/gen/X86_64Compile_gen.ml
@@ -24,7 +24,7 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
     let mach_size =
       let open TypBase in
       match Cfg.typ with
-      | Std (_,Quad) -> Quad
+      | Std (_,Double) -> Double
       | Int | Std (_,Word) -> Word
       | Std (_,Short) -> Short
       | Std (_,Byte) -> Byte
@@ -38,7 +38,7 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
       | Byte -> I8b
       | Short -> I16b
       | Word -> I32b
-      | Quad -> I64b
+      | Double -> I64b
       | S128 -> assert false
 
     let size_to_reg_size =
@@ -47,7 +47,7 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
       | Byte -> R8bL
       | Short -> R16b
       | Word -> R32b
-      | Quad -> R64b
+      | Double -> R64b
       | S128 -> assert false
 
     let size_reg_part = size_to_reg_size mach_size

--- a/gen/X86_64Compile_gen.ml
+++ b/gen/X86_64Compile_gen.ml
@@ -28,7 +28,7 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
       | Int | Std (_,Word) -> Word
       | Std (_,Short) -> Short
       | Std (_,Byte) -> Byte
-      | Std (_,S128) | Pteval
+      | Std (_,Quad) | Pteval
         -> assert false
 
 
@@ -39,7 +39,7 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
       | Short -> I16b
       | Word -> I32b
       | Double -> I64b
-      | S128 -> assert false
+      | Quad -> assert false
 
     let size_to_reg_size =
       let open X86_64Base in
@@ -48,7 +48,7 @@ module Make(Cfg:CompileCommon.Config) : XXXCompile_gen.S =
       | Short -> R16b
       | Word -> R32b
       | Double -> R64b
-      | S128 -> assert false
+      | Quad -> assert false
 
     let size_reg_part = size_to_reg_size mach_size
 

--- a/gen/common/machMixed.ml
+++ b/gen/common/machMixed.ml
@@ -55,7 +55,7 @@ module Make(C:Config)(Value:Value_gen.S) = struct
     let r = do_fold f Short (get_off Short) r in
     let r = do_fold f Word (get_off Word) r in
     let r = do_fold f Double (get_off Double) r in
-    let r = do_fold f S128 (get_off S128) r in
+    let r = do_fold f Quad (get_off Quad) r in
     r
 
   let tr_value sz v =
@@ -67,7 +67,7 @@ module Make(C:Config)(Value:Value_gen.S) = struct
       | Double ->
           let x = do_rec Word v in
           x lsl 32 + x
-      | S128 -> assert false in
+      | Quad -> assert false in
   Value.from_int (do_rec sz v)
 
 
@@ -112,7 +112,7 @@ module Vals(C:ValsConfig)(Value:Value_gen.S) = struct
     let nshift =  o * 8 in
     let mask =
       match sz with
-      | S128 -> assert false
+      | Quad -> assert false
       | Double -> -1
       | _ -> (1 lsl sz_bits) - 1 in
     let r = (v lsr nshift) land mask in

--- a/gen/common/machMixed.ml
+++ b/gen/common/machMixed.ml
@@ -54,7 +54,7 @@ module Make(C:Config)(Value:Value_gen.S) = struct
     let r = do_fold f Byte (get_off Byte) r in
     let r = do_fold f Short (get_off Short) r in
     let r = do_fold f Word (get_off Word) r in
-    let r = do_fold f Quad (get_off Quad) r in
+    let r = do_fold f Double (get_off Double) r in
     let r = do_fold f S128 (get_off S128) r in
     r
 
@@ -64,7 +64,7 @@ module Make(C:Config)(Value:Value_gen.S) = struct
       | Byte -> v
       | Short -> v lsl 8 + v
       | Word ->  v lsl 24 + v lsl 16 + v lsl 8 + v
-      | Quad ->
+      | Double ->
           let x = do_rec Word v in
           x lsl 32 + x
       | S128 -> assert false in
@@ -113,7 +113,7 @@ module Vals(C:ValsConfig)(Value:Value_gen.S) = struct
     let mask =
       match sz with
       | S128 -> assert false
-      | Quad -> -1
+      | Double -> -1
       | _ -> (1 lsl sz_bits) - 1 in
     let r = (v lsr nshift) land mask in
 (*      Printf.eprintf "EXTRACT (%s,%i)[0x%x]: 0x%x -> 0x%x\n"

--- a/gen/common/typBase.ml
+++ b/gen/common/typBase.ml
@@ -40,8 +40,8 @@ let parse s = match s with
 | "uint16_t" -> Some (Std (Unsigned,Short))
 | "int32_t" -> Some (Std (Signed,Word))
 | "uint32_t" -> Some (Std (Unsigned,Word))
-| "int64_t" -> Some (Std (Signed,Quad))
-| "uint64_t" -> Some (Std (Unsigned,Quad))
+| "int64_t" -> Some (Std (Signed,Double))
+| "uint64_t" -> Some (Std (Unsigned,Double))
 | "int128_t" -> Some (Std (Signed,S128))
 | "uint128_t" -> Some (Std (Unsigned,S128))
 | "__int128" -> Some (Std (Signed,S128))
@@ -56,8 +56,8 @@ let pp = function
 | Std (Unsigned,Short) ->  "uint16_t"
 | Std (Signed,Word) ->  "int32_t"
 | Std (Unsigned,Word) ->  "uint32_t"
-| Std (Signed,Quad) ->  "int64_t"
-| Std (Unsigned,Quad) ->  "uint64_t"
+| Std (Signed,Double) ->  "int64_t"
+| Std (Unsigned,Double) ->  "uint64_t"
 | Std (Signed,S128) ->  "__int128"
 | Std (Unsigned,S128) ->  "__uint128"
 | Pteval -> "pteval_t"
@@ -96,4 +96,4 @@ let is_pteval_t = function
 let get_size = function
   | Int -> Word
   | Std (_,sz) -> sz
-  | Pteval -> Quad
+  | Pteval -> Double

--- a/gen/common/typBase.ml
+++ b/gen/common/typBase.ml
@@ -42,10 +42,10 @@ let parse s = match s with
 | "uint32_t" -> Some (Std (Unsigned,Word))
 | "int64_t" -> Some (Std (Signed,Double))
 | "uint64_t" -> Some (Std (Unsigned,Double))
-| "int128_t" -> Some (Std (Signed,S128))
-| "uint128_t" -> Some (Std (Unsigned,S128))
-| "__int128" -> Some (Std (Signed,S128))
-| "__uint128" -> Some (Std (Unsigned,S128))
+| "int128_t" -> Some (Std (Signed,Quad))
+| "uint128_t" -> Some (Std (Unsigned,Quad))
+| "__int128" -> Some (Std (Signed,Quad))
+| "__uint128" -> Some (Std (Unsigned,Quad))
 | _ -> None
 
 let pp = function
@@ -58,8 +58,8 @@ let pp = function
 | Std (Unsigned,Word) ->  "uint32_t"
 | Std (Signed,Double) ->  "int64_t"
 | Std (Unsigned,Double) ->  "uint64_t"
-| Std (Signed,S128) ->  "__int128"
-| Std (Unsigned,S128) ->  "__uint128"
+| Std (Signed,Quad) ->  "__int128"
+| Std (Unsigned,Quad) ->  "__uint128"
 | Pteval -> "pteval_t"
 
 

--- a/gen/top_gen.ml
+++ b/gen/top_gen.ml
@@ -794,7 +794,7 @@ let max_set = IntSet.max_elt
           let globals = C.get_globals ~init:initvals n in
           let typ =
             if do_morello
-            then TypBase.Std (TypBase.Unsigned,MachSize.S128)
+            then TypBase.Std (TypBase.Unsigned,MachSize.Quad)
             else O.typ in
         let typ = Typ typ in
           List.fold_left

--- a/herd/AArch64Arch_herd.ml
+++ b/herd/AArch64Arch_herd.ml
@@ -254,7 +254,7 @@ module Make (C:Arch_herd.Config)(V:Value.AArch64) =
     | Vreg (_,(_,8)) -> MachSize.Byte
     | Vreg (_,(_,16)) -> MachSize.Short
     | Vreg (_,(_,32)) -> MachSize.Word
-    | Vreg (_,(_,64)) -> MachSize.Quad
+    | Vreg (_,(_,64)) -> MachSize.Double
     | _ -> assert false (* Unsupported arrangement specifier *)
 
     let mem_access_size = function

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -108,7 +108,7 @@ module Make
 
     let atomic_pair_allowed _ _ = true
 
-    let quad = MachSize.Quad (* This machine natural size *)
+    let quad = MachSize.Double (* This machine natural size *)
     and aexp = AArch64Explicit.Exp    (* Explicit accesses *)
 
     let tnt2annot =
@@ -197,7 +197,7 @@ module Make
         match ty with
         | V32 -> fun v -> uxtw_op v >>= m
         | V64 when not morello -> m
-        | V64 -> fun v -> uxt_op MachSize.Quad v >>= m
+        | V64 -> fun v -> uxt_op MachSize.Double v >>= m
         | V128 -> m
 
 (*  Promotion/Demotion *)
@@ -286,8 +286,8 @@ module Make
 
       let read_reg_sz port sz r ii = match sz with
       | MachSize.S128 -> read_reg_morello port r ii
-      | MachSize.Quad when not morello -> read_reg port r ii
-      | MachSize.Quad|MachSize.Word|MachSize.Short|MachSize.Byte ->
+      | MachSize.Double when not morello -> read_reg port r ii
+      | MachSize.Double|MachSize.Word|MachSize.Short|MachSize.Byte ->
           read_reg port r ii >>= uxt_op sz
 
       let read_reg_ord = read_reg_sz Port.No quad
@@ -614,8 +614,8 @@ module Make
       | AArch64.ZR -> M.unitT ()
       | _ -> match sz with
         | MachSize.S128 -> write_reg_morello r v ii
-        | MachSize.Quad when not morello -> write_reg r v ii
-        | MachSize.Quad|MachSize.Word|MachSize.Short|MachSize.Byte ->
+        | MachSize.Double when not morello -> write_reg r v ii
+        | MachSize.Double|MachSize.Word|MachSize.Short|MachSize.Byte ->
             mop sz v >>= fun v -> write_reg r v ii
 
       let write_reg_sz = do_write_reg_sz uxt_op
@@ -629,7 +629,7 @@ module Make
         | _ ->
            match sz with
            | MachSize.S128 -> write_reg_morello r v ii
-           | MachSize.Quad|MachSize.Word|MachSize.Short|MachSize.Byte ->
+           | MachSize.Double|MachSize.Word|MachSize.Short|MachSize.Byte ->
               op v >>= fun v -> write_reg r v ii
 
       let write_reg_sz_non_mixed =
@@ -666,7 +666,7 @@ module Make
         | AArch64Base.Vreg(_,(nelem,esize)) -> nelem * esize
         | _ -> assert false in
         match size with
-          | 64 -> MachSize.Quad
+          | 64 -> MachSize.Double
           | 128 -> MachSize.S128
           | _ -> assert false
 
@@ -1844,11 +1844,11 @@ Arguments:
               | UXTB -> Op.Mask  Byte
               | UXTH -> Op.Mask Short
               | UXTW -> Op.Mask Word
-              | UXTX ->  Op.Mask Quad
+              | UXTX ->  Op.Mask Double
               | SXTB -> Op.Sxt  Byte
               | SXTH -> Op.Sxt Short
               | SXTW -> Op.Sxt Word
-              | SXTX ->  Op.Sxt Quad
+              | SXTX ->  Op.Sxt Double
             end
 
 (* Apply a shift as monadic op *)
@@ -1881,7 +1881,7 @@ Arguments:
             read_reg_addr rs ii
         | K k, s -> (* Immediate with offset, with shift *)
             read_reg_addr rs ii
-            >>= fun v -> shift MachSize.Quad s (V.intToV k)
+            >>= fun v -> shift MachSize.Double s (V.intToV k)
             >>= M.add v
         | RV(v,r), S_NOEXT -> (* register, no shift *)
             (read_reg_addr rs ii >>| read_reg_addr_sz (tr_variant v) r ii)
@@ -1953,7 +1953,7 @@ Arguments:
          * then sign extend based on register size (var)
          *)
         let op = match var with
-          | MachSize.Quad -> sxt_op sz
+          | MachSize.Double -> sxt_op sz
           | MachSize.Word ->
              fun v -> sxt_op sz v >>=  uxt_op MachSize.Word
           | _ -> assert false in
@@ -2901,7 +2901,7 @@ Arguments:
         let open AArch64 in
         let nelem = scalable_nbytes / simd_variant_nbytes v in
         let off = predicate_count pat nelem * k in
-        let sz = MachSize.Quad in
+        let sz = MachSize.Double in
         (match op with
          | CNT -> mzero
          | INC -> read_reg_ord_sz sz r ii)
@@ -4283,7 +4283,7 @@ Arguments:
             !(simd_add r1 r2 r3 ii)
         | I_ADD_SIMD_S(r1,r2,r3) ->
             check_neon inst;
-            let sz = MachSize.Quad in
+            let sz = MachSize.Double in
             !(read_reg_neon Port.No r3 ii >>|
               read_reg_neon Port.No r2 ii >>= sum_elems
               >>= fun v -> write_reg_neon_sz sz r1 v ii)
@@ -4557,11 +4557,11 @@ Arguments:
         | I_RDVL (rd,k) ->
            check_sve inst;
            let v = scalable_nbytes * k |> V.intToV in
-           write_reg_sz_dest MachSize.Quad rd v ii
+           write_reg_sz_dest MachSize.Double rd v ii
            >>= nextSet rd
         |I_ADDVL (rd,rn,k) ->
            check_sve inst;
-           let sz = MachSize.Quad in
+           let sz = MachSize.Double in
            let off = scalable_nbytes * k in
            read_reg_ord_sz sz rn ii
            >>= M.op1 (Op.AddK off)
@@ -4779,8 +4779,8 @@ Arguments:
             | GCTAG -> M.op1 Op.CapaGetTag c
             | GCTYPE -> M.op1 (Op.LeftShift 18) c >>= fun v ->
                 M.op1 (Op.LogicalRightShift 113) v
-            | GCVALUE -> M.op1 (Op.Mask MachSize.Quad) c
-            end >>= fun v -> write_reg_sz MachSize.Quad rd v ii)
+            | GCVALUE -> M.op1 (Op.Mask MachSize.Double) c
+            end >>= fun v -> write_reg_sz MachSize.Double rd v ii)
         | I_SC(op,rd,rn,rm) ->
             check_morello inst ;
             !(begin
@@ -5078,7 +5078,7 @@ Arguments:
  * as an argument to the MRS and MSR instructions.
  *)
         | I_MSR (sreg,xt) -> begin
-            let sz = MachSize.Quad in
+            let sz = MachSize.Double in
             match sreg with
             | SYS_NZCV ->
               read_reg_ord_sz sz xt ii
@@ -5107,7 +5107,7 @@ Arguments:
                >>= fun v -> write_reg_dest xt v ii
                >>= nextSet xt
             | _ -> begin
-              let sz = MachSize.Quad in
+              let sz = MachSize.Double in
               let off = AArch64.sysreg_nv2off sreg in
               match C.variant Variant.NV2, off with
               | true, Some off ->

--- a/herd/AArch64Sem.ml
+++ b/herd/AArch64Sem.ml
@@ -262,7 +262,7 @@ module Make
         | AArch64.ZR -> M.unitT V.zero
         | _ ->
             M.read_loc port
-              (mk_read MachSize.S128 Annot.N aexp)
+              (mk_read MachSize.Quad Annot.N aexp)
               (A.Location_reg (ii.A.proc,r)) ii
 
       let read_reg_neon port r ii =
@@ -271,7 +271,7 @@ module Make
         | AArch64Base.Vreg(vr',_) -> (AArch64Base.SIMDreg vr')
         | _ -> assert false in
           let location = A.Location_reg (ii.A.proc,vr) in
-          M.read_loc port (mk_read MachSize.S128 Annot.N aexp) location ii
+          M.read_loc port (mk_read MachSize.Quad Annot.N aexp) location ii
 
       let neon_getlane cur_val idx esize =
         let mask = V.op1 (Op.LeftShift (idx*esize)) (AArch64.neon_mask esize) in
@@ -285,7 +285,7 @@ module Make
       | _ -> assert false
 
       let read_reg_sz port sz r ii = match sz with
-      | MachSize.S128 -> read_reg_morello port r ii
+      | MachSize.Quad -> read_reg_morello port r ii
       | MachSize.Double when not morello -> read_reg port r ii
       | MachSize.Double|MachSize.Word|MachSize.Short|MachSize.Byte ->
           read_reg port r ii >>= uxt_op sz
@@ -348,7 +348,7 @@ module Make
         if not morello then
           Warn.user_error "capabilities require -variant morello" ;
         M.write_loc
-          (mk_write MachSize.S128  Annot.N aexp Access.REG v)
+          (mk_write MachSize.Quad  Annot.N aexp Access.REG v)
           (A.Location_reg (ii.A.proc,r)) ii
 
       let neon_setlane old_val idx esize v =
@@ -375,9 +375,9 @@ module Make
           (* Clear unused register bits (zero extend) *)
           promote v >>= uxt_op sz >>= fun v ->
           let location = A.Location_reg (ii.A.proc,vr) in
-          M.write_loc (mk_write MachSize.S128 Annot.N aexp Access.REG v) location ii
+          M.write_loc (mk_write MachSize.Quad Annot.N aexp Access.REG v) location ii
 
-      let write_reg_neon = write_reg_neon_sz MachSize.S128
+      let write_reg_neon = write_reg_neon_sz MachSize.Quad
 
       let write_reg_neon_elem sz r idx v ii = match r with
       | AArch64Base.Vreg (_,(_,esize)) ->
@@ -447,7 +447,7 @@ module Make
         | AArch64Base.Preg(_,_) | AArch64Base.PMreg(_,_) -> r
         | _ -> assert false in
         let location = A.Location_reg (ii.A.proc,vr) in
-        M.read_loc Port.No (mk_read MachSize.S128 Annot.N aexp) location ii
+        M.read_loc Port.No (mk_read MachSize.Quad Annot.N aexp) location ii
 
       let predicate_setlane old_val idx psize v =
         let mask =
@@ -469,7 +469,7 @@ module Make
         | AArch64Base.Preg(_,_) -> r
         | _ -> assert false in
           let location = A.Location_reg (ii.A.proc,pr) in
-          M.write_loc (mk_write MachSize.S128 Annot.N aexp Access.REG v) location ii
+          M.write_loc (mk_write MachSize.Quad Annot.N aexp Access.REG v) location ii
 
       let get_predicate_last pred psize idx =
         predicate_getlane pred idx psize
@@ -500,7 +500,7 @@ module Make
         | AArch64Base.Zreg _ -> r
         | _ -> assert false in
           let location = A.Location_reg (ii.A.proc,vr) in
-          M.read_loc port (mk_read MachSize.S128 Annot.N aexp) location ii
+          M.read_loc port (mk_read MachSize.Quad Annot.N aexp) location ii
 
       let scalable_setlane old_val idx esize v =
         let mask =
@@ -529,9 +529,9 @@ module Make
         (* Clear unused register bits (zero extend) *)
           M.op1 (Op.Mask sz) v >>= fun v ->
           let location = A.Location_reg (ii.A.proc,pr) in
-          M.write_loc (mk_write MachSize.S128 Annot.N aexp Access.REG v) location ii
+          M.write_loc (mk_write MachSize.Quad Annot.N aexp Access.REG v) location ii
 
-      let write_reg_scalable = write_reg_scalable_sz MachSize.S128
+      let write_reg_scalable = write_reg_scalable_sz MachSize.Quad
 
       (* ZA offset, in bits, see ARM ARM B.1.4.10 "ZA tile access" *)
       let za_getoffset tile slice idx esize =
@@ -591,7 +591,7 @@ module Make
         | AArch64Base.ZAreg _ -> r
         | _ -> assert false in
           let location = A.Location_reg (ii.A.proc,vr) in
-          M.read_loc Port.No (mk_read MachSize.S128 Annot.N aexp) location ii
+          M.read_loc Port.No (mk_read MachSize.Quad Annot.N aexp) location ii
 
       let write_reg_za_sz sz r v ii =
         let pr = match r with
@@ -600,9 +600,9 @@ module Make
         (* Clear unused register bits (zero extend) *)
           M.op1 (Op.Mask sz) v >>= fun v ->
           let location = A.Location_reg (ii.A.proc,pr) in
-          M.write_loc (mk_write MachSize.S128 Annot.N aexp Access.REG v) location ii
+          M.write_loc (mk_write MachSize.Quad Annot.N aexp Access.REG v) location ii
 
-      let write_reg_za = write_reg_za_sz MachSize.S128
+      let write_reg_za = write_reg_za_sz MachSize.Quad
 
       let write_reg_scalable_rep r v ii =
         let nelem = scalable_nelem r in
@@ -613,7 +613,7 @@ module Make
       let do_write_reg_sz mop sz r v ii = match r with
       | AArch64.ZR -> M.unitT ()
       | _ -> match sz with
-        | MachSize.S128 -> write_reg_morello r v ii
+        | MachSize.Quad -> write_reg_morello r v ii
         | MachSize.Double when not morello -> write_reg r v ii
         | MachSize.Double|MachSize.Word|MachSize.Short|MachSize.Byte ->
             mop sz v >>= fun v -> write_reg r v ii
@@ -628,7 +628,7 @@ module Make
         | AArch64.ZR -> M.unitT ()
         | _ ->
            match sz with
-           | MachSize.S128 -> write_reg_morello r v ii
+           | MachSize.Quad -> write_reg_morello r v ii
            | MachSize.Double|MachSize.Word|MachSize.Short|MachSize.Byte ->
               op v >>= fun v -> write_reg r v ii
 
@@ -667,7 +667,7 @@ module Make
         | _ -> assert false in
         match size with
           | 64 -> MachSize.Double
-          | 128 -> MachSize.S128
+          | 128 -> MachSize.Quad
           | _ -> assert false
 
       let neon_sz_k var = let open AArch64Base in
@@ -775,7 +775,7 @@ module Make
 
       let process_read_capability sz a m ii =
         match sz with
-        | MachSize.S128 ->
+        | MachSize.Quad ->
             (M.op1 Op.CapaStrip a >>= fun a ->
              M.add_atomic_tag_read (m a) a
                (fun loc v -> Act.tag_access quad Dir.R loc v) ii)
@@ -1667,7 +1667,7 @@ module Make
    + ma abstracted for all variants
  *)
 
-      let to_perms str sz = str ^ if sz = MachSize.S128 then "_c" else ""
+      let to_perms str sz = str ^ if sz = MachSize.Quad then "_c" else ""
 
       let apply_mv mop mv = fun ac ma -> mop ac ma mv
 
@@ -2561,7 +2561,7 @@ Arguments:
         (* 128-bit Neon LDR/STR and friends are split into two 64-bit
          * single-copy atomic accesses. *)
         let mem_op = begin
-          if sz == MachSize.S128 then do_read_mem_2_ops_ret else do_read_mem_ret
+          if sz == MachSize.Quad then do_read_mem_2_ops_ret else do_read_mem_ret
         end in
         mem_op sz an aexp Access.VIR addr ii >>= fun v ->
         write_reg_neon_sz sz rd v ii
@@ -2572,7 +2572,7 @@ Arguments:
       let do_simd_str an sz ma rd ii =
         ma >>|
         read_reg_neon Port.Data rd ii >>= fun (addr,v) ->
-        if sz == MachSize.S128 then
+        if sz == MachSize.Quad then
           do_write_mem_2_ops sz an aexp Access.VIR addr v ii >>= B.next2T
         else
           demote v >>= fun v ->
@@ -2584,7 +2584,7 @@ Arguments:
       let simd_str_p sz ma rd rs k ii =
         ma >>|
         read_reg_neon Port.Data rd ii >>= fun (addr,v) ->
-        if sz == MachSize.S128 then
+        if sz == MachSize.Quad then
           (* 128-bit Neon LDR/STR and friends are split into two 64-bit
            * single-copy atomic accesses. *)
           write_mem_2_ops sz aexp Access.VIR addr v ii >>|
@@ -2608,7 +2608,7 @@ Arguments:
         let an = tnt2annot tnt in
         let open AArch64Base in
         let sz = tr_simd_variant var in
-        if sz == MachSize.S128 then
+        if sz == MachSize.Quad then
           (* 128-bit Neon LDR/STR are not single-copy atomic, but they
            * are single-copy atomic for each of the two 64-bit quantities
            * they access. This means that a 2x128-bit LDP/STP with Neon
@@ -3191,7 +3191,7 @@ Arguments:
 
       let load_m addr rlist ii =
         let op i =
-          let ops = neon_memops (load_elem MachSize.S128) addr i rlist ii in
+          let ops = neon_memops (load_elem MachSize.Quad) addr i rlist ii in
           reduce_ord ops in
         let ops = List.map op (Misc.interval 0 (neon_nelem (List.hd rlist))) in
         reduce_ord ops
@@ -3212,7 +3212,7 @@ Arguments:
       let load_m_contigous addr rlist ii =
         let op i r =
           let step = i*(neon_nelem r) in
-          let ops = neon_memops_contigous (load_elem MachSize.S128) addr step r ii in
+          let ops = neon_memops_contigous (load_elem MachSize.Quad) addr step r ii in
           reduce_ord ops in
         let ops = List.mapi op rlist in
         reduce_ord ops
@@ -3504,7 +3504,7 @@ Arguments:
           else
             ma >>| mv >>= _do_ldg in
         lift_memop rn Dir.R false false (fun ac ma mv -> do_ldg ac ma mv)
-        (to_perms "w" MachSize.S128) ma mv Annot.N ii
+        (to_perms "w" MachSize.Quad) ma mv Annot.N ii
 
       type double = Once|Twice
 
@@ -4246,12 +4246,12 @@ Arguments:
         | I_MOV_VE(r1,i1,r2,i2) ->
             check_neon inst;
             !(read_reg_neon_elem Port.No r2 i2 ii >>=
-              fun v -> write_reg_neon_elem MachSize.S128 r1 i1 v ii)
+              fun v -> write_reg_neon_elem MachSize.Quad r1 i1 v ii)
         | I_MOV_FG(r1,i,var,r2) ->
             check_neon inst;
             !(let sz = tr_variant var in
               read_reg_ord_sz sz r2 ii >>= promote >>=
-              fun v -> write_reg_neon_elem MachSize.S128 r1 i v ii)
+              fun v -> write_reg_neon_elem MachSize.Quad r1 i v ii)
         | I_MOV_TG(_,r1,r2,i) ->
             check_neon inst;
             !(read_reg_neon_elem Port.No r2 i ii >>= demote >>=
@@ -4291,7 +4291,7 @@ Arguments:
         | I_LDAP1(rs,i,rA,kr) ->
             check_neon inst;
             !!!(read_reg_addr rA ii >>= fun addr ->
-            (mem_ss (load_elem_ldar MachSize.S128 i) addr rs ii >>|
+            (mem_ss (load_elem_ldar MachSize.Quad i) addr rs ii >>|
             post_kr rA addr kr ii))
         | I_LD1(rs,i,rA,kr)
         | I_LD2(rs,i,rA,kr)
@@ -4299,7 +4299,7 @@ Arguments:
         | I_LD4(rs,i,rA,kr) ->
             check_neon inst;
             !!!(read_reg_addr rA ii >>= fun addr ->
-            (mem_ss (load_elem MachSize.S128 i) addr rs ii >>|
+            (mem_ss (load_elem MachSize.Quad i) addr rs ii >>|
             post_kr rA addr kr ii))
         | I_LD1R(rs,rA,kr)
         | I_LD2R(rs,rA,kr)
@@ -4307,7 +4307,7 @@ Arguments:
         | I_LD4R(rs,rA,kr) ->
             check_neon inst;
             !!!(read_reg_addr rA ii >>= fun addr ->
-            (mem_ss (load_elem_rep MachSize.S128) addr rs ii >>|
+            (mem_ss (load_elem_rep MachSize.Quad) addr rs ii >>|
             post_kr rA addr kr ii))
         | I_LD1M(rs,rA,kr) ->
             check_neon inst;
@@ -4705,72 +4705,72 @@ Arguments:
         (* Morello instructions *)
         | I_ALIGND(rd,rn,k) ->
             check_morello inst ;
-            !((read_reg_ord_sz MachSize.S128 rn ii >>=
+            !((read_reg_ord_sz MachSize.Quad rn ii >>=
             fun v -> M.op Op.Alignd v (V.intToV k))
-            >>= fun v -> write_reg_sz MachSize.S128 rd v ii)
+            >>= fun v -> write_reg_sz MachSize.Quad rd v ii)
         | I_ALIGNU(rd,rn,k) ->
             check_morello inst ;
-            !((read_reg_ord_sz MachSize.S128 rn ii >>=
+            !((read_reg_ord_sz MachSize.Quad rn ii >>=
             fun v -> M.op Op.Alignu v (V.intToV k))
-            >>= fun v -> write_reg_sz MachSize.S128 rd v ii)
+            >>= fun v -> write_reg_sz MachSize.Quad rd v ii)
         | I_BUILD(rd,rn,rm) ->
             check_morello inst ;
             !(begin
-              read_reg_ord_sz MachSize.S128 rn ii >>|
-              read_reg_ord_sz MachSize.S128 rm ii
+              read_reg_ord_sz MachSize.Quad rn ii >>|
+              read_reg_ord_sz MachSize.Quad rm ii
             end >>= fun (a,b) ->
             M.op Op.Build a b >>= fun v ->
-            write_reg_sz MachSize.S128 rd v ii)
+            write_reg_sz MachSize.Quad rd v ii)
         | I_CHKEQ(rn,rm) ->
             check_morello inst ;
             !(begin
-              read_reg_ord_sz MachSize.S128 rn ii >>|
-              read_reg_ord_sz MachSize.S128 rm ii
+              read_reg_ord_sz MachSize.Quad rn ii >>|
+              read_reg_ord_sz MachSize.Quad rm ii
             end >>= fun (v1,v2) ->
             M.op Op.Eq v1 v2 >>= fun v ->
             write_reg (PState PSTATE.N) v ii)
         | I_CHKSLD(rn) ->
             check_morello inst ;
-            !(read_reg_ord_sz MachSize.S128 rn ii >>= fun v ->
+            !(read_reg_ord_sz MachSize.Quad rn ii >>= fun v ->
             M.op1 Op.CheckSealed v >>= fun v -> write_reg (PState PSTATE.V) v ii)
         | I_CHKTGD(rn) ->
             check_morello inst ;
-            !(read_reg_ord_sz MachSize.S128 rn ii >>= fun v ->
+            !(read_reg_ord_sz MachSize.Quad rn ii >>= fun v ->
               M.op1 Op.CapaGetTag v >>= fun v ->
               write_reg (PState PSTATE.C) v ii)
         | I_CLRTAG(rd,rn) ->
             check_morello inst ;
-            !(read_reg_ord_sz MachSize.S128 rn ii >>= fun (v) ->
+            !(read_reg_ord_sz MachSize.Quad rn ii >>= fun (v) ->
             M.op Op.CapaSetTag v V.zero >>= fun v ->
-            write_reg_sz MachSize.S128 rd v ii)
+            write_reg_sz MachSize.Quad rd v ii)
         | I_CPYTYPE(rd,rn,rm) ->
             check_morello inst ;
             !(begin
-              read_reg_ord_sz MachSize.S128 rn ii >>|
-              read_reg_ord_sz MachSize.S128 rm ii
+              read_reg_ord_sz MachSize.Quad rn ii >>|
+              read_reg_ord_sz MachSize.Quad rm ii
             end >>= fun (v1,v2) -> M.op Op.CpyType v1 v2 >>= fun v ->
-            write_reg_sz MachSize.S128 rd v ii)
+            write_reg_sz MachSize.Quad rd v ii)
         | I_CPYVALUE(rd,rn,rm) ->
             check_morello inst ;
             !(begin
-              read_reg_ord_sz MachSize.S128 rn ii >>|
-              read_reg_ord_sz MachSize.S128 rm ii
+              read_reg_ord_sz MachSize.Quad rn ii >>|
+              read_reg_ord_sz MachSize.Quad rm ii
             end >>= fun (v1,v2) -> M.op Op.SetValue v1 v2 >>= fun v ->
-            write_reg_sz MachSize.S128 rd v ii)
+            write_reg_sz MachSize.Quad rd v ii)
         | I_CSEAL(rd,rn,rm) ->
             check_morello inst ;
             !(begin
-              read_reg_ord_sz MachSize.S128 rn ii >>|
-              read_reg_ord_sz MachSize.S128 rm ii
+              read_reg_ord_sz MachSize.Quad rn ii >>|
+              read_reg_ord_sz MachSize.Quad rm ii
             end >>= fun (v1,v2) ->
             M.op Op.CSeal v1 v2 >>= fun v ->
             (
-            write_reg_sz MachSize.S128 rd v ii |||
+            write_reg_sz MachSize.Quad rd v ii |||
             (* TODO: PSTATE overflow flag would need to be conditionally set *)
             write_nzcv_no_next M.A.V.(zero, zero, zero, zero) ii))
         | I_GC(op,rd,rn) ->
             check_morello inst ;
-            !(read_reg_ord_sz MachSize.S128 rn ii >>= begin fun c -> match op with
+            !(read_reg_ord_sz MachSize.Quad rn ii >>= begin fun c -> match op with
             | CFHI -> M.op1 (Op.LogicalRightShift 64) c
             | GCFLGS -> M.op1 (Op.AndK "0xff00000000000000") c
             | GCPERM -> M.op1 (Op.LogicalRightShift 110) c
@@ -4784,7 +4784,7 @@ Arguments:
         | I_SC(op,rd,rn,rm) ->
             check_morello inst ;
             !(begin
-              read_reg_ord_sz MachSize.S128 rn ii >>|
+              read_reg_ord_sz MachSize.Quad rn ii >>|
               read_reg_ord rm ii
             end >>=
             begin fun (cn, xm) -> match op with
@@ -4799,15 +4799,15 @@ Arguments:
                   M.op Op.CapaSetTag cn cond
               | SCVALUE -> M.op Op.SetValue cn xm
             end >>= fun v ->
-            write_reg_sz MachSize.S128 rd v ii)
+            write_reg_sz MachSize.Quad rd v ii)
         | I_SEAL(rd,rn,rm) ->
             check_morello inst ;
             !(begin
-              read_reg_ord_sz MachSize.S128 rn ii >>|
-              read_reg_ord_sz MachSize.S128 rm ii
+              read_reg_ord_sz MachSize.Quad rn ii >>|
+              read_reg_ord_sz MachSize.Quad rm ii
             end >>= fun (a,b) ->
             M.op Op.Seal a b >>= fun v ->
-            write_reg_sz MachSize.S128 rd v ii)
+            write_reg_sz MachSize.Quad rd v ii)
         | I_STCT(rt,rn) ->
             check_morello inst ;
             (* NB: only 1 access implemented out of the 4 *)
@@ -4817,7 +4817,7 @@ Arguments:
                   (ma >>| mv)
                   (fun (a,v) -> !(do_write_morello_tag a v ii))
                   ii)
-              (to_perms "tw" MachSize.S128)
+              (to_perms "tw" MachSize.Quad)
               (read_reg_addr rn ii)
               (read_reg_ord rt ii)
               Dir.W Annot.N ii (fun a -> a >>= M.ignore >>= B.next1T)
@@ -4836,7 +4836,7 @@ Arguments:
                           mzero
                         >>= fun tag -> !(write_reg_sz quad rt tag ii))
                       ii))
-              (to_perms "r" MachSize.S128)
+              (to_perms "r" MachSize.Quad)
               (read_reg_addr rn ii)
               mzero
               Dir.R Annot.N
@@ -4844,11 +4844,11 @@ Arguments:
         | I_UNSEAL(rd,rn,rm) ->
             check_morello inst ;
             !(begin
-              read_reg_ord_sz MachSize.S128 rn ii >>|
-              read_reg_ord_sz MachSize.S128 rm ii
+              read_reg_ord_sz MachSize.Quad rn ii >>|
+              read_reg_ord_sz MachSize.Quad rm ii
             end >>= fun (a,b) ->
             M.op Op.Unseal a b >>= fun v ->
-            write_reg_sz MachSize.S128 rd v ii)
+            write_reg_sz MachSize.Quad rd v ii)
 
         (* Operations *)
         | I_MOV(var,r,K k) ->

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -255,7 +255,7 @@ module Make (Conf : Config) = struct
       | 16 -> MachSize.Short
       | 32 -> MachSize.Word
       | 64 -> MachSize.Double
-      | 128 -> MachSize.S128
+      | 128 -> MachSize.Quad
       | _ ->
           Warn.fatal
             "Cannot access a register or memory with size %s" (V.pp_v v)

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -254,7 +254,7 @@ module Make (Conf : Config) = struct
       | 8 -> MachSize.Byte
       | 16 -> MachSize.Short
       | 32 -> MachSize.Word
-      | 64 -> MachSize.Quad
+      | 64 -> MachSize.Double
       | 128 -> MachSize.S128
       | _ ->
           Warn.fatal
@@ -484,7 +484,7 @@ module Make (Conf : Config) = struct
     let tr_regval = M.op1 (Op.ArchOp1 ASLOp.ToIntU)
 
     let mk_std_access (ii,poi) dir loc v =
-      let action = Act.Access (dir, loc, v, MachSize.Quad, areg_std) in
+      let action = Act.Access (dir, loc, v, MachSize.Double, areg_std) in
       M.mk_singleton_es action (use_ii_with_poi ii poi)
 
     let on_access_identifier dir (ii,_ as ii_poi) x scope v =
@@ -629,13 +629,13 @@ module Make (Conf : Config) = struct
     let read_register (ii, poi) ~reg:r_m =
       let* rval = r_m in
       let loc = virtual_to_loc_reg rval ii in
-      read_loc MachSize.Quad loc aneutral aexp areg (use_ii_with_poi ii poi)
+      read_loc MachSize.Double loc aneutral aexp areg (use_ii_with_poi ii poi)
       >>= from_aarch64_val
 
     let write_register (ii, poi) ~reg:r_m ~data:v_m =
       let* v = v_m >>= to_aarch64_val and* r = r_m in
       let loc = virtual_to_loc_reg r ii in
-      write_loc MachSize.Quad loc v aneutral aexp areg (use_ii_with_poi ii poi)
+      write_loc MachSize.Double loc v aneutral aexp areg (use_ii_with_poi ii poi)
 
     let do_read_memory (ii, poi) addr_m datasize_m an aexp acc =
       let* addr = M.as_addr_port addr_m and* datasize = datasize_m in

--- a/herd/BPFSem.ml
+++ b/herd/BPFSem.ml
@@ -27,7 +27,7 @@ struct
   let barriers = []
   let isync = None
 
-  (*  TODO: let nat_sz = MachSize.Quad (* 64-bit Registers *) *)
+  (*  TODO: let nat_sz = MachSize.Double (* 64-bit Registers *) *)
   let nat_sz = V.Cst.Scalar.machsize
   let atomic_pair_allowed _ _ = true
 

--- a/herd/CParseTest.ml
+++ b/herd/CParseTest.ml
@@ -49,7 +49,7 @@
   end
 
    let run =
-     if Conf.variant Variant.S128 then
+     if Conf.variant Variant.Quad then
        let module CValue = Int128Value.Make(CBase.Instr) in
        let module Run = MakeRun(CValue) in
        Run.X.run

--- a/herd/MIPSSem.ml
+++ b/herd/MIPSSem.ml
@@ -215,7 +215,7 @@ module
           | MIPS.LD (r1,k,r2) ->
               read_reg_addr r2 ii >>=
               (fun a -> M.add a (imm16ToV k)) >>=
-              (fun ea -> read_mem MachSize.Quad ea ii) >>=
+              (fun ea -> read_mem MachSize.Double ea ii) >>=
               (fun v -> write_reg r1 v ii)  >>= B.next1T
           | MIPS.SW (r1,k,r2) ->
               (read_reg_data r1 ii >>| read_reg_addr r2 ii) >>=

--- a/herd/PPCSem.ml
+++ b/herd/PPCSem.ml
@@ -38,7 +38,7 @@ module
     let nat_sz =  V.Cst.Scalar.machsize
     let atomic_pair_allowed _ _ = true
 
-    let () = assert (nat_sz = MachSize.Quad)
+    let () = assert (nat_sz = MachSize.Double)
 
 (****************************)
 (* Build semantics function *)

--- a/herd/X86Sem.ml
+++ b/herd/X86Sem.ml
@@ -197,7 +197,7 @@ module
               | X86.I_MOV _|X86.I_MOVL _ -> MachSize.Word
               | X86.I_MOVB _ ->  MachSize.Byte
               | X86.I_MOVW _ ->  MachSize.Short
-              | X86.I_MOVQ _ -> MachSize.Quad
+              | X86.I_MOVQ _ -> MachSize.Double
               | _ -> assert false in
               let port = check_data ea in
               (lval_ea ea ii >>| rval_op port sz locked op ii) >>=

--- a/herd/X86_64Arch_herd.ml
+++ b/herd/X86_64Arch_herd.ml
@@ -64,13 +64,13 @@ module Make (C:Arch_herd.Config)(V:Value.S) =
       | I8b -> MachSize.Byte
       | I16b -> MachSize.Short
       | I32b | INSb -> MachSize.Word
-      | I64b -> MachSize.Quad
+      | I64b -> MachSize.Double
 
     let reg_part_to_mach_size = function
       | R8bL | R8bH ->  MachSize.Byte
       | R16b -> MachSize.Short
       | R32b -> MachSize.Word
-      | R64b -> MachSize.Quad
+      | R64b -> MachSize.Double
 
     let reg_to_mach_size r = match r with
       | Ireg (_,p) -> reg_part_to_mach_size p

--- a/herd/X86_64Sem.ml
+++ b/herd/X86_64Sem.ml
@@ -56,7 +56,7 @@ module
         | X86_64.R8bL | X86_64.R8bH -> MachSize.Byte
         | X86_64.R16b -> MachSize.Short
         | X86_64.R32b -> MachSize.Word
-        | X86_64.R64b -> MachSize.Quad
+        | X86_64.R64b -> MachSize.Double
 
       let mk_read sz an loc v =
         let ac = Act.access_of_location_std loc in

--- a/herd/tests/instructions/C/C05.litmus
+++ b/herd/tests/instructions/C/C05.litmus
@@ -1,5 +1,5 @@
 C C05
-Variant=S128
+Variant=Quad
 
 {
 __int128_t x=1;

--- a/herd/tests/instructions/C/C06.litmus
+++ b/herd/tests/instructions/C/C06.litmus
@@ -1,6 +1,6 @@
 C C06
 
-Variant=S128
+Variant=Quad
 {
 __uint128_t x;
 }

--- a/herd/tests/instructions/C/C07.litmus
+++ b/herd/tests/instructions/C/C07.litmus
@@ -1,6 +1,6 @@
 C C07
 
-Variant=S128
+Variant=Quad
 {}
 
 P0 (int128_t *x) {

--- a/herd/tests/instructions/C/ci.cfg
+++ b/herd/tests/instructions/C/ci.cfg
@@ -1,3 +1,3 @@
 hexa true
 model herd/libdir/rc11.cat
-variant S128
+variant Quad

--- a/herd/variant.ml
+++ b/herd/variant.ml
@@ -100,7 +100,7 @@ type t =
 (* UDF control in AArch64 mode *)
   | ASL_AArch64_UDF
 (* Signed Int128 types *)
-  | S128
+  | Quad
 (* Strict interpretation of variant, e.g. -variant asl,strict *)
   | Strict
 (* Semi-strict interpretation of variant, e.g. -variant asl,warn *)
@@ -183,7 +183,7 @@ let (mode_variants, arch_variants) : t list * t list =
   | ASLType `Silence -> ASLType `Silence
   | ASLType `TypeCheck -> ASLType `TypeCheck
   | ASL_AArch64_UDF -> ASL_AArch64_UDF
-  | S128 -> S128
+  | Quad -> Quad
   | Strict -> Strict
   | Warn -> Warn
   | Telechat -> Telechat
@@ -207,7 +207,7 @@ let (mode_variants, arch_variants) : t list * t list =
         OptRfRMW; ConstrainedUnpredictable;
         Exp; CosOpt; Test; T 0;
         ASL; ASL_AArch64; ASLVersion `ASLv0; ASLVersion `ASLv1;
-        S128; Strict; Warn;
+        Quad; Strict; Warn;
         ASLType `Warn; ASLType `Silence; ASLType `TypeCheck; ASL_AArch64_UDF;
         Telechat; OldSolver; OOTA ]
   and precision_variants =
@@ -291,7 +291,7 @@ let parse s = match Misc.lowercase s with
 | "asltype+silence"-> Some (ASLType `Silence)
 | "asltype+check"  -> Some (ASLType `TypeCheck)
 | "asl+aarch64+udf" -> Some ASL_AArch64_UDF
-| "s128" -> Some S128
+| "quad"|"s128" -> Some Quad
 | "strict" -> Some Strict
 | "warn" -> Some Warn
 | "telechat" -> Some Telechat
@@ -398,7 +398,7 @@ let pp = function
   | ASL_AArch64 -> "ASL+AArch64"
   | ASLVersion `ASLv0 -> "ASLv0"
   | ASLVersion `ASLv1 -> "ASLv1"
-  | S128 -> "S128"
+  | Quad -> "Quad"
   | Strict -> "strict"
   | Warn -> "warn"
   | ASLType `Warn -> "ASLType+Warn"
@@ -482,7 +482,7 @@ let pp = function
   | ASL_AArch64 -> "Make the shared ASL code available in the environment (ASL only)"
   | ASLVersion `ASLv0 -> "Use the v0 version of the language (ASL only)"
   | ASLVersion `ASLv1 -> "Use the v1 version of the language (ASL only)"
-  | S128 -> ""
+  | Quad -> ""
   | Strict -> "Fail on non-supported instruction (AArch64+ASL only)"
   | Warn -> "Warn on non-supported instruction (AArch64+ASL only)"
   | ASLType `Warn -> "Warn on type-checking error (AArch64+ASL only)"

--- a/herd/variant.mli
+++ b/herd/variant.mli
@@ -101,7 +101,7 @@ type t =
 (* UDF control in ASL+AArch64 mode *)
   | ASL_AArch64_UDF
 (* Signed Int128 types *)
-  | S128
+  | Quad
 (* Strict interpretation of variant, e.g. -variant asl,strict *)
   | Strict
 (* Semi-strict interpretation of variant, e.g. -variant asl,warn *)

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1214,7 +1214,7 @@ let pp_variant = function
 let tr_variant = function
   | V32 -> MachSize.Word
   | V64 -> MachSize.Double
-  | V128 -> MachSize.S128
+  | V128 -> MachSize.Quad
 
 let container_size = function
   | RV16 _ -> MachSize.Short
@@ -1227,7 +1227,7 @@ let tr_simd_variant = function
   | VSIMD16 -> MachSize.Short
   | VSIMD32 -> MachSize.Word
   | VSIMD64 -> MachSize.Double
-  | VSIMD128 -> MachSize.S128
+  | VSIMD128 -> MachSize.Quad
 
 let simd_variant_nbytes v = tr_simd_variant v |> MachSize.nbytes
 

--- a/lib/AArch64Base.ml
+++ b/lib/AArch64Base.ml
@@ -1213,7 +1213,7 @@ let pp_variant = function
 
 let tr_variant = function
   | V32 -> MachSize.Word
-  | V64 -> MachSize.Quad
+  | V64 -> MachSize.Double
   | V128 -> MachSize.S128
 
 let container_size = function
@@ -1226,7 +1226,7 @@ let tr_simd_variant = function
   | VSIMD8 -> MachSize.Byte
   | VSIMD16 -> MachSize.Short
   | VSIMD32 -> MachSize.Word
-  | VSIMD64 -> MachSize.Quad
+  | VSIMD64 -> MachSize.Double
   | VSIMD128 -> MachSize.S128
 
 let simd_variant_nbytes v = tr_simd_variant v |> MachSize.nbytes

--- a/lib/ASLOp.ml
+++ b/lib/ASLOp.ml
@@ -369,9 +369,9 @@ let mask c sz =
   let open Constant in
   match c,sz with
 (* The following are 64bits quantities, the last two being virtual addresses *)
-  | ((PteVal _|Symbolic _),Quad)
+  | ((PteVal _|Symbolic _),Double)
 (* Non-signed 32bit quantity *)
-  | (Instruction _,(Word|Quad))
+  | (Instruction _,(Word|Double))
     -> Some c
   | _,_ -> None
 

--- a/lib/ASLScalar.ml
+++ b/lib/ASLScalar.ml
@@ -43,7 +43,7 @@ type t =
   | S_Label of String.t
   | S_String of String.t
 
-let machsize = MachSize.Quad (* Irrelevant here? *)
+let machsize = MachSize.Double (* Irrelevant here? *)
 let unique_zero = false
 let zero = S_Int Z.zero
 let one = S_Int Z.one

--- a/lib/BPFBase.ml
+++ b/lib/BPFBase.ml
@@ -159,7 +159,7 @@ let tr_width = function
   | Byte -> MachSize.Byte
   | Half -> MachSize.Short
   | Word -> MachSize.Word
-  | Double -> MachSize.Quad
+  | Double -> MachSize.Double
 ;;
 
 type signed = Sign.t

--- a/lib/CType.ml
+++ b/lib/CType.ml
@@ -220,7 +220,7 @@ let do_base_size =
   | "short"|"int16_t"|"uint16_t" -> Some Short
   | "int"|"int32_t"|"uint32_t" -> Some Word
   | "int64_t"|"uint64_t" -> Some Double
-  | "int128_t"|"uint128_t"|"__int128"|"__uint128" -> Some S128
+  | "int128_t"|"uint128_t"|"__int128"|"__uint128" -> Some Quad
   | _ -> None
 
 let rec base_size t = match t with

--- a/lib/CType.ml
+++ b/lib/CType.ml
@@ -219,7 +219,7 @@ let do_base_size =
   | "char"|"int8_t"|"uint8_t" -> Some Byte
   | "short"|"int16_t"|"uint16_t" -> Some Short
   | "int"|"int32_t"|"uint32_t" -> Some Word
-  | "int64_t"|"uint64_t" -> Some Quad
+  | "int64_t"|"uint64_t" -> Some Double
   | "int128_t"|"uint128_t"|"__int128"|"__uint128" -> Some S128
   | _ -> None
 

--- a/lib/PPCBase.ml
+++ b/lib/PPCBase.ml
@@ -319,7 +319,7 @@ let memo_load = function
   | MachSize.Short -> "lhz"
   | MachSize.Word -> "lwz"
   | MachSize.Double -> "ld"
-  | MachSize.S128 -> assert false
+  | MachSize.Quad -> assert false
 
 let memo_loadx sz = memo_load sz ^ "x"
 
@@ -328,7 +328,7 @@ let memo_store = function
   | MachSize.Short -> "sth"
   | MachSize.Word -> "stw"
   | MachSize.Double -> "std"
-  | MachSize.S128 -> assert false
+  | MachSize.Quad -> assert false
 
 let memo_storex sz = memo_store sz ^ "x"
 
@@ -745,9 +745,9 @@ let norm_ins ins =
   | Pcomment _
   | Plmw _|Pstmw _
           -> ins
-  | Pload (S128, _, _, _)|Ploadx (S128, _, _, _)|Pstore (S128, _, _, _)
-  | Plwax (S128, _, _, _)
-  | Pstorex (S128, _, _, _) -> assert false
+  | Pload (Quad, _, _, _)|Ploadx (Quad, _, _, _)|Pstore (Quad, _, _, _)
+  | Plwax (Quad, _, _, _)
+  | Pstorex (Quad, _, _, _) -> assert false
 
 let is_valid _ = true
 

--- a/lib/PPCBase.ml
+++ b/lib/PPCBase.ml
@@ -318,7 +318,7 @@ let memo_load = function
   | MachSize.Byte -> "lbz"
   | MachSize.Short -> "lhz"
   | MachSize.Word -> "lwz"
-  | MachSize.Quad -> "ld"
+  | MachSize.Double -> "ld"
   | MachSize.S128 -> assert false
 
 let memo_loadx sz = memo_load sz ^ "x"
@@ -327,7 +327,7 @@ let memo_store = function
   | MachSize.Byte -> "stb"
   | MachSize.Short -> "sth"
   | MachSize.Word -> "stw"
-  | MachSize.Quad -> "std"
+  | MachSize.Double -> "std"
   | MachSize.S128 -> assert false
 
 let memo_storex sz = memo_store sz ^ "x"
@@ -715,11 +715,11 @@ let get_next = function
 let norm_ins ins =
   let open MachSize in
   match ins with
-  | Pload(Quad,r1,cst,r2) -> Pload(Word,r1,cst,r2)
-  | Ploadx(Quad,r1,r2,r3) -> Ploadx(Word,r1,r2,r3)
-  | Plwax(Quad,r1,r2,r3) -> Plwax(Word,r1,r2,r3)
-  | Pstore(Quad,r1,cst,r2) -> Pstore(Word,r1,cst,r2)
-  | Pstorex(Quad,r1,r2,r3) -> Pstorex(Word,r1,r2,r3)
+  | Pload(Double,r1,cst,r2) -> Pload(Word,r1,cst,r2)
+  | Ploadx(Double,r1,r2,r3) -> Ploadx(Word,r1,r2,r3)
+  | Plwax(Double,r1,r2,r3) -> Plwax(Word,r1,r2,r3)
+  | Pstore(Double,r1,cst,r2) -> Pstore(Word,r1,cst,r2)
+  | Pstorex(Double,r1,r2,r3) -> Pstorex(Word,r1,r2,r3)
   | Pnop
   | Pload ((Byte|Short|Word),_,_,_)
   | Ploadx ((Byte|Short|Word),_,_,_)

--- a/lib/PPCParser.mly
+++ b/lib/PPCParser.mly
@@ -194,9 +194,9 @@ instr:
   | LWZU reg COMMA idx LPAR reg RPAR
     { Plwzu ($2,$4,$6)}
   | LD reg COMMA idx COMMA reg
-    { Pload (Quad,$2,$4,$6)}
+    { Pload (Double,$2,$4,$6)}
   | LD reg COMMA idx LPAR reg RPAR
-    { Pload (Quad,$2,$4,$6)}
+    { Pload (Double,$2,$4,$6)}
   | LBZX reg COMMA reg COMMA reg
     { Ploadx (Byte,$2,$4,$6)}
   | LHZX reg COMMA reg COMMA reg
@@ -204,7 +204,7 @@ instr:
   | LWZX reg COMMA reg COMMA reg
     { Ploadx (Word,$2,$4,$6)}
   | LDX reg COMMA reg COMMA reg
-    { Ploadx (Quad,$2,$4,$6)}
+    { Ploadx (Double,$2,$4,$6)}
   | MR reg COMMA reg
     { Pmr ($2,$4) }
   | STB reg COMMA idx COMMA reg
@@ -224,9 +224,9 @@ instr:
   | STWU reg COMMA idx LPAR reg RPAR
     { Pstwu ($2,$4,$6) }
   | STD reg COMMA idx COMMA reg
-    { Pstore (Quad,$2,$4,$6) }
+    { Pstore (Double,$2,$4,$6) }
   | STD reg COMMA idx LPAR reg RPAR
-    { Pstore (Quad,$2,$4,$6) }
+    { Pstore (Double,$2,$4,$6) }
   | STBX reg COMMA reg COMMA reg
     { Pstorex (Byte,$2,$4,$6) }
   | STHX reg COMMA reg COMMA reg
@@ -234,7 +234,7 @@ instr:
   | STWX reg COMMA reg COMMA reg
     { Pstorex (Word,$2,$4,$6) }
   | STDX reg COMMA reg COMMA reg
-    { Pstorex (Quad,$2,$4,$6) }
+    { Pstorex (Double,$2,$4,$6) }
   | LWARX  reg COMMA reg COMMA reg
     { Plwarx ($2,$4,$6)}
   | STWCX reg COMMA reg COMMA reg

--- a/lib/RISCVBase.ml
+++ b/lib/RISCVBase.ml
@@ -279,7 +279,7 @@ let tr_width = function
   | Byte -> MachSize.Byte
   | Half -> MachSize.Short
   | Word -> MachSize.Word
-  | Double -> MachSize.Quad
+  | Double -> MachSize.Double
 
 let pp_width = function
   | Byte -> "b"

--- a/lib/SVEScalar.ml
+++ b/lib/SVEScalar.ml
@@ -55,7 +55,7 @@ module BV = struct
     | Short -> fun v -> Z.logand v mask16
     | Word -> fun v ->  Z.logand v mask32
     | Double -> fun v -> logand v mask64
-    | S128 -> Misc.identity
+    | Quad -> Misc.identity
 end
 
 module Translate = struct

--- a/lib/SVEScalar.ml
+++ b/lib/SVEScalar.ml
@@ -54,7 +54,7 @@ module BV = struct
     | Byte -> fun v -> Z.logand v mask8
     | Short -> fun v -> Z.logand v mask16
     | Word -> fun v ->  Z.logand v mask32
-    | Quad -> fun v -> logand v mask64
+    | Double -> fun v -> logand v mask64
     | S128 -> Misc.identity
 end
 

--- a/lib/capabilityScalar.ml
+++ b/lib/capabilityScalar.ml
@@ -90,7 +90,7 @@ let mask sz =
      fun (_,v) -> false, Uint128.logand v (Uint128.of_uint16 Uint16.max_int)
   | Word ->
      fun (_,v) -> false, Uint128.logand v (Uint128.of_uint32 Uint32.max_int)
-  | Quad ->
+  | Double ->
      fun (_,v) -> false, Uint128.logand v (Uint128.of_uint64 Uint64.max_int)
   | S128 ->
      fun (t,v) -> t, v

--- a/lib/capabilityScalar.ml
+++ b/lib/capabilityScalar.ml
@@ -69,7 +69,7 @@ let addk (t,x) k = match k with
   | 1 -> false, Uint128.succ x
   | _ -> false, Uint128.add x (Uint128.of_int k)
 
-let machsize = MachSize.S128
+let machsize = MachSize.Quad
 
 let pp hexa (t,v) =
   Printf.sprintf "%s%s"
@@ -92,11 +92,11 @@ let mask sz =
      fun (_,v) -> false, Uint128.logand v (Uint128.of_uint32 Uint32.max_int)
   | Double ->
      fun (_,v) -> false, Uint128.logand v (Uint128.of_uint64 Uint64.max_int)
-  | S128 ->
+  | Quad ->
      fun (t,v) -> t, v
 
 let sxt sz v = match sz with
-  | MachSize.S128 -> v
+  | MachSize.Quad -> v
   | _ ->
      let t,v = mask sz v in
      let nb = MachSize.nbits sz in

--- a/lib/int128Scalar.ml
+++ b/lib/int128Scalar.ml
@@ -27,7 +27,7 @@ let addk x k = match k with
   | 1 -> Int128.succ x
   | _ -> Int128.add x (Int128.of_int k)
 
-let machsize = MachSize.S128
+let machsize = MachSize.Quad
 let pp hexa v =
   Printf.sprintf "%s" (if hexa then (Int128.to_string_hex v) else (Int128.to_string v))
 let pp_unsigned = pp (* Hum *)
@@ -43,10 +43,10 @@ let mask sz =
   | Short -> fun v -> Int128.logand v (Int128.of_int 0xffff)
   | Word -> fun v ->  Int128.logand v (Int128.of_int64 0xffffffffL)
   | Double -> fun (_,b) -> Int64.zero,b
-  | S128 -> fun v -> v
+  | Quad -> fun v -> v
 
 let sxt sz v = match sz with
-  | MachSize.S128 -> v
+  | MachSize.Quad -> v
   | _ ->
      let v = mask sz v in
      let nb = MachSize.nbits sz in

--- a/lib/int128Scalar.ml
+++ b/lib/int128Scalar.ml
@@ -42,7 +42,7 @@ let mask sz =
   | Byte -> fun v -> Int128.logand v (Int128.of_int 0xff)
   | Short -> fun v -> Int128.logand v (Int128.of_int 0xffff)
   | Word -> fun v ->  Int128.logand v (Int128.of_int64 0xffffffffL)
-  | Quad -> fun (_,b) -> Int64.zero,b
+  | Double -> fun (_,b) -> Int64.zero,b
   | S128 -> fun v -> v
 
 let sxt sz v = match sz with

--- a/lib/int32Scalar.ml
+++ b/lib/int32Scalar.ml
@@ -48,7 +48,7 @@ let mask sz =
   | Short -> fun v -> logand v 0xffffl
   | Word -> fun v -> v
   | Double -> fun v -> Warn.fatal "mask 32 bit value %s with double mask" (pp_unsigned true v)
-  | S128 -> fun v -> Warn.fatal "mask 32 bit value %s value with s128 mask" (pp_unsigned true v)
+  | Quad -> fun v -> Warn.fatal "mask 32 bit value %s value with quad mask" (pp_unsigned true v)
 
 let sxt sz v =
   let open MachSize in

--- a/lib/int32Scalar.ml
+++ b/lib/int32Scalar.ml
@@ -47,7 +47,7 @@ let mask sz =
   | Byte -> fun v -> logand v 0xffl
   | Short -> fun v -> logand v 0xffffl
   | Word -> fun v -> v
-  | Quad -> fun v -> Warn.fatal "mask 32 bit value %s with quad mask" (pp_unsigned true v)
+  | Double -> fun v -> Warn.fatal "mask 32 bit value %s with double mask" (pp_unsigned true v)
   | S128 -> fun v -> Warn.fatal "mask 32 bit value %s value with s128 mask" (pp_unsigned true v)
 
 let sxt sz v =

--- a/lib/int64Scalar.ml
+++ b/lib/int64Scalar.ml
@@ -29,7 +29,7 @@ let addk x k = match k with
   | 1 -> succ x
   | _ -> add x (of_int k)
 
-let machsize = MachSize.Quad
+let machsize = MachSize.Double
 
 let pp hexa v =
   Printf.sprintf (if hexa then "0x%Lx" else "%Li") v
@@ -46,13 +46,13 @@ let mask sz =
   | Byte -> fun v -> logand v 0xffL
   | Short -> fun v -> logand v 0xffffL
   | Word -> fun v ->  logand v 0xffffffffL
-  | Quad -> fun v -> v
+  | Double -> fun v -> v
   | S128 -> fun v -> Warn.fatal "mask 64 bit value %s with s128 mask" (pp_unsigned true v)
 
 let sxt sz v =
   let open MachSize in
   match sz with
-  | Quad -> v
+  | Double -> v
   | _ ->
      let v = mask sz v in
      let nb = nbits sz in

--- a/lib/int64Scalar.ml
+++ b/lib/int64Scalar.ml
@@ -47,7 +47,7 @@ let mask sz =
   | Short -> fun v -> logand v 0xffffL
   | Word -> fun v ->  logand v 0xffffffffL
   | Double -> fun v -> v
-  | S128 -> fun v -> Warn.fatal "mask 64 bit value %s with s128 mask" (pp_unsigned true v)
+  | Quad -> fun v -> Warn.fatal "mask 64 bit value %s with quad mask" (pp_unsigned true v)
 
 let sxt sz v =
   let open MachSize in

--- a/lib/machSize.ml
+++ b/lib/machSize.ml
@@ -14,14 +14,14 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type sz = Byte | Short | Word | Double | S128
+type sz = Byte | Short | Word | Double | Quad
 
 let pp = function
   | Byte -> "byte"
   | Short -> "short"
   | Word -> "word"
   | Double -> "double"
-  | S128 -> "s128"
+  | Quad -> "quad"
 
 
 let pp_short = function
@@ -29,28 +29,28 @@ let pp_short = function
   | Short -> "h"
   | Word -> "w"
   | Double -> "d"
-  | S128 -> "s"
+  | Quad -> "q"
 
 let debug = function
   | Byte -> "Byte"
   | Short -> "Short"
   | Word -> "Word"
   | Double -> "Double"
-  | S128 -> "S128"
+  | Quad -> "Quad"
 
 let nbytes = function
   | Byte -> 1
   | Short -> 2
   | Word -> 4
   | Double -> 8
-  | S128 -> 16
+  | Quad -> 16
 
 let log2bytes = function
   | Byte -> 0
   | Short -> 1
   | Word -> 2
   | Double -> 3
-  | S128 -> 4
+  | Quad -> 4
 
 let nbits sz = nbytes sz * 8
 
@@ -78,7 +78,7 @@ let tr_endian sz = match sz with
 | Byte -> fun x -> x
 | Short -> swap16
 | Word|Double -> swap (nbits sz)
-| S128 -> assert false
+| Quad -> assert false
 
 
 let l0 = [0;]
@@ -95,39 +95,39 @@ let l0123456789abcdef = [0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;]
 
 let off_byte = function
   | Byte -> l0
-  | Short|Word|Double|S128 -> []
+  | Short|Word|Double|Quad -> []
 
 let off_short = function
   | Byte -> l01
   | Short -> l0
-  | Word|Double|S128 -> []
+  | Word|Double|Quad -> []
 
 let off_word = function
   | Byte -> l0123
   | Short -> l02
   | Word -> l0
-  | Double|S128 -> []
+  | Double|Quad -> []
 
 let off_double = function
   | Byte -> l01234567
   | Short -> l0246
   | Word ->  l04
   | Double -> l0
-  | S128 -> []
+  | Quad -> []
 
-let off_s128 = function
+let off_quad = function
   | Byte -> l0123456789abcdef
   | Short -> l02468ace
   | Word -> l048c
   | Double -> l08
-  | S128 -> l0
+  | Quad -> l0
 
 let get_off sz = match sz with
 | Byte -> off_byte
 | Short -> off_short
 | Word -> off_word
 | Double -> off_double
-| S128 -> off_s128
+| Quad -> off_quad
 
 let get_off_reduced sz = match sz with
 | Byte -> off_byte
@@ -142,28 +142,28 @@ let get_off_reduced sz = match sz with
     | Byte|Short -> []
     | _ -> off_double sz
     end
-| S128 ->
+| Quad ->
     begin fun sz -> match sz with
     | Byte|Short|Word -> []
-    | _ -> off_s128 sz
+    | _ -> off_quad sz
   end
 
 let compare sz1 sz2 = match sz1,sz2 with
-| (Byte,(Short|Word|Double|S128))
-| (Short,(Word|Double|S128))
-| (Word,(Double|S128))
-| (Double,S128)
+| (Byte,(Short|Word|Double|Quad))
+| (Short,(Word|Double|Quad))
+| (Word,(Double|Quad))
+| (Double,Quad)
   -> -1
 | (Byte,Byte)
 | (Short,Short)
 | (Word,Word)
 | (Double,Double)
-| (S128,S128)
+| (Quad,Quad)
   -> 0
-| ((Short|Word|Double|S128),Byte)
-| ((Word|Double|S128),Short)
-| ((Double|S128),Word)
-| (S128,Double)
+| ((Short|Word|Double|Quad),Byte)
+| ((Word|Double|Quad),Short)
+| ((Double|Quad),Word)
+| (Quad,Double)
     -> 1
 
 let equal sz1 sz2 = compare sz1 sz2 = 0
@@ -183,10 +183,10 @@ let pred = function
   | Byte|Short -> Byte
   | Word -> Short
   | Double -> Word
-  | S128 -> Double
+  | Quad -> Double
 
 let at_least_word = function
-  | Double|S128 as sz -> sz
+  | Double|Quad as sz -> sz
   | Word|Short|Byte -> Word
 
 module Tag = struct
@@ -199,8 +199,8 @@ module Tag = struct
   | "byte" -> Some (Size Byte)
   | "short" -> Some (Size Short)
   | "word" -> Some (Size Word)
-  | "double"|"quad" -> Some (Size Double)
-  | "s128" -> Some (Size S128)
+  | "double" -> Some (Size Double)
+  | "quad"|"s128" -> Some (Size Quad)
   | "auto" -> Some Auto
   | _      -> None
 
@@ -219,7 +219,7 @@ type lr_sc =
 
 (* MTE granule *)
 
-let granule = S128
+let granule = Quad
 
 let granule_nbytes = nbytes granule
 

--- a/lib/machSize.ml
+++ b/lib/machSize.ml
@@ -14,13 +14,13 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type sz = Byte | Short | Word | Quad | S128
+type sz = Byte | Short | Word | Double | S128
 
 let pp = function
   | Byte -> "byte"
   | Short -> "short"
   | Word -> "word"
-  | Quad -> "quad"
+  | Double -> "double"
   | S128 -> "s128"
 
 
@@ -28,28 +28,28 @@ let pp_short = function
   | Byte -> "b"
   | Short -> "h"
   | Word -> "w"
-  | Quad -> "q"
+  | Double -> "d"
   | S128 -> "s"
 
 let debug = function
   | Byte -> "Byte"
   | Short -> "Short"
   | Word -> "Word"
-  | Quad -> "Quad"
+  | Double -> "Double"
   | S128 -> "S128"
 
 let nbytes = function
   | Byte -> 1
   | Short -> 2
   | Word -> 4
-  | Quad -> 8
+  | Double -> 8
   | S128 -> 16
 
 let log2bytes = function
   | Byte -> 0
   | Short -> 1
   | Word -> 2
-  | Quad -> 3
+  | Double -> 3
   | S128 -> 4
 
 let nbits sz = nbytes sz * 8
@@ -77,7 +77,7 @@ let rec swap k x =
 let tr_endian sz = match sz with
 | Byte -> fun x -> x
 | Short -> swap16
-| Word|Quad -> swap (nbits sz)
+| Word|Double -> swap (nbits sz)
 | S128 -> assert false
 
 
@@ -95,38 +95,38 @@ let l0123456789abcdef = [0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;]
 
 let off_byte = function
   | Byte -> l0
-  | Short|Word|Quad|S128 -> []
+  | Short|Word|Double|S128 -> []
 
 let off_short = function
   | Byte -> l01
   | Short -> l0
-  | Word|Quad|S128 -> []
+  | Word|Double|S128 -> []
 
 let off_word = function
   | Byte -> l0123
   | Short -> l02
   | Word -> l0
-  | Quad|S128 -> []
+  | Double|S128 -> []
 
-let off_quad = function
+let off_double = function
   | Byte -> l01234567
   | Short -> l0246
   | Word ->  l04
-  | Quad -> l0
+  | Double -> l0
   | S128 -> []
 
 let off_s128 = function
   | Byte -> l0123456789abcdef
   | Short -> l02468ace
   | Word -> l048c
-  | Quad -> l08
+  | Double -> l08
   | S128 -> l0
 
 let get_off sz = match sz with
 | Byte -> off_byte
 | Short -> off_short
 | Word -> off_word
-| Quad -> off_quad
+| Double -> off_double
 | S128 -> off_s128
 
 let get_off_reduced sz = match sz with
@@ -137,10 +137,10 @@ let get_off_reduced sz = match sz with
     | Byte -> []
     | _ -> off_word sz
     end
-| Quad ->
+| Double ->
     begin fun sz -> match sz with
     | Byte|Short -> []
-    | _ -> off_quad sz
+    | _ -> off_double sz
     end
 | S128 ->
     begin fun sz -> match sz with
@@ -149,21 +149,21 @@ let get_off_reduced sz = match sz with
   end
 
 let compare sz1 sz2 = match sz1,sz2 with
-| (Byte,(Short|Word|Quad|S128))
-| (Short,(Word|Quad|S128))
-| (Word,(Quad|S128))
-| (Quad,S128)
+| (Byte,(Short|Word|Double|S128))
+| (Short,(Word|Double|S128))
+| (Word,(Double|S128))
+| (Double,S128)
   -> -1
 | (Byte,Byte)
 | (Short,Short)
 | (Word,Word)
-| (Quad,Quad)
+| (Double,Double)
 | (S128,S128)
   -> 0
-| ((Short|Word|Quad|S128),Byte)
-| ((Word|Quad|S128),Short)
-| ((Quad|S128),Word)
-| (S128,Quad)
+| ((Short|Word|Double|S128),Byte)
+| ((Word|Double|S128),Short)
+| ((Double|S128),Word)
+| (S128,Double)
     -> 1
 
 let equal sz1 sz2 = compare sz1 sz2 = 0
@@ -182,24 +182,24 @@ let min sz1 sz2 = if compare sz1 sz2 <= 0 then sz1 else sz2
 let pred = function
   | Byte|Short -> Byte
   | Word -> Short
-  | Quad -> Word
-  | S128 -> Quad
+  | Double -> Word
+  | S128 -> Double
 
 let at_least_word = function
-  | Quad|S128 as sz -> sz
+  | Double|S128 as sz -> sz
   | Word|Short|Byte -> Word
 
 module Tag = struct
 
   type t = Auto | Size of sz
 
-  let tags = ["auto";"byte";"short";"word";"quad";"s128"]
+  let tags = ["auto";"byte";"short";"word";"double";"quad";"s128"]
 
   let parse tag = match Misc.lowercase tag with
   | "byte" -> Some (Size Byte)
   | "short" -> Some (Size Short)
   | "word" -> Some (Size Word)
-  | "quad" -> Some (Size Quad)
+  | "double"|"quad" -> Some (Size Double)
   | "s128" -> Some (Size S128)
   | "auto" -> Some Auto
   | _      -> None

--- a/lib/machSize.mli
+++ b/lib/machSize.mli
@@ -14,7 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type sz = Byte | Short | Word | Quad | S128
+type sz = Byte | Short | Word | Double | S128
 
 val pp : sz -> string
 val pp_short : sz -> string

--- a/lib/machSize.mli
+++ b/lib/machSize.mli
@@ -14,7 +14,7 @@
 (* "http://www.cecill.info". We also give a copy in LICENSE.txt.            *)
 (****************************************************************************)
 
-type sz = Byte | Short | Word | Double | S128
+type sz = Byte | Short | Word | Double | Quad
 
 val pp : sz -> string
 val pp_short : sz -> string

--- a/lib/symbValue.ml
+++ b/lib/symbValue.ml
@@ -644,7 +644,7 @@ module
   let cap_perm_load = 1 lsl 17
 
   let lo64 x =
-    Cst.Scalar.mask MachSize.Quad x
+    Cst.Scalar.mask MachSize.Double x
 
   let hi64 x =
     Cst.Scalar.shift_left (Cst.Scalar.shift_right_logical x 64) 64
@@ -750,7 +750,7 @@ module
     let tag1 = if Cst.Scalar.get_tag v1 then 1 else 0 in
     let tag2 = if Cst.Scalar.get_tag v2 then 1 else 0 in
     if tag1 = tag2
-      then Cst.Scalar.mask MachSize.Quad (Cst.Scalar.sub v1 v2)
+      then Cst.Scalar.mask MachSize.Double (Cst.Scalar.sub v1 v2)
       else Cst.Scalar.of_int ((tag1 - tag2) land 3)
 
   let check_perms perms a v =

--- a/lib/testType.ml
+++ b/lib/testType.ml
@@ -54,7 +54,7 @@ let size_of maximal = function
 | "uint32_t" ->  MachSize.Word
 | "char"|"int8_t" |"uint8_t" -> MachSize.Byte
 | "short" | "int16_t" | "uint16_t" -> MachSize.Short
-| "int64_t" | "uint64_t" -> MachSize.Quad
+| "int64_t" | "uint64_t" -> MachSize.Double
 | "__int128_t" | "__uint128_t"
 | "__int128" | "__uint128"
 | "int128_t" | "uint128_t" -> MachSize.S128

--- a/lib/testType.ml
+++ b/lib/testType.ml
@@ -57,7 +57,7 @@ let size_of maximal = function
 | "int64_t" | "uint64_t" -> MachSize.Double
 | "__int128_t" | "__uint128_t"
 | "__int128" | "__uint128"
-| "int128_t" | "uint128_t" -> MachSize.S128
+| "int128_t" | "uint128_t" -> MachSize.Quad
 | "intptr_t" | "uintptr_t" | "pteval_t" | "parel1_t"
   -> maximal (* Maximal size = ptr size *)
 | t -> Warn.fatal "Cannot find the size of type %s" t

--- a/lib/uint128Scalar.ml
+++ b/lib/uint128Scalar.ml
@@ -49,7 +49,7 @@ let mask sz =
   | Byte -> fun v -> Uint128.logand v (Uint128.of_uint8 Uint8.max_int)
   | Short -> fun v -> Uint128.logand v (Uint128.of_uint16 Uint16.max_int)
   | Word -> fun v ->  Uint128.logand v (Uint128.of_uint32 Uint32.max_int)
-  | Quad -> fun v -> Uint128.logand v (Uint128.of_uint64 Uint64.max_int)
+  | Double -> fun v -> Uint128.logand v (Uint128.of_uint64 Uint64.max_int)
   | S128 -> fun v -> v
 
 let sxt sz v = match sz with

--- a/lib/uint128Scalar.ml
+++ b/lib/uint128Scalar.ml
@@ -34,7 +34,7 @@ let addk x k = match k with
   | 1 -> succ x
   | _ -> add x (of_int k)
 
-let machsize = MachSize.S128
+let machsize = MachSize.Quad
 let pp hexa v =
   Printf.sprintf "%s" (if hexa then (Uint128.to_string_hex v) else (Uint128.to_string v))
 let pp_unsigned = pp (* Hum *)
@@ -50,10 +50,10 @@ let mask sz =
   | Short -> fun v -> Uint128.logand v (Uint128.of_uint16 Uint16.max_int)
   | Word -> fun v ->  Uint128.logand v (Uint128.of_uint32 Uint32.max_int)
   | Double -> fun v -> Uint128.logand v (Uint128.of_uint64 Uint64.max_int)
-  | S128 -> fun v -> v
+  | Quad -> fun v -> v
 
 let sxt sz v = match sz with
-  | MachSize.S128 -> v
+  | MachSize.Quad -> v
   | _ ->
      let v = mask sz v in
      let nb = MachSize.nbits sz in

--- a/litmus/PPCCompile_litmus.ml
+++ b/litmus/PPCCompile_litmus.ml
@@ -80,11 +80,11 @@ module Make(V:Constant.S)(C:Config) =
     | Word.W64 -> fun i -> i
     | Word.W32|Word.WXX ->
         fun i -> match i with
-        | Pload (Quad,a1,a2,a3) -> Pload (Word,a1,a2,a3)
-        | Pstore (Quad,a1,a2,a3) -> Pstore (Word,a1,a2,a3)
-        | Ploadx (Quad,a1,a2,a3) -> Ploadx (Word,a1,a2,a3)
-        | Plwax (Quad,a1,a2,a3) -> Plwax (Word,a1,a2,a3)
-        | Pstorex (Quad,a1,a2,a3) -> Pstorex (Word,a1,a2,a3)
+        | Pload (Double,a1,a2,a3) -> Pload (Word,a1,a2,a3)
+        | Pstore (Double,a1,a2,a3) -> Pstore (Word,a1,a2,a3)
+        | Ploadx (Double,a1,a2,a3) -> Ploadx (Word,a1,a2,a3)
+        | Plwax (Double,a1,a2,a3) -> Plwax (Word,a1,a2,a3)
+        | Pstorex (Double,a1,a2,a3) -> Pstorex (Word,a1,a2,a3)
         | _ -> i
 
     let emit_lbl lbl =

--- a/litmus/preSi.ml
+++ b/litmus/preSi.ml
@@ -1465,7 +1465,7 @@ module Make
         end else begin
           let nvars = List.length test.T.globals in
           let voff =
-            Misc.max_int (MachSize.nbytes MachSize.Quad) (U.max_align test) in
+            Misc.max_int (MachSize.nbytes MachSize.Double) (U.max_align test) in
           let needed = voff*nvars in (* bytes needed *)
           let line = Cfg.line + Cfg.line * ((needed-1)/Cfg.line) in
           O.f "#define LINE %i" line ;

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -331,7 +331,7 @@ end
         let sz =
           match CType.base_size t with
           | Some sz -> sz
-          | None -> MachSize.Quad (* Largest available *) in
+          | None -> MachSize.Double (* Largest available *) in
         MachSize.nbytes sz
 
         let max_align test =

--- a/litmus/variant_litmus.ml
+++ b/litmus/variant_litmus.ml
@@ -17,7 +17,7 @@
 type t =
   | Self (* Self modifying code *)
   | FaultHandling of Fault.Handling.t
-  | S128 (* 128 bit signed ints*)
+  | Quad (* 128 bit signed ints*)
   | Mixed (* Ignored *)
   | Vmsa  (* Checked *)
   | ETS2
@@ -39,7 +39,7 @@ let (mode_variants, arch_variants) : t list * t list =
   let f = function
   | Self -> Self
   | FaultHandling p -> FaultHandling p 
-  | S128 -> S128
+  | Quad -> Quad
   | Mixed -> Mixed
   | Vmsa -> Vmsa
   | ETS2 -> ETS2
@@ -58,7 +58,7 @@ let (mode_variants, arch_variants) : t list * t list =
   | ConstPacField -> ConstPacField
   in
   let base_modes =
-    List.map f [NoInit; S128; Telechat]
+    List.map f [NoInit; Quad; Telechat]
   and archs =
     List.map f
     [SVE; SME; Self; Mixed; Vmsa; ETS2; ExS; EIS; EOS;
@@ -85,7 +85,7 @@ let compare = compare
 
 let parse s = match Misc.lowercase s with
 | "noinit" -> Some NoInit
-| "s128" -> Some S128
+| "quad"|"s128" -> Some Quad
 | "ifetch"|"self" -> Some Self
 | "mixed" -> Some Mixed
 | "vmsa"|"kvm" -> Some Vmsa
@@ -129,7 +129,7 @@ let pp = function
   | NoInit -> "noinit"
   | Self -> "self"
   | Mixed -> "mixed"
-  | S128 -> "s128"
+  | Quad -> "s128"
   | Vmsa -> "vmsa"
   | ETS2 -> "ets2"
   | ExS -> "exs"

--- a/litmus/variant_litmus.mli
+++ b/litmus/variant_litmus.mli
@@ -17,7 +17,7 @@
 type t =
   | Self (* Self modifying code *)
   | FaultHandling of Fault.Handling.t
-  | S128 (* 128 bit signed ints*)
+  | Quad (* 128 bit signed ints*)
   | Mixed (* Ignored *)
   | Vmsa  (* Checked *)
   | ETS2 (* FEAT_ETS2 *)


### PR DESCRIPTION
This PR updates the machine-size terminology so that 64-bit values use Double/double and 128-bit values use Quad/quad.

  Changes include:

  - Rename the old 64-bit Quad size to Double.
  - Rename the old 128-bit S128 size to Quad.
  - Update architecture, parser, generator, scalar, variant, and litmus references to use the new names.
  - Keep s128 accepted as a compatibility alias where machine-size/variant tags are parsed.
  - Update C instruction tests and configs to use the new Quad variant naming.