### PR TITLE
[asl] Report error codes in error messages

### DIFF
--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -37,8 +37,8 @@ File ../tests/ASLDefinition.t/TypingErrorReporting.asl, line 3,
   characters 11 to 22:
     return 5 + "hello";
            ^^^^^^^^^^^
-ASL Type error: Illegal application of operator + on types integer {5}
-  and string.
+ASL Type error (TE_BO): Illegal application of operator + on types
+  integer {5} and string.
 \end{Verbatim}
 % CONSOLE_END
 
@@ -57,7 +57,8 @@ followed by an example of a report from \aslrefterm{} in a \linuxbashshellterm.
 % CONSOLE_BEGIN CONSOLE_STDERR CONSOLE_CMD aslref \definitiontests/DynamicErrorReporting.asl
 \begin{Verbatim}[fontsize=\footnotesize, frame=single]
 > aslref ../tests/ASLDefinition.t/DynamicErrorReporting.asl
-ASL Dynamic error: Illegal application of operator DIV for values 128 and 7.
+ASL Dynamic error (DE_BO): Illegal application of operator DIV for values 128
+  and 7.
 \end{Verbatim}
 % CONSOLE_END
 
@@ -81,7 +82,7 @@ File ../tests/ASLDefinition.t/AssertionStatement.asl, line 5,
   characters 11 to 22:
     assert a + b < 256;
            ^^^^^^^^^^^
-ASL Dynamic error: Assertion failed: ((a + b) < 256).
+ASL Dynamic error (DE_DAF): Assertion failed: ((a + b) < 256).
 \end{Verbatim}
 % CONSOLE_END
 
@@ -100,7 +101,7 @@ File ../tests/ASLDefinition.t/UnreachableStatement.asl, line 5,
   characters 8 to 20:
         unreachable;
         ^^^^^^^^^^^^
-ASL Dynamic error: unreachable reached.
+ASL Dynamic error (DE_UNR): unreachable reached.
 \end{Verbatim}
 % CONSOLE_END
 

--- a/asllib/doc/PrimitiveOperations.tex
+++ b/asllib/doc/PrimitiveOperations.tex
@@ -728,6 +728,7 @@ eq_enum: RED == GREEN = FALSE
 ne_enum: RED != RED = FALSE
 ne_enum: RED != GREEN = TRUE
 concat_string: 0 ++ '1' ++ 2.0 ++ TRUE ++ "foo" ++ RED = 00x12TRUEfooRED
+concat_string: '10' ++ '1' = 0x20x1
 \end{Verbatim}
 % CONSOLE_END
 

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -442,10 +442,23 @@ module PPrint = struct
     let of_error_handling_time : error_handling_time -> t = function
       | Static -> Static
       | Dynamic -> Dynamic
+
+    let matches_code (code : ErrorCode.t) (kind : t) =
+      match (code, kind) with
+      | Typing _, (Typing | Static)
+      | Build _, (Lexical | Parse | Static)
+      | Dynamic _, Dynamic ->
+          true
+      | _ -> false
   end
 
   let fprintf_err f kind code_opt =
     let pp_code fmt code = fprintf fmt " (%s)" (ErrorCode.to_string code) in
+    let () =
+      match code_opt with
+      | Some code -> assert (ErrorKind.matches_code code kind)
+      | None -> ()
+    in
     kdprintf (fun msg ->
         fprintf f "@[<hov 2>ASL %s error%a:@ %t@]" (ErrorKind.to_string kind)
           (pp_print_option pp_code) code_opt msg)

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -227,53 +227,61 @@ module PPrint = struct
 
   let pp_type_desc f ty = pp_ty f (ASTUtils.add_dummy_pos ty)
 
+  module ErrorKind = struct
+    type t = Lexical | Parse | Static | Typing | Dynamic | Internal
+
+    let to_string = function
+      | Lexical -> "Lexical"
+      | Parse -> "Grammar"
+      | Static -> "Static"
+      | Typing -> "Type"
+      | Dynamic -> "Dynamic"
+      | Internal -> "Internal"
+
+    let of_error_handling_time : error_handling_time -> t = function
+      | Static -> Static
+      | Dynamic -> Dynamic
+  end
+
   let fprintf_err f kind =
-    kdprintf (fun msg -> fprintf f "@[<hov 2>ASL %s error:@ %t@]" kind msg)
-
-  let lexical = "Lexical"
-  let parse = "Grammar"
-  let static = "Static"
-  let typing = "Type"
-  let dynamic = "Dynamic"
-  let internal = "Internal"
-
-  let error_handling_time_to_string = function
-    | Static -> static
-    | Dynamic -> dynamic
+    kdprintf (fun msg ->
+        fprintf f "@[<hov 2>ASL %s error:@ %t@]" (ErrorKind.to_string kind) msg)
 
   let pp_error_desc f e =
     let pp_err s fmt = fprintf_err f s fmt in
     match e.desc with
-    | ReservedIdentifier id -> pp_err lexical "%S is a reserved keyword." id
+    | ReservedIdentifier id -> pp_err Lexical "%S is a reserved keyword." id
     | UnsupportedBinop (t, op, v1, v2) ->
         pp_err
-          (error_handling_time_to_string t)
+          (ErrorKind.of_error_handling_time t)
           "Illegal application of operator %s for values@ %a@ and %a."
           (binop_to_string op) pp_literal v1 pp_literal v2
     | UnsupportedUnop (t, op, v) ->
         pp_err
-          (error_handling_time_to_string t)
+          (ErrorKind.of_error_handling_time t)
           "Illegal application of operator %s for value@ %a."
           (unop_to_string op) pp_literal v
     | UnsupportedExpr (t, e) ->
         pp_err
-          (error_handling_time_to_string t)
+          (ErrorKind.of_error_handling_time t)
           "Unsupported expression %a." pp_expr e
     | UnsupportedTy (t, ty) ->
-        pp_err (error_handling_time_to_string t) "Unsupported type %a." pp_ty ty
-    | InvalidExpr e -> pp_err typing "invalid expression %a." pp_expr e
+        pp_err
+          (ErrorKind.of_error_handling_time t)
+          "Unsupported type %a." pp_ty ty
+    | InvalidExpr e -> pp_err Typing "invalid expression %a." pp_expr e
     | MismatchType (v, [ ty ]) ->
-        pp_err dynamic "Mismatch type:@ value %s does not belong to type %a." v
+        pp_err Dynamic "Mismatch type:@ value %s does not belong to type %a." v
           pp_type_desc ty
     | MismatchType (v, li) ->
-        pp_err dynamic
+        pp_err Dynamic
           "Mismatch type:@ value %s@ does not subtype any of those types:@ %a" v
           (pp_comma_list pp_type_desc)
           li
     | BadField (s, ty) ->
-        pp_err typing "There is no field '%s'@ on type %a." s pp_ty ty
+        pp_err Typing "There is no field '%s'@ on type %a." s pp_ty ty
     | MissingField (fields, ty) ->
-        pp_err typing
+        pp_err Typing
           "Fields mismatch for creating a value of type %a@ -- Passed fields \
            are:@ %a"
           pp_ty ty
@@ -281,19 +289,21 @@ module PPrint = struct
           fields
     | EmptySlice ->
         assert (e.version = V0);
-        pp_err static
+        pp_err Static
           "cannot slice with empty slicing operator. This might also be due to \
            an incorrect getter/setter invocation."
     | BadSlices (t, slices, length) ->
         pp_err
-          (error_handling_time_to_string t)
+          (ErrorKind.of_error_handling_time t)
           "Cannot extract from bitvector of length %d slice %a." length
           pp_slice_list slices
-    | BadSlice slice -> pp_err static "invalid slice %a." pp_slice slice
+    | BadSlice slice -> pp_err Static "invalid slice %a." pp_slice slice
     | TypeInferenceNeeded ->
-        pp_err internal "Interpreter blocked. Type inference needed."
+        pp_err Internal "Interpreter blocked. Type inference needed."
     | UndefinedIdentifier (t, s) ->
-        pp_err (error_handling_time_to_string t) "Undefined identifier:@ '%s'" s
+        pp_err
+          (ErrorKind.of_error_handling_time t)
+          "Undefined identifier:@ '%s'" s
     | MismatchedCallType
         { subprogram_name = s; expected_call_type; found_call_type } ->
         let call_type_description call_type =
@@ -303,7 +313,7 @@ module PPrint = struct
           | ST_Setter -> "setter"
           | ST_Procedure -> "procedure"
         in
-        pp_err static
+        pp_err Static
           "Mismatched call type for subprogram '%s': expected a %s and found a \
            %s."
           s
@@ -311,7 +321,7 @@ module PPrint = struct
           (call_type_description found_call_type)
     | BadArity (t, name, expected, provided) ->
         pp_err
-          (error_handling_time_to_string t)
+          (ErrorKind.of_error_handling_time t)
           "Arity error while calling '%s':@ %d arguments expected and %d \
            provided."
           name expected provided
@@ -319,89 +329,89 @@ module PPrint = struct
         match (t, version) with
         | Static, V0 ->
             pp_err
-              (error_handling_time_to_string t)
+              (ErrorKind.of_error_handling_time t)
               "Could not infer all parameters while calling '%s':@ %d \
                parameters expected and %d inferred"
               name expected provided
         | _ ->
             pp_err
-              (error_handling_time_to_string t)
+              (ErrorKind.of_error_handling_time t)
               "Arity error while calling '%s':@ %d parameters expected and %d \
                provided"
               name expected provided)
     | ConflictingTypes ([ expected ], provided) ->
-        pp_err typing "a subtype of@ %a@ was expected,@ provided %a."
+        pp_err Typing "a subtype of@ %a@ was expected,@ provided %a."
           pp_type_desc expected pp_ty provided
     | ConflictingTypes (expected, provided) ->
-        pp_err typing "%a does@ not@ subtype@ any@ of:@ %a." pp_ty provided
+        pp_err Typing "%a does@ not@ subtype@ any@ of:@ %a." pp_ty provided
           (pp_comma_list pp_type_desc)
           expected
     | AssertionFailed (t, e) ->
         pp_err
-          (error_handling_time_to_string t)
+          (ErrorKind.of_error_handling_time t)
           "Assertion failed:@ %a." pp_expr e
     | CannotParse s -> (
         match s with
-        | None -> pp_err parse "Cannot parse."
-        | Some s -> pp_err parse "Cannot parse.@ %a" pp_print_text s)
+        | None -> pp_err Parse "Cannot parse."
+        | Some s -> pp_err Parse "Cannot parse.@ %a" pp_print_text s)
     | UnknownSymbol s ->
         let codes = List.map Char.code (List.of_seq (String.to_seq s)) in
         let not_printable code = code < 33 || code > 126 in
         if List.exists not_printable codes then
-          pp_err lexical "Unknown symbol (ASCII code point(s): %a)."
+          pp_err Lexical "Unknown symbol (ASCII code point(s): %a)."
             (pp_comma_list pp_print_int)
             codes
-        else pp_err lexical "Unknown symbol."
+        else pp_err Lexical "Unknown symbol."
     | NoCallCandidate (name, types) ->
-        pp_err typing
+        pp_err Typing
           "No subprogram declaration matches the invocation:@ %s(%a)." name
           (pp_comma_list pp_ty) types
     | BadTypesForBinop (op, t1, t2) ->
-        pp_err typing "Illegal application of operator %s on types@ %a@ and %a."
+        pp_err Typing "Illegal application of operator %s on types@ %a@ and %a."
           (binop_to_string op) pp_ty t1 pp_ty t2
     | ImpureExpression (e, ses) ->
-        pp_err typing
+        pp_err Typing
           "a pure expression was expected,@ found %a,@ which@ produces@ the@ \
            following@ side-effects:@ %a."
           pp_expr e SideEffect.SES.pp_print ses
     | MismatchedPurity s ->
-        pp_err typing "expected@ a@ %s@ expression/subprogram." s
+        pp_err Typing "expected@ a@ %s@ expression/subprogram." s
     | UnreconcilableTypes (t1, t2) ->
-        pp_err typing
+        pp_err Typing
           "cannot@ find@ a@ common@ ancestor@ to@ those@ two@ types@ %a@ and@ \
            %a."
           pp_ty t1 pp_ty t2
     | AssignToImmutable x ->
-        pp_err typing "cannot@ assign@ to@ immutable@ storage@ %S." x
+        pp_err Typing "cannot@ assign@ to@ immutable@ storage@ %S." x
     | AssignToTupleElement tuple_e ->
-        pp_err typing "cannot@ assign@ to@ the@ (immutable)@ tuple@ value@ %a."
+        pp_err Typing "cannot@ assign@ to@ the@ (immutable)@ tuple@ value@ %a."
           pp_lexpr tuple_e
     | AlreadyDeclaredIdentifier x ->
-        pp_err typing "cannot@ declare@ already@ declared@ element@ %S." x
+        pp_err Typing "cannot@ declare@ already@ declared@ element@ %S." x
     | BadReturnStmt None ->
-        pp_err typing "cannot return something from a procedure."
-    | UnexpectedSideEffect s -> pp_err dynamic "Unexpected side-effect: %s." s
-    | UncaughtException s -> pp_err dynamic "Uncaught exception: %s." s
+        pp_err Typing "cannot return something from a procedure."
+    | UnexpectedSideEffect s -> pp_err Dynamic "Unexpected side-effect: %s." s
+    | UncaughtException s -> pp_err Dynamic "Uncaught exception: %s." s
     | OverlappingSlices (slices, t) ->
         pp_err
-          (error_handling_time_to_string t)
+          (ErrorKind.of_error_handling_time t)
           "overlapping slices@ @[%a@]." pp_slice_list slices
     | BadLDI ldi ->
-        pp_err typing "Unsupported declaration:@ @[%a@]." pp_local_decl_item ldi
+        pp_err Typing "Unsupported declaration:@ @[%a@]." pp_local_decl_item ldi
     | BadRecursiveDecls decls ->
-        pp_err typing "multiple recursive declarations:@ @[%a@]."
+        pp_err Typing "multiple recursive declarations:@ @[%a@]."
           (pp_comma_list (fun f -> fprintf f "%S"))
           decls
-    | UnrespectedParserInvariant -> pp_err typing "Parser invariant broke."
+    | UnrespectedParserInvariant -> pp_err Typing "Parser invariant broke."
     | ConstrainedIntegerExpected t ->
-        pp_err typing "constrained@ integer@ expected,@ provided@ %a." pp_ty t
+        pp_err Typing "constrained@ integer@ expected,@ provided@ %a." pp_ty t
     | ParameterWithoutDecl s ->
-        pp_err typing
+        pp_err Typing
           "explicit@ parameter@ %S@ does@ not@ have@ a@ corresponding@ \
            defining@ argument."
           s
     | BadParameterDecl (name, expected, actual) ->
-        pp_err typing
+        pp_err Typing
           "incorrect@ parameter@ declaration@ for@ %S,@ expected@ @[{%a}@]@ \
            but@ @[{%a}@]@ provided"
           name
@@ -410,16 +420,16 @@ module PPrint = struct
           (pp_comma_list pp_print_string)
           actual
     | ArbitraryEmptyType t ->
-        pp_err dynamic "ARBITRARY of empty type %a." pp_ty t
+        pp_err Dynamic "ARBITRARY of empty type %a." pp_ty t
     | BaseValueEmptyType t ->
-        pp_err typing "base value of empty type %a." pp_ty t
+        pp_err Typing "base value of empty type %a." pp_ty t
     | BaseValueNonSymbolic (t, e) ->
-        pp_err typing
+        pp_err Typing
           "base@ value@ of@ type@ %a@ cannot@ be@ symbolically@ reduced@ \
            since@ it@ consists@ of@ %a."
           pp_ty t pp_expr e
     | BadATC (t1, t2) ->
-        pp_err typing
+        pp_err Typing
           "cannot@ perform@ Asserted@ Type@ Conversion@ on@ %a@ by@ %a." pp_ty
           t1 pp_ty t2
     | SetterWithoutCorrespondingGetter func ->
@@ -428,94 +438,94 @@ module PPrint = struct
           | (_, ret) :: args -> (ret, List.map snd args)
           | _ -> assert false
         in
-        pp_err typing
+        pp_err Typing
           "setter@ \"%s\"@ does@ not@ have@ a@ corresponding@ getter@ of@ \
            signature@ @[@[%a@]@ ->@ %a@]."
           func.name (pp_comma_list pp_ty) args pp_ty ret
     | BadPattern (p, t) ->
-        pp_err typing "Erroneous@ pattern@ %a@ for@ expression@ of@ type@ %a."
+        pp_err Typing "Erroneous@ pattern@ %a@ for@ expression@ of@ type@ %a."
           pp_pattern p pp_ty t
     | UnreachableReached t ->
-        pp_err (error_handling_time_to_string t) "unreachable reached."
+        pp_err (ErrorKind.of_error_handling_time t) "unreachable reached."
     | NonReturningFunction name ->
-        pp_err typing "not all control flow paths of the function %S@ %a." name
+        pp_err Typing "not all control flow paths of the function %S@ %a." name
           pp_print_text
           "are guaranteed to either return, raise an exception, or invoke \
            unreachable"
     | NoreturnViolation name ->
-        pp_err typing "the@ function %S@ %a." name pp_print_text
+        pp_err Typing "the@ function %S@ %a." name pp_print_text
           "is qualified with noreturn but may return on some control flow path"
     | RecursionLimitReached t ->
-        pp_err (error_handling_time_to_string t) "recursion limit reached."
+        pp_err (ErrorKind.of_error_handling_time t) "recursion limit reached."
     | LoopLimitReached t ->
-        pp_err (error_handling_time_to_string t) "loop limit reached."
+        pp_err (ErrorKind.of_error_handling_time t) "loop limit reached."
     | ConflictingSideEffects (s1, s2) ->
-        pp_err typing "conflicting side effects %a and %a" SideEffect.pp_print
+        pp_err Typing "conflicting side effects %a and %a" SideEffect.pp_print
           s1 SideEffect.pp_print s2
     | ConstantTimeBroken (e, ses) ->
-        pp_err typing
+        pp_err Typing
           "expected@ constant-time@ expression,@ got@ %a,@ which@ produces@ \
            the@ following@ side-effects:@ %a."
           pp_expr e SideEffect.SES.pp_print ses
     | BadReturnStmt (Some t) ->
-        pp_err typing
+        pp_err Typing
           "cannot@ return@ nothing@ from@ a@ function,@ an@ expression@ of@ \
            type@ %a@ is@ expected."
           pp_ty t
     | EmptyConstraints ->
-        pp_err typing
+        pp_err Typing
           "a well-constrained integer cannot have empty constraints."
     | ExpectedSingularType t ->
-        pp_err typing "%a@ %a." pp_print_text "expected singular type, found"
+        pp_err Typing "%a@ %a." pp_print_text "expected singular type, found"
           pp_ty t
     | ExpectedNamedType t ->
-        pp_err typing "%a@ %a." pp_print_text "expected a named type, found"
+        pp_err Typing "%a@ %a." pp_print_text "expected a named type, found"
           pp_ty t
     | UnexpectedPendingConstrained ->
-        pp_err typing "a pending constrained integer is illegal here."
+        pp_err Typing "a pending constrained integer is illegal here."
     | BitfieldsDontAlign
         { field1_absname; field2_absname; field1_absslices; field2_absslices }
       ->
-        pp_err typing
+        pp_err Typing
           "bitfields `%s` and `%s` are in the same scope but define different \
            slices of the containing bitvector type: %s and %s, respectively."
           field1_absname field2_absname field1_absslices field2_absslices
     | UnexpectedInitialisationThrow (exception_ty, global_storage_element_name)
       ->
-        pp_err dynamic
+        pp_err Dynamic
           "unexpected@ exception@ %a@ thrown@ during@ the@ evaluation@ of@ \
            the@ initialisation@ of@ the global@ storage@ element@ %S."
           pp_ty exception_ty global_storage_element_name
     | PrecisionLostDefining ->
-        pp_err typing
+        pp_err Typing
           "type@ used@ to@ define@ storage@ item@ is@ the@ result@ of@ \
            precision@ loss."
     | NegativeArrayLength (t, e_length, length) ->
         pp_err
-          (error_handling_time_to_string t)
+          (ErrorKind.of_error_handling_time t)
           "array@ length@ expression@ %a@ has@ negative@ length:@ %i." pp_expr
           e_length length
-    | MultipleWrites id -> pp_err parse "multiple@ writes@ to@ %S." id
+    | MultipleWrites id -> pp_err Parse "multiple@ writes@ to@ %S." id
     | MultipleImplementations (impl1, impl2) ->
-        pp_err typing
+        pp_err Typing
           "multiple@ overlapping@ `implementation`@ functions@ for@ %s:@ %a"
           impl1.desc.name (pp_print_list pp_pos) [ impl1; impl2 ]
     | NoOverrideCandidate ->
-        pp_err typing "no `impdef` for `implementation` function."
-    | UnexpectedCollection -> pp_err typing "unexpected collection."
+        pp_err Typing "no `impdef` for `implementation` function."
+    | UnexpectedCollection -> pp_err Typing "unexpected collection."
     | TooManyOverrideCandidates impdefs ->
-        pp_err typing
+        pp_err Typing
           "multiple@ `impdef`@ candidates@ for@ `implementation`:@ %a"
           (pp_print_list pp_pos) impdefs
     | BadPrimitiveArgument (t, name, reason) ->
         pp_err
-          (error_handling_time_to_string t)
+          (ErrorKind.of_error_handling_time t)
           "%s (primitive) expected an argument %s" name reason
     | NoEntryPoint ->
-        pp_err dynamic "%a" pp_print_text
+        pp_err Dynamic "%a" pp_print_text
           "no entrypoint supplied. Have you defined `func main() => integer`, \
            or did you mean to pass `--no-exec`?"
-    | ObsoleteSyntax fmt -> pp_err parse "Obsolete syntax:@ @[%t@]" fmt
+    | ObsoleteSyntax fmt -> pp_err Parse "Obsolete syntax:@ @[%t@]" fmt
 
   let fprintf_warn f =
     kdprintf (fun msg -> fprintf f "@[ASL Warning:@ %t@]" msg)

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -144,6 +144,187 @@ type warning_desc =
 
 type warning = warning_desc annotated
 
