### PR TITLE
Aligning implementation/specification error codes - phase 4/5

### DIFF
--- a/asllib/Interpreter.ml
+++ b/asllib/Interpreter.ml
@@ -396,14 +396,7 @@ module Make (B : Backend.S) (C : Config) = struct
   let v_to_int ~loc v =
     match B.v_to_z v with
     | Some z when Z.fits_int z -> Z.to_int z
-    | Some z ->
-        Printf.eprintf
-          "Overflow in asllib: cannot convert back to 63-bit integer the \
-           integer %a.\n\
-           %!"
-          Z.output z;
-        fatal_from_no_env loc
-          Error.(UnsupportedExpr (C.error_handling_time, loc))
+    | Some z -> fatal_from_no_env loc (Error.ImplementationIntegerOverflow z)
     | None ->
         fatal_from_no_env loc (MismatchType (B.debug_value v, [ integer' ]))
 

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -129,8 +129,7 @@ module NativeBackend (C : Config) = struct
   let non_tuple_exception v = mismatch_type v [ T_Tuple [] ]
 
   let bad_index i n =
-    mismatch_type (v_of_int i)
-      [ integer_range' zero_expr (expr_of_int (n - 1)) ]
+    Error.fatal_unknown_pos (Error.BadIndex (C.error_handling_time, i, n))
 
   let doesnt_have_fields_exception v =
     mismatch_type v [ T_Record []; T_Exception []; T_Collection [] ]

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -402,7 +402,7 @@ let rec unknown_of_aggregate_type unknown_of_singular_type ~eval_expr_sef ty =
           let n = Z.to_int n in
           if n >= 0 then
             NV_Vector (List.init n (fun _ -> unknown_of_type t_elem))
-          else Error.(fatal_from ty (UnsupportedExpr (Dynamic, e_length)))
+          else Error.(fatal_from ty (ArbitraryEmptyType ty))
       | _ -> (* Bad types *) assert false)
   | T_Record fields | T_Exception fields ->
       fields

--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -128,8 +128,9 @@ module NativeBackend (C : Config) = struct
   let v_exception li = v_record li
   let non_tuple_exception v = mismatch_type v [ T_Tuple [] ]
 
-  let bad_index i n =
-    Error.fatal_unknown_pos (Error.BadIndex (C.error_handling_time, i, n))
+  let bad_index start length =
+    Error.fatal_unknown_pos
+      (Error.BadIndex { handling_time = C.error_handling_time; start; length })
 
   let doesnt_have_fields_exception v =
     mismatch_type v [ T_Record []; T_Exception []; T_Collection [] ]

--- a/asllib/StaticInterpreter.ml
+++ b/asllib/StaticInterpreter.ml
@@ -67,7 +67,7 @@ let static_eval (senv : SEnv.env) (e : expr) : literal =
   | SI.Normal (Native.NV_Literal l, _env) ->
       l |: Instrumentation.TypingRule.StaticEval
   | SI.Normal _ | SI.Throwing _ | SI.Cutoff ->
-      Error.fatal_from e (UnsupportedExpr (Static, e))
+      Error.fatal_from e (StaticEvaluationFailure e)
 (* End *)
 
 let static_eval_to_int env e =

--- a/asllib/StaticInterpreter.mli
+++ b/asllib/StaticInterpreter.mli
@@ -30,8 +30,11 @@ val static_eval : StaticEnv.env -> AST.expr -> AST.literal
       if the a type error is detected or the expression is not one of the
       following: [E_Literal], [E_Var], [E_Binop], [E_Unop], [E_Slice], or
       [E_Cond].
-    @raise UnsupportedExpr if the given expression cannot evaluate to a literal.
-*)
+    @raise StaticEvaluationFailure
+      if the given expression cannot evaluate to a literal.
+    @raise other
+      static exceptions if they are triggered by the static interpreter, such as
+      [RecursionLimitReached Static] *)
 
 val static_eval_to_int : StaticEnv.env -> AST.expr -> int
 (** [static_eval_to_int env e] statically evaluates an integer-typed expression

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -206,6 +206,7 @@ module Property (C : ANNOTATE_CONFIG) = struct
   let assumption_failed () = raise TypingAssumptionFailed [@@inline]
   let ok () = () [@@inline]
   let check_true b fail () = if b then () else fail () [@@inline]
+  let check_all li f () = List.iter (fun x1 -> f x1 ()) li
   let check_all2 li1 li2 f () = List.iter2 (fun x1 x2 -> f x1 x2 ()) li1 li2
 end
 
@@ -1380,9 +1381,8 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         | T_Collection _ ->
             assert (not decl);
             let+ () =
-              check_true
-                (List.for_all (fun (_, t) -> has_structure_bits env t) fields)
-              @@ fun () -> fatal_from ~loc Error.(UnsupportedTy (Static, ty))
+              check_all fields' @@ fun (_, ty) ->
+              check_structure_bits ~loc:ty env ty
             in
             (T_Collection fields' |> here, ses) |: TypingRule.TStructuredDecl
         | _ -> assert false

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -3412,7 +3412,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       | T_Int UnConstrained
       | T_Real | T_String | T_Bool | T_Array _ | T_Named _ ->
           []
-      | _ -> Error.fatal_from (to_pos ty) (Error.UnsupportedTy (Static, ty))
+      | T_Enum _ | T_Record _ | T_Exception _ | T_Collection _
+      | T_Int (PendingConstrained | Parameterized _) ->
+          Error.fatal_from (to_pos ty) (Error.BadParameterType ty)
     in
     let types = func_sig_types func_sig in
     let all_parameters = List.concat_map (parameters_of_ty ~env) types in

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -3394,8 +3394,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
       | E_Cond (e, e1, e2) ->
           parameters_of_expr ~env e @ parameters_of_expr ~env e1
           @ parameters_of_expr ~env e2
-      | E_Tuple _ | _ ->
-          Error.fatal_from (to_pos e) (Error.UnsupportedExpr (Static, e))
+      | _ -> Error.fatal_from (to_pos e) (Error.BadParameterExpr e)
     in
     let parameters_of_constraint ~env c =
       match c with

--- a/asllib/doc/SubprogramDeclarations.tex
+++ b/asllib/doc/SubprogramDeclarations.tex
@@ -785,6 +785,10 @@ in \listingref{ParametersOfTy} are as follows:
 
 \ASLListing{The parameters extracted from argument types}{ParametersOfTy}{\typingtests/TypingRule.ParametersOfTy.asl}
 
+\ExampleDef{Type Not Permitted in a Subprogram Signature}
+The pending-constrained integer type in \listingref{ParametersOfTy-bad} is not permitted as an argument or return type of a subprogram.
+\ASLListing{A type not permitted as a subprogram argument type}{ParametersOfTy-bad}{\typingtests/TypingRule.ParametersOfTy.bad.asl}
+
 \ExampleRef{Ill-typed Type Declarations} shows an ill-typed argument type.
 
 

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -11447,15 +11447,19 @@ typing function paramsofty(tenv: static_envs, ty: ty) ->
   case other {
     or(
       ast_label(ty) in make_set(label_T_Array, label_T_Bool, label_T_Named, label_T_Real, label_T_String),
-      is_unconstrained_integer(ty),
-      is_parameterized_integer(ty)
+      is_unconstrained_integer(ty)
     ) { [_] };
     --
     empty_list;
   }
 
   case error {
-    binary_or(ast_label(ty) = label_T_Enum, is_structured(ty));
+    or(
+      ast_label(ty) = label_T_Enum,
+      is_structured(ty),
+      ty = T_Int(PendingConstrained),
+      is_parameterized_integer(ty)
+    );
     --
     TypeError(TE_BSPD);
   }

--- a/asllib/doc/asl.spec
+++ b/asllib/doc/asl.spec
@@ -11494,6 +11494,12 @@ typing function params_of_expr(tenv: static_envs, e: expr) ->
     concat(ids1, ids2);
   }
 
+  case e_literal {
+    e =: E_Literal(_);
+    --
+    empty_list;
+  }
+
   case e_tuple {
     e =: E_Tuple(es);
     es =: make_singleton_list(e1);
@@ -11511,8 +11517,15 @@ typing function params_of_expr(tenv: static_envs, e: expr) ->
     concat(ids0, concat(ids1, ids2));
   }
 
+  case e_tuple_error {
+    e =: E_Tuple(es);
+    list_len(es) != one;
+    --
+    TypeError(TE_BSPD);
+  }
+
   case other {
-    ast_label(e) not_in make_set(label_E_Binop, label_E_Tuple, label_E_Unop, label_E_Var);
+    ast_label(e) not_in make_set(label_E_Binop, label_E_Cond, label_E_Literal, label_E_Tuple, label_E_Unop, label_E_Var);
     --
     TypeError(TE_BSPD);
   }

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -54,8 +54,8 @@ type error_desc =
   | BadParameterArity of error_handling_time * version * identifier * int * int
   | UnsupportedBinop of error_handling_time * binop * literal * literal
   | UnsupportedUnop of error_handling_time * unop * literal
-  | UnsupportedExpr of error_handling_time * expr
   | StaticEvaluationFailure of expr
+  | ImplementationIntegerOverflow of Z.t
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
   | ATCExecutionFailure of error_handling_time * string * ty
@@ -325,8 +325,9 @@ module ErrorCode = struct
         Some (Typing SEF)
     | BadIndex (Dynamic, _, _) -> Some (Dynamic BI)
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
-    (********** TODO tidy up - does not cleanly correspond to a code **********)
-    | UnsupportedExpr _ -> None
+    (********** Errors without specification codes **********)
+    (* Implementation limitations are not ASL errors. *)
+    | ImplementationIntegerOverflow _ -> None
     (********** Should not happen **********)
     (* e.g. skipped type-checking, ASL0, internal option or invariant *)
     | MismatchType _ (* Skipped type-checking or violated typing invariant *) ->
@@ -485,12 +486,11 @@ module PPrint = struct
           (ErrorKind.of_error_handling_time t)
           "Illegal application of operator %s for value@ %a."
           (unop_to_string op) pp_literal v
-    | UnsupportedExpr (t, e) ->
-        pp_err
-          (ErrorKind.of_error_handling_time t)
-          "Unsupported expression %a." pp_expr e
     | StaticEvaluationFailure e ->
         pp_err Typing "Static evaluation of expression %a failed." pp_expr e
+    | ImplementationIntegerOverflow z ->
+        pp_err Internal "Integer %a exceeds aslref implementation limits."
+          Z.pp_print z
     | InvalidExpr e -> pp_err Typing "invalid expression %a." pp_expr e
     | MismatchType (v, [ ty ]) ->
         pp_err Dynamic "Mismatch type:@ value %s does not belong to type %a." v
@@ -879,8 +879,8 @@ module CSV = struct
     | BadParameterArity _ -> "BadParameterArity"
     | UnsupportedBinop _ -> "UnsupportedBinop"
     | UnsupportedUnop _ -> "UnsupportedUnop"
-    | UnsupportedExpr _ -> "UnsupportedExpr"
     | StaticEvaluationFailure _ -> "StaticEvaluationFailure"
+    | ImplementationIntegerOverflow _ -> "ImplementationIntegerOverflow"
     | InvalidExpr _ -> "InvalidExpr"
     | MismatchType _ -> "MismatchType"
     | ATCExecutionFailure _ -> "ATCExecutionFailure"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -90,6 +90,7 @@ type error_desc =
   | ParameterWithoutDecl of identifier
   | BadParameterDecl of identifier * identifier list * identifier list
       (** name, expected, actual *)
+  | BadParameterExpr of expr
   | BaseValueEmptyType of ty
   | ArbitraryEmptyType of ty
   | BaseValueNonSymbolic of ty * expr
@@ -291,8 +292,8 @@ module ErrorCode = struct
     | ImpureExpression _ | MismatchedPurity _ -> Some (Typing SEV)
     | AssignToImmutable _ -> Some (Typing AIM)
     | AlreadyDeclaredIdentifier _ -> Some (Typing IAD)
-    | BadReturnStmt _ | BadParameterDecl _ | NonReturningFunction _
-    | NoreturnViolation _ ->
+    | BadReturnStmt _ | BadParameterDecl _ | BadParameterExpr _
+    | NonReturningFunction _ | NoreturnViolation _ ->
         Some (Typing BSPD)
     | UncaughtException _ | UnexpectedInitialisationThrow _ -> Some (Dynamic UE)
     | OverlappingSlices (_, Dynamic) -> Some (Dynamic OSA)
@@ -681,6 +682,9 @@ module PPrint = struct
           expected
           (pp_comma_list pp_print_string)
           actual
+    | BadParameterExpr e ->
+        pp_err Typing
+          "Expression %a is not permitted in a subprogram signature." pp_expr e
     | ArbitraryEmptyType t ->
         pp_err Dynamic "ARBITRARY of empty type %a." pp_ty t
     | BaseValueEmptyType t ->
@@ -904,6 +908,7 @@ module CSV = struct
     | ConstrainedIntegerExpected _ -> "ConstrainedIntegerExpected"
     | ParameterWithoutDecl _ -> "ParameterWithoutDecl"
     | BadParameterDecl _ -> "BadParameterDecl"
+    | BadParameterExpr _ -> "BadParameterExpr"
     | BaseValueEmptyType _ -> "BaseValueEmptyType"
     | ArbitraryEmptyType _ -> "ArbitraryEmptyType"
     | BaseValueNonSymbolic _ -> "BaseValueNonSymbolic"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -55,6 +55,7 @@ type error_desc =
   | UnsupportedBinop of error_handling_time * binop * literal * literal
   | UnsupportedUnop of error_handling_time * unop * literal
   | UnsupportedExpr of error_handling_time * expr
+  | StaticEvaluationFailure of expr
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
   | ATCExecutionFailure of error_handling_time * string * ty
@@ -319,12 +320,13 @@ module ErrorCode = struct
     | AssertionFailed (Static, _)
     | ATCExecutionFailure (Static, _, _)
     | BadIndex (Static, _, _)
-    | BadPrimitiveArgument (Static, _, _) ->
+    | BadPrimitiveArgument (Static, _, _)
+    | StaticEvaluationFailure _ ->
         Some (Typing SEF)
     | BadIndex (Dynamic, _, _) -> Some (Dynamic BI)
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
     (********** TODO tidy up - does not cleanly correspond to a code **********)
-    | UnsupportedExpr _ (* For static interpretation *) -> None
+    | UnsupportedExpr _ -> None
     (********** Should not happen **********)
     (* e.g. skipped type-checking, ASL0, internal option or invariant *)
     | MismatchType _ (* Skipped type-checking or violated typing invariant *) ->
@@ -424,11 +426,6 @@ end
       assertion failures, cases we don't expect to hit etc.
     - TypingRule.TInt mismatch on empty case *)
 (* TODO: BE_RI unused in reference *)
-(* TODO: following not recoverable from implementation:
-- TE_SEF
-- DE_TAF
-- DE_BI
-*)
 
 module PPrint = struct
   open Format
@@ -492,6 +489,8 @@ module PPrint = struct
         pp_err
           (ErrorKind.of_error_handling_time t)
           "Unsupported expression %a." pp_expr e
+    | StaticEvaluationFailure e ->
+        pp_err Typing "Static evaluation of expression %a failed." pp_expr e
     | InvalidExpr e -> pp_err Typing "invalid expression %a." pp_expr e
     | MismatchType (v, [ ty ]) ->
         pp_err Dynamic "Mismatch type:@ value %s does not belong to type %a." v
@@ -881,6 +880,7 @@ module CSV = struct
     | UnsupportedBinop _ -> "UnsupportedBinop"
     | UnsupportedUnop _ -> "UnsupportedUnop"
     | UnsupportedExpr _ -> "UnsupportedExpr"
+    | StaticEvaluationFailure _ -> "StaticEvaluationFailure"
     | InvalidExpr _ -> "InvalidExpr"
     | MismatchType _ -> "MismatchType"
     | ATCExecutionFailure _ -> "ATCExecutionFailure"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -325,9 +325,10 @@ module ErrorCode = struct
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
     (********** TODO tidy up - does not cleanly correspond to a code **********)
     | UnsupportedExpr _ (* For static interpretation *) -> None
-    | MismatchType _ (* mismatched integers for loop limits *) -> None
     (********** Should not happen **********)
     (* e.g. skipped type-checking, ASL0, internal option or invariant *)
+    | MismatchType _ (* Skipped type-checking or violated typing invariant *) ->
+        None
     | EmptyConstraints (* An internal invariant *) -> None
     | TypeInferenceNeeded
     | UndefinedIdentifier (Dynamic, _)

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -31,6 +31,7 @@ type error_desc =
   | BadField of string * ty
   | MissingField of string list * ty
   | BadSlices of error_handling_time * slice list * int
+  | BadIndex of error_handling_time * int * int
   | BadTupleIndex of { index : int; length : int }
   | BadSlice of slice
   | EmptySlice
@@ -317,8 +318,10 @@ module ErrorCode = struct
     | NegativeArrayLength (Static, _, _)
     | AssertionFailed (Static, _)
     | ATCExecutionFailure (Static, _, _)
+    | BadIndex (Static, _, _)
     | BadPrimitiveArgument (Static, _, _) ->
         Some (Typing SEF)
+    | BadIndex (Dynamic, _, _) -> Some (Dynamic BI)
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
     (********** TODO tidy up - does not cleanly correspond to a code **********)
     | UnsupportedExpr _ (* For static interpretation *) -> None
@@ -521,6 +524,10 @@ module PPrint = struct
           (ErrorKind.of_error_handling_time t)
           "Cannot extract from bitvector of length %d slice %a." length
           pp_slice_list slices
+    | BadIndex (t, index, length) ->
+        pp_err
+          (ErrorKind.of_error_handling_time t)
+          "Index %d is outside the valid range 0..%d." index (length - 1)
     | BadTupleIndex { index; length } ->
         pp_err Typing "Tuple index %d is outside the valid range 0..%d." index
           (length - 1)
@@ -859,6 +866,7 @@ module CSV = struct
     | BadPattern _ -> "BadPattern"
     | MissingField _ -> "MissingField"
     | BadSlices _ -> "BadSlices"
+    | BadIndex _ -> "BadIndex"
     | BadTupleIndex _ -> "BadTupleIndex"
     | BadSlice _ -> "BadSlice"
     | EmptySlice -> "EmptySlice"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -54,7 +54,6 @@ type error_desc =
   | UnsupportedBinop of error_handling_time * binop * literal * literal
   | UnsupportedUnop of error_handling_time * unop * literal
   | UnsupportedExpr of error_handling_time * expr
-  | UnsupportedTy of error_handling_time * ty
   | InvalidExpr of expr
   | MismatchType of string * type_desc list
   | ATCExecutionFailure of error_handling_time * string * ty
@@ -91,6 +90,7 @@ type error_desc =
   | BadParameterDecl of identifier * identifier list * identifier list
       (** name, expected, actual *)
   | BadParameterExpr of expr
+  | BadParameterType of ty
   | BaseValueEmptyType of ty
   | ArbitraryEmptyType of ty
   | BaseValueNonSymbolic of ty * expr
@@ -293,7 +293,7 @@ module ErrorCode = struct
     | AssignToImmutable _ -> Some (Typing AIM)
     | AlreadyDeclaredIdentifier _ -> Some (Typing IAD)
     | BadReturnStmt _ | BadParameterDecl _ | BadParameterExpr _
-    | NonReturningFunction _ | NoreturnViolation _ ->
+    | BadParameterType _ | NonReturningFunction _ | NoreturnViolation _ ->
         Some (Typing BSPD)
     | UncaughtException _ | UnexpectedInitialisationThrow _ -> Some (Dynamic UE)
     | OverlappingSlices (_, Dynamic) -> Some (Dynamic OSA)
@@ -321,9 +321,7 @@ module ErrorCode = struct
         Some (Typing SEF)
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
     (********** TODO tidy up - does not cleanly correspond to a code **********)
-    | UnsupportedExpr _ | UnsupportedTy _
-    (* For static interpretation, parameters, and collections *) ->
-        None
+    | UnsupportedExpr _ (* For static interpretation *) -> None
     | MismatchType _ (* mismatched integers for loop limits *) -> None
     (********** Should not happen **********)
     (* e.g. skipped type-checking, ASL0, internal option or invariant *)
@@ -490,10 +488,6 @@ module PPrint = struct
         pp_err
           (ErrorKind.of_error_handling_time t)
           "Unsupported expression %a." pp_expr e
-    | UnsupportedTy (t, ty) ->
-        pp_err
-          (ErrorKind.of_error_handling_time t)
-          "Unsupported type %a." pp_ty ty
     | InvalidExpr e -> pp_err Typing "invalid expression %a." pp_expr e
     | MismatchType (v, [ ty ]) ->
         pp_err Dynamic "Mismatch type:@ value %s does not belong to type %a." v
@@ -685,6 +679,9 @@ module PPrint = struct
     | BadParameterExpr e ->
         pp_err Typing
           "Expression %a is not permitted in a subprogram signature." pp_expr e
+    | BadParameterType ty ->
+        pp_err Typing "Type %a is not permitted in a subprogram signature."
+          pp_ty ty
     | ArbitraryEmptyType t ->
         pp_err Dynamic "ARBITRARY of empty type %a." pp_ty t
     | BaseValueEmptyType t ->
@@ -875,7 +872,6 @@ module CSV = struct
     | UnsupportedBinop _ -> "UnsupportedBinop"
     | UnsupportedUnop _ -> "UnsupportedUnop"
     | UnsupportedExpr _ -> "UnsupportedExpr"
-    | UnsupportedTy _ -> "UnsupportedTy"
     | InvalidExpr _ -> "InvalidExpr"
     | MismatchType _ -> "MismatchType"
     | ATCExecutionFailure _ -> "ATCExecutionFailure"
@@ -909,6 +905,7 @@ module CSV = struct
     | ParameterWithoutDecl _ -> "ParameterWithoutDecl"
     | BadParameterDecl _ -> "BadParameterDecl"
     | BadParameterExpr _ -> "BadParameterExpr"
+    | BadParameterType _ -> "BadParameterType"
     | BaseValueEmptyType _ -> "BaseValueEmptyType"
     | ArbitraryEmptyType _ -> "ArbitraryEmptyType"
     | BaseValueNonSymbolic _ -> "BaseValueNonSymbolic"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -31,7 +31,11 @@ type error_desc =
   | BadField of string * ty
   | MissingField of string list * ty
   | BadSlices of error_handling_time * slice list * int
-  | BadIndex of error_handling_time * int * int
+  | BadIndex of {
+      handling_time : error_handling_time;
+      start : int;
+      length : int;
+    }
   | BadTupleIndex of { index : int; length : int }
   | BadSlice of slice
   | EmptySlice
@@ -319,11 +323,11 @@ module ErrorCode = struct
     | NegativeArrayLength (Static, _, _)
     | AssertionFailed (Static, _)
     | ATCExecutionFailure (Static, _, _)
-    | BadIndex (Static, _, _)
+    | BadIndex { handling_time = Static }
     | BadPrimitiveArgument (Static, _, _)
     | StaticEvaluationFailure _ ->
         Some (Typing SEF)
-    | BadIndex (Dynamic, _, _) -> Some (Dynamic BI)
+    | BadIndex { handling_time = Dynamic } -> Some (Dynamic BI)
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
     (********** Errors without specification codes **********)
     (* Implementation limitations are not ASL errors. *)
@@ -487,7 +491,10 @@ module PPrint = struct
           "Illegal application of operator %s for value@ %a."
           (unop_to_string op) pp_literal v
     | StaticEvaluationFailure e ->
-        pp_err Typing "Static evaluation of expression %a failed." pp_expr e
+        pp_err Typing
+          "Static evaluation of expression %a did not successfully produce a \
+           literal."
+          pp_expr e
     | ImplementationIntegerOverflow z ->
         pp_err Internal "Integer %a exceeds aslref implementation limits."
           Z.pp_print z
@@ -524,10 +531,10 @@ module PPrint = struct
           (ErrorKind.of_error_handling_time t)
           "Cannot extract from bitvector of length %d slice %a." length
           pp_slice_list slices
-    | BadIndex (t, index, length) ->
+    | BadIndex { handling_time; start; length } ->
         pp_err
-          (ErrorKind.of_error_handling_time t)
-          "Index %d is outside the valid range 0..%d." index (length - 1)
+          (ErrorKind.of_error_handling_time handling_time)
+          "Index %d is outside the valid range 0..%d." start (length - 1)
     | BadTupleIndex { index; length } ->
         pp_err Typing "Tuple index %d is outside the valid range 0..%d." index
           (length - 1)

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -28,8 +28,7 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.ECall.asl
   $ aslref SemanticsRule.EGetArray.asl
   $ aslref SemanticsRule.EGetArrayTooSmall.asl
-  ASL Dynamic error: Mismatch type:
-    value 3 does not belong to type integer {0..2}.
+  ASL Dynamic error (DE_BI): Index 3 is outside the valid range 0..2.
   [1]
   $ aslref SemanticsRule.ERecord.asl
   $ aslref SemanticsRule.EGetItem.asl

--- a/asllib/tests/ASLTypingReference.t/TypingRule.ParametersOfTy.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.ParametersOfTy.bad.asl
@@ -1,0 +1,4 @@
+func bad_parameter_type(x: integer{})
+begin
+  pass;
+end;

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -231,7 +231,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.ExtractParameters-bad1.asl, line 3, characters 15 to 36:
       arg0: bits(N as integer{8,16,32}),
                  ^^^^^^^^^^^^^^^^^^^^^
-  ASL Static error: Unsupported expression N as integer {8, 16, 32}.
+  ASL Type error (TE_BSPD):
+    Expression N as integer {8, 16, 32} is not permitted in a subprogram signature.
   [1]
   $ aslref TypingRule.BuiltinAggregateTypes.asl
   $ aslref --no-exec TypingRule.BuiltinExceptionType.asl
@@ -842,7 +843,8 @@ ASL Typing Tests / annotating types:
   File TypingRule.ParametersOfExpr.bad.asl, line 4, characters 15 to 27:
       z: integer{(D, E).item0}) => // Illegal expression in argument type
                  ^^^^^^^^^^^^
