### PR TITLE
[tools] Nicer output for the rehash tool

### DIFF
--- a/lib/splitter.mll
+++ b/lib/splitter.mll
@@ -199,13 +199,16 @@ and change_info found p buff = parse
     { incr_lineno lexbuf ;
       Buffer.add_char buff '\n' ;
       change_info found p buff lexbuf }
-| '\n'* '{' as lexed
-    { incr_lineno lexbuf ;
+| ('\n'* as nl) '{'
+    { for _k = 1 to String.length nl do
+        incr_lineno lexbuf ;
+        Buffer.add_char  buff '\n'
+      done ;
       if not found then begin
         let k,v = p in
         add_info buff k v
       end ;
-      Buffer.add_string buff lexed ;
+      Buffer.add_char buff '{' ;
       change_info found p buff lexbuf }
 | (name as key) blank* '=' blank* [^'\n']* '\n' as line
   { incr_lineno lexbuf ;


### PR DESCRIPTION
A small bug fix PR, eligible for fast merge.

In case a test had no expliciy hash, the added Hash metadata was sometime issued in a bizarre place.
Consider the test:
```
AArch64 A
(* A very simple test *)
{ int x=1; 0:X1=x; }
  P0          ;
  LDR W0,[X1] ;
forall 0:X0=1
```
Running **rehash7** yielded:
```
% rehash7 -hashes h.txt A.litmus
AArch64 A
(* A very simple test *)Hash=64feb72405036040a5ab3924aca0feb9

{ int x=1; 0:X1=x; }
  P0          ;
  LDR W0,[X1] ;
forall 0:X0=1
```
This is problematic as metadata must stand on a line of their own not to be ignored by tools. This PR fixes the problem by adding the hash meta data at the very end of the initial section:
```
% rehash7 -hashes h.txt A.litmus
AArch64 A
(* A very simple test *)
Hash=64feb72405036040a5ab3924aca0feb9
{ int x=1; 0:X1=x; }
  P0          ;
  LDR W0,[X1] ;
forall 0:X0=1
```