### PR TITLE
[herd,asl,vmsa] Better handle double pte reads for hardware updates

### DIFF
--- a/catalogue/aarch64-VMSA/cfgs/asl.cfg
+++ b/catalogue/aarch64-VMSA/cfgs/asl.cfg
@@ -1,5 +1,6 @@
 variant asl,vmsa,strict,fatal,d128
 timeout 300
+
 ## ADR inside
 nonames S-I2V+dmb.st+data_Imp_TTD_R
 nonames S-I2V+dmb.st+ctrl_Imp_TTD_R
@@ -14,8 +15,8 @@ nonames MP-via_fault_STLR
 nonames R-via_fault_STR
 nonames CASAL+FAIL+FH
 nonames CASAL+FAIL2+FH
-## Allow vs. Forbidden kind, beacuse of two PTE reads?
-nonames RW+RR-DMBLD+DMBLD-SWP4+WREG,WW+RR-DMBST+DMBLD-SWP4+WREG
+
+## Producting graphs
 graph cluster
 squished true
 showevents noregs

--- a/herd/AArch64ASLSem.ml
+++ b/herd/AArch64ASLSem.ml
@@ -1753,6 +1753,8 @@ module Make (TopConf : AArch64Sig.Config) (V : Value.AArch64ASL) :
       match ii.A.inst with
        (* Specific -> get TLBI key *)
       | I_OP3 (V64,LSR,_,_,OpExt.Imm (12,0))
+       (* Unsupported by the Arm ARM since M.c: only SY is supported. *)
+      | I_FENCE (DMB ((NSH | OSH | ISH), _))
       (* Register or zero comparison, 64 is for addresses and pteval,
          32 is for instructions *)
       | I_OP3 ((V64|V32),SUBS,ZR,_,

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -645,12 +645,6 @@ module Make (Conf : Config) = struct
     let read_memory ii ~n ~addr =
       do_read_memory ii addr n aneutral aexp avir
 
-    let read_pte ii ~n ~addr =
-      (* We do all the operations with 64 bits, even if the argument passed is different. *)
-      let* _ = n in
-      do_read_memory ii addr (M.unitT (V.intToV 64))
-        aneutral (AArch64Explicit.(NExp Other)) apte
-
     let read_memory_gen ii ~n ~addr ~accdesc ~access =
       let* accdesc = accdesc and* access = access in
       do_read_memory ii addr n (accdesc_to_annot Read accdesc)
@@ -675,41 +669,31 @@ module Make (Conf : Config) = struct
  * sets that appear in the aarch64.cat model source text.
  *)
 
-    let as_bool b_m =
-      let* b =  b_m in
-      let (>>=) = Option.bind in
-      V.as_scalar b >>= ASLScalar.as_bool |>
-      fun b -> M.unitT (Misc.as_some b)
+    let tthm = Option.value Conf.dirty ~default:DirtyBit.soft
 
-    let pte_nexp_nat proc is_write =
+    let pte_nexp_nat proc =
       let open DirtyBit in
       let open AArch64Explicit in
-      let d =
-        match Conf.dirty with
-        | None -> soft
-        | Some d -> d in
       NExp