+module ErrorCode = struct
+  type build =
+    | LE  (** Lexical *)
+    | PE  (** Parse *)
+    | RI  (** Reserved identifier *)
+    | BOP  (** Binary operation priority *)
+    | BD  (** Bad declaration *)
+
+  type typing =
+    | UI  (** Undefined identifier *)
+    | IAD  (** Identifier already declared *)
+    | AIM  (** Assign to immutable *)
+    | TSF  (** Type satisfaction failure *)
+    | LCA  (** Lowest common ancestor *)
+    | NBV  (** No base value *)
+    | TAF  (** Type assertion failure *)
+    | SEF  (** Static evaluation failure *)
+    | BO  (** Bad operands *)
+    | UT  (** Unexpected type *)
+    | BTI  (** Bad tuple index *)
+    | BS  (** Bad slices *)
+    | BF  (** Bad field *)
+    | BSPD  (** Bad subprogram declaration *)
+    | BD  (** Bad declaration *)
+    | BC  (** Bad call *)
+    | SEV  (** Side effect violation *)
+    | OE  (** Overriding error *)
+    | PLD  (** Declaration with an imprecise type *)
+
+  type dynamic =
+    | UNR  (** Unreachable *)
+    | DAF  (** Assertion failure *)
+    | TAF  (** Type assertion failure *)
+    | AET  (** Arbitrary empty type *)
+    | BO  (** Bad operands *)
+    | LE  (** Limit exceeded *)
+    | UE  (** Uncaught exception *)
+    | BI  (** Bad index *)
+    | OSA  (** Overlapping slice assignment *)
+    | NAL  (** Negative array length *)
+    | NEP  (** No entry point *)
+
+  type t = Build of build | Typing of typing | Dynamic of dynamic
+
+  (* TODO: consider using ppx to derive strings *)
+
+  let build_to_string : build -> string = function
+    | LE -> "LE"
+    | PE -> "PE"
+    | RI -> "RI"
+    | BOP -> "BOP"
+    | BD -> "BD"
+
+  let typing_to_string : typing -> string = function
+    | UI -> "UI"
+    | IAD -> "IAD"
+    | AIM -> "AIM"
+    | TSF -> "TSF"
+    | LCA -> "LCA"
+    | NBV -> "NBV"
+    | TAF -> "TAF"
+    | SEF -> "SEF"
+    | BO -> "BO"
+    | UT -> "UT"
+    | BTI -> "BTI"
+    | BS -> "BS"
+    | BF -> "BF"
+    | BSPD -> "BSPD"
+    | BD -> "BD"
+    | BC -> "BC"
+    | SEV -> "SEV"
+    | OE -> "OE"
+    | PLD -> "PLD"
+
+  let dynamic_to_string : dynamic -> string = function
+    | UNR -> "UNR"
+    | DAF -> "DAF"
+    | TAF -> "TAF"
+    | AET -> "AET"
+    | BO -> "BO"
+    | LE -> "LE"
+    | UE -> "UE"
+    | BI -> "BI"
+    | OSA -> "OSA"
+    | NAL -> "NAL"
+    | NEP -> "NEP"
+
+  let to_string = function
+    | Build b -> "BE_" ^ build_to_string b
+    | Typing t -> "TE_" ^ typing_to_string t
+    | Dynamic d -> "DE_" ^ dynamic_to_string d
+
+  let of_error e =
+    match e.desc with
+    (********** Errors that correspond to error codes **********)
+    | ReservedIdentifier _ -> Some (Build RI)
+    | UnknownSymbol _ -> Some (Build LE)
+    | ObsoleteSyntax _ -> Some (Build PE)
+    | BadField _ | MissingField _ -> Some (Typing BF)
+    | BadPattern _ | BadTypesForBinop _
+    | UnsupportedUnop (Static, _, _)
+    | UnsupportedBinop (Static, _, _, _) ->
+        Some (Typing BO)
+    | BadSlices (Static, _, _)
+    | BadSlice _ | EmptySlice
+    | OverlappingSlices (_, Static)
+    | BitfieldsDontAlign _ ->
+        Some (Typing BS) (* TODO: consider combining BadSlices and BadSlice *)
+    | UndefinedIdentifier (Static, _) -> Some (Typing UI)
+    | ConflictingTypes _ | AssignToTupleElement _ | ConstrainedIntegerExpected _
+    | UnexpectedPendingConstrained | ExpectedSingularType _
+    | ExpectedNamedType _ | UnexpectedCollection ->
+        Some (Typing UT)
+    | MismatchedCallType _
+    | BadParameterArity (Static, _, _, _, _)
+    | NoCallCandidate _ ->
+        Some (Typing BC)
+    | UnsupportedUnop (Dynamic, _, _) | UnsupportedBinop (Dynamic, _, _, _) ->
+        Some (Dynamic BO)
+    | AssertionFailed (Dynamic, _) | BadPrimitiveArgument (Dynamic, _, _) ->
+        Some (Dynamic DAF)
+    | ImpureExpression _ | MismatchedPurity _ -> Some (Typing SEV)
+    | AssignToImmutable _ -> Some (Typing AIM)
+    | AlreadyDeclaredIdentifier _ -> Some (Typing IAD)
+    | BadReturnStmt _ | BadParameterDecl _ | NonReturningFunction _
+    | NoreturnViolation _ ->
+        Some (Typing BSPD)
+    | UncaughtException _ -> Some (Dynamic UE)
+    | OverlappingSlices (_, Dynamic) -> Some (Dynamic OSA)
+    | BadLDI _ | BadRecursiveDecls _ -> Some (Typing BD)
+    | BadATC _ -> Some (Typing TAF)
+    | BaseValueEmptyType _ | BaseValueNonSymbolic _ -> Some (Typing NBV)
+    | ArbitraryEmptyType _ -> Some (Dynamic AET)
+    | UnreachableReached Dynamic -> Some (Dynamic UNR)
+    | LoopLimitReached Dynamic | RecursionLimitReached Dynamic ->
+        Some (Dynamic LE)
+    | NegativeArrayLength (Dynamic, _, _) -> Some (Dynamic NAL)
+    | MultipleImplementations _ | NoOverrideCandidate
+    | TooManyOverrideCandidates _ ->
+        Some (Typing OE)
+    | PrecisionLostDefining -> Some (Typing PLD)
+    | NoEntryPoint -> Some (Dynamic NEP)
+    | RecursionLimitReached Static
+    | UnreachableReached Static
+    | LoopLimitReached Static
+    | NegativeArrayLength (Static, _, _)
+    | AssertionFailed (Static, _)
+    | BadPrimitiveArgument (Static, _, _) ->
+        Some (Typing SEF)
+    (********** TODO tidy up - does not cleanly correspond to a code **********)
+    | BadArity (Static, _, _, _) (* also used for tuple unpacking *) -> None
+    | UnsupportedExpr _ | UnsupportedTy _
+    (* For static interpretation, parameters, and collections *) ->
+        None
+    | MismatchType _
+    (* dynamic ATC but also mismatched integers for loop limits *) ->
+        None
+    | CannotParse _ (* used in lexing too *) -> None
+    | UnreconcilableTypes _ (* both LCA and check_bit_widths_equal *) -> None
+    | EmptyConstraints (* does this need to be reflected in reference? *) ->
+        None
+    | MultipleWrites _
+    (* For desugaring, but uses `check_no_duplicates` which is always TE_IAD? *)
+      ->
+        None
+    | UnexpectedInitialisationThrow _ (* not represented in reference? *) ->
+        None
+    (********** Should not happen **********)
+    (* e.g. skipped type-checking, ASL0, internal option or invariant *)
+    | TypeInferenceNeeded
+    | UndefinedIdentifier (Dynamic, _)
+    | BadArity (Dynamic, _, _, _)
+    | BadParameterArity (Dynamic, _, _, _, _)
+    | InvalidExpr _ | UnexpectedSideEffect _ | UnrespectedParserInvariant
+    | ParameterWithoutDecl _ | SetterWithoutCorrespondingGetter _
+    | ConflictingSideEffects _ | ConstantTimeBroken _ ->
+        None
+    (********** Other **********)
+    | BadSlices (Dynamic, _, _) -> None (* only used in Native.ml *)
+end
+
 module PrintContext = struct
   (* Straight out of stdlib v5.2 *)
   let with_open filename continuation =
@@ -218,6 +399,26 @@ module PrintContext = struct
     else None
 end
 
+(** TODO
+    - SlicesToPositions - static or dynamic in implementation, but always TE_BS
+      in reference?
+    - Various errors are overused in several places - need to clearly
+      distinguish between ASL1 errors and e.g. ASL0 non-typechecked errors,
+      assertion failures, cases we don't expect to hit etc.
+    - TypingRule.TInt mismatch on empty case *)
+(* TODO: check_implementations_unique should be TE_OE in reference - instead just generic #TE *)
+(* TODO: BE_RI unused in reference *)
+(* TODO: following not recoverable from implementation:
+- BE_BOP
+- BE_BD
+- TE_TSF
+- TE_LCA
+- TE_SEF
+- TE_BTI
+- DE_TAF
+- DE_BI
+*)
+
 module PPrint = struct
   open Format
   open PP
@@ -243,12 +444,14 @@ module PPrint = struct
       | Dynamic -> Dynamic
   end
 
-  let fprintf_err f kind =
+  let fprintf_err f kind code_opt =
+    let pp_code fmt code = fprintf fmt " (%s)" (ErrorCode.to_string code) in
     kdprintf (fun msg ->
-        fprintf f "@[<hov 2>ASL %s error:@ %t@]" (ErrorKind.to_string kind) msg)
+        fprintf f "@[<hov 2>ASL %s error%a:@ %t@]" (ErrorKind.to_string kind)
+          (pp_print_option pp_code) code_opt msg)
 
   let pp_error_desc f e =
-    let pp_err s fmt = fprintf_err f s fmt in
+    let pp_err s fmt = fprintf_err f s (ErrorCode.of_error e) fmt in
     match e.desc with
     | ReservedIdentifier id -> pp_err Lexical "%S is a reserved keyword." id
     | UnsupportedBinop (t, op, v1, v2) ->

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -1,7 +1,7 @@
 Examples used in ASL High-level Definition:
   $ aslref main0.asl
   $ aslref main_uncaught.asl
-  ASL Dynamic error: Uncaught exception: MyException {}.
+  ASL Dynamic error (DE_UE): Uncaught exception: MyException {}.
   [1]
   $ aslref --no-exec spec1.asl
   $ aslref --no-exec spec2.asl
@@ -27,7 +27,7 @@ Examples used in ASL High-level Definition:
   File CaseStatement.no_otherwise.asl, line 17, characters 9 to 30:
       case test_and_increment(x) of
            ^^^^^^^^^^^^^^^^^^^^^
-  ASL Dynamic error: unreachable reached.
+  ASL Dynamic error (DE_UNR): unreachable reached.
   [1]
   $ aslref CaseStatement.where.asl
 
@@ -36,26 +36,27 @@ Examples used in ASL High-level Definition:
   File UnreachableStatement.asl, line 5, characters 8 to 20:
           unreachable;
           ^^^^^^^^^^^^
-  ASL Dynamic error: unreachable reached.
+  ASL Dynamic error (DE_UNR): unreachable reached.
   [1]
 
   $ aslref AssertionStatement.asl
   File AssertionStatement.asl, line 5, characters 11 to 22:
       assert a + b < 256;
              ^^^^^^^^^^^
-  ASL Dynamic error: Assertion failed: ((a + b) < 256).
+  ASL Dynamic error (DE_DAF): Assertion failed: ((a + b) < 256).
   [1]
 
   $ aslref TypingErrorReporting.asl
   File TypingErrorReporting.asl, line 3, characters 11 to 22:
       return 5 + "hello";
              ^^^^^^^^^^^
-  ASL Type error: Illegal application of operator + on types integer {5}
-    and string.
+  ASL Type error (TE_BO): Illegal application of operator + on types
+    integer {5} and string.
   [1]
 
   $ aslref DynamicErrorReporting.asl
-  ASL Dynamic error: Illegal application of operator DIV for values 128 and 7.
+  ASL Dynamic error (DE_BO): Illegal application of operator DIV for values 128
+    and 7.
   [1]
 
   $ aslref --no-exec Accessor.asl
@@ -66,8 +67,8 @@ Examples used in ASL High-level Definition:
   begin
     return Zeros{N};
   end;
-  ASL Type error: multiple overlapping `implementation` functions for Foo:
-    File OverridingBad.asl, line 1, character 0 to line 4, character 4
+  ASL Type error (TE_OE): multiple overlapping `implementation` functions for
+    Foo: File OverridingBad.asl, line 1, character 0 to line 4, character 4
     File OverridingBad.asl, line 11, character 0 to line 14, character 4
   [1]
 
@@ -97,7 +98,7 @@ Examples used in ASL High-level Definition:
   File GuideRule.TupleElementAccess.bad.asl, line 5, characters 18 to 25:
       x = (x.item1, x.item2);
                     ^^^^^^^
-  ASL Type error: There is no field 'item2' on type (integer, integer).
+  ASL Type error (TE_BF): There is no field 'item2' on type (integer, integer).
   [1]
   $ aslref GuideRule.AnonymousEnumerations.bad.asl
   File GuideRule.AnonymousEnumerations.bad.asl, line 4, characters 12 to 23:
@@ -109,7 +110,7 @@ Examples used in ASL High-level Definition:
   File GuideRule.TupleImmutability.asl, line 7, characters 6 to 11:
       x.item1 = '1'; // Illegal: tuples are immutable.
         ^^^^^
-  ASL Type error: cannot assign to the (immutable) tuple value x.
+  ASL Type error (TE_UT): cannot assign to the (immutable) tuple value x.
   [1]
 
   $ aslref ParameterOmission.asl
@@ -127,19 +128,19 @@ Examples used in ASL High-level Definition:
   File NamedTypes.bad.asl, line 8, characters 4 to 5:
       b = K; // Illegal: a Char cannot be directly assigned to a Byte
       ^
-  ASL Type error: a subtype of Byte was expected, provided Char.
+  ASL Type error (TE_UT): a subtype of Byte was expected, provided Char.
   [1]
   $ aslref --no-exec GuideRule.GlobalStorageCycles.bad1.asl
   File GuideRule.GlobalStorageCycles.bad1.asl, line 4, characters 0 to 10:
   var b = a;
   ^^^^^^^^^^
-  ASL Type error: multiple recursive declarations: "b", "a".
+  ASL Type error (TE_BD): multiple recursive declarations: "b", "a".
   [1]
   $ aslref --no-exec GuideRule.GlobalStorageCycles.bad2.asl
   File GuideRule.GlobalStorageCycles.bad2.asl, line 3, characters 0 to 23:
   var var1 : bits(size1); // cycle -- the type of var1 depends on size1 which depends
   ^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: multiple recursive declarations: "var1", "size1".
+  ASL Type error (TE_BD): multiple recursive declarations: "var1", "size1".
   [1]
   $ aslref --no-exec SubprogramDeclarations.asl
   $ aslref --no-exec GlobalPragma.asl
@@ -164,7 +165,7 @@ Examples used in ASL High-level Definition:
   File MutualRecursion.bad.asl, line 3, characters 11 to 17:
       return bar(a);
              ^^^^^^
-  ASL Dynamic error: recursion limit reached.
+  ASL Dynamic error (DE_LE): recursion limit reached.
   [1]
   $ aslref --no-exec Guide.OperatorPriority.asl
   $ aslref --no-exec TupleExpressions.asl
@@ -181,14 +182,14 @@ Examples used in ASL High-level Definition:
   File ConstrainedIntegers.bad.asl, line 7, characters 4 to 5:
       B = A; // illegal: {2,4,8} is not a subset of {2,4}.
       ^
-  ASL Type error: a subtype of integer {2, 4} was expected,
+  ASL Type error (TE_UT): a subtype of integer {2, 4} was expected,
     provided integer {2, 4, 8}.
   [1]
   $ aslref --no-exec ConstrainedIntegers.bad2.asl
   File ConstrainedIntegers.bad2.asl, line 8, characters 4 to 10:
       myIntA = myIntB; // Illegal even though at this point
       ^^^^^^
-  ASL Type error: a subtype of integer {1..10} was expected,
+  ASL Type error (TE_UT): a subtype of integer {1..10} was expected,
     provided integer {0..20}.
   [1]
   $ aslref --no-exec PrimitiveOperations.asl

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -12,7 +12,7 @@ ASL Semantics Tests:
   File SemanticsRule.EUndefIdent.asl, line 5, characters 9 to 10:
     assert y;
            ^
-  ASL Static error: Undefined identifier: 'y'
+  ASL Static error (TE_UI): Undefined identifier: 'y'
   [1]
 //  $ aslref SemanticsRule.EBinopPlusPrint.asl
   $ aslref SemanticsRule.EBinopPlusAssert.asl
@@ -22,7 +22,7 @@ ASL Semantics Tests:
   File SemanticsRule.ECondARBITRARY3or42.asl, line 10, characters 9 to 13:
     assert x==3;
            ^^^^
-  ASL Dynamic error: Assertion failed: (x == 3).
+  ASL Dynamic error (DE_DAF): Assertion failed: (x == 3).
   [1]
   $ aslref SemanticsRule.ESlice.asl
   $ aslref SemanticsRule.ECall.asl
@@ -40,7 +40,7 @@ ASL Semantics Tests:
   File SemanticsRule.EArbitraryInteger3.asl, line 5, characters 9 to 13:
     assert x==3;
            ^^^^
-  ASL Dynamic error: Assertion failed: (x == 3).
+  ASL Dynamic error (DE_DAF): Assertion failed: (x == 3).
   [1]
   $ aslref SemanticsRule.EArbitraryIntegerRange3-42-3.asl
   $ aslref SemanticsRule.EArbitraryIntegerRange3-42-42.asl
@@ -48,7 +48,7 @@ ASL Semantics Tests:
     characters 9 to 14:
     assert x==42;
            ^^^^^
-  ASL Dynamic error: Assertion failed: (x == 42).
+  ASL Dynamic error (DE_DAF): Assertion failed: (x == 42).
   [1]
   $ aslref SemanticsRule.EArbitraryArray.asl
   $ aslref SemanticsRule.EPattern.asl
@@ -70,7 +70,7 @@ ASL Semantics Tests:
       assert i <= 3;
       i = i + 1;
      end;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
   $ aslref SemanticsRule.SWhile.negative_limit.asl
   File SemanticsRule.SWhile.negative_limit.asl, line 4, character 2 to line 6,
@@ -78,7 +78,7 @@ ASL Semantics Tests:
     while TRUE looplimit -1 do
       println "This should not be printed";
     end;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
   $ aslref SemanticsRule.SRepeat.asl
   File SemanticsRule.SRepeat.asl, line 24, character 4 to line 31, character 17:
@@ -152,7 +152,7 @@ ASL Semantics Tests:
   File SemanticsRule.FUndefIdent.asl, line 4, characters 5 to 12:
        foo ();
        ^^^^^^^
-  ASL Static error: Undefined identifier: 'foo'
+  ASL Static error (TE_UI): Undefined identifier: 'foo'
   [1]
   $ aslref SemanticsRule.FCall.asl
   $ aslref SemanticsRule.PAll.asl
@@ -167,7 +167,7 @@ ASL Semantics Tests:
   File SemanticsRule.LEUndefIdentV1.asl, line 5, characters 2 to 3:
     y = 3;
     ^
-  ASL Static error: Undefined identifier: 'y'
+  ASL Static error (TE_UI): Undefined identifier: 'y'
   [1]
   $ aslref SemanticsRule.LESlice.asl
   $ aslref SemanticsRule.LESetField.asl
@@ -200,7 +200,7 @@ ASL Semantics Tests:
   File SemanticsRule.SAssertNo.asl, line 4, characters 10 to 17:
     assert (42 == 3);
             ^^^^^^^
-  ASL Dynamic error: Assertion failed: (42 == 3).
+  ASL Dynamic error (DE_DAF): Assertion failed: (42 == 3).
   [1]
   $ aslref SemanticsRule.LEDiscard.asl
   $ aslref SemanticsRule.LDDiscard.asl
@@ -229,13 +229,13 @@ ASL Semantics Tests:
   File SemanticsRule.SCond3.asl, line 3, characters 9 to 14:
     assert FALSE;
            ^^^^^
-  ASL Dynamic error: Assertion failed: FALSE.
+  ASL Dynamic error (DE_DAF): Assertion failed: FALSE.
   [1]
   $ aslref SemanticsRule.SCond4.asl
   $ aslref SemanticsRule.STry.asl
   $ aslref SemanticsRule.CheckNonOverlappingSlices.asl
   $ aslref SemanticsRule.CheckNonOverlappingSlices.bad.asl
-  ASL Dynamic error: overlapping slices (N - 2)+:2, 0+:1.
+  ASL Dynamic error (DE_OSA): overlapping slices (N - 2)+:2, 0+:1.
   [1]
   $ aslref SemanticsRule.DeclareGlobal.asl
   $ aslref SemanticsRule.EvalGlobals.asl
@@ -255,7 +255,7 @@ ASL Semantics Tests:
     characters 37 to 53:
       return if n == 0 then 1 else n * factorial(n - 1);
                                        ^^^^^^^^^^^^^^^^
-  ASL Dynamic error: recursion limit reached.
+  ASL Dynamic error (DE_LE): recursion limit reached.
   [1]
   $ aslref SemanticsRule.AssignArgs.asl
   $ aslref SemanticsRule.Call.asl

--- a/asllib/tests/ASLSyntaxReference.t/run.t
+++ b/asllib/tests/ASLSyntaxReference.t/run.t
@@ -7,7 +7,7 @@ Examples used to test syntax and AST building rules:
   $ aslref GuideRule.Whitespace1.asl
   $ aslref GuideRule.Whitespace2.asl
   $ aslref GuideRule.ReservedIdentifiers.bad.asl
-  ASL Lexical error: "__internal_var" is a reserved keyword.
+  ASL Lexical error (BE_RI): "__internal_var" is a reserved keyword.
   [1]
   $ aslref GuideRule.IdentifiersKeywords.bad.asl
   File GuideRule.IdentifiersKeywords.bad.asl, line 3, characters 8 to 12:

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -9,20 +9,21 @@ ASL Typing Tests:
   File TypingRule.SubtypeSatisfaction3.asl, line 8, characters 4 to 45:
       var dogLegs : AnimalLegs = myCircleSides; // illegal: unrelated types
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of AnimalLegs was expected, provided ShapeSides.
+  ASL Type error (TE_UT): a subtype of AnimalLegs was expected,
+    provided ShapeSides.
   [1]
   $ aslref TypingRule.SubtypeSatisfaction.bad1.asl
   File TypingRule.SubtypeSatisfaction.bad1.asl, line 8, characters 0 to 31:
   var x : integer{Int12} = Int12;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {2} was expected,
+  ASL Type error (TE_UT): a subtype of integer {2} was expected,
     provided integer {1..2}.
   [1]
   $ aslref TypingRule.SubtypeSatisfaction.bad2.asl
   File TypingRule.SubtypeSatisfaction.bad2.asl, line 7, characters 4 to 13:
       return N;
       ^^^^^^^^^
-  ASL Type error: a subtype of integer {N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {N} was expected,
     provided integer {2, 4}.
   [1]
   $ aslref TypingRule.TypeSatisfaction1.asl
@@ -31,21 +32,22 @@ ASL Typing Tests:
   File TypingRule.TypeSatisfaction3.asl, line 14, characters 2 to 6:
     pair = (1, dataT2);
     ^^^^
-  ASL Type error: a subtype of pairT was expected, provided (integer {1}, T2).
+  ASL Type error (TE_UT): a subtype of pairT was expected,
+    provided (integer {1}, T2).
   [1]
   $ aslref TypingRule.TypeSatisfaction.bad1.asl
   File TypingRule.TypeSatisfaction.bad1.asl, line 3, characters 4 to 25:
       var a: integer{0..N};
       ^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: base value of type integer {0..N} cannot be symbolically
-    reduced since it consists of N.
+  ASL Type error (TE_NBV): base value of type integer {0..N} cannot be
+    symbolically reduced since it consists of N.
   [1]
   $ aslref --no-exec TypingRule.TypeClashes.asl
   $ aslref --no-exec TypingRule.TypeClashes.bad.asl
   File TypingRule.TypeClashes.bad.asl, line 2, characters 0 to 32:
   func f(r: time) begin pass; end;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "f".
+  ASL Type error (TE_IAD): cannot declare already declared element "f".
   [1]
   $ aslref TypingRule.LowestCommonAncestor.asl
   $ aslref TypingRule.LowestCommonAncestor.bad.asl
@@ -106,7 +108,7 @@ ASL Typing Tests:
       },
       [1:0] common
   };
-  ASL Type error:
+  ASL Type error (TE_BS):
     bitfields `sub.common` and `common` are in the same scope but define different slices of the containing bitvector type: [0, 1] and [1:0], respectively.
   [1]
 
@@ -118,13 +120,13 @@ ASL Typing Tests / annotating types:
   File TypingRule.TNamed.bad1.asl, line 11, characters 4 to 13:
       foo(x.f); // Illegal: x.f is of type TypeB which does not type-satisfy TypeA.
       ^^^^^^^^^
-  ASL Type error: a subtype of TypeA was expected, provided TypeB.
+  ASL Type error (TE_UT): a subtype of TypeA was expected, provided TypeB.
   [1]
   $ aslref TypingRule.TNamed.bad2.asl
   File TypingRule.TNamed.bad2.asl, line 12, characters 4 to 13:
       foo(y.f); // illegal: y.f is of type TypeB which does not type-satisfy TypeA.
       ^^^^^^^^^
