### PR TITLE
Slight output format changes for **herd7** and **litmus7**

### DIFF
--- a/gen/tests/AArch64.MTE/LB+dmb.sy+amo.ldaddal-polt.litmus.expected
+++ b/gen/tests/AArch64.MTE/LB+dmb.sy+amo.ldaddal-polt.litmus.expected
@@ -1,10 +1,10 @@
 Test LB+dmb.sy+amo.ldaddal-polt Allowed
 States 6
-0:X1=0; 1:X1=0; [y]=1;  ~Fault(P0);
+0:X1=0; 1:X1=0; [y]=1; ~Fault(P0);
 0:X1=0; 1:X1=0; [y]=1; Fault(P0,TagCheck);
-0:X1=0; 1:X1=1; [y]=1;  ~Fault(P0);
+0:X1=0; 1:X1=1; [y]=1; ~Fault(P0);
 0:X1=0; 1:X1=1; [y]=1; Fault(P0,TagCheck);
-0:X1=0; 1:X1=1; [y]=3;  ~Fault(P0);
+0:X1=0; 1:X1=1; [y]=3; ~Fault(P0);
 0:X1=0; 1:X1=1; [y]=3; Fault(P0,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/LB+dmb.sypt+amo.ldaddal-polp.litmus.expected
+++ b/gen/tests/AArch64.MTE/LB+dmb.sypt+amo.ldaddal-polp.litmus.expected
@@ -1,8 +1,8 @@
 Test LB+dmb.sypt+amo.ldaddal-polp Allowed
 States 4
-0:X1=0; 1:X1=0; [y]=1;  ~Fault(P1);
+0:X1=0; 1:X1=0; [y]=1; ~Fault(P1);
 0:X1=0; 1:X1=0; [y]=1; Fault(P1,TagCheck);
-0:X1=1; 1:X1=0; [y]=1;  ~Fault(P1);
+0:X1=1; 1:X1=0; [y]=1; ~Fault(P1);
 0:X1=1; 1:X1=0; [y]=1; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/LB+dmb.sypt+amo.ldaddal-polt.litmus.expected
+++ b/gen/tests/AArch64.MTE/LB+dmb.sypt+amo.ldaddal-polt.litmus.expected
@@ -1,6 +1,6 @@
 Test LB+dmb.sypt+amo.ldaddal-polt Allowed
 States 4
-0:X1=0; 1:X1=0; [y]=1;  ~Fault(P1); ~Fault(P0);
+0:X1=0; 1:X1=0; [y]=1; ~Fault(P1); ~Fault(P0);
 0:X1=0; 1:X1=0; [y]=1; Fault(P0,TagCheck); ~Fault(P1);
 0:X1=0; 1:X1=0; [y]=1; Fault(P0,TagCheck); Fault(P1,TagCheck);
 0:X1=0; 1:X1=0; [y]=1; Fault(P1,TagCheck); ~Fault(P0);

--- a/gen/tests/AArch64.MTE/LB+dmb.sytt+amo.ldaddal-polp.litmus.expected
+++ b/gen/tests/AArch64.MTE/LB+dmb.sytt+amo.ldaddal-polp.litmus.expected
@@ -1,6 +1,6 @@
 Test LB+dmb.sytt+amo.ldaddal-polp Allowed
 States 2
-0:X0=x:green; 1:X0=0; [y]=1;  ~Fault(P1);
+0:X0=x:green; 1:X0=0; [y]=1; ~Fault(P1);
 0:X0=x:green; 1:X0=0; [y]=1; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/LB+dmb.sytt+amo.ldaddal-polt.litmus.expected
+++ b/gen/tests/AArch64.MTE/LB+dmb.sytt+amo.ldaddal-polt.litmus.expected
@@ -1,8 +1,8 @@
 Test LB+dmb.sytt+amo.ldaddal-polt Allowed
 States 4
-0:X0=x:green; 1:X0=0; [y]=1;  ~Fault(P1);
+0:X0=x:green; 1:X0=0; [y]=1; ~Fault(P1);
 0:X0=x:green; 1:X0=0; [y]=1; Fault(P1,TagCheck);
-0:X0=x:red; 1:X0=0; [y]=1;  ~Fault(P1);
+0:X0=x:red; 1:X0=0; [y]=1; ~Fault(P1);
 0:X0=x:red; 1:X0=0; [y]=1; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/MP+dmb.sypt+amo.ldaddal-polp.litmus.expected
+++ b/gen/tests/AArch64.MTE/MP+dmb.sypt+amo.ldaddal-polp.litmus.expected
@@ -1,8 +1,8 @@
 Test MP+dmb.sypt+amo.ldaddal-polp Allowed
 States 4
-1:X0=0; 1:X5=0; [y]=1;  ~Fault(P1);
+1:X0=0; 1:X5=0; [y]=1; ~Fault(P1);
 1:X0=0; 1:X5=0; [y]=1; Fault(P1,TagCheck);
-1:X0=0; 1:X5=1; [y]=1;  ~Fault(P1);
+1:X0=0; 1:X5=1; [y]=1; ~Fault(P1);
 1:X0=0; 1:X5=1; [y]=1; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/MP+dmb.sypt+amo.ldaddal-polt.litmus.expected
+++ b/gen/tests/AArch64.MTE/MP+dmb.sypt+amo.ldaddal-polt.litmus.expected
@@ -1,6 +1,6 @@
 Test MP+dmb.sypt+amo.ldaddal-polt Allowed
 States 2
-1:X0=0; 1:X5=x:green; [y]=1;  ~Fault(P1);
+1:X0=0; 1:X5=x:green; [y]=1; ~Fault(P1);
 1:X0=0; 1:X5=x:green; [y]=1; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/MP+dmb.sytp+amo.ldaddal-polp.litmus.expected
+++ b/gen/tests/AArch64.MTE/MP+dmb.sytp+amo.ldaddal-polp.litmus.expected
@@ -1,10 +1,10 @@
 Test MP+dmb.sytp+amo.ldaddal-polp Allowed
 States 6
-1:X2=0; 1:X5=0; [y]=1;  ~Fault(P1);
+1:X2=0; 1:X5=0; [y]=1; ~Fault(P1);
 1:X2=0; 1:X5=0; [y]=1; Fault(P1,TagCheck);
-1:X2=1; 1:X5=0; [y]=1;  ~Fault(P1);
+1:X2=1; 1:X5=0; [y]=1; ~Fault(P1);
 1:X2=1; 1:X5=0; [y]=1; Fault(P1,TagCheck);
-1:X2=1; 1:X5=0; [y]=3;  ~Fault(P1);
+1:X2=1; 1:X5=0; [y]=3; ~Fault(P1);
 1:X2=1; 1:X5=0; [y]=3; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/MP+dmb.sytt+amo.ldaddal-polp.litmus.expected
+++ b/gen/tests/AArch64.MTE/MP+dmb.sytt+amo.ldaddal-polp.litmus.expected
@@ -1,6 +1,6 @@
 Test MP+dmb.sytt+amo.ldaddal-polp Allowed
 States 2
-1:X4=0; 1:X6=0; [y]=1;  ~Fault(P1);
+1:X4=0; 1:X6=0; [y]=1; ~Fault(P1);
 1:X4=0; 1:X6=0; [y]=1; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/MP+dmb.sytt+amo.ldaddal-polt.litmus.expected
+++ b/gen/tests/AArch64.MTE/MP+dmb.sytt+amo.ldaddal-polt.litmus.expected
@@ -1,8 +1,8 @@
 Test MP+dmb.sytt+amo.ldaddal-polt Allowed
 States 4
-1:X4=0; 1:X6=x:green; [y]=1;  ~Fault(P1);
+1:X4=0; 1:X6=x:green; [y]=1; ~Fault(P1);
 1:X4=0; 1:X6=x:green; [y]=1; Fault(P1,TagCheck);
-1:X4=0; 1:X6=x:red; [y]=1;  ~Fault(P1);
+1:X4=0; 1:X6=x:red; [y]=1; ~Fault(P1);
 1:X4=0; 1:X6=x:red; [y]=1; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/S+dmb.sy+amo.ldaddal-polt.litmus.expected
+++ b/gen/tests/AArch64.MTE/S+dmb.sy+amo.ldaddal-polt.litmus.expected
@@ -1,10 +1,10 @@
 Test S+dmb.sy+amo.ldaddal-polt Allowed
 States 6
-1:X0=0; [x]=1; [y]=1;  ~Fault(P0);
+1:X0=0; [x]=1; [y]=1; ~Fault(P0);
 1:X0=0; [x]=1; [y]=1; Fault(P0,TagCheck);
-1:X0=1; [x]=1; [y]=1;  ~Fault(P0);
+1:X0=1; [x]=1; [y]=1; ~Fault(P0);
 1:X0=1; [x]=1; [y]=1; Fault(P0,TagCheck);
-1:X0=1; [x]=1; [y]=3;  ~Fault(P0);
+1:X0=1; [x]=1; [y]=3; ~Fault(P0);
 1:X0=1; [x]=1; [y]=3; Fault(P0,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/S+dmb.sypt+amo.ldaddal-polp.litmus.expected
+++ b/gen/tests/AArch64.MTE/S+dmb.sypt+amo.ldaddal-polp.litmus.expected
@@ -1,8 +1,8 @@
 Test S+dmb.sypt+amo.ldaddal-polp Allowed
 States 4
-1:X0=0; [x]=1; [y]=1;  ~Fault(P1);
+1:X0=0; [x]=1; [y]=1; ~Fault(P1);
 1:X0=0; [x]=1; [y]=1; Fault(P1,TagCheck);
-1:X0=0; [x]=2; [y]=1;  ~Fault(P1);
+1:X0=0; [x]=2; [y]=1; ~Fault(P1);
 1:X0=0; [x]=2; [y]=1; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/S+dmb.sypt+amo.ldaddal-polt.litmus.expected
+++ b/gen/tests/AArch64.MTE/S+dmb.sypt+amo.ldaddal-polt.litmus.expected
@@ -1,6 +1,6 @@
 Test S+dmb.sypt+amo.ldaddal-polt Allowed
 States 4
-1:X0=0; [x]=1; [y]=1;  ~Fault(P1); ~Fault(P0);
+1:X0=0; [x]=1; [y]=1; ~Fault(P1); ~Fault(P0);
 1:X0=0; [x]=1; [y]=1; Fault(P0,TagCheck); ~Fault(P1);
 1:X0=0; [x]=1; [y]=1; Fault(P0,TagCheck); Fault(P1,TagCheck);
 1:X0=0; [x]=1; [y]=1; Fault(P1,TagCheck); ~Fault(P0);

--- a/gen/tests/AArch64.MTE/S+dmb.sytp+amo.ldaddal-polp.litmus.expected
+++ b/gen/tests/AArch64.MTE/S+dmb.sytp+amo.ldaddal-polp.litmus.expected
@@ -1,10 +1,10 @@
 Test S+dmb.sytp+amo.ldaddal-polp Allowed
 States 6
-1:X2=0; [y]=1; [tag(x)]=:red;  ~Fault(P1);
+1:X2=0; [y]=1; [tag(x)]=:red; ~Fault(P1);
 1:X2=0; [y]=1; [tag(x)]=:red; Fault(P1,TagCheck);
-1:X2=1; [y]=1; [tag(x)]=:red;  ~Fault(P1);
+1:X2=1; [y]=1; [tag(x)]=:red; ~Fault(P1);
 1:X2=1; [y]=1; [tag(x)]=:red; Fault(P1,TagCheck);
-1:X2=1; [y]=3; [tag(x)]=:red;  ~Fault(P1);
+1:X2=1; [y]=3; [tag(x)]=:red; ~Fault(P1);
 1:X2=1; [y]=3; [tag(x)]=:red; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/S+dmb.sytt+amo.ldaddal-polp.litmus.expected
+++ b/gen/tests/AArch64.MTE/S+dmb.sytt+amo.ldaddal-polp.litmus.expected
@@ -1,6 +1,6 @@
 Test S+dmb.sytt+amo.ldaddal-polp Allowed
 States 2
-1:X4=0; [y]=1; [tag(x)]=:red;  ~Fault(P1);
+1:X4=0; [y]=1; [tag(x)]=:red; ~Fault(P1);
 1:X4=0; [y]=1; [tag(x)]=:red; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/gen/tests/AArch64.MTE/S+dmb.sytt+amo.ldaddal-polt.litmus.expected
+++ b/gen/tests/AArch64.MTE/S+dmb.sytt+amo.ldaddal-polt.litmus.expected
@@ -1,8 +1,8 @@
 Test S+dmb.sytt+amo.ldaddal-polt Allowed
 States 4
-1:X4=0; [y]=1; [tag(x)]=:blue;  ~Fault(P1);
+1:X4=0; [y]=1; [tag(x)]=:blue; ~Fault(P1);
 1:X4=0; [y]=1; [tag(x)]=:blue; Fault(P1,TagCheck);
-1:X4=0; [y]=1; [tag(x)]=:red;  ~Fault(P1);
+1:X4=0; [y]=1; [tag(x)]=:red; ~Fault(P1);
 1:X4=0; [y]=1; [tag(x)]=:red; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/herd/archExtra_herd.ml
+++ b/herd/archExtra_herd.ml
@@ -1034,8 +1034,9 @@ module Make(C:Config) (I:I) : S with module I = I
                 (fun f -> FaultAtomSet.exists
                     (fun f0 -> check_one_fatom f f0) fobs)
                 flts in
-          pp_st ^ " " ^
-          FaultSet.pp_str " "  (fun f -> pp_fault (data_intr_to_any_flt f) ^ ";")  flts ^
+          pp_st ^
+          FaultSet.pp_str ""
+            (fun f -> " " ^ pp_fault (data_intr_to_any_flt f) ^ ";")  flts ^
           String.concat "" noflts ^
           pp_solver
 

--- a/herd/tests/instructions/AArch64.MTE/B002.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B002.litmus.expected
@@ -1,6 +1,6 @@
 Test B002 Required
 States 1
-0:X5=2; [x]=1;  ~Fault(P0,x);
+0:X5=2; [x]=1; ~Fault(P0,x);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.MTE/B010.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B010.litmus.expected
@@ -1,6 +1,6 @@
 Test B010 Required
 States 1
-  ~Fault(P0,x);
+ ~Fault(P0,x);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.MTE/B012.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/B012.litmus.expected
@@ -1,6 +1,6 @@
 Test B012 Required
 States 1
-  ~Fault(P0,x);
+ ~Fault(P0,x);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.MTE/L01.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/L01.litmus.expected
@@ -1,8 +1,8 @@
 Test S+dmb.sytt+addrpt Allowed
 States 4
-1:X1=0; [tag(x)]=:blue;  ~Fault(P1);
+1:X1=0; [tag(x)]=:blue; ~Fault(P1);
 1:X1=0; [tag(x)]=:blue; Fault(P1,TagCheck);
-1:X1=0; [tag(x)]=:red;  ~Fault(P1);
+1:X1=0; [tag(x)]=:red; ~Fault(P1);
 1:X1=0; [tag(x)]=:red; Fault(P1,TagCheck);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.MTE/S01.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/S01.litmus.expected
@@ -1,6 +1,6 @@
 Test S01 Allowed
 States 2
-  ~Fault(P0,x);
+ ~Fault(P0,x);
  Fault(P0,x:red,TagCheck);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.MTE/Y014.litmus.expected
+++ b/herd/tests/instructions/AArch64.MTE/Y014.litmus.expected
@@ -1,6 +1,6 @@
 Test MP+dmb.st+irg.v2 Allowed
 States 16
-1:X0=0; 1:X2=0;  ~Fault(P1);
+1:X0=0; 1:X2=0; ~Fault(P1);
 1:X0=0; 1:X2=0; Fault(P1,x:black,TagCheck);
 1:X0=0; 1:X2=0; Fault(P1,x:blue,TagCheck);
 1:X0=0; 1:X2=0; Fault(P1,x:cyan,TagCheck);
@@ -14,8 +14,8 @@ States 16
 1:X0=0; 1:X2=2; Fault(P1,x:magenta,TagCheck);
 1:X0=0; 1:X2=2; Fault(P1,x:white,TagCheck);
 1:X0=0; 1:X2=2; Fault(P1,x:yellow,TagCheck);
-1:X0=1; 1:X2=0;  ~Fault(P1);
-1:X0=1; 1:X2=2;  ~Fault(P1);
+1:X0=1; 1:X2=0; ~Fault(P1);
+1:X0=1; 1:X2=2; ~Fault(P1);
 No
 Witnesses
 Positive: 0 Negative: 16

--- a/herd/tests/instructions/AArch64.PAC/A01.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A01.litmus.expected
@@ -1,6 +1,6 @@
 Test A01 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A02.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A02.litmus.expected
@@ -1,6 +1,6 @@
 Test A02 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A03.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A03.litmus.expected
@@ -1,6 +1,6 @@
 Test A03 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A04.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A04.litmus.expected
@@ -1,6 +1,6 @@
 Test A04 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A05.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A05.litmus.expected
@@ -1,6 +1,6 @@
 Test A05 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A06.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A06.litmus.expected
@@ -1,6 +1,6 @@
 Test A06 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A07.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A07.litmus.expected
@@ -1,6 +1,6 @@
 Test A07 Allowed
 States 2
-0:X1=42;  ~Fault(P0,MMU:Translation); pacda(x,0x35)=x;
+0:X1=42; ~Fault(P0,MMU:Translation); pacda(x,0x35)=x;
 0:X1=53; Fault(P0,x,MMU:Translation);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.PAC/A08.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A08.litmus.expected
@@ -1,6 +1,6 @@
 Test A08 Allowed
 States 2
-0:X1=42;  ~Fault(P0); pacda(x,0x35)=x;
+0:X1=42; ~Fault(P0); pacda(x,0x35)=x;
 0:X1=53; Fault(P0,x,D-MMU:Translation);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.PAC/A09.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A09.litmus.expected
@@ -1,7 +1,7 @@
 Test A09 Required
 States 2
-0:X1=42;  ~Fault(P0);
-0:X1=42;  ~Fault(P0); pacda(x,0x35)=x;
+0:X1=42; ~Fault(P0);
+0:X1=42; ~Fault(P0); pacda(x,0x35)=x;
 Ok
 Witnesses
 Positive: 2 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A10.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A10.litmus.expected
@@ -1,6 +1,6 @@
 Test A10 Allowed
 States 2
-0:X1=42;  ~Fault(P0,MMU:Translation); pacda(x,0x35)=x;
+0:X1=42; ~Fault(P0,MMU:Translation); pacda(x,0x35)=x;
 0:X1=53; Fault(P0,x,MMU:Translation);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.PAC/A11.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A11.litmus.expected
@@ -1,6 +1,6 @@
 Test A08 Allowed
 States 2
-0:X1=42;  ~Fault(P0); pacda(x,0x35)=x;
+0:X1=42; ~Fault(P0); pacda(x,0x35)=x;
 0:X1=53; Fault(P0,x,D-MMU:Translation);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.PAC/A15.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A15.litmus.expected
@@ -1,6 +1,6 @@
 Test A15 Required
 States 2
-0:X3=0;  ~Fault(P0,MMU:Translation); pacda(x,0x35)=x;
+0:X3=0; ~Fault(P0,MMU:Translation); pacda(x,0x35)=x;
 0:X3=42; Fault(P0,x,MMU:Translation);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.PAC/A16.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A16.litmus.expected
@@ -1,6 +1,6 @@
 Test A16 Required
 States 4
-0:X4=0;  ~Fault(P2,MMU:Translation); ~Fault(P1,MMU:Translation); pacdb(x,0x2a)=x; pacda(x,0x35)=x;
+0:X4=0; ~Fault(P2,MMU:Translation); ~Fault(P1,MMU:Translation); pacdb(x,0x2a)=x; pacda(x,0x35)=x;
 0:X4=1; Fault(P1,x,MMU:Translation); ~Fault(P2,MMU:Translation); pacdb(x,0x2a)=x;
 0:X4=1; Fault(P1,x,MMU:Translation); Fault(P2,x,MMU:Translation);
 0:X4=1; Fault(P2,x,MMU:Translation); ~Fault(P1,MMU:Translation); pacda(x,0x35)=x;

--- a/herd/tests/instructions/AArch64.PAC/A17.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A17.litmus.expected
@@ -1,6 +1,6 @@
 Test A17 Required
 States 4
-0:X4=0;  ~Fault(P2,MMU:Translation); ~Fault(P1,MMU:Translation); pacia(x,0x2a)=x; pacda(x,0x35)=x;
+0:X4=0; ~Fault(P2,MMU:Translation); ~Fault(P1,MMU:Translation); pacia(x,0x2a)=x; pacda(x,0x35)=x;
 0:X4=0; Fault(P1,x,MMU:Translation); Fault(P2,x,MMU:Translation);
 0:X4=1; Fault(P1,x,MMU:Translation); ~Fault(P2,MMU:Translation); pacia(x,0x2a)=x;
 0:X4=1; Fault(P2,x,MMU:Translation); ~Fault(P1,MMU:Translation); pacda(x,0x35)=x;

--- a/herd/tests/instructions/AArch64.PAC/A20.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A20.litmus.expected
@@ -1,6 +1,6 @@
 Test A20 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A21.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A21.litmus.expected
@@ -1,6 +1,6 @@
 Test A21 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A22.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A22.litmus.expected
@@ -1,6 +1,6 @@
 Test A22 Allowed
 States 2
-  ~Fault(P0,MMU:Translation); pacda(x,0x0)=x;
+ ~Fault(P0,MMU:Translation); pacda(x,0x0)=x;
  Fault(P0,x,MMU:Translation);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.PAC/A23.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A23.litmus.expected
@@ -1,7 +1,7 @@
 Test A23 Allowed
 States 2
 0:X1=0; Fault(P0,x,MMU:Translation);
-0:X1=42;  ~Fault(P0,MMU:Translation); pacda(x,0x0)=x;
+0:X1=42; ~Fault(P0,MMU:Translation); pacda(x,0x0)=x;
 Ok
 Witnesses
 Positive: 1 Negative: 1

--- a/herd/tests/instructions/AArch64.PAC/A25.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A25.litmus.expected
@@ -1,10 +1,10 @@
 Test A25 Required
 States 5
-0:X1=42;  ~Fault(P0);
-0:X1=42;  ~Fault(P0); pacda(x,0x0)=x;
-0:X1=42;  ~Fault(P0); pacdb(x,0x0)=x; pacda(x,0x0)=x;
-0:X1=42;  ~Fault(P0); pacda(x,0x0)=pacdb(x,0x0);
-0:X1=42;  ~Fault(P0); pacdb(x,0x0)=x;
+0:X1=42; ~Fault(P0);
+0:X1=42; ~Fault(P0); pacda(x,0x0)=x;
+0:X1=42; ~Fault(P0); pacdb(x,0x0)=x; pacda(x,0x0)=x;
+0:X1=42; ~Fault(P0); pacda(x,0x0)=pacdb(x,0x0);
+0:X1=42; ~Fault(P0); pacdb(x,0x0)=x;
 Ok
 Witnesses
 Positive: 5 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A26.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A26.litmus.expected
@@ -1,9 +1,9 @@
 Test A26 Required
 States 4
-0:X1=42;  ~Fault(P0);
-0:X1=42;  ~Fault(P0); pacda(x,0x0)=x;
-0:X1=42;  ~Fault(P0); pacdb(x,0x0)=x; pacda(x,0x0)=x;
-0:X1=42;  ~Fault(P0); pacda(x,0x0)=pacdb(x,0x0);
+0:X1=42; ~Fault(P0);
+0:X1=42; ~Fault(P0); pacda(x,0x0)=x;
+0:X1=42; ~Fault(P0); pacdb(x,0x0)=x; pacda(x,0x0)=x;
+0:X1=42; ~Fault(P0); pacda(x,0x0)=pacdb(x,0x0);
 Ok
 Witnesses
 Positive: 4 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A27.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A27.litmus.expected
@@ -1,6 +1,6 @@
 Test A27 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A28.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A28.litmus.expected
@@ -1,6 +1,6 @@
 Test A28 Required
 States 1
-0:X1=42;  ~Fault(P0);
+0:X1=42; ~Fault(P0);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.PAC/A31.litmus.expected
+++ b/herd/tests/instructions/AArch64.PAC/A31.litmus.expected
@@ -1,7 +1,7 @@
 Test A31 Required
 States 2
 0:X3=0; Fault(P0:L0,PacCheck:DA);
-0:X3=1;  ~Fault(P0:L0,PacCheck:DA); pacda(x,0x0)=x;
+0:X3=1; ~Fault(P0:L0,PacCheck:DA); pacda(x,0x0)=x;
 Ok
 Witnesses
 Positive: 2 Negative: 0

--- a/herd/tests/instructions/AArch64.gcs/G000.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G000.litmus.expected
@@ -1,7 +1,7 @@
 Test G000 Required
 States 2
-0:X1=0;  ~Fault(P0);
-0:X1=4;  ~Fault(P0);
+0:X1=0; ~Fault(P0);
+0:X1=4; ~Fault(P0);
 No
 Witnesses
 Positive: 1 Negative: 1

--- a/herd/tests/instructions/AArch64.gcs/G001.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G001.litmus.expected
@@ -1,6 +1,6 @@
 Test G001 Required
 States 2
-  ~Fault(P0:L0,GCS:POPM);
+ ~Fault(P0:L0,GCS:POPM);
  Fault(P0:L0,GCS:POPM);
 No
 Witnesses

--- a/herd/tests/instructions/AArch64.gcs/G002.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G002.litmus.expected
@@ -1,6 +1,6 @@
 Test G002 Required
 States 2
-0:X0=0;  ~Fault(P0);
+0:X0=0; ~Fault(P0);
 0:X0=0; Fault(P0:L0,GCS:PRET);
 No
 Witnesses

--- a/herd/tests/instructions/AArch64.gcs/G003.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G003.litmus.expected
@@ -1,6 +1,6 @@
 Test G003 Required
 States 2
-0:X0=0;  ~Fault(P0);
+0:X0=0; ~Fault(P0);
 0:X0=0; Fault(P0,GCS:PRET);
 No
 Witnesses

--- a/herd/tests/instructions/AArch64.gcs/G004.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G004.litmus.expected
@@ -1,6 +1,6 @@
 Test G004 Required
 States 3
-0:X0=0;  ~Fault(P0);
+0:X0=0; ~Fault(P0);
 0:X0=0; Fault(P0,GCS:PRET);
 0:X0=0; Fault(P0:L2,GCS:PRET);
 No

--- a/herd/tests/instructions/AArch64.gcs/G005.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G005.litmus.expected
@@ -1,7 +1,7 @@
 Test G005 Required
 States 2
 0:X1=0; Fault(P0,GCS:SS2);
-0:X1=4;  ~Fault(P0);
+0:X1=4; ~Fault(P0);
 No
 Witnesses
 Positive: 2 Negative: 2

--- a/herd/tests/instructions/AArch64.gcs/G006.litmus.expected
+++ b/herd/tests/instructions/AArch64.gcs/G006.litmus.expected
@@ -1,6 +1,6 @@
 Test G006 Required
 States 2
-  ~Fault(P0);
+ ~Fault(P0);
  Fault(P0,GCS:SS2);
 No
 Witnesses

--- a/herd/tests/instructions/AArch64.kvm/A016.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A016.litmus.expected
@@ -1,6 +1,6 @@
 Test A016 Allowed
 States 1
-  ~Fault(P0,UndefinedInstruction);
+ ~Fault(P0,UndefinedInstruction);
 No
 Witnesses
 Positive: 0 Negative: 1

--- a/herd/tests/instructions/AArch64.kvm/A017.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A017.litmus.expected
@@ -1,6 +1,6 @@
 Test A017 Required
 States 2
-  ~Fault(P1:L0,x,MMU:Translation);
+ ~Fault(P1:L0,x,MMU:Translation);
  Fault(P1:L0,x,MMU:Translation);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.kvm/A023.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/A023.litmus.expected
@@ -1,6 +1,6 @@
 Test A023 Forbidden
 States 3
-1:X2=0;  ~Fault(P1,x,MMU:Translation);
+1:X2=0; ~Fault(P1,x,MMU:Translation);
 1:X2=0; Fault(P1,x,MMU:Translation);
 1:X2=1; Fault(P1,x,MMU:Translation);
 Ok

--- a/herd/tests/instructions/AArch64.kvm/MP-I2V+rel+dmb.ld.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/MP-I2V+rel+dmb.ld.litmus.expected
@@ -1,7 +1,7 @@
 Test MP-I2V+rel+dmb.ld Allowed
 States 2
 1:X0=0; Fault(P1:L0,y,D-MMU:Translation);
-1:X0=1;  ~Fault(P1:L0,y);
+1:X0=1; ~Fault(P1:L0,y);
 No
 Witnesses
 Positive: 0 Negative: 2

--- a/herd/tests/instructions/AArch64.kvm/MP-I2V+rel+noret-dmb.ld.litmus.expected
+++ b/herd/tests/instructions/AArch64.kvm/MP-I2V+rel+noret-dmb.ld.litmus.expected
@@ -1,7 +1,7 @@
 Test MP-I2V+rel+noret-dmb.ld Allowed
 States 2
 1:X0=0; Fault(P1:L0,y,D-MMU:Translation);
-1:X0=1;  ~Fault(P1:L0,y);
+1:X0=1; ~Fault(P1:L0,y);
 No
 Witnesses
 Positive: 0 Negative: 2

--- a/herd/tests/instructions/AArch64.vmsa+mte/A001.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A001.litmus.expected
@@ -1,6 +1,6 @@
 Test A001 Required
 States 1
-[x]=1;  ~Fault(P0:L0,x);
+[x]=1; ~Fault(P0:L0,x);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.vmsa+mte/A006.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A006.litmus.expected
@@ -1,6 +1,6 @@
 Test A006 Required
 States 1
-[x]=1;  ~Fault(P0:L0,x);
+[x]=1; ~Fault(P0:L0,x);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.vmsa+mte/A008.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A008.litmus.expected
@@ -1,6 +1,6 @@
 Test A008 Allowed
 States 3
-[x]=0;  ~Fault(P0:L0,x,MMU:Translation);
+[x]=0; ~Fault(P0:L0,x,MMU:Translation);
 [x]=0; Fault(P0:L0,x,MMU:Translation);
 [x]=1; Fault(P0:L0,x,MMU:Translation);
 Ok

--- a/herd/tests/instructions/AArch64.vmsa+mte/A009.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A009.litmus.expected
@@ -1,7 +1,7 @@
 Test A009 Allowed
 States 3
 [tag(x)]=:green; Fault(P0:L0,x,MMU:Translation);
-[tag(x)]=:red;  ~Fault(P0:L0,x,MMU:Translation);
+[tag(x)]=:red; ~Fault(P0:L0,x,MMU:Translation);
 [tag(x)]=:red; Fault(P0:L0,x,MMU:Translation);
 Ok
 Witnesses

--- a/herd/tests/instructions/AArch64.vmsa+mte/A010.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A010.litmus.expected
@@ -1,6 +1,6 @@
 Test A010 Required
 States 1
-0:X1=1;  ~Fault(P0:L0,x,TagCheck);
+0:X1=1; ~Fault(P0:L0,x,TagCheck);
 Ok
 Witnesses
 Positive: 1 Negative: 0

--- a/herd/tests/instructions/AArch64.vmsa+mte/A011.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A011.litmus.expected
@@ -2,7 +2,7 @@ Test A011 Allowed
 States 3
 [x]=0; Fault(P0:L0,x:red,TagCheck);
 [x]=0; Fault(P0:L0,x:red,D-MMU:Permission);
-[x]=1;  ~Fault(P0:L0,x);
+[x]=1; ~Fault(P0:L0,x);
 Ok
 Witnesses
 Positive: 1 Negative: 2

--- a/herd/tests/instructions/AArch64.vmsa+mte/A012.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A012.litmus.expected
@@ -2,7 +2,7 @@ Test A012 Allowed
 States 3
 [x]=0; Fault(P0:L0,x:red,TagCheck);
 [x]=0; Fault(P0:L0,x:red,D-MMU:Permission);
-[x]=1;  ~Fault(P0:L0,x);
+[x]=1; ~Fault(P0:L0,x);
 Ok
 Witnesses
 Positive: 1 Negative: 2

--- a/herd/tests/instructions/AArch64.vmsa+mte/A013.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A013.litmus.expected
@@ -1,6 +1,6 @@
 Test A013 Allowed
 States 1
-  ~Fault(P0:L0,x,TagCheck);
+ ~Fault(P0:L0,x,TagCheck);
 No
 Witnesses
 Positive: 0 Negative: 3

--- a/herd/tests/instructions/AArch64.vmsa+mte/A014.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A014.litmus.expected
@@ -1,6 +1,6 @@
 Test A014 Allowed
 States 1
-  ~Fault(P0:L0,x,TagCheck);
+ ~Fault(P0:L0,x,TagCheck);
 No
 Witnesses
 Positive: 0 Negative: 3

--- a/herd/tests/instructions/AArch64.vmsa+mte/A016.litmus.expected
+++ b/herd/tests/instructions/AArch64.vmsa+mte/A016.litmus.expected
@@ -1,8 +1,8 @@
 Test A016 Allowed
 States 4
-[PTE(x)]=(oa:PA(x), db:0, dbm:1, attrs:(TaggedNormal));  ~Fault(P0,x);
+[PTE(x)]=(oa:PA(x), db:0, dbm:1, attrs:(TaggedNormal)); ~Fault(P0,x);
 [PTE(x)]=(oa:PA(x), db:0, dbm:1, attrs:(TaggedNormal)); Fault(P0,x:red,TagCheck);
-[PTE(x)]=(oa:PA(x), dbm:1, attrs:(TaggedNormal));  ~Fault(P0,x);
+[PTE(x)]=(oa:PA(x), dbm:1, attrs:(TaggedNormal)); ~Fault(P0,x);
 [PTE(x)]=(oa:PA(x), dbm:1, attrs:(TaggedNormal)); Fault(P0,x:red,TagCheck);
 Ok
 Witnesses

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -936,7 +936,7 @@ end
             | ForallStates _|NotExistsState _ -> "p_true == 0" in
             O.fi "int cond = %s;" to_check ;
             EPF.fi "%s\n" ["cond?\"Ok\":\"No\""] ;
-            EPF.fi "\nWitnesses\n" [] ;
+            EPF.fi "Witnesses\n" [] ;
             let fmt = "Positive: %PCTR, Negative: %PCTR\n" in
             EPF.fi fmt
               [(match c with
@@ -1080,6 +1080,7 @@ end
           | Mode.Std|Mode.PreSi ->
               let fmt = sprintf "Time %s %%f\n"  doc.Name.name in
               EPF.fi fmt ["total / 1000000.0"] ;
+              EPF.fi "\n" [];
               O.oi "fflush(out);"
           | Mode.Kvm ->
               if
@@ -1089,7 +1090,7 @@ end
               let s = sprintf "Time %s "  doc.Name.name in
               O.fi "puts(%S);" s ;
               O.oi "emit_millions(tsc_millions(total));" ;
-              O.oi "puts(\"\\n\");"
+              O.fi "puts(%S);" "\n\n"
           end ;
           begin match Cfg.mode with
           | Mode.PreSi|Mode.Kvm ->

--- a/litmus/tests/AArch64.kvm/A001.t
+++ b/litmus/tests/AArch64.kvm/A001.t
@@ -17,10 +17,10 @@ stable
   Histogram (1 states)
   4000000*>0:X0=1; 0:X2=1;
   No
-  
   Witnesses
   Positive: 0, Negative: 4000000
   Condition forall (0:X0=0 /\ 0:X2=0) is NOT validated
   Hash=b4f76ddaf0ec77a089ddb069cb87815f
   Variant=fatal
   Observation A001 Never 0 4000000
+

--- a/litmus/tests/AArch64.kvm/A005.t
+++ b/litmus/tests/AArch64.kvm/A005.t
@@ -31,10 +31,10 @@ stable
   Test A005 Required
   Histogram (1 states)
   4000000*>0:X0=1; 0:X2=0; 0:X3=1;
-  No
-  
+  No  
   Witnesses
   Positive: 0, Negative: 4000000
   Condition forall (0:X0=0 /\ 0:X2=1 /\ 0:X3=1) is NOT validated
   Hash=63fe95c5d285e45a9e941fb36d381f70
   Observation A005 Never 0 4000000
+

--- a/litmus/tests/AArch64/A04.t
+++ b/litmus/tests/AArch64/A04.t
@@ -17,9 +17,9 @@ stable
   Histogram (1 states)
   4000000*>0:X0=0;
   Ok
-  
   Witnesses
   Positive: 4000000, Negative: 0
   Condition exists (0:X0=0) is validated
   Hash=d64e911ddfaa8df8f0c4d17557b7562d
   Observation A4 Always 4000000 0
+

--- a/litmus/tests/X86_64/A009.t
+++ b/litmus/tests/X86_64/A009.t
@@ -1,5 +1,5 @@
 Use litmus7 to generate code from a litmus test
-
+  $ D=$(pwd)
   $ TEST="A009"
   $ mkdir "$TEST"
   $ litmus7 -set-libdir ../../libdir -o "$TEST" \
@@ -17,10 +17,28 @@ stable
   Histogram (1 states)
   200000:>0:rcx=-1;
   Ok
-  
   Witnesses
   Positive: 200000, Negative: 0
   Condition forall (0:rcx=-1) is validated
   Hash=7ca3c35015d75a877ccf509d75062e79
   Observation A009 Always 200000 0
+  
 
+Same test in "pre-silicium" mode
+  $ cd $D
+  $ litmus7 -set-libdir ../../libdir -o "$TEST" \
+  > "../../../herd/tests/instructions/X86_64/$TEST.litmus"  \
+  > -mach x86_64 -mode presi -a 2 -s 1k -r 200  
+  $ cd $TEST
+  $ make > /dev/null
+  $ "./$TEST.exe" | grep -v -e ^Time
+  Test A009 Required
+  Histogram (1 states)
+  400000:>0:rcx=-1;
+  Ok
+  Witnesses
+  Positive: 400000, Negative: 0
+  Condition forall (0:rcx=-1) is validated
+  Hash=7ca3c35015d75a877ccf509d75062e79
+  Observation A009 Always 400000 0
+  


### PR DESCRIPTION
Those changes are:
  1. **herd7**: get rid of one spurious space.
  2.  **litmus7**: end each test output with a blank line, to match other tools behaviour.
Those mundane modification entail some modifification of commited reference logs.

Modification 2. originates in the remark from PR #1973 that finding the end of  test outputs in a **litmus7** log is more involved than in the logs of other tools. Modification 1 results in nicer **herd7** logs.