### PR TITLE
[litmus] Fix cram test

### DIFF
--- a/litmus/tests/X86_64/A009.t
+++ b/litmus/tests/X86_64/A009.t
@@ -4,23 +4,23 @@ Use litmus7 to generate code from a litmus test
   $ mkdir "$TEST"
   $ litmus7 -set-libdir ../../libdir -o "$TEST" \
   > "../../../herd/tests/instructions/X86_64/$TEST.litmus"  \
-  > -mode std -a 4 -s 1k -r 100 \
-  > -mach x86_64
+  > -mach x86_64 -mode std -a 2 -s 1k -r 100
+
 
 Compile and run the litmus test natively, avoid printing the timing, it's not
 stable
 
   $ cd $TEST
   $ make > /dev/null
-  $ "./$TEST.exe" | sed '$d'
+  $ "./$TEST.exe" | grep -v -e ^Time
   Test A009 Required
   Histogram (1 states)
-  4000000:>0:rcx=-1;
+  200000:>0:rcx=-1;
   Ok
   
   Witnesses
-  Positive: 4000000, Negative: 0
+  Positive: 200000, Negative: 0
   Condition forall (0:rcx=-1) is validated
   Hash=7ca3c35015d75a877ccf509d75062e79
-  Observation A009 Always 4000000 0
+  Observation A009 Always 200000 0
 


### PR DESCRIPTION
In the test, **litmus7** options were `... -a 4 -s 1k -r 100 -mach x86_64 ...` The configuration file [`x86_64`](https://github.com/herd/herdtools7/blob/master/litmus/libdir/x86.cfg) defines all explicitly set options, which, as options are processed left-to-right, amounts to redefine those options.

In particular _avail_ (option `-a`) is re-defined to zero, and affinity is enabled (`affinity = incr0` in configuration file `litmus/libdir/x86_64`). As a result, the number of available cores corresponds to the number of logical cores of the tested machine! Hence, the test fails on my machine that features 24 logical cores. Fix consists in having the option `-mach x86_64` first. Additionally we change the `-a` setting to `-a 2` for safety. Then, we have 200k test runs on any machine.

Folowup to PR #1926 that introduced the cram test for litmus.