### PR TITLE
Aligning implementation/specification error codes - phase 2/5

### DIFF
--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -88,24 +88,22 @@ let check_is_associative ~loc (op : AST.binop) =
   | _ ->
       Error.(
         fatal_from loc
-          (CannotParse
-             (Some
-                (Format.sprintf
-                   "Binary operator `%s` is not associative - parenthesise to \
-                    disambiguate."
-                   (PP.binop_to_string op)))))
+          (BadBinopPriority
+             (Format.sprintf
+                "Binary operator `%s` is not associative - parenthesise to \
+                 disambiguate."
+                (PP.binop_to_string op))))
 
 
 let check_not_same_prec loc op op' =
   if prec op = prec op' then
     Error.(
       fatal_from loc
-        (CannotParse
-           (Some
-              (Format.sprintf
-                 "Operators `%s` and `%s` have the same priority - parenthesise \
-                  to disambiguate."
-                 (PP.binop_to_string op) (PP.binop_to_string op')))))
+        (BadBinopPriority
+           (Format.sprintf
+              "Operators `%s` and `%s` have the same priority - parenthesise \
+               to disambiguate."
+              (PP.binop_to_string op) (PP.binop_to_string op'))))
 
 let check_not_binop_same_prec op e =
   match e.desc with

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -477,8 +477,7 @@ let decl_item :=
   | vs=plist2(discard_or_identifier) ; {
       if List.for_all is_local_ignored vs then
         Error.fatal_here $startpos $endpos @@
-          Error.BadDeclarationSyntax
-            "A local declaration must declare at least one name."
+          Error.AllDiscardLocalDeclaration
       else LDI_Tuple vs
     }
 

--- a/asllib/Parser.mly
+++ b/asllib/Parser.mly
@@ -477,7 +477,8 @@ let decl_item :=
   | vs=plist2(discard_or_identifier) ; {
       if List.for_all is_local_ignored vs then
         Error.fatal_here $startpos $endpos @@
-          Error.CannotParse (Some "A local declaration must declare at least one name.")
+          Error.BadDeclarationSyntax
+            "A local declaration must declare at least one name."
       else LDI_Tuple vs
     }
 

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -2188,7 +2188,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                     E_GetItem (e2, index) |> add_pos_from ~loc:e,
                     ses1 )
                 else
-                  fatal_from ~loc (Error.BadField (field_name, t_e2))
+                  fatal_from ~loc
+                    (Error.BadTupleIndex { index; length = List.length tys })
                   |: TypingRule.EGetTupleItem
             (* End *)
             (* Begin EGetBadField *)

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -39,9 +39,6 @@ let add_pos_from ~loc = add_pos_from loc
 let conflict ~loc expected provided =
   fatal_from ~loc (Error.ConflictingTypes (expected, provided))
 
-let type_satisfaction_failure ~loc expected provided =
-  fatal_from ~loc (Error.TypeSatisfactionFailure (expected, provided))
-
 let plus e1 e2 = binop `ADD e1 e2
 let minus e1 e2 = binop `SUB e1 e2
 let t_bits_bitwidth e = T_Bits (e, [])
@@ -581,7 +578,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         Format.eprintf "@[<hv 2>Checking %a@ <: %a@]@." PP.pp_ty t1 PP.pp_ty t2
     in
     if Types.type_satisfies env t1 t2 then ()
-    else type_satisfaction_failure ~loc [ t2.desc ] t1
+    else
+      fatal_from ~loc
+        (Error.TypeSatisfactionFailure { expected = t2; provided = t1 })
 
   (* CheckStructureBoolean *)
 
@@ -2751,8 +2750,11 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     | _ -> Types.type_satisfies env t s
 
   let check_can_be_initialized_with ~loc env s t () =
-    if can_be_initialized_with env s t then ()
-    else type_satisfaction_failure ~loc [ s.desc ] t
+    if can_be_initialized_with env s t then
+      () |: TypingRule.CheckCanBeInitialisedWith
+    else
+      fatal_from ~loc
+        (Error.TypeSatisfactionFailure { expected = s; provided = t })
   (* End *)
 
   (* Begin ShouldRememberImmutableExpression *)

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -39,6 +39,9 @@ let add_pos_from ~loc = add_pos_from loc
 let conflict ~loc expected provided =
   fatal_from ~loc (Error.ConflictingTypes (expected, provided))
 
+let type_satisfaction_failure ~loc expected provided =
+  fatal_from ~loc (Error.TypeSatisfactionFailure (expected, provided))
+
 let plus e1 e2 = binop `ADD e1 e2
 let minus e1 e2 = binop `SUB e1 e2
 let t_bits_bitwidth e = T_Bits (e, [])
@@ -577,7 +580,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       if false then
         Format.eprintf "@[<hv 2>Checking %a@ <: %a@]@." PP.pp_ty t1 PP.pp_ty t2
     in
-    if Types.type_satisfies env t1 t2 then () else conflict ~loc [ t2.desc ] t1
+    if Types.type_satisfies env t1 t2 then ()
+    else type_satisfaction_failure ~loc [ t2.desc ] t1
 
   (* CheckStructureBoolean *)
 
@@ -2746,7 +2750,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     | _ -> Types.type_satisfies env t s
 
   let check_can_be_initialized_with ~loc env s t () =
-    if can_be_initialized_with env s t then () else conflict ~loc [ s.desc ] t
+    if can_be_initialized_with env s t then ()
+    else type_satisfaction_failure ~loc [ s.desc ] t
   (* End *)
 
   (* Begin ShouldRememberImmutableExpression *)

--- a/asllib/builder.ml
+++ b/asllib/builder.ml
@@ -140,15 +140,8 @@ let make_builtin d =
   let open AST in
   match d.desc with
   | D_Func f -> D_Func { f with builtin = true } |> ASTUtils.add_pos_from d
-  | D_TypeDecl _ ->
-      prerr_string "Type declaration cannot be builtin";
-      exit 1
-  | D_GlobalStorage _ ->
-      prerr_string "Storage declaration cannot be builtin";
-      exit 1
-  | D_Pragma _ ->
-      prerr_string "Pragma declaration cannot be builtin";
-      exit 1
+  | D_TypeDecl _ | D_GlobalStorage _ | D_Pragma _ ->
+      Error.fatal_from d Error.NonFunctionBuiltinDeclaration
 
 let stdlib =
   let filename = "ASL Standard Library" and ast_string = Asl_stdlib.stdlib in

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -213,8 +213,9 @@ The following table summarises all error codes.
   \hypertarget{def-buildbaddeclaration}{}
   \item[$\BuildBadDeclaration$]
     \textit{Bad declaration.}
-    A top-level declaration is invalid.
-    For example, the standard library defines a non-subprogram (\ASTRuleRef{SetBuiltin}).
+    A declaration is invalid.
+    For example, a local tuple declaration discards every item (\ASTRuleRef{DeclItem}),
+    or the standard library defines a non-subprogram (\ASTRuleRef{SetBuiltin}).
 \end{description}
 
 \section{Type Errors\label{sec:TypingErrors}}

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -247,6 +247,8 @@ The following table summarises all error codes.
 \item[$\TypeSatisfactionFailure$]
   \textit{Type satisfaction failure.}
   See \TypingRuleRef{TypeSatisfaction}.
+  For example, a value of \booleantypeterm{} is assigned to a variable of \integertypeterm{}
+  (See \TypingRuleRef{CheckCanBeInitializedWith}).
 
 \hypertarget{def-staticevaluationfailure}{}
 \item[$\StaticEvaluationFailure$]

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -31,6 +31,7 @@ type error_desc =
   | BadField of string * ty
   | MissingField of string list * ty
   | BadSlices of error_handling_time * slice list * int
+  | BadTupleIndex of { index : int; length : int }
   | BadSlice of slice
   | EmptySlice
   | TypeInferenceNeeded
@@ -250,6 +251,7 @@ module ErrorCode = struct
     | UnknownSymbol _ -> Some (Build LE)
     | ObsoleteSyntax _ -> Some (Build PE)
     | BadField _ | MissingField _ -> Some (Typing BF)
+    | BadTupleIndex _ -> Some (Typing BTI)
     | BadPattern _ | BadTypesForBinop _
     | UnsupportedUnop (Static, _, _)
     | UnsupportedBinop (Static, _, _, _) ->
@@ -417,7 +419,6 @@ end
 (* TODO: BE_RI unused in reference *)
 (* TODO: following not recoverable from implementation:
 - TE_SEF
-- TE_BTI
 - DE_TAF
 - DE_BI
 *)
@@ -516,6 +517,9 @@ module PPrint = struct
           (ErrorKind.of_error_handling_time t)
           "Cannot extract from bitvector of length %d slice %a." length
           pp_slice_list slices
+    | BadTupleIndex { index; length } ->
+        pp_err Typing "Tuple index %d is outside the valid range 0..%d." index
+          (length - 1)
     | BadSlice slice -> pp_err Static "invalid slice %a." pp_slice slice
     | TypeInferenceNeeded ->
         pp_err Internal "Interpreter blocked. Type inference needed."
@@ -827,6 +831,7 @@ module CSV = struct
     | BadPattern _ -> "BadPattern"
     | MissingField _ -> "MissingField"
     | BadSlices _ -> "BadSlices"
+    | BadTupleIndex _ -> "BadTupleIndex"
     | BadSlice _ -> "BadSlice"
     | EmptySlice -> "EmptySlice"
     | TypeInferenceNeeded -> "TypeInferenceNeeded"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -50,11 +50,12 @@ type error_desc =
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
   | ConflictingTypes of type_desc list * ty
-  | TypeSatisfactionFailure of type_desc list * ty
+  | TypeSatisfactionFailure of { expected : ty; provided : ty }
   | AssertionFailed of error_handling_time * expr
   | CannotParse of string option
   | BadBinopPriority of string
-  | BadDeclarationSyntax of string
+  | AllDiscardLocalDeclaration
+  | NonFunctionBuiltinDeclaration
   | UnknownSymbol of string
   | NoCallCandidate of string * ty list
   | BadTypesForBinop of binop * ty * ty
@@ -247,7 +248,8 @@ module ErrorCode = struct
     (********** Errors that correspond to error codes **********)
     | ReservedIdentifier _ -> Some (Build RI)
     | BadBinopPriority _ -> Some (Build BOP)
-    | BadDeclarationSyntax _ -> Some (Build BD)
+    | AllDiscardLocalDeclaration | NonFunctionBuiltinDeclaration ->
+        Some (Build BD)
     | UnknownSymbol _ -> Some (Build LE)
     | ObsoleteSyntax _ -> Some (Build PE)
     | BadField _ | MissingField _ -> Some (Typing BF)
@@ -562,15 +564,16 @@ module PPrint = struct
               "Arity error while calling '%s':@ %d parameters expected and %d \
                provided"
               name expected provided)
-    | ConflictingTypes ([ expected ], provided)
-    | TypeSatisfactionFailure ([ expected ], provided) ->
+    | ConflictingTypes ([ expected ], provided) ->
         pp_err Typing "a subtype of@ %a@ was expected,@ provided %a."
           pp_type_desc expected pp_ty provided
-    | ConflictingTypes (expected, provided)
-    | TypeSatisfactionFailure (expected, provided) ->
+    | ConflictingTypes (expected, provided) ->
         pp_err Typing "%a does@ not@ subtype@ any@ of:@ %a." pp_ty provided
           (pp_comma_list pp_type_desc)
           expected
+    | TypeSatisfactionFailure { expected; provided } ->
+        pp_err Typing "a subtype of@ %a@ was expected,@ provided %a." pp_ty
+          expected pp_ty provided
     | AssertionFailed (t, e) ->
         pp_err
           (ErrorKind.of_error_handling_time t)
@@ -580,7 +583,11 @@ module PPrint = struct
         | None -> pp_err Parse "Cannot parse."
         | Some s -> pp_err Parse "Cannot parse.@ %a" pp_print_text s)
     | BadBinopPriority message -> pp_err Parse "%a" pp_print_text message
-    | BadDeclarationSyntax message -> pp_err Parse "%a" pp_print_text message
+    | AllDiscardLocalDeclaration ->
+        pp_err Parse "%a" pp_print_text
+          "A local declaration must declare at least one name."
+    | NonFunctionBuiltinDeclaration ->
+        pp_err Parse "Only subprogram declarations may be marked as builtins."
     | UnknownSymbol s ->
         let codes = List.map Char.code (List.of_seq (String.to_seq s)) in
         let not_printable code = code < 33 || code > 126 in
@@ -850,7 +857,8 @@ module CSV = struct
     | AssertionFailed _ -> "AssertionFailed"
     | CannotParse _ -> "CannotParse"
     | BadBinopPriority _ -> "BadBinopPriority"
-    | BadDeclarationSyntax _ -> "BadDeclarationSyntax"
+    | AllDiscardLocalDeclaration -> "AllDiscardLocalDeclaration"
+    | NonFunctionBuiltinDeclaration -> "NonFunctionBuiltinDeclaration"
     | UnknownSymbol _ -> "UnknownSymbol"
     | NoCallCandidate _ -> "NoCallCandidate"
     | BadTypesForBinop _ -> "BadTypesForBinop"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -52,6 +52,7 @@ type error_desc =
   | AssertionFailed of error_handling_time * expr
   | CannotParse of string option
   | BadBinopPriority of string
+  | BadDeclarationSyntax of string
   | UnknownSymbol of string
   | NoCallCandidate of string * ty list
   | BadTypesForBinop of binop * ty * ty
@@ -244,6 +245,7 @@ module ErrorCode = struct
     (********** Errors that correspond to error codes **********)
     | ReservedIdentifier _ -> Some (Build RI)
     | BadBinopPriority _ -> Some (Build BOP)
+    | BadDeclarationSyntax _ -> Some (Build BD)
     | UnknownSymbol _ -> Some (Build LE)
     | ObsoleteSyntax _ -> Some (Build PE)
     | BadField _ | MissingField _ -> Some (Typing BF)
@@ -412,7 +414,6 @@ end
     - TypingRule.TInt mismatch on empty case *)
 (* TODO: BE_RI unused in reference *)
 (* TODO: following not recoverable from implementation:
-- BE_BD
 - TE_TSF
 - TE_LCA
 - TE_SEF
@@ -573,6 +574,7 @@ module PPrint = struct
         | None -> pp_err Parse "Cannot parse."
         | Some s -> pp_err Parse "Cannot parse.@ %a" pp_print_text s)
     | BadBinopPriority message -> pp_err Parse "%a" pp_print_text message
+    | BadDeclarationSyntax message -> pp_err Parse "%a" pp_print_text message
     | UnknownSymbol s ->
         let codes = List.map Char.code (List.of_seq (String.to_seq s)) in
         let not_printable code = code < 33 || code > 126 in
@@ -840,6 +842,7 @@ module CSV = struct
     | AssertionFailed _ -> "AssertionFailed"
     | CannotParse _ -> "CannotParse"
     | BadBinopPriority _ -> "BadBinopPriority"
+    | BadDeclarationSyntax _ -> "BadDeclarationSyntax"
     | UnknownSymbol _ -> "UnknownSymbol"
     | NoCallCandidate _ -> "NoCallCandidate"
     | BadTypesForBinop _ -> "BadTypesForBinop"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -51,6 +51,7 @@ type error_desc =
   | ConflictingTypes of type_desc list * ty
   | AssertionFailed of error_handling_time * expr
   | CannotParse of string option
+  | BadBinopPriority of string
   | UnknownSymbol of string
   | NoCallCandidate of string * ty list
   | BadTypesForBinop of binop * ty * ty
@@ -242,6 +243,7 @@ module ErrorCode = struct
     match e.desc with
     (********** Errors that correspond to error codes **********)
     | ReservedIdentifier _ -> Some (Build RI)
+    | BadBinopPriority _ -> Some (Build BOP)
     | UnknownSymbol _ -> Some (Build LE)
     | ObsoleteSyntax _ -> Some (Build PE)
     | BadField _ | MissingField _ -> Some (Typing BF)
@@ -410,7 +412,6 @@ end
     - TypingRule.TInt mismatch on empty case *)
 (* TODO: BE_RI unused in reference *)
 (* TODO: following not recoverable from implementation:
-- BE_BOP
 - BE_BD
 - TE_TSF
 - TE_LCA
@@ -571,6 +572,7 @@ module PPrint = struct
         match s with
         | None -> pp_err Parse "Cannot parse."
         | Some s -> pp_err Parse "Cannot parse.@ %a" pp_print_text s)
+    | BadBinopPriority message -> pp_err Parse "%a" pp_print_text message
     | UnknownSymbol s ->
         let codes = List.map Char.code (List.of_seq (String.to_seq s)) in
         let not_printable code = code < 33 || code > 126 in
@@ -837,6 +839,7 @@ module CSV = struct
     | ConflictingTypes _ -> "ConflictingTypes"
     | AssertionFailed _ -> "AssertionFailed"
     | CannotParse _ -> "CannotParse"
+    | BadBinopPriority _ -> "BadBinopPriority"
     | UnknownSymbol _ -> "UnknownSymbol"
     | NoCallCandidate _ -> "NoCallCandidate"
     | BadTypesForBinop _ -> "BadTypesForBinop"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -416,7 +416,6 @@ end
     - TypingRule.TInt mismatch on empty case *)
 (* TODO: BE_RI unused in reference *)
 (* TODO: following not recoverable from implementation:
-- TE_LCA
 - TE_SEF
 - TE_BTI
 - DE_TAF

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -49,6 +49,7 @@ type error_desc =
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
   | ConflictingTypes of type_desc list * ty
+  | TypeSatisfactionFailure of type_desc list * ty
   | AssertionFailed of error_handling_time * expr
   | CannotParse of string option
   | BadBinopPriority of string
@@ -259,6 +260,7 @@ module ErrorCode = struct
     | BitfieldsDontAlign _ ->
         Some (Typing BS) (* TODO: consider combining BadSlices and BadSlice *)
     | UndefinedIdentifier (Static, _) -> Some (Typing UI)
+    | TypeSatisfactionFailure _ -> Some (Typing TSF)
     | ConflictingTypes _ | AssignToTupleElement _ | ConstrainedIntegerExpected _
     | UnexpectedPendingConstrained | ExpectedSingularType _
     | ExpectedNamedType _ | UnexpectedCollection | MismatchedBitvectorWidths _
@@ -414,7 +416,6 @@ end
     - TypingRule.TInt mismatch on empty case *)
 (* TODO: BE_RI unused in reference *)
 (* TODO: following not recoverable from implementation:
-- TE_TSF
 - TE_LCA
 - TE_SEF
 - TE_BTI
@@ -558,10 +559,12 @@ module PPrint = struct
               "Arity error while calling '%s':@ %d parameters expected and %d \
                provided"
               name expected provided)
-    | ConflictingTypes ([ expected ], provided) ->
+    | ConflictingTypes ([ expected ], provided)
+    | TypeSatisfactionFailure ([ expected ], provided) ->
         pp_err Typing "a subtype of@ %a@ was expected,@ provided %a."
           pp_type_desc expected pp_ty provided
-    | ConflictingTypes (expected, provided) ->
+    | ConflictingTypes (expected, provided)
+    | TypeSatisfactionFailure (expected, provided) ->
         pp_err Typing "%a does@ not@ subtype@ any@ of:@ %a." pp_ty provided
           (pp_comma_list pp_type_desc)
           expected
@@ -839,6 +842,7 @@ module CSV = struct
     | InvalidExpr _ -> "InvalidExpr"
     | MismatchType _ -> "MismatchType"
     | ConflictingTypes _ -> "ConflictingTypes"
+    | TypeSatisfactionFailure _ -> "TypeSatisfactionFailure"
     | AssertionFailed _ -> "AssertionFailed"
     | CannotParse _ -> "CannotParse"
     | BadBinopPriority _ -> "BadBinopPriority"

--- a/asllib/instrumentation.ml
+++ b/asllib/instrumentation.ml
@@ -323,6 +323,7 @@ module TypingRule = struct
     | Domain
     | SubtypeSatisfaction
     | TypeSatisfaction
+    | CheckCanBeInitialisedWith
     | TypeClash
     | LowestCommonAncestor
     | ApplyUnopType
@@ -505,6 +506,7 @@ module TypingRule = struct
     | Structure -> "Structure"
     | SubtypeSatisfaction -> "SubtypeSatisfaction"
     | TypeSatisfaction -> "TypeSatisfaction"
+    | CheckCanBeInitialisedWith -> "CheckCanBeInitialisedWith"
     | TypeClash -> "TypeClash"
     | ApplyUnopType -> "ApplyUnopType"
     | ApplyBinopTypes -> "ApplyBinopTypes"

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -98,7 +98,7 @@ Examples used in ASL High-level Definition:
   File GuideRule.TupleElementAccess.bad.asl, line 5, characters 18 to 25:
       x = (x.item1, x.item2);
                     ^^^^^^^
-  ASL Type error (TE_BF): There is no field 'item2' on type (integer, integer).
+  ASL Type error (TE_BTI): Tuple index 2 is outside the valid range 0..1.
   [1]
   $ aslref GuideRule.AnonymousEnumerations.bad.asl
   File GuideRule.AnonymousEnumerations.bad.asl, line 4, characters 12 to 23:

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -128,7 +128,7 @@ Examples used in ASL High-level Definition:
   File NamedTypes.bad.asl, line 8, characters 4 to 5:
       b = K; // Illegal: a Char cannot be directly assigned to a Byte
       ^
-  ASL Type error (TE_UT): a subtype of Byte was expected, provided Char.
+  ASL Type error (TE_TSF): a subtype of Byte was expected, provided Char.
   [1]
   $ aslref --no-exec GuideRule.GlobalStorageCycles.bad1.asl
   File GuideRule.GlobalStorageCycles.bad1.asl, line 4, characters 0 to 10:
@@ -182,14 +182,14 @@ Examples used in ASL High-level Definition:
   File ConstrainedIntegers.bad.asl, line 7, characters 4 to 5:
       B = A; // illegal: {2,4,8} is not a subset of {2,4}.
       ^
-  ASL Type error (TE_UT): a subtype of integer {2, 4} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {2, 4} was expected,
     provided integer {2, 4, 8}.
   [1]
   $ aslref --no-exec ConstrainedIntegers.bad2.asl
   File ConstrainedIntegers.bad2.asl, line 8, characters 4 to 10:
       myIntA = myIntB; // Illegal even though at this point
       ^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {1..10} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {1..10} was expected,
     provided integer {0..20}.
   [1]
   $ aslref --no-exec PrimitiveOperations.asl

--- a/asllib/tests/ASLSyntaxReference.t/run.t
+++ b/asllib/tests/ASLSyntaxReference.t/run.t
@@ -38,35 +38,35 @@ Examples used to test syntax and AST building rules:
   File ASTRule.EBinop.bad1.asl, line 6, characters 20 to 25:
           let p_a_s = a + b - c;
                       ^^^^^
-  ASL Grammar error: Cannot parse. Operators `-` and `+` have the same priority
-    - parenthesise to disambiguate.
+  ASL Grammar error (BE_BOP): Operators `-` and `+` have the same priority -
+    parenthesise to disambiguate.
   [1]
   $ aslref ASTRule.EBinop.bad2.asl
   File ASTRule.EBinop.bad2.asl, line 6, characters 20 to 25:
           let p_s_a = a - b + c;
                       ^^^^^
-  ASL Grammar error: Cannot parse. Operators `+` and `-` have the same priority
-    - parenthesise to disambiguate.
+  ASL Grammar error (BE_BOP): Operators `+` and `-` have the same priority -
+    parenthesise to disambiguate.
   [1]
   $ aslref ASTRule.EBinop.bad3.asl
   File ASTRule.EBinop.bad3.asl, line 6, characters 23 to 30:
           let p_and_or = d AND e OR f;
                          ^^^^^^^
-  ASL Grammar error: Cannot parse. Operators `OR` and `AND` have the same
-    priority - parenthesise to disambiguate.
+  ASL Grammar error (BE_BOP): Operators `OR` and `AND` have the same priority -
+    parenthesise to disambiguate.
   [1]
   $ aslref ASTRule.EBinop.bad4.asl
   File ASTRule.EBinop.bad4.asl, line 6, characters 22 to 28:
           let p_eq_eq = a == b != g;
                         ^^^^^^
-  ASL Grammar error: Cannot parse. Operators `!=` and `==` have the same
-    priority - parenthesise to disambiguate.
+  ASL Grammar error (BE_BOP): Operators `!=` and `==` have the same priority -
+    parenthesise to disambiguate.
   [1]
   $ aslref ASTRule.EBinop.bad5.asl
   File ASTRule.EBinop.bad5.asl, line 6, characters 24 to 29:
           let p_sub_sub = a - b - c;
                           ^^^^^
-  ASL Grammar error: Cannot parse. Binary operator `-` is not associative -
+  ASL Grammar error (BE_BOP): Binary operator `-` is not associative -
     parenthesise to disambiguate.
   [1]
   $ aslref CaseStatement.bad.asl

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -9,21 +9,21 @@ ASL Typing Tests:
   File TypingRule.SubtypeSatisfaction3.asl, line 8, characters 4 to 45:
       var dogLegs : AnimalLegs = myCircleSides; // illegal: unrelated types
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of AnimalLegs was expected,
+  ASL Type error (TE_TSF): a subtype of AnimalLegs was expected,
     provided ShapeSides.
   [1]
   $ aslref TypingRule.SubtypeSatisfaction.bad1.asl
   File TypingRule.SubtypeSatisfaction.bad1.asl, line 8, characters 0 to 31:
   var x : integer{Int12} = Int12;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {2} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {2} was expected,
     provided integer {1..2}.
   [1]
   $ aslref TypingRule.SubtypeSatisfaction.bad2.asl
   File TypingRule.SubtypeSatisfaction.bad2.asl, line 7, characters 4 to 13:
       return N;
       ^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {N} was expected,
     provided integer {2, 4}.
   [1]
   $ aslref TypingRule.TypeSatisfaction1.asl
@@ -32,7 +32,7 @@ ASL Typing Tests:
   File TypingRule.TypeSatisfaction3.asl, line 14, characters 2 to 6:
     pair = (1, dataT2);
     ^^^^
-  ASL Type error (TE_UT): a subtype of pairT was expected,
+  ASL Type error (TE_TSF): a subtype of pairT was expected,
     provided (integer {1}, T2).
   [1]
   $ aslref TypingRule.TypeSatisfaction.bad1.asl
@@ -120,13 +120,13 @@ ASL Typing Tests / annotating types:
   File TypingRule.TNamed.bad1.asl, line 11, characters 4 to 13:
       foo(x.f); // Illegal: x.f is of type TypeB which does not type-satisfy TypeA.
       ^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of TypeA was expected, provided TypeB.
+  ASL Type error (TE_TSF): a subtype of TypeA was expected, provided TypeB.
   [1]
   $ aslref TypingRule.TNamed.bad2.asl
   File TypingRule.TNamed.bad2.asl, line 12, characters 4 to 13:
       foo(y.f); // illegal: y.f is of type TypeB which does not type-satisfy TypeA.
       ^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of TypeA was expected, provided TypeB.
+  ASL Type error (TE_TSF): a subtype of TypeA was expected, provided TypeB.
   [1]
   $ aslref TypingRule.TIntUnconstrained.asl
   $ aslref TypingRule.TIntWellConstrained.asl
@@ -241,7 +241,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.ConstraintMod.bad.asl, line 9, characters 4 to 5:
       z = 3; // Illegal: the type inferred for z is integer{0..2}
       ^
-  ASL Type error (TE_UT): a subtype of integer {0..2} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..2} was expected,
     provided integer {3}.
   [1]
   $ aslref --no-exec TypingRule.CheckConstrainedInteger.asl
@@ -644,7 +644,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.PMask.bad.asl, line 5, characters 11 to 34:
       assert '101010' IN {'xx10101'};
              ^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(7) was expected, provided bits(6).
+  ASL Type error (TE_TSF): a subtype of bits(7) was expected, provided bits(6).
   [1]
   $ aslref TypingRule.PAny.asl
   $ aslref TypingRule.PAny.bad.asl
@@ -924,7 +924,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateCall.bad.asl, line 6, characters 4 to 21:
       f{wid}(bus, bus); // Illegal
       ^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {2, 4} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {2, 4} was expected,
     provided integer {2, 4, 8}.
   [1]
   $ aslref TypingRule.AnnotateCall.bad2.asl
@@ -937,14 +937,14 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateCall.bad3.asl, line 9, characters 11 to 32:
       return constrained_func{N}();
              ^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {1, 2, 3} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {1, 2, 3} was expected,
     provided integer {2, 3, 4}.
   [1]
   $ aslref TypingRule.AnnotateCall.bad4.asl
   File TypingRule.AnnotateCall.bad4.asl, line 9, characters 11 to 32:
       return constrained_func{N}(); // requires an asserting type conversion
              ^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {1, 2, 3} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {1, 2, 3} was expected,
     provided integer {N}.
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad1.asl
@@ -968,7 +968,7 @@ ASL Typing Tests / annotating types:
     characters 8 to 24:
       - = plus{64}(bv1, w);
           ^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..64} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..64} was expected,
     provided integer {0..128}.
   [1]
   $ aslref TypingRule.AnnotateCallActualsTyped.bad4.asl
