### PR TITLE
[herd,asl] Fix wrong archive structure for features.json

### DIFF
--- a/herd/libdir/asl-pseudocode/Makefile
+++ b/herd/libdir/asl-pseudocode/Makefile
@@ -31,7 +31,7 @@ SYSREGS_OFILE := system_registers.asl
 SYSREGS_TAR_GZ := $(SYSREGS_NAME).tar.gz
 
 FEATURES_DIR := Exploration-Tools-Arm-Architecture-Features/AARCHMRS
-FEATURES_NAME := Features.json
+FEATURES_NAME := AARCHMRS_A_profile_FAT-$(ARCHITECTURE_RELEASE)/Features.json
 FEATURES_OFILE := features.asl
 FEATURES_TAR_GZ := AARCHMRS_A_profile_FAT-$(ARCHITECTURE_RELEASE).tar.gz
 


### PR DESCRIPTION
@ShaleXIONG reports [failing workflows](https://github.com/herd/herdtools7/actions/runs/32128119375/job/95696774095) with the following error:
```
tar: Features.json: Not found in archive
```

This is reproduced very easily on my machine (`make clean-asl-pseudocode asl-pseudocode`).

It looks like the structure of the AARCHMRS archive has changed, so we update the extraction process to extract the correct file.