-  ASL Type error: a subtype of TypeA was expected, provided TypeB.
+  ASL Type error (TE_UT): a subtype of TypeA was expected, provided TypeB.
   [1]
   $ aslref TypingRule.TIntUnconstrained.asl
   $ aslref TypingRule.TIntWellConstrained.asl
@@ -135,7 +137,7 @@ ASL Typing Tests / annotating types:
     characters 4 to 26:
       var g : integer{} = a;
       ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
 
   $ aslref --no-exec TypingRule.TInt.config_pending_constrained.bad.asl
@@ -143,7 +145,7 @@ ASL Typing Tests / annotating types:
     characters 0 to 26:
   config x : integer{} =  1;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a pending constrained integer is illegal here.
+  ASL Type error (TE_UT): a pending constrained integer is illegal here.
   [1]
 
   $ aslref TypingRule.TInt.rhs_pending_constrained.bad.asl
@@ -151,7 +153,7 @@ ASL Typing Tests / annotating types:
     characters 28 to 42:
       var x : integer{1..2} = 3 as integer{};
                               ^^^^^^^^^^^^^^
-  ASL Type error: a pending constrained integer is illegal here.
+  ASL Type error (TE_UT): a pending constrained integer is illegal here.
   [1]
 
   $ aslref TypingRule.AnnotateConstraint.asl
@@ -159,7 +161,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateConstraint.bad.asl, line 4, characters 17 to 18:
     let t: integer{x..x+1} = 2; // illegal as 'x' is not symbolically evaluable.
                    ^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
 
   $ aslref TypingRule.TBits.asl
@@ -167,7 +170,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.TBits.bad.asl, line 7, characters 17 to 31:
       var bv: bits(immutable_size);
                    ^^^^^^^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref TypingRule.TTuple.asl
   $ aslref TypingRule.TArray.asl
@@ -175,13 +178,14 @@ ASL Typing Tests / annotating types:
   File TypingRule.TArray.bad.asl, line 9, characters 32 to 58:
       var illegal_array1: array [[non_symbolically_evaluable]] of integer;
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
   $ aslref TypingRule.TArray.bad2.asl
   File TypingRule.TArray.bad2.asl, line 5, characters 4 to 61:
       var illegal_array2: array [[non_constrained]] of integer;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref TypingRule.AnnotateSymbolicallyEvaluableExpr.asl
   $ aslref --no-exec TypingRule.TEnumDecl.asl
@@ -190,20 +194,20 @@ ASL Typing Tests / annotating types:
   File TypingRule.TEnumDecl.bad.asl, line 1, characters 0 to 19:
   constant GREEN = 1;
   ^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "GREEN".
+  ASL Type error (TE_IAD): cannot declare already declared element "GREEN".
   [1]
   $ aslref --no-exec TypingRule.TEnumDecl.bad4.asl
   File TypingRule.TEnumDecl.bad4.asl, line 1, characters 14 to 48:
   type Color of enumeration { GREEN, ORANGE, RED };
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "RED".
+  ASL Type error (TE_IAD): cannot declare already declared element "RED".
   [1]
   $ aslref TypingRule.TRecordDecl.asl
   $ aslref TypingRule.TRecordDecl.bad.asl
   File TypingRule.TRecordDecl.bad.asl, line 1, characters 17 to 57:
   type MyRecord of record {v: integer, b: boolean, v: real};
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "v".
+  ASL Type error (TE_IAD): cannot declare already declared element "v".
   [1]
   $ aslref TypingRule.TExceptionDecl.asl
   $ aslref TypingRule.TCollection.asl
@@ -219,7 +223,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateFuncSig.bad.asl, line 4, characters 60 to 63:
   func signature_example(bv: bits(8)) => bits(16) recurselimit(W)
                                                               ^^^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
   $ aslref --no-exec TypingRule.ExtractParameters-bad1.asl
   File TypingRule.ExtractParameters-bad1.asl, line 3, characters 15 to 36:
@@ -236,7 +241,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.ConstraintMod.bad.asl, line 9, characters 4 to 5:
       z = 3; // Illegal: the type inferred for z is integer{0..2}
       ^
-  ASL Type error: a subtype of integer {0..2} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..2} was expected,
     provided integer {3}.
   [1]
   $ aslref --no-exec TypingRule.CheckConstrainedInteger.asl
@@ -255,13 +260,13 @@ ASL Typing Tests / annotating types:
   File TypingRule.BaseValue.bad_negative_width.asl, line 1, characters 0 to 24:
   var bits_base: bits(-3);
   ^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: base value of empty type bits((- 3)).
+  ASL Type error (TE_NBV): base value of empty type bits((- 3)).
   [1]
   $ aslref TypingRule.BaseValue.bad_empty.asl
   File TypingRule.BaseValue.bad_empty.asl, line 1, characters 0 to 22:
   var x : integer{5..0};
   ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: base value of empty type integer {5..0}.
+  ASL Type error (TE_NBV): base value of empty type integer {5..0}.
   [1]
 
   $ aslref TypingRule.UnopLiterals.asl
@@ -374,7 +379,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.EVar.undefined.asl, line 3, characters 12 to 13:
       var x = t;
               ^
-  ASL Static error: Undefined identifier: 't'
+  ASL Static error (TE_UI): Undefined identifier: 't'
   [1]
 
   $ aslref TypingRule.EGetRecordField.asl
@@ -382,20 +387,22 @@ ASL Typing Tests / annotating types:
   File TypingRule.EGetBadRecordField.asl, line 7, characters 10 to 36:
     var x = my_record.undeclared_field;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: There is no field 'undeclared_field' on type MyRecordType.
+  ASL Type error (TE_BF): There is no field 'undeclared_field'
+    on type MyRecordType.
   [1]
   $ aslref TypingRule.EGetBitfield.asl
   $ aslref TypingRule.EGetBadBitField.asl
   File TypingRule.EGetBadBitField.asl, line 7, characters 12 to 33:
       var x = p.undeclared_bitfield;
               ^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: There is no field 'undeclared_bitfield' on type Packet.
+  ASL Type error (TE_BF): There is no field 'undeclared_bitfield'
+    on type Packet.
   [1]
   $ aslref TypingRule.EGetBadField.asl
   File TypingRule.EGetBadField.asl, line 6, characters 12 to 15:
       var x = a.f;
               ^^^
-  ASL Type error: There is no field 'f' on type array [[5]] of integer.
+  ASL Type error (TE_BF): There is no field 'f' on type array [[5]] of integer.
   [1]
   $ aslref TypingRule.EGetFields.asl
   $ aslref --no-exec TypingRule.ATC.asl
@@ -406,14 +413,14 @@ ASL Typing Tests / annotating types:
   File TypingRule.ATC.bad.asl, line 4, characters 21 to 33:
       let B: integer = A as integer; // Illegal: bit cannot be an integer.
                        ^^^^^^^^^^^^
-  ASL Type error: cannot perform Asserted Type Conversion on bits(1) by
-    integer.
+  ASL Type error (TE_TAF): cannot perform Asserted Type Conversion on bits(1)
+    by integer.
   [1]
   $ aslref --no-exec TypingRule.CheckATC.asl
   File TypingRule.CheckATC.asl, line 6, characters 12 to 32:
       var a = 3.0 as integer{1, 2};
               ^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot perform Asserted Type Conversion on real by
+  ASL Type error (TE_TAF): cannot perform Asserted Type Conversion on real by
     integer {1, 2}.
   [1]
   $ aslref --no-exec TypingRule.IsGlobalUndefined.asl
@@ -425,8 +432,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.StaticEval.bad.asl, line 3, characters 5 to 20:
       [WORD_SIZE DIV 3 - 1:WORD_SIZE DIV 2] upper,
        ^^^^^^^^^^^^^^^
-  ASL Type error: Illegal application of operator DIV on types integer {64}
-    and integer {3}.
+  ASL Type error (TE_BO): Illegal application of operator DIV on types
+    integer {64} and integer {3}.
   [1]
   $ aslref TypingRule.Catcher.asl
   ExceptionType2 : x=2, g= 1
@@ -438,7 +445,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.LEVar.undefined.asl, line 3, characters 4 to 5:
       x = 42;
       ^
-  ASL Static error: Undefined identifier: 'x'
+  ASL Static error (TE_UI): Undefined identifier: 'x'
   [1]
   $ aslref TypingRule.LESetStructuredField.asl
   $ aslref TypingRule.LESetField.asl
@@ -446,29 +453,29 @@ ASL Typing Tests / annotating types:
   File TypingRule.LESetBadField.asl, line 10, characters 4 to 5:
       x.RED = 42;
       ^
-  ASL Type error: integer does not subtype any of: bits(-), record {  },
-    exception {  }, collection {  }.
+  ASL Type error (TE_UT): integer does not subtype any of: bits(-),
+    record {  }, exception {  }, collection {  }.
   [1]
   $ aslref TypingRule.LESetFields.asl
   $ aslref TypingRule.LESlice.bad.asl
   File TypingRule.LESlice.bad.asl, line 4, characters 3 to 11:
     x[3:0, 3] = '0 0000';
      ^^^^^^^^
-  ASL Static error: overlapping slices 0+:4, 3+:1.
+  ASL Static error (TE_BS): overlapping slices 0+:4, 3+:1.
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.asl
   $ aslref --no-exec TypingRule.SCall.bad.asl
   File TypingRule.SCall.bad.asl, line 11, characters 4 to 11:
       zero();
       ^^^^^^^
-  ASL Static error:
+  ASL Static error (TE_BC):
     Mismatched call type for subprogram 'zero': expected a procedure and found a function.
   [1]
   $ aslref --no-exec TypingRule.ECall.bad.asl
   File TypingRule.ECall.bad.asl, line 9, characters 8 to 13:
       - = nop(); // Illegal: nop is a procedure, therefore no value to consume.
           ^^^^^
-  ASL Static error:
+  ASL Static error (TE_BC):
     Mismatched call type for subprogram 'nop': expected a function and found a procedure.
   [1]
   $ aslref --no-exec TypingRule.SCond.asl
@@ -492,7 +499,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.SAssert.bad.asl, line 11, characters 10 to 23:
       assert(increment()); // illegal: increment is not readonly.
             ^^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref TypingRule.SWhile.asl
   File TypingRule.SWhile.asl, line 23, character 4 to line 29, character 8:
@@ -510,38 +517,39 @@ ASL Typing Tests / annotating types:
   File TypingRule.SWhile.bad_limit.asl, line 8, characters 26 to 33:
       while i < N looplimit i_limit do
                             ^^^^^^^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
   $ aslref TypingRule.SFor.bad1.asl
   File TypingRule.SFor.bad1.asl, line 5, character 4 to line 7, character 8:
       for i = 0 to 4 do
           pass;
       end;
-  ASL Type error: cannot declare already declared element "i".
+  ASL Type error (TE_IAD): cannot declare already declared element "i".
   [1]
   $ aslref TypingRule.SFor.bad2.asl
   File TypingRule.SFor.bad2.asl, line 5, characters 8 to 9:
           i = i + 1;
           ^
-  ASL Type error: cannot assign to immutable storage "i".
+  ASL Type error (TE_AIM): cannot assign to immutable storage "i".
   [1]
   $ aslref TypingRule.SFor.bad3.asl
   File TypingRule.SFor.bad3.asl, line 7, characters 4 to 5:
       j = 0; // Illegal: 'j' is in scope only in the loop body.
       ^
-  ASL Static error: Undefined identifier: 'j'
+  ASL Static error (TE_UI): Undefined identifier: 'j'
   [1]
   $ aslref TypingRule.SFor.bad4.asl
   File TypingRule.SFor.bad4.asl, line 11, characters 17 to 30:
       for j = 0 to upper_bound() do
                    ^^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref TypingRule.SReturn.bad.asl
   File TypingRule.SReturn.bad.asl, line 3, characters 4 to 13:
       return 0;
       ^^^^^^^^^
-  ASL Type error: cannot return something from a procedure.
+  ASL Type error (TE_BSPD): cannot return something from a procedure.
   [1]
   $ aslref --no-exec TypingRule.SPragma.asl
   File TypingRule.SPragma.asl, line 3, characters 4 to 39:
@@ -558,7 +566,7 @@ ASL Typing Tests / annotating types:
       [3:0, 5:3] data,
       [3*4 +: 4] value
   };
-  ASL Static error: overlapping slices 0+:4, 3+:3.
+  ASL Static error (TE_BS): overlapping slices 0+:4, 3+:3.
   [1]
   $ aslref --no-exec TypingRule.CheckPositionsInWidth.bad.asl
   File TypingRule.CheckPositionsInWidth.bad.asl, line 1, character 0 to line 5,
@@ -568,7 +576,7 @@ ASL Typing Tests / annotating types:
       [3:0, 5+:3] data,
       [3*5 +:5] value // Illegal: position 19 exceeds 15
   };
-  ASL Static error:
+  ASL Static error (TE_BS):
     Cannot extract from bitvector of length 16 slice (3 * 5)+:5.
   [1]
 
@@ -582,8 +590,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.CheckNoPrecisionLoss.asl, line 3, characters 0 to 14:
   var b = a * a;
   ^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref TypingRule.PrecisionJoin.asl
   File TypingRule.PrecisionJoin.asl, line 3, characters 9 to 14:
@@ -595,8 +603,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.PrecisionJoin.asl, line 3, characters 0 to 20:
   var b = (a * a) + 2;
   ^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
 
   $ aslref TypingRule.PSingle.asl
@@ -612,38 +620,38 @@ ASL Typing Tests / annotating types:
   File TypingRule.PRange.bad.asl, line 4, characters 11 to 32:
       assert 42.4 IN { -1.8..143 };
              ^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: Erroneous pattern (- (9.0 / 5.0)) .. 143 for expression of
-    type real.
+  ASL Type error (TE_BO): Erroneous pattern (- (9.0 / 5.0)) .. 143 for
+    expression of type real.
   [1]
   $ aslref TypingRule.PLeq.asl
   $ aslref TypingRule.PLeq.bad.asl
   File TypingRule.PLeq.bad.asl, line 4, characters 12 to 28:
        assert 3 IN { <= 42.0 };
               ^^^^^^^^^^^^^^^^
-  ASL Type error: Erroneous pattern <= (42.0 / 1.0) for expression of type
-    integer {3}.
+  ASL Type error (TE_BO): Erroneous pattern <= (42.0 / 1.0) for expression of
+    type integer {3}.
   [1]
   $ aslref TypingRule.PGeq.asl
   $ aslref TypingRule.PGeq.bad.asl
   File TypingRule.PGeq.bad.asl, line 4, characters 11 to 27:
       assert 42 IN { >= 3.0 };
              ^^^^^^^^^^^^^^^^
-  ASL Type error: Erroneous pattern >= (3.0 / 1.0) for expression of type
-    integer {42}.
+  ASL Type error (TE_BO): Erroneous pattern >= (3.0 / 1.0) for expression of
+    type integer {42}.
   [1]
   $ aslref TypingRule.PMask.asl
   $ aslref TypingRule.PMask.bad.asl
   File TypingRule.PMask.bad.asl, line 5, characters 11 to 34:
       assert '101010' IN {'xx10101'};
              ^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(7) was expected, provided bits(6).
+  ASL Type error (TE_UT): a subtype of bits(7) was expected, provided bits(6).
   [1]
   $ aslref TypingRule.PAny.asl
   $ aslref TypingRule.PAny.bad.asl
   File TypingRule.PAny.bad.asl, line 5, characters 11 to 29:
       assert TRUE IN {FALSE, 5};
              ^^^^^^^^^^^^^^^^^^
-  ASL Type error: Erroneous pattern 5 for expression of type boolean.
+  ASL Type error (TE_BO): Erroneous pattern 5 for expression of type boolean.
   [1]
 
   $ aslref TypingRule.CheckIsNotCollection.asl
@@ -673,13 +681,13 @@ ASL Typing Tests / annotating types:
               throw invalid_state{-};
           end;
       end;
-  ASL Type error:
+  ASL Type error (TE_BSPD):
     not all control flow paths of the function "incorrect_terminating_path" are
     guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
   $ aslref TypingRule.CheckControlFlow.bad3.asl
-  ASL Type error: the function "returning" is qualified with noreturn but may
-    return on some control flow path.
+  ASL Type error (TE_BSPD): the function "returning" is qualified with noreturn
+    but may return on some control flow path.
   [1]
   $ aslref --no-exec TypingRule.ApproxExprMin.asl
   $ aslref --no-exec TypingRule.ApproxExprMax.asl
@@ -700,8 +708,9 @@ ASL Typing Tests / annotating types:
       while (TRUE) do
           pass;
       end;
-  ASL Type error: not all control flow paths of the function "loop_forever" are
-    guaranteed to either return, raise an exception, or invoke unreachable.
+  ASL Type error (TE_BSPD):
+    not all control flow paths of the function "loop_forever" are guaranteed to
+    either return, raise an exception, or invoke unreachable.
   [1]
   $ aslref --no-exec TypingRule.DeclareType.asl
   $ aslref --no-exec TypingRule.DeclaredType.asl
@@ -709,7 +718,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.DeclaredType.bad.asl, line 3, characters 12 to 23:
       var x = 20 as MyInt;
               ^^^^^^^^^^^
-  ASL Static error: Undefined identifier: 'MyInt'
+  ASL Static error (TE_UI): Undefined identifier: 'MyInt'
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.config.asl
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.config.bad.asl
@@ -717,19 +726,19 @@ ASL Typing Tests / annotating types:
     characters 0 to 47:
   config c_inherited_constrained : integer{} = 5;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a pending constrained integer is illegal here.
+  ASL Type error (TE_UT): a pending constrained integer is illegal here.
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad1.asl
   File TypingRule.DeclareGlobalStorage.bad1.asl, line 3, characters 0 to 29:
   config c : integer{1..5} = x;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad2.asl
   File TypingRule.DeclareGlobalStorage.bad2.asl, line 3, characters 0 to 29:
   config c : integer{1..x} = 2;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref --no-exec TypingRule.DeclareGlobalStorage.bad3.asl
   File TypingRule.DeclareGlobalStorage.bad3.asl, line 2, characters 37 to 38:
@@ -746,7 +755,7 @@ ASL Typing Tests / annotating types:
     characters 0 to 36:
   var c_inherited_illegal : integer{};
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a pending constrained integer is illegal here.
+  ASL Type error (TE_UT): a pending constrained integer is illegal here.
   [1]
   $ aslref --no-exec TypingRule.UpdateGlobalStorage.constant.asl
   $ aslref --no-exec TypingRule.UpdateGlobalStorage.config.asl
@@ -755,7 +764,7 @@ ASL Typing Tests / annotating types:
     characters 0 to 39:
   config d: MyException = MyException{-};
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected singular type, found MyException.
+  ASL Type error (TE_UT): expected singular type, found MyException.
   [1]
   $ aslref --no-exec TypingRule.DefDecl.asl
   $ aslref --no-exec TypingRule.UseDecl.asl
@@ -782,8 +791,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.CheckGlobalPragma.bad.asl, line 2, characters 22 to 28:
   pragma bad_pragma 1, (2==3.0), x;
                         ^^^^^^
-  ASL Type error: Illegal application of operator == on types integer {2}
-    and real.
+  ASL Type error (TE_BO): Illegal application of operator == on types
+    integer {2} and real.
   [1]
   $ aslref --no-exec TypingRule.AddSubprogramDecls.asl
   $ aslref --no-exec TypingRule.TypeCheckAST.asl
@@ -795,13 +804,13 @@ ASL Typing Tests / annotating types:
   File TypingRule.TypeCheckMutuallyRec.bad.asl, line 1, characters 0 to 15:
   var g = foo(5);
   ^^^^^^^^^^^^^^^
-  ASL Type error: multiple recursive declarations: "foo", "g".
+  ASL Type error (TE_BD): multiple recursive declarations: "foo", "g".
   [1]
   $ aslref --no-exec TypingRule.TypeCheckMutuallyRec.bad2.asl
   File TypingRule.TypeCheckMutuallyRec.bad2.asl, line 2, characters 0 to 19:
   type other of base;
   ^^^^^^^^^^^^^^^^^^^
-  ASL Type error: multiple recursive declarations: "other", "base".
+  ASL Type error (TE_BD): multiple recursive declarations: "other", "base".
   [1]
   $ aslref --no-exec TypingRule.DeclareSubprograms.asl
   $ aslref --no-exec TypingRule.SubprogramForSignature.asl
@@ -812,14 +821,14 @@ ASL Typing Tests / annotating types:
     characters 8 to 17:
       - = add_10(5);
           ^^^^^^^^^
-  ASL Static error: Undefined identifier: 'add_10'
+  ASL Static error (TE_UI): Undefined identifier: 'add_10'
   [1]
   $ aslref TypingRule.SubprogramForSignature.bad.no_candidates.asl
   File TypingRule.SubprogramForSignature.bad.no_candidates.asl, line 8,
     characters 8 to 19:
       - = add_10(5.0);
           ^^^^^^^^^^^
-  ASL Type error: No subprogram declaration matches the invocation:
+  ASL Type error (TE_BC): No subprogram declaration matches the invocation:
     add_10(real).
   [1]
   $ aslref TypingRule.ExpressionList.asl
@@ -839,13 +848,13 @@ ASL Typing Tests / annotating types:
   File TypingRule.SubprogramTypesClash.bad1.asl, line 4, characters 8 to 22:
           return '1000';
           ^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "X".
+  ASL Type error (TE_IAD): cannot declare already declared element "X".
   [1]
   $ aslref TypingRule.SubprogramTypesClash.bad2.asl
   File TypingRule.SubprogramTypesClash.bad2.asl, line 1, characters 0 to 40:
   func X() => integer begin return 0; end;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "X".
+  ASL Type error (TE_IAD): cannot declare already declared element "X".
   [1]
   $ aslref TypingRule.SubprogramClash.bad1.asl
   File TypingRule.SubprogramClash.bad1.asl, line 1, character 0 to line 4,
@@ -854,7 +863,7 @@ ASL Typing Tests / annotating types:
   begin
     return 0;
   end;
-  ASL Type error: cannot declare already declared element "X".
+  ASL Type error (TE_IAD): cannot declare already declared element "X".
   [1]
   $ aslref --no-exec TypingRule.CheckParamDecls.asl
   $ aslref TypingRule.CheckParamDecls.bad.asl
@@ -867,8 +876,8 @@ ASL Typing Tests / annotating types:
   begin
       return Ones{D};
   end;
-  ASL Type error: incorrect parameter declaration for "parameter_lists",
-    expected {D, A, B, C} but {A, B, C, D} provided
+  ASL Type error (TE_BSPD): incorrect parameter declaration for
+    "parameter_lists", expected {D, A, B, C} but {A, B, C, D} provided
   [1]
   $ aslref TypingRule.AnnotateReturnType.bad.asl
   File TypingRule.AnnotateReturnType.bad.asl, line 3, characters 24 to 34:
@@ -881,7 +890,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateOneParam.bad1.asl, line 4, characters 0 to 50:
   func parameterized{A}(x: bits(A)) begin pass; end;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "A".
+  ASL Type error (TE_IAD): cannot declare already declared element "A".
   [1]
   $ aslref --no-exec TypingRule.AnnotateOneArg.asl
   $ aslref TypingRule.AnnotateOneArg.bad1.asl
@@ -893,7 +902,7 @@ ASL Typing Tests / annotating types:
       - = i;
       - = r;
   end;
-  ASL Type error: cannot declare already declared element "b".
+  ASL Type error (TE_IAD): cannot declare already declared element "b".
   [1]
   $ aslref TypingRule.AnnotateOneArg.bad2.asl
   File TypingRule.AnnotateOneArg.bad2.asl, line 2, characters 18 to 28:
@@ -906,7 +915,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateRetTy.bad.asl, line 15, characters 4 to 17:
       flip{64}(bv); // Illegal: the returned value must be consumed.
       ^^^^^^^^^^^^^
-  ASL Static error:
+  ASL Static error (TE_BC):
     Mismatched call type for subprogram 'flip': expected a procedure and found a function.
   [1]
   $ aslref --no-exec TypingRule.AnnotateCall.asl
@@ -915,27 +924,27 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateCall.bad.asl, line 6, characters 4 to 21:
       f{wid}(bus, bus); // Illegal
       ^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {2, 4} was expected,
+  ASL Type error (TE_UT): a subtype of integer {2, 4} was expected,
     provided integer {2, 4, 8}.
   [1]
   $ aslref TypingRule.AnnotateCall.bad2.asl
   File TypingRule.AnnotateCall.bad2.asl, line 13, characters 8 to 33:
       - = parameterized_func{arg}();
           ^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref TypingRule.AnnotateCall.bad3.asl
   File TypingRule.AnnotateCall.bad3.asl, line 9, characters 11 to 32:
       return constrained_func{N}();
              ^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {1, 2, 3} was expected,
+  ASL Type error (TE_UT): a subtype of integer {1, 2, 3} was expected,
     provided integer {2, 3, 4}.
   [1]
   $ aslref TypingRule.AnnotateCall.bad4.asl
   File TypingRule.AnnotateCall.bad4.asl, line 9, characters 11 to 32:
       return constrained_func{N}(); // requires an asserting type conversion
              ^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {1, 2, 3} was expected,
+  ASL Type error (TE_UT): a subtype of integer {1, 2, 3} was expected,
     provided integer {N}.
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad1.asl
@@ -943,7 +952,7 @@ ASL Typing Tests / annotating types:
     characters 8 to 32:
       - = xor_extend{64}(bv1, bv2); // Illegal: missing parameter for `M`.
           ^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Static error: Arity error while calling 'xor_extend':
+  ASL Static error (TE_BC): Arity error while calling 'xor_extend':
     2 parameters expected and 1 provided
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad2.asl
@@ -951,7 +960,7 @@ ASL Typing Tests / annotating types:
     characters 8 to 31:
       - = xor_extend{64, 32}(bv1);
           ^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: No subprogram declaration matches the invocation:
+  ASL Type error (TE_BC): No subprogram declaration matches the invocation:
     xor_extend(bits(64)).
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad3.asl
@@ -959,7 +968,7 @@ ASL Typing Tests / annotating types:
     characters 8 to 24:
       - = plus{64}(bv1, w);
           ^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..64} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..64} was expected,
     provided integer {0..128}.
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad4.asl
@@ -967,7 +976,7 @@ ASL Typing Tests / annotating types:
     characters 14 to 27:
       var arg = ones{myWid}();
                 ^^^^^^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref TypingRule.SubstExpr.asl
   $ aslref --no-exec TypingRule.CheckSymbolicallyEvaluable.asl
@@ -976,7 +985,7 @@ ASL Typing Tests / annotating types:
     characters 5 to 28:
       [symbolic_throwing{4}(4)] data
        ^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref TypingRule.EvalSliceExpr.asl
   $ aslref --no-exec TypingRule.SideEffectsLDK.asl
@@ -988,20 +997,20 @@ ASL Typing Tests / annotating types:
   File TypingRule.SESIsReadonly.bad1.asl, line 17, characters 11 to 37:
       assert y > write_side_effecting();
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref TypingRule.SESIsReadonly.bad2.asl
   File TypingRule.SESIsReadonly.bad2.asl, line 16, characters 17 to 39:
       for i = x to write_side_effecting() do
                    ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref TypingRule.SESIsPure.asl
   $ aslref TypingRule.SESIsPure.bad.asl
   File TypingRule.SESIsPure.bad.asl, line 4, characters 18 to 23:
   type Data of bits(g * 2) {
                     ^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref --no-exec TypingRule.SESForSubprogram.asl
   $ aslref --no-exec TypingRule.SESIsSymbolicallyEvaluable.asl
@@ -1010,7 +1019,8 @@ ASL Typing Tests / annotating types:
     characters 38 to 39:
       var bv: bits(x) = ARBITRARY: bits(x);
                                         ^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
   $ aslref TypingRule.SliceEqual.asl
   $ aslref TypingRule.SlicesEqual.asl
@@ -1019,7 +1029,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.RenameSubprograms.asl, line 3, characters 2 to 11:
     return 1;
     ^^^^^^^^^
-  ASL Type error: a subtype of boolean was expected, provided integer {1}.
+  ASL Type error (TE_UT): a subtype of boolean was expected,
+    provided integer {1}.
   [1]
   $ aslref TypingRule.ApproxConstraint.asl
   $ aslref TypingRule.ApproxConstraints.asl
@@ -1032,7 +1043,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.BitFieldEqual.bad1.asl, line 4, characters 4 to 71:
       var x : bits(64) { [1] data } = Zeros{64} as bits(64) { [2] data };
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits (64) { [1+:1] data } was expected,
+  ASL Type error (TE_UT): a subtype of bits (64) { [1+:1] data } was expected,
     provided bits (64) { [2+:1] data }.
   [1]
   $ aslref TypingRule.BitFieldEqual.bad2.asl
@@ -1040,15 +1051,16 @@ ASL Typing Tests / annotating types:
     character 43:
       var x : bits(64) { [16+:16] data { [0] lsb } } =  Zeros{64} as
               bits(64) { [31:16] data {  } };
-  ASL Type error: a subtype of bits (64) { [16+:16] data { [0+:1] lsb } }
-    was expected, provided bits (64) { [16+:16] data {  } }.
+  ASL Type error (TE_UT): a subtype of
+    bits (64) { [16+:16] data { [0+:1] lsb } } was expected,
+    provided bits (64) { [16+:16] data {  } }.
   [1]
   $ aslref --no-exec TypingRule.BitFieldsEqual.asl
   $ aslref TypingRule.BitFieldsEqual.bad.asl
   File TypingRule.BitFieldsEqual.bad.asl, line 6, characters 0 to 76:
   implementation func Foo(bv : bits(64) { [1] msb, [0] lsb }) begin pass; end;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: no `impdef` for `implementation` function.
+  ASL Type error (TE_OE): no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec TypingRule.TypeEqual.asl
   $ aslref TypingRule.ExprEqual.asl
@@ -1056,7 +1068,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.ReduceConstraint.asl, line 6, characters 4 to 67:
       var x : integer{3 * w, 0..(5 * z - z) - 2 * z,  w + z} = w + z;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..(2 * z), (z + w), (3 * w)}
+  ASL Type error (TE_UT): a subtype of integer {0..(2 * z), (z + w), (3 * w)}
     was expected, provided integer {0..2000}.
   [1]
   $ aslref TypingRule.ConstraintEqual.asl
@@ -1073,7 +1085,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.ApproxBottomTop.asl, line 5, characters 4 to 30:
       var x : integer{a..b} = a;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {a..b} was expected,
+  ASL Type error (TE_UT): a subtype of integer {a..b} was expected,
     provided integer {1..10}.
   [1]
   $ aslref TypingRule.SymdomOfWidthExpr.asl
@@ -1083,7 +1095,7 @@ ASL Typing Tests / annotating types:
     characters 4 to 33:
       let t: integer{x..x + 1} = 2;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {x..(x + 1)} was expected,
+  ASL Type error (TE_UT): a subtype of integer {x..(x + 1)} was expected,
     provided integer {2}.
   [1]
   $ aslref --no-exec TypingRule.AddGlobalImmutableExpr.asl
@@ -1095,34 +1107,34 @@ ASL Typing Tests / annotating types:
   File TypingRule.CheckVarNotInGEnv.bad.asl, line 1, characters 0 to 17:
   var RED: integer;
   ^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "RED".
+  ASL Type error (TE_IAD): cannot declare already declared element "RED".
   [1]
   $ aslref --no-exec TypingRule.CheckVarNotInEnv.bad1.asl
   File TypingRule.CheckVarNotInEnv.bad1.asl, line 1, characters 0 to 53:
   func foo{A}(bv: bits(A), A: integer) begin pass; end;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "A".
+  ASL Type error (TE_IAD): cannot declare already declared element "A".
   [1]
   $ aslref --no-exec TypingRule.CheckVarNotInEnv.bad2.asl
   File TypingRule.CheckVarNotInEnv.bad2.asl, line 3, characters 14 to 15:
       var x, y, y: integer;
                 ^
-  ASL Type error: cannot declare already declared element "y".
+  ASL Type error (TE_IAD): cannot declare already declared element "y".
   [1]
   $ aslref TypingRule.CheckBitsEqualWidth.asl
   $ aslref TypingRule.CheckBitsEqualWidth.bad.asl
   File TypingRule.CheckBitsEqualWidth.bad.asl, line 9, characters 15 to 21:
           return x == y; // Illegal: M and N are not necessarily equal.
                  ^^^^^^
-  ASL Type error: Illegal application of operator == on types bits(M)
+  ASL Type error (TE_BO): Illegal application of operator == on types bits(M)
     and bits(N).
   [1]
   $ aslref TypingRule.CheckBitsEqualWidth.bad2.asl
   File TypingRule.CheckBitsEqualWidth.bad2.asl, line 10, characters 11 to 23:
       cond = bit1 == bit2; // Illegal
              ^^^^^^^^^^^^
-  ASL Type error: Illegal application of operator == on types bits(int1)
-    and bits(int2).
+  ASL Type error (TE_BO): Illegal application of operator == on types
+    bits(int1) and bits(int2).
   [1]
   $ aslref --no-exec TypingRule.GetWellConstrainedStructure.asl
   $ aslref --no-exec TypingRule.MemBfs.asl
@@ -1130,7 +1142,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.MemBfs.bad.asl, line 9, characters 4 to 44:
       var x : bits(8) {[0] flag, [1] lsb} = y;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits (8) { [0+:1] flag, [1+:1] lsb }
+  ASL Type error (TE_UT): a subtype of bits (8) { [0+:1] flag, [1+:1] lsb }
     was expected, provided FlaggedPacket.
   [1]
   $ aslref --no-exec TypingRule.IntervalTooLarge.asl
@@ -1142,8 +1154,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.IntervalTooLarge.bad.asl, line 9, characters 4 to 29:
       var z: integer{} = b * 2;
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref --no-exec TypingRule.ExplodeIntervals.bad.asl
   File TypingRule.ExplodeIntervals.bad.asl, line 10, characters 23 to 28:
@@ -1153,8 +1165,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.ExplodeIntervals.bad.asl, line 10, characters 4 to 29:
       var z: integer{} = b * 2;
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref --no-exec TypingRule.FilterReduceConstraintDiv.asl
   $ aslref TypingRule.ReduceToZOpt.asl
@@ -1177,21 +1189,22 @@ ASL Typing Tests / annotating types:
   File TypingRule.EBinop.bad.asl, line 3, characters 10 to 19:
     let x = 3 DIV 0.0;
             ^^^^^^^^^
-  ASL Type error: Illegal application of operator DIV on types integer {3}
-    and real.
+  ASL Type error (TE_BO): Illegal application of operator DIV on types
+    integer {3} and real.
   [1]
   $ aslref --no-exec TypingRule.ECond.asl
   $ aslref TypingRule.ESlice.bad1.asl
   File TypingRule.ESlice.bad1.asl, line 10, characters 4 to 7:
       dst = src[w:1];
       ^^^
-  ASL Type error: a subtype of bits((k - 1)) was expected, provided bits(w).
+  ASL Type error (TE_UT): a subtype of bits((k - 1)) was expected,
+    provided bits(w).
   [1]
   $ aslref TypingRule.ESlice.bad2.asl
   File TypingRule.ESlice.bad2.asl, line 4, characters 12 to 20:
       let x = 5.0[2:0];
               ^^^^^^^^
-  ASL Type error: real does not subtype any of: integer, bits(-).
+  ASL Type error (TE_UT): real does not subtype any of: integer, bits(-).
   [1]
   $ aslref --no-exec TypingRule.Structure.asl
   $ aslref --no-exec TypingRule.AnonymousType.asl
@@ -1199,7 +1212,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateSlices.bad-impure.asl, line 12, characters 12 to 28:
     let y = x[side_effecting()];
               ^^^^^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref --no-exec TypingRule.AddNewFunc.bad1.asl
   File TypingRule.AddNewFunc.bad1.asl, line 8, character 0 to line 11,
@@ -1208,13 +1221,13 @@ ASL Typing Tests / annotating types:
   begin
       pass;
   end;
-  ASL Type error: cannot declare already declared element "f".
+  ASL Type error (TE_IAD): cannot declare already declared element "f".
   [1]
   $ aslref --no-exec TypingRule.AddNewFunc.bad2.asl
   File TypingRule.AddNewFunc.bad2.asl, line 18, characters 4 to 21:
       g(myCircle, 0.1); // illegal
       ^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of square was expected, provided circle.
+  ASL Type error (TE_UT): a subtype of square was expected, provided circle.
   [1]
   $ aslref --no-exec TypingRule.AddNewFunc.bad3.asl
   File TypingRule.AddNewFunc.bad3.asl, line 8, character 0 to line 11,
@@ -1223,7 +1236,7 @@ ASL Typing Tests / annotating types:
   begin
       pass;
   end;
-  ASL Type error: cannot declare already declared element "h".
+  ASL Type error (TE_IAD): cannot declare already declared element "h".
   [1]
 
   $ aslref --no-exec TypingRule.UseLDI.asl

--- a/asllib/tests/atcs.t
+++ b/asllib/tests/atcs.t
@@ -26,8 +26,8 @@ Bad structure ATCs
   File atcs2.asl, line 2, characters 11 to 23:
     let x = (3 as boolean);
              ^^^^^^^^^^^^
-  ASL Type error: cannot perform Asserted Type Conversion on integer {3} by
-    boolean.
+  ASL Type error (TE_TAF): cannot perform Asserted Type Conversion on
+    integer {3} by boolean.
   [1]
 
 ATCs on other types
@@ -64,7 +64,8 @@ ATCs on other types
   File atcs5.asl, line 5, characters 10 to 20:
     let y = x as myty2;
             ^^^^^^^^^^
-  ASL Type error: cannot perform Asserted Type Conversion on myty by myty2.
+  ASL Type error (TE_TAF): cannot perform Asserted Type Conversion on myty by
+    myty2.
   [1]
 
   $ cat > atcs6.asl <<EOF

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -27,7 +27,7 @@ Bad fields
     [10: 3] a,
     [2+:1] a,
   };
-  ASL Type error: cannot declare already declared element "a".
+  ASL Type error (TE_IAD): cannot declare already declared element "a".
   [1]
 
 Overlapping slices
@@ -44,7 +44,7 @@ Overlapping slices
     [23: 0] a,
     [10: 0, 3+: 2] b,
   };
-  ASL Static error: overlapping slices 0+:11, 3+:2.
+  ASL Static error (TE_BS): overlapping slices 0+:11, 3+:2.
   [1]
 
 Bad slices
@@ -61,7 +61,8 @@ Bad slices
     [10: 3] a,
     [14:12] b,
   };
-  ASL Static error: Cannot extract from bitvector of length 12 slice 12+:3.
+  ASL Static error (TE_BS):
+    Cannot extract from bitvector of length 12 slice 12+:3.
   [1]
 
   $ cat >bad-types5.asl <<EOF
@@ -77,7 +78,8 @@ Bad slices
     [10: 3] a,
     [-2+:1] b,
   };
-  ASL Static error: Cannot extract from bitvector of length 12 slice (- 2)+:1.
+  ASL Static error (TE_BS):
+    Cannot extract from bitvector of length 12 slice (- 2)+:1.
   [1]
 
   $ cat >bad-types6.asl <<EOF
@@ -99,7 +101,8 @@ Bad slices
       [10:8] c,
     },
   };
-  ASL Static error: Cannot extract from bitvector of length 3 slice 8+:3.
+  ASL Static error (TE_BS):
+    Cannot extract from bitvector of length 3 slice 8+:3.
   [1]
 
 Empty types
@@ -119,7 +122,7 @@ Arbitrary of empty type
   File bad-types7.asl, line 3, characters 38 to 52:
      let b: integer {1..0} = ARBITRARY: integer {1..0};
                                         ^^^^^^^^^^^^^^
-  ASL Dynamic error: ARBITRARY of empty type integer {1..0}.
+  ASL Dynamic error (DE_AET): ARBITRARY of empty type integer {1..0}.
   [1]
 
 Base value of empty type
@@ -136,5 +139,5 @@ Base value of empty type
   File bad-types8.asl, line 3, characters 2 to 24:
     var b: integer {1..0};
     ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: base value of empty type integer {1..0}.
+  ASL Type error (TE_NBV): base value of empty type integer {1..0}.
   [1]

--- a/asllib/tests/bitfield-alignment.t/run.t
+++ b/asllib/tests/bitfield-alignment.t/run.t
@@ -8,7 +8,7 @@
           [0] sub
       }
   };
-  ASL Type error:
+  ASL Type error (TE_BS):
     bitfields `sub` and `sub.sub` are in the same scope but define different slices of the containing bitvector type: [1:0] and [0], respectively.
   [1]
 
@@ -21,7 +21,7 @@
           }
       }
   };
-  ASL Type error:
+  ASL Type error (TE_BS):
     bitfields `sub` and `sub.sub.sub` are in the same scope but define different slices of the containing bitvector type: [1:0] and [1], respectively.
   [1]
 
@@ -36,7 +36,7 @@
   
       [1,0] lowest
   };
-  ASL Type error:
+  ASL Type error (TE_BS):
     bitfields `sub.sub.lowest` and `lowest` are in the same scope but define different slices of the containing bitvector type: [0, 1] and [1:0], respectively.
   [1]
 
@@ -44,17 +44,17 @@
   File non-constant-width.asl, line 4, characters 29 to 34:
     let x = Zeros{64} as (bits(sub_k) {[0] flag});
                                ^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref non-constant-global-width.asl
   File non-constant-global-width.asl, line 3, characters 21 to 26:
   type my_type of bits(sub_k) {
                        ^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref config-global-width.asl
   File config-global-width.asl, line 3, characters 21 to 26:
   type my_type of bits(sub_k) {
                        ^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]

--- a/asllib/tests/capture_output.expected
+++ b/asllib/tests/capture_output.expected
@@ -8,5 +8,5 @@ stderr:
 File capture_output.asl, line 4, characters 9 to 14:
   assert FALSE;
          ^^^^^
-ASL Dynamic error: Assertion failed: FALSE.
+ASL Dynamic error (DE_DAF): Assertion failed: FALSE.
 

--- a/asllib/tests/collections.t/run.t
+++ b/asllib/tests/collections.t/run.t
@@ -14,7 +14,7 @@
   File on-local-var.asl, line 8, characters 2 to 25:
     var col = MyCollection;
     ^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: unexpected collection.
+  ASL Type error (TE_UT): unexpected collection.
   [1]
   $ aslref with-non-bitvector-arg.asl
   File with-non-bitvector-arg.asl, line 1, character 0 to line 4, character 2:
@@ -36,14 +36,14 @@
   File on-local-tuple.asl, line 8, characters 2 to 33:
     var col2 = (my_collection, 32);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: unexpected collection.
+  ASL Type error (TE_UT): unexpected collection.
   [1]
 
   $ aslref on-global-var.asl
   File on-global-var.asl, line 6, characters 0 to 33:
   var MyCollection2 = MyCollection;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: unexpected collection.
+  ASL Type error (TE_UT): unexpected collection.
   [1]
 
   $ aslref on-type-declaration.asl

--- a/asllib/tests/constraint-size-limits.t/run.t
+++ b/asllib/tests/constraint-size-limits.t/run.t
@@ -3,15 +3,15 @@
   File constraint-mul-00.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error: a subtype of integer {0..4, 6, 8..9, 12, 16} was expected,
-    provided integer {15}.
+  ASL Type error (TE_UT): a subtype of integer {0..4, 6, 8..9, 12, 16}
+    was expected, provided integer {15}.
   [1]
 
   $ aslref constraint-mul-01.asl
   File constraint-mul-01.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error: a subtype of
+  ASL Type error (TE_UT): a subtype of
     integer {0..16, 18, 20..22, 24..28, 30, 32..33, 35..36, 39..40, 42, 
              44..45, ...} was expected, provided integer {255}.
   [1]
@@ -20,7 +20,7 @@
   File constraint-mul-02.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error: a subtype of
+  ASL Type error (TE_UT): a subtype of
     integer {0..36, 38..40, 42, 44..46, 48..52, 54..58, 60, 62..66, 68..70, 72,
              ...} was expected, provided integer {1023}.
   [1]
@@ -29,7 +29,7 @@
   File constraint-mul-03.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error: a subtype of
+  ASL Type error (TE_UT): a subtype of
     integer {0..66, 68..70, 72, 74..78, 80..82, 84..88, 90..96, 98..100, 102,
              104..106, ...} was expected, provided integer {4095}.
   [1]
@@ -38,7 +38,7 @@
   File constraint-mul-04.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error: a subtype of
+  ASL Type error (TE_UT): a subtype of
     integer {0..130, 132..136, 138, 140..148, 150, 152..156, 158..162,
              164..166, 168..172, 174..178, ...} was expected,
     provided integer {16383}.
@@ -48,7 +48,7 @@
   File constraint-mul-05.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error: a subtype of
+  ASL Type error (TE_UT): a subtype of
     integer {0..256, 258..262, 264..268, 270, 272..276, 278..280, 282,
              284..292, 294..306, 308..310, ...} was expected,
     provided integer {65535}.
@@ -64,8 +64,8 @@
   File constraint-mul-06.asl, line 6, characters 4 to 22:
       let n = a DIVRM b;     // 10 DIVRM 3 == 3
       ^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
 
   $ aslref constraint-mul-07.asl
@@ -78,8 +78,8 @@
   File constraint-mul-07.asl, line 6, characters 4 to 22:
       let n = a DIVRM b;     // 10 DIVRM 3 == 3
       ^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
 
   $ aslref constraint-mul-08.asl
@@ -92,8 +92,8 @@
   File constraint-mul-08.asl, line 6, characters 4 to 22:
       let n = a DIVRM b;     // 10 DIVRM 3 == 3
       ^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
 
   $ aslref constraint-mul-09.asl
@@ -106,8 +106,8 @@
   File constraint-mul-09.asl, line 6, characters 4 to 22:
       let n = a DIVRM b;     // 10 DIVRM 3 == 3
       ^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
 
   $ aslref constraint-mul-10.asl
@@ -120,8 +120,8 @@
   File constraint-mul-10.asl, line 6, characters 4 to 22:
       let n = a DIVRM b;     // 10 DIVRM 3 == 3
       ^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
 
 Other operations
@@ -135,8 +135,8 @@ Other operations
   File constraint-div.asl, line 7, characters 2 to 18:
     var z = a DIV b;
     ^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref constraint-divrm.asl
   File constraint-divrm.asl, line 7, characters 10 to 19:
@@ -148,8 +148,8 @@ Other operations
   File constraint-divrm.asl, line 7, characters 2 to 20:
     var z = a DIVRM b;
     ^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref constraint-minus.asl
   $ aslref constraint-mod.asl
@@ -160,8 +160,8 @@ Other operations
   File constraint-mod.asl, line 7, characters 2 to 18:
     var z = a MOD b;
     ^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref constraint-mod-half.asl
   $ aslref constraint-plus.asl
@@ -175,8 +175,8 @@ Other operations
   File constraint-pow.asl, line 7, characters 2 to 16:
     var z = a ^ b;
     ^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref constraint-shl.asl
   File constraint-shl.asl, line 7, characters 10 to 16:
@@ -188,8 +188,8 @@ Other operations
   File constraint-shl.asl, line 7, characters 2 to 17:
     var z = a << b;
     ^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref constraint-shr.asl
   File constraint-shr.asl, line 7, characters 10 to 16:
@@ -201,8 +201,8 @@ Other operations
   File constraint-shr.asl, line 7, characters 2 to 17:
     var z = a >> b;
     ^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref global-constraint-div.asl
   File global-constraint-div.asl, line 8, characters 8 to 15:
@@ -214,8 +214,8 @@ Other operations
   File global-constraint-div.asl, line 8, characters 0 to 16:
   var z = a DIV b;
   ^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref global-constraint-divrm.asl
   File global-constraint-divrm.asl, line 8, characters 8 to 17:
@@ -227,8 +227,8 @@ Other operations
   File global-constraint-divrm.asl, line 8, characters 0 to 18:
   var z = a DIVRM b;
   ^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref global-constraint-minus.asl
   $ aslref global-constraint-mod.asl
@@ -239,8 +239,8 @@ Other operations
   File global-constraint-mod.asl, line 8, characters 0 to 16:
   var z = a MOD b;
   ^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref global-constraint-plus.asl
   $ aslref global-constraint-pow.asl
@@ -253,8 +253,8 @@ Other operations
   File global-constraint-pow.asl, line 8, characters 0 to 14:
   var z = a ^ b;
   ^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref global-constraint-shl.asl
   File global-constraint-shl.asl, line 8, characters 8 to 14:
@@ -266,8 +266,8 @@ Other operations
   File global-constraint-shl.asl, line 8, characters 0 to 15:
   var z = a << b;
   ^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref global-constraint-shr.asl
   File global-constraint-shr.asl, line 8, characters 8 to 14:
@@ -279,8 +279,8 @@ Other operations
   File global-constraint-shr.asl, line 8, characters 0 to 15:
   var z = a >> b;
   ^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref global-constraint-mul.asl
   File global-constraint-mul.asl, line 7, characters 8 to 13:
@@ -292,8 +292,8 @@ Other operations
   File global-constraint-mul.asl, line 7, characters 0 to 14:
   var z = a * b;
   ^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
 
 With pending constraints
@@ -305,8 +305,8 @@ With pending constraints
   File pending.asl, line 6, characters 2 to 28:
     var z : integer{} = a * b;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref global-pending.asl
   File global-pending.asl, line 7, characters 19 to 24:
@@ -318,6 +318,6 @@ With pending constraints
   File global-pending.asl, line 7, characters 0 to 25:
   var z: integer{} = a * b;
   ^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]

