### PR TITLE
[herd,riscv] Signed and unsigned extensions of size 64 avoided.

### DIFF
--- a/herd/RISCVSem.ml
+++ b/herd/RISCVSem.ml
@@ -50,8 +50,21 @@ module
       let (>>!) = M.(>>!)
       let (>>::) = M.(>>::)
 
-      let sxt_op sz = M.op1 (Op.Sxt sz)
-      and uxt_op sz = M.op1 (Op.Mask sz)
+      (*
+       * We definitely implement riscv64.
+       * Hence signed extension and masking of
+       * size 64 bits are nop's.
+       *)
+
+      let unit64 mop sz =
+        let open MachSize in
+        match sz with
+        | S128 -> Warn.fatal "S128 size for RISCV"
+        | Quad -> M.unitT
+        | sz -> mop sz
+
+      let sxt_op = unit64 (fun sz -> M.op1 (Op.Sxt sz))
+      and uxt_op = unit64 (fun sz -> M.op1 (Op.Mask sz))
 
       let sxtw = sxt_op MachSize.Word
       and uxtw = uxt_op MachSize.Word

--- a/herd/tests/instructions/RISCV/A024.litmus
+++ b/herd/tests/instructions/RISCV/A024.litmus
@@ -1,0 +1,8 @@
+RISCV A024
+{
+  int *p; int x;
+  0:x1=p; 0:x2=x;
+}
+  P0          ;
+  sd x2,0(x1) ;
+forall [p]=x

--- a/herd/tests/instructions/RISCV/A024.litmus.expected
+++ b/herd/tests/instructions/RISCV/A024.litmus.expected
@@ -1,0 +1,10 @@
+Test A024 Required
+States 1
+[p]=x;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall ([p]=x)
+Observation A024 Always 1 0
+Hash=e6dc1586d57260311207cec9cac455a8
+

--- a/herd/tests/instructions/RISCV/A025.litmus
+++ b/herd/tests/instructions/RISCV/A025.litmus
@@ -1,0 +1,8 @@
+RISCV A025
+{
+  int x; int *p=x;
+  0:x1=p;
+}
+  P0          ;
+  ld x2,0(x1) ;
+forall 0:x2=x

--- a/herd/tests/instructions/RISCV/A025.litmus.expected
+++ b/herd/tests/instructions/RISCV/A025.litmus.expected
@@ -1,0 +1,10 @@
+Test A025 Required
+States 1
+0:x2=x;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:x2=x)
+Observation A025 Always 1 0
+Hash=1829acee48104f07269ad8904e722c14
+


### PR DESCRIPTION
As native size is 64 bit those two operations are the identity. However, the generic implementation cannot detect the situation. As a result, loading and storing symbolic addresses yielded fatal errors. Fix consists in not even applying those extension operations for quad (or 64bit) size

Typical test:
```
RISCV T
{
  int *p; int x;
  0:x1=p; 0:x2=x;
}
  P0          ;
  sd x2,0(x1) ;
```