### PR TITLE
[litmus] Warn when timebase counter is not available in standard mode.

### DIFF
--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -302,6 +302,11 @@ module Make
 
       let have_timebase = Insert.exists "timebase.c"
 
+      let () =
+        if do_timebase && not have_timebase then
+          Warn.warn_always
+            "No timebase counter, resort to simple reverse sense barriers" 
+
       (* Location utilities *)
       let get_global_names t = List.map fst t.T.globals
 


### PR DESCRIPTION
By contrast with presi/kvm mode, if no timebase counter  is available in standard mode, there is no fatal error.

Instead, synchronisation is performed by a simple reverse sense barrier, without the extra poll loop for time based synchronisation. Warn users about this.