-        (if is_write then
-           if d.hd proc then AFDB
-           else if d.ha proc then AF
-           else Other
-         else if d.ha proc then AF
+        (if tthm.hd proc then AFDB
+         else if tthm.ha proc then AF
          else Other)
 
-    (* Always quad size, whatever parameter _N is *)
-    let size_m_64 =  M.unitT (V.intToV 64)
+    let pte_read_annot proc =
+      let open DirtyBit in
+      if tthm.ha proc then aatomic else aneutral
 
-    (* Second pte read, used for flag update *)
-    let read_pte_again (iinst,_ as ii) ~n:_ ~addr ~is_write =
-      let* is_write = as_bool is_write in
-      let nexp_nat = pte_nexp_nat iinst.A.proc is_write in
-      do_read_memory ii addr size_m_64
-        aatomic nexp_nat apte
+    (* Always quad size, whatever parameter _N is *)
+    let size_m_64 = M.unitT (V.intToV 64)
+
+    let read_pte (iinst, _ as ii) ~n:_ ~addr =
+      let nexp_nat = pte_nexp_nat iinst.A.proc in
+      let annot = pte_read_annot iinst.A.proc in
+      do_read_memory ii addr size_m_64 annot nexp_nat apte
 
     (* Pte write for flag update *)
-    let write_pte (iinst,_ as ii) ~n:_ ~addr ~data ~is_write =
-      let* is_write = as_bool is_write in
-      let nexp_nat = pte_nexp_nat iinst.A.proc is_write in
+    let write_pte (iinst,_ as ii) ~n:_ ~addr ~data =
+      let nexp_nat = pte_nexp_nat iinst.A.proc in
       do_write_memory ii addr size_m_64 data aatomic nexp_nat apte
 
     (*********************)
@@ -801,11 +785,10 @@ module Make (Conf : Config) = struct
       let read_memory_gen = read_memory_gen
       let write_memory = write_memory
       let write_memory_gen = write_memory_gen
-      let read_pte_primitive = read_pte
       let data_abort_primitive = data_abort_fault
       let get_ha_primitive = get_ha
       let get_hd_primitive = get_hd
-      let read_pte_again_primitive = read_pte_again
+      let read_pte_primitive = read_pte
       let write_pte_primitive = write_pte
       let check_prop = check_prop
       let check_eq = check_eq

--- a/herd/ASLSemPrimitives.asl
+++ b/herd/ASLSemPrimitives.asl
@@ -102,29 +102,17 @@ begin pass; end;
 // physmem-vmsa.asl. It creates an Implicit Memory Read Effect, without an
 // atomic annotation. It is only called in the case of an implicit TTD read,
 // i.e. when the acctype field of accdesc is set to AccessType_TTW. It is only
-// called for the first TTD read of an address translation, that is the
-// non-atomic one.
+// called for the first TTD read of an address translation.
 
 func ReadPtePrimitive{N}(addr: bits(56)) => bits(N)
 begin return ARBITRARY: bits(N); end;
-
-// ReadPteAgainPrimitive() is called by our re-implementation of the function
-// AArch64.MemSwapTableDesc() in patches-vmsa.asl. It performs an atomic
-// version of ReadPtePrimitive(), i.e. it creates an Implicit Memory Read
-// effect, with an atomic annotation. As MemSwapTableDesc(), it is called when
-// the translation system finds out that the page table descriptor for an
-// address needs to be updated, in our case only when the AF or nDB bits need
-// to be changed in memory.
-
-func ReadPteAgainPrimitive{N}(addr: bits(56), is_write: boolean) => bits(N)
-begin pass; end;
 
 // WritePtePrimitive() is the counterpart of the ReadPteAgainPrimitive(). It is
 // called by AArch64.MemSwapTableDesc() in patches-vmsa.asl, and is to write
 // back the updated page table descriptor in memory. It creates an Implicit
 // Memory Write Effect, with an atomic annotation.
 
-func WritePtePrimitive{N}(addr: bits(56), data: bits(N), is_write: boolean)
+func WritePtePrimitive{N}(addr: bits(56), data: bits(N))
 begin pass; end;
 
 // Not used by AArch64, simplifications for the `pseudo-arch` mode.

--- a/herd/libdir/asl-pseudocode/physmem-vmsa.asl
+++ b/herd/libdir/asl-pseudocode/physmem-vmsa.asl
@@ -79,7 +79,7 @@ begin
     write_memory_gen{size}(desc.paddress.address, value,accdesc,eventaccess);
 
   elsif accdesc.acctype == AccessType_TTW then
-   WritePtePrimitive{size}(desc.paddress.address, value, accdesc.write);
+   WritePtePrimitive{size}(desc.paddress.address, value);
 
   else unreachable;
   end;
@@ -107,6 +107,7 @@ func PhysMemRead{size : PhysMemSize}
   (desc : AddressDescriptor, accdesc : AccessDescriptor)
   => (PhysMemRetStatus, bits(size))
 begin
+  // Explicit reads
   if accdesc.acctype == AccessType_GPR then
     // Event access for herd7
     let eventaccess = _PhysEventAccess(desc.vaddress);
@@ -122,21 +123,27 @@ begin
 
     return (PhysMemRetStatus_NoFault, value);
 
+  // Implicit reads
   elsif accdesc.acctype == AccessType_TTW then
     if accdesc.atomicop then
-      let value = ReadPteAgainPrimitive{size}(desc.paddress.address, accdesc.write);
+      // Here we are in the second call to PhysMemRead. This call happens when
+      // a translation table descriptor has to be updated. The semantics in
+      // herd do not perform this read, so we ignore it. We simply return the
+      // value read before, stored in PteRead128 or PteRead64.
 
-      // Does not type-check, and pteread128 tests do not pass until we store
-      // size information with symbolic bitvectors
+      // The following line does not type-check, and pteread128 tests do not
+      // pass until we store size information with symbolic bitvectors
       let pte_read = if size == 128 then PteRead128 /* as bits(size) */
                                     else PteRead64 /* as bits(size) */;
-      CheckEq(value, pte_read);
 
       return (PhysMemRetStatus_NoFault, pte_read);
 
     else
+      // First read to a PTE
       let value = ReadPtePrimitive{size}(desc.paddress.address);
 
+      // We store the value read in PteRead128 or PteRead64 so that the next
+      // call to PhysMemRead can simply return this value.
       if size == 128 then
         PteRead128 = value /* as bits(128) */;
       else
@@ -146,6 +153,7 @@ begin
 
       return (PhysMemRetStatus_NoFault, value);
     end;
+
   else unreachable;
   end;
 end;


### PR DESCRIPTION
This PR aims at restoring the correct behaviour of `herd -variant asl` on the long catalogue AArch64+VMSA tests.

To test it (warning very long):
```sh
make test.herd-asl.cata.aarch64-VMSA
```

Second commit is a bit irrelevant so if needed I'll split the PR in 2.

## Adding previously ignored tests

_first commit_

Those tests were previously not run because the ASL semantics for AArch64 (with VMSA activated) produced different results than the handwritten AArch64 semantics. After #1889, this is not the case anymore, so this PR adds them to the tests run with `make test-all`.

To test, use (after building and installing, with asl-pseudocode):
```sh
herd7 -speedcheck true -conf catalogue/aarch64-VMSA/cfgs/asl.cfg catalogue/aarch64-VMSA/tests/WW+RR-DMBST+DMBLD-SWP4+WREG.litmus catalogue/aarch64-VMSA/tests/RW+RR-DMBLD+DMBLD-SWP4+WREG.litmus
herd7 -speedcheck true catalogue/aarch64-VMSA/tests/WW+RR-DMBST+DMBLD-SWP4+WREG.litmus catalogue/aarch64-VMSA/tests/RW+RR-DMBLD+DMBLD-SWP4+WREG.litmus
```

## Ignoring the second call to PhysMemRead for hardware updates

_third commit_

There is a divergence in the model for hardware updates in herd and in the ASL in the Arm ARM: the herd semantics only perform a single read when the ASL in the Arm ARM performs 2 reads: a first, non-atomic, implicit effect reads the PTE, and if the PTE needs writing (in case of an hardware update), then a second atomic effect re-reads the PTE. If the values read in the two effects are different, then the translation is re-started.

Before this PR, we were generating a memory effect per call to `PhysMemRead`, but in order to avoid the expensive control-loop that ensures that the two values are equal, we were forcing the two values to be equal.

With this PR, we completely remove the second memory effect, and we return the same value for both calls to `PhysMemRead`.

This commit also rework the annotations placed on implicit effects. Some previous code was using the `accdesc.write` boolean flag of the access descriptor associated with the implicit accesses to understand if the explicit write was writing. This was an error as this flag only represents if the implicit access is writing. This commits thus defaults its value to true and inlines it.

## Flexible behaviour for DMBs

_second commit_

With #1890, we updated the ASL pseudocode to the version M.c of the Arm ARM. This version removes the uses of `DMB ISH`, `DMB OSH` and `DMB NSH`, only leaving `DMB SY`, and so #1890 was removing their semantics from `AArch64ASLSem.ml`.
This caused some problems for a few tests in the VMSA catalogue which now do not pass.
We fixed this by allowing the ASL semantics for AArch64 to simply call the handwritten semantics for those deprecated instructions.