-  ASL Static error: Unsupported expression (D, E).item0.
+  ASL Type error (TE_BSPD):
+    Expression (D, E).item0 is not permitted in a subprogram signature.
   [1]
   $ aslref --no-exec TypingRule.FuncSigTypes.asl
   $ aslref --no-exec TypingRule.SubprogramTypesClash.asl

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -838,6 +838,13 @@ ASL Typing Tests / annotating types:
   $ aslref TypingRule.RenameTyEqs.asl
   $ aslref TypingRule.CheckParamsTypeSat.asl
   $ aslref --no-exec TypingRule.ParametersOfTy.asl
+  $ aslref --no-exec TypingRule.ParametersOfTy.bad.asl
+  File TypingRule.ParametersOfTy.bad.asl, line 1, characters 27 to 36:
+  func bad_parameter_type(x: integer{})
+                             ^^^^^^^^^
+  ASL Type error (TE_BSPD):
+    Type integer{} is not permitted in a subprogram signature.
+  [1]
   $ aslref --no-exec TypingRule.ParametersOfExpr.asl
   $ aslref --no-exec TypingRule.ParametersOfExpr.bad.asl
   File TypingRule.ParametersOfExpr.bad.asl, line 4, characters 15 to 27:

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -125,6 +125,27 @@ Arbitrary of empty type
   ASL Dynamic error (DE_AET): ARBITRARY of empty type integer {1..0}.
   [1]
 
