### PR TITLE
Aligning implementation/specification error codes - phase 1/5

### DIFF
--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -2124,7 +2124,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                 let collection_var_name =
                   match e2.desc with
                   | E_Var x -> x
-                  | _ -> fatal_from ~loc Error.(UnsupportedExpr (Static, e))
+                  | _ -> fatal_from ~loc (Error.CollectionBaseNotVariable e2)
                 in
                 match List.assoc_opt field_name fields with
                 | None ->
@@ -2240,7 +2240,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                 let base_collection_name =
                   match e_base_annot.desc with
                   | E_Var x -> x
-                  | _ -> fatal_from ~loc Error.(UnsupportedExpr (Static, e))
+                  | _ ->
+                      fatal_from ~loc
+                        (Error.CollectionBaseNotVariable e_base_annot)
                 in
                 let get_bitfield_width name =
                   match List.assoc_opt name base_fields with
@@ -2581,7 +2583,13 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
          (* Begin LESetCollectionField *)
          | T_Collection fields ->
              let collection_var_name =
-               match le2.desc with LE_Var x -> x | _ -> assert false
+               match le2.desc with
+               | LE_Var x -> x
+               | _ ->
+                   (* assignable expressions start with an identifier,
+                      and collection types cannot be nested, so a collection
+                      base must be a variable. *)
+                   assert false
              in
              let t =
                match List.assoc_opt field fields with
@@ -2668,7 +2676,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
               | LE_Var x -> x
               | _ ->
                   fatal_from ~loc
