### PR TITLE
Aligning implementation/specification error codes - phase 3/5

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -530,7 +530,8 @@ module Make (B : Backend.S) (C : Config) = struct
         let* b = is_val_of_type e1 env v t in
         (if b then return_normal (v, new_env)
          else
-           fatal_from e1 env (Error.MismatchType (B.debug_value v, [ t.desc ])))
+           fatal_from e1 env
+             (Error.ATCFailure (C.error_handling_time, B.debug_value v, t.desc)))
         |: SemanticsRule.ATC
     (* End *)
     (* Begin EvalEVar *)

--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -531,7 +531,8 @@ module Make (B : Backend.S) (C : Config) = struct
         (if b then return_normal (v, new_env)
          else
            fatal_from e1 env
-             (Error.ATCFailure (C.error_handling_time, B.debug_value v, t.desc)))
+             (Error.ATCExecutionFailure
+                (C.error_handling_time, B.debug_value v, t)))
         |: SemanticsRule.ATC
     (* End *)
     (* Begin EvalEVar *)

--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -453,9 +453,9 @@ and token = parse
     | '<'                      { LT                               }
     | ">>"                     { SHR                              }
     | "&&"                     { BAND                             }
-    | "-->"                    {
+    | "-->" as symbol          {
         fatal lexbuf
-          (UnknownSymbol { symbol = "-->"; alternative = Some "==>" })
+          (UnknownSymbol { symbol; alternative = Some "==>" })
       }
     | "==>"                    { IMPL                             }
     | "<<"                     { SHL                              }
@@ -467,9 +467,9 @@ and token = parse
     | '{'                      { LBRACE                           }
     | "!="                     { NE                              }
     | '-'                      { MINUS                            }
-    | "<->"                    {
+    | "<->" as symbol          {
         fatal lexbuf
-          (UnknownSymbol { symbol = "<->"; alternative = Some "<=>" })
+          (UnknownSymbol { symbol; alternative = Some "<=>" })
       }
     | "<=>"                    { BEQ                              }
     | '['                      { LBRACKET                         }

--- a/asllib/Lexer.mll
+++ b/asllib/Lexer.mll
@@ -453,7 +453,10 @@ and token = parse
     | '<'                      { LT                               }
     | ">>"                     { SHR                              }
     | "&&"                     { BAND                             }
-    | "-->"                    { fatal lexbuf (CannotParse (Some "Did you mean `==>`?")) }
+    | "-->"                    {
+        fatal lexbuf
+          (UnknownSymbol { symbol = "-->"; alternative = Some "==>" })
+      }
     | "==>"                    { IMPL                             }
     | "<<"                     { SHL                              }
     | ']'                      { RBRACKET                         }
@@ -464,7 +467,10 @@ and token = parse
     | '{'                      { LBRACE                           }
     | "!="                     { NE                              }
     | '-'                      { MINUS                            }
-    | "<->"                    { fatal lexbuf (CannotParse (Some "Did you mean `<=>`?")) }
+    | "<->"                    {
+        fatal lexbuf
+          (UnknownSymbol { symbol = "<->"; alternative = Some "<=>" })
+      }
     | "<=>"                    { BEQ                              }
     | '['                      { LBRACKET                         }
     | "[["                     { LLBRACKET                        }

--- a/asllib/SimpleLexer0.mll
+++ b/asllib/SimpleLexer0.mll
@@ -304,7 +304,8 @@ rule token = parse
       {
         let p1 = Lexing.lexeme_start_p lexbuf and p2 = Lexing.lexeme_end_p lexbuf in
         let lexeme = Lexing.lexeme lexbuf in
-        Error.fatal_here p1 p2 (Error.UnknownSymbol lexeme)
+        Error.fatal_here p1 p2
+          (Error.UnknownSymbol { symbol = lexeme; alternative = None })
       }
 
 and comment depth = parse
@@ -319,4 +320,3 @@ and comment depth = parse
     let () = Printf.eprintf "Parsed token %s\n" (string_of_token tok) in
     tok
 }
-

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -1609,8 +1609,12 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
                List.length params )
       else if List.compare_lengths func_sig.args args != 0 then
         fatal_from ~loc
-        @@ Error.BadArity
-             (Static, name, List.length func_sig.args, List.length args)
+        @@ Error.BadCallArity
+             {
+               name;
+               expected = List.length func_sig.args;
+               provided = List.length args;
+             }
     in
     (* Check that call parameters are statically evaluable and type-satisfy the
        declaration parameters *)
@@ -1726,8 +1730,12 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     let () =
       if List.compare_lengths callee.args args1 != 0 then
         fatal_from ~loc
-        @@ Error.BadArity
-             (Static, name, List.length callee.args, List.length args1)
+        @@ Error.BadCallArity
+             {
+               name;
+               expected = List.length callee.args;
+               provided = List.length args1;
+             }
     in
     let eqs2 =
       let folder acc (_x, ty) (t_e, _e, _ses) =
@@ -2516,11 +2524,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           | T_Tuple tys ->
               if List.compare_lengths tys les != 0 then
                 Error.fatal_from le
-                  (Error.BadArity
-                     ( Static,
-                       "LEDestructuring",
-                       List.length tys,
-                       List.length les ))
+                  (Error.BadTupleArity
+                     { expected = List.length les; actual = List.length tys })
               else
                 let lhs_tys, les', sess =
                   List.map2 (annotate_lexpr_ty env) les tys |> list_split3
@@ -2799,11 +2804,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     | T_Tuple lhs_tys, T_Tuple rhs_tys ->
         if List.compare_lengths lhs_tys rhs_tys != 0 then
           fatal_from ~loc
-            (Error.BadArity
-               ( Static,
-                 "tuple initialization",
-                 List.length rhs_tys,
-                 List.length lhs_tys ))
+            (Error.BadTupleArity
+               { expected = List.length lhs_tys; actual = List.length rhs_tys })
         else
           let lhs_tys' =
             List.map2
@@ -2837,11 +2839,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
           | T_Tuple tys when List.compare_lengths tys names = 0 -> tys
           | T_Tuple tys ->
               fatal_from ~loc
-                (Error.BadArity
-                   ( Static,
-                     "tuple initialization",
-                     List.length tys,
-                     List.length names ))
+                (Error.BadTupleArity
+                   { expected = List.length names; actual = List.length tys })
           | _ -> conflict ~loc [ T_Tuple [] ] ty
         in
         let new_env =

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -580,7 +580,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     if Types.type_satisfies env t1 t2 then ()
     else
       fatal_from ~loc
-        (Error.TypeSatisfactionFailure { expected = t2; provided = t1 })
+        (Error.TypeSatisfactionFailure { expected = t2; actual = t1 })
 
   (* CheckStructureBoolean *)
 