@@ -1029,7 +1029,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.RenameSubprograms.asl, line 3, characters 2 to 11:
     return 1;
     ^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of boolean was expected,
+  ASL Type error (TE_TSF): a subtype of boolean was expected,
     provided integer {1}.
   [1]
   $ aslref TypingRule.ApproxConstraint.asl
@@ -1043,7 +1043,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.BitFieldEqual.bad1.asl, line 4, characters 4 to 71:
       var x : bits(64) { [1] data } = Zeros{64} as bits(64) { [2] data };
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits (64) { [1+:1] data } was expected,
+  ASL Type error (TE_TSF): a subtype of bits (64) { [1+:1] data } was expected,
     provided bits (64) { [2+:1] data }.
   [1]
   $ aslref TypingRule.BitFieldEqual.bad2.asl
@@ -1051,7 +1051,7 @@ ASL Typing Tests / annotating types:
     character 43:
       var x : bits(64) { [16+:16] data { [0] lsb } } =  Zeros{64} as
               bits(64) { [31:16] data {  } };
-  ASL Type error (TE_UT): a subtype of
+  ASL Type error (TE_TSF): a subtype of
     bits (64) { [16+:16] data { [0+:1] lsb } } was expected,
     provided bits (64) { [16+:16] data {  } }.
   [1]