--- a/asllib/tests/control-flow.t/run.t
+++ b/asllib/tests/control-flow.t/run.t
@@ -1,6 +1,6 @@
   $ aslref no-return.asl
-  ASL Type error: not all control flow paths of the function "main" are
-    guaranteed to either return, raise an exception, or invoke unreachable.
+  ASL Type error (TE_BSPD): not all control flow paths of the function "main"
+    are guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
 
   $ aslref with-return.asl
@@ -11,7 +11,7 @@
   File inherited-always-throw.asl, line 10, characters 2 to 27:
     let x = always_throws ();
     ^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error:
+  ASL Type error (TE_BSPD):
     not all control flow paths of the function "inherited_always_throws" are
     guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
@@ -20,8 +20,8 @@
   File if-return.asl, line 3, characters 2 to 31:
     if n >= 0 then return 1; end;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: not all control flow paths of the function "sign" are
-    guaranteed to either return, raise an exception, or invoke unreachable.
+  ASL Type error (TE_BSPD): not all control flow paths of the function "sign"
+    are guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
 
   $ aslref if-return-return.asl
@@ -33,8 +33,8 @@
     if n <= 0 then return -1;
     else if n >= 0 then return 1; end;
     end;
-  ASL Type error: not all control flow paths of the function "sign" are
-    guaranteed to either return, raise an exception, or invoke unreachable.
+  ASL Type error (TE_BSPD): not all control flow paths of the function "sign"
+    are guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
 
   $ aslref try-00.asl
@@ -43,8 +43,8 @@
   File try-01.asl, line 5, character 2 to line 6, character 40:
     try return 0;
     catch when E => print "caught E"; end;
-  ASL Type error: not all control flow paths of the function "test0" are
-    guaranteed to either return, raise an exception, or invoke unreachable.
+  ASL Type error (TE_BSPD): not all control flow paths of the function "test0"
+    are guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
 
   $ aslref try-02.asl
@@ -58,8 +58,8 @@
       when E => return 1;
       otherwise => println "Otherwise";
     end;
-  ASL Type error: not all control flow paths of the function "test0" are
-    guaranteed to either return, raise an exception, or invoke unreachable.
+  ASL Type error (TE_BSPD): not all control flow paths of the function "test0"
+    are guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
 
   $ aslref try-05.asl
@@ -70,8 +70,8 @@
       when F => println "Caught F";
       otherwise => throw E {-};
     end;
-  ASL Type error: not all control flow paths of the function "test0" are
-    guaranteed to either return, raise an exception, or invoke unreachable.
+  ASL Type error (TE_BSPD): not all control flow paths of the function "test0"
+    are guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
 
   $ aslref try-06.asl
@@ -81,8 +81,8 @@
       when E => return 1;
       otherwise => throw E {-};
     end;
-  ASL Type error: not all control flow paths of the function "test0" are
-    guaranteed to either return, raise an exception, or invoke unreachable.
+  ASL Type error (TE_BSPD): not all control flow paths of the function "test0"
+    are guaranteed to either return, raise an exception, or invoke unreachable.
   [1]
 
   $ aslref --no-exec while-noreturn.asl
@@ -90,8 +90,8 @@
     while b looplimit 10 do
       throw myexception{-};
     end;
-  ASL Type error: the function "Foo" is qualified with noreturn but may return
-    on some control flow path.
+  ASL Type error (TE_BSPD): the function "Foo" is qualified with noreturn but
+    may return on some control flow path.
   [1]
 
   $ aslref --no-exec for-noreturn.asl
@@ -99,8 +99,8 @@
     for i = 1 to 0 do
       throw myexception{-};
     end;
-  ASL Type error: the function "Foo" is qualified with noreturn but may return
-    on some control flow path.
+  ASL Type error (TE_BSPD): the function "Foo" is qualified with noreturn but
+    may return on some control flow path.
   [1]
 
   $ aslref --no-exec repeat-noreturn.asl

--- a/asllib/tests/division.t/run.t
+++ b/asllib/tests/division.t/run.t
@@ -9,8 +9,8 @@ Division by zero:
   File static-div-zero.asl, line 3, characters 19 to 26:
     let x: integer = 6 DIV 0;
                      ^^^^^^^
-  ASL Type error: Illegal application of operator DIV on types integer {6}
-    and integer {0}.
+  ASL Type error (TE_BO): Illegal application of operator DIV on types
+    integer {6} and integer {0}.
   [1]
 
   $ aslref static-divrm-zero.asl
@@ -19,8 +19,8 @@ Division by zero:
   File static-divrm-zero.asl, line 3, characters 19 to 28:
     let x: integer = 6 DIVRM 0;
                      ^^^^^^^^^
-  ASL Type error: Illegal application of operator DIVRM on types integer {6}
-    and integer {0}.
+  ASL Type error (TE_BO): Illegal application of operator DIVRM on types
+    integer {6} and integer {0}.
   [1]
 
   $ aslref static-mod-zero.asl
@@ -29,8 +29,8 @@ Division by zero:
   File static-mod-zero.asl, line 3, characters 19 to 26:
     let x: integer = 6 MOD 0;
                      ^^^^^^^
-  ASL Type error: Illegal application of operator MOD on types integer {6}
-    and integer {0}.
+  ASL Type error (TE_BO): Illegal application of operator MOD on types
+    integer {6} and integer {0}.
   [1]
 
 Unsupported divisions (caught at type-checking time):
@@ -41,8 +41,8 @@ Unsupported divisions (caught at type-checking time):
   File static-div-neg.asl, line 3, characters 19 to 27:
     let x: integer = 6 DIV -3;
                      ^^^^^^^^
-  ASL Type error: Illegal application of operator DIV on types integer {6}
-    and integer {(- 3)}.
+  ASL Type error (TE_BO): Illegal application of operator DIV on types
+    integer {6} and integer {(- 3)}.
   [1]
 
   $ aslref static-divrm-neg.asl
@@ -51,8 +51,8 @@ Unsupported divisions (caught at type-checking time):
   File static-divrm-neg.asl, line 3, characters 19 to 29:
     let x: integer = 6 DIVRM -3;
                      ^^^^^^^^^^
-  ASL Type error: Illegal application of operator DIVRM on types integer {6}
-    and integer {(- 3)}.
+  ASL Type error (TE_BO): Illegal application of operator DIVRM on types
+    integer {6} and integer {(- 3)}.
   [1]
 
   $ aslref static-mod-neg.asl
@@ -61,8 +61,8 @@ Unsupported divisions (caught at type-checking time):
   File static-mod-neg.asl, line 3, characters 19 to 27:
     let x: integer = 6 MOD -3;
                      ^^^^^^^^
-  ASL Type error: Illegal application of operator MOD on types integer {6}
-    and integer {(- 3)}.
+  ASL Type error (TE_BO): Illegal application of operator MOD on types
+    integer {6} and integer {(- 3)}.
   [1]
 
   $ aslref --no-exec static-div-undiv.asl
@@ -71,8 +71,8 @@ Unsupported divisions (caught at type-checking time):
   File static-div-undiv.asl, line 3, characters 19 to 26:
     let x: integer = 5 DIV 3;
                      ^^^^^^^
-  ASL Type error: Illegal application of operator DIV on types integer {5}
-    and integer {3}.
+  ASL Type error (TE_BO): Illegal application of operator DIV on types
+    integer {5} and integer {3}.
   [1]
   $ aslref --no-exec static-div-undiv-bis.asl
   File static-div-undiv-bis.asl, line 3, characters 11 to 18: Division will
@@ -80,8 +80,8 @@ Unsupported divisions (caught at type-checking time):
   File static-div-undiv-bis.asl, line 3, characters 11 to 18:
     let x = (1 DIV 2) as integer {3, 4};
              ^^^^^^^
-  ASL Type error: Illegal application of operator DIV on types integer {1}
-    and integer {2}.
+  ASL Type error (TE_BO): Illegal application of operator DIV on types
+    integer {1} and integer {2}.
   [1]
   $ aslref static-div-undiv-bis.asl
   File static-div-undiv-bis.asl, line 3, characters 11 to 18: Division will
@@ -89,8 +89,8 @@ Unsupported divisions (caught at type-checking time):
   File static-div-undiv-bis.asl, line 3, characters 11 to 18:
     let x = (1 DIV 2) as integer {3, 4};
              ^^^^^^^
-  ASL Type error: Illegal application of operator DIV on types integer {1}
-    and integer {2}.
+  ASL Type error (TE_BO): Illegal application of operator DIV on types
+    integer {1} and integer {2}.
   [1]
   $ aslref --no-exec static-div-undiv-ter.asl
 
@@ -101,36 +101,44 @@ Unsupported divisions (caught at type-checking time):
 For completeness, those operations are dynamic errors:
 
   $ aslref dynamic-div-neg.asl
-  ASL Dynamic error: Illegal application of operator DIV for values 6 and -3.
+  ASL Dynamic error (DE_BO): Illegal application of operator DIV for values 6
+    and -3.
   [1]
 
   $ aslref dynamic-divrm-neg.asl
-  ASL Dynamic error: Illegal application of operator DIVRM for values 6 and -3.
+  ASL Dynamic error (DE_BO): Illegal application of operator DIVRM for values 6
+    and -3.
   [1]
 
   $ aslref dynamic-mod-neg.asl
-  ASL Dynamic error: Illegal application of operator MOD for values 6 and -3.
+  ASL Dynamic error (DE_BO): Illegal application of operator MOD for values 6
+    and -3.
   [1]
 
   $ aslref dynamic-div-zero.asl
-  ASL Dynamic error: Illegal application of operator DIV for values 6 and 0.
+  ASL Dynamic error (DE_BO): Illegal application of operator DIV for values 6
+    and 0.
   [1]
 
   $ aslref dynamic-divrm-zero.asl
-  ASL Dynamic error: Illegal application of operator DIVRM for values 6 and 0.
+  ASL Dynamic error (DE_BO): Illegal application of operator DIVRM for values 6
+    and 0.
   [1]
 
   $ aslref dynamic-mod-zero.asl
-  ASL Dynamic error: Illegal application of operator MOD for values 6 and 0.
+  ASL Dynamic error (DE_BO): Illegal application of operator MOD for values 6
+    and 0.
   [1]
 
   $ aslref dynamic-div-undiv.asl
-  ASL Dynamic error: Illegal application of operator DIV for values 5 and 3.
+  ASL Dynamic error (DE_BO): Illegal application of operator DIV for values 5
+    and 3.
   [1]
 
 Parametric examples:
   $ aslref param-div-2.asl
-  ASL Dynamic error: Illegal application of operator DIV for values 3 and 2.
+  ASL Dynamic error (DE_BO): Illegal application of operator DIV for values 3
+    and 2.
   [1]
 
 More complicated examples
@@ -138,7 +146,8 @@ More complicated examples
 
 Fails because N typing cannot infer that N + 1 is strictly positive.
   $ aslref div-by-param.asl
-  ASL Dynamic error: Illegal application of operator DIV for values 5 and 2.
+  ASL Dynamic error (DE_BO): Illegal application of operator DIV for values 5
+    and 2.
   [1]
 
 Examples with multiple constraints in slices:
@@ -157,7 +166,8 @@ Example with constant:
   File div-constants.asl, line 3, characters 22 to 29:
   constant z: integer = x DIV y;
                         ^^^^^^^
-  ASL Static error: Illegal application of operator DIV for values 1 and 2.
+  ASL Static error (TE_BO): Illegal application of operator DIV for values 1
+    and 2.
   [1]
 
 Other example from typing.t:
@@ -165,7 +175,7 @@ Other example from typing.t:
   File TNegative9-1.asl, line 3, characters 4 to 59:
       let testB : bits(N) = Zeros{N DIV 4} :: Zeros{N DIV 2}; // bits(3N/4) != bits(N)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(N) was expected,
+  ASL Type error (TE_UT): a subtype of bits(N) was expected,
     provided bits(((3 * N) DIV 4)).
   [1]
   $ aslref --no-exec TPositive9.asl
@@ -175,8 +185,8 @@ Other polynomial equations:
   File rat-poly-00.asl, line 15, characters 9 to 19:
     assert c == '000';
            ^^^^^^^^^^
-  ASL Type error: Illegal application of operator == on types bits((7 DIV 2))
-    and bits(3).
+  ASL Type error (TE_BO): Illegal application of operator == on types
+    bits((7 DIV 2)) and bits(3).
   [1]
 
   $ aslref rat-poly-01.asl
@@ -185,8 +195,8 @@ Other polynomial equations:
 
 Division as POW:
   $ aslref zero-pow-neg.asl
-  ASL Dynamic error: Illegal application of operator ^ for values (0.0 / 1.0)
-    and -1.
+  ASL Dynamic error (DE_BO): Illegal application of operator ^ for values
+    (0.0 / 1.0) and -1.
   [1]
 
   $ aslref zero-pow-zero.asl

--- a/asllib/tests/explicit-parameters.t/run.t
+++ b/asllib/tests/explicit-parameters.t/run.t
@@ -7,7 +7,7 @@ Explicit parameter tests:
   begin
     return Zeros{A * B + C};
   end;
-  ASL Type error: incorrect parameter declaration for "Bad", expected
+  ASL Type error (TE_BSPD): incorrect parameter declaration for "Bad", expected
     {A, B, C, D, E} but {D, E, A, B, C} provided
   [1]
 
@@ -17,8 +17,8 @@ Explicit parameter tests:
   begin
     return 0;
   end;
-  ASL Type error: incorrect parameter declaration for "BadUnused", expected 
-    {} but {N} provided
+  ASL Type error (TE_BSPD): incorrect parameter declaration for "BadUnused",
+    expected {} but {N} provided
   [1]
 
   $ aslref undeclared-parameter.asl
@@ -27,8 +27,8 @@ Explicit parameter tests:
   begin
     return Zeros{N};
   end;
-  ASL Type error: incorrect parameter declaration for "BadUndeclared", expected
-    {N} but {} provided
+  ASL Type error (TE_BSPD): incorrect parameter declaration for
+    "BadUndeclared", expected {N} but {} provided
   [1]
 
   $ aslref duplicate-parameter.asl
@@ -37,7 +37,7 @@ Explicit parameter tests:
   begin
     return Zeros{N};
   end;
-  ASL Type error: cannot declare already declared element "N".
+  ASL Type error (TE_IAD): cannot declare already declared element "N".
   [1]
 
   $ aslref --version-eac1 argument-omission.asl
@@ -45,7 +45,7 @@ Explicit parameter tests:
   File argument-omission.asl, line 3, characters 21 to 28:
     let x : bits(64) = Zeros{};
                        ^^^^^^^
-  ASL Grammar error: Obsolete syntax:
+  ASL Grammar error (BE_PE): Obsolete syntax:
     Deprecated elided parameter call syntax, pass parameters explicitly.
   [1]
 
@@ -53,7 +53,7 @@ Explicit parameter tests:
   File omit-output-stdlib-param.asl, line 3, characters 21 to 41:
     let x : bits(64) = Extend('1111', TRUE);
                        ^^^^^^^^^^^^^^^^^^^^
-  ASL Static error: Arity error while calling 'Extend':
+  ASL Static error (TE_BC): Arity error while calling 'Extend':
     2 parameters expected and 1 provided
   [1]
 
@@ -63,5 +63,5 @@ Explicit parameter tests:
   begin
     return N + 1;
   end;
-  ASL Type error: cannot declare already declared element "N".
+  ASL Type error (TE_IAD): cannot declare already declared element "N".
   [1]

--- a/asllib/tests/intersecting_slices.t
+++ b/asllib/tests/intersecting_slices.t
@@ -28,7 +28,7 @@ Two intersecting slices...
   File intersecting_slices2.asl, line 5, characters 3 to 9:
     x[i, j] = '10';
      ^^^^^^
-  ASL Static error: overlapping slices i+:1, j+:1.
+  ASL Static error (TE_BS): overlapping slices i+:1, j+:1.
   [1]
 
 Two maybe intersecting slices...
@@ -45,7 +45,7 @@ Two maybe intersecting slices...
   > EOF
 
   $ aslref intersecting_slices3.asl
-  ASL Dynamic error: overlapping slices i+:1, j+:1.
+  ASL Dynamic error (DE_OSA): overlapping slices i+:1, j+:1.
   [1]
 
   $ cat>intersecting_slices3b.asl <<EOF
@@ -64,7 +64,7 @@ Two maybe intersecting slices...
   > EOF
 
   $ aslref intersecting_slices3b.asl
-  ASL Dynamic error: overlapping slices x+:1, y+:1.
+  ASL Dynamic error (DE_OSA): overlapping slices x+:1, y+:1.
   0x7
   [1]
 
@@ -84,5 +84,5 @@ Two intersecting bitfields
   File intersecting_slices4.asl, line 5, characters 2 to 12:
     x.[f1, f2] = '10';
     ^^^^^^^^^^
-  ASL Static error: overlapping slices 0+:1, 0+:1.
+  ASL Static error (TE_BS): overlapping slices 0+:1, 0+:1.
   [1]

--- a/asllib/tests/lca.t
+++ b/asllib/tests/lca.t
@@ -12,7 +12,8 @@
   File lca1.asl, line 6, characters 2 to 18:
     let c: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of real was expected, provided integer {2, 3}.
+  ASL Type error (TE_UT): a subtype of real was expected,
+    provided integer {2, 3}.
   [1]
 
   $ cat >lca2.asl <<EOF
@@ -28,7 +29,8 @@
   File lca2.asl, line 5, characters 2 to 28:
     let b: integer {2, 3} = x;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {2, 3} was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of integer {2, 3} was expected,
+    provided integer.
   [1]
 
   $ cat >lca3.asl <<EOF
@@ -44,7 +46,7 @@
   File lca3.asl, line 5, characters 2 to 25:
     let b: integer {N} = x;
     ^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {N} was expected,
     provided integer {3, N}.
   [1]
 
@@ -60,7 +62,8 @@
   File lca4.asl, line 4, characters 2 to 18:
     let a: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of real was expected, provided integer {0..N, 3}.
+  ASL Type error (TE_UT): a subtype of real was expected,
+    provided integer {0..N, 3}.
   [1]
 
   $ cat >lca5.asl <<EOF
@@ -93,7 +96,7 @@
   File lca6.asl, line 7, characters 2 to 18:
     let a: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of real was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of real was expected, provided integer.
   [1]
 
   $ cat >lca7.asl <<EOF
@@ -109,7 +112,8 @@
   File lca7.asl, line 5, characters 50 to 57:
     let x = if ARBITRARY: boolean then 3 as T1 else 2 as T2;
                                                     ^^^^^^^
-  ASL Type error: cannot perform Asserted Type Conversion on integer {2} by T2.
+  ASL Type error (TE_TAF): cannot perform Asserted Type Conversion on
+    integer {2} by T2.
   [1]
 
   $ cat >lca8.asl <<EOF
@@ -125,7 +129,7 @@
   File lca8.asl, line 5, characters 2 to 18:
     let a: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of real was expected, provided bits(3).
+  ASL Type error (TE_UT): a subtype of real was expected, provided bits(3).
   [1]
 
   $ cat >lca9.asl <<EOF
@@ -142,7 +146,7 @@
   File lca9.asl, line 6, characters 2 to 18:
     let b: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of real was expected, provided T1.
+  ASL Type error (TE_UT): a subtype of real was expected, provided T1.
   [1]
 
   $ cat >lca10.asl <<EOF
@@ -160,7 +164,7 @@
   File lca10.asl, line 7, characters 2 to 18:
     let b: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of real was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of real was expected, provided integer.
   [1]
 
   $ cat >lca11.asl <<EOF
@@ -212,5 +216,6 @@
   File lca14.asl, line 7, characters 2 to 18:
     let c: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of real was expected, provided array [[4]] of T1.
+  ASL Type error (TE_UT): a subtype of real was expected,
+    provided array [[4]] of T1.
   [1]

--- a/asllib/tests/lexer-v0.t
+++ b/asllib/tests/lexer-v0.t
@@ -12,14 +12,14 @@
   File comments1.asl, line 6, characters 11 to 12:
     var a = b;
              ^
-  ASL Static error: Undefined identifier: 'b'
+  ASL Static error (TE_UI): Undefined identifier: 'b'
   [1]
 
   $ aslref --v0-use-chunks -0 comments1.asl
   File comments1.asl, line 6, characters 11 to 12:
     var a = b;
              ^
-  ASL Static error: Undefined identifier: 'b'
+  ASL Static error (TE_UI): Undefined identifier: 'b'
   [1]
 
   $ cat >comments2.asl <<EOF
@@ -37,14 +37,14 @@
   File comments2.asl, line 7, characters 11 to 12:
     var a = b;
              ^
-  ASL Static error: Undefined identifier: 'b'
+  ASL Static error (TE_UI): Undefined identifier: 'b'
   [1]
 
   $ aslref --v0-use-chunks -0 comments2.asl
   File comments2.asl, line 7, characters 11 to 12:
    = 1;
              ^
-  ASL Static error: Undefined identifier: 'b'
+  ASL Static error (TE_UI): Undefined identifier: 'b'
   [1]
 
   $ cat >comments3.asl <<EOF
@@ -65,7 +65,7 @@
   File comments3.asl, line 9, characters 22 to 23:
   constant integer a = b;
                         ^
