### PR TITLE
[asl] Capture of ASL print output and error messages

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -66,6 +66,7 @@ module type Config = sig
   val display_call_stack_on_error : bool
   val track_symbolic_path : bool
   val bit_clear_optimisation : bool
+  val out_buffer : Buffer.t option
 end
 
 module Make (B : Backend.S) (C : Config) = struct
@@ -1239,9 +1240,15 @@ module Make (B : Backend.S) (C : Config) = struct
               e_list
               (pp_print_list ~pp_sep:pp_print_space pp_value)
               v_list
-          else (
-            List.map B.debug_value v_list |> String.concat "" |> print_string;
-            if newline then print_newline () else ())
+          else
+            let output = List.map B.debug_value v_list |> String.concat "" in
+            match C.out_buffer with
+            | None ->
+                print_string output;
+                if newline then print_newline ()
+            | Some buf ->
+                Buffer.add_string buf output;
+                if newline then Buffer.add_string buf "\n"
         in
         return_continue new_env |: SemanticsRule.SPrint
     (* End *)

--- a/asllib/Interpreter.mli
+++ b/asllib/Interpreter.mli
@@ -80,6 +80,9 @@ module type Config = sig
 
   val bit_clear_optimisation : bool
   (** Interpret [a AND NOT b] as [a BIC b]. *)
+
+  val out_buffer : Buffer.t option
+  (** Print ASL output to stdout when [None], or to [buf] when [Some buf]. *)
 end
 
 module Make (B : Backend.S) (C : Config) : S with module B = B

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -487,40 +487,42 @@ module DeterministicInterpreter (I : Instrumentation.SEMINSTR) =
 
 module DeterministicInterpreterNoInstr =
   DeterministicInterpreter (Instrumentation.SemanticsNoInstr)