-                    Error.(UnsupportedExpr (Static, expr_of_lexpr le))
+                    (Error.CollectionBaseNotVariable (expr_of_lexpr le_base))
             in
             let fold_bitvector_fields field (start, slices) =
               match List.assoc_opt field base_fields with

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1296,7 +1296,10 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         (match constraints with
           | PendingConstrained ->
               fatal_from ~loc Error.UnexpectedPendingConstrained
-          | WellConstrained ([], _) -> fatal_from ~loc Error.EmptyConstraints
+          | WellConstrained ([], _) ->
+              (* This is an internal invariant, as the parser requires at least
+                 one constraint. *)
+              fatal_from ~loc Error.EmptyConstraints
           | WellConstrained (constraints, precision) ->
               let new_constraints, sess =
                 list_map_split (annotate_constraint ~loc env) constraints

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -679,7 +679,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
   let check_bits_equal_width ~loc env t1 t2 () =
     try check_bits_equal_width' env t1 t2 ()
     with TypingAssumptionFailed ->
-      fatal_from ~loc (Error.UnreconcilableTypes (t1, t2))
+      fatal_from ~loc (Error.MismatchedBitvectorWidths (t1, t2))
   (* End *)
 
   let binop_is_ordered : binop -> bool = function

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -37,8 +37,8 @@ File ../tests/ASLDefinition.t/TypingErrorReporting.asl, line 3,
   characters 11 to 22:
     return 5 + "hello";
            ^^^^^^^^^^^
-ASL Type error (TE_BO): Illegal application of operator + on types
-  integer {5} and string.
+ASL Type error: Illegal application of operator + on types integer {5}
+  and string.
 \end{Verbatim}
 % CONSOLE_END
 
@@ -57,8 +57,7 @@ followed by an example of a report from \aslrefterm{} in a \linuxbashshellterm.
 % CONSOLE_BEGIN CONSOLE_STDERR CONSOLE_CMD aslref \definitiontests/DynamicErrorReporting.asl
 \begin{Verbatim}[fontsize=\footnotesize, frame=single]
 > aslref ../tests/ASLDefinition.t/DynamicErrorReporting.asl
-ASL Dynamic error (DE_BO): Illegal application of operator DIV for values 128
-  and 7.
+ASL Dynamic error: Illegal application of operator DIV for values 128 and 7.
 \end{Verbatim}
 % CONSOLE_END
 
@@ -82,7 +81,7 @@ File ../tests/ASLDefinition.t/AssertionStatement.asl, line 5,
   characters 11 to 22:
     assert a + b < 256;
            ^^^^^^^^^^^
-ASL Dynamic error (DE_DAF): Assertion failed: ((a + b) < 256).
+ASL Dynamic error: Assertion failed: ((a + b) < 256).
 \end{Verbatim}
 % CONSOLE_END
 
@@ -101,7 +100,7 @@ File ../tests/ASLDefinition.t/UnreachableStatement.asl, line 5,
   characters 8 to 20:
         unreachable;
         ^^^^^^^^^^^^
-ASL Dynamic error (DE_UNR): unreachable reached.
+ASL Dynamic error: unreachable reached.
 \end{Verbatim}
 % CONSOLE_END
 

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -37,8 +37,8 @@ File ../tests/ASLDefinition.t/TypingErrorReporting.asl, line 3,
   characters 11 to 22:
     return 5 + "hello";
            ^^^^^^^^^^^
-ASL Type error: Illegal application of operator + on types integer {5}
-  and string.
+ASL Type error (TE_BO): Illegal application of operator + on types
+  integer {5} and string.
 \end{Verbatim}
 % CONSOLE_END
 
@@ -57,7 +57,8 @@ followed by an example of a report from \aslrefterm{} in a \linuxbashshellterm.
 % CONSOLE_BEGIN CONSOLE_STDERR CONSOLE_CMD aslref \definitiontests/DynamicErrorReporting.asl
 \begin{Verbatim}[fontsize=\footnotesize, frame=single]
 > aslref ../tests/ASLDefinition.t/DynamicErrorReporting.asl
-ASL Dynamic error: Illegal application of operator DIV for values 128 and 7.
+ASL Dynamic error (DE_BO): Illegal application of operator DIV for values 128
+  and 7.
 \end{Verbatim}
 % CONSOLE_END
 
@@ -81,7 +82,7 @@ File ../tests/ASLDefinition.t/AssertionStatement.asl, line 5,
   characters 11 to 22:
     assert a + b < 256;
            ^^^^^^^^^^^
-ASL Dynamic error: Assertion failed: ((a + b) < 256).
+ASL Dynamic error (DE_DAF): Assertion failed: ((a + b) < 256).
 \end{Verbatim}
 % CONSOLE_END
 
@@ -100,7 +101,7 @@ File ../tests/ASLDefinition.t/UnreachableStatement.asl, line 5,
   characters 8 to 20:
         unreachable;
         ^^^^^^^^^^^^
-ASL Dynamic error: unreachable reached.
+ASL Dynamic error (DE_UNR): unreachable reached.
 \end{Verbatim}
 % CONSOLE_END
 

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -2617,6 +2617,12 @@ typing relation annotate_expr(tenv: static_envs, e: expr) -> (t: ty, new_e: expr
           TypeError(TE_BF);
         }
       }