-  ASL Static error: Undefined identifier: 'b'
+  ASL Static error (TE_UI): Undefined identifier: 'b'
   [1]
 
 

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -37,7 +37,7 @@
   File println5.asl, line 1, characters 32 to 33:
   constant msg = "Something with \p bad characters.";
                                   ^
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]
   $ cat >println6.asl <<EOF
   > constant msg = "Some unterminated string;
@@ -47,7 +47,7 @@
   File println6.asl, line 3, character 0:
   
   
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]
 
 C-Style comments
@@ -83,7 +83,7 @@ C-Style comments
   File comments2.asl, line 11, characters 8 to 9:
   let a = b;
           ^
-  ASL Static error: Undefined identifier: 'b'
+  ASL Static error (TE_UI): Undefined identifier: 'b'
   [1]
 
 Some problems with bitvectors and bitmasks:
@@ -122,7 +122,7 @@ Check that variables starting with `__` are reserved:
   > EOF
 
   $ aslref reserved0.asl
-  ASL Lexical error: "__reserved" is a reserved keyword.
+  ASL Lexical error (BE_RI): "__reserved" is a reserved keyword.
   [1]
 
 Forbidden patterns
@@ -133,7 +133,7 @@ Forbidden patterns
   File forbiddenhex01.asl, line 1, characters 8 to 11:
   let x = 0xh12;
           ^^^
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]
 
   $ cat >forbiddenhex02.asl <<EOF
@@ -143,7 +143,7 @@ Forbidden patterns
   File forbiddenhex02.asl, line 1, characters 8 to 11:
   let x = 0x_12;
           ^^^
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]
 
   $ cat >forbiddenhex03.asl <<EOF
@@ -153,7 +153,7 @@ Forbidden patterns
   File forbiddenhex03.asl, line 1, characters 8 to 13:
   let x = 0x12h12;
           ^^^^^
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]
 
   $ cat >forbiddenhex04.asl <<EOF
@@ -164,7 +164,7 @@ Forbidden patterns
   File forbiddenhex04.asl, line 2, characters 8 to 11:
   let x = 0x_foo;
           ^^^
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]
 
   $ cat >forbiddenreal01.asl <<EOF
@@ -174,7 +174,7 @@ Forbidden patterns
   File forbiddenreal01.asl, line 1, characters 8 to 11:
   let x = 1.h12;
           ^^^
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]
 
   $ cat >forbiddenreal02.asl <<EOF
@@ -184,7 +184,7 @@ Forbidden patterns
   File forbiddenreal02.asl, line 1, characters 8 to 11:
   let x = 1._12;
           ^^^
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]
 
   $ cat >forbiddenreal03.asl <<EOF
@@ -194,7 +194,7 @@ Forbidden patterns
   File forbiddenreal03.asl, line 1, characters 8 to 13:
   let x = 1.12h12;
           ^^^^^
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]
 
   $ cat >forbiddenreal04.asl <<EOF
@@ -205,5 +205,5 @@ Forbidden patterns
   File forbiddenreal04.asl, line 2, characters 8 to 11:
   let x = 1._foo;
           ^^^
-  ASL Lexical error: Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol.
   [1]

--- a/asllib/tests/loop-limits.t/run.t
+++ b/asllib/tests/loop-limits.t/run.t
@@ -16,7 +16,7 @@ While loops:
       i = i + 1;
       println i;
     end;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
 
   $ aslref while-exact.asl
@@ -26,7 +26,7 @@ While loops:
     while (i < 10) looplimit 9 do
       i = i + 1;
     end;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
 
   $ aslref while-no-limit.asl
@@ -51,7 +51,7 @@ Repeat loops:
       i = i + 1;
       println i;
     until (i >= 10) looplimit 5;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
 
   $ aslref repeat-exact.asl
@@ -61,7 +61,7 @@ Repeat loops:
     repeat
       i = i + 1;
     until (i >= 10) looplimit 9;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
 
   $ aslref repeat-no-limit.asl
@@ -80,7 +80,7 @@ Double loops
       while (j < 10) looplimit 5 do
         j = j + 1;
       end;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
 
   $ aslref double-while-incorrect-correct.asl
@@ -93,7 +93,7 @@ Double loops
         j = j + 1;
       end;
     end;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
 
   $ aslref double-while-incorrect-incorrect.asl
@@ -102,7 +102,7 @@ Double loops
       while (j < 10) looplimit 5 do
         j = j + 1;
       end;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
 
 For loops
@@ -112,7 +112,7 @@ For loops
     for i = 1 to n looplimit 10 do
       counter = counter + 1;
     end;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]
   $ aslref for-exact.asl
   $ aslref for-exact-minus-one.asl
@@ -153,7 +153,7 @@ Recursion limits:
   File recursion-incorrect.asl, line 6, characters 18 to 31:
     else return 1 + recurse (n+1); end;
                     ^^^^^^^^^^^^^
-  ASL Dynamic error: recursion limit reached.
+  ASL Dynamic error (DE_LE): recursion limit reached.
   [1]
 
   $ aslref recursion-exact.asl
@@ -164,7 +164,7 @@ Recursion limits:
   File recursion-exact-minus-one.asl, line 5, characters 18 to 31:
     else return 1 + recurse (n+1); end;
                     ^^^^^^^^^^^^^
-  ASL Dynamic error: recursion limit reached.
+  ASL Dynamic error (DE_LE): recursion limit reached.
   [1]
 
   $ aslref for-loop-zero.asl
@@ -172,5 +172,5 @@ Recursion limits:
     for index = 0 to 0 looplimit 0 do
         println "BODY";
     end;
-  ASL Dynamic error: loop limit reached.
+  ASL Dynamic error (DE_LE): loop limit reached.
   [1]

--- a/asllib/tests/overriding.t/run.t
+++ b/asllib/tests/overriding.t/run.t
@@ -27,7 +27,7 @@ Implementation without impdef
   begin
     return Zeros{N};
   end;
-  ASL Type error: no `impdef` for `implementation` function.
+  ASL Type error (TE_OE): no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-warn-all-impdefs-overridden implementation-only.asl
   File implementation-only.asl, line 1, character 0 to line 4, character 4:
@@ -35,7 +35,7 @@ Implementation without impdef
   begin
     return Zeros{N};
   end;
-  ASL Type error: no `impdef` for `implementation` function.
+  ASL Type error (TE_OE): no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-warn-implementations implementation-only.asl
   File implementation-only.asl, line 1, character 0 to line 4, character 4:
@@ -52,7 +52,8 @@ Clashing implementations
   begin
     return Zeros{N};
   end;
-  ASL Type error: multiple overlapping `implementation` functions for Foo:
+  ASL Type error (TE_OE): multiple overlapping `implementation` functions for
+    Foo:
     File clashing-implementations.asl, line 1, character 0 to line 4,
       character 4
     File clashing-implementations.asl, line 6, character 0 to line 9,
@@ -64,7 +65,8 @@ Clashing implementations
   begin
     return Zeros{N};
   end;
-  ASL Type error: multiple overlapping `implementation` functions for Foo:
+  ASL Type error (TE_OE): multiple overlapping `implementation` functions for
+    Foo:
     File clashing-implementations.asl, line 1, character 0 to line 4,
       character 4
     File clashing-implementations.asl, line 6, character 0 to line 9,
@@ -76,7 +78,8 @@ Clashing implementations
   begin
     return Zeros{N};
   end;
-  ASL Type error: multiple overlapping `implementation` functions for Foo:
+  ASL Type error (TE_OE): multiple overlapping `implementation` functions for
+    Foo:
     File clashing-implementations.asl, line 1, character 0 to line 4,
       character 4
     File clashing-implementations.asl, line 6, character 0 to line 9,
@@ -90,7 +93,7 @@ Clashing impdefs
   begin
     return Zeros{N};
   end;
-  ASL Type error: multiple `impdef` candidates for `implementation`:
+  ASL Type error (TE_OE): multiple `impdef` candidates for `implementation`:
     File clashing-impdefs.asl, line 1, character 0 to line 4, character 4
     File clashing-impdefs.asl, line 6, character 0 to line 9, character 4
   [1]
@@ -101,7 +104,7 @@ Clashing impdefs
   begin
     return Zeros{N};
   end;
-  ASL Type error: cannot declare already declared element "Foo".
+  ASL Type error (TE_IAD): cannot declare already declared element "Foo".
   [1]
 
 Bad implementations
@@ -111,7 +114,7 @@ Bad implementations
   begin
     return Ones{N};
   end;
-  ASL Type error: no `impdef` for `implementation` function.
+  ASL Type error (TE_OE): no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-permissive bad-implementation-param.asl
   File bad-implementation-param.asl, line 6, character 0 to line 9, character 4:
@@ -119,7 +122,7 @@ Bad implementations
   begin
     return Ones{N};
   end;
-  ASL Type error: no `impdef` for `implementation` function.
+  ASL Type error (TE_OE): no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-permissive bad-implementation-arg.asl
   File bad-implementation-arg.asl, line 6, character 0 to line 9, character 4:
@@ -127,7 +130,7 @@ Bad implementations
   begin
     return Ones{N};
   end;
-  ASL Type error: no `impdef` for `implementation` function.
+  ASL Type error (TE_OE): no `impdef` for `implementation` function.
   [1]
   $ aslref --no-exec --overriding-permissive bad-implementation-return.asl
   File bad-implementation-return.asl, line 6, character 0 to line 9,
@@ -136,7 +139,7 @@ Bad implementations
   begin
     return Ones{N};
   end;
-  ASL Type error: no `impdef` for `implementation` function.
+  ASL Type error (TE_OE): no `impdef` for `implementation` function.
   [1]
 
 Interactions with other features
@@ -146,5 +149,6 @@ Interactions with other features
   File type-check-impdef.asl, line 3, characters 2 to 20:
     return Zeros{N+1};
     ^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(N) was expected, provided bits((N + 1)).
+  ASL Type error (TE_UT): a subtype of bits(N) was expected,
+    provided bits((N + 1)).
   [1]

--- a/asllib/tests/pragma.t/run.t
+++ b/asllib/tests/pragma.t/run.t
@@ -33,8 +33,8 @@ Simple pragma examples
   File pragma_invalid.asl, line 1, characters 10 to 18:
   pragma p1 2 + TRUE;
             ^^^^^^^^
-  ASL Type error: Illegal application of operator + on types integer {2}
-    and boolean.
+  ASL Type error (TE_BO): Illegal application of operator + on types
+    integer {2} and boolean.
   [1]
 
   $ aslref pragma_invalid_stmt.asl
@@ -45,6 +45,6 @@ Simple pragma examples
   File pragma_invalid_stmt.asl, line 3, characters 21 to 26:
       pragma fail "test" + 1;
                        ^^^^^
-  ASL Type error: Illegal application of operator + on types string
+  ASL Type error (TE_BO): Illegal application of operator + on types string
     and integer {1}.
   [1]

--- a/asllib/tests/print.t
+++ b/asllib/tests/print.t
@@ -23,8 +23,8 @@
   File printer2.asl, line 2, characters 16 to 24:
     print ("Wow", 2 + 3.14, "some other string");
                   ^^^^^^^^
-  ASL Type error: Illegal application of operator + on types integer {2}
-    and real.
+  ASL Type error (TE_BO): Illegal application of operator + on types
+    integer {2} and real.
   [1]
 
   $ cat >printer3.asl <<EOF
@@ -69,6 +69,7 @@
   File print4.asl, line 2, characters 10 to 16:
     println (1, 2);
             ^^^^^^
-  ASL Type error: expected singular type, found (integer {1}, integer {2}).
+  ASL Type error (TE_UT): expected singular type, found
+    (integer {1}, integer {2}).
   [1]
 

--- a/asllib/tests/recursive.t/run.t
+++ b/asllib/tests/recursive.t/run.t
@@ -29,42 +29,42 @@
   File recursive-constant.asl, line 1, characters 13 to 14:
   constant x = x + 3;
                ^
-  ASL Static error: Undefined identifier: 'x'
+  ASL Static error (TE_UI): Undefined identifier: 'x'
   [1]
 
   $ aslref double-recursive-constant.asl
   File double-recursive-constant.asl, line 2, characters 0 to 19:
   constant y = x + 2;
   ^^^^^^^^^^^^^^^^^^^
-  ASL Type error: multiple recursive declarations: "y", "x".
+  ASL Type error (TE_BD): multiple recursive declarations: "y", "x".
   [1]
 
   $ aslref recursive-type.asl
   File recursive-type.asl, line 1, characters 13 to 34:
   type tree of (tree, integer, tree);
                ^^^^^^^^^^^^^^^^^^^^^
-  ASL Static error: Undefined identifier: 'tree'
+  ASL Static error (TE_UI): Undefined identifier: 'tree'
   [1]
 
   $ aslref double-recursive-types.asl
   File double-recursive-types.asl, line 2, characters 0 to 29:
   type node of (integer, tree);
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: multiple recursive declarations: "node", "tree".
+  ASL Type error (TE_BD): multiple recursive declarations: "node", "tree".
   [1]
 
   $ aslref fn-val-recursive.asl
   File fn-val-recursive.asl, line 1, characters 0 to 17:
   var x = f (4, 5);
   ^^^^^^^^^^^^^^^^^
-  ASL Type error: multiple recursive declarations: "f", "x".
+  ASL Type error (TE_BD): multiple recursive declarations: "f", "x".
   [1]
 
   $ aslref type-val-recursive.asl
   File type-val-recursive.asl, line 3, characters 0 to 24:
   type MyT of integer {x};
   ^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: multiple recursive declarations: "MyT", "x".
+  ASL Type error (TE_BD): multiple recursive declarations: "MyT", "x".
   [1]
 
   $ aslref enum-fn-recursive.asl
@@ -91,5 +91,5 @@
   File procedure-hits-limit.asl, line 6, characters 2 to 13:
     foo(x - 1);
     ^^^^^^^^^^^
-  ASL Dynamic error: recursion limit reached.
+  ASL Dynamic error (DE_LE): recursion limit reached.
   [1]

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -11,7 +11,8 @@ Type-checking errors:
   File anonymous-types-example.asl, line 21, characters 2 to 6:
     pair = (1, dataT2);
     ^^^^
-  ASL Type error: a subtype of pairT was expected, provided (integer {1}, T2).
+  ASL Type error (TE_UT): a subtype of pairT was expected,
+    provided (integer {1}, T2).
   [1]
 
   $ aslref duplicate_function_args.asl
@@ -20,7 +21,7 @@ Type-checking errors:
   begin
     pass;
   end;
-  ASL Type error: cannot declare already declared element "i".
+  ASL Type error (TE_IAD): cannot declare already declared element "i".
   [1]
 
   $ aslref duplicate_record_fields.asl
@@ -30,14 +31,14 @@ Type-checking errors:
     j: boolean,
     i: integer
   };
-  ASL Type error: cannot declare already declared element "i".
+  ASL Type error (TE_IAD): cannot declare already declared element "i".
   [1]
 
   $ aslref duplicate_enumeration_items.asl
   File duplicate_enumeration_items.asl, line 1, characters 10 to 33:
   type t of enumeration { i, j, i };
             ^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "i".
+  ASL Type error (TE_IAD): cannot declare already declared element "i".
   [1]
 
   $ aslref constant-zeros.asl
@@ -49,14 +50,14 @@ Bad types:
     [23: 0] a,
     [10: 0, 3+: 2] b,
   };
-  ASL Static error: overlapping slices 0+:11, 3+:2.
+  ASL Static error (TE_BS): overlapping slices 0+:11, 3+:2.
   [1]
 
   $ aslref bad-inclusion-in-symbolic-type.asl
   File bad-inclusion-in-symbolic-type.asl, line 2, characters 0 to 26:
   var ah: integer{2..A} = 1;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {2..A} was expected,
+  ASL Type error (TE_UT): a subtype of integer {2..A} was expected,
     provided integer {1}.
   [1]
 
@@ -78,7 +79,7 @@ Global ignored:
   File shadow-banning-bug.asl, line 5, characters 4 to 16:
       var g = 0.0;
       ^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "g".
+  ASL Type error (TE_IAD): cannot declare already declared element "g".
   [1]
 
   $ aslref shadow-banning-bug-2.asl
@@ -86,7 +87,7 @@ Global ignored:
     for i = 0 to 1 do
      pass;
     end;
-  ASL Type error: cannot declare already declared element "i".
+  ASL Type error (TE_IAD): cannot declare already declared element "i".
   [1]
 
 Constrained-type satisfaction:
@@ -103,7 +104,7 @@ Constrained-type satisfaction:
   File type-sat1.asl, line 5, characters 2 to 3:
     x = y; // illegal as domain of x is not a subset of domain of y
     ^
-  ASL Type error: a subtype of integer {8, 16} was expected,
+  ASL Type error (TE_UT): a subtype of integer {8, 16} was expected,
     provided integer {8, 16, 32}.
   [1]
 
@@ -120,21 +121,23 @@ Constrained-type satisfaction:
   File type-sat2.asl, line 5, characters 2 to 3:
     x = y; // illegal
     ^
-  ASL Type error: a subtype of integer {8, 16} was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of integer {8, 16} was expected,
+    provided integer.
   [1]
 
   $ aslref type_satisfaction_illegal_f3.asl
   File type_satisfaction_illegal_f3.asl, line 9, characters 4 to 17:
       invoke_me(x); // illegal as domains doesn't match
       ^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {8, 16} was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of integer {8, 16} was expected,
+    provided integer.
   [1]
 
   $ aslref type_satisfaction_illegal_f4.asl
   File type_satisfaction_illegal_f4.asl, line 9, characters 4 to 17:
       invoke_me(x);
       ^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {8, 16} was expected,
+  ASL Type error (TE_UT): a subtype of integer {8, 16} was expected,
     provided integer {8..64}.
   [1]
 
@@ -151,7 +154,7 @@ Constrained-type satisfaction:
   File type-sat3.asl, line 4, characters 2 to 29:
     var x: integer { 2, 4} = N;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {2, 4} was expected,
+  ASL Type error (TE_UT): a subtype of integer {2, 4} was expected,
     provided integer {N}.
   [1]
 
@@ -168,7 +171,7 @@ Constrained-type satisfaction:
   File type-sat4.asl, line 4, characters 2 to 29:
     var x: integer { 2, 4} = N;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {2, 4} was expected,
+  ASL Type error (TE_UT): a subtype of integer {2, 4} was expected,
     provided integer {N}.
   [1]
 
@@ -215,20 +218,21 @@ Parameterized integers:
   File bad-underconstrained-call.asl, line 9, characters 9 to 26:
     return GetBitAt{M}(x, M);
            ^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..(M - 1)} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..(M - 1)} was expected,
     provided integer {M}.
   [1]
   $ aslref bad-underconstrained-call-02.asl
   File bad-underconstrained-call-02.asl, line 8, characters 2 to 15:
     foo{M}(x, 3);
     ^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {M} was expected, provided integer {3}.
+  ASL Type error (TE_UT): a subtype of integer {M} was expected,
+    provided integer {3}.
   [1]
   $ aslref bad-underconstrained-call-03.asl
   File bad-underconstrained-call-03.asl, line 8, characters 2 to 19:
     foo{M}(x, M + 1);
     ^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {M} was expected,
+  ASL Type error (TE_UT): a subtype of integer {M} was expected,
     provided integer {(M + 1)}.
   [1]
   $ aslref bad-underconstrained-ctc.asl
@@ -242,14 +246,14 @@ Parameterized integers:
   File bad-underconstrained-return.asl, line 3, characters 2 to 15:
     return N + 1;
     ^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
     provided integer {(N + 1)}.
   [1]
   $ aslref bad-underconstrained-return-02.asl
   File bad-underconstrained-return-02.asl, line 3, characters 2 to 11:
     return 5;
     ^^^^^^^^^