+Array with negative length
+
+  $ cat >bad-types9.asl <<EOF
+  > func arbitrary_array{N}() => integer {N}
+  > begin
+  >   let x = ARBITRARY : array[[N]] of integer;
+  >   return N;
+  > end;
+  > func main() => integer
+  > begin
+  >   return arbitrary_array{-1}();
+  > end;
+  > EOF
+
+  $ aslref bad-types9.asl
+  File bad-types9.asl, line 3, characters 22 to 43:
+    let x = ARBITRARY : array[[N]] of integer;
+                        ^^^^^^^^^^^^^^^^^^^^^
+  ASL Dynamic error (DE_AET): ARBITRARY of empty type array [[N]] of integer.
+  [1]
+
 Base value of empty type
 
   $ cat >bad-types8.asl <<EOF

--- a/asllib/tests/collections.t/run.t
+++ b/asllib/tests/collections.t/run.t
@@ -25,13 +25,10 @@
   ASL Type error (TE_UT): unexpected collection.
   [1]
   $ aslref with-non-bitvector-arg.asl
-  File with-non-bitvector-arg.asl, line 1, character 0 to line 4, character 2:
-  var MyCollection : collection {
-    field1: bits(1),
+  File with-non-bitvector-arg.asl, line 3, characters 10 to 17:
     field2: integer,
-  };
-  ASL Static error:
-    Unsupported type collection { field1: bits(1), field2: integer }.
+            ^^^^^^^
+  ASL Type error (TE_UT): a subtype of bits(-) was expected, provided integer.
   [1]
   $ aslref on-function-return-type.asl
   File on-function-return-type.asl, line 6, characters 15 to 25:

--- a/asllib/tests/regressions.t/implementation-integer-overflow.asl
+++ b/asllib/tests/regressions.t/implementation-integer-overflow.asl
@@ -1,0 +1,4 @@
+func main() => integer begin
+  var xs : array[[2]] of integer;
+  return xs[[18446744073709551616]];
+end;

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -826,3 +826,8 @@ Static errors:
   ASL Type error (TE_UT): Tuple arity mismatch:
     expected 2 element(s); provided 3.
   [1]
+
+Implementation errors:
+  $ aslref --gnu-errors implementation-integer-overflow.asl
+  aslref: implementation-integer-overflow.asl:3:9: ASL Internal error: Integer 18446744073709551616 exceeds aslref implementation limits.
+  [1]

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -363,8 +363,7 @@ Parameterized integers:
 
   $ aslref array-lca.asl
   $ aslref array-index-error.asl
-  ASL Dynamic error: Mismatch type:
-    value 14 does not belong to type integer {0..4}.
+  ASL Dynamic error (DE_BI): Index 14 is outside the valid range 0..4.
   [1]
 
 Parameters bugs:
@@ -586,7 +585,7 @@ Required tests:
 
   $ aslref --gnu-errors gnu-errors.asl
   aslref: gnu-errors.asl:1:0: ASL Warning: the recursive function fact has no recursive limit annotation.