-
-module DeterministicInterpreterSingleSetInstr =
-  DeterministicInterpreter (Instrumentation.SemanticsSingleSetInstr)
+(** Fast path for interpretation: no instrumentation and no custom output *)
 
 let exit_value = function
   | NV_Literal (L_Int i) -> i |> Z.to_int
   | v -> mismatch_type v [ integer' ]
 
-let interpret ?instrumentation ?out_buffer static_env main_name ast =
-  match instrumentation with
-  | Some true ->
+let interpret ?(instrumentation = false) ?out_buffer static_env main_name ast =
+  match (instrumentation, out_buffer) with
+  | false, None ->
+      let res =
+        DeterministicInterpreterNoInstr.run_typed static_env main_name ast
+      in
+      (exit_value res, [])
+  | false, Some buf ->
+      let module Interpret =
+        Interpreter.Make
+          (DeterministicBackend)
+          (NativeConfig
+             (Instrumentation.SemanticsNoInstr)
+             (struct
+               let out_buffer = Some buf
+             end))
+      in
+      let res = Interpret.run_typed static_env main_name ast in
+      (exit_value res, [])
+  | true, _ ->
       let module B = Instrumentation.SemanticsSingleSetBuffer in
       B.reset ();
-      let res =
-        DeterministicInterpreterSingleSetInstr.run_typed static_env main_name
-          ast
+      let module Interpret =
+        Interpreter.Make
+          (DeterministicBackend)
+          (NativeConfig
+             (Instrumentation.SemanticsSingleSetInstr)
+             (struct
+               let out_buffer = out_buffer
+             end))
       in
+      let res = Interpret.run_typed static_env main_name ast in
       (exit_value res, B.get ())
-  | Some false | None -> (
-      match out_buffer with
-      | None ->
-          let res =
-            DeterministicInterpreterNoInstr.run_typed static_env main_name ast
-          in
-          (exit_value res, [])
-      | Some buf ->
-          let module Interpret =
-            Interpreter.Make
-              (DeterministicBackend)
-              (NativeConfig
-                 (Instrumentation.SemanticsNoInstr)
-                 (struct
-                   let out_buffer = Some buf
-                 end))
-          in
-          let res = Interpret.run_typed static_env main_name ast in
-          (exit_value res, []))

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -459,7 +459,12 @@ module DeterministicBackend = struct
     deterministic_unknown_of_type ~eval_expr_sef ty
 end
 
-module NativeConfig (I : Instrumentation.SEMINSTR) = struct
+module NativeConfig
+    (I : Instrumentation.SEMINSTR)
+    (S : sig
+      val out_buffer : Buffer.t option
+    end) =
+struct
   let unroll = 0
   let recursive_unroll _ = None
   let error_handling_time = Error.Dynamic
@@ -468,12 +473,17 @@ module NativeConfig (I : Instrumentation.SEMINSTR) = struct
   let display_call_stack_on_error = false
   let track_symbolic_path = false
   let bit_clear_optimisation = false
+  let out_buffer = S.out_buffer
 
   module Instr = I
 end
 
+module UseStdout = struct
+  let out_buffer = None
+end
+
 module DeterministicInterpreter (I : Instrumentation.SEMINSTR) =
-  Interpreter.Make (DeterministicBackend) (NativeConfig (I))
+  Interpreter.Make (DeterministicBackend) (NativeConfig (I) (UseStdout))
 
 module DeterministicInterpreterNoInstr =
   DeterministicInterpreter (Instrumentation.SemanticsNoInstr)
@@ -485,7 +495,7 @@ let exit_value = function
   | NV_Literal (L_Int i) -> i |> Z.to_int
   | v -> mismatch_type v [ integer' ]
 
-let interpret ?instrumentation static_env main_name ast =
+let interpret ?instrumentation ?out_buffer static_env main_name ast =
   match instrumentation with
   | Some true ->
       let module B = Instrumentation.SemanticsSingleSetBuffer in
@@ -495,8 +505,22 @@ let interpret ?instrumentation static_env main_name ast =
           ast
       in
       (exit_value res, B.get ())
-  | Some false | None ->
-      let res =
-        DeterministicInterpreterNoInstr.run_typed static_env main_name ast
-      in
-      (exit_value res, [])
+  | Some false | None -> (
+      match out_buffer with
+      | None ->
+          let res =
+            DeterministicInterpreterNoInstr.run_typed static_env main_name ast
+          in
+          (exit_value res, [])
+      | Some buf ->
+          let module Interpret =
+            Interpreter.Make
+              (DeterministicBackend)
+              (NativeConfig
+                 (Instrumentation.SemanticsNoInstr)
+                 (struct
+                   let out_buffer = Some buf
+                 end))
+          in
+          let res = Interpret.run_typed static_env main_name ast in
+          (exit_value res, []))

--- a/asllib/Native.mli
+++ b/asllib/Native.mli
@@ -46,6 +46,7 @@ module DeterministicInterpreter (I : Instrumentation.SEMINSTR) :
 
 val interpret :
   ?instrumentation:bool ->
+  ?out_buffer:Buffer.t ->
   StaticEnv.global ->
   AST.identifier ->
   AST.t ->

--- a/asllib/Runner.ml
+++ b/asllib/Runner.ml
@@ -49,6 +49,8 @@ type args = {
   no_stdlib0 : bool;
   v0_use_split_chunks : bool;
   version_eac1 : bool;
+  capture_output : (Buffer.t * Buffer.t) option;
+      (** Capture stdout/stderr (respectively) into the supplied buffers. *)
 }
 
 let default_args =
@@ -73,6 +75,7 @@ let default_args =
     no_stdlib0 = false;
     v0_use_split_chunks = false;
     version_eac1 = false;
+    capture_output = None;
   }
 
 (** Run ASLRef with the supplied arguments, and returns the exit code from the
@@ -153,6 +156,8 @@ let run (args : args) : int =
 
     let use_conflicting_side_effects_extension =
       args.use_conflicting_side_effects_extension
+
+    let err_buffer = Option.map snd args.capture_output
   end in
   let module T = Annotate (C) in
   let typed_ast, static_env = T.type_check_ast ast in
@@ -190,7 +195,9 @@ let run (args : args) : int =
     if args.exec then
       let instrumentation = if args.show_rules then true else false in
       let main_name = T.find_main static_env in
-      Native.interpret ~instrumentation static_env main_name typed_ast
+      let out_buffer = Option.map fst args.capture_output in
+      Native.interpret ~instrumentation ?out_buffer static_env main_name
+        typed_ast
     else (0, [])
   in
 
@@ -210,6 +217,7 @@ let safe_run args : int =
   with Error.ASLException e ->
     let module EP = Error.ErrorPrinter (struct
       let output_format = args.output_format
+      let err_buffer = Option.map snd args.capture_output
     end) in
     EP.eprintln e;
     1

--- a/asllib/StaticInterpreter.ml
+++ b/asllib/StaticInterpreter.ml
@@ -37,6 +37,10 @@ module InterpConf = struct
   let display_call_stack_on_error = false
   let track_symbolic_path = false
   let bit_clear_optimisation = false
+
+  (** Printing is considered impure by the type system, so we do not expect to
+      statically interpret print statements - no need to capture output. *)
+  let out_buffer = None
 end
 
 module SB = Native.StaticBackend

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -146,6 +146,7 @@ module type ANNOTATE_CONFIG = sig
   val fine_grained_side_effects : bool
   val use_conflicting_side_effects_extension : bool
   val override_mode : override_mode
+  val err_buffer : Buffer.t option
 end
 
 module type S = sig
@@ -4378,6 +4379,7 @@ module TypeCheckDefault = Annotate (struct
   let fine_grained_side_effects = false
   let use_conflicting_side_effects_extension = false
   let override_mode = Permissive
+  let err_buffer = None
 end)
 
 let type_and_run ?instrumentation ast =

--- a/asllib/Typing.mli
+++ b/asllib/Typing.mli
@@ -42,6 +42,7 @@ module type ANNOTATE_CONFIG = sig
   val fine_grained_side_effects : bool
   val use_conflicting_side_effects_extension : bool
   val override_mode : override_mode
+  val err_buffer : Buffer.t option
 end
 
 module type S = sig

--- a/asllib/aslref.ml
+++ b/asllib/aslref.ml
@@ -193,6 +193,7 @@ let parse_args () =
       no_stdlib0 = !no_stdlib0;
       v0_use_split_chunks = !v0_use_split_chunks;
       version_eac1 = !version_eac1;
+      capture_output = None;
     }
   in
 

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -719,12 +719,18 @@ type output_format = HumanReadable | CSV | GNU
 
 module type ERROR_PRINTER_CONFIG = sig
   val output_format : output_format
+  val err_buffer : Buffer.t option
 end
 
 module ErrorPrinter (C : ERROR_PRINTER_CONFIG) = struct
+  let err_formatter =
+    match C.err_buffer with
+    | None -> Format.err_formatter
+    | Some buf -> Format.formatter_of_buffer buf
+
   let eprintln e =
     match C.output_format with
-    | HumanReadable -> Format.eprintf "@[<2>%a@]@." pp_error e
+    | HumanReadable -> Format.fprintf err_formatter "@[<2>%a@]@." pp_error e
     | CSV -> Printf.eprintf "%a\n" pp_error_csv e
     | GNU -> Printf.eprintf "%a\n" (pp_gnu pp_error_desc) e
 

--- a/asllib/tests/capture_output.asl
+++ b/asllib/tests/capture_output.asl
@@ -1,0 +1,6 @@
+func main() => integer
+begin
+  println "test";
+  assert FALSE;
+  return 0;
+end;

--- a/asllib/tests/capture_output.expected
+++ b/asllib/tests/capture_output.expected
@@ -1,0 +1,12 @@
+exit code: 1
+
+stdout:
+test
+
+
+stderr:
+File capture_output.asl, line 4, characters 9 to 14:
+  assert FALSE;
+         ^^^^^
+ASL Dynamic error: Assertion failed: FALSE.
+

--- a/asllib/tests/capture_output.ml
+++ b/asllib/tests/capture_output.ml
@@ -1,0 +1,20 @@
+open Asllib
+
+let stdout_buf = Buffer.create 256
+let stderr_buf = Buffer.create 256
+
+let args =
+  Runner.
+    {
+      default_args with
+      exec = true;
+      capture_output = Some (stdout_buf, stderr_buf);
+      files = [ (NormalV1, "capture_output.asl") ];
+    }
+
+let code = Runner.safe_run args
+
+let () =
+  Printf.printf "exit code: %d\n\nstdout:\n%s\n\nstderr:\n%s\n" code
+    (Buffer.contents stdout_buf)
+    (Buffer.contents stderr_buf)

--- a/asllib/tests/dune
+++ b/asllib/tests/dune
@@ -31,7 +31,8 @@
    helpers
    ConstraintBinops
    Lexer
-   check_no_missing_file_in_run))
+   check_no_missing_file_in_run
+   capture_output))
  (flags
   (:standard -w -40-42))
  (action
@@ -39,6 +40,12 @@
    ASL_LIBDIR
    %{project_root}/asllib/libdir/
    (run %{test} -e))))
+
+(test
+ (name capture_output)
+ (modules capture_output)
+ (libraries asllib)
+ (deps capture_output.asl))
 
 (test
  (name Lexer)

--- a/herd/ASLSem.ml
+++ b/herd/ASLSem.ml
@@ -119,6 +119,7 @@ module Make (Conf : Config) = struct
     let fine_grained_side_effects = false
     let use_conflicting_side_effects_extension = false
     let override_mode = Asllib.Typing.Permissive
+    let err_buffer = None
   end)
 
   module ASLInterpreterConfig = struct
@@ -135,6 +136,7 @@ module Make (Conf : Config) = struct
     let display_call_stack_on_error = Conf.C.debug.Debug_herd.asl_stack
     let track_symbolic_path = true
     let bit_clear_optimisation = true
+    let out_buffer = None
 
     module Instr = Asllib.Instrumentation.SemanticsNoInstr
   end


### PR DESCRIPTION
Permit OCaml-level capture of ASLRef output.

- Covers ASL printed output (via `print`/`println`) and error messages reported by ASLRef.
- Enabled via the `Runner` module: two buffers (`Buffer.t`) can be supplied to enable capture.
- Parametrises the interpreter and the error printer to achieve this.