@@ -1068,7 +1068,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.ReduceConstraint.asl, line 6, characters 4 to 67:
       var x : integer{3 * w, 0..(5 * z - z) - 2 * z,  w + z} = w + z;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..(2 * z), (z + w), (3 * w)}
+  ASL Type error (TE_TSF): a subtype of integer {0..(2 * z), (z + w), (3 * w)}
     was expected, provided integer {0..2000}.
   [1]
   $ aslref TypingRule.ConstraintEqual.asl
@@ -1085,7 +1085,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.ApproxBottomTop.asl, line 5, characters 4 to 30:
       var x : integer{a..b} = a;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {a..b} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {a..b} was expected,
     provided integer {1..10}.
   [1]
   $ aslref TypingRule.SymdomOfWidthExpr.asl
@@ -1095,7 +1095,7 @@ ASL Typing Tests / annotating types:
     characters 4 to 33:
       let t: integer{x..x + 1} = 2;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {x..(x + 1)} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {x..(x + 1)} was expected,
     provided integer {2}.
   [1]
   $ aslref --no-exec TypingRule.AddGlobalImmutableExpr.asl
@@ -1142,7 +1142,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.MemBfs.bad.asl, line 9, characters 4 to 44:
       var x : bits(8) {[0] flag, [1] lsb} = y;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits (8) { [0+:1] flag, [1+:1] lsb }
