### PR TITLE
[herd] Print fault occurences as generated

### DIFF
--- a/doc/MP-TTD+DMB.ST+DMB.LD.litmus
+++ b/doc/MP-TTD+DMB.ST+DMB.LD.litmus
@@ -12,4 +12,4 @@ DMB ST      | DMB LD         ;
 MOV W7,#1   | L0: LDR W4,[X3];
 STR W7,[X8] |                ;
 exists(1:X7=1 /\
-  Fault(P1:L0,x,MMU:Translation))
+  Fault(P1:L0,x,D-MMU:Translation))

--- a/doc/MP-TTD+DMB.ST+DSB-ISB.litmus
+++ b/doc/MP-TTD+DMB.ST+DSB-ISB.litmus
@@ -13,6 +13,6 @@ DMB ST          | DSB SY         ;
 MOV W7,#1       | ISB            ;
 STR W7,[X8]     | L0: LDR W4,[X3];
 exists(1:X7=1 /\
-  Fault(P1:L0,x,MMU:Translation))
+  Fault(P1:L0,x,D-MMU:Translation))
 
 

--- a/doc/kvm-log.txt
+++ b/doc/kvm-log.txt
@@ -15,7 +15,7 @@ AArch64 MP-TTD+DMB.ST+DMB.LD
  MOV W7,#1   | L0: LDR W4,[X3] ;
  STR W7,[X8] |                 ;
 
-exists (1:X7=1 /\ fault(P1:L0,x,MMU:Translation))
+exists (1:X7=1 /\ fault(P1:L0,x,D-MMU:Translation))
 Generated assembler
 #START _litmus_P0
 	nop
@@ -41,15 +41,15 @@ Generated assembler
 /usr/bin/qemu-system-aarch64 -nodefaults -machine virt,gic-version=host -accel kvm -cpu host -device virtio-serial-device -device virtconsole,chardev=ctd -chardev testdev,id=ctd -device pci-testdev -display none -serial stdio -kernel M/./MP-TTD+DMB.ST+DMB.LD.flat -smp 4 -append -q # -initrd /tmp/tmp.HYxVtV2KEl
 Test MP-TTD+DMB.ST+DMB.LD Allowed
 Histogram (4 states)
-70    *>1:X7=1; fault(P1:L0,x,MMU:Translation);
-1975326:>1:X7=0; ~fault(P1:L0,x,MMU:Translation);
-21197 :>1:X7=0; fault(P1:L0,x,MMU:Translation);
-3407  :>1:X7=1; ~fault(P1:L0,x,MMU:Translation);
+70    *>1:X7=1; fault(P1:L0,x,D-MMU:Translation);
+1975326:>1:X7=0; ~fault(P1:L0,x,D-MMU:Translation);
+21197 :>1:X7=0; fault(P1:L0,x,D-MMU:Translation);
+3407  :>1:X7=1; ~fault(P1:L0,x,D-MMU:Translation);
 Ok
 
 Witnesses
 Positive: 70, Negative: 1999930
-Condition exists (1:X7=1 /\ fault(P1:L0,x,MMU:Translation)) is validated
+Condition exists (1:X7=1 /\ fault(P1:L0,x,D-MMU:Translation)) is validated
 Hash=e6d0396aa32c40b307db5f6921404c07
 EL0=P1
 Observation MP-TTD+DMB.ST+DMB.LD Sometimes 70 1999930
@@ -74,7 +74,7 @@ AArch64 MP-TTD+DMB.ST+DSB-ISB
  MOV W7,#1   | ISB             ;
  STR W7,[X8] | L0: LDR W4,[X3] ;
 
-exists (1:X7=1 /\ fault(P1:L0,x,MMU:Translation))
+exists (1:X7=1 /\ fault(P1:L0,x,D-MMU:Translation))
 Generated assembler
 #START _litmus_P0
 	nop
@@ -101,14 +101,14 @@ Generated assembler
 /usr/bin/qemu-system-aarch64 -nodefaults -machine virt,gic-version=host -accel kvm -cpu host -device virtio-serial-device -device virtconsole,chardev=ctd -chardev testdev,id=ctd -device pci-testdev -display none -serial stdio -kernel M/./MP-TTD+DMB.ST+DSB-ISB.flat -smp 4 -append -q # -initrd /tmp/tmp.b5PUkrphZb
 Test MP-TTD+DMB.ST+DSB-ISB Allowed
 Histogram (3 states)
