### PR TITLE
[asl] Add `error_handling_time` to various interpreter errors

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -705,7 +705,8 @@ module Make (B : Backend.S) (C : Config) = struct
         let () =
           if n_length < 0 then
             fatal_from e_length env
-              (Error.NegativeArrayLength (e_length, n_length))
+              (Error.NegativeArrayLength
+                 (C.error_handling_time, e_length, n_length))
         in
         let* v = B.create_vector (List.init n_length (Fun.const v_value)) in
         return_normal (v, new_env) |: SemanticsRule.EArray
@@ -1164,7 +1165,8 @@ module Make (B : Backend.S) (C : Config) = struct
         let*= env2, b = choice ~pos:s env1 v true false in
         if b then return_continue env2
         else
-          fatal_from e env2 @@ Error.AssertionFailed e |: SemanticsRule.SAssert
+          fatal_from e env2 @@ Error.AssertionFailed (C.error_handling_time, e)
+          |: SemanticsRule.SAssert
     (* End *)
     (* Begin EvalSWhile *)
     | S_While (e, e_limit_opt, body) ->
@@ -1253,7 +1255,8 @@ module Make (B : Backend.S) (C : Config) = struct
         return_continue new_env |: SemanticsRule.SPrint
     (* End *)
     | S_Pragma _ -> assert false
-    | S_Unreachable -> fail_from s env Error.UnreachableReached
+    | S_Unreachable ->
+        fail_from s env (Error.UnreachableReached C.error_handling_time)
 
   (* Evaluation of Blocks *)
   (* -------------------- *)
@@ -1317,7 +1320,7 @@ module Make (B : Backend.S) (C : Config) = struct
     | Some limit ->
         let new_limit = Z.pred limit in
         if Z.sign new_limit >= 0 then return (Some new_limit)
-        else fatal_from loc env Error.LoopLimitReached
+        else fatal_from loc env (Error.LoopLimitReached C.error_handling_time)
 
   (* Begin EvalLoop *)
   and eval_loop loc is_while env limit_opt e_cond body : stmt_eval_type =

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -281,7 +281,8 @@ module NativeBackend (C : Config) = struct
           if Z.gt i Z.zero then [ L_Int (Z.log2 i |> Z.of_int) |> nv_literal ]
           else
             Error.fatal_unknown_pos