-  aslref: :0:-1: ASL Dynamic error: Mismatch type: value 11 does not belong to type integer {0..9}.
+  aslref: :0:-1: ASL Dynamic error (DE_BI): Index 11 is outside the valid range 0..9.
   [1]
 
   $ aslref
@@ -733,39 +732,31 @@ Bounds checks
   ASL Dynamic error: Cannot extract from bitvector of length 0 slice -1+:1.
   [1]
   $ aslref bounds-checks-read-bitvector-2.asl
-  ASL Dynamic error: Mismatch type:
-    value 4 does not belong to type integer {0..3}.
+  ASL Dynamic error (DE_BI): Index 4 is outside the valid range 0..3.
   [1]
   $ aslref bounds-checks-write-bitvector-1.asl
   ASL Dynamic error: Cannot extract from bitvector of length 0 slice -1+:1.
   [1]
   $ aslref bounds-checks-write-bitvector-2.asl
-  ASL Dynamic error: Mismatch type:
-    value 5 does not belong to type integer {0..3}.
+  ASL Dynamic error (DE_BI): Index 5 is outside the valid range 0..3.
   [1]
   $ aslref bounds-checks-read-array-1.asl
-  ASL Dynamic error: Mismatch type:
-    value -1 does not belong to type integer {0..3}.
+  ASL Dynamic error (DE_BI): Index -1 is outside the valid range 0..3.
   [1]
   $ aslref bounds-checks-read-array-2.asl
