### PR TITLE
[asl] Tidying in errors

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -34,7 +34,6 @@ let fatal_from ~loc = Error.fatal_from loc
 let undefined_identifier ~loc x =
   fatal_from ~loc (Error.UndefinedIdentifier (Static, x))
 
-let invalid_expr e = fatal_from ~loc:e (Error.InvalidExpr e)
 let add_pos_from ~loc = add_pos_from loc
 
 let conflict ~loc expected provided =
@@ -357,7 +356,6 @@ module FunctionRenaming (C : ANNOTATE_CONFIG) = struct
             fatal_from ~loc
               (Error.MismatchedCallType
                  {
-                   error_handling_time = Static;
                    subprogram_name = name;
                    expected_call_type = call_type;
                    found_call_type = func_sig.subprogram_type;
@@ -1660,7 +1658,6 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           fatal_from ~loc
             (Error.MismatchedCallType
                {
-                 error_handling_time = Static;
                  subprogram_name = name;
                  expected_call_type = call_type;
                  found_call_type = func_sig.subprogram_type;
@@ -1694,7 +1691,6 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       fatal_from ~loc
         (MismatchedCallType
            {
-             error_handling_time = Static;
              subprogram_name = name;
              expected_call_type = call_type;
              found_call_type = callee.subprogram_type;
@@ -1848,7 +1844,6 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           fatal_from ~loc
             (Error.MismatchedCallType
                {
-                 error_handling_time = Static;
                  subprogram_name = name;
                  expected_call_type = call_type;
                  found_call_type = callee.subprogram_type;
@@ -2564,7 +2559,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                   annotate_set_array ~loc:le env t t_e (le2, ses2, e_index)
                 in
                 (t, le3, ses3)
-            | _ -> invalid_expr (expr_of_lexpr le1))
+            | _ ->
+                let e = expr_of_lexpr le1 in
+                fatal_from ~loc:e (Error.InvalidExpr e))
         | _ -> conflict ~loc:le1 [ default_t_bits ] t_le1
         (* End *))
     | LE_SetField (le1, field) ->

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1971,10 +1971,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         and t_false, e_false', ses_false = annotate_expr env e_false in
         let t =
           best_effort t_true (fun _ ->
-              match Types.lowest_common_ancestor ~loc:e env t_true t_false with
-              | None ->
-                  fatal_from ~loc (Error.UnreconcilableTypes (t_true, t_false))
-              | Some t -> t)
+              Types.lowest_common_ancestor ~loc:e env t_true t_false)
         in
         let ses = SES.union3 ses_cond ses_true ses_false in
         (t, E_Cond (e_cond', e_true', e_false') |> here, ses)

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -144,87 +144,7 @@ type warning_desc =
 
 type warning = warning_desc annotated
 
-let error_label = function
-  | ReservedIdentifier _ -> "ReservedIdentifier"
-  | BadField _ -> "BadField"
-  | BadPattern _ -> "BadPattern"
-  | MissingField _ -> "MissingField"
-  | BadSlices _ -> "BadSlices"
-  | BadSlice _ -> "BadSlice"
-  | EmptySlice -> "EmptySlice"
-  | TypeInferenceNeeded -> "TypeInferenceNeeded"
-  | UndefinedIdentifier _ -> "UndefinedIdentifier"
-  | MismatchedCallType _ -> "MismatchedCallType"
-  | BadArity _ -> "BadArity"
-  | BadParameterArity _ -> "BadParameterArity"
-  | UnsupportedBinop _ -> "UnsupportedBinop"
-  | UnsupportedUnop _ -> "UnsupportedUnop"
-  | UnsupportedExpr _ -> "UnsupportedExpr"
-  | UnsupportedTy _ -> "UnsupportedTy"
-  | InvalidExpr _ -> "InvalidExpr"
-  | MismatchType _ -> "MismatchType"
-  | ConflictingTypes _ -> "ConflictingTypes"
-  | AssertionFailed _ -> "AssertionFailed"
-  | CannotParse _ -> "CannotParse"
-  | UnknownSymbol _ -> "UnknownSymbol"
-  | NoCallCandidate _ -> "NoCallCandidate"
-  | BadTypesForBinop _ -> "BadTypesForBinop"
-  | ImpureExpression _ -> "ImpureExpression"
-  | MismatchedPurity _ -> "MismatchedPurity"
-  | UnreconcilableTypes _ -> "UnreconcilableTypes"
-  | AssignToImmutable _ -> "AssignToImmutable"
-  | AssignToTupleElement _ -> "AssignToTupleElement"
-  | AlreadyDeclaredIdentifier _ -> "AlreadyDeclaredIdentifier"
-  | BadReturnStmt _ -> "BadReturnStmt"
-  | UnexpectedSideEffect _ -> "UnexpectedSideEffect"
-  | UncaughtException _ -> "UncaughtException"
-  | OverlappingSlices _ -> "OverlappingSlices"
-  | BadLDI _ -> "BadLDI"
-  | BadRecursiveDecls _ -> "BadRecursiveDecls"
-  | UnrespectedParserInvariant -> "UnrespectedParserInvariant"
-  | BadATC _ -> "BadATC"
-  | ConstrainedIntegerExpected _ -> "ConstrainedIntegerExpected"
-  | ParameterWithoutDecl _ -> "ParameterWithoutDecl"
-  | BadParameterDecl _ -> "BadParameterDecl"
-  | BaseValueEmptyType _ -> "BaseValueEmptyType"
-  | ArbitraryEmptyType _ -> "ArbitraryEmptyType"
-  | BaseValueNonSymbolic _ -> "BaseValueNonSymbolic"
-  | SetterWithoutCorrespondingGetter _ -> "SetterWithoutCorrespondingGetter"
-  | NonReturningFunction _ -> "NonReturningFunction"
-  | NoreturnViolation _ -> "NoreturnViolation"
-  | UnreachableReached -> "UnreachableReached"
-  | LoopLimitReached -> "LoopLimitReached"
-  | RecursionLimitReached _ -> "RecursionLimitReached"
-  | EmptyConstraints -> "EmptyConstraints"
-  | UnexpectedPendingConstrained -> "UnexpectedPendingConstrained"
-  | BitfieldsDontAlign _ -> "BitfieldsDontAlign"
-  | ExpectedSingularType _ -> "ExpectedSingularType"
-  | ExpectedNamedType _ -> "ExpectedNamedType"
-  | ConflictingSideEffects _ -> "ConflictingSideEffects"
-  | ConstantTimeBroken _ -> "ConstantTimeBroken"
-  | MultipleWrites _ -> "MultipleWrites"
-  | UnexpectedInitialisationThrow _ -> "UnexpectedInitialisationThrow"
-  | NegativeArrayLength _ -> "NegativeArrayLength"
-  | MultipleImplementations _ -> "ClashingImplementations"
-  | NoOverrideCandidate -> "NoOverrideCandidate"
-  | TooManyOverrideCandidates _ -> "TooManyOverrideCandidates"
-  | PrecisionLostDefining -> "PrecisionLostDefining"
-  | UnexpectedCollection -> "UnexpectedCollection"
-  | BadPrimitiveArgument _ -> "BadPrimitiveArgument"
-  | NoEntryPoint -> "NoEntryPoint"
-  | ObsoleteSyntax _ -> "ObsoleteSyntax"
-
-let warning_label = function
-  | NoLoopLimit -> "NoLoopLimit"
-  | IntervalTooBigToBeExploded _ -> "IntervalTooBigToBeExploded"
-  | ConstraintSetPairToBigToBeExploded _ -> "ConstraintSetPairToBigToBeExploded"
-  | RemovingValuesFromConstraints _ -> "RemovingValuesFromConstraints"
-  | NoRecursionLimit _ -> "NoRecursionLimit"
-  | PragmaUse _ -> "PragmaUse"
-  | UnexpectedImplementation -> "UnexpectedImplementation"
-  | MissingOverride -> "MissingOverride"
-
-open struct
+module PrintContext = struct
   (* Straight out of stdlib v5.2 *)
   let with_open filename continuation =
     let chan = open_in filename in
@@ -629,7 +549,7 @@ module PPrint = struct
           "Missing `implementation` for `impdef` function."
 
   let pp_pos_begin f pos =
-    match display_error_context pos with
+    match PrintContext.display_error_context pos with
     | None when ASTUtils.is_dummy_pos pos -> ()
     | None -> fprintf f "@[<h>%a:@]@ " pp_pos pos
     | Some ctx -> fprintf f "@[<h>%a:@]@ %s@ " pp_pos pos ctx
@@ -651,37 +571,122 @@ end
 
 include PPrint
 
-let escape s =
-  let b = Buffer.create (String.length s) in
-  String.iter
-    (function
-      | '"' ->
-          Buffer.add_char b '"';
-          Buffer.add_char b '"'
-      | c -> Buffer.add_char b c)
-    s;
-  Buffer.contents b
+module CSV = struct
+  let error_label = function
+    | ReservedIdentifier _ -> "ReservedIdentifier"
+    | BadField _ -> "BadField"
+    | BadPattern _ -> "BadPattern"
+    | MissingField _ -> "MissingField"
+    | BadSlices _ -> "BadSlices"
+    | BadSlice _ -> "BadSlice"
+    | EmptySlice -> "EmptySlice"
+    | TypeInferenceNeeded -> "TypeInferenceNeeded"
+    | UndefinedIdentifier _ -> "UndefinedIdentifier"
+    | MismatchedCallType _ -> "MismatchedCallType"
+    | BadArity _ -> "BadArity"
+    | BadParameterArity _ -> "BadParameterArity"
+    | UnsupportedBinop _ -> "UnsupportedBinop"
+    | UnsupportedUnop _ -> "UnsupportedUnop"
+    | UnsupportedExpr _ -> "UnsupportedExpr"
+    | UnsupportedTy _ -> "UnsupportedTy"
+    | InvalidExpr _ -> "InvalidExpr"
+    | MismatchType _ -> "MismatchType"
+    | ConflictingTypes _ -> "ConflictingTypes"
+    | AssertionFailed _ -> "AssertionFailed"
+    | CannotParse _ -> "CannotParse"
+    | UnknownSymbol _ -> "UnknownSymbol"
+    | NoCallCandidate _ -> "NoCallCandidate"
+    | BadTypesForBinop _ -> "BadTypesForBinop"
+    | ImpureExpression _ -> "ImpureExpression"
+    | MismatchedPurity _ -> "MismatchedPurity"
+    | UnreconcilableTypes _ -> "UnreconcilableTypes"
+    | AssignToImmutable _ -> "AssignToImmutable"
+    | AssignToTupleElement _ -> "AssignToTupleElement"
+    | AlreadyDeclaredIdentifier _ -> "AlreadyDeclaredIdentifier"
+    | BadReturnStmt _ -> "BadReturnStmt"
+    | UnexpectedSideEffect _ -> "UnexpectedSideEffect"
+    | UncaughtException _ -> "UncaughtException"
+    | OverlappingSlices _ -> "OverlappingSlices"
+    | BadLDI _ -> "BadLDI"
+    | BadRecursiveDecls _ -> "BadRecursiveDecls"
+    | UnrespectedParserInvariant -> "UnrespectedParserInvariant"
+    | BadATC _ -> "BadATC"
+    | ConstrainedIntegerExpected _ -> "ConstrainedIntegerExpected"
+    | ParameterWithoutDecl _ -> "ParameterWithoutDecl"
+    | BadParameterDecl _ -> "BadParameterDecl"
+    | BaseValueEmptyType _ -> "BaseValueEmptyType"
+    | ArbitraryEmptyType _ -> "ArbitraryEmptyType"
+    | BaseValueNonSymbolic _ -> "BaseValueNonSymbolic"
+    | SetterWithoutCorrespondingGetter _ -> "SetterWithoutCorrespondingGetter"
+    | NonReturningFunction _ -> "NonReturningFunction"
+    | NoreturnViolation _ -> "NoreturnViolation"
+    | UnreachableReached -> "UnreachableReached"
+    | LoopLimitReached -> "LoopLimitReached"
+    | RecursionLimitReached _ -> "RecursionLimitReached"
+    | EmptyConstraints -> "EmptyConstraints"
+    | UnexpectedPendingConstrained -> "UnexpectedPendingConstrained"
+    | BitfieldsDontAlign _ -> "BitfieldsDontAlign"
+    | ExpectedSingularType _ -> "ExpectedSingularType"
+    | ExpectedNamedType _ -> "ExpectedNamedType"
+    | ConflictingSideEffects _ -> "ConflictingSideEffects"
+    | ConstantTimeBroken _ -> "ConstantTimeBroken"
+    | MultipleWrites _ -> "MultipleWrites"
+    | UnexpectedInitialisationThrow _ -> "UnexpectedInitialisationThrow"
+    | NegativeArrayLength _ -> "NegativeArrayLength"
+    | MultipleImplementations _ -> "ClashingImplementations"
+    | NoOverrideCandidate -> "NoOverrideCandidate"
+    | TooManyOverrideCandidates _ -> "TooManyOverrideCandidates"
+    | PrecisionLostDefining -> "PrecisionLostDefining"
+    | UnexpectedCollection -> "UnexpectedCollection"
+    | BadPrimitiveArgument _ -> "BadPrimitiveArgument"
+    | NoEntryPoint -> "NoEntryPoint"
+    | ObsoleteSyntax _ -> "ObsoleteSyntax"
 
-let pp_csv pp_desc label =
-  let pos_in_line pos = Lexing.(pos.pos_cnum - pos.pos_bol) in
-  fun f pos ->
-    Printf.fprintf f "\"%s\",%d,%d,%d,%d,%s,\"%s\""
-      (escape pos.pos_start.pos_fname)
-      pos.pos_start.pos_lnum
-      (pos_in_line pos.pos_start)
-      pos.pos_end.pos_lnum (pos_in_line pos.pos_end) (label pos.desc)
-      (desc_to_string_inf pp_desc pos |> escape)
+  let warning_label = function
+    | NoLoopLimit -> "NoLoopLimit"
+    | IntervalTooBigToBeExploded _ -> "IntervalTooBigToBeExploded"
+    | ConstraintSetPairToBigToBeExploded _ ->
+        "ConstraintSetPairToBigToBeExploded"
+    | RemovingValuesFromConstraints _ -> "RemovingValuesFromConstraints"
+    | NoRecursionLimit _ -> "NoRecursionLimit"
+    | PragmaUse _ -> "PragmaUse"
+    | UnexpectedImplementation -> "UnexpectedImplementation"
+    | MissingOverride -> "MissingOverride"
 
-let pp_error_csv f e = pp_csv pp_error_desc error_label f e
-let pp_warning_csv f w = pp_csv pp_warning_desc warning_label f w
+  let escape s =
+    let b = Buffer.create (String.length s) in
+    String.iter
+      (function
+        | '"' ->
+            Buffer.add_char b '"';
+            Buffer.add_char b '"'
+        | c -> Buffer.add_char b c)
+      s;
+    Buffer.contents b
 
-let pp_gnu pp_desc =
-  let pos_in_line pos = Lexing.(pos.pos_cnum - pos.pos_bol) in
-  fun f pos ->
-    Printf.fprintf f "aslref: %s:%d:%d: %s" pos.pos_start.pos_fname
-      pos.pos_start.pos_lnum
-      (pos_in_line pos.pos_start)
-      (desc_to_string_inf pp_desc pos)
+  let pp_csv pp_desc label =
+    let pos_in_line pos = Lexing.(pos.pos_cnum - pos.pos_bol) in
+    fun f pos ->
+      Printf.fprintf f "\"%s\",%d,%d,%d,%d,%s,\"%s\""
+        (escape pos.pos_start.pos_fname)
+        pos.pos_start.pos_lnum
+        (pos_in_line pos.pos_start)
+        pos.pos_end.pos_lnum (pos_in_line pos.pos_end) (label pos.desc)
+        (desc_to_string_inf pp_desc pos |> escape)
+
+  let pp_error f e = pp_csv pp_error_desc error_label f e
+  let pp_warning f w = pp_csv pp_warning_desc warning_label f w
+end
+
+module GNU = struct
+  let pp pp_desc =
+    let pos_in_line pos = Lexing.(pos.pos_cnum - pos.pos_bol) in
+    fun f pos ->
+      Printf.fprintf f "aslref: %s:%d:%d: %s" pos.pos_start.pos_fname
+        pos.pos_start.pos_lnum
+        (pos_in_line pos.pos_start)
+        (desc_to_string_inf pp_desc pos)
+end
 
 type output_format = HumanReadable | CSV | GNU
 
@@ -699,14 +704,14 @@ module ErrorPrinter (C : ERROR_PRINTER_CONFIG) = struct
   let eprintln e =
     match C.output_format with
     | HumanReadable -> Format.fprintf err_formatter "@[<2>%a@]@." pp_error e
-    | CSV -> Printf.eprintf "%a\n" pp_error_csv e
-    | GNU -> Printf.eprintf "%a\n" (pp_gnu pp_error_desc) e
+    | CSV -> Printf.eprintf "%a\n" CSV.pp_error e
+    | GNU -> Printf.eprintf "%a\n" (GNU.pp pp_error_desc) e
 
   let warn w =
     match C.output_format with
     | HumanReadable -> Format.eprintf "@[<2>%a@]@." pp_warning w
-    | CSV -> Printf.eprintf "%a\n" pp_warning_csv w
-    | GNU -> Printf.eprintf "%a\n" (pp_gnu pp_warning_desc) w
+    | CSV -> Printf.eprintf "%a\n" CSV.pp_warning w
+    | GNU -> Printf.eprintf "%a\n" (GNU.pp pp_warning_desc) w
 
   let warn_from ~loc w = ASTUtils.add_pos_from loc w |> warn
 end

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -36,7 +36,6 @@ type error_desc =
   | TypeInferenceNeeded
   | UndefinedIdentifier of error_handling_time * identifier
   | MismatchedCallType of {
-      error_handling_time : error_handling_time;
       subprogram_name : string;
       expected_call_type : subprogram_type;
       found_call_type : subprogram_type;
@@ -49,14 +48,12 @@ type error_desc =
   | UnsupportedTy of error_handling_time * ty
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
-  | NotYetImplemented of string
   | ConflictingTypes of type_desc list * ty
   | AssertionFailed of expr
   | CannotParse of string option
   | UnknownSymbol of string
   | NoCallCandidate of string * ty list
   | BadTypesForBinop of binop * ty * ty
-  | CircularDeclarations of string
   | ImpureExpression of expr * SideEffect.SES.t
       (** used for fine-grained analysis *)
   | MismatchedPurity of string  (** Used for coarse-grained analysis *)
@@ -80,12 +77,10 @@ type error_desc =
   | BaseValueEmptyType of ty
   | ArbitraryEmptyType of ty
   | BaseValueNonSymbolic of ty * expr
-  | SettingIntersectingSlices of bitfield list
   | SetterWithoutCorrespondingGetter of func
   | NonReturningFunction of identifier
   | NoreturnViolation of identifier
   | ConflictingSideEffects of SideEffect.t * SideEffect.t
-  | UnexpectedATC
   | UnreachableReached
   | LoopLimitReached
   | RecursionLimitReached of error_handling_time
@@ -99,7 +94,6 @@ type error_desc =
     }
   | ExpectedSingularType of ty
   | ExpectedNamedType of ty
-  | ConfigTimeBroken of expr * SideEffect.SES.t
   | ConstantTimeBroken of expr * SideEffect.SES.t
   | MultipleWrites of identifier
   | UnexpectedInitialisationThrow of
@@ -169,14 +163,12 @@ let error_label = function
   | UnsupportedTy _ -> "UnsupportedTy"
   | InvalidExpr _ -> "InvalidExpr"
   | MismatchType _ -> "MismatchType"
-  | NotYetImplemented _ -> "NotYetImplemented"
   | ConflictingTypes _ -> "ConflictingTypes"
   | AssertionFailed _ -> "AssertionFailed"
   | CannotParse _ -> "CannotParse"
   | UnknownSymbol _ -> "UnknownSymbol"
   | NoCallCandidate _ -> "NoCallCandidate"
   | BadTypesForBinop _ -> "BadTypesForBinop"
-  | CircularDeclarations _ -> "CircularDeclarations"
   | ImpureExpression _ -> "ImpureExpression"
   | MismatchedPurity _ -> "MismatchedPurity"
   | UnreconcilableTypes _ -> "UnreconcilableTypes"
@@ -197,11 +189,9 @@ let error_label = function
   | BaseValueEmptyType _ -> "BaseValueEmptyType"
   | ArbitraryEmptyType _ -> "ArbitraryEmptyType"
   | BaseValueNonSymbolic _ -> "BaseValueNonSymbolic"
-  | SettingIntersectingSlices _ -> "SettingIntersectingSlices"
   | SetterWithoutCorrespondingGetter _ -> "SetterWithoutCorrespondingGetter"
   | NonReturningFunction _ -> "NonReturningFunction"
   | NoreturnViolation _ -> "NoreturnViolation"
-  | UnexpectedATC -> "UnexpectedATC"
   | UnreachableReached -> "UnreachableReached"
   | LoopLimitReached -> "LoopLimitReached"
   | RecursionLimitReached _ -> "RecursionLimitReached"
@@ -211,7 +201,6 @@ let error_label = function
   | ExpectedSingularType _ -> "ExpectedSingularType"
   | ExpectedNamedType _ -> "ExpectedNamedType"
   | ConflictingSideEffects _ -> "ConflictingSideEffects"
-  | ConfigTimeBroken _ -> "ConfigTimeBroken"
   | ConstantTimeBroken _ -> "ConstantTimeBroken"
   | MultipleWrites _ -> "MultipleWrites"
   | UnexpectedInitialisationThrow _ -> "UnexpectedInitialisationThrow"
@@ -352,7 +341,7 @@ module PPrint = struct
           "Unsupported expression %a." pp_expr e
     | UnsupportedTy (t, ty) ->
         pp_err (error_handling_time_to_string t) "Unsupported type %a." pp_ty ty
-    | InvalidExpr e -> fprintf_err f typing "invalid expression %a." pp_expr e
+    | InvalidExpr e -> pp_err typing "invalid expression %a." pp_expr e
     | MismatchType (v, [ ty ]) ->
         pp_err dynamic "Mismatch type:@ value %s does not belong to type %a." v
           pp_type_desc ty
@@ -386,12 +375,7 @@ module PPrint = struct
     | UndefinedIdentifier (t, s) ->
         pp_err (error_handling_time_to_string t) "Undefined identifier:@ '%s'" s
     | MismatchedCallType
-        {
-          error_handling_time = t;
-          subprogram_name = s;
-          expected_call_type;
-          found_call_type;
-        } ->
+        { subprogram_name = s; expected_call_type; found_call_type } ->
         let call_type_description call_type =
           match call_type with
           | ST_Function -> "function"
@@ -399,8 +383,7 @@ module PPrint = struct
           | ST_Setter -> "setter"
           | ST_Procedure -> "procedure"
         in
-        pp_err
-          (error_handling_time_to_string t)
+        pp_err static
           "Mismatched call type for subprogram '%s': expected a %s and found a \
            %s."
           s
@@ -426,7 +409,6 @@ module PPrint = struct
               "Arity error while calling '%s':@ %d parameters expected and %d \
                provided"
               name expected provided)
-    | NotYetImplemented s -> pp_err internal "Not yet implemented: %s" s
     | ConflictingTypes ([ expected ], provided) ->
         pp_err typing "a subtype of@ %a@ was expected,@ provided %a."
           pp_type_desc expected pp_ty provided
@@ -454,11 +436,6 @@ module PPrint = struct
     | BadTypesForBinop (op, t1, t2) ->
         pp_err typing "Illegal application of operator %s on types@ %a@ and %a."
           (binop_to_string op) pp_ty t1 pp_ty t2
-    | CircularDeclarations x ->
-        pp_err dynamic
-          "ASL Evaluation error: circular definition of constants, including \
-           %S."
-          x
     | ImpureExpression (e, ses) ->
         pp_err typing
           "a pure expression was expected,@ found %a,@ which@ produces@ the@ \
@@ -522,9 +499,6 @@ module PPrint = struct
         pp_err typing
           "cannot@ perform@ Asserted@ Type@ Conversion@ on@ %a@ by@ %a." pp_ty
           t1 pp_ty t2
-    | SettingIntersectingSlices bitfields ->
-        pp_err typing "setting@ intersecting@ bitfields@ [%a]." pp_bitfields
-          bitfields
     | SetterWithoutCorrespondingGetter func ->
         let ret, args =
           match func.args with
@@ -535,7 +509,6 @@ module PPrint = struct
           "setter@ \"%s\"@ does@ not@ have@ a@ corresponding@ getter@ of@ \
            signature@ @[@[%a@]@ ->@ %a@]."
           func.name (pp_comma_list pp_ty) args pp_ty ret
-    | UnexpectedATC -> pp_err typing "unexpected ATC."
     | BadPattern (p, t) ->
         pp_err typing "Erroneous@ pattern@ %a@ for@ expression@ of@ type@ %a."
           pp_pattern p pp_ty t
@@ -554,11 +527,6 @@ module PPrint = struct
     | ConflictingSideEffects (s1, s2) ->
         pp_err typing "conflicting side effects %a and %a" SideEffect.pp_print
           s1 SideEffect.pp_print s2
-    | ConfigTimeBroken (e, ses) ->
-        pp_err typing
-          "expected@ config-time@ expression,@ got@ %a,@ which@ produces@ the@ \
-           following@ side-effects:@ %a."
-          pp_expr e SideEffect.SES.pp_print ses
     | ConstantTimeBroken (e, ses) ->
         pp_err typing
           "expected@ constant-time@ expression,@ got@ %a,@ which@ produces@ \

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -53,7 +53,7 @@ ASL Typing Tests:
       var o  = if ARBITRARY : boolean then arr1 else ex;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Type error: cannot find a common ancestor to those two types
-    array [[8]] of Word1 and Exc.
+    array [[8]] of Word1 and exception { i: integer }.
   [1]
   $ aslref --no-exec TypingRule.LowestCommonAncestor2.asl
   $ aslref TypingRule.ApplyUnopType.asl

--- a/asllib/tests/types.ml
+++ b/asllib/tests/types.ml
@@ -123,13 +123,17 @@ let lca_examples () =
   let bits_4 = !!(T_Bits (!$4, [])) in
   let bits_2 = !!(T_Bits (!$2, [])) in
 
-  assert (lowest_common_ancestor ~loc:bits_4 empty_env bits_4 bits_2 = None);
+  let _ =
+    try
+      let _ = lowest_common_ancestor ~loc:bits_4 empty_env bits_4 bits_2 in
+      assert false
+    with Error.ASLException { desc = Error.UnreconcilableTypes _ } -> ()
+  in
 
   let integer_4 = integer_exact !$4 in
   let integer_2 = integer_exact !$2 in
 
-  let lca = lowest_common_ancestor ~loc:bits_4 empty_env integer_4 integer_2 in
-  assert (Option.is_some lca);
+  let _ = lowest_common_ancestor ~loc:bits_4 empty_env integer_4 integer_2 in
   ()
 
 let type_clashes () =

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -581,22 +581,14 @@ let subprogram_clashes env (f1 : func) (f2 : func) =
 
 (* --------------------------------------------------------------------------*)
 
-(** [unpack_options li] is [Some [x1; ... x_n]] if [li] is
-    [[Some x1; ... Some x_n]], [None] otherwise *)
-let unpack_options li =
-  let exception NoneFound in
-  let unpack_one = function Some elt -> elt | None -> raise NoneFound in
-  try Some (List.map unpack_one li) with NoneFound -> None
-
 (* Begin LowestCommonAncestor *)
 let rec lowest_common_ancestor ~loc env s t =
   let here = add_pos_from loc in
-  let ( let+ ) o f = Option.map f o in
   (* The lowest common ancestor of types S and T is: *)
   (match (s.desc, t.desc) with
     | _, _ when type_equal env s t ->
         (* If S and T are the same type: S (or T). *)
-        Some s
+        s
     | T_Named s_name, T_Named t_name ->
         assert (not (String.equal s_name t_name));
         let anon_s = make_anonymous env s and anon_t = make_anonymous env t in
@@ -604,12 +596,12 @@ let rec lowest_common_ancestor ~loc env s t =
     | _, T_Named _ | T_Named _, _ ->
         let anon_s = make_anonymous env s and anon_t = make_anonymous env t in
         if type_equal env anon_s anon_t then
-          Some (match s.desc with T_Named _ -> s | _ -> t)
+          match s.desc with T_Named _ -> s | _ -> t
         else lowest_common_ancestor ~loc env anon_s anon_t
     | T_Int _, T_Int UnConstrained | T_Int UnConstrained, T_Int _ ->
         (* If either S or T is an unconstrained integer type: the unconstrained
          integer type. *)
-        Some integer
+        integer
     | T_Int _, T_Int (Parameterized _) | T_Int (Parameterized _), T_Int _ ->
         lowest_common_ancestor ~loc env (to_well_constrained s)
           (to_well_constrained t)
@@ -617,23 +609,20 @@ let rec lowest_common_ancestor ~loc env s t =
         (* If S and T both are well-constrained integer types: the
          well-constrained integer type with domain the union of the
          domains of S and T. *)
-        Some (well_constrained ~precision:(precision_join p1 p2) (cs_s @ cs_t))
+        well_constrained ~precision:(precision_join p1 p2) (cs_s @ cs_t)
     | T_Bits (e_s, _), T_Bits (e_t, _) when expr_equal env e_s e_t ->
         (* We forget the bitfields if they are not equal. *)
-        Some (T_Bits (e_s, []) |> here)
+        T_Bits (e_s, []) |> here
     | T_Array (length_s, ty_s), T_Array (length_t, ty_t)
       when expr_equal env length_s length_t ->
-        let+ t = lowest_common_ancestor ~loc env ty_s ty_t in
+        let t = lowest_common_ancestor ~loc env ty_s ty_t in
         T_Array (length_s, t) |> here
     | T_Tuple li_s, T_Tuple li_t when List.compare_lengths li_s li_t = 0 ->
         (* If S and T both are tuple types with the same number of elements:
          the tuple type with the type of each element the lowest common ancestor
          of the types of the corresponding elements of S and T. *)
-        let+ li =
-          List.map2 (lowest_common_ancestor ~loc env) li_s li_t
-          |> unpack_options
-        in
+        let li = List.map2 (lowest_common_ancestor ~loc env) li_s li_t in
         here (T_Tuple li)
-    | _ -> None)
+    | _ -> Error.fatal_from loc (Error.UnreconcilableTypes (s, t)))
   |: TypingRule.LowestCommonAncestor
 (* End *)

--- a/asllib/types.mli
+++ b/asllib/types.mli
@@ -80,7 +80,7 @@ val type_clashes : env -> ty -> ty -> bool
 val subprogram_clashes : env -> func -> func -> bool
 (** Subprogram clashing relation. *)
 
-val lowest_common_ancestor : loc:_ t_annotated -> env -> ty -> ty -> ty option
+val lowest_common_ancestor : loc:_ t_annotated -> env -> ty -> ty -> ty
 (** Lowest common ancestor. *)
 
 val type_equal : env -> ty -> ty -> bool


### PR DESCRIPTION
- Remove various unused error reporting bits
- Slightly reorganise `error.ml` - group into modules
- Refactor `Types.lowest_common_ancestor` to avoid an optional return type, and directly raise an exception in the `None` case

Factors out part of #1935.