### PR TITLE
[litmus] Add RISC-V timebase.c

### DIFF
--- a/litmus/libdir/_riscv/timebase.c
+++ b/litmus/libdir/_riscv/timebase.c
@@ -1,0 +1,20 @@
+/****************************************************************************/
+/*                           the diy toolsuite                              */
+/*                                                                          */
+/* Jade Alglave, University College London, UK.                             */
+/* Luc Maranget, INRIA Paris-Rocquencourt, France.                          */
+/*                                                                          */
+/* Copyright 2026-present Institut National de Recherche en Informatique et */
+/* en Automatique and the authors. All rights reserved.                     */
+/*                                                                          */
+/* This software is governed by the CeCILL-B license under French law and   */
+/* abiding by the rules of distribution of free software. You can use,      */
+/* modify and/ or redistribute the software under the terms of the CeCILL-B */
+/* license as circulated by CEA, CNRS and INRIA at the following URL        */
+/* "http://www.cecill.info". We also give a copy in LICENSE.txt.            */
+/****************************************************************************/
+inline static tb_t read_timebase(void) {
+  tb_t r;
+  asm __volatile__ ("rdtime %[r1]" :[r1] "=r" (r) : : "memory");
+  return r;
+}


### PR DESCRIPTION
`litmus7 -barrier timebase` failed on RISC-V (`No timebase for arch RISCV`).

Add `litmus/libdir/_riscv/timebase.c`, same `read_timebase()` as `_x86` / `_ppc`.
Uses `rdtime` (shared), not `rdcycle`.

```
litmus7 -set-libdir litmus/libdir -mode presi -barrier timebase \
  -alloc static -stdio false -a 2 -o /tmp/ht-yes MP.litmus
```