-1991985:>1:X7=0; ~fault(P1:L0,x,MMU:Translation);
-5938  :>1:X7=0; fault(P1:L0,x,MMU:Translation);
-2077  :>1:X7=1; ~fault(P1:L0,x,MMU:Translation);
+1991985:>1:X7=0; ~fault(P1:L0,x,D-MMU:Translation);
+5938  :>1:X7=0; fault(P1:L0,x,D-MMU:Translation);
+2077  :>1:X7=1; ~fault(P1:L0,x,D-MMU:Translation);
 No
 
 Witnesses
 Positive: 0, Negative: 2000000
-Condition exists (1:X7=1 /\ fault(P1:L0,x,MMU:Translation)) is NOT validated
+Condition exists (1:X7=1 /\ fault(P1:L0,x,D-MMU:Translation)) is NOT validated
 Hash=18e9682c0e7ed43f7f059cbfc47d781d
 EL0=P1
 Observation MP-TTD+DMB.ST+DSB-ISB Never 0 2000000

--- a/doc/litmus.tex
+++ b/doc/litmus.tex
@@ -2277,11 +2277,11 @@ entry of~\texttt{x}. The thread $T_0$ then signals by writing the
 value one into the location~\texttt{y}. Concurrently, $T_1$ reads the
 signal location~\texttt{y} and then attemps to read~\texttt{x}.
 The final condition