+  ASL Type error (TE_TSF): a subtype of bits (8) { [0+:1] flag, [1+:1] lsb }
     was expected, provided FlaggedPacket.
   [1]
   $ aslref --no-exec TypingRule.IntervalTooLarge.asl
@@ -1197,7 +1197,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.ESlice.bad1.asl, line 10, characters 4 to 7:
       dst = src[w:1];
       ^^^
-  ASL Type error (TE_UT): a subtype of bits((k - 1)) was expected,
+  ASL Type error (TE_TSF): a subtype of bits((k - 1)) was expected,
     provided bits(w).
   [1]
   $ aslref TypingRule.ESlice.bad2.asl
@@ -1227,7 +1227,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AddNewFunc.bad2.asl, line 18, characters 4 to 21:
       g(myCircle, 0.1); // illegal
       ^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of square was expected, provided circle.
+  ASL Type error (TE_TSF): a subtype of square was expected, provided circle.
   [1]
   $ aslref --no-exec TypingRule.AddNewFunc.bad3.asl
   File TypingRule.AddNewFunc.bad3.asl, line 8, character 0 to line 11,

--- a/asllib/tests/constraint-size-limits.t/run.t
+++ b/asllib/tests/constraint-size-limits.t/run.t
@@ -3,7 +3,7 @@
   File constraint-mul-00.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error (TE_UT): a subtype of integer {0..4, 6, 8..9, 12, 16}