-            @@ Error.BadPrimitiveArgument ("FloorLog2", "greater than 0")
+            @@ Error.BadPrimitiveArgument
+                 (C.error_handling_time, "FloorLog2", "greater than 0")
       | [ v ] -> mismatch_type v [ integer' ]
       | li ->
           Error.fatal_unknown_pos

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -49,7 +49,7 @@ type error_desc =
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
   | ConflictingTypes of type_desc list * ty
-  | AssertionFailed of expr
+  | AssertionFailed of error_handling_time * expr
   | CannotParse of string option
   | UnknownSymbol of string
   | NoCallCandidate of string * ty list
@@ -81,8 +81,8 @@ type error_desc =
   | NonReturningFunction of identifier
   | NoreturnViolation of identifier
   | ConflictingSideEffects of SideEffect.t * SideEffect.t
-  | UnreachableReached
-  | LoopLimitReached
+  | UnreachableReached of error_handling_time
+  | LoopLimitReached of error_handling_time
   | RecursionLimitReached of error_handling_time
   | EmptyConstraints
   | UnexpectedPendingConstrained
@@ -98,13 +98,13 @@ type error_desc =
   | MultipleWrites of identifier
   | UnexpectedInitialisationThrow of
       ty * identifier (* Exception type and global storage element name. *)
-  | NegativeArrayLength of expr * int
+  | NegativeArrayLength of error_handling_time * expr * int
   | MultipleImplementations of func annotated * func annotated
   | NoOverrideCandidate
   | TooManyOverrideCandidates of func annotated list
   | PrecisionLostDefining
   | UnexpectedCollection
-  | BadPrimitiveArgument of identifier * string
+  | BadPrimitiveArgument of error_handling_time * identifier * string
   | NoEntryPoint
   | ObsoleteSyntax of (Format.formatter -> unit)
 
@@ -336,7 +336,10 @@ module PPrint = struct
         pp_err typing "%a does@ not@ subtype@ any@ of:@ %a." pp_ty provided
           (pp_comma_list pp_type_desc)
           expected
-    | AssertionFailed e -> pp_err dynamic "Assertion failed:@ %a." pp_expr e
+    | AssertionFailed (t, e) ->
+        pp_err
+          (error_handling_time_to_string t)
+          "Assertion failed:@ %a." pp_expr e
     | CannotParse s -> (
         match s with
         | None -> pp_err parse "Cannot parse."
@@ -432,7 +435,8 @@ module PPrint = struct
     | BadPattern (p, t) ->
         pp_err typing "Erroneous@ pattern@ %a@ for@ expression@ of@ type@ %a."
           pp_pattern p pp_ty t
-    | UnreachableReached -> pp_err dynamic "unreachable reached."
+    | UnreachableReached t ->
+        pp_err (error_handling_time_to_string t) "unreachable reached."
     | NonReturningFunction name ->
         pp_err typing "not all control flow paths of the function %S@ %a." name
           pp_print_text
@@ -443,7 +447,8 @@ module PPrint = struct
           "is qualified with noreturn but may return on some control flow path"
     | RecursionLimitReached t ->
         pp_err (error_handling_time_to_string t) "recursion limit reached."
-    | LoopLimitReached -> pp_err dynamic "loop limit reached."
+    | LoopLimitReached t ->
+        pp_err (error_handling_time_to_string t) "loop limit reached."
     | ConflictingSideEffects (s1, s2) ->
         pp_err typing "conflicting side effects %a and %a" SideEffect.pp_print
           s1 SideEffect.pp_print s2
@@ -485,9 +490,10 @@ module PPrint = struct
         pp_err typing
           "type@ used@ to@ define@ storage@ item@ is@ the@ result@ of@ \
            precision@ loss."
-    | NegativeArrayLength (e_length, length) ->
-        pp_err dynamic
-          "array@ length@ expression@ %a@ has@ negative@ length@a: %i." pp_expr
+    | NegativeArrayLength (t, e_length, length) ->
+        pp_err
+          (error_handling_time_to_string t)
+          "array@ length@ expression@ %a@ has@ negative@ length:@ %i." pp_expr
           e_length length
     | MultipleWrites id -> pp_err parse "multiple@ writes@ to@ %S." id
     | MultipleImplementations (impl1, impl2) ->
@@ -501,8 +507,10 @@ module PPrint = struct
         pp_err typing
           "multiple@ `impdef`@ candidates@ for@ `implementation`:@ %a"
           (pp_print_list pp_pos) impdefs
-    | BadPrimitiveArgument (name, reason) ->
-        pp_err dynamic "%s (primitive) expected an argument %s" name reason
+    | BadPrimitiveArgument (t, name, reason) ->
+        pp_err
+          (error_handling_time_to_string t)
+          "%s (primitive) expected an argument %s" name reason
     | NoEntryPoint ->
         pp_err dynamic "%a" pp_print_text
           "no entrypoint supplied. Have you defined `func main() => integer`, \
@@ -620,8 +628,8 @@ module CSV = struct
     | SetterWithoutCorrespondingGetter _ -> "SetterWithoutCorrespondingGetter"
     | NonReturningFunction _ -> "NonReturningFunction"
     | NoreturnViolation _ -> "NoreturnViolation"
-    | UnreachableReached -> "UnreachableReached"
-    | LoopLimitReached -> "LoopLimitReached"
+    | UnreachableReached _ -> "UnreachableReached"
+    | LoopLimitReached _ -> "LoopLimitReached"
     | RecursionLimitReached _ -> "RecursionLimitReached"
     | EmptyConstraints -> "EmptyConstraints"
     | UnexpectedPendingConstrained -> "UnexpectedPendingConstrained"

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -774,3 +774,36 @@ If test environment reversion bug
   ASL Grammar error: Obsolete syntax:
     Deprecated slice syntax, use "3*2 +: 2" instead.
   [1]
+
+Static errors:
+  $ aslref --no-exec static-unreachable.asl
+  File static-unreachable.asl, line 3, characters 2 to 14:
+    unreachable;
+    ^^^^^^^^^^^^
+  ASL Static error: unreachable reached.
+  [1]
+  $ aslref --no-exec static-assertion.asl
+  File static-assertion.asl, line 3, characters 9 to 14:
+    assert FALSE;
+           ^^^^^
+  ASL Static error: Assertion failed: FALSE.
+  [1]
+  $ aslref --no-exec static-looplimit.asl
+  File static-looplimit.asl, line 3, character 2 to line 5, character 6:
+    for i = 0 to 0 looplimit 0 do
+      pass;
+    end;
+  ASL Static error: loop limit reached.
+  [1]
+  $ aslref --no-exec static-negative-array-length.asl
+  File static-negative-array-length.asl, line 3, characters 19 to 21:
+    var arr : array[[-1]] of integer;
+                     ^^
+  ASL Static error: array length expression -1 has negative length: -1.
+  [1]
+  $ aslref --no-exec static-bad-primitive.asl
+  File static-bad-primitive.asl, line 7, characters 13 to 33:
+  constant y = 2 as integer{foo(2)};
+               ^^^^^^^^^^^^^^^^^^^^
+  ASL Static error: FloorLog2 (primitive) expected an argument greater than 0
+  [1]

--- a/asllib/tests/regressions.t/static-assertion.asl
+++ b/asllib/tests/regressions.t/static-assertion.asl
@@ -1,0 +1,7 @@
+pure func foo(x: integer{2,3}) => integer{2,3}
+begin
+  assert FALSE;
+  return x;
+end;
+
+constant y = 2 as integer{foo(2)};

--- a/asllib/tests/regressions.t/static-bad-primitive.asl
+++ b/asllib/tests/regressions.t/static-bad-primitive.asl
@@ -1,0 +1,7 @@
+pure func foo(x: integer{2,3}) => integer{2,3}
+begin
+  - = FloorLog2(0);
+  return x;
+end;
+
+constant y = 2 as integer{foo(2)};

--- a/asllib/tests/regressions.t/static-looplimit.asl
+++ b/asllib/tests/regressions.t/static-looplimit.asl
@@ -1,0 +1,9 @@
+pure func foo(x: integer{2,3}) => integer{2,3}
+begin
+  for i = 0 to 0 looplimit 0 do
+    pass;
+  end;
+  return x;
+end;
+
+constant y = 2 as integer{foo(2)};

--- a/asllib/tests/regressions.t/static-negative-array-length.asl
+++ b/asllib/tests/regressions.t/static-negative-array-length.asl
@@ -1,0 +1,7 @@
+pure func foo(x: integer{2,3}) => integer{2,3}
+begin
+  var arr : array[[-1]] of integer;
+  return x;
+end;
+
+constant y = 2 as integer{foo(2)};

--- a/asllib/tests/regressions.t/static-unreachable.asl
+++ b/asllib/tests/regressions.t/static-unreachable.asl
@@ -1,0 +1,7 @@
+pure func foo(x: integer{2,3}) => integer{2,3}
+begin
+  unreachable;
+  return x;
+end;
+
+constant y = 2 as integer{foo(2)};


### PR DESCRIPTION
Some errors were reported as dynamic, even though static. Add some tests to show this.

Assists https://github.com/herd/herdtools7/pull/1935.