-  ASL Dynamic error: Mismatch type:
-    value 4 does not belong to type integer {0..3}.
+  ASL Dynamic error (DE_BI): Index 4 is outside the valid range 0..3.
   [1]
   $ aslref bounds-checks-write-array-1.asl
-  ASL Dynamic error: Mismatch type:
-    value -1 does not belong to type integer {0..3}.
+  ASL Dynamic error (DE_BI): Index -1 is outside the valid range 0..3.
   [1]
   $ aslref bounds-checks-write-array-2.asl
-  ASL Dynamic error: Mismatch type:
-    value 4 does not belong to type integer {0..3}.
+  ASL Dynamic error (DE_BI): Index 4 is outside the valid range 0..3.
   [1]
   $ aslref bounds-checks-read-zero-width-slice.asl
-  ASL Dynamic error: Mismatch type:
-    value 100 does not belong to type integer {0..3}.
+  ASL Dynamic error (DE_BI): Index 100 is outside the valid range 0..3.
   [1]
   $ aslref bounds-checks-write-zero-width-slice.asl
-  ASL Dynamic error: Mismatch type:
-    value 100 does not belong to type integer {0..3}.
+  ASL Dynamic error (DE_BI): Index 100 is outside the valid range 0..3.
   [1]
 
 If test environment reversion bug

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -817,7 +817,8 @@ Static errors:
   File static-evaluation-non-literal.asl, line 5, characters 13 to 24:
   constant C = R { x = 1 };
                ^^^^^^^^^^^