-  ASL Type error: a subtype of integer {0..N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
     provided integer {5}.
   [1]
 
@@ -272,14 +276,15 @@ Parameterized integers:
   File unreachable.asl, line 3, characters 2 to 14:
     unreachable;
     ^^^^^^^^^^^^
-  ASL Dynamic error: unreachable reached.
+  ASL Dynamic error (DE_UNR): unreachable reached.
   [1]
 
   $ aslref assign-to-global-immutable.asl
   File assign-to-global-immutable.asl, line 5, characters 2 to 21:
     my_immutable_global = 4;
     ^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot assign to immutable storage "my_immutable_global".
+  ASL Type error (TE_AIM): cannot assign to immutable storage
+    "my_immutable_global".
   [1]
 
   $ aslref equality.asl
@@ -287,7 +292,7 @@ Parameterized integers:
   File bad-equality.asl, line 3, characters 10 to 25:
     println (1, 2) == (1,2);
             ^^^^^^^^^^^^^^^
-  ASL Type error: Illegal application of operator == on types
+  ASL Type error (TE_BO): Illegal application of operator == on types
     (integer {1}, integer {2}) and (integer {1}, integer {2}).
   [1]
 
@@ -317,7 +322,7 @@ Parameterized integers:
   File duplicate_expr_record.asl, line 5, characters 12 to 27:
       var x = A{h = 5, h = 9};
               ^^^^^^^^^^^^^^^
-  ASL Type error: cannot declare already declared element "h".
+  ASL Type error (TE_IAD): cannot declare already declared element "h".
   [1]
 
   $ aslref same-precedence.asl
@@ -340,7 +345,8 @@ Parameterized integers:
   File rdiv_checks.asl, line 3, characters 12 to 25:
       var x = 5.3 / "hello";
               ^^^^^^^^^^^^^
-  ASL Type error: Illegal application of operator / on types real and string.
+  ASL Type error (TE_BO): Illegal application of operator / on types real
+    and string.
   [1]
 
   $ aslref record-getfields.asl
@@ -349,7 +355,7 @@ Parameterized integers:
   File integer-accessed-bitvector.asl, line 4, characters 2 to 3:
     x[0] = '1';
     ^
-  ASL Type error: a subtype of bits(-) was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of bits(-) was expected, provided integer.
   [1]
 
   $ aslref slice-width-shorthand.asl
@@ -365,45 +371,45 @@ Parameters bugs:
   File bug1.asl, line 5, characters 21 to 29:
     let foo: bits(x) = Zeros{y};
                        ^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref bug2.asl
   File bug2.asl, line 5, characters 10 to 17:
     let t = y[x: 0];
             ^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref bug3.asl
   File bug3.asl, line 4, characters 10 to 18:
     let t = Zeros{x};
             ^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref bug4.asl
   File bug4.asl, line 5, characters 11 to 31:
     let pb = Zeros{a} OR Zeros{b};
              ^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: Illegal application of operator OR on types bits(3)
+  ASL Type error (TE_BO): Illegal application of operator OR on types bits(3)
     and bits(4).
   [1]
   $ aslref arg-as-param-call.asl
   File arg-as-param-call.asl, line 8, characters 4 to 21:
       test{10}('1111');
       ^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(10) was expected, provided bits(4).
+  ASL Type error (TE_UT): a subtype of bits(10) was expected, provided bits(4).
   [1]
   $ aslref typed-param-call.asl
   File typed-param-call.asl, line 8, characters 4 to 18:
       test{2}('11');
       ^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {5..10} was expected,
+  ASL Type error (TE_UT): a subtype of integer {5..10} was expected,
     provided integer {2}.
   [1]
   $ aslref typed-arg-as-param-call.asl
   File typed-arg-as-param-call.asl, line 8, characters 4 to 18:
       test{2}('11');
       ^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {5..10} was expected,
+  ASL Type error (TE_UT): a subtype of integer {5..10} was expected,
     provided integer {2}.
   [1]
   $ aslref --no-exec defining_param.asl
@@ -442,7 +448,7 @@ Required tests:
   File exceptions.asl, line 73, characters 32 to 37:
           when COUNTING => assert FALSE;
                                   ^^^^^
-  ASL Dynamic error: Assertion failed: FALSE.
+  ASL Dynamic error (DE_DAF): Assertion failed: FALSE.
   [1]
   $ aslref func1.asl
   $ aslref func2.asl
@@ -466,7 +472,7 @@ Required tests:
   File records-2.bad.asl, line 36, characters 9 to 34:
     assert equal_a_record_ty (a, aa);
            ^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: No subprogram declaration matches the invocation:
+  ASL Type error (TE_BC): No subprogram declaration matches the invocation:
     equal_a_record_ty(a_record_ty, aa_record_ty).
   [1]
   $ aslref records.asl
@@ -477,27 +483,31 @@ Required tests:
     characters 2 to 45:
     var animalLegs: AnimalLegs = centipedeLegs;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of AnimalLegs was expected, provided InsectLegs.
+  ASL Type error (TE_UT): a subtype of AnimalLegs was expected,
+    provided InsectLegs.
   [1]
   $ aslref --no-exec subtype-satisfaction-shape-to-animal.bad.asl
   File subtype-satisfaction-shape-to-animal.bad.asl, line 9, characters 2 to 42:
     var dogLegs: AnimalLegs = myCircleSides;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of AnimalLegs was expected, provided ShapeSides.
+  ASL Type error (TE_UT): a subtype of AnimalLegs was expected,
+    provided ShapeSides.
   [1]
   $ aslref --no-exec subtype-satisfaction-word-count-to-packet-length.bad.asl
   File subtype-satisfaction-word-count-to-packet-length.bad.asl, line 9,
     characters 2 to 16:
     myPacketLength = myWordCount;
     ^^^^^^^^^^^^^^
-  ASL Type error: a subtype of PacketLength was expected, provided WordCount.
+  ASL Type error (TE_UT): a subtype of PacketLength was expected,
+    provided WordCount.
   [1]
   $ aslref --no-exec subtype-satisfaction-packet-length-to-word-count.bad.asl
   File subtype-satisfaction-packet-length-to-word-count.bad.asl, line 9,
     characters 2 to 13:
     myWordCount = myPacketLength;
     ^^^^^^^^^^^
-  ASL Type error: a subtype of WordCount was expected, provided PacketLength.
+  ASL Type error (TE_UT): a subtype of WordCount was expected,
+    provided PacketLength.
   [1]
   $ aslref tuples.asl
   $ aslref tuple-return.asl
@@ -514,7 +524,7 @@ Required tests:
   begin
     pass;
   end;
-  ASL Type error: cannot declare already declared element "f1".
+  ASL Type error (TE_IAD): cannot declare already declared element "f1".
   [1]
   $ aslref string_concat.asl
   $ aslref approx-expr-binop.asl
@@ -525,25 +535,25 @@ Required tests:
   File no-tabs.asl, line 3, characters 2 to 3:
     	// <-- this is a tab character
     ^
-  ASL Lexical error: Unknown symbol (ASCII code point(s): 9).
+  ASL Lexical error (BE_LE): Unknown symbol (ASCII code point(s): 9).
   [1]
   $ aslref no-tabs-in-line-comments.asl
   File no-tabs-in-line-comments.asl, line 3, characters 4 to 5:
     //	<-- this is a tab character
       ^
-  ASL Lexical error: Unknown symbol (ASCII code point(s): 9).
+  ASL Lexical error (BE_LE): Unknown symbol (ASCII code point(s): 9).
   [1]
   $ aslref no-tabs-in-block-comments.asl
   File no-tabs-in-block-comments.asl, line 3, characters 4 to 5:
     /*	<-- this is a tab character*/
       ^
-  ASL Lexical error: Unknown symbol (ASCII code point(s): 9).
+  ASL Lexical error (BE_LE): Unknown symbol (ASCII code point(s): 9).
   [1]
   $ aslref no-tabs-in-strings.asl
   File no-tabs-in-strings.asl, line 3, characters 11 to 12:
     let x = "	"; // this string contains a tab character
              ^
-  ASL Lexical error: Unknown symbol (ASCII code point(s): 9).
+  ASL Lexical error (BE_LE): Unknown symbol (ASCII code point(s): 9).
   [1]
   $ aslref accessor-overloading-2.asl
   nullary setter
@@ -569,7 +579,7 @@ Required tests:
   File undeclared-variable.asl, line 3, characters 2 to 5:
     bar = (32 - 46) * 0;
     ^^^
-  ASL Static error: Undefined identifier: 'bar'
+  ASL Static error (TE_UI): Undefined identifier: 'bar'
   [1]
 
   $ aslref --gnu-errors gnu-errors.asl
@@ -582,13 +592,13 @@ Required tests:
   [1]
 
   $ aslref no-main.asl
-  ASL Dynamic error: no entrypoint supplied. Have you defined `func main() =>
-    integer`, or did you mean to pass `--no-exec`?
+  ASL Dynamic error (DE_NEP): no entrypoint supplied. Have you defined `func
+    main() => integer`, or did you mean to pass `--no-exec`?
   [1]
 
   $ aslref main-wrong-type.asl
-  ASL Dynamic error: no entrypoint supplied. Have you defined `func main() =>
-    integer`, or did you mean to pass `--no-exec`?
+  ASL Dynamic error (DE_NEP): no entrypoint supplied. Have you defined `func
+    main() => integer`, or did you mean to pass `--no-exec`?
   [1]
 
   $ aslref overloaded-main.asl
@@ -598,7 +608,7 @@ Required tests:
   File asl0-error-handling-time.asl, line 2, characters 8 to 9:
     if reg[1] == '1' then 62 else 63 +: 1 field,
           ^
-  ASL Static error: Undefined identifier: 'reg'
+  ASL Static error (TE_UI): Undefined identifier: 'reg'
   [1]
 
 Base values
@@ -606,16 +616,16 @@ Base values
   File base_values.asl, line 5, characters 2 to 28:
     var x: integer {N..M, 42};
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: base value of type integer {42, N..M} cannot be symbolically
-    reduced since it consists of N.
+  ASL Type error (TE_NBV): base value of type integer {42, N..M} cannot be
+    symbolically reduced since it consists of N.
   [1]
 
   $ aslref base_values_empty.asl
   File base_values_empty.asl, line 3, characters 2 to 24:
     var x: integer {N..M};
     ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: base value of type integer {N..M} cannot be symbolically
-    reduced since it consists of N.
+  ASL Type error (TE_NBV): base value of type integer {N..M} cannot be
+    symbolically reduced since it consists of N.
   [1]
 
   $ aslref base_values_tuple.asl
@@ -626,13 +636,13 @@ Getters/setters
   File nonempty-getter-called-without-slices.asl, line 14, characters 10 to 12:
     let x = f1;
             ^^
-  ASL Static error: Undefined identifier: 'f1'
+  ASL Static error (TE_UI): Undefined identifier: 'f1'
   [1]
   $ aslref nonempty-setter-called-without-slices.asl
   File nonempty-setter-called-without-slices.asl, line 14, characters 2 to 4:
     f1 = 4;
     ^^
-  ASL Static error: Undefined identifier: 'f1'
+  ASL Static error (TE_UI): Undefined identifier: 'f1'
   [1]
   $ aslref setter_subfield.asl
   $ aslref setter_subslice.asl
@@ -645,7 +655,8 @@ Getters/setters
   File bad-pattern.asl, line 4, characters 7 to 12:
     when '101' => println ("Cannot happen");
          ^^^^^
-  ASL Type error: Erroneous pattern '101' for expression of type integer {3}.
+  ASL Type error (TE_BO): Erroneous pattern '101' for expression of type
+    integer {3}.
   [1]
   $ aslref pattern-masks-no-braces.asl
   File pattern-masks-no-braces.asl, line 4, characters 19 to 24:
@@ -666,7 +677,7 @@ Inherit integer constraints on left-hand sides
   File inherit-integer-constraints-bad-basic.asl, line 4, characters 2 to 11:
     return x;
     ^^^^^^^^^
-  ASL Type error: a subtype of integer {43} was expected,
+  ASL Type error (TE_UT): a subtype of integer {43} was expected,
     provided integer {42}.
   [1]
 
@@ -674,8 +685,8 @@ Inherit integer constraints on left-hand sides
   File inherit-integer-constraints-bad-tuple.asl, line 4, characters 2 to 28:
     return (y.item0, y.item2);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of (integer {42}, integer {0}) was expected,
-    provided (integer {42}, integer {43}).
+  ASL Type error (TE_UT): a subtype of (integer {42}, integer {0})
+    was expected, provided (integer {42}, integer {43}).
   [1]
 
   $ aslref inherit-integer-constraints-bad-type.asl
@@ -685,7 +696,7 @@ Inherit integer constraints on left-hand sides
       a : integer{},
       c : integer
   };
-  ASL Type error: a pending constrained integer is illegal here.
+  ASL Type error (TE_UT): a pending constrained integer is illegal here.
   [1]
 
 Left-hand sides
@@ -763,7 +774,7 @@ If test environment reversion bug
   File SliceFromZero.asl, line 4, characters 11 to 13:
     assert x[:3] == '100';
              ^^
-  ASL Grammar error: Obsolete syntax:
+  ASL Grammar error (BE_PE): Obsolete syntax:
     Deprecated slice syntax, use "0 +: 3" instead.
   [1]
   $ aslref --version-eac1 SliceStar.asl
@@ -771,7 +782,7 @@ If test environment reversion bug
   File SliceStar.asl, line 4, characters 11 to 15:
     assert x[3*:2] == '11';
              ^^^^
-  ASL Grammar error: Obsolete syntax:
+  ASL Grammar error (BE_PE): Obsolete syntax:
     Deprecated slice syntax, use "3*2 +: 2" instead.
   [1]
 
@@ -780,30 +791,32 @@ Static errors:
   File static-unreachable.asl, line 3, characters 2 to 14:
     unreachable;
     ^^^^^^^^^^^^
-  ASL Static error: unreachable reached.
+  ASL Static error (TE_SEF): unreachable reached.
   [1]
   $ aslref --no-exec static-assertion.asl
   File static-assertion.asl, line 3, characters 9 to 14:
     assert FALSE;
            ^^^^^
-  ASL Static error: Assertion failed: FALSE.
+  ASL Static error (TE_SEF): Assertion failed: FALSE.
   [1]
   $ aslref --no-exec static-looplimit.asl
   File static-looplimit.asl, line 3, character 2 to line 5, character 6:
     for i = 0 to 0 looplimit 0 do
       pass;
     end;
-  ASL Static error: loop limit reached.
+  ASL Static error (TE_SEF): loop limit reached.
   [1]
   $ aslref --no-exec static-negative-array-length.asl
   File static-negative-array-length.asl, line 3, characters 19 to 21:
     var arr : array[[-1]] of integer;
                      ^^
-  ASL Static error: array length expression -1 has negative length: -1.
+  ASL Static error (TE_SEF): array length expression -1 has negative length:
+    -1.
   [1]
   $ aslref --no-exec static-bad-primitive.asl
   File static-bad-primitive.asl, line 7, characters 13 to 33:
   constant y = 2 as integer{foo(2)};
                ^^^^^^^^^^^^^^^^^^^^
-  ASL Static error: FloorLog2 (primitive) expected an argument greater than 0
+  ASL Static error (TE_SEF):
+    FloorLog2 (primitive) expected an argument greater than 0
   [1]

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -84,25 +84,25 @@
   File constant-func-read.asl, line 5, character 2 to line 6, character 19:
     let y = X;
     return x * x + y;
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref constant-func-write.asl
   File constant-func-write.asl, line 5, character 2 to line 6, character 19:
     X = 3;
     return x * x + 3;
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref constant-func-unknown.asl
   File constant-func-unknown.asl, line 3, character 2 to line 4, character 23:
     let y = ARBITRARY: integer {0..3};
     return x * x + 3 + y;
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref constant-func-throw.asl
   File constant-func-throw.asl, line 5, characters 2 to 14:
     throw E {-};
     ^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref constant-func-throw-caught.asl
   File constant-func-throw-caught.asl, line 5, character 2 to line 9,
@@ -112,7 +112,7 @@
     catch
       when E => return 19;
     end;
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref constant-func-local-var.asl
   $ aslref constant-func-local-type-global-let.asl
@@ -123,7 +123,7 @@
     assert k == x;
   
     return 2 * k;
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref constant-func-local-type-local-let.asl
   $ aslref constant-func-sig-let.asl
@@ -132,7 +132,7 @@
   begin
     return x;
   end;
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
 
   $ aslref for-var-no-edit.asl
@@ -161,25 +161,25 @@
     let x = X;
     X = x + 1;
     return x;
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref for-write-throw.asl
   File for-write-throw.asl, line 5, characters 2 to 14:
     throw E {-};
     ^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref for-throw-throw.asl
   File for-throw-throw.asl, line 5, characters 2 to 14:
     throw E {-};
     ^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref for-throw.asl
   File for-throw.asl, line 5, characters 2 to 14:
     throw E {-};
     ^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref for-unknown.asl
 
@@ -187,19 +187,19 @@
   File config-uses-var.asl, line 2, characters 0 to 26:
   config Y: integer = X + 3;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref config-uses-config.asl
   File config-uses-config.asl, line 2, characters 0 to 22:
   config Y: integer = X;
   ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref config-uses-let.asl
   File config-uses-let.asl, line 2, characters 0 to 22:
   config Y: integer = X;
   ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref config-uses-constant.asl
   $ aslref config-uses-local-var.asl
@@ -209,19 +209,19 @@
   File config-uses-var-through-func.asl, line 5, characters 2 to 11:
     return X;
     ^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref config-uses-config-through-func.asl
   File config-uses-config-through-func.asl, line 5, characters 2 to 11:
     return X;
     ^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref config-uses-let-through-func.asl
   File config-uses-let-through-func.asl, line 5, characters 2 to 11:
     return X;
     ^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref config-uses-constant-through-func.asl
   $ aslref config-uses-atc.asl
@@ -235,7 +235,7 @@
   File config-uses-unknown.asl, line 3, characters 2 to 36:
     return ARBITRARY: integer {0..10};
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
 
   $ aslref assert-read.asl
@@ -244,13 +244,13 @@
     let x = X;
     X = x + 1;
     return x;
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref assert-throw.asl
   File assert-throw.asl, line 5, characters 2 to 14:
     throw E {-};
     ^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref assert-atc.asl
   File assert-atc.asl, line 3, characters 9 to 10:
@@ -267,27 +267,29 @@
   File type-read-local.asl, line 5, characters 18 to 19:
     let y: integer {x} = x;
                     ^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
   $ aslref type-read-local-let.asl
   $ aslref type-read.asl
   File type-read.asl, line 3, characters 19 to 20:
   type T of integer {X};
                      ^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
   $ aslref type-write.asl
   File type-write.asl, line 5, character 2 to line 7, character 11:
     let x = X;
     X = x + 1;
     return x;
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref type-unknown.asl
   File type-unknown.asl, line 3, characters 2 to 35:
     return ARBITRARY: integer {0, 1};
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
   $ aslref type-func-atc.asl
   File type-func-atc.asl, line 3, characters 9 to 10:
@@ -301,13 +303,14 @@
   File type-local-var.asl, line 5, characters 15 to 16:
     var y: bits (x);
                  ^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
   $ aslref type-throw.asl
   File type-throw.asl, line 5, characters 2 to 14:
     throw E {-};
     ^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
 
   $ aslref assert-atc.asl
@@ -322,14 +325,14 @@
   File assert-throw.asl, line 5, characters 2 to 14:
     throw E {-};
     ^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref assert-write.asl
   File assert-write.asl, line 5, character 2 to line 7, character 11:
     let x = X;
     X = x + 1;
     return x;
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref assert-unknown.asl
 
@@ -337,7 +340,7 @@
   File rec-assert-throw.asl, line 15, characters 9 to 37:
     assert throwing (n - 1, FALSE) == 3;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref rec-binop-atc-throw.asl
   File rec-binop-atc-throw.asl, line 3, character 0 to line 10, character 4:
@@ -496,13 +499,13 @@
   File constant-rec.asl, line 12, characters 10 to 17:
     let r = foo (1);
             ^^^^^^^
-  ASL Static error: recursion limit reached.
+  ASL Static error (TE_SEF): recursion limit reached.
   [1]
   $ aslref rec-local-type.asl
   File rec-local-type.asl, line 12, characters 10 to 24:
     let r = Zeros{foo (0)};
             ^^^^^^^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref rec-binop-rec.asl
   File rec-binop-rec.asl, line 6, character 0 to line 11, character 4:
@@ -546,7 +549,7 @@
   File config-type-uses-let.asl, line 2, characters 0 to 36:
   config Y : integer {0 .. 2 * X} = 0;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
 
   $ aslref -0 func-decl-0.asl use-func-decl.asl --no-exec
@@ -554,18 +557,18 @@
   File bad-use-func-decl-01.asl, line 3, characters 2 to 14:
     return h(x);
     ^^^^^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]
   $ aslref -0 func-decl-0.asl bad-use-func-decl-02.asl --no-exec
   File bad-use-func-decl-02.asl, line 3, characters 2 to 14:
     return g(x);
     ^^^^^^^^^^^^
-  ASL Type error: expected a pure expression/subprogram.
+  ASL Type error (TE_SEV): expected a pure expression/subprogram.
   [1]
 
   $ aslref print-non-readonly.asl
   File print-non-readonly.asl, line 3, characters 2 to 10:
     print 1;
     ^^^^^^^^
-  ASL Type error: expected a readonly expression/subprogram.
+  ASL Type error (TE_SEV): expected a readonly expression/subprogram.
   [1]

--- a/asllib/tests/stdlib.t/run.t
+++ b/asllib/tests/stdlib.t/run.t
@@ -47,11 +47,12 @@ Tests using ASLRef OCaml primitives for some stdlib functions
 Checking that --no-primitives option actually removes OCaml primitives
 (different errors are produced)
   $ aslref no-primitives-test.asl
-  ASL Dynamic error: FloorLog2 (primitive) expected an argument greater than 0
+  ASL Dynamic error (DE_DAF):
+    FloorLog2 (primitive) expected an argument greater than 0
   [1]
   $ aslref --no-primitives no-primitives-test.asl
   File ASL Standard Library, line 80, characters 11 to 16:
-  ASL Dynamic error: Assertion failed: (__stdlib_local_a > 0).
+  ASL Dynamic error (DE_DAF): Assertion failed: (__stdlib_local_a > 0).
   [1]
 
 Tests using ASL stdlib only

--- a/asllib/tests/typing.t/run.t
+++ b/asllib/tests/typing.t/run.t
@@ -18,21 +18,21 @@ H Examples
   File HExample16.asl, line 10, characters 19 to 36:
     let x: bits(a) = Reverse{a}(bv, b);
                      ^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {1..a} was expected,
+  ASL Type error (TE_UT): a subtype of integer {1..a} was expected,
     provided integer {8, 16, 32, 64}.
   [1]
   $ aslref --no-exec HExample17.asl
   File HExample17.asl, line 11, characters 19 to 36:
     let x: bits(a) = Reverse{a}(bv, b);
                      ^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {1..a} was expected,
+  ASL Type error (TE_UT): a subtype of integer {1..a} was expected,
     provided integer {32}.
   [1]
   $ aslref --no-exec HExample18.asl
   File HExample18.asl, line 12, characters 20 to 39:
     let x: bits(a2) = Reverse{a2}(bv, a2);
                       ^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {1..a2} was expected,
+  ASL Type error (TE_UT): a subtype of integer {1..a2} was expected,
     provided integer {8, 16, 32, 64}.
   [1]
 
@@ -45,21 +45,21 @@ Assignments of constrained integers
   File TNegative2-0.asl, line 4, characters 4 to 41:
       let testA : integer {0..2}    = size;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..2} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..2} was expected,
     provided integer {0..3}.
   [1]
   $ aslref --no-exec TNegative2-1.asl
   File TNegative2-1.asl, line 4, characters 4 to 42:
       let testB : integer {8,16,32} = size2;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {8, 16, 32} was expected,
+  ASL Type error (TE_UT): a subtype of integer {8, 16, 32} was expected,
     provided integer {8, 16, 32, 64}.
   [1]
   $ aslref --no-exec TNegative2-2.asl
   File TNegative2-2.asl, line 4, characters 4 to 42:
       let testC : integer {8,16,32} = myInt; // assignment of unconstrained integers to constrained integers is also illegal without a ATC
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {8, 16, 32} was expected,
+  ASL Type error (TE_UT): a subtype of integer {8, 16, 32} was expected,
     provided integer.
   [1]
 
@@ -75,48 +75,52 @@ Use of global vars in constraints
   File TPositive4-1.asl, line 5, characters 4 to 54:
       let testB : integer {LET_ALLOWED_NUMS_B}     = 16;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {8} was expected, provided integer {16}.
+  ASL Type error (TE_UT): a subtype of integer {8} was expected,
+    provided integer {16}.
   [1]
   $ aslref --no-exec TPositive4-2.asl
   File TPositive4-2.asl, line 8, characters 4 to 54:
       let testC : integer {LET_ALLOWED_NUMS_C}     = 16;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {LET_ALLOWED_NUMS_C} was expected,
-    provided integer {16}.
+  ASL Type error (TE_UT): a subtype of integer {LET_ALLOWED_NUMS_C}
+    was expected, provided integer {16}.
   [1]
   $ aslref --no-exec TPositive4-3.asl
   $ aslref --no-exec TPositive4-4.asl
   File TPositive4-4.asl, line 9, characters 4 to 54:
       let testF : integer {CONFIG_ALLOWED_NUMS}    = 16;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {CONFIG_ALLOWED_NUMS} was expected,
-    provided integer {16}.
+  ASL Type error (TE_UT): a subtype of integer {CONFIG_ALLOWED_NUMS}
+    was expected, provided integer {16}.
   [1]
   $ aslref --no-exec TPositive4-5.asl
   $ aslref --no-exec TReconsider4-0.asl
   File TReconsider4-0.asl, line 13, characters 4 to 54:
       let testA : integer {CONST_ALLOWED_NUMS}     = 16;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {8} was expected, provided integer {16}.
+  ASL Type error (TE_UT): a subtype of integer {8} was expected,
+    provided integer {16}.
   [1]
   $ aslref --no-exec TReconsider4-1.asl
   File TReconsider4-1.asl, line 14, characters 4 to 54:
       let testB : integer {0..CONST_ALLOWED_NUMS}  = 10;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..8} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..8} was expected,
     provided integer {10}.
   [1]
   $ aslref --no-exec TNegative4.asl
   File TNegative4.asl, line 5, characters 25 to 41:
       let testA : integer {VAR_ALLOWED_NUMS} = 8; // illegal var's aren't allowed in constraints
                            ^^^^^^^^^^^^^^^^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
   $ aslref --no-exec TNegative4-bis.asl
   File TNegative4-bis.asl, line 5, characters 25 to 41:
       let testA : integer {VAR_ALLOWED_NUMS} = 8; // illegal var's aren't allowed in constraints
                            ^^^^^^^^^^^^^^^^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
 
 Asserted type conversions
@@ -125,15 +129,15 @@ Asserted type conversions
   File TNegative5-0.asl, line 5, characters 4 to 38:
       let testA : integer {0..3} = temp; // illegal as value of type integer {8,16} can't be assigned to var of type integer {0..3}.
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..3} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..3} was expected,
     provided integer {8, 16}.
   [1]
   $ aslref --no-exec TNegative5-1.asl
   File TNegative5-1.asl, line 4, characters 26 to 41:
       let testB : integer = TRUE as integer;
                             ^^^^^^^^^^^^^^^
-  ASL Type error: cannot perform Asserted Type Conversion on boolean by
-    integer.
+  ASL Type error (TE_TAF): cannot perform Asserted Type Conversion on boolean
+    by integer.
   [1]
 
 Comparisons