+      case collection_bad_base {
+        L = label_T_Collection;
+        e2 != E_Var(_);
+        --
+        TypeError(TE_UT);
+      }
     }
 
     case bitfield {
@@ -2702,6 +2708,12 @@ typing relation annotate_expr(tenv: static_envs, e: expr) -> (t: ty, new_e: expr
       --
       (T_Bits(e_slice_width, empty_list), E_GetCollectionFields(base_collection_name, fields), ses_base)
       { math_layout = [_, [_] ] };
+    }
+    case collection_bad_base {
+      make_anonymous(tenv, t_base_annot) -> T_Collection(_);
+      e_base_annot != E_Var(_);
+      --
+      TypeError(TE_UT);
     }
     case error {
       make_anonymous(tenv, t_base_annot) -> t_base_annot_anon;
@@ -3578,6 +3590,13 @@ typing relation annotate_lexpr(tenv: static_envs, le: lexpr, t_e: ty) ->
      --
      (LE_SetCollectionFields(base_name, le_fields, slices), ses_base)
      { math_layout = [_, [_] ] };
+   }
+
+   case collection_bad_base {
+     t_base_anon =: T_Collection(_);
+     le_base != LE_Var(_);
+     --
+     TypeError(TE_UT);
    }
 
    case error {

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -8376,7 +8376,8 @@ typing function check_implementations_unique(impls: list0(func)) ->
 
   case non_empty {
     impls =: match_cons(h, t);
-    INDEX(i, t: signatures_match(h, t[i]) -> False);
+    INDEX(i, t: signatures_match(h, t[i]) -> matches[i]);
+    te_check(not_single(list_or(matches)), TE_OE) -> True;
     check_implementations_unique(t) -> True;
     --
     True;
@@ -8402,7 +8403,7 @@ typing function signatures_match(func1: func, func2: func) ->
   )
   { (_, [_]) };
   --
-  True;
+  match;
 ;
 
 typing function process_overrides(impdefs: list0(func), impls: list0(func)) ->

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -5196,8 +5196,7 @@ typing relation annotate_pattern(tenv: static_envs, t: ty, p: pattern) ->
     case bits {
       ast_label(t_struct) = label_T_Bits;
       te_check(ast_label(t_struct) = ast_label(t_e_struct), TE_BO) -> True;
-      check_bits_equal_width(tenv, t_struct, t_e_struct) -> b;
-      te_check(b, TE_BO) -> True;
+      check_bits_equal_width(tenv, t_struct, t_e_struct) -> True;
       --
       (Pattern_Single(e'), ses);
     }

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -306,8 +306,7 @@ module ErrorCode = struct
         None
     | CannotParse _ (* used in lexing too *) -> None
     | UnreconcilableTypes _ (* LCA failures *) -> None
-    | EmptyConstraints (* does this need to be reflected in reference? *) ->
-        None
+    | EmptyConstraints (* An internal invariant *) -> None
     | MultipleWrites _
     (* For desugaring, but uses `check_no_duplicates` which is always TE_IAD? *)
       ->

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -58,7 +58,7 @@ type error_desc =
       (** used for fine-grained analysis *)
   | MismatchedPurity of string  (** Used for coarse-grained analysis *)
   | MismatchedBitvectorWidths of ty * ty
-  | UnreconcilableTypes of ty * ty
+  | NoCommonAncestor of ty * ty
   | CollectionBaseNotVariable of expr
   | AssignToImmutable of string
   | AssignToTupleElement of lexpr
@@ -296,6 +296,7 @@ module ErrorCode = struct
     | AssertionFailed (Static, _)
     | BadPrimitiveArgument (Static, _, _) ->
         Some (Typing SEF)
+    | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
     (********** TODO tidy up - does not cleanly correspond to a code **********)
     | BadArity (Static, _, _, _) (* also used for tuple unpacking *) -> None
     | UnsupportedExpr _ | UnsupportedTy _
@@ -305,8 +306,6 @@ module ErrorCode = struct
     (* dynamic ATC but also mismatched integers for loop limits *) ->
         None
     | CannotParse _ (* used in lexing too *) -> None
-    | UnreconcilableTypes _ (* LCA failures *) -> None
-    | EmptyConstraints (* An internal invariant *) -> None
     | MultipleWrites _
     (* For desugaring, but uses `check_no_duplicates` which is always TE_IAD? *)
       ->
@@ -315,6 +314,7 @@ module ErrorCode = struct
         None
     (********** Should not happen **********)
     (* e.g. skipped type-checking, ASL0, internal option or invariant *)
+    | EmptyConstraints (* An internal invariant *) -> None
     | TypeInferenceNeeded
     | UndefinedIdentifier (Dynamic, _)
     | BadArity (Dynamic, _, _, _)
@@ -596,7 +596,7 @@ module PPrint = struct
     | MismatchedBitvectorWidths (t1, t2) ->
         pp_err Typing "bitvector types %a and %a must have equal widths." pp_ty
           t1 pp_ty t2
-    | UnreconcilableTypes (t1, t2) ->
+    | NoCommonAncestor (t1, t2) ->
         pp_err Typing
           "cannot@ find@ a@ common@ ancestor@ to@ those@ two@ types@ %a@ and@ \
            %a."
@@ -843,7 +843,7 @@ module CSV = struct
     | ImpureExpression _ -> "ImpureExpression"
     | MismatchedPurity _ -> "MismatchedPurity"
     | MismatchedBitvectorWidths _ -> "MismatchedBitvectorWidths"
-    | UnreconcilableTypes _ -> "UnreconcilableTypes"
+    | NoCommonAncestor _ -> "NoCommonAncestor"
     | CollectionBaseNotVariable _ -> "CollectionBaseNotVariable"
     | AssignToImmutable _ -> "AssignToImmutable"
     | AssignToTupleElement _ -> "AssignToTupleElement"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -57,6 +57,7 @@ type error_desc =
   | ImpureExpression of expr * SideEffect.SES.t
       (** used for fine-grained analysis *)
   | MismatchedPurity of string  (** Used for coarse-grained analysis *)
+  | MismatchedBitvectorWidths of ty * ty
   | UnreconcilableTypes of ty * ty
   | CollectionBaseNotVariable of expr
   | AssignToImmutable of string
@@ -256,8 +257,8 @@ module ErrorCode = struct
     | UndefinedIdentifier (Static, _) -> Some (Typing UI)
     | ConflictingTypes _ | AssignToTupleElement _ | ConstrainedIntegerExpected _
     | UnexpectedPendingConstrained | ExpectedSingularType _
-    | ExpectedNamedType _ | UnexpectedCollection | CollectionBaseNotVariable _
-      ->
+    | ExpectedNamedType _ | UnexpectedCollection | MismatchedBitvectorWidths _
+    | CollectionBaseNotVariable _ ->
         Some (Typing UT)
     | MismatchedCallType _
     | BadParameterArity (Static, _, _, _, _)
@@ -304,7 +305,7 @@ module ErrorCode = struct
     (* dynamic ATC but also mismatched integers for loop limits *) ->
         None
     | CannotParse _ (* used in lexing too *) -> None
-    | UnreconcilableTypes _ (* both LCA and check_bit_widths_equal *) -> None
+    | UnreconcilableTypes _ (* LCA failures *) -> None
     | EmptyConstraints (* does this need to be reflected in reference? *) ->
         None
     | MultipleWrites _
@@ -594,6 +595,9 @@ module PPrint = struct
           pp_expr e SideEffect.SES.pp_print ses
     | MismatchedPurity s ->
         pp_err Typing "expected@ a@ %s@ expression/subprogram." s
+    | MismatchedBitvectorWidths (t1, t2) ->
+        pp_err Typing "bitvector types %a and %a must have equal widths." pp_ty
+          t1 pp_ty t2
     | UnreconcilableTypes (t1, t2) ->
         pp_err Typing
           "cannot@ find@ a@ common@ ancestor@ to@ those@ two@ types@ %a@ and@ \
@@ -840,6 +844,7 @@ module CSV = struct
     | BadTypesForBinop _ -> "BadTypesForBinop"
     | ImpureExpression _ -> "ImpureExpression"
     | MismatchedPurity _ -> "MismatchedPurity"
+    | MismatchedBitvectorWidths _ -> "MismatchedBitvectorWidths"
     | UnreconcilableTypes _ -> "UnreconcilableTypes"
     | CollectionBaseNotVariable _ -> "CollectionBaseNotVariable"
     | AssignToImmutable _ -> "AssignToImmutable"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -58,6 +58,7 @@ type error_desc =
       (** used for fine-grained analysis *)
   | MismatchedPurity of string  (** Used for coarse-grained analysis *)
   | UnreconcilableTypes of ty * ty
+  | CollectionBaseNotVariable of expr
   | AssignToImmutable of string
   | AssignToTupleElement of lexpr
   | AlreadyDeclaredIdentifier of string
@@ -255,7 +256,8 @@ module ErrorCode = struct
     | UndefinedIdentifier (Static, _) -> Some (Typing UI)
     | ConflictingTypes _ | AssignToTupleElement _ | ConstrainedIntegerExpected _
     | UnexpectedPendingConstrained | ExpectedSingularType _
-    | ExpectedNamedType _ | UnexpectedCollection ->
+    | ExpectedNamedType _ | UnexpectedCollection | CollectionBaseNotVariable _
+      ->
         Some (Typing UT)
     | MismatchedCallType _
     | BadParameterArity (Static, _, _, _, _)
@@ -597,6 +599,11 @@ module PPrint = struct
           "cannot@ find@ a@ common@ ancestor@ to@ those@ two@ types@ %a@ and@ \
            %a."
           pp_ty t1 pp_ty t2
+    | CollectionBaseNotVariable e ->
+        pp_err Typing
+          "collection fields can only be accessed through a variable;@ \
+           provided base: %a."
+          pp_expr e
     | AssignToImmutable x ->
         pp_err Typing "cannot@ assign@ to@ immutable@ storage@ %S." x
     | AssignToTupleElement tuple_e ->
@@ -834,6 +841,7 @@ module CSV = struct
     | ImpureExpression _ -> "ImpureExpression"
     | MismatchedPurity _ -> "MismatchedPurity"
     | UnreconcilableTypes _ -> "UnreconcilableTypes"
+    | CollectionBaseNotVariable _ -> "CollectionBaseNotVariable"
     | AssignToImmutable _ -> "AssignToImmutable"
     | AssignToTupleElement _ -> "AssignToTupleElement"
     | AlreadyDeclaredIdentifier _ -> "AlreadyDeclaredIdentifier"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -409,7 +409,6 @@ end
       distinguish between ASL1 errors and e.g. ASL0 non-typechecked errors,
       assertion failures, cases we don't expect to hit etc.
     - TypingRule.TInt mismatch on empty case *)
-(* TODO: check_implementations_unique should be TE_OE in reference - instead just generic #TE *)
 (* TODO: BE_RI unused in reference *)
 (* TODO: following not recoverable from implementation:
 - BE_BOP

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -54,7 +54,7 @@ ASL Typing Tests:
   File TypingRule.LowestCommonAncestor.bad.asl, line 10, characters 13 to 53:
       var o  = if ARBITRARY : boolean then arr1 else ex;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot find a common ancestor to those two types
+  ASL Type error (TE_LCA): cannot find a common ancestor to those two types
     array [[8]] of Word1 and exception { i: integer }.
   [1]
   $ aslref --no-exec TypingRule.LowestCommonAncestor2.asl

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -612,8 +612,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.PSingle.bad.asl, line 4, characters 11 to 30:
       assert '101' IN { '1100' };
              ^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot find a common ancestor to those two types bits(3) and
-    bits(4).
+  ASL Type error (TE_UT):
+    bitvector types bits(3) and bits(4) must have equal widths.
   [1]
   $ aslref TypingRule.PRange.asl
   $ aslref TypingRule.PRange.bad.asl

--- a/asllib/tests/collections.t/non-variable-base.asl
+++ b/asllib/tests/collections.t/non-variable-base.asl
@@ -1,0 +1,7 @@
+var C1 : collection { field: bits(1) };
+var C2 : collection { field: bits(1) };
+
+func main() => integer begin
+  let x = (if TRUE then C1 else C2).field;
+  return 0;
+end;

--- a/asllib/tests/collections.t/run.t
+++ b/asllib/tests/collections.t/run.t
@@ -4,6 +4,14 @@
                          ^^^^^^^^^^
   ASL Grammar error: Cannot parse.
   [1]
+  $ aslref non-variable-base.asl
+  File non-variable-base.asl, line 5, characters 10 to 41:
+    let x = (if TRUE then C1 else C2).field;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ASL Type error (TE_UT):
+    collection fields can only be accessed through a variable;
+    provided base: if TRUE then C1 else C2.
+  [1]
   $ aslref on-local-func-arg.asl
   File on-local-func-arg.asl, line 6, characters 15 to 25:
   func foo (col: collection {

--- a/asllib/tests/lca.t
+++ b/asllib/tests/lca.t
@@ -77,8 +77,8 @@
   File lca5.asl, line 3, characters 10 to 48:
     let x = if ARBITRARY: boolean then TRUE else 3;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error: cannot find a common ancestor to those two types boolean and
-    integer {3}.
+  ASL Type error (TE_LCA): cannot find a common ancestor to those two types
+    boolean and integer {3}.
   [1]
 
   $ cat >lca6.asl <<EOF

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -103,8 +103,8 @@ Some problems with bitvectors and bitmasks:
   File masks0.asl, line 4, characters 17 to 28:
       let expr_a = '' IN {'1'};
                    ^^^^^^^^^^^
-  ASL Type error: cannot find a common ancestor to those two types bits(0) and
-    bits(1).
+  ASL Type error (TE_UT):
+    bitvector types bits(0) and bits(1) must have equal widths.
   [1]
 
 Check that variables starting with `__` are reserved:

--- a/asllib/tests/types.ml
+++ b/asllib/tests/types.ml
@@ -127,7 +127,7 @@ let lca_examples () =
     try
       let _ = lowest_common_ancestor ~loc:bits_4 empty_env bits_4 bits_2 in
       assert false
-    with Error.ASLException { desc = Error.UnreconcilableTypes _ } -> ()
+    with Error.ASLException { desc = Error.NoCommonAncestor _ } -> ()
   in
 
   let integer_4 = integer_exact !$4 in

--- a/asllib/types.ml
+++ b/asllib/types.ml
@@ -623,6 +623,6 @@ let rec lowest_common_ancestor ~loc env s t =
          of the types of the corresponding elements of S and T. *)
         let li = List.map2 (lowest_common_ancestor ~loc env) li_s li_t in
         here (T_Tuple li)
-    | _ -> Error.fatal_from loc (Error.UnreconcilableTypes (s, t)))
+    | _ -> Error.fatal_from loc (Error.NoCommonAncestor (s, t)))
   |: TypingRule.LowestCommonAncestor
 (* End *)


### PR DESCRIPTION
### Non-variable collection field access (`TE_UT`)
Collection storage is accessed through a variable. For expression whose base has collection type but is not a variable, the specification previously had no error case and the OCaml implementation raised the generic,
uncoded `UnsupportedExpr` diagnostic.

This change:
- adds the new error kind `CollectionBaseNotVariable`, mapped to the `TE_UT`;
- reports the actual base expression in the diagnostic;
- uses it for single-field reads, multi-field reads, and the corresponding multi-field assignment path;
- adds matching `TypeError(TE_UT)` cases to `asl.spec`;
- adds a new regression test using a conditional expression as a collection base.

### Mismatched bitvector widths (`TE_UT`)
The specification reports unequal bitvector widths as `TE_UT`. The implementation raised the uncoded `UnreconcilableTypes` diagnostic, which incorrectly described the failure as a missing common ancestor.

This change:
- adds the new error kind `MismatchedBitvectorWidths`;
- maps it to the existing `TE_UT` code;
- uses it in `check_bits_equal_width`;
- removes the redundant `TE_BO` check following `check_bits_equal_width` in the single-pattern specification rule.

### Overlapping implementations (`TE_OE`)
The OCaml implementation reports overlapping `implementation` subprograms as `TE_OE`, while the corresponding specification check previously produced a generic type error without a code.

This change:
- adds an explicit `TE_OE` check to `check_implementations_unique`;
- fixes `signatures_match` to return its calculated result rather than always returning `True`.

Updated the console outputs in `ErrorCodes.tex`.