@@ -1613,7 +1613,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
              {
                name;
                expected = List.length func_sig.args;
-               provided = List.length args;
+               actual = List.length args;
              }
     in
     (* Check that call parameters are statically evaluable and type-satisfy the
@@ -1734,7 +1734,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
              {
                name;
                expected = List.length callee.args;
-               provided = List.length args1;
+               actual = List.length args1;
              }
     in
     let eqs2 =
@@ -2759,7 +2759,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       () |: TypingRule.CheckCanBeInitialisedWith
     else
       fatal_from ~loc
-        (Error.TypeSatisfactionFailure { expected = s; provided = t })
+        (Error.TypeSatisfactionFailure { expected = s; actual = t })
   (* End *)
 
   (* Begin ShouldRememberImmutableExpression *)

--- a/asllib/builder.ml
+++ b/asllib/builder.ml
@@ -57,7 +57,8 @@ let from_lexbuf ast_type parser_config version (lexbuf : lexbuf) =
   in
   let unknown_symbol lexbuf =
     let lexeme = Lexing.lexeme lexbuf in
-    fatal_here lexbuf.lex_start_p lexbuf.lex_curr_p (UnknownSymbol lexeme)
+    fatal_here lexbuf.lex_start_p lexbuf.lex_curr_p
+      (UnknownSymbol { symbol = lexeme; alternative = None })
   in
   match version with
   | `ASLv1 -> (

--- a/asllib/doc/AssignableExpressions.tex
+++ b/asllib/doc/AssignableExpressions.tex
@@ -128,6 +128,7 @@ which we then desugar into abstract syntax in \secref{AssignableExpressionsDesug
 The function
 \[
   \buildlexpr(\overname{\parsenode{\Nlexpr}}{\vparsednode}) \;\aslto\; \overname{\lexpr}{\vastnode}
+  \cup \overname{\TBuildError}{\BuildErrorConfig}
 \]
 transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 
@@ -175,7 +176,7 @@ transforms a parse node $\vparsednode$ into an AST node $\vastnode$.
 \begin{mathpar}
 \inferrule[tuple\_fields]{
   \buildclist[\builddiscardoridentifier](\vids) \astarrow \astversion{\vids} \\
-  \desugarlhsfieldstuple(\id, \astversion{\vids}) \astarrow \vastnode
+  \desugarlhsfieldstuple(\id, \astversion{\vids}) \astarrow \vastnode \OrBuildError
 }{
   {
   \begin{array}{r}
@@ -414,8 +415,10 @@ is defined via the following rules:
 The function
 \[
   \desugarlhsfieldstuple(\overname{\Identifier}{\id} \aslsep \overname{\KleeneStar{\Option{\Identifier}}}{\fieldopts}) \;\aslto\; \overname{\lexpr}{\vlexpr}
+  \cup \overname{\TBuildError}{\BuildErrorConfig}
 \]
 transforms an assignment to a tuple of fields $\fields$ of variable $\id$ into an AST node $\vlexpr$.
+\ProseOtherwiseBuildError
 
 \ExampleDef{Desugaring a left-hand side fields tuple}
 \listingref{DesugarLHSFieldsTuple} shows an example of desugaring a left-hand side fields tuple.
@@ -424,7 +427,8 @@ transforms an assignment to a tuple of fields $\fields$ of variable $\id$ into a
 \begin{mathpar}
 \inferrule{
   \fields \eqdef \filteroptionlist{\fieldopts}\\
-  \checknoduplicates(\fields) \typearrow \True \OrTypeError \hva\\
+  \becheck(\listlen{\fields} = \cardinality{\listassetop{\fields}}, \ParseError)
+    \astarrow \True \OrBuildError \hva\\
   i \in 1..|\fieldopts|: \desugarlhsfieldopt(\id, \fieldopts[i]) \astarrow \vlexpr_i \\
   \vlexprs \eqdef [i \in 1..|\fieldopts|: \vlexpr_i]
 }{

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -9167,9 +9167,17 @@ semantics relation build_genv(tenv: static_envs, typed_spec: spec) -> (new_env: 
  prose_transition = "building the \environmentterm{} and \executiongraphterm{} from {typed_spec} starting in the context of {tenv} yields",
 } =
   env := (tenv, empty_denv);
-  eval_globals(typed_spec, (env, empty_graph)) -> (new_env, new_g) | DynErrorConfig(), DivergingConfig();
-  --
-  (new_env, new_g);
+  case normal {
+    eval_globals(typed_spec, (env, empty_graph)) -> (new_env, new_g) | DynErrorConfig(), DivergingConfig();
+    --
+    (new_env, new_g);
+  }
+
+  case throwing {
+    eval_globals(typed_spec, (env, empty_graph)) -> Throwing(_, _, _, _) | DynErrorConfig(), DivergingConfig();
+    --
+    DynamicError(DE_UE);
+  }
 ;
 
 //////////////////////////////////////////////////

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -42,6 +42,8 @@ type error_desc =
       found_call_type : subprogram_type;
     }
   | BadArity of error_handling_time * identifier * int * int
+  | BadCallArity of { name : identifier; expected : int; provided : int }
+  | BadTupleArity of { expected : int; actual : int }
   | BadParameterArity of error_handling_time * version * identifier * int * int
   | UnsupportedBinop of error_handling_time * binop * literal * literal
   | UnsupportedUnop of error_handling_time * unop * literal
@@ -272,10 +274,11 @@ module ErrorCode = struct
     | ExpectedNamedType _ | UnexpectedCollection | MismatchedBitvectorWidths _
     | CollectionBaseNotVariable _ ->
         Some (Typing UT)
-    | MismatchedCallType _
+    | MismatchedCallType _ | BadCallArity _
     | BadParameterArity (Static, _, _, _, _)
     | NoCallCandidate _ ->
         Some (Typing BC)
+    | BadTupleArity _ -> Some (Typing UT)
     | UnsupportedUnop (Dynamic, _, _) | UnsupportedBinop (Dynamic, _, _, _) ->
         Some (Dynamic BO)
     | AssertionFailed (Dynamic, _) | BadPrimitiveArgument (Dynamic, _, _) ->
@@ -312,7 +315,6 @@ module ErrorCode = struct
         Some (Typing SEF)
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
     (********** TODO tidy up - does not cleanly correspond to a code **********)
-    | BadArity (Static, _, _, _) (* also used for tuple unpacking *) -> None
     | UnsupportedExpr _ | UnsupportedTy _
     (* For static interpretation, parameters, and collections *) ->
         None
@@ -322,7 +324,7 @@ module ErrorCode = struct
     | EmptyConstraints (* An internal invariant *) -> None
     | TypeInferenceNeeded
     | UndefinedIdentifier (Dynamic, _)
-    | BadArity (Dynamic, _, _, _)
+    | BadArity _
     | BadParameterArity (Dynamic, _, _, _, _)
     | InvalidExpr _ | UnexpectedSideEffect _ | UnrespectedParserInvariant
     | ParameterWithoutDecl _ | SetterWithoutCorrespondingGetter _
@@ -549,6 +551,15 @@ module PPrint = struct
           "Arity error while calling '%s':@ %d arguments expected and %d \
            provided."
           name expected provided
+    | BadCallArity { name; expected; provided } ->
+        pp_err Typing
+          "Call to %S has incorrect argument arity:@ expected %d argument(s); \
+           provided %d."
+          name expected provided
+    | BadTupleArity { expected; actual } ->
+        pp_err Typing
+          "Tuple arity mismatch:@ expected %d element(s); provided %d." expected
+          actual
     | BadParameterArity (t, version, name, expected, provided) -> (
         match (t, version) with
         | Static, V0 ->
@@ -849,6 +860,8 @@ module CSV = struct
     | UndefinedIdentifier _ -> "UndefinedIdentifier"
     | MismatchedCallType _ -> "MismatchedCallType"
     | BadArity _ -> "BadArity"
+    | BadCallArity _ -> "BadCallArity"
+    | BadTupleArity _ -> "BadTupleArity"
     | BadParameterArity _ -> "BadParameterArity"
     | UnsupportedBinop _ -> "UnsupportedBinop"
     | UnsupportedUnop _ -> "UnsupportedUnop"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -56,7 +56,7 @@ type error_desc =
   | BadBinopPriority of string
   | AllDiscardLocalDeclaration
   | NonFunctionBuiltinDeclaration
-  | UnknownSymbol of string
+  | UnknownSymbol of { symbol : string; alternative : string option }
   | NoCallCandidate of string * ty list
   | BadTypesForBinop of binop * ty * ty
   | ImpureExpression of expr * SideEffect.SES.t
@@ -251,6 +251,7 @@ module ErrorCode = struct
     | AllDiscardLocalDeclaration | NonFunctionBuiltinDeclaration ->
         Some (Build BD)
     | UnknownSymbol _ -> Some (Build LE)
+    | CannotParse _ -> Some (Build PE)
     | ObsoleteSyntax _ -> Some (Build PE)
     | BadField _ | MissingField _ -> Some (Typing BF)
     | BadTupleIndex _ -> Some (Typing BTI)
@@ -315,7 +316,6 @@ module ErrorCode = struct
     | MismatchType _
     (* dynamic ATC but also mismatched integers for loop limits *) ->
         None
-    | CannotParse _ (* used in lexing too *) -> None
     | MultipleWrites _
     (* For desugaring, but uses `check_no_duplicates` which is always TE_IAD? *)
       ->
@@ -588,14 +588,19 @@ module PPrint = struct
           "A local declaration must declare at least one name."
     | NonFunctionBuiltinDeclaration ->
         pp_err Parse "Only subprogram declarations may be marked as builtins."
-    | UnknownSymbol s ->
-        let codes = List.map Char.code (List.of_seq (String.to_seq s)) in
+    | UnknownSymbol { symbol; alternative } -> (
+        let codes = List.map Char.code (List.of_seq (String.to_seq symbol)) in
         let not_printable code = code < 33 || code > 126 in
         if List.exists not_printable codes then
           pp_err Lexical "Unknown symbol (ASCII code point(s): %a)."
             (pp_comma_list pp_print_int)
             codes
-        else pp_err Lexical "Unknown symbol."
+        else
+          match alternative with
+          | None -> pp_err Lexical "Unknown symbol."
+          | Some alternative ->
+              pp_err Lexical "Unknown symbol %S.@ Did you mean %S?" symbol
+                alternative)
     | NoCallCandidate (name, types) ->
         pp_err Typing
           "No subprogram declaration matches the invocation:@ %s(%a)." name

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -307,6 +307,7 @@ module ErrorCode = struct
     | LoopLimitReached Static
     | NegativeArrayLength (Static, _, _)
     | AssertionFailed (Static, _)
+    | ATCFailure (Static, _, _)
     | BadPrimitiveArgument (Static, _, _) ->
         Some (Typing SEF)
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
@@ -315,9 +316,7 @@ module ErrorCode = struct
     | UnsupportedExpr _ | UnsupportedTy _
     (* For static interpretation, parameters, and collections *) ->
         None
-    | MismatchType _ (* mismatched integers for loop limits *)
-    | ATCFailure (Static, _, _) ->
-        None
+    | MismatchType _ (* mismatched integers for loop limits *) -> None
     | MultipleWrites _
     (* For desugaring, but uses `check_no_duplicates` which is always TE_IAD? *)
       ->

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -282,7 +282,7 @@ module ErrorCode = struct
         Some (Dynamic DAF)
     | ImpureExpression _ | MismatchedPurity _ -> Some (Typing SEV)
     | AssignToImmutable _ -> Some (Typing AIM)
-    | AlreadyDeclaredIdentifier _ -> Some (Typing IAD)
+    | AlreadyDeclaredIdentifier _ | MultipleWrites _ -> Some (Typing IAD)
     | BadReturnStmt _ | BadParameterDecl _ | NonReturningFunction _
     | NoreturnViolation _ ->
         Some (Typing BSPD)
@@ -317,10 +317,6 @@ module ErrorCode = struct
     (* For static interpretation, parameters, and collections *) ->
         None
     | MismatchType _ (* mismatched integers for loop limits *) -> None
-    | MultipleWrites _
-    (* For desugaring, but uses `check_no_duplicates` which is always TE_IAD? *)
-      ->
-        None
     (********** Should not happen **********)
     (* e.g. skipped type-checking, ASL0, internal option or invariant *)
     | EmptyConstraints (* An internal invariant *) -> None
@@ -755,7 +751,7 @@ module PPrint = struct
           (ErrorKind.of_error_handling_time t)
           "array@ length@ expression@ %a@ has@ negative@ length:@ %i." pp_expr
           e_length length
-    | MultipleWrites id -> pp_err Parse "multiple@ writes@ to@ %S." id
+    | MultipleWrites id -> pp_err Typing "multiple@ writes@ to@ %S." id
     | MultipleImplementations (impl1, impl2) ->
         pp_err Typing
           "multiple@ overlapping@ `implementation`@ functions@ for@ %s:@ %a"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -285,7 +285,7 @@ module ErrorCode = struct
     | BadReturnStmt _ | BadParameterDecl _ | NonReturningFunction _
     | NoreturnViolation _ ->
         Some (Typing BSPD)
-    | UncaughtException _ -> Some (Dynamic UE)
+    | UncaughtException _ | UnexpectedInitialisationThrow _ -> Some (Dynamic UE)
     | OverlappingSlices (_, Dynamic) -> Some (Dynamic OSA)
     | BadLDI _ | BadRecursiveDecls _ -> Some (Typing BD)
     | BadATC _ -> Some (Typing TAF)
@@ -319,8 +319,6 @@ module ErrorCode = struct
     | MultipleWrites _
     (* For desugaring, but uses `check_no_duplicates` which is always TE_IAD? *)
       ->
-        None
-    | UnexpectedInitialisationThrow _ (* not represented in reference? *) ->
         None
     (********** Should not happen **********)
     (* e.g. skipped type-checking, ASL0, internal option or invariant *)

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -49,6 +49,7 @@ type error_desc =
   | UnsupportedTy of error_handling_time * ty
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
+  | ATCFailure of error_handling_time * string * type_desc
   | ConflictingTypes of type_desc list * ty
   | TypeSatisfactionFailure of { expected : ty; provided : ty }
   | AssertionFailed of error_handling_time * expr
@@ -289,6 +290,7 @@ module ErrorCode = struct
     | OverlappingSlices (_, Dynamic) -> Some (Dynamic OSA)
     | BadLDI _ | BadRecursiveDecls _ -> Some (Typing BD)
     | BadATC _ -> Some (Typing TAF)
+    | ATCFailure (Dynamic, _, _) -> Some (Dynamic TAF)
     | BaseValueEmptyType _ | BaseValueNonSymbolic _ -> Some (Typing NBV)
     | ArbitraryEmptyType _ -> Some (Dynamic AET)
     | UnreachableReached Dynamic -> Some (Dynamic UNR)
@@ -313,8 +315,8 @@ module ErrorCode = struct
     | UnsupportedExpr _ | UnsupportedTy _
     (* For static interpretation, parameters, and collections *) ->
         None
-    | MismatchType _
-    (* dynamic ATC but also mismatched integers for loop limits *) ->
+    | MismatchType _ (* mismatched integers for loop limits *)
+    | ATCFailure (Static, _, _) ->
         None
     | MultipleWrites _
     (* For desugaring, but uses `check_no_duplicates` which is always TE_IAD? *)
@@ -498,6 +500,10 @@ module PPrint = struct
           "Mismatch type:@ value %s@ does not subtype any of those types:@ %a" v
           (pp_comma_list pp_type_desc)
           li
+    | ATCFailure (t, v, ty) ->
+        pp_err
+          (ErrorKind.of_error_handling_time t)
+          "Value %s does not satisfy the asserted type %a." v pp_type_desc ty
     | BadField (s, ty) ->
         pp_err Typing "There is no field '%s'@ on type %a." s pp_ty ty
     | MissingField (fields, ty) ->
@@ -855,6 +861,7 @@ module CSV = struct
     | UnsupportedTy _ -> "UnsupportedTy"
     | InvalidExpr _ -> "InvalidExpr"
     | MismatchType _ -> "MismatchType"
+    | ATCFailure _ -> "ATCFailure"
     | ConflictingTypes _ -> "ConflictingTypes"
     | TypeSatisfactionFailure _ -> "TypeSatisfactionFailure"
     | AssertionFailed _ -> "AssertionFailed"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -42,7 +42,13 @@ type error_desc =
       found_call_type : subprogram_type;
     }
   | BadArity of error_handling_time * identifier * int * int
-  | BadCallArity of { name : identifier; expected : int; provided : int }
+      (** [BadArity (time, name, expected, provided)] is raised when there is an
+          arity mismatch detected during evaluation when it should have been
+          detected at type-checking: a subprogram or primitive receives the
+          wrong number of arguments, a tuple assignment receives the wrong
+          number of values from a subprogram call, or an entry point returns the
+          wrong number of values. *)
+  | BadCallArity of { name : identifier; expected : int; actual : int }
   | BadTupleArity of { expected : int; actual : int }
   | BadParameterArity of error_handling_time * version * identifier * int * int
   | UnsupportedBinop of error_handling_time * binop * literal * literal
@@ -51,9 +57,9 @@ type error_desc =
   | UnsupportedTy of error_handling_time * ty
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
-  | ATCFailure of error_handling_time * string * type_desc
+  | ATCExecutionFailure of error_handling_time * string * ty
   | ConflictingTypes of type_desc list * ty
-  | TypeSatisfactionFailure of { expected : ty; provided : ty }
+  | TypeSatisfactionFailure of { expected : ty; actual : ty }
   | AssertionFailed of error_handling_time * expr
   | CannotParse of string option
   | BadBinopPriority of string
@@ -254,8 +260,7 @@ module ErrorCode = struct
     | AllDiscardLocalDeclaration | NonFunctionBuiltinDeclaration ->
         Some (Build BD)
     | UnknownSymbol _ -> Some (Build LE)
-    | CannotParse _ -> Some (Build PE)
-    | ObsoleteSyntax _ -> Some (Build PE)
+    | CannotParse _ | ObsoleteSyntax _ | MultipleWrites _ -> Some (Build PE)
     | BadField _ | MissingField _ -> Some (Typing BF)
     | BadTupleIndex _ -> Some (Typing BTI)
     | BadPattern _ | BadTypesForBinop _
@@ -285,7 +290,7 @@ module ErrorCode = struct
         Some (Dynamic DAF)
     | ImpureExpression _ | MismatchedPurity _ -> Some (Typing SEV)
     | AssignToImmutable _ -> Some (Typing AIM)
-    | AlreadyDeclaredIdentifier _ | MultipleWrites _ -> Some (Typing IAD)
+    | AlreadyDeclaredIdentifier _ -> Some (Typing IAD)
     | BadReturnStmt _ | BadParameterDecl _ | NonReturningFunction _
     | NoreturnViolation _ ->
         Some (Typing BSPD)
@@ -293,7 +298,7 @@ module ErrorCode = struct
     | OverlappingSlices (_, Dynamic) -> Some (Dynamic OSA)
     | BadLDI _ | BadRecursiveDecls _ -> Some (Typing BD)
     | BadATC _ -> Some (Typing TAF)
-    | ATCFailure (Dynamic, _, _) -> Some (Dynamic TAF)
+    | ATCExecutionFailure (Dynamic, _, _) -> Some (Dynamic TAF)
     | BaseValueEmptyType _ | BaseValueNonSymbolic _ -> Some (Typing NBV)
     | ArbitraryEmptyType _ -> Some (Dynamic AET)
     | UnreachableReached Dynamic -> Some (Dynamic UNR)
@@ -310,7 +315,7 @@ module ErrorCode = struct
     | LoopLimitReached Static
     | NegativeArrayLength (Static, _, _)
     | AssertionFailed (Static, _)
-    | ATCFailure (Static, _, _)
+    | ATCExecutionFailure (Static, _, _)
     | BadPrimitiveArgument (Static, _, _) ->
         Some (Typing SEF)
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
@@ -497,10 +502,11 @@ module PPrint = struct
           "Mismatch type:@ value %s@ does not subtype any of those types:@ %a" v
           (pp_comma_list pp_type_desc)
           li
-    | ATCFailure (t, v, ty) ->
+    | ATCExecutionFailure (t, v, ty) ->
         pp_err
           (ErrorKind.of_error_handling_time t)
-          "Value %s does not satisfy the asserted type %a." v pp_type_desc ty
+          "Value %s@ does@ not@ satisfy@ the@ asserted@ type@ @[%a@]." v pp_ty
+          ty
     | BadField (s, ty) ->
         pp_err Typing "There is no field '%s'@ on type %a." s pp_ty ty
     | MissingField (fields, ty) ->
@@ -545,17 +551,17 @@ module PPrint = struct
           s
           (call_type_description expected_call_type)
           (call_type_description found_call_type)
-    | BadArity (t, name, expected, provided) ->
+    | BadArity (t, name, expected, actual) ->
         pp_err
           (ErrorKind.of_error_handling_time t)
           "Arity error while calling '%s':@ %d arguments expected and %d \
            provided."
-          name expected provided
-    | BadCallArity { name; expected; provided } ->
+          name expected actual
+    | BadCallArity { name; expected; actual } ->
         pp_err Typing
           "Call to %S has incorrect argument arity:@ expected %d argument(s); \
            provided %d."
-          name expected provided
+          name expected actual
     | BadTupleArity { expected; actual } ->
         pp_err Typing
           "Tuple arity mismatch:@ expected %d element(s); provided %d." expected
@@ -581,9 +587,9 @@ module PPrint = struct
         pp_err Typing "%a does@ not@ subtype@ any@ of:@ %a." pp_ty provided
           (pp_comma_list pp_type_desc)
           expected
-    | TypeSatisfactionFailure { expected; provided } ->
+    | TypeSatisfactionFailure { expected; actual } ->
         pp_err Typing "a subtype of@ %a@ was expected,@ provided %a." pp_ty
-          expected pp_ty provided
+          expected pp_ty actual
     | AssertionFailed (t, e) ->
         pp_err
           (ErrorKind.of_error_handling_time t)
@@ -598,7 +604,7 @@ module PPrint = struct
           "A local declaration must declare at least one name."
     | NonFunctionBuiltinDeclaration ->
         pp_err Parse "Only subprogram declarations may be marked as builtins."
-    | UnknownSymbol { symbol; alternative } -> (
+    | UnknownSymbol { symbol; alternative } ->
         let codes = List.map Char.code (List.of_seq (String.to_seq symbol)) in
         let not_printable code = code < 33 || code > 126 in
         if List.exists not_printable codes then
@@ -606,11 +612,10 @@ module PPrint = struct
             (pp_comma_list pp_print_int)
             codes
         else
-          match alternative with
-          | None -> pp_err Lexical "Unknown symbol."
-          | Some alternative ->
-              pp_err Lexical "Unknown symbol %S.@ Did you mean %S?" symbol
-                alternative)
+          let pp_alternative fmt alt = fprintf fmt "@ Did you mean %S?" alt in
+          pp_err Lexical "Unknown symbol %S.%a" symbol
+            (pp_print_option pp_alternative)
+            alternative
     | NoCallCandidate (name, types) ->
         pp_err Typing
           "No subprogram declaration matches the invocation:@ %s(%a)." name
@@ -762,7 +767,7 @@ module PPrint = struct
           (ErrorKind.of_error_handling_time t)
           "array@ length@ expression@ %a@ has@ negative@ length:@ %i." pp_expr
           e_length length
-    | MultipleWrites id -> pp_err Typing "multiple@ writes@ to@ %S." id
+    | MultipleWrites id -> pp_err Parse "multiple@ writes@ to@ %S." id
     | MultipleImplementations (impl1, impl2) ->
         pp_err Typing
           "multiple@ overlapping@ `implementation`@ functions@ for@ %s:@ %a"
@@ -869,7 +874,7 @@ module CSV = struct
     | UnsupportedTy _ -> "UnsupportedTy"
     | InvalidExpr _ -> "InvalidExpr"
     | MismatchType _ -> "MismatchType"
-    | ATCFailure _ -> "ATCFailure"
+    | ATCExecutionFailure _ -> "ATCExecutionFailure"
     | ConflictingTypes _ -> "ConflictingTypes"
     | TypeSatisfactionFailure _ -> "TypeSatisfactionFailure"
     | AssertionFailed _ -> "AssertionFailed"

--- a/asllib/tests/ASLDefinition.t/run.t
+++ b/asllib/tests/ASLDefinition.t/run.t
@@ -104,7 +104,7 @@ Examples used in ASL High-level Definition:
   File GuideRule.AnonymousEnumerations.bad.asl, line 4, characters 12 to 23:
       var x : enumeration {RED, GREEN, BLUE};
               ^^^^^^^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref GuideRule.TupleImmutability.asl
   File GuideRule.TupleImmutability.asl, line 7, characters 6 to 11:
@@ -118,7 +118,7 @@ Examples used in ASL High-level Definition:
   File ParameterOmission.bad.asl, line 6, characters 17 to 18:
       result = LSL{}(result, 3);
                    ^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref --no-exec NamedTypes.asl
   $ aslref --no-exec NamedTypes2.asl
@@ -207,5 +207,5 @@ Examples used in ASL High-level Definition:
   File EmptyTuple.asl, line 1, characters 11 to 12:
   type T of ();
              ^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -218,8 +218,8 @@ ASL Semantics Tests:
   File SemanticsRule.ATCVariousErrors.asl, line 8, characters 28 to 29:
     var c: integer{4, 5, 6} = 2 as integer{4, 5, 6}; // A dynamic error
                               ^
-  ASL Dynamic error: Mismatch type:
-    value 2 does not belong to type integer {4, 5, 6}.
+  ASL Dynamic error (DE_TAF):
+    Value 2 does not satisfy the asserted type integer {4, 5, 6}.
   [1]
   $ aslref SemanticsRule.CatchNoThrow.asl
   No exception raised

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -281,6 +281,6 @@ ASL Semantics Tests:
   File SemanticsRule.EvalGlobals.bad1.asl, line 10, characters 0 to 12:
   var x = f();
   ^^^^^^^^^^^^
-  ASL Dynamic error: unexpected exception MyException thrown during the
+  ASL Dynamic error (DE_UE): unexpected exception MyException thrown during the
     evaluation of the initialisation of the global storage element "x".
   [1]

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -146,7 +146,7 @@ ASL Semantics Tests:
   File SemanticsRule.CatchNone.asl, line 15, characters 8 to 24:
     catch MyExceptionType1;
           ^^^^^^^^^^^^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref SemanticsRule.FUndefIdent.asl
   File SemanticsRule.FUndefIdent.asl, line 4, characters 5 to 12:
@@ -207,7 +207,8 @@ ASL Semantics Tests:
   File SemanticsRule.LDDiscard.asl, line 4, characters 6 to 7:
     var - : integer;
         ^
-  ASL Grammar error: Cannot parse. A local declaration must declare a name.
+  ASL Grammar error (BE_PE): Cannot parse. A local declaration must declare a
+    name.
   [1]
 
   $ aslref EvalCatchers.asl

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -218,8 +218,8 @@ ASL Semantics Tests:
   File SemanticsRule.ATCVariousErrors.asl, line 8, characters 28 to 29:
     var c: integer{4, 5, 6} = 2 as integer{4, 5, 6}; // A dynamic error
                               ^
-  ASL Dynamic error (DE_TAF):
-    Value 2 does not satisfy the asserted type integer {4, 5, 6}.
+  ASL Dynamic error (DE_TAF): Value 2 does not satisfy the asserted type
+    integer {4, 5, 6}.
   [1]
   $ aslref SemanticsRule.CatchNoThrow.asl
   No exception raised

--- a/asllib/tests/ASLSyntaxReference.t/run.t
+++ b/asllib/tests/ASLSyntaxReference.t/run.t
@@ -13,7 +13,7 @@ Examples used to test syntax and AST building rules:
   File GuideRule.IdentifiersKeywords.bad.asl, line 3, characters 8 to 12:
       var case = 5;
           ^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref ConventionRule.IdentifiersDifferingByCase.asl
   $ aslref --no-exec ConventionRule.IdentifierSingleUnderscore.asl
@@ -22,14 +22,16 @@ Examples used to test syntax and AST building rules:
     characters 6 to 7:
     let - = 42;
         ^
-  ASL Grammar error: Cannot parse. A local declaration must declare a name.
+  ASL Grammar error (BE_PE): Cannot parse. A local declaration must declare a
+    name.
   [1]
   $ aslref GuideRule.DiscardingGlobalStorageDeclarations.asl
   File GuideRule.DiscardingGlobalStorageDeclarations.asl, line 1,
     characters 4 to 5:
   let - = 42;
       ^
-  ASL Grammar error: Cannot parse. A global declaration must declare a name.
+  ASL Grammar error (BE_PE): Cannot parse. A global declaration must declare a
+    name.
   [1]
   $ aslref ASTRule.DesugarLHSAccess.asl
   $ aslref ASTRule.DesugarLHSTuple.asl
@@ -73,7 +75,7 @@ Examples used to test syntax and AST building rules:
   File CaseStatement.bad.asl, line 7, characters 8 to 12:
           when '11' => X[30] = 0;
           ^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref ASTRule.ReadModifyWriteSlice.asl
   $ aslref ASTRule.ReadModifyWriteField.asl

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -93,7 +93,8 @@ ASL Typing Tests:
   File TypingRule.LDDiscard.asl, line 4, characters 6 to 7:
     let - = 42;
         ^
-  ASL Grammar error: Cannot parse. A local declaration must declare a name.
+  ASL Grammar error (BE_PE): Cannot parse. A local declaration must declare a
+    name.
   [1]
   $ aslref TypingRule.LDVar.asl
   $ aslref TypingRule.LDTyped.asl
@@ -215,7 +216,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.TNonDecl.asl, line 1, characters 5 to 6:
   func (x: record { a: integer, b: boolean }) => integer
        ^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref TypingRule.TBitField.asl
   $ aslref --no-exec TypingRule.AnnotateFuncSig.asl
@@ -484,14 +485,14 @@ ASL Typing Tests / annotating types:
   File TypingRule.SDecl.bad1.asl, line 4, characters 4 to 12:
       constant c3 = 5;
       ^^^^^^^^
-  ASL Grammar error: Cannot parse. Local constant declarations are not valid
-    ASL1. Did you mean `let`?.
+  ASL Grammar error (BE_PE): Cannot parse. Local constant declarations are not
+    valid ASL1. Did you mean `let`?.
   [1]
   $ aslref TypingRule.SDecl.bad2.asl
   File TypingRule.SDecl.bad2.asl, line 4, characters 18 to 19:
       let y: integer;
                     ^
-  ASL Grammar error: Cannot parse. Declarations using `let` must have
+  ASL Grammar error (BE_PE): Cannot parse. Declarations using `let` must have
     initialising expressions.
     
   [1]
@@ -658,7 +659,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.CheckIsNotCollection.asl, line 3, characters 12 to 22:
     var test: collection {
               ^^^^^^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref TypingRule.TypecheckDecl.asl
   0x0000000000000000
@@ -744,8 +745,9 @@ ASL Typing Tests / annotating types:
   File TypingRule.DeclareGlobalStorage.bad3.asl, line 2, characters 37 to 38:
   config uninitialized_config : integer;
                                        ^
-  ASL Grammar error: Cannot parse. A `config` declaration must introduce a
-    single name, and have both a type annotation and initialising expression:
+  ASL Grammar error (BE_PE): Cannot parse. A `config` declaration must
+    introduce a single name, and have both a type annotation and initialising
+    expression:
       config name : type = initial_expression;
     
   [1]
@@ -883,7 +885,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateReturnType.bad.asl, line 3, characters 24 to 34:
   func returns_value() => collection { foo: bits(32)};
                           ^^^^^^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref --no-exec TypingRule.AnnotateOneParam.asl
   $ aslref TypingRule.AnnotateOneParam.bad1.asl
@@ -908,7 +910,7 @@ ASL Typing Tests / annotating types:
   File TypingRule.AnnotateOneArg.bad2.asl, line 2, characters 18 to 28:
   func arguments(b: collection {a: bits(7)})
                     ^^^^^^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref TypingRule.AnnotateRetTy.asl
   $ aslref TypingRule.AnnotateRetTy.bad.asl

--- a/asllib/tests/atcs.t
+++ b/asllib/tests/atcs.t
@@ -14,6 +14,19 @@ Deferred to execution ATCs
     Value 3 does not satisfy the asserted type integer {42}.
   [1]
 
+Static evaluation ATCs
+  $ cat >atcs-static.asl <<EOF
+  > constant X = 2 as integer {1};
+  > EOF
+
+  $ aslref --no-exec atcs-static.asl
+  File atcs-static.asl, line 1, characters 13 to 14:
+  constant X = 2 as integer {1};
+               ^
+  ASL Static error (TE_SEF):
+    Value 2 does not satisfy the asserted type integer {1}.
+  [1]
+
 Bad structure ATCs
   $ cat >atcs2.asl <<EOF
   > func main () => integer begin

--- a/asllib/tests/atcs.t
+++ b/asllib/tests/atcs.t
@@ -10,8 +10,8 @@ Deferred to execution ATCs
   File atcs1.asl, line 2, characters 11 to 12:
     let x = (3 as integer {42});
              ^
-  ASL Dynamic error: Mismatch type:
-    value 3 does not belong to type integer {42}.
+  ASL Dynamic error (DE_TAF):
+    Value 3 does not satisfy the asserted type integer {42}.
   [1]
 
 Bad structure ATCs
@@ -80,8 +80,9 @@ ATCs on other types
   File atcs6.asl, line 3, characters 11 to 25:
     let x = ((42, Zeros{4}) as myty);
              ^^^^^^^^^^^^^^
-  ASL Dynamic error: Mismatch type:
-    value [42, 0x0] does not belong to type (integer {0..10}, bits(4)).
+  ASL Dynamic error (DE_TAF):
+    Value [42, 0x0] does not satisfy the asserted type (integer {0..10},
+                                                       bits(4)).
   [1]
 
   $ cat > atcs7.asl <<EOF

--- a/asllib/tests/atcs.t
+++ b/asllib/tests/atcs.t
@@ -10,8 +10,8 @@ Deferred to execution ATCs
   File atcs1.asl, line 2, characters 11 to 12:
     let x = (3 as integer {42});
              ^
-  ASL Dynamic error (DE_TAF):
-    Value 3 does not satisfy the asserted type integer {42}.
+  ASL Dynamic error (DE_TAF): Value 3 does not satisfy the asserted type
+    integer {42}.
   [1]
 
 Static evaluation ATCs
@@ -23,8 +23,8 @@ Static evaluation ATCs
   File atcs-static.asl, line 1, characters 13 to 14:
   constant X = 2 as integer {1};
                ^
-  ASL Static error (TE_SEF):
-    Value 2 does not satisfy the asserted type integer {1}.
+  ASL Static error (TE_SEF): Value 2 does not satisfy the asserted type
+    integer {1}.
   [1]
 
 Bad structure ATCs
@@ -93,9 +93,8 @@ ATCs on other types
   File atcs6.asl, line 3, characters 11 to 25:
     let x = ((42, Zeros{4}) as myty);
              ^^^^^^^^^^^^^^
-  ASL Dynamic error (DE_TAF):
-    Value [42, 0x0] does not satisfy the asserted type (integer {0..10},
-                                                       bits(4)).
+  ASL Dynamic error (DE_TAF): Value [42, 0x0] does not satisfy the asserted
+    type (integer {0..10}, bits(4)).
   [1]
 
   $ cat > atcs7.asl <<EOF

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -7,7 +7,7 @@ Bad enumeration
   File bad-types1.asl, line 1, characters 23 to 24:
   type t of enumeration {};
                          ^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
 
 Invalid bitfields

--- a/asllib/tests/collections.t/run.t
+++ b/asllib/tests/collections.t/run.t
@@ -2,7 +2,7 @@
   File on-arbitrary.asl, line 3, characters 23 to 33:
     var col = ARBITRARY: collection {
                          ^^^^^^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref non-variable-base.asl
   File non-variable-base.asl, line 5, characters 10 to 41:
@@ -16,7 +16,7 @@
   File on-local-func-arg.asl, line 6, characters 15 to 25:
   func foo (col: collection {
                  ^^^^^^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref on-local-var.asl
   File on-local-var.asl, line 8, characters 2 to 25:
@@ -37,7 +37,7 @@
   File on-function-return-type.asl, line 6, characters 15 to 25:
   func foo () => collection {
                  ^^^^^^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
 
   $ aslref on-local-tuple.asl
@@ -58,5 +58,5 @@
   File on-type-declaration.asl, line 1, characters 21 to 31:
   type MyCollection of collection {
                        ^^^^^^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]

--- a/asllib/tests/lexer.t
+++ b/asllib/tests/lexer.t
@@ -37,7 +37,7 @@
   File println5.asl, line 1, characters 32 to 33:
   constant msg = "Something with \p bad characters.";
                                   ^
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "p".
   [1]
   $ cat >println6.asl <<EOF
   > constant msg = "Some unterminated string;
@@ -47,7 +47,7 @@
   File println6.asl, line 3, character 0:
   
   
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "".
   [1]
 
 C-Style comments
@@ -133,7 +133,7 @@ Forbidden patterns
   File forbiddenhex01.asl, line 1, characters 8 to 11:
   let x = 0xh12;
           ^^^
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "0xh".
   [1]
 
   $ cat >forbiddenhex02.asl <<EOF
@@ -143,7 +143,7 @@ Forbidden patterns
   File forbiddenhex02.asl, line 1, characters 8 to 11:
   let x = 0x_12;
           ^^^
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "0x_".
   [1]
 
   $ cat >forbiddenhex03.asl <<EOF
@@ -153,7 +153,7 @@ Forbidden patterns
   File forbiddenhex03.asl, line 1, characters 8 to 13:
   let x = 0x12h12;
           ^^^^^
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "0x12h".
   [1]
 
   $ cat >forbiddenhex04.asl <<EOF
@@ -164,7 +164,7 @@ Forbidden patterns
   File forbiddenhex04.asl, line 2, characters 8 to 11:
   let x = 0x_foo;
           ^^^
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "0x_".
   [1]
 
   $ cat >forbiddenreal01.asl <<EOF
@@ -174,7 +174,7 @@ Forbidden patterns
   File forbiddenreal01.asl, line 1, characters 8 to 11:
   let x = 1.h12;
           ^^^
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "1.h".
   [1]
 
   $ cat >forbiddenreal02.asl <<EOF
@@ -184,7 +184,7 @@ Forbidden patterns
   File forbiddenreal02.asl, line 1, characters 8 to 11:
   let x = 1._12;
           ^^^
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "1._".
   [1]
 
   $ cat >forbiddenreal03.asl <<EOF
@@ -194,7 +194,7 @@ Forbidden patterns
   File forbiddenreal03.asl, line 1, characters 8 to 13:
   let x = 1.12h12;
           ^^^^^
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "1.12h".
   [1]
 
   $ cat >forbiddenreal04.asl <<EOF
@@ -205,5 +205,5 @@ Forbidden patterns
   File forbiddenreal04.asl, line 2, characters 8 to 11:
   let x = 1._foo;
           ^^^
-  ASL Lexical error (BE_LE): Unknown symbol.
+  ASL Lexical error (BE_LE): Unknown symbol "1._".
   [1]

--- a/asllib/tests/parser-errors.t/run.t
+++ b/asllib/tests/parser-errors.t/run.t
@@ -10,15 +10,15 @@
   File no-expression-elsif.asl, line 1, characters 23 to 28:
   let x = if TRUE then 1 elsif FALSE then 2 else 3;
                          ^^^^^
-  ASL Grammar error: Cannot parse. Use `else if` instead.
+  ASL Grammar error (BE_PE): Cannot parse. Use `else if` instead.
   [1]
 
   $ aslref no_end_semicolon.asl
   File no_end_semicolon.asl, line 6, characters 2 to 8:
     return 0;
     ^^^^^^
-  ASL Grammar error: Cannot parse. The `end` keyword must be followed by a
-    semicolon (`;`).
+  ASL Grammar error (BE_PE): Cannot parse. The `end` keyword must be followed
+    by a semicolon (`;`).
     
   [1]
 
@@ -34,22 +34,23 @@
   File hyphenated-pending-constraint.asl, line 1, characters 14 to 17:
   let x: integer{-} = 5;
                 ^^^
-  ASL Grammar error: Cannot parse. Pending constraints are written `integer{}`.
+  ASL Grammar error (BE_PE): Cannot parse. Pending constraints are written
+    `integer{}`.
   [1]
 
   $ aslref local-constant.asl
   File local-constant.asl, line 3, characters 2 to 10:
     constant x = 1;
     ^^^^^^^^
-  ASL Grammar error: Cannot parse. Local constant declarations are not valid
-    ASL1. Did you mean `let`?.
+  ASL Grammar error (BE_PE): Cannot parse. Local constant declarations are not
+    valid ASL1. Did you mean `let`?.
   [1]
 
   $ aslref single-implication.asl
   File single-implication.asl, line 1, characters 10 to 13:
   let x = a --> b;
             ^^^
-  ASL Grammar error: Cannot parse. Did you mean `==>`?
+  ASL Lexical error (BE_LE): Unknown symbol "-->". Did you mean "==>"?
   [1]
 
   $ aslref binop-same-precedence.asl
@@ -64,23 +65,24 @@
   File empty-record.asl, line 1, characters 10 to 16:
   type X of record;
             ^^^^^^
-  ASL Grammar error: Cannot parse. Empty record types must be declared with
-    empty field list `{-}`.
+  ASL Grammar error (BE_PE): Cannot parse. Empty record types must be declared
+    with empty field list `{-}`.
   [1]
 
   $ aslref global-ignored.asl
   File global-ignored.asl, line 1, characters 4 to 5:
   var - = 1;
       ^
-  ASL Grammar error: Cannot parse. A global declaration must declare a name.
+  ASL Grammar error (BE_PE): Cannot parse. A global declaration must declare a
+    name.
   [1]
 
   $ aslref global-let-comma.asl
   File global-let-comma.asl, line 1, characters 5 to 6:
   let x, y : integer = 1;
        ^
-  ASL Grammar error: Cannot parse. A global `let` declaration must introduce a
-    single name and have an initialising expression:
+  ASL Grammar error (BE_PE): Cannot parse. A global `let` declaration must
+    introduce a single name and have an initialising expression:
       let name = initial_expression;
       let name : type = initial_expression;
     
@@ -90,8 +92,8 @@
   File local-let-no-parentheses.asl, line 3, characters 7 to 8:
     let a, b = foo();
          ^
-  ASL Grammar error: Cannot parse. A local `let` declaration must be of one of
-    the following forms:
+  ASL Grammar error (BE_PE): Cannot parse. A local `let` declaration must be of
+    one of the following forms:
       let name = expression;
       let name : type = expression;
       let (name1, -, ...) = expression;
@@ -103,8 +105,9 @@
   File multiple-configs.asl, line 1, characters 8 to 9:
   config x, y : integer = 1;
           ^
-  ASL Grammar error: Cannot parse. A `config` declaration must introduce a
-    single name, and have both a type annotation and initialising expression:
+  ASL Grammar error (BE_PE): Cannot parse. A `config` declaration must
+    introduce a single name, and have both a type annotation and initialising
+    expression:
       config name : type = initial_expression;
     
   [1]
@@ -113,8 +116,8 @@
   File multiple-constants.asl, line 1, characters 10 to 11:
   constant x, y : integer = 1;
             ^
-  ASL Grammar error: Cannot parse. A `constant` declaration must introduce a
-    single name and have an initialising expression:
+  ASL Grammar error (BE_PE): Cannot parse. A `constant` declaration must
+    introduce a single name and have an initialising expression:
       constant name = initial_expression;
       constant name : type = initial_expression;
     
@@ -124,15 +127,16 @@
   File single-biimplication.asl, line 1, characters 10 to 13:
   let x = a <-> b;
             ^^^
-  ASL Grammar error: Cannot parse. Did you mean `<=>`?
+  ASL Lexical error (BE_LE): Unknown symbol "<->". Did you mean "<=>"?
   [1]
 
   $ aslref uninitialised-config.asl
   File uninitialised-config.asl, line 1, characters 18 to 19:
   config x : integer;
                     ^
-  ASL Grammar error: Cannot parse. A `config` declaration must introduce a
-    single name, and have both a type annotation and initialising expression:
+  ASL Grammar error (BE_PE): Cannot parse. A `config` declaration must
+    introduce a single name, and have both a type annotation and initialising
+    expression:
       config name : type = initial_expression;
     
   [1]
@@ -141,8 +145,8 @@
   File uninitialised-constant.asl, line 1, characters 20 to 21:
   constant x : integer;
                       ^
-  ASL Grammar error: Cannot parse. A `constant` declaration must introduce a
-    single name and have an initialising expression:
+  ASL Grammar error (BE_PE): Cannot parse. A `constant` declaration must
+    introduce a single name and have an initialising expression:
       constant name = initial_expression;
       constant name : type = initial_expression;
     
@@ -152,7 +156,7 @@
   File uninitialised-let.asl, line 1, characters 15 to 16:
   let x : integer;
                  ^
-  ASL Grammar error: Cannot parse. Declarations using `let` must have
+  ASL Grammar error (BE_PE): Cannot parse. Declarations using `let` must have
     initialising expressions.
     
   [1]

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -822,3 +822,10 @@ Static errors:
   ASL Static error (TE_SEF):
     FloorLog2 (primitive) expected an argument greater than 0
   [1]
+  $ aslref tuple-arity-mismatch.asl
+  File tuple-arity-mismatch.asl, line 3, characters 2 to 25:
+    let (x, y) = (1, 2, 3);
+    ^^^^^^^^^^^^^^^^^^^^^^^
+  ASL Type error (TE_UT): Tuple arity mismatch:
+    expected 2 element(s); provided 3.
+  [1]

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -189,8 +189,8 @@ Runtime checks:
   File runtime-type-sat1.asl, line 3, characters 23 to 24:
     let x: integer {1} = 2 as integer {1};
                          ^
-  ASL Dynamic error: Mismatch type:
-    value 2 does not belong to type integer {1}.
+  ASL Dynamic error (DE_TAF):
+    Value 2 does not satisfy the asserted type integer {1}.
   [1]
 
   $ cat >runtime-type-sat2.asl <<EOF
@@ -208,8 +208,8 @@ Runtime checks:
   File runtime-type-sat2.asl, line 2, characters 10 to 18:
     let x = Zeros{4} as bits(size);
             ^^^^^^^^
-  ASL Dynamic error: Mismatch type:
-    value 0x0 does not belong to type bits(size).
+  ASL Dynamic error (DE_TAF):
+    Value 0x0 does not satisfy the asserted type bits(size).
   [1]
 
   $ aslref under-constrained-used.asl
@@ -240,8 +240,8 @@ Parameterized integers:
   File bad-underconstrained-ctc.asl, line 3, characters 12 to 13:
     return x[(N as integer {N - 1})];
               ^
-  ASL Dynamic error: Mismatch type:
-    value 4 does not belong to type integer {(N - 1)}.
+  ASL Dynamic error (DE_TAF):
+    Value 4 does not satisfy the asserted type integer {(N - 1)}.
   [1]
   $ aslref bad-underconstrained-return.asl
   File bad-underconstrained-return.asl, line 3, characters 2 to 15:

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -707,7 +707,7 @@ Left-hand sides
   File lhs-tuple-fields-same-field.asl, line 8, characters 2 to 4:
     bv.(fld, -, fld) = ('11', TRUE, '11');
     ^^
-  ASL Grammar error: multiple writes to "bv.fld".
+  ASL Type error (TE_IAD): multiple writes to "bv.fld".
   [1]
   $ aslref lhs-tuple-same-var.asl
   $ aslref lhs-expressivity.asl

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -72,7 +72,8 @@ Global ignored:
   File global_ignored.asl, line 1, characters 4 to 5:
   var - = 3 / 0;
       ^
-  ASL Grammar error: Cannot parse. A global declaration must declare a name.
+  ASL Grammar error (BE_PE): Cannot parse. A global declaration must declare a
+    name.
   [1]
 
   $ aslref shadow-banning-bug.asl
@@ -300,14 +301,14 @@ Parameterized integers:
   File setter_without_getter.asl, line 6, characters 0 to 3:
   end;
   ^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
 
   $ aslref getter_without_setter.asl
   File getter_without_setter.asl, line 6, characters 0 to 3:
   end;
   ^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
 
   $ aslref tuple_items.asl
@@ -316,7 +317,7 @@ Parameterized integers:
   File duplicated-otherwise.asl, line 7, characters 8 to 12:
           when 0.0 => println "2.0";
           ^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref duplicate_expr_record.asl
   File duplicate_expr_record.asl, line 5, characters 12 to 27:
@@ -424,7 +425,7 @@ Required tests:
   File asl0-patterns.asl, line 7, characters 25 to 29:
       if x[0+:4] IN '10x1' then // invalid
                            ^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref -0 unreachable-v0.asl
   $ aslref assign1.asl
@@ -437,7 +438,7 @@ Required tests:
   File concat-empty.asl, line 3, characters 45 to 46:
     let empty_concatenation_should_not_parse = [];
                                                ^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
   $ aslref concat01.asl
   $ aslref concat02.asl
@@ -566,7 +567,7 @@ Required tests:
   File empty-function.asl, line 3, characters 0 to 3:
   end;
   ^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
 
   $ aslref --no-type-check throw-local-env.asl
@@ -663,7 +664,7 @@ Getters/setters
   File pattern-masks-no-braces.asl, line 4, characters 19 to 24:
     assert ('111' IN '1xx') == TRUE;
                      ^^^^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
 
 ASLRef Field getter extension
@@ -724,7 +725,7 @@ Outdated syntax
   File noreturn_function.asl, line 2, characters 26 to 28:
   noreturn func returning() => integer
                             ^^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
 
 Bounds checks

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -189,8 +189,8 @@ Runtime checks:
   File runtime-type-sat1.asl, line 3, characters 23 to 24:
     let x: integer {1} = 2 as integer {1};
                          ^
-  ASL Dynamic error (DE_TAF):
-    Value 2 does not satisfy the asserted type integer {1}.
+  ASL Dynamic error (DE_TAF): Value 2 does not satisfy the asserted type
+    integer {1}.
   [1]
 
   $ cat >runtime-type-sat2.asl <<EOF
@@ -208,8 +208,8 @@ Runtime checks:
   File runtime-type-sat2.asl, line 2, characters 10 to 18:
     let x = Zeros{4} as bits(size);
             ^^^^^^^^
-  ASL Dynamic error (DE_TAF):
-    Value 0x0 does not satisfy the asserted type bits(size).
+  ASL Dynamic error (DE_TAF): Value 0x0 does not satisfy the asserted type
+    bits(size).
   [1]
 
   $ aslref under-constrained-used.asl
@@ -240,8 +240,8 @@ Parameterized integers:
   File bad-underconstrained-ctc.asl, line 3, characters 12 to 13:
     return x[(N as integer {N - 1})];
               ^
-  ASL Dynamic error (DE_TAF):
-    Value 4 does not satisfy the asserted type integer {(N - 1)}.
+  ASL Dynamic error (DE_TAF): Value 4 does not satisfy the asserted type
+    integer {(N - 1)}.
   [1]
   $ aslref bad-underconstrained-return.asl
   File bad-underconstrained-return.asl, line 3, characters 2 to 15:
@@ -707,7 +707,7 @@ Left-hand sides
   File lhs-tuple-fields-same-field.asl, line 8, characters 2 to 4:
     bv.(fld, -, fld) = ('11', TRUE, '11');
     ^^
-  ASL Type error (TE_IAD): multiple writes to "bv.fld".
+  ASL Grammar error (BE_PE): multiple writes to "bv.fld".
   [1]
   $ aslref lhs-tuple-same-var.asl
   $ aslref lhs-expressivity.asl

--- a/asllib/tests/regressions.t/tuple-arity-mismatch.asl
+++ b/asllib/tests/regressions.t/tuple-arity-mismatch.asl
@@ -1,0 +1,4 @@
+func main()
+begin
+  let (x, y) = (1, 2, 3);
+end;

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -541,8 +541,8 @@
   File global-throw-initialisation.asl, line 8, characters 0 to 29:
   let X: integer = throwing ();
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  ASL Dynamic error: unexpected exception E thrown during the evaluation of the
-    initialisation of the global storage element "X".
+  ASL Dynamic error (DE_UE): unexpected exception E thrown during the
+    evaluation of the initialisation of the global storage element "X".
   [1]
 
   $ aslref config-type-uses-let.asl

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -73,8 +73,8 @@
   File binop-write-atc.asl, line 5, characters 10 to 11:
     return (1 as integer {2});
             ^
-  ASL Dynamic error: Mismatch type:
-    value 1 does not belong to type integer {2}.
+  ASL Dynamic error (DE_TAF):
+    Value 1 does not satisfy the asserted type integer {2}.
   [1]
 // We don't need to decide about the following:
 // $ aslref binop-atc-atc.asl
@@ -228,8 +228,8 @@
   File config-uses-atc.asl, line 3, characters 9 to 10:
     return 0 as integer {10};
            ^
-  ASL Dynamic error: Mismatch type:
-    value 0 does not belong to type integer {10}.
+  ASL Dynamic error (DE_TAF):
+    Value 0 does not satisfy the asserted type integer {10}.
   [1]
   $ aslref config-uses-unknown.asl
   File config-uses-unknown.asl, line 3, characters 2 to 36:
@@ -256,8 +256,8 @@
   File assert-atc.asl, line 3, characters 9 to 10:
     assert 0 as integer {3} == 2;
            ^
-  ASL Dynamic error: Mismatch type:
-    value 0 does not belong to type integer {3}.
+  ASL Dynamic error (DE_TAF):
+    Value 0 does not satisfy the asserted type integer {3}.
   [1]
 
   $ aslref type-read-config.asl
@@ -295,8 +295,8 @@
   File type-func-atc.asl, line 3, characters 9 to 10:
     assert 0 as integer {3} == 2;
            ^
-  ASL Dynamic error: Mismatch type:
-    value 0 does not belong to type integer {3}.
+  ASL Dynamic error (DE_TAF):
+    Value 0 does not satisfy the asserted type integer {3}.
   [1]
   $ aslref type-func-local-var.asl
   $ aslref type-local-var.asl
@@ -317,8 +317,8 @@
   File assert-atc.asl, line 3, characters 9 to 10:
     assert 0 as integer {3} == 2;
            ^
-  ASL Dynamic error: Mismatch type:
-    value 0 does not belong to type integer {3}.
+  ASL Dynamic error (DE_TAF):
+    Value 0 does not satisfy the asserted type integer {3}.
   [1]
   $ aslref assert-read.asl
   $ aslref assert-throw.asl
@@ -357,8 +357,8 @@
   File rec-binop-atc-throw.asl, line 15, characters 37 to 38:
     let x = throwing (n - 1, FALSE) * (2 as integer {3});
                                        ^
-  ASL Dynamic error: Mismatch type:
-    value 2 does not belong to type integer {3}.
+  ASL Dynamic error (DE_TAF):
+    Value 2 does not satisfy the asserted type integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-binop-atc-throw.asl
   File rec-binop-atc-throw.asl, line 15, characters 10 to 54:
@@ -429,8 +429,8 @@
   File rec-assert.asl, line 9, characters 34 to 35:
     let x = not_throwing (n - 1) * (2 as integer {3});
                                     ^
-  ASL Dynamic error: Mismatch type:
-    value 2 does not belong to type integer {3}.
+  ASL Dynamic error (DE_TAF):
+    Value 2 does not satisfy the asserted type integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-assert.asl
   File rec-assert.asl, line 9, characters 10 to 51:
@@ -450,8 +450,8 @@
   File rec-binop-atc.asl, line 9, characters 34 to 35:
     let x = not_throwing (n - 1) * (2 as integer {3});
                                     ^
-  ASL Dynamic error: Mismatch type:
-    value 2 does not belong to type integer {3}.
+  ASL Dynamic error (DE_TAF):
+    Value 2 does not satisfy the asserted type integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-binop-atc.asl
   File rec-binop-atc.asl, line 9, characters 10 to 51:

--- a/asllib/tests/side-effects.t/run.t
+++ b/asllib/tests/side-effects.t/run.t
@@ -73,8 +73,8 @@
   File binop-write-atc.asl, line 5, characters 10 to 11:
     return (1 as integer {2});
             ^
-  ASL Dynamic error (DE_TAF):
-    Value 1 does not satisfy the asserted type integer {2}.
+  ASL Dynamic error (DE_TAF): Value 1 does not satisfy the asserted type
+    integer {2}.
   [1]
 // We don't need to decide about the following:
 // $ aslref binop-atc-atc.asl
@@ -228,8 +228,8 @@
   File config-uses-atc.asl, line 3, characters 9 to 10:
     return 0 as integer {10};
            ^
-  ASL Dynamic error (DE_TAF):
-    Value 0 does not satisfy the asserted type integer {10}.
+  ASL Dynamic error (DE_TAF): Value 0 does not satisfy the asserted type
+    integer {10}.
   [1]
   $ aslref config-uses-unknown.asl
   File config-uses-unknown.asl, line 3, characters 2 to 36:
@@ -256,8 +256,8 @@
   File assert-atc.asl, line 3, characters 9 to 10:
     assert 0 as integer {3} == 2;
            ^
-  ASL Dynamic error (DE_TAF):
-    Value 0 does not satisfy the asserted type integer {3}.
+  ASL Dynamic error (DE_TAF): Value 0 does not satisfy the asserted type
+    integer {3}.
   [1]
 
   $ aslref type-read-config.asl
@@ -295,8 +295,8 @@
   File type-func-atc.asl, line 3, characters 9 to 10:
     assert 0 as integer {3} == 2;
            ^
-  ASL Dynamic error (DE_TAF):
-    Value 0 does not satisfy the asserted type integer {3}.
+  ASL Dynamic error (DE_TAF): Value 0 does not satisfy the asserted type
+    integer {3}.
   [1]
   $ aslref type-func-local-var.asl
   $ aslref type-local-var.asl
@@ -317,8 +317,8 @@
   File assert-atc.asl, line 3, characters 9 to 10:
     assert 0 as integer {3} == 2;
            ^
-  ASL Dynamic error (DE_TAF):
-    Value 0 does not satisfy the asserted type integer {3}.
+  ASL Dynamic error (DE_TAF): Value 0 does not satisfy the asserted type
+    integer {3}.
   [1]
   $ aslref assert-read.asl
   $ aslref assert-throw.asl
@@ -357,8 +357,8 @@
   File rec-binop-atc-throw.asl, line 15, characters 37 to 38:
     let x = throwing (n - 1, FALSE) * (2 as integer {3});
                                        ^
-  ASL Dynamic error (DE_TAF):
-    Value 2 does not satisfy the asserted type integer {3}.
+  ASL Dynamic error (DE_TAF): Value 2 does not satisfy the asserted type
+    integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-binop-atc-throw.asl
   File rec-binop-atc-throw.asl, line 15, characters 10 to 54:
@@ -429,8 +429,8 @@
   File rec-assert.asl, line 9, characters 34 to 35:
     let x = not_throwing (n - 1) * (2 as integer {3});
                                     ^
-  ASL Dynamic error (DE_TAF):
-    Value 2 does not satisfy the asserted type integer {3}.
+  ASL Dynamic error (DE_TAF): Value 2 does not satisfy the asserted type
+    integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-assert.asl
   File rec-assert.asl, line 9, characters 10 to 51:
@@ -450,8 +450,8 @@
   File rec-binop-atc.asl, line 9, characters 34 to 35:
     let x = not_throwing (n - 1) * (2 as integer {3});
                                     ^
-  ASL Dynamic error (DE_TAF):
-    Value 2 does not satisfy the asserted type integer {3}.
+  ASL Dynamic error (DE_TAF): Value 2 does not satisfy the asserted type
+    integer {3}.
   [1]
   $ aslref --use-conflicting-side-effects-extension rec-binop-atc.asl
   File rec-binop-atc.asl, line 9, characters 10 to 51:

--- a/asllib/tests/typing.t/run.t
+++ b/asllib/tests/typing.t/run.t
@@ -507,7 +507,7 @@ C Tests
   File CNegative12.asl, line 2, characters 56 to 57:
   func negative12{N}(bv : bits(N), N: integer, bv2 : bits({0..N}))
                                                           ^
-  ASL Grammar error: Cannot parse.
+  ASL Grammar error (BE_PE): Cannot parse.
   [1]
 
 Extra tests by ASLRef team


### PR DESCRIPTION
## Distinguish lexical and parse failures
Lexer-detected invalid symbols now use `UnknownSymbol` and report `BE_LE`, preserving suggested replacements, while the remaining `CannotParse` errors report `BE_PE`.

## Classify global-initialization exceptions
Exceptions escaping global initialization now report `DE_UE`, and `build_genv` in `asl.spec` converts the corresponding throwing result to `DynamicError(DE_UE)`.

## Classify asserted-type-conversion failures
Failed asserted type conversions now use `ATCFailure`, reporting `DE_TAF` during dynamic evaluation and `TE_SEF` during static evaluation as specified by `asl.spec`.

## Classify repeated tuple-field writes
Repeated fields in tuple assignments now report `TE_IAD`, matching the specification's use of `check_no_duplicates` rather than the rework PR's disputed `BE_PE` mapping.

## Distinguish call and tuple arity failures
Static call arity failures now report `TE_BC` through `BadCallArity`, while tuple arity failures report `TE_UT` through `BadTupleArity`; unchecked runtime arity failures remain uncoded.