+  ASL Type error (TE_TSF): a subtype of integer {0..4, 6, 8..9, 12, 16}
     was expected, provided integer {15}.
   [1]
 
@@ -11,7 +11,7 @@
   File constraint-mul-01.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error (TE_UT): a subtype of
+  ASL Type error (TE_TSF): a subtype of
     integer {0..16, 18, 20..22, 24..28, 30, 32..33, 35..36, 39..40, 42, 
              44..45, ...} was expected, provided integer {255}.
   [1]
@@ -20,7 +20,7 @@
   File constraint-mul-02.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error (TE_UT): a subtype of
+  ASL Type error (TE_TSF): a subtype of
     integer {0..36, 38..40, 42, 44..46, 48..52, 54..58, 60, 62..66, 68..70, 72,
              ...} was expected, provided integer {1023}.
   [1]
@@ -29,7 +29,7 @@
   File constraint-mul-03.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error (TE_UT): a subtype of
+  ASL Type error (TE_TSF): a subtype of
     integer {0..66, 68..70, 72, 74..78, 80..82, 84..88, 90..96, 98..100, 102,
              104..106, ...} was expected, provided integer {4095}.
   [1]
@@ -38,7 +38,7 @@
   File constraint-mul-04.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error (TE_UT): a subtype of
+  ASL Type error (TE_TSF): a subtype of
     integer {0..130, 132..136, 138, 140..148, 150, 152..156, 158..162,
              164..166, 168..172, 174..178, ...} was expected,
     provided integer {16383}.
@@ -48,7 +48,7 @@
   File constraint-mul-05.asl, line 10, characters 4 to 6:
       b1 = (A * B) - 1; // Test if discrete or interval representation
       ^^
-  ASL Type error (TE_UT): a subtype of
+  ASL Type error (TE_TSF): a subtype of
     integer {0..256, 258..262, 264..268, 270, 272..276, 278..280, 282,
              284..292, 294..306, 308..310, ...} was expected,
     provided integer {65535}.

--- a/asllib/tests/division.t/run.t
+++ b/asllib/tests/division.t/run.t
@@ -175,7 +175,7 @@ Other example from typing.t:
   File TNegative9-1.asl, line 3, characters 4 to 59:
       let testB : bits(N) = Zeros{N DIV 4} :: Zeros{N DIV 2}; // bits(3N/4) != bits(N)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(N) was expected,
+  ASL Type error (TE_TSF): a subtype of bits(N) was expected,
     provided bits(((3 * N) DIV 4)).
   [1]
   $ aslref --no-exec TPositive9.asl

--- a/asllib/tests/lca.t
+++ b/asllib/tests/lca.t
@@ -12,7 +12,7 @@
   File lca1.asl, line 6, characters 2 to 18:
     let c: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of real was expected,
+  ASL Type error (TE_TSF): a subtype of real was expected,
     provided integer {2, 3}.
   [1]
 
@@ -29,7 +29,7 @@
   File lca2.asl, line 5, characters 2 to 28:
     let b: integer {2, 3} = x;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {2, 3} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {2, 3} was expected,
     provided integer.
   [1]
 
@@ -46,7 +46,7 @@
   File lca3.asl, line 5, characters 2 to 25:
     let b: integer {N} = x;
     ^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {N} was expected,
     provided integer {3, N}.
   [1]
 
@@ -62,7 +62,7 @@
   File lca4.asl, line 4, characters 2 to 18:
     let a: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of real was expected,
+  ASL Type error (TE_TSF): a subtype of real was expected,
     provided integer {0..N, 3}.
   [1]
 
@@ -96,7 +96,7 @@
   File lca6.asl, line 7, characters 2 to 18:
     let a: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of real was expected, provided integer.
+  ASL Type error (TE_TSF): a subtype of real was expected, provided integer.
   [1]
 
   $ cat >lca7.asl <<EOF
@@ -129,7 +129,7 @@
   File lca8.asl, line 5, characters 2 to 18:
     let a: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of real was expected, provided bits(3).
+  ASL Type error (TE_TSF): a subtype of real was expected, provided bits(3).
   [1]
 
   $ cat >lca9.asl <<EOF
@@ -146,7 +146,7 @@
   File lca9.asl, line 6, characters 2 to 18:
     let b: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of real was expected, provided T1.
+  ASL Type error (TE_TSF): a subtype of real was expected, provided T1.
   [1]
 
   $ cat >lca10.asl <<EOF
@@ -164,7 +164,7 @@
   File lca10.asl, line 7, characters 2 to 18:
     let b: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of real was expected, provided integer.
+  ASL Type error (TE_TSF): a subtype of real was expected, provided integer.
   [1]
 
   $ cat >lca11.asl <<EOF
@@ -216,6 +216,6 @@
   File lca14.asl, line 7, characters 2 to 18:
     let c: real = x;
     ^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of real was expected,
+  ASL Type error (TE_TSF): a subtype of real was expected,
     provided array [[4]] of T1.
   [1]

--- a/asllib/tests/overriding.t/run.t
+++ b/asllib/tests/overriding.t/run.t
@@ -149,6 +149,6 @@ Interactions with other features
   File type-check-impdef.asl, line 3, characters 2 to 20:
     return Zeros{N+1};
     ^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(N) was expected,
