### PR TITLE
Aligning implementation/specification error codes - phase 5/5

### DIFF
--- a/asllib/Native.ml
+++ b/asllib/Native.ml
@@ -182,7 +182,9 @@ module NativeBackend (C : Config) = struct
           Slice_Length (expr_of_int start, expr_of_int length))
         positions
     in
-    Error.(fatal_unknown_pos (BadSlices (C.error_handling_time, slices, 0)))
+    Error.(
+      fatal_unknown_pos
+        (BadSlices (NegativeStartOrLength (C.error_handling_time, slices))))
 
   let slices_to_positions positions =
     List.map

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -463,8 +463,9 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
         | _ -> assert false
       in
       let offset = eval_slice_expr env e1 and length = eval_slice_expr env e2 in
-      if offset > offset + length - 1 then
-        fatal_from ~loc @@ Error.(BadSlice slice)
+      if length <= 0 then
+        fatal_from ~loc
+        @@ Error.(BadSlices (NonPositiveLength { slice; length }))
       else
         DI.Interval.make offset (offset + length - 1)
         |: TypingRule.BitfieldSliceToPositions
@@ -834,7 +835,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
     let min_pos = Diet.Int.min_elt diet and max_pos = Diet.Int.max_elt diet in
     if 0 <= min_pos && max_pos < width then
       () |: TypingRule.CheckPositionsInWidth
-    else fatal_from ~loc (BadSlices (Error.Static, slices, width))
+    else fatal_from ~loc (BadSlices (OutOfBitvectorBounds (slices, width)))
   (* End *)
 
   (* Begin CheckSlicesInWidth *)

--- a/asllib/Typing.ml
+++ b/asllib/Typing.ml
@@ -2080,7 +2080,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             | T_Int _ | T_Bits _ ->
                 let+ () =
                   check_true (not (list_is_empty slices)) @@ fun () ->