-  ASL Type error (TE_SEF): Static evaluation of expression R { x = 1 } failed.
+  ASL Type error (TE_SEF):
+    Static evaluation of expression R { x = 1 } did not successfully produce a literal.
   [1]
   $ aslref tuple-arity-mismatch.asl
   File tuple-arity-mismatch.asl, line 3, characters 2 to 25:
@@ -828,6 +829,10 @@ Static errors:
   [1]
 
 Implementation errors:
-  $ aslref --gnu-errors implementation-integer-overflow.asl
-  aslref: implementation-integer-overflow.asl:3:9: ASL Internal error: Integer 18446744073709551616 exceeds aslref implementation limits.
+  $ aslref implementation-integer-overflow.asl
+  File implementation-integer-overflow.asl, line 3, characters 9 to 35:
+    return xs[[18446744073709551616]];
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ASL Internal error:
+    Integer 18446744073709551616 exceeds aslref implementation limits.
   [1]

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -813,6 +813,12 @@ Static errors:
   ASL Static error (TE_SEF):
     FloorLog2 (primitive) expected an argument greater than 0
   [1]
+  $ aslref --no-exec static-evaluation-non-literal.asl
+  File static-evaluation-non-literal.asl, line 5, characters 13 to 24:
+  constant C = R { x = 1 };
+               ^^^^^^^^^^^
+  ASL Type error (TE_SEF): Static evaluation of expression R { x = 1 } failed.
+  [1]
   $ aslref tuple-arity-mismatch.asl
   File tuple-arity-mismatch.asl, line 3, characters 2 to 25:
     let (x, y) = (1, 2, 3);