+  ASL Type error (TE_TSF): a subtype of bits(N) was expected,
     provided bits((N + 1)).
   [1]

--- a/asllib/tests/parser-errors.t/run.t
+++ b/asllib/tests/parser-errors.t/run.t
@@ -2,7 +2,7 @@
   File binop-non-associative.asl, line 1, characters 8 to 13:
   let x = a - b - c;
           ^^^^^
-  ASL Grammar error: Cannot parse. Binary operator `-` is not associative -
+  ASL Grammar error (BE_BOP): Binary operator `-` is not associative -
     parenthesise to disambiguate.
   [1]
 
@@ -56,8 +56,8 @@
   File binop-same-precedence.asl, line 1, characters 8 to 13:
   let x = a + b - c;
           ^^^^^
-  ASL Grammar error: Cannot parse. Operators `-` and `+` have the same priority
-    - parenthesise to disambiguate.
+  ASL Grammar error (BE_BOP): Operators `-` and `+` have the same priority -
+    parenthesise to disambiguate.
   [1]
 
   $ aslref empty-record.asl

--- a/asllib/tests/parser-errors.t/run.t
+++ b/asllib/tests/parser-errors.t/run.t
@@ -26,8 +26,8 @@
   File discard-locals.asl, line 3, characters 6 to 12:
     let (-, -) = (1, 2);
         ^^^^^^
-  ASL Grammar error: Cannot parse. A local declaration must declare at least
-    one name.
+  ASL Grammar error (BE_BD): A local declaration must declare at least one
+    name.
   [1]
 
   $ aslref hyphenated-pending-constraint.asl

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -11,7 +11,7 @@ Type-checking errors:
   File anonymous-types-example.asl, line 21, characters 2 to 6:
     pair = (1, dataT2);
     ^^^^
-  ASL Type error (TE_UT): a subtype of pairT was expected,
+  ASL Type error (TE_TSF): a subtype of pairT was expected,
     provided (integer {1}, T2).
   [1]
 
@@ -57,7 +57,7 @@ Bad types:
   File bad-inclusion-in-symbolic-type.asl, line 2, characters 0 to 26:
   var ah: integer{2..A} = 1;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {2..A} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {2..A} was expected,
     provided integer {1}.
   [1]
 
@@ -104,7 +104,7 @@ Constrained-type satisfaction:
   File type-sat1.asl, line 5, characters 2 to 3:
     x = y; // illegal as domain of x is not a subset of domain of y
     ^
-  ASL Type error (TE_UT): a subtype of integer {8, 16} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {8, 16} was expected,
     provided integer {8, 16, 32}.
   [1]
 
@@ -121,7 +121,7 @@ Constrained-type satisfaction:
   File type-sat2.asl, line 5, characters 2 to 3:
     x = y; // illegal
     ^
-  ASL Type error (TE_UT): a subtype of integer {8, 16} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {8, 16} was expected,
     provided integer.
   [1]
 
@@ -129,7 +129,7 @@ Constrained-type satisfaction:
   File type_satisfaction_illegal_f3.asl, line 9, characters 4 to 17:
       invoke_me(x); // illegal as domains doesn't match
       ^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {8, 16} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {8, 16} was expected,
     provided integer.
   [1]
 
@@ -137,7 +137,7 @@ Constrained-type satisfaction:
   File type_satisfaction_illegal_f4.asl, line 9, characters 4 to 17:
       invoke_me(x);
       ^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {8, 16} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {8, 16} was expected,
     provided integer {8..64}.
   [1]
 
@@ -154,7 +154,7 @@ Constrained-type satisfaction:
   File type-sat3.asl, line 4, characters 2 to 29:
     var x: integer { 2, 4} = N;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {2, 4} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {2, 4} was expected,
     provided integer {N}.
   [1]
 
@@ -171,7 +171,7 @@ Constrained-type satisfaction:
   File type-sat4.asl, line 4, characters 2 to 29:
     var x: integer { 2, 4} = N;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {2, 4} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {2, 4} was expected,
     provided integer {N}.
   [1]
 
@@ -218,21 +218,21 @@ Parameterized integers:
   File bad-underconstrained-call.asl, line 9, characters 9 to 26:
     return GetBitAt{M}(x, M);
            ^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..(M - 1)} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..(M - 1)} was expected,
     provided integer {M}.
   [1]
   $ aslref bad-underconstrained-call-02.asl
   File bad-underconstrained-call-02.asl, line 8, characters 2 to 15:
     foo{M}(x, 3);
     ^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {M} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {M} was expected,
     provided integer {3}.
   [1]
   $ aslref bad-underconstrained-call-03.asl
   File bad-underconstrained-call-03.asl, line 8, characters 2 to 19:
     foo{M}(x, M + 1);
     ^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {M} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {M} was expected,
     provided integer {(M + 1)}.
   [1]
   $ aslref bad-underconstrained-ctc.asl
@@ -246,14 +246,14 @@ Parameterized integers:
   File bad-underconstrained-return.asl, line 3, characters 2 to 15:
     return N + 1;
     ^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer {(N + 1)}.
   [1]
   $ aslref bad-underconstrained-return-02.asl
   File bad-underconstrained-return-02.asl, line 3, characters 2 to 11:
     return 5;
     ^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer {5}.
   [1]
 
@@ -396,20 +396,21 @@ Parameters bugs:
   File arg-as-param-call.asl, line 8, characters 4 to 21:
       test{10}('1111');
       ^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(10) was expected, provided bits(4).
+  ASL Type error (TE_TSF): a subtype of bits(10) was expected,
+    provided bits(4).
   [1]
   $ aslref typed-param-call.asl
   File typed-param-call.asl, line 8, characters 4 to 18:
       test{2}('11');
       ^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {5..10} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {5..10} was expected,
     provided integer {2}.
   [1]
   $ aslref typed-arg-as-param-call.asl
   File typed-arg-as-param-call.asl, line 8, characters 4 to 18:
       test{2}('11');
       ^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {5..10} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {5..10} was expected,
     provided integer {2}.
   [1]
   $ aslref --no-exec defining_param.asl
@@ -483,14 +484,14 @@ Required tests:
     characters 2 to 45:
     var animalLegs: AnimalLegs = centipedeLegs;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of AnimalLegs was expected,
+  ASL Type error (TE_TSF): a subtype of AnimalLegs was expected,
     provided InsectLegs.
   [1]
   $ aslref --no-exec subtype-satisfaction-shape-to-animal.bad.asl
   File subtype-satisfaction-shape-to-animal.bad.asl, line 9, characters 2 to 42:
     var dogLegs: AnimalLegs = myCircleSides;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of AnimalLegs was expected,
+  ASL Type error (TE_TSF): a subtype of AnimalLegs was expected,
     provided ShapeSides.
   [1]
   $ aslref --no-exec subtype-satisfaction-word-count-to-packet-length.bad.asl
@@ -498,7 +499,7 @@ Required tests:
     characters 2 to 16:
     myPacketLength = myWordCount;
     ^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of PacketLength was expected,
+  ASL Type error (TE_TSF): a subtype of PacketLength was expected,
     provided WordCount.
   [1]
   $ aslref --no-exec subtype-satisfaction-packet-length-to-word-count.bad.asl
@@ -506,7 +507,7 @@ Required tests:
     characters 2 to 13:
     myWordCount = myPacketLength;
     ^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of WordCount was expected,
+  ASL Type error (TE_TSF): a subtype of WordCount was expected,
     provided PacketLength.
   [1]
   $ aslref tuples.asl
@@ -677,7 +678,7 @@ Inherit integer constraints on left-hand sides
   File inherit-integer-constraints-bad-basic.asl, line 4, characters 2 to 11:
     return x;
     ^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {43} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {43} was expected,
     provided integer {42}.
   [1]
 
