### PR TITLE
[herd] Add special clause `include $dirname...` in configuration file

### DIFF
--- a/doc/herd.tex
+++ b/doc/herd.tex
@@ -2051,7 +2051,11 @@ lines ``\textit{key} \textit{arg}'' are interpreted
 as setting the value of parameter~\textit{key} to \textit{arg}.
 Each parameter has a corresponding option,
 usually \opt{-}\textit{key}, except for the single letter
-option \opt{-v} whose parameter is \opt{verbose}.
+options \opt{-v} whose parameter is \opt{verbose} and
+\opt{-I} whose parameter is \opt{include}. Additionally,
+the special syntax \opt{include $dirname} is recognised
+when being a prefix of the argument of the parameter~\opt{include}.
+This prefix stands for the directory name of the configuration file.
 
 As command line option are processed left-to-right,
 settings from a configuration file (option \opt{-conf})

--- a/herd/lexConf_herd.mll
+++ b/herd/lexConf_herd.mll
@@ -119,7 +119,13 @@ let handle_key dir main key arg = match key with
 | "verbose" ->  lex_int verbose arg
 | "suffix" ->  suffix := arg
 | "include" ->
-   includes := !includes @ [arg]
+     let arg =
+       let pat = "$dirname" in
+       if String.starts_with ~prefix:pat arg then
+         let lpat = String.length pat in
+         dir ^ String.sub arg lpat (String.length arg - lpat)
+       else arg in
+     includes := !includes @ [arg]
 | "timeout" ->
    lex_float_opt timeout arg
 | "debug" ->


### PR DESCRIPTION
If the argument to the include directive starts with the string $dirname, then `$dirname` is replaced with the directory of the configuration file. The resulting string is added to **herd7** search path.

This feature has been extracted from the initial version of PR #1942 and made into a PR for discussion and reference.