-\verb+exists(1:X7=1 /\ Fault(P1:L0,x,MMU:Translation)+
+\verb+exists(1:X7=1 /\ Fault(P1:L0,x,D-MMU:Translation)+
 describes the situation when the signal has been received by~$T_1$
 (\texttt{1:X7=1}), while $T_1$ has not yet noticed that $T_0$ has made
 accessing to~\texttt{x} valid
---- The atom \texttt{Fault(P1:L0,x,MMU:Translation)} corresponds to a
+--- The atom \texttt{Fault(P1:L0,x,D-MMU:Translation)} corresponds to a
 faulting attempt by~$T_1$ to read the location~\texttt{x}.
 The two tests differ by their synchronisation
 instructions: \atest{MP-TTD+DMB.ST+DMB.LD} is synchronised by fences
@@ -2326,15 +2326,15 @@ there:
 ...
 Test MP-TTD+DMB.ST+DMB.LD Allowed
 Histogram (4 states)
-70    *>1:X7=1; fault(P1:L0,x,MMU:Translation);
-1975326:>1:X7=0; ~fault(P1:L0,x,MMU:Translation);
-21197 :>1:X7=0; fault(P1:L0,x,MMU:Translation);
-3407  :>1:X7=1; ~fault(P1:L0,x,MMU:Translation);
+70    *>1:X7=1; fault(P1:L0,x,D-MMU:Translation);
+1975326:>1:X7=0; ~fault(P1:L0,x,D-MMU:Translation);
+21197 :>1:X7=0; fault(P1:L0,x,D-MMU:Translation);
+3407  :>1:X7=1; ~fault(P1:L0,x,D-MMU:Translation);
 Ok
 
 Witnesses
 Positive: 70, Negative: 1999930
-Condition exists (1:X7=1 /\ fault(P1:L0,x,MMU:Translation)) is validated
+Condition exists (1:X7=1 /\ fault(P1:L0,x,D-MMU:Translation)) is validated
 Hash=e6d0396aa32c40b307db5f6921404c07
 EL0=P1
 Observation MP-TTD+DMB.ST+DMB.LD Sometimes 70 1999930
@@ -2346,14 +2346,14 @@ Time MP-TTD+DMB.ST+DMB.LD 15.14
 
 Test MP-TTD+DMB.ST+DSB-ISB Allowed
 Histogram (3 states)
-1991985:>1:X7=0; ~fault(P1:L0,x,MMU:Translation);
-5938  :>1:X7=0; fault(P1:L0,x,MMU:Translation);
-2077  :>1:X7=1; ~fault(P1:L0,x,MMU:Translation);
+1991985:>1:X7=0; ~fault(P1:L0,x,D-MMU:Translation);
+5938  :>1:X7=0; fault(P1:L0,x,D-MMU:Translation);
+2077  :>1:X7=1; ~fault(P1:L0,x,D-MMU:Translation);
 No
 
 Witnesses
 Positive: 0, Negative: 2000000
-Condition exists (1:X7=1 /\ fault(P1:L0,x,MMU:Translation)) is NOT validated
+Condition exists (1:X7=1 /\ fault(P1:L0,x,D-MMU:Translation)) is NOT validated
 Hash=18e9682c0e7ed43f7f059cbfc47d781d
 EL0=P1
 Observation MP-TTD+DMB.ST+DSB-ISB Never 0 2000000

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -992,28 +992,6 @@ module Make(C:Config) (I:I) : S with module I = I
         then
           pp_st ^ pp_solver
         else
-          let data_intr_to_any_flt fault =
-            match fault with
-            | (lbl,loc, Some ft0, msg) ->
-                let any_flt =
-                  FaultAtomSet.fold
-                    (fun fatom k ->
-                      match fatom, k with
-                      | _, Some _ -> k
-                      | (_,_, Some ft_expected), None ->
-                          if check_one_fatom fault fatom
-                             && I.FaultType.matches ft0 ft_expected
-                          then Some ft_expected
-                          else None
-                      | _ -> k)
-                    fobs None
-                in
-                begin match any_flt with
-                | Some ft_expected -> (lbl,loc, Some ft_expected, msg)
-                | None -> fault
-                end
-            | _ -> fault
-          in
           let noflts =
             FaultAtomSet.fold
               (fun (((p,lbl),loc,ftype) as f0) k ->
@@ -1035,7 +1013,7 @@ module Make(C:Config) (I:I) : S with module I = I
                     (fun f0 -> check_one_fatom f f0) fobs)
                 flts in
           pp_st ^ " " ^
-          FaultSet.pp_str " "  (fun f -> pp_fault (data_intr_to_any_flt f) ^ ";")  flts ^
+          FaultSet.pp_str " "  (fun f -> pp_fault f ^ ";")  flts ^
           String.concat "" noflts ^
           pp_solver
 

--- a/herd/tests/instructions/AArch64.PAC/A07.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A07.litmus.expected
@@ -1,7 +1,7 @@
 Test A07 Allowed
 States 2
 0:X1=42;  ~Fault(P0,MMU:Translation); pacda(x,0x35)=x;
-0:X1=53; Fault(P0,x,MMU:Translation);
+0:X1=53; Fault(P0,x,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 1 Negative: 1

--- a/herd/tests/instructions/AArch64.PAC/A10.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A10.litmus.expected
@@ -1,7 +1,7 @@
 Test A10 Allowed
 States 2
 0:X1=42;  ~Fault(P0,MMU:Translation); pacda(x,0x35)=x;
-0:X1=53; Fault(P0,x,MMU:Translation);
+0:X1=53; Fault(P0,x,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 1 Negative: 1

--- a/herd/tests/instructions/AArch64.PAC/A15.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A15.litmus.expected
@@ -1,7 +1,7 @@
 Test A15 Required
 States 2
 0:X3=0;  ~Fault(P0,MMU:Translation); pacda(x,0x35)=x;
-0:X3=42; Fault(P0,x,MMU:Translation);
+0:X3=42; Fault(P0,x,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 2 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A16.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A16.litmus.expected
@@ -1,9 +1,9 @@
 Test A16 Required
 States 4
 0:X4=0;  ~Fault(P2,MMU:Translation); ~Fault(P1,MMU:Translation); pacdb(x,0x2a)=x; pacda(x,0x35)=x;
-0:X4=1; Fault(P1,x,MMU:Translation); ~Fault(P2,MMU:Translation); pacdb(x,0x2a)=x;
-0:X4=1; Fault(P1,x,MMU:Translation); Fault(P2,x,MMU:Translation);
-0:X4=1; Fault(P2,x,MMU:Translation); ~Fault(P1,MMU:Translation); pacda(x,0x35)=x;
+0:X4=1; Fault(P1,x,D-MMU:Translation); ~Fault(P2,MMU:Translation); pacdb(x,0x2a)=x;
+0:X4=1; Fault(P1,x,D-MMU:Translation); Fault(P2,x,D-MMU:Translation);
+0:X4=1; Fault(P2,x,D-MMU:Translation); ~Fault(P1,MMU:Translation); pacda(x,0x35)=x;
 Ok
 Witnesses
 Positive: 4 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A17.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A17.litmus.expected
@@ -1,9 +1,9 @@
 Test A17 Required
 States 4
 0:X4=0;  ~Fault(P2,MMU:Translation); ~Fault(P1,MMU:Translation); pacia(x,0x2a)=x; pacda(x,0x35)=x;
-0:X4=0; Fault(P1,x,MMU:Translation); Fault(P2,x,MMU:Translation);
-0:X4=1; Fault(P1,x,MMU:Translation); ~Fault(P2,MMU:Translation); pacia(x,0x2a)=x;
-0:X4=1; Fault(P2,x,MMU:Translation); ~Fault(P1,MMU:Translation); pacda(x,0x35)=x;
+0:X4=0; Fault(P1,x,D-MMU:Translation); Fault(P2,x,D-MMU:Translation);
+0:X4=1; Fault(P1,x,D-MMU:Translation); ~Fault(P2,MMU:Translation); pacia(x,0x2a)=x;
+0:X4=1; Fault(P2,x,D-MMU:Translation); ~Fault(P1,MMU:Translation); pacda(x,0x35)=x;
 Ok
 Witnesses
 Positive: 4 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A22.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A22.litmus.expected
@@ -1,7 +1,7 @@
 Test A22 Allowed
 States 2
   ~Fault(P0,MMU:Translation); pacda(x,0x0)=x;
- Fault(P0,x,MMU:Translation);
+ Fault(P0,x,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 1 Negative: 1

--- a/herd/tests/instructions/AArch64.PAC/A23.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A23.litmus.expected
@@ -1,6 +1,6 @@
 Test A23 Allowed
 States 2
-0:X1=0; Fault(P0,x,MMU:Translation);
+0:X1=0; Fault(P0,x,D-MMU:Translation);
 0:X1=42;  ~Fault(P0,MMU:Translation); pacda(x,0x0)=x;
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.kvm/A009.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A009.litmus.expected
@@ -1,6 +1,6 @@
 Test A009 Required
 States 1
- Fault(P0:L0,x,MMU:Translation);
+ Fault(P0:L0,x,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.kvm/A010.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A010.litmus.expected
@@ -1,6 +1,6 @@
 Test A010 Required
 States 1
- Fault(P0:L0,x,MMU:AccessFlag);
+ Fault(P0:L0,x,D-MMU:AccessFlag);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.kvm/A011.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A011.litmus.expected
@@ -1,6 +1,6 @@
 Test A011 Required
 States 1
- Fault(P0:L0,x,MMU:Permission);
+ Fault(P0:L0,x,D-MMU:Permission);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.kvm/A012.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A012.litmus.expected
@@ -1,6 +1,6 @@
 Test A012 Required
 States 1
- Fault(P0:L0,UndefinedInstruction); Fault(P0:L1,x,MMU:Translation); Fault(P0:L2,y,MMU:AccessFlag);
+ Fault(P0:L0,UndefinedInstruction); Fault(P0:L1,x,D-MMU:Translation); Fault(P0:L2,y,D-MMU:AccessFlag);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.kvm/A017.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A017.litmus.expected
@@ -1,7 +1,7 @@
 Test A017 Required
 States 2
   ~Fault(P1:L0,x,MMU:Translation);
- Fault(P1:L0,x,MMU:Translation);
+ Fault(P1:L0,x,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 3 Negative: 0

--- a/herd/tests/instructions/AArch64.kvm/A023.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A023.litmus.expected
@@ -1,8 +1,8 @@
 Test A023 Forbidden
 States 3
 1:X2=0;  ~Fault(P1,x,MMU:Translation);
-1:X2=0; Fault(P1,x,MMU:Translation);
-1:X2=1; Fault(P1,x,MMU:Translation);
+1:X2=0; Fault(P1,x,D-MMU:Translation);
+1:X2=1; Fault(P1,x,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 3 Negative: 0

--- a/herd/tests/instructions/AArch64.kvm/A029.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A029.litmus.expected
@@ -1,6 +1,6 @@
 Test A029 Required
 States 1
- Fault(P0,x,MMU:Permission);
+ Fault(P0,x,D-MMU:Permission);
 Ok
 Witnesses
 Positive: 4 Negative: 0

--- a/herd/tests/instructions/AArch64.kvm/A030.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A030.litmus.expected
@@ -1,6 +1,6 @@
 Test A030 Required
 States 1
- Fault(P0,x,MMU:Permission);
+ Fault(P0,x,D-MMU:Permission);
 Ok
 Witnesses
 Positive: 3 Negative: 0

--- a/herd/tests/instructions/AArch64.vmsa+mte/A002.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A002.litmus.expected
@@ -1,6 +1,6 @@
 Test A002 Required
 States 1
-[x]=0; Fault(P0:L0,x:green,MMU:Translation);
+[x]=0; Fault(P0:L0,x:green,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.vmsa+mte/A003.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A003.litmus.expected
@@ -1,6 +1,6 @@
 Test A003 Required
 States 1
-[x]=0; Fault(P0:L0,x:green,MMU:Permission);
+[x]=0; Fault(P0:L0,x:green,D-MMU:Permission);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.vmsa+mte/A005.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A005.litmus.expected
@@ -1,6 +1,6 @@
 Test A005 Required
 States 1
-[x]=0; Fault(P0:L0,x:red,MMU:Permission);
+[x]=0; Fault(P0:L0,x:red,D-MMU:Permission);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.vmsa+mte/A008.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A008.litmus.expected
@@ -1,8 +1,8 @@
 Test A008 Allowed
 States 3
 [x]=0;  ~Fault(P0:L0,x,MMU:Translation);
-[x]=0; Fault(P0:L0,x,MMU:Translation);
-[x]=1; Fault(P0:L0,x,MMU:Translation);
+[x]=0; Fault(P0:L0,x,D-MMU:Translation);
+[x]=1; Fault(P0:L0,x,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 1 Negative: 4

--- a/herd/tests/instructions/AArch64.vmsa+mte/A009.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A009.litmus.expected
@@ -1,8 +1,8 @@
 Test A009 Allowed
 States 3
-[tag(x)]=:green; Fault(P0:L0,x,MMU:Translation);
+[tag(x)]=:green; Fault(P0:L0,x,D-MMU:Translation);
 [tag(x)]=:red;  ~Fault(P0:L0,x,MMU:Translation);
-[tag(x)]=:red; Fault(P0:L0,x,MMU:Translation);
+[tag(x)]=:red; Fault(P0:L0,x,D-MMU:Translation);
 Ok
 Witnesses
 Positive: 1 Negative: 4


### PR DESCRIPTION
Fault occurrences that appear in final outcomes describe what occurred. There is no reason to change the fault type to match the one of the final condition.

Consider the test:
```
AArch64 LDR-AF-03
Variant=vmsa
{
int x=1;
[TTD(x)]=(af:0);
0:X1=x;
}
  P0        ;
LDR W0,[X1] ;
forall fault(P0,x,MMU:AccessFlag)
```
Before this PR, the fault specification in the final condition impacts the fault occurrrence in outcome:
```
$ herd7 LDR-AF-03.litmus 
Test LDR-AF-03 Required
States 1
 Fault(P0,x,MMU:AccessFlag);
Ok
Witnesses
Positive: 1 Negative: 0
Condition forall (fault(P0,x,MMU:AccessFlag))
Observation LDR-AF-03 Always 1 0
Time LDR-AF-03 0.01
Hash=5bbf6a0653a259f79a3acabf7a721567
```
With this PR, we have:
```
$ /opt/PR/bin/herd7 LDR-AF-03.litmus 
Test LDR-AF-03 Required
States 1
 Fault(P0,x,D-MMU:AccessFlag);
Ok
Witnesses
Positive: 1 Negative: 0
Condition forall (fault(P0,x,MMU:AccessFlag))
Observation LDR-AF-03 Always 1 0
Time LDR-AF-03 0.01
Hash=5bbf6a0653a259f79a3acabf7a721567
```
That is, the fault type of the printed occurrence is now complete: `D-MMU:AccessFlag`.

Rationale: It is obviously useful to provide users with as much information as possible on the faults that have occurred.  Moreover, if the final condition is `forall fault(P0)`  then the complete fault occurrence `Fault(P0,x,D-MMU:AccessFlag)` has always been printed. We see no reason for the final condition `forall(P0,x,MMU:AccessFlag)` to behave differently.


Partial revert of PR #1518.