@@ -685,7 +686,7 @@ Inherit integer constraints on left-hand sides
   File inherit-integer-constraints-bad-tuple.asl, line 4, characters 2 to 28:
     return (y.item0, y.item2);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of (integer {42}, integer {0})
+  ASL Type error (TE_TSF): a subtype of (integer {42}, integer {0})
     was expected, provided (integer {42}, integer {43}).
   [1]
 

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -329,16 +329,16 @@ Parameterized integers:
   File same-precedence.asl, line 6, characters 10 to 15:
     let x = a + b - c;
             ^^^^^
-  ASL Grammar error: Cannot parse. Operators `-` and `+` have the same priority
-    - parenthesise to disambiguate.
+  ASL Grammar error (BE_BOP): Operators `-` and `+` have the same priority -
+    parenthesise to disambiguate.
   [1]
 
   $ aslref same-precedence2.asl
   File same-precedence2.asl, line 6, characters 10 to 17:
     let d = a ==> b <=> c;
             ^^^^^^^
-  ASL Grammar error: Cannot parse. Operators `<=>` and `==>` have the same
-    priority - parenthesise to disambiguate.
+  ASL Grammar error (BE_BOP): Operators `<=>` and `==>` have the same priority
+    - parenthesise to disambiguate.
   [1]
 
   $ aslref rdiv_checks.asl

--- a/asllib/tests/typing.t/run.t
+++ b/asllib/tests/typing.t/run.t
@@ -18,21 +18,21 @@ H Examples
   File HExample16.asl, line 10, characters 19 to 36:
     let x: bits(a) = Reverse{a}(bv, b);
                      ^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {1..a} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {1..a} was expected,
     provided integer {8, 16, 32, 64}.
   [1]
   $ aslref --no-exec HExample17.asl
   File HExample17.asl, line 11, characters 19 to 36:
     let x: bits(a) = Reverse{a}(bv, b);
                      ^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {1..a} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {1..a} was expected,
     provided integer {32}.
   [1]
   $ aslref --no-exec HExample18.asl
   File HExample18.asl, line 12, characters 20 to 39:
     let x: bits(a2) = Reverse{a2}(bv, a2);
                       ^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {1..a2} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {1..a2} was expected,
     provided integer {8, 16, 32, 64}.
   [1]
 
@@ -45,21 +45,21 @@ Assignments of constrained integers
   File TNegative2-0.asl, line 4, characters 4 to 41:
       let testA : integer {0..2}    = size;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..2} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..2} was expected,
     provided integer {0..3}.
   [1]
   $ aslref --no-exec TNegative2-1.asl
   File TNegative2-1.asl, line 4, characters 4 to 42:
       let testB : integer {8,16,32} = size2;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {8, 16, 32} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {8, 16, 32} was expected,
     provided integer {8, 16, 32, 64}.
   [1]
   $ aslref --no-exec TNegative2-2.asl
   File TNegative2-2.asl, line 4, characters 4 to 42:
       let testC : integer {8,16,32} = myInt; // assignment of unconstrained integers to constrained integers is also illegal without a ATC
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {8, 16, 32} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {8, 16, 32} was expected,
     provided integer.
   [1]
 
@@ -75,14 +75,14 @@ Use of global vars in constraints
   File TPositive4-1.asl, line 5, characters 4 to 54:
       let testB : integer {LET_ALLOWED_NUMS_B}     = 16;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {8} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {8} was expected,
     provided integer {16}.
   [1]
   $ aslref --no-exec TPositive4-2.asl
   File TPositive4-2.asl, line 8, characters 4 to 54:
       let testC : integer {LET_ALLOWED_NUMS_C}     = 16;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {LET_ALLOWED_NUMS_C}
+  ASL Type error (TE_TSF): a subtype of integer {LET_ALLOWED_NUMS_C}
     was expected, provided integer {16}.
   [1]
   $ aslref --no-exec TPositive4-3.asl
@@ -90,7 +90,7 @@ Use of global vars in constraints
   File TPositive4-4.asl, line 9, characters 4 to 54:
       let testF : integer {CONFIG_ALLOWED_NUMS}    = 16;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {CONFIG_ALLOWED_NUMS}
+  ASL Type error (TE_TSF): a subtype of integer {CONFIG_ALLOWED_NUMS}
     was expected, provided integer {16}.
   [1]
   $ aslref --no-exec TPositive4-5.asl
@@ -98,14 +98,14 @@ Use of global vars in constraints
   File TReconsider4-0.asl, line 13, characters 4 to 54:
       let testA : integer {CONST_ALLOWED_NUMS}     = 16;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {8} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {8} was expected,
     provided integer {16}.
   [1]
   $ aslref --no-exec TReconsider4-1.asl
   File TReconsider4-1.asl, line 14, characters 4 to 54:
       let testB : integer {0..CONST_ALLOWED_NUMS}  = 10;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..8} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..8} was expected,
     provided integer {10}.
   [1]
   $ aslref --no-exec TNegative4.asl
@@ -129,7 +129,7 @@ Asserted type conversions
   File TNegative5-0.asl, line 5, characters 4 to 38:
       let testA : integer {0..3} = temp; // illegal as value of type integer {8,16} can't be assigned to var of type integer {0..3}.
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..3} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..3} was expected,
     provided integer {8, 16}.
   [1]
   $ aslref --no-exec TNegative5-1.asl
@@ -150,7 +150,7 @@ Named types
   File TNegative7.asl, line 7, characters 4 to 36:
       let testA : MyOtherSizes = size; // illegal as testA and size are different named types, even though they are the same structure and domain
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of MyOtherSizes was expected,
+  ASL Type error (TE_TSF): a subtype of MyOtherSizes was expected,
     provided MyBitsSizes.
   [1]
   $ aslref --no-exec KPositive01.asl
@@ -161,35 +161,35 @@ Loops
   File TPositive8-1.asl, line 5, characters 8 to 40:
           let testK : integer {8..31} = i;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {8..31} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {8..31} was expected,
     provided integer {100..110}.
   [1]
   $ aslref --no-exec TNegative8-0.asl
   File TNegative8-0.asl, line 5, characters 8 to 40:
           let testA : integer {0..7}  = i; // N is an unconstrained integer, so i is also unconstrained
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..7} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..7} was expected,
     provided integer.
   [1]
   $ aslref --no-exec TNegative8-1.asl
   File TNegative8-1.asl, line 5, characters 8 to 40:
           let testB : integer {0..7}  = i; // N is an unconstrained integer, so i is also unconstrained
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..7} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..7} was expected,
     provided integer.
   [1]
   $ aslref --no-exec TNegative8-2.asl
   File TNegative8-2.asl, line 5, characters 8 to 40:
           let testC : integer {7..31} = i; // N is an unconstrained integer, so i is also unconstrained
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {7..31} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {7..31} was expected,
     provided integer.
   [1]
   $ aslref --no-exec TNegative8-3.asl
   File TNegative8-3.asl, line 5, characters 8 to 40:
           let testD : integer {7..31} = i; // N is an unconstrained integer, so i is also unconstrained
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {7..31} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {7..31} was expected,
     provided integer.
   [1]
 
@@ -200,20 +200,21 @@ Bit vector widths defined by constrained integers
   File TNegative9-0.asl, line 3, characters 4 to 36:
       let testA : bits(8) = Zeros{16};
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(8) was expected, provided bits(16).
+  ASL Type error (TE_TSF): a subtype of bits(8) was expected,
+    provided bits(16).
   [1]
   $ aslref --no-exec TNegative9-1.asl
   File TNegative9-1.asl, line 3, characters 4 to 59:
       let testB : bits(N) = Zeros{N DIV 4} :: Zeros{N DIV 2}; // bits(3N/4) != bits(N)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(N) was expected,