@@ -146,7 +150,8 @@ Named types
   File TNegative7.asl, line 7, characters 4 to 36:
       let testA : MyOtherSizes = size; // illegal as testA and size are different named types, even though they are the same structure and domain
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of MyOtherSizes was expected, provided MyBitsSizes.
+  ASL Type error (TE_UT): a subtype of MyOtherSizes was expected,
+    provided MyBitsSizes.
   [1]
   $ aslref --no-exec KPositive01.asl
 
@@ -156,32 +161,36 @@ Loops
   File TPositive8-1.asl, line 5, characters 8 to 40:
           let testK : integer {8..31} = i;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {8..31} was expected,
+  ASL Type error (TE_UT): a subtype of integer {8..31} was expected,
     provided integer {100..110}.
   [1]
   $ aslref --no-exec TNegative8-0.asl
   File TNegative8-0.asl, line 5, characters 8 to 40:
           let testA : integer {0..7}  = i; // N is an unconstrained integer, so i is also unconstrained
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..7} was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of integer {0..7} was expected,
+    provided integer.
   [1]
   $ aslref --no-exec TNegative8-1.asl
   File TNegative8-1.asl, line 5, characters 8 to 40:
           let testB : integer {0..7}  = i; // N is an unconstrained integer, so i is also unconstrained
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..7} was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of integer {0..7} was expected,
+    provided integer.
   [1]
   $ aslref --no-exec TNegative8-2.asl
   File TNegative8-2.asl, line 5, characters 8 to 40:
           let testC : integer {7..31} = i; // N is an unconstrained integer, so i is also unconstrained
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {7..31} was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of integer {7..31} was expected,
+    provided integer.
   [1]
   $ aslref --no-exec TNegative8-3.asl
   File TNegative8-3.asl, line 5, characters 8 to 40:
           let testD : integer {7..31} = i; // N is an unconstrained integer, so i is also unconstrained
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {7..31} was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of integer {7..31} was expected,
+    provided integer.
   [1]
 
 Bit vector widths defined by constrained integers
@@ -191,32 +200,32 @@ Bit vector widths defined by constrained integers
   File TNegative9-0.asl, line 3, characters 4 to 36:
       let testA : bits(8) = Zeros{16};
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(8) was expected, provided bits(16).
+  ASL Type error (TE_UT): a subtype of bits(8) was expected, provided bits(16).
   [1]
   $ aslref --no-exec TNegative9-1.asl
   File TNegative9-1.asl, line 3, characters 4 to 59:
       let testB : bits(N) = Zeros{N DIV 4} :: Zeros{N DIV 2}; // bits(3N/4) != bits(N)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(N) was expected,
+  ASL Type error (TE_UT): a subtype of bits(N) was expected,
     provided bits(((3 * N) DIV 4)).
   [1]
   $ aslref --no-exec TNegative9-2.asl
   File TNegative9-2.asl, line 3, characters 4 to 35:
       let testC : bits(M) = Zeros{N};
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(M) was expected, provided bits(N).
+  ASL Type error (TE_UT): a subtype of bits(M) was expected, provided bits(N).
   [1]
   $ aslref --no-exec TNegative9-3.asl
   File TNegative9-3.asl, line 3, characters 26 to 34:
       let testD : bits(X) = Zeros{X}; // X isn't a constrained integer, so can't be used as bit width
                             ^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref --no-exec TNegative9-4.asl
   File TNegative9-4.asl, line 3, characters 4 to 35:
       let testE : bits(N) = Zeros{8}; // N != 8, even though 8 is in the constraint set for N. N could be 16 after all.
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(N) was expected, provided bits(8).
+  ASL Type error (TE_UT): a subtype of bits(N) was expected, provided bits(8).
   [1]
 
 Symbolic execution of bit vector widths expressions
@@ -227,20 +236,21 @@ Symbolic execution of bit vector widths expressions
   File TNegative10.asl, line 8, characters 32 to 38:
       let testA : bits(N) = Zeros{widthN};
                                   ^^^^^^
-  ASL Type error: expected a symbolically evaluable expression/subprogram.
+  ASL Type error (TE_SEV): expected a symbolically evaluable
+    expression/subprogram.
   [1]
   $ aslref --no-exec TNegative10-0.asl
   File TNegative10-0.asl, line 16, characters 4 to 53:
       let testB : bits(letWidthN1) = Zeros{letWidthN2}; // illegal as type bits(letWidthN1) is different from bits(letWidthN2).
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(letWidthN1) was expected,
+  ASL Type error (TE_UT): a subtype of bits(letWidthN1) was expected,
     provided bits(letWidthN2).
   [1]
   $ aslref --no-exec TNegative10-1.asl
   File TNegative10-1.asl, line 28, characters 4 to 49:
       let testC : bits(tempC3A)   = Zeros{tempC3B}; // illegal, type bits(tempC1) != bits(tempC3B)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(tempC3A) was expected,
+  ASL Type error (TE_UT): a subtype of bits(tempC3A) was expected,
     provided bits(tempC3B).
   [1]
 
@@ -249,7 +259,7 @@ Complex symbolic execution of bit vector widths expressions
   File TPositive11.asl, line 11, characters 4 to 64:
       let testA : bits(numBits)            = ZerosBytes{numBytes};
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(numBits) was expected,
+  ASL Type error (TE_UT): a subtype of bits(numBits) was expected,
     provided bits((8 * numBytes)).
   [1]
   $ aslref --no-exec TPositive11-0.asl
@@ -261,8 +271,8 @@ ATC's on bit vectors
   File TNegative12.asl, line 3, characters 16 to 32:
       let testA = N     as bits(8); // ATC's can't change structure.
                   ^^^^^^^^^^^^^^^^
-  ASL Type error: cannot perform Asserted Type Conversion on integer {8, 16} by
-    bits(8).
+  ASL Type error (TE_TAF): cannot perform Asserted Type Conversion on
+    integer {8, 16} by bits(8).
   [1]
 
 Large constraint sets
@@ -280,8 +290,8 @@ Large constraint sets
   File TPositive13.asl, line 8, characters 4 to 35:
       let testA =  UInt(a) * UInt(b);
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref --no-exec TDegraded13.asl
   File TDegraded13.asl, line 7, characters 29 to 46:
@@ -297,8 +307,8 @@ Large constraint sets
   File TDegraded13.asl, line 7, characters 4 to 47:
       let temp               = UInt(a) * UInt(b);
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref --no-exec TDegraded13-sets1.asl
   File TDegraded13-sets1.asl, line 3, characters 10 to 27:
@@ -314,8 +324,8 @@ Large constraint sets
   File TDegraded13-sets1.asl, line 3, characters 2 to 28:
     var z = UInt(a) * UInt(b);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
   $ aslref --no-exec TDegraded13-sets2.asl
   File TDegraded13-sets2.asl, line 3, characters 10 to 27:
@@ -331,8 +341,8 @@ Large constraint sets
   File TDegraded13-sets2.asl, line 3, characters 2 to 28:
     var z = UInt(a) * UInt(b);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: type used to define storage item is the result of precision
-    loss.
+  ASL Type error (TE_PLD): type used to define storage item is the result of
+    precision loss.
   [1]
 
 Named types for bit vector widths
@@ -341,13 +351,15 @@ Named types for bit vector widths
   File TNegative14-0.asl, line 6, characters 4 to 32:
       let tempA : NamedTypeB = w1;        // illegal, not the same type
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of NamedTypeB was expected, provided NamedTypeA.
+  ASL Type error (TE_UT): a subtype of NamedTypeB was expected,
+    provided NamedTypeA.
   [1]
   $ aslref --no-exec TNegative14-1.asl
   File TNegative14-1.asl, line 7, characters 4 to 39:
       let testB : bits(w1)   = Zeros{w2}; // illegal, just because w1 and w2 are the same type doesn't mean they are the same value, so
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of bits(w1) was expected, provided bits(w2).
+  ASL Type error (TE_UT): a subtype of bits(w1) was expected,
+    provided bits(w2).
   [1]
 
 Bit slice expressions
@@ -357,25 +369,25 @@ Bit slice expressions
   File TNegative15-0.asl, line 8, characters 20 to 37:
       let testA     = 0xA55A1234[x+7:x];
                       ^^^^^^^^^^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref --no-exec TNegative15-1.asl
   File TNegative15-1.asl, line 6, characters 20 to 38:
       let testB     = 0xA55A1234[0 +: x]; // illegal, bit width isn't a constrained integer
                       ^^^^^^^^^^^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref --no-exec TNegative15-2.asl
   File TNegative15-2.asl, line 6, characters 20 to 42:
       let testC     = 0xA55A1234[0 * x +: x]; // illegal, bit width isn't a constrained integer
                       ^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
   $ aslref --no-exec TNegative15-3.asl
   File TNegative15-3.asl, line 7, characters 24 to 32:
       testD[0 * x +: x] = Zeros{x}; // Same rules apply to bit slices on LHS
                           ^^^^^^^^
-  ASL Type error: constrained integer expected, provided integer.
+  ASL Type error (TE_UT): constrained integer expected, provided integer.
   [1]
 
 C Tests
@@ -384,14 +396,15 @@ C Tests
   File CPositive1-1.asl, line 5, characters 4 to 30:
       let z: integer {0..N} = y;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..N} was expected, provided integer.
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+    provided integer.
   [1]
   $ aslref --no-exec CPositive2.asl
   $ aslref --no-exec CPositive3.asl
   File CPositive3.asl, line 5, characters 4 to 31:
       var a : integer {0..N} = b;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
     provided integer {0}.
   [1]
   $ aslref --no-exec CPositive4.asl
@@ -401,7 +414,7 @@ C Tests
   File CPositive7.asl, line 4, characters 4 to 31:
       var a: integer{0..2*N} = x;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..(2 * N)} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..(2 * N)} was expected,
     provided integer {0..N}.
   [1]
   $ aslref --no-exec CPositive9.asl
@@ -413,14 +426,15 @@ C Tests
   File CNegative1.asl, line 5, characters 4 to 31:
       var a : integer {0..N} = b; // illegal
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
     provided integer {-1}.
   [1]
   $ aslref --no-exec CNegative2.asl
   File CNegative2.asl, line 4, characters 2 to 11:
     return 3; // illegal
     ^^^^^^^^^
-  ASL Type error: a subtype of integer {N} was expected, provided integer {3}.
+  ASL Type error (TE_UT): a subtype of integer {N} was expected,
+    provided integer {3}.
   [1]
   $ aslref --no-exec CNegative3.asl
   File CNegative3.asl, line 8, character 4 to line 13, character 8:
@@ -434,7 +448,7 @@ C Tests
   File CNegative3.asl, line 12, characters 8 to 9:
           z = z + 1; // should be illegal without ATC
           ^
-  ASL Type error: a subtype of integer {N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {N} was expected,
     provided integer {(N + 1)}.
   [1]
   $ aslref --no-exec CNegative4.asl
@@ -443,47 +457,49 @@ C Tests
           Ones{5} ::
           x
       );
-  ASL Type error: a subtype of bits(64) was expected, provided bits((N + 5)).
+  ASL Type error (TE_UT): a subtype of bits(64) was expected,
+    provided bits((N + 5)).
   [1]
   $ aslref --no-exec CNegative5.asl
   File CNegative5.asl, line 13, characters 2 to 33:
     printLengths{12}(3, Zeros{12}); // illegal
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {12} was expected, provided integer {3}.
+  ASL Type error (TE_UT): a subtype of integer {12} was expected,
+    provided integer {3}.
   [1]
   $ aslref --no-exec CNegative6.asl
   File CNegative6.asl, line 4, characters 2 to 15:
     return N + 1; // illegal
     ^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
     provided integer {(N + 1)}.
   [1]
   $ aslref --no-exec CNegative7.asl
   File CNegative7.asl, line 8, characters 9 to 26:
     return GetBitAt{M}(x, M); // illegal
            ^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..(M - 1)} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..(M - 1)} was expected,
     provided integer {M}.
   [1]
   $ aslref --no-exec CNegative8.asl
   File CNegative8.asl, line 7, characters 4 to 5:
       a = b; // illegal, would require ATC
       ^
-  ASL Type error: a subtype of integer {0..N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
     provided integer {0..M}.
   [1]
   $ aslref --no-exec CNegative10.asl
   File CNegative10.asl, line 7, characters 8 to 9:
           a = b; // illegal; only the static type is considered for type-checking
           ^
-  ASL Type error: a subtype of integer {0..N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
     provided integer {0..M}.
   [1]
   $ aslref --no-exec CNegative11.asl
   File CNegative11.asl, line 5, characters 4 to 5:
       z = M; // illegal
       ^
-  ASL Type error: a subtype of integer {0..N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
     provided integer {M}.
   [1]
   $ aslref --no-exec CNegative12.asl
@@ -498,7 +514,7 @@ Extra tests by ASLRef team
   File NegParam.asl, line 3, characters 2 to 28:
     let x: integer {0..N} = 0;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: a subtype of integer {0..N} was expected,
+  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
     provided integer {0}.
   [1]
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-02.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=23a9e8be018c119e4db50c721fdb9c89
+Hash=4c4a56945902d4281fbc78ee1168835b
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-03.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=a881e0cb1b96e2d661217652f3592c8f
+Hash=23197ae951e83f726fc972be67494972
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-04.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=786761feef0768ba6f6507782b2d19aa
+Hash=15e4e39096d663d979f42ce25ae1af1e
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-05.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Sometimes 1 3
-Hash=0ac99ff03f467930e725822f598becde
+Hash=d6dba1af03f91dfa6c9c3372cb41f573
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-06.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=ae0e8afc8c834ae9dba5dd19e24f946e
+Hash=b123d83d852ad838c027e839c36b52c8
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-07.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=27b46c42b63ce55723fc080977b992fd
+Hash=32c647331e9cac886fa9039453bacc83
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-08.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=a00efefc29a622abf8dea5ec7adcccdb
+Hash=65c962b27af654f48a3a0277fe5a191a
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-09.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=4eb08550c3a10a4cc86046c3d40aad09
+Hash=00b22e2e19aea7c6fd34e7d8c4fbe7bc
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-10.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=975ab5bb1d68495b3432716d0dde7c07
+Hash=a23c6b8b5f1d4a8127d48e5c40e830e0
 

--- a/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/LB-11.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 0 Negative: 3
 Condition exists (0:T0.0.x0=1 /\ 0:T1.0.x1=1)
 Observation LB-pseudo-arch Never 0 3
-Hash=5c1a328f3a00e6eb08e8522320e45493
+Hash=acabb8ba4268971d94b5a4e135ac96bf
 

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-01.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T1.0.a=1 /\ 0:T1.0.b=0)
 Observation MP-pseudo-arch Sometimes 1 3
-Hash=902d80754758bf3fa2382616fd557476
+Hash=9e8ec79b652072340ab8db1fd47bd5cc
 

--- a/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/MP-02.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:a=1 /\ 0:b=0)
 Observation MP-pseudo-arch Sometimes 1 3
-Hash=31ec73f632b721d57f47ada7827b471a
+Hash=bd572f49875e791d5aa1432d78a5152b
 

--- a/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/YL-01.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.res=1)
 Observation YL-01 Always 1 0
-Hash=f3dd6af1bf415b4f3d06713f0aa82cc3
+Hash=100c4baaa95889e41f668845d6f8fbc8
 

--- a/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/catch-exec-twice.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation catch-exec-twice Always 1 0
-Hash=c81d90cf213aedd85fb3788475e4211c
+Hash=5f7d25586206de158ecd70b67d937edc
 

--- a/herd/tests/instructions/ASL-pseudo-arch/collections-01.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/collections-01.litmus.expected
@@ -9,5 +9,5 @@ Witnesses
 Positive: 1 Negative: 3
 Condition exists (0:T1.0.a=1 /\ 0:T1.0.b=0)
 Observation collections-01 Sometimes 1 3
-Hash=8cc547cfa4493696116b09ca9dc46781
+Hash=ed9c4065d90dcadbcb2b46cb66ef0600
 

--- a/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/for-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation for-toofar Always 3 0
-Hash=9275da0fed9db4069e1ceaac8b8ce976
+Hash=8881ac9c462651c63b05f02d4472dc55
 

--- a/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/frozen-tuple-arg.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c=16)
 Observation frozen-tuple-arg Always 1 0
-Hash=4559d1c7dc1ba9e74660ae889d452b11
+Hash=22bb34b4ed1963ee0a8838e768838073
 

--- a/herd/tests/instructions/ASL-pseudo-arch/non-deterministic-case.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/non-deterministic-case.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation non-deterministic Always 1 0
-Hash=7cc98313d7619ae64e2a702df9cf57a1
+Hash=ce190ae6a5b89d43fe1cfa125f83c22f
 

--- a/herd/tests/instructions/ASL-pseudo-arch/non-deterministic-optimised.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/non-deterministic-optimised.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation non-deterministic Always 1 0
-Hash=a28e63ee1269e3e56a35851041d22e2b
+Hash=6b8174c44458ca2a502649fbf712ecb3
 

--- a/herd/tests/instructions/ASL-pseudo-arch/non-deterministic.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/non-deterministic.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation non-deterministic Always 2 0
-Hash=c6fe9cc1f62520b782ea376598c75379
+Hash=3c467fd62c8025688e6a63b17adcf0ba
 

--- a/herd/tests/instructions/ASL-pseudo-arch/recurse-arbitrary.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/recurse-arbitrary.litmus.expected
@@ -5,5 +5,5 @@ Witnesses
 Positive: 0 Negative: 0
 Condition forall (true)
 Observation recurse-arbitrary Never 0 0
-Hash=73b2264b3af0d004737edf62219b4216
+Hash=40d32c98068b9a82e24aa0e23539a394
 

--- a/herd/tests/instructions/ASL-pseudo-arch/recurse-ok.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/recurse-ok.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation recurse-ok Always 1 0
-Hash=cc5ff188bd6e314c5a9160a191b316ac
+Hash=6944aff00177a1a7adc734536b15121e
 

--- a/herd/tests/instructions/ASL-pseudo-arch/recurse-read-memory-a-bit-too-far.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/recurse-read-memory-a-bit-too-far.litmus.expected
@@ -5,5 +5,5 @@ Witnesses
 Positive: 0 Negative: 0
 Condition forall (true)
 Observation recurse-read-memory-a-bit-too-far Never 0 0
-Hash=4b7973d7d9291726e151472720214e1b
+Hash=c18e0e4dcce3a634a26b0d1e293c742c
 

--- a/herd/tests/instructions/ASL-pseudo-arch/recurse-read-memory-too-far.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/recurse-read-memory-too-far.litmus.expected
@@ -5,5 +5,5 @@ Witnesses
 Positive: 0 Negative: 0
 Condition forall (true)
 Observation recurse-read-memory-too-far Never 0 0
-Hash=57dd008a458224494ca9750c25ea8a07
+Hash=865780cca9b8694574b3b81a8b7766b6
 

--- a/herd/tests/instructions/ASL-pseudo-arch/recurse-read-memory.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/recurse-read-memory.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (true)
 Observation recurse-read-memory Always 1 0
-Hash=e953130aa9c1f377472928780c22b2f7
+Hash=4fb52e41855d6f26c63be3c9954e0abf
 

--- a/herd/tests/instructions/ASL-pseudo-arch/recurse-too-far-no-print.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/recurse-too-far-no-print.litmus.expected
@@ -5,5 +5,5 @@ Witnesses
 Positive: 0 Negative: 0
 Condition forall (true)
 Observation recurse-too-far-no-print Never 0 0
-Hash=abd5196ee6a439b4baf00eefdc7b590e
+Hash=58891f1ea6c2d76e82b5fd7cc5c46181
 

--- a/herd/tests/instructions/ASL-pseudo-arch/recurse-too-far.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/recurse-too-far.litmus.expected
@@ -5,5 +5,5 @@ Witnesses
 Positive: 0 Negative: 0
 Condition forall (true)
 Observation recurse-too-far Never 0 0
-Hash=bf14c45f7cc4275b98707a4bdaa28846
+Hash=85060d1527cbbc5a7558895ab205e4b9
 

--- a/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/repeat-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation repeat-toofar Always 3 0
-Hash=1f5ed73b74262b43712abce3dbdd1229
+Hash=1f99fe6d2bf483903cd88290ae841539
 

--- a/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/return-tuple.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.c=3)
 Observation return-tuple Always 1 0
-Hash=9798b9b885e5fde385244558bf917a7c
+Hash=a9cb2f417b55ac11cedc039c1d9990e5
 

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-assign.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:z=2)
 Observation throw-assign Always 1 0
-Hash=8128cab5151a83814c163edd688191c1
+Hash=1c9877da9a434e6a7130776fc692d91a
 

--- a/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/throw-propagate.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 7 Negative: 0
 Condition forall (0:z=2 /\ 0:t=2 /\ (0:g.0.a=0 /\ 0:main.0.y=0 \/ 0:g.0.a=1 /\ 0:main.0.y=1))
 Observation throw-propagate Always 7 0
-Hash=b13d2986880c6471a89df5d45548dc1a
+Hash=4a8a83b47538c288581d5a3c73c628d8
 

--- a/herd/tests/instructions/ASL-pseudo-arch/try-non-deterministic.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/try-non-deterministic.litmus.expected
@@ -7,5 +7,5 @@ Witnesses
 Positive: 2 Negative: 0
 Condition forall (true)
 Observation try-non-deterministic Always 2 0
-Hash=2da84543be5d1c634da0b52030193b23
+Hash=c67328745733d8a6dd03b42857029f9b
 

--- a/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
+++ b/herd/tests/instructions/ASL-pseudo-arch/while-toofar.litmus.expected
@@ -8,5 +8,5 @@ Witnesses
 Positive: 3 Negative: 0
 Condition forall (true)
 Observation while-toofar Always 3 0
-Hash=9ef5eea5f6e582ac44e04604259fd4c3
+Hash=622014379fdfa2791a7293b594967d93
 

--- a/herd/tests/instructions/ASL/bitfields1.litmus.expected
+++ b/herd/tests/instructions/ASL/bitfields1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.b=1 /\ 0:main.0.d=1 /\ 0:main.0.e=1)
 Observation bitfields1 Always 1 0
-Hash=77317685f9e2f3fb5825ed8e209c156f
+Hash=3e14c579e51f7c6419c44ae990a58717
 

--- a/herd/tests/instructions/ASL/case1.litmus.expected
+++ b/herd/tests/instructions/ASL/case1.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.a=1 /\ 0:main.0.b=0)
 Observation case1 Always 1 0
-Hash=158424eb42887db4841b49380d248781
+Hash=f99587737fda68c8a9bdd19332fbc46a
 

--- a/herd/tests/instructions/ASL/no-main.litmus.expected-failure
+++ b/herd/tests/instructions/ASL/no-main.litmus.expected-failure
@@ -1,2 +1,2 @@
-Warning: File "./herd/tests/instructions/ASL/no-main.litmus": ASL Dynamic error: no entrypoint supplied. Have you defined `func main() =>
-  integer`, or did you mean to pass `--no-exec`?
+Warning: File "./herd/tests/instructions/ASL/no-main.litmus": ASL Dynamic error (DE_NEP): no entrypoint supplied. Have you defined `func
+  main() => integer`, or did you mean to pass `--no-exec`?

--- a/herd/tests/instructions/ASL/records.litmus.expected
+++ b/herd/tests/instructions/ASL/records.litmus.expected
@@ -6,5 +6,5 @@ Witnesses
 Positive: 1 Negative: 0
 Condition forall (0:main.0.x=3)
 Observation records Always 1 0
-Hash=02770c764a69fc64aec74b26838f036a
+Hash=11f488a95e9289408f2c482c1f55f9b1
 


### PR DESCRIPTION
- Introduce `Error.ErrorCode` module, defining error codes from the reference
- Convert `Error.error`s to error codes where possible, leaving missing cases unspecified. These will need to be handled in future PRs that align the reference document and implementation. A TODO comment captures various discrepancies.
- Along the way, address a comment from @HadrienRenaud (https://github.com/herd/herdtools7/pull/1935#discussion_r3681138721)