--- a/asllib/tests/regressions.t/static-evaluation-non-literal.asl
+++ b/asllib/tests/regressions.t/static-evaluation-non-literal.asl
@@ -1,0 +1,5 @@
+type R of record {
+  x: integer,
+};
+
+constant C = R { x = 1 };


### PR DESCRIPTION
## Classify unsupported parameter expressions
Expressions that cannot define subprogram parameters now report `TE_BSPD` through `BadParameterExpr`, matching `params_of_expr` in `asl.spec`.

## Classify invalid collection field types
Non-bitvector collection fields now report `TE_UT` through `check_structure_bits`, matching the per-field `check_structure_label` checks in `asl.spec`.

## Classify unsupported parameter types
Types not permitted as subprogram argument or return types now report `TE_BSPD` through `BadParameterType`; `asl.spec` and a documented regression now cover pending-constrained integers, and the obsolete `UnsupportedTy` diagnostic is removed.

## Classify out-of-bounds indices
Out-of-bounds native vector accesses now report `DE_BI`, or `TE_SEF` during static evaluation, through `BadIndex` instead of the uncoded `MismatchType` diagnostic.

## Classify arbitrary negative-length arrays
Parameterized arrays whose length evaluates negatively now report `DE_AET` through `ArbitraryEmptyType`, matching `EArbitrary` in `asl.spec`.

## Classify static evaluation failures
Static evaluation that does not produce a literal now reports `TE_SEF` through `StaticEvaluationFailure`, matching `static_eval` in `asl.spec`.

## Classify implementation integer overflow
Integers exceeding OCaml `int` limits now report a structured internal `ImplementationIntegerOverflow` diagnostic instead of the uncoded `UnsupportedExpr`.