+  ASL Type error (TE_TSF): a subtype of bits(N) was expected,
     provided bits(((3 * N) DIV 4)).
   [1]
   $ aslref --no-exec TNegative9-2.asl
   File TNegative9-2.asl, line 3, characters 4 to 35:
       let testC : bits(M) = Zeros{N};
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(M) was expected, provided bits(N).
+  ASL Type error (TE_TSF): a subtype of bits(M) was expected, provided bits(N).
   [1]
   $ aslref --no-exec TNegative9-3.asl
   File TNegative9-3.asl, line 3, characters 26 to 34:
@@ -225,7 +226,7 @@ Bit vector widths defined by constrained integers
   File TNegative9-4.asl, line 3, characters 4 to 35:
       let testE : bits(N) = Zeros{8}; // N != 8, even though 8 is in the constraint set for N. N could be 16 after all.
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(N) was expected, provided bits(8).
+  ASL Type error (TE_TSF): a subtype of bits(N) was expected, provided bits(8).
   [1]
 
 Symbolic execution of bit vector widths expressions
@@ -243,14 +244,14 @@ Symbolic execution of bit vector widths expressions
   File TNegative10-0.asl, line 16, characters 4 to 53:
       let testB : bits(letWidthN1) = Zeros{letWidthN2}; // illegal as type bits(letWidthN1) is different from bits(letWidthN2).
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(letWidthN1) was expected,
+  ASL Type error (TE_TSF): a subtype of bits(letWidthN1) was expected,
     provided bits(letWidthN2).
   [1]
   $ aslref --no-exec TNegative10-1.asl
   File TNegative10-1.asl, line 28, characters 4 to 49:
       let testC : bits(tempC3A)   = Zeros{tempC3B}; // illegal, type bits(tempC1) != bits(tempC3B)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(tempC3A) was expected,
+  ASL Type error (TE_TSF): a subtype of bits(tempC3A) was expected,
     provided bits(tempC3B).
   [1]
 
@@ -259,7 +260,7 @@ Complex symbolic execution of bit vector widths expressions
   File TPositive11.asl, line 11, characters 4 to 64:
       let testA : bits(numBits)            = ZerosBytes{numBytes};
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(numBits) was expected,
+  ASL Type error (TE_TSF): a subtype of bits(numBits) was expected,
     provided bits((8 * numBytes)).
   [1]
   $ aslref --no-exec TPositive11-0.asl
@@ -351,14 +352,14 @@ Named types for bit vector widths
   File TNegative14-0.asl, line 6, characters 4 to 32:
       let tempA : NamedTypeB = w1;        // illegal, not the same type
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of NamedTypeB was expected,
+  ASL Type error (TE_TSF): a subtype of NamedTypeB was expected,
     provided NamedTypeA.
   [1]
   $ aslref --no-exec TNegative14-1.asl
   File TNegative14-1.asl, line 7, characters 4 to 39:
       let testB : bits(w1)   = Zeros{w2}; // illegal, just because w1 and w2 are the same type doesn't mean they are the same value, so
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of bits(w1) was expected,
+  ASL Type error (TE_TSF): a subtype of bits(w1) was expected,
     provided bits(w2).
   [1]
 
@@ -396,7 +397,7 @@ C Tests
   File CPositive1-1.asl, line 5, characters 4 to 30:
       let z: integer {0..N} = y;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer.
   [1]
   $ aslref --no-exec CPositive2.asl
@@ -404,7 +405,7 @@ C Tests
   File CPositive3.asl, line 5, characters 4 to 31:
       var a : integer {0..N} = b;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer {0}.
   [1]
   $ aslref --no-exec CPositive4.asl
@@ -414,7 +415,7 @@ C Tests
   File CPositive7.asl, line 4, characters 4 to 31:
       var a: integer{0..2*N} = x;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..(2 * N)} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..(2 * N)} was expected,
     provided integer {0..N}.
   [1]
   $ aslref --no-exec CPositive9.asl
@@ -426,14 +427,14 @@ C Tests
   File CNegative1.asl, line 5, characters 4 to 31:
       var a : integer {0..N} = b; // illegal
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer {-1}.
   [1]
   $ aslref --no-exec CNegative2.asl
   File CNegative2.asl, line 4, characters 2 to 11:
     return 3; // illegal
     ^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {N} was expected,
     provided integer {3}.
   [1]
   $ aslref --no-exec CNegative3.asl
@@ -448,7 +449,7 @@ C Tests
   File CNegative3.asl, line 12, characters 8 to 9:
           z = z + 1; // should be illegal without ATC
           ^
-  ASL Type error (TE_UT): a subtype of integer {N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {N} was expected,
     provided integer {(N + 1)}.
   [1]
   $ aslref --no-exec CNegative4.asl
@@ -457,49 +458,49 @@ C Tests
           Ones{5} ::
           x
       );
-  ASL Type error (TE_UT): a subtype of bits(64) was expected,
+  ASL Type error (TE_TSF): a subtype of bits(64) was expected,
     provided bits((N + 5)).
   [1]
   $ aslref --no-exec CNegative5.asl
   File CNegative5.asl, line 13, characters 2 to 33:
     printLengths{12}(3, Zeros{12}); // illegal
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {12} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {12} was expected,
     provided integer {3}.
   [1]
   $ aslref --no-exec CNegative6.asl
   File CNegative6.asl, line 4, characters 2 to 15:
     return N + 1; // illegal
     ^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer {(N + 1)}.
   [1]
   $ aslref --no-exec CNegative7.asl
   File CNegative7.asl, line 8, characters 9 to 26:
     return GetBitAt{M}(x, M); // illegal
            ^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..(M - 1)} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..(M - 1)} was expected,
     provided integer {M}.
   [1]
   $ aslref --no-exec CNegative8.asl
   File CNegative8.asl, line 7, characters 4 to 5:
       a = b; // illegal, would require ATC
       ^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer {0..M}.
   [1]
   $ aslref --no-exec CNegative10.asl
   File CNegative10.asl, line 7, characters 8 to 9:
           a = b; // illegal; only the static type is considered for type-checking
           ^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer {0..M}.
   [1]
   $ aslref --no-exec CNegative11.asl
   File CNegative11.asl, line 5, characters 4 to 5:
       z = M; // illegal
       ^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer {M}.
   [1]
   $ aslref --no-exec CNegative12.asl
@@ -514,7 +515,7 @@ Extra tests by ASLRef team
   File NegParam.asl, line 3, characters 2 to 28:
     let x: integer {0..N} = 0;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Type error (TE_UT): a subtype of integer {0..N} was expected,
+  ASL Type error (TE_TSF): a subtype of integer {0..N} was expected,
     provided integer {0}.
   [1]
 


### PR DESCRIPTION
### Binary operator priority (`BE_BOP`)
Unparenthesised binary operators with incompatible associativity or equal priority were reported as uncoded `CannotParse`. This change adds `BadBinopPriority`, mapped to `BE_BOP`, for both parser checks.

### Invalid all-discard local declaration (`BE_BD`)
All-discard local tuple declarations were reported as uncoded `CannotParse`, while the `BE_BD` documentation described only top-level declarations. This change adds:
1. `BadDeclarationSyntax`, mapped to `BE_BD`, and 
2. **updates the documentation to cover both local and top-level declarations**.

### Type satisfaction failures (`TE_TSF`)
Failures from `check_type_satisfies` and `check_can_be_initialized_with` were reported as `TE_UT`. This change adds `TypeSatisfactionFailure`, mapped to `TE_TSF`, for both helpers.

### Bad tuple index (`TE_BTI`)
Out-of-range tuple item selectors were reported as `TE_BF`. This change adds a dedicated `BadTupleIndex` diagnostic mapped to `TE_BTI`, as specified.