-                  fatal_from ~loc Error.EmptySlice
+                  fatal_from ~loc Error.(BadSlices Empty)
                 in
                 (* TODO: check that:
                    - Rule SNQJ: An expression or subexpression which
@@ -2558,7 +2558,7 @@ module Annotate (C : ANNOTATE_CONFIG) : S = struct
             let+ () = check_disjoint_slices ~loc env slices_annotated in
             let+ () =
               check_true (not (list_is_empty slices_annotated)) @@ fun () ->
-              fatal_from ~loc Error.EmptySlice
+              fatal_from ~loc Error.(BadSlices Empty)
             in
             let ses = ses_non_conflicting_union ~loc ses1 ses_slices in
             (t, LE_Slice (le2, slices_annotated) |> here, ses)

--- a/asllib/doc/ASLmacros.tex
+++ b/asllib/doc/ASLmacros.tex
@@ -1869,13 +1869,15 @@
 %% Build Error Codes
 \newcommand\BuildErrorPrefix[0]{\texttt{BE}}
 \newcommand\BuildErrorCode[1]{\texttt{\BuildErrorPrefix\_#1}}
-\newcommand\LexicalError[0]{\hyperlink{def-lexicalerrorresult}{\texttt{\#}\BuildErrorCode{LE}}}
-\newcommand\LexicalErrorConfig[0]{\LexicalError}
+\newcommand\TLexicalError[0]{\hyperlink{def-lexicalerrorresult}{\textsf{TLexicalError}}}
+\newcommand\LexicalErrorVal[1]{\hyperlink{def-lexicalerrorresult}{\textsf{LexicalError}}(#1)}
+\newcommand\LexicalError[0]{\hyperlink{def-lexicalerrorcode}{\BuildErrorCode{LE}}}
+\newcommand\LexicalErrorConfig[0]{\hyperlink{def-lexicalerrorconfig}{\texttt{\#LE}}}
+\newcommand\ReservedIdentifier[0]{\hyperlink{def-reservedidentifier}{\BuildErrorCode{RI}}}
 \newcommand\OrLexicalError[0]{\;\terminateas\;\LexicalErrorConfig}
 \newcommand\ParseError[0]{\hyperlink{def-parseerror}{\BuildErrorCode{PE}}}
 \newcommand\ParseErrorConfig[0]{\hyperlink{def-parseerror}{\texttt{\#}\BuildErrorCode{PE}}}
 \newcommand\OrParseError[0]{\;\terminateas\;\ParseErrorConfig}
-\newcommand\ReservedIdentifier[0]{\hyperlink{def-reservedidentifier}{\BuildErrorCode{RI}}}
 \newcommand\BinopPriority[0]{\hyperlink{def-binoppriority}{\BuildErrorCode{BOP}}}
 \newcommand\BuildBadDeclaration[0]{\hyperlink{def-buildbaddeclaration}{\BuildErrorCode{BD}}}
 

--- a/asllib/doc/ErrorCodes.tex
+++ b/asllib/doc/ErrorCodes.tex
@@ -188,6 +188,7 @@ The following table summarises all error codes.
 
 \section{Build Errors\label{sec:BuildErrors}}
 \begin{description}
+  \hypertarget{def-lexicalerrorcode}{}
   \item[$\LexicalError$]
     \textit{Lexical error.}
     An error was encountered during lexical analysis.

--- a/asllib/doc/LexicalStructure.tex
+++ b/asllib/doc/LexicalStructure.tex
@@ -331,12 +331,21 @@ can be useful for declaring a constant specific to the platform \verb|my_platfor
 Lexical analysis, which is also referred to as \emph{scanning}, is defined via the function
 \hypertarget{def-aslscan}{}
 \[
-\aslscan(\LexSpec, \KleeneStar{\REasciichar}) \aslto (\KleeneStar{\Token} \cup \{\LexicalErrorConfig\})
+\aslscan(\LexSpec, \KleeneStar{\REasciichar}) \aslto
+(\KleeneStar{\Token} \cup \overname{\TLexicalError}{\LexicalErrorConfig})
 \]
 \hypertarget{def-lexicalerrorresult}{}
-which takes a \emph{lexical specification} (explained soon), an ASL specification string
-given by a sequence of ASCII characters (stored as 8-bit bytes)
-and returns a sequence of tokens (tokens are defined below) or a \emph{lexical error} $\LexicalErrorConfig$.
+The type of lexical error configurations is
+\[
+  \TLexicalError \triangleq \LexicalErrorVal{\vc},
+  \qquad \vc \in \{\LexicalError, \ReservedIdentifier\}.
+\]
+\hypertarget{def-lexicalerrorconfig}{}
+We define the shorthand $\LexicalErrorConfig \triangleq \LexicalErrorVal{\vc}$ for lexical error
+configurations with any lexical error code $\vc \in \{\LexicalError, \ReservedIdentifier\}$.
+The function $\aslscan$ takes a \emph{lexical specification} (explained soon), an ASL specification
+string given by a sequence of ASCII characters (stored as 8-bit bytes), and returns a sequence of
+tokens (tokens are defined below) or a lexical error configuration $\LexicalErrorConfig$.
 
 Tokens have one of two forms:
 \begin{description}
@@ -417,7 +426,7 @@ The function $\aslscan$ is constructively defined via the following inference ru
 \inferrule[no\_match]{
   \maxmatches(R, s) = \emptylist
 }{
-  \aslscan(R, s) \scanarrow \LexicalErrorConfig
+  \aslscan(R, s) \scanarrow \LexicalErrorVal{\LexicalError}
 }
 \end{mathpar}
 
@@ -483,8 +492,9 @@ The lexeme action
 \actiontoken(f) \triangleq \lambda (s_1,s_2). \\
 \wrappedline\
 \begin{cases}
-  \LexicalErrorConfig & \text{if }f(s_1) = \Terror \text{ or}\\
-   & \aslscan(\spectoken, s_2) = \Terror\\
+  \LexicalErrorVal{\LexicalError} & \text{if }f(s_1) = \Terror\\
+  f(s_1) & \text{if }f(s_1) \in \TLexicalError\\
+  \aslscan(\spectoken, s_2) & \text{if }\aslscan(\spectoken, s_2) \in \TLexicalError\\
   [f(s_1)] \concat \aslscan(\spectoken, s_2) & \text{otherwise}
 \end{cases}
 \end{array}
@@ -542,7 +552,7 @@ $s$, which is given via a floating point representation.
 \[
 \eoftoken(s_1, s_2) \triangleq \begin{cases}
   \emptylist & s_2 = \emptylist\\
-  \LexicalErrorConfig & \text{otherwise}
+  \LexicalErrorVal{\LexicalError} & \text{otherwise}
 \end{cases}
 \]
 checks whether $\eof$ is not followed by more characters and returns a lexical error otherwise.
@@ -551,17 +561,18 @@ checks whether $\eof$ is not followed by more characters and returns a lexical e
 \LexicalRuleDef{ReservedIdentifiers}
 \hypertarget{def-toidentifier}{}
 The function $\toidentifier(s)$ checks whether $s$ is a legal identifier
-and if so returns $\Tidentifier(s)$. Otherwise, the result is a lexical error.
+and if so returns $\Tidentifier(s)$. Otherwise, the result is a lexical error configuration
+with the reserved identifier error code $\ReservedIdentifier$.
 
 \ProseParagraph
 Given a string $s$, $\toidentifier(s)$ checks whether $s$ starts with a double
-underscore. If so, the result is a lexical error. Otherwise the result is
+underscore. If so, the result is $\LexicalErrorVal{\ReservedIdentifier}$. Otherwise the result is
 $\Tidentifier(s)$.
 
 \FormallyParagraph
 \[
   \toidentifier(s) = \begin{cases}
-    \LexicalErrorConfig & \text{if }s = \underbracket{\texttt{ \_ } }\ \underbracket{\texttt{ \_ } } s'\\
+    \LexicalErrorVal{\ReservedIdentifier} & \text{if }s = \underbracket{\texttt{ \_ } }\ \underbracket{\texttt{ \_ } } s'\\
     \Tidentifier(s) & \text{otherwise}
   \end{cases}
 \]
@@ -669,7 +680,8 @@ $\eof$            & $\eoftoken$ \\
 To scan string literals, we define the following specialised scanning function.
 The function
 \[
-\scanstring(\overname{\KleeneStar{\REasciichar}}{\buff}, \overname{\KleeneStar{\REasciichar}}{s}) \aslto (\KleeneStar{\Token} \cup \{\LexicalErrorConfig\})
+\scanstring(\overname{\KleeneStar{\REasciichar}}{\buff}, \overname{\KleeneStar{\REasciichar}}{s}) \aslto
+(\KleeneStar{\Token} \cup \overname{\TLexicalError}{\LexicalErrorConfig})
 \]
 scans string with the $\specstring$ specification while building the final string literal in $\buff$.
 It is defined via the following rules:
@@ -677,7 +689,7 @@ It is defined via the following rules:
 \inferrule[no\_match]{
   \maxmatches(\specstring, s) = \emptylist
 }{
-  \scanstring(\buff, s) \scanarrow \LexicalErrorConfig
+  \scanstring(\buff, s) \scanarrow \LexicalErrorVal{\LexicalError}
 }
 \end{mathpar}
 

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -428,8 +428,7 @@ end
       in reference?
     - Various errors are overused in several places - need to clearly
       distinguish between ASL1 errors and e.g. ASL0 non-typechecked errors,
-      assertion failures, cases we don't expect to hit etc.
-    - TypingRule.TInt mismatch on empty case *)
+      assertion failures, cases we don't expect to hit etc. *)
 (* TODO: BE_RI unused in reference *)
 
 module PPrint = struct

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -26,18 +26,26 @@ open AST
 
 type error_handling_time = Static | Dynamic
 
+type bad_slices =
+  | NonPositiveLength of { slice : slice; length : int }
+      (** Converting a slice to positions during typing requires a positive
+          length. *)
+  | OutOfBitvectorBounds of slice list * int
+  | NegativeStartOrLength of error_handling_time * slice list
+      (** Native slicing permits a zero length, but requires non-negative starts
+          and lengths. *)
+
 type error_desc =
   | ReservedIdentifier of string
   | BadField of string * ty
   | MissingField of string list * ty
-  | BadSlices of error_handling_time * slice list * int
+  | BadSlices of bad_slices
   | BadIndex of {
       handling_time : error_handling_time;
       start : int;
       length : int;
     }
   | BadTupleIndex of { index : int; length : int }
-  | BadSlice of slice
   | EmptySlice
   | TypeInferenceNeeded
   | UndefinedIdentifier of error_handling_time * identifier
@@ -274,11 +282,13 @@ module ErrorCode = struct
     | UnsupportedUnop (Static, _, _)
     | UnsupportedBinop (Static, _, _, _) ->
         Some (Typing BO)
-    | BadSlices (Static, _, _)
-    | BadSlice _ | EmptySlice
+    | BadSlices
+        ( NonPositiveLength _ | OutOfBitvectorBounds _
+        | NegativeStartOrLength (Static, _) )
+    | EmptySlice
     | OverlappingSlices (_, Static)
     | BitfieldsDontAlign _ ->
-        Some (Typing BS) (* TODO: consider combining BadSlices and BadSlice *)
+        Some (Typing BS)
     | UndefinedIdentifier (Static, _) -> Some (Typing UI)
     | TypeSatisfactionFailure _ -> Some (Typing TSF)
     | ConflictingTypes _ | AssignToTupleElement _ | ConstrainedIntegerExpected _
@@ -328,6 +338,7 @@ module ErrorCode = struct
     | StaticEvaluationFailure _ ->
         Some (Typing SEF)
     | BadIndex { handling_time = Dynamic } -> Some (Dynamic BI)
+    | BadSlices (NegativeStartOrLength (Dynamic, _)) -> Some (Dynamic BI)
     | NoCommonAncestor _ (* LCA failures *) -> Some (Typing LCA)
     (********** Errors without specification codes **********)
     (* Implementation limitations are not ASL errors. *)
@@ -345,8 +356,6 @@ module ErrorCode = struct
     | ParameterWithoutDecl _ | SetterWithoutCorrespondingGetter _
     | ConflictingSideEffects _ | ConstantTimeBroken _ ->
         None
-    (********** Other **********)
-    | BadSlices (Dynamic, _, _) -> None (* only used in Native.ml *)
 end
 
 module PrintContext = struct
@@ -424,8 +433,6 @@ module PrintContext = struct
 end
 
 (** TODO
-    - SlicesToPositions - static or dynamic in implementation, but always TE_BS
-      in reference?
     - Various errors are overused in several places - need to clearly
       distinguish between ASL1 errors and e.g. ASL0 non-typechecked errors,
       assertion failures, cases we don't expect to hit etc. *)
@@ -523,11 +530,20 @@ module PPrint = struct
         pp_err Static
           "cannot slice with empty slicing operator. This might also be due to \
            an incorrect getter/setter invocation."
-    | BadSlices (t, slices, length) ->
+    | BadSlices (OutOfBitvectorBounds (slices, length)) ->
+        pp_err Static
+          "Slice selection %a includes a position outside the bounds of a \
+           bitvector of length %d."
+          pp_slice_list slices length
+    | BadSlices (NegativeStartOrLength (t, slices)) ->
         pp_err
           (ErrorKind.of_error_handling_time t)
-          "Cannot extract from bitvector of length %d slice %a." length
+          "Slice %a is invalid: its start and length must be non-negative."
           pp_slice_list slices
+    | BadSlices (NonPositiveLength { slice; length }) ->
+        pp_err Static
+          "Slice %a has length %d; slice lengths must be at least 1." pp_slice
+          slice length
     | BadIndex { handling_time; start; length } ->
         pp_err
           (ErrorKind.of_error_handling_time handling_time)
@@ -535,7 +551,6 @@ module PPrint = struct
     | BadTupleIndex { index; length } ->
         pp_err Typing "Tuple index %d is outside the valid range 0..%d." index
           (length - 1)
-    | BadSlice slice -> pp_err Static "invalid slice %a." pp_slice slice
     | TypeInferenceNeeded ->
         pp_err Internal "Interpreter blocked. Type inference needed."
     | UndefinedIdentifier (t, s) ->
@@ -872,7 +887,6 @@ module CSV = struct
     | BadSlices _ -> "BadSlices"
     | BadIndex _ -> "BadIndex"
     | BadTupleIndex _ -> "BadTupleIndex"
-    | BadSlice _ -> "BadSlice"
     | EmptySlice -> "EmptySlice"
     | TypeInferenceNeeded -> "TypeInferenceNeeded"
     | UndefinedIdentifier _ -> "UndefinedIdentifier"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -27,6 +27,7 @@ open AST
 type error_handling_time = Static | Dynamic
 
 type bad_slices =
+  | Empty  (** ASLv0 syntax may produce an empty slice list. *)
   | NonPositiveLength of { slice : slice; length : int }
       (** Converting a slice to positions during typing requires a positive
           length. *)
@@ -46,7 +47,6 @@ type error_desc =
       length : int;
     }
   | BadTupleIndex of { index : int; length : int }
-  | EmptySlice
   | TypeInferenceNeeded
   | UndefinedIdentifier of error_handling_time * identifier
   | MismatchedCallType of {
@@ -283,9 +283,8 @@ module ErrorCode = struct
     | UnsupportedBinop (Static, _, _, _) ->
         Some (Typing BO)
     | BadSlices
-        ( NonPositiveLength _ | OutOfBitvectorBounds _
+        ( Empty | NonPositiveLength _ | OutOfBitvectorBounds _
         | NegativeStartOrLength (Static, _) )
-    | EmptySlice
     | OverlappingSlices (_, Static)
     | BitfieldsDontAlign _ ->
         Some (Typing BS)
@@ -523,7 +522,7 @@ module PPrint = struct
           pp_ty ty
           (pp_print_list ~pp_sep:pp_print_space pp_print_string)
           fields
-    | EmptySlice ->
+    | BadSlices Empty ->
         assert (e.version = V0);
         pp_err Static
           "cannot slice with empty slicing operator. This might also be due to \
@@ -540,8 +539,9 @@ module PPrint = struct
           pp_slice_list slices
     | BadSlices (NonPositiveLength { slice; length }) ->
         pp_err Static
-          "Slice %a has length %d; slice lengths must be at least 1." pp_slice
-          slice length
+          "Slice %a has length %d; but the length of this slice must be at \
+           least 1."
+          pp_slice slice length
     | BadIndex { handling_time; start; length } ->
         pp_err
           (ErrorKind.of_error_handling_time handling_time)
@@ -885,7 +885,6 @@ module CSV = struct
     | BadSlices _ -> "BadSlices"
     | BadIndex _ -> "BadIndex"
     | BadTupleIndex _ -> "BadTupleIndex"
-    | EmptySlice -> "EmptySlice"
     | TypeInferenceNeeded -> "TypeInferenceNeeded"
     | UndefinedIdentifier _ -> "UndefinedIdentifier"
     | MismatchedCallType _ -> "MismatchedCallType"

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -432,10 +432,8 @@ module PrintContext = struct
     else None
 end
 
-(** TODO
-    - Various errors are overused in several places - need to clearly
-      distinguish between ASL1 errors and e.g. ASL0 non-typechecked errors,
-      assertion failures, cases we don't expect to hit etc. *)
+(** TODO: separate ASLv0 diagnostics, unchecked-execution failures, and internal
+    invariant violations from ASL errors. *)
 module PPrint = struct
   open Format
   open PP

--- a/asllib/error.ml
+++ b/asllib/error.ml
@@ -429,8 +429,6 @@ end
     - Various errors are overused in several places - need to clearly
       distinguish between ASL1 errors and e.g. ASL0 non-typechecked errors,
       assertion failures, cases we don't expect to hit etc. *)
-(* TODO: BE_RI unused in reference *)
-
 module PPrint = struct
   open Format
   open PP

--- a/asllib/tests/ASLSemanticsReference.t/run.t
+++ b/asllib/tests/ASLSemanticsReference.t/run.t
@@ -272,7 +272,8 @@ ASL Semantics Tests:
   $ aslref SemanticsRule.ReadIdentifier.asl
   $ aslref SemanticsRule.SlicesToPositions.asl
   $ aslref SemanticsRule.SlicesToPositions.bad.asl
-  ASL Dynamic error: Cannot extract from bitvector of length 0 slice -1+:6.
+  ASL Dynamic error (DE_BI):
+    Slice -1+:6 is invalid: its start and length must be non-negative.
   [1]
   $ aslref SemanticsRule.GetIndex.asl
   $ aslref SemanticsRule.GetField.asl

--- a/asllib/tests/ASLTypingReference.t/TypingRule.BitfieldSliceToPositions.bad.asl
+++ b/asllib/tests/ASLTypingReference.t/TypingRule.BitfieldSliceToPositions.bad.asl
@@ -1,0 +1,3 @@
+var myData: bits(16) {
+    [5+:0] data
+};

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -559,6 +559,15 @@ ASL Typing Tests / annotating types:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ASL Warning: pragma implementation_hidden will be ignored.
   $ aslref --no-exec TypingRule.BitfieldSliceToPositions.asl
+  $ aslref --no-exec TypingRule.BitfieldSliceToPositions.bad.asl
+  File TypingRule.BitfieldSliceToPositions.bad.asl, line 1, character 0 to
+    line 3, character 2:
+  var myData: bits(16) {
+      [5+:0] data
+  };
+  ASL Static error (TE_BS):
+    Slice 5+:0 has length 0; but the length of this slice must be at least 1.
+  [1]
   $ aslref TypingRule.DisjointSlicesToPositions.bad.asl
   File TypingRule.DisjointSlicesToPositions.bad.asl, line 1, character 0 to
     line 6, character 2:

--- a/asllib/tests/ASLTypingReference.t/run.t
+++ b/asllib/tests/ASLTypingReference.t/run.t
@@ -579,7 +579,7 @@ ASL Typing Tests / annotating types:
       [3*5 +:5] value // Illegal: position 19 exceeds 15
   };
   ASL Static error (TE_BS):
-    Cannot extract from bitvector of length 16 slice (3 * 5)+:5.
+    Slice selection (3 * 5)+:5 includes a position outside the bounds of a bitvector of length 16.
   [1]
 
   $ aslref TypingRule.CheckNoPrecisionLoss.asl

--- a/asllib/tests/bad-types.t
+++ b/asllib/tests/bad-types.t
@@ -62,7 +62,7 @@ Bad slices
     [14:12] b,
   };
   ASL Static error (TE_BS):
-    Cannot extract from bitvector of length 12 slice 12+:3.
+    Slice selection 12+:3 includes a position outside the bounds of a bitvector of length 12.
   [1]
 
   $ cat >bad-types5.asl <<EOF
@@ -79,7 +79,7 @@ Bad slices
     [-2+:1] b,
   };
   ASL Static error (TE_BS):
-    Cannot extract from bitvector of length 12 slice (- 2)+:1.
+    Slice selection (- 2)+:1 includes a position outside the bounds of a bitvector of length 12.
   [1]
 
   $ cat >bad-types6.asl <<EOF
@@ -102,7 +102,7 @@ Bad slices
     },
   };
   ASL Static error (TE_BS):
-    Cannot extract from bitvector of length 3 slice 8+:3.
+    Slice selection 8+:3 includes a position outside the bounds of a bitvector of length 3.
   [1]
 
 Empty types

--- a/asllib/tests/division.t/run.t
+++ b/asllib/tests/division.t/run.t
@@ -190,7 +190,8 @@ Other polynomial equations:
   [1]
 
   $ aslref rat-poly-01.asl
-  ASL Dynamic error: Cannot extract from bitvector of length 0 slice 0+:-2.
+  ASL Dynamic error (DE_BI):
+    Slice 0+:-2 is invalid: its start and length must be non-negative.
   [1]
 
 Division as POW:

--- a/asllib/tests/regressions.t/run.t
+++ b/asllib/tests/regressions.t/run.t
@@ -263,11 +263,13 @@ Parameterized integers:
 
   $ aslref empty-slice.asl
   0x0
-  ASL Dynamic error: Cannot extract from bitvector of length 0 slice 4+:-1.
+  ASL Dynamic error (DE_BI):
+    Slice 4+:-1 is invalid: its start and length must be non-negative.
   [1]
 
   $ aslref bad-slices.asl
-  ASL Dynamic error: Cannot extract from bitvector of length 0 slice 4+:-23.
+  ASL Dynamic error (DE_BI):
+    Slice 4+:-23 is invalid: its start and length must be non-negative.
   [1]
 
   $ aslref bad-shift.asl
@@ -729,13 +731,15 @@ Outdated syntax
 
 Bounds checks
   $ aslref bounds-checks-read-bitvector-1.asl
-  ASL Dynamic error: Cannot extract from bitvector of length 0 slice -1+:1.
+  ASL Dynamic error (DE_BI):
+    Slice -1+:1 is invalid: its start and length must be non-negative.
   [1]
   $ aslref bounds-checks-read-bitvector-2.asl
   ASL Dynamic error (DE_BI): Index 4 is outside the valid range 0..3.
   [1]
   $ aslref bounds-checks-write-bitvector-1.asl
-  ASL Dynamic error: Cannot extract from bitvector of length 0 slice -1+:1.
+  ASL Dynamic error (DE_BI):
+    Slice -1+:1 is invalid: its start and length must be non-negative.
   [1]
   $ aslref bounds-checks-write-bitvector-2.asl
   ASL Dynamic error (DE_BI): Index 5 is outside the valid range 0..3.


### PR DESCRIPTION
## Clarify empty integer constraints
Removed a stale TODO: ASL syntax and `asl.spec` require well-constrained integers to contain at least one constraint, so the implementation's empty case is an uncoded internal invariant.

## Align reserved-identifier errors
Reserved identifiers now produce `BE_RI` in the lexical formalism, matching the implementation.

## Classify invalid runtime slices
Runtime slices with a negative start or length now produce `DE_BI`, matching `asl.spec`; static slice failures remain `TE_BS` and use reason-specific `bad_slices` cases.
